### PR TITLE
test(pest): cobertura Wave A — 8 módulos críticos (Auditoria/Crm/Manufacturing/NFSe/Connector/Accounting/Superadmin/Officeimpresso)

### DIFF
--- a/Modules/Accounting/Tests/Feature/EntityBusinessIdConsistencyTest.php
+++ b/Modules/Accounting/Tests/Feature/EntityBusinessIdConsistencyTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Auditoria de consistência multi-tenant — todas as Entities Accounting que representam
+ * tabelas REAIS de negócio devem ter coluna `business_id` (Tier 0 IRREVOGÁVEL — ADR 0093).
+ *
+ * Itera sobre `Modules/Accounting/Entities/*.php`, resolve `$table` via reflection,
+ * filtra pra tabelas que existem no schema dev, e asserta presença de coluna `business_id`.
+ *
+ * Algumas Entities são DUPLICATAS de classes core UltimatePOS (`App\User`, `App\Business`,
+ * `App\Contact` etc — 70 arquivos é sinal disso). Tabelas core compartilhadas como `users`,
+ * `business`, `currencies`, `countries`, `genders`, `titles`, `professions`, `marital_statuses`,
+ * `client_types`, `client_relationships` são allowlisted pois NÃO são scope-per-business
+ * (são reference data global ou compartilhado).
+ *
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped(
+            'SQLite-incompatível: auditoria requer schema MySQL UltimatePOS completo (ADR 0101)'
+        );
+    }
+});
+
+/**
+ * Allowlist — tabelas que NÃO precisam de business_id porque são reference data global
+ * ou tabelas core UltimatePOS compartilhadas multi-tenant via outras chaves.
+ */
+const ACC_ALLOWLIST_NO_BIZ_ID = [
+    // Reference data global (sem scope por business)
+    'countries',
+    'currencies',
+    'genders',
+    'titles',
+    'professions',
+    'marital_statuses',
+    'client_types',
+    'client_relationships',
+    'units',
+    'payment_types',
+    'payment_term_types',
+    'types_of_service',
+    'account_types',
+    'account_detail_types',
+    'work_statuses',
+    'work_details',
+    'warranties',
+    // Tabelas core UltimatePOS (são reference / sistema, têm seu próprio padrão)
+    'business',
+    'system',
+    'document_and_note',
+    'media',
+    'reference_count',
+    'kyc_identifications',
+    'barcodes',
+    // Subtypes podem ter business_id=0 (default global) — testado separadamente em MultiTenantIsolationTest
+    'account_subtypes',
+];
+
+/**
+ * Helper — resolve nome da tabela da Entity via reflection (lê propriedade $table protected).
+ * Fallback: pluralize lowercase do classname (convenção Eloquent).
+ */
+function accResolveTableName(string $fqcn): string
+{
+    try {
+        $reflection = new ReflectionClass($fqcn);
+        $instance = $reflection->newInstanceWithoutConstructor();
+        $tableProp = $reflection->getProperty('table');
+        $tableProp->setAccessible(true);
+        $table = $tableProp->getValue($instance);
+        if (! empty($table)) {
+            return $table;
+        }
+    } catch (\Throwable $e) {
+        // fall through
+    }
+
+    // Convenção Eloquent: snake_case plural do classname
+    $short = (new ReflectionClass($fqcn))->getShortName();
+    $snake = strtolower(preg_replace('/(?<!^)[A-Z]/', '_$0', $short));
+
+    // pluralize simples
+    if (str_ends_with($snake, 'y')) {
+        return substr($snake, 0, -1) . 'ies';
+    }
+    if (str_ends_with($snake, 's')) {
+        return $snake;
+    }
+
+    return $snake . 's';
+}
+
+it('toda Entity Accounting mapeada a tabela existente declara business_id (Tier 0 ADR 0093)', function () {
+    $entityFiles = glob(base_path('Modules/Accounting/Entities/*.php'));
+
+    expect($entityFiles)->not->toBeEmpty('Glob não encontrou Entities — path errado?');
+
+    $offenders = [];
+    $audited = 0;
+    $skipped = [];
+
+    foreach ($entityFiles as $file) {
+        $classname = basename($file, '.php');
+        $fqcn = "Modules\\Accounting\\Entities\\{$classname}";
+
+        if (! class_exists($fqcn)) {
+            $skipped[] = "{$classname} (class não carrega)";
+            continue;
+        }
+
+        try {
+            $table = accResolveTableName($fqcn);
+        } catch (\Throwable $e) {
+            $skipped[] = "{$classname} (resolve table failed: {$e->getMessage()})";
+            continue;
+        }
+
+        // Tabela não existe no schema dev — skip (não é tabela viva)
+        if (! Schema::hasTable($table)) {
+            $skipped[] = "{$classname} → `{$table}` (tabela não existe no schema)";
+            continue;
+        }
+
+        // Tabela na allowlist (reference data / core compartilhada) — skip
+        if (in_array($table, ACC_ALLOWLIST_NO_BIZ_ID, true)) {
+            continue;
+        }
+
+        $audited++;
+
+        if (! Schema::hasColumn($table, 'business_id')) {
+            $offenders[] = "{$classname} → `{$table}` SEM coluna business_id";
+        }
+    }
+
+    // Pelo menos algumas Entities precisam ter sido auditadas — se 0, algo está errado
+    expect($audited)->toBeGreaterThan(0, 'Nenhuma Entity auditada — verificar path/schema');
+
+    expect($offenders)->toBeEmpty(
+        sprintf(
+            "Entities Accounting SEM business_id (violação Tier 0 ADR 0093):\n  - %s\n\nSkipped (%d): %s",
+            implode("\n  - ", $offenders),
+            count($skipped),
+            implode(', ', array_slice($skipped, 0, 5)) . (count($skipped) > 5 ? '...' : '')
+        )
+    );
+});
+
+it('Entities críticas têm coluna business_id confirmada', function () {
+    $critical = [
+        \Modules\Accounting\Entities\Account::class               => 'accounts',
+        \Modules\Accounting\Entities\ChartOfAccount::class        => 'chart_of_accounts',
+        \Modules\Accounting\Entities\Transfer::class              => 'transfers',
+        \Modules\Accounting\Entities\Budget::class                => 'budgets',
+    ];
+
+    $missing = [];
+
+    foreach ($critical as $fqcn => $expectedTable) {
+        if (! class_exists($fqcn)) {
+            $missing[] = "{$fqcn} (class não existe)";
+            continue;
+        }
+
+        $table = accResolveTableName($fqcn);
+
+        // Compara com expected pra detectar mismatch de nome
+        if ($table !== $expectedTable) {
+            // Mismatch é warn, não fail — alguma Entity pode ter $table custom
+        }
+
+        if (! Schema::hasTable($table)) {
+            $this->markTestSkipped("Tabela `{$table}` missing — rode migrate primeiro");
+        }
+
+        if (! Schema::hasColumn($table, 'business_id')) {
+            $missing[] = "{$fqcn} → `{$table}` SEM business_id";
+        }
+    }
+
+    expect($missing)->toBeEmpty(
+        "Entities críticas SEM business_id (Tier 0):\n  - " . implode("\n  - ", $missing)
+    );
+});
+
+it('journal_entries tem location_id que liga indiretamente ao business via business_locations', function () {
+    // JournalEntry é o caso especial — não tem business_id direto, escopa via JOIN
+    // em business_locations.business_id. Esta auditoria confirma o contrato indireto.
+    if (! Schema::hasTable('journal_entries') || ! Schema::hasTable('business_locations')) {
+        $this->markTestSkipped('Tabelas journal_entries ou business_locations missing');
+    }
+
+    expect(Schema::hasColumn('journal_entries', 'location_id'))->toBeTrue(
+        'journal_entries.location_id é necessário pra scope indireto via business_locations'
+    );
+    expect(Schema::hasColumn('business_locations', 'business_id'))->toBeTrue(
+        'business_locations.business_id é o link de tenant pra JournalEntry'
+    );
+});

--- a/Modules/Accounting/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/Accounting/Tests/Feature/MultiTenantIsolationTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Accounting\Entities\AccountSubtype;
+use Modules\Accounting\Entities\ChartOfAccount;
+use Modules\Accounting\Entities\JournalEntry;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Testa isolamento multi-tenant Tier 0 dos Models Accounting.
+ *
+ * IMPORTANTE — Accounting (módulo legacy UltimatePOS) NÃO tem BusinessScope global
+ * em todos os Models como ComunicacaoVisual ou Financeiro. Filtragem por business_id
+ * acontece via scopes locais (`forBusiness`) ou WHERE manual nos Controllers.
+ * Estes tests validam que esses scopes funcionam como esperado e que dados de biz=1
+ * NUNCA aparecem ao consultar como biz=99 (Tier 0 IRREVOGÁVEL — ADR 0093).
+ *
+ * NUNCA usar biz=4 (ROTA LIVRE — cliente Larissa produção) — conforme ADR 0101.
+ * Tests usam biz=1 (Wagner WR2) e biz=99 (fictício, sem dados).
+ *
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ */
+
+// Guard SQLite + tabelas: Models Accounting requerem schema MySQL UltimatePOS.
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped(
+            'SQLite-incompatível: Models Accounting requerem schema MySQL UltimatePOS ' .
+            '(ADR 0101 — Pest local mandatory contra DB dev real)'
+        );
+    }
+    foreach (['chart_of_accounts', 'journal_entries', 'account_subtypes', 'business_locations'] as $tbl) {
+        if (! Schema::hasTable($tbl)) {
+            $this->markTestSkipped("Tabela `{$tbl}` missing — rode migrate do módulo Accounting primeiro");
+        }
+    }
+});
+
+// IDs usados nos testes — biz=1 (Wagner) e biz=99 (fictício isolamento)
+const ACC_BIZ_WAGNER = 1;
+const ACC_BIZ_FICTICIO = 99;
+
+// ------------------------------------------------------------------
+// Helper — simula sessão de business sem autenticar user (suficiente pro scope manual)
+// ------------------------------------------------------------------
+function setAccBizSession(int $businessId): void
+{
+    session([
+        'business.id'      => $businessId,
+        'user.business_id' => $businessId,
+    ]);
+}
+
+// ------------------------------------------------------------------
+// ChartOfAccount — scope forBusiness filtra business_id
+// ------------------------------------------------------------------
+
+it('ChartOfAccount biz=1 não aparece via scope forBusiness com session biz=99', function () {
+    // Cria conta no biz=1 (insert direto bypassa qualquer scope na inserção)
+    $coa = ChartOfAccount::create([ // SUPERADMIN: inserção direta de teste seed
+        'business_id'  => ACC_BIZ_WAGNER,
+        'name'         => 'Conta Teste Isolamento',
+        'gl_code'      => 'TEST-ISOL-001',
+        'account_type' => 'asset',
+        'active'       => 1,
+    ]);
+
+    // Consulta com session biz=99 via scope manual `forBusiness` — NÃO deve aparecer
+    setAccBizSession(ACC_BIZ_FICTICIO);
+    $resultado = ChartOfAccount::forBusiness()->where('id', $coa->id)->get();
+
+    expect($resultado)->toHaveCount(0);
+})->afterEach(function () {
+    ChartOfAccount::where('gl_code', 'TEST-ISOL-001')
+        ->where('business_id', ACC_BIZ_WAGNER)
+        ->forceDelete();
+});
+
+it('ChartOfAccount biz=1 aparece via scope forBusiness com session biz=1', function () {
+    $coa = ChartOfAccount::create([ // SUPERADMIN: inserção direta de teste seed
+        'business_id'  => ACC_BIZ_WAGNER,
+        'name'         => 'Conta Teste Vis Same Biz',
+        'gl_code'      => 'TEST-ISOL-002',
+        'account_type' => 'asset',
+        'active'       => 1,
+    ]);
+
+    setAccBizSession(ACC_BIZ_WAGNER);
+    $resultado = ChartOfAccount::forBusiness()->where('id', $coa->id)->get();
+
+    expect($resultado)->toHaveCount(1);
+    expect($resultado->first()->gl_code)->toBe('TEST-ISOL-002');
+})->afterEach(function () {
+    ChartOfAccount::where('gl_code', 'TEST-ISOL-002')
+        ->where('business_id', ACC_BIZ_WAGNER)
+        ->forceDelete();
+});
+
+// ------------------------------------------------------------------
+// AccountSubtype — scope forBusiness permite biz=0 (default global) OR biz session
+// ------------------------------------------------------------------
+
+it('AccountSubtype biz=1 não aparece via forBusiness com session biz=99', function () {
+    $sub = AccountSubtype::create([ // SUPERADMIN: inserção direta de teste seed
+        'business_id'  => ACC_BIZ_WAGNER,
+        'account_type' => 'asset',
+        'name'         => 'Subtype Teste Isolamento',
+        'description'  => 'Pest isolation test',
+        'active'       => 1,
+    ]);
+
+    // Com session biz=99, scope forBusiness exige business_id=0 OR business_id=99.
+    // Como o nosso é biz=1, NÃO deve aparecer.
+    setAccBizSession(ACC_BIZ_FICTICIO);
+    $resultado = AccountSubtype::forBusiness()
+        ->where('account_subtypes.id', $sub->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(0);
+})->afterEach(function () {
+    AccountSubtype::where('name', 'Subtype Teste Isolamento')
+        ->where('business_id', ACC_BIZ_WAGNER)
+        ->forceDelete();
+});
+
+it('AccountSubtype com business_id=0 (default global) aparece pra qualquer biz', function () {
+    // business_id=0 é convenção do módulo pra "tipo default global" — aparece em qualquer biz
+    $sub = AccountSubtype::create([ // SUPERADMIN: inserção direta de teste seed
+        'business_id'  => 0,
+        'account_type' => 'asset',
+        'name'         => 'Subtype Default Teste',
+        'description'  => 'Global default',
+        'active'       => 1,
+    ]);
+
+    setAccBizSession(ACC_BIZ_FICTICIO);
+    $resultado = AccountSubtype::forBusiness()
+        ->where('account_subtypes.id', $sub->id)
+        ->get();
+
+    // Default global (business_id=0) é visível pra qualquer business — é o contrato do scope
+    expect($resultado)->toHaveCount(1);
+})->afterEach(function () {
+    AccountSubtype::where('name', 'Subtype Default Teste')
+        ->where('business_id', 0)
+        ->forceDelete();
+});
+
+// ------------------------------------------------------------------
+// JournalEntry — filtra via JOIN business_locations.business_id
+// ------------------------------------------------------------------
+
+it('JournalEntry biz=1 não aparece em query filtrada por business_locations.business_id=99', function () {
+    // Pega uma location de biz=1 — se não existir, skip
+    $locationBiz1 = DB::table('business_locations')
+        ->where('business_id', ACC_BIZ_WAGNER)
+        ->first();
+
+    if (! $locationBiz1) {
+        $this->markTestSkipped('Sem business_location pra biz=1 — rode seeder UltimatePOS primeiro');
+    }
+
+    // Cria chart_of_account no biz=1 (precisa pra FK)
+    $coa = ChartOfAccount::create([ // SUPERADMIN: inserção direta de teste seed
+        'business_id'  => ACC_BIZ_WAGNER,
+        'name'         => 'COA pra JE teste',
+        'gl_code'      => 'TEST-ISOL-JE',
+        'account_type' => 'asset',
+        'active'       => 1,
+    ]);
+
+    $je = JournalEntry::create([ // SUPERADMIN: inserção direta de teste seed
+        'reversed'             => 0,
+        'transaction_number'   => 'JE-TEST-ISOL-001',
+        'location_id'          => $locationBiz1->id,
+        'chart_of_account_id'  => $coa->id,
+        'transaction_type'     => 'transfer_entry',
+        'date'                 => now()->toDateString(),
+        'month'                => (int) now()->format('m'),
+        'year'                 => (int) now()->format('Y'),
+        'debit'                => 100,
+        'credit'               => 0,
+        'manual_entry'         => 0,
+    ]);
+
+    // Query como o Controller faz: leftJoin business_locations + where business_id=99
+    setAccBizSession(ACC_BIZ_FICTICIO);
+    $count = JournalEntry::leftJoin(
+        'business_locations',
+        'business_locations.id',
+        '=',
+        'journal_entries.location_id'
+    )
+        ->where('business_locations.business_id', ACC_BIZ_FICTICIO)
+        ->where('journal_entries.id', $je->id)
+        ->count();
+
+    expect($count)->toBe(0);
+})->afterEach(function () {
+    JournalEntry::where('transaction_number', 'JE-TEST-ISOL-001')->forceDelete();
+    ChartOfAccount::where('gl_code', 'TEST-ISOL-JE')
+        ->where('business_id', ACC_BIZ_WAGNER)
+        ->forceDelete();
+});
+
+// ------------------------------------------------------------------
+// Cross-tenant raw query — guard final
+// ------------------------------------------------------------------
+
+it('query raw com business_id=99 não retorna chart_of_accounts inseridos como biz=1', function () {
+    $coa = ChartOfAccount::create([ // SUPERADMIN: inserção direta de teste seed
+        'business_id'  => ACC_BIZ_WAGNER,
+        'name'         => 'COA Raw Cross-Tenant',
+        'gl_code'      => 'TEST-RAW-CT',
+        'account_type' => 'equity',
+        'active'       => 1,
+    ]);
+
+    $count = DB::table('chart_of_accounts')
+        ->where('business_id', ACC_BIZ_FICTICIO)
+        ->where('id', $coa->id)
+        ->count();
+
+    expect($count)->toBe(0);
+})->afterEach(function () {
+    ChartOfAccount::where('gl_code', 'TEST-RAW-CT')
+        ->where('business_id', ACC_BIZ_WAGNER)
+        ->forceDelete();
+});

--- a/Modules/Accounting/Tests/Feature/SmokeRoutesTest.php
+++ b/Modules/Accounting/Tests/Feature/SmokeRoutesTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke tests rotas Accounting — apenas status code < 500 + middleware auth aplicado.
+ *
+ * Não testa renderização completa nem lógica de negócio. Garante que:
+ *  - Rotas registradas existem (não 404)
+ *  - Middleware 'auth' redireciona usuário não autenticado (302 → login)
+ *  - Usuário autenticado biz=1 acessa sem 5xx (200, 302, 403 aceitos)
+ *
+ * @see Modules/Accounting/Http/routes.php
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped(
+            'SQLite-incompatível: smoke routes UltimatePOS precisam schema MySQL + seeders (ADR 0101)'
+        );
+    }
+    foreach (['business', 'users', 'roles', 'chart_of_accounts'] as $tbl) {
+        if (! Schema::hasTable($tbl)) {
+            $this->markTestSkipped("Tabela `{$tbl}` missing — rode migrate UltimatePOS primeiro");
+        }
+    }
+});
+
+// ------------------------------------------------------------------
+// Helper — autentica admin do biz=1 (Wagner WR2 — ADR 0101)
+// ------------------------------------------------------------------
+function actAsAccountingAdmin(): ?User
+{
+    $business = Business::find(1);
+    if (! $business) {
+        return null;
+    }
+    $user = User::where('business_id', $business->id)->first();
+    if (! $user) {
+        return null;
+    }
+
+    session([
+        'business.id'      => $business->id,
+        'business.name'    => $business->name,
+        'user.business_id' => $business->id,
+        'user.id'          => $user->id,
+        'is_admin'         => true,
+    ]);
+
+    test()->actingAs($user);
+
+    return $user;
+}
+
+// ------------------------------------------------------------------
+// Rota não autenticada — middleware redireciona pra login
+// ------------------------------------------------------------------
+
+it('GET /accounting/dashboard sem auth redireciona ou nega (não 500)', function () {
+    $response = $this->get('/accounting/dashboard');
+
+    // Aceitos: 302 (redirect login), 401 (unauthorized), 403 (forbidden)
+    // NUNCA 500 — significaria que middleware crashou.
+    expect($response->status())->toBeLessThan(500);
+});
+
+// ------------------------------------------------------------------
+// Rotas autenticadas biz=1 — não devem 5xx
+// ------------------------------------------------------------------
+
+it('GET /accounting/dashboard autenticado biz=1 responde sem 5xx', function () {
+    $user = actAsAccountingAdmin();
+    if (! $user) {
+        $this->markTestSkipped('Sem User pra biz=1 — seeder UltimatePOS necessário');
+    }
+
+    $response = $this->get('/accounting/dashboard');
+
+    expect($response->status())->toBeLessThan(500);
+});
+
+it('GET /accounting/chart_of_account autenticado biz=1 responde sem 5xx', function () {
+    $user = actAsAccountingAdmin();
+    if (! $user) {
+        $this->markTestSkipped('Sem User pra biz=1 — seeder UltimatePOS necessário');
+    }
+
+    $response = $this->get('/accounting/chart_of_account');
+
+    expect($response->status())->toBeLessThan(500);
+});
+
+it('GET /accounting/journal_entry autenticado biz=1 responde sem 5xx', function () {
+    $user = actAsAccountingAdmin();
+    if (! $user) {
+        $this->markTestSkipped('Sem User pra biz=1 — seeder UltimatePOS necessário');
+    }
+
+    $response = $this->get('/accounting/journal_entry');
+
+    expect($response->status())->toBeLessThan(500);
+});
+
+it('GET /accounting/trial_balance autenticado biz=1 responde sem 5xx', function () {
+    $user = actAsAccountingAdmin();
+    if (! $user) {
+        $this->markTestSkipped('Sem User pra biz=1 — seeder UltimatePOS necessário');
+    }
+
+    $response = $this->get('/accounting/trial_balance');
+
+    expect($response->status())->toBeLessThan(500);
+});
+
+it('GET /accounting/balance_sheet autenticado biz=1 responde sem 5xx', function () {
+    $user = actAsAccountingAdmin();
+    if (! $user) {
+        $this->markTestSkipped('Sem User pra biz=1 — seeder UltimatePOS necessário');
+    }
+
+    $response = $this->get('/accounting/balance_sheet');
+
+    expect($response->status())->toBeLessThan(500);
+});
+
+it('GET /accounting/transfers autenticado biz=1 responde sem 5xx', function () {
+    $user = actAsAccountingAdmin();
+    if (! $user) {
+        $this->markTestSkipped('Sem User pra biz=1 — seeder UltimatePOS necessário');
+    }
+
+    $response = $this->get('/accounting/transfers');
+
+    expect($response->status())->toBeLessThan(500);
+});

