### PR TITLE
feat(sells): Onda Cowork Sells/Quotations — visual reusa família Index

### DIFF
--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -17,6 +17,9 @@
 /* Sells/Show Cowork — readonly venda finalizada (espelha família Index) */
 @import "./sells-cowork-show.css";
 
+/* Sells/Quotations Cowork — lista orçamentos (extensões mínimas além da família Index) */
+@import "./sells-cowork-quotations.css";
+
 @theme {
   --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 

--- a/resources/css/sells-cowork-quotations.css
+++ b/resources/css/sells-cowork-quotations.css
@@ -1,0 +1,107 @@
+/* ───────────────────────────────────────────────────────────────────
+ * Sells Cowork — Sells/Quotations (cotações) extensões mínimas.
+ *
+ * Reusa a família .sells-cowork (tokens canon + paginação + filtros) e
+ * adiciona APENAS os toques específicos da página de cotações:
+ *   - badge "Orçamento" (pill destaque âmbar/dourado vs status pills vendas)
+ *   - botão "Converter em venda" (acento esverdeado — call-to-action)
+ *   - indicador de expiração de orçamento (chip vencido / a vencer)
+ *
+ * Importado por resources/css/inertia.css. Scope cumulativo:
+ *   <div class="sells-cowork sells-cowork-quotations">
+ * cohabita tokens da família Index sem reescrever nenhum.
+ *
+ * Refs:
+ *  - resources/css/sells-cowork.css (família canon — tokens base)
+ *  - resources/js/Pages/Sells/Quotations.charter.md (Mission + Goals)
+ *  - resources/js/Pages/Sells/Quotations.tsx (uso)
+ *  - memory/requisitos/_DesignSystem/RUNBOOK-onda-cowork.md
+ * ─────────────────────────────────────────────────────────────────── */
+
+.sells-cowork-quotations {
+  /* Tokens locais — orçamento (âmbar/dourado, distinto de paga/pendente vendas) */
+  --vd-quote-amber: oklch(0.72 0.14 75);
+  --vd-quote-amber-soft: oklch(0.96 0.05 75);
+  --vd-quote-amber-border: oklch(0.86 0.09 75);
+  --vd-quote-amber-text: oklch(0.42 0.13 70);
+
+  /* Tokens locais — converter em venda (esverdeado CTA, distinto de paga) */
+  --vd-quote-convert: oklch(0.60 0.12 145);
+  --vd-quote-convert-hover: oklch(0.55 0.13 145);
+  --vd-quote-convert-fg: #ffffff;
+
+  /* Tokens locais — expiração (vermelho-suave coerente com vd-delta-dn) */
+  --vd-quote-expired: oklch(0.55 0.16 25);
+  --vd-quote-expired-soft: oklch(0.96 0.04 25);
+  --vd-quote-expiring: oklch(0.62 0.13 60);
+  --vd-quote-expiring-soft: oklch(0.96 0.04 60);
+}
+
+/* ── Badge "Orçamento" — destaque sutil no header da página ── */
+.sells-cowork-quotations .vd-quote-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: var(--vd-quote-amber-soft);
+  border: 1px solid var(--vd-quote-amber-border);
+  color: var(--vd-quote-amber-text);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.4;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+}
+
+/* ── Botão "Converter em venda" (CTA verde, distinto de "Enviar") ── */
+.sells-cowork-quotations .vd-quote-convert-btn {
+  appearance: none;
+  background: var(--vd-quote-convert);
+  color: var(--vd-quote-convert-fg);
+  border: 1px solid var(--vd-quote-convert);
+  padding: 5px 11px;
+  border-radius: var(--radius-sm, 6px);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  transition: background .12s, border-color .12s;
+}
+.sells-cowork-quotations .vd-quote-convert-btn:hover {
+  background: var(--vd-quote-convert-hover);
+  border-color: var(--vd-quote-convert-hover);
+}
+.sells-cowork-quotations .vd-quote-convert-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* ── Chip de expiração (validade do orçamento) ── */
+.sells-cowork-quotations .vd-quote-expiry {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  line-height: 1.4;
+  font-variant-numeric: tabular-nums;
+}
+.sells-cowork-quotations .vd-quote-expiry.expired {
+  background: var(--vd-quote-expired-soft);
+  color: var(--vd-quote-expired);
+  border: 1px solid color-mix(in oklch, var(--vd-quote-expired) 30%, transparent);
+}
+.sells-cowork-quotations .vd-quote-expiry.expiring {
+  background: var(--vd-quote-expiring-soft);
+  color: var(--vd-quote-expiring);
+  border: 1px solid color-mix(in oklch, var(--vd-quote-expiring) 30%, transparent);
+}
+.sells-cowork-quotations .vd-quote-expiry.fresh {
+  background: var(--bg-2, oklch(0.965 0.004 90));
+  color: var(--text-dim, oklch(0.50 0.01 80));
+  border: 1px solid var(--border, oklch(0.90 0.004 90));
+}

