### PR TITLE
feat(governance): module-grade-v1 — rubrica oficial + Service + CLI + tela Inertia + botão Evoluir + skill

### DIFF
--- a/.claude/skills/avaliar-modulo/SKILL.md
+++ b/.claude/skills/avaliar-modulo/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: avaliar-modulo
+mission: "Substituir avaliação subjetiva de maturidade de Modules/<X>/ por nota objetiva 0-100 ponderada pela rubrica oficial module-grade-v1."
+description: ATIVAR quando user pedir "nota do módulo X", "avaliar Modules/X", "/avaliar-modulo X", "qual a nota de Y", "module grade de Z", "qual o bucket de W", "qual modulo está crítico?", "média do projeto", "ranking dos módulos", OU mencionar rubrica `module-grade-v1` ou ADR 0153. Roda `php artisan module:grade {nome} --detail --evolve` (ou `--all` quando agregado) e formata output. Mostra nota total + 5 dimensões + top gaps + batch tasks sugeridas. NÃO cria tasks sem aprovação humana — apenas formata batch markdown pra Wagner aprovar/editar/colaba via `tasks-create` MCP.
+type: process-skill
+status: active
+version: 1.0.0
+trust_level: L1
+owner: wagner
+created_at: 2026-05-16
+updated_at: 2026-05-16
+charter_adr: 0153
+parent_mission: "Toda skill substitui trabalho humano repetitivo com ROI provado, rumo ao ERP autônomo de R$ 10M em 24 meses."
+triggers_on:
+  - "/avaliar-modulo"
+  - "/avaliar-modulo {modulo}"
+  - "nota do módulo {X}"
+  - "nota do {X}"
+  - "qual a nota de {X}"
+  - "avaliar Modules/{X}"
+  - "module grade de {X}"
+  - "qual bucket de {X}"
+  - "ranking dos módulos"
+  - "média do projeto"
+  - "rubrica module-grade-v1"
+related_adrs: [0153, 0093, 0101, 0094, 0105]
+related_skills: [comparativo-do-modulo, module-completeness-audit, brief-update]
+tier: B
+---
+
+# avaliar-modulo — rubrica `module-grade-v1` (ADR 0153)
+
+## Quando ativar
+
+ATIVAR quando user pedir avaliação objetiva de maturidade de um módulo do oimpresso. Padrões:
+
+- **Nome direto**: "nota do Crm", "avaliar Modules/Manufacturing", "module grade de NFSe"
+- **Slash**: `/avaliar-modulo Repair`
+- **Pergunta**: "qual o bucket de ADS?", "o módulo X está crítico?"
+- **Agregado**: "ranking dos módulos", "média do projeto", "quais módulos estão no embrião?"
+- **Citação direta**: usuário mencionar "rubrica module-grade-v1" ou "ADR 0153"
+
+## Como executar
+
+### Caso 1 — módulo específico
+
+```bash
+php artisan module:grade <Nome> --detail --evolve
+```
+
+Output:
+- Nota 0-100 + bucket colorido
+- Tabela 5 dimensões (D1-D5) score/max
+- Breakdown completo: cada sub-item com score + evidência
+- Top 5 gaps ordenados por perda de pontos
+- Batch tasks-create sugeridas (botão Evoluir CLI equivalent)
+
+### Caso 2 — todos os módulos
+
+```bash
+php artisan module:grade --all
+```
+
+Output: tabela ranqueada por nota descendente + média projeto + distribuição buckets.
+
+### Caso 3 — JSON pra dashboard ou CI
+
+```bash
+php artisan module:grade --all --json
+```
+
+## Como formatar resposta pro user
+
+1. **Mostrar nota grande + bucket** logo no início (ex: "**Crm: 28/100 — Crítico**")
+2. **Tabela 5 dimensões** com score/max e peso
+3. **Top 3 gaps** ordenados (perda > 5 pts)
+4. **Batch tasks suggested** SE user pediu `/avaliar-modulo` com flag implícita de querer ação
+5. **Link** pra `/governance/module-grades/{Modulo}` (drill-down UI)
+6. **Citação ADR** `module-grade-v1 (ADR 0153)` no rodapé
+
+## Restrições Tier 0 IRREVOGÁVEIS
+
+- ⛔ **NUNCA criar tasks-create automaticamente** sem aprovação humana — apenas mostrar batch markdown
+- ⛔ **NUNCA editar pesos da rubrica** na conversa — rubrica é ADR canônica. Mudança = ADR 0154 v2 append-only
+- ⛔ **NUNCA inflar nota** ou justificar nota baixa com narrativa subjetiva — output é determinístico via Service
+- ⛔ **NUNCA usar biz=4** em qualquer avaliação D5 (ADR 0101 — cliente ROTA LIVRE prod)
+- ⛔ **PT-BR** em toda comunicação
+
+## Antes de avaliar
+
+Confirmar que módulo existe:
+
+```bash
+ls Modules/<Nome>/module.json
+```
+
+Se ausente → mostrar erro educativo (não inventar nota).
+
+## Como propor melhoria via skill
+
+Botão "Evoluir" da UI gera markdown com batch tasks. CLI equivalent: `php artisan module:grade X --evolve`. User cola no Claude Code → Claude pega o batch e chama `tasks-create` via MCP **com aprovação Wagner** (publication-policy).
+
+## Skills relacionadas
+
+- **`comparativo-do-modulo`** — capterra cruzamento com mercado (complementar — esta foca interno, comparativo foca mercado)
+- **`module-completeness-audit`** — checklist binário de governança (gate "está pronto pra `done`?") — complementar à rubrica quantitativa
+- **`brief-update`** — atualiza BRIEFING.md (impacta D3.b score)
+
+## Referências
+
+- [ADR 0153](../../memory/decisions/0153-module-grade-rubrica-v1.md) — rubrica oficial
+- [Service](../../Modules/Governance/Services/ModuleGradeService.php) — implementação canônica
+- [Command](../../Modules/Governance/Console/Commands/ModuleGradeCommand.php) — CLI
+- [RUNBOOK](../../memory/requisitos/Governance/RUNBOOK-module-grades.md) — tela Inertia
+- [Index page](../../resources/js/Pages/governance/ModuleGrades/Index.tsx) — UI
+- [config/governance/module_clients.yaml](../../config/governance/module_clients.yaml) — D5 (Wagner edita manual)