--- a/Modules/Auditoria/Tests/Feature/AuditoriaModuleTest.php
+++ b/Modules/Auditoria/Tests/Feature/AuditoriaModuleTest.php
@@ -2,6 +2,8 @@
 
 use Nwidart\Modules\Facades\Module;
 
+uses(Tests\TestCase::class);
+
 /**
  * Smoke test do scaffold Modules/Auditoria (US-AUDIT-007).
  *

--- a/Modules/Auditoria/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/Auditoria/Tests/Feature/MultiTenantIsolationTest.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Activitylog\Models\Activity;
+
+/**
+ * Testa isolamento multi-tenant Tier 0 do Modules/Auditoria.
+ *
+ * Auditoria NAO tem Entity propria — espelha `activity_log` (Spatie) que
+ * recebeu coluna `business_id` via migration legacy (2021_03_16) + colunas
+ * causer_kind/reverted_* via US-AUDIT-005. Isolamento e enforced no
+ * AuditoriaController via where('activity_log.business_id', $businessId)
+ * direto na query (nao via global scope).
+ *
+ * Este teste valida que:
+ *   - Activity criada com biz=1 NAO aparece quando filtro biz=99 e aplicado
+ *   - Activity criada com biz=1 APARECE quando filtro biz=1 e aplicado
+ *   - RevertService::canRevert() bloqueia cross-tenant (biz=99 user tentando
+ *     reverter Activity biz=1 deve receber deny)
+ *
+ * NUNCA usar biz=4 (ROTA LIVRE — cliente Larissa producao) — conforme
+ * ADR 0101. Tests usam biz=1 (Wagner WR2) e biz=99 (ficticio).
+ *
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ * @see memory/decisions/0127-modules-auditoria-ui-undo.md
+ */
+
+uses(Tests\TestCase::class);
+
+// Guard SQLite: activity_log com business_id + causer_kind requer schema MySQL UltimatePOS.
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompativel: activity_log com business_id + causer_kind requer schema MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasTable('activity_log')) {
+        $this->markTestSkipped('activity_log table missing — rode migrations Spatie + 2021_03_16_add_business_id primeiro');
+    }
+    if (! Schema::hasColumn('activity_log', 'business_id')) {
+        $this->markTestSkipped('coluna business_id ausente em activity_log — rode migration 2021_03_16_add_business_id_to_activity_log_table');
+    }
+});
+
+// IDs usados nos testes — biz=1 (Wagner) e biz=99 (ficticio isolamento)
+const AUDIT_BIZ_WAGNER = 1;
+const AUDIT_BIZ_FICTICIO = 99;
+
+// Marcadores unicos pra cleanup isolado (nao colide com producao)
+const AUDIT_LOG_NAME_TEST = 'auditoria-multitenant-test';
+
+// ------------------------------------------------------------------
+// Helpers internos
+// ------------------------------------------------------------------
+
+/**
+ * Simula sessao de um business sem autenticar usuario.
+ */
+function setAuditoriaBizSession(int $businessId): void
+{
+    session(['user.business_id' => $businessId]);
+}
+
+// ------------------------------------------------------------------
+// Cenarios
+// ------------------------------------------------------------------
+
+it('Activity biz=1 nao aparece em query filtrada por biz=99', function () {
+    // Cria Activity diretamente (Spatie nao usa global scope nessa Model)
+    $activity = Activity::create([
+        'log_name'    => AUDIT_LOG_NAME_TEST,
+        'description' => 'criou registro de teste auditoria',
+        'event'       => 'created',
+        'business_id' => AUDIT_BIZ_WAGNER,
+        'properties'  => ['old' => [], 'attributes' => ['nome' => 'X']],
+    ]);
+
+    // Replica filtro que AuditoriaController::index() aplica
+    setAuditoriaBizSession(AUDIT_BIZ_FICTICIO);
+    $resultado = Activity::query()
+        ->where('activity_log.business_id', AUDIT_BIZ_FICTICIO)
+        ->where('id', $activity->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(0);
+})->afterEach(function () {
+    Activity::where('log_name', AUDIT_LOG_NAME_TEST)
+        ->where('business_id', AUDIT_BIZ_WAGNER)
+        ->delete();
+});
+
+it('Activity biz=1 aparece em query filtrada por biz=1', function () {
+    $activity = Activity::create([
+        'log_name'    => AUDIT_LOG_NAME_TEST,
+        'description' => 'atualizou registro de teste auditoria',
+        'event'       => 'updated',
+        'business_id' => AUDIT_BIZ_WAGNER,
+        'properties'  => ['old' => ['status' => 'A'], 'attributes' => ['status' => 'B']],
+    ]);
+
+    setAuditoriaBizSession(AUDIT_BIZ_WAGNER);
+    $resultado = Activity::query()
+        ->where('activity_log.business_id', AUDIT_BIZ_WAGNER)
+        ->where('id', $activity->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(1);
+    expect($resultado->first()->event)->toBe('updated');
+    expect((int) $resultado->first()->business_id)->toBe(AUDIT_BIZ_WAGNER);
+})->afterEach(function () {
+    Activity::where('log_name', AUDIT_LOG_NAME_TEST)
+        ->where('business_id', AUDIT_BIZ_WAGNER)
+        ->delete();
+});
+
+it('listing scoped biz=99 nao vaza Activity de outro tenant biz=1', function () {
+    // Cria 3 Activities em biz=1
+    for ($i = 0; $i < 3; $i++) {
+        Activity::create([
+            'log_name'    => AUDIT_LOG_NAME_TEST,
+            'description' => "ativ vazamento {$i}",
+            'event'       => 'created',
+            'business_id' => AUDIT_BIZ_WAGNER,
+            'properties'  => ['old' => [], 'attributes' => ['idx' => $i]],
+        ]);
+    }
+
+    // Lista com filtro biz=99 — nao deve trazer nenhuma das 3
+    setAuditoriaBizSession(AUDIT_BIZ_FICTICIO);
+    $vazamento = Activity::query()
+        ->where('activity_log.business_id', AUDIT_BIZ_FICTICIO)
+        ->where('log_name', AUDIT_LOG_NAME_TEST)
+        ->count();
+
+    expect($vazamento)->toBe(0);
+})->afterEach(function () {
+    Activity::where('log_name', AUDIT_LOG_NAME_TEST)
+        ->where('business_id', AUDIT_BIZ_WAGNER)
+        ->delete();
+});
+
+it('RevertService::canRevert bloqueia cross-tenant biz=99 user tentando reverter biz=1', function () {
+    if (! class_exists(\Modules\Auditoria\Services\RevertService::class)) {
+        $this->markTestSkipped('RevertService nao existe (US-AUDIT-008 pendente).');
+    }
+    if (! class_exists(\App\User::class)) {
+        $this->markTestSkipped('App\\User nao encontrado — schema UltimatePOS incompleto.');
+    }
+
+    $activity = Activity::create([
+        'log_name'    => AUDIT_LOG_NAME_TEST,
+        'description' => 'activity biz=1 candidata a revert',
+        'event'       => 'updated',
+        'business_id' => AUDIT_BIZ_WAGNER,
+        'subject_type' => \App\Transaction::class,
+        'subject_id'  => 1, // pode ate nao existir — deny vem antes pela checagem de biz
+        'properties'  => ['old' => ['status' => 'final'], 'attributes' => ['status' => 'draft']],
+    ]);
+
+    // User com business_id=99 (ficticio) — nao deve poder reverter Activity biz=1
+    $userBiz99 = new \App\User();
+    $userBiz99->id = 999999;
+    $userBiz99->business_id = AUDIT_BIZ_FICTICIO;
+
+    $service = new \Modules\Auditoria\Services\RevertService();
+    $check = $service->canRevert($activity, $userBiz99);
+
+    expect($check->allowed)->toBeFalse();
+    expect($check->reason)->toContain('Tier 0');
+})->afterEach(function () {
+    Activity::where('log_name', AUDIT_LOG_NAME_TEST)
+        ->where('business_id', AUDIT_BIZ_WAGNER)
+        ->delete();
+});

--- a/Modules/Auditoria/Tests/Feature/SmokeRoutesTest.php
+++ b/Modules/Auditoria/Tests/Feature/SmokeRoutesTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Smoke das 3 rotas principais do AuditoriaController + checagem
+ * de middleware auth aplicado na stack canonica UltimatePOS.
+ *
+ * Valida que:
+ *   1. GET /auditoria (auditoria.index) responde <500 (200 ou 302 pra login)
+ *   2. GET /auditoria/{id} (auditoria.show) responde <500
+ *   3. POST /auditoria/{id}/revert (auditoria.revert) responde <500
+ *      (placeholder 501 atual e considerado smoke OK — ver
+ *      AuditoriaController::revert US-AUDIT-008 pendente)
+ *   4. Acesso anonimo (sem auth) e redirecionado/blocado pelo
+ *      middleware 'auth' da stack canonica
+ *
+ * Per stack UltimatePOS: ['web','SetSessionData','auth','language',
+ * 'timezone','AdminSidebarMenu','CheckUserLogin'] (Routes/web.php).
+ *
+ * NUNCA usar biz=4 (ROTA LIVRE producao) — ADR 0101. Tests assumem
+ * que rotas existem (validado em AuditoriaModuleTest) e so checam
+ * status HTTP nao-500.
+ *
+ * @see memory/decisions/0127-modules-auditoria-ui-undo.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+
+uses(Tests\TestCase::class);
+
+// Guard SQLite: middlewares UltimatePOS (SetSessionData/AdminSidebarMenu) requerem
+// tables MySQL como business/users/permissions; smoke real precisa schema completo.
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompativel: middlewares UltimatePOS (SetSessionData, AdminSidebarMenu) requerem schema MySQL com tables business/users/permissions (ADR 0101)');
+    }
+    if (! Schema::hasTable('activity_log')) {
+        $this->markTestSkipped('activity_log table missing — rode migrations Spatie primeiro');
+    }
+});
+
+// ------------------------------------------------------------------
+// Smoke routes
+// ------------------------------------------------------------------
+
+it('GET /auditoria (auditoria.index) responde com status < 500', function () {
+    // Sem auth — esperado redirect 302 pra login ou similar < 500.
+    // Importante: NAO deve crashar com 500 (signal de bug em Controller/middleware).
+    $response = $this->get(route('auditoria.index'));
+
+    expect($response->getStatusCode())->toBeLessThan(500);
+});
+
+it('GET /auditoria/{id} (auditoria.show) responde com status < 500', function () {
+    $response = $this->get(route('auditoria.show', ['activityId' => 1]));
+
+    expect($response->getStatusCode())->toBeLessThan(500);
+});
+
+it('POST /auditoria/{id}/revert (auditoria.revert) responde com status < 500', function () {
+    // Placeholder atual retorna 501 (Not Implemented) per
+    // AuditoriaController::revert. 501 < 500 nao bate — corrigir
+    // expectativa: 501 e classe 5xx, mas e SEMANTIC nao crash.
+    // Smoke real aqui: response existe e nao e 500 generico.
+    $response = $this->post(route('auditoria.revert', ['activityId' => 1]), [
+        'reason' => 'teste smoke route revert — placeholder',
+    ]);
+
+    // Aceita: 302 (redirect auth), 401/403 (auth fail), 419 (csrf), 501 (placeholder),
+    // 422 (validation). REJEITA: 500 (crash generico) e ausencia de response.
+    expect($response->getStatusCode())->not->toBe(500);
+});
+
+it('rota /auditoria bloqueia acesso anonimo via middleware auth', function () {
+    // Sem login — middleware 'auth' da stack canonica UltimatePOS deve
+    // interceptar e redirecionar pra /login ou retornar 401/403.
+    $response = $this->get(route('auditoria.index'));
+
+    $statusCode = $response->getStatusCode();
+    $isAuthBlocked = in_array($statusCode, [302, 401, 403], true);
+
+    expect($isAuthBlocked)->toBeTrue(
+        "Esperado status 302/401/403 (auth middleware) — recebeu {$statusCode}. ".
+        'Se 200, middleware auth NAO esta aplicado em /auditoria — violacao ADR 0127 stack canonica.'
+    );
+});

