### PR TITLE
feat(sells): reintegra Filtros avançados (DateFilter + GroupBy + Grade toggle)

### DIFF
--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -103,3 +103,54 @@
 }
 .sells-cowork .vd-pagi-btn:hover:not(:disabled) { background: var(--bg-2); }
 .sells-cowork .vd-pagi-btn:disabled { opacity: 0.4; cursor: not-allowed; }
+
+/* PR follow-up — Filtros avançados ▾ (DateFilter + GroupBy + Toggle Lista/Grade) */
+.sells-cowork .vd-tabs-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0 16px;
+  border-bottom: 1px solid var(--border);
+}
+.sells-cowork .vd-tabs-grow { flex: 1 1 auto; border-bottom: 0; }
+.sells-cowork .vd-tabs-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+.sells-cowork .vd-filters-toggle {
+  appearance: none;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 5px 10px;
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  font-family: inherit;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  cursor: pointer;
+  transition: background .12s, border-color .12s;
+}
+.sells-cowork .vd-filters-toggle:hover { background: var(--bg-2); }
+.sells-cowork .vd-filters-toggle.on {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+.sells-cowork .vd-filters-bar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  align-items: center;
+  padding: 12px 16px;
+  background: var(--bg-2);
+  border-bottom: 1px solid var(--border);
+}
+.sells-cowork .vd-grade-wrap {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
+}

--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -25,9 +25,20 @@ import {
   Plus,
   Printer,
   Search,
+  SlidersHorizontal,
   X,
 } from 'lucide-react';
 import SaleSheet from './_components/SaleSheet';
+// PR follow-up Cowork — filtros legacy reintegrados via barra colapsável "Filtros avançados ▾".
+// Refs: Index.charter.md v2 Goals · feedback-design-literal-copy §How to apply #5.
+import SellsDateFilter, {
+  computePresetRange,
+  type DateFilterPreset,
+} from './_components/SellsDateFilter';
+import SellsToggleViewMode, { type SellsViewMode } from './_components/SellsToggleViewMode';
+import SellsGroupByDropdown, { type GroupByField } from './_components/SellsGroupByDropdown';
+import SellsGradeAvancada from './_components/SellsGradeAvancada';
+import type { SellsTotals } from './_components/SellsTotalsRow';
 
 // ──────────────────────────────────────────────────────────────
 // TIPOS
@@ -435,8 +446,99 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
   const [rows, setRows] = useState<SaleRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [meta, setMeta] = useState<ListMeta | null>(null);
-  const [, setTotals] = useState<TotalsSummary | null>(null); // totals reservados pro footer summary v2
+  const [totals, setTotals] = useState<TotalsSummary | null>(null);
   const [openSaleId, setOpenSaleId] = useState<number | null>(null);
