### PR TITLE
feat(admin): Screen Review split — Dashboard (5 KPIs) + nav header

### DIFF
--- a/Modules/Admin/Http/Controllers/ScreenReviewController.php
+++ b/Modules/Admin/Http/Controllers/ScreenReviewController.php
@@ -57,6 +57,29 @@ class ScreenReviewController extends Controller
     }
 
     /**
+     * GET /admin/screen-review/dashboard — landing leve com 5 KPIs PDCA + alerta
+     * drift pending>7d. Atalho navegacional pra `/admin/screen-review` (tri-pane).
+     * Wagner pediu split (2026-05-17): KPIs viraram tela própria pra reduzir
+     * scroll na tri-pane operacional.
+     */
+    public function dashboard(): Response
+    {
+        $counts = $this->countAllStatuses();
+
+        return Inertia::render('Admin/ScreenReviewDashboard', [
+            'meta' => [
+                'generated_at' => now()->toIso8601String(),
+                'total_telas' => $counts['total'],
+                'pending_count' => $counts[self::STATUS_PENDING],
+                'approved_count' => $counts[self::STATUS_APPROVED],
+                'rejected_count' => $counts[self::STATUS_REJECTED],
+                'iterate_count' => $counts[self::STATUS_ITERATE],
+                'pending_over_7d' => $counts['pending_over_7d'],
+            ],
+        ]);
+    }
+
+    /**
      * GET /admin/screen-review — render tri-pane.
      */
     public function index(): Response

