### PR TITLE
test(pest): cobertura Wave B — 8 módulos P2/P3 (recriado base=main pós Wave A merge)

### DIFF
--- a/Modules/AssetManagement/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/AssetManagement/Tests/Feature/MultiTenantIsolationTest.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\AssetManagement\Entities\Asset;
+use Modules\AssetManagement\Entities\AssetMaintenance;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Testa isolamento multi-tenant Tier 0 dos Models AssetManagement.
+ *
+ * ATENÇÃO: Modules/AssetManagement é módulo LEGACY UltimatePOS — NÃO usa BusinessScope global.
+ * Isolamento é feito MANUALMENTE nos Controllers via `where('business_id', $business_id)`.
+ * Este test valida que dados de biz=1 não vazam para biz=99 quando filtros são aplicados.
+ *
+ * ADR 0093: multi-tenant isolation Tier 0 IRREVOGÁVEL.
+ * ADR 0101: NUNCA usar biz=4 (ROTA LIVRE — cliente Larissa) em tests; usar biz=1 (Wagner WR2) + biz=99 fictício.
+ *
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ */
+
+// Guard SQLite: Models AssetManagement legacy dependem do schema MySQL UltimatePOS completo
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: Models AssetManagement legacy requerem schema MySQL UltimatePOS — ADR 0101');
+    }
+    if (! Schema::hasTable('assets')) {
+        $this->markTestSkipped('assets table missing — rode Modules/AssetManagement migrate primeiro');
+    }
+    if (! Schema::hasTable('asset_maintenances')) {
+        $this->markTestSkipped('asset_maintenances table missing — rode Modules/AssetManagement migrate primeiro');
+    }
+});
+
+// IDs canônicos — biz=1 (Wagner WR2) e biz=99 (fictício)
+const BIZ_WAGNER = 1;
+const BIZ_FICTICIO = 99;
+
+// ------------------------------------------------------------------
+// Asset — isolamento via filtro manual where('business_id', ...)
+// ------------------------------------------------------------------
+
+it('Asset biz=1 não aparece em query filtrada por biz=99', function () {
+    // Criar asset em biz=1
+    $asset = Asset::create([
+        'business_id'    => BIZ_WAGNER,
+        'name'           => 'Notebook Teste Isolamento WR2',
+        'asset_code'     => 'AST-TST-9991',
+        'quantity'       => 1,
+        'unit_price'     => 3500.00,
+        'is_allocatable' => 1,
+        'purchase_type'  => 'owned',
+    ]);
+
+    // Query filtrando por biz=99 — NÃO deve trazer o asset criado em biz=1
+    $resultado = Asset::where('business_id', BIZ_FICTICIO)
+        ->where('id', $asset->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(0);
+})->afterEach(function () {
+    Asset::where('business_id', BIZ_WAGNER)
+        ->where('asset_code', 'AST-TST-9991')
+        ->forceDelete();
+});
+
+it('Asset biz=1 aparece em query filtrada por biz=1', function () {
+    $asset = Asset::create([
+        'business_id'    => BIZ_WAGNER,
+        'name'           => 'Impressora Teste WR2',
+        'asset_code'     => 'AST-TST-9992',
+        'quantity'       => 2,
+        'unit_price'     => 1200.00,
+        'is_allocatable' => 1,
+        'purchase_type'  => 'owned',
+    ]);
+
+    $resultado = Asset::where('business_id', BIZ_WAGNER)
+        ->where('id', $asset->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(1);
+    expect($resultado->first()->name)->toBe('Impressora Teste WR2');
+    expect((int) $resultado->first()->business_id)->toBe(BIZ_WAGNER);
+})->afterEach(function () {
+    Asset::where('business_id', BIZ_WAGNER)
+        ->where('asset_code', 'AST-TST-9992')
+        ->forceDelete();
+});
+
+// ------------------------------------------------------------------
+// AssetMaintenance — isolamento via asset.business_id (relacionamento)
+// ------------------------------------------------------------------
+
+it('AssetMaintenance biz=1 não aparece em join filtrado por biz=99', function () {
+    // Criar asset pai em biz=1
+    $asset = Asset::create([
+        'business_id'    => BIZ_WAGNER,
+        'name'           => 'Servidor Teste Manutencao',
+        'asset_code'     => 'AST-TST-9993',
+        'quantity'       => 1,
+        'unit_price'     => 8000.00,
+        'is_allocatable' => 0,
+        'purchase_type'  => 'owned',
+    ]);
+
+    // Criar manutenção vinculada
+    $maintenance = AssetMaintenance::create([
+        'asset_id'         => $asset->id,
+        'business_id'      => BIZ_WAGNER,
+        'maintenance_date' => now()->toDateString(),
+        'completion_date'  => now()->addDay()->toDateString(),
+        'description'      => 'Manutenção teste isolamento',
+        'cost'             => 200.00,
+        'status'           => 'completed',
+    ]);
+
+    // Query JOIN filtrando por biz=99 NÃO deve retornar manutenção do biz=1
+    $resultado = AssetMaintenance::join('assets', 'asset_maintenances.asset_id', '=', 'assets.id')
+        ->where('assets.business_id', BIZ_FICTICIO)
+        ->where('asset_maintenances.id', $maintenance->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(0);
+})->afterEach(function () {
+    $asset = Asset::where('asset_code', 'AST-TST-9993')->first();
+    if ($asset) {
+        AssetMaintenance::where('asset_id', $asset->id)->forceDelete();
+        $asset->forceDelete();
+    }
+});
+
+it('AssetMaintenance biz=1 aparece em join filtrado por biz=1', function () {
+    $asset = Asset::create([
+        'business_id'    => BIZ_WAGNER,
+        'name'           => 'Servidor Teste Manutencao 2',
+        'asset_code'     => 'AST-TST-9994',
+        'quantity'       => 1,
+        'unit_price'     => 8500.00,
+        'is_allocatable' => 0,
+        'purchase_type'  => 'owned',
+    ]);
+
+    $maintenance = AssetMaintenance::create([
+        'asset_id'         => $asset->id,
+        'business_id'      => BIZ_WAGNER,
+        'maintenance_date' => now()->toDateString(),
+        'description'      => 'Manutenção teste positivo',
+        'cost'             => 350.00,
+        'status'           => 'in_progress',
+    ]);
+
+    $resultado = AssetMaintenance::join('assets', 'asset_maintenances.asset_id', '=', 'assets.id')
+        ->where('assets.business_id', BIZ_WAGNER)
+        ->where('asset_maintenances.id', $maintenance->id)
+        ->select('asset_maintenances.*')
+        ->get();
+
+    expect($resultado)->toHaveCount(1);
+    expect($resultado->first()->description)->toBe('Manutenção teste positivo');
+})->afterEach(function () {
+    $asset = Asset::where('asset_code', 'AST-TST-9994')->first();
+    if ($asset) {
+        AssetMaintenance::where('asset_id', $asset->id)->forceDelete();
+        $asset->forceDelete();
+    }
+});

--- a/Modules/AssetManagement/Tests/Feature/ScaffoldTest.php
+++ b/Modules/AssetManagement/Tests/Feature/ScaffoldTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+use Nwidart\Modules\Facades\Module;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke test do scaffold Modules/AssetManagement.
+ *
+ * Garante que:
+ *   1. Módulo aparece registrado em nWidart (module.json carregado)
+ *   2. ServiceProvider AssetManagementServiceProvider carregou sem erro
+ *   3. Rotas resource principais (assets + allocation + asset-maintenance) registradas
+ *
+ * Refs: module.json (provider AssetManagementServiceProvider), ADR 0011 padrão Jana/Repair/Project
+ */
+
+it('cenario 1: modulo AssetManagement aparece registrado em nWidart', function () {
+    $module = Module::find('AssetManagement');
+    expect($module)->not->toBeNull('Modules/AssetManagement deveria estar registrado em nWidart');
+    expect($module->getName())->toBe('AssetManagement');
+});
+
+it('cenario 2: modulo AssetManagement esta ativo (module.json active=1)', function () {
+    $module = Module::find('AssetManagement');
+    expect($module)->not->toBeNull();
+    expect($module->isEnabled())->toBeTrue('AssetManagement deveria estar habilitado per module.json');
+});
+
+it('cenario 3: rotas resource principais registradas (assets/allocation/asset-maintenance index)', function () {
+    expect(\Route::has('assets.index'))->toBeTrue('assets.index deveria existir');
+    expect(\Route::has('allocation.index'))->toBeTrue('allocation.index deveria existir');
+    expect(\Route::has('asset-maintenance.index'))->toBeTrue('asset-maintenance.index deveria existir');
+});
+
+it('cenario 4: rota resource revocation.index registrada', function () {
+    expect(\Route::has('revocation.index'))->toBeTrue('revocation.index deveria existir per Route::resource em Routes/web.php');
+});

--- a/Modules/AssetManagement/Tests/Feature/SmokeRoutesTest.php
+++ b/Modules/AssetManagement/Tests/Feature/SmokeRoutesTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke test das rotas principais do Modules/AssetManagement.
+ *
+ * Valida que as rotas resource declaradas em Routes/web.php foram registradas
+ * pelo nWidart/laravel-modules e estão acessíveis via Route::has().
+ *
+ * Refs: Routes/web.php (Route::resource assets/allocation/revocation/settings/asset-maintenance)
+ * Padrão: skill `criar-modulo` + Modules/Auditoria/Tests/Feature/AuditoriaModuleTest.php
+ */
+
+it('cenario 1: rota nomeada assets.index existe', function () {
+    expect(\Route::has('assets.index'))->toBeTrue('Rota assets.index deveria existir per Routes/web.php');
+});
+
+it('cenario 2: rota nomeada assets.create existe', function () {
+    expect(\Route::has('assets.create'))->toBeTrue('Rota assets.create deveria existir');
+});
+
+it('cenario 3: rota nomeada allocation.index existe', function () {
+    expect(\Route::has('allocation.index'))->toBeTrue('Rota allocation.index deveria existir');
+});
+
+it('cenario 4: rota nomeada asset-maintenance.index existe', function () {
+    expect(\Route::has('asset-maintenance.index'))->toBeTrue('Rota asset-maintenance.index deveria existir');
+});

--- a/Modules/Brief/Tests/Feature/BriefMultiTenantTest.php
+++ b/Modules/Brief/Tests/Feature/BriefMultiTenantTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Testa isolamento multi-tenant Tier 0 do Brief (ADR 0091 + ADR 0093).
+ *
+ * Brief é estado consolidado por agent/usuário/business. A tabela canônica
+ * `mcp_briefs` vive no schema MCP (CT 100) mas tem coluna business_id pra
+ * suportar briefs por tenant futuramente (atualmente brief é por Wagner agent).
+ *
+ * Validação: registro biz=1 NÃO aparece com session biz=99 (e vice-versa)
+ * via query direta na tabela com WHERE business_id explícito.
+ *
+ * NUNCA biz=4 (ROTA LIVRE — cliente Larissa produção). Tests biz=1 (Wagner WR2)
+ * e biz=99 (fictício) — ADR 0101.
+ *
+ * @see memory/decisions/0091-daily-brief.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ */
+
+const BIZ_WAGNER = 1;
+const BIZ_FICTICIO = 99;
+
+// Guard SQLite: mcp_briefs vive no schema MCP MySQL only.
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped(
+            'SQLite-incompatível: mcp_briefs (schema MCP) requer MySQL — ADR 0091/0101'
+        );
+    }
+    if (! Schema::hasTable('mcp_briefs')) {
+        $this->markTestSkipped(
+            'mcp_briefs table missing — schema MCP não migrado neste ambiente'
+        );
+    }
+});
+
+it('Brief biz=1 nao aparece quando consultado com filtro biz=99', function () {
+    // Cleanup defensivo antes
+    DB::table('mcp_briefs')->where('content', 'like', '%PEST-MULTI-TENANT-TESTE-1%')->delete();
+
+    $hasBizCol = Schema::hasColumn('mcp_briefs', 'business_id');
+    $hasValidCol = Schema::hasColumn('mcp_briefs', 'valid');
+
+    $row = [
+        'content' => 'PEST-MULTI-TENANT-TESTE-1 brief Wagner biz=1 isolamento',
+        'token_count' => 100,
+        'generated_at' => now(),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ];
+    if ($hasBizCol) {
+        $row['business_id'] = BIZ_WAGNER;
+    }
+    if ($hasValidCol) {
+        $row['valid'] = 1;
+    }
+
+    $id = DB::table('mcp_briefs')->insertGetId($row);
+
+    try {
+        if ($hasBizCol) {
+            // Query com filtro biz=99 — NÃO deve retornar o brief biz=1
+            $resultado = DB::table('mcp_briefs')
+                ->where('id', $id)
+                ->where('business_id', BIZ_FICTICIO)
+                ->first();
+
+            expect($resultado)->toBeNull('Brief biz=1 NÃO deveria ser retornado com filtro biz=99 (ADR 0093)');
+
+            // Sanity check: com filtro correto biz=1, retorna
+            $resultadoCerto = DB::table('mcp_briefs')
+                ->where('id', $id)
+                ->where('business_id', BIZ_WAGNER)
+                ->first();
+
+            expect($resultadoCerto)->not->toBeNull('Brief biz=1 deveria ser retornado com filtro biz=1');
+        } else {
+            // Schema MCP atual não tem business_id (brief global por agent Wagner).
+            // Documentamos o gap pro futuro mas o teste passa marcado como skipped.
+            $this->markTestSkipped(
+                'mcp_briefs sem coluna business_id — brief atualmente é global '.
+                'por agent Wagner (ADR 0091). Adicionar business_id quando multi-tenant '.
+                'briefs forem implementados.'
+            );
+        }
+    } finally {
+        DB::table('mcp_briefs')->where('id', $id)->delete();
+    }
+});
+
+it('audit log brief-fetch e escrito com agent_id correto', function () {
+    // Validação tangencial: mcp_audit_log respeita schema esperado pelo controller.
+    if (! Schema::hasTable('mcp_audit_log')) {
+        $this->markTestSkipped('mcp_audit_log table missing — schema MCP não migrado');
+    }
+
+    $requestId = (string) \Str::uuid();
+    DB::table('mcp_audit_log')->insert([
+        'request_id' => $requestId,
+        'tool_or_resource' => 'brief-fetch',
+        'agent_id' => 'pest-test-wagner-biz1',
+        'user_id' => null,
+        'status' => 'ok',
+        'tokens_out' => 100,
+        'cache_read' => 1,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    try {
+        $log = DB::table('mcp_audit_log')->where('request_id', $requestId)->first();
+        expect($log)->not->toBeNull();
+        expect($log->tool_or_resource)->toBe('brief-fetch');
+        expect($log->agent_id)->toBe('pest-test-wagner-biz1');
+    } finally {
+        DB::table('mcp_audit_log')->where('request_id', $requestId)->delete();
+    }
+});

--- a/Modules/Brief/Tests/Feature/ScaffoldTest.php
+++ b/Modules/Brief/Tests/Feature/ScaffoldTest.php
@@ -1,0 +1,64 @@
+<?php
+
+use Nwidart\Modules\Facades\Module;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke test do scaffold Modules/Brief — Daily Brief (ADR 0091).
+ *
+ * Garante que:
+ *   1. Módulo aparece registrado em nWidart
+ *   2. ServiceProvider carrega sem erro
+ *   3. Rotas Install (ADR 0024) foram registradas
+ *   4. Rota API MCP brief-fetch foi registrada
+ *
+ * Refs: ADR 0091 Daily Brief, ADR 0024 receita criar módulo, skill criar-modulo
+ */
+
+it('cenario 1: modulo Brief aparece registrado em nWidart', function () {
+    $module = Module::find('Brief');
+    expect($module)->not->toBeNull('Modules/Brief deveria estar registrado');
+    expect($module->getName())->toBe('Brief');
+});
+
+it('cenario 2: BriefServiceProvider esta carregado', function () {
+    $module = Module::find('Brief');
+    expect($module)->not->toBeNull();
+    // Se o provider falhou no boot a app nem chega aqui — basta o módulo existir e estar enabled.
+    expect($module->isStatus(1))->toBeTrue('Brief deveria estar enabled (status=1)');
+});
+
+it('cenario 3: rota api MCP brief-fetch existe nomeada', function () {
+    expect(\Route::has('mcp.tools.brief-fetch'))
+        ->toBeTrue('Rota mcp.tools.brief-fetch deveria existir per Routes/api.php');
+});
+
+it('cenario 4: rotas Install ADR 0024 estao registradas', function () {
+    // Rotas /brief/install, /brief/install/uninstall, /brief/install/update
+    // existem mas não são nomeadas — checamos via routes collection.
+    $routes = collect(\Route::getRoutes()->getRoutes())
+        ->map(fn ($r) => $r->uri())
+        ->filter(fn ($uri) => str_starts_with($uri, 'brief/install'));
+
+    expect($routes->contains('brief/install'))
+        ->toBeTrue('Rota brief/install (ADR 0024) deveria existir');
+    expect($routes->contains('brief/install/uninstall'))
+        ->toBeTrue('Rota brief/install/uninstall (ADR 0024) deveria existir');
+    expect($routes->contains('brief/install/update'))
+        ->toBeTrue('Rota brief/install/update (ADR 0024) deveria existir');
+});
+
+it('cenario 5: DataController expõe superadmin_package e user_permissions', function () {
+    $controller = new \Modules\Brief\Http\Controllers\DataController;
+
+    $pkg = $controller->superadmin_package();
+    expect($pkg)->toBeArray()->and($pkg)->not->toBeEmpty();
+    expect($pkg[0])->toHaveKey('name')
+        ->and($pkg[0]['name'])->toBe('brief_module');
+
+    $perms = $controller->user_permissions();
+    expect($perms)->toBeArray()->and($perms)->not->toBeEmpty();
+    expect($perms[0])->toHaveKey('value')
+        ->and($perms[0]['value'])->toBe('brief.access');
+});

--- a/Modules/Brief/Tests/Feature/SmokeRoutesTest.php
+++ b/Modules/Brief/Tests/Feature/SmokeRoutesTest.php
@@ -1,0 +1,55 @@
+<?php
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke test rotas Brief — Install (ADR 0024) + endpoint MCP brief-fetch (ADR 0091).
+ *
+ * Não autentica usuário — só valida que rota responde algo coerente
+ * (redirect login ou 401/403/422 ao invés de 500/404).
+ *
+ * NUNCA biz=4 (ROTA LIVRE produção) — ADR 0101. Tests usam biz=1.
+ */
+
+// Guard SQLite: BriefFetchController consulta tabela mcp_briefs (schema MCP MySQL only).
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped(
+            'SQLite-incompatível: BriefFetchController consulta mcp_briefs (schema MCP MySQL). '.
+            'Wagner Pest local segue mandatory — ADR 0101 / ADR 0091'
+        );
+    }
+});
+
+it('rota brief/install nao retorna 500', function () {
+    // Sem autenticar — esperamos redirect login (302), 401/403 ou 200 (se middleware bypass test).
+    // O que NÃO queremos: 500 (erro de boot) nem 404 (rota não registrada).
+    $response = $this->get('/brief/install');
+
+    expect($response->status())->not->toBe(500, 'Rota brief/install não deveria estourar 500');
+    expect($response->status())->not->toBe(404, 'Rota brief/install deveria existir (ADR 0024)');
+});
+
+it('rota POST mcp/tools/brief-fetch existe e exige auth MCP', function () {
+    // Sem header X-MCP-Token, middleware mcp.auth deve rejeitar (401/403/422).
+    // Não esperamos 404 (rota faltando) nem 500 (erro de boot).
+    $response = $this->postJson('/api/mcp/tools/brief-fetch', [
+        'force_refresh' => false,
+    ]);
+
+    expect($response->status())->not->toBe(404, 'Rota MCP brief-fetch deveria existir');
+    expect($response->status())->not->toBe(500, 'Rota MCP brief-fetch não deveria estourar 500 sem auth');
+    // Aceita 401/403/422 (auth rejeitada) ou 429 (throttle agressivo)
+    expect(in_array($response->status(), [401, 403, 422, 429], true))
+        ->toBeTrue('brief-fetch sem auth MCP deveria retornar 401/403/422/429, retornou '.$response->status());
+});
+
+it('controller BriefFetch e injetavel via container', function () {
+    // Garante DI do BriefGeneratorService funciona — falha silenciosa de boot
+    // pega aqui antes de mockar request.
+    $controller = app(\Modules\Brief\Http\Controllers\BriefFetchController::class);
+    expect($controller)->toBeInstanceOf(\Modules\Brief\Http\Controllers\BriefFetchController::class);
+});

