### PR TITLE
fix(sells): 2 CRITICAL R-DS-001 — pills nav + remover-linha pra <Button> shadcn (pre-canary biz=4)

### DIFF
--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -636,16 +636,13 @@ export default function SellsCreate(props: SellsCreatePageProps) {
               const isActive = activeSection === tab.id;
               const Icon = tab.icon;
               return (
-                <button
+                <Button
                   key={tab.id}
                   type="button"
+                  variant={isActive ? 'default' : 'ghost'}
+                  size="sm"
                   onClick={() => scrollToSection(tab.id)}
-                  className={
-                    'inline-flex items-center gap-1.5 rounded-full px-3.5 py-1.5 text-xs font-medium transition-colors ' +
-                    (isActive
-                      ? 'bg-blue-50 text-blue-700 dark:bg-blue-950/50 dark:text-blue-300'
-                      : 'bg-muted/40 text-muted-foreground hover:bg-muted hover:text-foreground')
-                  }
+                  className="rounded-full text-xs"
                   aria-current={isActive ? 'true' : undefined}
                 >
                   <Icon size={13} />
@@ -654,13 +651,13 @@ export default function SellsCreate(props: SellsCreatePageProps) {
                     <span
                       className={
                         'ml-0.5 inline-flex h-4 min-w-4 items-center justify-center rounded-full px-1 text-[10px] tabular-nums ' +
-                        (isActive ? 'bg-blue-100 dark:bg-blue-900/60' : 'bg-background')
+                        (isActive ? 'bg-primary-foreground/20' : 'bg-background border border-border')
                       }
                     >
                       {tab.count}
                     </span>
                   )}
-                </button>
+                </Button>
               );
             })}
           </nav>
@@ -908,14 +905,16 @@ export default function SellsCreate(props: SellsCreatePageProps) {
                           {formatBRL(lineSubtotal)}
                         </td>
                         <td className="px-3 py-2 text-right align-middle">
-                          <button
+                          <Button
                             type="button"
+                            variant="ghost"
+                            size="icon-sm"
                             onClick={() => handleRemoveProduct(idx)}
                             aria-label={`Remover ${p.name}`}
-                            className="text-muted-foreground hover:text-destructive p-1"
+                            className="text-muted-foreground hover:text-destructive"
                           >
                             <Trash2 className="h-4 w-4" />
-                          </button>
+                          </Button>
                         </td>
                       </tr>
                     );


### PR DESCRIPTION
## Summary

Aplica **PR-FIX-1** do [AUDIT-cockpit-runbook-Create-2026-05-15.md](memory/requisitos/Sells/AUDIT-cockpit-runbook-Create-2026-05-15.md) — 2 CRITICAL R-DS-001 que estão bloqueando cutover biz=4 (Larissa @ ROTA LIVRE).

Estado: `Sells/Create.tsx` LIVE em biz=1 (Wagner) via flag `useV2SellsCreate`, **OFF em biz=4** (Larissa) — pré-canary. Audit modo B (CHECKLIST.md + Nielsen + R-DS-001..012) deu **nota 79/100** com 2 CRITICAL como blockers do cutover. Este PR resolve os 2 CRITICAL → score esperado **~87/100** (banda 🟢 cutover-ready).

## Delta

**1 arquivo, 11 inserções / 12 deleções (23 linhas, ≤300 ✅ commit-discipline)**

### Fix 1 — Filter pills nav (L.639-663)

5 pills (Dados / Produtos / Pagamento / Resumo / Mais opções) eram `<button>` HTML cru.

```diff
- <button
-   className={
-     'inline-flex items-center gap-1.5 rounded-full px-3.5 py-1.5 text-xs font-medium transition-colors ' +
-     (isActive
-       ? 'bg-blue-50 text-blue-700 dark:bg-blue-950/50 dark:text-blue-300'
-       : 'bg-muted/40 text-muted-foreground hover:bg-muted hover:text-foreground')
-   }
- >
+ <Button
+   variant={isActive ? 'default' : 'ghost'}
+   size="sm"
+   className="rounded-full text-xs"
+ >
```

Counter span migra `bg-blue-100/dark:bg-blue-900/60` → `bg-primary-foreground/20` (active) ou `bg-background border` (inactive). Tokens shadcn, sem cor crua.

### Fix 2 — Botão remover linha produto (L.911-918)

```diff
- <button
-   className="text-muted-foreground hover:text-destructive p-1"
- >
+ <Button
+   variant="ghost"
+   size="icon-sm"
+   className="text-muted-foreground hover:text-destructive"
+ >
```