--- a/Modules/Admin/Routes/web.php
+++ b/Modules/Admin/Routes/web.php
@@ -89,6 +89,10 @@ Route::middleware(['web', 'tailscale-only', 'SetSessionData', 'auth', 'is-wagner
         // {screenPath} usa where(.*) pra aceitar barras URL-encoded (Admin/GovernanceV4).
         // @see Modules\Admin\Http\Controllers\ScreenReviewController
         // @see resources/js/Pages/Admin/ScreenReview.charter.md
+        // Dashboard split (2026-05-17 Wagner) — landing leve com 5 KPIs PDCA.
+        // Registrada ANTES de /screen-review pra ordem importar (route precedence).
+        Route::get('screen-review/dashboard',                    [ScreenReviewController::class, 'dashboard'])
+            ->name('admin.screen-review.dashboard');
         Route::get('screen-review',                              [ScreenReviewController::class, 'index'])
             ->name('admin.screen-review');
         Route::post('screen-review/{screenPath}/status',         [ScreenReviewController::class, 'updateStatus'])

--- a/resources/js/Pages/Admin/ScreenReview.tsx
+++ b/resources/js/Pages/Admin/ScreenReview.tsx
@@ -15,14 +15,12 @@
 // Quando defer ainda não retornou, página entra em estado MOCK skeleton.
 
 import * as React from 'react';
-import { Head, router, useForm, Deferred } from '@inertiajs/react';
+import { Head, Link, router, Deferred } from '@inertiajs/react';
 import { toast } from 'sonner';
-import { Camera, Search as SearchIcon, Clock } from 'lucide-react';
+import { LayoutDashboard, Search as SearchIcon } from 'lucide-react';
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import PageHeader from '@/Components/shared/PageHeader';
-import KpiGrid from '@/Components/shared/KpiGrid';
-import KpiCard from '@/Components/shared/KpiCard';
 import { Button } from '@/Components/ui/button';
 import { Skeleton } from '@/Components/ui/skeleton';
 
@@ -185,69 +183,15 @@ function ScreenReview(props: ScreenReviewPageProps) {
                 <SearchIcon size={13} className="mr-1.5" />
                 Reload
               </Button>
+              <Button asChild variant="outline" size="sm" className="h-8 text-xs">
+                <Link href="/admin/screen-review/dashboard">
+                  <LayoutDashboard size={13} className="mr-1.5" />
+                  Dashboard
+                </Link>
+              </Button>
             </div>
           }
         />
-
-        {/* KPIs header */}
-        <KpiGrid cols={5}>
-          <KpiCard
-            label="Total telas"
-            value={meta.total_telas}
-            description=".tsx em Pages/"
-            icon="layers"
-            tone="default"
-            size="compact"
-          />
-          <KpiCard
-            label="Pendentes Wagner"
-            value={meta.pending_count}
-            description="sem .review.md ou último round=pending"
-            icon="clock"
-            tone={meta.pending_count > 0 ? 'warning' : 'success'}
-            size="compact"
-          />
-          <KpiCard
-            label="Aprovadas"
-            value={meta.approved_count}
-            description="último round=approved"
-            icon="check"
-            tone={meta.approved_count > 0 ? 'success' : 'default'}
-            size="compact"
-          />
-          <KpiCard
-            label="Em iteração"
-            value={meta.iterate_count}
-            description="loop F1.5 ativo"
-            icon="refresh-cw"
-            tone={meta.iterate_count > 0 ? 'info' : 'default'}
-            size="compact"
-          />
-          <KpiCard
-            label="Rejeitadas"
-            value={meta.rejected_count}
-            description="último round=rejected"
-            icon="x"
-            tone={meta.rejected_count > 0 ? 'danger' : 'default'}
-            size="compact"
-          />
-        </KpiGrid>
-
-        {/* Drift alert pending > 7d */}
-        {meta.pending_over_7d > 0 && (
-          <div
-            role="alert"
-            className="flex items-center gap-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-[12px] text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
-          >
-            <Clock size={14} className="shrink-0" />
-            <span>
-              <strong>{meta.pending_over_7d}</strong> tela
-              {meta.pending_over_7d === 1 ? '' : 's'} pendente
-              {meta.pending_over_7d === 1 ? '' : 's'} há &gt; 7 dias — Wagner
-              precisa revisar.
-            </span>
-          </div>
-        )}
 
         {/* Tri-pane */}
         <div
@@ -330,12 +274,7 @@ function ReaderSkeleton() {
 }
 
 ScreenReview.layout = (page: React.ReactNode) => (
-  <AppShellV2
-    title="Screen Review"
-    breadcrumbItems={[{ label: 'Admin' }, { label: 'Screen Review' }]}
-  >
-    {page}
-  </AppShellV2>
+  <AppShellV2 title="Screen Review">{page}</AppShellV2>
 );
 
 export default ScreenReview;

--- a/resources/js/Pages/Admin/ScreenReviewDashboard.charter.md
+++ b/resources/js/Pages/Admin/ScreenReviewDashboard.charter.md
@@ -1,0 +1,52 @@
+---
+page_id: admin.screen-review.dashboard
+route: /admin/screen-review/dashboard
+status: live
+owner: wagner
+adrs: [0104, 0122, 0160]
+related_pages: [admin.screen-review, admin.governance.v4]
+created: 2026-05-17
+---
+
+# Charter — Screen Review · Dashboard
+
+## Mission
+
+Visão executiva (read-only) do estado PDCA das 201+ telas Inertia/React do
+oimpresso. Wagner abre essa tela em 2 segundos pra saber se vale entrar na
+operação (tri-pane `/admin/screen-review`) ou se está tudo em dia.
+
+## Goals
+
+- 5 KPIs PDCA em 1 viewport sem scroll (Total / Pendentes / Aprovadas /
+  Iteração / Rejeitadas)
+- Alerta visual quando pending_over_7d > 0 (Wagner deixando bola passar)
+- Nav clara pra tri-pane operacional (`/admin/screen-review`) via header
+- Tempo render < 200ms (sem queries pesadas — só meta agregada do controller)
+
+## Non-Goals
+
+- Listar telas (isso é tri-pane)
+- Mostrar charters/screenshots
+- Editar status (Wagner faz na tri-pane)
+
+## UX targets
+
+- Header com PageHeader canon (icon `layout-dashboard`)
+- Actions header: `Reload` (ghost) + `Screen Review` (default — primária)
+- KpiGrid cols={5} responsivo (mobile empilha)
+- Drift alert amber só quando triggered
+- Cores tone semânticas (success/warning/info/danger/default) — sem hex cru
+
+## Anti-hooks
+
+- ⛔ NÃO duplicar lista de screens do `ScreenReview.tsx`
+- ⛔ NÃO chamar `Inertia::defer` no controller dashboard — payload trivial
+- ⛔ NÃO adicionar breadcrumb topnav (Wagner removeu intencionalmente 2026-05-17)
+- ⛔ NÃO criar atalhos de teclado nessa tela (atalhos vivem na tri-pane)
+
+## Related
+
+- `ScreenReview.tsx` — tri-pane operacional (origem do split)
+- `ScreenReviewController::dashboard()` — endpoint
+- `GovernanceV4.tsx` — mesmo padrão tri-pane (não dashboard split)

--- a/resources/js/Pages/Admin/ScreenReviewDashboard.tsx
+++ b/resources/js/Pages/Admin/ScreenReviewDashboard.tsx
@@ -1,0 +1,120 @@
+// @memcofre
+//   tela: /admin/screen-review/dashboard
+//   module: Admin
+//   stories: ONDA 7 Wave 31 W31-D (split Wagner pediu 2026-05-17)
+//   charter: resources/js/Pages/Admin/ScreenReviewDashboard.charter.md
+//   adrs: 0104, 0122, 0160
+//
+// Landing leve com 5 KPIs PDCA do Screen Review. Wagner pediu split:
+// KPIs sairam da tri-pane operacional (`/admin/screen-review`) e viraram
+// tela dedicada com nav `Screen Review` pro retorno.
+
+import * as React from 'react';
+import { Head, Link, router } from '@inertiajs/react';
+import { Clock, ListChecks, RefreshCw } from 'lucide-react';
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import PageHeader from '@/Components/shared/PageHeader';
+import KpiGrid from '@/Components/shared/KpiGrid';
+import KpiCard from '@/Components/shared/KpiCard';
+import { Button } from '@/Components/ui/button';
+
+import type { ScreenReviewMeta } from './ScreenReview';
+
+interface Props {
+  meta: ScreenReviewMeta;
+}
+
+function ScreenReviewDashboard({ meta }: Props) {
+  return (
+    <>
+      <Head title="Screen Review · Dashboard" />
+
+      <div className="flex flex-col gap-3 px-4 py-3">
+        <PageHeader
+          icon="layout-dashboard"
+          title="Screen Review · Dashboard"
+          description={`Visão PDCA · ${meta.total_telas} telas · gerado ${new Date(meta.generated_at).toLocaleString('pt-BR')}`}
+          action={
+            <div className="flex flex-wrap items-center gap-1.5">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="h-8 text-xs"
+                onClick={() => router.reload()}
+              >
+                <RefreshCw size={13} className="mr-1.5" />
+                Reload
+              </Button>
+              <Button asChild size="sm" className="h-8 text-xs">
+                <Link href="/admin/screen-review">
+                  <ListChecks size={13} className="mr-1.5" />
+                  Screen Review
+                </Link>
+              </Button>
+            </div>
+          }
+        />
+
+        <KpiGrid cols={5}>
+          <KpiCard
+            label="Total telas"
+            value={meta.total_telas}
+            description=".tsx em Pages/"
+            icon="layers"
+            tone="default"
+          />
+          <KpiCard
+            label="Pendentes Wagner"
+            value={meta.pending_count}
+            description="sem .review.md ou último round=pending"
+            icon="clock"
+            tone={meta.pending_count > 0 ? 'warning' : 'success'}
+          />
+          <KpiCard
+            label="Aprovadas"
+            value={meta.approved_count}
+            description="último round=approved"
+            icon="check"
+            tone={meta.approved_count > 0 ? 'success' : 'default'}
+          />
+          <KpiCard
+            label="Em iteração"
+            value={meta.iterate_count}
+            description="loop F1.5 ativo"
+            icon="refresh-cw"
+            tone={meta.iterate_count > 0 ? 'info' : 'default'}
+          />
+          <KpiCard
+            label="Rejeitadas"
+            value={meta.rejected_count}
+            description="último round=rejected"
+            icon="x"
+            tone={meta.rejected_count > 0 ? 'danger' : 'default'}
+          />
+        </KpiGrid>
+
+        {meta.pending_over_7d > 0 && (
+          <div
+            role="alert"
+            className="flex items-center gap-3 rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-[12px] text-amber-900 dark:border-amber-700 dark:bg-amber-950/40 dark:text-amber-200"
+          >
+            <Clock size={14} className="shrink-0" />
+            <span>
+              <strong>{meta.pending_over_7d}</strong> tela
+              {meta.pending_over_7d === 1 ? '' : 's'} pendente
+              {meta.pending_over_7d === 1 ? '' : 's'} há &gt; 7 dias — Wagner
+              precisa revisar.
+            </span>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+ScreenReviewDashboard.layout = (page: React.ReactNode) => (
+  <AppShellV2 title="Screen Review · Dashboard">{page}</AppShellV2>
+);
+
+export default ScreenReviewDashboard;


### PR DESCRIPTION
## Wagner pediu (2026-05-17)
> achei muito legal a tela de Screen Review, quero que remova o Topnav (Admin/Screen Review)
> quero que crie tela Dashboard coloque do lado do reload, Coloque Screen Review para poder voltar para tela principal.
> coloque [5 KPIs] no dashboard

## Mudanças
- **Page nova** `Admin/ScreenReviewDashboard.tsx` — landing leve com 5 KPIs PDCA + drift alert. Nav: `Reload` + `Screen Review` (primary).
- **Charter** `Admin/ScreenReviewDashboard.charter.md` — Mission/Goals/Anti-hooks (evitar duplicar lista tri-pane).
- **Page refactor** `Admin/ScreenReview.tsx` — removidos KpiGrid + 5 KpiCard + drift alert + breadcrumb topnav. Botão `Dashboard` adicionado ao lado de `Reload`. Imports orfãos enxugados (Camera, Clock, useForm).
- **Controller** `ScreenReviewController::dashboard()` — Inertia::render sem defer (payload trivial).
- **Route** `/admin/screen-review/dashboard` antes de `/screen-review` pra precedência.

## Test plan
- [ ] Pós-merge: Hostinger pull + npm build (quick-sync GHA)
- [ ] Chrome MCP: `/admin/screen-review/dashboard` renderiza 5 KPIs lado-a-lado
- [ ] Botão `Screen Review` navega pra `/admin/screen-review`
- [ ] `/admin/screen-review` sem KPIs no topo (tri-pane ocupa 100% do espaço)
- [ ] Sem breadcrumb "Admin / Screen Review" em ambas

Refs: ADR 0104 MWART · ADR 0122 Admin Center · ADR 0160 Governance v4

🤖 Generated with [Claude Code](https://claude.com/claude-code)