+
+  // PR follow-up Cowork — filtros legacy preservados US-SELL-015/017/018/019/021.
+  // viewMode (lista | grade-avancada), preset (Dia/Semana/Mês/Ano/Personalizado/all),
+  // dateField (7 opções: emissão/atualização/nfe/faturamento/envio/competência/prometido),
+  // groupBy (none/customer/payment_status/emission_month), sortKey/Dir.
+  const [viewMode, setViewMode] = useState<SellsViewMode>(() => {
+    const v = lsGet('viewMode', 'lista');
+    return (['lista', 'grade-avancada'] as const).includes(v as SellsViewMode)
+      ? (v as SellsViewMode)
+      : 'lista';
+  });
+  useEffect(() => lsSet('viewMode', viewMode), [viewMode]);
+
+  const [datePreset, setDatePreset] = useState<DateFilterPreset>(() => {
+    const v = lsGet('datePreset', 'all');
+    return (['day', 'week', 'month', 'year', 'custom', 'all'] as const).includes(
+      v as DateFilterPreset
+    )
+      ? (v as DateFilterPreset)
+      : 'all';
+  });
+  useEffect(() => lsSet('datePreset', datePreset), [datePreset]);
+
+  const [dateFrom, setDateFrom] = useState<string>(() => {
+    const stored = lsGet('datePreset', 'all') as DateFilterPreset;
+    if (stored !== 'all' && stored !== 'custom') return computePresetRange(stored).dateFrom;
+    return lsGet('dateFrom', '');
+  });
+  const [dateTo, setDateTo] = useState<string>(() => {
+    const stored = lsGet('datePreset', 'all') as DateFilterPreset;
+    if (stored !== 'all' && stored !== 'custom') return computePresetRange(stored).dateTo;
+    return lsGet('dateTo', '');
+  });
+  useEffect(() => lsSet('dateFrom', dateFrom), [dateFrom]);
+  useEffect(() => lsSet('dateTo', dateTo), [dateTo]);
+
+  const [dateField, setDateField] = useState<
+    'transaction_date' | 'updated_at' | 'nfe_issued_at' | 'invoiced_at'
+    | 'invoice_sent_at' | 'competence_date' | 'due_date'
+  >(() => {
+    const v = lsGet('dateField', 'transaction_date');
+    const allowed = [
+      'transaction_date', 'updated_at', 'nfe_issued_at', 'invoiced_at',
+      'invoice_sent_at', 'competence_date', 'due_date',
+    ] as const;
+    return (allowed as readonly string[]).includes(v) ? (v as typeof allowed[number]) : 'transaction_date';
+  });
+  useEffect(() => lsSet('dateField', dateField), [dateField]);
+
+  const [groupBy, setGroupBy] = useState<GroupByField>(() => {
+    const v = lsGet('groupBy', 'none');
+    const allowed = ['none', 'customer_name', 'payment_status', 'emission_month'] as const;
+    return (allowed as readonly string[]).includes(v) ? (v as GroupByField) : 'none';
+  });
+  useEffect(() => lsSet('groupBy', groupBy), [groupBy]);
+
+  type SortKey = 'transaction_date' | 'invoice_no' | 'customer_name' | 'final_total' | 'payment_status';
+  const [sortKey, setSortKey] = useState<SortKey>('transaction_date');
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
+  const handleSort = useCallback(
+    (k: SortKey) => {
+      setSortKey((prev) => {
+        if (k === prev) return prev;
+        return k;
+      });
+      setSortDir((prev) => {
+        if (k === sortKey) return prev === 'asc' ? 'desc' : 'asc';
+        return k === 'transaction_date' || k === 'final_total' ? 'desc' : 'asc';
+      });
+    },
+    [sortKey]
+  );
+
+  const handleDateFilterChange = useCallback(
+    (next: {
+      preset: DateFilterPreset;
+      dateFrom: string;
+      dateTo: string;
+      dateField: typeof dateField;
+    }) => {
+      setDatePreset(next.preset);
+      setDateFrom(next.dateFrom);
+      setDateTo(next.dateTo);
+      setDateField(next.dateField);
+    },
+    []
+  );
+
+  // Toggle de visibilidade da barra (default fechado pra não poluir o Cowork visual).
+  const [advancedOpen, setAdvancedOpen] = useState<boolean>(() => lsGet('advancedOpen', '0') === '1');
+  useEffect(() => lsSet('advancedOpen', advancedOpen ? '1' : '0'), [advancedOpen]);
 
   // Selection + favorites + focus row (J/K navigation).
   const [selectedIds, setSelectedIds] = useState<Set<number>>(() => new Set());
@@ -462,8 +564,7 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
   // Pagination + sort (preservados do legacy — controles ficam compactos no rodapé).
   const [page, setPage] = useState(1);
   const perPage = 50;
-  const sortKey = 'transaction_date';
-  const sortDir: 'asc' | 'desc' = 'desc';
+  // sortKey/sortDir agora vêm de state (declarados acima); permitem header clicáveis.
 
   // Refetch trigger (independente de filtros) — disparado por onSaleChanged do drawer.
   const [refetchToken, setRefetchToken] = useState(0);
@@ -490,6 +591,10 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
     params.set('page', String(page));
     params.set('sort', sortKey);
     params.set('dir', sortDir);
+    // PR follow-up — date_field + date_from/date_to do SellsDateFilter (US-SELL-018/021).
+    params.set('date_field', dateField);
+    if (dateFrom) params.set('date_from', dateFrom);
+    if (dateTo) params.set('date_to', dateTo);
 
     fetch(`/sells-list-json?${params.toString()}`, {
       headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
@@ -514,10 +619,13 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
     return () => {
       cancelled = true;
     };
-  }, [pillFilter, searchDebounced, page, perPage, sortKey, sortDir, refetchToken]);
+  }, [pillFilter, searchDebounced, page, perPage, sortKey, sortDir, dateField, dateFrom, dateTo, refetchToken]);
 
   // Reset page when filter changes.
-  useEffect(() => setPage(1), [pillFilter, searchDebounced]);
+  useEffect(
+    () => setPage(1),
+    [pillFilter, searchDebounced, sortKey, sortDir, dateField, dateFrom, dateTo]
+  );
 
   // SavedView + pill filtering (client-side composto).
   const currentSavedView: SavedView =