--- a/Modules/ConsultaOs/Tests/Feature/PublicTokenSecurityTest.php
+++ b/Modules/ConsultaOs/Tests/Feature/PublicTokenSecurityTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Security tests da rota publica de consulta de OS.
+ *
+ * Estado atual (2026-05-15): ConsultaOsController::buscar() usa mockData()
+ * in-memory — NAO consulta DB ainda. O TODO(query-real) no Controller diz que
+ * a busca real sera por invoice_no + ultimos 4 do telefone (padrao Repair),
+ * com filtro multi-tenant via transactions.business_id.
+ *
+ * Estes testes formam o CONTRATO DE SEGURANCA que a futura implementacao
+ * com DB precisa preservar. Hoje validamos comportamento via mock; quando
+ * Wagner migrar para query real (transactions table), os mesmos asserts
+ * precisarao continuar passando — agora consultando dados de biz=1 vs biz=99.
+ *
+ * Refs:
+ *   - ADR 0093 multi-tenant Tier 0 IRREVOGAVEL
+ *   - ADR 0101 tests biz=1 (Wagner WR2), nunca biz=4 (ROTA LIVRE cliente)
+ *   - Modules/Repair/Routes/web.php /repair-status (padrao a imitar)
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompativel: TestCase UltimatePOS requer schema MySQL (ADR 0101).');
+    }
+});
+
+// ID Wagner WR2 — biz canonico para tests (ADR 0101) e ID ficticio sem dados
+const BIZ_WAGNER = 1;
+const BIZ_FICTICIO = 99;
+
+it('cenario A: numero invalido/inexistente retorna 404 com found=false (sem vazar dados)', function () {
+    // Tentar varios numeros aleatorios — nenhum existe no mock.
+    $tentativas = ['00000', '99999', 'XYZ123', '4820']; // 4820 nao esta no mock
+
+    foreach ($tentativas as $numero) {
+        $response = $this->getJson('/consulta-os/buscar?numero='.urlencode($numero));
+
+        $response->assertStatus(404, "Numero invalido [{$numero}] deveria retornar 404");
+        $response->assertJson(['found' => false]);
+
+        // Garantir que nenhum dado de OS vazou na resposta de erro
+        $body = $response->json();
+        expect($body)->not->toHaveKey('os', "Numero invalido [{$numero}] NAO deve retornar payload 'os'");
+    }
+});
+
+it('cenario B: anonimo sem token/sem numero recebe 422 validation (sem listar nada)', function () {
+    // Rota /consulta-os/buscar exige campo 'numero' (Controller::buscar valida).
+    // Sem ele, retorna 422 — anonimo NUNCA consegue listar todas as OS de algum biz.
+    $response = $this->getJson('/consulta-os/buscar');
+
+    $response->assertStatus(422);
+
+    // Garantir que payload de erro NAO inclui dados de OS de nenhum business
+    $body = $response->json();
+    expect($body)->not->toHaveKey('os');
+    expect($body)->not->toHaveKey('data');
+});
+
+it('cenario C: anonimo NAO consegue brute-force enumeracao (rate-limit throttle:30,1 aplicado)', function () {
+    // Rota /consulta-os/buscar tem middleware 'throttle:30,1' (30 req/min).
+    // Esta e uma garantia ANTI brute-force — anonimo nao pode varrer numeros sequenciais
+    // ilimitadamente para descobrir OS de outros businesses.
+    //
+    // Validamos que middleware throttle esta registrado na rota.
+    $route = \Route::getRoutes()->getByName('consulta-os.buscar');
+    expect($route)->not->toBeNull('Rota consulta-os.buscar deveria existir');
+
+    $middlewares = $route->middleware();
+    $temThrottle = collect($middlewares)->contains(fn ($m) => str_starts_with($m, 'throttle:'));
+    expect($temThrottle)->toBeTrue(
+        'Rota publica consulta-os.buscar DEVE ter middleware throttle: para evitar enumeracao brute-force cross-business (ADR 0093).'
+    );
+});
+
+it('cenario D: cross-business — anonimo nao pode passar business_id como query e sobrescrever scope', function () {
+    // Tentar injetar business_id na query string — Controller atual ignora
+    // (mockData nao olha business_id). Quando migrar para DB real, multi-tenant
+    // Tier 0 IRREVOGAVEL (ADR 0093) GARANTE que cliente anonimo nao pode forcar
+    // escopo de outro business via query param.
+    //
+    // Hoje validamos que mesmo passando o param, a resposta segue o mock —
+    // NAO deve retornar lista ampla nem vazar metadata de outros businesses.
+    $response = $this->getJson('/consulta-os/buscar?numero=4821&business_id='.BIZ_FICTICIO);
+
+    // Numero 4821 existe no mock — Controller atual responde normalmente, ignorando business_id.
+    // O que IMPORTA: resposta NAO inclui campo business_id no payload (sem leak)
+    // e NAO retorna lista (apenas 1 registro pontual).
+    if ($response->getStatusCode() === 200) {
+        $body = $response->json();
+        expect($body)->toHaveKey('os');
+        expect($body['os'])->not->toHaveKey('business_id', 'Payload publico NAO deve vazar business_id (ADR 0093 PII guard).');
+
+        // Resposta deve ser registro unico, nunca array de OS
+        expect($body['os'])->toBeArray();
+        expect(isset($body['os'][0]))->toBeFalse('Resposta publica deve retornar 1 OS, nunca lista — anonimo nao tem permissao de listar.');
+    }
+});

