### PR TITLE
hotfix(admin): suporte real ADMIN_BYPASS_TAILSCALE (prod safe, defense-in-depth)

### DIFF
--- a/Modules/Admin/Config/config.php
+++ b/Modules/Admin/Config/config.php
@@ -42,4 +42,18 @@ return [
      * desabilitados).
      */
     'bypass_local' => env('ADMIN_BYPASS_LOCAL', false),
+
+    /**
+     * Bypass Tailscale-only restrito (válido em qualquer env, inclusive prod).
+     * Defense-in-depth preservado: middleware `is-wagner` (user_id=1) continua
+     * validando — apenas Wagner autenticado entra, mesmo com flag ON. Cada
+     * request bypass loga WARN em admin.tailscale_bypass pra auditoria.
+     *
+     * Caso de uso: Wagner acessando admin via Hostinger público (sem VPN
+     * Tailscale ativa no laptop). Ativado em prod 2026-05-17 quando setup
+     * Tailscale-only do Admin foi diferido pra Sprint posterior.
+     *
+     * Default false (CIDR Tailscale obrigatório).
+     */
+    'bypass_tailscale' => env('ADMIN_BYPASS_TAILSCALE', false),
 ];

--- a/Modules/Admin/Http/Middleware/TailscaleOnly.php
+++ b/Modules/Admin/Http/Middleware/TailscaleOnly.php
@@ -31,6 +31,18 @@ class TailscaleOnly
             return $next($request);
         }
 
+        // Bypass Tailscale-only restrito (qualquer env, inclusive prod). Defense-in-depth
+        // preservado — middleware `is-wagner` continua validando user_id=1. Log WARN
+        // pra auditoria. Ver config('admin.bypass_tailscale') + ADR 0122.
+        if (config('admin.bypass_tailscale')) {
+            \Log::channel('stack')->warning('admin.tailscale_bypass', [
+                'ip'    => $request->ip(),
+                'route' => $request->path(),
+                'env'   => app()->environment(),
+            ]);
+            return $next($request);
+        }
+
         $allowedCidrs = config('admin.tailscale_cidrs', '100.99.0.0/16');
         $cidrs = is_array($allowedCidrs)
             ? $allowedCidrs


### PR DESCRIPTION
## Problema
Flag \`ADMIN_BYPASS_TAILSCALE=true\` foi setada no \`.env\` Hostinger (sessão 2026-05-17 anterior) mas o middleware \`TailscaleOnly\` **NÃO conhecia** a chave — só lia \`admin.bypass_local\` + exigia \`APP_ENV=local\`. Em prod (\`APP_ENV=production\`) a flag era inerte.

Sintoma: Wagner acessando \`/admin/governance/v4\` logado → HTTP 403 "Acesso permitido apenas via Tailscale" mesmo com a flag setada.

## Fix
- \`Modules/Admin/Config/config.php\`: nova chave \`bypass_tailscale\` (via env \`ADMIN_BYPASS_TAILSCALE\`)
- \`TailscaleOnly@handle\`: checa a flag ANTES do CIDR check. Log WARN \`admin.tailscale_bypass\` pra auditoria

## Defense-in-depth preservado
- ✅ Middleware \`is-wagner\` continua validando \`user_id=1\` (DB check)
- ✅ Log de auditoria cada bypass (\`ip + route + env\`)
- ✅ Default \`false\` (CIDR Tailscale obrigatório se flag ausente)
- ✅ Independente de \`bypass_local\` — separação concerns

## Test plan
- [x] Middleware compila
- [x] Config nova chave funciona via \`env()\`
- [ ] Pós-merge: Hostinger pull + \`config:clear\` + Wagner valida \`/admin/governance/v4\` (espera 200 OK render)
- [ ] Log \`storage/logs/laravel.log\` mostra \`admin.tailscale_bypass\` warning

Refs: ADR 0122 Admin Center

🤖 Generated with [Claude Code](https://claude.com/claude-code)