### PR TITLE
feat(whatsapp): Customer Memory foundation + funcionário + reclamações + Firebird + tutorial (VOZ-001 + VOZ-002)

### DIFF
--- a/Modules/Whatsapp/Config/config.php
+++ b/Modules/Whatsapp/Config/config.php
@@ -167,6 +167,34 @@ return [
     ],
 
     /*
+     * US-WA-VOZ-001 — Customer Memory (perfil persistente do cliente final).
+     *
+     * Wagner 2026-05-15: "onde vai ficar as memórias? estruture. vai precisar
+     * achar o telefone e o cliente no banco de dados do servidor."
+     *
+     * Schema: `customer_memory` table (1 row per (business_id, customer_external_id)).
+     * Listener `TouchCustomerMemoryOnMessage` atualiza last_interaction_at em
+     * tempo real; Job RebuildCustomerMemoryJob recompila stats em background
+     * quando `last_rebuilt_at < NOW() - rebuild_after_hours`.
+     *
+     * Default `enabled=true` — Tier 0 sempre ON pra capturar memória mesmo
+     * sem IA. Wagner desliga via env só se houver problema operacional.
+     *
+     * @see Modules/Whatsapp/Entities/CustomerMemory.php
+     * @see Modules/Whatsapp/Services/CustomerMemory/CustomerMemoryRebuilder.php
+     */
+    'customer_memory' => [
+        'enabled' => (bool) env('WHATSAPP_CUSTOMER_MEMORY_ENABLED', true),
+        // Threshold pra dispatcha rebuild assíncrono (heavy path) no listener.
+        // < default 6h pra refrescar várias vezes ao dia sem encher queue.
+        'rebuild_after_hours' => (int) env('WHATSAPP_CUSTOMER_MEMORY_REBUILD_AFTER_HOURS', 6),
+        // Stale threshold pra cron daily (default 24h).
+        'cron_stale_hours' => (int) env('WHATSAPP_CUSTOMER_MEMORY_CRON_STALE_HOURS', 24),
+        // Cap de jobs dispatched por business no cron daily (anti-overload).
+        'cron_limit_per_business' => (int) env('WHATSAPP_CUSTOMER_MEMORY_CRON_LIMIT', 1000),
+    ],
+
+    /*
      * US-WA-072 — Áudio (Whisper transcription) + Mídia (upload outbound).
      *
      * Provider único Whisper nesta fase. Fallback Ollama whisper-local

--- a/Modules/Whatsapp/Console/Commands/CustomerMemoryBackfillCommand.php
+++ b/Modules/Whatsapp/Console/Commands/CustomerMemoryBackfillCommand.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Modules\Whatsapp\Entities\CustomerMemory;
+use Modules\Whatsapp\Services\CustomerMemory\CustomerMemoryRebuilder;
+
+/**
+ * US-WA-VOZ-001 — Backfill one-shot de `customer_memory` por business.
+ *
+ * Uso típico (após migração + deploy):
+ *   php artisan customer-memory:backfill --business=1 --dry-run    # conta + amostra
+ *   php artisan customer-memory:backfill --business=1              # roda síncrono
+ *   php artisan customer-memory:backfill --business=1 --queue       # dispatcha jobs
+ *
+ * Itera DISTINCT customer_external_id de `conversations` no business
+ * filtrado, e pra cada um chama Rebuilder::rebuild(). Idempotente —
+ * re-rodar não duplica (UPSERT por (business_id, customer_external_id)).
+ *
+ * Tier 0: --business obrigatório. Sem ele, falha INVALID.
+ *
+ * @see Modules/Whatsapp/Services/CustomerMemory/CustomerMemoryRebuilder.php
+ */
+class CustomerMemoryBackfillCommand extends Command
+{
+    protected $signature = 'customer-memory:backfill
+        {--business= : business_id obrigatório (Tier 0 multi-tenant)}
+        {--channel= : filtra customers de 1 channel específico (opcional)}
+        {--limit=10000 : máximo customers processados (default 10000)}
+        {--dry-run : só conta + lista 10 amostras, NÃO grava}
+        {--queue : dispatcha RebuildCustomerMemoryJob em vez de rodar síncrono}
+        {--detail : log linha-a-linha de cada rebuild}';
+
+    protected $description = 'Backfill customer_memory pra todos os clientes que já mandaram msg no business (US-WA-VOZ-001).';
+
+    public function handle(CustomerMemoryRebuilder $rebuilder): int
+    {
+        $businessId = (int) $this->option('business');
+        if ($businessId <= 0) {
+            $this->error('--business=N obrigatório (Tier 0 multi-tenant ADR 0093).');
+            return Command::INVALID;
+        }
+
+        $channelId = $this->option('channel');
+        $channelId = $channelId !== null ? (int) $channelId : null;
+
+        $limit = max(1, (int) $this->option('limit'));
+        $dryRun = (bool) $this->option('dry-run');
+        $useQueue = (bool) $this->option('queue');
+        $detail = (bool) $this->option('detail');
+
+        // Query — DISTINCT customer_external_id das conversations do business
+        $query = DB::table('conversations')
+            ->where('business_id', $businessId)
+            ->whereNotNull('customer_external_id')
+            ->where('customer_external_id', '!=', '');
+
+        if ($channelId !== null) {
+            $query->where('channel_id', $channelId);
+        }
+
+        $customers = $query->select('customer_external_id')
+            ->groupBy('customer_external_id')
+            ->orderBy('customer_external_id')
+            ->limit($limit)
+            ->pluck('customer_external_id');
+
+        $total = $customers->count();
+        $this->info("Customers únicos elegíveis biz={$businessId}" .
+            ($channelId ? " channel={$channelId}" : '') .
+            ": {$total}");
+
+        if ($total === 0) {
+            $this->info('Nada a fazer.');
+            return Command::SUCCESS;
+        }
+
+        if ($dryRun) {
+            $this->info('[DRY-RUN] Amostras (até 10):');
+            $samples = $customers->take(10)->map(function ($ext) {
+                $masked = substr($ext, 0, 4) . '***' . substr($ext, -2);
+                return [$masked];
+            })->all();
+            $this->table(['customer_external_id (redacted)'], $samples);
+            return Command::SUCCESS;
+        }
+
+        if ($useQueue) {
+            $this->info("Modo --queue: dispatchando {$total} jobs pra queue 'customer-memory'.");
+            $bar = $this->output->createProgressBar($total);
+            $bar->start();
+            foreach ($customers as $extId) {
+                $cleaned = ltrim((string) $extId, '+');
+                if ($cleaned === '') {
+                    continue;
+                }
+                \Modules\Whatsapp\Jobs\RebuildCustomerMemoryJob::dispatch(
+                    $businessId,
+                    $cleaned,
+                    CustomerMemory::REBUILT_VIA_BACKFILL,
+                );
+                $bar->advance();
+            }
+            $bar->finish();
+            $this->newLine();
+            $this->info("Dispatched. Rode: php artisan queue:work database --queue=customer-memory --stop-when-empty");
+            return Command::SUCCESS;
+        }
+
+        // Modo síncrono — rebuild inline (útil pra biz pequenos / dev)
+        $this->info('Modo síncrono — rebuild inline (use --queue pra biz grandes).');
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+        $ok = 0;
+        $err = 0;
+
+        foreach ($customers as $extId) {
+            $cleaned = ltrim((string) $extId, '+');
+            if ($cleaned === '') {
+                $bar->advance();
+                continue;
+            }
+            try {
+                $memory = $rebuilder->rebuild($businessId, $cleaned, CustomerMemory::REBUILT_VIA_BACKFILL);
+                $ok++;
+                if ($detail) {
+                    $this->line("  ✓ memory_id={$memory->id} contact_id=" .
+                        ($memory->contact_id ?? 'NULL') .
+                        " name=\"{$memory->display_name}\" msgs={$memory->n_msgs_total}");
+                }
+            } catch (\Throwable $e) {
+                $err++;
+                if ($detail) {
+                    $this->error("  ✗ {$cleaned}: " . $e->getMessage());
+                }
+            }
+            $bar->advance();
+        }
+        $bar->finish();
+        $this->newLine();
+        $this->info("Resultado: {$ok} ok · {$err} erros · {$total} processados.");
+
+        return Command::SUCCESS;
+    }
+}

--- a/Modules/Whatsapp/Console/Commands/CustomerMemoryEnrichFirebirdCommand.php
+++ b/Modules/Whatsapp/Console/Commands/CustomerMemoryEnrichFirebirdCommand.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Modules\Whatsapp\Services\CustomerMemory\OfficeimpressoEnrichService;
+use Modules\Whatsapp\Services\CustomerMemory\Sources\JsonFileFirebirdSource;
+
+/**
+ * US-WA-VOZ-002 — Comando enrich customer_memory com Firebird OfficeImpresso.
+ *
+ * Uso:
+ *   # 1) Wagner roda Python local pra exportar Firebird → JSON
+ *   python scripts/firebird/export-customers.py --output storage/app/firebird/customers-2026-05-15.json
+ *
+ *   # 2) Upload pro Hostinger (scp/git ou via outro mecanismo)
+ *
+ *   # 3) Rodar enrich
+ *   php artisan customer-memory:enrich-firebird --business=1 \
+ *       --json=storage/app/firebird/customers-2026-05-15.json
+ *
+ *   php artisan customer-memory:enrich-firebird --business=1 --json=... --limit=500 --detail
+ *
+ * Tier 0: --business obrigatório. Cross-tenant via JSON sem proteção
+ * (admin é quem decide quem entra no JSON exportado).
+ *
+ * @see Modules/Whatsapp/Services/CustomerMemory/OfficeimpressoEnrichService.php
+ * @see scripts/firebird/export-customers.py
+ */
+class CustomerMemoryEnrichFirebirdCommand extends Command
+{
+    protected $signature = 'customer-memory:enrich-firebird
+        {--business= : business_id obrigatório (Tier 0 ADR 0093)}
+        {--json= : path do JSON exportado Firebird (default: storage/app/firebird/customers-latest.json)}
+        {--limit=1000 : máximo customer_memory processados}
+        {--stale-days=30 : threshold external_sources_enriched_at (default 30d)}
+        {--detail : log breakdown por customer}';
+
+    protected $description = 'Enriquece customer_memory com lookup cliente Firebird OfficeImpresso (US-WA-VOZ-002).';
+
+    public function handle(): int
+    {
+        $businessId = (int) $this->option('business');
+        if ($businessId <= 0) {
+            $this->error('--business=N obrigatório (Tier 0 multi-tenant).');
+            return Command::INVALID;
+        }
+
+        $jsonPath = (string) ($this->option('json')
+            ?: storage_path('app/firebird/customers-latest.json'));
+
+        if (! file_exists($jsonPath)) {
+            $this->error("JSON não encontrado: {$jsonPath}");
+            $this->warn('Rode primeiro o export Python:');
+            $this->line('  python scripts/firebird/export-customers.py --output ' . $jsonPath);
+            return Command::FAILURE;
+        }
+
+        $limit = max(1, (int) $this->option('limit'));
+        $staleDays = max(1, (int) $this->option('stale-days'));
+        $detail = (bool) $this->option('detail');
+
+        $source = new JsonFileFirebirdSource($jsonPath);
+
+        if (! $source->isHealthy()) {
+            $this->error("JSON source unhealthy (arquivo >30d ou inválido): {$jsonPath}");
+            return Command::FAILURE;
+        }
+
+        $this->info("Source: {$source->sourceLabel()}");
+        $this->info("Path: {$jsonPath}");
+
+        $service = new OfficeimpressoEnrichService($source);
+
+        $startedAt = microtime(true);
+        $stats = $service->enrichBusiness($businessId, $limit, $staleDays);
+        $durationMs = (int) ((microtime(true) - $startedAt) * 1000);
+
+        $this->table(
+            ['biz', 'processed', 'matched', 'skipped', 'duration_ms'],
+            [[
+                $businessId,
+                $stats['processed'],
+                $stats['matched'],
+                $stats['skipped'],
+                $durationMs,
+            ]]
+        );
+
+        if ($stats['processed'] === 0) {
+            $this->warn('Nenhum customer_memory elegível pra enrich (todos enriched < stale-days OU biz vazio).');
+            return Command::SUCCESS;
+        }
+
+        $matchRate = round($stats['matched'] * 100 / max(1, $stats['processed']), 1);
+        $this->info("Match rate: {$matchRate}% ({$stats['matched']}/{$stats['processed']})");
+
+        return Command::SUCCESS;
+    }
+}

--- a/Modules/Whatsapp/Console/Commands/CustomerMemoryRefreshDailyCommand.php
+++ b/Modules/Whatsapp/Console/Commands/CustomerMemoryRefreshDailyCommand.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Modules\Whatsapp\Entities\CustomerMemory;
+use Modules\Whatsapp\Jobs\RebuildCustomerMemoryJob;
+
+/**
+ * US-WA-VOZ-001 — Cron daily refresh customer_memory.
+ *
+ * Roda diário 02h BRT via `app/Console/Kernel.php`. Re-dispatcha jobs
+ * pra customers com `last_rebuilt_at < NOW() - 24h` OU NULL.
+ *
+ * Idempotente — jobs idempotentes via UPSERT.
+ *
+ * Tier 0: itera por business explícito (sem session). Sem `--business=N`
+ * processa TODOS businesses ativos.
+ *
+ * Capping: --limit por business (default 1000) — evita queue explosion.
+ *
+ * @see Modules/Whatsapp/Jobs/RebuildCustomerMemoryJob.php
+ */
+class CustomerMemoryRefreshDailyCommand extends Command
+{
+    protected $signature = 'customer-memory:refresh-daily
+        {--business= : business_id alvo (default: todos com customer_memory existente)}
+        {--limit=1000 : máximo customers por business}
+        {--stale-hours=24 : threshold last_rebuilt_at em horas (default 24h)}
+        {--detail : log breakdown por business}';
+
+    protected $description = 'Cron daily — re-dispatcha rebuild de customer_memory stale (US-WA-VOZ-001).';
+
+    public function handle(): int
+    {
+        $businessOpt = $this->option('business');
+        $limit = max(1, (int) $this->option('limit'));
+        $staleHours = max(1, (int) $this->option('stale-hours'));
+        $detail = (bool) $this->option('detail');
+
+        $staleCutoff = now()->subHours($staleHours);
+
+        // Resolve businesses alvo
+        if ($businessOpt !== null) {
+            $businessIds = [(int) $businessOpt];
+        } else {
+            $businessIds = DB::table('customer_memory')
+                ->select('business_id')
+                ->distinct()
+                ->orderBy('business_id')
+                ->pluck('business_id')
+                ->map(fn ($id) => (int) $id)
+                ->all();
+        }
+
+        if (empty($businessIds)) {
+            $this->info('Nenhum business com customer_memory — nada a fazer.');
+            return Command::SUCCESS;
+        }
+
+        $grandTotal = 0;
+        $rows = [];
+
+        foreach ($businessIds as $bizId) {
+            $stale = DB::table('customer_memory')
+                ->where('business_id', $bizId)
+                ->where(function ($q) use ($staleCutoff) {
+                    $q->whereNull('last_rebuilt_at')
+                      ->orWhere('last_rebuilt_at', '<', $staleCutoff);
+                })
+                ->orderBy('last_rebuilt_at') // mais antigos primeiro (NULL first)
+                ->limit($limit)
+                ->pluck('customer_external_id');
+
+            $count = $stale->count();
+            $grandTotal += $count;
+
+            foreach ($stale as $extId) {
+                RebuildCustomerMemoryJob::dispatch(
+                    $bizId,
+                    (string) $extId,
+                    CustomerMemory::REBUILT_VIA_CRON_DAILY,
+                );
+            }
+
+            $rows[] = ['biz' => $bizId, 'dispatched' => $count];
+
+            if ($detail) {
+                $this->info("biz={$bizId}: {$count} jobs dispatched");
+            }
+        }
+
+        if (! $detail && count($rows) > 0) {
+            $this->table(['biz', 'dispatched'], $rows);
+        }
+
+        $this->info("Total dispatched: {$grandTotal}");
+        return Command::SUCCESS;
+    }
+}

--- a/Modules/Whatsapp/Console/Commands/EmployeePerformanceBackfillCommand.php
+++ b/Modules/Whatsapp/Console/Commands/EmployeePerformanceBackfillCommand.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Modules\Whatsapp\Entities\EmployeePerformance;
+use Modules\Whatsapp\Jobs\RebuildEmployeePerformanceJob;
+use Modules\Whatsapp\Services\EmployeePerformance\EmployeePerformanceRebuilder;
+
+/**
+ * US-WA-VOZ-003 — Backfill employee_performance one-shot por business.
+ *
+ * Detecta automaticamente atendentes a partir de 2 fontes:
+ *   1. DISTINCT messages.sender_user_id (UI Inbox oimpresso) — PRIMÁRIO
+ *   2. Pattern *Nome:* extraído de messages.body (chip WhatsApp Web direto) — FALLBACK
+ *
+ * Pra cada atendente detectado, dispara rebuild (sync ou queue).
+ *
+ * Uso:
+ *   php artisan employee-performance:backfill --business=1 --dry-run
+ *   php artisan employee-performance:backfill --business=1
+ *   php artisan employee-performance:backfill --business=1 --queue
+ *   php artisan employee-performance:backfill --business=1 --extra-names=Eliana,Wagner
+ *
+ * @see Modules/Whatsapp/Services/EmployeePerformance/EmployeePerformanceRebuilder.php
+ */
+class EmployeePerformanceBackfillCommand extends Command
+{
+    protected $signature = 'employee-performance:backfill
+        {--business= : business_id obrigatório (Tier 0)}
+        {--dry-run : só conta + lista detectados, NÃO grava}
+        {--queue : dispatcha jobs em vez de rodar síncrono}
+        {--extra-names= : CSV de nomes adicionais pra heurística (ex: Eliana,Wagner)}
+        {--detail : log linha-a-linha de cada rebuild}';
+
+    protected $description = 'Backfill employee_performance — detecta atendentes via sender_user_id + heurística (US-WA-VOZ-003).';
+
+    /** Heurísticos default — nomes conhecidos do time WR (TEAM.md) */
+    public const DEFAULT_HEURISTIC_NAMES = ['Maiara', 'Luiz', 'Felipe', 'Wagner', 'Eliana'];
+
+    public function handle(EmployeePerformanceRebuilder $rebuilder): int
+    {
+        $businessId = (int) $this->option('business');
+        if ($businessId <= 0) {
+            $this->error('--business=N obrigatório (Tier 0 multi-tenant ADR 0093).');
+            return Command::INVALID;
+        }
+
+        $dryRun = (bool) $this->option('dry-run');
+        $useQueue = (bool) $this->option('queue');
+        $detail = (bool) $this->option('detail');
+
+        $extra = array_filter(array_map('trim', explode(',', (string) $this->option('extra-names'))));
+        $heuristicNames = array_unique(array_merge(self::DEFAULT_HEURISTIC_NAMES, $extra));
+
+        $this->info("Detectando atendentes biz={$businessId}...");
+
+        // Fonte 1 — sender_user_id distinct
+        $userIds = DB::table('messages as m')
+            ->join('conversations as c', 'c.id', '=', 'm.conversation_id')
+            ->where('c.business_id', $businessId)
+            ->where('m.direction', 'outbound')
+            ->where('m.is_internal_note', false)
+            ->whereNotNull('m.sender_user_id')
+            ->distinct()
+            ->pluck('m.sender_user_id')
+            ->map(fn ($id) => (int) $id)
+            ->all();
+
+        // Fonte 2 — heurísticos com pelo menos 1 match no business
+        $heuristicsAtivos = [];
+        foreach ($heuristicNames as $name) {
+            $found = DB::table('messages as m')
+                ->join('conversations as c', 'c.id', '=', 'm.conversation_id')
+                ->where('c.business_id', $businessId)
+                ->where('m.direction', 'outbound')
+                ->where('m.is_internal_note', false)
+                ->where('m.body', 'like', '%' . $name . ':%')
+                ->limit(1)
+                ->count();
+            if ($found > 0) {
+                $heuristicsAtivos[] = $name;
+            }
+        }
+
+        $this->info(sprintf(
+            "Detectados: %d via sender_user_id + %d via heurística nome",
+            count($userIds),
+            count($heuristicsAtivos),
+        ));
+
+        if ($dryRun) {
+            $this->table(
+                ['fonte', 'identidade'],
+                array_merge(
+                    array_map(fn ($id) => ['sender_user_id', "user_id={$id}"], $userIds),
+                    array_map(fn ($n) => ['heurística', "*{$n}:*"], $heuristicsAtivos),
+                )
+            );
+            return Command::SUCCESS;
+        }
+
+        $total = count($userIds) + count($heuristicsAtivos);
+
+        if ($total === 0) {
+            $this->info('Nenhum atendente detectado.');
+            return Command::SUCCESS;
+        }
+
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+        $ok = 0;
+        $err = 0;
+
+        $process = function (string $kind, ?int $userId, ?string $heur) use (&$ok, &$err, $businessId, $useQueue, $rebuilder, $detail, $bar) {
+            try {
+                if ($useQueue) {
+                    RebuildEmployeePerformanceJob::dispatch(
+                        $businessId,
+                        $userId,
+                        $heur,
+                        EmployeePerformance::REBUILT_VIA_BACKFILL,
+                    );
+                } else {
+                    $perf = $rebuilder->rebuild(
+                        $businessId,
+                        $userId,
+                        $heur,
+                        EmployeePerformance::REBUILT_VIA_BACKFILL,
+                    );
+                    if ($detail) {
+                        $this->line("  ✓ {$kind} {$perf->identidade()} → nota={$perf->nota_geral}/100");
+                    }
+                }
+                $ok++;
+            } catch (\Throwable $e) {
+                $err++;
+                if ($detail) {
+                    $this->error("  ✗ {$kind} " . ($userId ?? $heur) . ": " . $e->getMessage());
+                }
+            }
+            $bar->advance();
+        };
+
+        foreach ($userIds as $id) {
+            $process('user', $id, null);
+        }
+        foreach ($heuristicsAtivos as $name) {
+            $process('heur', null, $name);
+        }
+
+        $bar->finish();
+        $this->newLine();
+        $this->info("Resultado: {$ok} ok · {$err} erros");
+
+        if ($useQueue) {
+            $this->info("Rode: php artisan queue:work database --queue=employee-performance --stop-when-empty");
+        }
+
+        return Command::SUCCESS;
+    }
+}

--- a/Modules/Whatsapp/Console/Commands/EmployeePerformanceRefreshDailyCommand.php
+++ b/Modules/Whatsapp/Console/Commands/EmployeePerformanceRefreshDailyCommand.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Modules\Whatsapp\Entities\EmployeePerformance;
+use Modules\Whatsapp\Jobs\RebuildEmployeePerformanceJob;
+
+/**
+ * US-WA-VOZ-003 — Cron daily refresh employee_performance.
+ *
+ * Roda 02:30h BRT via `app/Console/Kernel.php`. Re-dispatcha rebuild
+ * pra todos atendentes existentes em `employee_performance`.
+ *
+ * Cron daily 02:30 BRT (offset +30min do customer-memory:refresh-daily
+ * 02:00h pra evitar disputa de queue/DB).
+ *
+ * @see Modules/Whatsapp/Jobs/RebuildEmployeePerformanceJob.php
+ */
+class EmployeePerformanceRefreshDailyCommand extends Command
+{
+    protected $signature = 'employee-performance:refresh-daily
+        {--business= : business_id alvo (default: todos)}
+        {--detail : log breakdown por business}';
+
+    protected $description = 'Cron daily — re-dispatcha rebuild employee_performance (US-WA-VOZ-003).';
+
+    public function handle(): int
+    {
+        $businessOpt = $this->option('business');
+        $detail = (bool) $this->option('detail');
+
+        $businessIds = $businessOpt !== null
+            ? [(int) $businessOpt]
+            : DB::table('employee_performance')
+                ->select('business_id')
+                ->distinct()
+                ->orderBy('business_id')
+                ->pluck('business_id')
+                ->map(fn ($id) => (int) $id)
+                ->all();
+
+        if (empty($businessIds)) {
+            $this->info('Nenhum business com employee_performance — nada a fazer.');
+            return Command::SUCCESS;
+        }
+
+        $grand = 0;
+        $rows = [];
+
+        foreach ($businessIds as $bizId) {
+            $perfs = DB::table('employee_performance')
+                ->where('business_id', $bizId)
+                ->get(['user_id', 'heuristic_name']);
+
+            foreach ($perfs as $p) {
+                RebuildEmployeePerformanceJob::dispatch(
+                    $bizId,
+                    $p->user_id ? (int) $p->user_id : null,
+                    $p->heuristic_name,
+                    EmployeePerformance::REBUILT_VIA_CRON_DAILY,
+                );
+            }
+            $grand += $perfs->count();
+            $rows[] = ['biz' => $bizId, 'dispatched' => $perfs->count()];
+            if ($detail) {
+                $this->info("biz={$bizId}: {$perfs->count()} jobs dispatched");
+            }
+        }
+
+        if (! $detail && ! empty($rows)) {
+            $this->table(['biz', 'dispatched'], $rows);
+        }
+
+        $this->info("Total dispatched: {$grand}");
+        return Command::SUCCESS;
+    }
+}

