### PR TITLE
fix(ui): KpiGrid suporta cols=5 (Governance v4 layout vertical stack)

### DIFF
--- a/resources/js/Components/shared/KpiGrid.tsx
+++ b/resources/js/Components/shared/KpiGrid.tsx
@@ -8,6 +8,7 @@ import { cn } from '@/Lib/utils';
  *   2 → 1 col mobile, 2 tablet, 2 desktop
  *   3 → 1 col mobile, 2 tablet, 3 desktop
  *   4 → 1 col mobile, 2 tablet, 4 desktop (padrão)
+ *   5 → 1 col mobile, 2 tablet, 5 desktop (Governance v4 saúde KPIs)
  *   6 → 2 col mobile, 3 tablet, 6 desktop
  *
  * Uso:
@@ -18,7 +19,7 @@ import { cn } from '@/Lib/utils';
  *   </KpiGrid>
  */
 interface Props {
-  cols?: 2 | 3 | 4 | 6;
+  cols?: 2 | 3 | 4 | 5 | 6;
   children: React.ReactNode;
   className?: string;
 }
@@ -27,6 +28,7 @@ const colsMap: Record<NonNullable<Props['cols']>, string> = {
   2: 'grid-cols-1 sm:grid-cols-2',
   3: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-3',
   4: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-4',
+  5: 'grid-cols-1 sm:grid-cols-2 lg:grid-cols-5',
   6: 'grid-cols-2 sm:grid-cols-3 lg:grid-cols-6',
 };
 


### PR DESCRIPTION
Tri-pane Governance v4 colapsada a 104px porque KpiGrid não conhecia `cols={5}` → fallback grid-cols-1 empilhava 5 KPIs verticalmente.

**Antes** (validado Chrome MCP prod):
- KPI grid: `2268px / 106px × 5` (vertical stack 580px altura)
- Tri-pane kb-tri: 104.75px (deveria ser ~600px)

**Fix:** add `5` ao tipo Props.cols + colsMap (`grid-cols-1 sm:grid-cols-2 lg:grid-cols-5`).

Test plan: pós-merge + Hostinger pull + npm build + re-validar via Chrome MCP. Esperado: 5 KPIs lado-a-lado, tri-pane com ~600px altura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)