### PR TITLE
feat(jana): ConvSidePanel — header+search+tabs+badge unread (port Cowork chat.jsx layout-only)

### DIFF
--- a/memory/requisitos/Jana/Chat-visual-comparison.md
+++ b/memory/requisitos/Jana/Chat-visual-comparison.md
@@ -1,0 +1,169 @@
+---
+slug: jana-chat-visual-comparison
+title: "Jana/Chat — visual comparison (gate F1.5 layout-only)"
+type: visual-comparison
+module: Jana
+status: approved
+target_page: resources/js/Pages/Jana/Chat.tsx
+target_charter: resources/js/Pages/Jana/Chat.charter.md
+visual_source: memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/chat.jsx
+visual_source_html: memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/Oimpresso ERP - Chat.html
+related_adrs: [0094, 0104, 0107, 0110, 0114]
+date: 2026-05-15
+session: gifted-raman-ce3c6b
+escopo: layout-only (Wagner aprovou 2026-05-15)
+aprovacoes:
+  - escopo: 2026-05-15 via AskUserQuestion "Layout-only no Pages/Jana/Chat.tsx (Recomendado)"
+  - decisoes_4: 2026-05-15 via AskUserQuestion → labels Charter / mostrar todas tabs / client-side search / badge unread sim (bind ⌘K não)
+---
+
+# Chat.tsx — Visual Comparison F1.5
+
+> **Gate canônico** ADR 0107 + ADR 0114 antes de Edit/Write em Page. Wagner pediu *"implementar Oimpresso ERP - Chat.html"*; depois clarificou (em UI question) `Layout-only no Pages/Jana/Chat.tsx` preservando semântica Jana IA do charter.
+
+## TL;DR
+
+A tela **já está live** em `/copiloto` (URL legacy, módulo `Pages/Jana/Chat.tsx`). Thread+composer são delegados a `JanaAssistantUiChat` (lib `assistant-ui`) — **NÃO entram no escopo**. O delta visual está restrito à coluna esquerda (`ConvSidePanel`), que hoje é minimal (sb-action + sb-section-h + sb-conv bullet) e o protótipo Cowork tem rica (header + search + 4 tabs + ConvItem com avatar/preview/badge).
+
+Como `ConversaResumo` (backend) hoje só expõe `id/titulo/unread/origem/ativa`, **avatar/preview/badge ficam fora** (exigiriam migration + ADR de schema — proibido em "layout-only"). Entregamos os enriquecimentos que **não dependem de backend**: header, search local (filtra `titulo` client-side), tabs filtro com **labels do charter** (Todas/Minhas/Compartilhadas/Arquivadas — NÃO os do Cowork OS/Equipes/Clientes que conflitam com Charter §Goals).
+
+## Comparáveis canônicos (Charter §15 — mwart-comparative V4)
+
+- **Linear Inbox** (densidade thread + atalhos J/K) — referência principal mantida
+- **Front conversation view** — referência pra `data_table`/`action_card`
+- **ChatGPT** — só streaming/composer (bubble grande = anti-pattern aqui)
+
+Cowork `chat.jsx` adiciona **header + search + tabs** úteis ao Charter; outras peças (ConvItem rico, file attachment ✓✓, "Recebido, vou verificar 👍" auto-reply mockada) são **Non-Goals explícitos** do charter ou exigem schema novo.
+
+## 15 dimensões (Cowork chat.jsx ↔ Pages/Jana/Chat.tsx atual ↔ alvo proposto)
+
+| # | Dimensão | Cowork chat.jsx | Chat.tsx atual | Alvo proposto (layout-only) | Veredito |
+|---|---|---|---|---|---|
+| 1 | **Layout master/detail** | `.app` grid sidebar+thread | `copiloto-chat-layout` grid 320/1fr | Mantém | ✅ paridade |
+| 2 | **Header da lista** | `<h2>Chat</h2>` + filter btn + nova conv btn | sb-actions verticais ("Nova conversa" linha inteira) | Adiciona barra `<header>` topo c/ título "Chat" + 2 icon-buttons à direita | 🟡 add |
+| 3 | **Search input** | `<input>` + `⌘K` kbd hint | ausente | Adiciona search controlado, filtra `titulo` client-side (case-insensitive) | 🟡 add |
+| 4 | **Tabs/filtros** | 4 pills (Todas/OS/Equipes/Clientes) | apenas separadores "Fixadas"/"Recentes" | 4 pills **labels do Charter** (Todas/Minhas/Compartilhadas/Arquivadas). Filtro client-side só "Todas" funcional hoje (resto vira UI gating até backend expor flag) | 🟡 add charter-compliant |
+| 5 | **Conv item — avatar** | `.av` + gradient determinístico + dot online | bullet 10px só | **Fora do escopo** (backend não expõe avatar/online) | ❌ defer |
+| 6 | **Conv item — preview/snippet** | última msg em `<div class="preview">` | só título | **Fora do escopo** (backend não retorna `preview`) | ❌ defer |
+| 7 | **Conv item — tag tipo** | `.tag.os` / `.tag.eq` (OS/Equipe/Cliente) | ausente | **Fora do escopo** (Charter Non-Goal: tipos OS/Equipe são chat humano-humano, não Jana IA) | ❌ skip (anti-charter) |
+| 8 | **Conv item — unread badge** | `<span class="badge">` número | já existe (`unread`) mas não renderizado no `sb-conv` | Adiciona pequena badge ao lado direito do `sb-conv-t` quando `unread > 0` | 🟡 add (backend já expõe) |
+| 9 | **Pinned vs Recentes** | grupos com `.list-group-h` "Fixadas"/"Recentes" | `sb-section-h` "Fixadas"/"Recentes" | Mantém | ✅ paridade |
+| 10 | **Thread header** | `.th-head` avatar+nome+dot+actions | `ThreadHeader` do `@/Components/cockpit/Thread` (cobre tudo) | Mantém — fora do escopo | ✅ paridade |
+| 11 | **Composer** | textarea auto-grow + toolbar + send | `JanaAssistantUiChat` (lib assistant-ui) | Mantém — Charter exige Brain B streaming, não o composer mock do Cowork | ✅ charter-compliant |
+| 12 | **Bubble assistant** | "them" simples (texto + ✓✓) | `JanaAssistantUiChat` (markdown + code highlight via assistant-ui) | Mantém | ✅ richer-than-cowork |
+| 13 | **Empty state** | `.empty` "Selecione uma conversa" + `⌘K` hint | tela vai direto pra conversa ativa (não tem empty state) | **Fora do escopo** — fluxo Inertia sempre tem conversa default | ✅ N/A |
+| 14 | **Atalhos teclado** | `⌘K` hint visual | `⌘N` em `sb-action` Nova conversa | Mantém `⌘N`, adiciona `⌘K` visual no search (sem binding ainda — backlog do Charter §UX Targets) | 🟡 add visual |
+| 15 | **CSS scope** | global `:root`+`body` em styles.css 120KB | escopado `.cockpit{}` em cockpit.css + Tailwind utilities (ADR 0110) | Tailwind utilities inline + classes existentes (`sb-*`, `kbd`) — **zero novo CSS global** | ✅ ADR 0110 |
+
+## Delta concreto (diff plan)
+
+**Arquivos tocados (1):** `resources/js/Pages/Jana/Chat.tsx`
+
+**Linhas afetadas:** ~80 (substitui `ConvSidePanel` interno por versão com header+search+tabs+filter; mantém props/types existentes).
+
+**Pseudo-diff:**
+
+```diff
+ function ConvSidePanel({ fixadas, recentes, activeConvId, onSelectConv }: { ... }) {
++  const [query, setQuery] = useState('');
++  const [tab, setTab] = useState<'todas'|'minhas'|'compartilhadas'|'arquivadas'>('todas');
++
++  const norm = (s: string) => s.toLowerCase().normalize('NFD').replace(/\p{Diacritic}/gu, '');
++  const matchQ = (c: ConversaResumo) => !query.trim() || norm(c.titulo).includes(norm(query.trim()));
++  const filteredFixadas = fixadas.filter(matchQ);
++  const filteredRecentes = recentes.filter(matchQ);
++
+   return (
+     <aside className="copiloto-chat-convs">
++      <header className="cs-head"><h2>Chat</h2><button .../><button .../></header>
++      <div className="cs-search">
++        <Search size={12}/><input value={query} onChange={...} placeholder="Buscar conversas..."/>
++        <span className="kbd">⌘K</span>
++      </div>
++      <div className="cs-tabs">
++        {TABS.map(t => <button className={cls('cs-tab', tab===t.id && 'active')} ...>{t.label}</button>)}
++      </div>
+
+       <div className="sb-actions">
+         <a href="/jana/conversas/nova" className="sb-action">…</a>
+         …
+       </div>
+
+       <div className="sb-section-h">Fixadas</div>
+-      {fixadas.map(c => …)}
++      {filteredFixadas.map(c => <SbConvItem c={c} active={…} onSelect={…} />)}
+       <div className="sb-section-h">Recentes</div>
+-      {recentes.map(c => …)}
++      {filteredRecentes.map(c => <SbConvItem c={c} active={…} onSelect={…} />)}
+     </aside>
+   );
+ }
+
++function SbConvItem({ c, active, onSelect }: { c: ConversaResumo; active: boolean; onSelect: (id: string) => void }) {
++  return (
++    <div className={cls('sb-conv', active && 'active')} onClick={() => onSelect(c.id)}>
++      <span className={cls('sb-bullet', c.unread && 'filled')}/>
++      <span className="sb-conv-t">{c.titulo}</span>
++      {c.unread ? <span className="sb-conv-badge">{c.unread}</span> : null}
++    </div>
++  );
++}
+```
+
+## Classes CSS
+
+- ✅ **Reusa existentes** em `resources/css/cockpit.css`: `.sb-actions`, `.sb-action`, `.sb-section-h`, `.sb-conv`, `.sb-bullet`, `.kbd`, `.beta`, `.copiloto-chat-convs`
+- 🟡 **Adiciona** (mínimo, escopados em `.cockpit .copiloto-chat-convs`):
+  - `.cs-head` — header com título + 2 icon-btn
+  - `.cs-search` — wrap pro input + `Search` icon + `⌘K` kbd
+  - `.cs-tabs` / `.cs-tab` / `.cs-tab.active` — 4 pills inline
+  - `.sb-conv-badge` — badge unread minúscula ao lado direito (`bg-primary text-primary-foreground` mas via CSS pra não brigar com tema)
+- ❌ **Não importa** styles.css do Cowork (escopo global vs `.cockpit{}` — ADR `_DS UI-0012` repo vence)
+
+## Pest GUARD (charter §Métricas vivas — escopo desta PR)
+
+Charter lista 13 testes (`JanaChatCharterTest.php`). Em "layout-only" entra subset que toca lista de conversas:
+
+```php
+it('renders search input in ConvSidePanel')                 // novo
+it('renders 4 filter tabs (Todas/Minhas/Compartilhadas/Arquivadas)')  // novo
+it('filters conv list by titulo (case+accent-insensitive) on query input')  // novo
+it('uses localStorage prefix oimpresso.jana.* (never sessionStorage)')  // charter
+it('renders at 1280px without horizontal scroll')           // charter
+it('isolates threads by business_id')                       // charter (pré-existente — não regrede)
+```
+
+Demais testes (`first-paint`, `streaming token`, `auto-scroll pause`, `PII sanitizer`) ficam pra PR seguinte (composer/thread já são delegados a `JanaAssistantUiChat`, fora do escopo).
+
+## Anti-padrões F3 Financeiro evitados explicitamente
+
+Conferindo contra [`prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md`](../../../prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md):
+
+| Anti-padrão | Aplicabilidade aqui | Como evitado |
+|---|---|---|
+| M-AP-1 (auto-doc ignorada) | Sim | Li Chat.charter.md + RUNBOOK-chat.md + ConversaResumo type + Thread.tsx (callsite CHAT_TABS) ANTES |
+| M-AP-2 (marketing > realidade) | Sim | PR title vai ser `feat(jana): ConvSidePanel — header+search+tabs (layout-only, charter §Goals)` — não "Chat F3 completo" |
+| M-AP-3 (aceitação tácita = aprovação) | Sim | Wagner aprovou OPÇÃO 1 ("Layout-only"); este doc é o F1.5 gate; aguarda go-ahead explícito antes de Edit |
+| M-AP-4 (schema fantasma) | Sim | `ConversaResumo` mantido intacto; sem migration; campos avatar/preview/tag ficam `❌ defer` |
+| T-AP (middleware/Models fantasma) | N/A | Sem mudança backend |
+| T-AP (regressão fix em prod) | Sim | Chat.tsx vai ser tocado por DIFF cirúrgico — `JanaAssistantUiChat`, `ThreadHeader`, `PropostaCard`, props/types **intocados** |
+
+## Decisões pendentes pra Wagner aprovar (antes de Edit)
+
+1. ✅ **Escopo confirmado** (UI question 2026-05-15): "Layout-only no Pages/Jana/Chat.tsx"
+2. ⏳ **Labels dos 4 tabs**: Charter diz `Todas/Minhas/Compartilhadas/Arquivadas` — confirma?
+3. ⏳ **Funcionalidade dos tabs hoje**: só "Todas" filtra (resto é UI gating até backend expor `compartilhada`/`arquivada` em `ConversaResumo`). OK ou prefere esconder os 3 não-funcionais até backend?
+4. ⏳ **Search**: filtra `titulo` client-side (não chama `/jana/conversas?q=`). OK ou quer roundtrip backend?
+5. ⏳ **`⌘K` binding teclado**: charter pede focus composer com `/`; `⌘K` no search é só visual (sem binding nesta PR). OK?
+6. ⏳ **Unread badge no `.sb-conv`**: pequena badge à direita quando `unread > 0`. Aprovado?
+
+## Refs
+
+- [Chat.charter.md (LIVE v1)](../../../resources/js/Pages/Jana/Chat.charter.md)
+- [RUNBOOK-chat.md](RUNBOOK-chat.md)
+- [Cowork chat.jsx (visual source)](../_DesignSystem/ui_kits/cowork-2026-05-09/chat.jsx)
+- [ADR 0107 — visual gate F1.5](../../decisions/0107-emendation-0104-visual-comparison-gate-f3.md)
+- [ADR 0114 — loop Cowork formalizado](../../decisions/0114-prototipo-ui-cowork-loop-formalizado.md)
+- [ADR 0110 — Cockpit Pattern V2](../../decisions/0110-cockpit-pattern-v2-canon-list-detail.md)
+- [ADR 0094 — Constituição v2](../../decisions/0094-constituicao-v2-7-camadas-8-principios.md)
+- [LICOES_F3_FINANCEIRO_REJEITADO.md (anti-padrões)](../../../prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md)