**Nota:** audit prescreveu `size="icon"` (36px). Optei por `size="icon-sm"` (32px = h-8) pra match com inputs `h-8` vizinhos na tabela de produtos (densidade vertical alinhada). Mesma família shadcn, decisão consciente vs literal do audit.

## Conformidade

| Regra | Status |
|---|---|
| **R-DS-001** (canon shadcn primitives, sem `<button>` HTML cru) | ✅ resolvido |
| **R-DS-006** (focus ring shadcn) | ✅ ganho embutido no Button |
| **R-DS-002** (tokens, sem cor crua) | ✅ removido `bg-blue-50/950` → `bg-primary` |
| **Charter Create.charter.md UX Targets** (1280px sem scroll horizontal) | ✅ Button shadcn não altera dimensões |
| **Multi-tenant Tier 0 ADR 0093** | ✅ zero backend change |
| **commit-discipline** (≤300 linhas, 1 PR = 1 intent) | ✅ 23 linhas, intent único (R-DS-001 fixes) |

## Score esperado pós-merge

| Categoria | Antes | Esperado | Detalhe |
|---|---|---|---|
| DS (40) | 30 | **~38** | 2 CRITICAL R-DS-001 resolvidos |
| ADR (30) | 30 | 30 | mantido |
| UX (30) | 19 | 19 | WARN/INFO ficam pra PR-FIX-2 ou backlog |
| **TOTAL** | **79** | **~87** | 🟡→🟢 banda Bom→Cutover-ready |

## Não está neste PR (intencional)

- ❌ PR-FIX-2 (2 WARN ROI alto): atalho `/` + remover subtitle redundante — separar pra revisão isolada
- ❌ WARN H1/Q4 skeleton KPIs no mount — backlog pós-canary
- ❌ WARN H3/Q2 confirma Cancel com unsaved — backlog pós-canary
- ❌ INFO grid breakpoints / h-8 inputs / OS detect ⌘ vs Ctrl — descartados pelo audit (Larissa Windows desktop, sem touch)
- ❌ 7 TS errors pré-existentes em Create.tsx (Search/PageHeader unused imports, OptionMap signatures, etc) — não tocados, backlog separado

## Coexistência com 6 agents BG do plano híbrido 2026-05-15

Audit menciona "fixes propostos aguardam consolidação dos 6 agents BG porque tocam linhas que vão mudar". Este PR toca **apenas L.639-663 (pills nav) + L.911-918 (botão remover)** — fora do escopo natural dos 6 agents (Edit, ContactQuickAdd, ProductQuickAdd, Hotkeys, CashDenomination, ContactSummary). Pode mergear em paralelo a esses.

## Test plan

- [ ] Smoke `/sells/create` biz=1 — 5 filter pills rendem como `<Button>` shadcn; click em pill ativa highlight + scroll-spy mantém
- [ ] Smoke pill counter: adicionar produto → counter "Produtos" mostra contagem com `bg-primary-foreground/20` (active) ou `bg-background border` (inactive)
- [ ] Smoke tabela produtos: hover no botão remover linha → text-destructive transition
- [ ] Smoke a11y: Tab keyboard → focus ring shadcn visível em pills + botão remover (ganho embutido)
- [ ] Pest pré-existente em `tests/Feature/Sells/SellsCreatePageTest.php` (39+ testes estruturais) continua passando
- [ ] Re-audit modo B (skill `cockpit-runbook`) confirma score ≥85 antes de cutover biz=4

## Refs

- [AUDIT-cockpit-runbook-Create-2026-05-15.md](memory/requisitos/Sells/AUDIT-cockpit-runbook-Create-2026-05-15.md) — audit fonte (PR-FIX-1)
- [resources/js/Pages/Sells/Create.charter.md](resources/js/Pages/Sells/Create.charter.md) — charter LIVE v1
- [memory/requisitos/Sells/sells-create-visual-comparison.md](memory/requisitos/Sells/sells-create-visual-comparison.md) — visual comparison APPROVED 2026-05-08
- [memory/requisitos/Sells/RUNBOOK-create.md](memory/requisitos/Sells/RUNBOOK-create.md)
- [memory/requisitos/_DesignSystem/SPEC.md](memory/requisitos/_DesignSystem/SPEC.md) — R-DS-001..012
- [ADR 0110 Cockpit Pattern V2](memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md)
- [ADR 0094 Constituição v2](memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md)
- [.claude/skills/cockpit-runbook/CHECKLIST.md](.claude/skills/cockpit-runbook/CHECKLIST.md) — regras modo B

🤖 Generated with [Claude Code](https://claude.com/claude-code)