### PR TITLE
fix(kb): Pest descobre Helpers do módulo + uses(TestCase) aplicado

### DIFF
--- a/Modules/KB/Tests/Helpers.php
+++ b/Modules/KB/Tests/Helpers.php
@@ -28,9 +28,11 @@ use Illuminate\Support\Facades\Schema;
 |   - kbActAsUser($bizId, $userId=42, array $permissions=[])  → autentica + session()
 |   - kbCreateBusinessRow($bizId)
 |   - kbCreateMcpDoc($bizId, $type='adr', array $overrides=[])
+|
+| Carregado via composer autoload-dev.files (Pest discovery não sobe acima
+| do testsuite root no phpunit.xml — `Modules/KB/Tests/Feature` + `/Unit`).
+| `uses(...)->in(__DIR__)` foi movido pra Pest.php dentro de cada subdir.
 */
-
-uses(Tests\TestCase::class)->in(__DIR__);
 
 /**
  * Cria as tabelas mínimas necessárias pros tests do KB.

--- a/composer.json
+++ b/composer.json
@@ -84,7 +84,10 @@
     "autoload-dev": {
         "psr-4": {
             "Tests\\": "tests/"
-        }
+        },
+        "files": [
+            "Modules/KB/Tests/Helpers.php"
+        ]
     },
     "scripts": {
         "post-root-package-install": [

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -3,3 +3,11 @@
 use Tests\TestCase;
 
 uses(TestCase::class)->in('Feature');
+
+// Pest 3.x descobre `Pest.php` somente em `tests/` (Bootstrappers\BootFiles),
+// então o `uses(...)->in()` de módulos com test suites próprios precisa ficar
+// AQUI mesmo. `realpath` resolve worktrees / junctions.
+$kbFeatureDir = realpath(__DIR__ . '/../Modules/KB/Tests/Feature');
+$kbUnitDir    = realpath(__DIR__ . '/../Modules/KB/Tests/Unit');
+if ($kbFeatureDir !== false) { uses(TestCase::class)->in($kbFeatureDir); }
+if ($kbUnitDir    !== false) { uses(TestCase::class)->in($kbUnitDir); }


### PR DESCRIPTION
## Summary

`Modules/KB/Tests/Pest.php` (PR #934) definia 5 helpers globais (`kbBootstrapSchema`, `kbActAsUser`, `kbTeardownSchema`, `kbCreateBusinessRow`, `kbCreateMcpDoc`) e `uses(Tests\TestCase::class)->in(__DIR__)` — mas nenhum dos dois era aplicado pelo Pest 3.x, porque:

1. [`Pest\Bootstrappers\BootFiles`](vendor/pestphp/pest/src/Bootstrappers/BootFiles.php) só procura `Pest.php`/`Helpers.php` em `tests/` (root da suite)
2. `uses(...)->in(__DIR__)` definido em `Modules/*` nunca é executado

Sintoma: `vendor/bin/pest Modules/KB/Tests/Unit/` falhava com `Call to undefined function kbBootstrapSchema()` (antes do autoload-dev.files) ou `A facade root has not been set` (depois — Laravel não bootava porque `TestCase` não era aplicado).

## Fix em 3 frentes

1. **Renomear** `Modules/KB/Tests/Pest.php` → `Modules/KB/Tests/Helpers.php` (nome neutro, conteúdo intacto — 5 funções globais `kb*`)
2. **`composer.json autoload-dev.files`** carrega `Helpers.php` no bootstrap do PHPUnit/Pest → funções viram globais antes do primeiro test rodar
3. **`tests/Pest.php`** aplica `uses(Tests\TestCase::class)` em `Modules/KB/Tests/Feature` e `Modules/KB/Tests/Unit` via `realpath` (resolve worktrees + junctions Windows)

## Test plan

- [x] **Antes:** `pest Modules/KB/Tests/Unit/KbNodeTest.php` → 12 failed, 0 assertions
- [x] **Depois:** `pest Modules/KB/Tests/Unit/` → **15 passed**, 24 failed (45 assertions)
- [x] Os 24 failures são bugs **independentes** — `KbNodeObserver` não enforça invariante R1 (`is_editable=false ⇒ body_blocks IS NULL`), `KbNodeVersionObserver` não bloqueia UPDATE/DELETE append-only, `KbBridgeFromMcpJob` incompleto. Antes deste fix nem rodavam.
- [ ] CI verde

## Não muda sinal do CI

- `ci.yml` → `tests/Feature/Form` only (KB não está)
- `modules-pest.yml` matrix → `Arquivos`, `ComunicacaoVisual`, `NfeBrasil`, `Repair` (KB não está)

Merge deste PR NÃO ativa KB no CI. Adicionar `KB` ao matrix fica pra PR separado **depois** dos 24 fails serem resolvidos (Observers + Job KbBridgeFromMcp completos).

## Follow-ups (fora do escopo)

- [ ] `KbNodeObserver` enforça `is_editable=false ⇒ body_blocks IS NULL` no `saving` event
- [ ] `KbNodeVersionObserver` lança Exception em `updating`/`deleting` (append-only)
- [ ] `KbDecisionTreeStepObserver` valida branch yes/no tem exatamente 1 de (next OR fix)
- [ ] `KbBridgeFromMcpJob` (referenced/derived edges, idempotência, soft-delete cascade)
- [ ] Schema KB seeds completos (categoria + 18 artigos op + 3 trilhas + 3 trees) — `php artisan module:seed KB`

Refs: [PR #934](https://github.com/wagnerra23/oimpresso.com/pull/934), [ADR 0150](memory/decisions/0150-kb-unificado-grafo-conhecimento-modulo-ia-central.md), `vendor/pestphp/pest/src/Bootstrappers/BootFiles.php`

🤖 Generated with [Claude Code](https://claude.com/claude-code)