--- a/Modules/ConsultaOs/Tests/Feature/ScaffoldTest.php
+++ b/Modules/ConsultaOs/Tests/Feature/ScaffoldTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Nwidart\Modules\Facades\Module;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke test do scaffold Modules/ConsultaOs (portal publico de consulta de OS).
+ *
+ * Garante que:
+ *   1. Modulo aparece registrado em nWidart
+ *   2. Rotas web /consulta-os foram registradas com nomes esperados
+ *
+ * Refs: ADR 0011 padrao Jana/Repair/Project, ADR 0024 install routes, skill criar-modulo.
+ */
+
+it('cenario 1: modulo ConsultaOs aparece registrado em nWidart', function () {
+    $module = Module::find('ConsultaOs');
+    expect($module)->not->toBeNull('Modules/ConsultaOs deveria estar registrado');
+    expect($module->getName())->toBe('ConsultaOs');
+});
+
+it('cenario 2: rota nomeada consulta-os.index existe', function () {
+    expect(\Route::has('consulta-os.index'))
+        ->toBeTrue('Rota consulta-os.index deveria existir per Routes/web.php');
+});
+
+it('cenario 3: rota nomeada consulta-os.buscar existe', function () {
+    expect(\Route::has('consulta-os.buscar'))
+        ->toBeTrue('Rota consulta-os.buscar deveria existir');
+});

--- a/Modules/ConsultaOs/Tests/Feature/SmokeRoutesTest.php
+++ b/Modules/ConsultaOs/Tests/Feature/SmokeRoutesTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke tests de rotas publicas Modules/ConsultaOs.
+ *
+ * Portal publico (sem auth) — espelha Modules/Repair/Routes/web.php (/repair-status).
+ * Implementacao atual usa mockData() in-memory no Controller — sem dependencia DB
+ * pra rotas publicas, mas pode ser que TestCase boot precise de schema.
+ *
+ * Refs: ADR 0101 (tests com biz=1 quando aplicavel — nao se aplica aqui pois rotas
+ * publicas nao tem sessao de business).
+ */
+
+// Guard SQLite: se boot do TestCase falhar em SQLite (config UltimatePOS), skip.
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompativel: TestCase UltimatePOS requer schema MySQL — Wagner Pest local segue mandatory (ADR 0101).');
+    }
+});
+
+it('rota publica GET /consulta-os retorna 200 (Inertia Index)', function () {
+    $response = $this->get('/consulta-os');
+
+    // Pagina Inertia renderiza com 200 OK. Em testes Inertia retorna JSON
+    // ou HTML dependendo do header — qualquer 200 satisfaz smoke.
+    expect($response->getStatusCode())->toBe(200);
+});
+
+it('rota publica GET /consulta-os/buscar com numero conhecido retorna found=true', function () {
+    // mockData() do Controller tem chave '4821' (Acme Comercio).
+    $response = $this->getJson('/consulta-os/buscar?numero=4821');
+
+    $response->assertStatus(200);
+    $response->assertJson(['found' => true]);
+    expect($response->json('os.client'))->toBe('Acme Comércio Ltda');
+});
+
+it('rota publica GET /consulta-os/buscar com numero inexistente retorna 404', function () {
+    $response = $this->getJson('/consulta-os/buscar?numero=99999');
+
+    $response->assertStatus(404);
+    $response->assertJson(['found' => false]);
+});
+
+it('rota publica GET /consulta-os/buscar sem numero retorna 422 (validation)', function () {
+    $response = $this->getJson('/consulta-os/buscar');
+
+    // Laravel valida 'required' no input — retorna 422 em JSON.
+    $response->assertStatus(422);
+});

--- a/Modules/Governance/Tests/Feature/GovernanceGateTest.php
+++ b/Modules/Governance/Tests/Feature/GovernanceGateTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Auth gate das rotas /governance.
+ *
+ * MVP atual (ADR 0086) protege rotas via `auth` middleware UltimatePOS — não há
+ * permission Spatie específica por enquanto (Fase 5+1 adiciona ActionGate strict).
+ * Este teste valida o que está implementado HOJE:
+ *
+ *   1. Usuário ANÔNIMO é bloqueado (redirect login OU 401/403)
+ *   2. Rotas críticas (/governance, /audit, /drift) exigem auth
+ *   3. ActionGate middleware existe e modo default é `warn` (não bloqueia)
+ *
+ * Quando Fase 5+1 promover ActionGate pra `strict`, este teste deve ser
+ * expandido pra cobrir: user sem trust_level → 403; user com L0/L1 → 200.
+ *
+ * SQLite guard obrigatório. biz=1 NUNCA biz=4 (ADR 0101).
+ *
+ * Refs: ADR 0086 (Governance MVP UI), ADR 0093 (Multi-tenant Tier 0),
+ * Constituição Art. 8 (Policy Gating).
+ */
+beforeEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('GovernanceGateTest roda apenas em SQLite in-memory (guard ADR 0101)');
+    }
+
+    // Tabelas mínimas pra Controllers não explodirem no boot
+    Schema::dropIfExists('mcp_memory_documents');
+    Schema::dropIfExists('mcp_governance_rules');
+    Schema::dropIfExists('mcp_skill_versions');
+    Schema::dropIfExists('mcp_audit_log');
+    Schema::dropIfExists('mcp_actors');
+
+    Schema::create('mcp_memory_documents', function (Blueprint $t) {
+        $t->id();
+        $t->string('slug')->unique();
+        $t->string('title');
+        $t->string('type', 30)->default('adr');
+        $t->string('status', 30)->nullable();
+        $t->timestamp('deleted_at')->nullable();
+        $t->timestamps();
+    });
+    Schema::create('mcp_governance_rules', function (Blueprint $t) {
+        $t->id();
+        $t->string('name');
+        $t->boolean('enabled')->default(true);
+        $t->timestamps();
+    });
+    Schema::create('mcp_skill_versions', function (Blueprint $t) {
+        $t->id();
+        $t->string('slug');
+        $t->string('status', 30)->default('draft');
+        $t->timestamps();
+    });
+    Schema::create('mcp_audit_log', function (Blueprint $t) {
+        $t->id();
+        $t->unsignedBigInteger('user_id')->nullable();
+        $t->unsignedBigInteger('business_id')->nullable();
+        $t->string('endpoint', 60);
+        $t->string('tool_or_resource', 120)->nullable();
+        $t->string('status', 30)->default('ok');
+        $t->unsignedInteger('duration_ms')->nullable();
+        $t->timestamp('ts')->useCurrent();
+    });
+    Schema::create('mcp_actors', function (Blueprint $t) {
+        $t->id();
+        $t->string('slug')->unique();
+        $t->string('display_name')->nullable();
+        $t->unsignedBigInteger('user_id')->nullable();
+        $t->timestamp('revoked_at')->nullable();
+        $t->timestamps();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_actors');
+    Schema::dropIfExists('mcp_audit_log');
+    Schema::dropIfExists('mcp_skill_versions');
+    Schema::dropIfExists('mcp_governance_rules');
+    Schema::dropIfExists('mcp_memory_documents');
+});
+
+it('cenario 1: anonimo bloqueado em /governance (sem auth)', function () {
+    $response = $this->get('/governance');
+    // auth middleware redireciona pra login (302) OU retorna 401/403
+    expect($response->status())->toBeIn([301, 302, 401, 403],
+        "Anonimo deveria ser bloqueado em /governance, recebeu {$response->status()}");
+
+    // Nunca 200 (vazaria dashboard sensivel)
+    expect($response->status())->not->toBe(200);
+});
+
+it('cenario 2: anonimo bloqueado em /governance/audit (Constituicao Art. 9)', function () {
+    $response = $this->get('/governance/audit');
+    expect($response->status())->toBeIn([301, 302, 401, 403]);
+    expect($response->status())->not->toBe(200);
+});
+
+it('cenario 3: anonimo bloqueado em /governance/drift', function () {
+    $response = $this->get('/governance/drift');
+    expect($response->status())->toBeIn([301, 302, 401, 403]);
+    expect($response->status())->not->toBe(200);
+});
+
+it('cenario 4: anonimo bloqueado em /governance/policies', function () {
+    $response = $this->get('/governance/policies');
+    expect($response->status())->toBeIn([301, 302, 401, 403]);
+    expect($response->status())->not->toBe(200);
+});
+
+it('cenario 5: ActionGate middleware existe e modo default e warn', function () {
+    expect(class_exists(\Modules\Governance\Http\Middleware\ActionGate::class))->toBeTrue();
+    // Modo default `warn` por config — Fase 5+1 promove pra `strict`
+    expect(config('governance.actiongate_mode', 'warn'))->toBeIn(['off', 'warn', 'strict']);
+});
+
+it('cenario 6: middleware stack das rotas inclui auth', function () {
+    // Pega rota nomeada e verifica que algum middleware auth-relacionado está aplicado.
+    // Aceita 'auth', 'auth:web', 'Authenticate' FQCN — pattern UltimatePOS pode aplicar
+    // via grupo/alias/classe direta dependendo da versão.
+    $route = \Route::getRoutes()->getByName('governance.admin.dashboard');
+    expect($route)->not->toBeNull('Rota governance.admin.dashboard deveria existir');
+
+    $middlewares = $route->gatherMiddleware();
+    $hasAuthLike = collect($middlewares)->contains(
+        fn ($m) => is_string($m) && stripos($m, 'auth') !== false
+    );
+    expect($hasAuthLike)->toBeTrue(
+        'Rota /governance deveria ter algum middleware auth-relacionado (got: ' . json_encode($middlewares) . ')'
+    );
+});

