### PR TITLE
fix(security): middleware RedirectPublicPath — fallback 301 /public/X

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -14,6 +14,10 @@ class Kernel extends HttpKernel
      * @var array
      */
     protected $middleware = [
+        // Fallback PHP-side do redirect /public/X → /X. Roda ANTES de tudo
+        // porque o .htaccess raiz não consegue interceptar em LiteSpeed em
+        // alguns paths (request com auth passava direto). Ver hostinger.md.
+        \App\Http\Middleware\RedirectPublicPath::class,
         \App\Http\Middleware\TrustProxies::class,
         \Illuminate\Http\Middleware\HandleCors::class,
         \App\Http\Middleware\PreventRequestsDuringMaintenance::class,

--- a/app/Http/Middleware/RedirectPublicPath.php
+++ b/app/Http/Middleware/RedirectPublicPath.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Redirect 301 de /public/X → /X — fallback PHP-side do .htaccess raiz.
+ *
+ * Hostinger Cloud Startup tem DocumentRoot apontando pra raiz do repo
+ * (~/domains/oimpresso.com/public_html/), não pra public_html/public/. Por isso
+ * /public/X funciona acessado direto. O .htaccess raiz tenta interceptar via
+ * RewriteCond %{THE_REQUEST} ^[A-Z]{3,9}\s/public/ mas LiteSpeed Hostinger NÃO
+ * dispara a regra em alguns paths (descoberto 17/mai 2026 — request com auth
+ * passava direto pelo Laravel, address bar ficava /public/admin).
+ *
+ * Este middleware garante o redirect independente do servidor web. Roda como
+ * primeiro middleware global, ANTES de TrustProxies, CORS, sessão e auth.
+ *
+ * @see memory/reference/hostinger.md
+ */
+class RedirectPublicPath
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $path = $request->path();
+
+        if ($path !== 'public' && ! str_starts_with($path, 'public/')) {
+            return $next($request);
+        }
+
+        $newPath = $path === 'public' ? '/' : '/' . substr($path, strlen('public/'));
+        $query = $request->getQueryString();
+
+        return redirect()->to($newPath . ($query !== null && $query !== '' ? '?' . $query : ''), 301);
+    }
+}

--- a/tests/Feature/Http/RedirectPublicPathTest.php
+++ b/tests/Feature/Http/RedirectPublicPathTest.php
@@ -1,0 +1,65 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+beforeEach(function () {
+    // Rotas dummy pra confirmar que /admin / / não disparam 301 quando
+    // alcançados pelo path canônico (auth pode redirect 302, mas nunca 301).
+    Route::get('/admin', fn () => 'admin')->name('test.admin');
+    Route::get('/admin/sub', fn () => 'admin sub')->name('test.admin.sub');
+    Route::get('/', fn () => 'root')->name('test.root');
+    Route::get('/publicly-traded-stuff', fn () => 'unrelated')->name('test.publicly');
+});
+
+it('redireciona /public/admin pra /admin com 301', function () {
+    $response = $this->get('/public/admin');
+
+    expect($response->status())->toBe(301);
+    expect($response->headers->get('Location'))->toEndWith('/admin');
+});
+
+it('redireciona /public/admin/sub pra /admin/sub com 301', function () {
+    $response = $this->get('/public/admin/sub');
+
+    expect($response->status())->toBe(301);
+    expect($response->headers->get('Location'))->toEndWith('/admin/sub');
+});
+
+it('redireciona /public bare pra / com 301', function () {
+    $response = $this->get('/public');
+
+    expect($response->status())->toBe(301);
+    // Laravel pode emitir URL absoluta com ou sem trailing slash — aceita ambos
+    expect($response->headers->get('Location'))->toMatch('#^https?://[^/]+/?$#');
+});
+
+it('preserva query string no redirect (Symfony pode normalizar ordem)', function () {
+    $response = $this->get('/public/admin?foo=bar&baz=qux');
+
+    expect($response->status())->toBe(301);
+    $location = $response->headers->get('Location');
+    expect($location)->toContain('/admin?');
+    expect($location)->toContain('foo=bar');
+    expect($location)->toContain('baz=qux');
+});
+
+it('não dispara em paths que começam com "publicly" (palavra diferente)', function () {
+    $response = $this->get('/publicly-traded-stuff');
+
+    expect($response->status())->not->toBe(301);
+    expect($response->status())->toBe(200);
+});
+
+it('não dispara em path canônico /admin', function () {
+    $response = $this->get('/admin');
+
+    expect($response->status())->not->toBe(301);
+    expect($response->status())->toBe(200);
+});
+
+it('não dispara em path canônico /', function () {
+    $response = $this->get('/');
+
+    expect($response->status())->not->toBe(301);
+    expect($response->status())->toBe(200);
+});