--- a/Modules/Connector/Tests/Feature/AuthApiTest.php
+++ b/Modules/Connector/Tests/Feature/AuthApiTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke do pipeline de autenticação Passport (auth:api) do Modules/Connector.
+ *
+ * O Connector expõe API REST extensa pra clientes externos (Delphi WR Comercial,
+ * SaaS Woo, etc) — toda rota está sob middleware `['log.delphi', 'auth:api', 'timezone']`
+ * conforme [Modules/Connector/Routes/api.php](../../Routes/api.php).
+ *
+ * Este teste NÃO valida geração de token real (Passport personal access client
+ * pode não estar provisionado em CI). Apenas garante:
+ *   1. Endpoints rejeitam acesso sem Bearer → 401
+ *   2. Endpoints rejeitam Bearer inválido → 401
+ *   3. Pipeline auth:api está ANTES do controller (não há 200 anônimo)
+ *
+ * Para testes de token real, ver [DelphiOImpressoContractTest](../../../../tests/Feature/Connector/DelphiOImpressoContractTest.php).
+ *
+ * @see memory/decisions/0021-...-connector-delphi-restaurado.md (se existir — ADR 0021)
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md (Tier 0 — token sempre carrega business_id)
+ */
+
+beforeEach(function () {
+    // Guard SQLite: Passport + UltimatePOS schema requerem MySQL/MariaDB real.
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: Passport + UltimatePOS Connector requerem schema MySQL (ADR 0101)');
+    }
+});
+
+it('endpoints Connector API rejeitam acesso sem Bearer (401)', function () {
+    // Smoke nos endpoints REST principais do Connector — todos protegidos por
+    // auth:api. Sem Bearer = 401 Unauthenticated.
+    $endpoints = [
+        ['GET',  '/connector/api/contactapi'],
+        ['GET',  '/connector/api/product'],
+        ['GET',  '/connector/api/sell'],
+        ['GET',  '/connector/api/business-location'],
+        ['GET',  '/connector/api/taxonomy'],
+        ['GET',  '/connector/api/business-details'],
+    ];
+
+    foreach ($endpoints as [$method, $url]) {
+        $r = $this->withHeaders(['Accept' => 'application/json'])->call($method, $url);
+        // 401 Unauthenticated é o esperado. 404 indica rota não registrada (regressão).
+        expect($r->getStatusCode())->toBeIn([401, 422], "Endpoint {$method} {$url} retornou {$r->getStatusCode()}, esperado 401");
+        expect($r->getStatusCode())->not->toBe(404, "Rota {$method} {$url} não está registrada (404)");
+        expect($r->getStatusCode())->not->toBe(200, "Endpoint {$method} {$url} retornou 200 sem auth — pipeline auth:api quebrado!");
+    }
+});
+
+it('endpoints Connector API rejeitam Bearer token inválido (401)', function () {
+    $endpoints = [
+        ['GET',  '/connector/api/contactapi'],
+        ['GET',  '/connector/api/product'],
+        ['GET',  '/connector/api/sell'],
+    ];
+
+    foreach ($endpoints as [$method, $url]) {
+        $r = $this->withHeaders([
+            'Accept'        => 'application/json',
+            'Authorization' => 'Bearer token-invalido-falso-' . uniqid(),
+        ])->call($method, $url);
+
+        // Passport rejeita token mal-formado/expirado/inexistente → 401
+        expect($r->getStatusCode())->toBe(401, "Endpoint {$method} {$url} aceitou token inválido — fail-secure quebrado!");
+    }
+});
+
+it('endpoints CRM e FieldForce também exigem auth:api', function () {
+    // Sub-grupos com middleware próprio mas mesmo stack auth:api.
+    $endpoints = [
+        ['GET',  '/connector/api/crm/follow-ups'],
+        ['GET',  '/connector/api/crm/leads'],
+        ['GET',  '/connector/api/field-force'],
+    ];
+
+    foreach ($endpoints as [$method, $url]) {
+        $r = $this->withHeaders(['Accept' => 'application/json'])->call($method, $url);
+        expect($r->getStatusCode())->toBeIn([401, 422], "Sub-API {$method} {$url} status inesperado: {$r->getStatusCode()}");
+        expect($r->getStatusCode())->not->toBe(200, "Sub-API {$method} {$url} retornou 200 sem auth!");
+    }
+});
+
+it('rotas Connector estão registradas com middleware auth:api', function () {
+    // Audita o registro de rotas — protege contra alguém remover auth:api do grupo.
+    $routes = Route::getRoutes();
+    $connectorRoutes = collect($routes)->filter(function ($r) {
+        return str_starts_with($r->uri(), 'connector/api');
+    });
+
+    expect($connectorRoutes->count())->toBeGreaterThan(10, 'Esperado >10 rotas registradas em connector/api/*');
+
+    // Toda rota Connector API DEVE incluir auth:api no middleware
+    $semAuth = $connectorRoutes->filter(function ($r) {
+        return ! in_array('auth:api', $r->gatherMiddleware(), true);
+    });
+
+    expect($semAuth->count())->toBe(0, 'Rotas Connector sem auth:api: ' . $semAuth->pluck('uri')->implode(', '));
+});
+
+it('middleware log.delphi aplicado ANTES de auth:api (captura 401 também)', function () {
+    // Guard de ordem — log.delphi precisa rodar antes pra logar tentativas
+    // não-autenticadas. Se inverter, perdemos visibilidade de auth failures
+    // (Delphi mandando token expirado, ataques de força bruta, etc).
+    $routesFile = file_get_contents(base_path('Modules/Connector/Routes/api.php'));
+    expect($routesFile)->toContain("'log.delphi', 'auth:api'");
+});

--- a/Modules/Connector/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/Connector/Tests/Feature/MultiTenantIsolationTest.php
@@ -1,0 +1,213 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Contact;
+use App\Product;
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Isolamento multi-tenant Tier 0 IRREVOGÁVEL ([ADR 0093]) na API Connector.
+ *
+ * Connector é o ÚNICO ponto onde um cliente externo (Delphi/Woo/SaaS) acessa
+ * dados de negócio via token Passport. Vazar dados entre tenants aqui é o
+ * pior bug possível — exposição cruzada de Contacts/Products/Transactions
+ * entre clientes pagos.
+ *
+ * Regra: token Passport carrega `business_id` via `user.business_id`.
+ * Toda query DEVE respeitar global scope.
+ *
+ * NUNCA usar biz=4 (ROTA LIVRE — cliente Larissa produção) — conforme ADR 0101.
+ * Tests usam biz=1 (Wagner WR2) e biz=99 (fictício isolamento).
+ *
+ * Estratégia: insere dado em biz=1 via withoutGlobalScopes; simula sessão
+ * biz=99; valida que query SEM withoutGlobalScopes NÃO retorna o registro.
+ *
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ */
+
+const BIZ_WAGNER = 1;
+const BIZ_FICTICIO = 99;
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: Connector + UltimatePOS Models requerem schema MySQL (ADR 0101)');
+    }
+    if (! Schema::hasTable('contacts') || ! Schema::hasTable('products') || ! Schema::hasTable('business')) {
+        $this->markTestSkipped('Schema UltimatePOS incompleto — rode migrate primeiro');
+    }
+});
+
+/**
+ * Helper: simula sessão authenticada de um business sem precisar de Passport real.
+ * Global scope `BusinessIdScope` de UltimatePOS lê `session('user.business_id')`.
+ */
+function setConnectorBizSession(int $businessId): void
+{
+    session(['user.business_id' => $businessId]);
+}
+
+// ------------------------------------------------------------------
+// Contact (App\Contact) — endpoint /connector/api/contactapi
+// ------------------------------------------------------------------
+
+it('Contact biz=1 NÃO aparece quando session é biz=99 (Connector contactapi)', function () {
+    // Insere contato cru no biz=1 (SUPERADMIN: bypass scope só pra setup do test).
+    $contactId = DB::table('contacts')->insertGetId([ // SUPERADMIN: seed direto pra isolar test do scope
+        'business_id'  => BIZ_WAGNER,
+        'type'         => 'customer',
+        'name'         => 'CONNECTOR-ISOLATION-TEST-' . uniqid(),
+        'contact_id'   => 'CT-ISO-' . uniqid(),
+        'created_at'   => now(),
+        'updated_at'   => now(),
+    ]);
+
+    try {
+        // Simula token Passport de user no biz=99
+        setConnectorBizSession(BIZ_FICTICIO);
+
+        // Query SEM withoutGlobalScopes — global scope DEVE filtrar
+        $resultado = Contact::where('id', $contactId)->get();
+
+        expect($resultado)->toHaveCount(0, 'VAZAMENTO TIER 0: Contact biz=1 visível com session biz=99!');
+    } finally {
+        DB::table('contacts')->where('id', $contactId)->delete(); // SUPERADMIN: cleanup
+    }
+});
+
+it('Contact biz=1 aparece quando session é biz=1 (controle positivo)', function () {
+    $contactId = DB::table('contacts')->insertGetId([ // SUPERADMIN: seed direto
+        'business_id'  => BIZ_WAGNER,
+        'type'         => 'customer',
+        'name'         => 'CONNECTOR-ISO-POS-' . uniqid(),
+        'contact_id'   => 'CT-POS-' . uniqid(),
+        'created_at'   => now(),
+        'updated_at'   => now(),
+    ]);
+
+    try {
+        setConnectorBizSession(BIZ_WAGNER);
+
+        $resultado = Contact::where('id', $contactId)->get();
+        expect($resultado)->toHaveCount(1, 'Contact biz=1 não aparece com session biz=1 — scope quebrado!');
+    } finally {
+        DB::table('contacts')->where('id', $contactId)->delete(); // SUPERADMIN: cleanup
+    }
+});
+
+// ------------------------------------------------------------------
+// Product (App\Product) — endpoint /connector/api/product
+// ------------------------------------------------------------------
+
+it('Product biz=1 NÃO aparece quando session é biz=99 (Connector product)', function () {
+    $productId = DB::table('products')->insertGetId([ // SUPERADMIN: seed direto
+        'business_id'   => BIZ_WAGNER,
+        'name'          => 'CONNECTOR-PRD-ISO-' . uniqid(),
+        'type'          => 'single',
+        'unit_id'       => 1,
+        'sku'           => 'SKU-ISO-' . uniqid(),
+        'enable_stock'  => 0,
+        'created_at'    => now(),
+        'updated_at'    => now(),
+    ]);
+
+    try {
+        setConnectorBizSession(BIZ_FICTICIO);
+
+        $resultado = Product::where('id', $productId)->get();
+
+        expect($resultado)->toHaveCount(0, 'VAZAMENTO TIER 0: Product biz=1 visível com session biz=99!');
+    } finally {
+        DB::table('products')->where('id', $productId)->delete(); // SUPERADMIN: cleanup
+    }
+});
+
+it('Product biz=1 aparece quando session é biz=1 (controle positivo)', function () {
+    $productId = DB::table('products')->insertGetId([ // SUPERADMIN: seed direto
+        'business_id'   => BIZ_WAGNER,
+        'name'          => 'CONNECTOR-PRD-POS-' . uniqid(),
+        'type'          => 'single',
+        'unit_id'       => 1,
+        'sku'           => 'SKU-POS-' . uniqid(),
+        'enable_stock'  => 0,
+        'created_at'    => now(),
+        'updated_at'    => now(),
+    ]);
+
+    try {
+        setConnectorBizSession(BIZ_WAGNER);
+
+        $resultado = Product::where('id', $productId)->get();
+        expect($resultado)->toHaveCount(1, 'Product biz=1 não aparece com session biz=1 — scope quebrado!');
+    } finally {
+        DB::table('products')->where('id', $productId)->delete(); // SUPERADMIN: cleanup
+    }
+});
+
+// ------------------------------------------------------------------
+// Transaction (sells/expense) — endpoint /connector/api/sell + /expense
+// ------------------------------------------------------------------
+
+it('Transaction biz=1 (venda) NÃO aparece quando session é biz=99', function () {
+    if (! Schema::hasTable('transactions')) {
+        $this->markTestSkipped('transactions table missing — rode UltimatePOS migrate');
+    }
+
+    $transactionId = DB::table('transactions')->insertGetId([ // SUPERADMIN: seed direto
+        'business_id'   => BIZ_WAGNER,
+        'location_id'   => 1,
+        'type'          => 'sell',
+        'status'        => 'final',
+        'payment_status'=> 'due',
+        'invoice_no'    => 'INV-CONN-ISO-' . substr(uniqid(), -8),
+        'transaction_date' => now(),
+        'total_before_tax' => 100.00,
+        'final_total'   => 100.00,
+        'created_at'    => now(),
+        'updated_at'    => now(),
+    ]);
+
+    try {
+        setConnectorBizSession(BIZ_FICTICIO);
+
+        // Query direta — sem global scope explícito, mas Transaction model deve ter o scope.
+        $resultado = \App\Transaction::where('id', $transactionId)->get();
+
+        expect($resultado)->toHaveCount(0, 'VAZAMENTO TIER 0: Transaction biz=1 visível com session biz=99!');
+    } finally {
+        DB::table('transactions')->where('id', $transactionId)->delete(); // SUPERADMIN: cleanup
+    }
+});
+
+// ------------------------------------------------------------------
+// User (App\User) — endpoint /connector/api/user
+// ------------------------------------------------------------------
+
+it('User biz=1 NÃO aparece quando session é biz=99 (Connector user listing)', function () {
+    $userId = DB::table('users')->insertGetId([ // SUPERADMIN: seed direto
+        'business_id'   => BIZ_WAGNER,
+        'username'      => 'conn-iso-' . substr(uniqid(), -10),
+        'password'      => bcrypt('x'),
+        'first_name'    => 'IsolationTest',
+        'surname'       => 'Connector',
+        'language'      => 'pt_BR',
+        'created_at'    => now(),
+        'updated_at'    => now(),
+    ]);
+
+    try {
+        setConnectorBizSession(BIZ_FICTICIO);
+
+        // User model tem global scope business_id em UltimatePOS
+        $resultado = User::where('id', $userId)->get();
+
+        expect($resultado)->toHaveCount(0, 'VAZAMENTO TIER 0: User biz=1 visível com session biz=99!');
+    } finally {
+        DB::table('users')->where('id', $userId)->delete(); // SUPERADMIN: cleanup
+    }
+});

--- a/Modules/Connector/Tests/Feature/SmokeApiRoutesTest.php
+++ b/Modules/Connector/Tests/Feature/SmokeApiRoutesTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke das rotas REST principais do Modules/Connector — garante que estão
+ * registradas (sem 404), sem precisar de token Passport real.
+ *
+ * O Connector expõe API a clientes externos (Woo, SaaS, Delphi WR Comercial).
+ * Qualquer remoção acidental de rota quebra integrações em prod silenciosamente
+ * (route:cache não detecta — rotas inexistentes retornam 404 padrão sem alerta).
+ *
+ * Estratégia: usar Route::has() OR fazer request sem auth e validar que NÃO é 404.
+ * 401/422 = rota existe + middleware funcionando = ✅
+ * 404     = rota foi removida silenciosamente = ❌ regressão
+ *
+ * @see Modules/Connector/Routes/api.php (definição canônica)
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: Connector API requer schema MySQL UltimatePOS (ADR 0101)');
+    }
+});
+
+it('rota GET /connector/api/contactapi (listar contatos) está registrada', function () {
+    $r = $this->withHeaders(['Accept' => 'application/json'])->get('/connector/api/contactapi');
+    expect($r->getStatusCode())->not->toBe(404, 'Rota contactapi removida silenciosamente!');
+    expect($r->getStatusCode())->toBeIn([401, 422]);
+});
+
+it('rota GET /connector/api/product (listar produtos) está registrada', function () {
+    $r = $this->withHeaders(['Accept' => 'application/json'])->get('/connector/api/product');
+    expect($r->getStatusCode())->not->toBe(404, 'Rota product removida silenciosamente!');
+    expect($r->getStatusCode())->toBeIn([401, 422]);
+});
+
+it('rota GET /connector/api/sell (listar vendas/transactions) está registrada', function () {
+    $r = $this->withHeaders(['Accept' => 'application/json'])->get('/connector/api/sell');
+    expect($r->getStatusCode())->not->toBe(404, 'Rota sell removida silenciosamente!');
+    expect($r->getStatusCode())->toBeIn([401, 422]);
+});
+
+it('rota GET /connector/api/business-details está registrada', function () {
+    $r = $this->withHeaders(['Accept' => 'application/json'])->get('/connector/api/business-details');
+    expect($r->getStatusCode())->not->toBe(404, 'Rota business-details removida silenciosamente!');
+    expect($r->getStatusCode())->toBeIn([401, 422]);
+});
+
+it('rota GET /connector/api/taxonomy (categorias) está registrada', function () {
+    $r = $this->withHeaders(['Accept' => 'application/json'])->get('/connector/api/taxonomy');
+    expect($r->getStatusCode())->not->toBe(404, 'Rota taxonomy removida silenciosamente!');
+    expect($r->getStatusCode())->toBeIn([401, 422]);
+});
+
+it('rotas Resource Connector estão todas registradas via Route::has()', function () {
+    // Usa nomes Laravel gerados por Route::resource() pra validar via Route::has().
+    // Names canônicos: connector.<resource>.<action> (prefix declarado em api.php).
+    $namedRoutes = [
+        'connector.contactapi.index',
+        'connector.contactapi.show',
+        'connector.product.index',
+        'connector.product.show',
+        'connector.sell.index',
+        'connector.sell.store',
+        'connector.business-location.index',
+        'connector.tax.index',
+        'connector.brand.index',
+        'connector.unit.index',
+        'connector.delphi.processa-dados-cliente',
+        'connector.delphi.salvar-cliente',
+        'connector.delphi.oimpresso.registrar',
+        'connector.delphi.check-update',
+    ];
+
+    $missing = [];
+    foreach ($namedRoutes as $name) {
+        if (! Route::has($name)) {
+            $missing[] = $name;
+        }
+    }
+
+    expect($missing)->toBe([], 'Rotas Connector ausentes: ' . implode(', ', $missing));
+});
+
+it('Connector expõe pelo menos 20 rotas /connector/api/*', function () {
+    // Sanity check de cobertura mínima — Connector tem 23+ controllers Api/.
+    // Se cair abaixo de 20, é sinal de remoção acidental de bloco inteiro.
+    $count = collect(Route::getRoutes())->filter(function ($r) {
+        return str_starts_with($r->uri(), 'connector/api');
+    })->count();
+
+    expect($count)->toBeGreaterThanOrEqual(20, "Esperado >=20 rotas connector/api/*, achou {$count}");
+});
+
+it('rotas de pagamento contactapi-payment e shipping estão registradas', function () {
+    // Endpoints transacionais críticos pra integração financeira externa.
+    $r1 = $this->withHeaders(['Accept' => 'application/json'])->post('/connector/api/contactapi-payment');
+    expect($r1->getStatusCode())->not->toBe(404);
+
+    $r2 = $this->withHeaders(['Accept' => 'application/json'])->post('/connector/api/update-shipping-status');
+    expect($r2->getStatusCode())->not->toBe(404);
+});
+
+it('endpoint de registro de usuário não é exposto sem auth', function () {
+    // user-registration é POST com auth:api. Se cair pra 200 sem token = brecha.
+    $r = $this->withHeaders(['Accept' => 'application/json'])
+        ->postJson('/connector/api/user-registration', ['username' => 'evil', 'password' => 'x']);
+    expect($r->getStatusCode())->toBeIn([401, 422]);
+    expect($r->getStatusCode())->not->toBe(200, 'user-registration aceitou request sem auth — brecha crítica!');
+    expect($r->getStatusCode())->not->toBe(201);
+});

--- a/Modules/Crm/Tests/Feature/InstallControllerTest.php
+++ b/Modules/Crm/Tests/Feature/InstallControllerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Http\Controllers\BaseModuleInstallController;
+use Modules\Crm\Http\Controllers\InstallController;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke tests do InstallController — Modules/Crm.
+ *
+ * Valida que o controller está corretamente configurado para o install 1-click
+ * (ADR 0024 / BaseModuleInstallController). Os métodos protegidos retornam os
+ * valores esperados pelo framework de instalação.
+ *
+ * Tests biz=1 (Wagner WR2) conforme ADR 0101 — nunca biz=4 (cliente ROTA LIVRE).
+ *
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ * @see memory/decisions/0024-instalacao-1-clique-modulos.md
+ * @see memory/requisitos/Infra/RUNBOOK-criar-modulo.md §5
+ */
+
+it('InstallController estende BaseModuleInstallController', function () {
+    $controller = new InstallController();
+    expect($controller)->toBeInstanceOf(BaseModuleInstallController::class);
+});
+
+it('InstallController::moduleName() retorna Crm', function () {
+    $controller = new InstallController();
+    $method = new ReflectionMethod($controller, 'moduleName');
+    $method->setAccessible(true);
+
+    expect($method->invoke($controller))->toBe('Crm');
+});
+
+it('InstallController::moduleSystemKey() retorna crm (lowercase)', function () {
+    // Convenção UltimatePOS: moduleSystemKey === strtolower(moduleName) — kebab quebra
+    // isModuleInstalled() em app/Utils/ModuleUtil.php. Bug catalogado 2026-05-13.
+    $controller = new InstallController();
+    $method = new ReflectionMethod($controller, 'moduleSystemKey');
+    $method->setAccessible(true);
+
+    expect($method->invoke($controller))->toBe('crm');
+});
+
+it('InstallController::moduleVersion() retorna versão semver-like válida', function () {
+    $controller = new InstallController();
+    $method = new ReflectionMethod($controller, 'moduleVersion');
+    $method->setAccessible(true);
+
+    $version = $method->invoke($controller);
+    expect($version)->toBeString();
+    // CRM usa formato X.Y (config crm.module_version default '2.1') — aceita X.Y ou X.Y.Z
+    expect($version)->toMatch('/^\d+\.\d+(\.\d+)?$/');
+});
+
+it('CrmServiceProvider registrado em module.json', function () {
+    $manifest = json_decode(file_get_contents(
+        __DIR__.'/../../module.json'
+    ), true);
+
+    expect($manifest['name'])->toBe('Crm');
+    expect($manifest['alias'])->toBe('crm');
+    expect($manifest['providers'])->toContain('Modules\\Crm\\Providers\\CrmServiceProvider');
+});

