### PR TITLE
docs(governance): checklist pós-merge canônico + ADR 0167 errata 0130 índice histórico longo

### DIFF
--- a/memory/decisions/0167-errata-0130-indice-handoff-historico-longo.md
+++ b/memory/decisions/0167-errata-0130-indice-handoff-historico-longo.md
@@ -1,0 +1,105 @@
+---
+slug: 0167-errata-0130-indice-handoff-historico-longo
+number: 0167
+title: "Errata ADR 0130 — Índice de handoff mantém histórico longo (não trunca 5)"
+type: adr
+status: accepted
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: 2026-05-17
+accepted_at: 2026-05-17
+review_at: 2026-11-17
+module: Governance
+quarter: 2026-Q2
+tags: [errata, handoff, memoria, governanca, indice, append-only]
+supersedes: []
+supersedes_partially: []
+superseded_by: []
+amends: [0130]
+related: [0061, 0070, 0094, 0119, 0130, 0131]
+pii: false
+review_triggers:
+  - "Diretório `memory/handoffs/` ultrapassar 200 arquivos (vs gate antigo 100 em ADR 0130) — avaliar arquivamento `memory/handoffs/_archive/YYYY/`"
+  - "Índice `memory/08-handoff.md` ultrapassar 300 linhas — avaliar agrupamento por mês/quarter"
+  - "Tool MCP `handoff-list` ou `handoff-fetch` criadas — índice pode encolher pra stub apontando pra tools (cenário review_trigger original da ADR 0130)"
+  - "Brief-fetch passar a expor histórico de handoffs nativamente — reavaliar necessidade do índice longo"
+---
+
+# ADR 0167 — Errata ADR 0130: Índice mantém histórico longo
+
+## Status
+
+**Accepted** — errata complementar à [ADR 0130](0130-handoff-append-only-mcp-first.md). NÃO substitui (append-only Tier 0 IRREVOGÁVEL — [ADR 0094](0094-constituicao-v2-7-camadas-8-principios.md) §3 + proibições.md §Memória/governança). Formaliza convenção que já operava de facto.
+
+## 1. Contexto — drift detectado 2026-05-17
+
+[ADR 0130](0130-handoff-append-only-mcp-first.md) §2 declarou textualmente:
+
+> *"Índice **pode ser editado** (é o único arquivo de governança que muda no fluxo normal). Mas só pra: adicionar entrada nova no topo, truncar lista pros 5 mais recentes (resto fica em `memory/handoffs/` acessível por glob)"*
+
+Auditoria 2026-05-17 (sessão `sharp-shannon-c7ae87` consolidando checklist pós-merge em [memory/reference/checklist-pos-merge.md](../reference/checklist-pos-merge.md)) detectou que [`memory/08-handoff.md`](../08-handoff.md) tem ~35 entradas, não 5.
+
+Convenção evoluiu de facto entre 2026-05-10 (ADR 0130 aceita) e 2026-05-17. Wagner, consultado: **"não pode truncar"**.
+
+## 2. Decisão
+
+§2 da ADR 0130 fica emendado:
+
+| Item | ADR 0130 original | ADR 0167 errata |
+|---|---|---|
+| Truncamento do índice | Pros 5 mais recentes | **Sem truncamento** — histórico longo mantido |
+| Tamanho esperado do índice | ~30 linhas | Crescente (~35 linhas em 2026-05-17; review trigger em 300 linhas) |
+| O que o índice é | Lista enxuta + ponteiros | Mapa narrativo cronológico do projeto + ponteiros |
+| Manutenção | Adiciona no topo + truncar 5º | Adiciona no topo, nada mais |
+
+Demais regras da ADR 0130 (handoffs append-only em `memory/handoffs/YYYY-MM-DD-HHMM-<slug>.md`, MCP-first OBRIGATÓRIO antes do Write, seção `## Estado MCP no momento do fechamento` como prova) **continuam intactas**.
+
+## 3. Justificativa
+
+3 razões observadas em prática 2026-05-10 a 2026-05-17:
+
+1. **Mapa narrativo serve descoberta retroativa** — dev novo entrante (Felipe/Maiara/Eliana/Luiz no time MCP) varre índice e vê evolução do projeto sem precisar `ls memory/handoffs/`. Linhas-resumo no índice condensam contexto que `brief-fetch` (Tier A) não cobre (foco brief é estado VIVO, não histórico interpretativo).
+2. **Custo trivial** — índice é só ponteiros (35 linhas atuais ≈ 7KB). Handoffs reais ficam em `memory/handoffs/` (350+ KB). Truncar pros 5 não economiza nada material.
+3. **Brief-fetch + tools MCP cobrem estado vivo** — quem quer "o que tá acontecendo agora" usa `brief-fetch`/`my-work`/`cycles-active`, não índice de handoff. Índice serve propósito ortogonal: cronologia interpretativa append-only.
+
+## 4. Implicações operacionais
+
+### O que muda
+
+- Skill `memory-sync` SKILL.md §"Handoff append-only" linha *"truncar 5º item se passou"* → **"adicionar entrada nova no topo, nada mais"**
+- Doc `memory/how-trabalhar.md` §"Ao terminar uma sessão" passo 2 (se mencionar truncamento) → idem
+- Doc `memory/reference/checklist-pos-merge.md` §5c (criado no mesmo PR desta errata) já alinhado com esta decisão
+
+### O que NÃO muda
+
+- ADR 0130 §1 (diretório `memory/handoffs/` append-only) — IRREVOGÁVEL
+- ADR 0130 §3 (MCP-first checklist obrigatório antes do Write) — IRREVOGÁVEL
+- ADR 0130 §6 (hook bloqueador dormente — ativa se reincidência overwrite) — mantido
+- Conteúdo do índice (linhas existentes não são editadas, só adicionadas no topo)
+
+## 5. Limite operacional (review_trigger)
+
+Quando índice passar de **300 linhas** (~50-60 entradas) considerar:
+
+- (a) Agrupar por quarter: `## Q2-2026` / `## Q3-2026` headers separadores
+- (b) Mover entradas >6 meses pra `memory/08-handoff-archive.md` (continuando append-only)
+- (c) Criar tool MCP `handoff-list --since/--until` que reduz índice a stub
+
+Nenhuma das 3 opções é pré-decidida — depende do estado do projeto em 2026-11-17 (review formal desta errata).
+
+## 6. Append-only verificação
+
+Esta ADR:
+- ✅ NÃO edita ADR 0130 (append-only Tier 0 IRREVOGÁVEL)
+- ✅ Tem `amends: [0130]` declarado no frontmatter
+- ✅ ADR 0130 segue `accepted` — esta errata não muda status
+- ✅ Cadeia de auditoria: leitor da 0130 → vê `related: [...0167...]` quando essa ref for adicionada (não-bloqueante pra mergeer esta errata)
+
+## 7. Referências
+
+- [ADR 0130](0130-handoff-append-only-mcp-first.md) — original handoff append-only + MCP-first (emendada por esta errata)
+- [ADR 0094](0094-constituicao-v2-7-camadas-8-principios.md) — Constituição v2 mãe (princípio 7 transparência fundamenta histórico longo)
+- [ADR 0061](0061-conhecimento-canonico-git-mcp-zero-automem.md) — zero auto-mem privada (histórico canon vai pro git, time MCP enxerga)
+- [ADR 0070](0070-jira-style-task-management-current-md-removed.md) — tasks Jira-style (handoff narrativo é complemento ortogonal)
+- [memory/reference/checklist-pos-merge.md](../reference/checklist-pos-merge.md) — doc operacional onde esta decisão é citada no passo 5c

