### PR TITLE
hotfix(admin): hideTopbar Screen Review (remover 'WR2 Sistemas / Chat')

### DIFF
--- a/resources/js/Pages/Admin/ScreenReview.tsx
+++ b/resources/js/Pages/Admin/ScreenReview.tsx
@@ -274,7 +274,7 @@ function ReaderSkeleton() {
 }
 
 ScreenReview.layout = (page: React.ReactNode) => (
-  <AppShellV2 title="Screen Review">{page}</AppShellV2>
+  <AppShellV2 title="Screen Review" hideTopbar>{page}</AppShellV2>
 );
 
 export default ScreenReview;

--- a/resources/js/Pages/Admin/ScreenReviewDashboard.tsx
+++ b/resources/js/Pages/Admin/ScreenReviewDashboard.tsx
@@ -114,7 +114,7 @@ function ScreenReviewDashboard({ meta }: Props) {
 }
 
 ScreenReviewDashboard.layout = (page: React.ReactNode) => (
-  <AppShellV2 title="Screen Review · Dashboard">{page}</AppShellV2>
+  <AppShellV2 title="Screen Review · Dashboard" hideTopbar>{page}</AppShellV2>
 );
 
 export default ScreenReviewDashboard;


### PR DESCRIPTION
Wagner viu breadcrumb global `WR2 Sistemas / Chat` ainda renderizando — não era o breadcrumb da PageHeader (esse já removi), era a topbar global do AppShellV2 (breadcrumb + topnav módulo).

Fix: `hideTopbar` prop nas 2 telas (já existe no AppShellV2, usado em Caixa Unificada V4 quando header próprio torna topbar redundante).

🤖 Generated with [Claude Code](https://claude.com/claude-code)