--- a/Modules/Crm/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/Crm/Tests/Feature/MultiTenantIsolationTest.php
@@ -1,0 +1,211 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Crm\Entities\Campaign;
+use Modules\Crm\Entities\Leaduser;
+use Modules\Crm\Entities\Schedule;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Testa isolamento multi-tenant Tier 0 dos Models Crm.
+ *
+ * IMPORTANTE — Models do CRM (Schedule, Campaign) NÃO têm global scope BusinessScope
+ * (padrão UltimatePOS legacy). O isolamento depende de Controllers usarem
+ * `where('business_id', auth()->user()->business_id)` explicitamente. Estes testes
+ * verificam o contrato mais fraco mas crítico:
+ *
+ *   1. Coluna `business_id` é NOT NULL e populada em todos os inserts canônicos
+ *   2. Query `where('business_id', X)` isola corretamente (não vaza biz Y)
+ *   3. `crm_lead_users` NÃO tem business_id direto — herda via `contacts.business_id`
+ *
+ * ADR 0093: business_id obrigatório em tabelas de negócio.
+ * ADR 0101: NUNCA usar biz=4 (ROTA LIVRE — cliente Larissa produção) em tests.
+ * Tests usam biz=1 (Wagner WR2) e biz=99 (fictício, sem dados reais).
+ *
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ */
+
+const CRM_BIZ_WAGNER = 1;
+const CRM_BIZ_FICTICIO = 99;
+
+beforeEach(function () {
+    // SQLite guard: schema UltimatePOS (FKs contacts, business, users) só roda em MySQL real.
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: Models Crm requerem schema MySQL UltimatePOS com FKs business/contacts (ADR 0101)');
+    }
+    if (! Schema::hasTable('crm_schedules')) {
+        $this->markTestSkipped('crm_schedules table missing — rode Modules/Crm migrate primeiro');
+    }
+    if (! Schema::hasTable('crm_campaigns')) {
+        $this->markTestSkipped('crm_campaigns table missing — rode Modules/Crm migrate primeiro');
+    }
+});
+
+// ------------------------------------------------------------------
+// Schedule (crm_schedules — tem business_id direto)
+// ------------------------------------------------------------------
+
+it('Schedule biz=1 NÃO aparece em query where business_id=99', function () {
+    // Resolve um contato existente em biz=1 pra satisfazer FK contact_id.
+    $contactId = DB::table('contacts')->where('business_id', CRM_BIZ_WAGNER)->value('id');
+    if (! $contactId) {
+        $this->markTestSkipped('Nenhum contato biz=1 encontrado pra satisfazer FK crm_schedules.contact_id');
+    }
+
+    $sched = Schedule::create([
+        'business_id'     => CRM_BIZ_WAGNER,
+        'contact_id'      => $contactId,
+        'title'           => 'Followup TESTE ISO 99991',
+        'status'          => 'open',
+        'start_datetime'  => now(),
+        'end_datetime'    => now()->addHour(),
+        'schedule_type'   => 'call',
+        'created_by'      => 1,
+    ]);
+
+    // Cross-tenant: ninguém com biz=99 deve enxergar via filtro explícito.
+    $resultado = Schedule::where('business_id', CRM_BIZ_FICTICIO)
+        ->where('id', $sched->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(0);
+})->afterEach(function () {
+    Schedule::where('title', 'Followup TESTE ISO 99991')->delete();
+});
+
+it('Schedule biz=1 aparece em query where business_id=1', function () {
+    $contactId = DB::table('contacts')->where('business_id', CRM_BIZ_WAGNER)->value('id');
+    if (! $contactId) {
+        $this->markTestSkipped('Nenhum contato biz=1 encontrado pra satisfazer FK crm_schedules.contact_id');
+    }
+
+    $sched = Schedule::create([
+        'business_id'     => CRM_BIZ_WAGNER,
+        'contact_id'      => $contactId,
+        'title'           => 'Followup TESTE ISO 99992',
+        'status'          => 'scheduled',
+        'start_datetime'  => now(),
+        'end_datetime'    => now()->addHour(),
+        'schedule_type'   => 'meeting',
+        'created_by'      => 1,
+    ]);
+
+    $resultado = Schedule::where('business_id', CRM_BIZ_WAGNER)
+        ->where('id', $sched->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(1);
+    expect($resultado->first()->title)->toBe('Followup TESTE ISO 99992');
+    expect((int) $resultado->first()->business_id)->toBe(CRM_BIZ_WAGNER);
+})->afterEach(function () {
+    Schedule::where('title', 'Followup TESTE ISO 99992')->delete();
+});
+
+// ------------------------------------------------------------------
+// Campaign (crm_campaigns — tem business_id direto)
+// ------------------------------------------------------------------
+
+it('Campaign biz=1 NÃO aparece em query where business_id=99', function () {
+    $camp = Campaign::create([
+        'business_id'   => CRM_BIZ_WAGNER,
+        'name'          => 'Campanha TESTE ISO 99991',
+        'campaign_type' => 'email',
+        'subject'       => 'Subject ficticio',
+        'email_body'    => '<p>body teste</p>',
+        'contact_ids'   => json_encode([]),
+        'created_by'    => 1,
+    ]);
+
+    $resultado = Campaign::where('business_id', CRM_BIZ_FICTICIO)
+        ->where('id', $camp->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(0);
+})->afterEach(function () {
+    Campaign::where('name', 'Campanha TESTE ISO 99991')->delete();
+});
+
+it('Campaign biz=1 aparece em query where business_id=1', function () {
+    $camp = Campaign::create([
+        'business_id'   => CRM_BIZ_WAGNER,
+        'name'          => 'Campanha TESTE ISO 99992',
+        'campaign_type' => 'sms',
+        'sms_body'      => 'Mensagem teste',
+        'contact_ids'   => json_encode([]),
+        'created_by'    => 1,
+    ]);
+
+    $resultado = Campaign::where('business_id', CRM_BIZ_WAGNER)
+        ->where('id', $camp->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(1);
+    expect($resultado->first()->name)->toBe('Campanha TESTE ISO 99992');
+    expect((int) $resultado->first()->business_id)->toBe(CRM_BIZ_WAGNER);
+})->afterEach(function () {
+    Campaign::where('name', 'Campanha TESTE ISO 99992')->delete();
+});
+
+// ------------------------------------------------------------------
+// Leaduser (crm_lead_users — pivot SEM business_id direto)
+// ------------------------------------------------------------------
+// Isolamento herda de contacts.business_id via FK contact_id ON DELETE CASCADE.
+// Verifica que pivot NÃO vaza cross-tenant quando filtrado via join em contacts.
+
+it('Leaduser pivot herda isolamento via contacts.business_id (cross-tenant query bloqueia)', function () {
+    $contactBiz1 = DB::table('contacts')->where('business_id', CRM_BIZ_WAGNER)->value('id');
+    if (! $contactBiz1) {
+        $this->markTestSkipped('Nenhum contato biz=1 encontrado pra criar pivot Leaduser');
+    }
+
+    $userIdWagner = DB::table('users')->where('business_id', CRM_BIZ_WAGNER)->value('id');
+    if (! $userIdWagner) {
+        $this->markTestSkipped('Nenhum user biz=1 encontrado pra pivot Leaduser');
+    }
+
+    $pivot = Leaduser::create([
+        'contact_id' => $contactBiz1,
+        'user_id'    => $userIdWagner,
+    ]);
+
+    // Cross-tenant join: pivot só aparece via contacts cujo business_id casa.
+    $vazaCrossTenant = Leaduser::join('contacts', 'crm_lead_users.contact_id', '=', 'contacts.id')
+        ->where('contacts.business_id', CRM_BIZ_FICTICIO)
+        ->where('crm_lead_users.id', $pivot->id)
+        ->count();
+
+    expect($vazaCrossTenant)->toBe(0);
+})->afterEach(function () {
+    // Cleanup defensivo — só os pivots recém criados sem afetar legacy
+    DB::table('crm_lead_users')
+        ->whereIn('contact_id', function ($q) {
+            $q->select('id')->from('contacts')->where('business_id', CRM_BIZ_WAGNER);
+        })
+        ->where('user_id', DB::table('users')->where('business_id', CRM_BIZ_WAGNER)->value('id'))
+        ->orderByDesc('id')
+        ->limit(1)
+        ->delete();
+});
+
+// ------------------------------------------------------------------
+// Contract: business_id NOT NULL nas tabelas críticas do Crm
+// ------------------------------------------------------------------
+
+it('crm_schedules tem coluna business_id NOT NULL', function () {
+    expect(Schema::hasColumn('crm_schedules', 'business_id'))->toBeTrue();
+    $col = collect(DB::select('SHOW COLUMNS FROM crm_schedules LIKE ?', ['business_id']))->first();
+    expect($col)->not->toBeNull();
+    expect($col->Null)->toBe('NO');
+});
+
+it('crm_campaigns tem coluna business_id NOT NULL', function () {
+    expect(Schema::hasColumn('crm_campaigns', 'business_id'))->toBeTrue();
+    $col = collect(DB::select('SHOW COLUMNS FROM crm_campaigns LIKE ?', ['business_id']))->first();
+    expect($col)->not->toBeNull();
+    expect($col->Null)->toBe('NO');
+});

--- a/Modules/Crm/Tests/Feature/SmokeRoutesTest.php
+++ b/Modules/Crm/Tests/Feature/SmokeRoutesTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Nwidart\Modules\Facades\Module;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke tests das rotas principais do Modules/Crm.
+ *
+ * Garante que:
+ *   1. Modulo Crm aparece registrado em nWidart
+ *   2. Rotas resource principais foram registradas (follow-ups, leads, campaigns, proposals, contact-login)
+ *   3. Stack de middlewares UltimatePOS aplica (web + auth + SetSessionData + AdminSidebarMenu + CheckUserLogin)
+ *
+ * Tests não autenticam — só validam registro/binding. Smoke routes autenticadas
+ * exigiriam factory User+Business completa do schema UltimatePOS (out of scope desta wave).
+ *
+ * Refs: ADR 0093 multi-tenant scope, ADR 0011 padrao Jana/Repair, skill criar-modulo.
+ *
+ * @see Modules/Crm/Routes/web.php
+ */
+
+it('cenario 1: módulo Crm aparece registrado em nWidart', function () {
+    $module = Module::find('Crm');
+    expect($module)->not->toBeNull('Modules/Crm deveria estar registrado em nWidart');
+    expect($module->getName())->toBe('Crm');
+});
+
+it('cenario 2: módulo Crm está ativo (alias=crm, active=1)', function () {
+    $manifest = json_decode(file_get_contents(
+        __DIR__.'/../../module.json'
+    ), true);
+
+    expect($manifest['active'])->toBe(1);
+    expect($manifest['alias'])->toBe('crm');
+});
+
+it('cenario 3: rota nomeada follow-ups.index existe (Schedule resource)', function () {
+    expect(\Route::has('follow-ups.index'))->toBeTrue(
+        'Rota follow-ups.index deveria existir per Routes/web.php (Route::resource follow-ups)'
+    );
+});
+
+it('cenario 4: rota nomeada leads.index existe (Lead resource)', function () {
+    expect(\Route::has('leads.index'))->toBeTrue(
+        'Rota leads.index deveria existir per Routes/web.php (Route::resource leads)'
+    );
+});
+
+it('cenario 5: rota nomeada campaigns.index existe (Campaign resource)', function () {
+    expect(\Route::has('campaigns.index'))->toBeTrue(
+        'Rota campaigns.index deveria existir per Routes/web.php (Route::resource campaigns)'
+    );
+});
+
+it('cenario 6: rota nomeada contact-login.index existe (ContactLogin resource)', function () {
+    expect(\Route::has('contact-login.index'))->toBeTrue(
+        'Rota contact-login.index deveria existir per Routes/web.php'
+    );
+});
+
+it('cenario 7: rota nomeada proposals.index existe (Proposal resource)', function () {
+    expect(\Route::has('proposals.index'))->toBeTrue(
+        'Rota proposals.index deveria existir per Routes/web.php (Route::resource proposals)'
+    );
+});
+
+it('cenario 8: stack de middlewares Crm inclui auth + SetSessionData + AdminSidebarMenu', function () {
+    // Inspeciona uma das rotas resource do grupo crm/ — todas compartilham o mesmo stack.
+    $route = \Route::getRoutes()->getByName('campaigns.index');
+    expect($route)->not->toBeNull();
+
+    $middlewares = $route->gatherMiddleware();
+
+    // UltimatePOS stack padrão (rotas autenticadas backend)
+    expect($middlewares)->toContain('auth');
+    expect($middlewares)->toContain('SetSessionData');
+    expect($middlewares)->toContain('AdminSidebarMenu');
+    expect($middlewares)->toContain('CheckUserLogin');
+});
+
+it('cenario 9: rotas install/uninstall estão registradas (Wagner aprova superadmin)', function () {
+    // Routes/web.php:37-40 — get install, post install, get install/uninstall, get install/update.
+    $routes = collect(\Route::getRoutes())->map(fn ($r) => $r->uri())->toArray();
+
+    expect(collect($routes))->toContain('crm/install');
+    expect(collect($routes))->toContain('crm/install/uninstall');
+});

--- a/Modules/Manufacturing/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/Manufacturing/Tests/Feature/MultiTenantIsolationTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Manufacturing\Entities\MfgIngredientGroup;
+use Modules\Manufacturing\Entities\MfgRecipe;
+use Modules\Manufacturing\Entities\MfgRecipeIngredient;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Testa isolamento multi-tenant Tier 0 do módulo Manufacturing.
+ *
+ * Contexto schema legacy UltimatePOS (NÃO há global scope BusinessScope nessas Models):
+ *
+ *   - mfg_recipes               → isolamento INDIRETO via products.business_id (JOIN variation→product)
+ *   - mfg_recipe_ingredients    → isolamento INDIRETO via parent recipe (FK cascade)
+ *   - mfg_ingredient_groups     → isolamento DIRETO via coluna business_id
+ *
+ * ADR 0093: business_id Tier 0 IRREVOGÁVEL. Cobertura por filtragem explícita
+ * `where('business_id', $bizId)` ou JOIN `products.business_id`, que é o padrão
+ * usado em `MfgRecipe::forDropdown()` e `ProductionController::index()`.
+ *
+ * NUNCA usar biz=4 (ROTA LIVRE — cliente Larissa em produção) — conforme ADR 0101.
+ * Tests usam biz=1 (Wagner WR2) e biz=99 (fictício, sem dados reais).
+ *
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ */
+
+// Guard SQLite + schema. UltimatePOS Manufacturing requer schema MySQL real.
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: Manufacturing depende de schema MySQL UltimatePOS (products/variations/business). ADR 0101.');
+    }
+    if (! Schema::hasTable('mfg_recipes') || ! Schema::hasTable('mfg_recipe_ingredients') || ! Schema::hasTable('mfg_ingredient_groups')) {
+        $this->markTestSkipped('Tabelas Manufacturing ausentes — rode Modules/Manufacturing install primeiro.');
+    }
+});
+
+const BIZ_WAGNER = 1;
+const BIZ_FICTICIO = 99;
+
+// ------------------------------------------------------------------
+// MfgIngredientGroup — isolamento DIRETO via coluna business_id
+// ------------------------------------------------------------------
+
+it('MfgIngredientGroup biz=1 não aparece quando filtrado por biz=99', function () {
+    $group = MfgIngredientGroup::create([ // SUPERADMIN: inserção direta de teste (sem global scope na Model)
+        'business_id' => BIZ_WAGNER,
+        'name'        => 'Grupo Teste Isolamento Wagner',
+        'description' => 'Grupo do biz=1 que NÃO pode aparecer em queries do biz=99',
+    ]);
+
+    // Filtro explícito biz=99 — NÃO deve retornar o registro de biz=1
+    $resultado = MfgIngredientGroup::where('business_id', BIZ_FICTICIO)
+        ->where('id', $group->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(0);
+})->afterEach(function () {
+    MfgIngredientGroup::where('name', 'Grupo Teste Isolamento Wagner')->delete();
+});
+
+it('MfgIngredientGroup biz=1 aparece quando filtrado por biz=1', function () {
+    $group = MfgIngredientGroup::create([ // SUPERADMIN: inserção direta de teste
+        'business_id' => BIZ_WAGNER,
+        'name'        => 'Grupo Teste Visivel Wagner',
+        'description' => 'Confirma que filtro biz=1 retorna registro próprio',
+    ]);
+
+    $resultado = MfgIngredientGroup::where('business_id', BIZ_WAGNER)
+        ->where('id', $group->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(1);
+    expect($resultado->first()->name)->toBe('Grupo Teste Visivel Wagner');
+    expect((int) $resultado->first()->business_id)->toBe(BIZ_WAGNER);
+})->afterEach(function () {
+    MfgIngredientGroup::where('name', 'Grupo Teste Visivel Wagner')->delete();
+});
+
+it('listagem MfgIngredientGroup com filtro biz=99 não vaza grupos do biz=1', function () {
+    // Insere 3 grupos pra biz=1
+    foreach (['Lote-Iso-A', 'Lote-Iso-B', 'Lote-Iso-C'] as $nome) {
+        MfgIngredientGroup::create([ // SUPERADMIN: setup de cenário
+            'business_id' => BIZ_WAGNER,
+            'name'        => $nome,
+            'description' => 'lote-isolamento',
+        ]);
+    }
+
+    // Query "as if biz=99" — escopo correto não pode pegar nada
+    $vazamento = MfgIngredientGroup::where('business_id', BIZ_FICTICIO)
+        ->where('description', 'lote-isolamento')
+        ->count();
+
+    expect($vazamento)->toBe(0);
+})->afterEach(function () {
+    MfgIngredientGroup::where('description', 'lote-isolamento')->delete();
+});
+
+// ------------------------------------------------------------------
+// MfgRecipe — isolamento INDIRETO via products.business_id (JOIN chain)
+// ------------------------------------------------------------------
+
+it('MfgRecipe pertence a apenas um business via chain variation→product.business_id', function () {
+    // Pré-condição: existe pelo menos 1 product em biz=1 com variation pra cravar a recipe.
+    $variationBiz1 = DB::table('variations as v')
+        ->join('products as p', 'p.id', '=', 'v.product_id')
+        ->where('p.business_id', BIZ_WAGNER)
+        ->select('v.id', 'p.business_id')
+        ->first();
+
+    if (! $variationBiz1) {
+        $this->markTestSkipped('Sem variation em biz=1 — seed UltimatePOS Demo ausente pra esse teste de chain isolation.');
+    }
+
+    $recipe = MfgRecipe::create([
+        'product_id'       => DB::table('variations')->where('id', $variationBiz1->id)->value('product_id'),
+        'variation_id'     => $variationBiz1->id,
+        'instructions'     => 'recipe-teste-isolamento-chain',
+        'waste_percent'    => 0,
+        'ingredients_cost' => 10.0000,
+        'extra_cost'       => 0,
+        'total_quantity'   => 1.0000,
+        'final_price'      => 10.0000,
+    ]);
+
+    // Pattern usado em MfgRecipe::forDropdown() — JOIN explícito com p.business_id
+    $vazamento = MfgRecipe::join('variations as v', 'mfg_recipes.variation_id', '=', 'v.id')
+        ->join('products as p', 'v.product_id', '=', 'p.id')
+        ->where('p.business_id', BIZ_FICTICIO)
+        ->where('mfg_recipes.id', $recipe->id)
+        ->count();
+
+    expect($vazamento)->toBe(0);
+
+    // Mas com filtro biz=1 a recipe aparece
+    $proprio = MfgRecipe::join('variations as v', 'mfg_recipes.variation_id', '=', 'v.id')
+        ->join('products as p', 'v.product_id', '=', 'p.id')
+        ->where('p.business_id', BIZ_WAGNER)
+        ->where('mfg_recipes.id', $recipe->id)
+        ->count();
+
+    expect($proprio)->toBe(1);
+})->afterEach(function () {
+    MfgRecipe::where('instructions', 'recipe-teste-isolamento-chain')->delete();
+});
+
+// ------------------------------------------------------------------
+// MfgRecipeIngredient — isolamento INDIRETO via parent recipe (FK cascade)
+// ------------------------------------------------------------------
+
+it('MfgRecipeIngredient herda isolamento via parent MfgRecipe (cascade)', function () {
+    $variationBiz1 = DB::table('variations as v')
+        ->join('products as p', 'p.id', '=', 'v.product_id')
+        ->where('p.business_id', BIZ_WAGNER)
+        ->select('v.id', 'v.product_id', 'p.business_id')
+        ->first();
+
+    if (! $variationBiz1) {
+        $this->markTestSkipped('Sem variation em biz=1 pra cravar parent recipe.');
+    }
+
+    $recipe = MfgRecipe::create([
+        'product_id'       => $variationBiz1->product_id,
+        'variation_id'     => $variationBiz1->id,
+        'instructions'     => 'recipe-teste-ingredient-cascade',
+        'waste_percent'    => 0,
+        'ingredients_cost' => 0,
+        'extra_cost'       => 0,
+        'total_quantity'   => 1,
+        'final_price'      => 1,
+    ]);
+
+    $ingredient = MfgRecipeIngredient::create([
+        'mfg_recipe_id' => $recipe->id,
+        'variation_id'  => $variationBiz1->id,
+        'quantity'      => 2.5000,
+    ]);
+
+    // Ingredient com chain biz=99 NÃO retorna
+    $vazamento = MfgRecipeIngredient::join('mfg_recipes as r', 'mfg_recipe_ingredients.mfg_recipe_id', '=', 'r.id')
+        ->join('variations as v', 'r.variation_id', '=', 'v.id')
+        ->join('products as p', 'v.product_id', '=', 'p.id')
+        ->where('p.business_id', BIZ_FICTICIO)
+        ->where('mfg_recipe_ingredients.id', $ingredient->id)
+        ->count();
+
+    expect($vazamento)->toBe(0);
+
+    // Com biz=1, aparece
+    $proprio = MfgRecipeIngredient::join('mfg_recipes as r', 'mfg_recipe_ingredients.mfg_recipe_id', '=', 'r.id')
+        ->join('variations as v', 'r.variation_id', '=', 'v.id')
+        ->join('products as p', 'v.product_id', '=', 'p.id')
+        ->where('p.business_id', BIZ_WAGNER)
+        ->where('mfg_recipe_ingredients.id', $ingredient->id)
+        ->count();
+
+    expect($proprio)->toBe(1);
+})->afterEach(function () {
+    // FK cascade delete já remove os ingredients quando a recipe é apagada
+    MfgRecipe::where('instructions', 'recipe-teste-ingredient-cascade')->delete();
+});

--- a/Modules/Manufacturing/Tests/Feature/RecipeBomIntegrityTest.php
+++ b/Modules/Manufacturing/Tests/Feature/RecipeBomIntegrityTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Manufacturing\Entities\MfgRecipe;
+use Modules\Manufacturing\Entities\MfgRecipeIngredient;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Testa integridade BOM (Bill of Materials) do Manufacturing — multi-tenant Tier 0.
+ *
+ * Schema legacy UltimatePOS: `mfg_recipe_ingredients` NÃO tem coluna `business_id`
+ * direta. O isolamento depende de TRÊS invariantes:
+ *
+ *   1. Toda ingredient.variation_id deve apontar pra variation cujo
+ *      products.business_id === parent recipe.product → products.business_id
+ *      (mesma "vertical" de business — nunca cross-tenant)
+ *   2. FK `mfg_recipe_id ON DELETE CASCADE` garante que apagar a recipe pai
+ *      apaga os ingredients filhos — sem órfãos cross-tenant
+ *   3. Pattern `MfgRecipe::forDropdown($business_id)` JOIN products.business_id
+ *      é o ÚNICO caminho seguro de listar recipes — fora dele há risco
+ *
+ * Este test valida (1) cenário válido e (2) tentativa de cross-tenant.
+ *
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see Modules/Manufacturing/Entities/MfgRecipe.php (forDropdown)
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: schema UltimatePOS MySQL obrigatório. ADR 0101.');
+    }
+    if (! Schema::hasTable('mfg_recipes') || ! Schema::hasTable('mfg_recipe_ingredients')) {
+        $this->markTestSkipped('Tabelas Manufacturing ausentes — rode install primeiro.');
+    }
+});
+
+it('cenário válido: recipe e ingredient pertencem ao mesmo business via chain products.business_id', function () {
+    $variationBiz1 = DB::table('variations as v')
+        ->join('products as p', 'p.id', '=', 'v.product_id')
+        ->where('p.business_id', 1) // biz=1 Wagner
+        ->select('v.id as variation_id', 'v.product_id', 'p.business_id')
+        ->first();
+
+    if (! $variationBiz1) {
+        $this->markTestSkipped('Sem variation em biz=1 — base sem seed UltimatePOS Demo.');
+    }
+
+    $recipe = MfgRecipe::create([
+        'product_id'       => $variationBiz1->product_id,
+        'variation_id'     => $variationBiz1->variation_id,
+        'instructions'     => 'bom-integrity-cenario-valido',
+        'waste_percent'    => 0,
+        'ingredients_cost' => 5.0000,
+        'extra_cost'       => 0,
+        'total_quantity'   => 1.0000,
+        'final_price'      => 5.0000,
+    ]);
+
+    $ingredient = MfgRecipeIngredient::create([
+        'mfg_recipe_id' => $recipe->id,
+        'variation_id'  => $variationBiz1->variation_id, // mesma variation = mesmo biz por construção
+        'quantity'      => 1.0000,
+    ]);
+
+    // Valida invariante 1: chain ingredient → variation → product.business_id
+    // === chain recipe → variation → product.business_id
+    $bizIngredient = DB::table('mfg_recipe_ingredients as mri')
+        ->join('variations as v', 'mri.variation_id', '=', 'v.id')
+        ->join('products as p', 'v.product_id', '=', 'p.id')
+        ->where('mri.id', $ingredient->id)
+        ->value('p.business_id');
+
+    $bizRecipe = DB::table('mfg_recipes as r')
+        ->join('variations as v', 'r.variation_id', '=', 'v.id')
+        ->join('products as p', 'v.product_id', '=', 'p.id')
+        ->where('r.id', $recipe->id)
+        ->value('p.business_id');
+
+    expect((int) $bizIngredient)->toBe((int) $bizRecipe);
+    expect((int) $bizRecipe)->toBe(1);
+})->afterEach(function () {
+    MfgRecipe::where('instructions', 'bom-integrity-cenario-valido')->delete();
+});
+
+it('cascade delete: apagar recipe pai remove ingredient filho (sem órfão cross-tenant)', function () {
+    $variationBiz1 = DB::table('variations as v')
+        ->join('products as p', 'p.id', '=', 'v.product_id')
+        ->where('p.business_id', 1)
+        ->select('v.id as variation_id', 'v.product_id')
+        ->first();
+
+    if (! $variationBiz1) {
+        $this->markTestSkipped('Sem variation em biz=1.');
+    }
+
+    $recipe = MfgRecipe::create([
+        'product_id'       => $variationBiz1->product_id,
+        'variation_id'     => $variationBiz1->variation_id,
+        'instructions'     => 'bom-integrity-cascade-test',
+        'waste_percent'    => 0,
+        'ingredients_cost' => 0,
+        'extra_cost'       => 0,
+        'total_quantity'   => 1,
+        'final_price'      => 1,
+    ]);
+
+    $ingredientId = MfgRecipeIngredient::create([
+        'mfg_recipe_id' => $recipe->id,
+        'variation_id'  => $variationBiz1->variation_id,
+        'quantity'      => 0.5000,
+    ])->id;
+
+    // Antes do delete: ingredient existe
+    expect(MfgRecipeIngredient::where('id', $ingredientId)->count())->toBe(1);
+
+    // Apaga recipe pai — FK cascade deve apagar ingredient filho
+    $recipe->delete();
+
+    // Pós-delete: ingredient não existe mais (sem órfão)
+    expect(MfgRecipeIngredient::where('id', $ingredientId)->count())->toBe(0);
+});
+
+it('tentativa cross-tenant: ingredient apontando pra variation de outro business gera inconsistência detectável', function () {
+    // Busca variation em biz=1 pra criar a recipe
+    $varBiz1 = DB::table('variations as v')
+        ->join('products as p', 'p.id', '=', 'v.product_id')
+        ->where('p.business_id', 1)
+        ->select('v.id as variation_id', 'v.product_id')
+        ->first();
+
+    // Busca variation em outro business (qualquer biz_id != 1) pra simular cross-tenant attack
+    $varOutroBiz = DB::table('variations as v')
+        ->join('products as p', 'p.id', '=', 'v.product_id')
+        ->where('p.business_id', '!=', 1)
+        ->select('v.id as variation_id', 'v.product_id', 'p.business_id')
+        ->first();
+
+    if (! $varBiz1 || ! $varOutroBiz) {
+        $this->markTestSkipped('Setup multi-tenant insuficiente — precisa de variations em ≥2 businesses.');
+    }
+
+    $recipe = MfgRecipe::create([
+        'product_id'       => $varBiz1->product_id,
+        'variation_id'     => $varBiz1->variation_id, // recipe ancorada em biz=1
+        'instructions'     => 'bom-integrity-cross-tenant-attack',
+        'waste_percent'    => 0,
+        'ingredients_cost' => 0,
+        'extra_cost'       => 0,
+        'total_quantity'   => 1,
+        'final_price'      => 1,
+    ]);
+
+    // ATTACK: criar ingredient apontando pra variation de business diferente.
+    // O schema PERMITE (não há FK constraint forçando match), mas o QUERY PATTERN
+    // canônico (JOIN products.business_id) detecta a inconsistência.
+    $ingredientMalicioso = MfgRecipeIngredient::create([
+        'mfg_recipe_id' => $recipe->id,
+        'variation_id'  => $varOutroBiz->variation_id, // ← variation de OUTRO biz!
+        'quantity'      => 1.0000,
+    ]);
+
+    // Detector de inconsistência: business do recipe vs business do ingredient
+    $bizDoRecipe = DB::table('mfg_recipes as r')
+        ->join('variations as v', 'r.variation_id', '=', 'v.id')
+        ->join('products as p', 'v.product_id', '=', 'p.id')
+        ->where('r.id', $recipe->id)
+        ->value('p.business_id');
+
+    $bizDoIngredient = DB::table('mfg_recipe_ingredients as mri')
+        ->join('variations as v', 'mri.variation_id', '=', 'v.id')
+        ->join('products as p', 'v.product_id', '=', 'p.id')
+        ->where('mri.id', $ingredientMalicioso->id)
+        ->value('p.business_id');
+
+    // Esse cenário PROVA que o app DEVE rejeitar essa inserção em camada Controller/Service —
+    // o schema não defende sozinho. Aqui a divergência fica visível pra auditoria.
+    expect((int) $bizDoRecipe)->not->toBe((int) $bizDoIngredient);
+
+    // Quando filtrado pelo business da recipe (1), o ingredient NÃO aparece — isolamento
+    // funcional preservado mesmo com row inconsistente
+    $vazamento = DB::table('mfg_recipe_ingredients as mri')
+        ->join('variations as v', 'mri.variation_id', '=', 'v.id')
+        ->join('products as p', 'v.product_id', '=', 'p.id')
+        ->where('p.business_id', 1)
+        ->where('mri.id', $ingredientMalicioso->id)
+        ->count();
+
+    expect($vazamento)->toBe(0);
+})->afterEach(function () {
+    MfgRecipe::where('instructions', 'bom-integrity-cross-tenant-attack')->delete();
+});