--- a/memory/reference/_INDEX.md
+++ b/memory/reference/_INDEX.md
@@ -88,6 +88,7 @@
 
 ## Workflow & triggers
 
+- [checklist-pos-merge.md](checklist-pos-merge.md) — **Checklist canônico unificado pós-merge** (8 passos consolidando ADR 0070/0130/0164 + skills tela-smoke-pos-merge/brief-update/memory-sync + workflow GHA) — tabela de gatilhos por tipo de PR + estado auditado
 - [trigger-guarde-no-cofre.md](trigger-guarde-no-cofre.md) — Comando reservado Wagner: classifica decisão/regra/evidência e grava em ADR/SPEC/docs_evidences
 - [cursor-collaboration.md](cursor-collaboration.md) — Cursor é outra IA paralela; checa `memory/sessions/` + `git status` antes de começar
 

--- a/memory/reference/checklist-pos-merge.md
+++ b/memory/reference/checklist-pos-merge.md
@@ -1,0 +1,183 @@
+# Checklist pós-merge canônico
+
+> **Por que existe:** 8 passos pós-merge estavam dispersos em ADR 0070, ADR 0130, ADR 0164, skill `tela-smoke-pos-merge`, skill `brief-update`, skill `memory-sync` e workflow GHA. Este doc consolida em 1 página com fontes cruzadas + estado real (auditado 2026-05-17 — workflow GHA com 5/5 runs success). Wagner pediu doc unificado pra time MCP (Felipe/Maiara/Eliana/Luiz) não precisar caçar.
+
+## Quando aplicar
+
+Após **qualquer PR mergeado em `main`** que toque código produtivo. PRs puramente docs/chore/test pulam itens 2, 4, 5 (ver exceções inline).
+
+## Os 8 passos
+
+### 1. CI verde + deploy
+
+Aguardar GitHub Actions workflow `Deploy` concluir success. Se falhar:
+- **Rollback via PR revert**, nunca force-push em `main` (proibido — `memory/proibicoes.md` §Código)
+- Hostinger prod biz=1 — quick-sync SSH é fallback ([reference/deploy-recovery-patterns.md](deploy-recovery-patterns.md) §2.1 "tela não aparece pós-merge")
+
+### 2. Smoke pós-merge (semi-automático)
+
+**SE** o PR tocou `resources/js/Pages/**/*.tsx`:
+
+Workflow [.github/workflows/screen-smoke-after-merge.yml](../../.github/workflows/screen-smoke-after-merge.yml) detecta automaticamente, comenta no PR e cria notice. **Mas o smoke real (browser MCP screenshot + console errors + perf metrics) ainda exige ação:**
+
+| Caminho | Quem | Quando |
+|---|---|---|
+| `/admin/screen-review` UI (Tailscale) | Wagner manual | Imediato pós-merge se quiser ver |
+| Cron daily 09:00 BRT | Sistema | Batch das pendentes |
+| `gh workflow run screen-smoke-after-merge.yml -f screen_path=<Mod>/<Tela>` | Qualquer dev | Force re-smoke |
+
+**Skill `tela-smoke-pos-merge` (Tier B)** executa o smoke real quando Wagner pede explícito. Pré-flight obrigatório antes:
+- Ler `<Tela>.charter.md` (UX targets/latência alvo)
+- Ler `<Tela>.review.md` anterior (baseline)
+- Ler `<Modulo>/UI-CATALOG.md` (contexto)
+- Verificar Vaultwarden item `screen-smoke/wagner-prod-readonly` existe
+
+Output: `<Tela>.review.md` round N + `<Tela>.smoke-log.md` + `<Modulo>/UI-CATALOG.md` + entry `mcp_alertas` notificando Wagner.
+
+Wagner decide no round N: `decisão: approved | rejected | iterate`. Só `approved` marca `<Tela>.charter.md` `status: live`.
+
+**Tier 0:** screenshots passam por `PiiRedactor` (CPF/CNPJ/email/fone) ANTES de salvar — ADR 0093. Usa biz=99 fake por padrão, não biz=4 ROTA LIVRE — [ADR 0101](../decisions/0101-tests-business-id-1-nunca-cliente.md).
+
+Detalhes: [`.claude/skills/tela-smoke-pos-merge/SKILL.md`](../../.claude/skills/tela-smoke-pos-merge/SKILL.md) + [ADR 0164](../decisions/0164-screen-review-pdca-tela-smoke-pos-merge.md) + [memory/requisitos/Admin/SCREEN-REVIEW-RUNBOOK.md](../requisitos/Admin/SCREEN-REVIEW-RUNBOOK.md).
+
+### 3. `tasks-update <ID> status:done`
+
+Para cada US `Refs: <ID>` mencionada no commit/PR:
+
+```
+tasks-update task_id:US-XXX-NNN status:done
+```
+
+Via tool MCP — **nunca markdown**. CURRENT.md/TASKS.md foram removidos em 2026-05-04 ([ADR 0070](../decisions/0070-jira-style-task-management-current-md-removed.md)).
+
+Webhook GitHub também auto-detecta `(?i)(refs|fixes|closes|resolves)\s+<KEY>-\d+` em commits/branches e atualiza `mcp_tasks` automaticamente, **mas** confirma via `my-work` no fim — falha silenciosa é possível.
+
+### 4. BRIEFING.md atualizado (skill `brief-update` Tier B)
+
+**SE** o PR alterou capacidade/UX/score Capterra/gap/diferencial do módulo:
+
+Skill `brief-update` auto-ativa e atualiza `memory/requisitos/<Modulo>/BRIEFING.md` (1 página executiva, ≤150 linhas). Lê COMPARATIVO + CAPTERRA-INVENTARIO + AUDIT-LOG + SPEC + últimos handoffs e regenera.
+
+**Skip legítimo:** PR `chore(...)`/`test(...)`/`refactor(...)` pequeno sem impacto user-visible, hotfix <30min, docs-only.
+
+**Preferido:** commit `+ briefing update` no MESMO PR (não criar PR separado). Se PR já mergeou, abre PR pequeno `docs(<modulo>): atualiza BRIEFING pós-#NNN`.
+
+**Hoje:** 34 BRIEFINGs canônicos existem (1 por módulo) — [`memory/requisitos/*/BRIEFING.md`](../requisitos/). Template em [`memory/requisitos/_DesignSystem/BRIEFING-TEMPLATE.md`](../requisitos/_DesignSystem/BRIEFING-TEMPLATE.md).
+
+Detalhes: [`.claude/skills/brief-update/SKILL.md`](../../.claude/skills/brief-update/SKILL.md).
+
+### 5. Handoff append-only (apenas em fechamento de chapter)
+
+**Nem todo merge exige handoff novo.** Handoff é pra fechamento de **chapter narrativo** — mega-feature, marco, pivot, sessão grande (5+ PRs). Merge de PR isolado normalmente NÃO gera handoff.
+
+**SE** for fechamento de chapter ([ADR 0130](../decisions/0130-handoff-append-only-mcp-first.md)):
+
+#### 5a. MCP-first OBRIGATÓRIO antes do Write
+
+Ordem exata — capturar resultado pra incluir no handoff:
+
+1. `cycles-active` — cycle + goals + drift detectado
+2. `my-work` — tasks DOING/REVIEW reais
+3. `sessions-recent limit:3` — handoffs irmãs nas últimas horas
+4. `decisions-search since:<data-último-handoff>` — ADRs aceitas no intervalo
+5. (suspeita paralela) `whats-active` — [ADR 0119](../decisions/0119-paralelismo-sessoes-whats-active-tier-1.md)
+
+#### 5b. Criar arquivo novo (append-only — nunca editar depois)
+
+```
+memory/handoffs/YYYY-MM-DD-HHMM-<slug-kebab>.md
+```
+
+**Deve ter** seção `## Estado MCP no momento do fechamento` com snapshot dos 4 outputs MCP — **prova, não promessa**.
+
+#### 5c. Atualizar índice `memory/08-handoff.md`
+
+Adicionar **1 linha no topo** da lista "Últimos handoffs" apontando pro arquivo novo.
+
+⚠️ **Drift detectado 2026-05-17:** ADR 0130 §2 diz "truncar 5 mais recentes", mas o índice atual tem ~35 entradas. Convenção evoluiu de facto pra histórico mais longo no índice. Wagner decide se formaliza emenda ou trunca.
+
+### 6. Session log (`memory/sessions/`)
+
+Criar `memory/sessions/YYYY-MM-DD-<slug>.md` descrevendo o **trabalho cronológico** (o que foi feito, decisões tomadas, comandos executados).
+
+**Diferença vs handoff:** session log conta o trabalho; handoff conta o estado interpretativo pro próximo Claude. Ambos podem coexistir num mesmo dia.
+
+Glob duplicação antes de criar: `memory/sessions/YYYY-MM-DD-*.md` — se já existir similar do dia, EDITA em vez de criar novo ([proibicoes.md §Memória/governança](../proibicoes.md)).
+
+### 7. ADR nova (se decisão arquitetural)
+
+Se o PR introduziu padrão novo, tecnologia nova, ou mudou convenção canônica:
+
+Criar `memory/decisions/NNNN-<slug>.md` no formato Nygard (status/contexto/decisão/consequências). Append-only — **nunca editar accepted**. Mudança = nova ADR com `supersedes: [N]`.
+
+CI `governance-gate.yml` Job 1 bloqueia merge de PR que edite ADR canon com status `M`/`R*`. CONSTITUTION editada exige label `constitution-amendment` + `audit-*.md` no mesmo PR (§10.4 Cascade Review).
+
+Lifecycle: [memory/decisions/_INDEX-LIFECYCLE.md](../decisions/_INDEX-LIFECYCLE.md).
+
+### 8. `git push` memory/ (skill `memory-sync` Tier B)
+
+Webhook GitHub→MCP só sincroniza após `git push`. Time (Felipe/Maiara/Eliana/Luiz) só enxerga via tools MCP (`decisions-search`, `memoria-search`) depois disso.
+
+Skill `memory-sync` automatiza via comando `/sync-mem`:
+1. Detecta pendências em `memory/`, `MEMORY.md`, `TEAM.md`, `CLAUDE.md`, `DESIGN.md`, `INFRA.md`
+2. Agrupa em commit semântico
+3. Push → webhook MCP em <60s
+
+**Não usar:**
+- `git add -A` ou `git add .` — pode pegar `.env`/credenciais
+- `--no-verify` — gitleaks/pre-commit existem por razão
+- Commitar código (`Modules/`, `app/`, `resources/`) junto — esses seguem fluxo PR normal
+
+Detalhes: [`.claude/skills/memory-sync/SKILL.md`](../../.claude/skills/memory-sync/SKILL.md).
+
+## Tabela de gatilhos por tipo de PR
+
+| Tipo PR | Passos obrigatórios | Passos puláveis |
+|---|---|---|
+| `feat(<mod>)` toca Modules + Pages | 1-8 todos | — |
+| `fix(<mod>)` bug crítico | 1, 2, 3, 6, 8 | 4 (skip se não muda capacidade), 5 (skip se merge isolado), 7 (skip se não tem ADR) |
+| `refactor(<mod>)` sem impacto user-visible | 1, 3, 6, 8 | 2, 4, 5, 7 |
+| `chore(<mod>)` deps/CI/lint | 1, 8 | 2, 3, 4, 5, 6, 7 |
+| `test(<mod>)` test-only | 1, 8 | 2, 3, 4, 5, 6, 7 |
+| `docs(<mod>)` docs canon | 1, 6, 8 | 2, 3, 4, 5, 7 |
+| `hotfix(<mod>)` <30min emergency | 1, 3, 8 | 2 (smoke depois), 4-7 |
+
+## Cycle drift — passo zero implícito
+
+Se brief diário mostrar **0% PRs alinhados com cycle ativo** (cycle drift detectado — aprendizado retro CYCLE-01), avaliar `cycles-close --rollover` + `cycles-create` novo. Não é bloqueador, é sinal de pivot estratégico não-registrado.
+
+Hoje (2026-05-17): brief mostra CYCLE-06 com drift 38/38 PRs 0% alinhados. Wagner consciente — pivot operacional Martinho + FSM + Jana V2 em curso.
+
+## Estado real auditado 2026-05-17
+
+| Peça | Status |
+|---|---|
+| Workflow `screen-smoke-after-merge.yml` | ✅ 5/5 runs success últimas horas |
+| Skill `tela-smoke-pos-merge` | ✅ ativa Tier B + 100+ `.review.md` criados |
+| Skill `brief-update` | ✅ ativa Tier B + 34 BRIEFINGs canônicos |
+| Skill `memory-sync` | ✅ ativa Tier B + checklist MCP-first em SKILL.md |
+| ADR 0070 / 0130 / 0164 | ✅ accepted canon |
+| Índice `08-handoff.md` truncamento | ⚠️ drift de facto (35 entradas vs ADR 0130 "truncar 5") — Wagner decide |
+| Doc canônico unificado checklist | ✅ este arquivo (criado 2026-05-17) |
+
+## Anti-patterns proibidos
+
+- ⛔ **Editar handoff antigo** — append-only ADR 0130
+- ⛔ **Pular `brief-fetch` no início de sessão** — Tier A bloqueador
+- ⛔ **Criar session log sem `Glob`/`Grep` antes** — duplicação proibida
+- ⛔ **Editar ADR canon com status `accepted`** — append-only, criar nova com `supersedes`
+- ⛔ **`tasks-update` em markdown** — CURRENT.md/TASKS.md REMOVIDOS (ADR 0070)
+- ⛔ **Screenshot prod sem auto-mask PII** — viola Tier 0 ADR 0093
+- ⛔ **Smoke biz=4 ROTA LIVRE sem justificativa charter** — usar biz=99 fake (ADR 0101)
+
+## Refs canônicas
+
+- [ADR 0070](../decisions/0070-jira-style-task-management-current-md-removed.md) — Jira-style tasks (passos 3, 7)
+- [ADR 0130](../decisions/0130-handoff-append-only-mcp-first.md) — Handoff append-only + MCP-first (passo 5)
+- [ADR 0164](../decisions/0164-screen-review-pdca-tela-smoke-pos-merge.md) — Screen Review PDCA (passo 2)
+- [ADR 0093](../decisions/0093-multi-tenant-isolation-tier-0.md) — Multi-tenant Tier 0 (PII redactor passo 2)
+- [ADR 0101](../decisions/0101-tests-business-id-1-nunca-cliente.md) — biz=99 não biz=4 em smoke
+- [memory/how-trabalhar.md §"Ao terminar uma sessão"](../how-trabalhar.md) — protocolo geral
+- [memory/proibicoes.md](../proibicoes.md) — Tier 0 IRREVOGÁVEIS
+
+**Atualizado:** 2026-05-17 — auditoria pós-merge cross-fontes consolidada num doc canônico unificado (pedido Wagner sessão `sharp-shannon-c7ae87`).

