### PR TITLE
fix(security): RedirectPublicPath usa getRequestUri (path() strip /public em prod)

### DIFF
--- a/app/Http/Middleware/RedirectPublicPath.php
+++ b/app/Http/Middleware/RedirectPublicPath.php
@@ -25,13 +25,19 @@ class RedirectPublicPath
 {
     public function handle(Request $request, Closure $next): Response
     {
-        $path = $request->path();
+        // ATENÇÃO: usar getRequestUri() em vez de path(). Em prod o Symfony Request
+        // detecta SCRIPT_NAME=/public/index.php e strip "/public" automaticamente
+        // do path() — então em HTTP real /public/admin → path()=admin (sem prefix).
+        // getRequestUri() preserva o path bruto do cliente, incluindo "/public/".
+        // Descoberto via probe inline 17/mai 2026.
+        $uri = $request->getRequestUri();
+        $pathOnly = strtok($uri, '?');
 
-        if ($path !== 'public' && ! str_starts_with($path, 'public/')) {
+        if ($pathOnly !== '/public' && ! str_starts_with((string) $pathOnly, '/public/')) {
             return $next($request);
         }
 
-        $newPath = $path === 'public' ? '/' : '/' . substr($path, strlen('public/'));
+        $newPath = $pathOnly === '/public' ? '/' : substr($pathOnly, strlen('/public'));
         $query = $request->getQueryString();
 
         return redirect()->to($newPath . ($query !== null && $query !== '' ? '?' . $query : ''), 301);


### PR DESCRIPTION
## Resumo

PR [#1026](https://github.com/wagnerra23/oimpresso.com/pull/1026) adicionou middleware `RedirectPublicPath`. **Pest local 7/7 verde**. Deploy prod **bug** — middleware nunca disparou:

```
$ curl -sv https://oimpresso.com/public/admin
< HTTP/1.1 302 Found
< Location: https://oimpresso.com/login    ← Laravel auth, NÃO meu 301
```

## Causa raiz

`Request::path()` em produção retorna `admin` (sem prefix `public/`) porque:

- Hostinger DocumentRoot aponta raiz do repo, então Apache rewrite serve via `public/index.php`
- `SCRIPT_NAME=/public/index.php`, `REQUEST_URI=/public/admin`
- Symfony Request detecta basePath comum = `/public` e **automaticamente strip** do `path()`/`getPathInfo()`

Logo `str_starts_with('admin', 'public/')` = false → middleware bypassa.

**Pest local não pegou** porque `Request::create()` não tem SCRIPT_NAME → basePath vazio → `path()` retorna URI completa (com prefix). Falso positivo.

## Validação via probe inline em prod

```
REAL request /public/admin_probe_*.php:
  REQUEST_URI: /public/admin_probe_*.php
  request->path(): /                          ← stripped!
  request->getRequestUri(): /public/admin_probe_*.php  ← OK
```

## Fix (1 arquivo, +9/-3 linhas)

Trocar `$request->path()` por `$request->getRequestUri()` (REQUEST_URI bruto sem strip). Comentário inline explica o trap pra próximo dev.

## Tests

- ✅ Pest local: **7 passed, 16 assertions** (mesmas asserções que #1026)
- ⏳ Smoke prod pós-deploy

Os tests passam em ambos cenários porque `Request::create()` (usado em test) produz comportamento equivalente entre `path()` e `getRequestUri()` quando SCRIPT_NAME está vazio. Em prod **só `getRequestUri()` funciona**.

## Pós-merge

```bash
ssh ... 'cd ~/domains/oimpresso.com/public_html && \
  git fetch origin main && git reset --hard origin/main && \
  /usr/bin/php artisan optimize:clear'
# + opcache_reset via _opcache_reset.php temp file
```

Smoke esperado:
```bash
curl -sv https://oimpresso.com/public/admin | grep '< HTTP\|< Location'
< HTTP/1.1 301 Moved Permanently
< Location: https://oimpresso.com/admin
```

## Ref

- Supersedes parte: PR [#1026](https://github.com/wagnerra23/oimpresso.com/pull/1026)
- `memory/reference/hostinger.md`