--- a/Modules/Manufacturing/Tests/Feature/SmokeRoutesTest.php
+++ b/Modules/Manufacturing/Tests/Feature/SmokeRoutesTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke tests das rotas web Manufacturing.
+ *
+ * Objetivo: garantir que nenhuma rota do módulo retorna 5xx (erro de servidor)
+ * mesmo sem usuário autenticado. Sem auth o middleware `auth` redireciona
+ * pra /login (302) — comportamento esperado. O que NÃO pode acontecer é:
+ *
+ *   - 500 (Internal Server Error — bug)
+ *   - 503 (Service Unavailable — daemon morto)
+ *   - Exception não-tratada
+ *
+ * Não tentamos validar payload/conteúdo aqui — isso é responsabilidade de
+ * tests de integração com auth real (out of scope desta smoke layer).
+ *
+ * @see Modules/Manufacturing/Routes/web.php
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: middlewares UltimatePOS dependem schema MySQL. ADR 0101.');
+    }
+    if (! Schema::hasTable('mfg_recipes')) {
+        $this->markTestSkipped('Manufacturing não instalado nesta base.');
+    }
+});
+
+it('GET /manufacturing/recipe (recipe.index) não retorna 5xx', function () {
+    $response = $this->get('/manufacturing/recipe');
+
+    // Aceito: 200 (autenticado), 302 (redirect pra /login), 401/403 (sem permissão).
+    // Inaceitável: 5xx.
+    expect($response->getStatusCode())->toBeLessThan(500);
+});
+
+it('GET /manufacturing/production (production.index) não retorna 5xx', function () {
+    $response = $this->get('/manufacturing/production');
+
+    expect($response->getStatusCode())->toBeLessThan(500);
+});
+
+it('GET /manufacturing/settings (settings.index) não retorna 5xx', function () {
+    $response = $this->get('/manufacturing/settings');
+
+    expect($response->getStatusCode())->toBeLessThan(500);
+});
+
+it('GET /manufacturing/report não retorna 5xx', function () {
+    $response = $this->get('/manufacturing/report');
+
+    expect($response->getStatusCode())->toBeLessThan(500);
+});
+
+it('rotas Manufacturing sem auth redirecionam pra /login (middleware auth ativo)', function () {
+    // Pelo menos uma das rotas deve disparar fluxo de auth quando convidado.
+    // Se NENHUMA redireciona, o stack de middlewares ['web', 'auth', ...] está quebrado.
+    $rotas = [
+        '/manufacturing/recipe',
+        '/manufacturing/production',
+        '/manufacturing/settings',
+    ];
+
+    $algumaRedireciona = false;
+    foreach ($rotas as $rota) {
+        $r = $this->get($rota);
+        if ($r->getStatusCode() === 302) {
+            $algumaRedireciona = true;
+            break;
+        }
+    }
+
+    expect($algumaRedireciona)->toBeTrue();
+});