--- a/memory/reference/checklist-pos-merge.md
+++ b/memory/reference/checklist-pos-merge.md
@@ -92,9 +92,9 @@ memory/handoffs/YYYY-MM-DD-HHMM-<slug-kebab>.md
 
 #### 5c. Atualizar índice `memory/08-handoff.md`
 
-Adicionar **1 linha no topo** da lista "Últimos handoffs" apontando pro arquivo novo.
+Adicionar **1 linha no topo** da lista "Últimos handoffs" apontando pro arquivo novo. **Nada mais** — não truncar, não reordenar, não editar entradas antigas.
 
-⚠️ **Drift detectado 2026-05-17:** ADR 0130 §2 diz "truncar 5 mais recentes", mas o índice atual tem ~35 entradas. Convenção evoluiu de facto pra histórico mais longo no índice. Wagner decide se formaliza emenda ou trunca.
+Histórico longo é convenção canônica formal — [ADR 0167](../decisions/0167-errata-0130-indice-handoff-historico-longo.md) emenda ADR 0130 §2 ("truncar pros 5 mais recentes" → "histórico longo mantido como mapa narrativo cronológico"). Review trigger em 300 linhas.
 
 ### 6. Session log (`memory/sessions/`)
 
@@ -156,8 +156,8 @@ Hoje (2026-05-17): brief mostra CYCLE-06 com drift 38/38 PRs 0% alinhados. Wagne
 | Skill `tela-smoke-pos-merge` | ✅ ativa Tier B + 100+ `.review.md` criados |
 | Skill `brief-update` | ✅ ativa Tier B + 34 BRIEFINGs canônicos |
 | Skill `memory-sync` | ✅ ativa Tier B + checklist MCP-first em SKILL.md |
