### PR TITLE
hotfix(prod): remove UTF-8 BOM 5 arquivos PHP — fix oimpresso.com/sells crash

### DIFF
--- a/Modules/Cms/Http/Controllers/CmsController.php
+++ b/Modules/Cms/Http/Controllers/CmsController.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 namespace Modules\Cms\Http\Controllers;
 

--- a/Modules/Crm/Entities/CrmCallLog.php
+++ b/Modules/Crm/Entities/CrmCallLog.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 namespace Modules\Crm\Entities;
 

--- a/Modules/Crm/Entities/CrmMarketplace.php
+++ b/Modules/Crm/Entities/CrmMarketplace.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 namespace Modules\Crm\Entities;
 

--- a/Modules/Crm/Entities/Proposal.php
+++ b/Modules/Crm/Entities/Proposal.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 namespace Modules\Crm\Entities;
 

--- a/Modules/Crm/Entities/ProposalTemplate.php
+++ b/Modules/Crm/Entities/ProposalTemplate.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 namespace Modules\Crm\Entities;
 


### PR DESCRIPTION
URGENTE — Wagner reportou prod crash em /sells (e qualquer rota que load Cms/Crm). PowerShell Set-Content -Encoding utf8 (PS 5.1) grava UTF-8 COM BOM (0xEF 0xBB 0xBF). PHP não interpreta <?php quando há BOM antes — vira HTML output, namespace declaration falha. Fix: remove BOM via Python.