### PR TITLE
feat(rb): US-RB-055 schema aditivo v9,75 — notes/favorites/events + cached cols (Onda 1)

### DIFF
--- a/Modules/RecurringBilling/Database/Migrations/2026_05_16_120000_recurring_v975_schema.php
+++ b/Modules/RecurringBilling/Database/Migrations/2026_05_16_120000_recurring_v975_schema.php
@@ -1,0 +1,193 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * RecurringBilling v9,75 — schema aditivo Onda 1.
+ *
+ * Adiciona:
+ *  - 3 tabelas novas: rb_subscription_notes, rb_subscription_favorites, rb_subscription_events
+ *  - 8 colunas em rb_subscriptions (payment_method, last_jobsheet_id, *_cached, paused_until, churn_reason, contact_phone_cached)
+ *  - 4 colunas em rb_plans (descricao_curta, fiscal_type, fiscal_cfop, fiscal_servico)
+ *
+ * Todas operações idempotentes (Schema::hasColumn / hasTable guards — ADR tech/0008).
+ * Backfill cached cols via comando `php artisan rb:backfill-cached-fields` (Onda 2).
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL: toda tabela nova tem business_id indexed.
+ * Refs: ADR 0093 multi-tenant, Method KB-9,75, memory/requisitos/RecurringBilling/Index-visual-comparison.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        $this->extendSubscriptions();
+        $this->extendPlans();
+        $this->createNotesTable();
+        $this->createFavoritesTable();
+        $this->createEventsTable();
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('rb_subscription_events');
+        Schema::dropIfExists('rb_subscription_favorites');
+        Schema::dropIfExists('rb_subscription_notes');
+
+        Schema::table('rb_plans', function (Blueprint $table) {
+            foreach (['fiscal_servico', 'fiscal_cfop', 'fiscal_type', 'descricao_curta'] as $col) {
+                if (Schema::hasColumn('rb_plans', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
+
+        Schema::table('rb_subscriptions', function (Blueprint $table) {
+            foreach ([
+                'contact_phone_cached', 'churn_reason', 'paused_until',
+                'total_revenue_cached', 'failed_count_cached', 'total_paid_cached',
+                'last_jobsheet_id', 'payment_method',
+            ] as $col) {
+                if (Schema::hasColumn('rb_subscriptions', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
+    }
+
+    private function extendSubscriptions(): void
+    {
+        Schema::table('rb_subscriptions', function (Blueprint $table) {
+            if (! Schema::hasColumn('rb_subscriptions', 'payment_method')) {
+                $table->enum('payment_method', ['pix', 'boleto', 'card'])->nullable()
+                    ->after('conta_bancaria_id');
+            }
+            if (! Schema::hasColumn('rb_subscriptions', 'last_jobsheet_id')) {
+                $table->unsignedBigInteger('last_jobsheet_id')->nullable()
+                    ->after('payment_method')
+                    ->comment('Soft link Modules/Repair JobSheet — sem FK pra preservar SoC Tier 0 (ADR 0094 §5)');
+            }
+            if (! Schema::hasColumn('rb_subscriptions', 'total_paid_cached')) {
+                $table->unsignedSmallInteger('total_paid_cached')->default(0)
+                    ->after('last_jobsheet_id');
+            }
+            if (! Schema::hasColumn('rb_subscriptions', 'failed_count_cached')) {
+                $table->unsignedSmallInteger('failed_count_cached')->default(0)
+                    ->after('total_paid_cached');
+            }
+            if (! Schema::hasColumn('rb_subscriptions', 'total_revenue_cached')) {
+                $table->decimal('total_revenue_cached', 14, 2)->default(0)
+                    ->after('failed_count_cached');
+            }
+            if (! Schema::hasColumn('rb_subscriptions', 'paused_until')) {
+                $table->date('paused_until')->nullable()
+                    ->after('total_revenue_cached');
+            }
+            if (! Schema::hasColumn('rb_subscriptions', 'churn_reason')) {
+                $table->string('churn_reason', 64)->nullable()
+                    ->after('paused_until');
+            }
+            if (! Schema::hasColumn('rb_subscriptions', 'contact_phone_cached')) {
+                $table->string('contact_phone_cached', 32)->nullable()
+                    ->after('churn_reason')
+                    ->comment('Denormalizado pra lista rápida — atualizado via Observer Contact');
+            }
+        });
+    }
+
+    private function extendPlans(): void
+    {
+        Schema::table('rb_plans', function (Blueprint $table) {
+            if (! Schema::hasColumn('rb_plans', 'descricao_curta')) {
+                $table->string('descricao_curta', 200)->nullable()
+                    ->after('description');
+            }
+            if (! Schema::hasColumn('rb_plans', 'fiscal_type')) {
+                $table->enum('fiscal_type', ['nfe', 'nfse', 'none'])->default('none')
+                    ->after('ativo');
+            }
+            if (! Schema::hasColumn('rb_plans', 'fiscal_cfop')) {
+                $table->string('fiscal_cfop', 8)->nullable()
+                    ->after('fiscal_type')
+                    ->comment('CFOP NFe 55 quando fiscal_type=nfe');
+            }
+            if (! Schema::hasColumn('rb_plans', 'fiscal_servico')) {
+                $table->string('fiscal_servico', 8)->nullable()
+                    ->after('fiscal_cfop')
+                    ->comment('Código serviço NFS-e quando fiscal_type=nfse');
+            }
+        });
+    }
+
+    private function createNotesTable(): void
+    {
+        if (Schema::hasTable('rb_subscription_notes')) {
+            return;
+        }
+
+        Schema::create('rb_subscription_notes', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('business_id')->index();
+            $table->foreignId('subscription_id')->constrained('rb_subscriptions')->cascadeOnDelete();
+            $table->unsignedInteger('user_id')
+                ->comment('Autor — FK users.id (UPos legado int unsigned)');
+            $table->text('body');
+            $table->boolean('is_pinned')->default(false);
+            $table->timestamps();
+            $table->softDeletes();
+
+            $table->index(['subscription_id', 'is_pinned'], 'rb_notes_sub_pin_idx');
+            $table->index(['business_id', 'created_at'], 'rb_notes_biz_created_idx');
+
+            $table->foreign('user_id', 'rb_notes_user_fk')
+                ->references('id')->on('users')->cascadeOnDelete();
+        });
+    }
+
+    private function createFavoritesTable(): void
+    {
+        if (Schema::hasTable('rb_subscription_favorites')) {
+            return;
+        }
+
+        Schema::create('rb_subscription_favorites', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('business_id')->index();
+            $table->foreignId('subscription_id')->constrained('rb_subscriptions')->cascadeOnDelete();
+            $table->unsignedInteger('user_id')
+                ->comment('Favorito pessoal — FK users.id');
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->unique(['user_id', 'subscription_id'], 'rb_fav_user_sub_unique');
+
+            $table->foreign('user_id', 'rb_fav_user_fk')
+                ->references('id')->on('users')->cascadeOnDelete();
+        });
+    }
+
+    private function createEventsTable(): void
+    {
+        if (Schema::hasTable('rb_subscription_events')) {
+            return;
+        }
+
+        Schema::create('rb_subscription_events', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('business_id')->index();
+            $table->foreignId('subscription_id')->constrained('rb_subscriptions')->cascadeOnDelete();
+            $table->enum('kind', [
+                'event-create', 'event-status', 'event-plan',
+                'event-charge', 'event-retry', 'event-nf', 'note',
+            ]);
+            $table->string('by_actor', 64)
+                ->comment('Quem disparou: sistema, SEFAZ, Eliana, Wagner, contact.name, etc');
+            $table->text('body');
+            $table->dateTime('occurred_at')->index();
+            $table->timestamps();
+
+            $table->index(['subscription_id', 'occurred_at'], 'rb_events_sub_at_idx');
+            $table->index(['business_id', 'occurred_at'], 'rb_events_biz_at_idx');
+        });
+    }
+};

--- a/Modules/RecurringBilling/Models/Plan.php
+++ b/Modules/RecurringBilling/Models/Plan.php
@@ -25,6 +25,8 @@ class Plan extends Model
         'business_id', 'name', 'slug', 'description',
         'valor', 'ciclo', 'ciclo_dias', 'trial_days',
         'ativo', 'metadata',
+        // v9,75 — Onda 1 schema aditivo
+        'descricao_curta', 'fiscal_type', 'fiscal_cfop', 'fiscal_servico',
     ];
 
     protected $casts = [

--- a/Modules/RecurringBilling/Models/Subscription.php
+++ b/Modules/RecurringBilling/Models/Subscription.php
@@ -35,6 +35,10 @@ class Subscription extends Model
         'start_date', 'next_due_date', 'billing_anchor_date',
         'canceled_at', 'paused_at',
         'conta_bancaria_id', 'metadata',
+        // v9,75 — Onda 1 schema aditivo
+        'payment_method', 'last_jobsheet_id',
+        'total_paid_cached', 'failed_count_cached', 'total_revenue_cached',
+        'paused_until', 'churn_reason', 'contact_phone_cached',
     ];
 
     protected $casts = [
@@ -44,6 +48,9 @@ class Subscription extends Model
         'canceled_at'          => 'datetime',
         'paused_at'            => 'datetime',
         'metadata'             => 'array',
+        // v9,75
+        'paused_until'         => 'date',
+        'total_revenue_cached' => 'decimal:2',
     ];
 
     public function plan(): BelongsTo
@@ -64,6 +71,28 @@ class Subscription extends Model
     public function invoices(): HasMany
     {
         return $this->hasMany(Invoice::class, 'subscription_id');
+    }
+
+    public function notes(): HasMany
+    {
+        return $this->hasMany(SubscriptionNote::class, 'subscription_id');
+    }
+
+    public function pinnedNote()
+    {
+        return $this->hasOne(SubscriptionNote::class, 'subscription_id')
+            ->where('is_pinned', true)
+            ->latest('updated_at');
+    }
+
+    public function favorites(): HasMany
+    {
+        return $this->hasMany(SubscriptionFavorite::class, 'subscription_id');
+    }
+
+    public function events(): HasMany
+    {
+        return $this->hasMany(SubscriptionEvent::class, 'subscription_id');
     }
 
     public function scopeAtivas(Builder $q): Builder

--- a/Modules/RecurringBilling/Models/SubscriptionEvent.php
+++ b/Modules/RecurringBilling/Models/SubscriptionEvent.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Modules\RecurringBilling\Models;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Timeline append-only de eventos por assinatura.
+ * Mistura eventos automáticos (sistema/SEFAZ) com notas humanas (Eliana/Wagner/contact).
+ *
+ * Kinds canônicos (visual canon recurring-data.jsx TIMELINES):
+ *   event-create   — assinatura criada
+ *   event-status   — mudança de status (cancelada/pausada/reativada)
+ *   event-plan     — mudança de plano (upgrade/downgrade)
+ *   event-charge   — cobrança disparada/paga
+ *   event-retry    — tentativa de re-cobrança
+ *   event-nf       — emissão de NFe/NFS-e (e reenvios)
+ *   note           — nota livre humano
+ *
+ * Append-only: sem update/delete (regra cultural — Pest test garante).
+ * Multi-tenant Tier 0 IRREVOGÁVEL: business_id global scope.
+ */
+class SubscriptionEvent extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'rb_subscription_events';
+
+    protected $fillable = [
+        'business_id', 'subscription_id', 'kind',
+        'by_actor', 'body', 'occurred_at',
+    ];
+
+    protected $casts = [
+        'occurred_at' => 'datetime',
+    ];
+
+    public const KIND_CREATE  = 'event-create';
+    public const KIND_STATUS  = 'event-status';
+    public const KIND_PLAN    = 'event-plan';
+    public const KIND_CHARGE  = 'event-charge';
+    public const KIND_RETRY   = 'event-retry';
+    public const KIND_NF      = 'event-nf';
+    public const KIND_NOTE    = 'note';
+
+    public function subscription(): BelongsTo
+    {
+        return $this->belongsTo(Subscription::class, 'subscription_id');
+    }
+
+    public function scopeRecent(Builder $q, int $limit = 20): Builder
+    {
+        return $q->orderByDesc('occurred_at')->limit($limit);
+    }
+}

--- a/Modules/RecurringBilling/Models/SubscriptionFavorite.php
+++ b/Modules/RecurringBilling/Models/SubscriptionFavorite.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Modules\RecurringBilling\Models;
+
+use App\Concerns\HasBusinessScope;
+use App\User;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Favorito pessoal por operador — UNIQUE(user_id, subscription_id).
+ *
+ * Suporta filtro `Mostrar só favoritos` da sidebar (visual canon screenshot Wagner 2026-05-16).
+ * Eliana tem 3-5 assinantes que monitora diário.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL: business_id global scope.
+ */
+class SubscriptionFavorite extends Model
+{
+    use HasBusinessScope;
+
+    public $timestamps = false;
+
+    protected $table = 'rb_subscription_favorites';
+
+    protected $fillable = [
+        'business_id', 'subscription_id', 'user_id', 'created_at',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+    ];
+
+    public function subscription(): BelongsTo
+    {
+        return $this->belongsTo(Subscription::class, 'subscription_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/Modules/RecurringBilling/Models/SubscriptionNote.php
+++ b/Modules/RecurringBilling/Models/SubscriptionNote.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Modules\RecurringBilling\Models;
+
+use App\Concerns\HasBusinessScope;
+use App\User;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+
+/**
+ * Nota interna por assinatura — visível só pra equipe (não para cliente final).
+ * Suporta `is_pinned` pra fixar 1 nota no topo do drawer detalhe (visual canon screenshot Wagner 2026-05-16).
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL: business_id global scope.
+ */
+class SubscriptionNote extends Model
+{
+    use HasBusinessScope;
+
+    use SoftDeletes;
+
+    protected $table = 'rb_subscription_notes';
+
+    protected $fillable = [
+        'business_id', 'subscription_id', 'user_id',
+        'body', 'is_pinned',
+    ];
+
+    protected $casts = [
+        'is_pinned' => 'boolean',
+    ];
+
+    public function subscription(): BelongsTo
+    {
+        return $this->belongsTo(Subscription::class, 'subscription_id');
+    }
+
+    public function author(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+
+    public function scopePinned(Builder $q): Builder
+    {
+        return $q->where('is_pinned', true);
+    }
+}

--- a/Modules/RecurringBilling/Tests/Feature/RecurringV975SchemaTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/RecurringV975SchemaTest.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Modules\RecurringBilling\Models\Plan;
+use Modules\RecurringBilling\Models\Subscription;
+use Modules\RecurringBilling\Models\SubscriptionEvent;
+use Modules\RecurringBilling\Models\SubscriptionFavorite;
+use Modules\RecurringBilling\Models\SubscriptionNote;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Onda 1 v9,75 schema · valida 3 tabelas novas (notes/favorites/events) +
+ * 12 colunas aditivas em subs/plans + scope multi-tenant + UNIQUE constraints.
+ *
+ * Padrão SQLite-stub (mesmo DomainModelsTest) — UPos legacy quebra com migrations.
+ */
+beforeEach(function () {
+    foreach ([
+        'rb_subscription_events', 'rb_subscription_favorites', 'rb_subscription_notes',
+        'rb_subscriptions', 'rb_plans', 'users', 'contacts',
+    ] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('contacts', function ($t) {
+        $t->increments('id');
+        $t->unsignedInteger('business_id')->index();
+        $t->timestamps();
+    });
+    Schema::create('users', function ($t) {
+        $t->increments('id');
+        $t->string('username')->nullable();
+        $t->timestamps();
+    });
+    Schema::create('rb_plans', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->string('name', 150);
+        $t->string('slug', 80);
+        $t->text('description')->nullable();
+        $t->string('descricao_curta', 200)->nullable();
+        $t->decimal('valor', 15, 2);
+        $t->string('ciclo', 20);
+        $t->unsignedSmallInteger('ciclo_dias')->nullable();
+        $t->unsignedSmallInteger('trial_days')->default(0);
+        $t->boolean('ativo')->default(true);
+        $t->string('fiscal_type', 10)->default('none');
+        $t->string('fiscal_cfop', 8)->nullable();
+        $t->string('fiscal_servico', 8)->nullable();
+        $t->json('metadata')->nullable();
+        $t->timestamps();
+        $t->softDeletes();
+        $t->unique(['business_id', 'slug']);
+    });
+    Schema::create('rb_subscriptions', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->foreignId('plan_id')->constrained('rb_plans');
+        $t->unsignedInteger('contact_id');
+        $t->string('status', 20)->default('active');
+        $t->date('start_date');
+        $t->date('next_due_date');
+        $t->date('billing_anchor_date');
+        $t->dateTime('canceled_at')->nullable();
+        $t->dateTime('paused_at')->nullable();
+        $t->unsignedInteger('conta_bancaria_id')->nullable();
+        $t->string('payment_method', 10)->nullable();
+        $t->unsignedBigInteger('last_jobsheet_id')->nullable();
+        $t->unsignedSmallInteger('total_paid_cached')->default(0);
+        $t->unsignedSmallInteger('failed_count_cached')->default(0);
+        $t->decimal('total_revenue_cached', 14, 2)->default(0);
+        $t->date('paused_until')->nullable();
+        $t->string('churn_reason', 64)->nullable();
+        $t->string('contact_phone_cached', 32)->nullable();
+        $t->json('metadata')->nullable();
+        $t->timestamps();
+        $t->softDeletes();
+    });
+    Schema::create('rb_subscription_notes', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->foreignId('subscription_id')->constrained('rb_subscriptions');
+        $t->unsignedInteger('user_id');
+        $t->text('body');
+        $t->boolean('is_pinned')->default(false);
+        $t->timestamps();
+        $t->softDeletes();
+    });
+    Schema::create('rb_subscription_favorites', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->foreignId('subscription_id')->constrained('rb_subscriptions');
+        $t->unsignedInteger('user_id');
+        $t->timestamp('created_at')->useCurrent();
+        $t->unique(['user_id', 'subscription_id']);
+    });
+    Schema::create('rb_subscription_events', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->foreignId('subscription_id')->constrained('rb_subscriptions');
+        $t->string('kind', 20);
+        $t->string('by_actor', 64);
+        $t->text('body');
+        $t->dateTime('occurred_at');
+        $t->timestamps();
+    });
+
+    \DB::table('users')->insert(['id' => 1, 'created_at' => now(), 'updated_at' => now()]);
+    \DB::table('contacts')->insert(['id' => 1, 'business_id' => 1, 'created_at' => now(), 'updated_at' => now()]);
+});
+
+afterEach(function () {
+    foreach ([
+        'rb_subscription_events', 'rb_subscription_favorites', 'rb_subscription_notes',
+        'rb_subscriptions', 'rb_plans', 'users', 'contacts',
+    ] as $t) {
+        Schema::dropIfExists($t);
+    }
+});
+
+function makeSub(int $bizId = 1, string $method = null): Subscription
+{
+    $plan = Plan::create([
+        'business_id' => $bizId, 'name' => 'P', 'slug' => "p-{$bizId}",
+        'valor' => 100, 'ciclo' => 'monthly',
+        'fiscal_type' => 'nfe', 'fiscal_cfop' => '5102',
+    ]);
+    return Subscription::create([
+        'business_id'         => $bizId,
+        'plan_id'             => $plan->id,
+        'contact_id'          => 1,
+        'status'              => 'active',
+        'start_date'          => '2026-05-01',
+        'next_due_date'       => '2026-06-01',
+        'billing_anchor_date' => '2026-05-01',
+        'payment_method'      => $method,
+    ]);
+}
+
+it('Plan aceita campos fiscais v9,75 (fiscal_type + cfop + servico)', function () {
+    $plan = Plan::create([
+        'business_id' => 1, 'name' => 'Fachada', 'slug' => 'fachada',
+        'valor' => 1620, 'ciclo' => 'monthly',
+        'descricao_curta' => 'Fachada ACM + faixa promocional 30 dias',
+        'fiscal_type' => 'nfse', 'fiscal_servico' => '01.07',
+    ]);
+
+    expect($plan->fiscal_type)->toBe('nfse')
+        ->and($plan->fiscal_servico)->toBe('01.07')
+        ->and($plan->descricao_curta)->toContain('Fachada ACM');
+});
+
+it('Subscription aceita payment_method + paused_until + churn_reason + cached cols', function () {
+    $sub = makeSub(1, 'pix');
+    $sub->total_paid_cached = 14;
+    $sub->failed_count_cached = 0;
+    $sub->total_revenue_cached = 6720;
+    $sub->paused_until = '2026-07-01';
+    $sub->churn_reason = 'preço';
+    $sub->contact_phone_cached = '19 99876-1234';
+    $sub->save();
+
+    $sub->refresh();
+    expect($sub->payment_method)->toBe('pix')
+        ->and($sub->total_paid_cached)->toBe(14)
+        ->and((float) $sub->total_revenue_cached)->toBe(6720.00)
+        ->and($sub->paused_until->format('Y-m-d'))->toBe('2026-07-01')
+        ->and($sub->churn_reason)->toBe('preço');
+});
+
+it('SubscriptionNote cria + is_pinned cast bool + scope pinned()', function () {
+    $sub = makeSub();
+    SubscriptionNote::create([
+        'business_id' => 1, 'subscription_id' => $sub->id, 'user_id' => 1,
+        'body' => 'Nota normal', 'is_pinned' => false,
+    ]);
+    SubscriptionNote::create([
+        'business_id' => 1, 'subscription_id' => $sub->id, 'user_id' => 1,
+        'body' => '5 lojas · KV diferente', 'is_pinned' => true,
+    ]);
+
+    expect(SubscriptionNote::count())->toBe(2)
+        ->and(SubscriptionNote::pinned()->count())->toBe(1)
+        ->and(SubscriptionNote::pinned()->first()->is_pinned)->toBeTrue();
+});
+
+it('SubscriptionFavorite UNIQUE(user_id, subscription_id) impede duplicação', function () {
+    $sub = makeSub();
+    SubscriptionFavorite::create(['business_id' => 1, 'subscription_id' => $sub->id, 'user_id' => 1]);
+
+    expect(fn () => SubscriptionFavorite::create([
+        'business_id' => 1, 'subscription_id' => $sub->id, 'user_id' => 1,
+    ]))->toThrow(\Illuminate\Database\QueryException::class);
+});
+
+it('SubscriptionEvent registra kind canônico + ordena por occurred_at desc (scope recent)', function () {
+    $sub = makeSub();
+    SubscriptionEvent::create([
+        'business_id' => 1, 'subscription_id' => $sub->id,
+        'kind' => SubscriptionEvent::KIND_CREATE, 'by_actor' => 'sistema',
+        'body' => 'Assinatura criada', 'occurred_at' => '2026-05-01 10:00',
+    ]);
+    SubscriptionEvent::create([
+        'business_id' => 1, 'subscription_id' => $sub->id,
+        'kind' => SubscriptionEvent::KIND_CHARGE, 'by_actor' => 'sistema',
+        'body' => 'Cobrança paga R$ 100', 'occurred_at' => '2026-05-02 10:00',
+    ]);
+
+    $recent = SubscriptionEvent::recent(5)->get();
+
+    expect($recent)->toHaveCount(2)
+        ->and($recent->first()->kind)->toBe(SubscriptionEvent::KIND_CHARGE);
+});
+
+it('multi-tenant: biz=99 não enxerga notes/favorites/events de biz=1 via HasBusinessScope', function () {
+    $subA = makeSub(1);
+    $subB = makeSub(99);
+
+    SubscriptionNote::create(['business_id' => 1, 'subscription_id' => $subA->id, 'user_id' => 1, 'body' => 'a']);
+    SubscriptionNote::create(['business_id' => 99, 'subscription_id' => $subB->id, 'user_id' => 1, 'body' => 'b']);
+    SubscriptionFavorite::create(['business_id' => 1, 'subscription_id' => $subA->id, 'user_id' => 1]);
+    SubscriptionFavorite::create(['business_id' => 99, 'subscription_id' => $subB->id, 'user_id' => 1]);
+    SubscriptionEvent::create(['business_id' => 1, 'subscription_id' => $subA->id, 'kind' => 'note', 'by_actor' => 'x', 'body' => 'a', 'occurred_at' => now()]);
+    SubscriptionEvent::create(['business_id' => 99, 'subscription_id' => $subB->id, 'kind' => 'note', 'by_actor' => 'x', 'body' => 'b', 'occurred_at' => now()]);
+
+    session(['business' => ['id' => 1]]);
+
+    expect(SubscriptionNote::count())->toBe(1)
+        ->and(SubscriptionFavorite::count())->toBe(1)
+        ->and(SubscriptionEvent::count())->toBe(1);
+});


### PR DESCRIPTION
## Summary

**Onda 1** — fundação schema pra suportar a tela Cobrança Recorrente v9,75/10 (visual canon validado em #968 já mergeado).

Schema aditivo idempotente (`Schema::hasColumn` / `hasTable` guards — ADR tech/0008):

**3 tabelas novas:**
- `rb_subscription_notes` — id, business_id, subscription_id, user_id, body, is_pinned
- `rb_subscription_favorites` — UNIQUE(user_id, sub_id) pra filtro "★ Mostrar só favoritos"
- `rb_subscription_events` — timeline append-only (7 kinds canônicos)

**8 colunas em `rb_subscriptions`:** payment_method, last_jobsheet_id (soft link Repair sem FK), 3 cached cols (backfill Onda 2), paused_until, churn_reason, contact_phone_cached.

**4 colunas em `rb_plans`:** descricao_curta, fiscal_type, fiscal_cfop, fiscal_servico.

**3 Models novos** com `HasBusinessScope` (Tier 0 IRREVOGÁVEL — ADR 0093): SubscriptionNote (pinned scope) · SubscriptionFavorite (UNIQUE) · SubscriptionEvent (kind constants + recent scope).

**Pest** cobre 6 cenários: campos fiscais Plan · campos novos Subscription · is_pinned cast · UNIQUE favorites · timeline ordering · isolamento biz=1 vs biz=99.

## Test plan

- [ ] `php artisan migrate --path=Modules/RecurringBilling/Database/Migrations/2026_05_16_120000_recurring_v975_schema.php`
- [ ] Re-run migration — não deve duplicar colunas (idempotente)
- [ ] `vendor/bin/pest Modules/RecurringBilling/Tests/Feature/RecurringV975SchemaTest.php` — 6 testes verde
- [ ] `php artisan migrate:rollback --step=1` — down() limpa tudo
- [ ] Cross-tenant: `session(['business' => ['id' => 99]]); SubscriptionNote::count()` retorna 0

## Refs

- US-RB-055 (criada via tasks-create 2026-05-16)
- Visual canon: #968 (já mergeado)
- ADR 0093 multi-tenant Tier 0 · ADR 0094 §5 SoC brutal (soft link Repair)

🤖 Generated with [Claude Code](https://claude.com/claude-code)