-| ADR 0070 / 0130 / 0164 | ✅ accepted canon |
-| Índice `08-handoff.md` truncamento | ⚠️ drift de facto (35 entradas vs ADR 0130 "truncar 5") — Wagner decide |
+| ADR 0070 / 0130 / 0164 / 0167 | ✅ accepted canon |
+| Índice `08-handoff.md` histórico longo | ✅ formalizado por ADR 0167 errata (~35 entradas mantidas como mapa cronológico) |
 | Doc canônico unificado checklist | ✅ este arquivo (criado 2026-05-17) |
 
 ## Anti-patterns proibidos
@@ -174,6 +174,7 @@ Hoje (2026-05-17): brief mostra CYCLE-06 com drift 38/38 PRs 0% alinhados. Wagne
 
 - [ADR 0070](../decisions/0070-jira-style-task-management-current-md-removed.md) — Jira-style tasks (passos 3, 7)
 - [ADR 0130](../decisions/0130-handoff-append-only-mcp-first.md) — Handoff append-only + MCP-first (passo 5)
+- [ADR 0167](../decisions/0167-errata-0130-indice-handoff-historico-longo.md) — Errata 0130: índice mantém histórico longo (passo 5c)
 - [ADR 0164](../decisions/0164-screen-review-pdca-tela-smoke-pos-merge.md) — Screen Review PDCA (passo 2)
 - [ADR 0093](../decisions/0093-multi-tenant-isolation-tier-0.md) — Multi-tenant Tier 0 (PII redactor passo 2)
 - [ADR 0101](../decisions/0101-tests-business-id-1-nunca-cliente.md) — biz=99 não biz=4 em smoke


