### PR TITLE
feat(sells): Audit Trail FSM real via sale_stage_history (Onda 3.5)

### DIFF
--- a/app/Http/Controllers/SellAuditController.php
+++ b/app/Http/Controllers/SellAuditController.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Domain\Fsm\Models\SaleStageHistory;
+use App\Transaction;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * US-SELL-COWORK-R3-CURADORIA Onda 3.5 — Audit Trail FSM real.
+ *
+ * GET /sells/{sale}/audit → retorna histórico de transições FSM
+ *   (sale_stage_history) já formatado pra consumo direto pelo componente
+ *   resources/js/Pages/Sells/_components/SaleAuditTrail.tsx.
+ *
+ * Diferença vs SaleHistoryController (/api/sells/{id}/history):
+ *   - History: payload "cru" (from_stage como objeto {key,name,color}) pro
+ *     componente <SaleTimeline /> que renderiza badges coloridos
+ *   - Audit: payload "flat amigável" (from_stage como label string) pro
+ *     componente compacto <SaleAuditTrail /> que renderiza linhas timeline
+ *
+ * Multi-tenant Tier 0 (ADR 0093): escopo explícito por session
+ *   `user.business_id` na query da Transaction + filtro `business_id` na
+ *   query do SaleStageHistory (defesa em profundidade contra cross-tenant).
+ *
+ * Sem novo middleware/permission — herda `['web','auth']` do grupo. Fallback
+ * Onda 3 (derivação determinística no frontend) permanece via prop opcional
+ * `realApiUrl` em SaleAuditTrail.tsx (sem realApiUrl → modo determinístico).
+ *
+ * Refs:
+ *   - ADR 0143 FSM Pipeline LIVE prod biz=1
+ *   - Onda 3 R3 Curadoria (PR #1041)
+ */
+class SellAuditController extends Controller
+{
+    public function show(Request $request, int $sale): JsonResponse
+    {
+        if (! auth()->check()) {
+            abort(Response::HTTP_UNAUTHORIZED);
+        }
+
+        $businessId = (int) $request->session()->get('user.business_id');
+
+        // Tier 0 multi-tenant: confirma que sale pertence ao business
+        // ANTES de tocar sale_stage_history (defesa em profundidade).
+        $venda = Transaction::where('business_id', $businessId)
+            ->where('type', 'sell')
+            ->find($sale);
+
+        if (! $venda) {
+            return response()->json(['error' => 'Venda não encontrada'], 404);
+        }
+
+        $items = SaleStageHistory::query()
+            ->where('business_id', $businessId)
+            ->where('transaction_id', $venda->id)
+            ->with([
+                'action:id,key,label',
+                'fromStage:id,key,name',
+                'toStage:id,key,name',
+            ])
+            ->orderBy('executed_at', 'asc')
+            ->limit(200)
+            ->get();
+
+        // user_id → username resolve manual (sem relationship em SaleStageHistory
+        // pra evitar dependência circular com User; query 1+1 controlada — mesmo
+        // pattern já adotado em SaleHistoryController).
+        $userIds = $items->pluck('user_id')->filter()->unique()->values();
+        $userNames = \DB::table('users')
+            ->whereIn('id', $userIds)
+            ->get(['id', 'first_name', 'surname', 'username'])
+            ->keyBy('id');
+
+        $history = $items->map(function (SaleStageHistory $h) use ($userNames): array {
+            $userName = 'sistema';
+            if ($h->user_id && isset($userNames[$h->user_id])) {
+                $u = $userNames[$h->user_id];
+                $fullName = trim(($u->first_name ?? '') . ' ' . ($u->surname ?? ''));
+                $userName = $fullName !== '' ? $fullName : ($u->username ?? 'sistema');
+            }
+
+            return [
+                'id' => $h->id,
+                'when' => $h->executed_at?->toIso8601String(),
+                'from_stage' => $h->fromStage?->name,
+                'to_stage' => $h->toStage?->name ?? '—',
+                'action' => $h->action?->label ?? 'Pipeline iniciado',
+                'action_key' => $h->action?->key,
+                'user_name' => $userName,
+            ];
+        });
+
+        return response()->json([
+            'venda_id' => $venda->id,
+            'invoice_no' => $venda->invoice_no,
+            'count' => $history->count(),
+            'history' => $history,
+        ]);
+    }
+}

--- a/resources/js/Pages/Sells/_components/SaleAuditTrail.tsx
+++ b/resources/js/Pages/Sells/_components/SaleAuditTrail.tsx
@@ -1,21 +1,25 @@
-// SaleAuditTrail — Cowork KB-9.75 Sells Onda 3 R3 Curadoria
-// (histórico de edições + emissões fiscais + transições FSM).
+// SaleAuditTrail — Cowork KB-9.75 Sells Onda 3 R3 Curadoria + Onda 3.5
+// (histórico de edições + emissões fiscais + transições FSM REAIS).
 //
 // Refs:
 //  - prototipo-ui/prototipos/sells-index/vendas-curation.jsx (canonical source)
 //  - sale_stage_history table (ADR 0143 FSM Pipeline live biz=1)
-//  - SellController::sheetData (futuro: retornará audit_trail real)
+//  - GET /sells/{sale}/audit → SellAuditController (Onda 3.5)
 //
-// Esta Onda: render frontend determinístico baseado no SaleDetail (cria/edita/
-// emite). Onda 3.5 plugará em sale_stage_history + transaction audit log real.
+// Modos suportados:
+//  1) DETERMINÍSTICO (Onda 3 — default): prop `venda: SaleAuditInput` → render
+//     entries derivadas no frontend (create/payment/fiscal/reject).
+//  2) REAL FSM (Onda 3.5 — opt-in): prop `realApiUrl` → fetch
+//     /sells/{id}/audit e render entries reais de sale_stage_history. Em caso
+//     de erro/loading, faz fallback pro modo determinístico (preserva UX).
 
-import { useMemo, type ReactNode } from 'react';
-import { Plus, Pencil, FileText, AlertTriangle, CheckCircle2 } from 'lucide-react';
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+import { Plus, Pencil, FileText, AlertTriangle, CheckCircle2, GitBranch } from 'lucide-react';
 
 interface AuditEntry {
   when: string;
   who: string;
-  kind: 'create' | 'edit' | 'fiscal' | 'reject' | 'payment';
+  kind: 'create' | 'edit' | 'fiscal' | 'reject' | 'payment' | 'fsm';
   desc: string;
   diff?: { from: number; to: number; pct: number };
 }
@@ -34,6 +38,24 @@ interface SaleAuditInput {
   fiscal_emitted_at?: string | null;
   fiscal_fail_reason?: string | null;
   current_stage_label?: string | null;
+}
+
+// Payload retornado por SellAuditController (Onda 3.5).
+interface FsmHistoryEntry {
+  id: number;
+  when: string | null;
+  from_stage: string | null;
+  to_stage: string;
+  action: string;
+  action_key: string | null;
+  user_name: string;
+}
+
+interface FsmAuditResponse {
+  venda_id: number;
+  invoice_no: string;
+  count: number;
+  history: FsmHistoryEntry[];
 }
 
 function buildEntries(venda: SaleAuditInput): AuditEntry[] {
@@ -91,6 +113,21 @@ function buildEntries(venda: SaleAuditInput): AuditEntry[] {
   return entries.sort((a, b) => a.when.localeCompare(b.when));
 }
 
+// Onda 3.5 — converte payload real de sale_stage_history pra AuditEntry.
+function fsmHistoryToEntries(history: FsmHistoryEntry[]): AuditEntry[] {
+  return history.map((h) => {
+    const transitionDesc = h.from_stage
+      ? `${h.action} · ${h.from_stage} → ${h.to_stage}`
+      : `${h.action} · → ${h.to_stage}`;
+    return {
+      when: formatDateTime(h.when ?? null),
+      who: h.user_name || 'sistema',
+      kind: 'fsm' as const,
+      desc: transitionDesc,
+    };
+  });
+}
+
 function formatDateTime(iso: string | null | undefined): string {
   if (!iso) return '—';
   const d = new Date(iso);
@@ -110,6 +147,7 @@ const KIND_ICON: Record<AuditEntry['kind'], ReactNode> = {
   fiscal: <FileText size={11} />,
   reject: <AlertTriangle size={11} />,
   payment: <CheckCircle2 size={11} />,
+  fsm: <GitBranch size={11} />,
 };
 
 const KIND_LABEL: Record<AuditEntry['kind'], string> = {
@@ -118,20 +156,94 @@ const KIND_LABEL: Record<AuditEntry['kind'], string> = {
   fiscal: 'fiscal',
   reject: 'erro',
   payment: 'pagou',
+  fsm: 'pipeline',
 };
 
 interface Props {
   venda: SaleAuditInput;
+  /**
+   * Onda 3.5 — se setado, faz fetch GET nessa URL pra buscar entries reais
+   * de sale_stage_history (Controller SellAuditController). Em erro/timeout
+   * cai automaticamente no fallback determinístico (preserva UX).
+   * Ex: `/sells/123/audit`
+   */
+  realApiUrl?: string;
 }
 
-export default function SaleAuditTrail({ venda }: Props): ReactNode {
-  const entries = useMemo(() => buildEntries(venda), [venda]);
+export default function SaleAuditTrail({ venda, realApiUrl }: Props): ReactNode {
+  const fallbackEntries = useMemo(() => buildEntries(venda), [venda]);
+  const [realEntries, setRealEntries] = useState<AuditEntry[] | null>(null);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (!realApiUrl) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(false);
+    fetch(realApiUrl, {
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json' },
+    })
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json() as Promise<FsmAuditResponse>;
+      })
+      .then((json) => {
+        if (cancelled) return;
+        const entries = fsmHistoryToEntries(json.history || []);
+        setRealEntries(entries);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setError(true);
+        setRealEntries(null);
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [realApiUrl]);
+
+  // Estratégia de fallback (Onda 3.5):
+  //  - sem realApiUrl → sempre determinístico (modo Onda 3 original)
+  //  - com realApiUrl + dados reais OK → real
+  //  - com realApiUrl + erro → determinístico (UX preservada)
+  //  - com realApiUrl + carregando → skeleton
+  const usingReal = !!realApiUrl && realEntries !== null && !error;
+  const entries = usingReal ? (realEntries as AuditEntry[]) : fallbackEntries;
+
+  if (loading && realApiUrl) {
+    return (
+      <div className="vd-audit">
+        <div className="vd-audit-h">
+          <h4>Histórico</h4>
+          <small>carregando auditoria FSM…</small>
+        </div>
+        <ul className="vd-audit-list">
+          <li className="vd-audit-row vd-audit-skeleton">
+            <span className="vd-audit-ic">⋯</span>
+            <div className="vd-audit-body">
+              <header><b>—</b><time>—</time></header>
+              <p>carregando…</p>
+            </div>
+          </li>
+        </ul>
+      </div>
+    );
+  }
+
   if (entries.length === 0) return null;
   return (
     <div className="vd-audit">
       <div className="vd-audit-h">
         <h4>Histórico</h4>
-        <small>{entries.length} entrada{entries.length === 1 ? '' : 's'} · auditoria</small>
+        <small>
+          {entries.length} entrada{entries.length === 1 ? '' : 's'} · auditoria
+          {usingReal ? ' · FSM real' : ''}
+        </small>
       </div>
       <ul className="vd-audit-list">
         {entries.map((e, i) => (
@@ -163,4 +275,4 @@ export default function SaleAuditTrail({ venda }: Props): ReactNode {
   );
 }
 
-export type { SaleAuditInput };
+export type { SaleAuditInput, FsmHistoryEntry, FsmAuditResponse };

--- a/routes/web.php
+++ b/routes/web.php
@@ -272,6 +272,10 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     // US-SELL-035 — Timeline FSM (sale_stage_history) pra drawer e auditoria.
     Route::get('/api/sells/{id}/history', [\App\Http\Controllers\SaleHistoryController::class, 'index'])
         ->name('sells.history');
+    // US-SELL-COWORK-R3-CURADORIA Onda 3.5 — Audit Trail FSM real (formato flat
+    // amigável pro componente SaleAuditTrail.tsx). Multi-tenant Tier 0.
+    Route::get('/sells/{sale}/audit', [\App\Http\Controllers\SellAuditController::class, 'show'])
+        ->name('sells.audit');
     // Wire-up UI FSM — actions disponíveis no stage atual + execute transição.
     Route::get('/api/sells/{id}/fsm-actions', [\App\Http\Controllers\SaleFsmActionController::class, 'actions'])
         ->name('sells.fsm-actions');

--- a/tests/Feature/Sells/SellsAuditTrailRealTest.php
+++ b/tests/Feature/Sells/SellsAuditTrailRealTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest — US-SELL-COWORK-R3-CURADORIA Onda 3.5 — Audit Trail FSM real.
+ *
+ * Cobertura estrutural (file_get_contents + ReflectionClass) — garante que:
+ *  - Controller SellAuditController existe com método show()
+ *  - Multi-tenant Tier 0 (ADR 0093): scope explícito por business_id
+ *  - Rota /sells/{sale}/audit registrada com FQCN (ADR rule routes.md)
+ *  - SaleAuditTrail.tsx aceita prop opcional realApiUrl
+ *  - Fallback determinístico preservado (sem realApiUrl continua igual Onda 3)
+ *
+ * Refs:
+ *  - app/Http/Controllers/SellAuditController.php
+ *  - routes/web.php (linha sells.audit)
+ *  - resources/js/Pages/Sells/_components/SaleAuditTrail.tsx
+ *  - ADR 0143 FSM Pipeline LIVE prod biz=1
+ */
+
+const ONDA35_CTRL_PATH = 'app/Http/Controllers/SellAuditController.php';
+const ONDA35_ROUTES_PATH = 'routes/web.php';
+const ONDA35_AUDIT_TSX_PATH = 'resources/js/Pages/Sells/_components/SaleAuditTrail.tsx';
+
+function onda35Read(string $rel): string
+{
+    return file_get_contents(base_path($rel));
+}
+
+// ─── Controller existe + estrutura ────────────────────────────────────
+
+it('SellAuditController file existe no path canônico', function () {
+    expect(file_exists(base_path(ONDA35_CTRL_PATH)))->toBeTrue();
+});
+
+it('SellAuditController class existe + tem método show', function () {
+    expect(class_exists(\App\Http\Controllers\SellAuditController::class))->toBeTrue();
+    expect(method_exists(\App\Http\Controllers\SellAuditController::class, 'show'))->toBeTrue();
+});
+
+it('SellAuditController estende Controller base', function () {
+    $ref = new ReflectionClass(\App\Http\Controllers\SellAuditController::class);
+    expect($ref->getParentClass()?->getName())->toBe(\App\Http\Controllers\Controller::class);
+});
+
+it('SellAuditController::show tem assinatura (Request, int sale): JsonResponse', function () {
+    $ref = new ReflectionMethod(\App\Http\Controllers\SellAuditController::class, 'show');
+    $params = $ref->getParameters();
+    expect($params)->toHaveCount(2);
+    expect($params[0]->getName())->toBe('request');
+    expect($params[1]->getName())->toBe('sale');
+    expect($params[1]->getType()?->getName())->toBe('int');
+    expect($ref->getReturnType()?->getName())->toBe(\Illuminate\Http\JsonResponse::class);
+});
+
+// ─── Multi-tenant Tier 0 (ADR 0093) ───────────────────────────────────
+
+it('SellAuditController aplica multi-tenant Tier 0 (business_id scope explícito)', function () {
+    $source = onda35Read(ONDA35_CTRL_PATH);
+    expect($source)
+        ->toContain("session()->get('user.business_id')")
+        ->toContain("where('business_id', \$businessId)")
+        ->toContain("Transaction::where('business_id', \$businessId)");
+});
+
+it('SellAuditController filtra type=sell pra não vazar compras/devoluções', function () {
+    $source = onda35Read(ONDA35_CTRL_PATH);
+    expect($source)->toContain("where('type', 'sell')");
+});
+
+it('SellAuditController consulta sale_stage_history canônica (ADR 0143)', function () {
+    $source = onda35Read(ONDA35_CTRL_PATH);
+    expect($source)
+        ->toContain('SaleStageHistory::query()')
+        ->toContain("where('transaction_id', \$venda->id)")
+        ->toContain("orderBy('executed_at', 'asc')");
+});
+
+it('SellAuditController retorna 404 se venda não existe ou cross-tenant', function () {
+    $source = onda35Read(ONDA35_CTRL_PATH);
+    expect($source)
+        ->toContain("'Venda não encontrada'")
+        ->toContain('], 404);');
+});
+
+it('SellAuditController retorna 401 se não autenticado', function () {
+    $source = onda35Read(ONDA35_CTRL_PATH);
+    expect($source)
+        ->toContain('auth()->check()')
+        ->toContain('Response::HTTP_UNAUTHORIZED');
+});
+
+// ─── Payload formato esperado pelo componente ─────────────────────────
+
+it('SellAuditController retorna formato flat amigável { id, when, from_stage, to_stage, action, user_name }', function () {
+    $source = onda35Read(ONDA35_CTRL_PATH);
+    expect($source)
+        ->toContain("'id' => \$h->id")
+        ->toContain("'when' => \$h->executed_at?->toIso8601String()")
+        ->toContain("'from_stage' => \$h->fromStage?->name")
+        ->toContain("'to_stage' => \$h->toStage?->name ?? '—'")
+        ->toContain("'action' => \$h->action?->label ?? 'Pipeline iniciado'")
+        ->toContain("'user_name' => \$userName");
+});
+
+it('SellAuditController eager-load minimalista (action,fromStage,toStage)', function () {
+    $source = onda35Read(ONDA35_CTRL_PATH);
+    expect($source)
+        ->toContain("'action:id,key,label'")
+        ->toContain("'fromStage:id,key,name'")
+        ->toContain("'toStage:id,key,name'");
+});
+
+// ─── Rota registrada com FQCN ─────────────────────────────────────────
+
+it('Rota /sells/{sale}/audit registrada com FQCN (ADR rule routes.md)', function () {
+    $source = onda35Read(ONDA35_ROUTES_PATH);
+    expect($source)
+        ->toContain("Route::get('/sells/{sale}/audit'")
+        ->toContain('\App\Http\Controllers\SellAuditController::class')
+        ->toContain("->name('sells.audit')");
+});
+
+it('Rota sells.audit aparece em route:list', function () {
+    $routes = collect(\Illuminate\Support\Facades\Route::getRoutes()->getRoutes())
+        ->map(fn ($r) => $r->getName())
+        ->filter()
+        ->values()
+        ->toArray();
+    expect($routes)->toContain('sells.audit');
+});
+
+// ─── Frontend: SaleAuditTrail.tsx aceita realApiUrl + preserva fallback ──
+
+it('SaleAuditTrail.tsx aceita prop opcional realApiUrl', function () {
+    $source = onda35Read(ONDA35_AUDIT_TSX_PATH);
+    expect($source)
+        ->toContain('realApiUrl?: string')
+        ->toContain('realApiUrl?: string;');
+});
+
+it('SaleAuditTrail.tsx fetcha realApiUrl com credentials same-origin', function () {
+    $source = onda35Read(ONDA35_AUDIT_TSX_PATH);
+    expect($source)
+        ->toContain('fetch(realApiUrl,')
+        ->toContain("credentials: 'same-origin'")
+        ->toContain("Accept: 'application/json'");
+});
+
+it('SaleAuditTrail.tsx tem tipos FsmHistoryEntry + FsmAuditResponse', function () {
+    $source = onda35Read(ONDA35_AUDIT_TSX_PATH);
+    expect($source)
+        ->toContain('interface FsmHistoryEntry')
+        ->toContain('interface FsmAuditResponse')
+        ->toContain('export type { SaleAuditInput, FsmHistoryEntry, FsmAuditResponse }');
+});
+
+it('SaleAuditTrail.tsx preserva buildEntries determinístico (fallback Onda 3)', function () {
+    $source = onda35Read(ONDA35_AUDIT_TSX_PATH);
+    // Mesmas asserções do SellsOnda3CuradoriaTest pra garantir que fallback
+    // continua funcional após refactor.
+    expect($source)
+        ->toContain("kind: 'create'")
+        ->toContain("kind: 'payment'")
+        ->toContain("kind: 'fiscal'")
+        ->toContain("kind: 'reject'")
+        ->toContain("'autorizada'")
+        ->toContain("'rejeitada'")
+        ->toContain('function buildEntries(venda: SaleAuditInput)');
+});
+
+it('SaleAuditTrail.tsx sem realApiUrl usa modo determinístico (UX preservada)', function () {
+    $source = onda35Read(ONDA35_AUDIT_TSX_PATH);
+    expect($source)
+        ->toContain('if (!realApiUrl) return;')
+        ->toContain('usingReal ? (realEntries as AuditEntry[]) : fallbackEntries');
+});
+
+it('SaleAuditTrail.tsx fallback em erro fetch (UX preservada)', function () {
+    $source = onda35Read(ONDA35_AUDIT_TSX_PATH);
+    expect($source)
+        ->toContain('.catch(()')
+        ->toContain('setError(true)')
+        ->toContain('setRealEntries(null)');
+});
+
+it('SaleAuditTrail.tsx novo kind fsm tem icon + label', function () {
+    $source = onda35Read(ONDA35_AUDIT_TSX_PATH);
+    expect($source)
+        ->toContain("kind: 'fsm'")
+        ->toContain('GitBranch')
+        ->toContain("fsm: 'pipeline'");
+});
+
+it('SaleAuditTrail.tsx fsmHistoryToEntries converte payload real pra AuditEntry', function () {
+    $source = onda35Read(ONDA35_AUDIT_TSX_PATH);
+    expect($source)
+        ->toContain('function fsmHistoryToEntries(history: FsmHistoryEntry[]): AuditEntry[]')
+        ->toContain('h.from_stage')
+        ->toContain('h.to_stage')
+        ->toContain('h.action');
+});
+
+it('SaleAuditTrail.tsx default export preservado (back-compat consumidores)', function () {
+    $source = onda35Read(ONDA35_AUDIT_TSX_PATH);
+    expect($source)
+        ->toContain('export default function SaleAuditTrail(')
+        ->toContain('export type { SaleAuditInput');
+});


### PR DESCRIPTION
## Resumo

**C3** da execução paralela A+C — plug real do `SaleAuditTrail.tsx` (mergeado em PR #1041 com fonte derivada frontend) em `sale_stage_history` (tabela FSM canônica ADR 0143 live prod biz=1) via novo endpoint.

## Backend

- **`app/Http/Controllers/SellAuditController.php`** (NOVO 4 KB)
  - Multi-tenant Tier 0 **explícito**: `session('user.business_id')` + `->where('business_id', $businessId)` em Transaction E SaleStageHistory (defesa em profundidade ADR 0093)
  - Eager-load minimalista (action/fromStage/toStage)
  - Resposta JSON shape flat amigável pro frontend
- **`routes/web.php`** — `GET /sells/{sale}/audit` FQCN

## Frontend

- **`SaleAuditTrail.tsx`** refactor opt-in:
  - Prop nova opcional `realApiUrl?: string`
  - Se setada → `useEffect` fetch + setState real
  - Fallback automático ao modo determinístico em erro/loading
  - **Back-compat 100%**: chamadas existentes sem `realApiUrl` continuam idênticas

## Smoke

- ✅ Pest novo: **22 passed (62 assertions)** em 6.13s
- ✅ Pest regression Onda 3: **23 passed** em 7.92s (não quebrou nada)
- ✅ `route:list | grep sells.audit` → registrado
- ✅ TS check: zero erro novo em SaleAuditTrail.tsx

## NÃO INCLUI

Rate-limit middleware, WebSocket live updates, retenção LGPD payload_snapshot, OpenTelemetry span, badge recência relativa, **ativação no SaleSheet consumidor** (PR follow-up trocando `<SaleAuditTrail/>` pra passar `realApiUrl=\`).

## Refs

ADR 0143 FSM canônico · ADR 0093 multi-tenant Tier 0 · PR #1041

🤖 Generated with Claude Code


## Infra Contract

Toca `routes/web.php` — path crítico per `memory/proibicoes.md` §"Claim sem evidência".

### Happy path curl (smoke prod pós-deploy SSH Hostinger)

```bash
# Não autenticado → 302 redirect login
curl -sv -o /dev/null --max-time 30 "https://oimpresso.com/sells/1/audit" 2>&1 | grep "^< HTTP\|^< Location"
# Esperado:
# < HTTP/1.1 302 Found
# < Location: https://oimpresso.com/login

# Autenticado biz=1, sale existente → 200 JSON {venda_id, invoice_no, history:[]}
# Autenticado biz=1, sale de outro tenant → 404 (Tier 0 escopo)
```

### Regression adjacent

- `GET /api/sells/{id}/history` → continua funcionando (timeline FSM diferente endpoint)
- `GET /api/sells/{id}/fsm-actions` → continua (Wire-up FSM separado)
- `POST /sells/{id}/fsm-action` → continua (executor FSM separado)

### Environment delta

- Endpoint puro Eloquent — funciona idêntico em Hostinger / CT 100 / Local
- Multi-tenant Tier 0 EXPLÍCITO no Controller (não depende global scope)
- Sem dependência externa, sem Chrome, sem rate-limit (catalogado em NÃO INCLUI)
