### PR TITLE
feat(caixa-unificada): Wave 5 F1 — filtros power-user (5 filtros backend + UI)

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
@@ -75,6 +75,16 @@ class CaixaUnificadaController extends Controller
         $search = (string) $request->input('q', '');
         $threadId = $request->input('thread');
 
+        // Wave 5 F1 — filtros power-user paridade Inbox legacy
+        $within24h = $request->has('within24h')
+            ? filter_var($request->input('within24h'), FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE)
+            : null;
+        $unlinked = (bool) $request->input('unlinked', false);
+        $mediaInbound24h = (bool) $request->input('media_inbound_24h', false);
+        $inboundAging = $request->input('inbound_aging'); // 6h/12h/24h/48h/7d
+        $orderBy = (string) $request->input('order_by', 'last_message'); // last_message | inbound
+        $activeTagIds = array_filter(array_map('intval', (array) $request->input('tags', [])));
+
         // ACL gate per-canal — se selecionou `account_id`, valida ANTES
         // (defense-in-depth — fail-loud em vez de lista vazia confusa).
         if ($accountFilter !== null) {
@@ -124,7 +134,8 @@ class CaixaUnificadaController extends Controller
         return Inertia::render('Atendimento/CaixaUnificada/Index', [
             // ─── DEFER: props caras (skip quando partial reload `only:[]` não pede) ───
             'conversations' => Inertia::defer(fn () => $this->buildConversationsPayload(
-                $businessId, $userId, $statusFilter, $channelTypeFilter, $accountFilter, $queueFilter, $search
+                $businessId, $userId, $statusFilter, $channelTypeFilter, $accountFilter, $queueFilter, $search,
+                $within24h, $unlinked, $mediaInbound24h, $inboundAging, $orderBy, $activeTagIds
             )),
             'stats' => Inertia::defer(fn () => $this->buildStatsPayload($businessId, $userId)),
             'availableChannels' => Inertia::defer(fn () => $this->buildAvailableChannelsPayload($businessId, $userId)),
@@ -138,6 +149,13 @@ class CaixaUnificadaController extends Controller
             'accountFilter' => $accountFilter,
             'queueFilter' => $queueFilter,
             'q' => $search,
+            // Wave 5 F1: filtros power-user pra UI sincronizar
+            'within24h' => $within24h,
+            'unlinked' => $unlinked,
+            'mediaInbound24h' => $mediaInbound24h,
+            'inboundAging' => $inboundAging,
+            'orderBy' => $orderBy,
+            'activeTagIds' => array_values($activeTagIds),
             'thread' => $thread,
             'messages' => $messages,
             'centrifugoConfig' => $centrifugoConfig,
@@ -160,7 +178,13 @@ class CaixaUnificadaController extends Controller
         ?string $channelTypeFilter,
         ?int $accountFilter,
         ?string $queueFilter,
-        string $search
+        string $search,
+        ?bool $within24h = null,
+        bool $unlinked = false,
+        bool $mediaInbound24h = false,
+        ?string $inboundAging = null,
+        string $orderBy = 'last_message',
+        array $activeTagIds = []
     ): array {
         $convQuery = Conversation::query()
             ->where('business_id', $businessId)
@@ -210,8 +234,55 @@ class CaixaUnificadaController extends Controller
             });
         }
 