### PR DESCRIPTION
## Resumo

PR [#1024](https://github.com/wagnerra23/oimpresso.com/pull/1024) adicionou regra `.htaccess`:
```apache
RewriteCond %{THE_REQUEST} ^[A-Z]{3,9}\s/public/ [NC]
RewriteRule ^public/(.*)$ /$1 [R=301,L]
```

Mas **LiteSpeed Hostinger NÃO dispara a regra** em alguns paths. Reprodução prod:

```
$ curl -sv https://oimpresso.com/public/admin | grep '< HTTP\|< Location'
< HTTP/1.1 302 Found                          ← 302 Laravel auth, NÃO 301 .htaccess
< Cache-Control: no-cache, no-store, must-revalidate, max-age=0
< Location: https://oimpresso.com/login
```

Usuário **logado** acessando `/public/admin` → Laravel auth passa → Controller executa → address bar fica `/public/admin` permanente. `forceRootUrl` (do #1024) salva Ziggy/assets, mas a URL na barra fica feia. Wagner reportou: *"mcp ainda informando falso https://oimpresso.com/public/admin"*.

## Solução

Middleware PHP-side garante o redirect independente do servidor web — testável via Pest, sem depender de regex `.htaccess` que LiteSpeed interpreta diferente.

## Mudanças (+108 linhas, 3 arquivos)

- **`app/Http/Middleware/RedirectPublicPath.php`** — detecta `path()` iniciando com `public/` ou bare `public`, força redirect 301 pra path canônico, preserva query string.
- **`app/Http/Kernel.php`** — registra como **primeiro** middleware global (antes de TrustProxies, CORS, sessão, auth — early-return ANTES de bootar sessão).
- **`tests/Feature/Http/RedirectPublicPathTest.php`** — 7 casos Pest:
  - `/public/admin` → 301 `/admin`
  - `/public/admin/sub` → 301 `/admin/sub`
  - `/public` bare → 301 `/`
  - `/public/admin?foo=bar&baz=qux` → 301 preservando query (Symfony pode normalizar ordem)
  - `/publicly-traded-stuff` → 200 (negative match, sem confusão)
  - `/admin` canon → 200 (sem regressão)
  - `/` canon → 200 (sem regressão)

## Validação

- ✅ Pest local: **7 passed, 16 assertions** (2.65s)
- ✅ Smoke local Herd:
  ```
  > GET /public/admin HTTP/1.1
  < HTTP/1.1 301 Moved Permanently
  < Location: https://oimpresso.test/admin
  ```
- ✅ `/admin` canon local: 302 Laravel auth → `/login` (sem regressão)
- ⏳ Smoke prod pendente pós-merge

## Relação com `.htaccess`

`.htaccess` raiz (de #1024) fica como **camada complementar**:
- ✅ Bloqueio de pastas Laravel (`app/`, `bootstrap/`, `vendor/`, `.env`, etc) ainda funciona
- ⚠️ Regra 301 `/public/X` no `.htaccess` permanece mas comprovadamente não dispara em LiteSpeed — fica como dead code documentado (alternativa: removê-la em PR futuro)

## Riscos

- **Performance**: 1 string comparison adicional por request. O(1), trivial.
- **Path edge cases**: cobertos pelos tests (`/publicly-*` não match, query preservada).
- **Cookies**: redirect 301 same-origin preserva XSRF-TOKEN (path=/). Sem impacto sessão.

## Pós-merge

```bash
ssh ... 'cd ~/domains/oimpresso.com/public_html && \
  git fetch origin main && git reset --hard origin/main && \
  /usr/bin/php artisan config:clear && \
  /usr/bin/php artisan cache:clear'
```

Smoke prod: `curl -sv https://oimpresso.com/public/admin` deve mostrar `< HTTP/1.1 301`.

## Ref

- Supersedes: PR [#1024](https://github.com/wagnerra23/oimpresso.com/pull/1024) (fix parcial)
- `memory/reference/hostinger.md` — DocumentRoot raiz do repo