### PR TITLE
feat(sells): plug SaleAuditTrail em /sells/{id}/audit real (P0)

### DIFF
--- a/resources/js/Pages/Sells/_components/SaleSheet.tsx
+++ b/resources/js/Pages/Sells/_components/SaleSheet.tsx
@@ -673,7 +673,13 @@ export default function SaleSheet({
                   Render frontend determinístico baseado em SaleDetail.
                   Onda 3.5 plugará em sale_stage_history real (ADR 0143 FSM). */}
               <div className="sells-cowork-curadoria">
+                {/* US-SELL-COWORK-R3-CURADORIA Onda 3.5 (PR #1051 plug) —
+                    plugado em sale_stage_history real via endpoint
+                    /sells/{id}/audit (ADR 0143 FSM live prod biz=1).
+                    Em erro/loading, SaleAuditTrail faz fallback
+                    automático pro modo determinístico via prop `venda`. */}
                 <SaleAuditTrail
+                  realApiUrl={`/sells/${data.id}/audit`}
                   venda={
                     {
                       id: data.id,


### PR DESCRIPTION
## Resumo

**P0 follow-up** de PR #1051 — passa prop `realApiUrl` pro SaleAuditTrail no SaleSheet drawer.

Agora o painel mostra transições FSM reais de `sale_stage_history` (ADR 0143 live prod biz=1) em vez do modo determinístico frontend.

Fallback automático preservado em erro fetch ou loading.

Mudança: 6 linhas em SaleSheet.tsx (1 prop nova + comentário).

## Refs

PR #1051 Audit Trail FSM real · ADR 0143

🤖 Generated with Claude Code