### PR TITLE
feat(caixa-unificada): 🎉 CUTOVER — /inbox 301 → /caixa-unificada + charter historical

### DIFF
--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -82,14 +82,19 @@ Route::group([
     'middleware' => ['web', 'SetSessionData', 'auth', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin'],
     'prefix'     => 'atendimento',
 ], function () {
-    // Inbox omnichannel — lê schema novo (Channel + Conversation + Message)
-    Route::get('/inbox', [InboxController::class, 'index'])
-        ->middleware('can:whatsapp.access')
+    // CUTOVER 2026-05-15: GET /inbox redireciona pra Caixa Unificada V4 (301 permanent).
+    // Inventário §6 do INVENTARIO-CUTOVER-CAIXA-UNIFICADA-V4.md.
+    // - Route name `atendimento.inbox.index` preservado (compat Pest + frontend legacy)
+    // - Query string preserved automaticamente pelo Laravel Route::redirect
+    // - Sub-rotas POST/PATCH (/inbox/{id}/send, /inbox/{id}/tags, etc) PERMANECEM
+    //   intactas — Caixa Unificada V4 reusa todos os endpoints (sem duplicar contrato)
+    // - Charter Inbox/Index.charter.md vira lifecycle: historical no mesmo PR
+    // - Pages/Atendimento/Inbox/ removida em F6 (PR seguinte, 1 sprint depois)
+    Route::redirect('/inbox', '/atendimento/caixa-unificada', 301)
         ->name('atendimento.inbox.index');
 
-    // Caixa Unificada V4 — redesign Cowork omnichannel (ADR 0114 loop).
-    // Coexiste com /atendimento/inbox durante canary 7d. Cutover em PR seguinte.
-    // Fonte visual canônica: prototipo-ui/prototipos/caixa-unificada/
+    // Caixa Unificada V4 — substituiu /atendimento/inbox no cutover 2026-05-15.
+    // Fonte visual canônica: prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx
     Route::get('/caixa-unificada', [CaixaUnificadaController::class, 'index'])
         ->middleware('can:whatsapp.access')
         ->name('atendimento.caixa-unificada.index');

--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -2,8 +2,10 @@
 page: /atendimento/caixa-unificada
 component: resources/js/Pages/Atendimento/CaixaUnificada/Index.tsx
 owner: wagner
-status: in_canary
+status: live
 last_validated: 2026-05-15
+cutover_at: 2026-05-15
+supersedes: resources/js/Pages/Atendimento/Inbox/Index.charter.md
 parent_module: Whatsapp
 parent_adr: memory/decisions/0135-omnichannel-inbox-arquitetura.md
 visual_source: prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx

--- a/resources/js/Pages/Atendimento/Inbox/Index.charter.md
+++ b/resources/js/Pages/Atendimento/Inbox/Index.charter.md
@@ -2,14 +2,25 @@
 page: /atendimento/inbox
 component: resources/js/Pages/Atendimento/Inbox/Index.tsx
 owner: wagner
-status: live
+status: historical
+lifecycle: historical
+superseded_by: resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
 last_validated: 2026-05-11
+deprecated_at: 2026-05-15
 parent_module: Whatsapp
 parent_adr: memory/decisions/0135-omnichannel-inbox-arquitetura.md
 related_adrs: [0039, 0058, 0093, 0094, 0104, 0110, 0135]
 tier: A
-charter_version: 1
+charter_version: 2
 ---
+
+> ⚠️ **DEPRECATED 2026-05-15** — substituída por `/atendimento/caixa-unificada` (Caixa Unificada V4).
+> GET `/atendimento/inbox` agora redireciona 301 → `/atendimento/caixa-unificada`.
+> Sub-rotas POST/PATCH (`/inbox/{id}/send`, `/inbox/{id}/tags`, etc) ainda servem
+> a V4 — backend NÃO foi descontinuado, só a UI Inertia legacy.
+>
+> **Remoção dos arquivos `Pages/Atendimento/Inbox/`** em F6 (PR seguinte, 1 sprint).
+> Detalhes do cutover: [INVENTARIO-CUTOVER-CAIXA-UNIFICADA-V4.md §6](../../../memory/requisitos/Whatsapp/INVENTARIO-CUTOVER-CAIXA-UNIFICADA-V4.md).
 
 # Page Charter — `/atendimento/inbox`
 


### PR DESCRIPTION
## Summary

**🎉 CUTOVER FINAL** — F5 do INVENTARIO §6. Wagner aprovou após F1 paridade 100% + polimentos Cowork 98%.

### Mudanças

| Arquivo | Mudança |
|---|---|
| `Routes/web.php` | `Route::get('/inbox')` → `Route::redirect('/inbox', '/atendimento/caixa-unificada', 301)` (preserva query string + route name) |
| `Inbox/Index.charter.md` | `status: live` → `status: historical` + `superseded_by` |
| `CaixaUnificada/Index.charter.md` | `status: in_canary` → `status: live` + `supersedes` |

### O que NÃO muda

- ✅ `Pages/Atendimento/Inbox/` permanece em disco (remoção em F6, ~1 sprint)
- ✅ `InboxController` permanece — V4 reusa POST `/send`, PATCH `/tags` etc
- ✅ Sub-rotas Inbox permanecem funcionais (send/tags/block/contact/media/interactive)
- ✅ Route name `atendimento.inbox.index` preservado (Pest test passa)

### Próximo PR (F6 limpeza, não-bloqueante)

- Remover `Pages/Atendimento/Inbox/Index.tsx` + charter + `_components/`
- Migrar `InboxFilters/MultiPhone/SendInteractive/Cleanup/QueueDerivation` Pest tests pra CaixaUnif*
- Eventual remoção do Route::redirect (~30d após cutover, quando histórico URLs salvas zerar)

## Test plan

- [ ] Acessar `/atendimento/inbox` → 301 → `/atendimento/caixa-unificada`
- [ ] Acessar `/atendimento/inbox?tab=resolved&thread=123` → preserva query string
- [ ] Submit POST `/atendimento/inbox/{id}/send` ainda funciona (V4 chama)
- [ ] Route name `atendimento.inbox.index` ainda gera URL válida no PHP

## Histórico do cycle

15+ PRs nessa Caixa Unificada V4 hoje:
- #889/#904/#909 (topnav cleanup + hideTopbar)
- #911/#912 (Wave 1+2: atalhos + tabs)
- #914/#915/#917/#918 (polimentos OKLCH)
- #920/#921 (Wave 3-A+B: sidebar actions)
- #922/#925 (Wave 4-A+B: mídia + áudio + interactive)
- #923/#924 (Wave 5+5-B: filtros power-user)
- #913 (protótipo Cowork V4 + US-WA-301..307 spec)
- ESTE PR (cutover)

🤖 Generated with [Claude Code](https://claude.com/claude-code)