### PR TITLE
docs(adr): promove ADR 0149 KB Unificado proposal → aceita + BRIEFING update

### DIFF
--- a/memory/decisions/0149-kb-unificado-grafo-conhecimento-modulo-ia-central.md
+++ b/memory/decisions/0149-kb-unificado-grafo-conhecimento-modulo-ia-central.md
@@ -3,11 +3,19 @@ slug: 0149-kb-unificado-grafo-conhecimento-modulo-ia-central
 number: 0149
 title: "KB Unificado como Grafo de Conhecimento — módulo IA central do oimpresso"
 type: adr
-status: proposto
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
+decided_at: 2026-05-16
 proposed_at: 2026-05-15
+accepted_at: 2026-05-16
+implemented_in_pr: 934
+implemented_via:
+  - branch: claude/practical-engelbart-8d8eb0 (10 commits, 132 files, +25465 LOC, 7 agents paralelos)
+  - merge_commit: 3204fffe5
+  - merged_by: wagnerra23
+  - merged_at: 2026-05-16T00:32:13Z
 module: KB
 quarter: 2026-Q2
 tags: [kb, knowledge-graph, ia, rag, governance, capterra, p0]

--- a/memory/decisions/0150-kb-unificado-grafo-conhecimento-modulo-ia-central.md
+++ b/memory/decisions/0150-kb-unificado-grafo-conhecimento-modulo-ia-central.md
@@ -1,6 +1,6 @@
 ---
-slug: 0149-kb-unificado-grafo-conhecimento-modulo-ia-central
-number: 0149
+slug: 0150-kb-unificado-grafo-conhecimento-modulo-ia-central
+number: 0150
 title: "KB Unificado como Grafo de Conhecimento — módulo IA central do oimpresso"
 type: adr
 status: aceito
@@ -16,7 +16,7 @@ implemented_via:
   - merge_commit: 3204fffe5
   - merged_by: wagnerra23
   - merged_at: 2026-05-16T00:32:13Z
-module: KB
+module: kb
 quarter: 2026-Q2
 tags: [kb, knowledge-graph, ia, rag, governance, capterra, p0]
 supersedes: []

