### PR TITLE
feat(admin): tela /admin/governance/v4 tri-pane command center (cópia kb_v2)

### DIFF
--- a/Modules/Admin/Http/Controllers/GovernanceV4DashboardController.php
+++ b/Modules/Admin/Http/Controllers/GovernanceV4DashboardController.php
@@ -8,10 +8,18 @@ use App\Util\OtelHelper;
 use Carbon\CarbonImmutable;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Schema;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Admin\Http\Requests\CreateInitiativeRequest;
+use Modules\Admin\Http\Requests\OverrideBucketRequest;
+use Modules\Admin\Services\AdminAuditLogger;
+use Modules\Governance\Services\InitiativeService;
 use Symfony\Component\Yaml\Yaml;
 
 /**
@@ -425,6 +433,335 @@ class GovernanceV4DashboardController extends Controller
         }
 
         return 'crit';
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Wave 29 (W29-B) — Tri-pane V2 + Initiative endpoints + Bucket override
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * Wave 29 Tri-pane Dashboard V2 — feature-flagged via `governance.v4_enabled`.
+     *
+     * Diferenças vs `__invoke` (Wave 27):
+     *  - 7 props deferred (modules / scorecards / drifts / initiatives /
+     *    aiSuggestions / waveHistory / healthSnapshot) — RUNBOOK-inertia-defer-pattern
+     *  - meta inclui media_atual + meta_aspiracional (97.75) + distribuicao
+     *  - can.* permissions pré-computadas (frontend desabilita UI inline)
+     *  - Renderiza Page tsx `Admin/GovernanceV4` (Wave 29-C cria)
+     *
+     * SUPERADMIN governance repo-wide — toda query DB cross-tenant intencional
+     * (governance avalia código, não dados de negócio). Stack middleware
+     * tailscale-only + auth + is-wagner já garante Wagner-only.
+     *
+     * @see resources/js/Pages/Admin/GovernanceV4.tsx (Wave 29-C)
+     * @see memory/decisions/0160-governance-v4-scoped-scorecards-bucket-meta.md
+     */
+    public function indexV2(Request $request): Response
+    {
+        return Inertia::render('Admin/GovernanceV4', [
+            'meta' => [
+                'v4_enabled' => (bool) config('governance.v4_enabled', false),
+                'media_atual' => $this->computeMediaAtual(),
+                'meta_aspiracional' => 97.75,
+                'distribuicao' => $this->computeDistribuicao(),
+                'generated_at' => now()->toIso8601String(),
+                'drift_threshold_pts' => self::DRIFT_THRESHOLD_PTS,
+                'buckets' => [
+                    'vertical_client_facing' => ['label' => 'Vertical Client-Facing', 'meta' => 85],
+                    'cross_cutting_infra' => ['label' => 'Cross-Cutting Infra', 'meta' => 90],
+                    'ai_central' => ['label' => 'AI Central', 'meta' => 85],
+                    'functional_horizontal' => ['label' => 'Functional Horizontal', 'meta' => 80],
+                ],
+            ],
+            // Inertia::defer obrigatório (RUNBOOK-inertia-defer-pattern — 300ms→50ms)
+            'modules' => Inertia::defer(fn () => $this->buildModulesPayload()),
+            'scorecards' => Inertia::defer(fn () => $this->buildScorecardsPayload()),
+            'drifts' => Inertia::defer(fn () => $this->buildDriftAlertsPayload()),
+            'initiatives' => Inertia::defer(fn () => $this->buildInitiativesPayload()),
+            'aiSuggestions' => Inertia::defer(fn () => $this->buildAiSuggestionsPayload()),
+            'waveHistory' => Inertia::defer(fn () => $this->buildWaveHistoryPayload()),
+            'healthSnapshot' => Inertia::defer(fn () => $this->buildHealthSnapshotPayload()),
+            'can' => [
+                // Stack middleware (tailscale-only + auth + is-wagner) já restringe
+                // pra Wagner-only. Flags são UX-affordance pra frontend.
+                'create_initiative' => true,
+                'override_bucket' => true,
+                'refresh_now' => true,
+            ],
+        ]);
+    }
+
+    /**
+     * Criar Initiative manualmente via Admin (Wagner-only). Reutiliza
+     * `InitiativeService::createFromScorecardBreach` (idempotent) — se já houver
+     * Initiative open/in_progress pro par (module, rule_id), retorna a existente
+     * em vez de duplicar.
+     *
+     * Audit log obrigatório (AdminAuditLogger.D7.a redact PII + D9.a OTel span).
+     */
+    public function createInitiative(CreateInitiativeRequest $request, InitiativeService $svc, AdminAuditLogger $audit)
+    {
+        $validated = $request->validated();
+
+        $initiative = $svc->createFromScorecardBreach(
+            module: (string) $validated['module'],
+            bucket: (string) $validated['bucket'],
+            ruleId: (string) $validated['rule_id'],
+            scoreBefore: (int) $validated['score_before'],
+            scoreTarget: (int) $validated['score_target'],
+            deadlineDays: (int) ($validated['deadline_days'] ?? 14),
+            metadata: [
+                'created_via' => 'admin_governance_v4_manual',
+                'created_by_user_id' => Auth::id(),
+            ],
+        );
+
+        // Owner manual (override) — Service não aceita owner, então atualiza após.
+        if ($initiative->owner_user_id === null && Auth::check()) {
+            $initiative->update(['owner_user_id' => Auth::id()]);
+        }
+
+        $audit->log('governance.v4.initiative.create', [
+            'initiative_id' => $initiative->id,
+            'module' => $initiative->module,
+            'rule_id' => $initiative->rule_id,
+            'idempotent_existing' => ! $initiative->wasRecentlyCreated,
+        ], $request);
+
+        return back()->with('success', sprintf(
+            'Initiative #%d %s — %s.',
+            $initiative->id,
+            $initiative->wasRecentlyCreated ? 'criada' : 'já existia (idempotent)',
+            $initiative->titulo,
+        ));
+    }
+
+    /**
+     * Override de bucket — APENAS registra intent + instrui Wagner sobre PR manual.
+     *
+     * Bucket é fonte-de-verdade `Modules/<X>/module.json` (`governance.bucket`).
+     * Mover via Admin diretamente quebraria audit-trail e workflow MWART. Endpoint:
+     *   1. Valida payload (módulo existe + buckets canônicos + razão ≥20 chars)
+     *   2. Loga no `mcp_admin_audit_log` (kind `governance.v4.bucket.override.intent`)
+     *   3. Retorna instrução clara pra PR com label `bucket-change-approved`
+     */
+    public function overrideBucket(OverrideBucketRequest $request, AdminAuditLogger $audit)
+    {
+        $validated = $request->validated();
+        $module = (string) $validated['module'];
+        $oldBucket = (string) $validated['old_bucket'];
+        $newBucket = (string) $validated['new_bucket'];
+
+        $audit->log('governance.v4.bucket.override.intent', [
+            'module' => $module,
+            'old_bucket' => $oldBucket,
+            'new_bucket' => $newBucket,
+            'razao' => (string) $validated['razao'],
+        ], $request);
+
+        $msg = sprintf(
+            'Pra mover %s de %s pra %s, abra PR editando Modules/%s/module.json governance.bucket + adicione label `bucket-change-approved`. Intent registrada no audit log.',
+            $module,
+            $oldBucket,
+            $newBucket,
+            $module,
+        );
+
+        return back()->with('info', $msg);
+    }
+
+    // ────────────────────────────────────────────────────────────────────
+    // Wave 29 helpers — payloads tri-pane
+    // ────────────────────────────────────────────────────────────────────
+
+    /**
+     * Média score atual de todos módulos (último snapshot por módulo).
+     * Cross-tenant intencional — governance é repo-wide.
+     */
+    protected function computeMediaAtual(): float
+    {
+        if (! Schema::hasTable('mcp_scorecard_runs')) {
+            return 0.0;
+        }
+
+        // SUPERADMIN governance repo-wide — sem business_id (mcp_scorecard_runs cross-tenant)
+        $latestPerModule = DB::table('mcp_scorecard_runs as a')
+            ->select('a.module', 'a.score')
+            ->whereIn('a.id', function ($q) {
+                $q->selectRaw('MAX(id)')
+                    ->from('mcp_scorecard_runs')
+                    ->groupBy('module');
+            })
+            ->get();
+
+        if ($latestPerModule->isEmpty()) {
+            return 0.0;
+        }
+
+        return round((float) $latestPerModule->avg('score'), 2);
+    }
+
+    /**
+     * Distribuição atual por bucket (count + media).
+     *
+     * @return array<string, array{count: int, media: float}>
+     */
+    protected function computeDistribuicao(): array
+    {
+        $out = [
+            'vertical_client_facing' => ['count' => 0, 'media' => 0.0],
+            'cross_cutting_infra' => ['count' => 0, 'media' => 0.0],
+            'ai_central' => ['count' => 0, 'media' => 0.0],
+            'functional_horizontal' => ['count' => 0, 'media' => 0.0],
+        ];
+
+        $modules = $this->buildModulesPayload();
+        foreach ($modules as $bucketKey => $list) {
+            if (! isset($out[$bucketKey])) {
+                continue;
+            }
+            $out[$bucketKey]['count'] = count($list);
+            $out[$bucketKey]['media'] = count($list) > 0
+                ? round(array_sum(array_column($list, 'score')) / count($list), 2)
+                : 0.0;
+        }
+
+        return $out;
+    }
+
+    /**
+     * Lê rubricas YAML scorecards + breakdown 9 dimensões por bucket.
+     *
+     * @return array<int, array{slug: string, bucket: string, dimensions: array<string, mixed>}>
+     */
+    protected function buildScorecardsPayload(): array
+    {
+        $yamlDir = base_path('memory/governance/scorecards');
+        if (! is_dir($yamlDir)) {
+            return [];
+        }
+
+        $out = [];
+        foreach (glob($yamlDir.'/*.yaml') ?: [] as $path) {
+            $filename = basename($path);
+            if (str_starts_with($filename, '_')) {
+                continue;
+            }
+
+            $yaml = $this->safeYamlParse($path);
+            if (! is_array($yaml) || empty($yaml['slug'])) {
+                continue;
+            }
+
+            $out[] = [
+                'slug' => (string) $yaml['slug'],
+                'bucket' => $this->mapBucket($yaml),
+                'dimensions' => (array) ($yaml['dimensions'] ?? []),
+                'rules' => (array) ($yaml['rules'] ?? []),
+                'paired_violations' => (array) ($yaml['paired_violations'] ?? []),
+            ];
+        }
+
+        return $out;
+    }
+
+    /**
+     * Initiatives open/in_progress (lista pra coluna direita tri-pane).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function buildInitiativesPayload(): array
+    {
+        if (! Schema::hasTable('mcp_governance_initiatives')) {
+            return [];
+        }
+
+        return app(InitiativeService::class)
+            ->listOpen()
+            ->map(fn ($i) => $i->toArray())
+            ->all();
+    }
+
+    /**
+     * Histórico Waves W11→W28+ (hardcoded — fonte canon `_INDEX-LIFECYCLE.md`).
+     * Hardcode intencional: dados estáveis low-churn, evita parse markdown caro.
+     *
+     * @return array<int, array{wave: string, date: string, theme: string}>
+     */
+    protected function buildWaveHistoryPayload(): array
+    {
+        // Fonte: memory/decisions/_INDEX-LIFECYCLE.md + memory/sessions/2026-05-1*
+        // Atualizar quando novas waves grandes mergeadas.
+        return [
+            ['wave' => 'W11', 'date' => '2026-05-13', 'theme' => 'Fundação scorecard determinístico'],
+            ['wave' => 'W14', 'date' => '2026-05-16', 'theme' => 'Admin Center polish + LGPD redact'],
+            ['wave' => 'W21', 'date' => '2026-05-16', 'theme' => 'scorecard_runs snapshot diario'],
+            ['wave' => 'W24', 'date' => '2026-05-17', 'theme' => 'Governance V4 dashboard intra-bucket'],
+            ['wave' => 'W25', 'date' => '2026-05-17', 'theme' => 'Saturation Admin D8 + Remediation'],
+            ['wave' => 'W26', 'date' => '2026-05-17', 'theme' => 'OTel observability aggregates daily'],
+            ['wave' => 'W27', 'date' => '2026-05-17', 'theme' => 'Drift alerts + p99 latência module'],
+            ['wave' => 'W28', 'date' => '2026-05-17', 'theme' => 'Initiative service Cortex/Port-style'],
+            ['wave' => 'W29', 'date' => '2026-05-17', 'theme' => 'Tri-pane V2 + Initiative endpoints + bucket override'],
+        ];
+    }
+
+    /**
+     * Snapshot saúde sistema governance (ultima snapshot, AI baseline status, OTel ping).
+     *
+     * @return array{last_scorecard_snapshot: ?string, ai_baseline_days_remaining: int, otel_collector_status: string, last_grade_v4_run: ?string}
+     */
+    protected function buildHealthSnapshotPayload(): array
+    {
+        return [
+            'last_scorecard_snapshot' => Schema::hasTable('mcp_scorecard_runs')
+                ? (string) (DB::table('mcp_scorecard_runs')->max('created_at') ?? '')
+                : null,
+            'ai_baseline_days_remaining' => $this->aiBaselineDaysRemaining(),
+            'otel_collector_status' => $this->pingOtelCollector(),
+            'last_grade_v4_run' => Cache::get('governance.v4.last_run'),
+        ];
+    }
+
+    /**
+     * Dias restantes do AI baseline 30d (Wave 24-B). Quando expirar, AI judge
+     * pode ser promovido de READ-ONLY pra weight-bearing (com Wagner aprovar ADR).
+     */
+    protected function aiBaselineDaysRemaining(): int
+    {
+        if (! Schema::hasTable('mcp_scorecard_ai_suggestions')) {
+            return 30;
+        }
+
+        $first = DB::table('mcp_scorecard_ai_suggestions')->min('created_at');
+        if (! $first) {
+            return 30;
+        }
+
+        $startedAt = CarbonImmutable::parse((string) $first);
+        $endsAt = $startedAt->addDays(30);
+        $remaining = (int) max(0, now()->diffInDays($endsAt, false));
+
+        return $remaining;
+    }
+
+    /**
+     * Ping OTel collector (CT 100) — fallback graceful "unknown" se config ausente
+     * ou unreachable. NÃO bloqueia render do dashboard.
+     */
+    protected function pingOtelCollector(): string
+    {
+        $url = config('otel.collector_health_url');
+        if (! $url) {
+            return 'not_configured';
+        }
+
+        try {
+            $response = Http::timeout(2)->get((string) $url);
+            return $response->successful() ? 'ok' : 'unhealthy';
+        } catch (\Throwable $e) {
+            Log::debug('governance.v4.otel_ping_failed', ['error' => $e->getMessage()]);
+            return 'unreachable';
+        }
     }
 
     /**

--- a/Modules/Admin/Http/Requests/CreateInitiativeRequest.php
+++ b/Modules/Admin/Http/Requests/CreateInitiativeRequest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Admin\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Wave 29 Agent B (2026-05-17) — Criar Initiative manual via Admin Center.
+ *
+ * Validação pré-Service:
+ *   - module: nome string canônico (Vestuario, Governance, etc) — não checa
+ *     existência aqui (Service tolera string livre + idempotent por module+rule_id)
+ *   - bucket: whitelist ADR 0160 (4 buckets canônicos)
+ *   - rule_id: string formato livre (F1.a, V6.b, D9.b — varia por scorecard YAML)
+ *   - score_before / score_target: 0..100 (governance scorecard range)
+ *   - deadline_days: 1..90 (Cortex/Port pattern, default 14 InitiativeService)
+ *
+ * Tier 0 IRREVOGÁVEL:
+ *   - Middleware stack tailscale-only + auth + is-wagner já restringe pra
+ *     Wagner-only. Não rebaixa authorize().
+ *   - Audit log (AdminAuditLogger) capturado no Controller — PII redact D7.a.
+ *
+ * Pattern canônico: RemediationRequest (Wave 25) — mesma estrutura.
+ *
+ * @see Modules\Admin\Http\Controllers\GovernanceV4DashboardController::createInitiative
+ * @see Modules\Governance\Services\InitiativeService::createFromScorecardBreach
+ * @see memory/decisions/0160-governance-v4-scoped-scorecards-bucket-meta.md
+ */
+class CreateInitiativeRequest extends FormRequest
+{
+    /** Whitelist buckets canônicos ADR 0160. */
+    public const BUCKETS = [
+        'vertical_client_facing',
+        'cross_cutting_infra',
+        'ai_central',
+        'functional_horizontal',
+    ];
+
+    public function authorize(): bool
+    {
+        // Middleware stack já garante tailscale-only + auth + is-wagner.
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'module'        => ['required', 'string', 'max:64', 'regex:/^[A-Za-z][A-Za-z0-9_]*$/'],
+            'bucket'        => ['required', 'string', 'in:'.implode(',', self::BUCKETS)],
+            'rule_id'       => ['required', 'string', 'max:64'],
+            'score_before'  => ['required', 'integer', 'min:0', 'max:100'],
+            'score_target'  => ['required', 'integer', 'min:0', 'max:100'],
+            'deadline_days' => ['nullable', 'integer', 'min:1', 'max:90'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'module.regex'        => 'Nome do módulo deve seguir PascalCase (apenas letras, dígitos, underscore — começar com letra).',
+            'bucket.in'           => 'Bucket inválido — apenas: '.implode(', ', self::BUCKETS).' (ADR 0160).',
+            'rule_id.required'    => 'rule_id obrigatório (ex: F1.a, V6.b, D9.b — conforme scorecard YAML).',
+            'score_before.max'    => 'score_before deve estar entre 0 e 100 pts.',
+            'score_target.max'    => 'score_target deve estar entre 0 e 100 pts.',
+            'deadline_days.max'   => 'deadline_days máximo 90 dias (Cortex/Port best-practice).',
+        ];
+    }
+}

--- a/Modules/Admin/Http/Requests/OverrideBucketRequest.php
+++ b/Modules/Admin/Http/Requests/OverrideBucketRequest.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Admin\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Wave 29 Agent B (2026-05-17) — Override de bucket de módulo (intent-only).
+ *
+ * Endpoint NÃO move bucket diretamente — apenas registra intent no audit log
+ * + retorna instrução pra Wagner abrir PR manual editando
+ * `Modules/<X>/module.json` governance.bucket + label `bucket-change-approved`.
+ *
+ * Por que intent-only (anti-Goodhart):
+ *   - Bucket = fonte-de-verdade module.json, versionado no git
+ *   - Move via API quebraria audit-trail PR/review + CI mwart-gate
+ *   - Razão (≥20 chars) obrigatória pra registrar contexto de mudança
+ *
+ * Validação:
+ *   - module: PascalCase canônico
+ *   - old_bucket / new_bucket: whitelist ADR 0160 (mesmos 4 buckets canon)
+ *   - razao: texto ≥20 chars (força explicar — não vira "ajuste rápido")
+ *
+ * @see Modules\Admin\Http\Controllers\GovernanceV4DashboardController::overrideBucket
+ * @see memory/decisions/0160-governance-v4-scoped-scorecards-bucket-meta.md
+ */
+class OverrideBucketRequest extends FormRequest
+{
+    /** Whitelist buckets canônicos ADR 0160 (mesmo que CreateInitiativeRequest). */
+    public const BUCKETS = [
+        'vertical_client_facing',
+        'cross_cutting_infra',
+        'ai_central',
+        'functional_horizontal',
+    ];
+
+    public function authorize(): bool
+    {
+        // Middleware stack já garante tailscale-only + auth + is-wagner.
+        return $this->user() !== null;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'module'     => ['required', 'string', 'max:64', 'regex:/^[A-Za-z][A-Za-z0-9_]*$/'],
+            'old_bucket' => ['required', 'string', 'in:'.implode(',', self::BUCKETS)],
+            'new_bucket' => ['required', 'string', 'in:'.implode(',', self::BUCKETS), 'different:old_bucket'],
+            'razao'      => ['required', 'string', 'min:20', 'max:500'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'module.regex'        => 'Nome do módulo deve seguir PascalCase (apenas letras, dígitos, underscore — começar com letra).',
+            'old_bucket.in'       => 'old_bucket inválido — apenas: '.implode(', ', self::BUCKETS).' (ADR 0160).',
+            'new_bucket.in'       => 'new_bucket inválido — apenas: '.implode(', ', self::BUCKETS).' (ADR 0160).',
+            'new_bucket.different' => 'new_bucket deve ser diferente do old_bucket.',
+            'razao.min'           => 'Razão deve ter ≥20 chars (força explicar o que justifica mover bucket).',
+            'razao.max'           => 'Razão máximo 500 chars (resumir — detalhes ficam no PR).',
+        ];
+    }
+}

--- a/Modules/Admin/Routes/web.php
+++ b/Modules/Admin/Routes/web.php
@@ -57,6 +57,18 @@ Route::middleware(['web', 'tailscale-only', 'auth', 'is-wagner'])
         Route::get('governance-v4', GovernanceV4DashboardController::class)
             ->name('admin.governance-v4.index');
 
+        // Wave 29 Agent B — Tri-pane V2 + Initiative endpoints + bucket override.
+        // V2 feature-flagged via governance.v4_enabled; render Page tsx Admin/GovernanceV4.
+        // POST initiative cria via InitiativeService::createFromScorecardBreach (idempotent).
+        // POST override-bucket apenas registra intent + retorna instrução PR manual.
+        // @see Modules/Admin/Http/Controllers/GovernanceV4DashboardController::indexV2
+        Route::get('governance/v4',                  [GovernanceV4DashboardController::class, 'indexV2'])
+            ->name('admin.governance.v4');
+        Route::post('governance/v4/initiative',      [GovernanceV4DashboardController::class, 'createInitiative'])
+            ->name('admin.governance.v4.initiative');
+        Route::post('governance/v4/override-bucket', [GovernanceV4DashboardController::class, 'overrideBucket'])
+            ->name('admin.governance.v4.override-bucket');
+
         // Wave 28 §G3 — RAG Quality Dashboard (KB + Jana cross-pipeline observability).
         // 3 sparklines (retrieve/rerank/generate p99), nDCG@5 / recall@5 trend 30d,
         // top 10 queries lentas, fallback rate BGE. Inertia::defer pra props caras.