--- a/Modules/NFSe/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/NFSe/Tests/Feature/MultiTenantIsolationTest.php
@@ -1,0 +1,246 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\NFSe\Models\NfseEmissao;
+use Modules\NFSe\Models\NfseProviderConfig;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Testa isolamento multi-tenant Tier 0 dos Models NFSe.
+ *
+ * NFSe = Nota Fiscal de Serviço Eletrônica (fiscal/compliance). Vazar dado
+ * cross-tenant aqui é incidente regulatório — IRS estadual/municipal exposto.
+ *
+ * ADR 0093: global scope business_id IRREVOGÁVEL (trait NfseBusinessScope).
+ * Dados do biz=1 NÃO podem aparecer em queries com session biz=99 e vice-versa.
+ *
+ * NUNCA usar biz=4 (ROTA LIVRE — cliente Larissa produção) — conforme ADR 0101.
+ * Tests usam biz=1 (Wagner WR2) e biz=99 (fictício, sem dados reais).
+ *
+ * Modelos cobertos:
+ *   - NfseEmissao        (tabela nfse_emissoes)
+ *   - NfseProviderConfig (tabela nfse_provider_configs)
+ *
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ * @see Modules/NFSe/Models/Concerns/NfseBusinessScope.php
+ */
+
+// Guard SQLite: Models NFSe com global scope requerem schema MySQL UltimatePOS.
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: Models NFSe com NfseBusinessScope requerem schema MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasTable('nfse_emissoes') || ! Schema::hasTable('nfse_provider_configs')) {
+        $this->markTestSkipped('Tabelas nfse_emissoes / nfse_provider_configs ausentes — rode Modules/NFSe migrate primeiro');
+    }
+});
+
+// IDs usados nos testes — biz=1 (Wagner WR2) e biz=99 (fictício isolamento)
+const BIZ_NFSE_WAGNER   = 1;
+const BIZ_NFSE_FICTICIO = 99;
+
+// ------------------------------------------------------------------
+// Helpers internos
+// ------------------------------------------------------------------
+
+/**
+ * Simula sessão de um business sem autenticar usuário (suficiente pro global scope NFSe).
+ */
+function setNfseBizSession(int $businessId): void
+{
+    session(['user.business_id' => $businessId]);
+}
+
+// ------------------------------------------------------------------
+// NfseEmissao — emissão de nota fiscal de serviço
+// ------------------------------------------------------------------
+
+it('NfseEmissao biz=1 não aparece com session biz=99', function () {
+    // Insere emissão biz=1 bypassando scope (setup de teste)
+    $emissao = NfseEmissao::withoutGlobalScopes()->create([ // SUPERADMIN: setup de teste cross-tenant
+        'business_id'      => BIZ_NFSE_WAGNER,
+        'serie'            => 'RPS',
+        'rps_numero'       => 'RPS-TESTE-ISOL-001',
+        'competencia'      => now()->startOfMonth()->toDateString(),
+        'tomador_cnpj'     => '00000000000000', // PII redacted — CNPJ fictício
+        'tomador_nome'     => 'TOMADOR FICTICIO TESTE LTDA',
+        'descricao'        => 'Servico teste isolamento multi-tenant',
+        'valor_servicos'   => 100.00,
+        'valor_base_calculo' => 100.00,
+        'aliquota_iss'     => 0.02,
+        'valor_iss'        => 2.00,
+        'status'           => 'rascunho',
+        'idempotency_key'  => 'TEST-ISOL-NFSE-EMISSAO-001-' . uniqid(),
+    ]);
+
+    // Consulta com session biz=99 — NÃO deve aparecer (Tier 0 isolation)
+    setNfseBizSession(BIZ_NFSE_FICTICIO);
+    $resultado = NfseEmissao::where('id', $emissao->id)->get();
+
+    expect($resultado)->toHaveCount(0);
+})->afterEach(function () {
+    NfseEmissao::withoutGlobalScopes()
+        ->where('rps_numero', 'RPS-TESTE-ISOL-001')
+        ->forceDelete();
+});
+
+it('NfseEmissao biz=1 aparece com session biz=1', function () {
+    $emissao = NfseEmissao::withoutGlobalScopes()->create([ // SUPERADMIN: setup de teste cross-tenant
+        'business_id'      => BIZ_NFSE_WAGNER,
+        'serie'            => 'RPS',
+        'rps_numero'       => 'RPS-TESTE-ISOL-002',
+        'competencia'      => now()->startOfMonth()->toDateString(),
+        'tomador_cnpj'     => '00000000000000',
+        'tomador_nome'     => 'TOMADOR FICTICIO TESTE 2 LTDA',
+        'descricao'        => 'Servico teste mesmo-tenant',
+        'valor_servicos'   => 250.00,
+        'valor_base_calculo' => 250.00,
+        'aliquota_iss'     => 0.02,
+        'valor_iss'        => 5.00,
+        'status'           => 'rascunho',
+        'idempotency_key'  => 'TEST-ISOL-NFSE-EMISSAO-002-' . uniqid(),
+    ]);
+
+    setNfseBizSession(BIZ_NFSE_WAGNER);
+    $resultado = NfseEmissao::where('id', $emissao->id)->get();
+
+    expect($resultado)->toHaveCount(1);
+    expect($resultado->first()->rps_numero)->toBe('RPS-TESTE-ISOL-002');
+})->afterEach(function () {
+    NfseEmissao::withoutGlobalScopes()
+        ->where('rps_numero', 'RPS-TESTE-ISOL-002')
+        ->forceDelete();
+});
+
+it('NfseEmissao all() com session biz=99 retorna apenas dados do biz=99', function () {
+    // Cria 2 emissões — uma biz=1, outra biz=99
+    NfseEmissao::withoutGlobalScopes()->create([ // SUPERADMIN: setup de teste cross-tenant
+        'business_id'      => BIZ_NFSE_WAGNER,
+        'serie'            => 'RPS',
+        'rps_numero'       => 'RPS-TESTE-ISOL-CROSS-W',
+        'competencia'      => now()->startOfMonth()->toDateString(),
+        'tomador_nome'     => 'WAGNER WR2 TESTE FICTICIO',
+        'descricao'        => 'Servico biz=1',
+        'valor_servicos'   => 100.00,
+        'valor_base_calculo' => 100.00,
+        'valor_iss'        => 2.00,
+        'status'           => 'rascunho',
+        'idempotency_key'  => 'TEST-ISOL-NFSE-CROSS-W-' . uniqid(),
+    ]);
+
+    NfseEmissao::withoutGlobalScopes()->create([ // SUPERADMIN: setup de teste cross-tenant
+        'business_id'      => BIZ_NFSE_FICTICIO,
+        'serie'            => 'RPS',
+        'rps_numero'       => 'RPS-TESTE-ISOL-CROSS-F',
+        'competencia'      => now()->startOfMonth()->toDateString(),
+        'tomador_nome'     => 'FICTICIO BIZ 99 TESTE',
+        'descricao'        => 'Servico biz=99',
+        'valor_servicos'   => 50.00,
+        'valor_base_calculo' => 50.00,
+        'valor_iss'        => 1.00,
+        'status'           => 'rascunho',
+        'idempotency_key'  => 'TEST-ISOL-NFSE-CROSS-F-' . uniqid(),
+    ]);
+
+    // Session biz=99 só enxerga RPS-TESTE-ISOL-CROSS-F
+    setNfseBizSession(BIZ_NFSE_FICTICIO);
+    $resultado = NfseEmissao::whereIn('rps_numero', ['RPS-TESTE-ISOL-CROSS-W', 'RPS-TESTE-ISOL-CROSS-F'])->get();
+
+    expect($resultado)->toHaveCount(1);
+    expect($resultado->first()->rps_numero)->toBe('RPS-TESTE-ISOL-CROSS-F');
+    expect($resultado->first()->business_id)->toBe(BIZ_NFSE_FICTICIO);
+})->afterEach(function () {
+    NfseEmissao::withoutGlobalScopes()
+        ->whereIn('rps_numero', ['RPS-TESTE-ISOL-CROSS-W', 'RPS-TESTE-ISOL-CROSS-F'])
+        ->forceDelete();
+});
+
+// ------------------------------------------------------------------
+// NfseProviderConfig — configuração de prefeitura por business
+// ------------------------------------------------------------------
+
+it('NfseProviderConfig biz=1 não aparece com session biz=99', function () {
+    $config = NfseProviderConfig::withoutGlobalScopes()->create([ // SUPERADMIN: setup de teste cross-tenant
+        'business_id'           => BIZ_NFSE_WAGNER,
+        'provider'              => 'sn_nfse_federal',
+        'municipio_codigo_ibge' => '4218905', // Termas do Gravatal/SC (fictício para teste — único por business)
+        'serie_default'         => 'RPS',
+        'cnae'                  => '6201-5/00',
+        'lc116_codigo_default'  => '1.05',
+        'aliquota_iss'          => 0.02,
+        'ambiente'              => 'homologacao',
+    ]);
+
+    // Consulta com session biz=99 — NÃO deve aparecer
+    setNfseBizSession(BIZ_NFSE_FICTICIO);
+    $resultado = NfseProviderConfig::where('id', $config->id)->get();
+
+    expect($resultado)->toHaveCount(0);
+})->afterEach(function () {
+    NfseProviderConfig::withoutGlobalScopes()
+        ->where('business_id', BIZ_NFSE_WAGNER)
+        ->where('municipio_codigo_ibge', '4218905')
+        ->forceDelete();
+});
+
+it('NfseProviderConfig biz=1 aparece com session biz=1', function () {
+    $config = NfseProviderConfig::withoutGlobalScopes()->create([ // SUPERADMIN: setup de teste cross-tenant
+        'business_id'           => BIZ_NFSE_WAGNER,
+        'provider'              => 'sn_nfse_federal',
+        'municipio_codigo_ibge' => '3550308', // São Paulo (fictício para teste)
+        'serie_default'         => 'RPS',
+        'cnae'                  => '6201-5/00',
+        'lc116_codigo_default'  => '1.05',
+        'aliquota_iss'          => 0.05,
+        'ambiente'              => 'homologacao',
+    ]);
+
+    setNfseBizSession(BIZ_NFSE_WAGNER);
+    $resultado = NfseProviderConfig::where('id', $config->id)->get();
+
+    expect($resultado)->toHaveCount(1);
+    expect($resultado->first()->municipio_codigo_ibge)->toBe('3550308');
+    expect($resultado->first()->ambiente)->toBe('homologacao');
+})->afterEach(function () {
+    NfseProviderConfig::withoutGlobalScopes()
+        ->where('business_id', BIZ_NFSE_WAGNER)
+        ->where('municipio_codigo_ibge', '3550308')
+        ->forceDelete();
+});
+
+it('NfseProviderConfig biz=1 e biz=99 coexistem isolados no mesmo município', function () {
+    // unique(business_id, municipio_codigo_ibge) permite mesma cidade em business diferente
+    $configWagner = NfseProviderConfig::withoutGlobalScopes()->create([ // SUPERADMIN: setup de teste cross-tenant
+        'business_id'           => BIZ_NFSE_WAGNER,
+        'provider'              => 'sn_nfse_federal',
+        'municipio_codigo_ibge' => '4314902', // Porto Alegre
+        'ambiente'              => 'producao',
+        'aliquota_iss'          => 0.04,
+    ]);
+
+    $configFicticio = NfseProviderConfig::withoutGlobalScopes()->create([ // SUPERADMIN: setup de teste cross-tenant
+        'business_id'           => BIZ_NFSE_FICTICIO,
+        'provider'              => 'sn_nfse_federal',
+        'municipio_codigo_ibge' => '4314902', // mesmo município, outro tenant
+        'ambiente'              => 'homologacao',
+        'aliquota_iss'          => 0.02,
+    ]);
+
+    // Session biz=99 SÓ enxerga config do biz=99 (não vaza ambiente=producao do biz=1)
+    setNfseBizSession(BIZ_NFSE_FICTICIO);
+    $resultado = NfseProviderConfig::where('municipio_codigo_ibge', '4314902')->get();
+
+    expect($resultado)->toHaveCount(1);
+    expect($resultado->first()->business_id)->toBe(BIZ_NFSE_FICTICIO);
+    expect($resultado->first()->ambiente)->toBe('homologacao');
+})->afterEach(function () {
+    NfseProviderConfig::withoutGlobalScopes()
+        ->where('municipio_codigo_ibge', '4314902')
+        ->whereIn('business_id', [BIZ_NFSE_WAGNER, BIZ_NFSE_FICTICIO])
+        ->forceDelete();
+});

--- a/Modules/NFSe/Tests/Feature/ScaffoldTest.php
+++ b/Modules/NFSe/Tests/Feature/ScaffoldTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+use Nwidart\Modules\Facades\Module;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke test do scaffold Modules/NFSe.
+ *
+ * Garante que:
+ *   1. Módulo NFSe aparece registrado em nWidart
+ *   2. ServiceProvider carrega sem erro
+ *   3. Rotas web nomeadas foram registradas (nfse.index, nfse.create, nfse.show, nfse.store, nfse.cancelar, nfse.pdf)
+ *
+ * Refs: Modules/NFSe/module.json (alias=nfse, priority=0)
+ *       Modules/NFSe/Routes/web.php
+ *       ADR 0011 (padrão Jana/Repair/Project)
+ *       skill criar-modulo
+ */
+
+it('cenário 1: módulo NFSe aparece registrado em nWidart', function () {
+    $module = Module::find('NFSe');
+    expect($module)->not->toBeNull('Modules/NFSe deveria estar registrado em nWidart (ver module.json)');
+    expect($module->getName())->toBe('NFSe');
+});
+
+it('cenário 2: módulo NFSe expõe alias correto (nfse) em module.json', function () {
+    $module = Module::find('NFSe');
+
+    if ($module === null) {
+        $this->markTestSkipped('Módulo NFSe não está registrado — skip alias check');
+    }
+
+    expect($module->get('alias'))->toBe('nfse');
+});
+
+it('cenário 3: rota nomeada nfse.index existe', function () {
+    expect(\Route::has('nfse.index'))->toBeTrue('Rota nfse.index deveria existir per Modules/NFSe/Routes/web.php');
+});
+
+it('cenário 4: rota nomeada nfse.create existe', function () {
+    expect(\Route::has('nfse.create'))->toBeTrue('Rota nfse.create (GET /nfse/emitir) deveria existir');
+});
+
+it('cenário 5: rota nomeada nfse.store existe', function () {
+    expect(\Route::has('nfse.store'))->toBeTrue('Rota nfse.store (POST /nfse/emitir) deveria existir');
+});
+
+it('cenário 6: rota nomeada nfse.show existe', function () {
+    expect(\Route::has('nfse.show'))->toBeTrue('Rota nfse.show (GET /nfse/{nfse}) deveria existir');
+});
+
+it('cenário 7: rota nomeada nfse.cancelar existe', function () {
+    expect(\Route::has('nfse.cancelar'))->toBeTrue('Rota nfse.cancelar (POST /nfse/{nfse}/cancelar) deveria existir');
+});
+
+it('cenário 8: rota nomeada nfse.pdf existe', function () {
+    expect(\Route::has('nfse.pdf'))->toBeTrue('Rota nfse.pdf (GET /nfse/{nfse}/pdf) deveria existir');
+});
+
+it('cenário 9: ServiceProvider de NFSe não lança erro ao bootar', function () {
+    // Se a aplicação subiu sem fatal, o ServiceProvider rodou. Confirmar via classe existir.
+    expect(class_exists(\Modules\NFSe\Providers\NfseServiceProvider::class))
+        ->toBeTrue('NfseServiceProvider deveria estar autoloaded');
+});

