### PR TITLE
fix(kb): FK author_user_id compatível com users.id (UltimatePOS legacy int unsigned)

### DIFF
--- a/Modules/KB/Database/Migrations/2026_05_15_100003_create_kb_nodes_table.php
+++ b/Modules/KB/Database/Migrations/2026_05_15_100003_create_kb_nodes_table.php
@@ -83,7 +83,8 @@ return new class extends Migration {
             $table->unsignedInteger('os_linked_count')->default(0);
 
             // Meta.
-            $table->unsignedBigInteger('author_user_id')->nullable();
+            // refs users.id (int unsigned, UltimatePOS legacy)
+            $table->unsignedInteger('author_user_id')->nullable();
             $table->unsignedSmallInteger('read_time_min')->nullable();
             $table->timestamp('last_verified_at')->nullable()
                 ->comment('última re-verificação pelo dono (botão "Re-verificar")');

--- a/Modules/KB/Database/Migrations/2026_05_15_100005_create_kb_paths_table.php
+++ b/Modules/KB/Database/Migrations/2026_05_15_100005_create_kb_paths_table.php
@@ -30,7 +30,8 @@ return new class extends Migration {
             $table->unsignedSmallInteger('hue')->default(240);
             $table->string('status', 40)->default('published')
                 ->comment('draft|published|archived');
-            $table->unsignedBigInteger('author_user_id')->nullable();
+            // refs users.id (int unsigned, UltimatePOS legacy)
+            $table->unsignedInteger('author_user_id')->nullable();
             $table->timestamps();
             $table->softDeletes();
 

--- a/Modules/KB/Database/Migrations/2026_05_15_100007_create_kb_decision_trees_table.php
+++ b/Modules/KB/Database/Migrations/2026_05_15_100007_create_kb_decision_trees_table.php
@@ -32,7 +32,8 @@ return new class extends Migration {
                 ->comment('draft|published|archived');
             $table->unsignedBigInteger('root_step_id')->nullable()
                 ->comment('primeiro passo (entry point) — populado após criação');
-            $table->unsignedBigInteger('author_user_id')->nullable();
+            // refs users.id (int unsigned, UltimatePOS legacy)
+            $table->unsignedInteger('author_user_id')->nullable();
             $table->timestamps();
             $table->softDeletes();
 

--- a/Modules/KB/Database/Migrations/2026_05_15_100009_create_kb_node_versions_table.php
+++ b/Modules/KB/Database/Migrations/2026_05_15_100009_create_kb_node_versions_table.php
@@ -28,7 +28,8 @@ return new class extends Migration {
             $table->unsignedInteger('business_id');
             $table->unsignedBigInteger('node_id');
             $table->timestamp('version_at');
-            $table->unsignedBigInteger('author_user_id')->nullable();
+            // refs users.id (int unsigned, UltimatePOS legacy)
+            $table->unsignedInteger('author_user_id')->nullable();
             $table->json('snapshot')
                 ->comment('{title, excerpt, body_blocks, tags, status, category_id, subcategory_id, nivel, equip}');
             $table->string('change_reason', 255)->nullable();

--- a/Modules/KB/Database/Migrations/2026_05_15_100010_create_kb_favorites_table.php
+++ b/Modules/KB/Database/Migrations/2026_05_15_100010_create_kb_favorites_table.php
@@ -22,7 +22,8 @@ return new class extends Migration {
         Schema::create('kb_favorites', function (Blueprint $table) {
             $table->bigIncrements('id');
             $table->unsignedInteger('business_id');
-            $table->unsignedBigInteger('user_id');
+            // refs users.id (int unsigned, UltimatePOS legacy)
+            $table->unsignedInteger('user_id');
             $table->unsignedBigInteger('node_id');
             $table->timestamp('created_at')->nullable();
 

--- a/Modules/KB/Database/Migrations/2026_05_15_100011_create_kb_comments_table.php
+++ b/Modules/KB/Database/Migrations/2026_05_15_100011_create_kb_comments_table.php
@@ -26,7 +26,8 @@ return new class extends Migration {
             $table->unsignedSmallInteger('block_idx')
                 ->comment('index do bloco em body_blocks (0-based)');
             $table->text('text');
-            $table->unsignedBigInteger('author_user_id');
+            // refs users.id (int unsigned, UltimatePOS legacy)
+            $table->unsignedInteger('author_user_id');
             $table->timestamps();
             $table->softDeletes();
 


### PR DESCRIPTION
## Summary

- 6 migrations KB (PR #934) declaravam `*_user_id` como `unsignedBigInteger` mas `users.id` é `int unsigned` no UltimatePOS legacy → FK falhava com `SQLSTATE[HY000]:3780` e 9 das 12 migrations não aplicavam em MySQL real
- Fix: `unsignedBigInteger` → `unsignedInteger` nas 6 colunas que referenciam `users.id`
- `business_id` já estava correto; `source_doc_id` (refs `mcp_memory_documents.id` bigint) mantido

## Como reproduzi o bug

```sh
php artisan module:migrate KB
# Failing migration: 2026_05_15_100003_create_kb_nodes_table.php
# SQLSTATE[HY000]: General error: 3780 Referencing column 'author_user_id'
# and referenced column 'id' in foreign key constraint 'fk_kb_nodes_author'
# are incompatible.
```

Tipos confirmados via `INFORMATION_SCHEMA.COLUMNS`:

| Tabela | id |
|---|---|
| `users` | `int unsigned` |
| `business` | `int unsigned` |
| `mcp_memory_documents` | `bigint unsigned` |

## Test plan

- [x] `php artisan module:migrate KB` → **12/12 DONE** local (worktree dreamy-satoshi-eacde6)
- [x] Diff cirúrgico: 6 arquivos, +12/-6 linhas, zero mudança de lógica
- [ ] CI verde
- [ ] Smoke `/kb/v2` após merge (renderiza tri-pane com 18 nós mock — fallback do Index.v2.tsx)

## Follow-up (fora do escopo deste PR)

- Pest tests do módulo KB (`Modules/KB/Tests/Pest.php`) usam `kbBootstrapSchema()` helper que não é descoberto pelo Pest principal — bug pré-existente do PR #934, ortogonal a este fix
- Após merge, rodar `php artisan module:seed KB` pra popular categorias + bridge first-run

Refs: [PR #934](https://github.com/wagnerra23/oimpresso.com/pull/934) (KB Unificado), [ADR 0150](memory/decisions/0150-kb-unificado-grafo-conhecimento-modulo-ia-central.md), [SCHEMA-DB-V1.md §3](memory/requisitos/KB/SCHEMA-DB-V1.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)