### PR TITLE
feat(cockpit): Sidebar rail mode + cores hue por grupo (canon Cowork)

### DIFF
--- a/memory/requisitos/_DesignSystem/sidebar-rail-mode-visual-comparison.md
+++ b/memory/requisitos/_DesignSystem/sidebar-rail-mode-visual-comparison.md
@@ -1,0 +1,69 @@
+# Sidebar — rail mode + cores por grupo (visual-comparison)
+
+**Tela:** Layout global `AppShellV2` (sidebar global do ERP)
+**Fonte canônica visual:** `prototipo-ui/_cowork-export-2026-05-15/sidebar.jsx` + `styles.css` (linhas 5039-5350) + `data.jsx` (`GROUP_META`)
+**Gate F1.5 MWART:** [ADR 0104](../../decisions/0104-processo-mwart-canonico-unico-caminho.md) + [ADR 0114](../../decisions/0114-prototipo-ui-cowork-loop-formalizado.md)
+**Aprovação screenshot Wagner:** AskUserQuestion 2026-05-16 — "Escopo completo (recomendado)"
+**Skip design-critique:** Wagner aprovou (protótipo veio do loop Cowork formal, já sancionado)
+
+## Capacidades novas a portar
+
+| # | Capacidade | Spec protótipo | Decisão portabilidade |
+|---|---|---|---|
+| 1 | Modo `rail` (~56px ícone-only) | `sidebar.jsx:407-440` prop `mode` + variante `SidebarMenuRail` com tooltip `data-tip` + flyout posicionado | Adicionar prop `mode` em `<SidebarMenu>` + novo componente `<SidebarMenuRail>` |
+| 2 | Alça `.sb-collapse-handle` borda direita | `sidebar.jsx:427-437` botão 20×36px, chevron `‹`/`›`, `opacity 0→1` em `.sb:hover`, atalho ⌘\\ | Adicionar dentro do `<aside className="sb">` em AppShellV2 |
+| 3 | Alça flutuante `.sb-reopen-handle` (sidebar oculta) | `sidebar.jsx:443-455` botão fixed left:0, expande no hover | Renderizar condicionalmente quando `mode === 'hidden'` (Fase 2 — agora só rail/expanded) |
+| 4 | Cor por grupo (hue OKLCH) | `data.jsx:334` `GROUP_META` 10 hues; `sidebar.jsx:170-200` aplica `oklch(0.62 0.13 var(--gh))` no dot + `oklch(0.46 0.10 var(--gh))` no label | Adicionar `SIDEBAR_GROUP_HUE: Record<groupKey, number>` em shared.ts + CSS var `--gh` por grupo |
+| 5 | Persist `mode` em LS | `localStorage.oimpresso.menu.expanded` (já existe) + novo `oimpresso.sb.mode` | Adicionar `LS.SB_MODE` em shared.ts |
+
+## Paleta hue por grupo (mapeamento Cowork → SIDEBAR_GROUPS atual)
+
+Cowork `GROUP_META` tem 10 grupos com hue. AppShellV2 hoje tem 11 grupos. Mapeamento canônico:
+
+| AppShellV2 `groupKey` | Label atual | Hue (OKLCH) | Cor visual |
+|---|---|---|---|
+| `office` | ACESSOS RÁPIDOS | 60 | amarelo-ouro |
+| `oficina` | OFICINA AUTO | 350 | rosa/vermelho (vertical) |
+| `fin` | FINANCEIRO | 145 | verde |
+| `estoque` | ESTOQUE | 30 | laranja (Produção/estoque) |
+| `fiscal` | FISCAL | 200 | ciano (Integrações/fiscal SEFAZ) |
+| `rh` | RH | 295 | roxo (Pessoas) |
+| `conhecimento` | CONHECIMENTO | 80 | verde-oliva (Outros/KB) |
+| `rel` | RELATÓRIOS | 240 | azul-escuro (Gestão) |
+| `ia` | IA & PRODUTIVIDADE | 220 | azul (Comercial/IA pareada) |
+| `governanca` | GOVERNANÇA | 270 | violeta (Config./Admin) |
+| `plataforma` | PLATAFORMA | 200 | ciano (Integrações) |
+| `mais` | MAIS | — | sem cor (fallback neutro) |
+
+## Trade-offs decididos
+
+- **Modo `hidden` (sidebar 0px) fica fora desta entrega.** Protótipo prevê via `SidebarReopenHandle`, mas não é prioridade — adicionar em PR seguinte se Wagner pedir.
+- **Atalho ⌘\\ adicionado** mas conflito com `Cmd+K` da Command Palette inexistente (paleta usa `K`, alça usa `\\`).
+- **Tooltip `data-tip` puro CSS** (sem lib) — segue protótipo Cowork.
+- **CSS vars `--gh` injetadas inline por grupo** via `style={{ ['--gh']: hue }}` no `<div className="sb-group">` (mesmo padrão protótipo).
+- **Persist por grupo (`oimpresso.cockpit.group.${key}.expanded`) preservado** — só o `mode` é novo LS key.
+
+## Anti-padrões evitados
+
+- ❌ Não duplicar `SIDEBAR_GROUPS` em outro arquivo — hue vira `Record<groupKey, number>` separado em shared.ts, paralelo ao array existente em Sidebar.tsx.
+- ❌ Não mudar API pública de `<AppShellV2>` — nova prop `defaultSidebarMode?: 'expanded' | 'rail'` é opcional, default `expanded`.
+- ❌ Não trocar `lucide-react` por SVG inline — segue padrão Cockpit V2 atual.
+- ❌ Não rebatizar grupos pra refletir labels Cowork (`Operação`, `Comercial` etc) — `SIDEBAR_GROUPS` é canônico do shell real (US-WA-082+083); cores só ressaltam visualmente.
+
+## Estimativa
+
+| Arquivo | Linhas adicionadas | Tipo |
+|---|---|---|
+| `shared.ts` | +30 | LS key + GROUP_HUE map |
+| `Sidebar.tsx` | +130 | SidebarMenuRail + cores no SidebarGroup |
+| `AppShellV2.tsx` | +60 | mode state + alça + atalho ⌘\\ |
+| `cockpit.css` | +220 | rail mode + cores hue |
+| `sidebar-rail-mode-visual-comparison.md` | +80 | este doc |
+| **TOTAL** | **~520** | Ultrapassa o limite ≤300 linhas (ADR 0094) mas é 1 intent única (sidebar canônico portado), justificado em PR description. |
+
+## Pós-merge
+
+- Smoke biz=1 manual: `/dashboard` → click alça colapsa → click ícone grupo → flyout abre → click sub-item navega.
+- LS persistido entre navegações (refresh F5 mantém modo).
+- Acessibilidade: alça tem `aria-label`, atalho ⌘\\ no `title`.
+- Cores: Larissa (cliente piloto monitor 1280px) — confirmar contraste OKLCH 0.46/0.10/hue passa AA contra `var(--sb-bg)` (light/dark).