--- a/Modules/Governance/Tests/Feature/ScaffoldTest.php
+++ b/Modules/Governance/Tests/Feature/ScaffoldTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Nwidart\Modules\Facades\Module;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke scaffold pra Modules/Governance.
+ *
+ * Garante que:
+ *   1. nWidart enxerga o módulo registrado
+ *   2. GovernanceServiceProvider carrega sem erro (classe existe + provides)
+ *   3. As 7 rotas nomeadas em Http/routes.php existem
+ *   4. Os 6 Controllers existem (DashboardController + 5 outros)
+ *   5. ActionGate middleware foi aliasado pra `actiongate`
+ *
+ * Refs: ADR 0011 padrão Jana/Repair, ADR 0024 InstallController, ADR 0086 MVP Governance UI.
+ */
+it('cenario 1: modulo Governance esta registrado em nWidart', function () {
+    $module = Module::find('Governance');
+    expect($module)->not->toBeNull('Modules/Governance deveria estar registrado em nWidart');
+    expect($module->getName())->toBe('Governance');
+});
+
+it('cenario 2: GovernanceServiceProvider existe e e carregavel', function () {
+    expect(class_exists(\Modules\Governance\Providers\GovernanceServiceProvider::class))
+        ->toBeTrue('ServiceProvider canonico deveria existir');
+});
+
+it('cenario 3: rota nomeada governance.admin.dashboard existe', function () {
+    expect(\Route::has('governance.admin.dashboard'))
+        ->toBeTrue('Rota governance.admin.dashboard deveria existir (DashboardController@index)');
+});
+
+it('cenario 4: rota nomeada governance.policies.index existe', function () {
+    expect(\Route::has('governance.policies.index'))
+        ->toBeTrue('Rota governance.policies.index deveria existir');
+});
+
+it('cenario 5: rota nomeada governance.audit.index existe', function () {
+    expect(\Route::has('governance.audit.index'))
+        ->toBeTrue('Rota governance.audit.index deveria existir (AuditController@index)');
+});
+
+it('cenario 6: rota nomeada governance.drift.index existe', function () {
+    expect(\Route::has('governance.drift.index'))
+        ->toBeTrue('Rota governance.drift.index deveria existir (DriftAlertsController@index)');
+});
+
+it('cenario 7: rota Install nomeada governance.install.index existe', function () {
+    expect(\Route::has('governance.install.index'))
+        ->toBeTrue('Rota governance.install.index deveria existir (ADR 0024)');
+});
+
+it('cenario 8: rota Install uninstall existe (ADR 0024 padrao)', function () {
+    expect(\Route::has('governance.install.uninstall'))
+        ->toBeTrue('Rota governance.install.uninstall deveria existir');
+});
+
+it('cenario 9: rota Install update existe (ADR 0024 padrao)', function () {
+    expect(\Route::has('governance.install.update'))
+        ->toBeTrue('Rota governance.install.update deveria existir');
+});
+
+it('cenario 10: os 6 Controllers existem', function () {
+    expect(class_exists(\Modules\Governance\Http\Controllers\DashboardController::class))->toBeTrue();
+    expect(class_exists(\Modules\Governance\Http\Controllers\PoliciesController::class))->toBeTrue();
+    expect(class_exists(\Modules\Governance\Http\Controllers\AuditController::class))->toBeTrue();
+    expect(class_exists(\Modules\Governance\Http\Controllers\DriftAlertsController::class))->toBeTrue();
+    expect(class_exists(\Modules\Governance\Http\Controllers\InstallController::class))->toBeTrue();
+    expect(class_exists(\Modules\Governance\Http\Controllers\DataController::class))->toBeTrue();
+});
+
+it('cenario 11: ActionGate middleware foi registrado como alias actiongate', function () {
+    /** @var \Illuminate\Routing\Router $router */
+    $router = app('router');
+    $aliases = $router->getMiddleware();
+    expect($aliases)->toHaveKey('actiongate');
+    expect($aliases['actiongate'])->toBe(\Modules\Governance\Http\Middleware\ActionGate::class);
+});

--- a/Modules/Governance/Tests/Feature/SmokeRoutesTest.php
+++ b/Modules/Governance/Tests/Feature/SmokeRoutesTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke das rotas principais /governance.
+ *
+ * Apenas valida que rotas respondem status <500 (sem 500 = sem erro PHP).
+ * Não autentica usuário — espera-se 302 (redirect login) ou 401, NUNCA 500.
+ *
+ * SQLite guard obrigatório (ADR multi-tenant Tier 0): só roda em sqlite
+ * pra não vazar pra MySQL de homolog/prod. Schema mínimo criado em-memory.
+ *
+ * biz=1 (Wagner WR2) — NUNCA biz=4 cliente (ADR 0101).
+ *
+ * Refs: ADR 0086 (Governance MVP UI), ADR 0011 (padrão Jana/Repair).
+ */
+beforeEach(function () {
+    if (config('database.default') !== 'sqlite') {
+        $this->markTestSkipped('SmokeRoutesTest roda apenas em SQLite in-memory (guard ADR 0101)');
+    }
+
+    // Schemas mínimos pras tabelas que o DashboardController/AuditController consultam.
+    // Cada Controller já degrada graciosamente via Schema::hasTable, mas precisamos
+    // que a app não exploda no boot da query. Criar shape mínimo:
+    Schema::dropIfExists('mcp_memory_documents');
+    Schema::dropIfExists('mcp_governance_rules');
+    Schema::dropIfExists('mcp_skill_versions');
+    Schema::dropIfExists('mcp_audit_log');
+    Schema::dropIfExists('mcp_actors');
+
+    Schema::create('mcp_memory_documents', function (Blueprint $t) {
+        $t->id();
+        $t->string('slug')->unique();
+        $t->string('title');
+        $t->string('type', 30)->default('adr');
+        $t->string('status', 30)->nullable();
+        $t->timestamp('deleted_at')->nullable();
+        $t->timestamps();
+    });
+
+    Schema::create('mcp_governance_rules', function (Blueprint $t) {
+        $t->id();
+        $t->string('name');
+        $t->boolean('enabled')->default(true);
+        $t->timestamps();
+    });
+
+    Schema::create('mcp_skill_versions', function (Blueprint $t) {
+        $t->id();
+        $t->string('slug');
+        $t->string('status', 30)->default('draft');
+        $t->timestamps();
+    });
+
+    Schema::create('mcp_audit_log', function (Blueprint $t) {
+        $t->id();
+        $t->unsignedBigInteger('user_id')->nullable();
+        $t->unsignedBigInteger('business_id')->nullable();
+        $t->string('endpoint', 60);
+        $t->string('tool_or_resource', 120)->nullable();
+        $t->string('status', 30)->default('ok');
+        $t->unsignedInteger('duration_ms')->nullable();
+        $t->timestamp('ts')->useCurrent();
+    });
+
+    Schema::create('mcp_actors', function (Blueprint $t) {
+        $t->id();
+        $t->string('slug')->unique();
+        $t->string('display_name')->nullable();
+        $t->unsignedBigInteger('user_id')->nullable();
+        $t->timestamp('revoked_at')->nullable();
+        $t->timestamps();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_actors');
+    Schema::dropIfExists('mcp_audit_log');
+    Schema::dropIfExists('mcp_skill_versions');
+    Schema::dropIfExists('mcp_governance_rules');
+    Schema::dropIfExists('mcp_memory_documents');
+});
+
+/**
+ * Conjunto de rotas principais — todas devem responder <500.
+ * Como nenhuma sessão biz=1 está montada, esperamos redirect/401 (não-200).
+ * Importante: zero 500.
+ */
+$rotas = [
+    '/governance',
+    '/governance/policies',
+    '/governance/audit',
+    '/governance/drift',
+];
+
+foreach ($rotas as $rota) {
+    it("smoke: GET {$rota} responde status < 500", function () use ($rota) {
+        $response = $this->get($rota);
+        expect($response->status())->toBeLessThan(500, "GET {$rota} retornou {$response->status()} (esperado <500)");
+    });
+}
+
+it('smoke: rota raiz /governance redireciona quando anonimo (middleware auth)', function () {
+    $response = $this->get('/governance');
+    // 302 redirect pro login OU 401/403 — todos são "não-500"
+    expect($response->status())->toBeIn([200, 301, 302, 401, 403]);
+});

--- a/Modules/Governance/Tests/Pest.php
+++ b/Modules/Governance/Tests/Pest.php
@@ -1,0 +1,5 @@
+<?php
+
+use Tests\TestCase;
+
+uses(TestCase::class)->in(__DIR__);

--- a/Modules/ProductCatalogue/Tests/Feature/ScaffoldTest.php
+++ b/Modules/ProductCatalogue/Tests/Feature/ScaffoldTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use Nwidart\Modules\Facades\Module;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke test do scaffold Modules/ProductCatalogue (Wave B — gap P3).
+ *
+ * Garante que:
+ *   1. Módulo aparece registrado em nWidart (laravel-modules ^10)
+ *   2. ProductCatalogueServiceProvider carrega sem erro
+ *   3. RouteServiceProvider registrou rotas web (URIs)
+ *   4. InstallController estende BaseModuleInstallController (padrão UltimatePOS)
+ *
+ * NOTA — multi-tenant: ProductCatalogue é catálogo público (sem Eloquent Models/Entities
+ * próprios — usa App\Product, App\Business, App\Discount herdados do core UltimatePOS).
+ * Portanto NÃO há `MultiTenantIsolationTest` pra este módulo — isolamento é
+ * coberto pelos testes dos models core (App\Product já tem business_id global scope).
+ * Controllers recebem $business_id como parâmetro de rota pública (catálogo
+ * compartilhável via QR code), respeitando filtro `Product::where('business_id', $bid)`.
+ *
+ * Refs: ADR 0011 padrão Jana/Repair, skill criar-modulo, [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)
+ */
+
+it('cenario 1: modulo ProductCatalogue aparece registrado em nWidart', function () {
+    $module = Module::find('ProductCatalogue');
+    expect($module)->not->toBeNull('Modules/ProductCatalogue deveria estar registrado em nWidart');
+    expect($module->getName())->toBe('ProductCatalogue');
+});
+
+it('cenario 2: ServiceProvider do modulo esta carregado', function () {
+    $providers = app()->getLoadedProviders();
+    expect($providers)->toHaveKey(\Modules\ProductCatalogue\Providers\ProductCatalogueServiceProvider::class);
+});
+
+it('cenario 3: rota publica do catalogo (catalogue/{business}/{location}) esta registrada', function () {
+    $routes = \Route::getRoutes();
+    $uris = collect($routes)->map(fn ($r) => $r->uri())->all();
+
+    expect($uris)->toContain('catalogue/{business_id}/{location_id}');
+});
+
+it('cenario 4: rota show-catalogue/{business}/{product} esta registrada', function () {
+    $routes = \Route::getRoutes();
+    $uris = collect($routes)->map(fn ($r) => $r->uri())->all();
+
+    expect($uris)->toContain('show-catalogue/{business_id}/{product_id}');
+});
+
+it('cenario 5: rota admin product-catalogue/catalogue-qr esta registrada', function () {
+    $routes = \Route::getRoutes();
+    $uris = collect($routes)->map(fn ($r) => $r->uri())->all();
+
+    expect($uris)->toContain('product-catalogue/catalogue-qr');
+});
+
+it('cenario 6: InstallController estende BaseModuleInstallController (padrao UltimatePOS)', function () {
+    expect(is_subclass_of(
+        \Modules\ProductCatalogue\Http\Controllers\InstallController::class,
+        \App\Http\Controllers\BaseModuleInstallController::class
+    ))->toBeTrue('InstallController deveria estender BaseModuleInstallController per ADR 0011');
+});
+
+it('cenario 7: rotas de install product-catalogue (index/install/uninstall/update) registradas', function () {
+    $routes = \Route::getRoutes();
+    $uris = collect($routes)->map(fn ($r) => $r->uri())->all();
+
+    expect($uris)->toContain('product-catalogue/install');
+    expect($uris)->toContain('product-catalogue/install/uninstall');
+    expect($uris)->toContain('product-catalogue/install/update');
+});

--- a/Modules/ProductCatalogue/Tests/Feature/SmokeRoutesTest.php
+++ b/Modules/ProductCatalogue/Tests/Feature/SmokeRoutesTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke routes Modules/ProductCatalogue — Wave B (gap P3).
+ *
+ * Cobre as 3 rotas principais do catalogo:
+ *   - GET /catalogue/{business_id}/{location_id} — index publico (catalogo compartilhavel)
+ *   - GET /show-catalogue/{business_id}/{product_id} — detalhe produto publico
+ *   - GET /product-catalogue/catalogue-qr — geracao QR code (admin autenticado)
+ *
+ * Estrategia: verifica que rotas respondem (nao retornam 500 puro) e que controllers
+ * sao despachaveis. Tests usam biz=1 (Wagner WR2) — NUNCA biz=4 (Larissa producao) — ADR 0101.
+ *
+ * SQLite-incompatible: ProductCatalogue depende de App\Product + relacoes
+ * (variations, product_locations, discounts) com schema MySQL UltimatePOS.
+ *
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ */
+
+// Guard SQLite — Models core UltimatePOS requerem MySQL schema completo
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompativel: ProductCatalogue depende de App\\Product + relacoes do schema MySQL UltimatePOS (Wagner Pest local segue mandatory — ADR 0101)');
+    }
+    if (! Schema::hasTable('products') || ! Schema::hasTable('business')) {
+        $this->markTestSkipped('Schema UltimatePOS incompleto — rode migrate primeiro');
+    }
+});
+
+const BIZ_WAGNER_CAT = 1;
+
+it('rota publica /catalogue/{biz}/{loc} responde (nao 500 puro)', function () {
+    // Smoke: rota deve resolver Controller + Model lookup. Pode 404 (sem data),
+    // mas nao deve 500 com fatal error de class-not-found ou typo em namespace.
+    $response = $this->get('/catalogue/' . BIZ_WAGNER_CAT . '/1');
+
+    // Aceita 200 (catalogo renderizou), 404 (location nao existe), 302 (redirect).
+    // Rejeita 500 (fatal) — sinal de typo namespace ou Provider broken.
+    expect($response->status())->not->toBe(500);
+});
+
+it('rota publica /show-catalogue/{biz}/{id} responde (nao 500 puro)', function () {
+    $response = $this->get('/show-catalogue/' . BIZ_WAGNER_CAT . '/999999');
+
+    // 404 esperado quando product_id=999999 nao existe; smoke nao quer 500.
+    expect($response->status())->not->toBe(500);
+});
+
+it('rota admin /product-catalogue/catalogue-qr exige autenticacao (302/401/403)', function () {
+    // Sem auth, middleware 'auth' redireciona pro login (302) ou retorna 401/403.
+    $response = $this->get('/product-catalogue/catalogue-qr');
+
+    expect($response->status())->toBeIn([302, 401, 403]);
+});
+
+it('rotas product-catalogue carregam stack middleware UltimatePOS', function () {
+    $route = collect(\Route::getRoutes())
+        ->first(fn ($r) => $r->uri() === 'product-catalogue/catalogue-qr');
+
+    expect($route)->not->toBeNull('Rota product-catalogue/catalogue-qr deveria existir');
+
+    $middleware = $route->gatherMiddleware();
+    // Stack canonico UltimatePOS — at least 'web' + 'auth' presentes (skill runtime-rules)
+    expect($middleware)->toContain('web');
+    expect($middleware)->toContain('auth');
+});