--- a/resources/css/cockpit.css
+++ b/resources/css/cockpit.css
@@ -1509,6 +1509,168 @@
   .cockpit .copiloto-chat-convs { display: none; }
 }
 
+/* ConvSidePanel header (Chat title + filtros + nova conv)
+   Cowork chat.jsx visual port — gate F1.5 Chat-visual-comparison.md.
+   Escopo cirúrgico em .copiloto-chat-convs (não polui outros chats). */
+.cockpit .copiloto-chat-convs .cs-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 4px 8px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 8px;
+}
+.cockpit .copiloto-chat-convs .cs-head h2 {
+  flex: 1 1 auto;
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: -0.01em;
+}
+.cockpit .copiloto-chat-convs .cs-iconbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--text-mute);
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.cockpit .copiloto-chat-convs .cs-iconbtn:hover {
+  background: var(--sb-hover);
+  color: var(--text);
+  border-color: var(--border);
+}
+.cockpit .copiloto-chat-convs .cs-iconbtn.primary {
+  background: var(--accent, oklch(0.62 0.18 250));
+  color: var(--accent-fg, #fff);
+  border-color: transparent;
+}
+.cockpit .copiloto-chat-convs .cs-iconbtn.primary:hover {
+  filter: brightness(1.05);
+}
+
+/* Search client-side (filtra titulo case+acento-insensitive) */
+.cockpit .copiloto-chat-convs .cs-search {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 8px;
+  padding: 0 4px;
+}
+.cockpit .copiloto-chat-convs .cs-search .cs-search-ic {
+  position: absolute;
+  left: 12px;
+  color: var(--text-mute);
+  pointer-events: none;
+}
+.cockpit .copiloto-chat-convs .cs-search input {
+  flex: 1 1 auto;
+  height: 28px;
+  padding: 0 38px 0 26px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg-1);
+  color: var(--text);
+  font-size: 12px;
+  outline: none;
+  transition: border-color 0.12s;
+}
+.cockpit .copiloto-chat-convs .cs-search input::placeholder {
+  color: var(--text-mute);
+}
+.cockpit .copiloto-chat-convs .cs-search input:focus {
+  border-color: var(--accent, oklch(0.62 0.18 250));
+}
+.cockpit .copiloto-chat-convs .cs-search .kbd {
+  position: absolute;
+  right: 10px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text-mute);
+  padding: 1px 4px;
+  border-radius: 4px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  pointer-events: none;
+}
+
+/* 4 tabs filtro (Todas/Minhas/Compartilhadas/Arquivadas — Charter §Goals) */
+.cockpit .copiloto-chat-convs .cs-tabs {
+  display: flex;
+  gap: 4px;
+  padding: 0 4px 10px;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: 6px;
+  overflow-x: auto;
+  scrollbar-width: none;
+}
+.cockpit .copiloto-chat-convs .cs-tabs::-webkit-scrollbar { display: none; }
+.cockpit .copiloto-chat-convs .cs-tab {
+  flex: 0 0 auto;
+  padding: 3px 9px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-mute);
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+.cockpit .copiloto-chat-convs .cs-tab:hover {
+  background: var(--sb-hover);
+  color: var(--text);
+}
+.cockpit .copiloto-chat-convs .cs-tab.active {
+  background: var(--text);
+  color: var(--bg-1);
+  border-color: var(--text);
+}
+
+/* Empty state pros tabs ainda não funcionais (Minhas/Compartilhadas/Arquivadas) */
+.cockpit .copiloto-chat-convs .cs-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 32px 16px;
+  text-align: center;
+  color: var(--text-mute);
+  font-size: 12px;
+  gap: 4px;
+}
+.cockpit .copiloto-chat-convs .cs-empty small {
+  font-size: 10.5px;
+  opacity: 0.8;
+  max-width: 200px;
+  line-height: 1.4;
+}
+
+/* Badge unread minúscula ao lado direito do sb-conv-t (backend já expõe `unread`) */
+.cockpit .copiloto-chat-convs .sb-conv-badge {
+  flex: 0 0 auto;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: oklch(0.78 0.16 75); /* amber — alinhado com sb-bullet.filled */
+  color: oklch(0.20 0.04 75);
+  font-size: 10px;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  letter-spacing: -0.02em;
+}
+
 /* ────────────────── Sidebar single-pane (UI-0011) ────────────────── */
 /* Tarefas + Chat — hover/active arredondado (canon Cowork 2026-04-27).
    Wagner 2026-05-05: "seleção arredondada dos itens quando hover". */

