### PR TITLE
fix(sells): PR-FIX-2 audit 2026-05-15 — atalho `/` + subtitle redundante + empty state honesto

### DIFF
--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -476,6 +476,33 @@ export default function SellsCreate(props: SellsCreatePageProps) {
     return () => window.removeEventListener('keydown', onEsc);
   }, []);
 
+  // US-SELL-007 — Atalho `/` top-level: foca busca de produto (canon Cockpit list/form).
+  // PR-FIX-2 audit 2026-05-15 — elimina débito "em breve" do empty state e cumpre
+  // promessa do charter §UX Targets. Não dispara quando user está digitando em
+  // input/textarea/select/contentEditable (evita roubar `/` em campo de busca/notas).
+  useEffect(() => {
+    const onSlash = (e: KeyboardEvent) => {
+      if (e.key !== '/' || e.metaKey || e.ctrlKey || e.altKey) return;
+      const active = document.activeElement as HTMLElement | null;
+      const tag = active?.tagName.toLowerCase();
+      if (
+        tag === 'input' ||
+        tag === 'textarea' ||
+        tag === 'select' ||
+        active?.isContentEditable
+      ) {
+        return;
+      }
+      e.preventDefault();
+      const input = productSearchRef.current?.querySelector<HTMLInputElement>(
+        'input[type="search"]',
+      );
+      input?.focus();
+    };
+    window.addEventListener('keydown', onSlash);
+    return () => window.removeEventListener('keydown', onSlash);
+  }, []);
+
   // US-SELL-010 — Auto-open <details> "Mais opções" quando erro está em campo colapsado.
   // Larissa scrola pro erro mas a seção fica fechada — sem isso ela não acha o campo.
   // Detectado pelo design-arte agent 2026-05-13 como maior gap UX restante.
@@ -608,15 +635,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
                 Adicionar venda
               </h1>
               <p className="text-sm text-muted-foreground mt-1 leading-relaxed">
-                Registre uma venda completa — cliente, produtos, pagamento e frete.{' '}
-                {props.defaultLocation?.name && (
-                  <span>
-                    Local:{' '}
-                    <span className="font-medium text-foreground">
-                      {props.defaultLocation.name}
-                    </span>
-                  </span>
-                )}
+                Registre uma venda completa — cliente, produtos, pagamento e frete.
               </p>
             </div>
           </div>
@@ -824,7 +843,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
             <EmptyState
               icon="package"
               title="Nenhum produto adicionado"