### PR DESCRIPTION
## Summary

- **Doc canônico unificado** (`memory/reference/checklist-pos-merge.md`, 190 linhas) consolida os 8 passos pós-merge que estavam dispersos em ADR 0070/0130/0164 + 3 skills + workflow GHA.
- **Tabela de gatilhos por tipo de PR** (feat/fix/refactor/chore/test/docs/hotfix) mostra quais passos pular — time MCP (Felipe/Maiara/Eliana/Luiz) entra sem caçar.
- **Corrige imprecisão difundida** "smoke automático pós-merge": workflow `screen-smoke-after-merge.yml` é **semi-automático** (detecta + comenta + notifica, mas smoke real ainda manual via UI / `gh workflow run` / cron daily).
- **ADR 0167 errata 0130** (`memory/decisions/0167-errata-0130-indice-handoff-historico-longo.md`, 105 linhas) formaliza decisão Wagner *\"não pode truncar\"* — índice `08-handoff.md` mantém histórico longo como mapa narrativo cronológico, NÃO trunca pros 5 (override §2 da ADR 0130).

## Append-only verificado

ADR 0167 NÃO edita ADR 0130 (Tier 0 IRREVOGÁVEL — `proibicoes.md` §Memória/governança). Tem `amends: [0130]` no frontmatter. ADR 0130 permanece `accepted` — convenção evoluída fica documentada formalmente em ADR errata separada.