--- a/resources/js/Pages/Jana/Chat.tsx
+++ b/resources/js/Pages/Jana/Chat.tsx
@@ -8,8 +8,8 @@
 //   module: Copiloto
 
 import { Head, router } from '@inertiajs/react';
-import { useMemo, type ReactNode } from 'react';
-import { Bell, Cog, Inbox, Pin, Plus } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { Bell, Cog, Inbox, Pin, Plus, Search, SlidersHorizontal } from 'lucide-react';
 import { toast } from 'sonner';
 
 import AppShellV2 from '@/Layouts/AppShellV2';
@@ -292,6 +292,29 @@ export default function Chat({
 }
 
 // ── ConvSidePanel — lista de conversas migrada da SidebarChat removida ─
+//
+// Layout enriquecido conforme Cowork chat.jsx (snapshot 2026-05-09) + Charter
+// §Goals: header + search client-side + 4 tabs filtro (labels Charter Todas/
+// Minhas/Compartilhadas/Arquivadas — não OS/Equipe/Clientes do Cowork que
+// conflitam com semântica Jana IA). Gate F1.5 em Chat-visual-comparison.md.
+//
+// Hoje só 'todas' filtra de fato (backend não expõe flag compartilhada/
+// arquivada em ConversaResumo). 'minhas/compartilhadas/arquivadas' mostram
+// empty state "Em breve" pra dar preview do roadmap.
+
+type ConvTab = 'todas' | 'minhas' | 'compartilhadas' | 'arquivadas';
+
+const CONV_TABS: Array<{ id: ConvTab; label: string }> = [
+  { id: 'todas',           label: 'Todas'         },
+  { id: 'minhas',          label: 'Minhas'        },
+  { id: 'compartilhadas',  label: 'Compartilhadas'},
+  { id: 'arquivadas',      label: 'Arquivadas'    },
+];
+
+// Normaliza pra busca acento-insensitive
+function normalizeSearch(s: string): string {
+  return s.toLowerCase().normalize('NFD').replace(/\p{Diacritic}/gu, '');
+}
 
 function ConvSidePanel({
   fixadas,
@@ -304,13 +327,67 @@ function ConvSidePanel({
   activeConvId: string;
   onSelectConv: (id: string) => void;
 }) {
+  const [query, setQuery] = useState('');
+  const [tab, setTab] = useState<ConvTab>('todas');
+
+  const { fixadasShow, recentesShow, showEmptyTabPlaceholder } = useMemo(() => {
+    if (tab !== 'todas') {
+      // Backend ainda não expõe flag compartilhada/arquivada — mostra empty
+      // state e mantém lista vazia até backend evoluir.
+      return { fixadasShow: [], recentesShow: [], showEmptyTabPlaceholder: true };
+    }
+    const q = normalizeSearch(query.trim());
+    if (!q) {
+      return { fixadasShow: fixadas, recentesShow: recentes, showEmptyTabPlaceholder: false };
+    }
+    const matchQ = (c: ConversaResumo) => normalizeSearch(c.titulo).includes(q);
+    return {
+      fixadasShow: fixadas.filter(matchQ),
+      recentesShow: recentes.filter(matchQ),
+      showEmptyTabPlaceholder: false,
+    };
+  }, [fixadas, recentes, query, tab]);
+
   return (
     <aside className="copiloto-chat-convs">
-      <div className="sb-actions">
-        <a href="/jana/conversas/nova" className="sb-action">
-          <Plus size={14} /> <span>Nova conversa</span>
-          <span className="kbd" style={{ marginLeft: 'auto' }}>⌘N</span>
+      <header className="cs-head">
+        <h2>Chat</h2>
+        <button type="button" className="cs-iconbtn" title="Filtros" aria-label="Filtros">
+          <SlidersHorizontal size={14} />
+        </button>
+        <a href="/jana/conversas/nova" className="cs-iconbtn primary" title="Nova conversa · ⌘N" aria-label="Nova conversa">
+          <Plus size={14} />
         </a>
+      </header>
+
+      <div className="cs-search">
+        <Search size={12} className="cs-search-ic" />
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Buscar conversas..."
+          aria-label="Buscar conversas"
+        />
+        <span className="kbd">⌘K</span>
+      </div>
+
+      <div className="cs-tabs" role="tablist" aria-label="Filtros de conversa">
+        {CONV_TABS.map((t) => (
+          <button
+            key={t.id}
+            type="button"
+            role="tab"
+            aria-selected={tab === t.id}
+            className={`cs-tab ${tab === t.id ? 'active' : ''}`}
+            onClick={() => setTab(t.id)}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="sb-actions">
         <a href="/tarefas" className="sb-action">
           <Inbox size={14} /> <span>Tarefas</span>
         </a>
@@ -323,41 +400,60 @@ function ConvSidePanel({
         </div>
       </div>
 
-      <div className="sb-section-h">Fixadas</div>
-      {fixadas.length === 0 ? (
-        <div className="sb-action" style={{ opacity: 0.6 }}>
-          <Pin size={14} /> <span>Arraste para fixar</span>
+      {showEmptyTabPlaceholder ? (
+        <div className="cs-empty">
+          <span>Em breve</span>
+          <small>Filtro disponível quando o backend expor o campo.</small>
         </div>
       ) : (
-        fixadas.map((c) => (
-          <div
-            key={c.id}
-            className={`sb-conv ${c.id === activeConvId ? 'active' : ''}`}
-            onClick={() => onSelectConv(c.id)}
-          >
-            <span className={`sb-bullet ${c.unread ? 'filled' : ''}`} />
-            <span className="sb-conv-t">{c.titulo}</span>
-          </div>
-        ))
-      )}
+        <>
+          <div className="sb-section-h">Fixadas</div>
+          {fixadasShow.length === 0 ? (
+            <div className="sb-action" style={{ opacity: 0.6 }}>
+              <Pin size={14} /> <span>{query ? 'Nenhuma fixada nesta busca' : 'Arraste para fixar'}</span>
+            </div>
+          ) : (
+            fixadasShow.map((c) => (
+              <SbConvItem key={c.id} c={c} active={c.id === activeConvId} onSelect={onSelectConv} />
+            ))
+          )}
 
-      <div className="sb-section-h">Recentes</div>
-      {recentes.length === 0 ? (
-        <div className="sb-action" style={{ opacity: 0.6 }}>
-          <span>Nenhuma conversa ainda</span>
-        </div>
-      ) : (
-        recentes.map((c) => (
-          <div
-            key={c.id}
-            className={`sb-conv ${c.id === activeConvId ? 'active' : ''}`}
-            onClick={() => onSelectConv(c.id)}
-          >
-            <span className={`sb-bullet ${c.unread ? 'filled' : ''}`} />
-            <span className="sb-conv-t">{c.titulo}</span>
-          </div>
-        ))
+          <div className="sb-section-h">Recentes</div>
+          {recentesShow.length === 0 ? (
+            <div className="sb-action" style={{ opacity: 0.6 }}>
+              <span>{query ? 'Nenhuma recente nesta busca' : 'Nenhuma conversa ainda'}</span>
+            </div>
+          ) : (
+            recentesShow.map((c) => (
+              <SbConvItem key={c.id} c={c} active={c.id === activeConvId} onSelect={onSelectConv} />
+            ))
+          )}
+        </>
       )}
     </aside>
+  );
+}
+
+function SbConvItem({
+  c,
+  active,
+  onSelect,
+}: {
+  c: ConversaResumo;
+  active: boolean;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <div
+      className={`sb-conv ${active ? 'active' : ''}`}
+      onClick={() => onSelect(c.id)}
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => { if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); onSelect(c.id); } }}
+    >
+      <span className={`sb-bullet ${c.unread ? 'filled' : ''}`} />
+      <span className="sb-conv-t">{c.titulo}</span>
+      {c.unread ? <span className="sb-conv-badge">{c.unread > 99 ? '99+' : c.unread}</span> : null}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

Porta o visual da `ConvList` do snapshot **Cowork 2026-05-09 chat.jsx** pra `ConvSidePanel` da Page `/copiloto` (Pages/Jana/Chat.tsx), **layout-only** — preservando 100% da semântica Jana IA do `Chat.charter.md` (LIVE v1).

**Origem do pedido:** Wagner colou link Anthropic Cowork (`api.anthropic.com/v1/design/h/t0ok_9xanV71ntqYUAkHtA?open_file=Oimpresso+ERP+-+Chat.html`) — URL retornou 404 via WebFetch. Usado snapshot local canônico [`memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/`](memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/) (canon visual atualizado por _DS UI-0012).

## Delta concreto (3 arquivos)

| Arquivo | + | − | Função |
|---|---|---|---|
| `resources/js/Pages/Jana/Chat.tsx` | 133 | 37 | ConvSidePanel enriquecido (header+search+tabs+badge) + SbConvItem extraído + helper `normalizeSearch` |
| `resources/css/cockpit.css` | 162 | 0 | Classes `.cs-head/.cs-iconbtn/.cs-search/.cs-tabs/.cs-tab/.cs-empty/.sb-conv-badge` escopadas em `.cockpit .copiloto-chat-convs` |
| `memory/requisitos/Jana/Chat-visual-comparison.md` | 169 | 0 | Gate F1.5 ADR 0107 — 15 dimensões + plano + anti-padrões F3 conferidos + 4 decisões Wagner |

## O que entrou

- ✅ Header `<h2>Chat</h2>` + 2 icon-btn (filtros placeholder + nova conv `⌘N`)
- ✅ Search input client-side filtrando `titulo` (case+acento-insensitive via `String.prototype.normalize('NFD')`)
- ✅ 4 tabs filtro **labels do Charter §Goals**: Todas / Minhas / Compartilhadas / Arquivadas
- ✅ Badge `unread` mini ao lado do `sb-conv-t` (campo já existe em `ConversaResumo` — só não renderizado antes)
- ✅ Empty state "Em breve" pros 3 tabs ainda não funcionais (backend não expõe flag `compartilhada`/`arquivada`) — preview do roadmap sem mentir UX

## O que NÃO entrou (e por quê)

- ❌ **ConvItem rico com avatar+preview+tag-tipo-OS** — Charter §Non-Goals proíbe tipos OS/Equipe (chat humano-humano ≠ Jana IA). Exigiria migration + ADR schema (proibido em "layout-only")
- ❌ **File attachment ✓✓** — Charter §Non-Goals (backlog M2, depende Brain B vision policy)
- ❌ **Composer Cowork mock auto-reply** — Charter exige Brain B real via `JanaAssistantUiChat` (lib `assistant-ui`) que já está em prod
- ❌ **Bind teclado `⌘K`** — Wagner decidiu (AskUserQuestion 2026-05-15) que `⌘K` fica só visual nesta PR (charter pede `/` pra composer, `⌘K` cairia em command palette futura)
- ❌ **Roundtrip search backend** — Wagner decidiu client-side (zero backend change)

## Conformidade

### Charter [Chat.charter.md](resources/js/Pages/Jana/Chat.charter.md) LIVE v1
- ✅ Mission preservada (Jana IA assistant ≠ chat humano-humano)
- ✅ Goals §"pills de filtro `rounded-full`: Todas / Minhas / Compartilhadas / Arquivadas" — implementado
- ✅ Non-Goals respeitados (sem anexo, sem editar msg, sem voice)
- ✅ UX Targets: 1280px sem scroll horizontal mantido

### Multi-tenant Tier 0 ADR 0093
- ✅ Zero backend change — `business_id` global scope intocado
- ✅ Nenhuma nova query, nenhum novo Controller, nenhum novo Model

### Anti-padrões F3 Financeiro Rejeitado
Conferidos contra [`prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md`](prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md):

| Anti-padrão | Risco | Status |
|---|---|---|
| M-AP-1 auto-doc ignorada | Pular charter + RUNBOOK | ✅ Lidos ANTES (charter LIVE v1, RUNBOOK-chat, ConversaResumo type, Thread.tsx callsite CHAT_TABS) |
| M-AP-2 marketing > realidade | Title "F3 completo" sendo stub | ✅ Title honesto "layout-only" |
| M-AP-3 aprovação tácita = double-gate | Wagner "f3" = pulou F1.5+F2 | ✅ F1.5 gate explícito via visual-comparison.md aprovado + AskUserQuestion 2026-05-15 |
| M-AP-4 schema fantasma | Models inventados | ✅ `ConversaResumo` intacto, sem migration |

## Test plan

- [ ] `npx tsc --noEmit` — 0 erros em `Pages/Jana/Chat.tsx` (validado pré-commit)
- [ ] Smoke `/copiloto` local — sidebar renderiza header+search+tabs+badge
- [ ] Smoke search — digitar título parcial filtra fixadas+recentes (acento-insensitive)
- [ ] Smoke tabs — click "Minhas" mostra empty state "Em breve"; click "Todas" volta lista
- [ ] Smoke badge — conversa com `unread > 0` mostra badge à direita; `unread > 99` mostra "99+"
- [ ] Smoke 1280px — sem scroll horizontal
- [ ] Smoke Pest pré-existente em `tests/Feature/Modules/Copiloto/` continua passando (não toquei backend)

## Refs

- [Chat.charter.md (LIVE v1)](resources/js/Pages/Jana/Chat.charter.md)
- [memory/requisitos/Jana/Chat-visual-comparison.md](memory/requisitos/Jana/Chat-visual-comparison.md) — gate F1.5
- [memory/requisitos/Jana/RUNBOOK-chat.md](memory/requisitos/Jana/RUNBOOK-chat.md)
- [memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/chat.jsx](memory/requisitos/_DesignSystem/ui_kits/cowork-2026-05-09/chat.jsx) — visual source
- [ADR 0094 Constituição v2](memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md)
- [ADR 0104 MWART processo único](memory/decisions/0104-processo-mwart-canonico-unico-caminho.md)
- [ADR 0107 Visual gate F1.5](memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md)
- [ADR 0110 Cockpit Pattern V2](memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md)
- [ADR 0114 Cowork loop formalizado](memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)