@@ -994,22 +1102,81 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
           )}
         </div>
 
-        {/* 5 status pills */}
-        <div className="os-tabs">
-          {(['todas', 'paga', 'pendente', 'faturada', 'cancelada'] as const).map((s) => (
+        {/* 5 status pills + toggle "Filtros avançados ▾" (PR follow-up) */}
+        <div className="vd-tabs-row">
+          <div className="os-tabs vd-tabs-grow">
+            {(['todas', 'paga', 'pendente', 'faturada', 'cancelada'] as const).map((s) => (
+              <button
+                key={s}
+                type="button"
+                className={'os-tab' + (pillFilter === s ? ' active' : '')}
+                onClick={() => setPillFilter(s)}
+              >
+                {STATUS_LABEL[s] ?? s}
+                <span className="os-tab-n">{countByPill(s)}</span>
+              </button>
+            ))}
+          </div>
+          <div className="vd-tabs-actions">
+            <SellsToggleViewMode viewMode={viewMode} onChange={setViewMode} />
             <button
-              key={s}
               type="button"
-              className={'os-tab' + (pillFilter === s ? ' active' : '')}
-              onClick={() => setPillFilter(s)}
+              className={'vd-filters-toggle' + (advancedOpen ? ' on' : '')}
+              onClick={() => setAdvancedOpen((v) => !v)}
+              aria-expanded={advancedOpen}
+              title="Filtros avançados (período, data, agrupamento)"
             >
-              {STATUS_LABEL[s] ?? s}
-              <span className="os-tab-n">{countByPill(s)}</span>
+              <SlidersHorizontal size={12} />
+              <span>Filtros avançados</span>
+              <ChevronDown
+                size={11}
+                style={{
+                  transition: 'transform .12s',
+                  transform: advancedOpen ? 'rotate(180deg)' : 'none',
+                }}
+              />
             </button>
-          ))}
+          </div>
         </div>
 
