### PR TITLE
hotfix(governance): rollback Inertia::defer em 4 Controllers — Pages crashavam com undefined props

### DIFF
--- a/Modules/Governance/Http/Controllers/AuditController.php
+++ b/Modules/Governance/Http/Controllers/AuditController.php
@@ -42,13 +42,12 @@ class AuditController extends Controller
             'status'   => $status,
         ];
 
-        // Inertia::defer pra props com queries DB (skill inertia-defer-default).
-        // Filters UI state eager — usado pra estado dos selects/inputs.
+        // ROLLBACK Wave W7 #953: Inertia::defer quebrava Pages que esperam props eager.
         return Inertia::render('governance/Audit', [
-            'entries'             => Inertia::defer(fn () => $this->buildEntriesPayload($filterPayload)),
-            'kpis'                => Inertia::defer(fn () => $this->buildKpisPayload($filterPayload)),
-            'available_endpoints' => Inertia::defer(fn () => $this->service->availableEndpoints()),
-            'available_actors'    => Inertia::defer(fn () => $this->service->availableActors()),
+            'entries'             => $this->buildEntriesPayload($filterPayload),
+            'kpis'                => $this->buildKpisPayload($filterPayload),
+            'available_endpoints' => $this->service->availableEndpoints(),
+            'available_actors'    => $this->service->availableActors(),
             'filters'             => $filterPayload,
         ]);
     }

--- a/Modules/Governance/Http/Controllers/DashboardController.php
+++ b/Modules/Governance/Http/Controllers/DashboardController.php
@@ -44,14 +44,16 @@ class DashboardController extends Controller
         // Eager: trivial (escalar estático sem I/O).
         $compliancePct = (7 * 10) + (2 * 5) + 0; // = 80
 
-        // Inertia::defer pra props com queries DB (skill inertia-defer-default).
-        // Pages frontend wrap em <Deferred data="..." fallback={skeleton}> pra SPA-feel.
+        // ROLLBACK Wave W7 #953: Inertia::defer quebrava Pages que esperam props eager.
+        // Pages frontend não foram atualizadas com <Deferred> wrapper — kpis undefined crashava.
+        // Restaurado eager até Pages serem refatoradas (issue follow-up Wave W7).
+        $health = $this->saudeEcosistema();
         return Inertia::render('governance/Dashboard', [
-            'kpis'              => Inertia::defer(fn () => $this->buildKpisPayload()),
-            'pending_adrs'      => Inertia::defer(fn () => $this->buildPendingAdrsPayload()),
-            'audit_highlights'  => Inertia::defer(fn () => $this->buildAuditHighlightsPayload()),
-            'health_kpis'       => Inertia::defer(fn () => $this->saudeEcosistema()['kpis']),
-            'narratives'        => Inertia::defer(fn () => $this->saudeEcosistema()['narratives']),
+            'kpis'              => $this->buildKpisPayload(),
+            'pending_adrs'      => $this->buildPendingAdrsPayload(),
+            'audit_highlights'  => $this->buildAuditHighlightsPayload(),
+            'health_kpis'       => $health['kpis'],
+            'narratives'        => $health['narratives'],
             // Configs estáticas — eager (zero I/O).
             'actiongate_mode'   => config('governance.actiongate_mode', 'warn'),
             'next_review_at'    => config('governance.next_review_at'),

--- a/Modules/Governance/Http/Controllers/DriftAlertsController.php
+++ b/Modules/Governance/Http/Controllers/DriftAlertsController.php
@@ -33,13 +33,13 @@ class DriftAlertsController extends Controller
 
     public function index(Request $request): Response
     {
-        // Inertia::defer pra props com filesystem scan (slow — N módulos × parse YAML)
-        // + DB query (persistedAlerts) — skill inertia-defer-default.
+        // ROLLBACK Wave W7 #953: Inertia::defer quebrava Pages que esperam props eager.
+        $drifts = $this->buildDriftsPayload();
         return Inertia::render('governance/DriftAlerts', [
-            'kpis'                  => Inertia::defer(fn () => $this->buildKpisPayload()),
-            'report'                => Inertia::defer(fn () => $this->buildDriftsPayload()->get('report', [])),
-            'modules_without_scope' => Inertia::defer(fn () => $this->buildDriftsPayload()->get('modules_without_scope', [])),
-            'persisted_alerts'      => Inertia::defer(fn () => $this->service->persistedAlerts()),
+            'kpis'                  => $this->buildKpisPayload(),
+            'report'                => $drifts->get('report', []),
+            'modules_without_scope' => $drifts->get('modules_without_scope', []),
+            'persisted_alerts'      => $this->service->persistedAlerts(),
         ]);
     }
 

--- a/Modules/Governance/Http/Controllers/PoliciesController.php
+++ b/Modules/Governance/Http/Controllers/PoliciesController.php
@@ -34,10 +34,10 @@ class PoliciesController extends Controller
 
     public function index(Request $request): Response
     {
-        // Inertia::defer pra props com query DB (skill inertia-defer-default).
+        // ROLLBACK Wave W7 #953: Inertia::defer quebrava Pages que esperam props eager.
         return Inertia::render('governance/Policies', [
-            'rules_by_category' => Inertia::defer(fn () => $this->buildRulesByCategoryPayload()),
-            'kpis'              => Inertia::defer(fn () => $this->buildKpisPayload()),
+            'rules_by_category' => $this->buildRulesByCategoryPayload(),
+            'kpis'              => $this->buildKpisPayload(),
         ]);
     }
 


### PR DESCRIPTION
INCIDENTE: /governance + audit + drift + policies tela branca. CAUSA: Wave W7 fez Inertia::defer mas Pages não foram atualizadas pra <Deferred>. FIX: rollback defer wrapping (Service extracts preservados). Follow-up: refactor Pages.