### PR TITLE
hotfix(housekeeping): limpar markers git em PHPDoc cross-projeto

### DIFF
--- a/Modules/Accounting/Services/BudgetService.php
+++ b/Modules/Accounting/Services/BudgetService.php
@@ -5,12 +5,15 @@ namespace Modules\Accounting\Services;
 use App\Util\OtelHelper;
 
 /**
-<<<<<<< HEAD
  * BudgetService — orçamento mensal/trimestral/anual Accounting (legacy UltimatePOS).
  *
  * Stateless após Wave 28 D9 instrumentation. Mantém retro-compat com construtor com
  * argumentos (legacy code Controllers ainda usa) mas adiciona span observável aos
  * cálculos críticos pra rastrear latência de geração de relatório anual.
+ *
+ * Wave 27 D9.a — spans OtelHelper::spanBiz nos converters quarterly/yearly
+ * (hot-path do BudgetController quando recalcula período inteiro). Zero-cost
+ * OTel quando `otel.enabled=false` (default Hostinger).
  *
  * Multi-tenant Tier 0 ({@see ADR 0093}): Service stateless — toda query DB que ler
  * Budget DEVE passar business_id explicitamente NO callsite (Controller já faz). Este
@@ -21,18 +24,6 @@ use App\Util\OtelHelper;
  *
  * @see Modules\Accounting\Http\Controllers\BudgetController
  * @see Modules\Accounting\Tests\Feature\Wave28AccountingSaturationTest
-=======
- * BudgetService — utilitários de orçamento (mensal/trimestral/anual).
- *
- * Wave 27 D9.a — spans OtelHelper::spanBiz nos converters quartely/yearly
- * (hot-path do BudgetController quando recalcula período inteiro). Zero-cost
- * OTel quando `otel.enabled=false` (default Hostinger).
- *
- * Multi-tenant Tier 0 (ADR 0093): Service não toca DB diretamente — atua sobre
- * arrays/inteiros recebidos do Controller, isolation fica no caller.
- *
- * @see Modules\Accounting\Http\Controllers\BudgetController
->>>>>>> origin/main
  */
 class BudgetService
 {
@@ -93,12 +84,9 @@ class BudgetService
 
     public function quartelyBudgetToMonthly(array $months, int $quarter_budget, bool $eliminate_decimals)
     {
-<<<<<<< HEAD
-        return OtelHelper::spanBiz('accounting.budget.quarterly_to_monthly', function () use ($months, $quarter_budget, $eliminate_decimals) {
-=======
         // W27 D9.a: span observa converter quartely (BudgetController hot-path).
-        return OtelHelper::spanBiz('accounting.budget.quartely_to_monthly', function () use ($months, $quarter_budget, $eliminate_decimals) {
->>>>>>> origin/main
+        // Wave 28: span name padronizado 'quarterly_to_monthly' (HEAD canon, sem typo).
+        return OtelHelper::spanBiz('accounting.budget.quarterly_to_monthly', function () use ($months, $quarter_budget, $eliminate_decimals) {
             $monthly_budget = [];
 
             switch ($eliminate_decimals) {
@@ -128,22 +116,15 @@ class BudgetService
             return $monthly_budget;
         }, [
             'module'             => 'Accounting',
-<<<<<<< HEAD
             'quarter_budget'     => $quarter_budget,
             'eliminate_decimals' => $eliminate_decimals,
             // Sem PII (apenas valor numérico do orçamento — não é dado pessoal).
-=======
-            'eliminate_decimals' => $eliminate_decimals,
->>>>>>> origin/main
         ]);
     }
 
     public function yearlyBudgetToMonthly(int $yearly_budget, bool $eliminate_decimals)
     {
-<<<<<<< HEAD
-=======
         // W27 D9.a: span observa converter yearly (BudgetController hot-path).
->>>>>>> origin/main
         return OtelHelper::spanBiz('accounting.budget.yearly_to_monthly', function () use ($yearly_budget, $eliminate_decimals) {
             $monthly_budget = [];
 
@@ -175,10 +156,7 @@ class BudgetService
             return $monthly_budget;
         }, [
             'module'             => 'Accounting',
-<<<<<<< HEAD
             'yearly_budget'      => $yearly_budget,
-=======
->>>>>>> origin/main
             'eliminate_decimals' => $eliminate_decimals,
         ]);
     }

--- a/Modules/Arquivos/Services/ArquivosRetentionService.php
+++ b/Modules/Arquivos/Services/ArquivosRetentionService.php
@@ -184,7 +184,6 @@ class ArquivosRetentionService
     }
 
     /**
-<<<<<<< HEAD
      * Wave 28 D9 — summary aging counts read-only por business (idempotente, zero mutação).
      *
      * Sai do dry_run loop do `run()` pra cenário "quero ver o cenário SEM nem listar".
@@ -221,7 +220,15 @@ class ArquivosRetentionService
                 'soft_deleted'      => $softDeleted,
                 'expired_eligible'  => $expiredEligible,
                 'business_id'       => $businessId,
-=======
+            ];
+        }, [
+            'module'         => 'Arquivos',
+            'business_id'    => $businessId,
+            'retention_days' => $retentionDays,
+        ]);
+    }
+
+    /**
      * Wave 27 D9.a — preview agregado pra Auditor LGPD (UI dashboard).
      *
      * Conta arquivos elegíveis por bucket SEM mutar nada — span dedicado
@@ -261,7 +268,6 @@ class ArquivosRetentionService
                 'total'     => $total,
                 'by_bucket' => $byBucket,
                 'oldest_at' => $oldest,
->>>>>>> origin/main
             ];
         }, [
             'module'         => 'Arquivos',
@@ -269,8 +275,6 @@ class ArquivosRetentionService
             'retention_days' => $retentionDays,
         ]);
     }
-<<<<<<< HEAD
-=======
 
     /**
      * Wave 27 D9.a — relatório pós-batch (artefato pra Auditor LGPD assinar).
@@ -315,5 +319,4 @@ class ArquivosRetentionService
             'purged'         => (int) ($runResult['purged'] ?? 0),
         ]);
     }
->>>>>>> origin/main
 }

--- a/Modules/Manufacturing/Services/ProductionService.php
+++ b/Modules/Manufacturing/Services/ProductionService.php
@@ -117,13 +117,12 @@ class ProductionService
     }
 
     /**
-<<<<<<< HEAD
      * Custo médio de produção — usado em widgets dashboard Manufacturing.
      *
      * Wave 27 D9.a — span observa agregada cara (média ponderada sobre todas as
      * production_purchase do business). Zero-cost OTel quando otel.enabled=false.
      *
-     * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093) — caller injeta business_id.
+     * Multi-tenant Tier 0 IRREVOGÁVEIS (ADR 0093) — caller injeta business_id.
      *
      * @param  int  $businessId  Tenant — NUNCA omitir, NUNCA usar session() em Job.
      * @return float Custo médio (zero se não houver produções).
@@ -140,7 +139,10 @@ class ProductionService
             return (float) ($value ?? 0.0);
         }, [
             'module' => 'Manufacturing',
-=======
+        ]);
+    }
+
+    /**
      * Wave 26 D9 — KPIs por janela temporal (últimos N dias) pra dashboard.
      *
      * Spans observáveis pra hot-path de dashboards reagentes (Producao card).
@@ -171,7 +173,6 @@ class ProductionService
         }, [
             'module'      => 'Manufacturing',
             'window_days' => $windowDays,
->>>>>>> origin/main
         ]);
     }
 }

--- a/Modules/NFSe/Tests/Feature/Wave27PolishTest.php
+++ b/Modules/NFSe/Tests/Feature/Wave27PolishTest.php
@@ -203,11 +203,7 @@ describe('Wave 27 NFSe POLISH FINAL', function () {
 
         // PII tomador rastreado pra LGPD Art. 37 (registro operações tratamento dados)
         foreach (['tomador_cnpj', 'tomador_cpf', 'tomador_nome', 'tomador_email'] as $pii) {
-<<<<<<< HEAD
             expect($fillable)->toContain($pii, "PII {$pii} deve estar em logFillable pra audit LGPD");
-=======
-            expect(in_array($pii, $fillable, true))->toBeTrue("PII {$pii} deve estar em logFillable pra audit LGPD");
->>>>>>> origin/main
         }
     });
 
@@ -215,11 +211,7 @@ describe('Wave 27 NFSe POLISH FINAL', function () {
         $fillable = (new NfseEmissao())->getFillable();
 
         foreach (['valor_servicos', 'valor_iss', 'aliquota_iss', 'lc116_codigo', 'iss_retido'] as $fiscal) {
-<<<<<<< HEAD
             expect($fillable)->toContain($fiscal, "Campo fiscal {$fiscal} deve estar em audit trail");
-=======
-            expect(in_array($fiscal, $fillable, true))->toBeTrue("Campo fiscal {$fiscal} deve estar em audit trail");
->>>>>>> origin/main
         }
     });
 
@@ -309,16 +301,11 @@ describe('Wave 27 NFSe POLISH FINAL', function () {
     it('Tier 0: NfseEmissaoService.cancelar registra motivo (auditoria fiscal)', function () {
         $src = file_get_contents((new ReflectionClass(NfseEmissaoService::class))->getFileName());
 
-<<<<<<< HEAD
-        expect($src)->toContain('cancelar(NfseEmissao $emissao, string $motivo)')
-            ->and($src)->toContain("'motivo' => \$motivo");
-=======
         expect($src)->toContain('cancelar(NfseEmissao $emissao, string $motivo)');
 
         // Aceita alinhamento de espaços ('motivo'      => $motivo).
         expect(preg_match('/[\'"]motivo[\'"]\s*=>\s*\$motivo/', $src))->toBe(1,
             'cancelar() deve registrar motivo em log estruturado');
->>>>>>> origin/main
     });
 
     it('Tier 0: NfseProviderConfig isProducao() helper (gate anti-erro homolog→prod)', function () {

--- a/Modules/NfeBrasil/Services/CertificadoService.php
+++ b/Modules/NfeBrasil/Services/CertificadoService.php
@@ -50,13 +50,6 @@ class CertificadoService
      */
     public function validar(string $pfxBase64, string $senha): array
     {
-<<<<<<< HEAD
-        return OtelHelper::span('nfe.certificado_validar', [
-            'pfx_size_bytes' => strlen($pfxBase64),
-        ], fn () => $this->validarInterno($pfxBase64, $senha));
-    }
-
-=======
         // D9 Wave 26 — span no parse PKCS12 (hot-path SEFAZ — senha/pfx NUNCA em attributes).
         // Defesa Tier 0: attributes carregam APENAS booleans/length, nunca conteudo do .pfx ou senha.
         return OtelHelper::spanBiz('nfe.certificado.validar', function () use ($pfxBase64, $senha): array {
@@ -67,7 +60,6 @@ class CertificadoService
     /**
      * Implementacao interna de validar — wrap span OTel acima (D9 Wave 26).
      */
->>>>>>> origin/main
     private function validarInterno(string $pfxBase64, string $senha): array
     {
         $binary = base64_decode($pfxBase64, true);

--- a/Modules/Officeimpresso/Tests/Feature/Wave27PolishTest.php
+++ b/Modules/Officeimpresso/Tests/Feature/Wave27PolishTest.php
@@ -60,11 +60,7 @@ describe('Wave 27 Officeimpresso POLISH FINAL', function () {
         ];
 
         foreach ($canonicos as $m) {
-<<<<<<< HEAD
             expect($methods)->toContain($m, "LicencaService deve expor método público {$m}");
-=======
-            expect(in_array($m, $methods, true))->toBeTrue("LicencaService deve expor método público {$m}");
->>>>>>> origin/main
         }
     });
 
@@ -132,11 +128,7 @@ describe('Wave 27 Officeimpresso POLISH FINAL', function () {
         $campos = $const->getValue();
         foreach (['event', 'licenca_id', 'error_code', 'error_message',
                   'endpoint', 'http_method', 'http_status', 'duration_ms'] as $f) {
-<<<<<<< HEAD
             expect($campos)->toContain($f, "CAMPOS_CONHECIDOS deve incluir {$f}");
-=======
-            expect(in_array($f, $campos, true))->toBeTrue("CAMPOS_CONHECIDOS deve incluir {$f}");
->>>>>>> origin/main
         }
     });
 
@@ -215,11 +207,7 @@ describe('Wave 27 Officeimpresso POLISH FINAL', function () {
         // PATCH-friendly: Wagner pode atualizar 1 campo só (ex: liberar versao_disponivel)
         foreach (['caminho_banco_servidor', 'versao_obrigatoria', 'versao_disponivel', 'officeimpresso_numerodemaquinas'] as $field) {
             $rule = implode('|', $rules[$field]);
-<<<<<<< HEAD
             expect($rule)->toContain('sometimes', "Campo {$field} deve ser 'sometimes' (PATCH-friendly)");
-=======
-            expect(str_contains($rule, 'sometimes'))->toBeTrue("Campo {$field} deve ser 'sometimes' (PATCH-friendly)");
->>>>>>> origin/main
         }
     });
 
@@ -241,11 +229,7 @@ describe('Wave 27 Officeimpresso POLISH FINAL', function () {
 
         // Campos contrato Delphi (NÃO renomear — sincronização HTTP)
         foreach (['licenca_id', 'hd', 'processador', 'memoria', 'versao_exe'] as $field) {
-<<<<<<< HEAD
             expect($rules)->toHaveKey($field, "StoreLicencaRequest deve preservar campo Delphi {$field}");
-=======
-            expect(array_key_exists($field, $rules))->toBeTrue("StoreLicencaRequest deve preservar campo Delphi {$field}");
->>>>>>> origin/main
         }
     });
 
@@ -281,11 +265,7 @@ describe('Wave 27 Officeimpresso POLISH FINAL', function () {
             'officeimpresso.empresa.atualizar',
             'officeimpresso.empresa.alternar_bloqueio',
         ] as $span) {
-<<<<<<< HEAD
             expect($src)->toContain("'{$span}'", "Span canon {$span} ausente");
-=======
-            expect(str_contains($src, "'{$span}'"))->toBeTrue("Span canon {$span} ausente");
->>>>>>> origin/main
         }
     });
 
@@ -305,18 +285,12 @@ describe('Wave 27 Officeimpresso POLISH FINAL', function () {
     it('D9 spans: LicencaAuditService span registrar com attributes canon', function () {
         $src = file_get_contents((new ReflectionClass(LicencaAuditService::class))->getFileName());
 
-<<<<<<< HEAD
-        expect($src)->toContain("OtelHelper::spanBiz('officeimpresso.licenca_audit.registrar'")
-            ->and($src)->toContain("'module' => 'Officeimpresso'")
-            ->and($src)->toContain("'event'")
-=======
         expect($src)->toContain("OtelHelper::spanBiz('officeimpresso.licenca_audit.registrar'");
 
         // Atributos canon com tolerância a alinhamento de espaços/padding
         expect(preg_match("/['\"]module['\"]\s*=>\s*['\"]Officeimpresso['\"]/", $src))->toBe(1,
             'LicencaAuditService deve declarar module => Officeimpresso em span attributes');
         expect($src)->toContain("'event'")
->>>>>>> origin/main
             ->and($src)->toContain("'has_error'")
             ->and($src)->toContain("'http_status'");
     });

--- a/Modules/RecurringBilling/Tests/Feature/Wave27PolishTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/Wave27PolishTest.php
@@ -41,11 +41,7 @@ describe('Wave 27 RecurringBilling POLISH FINAL', function () {
             ->toArray();
 
         foreach (['emitir', 'cancelar', 'pdf', 'refundAsaas', 'fetchPaymentAsaas'] as $m) {
-<<<<<<< HEAD
             expect($methods)->toContain($m, "BoletoService deve expor método público {$m}");
-=======
-            expect(in_array($m, $methods, true))->toBeTrue("BoletoService deve expor método público {$m}");
->>>>>>> origin/main
         }
     });
 
@@ -81,11 +77,7 @@ describe('Wave 27 RecurringBilling POLISH FINAL', function () {
             ->toArray();
 
         foreach (['criar', 'pausar', 'retomar', 'cancelar', 'calcularProximoVencimento'] as $m) {
-<<<<<<< HEAD
             expect($methods)->toContain($m, "AssinaturaService deve expor método público {$m}");
-=======
-            expect(in_array($m, $methods, true))->toBeTrue("AssinaturaService deve expor método público {$m}");
->>>>>>> origin/main
         }
     });
 


### PR DESCRIPTION
7 arquivos com conflitos em PHPDoc/comentários (não quebram PHP mas sujos). Resolução: PHPDoc consolida ambas contribuições, código real escolhe origin/main ou MERGE preservando ambas features. 7/7 php -l OK.