-              description="Use a busca acima ou aperte / pra focar (em breve)."
+              description="Use a busca acima ou aperte / pra focar."
               action={
                 <Button variant="outline" size="sm" onClick={focusProductSearch}>
                   Buscar produto


### PR DESCRIPTION
## Summary

Aplica **PR-FIX-2** do [audit modo B 2026-05-15](memory/requisitos/Sells/AUDIT-cockpit-runbook-Create-2026-05-15.md) — 2 WARN ROI alto restantes pré-canary biz=4 (Larissa @ ROTA LIVRE).

**Independente** do [PR #937](https://github.com/wagnerra23/oimpresso.com/pull/937) (PR-FIX-1, 2 CRITICAL R-DS-001) — branch a partir de `origin/main`, mergeável em qualquer ordem. Linhas tocadas não colidem (PR-FIX-1: pills L.639 + remover-linha L.911; PR-FIX-2: subtitle L.610 + useEffect L.466 + empty state L.827).

## Delta

**1 arquivo, 29 inserções / 10 deleções (39 linhas, ≤300 ✅ commit-discipline)**

### Fix 1 — Subtitle redundante removido (L.610-621)
Audit: *"Subtitle exibe 'Local: <name>' mesmo com campo Local visível abaixo no Card 'Dados da venda' l.789. Ruído duplicado. Larissa lê 2x a mesma info."*

```diff
- <p className="text-sm text-muted-foreground mt-1 leading-relaxed">
-   Registre uma venda completa — cliente, produtos, pagamento e frete.{' '}
-   {props.defaultLocation?.name && (
-     <span>
-       Local:{' '}
-       <span className="font-medium text-foreground">
-         {props.defaultLocation.name}
-       </span>
-     </span>
-   )}
- </p>
+ <p className="text-sm text-muted-foreground mt-1 leading-relaxed">
+   Registre uma venda completa — cliente, produtos, pagamento e frete.
+ </p>
```

### Fix 2 — Atalho `/` foca busca de produto (L.466+ novo useEffect)
Audit: *"Empty state diz 'aperte / pra focar (em breve)' — promessa quebrada porque atalho `/` nunca foi implementado (US-SELL-007 backlog há tempo). Texto 'em breve' há meses sinaliza débito."*

Adiciona 3º `useEffect` keydown global (vizinho aos useEffects Esc + Cmd+Enter pré-existentes). Guards essenciais:

- ❌ Não dispara se `metaKey`/`ctrlKey`/`altKey` (preserva atalhos browser)
- ❌ Não rouba `/` em `input`/`textarea`/`select`/`contentEditable` (não interfere campo notas, busca, autocompletes)
- ✅ `preventDefault` só APÓS confirmar guard
- ✅ `removeEventListener` no cleanup (sem leak)

Reusa pattern do helper `focusProductSearch` (l.345-350) — `productSearchRef.current?.querySelector('input[type="search"]')`. Sem dep externa.

### Fix 3 — Empty state honesto (L.827)
Consequência do Fix 2: a promessa virou realidade.

```diff
- description="Use a busca acima ou aperte / pra focar (em breve)."
+ description="Use a busca acima ou aperte / pra focar."
```

## Score esperado

| Categoria | Antes | Pós PR-FIX-2 | Combinado (PR #937 + #este) |
|---|---|---|---|
| DS (40) | 30 | 30 (não tocado) | ~38 (#937) |
| ADR (30) | 30 | 30 | 30 |
| UX (30) | 19 | **~23** (2 WARN H7/Q5 + H8 resolvidos) | ~23 |
| **TOTAL** | **79** | **~83** | **~91** 🟢 cutover-ready |

## Conformidade

- ✅ **Charter `Create.charter.md` §Goals:** "Atalho `/` foca composer..." → agora cumpre promessa (era pendente)
- ✅ **Charter §UX Targets:** "Atalhos respondem < 100ms" — useEffect global é nativo
- ✅ **Multi-tenant Tier 0 ADR 0093:** zero backend change
- ✅ **R-DS-012 localStorage prefix:** não tocado (não é localStorage feature)
- ✅ **commit-discipline:** 39 linhas, 1 PR = 1 intent (PR-FIX-2 audit)
- ✅ **tsc:** 0 erros novos. 7 pré-existentes (Search/PageHeader unused, OptionMap signatures) não tocados — backlog separado

## Não está neste PR (intencional)

- ❌ WARN H1/Q4 Skeleton KPIs no mount inicial — backlog pós-canary (audit ~1h, ROI médio)
- ❌ WARN H3/Q2 confirma Cancel com unsaved — backlog pós-canary (~30min)
- ❌ 7 TS errors pré-existentes — backlog separado
- ❌ 2 CRITICAL R-DS-001 — esses são do **PR-FIX-1 #937**

## Test plan

- [ ] Smoke `/sells/create` biz=1 — subtitle NÃO mostra mais "Local: X" (visível só no Card abaixo)
- [ ] Smoke atalho `/`: tela renderizada → aperta `/` sem foco em input → busca produto recebe foco
- [ ] Smoke negativo: foco em input/textarea/select → aperta `/` → caractere `/` digitado normalmente (não rouba)
- [ ] Smoke modificadores: `Ctrl+/` ou `Cmd+/` (atalho browser) → não dispara focusProductSearch
- [ ] Smoke empty state: produtos vazios → mensagem diz só "Use a busca acima ou aperte / pra focar." (sem "em breve")
- [ ] Re-audit modo B → confirma UX 19→23/30 + total ≥83/100

## Refs

- [AUDIT-cockpit-runbook-Create-2026-05-15.md](memory/requisitos/Sells/AUDIT-cockpit-runbook-Create-2026-05-15.md) §WARN H7/Q5 + §WARN H8 + §Recomendação executável PR-FIX-2
- [resources/js/Pages/Sells/Create.charter.md](resources/js/Pages/Sells/Create.charter.md) §Goals, §UX Targets
- [memory/requisitos/Sells/SPEC.md](memory/requisitos/Sells/SPEC.md) US-SELL-007 (atalhos teclado)
- [ADR 0110 Cockpit Pattern V2](memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md)
- [PR #937 PR-FIX-1](https://github.com/wagnerra23/oimpresso.com/pull/937) — irmão (2 CRITICAL R-DS-001), independente

🤖 Generated with [Claude Code](https://claude.com/claude-code)