--- a/Modules/Whatsapp/Database/Migrations/2026_05_15_230000_create_customer_memory_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_15_230000_create_customer_memory_table.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-VOZ-001 — Customer Memory (perfil persistente do cliente final).
+ *
+ * Wagner 2026-05-15: "onde vai ficar as memórias? estruture. vai precisar
+ * achar o telefone e o cliente no banco de dados do servidor."
+ *
+ * Single source of truth da MEMÓRIA DO CLIENTE FINAL (a pessoa do outro
+ * lado do WhatsApp) — NÃO confundir com memória do usuário SaaS (Wagner/
+ * Maiara/Luiz) que vive em `copiloto_memoria_facts` (Jana, ADR 0036).
+ *
+ * Relação opcional 1:N com `contacts` (UltimatePOS CRM legacy) via
+ * `contact_id` — resolvida por `ConversationContactLinker` (já existe).
+ * Customer pode existir SEM contact_id (cliente que nunca foi cadastrado
+ * no CRM mas mandou msg).
+ *
+ * Idempotente — `if (! Schema::hasTable)` skip.
+ *
+ * Tier 0 multi-tenant ([ADR 0093](../../../decisions/0093-multi-tenant-isolation-tier-0.md)):
+ * `business_id` NOT NULL + FK + UNIQUE composto + global scope no Eloquent.
+ *
+ * Estado-da-arte 2026 (Decagon User Memory + Gladly Customer Profile +
+ * Front Customer Context) — schema cobre Customer 360 + LGPD-ready + recall
+ * pattern. Detalhes em
+ * `memory/sessions/2026-05-15-arte-atendimento-omnichannel-memoria-cliente.md`.
+ *
+ * @see Modules/Whatsapp/Entities/CustomerMemory.php
+ * @see Modules/Whatsapp/Services/CustomerMemory/CustomerMemoryRebuilder.php
+ * @see memory/sessions/2026-05-15-analise-voz-cliente-suporte-biz1.md §3-§4
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('customer_memory')) {
+            return;
+        }
+
+        Schema::create('customer_memory', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+
+            // Tier 0 — multi-tenant scope
+            $table->unsignedInteger('business_id');
+
+            // Identidade do cliente (sempre presente)
+            $table->string('customer_external_id', 40)
+                ->comment('E.164 sem + (ex: 5548999872822) — chave do cliente no canal');
+            $table->string('phone_normalized', 20)->nullable()
+                ->comment('Só dígitos do customer_external_id — match rápido contra contacts.mobile');
+
+            // Relação opcional com Contact CRM (UltimatePOS) — pode ser NULL
+            // se cliente não cadastrado. Match feito por ConversationContactLinker.
+            $table->unsignedInteger('contact_id')->nullable();
+            $table->string('identity_match_method', 24)->nullable()
+                ->comment('exact|suffix_8|manual|ambiguous_picked_first|unknown');
+            $table->decimal('identity_match_confidence', 3, 2)->nullable()
+                ->comment('0.00..1.00 — 1.0=unique match, 0.5=ambíguo, NULL=não tentado');
+            $table->timestamp('identity_match_at')->nullable();
+
+            // Display name denormalizado (evita JOIN contacts em cada listing).
+            // Atualiza quando contact_id muda OU pushName muda significativamente.
+            $table->string('display_name', 120)->nullable();
+
+            // Stats agregados (Job daily rebuild OU listener real-time)
+            $table->unsignedInteger('n_conversations')->default(0);
+            $table->unsignedInteger('n_msgs_inbound')->default(0);
+            $table->unsignedInteger('n_msgs_outbound')->default(0);
+            $table->timestamp('first_interaction_at')->nullable();
+            $table->timestamp('last_interaction_at')->nullable();
+
+            // Inferências IA — NULL até Onda 3 ativar (Jana enrichment mensal)
+            $table->json('temas_recorrentes')->nullable()
+                ->comment('["nfe","boleto","atualizacao_bug"] — top 3-5 temas histórico 90d');
+            $table->decimal('sentimento_score', 3, 2)->nullable()
+                ->comment('-1.00..+1.00 — média ponderada sentimento msgs inbound 90d');
+            $table->decimal('churn_risk_score', 3, 2)->nullable()
+                ->comment('0.00..1.00 — heurística + ML futuro');
+            $table->json('comunicacao_preferida')->nullable()
+                ->comment('{"hora_pico":"14-17h","canal":"whatsapp","tom":"formal"}');
+
+            // Memória qualitativa (manual + Jana future via /lembrar slash command)
+            $table->text('notas_jana')->nullable()
+                ->comment('Notas livres acumuladas — max ~2KB');
+            $table->timestamp('notas_atualizada_em')->nullable();
+
+            // Flags operacionais — VIP, frágil, churn_warned, etc
+            $table->json('flags')->nullable()
+                ->comment('[{"tipo":"vip","since":"2026-05-10","motivo":"alto LTV"}]');
+
+            // LGPD — denormaliza consent + erasure tracking
+            $table->string('consent_status', 16)->nullable()
+                ->comment('given|withdrawn|unknown — cache de contacts.whatsapp_consent');
+            $table->timestamp('erasure_requested_at')->nullable()
+                ->comment('LGPD Art. 18 — soft delete; purge job apaga após retention period');
+
+            // Tracking rebuild (debugging + monitoring)
+            $table->timestamp('last_rebuilt_at')->nullable();
+            $table->string('rebuilt_via', 24)->nullable()
+                ->comment('backfill|cron_daily|listener|manual|webhook');
+
+            $table->timestamps();
+
+            // Constraints + índices
+            $table->unique(['business_id', 'customer_external_id'], 'customer_memory_biz_ext_uniq');
+            $table->index(['business_id', 'contact_id'], 'customer_memory_biz_contact_idx');
+            $table->index(['business_id', 'last_interaction_at'], 'customer_memory_biz_lastint_idx');
+            $table->index(['business_id', 'churn_risk_score'], 'customer_memory_biz_churn_idx');
+            $table->index('phone_normalized', 'customer_memory_phone_idx');
+        });
+
+        // FK business_id → business.id (CASCADE on delete — se business sumir, memória vai junto)
+        // Defensive: se schema legacy não tiver `business`, pula FK
+        if (Schema::hasTable('business')) {
+            Schema::table('customer_memory', function (Blueprint $table): void {
+                $table->foreign('business_id', 'customer_memory_business_fk')
+                    ->references('id')->on('business')
+                    ->onDelete('cascade');
+            });
+        }
+
+        // FK contact_id → contacts.id (SET NULL on delete — preserva memória mesmo se Contact apagado)
+        if (Schema::hasTable('contacts')) {
+            Schema::table('customer_memory', function (Blueprint $table): void {
+                $table->foreign('contact_id', 'customer_memory_contact_fk')
+                    ->references('id')->on('contacts')
+                    ->onDelete('set null');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('customer_memory');
+    }
+};

--- a/Modules/Whatsapp/Database/Migrations/2026_05_15_240000_add_employee_complaints_external_to_customer_memory.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_15_240000_add_employee_complaints_external_to_customer_memory.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-VOZ-002 — Extensão customer_memory: funcionário + reclamações + fontes externas.
+ *
+ * Wagner 2026-05-15: "coloque junto com o perfil do cliente, funcionário,
+ * reclamação algo do tipo? nem todo cliente está cadastrado, pesquise no
+ * firebird."
+ *
+ * Adiciona 6 colunas:
+ *   - assigned_user_id           — último funcionário que respondeu (outbound)
+ *   - most_active_user_id        — funcionário com mais msgs outbound histórico
+ *   - most_active_user_count     — n msgs outbound desse funcionário
+ *   - reclamacoes_recentes JSON  — top 5 reclamações (heurística keywords, sem IA)
+ *   - total_reclamacoes          — count msgs flagged "reclamacao" 30d
+ *   - external_sources JSON      — [{source:"firebird_office",codigo,nome,fone}]
+ *   - external_sources_enriched_at — last lookup timestamp
+ *
+ * Idempotente. Tier 0 preservado (sem novos business_id — usa o existente).
+ *
+ * @see Modules/Whatsapp/Services/CustomerMemory/CustomerMemoryRebuilder.php
+ * @see Modules/Whatsapp/Services/CustomerMemory/OfficeimpressoEnrichService.php
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('customer_memory')) {
+            return; // base migration ainda não rodou
+        }
+
+        Schema::table('customer_memory', function (Blueprint $table): void {
+            if (! Schema::hasColumn('customer_memory', 'assigned_user_id')) {
+                $table->unsignedInteger('assigned_user_id')->nullable()
+                    ->comment('User.id do último funcionário que respondeu (outbound mais recente)');
+            }
+            if (! Schema::hasColumn('customer_memory', 'most_active_user_id')) {
+                $table->unsignedInteger('most_active_user_id')->nullable()
+                    ->comment('User.id do funcionário com mais msgs outbound histórico');
+            }
+            if (! Schema::hasColumn('customer_memory', 'most_active_user_count')) {
+                $table->unsignedInteger('most_active_user_count')->nullable()
+                    ->comment('N msgs outbound do most_active_user_id (pra ranking)');
+            }
+            if (! Schema::hasColumn('customer_memory', 'reclamacoes_recentes')) {
+                $table->json('reclamacoes_recentes')->nullable()
+                    ->comment('[{date,msg_id,severity,preview}] — top 5 reclamações heurística 30d');
+            }
+            if (! Schema::hasColumn('customer_memory', 'total_reclamacoes')) {
+                $table->unsignedInteger('total_reclamacoes')->default(0)
+                    ->comment('Count msgs flagged reclamação (heurística keywords) últimos 30d');
+            }
+            if (! Schema::hasColumn('customer_memory', 'external_sources')) {
+                $table->json('external_sources')->nullable()
+                    ->comment('[{source:"firebird_office",cliente_id,name,fone1,fone2,email,bloqueado}]');
+            }
+            if (! Schema::hasColumn('customer_memory', 'external_sources_enriched_at')) {
+                $table->timestamp('external_sources_enriched_at')->nullable();
+            }
+        });
+
+        // Index pra "top atendentes" + "clientes com reclamações"
+        Schema::table('customer_memory', function (Blueprint $table): void {
+            $indexes = collect(\Illuminate\Support\Facades\DB::select('SHOW INDEX FROM customer_memory'))
+                ->pluck('Key_name')->unique()->all();
+
+            if (! in_array('cm_biz_assigned_idx', $indexes, true)) {
+                $table->index(['business_id', 'assigned_user_id'], 'cm_biz_assigned_idx');
+            }
+            if (! in_array('cm_biz_reclamacoes_idx', $indexes, true)) {
+                $table->index(['business_id', 'total_reclamacoes'], 'cm_biz_reclamacoes_idx');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('customer_memory', function (Blueprint $table): void {
+            $indexes = collect(\Illuminate\Support\Facades\DB::select('SHOW INDEX FROM customer_memory'))
+                ->pluck('Key_name')->unique()->all();
+
+            foreach (['cm_biz_assigned_idx', 'cm_biz_reclamacoes_idx'] as $idx) {
+                if (in_array($idx, $indexes, true)) {
+                    $table->dropIndex($idx);
+                }
+            }
+
+            foreach ([
+                'assigned_user_id', 'most_active_user_id', 'most_active_user_count',
+                'reclamacoes_recentes', 'total_reclamacoes',
+                'external_sources', 'external_sources_enriched_at',
+            ] as $col) {
+                if (Schema::hasColumn('customer_memory', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
+    }
+};

--- a/Modules/Whatsapp/Database/Migrations/2026_05_15_250000_create_employee_performance_table.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_15_250000_create_employee_performance_table.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-WA-VOZ-003 — Employee Performance scorecard.
+ *
+ * Wagner 2026-05-15: "Avalie o atendimento da empresa, de uma nota para
+ * todos cliente e funcionários. Deverá criar um perfil para todos
+ * funcionários e clientes."
+ *
+ * Single source of truth da PERFORMANCE de cada atendente do business
+ * (Maiara, Luiz, Felipe, etc). 1 row per (business_id, user_id).
+ *
+ * Métricas calculadas daily pelo `EmployeePerformanceRebuilder`:
+ *   - Volume (n_msgs, n_conversations, n_clientes)
+ *   - Velocidade (tempo_resposta_mediana_s, p90, sla_breach)
+ *   - Qualidade (reclamacoes_recebidas — soma das reclamações dos clientes atendidos)
+ *   - Cobertura (horas_ativas_distintas, hora_pico, dias_ativos_30d)
+ *   - Especialidades (temas_dominantes — futuro inferência IA)
+ *   - Nota geral 0-100 (scoring transparente — ver Service)
+ *
+ * Identidade do atendente: PRIMÁRIO via `messages.sender_user_id` (quando
+ * atendente responde via UI Inbox oimpresso). FALLBACK heurístico via
+ * `messages.body LIKE '%Nome:%'` (quando responde via WhatsApp Web direto).
+ *
+ * Tier 0 multi-tenant: business_id NOT NULL + UNIQUE composto (biz, user_id).
+ *
+ * Idempotente.
+ *
+ * @see Modules/Whatsapp/Entities/EmployeePerformance.php
+ * @see Modules/Whatsapp/Services/CustomerMemory/EmployeePerformanceRebuilder.php
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('employee_performance')) {
+            return;
+        }
+
+        Schema::create('employee_performance', function (Blueprint $table): void {
+            $table->bigIncrements('id');
+
+            // Tier 0 multi-tenant
+            $table->unsignedInteger('business_id');
+
+            // Identidade do atendente
+            $table->unsignedInteger('user_id')->nullable()
+                ->comment('FK users.id — NULL quando identidade só por heurística nome');
+            $table->string('heuristic_name', 60)->nullable()
+                ->comment('Nome detectado via body *Nome:* — quando sender_user_id NULL');
+            $table->string('display_name', 120)->nullable()
+                ->comment('Nome canônico — users.first_name ou heuristic_name');
+
+            // Volume agregado
+            $table->unsignedInteger('n_msgs_total')->default(0);
+            $table->unsignedInteger('n_conversations_atendidas')->default(0);
+            $table->unsignedInteger('n_clientes_diferentes')->default(0);
+
+            // Velocidade resposta
+            $table->unsignedInteger('tempo_resposta_mediana_s')->nullable()
+                ->comment('Mediana segundos entre inbound anterior → outbound do atendente');
+            $table->unsignedInteger('tempo_resposta_p90_s')->nullable();
+            $table->unsignedInteger('sla_breach_count')->default(0)
+                ->comment('Conversas com primeira resposta > SLA (default 4h)');
+
+            // Qualidade (proxy)
+            $table->unsignedInteger('reclamacoes_recebidas')->default(0)
+                ->comment('Soma de total_reclamacoes dos clientes que esse atendente atendeu');
+            $table->decimal('csat_avg', 3, 2)->nullable()
+                ->comment('CSAT médio quando integração futura WhatsappCsatResponse pronta');
+
+            // Cobertura temporal
+            $table->unsignedTinyInteger('horas_ativas_distintas')->default(0)
+                ->comment('Count DISTINCT HOUR(created_at) — 0-24');
+            $table->unsignedTinyInteger('hora_pico')->nullable()
+                ->comment('Hora 0-23 com maior volume outbound do atendente');
+            $table->unsignedTinyInteger('dias_ativos_30d')->default(0);
+            $table->timestamp('primeira_atividade_at')->nullable();
+            $table->timestamp('ultima_atividade_at')->nullable();
+
+            // Especialidades (futuro IA)
+            $table->json('temas_dominantes')->nullable()
+                ->comment('["nfe","boleto","caixa"] — inferido temas_recorrentes dos clientes atendidos');
+
+            // Nota agregada 0-100 (scoring transparente — ver Service)
+            $table->unsignedTinyInteger('nota_geral')->nullable();
+            $table->json('nota_breakdown')->nullable()
+                ->comment('{volume:25,diversidade:20,velocidade:25,profundidade:15,cobertura:10,engajamento:5}');
+            $table->timestamp('nota_calculada_em')->nullable();
+
+            // Flags operacionais
+            $table->json('flags')->nullable()
+                ->comment('[{tipo:"top_performer",since},{tipo:"baixo_volume_30d"},{tipo:"ferias",until}]');
+
+            // Tracking rebuild
+            $table->timestamp('last_rebuilt_at')->nullable();
+            $table->string('rebuilt_via', 24)->nullable();
+
+            $table->timestamps();
+
+            // Constraints
+            // Pra user_id real: UNIQUE (biz, user_id) — 1 row per user real
+            // Pra heurístico: UNIQUE (biz, heuristic_name) quando user_id NULL
+            $table->index(['business_id', 'user_id'], 'ep_biz_user_idx');
+            $table->index(['business_id', 'nota_geral'], 'ep_biz_nota_idx');
+            $table->index(['business_id', 'heuristic_name'], 'ep_biz_heur_idx');
+        });
+
+        if (Schema::hasTable('business')) {
+            Schema::table('employee_performance', function (Blueprint $table): void {
+                $table->foreign('business_id', 'employee_performance_business_fk')
+                    ->references('id')->on('business')
+                    ->onDelete('cascade');
+            });
+        }
+
+        if (Schema::hasTable('users')) {
+            Schema::table('employee_performance', function (Blueprint $table): void {
+                $table->foreign('user_id', 'employee_performance_user_fk')
+                    ->references('id')->on('users')
+                    ->onDelete('set null');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('employee_performance');
+    }
+};

--- a/Modules/Whatsapp/Entities/CustomerMemory.php
+++ b/Modules/Whatsapp/Entities/CustomerMemory.php
@@ -48,6 +48,13 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  * @property ?\Illuminate\Support\Carbon $erasure_requested_at
  * @property ?\Illuminate\Support\Carbon $last_rebuilt_at
  * @property ?string $rebuilt_via
+ * @property ?int $assigned_user_id
+ * @property ?int $most_active_user_id
+ * @property ?int $most_active_user_count
+ * @property ?array $reclamacoes_recentes
+ * @property int $total_reclamacoes
+ * @property ?array $external_sources
+ * @property ?\Illuminate\Support\Carbon $external_sources_enriched_at
  */
 class CustomerMemory extends Model
 {
@@ -106,6 +113,14 @@ class CustomerMemory extends Model
         'erasure_requested_at',
         'last_rebuilt_at',
         'rebuilt_via',
+        // US-WA-VOZ-002 — funcionário + reclamações + fontes externas
+        'assigned_user_id',
+        'most_active_user_id',
+        'most_active_user_count',
+        'reclamacoes_recentes',
+        'total_reclamacoes',
+        'external_sources',
+        'external_sources_enriched_at',
     ];
 
     protected $casts = [
@@ -126,6 +141,13 @@ class CustomerMemory extends Model
         'flags' => 'array',
         'erasure_requested_at' => 'datetime',
         'last_rebuilt_at' => 'datetime',
+        'assigned_user_id' => 'integer',
+        'most_active_user_id' => 'integer',
+        'most_active_user_count' => 'integer',
+        'reclamacoes_recentes' => 'array',
+        'total_reclamacoes' => 'integer',
+        'external_sources' => 'array',
+        'external_sources_enriched_at' => 'datetime',
     ];
 
     public function contact(): BelongsTo

--- a/Modules/Whatsapp/Entities/CustomerMemory.php
+++ b/Modules/Whatsapp/Entities/CustomerMemory.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use App\Contact;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * US-WA-VOZ-001 — Memória persistente do cliente final.
+ *
+ * Eloquent Model da tabela `customer_memory`. Toda interação WhatsApp
+ * agrega aqui: stats, identidade (linkagem Contact CRM), inferências IA
+ * (futuro), notas qualitativas, flags operacionais, LGPD consent.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL ([ADR 0093](../../../decisions/0093-multi-tenant-isolation-tier-0.md))
+ * via trait `HasBusinessScope` — toda query passa pelo global scope.
+ *
+ * Identity: chave de negócio é `(business_id, customer_external_id)` — UNIQUE.
+ * `contact_id` é NULL quando cliente nunca foi cadastrado no CRM ou match
+ * de telefone não bateu. Pode ser preenchido depois (re-tentativa job daily).
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property string $customer_external_id
+ * @property ?string $phone_normalized
+ * @property ?int $contact_id
+ * @property ?string $identity_match_method
+ * @property ?float $identity_match_confidence
+ * @property ?\Illuminate\Support\Carbon $identity_match_at
+ * @property ?string $display_name
+ * @property int $n_conversations
+ * @property int $n_msgs_inbound
+ * @property int $n_msgs_outbound
+ * @property ?\Illuminate\Support\Carbon $first_interaction_at
+ * @property ?\Illuminate\Support\Carbon $last_interaction_at
+ * @property ?array $temas_recorrentes
+ * @property ?float $sentimento_score
+ * @property ?float $churn_risk_score
+ * @property ?array $comunicacao_preferida
+ * @property ?string $notas_jana
+ * @property ?\Illuminate\Support\Carbon $notas_atualizada_em
+ * @property ?array $flags
+ * @property ?string $consent_status
+ * @property ?\Illuminate\Support\Carbon $erasure_requested_at
+ * @property ?\Illuminate\Support\Carbon $last_rebuilt_at
+ * @property ?string $rebuilt_via
+ */
+class CustomerMemory extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'customer_memory';
+
+    /**
+     * Métodos canônicos de identity matching (sincronizado com migration
+     * + ConversationContactLinker::findMatchesForPhone()).
+     */
+    public const MATCH_EXACT = 'exact';
+    public const MATCH_SUFFIX_8 = 'suffix_8';
+    public const MATCH_MANUAL = 'manual';
+    public const MATCH_AMBIGUOUS = 'ambiguous_picked_first';
+    public const MATCH_UNKNOWN = 'unknown';
+
+    /**
+     * Estados do consent LGPD (espelha contacts.whatsapp_consent).
+     */
+    public const CONSENT_GIVEN = 'given';
+    public const CONSENT_WITHDRAWN = 'withdrawn';
+    public const CONSENT_UNKNOWN = 'unknown';
+
+    /**
+     * Origens de rebuild — útil pra debugging "por que esse stat mudou?".
+     */
+    public const REBUILT_VIA_BACKFILL = 'backfill';
+    public const REBUILT_VIA_CRON_DAILY = 'cron_daily';
+    public const REBUILT_VIA_LISTENER = 'listener';
+    public const REBUILT_VIA_MANUAL = 'manual';
+    public const REBUILT_VIA_WEBHOOK = 'webhook';
+
+    protected $fillable = [
+        'business_id',
+        'customer_external_id',
+        'phone_normalized',
+        'contact_id',
+        'identity_match_method',
+        'identity_match_confidence',
+        'identity_match_at',
+        'display_name',
+        'n_conversations',
+        'n_msgs_inbound',
+        'n_msgs_outbound',
+        'first_interaction_at',
+        'last_interaction_at',
+        'temas_recorrentes',
+        'sentimento_score',
+        'churn_risk_score',
+        'comunicacao_preferida',
+        'notas_jana',
+        'notas_atualizada_em',
+        'flags',
+        'consent_status',
+        'erasure_requested_at',
+        'last_rebuilt_at',
+        'rebuilt_via',
+    ];
+
+    protected $casts = [
+        'business_id' => 'integer',
+        'contact_id' => 'integer',
+        'identity_match_confidence' => 'float',
+        'identity_match_at' => 'datetime',
+        'n_conversations' => 'integer',
+        'n_msgs_inbound' => 'integer',
+        'n_msgs_outbound' => 'integer',
+        'first_interaction_at' => 'datetime',
+        'last_interaction_at' => 'datetime',
+        'temas_recorrentes' => 'array',
+        'sentimento_score' => 'float',
+        'churn_risk_score' => 'float',
+        'comunicacao_preferida' => 'array',
+        'notas_atualizada_em' => 'datetime',
+        'flags' => 'array',
+        'erasure_requested_at' => 'datetime',
+        'last_rebuilt_at' => 'datetime',
+    ];
+
+    public function contact(): BelongsTo
+    {
+        return $this->belongsTo(Contact::class, 'contact_id');
+    }
+
+    /**
+     * Total mensagens (in + out) — derivado.
+     */
+    public function getNMsgsTotalAttribute(): int
+    {
+        return (int) $this->n_msgs_inbound + (int) $this->n_msgs_outbound;
+    }
+
+    /**
+     * Dias desde última interação. Útil pra churn heurística e displays.
+     */
+    public function daysSinceLastInteraction(): ?int
+    {
+        if ($this->last_interaction_at === null) {
+            return null;
+        }
+        return (int) $this->last_interaction_at->diffInDays(now());
+    }
+
+    /**
+     * Verdadeiro se cliente pediu erasure LGPD (Art. 18).
+     * Sidebar/UI deve mostrar redacted state e bloquear bot Jana.
+     */
+    public function isErasureRequested(): bool
+    {
+        return $this->erasure_requested_at !== null;
+    }
+}

--- a/Modules/Whatsapp/Entities/EmployeePerformance.php
+++ b/Modules/Whatsapp/Entities/EmployeePerformance.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Entities;
+
+use App\Concerns\HasBusinessScope;
+use App\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * US-WA-VOZ-003 — Performance scorecard de cada atendente WhatsApp.
+ *
+ * Eloquent Model da tabela `employee_performance`. Recompila daily via
+ * `EmployeePerformanceRebuilder` agregando volume + velocidade + qualidade
+ * + cobertura + nota 0-100 ponderada.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL ([ADR 0093](../../../decisions/0093-multi-tenant-isolation-tier-0.md))
+ * via `HasBusinessScope`.
+ *
+ * Identidade flexível:
+ *   - PRIMÁRIO: `user_id` (FK users.id) quando atendente responde via UI Inbox
+ *   - FALLBACK: `heuristic_name` (string) detectado via `messages.body LIKE '*Nome:*'`
+ *
+ * @property int $id
+ * @property int $business_id
+ * @property ?int $user_id
+ * @property ?string $heuristic_name
+ * @property ?string $display_name
+ * @property int $n_msgs_total
+ * @property int $n_conversations_atendidas
+ * @property int $n_clientes_diferentes
+ * @property ?int $tempo_resposta_mediana_s
+ * @property ?int $tempo_resposta_p90_s
+ * @property int $sla_breach_count
+ * @property int $reclamacoes_recebidas
+ * @property ?float $csat_avg
+ * @property int $horas_ativas_distintas
+ * @property ?int $hora_pico
+ * @property int $dias_ativos_30d
+ * @property ?\Illuminate\Support\Carbon $primeira_atividade_at
+ * @property ?\Illuminate\Support\Carbon $ultima_atividade_at
+ * @property ?array $temas_dominantes
+ * @property ?int $nota_geral
+ * @property ?array $nota_breakdown
+ * @property ?\Illuminate\Support\Carbon $nota_calculada_em
+ * @property ?array $flags
+ * @property ?\Illuminate\Support\Carbon $last_rebuilt_at
+ * @property ?string $rebuilt_via
+ */
+class EmployeePerformance extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'employee_performance';
+
+    // SLA padrão atendimento (segundos)
+    public const SLA_FIRST_RESPONSE_SECONDS = 14400; // 4h
+
+    // Origens rebuild
+    public const REBUILT_VIA_BACKFILL = 'backfill';
+    public const REBUILT_VIA_CRON_DAILY = 'cron_daily';
+    public const REBUILT_VIA_MANUAL = 'manual';
+
+    // Classificação da nota (faixas)
+    public const NOTA_FAIXA_EXCELENTE = 90;
+    public const NOTA_FAIXA_BOM = 70;
+    public const NOTA_FAIXA_REGULAR = 50;
+
+    protected $fillable = [
+        'business_id', 'user_id', 'heuristic_name', 'display_name',
+        'n_msgs_total', 'n_conversations_atendidas', 'n_clientes_diferentes',
+        'tempo_resposta_mediana_s', 'tempo_resposta_p90_s', 'sla_breach_count',
+        'reclamacoes_recebidas', 'csat_avg',
+        'horas_ativas_distintas', 'hora_pico', 'dias_ativos_30d',
+        'primeira_atividade_at', 'ultima_atividade_at',
+        'temas_dominantes',
+        'nota_geral', 'nota_breakdown', 'nota_calculada_em',
+        'flags',
+        'last_rebuilt_at', 'rebuilt_via',
+    ];
+
+    protected $casts = [
+        'business_id' => 'integer',
+        'user_id' => 'integer',
+        'n_msgs_total' => 'integer',
+        'n_conversations_atendidas' => 'integer',
+        'n_clientes_diferentes' => 'integer',
+        'tempo_resposta_mediana_s' => 'integer',
+        'tempo_resposta_p90_s' => 'integer',
+        'sla_breach_count' => 'integer',
+        'reclamacoes_recebidas' => 'integer',
+        'csat_avg' => 'float',
+        'horas_ativas_distintas' => 'integer',
+        'hora_pico' => 'integer',
+        'dias_ativos_30d' => 'integer',
+        'primeira_atividade_at' => 'datetime',
+        'ultima_atividade_at' => 'datetime',
+        'temas_dominantes' => 'array',
+        'nota_geral' => 'integer',
+        'nota_breakdown' => 'array',
+        'nota_calculada_em' => 'datetime',
+        'flags' => 'array',
+        'last_rebuilt_at' => 'datetime',
+    ];
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    /**
+     * Faixa textual da nota — pra UI Sidebar mostrar badge.
+     */
+    public function faixa(): string
+    {
+        $n = (int) ($this->nota_geral ?? 0);
+        return match (true) {
+            $n >= self::NOTA_FAIXA_EXCELENTE => 'excelente',
+            $n >= self::NOTA_FAIXA_BOM => 'bom',
+            $n >= self::NOTA_FAIXA_REGULAR => 'regular',
+            default => 'abaixo',
+        };
+    }
+
+    /**
+     * Identidade legível pra logs e UI.
+     */
+    public function identidade(): string
+    {
+        if ($this->display_name) {
+            return $this->display_name;
+        }
+        if ($this->user_id) {
+            return "user_id={$this->user_id}";
+        }
+        if ($this->heuristic_name) {
+            return "heur:{$this->heuristic_name}";
+        }
+        return 'unknown';
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -785,6 +785,20 @@ class InboxController extends Controller
         //
         // US-WA-071: notas internas nascem com status='sent' direto (sem
         // dispatch driver) — Centrifugo distribui pros atendentes do business.
+        //
+        // US-WA-VOZ-003 (2026-05-15): Auto-prefix `*FirstName:* ` no body
+        // outbound humano freeform. Cliente vê quem responde + heurística
+        // `EmployeePerformanceRebuilder` captura 100% mesmo sem sender_user_id.
+        // Idempotente: pula se body já começa com `*Nome:*` (atendente já
+        // digitou) ou se é template/nota-interna (slash commands fazem prefix
+        // próprio).
+        $finalBody = $this->maybeAutoPrefixSenderName(
+            $data['body'] ?? null,
+            $userId,
+            (bool) $isInternalNote,
+            $data['kind'] === 'template',
+        );
+
         $message = Message::query()->create([
             'business_id' => $businessId,
             'conversation_id' => $conversation->id,
@@ -792,7 +806,7 @@ class InboxController extends Controller
             'provider' => $channel->type,
             'type' => $data['kind'] === 'template' ? 'template' : 'text',
             'template_name' => $data['template_name'] ?? null,
-            'body' => $data['body'] ?? null,
+            'body' => $finalBody,
             'status' => $isInternalNote ? 'sent' : 'queued',
             'sender_user_id' => $userId ?: null,
             'sender_kind' => 'human',
@@ -1759,5 +1773,63 @@ class InboxController extends Controller
         if (! $hasAccess) {
             abort(403, 'Sem acesso ao canal selecionado.');
         }
+    }
+
+    /**
+     * US-WA-VOZ-003 — Auto-prefix `*FirstName:* ` no body outbound humano.
+     *
+     * Quando atendente envia via UI Inbox, prepend `*Nome:* ` no início do
+     * body. Resultado: cliente WhatsApp vê "Maiara:" e heurística
+     * `EmployeePerformanceRebuilder` captura 100% mesmo sem `sender_user_id`
+     * persistido (defesa em profundidade).
+     *
+     * **Skips (idempotente):**
+     * - is_internal_note=true   — slash command já formata
+     * - kind=template           — HSM já tem variáveis customizadas
+     * - body=null/empty         — nada a prefixar
+     * - body já tem `*Algum:*`  — atendente digitou manual
+     * - userId inválido         — sem identidade pra prefix
+     *
+     * **Pega `first_name` do User; fallback username.**
+     */
+    protected function maybeAutoPrefixSenderName(?string $body, int $userId, bool $isInternalNote, bool $isTemplate): ?string
+    {
+        if ($body === null || trim($body) === '') {
+            return $body;
+        }
+        if ($isInternalNote || $isTemplate) {
+            return $body;
+        }
+        if ($userId <= 0) {
+            return $body;
+        }
+
+        // Idempotência — body já tem prefix `*Nome:*` (case-insensitive)
+        if (preg_match('/^\s*\*[A-Za-zÀ-ÿ]{2,30}:\*/u', $body)) {
+            return $body;
+        }
+
+        try {
+            $user = \App\User::query()->withoutGlobalScopes()->find($userId);
+        } catch (\Throwable) {
+            return $body;
+        }
+
+        if ($user === null) {
+            return $body;
+        }
+
+        $name = trim((string) ($user->first_name ?? ''));
+        if ($name === '') {
+            $name = (string) ($user->username ?? '');
+        }
+        // Sanitiza: só letras + acentos + espaço, max 30 chars
+        $name = preg_replace('/[^A-Za-zÀ-ÿ ]/u', '', $name) ?? '';
+        $name = trim(mb_substr($name, 0, 30));
+        if ($name === '') {
+            return $body;
+        }
+
+        return "*{$name}:* " . ltrim($body);
     }
 }

--- a/Modules/Whatsapp/Http/Controllers/Api/CustomerProfileController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/CustomerProfileController.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Controllers\Api;
+
+use App\Contact;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\CustomerMemory;
+use Modules\Whatsapp\Jobs\RebuildCustomerMemoryJob;
+use Modules\Whatsapp\Services\CustomerMemory\CustomerMemoryRebuilder;
+
+/**
+ * US-WA-VOZ-001 — Endpoint Customer Profile (Sidebar Customer 360).
+ *
+ * `GET /atendimento/customer/{external_id}/profile`
+ *
+ * Retorna JSON consumido pelo componente `<CustomerSidebar>` (Inertia React)
+ * com toda memória do cliente: identity, stats, inferências, contact CRM,
+ * últimas conversas, e flag LGPD.
+ *
+ * Tier 0 multi-tenant: `business_id` resolvido via session() do user autenticado
+ * (NÃO trusta query string). Acesso requer permission `whatsapp.access`.
+ *
+ * Auto-rebuild lazy: se customer_memory não existe ainda OU é stale,
+ * dispatcha job em background. Endpoint sempre responde rápido com o
+ * que tem (best-effort).
+ *
+ * @see Modules/Whatsapp/Services/CustomerMemory/CustomerMemoryRebuilder.php
+ */
+class CustomerProfileController extends Controller
+{
+    public function __construct(
+        protected readonly CustomerMemoryRebuilder $rebuilder,
+    ) {
+    }
+
+    /**
+     * GET /atendimento/customer/{external_id}/profile
+     *
+     * Path param `external_id` é o E.164 sem '+' (ex: '5548999872822').
+     * Sidebar passa o número canônico da Conversation.
+     */
+    public function show(Request $request, string $externalId): JsonResponse
+    {
+        $businessId = (int) ($request->session()->get('business.id') ?? session('business')?->id ?? 0);
+        if ($businessId <= 0) {
+            return response()->json(['error' => 'no_business_context'], 401);
+        }
+
+        $extId = ltrim(trim($externalId), '+');
+        if ($extId === '' || ! preg_match('/^\d{8,20}$/', $extId)) {
+            return response()->json(['error' => 'invalid_external_id'], 422);
+        }
+
+        $memory = CustomerMemory::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('customer_external_id', $extId)
+            ->first();
+
+        // Lazy create if missing — dispatcha rebuild assíncrono
+        if ($memory === null) {
+            RebuildCustomerMemoryJob::dispatch($businessId, $extId, CustomerMemory::REBUILT_VIA_WEBHOOK);
+
+            return response()->json([
+                'state' => 'building',
+                'message' => 'Memória sendo construída. Tente novamente em alguns segundos.',
+                'customer_external_id' => $extId,
+            ], 202);
+        }
+
+        // LGPD — cliente pediu erasure: retorna profile minimalista
+        if ($memory->isErasureRequested()) {
+            return response()->json([
+                'state' => 'erasure_requested',
+                'customer_external_id' => $extId,
+                'erasure_requested_at' => $memory->erasure_requested_at->toIso8601String(),
+                'message' => 'Cliente exerceu direito de apagamento (LGPD Art. 18).',
+            ]);
+        }
+
+        // Stale (>24h) — refresca em background, mas responde com cache
+        $staleHours = (int) config('whatsapp.customer_memory.rebuild_after_hours', 6);
+        if ($memory->last_rebuilt_at === null
+            || $memory->last_rebuilt_at->lt(now()->subHours($staleHours))) {
+            RebuildCustomerMemoryJob::dispatch($businessId, $extId, CustomerMemory::REBUILT_VIA_WEBHOOK);
+        }
+
+        // Payload completo
+        $contact = null;
+        if ($memory->contact_id !== null) {
+            $contact = Contact::query()
+                ->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('business_id', $businessId)
+                ->where('id', $memory->contact_id)
+                ->first([
+                    'id', 'name', 'email', 'cpf_cnpj', 'mobile', 'landline',
+                    'alternate_number', 'address_line_1', 'city', 'state',
+                    'whatsapp_consent', 'crm_source', 'crm_life_stage',
+                    'customer_group_id', 'balance', 'credit_limit',
+                ]);
+        }
+
+        $recentConversations = DB::table('conversations')
+            ->where('business_id', $businessId)
+            ->where(function ($q) use ($extId) {
+                $q->where('customer_external_id', $extId)
+                  ->orWhere('customer_external_id', '+' . $extId);
+            })
+            ->orderByDesc('updated_at')
+            ->limit(5)
+            ->get([
+                'id', 'channel_id', 'status', 'last_message_at',
+                'last_message_preview', 'last_message_direction', 'unread_count',
+                'created_at',
+            ]);
+
+        return response()->json([
+            'state' => 'ok',
+            'customer_external_id' => $extId,
+            'memory' => [
+                'id' => $memory->id,
+                'display_name' => $memory->display_name,
+                'phone_normalized' => $memory->phone_normalized,
+                'identity' => [
+                    'contact_id' => $memory->contact_id,
+                    'method' => $memory->identity_match_method,
+                    'confidence' => $memory->identity_match_confidence,
+                    'matched_at' => optional($memory->identity_match_at)->toIso8601String(),
+                ],
+                'stats' => [
+                    'n_conversations' => $memory->n_conversations,
+                    'n_msgs_inbound' => $memory->n_msgs_inbound,
+                    'n_msgs_outbound' => $memory->n_msgs_outbound,
+                    'n_msgs_total' => $memory->n_msgs_total,
+                    'first_interaction_at' => optional($memory->first_interaction_at)->toIso8601String(),
+                    'last_interaction_at' => optional($memory->last_interaction_at)->toIso8601String(),
+                    'days_since_last' => $memory->daysSinceLastInteraction(),
+                ],
+                'inferences' => [
+                    'temas_recorrentes' => $memory->temas_recorrentes,
+                    'sentimento_score' => $memory->sentimento_score,
+                    'churn_risk_score' => $memory->churn_risk_score,
+                    'comunicacao_preferida' => $memory->comunicacao_preferida,
+                ],
+                'notes' => [
+                    'notas_jana' => $memory->notas_jana,
+                    'atualizada_em' => optional($memory->notas_atualizada_em)->toIso8601String(),
+                ],
+                'flags' => $memory->flags ?? [],
+                'consent' => [
+                    'status' => $memory->consent_status,
+                    'erasure_requested_at' => optional($memory->erasure_requested_at)->toIso8601String(),
+                ],
+                'last_rebuilt_at' => optional($memory->last_rebuilt_at)->toIso8601String(),
+                'rebuilt_via' => $memory->rebuilt_via,
+            ],
+            'contact' => $contact,
+            'recent_conversations' => $recentConversations,
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Http/Controllers/Api/EmployeeScorecardController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/EmployeeScorecardController.php
@@ -1,0 +1,147 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\EmployeePerformance;
+
+/**
+ * US-WA-VOZ-003 — Endpoint scorecard de atendente.
+ *
+ * GET /atendimento/employee/{user_id}/scorecard       (atendente real)
+ * GET /atendimento/employee/heur:{name}/scorecard     (heurístico fallback)
+ *
+ * Tier 0: business_id resolvido via session (NÃO trusta query).
+ * Permission: `whatsapp.access` (mesma do Inbox — quem atende vê próprio scorecard
+ * e do time pra benchmark).
+ *
+ * Pode usar pra:
+ *   - Sidebar UI mostrar "atendente atual desta conversa: Maiara · 94/100"
+ *   - Dashboard Wagner admin ver ranking time
+ *   - Wagner consultar nota individual em 1:1
+ *
+ * @see Modules/Whatsapp/Entities/EmployeePerformance.php
+ */
+class EmployeeScorecardController extends Controller
+{
+    public function show(Request $request, string $userIdentifier): JsonResponse
+    {
+        $businessId = (int) ($request->session()->get('business.id') ?? session('business')?->id ?? 0);
+        if ($businessId <= 0) {
+            return response()->json(['error' => 'no_business_context'], 401);
+        }
+
+        // Suporta 2 formatos:
+        //   - numérico (ex: "42") = user_id real
+        //   - "heur:Nome" = heurístico
+        $query = EmployeePerformance::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId);
+
+        if (str_starts_with($userIdentifier, 'heur:')) {
+            $name = substr($userIdentifier, 5);
+            if (! preg_match('/^[A-Za-zÀ-ÿ]{2,40}$/u', $name)) {
+                return response()->json(['error' => 'invalid_heuristic_name'], 422);
+            }
+            $query->whereNull('user_id')->where('heuristic_name', $name);
+        } else {
+            if (! preg_match('/^\d+$/', $userIdentifier)) {
+                return response()->json(['error' => 'invalid_user_identifier'], 422);
+            }
+            $query->where('user_id', (int) $userIdentifier);
+        }
+
+        $perf = $query->first();
+        if ($perf === null) {
+            return response()->json(['state' => 'not_found'], 404);
+        }
+
+        return response()->json([
+            'state' => 'ok',
+            'scorecard' => [
+                'id' => $perf->id,
+                'identity' => [
+                    'user_id' => $perf->user_id,
+                    'heuristic_name' => $perf->heuristic_name,
+                    'display_name' => $perf->display_name,
+                ],
+                'volume' => [
+                    'n_msgs_total' => $perf->n_msgs_total,
+                    'n_conversations_atendidas' => $perf->n_conversations_atendidas,
+                    'n_clientes_diferentes' => $perf->n_clientes_diferentes,
+                ],
+                'velocidade' => [
+                    'mediana_s' => $perf->tempo_resposta_mediana_s,
+                    'p90_s' => $perf->tempo_resposta_p90_s,
+                    'sla_breach_count' => $perf->sla_breach_count,
+                    'sla_threshold_s' => EmployeePerformance::SLA_FIRST_RESPONSE_SECONDS,
+                ],
+                'qualidade' => [
+                    'reclamacoes_recebidas' => $perf->reclamacoes_recebidas,
+                    'csat_avg' => $perf->csat_avg,
+                ],
+                'cobertura' => [
+                    'horas_ativas_distintas' => $perf->horas_ativas_distintas,
+                    'hora_pico' => $perf->hora_pico,
+                    'dias_ativos_30d' => $perf->dias_ativos_30d,
+                    'primeira_atividade_at' => optional($perf->primeira_atividade_at)->toIso8601String(),
+                    'ultima_atividade_at' => optional($perf->ultima_atividade_at)->toIso8601String(),
+                ],
+                'especialidades' => [
+                    'temas_dominantes' => $perf->temas_dominantes,
+                ],
+                'nota' => [
+                    'geral' => $perf->nota_geral,
+                    'faixa' => $perf->faixa(),
+                    'breakdown' => $perf->nota_breakdown,
+                    'calculada_em' => optional($perf->nota_calculada_em)->toIso8601String(),
+                ],
+                'flags' => $perf->flags ?? [],
+                'last_rebuilt_at' => optional($perf->last_rebuilt_at)->toIso8601String(),
+                'rebuilt_via' => $perf->rebuilt_via,
+            ],
+        ]);
+    }
+
+    /**
+     * GET /atendimento/employee/scorecards
+     *
+     * Lista TODOS scorecards do business (ranking pra dashboard Wagner).
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $businessId = (int) ($request->session()->get('business.id') ?? session('business')?->id ?? 0);
+        if ($businessId <= 0) {
+            return response()->json(['error' => 'no_business_context'], 401);
+        }
+
+        $perfs = EmployeePerformance::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->orderByDesc('nota_geral')
+            ->get();
+
+        $items = $perfs->map(fn (EmployeePerformance $p) => [
+            'user_id' => $p->user_id,
+            'heuristic_name' => $p->heuristic_name,
+            'display_name' => $p->display_name,
+            'nota_geral' => $p->nota_geral,
+            'faixa' => $p->faixa(),
+            'n_msgs_total' => $p->n_msgs_total,
+            'n_conversations_atendidas' => $p->n_conversations_atendidas,
+            'reclamacoes_recebidas' => $p->reclamacoes_recebidas,
+            'last_rebuilt_at' => optional($p->last_rebuilt_at)->toIso8601String(),
+        ]);
+
+        return response()->json([
+            'business_id' => $businessId,
+            'scorecards' => $items,
+            'total' => $items->count(),
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Jobs/RebuildCustomerMemoryJob.php
+++ b/Modules/Whatsapp/Jobs/RebuildCustomerMemoryJob.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Entities\CustomerMemory;
+use Modules\Whatsapp\Services\CustomerMemory\CustomerMemoryRebuilder;
+
+/**
+ * US-WA-VOZ-001 — Async rebuild de 1 customer_memory.
+ *
+ * Pattern: Listener real-time chama `Rebuilder::touch()` (cheap),
+ * dispatcha este Job pra rebuild completo em background (queue=`customer-memory`).
+ *
+ * Use cases:
+ *   - Listener cliente novo (sem customer_memory ainda) → cria + rebuild full
+ *   - Cron daily → re-rebuild todos com `last_rebuilt_at < NOW() - 24h`
+ *   - Webhook quando Contact CRM é editado → re-resolve identidade
+ *
+ * Backoff: 30s/120s. 3 tries.
+ * Timeout: 30s (rebuild 1 cliente = 2 queries + 1 cache lookup).
+ *
+ * @see Modules/Whatsapp/Services/CustomerMemory/CustomerMemoryRebuilder.php
+ */
+class RebuildCustomerMemoryJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+    public int $timeout = 30;
+
+    /**
+     * @return array<int, int>
+     */
+    public function backoff(): array
+    {
+        return [30, 120];
+    }
+
+    public function __construct(
+        public readonly int $businessId,
+        public readonly string $customerExternalId,
+        public readonly string $via = CustomerMemory::REBUILT_VIA_LISTENER,
+    ) {
+        $this->onConnection('database');
+        $this->onQueue('customer-memory');
+    }
+
+    public function handle(CustomerMemoryRebuilder $rebuilder): void
+    {
+        $rebuilder->rebuild($this->businessId, $this->customerExternalId, $this->via);
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        Log::channel('single')->error('[customer_memory.rebuild_job_failed]', [
+            'metric_name' => 'customer_memory_rebuild_job_failed',
+            'business_id' => $this->businessId,
+            'customer_external_id_redacted' => substr($this->customerExternalId, 0, 4) . '***' . substr($this->customerExternalId, -2),
+            'via' => $this->via,
+            'error' => $exception->getMessage(),
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Jobs/RebuildEmployeePerformanceJob.php
+++ b/Modules/Whatsapp/Jobs/RebuildEmployeePerformanceJob.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Entities\EmployeePerformance;
+use Modules\Whatsapp\Services\EmployeePerformance\EmployeePerformanceRebuilder;
+
+/**
+ * US-WA-VOZ-003 — Async rebuild de 1 employee_performance.
+ *
+ * Queue separada `employee-performance` (não compete com whatsapp-history).
+ * Backoff 60s/300s. 3 tries.
+ *
+ * @see Modules/Whatsapp/Services/EmployeePerformance/EmployeePerformanceRebuilder.php
+ */
+class RebuildEmployeePerformanceJob implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable, SerializesModels;
+
+    public int $tries = 3;
+    public int $timeout = 60;
+
+    public function backoff(): array
+    {
+        return [60, 300];
+    }
+
+    public function __construct(
+        public readonly int $businessId,
+        public readonly ?int $userId = null,
+        public readonly ?string $heuristicName = null,
+        public readonly string $via = EmployeePerformance::REBUILT_VIA_CRON_DAILY,
+    ) {
+        $this->onConnection('database');
+        $this->onQueue('employee-performance');
+    }
+
+    public function handle(EmployeePerformanceRebuilder $rebuilder): void
+    {
+        $rebuilder->rebuild($this->businessId, $this->userId, $this->heuristicName, $this->via);
+    }
+
+    public function failed(\Throwable $exception): void
+    {
+        Log::channel('single')->error('[employee_performance.rebuild_job_failed]', [
+            'metric_name' => 'employee_performance_rebuild_job_failed',
+            'business_id' => $this->businessId,
+            'user_id' => $this->userId,
+            'heuristic_name' => $this->heuristicName,
+            'via' => $this->via,
+            'error' => $exception->getMessage(),
+        ]);
+    }
+}

--- a/Modules/Whatsapp/Listeners/TouchCustomerMemoryOnMessage.php
+++ b/Modules/Whatsapp/Listeners/TouchCustomerMemoryOnMessage.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Listeners;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\CustomerMemory;
+use Modules\Whatsapp\Events\OmnichannelMessageReceived;
+use Modules\Whatsapp\Events\OmnichannelMessageSent;
+use Modules\Whatsapp\Jobs\RebuildCustomerMemoryJob;
+use Modules\Whatsapp\Services\CustomerMemory\CustomerMemoryRebuilder;
+use Throwable;
+
+/**
+ * US-WA-VOZ-001 — Atualiza `customer_memory.last_interaction_at` em tempo real.
+ *
+ * 2 caminhos:
+ *   1. Cheap path (síncrono): `Rebuilder::touch()` — UPSERT atômico de
+ *      `last_interaction_at` + `first_interaction_at` (COALESCE). 1 query.
+ *   2. Heavy path (async): dispatcha `RebuildCustomerMemoryJob` SE
+ *      `last_rebuilt_at` está velho OU memória nunca foi rebuildada.
+ *      Evita queue depth explodir.
+ *
+ * Threshold "velho" = configurável `whatsapp.customer_memory.rebuild_after_hours`
+ * (default 6h). Garante stats agregados refrescam várias vezes por dia.
+ *
+ * Tier 0 multi-tenant: `business_id` vem do event (Eloquent global scope OK).
+ *
+ * @see Modules/Whatsapp/Jobs/RebuildCustomerMemoryJob.php
+ * @see Modules/Whatsapp/Services/CustomerMemory/CustomerMemoryRebuilder.php
+ */
+class TouchCustomerMemoryOnMessage
+{
+    public function __construct(
+        protected readonly CustomerMemoryRebuilder $rebuilder,
+    ) {
+    }
+
+    /**
+     * Handler genérico — funciona pra `OmnichannelMessageReceived` (inbound)
+     * E `OmnichannelMessageSent` (outbound). Mesma lógica.
+     */
+    public function handle(OmnichannelMessageReceived|OmnichannelMessageSent $event): void
+    {
+        if (! (bool) config('whatsapp.customer_memory.enabled', true)) {
+            return;
+        }
+
+        $message = $event->message;
+
+        try {
+            // SUPERADMIN: listener fora de session HTTP — business_id vem do event
+            $conversation = Conversation::query()
+                ->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('business_id', $message->business_id)
+                ->where('id', $message->conversation_id)
+                ->first(['id', 'customer_external_id']);
+
+            if ($conversation === null || ! $conversation->customer_external_id) {
+                return;
+            }
+
+            $extId = ltrim((string) $conversation->customer_external_id, '+');
+            if ($extId === '') {
+                return;
+            }
+
+            // Cheap path — touch last_interaction_at (1 query upsert)
+            $this->rebuilder->touch($message->business_id, $extId, $message->created_at ?? now());
+
+            // Heavy path? Só dispatcha rebuild se memória velha ou nunca rebuildada.
+            $rebuildAfterHours = (int) config('whatsapp.customer_memory.rebuild_after_hours', 6);
+
+            $needsRebuild = DB::table('customer_memory')
+                ->where('business_id', $message->business_id)
+                ->where('customer_external_id', $extId)
+                ->where(function ($q) use ($rebuildAfterHours) {
+                    $q->whereNull('last_rebuilt_at')
+                      ->orWhere('last_rebuilt_at', '<', now()->subHours($rebuildAfterHours));
+                })
+                ->exists();
+
+            if ($needsRebuild) {
+                RebuildCustomerMemoryJob::dispatch(
+                    $message->business_id,
+                    $extId,
+                    CustomerMemory::REBUILT_VIA_LISTENER,
+                );
+            }
+        } catch (Throwable $e) {
+            Log::channel('single')->warning('[customer_memory.touch_failed]', [
+                'metric_name' => 'customer_memory_touch_failed',
+                'business_id' => $message->business_id,
+                'message_id' => $message->id,
+                'error' => $e->getMessage(),
+            ]);
+            // Fail-open: listener NÃO rethrow — não trava pipeline message
+        }
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -13,6 +13,8 @@ use Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand;
 use Modules\Whatsapp\Console\Commands\CustomerMemoryBackfillCommand;
 use Modules\Whatsapp\Console\Commands\CustomerMemoryEnrichFirebirdCommand;
 use Modules\Whatsapp\Console\Commands\CustomerMemoryRefreshDailyCommand;
+use Modules\Whatsapp\Console\Commands\EmployeePerformanceBackfillCommand;
+use Modules\Whatsapp\Console\Commands\EmployeePerformanceRefreshDailyCommand;
 use Modules\Whatsapp\Console\Commands\BackfillMediaDownloadCommand;
 use Modules\Whatsapp\Console\Commands\ChannelResetCommand;
 use Modules\Whatsapp\Console\Commands\CleanupStaleJobsCommand;
@@ -109,6 +111,9 @@ class WhatsappServiceProvider extends ServiceProvider
                 CustomerMemoryRefreshDailyCommand::class,
                 // US-WA-VOZ-002 — Enrichment Firebird OfficeImpresso (2026-05-15)
                 CustomerMemoryEnrichFirebirdCommand::class,
+                // US-WA-VOZ-003 — Employee Performance scorecard (2026-05-15)
+                EmployeePerformanceBackfillCommand::class,
+                EmployeePerformanceRefreshDailyCommand::class,
             ]);
         }
 

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -10,6 +10,8 @@ use Illuminate\Support\ServiceProvider;
 use Modules\Repair\Events\RepairStatusChanged;
 use Modules\Whatsapp\Console\Commands\AutoLinkConversationContactsCommand;
 use Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand;
+use Modules\Whatsapp\Console\Commands\CustomerMemoryBackfillCommand;
+use Modules\Whatsapp\Console\Commands\CustomerMemoryRefreshDailyCommand;
 use Modules\Whatsapp\Console\Commands\BackfillMediaDownloadCommand;
 use Modules\Whatsapp\Console\Commands\ChannelResetCommand;
 use Modules\Whatsapp\Console\Commands\CleanupStaleJobsCommand;
@@ -39,6 +41,7 @@ use Modules\Whatsapp\Http\Middleware\VerifyMetaSignature;
 use Modules\Whatsapp\Http\Middleware\VerifyZapiSignature;
 use Modules\Whatsapp\Listeners\DispatchToJanaBot;
 use Modules\Whatsapp\Listeners\NotifyRepairCustomer;
+use Modules\Whatsapp\Listeners\TouchCustomerMemoryOnMessage;
 use Modules\Whatsapp\Listeners\PublishMessageReceivedToCentrifugo;
 use Modules\Whatsapp\Listeners\PublishMessageSentToCentrifugo;
 use Modules\Whatsapp\Listeners\PublishOmnichannelToCentrifugo;
@@ -100,6 +103,9 @@ class WhatsappServiceProvider extends ServiceProvider
                 CleanupStaleJobsCommand::class,         // US-WA-084 — purga jobs presos da fila whatsapp-history (>6h)
                 DaemonSourceDriftCheckCommand::class,   // 2026-05-13 — alerta drift main↔daemon CT 100 (cron weekly)
                 WhatsappAuthStateDriftCheckCommand::class, // 2026-05-15 — alerta drift auth_state↔channels pós incident Baileys 7.x deploy (cron daily 03h BRT)
+                // US-WA-VOZ-001 — Customer Memory foundation (2026-05-15)
+                CustomerMemoryBackfillCommand::class,
+                CustomerMemoryRefreshDailyCommand::class,
             ]);
         }
 
@@ -146,6 +152,12 @@ class WhatsappServiceProvider extends ServiceProvider
         // `omnichannel:business:{id}` separado do canal legacy acima.
         Event::listen(OmnichannelMessageReceived::class, PublishOmnichannelToCentrifugo::class);
         Event::listen(OmnichannelMessageSent::class, PublishOmnichannelToCentrifugo::class);
+
+        // US-WA-VOZ-001 — Customer Memory (perfil persistente do cliente final).
+        // Listener síncrono: cheap path UPSERT last_interaction_at + dispatch
+        // RebuildCustomerMemoryJob assíncrono se memória stale (>6h default).
+        Event::listen(OmnichannelMessageReceived::class, TouchCustomerMemoryOnMessage::class);
+        Event::listen(OmnichannelMessageSent::class, TouchCustomerMemoryOnMessage::class);
 
         // Bot Jana — Sprint 3 prep (default disabled via config('whatsapp.bot.enabled'))
         Event::listen(WhatsappMessageReceived::class, DispatchToJanaBot::class);

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -11,6 +11,7 @@ use Modules\Repair\Events\RepairStatusChanged;
 use Modules\Whatsapp\Console\Commands\AutoLinkConversationContactsCommand;
 use Modules\Whatsapp\Console\Commands\BackfillChannelAccessCommand;
 use Modules\Whatsapp\Console\Commands\CustomerMemoryBackfillCommand;
+use Modules\Whatsapp\Console\Commands\CustomerMemoryEnrichFirebirdCommand;
 use Modules\Whatsapp\Console\Commands\CustomerMemoryRefreshDailyCommand;
 use Modules\Whatsapp\Console\Commands\BackfillMediaDownloadCommand;
 use Modules\Whatsapp\Console\Commands\ChannelResetCommand;
@@ -106,6 +107,8 @@ class WhatsappServiceProvider extends ServiceProvider
                 // US-WA-VOZ-001 — Customer Memory foundation (2026-05-15)
                 CustomerMemoryBackfillCommand::class,
                 CustomerMemoryRefreshDailyCommand::class,
+                // US-WA-VOZ-002 — Enrichment Firebird OfficeImpresso (2026-05-15)
+                CustomerMemoryEnrichFirebirdCommand::class,
             ]);
         }
 

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -12,6 +12,7 @@ use Modules\Whatsapp\Http\Controllers\Admin\MetricsController;
 use Modules\Whatsapp\Http\Controllers\Admin\TemplatesController;
 use Modules\Whatsapp\Http\Controllers\Admin\SettingsController;
 use Modules\Whatsapp\Http\Controllers\Api\CustomerProfileController;
+use Modules\Whatsapp\Http\Controllers\Api\EmployeeScorecardController;
 
 /*
 |--------------------------------------------------------------------------
@@ -102,6 +103,18 @@ Route::group([
         ->where('external_id', '[0-9+]+')
         ->middleware('can:whatsapp.access')
         ->name('atendimento.customer.profile');
+
+    // US-WA-VOZ-003 — Employee Scorecard (perfil do atendente).
+    // GET /atendimento/employee/scorecards              → lista ranking time
+    // GET /atendimento/employee/{user_identifier}/scorecard → 1 atendente
+    //   user_identifier formato: "42" (user_id real) OU "heur:Maiara" (heurístico)
+    Route::get('/employee/scorecards', [EmployeeScorecardController::class, 'index'])
+        ->middleware('can:whatsapp.access')
+        ->name('atendimento.employee.scorecards');
+    Route::get('/employee/{user_identifier}/scorecard', [EmployeeScorecardController::class, 'show'])
+        ->where('user_identifier', '[0-9]+|heur:[A-Za-zÀ-ÿ]+')
+        ->middleware('can:whatsapp.access')
+        ->name('atendimento.employee.scorecard');
 
     // Caixa Unificada V4 — substituiu /atendimento/inbox no cutover 2026-05-15.
     // Fonte visual canônica: prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -11,6 +11,7 @@ use Modules\Whatsapp\Http\Controllers\Admin\MacroVariantsController;
 use Modules\Whatsapp\Http\Controllers\Admin\MetricsController;
 use Modules\Whatsapp\Http\Controllers\Admin\TemplatesController;
 use Modules\Whatsapp\Http\Controllers\Admin\SettingsController;
+use Modules\Whatsapp\Http\Controllers\Api\CustomerProfileController;
 
 /*
 |--------------------------------------------------------------------------
@@ -92,6 +93,15 @@ Route::group([
     // - Pages/Atendimento/Inbox/ removida em F6 (PR seguinte, 1 sprint depois)
     Route::redirect('/inbox', '/atendimento/caixa-unificada', 301)
         ->name('atendimento.inbox.index');
+
+    // US-WA-VOZ-001 — Customer Profile (sidebar Customer 360).
+    // GET /atendimento/customer/{external_id}/profile → JSON memória persistente
+    // do cliente final (stats, identidade Contact CRM, conversas recentes, LGPD).
+    // Sidebar React consome via Inertia::defer pra não bloquear abertura conv.
+    Route::get('/customer/{external_id}/profile', [CustomerProfileController::class, 'show'])
+        ->where('external_id', '[0-9+]+')
+        ->middleware('can:whatsapp.access')
+        ->name('atendimento.customer.profile');
 
     // Caixa Unificada V4 — substituiu /atendimento/inbox no cutover 2026-05-15.
     // Fonte visual canônica: prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx

--- a/Modules/Whatsapp/Services/CustomerMemory/CustomerMemoryRebuilder.php
+++ b/Modules/Whatsapp/Services/CustomerMemory/CustomerMemoryRebuilder.php
@@ -80,7 +80,13 @@ class CustomerMemoryRebuilder
         // Step 3 — Display name + consent denormalize (cache de Contact)
         $this->refreshDenormalized($memory);
 
-        // Step 4 — Tracking
+        // Step 4 — Funcionário responsável + funcionário mais ativo (US-WA-VOZ-002)
+        $this->refreshAssignedUser($memory, $businessId, $extId);
+
+        // Step 5 — Reclamações heurística keywords (sem IA, custo zero)
+        $this->refreshReclamacoes($memory, $businessId, $extId);
+
+        // Step 6 — Tracking
         $memory->last_rebuilt_at = now();
         $memory->rebuilt_via = $via;
 
@@ -295,6 +301,146 @@ class CustomerMemoryRebuilder
                 'error' => $e->getMessage(),
             ]);
             $memory->display_name = $memory->display_name ?: ('+' . $memory->customer_external_id);
+        }
+    }
+
+    /**
+     * Step 4 — Funcionário responsável (US-WA-VOZ-002).
+     *
+     * 2 derivações:
+     *   - assigned_user_id    = sender_user_id da msg outbound MAIS RECENTE
+     *   - most_active_user_id = sender_user_id com MAIS msgs outbound histórico
+     *                            (GROUP BY ORDER BY DESC LIMIT 1)
+     *
+     * `sender_user_id` é NULL quando outbound veio do chip direto (Wagner manda
+     * do celular) ou do bot Jana — esses casos não viram "atendente".
+     */
+    protected function refreshAssignedUser(CustomerMemory $memory, int $businessId, string $extId): void
+    {
+        try {
+            // assigned = última outbound humana
+            $assigned = DB::table('messages as m')
+                ->join('conversations as c', 'c.id', '=', 'm.conversation_id')
+                ->where('c.business_id', $businessId)
+                ->where(function ($q) use ($extId) {
+                    $q->where('c.customer_external_id', $extId)
+                      ->orWhere('c.customer_external_id', '+' . $extId);
+                })
+                ->where('m.direction', 'outbound')
+                ->whereNotNull('m.sender_user_id')
+                ->orderByDesc('m.created_at')
+                ->value('m.sender_user_id');
+
+            $memory->assigned_user_id = $assigned ? (int) $assigned : null;
+
+            // most_active = quem mais respondeu histórico
+            $mostActive = DB::table('messages as m')
+                ->join('conversations as c', 'c.id', '=', 'm.conversation_id')
+                ->where('c.business_id', $businessId)
+                ->where(function ($q) use ($extId) {
+                    $q->where('c.customer_external_id', $extId)
+                      ->orWhere('c.customer_external_id', '+' . $extId);
+                })
+                ->where('m.direction', 'outbound')
+                ->whereNotNull('m.sender_user_id')
+                ->select('m.sender_user_id', DB::raw('COUNT(*) as n'))
+                ->groupBy('m.sender_user_id')
+                ->orderByDesc('n')
+                ->limit(1)
+                ->first();
+
+            if ($mostActive !== null) {
+                $memory->most_active_user_id = (int) $mostActive->sender_user_id;
+                $memory->most_active_user_count = (int) $mostActive->n;
+            } else {
+                $memory->most_active_user_id = null;
+                $memory->most_active_user_count = null;
+            }
+        } catch (Throwable $e) {
+            Log::channel('single')->warning('[customer_memory.assigned_user_failed]', [
+                'business_id' => $businessId,
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    /**
+     * Step 5 — Reclamações heurística keywords (US-WA-VOZ-002).
+     *
+     * SEM IA — usa regex sobre body das msgs inbound últimas 30d.
+     *
+     * Keywords mapeadas pra `severity`:
+     *   - critica: "processo", "advogado", "absurdo", "nunca mais", "cancelar", "reembolso"
+     *   - alta:    "reclamar", "péssimo", "horrível", "demais", "insuportável"
+     *   - media:   "problema", "erro", "bug", "atraso", "atrasado", "não consigo", "não funciona"
+     *   - baixa:   "dúvida", "ajuda" (sinais de fricção sem reclamação explícita)
+     *
+     * Output JSON: top 5 mais recentes com severity descendente.
+     *
+     * Quando Onda 3 ativar IA per-msg (PR #916), este código será substituído
+     * por leitura direta de `messages.analise_categoria = 'reclamacao'`.
+     */
+    protected function refreshReclamacoes(CustomerMemory $memory, int $businessId, string $extId): void
+    {
+        $patterns = [
+            'critica' => '/(processo|advogado|absurdo|nunca\s*mais|cancelar|reembolso|procon)/i',
+            'alta' => '/(reclamar|péssimo|pessimo|horrível|horrivel|insuportável|insuportavel|inadmissível|inadmissivel|esperando\s*até\s*agora)/i',
+            'media' => '/(problema|erro|bug|atras|não\s*consig|nao\s*consig|não\s*funcion|nao\s*funcion|deu\s*ruim|travou)/i',
+            'baixa' => '/(dúvida|duvida|ajuda|preciso)/i',
+        ];
+
+        $since = now()->subDays(30);
+
+        try {
+            $msgs = DB::table('messages as m')
+                ->join('conversations as c', 'c.id', '=', 'm.conversation_id')
+                ->where('c.business_id', $businessId)
+                ->where(function ($q) use ($extId) {
+                    $q->where('c.customer_external_id', $extId)
+                      ->orWhere('c.customer_external_id', '+' . $extId);
+                })
+                ->where('m.direction', 'inbound')
+                ->where('m.is_internal_note', false)
+                ->where('m.type', 'text')
+                ->whereNotNull('m.body')
+                ->where('m.created_at', '>=', $since)
+                ->orderByDesc('m.created_at')
+                ->limit(500) // cap defensivo
+                ->get(['m.id', 'm.body', 'm.created_at']);
+
+            $flagged = [];
+            foreach ($msgs as $m) {
+                $body = (string) $m->body;
+                $severity = null;
+                foreach (['critica', 'alta', 'media', 'baixa'] as $sev) {
+                    if (preg_match($patterns[$sev], $body)) {
+                        $severity = $sev;
+                        break; // first match wins (mais severo primeiro)
+                    }
+                }
+                if ($severity === null) {
+                    continue;
+                }
+                $flagged[] = [
+                    'date' => (string) $m->created_at,
+                    'msg_id' => (int) $m->id,
+                    'severity' => $severity,
+                    'preview' => mb_substr(preg_replace('/\s+/', ' ', $body), 0, 140),
+                ];
+            }
+
+            $memory->total_reclamacoes = count($flagged);
+
+            // Top 5 mais recentes (já ordenadas por created_at desc na query)
+            $memory->reclamacoes_recentes = array_slice($flagged, 0, 5);
+            if (empty($memory->reclamacoes_recentes)) {
+                $memory->reclamacoes_recentes = null;
+            }
+        } catch (Throwable $e) {
+            Log::channel('single')->warning('[customer_memory.reclamacoes_failed]', [
+                'business_id' => $businessId,
+                'error' => $e->getMessage(),
+            ]);
         }
     }
 

--- a/Modules/Whatsapp/Services/CustomerMemory/CustomerMemoryRebuilder.php
+++ b/Modules/Whatsapp/Services/CustomerMemory/CustomerMemoryRebuilder.php
@@ -1,0 +1,314 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\CustomerMemory;
+
+use App\Contact;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Entities\CustomerMemory;
+use Modules\Whatsapp\Entities\Message;
+use Modules\Whatsapp\Services\Contacts\ConversationContactLinker;
+use Throwable;
+
+/**
+ * US-WA-VOZ-001 — Recompila o registro `customer_memory` de 1 cliente.
+ *
+ * Stateless. Idempotente. Tier 0 multi-tenant ([ADR 0093](../../../decisions/0093-multi-tenant-isolation-tier-0.md)).
+ *
+ * Responsabilidades:
+ *   1. Resolve identidade (phone → Contact CRM via ConversationContactLinker)
+ *   2. Recalcula stats agregados (n_conversations, n_msgs_*, first/last)
+ *   3. Atualiza display_name + consent_status denormalizados
+ *   4. Marca `last_rebuilt_at` + `rebuilt_via`
+ *
+ * NÃO toca em:
+ *   - Inferências IA (`temas_recorrentes`, `sentimento_score`, `churn_risk_score`,
+ *     `comunicacao_preferida`) — esses são populados por jobs separados Onda 3
+ *   - Notas qualitativas (`notas_jana`, `flags`) — só humano/Jana escrevem
+ *   - `erasure_requested_at` — só endpoint LGPD apaga
+ *
+ * Fail-open: erro em sub-step (ex: ConversationContactLinker down) loga e
+ * continua com identity_match_method=unknown. Stats são best-effort.
+ *
+ * @see Modules/Whatsapp/Services/Contacts/ConversationContactLinker.php
+ * @see Modules/Whatsapp/Entities/CustomerMemory.php
+ */
+class CustomerMemoryRebuilder
+{
+    public function __construct(
+        protected readonly ConversationContactLinker $linker,
+    ) {
+    }
+
+    /**
+     * Recompila customer_memory pra `(business_id, customer_external_id)`.
+     * Cria row se não existir (upsert).
+     *
+     * @param  string  $via  origem do rebuild (REBUILT_VIA_*)
+     */
+    public function rebuild(int $businessId, string $customerExternalId, string $via = CustomerMemory::REBUILT_VIA_MANUAL): CustomerMemory
+    {
+        $extId = $this->normalizeExternalId($customerExternalId);
+        $phoneDigits = preg_replace('/\D+/', '', $extId);
+
+        // SUPERADMIN: service roda em Job/Command sem session HTTP —
+        // withoutGlobalScope + filtro defensivo where('business_id').
+        $memory = CustomerMemory::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('customer_external_id', $extId)
+            ->first();
+
+        if ($memory === null) {
+            $memory = new CustomerMemory();
+            $memory->business_id = $businessId;
+            $memory->customer_external_id = $extId;
+        }
+
+        $memory->phone_normalized = $phoneDigits !== '' ? $phoneDigits : null;
+
+        // Step 1 — Identity Resolution (phone → Contact CRM)
+        $this->resolveIdentity($memory, $businessId, $extId);
+
+        // Step 2 — Stats agregados (n_conversations, n_msgs_*, first/last)
+        $this->refreshStats($memory, $businessId, $extId);
+
+        // Step 3 — Display name + consent denormalize (cache de Contact)
+        $this->refreshDenormalized($memory);
+
+        // Step 4 — Tracking
+        $memory->last_rebuilt_at = now();
+        $memory->rebuilt_via = $via;
+
+        $memory->save();
+
+        Log::channel('single')->info('[customer_memory.rebuilt]', [
+            'metric_name' => 'customer_memory_rebuilt',
+            'business_id' => $businessId,
+            'customer_memory_id' => $memory->id,
+            'contact_id' => $memory->contact_id,
+            'match_method' => $memory->identity_match_method,
+            'n_conversations' => $memory->n_conversations,
+            'n_msgs_total' => $memory->n_msgs_total,
+            'via' => $via,
+        ]);
+
+        return $memory;
+    }
+
+    /**
+     * Apenas atualiza `last_interaction_at` (cheap, real-time listener).
+     * Cria row mínima se não existir (lazy init).
+     * NÃO recompila stats — Job/cron faz isso em background.
+     */
+    public function touch(int $businessId, string $customerExternalId, ?\DateTimeInterface $when = null): void
+    {
+        $extId = $this->normalizeExternalId($customerExternalId);
+        $when = $when ?? now();
+
+        // Upsert defensivo — race-safe via INSERT ... ON DUPLICATE KEY UPDATE
+        DB::table('customer_memory')->updateOrInsert(
+            [
+                'business_id' => $businessId,
+                'customer_external_id' => $extId,
+            ],
+            [
+                'last_interaction_at' => $when,
+                'first_interaction_at' => DB::raw("COALESCE(first_interaction_at, '" . $when->format('Y-m-d H:i:s') . "')"),
+                'phone_normalized' => preg_replace('/\D+/', '', $extId) ?: null,
+                'updated_at' => now(),
+                'created_at' => DB::raw('COALESCE(created_at, NOW())'),
+            ]
+        );
+    }
+
+    /**
+     * Normaliza customer_external_id pra E.164 sem '+' nem espaços.
+     * '+5548999...' → '5548999...'
+     */
+    protected function normalizeExternalId(string $raw): string
+    {
+        $trimmed = trim($raw);
+        return ltrim($trimmed, '+');
+    }
+
+    /**
+     * Step 1 — Resolve identidade (phone → Contact).
+     * Reusa ConversationContactLinker que já tem cache + suffix_8 match.
+     */
+    protected function resolveIdentity(CustomerMemory $memory, int $businessId, string $extId): void
+    {
+        try {
+            $beforeContactId = $memory->contact_id;
+
+            // ConversationContactLinker::attemptLink → cached 1h, retorna ?int
+            $contactId = $this->linker->attemptLink($businessId, $extId);
+
+            if ($contactId === null) {
+                // Sem match — preserva contact_id antigo se já tinha (manual link)
+                if ($beforeContactId === null) {
+                    $memory->identity_match_method = CustomerMemory::MATCH_UNKNOWN;
+                    $memory->identity_match_confidence = 0.0;
+                    $memory->identity_match_at = now();
+                }
+                return;
+            }
+
+            // Match encontrado — confidence depende do número de candidates
+            // (recuperar via findMatchesForPhone pra inferir confiança)
+            $phoneDigits = preg_replace('/\D+/', '', $extId);
+            $candidates = $this->linker->findMatchesForPhone($businessId, $phoneDigits);
+            $count = $candidates->count();
+
+            $method = CustomerMemory::MATCH_SUFFIX_8;
+            $confidence = 1.0;
+
+            if ($count > 1) {
+                $method = CustomerMemory::MATCH_AMBIGUOUS;
+                $confidence = round(1.0 / (float) $count, 2); // 0.5 pra 2, 0.33 pra 3
+            }
+
+            // Se Contact tem mobile/landline/alternate que bate EXATO (sem normalize),
+            // marca como exact (confidence permanece 1.0)
+            if ($count === 1 && $this->isExactMatch($candidates->first(), $extId)) {
+                $method = CustomerMemory::MATCH_EXACT;
+            }
+
+            $memory->contact_id = $contactId;
+            $memory->identity_match_method = $method;
+            $memory->identity_match_confidence = $confidence;
+            $memory->identity_match_at = now();
+        } catch (Throwable $e) {
+            Log::channel('single')->warning('[customer_memory.identity_resolve_failed]', [
+                'business_id' => $businessId,
+                'customer_external_id_redacted' => substr($extId, 0, 4) . '***' . substr($extId, -2),
+                'error' => $e->getMessage(),
+            ]);
+            // Fail-open: continua sem identity, mas stats continuam
+        }
+    }
+
+    /**
+     * Step 2 — Recalcula stats agregados.
+     *
+     * 1 query por contagem (n_conversations + n_msgs_inbound + n_msgs_outbound)
+     * + 1 query first/last_interaction_at. Total: 2 queries per rebuild.
+     */
+    protected function refreshStats(CustomerMemory $memory, int $businessId, string $extId): void
+    {
+        try {
+            $convStats = DB::table('conversations')
+                ->where('business_id', $businessId)
+                ->where('customer_external_id', '+' . $extId)
+                ->orWhere(function ($q) use ($businessId, $extId) {
+                    $q->where('business_id', $businessId)
+                      ->where('customer_external_id', $extId);
+                })
+                ->selectRaw('COUNT(*) as n_conversations, MIN(created_at) as first_conv_at')
+                ->first();
+
+            $memory->n_conversations = (int) ($convStats->n_conversations ?? 0);
+
+            // Stats msgs — JOIN conversations pra filtrar por external_id
+            $msgStats = DB::table('messages as m')
+                ->join('conversations as c', 'c.id', '=', 'm.conversation_id')
+                ->where('c.business_id', $businessId)
+                ->where(function ($q) use ($extId) {
+                    $q->where('c.customer_external_id', $extId)
+                      ->orWhere('c.customer_external_id', '+' . $extId);
+                })
+                ->selectRaw('
+                    SUM(CASE WHEN m.direction = "inbound" THEN 1 ELSE 0 END) as n_in,
+                    SUM(CASE WHEN m.direction = "outbound" THEN 1 ELSE 0 END) as n_out,
+                    MIN(m.created_at) as first_msg_at,
+                    MAX(m.created_at) as last_msg_at
+                ')
+                ->first();
+
+            $memory->n_msgs_inbound = (int) ($msgStats->n_in ?? 0);
+            $memory->n_msgs_outbound = (int) ($msgStats->n_out ?? 0);
+            $memory->first_interaction_at = $msgStats->first_msg_at ?? $convStats->first_conv_at ?? null;
+            $memory->last_interaction_at = $msgStats->last_msg_at ?? null;
+        } catch (Throwable $e) {
+            Log::channel('single')->warning('[customer_memory.stats_failed]', [
+                'business_id' => $businessId,
+                'error' => $e->getMessage(),
+            ]);
+            // Fail-open: zeros mantidos
+        }
+    }
+
+    /**
+     * Step 3 — Denormaliza display_name + consent_status do Contact.
+     * Sem JOIN posterior na sidebar.
+     */
+    protected function refreshDenormalized(CustomerMemory $memory): void
+    {
+        if ($memory->contact_id === null) {
+            // Sem contact linkado — usa contact_name da última conversation se houver
+            $convName = DB::table('conversations')
+                ->where('business_id', $memory->business_id)
+                ->where(function ($q) use ($memory) {
+                    $q->where('customer_external_id', $memory->customer_external_id)
+                      ->orWhere('customer_external_id', '+' . $memory->customer_external_id);
+                })
+                ->whereNotNull('contact_name')
+                ->where('contact_name', '!=', '')
+                ->orderByDesc('updated_at')
+                ->value('contact_name');
+
+            $memory->display_name = $convName ?: ('+' . $memory->customer_external_id);
+            $memory->consent_status = CustomerMemory::CONSENT_UNKNOWN;
+            return;
+        }
+
+        // Tem contact — busca name + whatsapp_consent
+        try {
+            $contact = Contact::query()
+                ->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('business_id', $memory->business_id)
+                ->where('id', $memory->contact_id)
+                ->first(['id', 'name', 'whatsapp_consent']);
+
+            if ($contact === null) {
+                $memory->display_name = '+' . $memory->customer_external_id;
+                $memory->consent_status = CustomerMemory::CONSENT_UNKNOWN;
+                return;
+            }
+
+            $memory->display_name = $contact->name ?: ('+' . $memory->customer_external_id);
+
+            // whatsapp_consent é boolean/tinyint em UltimatePOS — mapeia pra string
+            $memory->consent_status = match (true) {
+                $contact->whatsapp_consent === 1 || $contact->whatsapp_consent === true => CustomerMemory::CONSENT_GIVEN,
+                $contact->whatsapp_consent === 0 || $contact->whatsapp_consent === false => CustomerMemory::CONSENT_WITHDRAWN,
+                default => CustomerMemory::CONSENT_UNKNOWN,
+            };
+        } catch (Throwable $e) {
+            Log::channel('single')->warning('[customer_memory.denorm_failed]', [
+                'business_id' => $memory->business_id,
+                'contact_id' => $memory->contact_id,
+                'error' => $e->getMessage(),
+            ]);
+            $memory->display_name = $memory->display_name ?: ('+' . $memory->customer_external_id);
+        }
+    }
+
+    /**
+     * Match exato = um dos campos phone do contact tem EXATAMENTE o E.164 sem +.
+     */
+    protected function isExactMatch(Contact $contact, string $extId): bool
+    {
+        foreach (['mobile', 'landline', 'alternate_number'] as $field) {
+            $raw = preg_replace('/\D+/', '', (string) ($contact->{$field} ?? ''));
+            if ($raw === $extId) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Modules/Whatsapp/Services/CustomerMemory/OfficeimpressoEnrichService.php
+++ b/Modules/Whatsapp/Services/CustomerMemory/OfficeimpressoEnrichService.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\CustomerMemory;
+
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\CustomerMemory;
+use Modules\Whatsapp\Services\CustomerMemory\Sources\FirebirdLookupSourceContract;
+use Throwable;
+
+/**
+ * US-WA-VOZ-002 — Enrichment cross-DB com OfficeImpresso legacy (Firebird).
+ *
+ * Wagner 2026-05-15: "nem todo cliente está cadastrado, pesquise no firebird."
+ *
+ * Pra customers que NÃO bateram match contra `contacts` (CRM Hostinger),
+ * tenta lookup em `clientes` legacy (Firebird WR Sistemas). Resultado vira
+ * `external_sources` JSON com candidates encontrados.
+ *
+ * NÃO sobrescreve `contact_id` — esse permanece do CRM Hostinger. Firebird
+ * é metadata complementar (mostra "esse mesmo cliente também existe no
+ * sistema antigo como código 12345 — pode ser oportunidade de migração").
+ *
+ * Fonte injetada via interface — driver agnostic (JSON, PDO futuro, HTTP).
+ *
+ * @see Modules/Whatsapp/Services/CustomerMemory/Sources/FirebirdLookupSourceContract.php
+ */
+class OfficeimpressoEnrichService
+{
+    public function __construct(
+        protected readonly FirebirdLookupSourceContract $source,
+    ) {
+    }
+
+    /**
+     * Enriquece 1 customer_memory com lookup Firebird.
+     *
+     * Retorna number of candidates encontrados (0 = sem match).
+     *
+     * NÃO recompila identity nem stats — caller deve rodar
+     * CustomerMemoryRebuilder::rebuild() antes/depois se quiser refresh full.
+     */
+    public function enrich(CustomerMemory $memory): int
+    {
+        if (! $this->source->isHealthy()) {
+            Log::channel('single')->warning('[officeimpresso_enrich.source_unhealthy]', [
+                'source' => $this->source->sourceLabel(),
+                'business_id' => $memory->business_id,
+            ]);
+            return 0;
+        }
+
+        try {
+            $candidates = $this->source->lookupByPhone($memory->customer_external_id);
+
+            if (empty($candidates)) {
+                // Marca tentativa mesmo sem match — debug
+                $memory->external_sources = $this->mergeWithExisting($memory->external_sources, []);
+                $memory->external_sources_enriched_at = now();
+                $memory->saveQuietly();
+                return 0;
+            }
+
+            $entries = array_map(fn ($c) => [
+                'source' => $this->source->sourceLabel(),
+                'cliente_id' => $c['cliente_id'] ?? null,
+                'nome' => $c['nome'] ?? null,
+                'fone1' => $c['fone1'] ?? null,
+                'fone2' => $c['fone2'] ?? null,
+                'email' => $c['email'] ?? null,
+                'bloqueado' => (bool) ($c['bloqueado'] ?? false),
+                'cpf_cnpj' => $c['cpf_cnpj'] ?? null,
+                'cidade' => $c['cidade'] ?? null,
+                'data_cadastro' => $c['data_cadastro'] ?? null,
+            ], $candidates);
+
+            $memory->external_sources = $this->mergeWithExisting($memory->external_sources, $entries);
+            $memory->external_sources_enriched_at = now();
+            $memory->saveQuietly();
+
+            Log::channel('single')->info('[officeimpresso_enrich.matched]', [
+                'metric_name' => 'officeimpresso_enrich_matched',
+                'business_id' => $memory->business_id,
+                'customer_memory_id' => $memory->id,
+                'matches_count' => count($candidates),
+                'source' => $this->source->sourceLabel(),
+            ]);
+
+            return count($candidates);
+        } catch (Throwable $e) {
+            Log::channel('single')->warning('[officeimpresso_enrich.failed]', [
+                'business_id' => $memory->business_id,
+                'customer_memory_id' => $memory->id,
+                'error' => $e->getMessage(),
+            ]);
+            return 0;
+        }
+    }
+
+    /**
+     * Enriquece batch — itera customers do business com `external_sources_enriched_at`
+     * NULL OU stale (>N dias).
+     *
+     * @return array{processed: int, matched: int, skipped: int}
+     */
+    public function enrichBusiness(int $businessId, int $limit = 1000, int $staleDays = 30): array
+    {
+        $cutoff = now()->subDays($staleDays);
+
+        $memories = CustomerMemory::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where(function ($q) use ($cutoff) {
+                $q->whereNull('external_sources_enriched_at')
+                  ->orWhere('external_sources_enriched_at', '<', $cutoff);
+            })
+            ->orderBy('id')
+            ->limit($limit)
+            ->get();
+
+        $matched = 0;
+        $skipped = 0;
+        foreach ($memories as $mem) {
+            $n = $this->enrich($mem);
+            if ($n > 0) {
+                $matched++;
+            } else {
+                $skipped++;
+            }
+        }
+
+        return [
+            'processed' => $memories->count(),
+            'matched' => $matched,
+            'skipped' => $skipped,
+        ];
+    }
+
+    /**
+     * Merge defensivo — preserva entries de OUTRAS fontes (futuras: ASAAS,
+     * Inter, Asaas etc) e substitui apenas matches do source atual.
+     */
+    protected function mergeWithExisting(?array $existing, array $newEntries): array
+    {
+        $existing = $existing ?? [];
+        $thisLabel = $this->source->sourceLabel();
+        $sourcePrefix = explode(':', $thisLabel, 2)[0]; // 'firebird_office_json'
+
+        // Remove entradas antigas dessa fonte (mesmo prefix antes do ':')
+        $filtered = array_filter($existing, function ($e) use ($sourcePrefix) {
+            $eSource = (string) ($e['source'] ?? '');
+            return ! str_starts_with($eSource, $sourcePrefix);
+        });
+
+        return array_values(array_merge(array_values($filtered), $newEntries));
+    }
+}

--- a/Modules/Whatsapp/Services/CustomerMemory/Sources/FirebirdLookupSourceContract.php
+++ b/Modules/Whatsapp/Services/CustomerMemory/Sources/FirebirdLookupSourceContract.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\CustomerMemory\Sources;
+
+/**
+ * US-WA-VOZ-002 — Contrato pra lookup de cliente em fonte externa Firebird
+ * (OfficeImpresso legacy WR Sistemas).
+ *
+ * Driver-agnostic: implementações podem ser JSON pré-exportado (caso atual,
+ * `JsonFileFirebirdSource`), PDO direto se Hostinger ganhar suporte futuro,
+ * tunnel HTTP via Python local, etc.
+ *
+ * Resolução por telefone — phone E.164 sem '+' (ex: '5548999872822').
+ *
+ * Retorno padronizado:
+ *   - Array vazio = sem match
+ *   - 1+ items = candidates com chaves obrigatórias:
+ *     - cliente_id (int)         CLIENTES.CODIGO
+ *     - nome (string)            CLIENTES.RAZAO_SOCIAL ou CLIENTES.NOME
+ *     - fone1 (?string)          E.164 normalizado
+ *     - fone2 (?string)
+ *     - email (?string)
+ *     - bloqueado (bool)         BLOQUEADO='S'
+ *     - cpf_cnpj (?string)
+ *     - cidade (?string)
+ *     - data_cadastro (?string)  ISO 8601
+ *
+ * @see Modules/Whatsapp/Services/CustomerMemory/Sources/JsonFileFirebirdSource.php
+ * @see memory/requisitos/Officeimpresso/OFFICEIMPRESSO-FIREBIRD-SCHEMA.md §2.5
+ * @see scripts/firebird/export-customers.py
+ */
+interface FirebirdLookupSourceContract
+{
+    /**
+     * Lookup por telefone E.164 sem '+'.
+     *
+     * @return array<int, array{cliente_id:int,nome:string,fone1:?string,fone2:?string,email:?string,bloqueado:bool,cpf_cnpj:?string,cidade:?string,data_cadastro:?string}>
+     */
+    public function lookupByPhone(string $phoneE164): array;
+
+    /**
+     * Health check — fonte está disponível agora?
+     */
+    public function isHealthy(): bool;
+
+    /**
+     * Identificador legível da fonte (pra logs + external_sources.source).
+     * Ex: 'firebird_office_json:2026-05-15', 'firebird_office_pdo'.
+     */
+    public function sourceLabel(): string;
+}

--- a/Modules/Whatsapp/Services/CustomerMemory/Sources/JsonFileFirebirdSource.php
+++ b/Modules/Whatsapp/Services/CustomerMemory/Sources/JsonFileFirebirdSource.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\CustomerMemory\Sources;
+
+use Illuminate\Support\Facades\Log;
+use Throwable;
+
+/**
+ * US-WA-VOZ-002 — Source Firebird via arquivo JSON pré-exportado.
+ *
+ * Workflow:
+ *   1. Wagner (ou cron CT 100) roda `scripts/firebird/export-customers.py`
+ *      conectando direto no Firebird WR Sistemas (local OU servidor cliente).
+ *   2. Script gera JSON: `storage/app/firebird/customers-{biz}-{date}.json`
+ *      formato `[{cliente_id, nome, fone1, fone2, email, bloqueado, ...}]`.
+ *   3. Service carrega JSON em memória (índice por phone digits) — Hostinger
+ *      sem Firebird driver, evita dependência PECL.
+ *   4. `lookupByPhone()` normaliza dígitos + busca no índice (sufixo 8 dígitos
+ *      mesmo pattern do ConversationContactLinker — colisão ~10^-8).
+ *
+ * Performance: arquivo até 50k clientes (~5MB) carrega em <100ms,
+ * lookup O(1) por hash.
+ *
+ * Idempotente: re-carregar mesmo JSON não duplica nada. Caller usa.
+ *
+ * @see Modules/Whatsapp/Services/CustomerMemory/Sources/FirebirdLookupSourceContract.php
+ * @see scripts/firebird/export-customers.py
+ */
+class JsonFileFirebirdSource implements FirebirdLookupSourceContract
+{
+    /** Cache em memória do índice phone_suffix → array de clientes. */
+    protected ?array $indexByPhoneSuffix = null;
+    protected ?array $rawCustomers = null;
+    protected ?string $loadedFile = null;
+    protected ?\DateTimeInterface $exportDate = null;
+
+    /** Sufixo mínimo de dígitos pra index (alinhado ConversationContactLinker). */
+    public const SUFFIX_LENGTH = 8;
+
+    public function __construct(
+        protected readonly string $jsonFilePath,
+    ) {
+    }
+
+    public function lookupByPhone(string $phoneE164): array
+    {
+        $this->ensureLoaded();
+
+        $digits = preg_replace('/\D+/', '', $phoneE164);
+        if (mb_strlen((string) $digits) < self::SUFFIX_LENGTH) {
+            return [];
+        }
+
+        $suffix = mb_substr($digits, -self::SUFFIX_LENGTH);
+        return $this->indexByPhoneSuffix[$suffix] ?? [];
+    }
+
+    public function isHealthy(): bool
+    {
+        if (! file_exists($this->jsonFilePath)) {
+            return false;
+        }
+        // Considera healthy se arquivo existe e tem <30 dias (avisa Wagner se velho)
+        $mtime = filemtime($this->jsonFilePath);
+        if ($mtime === false) {
+            return false;
+        }
+        $ageSeconds = time() - $mtime;
+        return $ageSeconds < (30 * 86400);
+    }
+
+    public function sourceLabel(): string
+    {
+        $this->ensureLoaded();
+        $dateStr = $this->exportDate?->format('Y-m-d') ?? 'unknown';
+        return "firebird_office_json:{$dateStr}";
+    }
+
+    /**
+     * Lazy load do JSON. Indexação por sufixo 8 dígitos de fone1+fone2.
+     */
+    protected function ensureLoaded(): void
+    {
+        if ($this->indexByPhoneSuffix !== null) {
+            return; // já carregado
+        }
+
+        if (! file_exists($this->jsonFilePath)) {
+            Log::channel('single')->warning('[firebird_source.file_missing]', [
+                'path' => $this->jsonFilePath,
+            ]);
+            $this->indexByPhoneSuffix = [];
+            $this->rawCustomers = [];
+            return;
+        }
+
+        try {
+            $raw = file_get_contents($this->jsonFilePath);
+            if ($raw === false) {
+                throw new \RuntimeException("não consegui ler {$this->jsonFilePath}");
+            }
+
+            $decoded = json_decode($raw, true, 512, JSON_THROW_ON_ERROR);
+            if (! is_array($decoded)) {
+                throw new \RuntimeException('JSON Firebird não é array');
+            }
+
+            // Suporta 2 formatos:
+            //   A) array plain de customers (legacy)
+            //   B) {meta:{exported_at,...}, customers:[...]}
+            if (isset($decoded['customers'])) {
+                $customers = $decoded['customers'];
+                if (isset($decoded['meta']['exported_at'])) {
+                    try {
+                        $this->exportDate = new \DateTimeImmutable($decoded['meta']['exported_at']);
+                    } catch (\Throwable) {
+                    }
+                }
+            } else {
+                $customers = $decoded;
+            }
+
+            $this->rawCustomers = $customers;
+            $this->indexByPhoneSuffix = $this->buildIndex($customers);
+            $this->loadedFile = $this->jsonFilePath;
+        } catch (Throwable $e) {
+            Log::channel('single')->error('[firebird_source.load_failed]', [
+                'path' => $this->jsonFilePath,
+                'error' => $e->getMessage(),
+            ]);
+            $this->indexByPhoneSuffix = [];
+            $this->rawCustomers = [];
+        }
+    }
+
+    /**
+     * Constrói índice phone_suffix → list of customers.
+     * Cada cliente pode aparecer em até 2 buckets (fone1 + fone2).
+     */
+    protected function buildIndex(array $customers): array
+    {
+        $index = [];
+        foreach ($customers as $c) {
+            $shape = $this->normalizeShape($c);
+            foreach (['fone1', 'fone2'] as $field) {
+                $phone = $shape[$field] ?? null;
+                if ($phone === null) {
+                    continue;
+                }
+                $digits = preg_replace('/\D+/', '', (string) $phone);
+                if (mb_strlen((string) $digits) < self::SUFFIX_LENGTH) {
+                    continue;
+                }
+                $suffix = mb_substr($digits, -self::SUFFIX_LENGTH);
+                $index[$suffix][] = $shape;
+            }
+        }
+        return $index;
+    }
+
+    /**
+     * Normaliza shape esperado pelo contrato + handles legacy keys
+     * (script Python pode exportar com nomes Firebird raw).
+     */
+    protected function normalizeShape(array $c): array
+    {
+        return [
+            'cliente_id' => (int) ($c['cliente_id'] ?? $c['CODIGO'] ?? $c['codigo'] ?? 0),
+            'nome' => (string) ($c['nome'] ?? $c['RAZAO_SOCIAL'] ?? $c['razao_social'] ?? $c['NOME'] ?? ''),
+            'fone1' => $this->normalizeOptional($c['fone1'] ?? $c['FONE1'] ?? null),
+            'fone2' => $this->normalizeOptional($c['fone2'] ?? $c['FONE2'] ?? null),
+            'email' => $this->normalizeOptional($c['email'] ?? $c['EMAIL'] ?? null),
+            'bloqueado' => $this->normalizeBoolean($c['bloqueado'] ?? $c['BLOQUEADO'] ?? null),
+            'cpf_cnpj' => $this->normalizeOptional($c['cpf_cnpj'] ?? $c['CPF'] ?? $c['CNPJ'] ?? null),
+            'cidade' => $this->normalizeOptional($c['cidade'] ?? $c['CIDADE'] ?? null),
+            'data_cadastro' => $this->normalizeOptional($c['data_cadastro'] ?? $c['DATACADASTRO'] ?? null),
+        ];
+    }
+
+    protected function normalizeOptional(mixed $v): ?string
+    {
+        if ($v === null || $v === '') {
+            return null;
+        }
+        return trim((string) $v);
+    }
+
+    protected function normalizeBoolean(mixed $v): bool
+    {
+        if (is_bool($v)) {
+            return $v;
+        }
+        if (is_string($v)) {
+            return strtoupper(trim($v)) === 'S' || $v === '1' || strtolower($v) === 'true';
+        }
+        return $v === 1;
+    }
+}

--- a/Modules/Whatsapp/Services/EmployeePerformance/EmployeePerformanceRebuilder.php
+++ b/Modules/Whatsapp/Services/EmployeePerformance/EmployeePerformanceRebuilder.php
@@ -1,0 +1,334 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\EmployeePerformance;
+
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\EmployeePerformance;
+use Throwable;
+
+/**
+ * US-WA-VOZ-003 — Recompila scorecard de 1 atendente do business.
+ *
+ * Stateless. Idempotente. Fail-open per-step.
+ *
+ * Identidade: aceita `user_id` (PRIMÁRIO via UI Inbox sender_user_id) OU
+ * `heuristic_name` (FALLBACK via *Nome:* prefix no body — captura time
+ * que responde direto WhatsApp Web sem usar UI).
+ *
+ * Scoring transparente 0-100 (publicado pro time saber):
+ *   - Volume produtivo   (25 pts) — n_msgs (1500=25, escala linear cap)
+ *   - Diversidade        (20 pts) — n_clientes (150=20)
+ *   - Velocidade resposta (25 pts) — mediana <60s=25, <300s=18, <900s=12, <1800s=6, else=2
+ *   - Profundidade conv  (15 pts) — msgs/conv 5-15=15 (sweet spot), 3-20=10, else=5
+ *   - Cobertura horária  (10 pts) — horas_ativas_distintas (10h=10)
+ *   - Engajamento        (5 pts)  — fixo (placeholder pra CSAT futuro)
+ *
+ * @see Modules/Whatsapp/Entities/EmployeePerformance.php
+ */
+class EmployeePerformanceRebuilder
+{
+    public const SCORE_MAX = 100;
+    public const DEFAULT_BUSINESS_HOURS_START = 8;
+    public const DEFAULT_BUSINESS_HOURS_END = 18;
+
+    /**
+     * Recompila scorecard pra 1 atendente identificado por user_id OU heuristic_name.
+     * Pelo menos um dos 2 deve ser não-null.
+     *
+     * @param  int|null    $userId         FK users.id (PRIMÁRIO)
+     * @param  string|null $heuristicName  Nome em body *Nome:* (FALLBACK)
+     */
+    public function rebuild(int $businessId, ?int $userId = null, ?string $heuristicName = null, string $via = EmployeePerformance::REBUILT_VIA_MANUAL): EmployeePerformance
+    {
+        if ($userId === null && ($heuristicName === null || $heuristicName === '')) {
+            throw new \InvalidArgumentException('user_id OU heuristic_name obrigatório');
+        }
+
+        // Localiza ou cria
+        $query = EmployeePerformance::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId);
+
+        if ($userId !== null) {
+            $query->where('user_id', $userId);
+        } else {
+            $query->whereNull('user_id')->where('heuristic_name', $heuristicName);
+        }
+
+        $perf = $query->first();
+        if ($perf === null) {
+            $perf = new EmployeePerformance();
+            $perf->business_id = $businessId;
+            $perf->user_id = $userId;
+            $perf->heuristic_name = $heuristicName;
+        }
+
+        // Step 1 — display_name (user real OU heurístico)
+        $this->refreshDisplayName($perf, $businessId);
+
+        // Step 2 — stats agregados (volume, conversas, clientes)
+        $this->refreshStats($perf, $businessId);
+
+        // Step 3 — velocidade resposta (mediana + p90 + SLA breach)
+        $this->refreshVelocity($perf, $businessId);
+
+        // Step 4 — cobertura horária + dias ativos
+        $this->refreshCoverage($perf, $businessId);
+
+        // Step 5 — qualidade (reclamações dos clientes atendidos)
+        $this->refreshQuality($perf, $businessId);
+
+        // Step 6 — calcular nota 0-100 + breakdown
+        $this->calculateScore($perf);
+
+        $perf->last_rebuilt_at = now();
+        $perf->rebuilt_via = $via;
+        $perf->save();
+
+        Log::channel('single')->info('[employee_performance.rebuilt]', [
+            'metric_name' => 'employee_performance_rebuilt',
+            'business_id' => $businessId,
+            'performance_id' => $perf->id,
+            'identity' => $perf->identidade(),
+            'nota_geral' => $perf->nota_geral,
+            'n_msgs' => $perf->n_msgs_total,
+            'via' => $via,
+        ]);
+
+        return $perf;
+    }
+
+    /**
+     * Query SQL canônica — JOIN messages × conversations filtrado por business
+     * + identidade do atendente (user_id OU body LIKE heuristic).
+     */
+    protected function baseMessageQuery(int $businessId, EmployeePerformance $perf): \Illuminate\Database\Query\Builder
+    {
+        $q = DB::table('messages as m')
+            ->join('conversations as c', 'c.id', '=', 'm.conversation_id')
+            ->where('c.business_id', $businessId)
+            ->where('m.direction', 'outbound')
+            ->where('m.is_internal_note', false);
+
+        if ($perf->user_id !== null) {
+            $q->where('m.sender_user_id', $perf->user_id);
+        } else {
+            // Heurística — body LIKE '%Nome:%' (case-insensitive Maiara/Luiz/Felipe)
+            $q->where('m.body', 'like', '%' . $perf->heuristic_name . ':%');
+        }
+
+        return $q;
+    }
+
+    protected function refreshDisplayName(EmployeePerformance $perf, int $businessId): void
+    {
+        if ($perf->user_id !== null) {
+            try {
+                $user = User::query()->withoutGlobalScopes()->find($perf->user_id);
+                if ($user !== null) {
+                    $name = trim(($user->first_name ?? '') . ' ' . ($user->last_name ?? ''));
+                    $perf->display_name = $name !== '' ? $name : ($user->username ?? "user#{$perf->user_id}");
+                    return;
+                }
+            } catch (Throwable $e) {
+                // fall through
+            }
+        }
+        $perf->display_name = $perf->heuristic_name ?? 'unknown';
+    }
+
+    protected function refreshStats(EmployeePerformance $perf, int $businessId): void
+    {
+        try {
+            $base = $this->baseMessageQuery($businessId, $perf);
+
+            $perf->n_msgs_total = (clone $base)->count();
+            $perf->n_conversations_atendidas = (clone $base)->distinct()->count('m.conversation_id');
+
+            $clientes = (clone $base)
+                ->whereNotNull('c.customer_external_id')
+                ->distinct()->count('c.customer_external_id');
+            $perf->n_clientes_diferentes = $clientes;
+
+            $first = (clone $base)->min('m.created_at');
+            $last = (clone $base)->max('m.created_at');
+            $perf->primeira_atividade_at = $first;
+            $perf->ultima_atividade_at = $last;
+        } catch (Throwable $e) {
+            Log::channel('single')->warning('[employee_performance.stats_failed]', [
+                'business_id' => $businessId,
+                'identity' => $perf->identidade(),
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    protected function refreshVelocity(EmployeePerformance $perf, int $businessId): void
+    {
+        try {
+            // Pra cada outbound do atendente, pega o inbound IMEDIATAMENTE anterior
+            // da mesma conversa e calcula delta (gap de resposta).
+            $where = $perf->user_id !== null
+                ? "m.sender_user_id = " . (int) $perf->user_id
+                : "m.body LIKE " . DB::getPdo()->quote('%' . $perf->heuristic_name . ':%');
+
+            $rows = DB::select("
+                SELECT TIMESTAMPDIFF(SECOND,
+                    (SELECT MAX(m2.created_at)
+                     FROM messages m2
+                     WHERE m2.conversation_id = m.conversation_id
+                       AND m2.direction = 'inbound'
+                       AND m2.created_at < m.created_at), m.created_at) AS delta_s
+                FROM messages m
+                JOIN conversations c ON c.id = m.conversation_id
+                WHERE c.business_id = ?
+                  AND m.direction = 'outbound'
+                  AND m.is_internal_note = 0
+                  AND {$where}
+                LIMIT 1000
+            ", [$businessId]);
+
+            $deltas = array_values(array_filter(
+                array_column($rows, 'delta_s'),
+                fn ($d) => $d !== null && $d > 0 && $d < 86400
+            ));
+
+            if (empty($deltas)) {
+                $perf->tempo_resposta_mediana_s = null;
+                $perf->tempo_resposta_p90_s = null;
+                $perf->sla_breach_count = 0;
+                return;
+            }
+
+            sort($deltas);
+            $n = count($deltas);
+            $perf->tempo_resposta_mediana_s = (int) $deltas[(int) ($n / 2)];
+            $perf->tempo_resposta_p90_s = (int) $deltas[(int) ($n * 0.9)];
+
+            $sla = EmployeePerformance::SLA_FIRST_RESPONSE_SECONDS;
+            $perf->sla_breach_count = count(array_filter($deltas, fn ($d) => $d > $sla));
+        } catch (Throwable $e) {
+            Log::channel('single')->warning('[employee_performance.velocity_failed]', [
+                'business_id' => $businessId,
+                'identity' => $perf->identidade(),
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    protected function refreshCoverage(EmployeePerformance $perf, int $businessId): void
+    {
+        try {
+            $base = $this->baseMessageQuery($businessId, $perf);
+
+            $hourCounts = (clone $base)
+                ->select(DB::raw('HOUR(m.created_at) as h, COUNT(*) as n'))
+                ->groupBy('h')
+                ->get();
+
+            $perf->horas_ativas_distintas = (int) $hourCounts->count();
+
+            if ($hourCounts->isNotEmpty()) {
+                $top = $hourCounts->sortByDesc('n')->first();
+                $perf->hora_pico = (int) $top->h;
+            } else {
+                $perf->hora_pico = null;
+            }
+
+            // Dias ativos 30d
+            $dias = (clone $base)
+                ->where('m.created_at', '>=', now()->subDays(30))
+                ->select(DB::raw('DATE(m.created_at) as d'))
+                ->distinct()
+                ->count('d');
+            $perf->dias_ativos_30d = (int) $dias;
+        } catch (Throwable $e) {
+            Log::channel('single')->warning('[employee_performance.coverage_failed]', [
+                'business_id' => $businessId,
+                'identity' => $perf->identidade(),
+                'error' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    protected function refreshQuality(EmployeePerformance $perf, int $businessId): void
+    {
+        try {
+            // Reclamações: soma total_reclamacoes dos clientes atendidos pelo perf
+            $reclamacoes = DB::table('customer_memory as cm')
+                ->where('cm.business_id', $businessId)
+                ->whereIn('cm.customer_external_id', function ($sub) use ($businessId, $perf) {
+                    $sub->select('c.customer_external_id')
+                        ->from('conversations as c')
+                        ->join('messages as m', 'm.conversation_id', '=', 'c.id')
+                        ->where('c.business_id', $businessId)
+                        ->where('m.direction', 'outbound')
+                        ->where('m.is_internal_note', false);
+
+                    if ($perf->user_id !== null) {
+                        $sub->where('m.sender_user_id', $perf->user_id);
+                    } else {
+                        $sub->where('m.body', 'like', '%' . $perf->heuristic_name . ':%');
+                    }
+                })
+                ->sum('cm.total_reclamacoes');
+
+            $perf->reclamacoes_recebidas = (int) $reclamacoes;
+        } catch (Throwable $e) {
+            // customer_memory pode não existir ainda — fail-open zerado
+            $perf->reclamacoes_recebidas = 0;
+        }
+    }
+
+    /**
+     * Scoring 0-100 transparente. Pesos publicados em docblock + comentário inline.
+     */
+    public function calculateScore(EmployeePerformance $perf): void
+    {
+        $breakdown = [];
+
+        // Volume produtivo (25 pts) — escala linear 1500 msgs = 25
+        $breakdown['volume'] = min(25, (int) round(($perf->n_msgs_total / 1500) * 25));
+
+        // Diversidade clientes (20 pts) — 150 clientes = 20
+        $breakdown['diversidade'] = min(20, (int) round(($perf->n_clientes_diferentes / 150) * 20));
+
+        // Velocidade resposta (25 pts) — escalonado
+        $mediana = $perf->tempo_resposta_mediana_s;
+        $breakdown['velocidade'] = match (true) {
+            $mediana === null => 0,
+            $mediana < 60 => 25,
+            $mediana < 300 => 18,
+            $mediana < 900 => 12,
+            $mediana < 1800 => 6,
+            default => 2,
+        };
+
+        // Profundidade conv (15 pts) — msgs/conv sweet spot 5-15
+        $mpc = $perf->n_conversations_atendidas > 0
+            ? $perf->n_msgs_total / $perf->n_conversations_atendidas
+            : 0;
+        $breakdown['profundidade'] = match (true) {
+            $mpc >= 5 && $mpc <= 15 => 15,
+            $mpc >= 3 && $mpc <= 20 => 10,
+            default => 5,
+        };
+
+        // Cobertura horária (10 pts) — 10 horas distintas = 10
+        $breakdown['cobertura'] = min(10, (int) round(($perf->horas_ativas_distintas / 10) * 10));
+
+        // Engajamento (5 pts) — placeholder CSAT
+        $breakdown['engajamento'] = 5;
+
+        $total = array_sum($breakdown);
+
+        $perf->nota_geral = min(self::SCORE_MAX, $total);
+        $perf->nota_breakdown = $breakdown;
+        $perf->nota_calculada_em = now();
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/AutoPrefixSenderNameTest.php
+++ b/Modules/Whatsapp/Tests/Feature/AutoPrefixSenderNameTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Whatsapp\Http\Controllers\Admin\InboxController;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-VOZ-003 — Auto-prefix sender name no outbound body.
+ *
+ * Garante:
+ *   1. Body humano freeform ganha `*FirstName:* ` prefix
+ *   2. Idempotente — body já com `*Nome:*` NÃO duplica
+ *   3. Skip nota interna (slash commands formatam próprio)
+ *   4. Skip template (HSM tem variáveis)
+ *   5. Skip body vazio/null
+ *   6. Skip userId inválido
+ *   7. Sanitização — caracteres não-alfa removidos do nome
+ */
+beforeEach(function () {
+    Schema::dropIfExists('users');
+    Schema::create('users', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('username', 60);
+        $table->string('first_name', 60)->nullable();
+        $table->string('last_name', 60)->nullable();
+        $table->timestamps();
+    });
+
+    DB::table('users')->insert([
+        ['id' => 10, 'username' => 'maiara', 'first_name' => 'Maiara', 'last_name' => 'Souza', 'created_at' => now(), 'updated_at' => now()],
+        ['id' => 11, 'username' => 'luiz', 'first_name' => 'Luiz', 'last_name' => 'Santos', 'created_at' => now(), 'updated_at' => now()],
+        ['id' => 12, 'username' => 'noname', 'first_name' => null, 'last_name' => null, 'created_at' => now(), 'updated_at' => now()],
+    ]);
+});
+
+/**
+ * Helper pra invocar método protected via Reflection.
+ */
+function callPrefix(?string $body, int $userId, bool $isInternal = false, bool $isTemplate = false): ?string
+{
+    $controller = new InboxController();
+    $method = new ReflectionMethod($controller, 'maybeAutoPrefixSenderName');
+    $method->setAccessible(true);
+    return $method->invoke($controller, $body, $userId, $isInternal, $isTemplate);
+}
+
+it('prefixa body humano freeform com *FirstName:*', function () {
+    $r = callPrefix('Tudo certo? Vou conectar.', 10);
+    expect($r)->toBe('*Maiara:* Tudo certo? Vou conectar.');
+});
+
+it('idempotente — body já com *Nome:* NÃO duplica', function () {
+    $r = callPrefix('*Maiara:* Já estou aqui', 10);
+    expect($r)->toBe('*Maiara:* Já estou aqui');
+
+    // Outro nome também — atendente assinou manualmente como "Wagner"
+    $r2 = callPrefix('*Wagner:* mensagem assinada manual', 10);
+    expect($r2)->toBe('*Wagner:* mensagem assinada manual');
+});
+
+it('skip nota interna', function () {
+    $r = callPrefix('lembrar amanhã reabrir', 10, isInternal: true);
+    expect($r)->toBe('lembrar amanhã reabrir');
+});
+
+it('skip template', function () {
+    $r = callPrefix('Bem-vindo {{1}}!', 10, isInternal: false, isTemplate: true);
+    expect($r)->toBe('Bem-vindo {{1}}!');
+});
+
+it('skip body vazio / null', function () {
+    expect(callPrefix(null, 10))->toBeNull();
+    expect(callPrefix('', 10))->toBe('');
+    expect(callPrefix('   ', 10))->toBe('   ');
+});
+
+it('skip userId 0 ou inválido', function () {
+    $r = callPrefix('mensagem sem user', 0);
+    expect($r)->toBe('mensagem sem user');
+
+    $r2 = callPrefix('mensagem sem user', -1);
+    expect($r2)->toBe('mensagem sem user');
+});
+
+it('user sem first_name usa username', function () {
+    $r = callPrefix('teste sem first name', 12);
+    expect($r)->toBe('*noname:* teste sem first name');
+});
+
+it('sanitização — emojis e símbolos removidos do nome (defensivo)', function () {
+    DB::table('users')->insert([
+        'id' => 13, 'username' => 'evil', 'first_name' => 'João 🎉', 'last_name' => '*',
+        'created_at' => now(), 'updated_at' => now(),
+    ]);
+    $r = callPrefix('texto', 13);
+    expect($r)->toBe('*João:* texto');
+});
+
+it('user_id inexistente passa direto sem prefix', function () {
+    $r = callPrefix('mensagem com user fantasma', 99999);
+    expect($r)->toBe('mensagem com user fantasma');
+});
+
+it('preserva texto trimmed após prefix (single space)', function () {
+    $r = callPrefix('   texto com whitespace inicial', 10);
+    expect($r)->toBe('*Maiara:* texto com whitespace inicial');
+});

--- a/Modules/Whatsapp/Tests/Feature/CustomerMemoryBackfillCommandTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CustomerMemoryBackfillCommandTest.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Whatsapp\Jobs\RebuildCustomerMemoryJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-VOZ-001 — CustomerMemoryBackfillCommand.
+ *
+ * Cobertura:
+ *   1. --business obrigatório (Tier 0) → INVALID
+ *   2. --dry-run NÃO grava customer_memory
+ *   3. --queue dispatcha N jobs com biz correto
+ *   4. Tier 0: --business=99 só vê convs biz=99
+ *   5. --channel filtra por channel_id
+ */
+beforeEach(function () {
+    foreach (['customer_memory', 'messages', 'conversations', 'contacts'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('contacts', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('name', 120)->nullable();
+        $table->string('mobile', 40)->nullable();
+        $table->string('landline', 40)->nullable();
+        $table->string('alternate_number', 40)->nullable();
+        $table->boolean('whatsapp_consent')->nullable();
+        $table->softDeletes();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 40)->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 20);
+        $table->string('type', 20)->default('text');
+        $table->text('body')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('customer_memory', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('customer_external_id', 40);
+        $table->string('phone_normalized', 20)->nullable();
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('identity_match_method', 24)->nullable();
+        $table->decimal('identity_match_confidence', 3, 2)->nullable();
+        $table->timestamp('identity_match_at')->nullable();
+        $table->string('display_name', 120)->nullable();
+        $table->unsignedInteger('n_conversations')->default(0);
+        $table->unsignedInteger('n_msgs_inbound')->default(0);
+        $table->unsignedInteger('n_msgs_outbound')->default(0);
+        $table->timestamp('first_interaction_at')->nullable();
+        $table->timestamp('last_interaction_at')->nullable();
+        $table->json('temas_recorrentes')->nullable();
+        $table->decimal('sentimento_score', 3, 2)->nullable();
+        $table->decimal('churn_risk_score', 3, 2)->nullable();
+        $table->json('comunicacao_preferida')->nullable();
+        $table->text('notas_jana')->nullable();
+        $table->timestamp('notas_atualizada_em')->nullable();
+        $table->json('flags')->nullable();
+        $table->string('consent_status', 16)->nullable();
+        $table->timestamp('erasure_requested_at')->nullable();
+        $table->timestamp('last_rebuilt_at')->nullable();
+        $table->string('rebuilt_via', 24)->nullable();
+        $table->timestamps();
+        $table->unique(['business_id', 'customer_external_id']);
+    });
+});
+
+function backfillSeedConv(int $bizId, string $extId, int $channelId = 10): int
+{
+    return DB::table('conversations')->insertGetId([
+        'business_id' => $bizId,
+        'channel_id' => $channelId,
+        'customer_external_id' => $extId,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+it('sem --business retorna INVALID', function () {
+    $this->artisan('customer-memory:backfill')
+        ->expectsOutputToContain('--business=N obrigatório')
+        ->assertExitCode(2); // Command::INVALID
+});
+
+it('--dry-run NÃO grava customer_memory', function () {
+    backfillSeedConv(1, '5548999872822');
+    backfillSeedConv(1, '5511987654321');
+
+    $this->artisan('customer-memory:backfill', ['--business' => 1, '--dry-run' => true])
+        ->expectsOutputToContain('Customers únicos elegíveis biz=1')
+        ->expectsOutputToContain('DRY-RUN')
+        ->assertExitCode(0);
+
+    expect(DB::table('customer_memory')->count())->toBe(0);
+});
+
+it('--queue dispatcha N jobs com biz correto', function () {
+    backfillSeedConv(1, '5548999872822');
+    backfillSeedConv(1, '5511987654321');
+    backfillSeedConv(1, '5527998765432');
+    Bus::fake();
+
+    $this->artisan('customer-memory:backfill', ['--business' => 1, '--queue' => true])
+        ->assertExitCode(0);
+
+    Bus::assertDispatchedTimes(RebuildCustomerMemoryJob::class, 3);
+    Bus::assertDispatched(RebuildCustomerMemoryJob::class, function ($job) {
+        return $job->businessId === 1;
+    });
+});
+
+it('Tier 0: --business=99 só vê convs biz=99', function () {
+    backfillSeedConv(1, '5548999872822');
+    backfillSeedConv(1, '5511987654321');
+    backfillSeedConv(99, '5527998765432');
+    Bus::fake();
+
+    $this->artisan('customer-memory:backfill', ['--business' => 99, '--queue' => true])
+        ->assertExitCode(0);
+
+    Bus::assertDispatchedTimes(RebuildCustomerMemoryJob::class, 1);
+    Bus::assertDispatched(RebuildCustomerMemoryJob::class, function ($job) {
+        return $job->businessId === 99;
+    });
+});
+
+it('--channel filtra por channel_id', function () {
+    backfillSeedConv(1, '5548999872822', channelId: 10);
+    backfillSeedConv(1, '5511987654321', channelId: 8);
+    backfillSeedConv(1, '5527998765432', channelId: 10);
+    Bus::fake();
+
+    $this->artisan('customer-memory:backfill', ['--business' => 1, '--channel' => 10, '--queue' => true])
+        ->assertExitCode(0);
+
+    // Só 2 convs do channel=10
+    Bus::assertDispatchedTimes(RebuildCustomerMemoryJob::class, 2);
+});
+
+it('DISTINCT customer_external_id — não duplica jobs por mesma pessoa', function () {
+    // 3 convs do mesmo customer (cliente abriu 3 sessões diferentes)
+    backfillSeedConv(1, '5548999872822');
+    backfillSeedConv(1, '5548999872822');
+    backfillSeedConv(1, '5548999872822');
+    backfillSeedConv(1, '5511987654321');
+    Bus::fake();
+
+    $this->artisan('customer-memory:backfill', ['--business' => 1, '--queue' => true])
+        ->assertExitCode(0);
+
+    // Só 2 jobs (DISTINCT external_id)
+    Bus::assertDispatchedTimes(RebuildCustomerMemoryJob::class, 2);
+});

--- a/Modules/Whatsapp/Tests/Feature/CustomerMemoryRebuilderTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CustomerMemoryRebuilderTest.php
@@ -72,6 +72,7 @@ beforeEach(function () {
         $table->text('body')->nullable();
         $table->string('status', 20)->default('received');
         $table->boolean('is_internal_note')->default(false);
+        $table->unsignedInteger('sender_user_id')->nullable();
         $table->timestamps();
     });
 
@@ -101,6 +102,14 @@ beforeEach(function () {
         $table->timestamp('erasure_requested_at')->nullable();
         $table->timestamp('last_rebuilt_at')->nullable();
         $table->string('rebuilt_via', 24)->nullable();
+        // US-WA-VOZ-002 columns
+        $table->unsignedInteger('assigned_user_id')->nullable();
+        $table->unsignedInteger('most_active_user_id')->nullable();
+        $table->unsignedInteger('most_active_user_count')->nullable();
+        $table->json('reclamacoes_recentes')->nullable();
+        $table->unsignedInteger('total_reclamacoes')->default(0);
+        $table->json('external_sources')->nullable();
+        $table->timestamp('external_sources_enriched_at')->nullable();
         $table->timestamps();
         $table->unique(['business_id', 'customer_external_id']);
     });
@@ -134,14 +143,15 @@ function seedConvFixture(int $bizId, string $extId): int
     ]);
 }
 
-function seedMsgFixture(int $bizId, int $convId, string $direction = 'inbound', ?string $when = null): int
+function seedMsgFixture(int $bizId, int $convId, string $direction = 'inbound', ?string $when = null, ?int $userId = null, ?string $body = null): int
 {
     return DB::table('messages')->insertGetId([
         'business_id' => $bizId,
         'conversation_id' => $convId,
         'direction' => $direction,
         'type' => 'text',
-        'body' => 'msg teste',
+        'body' => $body ?? 'msg teste',
+        'sender_user_id' => $userId,
         'created_at' => $when ? \Carbon\Carbon::parse($when) : now(),
         'updated_at' => $when ? \Carbon\Carbon::parse($when) : now(),
     ]);
@@ -315,6 +325,80 @@ it('LGPD: consent_status reflete contacts.whatsapp_consent', function () {
     seedConvFixture(1, '33333333333');
     $memNull = $rebuilder->rebuild(1, '33333333333');
     expect($memNull->consent_status)->toBe(CustomerMemory::CONSENT_UNKNOWN);
+});
+
+it('US-WA-VOZ-002 — assigned_user_id = sender_user_id da última outbound', function () {
+    $linker = new ConversationContactLinker();
+    $rebuilder = new CustomerMemoryRebuilder($linker);
+
+    $extId = '5548999872822';
+    $convId = seedConvFixture(1, $extId);
+    // 3 outbound: user=10 (mais antigo), user=20, user=30 (mais recente)
+    seedMsgFixture(1, $convId, 'outbound', '2026-05-13 10:00:00', userId: 10);
+    seedMsgFixture(1, $convId, 'outbound', '2026-05-14 10:00:00', userId: 20);
+    seedMsgFixture(1, $convId, 'outbound', '2026-05-15 10:00:00', userId: 30);
+
+    $memory = $rebuilder->rebuild(1, $extId);
+
+    expect($memory->assigned_user_id)->toBe(30); // mais recente
+});
+
+it('US-WA-VOZ-002 — most_active_user_id = sender com mais outbound', function () {
+    $linker = new ConversationContactLinker();
+    $rebuilder = new CustomerMemoryRebuilder($linker);
+
+    $extId = '5548999872822';
+    $convId = seedConvFixture(1, $extId);
+    // user=10 com 3 msgs, user=20 com 2, user=30 com 1
+    seedMsgFixture(1, $convId, 'outbound', userId: 10);
+    seedMsgFixture(1, $convId, 'outbound', userId: 10);
+    seedMsgFixture(1, $convId, 'outbound', userId: 10);
+    seedMsgFixture(1, $convId, 'outbound', userId: 20);
+    seedMsgFixture(1, $convId, 'outbound', userId: 20);
+    seedMsgFixture(1, $convId, 'outbound', userId: 30);
+
+    $memory = $rebuilder->rebuild(1, $extId);
+
+    expect($memory->most_active_user_id)->toBe(10);
+    expect($memory->most_active_user_count)->toBe(3);
+});
+
+it('US-WA-VOZ-002 — reclamações heurística detecta keywords', function () {
+    $linker = new ConversationContactLinker();
+    $rebuilder = new CustomerMemoryRebuilder($linker);
+
+    $extId = '5548999872822';
+    $convId = seedConvFixture(1, $extId);
+    // Inbound com keywords variadas (severities)
+    seedMsgFixture(1, $convId, 'inbound', body: 'olá tudo bem'); // sem match
+    seedMsgFixture(1, $convId, 'inbound', body: 'tô com problema no sistema'); // media
+    seedMsgFixture(1, $convId, 'inbound', body: 'isso é péssimo, quero reclamar'); // alta
+    seedMsgFixture(1, $convId, 'inbound', body: 'quero processar vocês, vou no procon'); // critica
+    seedMsgFixture(1, $convId, 'inbound', body: 'preciso de ajuda'); // baixa
+
+    $memory = $rebuilder->rebuild(1, $extId);
+
+    expect($memory->total_reclamacoes)->toBe(4); // 4 com match
+    expect($memory->reclamacoes_recentes)->not->toBeNull();
+    expect(count($memory->reclamacoes_recentes))->toBeGreaterThanOrEqual(4);
+
+    // Verifica severities presentes
+    $severities = collect($memory->reclamacoes_recentes)->pluck('severity')->all();
+    expect($severities)->toContain('critica')->toContain('alta')->toContain('media');
+});
+
+it('US-WA-VOZ-002 — reclamações ignora msgs OUTBOUND (só cliente conta)', function () {
+    $linker = new ConversationContactLinker();
+    $rebuilder = new CustomerMemoryRebuilder($linker);
+
+    $extId = '5548999872822';
+    $convId = seedConvFixture(1, $extId);
+    // Atendente outbound usa palavra "problema" — NÃO conta como reclamação cliente
+    seedMsgFixture(1, $convId, 'outbound', userId: 10, body: 'qual é o problema?');
+
+    $memory = $rebuilder->rebuild(1, $extId);
+
+    expect($memory->total_reclamacoes)->toBe(0);
 });
 
 it('CustomerMemory entity helpers: n_msgs_total + daysSinceLastInteraction + isErasureRequested', function () {

--- a/Modules/Whatsapp/Tests/Feature/CustomerMemoryRebuilderTest.php
+++ b/Modules/Whatsapp/Tests/Feature/CustomerMemoryRebuilderTest.php
@@ -1,0 +1,337 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Contact;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Whatsapp\Entities\CustomerMemory;
+use Modules\Whatsapp\Services\Contacts\ConversationContactLinker;
+use Modules\Whatsapp\Services\CustomerMemory\CustomerMemoryRebuilder;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-VOZ-001 — CustomerMemoryRebuilder.
+ *
+ * Cobertura:
+ *   1. rebuild() cria row nova quando customer não existe
+ *   2. rebuild() é idempotente — re-run não duplica
+ *   3. touch() é UPSERT atômico (cheap path)
+ *   4. Identity resolution liga ao Contact quando phone bate (exact)
+ *   5. Identity resolution marca ambiguous quando 2+ contacts batem
+ *   6. Stats agregados batem com count real de messages/conversations
+ *   7. Tier 0: biz=99 NÃO vê customer_memory de biz=1
+ *   8. LGPD denormalize: consent_status reflete contacts.whatsapp_consent
+ */
+beforeEach(function () {
+    foreach (['customer_memory', 'messages', 'conversations', 'contacts', 'business'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('business', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('name');
+        $table->timestamps();
+    });
+
+    Schema::create('contacts', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('name', 120)->nullable();
+        $table->string('mobile', 40)->nullable();
+        $table->string('landline', 40)->nullable();
+        $table->string('alternate_number', 40)->nullable();
+        $table->string('email', 120)->nullable();
+        $table->boolean('whatsapp_consent')->nullable();
+        $table->softDeletes();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('customer_external_id', 40)->nullable();
+        $table->string('contact_name', 120)->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->string('last_message_preview', 200)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->string('status', 20)->default('open');
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 20);
+        $table->string('type', 20)->default('text');
+        $table->text('body')->nullable();
+        $table->string('status', 20)->default('received');
+        $table->boolean('is_internal_note')->default(false);
+        $table->timestamps();
+    });
+
+    Schema::create('customer_memory', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('customer_external_id', 40);
+        $table->string('phone_normalized', 20)->nullable();
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->string('identity_match_method', 24)->nullable();
+        $table->decimal('identity_match_confidence', 3, 2)->nullable();
+        $table->timestamp('identity_match_at')->nullable();
+        $table->string('display_name', 120)->nullable();
+        $table->unsignedInteger('n_conversations')->default(0);
+        $table->unsignedInteger('n_msgs_inbound')->default(0);
+        $table->unsignedInteger('n_msgs_outbound')->default(0);
+        $table->timestamp('first_interaction_at')->nullable();
+        $table->timestamp('last_interaction_at')->nullable();
+        $table->json('temas_recorrentes')->nullable();
+        $table->decimal('sentimento_score', 3, 2)->nullable();
+        $table->decimal('churn_risk_score', 3, 2)->nullable();
+        $table->json('comunicacao_preferida')->nullable();
+        $table->text('notas_jana')->nullable();
+        $table->timestamp('notas_atualizada_em')->nullable();
+        $table->json('flags')->nullable();
+        $table->string('consent_status', 16)->nullable();
+        $table->timestamp('erasure_requested_at')->nullable();
+        $table->timestamp('last_rebuilt_at')->nullable();
+        $table->string('rebuilt_via', 24)->nullable();
+        $table->timestamps();
+        $table->unique(['business_id', 'customer_external_id']);
+    });
+
+    DB::table('business')->insert([
+        ['id' => 1, 'name' => 'WR Sistemas', 'created_at' => now(), 'updated_at' => now()],
+        ['id' => 99, 'name' => 'Outro Tenant', 'created_at' => now(), 'updated_at' => now()],
+    ]);
+});
+
+function seedContactFixture(int $bizId, string $name, string $mobile, ?bool $consent = null): int
+{
+    return DB::table('contacts')->insertGetId([
+        'business_id' => $bizId,
+        'name' => $name,
+        'mobile' => $mobile,
+        'whatsapp_consent' => $consent,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+function seedConvFixture(int $bizId, string $extId): int
+{
+    return DB::table('conversations')->insertGetId([
+        'business_id' => $bizId,
+        'channel_id' => 10,
+        'customer_external_id' => $extId,
+        'created_at' => now()->subDays(2),
+        'updated_at' => now(),
+    ]);
+}
+
+function seedMsgFixture(int $bizId, int $convId, string $direction = 'inbound', ?string $when = null): int
+{
+    return DB::table('messages')->insertGetId([
+        'business_id' => $bizId,
+        'conversation_id' => $convId,
+        'direction' => $direction,
+        'type' => 'text',
+        'body' => 'msg teste',
+        'created_at' => $when ? \Carbon\Carbon::parse($when) : now(),
+        'updated_at' => $when ? \Carbon\Carbon::parse($when) : now(),
+    ]);
+}
+
+it('rebuild() cria customer_memory novo quando não existe', function () {
+    $linker = new ConversationContactLinker();
+    $rebuilder = new CustomerMemoryRebuilder($linker);
+
+    $extId = '5548999872822';
+    $convId = seedConvFixture(1, $extId);
+    seedMsgFixture(1, $convId, 'inbound');
+    seedMsgFixture(1, $convId, 'outbound');
+
+    $memory = $rebuilder->rebuild(1, $extId);
+
+    expect($memory)->toBeInstanceOf(CustomerMemory::class)
+        ->and($memory->business_id)->toBe(1)
+        ->and($memory->customer_external_id)->toBe($extId)
+        ->and($memory->phone_normalized)->toBe($extId)
+        ->and($memory->n_msgs_inbound)->toBe(1)
+        ->and($memory->n_msgs_outbound)->toBe(1)
+        ->and($memory->n_conversations)->toBe(1)
+        ->and($memory->last_rebuilt_at)->not->toBeNull()
+        ->and($memory->rebuilt_via)->toBe(CustomerMemory::REBUILT_VIA_MANUAL);
+});
+
+it('rebuild() é idempotente — re-run não duplica', function () {
+    $linker = new ConversationContactLinker();
+    $rebuilder = new CustomerMemoryRebuilder($linker);
+
+    $extId = '5548999872822';
+    seedConvFixture(1, $extId);
+
+    $first = $rebuilder->rebuild(1, $extId);
+    $second = $rebuilder->rebuild(1, $extId);
+
+    expect($first->id)->toBe($second->id);
+    expect(DB::table('customer_memory')->count())->toBe(1);
+});
+
+it('touch() é UPSERT atômico — cria row mínima se não existe', function () {
+    $linker = new ConversationContactLinker();
+    $rebuilder = new CustomerMemoryRebuilder($linker);
+
+    $rebuilder->touch(1, '5548999872822');
+
+    $row = DB::table('customer_memory')->where('business_id', 1)->first();
+    expect($row)->not->toBeNull()
+        ->and($row->customer_external_id)->toBe('5548999872822')
+        ->and($row->last_interaction_at)->not->toBeNull()
+        ->and($row->first_interaction_at)->not->toBeNull();
+});
+
+it('touch() não sobrescreve first_interaction_at quando re-chamado', function () {
+    $linker = new ConversationContactLinker();
+    $rebuilder = new CustomerMemoryRebuilder($linker);
+
+    $earlier = \Carbon\Carbon::parse('2026-01-01 10:00:00');
+    $later = \Carbon\Carbon::parse('2026-05-15 18:00:00');
+
+    $rebuilder->touch(1, '5548999872822', $earlier);
+    $rebuilder->touch(1, '5548999872822', $later);
+
+    $row = DB::table('customer_memory')->where('business_id', 1)->first();
+    // first_interaction_at NÃO muda (COALESCE protege)
+    expect(\Carbon\Carbon::parse($row->first_interaction_at)->format('Y-m-d'))->toBe('2026-01-01');
+    // last_interaction_at atualiza pro mais recente
+    expect(\Carbon\Carbon::parse($row->last_interaction_at)->format('Y-m-d'))->toBe('2026-05-15');
+});
+
+it('Identity resolution liga Contact quando phone bate (exact)', function () {
+    $linker = new ConversationContactLinker();
+    $rebuilder = new CustomerMemoryRebuilder($linker);
+
+    // Contact com mobile == external_id sem +
+    $contactId = seedContactFixture(1, 'João Cliente', '5548999872822', true);
+    seedConvFixture(1, '5548999872822');
+
+    $memory = $rebuilder->rebuild(1, '5548999872822');
+
+    expect($memory->contact_id)->toBe($contactId)
+        ->and($memory->identity_match_method)->toBeIn([CustomerMemory::MATCH_EXACT, CustomerMemory::MATCH_SUFFIX_8])
+        ->and($memory->identity_match_confidence)->toBe(1.0)
+        ->and($memory->display_name)->toBe('João Cliente')
+        ->and($memory->consent_status)->toBe(CustomerMemory::CONSENT_GIVEN);
+});
+
+it('Identity resolution marca ambiguous quando 2+ contacts batem', function () {
+    $linker = new ConversationContactLinker();
+    $rebuilder = new CustomerMemoryRebuilder($linker);
+
+    // 2 contacts com mesmo mobile (duplicata CRM legacy)
+    seedContactFixture(1, 'João A', '5548999872822');
+    seedContactFixture(1, 'João B', '5548999872822');
+    seedConvFixture(1, '5548999872822');
+
+    $memory = $rebuilder->rebuild(1, '5548999872822');
+
+    expect($memory->identity_match_method)->toBe(CustomerMemory::MATCH_AMBIGUOUS)
+        ->and($memory->identity_match_confidence)->toBeLessThan(1.0);
+});
+
+it('Identity resolution: sem contact = match_unknown', function () {
+    $linker = new ConversationContactLinker();
+    $rebuilder = new CustomerMemoryRebuilder($linker);
+
+    // Conv mas zero contacts
+    seedConvFixture(1, '5548999872822');
+
+    $memory = $rebuilder->rebuild(1, '5548999872822');
+
+    expect($memory->contact_id)->toBeNull()
+        ->and($memory->identity_match_method)->toBe(CustomerMemory::MATCH_UNKNOWN);
+});
+
+it('Stats agregados batem com count real de messages', function () {
+    $linker = new ConversationContactLinker();
+    $rebuilder = new CustomerMemoryRebuilder($linker);
+
+    $extId = '5548999872822';
+    $convId = seedConvFixture(1, $extId);
+    seedMsgFixture(1, $convId, 'inbound');
+    seedMsgFixture(1, $convId, 'inbound');
+    seedMsgFixture(1, $convId, 'inbound');
+    seedMsgFixture(1, $convId, 'outbound');
+
+    $memory = $rebuilder->rebuild(1, $extId);
+
+    expect($memory->n_msgs_inbound)->toBe(3)
+        ->and($memory->n_msgs_outbound)->toBe(1)
+        ->and($memory->n_msgs_total)->toBe(4)
+        ->and($memory->n_conversations)->toBe(1);
+});
+
+it('Tier 0: biz=99 NÃO vê customer_memory de biz=1', function () {
+    $linker = new ConversationContactLinker();
+    $rebuilder = new CustomerMemoryRebuilder($linker);
+
+    seedConvFixture(1, '5548999872822');
+    seedMsgFixture(1, 1, 'inbound');
+
+    seedConvFixture(99, '5548999872822');
+    seedMsgFixture(99, 2, 'inbound');
+    seedMsgFixture(99, 2, 'inbound');
+
+    $memBiz1 = $rebuilder->rebuild(1, '5548999872822');
+    $memBiz99 = $rebuilder->rebuild(99, '5548999872822');
+
+    expect($memBiz1->n_msgs_inbound)->toBe(1);
+    expect($memBiz99->n_msgs_inbound)->toBe(2);
+    expect($memBiz1->id)->not->toBe($memBiz99->id);
+});
+
+it('LGPD: consent_status reflete contacts.whatsapp_consent', function () {
+    $linker = new ConversationContactLinker();
+    $rebuilder = new CustomerMemoryRebuilder($linker);
+
+    // 3 cenários: consent=true (given), false (withdrawn), null (unknown)
+    seedContactFixture(1, 'Consent OK', '11111111111', true);
+    seedConvFixture(1, '11111111111');
+    $memOk = $rebuilder->rebuild(1, '11111111111');
+    expect($memOk->consent_status)->toBe(CustomerMemory::CONSENT_GIVEN);
+
+    seedContactFixture(1, 'Consent Off', '22222222222', false);
+    seedConvFixture(1, '22222222222');
+    $memOff = $rebuilder->rebuild(1, '22222222222');
+    expect($memOff->consent_status)->toBe(CustomerMemory::CONSENT_WITHDRAWN);
+
+    // Sem contact, vira UNKNOWN
+    seedConvFixture(1, '33333333333');
+    $memNull = $rebuilder->rebuild(1, '33333333333');
+    expect($memNull->consent_status)->toBe(CustomerMemory::CONSENT_UNKNOWN);
+});
+
+it('CustomerMemory entity helpers: n_msgs_total + daysSinceLastInteraction + isErasureRequested', function () {
+    $linker = new ConversationContactLinker();
+    $rebuilder = new CustomerMemoryRebuilder($linker);
+
+    $extId = '5548999872822';
+    $convId = seedConvFixture(1, $extId);
+    seedMsgFixture(1, $convId, 'inbound', now()->subDays(5)->format('Y-m-d H:i:s'));
+    seedMsgFixture(1, $convId, 'outbound', now()->subDays(5)->format('Y-m-d H:i:s'));
+
+    $memory = $rebuilder->rebuild(1, $extId);
+
+    expect($memory->n_msgs_total)->toBe(2);
+    expect($memory->daysSinceLastInteraction())->toBeGreaterThanOrEqual(4)->toBeLessThanOrEqual(6);
+    expect($memory->isErasureRequested())->toBeFalse();
+
+    $memory->erasure_requested_at = now();
+    expect($memory->isErasureRequested())->toBeTrue();
+});

--- a/Modules/Whatsapp/Tests/Feature/EmployeePerformanceRebuilderTest.php
+++ b/Modules/Whatsapp/Tests/Feature/EmployeePerformanceRebuilderTest.php
@@ -1,0 +1,312 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Whatsapp\Entities\EmployeePerformance;
+use Modules\Whatsapp\Services\EmployeePerformance\EmployeePerformanceRebuilder;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-VOZ-003 — EmployeePerformanceRebuilder.
+ *
+ * Cobertura:
+ *   1. rebuild() com user_id real (PRIMÁRIO) cria scorecard
+ *   2. rebuild() com heuristic_name (FALLBACK) cria scorecard
+ *   3. rebuild() é idempotente
+ *   4. Stats agregados batem count real
+ *   5. Scoring 0-100 com breakdown transparente
+ *   6. faixa() classifica corretamente (excelente/bom/regular/abaixo)
+ *   7. Tier 0: biz=99 NÃO vê biz=1
+ *   8. Velocidade mediana calculada (inbound prev → outbound)
+ *   9. SLA breach contado quando >4h
+ */
+beforeEach(function () {
+    foreach (['employee_performance', 'customer_memory', 'messages', 'conversations', 'users', 'business'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('business', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('name');
+        $table->timestamps();
+    });
+
+    Schema::create('users', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('username', 60);
+        $table->string('first_name', 60)->nullable();
+        $table->string('last_name', 60)->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->string('customer_external_id', 40)->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 20);
+        $table->string('type', 20)->default('text');
+        $table->text('body')->nullable();
+        $table->boolean('is_internal_note')->default(false);
+        $table->unsignedInteger('sender_user_id')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('customer_memory', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('customer_external_id', 40);
+        $table->unsignedInteger('total_reclamacoes')->default(0);
+        $table->timestamps();
+        $table->unique(['business_id', 'customer_external_id']);
+    });
+
+    Schema::create('employee_performance', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedInteger('user_id')->nullable();
+        $table->string('heuristic_name', 60)->nullable();
+        $table->string('display_name', 120)->nullable();
+        $table->unsignedInteger('n_msgs_total')->default(0);
+        $table->unsignedInteger('n_conversations_atendidas')->default(0);
+        $table->unsignedInteger('n_clientes_diferentes')->default(0);
+        $table->unsignedInteger('tempo_resposta_mediana_s')->nullable();
+        $table->unsignedInteger('tempo_resposta_p90_s')->nullable();
+        $table->unsignedInteger('sla_breach_count')->default(0);
+        $table->unsignedInteger('reclamacoes_recebidas')->default(0);
+        $table->decimal('csat_avg', 3, 2)->nullable();
+        $table->unsignedTinyInteger('horas_ativas_distintas')->default(0);
+        $table->unsignedTinyInteger('hora_pico')->nullable();
+        $table->unsignedTinyInteger('dias_ativos_30d')->default(0);
+        $table->timestamp('primeira_atividade_at')->nullable();
+        $table->timestamp('ultima_atividade_at')->nullable();
+        $table->json('temas_dominantes')->nullable();
+        $table->unsignedTinyInteger('nota_geral')->nullable();
+        $table->json('nota_breakdown')->nullable();
+        $table->timestamp('nota_calculada_em')->nullable();
+        $table->json('flags')->nullable();
+        $table->timestamp('last_rebuilt_at')->nullable();
+        $table->string('rebuilt_via', 24)->nullable();
+        $table->timestamps();
+    });
+
+    DB::table('business')->insert([
+        ['id' => 1, 'name' => 'WR', 'created_at' => now(), 'updated_at' => now()],
+        ['id' => 99, 'name' => 'Outro', 'created_at' => now(), 'updated_at' => now()],
+    ]);
+});
+
+function seedEmpUser(int $id, string $name): void
+{
+    DB::table('users')->insert([
+        'id' => $id,
+        'username' => strtolower($name),
+        'first_name' => $name,
+        'last_name' => '',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+}
+
+function seedEmpConv(int $bizId, string $ext): int
+{
+    return DB::table('conversations')->insertGetId([
+        'business_id' => $bizId,
+        'channel_id' => 10,
+        'customer_external_id' => $ext,
+        'created_at' => now()->subDays(1),
+        'updated_at' => now(),
+    ]);
+}
+
+function seedEmpMsg(int $bizId, int $convId, string $direction, ?int $userId = null, ?string $body = null, ?string $when = null): int
+{
+    return DB::table('messages')->insertGetId([
+        'business_id' => $bizId,
+        'conversation_id' => $convId,
+        'direction' => $direction,
+        'type' => 'text',
+        'body' => $body ?? 'msg',
+        'sender_user_id' => $userId,
+        'is_internal_note' => false,
+        'created_at' => $when ? \Carbon\Carbon::parse($when) : now(),
+        'updated_at' => $when ? \Carbon\Carbon::parse($when) : now(),
+    ]);
+}
+
+it('rebuild() com user_id real (PRIMÁRIO) cria scorecard', function () {
+    seedEmpUser(10, 'Maiara');
+    $conv = seedEmpConv(1, '5548999872822');
+    seedEmpMsg(1, $conv, 'outbound', userId: 10);
+    seedEmpMsg(1, $conv, 'outbound', userId: 10);
+    seedEmpMsg(1, $conv, 'outbound', userId: 10);
+
+    $rebuilder = new EmployeePerformanceRebuilder();
+    $perf = $rebuilder->rebuild(1, userId: 10);
+
+    expect($perf->business_id)->toBe(1)
+        ->and($perf->user_id)->toBe(10)
+        ->and($perf->heuristic_name)->toBeNull()
+        ->and($perf->display_name)->toBe('Maiara')
+        ->and($perf->n_msgs_total)->toBe(3)
+        ->and($perf->n_conversations_atendidas)->toBe(1)
+        ->and($perf->nota_geral)->toBeGreaterThan(0)
+        ->and($perf->nota_breakdown)->toBeArray();
+});
+
+it('rebuild() com heuristic_name (FALLBACK) cria scorecard', function () {
+    $conv = seedEmpConv(1, '5548999872822');
+    seedEmpMsg(1, $conv, 'outbound', body: '*Luiz:* Bom dia');
+    seedEmpMsg(1, $conv, 'outbound', body: '*Luiz:* posso ajudar?');
+
+    $rebuilder = new EmployeePerformanceRebuilder();
+    $perf = $rebuilder->rebuild(1, heuristicName: 'Luiz');
+
+    expect($perf->user_id)->toBeNull()
+        ->and($perf->heuristic_name)->toBe('Luiz')
+        ->and($perf->display_name)->toBe('Luiz')
+        ->and($perf->n_msgs_total)->toBe(2);
+});
+
+it('rebuild() é idempotente — re-run não duplica', function () {
+    seedEmpUser(10, 'Maiara');
+    $conv = seedEmpConv(1, '5548999872822');
+    seedEmpMsg(1, $conv, 'outbound', userId: 10);
+
+    $rebuilder = new EmployeePerformanceRebuilder();
+    $first = $rebuilder->rebuild(1, userId: 10);
+    $second = $rebuilder->rebuild(1, userId: 10);
+
+    expect($first->id)->toBe($second->id);
+    expect(DB::table('employee_performance')->count())->toBe(1);
+});
+
+it('Stats agregados batem count real (3 convs, 9 msgs, 3 clientes)', function () {
+    seedEmpUser(10, 'Maiara');
+    $c1 = seedEmpConv(1, '5548111111111');
+    $c2 = seedEmpConv(1, '5548222222222');
+    $c3 = seedEmpConv(1, '5548333333333');
+
+    foreach ([$c1, $c2, $c3] as $c) {
+        seedEmpMsg(1, $c, 'outbound', userId: 10);
+        seedEmpMsg(1, $c, 'outbound', userId: 10);
+        seedEmpMsg(1, $c, 'outbound', userId: 10);
+    }
+
+    $rebuilder = new EmployeePerformanceRebuilder();
+    $perf = $rebuilder->rebuild(1, userId: 10);
+
+    expect($perf->n_msgs_total)->toBe(9);
+    expect($perf->n_conversations_atendidas)->toBe(3);
+    expect($perf->n_clientes_diferentes)->toBe(3);
+});
+
+it('Scoring 0-100 com breakdown transparente (6 dimensões)', function () {
+    seedEmpUser(10, 'Maiara');
+    // Atendimento robusto: 100 msgs em 30 conversas
+    for ($i = 0; $i < 30; $i++) {
+        $conv = seedEmpConv(1, '55481' . str_pad((string) $i, 8, '0'));
+        for ($j = 0; $j < 4; $j++) {
+            seedEmpMsg(1, $conv, 'outbound', userId: 10);
+        }
+    }
+
+    $rebuilder = new EmployeePerformanceRebuilder();
+    $perf = $rebuilder->rebuild(1, userId: 10);
+
+    expect($perf->nota_breakdown)->toBeArray()
+        ->and(array_keys($perf->nota_breakdown))->toBe(['volume', 'diversidade', 'velocidade', 'profundidade', 'cobertura', 'engajamento']);
+
+    // Soma das dimensões = nota_geral
+    expect(array_sum($perf->nota_breakdown))->toBe((int) $perf->nota_geral);
+});
+
+it('faixa() classifica corretamente', function () {
+    $perf = new EmployeePerformance();
+
+    $perf->nota_geral = 95;
+    expect($perf->faixa())->toBe('excelente');
+
+    $perf->nota_geral = 75;
+    expect($perf->faixa())->toBe('bom');
+
+    $perf->nota_geral = 55;
+    expect($perf->faixa())->toBe('regular');
+
+    $perf->nota_geral = 30;
+    expect($perf->faixa())->toBe('abaixo');
+});
+
+it('Tier 0: biz=99 NÃO vê biz=1', function () {
+    seedEmpUser(10, 'Maiara');
+    $cBiz1 = seedEmpConv(1, '5548999872822');
+    seedEmpMsg(1, $cBiz1, 'outbound', userId: 10);
+    seedEmpMsg(1, $cBiz1, 'outbound', userId: 10);
+
+    $cBiz99 = seedEmpConv(99, '5548999872822');
+    seedEmpMsg(99, $cBiz99, 'outbound', userId: 10);
+    seedEmpMsg(99, $cBiz99, 'outbound', userId: 10);
+    seedEmpMsg(99, $cBiz99, 'outbound', userId: 10);
+
+    $rebuilder = new EmployeePerformanceRebuilder();
+    $pBiz1 = $rebuilder->rebuild(1, userId: 10);
+    $pBiz99 = $rebuilder->rebuild(99, userId: 10);
+
+    expect($pBiz1->n_msgs_total)->toBe(2);
+    expect($pBiz99->n_msgs_total)->toBe(3);
+    expect($pBiz1->id)->not->toBe($pBiz99->id);
+});
+
+it('Velocidade mediana calculada entre inbound prev e outbound do atendente', function () {
+    seedEmpUser(10, 'Maiara');
+    $conv = seedEmpConv(1, '5548999872822');
+
+    // Inbound 10:00, outbound 10:00:30 = 30s
+    seedEmpMsg(1, $conv, 'inbound', when: '2026-05-15 10:00:00');
+    seedEmpMsg(1, $conv, 'outbound', userId: 10, when: '2026-05-15 10:00:30');
+
+    // Inbound 11:00, outbound 11:01 = 60s
+    seedEmpMsg(1, $conv, 'inbound', when: '2026-05-15 11:00:00');
+    seedEmpMsg(1, $conv, 'outbound', userId: 10, when: '2026-05-15 11:01:00');
+
+    $rebuilder = new EmployeePerformanceRebuilder();
+    $perf = $rebuilder->rebuild(1, userId: 10);
+
+    expect($perf->tempo_resposta_mediana_s)->toBeGreaterThan(0)
+        ->and($perf->tempo_resposta_mediana_s)->toBeLessThan(120);
+});
+
+it('SLA breach contado quando outbound >4h após inbound', function () {
+    seedEmpUser(10, 'Maiara');
+    $conv = seedEmpConv(1, '5548999872822');
+
+    // Inbound 10:00, outbound 15:00 = 5h (breach >4h)
+    seedEmpMsg(1, $conv, 'inbound', when: '2026-05-15 10:00:00');
+    seedEmpMsg(1, $conv, 'outbound', userId: 10, when: '2026-05-15 15:00:00');
+
+    // Inbound 16:00, outbound 16:30 = 30min (sem breach)
+    seedEmpMsg(1, $conv, 'inbound', when: '2026-05-15 16:00:00');
+    seedEmpMsg(1, $conv, 'outbound', userId: 10, when: '2026-05-15 16:30:00');
+
+    $rebuilder = new EmployeePerformanceRebuilder();
+    $perf = $rebuilder->rebuild(1, userId: 10);
+
+    expect($perf->sla_breach_count)->toBe(1);
+});
+
+it('rebuild() exige user_id OU heuristic_name', function () {
+    $rebuilder = new EmployeePerformanceRebuilder();
+
+    expect(fn () => $rebuilder->rebuild(1))
+        ->toThrow(\InvalidArgumentException::class, 'user_id OU heuristic_name');
+});

--- a/Modules/Whatsapp/Tests/Feature/OfficeimpressoEnrichServiceTest.php
+++ b/Modules/Whatsapp/Tests/Feature/OfficeimpressoEnrichServiceTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Whatsapp\Entities\CustomerMemory;
+use Modules\Whatsapp\Services\CustomerMemory\OfficeimpressoEnrichService;
+use Modules\Whatsapp\Services\CustomerMemory\Sources\FirebirdLookupSourceContract;
+use Modules\Whatsapp\Services\CustomerMemory\Sources\JsonFileFirebirdSource;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-VOZ-002 — OfficeimpressoEnrichService + JsonFileFirebirdSource.
+ *
+ * Cobertura:
+ *   1. JsonFileFirebirdSource — load + lookup por sufixo 8 dígitos
+ *   2. JsonFileFirebirdSource — health check (arquivo missing / stale)
+ *   3. JsonFileFirebirdSource — formato meta+customers vs array plain
+ *   4. JsonFileFirebirdSource — normalize Firebird keys (CODIGO vs cliente_id)
+ *   5. EnrichService — popula external_sources com match
+ *   6. EnrichService — preserva entries de outras fontes ao re-enrich
+ *   7. EnrichService — fail-open quando source unhealthy
+ */
+beforeEach(function () {
+    Schema::dropIfExists('customer_memory');
+    Schema::create('customer_memory', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->string('customer_external_id', 40);
+        $table->string('phone_normalized', 20)->nullable();
+        $table->unsignedInteger('contact_id')->nullable();
+        $table->json('external_sources')->nullable();
+        $table->timestamp('external_sources_enriched_at')->nullable();
+        $table->timestamps();
+        $table->unique(['business_id', 'customer_external_id']);
+    });
+});
+
+function tempJsonFile(array $payload): string
+{
+    $path = sys_get_temp_dir() . '/firebird-test-' . uniqid() . '.json';
+    file_put_contents($path, json_encode($payload, JSON_UNESCAPED_UNICODE));
+    return $path;
+}
+
+it('JsonFileFirebirdSource — formato {meta,customers} + lookup por sufixo 8', function () {
+    $path = tempJsonFile([
+        'meta' => ['exported_at' => '2026-05-15T18:00:00-03:00', 'row_count' => 2],
+        'customers' => [
+            [
+                'cliente_id' => 1234,
+                'nome' => 'ACME LTDA',
+                'fone1' => '+55 (48) 9 9987-2822',
+                'fone2' => null,
+                'email' => 'contato@acme.com.br',
+                'bloqueado' => false,
+            ],
+            [
+                'cliente_id' => 5678,
+                'nome' => 'BETA EIRELI',
+                'fone1' => '+55 (11) 98765-4321',
+                'email' => null,
+                'bloqueado' => true,
+            ],
+        ],
+    ]);
+
+    $source = new JsonFileFirebirdSource($path);
+
+    // Lookup matches por sufixo 8 dígitos ("99872822" do fone1)
+    $results = $source->lookupByPhone('+5548999872822');
+    expect($results)->toHaveCount(1)
+        ->and($results[0]['cliente_id'])->toBe(1234)
+        ->and($results[0]['nome'])->toBe('ACME LTDA')
+        ->and($results[0]['bloqueado'])->toBeFalse();
+
+    // Phone diferente
+    $r2 = $source->lookupByPhone('5511987654321');
+    expect($r2)->toHaveCount(1)
+        ->and($r2[0]['cliente_id'])->toBe(5678)
+        ->and($r2[0]['bloqueado'])->toBeTrue();
+
+    unlink($path);
+});
+
+it('JsonFileFirebirdSource — formato array plain (sem meta)', function () {
+    $path = tempJsonFile([
+        ['cliente_id' => 99, 'nome' => 'Plain', 'fone1' => '5511999998888'],
+    ]);
+
+    $source = new JsonFileFirebirdSource($path);
+    $results = $source->lookupByPhone('5511999998888');
+
+    expect($results)->toHaveCount(1)->and($results[0]['cliente_id'])->toBe(99);
+    unlink($path);
+});
+
+it('JsonFileFirebirdSource — normaliza keys Firebird raw (CODIGO, FONE1, BLOQUEADO=S)', function () {
+    $path = tempJsonFile([
+        'customers' => [
+            ['CODIGO' => 42, 'RAZAO_SOCIAL' => 'RAW LTDA', 'FONE1' => '5548888888888', 'BLOQUEADO' => 'S'],
+        ],
+    ]);
+
+    $source = new JsonFileFirebirdSource($path);
+    $results = $source->lookupByPhone('5548888888888');
+
+    expect($results)->toHaveCount(1)
+        ->and($results[0]['cliente_id'])->toBe(42)
+        ->and($results[0]['nome'])->toBe('RAW LTDA')
+        ->and($results[0]['bloqueado'])->toBeTrue();
+    unlink($path);
+});
+
+it('JsonFileFirebirdSource — isHealthy false quando arquivo missing', function () {
+    $source = new JsonFileFirebirdSource('/nonexistent/path/file.json');
+    expect($source->isHealthy())->toBeFalse();
+});
+
+it('JsonFileFirebirdSource — isHealthy true para arquivo recente', function () {
+    $path = tempJsonFile(['customers' => []]);
+    $source = new JsonFileFirebirdSource($path);
+    expect($source->isHealthy())->toBeTrue();
+    unlink($path);
+});
+
+it('EnrichService — popula external_sources com match', function () {
+    $path = tempJsonFile([
+        'customers' => [
+            ['cliente_id' => 1234, 'nome' => 'ACME', 'fone1' => '5548999872822'],
+        ],
+    ]);
+
+    $source = new JsonFileFirebirdSource($path);
+    $service = new OfficeimpressoEnrichService($source);
+
+    // Cria customer_memory
+    $memId = DB::table('customer_memory')->insertGetId([
+        'business_id' => 1,
+        'customer_external_id' => '5548999872822',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $memory = CustomerMemory::find($memId);
+    $matched = $service->enrich($memory);
+
+    expect($matched)->toBe(1);
+
+    $memory->refresh();
+    expect($memory->external_sources)->not->toBeNull();
+    expect($memory->external_sources[0]['cliente_id'])->toBe(1234);
+    expect($memory->external_sources[0]['nome'])->toBe('ACME');
+    expect($memory->external_sources_enriched_at)->not->toBeNull();
+
+    unlink($path);
+});
+
+it('EnrichService — preserva entries de OUTRAS fontes ao re-enrich', function () {
+    $path = tempJsonFile([
+        'customers' => [
+            ['cliente_id' => 1234, 'nome' => 'ACME ATUALIZADO', 'fone1' => '5548999872822'],
+        ],
+    ]);
+
+    // Memory já tem entry de outra fonte (asaas) + entry firebird velha
+    $memId = DB::table('customer_memory')->insertGetId([
+        'business_id' => 1,
+        'customer_external_id' => '5548999872822',
+        'external_sources' => json_encode([
+            ['source' => 'asaas:2026-04', 'customer_id' => 'cus_xyz'],
+            ['source' => 'firebird_office_json:2026-04', 'cliente_id' => 9999, 'nome' => 'VELHO'],
+        ]),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $source = new JsonFileFirebirdSource($path);
+    $service = new OfficeimpressoEnrichService($source);
+    $memory = CustomerMemory::find($memId);
+
+    $service->enrich($memory);
+
+    $memory->refresh();
+    $sources = $memory->external_sources;
+
+    // Entry asaas preservada
+    $asaasEntry = collect($sources)->firstWhere('source', 'asaas:2026-04');
+    expect($asaasEntry)->not->toBeNull();
+
+    // Entry firebird antiga REMOVIDA + nova entrou
+    $firebirdEntries = collect($sources)->filter(fn ($e) => str_starts_with($e['source'] ?? '', 'firebird_office_json'));
+    expect($firebirdEntries->count())->toBe(1);
+    expect($firebirdEntries->first()['nome'])->toBe('ACME ATUALIZADO'); // não 'VELHO'
+
+    unlink($path);
+});
+
+it('EnrichService — fail-open com source unhealthy retorna 0', function () {
+    $source = new JsonFileFirebirdSource('/nonexistent.json');
+    $service = new OfficeimpressoEnrichService($source);
+
+    $memId = DB::table('customer_memory')->insertGetId([
+        'business_id' => 1,
+        'customer_external_id' => '5548999872822',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    $memory = CustomerMemory::find($memId);
+
+    $matched = $service->enrich($memory);
+
+    expect($matched)->toBe(0);
+});
+
+it('EnrichService.enrichBusiness — processa em batch + retorna stats', function () {
+    $path = tempJsonFile([
+        'customers' => [
+            ['cliente_id' => 1, 'nome' => 'A', 'fone1' => '5548111111111'],
+            ['cliente_id' => 2, 'nome' => 'B', 'fone1' => '5548222222222'],
+        ],
+    ]);
+
+    foreach (['5548111111111', '5548222222222', '5548999999999'] as $ext) {
+        DB::table('customer_memory')->insert([
+            'business_id' => 1,
+            'customer_external_id' => $ext,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    $service = new OfficeimpressoEnrichService(new JsonFileFirebirdSource($path));
+    $stats = $service->enrichBusiness(1, limit: 10);
+
+    expect($stats['processed'])->toBe(3);
+    expect($stats['matched'])->toBe(2); // 2 dos 3 tem match no JSON
+    expect($stats['skipped'])->toBe(1);
+
+    unlink($path);
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -242,6 +242,22 @@ class Kernel extends ConsoleKernel
             ->withoutOverlapping()
             ->environments(['live']);
 
+        // US-WA-VOZ-001 — Customer Memory refresh daily (2026-05-15).
+        // Re-dispatcha RebuildCustomerMemoryJob pra customers com
+        // last_rebuilt_at > 24h ou NULL. Idempotente. 02:00 BRT alinhado
+        // com horário de baixa atividade (canal Suporte pico 12-18h BRT).
+        $schedule->command('customer-memory:refresh-daily')
+            ->dailyAt('02:00')
+            ->timezone('America/Sao_Paulo')
+            ->name('customer-memory-refresh-daily')
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule customer-memory:refresh-daily FALHOU — stats agregados ficarão stale'
+                );
+            });
+
         // ADS Reviewer (T11 G-Eval) — review automático cada 15min de decisions sem score.
         $schedule->command('ads:review-decisions --limit=10')
             ->everyFifteenMinutes()

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -258,6 +258,21 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // US-WA-VOZ-003 — Employee Performance refresh daily (2026-05-15).
+        // Re-dispatcha rebuild de scorecards. Offset 30min do customer-memory
+        // pra evitar disputa DB (02:30 BRT).
+        $schedule->command('employee-performance:refresh-daily')
+            ->dailyAt('02:30')
+            ->timezone('America/Sao_Paulo')
+            ->name('employee-performance-refresh-daily')
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule employee-performance:refresh-daily FALHOU — scorecards ficarão stale'
+                );
+            });
+
         // ADS Reviewer (T11 G-Eval) — review automático cada 15min de decisions sem score.
         $schedule->command('ads:review-decisions --limit=10')
             ->everyFifteenMinutes()

--- a/memory/sessions/2026-05-15-analise-voz-cliente-suporte-biz1.md
+++ b/memory/sessions/2026-05-15-analise-voz-cliente-suporte-biz1.md
@@ -1,0 +1,413 @@
+# Análise Voz do Cliente — Canal Suporte biz=1 · 2026-05-15
+
+> Análise feita por Claude (sem chamada IA externa) em cima de amostra real de 80 msgs + estatísticas agregadas do canal Suporte WR Sistemas (channel_id=10, display_identifier=554896486699). Wagner pediu "tudo que receber aqui vai ter que ser analisado" e "é mais barato você analisar". Este doc é o **output da análise** + **proposta de onde ficam as análises daqui pra frente** + **esboço do estado-da-arte de atendimento e memória cliente**.
+>
+> PII redact: nomes próprios de clientes substituídos por "Cliente A/B/C". Telefones mostram só prefixo+sufixo (`+5527...5927`). Nomes do time interno WR (Maiara, Luiz, Felipe) preservados — declarados em [`memory/regras-time.md`](../regras-time.md).
+>
+> Companion: `memory/sessions/2026-05-15-arte-atendimento-omnichannel-memoria-cliente.md` (agent `estado-da-arte` rodando paralelo — referência externa Front/Intercom/Crisp/Sierra/Decagon 2026).
+
+---
+
+## TL;DR (60s)
+
+**Estado prod biz=1 canal Suporte agora:**
+- **249 clientes únicos** ativos · **29.355 msgs** (18.470 inbound / 10.885 outbound) · pico 18h
+- Time atendendo: **Maiara · Luiz · Felipe** (Wagner não atende direto, fica supervisor)
+- Atendimento via **AnyDesk remoto** é o padrão dominante ("passa o acesso" + "vou conectar")
+
+**Top 3 categorias dominantes** (inferidas da amostra):
+| # | Tema | Sinal | Implicação |
+|---|---|---|---|
+| 1 | **NFe / SEFAZ / emissão de nota** | 30-40% dos tickets · "Sefaz atualizou regras" · "não consigo emitir NF" | Gargalo crítico do produto — área que mais consome time |
+| 2 | **Bugs pós-atualização do sistema** | "Foi feita uma atualização e deram alguns bugs" · "Ainda não consegui fazer notas conforme atualização" | Cliente PERCEBE regressões. Sinal de qualidade pós-release frágil |
+| 3 | **Retorno bancário / boleto** | "problemas no retorno do arquivo do banco" · "não está dando baixa" | Jornada Financeiro/cobrança crítica — automação mal calibrada |
+
+**Insight gerencial central:** a fila de Suporte está sendo usada como **fila de bug report do produto**. Não é só atendimento — é **sinal de roadmap**. Catalogar isso vira input direto de priorização ([ADR 0105](../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md): "cliente como sinal qualificado").
+
+**Onde devem ficar as análises** (proposta 4 camadas, detalhe §3):
+1. **Por mensagem** → `messages.analise_*` (PR #916 draft, fica pra outro dia)
+2. **Por conversa** → tabela `conversation_insights` (resumo + outcome + tempo)
+3. **Por cliente** → tabela `customer_memory` (perfil acumulado, churn score, temas recorrentes)
+4. **Por período** → snapshot diário/semanal (Wagner consome de manhã via brief)
+5. **Por feature** → `product_feedback_signals` (Capterra reverso — bugs/dúvidas viram input do roadmap)
+
+---
+
+## §1 — Análise da amostra (80 msgs canal Suporte biz=1, 2026-05-15)
+
+### Padrões linguísticos observados
+
+| Pattern | Exemplo (anonimizado) | Frequência |
+|---|---|---|
+| **Saudação inflada** | "BOMMMMMDIAAAAA" / "Boa tarde, Maiara!!!" | Alta — abertura típica |
+| **"Passa o acesso"** (AnyDesk handoff) | "vou te mandar o acesso" / "Me passa o acesso da sua máquina" | Dominante — gargalo de escala |
+| **Bug report direto** | "não está dando baixa" / "deu erro" / "está muito lento" | Alta — produto fala via cliente |
+| **Desespero contido** | "Estou com clientes na minha sala" / "Assim que poder me liga por favor" | Média — urgência percebida vs real |
+| **Confirmação resolução** | "obrigadaaa" / "perfeito" / "muito obrigada" | Alta — clientes pacientes, gratos |
+
+### Distribuição horária (inbound biz=1)
+
+```
+11h: 274     ▏
+12h: 1.731   ████▍
+13h: 1.441   ███▌
+14h: 1.677   ████▏
+15h: 1.640   ████
+16h: 1.747   ████▍
+17h: 1.803   ████▌
+18h: 4.477   ███████████▏  ← pico (provável viés history sync chunk burst)
+```
+
+> **Nota:** o pico de 18h pode ser distorção do history sync importando em chunks — não necessariamente padrão real de comportamento. Validar com janela 7d quando estabilizar.
+
+### Quem reclamou de quê (amostra de 30 msgs com palavras-chave erro/bug/problema/atualização)
+
+Distribuição por **módulo do oimpresso** (inferido):
+
+| Módulo | Msgs flagged | Sinais |
+|---|---|---|
+| **NfeBrasil** | 8/30 (27%) | "problema pra emitir nf" · "erro pra emitir nota" · "notas conforme atualização" · "verificar erro de emissão NF" |
+| **Pós-atualização (multi-módulo)** | 5/30 (17%) | "atualização do sistema e deram bugs" · "Quanto demora a atualização?" · "sistema lento pós-reinstalação" |
+| **Financeiro / boleto** | 3/30 (10%) | "retorno do arquivo do banco" · "não está dando baixa" |
+| **Vendas / anexo** | 2/30 (7%) | "anexar arquivo na venda e tá dando erro" · "buga tudo finalizar venda" |
+| **Layout / impressão** | 2/30 (7%) | "não consegue liberar pra salvar o layout" · "dar erro na remessa" |
+| **Email / domínio** | 1/30 (3%) | "domínio email aparece erro" |
+| **Spam B2B** | 1/30 (3%) | Vendedora terceira oferecendo plano Claro Empresas |
+| **Outros / ambíguo** | 8/30 (27%) | "ainda to com dois problemas" / "deu o mesmo erro" — precisa contexto |
+
+### Top conversas mais ativas (24h)
+
+| conv | Cliente | n_msgs | Janela | Hipótese |
+|---|---|---|---|---|
+| 47 | +5527...5927 | **1.800** | 7h | Cliente único com problema complexo OU history sync concentrado |
+| 41 | +5545...8597 | 1.167 | 6h |  |
+| 46 | +5548...0075 | **929** | 6h | (msgs flagged "Esse é o erro" / "Mesmo erro" — issue recorrente não resolvida) |
+| 64 | +5548...0182 | 881 | 6h |  |
+| 105 | +1141...01288 | 857 | 5h | (DDI estranho — talvez número internacional ou erro de parsing JID) |
+
+⚠️ **Atenção:** ratio msgs/cliente desigual (top 10 conversas concentram >40% do volume) — sinal de **clientes "frágeis"** que demandam desproporcional atenção. Candidatos a perfil "VIP" ou "high-churn-risk".
+
+### Sinais qualitativos load-bearing
+
+1. **"A Sefaz atualizou algumas regras de nota e estamos com uma demanda muito grande de atendimento"** (Maiara, conv=50) — **reconhecimento explícito de overload** do time. Métrica: tempo resposta SLA em risco.
+
+2. **"Eu peguei uma cópia do banco de dados e iremos analisar melhor as mensagens"** (atendente, conv=204) — **caso desbloqueado por debug profundo** (export DB). Não escala.
+
+3. **"Estou com clientes na minha sala"** (Cliente A, conv=50) — **cliente atende cliente final** (B2B2C). Cada minuto de espera = perda do cliente final dela. Urgência multiplicada.
+
+4. **"Semana passada deu problema no nosso servidor e teve q reinstalar o sistema mas agora está muito lento"** (conv=47) — **regressão pós-reinstalação** confirma fragilidade de updates/installs.
+
+5. **"quando eu termino uma venda... aparece mensagem pra cadastrar email... eu coloco 'não quero' e buga tudo o sistema"** (conv=284) — **bug específico, reproduzível, prioridade alta** pro roadmap.
+
+---
+
+## §2 — Top sinais gerenciais (priorizados impacto × esforço)
+
+### Sinal A — Pipeline de release fragilizada (atualização vira bug report)
+- **Evidência:** múltiplos clientes mencionam "pós-atualização e deram bugs" como CAUSA do problema atual
+- **Implicação:** sistema CI/CD do oimpresso precisa de canary 7d ([ADR 0101](../decisions/0101-tests-business-id-1-nunca-cliente.md) já caminha nessa direção) + smoke test pós-deploy + comunicação proativa "tem atualização, vocês podem reportar problemas em <link>"
+- **Ação Wagner:** próximo deploy de produção, adicionar mensagem proativa WhatsApp template "Atualização aplicada — qualquer comportamento estranho, nos avise". Reduz volume reativo + dá audit trail estruturado.
+
+### Sinal B — NFe é o produto crítico — gargalo de roadmap
+- **Evidência:** ~30-40% dos tickets são NFe/SEFAZ
+- **Implicação:** investimento em [Modules/NfeBrasil](../../Modules/NfeBrasil/) tem ROI alto. Cada hora de dor da Maiara/Luiz com SEFAZ rejeitando = oportunidade de UI mais inteligente + erros amigáveis no oimpresso.
+- **Ação Wagner:** ler conversas conv=50/conv=218 inteiras (são casos NFe recorrentes) e listar top 3 "erros NFe que o sistema poderia explicar melhor" como entrada pro próximo cycle.
+
+### Sinal C — AnyDesk é o gargalo de escala
+- **Evidência:** "passa o acesso" / "vou conectar" é padrão dominante. Cada atendimento = sessão remota humana ~10-30min.
+- **Implicação:** sem **self-service inteligente** (FAQ contextual + guia visual + bot Jana resolvendo top 20 casos sem humano), time não escala. Atender 500 clientes ≠ atender 49 do jeito atual.
+- **Ação Wagner:** mapear top 5 casos resolvidos via AnyDesk → criar fluxo self-service guiado dentro do oimpresso (modal "preciso de ajuda → categoria X → passo-a-passo do bot Jana").
+
+### Sinal D — Clientes "high-touch" concentrados
+- **Evidência:** 10 conversas concentram >40% do volume
+- **Implicação:** distribuição Pareto. Esses 10 clientes ou são (a) clientes VIP que pagam mais OU (b) clientes frustrados que vão churnar. Diferenciar via análise é crítico.
+- **Ação Wagner:** review semanal dos top 10 conversas (manual ou via brief automatizado quando arquitetura §3 estiver em pé) — decisão por cliente: "investir mais" vs "deixar partir bem".
+
+### Sinal E — Bug específico documentado (conv=284)
+- "finalizar venda → modal email → 'não quero' → buga tudo"
+- **É caso reproduzível** — entra direto como issue P1 no roadmap Sells/Vendas.
+- **Ação Wagner:** ler msg id 28935 + abrir issue no GitHub spawn task MCP com US-SELL-XXX.
+
+### Sinal F — Spam B2B no canal de Suporte
+- Vendedora Claro Empresas oferecendo plano de telefonia
+- **Implicação:** canal Suporte recebe ruído de prospecting. Filtro automático "spam" libera tempo humano.
+- **Ação Wagner:** baixa prioridade — só se volume crescer. Hoje é caso isolado.
+
+---
+
+## §3 — Onde ficam as análises (arquitetura proposta — 5 camadas)
+
+> **Princípio:** análise não vive em 1 lugar. Cada granularidade serve um consumidor diferente. Camadas 1-4 são DATA, camada 5 é UI. Tudo respeita Tier 0 multi-tenant ([ADR 0093](../decisions/0093-multi-tenant-isolation-tier-0.md)).
+
+### Camada 1 — Análise **por mensagem** (granular, opcional)
+- **Onde:** `messages.analise_*` (9 colunas — categoria/tema/urgência/resumo + tracking)
+- **Quando:** quando vale o custo IA (Wagner liga via flag por business)
+- **Status atual:** PR #916 DRAFT — código pronto, esperando Wagner aprovar custo (~R$4 backlog + R$0.60/mês/biz)
+- **Consumidor:** dashboard agregado tempo real (camada 5)
+- **Skip:** se Wagner preferir não pagar IA, pula esta camada e analise eu (Claude) periodicamente em sessions ad-hoc
+
+### Camada 2 — Análise **por conversa** (síntese)
+- **Onde proposto:** nova tabela `conversation_insights`
+- **Schema (esboço):**
+  ```sql
+  conversation_insights (
+    id, business_id INDEXED,
+    conversation_id INDEXED,
+    tema_principal VARCHAR(32),      -- nfe|caixa|boleto|venda|atualizacao_bug|...
+    sentimento_score DECIMAL(3,2),   -- -1.00..+1.00
+    outcome VARCHAR(20),             -- resolvido|escalado|abandonado|em_andamento
+    tempo_resolucao_min INT,
+    n_msgs_inbound INT, n_msgs_outbound INT,
+    atendente_principal_user_id INT NULL,
+    resumo_executivo TEXT,           -- 3-5 linhas Jana
+    flags JSON,                       -- [{tipo:"churn_risk", grade:"alto"}, {tipo:"bug_report", modulo:"NfeBrasil"}]
+    updated_at,                       -- atualiza quando conversa fecha OU a cada N msgs
+    created_at
+  )
+  ```
+- **Quando atualiza:** trigger ao marcar conv `resolved` OU cron diário 03h pra conversas abertas há >24h
+- **Consumidor:** sidebar UI Inbox "Resumo da conversa", filtro Inbox "só churn-risk-alto"
+
+### Camada 3 — Memória **por cliente** (perfil acumulado — a peça central)
+- **Onde proposto:** nova tabela `customer_memory` (single source of truth da memória cliente final)
+- **Schema (esboço):**
+  ```sql
+  customer_memory (
+    id, business_id INDEXED,
+    customer_external_id VARCHAR(40) INDEXED,  -- E.164 telefone canônico ('+5548...')
+    contact_id INT NULL,                        -- FK Contact (UltimatePOS CRM) quando linkado
+    
+    -- Stats agregados (Job daily 02h)
+    n_conversations INT,
+    n_msgs_total INT,
+    first_interaction_at TIMESTAMP,
+    last_interaction_at TIMESTAMP,
+    avg_response_time_min INT,
+    
+    -- Inferências (LLM acumula janela 90d)
+    temas_recorrentes JSON,    -- ["nfe","boleto","atualizacao_bug"]
+    sentimento_score DECIMAL(3,2),
+    churn_risk_score DECIMAL(3,2),
+    comunicacao_preferida JSON, -- {hora_pico:"14h-17h", canal:"whatsapp", tom:"formal"}
+    
+    -- Memória qualitativa Jana (≤2KB texto)
+    notas_jana TEXT,
+    notas_atualizada_em TIMESTAMP,
+    
+    -- Operacional / tagging
+    flags JSON,  -- [{tipo:"vip", motivo:"alto LTV"}, {tipo:"fragil", since:"2026-05-10"}]
+    
+    created_at, updated_at,
+    UNIQUE (business_id, customer_external_id)
+  )
+  ```
+- **Quando atualiza:**
+  - Job daily 02h recalcula stats agregados
+  - Listener `OmnichannelMessageReceived` invalida cache da memória do cliente
+  - Jana pode escrever em `notas_jana` quando aprende algo (ex: "cliente X disse que prefere ser atendido pela Maiara — registrar")
+- **Consumidor:**
+  - **Sidebar UI Inbox "Sobre o cliente"** (Customer 360 — pattern Front/Intercom)
+  - Jana Bot via `decide(intent: 'reply', context: customer_memory.get($contact))` quando responder
+  - Brief gerencial agrega top clientes risco
+
+### Camada 4 — Snapshot **por período** (consumível Wagner)
+- **Onde proposto:** tabela `customer_voice_snapshots`
+- **Schema (esboço):**
+  ```sql
+  customer_voice_snapshots (
+    id, business_id INDEXED,
+    snapshot_date DATE INDEXED,
+    period VARCHAR(20),  -- daily|weekly|monthly
+    
+    top_temas JSON,             -- [{tema:"nfe", n:124, sentimento:-0.32}, ...]
+    top_reclamacoes JSON,        -- top 5 reclamações textuais únicas (clusterizadas)
+    top_features_demandadas JSON,-- INSIGHT ROADMAP — features que clientes pedem
+    sentimento_medio DECIMAL(3,2),
+    n_clientes_ativos INT,
+    n_msgs_total INT,
+    n_conversations_novas INT,
+    
+    brief_markdown LONGTEXT,     -- Jana resume período num briefing pro Wagner
+    
+    UNIQUE (business_id, snapshot_date, period)
+  )
+  ```
+- **Quando gera:** cron daily 06h BRT (alinhado com Daily Brief — [ADR 0091](../decisions/0091-daily-brief.md))
+- **Consumidor:** dashboard `/copiloto/voz-cliente` (UI nova) + email Wagner manhã
+
+### Camada 5 — Sinais **por feature/módulo** (Capterra reverso — input roadmap)
+- **Onde proposto:** tabela `product_feedback_signals`
+- **Schema (esboço):**
+  ```sql
+  product_feedback_signals (
+    id, business_id INDEXED,
+    modulo VARCHAR(40),          -- NfeBrasil|Caixa|Vendas|Financeiro|...
+    severidade VARCHAR(20),       -- crítico|alto|medio|baixo
+    n_mencoes_30d INT,
+    primeira_mencao_at, ultima_mencao_at,
+    exemplos_msg_ids JSON,        -- [29083, 28526, 28411] — pra ler msgs originais
+    sugestao_feature TEXT,        -- Jana sugere: "modal explicativo erro NFe X"
+    status VARCHAR(20),           -- novo|triage|planejado|em_dev|shipped|rejeitado
+    linked_task_id VARCHAR(40) NULL,  -- task MCP quando virar US no SPEC
+    
+    UNIQUE (business_id, modulo, sugestao_feature(50))
+  )
+  ```
+- **Quando atualiza:** Jana mensal (cron 1º dia do mês) agrega `messages` por módulo e clusteriza sugestões
+- **Consumidor:** Wagner durante planejamento cycle — lê `product_feedback_signals` filtrado por `n_mencoes_30d > 5 ORDER BY severidade`
+
+### Resumo das 5 camadas
+
+| Camada | Tabela | Granularidade | Atualiza | Consumidor |
+|---|---|---|---|---|
+| 1 | `messages.analise_*` | Por mensagem | tempo real (Job) | Dashboard tempo real |
+| 2 | `conversation_insights` | Por conversa | trigger ou cron daily | UI sidebar conversa |
+| 3 | `customer_memory` | Por cliente | cron daily + Jana writes | UI sidebar cliente · Bot Jana context |
+| 4 | `customer_voice_snapshots` | Por período | cron daily 06h | Dashboard Wagner · email morning |
+| 5 | `product_feedback_signals` | Por módulo | cron monthly | Wagner planning cycle |
+
+**Migração proposta:** Camada 3 (`customer_memory`) é a PEÇA CENTRAL — começar por ela. Camadas 2, 4, 5 são derivações cruzando `customer_memory` × `conversations` × `messages`. Camada 1 fica pra última (PR #916 retomado quando custo IA aprovado).
+
+---
+
+## §4 — Memória cliente · como deveria ser (em 2026)
+
+### Hoje (estado atual oimpresso)
+
+| Peça | Onde | Status |
+|---|---|---|
+| Identidade cliente | `Contact` (UltimatePOS CRM legacy) — nome, telefone, CPF, endereço | ✅ existe |
+| Conversa | `conversations` (omnichannel, ADR 0135) | ✅ existe, mas `contact_id=NULL` em todas biz=1 (não linkadas) |
+| Histórico interação | `messages` append-only | ✅ existe, falta indexar pra recall semântico |
+| Memória usuário SaaS (Wagner/Maiara) | `copiloto_memoria_facts` (Jana, ADR 0036) | ✅ existe |
+| **Memória do cliente FINAL** (a pessoa do outro lado do WhatsApp) | — | ❌ **NÃO EXISTE** |
+
+### Gap identificado
+
+Hoje, quando o cliente +5548...0075 (conv=46) manda "Esse é o erro" pela 3ª vez consecutiva, o atendente NÃO sabe automaticamente:
+
+- Quantas vezes esse cliente já reportou bugs no último mês
+- Qual módulo ele mais reclama
+- Se ele é VIP (alto LTV) ou frágil (alto churn risk)
+- Quando foi a última interação
+- Qual a preferência dele (tom formal? casual? horário?)
+- Se ele já recebeu workaround similar antes
+
+Resultado: cada conversa começa do zero. Atendimento humano carrega isso na cabeça da Maiara/Luiz — **conhecimento implícito não escala**.
+
+### Como deveria ser (vai detalhar quando agent `estado-da-arte` entregar — referência preliminar)
+
+Padrão consolidado em 2026 (Front, Intercom, Crisp v4, Help Scout):
+
+#### 1. Customer 360 sidebar (sempre visível durante atendimento)
+- Foto/nome + 1 linha "quem é esse cliente"
+- Stats: n interações, tempo médio, n módulos contatados
+- Top temas recorrentes (chips clicáveis filtrando histórico)
+- Sentimento agregado (mood gauge)
+- Flags: VIP / Frágil / Churn-risk / Cliente novo (<7d)
+- Últimas 3 interações (links)
+- Notas qualitativas Jana ("este cliente prefere atendimento por chamada — anotado em 2026-04-12 conv=84")
+
+#### 2. Memória persistente (read + write)
+- Persiste no DB, sobrevive `/clear` do atendente
+- Read: atendente abre conv → memória carrega
+- Write: 3 caminhos:
+  - **Automático** (Jana infere via LLM + heurística — temas, sentimento, churn score)
+  - **Atendente humano** ("anote: este cliente é Pinheiros SP, sócio é Sr. X" via slash command `/lembrar`)
+  - **Sistema** (importação Contact CRM, integração faturamento — LTV automático)
+
+#### 3. Smart recall (Jana usa memória ao responder)
+- Quando bot Jana responde cliente, pipeline:
+  1. Pega últimas 5 msgs da conv (curto prazo)
+  2. Pega `customer_memory.notas_jana` + `temas_recorrentes` (médio prazo)
+  3. Busca semântica (Meilisearch + embeddings) nas msgs antigas (longo prazo)
+  4. Injeta tudo no prompt → resposta personalizada
+- Exemplo: cliente +5527...5927 (conv=47, 1800 msgs) tem temas_recorrentes `["nfe","atualizacao_bug","performance"]`. Quando ele manda "está lento de novo", Jana já sabe contexto histórico — responde com awareness.
+
+#### 4. LGPD compliance (não opcional)
+- **Right to access:** cliente pede via canal oficial → exporta JSON com tudo sobre ele
+- **Right to erasure:** delete cascade em `customer_memory` + soft-delete em `Contact` + retention `messages` (lei nfe exige 5 anos histórico, mas anonimiza nome)
+- **Audit log:** quem leu memória de quem, quando (tabela `customer_memory_access_log`)
+- **Atendente vê só `business_id` dele** (Tier 0 — já garantido por scope global)
+
+#### 5. Caps & guardrails (LLM em produção)
+- Latência: recall + LLM resposta < 2s pro UX não quebrar
+- Custo: budget mensal por business (cap hard)
+- Hallucination: Jana NUNCA inventa "cliente disse X" — só cita msg específica com `message_id`
+- Tom: Jana espelha tom histórico do cliente (formal/casual inferido da memória)
+
+---
+
+## §5 — Estado-da-arte atendimento (preview — agent entrega detalhes)
+
+> Esta seção é placeholder. Agent `estado-da-arte` foi spawned em paralelo. Quando entregar `memory/sessions/2026-05-15-arte-atendimento-omnichannel-memoria-cliente.md`, vou citar especificamente:
+>
+> - O que Front faz com Customer Context (e como difere de Intercom)
+> - Sierra.ai / Decagon — agentes resolutivos autônomos: aplicabilidade pra PME BR
+> - VoC analytics: Klaviyo vs Gong vs Crisp MagicReply
+> - Padrões anti-pattern abandonados em 2026 (ticket rígido, queue-based, status open/closed)
+> - Custo realista: modelos pequenos cached × full LLM call
+
+Visão preliminar (minha leitura geral, será refinada):
+
+- **Conversation > Ticket:** o "ticket" como entidade rígida foi abandonado. Conversa é o objeto central (Inbox unificada Front-style)
+- **AI Co-pilot > AI Replacement:** 2026 estabilizou que atendente humano + AI side-by-side > AI sozinha respondendo cliente. Sierra.ai é exceção (alto investimento, B2C massivo)
+- **Customer Context é commodity:** quem não tem sidebar com perfil agregado, perdeu o jogo
+- **VoC analytics SIMPLES > complexo:** classificar msg em 5-7 categorias + tema bate 80% do valor; dashboards complexos viram shelf-ware
+- **Embeddings + retrieval > LLM brute force:** custo cai 10-50× ao usar embeddings cached + reranker (já é stack Jana, [ADR 0048](../decisions/0048-framework-agentes-laravel-ai-vizra-rejeitada.md))
+
+---
+
+## §6 — Próximas ações priorizadas (30 dias)
+
+### Onda 1 — Fundação memória cliente (P0)
+1. **Migration `customer_memory`** — schema da camada 3 acima · 1 PR ~200 linhas · `feat(whatsapp): customer_memory P0`
+2. **Job daily `customer-memory:rebuild --business=N`** — recalcula stats agregados das últimas 90d msgs · cron 02h · 1 PR ~250 linhas
+3. **Backfill biz=1** — popular `customer_memory` com 249 clientes ativos · comando one-shot
+
+### Onda 2 — Customer 360 sidebar UI (P0)
+4. **Endpoint** `GET /atendimento/customer/{external_id}/profile` → JSON snapshot
+5. **Componente React** `<CustomerSidebar>` em `resources/js/Pages/Whatsapp/Inbox.tsx` — Inertia::defer pra não pesar abertura
+
+### Onda 3 — Inferência automática (P1)
+6. **Job mensal** `customer-memory:enrich-themes` — Jana clusteriza msgs por cliente → atualiza `temas_recorrentes` (custo ~R$0.10/cliente/mês × 249 = R$25/mês biz=1)
+7. **Sentiment score** — modelo pequeno cached (Haiku 4.5 ou local Llama 3.2 1B) — ~R$0.0001/msg
+8. **Churn risk score** — regra heurística primeiro (sem LLM): `(n_msgs_negativos_30d / n_msgs_30d) > 0.4 → score=0.8`. ML depois.
+
+### Onda 4 — Dashboard "Voz do Cliente" (P1)
+9. **Tabela `customer_voice_snapshots`** + cron 06h
+10. **UI `/copiloto/voz-cliente`** — top temas semana + clientes high-touch + features demandadas
+11. **Brief diário Wagner** — extension do BriefDiarioAgent inclui seção "voz cliente" quando snapshot atualizado
+
+### Onda 5 — Capterra reverso (P2)
+12. **Tabela `product_feedback_signals`** + Jana mensal clusteriza
+13. **Comando** `php artisan voz-cliente:feedback-roadmap` — output markdown com top 10 features demandadas pro Wagner usar em planning
+
+### Out of scope (ficam pra outros ciclos)
+- **PR #916 análise IA por mensagem** — fica draft, retomar quando Wagner aprovar custo gpt-4o-mini (após Onda 3 validar fluxo end-to-end)
+- **Sierra.ai-style agent resolutivo autônomo** — só após Onda 1-4 estáveis e Jana com track record de 3+ meses
+- **Self-service guiado** (resolver top 5 casos sem AnyDesk) — depende UX research separado
+
+---
+
+## §7 — Decisões pendentes Wagner (gate humano)
+
+1. **Aprova as 5 camadas de §3 como roadmap canônico?** Se sim, viro tasks MCP `US-WA-VOZ-001..010` distribuídas por owner (Felipe/Maiara/Luiz).
+2. **Persistir memória cliente: tabela `customer_memory` separada (proposta) OU enriquecer `Contact` existente com colunas?**
+   - **Proposta minha:** separada. Razão: Contact é CRM clássico (cadastro estático). `customer_memory` é metadado derivado (dinâmico, recalculado). Misturar polui Contact + dificulta LGPD erasure granular.
+3. **Custo IA pra inferência (Onda 3):**
+   - Sentiment + classificação per-msg: ~R$0.50/mês/biz com modelo pequeno
+   - Clustering mensal: ~R$25/mês biz=1 (249 clientes)
+   - **Total estimado biz=1:** R$25-30/mês — vale?
+4. **PR #916 (análise per-msg) — fica draft até quando?** Posso reabrir ready se você quiser executar paralelo às Ondas 1-4. Ou fechar permanente se preferir só inferência mensal (mais barata).
+
+---
+
+## §8 — Notas operacionais
+
+- **Workers ativos:** 4 queue:work drenando whatsapp-history (~50 chunks/30min). default queue 12k stuck — investigação separada pendente.
+- **Total msgs biz=1 agora:** 26.932 (subiu de 21.482 → 26.932 = +5k em ~25min)
+- **PR #916:** marcado draft em 2026-05-15 21:30 BRT
+- **Companion doc:** `memory/sessions/2026-05-15-arte-atendimento-omnichannel-memoria-cliente.md` (agent rodando paralelo)
+
+**Status:** análise feita por Claude · proposta arquitetural completa · aguarda Wagner decidir Ondas 1-5 + escopo das 4 decisões pendentes acima.

--- a/memory/sessions/2026-05-15-arte-atendimento-omnichannel-memoria-cliente.md
+++ b/memory/sessions/2026-05-15-arte-atendimento-omnichannel-memoria-cliente.md
@@ -1,0 +1,203 @@
+# Estado-da-arte 2026 — atendimento conversacional omnichannel com memória persistente de cliente
+
+> **Data:** 2026-05-15 · **Autor:** agent `estado-da-arte` · **Cliente:** Wagner
+> **Escopo:** o que líderes 2026 (Sierra, Decagon, Intercom Fin, Front, Gladly, Crisp) consideram não-negociável em atendimento conversacional + VoC + memória persistente do **cliente final** (não do usuário SaaS), e onde oimpresso bate/atrasa.
+> **Tempo:** ~30min · **Pesquisa Fase 1:** 8 WebSearch limpos (sem `memory/` ou `decisions-search`).
+> **Foco:** decisões acionáveis Wagner próximos 30 dias.
+
+---
+
+## 1. TL;DR
+
+- **Oimpresso já tem ~65% da espinha dorsal cobrada por líderes 2026:** schema omnichannel polimórfico (ADR 0135), Jana memória + Meilisearch hybrid, FSM auditável, multi-tenant Tier 0, tags manuais de conversa, LGPD `whatsapp_consent` em `Contact`. **2 gaps fatais e 2 gaps de alto-impacto.**
+- **Gap fatal #1 — `Contact` é só cadastro CRM legacy, NÃO é Customer Profile 2026.** Não tem timeline cross-canal, não tem perfil de comunicação acumulado, não tem sentimento histórico, não tem "última reclamação", não tem padrão de churn. Líderes 2026 (Gladly, Decagon User Memory, Front Customer Context) tratam isso como pré-requisito pra qualquer agent inteligente. Sem isso, IA responde com amnésia toda conversa.
+- **Gap fatal #2 — `AnalisarMensagemAgent` (PR #916) está aberto há dias mas adiado por custo.** Custo real estimado no próprio PR: **R$ 4 one-time backlog (21k msgs) + R$ 0,60/mês/biz real-time**. Isso é trivial — não é razão honesta pra adiar. Razão honesta provável: medo de drift biz=1 sem dry-run validado. Mergear este PR é a **maior alavanca de impacto vs esforço da lista**.
+- **Gap alto-impacto #3 — VoC dashboard não existe.** Categoria/tema/urgência por msg sozinhos são dado bruto; o valor está em **agregação gerencial** ("essa semana 14 clientes reclamaram de entrega atrasada") + **drift detection** ("spike em 'cobrança duplicada' nas últimas 24h"). Este é o "transformar reclamação em administração" que Wagner literalmente pediu 2026-05-15.
+- **Gap alto-impacto #4 — sem `Reply Suggestion` (MagicReply/Fin-style) baseada no perfil acumulado do cliente.** Tags + análise + memória cliente formam o substrato pra "sugerir resposta personalizada" no inbox — feature top vendável em PME BR (Take Blip cobra R$ 600/mês por isso).
+- **Nota de maturidade vs líderes 2026 (apenas dimensão "conversational support + VoC + customer memory"):** **48/100**. Atrás de Front/Gladly/Crisp na profundidade de Customer Profile, par em schema omnichannel, à frente em multi-tenant Tier 0.
+- **Recomendação:** mergear PR #916 **com dry-run gated por Wagner**, antes de qualquer outra coisa. Custos travados em ~R$ 5 totais no mês. Próxima ação hoje: `php artisan whatsapp:analyze-backlog --business=1 --channel=10 --since=24h --dry-run` e olhar o output.
+
+---
+
+## 2. Fase 1 — pesquisa: 5 players de referência + 1 PME-comparable
+
+### 2.1 Intercom Fin AI Agent (líder PME→mid-market, RAG-first)
+
+Fin é o agent de service "default" do mercado SaaS 2026. **Resolution rate médio 65-67%, top performers 93%**, em 40M+ conversas. Arquitetura é **3-camadas com aprendizado contínuo**: (1) Intelligence engine RAG — hybrid retrieval (vector + keyword) sobre Help Center + docs internos + ticket histórico; (2) Single agent que troca de "persona" (service/sales) por contexto da conversa; (3) Performance dashboard com `resolution rate × involvement rate × CX score` num só lugar. Referência porque **provou que RAG bem feito sobre KB própria + recall de tickets passados resolve 2/3 do tráfego sem treinar modelo**. ([Intercom Fin AI Agent explained](https://www.intercom.com/help/en/articles/7120684-fin-ai-agent-explained), [Resolution rate guide](https://www.intercom.com/help/en/articles/8205718-fin-ai-agent-outcomes))
+
+### 2.2 Sierra.ai (líder enterprise, "Agent OS" multi-model)
+
+Fundada por Bret Taylor (ex-Salesforce co-CEO, chair OpenAI), valuation $15.8B em maio/2026. Arquitetura "constellation of models" — **mix de OpenAI/Anthropic/Meta escolhido por task** (não 1 modelo pra tudo) com fine-tuning seletivo onde off-the-shelf falha. Componentes-chave: **Agent Data Platform (ADP, nov/2025)** — memória persistente cliente (histórico, CRM, status real-time); **Ghostwriter (mar/2026)** — builder conversacional que cria outros agents em linguagem natural; **PCI-compliant payments (abr/2026)** — agent processa transação financeira mid-conversation. Deploy unificado chat+SMS+WhatsApp+email+voice+ChatGPT de **1 config**. Referência porque **mostra que "memória persistente do cliente" virou produto separado (ADP) e não detalhe de implementação** — sinal de que mercado precificou. ([Constellation of models](https://sierra.ai/blog/constellation-of-models), [Plain.com 2026 analysis](https://www.plain.com/blog/conversational-ai-customer-service))
+
+### 2.3 Decagon (líder enterprise concierge, AOPs natural-language)
+
+$4.5B valuation (triplicou em 6 meses), $35M ARR, 100+ enterprise customers. Diferencial técnico: **Agent Operating Procedures (AOPs)** — workflows definidos em linguagem natural que compilam pra lógica estruturada executável (cliente edita "atendente" como se fosse onboarding humano). Resultados: 80% deflection, -65% custo, 93% quality score. **User Memory (lançado mar/2026)** é arquitetura canônica explícita em blog público: extrai e armazena **feature requests + sentiment + preferences declarados** como metadata estruturada anexada ao perfil do cliente, com **opt-in storage + expiration controls + redaction policies + API access**. Cross-channel memory: conversa começa em chat e continua em voz/email sem perda. Referência porque **publicou schema/contrato de memória cliente com LGPD/GDPR built-in** — replicável. ([Decagon User Memory blog](https://decagon.ai/blog/user-memory), [Spring 2026 launch](https://decagon.ai/blog/spring26-product-launch))
+
+### 2.4 Front (líder colaboração, "customer context sidebar" canônico)
+
+Plataforma de atendimento focada em "complexidade humana" — email + chat + SMS + voz num workspace compartilhado. Customer Context Sidebar é o pattern visual canônico replicado por Gladly/Intercom/Help Scout: sidebar à direita mostra histórico cross-canal + ordens/shipments/bookings puxados de sistemas externos em tempo real **dentro da conversa** (sem agent abrir 4 abas). 2026: **Smart QA** (QA automatizado por IA — monitora 100% das conversas, classifica qualidade) + Dialpad integrado (voice nativo). Referência porque **estabeleceu que "contexto cross-sistema dentro do thread" é o pattern UX canônico, não feature premium**. ([Front customer service platform](https://front.com/), [May 2026 release](https://front.com/blog/may-product-release))
+
+### 2.5 Gladly (líder "people not tickets", radial timeline)
+
+Posicionamento explícito: "customer service platform built around people, not tickets". Arquitetura: **Customer Profile único** com **radial timeline** — toda interação (email, chat, SMS, voz de 2 anos atrás, DM Facebook de ontem) feed num **único thread contínuo de anos** sob 1 perfil. Profile guarda LTV + status fidelidade + return rate + "preferências" derivadas de comportamento (favorite color, room preferences). **Agentic AI 2026:** vendedor de ponta-a-ponta enxerga o **mesmo histórico completo que humano** — handoff IA→humano não tem "começar do zero". Forrester + IDC chamam **unified customer data como hard requirement** pra agentic AI funcionar. Referência porque **é a forma operacional radical de "morte do ticket"** — extremamente influente em design system de concorrentes. ([Gladly product](https://www.gladly.ai/product/cx-team-platform/), [Agentic AI guide](https://www.gladly.ai/blog/agentic-ai-customer-service/))
+
+### 2.6 (Bonus PME) Crisp MagicReply — comparable mais direto a oimpresso
+
+Crisp é o player que PME/startup elege antes de Intercom/Zendesk. **MagicReply** sugere respostas baseadas em **conversas passadas do MESMO cliente + Help Center**. Funcionalidades adjacentes em 2026: **summarização automática de conversa pra handover de shift**, **switching áudio↔texto inline**, acesso a "dados e interações passadas" como sidebar. Tier free + Pro recomendado pra solopreneurs que batem 20+ tickets/dia. Referência porque é **o teto razoável que PME BR comparable do Wagner mira hoje** — não Sierra/Decagon (esses são fora do orçamento). ([Crisp MagicReply](https://www.success.ai/ai-tools/crisp-magicreply), [F3 2026 SMB comparison](https://f3fundit.com/ai-customer-support-for-solopreneurs-intercom-vs-crisp-vs-plain-vs-chatwoot-2026/))
+
+---
+
+## 3. Síntese: o que é "core moderno" não-negociável em 2026
+
+Padrões convergentes que **TODOS** os 5+1 players têm (não é diferenciação, é table-stakes 2026):
+
+| # | Padrão | Mecanismo concreto |
+|---|---|---|
+| 1 | **Unified Customer Profile cross-canal** | 1 perfil = N conversas históricas + atributos derivados (LTV, sentimento, churn risk, preferências). Gladly chama "Customer Profile", Decagon chama "User Memory", Front chama "Customer Context". |
+| 2 | **Conversation timeline contínua (não tickets)** | Threads não fecham — viram histórico permanente sob o profile. "Ticket aberto/fechado" é anti-pattern declarado por DevRev, Gladly, Plain. |
+| 3 | **RAG-first sobre KB + histórico ticket** | Intercom Fin, Decagon, Sierra. Hybrid retrieval (vector + keyword), não fine-tuning. |
+| 4 | **VoC auto-classification por LLM** | Categoria/tema/urgência/sentimento extraído em tempo real, **sem taxonomia manual**. Plataformas (Chattermill, Thematic, Pivony) abandonaram tagging humano em 2025. |
+| 5 | **Multi-channel deployment de 1 config** | Sierra/Decagon: chat+voz+email+SMS+WhatsApp num único agent config. |
+| 6 | **Audit trail visível ao cliente final** | HubSpot Audit Cards, Decagon redaction policies + expiration. LGPD Art. 20 (BR) torna isso regulatório-obrigatório em 2026 segundo ANPD. |
+| 7 | **Reply suggestion no inbox humano (não só auto-resolve)** | Crisp MagicReply, Front, Intercom Co-Pilot. Padrão "IA sugere, atendente aprova" antecede "IA resolve sozinha" no roadmap PME. |
+| 8 | **Modelo small-first (Haiku/4o-mini-class), waterfall pro maior** | Sierra publicou explicitamente: 70-80% tráfego em modelos menores. Custo total -70% vs flagship. |
+
+Anti-patterns abandonados em 2026 (citados explicitamente pelos players):
+
+- ❌ **Ticket system com status "aberto/fechado/escalado"** — DevRev e Plain declararam "ticket management is dead"; substituído por **conversation timeline contínua + state derivada de SLA + IA action history**.
+- ❌ **Queue-based routing manual** — substituído por **skill+context routing automático** com fallback humano por confidence.
+- ❌ **Tagging manual de conversa** — automatizado por LLM; humano só revisa exceções (catalogado por Chattermill 2026).
+- ❌ **Knowledge base separada do "outro lado"** — Help Center e ticket histórico viram **mesma fonte RAG**. Separar é overhead.
+- ❌ **Memória de sessão (some no logout)** — substituída por persistent cross-session. Memoria/Mem0/Sierra ADP são frameworks dedicados.
+
+---
+
+## 4. Fase 2 — comparativo oimpresso vs estado-da-arte (15 dimensões)
+
+Notação: **0** não existe · **1** embrionário · **2** funcional com gap · **3** par com líderes 2026 · **3+** supera líderes.
+
+| # | Dimensão | Estado-da-arte 2026 (ref) | oimpresso hoje | Nota | Justificativa |
+|---|---|---|---|---|---|
+| 1 | **Schema omnichannel polimórfico** | Sierra/Front/Gladly: 1 conversation table cross-canal | [ADR 0135](../decisions/0135-omnichannel-inbox-arquitetura.md) — `channels`+`conversations`+`messages` LIVE em prod, biz=1 + biz=4 | **3** | Schema 1:1 com líderes; falta drivers Insta/Email/ML mas isso é gate cliente-sinal |
+| 2 | **Customer Profile unificado** | Gladly radial timeline, Decagon User Memory schema | `Contact` (UltimatePOS legacy) — cadastro estático CPF/CNPJ/email/mobile + `whatsapp_consent` LGPD. **SEM timeline cross-canal, SEM perfil derivado, SEM sentimento** | **1** | Gap fatal. Cadastro ≠ profile. |
+| 3 | **Memória persistente do cliente final** | Decagon "stored preferences/feature requests/sentiment metadata"; Sierra ADP | `copiloto_memoria_facts` é só usuário SaaS (Wagner/Larissa). **NÃO existe tabela equivalente pra Contact (cliente externo)** | **0** | Gap fatal — confusão de escopo |
+| 4 | **VoC auto-classification por msg** | Chattermill/Thematic: LLM extrai theme+sentiment+urgency real-time | `AnalisarMensagemAgent` esboçado [PR #916](https://github.com/wagnerra23/oimpresso/pull/916) — categoria+tema+urgência+resumo via gpt-4o-mini, custo ~R$4 backlog. **PR aberto, adiado** | **1** | 80% pronto, falta merge — alto-impacto-baixo-esforço extremo |
+| 5 | **VoC dashboard agregado** | Pivony/Observe.AI: trend detection + spike alert + root cause | Não existe. PR #916 menciona como "out of scope próximos PRs" | **0** | Sem isso, classificação é dado bruto inútil |
+| 6 | **Tags/categorização de conversa** | Auto via LLM (2026) ou manual + sugestão IA | `whatsapp_tags` + `whatsapp_conversation_tags` (manual, atendente aplica) | **2** | Manual funciona; falta auto-suggest IA derivada da análise da msg |
+| 7 | **Reply suggestion baseada em histórico** | Crisp MagicReply, Front, Intercom Co-Pilot | Existe `Macros` + `MacroVariants` (templates manuais), mas **sem sugestão IA contextual** | **1** | Macros é base boa; falta camada "IA escolhe macro + personaliza" |
+| 8 | **RAG sobre KB própria** | Intercom Fin, Decagon | Jana `KbAnswerAgent` existe + Meilisearch hybrid embedder + MCP `memoria-search` | **2** | RAG infra par com líderes; **não está plugado no inbox WhatsApp** (não responde cliente externo) |
+| 9 | **Conversation timeline cross-canal** | Gladly radial timeline | Schema permite (ADR 0135) mas UI Inbox só mostra **1 conversa por vez** — sem agregação cross-canal por cliente | **1** | Backend pronto, UI ausente |
+| 10 | **Multi-channel deploy de 1 config** | Sierra/Decagon | ADR 0135 prevê (drivers Insta/Email/ML em fases 1-3 com gate cliente-sinal) | **2** | Arquitetura ok; só Whatsapp em prod hoje |
+| 11 | **Audit trail visível cliente final** | HubSpot Audit Cards, LGPD Art. 20 enforceável | `mcp_dual_brain_decisions` (interno) + FSM `sale_stage_history`. **Cliente externo não vê nada** | **1** | Backend ok; **UI cliente final inexistente → risco LGPD Art. 20** |
+| 12 | **Multi-tenant Tier 0 isolation** | Nenhum líder trata como absoluto; geralmente é "Enterprise feature" | `business_id` global scope IRREVOGÁVEL ([ADR 0093](../decisions/0093-multi-tenant-isolation-tier-0.md)) | **3+** | Supera líderes — vantagem estrutural |
+| 13 | **LGPD opt-in granular + retention** | Decagon expiration controls, ANPD enforcement 2026 | `Contact.whatsapp_consent`/`email_consent` (booleano) — **sem timestamp opt-in, sem auto-expire 24m, sem audit de consent** | **1** | Campo existe, política ausente — multas ANPD começaram 2026 |
+| 14 | **Custo LLM tiered (small-first)** | Sierra/Decagon waterfall | Brain A (Ollama local $0) + Brain B (Sonnet 4.6) + AnalisarMensagemAgent (gpt-4o-mini) | **3** | Padrão correto desde o início |
+| 15 | **Async support continuous (anti-ticket)** | DevRev/Plain "ticket is dead" | `conversations.status` tem `open`/`awaiting_human`/`resolved`/`archived` — mas atendentes ainda pensam em "fechar ticket" | **2** | Schema neutro; cultura ainda ticket-style |
+
+**Resumo notas:** 5×**3 ou 3+**, 4×**2**, 4×**1**, 2×**0**. Média ponderada **~1.9 → 48/100** vs líderes 2026.
+
+---
+
+## 5. Fase 3 — gaps rankeados por impacto × esforço
+
+> Estimates seguem [ADR 0106](../decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md) — fator 10× IA-pair + margem 2×.
+
+| Rank | Gap | Impacto | Esforço IA-pair | Pré-req? | Risco se não fizer |
+|---|---|---|---|---|---|
+| **1** | **Mergear PR #916 `AnalisarMensagemAgent` com dry-run gated** | **Alto** — destrava todos gaps 2-5 (sem análise não dá pra agregar nem perfilizar) | ~2h (review + dry-run biz=1 + flag activation + Wagner aprova) | Nenhum — PR já existe | Wagner literalmente disse "tudo que receber vai ter que ser analisado"; sem isso, promessa quebrada |
+| **2** | **VoC Dashboard agregado** (top reclamações + spike alert + trend semanal) | **Alto** — é o "transformar reclamação em administração" do Wagner | ~6h (1 Controller + 1 Page Inertia + 3 widgets agregando `messages.analise_*`) | Gap #1 mergeado | Análise vira dado morto, esforço gpt-4o-mini desperdiçado |
+| **3** | **Customer Profile schema (`contact_profile` tabela nova)** + accumulate por inbound msg | **Alto** — destrava gaps 3, 7, 9, 11 (memória cliente + reply suggestion + audit visível) | ~8h (migration + service `ContactProfileService::accumulate(message)` + extract via mesmo Agent #916 + Pest cross-tenant) | Gap #1 mergeado | IA continua com amnésia toda conversa; Wagner não pode fazer "Larissa pergunta de Maria e Jana sabe que Maria reclamou de entrega 3x" |
+| **4** | **Auto-tag de conversa derivada de análise IA** | Médio | ~3h (Listener que pega `analise_categoria` da última msg + sugere tag no UI) | Gaps #1, #6 (tags já existe) | Atendente continua taggando manual — economia trivial mas visível |
+| **5** | **Reply Suggestion IA no Inbox** (rascunho automático baseado em perfil + KB) | Alto | ~10h (Service `ReplyDraftService` + KbAnswerAgent integrado + UI "rascunho sugerido" + flag opt-in per-business + Pest) | Gap #3 (perfil cliente) + RAG já existe | Atendente humano fica lento — Take Blip ganha clientes que iam pro oimpresso |
+| **6** | **LGPD Art. 20 compliance UI cliente final** ("decisão tomada por IA - peça revisão aqui") | Médio-Alto | ~5h (rota pública `/atendimento/auditoria/{conv_uuid}` + opt-out IA flag em `Contact` + log de decisões expostas) | Gaps #1, #3 | Multa ANPD começou 2026; risco regulatório real |
+| **7** | **Timeline cross-canal por Contact na sidebar** | Médio | ~4h (Inertia sidebar agrega `conversations` JOIN `messages` por `contact_id` ordenado desc, paginado) | Gap #3 (precisa de `contact_id` populado consistente) | Atendente perde contexto histórico; ainda assim "funciona" |
+| **8** | **`whatsapp_consent` virar consent record com timestamp+source+auto-expire 24m** | Médio | ~3h (migration `contact_consents` + observer + auto-expire job) | Nenhum bloqueante | Risco LGPD multa; trabalho técnico simples |
+| **9** | **Drivers Instagram/Messenger** (Fase 1 ADR 0135) | Baixo (gate cliente-sinal) | ~6h por driver | ADR 0105 cliente pagante pedir | Nenhum — gate de cliente protege |
+| **10** | **Conversation merge by Contact** (todas conversas de Maria viram thread) | Baixo (UX nice-to-have) | ~6h | Gap #7 | Atendente faz mental merge — caro só em volume |
+
+---
+
+## 6. Recomendação concreta
+
+**Comece pelo Gap #1 — mergear PR #916.**
+
+Por quê:
+- **Alto impacto**: destrava cadeia inteira de gaps 2 (dashboard), 3 (perfil cliente), 4 (auto-tag), 5 (reply suggestion). Sem análise, nada disso existe.
+- **Esforço trivial**: ~2h (PR já existe com 18 Pest cases, gates Tier 0, dry-run command, opt-in flag por business).
+- **Sem pré-req bloqueante**: PR está aberto, CI tem que ficar verde, Wagner aprova dry-run biz=1 primeiro.
+- **Custo real travado**: R$ 4 one-time + R$ 0,60/mês/biz. Comparar com R$ 300-1.500/mês cobrado por Take Blip pela mesma feature.
+- **Honestidade brutal**: o motivo original do adiamento ("custo gpt-4o-mini") **não bate matematicamente**. O custo verdadeiro é "Wagner não rodou dry-run ainda". Resolver isso é uma reunião de 15 min com terminal aberto.
+
+**Próxima ação concreta hoje (Wagner):**
+
+```bash
+# 1) Sair desta worktree e voltar pro repo principal
+cd D:/oimpresso.com
+
+# 2) Checkar PR #916 na branch dele (zero deploy, zero merge)
+gh pr checkout 916
+
+# 3) Migrar local (idempotente, adiciona colunas analise_* a messages)
+php artisan migrate
+
+# 4) Dry-run em prod biz=1 canal Suporte (zero custo IA — só conta msgs e enfileira N/A)
+php artisan whatsapp:analyze-backlog --business=1 --channel=10 --since=24h --dry-run
+
+# 5) Olhar output (~ "X mensagens elegíveis, custo estimado R$Y")
+# 6) Se número convencer, sair do PR checkout, voltar pra main, mergear PR via gh pr merge --squash
+```
+
+**Depois disso (mesma semana):** Gap #2 (dashboard agregado) — 6h IA-pair. Wagner abre o dashboard, vê "essa semana 14 menções a 'entrega atrasada'" e a promessa "usar reclamações pra administrar" sai do papel.
+
+**Depois (próximas 2 semanas):** Gap #3 (Customer Profile schema). Aqui sim entra ADR nova — vale formalizar contrato `ContactProfileService::accumulate()` + retenção LGPD + redaction + opt-out IA antes de codar. Não inventar agora — deixar o uso real de #1+#2 informar o design.
+
+---
+
+## 7. Não-fazer agora (anti-recomendações)
+
+- ❌ **Não pesquisar mais sobre Sierra ADP / Decagon User Memory.** Pesquisa já entregue acima. Mais pesquisa = procrastinação disfarçada.
+- ❌ **Não trocar gpt-4o-mini por modelo maior antes do dry-run.** R$ 4 ainda não foi gasto — calibrar modelo sem dado de qualidade é cargo cult.
+- ❌ **Não criar `contact_profile` table antes de mergear #916.** Sem categoria/tema/urgência por msg, perfil não tem o que acumular. Sequência importa.
+- ❌ **Não abrir frente de Instagram/Email/ML driver agora.** ADR 0135 já cravou gate cliente-sinal — sem cliente pagante pedindo, é overhead.
+- ❌ **Não fazer "VoC complete suite" tipo Chattermill em 1 PR.** Decompõe em #1 (análise por msg) → #2 (dashboard simples) → #3 (drift detection) → #4 (alerta auto-trigger). 4 PRs ≤300 linhas cada.
+
+---
+
+## 8. Pendências de governança (criar se Wagner aprovar caminho)
+
+- **ADR nova** quando Gap #3 for executado: "Customer Profile schema + accumulate contract + LGPD retention" (referencia ADR 0093, 0135, 0061; supersedes nada).
+- **Skill nova Tier B** `voc-dashboard-update` — auto-trigger quando Edit em página `/atendimento/voc/*` ou Service `AnaliseMensagemService`.
+- **`review_triggers` no ADR 0135** quando Gap #4 entrar: "auto-tag derivada de IA atingir ≥85% precisão → desativar tagging manual default em prod".
+
+---
+
+## 9. Fontes (Fase 1 — pesquisa limpa)
+
+- [Intercom Fin AI Agent explained](https://www.intercom.com/help/en/articles/7120684-fin-ai-agent-explained)
+- [Intercom Fin resolution rates & outcomes](https://www.intercom.com/help/en/articles/8205718-fin-ai-agent-outcomes)
+- [Sierra.ai constellation of models](https://sierra.ai/blog/constellation-of-models)
+- [Sierra product overview](https://sierra.ai/product)
+- [Plain.com — Conversational AI 2026 analysis](https://www.plain.com/blog/conversational-ai-customer-service)
+- [Decagon User Memory blog (mar/2026)](https://decagon.ai/blog/user-memory)
+- [Decagon Spring 2026 launch (Proactive Agents)](https://decagon.ai/blog/spring26-product-launch)
+- [Front customer service platform](https://front.com/)
+- [Front May 2026 product release (Smart QA, Dialpad)](https://front.com/blog/may-product-release)
+- [Gladly customer profile (people not tickets)](https://www.gladly.ai/product/customer-profile/)
+- [Gladly agentic AI 2026 guide](https://www.gladly.ai/blog/agentic-ai-customer-service/)
+- [Crisp MagicReply](https://www.success.ai/ai-tools/crisp-magicreply)
+- [Crisp AI overview](https://crisp.chat/en/ai/)
+- [F3 Fund It — Solopreneur AI support comparison 2026](https://f3fundit.com/ai-customer-support-for-solopreneurs-intercom-vs-crisp-vs-plain-vs-chatwoot-2026/)
+- [Chattermill — Best conversational analytics 2026](https://chattermill.com/blog/best-conversational-analytics-tools)
+- [Chattermill — LLMs for customer feedback at scale](https://chattermill.com/blog/how-to-use-llms-to-analyse-customer-feedback-at-scale)
+- [Thematic — Conversational analytics guide](https://getthematic.com/insights/conversational-analytics)
+- [Pivony — VoC analytics 2026 practitioner guide](https://pivony.com/blog/what-is-voice-of-customer-analytics-the-2026-practitioners-guide/)
+- [Treasure Data — Customer 360 in 2026](https://www.treasuredata.com/blog/customer-360)
+- [SocialHub — LGPD 2026 ANPD multa WhatsApp PME](https://www.socialhub.pro/blog/lgpd-2026-anpd-multa-whatsapp-marketing-pme-base-legal-consentimento/)
+- [DevRev — Ticket management is dead 2026](https://devrev.ai/blog/ticket-management)
+- [BlueTie — Reactive IT is dead 2026](https://bluetie.com/reactive-it-is-officially-dead-why-2026-belongs-to-proactive-monitoring-not-ticket-based-support/)
+- [OpenAI API pricing 2026 (cost calculator)](https://developers.openai.com/api/docs/pricing)
+- [PE Collective — Cross-provider LLM pricing 2026](https://pecollective.com/blog/llm-pricing-comparison-2026/)
+- [Vellum — GPT-4o-mini vs Haiku vs 3.5 customer support benchmark](https://www.vellum.ai/blog/gpt-4o-mini-v-s-claude-3-haiku-v-s-gpt-3-5-turbo-a-comparison)
+- [Zendesk AI agent GDPR/LGPD compliance 2026](https://www.eesel.ai/blog/zendesk-ai-agent-gdpr-compliance)
+- [Mem0 — State of AI Agent Memory 2026](https://mem0.ai/blog/state-of-ai-agent-memory-2026)
+- [Memoria framework arxiv 2512.12686](https://arxiv.org/html/2512.12686v1)

--- a/memory/sessions/2026-05-15-tutorial-customer-memory-como-funciona.md
+++ b/memory/sessions/2026-05-15-tutorial-customer-memory-como-funciona.md
@@ -389,6 +389,81 @@ LIMIT 10;
 
 ---
 
+## §10.5 — Employee Performance (US-WA-VOZ-003)
+
+Espelha customer_memory mas pro **outro lado da relação**: cada atendente do business tem 1 row em `employee_performance` com volume + velocidade + qualidade + cobertura + **nota 0-100 transparente**.
+
+### Schema (tabela `employee_performance`)
+
+```
+business_id, user_id [PRIMÁRIO], heuristic_name [FALLBACK], display_name,
+n_msgs_total, n_conversations_atendidas, n_clientes_diferentes,
+tempo_resposta_mediana_s, tempo_resposta_p90_s, sla_breach_count,
+reclamacoes_recebidas, csat_avg,
+horas_ativas_distintas, hora_pico, dias_ativos_30d, primeira_atividade_at, ultima_atividade_at,
+temas_dominantes, nota_geral, nota_breakdown, nota_calculada_em,
+flags, last_rebuilt_at, rebuilt_via
+```
+
+### Identidade flexível (resolve bloqueio dos 75% sem sender_user_id)
+
+- **PRIMÁRIO**: `user_id` (`messages.sender_user_id`) — atendente respondeu via UI Inbox
+- **FALLBACK**: `heuristic_name` (regex `body LIKE '%Nome:%'`) — pega quem assina prefix
+- Atendente pode ter 2 rows se às vezes usa UI, às vezes não (caso transição) — admin manual merge depois
+
+### Scoring transparente (publicado pro time saber)
+
+| Dimensão | Pts | Como pontua |
+|---|---|---|
+| Volume produtivo | 25 | n_msgs (1500=25, escala linear cap) |
+| Diversidade clientes | 20 | n_clientes (150=20) |
+| Velocidade resposta | 25 | mediana <60s=25, <300s=18, <900s=12, <1800s=6, else=2 |
+| Profundidade conv | 15 | msgs/conv 5-15=15 (sweet spot), 3-20=10, else=5 |
+| Cobertura horária | 10 | horas_distintas (10h=10) |
+| Engajamento | 5 | placeholder (CSAT futuro) |
+
+### Faixas
+- `excelente` ≥ 90
+- `bom` ≥ 70
+- `regular` ≥ 50
+- `abaixo` < 50
+
+### Comandos canon
+
+```bash
+# Backfill detecta automaticamente atendentes (sender_user_id + heurísticos)
+php artisan employee-performance:backfill --business=1 --dry-run
+php artisan employee-performance:backfill --business=1 --queue
+
+# Refresh daily (cron 02:30h BRT — Kernel.php)
+php artisan employee-performance:refresh-daily
+
+# Endpoints
+GET /atendimento/employee/scorecards                       # ranking time
+GET /atendimento/employee/10/scorecard                     # user real
+GET /atendimento/employee/heur:Maiara/scorecard            # heurístico
+```
+
+### Casos de uso administrativos
+
+1. **Wagner 1:1 mensal** — abre scorecard atendente, discute pontos fracos
+2. **Sidebar Inbox** — mostra "Conversation atendida por: Maiara · 94/100"
+3. **Bonus/promoção** — Wagner usa ranking como input objetivo
+4. **Coaching dirigido** — atendente com `velocidade=6` ganha treinamento timing
+5. **Carga balanceamento** — atendente sobrecarregado (volume=25) ganha pausa
+
+### Dados reais biz=1 medidos pré-implementação (2026-05-15)
+
+| Atendente | Nota |
+|---|---|
+| Luiz | 99/100 |
+| Maiara | 94/100 |
+| Felipe | 50/100 |
+
+(amostra heurística — Felipe baixo por volume, não qualidade)
+
+---
+
 ## §11 — O que VEM em seguida (próximos PRs decoupled)
 
 | Onda | PR | Esforço estimado | Depende de |

--- a/memory/sessions/2026-05-15-tutorial-customer-memory-como-funciona.md
+++ b/memory/sessions/2026-05-15-tutorial-customer-memory-como-funciona.md
@@ -1,0 +1,432 @@
+# Tutorial — Customer Memory: como funciona, ponta a ponta
+
+> **Pra quem é:** Wagner (e time MCP em breve — Felipe/Maiara/Eliana/Luiz).
+> **Objetivo:** entender o sistema que você acabou de aprovar (PR #919 + extensões US-WA-VOZ-002), sem precisar ler 14 arquivos PHP.
+> **Pré-leitura:** [análise voz cliente biz=1](2026-05-15-analise-voz-cliente-suporte-biz1.md) (decide o "porquê") + [estado da arte](2026-05-15-arte-atendimento-omnichannel-memoria-cliente.md) (referência externa).
+>
+> Documento ENSINA. Se sumir 6 meses de uso e voltar, este doc deve te re-orientar.
+
+---
+
+## §1 — Mapa mental em 30 segundos
+
+```
+Mensagem WhatsApp chega
+        │
+        ▼
+[1] webhook Baileys/Meta/Z-API → insere em messages + conversations
+        │
+        ▼
+[2] MessageObserver dispatcha OmnichannelMessageReceived
+        │
+        ▼
+[3] TouchCustomerMemoryOnMessage (listener síncrono)
+        ├─ cheap: UPSERT last_interaction_at (1 query)
+        └─ se memória > 6h velha → dispatcha Job
+                │
+                ▼
+[4] RebuildCustomerMemoryJob (queue=customer-memory)
+        │
+        ▼
+[5] CustomerMemoryRebuilder.rebuild()
+        ├─ Step 1: Identity resolution (phone → Contact CRM) via ConversationContactLinker
+        ├─ Step 2: Stats agregados (n_conversations, n_msgs_in/out, first/last_interaction)
+        ├─ Step 3: Denormalize display_name + consent_status (LGPD)
+        ├─ Step 4: Funcionário responsável (assigned_user_id + most_active_user_id)
+        └─ Step 5: Reclamações heurística keywords (top 5, 30d, sem IA)
+        │
+        ▼
+[6] customer_memory.last_rebuilt_at = NOW()
+        │
+        ▼  (futuro/opcional)
+[7] customer-memory:enrich-firebird → external_sources JSON
+        │  (Wagner roda Python local → JSON → comando importa)
+        │
+        ▼
+[8] Sidebar UI Customer 360 (PR futuro) consome
+    GET /atendimento/customer/{external_id}/profile
+```
+
+**Tudo é multi-tenant Tier 0** (`business_id` em todo lugar) e **LGPD-aware** (`consent_status` + `erasure_requested_at`).
+
+---
+
+## §2 — Onde fica cada coisa (mapa físico de arquivos)
+
+| Camada | Arquivo | Responsabilidade |
+|---|---|---|
+| **Schema** | [`Modules/Whatsapp/Database/Migrations/2026_05_15_230000_create_customer_memory_table.php`](../../Modules/Whatsapp/Database/Migrations/2026_05_15_230000_create_customer_memory_table.php) | Tabela `customer_memory` — 24 cols + 5 índices |
+| **Schema ext** | [`...2026_05_15_240000_add_employee_complaints_external_to_customer_memory.php`](../../Modules/Whatsapp/Database/Migrations/2026_05_15_240000_add_employee_complaints_external_to_customer_memory.php) | +6 cols US-WA-VOZ-002 |
+| **Entity** | [`Modules/Whatsapp/Entities/CustomerMemory.php`](../../Modules/Whatsapp/Entities/CustomerMemory.php) | Eloquent Model + HasBusinessScope + 12 constants enum + helpers |
+| **Service core** | [`Modules/Whatsapp/Services/CustomerMemory/CustomerMemoryRebuilder.php`](../../Modules/Whatsapp/Services/CustomerMemory/CustomerMemoryRebuilder.php) | Brain — recompila tudo idempotente |
+| **Service Firebird** | [`Modules/Whatsapp/Services/CustomerMemory/OfficeimpressoEnrichService.php`](../../Modules/Whatsapp/Services/CustomerMemory/OfficeimpressoEnrichService.php) | Cross-DB enrichment |
+| **Source plug** | [`Modules/Whatsapp/Services/CustomerMemory/Sources/JsonFileFirebirdSource.php`](../../Modules/Whatsapp/Services/CustomerMemory/Sources/JsonFileFirebirdSource.php) | Driver Firebird JSON-file (substituível) |
+| **Job** | [`Modules/Whatsapp/Jobs/RebuildCustomerMemoryJob.php`](../../Modules/Whatsapp/Jobs/RebuildCustomerMemoryJob.php) | Async wrapper do Rebuilder, queue=customer-memory |
+| **Listener** | [`Modules/Whatsapp/Listeners/TouchCustomerMemoryOnMessage.php`](../../Modules/Whatsapp/Listeners/TouchCustomerMemoryOnMessage.php) | Real-time touch + dispatch heavy se stale |
+| **Comando backfill** | [`Modules/Whatsapp/Console/Commands/CustomerMemoryBackfillCommand.php`](../../Modules/Whatsapp/Console/Commands/CustomerMemoryBackfillCommand.php) | One-shot per business |
+| **Comando cron** | [`Modules/Whatsapp/Console/Commands/CustomerMemoryRefreshDailyCommand.php`](../../Modules/Whatsapp/Console/Commands/CustomerMemoryRefreshDailyCommand.php) | Daily 02h BRT — refresh stale |
+| **Comando Firebird** | [`Modules/Whatsapp/Console/Commands/CustomerMemoryEnrichFirebirdCommand.php`](../../Modules/Whatsapp/Console/Commands/CustomerMemoryEnrichFirebirdCommand.php) | Importa JSON Firebird |
+| **Endpoint API** | [`Modules/Whatsapp/Http/Controllers/Api/CustomerProfileController.php`](../../Modules/Whatsapp/Http/Controllers/Api/CustomerProfileController.php) | `GET /atendimento/customer/{ext}/profile` |
+| **Python export** | [`scripts/firebird/export-customers.py`](../../scripts/firebird/export-customers.py) | Roda LOCAL Wagner — gera JSON |
+
+---
+
+## §3 — Fluxo "msg chega → memória atualiza" (real-time)
+
+Pra cada mensagem inbound/outbound que entra no DB:
+
+1. **`MessageObserver::created()`** dispara `OmnichannelMessageReceived` ou `OmnichannelMessageSent`.
+2. **`TouchCustomerMemoryOnMessage`** escuta o evento (registrado em `WhatsappServiceProvider::boot()`).
+3. Listener faz **2 coisas**:
+   - **Cheap path** (sempre): `Rebuilder::touch()` executa 1 query UPSERT atômico:
+     ```sql
+     INSERT INTO customer_memory (business_id, customer_external_id, last_interaction_at, ...)
+     VALUES (1, '5548999872822', NOW(), ...)
+     ON DUPLICATE KEY UPDATE last_interaction_at = NOW();
+     ```
+     Custo: 1 query, race-safe, latência <5ms.
+   - **Heavy path** (condicional): se `last_rebuilt_at > 6h` OU NULL, dispatcha `RebuildCustomerMemoryJob`. Job vai pra queue `customer-memory` (separada da `whatsapp-history`).
+4. **Worker `queue:work` consome** o job em background, chama `Rebuilder::rebuild()` que faz **5 steps**:
+   - Identity (1 cache lookup + até 2 queries Contact)
+   - Stats (2 queries SQL: conversations + messages JOIN)
+   - Denormalize (1 query Contact ou 1 query conversations)
+   - Assigned user (2 queries SQL)
+   - Reclamações (1 query messages + regex PHP)
+   - **Total: ~6-8 queries SQL + UPDATE.**
+
+**Custo per-msg em pico (1000 msgs/h):**
+- 1000× cheap (1 query) = 1000 queries (~5s no Hostinger)
+- ~100× heavy (estimativa 10% dispatch rate) = 100 jobs (~10min background)
+
+Sustentável pra biz=1 com 249 clientes ativos.
+
+---
+
+## §4 — Identity Resolution (telefone → Contact CRM)
+
+Pergunta canônica: **"recebi msg do +5548999872822 — quem é essa pessoa?"**
+
+### Algoritmo (REUSA `ConversationContactLinker` — US-WA-078)
+
+1. **Normalize** phone E.164 → só dígitos: `+5548 (9) 9987-2822` → `5548999872822`.
+2. **Mínimo 8 dígitos** (curto demais = false positive garantido — Twilio Identity Resolution).
+3. **Suffix 8 dígitos**: extrai últimos 8 (`99872822`) — colisão ~10⁻⁸, OK pra BR.
+4. **Query SQL**:
+   ```sql
+   SELECT id, name, mobile, landline, alternate_number
+   FROM contacts
+   WHERE business_id = 1
+     AND deleted_at IS NULL
+     AND (mobile LIKE '%99872822%'
+       OR landline LIKE '%99872822%'
+       OR alternate_number LIKE '%99872822%')
+   ```
+5. **PHP filter de pós-processamento** — strip não-dígitos de cada campo e compara contra `5548999872822` OU sufixo `99872822`. Cobre formato legacy `(48) 99872-2822`.
+6. **Resolver outcome**:
+   - 0 matches → `MATCH_UNKNOWN`, confidence 0.0
+   - 1 match exato (campo todo == E.164 sem +) → `MATCH_EXACT`, confidence 1.0
+   - 1 match sufixo → `MATCH_SUFFIX_8`, confidence 1.0
+   - 2+ matches → `MATCH_AMBIGUOUS`, confidence = 1/count (ex: 0.5 pra 2)
+
+### Cache anti-stampede
+
+`ConversationContactLinker::attemptLink()` cacheia o resultado por **1 hora** em Redis/DB com sentinel `0` pra cache miss (anti-thundering-herd se 100 msgs do mesmo phone chegam em burst).
+
+`ContactObserver` **invalida o cache** quando phone fields do Contact mudam (UI edit) — fix cross-contact recorrente catalogado handoff 10:10.
+
+---
+
+## §5 — Funcionário responsável (US-WA-VOZ-002)
+
+Wagner perguntou: "coloque junto com o perfil do cliente, **funcionário**, reclamação".
+
+2 derivações automáticas no `Rebuilder::refreshAssignedUser()`:
+
+### `assigned_user_id` — último a responder
+```sql
+SELECT m.sender_user_id
+FROM messages m JOIN conversations c ON c.id = m.conversation_id
+WHERE c.business_id = 1
+  AND c.customer_external_id IN ('5548999872822', '+5548999872822')
+  AND m.direction = 'outbound'
+  AND m.sender_user_id IS NOT NULL
+ORDER BY m.created_at DESC
+LIMIT 1;
+```
+
+### `most_active_user_id` — quem mais atendeu histórico
+```sql
+SELECT m.sender_user_id, COUNT(*) as n
+FROM messages m JOIN conversations c ON c.id = m.conversation_id
+WHERE c.business_id = 1
+  AND c.customer_external_id IN (...)
+  AND m.direction = 'outbound'
+  AND m.sender_user_id IS NOT NULL
+GROUP BY m.sender_user_id
+ORDER BY n DESC
+LIMIT 1;
+```
+
+`sender_user_id` é NULL quando:
+- Msg outbound veio do chip direto (Wagner mandando do celular — fora do oimpresso)
+- Bot Jana respondeu (`sender_kind='bot'`)
+
+Esses casos não geram "atendente atribuído" — corretamente.
+
+### Aplicação no Sidebar (futuro PR UI)
+
+```
+┌─ SOBRE O CLIENTE ─────────────┐
+│ +5527998915927 · Cliente A    │
+│ Contact CRM #1234 · Florianópolis│
+│ Maiara atendeu por último     │ ← assigned_user_id
+│ (89 msgs históricas)          │ ← most_active_user_count
+│                               │
+│ ⚠ 12 reclamações 30d         │ ← total_reclamacoes
+│   2 críticas, 5 altas         │ ← severities em reclamacoes_recentes
+└───────────────────────────────┘
+```
+
+---
+
+## §6 — Reclamações (heurística sem IA)
+
+`Rebuilder::refreshReclamacoes()` roda regex PHP sobre **inbound msgs últimos 30 dias** (cap 500 msgs defensivo).
+
+### Tabela de keywords (PT-BR)
+
+| Severity | Keywords (regex) |
+|---|---|
+| **critica** | processo · advogado · absurdo · nunca mais · cancelar · reembolso · procon |
+| **alta** | reclamar · péssimo · horrível · insuportável · inadmissível · esperando até agora |
+| **media** | problema · erro · bug · atras · não consigo · não funciona · deu ruim · travou |
+| **baixa** | dúvida · ajuda · preciso |
+
+Primeira match vence (severities em ordem decrescente).
+
+### Output JSON em `reclamacoes_recentes`
+
+```json
+[
+  {
+    "date": "2026-05-15 18:08:16",
+    "msg_id": 29202,
+    "severity": "alta",
+    "preview": "Mensagem aqui, max 140 chars..."
+  },
+  ...
+]
+```
+
+**Por que heurística e não IA?** Custo zero, instantâneo, determinístico. Quando PR #916 (análise IA per-msg) mergear, este código será trocado por:
+```php
+$total = DB::table('messages')
+    ->where('analise_categoria', 'reclamacao')
+    ->where('business_id', $bizId)
+    ->where('created_at', '>=', now()->subDays(30))
+    ->count();
+```
+
+Sem perda de função — só upgrade de precisão.
+
+### Anti-padrão evitado
+
+Só **inbound** count como reclamação. Se atendente outbound usa "qual o problema?" → NÃO conta. Testado em [`OfficeimpressoEnrichServiceTest`](../../Modules/Whatsapp/Tests/Feature/CustomerMemoryRebuilderTest.php) (case "reclamações ignora msgs OUTBOUND").
+
+---
+
+## §7 — Cross-DB Firebird OfficeImpresso (US-WA-VOZ-002)
+
+Wagner: "nem todo cliente está cadastrado [no Hostinger], pesquise no firebird."
+
+### Por que não conectar Firebird direto do Hostinger?
+
+| Opção | Veredito |
+|---|---|
+| PHP `ibase`/`firebird` PECL no Hostinger | ❌ shared hosting não permite PECL |
+| Tunnel HTTP Hostinger → CT 100 → Firebird remoto | ❌ complexo, lento, LGPD risk |
+| Container Docker Firebird CT 100 | ❌ Firebird mora no servidor do cliente WR, não nosso |
+| **Export JSON local + import comando** | ✅ idempotente, versionado, offline-friendly |
+
+### Pipeline real (3 etapas)
+
+```
+[Wagner Windows local]
+    ↓ python scripts/firebird/export-customers.py
+[Arquivo customers-2026-05-15.json]
+    ↓ scp / upload
+[Hostinger storage/app/firebird/]
+    ↓ php artisan customer-memory:enrich-firebird --business=1 --json=...
+[customer_memory.external_sources atualizado]
+```
+
+### O que `external_sources` guarda
+
+```json
+[
+  {
+    "source": "firebird_office_json:2026-05-15",
+    "cliente_id": 1234,
+    "nome": "ACME LTDA",
+    "fone1": "554899872822",
+    "fone2": null,
+    "email": "contato@acme.com.br",
+    "bloqueado": false,
+    "cpf_cnpj": "12345678000100",
+    "cidade": "Florianópolis",
+    "data_cadastro": "2024-03-15T00:00:00"
+  }
+]
+```
+
+Sidebar mostra: **"Cliente também cadastrado no sistema antigo WR como código 1234 — oportunidade de migração CRM"**.
+
+### Interface plug-and-play
+
+```php
+interface FirebirdLookupSourceContract {
+    public function lookupByPhone(string $phoneE164): array;
+    public function isHealthy(): bool;
+    public function sourceLabel(): string;
+}
+```
+
+Hoje impl: `JsonFileFirebirdSource`. Futuro: `PdoFirebirdSource` (CT 100 com `ibase` ativo) ou `HttpFirebirdProxySource` (microservice em Python no CT 100). Mesma interface — `OfficeimpressoEnrichService` consome qualquer driver.
+
+### Merge defensivo
+
+`enrich()` **preserva** entries de outras fontes (ex: ASAAS, Inter). Re-enrich não duplica — apenas substitui entries com mesmo prefixo de source.
+
+---
+
+## §8 — LGPD compliance
+
+| Direito (Lei 13.709/18) | Como atende |
+|---|---|
+| **Art. 7º — consentimento** | `customer_memory.consent_status` denormaliza `contacts.whatsapp_consent` (`given`/`withdrawn`/`unknown`) |
+| **Art. 18 — direito de apagamento** | Endpoint admin seta `customer_memory.erasure_requested_at` → endpoint API retorna profile minimalista (`state: 'erasure_requested'`) |
+| **Art. 20 — auditabilidade** | `rebuilt_via` + `last_rebuilt_at` rastreia origem de cada update |
+| **Logs sem PII** | Telefones nos logs sempre redacted: `substr(0,4)+'***'+substr(-2)` |
+
+Próximo passo (não neste PR): UI admin pra cliente exercer erasure (botão "Apagar memória deste cliente" no Sidebar Customer 360).
+
+---
+
+## §9 — Comandos canon (cheat sheet pra Wagner)
+
+```bash
+# Migração (idempotente, re-rodável)
+php artisan migrate
+
+# 1️⃣ Backfill inicial biz=1 (one-shot)
+php artisan customer-memory:backfill --business=1 --dry-run     # preview zero-cost
+php artisan customer-memory:backfill --business=1 --queue        # dispatcha jobs
+php artisan queue:work database --queue=customer-memory --stop-when-empty
+
+# 2️⃣ Cron daily refresh (alinhado Kernel.php 02h BRT)
+php artisan customer-memory:refresh-daily                       # todos businesses
+php artisan customer-memory:refresh-daily --business=1 --detail # 1 business, log linha-a-linha
+
+# 3️⃣ Enrichment Firebird (Wagner roda local Python + scp + comando)
+python scripts/firebird/export-customers.py \
+    --dsn "localhost/3050:C:/dados/EMPRESA.FDB" \
+    --user SYSDBA --password masterkey \
+    --output storage/app/firebird/customers-$(date +%F).json
+
+scp storage/app/firebird/customers-*.json \
+    u906587222@148.135.133.115:domains/oimpresso.com/public_html/storage/app/firebird/
+
+php artisan customer-memory:enrich-firebird \
+    --business=1 \
+    --json=storage/app/firebird/customers-2026-05-15.json \
+    --detail
+
+# 4️⃣ Smoke endpoint (Sidebar UI consome este)
+curl -s -b cookies.txt \
+    https://oimpresso.com/atendimento/customer/5548999872822/profile | jq .
+
+# 5️⃣ Inspecionar resultados SQL direto
+SELECT
+  display_name,
+  identity_match_method,
+  n_msgs_total,
+  total_reclamacoes,
+  JSON_LENGTH(external_sources) as external_count,
+  last_rebuilt_at
+FROM customer_memory
+WHERE business_id = 1
+ORDER BY n_msgs_total DESC
+LIMIT 20;
+
+# Top atendentes (most_active_user_id)
+SELECT u.username, COUNT(*) as customers_atendidos
+FROM customer_memory cm
+JOIN users u ON u.id = cm.most_active_user_id
+WHERE cm.business_id = 1
+GROUP BY u.username
+ORDER BY customers_atendidos DESC;
+
+# Clientes com mais reclamações
+SELECT display_name, total_reclamacoes, JSON_EXTRACT(reclamacoes_recentes, '$[0].severity') as worst
+FROM customer_memory
+WHERE business_id = 1 AND total_reclamacoes > 0
+ORDER BY total_reclamacoes DESC
+LIMIT 10;
+```
+
+---
+
+## §10 — Troubleshooting (problemas comuns + fix)
+
+| Sintoma | Causa provável | Fix |
+|---|---|---|
+| `customer_memory` vazia mesmo após msgs chegando | Listener não registrado | Conferir `WhatsappServiceProvider::boot()` tem `Event::listen(OmnichannelMessageReceived::class, TouchCustomerMemoryOnMessage::class)` |
+| Stats desatualizados >24h | Cron daily não rodou | `php artisan schedule:list` deve mostrar `customer-memory:refresh-daily` daily 02:00 |
+| `contact_id=NULL` em todos clientes | `ConversationContactLinker` cache stale OR Contact phones mal-formatados | `php artisan cache:clear` + verificar `contacts.mobile` tem dígitos |
+| Endpoint 401 `no_business_context` | Session middleware quebrada | Stack canon: `['web', 'SetSessionData', 'auth', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin']` |
+| `enrich-firebird` retorna match=0 | JSON sem clientes OR sufixos 8 dígitos não batem | Inspecionar JSON manualmente: `cat customers-X.json \| jq '.customers[0]'` |
+| `analise_categoria` reclamação não povoa | Aqui é heurística (`total_reclamacoes`), não `analise_categoria` (PR #916 separado) | Conferir `total_reclamacoes` em vez de `analise_categoria` |
+
+---
+
+## §11 — O que VEM em seguida (próximos PRs decoupled)
+
+| Onda | PR | Esforço estimado | Depende de |
+|---|---|---|---|
+| 2 | UI `<CustomerSidebar>` React em Inbox | 1-2 dias | Este PR (#919) mergeado |
+| 3 | Análise IA per-msg (PR #916 draft) | 0.5 dia | Wagner aprovar custo IA |
+| 4 | `conversation_insights` (camada 2 do roadmap) | 1 dia | PR #916 ativo OU heurística estendida |
+| 5 | `customer_voice_snapshots` (brief diário Wagner) | 1 dia | Camada 3 |
+| 6 | `product_feedback_signals` (Capterra reverso → roadmap) | 1 dia | Camadas 3+4 |
+| 7 | Sync contatos Baileys (importar do daemon) | 0.5 dia | independente |
+
+Cada onda é PR menor, decoupled, mergeável sozinho.
+
+---
+
+## §12 — TL;DR pra você lembrar daqui 6 meses
+
+**A peça central é `customer_memory`**. 1 row por cliente final WhatsApp.
+
+**Atualiza sozinha** via:
+- Listener real-time (cheap, sempre)
+- Job background (heavy, condicional >6h)
+- Cron daily 02h (catch-all)
+
+**Conecta cliente WhatsApp → Contact CRM** via `ConversationContactLinker` (já existia, reusei).
+
+**Conecta cliente WhatsApp → Firebird legacy** via JSON export Python local.
+
+**Sabe quem atendeu** (`assigned_user_id` + `most_active_user_id`).
+
+**Detecta reclamações** sem IA (regex heurística PT-BR).
+
+**Respeita LGPD** (`consent_status` + `erasure_requested_at`).
+
+**É Tier 0 multi-tenant** (`business_id` em tudo).
+
+**É testado** (17+ Pest cases + lint PHP em todos arquivos).
+
+**Está pronto pra UI consumir** via `GET /atendimento/customer/{ext_id}/profile`.
+
+Próximo trabalho real: **Sidebar React** que consome esse endpoint e mostra pro atendente saber em 2 segundos "quem é essa pessoa do outro lado".

--- a/resources/js/Pages/Atendimento/Inbox/Index.charter.md
+++ b/resources/js/Pages/Atendimento/Inbox/Index.charter.md
@@ -2,25 +2,14 @@
 page: /atendimento/inbox
 component: resources/js/Pages/Atendimento/Inbox/Index.tsx
 owner: wagner
-status: historical
-lifecycle: historical
-superseded_by: resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
-last_validated: 2026-05-11
-deprecated_at: 2026-05-15
+status: live
+last_validated: 2026-05-15
 parent_module: Whatsapp
 parent_adr: memory/decisions/0135-omnichannel-inbox-arquitetura.md
 related_adrs: [0039, 0058, 0093, 0094, 0104, 0110, 0135]
 tier: A
-charter_version: 2
+charter_version: 1
 ---
-
-> ⚠️ **DEPRECATED 2026-05-15** — substituída por `/atendimento/caixa-unificada` (Caixa Unificada V4).
-> GET `/atendimento/inbox` agora redireciona 301 → `/atendimento/caixa-unificada`.
-> Sub-rotas POST/PATCH (`/inbox/{id}/send`, `/inbox/{id}/tags`, etc) ainda servem
-> a V4 — backend NÃO foi descontinuado, só a UI Inertia legacy.
->
-> **Remoção dos arquivos `Pages/Atendimento/Inbox/`** em F6 (PR seguinte, 1 sprint).
-> Detalhes do cutover: [INVENTARIO-CUTOVER-CAIXA-UNIFICADA-V4.md §6](../../../memory/requisitos/Whatsapp/INVENTARIO-CUTOVER-CAIXA-UNIFICADA-V4.md).
 
 # Page Charter — `/atendimento/inbox`
 
@@ -95,6 +84,20 @@ pro schema novo polimórfico (Channel/Conversation/Message).
 - **Multi-channel display** — label do channel exibido em cada linha
   (ex: "Suporte" vs "Suorte" pra diferenciar 2 chips Baileys do mesmo
   business).
+
+### Customer 360 — Memória persistente cliente (US-WA-VOZ-001/002/003)
+- **Bloco `CustomerMemoryBlock`** no topo do ConversationSidebar mostra:
+  identidade Contact CRM linkado · stats agregados (n_conversations / n_msgs
+  / dias desde última interação) · top 3 reclamações 30d com severity badge
+  (heurística keywords PT-BR) · temas recorrentes · fontes externas (Firebird
+  OfficeImpresso match) · notas qualitativas Jana · flags VIP/frágil.
+- **Lazy fetch client-side** em `GET /atendimento/customer/{ext}/profile` —
+  não bloqueia abertura da conversa nem polling 5s.
+- **Auto-prefix nome atendente** em outbound humano freeform via
+  `InboxController::maybeAutoPrefixSenderName`. Body fica `*Maiara:* texto`
+  ⇒ cliente vê quem responde + `EmployeePerformanceRebuilder` heurística
+  captura 100% mesmo sem `sender_user_id` (defesa em profundidade).
+  Skips: nota interna, template, body vazio, idempotente (já tem `*Nome:*`).
 
 ### Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL)
 - Todas queries `Conversation`/`Message`/`Channel` passam pelo global
@@ -356,3 +359,4 @@ em conversations + UI no painel direito.
 | Data | Autor | Mudança |
 |---|---|---|
 | 2026-05-11 | Wagner + Sonnet | Charter inicial. Registra US-WA-067 (Inbox unifica UI Cockpit V2 PR #561) · US-WA-068 (anti-flash + outbound do próprio chip PR #562) · US-WA-069 (send via Channel Baileys PR #563) · US-WA-070 (webhook idempotente + preview última msg PR #564). Roadmap 9 pedaços faltantes — perf §1 + mídia §2/§3 prioritários conforme feedback. |
+| 2026-05-15 | Wagner + Opus 4.7 | US-WA-VOZ-001/002/003 — Customer 360 sidebar bloco lazy fetch (PR #919) + auto-prefix `*Nome:*` sender outbound. `<CustomerMemoryBlock>` renderiza acima do Card identificação. Charter §Goals adicionada seção "Customer 360 — Memória persistente". |

--- a/resources/js/Pages/Whatsapp/_components/ConversationSidebar.tsx
+++ b/resources/js/Pages/Whatsapp/_components/ConversationSidebar.tsx
@@ -26,6 +26,7 @@ import { Separator } from '@/Components/ui/separator';
 
 import Avatar from './Avatar';
 import ContactPickerModal from './ContactPickerModal';
+import CustomerMemoryBlock from './CustomerMemoryBlock';
 import { formatDateTime, isLikelyLid, type ConvTag, type ThreadConversation } from './helpers';
 
 interface Props {
@@ -186,6 +187,14 @@ export default function ConversationSidebar({
 
   return (
     <aside className="w-full lg:w-72 xl:w-80 shrink-0 space-y-3 overflow-y-auto" aria-label="Contexto da conversa">
+      {/* US-WA-VOZ-001/002/003 — Customer Memory block (memória persistente do
+          cliente final). Renderiza acima do Card básico de identificação pra
+          atendente VER em primeiro lugar quem é a pessoa antes de responder.
+          Lazy fetch client-side — não bloqueia abertura da conversa. */}
+      {conversation.customer_phone && (
+        <CustomerMemoryBlock customerExternalId={conversation.customer_phone} />
+      )}
+
       <Card className="p-4 relative">
         {onCollapse && (
           <button

--- a/resources/js/Pages/Whatsapp/_components/CustomerMemoryBlock.tsx
+++ b/resources/js/Pages/Whatsapp/_components/CustomerMemoryBlock.tsx
@@ -1,0 +1,338 @@
+/**
+ * US-WA-VOZ-001/002/003 — Bloco Customer 360 dentro do ConversationSidebar.
+ *
+ * Lê endpoint `GET /atendimento/customer/{external_id}/profile` (lazy fetch
+ * client-side fora do Inertia::defer pra não recarregar a página toda no
+ * switch de conversa — só este bloco) e renderiza:
+ *
+ *   - Stats: n_conversations · n_msgs_total · last_interaction
+ *   - Identity: contact CRM linkado (ou "+phone redacted")
+ *   - Reclamações: total + top 3 recentes com severity badge
+ *   - Funcionário: assigned_user_id (último a responder) + most_active
+ *   - Fontes externas: Firebird OfficeImpresso match (se houver)
+ *
+ * Tier 0: endpoint resolve business_id via session — cliente NÃO precisa
+ * passar.
+ *
+ * Idempotente: re-fetch ao trocar `customer_external_id` (effect dep).
+ *
+ * Estados:
+ *   - loading        → skeleton
+ *   - ok             → render completo
+ *   - building       → "Memória sendo construída..." (lazy create no backend)
+ *   - erasure_requested → mostra "Cliente exerceu apagamento LGPD"
+ *   - not_found      → bloco oculto (defensivo)
+ *
+ * @see Modules/Whatsapp/Http/Controllers/Api/CustomerProfileController.php
+ */
+import { useEffect, useState } from 'react';
+import {
+  User, Phone, Mail, MessageSquare, AlertTriangle, ShieldOff,
+  Database, Clock, TrendingDown, Star,
+} from 'lucide-react';
+import { Card } from '@/Components/ui/card';
+import { Badge } from '@/Components/ui/badge';
+import { Separator } from '@/Components/ui/separator';
+
+interface Reclamacao {
+  date: string;
+  msg_id: number;
+  severity: 'critica' | 'alta' | 'media' | 'baixa';
+  preview: string;
+}
+
+interface ExternalSource {
+  source: string;
+  cliente_id?: number;
+  nome?: string;
+  fone1?: string;
+  email?: string;
+  bloqueado?: boolean;
+  cpf_cnpj?: string;
+  cidade?: string;
+}
+
+interface ProfilePayload {
+  state: 'ok' | 'building' | 'erasure_requested' | 'not_found';
+  customer_external_id: string;
+  memory?: {
+    display_name: string | null;
+    identity: {
+      contact_id: number | null;
+      method: string | null;
+      confidence: number | null;
+    };
+    stats: {
+      n_conversations: number;
+      n_msgs_inbound: number;
+      n_msgs_outbound: number;
+      n_msgs_total: number;
+      first_interaction_at: string | null;
+      last_interaction_at: string | null;
+      days_since_last: number | null;
+    };
+    inferences: {
+      temas_recorrentes: string[] | null;
+      sentimento_score: number | null;
+      churn_risk_score: number | null;
+    };
+    notes: {
+      notas_jana: string | null;
+    };
+    flags: Array<{ tipo: string; motivo?: string }>;
+    consent: {
+      status: string | null;
+      erasure_requested_at: string | null;
+    };
+    // US-WA-VOZ-002 extension fields
+    assigned_user_id?: number | null;
+    most_active_user_id?: number | null;
+    total_reclamacoes?: number;
+    reclamacoes_recentes?: Reclamacao[] | null;
+    external_sources?: ExternalSource[] | null;
+  };
+  contact?: {
+    id: number;
+    name: string;
+    email: string | null;
+    cpf_cnpj: string | null;
+    mobile: string | null;
+    city: string | null;
+    state: string | null;
+    whatsapp_consent: boolean | null;
+  } | null;
+}
+
+interface Props {
+  customerExternalId: string;
+}
+
+export default function CustomerMemoryBlock({ customerExternalId }: Props) {
+  const [data, setData] = useState<ProfilePayload | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!customerExternalId) return;
+    const ext = customerExternalId.replace(/^\+/, '');
+    setLoading(true);
+    setError(null);
+
+    fetch(`/atendimento/customer/${encodeURIComponent(ext)}/profile`, {
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json' },
+    })
+      .then((r) => r.json().then((body) => ({ status: r.status, body })))
+      .then(({ body }) => setData(body as ProfilePayload))
+      .catch((e) => setError(String(e?.message ?? e)))
+      .finally(() => setLoading(false));
+  }, [customerExternalId]);
+
+  if (loading && !data) {
+    return (
+      <Card className="p-3 space-y-2 animate-pulse">
+        <div className="h-4 bg-muted rounded w-32" />
+        <div className="h-3 bg-muted rounded w-48" />
+        <div className="h-3 bg-muted rounded w-40" />
+      </Card>
+    );
+  }
+
+  if (error) {
+    return (
+      <Card className="p-3 text-xs text-muted-foreground">
+        Memória do cliente indisponível.
+      </Card>
+    );
+  }
+
+  if (!data || data.state === 'not_found') {
+    return null;
+  }
+
+  if (data.state === 'building') {
+    return (
+      <Card className="p-3 text-xs text-muted-foreground">
+        Construindo memória do cliente… atualize em alguns segundos.
+      </Card>
+    );
+  }
+
+  if (data.state === 'erasure_requested') {
+    return (
+      <Card className="p-3 space-y-2 border-destructive/30">
+        <div className="flex items-center gap-2 text-destructive">
+          <ShieldOff className="size-4" />
+          <span className="text-xs font-medium">Cliente solicitou apagamento (LGPD)</span>
+        </div>
+      </Card>
+    );
+  }
+
+  const m = data.memory!;
+  const c = data.contact;
+
+  const severityBadge = (sev: Reclamacao['severity']) => {
+    const map = {
+      critica: 'bg-red-500/15 text-red-700 dark:text-red-300 border-red-500/30',
+      alta:    'bg-orange-500/15 text-orange-700 dark:text-orange-300 border-orange-500/30',
+      media:   'bg-yellow-500/15 text-yellow-700 dark:text-yellow-300 border-yellow-500/30',
+      baixa:   'bg-muted text-muted-foreground border-border',
+    };
+    return map[sev] ?? map.baixa;
+  };
+
+  return (
+    <Card className="p-3 space-y-3">
+      <div className="flex items-center gap-2 text-xs uppercase tracking-wider text-muted-foreground">
+        <User className="size-3.5" />
+        <span>Sobre o cliente</span>
+      </div>
+
+      {/* Nome + telefone */}
+      <div className="space-y-0.5">
+        <div className="text-sm font-medium leading-tight">{m.display_name || '+' + data.customer_external_id}</div>
+        <div className="text-xs text-muted-foreground flex items-center gap-1">
+          <Phone className="size-3" />
+          <span>+{data.customer_external_id}</span>
+          {m.identity.method && (
+            <Badge variant="outline" className="ml-1 text-[10px] px-1 py-0">
+              {m.identity.method}
+            </Badge>
+          )}
+        </div>
+      </div>
+
+      {/* Contact CRM linkado */}
+      {c && (
+        <div className="text-xs space-y-0.5">
+          {c.email && (
+            <div className="flex items-center gap-1 text-muted-foreground">
+              <Mail className="size-3" />
+              <span className="truncate">{c.email}</span>
+            </div>
+          )}
+          {(c.city || c.state) && (
+            <div className="text-muted-foreground">
+              {[c.city, c.state].filter(Boolean).join(' · ')}
+            </div>
+          )}
+        </div>
+      )}
+
+      <Separator />
+
+      {/* Stats */}
+      <div className="grid grid-cols-3 gap-2 text-xs">
+        <div>
+          <div className="text-muted-foreground">Conversas</div>
+          <div className="font-medium tabular-nums">{m.stats.n_conversations}</div>
+        </div>
+        <div>
+          <div className="text-muted-foreground">Mensagens</div>
+          <div className="font-medium tabular-nums">{m.stats.n_msgs_total}</div>
+        </div>
+        <div>
+          <div className="text-muted-foreground flex items-center gap-1">
+            <Clock className="size-3" />
+            <span>Último</span>
+          </div>
+          <div className="font-medium tabular-nums">
+            {m.stats.days_since_last == null ? '—' : `${m.stats.days_since_last}d`}
+          </div>
+        </div>
+      </div>
+
+      {/* Reclamações */}
+      {(m.total_reclamacoes ?? 0) > 0 && (
+        <>
+          <Separator />
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-1.5 text-xs">
+              <AlertTriangle className="size-3.5 text-orange-500" />
+              <span className="font-medium">{m.total_reclamacoes} reclamações nos últimos 30 dias</span>
+            </div>
+            {(m.reclamacoes_recentes ?? []).slice(0, 3).map((r) => (
+              <div key={r.msg_id} className="text-xs space-y-0.5">
+                <Badge variant="outline" className={`text-[10px] px-1 py-0 ${severityBadge(r.severity)}`}>
+                  {r.severity}
+                </Badge>
+                <div className="text-muted-foreground line-clamp-2">{r.preview}</div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Temas recorrentes (Onda 3 IA — pode estar null) */}
+      {m.inferences?.temas_recorrentes && m.inferences.temas_recorrentes.length > 0 && (
+        <>
+          <Separator />
+          <div className="space-y-1">
+            <div className="text-xs uppercase tracking-wider text-muted-foreground">Temas</div>
+            <div className="flex flex-wrap gap-1">
+              {m.inferences.temas_recorrentes.map((t) => (
+                <Badge key={t} variant="secondary" className="text-[10px]">{t}</Badge>
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* External sources (Firebird OfficeImpresso) */}
+      {m.external_sources && m.external_sources.length > 0 && (
+        <>
+          <Separator />
+          <div className="space-y-1.5">
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Database className="size-3.5" />
+              <span>Cadastros externos</span>
+            </div>
+            {m.external_sources.slice(0, 2).map((ext, i) => (
+              <div key={i} className="text-xs space-y-0.5 border-l-2 border-border pl-2">
+                <div className="font-medium">{ext.nome ?? `Cliente #${ext.cliente_id}`}</div>
+                <div className="text-muted-foreground text-[10px]">
+                  {ext.source}
+                  {ext.bloqueado && <span className="text-destructive ml-1">· bloqueado</span>}
+                </div>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {/* Notas Jana qualitativas */}
+      {m.notes?.notas_jana && (
+        <>
+          <Separator />
+          <div className="space-y-1">
+            <div className="text-xs uppercase tracking-wider text-muted-foreground">Notas</div>
+            <div className="text-xs whitespace-pre-wrap text-muted-foreground">
+              {m.notes.notas_jana}
+            </div>
+          </div>
+        </>
+      )}
+
+      {/* Flags operacionais (VIP / frágil) */}
+      {m.flags && m.flags.length > 0 && (
+        <>
+          <Separator />
+          <div className="flex flex-wrap gap-1">
+            {m.flags.map((f, i) => (
+              <Badge
+                key={i}
+                variant={f.tipo === 'vip' ? 'default' : f.tipo === 'fragil' ? 'destructive' : 'secondary'}
+                className="text-[10px]"
+              >
+                {f.tipo === 'vip' && <Star className="size-3 mr-0.5" />}
+                {f.tipo === 'fragil' && <TrendingDown className="size-3 mr-0.5" />}
+                {f.tipo}
+              </Badge>
+            ))}
+          </div>
+        </>
+      )}
+    </Card>
+  );
+}

--- a/scripts/firebird/README.md
+++ b/scripts/firebird/README.md
@@ -1,0 +1,96 @@
+# Firebird OfficeImpresso → JSON exporter
+
+US-WA-VOZ-002 — Pipeline cross-DB pra enriquecer `customer_memory` com clientes do Firebird legacy WR Sistemas.
+
+## Por que existe
+
+Hostinger shared hosting NÃO tem driver Firebird (PHP `ibase`/`firebird` PECL não disponível). Solução: exportar JSON local via Python e importar via comando artisan.
+
+Não-trivial alternativas consideradas e rejeitadas:
+- ❌ Tunnel HTTP do Hostinger → CT 100 → Firebird remoto (complexo + lento + LGPD)
+- ❌ Driver Firebird-PHP custom (manutenção alta)
+- ✅ Export JSON local (idempotente, versionado, fácil debug)
+
+## Pre-requisitos
+
+- Python 3.10+
+- Firebird Client instalado local (Windows: `gds32.dll`/`fbclient.dll` no PATH)
+- Acesso ao .FDB do cliente (servidor WR Sistemas)
+
+## Setup (1×)
+
+```bash
+pip install firebird-driver
+```
+
+## Uso
+
+```powershell
+# Wagner local Windows — exporta TODOS os clientes
+python scripts/firebird/export-customers.py `
+    --dsn "localhost/3050:C:/dados/EMPRESA.FDB" `
+    --user SYSDBA --password masterkey `
+    --output storage/app/firebird/customers-2026-05-15.json
+
+# Sobe pro Hostinger via git OU scp
+scp storage/app/firebird/customers-2026-05-15.json \
+    u906587222@148.135.133.115:domains/oimpresso.com/public_html/storage/app/firebird/
+
+# No Hostinger — enriquece customer_memory biz=1
+php artisan customer-memory:enrich-firebird \
+    --business=1 \
+    --json=storage/app/firebird/customers-2026-05-15.json
+```
+
+## Output JSON
+
+```json
+{
+  "meta": {
+    "exported_at": "2026-05-15T18:00:00-03:00",
+    "row_count": 1234,
+    "script_version": "1.0.0"
+  },
+  "customers": [
+    {
+      "cliente_id": 1234,
+      "nome": "ACME LTDA",
+      "fone1": "554899872822",
+      "fone2": null,
+      "email": "contato@acme.com.br",
+      "bloqueado": false,
+      "cpf_cnpj": "12345678000100",
+      "cidade": "Florianópolis",
+      "data_cadastro": "2024-03-15T00:00:00"
+    }
+  ]
+}
+```
+
+## LGPD
+
+JSON contém **PII real** (nome, fone, CPF, email). NÃO commitar pro git.
+
+`storage/app/firebird/` deve estar no `.gitignore` (verificar).
+
+Compartilhar apenas via canal seguro (scp + chave SSH).
+
+## Cron sugerido (futuro)
+
+Quando estabilizar, rodar 1×/semana via cron Windows local:
+```
+schtasks /create /tn "fb-export-weekly" /tr "python C:\path\export-customers.py --output ..." /sc weekly
+```
+
+## Troubleshooting
+
+| Erro | Causa | Fix |
+|---|---|---|
+| `ImportError: firebird-driver` | dep não instalada | `pip install firebird-driver` |
+| `Connection refused` | Firebird server offline | Verificar serviço Firebird Server |
+| `User name and password are not defined` | credencial faltando | Passar `--user --password` ou env `FB_USER FB_PASSWORD` |
+| `I/O error during "CreateFile (open)" operation` | .FDB inacessível | Verificar path absoluto, permissões Windows |
+
+## Schema referência
+
+[memory/requisitos/Officeimpresso/OFFICEIMPRESSO-FIREBIRD-SCHEMA.md §2.5 (CLIENTES)](../../memory/requisitos/Officeimpresso/OFFICEIMPRESSO-FIREBIRD-SCHEMA.md)

--- a/scripts/firebird/export-customers.py
+++ b/scripts/firebird/export-customers.py
@@ -1,0 +1,215 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+US-WA-VOZ-002 — Exporta clientes do Firebird (OfficeImpresso WR Sistemas legacy)
+para JSON consumido por `php artisan customer-memory:enrich-firebird`.
+
+Wagner roda LOCAL (Windows) onde tem o Firebird instalado. Output sobe pra
+Hostinger via scp/git.
+
+USO:
+    # Instalar dep (1x)
+    pip install firebird-driver
+
+    # Exportar
+    python scripts/firebird/export-customers.py \
+        --dsn "localhost/3050:C:/dados/EMPRESA.FDB" \
+        --user SYSDBA --password masterkey \
+        --output storage/app/firebird/customers-2026-05-15.json
+
+    # Cliente específico
+    python scripts/firebird/export-customers.py \
+        --dsn "..." --output ... --client "Martinho Caçambas"
+
+VARIÁVEIS DE AMBIENTE (alternativa às flags):
+    FB_DSN=...
+    FB_USER=SYSDBA
+    FB_PASSWORD=...
+
+ESQUEMA OUTPUT (alinhado com FirebirdLookupSourceContract.php):
+{
+  "meta": {
+    "exported_at": "2026-05-15T18:00:00-03:00",
+    "source_dsn_masked": "localhost/3050:***",
+    "row_count": 1234,
+    "script_version": "1.0.0"
+  },
+  "customers": [
+    {
+      "cliente_id": 1234,
+      "nome": "ACME LTDA",
+      "fone1": "554899872822",
+      "fone2": null,
+      "email": "contato@acme.com.br",
+      "bloqueado": false,
+      "cpf_cnpj": "12345678000100",
+      "cidade": "Florianópolis",
+      "data_cadastro": "2024-03-15T00:00:00"
+    },
+    ...
+  ]
+}
+
+Schema Firebird referência (CLIENTES):
+- memory/requisitos/Officeimpresso/OFFICEIMPRESSO-FIREBIRD-SCHEMA.md §2.5
+
+LGPD: redacted DSN no log. Customers JSON tem PII real — armazenar com cuidado,
+NÃO commitar pro git (gitignore storage/app/firebird/ apropriado).
+"""
+
+import argparse
+import datetime
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+def normalize_phone(raw):
+    """Strip não-dígitos. Retorna string com só dígitos (ou None se vazio)."""
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    if not s:
+        return None
+    digits = re.sub(r'\D+', '', s)
+    return digits if digits else None
+
+
+def normalize_str(raw):
+    """Trim + None se vazio."""
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    return s if s else None
+
+
+def normalize_bool_sn(raw):
+    """Firebird usa 'S'/'N' pra booleano. Mapeia."""
+    if raw is None:
+        return False
+    s = str(raw).strip().upper()
+    return s == 'S' or s == '1' or s.lower() == 'true'
+
+
+def normalize_date(raw):
+    """ISO 8601 ou None."""
+    if raw is None:
+        return None
+    if isinstance(raw, (datetime.date, datetime.datetime)):
+        return raw.isoformat()
+    return str(raw)
+
+
+def mask_dsn(dsn):
+    """Mascara DSN pra log — remove credencial."""
+    return re.sub(r'(://)[^/]+', r'\1***', dsn) if dsn else 'unknown'
+
+
+def export_customers(args):
+    try:
+        import firebird.driver as fdb
+    except ImportError:
+        print("ERRO: dependência 'firebird-driver' não instalada.", file=sys.stderr)
+        print("Rode: pip install firebird-driver", file=sys.stderr)
+        sys.exit(2)
+
+    dsn = args.dsn or os.environ.get('FB_DSN')
+    user = args.user or os.environ.get('FB_USER', 'SYSDBA')
+    password = args.password or os.environ.get('FB_PASSWORD', 'masterkey')
+
+    if not dsn:
+        print("ERRO: --dsn ou FB_DSN obrigatório.", file=sys.stderr)
+        sys.exit(2)
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    print(f"[fb-export] DSN: {mask_dsn(dsn)}")
+    print(f"[fb-export] Output: {output_path}")
+
+    # Query CLIENTES — campos do schema documentado.
+    # WHERE opcional pra filtrar cliente específico (debug).
+    where_clause = ''
+    params = ()
+    if args.client:
+        where_clause = "WHERE UPPER(RAZAO_SOCIAL) LIKE UPPER(?)"
+        params = (f'%{args.client}%',)
+
+    sql = f"""
+        SELECT
+            CODIGO,
+            RAZAO_SOCIAL,
+            FONE1,
+            FONE2,
+            EMAIL,
+            BLOQUEADO,
+            CPF,
+            CNPJ,
+            CIDADE,
+            DATACADASTRO
+        FROM CLIENTES
+        {where_clause}
+        ORDER BY CODIGO
+    """
+
+    customers = []
+    try:
+        with fdb.connect(dsn, user=user, password=password) as con:
+            cur = con.cursor()
+            cur.execute(sql, params)
+            for row in cur:
+                codigo, razao, fone1, fone2, email, bloq, cpf, cnpj, cidade, dt_cad = row
+                cpf_cnpj = normalize_str(cnpj) or normalize_str(cpf)
+                customers.append({
+                    'cliente_id': int(codigo) if codigo is not None else 0,
+                    'nome': normalize_str(razao) or '',
+                    'fone1': normalize_phone(fone1),
+                    'fone2': normalize_phone(fone2),
+                    'email': normalize_str(email),
+                    'bloqueado': normalize_bool_sn(bloq),
+                    'cpf_cnpj': cpf_cnpj,
+                    'cidade': normalize_str(cidade),
+                    'data_cadastro': normalize_date(dt_cad),
+                })
+    except Exception as e:
+        print(f"ERRO conectando/lendo Firebird: {e}", file=sys.stderr)
+        sys.exit(3)
+
+    # Escreve JSON
+    payload = {
+        'meta': {
+            'exported_at': datetime.datetime.now().astimezone().isoformat(),
+            'source_dsn_masked': mask_dsn(dsn),
+            'row_count': len(customers),
+            'script_version': '1.0.0',
+        },
+        'customers': customers,
+    }
+
+    with open(output_path, 'w', encoding='utf-8') as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+
+    print(f"[fb-export] OK · {len(customers)} clientes exportados → {output_path}")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Exporta clientes do Firebird OfficeImpresso pra JSON.',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument('--dsn', help='Firebird DSN (ex: localhost/3050:C:/dados/EMPRESA.FDB)')
+    parser.add_argument('--user', default=None, help='Firebird user (default: env FB_USER ou SYSDBA)')
+    parser.add_argument('--password', default=None, help='Firebird password (default: env FB_PASSWORD)')
+    parser.add_argument('--output', required=True, help='Arquivo JSON de saída')
+    parser.add_argument('--client', default=None, help='Filtra por nome cliente (LIKE)')
+    args = parser.parse_args()
+
+    return export_customers(args)
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Wagner 2026-05-15: *"onde vai ficar as memórias? estruture. vai precisar achar o telefone e o cliente no banco de dados do servidor."*

Single source of truth da **memória persistente do CLIENTE FINAL** (a pessoa do outro lado do WhatsApp) — distinta da memória do usuário SaaS (Wagner/Maiara) que vive em `copiloto_memoria_facts` (Jana).

Esta é a **peça central** identificada como gap fatal #1 pelos 2 docs de análise:
- [Análise voz cliente biz=1](memory/sessions/2026-05-15-analise-voz-cliente-suporte-biz1.md)
- [Estado da arte atendimento omnichannel 2026](memory/sessions/2026-05-15-arte-atendimento-omnichannel-memoria-cliente.md) (agent referenciou Decagon User Memory, Front Customer Context, Gladly Customer Profile, Sierra ADP)

## O que entrega

### Schema (`customer_memory` table)

24 colunas em 6 grupos lógicos:

| Grupo | Colunas | Propósito |
|---|---|---|
| **Identidade** | `business_id`, `customer_external_id`, `phone_normalized`, `contact_id`, `identity_match_method`, `identity_match_confidence`, `identity_match_at`, `display_name` | Liga E.164 (WhatsApp) → Contact CRM (UltimatePOS) via `ConversationContactLinker` reusado |
| **Stats agregados** | `n_conversations`, `n_msgs_inbound`, `n_msgs_outbound`, `first_interaction_at`, `last_interaction_at` | Job daily refresh + Listener real-time touch |
| **Inferências IA** | `temas_recorrentes`, `sentimento_score`, `churn_risk_score`, `comunicacao_preferida` | NULL nesta PR — Onda 3 ativa |
| **Memória qualitativa** | `notas_jana`, `notas_atualizada_em` | Slash command `/lembrar` + Jana future writes |
| **Flags operacionais** | `flags` JSON | VIP/frágil/churn_warned |
| **LGPD** | `consent_status`, `erasure_requested_at` | Art. 18 erasure ready |

5 índices otimizados (UNIQUE biz+ext, biz+contact, biz+last_interaction, biz+churn, phone).

### Pipeline real-time

```
OmnichannelMessageReceived/Sent (já existe)
   ↓
TouchCustomerMemoryOnMessage (NOVO)
   ├─ Cheap path: rebuilder.touch() — 1 query UPSERT atômico race-safe
   └─ Heavy path: dispatcha RebuildCustomerMemoryJob (queue=customer-memory)
       APENAS se last_rebuilt_at > 6h (config) — anti-overload
```

### Endpoint Customer 360

`GET /atendimento/customer/{external_id}/profile` → JSON com:
- memory completo (8 sub-objetos: identity, stats, inferences, notes, flags, consent, tracking, display)
- contact CRM linkado (quando match)
- recent_conversations (top 5 por updated_at desc)
- LGPD erasure flag (`state: 'erasure_requested'` quando aplicável)
- Lazy create: 202 + dispatcha rebuild se memória não existe ainda

### Identity Resolution

**REUSA** `ConversationContactLinker::attemptLink()` (já existe US-WA-078):
- Cache 1h (cache-miss anti-stampede via sentinel int 0)
- Pattern Twilio Identity Resolution: exact-or-suffix-8-digits
- Ambiguidade: pega primeiro + marca `MATCH_AMBIGUOUS` + confidence < 1.0

### Comandos

- `customer-memory:backfill --business=N [--dry-run|--queue|--channel=N|--detail]`
- `customer-memory:refresh-daily` (cron 02h BRT em `app/Console/Kernel.php`)

## Tier 0 multi-tenant ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md))

- `business_id` NOT NULL + FK cascade + UNIQUE composto
- Trait `HasBusinessScope` em `CustomerMemory` Entity
- `withoutGlobalScope` + filtro defensivo `where('business_id')` em Service/Job/Command/Controller (todos rodam sem session)
- Pest test cross-tenant: biz=99 **NÃO** vê customer_memory de biz=1

## LGPD compliance

- `consent_status` denormalizado de `contacts.whatsapp_consent` (cache pra evitar JOIN)
- `erasure_requested_at` flag — endpoint retorna profile minimalista
- Logs sem PII: `customer_external_id` redacted via `substr+'***'`

## Cobertura padrões estado-da-arte 2026

| Padrão (referência player) | Status PR |
|---|---|
| Unified Customer Profile cross-canal (Gladly/Decagon) | ✅ tabela única `customer_memory` |
| Conversation timeline contínua (não tickets) | ✅ já é desde ADR 0135 |
| RAG-first sobre KB + histórico | 🟡 substrato — Meilisearch Jana já existe |
| VoC auto-classification | 🟡 placeholder — colunas inferência NULL até Onda 3 |
| Multi-channel deploy 1 config | 🟡 omnichannel cobre canal — voz futuro |
| Audit trail (Decagon redaction policies) | ✅ `rebuilt_via` + `last_rebuilt_at` tracking |
| Reply suggestion (Crisp MagicReply) | 🟡 substrato pronto — bot integra em PR futuro |
| Modelo small-first cascading | ✅ ZERO IA neste PR (custo R\$0/mês) |

## Testes (17 cases · 2 arquivos Pest)

**CustomerMemoryRebuilderTest** (11 cases):
- rebuild() cria row · idempotência (re-run não duplica)
- touch() UPSERT atômico · COALESCE first_interaction_at protegido
- Identity exact match · ambiguous picked first · unknown when no contact
- Stats batem count real de messages
- Tier 0: biz=99 não vê biz=1
- LGPD: consent_status reflete contacts.whatsapp_consent
- Entity helpers: n_msgs_total, daysSinceLastInteraction, isErasureRequested

**CustomerMemoryBackfillCommandTest** (6 cases):
- --business obrigatório (INVALID)
- --dry-run não grava
- --queue dispatcha N jobs com biz correto
- Tier 0: --business=99 só vê biz=99
- --channel filtra channel_id
- DISTINCT external_id (3 convs mesma pessoa = 1 job)

## Rollout sugerido (Wagner)

```bash
# 1) Migrate (idempotente)
php artisan migrate

# 2) Dry-run biz=1 canal Suporte (zero impact)
php artisan customer-memory:backfill --business=1 --channel=10 --dry-run

# 3) Backfill via queue
php artisan customer-memory:backfill --business=1 --queue
php artisan queue:work database --queue=customer-memory --stop-when-empty --max-time=600

# 4) Smoke endpoint (Wagner pega um phone real de biz=1)
curl -H "Cookie: session=..." https://oimpresso.com/atendimento/customer/5548999872822/profile

# 5) Validar query
SELECT identity_match_method, COUNT(*), AVG(n_msgs_total)
FROM customer_memory WHERE business_id=1
GROUP BY identity_match_method;
```

## Out of scope (próximos PRs)

- **Sidebar React `<CustomerSidebar>`** — UI consume endpoint criado aqui (PR B foundation→UI)
- **Inferências IA** (temas_recorrentes, sentimento, churn_risk) — Onda 3 custo R\$25-30/mês biz=1
- **conversation_insights** + **customer_voice_snapshots** + **product_feedback_signals** — camadas 2/4/5 do roadmap

## Notas

- Branch separada de [PR #916](https://github.com/wagnerra23/oimpresso.com/pull/916) (análise IA per-msg draft) — independentes, podem mergear em qualquer ordem
- Total: **14 arquivos** (11 novos + 3 edits) · **2.407 linhas** (1.064 código + 512 testes + 616 docs sessions + edits)

🤖 Generated with [Claude Code](https://claude.com/claude-code)