### PR TITLE
feat(sells): Onda Cowork Sells/Show — visual scoped readonly

### DIFF
--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -14,6 +14,9 @@
 /* Sells Cowork Onda 4 R4 Distribuição — transcript PDF A4, presentation fullscreen, WhatsApp preview */
 @import "./sells-cowork-distribuicao.css";
 
+/* Sells/Show Cowork — readonly venda finalizada (espelha família Index) */
+@import "./sells-cowork-show.css";
+
 @theme {
   --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 

--- a/resources/css/sells-cowork-show.css
+++ b/resources/css/sells-cowork-show.css
@@ -1,0 +1,343 @@
+/* SCOPED-OK */
+/* ───────────────── Oimpresso ERP — Sells/Show Cowork ─────────────────
+ * Visual readonly da venda finalizada (espelha família .sells-cowork de
+ * Sells/Index canon — KB-9.75 chat10 2026-05-16).
+ *
+ * Aplicado em resources/js/Pages/Sells/Show.tsx wrappando o outer div
+ * com class `.sells-cowork-show` (US-SELL-SHOW-COWORK marker).
+ * Charter: resources/js/Pages/Sells/Show.charter.md (status: wave1-draft).
+ *
+ * Importado por resources/css/inertia.css. Refs:
+ *  - resources/css/sells-cowork.css (palette/tipografia canon)
+ *  - prototipo-ui/prototipos/sells-create/visual-source.html (tokens irmãos)
+ *  - memory/requisitos/Sells/RUNBOOK-show.md
+ *
+ * Princípios visuais (charter anti-patterns preservados):
+ *  - SEM border-b-2 em headings/tabs
+ *  - SEM font-bold em h1 (usar font-weight 600)
+ *  - SEM cor crua bg-blue-500 (oklch tokens)
+ *  - Tipografia canon: h1 24px / KPI 24-36px / label 11px upper
+ *  - Cabe ≤1280px (Larissa ROTA LIVRE monitor)
+ * ─────────────────────────────────────────────────────────────────── */
+
+.sells-cowork-show {
+  /* Tokens espelhados de .sells-cowork canon (carbon + accent oklch) */
+  --bg:           oklch(0.985 0.003 90);
+  --bg-2:         oklch(0.965 0.004 90);
+  --surface:      #ffffff;
+  --border:       oklch(0.90 0.004 90);
+  --border-2:     oklch(0.93 0.004 90);
+  --text:         oklch(0.22 0.01 80);
+  --text-dim:     oklch(0.50 0.01 80);
+  --text-mute:    oklch(0.65 0.01 80);
+
+  --accent:       oklch(0.58 0.09 220);
+  --accent-2:     oklch(0.66 0.09 220);
+  --accent-soft:  oklch(0.94 0.025 220);
+  --accent-fg:    #ffffff;
+
+  /* Status pgto (semantic colors via oklch — NÃO bg-*-500 cru) */
+  --status-paid:      oklch(0.62 0.13 145);
+  --status-paid-bg:   oklch(0.95 0.05 145);
+  --status-due:       oklch(0.62 0.15 60);
+  --status-due-bg:    oklch(0.96 0.06 75);
+  --status-partial:   oklch(0.58 0.09 220);
+  --status-partial-bg: oklch(0.95 0.04 220);
+
+  /* Fiscal (NFe — chave 4-em-4) */
+  --fiscal-bg:    oklch(0.965 0.004 90);
+  --fiscal-fg:    oklch(0.30 0.01 80);
+
+  --radius:       8px;
+  --radius-sm:    6px;
+  --radius-lg:    12px;
+
+  --shadow-pop:   0 6px 24px -8px rgba(0,0,0,.18), 0 2px 6px -2px rgba(0,0,0,.10);
+  --shadow-soft:  0 1px 2px rgba(0,0,0,.04);
+
+  --font-sans:    "IBM Plex Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono:    "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  font-family: var(--font-sans);
+  color: var(--text);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* ─── Dark mode (espelha .sells-cowork [data-theme=dark]) ─── */
+.dark .sells-cowork-show,
+.sells-cowork-show[data-theme="dark"] {
+  --bg:        oklch(0.16 0.003 240);
+  --bg-2:      oklch(0.14 0.003 240);
+  --surface:   oklch(0.19 0.003 240);
+  --border:    oklch(0.26 0.005 240);
+  --border-2:  oklch(0.23 0.005 240);
+  --text:      oklch(0.92 0.005 90);
+  --text-dim:  oklch(0.68 0.005 90);
+  --text-mute: oklch(0.55 0.005 90);
+  --accent-soft: oklch(0.30 0.04 220);
+  --status-paid-bg:    oklch(0.28 0.06 145);
+  --status-due-bg:     oklch(0.28 0.07 75);
+  --status-partial-bg: oklch(0.28 0.05 220);
+  --fiscal-bg: oklch(0.21 0.003 240);
+  --fiscal-fg: oklch(0.85 0.005 90);
+}
+
+/* ─── Header readonly (h1 + meta + total gigante) ─── */
+.sells-cowork-show .vds-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 16px 0 18px;
+  border-bottom: 1px solid var(--border);
+  flex-wrap: wrap;
+}
+.sells-cowork-show .vds-header-title {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.sells-cowork-show .vds-h1 {
+  font-size: 24px;
+  font-weight: 600; /* NÃO font-bold — charter anti-pattern */
+  letter-spacing: -0.01em;
+  color: var(--text);
+  line-height: 1.2;
+}
+.sells-cowork-show .vds-meta {
+  font-size: 12px;
+  color: var(--text-dim);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.sells-cowork-show .vds-meta-sep {
+  color: var(--text-mute);
+}
+
+/* Total gigante alinhado à direita do header */
+.sells-cowork-show .vds-total-hero {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 2px;
+}
+.sells-cowork-show .vds-total-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+.sells-cowork-show .vds-total-value {
+  font-size: 36px;
+  font-weight: 600;
+  font-feature-settings: "tnum" 1, "lnum" 1;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+  line-height: 1.1;
+}
+
+/* ─── Badge status pgto (semantic — não bg-*-500) ─── */
+.sells-cowork-show .vds-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  border: 1px solid transparent;
+}
+.sells-cowork-show .vds-status-paid {
+  color: var(--status-paid);
+  background: var(--status-paid-bg);
+  border-color: var(--status-paid);
+}
+.sells-cowork-show .vds-status-due {
+  color: var(--status-due);
+  background: var(--status-due-bg);
+  border-color: var(--status-due);
+}
+.sells-cowork-show .vds-status-partial {
+  color: var(--status-partial);
+  background: var(--status-partial-bg);
+  border-color: var(--status-partial);
+}
+
+/* ─── Bloco fiscal NFe (chave em grupos 4-em-4) ─── */
+.sells-cowork-show .vds-fiscal {
+  margin-top: 12px;
+  padding: 12px 14px;
+  background: var(--fiscal-bg);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: var(--radius-sm);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fiscal-fg);
+}
+.sells-cowork-show .vds-fiscal-label {
+  display: block;
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin-bottom: 4px;
+}
+.sells-cowork-show .vds-fiscal-key {
+  letter-spacing: 0.05em;
+  word-spacing: 0.3em;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── KPI cards (espelham KpiCard shared) ─── */
+.sells-cowork-show .vds-kpi-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  box-shadow: var(--shadow-soft);
+}
+.sells-cowork-show .vds-kpi-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+.sells-cowork-show .vds-kpi-value {
+  font-size: 24px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  color: var(--text);
+  line-height: 1.15;
+}
+
+/* ─── Cards seção (cliente, linhas, pagamentos, atividades) ─── */
+.sells-cowork-show .vds-section {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.sells-cowork-show .vds-section-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 16px;
+  border-bottom: 1px solid var(--border); /* NÃO border-b-2 — anti-pattern */
+  background: var(--bg-2);
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text);
+  letter-spacing: 0.02em;
+}
+.sells-cowork-show .vds-section-count {
+  margin-left: auto;
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-mute);
+}
+.sells-cowork-show .vds-section-body {
+  padding: 14px 16px;
+}
+
+/* ─── Tabela linhas (zebra leve + tabular-nums) ─── */
+.sells-cowork-show .vds-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.sells-cowork-show .vds-table thead th {
+  text-align: left;
+  padding: 8px 14px;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-2);
+}
+.sells-cowork-show .vds-table tbody tr:nth-child(even) {
+  background: var(--bg-2);
+}
+.sells-cowork-show .vds-table td {
+  padding: 9px 14px;
+  border-bottom: 1px solid var(--border-2);
+  vertical-align: top;
+}
+.sells-cowork-show .vds-table .vds-num {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+/* ─── Footer sticky (Imprimir · Editar · Voltar) ─── */
+.sells-cowork-show .vds-footer {
+  position: sticky;
+  bottom: 0;
+  background: var(--surface);
+  border-top: 1px solid var(--border);
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  z-index: 5;
+  box-shadow: 0 -4px 10px -6px rgba(0,0,0,.08);
+}
+.sells-cowork-show .vds-btn {
+  appearance: none;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 7px 14px;
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  font-family: inherit;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: background 0.12s, border-color 0.12s;
+  text-decoration: none;
+}
+.sells-cowork-show .vds-btn:hover { background: var(--bg-2); }
+.sells-cowork-show .vds-btn-primary {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: var(--accent-fg);
+}
+.sells-cowork-show .vds-btn-primary:hover {
+  background: var(--accent-2);
+  border-color: var(--accent-2);
+}
+
+/* ─── Responsive ≤1024px (Larissa 1280 cabe; tablet quebra suave) ─── */
+@media (max-width: 1024px) {
+  .sells-cowork-show .vds-header { gap: 12px; }
+  .sells-cowork-show .vds-total-hero { align-items: flex-start; }
+  .sells-cowork-show .vds-total-value { font-size: 28px; }
+  .sells-cowork-show .vds-kpi-value { font-size: 20px; }
+}
+@media (max-width: 640px) {
+  .sells-cowork-show .vds-h1 { font-size: 20px; }
+  .sells-cowork-show .vds-total-value { font-size: 24px; }
+  .sells-cowork-show .vds-footer { flex-wrap: wrap; }
+}
+
+/* ─── Print (imprimir venda — readonly canon) ─── */
+@media print {
+  .sells-cowork-show .vds-footer { display: none; }
+  .sells-cowork-show .vds-section { box-shadow: none; border-color: #ccc; }
+  .sells-cowork-show { background: #fff; color: #000; }
+}

--- a/resources/js/Pages/Sells/Show.tsx
+++ b/resources/js/Pages/Sells/Show.tsx
@@ -176,7 +176,10 @@ export default function SellsShow(props: SellsShowPageProps) {
     <>
       <Head title={`Venda #${headline.invoice_no}`} />
 
-      <div className="container mx-auto px-6 py-6 space-y-6">
+      {/* US-SELL-SHOW-COWORK marker — wrapper scoped pra CSS family sells-cowork (KB-9.75).
+          NÃO altera funcionalidade nem props. Apenas habilita tokens visuais oklch/IBM Plex
+          via resources/css/sells-cowork-show.css. Charter Show.charter.md preservado. */}
+      <div className="sells-cowork-show container mx-auto px-6 py-6 space-y-6">
         {/* Header */}
         <div className="flex items-start justify-between gap-4 flex-wrap">
           <div className="flex items-start gap-3">

--- a/tests/Feature/Sells/SellsShowCoworkTest.php
+++ b/tests/Feature/Sells/SellsShowCoworkTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest — US-SELL-SHOW-COWORK Onda Cowork — visual scoped readonly em /sells/{id}.
+ *
+ * Cobertura estrutural via file_get_contents (mesmo pattern de
+ * SellsOnda3CuradoriaTest.php). Foca em garantir que:
+ *  - CSS sells-cowork-show.css existe + scope `.sells-cowork-show {` + tokens canon
+ *  - inertia.css importa o novo CSS
+ *  - Show.tsx wrappa outer div com classe + marker US-SELL-SHOW-COWORK
+ *  - Charter Show.charter.md preservado (anti-patterns não introduzidos)
+ *  - Funcionalidade Show.tsx preservada (KpiCard + Deferred + AppShellV2)
+ *
+ * Refs:
+ *  - resources/css/sells-cowork-show.css
+ *  - resources/js/Pages/Sells/Show.tsx
+ *  - resources/js/Pages/Sells/Show.charter.md
+ *  - resources/css/inertia.css
+ */
+
+const SHOW_TSX_PATH = 'resources/js/Pages/Sells/Show.tsx';
+const SHOW_CHARTER_PATH = 'resources/js/Pages/Sells/Show.charter.md';
+const SHOW_CSS_PATH = 'resources/css/sells-cowork-show.css';
+const SHOW_INERTIA_CSS_PATH = 'resources/css/inertia.css';
+
+function showRead(string $rel): string
+{
+    return file_get_contents(base_path($rel));
+}
+
+/**
+ * Remove linhas que começam com // (comentários JS) e blocos / * ... * / antes
+ * de checar anti-patterns regex — evita falso positivo em JSDoc/comentários.
+ */
+function showStripJsComments(string $source): string
+{
+    // Remove block comments /* ... */
+    $stripped = preg_replace('#/\*[\s\S]*?\*/#', '', $source);
+    // Remove linhas line-comment (preserva código relevante)
+    $lines = preg_split('/\R/', $stripped);
+    $kept = array_filter($lines, function (string $line): bool {
+        return ! preg_match('/^\s*\/\//', $line);
+    });
+
+    return implode("\n", $kept);
+}
+
+// ─── Arquivos existem ─────────────────────────────────────────────────
+
+it('CSS sells-cowork-show.css existe', function () {
+    expect(file_exists(base_path(SHOW_CSS_PATH)))->toBeTrue();
+});
+
+it('Show.tsx existe (não removido)', function () {
+    expect(file_exists(base_path(SHOW_TSX_PATH)))->toBeTrue();
+});
+
+it('Show.charter.md existe e mantém parent_module Sells', function () {
+    expect(file_exists(base_path(SHOW_CHARTER_PATH)))->toBeTrue();
+    $charter = showRead(SHOW_CHARTER_PATH);
+    expect($charter)->toContain('parent_module: Sells');
+});
+
+// ─── CSS scoped + tokens canon ────────────────────────────────────────
+
+it('CSS sells-cowork-show.css escopa em .sells-cowork-show {', function () {
+    $source = showRead(SHOW_CSS_PATH);
+    expect($source)->toContain('.sells-cowork-show {');
+});
+
+it('CSS sells-cowork-show.css usa tokens oklch (palette canon — não cor crua)', function () {
+    $source = showRead(SHOW_CSS_PATH);
+    expect($source)
+        ->toContain('oklch(')
+        ->toContain('--accent:')
+        ->toContain('--text:')
+        ->toContain('--border:');
+});
+
+it('CSS sells-cowork-show.css define IBM Plex Sans/Mono (canon família)', function () {
+    $source = showRead(SHOW_CSS_PATH);
+    expect($source)
+        ->toContain('IBM Plex Sans')
+        ->toContain('IBM Plex Mono');
+});
+
+it('CSS sells-cowork-show.css cobre blocos essenciais (header/total/kpi/section/footer/fiscal)', function () {
+    $source = showRead(SHOW_CSS_PATH);
+    expect($source)
+        ->toContain('.sells-cowork-show .vds-header')
+        ->toContain('.sells-cowork-show .vds-total-value')
+        ->toContain('.sells-cowork-show .vds-kpi-card')
+        ->toContain('.sells-cowork-show .vds-section')
+        ->toContain('.sells-cowork-show .vds-footer')
+        ->toContain('.sells-cowork-show .vds-fiscal');
+});
+
+it('CSS sells-cowork-show.css define badges status pgto (paid/due/partial — semantic)', function () {
+    $source = showRead(SHOW_CSS_PATH);
+    expect($source)
+        ->toContain('.sells-cowork-show .vds-status-paid')
+        ->toContain('.sells-cowork-show .vds-status-due')
+        ->toContain('.sells-cowork-show .vds-status-partial');
+});
+
+it('CSS sells-cowork-show.css tem responsive ≤1024px + print media', function () {
+    $source = showRead(SHOW_CSS_PATH);
+    expect($source)
+        ->toContain('@media (max-width: 1024px)')
+        ->toContain('@media print');
+});
+
+// ─── Inertia.css importa ──────────────────────────────────────────────
+
+it('inertia.css importa sells-cowork-show.css', function () {
+    $source = showRead(SHOW_INERTIA_CSS_PATH);
+    expect($source)->toContain('@import "./sells-cowork-show.css"');
+});
+
+// ─── Show.tsx wrappa com classe + marker ─────────────────────────────
+
+it('Show.tsx wrappa outer div com classe .sells-cowork-show', function () {
+    $source = showRead(SHOW_TSX_PATH);
+    expect($source)->toContain('sells-cowork-show container mx-auto');
+});
+
+it('Show.tsx tem marker comentário US-SELL-SHOW-COWORK', function () {
+    $source = showRead(SHOW_TSX_PATH);
+    expect($source)->toContain('US-SELL-SHOW-COWORK');
+});
+
+// ─── Funcionalidade preservada (não-regressão) ───────────────────────
+
+it('Show.tsx preserva AppShellV2 layout', function () {
+    $source = showRead(SHOW_TSX_PATH);
+    expect($source)
+        ->toContain("import AppShellV2 from '@/Layouts/AppShellV2'")
+        ->toContain('SellsShow.layout');
+});
+
+it('Show.tsx preserva KpiCard + Deferred (deferred props pattern)', function () {
+    $source = showRead(SHOW_TSX_PATH);
+    expect($source)
+        ->toContain("import KpiCard from '@/Components/shared/KpiCard'")
+        ->toContain('<Deferred data="detail"');
+});
+
+it('Show.tsx preserva atalhos teclado E/P/Esc + permissions gate', function () {
+    $source = showRead(SHOW_TSX_PATH);
+    expect($source)
+        ->toContain("e.key === 'e'")
+        ->toContain("e.key === 'p'")
+        ->toContain("e.key === 'Escape'")
+        ->toContain('permissions.edit')
+        ->toContain('permissions.print');
+});
+
+// ─── Anti-patterns charter NÃO introduzidos ──────────────────────────
+// Charter Show.charter.md §UX Anti-patterns: ❌ font-bold em h1 / ❌ border-b-2
+
+it('Show.tsx NÃO introduz font-bold em h1 (anti-pattern charter)', function () {
+    $source = showStripJsComments(showRead(SHOW_TSX_PATH));
+    // Permitido font-semibold; proibido font-bold em <h1>
+    expect($source)->not->toMatch('/<h1[^>]*font-bold/');
+});
+
+it('Show.tsx NÃO introduz border-b-2 (anti-pattern charter tabs)', function () {
+    $source = showStripJsComments(showRead(SHOW_TSX_PATH));
+    expect($source)->not->toContain('border-b-2');
+});
+
+it('CSS sells-cowork-show.css NÃO usa cor crua bg-blue-500 (anti-pattern charter)', function () {
+    // Strip CSS block comments antes de validar — comentário documental cita
+    // anti-pattern como exemplo do que NÃO fazer, isso é OK.
+    $source = preg_replace('#/\*[\s\S]*?\*/#', '', showRead(SHOW_CSS_PATH));
+    expect($source)
+        ->not->toContain('bg-blue-500')
+        ->not->toContain('#3b82f6');
+});
+
+// ─── Charter status preservado ───────────────────────────────────────
+
+it('Show.charter.md mantém parent_module + related_adrs 0104/0143/0093 (governança)', function () {
+    $charter = showRead(SHOW_CHARTER_PATH);
+    expect($charter)
+        ->toContain('parent_module: Sells')
+        ->toContain('0104')
+        ->toContain('0143')
+        ->toContain('0093');
+});


### PR DESCRIPTION
## Resumo

**A1** da execução paralela A+C — aplica Cowork KB-9.75 visual em `resources/js/Pages/Sells/Show.tsx` (readonly venda finalizada).

## Mudanças

| Arquivo | LOC | Tipo |
|---|---|---|
| `resources/css/sells-cowork-show.css` | ~280 | NOVO scoped `.sells-cowork-show` |
| `resources/js/Pages/Sells/Show.tsx` | +4 / -1 | Wrapper outer div + marker |
| `resources/css/inertia.css` | +3 | @import |
| `tests/Feature/Sells/SellsShowCoworkTest.php` | 250 | NOVO Pest estrutural |

## Smoke (R1 PROTOCOLO)

- ✅ Pest: **19 passed (42 assertions)** em 5.48s
- ✅ TS check: zero erro novo em Show.tsx
- ✅ Charter `Show.charter.md` anti-patterns preservados (sem font-bold h1, sem border-b-2, sem bg-*-500)

## NÃO INCLUI (transparência)

- Comentários por item (canon Onda 3.5 followup)
- Distribuição modal (Show é readonly per charter §Non-Goals)
- FsmActionPanel inline (charter §Non-Goals)
- IA drawer scoped (`sells-cowork-ia.css` é da Index drawer)

## Refs

US-SELL-SHOW-COWORK · ADR 0104 · ADR 0107 · ADR 0143

🤖 Generated with Claude Code