### PR TITLE
feat(whatsapp): CustomerMemoryBlock no ContextSidebarV4 (cutover-safe)

### DIFF
--- a/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/Index.charter.md
@@ -254,3 +254,4 @@ Após Wagner aprovar canary 7d:
 | Data | Autor | Mudança |
 |---|---|---|
 | 2026-05-15 | Wagner + Opus 4.7 (Agente D wave fix) | Charter inicial. Implementação F3-F5 do RUNBOOK `cowork-prototype-replication` ADR 0114. Fonte canônica `prototipo-ui/prototipos/caixa-unificada/inbox-page.jsx` (802 LOC Cowork). Coexiste com `/atendimento/inbox` legacy durante canary 7d. Próximo gate: Wagner aprovar SCREENSHOT manual rodando localhost antes de canary começar. |
+| 2026-05-15 | Wagner + Opus 4.7 | Adicionado `<CustomerMemoryBlock>` (US-WA-VOZ-001/002/003 — PR #919) no topo do `ContextSidebarV4`. Lazy fetch `GET /atendimento/customer/{ext}/profile`. Mostra identidade Contact CRM, stats agregados, top 3 reclamações 30d com severity, external_sources Firebird, flags VIP/frágil, LGPD. Mesmo componente usado pelo Inbox legacy (`ConversationSidebar.tsx`) — atendente vê Customer 360 em qualquer tela durante cutover. |

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ContextSidebarV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ContextSidebarV4.tsx
@@ -25,6 +25,7 @@ import {
   PopoverTrigger,
 } from '@/Components/ui/popover';
 import ContactPickerModal from '@/Pages/Whatsapp/_components/ContactPickerModal';
+import CustomerMemoryBlock from '@/Pages/Whatsapp/_components/CustomerMemoryBlock';
 import type {
   CaixaUnifThread,
   ChannelCatalogItem,
@@ -115,6 +116,15 @@ export default function ContextSidebarV4({ thread, channels, queues, availableTa
       </div>
 
       <div className="flex-1 overflow-auto px-4 py-3 flex flex-col gap-2.5">
+        {/* US-WA-VOZ-001/002/003 — Customer Memory block (perfil persistente cliente).
+            Renderiza no topo do contexto. Lazy fetch client-side via endpoint
+            /atendimento/customer/{ext}/profile — não bloqueia abertura nem polling 5s.
+            Mostra identidade Contact CRM, stats, reclamações 30d (heurística),
+            external_sources Firebird OfficeImpresso, flags VIP/frágil, LGPD. */}
+        {thread.customer_external_id && (
+          <CustomerMemoryBlock customerExternalId={thread.customer_external_id} />
+        )}
+
         {/* 1. Fila */}
         <div className="pb-2.5 border-b border-border/50 flex flex-col gap-0.5">
           <small className="text-[9.5px] uppercase tracking-[0.06em] text-muted-foreground font-semibold">


### PR DESCRIPTION
## Summary

Continuação direta do PR #919 (mergeado). Adiciona o `<CustomerMemoryBlock>` na sidebar canônica pós-cutover (Caixa Unificada V4).

**Por que:** Inbox legacy (`/atendimento/inbox`) foi marcada `lifecycle: historical` 2026-05-15 e redireciona 301 → `/atendimento/caixa-unificada`. Sem este PR, o Customer 360 só aparecia no componente legacy (`ConversationSidebar.tsx`) — sumiria pro atendente quando Inbox legacy for removido em 1 sprint.

## Mudança

- **`ContextSidebarV4.tsx`** importa e renderiza `<CustomerMemoryBlock>` no topo (acima das 9 sections existentes: Fila/Atribuído/Canal/Tags/etc)
- **Charter `CaixaUnificada/Index.charter.md`** entry histórico atualizado
- Reusa o componente já existente — 0 lógica nova
- Lazy fetch client-side (não bloqueia abertura conv nem polling 5s)
- Tier 0 preservado (endpoint resolve business_id via session)

## Testing

- ✅ Componente já testado pelo merge anterior (PR #919)
- ✅ Backend `GET /atendimento/customer/{ext}/profile` rodando prod biz=1 (338 customer_memory rows backfilled)
- ⏳ Smoke visual local Wagner — após mergear, abrir `/atendimento/caixa-unificada` e clicar conversa

## Resultado esperado

Atendente abre conversa em /atendimento/caixa-unificada → sidebar direita mostra Customer 360 (mesma UX que estava só no Inbox legacy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)