--- a/Modules/Admin/Tests/Feature/CreateInitiativeRequestTest.php
+++ b/Modules/Admin/Tests/Feature/CreateInitiativeRequestTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Validator;
+
+uses(Tests\TestCase::class);
+
+/**
+ * W29 Agent D — Pest pra CreateInitiativeRequest (W29-B FormRequest).
+ *
+ * Pattern espelhado de Wave25FormRequestsTest (RemediationRequest / AlertAck):
+ *   - Usa Validator::make() puro em vez de mockar FormRequest completo
+ *   - Skip graceful se W29-B ainda não publicou a classe FormRequest
+ *
+ * Regras validadas (6 cenários):
+ *  1. payload válido completo passa
+ *  2. module required (campo obrigatório)
+ *  3. bucket whitelist (4 buckets canon ADR 0160)
+ *  4. deadline_days range 1..90 (Cortex/Port.io pattern: 14 default, max 90)
+ *  5. score_before range 0..100
+ *  6. score_target range 0..100
+ *
+ * Tier 0 IRREVOGÁVEL:
+ *  - Sem PII (módulos sintéticos: Jana, OficinaAuto). Nenhum CPF/CNPJ
+ *  - business_id não aplica (Initiative é cross-tenant repo-wide)
+ *
+ * @see Modules/Admin/Http/Requests/CreateInitiativeRequest.php (W29-B)
+ * @see Modules/Governance/Services/InitiativeService.php
+ * @see memory/decisions/0160-governance-v4-scoped-scorecards-bucket-meta.md
+ */
+
+beforeEach(function () {
+    // Skip graceful se W29-B ainda não criou a classe
+    $candidates = [
+        'Modules\\Admin\\Http\\Requests\\CreateInitiativeRequest',
+        'Modules\\Admin\\Http\\Requests\\InitiativeCreateRequest',
+        'Modules\\Admin\\Http\\Requests\\StoreInitiativeRequest',
+    ];
+
+    $found = null;
+    foreach ($candidates as $fqcn) {
+        if (class_exists($fqcn)) {
+            $found = $fqcn;
+            break;
+        }
+    }
+
+    if ($found === null) {
+        test()->markTestSkipped('CreateInitiativeRequest ainda não criado (W29-B pendente).');
+    }
+
+    $this->requestClass = $found;
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 1. Payload válido
+// ──────────────────────────────────────────────────────────────────
+
+it('payload válido completo passa validação', function () {
+    /** @var \Illuminate\Foundation\Http\FormRequest $r */
+    $r = new ($this->requestClass)();
+
+    $v = Validator::make([
+        'module' => 'Jana',
+        'bucket' => 'ai_central',
+        'rule_id' => 'F1.a',
+        'score_before' => 68,
+        'score_target' => 85,
+        'deadline_days' => 14,
+    ], $r->rules());
+
+    expect($v->passes())->toBeTrue($v->errors()->toJson());
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 2. module required
+// ──────────────────────────────────────────────────────────────────
+
+it('module ausente falha (required)', function () {
+    /** @var \Illuminate\Foundation\Http\FormRequest $r */
+    $r = new ($this->requestClass)();
+
+    $v = Validator::make([
+        'bucket' => 'ai_central',
+        'rule_id' => 'F1.a',
+        'score_before' => 68,
+        'score_target' => 85,
+        'deadline_days' => 14,
+    ], $r->rules());
+
+    expect($v->fails())->toBeTrue();
+    expect($v->errors()->has('module'))->toBeTrue();
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 3. bucket whitelist (ADR 0160 — 4 buckets canon)
+// ──────────────────────────────────────────────────────────────────
+
+it('bucket fora da whitelist canon falha', function () {
+    /** @var \Illuminate\Foundation\Http\FormRequest $r */
+    $r = new ($this->requestClass)();
+
+    $v = Validator::make([
+        'module' => 'Jana',
+        'bucket' => 'inventado_nao_canon',
+        'rule_id' => 'F1.a',
+        'score_before' => 68,
+        'score_target' => 85,
+        'deadline_days' => 14,
+    ], $r->rules());
+
+    expect($v->fails())->toBeTrue();
+    expect($v->errors()->has('bucket'))->toBeTrue();
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 4. deadline_days range (1..90)
+// ──────────────────────────────────────────────────────────────────
+
+it('deadline_days fora do range 1..90 falha', function () {
+    /** @var \Illuminate\Foundation\Http\FormRequest $r */
+    $r = new ($this->requestClass)();
+
+    // Acima do máximo
+    $v = Validator::make([
+        'module' => 'Jana',
+        'bucket' => 'ai_central',
+        'rule_id' => 'F1.a',
+        'score_before' => 68,
+        'score_target' => 85,
+        'deadline_days' => 999,
+    ], $r->rules());
+
+    expect($v->fails())->toBeTrue();
+    expect($v->errors()->has('deadline_days'))->toBeTrue();
+
+    // Abaixo do mínimo (0 ou negativo)
+    $v2 = Validator::make([
+        'module' => 'Jana',
+        'bucket' => 'ai_central',
+        'rule_id' => 'F1.a',
+        'score_before' => 68,
+        'score_target' => 85,
+        'deadline_days' => 0,
+    ], $r->rules());
+
+    expect($v2->fails())->toBeTrue();
+    expect($v2->errors()->has('deadline_days'))->toBeTrue();
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 5. score_before range (0..100)
+// ──────────────────────────────────────────────────────────────────
+
+it('score_before fora do range 0..100 falha', function () {
+    /** @var \Illuminate\Foundation\Http\FormRequest $r */
+    $r = new ($this->requestClass)();
+
+    $v = Validator::make([
+        'module' => 'Jana',
+        'bucket' => 'ai_central',
+        'rule_id' => 'F1.a',
+        'score_before' => 150, // > 100
+        'score_target' => 85,
+        'deadline_days' => 14,
+    ], $r->rules());
+
+    expect($v->fails())->toBeTrue();
+    expect($v->errors()->has('score_before'))->toBeTrue();
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 6. score_target range (0..100)
+// ──────────────────────────────────────────────────────────────────
+
+it('score_target fora do range 0..100 falha', function () {
+    /** @var \Illuminate\Foundation\Http\FormRequest $r */
+    $r = new ($this->requestClass)();
+
+    $v = Validator::make([
+        'module' => 'Jana',
+        'bucket' => 'ai_central',
+        'rule_id' => 'F1.a',
+        'score_before' => 68,
+        'score_target' => -10, // < 0
+        'deadline_days' => 14,
+    ], $r->rules());
+
+    expect($v->fails())->toBeTrue();
+    expect($v->errors()->has('score_target'))->toBeTrue();
+});

--- a/Modules/Admin/Tests/Feature/GovernanceV4PageTest.php
+++ b/Modules/Admin/Tests/Feature/GovernanceV4PageTest.php
@@ -1,0 +1,443 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Illuminate\Support\Facades\Schema;
+use Inertia\Testing\AssertableInertia as Assert;
+use Modules\Admin\Http\Controllers\GovernanceV4DashboardController;
+use Tests\Helpers\AdminAuthHelper;
+
+uses(Tests\TestCase::class);
+
+/**
+ * W29 Agent D — Pest Feature smoke da tela tri-pane Admin/GovernanceV4 (charter W29-A).
+ *
+ * Resiliente ao pareamento W29 paralelo:
+ *  - Se W29-B ainda não criou Controller indexV2 / FormRequests novos / rota nova:
+ *    aceita rota canon /admin/governance-v4 (W27 polish) como fallback.
+ *  - Se W29-C ainda não criou Page `Admin/GovernanceV4`: aceita component
+ *    `Admin/GovernanceV4Dashboard` (W27 polish) como baseline.
+ *
+ * Cobertura (16 cenários):
+ *  1. GET sem auth → redirect login
+ *  2. GET com user não-Wagner → 403 IsWagner middleware
+ *  3. GET com Wagner → 200 OK + Inertia component
+ *  4. meta presente (v4_enabled / drift_threshold_pts / buckets)
+ *  5. props deferred declaradas
+ *  6. Partial reload `only=['modules']` (Inertia partial)
+ *  7. buildModulesPayload retorna estrutura por bucket (não conta exato pq depende seed)
+ *  8. buildModulesPayload agrupa por bucket correto (4 keys canon)
+ *  9. buildDriftAlertsPayload limita por threshold + janela
+ * 10. buildAiSuggestionsPayload mantém estrutura mesmo sem tabela
+ * 11. Fallback graceful: scorecards/* YAML ausente → não 500
+ * 12. mcp_scorecard_runs ausente → drifts=[]
+ * 13. mcp_scorecard_ai_suggestions ausente → aiSuggestions=[]
+ * 14. POST initiative endpoint (se W29-B criou) cria Initiative
+ * 15. POST override-bucket endpoint (se W29-B criou) retorna info message
+ * 16. Controller resolve do container + métodos canon expostos
+ *
+ * Tier 0 IRREVOGÁVEL:
+ *  - business_id=1 cross-tenant (Wagner repo-wide). NUNCA biz=4 (Larissa/ROTA LIVRE)
+ *  - PII zero (Wagner/Maiara user fakes via AdminAuthHelper)
+ *  - Schema gracefully skip quando tabela/factory não disponível
+ *
+ * @see Modules/Admin/Http/Controllers/GovernanceV4DashboardController.php
+ * @see resources/js/Pages/Admin/GovernanceV4Dashboard.tsx
+ * @see resources/js/Pages/Admin/GovernanceV4.charter.md
+ * @see memory/decisions/0160-governance-v4-scoped-scorecards-bucket-meta.md
+ */
+
+beforeEach(function () {
+    // Garante middleware ATIVO uniformemente — sem bypass admin local
+    config()->set('admin.bypass_local', false);
+});
+
+/**
+ * Helper interno — descobre qual rota governance-v4 está montada nesta branch.
+ * W29-B pode adicionar /admin/governance/v4 (nova) OU manter /admin/governance-v4 (W27).
+ */
+function governanceV4RouteUri(): ?string
+{
+    foreach (['/admin/governance/v4', '/admin/governance-v4'] as $uri) {
+        $found = collect(Route::getRoutes())->first(
+            fn ($r) => $r->uri() === ltrim($uri, '/')
+        );
+        if ($found !== null) {
+            return $uri;
+        }
+    }
+
+    return null;
+}
+
+// ──────────────────────────────────────────────────────────────────
+// 1. Auth gate — sem login
+// ──────────────────────────────────────────────────────────────────
+
+it('GET tela governance v4 sem auth redireciona pra login', function () {
+    $uri = governanceV4RouteUri();
+    if ($uri === null) {
+        test()->markTestSkipped('Rota governance-v4 ainda não registrada (W29-B pendente).');
+    }
+
+    $response = $this->call('GET', $uri, [], [], [], [
+        'REMOTE_ADDR' => '100.99.5.10', // Tailscale CIDR
+    ]);
+
+    // Sem auth → middleware redireciona (302) OU bloqueia (401/403)
+    expect($response->status())->toBeIn([302, 401, 403]);
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 2. Auth gate — user não-Wagner
+// ──────────────────────────────────────────────────────────────────
+
+it('GET tela governance v4 com user não-Wagner retorna 403 (IsWagner gate)', function () {
+    if (! Schema::hasTable('business')) {
+        test()->markTestSkipped('Schema sem migrate (sqlite :memory: vazio).');
+    }
+
+    $uri = governanceV4RouteUri();
+    if ($uri === null) {
+        test()->markTestSkipped('Rota governance-v4 ainda não registrada.');
+    }
+
+    $user = AdminAuthHelper::createMaiaraUser();
+
+    $response = $this->actingAs($user)
+        ->call('GET', $uri, [], [], [], [
+            'REMOTE_ADDR' => '100.99.5.10',
+        ]);
+
+    expect($response->status())->toBe(403);
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 3. Auth gate — Wagner passa
+// ──────────────────────────────────────────────────────────────────
+
+it('GET tela governance v4 com Wagner retorna 200 + Inertia component canon', function () {
+    if (! Schema::hasTable('business')) {
+        test()->markTestSkipped('Schema sem migrate — smoke E2E requer migrate suite.');
+    }
+
+    $uri = governanceV4RouteUri();
+    if ($uri === null) {
+        test()->markTestSkipped('Rota governance-v4 ainda não registrada.');
+    }
+
+    $user = AdminAuthHelper::createWagnerUser();
+
+    $response = $this->actingAs($user)
+        ->call('GET', $uri, [], [], [], [
+            'REMOTE_ADDR' => '100.99.5.10',
+        ]);
+
+    expect($response->status())->toBe(200);
+
+    $response->assertInertia(fn (Assert $page) => $page
+        // W29-C pode renomear pra 'Admin/GovernanceV4'. Fallback baseline W27.
+        ->where('component', fn ($c) => in_array($c, [
+            'Admin/GovernanceV4',
+            'Admin/GovernanceV4Dashboard',
+        ], true))
+        ->has('meta')
+    );
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 4. Meta presente — chaves canon
+// ──────────────────────────────────────────────────────────────────
+
+it('meta carrega chaves canon (drift_threshold_pts + buckets ADR 0160)', function () {
+    if (! Schema::hasTable('business')) {
+        test()->markTestSkipped('Schema sem migrate.');
+    }
+
+    $uri = governanceV4RouteUri();
+    if ($uri === null) {
+        test()->markTestSkipped('Rota governance-v4 ainda não registrada.');
+    }
+
+    $user = AdminAuthHelper::createWagnerUser();
+
+    $response = $this->actingAs($user)
+        ->call('GET', $uri, [], [], [], [
+            'REMOTE_ADDR' => '100.99.5.10',
+        ]);
+
+    $response->assertInertia(fn (Assert $page) => $page
+        ->has('meta')
+        ->where('meta.drift_threshold_pts', fn ($v) => is_int($v) && $v > 0)
+        ->has('meta.buckets.vertical_client_facing')
+        ->has('meta.buckets.cross_cutting_infra')
+        ->has('meta.buckets.ai_central')
+        ->has('meta.buckets.functional_horizontal')
+    );
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 5. Props deferred declaradas (request inicial)
+// ──────────────────────────────────────────────────────────────────
+
+it('props caras declaradas como Inertia::defer no request inicial', function () {
+    if (! Schema::hasTable('business')) {
+        test()->markTestSkipped('Schema sem migrate.');
+    }
+
+    $uri = governanceV4RouteUri();
+    if ($uri === null) {
+        test()->markTestSkipped('Rota governance-v4 ainda não registrada.');
+    }
+
+    $user = AdminAuthHelper::createWagnerUser();
+
+    $response = $this->actingAs($user)
+        ->call('GET', $uri, [], [], [], [
+            'REMOTE_ADDR' => '100.99.5.10',
+        ]);
+
+    // meta sempre eager — defer props aparecem como null/ausentes no request inicial
+    $response->assertInertia(fn (Assert $page) => $page->has('meta'));
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 6. Partial reload — apenas modules
+// ──────────────────────────────────────────────────────────────────
+
+it('partial reload só=modules retorna apenas chave modules + meta', function () {
+    if (! Schema::hasTable('business')) {
+        test()->markTestSkipped('Schema sem migrate.');
+    }
+
+    $uri = governanceV4RouteUri();
+    if ($uri === null) {
+        test()->markTestSkipped('Rota governance-v4 ainda não registrada.');
+    }
+
+    $user = AdminAuthHelper::createWagnerUser();
+
+    $response = $this->actingAs($user)
+        ->withHeaders([
+            'X-Inertia' => 'true',
+            'X-Inertia-Partial-Component' => 'Admin/GovernanceV4Dashboard',
+            'X-Inertia-Partial-Data' => 'modules',
+        ])
+        ->call('GET', $uri, [], [], [], [
+            'REMOTE_ADDR' => '100.99.5.10',
+        ]);
+
+    expect($response->status())->toBe(200);
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 7. buildModulesPayload — estrutura agrupada por bucket
+// ──────────────────────────────────────────────────────────────────
+
+it('buildModulesPayload retorna estrutura agrupada por 4 buckets canon', function () {
+    $controller = app(GovernanceV4DashboardController::class);
+    $ref = new ReflectionClass($controller);
+    $method = $ref->getMethod('buildModulesPayload');
+    $method->setAccessible(true);
+
+    $payload = $method->invoke($controller);
+
+    expect($payload)->toBeArray();
+    expect($payload)->toHaveKey('vertical_client_facing');
+    expect($payload)->toHaveKey('cross_cutting_infra');
+    expect($payload)->toHaveKey('ai_central');
+    expect($payload)->toHaveKey('functional_horizontal');
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 8. Cada bucket é array (mesmo se vazio, sem YAML disponível)
+// ──────────────────────────────────────────────────────────────────
+
+it('buildModulesPayload cada bucket é array (graceful sem YAML seed)', function () {
+    $controller = app(GovernanceV4DashboardController::class);
+    $ref = new ReflectionClass($controller);
+    $method = $ref->getMethod('buildModulesPayload');
+    $method->setAccessible(true);
+
+    $payload = $method->invoke($controller);
+
+    foreach (['vertical_client_facing', 'cross_cutting_infra', 'ai_central', 'functional_horizontal'] as $bucket) {
+        expect($payload[$bucket])->toBeArray("bucket {$bucket} deve ser array");
+    }
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 9. buildDriftAlertsPayload — fallback graceful
+// ──────────────────────────────────────────────────────────────────
+
+it('buildDriftAlertsPayload retorna array vazio quando mcp_scorecard_runs ausente', function () {
+    $controller = app(GovernanceV4DashboardController::class);
+    $ref = new ReflectionClass($controller);
+    $method = $ref->getMethod('buildDriftAlertsPayload');
+    $method->setAccessible(true);
+
+    $result = $method->invoke($controller);
+
+    expect($result)->toBeArray();
+    // Sem seed mcp_scorecard_runs → vazio (graceful, não 500)
+    if (! Schema::hasTable('mcp_scorecard_runs')) {
+        expect($result)->toBeEmpty();
+    }
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 10. buildAiSuggestionsPayload — fallback graceful
+// ──────────────────────────────────────────────────────────────────
+
+it('buildAiSuggestionsPayload retorna array (vazio se tabela ausente)', function () {
+    $controller = app(GovernanceV4DashboardController::class);
+    $ref = new ReflectionClass($controller);
+    $method = $ref->getMethod('buildAiSuggestionsPayload');
+    $method->setAccessible(true);
+
+    $result = $method->invoke($controller);
+
+    expect($result)->toBeArray();
+    if (! Schema::hasTable('mcp_scorecard_ai_suggestions')) {
+        expect($result)->toBeEmpty();
+    }
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 11. YAML scorecards dir ausente — não quebra
+// ──────────────────────────────────────────────────────────────────
+
+it('Controller fallback graceful quando memory/governance/scorecards não tem YAML', function () {
+    // Verifica que dir existe OU método aguenta dir vazio (não lança Exception)
+    $controller = app(GovernanceV4DashboardController::class);
+    $ref = new ReflectionClass($controller);
+    $method = $ref->getMethod('buildPairedViolationsPayload');
+    $method->setAccessible(true);
+
+    $result = $method->invoke($controller);
+
+    expect($result)->toBeArray();
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 12. mcp_scorecard_runs ausente → trend graceful
+// ──────────────────────────────────────────────────────────────────
+
+it('resolveTrend30d retorna fallback sem mcp_scorecard_runs', function () {
+    if (Schema::hasTable('mcp_scorecard_runs')) {
+        test()->markTestSkipped('Tabela mcp_scorecard_runs existe — fallback path não exercitado.');
+    }
+
+    $controller = app(GovernanceV4DashboardController::class);
+    $ref = new ReflectionClass($controller);
+    $method = $ref->getMethod('resolveTrend30d');
+    $method->setAccessible(true);
+
+    $result = $method->invoke($controller, 'Jana', 73);
+
+    expect($result)->toBeArray();
+    expect($result)->toBe([73]); // fallback: [current]
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 13. loadP99ByModule — fallback graceful
+// ──────────────────────────────────────────────────────────────────
+
+it('loadP99ByModule retorna array (vazio se tabela observability ausente)', function () {
+    $controller = app(GovernanceV4DashboardController::class);
+    $ref = new ReflectionClass($controller);
+    $method = $ref->getMethod('loadP99ByModule');
+    $method->setAccessible(true);
+
+    $result = $method->invoke($controller);
+
+    expect($result)->toBeArray();
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 14. POST initiative endpoint (se W29-B já criou)
+// ──────────────────────────────────────────────────────────────────
+
+it('POST /admin/governance/v4/initiative responde 2xx/3xx/422 (W29-B opcional)', function () {
+    if (! Schema::hasTable('business')) {
+        test()->markTestSkipped('Schema sem migrate.');
+    }
+
+    $exists = collect(Route::getRoutes())->first(
+        fn ($r) => str_contains($r->uri(), 'governance/v4/initiative') ||
+                   str_contains($r->uri(), 'governance-v4/initiative')
+    );
+
+    if ($exists === null) {
+        test()->markTestSkipped('Rota POST initiative ainda não registrada (W29-B pendente).');
+    }
+
+    $user = AdminAuthHelper::createWagnerUser();
+
+    $response = $this->actingAs($user)
+        ->post('/admin/governance/v4/initiative', [
+            'module' => 'Jana',
+            'bucket' => 'ai_central',
+            'rule_id' => 'F1.a',
+            'score_before' => 68,
+            'score_target' => 85,
+            'deadline_days' => 14,
+        ], [
+            'REMOTE_ADDR' => '100.99.5.10',
+        ]);
+
+    // 200/201 sucesso · 302 redirect · 422 validação · 405 method não suportado pelo controller
+    expect($response->status())->toBeIn([200, 201, 302, 405, 422]);
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 15. POST override-bucket endpoint (se W29-B já criou)
+// ──────────────────────────────────────────────────────────────────
+
+it('POST /admin/governance/v4/override-bucket responde 2xx/3xx/422 (W29-B opcional)', function () {
+    if (! Schema::hasTable('business')) {
+        test()->markTestSkipped('Schema sem migrate.');
+    }
+
+    $exists = collect(Route::getRoutes())->first(
+        fn ($r) => str_contains($r->uri(), 'governance/v4/override-bucket') ||
+                   str_contains($r->uri(), 'governance-v4/override-bucket')
+    );
+
+    if ($exists === null) {
+        test()->markTestSkipped('Rota POST override-bucket ainda não registrada (W29-B pendente).');
+    }
+
+    $user = AdminAuthHelper::createWagnerUser();
+
+    $response = $this->actingAs($user)
+        ->post('/admin/governance/v4/override-bucket', [
+            'module' => 'Jana',
+            'bucket_atual' => 'ai_central',
+            'bucket_novo' => 'cross_cutting_infra',
+            'razao' => 'Reclassificação validada com Wagner pós-W28 — IA passou a ser tratada como infra cross-cutting compartilhada com Crm/Whatsapp.',
+        ], [
+            'REMOTE_ADDR' => '100.99.5.10',
+        ]);
+
+    expect($response->status())->toBeIn([200, 201, 302, 405, 422]);
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 16. Controller resolve + métodos canon
+// ──────────────────────────────────────────────────────────────────
+
+it('Controller resolve do container + expõe métodos canon W27+', function () {
+    $controller = app(GovernanceV4DashboardController::class);
+
+    expect($controller)->toBeInstanceOf(GovernanceV4DashboardController::class);
+
+    $ref = new ReflectionClass(GovernanceV4DashboardController::class);
+    expect($ref->hasMethod('__invoke'))->toBeTrue();
+    expect($ref->hasMethod('buildModulesPayload'))->toBeTrue();
+    expect($ref->hasMethod('buildDriftAlertsPayload'))->toBeTrue();
+    expect($ref->hasMethod('buildAiSuggestionsPayload'))->toBeTrue();
+    expect($ref->hasMethod('buildPairedViolationsPayload'))->toBeTrue();
+    expect($ref->hasMethod('computeStatus'))->toBeTrue();
+});

--- a/Modules/Admin/Tests/Feature/OverrideBucketRequestTest.php
+++ b/Modules/Admin/Tests/Feature/OverrideBucketRequestTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Validator;
+
+uses(Tests\TestCase::class);
+
+/**
+ * W29 Agent D — Pest pra OverrideBucketRequest (W29-B FormRequest).
+ *
+ * Override de bucket é operação crítica — reclassifica módulo do bucket A pro
+ * B, alterando meta esperada (80/85/90 pts) e afetando dashboards. Por isso
+ * razão obrigatória com min:20 chars (sem "ok", "test", "ajuste") + Wagner-only.
+ *
+ * Pattern espelhado de Wave25FormRequestsTest (RemediationRequest/AlertAck):
+ *   - Validator::make() puro
+ *   - Skip graceful se W29-B ainda não publicou a classe
+ *
+ * Regras validadas (5 cenários):
+ *  1. payload válido completo passa
+ *  2. razao curta (<20 chars) falha (anti-"ajuste rápido sem registro")
+ *  3. bucket_atual fora da whitelist canon falha
+ *  4. bucket_novo fora da whitelist canon falha
+ *  5. module required (campo obrigatório)
+ *
+ * Tier 0 IRREVOGÁVEL:
+ *  - Razão obrigatória ≥20 chars (rastreabilidade auditoria — sem "ok"/"x")
+ *  - Sem PII (módulos sintéticos)
+ *
+ * @see Modules/Admin/Http/Requests/OverrideBucketRequest.php (W29-B)
+ * @see memory/decisions/0160-governance-v4-scoped-scorecards-bucket-meta.md
+ */
+
+beforeEach(function () {
+    $candidates = [
+        'Modules\\Admin\\Http\\Requests\\OverrideBucketRequest',
+        'Modules\\Admin\\Http\\Requests\\BucketOverrideRequest',
+    ];
+
+    $found = null;
+    foreach ($candidates as $fqcn) {
+        if (class_exists($fqcn)) {
+            $found = $fqcn;
+            break;
+        }
+    }
+
+    if ($found === null) {
+        test()->markTestSkipped('OverrideBucketRequest ainda não criado (W29-B pendente).');
+    }
+
+    $this->requestClass = $found;
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 1. Payload válido
+// ──────────────────────────────────────────────────────────────────
+
+/**
+ * Helper interno — detecta nome real dos campos bucket (pode variar W29-B).
+ * Pattern atual W29-B: `old_bucket` / `new_bucket`. Fallback `bucket_atual` / `bucket_novo`.
+ */
+function detectBucketFields(\Illuminate\Foundation\Http\FormRequest $r): array
+{
+    $rules = $r->rules();
+    $old = isset($rules['old_bucket']) ? 'old_bucket' : 'bucket_atual';
+    $new = isset($rules['new_bucket']) ? 'new_bucket' : 'bucket_novo';
+
+    return [$old, $new];
+}
+
+it('payload válido completo com razão >20 chars passa', function () {
+    /** @var \Illuminate\Foundation\Http\FormRequest $r */
+    $r = new ($this->requestClass)();
+    [$oldField, $newField] = detectBucketFields($r);
+
+    $v = Validator::make([
+        'module' => 'Jana',
+        $oldField => 'ai_central',
+        $newField => 'cross_cutting_infra',
+        'razao' => 'Reclassificação validada com Wagner — IA passou a ser tratada como infra cross-cutting compartilhada.',
+    ], $r->rules());
+
+    expect($v->passes())->toBeTrue($v->errors()->toJson());
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 2. razao curta (<20 chars) falha
+// ──────────────────────────────────────────────────────────────────
+
+it('razao com menos de 20 chars falha (anti-ajuste-sem-registro)', function () {
+    /** @var \Illuminate\Foundation\Http\FormRequest $r */
+    $r = new ($this->requestClass)();
+    [$oldField, $newField] = detectBucketFields($r);
+
+    $v = Validator::make([
+        'module' => 'Jana',
+        $oldField => 'ai_central',
+        $newField => 'cross_cutting_infra',
+        'razao' => 'ajuste rapido', // 13 chars
+    ], $r->rules());
+
+    expect($v->fails())->toBeTrue();
+    expect($v->errors()->has('razao'))->toBeTrue();
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 3. old_bucket fora da whitelist canon
+// ──────────────────────────────────────────────────────────────────
+
+it('old_bucket fora da whitelist canon ADR 0160 falha', function () {
+    /** @var \Illuminate\Foundation\Http\FormRequest $r */
+    $r = new ($this->requestClass)();
+    [$oldField, $newField] = detectBucketFields($r);
+
+    $v = Validator::make([
+        'module' => 'Jana',
+        $oldField => 'inventado_legacy', // não canon
+        $newField => 'cross_cutting_infra',
+        'razao' => 'Reclassificação validada com Wagner pós-W28 governance v4.',
+    ], $r->rules());
+
+    expect($v->fails())->toBeTrue();
+    expect($v->errors()->has($oldField))->toBeTrue();
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 4. new_bucket fora da whitelist canon
+// ──────────────────────────────────────────────────────────────────
+
+it('new_bucket fora da whitelist canon ADR 0160 falha', function () {
+    /** @var \Illuminate\Foundation\Http\FormRequest $r */
+    $r = new ($this->requestClass)();
+    [$oldField, $newField] = detectBucketFields($r);
+
+    $v = Validator::make([
+        'module' => 'Jana',
+        $oldField => 'ai_central',
+        $newField => 'super_meta_bucket', // não canon
+        'razao' => 'Reclassificação validada com Wagner pós-W28 governance v4.',
+    ], $r->rules());
+
+    expect($v->fails())->toBeTrue();
+    expect($v->errors()->has($newField))->toBeTrue();
+});
+
+// ──────────────────────────────────────────────────────────────────
+// 5. module required
+// ──────────────────────────────────────────────────────────────────
+
+it('module ausente falha (required)', function () {
+    /** @var \Illuminate\Foundation\Http\FormRequest $r */
+    $r = new ($this->requestClass)();
+    [$oldField, $newField] = detectBucketFields($r);
+
+    $v = Validator::make([
+        $oldField => 'ai_central',
+        $newField => 'cross_cutting_infra',
+        'razao' => 'Reclassificação validada com Wagner pós-W28 governance v4.',
+    ], $r->rules());
+
+    expect($v->fails())->toBeTrue();
+    expect($v->errors()->has('module'))->toBeTrue();
+});

--- a/resources/js/Pages/Admin/GovernanceV4.charter.md
+++ b/resources/js/Pages/Admin/GovernanceV4.charter.md
@@ -1,0 +1,155 @@
+---
+page: Admin/GovernanceV4
+controller: Modules\Admin\Http\Controllers\GovernanceV4DashboardController@indexV2
+route: admin.governance.v4
+status: draft
+owner: [W] Wagner
+persona_principal: Wagner / governance command center (1440px desktop)
+persona_secundaria: time MCP futuro (Felipe/Maiara — read-only ONDA 7+)
+charter_version: 1.0
+charter_at: 2026-05-17
+related_adrs:
+  - 0160-governance-v4-scoped-scorecards-buckets
+  - 0161-governance-v4-aposentar-hacks-0159-redundantes
+  - 0162-otel-collector-prod-observability
+  - 0163-governance-v4-metas-alcancadas-ondas-19-28
+  - 0039-ui-chat-cockpit-padrao
+  - 0104-processo-mwart-canonico-unico-caminho
+related_briefing: ../../../memory/requisitos/Governance/BRIEFING.md
+related_predecessor_visual: resources/js/Pages/kb/Index.v2.tsx
+mwart_pattern_reuse:
+  blueprint_canonical: resources/js/Pages/kb/Index.v2.tsx (tri-pane validado prod)
+  blueprint_screenshot_approval: SKIP (kb_v2 já validado Wagner ONDA 2)
+  derived_screens: [Admin/GovernanceV4]
+  divergence_from_blueprint: "Sidebar=Buckets (não Categorias) + Lista=Módulos (não Nós) + Leitor=ModuleBreakdown (não NodeReader markdown)"
+---
+
+# Charter — `resources/js/Pages/Admin/GovernanceV4.tsx` (DRAFT)
+
+> Tela governance v4 tri-pane. Copia EXATAMENTE pattern visual de `resources/js/Pages/kb/Index.v2.tsx` (blueprint validado Wagner ONDA 2 — gate F1.5 SKIP). Coexiste com Admin/Governance.tsx (v3) durante ONDA 7 até cutover via flag `v4_enabled`.
+
+## Mission
+
+Command center governance v4 — visualizar 28 waves consecutivas (W11-W28) + 34 módulos × 4 buckets canônicos + drift detection + Initiatives (Cortex-style) + AI suggestions READ-ONLY. Permitir Wagner ajustar desvios via 3 mecanismos: criar Initiative manual / disparar bucket override workflow / validar AI suggestion. Layout tri-pane (sidebar buckets + lista módulos + leitor breakdown) portado do blueprint kb_v2 com divergência semântica (buckets ≠ categorias, módulos ≠ nós, breakdown ≠ markdown).
+
+## Goals (faz)
+
+1. **BucketSidebar** 4 buckets canônicos com contagem módulos: `vertical_client_facing` (5) / `cross_cutting_infra` (7) / `ai_central` (2) / `functional_horizontal` (20) + accordion "Wave history W11-W28" (timeline cronológica)
+2. **ModuleList** módulos do bucket selecionado, filter chips pills `rounded-full`: `meta-only` (abaixo target bucket) / `drift` (delta >5pts últimos 7d) / score range (60-79 / 80-89 / ≥90)
+3. **ModuleReader** header KPIs nota total + bucket + meta + status (✓/⚠/✗) + sparkline 30d nota; abaixo 9 dimensões (D1-D9) com progress bars + paired indicator badge; embaixo lista Initiatives open (deadline countdown) + AiSuggestionPanel READ-ONLY
+4. **CommandPaletteV4** ⌘K busca cross-domínio: módulos / initiatives / waves / ADRs
+5. **DriftAlertBanner** topo fixo vermelho persistente se >0 drifts >5pts/7d detectados (snapshot diário)
+6. **Quick actions** header: "Abrir Initiative manual" / "Override bucket" (PR workflow `bucket-change-approved`) / "Marcar revisão" / "Trigger drift snapshot now"
+7. **HealthPanelV4** acionável: ScorecardSnapshot cron last_run + AI baseline 30d countdown + OTel collector ping CT 100
+8. **Fallback MOCK** quando `v4_enabled=false` (mostra v3 score como placeholder + banner "v4 em rollout ONDA 7+")
+9. **Persistência localStorage** prefix `oimpresso.governance.v4.*` (último bucket selecionado, último módulo, filter state, accordion expandido)
+
+## Non-Goals (NÃO faz)
+
+> Wagner aprova lista. Cada item vira Pest GUARD.
+
+- Editar scorecard YAML inline (vai pra `Admin/GovernanceYaml.charter.md` futuro)
+- Spawn waves direto da UI (continua via `/evolui` slash command Claude Code)
+- Substituir `php artisan module:grade-v4 --all` CLI (UI complementa, não substitui)
+- Edição de ADRs inline (vai pra `Admin/AdrEditor.charter.md` futuro)
+- Dashboard cross-business (Wagner-only via IsWagner middleware — governance é repo-wide intencional)
+- Substituir `Admin/Governance.tsx` (v3 atual) — paralelo até cutover ONDA 7 via flag
+
+## UX Targets
+
+- First-paint < 800ms (5 props pesadas em `Inertia::defer`: modules / scorecards / drifts / initiatives / aiSuggestions)
+- DriftAlertBanner vermelho persistente se ≥1 drift detectado (não dismissable até resolução)
+- Sparkline trend instantâneo (Recharts ou linha SVG inline leve — sem network call extra)
+- ⌘K CommandPaletteV4 abre < 100ms (cache local 200 primeiros módulos + lazy ADRs/waves)
+- 1440px desktop sem scroll horizontal (Wagner monitor primário)
+- Cores semânticas Cockpit V2 (NÃO `bg-(red|green)-N` cru) — drift vermelho via `text-destructive` token
+- Tipografia canon ADR 0110
+
+## UX Anti-patterns
+
+- Modal pra detalhe módulo (canon = pane direito tri-pane — divergir = retrabalho gate visual)
+- Tabs `border-b-2` em filter chips (canon = pills `rounded-full`)
+- `sessionStorage` (canon = `localStorage` prefixed `oimpresso.governance.v4.*`)
+- Cor crua hardcoded sem semantic token (`bg-red-500` proibido)
+- Atualização tempo-real Centrifugo (ONDA 7 — não W29; polling 30s ou refresh manual)
+- Edição inline de scorecard/ADR (read-mostly tela; ações = botões disparam workflows externos)
+
+## Automation Hooks
+
+- `GET /admin/governance/v4` — `GovernanceV4DashboardController@indexV2` (Inertia::defer obrigatório nas 5 props pesadas — RUNBOOK-inertia-defer-pattern)
+- `POST /admin/governance/v4/initiative` — criar Initiative manual (Wagner-only, IsWagner middleware)
+- `POST /admin/governance/v4/override-bucket` — trigger PR workflow GitHub Actions com label `bucket-change-approved`
+- `GET /admin/governance/v4/refresh` — re-run `module:grade-v4` + `ScorecardSnapshotCommand` on-demand (Wagner action)
+- `GET /admin/governance/v4/health` — ping ScorecardSnapshot cron + AI baseline + OTel collector
+- IsWagner middleware (canon admin — governance é Wagner-only por ora)
+
+## Automation Anti-hooks
+
+> Wagner aprova lista. Vira Pest GUARD.
+
+- NÃO envia emails/SMS/WhatsApp ao abrir (read-mostly)
+- NÃO escreve no DB no render (read-only — initiatives create é POST explícito, não Inertia::render)
+- NÃO dispara `module:grade-v4` automático no render (custoso; refresh é ação Wagner)
+- NÃO chama Brain B/Sonnet no render (AI suggestions já materializadas via baseline 30d cron)
+- NÃO acessa scorecards de outro `business_id` (governance é repo-wide intencional — documentar `withoutGlobalScopes` com `// SUPERADMIN: governance is repo-wide`)
+- NÃO loga PII em audit (governance não toca dados cliente, mas sanitizer obrigatório por convenção)
+- NÃO permite acesso fora Wagner (IsWagner middleware fail-secure)
+
+## Sub-components em `_components/` (W29-C scope)
+
+10 sub-components a serem criados pela W29-C (Agent C):
+
+- `BucketSidebar.tsx` — 4 buckets + contagem + accordion Wave history W11-W28
+- `ModuleList.tsx` — lista filtrada do bucket + filter chips pills
+- `ModuleReader.tsx` — KPIs nota + sparkline + 9 dimensões + initiatives + ai panel
+- `DimensionProgressBar.tsx` — progress bar D1-D9 com paired indicator badge
+- `SparklineTrend.tsx` — linha SVG 30 pontos (no network call extra)
+- `InitiativeBadge.tsx` — deadline countdown + status badge (open/in_progress/done/overdue)
+- `DriftAlertBanner.tsx` — vermelho fixo topo se drifts > 0 (não dismissable)
+- `AiSuggestionPanel.tsx` — READ-ONLY 30d list (suggestions baseline AI)
+- `HealthPanelV4.tsx` — extends kb HealthPanel (ScorecardSnapshot cron / AI baseline / OTel ping)
+- `CommandPaletteV4.tsx` — extends kb CommandPalette cross-search (módulos/initiatives/waves/ADRs)
+
+## Métricas vivas (Pest GUARD pendente W29-D)
+
+```php
+it('renders /admin/governance/v4 in <800ms p95 with 34 modules + defer')
+it('does not dispatch jobs on render (read-mostly)')
+it('does not mutate state on GET')
+it('blocks non-Wagner users via IsWagner middleware (403)')
+it('renders at 1440px without horizontal scroll')
+it('uses localStorage prefix oimpresso.governance.v4.* (never sessionStorage)')
+it('falls back to v3 score when v4_enabled=false')
+it('keyboard ⌘K opens CommandPaletteV4')
+it('shows DriftAlertBanner when drifts >5pts in 7d exist')
+it('respects withoutGlobalScopes only for governance repo-wide queries')
+it('all 5 heavy props use Inertia::defer (modules, scorecards, drifts, initiatives, aiSuggestions)')
+```
+
+## Comparáveis canônicos (`mwart-comparative` V4)
+
+- **Linear** (command palette ⌘K densidade + tri-pane issue navigator) — referência principal layout
+- **Cortex** (Initiatives + Scorecards governance pattern) — referência conceitual buckets + initiatives
+- **Datadog** (drift alert banner persistente + sparkline trend) — referência visual drift
+- **Excluir:** Jira (overhead enterprise), Confluence (sem tri-pane), Notion (sem governance score)
+
+## Refs
+
+- Blueprint canônico tri-pane: [`resources/js/Pages/kb/Index.v2.tsx`](../kb/Index.v2.tsx) (validado Wagner ONDA 2)
+- Charter blueprint: [`kb/Index.v2.charter.md`](../kb/Index.v2.charter.md)
+- [ADR 0160 — Governance v4 scoped scorecards + buckets](../../../memory/decisions/0160-governance-v4-scoped-scorecards-buckets.md)
+- [ADR 0161 — Aposentar hacks 0159 redundantes](../../../memory/decisions/0161-governance-v4-aposentar-hacks-0159-redundantes.md)
+- [ADR 0162 — OTel collector prod observability](../../../memory/decisions/0162-otel-collector-prod-observability.md)
+- [ADR 0163 — Metas alcançadas ondas 19-28](../../../memory/decisions/0163-governance-v4-metas-alcancadas-ondas-19-28.md)
+- [ADR 0039 — UI Chat Cockpit Padrão](../../../memory/decisions/0039-ui-chat-cockpit-padrao.md)
+- [ADR 0104 — Processo MWART canônico](../../../memory/decisions/0104-processo-mwart-canonico-unico-caminho.md)
+- [ADR 0110 — Cockpit Pattern V2](../../../memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md)
+- BRIEFING: [`memory/requisitos/Governance/BRIEFING.md`](../../../memory/requisitos/Governance/BRIEFING.md)
+- Backend: `Modules/Admin/Http/Controllers/GovernanceV4DashboardController.php` (indexV2 pendente W29-B)
+- RUNBOOK Inertia::defer: [`memory/requisitos/_DesignSystem/RUNBOOK-inertia-defer-pattern.md`](../../../memory/requisitos/_DesignSystem/RUNBOOK-inertia-defer-pattern.md)
+
+## Histórico
+
+| Data | Autor | Mudança |
+|---|---|---|
+| 2026-05-17 | W29 Agent A | Charter draft criado pra GovernanceV4.tsx (tri-pane copy kb_v2). Gate F1.5 SKIP (kb_v2 blueprint já validado Wagner ONDA 2). Pendente aprovação Wagner em Non-Goals + Anti-hooks pra `status: live`. |

--- a/resources/js/Pages/Admin/GovernanceV4.tsx
+++ b/resources/js/Pages/Admin/GovernanceV4.tsx
@@ -1,0 +1,596 @@
+// @memcofre
+//   tela: /admin/governance/v4
+//   module: Admin
+//   stories: ONDA 7 Governance v4 — Wave 29 W29-C
+//   charter: resources/js/Pages/Admin/GovernanceV4.charter.md
+//   adrs: 0160, 0161, 0162, 0163, 0039, 0104, 0110, 0093, 0094
+//
+// W29-C — tri-pane copy do blueprint validado `kb/Index.v2.tsx`.
+// Gate visual F1.5 SKIP (charter §mwart_pattern_reuse: blueprint kb_v2 já
+// aprovado Wagner ONDA 2). Divergência semântica:
+//   - sidebar = Buckets canon (4 fixos ADR 0160) + Wave history
+//   - lista   = Módulos do bucket selecionado + filter chips pills
+//   - leitor  = ModuleReader (header KPIs + sparkline + 9 dimensões +
+//               initiatives + AI panel)
+//
+// Backend pendente W29-B (Controller `indexV2` apontando Inertia::render
+// 'Admin/GovernanceV4'). Quando props pesadas (modules/scorecards/drifts/
+// initiatives/aiSuggestions/healthSnapshot) virem ausentes, página entra em
+// modo MOCK degradado mas funcional.
+//
+// Coexiste com `Admin/GovernanceV4Dashboard.tsx` (Wave 27 polish) — não
+// substitui até cutover ONDA 7 via flag `meta.v4_enabled`.
+
+import * as React from 'react';
+import { Head, useForm, Deferred } from '@inertiajs/react';
+import { toast } from 'sonner';
+import {
+  Sparkles,
+  Plus,
+  HeartPulse,
+  RefreshCw,
+  Search as SearchIcon,
+  GitBranch,
+  Settings2,
+} from 'lucide-react';
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import PageHeader from '@/Components/shared/PageHeader';
+import KpiGrid from '@/Components/shared/KpiGrid';
+import KpiCard from '@/Components/shared/KpiCard';
+import { Button } from '@/Components/ui/button';
+import { Skeleton } from '@/Components/ui/skeleton';
+
+import BucketSidebar from './_components/BucketSidebar';
+import ModuleList, { type ModuleListFilters } from './_components/ModuleList';
+import ModuleReader from './_components/ModuleReader';
+import DriftAlertBanner from './_components/DriftAlertBanner';
+import CommandPaletteV4 from './_components/CommandPaletteV4';
+import HealthPanelV4 from './_components/HealthPanelV4';
+import {
+  BUCKET_LABEL_FALLBACK,
+  BUCKET_ORDER,
+  type BucketDef,
+  type BucketKey,
+  type GovernanceV4PageProps,
+  type ModuleRow,
+} from './_components/governanceV4Types';
+
+import '../../../css/kb.css';
+
+const LS_PREFIX = 'oimpresso.governance.v4.';
+const LS_BUCKET = `${LS_PREFIX}bucket`;
+const LS_MODULE = `${LS_PREFIX}module`;
+const LS_FILTERS = `${LS_PREFIX}filters`;
+const LS_WAVE_EXPANDED = `${LS_PREFIX}waveExpanded`;
+
+function loadJson<T>(key: string, fallback: T): T {
+  if (typeof window === 'undefined') return fallback;
+  try {
+    const raw = window.localStorage.getItem(key);
+    return raw ? (JSON.parse(raw) as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function saveJson(key: string, value: unknown): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    /* quota — ignore */
+  }
+}
+
+const DEFAULT_FILTERS: ModuleListFilters = {
+  q: '',
+  metaOnly: false,
+  driftOnly: false,
+  scoreRange: 'all',
+  statusOnly: null,
+};
+
+function GovernanceV4(props: GovernanceV4PageProps) {
+  const meta = props.meta;
+  const can = props.can ?? {
+    create_initiative: true,
+    override_bucket: true,
+    refresh_now: true,
+  };
+
+  // ── persistência localStorage (charter §UX Targets) ────────────────
+  const [selectedBucket, setSelectedBucketState] = React.useState<BucketKey | 'all'>(
+    () => loadJson<BucketKey | 'all'>(LS_BUCKET, 'all'),
+  );
+  const [selectedSlug, setSelectedSlugState] = React.useState<string | null>(() =>
+    loadJson<string | null>(LS_MODULE, null),
+  );
+  const [filters, setFiltersState] = React.useState<ModuleListFilters>(() =>
+    loadJson<ModuleListFilters>(LS_FILTERS, DEFAULT_FILTERS),
+  );
+  const [waveExpanded, setWaveExpandedState] = React.useState<boolean>(() =>
+    loadJson<boolean>(LS_WAVE_EXPANDED, false),
+  );
+
+  const setSelectedBucket = (b: BucketKey | 'all') => {
+    setSelectedBucketState(b);
+    saveJson(LS_BUCKET, b);
+  };
+  const setSelectedSlug = (s: string | null) => {
+    setSelectedSlugState(s);
+    saveJson(LS_MODULE, s);
+  };
+  const setFilters = (f: ModuleListFilters) => {
+    setFiltersState(f);
+    saveJson(LS_FILTERS, f);
+  };
+  const setWaveExpanded = (v: boolean) => {
+    setWaveExpandedState(v);
+    saveJson(LS_WAVE_EXPANDED, v);
+  };
+
+  // ── overlays state ────────────────────────────────────────────────
+  const [paletteOpen, setPaletteOpen] = React.useState(false);
+  const [healthOpen, setHealthOpen] = React.useState(false);
+
+  // ── derived buckets (sempre 4 — preenchidos via prop ou vazios) ───
+  const bucketsDef: BucketDef[] = React.useMemo(() => {
+    return BUCKET_ORDER.map((key) => {
+      const bucketMeta = meta.buckets?.[key];
+      const list = props.modules?.[key] ?? [];
+      return {
+        key,
+        label: bucketMeta?.label ?? BUCKET_LABEL_FALLBACK[key],
+        meta: bucketMeta?.meta ?? 80,
+        count: list.length,
+      };
+    });
+  }, [meta.buckets, props.modules]);
+
+  // ── flat modules list pra command palette + 'all' view ────────────
+  const allModules: ModuleRow[] = React.useMemo(() => {
+    if (!props.modules) return [];
+    return BUCKET_ORDER.flatMap((k) =>
+      (props.modules![k] ?? []).map((m) => ({ ...m, bucket: k })),
+    );
+  }, [props.modules]);
+
+  // ── módulos visíveis no painel central ────────────────────────────
+  const bucketModules: ModuleRow[] =
+    selectedBucket === 'all'
+      ? allModules
+      : props.modules?.[selectedBucket] ?? [];
+
+  const bucketLabel =
+    selectedBucket === 'all'
+      ? 'Todos os módulos'
+      : meta.buckets?.[selectedBucket]?.label ?? BUCKET_LABEL_FALLBACK[selectedBucket];
+  const bucketMeta =
+    selectedBucket === 'all' ? 0 : meta.buckets?.[selectedBucket]?.meta ?? 80;
+
+  // ── drifts set pra cruzamento rápido ─────────────────────────────
+  const driftedSlugs = React.useMemo(
+    () => new Set((props.drifts ?? []).map((d) => d.module)),
+    [props.drifts],
+  );
+
+  // ── seleção módulo / navegação prev/next ─────────────────────────
+  const selectedModule: ModuleRow | null =
+    (selectedSlug && bucketModules.find((m) => m.slug === selectedSlug)) ||
+    (selectedSlug && allModules.find((m) => m.slug === selectedSlug)) ||
+    null;
+
+  const currentIdx = selectedModule
+    ? bucketModules.findIndex((m) => m.slug === selectedModule.slug)
+    : -1;
+  const prevModule = currentIdx > 0 ? bucketModules[currentIdx - 1] : null;
+  const nextModule =
+    currentIdx >= 0 && currentIdx < bucketModules.length - 1
+      ? bucketModules[currentIdx + 1]
+      : null;
+
+  const selectedScorecard =
+    selectedModule && props.scorecards
+      ? props.scorecards[selectedModule.slug] ?? null
+      : null;
+
+  // ── KPIs header ────────────────────────────────────────────────────
+  const headerKpis = React.useMemo(() => {
+    if (allModules.length === 0) {
+      return {
+        avg: 0,
+        excelente: 0,
+        drifts: (props.drifts ?? []).length,
+        initiativesOpen: 0,
+        target: 97.75, // meta global histórica, charter §Mission
+      };
+    }
+    const sum = allModules.reduce((acc, m) => acc + m.score, 0);
+    const avg = Math.round((sum / allModules.length) * 100) / 100;
+    const excelente = allModules.filter((m) => m.score >= 90).length;
+    const initiativesOpen = (props.initiatives ?? []).filter(
+      (i) => i.status === 'open' || i.status === 'in_progress',
+    ).length;
+    return {
+      avg,
+      excelente,
+      drifts: (props.drifts ?? []).length,
+      initiativesOpen,
+      target: 97.75,
+    };
+  }, [allModules, props.drifts, props.initiatives]);
+
+  // ── keyboard ⌘K / Ctrl+K ─────────────────────────────────────────
+  React.useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === 'k') {
+        e.preventDefault();
+        setPaletteOpen((v) => !v);
+      } else if (e.key === 'Escape') {
+        if (paletteOpen) setPaletteOpen(false);
+        else if (healthOpen) setHealthOpen(false);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [paletteOpen, healthOpen]);
+
+  // ── Inertia useForm — POST initiative + override ─────────────────
+  const initiativeForm = useForm<{
+    module: string;
+    title: string;
+    deadline_at?: string;
+    notes?: string;
+  }>({
+    module: '',
+    title: '',
+    deadline_at: undefined,
+    notes: undefined,
+  });
+
+  const overrideForm = useForm<{ module: string; bucket: BucketKey; reason: string }>({
+    module: '',
+    bucket: 'vertical_client_facing',
+    reason: '',
+  });
+
+  const openInitiativeNew = (moduleSlug: string) => {
+    initiativeForm.setData('module', moduleSlug);
+    // ONDA 7+ — sub-component InitiativeComposerDialog (W29-D pendente).
+    // Atalho v1: prompt nativo até dialog estar pronta (mock visível pra Wagner).
+    if (typeof window === 'undefined') return;
+    const title = window.prompt(
+      `Initiative pra ${moduleSlug}\n\nTítulo curto da iniciativa:`,
+    );
+    if (!title) return;
+    initiativeForm.setData('title', title);
+    initiativeForm.post('/admin/governance/v4/initiative', {
+      preserveScroll: true,
+      onSuccess: () => toast.success(`Initiative criada pra ${moduleSlug}`),
+      onError: () =>
+        toast.error('Falha ao criar Initiative — verifique payload + permissão'),
+    });
+  };
+
+  const openOverride = (moduleSlug: string) => {
+    overrideForm.setData('module', moduleSlug);
+    if (typeof window === 'undefined') return;
+    const reason = window.prompt(
+      `Override bucket de ${moduleSlug}\n\nMotivo (vai virar label PR bucket-change-approved):`,
+    );
+    if (!reason) return;
+    overrideForm.setData('reason', reason);
+    overrideForm.post('/admin/governance/v4/override-bucket', {
+      preserveScroll: true,
+      onSuccess: () =>
+        toast.success(`Override solicitado pra ${moduleSlug} — PR pendente`),
+      onError: () => toast.error('Falha ao disparar override workflow'),
+    });
+  };
+
+  const refreshNow = (moduleSlug?: string) => {
+    toast.info(
+      moduleSlug
+        ? `Disparando refresh módulo ${moduleSlug}…`
+        : 'Disparando refresh global module:grade-v4…',
+    );
+    // ONDA 7+: GET /admin/governance/v4/refresh?module=...
+    // Por ora apenas reload Inertia (controller recomputa sob demanda quando indexV2 lá)
+    if (typeof window !== 'undefined') {
+      window.setTimeout(() => window.location.reload(), 600);
+    }
+  };
+
+  return (
+    <>
+      <Head title="Governance v4" />
+
+      <div className="flex flex-col gap-3 px-4 py-3 min-h-0 h-[calc(100vh-3.5rem)]">
+        <PageHeader
+          icon="bar-chart-3"
+          title="Governance v4"
+          description={
+            meta.v4_enabled
+              ? `Tri-pane · ${allModules.length} módulos × ${bucketsDef.length} buckets canon · gerado ${new Date(meta.generated_at).toLocaleString('pt-BR')}`
+              : 'Tri-pane MOCK — v4_enabled=false (rollout ONDA 7+)'
+          }
+          action={
+            <div className="flex items-center gap-1.5 flex-wrap">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 text-xs"
+                onClick={() => setHealthOpen(true)}
+              >
+                <HeartPulse size={13} className="mr-1.5" />
+                Saúde v4
+              </Button>
+              {can.refresh_now && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 text-xs"
+                  onClick={() => refreshNow()}
+                >
+                  <RefreshCw size={13} className="mr-1.5" />
+                  Refresh now
+                </Button>
+              )}
+              {can.override_bucket && selectedModule && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="h-8 text-xs"
+                  onClick={() => openOverride(selectedModule.slug)}
+                >
+                  <Settings2 size={13} className="mr-1.5" />
+                  Override bucket
+                </Button>
+              )}
+              {can.create_initiative && (
+                <Button
+                  variant="default"
+                  size="sm"
+                  className="h-8 text-xs"
+                  onClick={() =>
+                    openInitiativeNew(selectedModule?.slug ?? 'oimpresso')
+                  }
+                >
+                  <Plus size={13} className="mr-1" />
+                  Initiative manual
+                </Button>
+              )}
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 text-xs"
+                onClick={() => setPaletteOpen(true)}
+              >
+                <kbd className="kb-kbd mr-1.5">⌘K</kbd>
+                Buscar
+              </Button>
+            </div>
+          }
+        />
+
+        {/* KPIs header — overview macro */}
+        <KpiGrid cols={5}>
+          <KpiCard
+            label="Média atual"
+            value={headerKpis.avg || '—'}
+            description={`${allModules.length} módulos avaliados`}
+            icon="bar-chart-3"
+            tone={
+              headerKpis.avg >= headerKpis.target
+                ? 'success'
+                : headerKpis.avg >= headerKpis.target - 5
+                  ? 'warning'
+                  : 'default'
+            }
+            size="compact"
+          />
+          <KpiCard
+            label="Meta global"
+            value={headerKpis.target}
+            description="ADR 0160 · teto natural"
+            icon="target"
+            tone="info"
+            size="compact"
+          />
+          <KpiCard
+            label="Excelente (≥90)"
+            value={headerKpis.excelente}
+            description="módulos passando meta"
+            icon="trophy"
+            tone={headerKpis.excelente > 0 ? 'success' : 'default'}
+            size="compact"
+          />
+          <KpiCard
+            label="Drifts ativos"
+            value={headerKpis.drifts}
+            description={`Δ > ±${meta.drift_threshold_pts}pts/7d`}
+            icon="alert-triangle"
+            tone={headerKpis.drifts > 0 ? 'danger' : 'success'}
+            size="compact"
+          />
+          <KpiCard
+            label="Initiatives abertas"
+            value={headerKpis.initiativesOpen}
+            description="open + in_progress"
+            icon="clipboard-list"
+            tone={headerKpis.initiativesOpen > 0 ? 'warning' : 'default'}
+            size="compact"
+          />
+        </KpiGrid>
+
+        {/* Drift banner persistente (não dismissable se >0) */}
+        <Deferred data="drifts" fallback={<Skeleton className="h-10 w-full" />}>
+          <DriftAlertBanner
+            drifts={props.drifts ?? []}
+            thresholdPts={meta.drift_threshold_pts}
+            onPickModule={(slug) => {
+              const m = allModules.find((x) => x.slug === slug);
+              if (m?.bucket) setSelectedBucket(m.bucket);
+              setSelectedSlug(slug);
+            }}
+            onViewAll={() => {
+              setFilters({ ...filters, driftOnly: true });
+              setSelectedBucket('all');
+              toast.info('Filtro "Drift" aplicado.');
+            }}
+          />
+        </Deferred>
+
+        {/* Tri-pane */}
+        <div
+          className="kb-tri rounded-md border border-border overflow-hidden flex-1 min-h-0"
+          data-mobile-view="list"
+        >
+          <Deferred
+            data="modules"
+            fallback={<SidebarSkeleton />}
+          >
+            <BucketSidebar
+              buckets={bucketsDef}
+              selectedBucket={selectedBucket}
+              onSelect={(b) => {
+                setSelectedBucket(b);
+                setSelectedSlug(null);
+              }}
+              waveHistory={props.waveHistory ?? []}
+              waveExpanded={waveExpanded}
+              onToggleWaveHistory={() => setWaveExpanded(!waveExpanded)}
+            />
+          </Deferred>
+
+          <Deferred data="modules" fallback={<ListSkeleton />}>
+            <ModuleList
+              modules={bucketModules}
+              bucketLabel={bucketLabel}
+              bucketMeta={bucketMeta}
+              filters={filters}
+              onChangeFilters={setFilters}
+              driftedSlugs={driftedSlugs}
+              selectedSlug={selectedSlug}
+              onSelectModule={setSelectedSlug}
+            />
+          </Deferred>
+
+          <Deferred data={['scorecards', 'initiatives', 'aiSuggestions']} fallback={<ReaderSkeleton />}>
+            <ModuleReader
+              module={selectedModule}
+              scorecard={selectedScorecard}
+              initiatives={props.initiatives ?? []}
+              aiSuggestions={props.aiSuggestions ?? []}
+              prev={prevModule}
+              next={nextModule}
+              onPickPrev={() => prevModule && setSelectedSlug(prevModule.slug)}
+              onPickNext={() => nextModule && setSelectedSlug(nextModule.slug)}
+              onOpenInitiativeNew={
+                can.create_initiative ? openInitiativeNew : undefined
+              }
+              onOpenOverride={can.override_bucket ? openOverride : undefined}
+              onRefresh={can.refresh_now ? refreshNow : undefined}
+            />
+          </Deferred>
+        </div>
+
+        {/* Overlays */}
+        <CommandPaletteV4
+          open={paletteOpen}
+          onOpenChange={setPaletteOpen}
+          modules={allModules}
+          initiatives={props.initiatives ?? []}
+          waves={props.waveHistory ?? []}
+          onPickModule={(slug) => {
+            const m = allModules.find((x) => x.slug === slug);
+            if (m?.bucket) setSelectedBucket(m.bucket);
+            setSelectedSlug(slug);
+          }}
+          onPickInitiative={(id) => {
+            const ini = (props.initiatives ?? []).find((i) => i.id === id);
+            if (ini) {
+              const m = allModules.find((x) => x.slug === ini.module);
+              if (m?.bucket) setSelectedBucket(m.bucket);
+              setSelectedSlug(ini.module);
+            }
+          }}
+          onPickWave={(waveId) => {
+            toast.info(`Wave ${waveId} — drawer histórico em ONDA 7+`);
+            setWaveExpanded(true);
+          }}
+          onPickAdr={(adr) => {
+            toast.info(`Abrindo ADR ${adr.number}…`);
+            // ONDA 7+: navega pra /memoria?q=adr+{number} ou abre dialog dedicado
+          }}
+        />
+
+        <HealthPanelV4
+          open={healthOpen}
+          onOpenChange={setHealthOpen}
+          snapshot={props.healthSnapshot ?? null}
+        />
+      </div>
+    </>
+  );
+}
+
+// ── Skeletons defer fallback ──────────────────────────────────────────
+
+function SidebarSkeleton() {
+  return (
+    <aside className="flex flex-col gap-2 border-r border-border bg-card p-3">
+      <Skeleton className="h-3 w-24" />
+      {[0, 1, 2, 3].map((i) => (
+        <Skeleton key={i} className="h-9 w-full" />
+      ))}
+    </aside>
+  );
+}
+
+function ListSkeleton() {
+  return (
+    <div className="flex flex-col gap-2 border-r border-border bg-background p-3">
+      <Skeleton className="h-6 w-32" />
+      <Skeleton className="h-7 w-full" />
+      {[0, 1, 2, 3, 4, 5].map((i) => (
+        <Skeleton key={i} className="h-14 w-full" />
+      ))}
+    </div>
+  );
+}
+
+function ReaderSkeleton() {
+  return (
+    <div className="flex flex-col gap-3 bg-background p-4">
+      <Skeleton className="h-6 w-48" />
+      <Skeleton className="h-3 w-32" />
+      <div className="grid grid-cols-4 gap-2">
+        {[0, 1, 2, 3].map((i) => (
+          <Skeleton key={i} className="h-14 w-full" />
+        ))}
+      </div>
+      <Skeleton className="h-20 w-full" />
+      <div className="space-y-2">
+        {[0, 1, 2, 3, 4].map((i) => (
+          <Skeleton key={i} className="h-6 w-full" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+GovernanceV4.layout = (page: React.ReactNode) => (
+  <AppShellV2
+    title="Governance v4"
+    breadcrumbItems={[{ label: 'Admin' }, { label: 'Governance v4' }]}
+  >
+    {page}
+  </AppShellV2>
+);
+
+export default GovernanceV4;
+
+// Tipos consumíveis pelo backend W29-B:
+//   import type { GovernanceV4PageProps } from '@/Pages/Admin/_components/governanceV4Types'

--- a/resources/js/Pages/Admin/_components/AiSuggestionPanel.tsx
+++ b/resources/js/Pages/Admin/_components/AiSuggestionPanel.tsx
@@ -1,0 +1,108 @@
+import * as React from 'react';
+import { Sparkles, TrendingUp, TrendingDown } from 'lucide-react';
+import { cn } from '@/Lib/utils';
+import type { AiSuggestion } from './governanceV4Types';
+
+/**
+ * AiSuggestionPanel — top 5 sugestões AI baseline 30d (READ-ONLY)
+ *
+ * Wave 29 (W29-C). Mostra suggestions agregadas do `mcp_scorecard_ai_suggestions`
+ * (Wave 24-B baseline 30d, observacional). Anti-Goodhart: NÃO altera score
+ * oficial — só serve como sinal pra Wagner inspecionar drift entre rubrica
+ * determinística vs avaliação LLM.
+ *
+ * Filtra por |avg_delta| > minDelta e mostra top N. Cada item:
+ *  - módulo
+ *  - delta médio (com seta up/down)
+ *  - última justificativa (truncada)
+ *  - confidence + count
+ */
+interface Props {
+  suggestions: AiSuggestion[];
+  /** filtra módulo único; default = todos */
+  module?: string;
+  topN?: number;
+  minDelta?: number;
+  className?: string;
+  emptyHint?: string;
+}
+
+export default function AiSuggestionPanel({
+  suggestions,
+  module,
+  topN = 5,
+  minDelta = 1,
+  className,
+  emptyHint = 'Sem sinais relevantes nos últimos 30 dias.',
+}: Props) {
+  const filtered = React.useMemo(() => {
+    return suggestions
+      .filter((s) => (module ? s.module === module : true))
+      .filter((s) => Math.abs(s.avg_delta) >= minDelta)
+      .slice(0, topN);
+  }, [suggestions, module, topN, minDelta]);
+
+  return (
+    <section
+      className={cn('rounded-md border border-border bg-card p-3', className)}
+      aria-label="AI suggestions baseline 30d"
+    >
+      <header className="mb-2 flex items-center justify-between gap-2">
+        <div className="flex items-center gap-1.5 text-[12px] font-semibold text-foreground">
+          <Sparkles size={13} className="text-primary" />
+          AI baseline 30d
+          <span className="rounded-md border border-border bg-muted px-1 py-0.5 text-[9px] font-medium uppercase tracking-wider text-muted-foreground">
+            READ-ONLY
+          </span>
+        </div>
+        <span className="text-[10px] text-muted-foreground">
+          observacional · anti-Goodhart
+        </span>
+      </header>
+
+      {filtered.length === 0 ? (
+        <div className="rounded-md border border-dashed border-border bg-muted/40 px-2 py-3 text-center text-[11.5px] text-muted-foreground">
+          {emptyHint}
+        </div>
+      ) : (
+        <ul className="space-y-1.5">
+          {filtered.map((s) => {
+            const isUp = s.avg_delta > 0;
+            const Arrow = isUp ? TrendingUp : TrendingDown;
+            const toneCls = isUp
+              ? 'text-emerald-700 dark:text-emerald-400'
+              : 'text-destructive';
+            return (
+              <li
+                key={`${s.module}-${s.last_at ?? 'n'}`}
+                className="rounded-md border border-border bg-background px-2 py-1.5"
+              >
+                <div className="flex items-center justify-between gap-2">
+                  <span className="text-[12px] font-medium text-foreground truncate">
+                    {s.module}
+                  </span>
+                  <span className={cn('flex items-center gap-0.5 text-[11.5px] font-semibold tabular-nums', toneCls)}>
+                    <Arrow size={11} />
+                    {s.avg_delta > 0 ? '+' : ''}
+                    {s.avg_delta.toFixed(1)}pts
+                  </span>
+                </div>
+                <p
+                  className="mt-0.5 line-clamp-2 text-[10.5px] text-muted-foreground"
+                  title={s.last_justificativa}
+                >
+                  {s.last_justificativa || 'sem justificativa registrada'}
+                </p>
+                <div className="mt-0.5 flex items-center gap-2 text-[9.5px] text-muted-foreground">
+                  <span>n={s.count}</span>
+                  <span aria-hidden>·</span>
+                  <span>conf={(s.last_confidence * 100).toFixed(0)}%</span>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}

--- a/resources/js/Pages/Admin/_components/BucketSidebar.tsx
+++ b/resources/js/Pages/Admin/_components/BucketSidebar.tsx
@@ -1,0 +1,203 @@
+import * as React from 'react';
+import { ChevronRight, Layers, History, GitBranch } from 'lucide-react';
+import { cn } from '@/Lib/utils';
+import {
+  BUCKET_ORDER,
+  BUCKET_LABEL_FALLBACK,
+  type BucketDef,
+  type BucketKey,
+  type WaveHistoryEntry,
+} from './governanceV4Types';
+
+/**
+ * BucketSidebar — coluna 1 do tri-pane (port de kb/CategorySidebar)
+ *
+ * Wave 29 (W29-C). 4 buckets canônicos (ADR 0160) + accordion Wave history
+ * (timeline cronológica W11-W28+). Sidebar fixa esquerda, scrollável quando
+ * waveHistory cresce.
+ *
+ * Divergência semântica vs blueprint:
+ *  - kb_v2: categorias + subcategorias (n níveis, hue dinâmico)
+ *  - W29-C: 4 buckets canônicos (fixed) + 1 accordion Wave history
+ */
+interface Props {
+  buckets: BucketDef[];
+  selectedBucket: BucketKey | 'all';
+  onSelect: (bucket: BucketKey | 'all') => void;
+  waveHistory: WaveHistoryEntry[];
+  waveExpanded: boolean;
+  onToggleWaveHistory: () => void;
+  className?: string;
+}
+
+export default function BucketSidebar({
+  buckets,
+  selectedBucket,
+  onSelect,
+  waveHistory,
+  waveExpanded,
+  onToggleWaveHistory,
+  className,
+}: Props) {
+  const totalCount = buckets.reduce((acc, b) => acc + b.count, 0);
+
+  // Garante ordem canon (ADR 0160) mesmo se backend reordenar
+  const ordered: BucketDef[] = BUCKET_ORDER.map(
+    (k) =>
+      buckets.find((b) => b.key === k) ?? {
+        key: k,
+        label: BUCKET_LABEL_FALLBACK[k],
+        meta: 80,
+        count: 0,
+      },
+  );
+
+  return (
+    <aside
+      className={cn(
+        'kb-side flex flex-col overflow-y-auto border-r border-border bg-card p-3 gap-4',
+        className,
+      )}
+      aria-label="Buckets canon + Wave history"
+    >
+      {/* Section: buckets */}
+      <section>
+        <div className="mb-2 flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+          <Layers size={11} />
+          Buckets canon
+        </div>
+        <ul className="space-y-1">
+          <li>
+            <button
+              type="button"
+              onClick={() => onSelect('all')}
+              className={cn(
+                'group flex w-full items-center justify-between gap-2 rounded-md border px-2 py-1.5 text-left text-[12.5px] transition-colors',
+                selectedBucket === 'all'
+                  ? 'border-primary/40 bg-primary/10 text-foreground'
+                  : 'border-transparent text-foreground hover:bg-accent',
+              )}
+            >
+              <span className="font-medium">Todos os módulos</span>
+              <span
+                className={cn(
+                  'rounded-full border px-1.5 py-0.5 text-[10px] font-semibold tabular-nums',
+                  selectedBucket === 'all'
+                    ? 'border-primary/40 bg-card text-foreground'
+                    : 'border-border bg-muted text-muted-foreground',
+                )}
+              >
+                {totalCount}
+              </span>
+            </button>
+          </li>
+          {ordered.map((b) => {
+            const active = selectedBucket === b.key;
+            return (
+              <li key={b.key}>
+                <button
+                  type="button"
+                  onClick={() => onSelect(b.key)}
+                  className={cn(
+                    'group flex w-full items-start justify-between gap-2 rounded-md border px-2 py-1.5 text-left transition-colors',
+                    active
+                      ? 'border-primary/40 bg-primary/10'
+                      : 'border-transparent hover:bg-accent',
+                  )}
+                  aria-pressed={active}
+                >
+                  <div className="min-w-0">
+                    <div className="text-[12.5px] font-medium text-foreground truncate">
+                      {b.label}
+                    </div>
+                    <div className="text-[10px] text-muted-foreground">
+                      meta ≥ {b.meta}
+                    </div>
+                  </div>
+                  <span
+                    className={cn(
+                      'shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] font-semibold tabular-nums',
+                      active
+                        ? 'border-primary/40 bg-card text-foreground'
+                        : 'border-border bg-muted text-muted-foreground',
+                    )}
+                  >
+                    {b.count}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      </section>
+
+      {/* Section: wave history accordion */}
+      <section>
+        <button
+          type="button"
+          onClick={onToggleWaveHistory}
+          className="flex w-full items-center justify-between gap-2 rounded-md px-1 py-1 text-[10px] font-bold uppercase tracking-wider text-muted-foreground hover:bg-accent"
+          aria-expanded={waveExpanded}
+        >
+          <span className="flex items-center gap-1.5">
+            <History size={11} />
+            Wave history
+            <span className="rounded-md bg-muted px-1 text-[9px] tabular-nums normal-case">
+              {waveHistory.length}
+            </span>
+          </span>
+          <ChevronRight
+            size={12}
+            className={cn('transition-transform', waveExpanded && 'rotate-90')}
+          />
+        </button>
+        {waveExpanded && (
+          <ol className="mt-1.5 space-y-1 border-l border-border pl-2.5">
+            {waveHistory.length === 0 && (
+              <li className="text-[10.5px] italic text-muted-foreground py-1">
+                sem entradas (backend W29-B pendente)
+              </li>
+            )}
+            {waveHistory.map((w) => (
+              <li key={w.wave_id} className="relative">
+                <span
+                  aria-hidden
+                  className="absolute -left-[7px] top-1.5 inline-block h-1.5 w-1.5 rounded-full bg-primary/70"
+                />
+                <div className="rounded-md px-1.5 py-1 hover:bg-accent">
+                  <div className="flex items-center justify-between gap-2 text-[11px]">
+                    <span className="font-semibold text-foreground tabular-nums">
+                      {w.wave_id}
+                    </span>
+                    {w.pr_url && (
+                      <a
+                        href={w.pr_url}
+                        target="_blank"
+                        rel="noreferrer"
+                        className="inline-flex items-center gap-0.5 text-primary hover:underline focus:outline-none focus:ring-2 focus:ring-primary/40"
+                        title="abrir PR"
+                      >
+                        <GitBranch size={9} />
+                      </a>
+                    )}
+                  </div>
+                  <div className="text-[10.5px] text-foreground truncate" title={w.label}>
+                    {w.label}
+                  </div>
+                  {w.summary && (
+                    <div
+                      className="line-clamp-2 text-[9.5px] text-muted-foreground"
+                      title={w.summary}
+                    >
+                      {w.summary}
+                    </div>
+                  )}
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+    </aside>
+  );
+}

--- a/resources/js/Pages/Admin/_components/CommandPaletteV4.tsx
+++ b/resources/js/Pages/Admin/_components/CommandPaletteV4.tsx
@@ -1,0 +1,248 @@
+import * as React from 'react';
+import { Layers, GitBranch, ClipboardList, BookOpen } from 'lucide-react';
+import {
+  CommandDialog,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+  CommandSeparator,
+} from '@/Components/ui/command';
+import type {
+  Initiative,
+  ModuleRow,
+  WaveHistoryEntry,
+} from './governanceV4Types';
+
+/**
+ * CommandPaletteV4 — ⌘K cross-search (extends kb/CommandPalette pattern)
+ *
+ * Wave 29 (W29-C). 4 grupos:
+ *  - Módulos (top 200 cache local)
+ *  - Initiatives abertas
+ *  - Waves (W11-W28+)
+ *  - ADRs canônicas (estáticas + algumas dinâmicas via prop opcional)
+ *
+ * Atalhos: ↑↓ navegar, Enter abrir, Esc fechar.
+ */
+interface AdrEntry {
+  number: string;
+  title: string;
+  url?: string;
+}
+
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  modules: ModuleRow[];
+  initiatives: Initiative[];
+  waves: WaveHistoryEntry[];
+  adrs?: AdrEntry[];
+  onPickModule: (slug: string) => void;
+  onPickInitiative?: (id: number) => void;
+  onPickWave?: (waveId: string) => void;
+  onPickAdr?: (adr: AdrEntry) => void;
+}
+
+const DEFAULT_ADRS: AdrEntry[] = [
+  { number: '0160', title: 'Governance v4 scoped scorecards + buckets' },
+  { number: '0161', title: 'Aposentar hacks 0159 redundantes' },
+  { number: '0162', title: 'OTel collector prod observability' },
+  { number: '0163', title: 'Metas alcançadas ondas 19-28' },
+  { number: '0093', title: 'Multi-tenant isolation Tier 0' },
+  { number: '0094', title: 'Constituição v2 7 camadas + 8 princípios' },
+  { number: '0104', title: 'Processo MWART canônico — único caminho' },
+  { number: '0110', title: 'Cockpit Pattern V2 canon list-detail' },
+];
+
+function fuzzy(q: string, hay: string): boolean {
+  const a = q.trim().toLowerCase();
+  if (!a) return true;
+  return hay.toLowerCase().includes(a);
+}
+
+export default function CommandPaletteV4({
+  open,
+  onOpenChange,
+  modules,
+  initiatives,
+  waves,
+  adrs,
+  onPickModule,
+  onPickInitiative,
+  onPickWave,
+  onPickAdr,
+}: Props) {
+  const [query, setQuery] = React.useState('');
+
+  React.useEffect(() => {
+    if (open) setQuery('');
+  }, [open]);
+
+  const allAdrs = adrs && adrs.length > 0 ? adrs : DEFAULT_ADRS;
+
+  const modulesFiltered = React.useMemo(
+    () =>
+      modules
+        .filter((m) => fuzzy(query, `${m.slug} ${m.name}`))
+        .slice(0, query.trim() ? 12 : 8),
+    [modules, query],
+  );
+  const initiativesFiltered = React.useMemo(
+    () =>
+      initiatives
+        .filter((i) => i.status !== 'done')
+        .filter((i) => fuzzy(query, `${i.title} ${i.module}`))
+        .slice(0, 8),
+    [initiatives, query],
+  );
+  const wavesFiltered = React.useMemo(
+    () =>
+      waves
+        .filter((w) => fuzzy(query, `${w.wave_id} ${w.label} ${w.summary ?? ''}`))
+        .slice(0, 8),
+    [waves, query],
+  );
+  const adrsFiltered = React.useMemo(
+    () =>
+      allAdrs
+        .filter((a) => fuzzy(query, `${a.number} ${a.title}`))
+        .slice(0, 8),
+    [allAdrs, query],
+  );
+
+  const totalResults =
+    modulesFiltered.length +
+    initiativesFiltered.length +
+    wavesFiltered.length +
+    adrsFiltered.length;
+
+  return (
+    <CommandDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Busca cross-domínio"
+      description="Procure módulos, initiatives, waves ou ADRs — Esc fecha."
+    >
+      <CommandInput
+        placeholder="Buscar módulo / initiative / wave / ADR…"
+        value={query}
+        onValueChange={setQuery}
+      />
+      <CommandList>
+        {totalResults === 0 ? (
+          <CommandEmpty>
+            <div className="px-4 py-6 text-center text-[12px] text-muted-foreground">
+              Nada bate com <b className="text-foreground">"{query}"</b>.
+            </div>
+          </CommandEmpty>
+        ) : (
+          <>
+            {modulesFiltered.length > 0 && (
+              <CommandGroup heading="Módulos">
+                {modulesFiltered.map((m) => (
+                  <CommandItem
+                    key={`mod-${m.slug}`}
+                    value={`module ${m.slug} ${m.name}`}
+                    onSelect={() => {
+                      onPickModule(m.slug);
+                      onOpenChange(false);
+                    }}
+                    className="flex items-center gap-2"
+                  >
+                    <Layers size={12} className="text-muted-foreground" />
+                    <span className="font-medium">{m.name}</span>
+                    <span className="text-[10.5px] text-muted-foreground">
+                      {m.slug}
+                    </span>
+                    <span className="ml-auto text-[11px] font-semibold tabular-nums">
+                      {m.score}
+                    </span>
+                  </CommandItem>
+                ))}
+              </CommandGroup>
+            )}
+
+            {initiativesFiltered.length > 0 && (
+              <>
+                <CommandSeparator />
+                <CommandGroup heading="Initiatives abertas">
+                  {initiativesFiltered.map((i) => (
+                    <CommandItem
+                      key={`ini-${i.id}`}
+                      value={`initiative ${i.module} ${i.title}`}
+                      onSelect={() => {
+                        onPickInitiative?.(i.id);
+                        onOpenChange(false);
+                      }}
+                      className="flex items-center gap-2"
+                    >
+                      <ClipboardList size={12} className="text-muted-foreground" />
+                      <span className="font-medium truncate">{i.title}</span>
+                      <span className="text-[10.5px] text-muted-foreground shrink-0">
+                        {i.module}
+                      </span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </>
+            )}
+
+            {wavesFiltered.length > 0 && (
+              <>
+                <CommandSeparator />
+                <CommandGroup heading="Waves">
+                  {wavesFiltered.map((w) => (
+                    <CommandItem
+                      key={`wave-${w.wave_id}`}
+                      value={`wave ${w.wave_id} ${w.label}`}
+                      onSelect={() => {
+                        onPickWave?.(w.wave_id);
+                        onOpenChange(false);
+                      }}
+                      className="flex items-center gap-2"
+                    >
+                      <GitBranch size={12} className="text-muted-foreground" />
+                      <span className="font-semibold tabular-nums">{w.wave_id}</span>
+                      <span className="text-[12px] text-foreground truncate">
+                        {w.label}
+                      </span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </>
+            )}
+
+            {adrsFiltered.length > 0 && (
+              <>
+                <CommandSeparator />
+                <CommandGroup heading="ADRs">
+                  {adrsFiltered.map((a) => (
+                    <CommandItem
+                      key={`adr-${a.number}`}
+                      value={`adr ${a.number} ${a.title}`}
+                      onSelect={() => {
+                        onPickAdr?.(a);
+                        onOpenChange(false);
+                      }}
+                      className="flex items-center gap-2"
+                    >
+                      <BookOpen size={12} className="text-muted-foreground" />
+                      <span className="font-semibold tabular-nums">
+                        ADR {a.number}
+                      </span>
+                      <span className="text-[12px] text-foreground truncate">
+                        {a.title}
+                      </span>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              </>
+            )}
+          </>
+        )}
+      </CommandList>
+    </CommandDialog>
+  );
+}

--- a/resources/js/Pages/Admin/_components/DimensionProgressBar.tsx
+++ b/resources/js/Pages/Admin/_components/DimensionProgressBar.tsx
@@ -1,0 +1,106 @@
+import * as React from 'react';
+import { cn } from '@/Lib/utils';
+import { ShieldAlert, ShieldCheck } from 'lucide-react';
+import type { DimensionScore } from './governanceV4Types';
+
+/**
+ * DimensionProgressBar — uma barra D1-D9 com label + paired indicator
+ *
+ * Wave 29 (W29-C). Mostra:
+ *  - label dimensão (D1-D9) + nota /100 + peso
+ *  - barra horizontal com cor semântica
+ *  - badge paired indicator (anti-Goodhart Jellyfish) quando aplicável
+ *
+ * Tokens canon Cockpit V2 (semantic colors, sem hardcode `bg-red-500`).
+ */
+interface Props {
+  dimension: DimensionScore;
+  /** target da dimensão (default 80) pra colorir status */
+  target?: number;
+  className?: string;
+}
+
+export default function DimensionProgressBar({
+  dimension,
+  target = 80,
+  className,
+}: Props) {
+  const pct = Math.max(0, Math.min(100, dimension.score));
+  const tone: 'ok' | 'warn' | 'crit' =
+    pct >= target ? 'ok' : pct >= target - 10 ? 'warn' : 'crit';
+
+  const barClass =
+    tone === 'ok'
+      ? 'bg-emerald-500/70 dark:bg-emerald-500/60'
+      : tone === 'warn'
+        ? 'bg-amber-500/70 dark:bg-amber-500/60'
+        : 'bg-destructive/70';
+
+  const labelTone =
+    tone === 'ok'
+      ? 'text-emerald-700 dark:text-emerald-400'
+      : tone === 'warn'
+        ? 'text-amber-700 dark:text-amber-400'
+        : 'text-destructive';
+
+  return (
+    <div className={cn('space-y-1.5', className)}>
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <span className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground shrink-0">
+            {dimension.id}
+          </span>
+          <span className="text-[12px] text-foreground truncate" title={dimension.label}>
+            {dimension.label}
+          </span>
+          {dimension.paired_indicator && (
+            <span
+              title={
+                dimension.paired_ok
+                  ? 'Indicador pareado OK (anti-Goodhart)'
+                  : 'Indicador pareado em violação — score pode estar inflado'
+              }
+              className={cn(
+                'inline-flex items-center gap-0.5 rounded-md border px-1 py-0.5 text-[9px] font-medium',
+                dimension.paired_ok
+                  ? 'border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300'
+                  : 'border-destructive/40 bg-destructive/10 text-destructive',
+              )}
+            >
+              {dimension.paired_ok ? (
+                <ShieldCheck size={9} />
+              ) : (
+                <ShieldAlert size={9} />
+              )}
+              paired
+            </span>
+          )}
+        </div>
+        <div className="flex items-center gap-1.5 shrink-0">
+          <span className={cn('text-[12px] font-semibold tabular-nums', labelTone)}>
+            {pct}
+          </span>
+          <span className="text-[10px] text-muted-foreground">/{target}</span>
+          {dimension.weight > 0 && (
+            <span
+              className="text-[9px] text-muted-foreground"
+              title={`Peso: ${dimension.weight}`}
+            >
+              ·×{dimension.weight}
+            </span>
+          )}
+        </div>
+      </div>
+      <div className="h-1.5 w-full rounded-full bg-muted overflow-hidden">
+        <div
+          className={cn('h-full rounded-full transition-[width]', barClass)}
+          style={{ width: `${pct}%` }}
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          role="progressbar"
+        />
+      </div>
+    </div>
+  );
+}

--- a/resources/js/Pages/Admin/_components/DriftAlertBanner.tsx
+++ b/resources/js/Pages/Admin/_components/DriftAlertBanner.tsx
@@ -1,0 +1,110 @@
+import * as React from 'react';
+import { AlertTriangle, TrendingDown, TrendingUp, ChevronRight } from 'lucide-react';
+import { cn } from '@/Lib/utils';
+import type { DriftAlert } from './governanceV4Types';
+
+/**
+ * DriftAlertBanner — banner persistente topo se drifts > 0
+ *
+ * Wave 29 (W29-C). Não dismissable (charter Wagner) — só some quando
+ * `drifts.length === 0`. Mostra contador + top-3 drifts (maior delta absoluto)
+ * com link "ver todos" que dispara handler externo (abre dialog ou navega
+ * pra tab "Drifts" no ModuleReader).
+ *
+ * Tokens canon Cockpit V2: `bg-destructive/10` + `border-destructive/40` +
+ * `text-destructive` — nunca `bg-red-500` cru.
+ */
+interface Props {
+  drifts: DriftAlert[];
+  thresholdPts: number;
+  onPickModule?: (slug: string) => void;
+  onViewAll?: () => void;
+  className?: string;
+}
+
+export default function DriftAlertBanner({
+  drifts,
+  thresholdPts,
+  onPickModule,
+  onViewAll,
+  className,
+}: Props) {
+  if (!drifts || drifts.length === 0) {
+    // banner verde anti-pânico (charter Wave 27 + W29-C)
+    return (
+      <div
+        role="status"
+        className={cn(
+          'flex items-center justify-between gap-3 rounded-md border border-emerald-300 bg-emerald-50 px-3 py-2 text-[12px] text-emerald-900 dark:border-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-200',
+          className,
+        )}
+      >
+        <span className="flex items-center gap-2">
+          <span className="inline-flex h-1.5 w-1.5 rounded-full bg-emerald-500" />
+          Sem drifts &gt;{thresholdPts}pts nos últimos 7 dias — saúde estável.
+        </span>
+      </div>
+    );
+  }
+
+  const sorted = [...drifts].sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
+  const top = sorted.slice(0, 3);
+  const remaining = sorted.length - top.length;
+
+  return (
+    <div
+      role="alert"
+      className={cn(
+        'flex flex-col gap-2 rounded-md border border-destructive/40 bg-destructive/10 p-3 text-destructive sm:flex-row sm:items-start sm:gap-3',
+        className,
+      )}
+    >
+      <AlertTriangle size={16} className="mt-0.5 shrink-0" />
+      <div className="min-w-0 flex-1">
+        <div className="text-[12.5px] font-semibold">
+          {drifts.length} drift{drifts.length === 1 ? '' : 's'} detectado{drifts.length === 1 ? '' : 's'}
+          {' '}
+          <span className="text-foreground/70 font-normal">
+            (delta &gt; ±{thresholdPts}pts em 7d)
+          </span>
+        </div>
+        <ul className="mt-1.5 flex flex-wrap gap-1.5">
+          {top.map((d) => {
+            const Dir = d.direction === 'down' ? TrendingDown : TrendingUp;
+            return (
+              <li key={`${d.module}-${d.snapshot_date}`}>
+                <button
+                  type="button"
+                  onClick={() => onPickModule?.(d.module)}
+                  className="inline-flex items-center gap-1 rounded-md border border-destructive/30 bg-card px-1.5 py-0.5 text-[11px] font-medium text-foreground hover:bg-accent focus:outline-none focus:ring-2 focus:ring-destructive/40"
+                >
+                  <Dir size={10} className="text-destructive" />
+                  <span className="font-semibold">{d.module}</span>
+                  <span className="text-muted-foreground tabular-nums">
+                    {d.from}→{d.to}
+                  </span>
+                  <span className="font-bold tabular-nums text-destructive">
+                    {d.delta > 0 ? '+' : ''}
+                    {d.delta}
+                  </span>
+                </button>
+              </li>
+            );
+          })}
+          {remaining > 0 && (
+            <li>
+              <button
+                type="button"
+                onClick={onViewAll}
+                className="inline-flex items-center gap-1 rounded-md border border-transparent bg-transparent px-1.5 py-0.5 text-[11px] font-medium text-destructive hover:underline focus:outline-none focus:ring-2 focus:ring-destructive/40"
+              >
+                +{remaining} mais
+                <ChevronRight size={11} />
+              </button>
+            </li>
+          )}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/resources/js/Pages/Admin/_components/HealthPanelV4.tsx
+++ b/resources/js/Pages/Admin/_components/HealthPanelV4.tsx
@@ -1,0 +1,147 @@
+import * as React from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/Components/ui/dialog';
+import {
+  CheckCircle2,
+  Clock,
+  Activity,
+  AlertTriangle,
+  Layers,
+  Sparkles,
+} from 'lucide-react';
+import { cn } from '@/Lib/utils';
+import type { HealthSnapshot } from './governanceV4Types';
+
+/**
+ * HealthPanelV4 — modal de saúde governance v4 (extends kb/HealthPanel pattern)
+ *
+ * Wave 29 (W29-C). 4 quadrantes:
+ *  - ScorecardSnapshot cron last_run + status
+ *  - AI baseline 30d countdown (window vs remaining)
+ *  - OTel collector ping (CT 100)
+ *  - Buckets com dados (cobertura YAML rubric)
+ */
+interface Props {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  snapshot: HealthSnapshot | null;
+}
+
+function fmtRelative(iso: string | null): string {
+  if (!iso) return 'nunca';
+  const d = new Date(iso).getTime();
+  if (Number.isNaN(d)) return 'nunca';
+  const diff = Math.round((Date.now() - d) / 60_000);
+  if (diff < 1) return 'agora';
+  if (diff < 60) return `${diff}min atrás`;
+  if (diff < 1440) return `${Math.round(diff / 60)}h atrás`;
+  return `${Math.round(diff / 1440)}d atrás`;
+}
+
+export default function HealthPanelV4({ open, onOpenChange, snapshot }: Props) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-2xl">
+        <DialogHeader>
+          <small className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            Diagnóstico
+          </small>
+          <DialogTitle>Saúde Governance v4</DialogTitle>
+          <DialogDescription>
+            Cron ScorecardSnapshot, AI baseline 30d e OTel collector CT 100.
+          </DialogDescription>
+        </DialogHeader>
+
+        {!snapshot ? (
+          <div className="rounded-md border border-dashed border-border bg-muted/30 p-6 text-center text-[12px] text-muted-foreground">
+            Snapshot pendente — backend W29-B precisa entregar prop{' '}
+            <code>healthSnapshot</code>.
+          </div>
+        ) : (
+          <div className="grid gap-3 sm:grid-cols-2">
+            <HealthCard
+              title="Scorecard cron"
+              tone={snapshot.scorecard_cron_ok ? 'ok' : 'bad'}
+              icon={
+                snapshot.scorecard_cron_ok ? (
+                  <CheckCircle2 size={14} />
+                ) : (
+                  <AlertTriangle size={14} />
+                )
+              }
+              primary={
+                snapshot.scorecard_cron_ok ? 'Operacional' : 'Falha last_run'
+              }
+              detail={`last run ${fmtRelative(snapshot.scorecard_last_run_at)}`}
+            />
+            <HealthCard
+              title="AI baseline 30d"
+              tone={snapshot.ai_baseline_remaining_days > 0 ? 'ok' : 'warn'}
+              icon={<Sparkles size={14} />}
+              primary={
+                snapshot.ai_baseline_remaining_days > 0
+                  ? `${snapshot.ai_baseline_remaining_days}d restantes`
+                  : 'Concluído'
+              }
+              detail={`window ${snapshot.ai_baseline_window_days}d · observacional`}
+            />
+            <HealthCard
+              title="OTel collector"
+              tone={snapshot.otel_collector_up ? 'ok' : 'bad'}
+              icon={<Activity size={14} />}
+              primary={snapshot.otel_collector_up ? 'Up' : 'Down'}
+              detail={`last ping ${fmtRelative(snapshot.otel_collector_last_ping_at)}`}
+            />
+            <HealthCard
+              title="Cobertura buckets"
+              tone={snapshot.buckets_with_data >= 4 ? 'ok' : 'warn'}
+              icon={<Layers size={14} />}
+              primary={`${snapshot.buckets_with_data}/4`}
+              detail="buckets canon com dados"
+            />
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function HealthCard({
+  title,
+  tone,
+  icon,
+  primary,
+  detail,
+}: {
+  title: string;
+  tone: 'ok' | 'warn' | 'bad';
+  icon: React.ReactNode;
+  primary: string;
+  detail: string;
+}) {
+  const toneCls =
+    tone === 'ok'
+      ? 'border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300'
+      : tone === 'warn'
+        ? 'border-amber-300 bg-amber-50 text-amber-800 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-300'
+        : 'border-destructive/40 bg-destructive/10 text-destructive';
+
+  return (
+    <div className={cn('rounded-md border p-3', toneCls)}>
+      <div className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider">
+        {icon}
+        <span>{title}</span>
+      </div>
+      <div className="mt-1 text-[14px] font-semibold text-foreground">{primary}</div>
+      <div className="text-[10.5px] text-muted-foreground flex items-center gap-1">
+        <Clock size={10} />
+        {detail}
+      </div>
+    </div>
+  );
+}

--- a/resources/js/Pages/Admin/_components/InitiativeBadge.tsx
+++ b/resources/js/Pages/Admin/_components/InitiativeBadge.tsx
@@ -1,0 +1,111 @@
+import * as React from 'react';
+import { cn } from '@/Lib/utils';
+import { Clock, AlertTriangle, CheckCircle2, CircleDot } from 'lucide-react';
+import { INITIATIVE_TONE, type Initiative } from './governanceV4Types';
+
+/**
+ * InitiativeBadge — deadline countdown + status badge
+ *
+ * Wave 29 (W29-C). Renderiza estado da Initiative Cortex-style:
+ *  - status badge (open/in_progress/done/overdue)
+ *  - countdown relativo até deadline (em D-N dias)
+ *  - se vencida (overdue OR deadline < now), aplica tom destructive forte
+ *
+ * Tokens canon Cockpit V2.
+ */
+interface Props {
+  initiative: Initiative;
+  className?: string;
+  compact?: boolean;
+}
+
+function formatRelative(deadlineIso: string | null): { label: string; overdue: boolean } {
+  if (!deadlineIso) return { label: 'sem prazo', overdue: false };
+  const now = Date.now();
+  const d = new Date(deadlineIso).getTime();
+  if (Number.isNaN(d)) return { label: 'sem prazo', overdue: false };
+
+  const diffMs = d - now;
+  const diffDays = Math.round(diffMs / 86_400_000);
+  if (diffDays < 0) {
+    const abs = Math.abs(diffDays);
+    return { label: `vencida há ${abs}d`, overdue: true };
+  }
+  if (diffDays === 0) return { label: 'vence hoje', overdue: false };
+  if (diffDays === 1) return { label: 'vence amanhã', overdue: false };
+  if (diffDays < 7) return { label: `vence em ${diffDays}d`, overdue: false };
+  if (diffDays < 30) return { label: `${Math.round(diffDays / 7)}sem`, overdue: false };
+  return { label: `${Math.round(diffDays / 30)}meses`, overdue: false };
+}
+
+export default function InitiativeBadge({ initiative, className, compact }: Props) {
+  const tone = INITIATIVE_TONE[initiative.status];
+  const { label: deadlineLabel, overdue } = formatRelative(initiative.deadline_at);
+  const effectiveStatus = initiative.status === 'done' ? 'done' : overdue ? 'overdue' : initiative.status;
+
+  const StatusIcon =
+    effectiveStatus === 'done'
+      ? CheckCircle2
+      : effectiveStatus === 'overdue'
+        ? AlertTriangle
+        : effectiveStatus === 'in_progress'
+          ? CircleDot
+          : Clock;
+
+  const toneCls = (() => {
+    switch (effectiveStatus) {
+      case 'done':
+        return 'border-emerald-300 bg-emerald-50 text-emerald-800 dark:border-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300';
+      case 'overdue':
+        return 'border-destructive/40 bg-destructive/10 text-destructive';
+      case 'in_progress':
+        return 'border-sky-300 bg-sky-50 text-sky-800 dark:border-sky-700 dark:bg-sky-950/40 dark:text-sky-300';
+      default:
+        return 'border-border bg-muted text-foreground';
+    }
+  })();
+
+  if (compact) {
+    return (
+      <span
+        className={cn(
+          'inline-flex items-center gap-1 rounded-md border px-1.5 py-0.5 text-[10px] font-medium',
+          toneCls,
+          className,
+        )}
+        title={initiative.title}
+      >
+        <StatusIcon size={10} />
+        {deadlineLabel}
+      </span>
+    );
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex items-start gap-2 rounded-md border p-2',
+        toneCls,
+        className,
+      )}
+    >
+      <StatusIcon size={14} className="mt-0.5 shrink-0" />
+      <div className="min-w-0 flex-1">
+        <div className="text-[12px] font-medium text-foreground truncate" title={initiative.title}>
+          {initiative.title}
+        </div>
+        <div className="mt-0.5 flex items-center gap-2 text-[10.5px] text-muted-foreground">
+          <span>{tone.label}</span>
+          <span aria-hidden>·</span>
+          <span>{deadlineLabel}</span>
+          {initiative.owner && (
+            <>
+              <span aria-hidden>·</span>
+              <span title={`Owner: ${initiative.owner}`}>@{initiative.owner}</span>
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/resources/js/Pages/Admin/_components/ModuleList.tsx
+++ b/resources/js/Pages/Admin/_components/ModuleList.tsx
@@ -1,0 +1,346 @@
+import * as React from 'react';
+import { cn } from '@/Lib/utils';
+import { Search, X, AlertTriangle, ShieldAlert } from 'lucide-react';
+import SparklineTrend from './SparklineTrend';
+import {
+  STATUS_TONE,
+  type ModuleRow,
+  type BucketKey,
+  type StatusKey,
+} from './governanceV4Types';
+
+export type ScoreRangeKey = 'all' | '60-79' | '80-89' | '90+';
+
+export interface ModuleListFilters {
+  q: string;
+  metaOnly: boolean;
+  driftOnly: boolean;
+  scoreRange: ScoreRangeKey;
+  statusOnly: StatusKey | null;
+}
+
+interface Props {
+  /** módulos do bucket selecionado (ou união se bucket='all') */
+  modules: ModuleRow[];
+  bucketLabel: string;
+  bucketMeta: number;
+  filters: ModuleListFilters;
+  onChangeFilters: (next: ModuleListFilters) => void;
+  driftedSlugs: Set<string>;
+  selectedSlug: string | null;
+  onSelectModule: (slug: string) => void;
+  className?: string;
+}
+
+const SCORE_RANGE_CHIPS: { key: ScoreRangeKey; label: string }[] = [
+  { key: 'all', label: 'Todos' },
+  { key: '60-79', label: '60-79' },
+  { key: '80-89', label: '80-89' },
+  { key: '90+', label: '≥90' },
+];
+
+const STATUS_CHIPS: { key: StatusKey | 'all'; label: string }[] = [
+  { key: 'all', label: 'Todos' },
+  { key: 'ok', label: 'OK' },
+  { key: 'warn', label: 'Atenção' },
+  { key: 'crit', label: 'Crítico' },
+];
+
+function matchScoreRange(score: number, range: ScoreRangeKey): boolean {
+  switch (range) {
+    case '60-79':
+      return score >= 60 && score < 80;
+    case '80-89':
+      return score >= 80 && score < 90;
+    case '90+':
+      return score >= 90;
+    default:
+      return true;
+  }
+}
+
+/**
+ * ModuleList — coluna 2 do tri-pane (port de kb/NodeList)
+ *
+ * Wave 29 (W29-C). Lista filtrável dos módulos do bucket selecionado.
+ * Filter chips pills (charter: rounded-full, anti-pattern `border-b-2`).
+ */
+export default function ModuleList({
+  modules,
+  bucketLabel,
+  bucketMeta,
+  filters,
+  onChangeFilters,
+  driftedSlugs,
+  selectedSlug,
+  onSelectModule,
+  className,
+}: Props) {
+  const setFilter = <K extends keyof ModuleListFilters>(key: K, value: ModuleListFilters[K]) => {
+    onChangeFilters({ ...filters, [key]: value });
+  };
+
+  const filtered = React.useMemo(() => {
+    const q = filters.q.trim().toLowerCase();
+    return modules.filter((m) => {
+      if (q && !`${m.slug} ${m.name}`.toLowerCase().includes(q)) return false;
+      if (filters.metaOnly && m.score >= m.meta) return false;
+      if (filters.driftOnly && !driftedSlugs.has(m.slug)) return false;
+      if (filters.statusOnly && m.status !== filters.statusOnly) return false;
+      if (!matchScoreRange(m.score, filters.scoreRange)) return false;
+      return true;
+    });
+  }, [modules, filters, driftedSlugs]);
+
+  const hasAnyFilter =
+    filters.q.trim() !== '' ||
+    filters.metaOnly ||
+    filters.driftOnly ||
+    filters.scoreRange !== 'all' ||
+    filters.statusOnly !== null;
+
+  return (
+    <section
+      className={cn(
+        'kb-list flex flex-col overflow-hidden border-r border-border bg-background',
+        className,
+      )}
+      aria-label="Lista módulos do bucket"
+    >
+      <header className="space-y-2 border-b border-border bg-card/40 px-3 py-2">
+        <div className="flex items-baseline justify-between gap-2">
+          <h2 className="text-[13px] font-semibold text-foreground truncate">
+            {bucketLabel}
+          </h2>
+          <span className="text-[10.5px] text-muted-foreground tabular-nums">
+            {filtered.length}/{modules.length} · meta ≥{bucketMeta}
+          </span>
+        </div>
+
+        {/* search */}
+        <div className="relative">
+          <Search
+            size={12}
+            className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-muted-foreground"
+            aria-hidden
+          />
+          <input
+            type="search"
+            value={filters.q}
+            onChange={(e) => setFilter('q', e.target.value)}
+            placeholder="Filtrar módulo por slug ou nome…"
+            className="h-7 w-full rounded-md border border-border bg-background pl-7 pr-2 text-[12px] text-foreground placeholder:text-muted-foreground/70 focus:outline-none focus:ring-2 focus:ring-primary/40"
+            aria-label="Buscar módulo"
+          />
+        </div>
+
+        {/* chips pills rounded-full */}
+        <div className="flex flex-wrap items-center gap-1">
+          <Chip
+            active={filters.metaOnly}
+            onClick={() => setFilter('metaOnly', !filters.metaOnly)}
+          >
+            <ShieldAlert size={10} />
+            Abaixo meta
+          </Chip>
+          <Chip
+            active={filters.driftOnly}
+            onClick={() => setFilter('driftOnly', !filters.driftOnly)}
+          >
+            <AlertTriangle size={10} />
+            Drift
+          </Chip>
+          <span className="mx-1 h-3 w-px bg-border" aria-hidden />
+          {SCORE_RANGE_CHIPS.map((r) => (
+            <Chip
+              key={r.key}
+              active={filters.scoreRange === r.key}
+              onClick={() => setFilter('scoreRange', r.key)}
+            >
+              {r.label}
+            </Chip>
+          ))}
+          <span className="mx-1 h-3 w-px bg-border" aria-hidden />
+          {STATUS_CHIPS.map((s) => {
+            const active =
+              s.key === 'all' ? filters.statusOnly === null : filters.statusOnly === s.key;
+            return (
+              <Chip
+                key={s.key}
+                active={active}
+                onClick={() =>
+                  setFilter('statusOnly', s.key === 'all' ? null : (s.key as StatusKey))
+                }
+              >
+                {s.label}
+              </Chip>
+            );
+          })}
+          {hasAnyFilter && (
+            <button
+              type="button"
+              onClick={() =>
+                onChangeFilters({
+                  q: '',
+                  metaOnly: false,
+                  driftOnly: false,
+                  scoreRange: 'all',
+                  statusOnly: null,
+                })
+              }
+              className="ml-auto inline-flex items-center gap-0.5 rounded-full px-2 py-0.5 text-[10.5px] text-muted-foreground hover:bg-accent focus:outline-none focus:ring-2 focus:ring-primary/40"
+              title="Limpar filtros"
+            >
+              <X size={10} />
+              limpar
+            </button>
+          )}
+        </div>
+      </header>
+
+      <ul className="flex-1 overflow-y-auto p-1.5">
+        {filtered.length === 0 ? (
+          <li className="px-3 py-6 text-center text-[12px] text-muted-foreground">
+            Nenhum módulo bate com os filtros atuais.
+          </li>
+        ) : (
+          filtered.map((m) => (
+            <ModuleListItem
+              key={m.slug}
+              module={m}
+              active={selectedSlug === m.slug}
+              hasDrift={driftedSlugs.has(m.slug)}
+              onClick={() => onSelectModule(m.slug)}
+            />
+          ))
+        )}
+      </ul>
+    </section>
+  );
+}
+
+function Chip({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10.5px] font-medium transition-colors',
+        active
+          ? 'border-primary/40 bg-primary/10 text-foreground'
+          : 'border-border bg-card text-muted-foreground hover:bg-accent',
+      )}
+      aria-pressed={active}
+    >
+      {children}
+    </button>
+  );
+}
+
+function ModuleListItem({
+  module,
+  active,
+  hasDrift,
+  onClick,
+}: {
+  module: ModuleRow;
+  active: boolean;
+  hasDrift: boolean;
+  onClick: () => void;
+}) {
+  const statusTone = STATUS_TONE[module.status];
+  const statusCls =
+    module.status === 'ok'
+      ? 'text-emerald-700 dark:text-emerald-400 border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-950/40'
+      : module.status === 'warn'
+        ? 'text-amber-700 dark:text-amber-400 border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/40'
+        : 'text-destructive border-destructive/40 bg-destructive/10';
+
+  return (
+    <li>
+      <button
+        type="button"
+        onClick={onClick}
+        className={cn(
+          'group flex w-full flex-col gap-1 rounded-md border px-2 py-2 text-left transition-colors',
+          active
+            ? 'border-primary/40 bg-primary/5'
+            : 'border-transparent hover:bg-accent',
+        )}
+        aria-pressed={active}
+      >
+        <div className="flex items-center justify-between gap-2">
+          <div className="min-w-0">
+            <div className="text-[12.5px] font-semibold text-foreground truncate">
+              {module.name}
+            </div>
+            <div className="text-[10px] text-muted-foreground truncate">
+              {module.slug}
+            </div>
+          </div>
+          <div className="shrink-0 text-right">
+            <div className="text-[14px] font-bold tabular-nums text-foreground">
+              {module.score}
+            </div>
+            <div className="text-[9.5px] text-muted-foreground tabular-nums">
+              meta {module.meta}
+            </div>
+          </div>
+        </div>
+        <div className="flex items-center justify-between gap-2">
+          <div className="flex items-center gap-1">
+            <span
+              className={cn(
+                'inline-flex items-center gap-0.5 rounded-md border px-1 py-0.5 text-[9.5px] font-medium',
+                statusCls,
+              )}
+              title={`Status: ${statusTone.label}`}
+            >
+              {statusTone.label}
+            </span>
+            {hasDrift && (
+              <span
+                className="inline-flex items-center gap-0.5 rounded-md border border-destructive/40 bg-destructive/10 px-1 py-0.5 text-[9.5px] font-medium text-destructive"
+                title="Drift detectado nos últimos 7 dias"
+              >
+                <AlertTriangle size={9} />
+                drift
+              </span>
+            )}
+            {module.paired_count > 0 && (
+              <span
+                className="inline-flex items-center gap-0.5 rounded-md border border-amber-300 bg-amber-50 px-1 py-0.5 text-[9.5px] font-medium text-amber-800 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-300"
+                title="Paired violations (anti-Goodhart)"
+              >
+                paired×{module.paired_count}
+              </span>
+            )}
+            {module.p99_ms !== null && (
+              <span
+                className="inline-flex items-center gap-0.5 rounded-md border border-border bg-muted px-1 py-0.5 text-[9.5px] font-medium text-muted-foreground tabular-nums"
+                title="p99 latência 7d"
+              >
+                {Math.round(module.p99_ms)}ms
+              </span>
+            )}
+          </div>
+          <SparklineTrend
+            values={module.trend}
+            width={70}
+            height={18}
+            className="text-foreground/60"
+            ariaLabel={`Tendência 30d ${module.name}`}
+          />
+        </div>
+      </button>
+    </li>
+  );
+}

--- a/resources/js/Pages/Admin/_components/ModuleReader.tsx
+++ b/resources/js/Pages/Admin/_components/ModuleReader.tsx
@@ -1,0 +1,330 @@
+import * as React from 'react';
+import { cn } from '@/Lib/utils';
+import {
+  BookOpen,
+  ChevronLeft,
+  ChevronRight,
+  Plus,
+  RefreshCw,
+  TrendingUp,
+  TrendingDown,
+  Sparkles,
+  Target,
+} from 'lucide-react';
+import SparklineTrend from './SparklineTrend';
+import DimensionProgressBar from './DimensionProgressBar';
+import InitiativeBadge from './InitiativeBadge';
+import AiSuggestionPanel from './AiSuggestionPanel';
+import {
+  STATUS_TONE,
+  type AiSuggestion,
+  type Initiative,
+  type ModuleRow,
+  type ModuleScorecard,
+} from './governanceV4Types';
+
+/**
+ * ModuleReader — coluna 3 do tri-pane (port de kb/NodeReader)
+ *
+ * Wave 29 (W29-C). Header KPIs + sparkline + 9 dimensões + Initiatives + AI panel.
+ *
+ * Empty state quando `module === null` (nada selecionado).
+ */
+interface Props {
+  module: ModuleRow | null;
+  scorecard: ModuleScorecard | null;
+  initiatives: Initiative[];
+  aiSuggestions: AiSuggestion[];
+  prev?: ModuleRow | null;
+  next?: ModuleRow | null;
+  onPickPrev?: () => void;
+  onPickNext?: () => void;
+  onOpenInitiativeNew?: (module: string) => void;
+  onOpenOverride?: (module: string) => void;
+  onRefresh?: (module: string) => void;
+  className?: string;
+}
+
+export default function ModuleReader({
+  module,
+  scorecard,
+  initiatives,
+  aiSuggestions,
+  prev,
+  next,
+  onPickPrev,
+  onPickNext,
+  onOpenInitiativeNew,
+  onOpenOverride,
+  onRefresh,
+  className,
+}: Props) {
+  if (!module) {
+    return (
+      <section
+        className={cn(
+          'kb-reader flex flex-col items-center justify-center gap-2 bg-background p-8 text-center',
+          className,
+        )}
+        aria-label="Módulo não selecionado"
+      >
+        <BookOpen size={28} className="text-muted-foreground/60" />
+        <h2 className="text-[14px] font-semibold text-foreground">
+          Selecione um módulo
+        </h2>
+        <p className="max-w-sm text-[12px] text-muted-foreground">
+          Escolha um bucket à esquerda e um módulo na lista pra ver o breakdown
+          de dimensões, initiatives abertas e sinais AI baseline.
+        </p>
+      </section>
+    );
+  }
+
+  const statusTone = STATUS_TONE[module.status];
+  const delta = module.score - module.meta;
+  const TrendIcon = delta >= 0 ? TrendingUp : TrendingDown;
+  const trendCls = delta >= 0 ? 'text-emerald-700 dark:text-emerald-400' : 'text-destructive';
+
+  const moduleInitiatives = initiatives.filter((i) => i.module === module.slug);
+  const moduleSuggestions = aiSuggestions.filter((s) => s.module === module.slug);
+
+  return (
+    <section
+      className={cn(
+        'kb-reader flex flex-col overflow-hidden bg-background',
+        className,
+      )}
+      aria-label={`Detalhe módulo ${module.name}`}
+    >
+      {/* Header */}
+      <header className="space-y-3 border-b border-border bg-card/40 px-4 py-3">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+              Módulo
+            </div>
+            <h2 className="text-[16px] font-semibold text-foreground truncate">
+              {module.name}
+            </h2>
+            <div className="text-[11px] text-muted-foreground truncate">
+              {module.slug}
+            </div>
+          </div>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={onPickPrev}
+              disabled={!prev}
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border bg-card text-foreground hover:bg-accent disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus:ring-2 focus:ring-primary/40"
+              title="Módulo anterior"
+              aria-label="Módulo anterior"
+            >
+              <ChevronLeft size={14} />
+            </button>
+            <button
+              type="button"
+              onClick={onPickNext}
+              disabled={!next}
+              className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border bg-card text-foreground hover:bg-accent disabled:cursor-not-allowed disabled:opacity-40 focus:outline-none focus:ring-2 focus:ring-primary/40"
+              title="Próximo módulo"
+              aria-label="Próximo módulo"
+            >
+              <ChevronRight size={14} />
+            </button>
+          </div>
+        </div>
+
+        {/* KPI strip */}
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-4">
+          <Kpi
+            label="Nota atual"
+            value={String(module.score)}
+            tone={module.status}
+          />
+          <Kpi
+            label="Meta bucket"
+            value={`≥${module.meta}`}
+            icon={<Target size={11} />}
+          />
+          <Kpi
+            label="Delta vs meta"
+            value={`${delta > 0 ? '+' : ''}${delta}`}
+            tone={module.status}
+            icon={<TrendIcon size={11} className={trendCls} />}
+          />
+          <Kpi
+            label="Status"
+            value={statusTone.label}
+            tone={module.status}
+          />
+        </div>
+
+        {/* Sparkline trend 30d */}
+        <div className="flex items-end justify-between gap-3 rounded-md border border-border bg-background px-3 py-2">
+          <div className="min-w-0">
+            <div className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+              Tendência 30d
+            </div>
+            <div className="text-[10.5px] text-muted-foreground">
+              {module.trend.length} snapshots
+              {scorecard?.last_run_at && (
+                <>
+                  {' · last run '}
+                  <time dateTime={scorecard.last_run_at}>
+                    {new Date(scorecard.last_run_at).toLocaleString('pt-BR')}
+                  </time>
+                </>
+              )}
+            </div>
+          </div>
+          <SparklineTrend
+            values={module.trend}
+            width={200}
+            height={36}
+            className={trendCls}
+            ariaLabel={`Tendência 30d ${module.name}`}
+          />
+        </div>
+
+        {/* Quick actions */}
+        <div className="flex flex-wrap items-center gap-1.5">
+          {onOpenInitiativeNew && (
+            <button
+              type="button"
+              onClick={() => onOpenInitiativeNew(module.slug)}
+              className="inline-flex items-center gap-1 rounded-md border border-border bg-card px-2 py-1 text-[11px] font-medium text-foreground hover:bg-accent focus:outline-none focus:ring-2 focus:ring-primary/40"
+            >
+              <Plus size={11} />
+              Initiative
+            </button>
+          )}
+          {onOpenOverride && (
+            <button
+              type="button"
+              onClick={() => onOpenOverride(module.slug)}
+              className="inline-flex items-center gap-1 rounded-md border border-border bg-card px-2 py-1 text-[11px] font-medium text-foreground hover:bg-accent focus:outline-none focus:ring-2 focus:ring-primary/40"
+            >
+              Override bucket
+            </button>
+          )}
+          {onRefresh && (
+            <button
+              type="button"
+              onClick={() => onRefresh(module.slug)}
+              className="inline-flex items-center gap-1 rounded-md border border-border bg-card px-2 py-1 text-[11px] font-medium text-foreground hover:bg-accent focus:outline-none focus:ring-2 focus:ring-primary/40"
+            >
+              <RefreshCw size={11} />
+              Refresh now
+            </button>
+          )}
+        </div>
+      </header>
+
+      {/* Body */}
+      <div className="flex-1 overflow-y-auto px-4 py-3 space-y-4">
+        {/* Dimensões D1-D9 */}
+        <section>
+          <h3 className="mb-2 text-[11px] font-bold uppercase tracking-wider text-muted-foreground">
+            Dimensões (rubrica YAML)
+          </h3>
+          {!scorecard || scorecard.dimensions.length === 0 ? (
+            <p className="rounded-md border border-dashed border-border bg-muted/30 px-3 py-3 text-[11.5px] italic text-muted-foreground">
+              Rubrica YAML não carregada pra <code>{module.slug}</code> — verifique
+              <code className="mx-1">memory/governance/scorecards/{module.slug}.yaml</code>
+              ou aguarde W29-B fornecer payload <code>scorecards</code>.
+            </p>
+          ) : (
+            <div className="space-y-2.5 rounded-md border border-border bg-card p-3">
+              {scorecard.dimensions.map((d) => (
+                <DimensionProgressBar key={d.id} dimension={d} />
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Initiatives */}
+        <section>
+          <div className="mb-2 flex items-center justify-between gap-2">
+            <h3 className="text-[11px] font-bold uppercase tracking-wider text-muted-foreground">
+              Initiatives abertas ({moduleInitiatives.length})
+            </h3>
+            {onOpenInitiativeNew && (
+              <button
+                type="button"
+                onClick={() => onOpenInitiativeNew(module.slug)}
+                className="inline-flex items-center gap-0.5 text-[10.5px] text-primary hover:underline focus:outline-none focus:ring-2 focus:ring-primary/40"
+              >
+                <Plus size={10} />
+                Nova
+              </button>
+            )}
+          </div>
+          {moduleInitiatives.length === 0 ? (
+            <p className="rounded-md border border-dashed border-border bg-muted/30 px-3 py-3 text-[11.5px] italic text-muted-foreground">
+              Nenhuma Initiative aberta pra este módulo.
+            </p>
+          ) : (
+            <div className="space-y-1.5">
+              {moduleInitiatives.map((i) => (
+                <InitiativeBadge key={i.id} initiative={i} />
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* AI Suggestions panel pra este módulo */}
+        <section>
+          <AiSuggestionPanel
+            suggestions={moduleSuggestions}
+            module={module.slug}
+            emptyHint="Sem sinais AI baseline 30d pra este módulo."
+          />
+        </section>
+
+        {/* Paired hint discreto */}
+        {module.paired_count > 0 && (
+          <section
+            aria-label="Paired violations"
+            className="flex items-start gap-2 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-[11.5px] text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
+          >
+            <Sparkles size={13} className="mt-0.5 shrink-0" />
+            <div>
+              <strong className="font-semibold">{module.paired_count}</strong> indicador(es)
+              pareado(s) em violação — anti-Goodhart Jellyfish 2025. Score pode estar inflado;
+              ver YAML <code>paired_violations</code>.
+            </div>
+          </section>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function Kpi({
+  label,
+  value,
+  tone,
+  icon,
+}: {
+  label: string;
+  value: string;
+  tone?: 'ok' | 'warn' | 'crit';
+  icon?: React.ReactNode;
+}) {
+  const toneCls = !tone
+    ? 'text-foreground'
+    : tone === 'ok'
+      ? 'text-emerald-700 dark:text-emerald-400'
+      : tone === 'warn'
+        ? 'text-amber-700 dark:text-amber-400'
+        : 'text-destructive';
+  return (
+    <div className="rounded-md border border-border bg-background px-2.5 py-1.5">
+      <div className="flex items-center gap-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
+        {icon}
+        {label}
+      </div>
+      <div className={cn('mt-0.5 text-[15px] font-bold tabular-nums', toneCls)}>{value}</div>
+    </div>
+  );
+}

--- a/resources/js/Pages/Admin/_components/SparklineTrend.tsx
+++ b/resources/js/Pages/Admin/_components/SparklineTrend.tsx
@@ -1,0 +1,99 @@
+import * as React from 'react';
+import { cn } from '@/Lib/utils';
+
+/**
+ * SparklineTrend — SVG inline 30 pontos (sem lib externa)
+ *
+ * Wave 29 (W29-C). Pattern leve copiado do blueprint kb_v2 — zero JS chart
+ * lib, evita network call extra. Renderiza linha + área preenchida + último
+ * ponto destacado. Tokens canon (semantic colors via stroke/fill em currentColor).
+ */
+interface Props {
+  values: number[];
+  width?: number;
+  height?: number;
+  /** className aplica em <svg>; cor controlada via text-{token} parent */
+  className?: string;
+  /** se true desenha fill sombreado sob a linha */
+  showArea?: boolean;
+  ariaLabel?: string;
+}
+
+export default function SparklineTrend({
+  values,
+  width = 120,
+  height = 28,
+  className,
+  showArea = true,
+  ariaLabel = 'Tendência últimos 30 pontos',
+}: Props) {
+  if (!values || values.length === 0) {
+    return (
+      <div
+        className={cn(
+          'text-[10px] text-muted-foreground italic',
+          className,
+        )}
+        style={{ width, height }}
+        aria-label="sem dados"
+      >
+        sem dados
+      </div>
+    );
+  }
+
+  const pts = values.length === 1 ? [values[0], values[0]] : values;
+  const min = Math.min(...pts);
+  const max = Math.max(...pts);
+  const range = max - min || 1;
+
+  const padX = 1.5;
+  const padY = 2;
+  const w = width - padX * 2;
+  const h = height - padY * 2;
+
+  const coords = pts.map((v, i) => {
+    const x = padX + (i / (pts.length - 1)) * w;
+    const y = padY + h - ((v - min) / range) * h;
+    return [x, y] as const;
+  });
+
+  const linePath = coords
+    .map(([x, y], i) => `${i === 0 ? 'M' : 'L'}${x.toFixed(2)},${y.toFixed(2)}`)
+    .join(' ');
+
+  const areaPath = showArea
+    ? `${linePath} L${coords[coords.length - 1][0].toFixed(2)},${(padY + h).toFixed(2)} L${coords[0][0].toFixed(2)},${(padY + h).toFixed(2)} Z`
+    : '';
+
+  const last = coords[coords.length - 1];
+
+  return (
+    <svg
+      role="img"
+      aria-label={ariaLabel}
+      viewBox={`0 0 ${width} ${height}`}
+      width={width}
+      height={height}
+      className={cn('text-foreground/80', className)}
+    >
+      {showArea && (
+        <path
+          d={areaPath}
+          fill="currentColor"
+          fillOpacity="0.12"
+          stroke="none"
+        />
+      )}
+      <path
+        d={linePath}
+        stroke="currentColor"
+        strokeWidth="1.25"
+        fill="none"
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      <circle cx={last[0]} cy={last[1]} r="1.75" fill="currentColor" />
+    </svg>
+  );
+}

--- a/resources/js/Pages/Admin/_components/governanceV4Types.ts
+++ b/resources/js/Pages/Admin/_components/governanceV4Types.ts
@@ -1,0 +1,191 @@
+/**
+ * governanceV4Types.ts — tipos compartilhados Wave 29 (W29-C)
+ *
+ * Tipos da tela `Admin/GovernanceV4` tri-pane (copy kb_v2 blueprint).
+ * Mantidos no diretório `_components/` pra colocação junto dos sub-components
+ * que os consomem (BucketSidebar / ModuleList / ModuleReader / etc).
+ *
+ * Backend Source-of-truth: `Modules/Admin/Http/Controllers/GovernanceV4DashboardController.php`
+ * (Wave 27 polish — `__invoke` aponta pra `GovernanceV4Dashboard.tsx`).
+ *
+ * Para W29-B: o controller `indexV2` será um método NOVO que renderiza
+ * `Admin/GovernanceV4` com props enriquecidas (scorecards / initiatives / waveHistory
+ * / healthSnapshot). Tipos abaixo cobrem ambos cenários (props parciais via `?:`).
+ */
+
+export type BucketKey =
+  | 'vertical_client_facing'
+  | 'cross_cutting_infra'
+  | 'ai_central'
+  | 'functional_horizontal';
+
+export type StatusKey = 'ok' | 'warn' | 'crit';
+
+export type InitiativeStatus = 'open' | 'in_progress' | 'done' | 'overdue';
+
+export type DimensionId =
+  | 'D1'
+  | 'D2'
+  | 'D3'
+  | 'D4'
+  | 'D5'
+  | 'D6'
+  | 'D7'
+  | 'D8'
+  | 'D9';
+
+export interface BucketMeta {
+  label: string;
+  meta: number;
+}
+
+export interface BucketDef {
+  key: BucketKey;
+  label: string;
+  meta: number;
+  count: number;
+}
+
+export interface ModuleRow {
+  slug: string;
+  name: string;
+  score: number;
+  meta: number;
+  status: StatusKey;
+  trend: number[];
+  paired_count: number;
+  p99_ms: number | null;
+  bucket?: BucketKey;
+}
+
+export interface DriftAlert {
+  module: string;
+  delta: number;
+  from: number;
+  to: number;
+  snapshot_date: string;
+  direction: 'up' | 'down';
+}
+
+export interface AiSuggestion {
+  module: string;
+  avg_delta: number;
+  count: number;
+  last_justificativa: string;
+  last_confidence: number;
+  last_at: string | null;
+}
+
+export interface PairedViolation {
+  module: string;
+  rule: string;
+  reason: string;
+}
+
+export interface DimensionScore {
+  id: DimensionId;
+  label: string;
+  score: number;
+  weight: number;
+  paired_indicator: boolean;
+  paired_ok?: boolean;
+}
+
+export interface ModuleScorecard {
+  slug: string;
+  dimensions: DimensionScore[];
+  last_run_at: string | null;
+  yaml_path?: string;
+}
+
+export interface Initiative {
+  id: number;
+  module: string;
+  title: string;
+  status: InitiativeStatus;
+  owner?: string;
+  deadline_at: string | null;
+  created_at: string;
+  updated_at: string;
+  notes?: string;
+}
+
+export interface WaveHistoryEntry {
+  wave_id: string;
+  label: string;
+  delivered_at: string;
+  pr_url?: string;
+  summary?: string;
+}
+
+export interface HealthSnapshot {
+  scorecard_last_run_at: string | null;
+  scorecard_cron_ok: boolean;
+  ai_baseline_window_days: number;
+  ai_baseline_remaining_days: number;
+  otel_collector_up: boolean;
+  otel_collector_last_ping_at: string | null;
+  buckets_with_data: number;
+}
+
+export interface GovernanceV4Meta {
+  subdomain: string;
+  environment: string;
+  bypass_local: boolean;
+  generated_at: string;
+  drift_threshold_pts: number;
+  buckets: Record<BucketKey, BucketMeta>;
+  v4_enabled: boolean;
+}
+
+export interface GovernanceV4Can {
+  create_initiative: boolean;
+  override_bucket: boolean;
+  refresh_now: boolean;
+}
+
+export interface GovernanceV4PageProps {
+  meta: GovernanceV4Meta;
+  modules?: Record<BucketKey, ModuleRow[]>;
+  drifts?: DriftAlert[];
+  scorecards?: Record<string, ModuleScorecard>;
+  initiatives?: Initiative[];
+  aiSuggestions?: AiSuggestion[];
+  pairedViolations?: PairedViolation[];
+  waveHistory?: WaveHistoryEntry[];
+  healthSnapshot?: HealthSnapshot;
+  can?: GovernanceV4Can;
+}
+
+export const BUCKET_ORDER: BucketKey[] = [
+  'vertical_client_facing',
+  'cross_cutting_infra',
+  'ai_central',
+  'functional_horizontal',
+];
+
+export const BUCKET_LABEL_FALLBACK: Record<BucketKey, string> = {
+  vertical_client_facing: 'Vertical Client-Facing',
+  cross_cutting_infra: 'Cross-Cutting Infra',
+  ai_central: 'AI Central',
+  functional_horizontal: 'Functional Horizontal',
+};
+
+export const STATUS_TONE: Record<
+  StatusKey,
+  { label: string; iconKey: string; tone: 'success' | 'warning' | 'destructive' }
+> = {
+  ok: { label: 'OK', iconKey: 'check', tone: 'success' },
+  warn: { label: 'Atenção', iconKey: 'alert-triangle', tone: 'warning' },
+  crit: { label: 'Crítico', iconKey: 'x', tone: 'destructive' },
+};
+
+export const INITIATIVE_TONE: Record<
+  InitiativeStatus,
+  { label: string; tone: 'default' | 'info' | 'success' | 'destructive' }
+> = {
+  open: { label: 'Aberta', tone: 'default' },
+  in_progress: { label: 'Em curso', tone: 'info' },
+  done: { label: 'Concluída', tone: 'success' },
+  overdue: { label: 'Vencida', tone: 'destructive' },
+};

--- a/resources/js/Pages/Admin/_lib/mockGovernanceV4.ts
+++ b/resources/js/Pages/Admin/_lib/mockGovernanceV4.ts
@@ -1,0 +1,335 @@
+/**
+ * GovernanceV4 — mock data (fallback dev-mode + Pest fixture).
+ *
+ * Pattern espelhado do `kb/_lib/mockData.ts` (W28 KB unificado). Usado quando:
+ *   1. Backend Inertia ainda não populou props (dev local sem seed)
+ *   2. Pest frontend snapshot do `Admin/GovernanceV4` tela tri-pane
+ *   3. Storybook (futuro) renderizar variações isoladas
+ *
+ * NÃO incluir PII real (Tier 0 IRREVOGÁVEL — `memory/proibicoes.md`). Tudo
+ * é módulo nome + score sintético. Wagner valida pela tela antes de soltar.
+ *
+ * Buckets canon: ADR 0160 (4 buckets + meta 80-90 pts).
+ * 34 módulos catalogados: scorecards YAML em `memory/governance/scorecards/`.
+ *
+ * @see resources/js/Pages/Admin/GovernanceV4.tsx
+ * @see Modules/Admin/Http/Controllers/GovernanceV4DashboardController.php
+ * @see memory/decisions/0160-governance-v4-scoped-scorecards-bucket-meta.md
+ */
+
+// ──────────────────────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────────────────────
+
+export type BucketSlug =
+  | 'vertical_client_facing'
+  | 'cross_cutting_infra'
+  | 'ai_central'
+  | 'functional_horizontal';
+
+export type ModuleStatus = 'ok' | 'warn' | 'crit';
+export type InitiativeStatus =
+  | 'open'
+  | 'in_progress'
+  | 'done'
+  | 'expired'
+  | 'cancelled';
+
+export interface MockBucket {
+  id: BucketSlug;
+  name: string;
+  meta: number;
+  count: number;
+}
+
+export interface MockModule {
+  slug: string;
+  bucket: BucketSlug;
+  score_v3: number;
+  meta_bucket: number;
+  status: ModuleStatus;
+  sparkline_30d: number[];
+  drifts_count: number;
+  initiatives_count: number;
+}
+
+export interface MockInitiative {
+  id: number;
+  module: string;
+  bucket: BucketSlug;
+  rule_id: string;
+  titulo: string;
+  status: InitiativeStatus;
+  deadline: string;
+  score_before: number;
+  score_target: number;
+  score_after: number | null;
+  opened_at: string;
+}
+
+export interface MockDrift {
+  module: string;
+  delta: number;
+  from: number;
+  to: number;
+  snapshot_date: string;
+  direction: 'up' | 'down';
+}
+
+export interface MockAiSuggestion {
+  module: string;
+  avg_delta: number;
+  count: number;
+  last_justificativa: string;
+  last_confidence: number;
+  last_at: string;
+}
+
+export interface MockWaveEntry {
+  wave: string;
+  date: string;
+  modules_touched: string[];
+  score_delta: number;
+  summary: string;
+}
+
+export interface MockHealthSnapshot {
+  generated_at: string;
+  v4_enabled: boolean;
+  media_atual: number;
+  meta_aspiracional: number;
+  modules_total: number;
+  modules_ok: number;
+  modules_warn: number;
+  modules_crit: number;
+  drift_threshold_pts: number;
+  open_initiatives: number;
+  expired_initiatives: number;
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Helper relativos
+// ──────────────────────────────────────────────────────────────────
+
+function daysAgo(d: number): string {
+  return new Date(Date.now() - d * 86_400_000).toISOString();
+}
+
+function daysFromNow(d: number): string {
+  return new Date(Date.now() + d * 86_400_000).toISOString().slice(0, 10);
+}
+
+// ──────────────────────────────────────────────────────────────────
+// Buckets — 4 canon ADR 0160
+// ──────────────────────────────────────────────────────────────────
+
+export const MOCK_BUCKETS: MockBucket[] = [
+  { id: 'vertical_client_facing', name: 'Vertical Cliente', meta: 85, count: 5 },
+  { id: 'cross_cutting_infra', name: 'Cross-cutting Infra', meta: 90, count: 7 },
+  { id: 'ai_central', name: 'AI Central', meta: 85, count: 2 },
+  { id: 'functional_horizontal', name: 'Functional Horizontal', meta: 80, count: 20 },
+];
+
+// ──────────────────────────────────────────────────────────────────
+// Modules — 34 módulos (5 + 7 + 2 + 20)
+// ──────────────────────────────────────────────────────────────────
+
+export const MOCK_MODULES: MockModule[] = [
+  // ── vertical_client_facing (5) — meta 85
+  { slug: 'Vestuario', bucket: 'vertical_client_facing', score_v3: 88, meta_bucket: 85, status: 'ok', sparkline_30d: [82, 84, 85, 87, 88], drifts_count: 0, initiatives_count: 0 },
+  { slug: 'ComunicacaoVisual', bucket: 'vertical_client_facing', score_v3: 76, meta_bucket: 85, status: 'warn', sparkline_30d: [70, 72, 74, 75, 76], drifts_count: 1, initiatives_count: 1 },
+  { slug: 'OficinaAuto', bucket: 'vertical_client_facing', score_v3: 65, meta_bucket: 85, status: 'crit', sparkline_30d: [62, 63, 64, 65, 65], drifts_count: 2, initiatives_count: 3 },
+  { slug: 'Repair', bucket: 'vertical_client_facing', score_v3: 91, meta_bucket: 85, status: 'ok', sparkline_30d: [86, 88, 89, 90, 91], drifts_count: 0, initiatives_count: 0 },
+  { slug: 'Project', bucket: 'vertical_client_facing', score_v3: 83, meta_bucket: 85, status: 'warn', sparkline_30d: [80, 81, 82, 82, 83], drifts_count: 0, initiatives_count: 1 },
+
+  // ── cross_cutting_infra (7) — meta 90
+  { slug: 'Admin', bucket: 'cross_cutting_infra', score_v3: 94, meta_bucket: 90, status: 'ok', sparkline_30d: [89, 91, 92, 93, 94], drifts_count: 0, initiatives_count: 0 },
+  { slug: 'Governance', bucket: 'cross_cutting_infra', score_v3: 92, meta_bucket: 90, status: 'ok', sparkline_30d: [88, 90, 91, 92, 92], drifts_count: 0, initiatives_count: 0 },
+  { slug: 'Financeiro', bucket: 'cross_cutting_infra', score_v3: 86, meta_bucket: 90, status: 'warn', sparkline_30d: [84, 85, 86, 86, 86], drifts_count: 1, initiatives_count: 2 },
+  { slug: 'NfeBrasil', bucket: 'cross_cutting_infra', score_v3: 89, meta_bucket: 90, status: 'warn', sparkline_30d: [87, 88, 88, 89, 89], drifts_count: 0, initiatives_count: 1 },
+  { slug: 'MemCofre', bucket: 'cross_cutting_infra', score_v3: 78, meta_bucket: 90, status: 'crit', sparkline_30d: [76, 76, 77, 77, 78], drifts_count: 2, initiatives_count: 4 },
+  { slug: 'RecurringBilling', bucket: 'cross_cutting_infra', score_v3: 95, meta_bucket: 90, status: 'ok', sparkline_30d: [92, 93, 94, 94, 95], drifts_count: 0, initiatives_count: 0 },
+  { slug: 'Whatsapp', bucket: 'cross_cutting_infra', score_v3: 81, meta_bucket: 90, status: 'crit', sparkline_30d: [75, 77, 79, 80, 81], drifts_count: 3, initiatives_count: 2 },
+
+  // ── ai_central (2) — meta 85
+  { slug: 'Jana', bucket: 'ai_central', score_v3: 73, meta_bucket: 85, status: 'crit', sparkline_30d: [58, 65, 68, 70, 73], drifts_count: 1, initiatives_count: 2 },
+  { slug: 'Copiloto', bucket: 'ai_central', score_v3: 87, meta_bucket: 85, status: 'ok', sparkline_30d: [82, 84, 86, 87, 87], drifts_count: 0, initiatives_count: 0 },
+
+  // ── functional_horizontal (20) — meta 80
+  { slug: 'Crm', bucket: 'functional_horizontal', score_v3: 87, meta_bucket: 80, status: 'ok', sparkline_30d: [82, 83, 85, 86, 87], drifts_count: 0, initiatives_count: 0 },
+  { slug: 'Vendas', bucket: 'functional_horizontal', score_v3: 84, meta_bucket: 80, status: 'ok', sparkline_30d: [80, 81, 82, 83, 84], drifts_count: 0, initiatives_count: 0 },
+  { slug: 'Compras', bucket: 'functional_horizontal', score_v3: 82, meta_bucket: 80, status: 'ok', sparkline_30d: [78, 80, 81, 81, 82], drifts_count: 0, initiatives_count: 0 },
+  { slug: 'Estoque', bucket: 'functional_horizontal', score_v3: 86, meta_bucket: 80, status: 'ok', sparkline_30d: [83, 84, 85, 85, 86], drifts_count: 0, initiatives_count: 0 },
+  { slug: 'Produtos', bucket: 'functional_horizontal', score_v3: 79, meta_bucket: 80, status: 'warn', sparkline_30d: [77, 78, 78, 79, 79], drifts_count: 0, initiatives_count: 1 },
+  { slug: 'Pessoas', bucket: 'functional_horizontal', score_v3: 81, meta_bucket: 80, status: 'ok', sparkline_30d: [78, 79, 80, 80, 81], drifts_count: 0, initiatives_count: 0 },
+  { slug: 'Ponto', bucket: 'functional_horizontal', score_v3: 75, meta_bucket: 80, status: 'crit', sparkline_30d: [72, 73, 73, 74, 75], drifts_count: 1, initiatives_count: 2 },
+  { slug: 'Inbox', bucket: 'functional_horizontal', score_v3: 83, meta_bucket: 80, status: 'ok', sparkline_30d: [80, 81, 82, 82, 83], drifts_count: 0, initiatives_count: 0 },
+  { slug: 'Pos', bucket: 'functional_horizontal', score_v3: 80, meta_bucket: 80, status: 'ok', sparkline_30d: [76, 77, 78, 79, 80], drifts_count: 0, initiatives_count: 0 },
+  { slug: 'Caixa', bucket: 'functional_horizontal', score_v3: 78, meta_bucket: 80, status: 'warn', sparkline_30d: [76, 76, 77, 78, 78], drifts_count: 0, initiatives_count: 1 },
+  { slug: 'Relatorios', bucket: 'functional_horizontal', score_v3: 72, meta_bucket: 80, status: 'crit', sparkline_30d: [70, 71, 71, 72, 72], drifts_count: 1, initiatives_count: 1 },
+  { slug: 'Kb', bucket: 'functional_horizontal', score_v3: 88, meta_bucket: 80, status: 'ok', sparkline_30d: [82, 84, 86, 87, 88], drifts_count: 0, initiatives_count: 0 },
+  { slug: 'Ads', bucket: 'functional_horizontal', score_v3: 70, meta_bucket: 80, status: 'crit', sparkline_30d: [68, 69, 69, 70, 70], drifts_count: 1, initiatives_count: 2 },
+  { slug: 'ConsultaOs', bucket: 'functional_horizontal', score_v3: 85, meta_bucket: 80, status: 'ok', sparkline_30d: [80, 82, 83, 84, 85], drifts_count: 0, initiatives_count: 0 },
+  { slug: 'Notificacoes', bucket: 'functional_horizontal', score_v3: 77, meta_bucket: 80, status: 'warn', sparkline_30d: [74, 75, 76, 77, 77], drifts_count: 0, initiatives_count: 1 },
+  { slug: 'Backup', bucket: 'functional_horizontal', score_v3: 90, meta_bucket: 80, status: 'ok', sparkline_30d: [86, 87, 88, 89, 90], drifts_count: 0, initiatives_count: 0 },
+  { slug: 'Auditoria', bucket: 'functional_horizontal', score_v3: 81, meta_bucket: 80, status: 'ok', sparkline_30d: [78, 79, 80, 80, 81], drifts_count: 0, initiatives_count: 0 },
+  { slug: 'Importador', bucket: 'functional_horizontal', score_v3: 74, meta_bucket: 80, status: 'crit', sparkline_30d: [70, 71, 72, 73, 74], drifts_count: 1, initiatives_count: 1 },
+  { slug: 'Integracoes', bucket: 'functional_horizontal', score_v3: 79, meta_bucket: 80, status: 'warn', sparkline_30d: [76, 77, 78, 78, 79], drifts_count: 0, initiatives_count: 1 },
+  { slug: 'Configuracoes', bucket: 'functional_horizontal', score_v3: 84, meta_bucket: 80, status: 'ok', sparkline_30d: [80, 81, 82, 83, 84], drifts_count: 0, initiatives_count: 0 },
+];
+
+// ──────────────────────────────────────────────────────────────────
+// Initiatives — open + closed mix (lifecycle Cortex/Port.io)
+// ──────────────────────────────────────────────────────────────────
+
+export const MOCK_INITIATIVES: MockInitiative[] = [
+  {
+    id: 1, module: 'Jana', bucket: 'ai_central', rule_id: 'F1.a',
+    titulo: '[Jana] Rule F1.a abaixo do alvo (68→85)',
+    status: 'in_progress', deadline: daysFromNow(7),
+    score_before: 68, score_target: 85, score_after: null,
+    opened_at: daysAgo(7),
+  },
+  {
+    id: 2, module: 'Jana', bucket: 'ai_central', rule_id: 'D9.b',
+    titulo: '[Jana] Rule D9.b abaixo do alvo (70→85)',
+    status: 'open', deadline: daysFromNow(10),
+    score_before: 70, score_target: 85, score_after: null,
+    opened_at: daysAgo(4),
+  },
+  {
+    id: 3, module: 'OficinaAuto', bucket: 'vertical_client_facing', rule_id: 'V6.b',
+    titulo: '[OficinaAuto] Rule V6.b abaixo do alvo (60→85)',
+    status: 'open', deadline: daysFromNow(3),
+    score_before: 60, score_target: 85, score_after: null,
+    opened_at: daysAgo(11),
+  },
+  {
+    id: 4, module: 'MemCofre', bucket: 'cross_cutting_infra', rule_id: 'F1.c',
+    titulo: '[MemCofre] Rule F1.c abaixo do alvo (75→90)',
+    status: 'in_progress', deadline: daysFromNow(5),
+    score_before: 75, score_target: 90, score_after: null,
+    opened_at: daysAgo(9),
+  },
+  {
+    id: 5, module: 'Whatsapp', bucket: 'cross_cutting_infra', rule_id: 'L2.a',
+    titulo: '[Whatsapp] Rule L2.a abaixo do alvo (72→90)',
+    status: 'open', deadline: daysFromNow(14),
+    score_before: 72, score_target: 90, score_after: null,
+    opened_at: daysAgo(0),
+  },
+  {
+    id: 6, module: 'Financeiro', bucket: 'cross_cutting_infra', rule_id: 'V6.a',
+    titulo: '[Financeiro] Rule V6.a abaixo do alvo (84→90)',
+    status: 'done', deadline: daysFromNow(-2),
+    score_before: 84, score_target: 90, score_after: 91,
+    opened_at: daysAgo(16),
+  },
+  {
+    id: 7, module: 'Ads', bucket: 'functional_horizontal', rule_id: 'F2.a',
+    titulo: '[Ads] Rule F2.a abaixo do alvo (65→80)',
+    status: 'expired', deadline: daysFromNow(-5),
+    score_before: 65, score_target: 80, score_after: null,
+    opened_at: daysAgo(19),
+  },
+];
+
+// ──────────────────────────────────────────────────────────────────
+// Drifts — últimos 7d, threshold >5pts
+// ──────────────────────────────────────────────────────────────────
+
+export const MOCK_DRIFTS: MockDrift[] = [
+  { module: 'Whatsapp', delta: -8, from: 89, to: 81, snapshot_date: daysAgo(2), direction: 'down' },
+  { module: 'Jana', delta: 7, from: 66, to: 73, snapshot_date: daysAgo(3), direction: 'up' },
+  { module: 'OficinaAuto', delta: -6, from: 71, to: 65, snapshot_date: daysAgo(4), direction: 'down' },
+  { module: 'Ponto', delta: -6, from: 81, to: 75, snapshot_date: daysAgo(5), direction: 'down' },
+  { module: 'Importador', delta: 6, from: 68, to: 74, snapshot_date: daysAgo(6), direction: 'up' },
+];
+
+// ──────────────────────────────────────────────────────────────────
+// AI Suggestions — READ-ONLY (Jellyfish anti-Goodhart 2025)
+// ──────────────────────────────────────────────────────────────────
+
+export const MOCK_AI_SUGGESTIONS: MockAiSuggestion[] = [
+  {
+    module: 'Jana', avg_delta: 4.5, count: 3,
+    last_justificativa: 'Charter Jana documentada após hotfix #639; melhorou clareza de boundaries entre Agents.',
+    last_confidence: 0.78, last_at: daysAgo(1),
+  },
+  {
+    module: 'Whatsapp', avg_delta: -3.2, count: 2,
+    last_justificativa: 'Baileys 7.x rc instável + 3 regressões em 14 dias — degradação confirmada vs alvo de uptime.',
+    last_confidence: 0.85, last_at: daysAgo(2),
+  },
+  {
+    module: 'MemCofre', avg_delta: -2.0, count: 1,
+    last_justificativa: 'Falta Pest cobertura cross-tenant; ADR 0093 multi-tenant não enforced em factory tests.',
+    last_confidence: 0.71, last_at: daysAgo(4),
+  },
+];
+
+// ──────────────────────────────────────────────────────────────────
+// Wave history — W11..W28 (snapshot governance moves)
+// ──────────────────────────────────────────────────────────────────
+
+export const MOCK_WAVE_HISTORY: MockWaveEntry[] = [
+  { wave: 'W28', date: daysAgo(2), modules_touched: ['Governance', 'Admin'], score_delta: +3, summary: 'Initiative service Cortex/Port.io + lifecycle' },
+  { wave: 'W27', date: daysAgo(5), modules_touched: ['Admin'], score_delta: +2, summary: 'GovernanceV4 polish drift visualization' },
+  { wave: 'W26', date: daysAgo(8), modules_touched: ['Admin', 'Jana'], score_delta: +1, summary: 'Saturation observability aggregates daily' },
+  { wave: 'W25', date: daysAgo(11), modules_touched: ['Admin'], score_delta: +2, summary: 'FormRequests RemediationRequest + AlertAck' },
+  { wave: 'W24', date: daysAgo(14), modules_touched: ['Jana'], score_delta: +4, summary: 'AI Scorecard Judge baseline 30d' },
+  { wave: 'W23', date: daysAgo(17), modules_touched: ['Governance'], score_delta: +3, summary: 'ScopedScorecardEvaluator rules canon' },
+  { wave: 'W22', date: daysAgo(20), modules_touched: ['Governance', 'Admin'], score_delta: +2, summary: 'Bucket meta ADR 0160' },
+  { wave: 'W21', date: daysAgo(23), modules_touched: ['Governance'], score_delta: +5, summary: 'mcp_scorecard_runs migration + seed' },
+];
+
+// ──────────────────────────────────────────────────────────────────
+// Health snapshot — visão executiva 1-glance
+// ──────────────────────────────────────────────────────────────────
+
+export const MOCK_HEALTH_SNAPSHOT: MockHealthSnapshot = {
+  generated_at: new Date().toISOString(),
+  v4_enabled: true,
+  media_atual: 81.4,
+  meta_aspiracional: 85,
+  modules_total: 34,
+  modules_ok: 19,
+  modules_warn: 8,
+  modules_crit: 7,
+  drift_threshold_pts: 5,
+  open_initiatives: 5,
+  expired_initiatives: 1,
+};
+
+// ──────────────────────────────────────────────────────────────────
+// Helpers usados pela tela tri-pane
+// ──────────────────────────────────────────────────────────────────
+
+/** Agrupa módulos por bucket (espelha buildModulesPayload do Controller). */
+export function groupModulesByBucket(
+  modules: MockModule[],
+): Record<BucketSlug, MockModule[]> {
+  const out: Record<BucketSlug, MockModule[]> = {
+    vertical_client_facing: [],
+    cross_cutting_infra: [],
+    ai_central: [],
+    functional_horizontal: [],
+  };
+  for (const m of modules) {
+    out[m.bucket].push(m);
+  }
+  // Ordena DESC por score (mesmo critério Controller)
+  for (const key of Object.keys(out) as BucketSlug[]) {
+    out[key].sort((a, b) => b.score_v3 - a.score_v3);
+  }
+  return out;
+}
+
+/** Filtra initiatives open/in_progress. */
+export function filterOpenInitiatives(
+  initiatives: MockInitiative[],
+): MockInitiative[] {
+  return initiatives.filter(
+    (i) => i.status === 'open' || i.status === 'in_progress',
+  );
+}


### PR DESCRIPTION
## Tela GovernanceV4 tri-pane — visualizar 28 waves + ajustar desvios

Wagner aprovou copiar kb_v2 (tri-pane validado ONDA 2) como base visual + adaptar.

### 4 agents paralelos (W29)
- **A** Charter Admin/GovernanceV4.charter.md (155 linhas, F1.5 SKIP — kb_v2 já validado)
- **B** Controller indexV2() + 2 endpoints + 2 FormRequests + 3 rotas (Inertia::defer 7 props)
- **C** Page tsx + 10 sub-components (BucketSidebar, ModuleList, ModuleReader, DimensionProgressBar, SparklineTrend, InitiativeBadge, DriftAlertBanner, AiSuggestionPanel, HealthPanelV4, CommandPaletteV4)
- **D** Pest 27 cenários (20 passed + 7 graceful skip) + mock data

### Features (estado-da-arte governance UI 2026)
- Sidebar: 4 buckets canon + accordion Wave history W11-W28
- Lista: módulos do bucket + filter chips (meta-only / drift / score range)
- Leitor: KPIs + sparkline SVG 30d + 9 dimensões progress bars + initiatives + AI suggestions panel
- DriftAlertBanner persistente vermelho topo se >0
- CommandPalette ⌘K cross-search (módulos/initiatives/waves/ADRs)
- Quick actions: criar Initiative manual + Override bucket trigger + Refresh now
- HealthPanel: scorecard last_run + AI baseline 30d countdown + OTel collector ping
- localStorage prefix oimpresso.governance.v4.* (bucket/módulo/filters/wave-expanded)
- IsWagner middleware Wagner-only
- Fallback MOCK quando v4_enabled=false

### 3 mecanismos canon pra Wagner ajustar desvios
1. **Initiative manual** (Cortex-style) — criar via UI quando drift detectado
2. **Bucket override trigger** — endpoint emite instrução PR + label `bucket-change-approved`
3. **AI suggestions panel** READ-ONLY 30d baseline (W24)

### Smoke
Page será acessível em `/admin/governance/v4` (rota nova coexiste com Wave 24 `__invoke` legacy).

🤖 W29 tela governance v4