--- a/Modules/NFSe/Tests/Feature/SmokeRoutesTest.php
+++ b/Modules/NFSe/Tests/Feature/SmokeRoutesTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke das rotas principais do módulo NFSe.
+ *
+ * Garante apenas que:
+ *   1. Rotas estão registradas no router Laravel
+ *   2. Middleware 'auth' está presente (redirect 302 → login para guest)
+ *   3. Não há erro fatal 500 na resolução das rotas
+ *
+ * NÃO testa lógica de Controller — apenas que o scaffold está plugado.
+ *
+ * Refs: Routes/web.php — middleware stack UltimatePOS
+ *   ['web', 'SetSessionData', 'auth', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin']
+ */
+
+it('rota nfse.index responde redirect 302 para guest (middleware auth ativo)', function () {
+    if (! Route::has('nfse.index')) {
+        $this->markTestSkipped('Rota nfse.index não registrada — pular smoke');
+    }
+
+    $response = $this->get(route('nfse.index'));
+
+    // Guest sem session → middleware auth redireciona pra /login (302). Status < 500 ok.
+    expect($response->status())->toBeLessThan(500);
+    expect($response->status())->toBeIn([302, 401, 403]);
+});
+
+it('rota nfse.create responde redirect 302 para guest (middleware auth ativo)', function () {
+    if (! Route::has('nfse.create')) {
+        $this->markTestSkipped('Rota nfse.create não registrada — pular smoke');
+    }
+
+    $response = $this->get(route('nfse.create'));
+
+    expect($response->status())->toBeLessThan(500);
+    expect($response->status())->toBeIn([302, 401, 403]);
+});
+
+it('rota nfse.show está registrada e bloqueia guest', function () {
+    if (! Route::has('nfse.show')) {
+        $this->markTestSkipped('Rota nfse.show não registrada — pular smoke');
+    }
+
+    // Rota usa {nfse} param — passar ID fictício; middleware auth corta antes da resolução do model.
+    $response = $this->get(route('nfse.show', ['nfse' => 99999]));
+
+    expect($response->status())->toBeLessThan(500);
+    expect($response->status())->toBeIn([302, 401, 403, 404]);
+});
+
+it('rota nfse.pdf está registrada e bloqueia guest', function () {
+    if (! Route::has('nfse.pdf')) {
+        $this->markTestSkipped('Rota nfse.pdf não registrada — pular smoke');
+    }
+
+    $response = $this->get(route('nfse.pdf', ['nfse' => 99999]));
+
+    expect($response->status())->toBeLessThan(500);
+    expect($response->status())->toBeIn([302, 401, 403, 404]);
+});
+
+it('rota nfse.store (POST emitir) está registrada e bloqueia guest', function () {
+    if (! Route::has('nfse.store')) {
+        $this->markTestSkipped('Rota nfse.store não registrada — pular smoke');
+    }
+
+    $response = $this->post(route('nfse.store'), []);
+
+    // Guest → 302 redirect login. CSRF token também pode falhar — mas o ponto é apenas <500.
+    expect($response->status())->toBeLessThan(500);
+});
+
+it('rota install /nfse/install responde (rota de Install)', function () {
+    // Install routes não tem name() — checar via path. Wagner usa /manage-modules → Install.
+    $response = $this->get('/nfse/install');
+
+    // Guest → middleware auth bloqueia. Aceitável: 302/401/403/404. Erro: 500.
+    expect($response->status())->toBeLessThan(500);
+});

--- a/Modules/Officeimpresso/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/Officeimpresso/Tests/Feature/MultiTenantIsolationTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Officeimpresso\Entities\Licenca_Computador;
+use Modules\Officeimpresso\Entities\LicencaLog;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Isolamento multi-tenant Tier 0 das Entities do modulo Officeimpresso.
+ *
+ * Officeimpresso é bridge legacy Delphi WR Sistemas → oimpresso Laravel.
+ * Os Models nao registram global scope (Controllers filtram via session('user.business_id')),
+ * portanto o teste valida ISOLAMENTO POR business_id COLUNAR — o invariante de que dados
+ * de um business so aparecem em queries scoped por business_id, conforme padrao herdado UltimatePOS.
+ *
+ * NUNCA usar biz=4 (ROTA LIVRE — cliente Larissa producao) — ADR 0101.
+ * Tests usam biz=1 (Wagner WR2) e biz=99 (ficticio, sem dados reais).
+ *
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ */
+
+// Guard SQLite: schemas Officeimpresso herdam estrutura MySQL UltimatePOS.
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompativel: tabelas Officeimpresso requerem schema MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasTable('licenca_computador')) {
+        $this->markTestSkipped('Tabela licenca_computador ausente — rode migrate primeiro');
+    }
+    if (! Schema::hasTable('licenca_log')) {
+        $this->markTestSkipped('Tabela licenca_log ausente — rode migrate primeiro');
+    }
+});
+
+const BIZ_WAGNER = 1;
+const BIZ_FICTICIO = 99;
+
+// ------------------------------------------------------------------
+// Licenca_Computador (computador desktop licenciado bridge Delphi)
+// ------------------------------------------------------------------
+
+it('Licenca_Computador biz=1 nao aparece em query scoped por biz=99', function () {
+    // SUPERADMIN: inserção direta sem session pra teste cross-tenant determinístico
+    $licenca = Licenca_Computador::create([
+        'business_id' => BIZ_WAGNER,
+        'hd'          => 'HD-TESTE-ISOL-991',
+        'user_win'    => 'usr_teste',
+        'hostname'    => 'pc-teste-isol-991',
+        'bloqueado'   => 0,
+    ]);
+
+    // Query scoped pelo business ficticio NAO deve enxergar a licenca do biz=1
+    $resultado = Licenca_Computador::where('business_id', BIZ_FICTICIO)
+        ->where('id', $licenca->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(0);
+})->afterEach(function () {
+    Licenca_Computador::where('hd', 'HD-TESTE-ISOL-991')->delete();
+});
+
+it('Licenca_Computador biz=1 aparece em query scoped por biz=1', function () {
+    // SUPERADMIN: inserção direta de teste
+    $licenca = Licenca_Computador::create([
+        'business_id' => BIZ_WAGNER,
+        'hd'          => 'HD-TESTE-ISOL-992',
+        'user_win'    => 'usr_teste',
+        'hostname'    => 'pc-teste-isol-992',
+        'bloqueado'   => 0,
+    ]);
+
+    $resultado = Licenca_Computador::where('business_id', BIZ_WAGNER)
+        ->where('id', $licenca->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(1);
+    expect($resultado->first()->hostname)->toBe('pc-teste-isol-992');
+})->afterEach(function () {
+    Licenca_Computador::where('hd', 'HD-TESTE-ISOL-992')->delete();
+});
+
+// ------------------------------------------------------------------
+// LicencaLog (append-only log de eventos auth/acesso)
+// ------------------------------------------------------------------
+
+it('LicencaLog biz=1 nao aparece em query scoped por biz=99', function () {
+    // SUPERADMIN: inserção direta de teste — append-only, sem business scope global
+    $log = LicencaLog::create([
+        'business_id' => BIZ_WAGNER,
+        'event'       => 'login_attempt',
+        'source'      => 'desktop_audit',
+        'ip'          => '10.0.0.99',
+        'user_agent'  => 'pest-teste-isol-991',
+        'created_at'  => now(),
+    ]);
+
+    $resultado = LicencaLog::where('business_id', BIZ_FICTICIO)
+        ->where('id', $log->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(0);
+})->afterEach(function () {
+    LicencaLog::where('user_agent', 'pest-teste-isol-991')->delete();
+});
+
+it('LicencaLog biz=1 aparece em query scoped por biz=1', function () {
+    // SUPERADMIN: inserção direta de teste
+    $log = LicencaLog::create([
+        'business_id' => BIZ_WAGNER,
+        'event'       => 'login_success',
+        'source'      => 'desktop_audit',
+        'ip'          => '10.0.0.1',
+        'user_agent'  => 'pest-teste-isol-992',
+        'created_at'  => now(),
+    ]);
+
+    $resultado = LicencaLog::where('business_id', BIZ_WAGNER)
+        ->where('id', $log->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(1);
+    expect($resultado->first()->event)->toBe('login_success');
+    expect($resultado->first()->user_agent)->toBe('pest-teste-isol-992');
+})->afterEach(function () {
+    LicencaLog::where('user_agent', 'pest-teste-isol-992')->delete();
+});
+
+it('LicencaLog mantem business_id como column obrigatoria (fillable)', function () {
+    // Garante que a Entity nao removeu accidentamente business_id da fillable list — guard regressivo
+    $log = new LicencaLog;
+    expect($log->getFillable())->toContain('business_id');
+});
+
+it('Licenca_Computador mantem business_id como column obrigatoria (fillable)', function () {
+    $licenca = new Licenca_Computador;
+    expect($licenca->getFillable())->toContain('business_id');
+});

--- a/Modules/Officeimpresso/Tests/Feature/ScaffoldTest.php
+++ b/Modules/Officeimpresso/Tests/Feature/ScaffoldTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use Nwidart\Modules\Facades\Module;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke test do scaffold Modules/Officeimpresso.
+ *
+ * Garante que:
+ *   1. Modulo aparece registrado em nWidart Module::find()
+ *   2. ServiceProvider carrega sem erro (Module::find retorna instancia ativa)
+ *   3. Rotas web nomeadas principais foram registradas via Route::has()
+ *
+ * Officeimpresso é bridge legacy Delphi WR Sistemas → oimpresso Laravel.
+ *
+ * Refs: ADR 0011 padrao Jana/Repair/Project, skill criar-modulo, ADR 0024.
+ *
+ * @see Modules/Officeimpresso/module.json (alias=officeimpresso, active=1)
+ */
+
+it('cenario 1: modulo Officeimpresso aparece registrado em nWidart', function () {
+    $module = Module::find('Officeimpresso');
+    expect($module)->not->toBeNull('Modules/Officeimpresso deveria estar registrado em nWidart');
+    expect($module->getName())->toBe('Officeimpresso');
+});
+
+it('cenario 2: modulo Officeimpresso esta ativo (active=1 em module.json)', function () {
+    $module = Module::find('Officeimpresso');
+    expect($module->isEnabled())->toBeTrue('Modules/Officeimpresso deveria estar ativo');
+});
+
+it('cenario 3: rota licenca_computador.index existe', function () {
+    expect(Route::has('licenca_computador.index'))
+        ->toBeTrue('Rota licenca_computador.index deveria existir per Routes/web.php (Route::resource)');
+});
+
+it('cenario 4: rota officeimpresso.catalogue existe', function () {
+    expect(Route::has('officeimpresso.catalogue'))
+        ->toBeTrue('Rota officeimpresso.catalogue deveria existir');
+});
+
+it('cenario 5: rota officeimpresso.install existe', function () {
+    expect(Route::has('officeimpresso.install'))
+        ->toBeTrue('Rota officeimpresso.install deveria existir (botao Install no superadmin)');
+});
+
+it('cenario 6: rota officeimpresso.install.post existe', function () {
+    expect(Route::has('officeimpresso.install.post'))
+        ->toBeTrue('Rota officeimpresso.install.post deveria existir (3 rotas Install — skill criar-modulo)');
+});
+
+it('cenario 7: rota officeimpresso.install.uninstall existe', function () {
+    expect(Route::has('officeimpresso.install.uninstall'))
+        ->toBeTrue('Rota officeimpresso.install.uninstall deveria existir');
+});
+
+it('cenario 8: rota computadores existe', function () {
+    expect(Route::has('computadores'))
+        ->toBeTrue('Rota computadores deveria existir');
+});
+
+it('cenario 9: rota licenca_log.index existe', function () {
+    expect(Route::has('licenca_log.index'))
+        ->toBeTrue('Rota licenca_log.index deveria existir per Routes/web.php (Route::resource)');
+});
+
+it('cenario 10: rota licenca_log.timeline existe', function () {
+    expect(Route::has('licenca_log.timeline'))
+        ->toBeTrue('Rota licenca_log.timeline existe pra UI append-only de eventos');
+});

--- a/Modules/Officeimpresso/Tests/Feature/SmokeRoutesTest.php
+++ b/Modules/Officeimpresso/Tests/Feature/SmokeRoutesTest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke test das rotas principais do modulo Officeimpresso.
+ *
+ * Validacao MINIMA — apenas:
+ *   - middleware auth bloqueia request anonimo (302 redirect pra login)
+ *   - rota nao explode com 500
+ *
+ * NAO testa autorizacao fina nem dados — soh saude do roteamento.
+ *
+ * @see Modules/Officeimpresso/Routes/web.php
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompativel: stack UltimatePOS requer schema MySQL (ADR 0101)');
+    }
+    if (! Schema::hasTable('users')) {
+        $this->markTestSkipped('Tabela users ausente — schema UltimatePOS necessario');
+    }
+});
+
+it('rota licenca_computador.index redireciona anonimo pra login (status <500)', function () {
+    // Sem autenticacao, middleware auth redirect — esperamos 302 ou 401, NUNCA 500
+    $response = $this->get(route('licenca_computador.index'));
+
+    expect($response->status())->toBeLessThan(500);
+    expect($response->status())->toBeIn([302, 401, 403]);
+});
+
+it('rota computadores redireciona anonimo pra login (status <500)', function () {
+    $response = $this->get(route('computadores'));
+
+    expect($response->status())->toBeLessThan(500);
+    expect($response->status())->toBeIn([302, 401, 403]);
+});
+
+it('rota licenca_log.index redireciona anonimo pra login (status <500)', function () {
+    $response = $this->get(route('licenca_log.index'));
+
+    expect($response->status())->toBeLessThan(500);
+    expect($response->status())->toBeIn([302, 401, 403]);
+});
+
+it('rota officeimpresso.catalogue-qr redireciona anonimo pra login (status <500)', function () {
+    $response = $this->get(route('officeimpresso.catalogue-qr'));
+
+    expect($response->status())->toBeLessThan(500);
+    expect($response->status())->toBeIn([302, 401, 403]);
+});
+
+it('rota officeimpresso.install redireciona anonimo pra login (status <500)', function () {
+    $response = $this->get(route('officeimpresso.install'));
+
+    expect($response->status())->toBeLessThan(500);
+    expect($response->status())->toBeIn([302, 401, 403]);
+});

--- a/Modules/Superadmin/Tests/Feature/CrossTenantSuperadminTest.php
+++ b/Modules/Superadmin/Tests/Feature/CrossTenantSuperadminTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Superadmin\Entities\Package;
+use Spatie\Permission\Models\Permission;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Cross-tenant test pro Superadmin (backoffice UltimatePOS).
+ *
+ * Diferente do isolamento Tier 0 ADR 0093 (cada Module business-scoped),
+ * Superadmin é INTENCIONALMENTE cross-tenant: gerencia todos businesses,
+ * cria/edita Packages globais, comunica com toda base.
+ *
+ * Validações:
+ *   1. Package é entity GLOBAL (sem business_id obrigatório, sem global scope).
+ *   2. Superadmin (biz=1 + permission `superadmin`) VÊ businesses de biz=99 (fictício)
+ *      via Eloquent direto — uso INTENCIONAL de cross-tenant.
+ *   3. Usuário normal (biz=1, SEM permission `superadmin`) NÃO consegue acessar
+ *      rotas /superadmin/* — bloqueio é obrigatório.
+ *
+ * NUNCA biz=4 (ROTA LIVRE produção — ADR 0101). Usar biz=1 (Wagner) e biz=99 (fictício).
+ *
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: Superadmin + Spatie + business multi-tenant exigem schema MySQL UltimatePOS.');
+    }
+    if (! Schema::hasTable('users') || ! Schema::hasTable('business') || ! Schema::hasTable('packages')) {
+        $this->markTestSkipped('Schema UltimatePOS ausente — rode migrations primeiro.');
+    }
+});
+
+const BIZ_WAGNER_CT = 1;
+const BIZ_FICTICIO_CT = 99;
+
+// ---------- Validação 1: Package é entity global (sem business_id global scope) ----------
+
+it('Package é entity global — sem BusinessScope, visível cross-tenant', function () {
+    // Cria pacote sem business_id (entity global pra plano SaaS).
+    $pkg = Package::create([ // SUPERADMIN: Package é cross-tenant intencional (SaaS plan)
+        'name'         => 'Pacote Teste Cross-Tenant',
+        'description'  => 'Pacote SaaS visível pra todos businesses',
+        'location_count' => 1,
+        'user_count'   => 5,
+        'product_count' => 100,
+        'invoice_count' => 1000,
+        'interval'     => 'months',
+        'interval_count' => 1,
+        'trial_days'   => 7,
+        'price'        => 0,
+        'is_active'    => 1,
+        'sort_order'   => 999,
+        'is_private'   => 0,
+        'is_one_time'  => 0,
+    ]);
+
+    // Visível independente de session business_id (não tem global scope BusinessScope)
+    session(['user.business_id' => BIZ_WAGNER_CT]);
+    $vistoBiz1 = Package::where('id', $pkg->id)->count();
+
+    session(['user.business_id' => BIZ_FICTICIO_CT]);
+    $vistoBiz99 = Package::where('id', $pkg->id)->count();
+
+    expect($vistoBiz1)->toBe(1, 'Package deve aparecer com session biz=1');
+    expect($vistoBiz99)->toBe(1, 'Package deve aparecer com session biz=99 (cross-tenant intencional)');
+})->afterEach(function () {
+    Package::where('name', 'Pacote Teste Cross-Tenant')->forceDelete();
+});
+
+// ---------- Validação 2: Superadmin vê businesses cross-tenant ----------
+
+it('Superadmin consulta cross-tenant business — vê biz=1 e biz=99 simultaneamente', function () {
+    Business::firstOrCreate(
+        ['id' => BIZ_WAGNER_CT],
+        ['name' => 'Wagner Teste CT', 'currency_id' => 1]
+    );
+    Business::firstOrCreate(
+        ['id' => BIZ_FICTICIO_CT],
+        ['name' => 'Business Ficticio CT', 'currency_id' => 1]
+    );
+
+    // SUPERADMIN: lista de businesses é uso intencional cross-tenant (sem global scope porque Business é a entidade-pai).
+    $count = Business::whereIn('id', [BIZ_WAGNER_CT, BIZ_FICTICIO_CT])->count();
+
+    expect($count)->toBe(2, 'Superadmin deve enxergar businesses de tenants diferentes na mesma query');
+});
+
+// ---------- Validação 3: usuário normal (sem permission) NÃO acessa rotas superadmin ----------
+
+it('usuário biz=1 SEM permission superadmin é bloqueado em /superadmin', function () {
+    Business::firstOrCreate(
+        ['id' => BIZ_WAGNER_CT],
+        ['name' => 'Wagner Teste CT', 'currency_id' => 1]
+    );
+
+    $userNormal = User::firstOrCreate(
+        ['username' => 'usuario_normal_biz1_cross_test'],
+        [
+            'email'       => 'normal_biz1_cross@test.local',
+            'password'    => bcrypt('secret'),
+            'business_id' => BIZ_WAGNER_CT,
+            'first_name'  => 'Normal',
+            'last_name'   => 'Biz1',
+        ]
+    );
+
+    // Garantir: sem role, sem permission
+    $userNormal->syncRoles([]);
+    $userNormal->syncPermissions([]);
+
+    $response = $this->actingAs($userNormal)->get('/superadmin/business');
+
+    // Middleware `superadmin` redireciona (302) ou nega (403). Nunca 200.
+    expect($response->status())->toBeIn([302, 403]);
+    expect($response->status())->not->toBe(200, 'Usuário sem permission JAMAIS pode receber 200 em /superadmin/*');
+});
+
+it('usuário biz=99 SEM permission superadmin é bloqueado em /superadmin (mesmo tenant fictício)', function () {
+    Business::firstOrCreate(
+        ['id' => BIZ_FICTICIO_CT],
+        ['name' => 'Business Ficticio CT', 'currency_id' => 1]
+    );
+
+    $userBiz99 = User::firstOrCreate(
+        ['username' => 'usuario_normal_biz99_cross_test'],
+        [
+            'email'       => 'normal_biz99_cross@test.local',
+            'password'    => bcrypt('secret'),
+            'business_id' => BIZ_FICTICIO_CT,
+            'first_name'  => 'Normal',
+            'last_name'   => 'Biz99',
+        ]
+    );
+
+    $userBiz99->syncRoles([]);
+    $userBiz99->syncPermissions([]);
+
+    $response = $this->actingAs($userBiz99)->get('/superadmin/packages');
+
+    expect($response->status())->toBeIn([302, 403]);
+    expect($response->status())->not->toBe(200);
+});
+
+// ---------- Validação 4: Permission `superadmin` libera acesso cross-tenant ----------
+
+it('usuário biz=1 COM permission superadmin recebe status válido em /superadmin', function () {
+    Business::firstOrCreate(
+        ['id' => BIZ_WAGNER_CT],
+        ['name' => 'Wagner Teste CT', 'currency_id' => 1]
+    );
+
+    $userAdmin = User::firstOrCreate(
+        ['username' => 'usuario_superadmin_biz1_cross_test'],
+        [
+            'email'       => 'admin_biz1_cross@test.local',
+            'password'    => bcrypt('secret'),
+            'business_id' => BIZ_WAGNER_CT,
+            'first_name'  => 'Admin',
+            'last_name'   => 'Biz1',
+        ]
+    );
+
+    $permission = Permission::firstOrCreate(
+        ['name' => 'superadmin', 'guard_name' => 'web']
+    );
+
+    if (! $userAdmin->hasPermissionTo('superadmin')) {
+        $userAdmin->givePermissionTo($permission);
+    }
+
+    $response = $this->actingAs($userAdmin)->get('/superadmin');
+
+    // Pode ser 200 (sucesso) ou outros status <500 dependendo de data/feature flags. Nunca 5xx.
+    expect($response->status())->toBeLessThan(500);
+});

--- a/Modules/Superadmin/Tests/Feature/SmokeRoutesTest.php
+++ b/Modules/Superadmin/Tests/Feature/SmokeRoutesTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Permission\Models\Permission;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke tests pras rotas Superadmin com usuário autenticado COM permission `superadmin`.
+ *
+ * Não verifica conteúdo da view — apenas que o pipeline middleware + Controller não
+ * lança 5xx (status < 500). Aceita 200/302/403 dependendo de feature flags / data.
+ *
+ * Objetivo: detectar regressão em estrutura de rota (binding, FQCN, middleware stack).
+ *
+ * NUNCA biz=4 (ROTA LIVRE — ADR 0101). Usar biz=1 (Wagner WR2).
+ *
+ * @see Modules/Superadmin/Routes/web.php
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: Superadmin requer schema MySQL UltimatePOS (Spatie + business + users).');
+    }
+    if (! Schema::hasTable('users') || ! Schema::hasTable('business') || ! Schema::hasTable('permissions')) {
+        $this->markTestSkipped('Schema UltimatePOS ausente — rode migrations primeiro.');
+    }
+});
+
+const BIZ_WAGNER_SMOKE = 1;
+
+/**
+ * Cria usuário autenticado com permission `superadmin` no biz=1 pra smoke.
+ */
+function makeSuperadminParaSmoke(): User
+{
+    Business::firstOrCreate(
+        ['id' => BIZ_WAGNER_SMOKE],
+        ['name' => 'Wagner Teste Smoke', 'currency_id' => 1]
+    );
+
+    $user = User::firstOrCreate(
+        ['username' => 'superadmin_smoke_test'],
+        [
+            'email'       => 'superadmin_smoke@test.local',
+            'password'    => bcrypt('secret'),
+            'business_id' => BIZ_WAGNER_SMOKE,
+            'first_name'  => 'Smoke',
+            'last_name'   => 'Superadmin',
+        ]
+    );
+
+    $permission = Permission::firstOrCreate(
+        ['name' => 'superadmin', 'guard_name' => 'web']
+    );
+
+    if (! $user->hasPermissionTo('superadmin')) {
+        $user->givePermissionTo($permission);
+    }
+
+    return $user;
+}
+
+// ---------- Smoke 5 rotas principais ----------
+
+it('GET /superadmin (dashboard) não retorna 5xx', function () {
+    $user = makeSuperadminParaSmoke();
+
+    $response = $this->actingAs($user)->get('/superadmin');
+
+    expect($response->status())->toBeLessThan(500);
+});
+
+it('GET /superadmin/business (listagem businesses) não retorna 5xx', function () {
+    $user = makeSuperadminParaSmoke();
+
+    $response = $this->actingAs($user)->get('/superadmin/business');
+
+    expect($response->status())->toBeLessThan(500);
+});
+
+it('GET /superadmin/packages (listagem packages) não retorna 5xx', function () {
+    $user = makeSuperadminParaSmoke();
+
+    $response = $this->actingAs($user)->get('/superadmin/packages');
+
+    expect($response->status())->toBeLessThan(500);
+});
+
+it('GET /superadmin/communicator (comunicação) não retorna 5xx', function () {
+    $user = makeSuperadminParaSmoke();
+
+    $response = $this->actingAs($user)->get('/superadmin/communicator');
+
+    expect($response->status())->toBeLessThan(500);
+});
+
+it('GET /superadmin/frontend-pages (CMS páginas públicas) não retorna 5xx', function () {
+    $user = makeSuperadminParaSmoke();
+
+    $response = $this->actingAs($user)->get('/superadmin/frontend-pages');
+
+    expect($response->status())->toBeLessThan(500);
+});
+
+it('GET /pricing (rota pública pricing) não retorna 5xx', function () {
+    // Rota pública (sem auth) — deve responder
+    $response = $this->get('/pricing');
+
+    expect($response->status())->toBeLessThan(500);
+});

--- a/Modules/Superadmin/Tests/Feature/SuperadminGateTest.php
+++ b/Modules/Superadmin/Tests/Feature/SuperadminGateTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Pest gate test pras rotas do módulo Superadmin (backoffice UltimatePOS).
+ *
+ * Toda rota sob prefixo `/superadmin` é protegida pelo middleware `superadmin`
+ * + gate manual `auth()->user()->can('superadmin')` em vários Controllers.
+ *
+ * Cobertura:
+ *   - usuário sem permission `superadmin` → 403/302 (bloqueio)
+ *   - usuário guest → 302 (redirect login) ou 403
+ *
+ * NUNCA biz=4 (ROTA LIVRE produção — ADR 0101). Usar biz=1 (Wagner WR2).
+ *
+ * @see Modules/Superadmin/Routes/web.php
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+
+// Guard SQLite: rotas Superadmin requerem schema MySQL UltimatePOS (users, business, roles, permissions Spatie).
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: Superadmin requer schema MySQL UltimatePOS (Spatie roles + business + users).');
+    }
+    if (! Schema::hasTable('users') || ! Schema::hasTable('business') || ! Schema::hasTable('permissions')) {
+        $this->markTestSkipped('Schema UltimatePOS ausente — rode migrations primeiro.');
+    }
+});
+
+const BIZ_WAGNER_GATE = 1;
+
+/**
+ * Cria usuário SEM permission `superadmin` no biz=1 (Wagner).
+ */
+function makeUserSemSuperadmin(): User
+{
+    Business::firstOrCreate(
+        ['id' => BIZ_WAGNER_GATE],
+        ['name' => 'Wagner Teste Gate', 'currency_id' => 1]
+    );
+
+    $user = User::firstOrCreate(
+        ['username' => 'usuario_sem_superadmin_test'],
+        [
+            'email'       => 'sem_superadmin@test.local',
+            'password'    => bcrypt('secret'),
+            'business_id' => BIZ_WAGNER_GATE,
+            'first_name'  => 'Sem',
+            'last_name'   => 'Superadmin',
+        ]
+    );
+
+    // Garantir que o user NÃO tem permission/role superadmin
+    $user->syncRoles([]);
+    $user->syncPermissions([]);
+
+    return $user;
+}
+
+/**
+ * Cria usuário COM permission `superadmin` no biz=1.
+ */
+function makeUserComSuperadmin(): User
+{
+    Business::firstOrCreate(
+        ['id' => BIZ_WAGNER_GATE],
+        ['name' => 'Wagner Teste Gate', 'currency_id' => 1]
+    );
+
+    $user = User::firstOrCreate(
+        ['username' => 'usuario_com_superadmin_test'],
+        [
+            'email'       => 'com_superadmin@test.local',
+            'password'    => bcrypt('secret'),
+            'business_id' => BIZ_WAGNER_GATE,
+            'first_name'  => 'Com',
+            'last_name'   => 'Superadmin',
+        ]
+    );
+
+    // Permission Spatie: superadmin global (guard web)
+    $permission = Permission::firstOrCreate(
+        ['name' => 'superadmin', 'guard_name' => 'web']
+    );
+
+    if (! $user->hasPermissionTo('superadmin')) {
+        $user->givePermissionTo($permission);
+    }
+
+    return $user;
+}
+
+// ---------- Cenário 1: usuário SEM permission é bloqueado ----------
+
+it('rota superadmin dashboard bloqueia usuário sem permission', function () {
+    $user = makeUserSemSuperadmin();
+
+    $response = $this->actingAs($user)->get('/superadmin');
+
+    // Middleware `superadmin` redireciona (302) ou nega (403); ambos válidos como bloqueio.
+    expect($response->status())->toBeIn([302, 403]);
+});
+
+it('rota superadmin business.index bloqueia usuário sem permission', function () {
+    $user = makeUserSemSuperadmin();
+
+    $response = $this->actingAs($user)->get('/superadmin/business');
+
+    expect($response->status())->toBeIn([302, 403]);
+});
+
+it('rota superadmin packages.index bloqueia usuário sem permission', function () {
+    $user = makeUserSemSuperadmin();
+
+    $response = $this->actingAs($user)->get('/superadmin/packages');
+
+    expect($response->status())->toBeIn([302, 403]);
+});
+
+it('rota superadmin communicator bloqueia usuário sem permission', function () {
+    $user = makeUserSemSuperadmin();
+
+    $response = $this->actingAs($user)->get('/superadmin/communicator');
+
+    expect($response->status())->toBeIn([302, 403]);
+});
+
+// ---------- Cenário 2: guest (sem auth) é bloqueado ----------
+
+it('rota superadmin dashboard exige autenticação (guest redireciona)', function () {
+    $response = $this->get('/superadmin');
+
+    // Sem auth: middleware `auth` redireciona pra login (302) OU middleware `superadmin` nega (403).
+    expect($response->status())->toBeIn([302, 403]);
+});
+
+it('rota superadmin packages exige autenticação (guest redireciona)', function () {
+    $response = $this->get('/superadmin/packages');
+
+    expect($response->status())->toBeIn([302, 403]);
+});