+        // Wave 5 F1 — filtros power-user paridade Inbox legacy
+
+        // within24h tri-estado: janela Meta 24h (last_inbound_at >/< now-24h)
+        if ($within24h === true) {
+            $convQuery->where('last_inbound_at', '>=', now()->subHours(24));
+        } elseif ($within24h === false) {
+            $convQuery->where(function ($q) {
+                $q->whereNull('last_inbound_at')
+                  ->orWhere('last_inbound_at', '<', now()->subHours(24));
+            });
+        }
+
+        // unlinked: convs sem Contact CRM vinculado
+        if ($unlinked) {
+            $convQuery->whereNull('contact_id');
+        }
+
+        // mediaInbound24h: convs com mensagem inbound type=image/video/audio/document nas 24h
+        if ($mediaInbound24h) {
+            $convQuery->whereExists(function ($q) {
+                $q->select(\DB::raw(1))
+                    ->from('whatsapp_messages')
+                    ->whereColumn('whatsapp_messages.conversation_id', 'conversations.id')
+                    ->where('direction', 'inbound')
+                    ->whereIn('type', ['image', 'video', 'audio', 'document'])
+                    ->where('created_at', '>=', now()->subHours(24));
+            });
+        }
+
+        // inboundAging: aguardando resposta há mais de N horas
+        $agingMap = ['6h' => 6, '12h' => 12, '24h' => 24, '48h' => 48, '7d' => 168];
+        if ($inboundAging && isset($agingMap[$inboundAging])) {
+            $convQuery->where('last_inbound_at', '<=', now()->subHours($agingMap[$inboundAging]))
+                ->where(function ($q) {
+                    $q->whereNull('last_outbound_at')
+                      ->orWhereColumn('last_inbound_at', '>', 'last_outbound_at');
+                });
+        }
+
+        // Filtro por tags (intersecção — pelo menos 1 tag das selecionadas)
+        if (! empty($activeTagIds)) {
+            $convQuery->whereHas('tags', fn ($q) => $q->whereIn('whatsapp_conversation_tags.tag_id', $activeTagIds));
+        }
+
+        // Ordenação alternativa: por último inbound (vs default last_message_at)
+        $orderColumn = $orderBy === 'inbound' ? 'last_inbound_at' : 'last_message_at';
+
         $paginated = $convQuery
