### PR TITLE
feat(ui): PageHeader nav slot + PageNavTabs (chips numerados intra-módulo)

### DIFF
--- a/resources/js/Components/shared/PageHeader.tsx
+++ b/resources/js/Components/shared/PageHeader.tsx
@@ -5,15 +5,23 @@ import { cn } from '@/Lib/utils';
 /**
  * PageHeader — cabeçalho padronizado de tela operacional.
  *
- * Layout:
- *   [icon] Titulo grande                    [slot action]
+ * Layout 3 colunas:
+ *   [icon] Titulo grande      [slot nav]       [slot action]
  *          Descricao opcional abaixo
+ *
+ * Wagner 2026-05-17: topbar global removida (`hideTopbar=true` default).
+ * Navegação intra-módulo (ex: Financeiro Lançamentos/Conciliação/Fluxo/DRE)
+ * agora vive no slot `nav` do PageHeader, ao lado do título.
  *
  * Uso:
  *   <PageHeader
  *     icon="calendar-clock"
  *     title="Aprovações pendentes"
  *     description="12 solicitações aguardando revisão"
+ *     nav={<PageNavTabs items={[
+ *       { label: 'Lançamentos', href: '/financeiro', count: 27, hotkey: 1, active: true },
+ *       { label: 'Conciliação', href: '/financeiro/conciliacao', count: 18, hotkey: 2 },
+ *     ]} />}
  *     action={<Button>Nova intercorrência</Button>}
  *   />
  *
@@ -23,16 +31,17 @@ interface Props {
   title: string;
   description?: string;
   icon?: string;
+  nav?: React.ReactNode;
   action?: React.ReactNode;
   className?: string;
 }
 
-export default function PageHeader({ title, description, icon, action, className }: Props) {
+export default function PageHeader({ title, description, icon, nav, action, className }: Props) {
   return (
     <div
       data-slot="page-header"
       className={cn(
-        'flex flex-col gap-3 pb-4 border-b border-border md:flex-row md:items-start md:justify-between',
+        'flex flex-col gap-3 pb-4 border-b border-border md:flex-row md:items-center md:justify-between',
         className,
       )}
     >
@@ -56,6 +65,11 @@ export default function PageHeader({ title, description, icon, action, className
           )}
         </div>
       </div>
+      {nav && (
+        <div data-slot="page-header-nav" className="min-w-0 flex-1 md:flex md:justify-center">
+          {nav}
+        </div>
+      )}
       {action && <div data-slot="page-header-action" className="shrink-0">{action}</div>}
     </div>
   );

--- a/resources/js/Components/shared/PageNavTabs.tsx
+++ b/resources/js/Components/shared/PageNavTabs.tsx
@@ -1,0 +1,82 @@
+import * as React from 'react';
+import { Link } from '@inertiajs/react';
+import { cn } from '@/Lib/utils';
+
+/**
+ * PageNavTabs — chips numerados de navegação intra-módulo dentro do PageHeader.
+ *
+ * Pattern Wagner aprovou 2026-05-17 (protótipo Cowork financeiro-app.jsx):
+ *   [1] Lançamentos [27]   [2] Conciliação [18]   [3] Fluxo de caixa   [4] DRE
+ *
+ * - `hotkey` numerado opcional (1-9) — só visual por enquanto, dispatcher de
+ *   atalho fica a cargo da página se quiser (event listener Key1..Key9).
+ * - `count` opcional — badge à direita do label (pendentes, abertos, etc).
+ * - `active` controla destaque visual; `href` faz o link.
+ *
+ * Usado como `nav` slot do PageHeader.
+ */
+export interface PageNavTabItem {
+  label: string;
+  href: string;
+  count?: number;
+  hotkey?: number;
+  active?: boolean;
+}
+
+interface Props {
+  items: PageNavTabItem[];
+  className?: string;
+}
+
+export default function PageNavTabs({ items, className }: Props) {
+  return (
+    <nav
+      aria-label="Navegação da página"
+      data-slot="page-nav-tabs"
+      className={cn(
+        'inline-flex flex-wrap items-center gap-1 rounded-md border border-border bg-muted/40 p-0.5',
+        className,
+      )}
+    >
+      {items.map((item, idx) => (
+        <Link
+          key={`${item.href}-${idx}`}
+          href={item.href}
+          className={cn(
+            'group inline-flex items-center gap-1.5 rounded-[5px] px-2.5 py-1 text-[12.5px] transition-colors',
+            item.active
+              ? 'bg-background text-foreground font-medium shadow-sm'
+              : 'text-muted-foreground hover:text-foreground hover:bg-background/50',
+          )}
+        >
+          {item.hotkey !== undefined && (
+            <kbd
+              aria-hidden
+              className={cn(
+                'inline-flex h-4 min-w-[16px] items-center justify-center rounded border px-1 text-[10px] font-mono font-medium leading-none',
+                item.active
+                  ? 'border-foreground/20 bg-foreground text-background'
+                  : 'border-border bg-background text-muted-foreground group-hover:text-foreground',
+              )}
+            >
+              {item.hotkey}
+            </kbd>
+          )}
+          <span>{item.label}</span>
+          {item.count !== undefined && item.count > 0 && (
+            <span
+              className={cn(
+                'inline-flex h-4 min-w-[18px] items-center justify-center rounded-full px-1 text-[10px] font-medium tabular-nums',
+                item.active
+                  ? 'bg-primary/10 text-primary'
+                  : 'bg-muted text-muted-foreground',
+              )}
+            >
+              {item.count}
+            </span>
+          )}
+        </Link>
+      ))}
+    </nav>
+  );
+}

