### PR TITLE
hotfix(admin): IsWagner aceita superadmin#{biz} (UltimatePOS Spatie multi-tenant)

### DIFF
--- a/Modules/Admin/Http/Middleware/IsWagner.php
+++ b/Modules/Admin/Http/Middleware/IsWagner.php
@@ -44,7 +44,10 @@ class IsWagner
 
         $userIdMatch     = (int) $user->id === $expectedUserId;
         $businessIdMatch = (int) ($user->business_id ?? 0) === $expectedBusinessId;
-        $hasRole         = method_exists($user, 'hasRole') && $user->hasRole('superadmin');
+        // UltimatePOS Spatie usa suffix #{biz} (roles.business_id NOT NULL — FK).
+        // Aceita 'superadmin' (legacy global) OU 'superadmin#{biz}' (canon multi-tenant).
+        $hasRole         = method_exists($user, 'hasRole')
+            && ($user->hasRole('superadmin') || $user->hasRole("superadmin#{$expectedBusinessId}"));
 
         // Caminho normal: 3 condições AND
         if ($userIdMatch && $businessIdMatch && $hasRole) {


### PR DESCRIPTION
## Problema

Middleware `IsWagner` exigia `hasRole('superadmin')` exato. UltimatePOS Spatie usa suffix `#{biz}` (roles.business_id NOT NULL — FK), então Wagner tem `Admin#1`, `vendas.enviar#1`, etc — mas NUNCA `superadmin` raw (violaria FK).

Sintoma pós-hotfix #1005: bypass Tailscale OK → caiu em is-wagner mesmo com user_id=1 + business_id=1.

Log: `admin.unauthorized reason=gate_check_failed user_id=1`

## Fix
`IsWagner@handle` aceita `superadmin` (legacy global) OU `superadmin#{biz}` (canon UltimatePOS).

## Setup paralelo (já feito via tinker prod)
- Role `superadmin#1` criada (id=672, business_id=1, guard_name=web)
- Assigned a Wagner (user_id=1)

## Test plan
- [x] Middleware compila
- [ ] Pós-merge: Wagner valida `/admin/governance/v4` (espera 200 OK render tri-pane)

Refs: ADR 0122 Admin Center | ADR 0093 multi-tenant Tier 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)