### PR TITLE
feat(ui): topbar removida global do AppShellV2 (default hideTopbar=true)

### DIFF
--- a/resources/js/Layouts/AppShellV2.tsx
+++ b/resources/js/Layouts/AppShellV2.tsx
@@ -127,8 +127,10 @@ interface AppShellV2Props {
   breadcrumbItems?: Array<{ label: string; href?: string }>;
   /**
    * Esconde a barra superior (breadcrumb + topnav do módulo) inteira.
-   * Usado em telas com header próprio que torna a topbar redundante (ex.: Caixa Unificada V4).
-   * Default: false.
+   * Default invertido pra TRUE em 2026-05-17 (Wagner): topbar global removida
+   * em todo o ERP, navegação fica por sidebar + PageHeader. Páginas que ainda
+   * querem topnav-de-módulo passam `hideTopbar={false}` explicitamente.
+   * Caso original (Caixa Unificada V4) usava esta prop quando default era false.
    */
   hideTopbar?: boolean;
 }
@@ -213,7 +215,7 @@ export default function AppShellV2({
   onSelectConv,
   breadcrumb,
   breadcrumbItems,
-  hideTopbar = false,
+  hideTopbar = true,
 }: AppShellV2Props) {
   // Pega o menu compartilhado do shell (LegacyMenuAdapter via Inertia share)
   const page = usePage();

--- a/resources/js/Pages/Admin/ScreenReview.tsx
+++ b/resources/js/Pages/Admin/ScreenReview.tsx
@@ -274,7 +274,7 @@ function ReaderSkeleton() {
 }
 
 ScreenReview.layout = (page: React.ReactNode) => (
-  <AppShellV2 title="Screen Review" hideTopbar>{page}</AppShellV2>
+  <AppShellV2 title="Screen Review">{page}</AppShellV2>
 );
 
 export default ScreenReview;

--- a/resources/js/Pages/Admin/ScreenReviewDashboard.tsx
+++ b/resources/js/Pages/Admin/ScreenReviewDashboard.tsx
@@ -114,7 +114,7 @@ function ScreenReviewDashboard({ meta }: Props) {
 }
 
 ScreenReviewDashboard.layout = (page: React.ReactNode) => (
-  <AppShellV2 title="Screen Review · Dashboard" hideTopbar>{page}</AppShellV2>
+  <AppShellV2 title="Screen Review · Dashboard">{page}</AppShellV2>
 );
 
 export default ScreenReviewDashboard;


### PR DESCRIPTION
Wagner pediu remover topbar (breadcrumb 'WR2 Sistemas / Chat' + chips topnav-do-módulo) de todo o ERP. Navegação fica via sidebar + PageHeader.

**Estratégia:** inverter default da prop `hideTopbar` (false → true) em vez de deletar código. Páginas que ainda quiserem topnav-de-módulo passam `hideTopbar={false}` explicitamente. Reversão por tela é trivial.

**Impacto:**
- Toda tela Inertia/React nasce sem topbar
- Ganha ~44px vertical por tela
- PageHeader vira o único header visual
- Telas full-screen (Caixa Unificada V4) continuam ok

Cleanup: removido `hideTopbar` redundante das 2 telas Screen Review (agora default).

Refs: ADR 0104 MWART · ADR UI-0008 Cockpit Pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)