### PR TITLE
fix(admin): sidebar vazia em /admin/* — middleware AdminSidebarMenu

### DIFF
--- a/Modules/Admin/Routes/web.php
+++ b/Modules/Admin/Routes/web.php
@@ -35,8 +35,12 @@ Route::middleware(['web', 'authh', 'auth', 'SetSessionData', 'language', 'timezo
     });
 
 // Painel principal Wagner-only — ordem de middleware crítica:
-// tailscale-only (zero cost IP) -> auth -> is-wagner (DB check)
-Route::middleware(['web', 'tailscale-only', 'auth', 'is-wagner'])
+// tailscale-only (zero cost IP) -> SetSessionData (popula session.business
+// usado pelo AdminSidebarMenu) -> auth -> is-wagner (DB check) ->
+// language/timezone (cosmetic UltimatePOS) -> AdminSidebarMenu (popula
+// Menu::create('admin-sidebar-menu') consumido pelo HandleInertiaRequests
+// como shell.menu; sem ele o Cockpit Sidebar exibe "Menu vazio")
+Route::middleware(['web', 'tailscale-only', 'SetSessionData', 'auth', 'is-wagner', 'language', 'timezone', 'AdminSidebarMenu'])
     ->prefix('admin')
     ->group(function () {
         Route::get('/', IndexController::class)->name('admin.index');


### PR DESCRIPTION
## Problema
Rota `/admin/governance/v4` (e todas `/admin/*`) usava stack mínima `['web','tailscale-only','auth','is-wagner']`. Sem `AdminSidebarMenu` middleware o `Menu::create('admin-sidebar-menu')` nunca era populado → `ShellMenuBuilder::build()` retornava `[]` → `HandleInertiaRequests` share `shell.menu = []` → Cockpit Sidebar exibia *Menu vazio*.

Sem `SetSessionData` o `session('business.enabled_modules')` ficava vazio, metade dos dropdowns UltimatePOS abortava early.

## Fix
Stack canon UltimatePOS preservando triple-gate Admin:

`['web','tailscale-only','SetSessionData','auth','is-wagner','language','timezone','AdminSidebarMenu']`

Ordem é crítica:
- `tailscale-only` PRIMEIRO (zero cost IP)
- `SetSessionData` ANTES de `auth` (popula `business` pre-login)
- `AdminSidebarMenu` POR ÚLTIMO (precisa session + Auth user)
- `is-wagner` mantém DB check Wagner-only

## Test plan
- [x] Stack compila
- [ ] Pós-merge: Hostinger pull → re-validar via Chrome MCP (esperado: sidebar com Home/Vendas/Estoque/Contatos/etc rendered, NÃO mais "Menu vazio")

Refs: ADR 0122 Admin Center · `.claude/rules/routes.md` stack canônico

🤖 Generated with [Claude Code](https://claude.com/claude-code)