-        {/* TABLE */}
+        {/* Barra colapsável Filtros avançados (US-SELL-018/019/021 preservados) */}
+        {advancedOpen && (
+          <div className="vd-filters-bar">
+            <SellsDateFilter
+              preset={datePreset}
+              dateFrom={dateFrom}
+              dateTo={dateTo}
+              dateField={dateField}
+              onChange={handleDateFilterChange}
+            />
+            {viewMode === 'grade-avancada' && (
+              <SellsGroupByDropdown groupBy={groupBy} onChange={setGroupBy} />
+            )}
+          </div>
+        )}
+
+        {/* TABLE — Cowork (lista) OU Grade Avançada (toggle) */}
+        {viewMode === 'grade-avancada' ? (
+          <div className="vd-grade-wrap">
+            <SellsGradeAvancada
+              rows={rows}
+              loading={loading}
+              totals={totals as SellsTotals | null}
+              selectedIds={selectedIds}
+              onToggleSelect={toggleSel}
+              onToggleSelectAll={toggleAll}
+              onClearSelection={() => setSelectedIds(new Set())}
+              onRowClick={(id: number) => setOpenSaleId(id)}
+              openSaleId={openSaleId}
+              totalFiltered={meta?.total ?? rows.length}
+              sortKey={sortKey}
+              sortDir={sortDir}
+              onSort={handleSort}
+              groupBy={groupBy}
+              onGroupByChange={setGroupBy}
+            />
+          </div>
+        ) : (
         <div className="os-table-wrap">
           <table className="os-table vendas-table vd-aplus-table">
             <thead>
@@ -1186,6 +1353,7 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
             </tbody>
           </table>
         </div>
+        )}
 
         {/* Pagination compacta (preserva contrato US-SELL-008) */}
         {meta && meta.last_page > 1 && (


### PR DESCRIPTION
## Summary

Follow-up imediato do [#1032](https://github.com/wagnerra23/oimpresso.com/pull/1032) (cópia visual integral KB-9.75). Verificação Brave pós-merge detectou que 3 features legacy do Cockpit V2 ficaram com componentes em `_components/` mas **não foram montadas** no rewrite Cowork. Este PR reintegra todas elas via barra colapsável **\"Filtros avançados ▾\"**, preservando o visual Cowork limpo no estado default (fechado).

## Features restauradas

| Componente | US | Onde aparece |
|---|---|---|
| `SellsDateFilter` | US-SELL-018/021 | Barra colapsável (sempre) |
| `SellsGroupByDropdown` | US-SELL-019 | Barra colapsável (só em Grade Avançada) |
| `SellsToggleViewMode` (Lista \| Grade Avançada) | US-SELL-015 ADR 0136 | Linha das pills, à direita |
| `SellsGradeAvancada` (TanStack table + agrupamento) | US-SELL-016/017 | Quando toggle=Grade |

## UX

- **Botão \"Filtros avançados ▾\"** no canto direito da linha das 5 status pills, ao lado do toggle Lista/Grade. **Default fechado** — preserva visual Cowork limpo.
- **Barra colapsável** aparece entre as pills e a tabela quando aberto:
  - `SellsDateFilter`: preset Dia/Semana/Mês/Ano/Personalizado/All + dropdown 7 opções de data (Emissão/Última alteração/Emissão NF/Faturamento/Envio/Competência/Prometido)
  - `SellsGroupByDropdown` (só em modo Grade): none/customer_name/payment_status/emission_month
- **Toggle Lista/Grade** decide qual tabela renderiza:
  - **Lista** (Cowork, default): tabela 10 cols com SLA pill + Pipeline dots + Fiscal badges + Seller avatar
  - **Grade Avançada** (legacy preservado): TanStack table com agrupamento, sort por header, totalizador rodapé

## State preservado

- `localStorage` keys **idênticas ao legacy** pré-Cowork: `oimpresso.sells.viewMode` / `.datePreset` / `.dateField` / `.dateFrom` / `.dateTo` / `.groupBy` / `.advancedOpen` — usuários NÃO perdem preferências.
- Fetch `/sells-list-json` estende params: `date_field` + `date_from` + `date_to` + `sort` + `dir` (todos já suportados pelo backend desde PR #1032).
- `sortKey`/`sortDir` saem de const pra state — habilita sort por header click na Grade Avançada via callback `handleSort`.
- `totals` state (estava `[, setTotals]` descartado em #1032) — agora populado e passado pra `<SellsGradeAvancada>`.

## CSS (~50 linhas novas em `inertia.css`)

4 classes novas scoped sob `.sells-cowork`:
- `.vd-tabs-row` — wrapper que junta pills + toggle/filtros na mesma linha
- `.vd-tabs-grow` / `.vd-tabs-actions` — flex split
- `.vd-filters-toggle` — botão \"Filtros avançados ▾\" (estado on/off)
- `.vd-filters-bar` — barra colapsável bg muted
- `.vd-grade-wrap` — wrapper preservando layout flex do `.os-page` quando Grade Avançada renderiza

Sem mudança no `sells-cowork.css` (preservado verbatim do prototype).

## Tier 0 honrado

- ✅ `business_id` global scope preservado (ADR 0093)
- ✅ Mesmas `localStorage` keys do legacy (sem invalidar pref dos usuários officeimpresso)
- ✅ Endpoint `/sells-list-json` não mudou interface — apenas usado com mais params
- ✅ `SellsGradeAvancada` legacy intocado — preserva contratos US-SELL-016/017/019

## Test plan

- [ ] CI verde (TS check + Pest 49 + visual-regression)
- [ ] Pos-deploy: cliente officeimpresso (`legacy_origin=officeimpresso`) abre `/sells` e vê Grade Avançada como default (preserva comportamento ADR 0136)
- [ ] Pos-deploy: cliente non-legacy abre `/sells` e vê Lista Cowork como default + clica toggle Grade pra alternar
- [ ] Pos-deploy: clica \"Filtros avançados ▾\" → barra abre com SellsDateFilter + (em Grade) GroupByDropdown
- [ ] `localStorage` keys legacy preservadas — refresh página mantém preferências
- [ ] Module Grade gate — Sells não regride

## Refs

- PR base: [#1032](https://github.com/wagnerra23/oimpresso.com/pull/1032) (cópia visual integral KB-9.75)
- Index.charter.md v2 §Non-Goals — itens 3-4 (Date field + Group-by) **revertidos** pra Goals (atualizar charter em PR irmão de docs)
- ADR 0136 Sells viewMode toggle preservado
- US-SELL-015/016/017/018/019/021 contratos preservados
- [feedback-design-literal-copy-quando-aprovado.md](memory/reference/feedback-design-literal-copy-quando-aprovado.md) §How to apply #5 — verificação Brave detectou gap, hotfix follow-up canônico
- Decisão Wagner: \"Sim, merge agora + abre PR follow-up dos filtros\" (sessão 2026-05-17 stupefied-noether-89f83d)

🤖 Generated with [Claude Code](https://claude.com/claude-code)