--- a/memory/sessions/2026-05-15-inventario-pest-coverage.md
+++ b/memory/sessions/2026-05-15-inventario-pest-coverage.md
@@ -1,0 +1,92 @@
+---
+data: 2026-05-15
+sessao: practical-varahamihira-f99694
+tema: Inventario Pest coverage + spawn 8 agents paralelos
+tipo: session-log
+---
+
+# Inventario Pest coverage 2026-05-15 + plano paralelo
+
+## Contexto
+
+Wagner pediu (texto): *"Pode fazer um iventario do sitema? testar e criar teste para coordenar tudo temos muito tokens pode automatizar todos os testes aTÉ AMANHA?"*
+
+Escopo confirmado via AskUserQuestion:
+- **Opcao 2**: Tudo paralelo agora — inventario + Pest critico hoje
+- **Opcao A** (restricao): Pest APENAS (zero produção, zero migration nova) — agents so criam tests/
+
+## Mapa Modules x Pest coverage
+
+**34 Modules** descobertos via `Glob Modules/*/module.json`.
+
+**18 registrados em phpunit.xml** (Feature ou Unit):
+ADS (Unit), Admin, Arquivos, Cms, ComunicacaoVisual, Essentials, Financeiro, Jana, KB, NfeBrasil, OficinaAuto, Ponto, ProjectMgmt, RecurringBilling, Repair, TeamMcp, Vestuario, Whatsapp.
+
+**16 SEM registro phpunit.xml** (potencial falsa cobertura ou zero cobertura):
+
+| Modulo | Tests/ existem? | Controllers | Entities/Models | Prioridade |
+|---|---|---|---|---|
+| **Auditoria** | ✅ 2 tests (Pest.php + AuditoriaModuleTest) MAS nao registrado | 3 | 0 | **P0 FATAL** (falsa cobertura — proibicao CLAUDE.md) |
+| **Crm** | ❌ 0 | 21 | 11 | **P0** (PII cliente, alta superficie) |
+| **Manufacturing** | ❌ 0 | 6 | 3 | **P0** (FSM canon via OficinaAuto) |
+| **NFSe** | ❌ 0 | 3 | 4 | **P0** (fiscal!) |
+| **Connector** | ❌ 0 | 30 | 0 | **P0** (integracao externa) |
+| **Accounting** | ❌ 0 | 12 | **70** | P1 |
+| **Superadmin** | ❌ 0 | 14 | 4 | P1 (governanca) |
+| **Officeimpresso** | ❌ 0 | 7 | 2 | P1 (legacy bridge) |
+| SRS | ❌ 0 | 8 | 7 | P2 |
+| AssetManagement | ❌ 0 | 7 | 4 | P2 |
+| Governance | ❌ 0 | 6 | 0 | P2 |
+| Spreadsheet | ❌ 0 | 3 | 2 | P3 |
+| ProductCatalogue | ❌ 0 | 3 | 0 | P3 |
+| ConsultaOs | ❌ 0 | 3 | 0 | P3 |
+| Brief | ❌ 0 | 3 | 0 | P3 |
+| Woocommerce | ❌ 0 | 4 | 1 | P3 |
+
+## Estrategia ofensiva: 8 agents paralelos (Wave A)
+
+Cada agent recebe 1 modulo isolado. Restricoes Tier 0 IRREVOGAVEIS:
+- APENAS Write/Edit em `Modules/<X>/Tests/Feature/**` (zero Controller/Service/Migration)
+- biz=1 (ADR 0101) com fallback cross-tenant biz=99 isolation
+- business_id global scope obrigatorio
+- PT-BR em comentarios + texto
+- ZERO git ops (parent consolida)
+- Output: lista arquivos criados + 1 linha sumario por arquivo
+
+Cada agent deve criar minimo 2 tests:
+1. **MultiTenantIsolationTest** — Tier 0 cross-tenant biz=1 vs biz=99
+2. **InstallControllerTest** ou **DataControllerTest** — smoke install/data
+3. Bonus: 1 smoke Index/Create route (se Controller principal)
+
+### Distribuicao (8 agents Wave A):
+
+| Agent | Modulo | Foco minimo |
+|---|---|---|
+| A1 | Auditoria | Registrar phpunit.xml + completar smoke (ja tem 2 tests, gap = registro) |
+| A2 | Crm | MultiTenantIsolation + InstallController + smoke 3 Controllers principais (Contact/Lead/Schedule) |
+| A3 | Manufacturing | MultiTenantIsolation + RecipeController smoke (FSM canon) |
+| A4 | NFSe | MultiTenantIsolation + smoke emissao route (fiscal) |
+| A5 | Connector | MultiTenantIsolation + smoke 3 Controllers top (30 total = sample) |
+| A6 | Accounting | MultiTenantIsolation + smoke 3 entities top (70 entities = sample) |
+| A7 | Superadmin | MultiTenantIsolation + governanca smoke |
+| A8 | Officeimpresso | MultiTenantIsolation + bridge legacy smoke |
+
+P2/P3 modulos (SRS, AssetManagement, Governance, Spreadsheet, ProductCatalogue, ConsultaOs, Brief, Woocommerce) ficam Wave B amanha — se Wave A entregar verde.
+
+## Consolidacao parent (Claude main)
+
+Apos agents terminarem:
+1. Glob `Modules/*/Tests/Feature/*Test.php` (validar criacao)
+2. Edit `phpunit.xml` adicionando 8 paths novos no testsuite Feature
+3. `composer dump-autoload`
+4. `./vendor/bin/pest --filter MultiTenantIsolation --parallel` (valida verde isoladamente)
+5. `./vendor/bin/pest --parallel` (full suite — opcional se primeiro passar)
+6. Create branch + commit + PR (1 PR consolidado, ≤300 linhas por convencao mas pode esticar p/ tests — flagging Wagner)
+
+## Estado MCP no momento do disparo
+
+- Cycle: CYCLE-06 Martinho prod + FSM rollout + Jana V2 demo (12d restantes)
+- WIP: 3 HITL pending Wagner (CMS-001, FIN-004)
+- ADRs recentes: 1388 Cascade Review, 1396 Onda 6, 1455 Screen-Pattern Reuse, 1462 KB Grafo
+- Skill `brief-first` Tier A ja chamado via hook SessionStart
+- Worktree: practical-varahamihira-f99694 (isolada)

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -34,6 +34,14 @@
             <directory>./Modules/TeamMcp/Tests/Feature</directory>
             <directory>./Modules/KB/Tests/Feature</directory>
             <directory>./Modules/KB/Tests/Unit</directory>
+            <directory>./Modules/Auditoria/Tests/Feature</directory>
+            <directory>./Modules/Crm/Tests/Feature</directory>
+            <directory>./Modules/Manufacturing/Tests/Feature</directory>
+            <directory>./Modules/NFSe/Tests/Feature</directory>
+            <directory>./Modules/Connector/Tests/Feature</directory>
+            <directory>./Modules/Accounting/Tests/Feature</directory>
+            <directory>./Modules/Superadmin/Tests/Feature</directory>
+            <directory>./Modules/Officeimpresso/Tests/Feature</directory>
         </testsuite>
     </testsuites>
     <source>


### PR DESCRIPTION
## Summary

Wave A da iniciativa "cobertura Pest total dos 34 Modules". 8 agents Pest isolados rodaram em paralelo, cada um cobrindo 1 módulo crítico (P0/P1) que estava **0 testes + não registrado em phpunit.xml** (falsa cobertura — proibição CLAUDE.md).

- **23 arquivos Pest novos** (~3.3k linhas)
- **141 testes adicionados / 60 assertions**
- **Local SQLite**: 43 passed + 98 skipped controlados (SQLite guard ADR 0101) + **0 failed**
- **phpunit.xml**: +8 paths registrados (Auditoria/Crm/Manufacturing/NFSe/Connector/Accounting/Superadmin/Officeimpresso)
- **Fix lateral**: `Modules/Auditoria/Tests/Feature/AuditoriaModuleTest.php` (uses Tests\TestCase pre-existente, estava 100% morto sem bootstrap)
- **Cobertura suite**: 18 → 26 de 34 modulos (76%). Wave B (8 P2/P3 restantes) em paralelo agora.

## Cobertura por módulo

| Módulo | Arquivos | Cenários | Foco |
|---|---|---|---|
| Auditoria | 2 novos + 1 fix | 12 | MultiTenant activity_log + SmokeRoutes + bootstrap fix |
| Crm | 3 | 21 | MultiTenant Schedule/Campaign/Leaduser + Install + Smoke 5 rotas |
| Manufacturing | 3 | 13 | MultiTenant chain JOIN + RecipeBomIntegrity + Smoke 4 rotas |
| NFSe | 3 | 21 | MultiTenant fiscal + Scaffold + Smoke 6 rotas |
| Connector | 3 | 20 | AuthApi (auth pipeline) + MultiTenant + Smoke 14 named routes |
| Accounting | 3 | ~15 | MultiTenant + EntityBusinessIdConsistency (70 entities audit) + Smoke |
| Superadmin | 3 | ~15 | SuperadminGate (Spatie permission) + CrossTenant intencional + Smoke |
| Officeimpresso | 3 | ~10 | MultiTenant + Scaffold + Smoke 5 rotas |

## Descobertas durante implementação (registrar em ADR futura?)

UltimatePOS legacy modules **NÃO seguem** o padrão Tier 0 ADR 0093 estritamente:
- **Manufacturing**: Entities NÃO têm BusinessScope global; isolam via JOIN chain `variation → products.business_id`
- **Accounting**: NÃO usa BusinessScope global automático — filtra via scopes manuais (`forBusiness`) ou WHERE em joins
- **Crm**: Models legacy UltimatePOS — Controllers filtram explicitamente, não scope
- **Officeimpresso**: Entities têm `business_id` no fillable mas SEM BusinessScope global — isolamento column-level Controller-enforced

Tests refletem **realidade**, não inventam global scope. Pode virar ADR pendente: "padronizar BusinessScope nos módulos legacy".

## Tradeoff aceito

1 PR consolidado >300 linhas (26 arquivos, ~3.4k linhas) em vez de 8 PRs separados — economia de overhead pra revisor + zero conflito entre agents (áreas isoladas por módulo). 100% tests, zero touch Controller/Service/Migration.

## Test plan

- [ ] CI Pest no MySQL valida os 98 skipped que SQLite local pulou (cross-tenant biz=1 vs biz=99)
- [ ] Verificar zero impacto em suites já existentes (Modules/Jana, Financeiro, Vestuario etc) — `vendor/bin/pest --parallel`
- [ ] Wagner revisa descobertas legacy (Accounting/Crm/Manufacturing/Officeimpresso sem BusinessScope) — decide se vira ADR follow-up
- [ ] Smoke local SQLite confirmado: 43 passed / 98 skipped / 0 failed / 43s

Refs: ADR 0093 Multi-tenant Tier 0, ADR 0101 biz=1 nunca cliente, ADR 0094 Constituição v2, `memory/sessions/2026-05-15-inventario-pest-coverage.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)