-            ->orderByDesc('last_message_at')
+            ->orderByDesc($orderColumn)
             ->paginate(50);
 
         $data = $paginated->getCollection()

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
@@ -74,6 +74,13 @@ interface Props {
    */
   statusFilter: CaixaUnifStatus | CaixaUnifTab;
   channelTypeFilter: string | null;
+  // Wave 5 F1 — filtros power-user (sincronizam URL)
+  within24h?: boolean | null;
+  unlinked?: boolean;
+  mediaInbound24h?: boolean;
+  inboundAging?: '6h' | '12h' | '24h' | '48h' | '7d' | null;
+  orderBy?: 'last_message' | 'inbound';
+  activeTagIds?: number[];
   accountFilter: number | null;
   queueFilter: string | null;
   q: string;
@@ -90,6 +97,7 @@ export default function CaixaUnificadaIndex({
   statusFilter, channelTypeFilter, accountFilter, queueFilter: _queueFilter, q,
   thread, messages, centrifugoConfig,
   queues, defaultQueue: _defaultQueue,
+  within24h, unlinked, mediaInbound24h, inboundAging, orderBy,
 }: Props) {
   // Centrifugo real-time (US-WA-068 anti-flash com preserveScroll + preserveState)
   useEffect(() => {
@@ -411,6 +419,11 @@ export default function CaixaUnificadaIndex({
             status={statusFilter}
             q={q}
             onSelect={selectThread}
+            within24h={within24h}
+            unlinked={unlinked}
+            mediaInbound24h={mediaInbound24h}
+            inboundAging={inboundAging}
+            orderBy={orderBy}
           />
         </Deferred>
 

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationListV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationListV4.tsx
@@ -14,7 +14,7 @@
 
 import { useMemo, useState } from 'react';
 import { router } from '@inertiajs/react';
-import { Search, X } from 'lucide-react';
+import { Clock, Paperclip, Search, UserPlus, X } from 'lucide-react';
 import { cn } from '@/Lib/utils';
 import {
   type CaixaUnifConversation,
@@ -28,6 +28,9 @@ import {
   relativeTimeBR,
 } from './helpers';
 
+type InboundAging = '6h' | '12h' | '24h' | '48h' | '7d' | null;
+type OrderBy = 'last_message' | 'inbound';
+
 interface Props {
   conversations: Paginated<CaixaUnifConversation>;
   channels: ChannelCatalogItem[];
@@ -38,6 +41,12 @@ interface Props {
   status: CaixaUnifStatus | CaixaUnifTab;
   q: string;
   onSelect: (id: number) => void;
+  // Wave 5 F1 — filtros power-user (sincronizam URL)
+  within24h?: boolean | null;
+  unlinked?: boolean;
+  mediaInbound24h?: boolean;
+  inboundAging?: InboundAging;
+  orderBy?: OrderBy;
 }
 
 const TABS: { id: CaixaUnifTab; label: string; statKey?: keyof CaixaUnifStats; title?: string }[] = [
@@ -52,6 +61,8 @@ const TABS: { id: CaixaUnifTab; label: string; statKey?: keyof CaixaUnifStats; t
 
 export default function ConversationListV4({
   conversations, channels, stats, selectedId, status, q, onSelect,
+  within24h = null, unlinked = false, mediaInbound24h = false,
+  inboundAging = null, orderBy = 'last_message',
 }: Props) {
   const [searchInput, setSearchInput] = useState(q);
   const tab = status as CaixaUnifTab;
@@ -62,10 +73,24 @@ export default function ConversationListV4({
     return map;
   }, [channels]);
 
+  // Helper Wave 5 F1: preserva todos filtros ao navegar
+  function buildQuery(overrides: Record<string, unknown> = {}) {
+    return {
+      tab,
+      q: q || undefined,
+      within24h: within24h !== null ? (within24h ? '1' : '0') : undefined,
+      unlinked: unlinked ? '1' : undefined,
+      media_inbound_24h: mediaInbound24h ? '1' : undefined,
+      inbound_aging: inboundAging ?? undefined,
+      order_by: orderBy !== 'last_message' ? orderBy : undefined,
+      ...overrides,
+    };
+  }
+
   function applyTab(next: CaixaUnifTab) {
     router.get(
       route('atendimento.caixa-unificada.index'),
-      { tab: next, q: q || undefined },
+      buildQuery({ tab: next }),
       { preserveScroll: true, preserveState: true, only: ['conversations', 'stats'] },
     );
   }
@@ -73,10 +98,32 @@ export default function ConversationListV4({
   function applySearch(value: string) {
     router.get(
       route('atendimento.caixa-unificada.index'),
-      { tab, q: value || undefined },
+      buildQuery({ q: value || undefined }),
       { preserveScroll: true, preserveState: true, only: ['conversations', 'stats'], replace: true },
     );
   }
+
+  function applyFilter(overrides: Record<string, unknown>) {
+    router.get(
+      route('atendimento.caixa-unificada.index'),
+      buildQuery(overrides),
+      { preserveScroll: true, preserveState: true, only: ['conversations', 'stats'] },
+    );
+  }
+
+  // Tri-estado within24h: null → true → false → null
+  function cycleWithin24h() {
+    const next = within24h === null ? true : within24h === true ? false : null;
+    applyFilter({ within24h: next === null ? undefined : next ? '1' : '0' });
+  }
+
+  const activeFilterCount = [
+    within24h !== null,
+    unlinked,
+    mediaInbound24h,
+    inboundAging !== null,
+    orderBy !== 'last_message',
+  ].filter(Boolean).length;
 
   return (
     <aside
@@ -130,6 +177,80 @@ export default function ConversationListV4({
             </button>
           );
         })}
+      </div>
+
+      {/* Wave 5 F1 — Filtros power-user (3 chips + 2 dropdowns) */}
+      <div className="flex flex-wrap items-center gap-1 px-2 py-1.5 border-b text-[11px]">
+        <FilterChip
+          active={unlinked}
+          onClick={() => applyFilter({ unlinked: !unlinked ? '1' : undefined })}
+          icon={<UserPlus size={11} aria-hidden />}
+          label="Sem CRM"
+          title="Conversas sem Contact CRM vinculado (oportunidade de cadastro)"
+        />
+        <FilterChip
+          active={within24h !== null}
+          onClick={cycleWithin24h}
+          icon={<Clock size={11} aria-hidden />}
+          label={within24h === false ? '24h fechada' : within24h === true ? '24h aberta' : 'Janela 24h'}
+          title="Janela Meta 24h — clique alterna aberta → fechada → sem filtro"
+        />
+        <FilterChip
+          active={mediaInbound24h}
+          onClick={() => applyFilter({ media_inbound_24h: !mediaInbound24h ? '1' : undefined })}
+          icon={<Paperclip size={11} aria-hidden />}
+          label="Mídia 24h"
+          title="Só conversas com foto/áudio/vídeo/doc recebidos nas últimas 24h"
+        />
+
+        {/* Aging dropdown */}
+        <select
+          value={inboundAging ?? ''}
+          onChange={e => applyFilter({ inbound_aging: e.target.value || undefined })}
+          aria-label="Esperando resposta há mais de"
+          data-testid="caixa-unif-filter-aging"
+          className={cn(
+            'h-6 px-1.5 text-[11px] rounded border bg-card cursor-pointer hover:bg-muted focus:outline-none focus:border-primary',
+            inboundAging ? 'border-primary text-primary font-medium' : 'border-border text-muted-foreground',
+          )}
+        >
+          <option value="">Esperando há…</option>
+          <option value="6h">&gt; 6h</option>
+          <option value="12h">&gt; 12h</option>
+          <option value="24h">&gt; 24h</option>
+          <option value="48h">&gt; 48h</option>
+          <option value="7d">&gt; 7 dias</option>
+        </select>
+
+        {/* OrderBy dropdown */}
+        <select
+          value={orderBy}
+          onChange={e => applyFilter({ order_by: e.target.value === 'last_message' ? undefined : e.target.value })}
+          aria-label="Ordenar por"
+          data-testid="caixa-unif-filter-orderby"
+          className={cn(
+            'h-6 px-1.5 text-[11px] rounded border bg-card cursor-pointer hover:bg-muted focus:outline-none focus:border-primary',
+            orderBy !== 'last_message' ? 'border-primary text-primary font-medium' : 'border-border text-muted-foreground',
+          )}
+        >
+          <option value="last_message">Última msg</option>
+          <option value="inbound">Último inbound</option>
+        </select>
+
+        {activeFilterCount > 0 && (
+          <button
+            type="button"
+            onClick={() => applyFilter({
+              within24h: undefined, unlinked: undefined, media_inbound_24h: undefined,
+              inbound_aging: undefined, order_by: undefined,
+            })}
+            className="ml-auto inline-flex items-center gap-0.5 text-[10.5px] text-muted-foreground hover:text-foreground transition-colors"
+            data-testid="caixa-unif-filter-clear"
+            title={`Limpar ${activeFilterCount} filtro${activeFilterCount > 1 ? 's' : ''}`}
+          >
+            <X size={11} aria-hidden /> limpar
+          </button>
+        )}
       </div>
 
       {/* Busca inline */}
@@ -265,5 +386,34 @@ export default function ConversationListV4({
         </ul>
       )}
     </aside>
+  );
+}
+
+// Wave 5 F1 — FilterChip compacto (pattern Inbox legacy ConversationList.tsx)
+function FilterChip({
+  active, onClick, icon, label, title,
+}: {
+  active: boolean;
+  onClick: () => void;
+  icon: React.ReactNode;
+  label: string;
+  title?: string;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      title={title}
+      aria-pressed={active}
+      className={cn(
+        'inline-flex items-center gap-1 h-6 px-2 rounded-full border text-[10.5px] font-medium transition-colors',
+        active
+          ? 'bg-primary/10 border-primary text-primary'
+          : 'bg-card border-border text-muted-foreground hover:text-foreground hover:border-muted-foreground',
+      )}
+    >
+      {icon}
+      {label}
+    </button>
   );
 }


### PR DESCRIPTION
## Summary

Inventário §2.1 Wave 5 — paridade Inbox legacy. Adiciona 5 filtros power-user na Caixa Unificada V4.

| Filtro | UI |
|---|---|
| `within24h` tri-estado (Meta janela 24h) | Chip toggle alterna 3 estados |
| `unlinked` | Chip "Sem CRM" |
| `mediaInbound24h` | Chip "Mídia 24h" |
| `inboundAging` | Dropdown "Esperando há… 6h/12h/24h/48h/7d" |
| `orderBy` | Dropdown "Última msg / Último inbound" |

Backend `CaixaUnificadaController` aceita 6 query params + aplica em `buildConversationsPayload`.

## Test plan

- [ ] Carregar Caixa Unificada → 5 filtros visíveis abaixo das tabs
- [ ] Click "Sem CRM" → lista filtra convs sem `contact_id`
- [ ] Click "Janela 24h" 3x → tri-estado (aberta → fechada → sem filtro)
- [ ] Aging dropdown 24h → só convs aguardando > 24h
- [ ] OrderBy "Último inbound" → reordena por last_inbound_at
- [ ] Botão "limpar" reseta tudo

Wave 5-B (filtro tags multi-select Popover) fica pro próximo PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)