--- a/Modules/SRS/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/SRS/Tests/Feature/MultiTenantIsolationTest.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\SRS\Entities\DocRequirement;
+use Modules\SRS\Entities\DocSource;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Testa isolamento multi-tenant COLUMN-level dos Models SRS (docs_*).
+ *
+ * NOTA importante: Modules/SRS NÃO usa BusinessScope global (verificado nas Entities
+ * DocSource/DocRequirement/DocEvidence/DocPage — sem boot() com global scope).
+ * As tabelas docs_sources e docs_requirements TÊM coluna business_id (verificado
+ * em Database/Migrations/2026_04_22_000001 e 2026_04_22_000003).
+ *
+ * Portanto este teste valida isolamento COLUMN-level — toda query de produção
+ * DEVE incluir where('business_id', ...) explícito. Se algum Controller esquecer,
+ * vazamento cross-tenant acontece. Adicionar BusinessScope global ao SRS é
+ * proposta P0 separada (não no escopo deste PR Pest-only).
+ *
+ * ADR 0093: multi-tenant Tier 0 IRREVOGÁVEL.
+ * ADR 0101: tests usam biz=1 (Wagner WR2) e biz=99 (fictício) — NUNCA biz=4 (ROTA LIVRE prod).
+ *
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ */
+
+const BIZ_WAGNER = 1;
+const BIZ_FICTICIO = 99;
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: schema docs_* requer MySQL UltimatePOS — rodar Pest local com MySQL (ADR 0101)');
+    }
+    if (! Schema::hasTable('docs_sources') || ! Schema::hasTable('docs_requirements')) {
+        $this->markTestSkipped('Tabelas docs_* ausentes — rode `php artisan module:migrate SRS` primeiro');
+    }
+});
+
+// ------------------------------------------------------------------
+// DocSource — isolamento column-level via where('business_id', ...)
+// ------------------------------------------------------------------
+
+it('DocSource biz=1 NÃO aparece em query filtrada por biz=99 (isolamento column-level)', function () {
+    $source = DocSource::create([
+        'business_id'   => BIZ_WAGNER,
+        'type'          => 'text',
+        'title'         => 'SRS Teste Isolamento DocSource',
+        'module_target' => 'TesteFicticio',
+        'body_text'     => 'conteúdo arbitrário pra teste',
+    ]);
+
+    // Consulta com filter explícito biz=99 — NÃO deve aparecer
+    $resultado = DocSource::where('business_id', BIZ_FICTICIO)
+        ->where('id', $source->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(0);
+})->afterEach(function () {
+    DocSource::where('title', 'SRS Teste Isolamento DocSource')->delete();
+});
+
+it('DocSource biz=1 aparece em query filtrada por biz=1', function () {
+    $source = DocSource::create([
+        'business_id'   => BIZ_WAGNER,
+        'type'          => 'text',
+        'title'         => 'SRS Teste Visibilidade DocSource',
+        'module_target' => 'TesteFicticio',
+        'body_text'     => 'visível pro próprio business',
+    ]);
+
+    $resultado = DocSource::where('business_id', BIZ_WAGNER)
+        ->where('id', $source->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(1);
+    expect($resultado->first()->title)->toBe('SRS Teste Visibilidade DocSource');
+})->afterEach(function () {
+    DocSource::where('title', 'SRS Teste Visibilidade DocSource')->delete();
+});
+
+// ------------------------------------------------------------------
+// DocRequirement — isolamento column-level
+// ------------------------------------------------------------------
+
+it('DocRequirement biz=1 NÃO aparece em query filtrada por biz=99', function () {
+    $req = DocRequirement::create([
+        'business_id'   => BIZ_WAGNER,
+        'module_target' => 'TesteFicticio',
+        'external_id'   => 'US-SRS-TEST-99991',
+        'kind'          => 'user_story',
+        'title'         => 'SRS Teste Isolamento Requirement',
+        'status'        => 'draft',
+    ]);
+
+    $resultado = DocRequirement::where('business_id', BIZ_FICTICIO)
+        ->where('id', $req->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(0);
+})->afterEach(function () {
+    DocRequirement::where('external_id', 'US-SRS-TEST-99991')->delete();
+});
+
+it('DocRequirement biz=1 aparece em query filtrada por biz=1', function () {
+    $req = DocRequirement::create([
+        'business_id'   => BIZ_WAGNER,
+        'module_target' => 'TesteFicticio',
+        'external_id'   => 'US-SRS-TEST-99992',
+        'kind'          => 'user_story',
+        'title'         => 'SRS Teste Visibilidade Requirement',
+        'status'        => 'draft',
+    ]);
+
+    $resultado = DocRequirement::where('business_id', BIZ_WAGNER)
+        ->where('id', $req->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(1);
+    expect($resultado->first()->external_id)->toBe('US-SRS-TEST-99992');
+})->afterEach(function () {
+    DocRequirement::where('external_id', 'US-SRS-TEST-99992')->delete();
+});
+
+// ------------------------------------------------------------------
+// Cross-tenant — biz=1 e biz=99 coexistem sem vazamento
+// ------------------------------------------------------------------
+
+it('DocSource biz=1 e biz=99 são isolados em queries simultâneas', function () {
+    $sourceBiz1 = DocSource::create([
+        'business_id'   => BIZ_WAGNER,
+        'type'          => 'text',
+        'title'         => 'SRS Cross-Tenant Biz1',
+        'module_target' => 'TesteFicticio',
+    ]);
+
+    $sourceBiz99 = DocSource::create([
+        'business_id'   => BIZ_FICTICIO,
+        'type'          => 'text',
+        'title'         => 'SRS Cross-Tenant Biz99',
+        'module_target' => 'TesteFicticio',
+    ]);
+
+    // Query biz=1 só enxerga biz=1
+    $resBiz1 = DocSource::where('business_id', BIZ_WAGNER)
+        ->whereIn('id', [$sourceBiz1->id, $sourceBiz99->id])
+        ->get();
+    expect($resBiz1)->toHaveCount(1);
+    expect($resBiz1->first()->business_id)->toBe(BIZ_WAGNER);
+
+    // Query biz=99 só enxerga biz=99
+    $resBiz99 = DocSource::where('business_id', BIZ_FICTICIO)
+        ->whereIn('id', [$sourceBiz1->id, $sourceBiz99->id])
+        ->get();
+    expect($resBiz99)->toHaveCount(1);
+    expect($resBiz99->first()->business_id)->toBe(BIZ_FICTICIO);
+})->afterEach(function () {
+    DocSource::whereIn('title', ['SRS Cross-Tenant Biz1', 'SRS Cross-Tenant Biz99'])->delete();
+});

--- a/Modules/SRS/Tests/Feature/ScaffoldTest.php
+++ b/Modules/SRS/Tests/Feature/ScaffoldTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use Nwidart\Modules\Facades\Module;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke test do scaffold Modules/SRS (rename de MemCofre — PR #97 Fase 3.7).
+ *
+ * Garante que:
+ *   1. Módulo aparece registrado em nWidart sob o nome canônico "SRS"
+ *   2. ServiceProvider carrega sem erro
+ *   3. Rotas web nomeadas estão registradas (memcofre.* legacy + srs.install.*)
+ *
+ * Refs: ADR 0011 padrão Jana/Repair/Project, skill criar-modulo,
+ *       memory/proibicoes.md §"Não criar Modules/X/Tests/ sem registrar em phpunit.xml"
+ */
+
+it('cenário 1: módulo SRS aparece registrado em nWidart', function () {
+    $module = Module::find('SRS');
+    expect($module)->not->toBeNull('Modules/SRS deveria estar registrado em nWidart');
+    expect($module->getName())->toBe('SRS');
+});
+
+it('cenário 2: rota nomeada memcofre.dashboard existe (legacy prefix preservado)', function () {
+    expect(\Route::has('memcofre.dashboard'))->toBeTrue('Rota memcofre.dashboard deveria existir per Http/routes.php');
+});
+
+it('cenário 3: rota nomeada memcofre.ingest existe', function () {
+    expect(\Route::has('memcofre.ingest'))->toBeTrue('Rota memcofre.ingest deveria existir');
+});
+
+it('cenário 4: rota nomeada memcofre.inbox existe', function () {
+    expect(\Route::has('memcofre.inbox'))->toBeTrue('Rota memcofre.inbox deveria existir');
+});
+
+it('cenário 5: rota nomeada srs.install.index existe (3 rotas Install canônicas)', function () {
+    expect(\Route::has('srs.install.index'))->toBeTrue('Rota srs.install.index deveria existir');
+});
+
+it('cenário 6: rota nomeada srs.install.run existe (POST install)', function () {
+    expect(\Route::has('srs.install.run'))->toBeTrue('Rota srs.install.run deveria existir');
+});
+
+it('cenário 7: rota nomeada srs.install.uninstall existe', function () {
+    expect(\Route::has('srs.install.uninstall'))->toBeTrue('Rota srs.install.uninstall deveria existir');
+});
+
+it('cenário 8: rota nomeada memcofre.chat existe (assistente IA)', function () {
+    expect(\Route::has('memcofre.chat'))->toBeTrue('Rota memcofre.chat deveria existir');
+});

--- a/Modules/SRS/Tests/Feature/SmokeRoutesTest.php
+++ b/Modules/SRS/Tests/Feature/SmokeRoutesTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke test das rotas principais de Modules/SRS.
+ *
+ * Garante que rotas retornam status <500 (middleware auth pode redirecionar 302,
+ * isso é OK — comprova que rota existe e middleware stack carrega sem erro).
+ *
+ * Sem login (não testa lógica de negócio); valida apenas que:
+ *   1. Rota está registrada (Route::has)
+ *   2. Middleware stack carrega (sem 500)
+ *
+ * ADR 0011: padrão Jana/Repair/Project — smoke routes obrigatório por módulo.
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: middleware UltimatePOS requer schema MySQL (business/users)');
+    }
+    if (! Schema::hasTable('docs_sources')) {
+        $this->markTestSkipped('Tabelas docs_* ausentes — rode `php artisan module:migrate SRS` primeiro');
+    }
+});
+
+it('rota memcofre.dashboard responde sem 500 (auth pode redirecionar)', function () {
+    $response = $this->get(route('memcofre.dashboard'));
+    expect($response->getStatusCode())->toBeLessThan(500);
+});
+
+it('rota memcofre.ingest responde sem 500', function () {
+    $response = $this->get(route('memcofre.ingest'));
+    expect($response->getStatusCode())->toBeLessThan(500);
+});
+
+it('rota memcofre.inbox responde sem 500', function () {
+    $response = $this->get(route('memcofre.inbox'));
+    expect($response->getStatusCode())->toBeLessThan(500);
+});
+
+it('rota srs.install.index responde sem 500', function () {
+    $response = $this->get(route('srs.install.index'));
+    expect($response->getStatusCode())->toBeLessThan(500);
+});
+
+it('redirect legacy /memcofre/install retorna 301 pra /srs/install', function () {
+    $response = $this->get('/memcofre/install');
+    // 301 esperado conforme routes.php — mas se middleware auth interceptar, vira 302; ambos <500
+    expect($response->getStatusCode())->toBeLessThan(500);
+});

--- a/Modules/Spreadsheet/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/Spreadsheet/Tests/Feature/MultiTenantIsolationTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Spreadsheet\Entities\Spreadsheet;
+use Modules\Spreadsheet\Entities\SpreadsheetShare;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Testa isolamento multi-tenant das Entities do Modules/Spreadsheet.
+ *
+ * Observação: Spreadsheet/SpreadsheetShare NÃO tem BusinessScope global — o
+ * isolamento é feito manualmente via where('business_id', ...) no Controller
+ * (ver SpreadsheetController::index linha ~56). Estes testes garantem que:
+ *   1. A coluna business_id existe e segrega o dado (Spreadsheet).
+ *   2. SpreadsheetShare herda o tenant via FK sheet_spreadsheet_id (cascade).
+ *
+ * ADR 0093: multi-tenant isolation Tier 0 IRREVOGÁVEL.
+ * ADR 0101: usar biz=1 (Wagner WR2), NUNCA biz=4 (ROTA LIVRE — cliente).
+ *
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ */
+
+// Guard SQLite: schema usa FK ON DELETE CASCADE pra tabela `business` do UltimatePOS.
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: schema requer tabela `business` UltimatePOS (FK cascade).');
+    }
+    if (! Schema::hasTable('sheet_spreadsheets')) {
+        $this->markTestSkipped('Tabela sheet_spreadsheets ausente — rode migrate do Modules/Spreadsheet primeiro.');
+    }
+    if (! Schema::hasTable('sheet_spreadsheet_shares')) {
+        $this->markTestSkipped('Tabela sheet_spreadsheet_shares ausente — rode migrate do Modules/Spreadsheet primeiro.');
+    }
+});
+
+// IDs usados nos testes — biz=1 (Wagner) e biz=99 (fictício isolamento)
+const BIZ_WAGNER_SPS = 1;
+const BIZ_FICTICIO_SPS = 99;
+
+// ------------------------------------------------------------------
+// Spreadsheet — isolamento via where('business_id', ...) manual
+// ------------------------------------------------------------------
+
+it('Spreadsheet biz=1 não aparece em query filtrada por biz=99', function () {
+    $sheet = Spreadsheet::create([
+        'business_id' => BIZ_WAGNER_SPS,
+        'name'        => 'Planilha Teste Wagner Isolamento',
+        'sheet_data'  => ['rows' => [['A1' => 'teste']]],
+        'created_by'  => 1,
+    ]);
+
+    // Mesma query que o Controller faz: where('business_id', $biz)
+    $resultado = Spreadsheet::where('business_id', BIZ_FICTICIO_SPS)
+        ->where('id', $sheet->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(0);
+})->afterEach(function () {
+    Spreadsheet::where('name', 'Planilha Teste Wagner Isolamento')->delete();
+});
+
+it('Spreadsheet biz=1 aparece em query filtrada por biz=1', function () {
+    $sheet = Spreadsheet::create([
+        'business_id' => BIZ_WAGNER_SPS,
+        'name'        => 'Planilha Teste Wagner Visivel',
+        'sheet_data'  => ['rows' => [['A1' => 'visivel']]],
+        'created_by'  => 1,
+    ]);
+
+    $resultado = Spreadsheet::where('business_id', BIZ_WAGNER_SPS)
+        ->where('id', $sheet->id)
+        ->get();
+
+    expect($resultado)->toHaveCount(1);
+    expect($resultado->first()->name)->toBe('Planilha Teste Wagner Visivel');
+})->afterEach(function () {
+    Spreadsheet::where('name', 'Planilha Teste Wagner Visivel')->delete();
+});
+
+it('Spreadsheet tem coluna business_id na tabela', function () {
+    expect(Schema::hasColumn('sheet_spreadsheets', 'business_id'))->toBeTrue(
+        'sheet_spreadsheets.business_id obrigatório (ADR 0093 — multi-tenant Tier 0)'
+    );
+});
+
+// ------------------------------------------------------------------
+// SpreadsheetShare — isolamento via FK sheet_spreadsheet_id (filho)
+// ------------------------------------------------------------------
+
+it('SpreadsheetShare herda tenant via FK sheet_spreadsheet_id', function () {
+    // Spreadsheet pai do biz=1
+    $sheet = Spreadsheet::create([
+        'business_id' => BIZ_WAGNER_SPS,
+        'name'        => 'Planilha Pai Share Teste',
+        'sheet_data'  => [],
+        'created_by'  => 1,
+    ]);
+
+    $share = SpreadsheetShare::create([
+        'sheet_spreadsheet_id' => $sheet->id,
+        'shared_with'          => 'user',
+        'shared_id'            => 1,
+    ]);
+
+    // Filtrar shares cujo pai pertence ao biz=99 — não aparece
+    $resultadoBiz99 = SpreadsheetShare::whereHas('sheet_spreadsheet_id', function () {
+    })->whereIn('sheet_spreadsheet_id', function ($q) {
+        $q->select('id')->from('sheet_spreadsheets')->where('business_id', BIZ_FICTICIO_SPS);
+    })->where('id', $share->id)->get();
+
+    expect($resultadoBiz99)->toHaveCount(0);
+
+    // Filtrar shares cujo pai pertence ao biz=1 — aparece
+    $resultadoBiz1 = SpreadsheetShare::whereIn('sheet_spreadsheet_id', function ($q) {
+        $q->select('id')->from('sheet_spreadsheets')->where('business_id', BIZ_WAGNER_SPS);
+    })->where('id', $share->id)->get();
+
+    expect($resultadoBiz1)->toHaveCount(1);
+})->afterEach(function () {
+    $ids = Spreadsheet::where('name', 'Planilha Pai Share Teste')->pluck('id');
+    SpreadsheetShare::whereIn('sheet_spreadsheet_id', $ids)->delete();
+    Spreadsheet::whereIn('id', $ids)->delete();
+});
+
+it('SpreadsheetShare cascade delete quando spreadsheet pai é apagado', function () {
+    $sheet = Spreadsheet::create([
+        'business_id' => BIZ_WAGNER_SPS,
+        'name'        => 'Planilha Cascade Teste',
+        'sheet_data'  => [],
+        'created_by'  => 1,
+    ]);
+
+    $share = SpreadsheetShare::create([
+        'sheet_spreadsheet_id' => $sheet->id,
+        'shared_with'          => 'user',
+        'shared_id'            => 1,
+    ]);
+
+    $shareId = $share->id;
+    $sheet->delete();
+
+    // FK ON DELETE CASCADE remove o share automaticamente
+    expect(SpreadsheetShare::find($shareId))->toBeNull(
+        'SpreadsheetShare deveria ser removido em cascade quando pai é apagado'
+    );
+});

--- a/Modules/Spreadsheet/Tests/Feature/ScaffoldTest.php
+++ b/Modules/Spreadsheet/Tests/Feature/ScaffoldTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+use Nwidart\Modules\Facades\Module;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke test do scaffold Modules/Spreadsheet (US-SHEET-001 — gap P3).
+ *
+ * Garante que:
+ *   1. Módulo aparece registrado em nWidart (module.json válido).
+ *   2. ServiceProvider carrega sem erro de boot.
+ *   3. Rotas web foram registradas (via Route::has nas rotas resource).
+ *
+ * Refs:
+ *   - ADR 0011 (padrão Jana/Repair/Project)
+ *   - skill `criar-modulo` (8 peças obrigatórias)
+ *   - memory/requisitos/Infra/RUNBOOK-criar-modulo.md
+ */
+
+it('cenário 1: módulo Spreadsheet aparece registrado em nWidart', function () {
+    $module = Module::find('Spreadsheet');
+
+    expect($module)->not->toBeNull('Modules/Spreadsheet deveria estar registrado em nWidart');
+    expect($module->getName())->toBe('Spreadsheet');
+});
+
+it('cenário 2: módulo Spreadsheet está ativo (active=1 no module.json)', function () {
+    $module = Module::find('Spreadsheet');
+
+    expect($module)->not->toBeNull();
+    expect($module->isEnabled())->toBeTrue('Spreadsheet deveria estar enabled (active=1)');
+});
+
+it('cenário 3: rota nomeada sheets.index existe (Route::resource auto-name)', function () {
+    expect(\Route::has('sheets.index'))->toBeTrue(
+        'Route::resource(sheets, SpreadsheetController) deveria gerar sheets.index'
+    );
+});
+
+it('cenário 4: rota nomeada sheets.destroy existe (Route::resource auto-name)', function () {
+    expect(\Route::has('sheets.destroy'))->toBeTrue(
+        'Route::resource(sheets) deveria gerar sheets.destroy'
+    );
+});
+
+it('cenário 5: ServiceProvider Spreadsheet está carregado no container Laravel', function () {
+    $providers = app()->getLoadedProviders();
+
+    expect($providers)->toHaveKey(\Modules\Spreadsheet\Providers\SpreadsheetServiceProvider::class);
+});

--- a/Modules/Spreadsheet/Tests/Feature/SmokeRoutesTest.php
+++ b/Modules/Spreadsheet/Tests/Feature/SmokeRoutesTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke test das rotas principais do Modules/Spreadsheet.
+ *
+ * Verifica que o RouteServiceProvider do módulo registra as rotas declaradas
+ * em Modules/Spreadsheet/Routes/web.php sem erro de boot.
+ *
+ * Rotas declaradas (prefix `spreadsheet`):
+ *   - GET    spreadsheet/get-sheet/{id}/share
+ *   - POST   spreadsheet/post-share-sheet
+ *   - Route::resource('sheets') → spreadsheet/sheets.{index,create,store,show,update,destroy}
+ *   - GET    spreadsheet/install
+ *   - POST   spreadsheet/install
+ *   - GET    spreadsheet/install/uninstall
+ *   - GET    spreadsheet/install/update
+ *   - POST   spreadsheet/add-folder
+ *   - POST   spreadsheet/move-to-folder
+ *
+ * @see Modules/Spreadsheet/Routes/web.php
+ */
+
+it('rota nomeada sheets.index existe (Route::resource)', function () {
+    expect(Route::has('sheets.index'))->toBeTrue(
+        'Route::resource(sheets) deveria gerar nome auto sheets.index'
+    );
+});
+
+it('rota nomeada sheets.store existe (Route::resource)', function () {
+    expect(Route::has('sheets.store'))->toBeTrue(
+        'Route::resource(sheets) deveria gerar nome auto sheets.store'
+    );
+});
+
+it('rota nomeada sheets.show existe (Route::resource)', function () {
+    expect(Route::has('sheets.show'))->toBeTrue(
+        'Route::resource(sheets) deveria gerar nome auto sheets.show'
+    );
+});
+
+it('rota GET spreadsheet/install é resolvível pela URL', function () {
+    $route = Route::getRoutes()->match(
+        Illuminate\Http\Request::create('/spreadsheet/install', 'GET')
+    );
+
+    expect($route)->not->toBeNull();
+    expect($route->getActionName())
+        ->toBe('Modules\\Spreadsheet\\Http\\Controllers\\InstallController@index');
+});
+
+it('rota POST spreadsheet/post-share-sheet é resolvível pela URL', function () {
+    $route = Route::getRoutes()->match(
+        Illuminate\Http\Request::create('/spreadsheet/post-share-sheet', 'POST')
+    );
+
+    expect($route)->not->toBeNull();
+    expect($route->getActionName())->toContain('SpreadsheetController');
+    expect($route->getActionName())->toContain('postShareSpreadsheet');
+});

--- a/Modules/Woocommerce/Tests/Feature/MultiTenantIsolationTest.php
+++ b/Modules/Woocommerce/Tests/Feature/MultiTenantIsolationTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Woocommerce\Entities\WoocommerceSyncLog;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Isolamento multi-tenant Tier 0 IRREVOGÁVEL ([ADR 0093]) no módulo Woocommerce.
+ *
+ * Woocommerce é integração externa que armazena:
+ *   - woocommerce_sync_logs (logs de sync produtos/categorias/orders)  → business_id NOT NULL
+ *   - business.woocommerce_api_settings (URL/consumer_key/secret API) → 1 setting por biz
+ *   - business.woocommerce_wh_oc_secret (segredo de webhook order-created/updated)
+ *
+ * Vazamento aqui = token API WooCommerce do biz=1 visível ao biz=99
+ *   → terceiro consegue ler/criar produtos no WooCommerce do cliente errado.
+ *
+ * NUNCA usar biz=4 (ROTA LIVRE — cliente Larissa) — ADR 0101.
+ * Tests usam biz=1 (Wagner WR2) e biz=99 (fictício isolamento).
+ *
+ * NOTA: WoocommerceSyncLog NÃO tem BusinessScope global hoje (Entity é Model puro,
+ * `protected $guarded = ['id']`). Tests aqui validam isolamento por filtro EXPLÍCITO
+ * `where('business_id', X)` — pattern usado pelo WoocommerceController:
+ *   `WoocommerceSyncLog::where('business_id', $business_id)->...`
+ *
+ * Se futuramente adicionarem BusinessScope (recomendado), basta remover o filtro
+ * explícito dos tests "scope" abaixo.
+ *
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ */
+
+const WC_BIZ_WAGNER = 1;
+const WC_BIZ_FICTICIO = 99;
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: Woocommerce + UltimatePOS schema requerem MySQL (ADR 0101)');
+    }
+    if (! Schema::hasTable('woocommerce_sync_logs') || ! Schema::hasTable('business')) {
+        $this->markTestSkipped('Schema Woocommerce/UltimatePOS incompleto — rode migrate primeiro');
+    }
+});
+
+// ------------------------------------------------------------------
+// WoocommerceSyncLog — isolamento por filtro explícito business_id
+// ------------------------------------------------------------------
+
+it('WoocommerceSyncLog biz=1 NÃO vaza pra filtro business_id=99', function () {
+    // Seed: log de sync no biz=1
+    $logId = DB::table('woocommerce_sync_logs')->insertGetId([
+        'business_id'    => WC_BIZ_WAGNER,
+        'sync_type'      => 'products',
+        'operation_type' => 'created',
+        'data'           => json_encode(['wc_product_id' => 12345]),
+        'details'        => json_encode(['test' => 'WC-ISOLATION-' . uniqid()]),
+        'created_by'     => 1,
+        'created_at'     => now(),
+        'updated_at'     => now(),
+    ]);
+
+    try {
+        // Query do Controller (real): filtro explícito por business_id
+        $vazado = WoocommerceSyncLog::where('business_id', WC_BIZ_FICTICIO)
+            ->where('id', $logId)
+            ->get();
+
+        expect($vazado)->toHaveCount(0, 'VAZAMENTO TIER 0: sync_log biz=1 visível com filtro biz=99!');
+    } finally {
+        DB::table('woocommerce_sync_logs')->where('id', $logId)->delete(); // SUPERADMIN: cleanup
+    }
+});
+
+it('WoocommerceSyncLog biz=1 aparece com filtro business_id=1', function () {
+    $sentinel = 'WC-AUTO-' . uniqid();
+    $logId = DB::table('woocommerce_sync_logs')->insertGetId([
+        'business_id'    => WC_BIZ_WAGNER,
+        'sync_type'      => 'categories',
+        'operation_type' => 'updated',
+        'data'           => json_encode(['marker' => $sentinel]),
+        'details'        => null,
+        'created_by'     => 1,
+        'created_at'     => now(),
+        'updated_at'     => now(),
+    ]);
+
+    try {
+        $found = WoocommerceSyncLog::where('business_id', WC_BIZ_WAGNER)
+            ->where('id', $logId)
+            ->first();
+
+        expect($found)->not->toBeNull('sync_log biz=1 deveria aparecer com filtro biz=1');
+        expect((int) $found->business_id)->toBe(WC_BIZ_WAGNER);
+        expect($found->sync_type)->toBe('categories');
+    } finally {
+        DB::table('woocommerce_sync_logs')->where('id', $logId)->delete(); // SUPERADMIN: cleanup
+    }
+});
+
+// ------------------------------------------------------------------
+// API settings WooCommerce — segredo NÃO vaza entre business
+// ------------------------------------------------------------------
+
+it('woocommerce_api_settings do biz=1 NÃO aparece em SELECT do biz=99', function () {
+    if (! Schema::hasColumn('business', 'woocommerce_api_settings')) {
+        $this->markTestSkipped('coluna woocommerce_api_settings ausente — rode migrations Woocommerce');
+    }
+
+    $businessExists = DB::table('business')->where('id', WC_BIZ_WAGNER)->exists();
+    if (! $businessExists) {
+        $this->markTestSkipped('business id=1 não existe no DB de teste');
+    }
+
+    // Snapshot original — restaura no finally pra não poluir DB compartilhado
+    $original = DB::table('business')->where('id', WC_BIZ_WAGNER)->value('woocommerce_api_settings');
+
+    $tokenFake = 'WC-FAKE-TOKEN-' . uniqid();
+    DB::table('business')->where('id', WC_BIZ_WAGNER)->update([
+        'woocommerce_api_settings' => json_encode([
+            'woocommerce_app_url'        => 'https://exemplo.test',
+            'woocommerce_consumer_key'   => $tokenFake,
+            'woocommerce_consumer_secret' => 'SECRET-FAKE-' . uniqid(),
+        ]),
+    ]);
+
+    try {
+        // Pattern real WoocommerceUtil::get_api_settings($business_id) — filtra por id
+        $bizOutroTenant = DB::table('business')
+            ->where('id', WC_BIZ_FICTICIO)
+            ->value('woocommerce_api_settings');
+
+        // biz=99 NÃO deve trazer o settings do biz=1 (ou não existe, ou tem outro valor)
+        if ($bizOutroTenant !== null) {
+            expect($bizOutroTenant)->not->toContain($tokenFake, 'VAZAMENTO TIER 0: token API biz=1 visível no settings do biz=99!');
+        } else {
+            expect($bizOutroTenant)->toBeNull();
+        }
+    } finally {
+        DB::table('business')->where('id', WC_BIZ_WAGNER)->update([
+            'woocommerce_api_settings' => $original,
+        ]);
+    }
+});
+
+it('woocommerce_wh_oc_secret do biz=1 NÃO é igual ao do biz=99', function () {
+    if (! Schema::hasColumn('business', 'woocommerce_wh_oc_secret')) {
+        $this->markTestSkipped('coluna woocommerce_wh_oc_secret ausente — rode migrations Woocommerce');
+    }
+
+    $secretBiz1 = DB::table('business')->where('id', WC_BIZ_WAGNER)->value('woocommerce_wh_oc_secret');
+    $secretBiz99 = DB::table('business')->where('id', WC_BIZ_FICTICIO)->value('woocommerce_wh_oc_secret');
+
+    // Se ambos existem e são iguais E não vazios → assinatura webhook seria intercambiável.
+    if (! empty($secretBiz1) && ! empty($secretBiz99)) {
+        expect($secretBiz1)->not->toBe($secretBiz99,
+            'VAZAMENTO TIER 0: webhook secret idêntico entre biz=1 e biz=99 — webhook de um biz dispararia order do outro!');
+    } else {
+        // Caso default — pelo menos um é null/vazio, isolamento OK por ausência
+        expect(true)->toBeTrue();
+    }
+});
+
+// ------------------------------------------------------------------
+// Sanity — bypass com withoutGlobalScopes ainda exige filtro consciente
+// ------------------------------------------------------------------
+
+it('seed biz=1 + filtro biz=99 retorna zero registros mesmo sem global scope', function () {
+    // Insere 2 logs: 1 em cada biz, mesmo sync_type, mesma janela temporal
+    $marker = 'WC-CROSS-' . uniqid();
+
+    $idBiz1 = DB::table('woocommerce_sync_logs')->insertGetId([
+        'business_id'    => WC_BIZ_WAGNER,
+        'sync_type'      => 'orders',
+        'operation_type' => 'created',
+        'data'           => json_encode(['marker' => $marker]),
+        'details'        => null,
+        'created_by'     => 1,
+        'created_at'     => now(),
+        'updated_at'     => now(),
+    ]);
+
+    $idBiz99 = DB::table('woocommerce_sync_logs')->insertGetId([
+        'business_id'    => WC_BIZ_FICTICIO,
+        'sync_type'      => 'orders',
+        'operation_type' => 'created',
+        'data'           => json_encode(['marker' => $marker]),
+        'details'        => null,
+        'created_by'     => 1,
+        'created_at'     => now(),
+        'updated_at'     => now(),
+    ]);
+
+    try {
+        // Filtro real do Controller — deve cada biz ver apenas o próprio
+        $countBiz1 = WoocommerceSyncLog::where('business_id', WC_BIZ_WAGNER)
+            ->where('data', 'like', '%' . $marker . '%')
+            ->count();
+
+        $countBiz99 = WoocommerceSyncLog::where('business_id', WC_BIZ_FICTICIO)
+            ->where('data', 'like', '%' . $marker . '%')
+            ->count();
+
+        expect($countBiz1)->toBe(1, 'biz=1 deveria ver exatamente 1 log próprio');
+        expect($countBiz99)->toBe(1, 'biz=99 deveria ver exatamente 1 log próprio (não 2)');
+    } finally {
+        DB::table('woocommerce_sync_logs')->whereIn('id', [$idBiz1, $idBiz99])->delete(); // SUPERADMIN: cleanup
+    }
+});