--- a/resources/js/Pages/Sells/Quotations.tsx
+++ b/resources/js/Pages/Sells/Quotations.tsx
@@ -1,8 +1,13 @@
 // Wave 1 W1-A — MWART /sells/quotations (Cotações).
+// US-SELL-QUOTATIONS-COWORK marker — Onda Cowork Sells/Quotations (visual reuse família Index).
 // Refs: ADR 0104, ADR 0149 (pattern reuse Sells/Drafts), ADR 0110, ADR 0143 (FSM quote_*), ADR 0093.
 //
 // Lista cotações (status=draft + sub_status=quotation). Pattern idêntico Drafts;
 // muda título, endpoint AJAX (?is_quotation=1), ações específicas (enviar/converter).
+//
+// Visual: wrapper outer reusa família .sells-cowork (tokens canon + filtros + paginação)
+// e adiciona .sells-cowork-quotations (extensões mínimas: badge orçamento, CTA converter,
+// chip expiração). Sem mudar Controller / props / funcionalidade.
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Deferred, Head, Link, router } from '@inertiajs/react';
@@ -119,7 +124,7 @@ export default function SellsQuotations(props: SellsQuotationsPageProps) {
     <>
       <Head title="Cotações" />
 
-      <div className="container mx-auto px-6 py-6 space-y-6">
+      <div className="sells-cowork sells-cowork-quotations container mx-auto px-6 py-6 space-y-6">
         {/* Header */}
         <div className="flex items-start justify-between gap-4 flex-wrap">
           <div className="flex items-start gap-3">
@@ -129,7 +134,10 @@ export default function SellsQuotations(props: SellsQuotationsPageProps) {
               </Link>
             </Button>
             <div>
-              <h1 className="text-2xl font-semibold tracking-tight">Cotações</h1>
+              <div className="flex items-center gap-2">
+                <h1 className="text-2xl font-semibold tracking-tight">Cotações</h1>
+                <span className="vd-quote-badge" aria-label="Tipo: Orçamento">Orçamento</span>
+              </div>
               <p className="text-sm text-muted-foreground mt-1">
                 Propostas formais — enviar pro cliente e converter em venda quando aprovado.
               </p>

--- a/tests/Feature/Sells/SellsQuotationsCoworkTest.php
+++ b/tests/Feature/Sells/SellsQuotationsCoworkTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest — Onda Cowork Sells/Quotations — estrutura visual scoped.
+ *
+ * Cobertura estrutural via file_get_contents (Pest browser cobre interativo
+ * quando estabilizar). Foca em garantir que:
+ *  - CSS sells-cowork-quotations.css existe + scope correto + tokens locais
+ *  - inertia.css importa sells-cowork-quotations.css
+ *  - Quotations.tsx wrappa div outer com AMBAS classes (família + extensão)
+ *  - Marcadores canônicos (US-SELL-QUOTATIONS-COWORK + ADR refs) presentes
+ *  - Charter Quotations.charter.md preservado intacto
+ *  - Componentes específicos da página (badge "Orçamento") renderizam
+ *  - Anti-pattern: NÃO tocar Index.tsx (área proibida do agent vizinho)
+ *
+ * Refs:
+ *  - resources/css/sells-cowork-quotations.css (novo)
+ *  - resources/js/Pages/Sells/Quotations.tsx (modificado wrapper)
+ *  - resources/js/Pages/Sells/Quotations.charter.md (preservado)
+ *  - memory/requisitos/_DesignSystem/RUNBOOK-onda-cowork.md
+ */
+
+const QUOTATIONS_TSX_PATH = 'resources/js/Pages/Sells/Quotations.tsx';
+const QUOTATIONS_CHARTER_PATH = 'resources/js/Pages/Sells/Quotations.charter.md';
+const QUOTATIONS_CSS_PATH = 'resources/css/sells-cowork-quotations.css';
+const QUOTATIONS_INERTIA_CSS_PATH = 'resources/css/inertia.css';
+const QUOTATIONS_INDEX_TSX_PATH = 'resources/js/Pages/Sells/Index.tsx';
+const QUOTATIONS_FAMILY_CSS_PATH = 'resources/css/sells-cowork.css';
+
+function quotationsRead(string $rel): string
+{
+    return file_get_contents(base_path($rel));
+}
+
+// ─── Arquivos existem (smoke estrutural) ──────────────────────────────
+
+it('CSS sells-cowork-quotations.css existe', function () {
+    expect(file_exists(base_path(QUOTATIONS_CSS_PATH)))->toBeTrue();
+});
+
+it('Quotations.tsx ainda existe (não removido)', function () {
+    expect(file_exists(base_path(QUOTATIONS_TSX_PATH)))->toBeTrue();
+});
+
+it('Quotations.charter.md preservado (não removido nem deslocado)', function () {
+    expect(file_exists(base_path(QUOTATIONS_CHARTER_PATH)))->toBeTrue();
+});
+
+// ─── CSS scoped + tokens locais ──────────────────────────────────────
+
+it('CSS sells-cowork-quotations.css scopa sob .sells-cowork-quotations', function () {
+    $source = quotationsRead(QUOTATIONS_CSS_PATH);
+    expect($source)->toContain('.sells-cowork-quotations {');
+});
+
+it('CSS define tokens locais âmbar (badge orçamento), convert (CTA), expiry (chip)', function () {
+    $source = quotationsRead(QUOTATIONS_CSS_PATH);
+    expect($source)
+        ->toContain('--vd-quote-amber:')
+        ->toContain('--vd-quote-amber-soft:')
+        ->toContain('--vd-quote-convert:')
+        ->toContain('--vd-quote-expired:')
+        ->toContain('--vd-quote-expiring:');
+});
+
+it('CSS define classes principais (badge, convert-btn, expiry chip 3 variants)', function () {
+    $source = quotationsRead(QUOTATIONS_CSS_PATH);
+    expect($source)
+        ->toContain('.sells-cowork-quotations .vd-quote-badge')
+        ->toContain('.sells-cowork-quotations .vd-quote-convert-btn')
+        ->toContain('.sells-cowork-quotations .vd-quote-expiry')
+        ->toContain('.vd-quote-expiry.expired')
+        ->toContain('.vd-quote-expiry.expiring')
+        ->toContain('.vd-quote-expiry.fresh');
+});
+
+it('CSS NÃO redefine tokens da família Index (--bg, --accent, --text base preservados na família)', function () {
+    $source = quotationsRead(QUOTATIONS_CSS_PATH);
+    // Tokens locais OK (--vd-quote-*); mas a página NÃO redeclara variáveis canon
+    // da família Index (--accent, --surface, --row-h, --shadow-pop etc.) — reusa via cascata.
+    expect($source)
+        ->not->toContain('--accent:')
+        ->not->toContain('--surface:')
+        ->not->toContain('--row-h:')
+        ->not->toContain('--shadow-pop:')
+        ->not->toContain('--sb-bg:');
+});
+
+// ─── inertia.css importa novo CSS ────────────────────────────────────
+
+it('inertia.css importa sells-cowork-quotations.css', function () {
+    $source = quotationsRead(QUOTATIONS_INERTIA_CSS_PATH);
+    expect($source)->toContain('@import "./sells-cowork-quotations.css"');
+});
+
+it('inertia.css preserva imports da família Index (não removeu sells-cowork.css)', function () {
+    $source = quotationsRead(QUOTATIONS_INERTIA_CSS_PATH);
+    expect($source)
+        ->toContain('@import "./sells-cowork.css"')
+        ->toContain('@import "./sells-cowork-ia.css"')
+        ->toContain('@import "./sells-cowork-curadoria.css"')
+        ->toContain('@import "./sells-cowork-distribuicao.css"');
+});
+
+// ─── Quotations.tsx wrappa com escopo cumulativo ─────────────────────
+
+it('Quotations.tsx wrappa div outer com AMBAS classes (sells-cowork + sells-cowork-quotations)', function () {
+    $source = quotationsRead(QUOTATIONS_TSX_PATH);
+    // Match em className só — descarta menções em comentário (ignora linhas que começam com //)
+    $lines = explode("\n", $source);
+    $hasWrapper = false;
+    foreach ($lines as $line) {
+        $trimmed = ltrim($line);
+        if (str_starts_with($trimmed, '//') || str_starts_with($trimmed, '*')) {
+            continue;
+        }
+        // Procura className que contém AMBAS classes na mesma string literal
+        if (preg_match('/className=["`][^"`]*\bsells-cowork\b[^"`]*\bsells-cowork-quotations\b[^"`]*["`]/', $line)) {
+            $hasWrapper = true;
+            break;
+        }
+    }
+    expect($hasWrapper)->toBeTrue();
+});
+
+it('Quotations.tsx contém marcador US-SELL-QUOTATIONS-COWORK', function () {
+    $source = quotationsRead(QUOTATIONS_TSX_PATH);
+    expect($source)->toContain('US-SELL-QUOTATIONS-COWORK');
+});
+
+it('Quotations.tsx renderiza badge "Orçamento" (vd-quote-badge)', function () {
+    $source = quotationsRead(QUOTATIONS_TSX_PATH);
+    expect($source)
+        ->toContain('vd-quote-badge')
+        ->toContain('Orçamento');
+});
+
+it('Quotations.tsx preserva funcionalidade core (props, fetch, atalhos N/Esc)', function () {
+    $source = quotationsRead(QUOTATIONS_TSX_PATH);
+    expect($source)
+        ->toContain('export default function SellsQuotations')
+        ->toContain('fetchQuotations')
+        ->toContain("if (e.key === 'n')")
+        ->toContain("if (e.key === 'Escape')")
+        ->toContain('SellsQuotations.layout');
+});
+
+it('Quotations.tsx preserva referência ADR canônicas (104, 149, 110, 143, 093)', function () {
+    $source = quotationsRead(QUOTATIONS_TSX_PATH);
+    expect($source)
+        ->toContain('ADR 0104')
+        ->toContain('ADR 0149')
+        ->toContain('ADR 0110')
+        ->toContain('ADR 0143')
+        ->toContain('ADR 0093');
+});
+
+// ─── Charter preservado ──────────────────────────────────────────────
+
+it('Quotations.charter.md preserva Mission + page header (frontmatter intacto)', function () {
+    $source = quotationsRead(QUOTATIONS_CHARTER_PATH);
+    expect($source)
+        ->toContain('page: /sells/quotations')
+        ->toContain('component: resources/js/Pages/Sells/Quotations.tsx')
+        ->toContain('# Page Charter — /sells/quotations')
+        ->toContain('## Mission');
+});
+
+// ─── Anti-pattern: áreas proibidas intactas ──────────────────────────
+
+it('Index.tsx NÃO foi tocado por esta Onda (área proibida do agent vizinho)', function () {
+    $source = quotationsRead(QUOTATIONS_INDEX_TSX_PATH);
+    // Garante que Index NÃO recebeu marcador específico de Quotations (sinal de invasão)
+    expect($source)
+        ->not->toContain('US-SELL-QUOTATIONS-COWORK')
+        ->not->toContain('sells-cowork-quotations');
+});
+
+it('sells-cowork.css canon família Index intacta (não recebeu tokens orçamento)', function () {
+    $source = quotationsRead(QUOTATIONS_FAMILY_CSS_PATH);
+    expect($source)
+        ->not->toContain('--vd-quote-amber')
+        ->not->toContain('--vd-quote-convert')
+        ->not->toContain('vd-quote-badge');
+});


### PR DESCRIPTION
## Resumo

**A3** da execução paralela A+C — aplica Cowork visual em `resources/js/Pages/Sells/Quotations.tsx` (lista orçamentos) reusando família CSS já mergeada do Sells/Index via cascata.

## Mudanças

| Arquivo | LOC | Tipo |
|---|---|---|
| `resources/css/sells-cowork-quotations.css` | 108 | NOVO extensões mínimas |
| `resources/js/Pages/Sells/Quotations.tsx` | +diff | Wrapper duplo + badge Orçamento |
| `resources/css/inertia.css` | +3 | @import |
| `tests/Feature/Sells/SellsQuotationsCoworkTest.php` | ~250 | NOVO Pest 17 testes |

## Smoke (R1 PROTOCOLO)

- ✅ Pest: **17 passed (48 assertions)** em 82.81s
- ✅ TS check: zero erro novo em Quotations.tsx

## NÃO INCLUI

Novo Controller, novos endpoints, mudança Index/Show/Edit/Drafts/Subscriptions/Create, mudança família CSS Index. Cobertura puramente visual scoped.

## Refs

US-SELL-QUOTATIONS-COWORK · ADR 0104 · ADR 0107

🤖 Generated with Claude Code