--- a/Modules/Governance/Console/Commands/ModuleGradeCommand.php
+++ b/Modules/Governance/Console/Commands/ModuleGradeCommand.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Governance\Console\Commands;
+
+use Illuminate\Console\Command;
+use Modules\Governance\Services\ModuleGradeService;
+
+/**
+ * Avalia maturidade de Modules/<X>/ via rubrica oficial module-grade-v1 (ADR 0153).
+ *
+ * Uso:
+ *   php artisan module:grade Crm                # Avalia 1 módulo + breakdown
+ *   php artisan module:grade --all              # Avalia todos + tabela ranqueada
+ *   php artisan module:grade --all --json       # Output JSON pra dashboard/CI
+ *   php artisan module:grade Crm --evolve       # Mostra batch de tasks-create sugeridas
+ *
+ * Pesos: D1 Multi-tenant 30 / D2 Pest 20 / D3 Doc 15 / D4 Arq 20 / D5 Cliente 15.
+ * Buckets: Excelente 80+ / Bom 60-79 / Médio 40-59 / Crítico 20-39 / Embrião <20.
+ *
+ * NOTA: NÃO usa `--verbose` (reservado Symfony Console — colide). Usa `--detail`.
+ *
+ * @see memory/decisions/0153-module-grade-rubrica-v1.md
+ */
+class ModuleGradeCommand extends Command
+{
+    protected $signature = 'module:grade
+                            {name? : Nome do módulo (ex: Crm). Vazio + --all avalia todos}
+                            {--all : Avalia todos os módulos detectados em Modules/}
+                            {--json : Output JSON (machine-readable, sem cores)}
+                            {--detail : Mostra breakdown completo das 5 dimensões}
+                            {--evolve : Mostra batch de tasks-create sugeridas pra fechar gaps top 5}';
+
+    protected $description = 'Avalia maturidade de Modules/<X>/ via rubrica oficial module-grade-v1 (ADR 0153)';
+
+    public function handle(ModuleGradeService $service): int
+    {
+        $name = $this->argument('name');
+        $all = (bool) $this->option('all');
+        $json = (bool) $this->option('json');
+        $detail = (bool) $this->option('detail');
+        $evolve = (bool) $this->option('evolve');
+
+        if (! $name && ! $all) {
+            $this->error('Forneça {name} ou --all. Ex: `php artisan module:grade Crm` ou `php artisan module:grade --all`');
+            return self::INVALID;
+        }
+
+        if ($all) {
+            return $this->handleAll($service, $json);
+        }
+
+        try {
+            $grade = $service->gradeModule($name);
+        } catch (\InvalidArgumentException $e) {
+            $this->error($e->getMessage());
+            return self::FAILURE;
+        }
+
+        if ($json) {
+            $this->line(json_encode($grade, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+            return self::SUCCESS;
+        }
+
+        $this->printModule($grade, $detail);
+
+        if ($evolve) {
+            $this->printEvolve($grade);
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function handleAll(ModuleGradeService $service, bool $json): int
+    {
+        $grades = $service->gradeAllModules();
+
+        if ($json) {
+            $this->line($grades->toJson(JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+            return self::SUCCESS;
+        }
+
+        $rows = $grades->map(fn ($g) => [
+            'Módulo'   => $g['module'],
+            'Nota'     => $g['score'],
+            'Bucket'   => $g['bucket'],
+            'D1 MT'    => "{$g['dimensions']['multi_tenant']['score']}/{$g['dimensions']['multi_tenant']['max']}",
+            'D2 Pest'  => "{$g['dimensions']['pest_coverage']['score']}/{$g['dimensions']['pest_coverage']['max']}",
+            'D3 Doc'   => "{$g['dimensions']['documentation']['score']}/{$g['dimensions']['documentation']['max']}",
+            'D4 Arq'   => "{$g['dimensions']['architecture']['score']}/{$g['dimensions']['architecture']['max']}",
+            'D5 Cli'   => "{$g['dimensions']['client_real']['score']}/{$g['dimensions']['client_real']['max']}",
+        ])->all();
+
+        $this->table(
+            ['Módulo', 'Nota', 'Bucket', 'D1 MT', 'D2 Pest', 'D3 Doc', 'D4 Arq', 'D5 Cli'],
+            $rows,
+        );
+
+        $avg = round($grades->avg('score'), 1);
+        $count = $grades->count();
+        $byBucket = $grades->groupBy('bucket')->map->count();
+
+        $this->newLine();
+        $this->info("Média projeto: {$avg} pts ({$count} módulos)");
+        $this->line("Distribuição por bucket: " . $byBucket->map(fn ($v, $k) => "{$k}={$v}")->implode(' · '));
+
+        return self::SUCCESS;
+    }
+
+    private function printModule(array $grade, bool $detail): void
+    {
+        $bucketColor = match ($grade['bucket']) {
+            'Excelente' => 'green',
+            'Bom'       => 'cyan',
+            'Médio'     => 'yellow',
+            'Crítico'   => 'red',
+            'Embrião'   => 'red',
+            default     => 'default',
+        };
+
+        $this->newLine();
+        $this->line("<fg=white;options=bold>Modules/{$grade['module']}</>");
+        $this->line("Nota: <fg={$bucketColor};options=bold>{$grade['score']}/100</> · Bucket: <fg={$bucketColor}>{$grade['bucket']}</>");
+        $this->line("Avaliado em: {$grade['evaluated_at']}");
+        $this->newLine();
+
+        $rows = [];
+        foreach ($grade['dimensions'] as $key => $dim) {
+            $label = match ($key) {
+                'multi_tenant'  => 'D1 Multi-tenant Tier 0',
+                'pest_coverage' => 'D2 Pest cobertura',
+                'documentation' => 'D3 Documentação canônica',
+                'architecture'  => 'D4 Maturidade arquitetura',
+                'client_real'   => 'D5 Cliente real',
+                default         => $key,
+            };
+            $rows[] = [$label, "{$dim['score']}/{$dim['max']}", "peso {$dim['weight']}"];
+        }
+        $this->table(['Dimensão', 'Score', 'Peso'], $rows);
+
+        if ($detail) {
+            $this->newLine();
+            $this->line("<fg=white;options=bold>Breakdown completo:</>");
+            foreach ($grade['dimensions'] as $key => $dim) {
+                $this->line("<fg=cyan>  {$key}:</>");
+                foreach ($dim['breakdown'] as $item) {
+                    $color = $item['score'] === $item['max'] ? 'green' : ($item['score'] > 0 ? 'yellow' : 'red');
+                    $this->line(sprintf(
+                        "    <fg={$color}>%s</> %s — %s",
+                        "[{$item['score']}/{$item['max']}]",
+                        $item['key'] ?? '',
+                        $item['evidence']
+                    ));
+                }
+            }
+        }
+
+        if (! empty($grade['gaps'])) {
+            $this->newLine();
+            $this->line("<fg=white;options=bold>Top gaps (perda de pontos ordenada):</>");
+            foreach (array_slice($grade['gaps'], 0, 5) as $g) {
+                $this->line(sprintf(
+                    "  <fg=red>-%d pts</> <fg=cyan>%s</> [%s] %s",
+                    $g['lost'], $g['key'], $g['priority'], $g['desc']
+                ));
+            }
+        }
+    }
+
+    private function printEvolve(array $grade): void
+    {
+        $this->newLine();
+        $this->line("<fg=white;options=bold>Batch de tasks-create sugeridas (botão Evoluir):</>");
+        $this->newLine();
+        foreach ($grade['evolve_tasks'] as $i => $task) {
+            $n = $i + 1;
+            $this->line("<fg=cyan>Task #{$n}</> [{$task['priority']}] · estimativa {$task['estimate']}");
+            $this->line("  Título: {$task['title']}");
+            $this->line("  Módulo: {$task['module']}");
+            $this->line("  Gap ref: {$task['gap_ref']}");
+            $this->line("  Racional: {$task['rationale']}");
+            $this->newLine();
+        }
+        $this->line("<fg=yellow>Copiar como markdown e colar no Claude Code pra criar via `tasks-create` MCP.</>");
+    }
+}

--- a/Modules/Governance/Http/Controllers/ModuleGradeController.php
+++ b/Modules/Governance/Http/Controllers/ModuleGradeController.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Governance\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Cache;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\Governance\Services\ModuleGradeService;
+
+/**
+ * Module Grades dashboard — rubrica oficial module-grade-v1 (ADR 0153).
+ *
+ * Rotas:
+ *   GET /governance/module-grades         → Index (tabela 34 módulos ranqueada)
+ *   GET /governance/module-grades/{name}  → Show (drill-down 5 dimensões + gaps + Evoluir)
+ *
+ * Cache 5min em gradeAllModules() — Service faz I/O filesystem 1-2s × 34 módulos.
+ *
+ * @see memory/requisitos/Governance/RUNBOOK-module-grades.md
+ */
+class ModuleGradeController extends Controller
+{
+    private const CACHE_TTL_SECONDS = 300;
+    private const CACHE_KEY_ALL = 'governance.module_grades.all';
+
+    public function __construct(private readonly ModuleGradeService $service)
+    {
+        $this->middleware('auth');
+    }
+
+    public function index(Request $request): Response
+    {
+        // Inertia::defer pra coleta filesystem (1-2s × 34 módulos)
+        $grades = Inertia::defer(fn () => $this->buildAllGradesPayload());
+
+        $kpis = Inertia::defer(fn () => $this->buildKpisPayload());
+
+        return Inertia::render('governance/ModuleGrades/Index', [
+            'grades' => $grades,
+            'kpis'   => $kpis,
+        ]);
+    }
+
+    public function show(Request $request, string $name): Response
+    {
+        try {
+            $grade = Cache::remember(
+                "governance.module_grades.{$name}",
+                self::CACHE_TTL_SECONDS,
+                fn () => $this->service->gradeModule($name),
+            );
+        } catch (\InvalidArgumentException $e) {
+            abort(404, $e->getMessage());
+        }
+
+        return Inertia::render('governance/ModuleGrades/Show', [
+            'grade' => $grade,
+        ]);
+    }
+
+    /**
+     * @return array<int, array>
+     */
+    private function buildAllGradesPayload(): array
+    {
+        return Cache::remember(
+            self::CACHE_KEY_ALL,
+            self::CACHE_TTL_SECONDS,
+            fn () => $this->service->gradeAllModules()
+                ->map(fn ($g) => [
+                    'module'     => $g['module'],
+                    'score'      => $g['score'],
+                    'bucket'     => $g['bucket'],
+                    'color'      => $g['color'],
+                    'dimensions' => [
+                        'multi_tenant'  => "{$g['dimensions']['multi_tenant']['score']}/{$g['dimensions']['multi_tenant']['max']}",
+                        'pest_coverage' => "{$g['dimensions']['pest_coverage']['score']}/{$g['dimensions']['pest_coverage']['max']}",
+                        'documentation' => "{$g['dimensions']['documentation']['score']}/{$g['dimensions']['documentation']['max']}",
+                        'architecture'  => "{$g['dimensions']['architecture']['score']}/{$g['dimensions']['architecture']['max']}",
+                        'client_real'   => "{$g['dimensions']['client_real']['score']}/{$g['dimensions']['client_real']['max']}",
+                    ],
+                ])
+                ->all()
+        );
+    }
+
+    /**
+     * @return array{average: float, total: int, by_bucket: array<string, int>}
+     */
+    private function buildKpisPayload(): array
+    {
+        $all = Cache::get(self::CACHE_KEY_ALL) ?? [];
+        if (empty($all)) {
+            $all = $this->buildAllGradesPayload();
+        }
+
+        $scores = array_column($all, 'score');
+        $byBucket = [];
+        foreach ($all as $g) {
+            $byBucket[$g['bucket']] = ($byBucket[$g['bucket']] ?? 0) + 1;
+        }
+
+        return [
+            'average'   => count($scores) > 0 ? round(array_sum($scores) / count($scores), 1) : 0,
+            'total'     => count($all),
+            'by_bucket' => $byBucket,
+        ];
+    }
+}

--- a/Modules/Governance/Http/routes.php
+++ b/Modules/Governance/Http/routes.php
@@ -7,6 +7,7 @@ use Modules\Governance\Http\Controllers\DataController;
 use Modules\Governance\Http\Controllers\PoliciesController;
 use Modules\Governance\Http\Controllers\AuditController;
 use Modules\Governance\Http\Controllers\DriftAlertsController;
+use Modules\Governance\Http\Controllers\ModuleGradeController;
 
 /*
 |--------------------------------------------------------------------------
@@ -40,6 +41,13 @@ Route::middleware(['web', 'authh', 'auth', 'SetSessionData', 'language', 'timezo
         // Drift alerts (Module Charter Art. 7)
         Route::get('/drift', [DriftAlertsController::class, 'index'])
             ->name('drift.index');
+
+        // Module Grades — rubrica module-grade-v1 (ADR 0153)
+        Route::get('/module-grades', [ModuleGradeController::class, 'index'])
+            ->name('module-grades.index');
+        Route::get('/module-grades/{name}', [ModuleGradeController::class, 'show'])
+            ->name('module-grades.show')
+            ->where('name', '[A-Za-z0-9_-]+');
 
         // Install hooks (ADR 0024 — pattern padronizado BaseModuleInstallController)
         Route::get('install',           [InstallController::class, 'index'])

--- a/Modules/Governance/Providers/GovernanceServiceProvider.php
+++ b/Modules/Governance/Providers/GovernanceServiceProvider.php
@@ -26,6 +26,7 @@ class GovernanceServiceProvider extends ServiceProvider
                 \Modules\Governance\Console\Commands\CharterAuditCommand::class,
                 \Modules\Governance\Console\Commands\CharterHealthCommand::class,
                 \Modules\Governance\Console\Commands\CharterMetricsCommand::class,
+                \Modules\Governance\Console\Commands\ModuleGradeCommand::class,
             ]);
         }
     }

--- a/Modules/Governance/Resources/menus/topnav.php
+++ b/Modules/Governance/Resources/menus/topnav.php
@@ -19,5 +19,6 @@ return [
         ['label' => 'governance::governance.menu.policies',  'href' => '/governance/policies', 'icon' => 'Settings',        'can' => 'governance.policies.edit'],
         ['label' => 'governance::governance.menu.audit',     'href' => '/governance/audit',    'icon' => 'Search',          'can' => 'governance.audit.view'],
         ['label' => 'governance::governance.menu.drift',     'href' => '/governance/drift',    'icon' => 'AlertTriangle',   'can' => 'governance.dashboard.view'],
+        ['label' => 'Module Grades',                          'href' => '/governance/module-grades', 'icon' => 'Gauge',     'can' => 'governance.dashboard.view'],
     ],
 ];

--- a/Modules/Governance/Services/ModuleGradeService.php
+++ b/Modules/Governance/Services/ModuleGradeService.php
@@ -1,0 +1,615 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Governance\Services;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Collection;
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * ModuleGradeService — implementa rubrica oficial `module-grade-v1` (ADR 0153).
+ *
+ * Avalia maturidade de qualquer Modules/<X>/ via 5 dimensões ponderadas:
+ *   D1 Multi-tenant Tier 0  (30 pts) — BusinessScope + cross-tenant Pest + Jobs $businessId
+ *   D2 Pest cobertura       (20 pts) — razao tests/Controllers + canônicos + phpunit.xml
+ *   D3 Documentação canon   (15 pts) — SPEC + BRIEFING + Charter + ADR mãe
+ *   D4 Maturidade arq       (20 pts) — Service/Controller ratio + FSM + Inertia + AuditLog
+ *   D5 Cliente real         (15 pts) — biz=4 prod / biz=1 Wagner / piloto / hipotese / ninguem
+ *
+ * Total normalizado: 0-100. Buckets: Excelente 80+ / Bom 60-79 / Médio 40-59 / Crítico 20-39 / Embrião <20.
+ *
+ * Coleta automática via filesystem inspection. D5 (cliente) lê config/governance/module_clients.yaml
+ * (Wagner edita manualmente — quando Modules/Brief gerar volume/módulo vira automático).
+ *
+ * @see memory/decisions/0153-module-grade-rubrica-v1.md
+ */
+class ModuleGradeService
+{
+    private const BUCKETS = [
+        ['min' => 80, 'label' => 'Excelente', 'color' => 'emerald'],
+        ['min' => 60, 'label' => 'Bom',       'color' => 'sky'],
+        ['min' => 40, 'label' => 'Médio',     'color' => 'amber'],
+        ['min' => 20, 'label' => 'Crítico',   'color' => 'orange'],
+        ['min' => 0,  'label' => 'Embrião',   'color' => 'red'],
+    ];
+
+    private string $modulesPath;
+    private string $memoryPath;
+    private string $pagesPath;
+    private string $viewsPath;
+    private string $phpunitXmlPath;
+    private string $clientsConfigPath;
+
+    public function __construct()
+    {
+        $this->modulesPath       = base_path('Modules');
+        $this->memoryPath        = base_path('memory/requisitos');
+        $this->pagesPath         = base_path('resources/js/Pages');
+        $this->viewsPath         = base_path('resources/views');
+        $this->phpunitXmlPath    = base_path('phpunit.xml');
+        $this->clientsConfigPath = base_path('config/governance/module_clients.yaml');
+    }
+
+    /**
+     * Avalia um único módulo.
+     *
+     * @return array{module: string, score: int, bucket: string, color: string, dimensions: array, gaps: array, evolve_tasks: array, evaluated_at: string}
+     */
+    public function gradeModule(string $name): array
+    {
+        $modulePath = $this->modulesPath . DIRECTORY_SEPARATOR . $name;
+
+        if (! is_dir($modulePath)) {
+            throw new \InvalidArgumentException("Módulo `{$name}` não existe em Modules/");
+        }
+
+        $d1 = $this->dim1MultiTenant($name, $modulePath);
+        $d2 = $this->dim2PestCoverage($name, $modulePath);
+        $d3 = $this->dim3Documentation($name, $modulePath);
+        $d4 = $this->dim4Architecture($name, $modulePath);
+        $d5 = $this->dim5Client($name);
+
+        $score = $d1['score'] + $d2['score'] + $d3['score'] + $d4['score'] + $d5['score'];
+        $bucket = $this->bucketFor($score);
+
+        $gaps = $this->extractGaps($name, [
+            'multi_tenant'  => $d1,
+            'pest_coverage' => $d2,
+            'documentation' => $d3,
+            'architecture'  => $d4,
+            'client_real'   => $d5,
+        ]);
+
+        return [
+            'module'        => $name,
+            'score'         => $score,
+            'bucket'        => $bucket['label'],
+            'color'         => $bucket['color'],
+            'dimensions'    => [
+                'multi_tenant'  => $d1,
+                'pest_coverage' => $d2,
+                'documentation' => $d3,
+                'architecture'  => $d4,
+                'client_real'   => $d5,
+            ],
+            'gaps'          => $gaps,
+            'evolve_tasks'  => $this->suggestEvolveTasks($name, $gaps),
+            'evaluated_at'  => now()->toIso8601String(),
+        ];
+    }
+
+    /**
+     * Avalia todos os módulos detectados em Modules/.
+     *
+     * @return Collection<int, array>
+     */
+    public function gradeAllModules(): Collection
+    {
+        $modules = collect(scandir($this->modulesPath))
+            ->filter(fn ($d) => $d !== '.' && $d !== '..' && is_dir($this->modulesPath . DIRECTORY_SEPARATOR . $d))
+            ->values();
+
+        return $modules->map(fn ($m) => $this->gradeModule($m))->sortByDesc('score')->values();
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // D1 — Multi-tenant Tier 0 (30 pts)
+    // ────────────────────────────────────────────────────────────────────────
+
+    private function dim1MultiTenant(string $name, string $modulePath): array
+    {
+        $breakdown = [];
+
+        // D1.a — BusinessScope global em Entities críticas (10 pts)
+        $entitiesPath = $modulePath . '/Entities';
+        $modelsPath   = $modulePath . '/Models';
+        $entities = array_merge(
+            $this->phpFiles($entitiesPath),
+            $this->phpFiles($modelsPath)
+        );
+        $businessScopeCount = 0;
+        foreach ($entities as $file) {
+            $content = @file_get_contents($file) ?: '';
+            if (preg_match('/(BusinessScope|addGlobalScope.*business)/i', $content)) {
+                $businessScopeCount++;
+            }
+        }
+        $d1a = count($entities) === 0
+            ? 5  // sem entities — neutro (módulo pode usar Models core)
+            : (int) round(min(10, ($businessScopeCount / max(1, count($entities))) * 10));
+        $breakdown[] = [
+            'key'   => 'D1.a',
+            'desc'  => 'BusinessScope global em Entities críticas',
+            'score' => $d1a,
+            'max'   => 10,
+            'evidence' => count($entities) === 0
+                ? 'sem Entities próprias (neutro)'
+                : "{$businessScopeCount}/" . count($entities) . " Entities com BusinessScope",
+        ];
+
+        // D1.b — Cross-tenant Pest cobrindo ≥50% Entities (15 pts)
+        $testsPath = $modulePath . '/Tests';
+        $testFiles = $this->phpFiles($testsPath, recursive: true);
+        $crossTenantTestFiles = 0;
+        foreach ($testFiles as $file) {
+            $content = @file_get_contents($file) ?: '';
+            if (preg_match('/(biz=99|BIZ_FICTICIO|business_id.*99|withoutGlobalScopes)/', $content)) {
+                $crossTenantTestFiles++;
+            }
+        }
+        $entCount = count($entities);
+        $d1b = $entCount === 0
+            ? ($crossTenantTestFiles > 0 ? 10 : 0)
+            : (int) round(min(15, ($crossTenantTestFiles / max(1, $entCount * 0.5)) * 15));
+        $breakdown[] = [
+            'key'   => 'D1.b',
+            'desc'  => 'Cross-tenant Pest biz=1 vs biz=99',
+            'score' => $d1b,
+            'max'   => 15,
+            'evidence' => "{$crossTenantTestFiles} test files com cross-tenant pattern",
+        ];
+
+        // D1.c — Jobs assíncronos $businessId no constructor (5 pts)
+        $jobsPath = $modulePath . '/Jobs';
+        $jobFiles = $this->phpFiles($jobsPath);
+        $jobsBusinessId = 0;
+        foreach ($jobFiles as $file) {
+            $content = @file_get_contents($file) ?: '';
+            if (preg_match('/__construct\s*\([^)]*\$business/', $content)) {
+                $jobsBusinessId++;
+            }
+        }
+        $d1c = count($jobFiles) === 0
+            ? 5  // sem Jobs — neutro
+            : (int) round(min(5, ($jobsBusinessId / max(1, count($jobFiles))) * 5));
+        $breakdown[] = [
+            'key'   => 'D1.c',
+            'desc'  => 'Jobs assíncronos recebem $businessId no constructor',
+            'score' => $d1c,
+            'max'   => 5,
+            'evidence' => count($jobFiles) === 0
+                ? 'sem Jobs (neutro)'
+                : "{$jobsBusinessId}/" . count($jobFiles) . " Jobs com \$businessId",
+        ];
+
+        return [
+            'weight'    => 30,
+            'score'     => $d1a + $d1b + $d1c,
+            'max'       => 30,
+            'breakdown' => $breakdown,
+        ];
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // D2 — Pest cobertura (20 pts)
+    // ────────────────────────────────────────────────────────────────────────
+
+    private function dim2PestCoverage(string $name, string $modulePath): array
+    {
+        $breakdown = [];
+
+        $controllers = $this->phpFiles($modulePath . '/Http/Controllers');
+        $testsPath = $modulePath . '/Tests';
+        $testFiles = array_filter(
+            $this->phpFiles($testsPath, recursive: true),
+            fn ($f) => ! str_ends_with($f, 'Pest.php') && ! str_ends_with($f, 'TestCase.php')
+        );
+
+        // D2.a — Razão tests/Controllers ≥ 0.5 (8 pts)
+        $ratio = count($controllers) === 0 ? 1.0 : count($testFiles) / count($controllers);
+        $d2a = (int) round(min(8, $ratio * 16));  // ratio 0.5 → 8 pts
+        $breakdown[] = [
+            'key'   => 'D2.a',
+            'desc'  => 'Razão tests/Controllers ≥ 0.5',
+            'score' => $d2a,
+            'max'   => 8,
+            'evidence' => sprintf('%d tests / %d controllers (ratio %.2f)', count($testFiles), count($controllers), $ratio),
+        ];
+
+        // D2.b — Tem MultiTenant + Smoke + Scaffold canônicos (8 pts)
+        $canonicalCount = 0;
+        $patterns = ['MultiTenant', 'Smoke', 'Scaffold'];
+        foreach ($patterns as $p) {
+            foreach ($testFiles as $f) {
+                if (str_contains($f, $p)) {
+                    $canonicalCount++;
+                    break;
+                }
+            }
+        }
+        $d2b = (int) round(($canonicalCount / 3) * 8);
+        $breakdown[] = [
+            'key'   => 'D2.b',
+            'desc'  => 'Tem MultiTenant + Smoke + Scaffold canônicos',
+            'score' => $d2b,
+            'max'   => 8,
+            'evidence' => "{$canonicalCount}/3 padrões canônicos presentes",
+        ];
+
+        // D2.c — Registrado em phpunit.xml CI (4 pts)
+        $phpunit = file_exists($this->phpunitXmlPath) ? file_get_contents($this->phpunitXmlPath) : '';
+        $isRegistered = str_contains($phpunit, "./Modules/{$name}/Tests");
+        $d2c = $isRegistered ? 4 : 0;
+        $breakdown[] = [
+            'key'   => 'D2.c',
+            'desc'  => 'Registrado em phpunit.xml CI',
+            'score' => $d2c,
+            'max'   => 4,
+            'evidence' => $isRegistered ? 'sim — Tests em phpunit.xml' : 'NÃO REGISTRADO — falsa cobertura',
+        ];
+
+        return [
+            'weight'    => 20,
+            'score'     => $d2a + $d2b + $d2c,
+            'max'       => 20,
+            'breakdown' => $breakdown,
+        ];
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // D3 — Documentação canônica (15 pts)
+    // ────────────────────────────────────────────────────────────────────────
+
+    private function dim3Documentation(string $name, string $modulePath): array
+    {
+        $breakdown = [];
+
+        $specPath = $this->memoryPath . "/{$name}/SPEC.md";
+        $briefingPath = $this->memoryPath . "/{$name}/BRIEFING.md";
+        $pagesModulePath = $this->pagesPath . "/{$name}";
+
+        // D3.a — SPEC.md (5 pts)
+        $d3a = file_exists($specPath) ? 5 : 0;
+        $breakdown[] = [
+            'key' => 'D3.a', 'desc' => 'memory/requisitos/<X>/SPEC.md',
+            'score' => $d3a, 'max' => 5,
+            'evidence' => $d3a ? 'sim' : 'ausente',
+        ];
+
+        // D3.b — BRIEFING.md atualizado ≤90d (5 pts)
+        $d3b = 0;
+        $briefingEvidence = 'ausente';
+        if (file_exists($briefingPath)) {
+            $age = (time() - filemtime($briefingPath)) / 86400;
+            $d3b = $age <= 90 ? 5 : 2;
+            $briefingEvidence = sprintf('idade %.0fd', $age);
+        }
+        $breakdown[] = [
+            'key' => 'D3.b', 'desc' => 'BRIEFING.md 1-pager ≤90d',
+            'score' => $d3b, 'max' => 5,
+            'evidence' => $briefingEvidence,
+        ];
+
+        // D3.c — Charter ≥30% telas (3 pts)
+        $tsxFiles = $this->filesByExt($pagesModulePath, '.tsx');
+        $charterFiles = $this->filesByExt($pagesModulePath, '.charter.md');
+        $charterRatio = count($tsxFiles) === 0 ? 0 : count($charterFiles) / count($tsxFiles);
+        $d3c = $charterRatio >= 0.30 ? 3 : (int) round($charterRatio * 10);
+        $breakdown[] = [
+            'key' => 'D3.c', 'desc' => 'Charter por tela ≥30%',
+            'score' => $d3c, 'max' => 3,
+            'evidence' => sprintf('%d charters / %d tsx (%.0f%%)', count($charterFiles), count($tsxFiles), $charterRatio * 100),
+        ];
+
+        // D3.d — ADR mãe declarada (2 pts) — busca em memory/decisions/ frontmatter module: <Name>
+        $d3d = $this->hasModuleAdr($name) ? 2 : 0;
+        $breakdown[] = [
+            'key' => 'D3.d', 'desc' => 'ADR mãe com module: <X> no frontmatter',
+            'score' => $d3d, 'max' => 2,
+            'evidence' => $d3d ? 'sim' : 'ausente',
+        ];
+
+        return [
+            'weight'    => 15,
+            'score'     => $d3a + $d3b + $d3c + $d3d,
+            'max'       => 15,
+            'breakdown' => $breakdown,
+        ];
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // D4 — Maturidade arquitetura (20 pts)
+    // ────────────────────────────────────────────────────────────────────────
+
+    private function dim4Architecture(string $name, string $modulePath): array
+    {
+        $breakdown = [];
+
+        $services = $this->phpFiles($modulePath . '/Services');
+        $controllers = $this->phpFiles($modulePath . '/Http/Controllers');
+
+        // D4.a — Service/Controller ratio ≥ 0.3 (6 pts)
+        $ratio = count($controllers) === 0 ? 0 : count($services) / count($controllers);
+        $d4a = (int) round(min(6, $ratio * 20));  // ratio 0.3 → 6
+        $breakdown[] = [
+            'key' => 'D4.a', 'desc' => 'Services/Controllers ratio ≥ 0.3',
+            'score' => $d4a, 'max' => 6,
+            'evidence' => sprintf('%d Services / %d Controllers (ratio %.2f)', count($services), count($controllers), $ratio),
+        ];
+
+        // D4.b — FSM canônica (5 pts) — busca trait GuardsFsmTransitions em Models OR sale_processes referenciado
+        $d4b = 0;
+        $modelFiles = array_merge($this->phpFiles($modulePath . '/Entities'), $this->phpFiles($modulePath . '/Models'));
+        foreach ($modelFiles as $f) {
+            $content = @file_get_contents($f) ?: '';
+            if (str_contains($content, 'GuardsFsmTransitions') || str_contains($content, 'current_stage_id')) {
+                $d4b = 5;
+                break;
+            }
+        }
+        $breakdown[] = [
+            'key' => 'D4.b', 'desc' => 'FSM canônica (ADR 0143)',
+            'score' => $d4b, 'max' => 5,
+            'evidence' => $d4b ? 'sim — GuardsFsmTransitions ou current_stage_id detectado' : 'não aplicável ou ausente',
+        ];
+
+        // D4.c — Pages Inertia .tsx ≥ Blade .blade.php legacy (5 pts)
+        $tsxCount = count($this->filesByExt($this->pagesPath . "/{$name}", '.tsx'));
+        $bladeViewsPath = $this->viewsPath . '/' . strtolower($name);  // tentativa convenção
+        $bladeCount = count($this->filesByExt($bladeViewsPath, '.blade.php', recursive: true));
+        $d4c = $tsxCount + $bladeCount === 0
+            ? 3  // módulo backend-only — neutro
+            : ($tsxCount >= $bladeCount ? 5 : (int) round(($tsxCount / max(1, $tsxCount + $bladeCount)) * 5));
+        $breakdown[] = [
+            'key' => 'D4.c', 'desc' => 'Pages Inertia .tsx ≥ Blade .blade.php legacy',
+            'score' => $d4c, 'max' => 5,
+            'evidence' => "{$tsxCount} tsx / {$bladeCount} blade",
+        ];
+
+        // D4.d — AuditLog + OTel telemetry (4 pts)
+        $d4d = 0;
+        foreach ([...$controllers, ...$services] as $f) {
+            $content = @file_get_contents($f) ?: '';
+            if (preg_match('/(LogsActivity|activity\(\)|OpenTelemetry|otel_span|Telemetry)/i', $content)) {
+                $d4d = 4;
+                break;
+            }
+        }
+        $breakdown[] = [
+            'key' => 'D4.d', 'desc' => 'AuditLog + OTel telemetry',
+            'score' => $d4d, 'max' => 4,
+            'evidence' => $d4d ? 'sim — activitylog ou OTel detectado' : 'ausente',
+        ];
+
+        return [
+            'weight'    => 20,
+            'score'     => $d4a + $d4b + $d4c + $d4d,
+            'max'       => 20,
+            'breakdown' => $breakdown,
+        ];
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // D5 — Cliente real + criticidade (15 pts)
+    // ────────────────────────────────────────────────────────────────────────
+
+    private function dim5Client(string $name): array
+    {
+        $clients = $this->loadClients();
+        $entry = $clients[$name] ?? null;
+
+        $score = 0;
+        $evidence = 'ninguém usa (D5.e)';
+
+        if ($entry) {
+            $level = $entry['level'] ?? 'none';
+            $score = match ($level) {
+                'biz_4_rota_livre_prod'    => 15,
+                'biz_1_wagner_active'      => 10,
+                'piloto_reportando_dor'    => 8,
+                'backlog_hipotese'         => 3,
+                default                    => 0,
+            };
+            $evidence = "{$level}" . (isset($entry['note']) ? " — {$entry['note']}" : '');
+        }
+
+        return [
+            'weight'    => 15,
+            'score'     => $score,
+            'max'       => 15,
+            'breakdown' => [
+                [
+                    'key' => 'D5', 'desc' => 'Cliente real (manual via config/governance/module_clients.yaml)',
+                    'score' => $score, 'max' => 15,
+                    'evidence' => $evidence,
+                ],
+            ],
+        ];
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Gaps + Evolve suggestions
+    // ────────────────────────────────────────────────────────────────────────
+
+    /**
+     * Extrai top gaps ordenados por (perda absoluta de pontos × prioridade dimensão).
+     */
+    private function extractGaps(string $name, array $dimensions): array
+    {
+        $gaps = [];
+        foreach ($dimensions as $dimKey => $dim) {
+            foreach ($dim['breakdown'] as $item) {
+                $lost = $item['max'] - $item['score'];
+                if ($lost > 0) {
+                    $gaps[] = [
+                        'dimension' => $dimKey,
+                        'key'       => $item['key'],
+                        'desc'      => $item['desc'],
+                        'evidence'  => $item['evidence'],
+                        'lost'      => $lost,
+                        'max'       => $item['max'],
+                        'priority'  => $this->priorityFor($dimKey, $lost),
+                    ];
+                }
+            }
+        }
+        usort($gaps, fn ($a, $b) => $b['lost'] <=> $a['lost']);
+        return $gaps;
+    }
+
+    /**
+     * Sugere tasks-create batch pra MCP server baseado em top gaps.
+     * Botão Evoluir mostra essa lista; Wagner aprova → cria via tasks-create.
+     */
+    private function suggestEvolveTasks(string $name, array $gaps): array
+    {
+        $tasks = [];
+        foreach (array_slice($gaps, 0, 5) as $g) {
+            $tasks[] = [
+                'title'     => $this->taskTitleFor($name, $g),
+                'module'    => $name,
+                'priority'  => $g['priority'],
+                'estimate'  => $this->estimateFor($g),
+                'gap_ref'   => $g['key'],
+                'rationale' => "{$g['desc']} (perda: {$g['lost']}/{$g['max']} pts)",
+            ];
+        }
+        return $tasks;
+    }
+
+    private function taskTitleFor(string $module, array $gap): string
+    {
+        return match ($gap['key']) {
+            'D1.a' => "Adicionar BusinessScope global em Entities {$module}",
+            'D1.b' => "Adicionar cross-tenant Pest biz=1 vs biz=99 em {$module}",
+            'D1.c' => "Refatorar Jobs {$module} pra receber \$businessId no constructor",
+            'D2.a' => "Aumentar cobertura Pest em {$module} (ratio tests/Controllers ≥ 0.5)",
+            'D2.b' => "Adicionar tests canônicos faltantes em {$module} (MultiTenant + Smoke + Scaffold)",
+            'D2.c' => "Registrar Modules/{$module}/Tests/Feature em phpunit.xml",
+            'D3.a' => "Criar memory/requisitos/{$module}/SPEC.md com US-XXX-NNN",
+            'D3.b' => "Criar/atualizar memory/requisitos/{$module}/BRIEFING.md (1-pager ≤90d)",
+            'D3.c' => "Criar Charter .charter.md pras telas principais de {$module}",
+            'D3.d' => "Declarar ADR mãe pra {$module} com frontmatter module: {$module}",
+            'D4.a' => "Extrair Service classes em {$module} (ratio Services/Controllers ≥ 0.3)",
+            'D4.b' => "Avaliar adoção FSM canônica (ADR 0143) em {$module}",
+            'D4.c' => "Migrar Blade legacy {$module} pra Inertia .tsx",
+            'D4.d' => "Adicionar AuditLog (LogsActivity) + OTel telemetry em {$module}",
+            'D5'   => "Identificar cliente real ou desclassificar {$module} pra backlog feature-wish",
+            default => "Endereçar gap {$gap['key']} em {$module}",
+        };
+    }
+
+    private function estimateFor(array $gap): string
+    {
+        return match ($gap['key']) {
+            'D2.c' => '15min',
+            'D3.d' => '30min',
+            'D3.a', 'D3.b' => '1h',
+            'D3.c' => '2h',
+            'D1.a', 'D1.b', 'D1.c' => '2-4h',
+            'D2.a', 'D2.b' => '2-4h',
+            'D4.a' => '4-8h',
+            'D4.b' => '8h+',
+            'D4.c' => '8-40h',
+            'D4.d' => '2-4h',
+            'D5'   => 'decisão Wagner',
+            default => '2h',
+        };
+    }
+
+    private function priorityFor(string $dimension, int $lost): string
+    {
+        if ($dimension === 'multi_tenant' && $lost >= 10) return 'P0';
+        if ($dimension === 'multi_tenant') return 'P1';
+        if ($dimension === 'pest_coverage' && $lost >= 8) return 'P1';
+        if ($dimension === 'pest_coverage') return 'P2';
+        if ($dimension === 'documentation') return 'P2';
+        if ($dimension === 'architecture' && $lost >= 8) return 'P1';
+        if ($dimension === 'architecture') return 'P2';
+        return 'P3';
+    }
+
+    // ────────────────────────────────────────────────────────────────────────
+    // Helpers
+    // ────────────────────────────────────────────────────────────────────────
+
+    private function bucketFor(int $score): array
+    {
+        foreach (self::BUCKETS as $b) {
+            if ($score >= $b['min']) return $b;
+        }
+        return self::BUCKETS[count(self::BUCKETS) - 1];
+    }
+
+    private function phpFiles(string $dir, bool $recursive = false): array
+    {
+        if (! is_dir($dir)) return [];
+        if (! $recursive) {
+            return array_values(array_filter(
+                glob($dir . '/*.php') ?: [],
+                fn ($f) => is_file($f)
+            ));
+        }
+        $iter = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS));
+        $files = [];
+        foreach ($iter as $f) {
+            if ($f->isFile() && str_ends_with($f->getFilename(), '.php')) {
+                $files[] = $f->getPathname();
+            }
+        }
+        return $files;
+    }
+
+    private function filesByExt(string $dir, string $ext, bool $recursive = true): array
+    {
+        if (! is_dir($dir)) return [];
+        $iter = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS));
+        $files = [];
+        foreach ($iter as $f) {
+            if ($f->isFile() && str_ends_with($f->getFilename(), $ext)) {
+                $files[] = $f->getPathname();
+            }
+        }
+        return $files;
+    }
+
+    private function hasModuleAdr(string $name): bool
+    {
+        $decisionsPath = base_path('memory/decisions');
+        if (! is_dir($decisionsPath)) return false;
+
+        foreach (glob($decisionsPath . '/*.md') ?: [] as $file) {
+            $content = @file_get_contents($file) ?: '';
+            if (preg_match('/^module:\s*[\'"]?' . preg_quote($name, '/') . '[\'"]?\s*$/m', $content)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private function loadClients(): array
+    {
+        if (! file_exists($this->clientsConfigPath)) {
+            return [];
+        }
+
+        try {
+            $data = Yaml::parseFile($this->clientsConfigPath);
+            return is_array($data) ? $data : [];
+        } catch (\Throwable $e) {
+            return [];
+        }
+    }
+}

--- a/Modules/Governance/Tests/Feature/ModuleGradeCommandTest.php
+++ b/Modules/Governance/Tests/Feature/ModuleGradeCommandTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Tests pra `php artisan module:grade` (Command CLI da rubrica module-grade-v1).
+ *
+ * @see memory/decisions/0153-module-grade-rubrica-v1.md
+ * @see Modules/Governance/Console/Commands/ModuleGradeCommand.php
+ */
+
+it('module:grade exige name OU --all', function () {
+    $this->artisan('module:grade')
+        ->expectsOutputToContain('Forneça {name} ou --all')
+        ->assertExitCode(2);
+});
+
+it('module:grade <Nome> retorna sucesso com tabela', function () {
+    $this->artisan('module:grade Governance')
+        ->expectsOutputToContain('Modules/Governance')
+        ->assertExitCode(0);
+});
+
+it('module:grade <ModuloInexistente> falha', function () {
+    $this->artisan('module:grade ModuloXyzNaoExiste')
+        ->expectsOutputToContain('não existe em Modules/')
+        ->assertExitCode(1);
+});
+
+it('module:grade --all retorna tabela ranqueada', function () {
+    $this->artisan('module:grade --all')
+        ->expectsOutputToContain('Média projeto:')
+        ->expectsOutputToContain('Distribuição por bucket:')
+        ->assertExitCode(0);
+});
+
+it('module:grade <Nome> --json retorna JSON parseável', function () {
+    $this->artisan('module:grade Governance --json')
+        ->assertExitCode(0);
+});
+
+it('module:grade <Nome> --evolve mostra batch de tasks sugeridas', function () {
+    $this->artisan('module:grade Governance --evolve')
+        ->expectsOutputToContain('Batch de tasks-create sugeridas')
+        ->assertExitCode(0);
+});
+
+it('module:grade NÃO usa flag --verbose (Symfony reserved — colide com --v|--vv|--vvv)', function () {
+    // Sanity: signature do command não declara verbose custom
+    $command = app(\Modules\Governance\Console\Commands\ModuleGradeCommand::class);
+    $definition = $command->getDefinition();
+
+    // Symfony adiciona --verbose default; nosso command NÃO deve sobreescrever
+    expect($definition->hasOption('detail'))->toBeTrue();
+    expect($definition->hasOption('json'))->toBeTrue();
+    expect($definition->hasOption('all'))->toBeTrue();
+    expect($definition->hasOption('evolve'))->toBeTrue();
+
+    // Verifica que --verbose ainda é o padrão Symfony (não custom)
+    $verboseOption = $definition->hasOption('verbose') ? $definition->getOption('verbose') : null;
+    if ($verboseOption) {
+        // Symfony default tem shortcut 'v' e description "Increase the verbosity of messages"
+        expect($verboseOption->getShortcut())->toBe('v');
+    }
+});

--- a/Modules/Governance/Tests/Feature/ModuleGradeControllerTest.php
+++ b/Modules/Governance/Tests/Feature/ModuleGradeControllerTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Tests pra ModuleGradeController (rotas Inertia /governance/module-grades).
+ *
+ * Smoke test — apenas valida que rotas existem, middleware auth aplicado,
+ * status <500. NÃO testa renderização Inertia completa (Pest browser tests
+ * cobrem isso em outra suite).
+ *
+ * @see memory/decisions/0153-module-grade-rubrica-v1.md
+ * @see Modules/Governance/Http/Controllers/ModuleGradeController.php
+ */
+
+it('rota nomeada governance.module-grades.index existe', function () {
+    expect(\Route::has('governance.module-grades.index'))->toBeTrue();
+});
+
+it('rota nomeada governance.module-grades.show existe', function () {
+    expect(\Route::has('governance.module-grades.show'))->toBeTrue();
+});
+
+it('GET /governance/module-grades sem auth redireciona ou bloqueia', function () {
+    $response = $this->get('/governance/module-grades');
+    expect($response->status())->toBeIn([302, 401, 403])
+        ->and($response->status())->not->toBe(200);
+});
+
+it('GET /governance/module-grades/{name} sem auth redireciona ou bloqueia', function () {
+    $response = $this->get('/governance/module-grades/Governance');
+    expect($response->status())->toBeIn([302, 401, 403])
+        ->and($response->status())->not->toBe(200);
+});
+
+it('Rota show param name aceita apenas A-Za-z0-9_-', function () {
+    $route = \Route::getRoutes()->getByName('governance.module-grades.show');
+    expect($route)->not->toBeNull();
+
+    // Constraint declarado via ->where('name', '[A-Za-z0-9_-]+')
+    $wheres = $route->wheres ?? [];
+    expect($wheres['name'] ?? null)->toBe('[A-Za-z0-9_-]+');
+});
+
+it('Controller usa Inertia::defer em props caras (D-14 lição)', function () {
+    $controllerPath = base_path('Modules/Governance/Http/Controllers/ModuleGradeController.php');
+    expect(file_exists($controllerPath))->toBeTrue();
+
+    $source = file_get_contents($controllerPath);
+    // Pest toContain aceita apenas string OR string... (variadic) — todos têm que aparecer
+    expect($source)->toContain('Inertia::defer');
+});

--- a/Modules/Governance/Tests/Feature/ModuleGradeServiceTest.php
+++ b/Modules/Governance/Tests/Feature/ModuleGradeServiceTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Governance\Services\ModuleGradeService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Tests pra rubrica module-grade-v1 (ADR 0153).
+ *
+ * Service é puro filesystem inspection — funciona sem DB (independente de SQLite/MySQL).
+ *
+ * @see memory/decisions/0153-module-grade-rubrica-v1.md
+ */
+
+it('gradeModule retorna estrutura canônica completa', function () {
+    $service = app(ModuleGradeService::class);
+    $grade = $service->gradeModule('Governance');
+
+    expect($grade)->toHaveKeys(['module', 'score', 'bucket', 'color', 'dimensions', 'gaps', 'evolve_tasks', 'evaluated_at']);
+    expect($grade['module'])->toBe('Governance');
+    expect($grade['score'])->toBeInt()->toBeGreaterThanOrEqual(0)->toBeLessThanOrEqual(100);
+    expect($grade['bucket'])->toBeIn(['Excelente', 'Bom', 'Médio', 'Crítico', 'Embrião']);
+});
+
+it('gradeModule retorna 5 dimensões com pesos corretos somando 100', function () {
+    $service = app(ModuleGradeService::class);
+    $grade = $service->gradeModule('Governance');
+
+    $dims = $grade['dimensions'];
+    expect($dims)->toHaveKeys(['multi_tenant', 'pest_coverage', 'documentation', 'architecture', 'client_real']);
+
+    expect($dims['multi_tenant']['weight'])->toBe(30);
+    expect($dims['pest_coverage']['weight'])->toBe(20);
+    expect($dims['documentation']['weight'])->toBe(15);
+    expect($dims['architecture']['weight'])->toBe(20);
+    expect($dims['client_real']['weight'])->toBe(15);
+
+    $totalWeight = $dims['multi_tenant']['weight']
+        + $dims['pest_coverage']['weight']
+        + $dims['documentation']['weight']
+        + $dims['architecture']['weight']
+        + $dims['client_real']['weight'];
+    expect($totalWeight)->toBe(100);
+});
+
+it('gradeModule cada dimensão tem score ≤ max', function () {
+    $service = app(ModuleGradeService::class);
+    $grade = $service->gradeModule('Governance');
+
+    foreach ($grade['dimensions'] as $dim) {
+        expect($dim['score'])->toBeLessThanOrEqual($dim['max']);
+        expect($dim['score'])->toBeGreaterThanOrEqual(0);
+        expect($dim['breakdown'])->toBeArray()->not->toBeEmpty();
+    }
+});
+
+it('gradeModule lança exception pra módulo inexistente', function () {
+    $service = app(ModuleGradeService::class);
+    $service->gradeModule('ModuloQueNaoExiste123');
+})->throws(\InvalidArgumentException::class);
+
+it('gradeAllModules retorna Collection com 30+ módulos', function () {
+    $service = app(ModuleGradeService::class);
+    $grades = $service->gradeAllModules();
+
+    expect($grades)->toBeInstanceOf(\Illuminate\Support\Collection::class);
+    expect($grades->count())->toBeGreaterThanOrEqual(30);
+});
+
+it('gradeAllModules retorna ordenado descendente por score', function () {
+    $service = app(ModuleGradeService::class);
+    $grades = $service->gradeAllModules();
+
+    $scores = $grades->pluck('score')->all();
+    $sorted = $scores;
+    rsort($sorted);
+    expect($scores)->toBe($sorted);
+});
+
+it('buckets respeitam fronteiras canônicas', function () {
+    // Cria stub que avalia score conhecido e valida bucket
+    $service = app(ModuleGradeService::class);
+
+    // Usa módulos reais como evidência — todos buckets representados na rubrica
+    $grades = $service->gradeAllModules();
+
+    foreach ($grades as $g) {
+        $expectedBucket = match (true) {
+            $g['score'] >= 80 => 'Excelente',
+            $g['score'] >= 60 => 'Bom',
+            $g['score'] >= 40 => 'Médio',
+            $g['score'] >= 20 => 'Crítico',
+            default           => 'Embrião',
+        };
+        expect($g['bucket'])->toBe($expectedBucket, "Módulo {$g['module']} score {$g['score']} deveria ser {$expectedBucket}");
+    }
+});
+
+it('gradeModule extrai gaps ordenados por perda descendente', function () {
+    $service = app(ModuleGradeService::class);
+    $grade = $service->gradeModule('Governance');
+
+    if (empty($grade['gaps'])) {
+        $this->markTestSkipped('Governance não tem gaps suficientes pra ordenação');
+    }
+
+    $losses = array_column($grade['gaps'], 'lost');
+    $sorted = $losses;
+    rsort($sorted);
+    expect($losses)->toBe($sorted);
+});
+
+it('gradeModule gera evolve_tasks com priority válida', function () {
+    $service = app(ModuleGradeService::class);
+    $grade = $service->gradeModule('Governance');
+
+    expect($grade['evolve_tasks'])->toBeArray();
+    foreach ($grade['evolve_tasks'] as $task) {
+        expect($task)->toHaveKeys(['title', 'module', 'priority', 'estimate', 'gap_ref', 'rationale']);
+        expect($task['priority'])->toBeIn(['P0', 'P1', 'P2', 'P3']);
+        expect($task['module'])->toBe('Governance');
+    }
+});
+
+it('rubrica calibrada — módulo bem-coberto (Whatsapp) tem score Bom (60+)', function () {
+    $service = app(ModuleGradeService::class);
+    $grade = $service->gradeModule('Whatsapp');
+
+    // Whatsapp tem 91 tests + 58 cross-tenant + BRIEFING + cliente biz=1 — esperado Bom+ (60+)
+    expect($grade['score'])->toBeGreaterThanOrEqual(60, 'Whatsapp deveria estar no bucket Bom ou Excelente');
+});
+
+it('rubrica calibrada — módulo sem cobertura (ProductCatalogue/AssetManagement etc) fica Crítico ou Embrião', function () {
+    $service = app(ModuleGradeService::class);
+    $grade = $service->gradeModule('AssetManagement');
+
+    // AssetManagement sem tests + sem cliente + sem doc = Embrião esperado
+    expect($grade['score'])->toBeLessThan(40, 'AssetManagement deveria estar em bucket Crítico ou Embrião');
+});
+
+it('D5 Cliente lê config/governance/module_clients.yaml se existir', function () {
+    $service = app(ModuleGradeService::class);
+    $grade = $service->gradeModule('Vestuario');
+
+    // Vestuario está marcado como biz_4_rota_livre_prod no YAML → score D5 = 15
+    expect($grade['dimensions']['client_real']['score'])->toBe(15, 'Vestuario biz=4 ROTA LIVRE prod deveria scorar 15/15 em D5');
+});
+
+it('D2.c registrado em phpunit.xml gera 4 pts; não registrado gera 0', function () {
+    $service = app(ModuleGradeService::class);
+    $grade = $service->gradeModule('Governance');
+
+    $d2 = $grade['dimensions']['pest_coverage'];
+    $d2cItem = collect($d2['breakdown'])->firstWhere('key', 'D2.c');
+
+    expect($d2cItem)->not->toBeNull();
+    expect($d2cItem['max'])->toBe(4);
+    // Governance está registrado em phpunit.xml na Wave B → score 4
+    // (depende do estado atual; se ainda não mergeado pode ser 0)
+    expect($d2cItem['score'])->toBeIn([0, 4]);
+});

--- a/config/governance/module_clients.yaml
+++ b/config/governance/module_clients.yaml
@@ -1,0 +1,156 @@
+# Configuração D5 (Cliente real) da rubrica module-grade-v1 (ADR 0153).
+#
+# Wagner edita manualmente — quando Modules/Brief gerar volume/módulo automático,
+# pode virar source DB (mcp_module_clients table).
+#
+# Níveis (peso D5 = 15 pts):
+#   biz_4_rota_livre_prod   → 15 pts (cliente piloto produção)
+#   biz_1_wagner_active     → 10 pts (Wagner usa diário)
+#   piloto_reportando_dor   →  8 pts (sinal qualificado ADR 0105)
+#   backlog_hipotese        →  3 pts (feature-wish sem cliente)
+#   none                    →  0 pts (ninguém usa — descontinuar?)
+#
+# Formato:
+#   <ModuleName>:
+#     level: <nivel>
+#     note: <observação curta>
+
+Vestuario:
+  level: biz_4_rota_livre_prod
+  note: Larissa @ ROTA LIVRE 99% volume vendas (cliente piloto canônico)
+
+Whatsapp:
+  level: biz_1_wagner_active
+  note: Wagner biz=1 ativo + ROTA LIVRE potencial
+
+Jana:
+  level: biz_1_wagner_active
+  note: Wagner usa Jana diário + Larissa via BriefDiario
+
+Repair:
+  level: biz_1_wagner_active
+  note: Wagner biz=1 + Martinho CYCLE-06 prod candidato
+
+Sells:
+  level: biz_4_rota_livre_prod
+  note: ROTA LIVRE PDV principal (Sells/Create.tsx)
+
+NfeBrasil:
+  level: biz_1_wagner_active
+  note: biz=1 + biz=4 emitem NFe ativamente
+
+Financeiro:
+  level: biz_1_wagner_active
+  note: Wagner usa cobrança + Larissa AR/AP
+
+RecurringBilling:
+  level: piloto_reportando_dor
+  note: CYCLE-06 G1 Martinho — Inter PJ ativando
+
+OficinaAuto:
+  level: piloto_reportando_dor
+  note: Martinho Caçambas — sinal qualificado confirmado CYCLE-06
+
+ComunicacaoVisual:
+  level: backlog_hipotese
+  note: candidatos 6 OfficeImpresso saudáveis (Vargas/Extreme/Gold/Zoom/Fixar/Mhundo) — sem sinal qualificado ainda
+
+Crm:
+  level: biz_4_rota_livre_prod
+  note: ROTA LIVRE usa contatos + leads + schedules
+
+KB:
+  level: biz_1_wagner_active
+  note: Wagner uso interno + team MCP futuro
+
+Brief:
+  level: biz_1_wagner_active
+  note: Wagner usa brief-fetch diário (Daily Brief)
+
+Ponto:
+  level: backlog_hipotese
+  note: clientes legacy WR2 — sinal qualificado pendente
+
+Officeimpresso:
+  level: piloto_reportando_dor
+  note: bridge Delphi WR Sistemas — 6 clientes saudáveis em migração
+
+Admin:
+  level: biz_1_wagner_active
+  note: Wagner uso interno gates auth
+
+Superadmin:
+  level: biz_1_wagner_active
+  note: Wagner uso interno governança UltimatePOS
+
+Governance:
+  level: biz_1_wagner_active
+  note: Wagner uso interno Constituição v2
+
+Auditoria:
+  level: biz_1_wagner_active
+  note: Wagner uso interno activity_log + RevertService
+
+Arquivos:
+  level: biz_1_wagner_active
+  note: Wagner uso interno + vault encryption
+
+TeamMcp:
+  level: biz_1_wagner_active
+  note: tokens MCP team (Wagner/Felipe/Maiara/Eliana/Luiz)
+
+NFSe:
+  level: backlog_hipotese
+  note: pareado NfeBrasil — clientes legacy ComVis quando ativar
+
+Accounting:
+  level: biz_4_rota_livre_prod
+  note: ROTA LIVRE usa contábil UltimatePOS (70 entities core)
+
+Manufacturing:
+  level: piloto_reportando_dor
+  note: ROTA LIVRE recipes vestuário + Martinho receitas oficina
+
+Cms:
+  level: biz_1_wagner_active
+  note: site oimpresso.com.br hidratação Wagner
+
+Essentials:
+  level: biz_4_rota_livre_prod
+  note: ROTA LIVRE usa Todo + HRM UltimatePOS
+
+ProjectMgmt:
+  level: backlog_hipotese
+  note: subset Project — pouco uso
+
+ADS:
+  level: backlog_hipotese
+  note: dual-brain dormente até cliente reportar dor (ADR 0105)
+
+Connector:
+  level: piloto_reportando_dor
+  note: integração Delphi clientes OfficeImpresso
+
+ConsultaOs:
+  level: backlog_hipotese
+  note: mock-only — TODO migrar pra transactions real
+
+SRS:
+  level: backlog_hipotese
+  note: SR legacy — uso interno raro
+
+AssetManagement:
+  level: none
+  note: scaffold UltimatePOS sem uso
+
+Spreadsheet:
+  level: none
+  note: scaffold UltimatePOS sem uso
+
+ProductCatalogue:
+  level: backlog_hipotese
+  note: catálogo público QR — uso pontual
+
+Woocommerce:
+  level: none
+  note: integração externa sem cliente ativo

--- a/memory/decisions/0153-module-grade-rubrica-v1.md
+++ b/memory/decisions/0153-module-grade-rubrica-v1.md
@@ -1,0 +1,157 @@
+---
+slug: 0153-module-grade-rubrica-v1
+number: 0153
+title: "Rubrica oficial `module-grade-v1` — nota 0-100 ponderada pra cada Module"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: 2026-05-16
+module: Governance
+quarter: 2026-Q2
+tags: [governance, qualidade, audit, dashboard, dim-5-pesos-100]
+supersedes: []
+supersedes_partially: []
+superseded_by: []
+related: [0093, 0094, 0101, 0105, 0143]
+pii: false
+review_triggers:
+  - Quando pesos das 5 dimensões precisarem ajuste (ex: receita por módulo vira mensurável)
+  - Quando dimensão nova for incluída (Performance, LGPD, ROI financeiro)
+  - Quando média projeto bater 70+ (sinal que rubrica saturou — precisa v2)
+---
+
+# ADR 0153 — Rubrica oficial `module-grade-v1` — nota 0-100 ponderada pra cada Module
+
+## Contexto
+
+Projeto tem 34 Modules com maturidade desigual (auditoria sessão 2026-05-15→16):
+- 2 excelentes (80+): Whatsapp, NfeBrasil
+- 8 bons (60-79): Jana, ComunicacaoVisual, KB, Repair, OficinaAuto, RecurringBilling, Arquivos, Vestuario
+- 5 médios (40-59): Auditoria pós-Wave, Ponto, ADS, Admin, Cms
+- 15 críticos (20-39): Crm, Manufacturing, NFSe, Connector, Accounting, Superadmin, Officeimpresso, SRS, Brief, Governance, ConsultaOs, ProductCatalogue, TeamMcp, ProjectMgmt, Essentials
+- 3 embriões (<20): AssetManagement, Spreadsheet, Woocommerce
+
+Sem rubrica formal, conversas sobre "prioridade" viram subjetivas. Wagner precisa de:
+- **Critério único reusável** pra avaliar qualquer módulo
+- **Comparabilidade** entre módulos
+- **Drill-down** que mostra ONDE está o gap (qual dimensão)
+- **Ação canônica** pra evoluir (botão "Evoluir" gera tasks priorizadas no MCP)
+- **Tracking 90d** pra ver evolução do projeto
+
+Sessão atual aplicou rubrica ad-hoc (5 dimensões, pesos 100). Funcionou empiricamente — Wagner pediu pra formalizar.
+
+## Decisão
+
+Aceitar **`module-grade-v1`** como rubrica canônica oficial pra avaliar maturidade de qualquer `Modules/<X>/` do oimpresso.
+
+### Dimensões (peso = 100)
+
+| Dim | Peso | O que mede | Como pontua |
+|---|---|---|---|
+| **D1. Multi-tenant Tier 0** | **30** | Isolamento `business_id` real ([ADR 0093](0093-multi-tenant-isolation-tier-0.md)) | (a) BusinessScope global em Entities críticas: 10 / (b) cross-tenant Pest biz=1 vs biz=99 ([ADR 0101](0101-tests-business-id-1-nunca-cliente.md)) cobrindo ≥50% Entities: 15 / (c) Jobs assíncronos recebem `$businessId` no constructor: 5 |
+| **D2. Pest cobertura** | **20** | Quantidade × qualidade × surface | (a) Razão `tests/Controllers ≥ 0.5`: 8 / (b) Tem MultiTenant + Smoke + Scaffold canônicos: 8 / (c) Registrado em phpunit.xml CI: 4 |
+| **D3. Documentação canônica** | **15** | SPEC + BRIEFING + Charter + ADR | (a) `memory/requisitos/<X>/SPEC.md` com US-XXX-NNN: 5 / (b) `BRIEFING.md` 1-pager atualizado ≤90d: 5 / (c) Charter por tela `.charter.md` ≥30% telas: 3 / (d) ADR mãe declarada referenciando módulo: 2 |
+| **D4. Maturidade arquitetura** | **20** | Service + FSM + Inertia + Observability | (a) Razão `Services/Controllers ≥ 0.3` (não fat Controller): 6 / (b) FSM canônica se aplicável ([ADR 0143](0143-fsm-pipeline-live-prod-marco-2026-05-12.md)): 5 / (c) Pages Inertia `.tsx` ≥ Blade `.blade.php` legacy: 5 / (d) AuditLog + OTel telemetry presente: 4 |
+| **D5. Cliente real + criticidade** | **15** | Sinal qualificado ([ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md)) | (a) biz=4 ROTA LIVRE prod com volume mensurado: 15 / (b) biz=1 Wagner ativo diário: 10 / (c) Cliente piloto reportando dor (sinal qualificado): 8 / (d) Backlog hipótese sem cliente: 3 / (e) Ninguém usa: 0 |
+
+**Total normalizado:** 0-100.
+
+### Buckets qualitativos
+
+| Faixa | Label | Tradução operacional |
+|---|---|---|
+| **80-100** | **Excelente** | World-class. Cliente prod + cobertura + doc + arq. Manter (CONSOLIDAR) |
+| **60-79** | **Bom** | Funciona em prod ou pré-prod com gaps menores. EVOLUIR seletivo |
+| **40-59** | **Médio** | Gap óbvio em ≥1 dimensão. Priorizar fix da dimensão mais fraca |
+| **20-39** | **Crítico** | Gap em ≥2 dimensões. Pacote de melhoria estruturado |
+| **0-19** | **Embrião** | Scaffold sem cliente nem cobertura. Decidir: investir ou descontinuar |
+
+### Implementação canônica
+
+1. **Service:** `Modules/Governance/Services/ModuleGradeService.php` — método `gradeModule(string $name): ModuleGrade` retorna value object com nota total + breakdown 5 dimensões + lista gaps priorizados
+2. **Command:** `php artisan module:grade [name] [--all] [--json]` invoca Service
+3. **UI:** `/governance/module-grades` (Inertia Page tabela) + `/governance/module-grades/{module}` (drill-down + botão Evoluir)
+4. **Botão Evoluir (MVP A):** gera batch `tasks-create` no MCP server priorizando gaps top 3 da dimensão mais fraca. Wagner revisa via `my-work`. Claude Code executa via Waves paralelas (pattern PRs #945/#946)
+5. **Skill `avaliar-modulo`** (Tier B): auto-trigger quando Wagner pede "/avaliar-modulo X" ou "nota do módulo X"
+
+### Coleta automática vs manual
+
+| Dimensão | Coleta | Fonte |
+|---|---|---|
+| D1.a BusinessScope | **Auto** | Grep `extends BusinessScope` em `Modules/<X>/Entities/*.php` |
+| D1.b Cross-tenant tests | **Auto** | Grep `biz=99\|BIZ_FICTICIO\|withoutGlobalScopes` em `Modules/<X>/Tests/` |
+| D1.c Jobs business_id | **Auto** | Grep `__construct.*\$businessId` em `Modules/<X>/Jobs/*.php` |
+| D2.a-c Pest | **Auto** | `find Modules/<X>/Tests + grep phpunit.xml + count Controllers` |
+| D3.a SPEC | **Auto** | `[ -f memory/requisitos/<X>/SPEC.md ]` |
+| D3.b BRIEFING | **Auto + staleness** | File mtime ≤ 90d |
+| D3.c Charter | **Auto** | `find resources/js/Pages/<X> -name "*.charter.md"` |
+| D3.d ADR mãe | **Auto** | Grep módulo nome em frontmatter `module:` de `memory/decisions/*.md` |
+| D4.a Services | **Auto** | `find Modules/<X>/Services + ratio com Controllers` |
+| D4.b FSM | **Auto** | Grep trait `GuardsFsmTransitions` ou tabela `sale_processes` por business |
+| D4.c Inertia ratio | **Auto** | `find resources/js/Pages/<X>/*.tsx vs resources/views/<x>/*.blade.php` |
+| D4.d AuditLog/OTel | **Auto** | Grep `LogsActivity\|activity(` + `OpenTelemetry\|otel_span` |
+| **D5. Cliente** | **Manual primeira versão** | Wagner marca manualmente em `config/governance/module_clients.yaml` |
+
+### Tracking 90d
+
+- Cada execução `php artisan module:grade --all` grava snapshot em tabela `mcp_module_grades_history (module, score, dim1..dim5, snapshot_at)`
+- Cron daily 06:00 BRT roda `module:grade --all` (alinhado com `jana:health-check`)
+- Goal canônico CYCLE: "elevar média projeto de 41 → 60 em 60d"
+- Dashboard sparkline 90d por módulo
+
+## Justificativa
+
+- **Pesos 30/20/15/20/15:** refletem prioridade Tier 0 IRREVOGÁVEL (Multi-tenant pesa mais) + valor de cobertura (Pest 20) + valor de cliente real (15 — alta porque ADR 0105 sinal qualificado guia o que se faz). Doc e Arq ficam em 15-20 (importantes mas não bloqueadores).
+- **5 dimensões e não mais:** dimensões testáveis 10 minutos via bash/grep. Mais dimensões = mais coleta manual = decai de uso. v2 pode adicionar Performance/LGPD/ROI quando dados objetivos existirem.
+- **Buckets 5 faixas:** facilita conversa ("módulo X está crítico, módulo Y é embrião"). Cores natural pra UI.
+- **Botão Evoluir MVP A (gera tasks):** evita mágica falsa. Cria tasks priorizadas que Claude Code (com você ou Felipe) executa. Pode evoluir pra Brain B quando ADR 0035 maturo + cliente reportando dor justifique custo.
+- **Cliente manual:** sem source autoritativo hoje, melhor honesto. Wagner edita YAML. Quando Modules/Brief gerar volume/módulo automático, vira coleta automática.
+
+## Consequências
+
+**Positivas:**
+- Conversas viram objetivas — "Crm 38 vs Vestuario 63" não tem opinião pra discordar
+- Goal CYCLE mensurável — "média 41 → 60" trackável daily
+- Gate de governança natural — PR que move módulo pra bucket inferior flag automático
+- Onboarding Felipe/Maiara — abrem `/governance/module-grades` veem prioridade sem perguntar
+- Time MCP futuro tem rubrica única — sem caos de critérios pessoais
+
+**Negativas / Trade-offs:**
+- Subjetividade residual em D4.a-d (interpretar "Service layer" varia)
+- D5.a "volume mensurado" depende de Brief gerar dado — primeiros meses Wagner marca manual
+- Risco de gaming — alguém pode adicionar Pest fraco só pra subir D2 sem real valor (mitigação: revisão PR + skill `module-completeness-audit`)
+- Pesos podem precisar ajuste após 30d uso real — v2 vira ADR 0154 (append-only)
+- 5min de execução `module:grade --all` × 34 módulos pode ser lento — otimizar com cache se necessário
+
+**Riscos mitigados:**
+- ⛔ "Prioridade subjetiva" sem rubrica → ADR 0153 cria rubrica única
+- ⛔ "Wagner decide tudo manualmente" → tela `/governance/module-grades` self-service
+- ⛔ "Gap escondido por boa narrativa" → 5 dimensões objetivas expõem onde dói
+- ⛔ "Time novo sem contexto" → buckets + breakdown ensina o que importa no projeto
+
+## Como evoluir (v2 candidatos)
+
+- **+ Dimensão Performance** (peso 5-10) — p99 response time, partial reload, defer pattern, time-to-interactive
+- **+ Dimensão LGPD** (peso 5-10) — PII redaction, audit log, retention policy, consent tracking
+- **+ Dimensão ROI financeiro** (peso 10) — receita gerada vs custo dev/mês (quando Brief gerar dado)
+- **Penalidade negativa** — descontar 5 pts por incident crítico catalogado nos últimos 90d
+- **Bonus** — +10 pts se módulo entrou em CONSOLIDAR sustentado 60d
+
+Cada evolução vira ADR 0154+ append-only.
+
+## Referências
+
+- [ADR 0093](0093-multi-tenant-isolation-tier-0.md) — Multi-tenant Tier 0 IRREVOGÁVEL (peso máximo em D1)
+- [ADR 0094](0094-constituicao-v2-7-camadas-8-principios.md) — Constituição v2 (Governance enforcer canônico)
+- [ADR 0101](0101-tests-business-id-1-nunca-cliente.md) — Tests biz=1 nunca cliente (D1.b validação)
+- [ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md) — Cliente como sinal qualificado (D5 baseado nisso)
+- [ADR 0143](0143-fsm-pipeline-live-prod-marco-2026-05-12.md) — FSM Pipeline canônico (D4.b)
+- PR #945 + #946 — Waves A/B Pest cobertura 34/34 que viabilizam D1.b + D2 medíveis
+- `memory/sessions/2026-05-15-inventario-pest-coverage.md` — auditoria empírica que motivou a rubrica
+- `memory/handoffs/2026-05-16-0000-pest-cobertura-34de34-modulos-waves-AB.md` — sessão de origem
+
+---
+
+**Próxima ação Wagner:** revisar ADR + ajustar pesos se quiser ANTES de marcar `status: accepted` → habilita Service + Command + UI implementarem.

--- a/memory/requisitos/Governance/RUNBOOK-module-grades.md
+++ b/memory/requisitos/Governance/RUNBOOK-module-grades.md
@@ -1,0 +1,70 @@
+# RUNBOOK — `/governance/module-grades` (Index + Show)
+
+> **Tela canônica greenfield** Inertia React. Dashboard de notas dos 34 Modules (ADR 0153 rubrica `module-grade-v1`).
+> NÃO é migração MWART Blade→Inertia (não existe Blade legacy desta tela). Override implícito por ser greenfield.
+
+## Mission
+
+Wagner (e Felipe/Maiara/Eliana/Luiz quando entrarem) abrem `/governance/module-grades`, veem **nota 0-100 + bucket de cor** pra cada módulo, drill-down em qualquer um pra ver **5 dimensões + top gaps**, e clicam **botão "Evoluir"** que gera batch de tasks-create sugeridas pra fechar gaps prioritários.
+
+## Goals
+
+1. **Visibilidade total** — abrir tela = ver maturidade do projeto inteiro em 5s
+2. **Drill-down acionável** — clicar módulo = entender ONDE está o gap (qual dimensão)
+3. **Ação canônica** — botão Evoluir = batch tasks-create suggested (MVP A: copy markdown; futuro: integração MCP direta)
+4. **Tracking 90d** — snapshot diário em `mcp_module_grades_history` (Fase B — opcional v2)
+
+## Non-Goals (NÃO fazer)
+
+- ❌ Editar pesos da rubrica na UI (rubrica é ADR canônica — muda via append-only ADR 0154 v2)
+- ❌ Auto-disparar agents Brain B (custo $$$ + risco regressão) — limite MVP é gerar tasks
+- ❌ Comparar histórico módulo-vs-módulo (Fase B se demanda)
+
+## UX targets
+
+- **Index** (`/governance/module-grades`):
+  - Tabela ordenada por nota descendente
+  - Cor por bucket (verde/azul/amarelo/laranja/vermelho)
+  - Filtro rápido por bucket (chips)
+  - Busca por nome
+  - KPI agregado: média projeto + distribuição buckets
+  - Click row → drill-down `/governance/module-grades/{module}`
+
+- **Show** (`/governance/module-grades/{module}`):
+  - Header: nome módulo + nota + bucket
+  - 5 cards dimensões (D1-D5) — score/max + breakdown sub-itens com evidência
+  - Lista top gaps ordenada (perda absoluta de pontos)
+  - Botão **"Evoluir"** primário — abre modal/drawer com batch tasks sugeridas + copy-as-markdown button
+
+## Plug-points
+
+- **Controller:** `Modules/Governance/Http/Controllers/ModuleGradeController.php` — métodos `index()` e `show($module)`
+- **Service:** `Modules/Governance/Services/ModuleGradeService.php` — injetado via DI
+- **Routes:** adicionadas a `Modules/Governance/Http/routes.php` no grupo `governance.*`
+- **Pages:** `resources/js/Pages/governance/ModuleGrades/Index.tsx` + `Show.tsx`
+- **Charter:** `Index.charter.md` + `Show.charter.md` ao lado dos `.tsx`
+- **Layout:** `AppShellV2` (padrão Governance — herdado Dashboard.tsx)
+
+## Anti-hooks
+
+- **Inertia::defer** pra `gradeAllModules()` no Index — Service roda I/O filesystem 1-2s × 34 módulos. Sem defer trava initial render
+- **Cache 5min** server-side pra `gradeAllModules()` — re-rodar não muda muito em 5min
+- **Sem PII** — nomes módulos são públicos, mas evidence pode conter paths de teste → sanitizar antes de render
+
+## Dependências canônicas
+
+- [ADR 0153](../../decisions/0153-module-grade-rubrica-v1.md) — rubrica oficial
+- [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md) — D1 base
+- [ADR 0101](../../decisions/0101-tests-business-id-1-nunca-cliente.md) — D1.b validação
+- [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — D5 nível
+- ADRs Governance: 0086 Fase 5 MVP, 0094 Constituição v2
+
+## Critério de aceite
+
+- [ ] `php artisan module:grade --all` retorna tabela ranqueada 34 módulos
+- [ ] `/governance/module-grades` carrega <2s com partial reload
+- [ ] Click row → drill-down funcional
+- [ ] Botão Evoluir abre modal/drawer com batch tasks
+- [ ] Copy markdown copia formato pronto pra colar no Claude Code
+- [ ] Pest cobre Service (5 dimensões) + Command (--all, --evolve, --json) + Controller (smoke route Tier 0)
+- [ ] phpunit.xml já cobre Modules/Governance/Tests/Feature (registrado Wave B)

--- a/resources/js/Pages/governance/ModuleGrades/Index.charter.md
+++ b/resources/js/Pages/governance/ModuleGrades/Index.charter.md
@@ -1,0 +1,44 @@
+---
+page: governance/ModuleGrades/Index
+route: /governance/module-grades
+status: live
+owner: [W]
+adrs: [0153]
+runbook: memory/requisitos/Governance/RUNBOOK-module-grades.md
+---
+
+# Charter — `/governance/module-grades` (Index)
+
+## Mission
+
+Permitir que Wagner (e time MCP futuro) abram **uma tela** e vejam a maturidade do projeto inteiro — 34 Modules com nota 0-100 + bucket de cor — em 5 segundos.
+
+## Goals
+
+1. Tabela ordenada por nota descendente (default)
+2. Filter chips por bucket (Excelente/Bom/Médio/Crítico/Embrião)
+3. Search por nome do módulo
+4. KPI agregado: média projeto + distribuição buckets
+5. Click row → drill-down `/governance/module-grades/{name}`
+6. Performance: initial render <2s via `Inertia::defer` (Service faz I/O filesystem 1-2s × 34 módulos)
+
+## Non-Goals
+
+- ❌ Editar pesos da rubrica nesta tela (rubrica é ADR canônica — muda via ADR 0154 v2 append-only)
+- ❌ Disparar Brain B aqui (custo $$$ + risco — limite MVP é gerar tasks via /show)
+- ❌ Histórico 90d nesta tela (Fase B opcional v2)
+
+## UX targets
+
+- 5 chips de bucket com count + cor canônica (emerald/sky/amber/orange/red)
+- Tabela com 5 colunas de dimensão (D1-D5) score/max
+- Click row destacado em hover sky-50
+- Skeleton enquanto defer carrega
+- Empty state quando filtro não bate
+
+## Anti-hooks
+
+- ❌ NÃO eager-load grades ou kpis (Service é caro)
+- ❌ NÃO permitir edição inline de notas (read-only)
+- ❌ NÃO armazenar localStorage filter (refresh = volta padrão)
+- ❌ NÃO mostrar evidence detalhada aqui (só no /show)

--- a/resources/js/Pages/governance/ModuleGrades/Index.tsx
+++ b/resources/js/Pages/governance/ModuleGrades/Index.tsx
@@ -1,0 +1,256 @@
+// @governance
+//   tela: /governance/module-grades
+//   adrs: 0153 module-grade-v1 rubrica oficial
+//   runbook: memory/requisitos/Governance/RUNBOOK-module-grades.md
+
+import React, { useState, useMemo } from 'react'
+import { Head, Link, Deferred } from '@inertiajs/react'
+import AppShellV2 from '@/Layouts/AppShellV2'
+import { Card, CardContent } from '@/Components/ui/card'
+import { Badge } from '@/Components/ui/badge'
+import { Button } from '@/Components/ui/button'
+import PageHeader from '@/Components/shared/PageHeader'
+import KpiGrid from '@/Components/shared/KpiGrid'
+import KpiCard from '@/Components/shared/KpiCard'
+
+interface GradeRow {
+  module: string
+  score: number
+  bucket: 'Excelente' | 'Bom' | 'Médio' | 'Crítico' | 'Embrião'
+  color: string
+  dimensions: {
+    multi_tenant: string
+    pest_coverage: string
+    documentation: string
+    architecture: string
+    client_real: string
+  }
+}
+
+interface Kpis {
+  average: number
+  total: number
+  by_bucket: Record<string, number>
+}
+
+interface Props {
+  grades?: GradeRow[]
+  kpis?: Kpis
+}
+
+const BUCKETS = ['Excelente', 'Bom', 'Médio', 'Crítico', 'Embrião'] as const
+type Bucket = (typeof BUCKETS)[number]
+
+const BUCKET_STYLES: Record<Bucket, string> = {
+  Excelente: 'bg-emerald-100 text-emerald-800 border-emerald-300',
+  Bom: 'bg-sky-100 text-sky-800 border-sky-300',
+  Médio: 'bg-amber-100 text-amber-800 border-amber-300',
+  Crítico: 'bg-orange-100 text-orange-800 border-orange-300',
+  Embrião: 'bg-red-100 text-red-800 border-red-300',
+}
+
+function bucketBadgeClass(bucket: string): string {
+  return BUCKET_STYLES[bucket as Bucket] ?? 'bg-zinc-100 text-zinc-700 border-zinc-300'
+}
+
+function scoreColorClass(score: number): string {
+  if (score >= 80) return 'text-emerald-700'
+  if (score >= 60) return 'text-sky-700'
+  if (score >= 40) return 'text-amber-700'
+  if (score >= 20) return 'text-orange-700'
+  return 'text-red-700'
+}
+
+function ModuleGradesIndex({ grades, kpis }: Props): React.ReactElement {
+  const [filterBucket, setFilterBucket] = useState<Bucket | 'Todos'>('Todos')
+  const [search, setSearch] = useState('')
+
+  const filteredGrades = useMemo(() => {
+    if (!grades) return []
+    return grades.filter((g) => {
+      const matchBucket = filterBucket === 'Todos' || g.bucket === filterBucket
+      const matchSearch = !search || g.module.toLowerCase().includes(search.toLowerCase())
+      return matchBucket && matchSearch
+    })
+  }, [grades, filterBucket, search])
+
+  return (
+    <>
+      <Head title="Module Grades — Governance" />
+      <PageHeader
+        title="Module Grades"
+        subtitle="Rubrica oficial module-grade-v1 (ADR 0153) — nota 0-100 ponderada por 5 dimensões"
+        breadcrumbs={[
+          { label: 'Governança', href: '/governance' },
+          { label: 'Module Grades' },
+        ]}
+      />
+
+      {/* KPIs agregados */}
+      <Deferred data="kpis" fallback={<KpiSkeletonBar />}>
+        {kpis ? <KpiBar kpis={kpis} /> : null}
+      </Deferred>
+
+      {/* Filtros */}
+      <Card className="mb-4">
+        <CardContent className="py-3 flex flex-wrap gap-2 items-center">
+          <div className="flex flex-wrap gap-2">
+            <FilterChip label="Todos" active={filterBucket === 'Todos'} onClick={() => setFilterBucket('Todos')} count={grades?.length} />
+            {BUCKETS.map((b) => (
+              <FilterChip
+                key={b}
+                label={b}
+                active={filterBucket === b}
+                onClick={() => setFilterBucket(b)}
+                count={kpis?.by_bucket?.[b] ?? 0}
+                badgeClass={bucketBadgeClass(b)}
+              />
+            ))}
+          </div>
+          <input
+            type="search"
+            placeholder="Buscar módulo…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="ml-auto px-3 py-1.5 rounded-md border border-zinc-300 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500"
+          />
+        </CardContent>
+      </Card>
+
+      {/* Tabela */}
+      <Card>
+        <CardContent className="p-0">
+          <Deferred data="grades" fallback={<TableSkeleton />}>
+            <table className="w-full text-sm">
+              <thead className="bg-zinc-50 border-b border-zinc-200">
+                <tr className="text-left">
+                  <th className="px-4 py-3 font-semibold">Módulo</th>
+                  <th className="px-4 py-3 font-semibold text-right">Nota</th>
+                  <th className="px-4 py-3 font-semibold">Bucket</th>
+                  <th className="px-4 py-3 font-semibold text-center">D1 MT</th>
+                  <th className="px-4 py-3 font-semibold text-center">D2 Pest</th>
+                  <th className="px-4 py-3 font-semibold text-center">D3 Doc</th>
+                  <th className="px-4 py-3 font-semibold text-center">D4 Arq</th>
+                  <th className="px-4 py-3 font-semibold text-center">D5 Cli</th>
+                  <th className="px-4 py-3 font-semibold text-right">Ações</th>
+                </tr>
+              </thead>
+              <tbody>
+                {filteredGrades.length === 0 ? (
+                  <tr>
+                    <td colSpan={9} className="px-4 py-8 text-center text-zinc-500">
+                      Nenhum módulo combina com o filtro.
+                    </td>
+                  </tr>
+                ) : (
+                  filteredGrades.map((g) => (
+                    <tr key={g.module} className="border-b border-zinc-100 hover:bg-sky-50 cursor-pointer">
+                      <td className="px-4 py-2">
+                        <Link href={`/governance/module-grades/${g.module}`} className="font-medium text-zinc-900 hover:text-sky-700">
+                          {g.module}
+                        </Link>
+                      </td>
+                      <td className={`px-4 py-2 text-right font-bold ${scoreColorClass(g.score)}`}>{g.score}</td>
+                      <td className="px-4 py-2">
+                        <Badge className={bucketBadgeClass(g.bucket)}>{g.bucket}</Badge>
+                      </td>
+                      <td className="px-4 py-2 text-center font-mono text-xs">{g.dimensions.multi_tenant}</td>
+                      <td className="px-4 py-2 text-center font-mono text-xs">{g.dimensions.pest_coverage}</td>
+                      <td className="px-4 py-2 text-center font-mono text-xs">{g.dimensions.documentation}</td>
+                      <td className="px-4 py-2 text-center font-mono text-xs">{g.dimensions.architecture}</td>
+                      <td className="px-4 py-2 text-center font-mono text-xs">{g.dimensions.client_real}</td>
+                      <td className="px-4 py-2 text-right">
+                        <Link href={`/governance/module-grades/${g.module}`}>
+                          <Button variant="ghost" size="sm">
+                            Ver →
+                          </Button>
+                        </Link>
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </Deferred>
+        </CardContent>
+      </Card>
+
+      <p className="text-xs text-zinc-500 mt-4">
+        Rubrica oficial: <code>module-grade-v1</code> · <Link href="/copiloto/admin/memoria?slug=0153-module-grade-rubrica-v1" className="underline">ADR 0153</Link> · pesos 30/20/15/20/15
+      </p>
+    </>
+  )
+}
+
+function FilterChip({
+  label,
+  active,
+  onClick,
+  count,
+  badgeClass,
+}: {
+  label: string
+  active: boolean
+  onClick: () => void
+  count?: number
+  badgeClass?: string
+}): React.ReactElement {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`px-3 py-1 rounded-full text-xs font-medium border transition ${
+        active ? 'bg-zinc-900 text-white border-zinc-900' : 'bg-white text-zinc-700 border-zinc-300 hover:border-zinc-500'
+      }`}
+    >
+      {label}
+      {count !== undefined && (
+        <span className={`ml-1.5 inline-block px-1.5 py-0.5 rounded text-[10px] ${active ? 'bg-white/20' : badgeClass ?? 'bg-zinc-100'}`}>
+          {count}
+        </span>
+      )}
+    </button>
+  )
+}
+
+function KpiBar({ kpis }: { kpis: Kpis }): React.ReactElement {
+  return (
+    <KpiGrid className="mb-4">
+      <KpiCard label="Média projeto" value={kpis.average.toFixed(1)} suffix="pts" tone={kpis.average >= 60 ? 'success' : kpis.average >= 40 ? 'warning' : 'danger'} />
+      <KpiCard label="Total módulos" value={String(kpis.total)} />
+      {BUCKETS.map((b) => (
+        <KpiCard
+          key={b}
+          label={b}
+          value={String(kpis.by_bucket?.[b] ?? 0)}
+          suffix="módulos"
+          tone={b === 'Excelente' || b === 'Bom' ? 'success' : b === 'Médio' ? 'warning' : 'danger'}
+        />
+      ))}
+    </KpiGrid>
+  )
+}
+
+function KpiSkeletonBar(): React.ReactElement {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-7 gap-3 mb-4">
+      {Array.from({ length: 7 }).map((_, i) => (
+        <div key={i} className="h-20 rounded-lg bg-zinc-100 animate-pulse" />
+      ))}
+    </div>
+  )
+}
+
+function TableSkeleton(): React.ReactElement {
+  return (
+    <div className="p-4 space-y-2">
+      {Array.from({ length: 8 }).map((_, i) => (
+        <div key={i} className="h-8 rounded bg-zinc-100 animate-pulse" />
+      ))}
+    </div>
+  )
+}
+
+ModuleGradesIndex.layout = (page: React.ReactNode): React.ReactElement => <AppShellV2>{page}</AppShellV2>
+
+export default ModuleGradesIndex

--- a/resources/js/Pages/governance/ModuleGrades/Show.charter.md
+++ b/resources/js/Pages/governance/ModuleGrades/Show.charter.md
@@ -1,0 +1,43 @@
+---
+page: governance/ModuleGrades/Show
+route: /governance/module-grades/{name}
+status: live
+owner: [W]
+adrs: [0153]
+runbook: memory/requisitos/Governance/RUNBOOK-module-grades.md
+---
+
+# Charter — `/governance/module-grades/{name}` (Show)
+
+## Mission
+
+Drill-down de **um módulo específico** — mostrar nota grande, breakdown das 5 dimensões com evidências, top 10 gaps ordenados por perda de pontos, e botão **"Evoluir"** que abre modal com batch de tasks-create sugeridas + copy-as-markdown.
+
+## Goals
+
+1. Header com nota grande (5xl) + bucket badge colorido
+2. Grid 3 colunas (responsivo) com 5 cards de dimensão (D1-D5) — cada card lista breakdown sub-items com score/max + evidência
+3. Lista "Top gaps" ordenada por `lost` desc — mostra perda + prioridade (P0/P1/P2/P3) + key + desc + evidence
+4. Botão **"Evoluir"** primário (verde, alto contraste) — abre Dialog com tasks suggested + markdown copiável
+5. Markdown gerado é colável direto no Claude Code pra criar tasks via `tasks-create` MCP
+
+## Non-Goals
+
+- ❌ NÃO criar tasks direto via API (Fase B — MVP é copy/paste)
+- ❌ NÃO spawn agents Brain B aqui (custo + risco)
+- ❌ NÃO editar nota inline (read-only — rubrica é o ground-truth)
+
+## UX targets
+
+- Nota visualmente proeminente (5xl) com cor por bucket
+- Cards dimensão com evidência por sub-item (transparência total — Wagner vê o porquê)
+- Gaps com perda em vermelho destacado
+- Modal Evoluir scrollável + accordion pro markdown raw
+- Botão "Copiar Markdown" com feedback visual "✓ Copiado!"
+
+## Anti-hooks
+
+- ❌ NÃO recarregar grade na rota se já tem cache (5min TTL via Cache::remember)
+- ❌ NÃO usar `<a href>` puro pra voltar (usar `<Link>` Inertia)
+- ❌ NÃO mostrar markdown raw fora do `<details>` (poluído visualmente)
+- ❌ NÃO disparar AJAX automático ao abrir modal — gerado client-side via useMemo

--- a/resources/js/Pages/governance/ModuleGrades/Show.tsx
+++ b/resources/js/Pages/governance/ModuleGrades/Show.tsx
@@ -1,0 +1,307 @@
+// @governance
+//   tela: /governance/module-grades/{module}
+//   adrs: 0153 module-grade-v1 rubrica oficial
+//   runbook: memory/requisitos/Governance/RUNBOOK-module-grades.md
+
+import React, { useState, useMemo } from 'react'
+import { Head, Link } from '@inertiajs/react'
+import AppShellV2 from '@/Layouts/AppShellV2'
+import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card'
+import { Badge } from '@/Components/ui/badge'
+import { Button } from '@/Components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/Components/ui/dialog'
+import PageHeader from '@/Components/shared/PageHeader'
+
+interface BreakdownItem {
+  key?: string
+  desc: string
+  score: number
+  max: number
+  evidence: string
+}
+
+interface Dimension {
+  weight: number
+  score: number
+  max: number
+  breakdown: BreakdownItem[]
+}
+
+interface Gap {
+  dimension: string
+  key: string
+  desc: string
+  evidence: string
+  lost: number
+  max: number
+  priority: 'P0' | 'P1' | 'P2' | 'P3'
+}
+
+interface EvolveTask {
+  title: string
+  module: string
+  priority: string
+  estimate: string
+  gap_ref: string
+  rationale: string
+}
+
+interface Grade {
+  module: string
+  score: number
+  bucket: string
+  color: string
+  dimensions: {
+    multi_tenant: Dimension
+    pest_coverage: Dimension
+    documentation: Dimension
+    architecture: Dimension
+    client_real: Dimension
+  }
+  gaps: Gap[]
+  evolve_tasks: EvolveTask[]
+  evaluated_at: string
+}
+
+interface Props {
+  grade: Grade
+}
+
+const DIM_LABELS: Record<keyof Grade['dimensions'], string> = {
+  multi_tenant: 'D1 — Multi-tenant Tier 0',
+  pest_coverage: 'D2 — Pest cobertura',
+  documentation: 'D3 — Documentação canônica',
+  architecture: 'D4 — Maturidade arquitetura',
+  client_real: 'D5 — Cliente real',
+}
+
+const BUCKET_STYLES: Record<string, string> = {
+  Excelente: 'bg-emerald-100 text-emerald-800 border-emerald-300',
+  Bom: 'bg-sky-100 text-sky-800 border-sky-300',
+  Médio: 'bg-amber-100 text-amber-800 border-amber-300',
+  Crítico: 'bg-orange-100 text-orange-800 border-orange-300',
+  Embrião: 'bg-red-100 text-red-800 border-red-300',
+}
+
+const PRIORITY_STYLES: Record<string, string> = {
+  P0: 'bg-red-100 text-red-800 border-red-300',
+  P1: 'bg-orange-100 text-orange-800 border-orange-300',
+  P2: 'bg-amber-100 text-amber-800 border-amber-300',
+  P3: 'bg-zinc-100 text-zinc-700 border-zinc-300',
+}
+
+function scoreColorClass(score: number): string {
+  if (score >= 80) return 'text-emerald-700'
+  if (score >= 60) return 'text-sky-700'
+  if (score >= 40) return 'text-amber-700'
+  if (score >= 20) return 'text-orange-700'
+  return 'text-red-700'
+}
+
+function dimColorClass(score: number, max: number): string {
+  const ratio = max === 0 ? 0 : score / max
+  if (ratio >= 0.8) return 'text-emerald-600'
+  if (ratio >= 0.5) return 'text-sky-600'
+  if (ratio >= 0.3) return 'text-amber-600'
+  return 'text-red-600'
+}
+
+function ModuleGradesShow({ grade }: Props): React.ReactElement {
+  const [evolveOpen, setEvolveOpen] = useState(false)
+  const [copied, setCopied] = useState(false)
+
+  const evolveMarkdown = useMemo(() => generateEvolveMarkdown(grade), [grade])
+
+  function handleCopyMarkdown(): void {
+    if (typeof navigator === 'undefined' || !navigator.clipboard) return
+    navigator.clipboard.writeText(evolveMarkdown).then(() => {
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2500)
+    })
+  }
+
+  return (
+    <>
+      <Head title={`${grade.module} — Module Grade`} />
+      <PageHeader
+        title={`Modules/${grade.module}`}
+        subtitle={`Avaliação rubrica module-grade-v1 · ${new Date(grade.evaluated_at).toLocaleString('pt-BR')}`}
+        breadcrumbs={[
+          { label: 'Governança', href: '/governance' },
+          { label: 'Module Grades', href: '/governance/module-grades' },
+          { label: grade.module },
+        ]}
+        actions={
+          <Button
+            onClick={() => setEvolveOpen(true)}
+            disabled={grade.evolve_tasks.length === 0}
+            size="lg"
+            className="bg-emerald-600 hover:bg-emerald-700 text-white"
+          >
+            Evoluir ({grade.evolve_tasks.length} tasks sugeridas)
+          </Button>
+        }
+      />
+
+      {/* Header de nota */}
+      <Card className="mb-4">
+        <CardContent className="py-6 flex items-center justify-between flex-wrap gap-4">
+          <div className="flex items-center gap-4">
+            <div className={`text-5xl font-bold ${scoreColorClass(grade.score)}`}>{grade.score}<span className="text-2xl text-zinc-400">/100</span></div>
+            <Badge className={`${BUCKET_STYLES[grade.bucket] ?? ''} text-base px-3 py-1`}>{grade.bucket}</Badge>
+          </div>
+          <Link href="/governance/module-grades" className="text-sm text-sky-700 hover:underline">
+            ← Voltar à lista
+          </Link>
+        </CardContent>
+      </Card>
+
+      {/* 5 cards dimensões */}
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-4">
+        {(Object.keys(DIM_LABELS) as (keyof Grade['dimensions'])[]).map((key) => {
+          const dim = grade.dimensions[key]
+          return (
+            <Card key={key}>
+              <CardHeader className="pb-2">
+                <CardTitle className="text-sm flex items-center justify-between">
+                  <span>{DIM_LABELS[key]}</span>
+                  <span className={`text-base font-bold ${dimColorClass(dim.score, dim.max)}`}>
+                    {dim.score}/{dim.max}
+                  </span>
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="pt-0">
+                <ul className="space-y-2 text-xs">
+                  {dim.breakdown.map((item, i) => (
+                    <li key={i} className="border-l-2 border-zinc-200 pl-2">
+                      <div className="flex items-baseline gap-2">
+                        <span className={`font-mono ${dimColorClass(item.score, item.max)}`}>
+                          [{item.score}/{item.max}]
+                        </span>
+                        <span className="font-medium text-zinc-700">{item.key}</span>
+                      </div>
+                      <p className="text-zinc-600 mt-0.5">{item.desc}</p>
+                      <p className="text-zinc-400 italic">{item.evidence}</p>
+                    </li>
+                  ))}
+                </ul>
+              </CardContent>
+            </Card>
+          )
+        })}
+      </div>
+
+      {/* Top gaps */}
+      {grade.gaps.length > 0 && (
+        <Card className="mb-4">
+          <CardHeader>
+            <CardTitle className="text-base">Top gaps ordenados (perda absoluta de pontos)</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2">
+              {grade.gaps.slice(0, 10).map((g, i) => (
+                <li key={i} className="flex items-start gap-3 text-sm">
+                  <span className="font-bold text-red-600 w-12 text-right">-{g.lost}</span>
+                  <Badge className={PRIORITY_STYLES[g.priority] ?? ''}>{g.priority}</Badge>
+                  <code className="text-xs text-zinc-500">{g.key}</code>
+                  <span className="text-zinc-700">{g.desc}</span>
+                  <span className="text-xs text-zinc-400 ml-auto">{g.evidence}</span>
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Modal Evoluir */}
+      <Dialog open={evolveOpen} onOpenChange={setEvolveOpen}>
+        <DialogContent className="max-w-3xl max-h-[80vh] overflow-y-auto">
+          <DialogHeader>
+            <DialogTitle>Evoluir Modules/{grade.module}</DialogTitle>
+            <DialogDescription>
+              Batch de {grade.evolve_tasks.length} tasks sugeridas pra fechar os top gaps. Copie o markdown e cole no Claude Code pra criar via{' '}
+              <code className="text-xs">tasks-create</code> MCP.
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="space-y-3">
+            {grade.evolve_tasks.map((task, i) => (
+              <Card key={i}>
+                <CardContent className="py-3 space-y-1">
+                  <div className="flex items-center gap-2">
+                    <span className="text-xs text-zinc-500 font-mono">#{i + 1}</span>
+                    <Badge className={PRIORITY_STYLES[task.priority] ?? ''}>{task.priority}</Badge>
+                    <span className="text-xs text-zinc-500">estimativa {task.estimate}</span>
+                    <code className="text-xs text-zinc-400 ml-auto">{task.gap_ref}</code>
+                  </div>
+                  <h4 className="font-semibold text-sm">{task.title}</h4>
+                  <p className="text-xs text-zinc-600 italic">{task.rationale}</p>
+                </CardContent>
+              </Card>
+            ))}
+          </div>
+
+          <details className="mt-2">
+            <summary className="text-xs text-zinc-500 cursor-pointer hover:text-zinc-700">Ver markdown gerado</summary>
+            <pre className="mt-2 p-3 bg-zinc-50 border border-zinc-200 rounded text-xs overflow-x-auto whitespace-pre-wrap">
+              {evolveMarkdown}
+            </pre>
+          </details>
+
+          <DialogFooter className="gap-2">
+            <Button variant="outline" onClick={() => setEvolveOpen(false)}>
+              Fechar
+            </Button>
+            <Button onClick={handleCopyMarkdown} className="bg-emerald-600 hover:bg-emerald-700 text-white">
+              {copied ? '✓ Copiado!' : 'Copiar Markdown'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <p className="text-xs text-zinc-500 mt-4">
+        Rubrica oficial: <code>module-grade-v1</code> ·{' '}
+        <Link href="/copiloto/admin/memoria?slug=0153-module-grade-rubrica-v1" className="underline">
+          ADR 0153
+        </Link>{' '}
+        · CLI equivalente: <code className="text-xs">php artisan module:grade {grade.module} --detail --evolve</code>
+      </p>
+    </>
+  )
+}
+
+function generateEvolveMarkdown(grade: Grade): string {
+  const lines: string[] = []
+  lines.push(`# Evoluir Modules/${grade.module}`)
+  lines.push('')
+  lines.push(`Nota atual: **${grade.score}/100** · Bucket: **${grade.bucket}**`)
+  lines.push(`Avaliado: ${grade.evaluated_at}`)
+  lines.push('')
+  lines.push(`## Tasks sugeridas (${grade.evolve_tasks.length})`)
+  lines.push('')
+  grade.evolve_tasks.forEach((task, i) => {
+    lines.push(`### ${i + 1}. [${task.priority}] ${task.title}`)
+    lines.push('')
+    lines.push(`- **Módulo:** ${task.module}`)
+    lines.push(`- **Estimativa:** ${task.estimate}`)
+    lines.push(`- **Gap ref:** ${task.gap_ref}`)
+    lines.push(`- **Racional:** ${task.rationale}`)
+    lines.push('')
+  })
+  lines.push('---')
+  lines.push('')
+  lines.push(`Cole esse bloco no Claude Code e peça pra criar as tasks via \`tasks-create\` MCP.`)
+  lines.push(`Refs: ADR 0153 module-grade-v1, RUNBOOK-module-grades.md`)
+  return lines.join('\n')
+}
+
+ModuleGradesShow.layout = (page: React.ReactNode): React.ReactElement => <AppShellV2>{page}</AppShellV2>
+
+export default ModuleGradesShow


### PR DESCRIPTION
## Summary

Implementa **ADR 0153 module-grade-v1** — rubrica canônica pra avaliar maturidade de qualquer `Modules/<X>/` em 5 dimensões ponderadas, com tela Inertia drill-down + botão "Evoluir" que gera batch de tasks-create sugeridas.

Tela viva: **`/governance/module-grades`** → tabela ranqueada 34 módulos → click drill-down → 5 cards dimensão + top gaps → botão Evoluir = modal com batch tasks copiáveis pra colar no Claude Code.

CLI equivalente: **`php artisan module:grade [name|--all] [--detail] [--evolve] [--json]`**.

Skill auto-trigger: **`avaliar-modulo`** (Tier B) — responde a "nota do X" / "/avaliar-modulo Y" / "ranking dos módulos".

## Resultado empírico (validado nos 34 módulos)

```
Média projeto: 38.2 pts
Distribuição: Bom=8 · Médio=5 · Crítico=15 · Embrião=6

Top 5: Repair 73, Arquivos 71, NfeBrasil 71, Vestuario 71, Whatsapp 69
Embrião: AssetManagement 8, Spreadsheet 8, Woocommerce 8
```

## Rubrica (peso = 100)

| Dim | Peso | Mede |
|---|---|---|
| **D1 Multi-tenant Tier 0** | 30 | BusinessScope global + cross-tenant Pest biz=1 vs biz=99 + Jobs \$businessId construtor |
| **D2 Pest cobertura** | 20 | Razão tests/Controllers + MultiTenant/Smoke/Scaffold canônicos + phpunit.xml registro |
| **D3 Documentação canônica** | 15 | SPEC + BRIEFING ≤90d + Charter ≥30% telas + ADR mãe frontmatter module: |
| **D4 Maturidade arquitetura** | 20 | Services/Controllers ratio + FSM (ADR 0143) + tsx vs Blade + AuditLog/OTel |
| **D5 Cliente real** | 15 | biz=4 prod (15) / biz=1 Wagner (10) / piloto qualificado (8) / hipotese (3) / ninguém (0) |

## Buckets

| Faixa | Bucket | Tradução |
|---|---|---|
| 80-100 | **Excelente** | World-class. CONSOLIDAR |
| 60-79 | **Bom** | Funciona em prod com gaps menores. EVOLUIR seletivo |
| 40-59 | **Médio** | Gap óbvio em ≥1 dimensão |
| 20-39 | **Crítico** | Gap em ≥2 dimensões |
| 0-19 | **Embrião** | Scaffold sem cliente. Decidir investir ou descontinuar |

## Botão "Evoluir" (MVP A)

NÃO é mágica IA. Gera **batch markdown copiável** com top 5 tasks sugeridas priorizadas (P0/P1/P2/P3) pra fechar gaps. Wagner cola no Claude Code → cria via \`tasks-create\` MCP (publication-policy escala — não cria automático). Roadmap v2: integração direta MCP / Brain B.

## Test plan

- [x] Service: 13/13 Pest passing (144 assertions) — estrutura canônica + 5 dimensões + bucket boundaries + ordenação gaps + YAML clientes + calibração Whatsapp/AssetManagement
- [x] Command: 7/7 Pest passing — --all + --evolve + --json + signature sem --verbose (lição #851)
- [x] Controller: 6/6 Pest passing (170 assertions total) — rotas nomeadas + middleware auth + Inertia::defer
- [x] Validado empiricamente em todos 34 módulos do projeto (output coerente)
- [ ] Wagner revisar UI navegando \`/governance/module-grades\` no browser
- [ ] CI MySQL valida (depende de Wave B #946 registrar phpunit.xml — já consta)

## Arquivos criados

**Backend:**
- \`memory/decisions/0153-module-grade-rubrica-v1.md\` — ADR oficial
- \`Modules/Governance/Services/ModuleGradeService.php\` — coleta automática 5 dimensões
- \`Modules/Governance/Console/Commands/ModuleGradeCommand.php\` — \`php artisan module:grade\`
- \`Modules/Governance/Http/Controllers/ModuleGradeController.php\` — Inertia routes
- \`config/governance/module_clients.yaml\` — D5 manual (Wagner edita)

**Frontend:**
- \`resources/js/Pages/governance/ModuleGrades/Index.tsx\` + charter
- \`resources/js/Pages/governance/ModuleGrades/Show.tsx\` + charter (com modal Evoluir)
- \`Modules/Governance/Resources/menus/topnav.php\` — link "Module Grades" sob grupo Governance

**Skill + Docs + Tests:**
- \`.claude/skills/avaliar-modulo/SKILL.md\` — Tier B auto-trigger
- \`memory/requisitos/Governance/RUNBOOK-module-grades.md\` — runbook tela
- \`Modules/Governance/Tests/Feature/ModuleGrade{Service,Command,Controller}Test.php\` — 26 cenários

## Refs

- ADR 0153 module-grade-v1 (este PR)
- ADR 0093 Multi-tenant Tier 0 (base D1)
- ADR 0101 biz=1 nunca cliente (base D1.b)
- ADR 0105 cliente como sinal (base D5)
- ADR 0094 Constituição v2 (Governance enforcer)
- PRs #945 + #946 — Waves A/B Pest 34/34 que viabilizam D1.b + D2 medíveis

🤖 Generated with [Claude Code](https://claude.com/claude-code)