--- a/Modules/Woocommerce/Tests/Feature/ScaffoldTest.php
+++ b/Modules/Woocommerce/Tests/Feature/ScaffoldTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+use Nwidart\Modules\Facades\Module;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke do scaffold Modules/Woocommerce.
+ *
+ * Garante que:
+ *   1. Módulo aparece registrado em nWidart
+ *   2. ServiceProvider carrega sem erro
+ *   3. Entity WoocommerceSyncLog é resolvable e aponta pra tabela correta
+ *   4. Rotas web e webhook foram registradas (URI matching, já que módulo
+ *      legacy não usa `->name(...)` em todas as rotas)
+ *
+ * Refs: ADR 0011 padrão Jana/Repair/Project · skill criar-modulo
+ */
+
+it('módulo Woocommerce aparece registrado em nWidart', function () {
+    $module = Module::find('Woocommerce');
+
+    expect($module)->not->toBeNull('Modules/Woocommerce deveria estar registrado em nWidart');
+    expect($module->getName())->toBe('Woocommerce');
+});
+
+it('módulo Woocommerce está ativo (module.json active=1)', function () {
+    $module = Module::find('Woocommerce');
+
+    expect($module)->not->toBeNull();
+    expect($module->isEnabled())->toBeTrue('Modules/Woocommerce deveria estar enabled');
+});
+
+it('Entity WoocommerceSyncLog resolve e aponta pra tabela woocommerce_sync_logs', function () {
+    $model = new \Modules\Woocommerce\Entities\WoocommerceSyncLog;
+
+    expect($model->getTable())->toBe('woocommerce_sync_logs');
+});
+
+it('rota webhook order-created registrada por URI', function () {
+    $routes = collect(\Route::getRoutes()->getRoutes())
+        ->map(fn ($r) => $r->uri())
+        ->values();
+
+    expect($routes->contains('webhook/order-created/{business_id}'))->toBeTrue(
+        'Rota POST /webhook/order-created/{business_id} deveria existir em Routes/web.php'
+    );
+});
+
+it('rota /woocommerce index registrada por URI', function () {
+    $routes = collect(\Route::getRoutes()->getRoutes())
+        ->map(fn ($r) => $r->uri())
+        ->values();
+
+    expect($routes->contains('woocommerce'))->toBeTrue(
+        'Rota GET /woocommerce deveria existir em Routes/web.php'
+    );
+});
+
+it('rota /woocommerce/install registrada por URI', function () {
+    $routes = collect(\Route::getRoutes()->getRoutes())
+        ->map(fn ($r) => $r->uri())
+        ->values();
+
+    expect($routes->contains('woocommerce/install'))->toBeTrue(
+        'Rota /woocommerce/install deveria existir (InstallController)'
+    );
+});
+
+it('rota /woocommerce/sync-products registrada por URI', function () {
+    $routes = collect(\Route::getRoutes()->getRoutes())
+        ->map(fn ($r) => $r->uri())
+        ->values();
+
+    expect($routes->contains('woocommerce/sync-products'))->toBeTrue(
+        'Rota /woocommerce/sync-products deveria existir'
+    );
+});
+
+it('Controllers principais resolvem via container', function () {
+    expect(class_exists(\Modules\Woocommerce\Http\Controllers\WoocommerceController::class))->toBeTrue();
+    expect(class_exists(\Modules\Woocommerce\Http\Controllers\WoocommerceWebhookController::class))->toBeTrue();
+    expect(class_exists(\Modules\Woocommerce\Http\Controllers\InstallController::class))->toBeTrue();
+    expect(class_exists(\Modules\Woocommerce\Http\Controllers\DataController::class))->toBeTrue();
+});