--- a/resources/css/cockpit.css
+++ b/resources/css/cockpit.css
@@ -115,7 +115,13 @@
   text-rendering: optimizeLegibility;
 }
 .cockpit[data-linked="off"] { grid-template-columns: 260px 1fr 0; }
-@media (max-width: 1280px) { .cockpit { grid-template-columns: 260px 1fr 0; } }.cockpit .main {
+/* Sidebar rail (56px) — Wagner 2026-05-16, espelha prototipo Cowork. */
+.cockpit[data-sidebar="rail"] { grid-template-columns: 56px 1fr 320px; }
+.cockpit[data-sidebar="rail"][data-linked="off"] { grid-template-columns: 56px 1fr 0; }
+@media (max-width: 1280px) {
+  .cockpit { grid-template-columns: 260px 1fr 0; }
+  .cockpit[data-sidebar="rail"] { grid-template-columns: 56px 1fr 0; }
+}.cockpit .main {
   display: grid;
   /* 3 rows: topbar (44px) + topnav-module opcional (auto, ~40px quando presente) + main-body (1fr).
      Antes era `44px 1fr` — quando o topnav-module foi adicionado (Wagner 2026-05-07
@@ -1982,4 +1988,256 @@
 .cockpit .tk-detail-body .empty { text-align: center; color: var(--text-mute); padding: 32px; font-size: 12.5px; }
 @media (max-width: 1023px) {
   .cockpit .tk-page { grid-template-columns: 1fr; }
+}
+
+/* ════════════════════════════════════════════════════════════════════════
+   SIDEBAR RAIL MODE + GROUP COLORS — Wagner 2026-05-16
+   Espelha prototipo Cowork _cowork-export-2026-05-15/sidebar.jsx + styles.css
+   (linhas 5039-5350). 5 capacidades portadas:
+     1. Modo rail (56px ícone-only) + flyout grupo
+     2. Alça .sb-collapse-handle borda direita on-hover
+     3. (placeholder modo hidden — Fase 2)
+     4. Cor por grupo (hue OKLCH) via CSS var --gh
+     5. Persistência LS oimpresso.sb.mode (gerenciado em AppShellV2)
+   ════════════════════════════════════════════════════════════════════════ */
+
+.cockpit .sb { position: relative; overflow: visible; }
+
+/* ── Alça de colapsar/expandir (borda direita) ─────────────────────────── */
+.cockpit .sb-collapse-handle {
+  position: absolute;
+  top: 50%;
+  right: -10px;
+  transform: translateY(-50%);
+  width: 20px;
+  height: 36px;
+  border-radius: 4px;
+  border: 1px solid var(--sb-border);
+  background: var(--sb-bg);
+  color: var(--sb-text-dim);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  z-index: 30;
+  opacity: 0;
+  transition: opacity 120ms, color 120ms, background 120ms;
+  padding: 0;
+}
+.cockpit .sb:hover .sb-collapse-handle,
+.cockpit .sb-collapse-handle:focus-visible,
+.cockpit .sb-collapse-handle:hover {
+  opacity: 1;
+}
+.cockpit .sb-collapse-handle:hover {
+  background: var(--sb-active);
+  color: var(--sb-text-hi);
+}
+
+/* ── Cores por grupo (CSS var --gh) ────────────────────────────────────── */
+.cockpit .sb-group-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: oklch(0.62 0.13 var(--gh, 220));
+  flex-shrink: 0;
+  opacity: 0.85;
+  display: inline-block;
+}
+.cockpit[data-theme="dark"] .sb-group-dot {
+  background: oklch(0.68 0.13 var(--gh, 220));
+}
+.cockpit .sb-group[style*="--gh"] .sb-group-h .sb-group-l {
+  color: oklch(0.46 0.10 var(--gh, 220));
+}
+.cockpit[data-theme="dark"] .sb-group[style*="--gh"] .sb-group-h .sb-group-l {
+  color: oklch(0.78 0.08 var(--gh, 220));
+}
+
+/* ── Modo RAIL (56px ícone-only) ───────────────────────────────────────── */
+.cockpit .sb--rail { overflow: visible; }
+.cockpit .sb--rail .sb-top {
+  padding: 8px 8px 6px;
+  display: grid;
+  place-items: center;
+}
+.cockpit .sb--rail .sb-cp-btn .name,
+.cockpit .sb--rail .sb-cp-btn .chev {
+  display: none;
+}
+.cockpit .sb--rail .sb-cp-btn {
+  padding: 4px;
+  background: transparent;
+  width: 40px;
+  height: 40px;
+  display: grid;
+  place-items: center;
+}
+.cockpit .sb--rail .sb-cp-btn .avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  font-size: 11px;
+}
+/* Dropdown empresa quando em rail: abre à direita */
+.cockpit .sb--rail .sb-dd {
+  left: calc(100% + 8px);
+  top: 0;
+  right: auto;
+  width: 220px;
+  z-index: 50;
+}
+
+.cockpit .sb--rail .sb-body { padding: 4px 0; }
+
+.cockpit .sb-menu-rail {
+  padding: 4px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+.cockpit .sb-rail-sep {
+  width: 24px;
+  height: 1px;
+  background: var(--sb-border);
+  margin: 6px 0;
+  opacity: 0.6;
+}
+.cockpit .sb-rail-btn {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--sb-text);
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  position: relative;
+  padding: 0;
+  text-decoration: none;
+  transition: background 100ms, color 100ms;
+}
+.cockpit .sb-rail-btn:hover {
+  background: var(--sb-hover);
+  color: var(--sb-text-hi);
+}
+.cockpit .sb-rail-btn.open {
+  background: var(--sb-active);
+  color: var(--sb-text-hi);
+}
+.cockpit .sb-rail-btn .ic {
+  width: 18px;
+  height: 18px;
+  opacity: 0.9;
+}
+.cockpit .sb-rail-btn.open .ic { opacity: 1; }
+.cockpit .sb-rail-btn.sb-rail-group .ic {
+  color: oklch(0.62 0.13 var(--gh, 220));
+}
+.cockpit[data-theme="dark"] .sb-rail-btn.sb-rail-group .ic {
+  color: oklch(0.72 0.13 var(--gh, 220));
+}
+
+/* Badge indicador (sb-shortcut rail) — bolinha laranja no canto */
+.cockpit .sb-rail-dot-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: oklch(0.62 0.18 30);
+  box-shadow: 0 0 0 2px var(--sb-bg);
+}
+
+/* Tooltip via data-tip (somente no rail, hover ~600ms) */
+.cockpit .sb--rail [data-tip] { position: relative; }
+.cockpit .sb--rail [data-tip]::after {
+  content: attr(data-tip);
+  position: absolute;
+  left: calc(100% + 8px);
+  top: 50%;
+  transform: translateY(-50%);
+  padding: 4px 8px;
+  background: var(--sb-bg-2);
+  color: var(--sb-text-hi);
+  border: 1px solid var(--sb-border);
+  border-radius: 4px;
+  font-size: 11.5px;
+  font-weight: 500;
+  white-space: nowrap;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity 120ms 400ms;
+  z-index: 60;
+}
+.cockpit .sb--rail [data-tip]:hover::after {
+  opacity: 1;
+  transition-delay: 0ms;
+}
+/* Não exibir tooltip quando flyout do mesmo botão está aberto */
+.cockpit .sb--rail .sb-rail-btn.open[data-tip]::after { opacity: 0; }
+
+/* Flyout do grupo (cascata lateral quando clica no botão rail) */
+.cockpit .sb-rail-flyout {
+  min-width: 220px;
+  background: var(--sb-bg-2);
+  border: 1px solid var(--sb-border);
+  border-radius: 6px;
+  padding: 6px;
+  box-shadow: 0 8px 24px oklch(0 0 0 / 0.18);
+  z-index: 55;
+}
+.cockpit .sb-rail-flyout-h {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 6px 6px;
+  border-bottom: 1px solid var(--sb-border);
+  margin-bottom: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+.cockpit .sb-rail-flyout-l {
+  flex: 1 1 auto;
+  color: oklch(0.46 0.10 var(--gh, 220));
+}
+.cockpit[data-theme="dark"] .sb-rail-flyout-l {
+  color: oklch(0.78 0.08 var(--gh, 220));
+}
+.cockpit .sb-rail-flyout .sb-group-n {
+  font-size: 9.5px;
+  font-family: var(--mono, ui-monospace, monospace);
+  color: var(--text-mute, var(--sb-text-dim));
+  font-weight: 500;
+}
+
+/* ── Footer (user) em rail: só avatar ──────────────────────────────────── */
+.cockpit .sb--rail .sb-user-btn .who,
+.cockpit .sb--rail .sb-user-btn > svg {
+  display: none;
+}
+.cockpit .sb--rail .sb-user-btn {
+  padding: 6px;
+  background: transparent;
+  width: 40px;
+  height: 40px;
+  margin: 0 auto;
+  display: grid;
+  place-items: center;
+}
+.cockpit .sb--rail .sb-user-btn .avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  font-size: 11px;
+}
+.cockpit .sb--rail .sb-user-wrap {
+  padding: 8px;
+  display: grid;
+  place-items: center;
 }

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -85,6 +85,8 @@ import {
   BusinessOpt,
   LS,
   ShellMenuItem,
+  SIDEBAR_GROUP_HUE,
+  SidebarMode,
   gradientFor,
   isSuperadminMenu,
   isUserMenuItem,
@@ -394,12 +396,17 @@ function SidebarGroup({
     localStorage.setItem(lsKey, expanded ? '1' : '0');
   }, [expanded, lsKey]);
 
+  // Hue OKLCH por grupo (canon Cowork) — aplica no dot + label header.
+  // Items não mapeados (ex. 'mais') ficam neutros (sem var --gh).
+  const hue = SIDEBAR_GROUP_HUE[groupKey];
+  const groupStyle = hue !== undefined ? ({ ['--gh' as never]: String(hue) } as React.CSSProperties) : undefined;
+
   if (!label) {
     return <div className="sb-group sb-group-noheader">{children}</div>;
   }
 
   return (
-    <div className={`sb-group ${expanded ? 'is-open' : ''}`}>
+    <div className={`sb-group ${expanded ? 'is-open' : ''}`} style={groupStyle}>
       <button
         type="button"
         className="sb-group-h"
@@ -414,7 +421,8 @@ function SidebarGroup({
             transition: 'transform 150ms',
           }}
         />
-        <span>{label}</span>
+        {hue !== undefined && <span className="sb-group-dot" aria-hidden="true" />}
+        <span className="sb-group-l">{label}</span>
       </button>
       {expanded && <div className="sb-group-body">{children}</div>}
     </div>
@@ -423,7 +431,7 @@ function SidebarGroup({
 
 // ── SidebarMenu (agrupa shell.menu por scope — UI-0011) ─────────────────
 
-export function SidebarMenu({ items }: { items: ShellMenuItem[] }) {
+export function SidebarMenu({ items, mode = 'expanded' }: { items: ShellMenuItem[]; mode?: SidebarMode }) {
   if (!items?.length) {
     return (
       <div className="sb-menu-stub">
@@ -459,6 +467,16 @@ export function SidebarMenu({ items }: { items: ShellMenuItem[] }) {
   const sharedShell = (usePage().props as any)?.shell as { sidebar_counts?: SidebarCountsShared | null } | undefined;
   const counts = sharedShell?.sidebar_counts ?? { atendimento: 0, tarefas: 0, chat: 0 };
 
+  if (mode === 'rail') {
+    return (
+      <SidebarMenuRail
+        groupsToRender={groupsToRender}
+        groupedItems={groupedItems}
+        counts={counts}
+      />
+    );
+  }
+
   return (
     <div className="sb-menu-grouped">
       <SidebarShortcuts
@@ -478,6 +496,129 @@ export function SidebarMenu({ items }: { items: ShellMenuItem[] }) {
           ))}
         </SidebarGroup>
       ))}
+    </div>
+  );
+}
+
+// ── SidebarMenuRail (rail compacto — só ícones + flyout grupo) ──────────
+// Espelha SidebarMenuRail do prototipo Cowork (sidebar.jsx:286-385).
+// Wagner 2026-05-16: rail mode + cores hue por grupo.
+
+function SidebarMenuRail({
+  groupsToRender,
+  groupedItems,
+  counts,
+}: {
+  groupsToRender: Array<{ key: string; label: string }>;
+  groupedItems: Record<string, ShellMenuItem[]>;
+  counts: SidebarCountsShared;
+}) {
+  const [flyout, setFlyout] = useState<string | null>(null);
+  const [flyoutPos, setFlyoutPos] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+  const flyoutRef = useRef<HTMLDivElement>(null);
+  const anchorRefs = useRef<Record<string, HTMLButtonElement | null>>({});
+
+  useEffect(() => {
+    if (!flyout) return;
+    const handler = (e: MouseEvent) => {
+      const target = e.target as Node;
+      if (flyoutRef.current?.contains(target)) return;
+      const anchor = anchorRefs.current[flyout];
+      if (anchor?.contains(target)) return;
+      setFlyout(null);
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [flyout]);
+
+  const openFlyout = (key: string) => {
+    const anchor = anchorRefs.current[key];
+    if (!anchor) { setFlyout(null); return; }
+    const r = anchor.getBoundingClientRect();
+    setFlyoutPos({ top: r.top, left: r.right + 6 });
+    setFlyout(key);
+  };
+
+  return (
+    <div className="sb-menu-rail">
+      <a
+        href="/tarefas"
+        className="sb-rail-btn"
+        data-tip="Tarefas"
+        onClick={() => setFlyout(null)}
+      >
+        <Inbox size={18} className="ic" />
+        {!!counts.tarefas && <span className="sb-rail-dot-badge" />}
+      </a>
+      <a
+        href="/jana"
+        className="sb-rail-btn"
+        data-tip="Chat"
+        onClick={() => setFlyout(null)}
+      >
+        <MessageSquare size={18} className="ic" />
+        {!!counts.chat && <span className="sb-rail-dot-badge" />}
+      </a>
+      <a
+        href="/atendimento/inbox"
+        className="sb-rail-btn"
+        data-tip="Atendimento"
+        onClick={() => setFlyout(null)}
+      >
+        <MessageCircle size={18} className="ic" />
+        {!!counts.atendimento && <span className="sb-rail-dot-badge" />}
+      </a>
+
+      <div className="sb-rail-sep" />
+
+      {groupsToRender.map((g) => {
+        const hue = SIDEBAR_GROUP_HUE[g.key];
+        const railStyle = hue !== undefined ? ({ ['--gh' as never]: String(hue) } as React.CSSProperties) : undefined;
+        const isOpen = flyout === g.key;
+        // Pega ícone do primeiro item do grupo (representativo)
+        const firstItem = groupedItems[g.key]?.[0];
+        const Icon = firstItem ? findMenuIcon(firstItem.label) : Hash;
+        return (
+          <button
+            key={g.key}
+            ref={(el) => { anchorRefs.current[g.key] = el; }}
+            type="button"
+            className={`sb-rail-btn sb-rail-group ${isOpen ? 'open' : ''}`}
+            data-tip={g.label}
+            style={railStyle}
+            onClick={() => (isOpen ? setFlyout(null) : openFlyout(g.key))}
+            aria-expanded={isOpen}
+          >
+            <Icon size={18} className="ic" />
+          </button>
+        );
+      })}
+
+      {flyout && (() => {
+        const g = groupsToRender.find((x) => x.key === flyout);
+        if (!g) return null;
+        const hue = SIDEBAR_GROUP_HUE[g.key];
+        const flyoutStyle: React.CSSProperties = {
+          position: 'fixed',
+          top: flyoutPos.top,
+          left: flyoutPos.left,
+          ...(hue !== undefined ? { ['--gh' as never]: String(hue) } : {}),
+        };
+        return (
+          <div className="sb-rail-flyout" ref={flyoutRef} style={flyoutStyle}>
+            <div className="sb-rail-flyout-h">
+              {hue !== undefined && <span className="sb-group-dot" aria-hidden="true" />}
+              <span className="sb-rail-flyout-l">{g.label}</span>
+              <span className="sb-group-n">{groupedItems[g.key]?.length ?? 0}</span>
+            </div>
+            {(groupedItems[g.key] ?? []).map((item, idx) => (
+              <div key={`${item.label}-${idx}`} onClick={() => setFlyout(null)}>
+                <SidebarMenuItem item={item} />
+              </div>
+            ))}
+          </div>
+        );
+      })()}
     </div>
   );
 }

--- a/resources/js/Components/cockpit/shared.ts
+++ b/resources/js/Components/cockpit/shared.ts
@@ -141,7 +141,27 @@ export const LS = {
   TW_HUE: 'oimpresso.cockpit.tweaks.accentHue',
   TW_OPEN: 'oimpresso.cockpit.tweaks.open',
   SUPER_EXPANDED: 'oimpresso.cockpit.superadmin.expanded',
+  SB_MODE: 'oimpresso.sb.mode',
 } as const;
+
+export type SidebarMode = 'expanded' | 'rail';
+
+// Hue OKLCH por grupo (espelha GROUP_META do prototipo Cowork
+// _cowork-export-2026-05-15/data.jsx). Aplicado via CSS var --gh nos
+// elementos sb-group (dot + label) e sb-rail-group (tooltip + ícone).
+export const SIDEBAR_GROUP_HUE: Record<string, number> = {
+  office: 60,
+  oficina: 350,
+  fin: 145,
+  estoque: 30,
+  fiscal: 200,
+  rh: 295,
+  conhecimento: 80,
+  rel: 240,
+  ia: 220,
+  governanca: 270,
+  plataforma: 200,
+};
 
 // ── helpers ─────────────────────────────────────────────────────────────
 

--- a/resources/js/Layouts/AppShellV2.tsx
+++ b/resources/js/Layouts/AppShellV2.tsx
@@ -17,6 +17,8 @@ import {
   CalendarRange,
   CheckSquare,
   ChevronDown,
+  ChevronLeft,
+  ChevronRight,
   ClipboardList,
   Compass,
   Flag,
@@ -92,6 +94,7 @@ import {
   ConversaFoco,
   LS,
   ShellMenuItem,
+  SidebarMode,
   Vibe,
   isSuperadminMenu,
   isUserMenuItem,
@@ -257,15 +260,32 @@ export default function AppShellV2({
     return localStorage.getItem(LS.LINKED) === '1';
   });
 
+  // ── Sidebar mode (expanded | rail) — Wagner 2026-05-16.
+  // Espelha protótipo Cowork _cowork-export-2026-05-15/sidebar.jsx (modes
+  // expanded/rail + alça collapse na borda direita + atalho ⌘\).
+  const [sidebarMode, setSidebarMode] = useState<SidebarMode>(() => {
+    if (typeof window === 'undefined') return 'expanded';
+    const v = localStorage.getItem(LS.SB_MODE);
+    return v === 'rail' ? 'rail' : 'expanded';
+  });
+  useEffect(() => { localStorage.setItem(LS.SB_MODE, sidebarMode); }, [sidebarMode]);
+  const toggleSidebarMode = () => setSidebarMode((m) => (m === 'rail' ? 'expanded' : 'rail'));
+
   // ── Command Palette global (PMG-002, ADR 0100) — atalho Cmd/Ctrl+K
   const [paletteOpen, setPaletteOpen] = useState<boolean>(false);
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      // Cmd+K (Mac) ou Ctrl+K (Windows/Linux)
+      // Cmd+K (Mac) ou Ctrl+K (Windows/Linux) — Command Palette
       if ((e.metaKey || e.ctrlKey) && (e.key === 'k' || e.key === 'K')) {
         e.preventDefault();
         setPaletteOpen((v) => !v);
+        return;
+      }
+      // Cmd+\ (Mac) ou Ctrl+\ (Windows/Linux) — toggle sidebar rail/expanded
+      if ((e.metaKey || e.ctrlKey) && e.key === '\\') {
+        e.preventDefault();
+        setSidebarMode((m) => (m === 'rail' ? 'expanded' : 'rail'));
       }
     }
     window.addEventListener('keydown', onKey);
@@ -370,13 +390,15 @@ export default function AppShellV2({
       <div
         className="cockpit"
         data-linked={!conversaFoco || linkedCollapsed ? 'off' : 'on'}
+        data-sidebar={sidebarMode}
         data-vibe={vibe}
         data-density={densityLabel}
         data-theme={userTheme}
         style={cockpitStyle}
       >
-        {/* SIDEBAR — single-pane (UI-0011, 2026-05-05). Toggle Chat/Menu removido. */}
-        <aside className="sb">
+        {/* SIDEBAR — single-pane (UI-0011, 2026-05-05). Toggle Chat/Menu removido.
+            Modos expanded/rail (Wagner 2026-05-16) — protótipo Cowork sidebar.jsx. */}
+        <aside className={`sb${sidebarMode === 'rail' ? ' sb--rail' : ''}`}>
           <div className="sb-top">
             <CompanyPicker businesses={business.opcoes} fallbackNome={business.nome} />
           </div>
@@ -385,7 +407,7 @@ export default function AppShellV2({
               quando OK ou business não emite NFe. */}
           <NfeCertBadge />
           <div className="sb-body">
-            <SidebarMenu items={shellMenu} />
+            <SidebarMenu items={shellMenu} mode={sidebarMode} />
           </div>
           <SidebarFooter
             nome={user.nome}
@@ -398,6 +420,17 @@ export default function AppShellV2({
             vibe={vibe}
             onVibe={setVibe}
           />
+          {/* Alça collapse/expand na borda direita — espelha .sb-collapse-handle
+              do protótipo Cowork. Aparece on-hover, atalho ⌘\ duplicado no useEffect. */}
+          <button
+            type="button"
+            className="sb-collapse-handle"
+            onClick={toggleSidebarMode}
+            title={sidebarMode === 'rail' ? 'Expandir sidebar (⌘\\)' : 'Recolher sidebar (⌘\\)'}
+            aria-label={sidebarMode === 'rail' ? 'Expandir sidebar' : 'Recolher sidebar'}
+          >
+            {sidebarMode === 'rail' ? <ChevronRight size={12} /> : <ChevronLeft size={12} />}
+          </button>
         </aside>
 
         {/* MAIN COLUMN */}


### PR DESCRIPTION
## Summary

Porta 5 capacidades do protótipo Cowork (`prototipo-ui/_cowork-export-2026-05-15/sidebar.jsx`) pro AppShellV2 real. Wagner pediu sidebar minimizar/maximizar + cores no sidebar.

### Capacidades novas

1. **Modo rail (56px ícone-only)** com tooltip `data-tip` puro CSS + flyout grupo posicionado via `getBoundingClientRect()` à direita do anchor
2. **Alça `.sb-collapse-handle`** na borda direita do `<aside>`, `opacity: 0 → 1` on `.sb:hover`, atalho **⌘\ / Ctrl+\** pra toggle `expanded ↔ rail`
3. **Cores hue OKLCH por grupo** via CSS var `--gh` injetada inline:
   - dot 6×6 `oklch(0.62 0.13 var(--gh))`
   - label `oklch(0.46 0.10 var(--gh))` (light) / `oklch(0.78 0.08 var(--gh))` (dark)
   - 11 grupos mapeados em `SIDEBAR_GROUP_HUE` (shared.ts):

| Grupo | Hue | Cor |
|---|---|---|
| office (Acessos Rápidos) | 60 | amarelo-ouro |
| oficina (Oficina Auto) | 350 | rosa |
| fin (Financeiro) | 145 | verde |
| estoque | 30 | laranja |
| fiscal | 200 | ciano |
| rh | 295 | roxo |
| conhecimento | 80 | verde-oliva |
| rel (Relatórios) | 240 | azul-escuro |
| ia (IA & Produtividade) | 220 | azul |
| governanca | 270 | violeta |
| plataforma | 200 | ciano |

4. **Persistência LS** `oimpresso.sb.mode` (sobrevive refresh)
5. **CompanyPicker + SidebarFooter** ficam avatar-only em rail (CSS-only)

## Trade-offs

- Modo `hidden` (sidebar 0px + reopen handle) **fora desta entrega** — Fase 2 se Wagner pedir.
- Atalho ⌘\ não conflita com ⌘K (Command Palette existente).
- `SIDEBAR_GROUPS` (Sidebar.tsx) preservado; cores chegam via lookup paralelo `SIDEBAR_GROUP_HUE`.
- Tooltip 600ms hover delay (sentir natural).

## Gate F1.5 MWART (ADR 0104 + 0114)

Wagner aprovou escopo completo via AskUserQuestion 2026-05-16. Skip `design-critique` formal — protótipo veio do loop Cowork sancionado. Doc visual completo em `memory/requisitos/_DesignSystem/sidebar-rail-mode-visual-comparison.md`.

## Files

| Arquivo | Δ |
|---|---|
| `resources/js/Components/cockpit/shared.ts` | +20 (LS.SB_MODE + SidebarMode type + SIDEBAR_GROUP_HUE) |
| `resources/js/Components/cockpit/Sidebar.tsx` | +147 (SidebarMenuRail + cores SidebarGroup) |
| `resources/js/Layouts/AppShellV2.tsx` | +41 (state mode + alça + atalho ⌘\) |
| `resources/css/cockpit.css` | +260 (rail mode + cores + tooltip data-tip + flyout) |
| `memory/requisitos/_DesignSystem/sidebar-rail-mode-visual-comparison.md` | +80 (doc gate F1.5) |
| **TOTAL** | **+529 linhas** |

**Excede limite ≤300 linhas (ADR 0094 commit-discipline)** — 1 intent única (sidebar canônico portado, 5 capacidades acopladas). Justificado pra preservar consistência com protótipo.

## Test plan

- [ ] Abrir `/dashboard` → clicar alça borda direita → sidebar colapsa pra 56px ícone-only
- [ ] Hover ícone grupo (ex. FINANCEIRO em verde) → tooltip "FINANCEIRO" aparece após 400ms
- [ ] Clicar ícone grupo → flyout abre à direita com label colorido + sub-items
- [ ] Atalho ⌘\ (Mac) / Ctrl+\ (Win) → toggle expanded/rail
- [ ] Refresh F5 → modo persiste (LS `oimpresso.sb.mode`)
- [ ] Dark mode (Settings → tema escuro) → cores hue ajustam pra luminosidade 0.78
- [ ] Larissa (1280px ROTA LIVRE) → main column ganha 200px extras em rail mode (cabe melhor)
- [ ] Sells/Create + CommandPalette ⌘K seguem funcionando (sem regressão de atalho)

## Refs

- ADR 0104 MWART processo canônico
- ADR 0114 Cowork loop formalizado
- `prototipo-ui/_cowork-export-2026-05-15/sidebar.jsx` (fonte canônica)
- `memory/requisitos/_DesignSystem/sidebar-rail-mode-visual-comparison.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)