--- a/resources/js/Pages/Admin/ScreenReview.tsx
+++ b/resources/js/Pages/Admin/ScreenReview.tsx
@@ -15,12 +15,13 @@
 // Quando defer ainda não retornou, página entra em estado MOCK skeleton.
 
 import * as React from 'react';
-import { Head, Link, router, Deferred } from '@inertiajs/react';
+import { Head, router, Deferred } from '@inertiajs/react';
 import { toast } from 'sonner';
-import { LayoutDashboard, Search as SearchIcon } from 'lucide-react';
+import { Search as SearchIcon } from 'lucide-react';
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import PageHeader from '@/Components/shared/PageHeader';
+import PageNavTabs from '@/Components/shared/PageNavTabs';
 import { Button } from '@/Components/ui/button';
 import { Skeleton } from '@/Components/ui/skeleton';
 
@@ -172,24 +173,30 @@ function ScreenReview(props: ScreenReviewPageProps) {
           icon="camera"
           title="Screen Review"
           description={`PDCA Wagner-Claude loop · ${meta.total_telas} telas · gerado ${new Date(meta.generated_at).toLocaleString('pt-BR')}`}
+          nav={
+            <PageNavTabs
+              items={[
+                { label: 'Dashboard', href: '/admin/screen-review/dashboard', hotkey: 1 },
+                {
+                  label: 'Triagem',
+                  href: '/admin/screen-review',
+                  count: meta.pending_count,
+                  hotkey: 2,
+                  active: true,
+                },
+              ]}
+            />
+          }
           action={
-            <div className="flex flex-wrap items-center gap-1.5">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-8 text-xs"
-                onClick={() => router.reload()}
-              >
-                <SearchIcon size={13} className="mr-1.5" />
-                Reload
-              </Button>
-              <Button asChild variant="outline" size="sm" className="h-8 text-xs">
-                <Link href="/admin/screen-review/dashboard">
-                  <LayoutDashboard size={13} className="mr-1.5" />
-                  Dashboard
-                </Link>
-              </Button>
-            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 text-xs"
+              onClick={() => router.reload()}
+            >
+              <SearchIcon size={13} className="mr-1.5" />
+              Reload
+            </Button>
           }
         />
 

--- a/resources/js/Pages/Admin/ScreenReviewDashboard.tsx
+++ b/resources/js/Pages/Admin/ScreenReviewDashboard.tsx
@@ -10,11 +10,12 @@
 // tela dedicada com nav `Screen Review` pro retorno.
 
 import * as React from 'react';
-import { Head, Link, router } from '@inertiajs/react';
-import { Clock, ListChecks, RefreshCw } from 'lucide-react';
+import { Head, router } from '@inertiajs/react';
+import { Clock, RefreshCw } from 'lucide-react';
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import PageHeader from '@/Components/shared/PageHeader';
+import PageNavTabs from '@/Components/shared/PageNavTabs';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
 import { Button } from '@/Components/ui/button';
@@ -35,24 +36,29 @@ function ScreenReviewDashboard({ meta }: Props) {
           icon="layout-dashboard"
           title="Screen Review · Dashboard"
           description={`Visão PDCA · ${meta.total_telas} telas · gerado ${new Date(meta.generated_at).toLocaleString('pt-BR')}`}
+          nav={
+            <PageNavTabs
+              items={[
+                { label: 'Dashboard', href: '/admin/screen-review/dashboard', hotkey: 1, active: true },
+                {
+                  label: 'Triagem',
+                  href: '/admin/screen-review',
+                  count: meta.pending_count,
+                  hotkey: 2,
+                },
+              ]}
+            />
+          }
           action={
-            <div className="flex flex-wrap items-center gap-1.5">
-              <Button
-                variant="ghost"
-                size="sm"
-                className="h-8 text-xs"
-                onClick={() => router.reload()}
-              >
-                <RefreshCw size={13} className="mr-1.5" />
-                Reload
-              </Button>
-              <Button asChild size="sm" className="h-8 text-xs">
-                <Link href="/admin/screen-review">
-                  <ListChecks size={13} className="mr-1.5" />
-                  Screen Review
-                </Link>
-              </Button>
-            </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 text-xs"
+              onClick={() => router.reload()}
+            >
+              <RefreshCw size={13} className="mr-1.5" />
+              Reload
+            </Button>
           }
         />
 


### PR DESCRIPTION
Wagner pediu (2026-05-17): nav intra-módulo **ao lado do título** — substituindo a topbar global removida em #1011.

## Pattern adotado
Vindo de `prototipo-ui/_cowork-export-2026-05-15/financeiro-app.jsx` (screenshot Wagner enviou):

```
[icon] Titulo grande      [1 Lançamentos 27 · 2 Conciliação 18]    [actions]
```

## Mudanças
- **PageHeader.tsx**: prop nova `nav?: React.ReactNode` → renderiza no centro entre title e action.
- **PageNavTabs.tsx** (novo): chips com hotkey numerado + label + count opcional. Cada item é Inertia `<Link>`.
- **ScreenReview.tsx**: substitui botão Dashboard pelo PageNavTabs (2 chips — Dashboard hotkey=1, Triagem hotkey=2 active com count pending).
- **ScreenReviewDashboard.tsx**: idem (Dashboard active + Triagem).

## Aplicar em outros módulos é opcional
Cada Page decide se passa `nav={<PageNavTabs items=[...] />}` no PageHeader. Demo nas 2 Screen Review primeiro pra Wagner aprovar visual.

## Test plan
- [ ] Pós-merge: validar via Chrome MCP em `/admin/screen-review` e `/admin/screen-review/dashboard`
- [ ] Chips numerados visíveis (1, 2) com label + count
- [ ] Active state correto (background contrastante)

Refs: ADR 0110 Cockpit V2 · ADR 0104 MWART

🤖 Generated with [Claude Code](https://claude.com/claude-code)