--- a/Modules/Woocommerce/Tests/Feature/SmokeRoutesTest.php
+++ b/Modules/Woocommerce/Tests/Feature/SmokeRoutesTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke das rotas principais Modules/Woocommerce.
+ *
+ * Garante que rotas registradas em Routes/web.php e Routes/api.php existem
+ * e respondem com middleware esperado (não 500, não rota faltando).
+ *
+ * Rotas web exigem stack `web, SetSessionData, auth, language, timezone, AdminSidebarMenu`.
+ * Sem auth → redirect 302 pra login (NUNCA 500/404).
+ *
+ * Webhooks (sem auth) — pegam `business_id` na URL e validam HMAC do payload.
+ * Sem secret/payload válido → emergency log + resposta controlada (nunca 500 cru).
+ *
+ * NÃO usa token WooCommerce real — só smoke de roteamento + middleware.
+ *
+ * @see Modules/Woocommerce/Routes/web.php
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+
+it('rota GET /woocommerce existe e exige auth (302 redirect, não 500)', function () {
+    $response = $this->get('/woocommerce');
+
+    // Sem auth → redirect login. Crítico que NÃO seja 500 (controller boot quebrado)
+    // nem 404 (rota não registrada).
+    expect($response->status())->toBeIn([302, 401, 403]);
+});
+
+it('rota GET /woocommerce/api-settings existe e exige auth', function () {
+    $response = $this->get('/woocommerce/api-settings');
+
+    expect($response->status())->toBeIn([302, 401, 403]);
+});
+
+it('rota GET /woocommerce/sync-products existe e exige auth', function () {
+    $response = $this->get('/woocommerce/sync-products');
+
+    expect($response->status())->toBeIn([302, 401, 403]);
+});
+
+it('rota GET /woocommerce/install existe e exige auth', function () {
+    $response = $this->get('/woocommerce/install');
+
+    expect($response->status())->toBeIn([302, 401, 403]);
+});
+
+it('webhook POST /webhook/order-created/{biz} aceita request (não 404)', function () {
+    // Webhook NÃO usa auth (valida HMAC). Smoke: rota responde algo controlado.
+    // Sem secret/payload correto → controller loga emergência mas não crasha 500.
+    $response = $this->post('/webhook/order-created/1', [], [
+        'X-WC-Webhook-Signature' => 'fake-signature-smoke-test',
+    ]);
+
+    // Aceitar 200 (controller engoliu mismatch e logou) ou 4xx/5xx-controlado.
+    // O que NÃO pode é 404 (rota não registrada).
+    expect($response->status())->not->toBe(404);
+});
+
+it('webhook POST /webhook/order-updated/{biz} aceita request (não 404)', function () {
+    $response = $this->post('/webhook/order-updated/1', [], [
+        'X-WC-Webhook-Signature' => 'fake-sig-smoke',
+    ]);
+
+    expect($response->status())->not->toBe(404);
+});
+
+it('GET /woocommerce/sync-categories existe e exige auth', function () {
+    $response = $this->get('/woocommerce/sync-categories');
+
+    expect($response->status())->toBeIn([302, 401, 403]);
+});
+
+it('GET /woocommerce/view-sync-log existe e exige auth', function () {
+    $response = $this->get('/woocommerce/view-sync-log');
+
+    expect($response->status())->toBeIn([302, 401, 403]);
+});

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -42,6 +42,14 @@
             <directory>./Modules/Accounting/Tests/Feature</directory>
             <directory>./Modules/Superadmin/Tests/Feature</directory>
             <directory>./Modules/Officeimpresso/Tests/Feature</directory>
+            <directory>./Modules/SRS/Tests/Feature</directory>
+            <directory>./Modules/AssetManagement/Tests/Feature</directory>
+            <directory>./Modules/Governance/Tests/Feature</directory>
+            <directory>./Modules/Spreadsheet/Tests/Feature</directory>
+            <directory>./Modules/ProductCatalogue/Tests/Feature</directory>
+            <directory>./Modules/ConsultaOs/Tests/Feature</directory>
+            <directory>./Modules/Brief/Tests/Feature</directory>
+            <directory>./Modules/Woocommerce/Tests/Feature</directory>
         </testsuite>
     </testsuites>
     <source>


### PR DESCRIPTION
Continuação de #946 (fechado quando Wave A foi mergeada — base ficou órfã). Conteúdo idêntico — cherry-pick do commit 019e0b73f.

## Resumo
- 24 arquivos Pest novos / 120 testes / 122 assertions
- SQLite local: 79 passed / 41 skipped / **0 failed**
- phpunit.xml +8 paths (SRS/AssetManagement/Governance/Spreadsheet/ProductCatalogue/ConsultaOs/Brief/Woocommerce)

Detalhes completos no commit message. Refs ADR 0093, ADR 0101, ADR 0094.