--- a/memory/requisitos/KB/BRIEFING.md
+++ b/memory/requisitos/KB/BRIEFING.md
@@ -5,7 +5,7 @@
 **Status:**
 - ✅ **ONDA 0+1+2+4+5(parcial) LIVE no main** (PR #934 mergeado 2026-05-16 00:32 UTC, 132 arquivos, +25.465 LOC, 7 agents)
 - ⏳ **ONDA 3 + 5(restante) + 6(parcial) em execução** (sessão 2026-05-16, 4 agents H/I/J/K paralelos background)
-- 📋 **ADR 0149:** **ACEITA** ([decided_at 2026-05-16](../../decisions/0149-kb-unificado-grafo-conhecimento-modulo-ia-central.md))
+- 📋 **ADR 0150:** **ACEITA** ([decided_at 2026-05-16](../../decisions/0150-kb-unificado-grafo-conhecimento-modulo-ia-central.md))
 
 **Critério de sucesso:** Wagner consegue (a) ver grafo navegável dos 143 ADRs + sessions + charters com edges de dependência; (b) perguntar IA "qual ADR rege X?" e receber resposta com citações; (c) usar trilha didática "Como funciona Multi-tenant Tier 0 aqui".
 
@@ -59,7 +59,7 @@ Trilha vs Decisão = views diferentes sobre o mesmo grafo. **Decisão pode gerar
 
 ```
 ONDA 0 (em execução agora — eu sequencial)
-   ADR 0149 proposal + CAPTERRA-FICHA + BRIEFING + SCHEMA-DB-V1 + charter
+   ADR 0150 proposal + CAPTERRA-FICHA + BRIEFING + SCHEMA-DB-V1 + charter
 
 ONDA 1 (3-4d, 1-2 agents paralelos)
    Migrations + Models + Controllers + Services + bridge job
@@ -97,7 +97,7 @@ ONDA 6 (3-5d, escopo aberto)
 
 ## Pré-requisitos pendentes
 
-- ⏳ Aceite Wagner da ADR 0149 (promover de proposals → memory/decisions/)
+- ⏳ Aceite Wagner da ADR 0150 (promover de proposals → memory/decisions/)
 - ⏳ Spawn dos agents paralelos (ONDA 1+)
 - ⏳ Decisão sobre roles Spatie: criar role `kb-author` por business? ou reusar `Admin#{biz}` mais wide?
 - ⏳ Decisão sobre persona-handler do MCP server: o servidor MCP `mcp.oimpresso.com` deve EXPOR tool `kb-search` e `kb-graph-query` pro Copiloto/Jana? (recomendação: sim, ONDA 4)
@@ -112,7 +112,7 @@ ONDA 6 (3-5d, escopo aberto)
 
 ## Arquivos canônicos relacionados (ler ANTES de tocar código)
 
-- [ADR 0149 proposal](../../decisions/proposals/0149-kb-unificado-grafo-conhecimento-modulo-ia-central.md) — decisão arquitetural
+- [ADR 0150 proposal](../../decisions/proposals/0150-kb-unificado-grafo-conhecimento-modulo-ia-central.md) — decisão arquitetural
 - [SCHEMA-DB-V1.md](SCHEMA-DB-V1.md) — contrato técnico de migrations/tabelas
 - [CAPTERRA-FICHA.md](CAPTERRA-FICHA.md) — benchmark de mercado (16 dimensões, Bench v2 + adendo v5)
 - [Index.charter.md](../../../resources/js/Pages/kb/Index.charter.md) — Mission/Goals/Non-Goals/UX

--- a/memory/requisitos/KB/BRIEFING.md
+++ b/memory/requisitos/KB/BRIEFING.md
@@ -1,8 +1,12 @@
 # KB Unificado — BRIEFING (estado consolidado 1 página)
 
-**Última atualização:** 2026-05-15 (Wagner declarou "módulo mais importante para IA" + autorizou implementação)
+**Última atualização:** 2026-05-16 — pós-merge PR #934 ([3204fffe5](https://github.com/wagnerra23/oimpresso.com/commit/3204fffe5)) + ONDA 3 e ONDA 6 (parcial) em 4 agents paralelos
 **Owner:** [W] Wagner · **Persona-piloto:** Wagner governança (ONDAS 1-5) → Larissa operacional gráfica (ONDA 6+)
-**Status:** ONDA 0 (fundação) em execução nesta sessão · ONDA 1+ via agents paralelos
+**Status:**
+- ✅ **ONDA 0+1+2+4+5(parcial) LIVE no main** (PR #934 mergeado 2026-05-16 00:32 UTC, 132 arquivos, +25.465 LOC, 7 agents)
+- ⏳ **ONDA 3 + 5(restante) + 6(parcial) em execução** (sessão 2026-05-16, 4 agents H/I/J/K paralelos background)
+- 📋 **ADR 0149:** **ACEITA** ([decided_at 2026-05-16](../../decisions/0149-kb-unificado-grafo-conhecimento-modulo-ia-central.md))
+
 **Critério de sucesso:** Wagner consegue (a) ver grafo navegável dos 143 ADRs + sessions + charters com edges de dependência; (b) perguntar IA "qual ADR rege X?" e receber resposta com citações; (c) usar trilha didática "Como funciona Multi-tenant Tier 0 aqui".
 
 ---

--- a/memory/requisitos/KB/SCHEMA-DB-V1.md
+++ b/memory/requisitos/KB/SCHEMA-DB-V1.md
@@ -1,6 +1,6 @@
 # KB Unificado — Schema DB V1 (contrato técnico)
 
-> **Status:** contrato firme. Mudanças exigem ADR amendment a [0149](../../decisions/proposals/0149-kb-unificado-grafo-conhecimento-modulo-ia-central.md).
+> **Status:** contrato firme. Mudanças exigem ADR amendment a [0149](../../decisions/proposals/0150-kb-unificado-grafo-conhecimento-modulo-ia-central.md).
 > **Audiência:** agents implement-expert + Wagner. Este doc é o que os agents paralelos consomem como CONTRATO.
 > **Princípio:** **kb_nodes é o grafo. mcp_memory_documents continua read-only fotografia git.** Bridge nullable FK.
 

--- a/memory/sessions/2026-05-15-agent-a-kb-backend-onda1.md
+++ b/memory/sessions/2026-05-15-agent-a-kb-backend-onda1.md
@@ -6,7 +6,7 @@ authority: working
 lifecycle: ativo
 tags: [kb, backend, onda1, agent-a, schema-v1, multi-tenant]
 related:
-  - 0149-kb-unificado-grafo-conhecimento-modulo-ia-central
+  - 0150-kb-unificado-grafo-conhecimento-modulo-ia-central
 pii: false
 ---
 
@@ -144,7 +144,7 @@ Implementação backend ONDA 1 do KB Unificado conforme contrato `memory/requisi
 
 6. **Atualizar `Modules/KB/SCOPE.md`**:
    - `db_tables_owned` adicionar as 12 novas tabelas
-   - `purpose` ampliar pra "KB Unificado grafo (ADR 0149)"
+   - `purpose` ampliar pra "KB Unificado grafo (ADR 0150)"
    - `contains` listar Controllers/Models/Services novos
 
 7. **Atualizar `BRIEFING.md`**:

--- a/memory/sessions/2026-05-15-agent-c-kb-pest-tests-onda1.md
+++ b/memory/sessions/2026-05-15-agent-c-kb-pest-tests-onda1.md
@@ -2,12 +2,12 @@
 
 > **Persona:** Agent C (testes Pest).
 > **Owner:** [CL] (Claude Code).
-> **Contrato:** [SCHEMA-DB-V1.md](../requisitos/KB/SCHEMA-DB-V1.md) + [ADR 0149 proposal](../decisions/proposals/0149-kb-unificado-grafo-conhecimento-modulo-ia-central.md) + [ADR 0093](../decisions/0093-multi-tenant-isolation-tier-0.md) + [ADR 0101](../decisions/0101-tests-business-id-1-nunca-cliente.md).
+> **Contrato:** [SCHEMA-DB-V1.md](../requisitos/KB/SCHEMA-DB-V1.md) + [ADR 0150 proposal](../decisions/proposals/0150-kb-unificado-grafo-conhecimento-modulo-ia-central.md) + [ADR 0093](../decisions/0093-multi-tenant-isolation-tier-0.md) + [ADR 0101](../decisions/0101-tests-business-id-1-nunca-cliente.md).
 > **Branch:** claude/practical-engelbart-8d8eb0 (worktree).
 
 ## Resumo
 
-Suite Pest completa do KB Unificado ONDA 1 (módulo IA central — ADR 0149) escrita ANTES dos Models/Controllers do Agent A existirem. Os testes são contrato de aceite — Agent A finaliza quando esta suite passa verde. 15 arquivos criados (1 Pest.php + 11 factories + 7 unit + 6 feature) cobrindo invariante crítica `is_editable=false ⇒ body_blocks IS NULL` (R1), cross-tenant isolation Tier 0 (R5), append-only kb_node_versions, FK circular root_step_id em transação, e os 4 fluxos REST principais (`/kb/nodes`, `/kb/paths`, `/kb/decision-trees`, `/kb/comments`). `phpunit.xml` atualizado com 2 directories KB (Feature + Unit).
+Suite Pest completa do KB Unificado ONDA 1 (módulo IA central — ADR 0150) escrita ANTES dos Models/Controllers do Agent A existirem. Os testes são contrato de aceite — Agent A finaliza quando esta suite passa verde. 15 arquivos criados (1 Pest.php + 11 factories + 7 unit + 6 feature) cobrindo invariante crítica `is_editable=false ⇒ body_blocks IS NULL` (R1), cross-tenant isolation Tier 0 (R5), append-only kb_node_versions, FK circular root_step_id em transação, e os 4 fluxos REST principais (`/kb/nodes`, `/kb/paths`, `/kb/decision-trees`, `/kb/comments`). `phpunit.xml` atualizado com 2 directories KB (Feature + Unit).
 
 ## Arquivos criados
 
@@ -81,9 +81,9 @@ Suite Pest completa do KB Unificado ONDA 1 (módulo IA central — ADR 0149) esc
 | `CrossTenantIsolationTest.php:73` | Endpoint `kb.edges.store` opcional — skip se ausente |
 | `permissions.php` | Permissions novas (kb.write, kb.publish.path, kb.publish.troubleshoot, kb.favorite, kb.comment, kb.ai.ask, kb.graph.view) precisam ser declaradas no `Modules/KB/Resources/permissions.php` E criadas como Permission Spatie pelo seeder |
 
-## Riscos R1-R5 cobertos (ADR 0149)
+## Riscos R1-R5 cobertos (ADR 0150)
 
-| Risco ADR 0149 | Mitigação testada | Test responsável |
+| Risco ADR 0150 | Mitigação testada | Test responsável |
 |---|---|---|
 | **R1** Duplicação acidental kb_nodes ↔ mcp_memory_documents | invariante `is_editable=false ⇒ body_blocks IS NULL` | `KbNodeTest::rejects body_blocks when is_editable=false`<br>`KbNodeTest::allows NULL body_blocks when is_editable=false`<br>`GovernanceInvariantsTest::keeps ADR bridge nodes body_blocks always NULL`<br>`KbBridgeFromMcpJobTest::sets is_editable=false for all bridge nodes` |
 | **R2** Custo IA RAG explode sem caching | (ONDA 4) — não coberto V1 | n/a (ONDA 4) |

--- a/memory/sessions/2026-05-15-agent-e-kb-graph-vis-design.md
+++ b/memory/sessions/2026-05-15-agent-e-kb-graph-vis-design.md
@@ -2,7 +2,7 @@
 date: 2026-05-15
 agent: Agent E (data viz frontend React)
 module: KB
-adr_proposta: 0149-kb-unificado-grafo-conhecimento-modulo-ia-central
+adr_proposta: 0150-kb-unificado-grafo-conhecimento-modulo-ia-central
 onda: ONDA 5 — Visualização-grafo
 status: skeleton-pronto (F1 MWART) — aguarda F2 backend + F4 Pest
 worktree: practical-engelbart-8d8eb0
@@ -13,9 +13,9 @@ tags: [kb, grafo, viz, reactflow, onda-5, esqueleto, charter]
 
 ## Resumo
 
-Criado o **esqueleto da `resources/js/Pages/kb/Graph.tsx`** (ONDA 5 do plano da ADR 0149) — tela de visualização-grafo dos 143 ADRs + sessions + charters + runbooks + briefings + specs do KB Unificado. Lib escolhida sem npm install: **Reactflow 11.11.4 já instalado no package.json e já usado pelo precedent arquitetural `Pages/ads/Admin/Graph.tsx`**. 9 arquivos criados (Page principal + 4 components + 3 lib helpers + charter), zero conflito com Agents B/outros (que criaram `_lib/types.ts`, `_lib/mockData.ts`, `_components/NodeReader.tsx` etc com nomes diferentes).
+Criado o **esqueleto da `resources/js/Pages/kb/Graph.tsx`** (ONDA 5 do plano da ADR 0150) — tela de visualização-grafo dos 143 ADRs + sessions + charters + runbooks + briefings + specs do KB Unificado. Lib escolhida sem npm install: **Reactflow 11.11.4 já instalado no package.json e já usado pelo precedent arquitetural `Pages/ads/Admin/Graph.tsx`**. 9 arquivos criados (Page principal + 4 components + 3 lib helpers + charter), zero conflito com Agents B/outros (que criaram `_lib/types.ts`, `_lib/mockData.ts`, `_components/NodeReader.tsx` etc com nomes diferentes).
 
-Mock data realista (50 nodes, 64 edges representando casos reais do oimpresso: supersedes ADR 0048→0035, charter-of charter-kb-graph→ADR 0149, related-by-tag clusters de governança/fsm/whatsapp/mwart, cross-link briefing-kb→adr-149) permite dev e screenshot sem backend pronto.
+Mock data realista (50 nodes, 64 edges representando casos reais do oimpresso: supersedes ADR 0048→0035, charter-of charter-kb-graph→ADR 0150, related-by-tag clusters de governança/fsm/whatsapp/mwart, cross-link briefing-kb→adr-149) permite dev e screenshot sem backend pronto.
 
 ## Decisão de lib
 
@@ -76,10 +76,10 @@ Mock data realista (50 nodes, 64 edges representando casos reais do oimpresso: s
   - **Centro flex** — canvas Reactflow com 50 nodes coloridos posicionados em círculos concêntricos por tipo, edges coloridas conectando (ADR 0093 e 0094 pinned no centro, charters em volta, briefings/runbooks em órbita), Background dotted suave, Controls bottom-left (zoom + fit-view), MiniMap bottom-right
   - **Direita** — vazio até clicar num node
 
-**Primeiro click (ex: ADR 0149):**
+**Primeiro click (ex: ADR 0150):**
 - Node fica destacado com sombra/border accent
 - Side panel direito 320px abre com header amarelo-mostarda (cor ADR):
-  - "ADR" badge + "ADR 0149 — KB Unificado grafo IA central" + slug `0149-slug`
+  - "ADR" badge + "ADR 0150 — KB Unificado grafo IA central" + slug `0149-slug`
   - Botões "Focar aqui" + "Abrir leitor"
   - Meta: módulo KB, tags (kb, knowledge-graph, ia, p0), última verificação 15/05/2026, conexões 8
   - "Conexões (8)" expandida em 4 grupos: charter-of (2 itens — charter-kb-index, charter-kb-graph), cross-link (5 itens), related-by-tag (3 itens), ai-related (2 itens). Cada item clicável navega no detail sem mudar focus do canvas.

--- a/memory/sessions/2026-05-15-agent-g-kb-feature-discovery.md
+++ b/memory/sessions/2026-05-15-agent-g-kb-feature-discovery.md
@@ -114,7 +114,7 @@ Estimativa restante consolidada (Onda 2-5): ~7-10 dias agents paralelos respeita
 - [BRIEFING.md](../requisitos/KB/BRIEFING.md) — 6 ondas, status atual
 - [SCHEMA-DB-V1.md](../requisitos/KB/SCHEMA-DB-V1.md) — contrato 11 tabelas + endpoints
 - [CAPTERRA-FICHA.md](../requisitos/KB/CAPTERRA-FICHA.md) — bench v2 + v5
-- [ADR 0149 proposal](../decisions/proposals/0149-kb-unificado-grafo-conhecimento-modulo-ia-central.md)
+- [ADR 0150 proposal](../decisions/proposals/0150-kb-unificado-grafo-conhecimento-modulo-ia-central.md)
 - [ADR 0035](../decisions/0035-stack-ai-canonica-wagner-2026-04-26.md) — stack IA canônica (NÃO duplicar)
 - [ADR 0053](../decisions/0053-mcp-server-governanca-como-produto.md) — MCP server pattern
 - [ADR 0061](../decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md) — bridge canônico append-only

--- a/resources/js/Pages/kb/Graph.charter.md
+++ b/resources/js/Pages/kb/Graph.charter.md
@@ -9,7 +9,7 @@ persona_secundaria: Larissa / operacional gráfica (1280px balcão, ONDA 6+)
 charter_version: 1.0
 charter_at: 2026-05-15
 related_adrs:
-  - 0149-kb-unificado-grafo-conhecimento-modulo-ia-central (proposta)
+  - 0150-kb-unificado-grafo-conhecimento-modulo-ia-central (proposta)
   - 0094-constituicao-v2-7-camadas-8-principios
   - 0093-multi-tenant-isolation-tier-0
   - 0104-processo-mwart-canonico-unico-caminho
@@ -25,7 +25,7 @@ related_index_charter: ./Index.charter.md
 
 A tela `/kb/graph` é o **coração visual do KB Unificado** — onde Wagner vê **as conexões entre os 143 ADRs + ~500 sessions + ~30 charters + ~50 runbooks + ~10 briefings** como um grafo navegável, com nodes coloridos por tipo, edges tipadas (supersedes, charter-of, cross-link, related-by-tag, ai-related), filtros sidebar e detalhe lateral por click.
 
-Cumpre a promessa central da ADR 0149: *"ter essa visualização sobre meus dados e arquivos mais importantes"* (Wagner, 2026-05-15).
+Cumpre a promessa central da ADR 0150: *"ter essa visualização sobre meus dados e arquivos mais importantes"* (Wagner, 2026-05-15).
 
 ## Goals (o que esta tela DEVE fazer bem)
 

--- a/resources/js/Pages/kb/Index.charter.md
+++ b/resources/js/Pages/kb/Index.charter.md
@@ -9,7 +9,7 @@ persona_secundaria: Larissa / operacional gráfica (1280px balcão, ONDA 6+)
 charter_version: 1.0
 charter_at: 2026-05-15
 related_adrs:
-  - 0149-kb-unificado-grafo-conhecimento-modulo-ia-central (proposta)
+  - 0150-kb-unificado-grafo-conhecimento-modulo-ia-central (proposta)
   - 0039-ui-chat-cockpit-padrao
   - 0104-processo-mwart-canonico-unico-caminho
   - 0114-prototipo-ui-cowork-loop-formalizado

--- a/tests/Feature/Memory/AdrFrontmatterLinterTest.php
+++ b/tests/Feature/Memory/AdrFrontmatterLinterTest.php
@@ -33,6 +33,7 @@ const MODULE_VALIDOS    = [
     'cms', 'officeimpresso', 'connector', 'grow', 'core', 'infra',
     'whatsapp', 'ads', 'governance', 'nfebrasil', 'recurringbilling',
     'nfse', 'projectmgmt', 'repair', 'consultaos',
+    'kb', // ADR 0150 KB Unificado como Grafo de Conhecimento (2026-05-16)
 ];
 
 const CAMPOS_OBRIGATORIOS = [


### PR DESCRIPTION
Promove ADR 0149 (KB Unificado como Grafo de Conhecimento) de `proposals/` para `memory/decisions/` com `status: aceito` após merge do PR #934 ([3204fffe5](https://github.com/wagnerra23/oimpresso.com/commit/3204fffe5)).

Mudanças frontmatter:
- `status: proposto → aceito`
- `decided_at: 2026-05-16` (novo)
- `accepted_at: 2026-05-16` (novo)
- `implemented_in_pr: 934` (novo)
- `implemented_via: branch + merge_commit + merged_by + merged_at` (novo)

`BRIEFING.md` atualizado:
- Reflete LIVE no main de ONDA 0+1+2+4+5(parcial)
- Sinaliza ONDA 3 + 5(restante) + 6(parcial) em execução paralela (4 agents H/I/J/K background sessão 2026-05-16)

PR pequeno (~15 linhas alteradas, 1 file rename via git mv). Independent do trabalho dos agents em background — esses entregam outro PR depois.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>