## Estado auditado 2026-05-17

| Peça | Status |
|---|---|
| Workflow `screen-smoke-after-merge.yml` | ✅ 5/5 runs success últimas horas |
| Skill `tela-smoke-pos-merge` Tier B | ✅ 100+ `.review.md` em prod |
| Skill `brief-update` Tier B | ✅ 34 BRIEFINGs canônicos |
| Skill `memory-sync` Tier B | ✅ checklist MCP-first em SKILL.md |
| ADR 0070 / 0130 / 0164 | ✅ accepted canon |
| Índice `08-handoff.md` histórico longo | ✅ formalizado por ADR 0167 errata |
| Doc canônico unificado checklist | ✅ criado |

## Commits

1. `444eae798` — doc canônico checklist-pos-merge.md + entrada índice _INDEX.md (+184 linhas)
2. `c449a065c` — ADR 0167 errata + atualização §5c do doc removendo \"drift detectado\" (+110 linhas)

Total: **+294 linhas** — dentro do limite 300 da skill `commit-discipline`.

## Test plan

- [ ] Wagner valida que o doc reflete o checklist canônico pro time MCP
- [ ] Wagner valida texto da errata 0167 (especialmente §3 justificativa)
- [ ] CI `governance-gate.yml` Job 1 (append-only enforcement) passa — ADR 0167 tem status `accepted` desde criação, sem edits de ADR existente
- [ ] Após merge: `decisions-search query:\"errata 0130\"` retorna ADR 0167 via webhook GitHub→MCP (<60s)
- [ ] Sem teste automatizado adicional — é doc canon, não código

## Refs

ADR 0070, ADR 0130, ADR 0164, ADR 0167 (nova), ADR 0093, ADR 0094, ADR 0101

🤖 Generated with [Claude Code](https://claude.com/claude-code)