### PR TITLE
feat(prototipo-ui): KB-9.75 em Vendas e Financeiro · 9,75/10 ambos

### DIFF
--- a/prototipo-ui/COWORK_NOTES.md
+++ b/prototipo-ui/COWORK_NOTES.md
@@ -266,3 +266,24 @@ Fallback aceito se `bg-primary` ficar pesado em densidade alta da lista de conve
 
 [CL] F3 só depois F2 — substitui `Cockpit.tsx` in-place + sub-componentes em `Pages/Jana/_components/Cockpit/` + 7 Pest GUARDs (R-JANA-COCKPIT-001..007 spec no charter).
 
+
+---
+
+### 2026-05-18 — Vendas + Financeiro · método KB-9.75 completo
+
+**Branch:** `feat/vendas-financeiro-kb-9.75`
+**PR:** #1064
+**Score:** Vendas 9,75/10 · Financeiro 9,75/10
+**Reuso:** ~70% dos componentes do Financeiro vieram do Vendas
+
+**Pra Code:**
+1. Mergear o PR após screenshot approval (Wagner)
+2. Atualizar `SYNC_LOG.md` apontando este sync como v2 da aplicação do método
+3. Atualizar `TELAS_REVIEW_QUEUE.md`: marcar Sells/Index, Sells/Create e Financeiro/Unified como **done · A+** (≥9,5)
+
+**Próximas aplicações sugeridas:**
+- CRM (persona Bruna · score atual ~6,5)
+- Compras (persona Wagner+Bruna · liga com Financeiro já feito)
+- Equipe / Chat interno (persona times · multi-canal)
+
+[PROCESSADO 2026-05-18]

--- a/prototipo-ui/Oimpresso ERP - Chat.html
+++ b/prototipo-ui/Oimpresso ERP - Chat.html
@@ -1,0 +1,105 @@
+<!doctype html>
+<html lang="pt-BR">
+<head>
+<style data-omelette-injected>html,body{background:transparent}</style><script data-omelette-injected>(()=>{var j=["https://claude.ai","https://preview.claude.ai"];var x=true;var S=30000;var f=3000;document.addEventListener("DOMContentLoaded",()=>{const H=window.Babel;const G="om-src-id";if(H&&H.registerPlugin&&!(H.availablePlugins&&H.availablePlugins[G])){H.registerPlugin(G,({types:Y})=>({visitor:{JSXOpeningElement(U,Q){const J=U.node;if(J.name&&J.name.type==="JSXMemberExpression")return;for(let V=0;V<J.attributes.length;V++){const L=J.attributes[V];if(L.type==="JSXAttribute"&&L.name&&L.name.name==="data-om-id")return}const W=Q.file&&Q.file.opts&&Q.file.opts.filename||"?";const Z=J.loc&&J.loc.start;const z=`jsx:${W}:${J.start??0}:${Z?Z.line:0}:${Z?Z.column+1:0}`;J.attributes.push(Y.jsxAttribute(Y.jsxIdentifier("data-om-id"),Y.stringLiteral(z)))}}}))}const k="om-text-extract";let A=false;if(x&&H&&H.registerPlugin&&!(H.availablePlugins&&H.availablePlugins[k])){const Y=window.React;if(Y&&Y.useSyncExternalStore&&Y.createElement){A=true;const U={};const Q=new Set;let J=0;window.__omTextO=U;window.__omTextSet=(z)=>{for(const V in z){const L=z[V];if(L==null)delete U[V];else U[V]=L}J++;Q.forEach((V)=>V())};const W=(z)=>{Q.add(z);return()=>Q.delete(z)};const Z=()=>J;window.__OmT=function z(V){Y.useSyncExternalStore(W,Z,Z);return Y.createElement("span",{"data-om-text":V.i,className:"__om-t"},V.i in U?U[V.i]:V.children)};H.registerPlugin(k,({types:z})=>{const V={style:1,script:1,noscript:1,textarea:1,title:1,option:1,text:1,tspan:1,textPath:1};const L={placeholder:1,alt:1,title:1,label:1,"aria-label":1,"aria-description":1,"aria-placeholder":1};const _=($,C)=>z.logicalExpression("??",z.memberExpression(z.logicalExpression("||",z.memberExpression(z.identifier("window"),z.identifier("__omTextO")),z.objectExpression([])),z.stringLiteral($),true),C);const E=($)=>$.file&&$.file.opts&&$.file.opts.filename||"?";const B=($)=>$.file&&$.file.code||"";const b=($,C)=>{const X=(F)=>F&&F.start!=null&&F.end!=null&&(F.type==="StringLiteral"||F.type==="TemplateLiteral"&&F.expressions.length===0)?[F.start,F.end]:null;const N=X(C);if(N)return N;if(C&&C.type==="Identifier"){const F=$.scope.getBinding(C.name);if(F&&F.constant&&F.path.node.type==="VariableDeclarator"){return X(F.path.node.init)}}return null};const M=($,C,X)=>{const N=$.node;let F=false;const w=(K,q)=>{F=true;return z.jsxElement(z.jsxOpeningElement(z.jsxIdentifier("__OmT"),[z.jsxAttribute(z.jsxIdentifier("i"),z.stringLiteral(K))],false),z.jsxClosingElement(z.jsxIdentifier("__OmT")),[q],false)};const D=N.children.map((K)=>{if(K.type==="JSXText"){if(K.start==null||K.end==null)return K;const q=X.slice(K.start,K.end);const R=q.length-q.trimStart().length;const m=q.length-q.trimEnd().length;if(R+m>=q.length)return K;return w(`txt:${C}:${K.start+R}:${K.end-m}`,K)}if(K.type==="JSXExpressionContainer"){const q=b($,K.expression);if(q)return w(`str:${C}:${q[0]}:${q[1]}`,K)}return K});if(F)N.children=D};return{visitor:{JSXOpeningElement($,C){const X=$.node;const N=E(C);const F={};for(let w=0;w<X.attributes.length;w++){const D=X.attributes[w];if(D.type!=="JSXAttribute"||!D.name)continue;const K=D.name.name;if(!L[K])continue;if(!D.value||D.value.type!=="StringLiteral")continue;if(D.value.start==null||D.value.end==null)continue;const q=`txt:${N}:${D.value.start}:${D.value.end}`;F[K]=q;D.value=z.jsxExpressionContainer(_(q,z.stringLiteral(D.value.value)))}if(Object.keys(F).length){X.attributes.push(z.jsxAttribute(z.jsxIdentifier("data-om-text-attrs"),z.stringLiteral(JSON.stringify(F))))}},JSXElement($,C){const X=$.node.openingElement;const N=X&&X.name&&X.name.name;if(N==="__OmT")return;if(typeof N==="string"&&V[N])return;M($,E(C),B(C))},JSXFragment($,C){M($,E(C),B(C))}}}})}}const u=A?["transform-react-jsx-source",G,k]:["transform-react-jsx-source",G];document.querySelectorAll('script[type="text/babel"],script[type="text/jsx"]').forEach((Y,U)=>{const Q=Y.getAttribute("data-plugins")||"";const J=u.filter((W)=>Q.indexOf(W)<0);if(J.length){Y.setAttribute("data-plugins",Q?`${Q},${J.join(",")}`:J.join(","))}if(!Y.hasAttribute("data-filename")){Y.setAttribute("data-filename",Y.getAttribute("src")||`inline-${U}`)}})});var y=window.parent;if(y&&y!==window){const H=(Q,J)=>{try{y.postMessage({__omelette_log:true,type:Q,data:J},"*")}catch{}};["log","warn","error"].forEach((Q)=>{const J=console[Q];console[Q]=(...W)=>{const Z=W.map((z)=>{try{return typeof z==="object"?JSON.stringify(z):String(z)}catch{try{return String(z)}catch{return"[unstringifiable]"}}}).join(" ");H(Q,Z);J.apply(console,W)}});window.addEventListener("error",(Q)=>{const J=Q.target;if(J&&J!==window&&J.tagName){const W=J.src||J.href||"";H("resource_error",`${J.tagName} failed to load: ${W}`)}else{H("error",`${Q.message||"Unknown error"} at ${Q.filename||"?"}:${Q.lineno||0}:${Q.colno||0}`)}},true);window.addEventListener("unhandledrejection",(Q)=>{const J=Q.reason;const W=J instanceof Error?`${J.message} ${J.stack}`:String(J);H("error",`Unhandled rejection: ${W}`)});const G=()=>{try{y.postMessage({type:"omelette:height",height:document.documentElement.scrollHeight},"*")}catch{}};if(document.readyState==="complete")G();else window.addEventListener("load",G);if(window.ResizeObserver)new ResizeObserver(G).observe(document.documentElement);const k={};let A=0;window.claude={complete(Q){return new Promise((J,W)=>{if(!j.length){W(new Error("claude.complete: no parent origin"));return}const Z=`c${++A}`;const z=()=>setTimeout(()=>{delete k[Z];W(new Error(`claude.complete: no data for ${S/1000}s`))},S);const V=z();k[Z]={resolve:J,reject:W,text:"",t:V,arm:z};try{for(const L of j){y.postMessage({__om_api:true,id:Z,body:Q},L)}}catch(L){clearTimeout(V);delete k[Z];W(L)}})}};const u={};let Y=0;window.omelette={writeFile:(Q,J)=>new Promise((W,Z)=>{if(!j.length){W();return}const z=`f${++Y}`;const V=setTimeout(()=>{delete u[z];W()},f);u[z]={resolve:W,reject:Z,t:V};try{for(const L of j){y.postMessage({__om_file:true,id:z,op:"write",path:Q,content:J},L)}}catch{clearTimeout(V);delete u[z];W()}})};const U=(Q)=>{try{return JSON.stringify(Q)}catch{return JSON.stringify(String(Q))}};window.addEventListener("message",(Q)=>{if(j.indexOf(Q.origin)<0)return;if(Q.source!==y)return;const J=Q.data;if(!J)return;if(J.type==="omelette-preview-refresh"){if(typeof J.token!=="string"||!/^[0-9a-f.-]+$/.test(J.token))return;const z=Math.max(1,Math.floor((J.expiresAt||0)-Date.now()/1000));document.cookie="__Host-omelette-preview="+J.token+"; Path=/; Secure; SameSite=None; Partitioned; Max-Age="+z;return}if(J.__om_file_r){const z=u[J.id];if(!z)return;clearTimeout(z.t);delete u[J.id];if(J.ok)z.resolve();else z.reject(new Error(J.error||"write failed"));return}if(J.__om_api_r){const z=k[J.id];if(!z)return;if(J.error!=null){clearTimeout(z.t);delete k[J.id];z.reject(new Error(J.error));return}if(J.chunk!=null){clearTimeout(z.t);z.t=z.arm();z.text+=J.chunk;return}if(J.done){clearTimeout(z.t);delete k[J.id];z.resolve(J.text!=null?J.text:z.text);return}return}if(!J.__om_eval)return;const W=J;const Z=(z)=>{Q.source.postMessage({...z,__om_eval_r:1,id:W.id},Q.origin)};try{const z=(0,eval)(W.code);if(z&&typeof z.then==="function"){z.then((V)=>Z({ok:1,v:U(V)}),(V)=>Z({ok:0,e:String(V)}))}else{Z({ok:1,v:U(z)})}}catch(z){Z({ok:0,e:String(z)})}})}})();
+</script>
+
+<meta charset="utf-8"/>
+<meta name="viewport" content="width=device-width,initial-scale=1"/>
+<title>Oimpresso ERP — Chat</title>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+<link rel="stylesheet" href="styles.css"/>
+<link rel="stylesheet" href="compras-page.css"/>
+<link rel="stylesheet" href="oficina-page.css"/>
+<link rel="stylesheet" href="fin-boletos.css"/>
+<link rel="stylesheet" href="mockup-pages.css"/>
+<link rel="stylesheet" href="crm-page.css"/>
+<link rel="stylesheet" href="inbox-page.css"/>
+<link rel="stylesheet" href="equipe-page.css"/>
+<link rel="stylesheet" href="kb-page.css"/>
+<link rel="stylesheet" href="prod-page-extras.css"/>
+<link rel="stylesheet" href="prod-mec.css"/>
+<link rel="stylesheet" href="chat-jana.css"/>
+<!-- Tailwind CDN (preflight desligado pra não sobrescrever o styles.css do shell) -->
+<script src="https://cdn.tailwindcss.com"></script>
+<script>
+  tailwind.config = {
+    corePlugins: { preflight: false },
+    theme: {
+      extend: {
+        fontFamily: {
+          sans: ['"IBM Plex Sans"', 'system-ui', 'sans-serif'],
+          mono: ['"IBM Plex Mono"', 'ui-monospace', 'SFMono-Regular', 'monospace'],
+        },
+      },
+    },
+  };
+</script>
+<script src="https://unpkg.com/react@18.3.1/umd/react.development.js" integrity="sha384-hD6/rw4ppMLGNu3tX5cjIb+uRZ7UkRJ6BPkLpg4hAu/6onKUg4lLsHAs9EBPT82L" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/react-dom@18.3.1/umd/react-dom.development.js" integrity="sha384-u6aeetuaXnQ38mYT8rp6sbXaQe3NL9t+IBXmnYxwkUI2Hw4bsp2Wvmx4yRQF1uAm" crossorigin="anonymous"></script>
+<script src="https://unpkg.com/@babel/standalone@7.29.0/babel.min.js" integrity="sha384-m08KidiNqLdpJqLq95G/LEi8Qvjl/xUYll3QILypMoQ65QorJ9Lvtp2RXYGBFj1y" crossorigin="anonymous"></script>
+</head>
+<body>
+<div id="app"></div>
+
+<script type="text/babel" src="tweaks-panel.jsx"></script>
+<script type="text/babel" src="icons.jsx"></script>
+<script type="text/babel" src="data.jsx"></script>
+<script type="text/babel" src="data-os.jsx"></script>
+<script type="text/babel" src="data-clientes.jsx"></script>
+<script type="text/babel" src="sidebar.jsx"></script>
+<script type="text/babel" src="chat.jsx"></script>
+<script type="text/babel" src="chat-jana.jsx"></script>
+<script type="text/babel" src="linked-apps.jsx"></script>
+<script type="text/babel" src="viewers.jsx"></script>
+<script type="text/babel" src="tasks.jsx"></script>
+<script type="text/babel" src="os-page.jsx"></script>
+<script type="text/babel" src="clientes-page.jsx"></script>
+<script type="text/babel" src="data-orc-prod.jsx"></script>
+<script type="text/babel" src="data-vendas.jsx"></script>
+<script type="text/babel" src="vendas-page.jsx"></script>
+<script type="text/babel" src="vendas-extras.jsx"></script>
+<script type="text/babel" src="vendas-shortcuts.jsx"></script>
+<script type="text/babel" src="vendas-ai.jsx"></script>
+<script type="text/babel" src="vendas-curation.jsx"></script>
+<script type="text/babel" src="vendas-output.jsx"></script>
+<script type="text/babel" src="vendas-tweaks.jsx"></script>
+<script type="text/babel" src="orc-page.jsx"></script>
+<script type="text/babel" src="prod-page.jsx"></script>
+<script type="text/babel" src="producao-page.jsx"></script>
+<!-- Módulo Financeiro (migrado de Financeiro Unificado.html) -->
+<script type="text/babel" src="financeiro-icons.jsx"></script>
+<script type="text/babel" src="financeiro-data.jsx"></script>
+<script type="text/babel" src="financeiro-telas-extras.jsx"></script>
+<script type="text/babel" src="financeiro-curation.jsx"></script>
+<script type="text/babel" src="financeiro-ai.jsx"></script>
+<script type="text/babel" src="financeiro-output.jsx"></script>
+<script type="text/babel" src="financeiro-app.jsx"></script>
+<!-- Módulo Boletos (migrado de Boleto e Contas Inter.html) -->
+<script type="text/babel" src="boleto-contas-app.jsx"></script>
+<!-- Módulo Compras (migrado de Compras.html) -->
+<script type="text/babel" src="compras-page.jsx"></script>
+<!-- Módulo Oficina Auto (migrado de Produção Oficina - Tela.html) -->
+<script type="text/babel" src="oficina-page.jsx"></script>
+<!-- Mockup pages: 16 telas faltantes renderizadas como React components -->
+<script src="mockup-bodies.js"></script>
+<script type="text/babel" src="mockup-pages.jsx"></script>
+<script type="text/babel" src="crm-page.jsx"></script>
+<script type="text/babel" src="inbox-page.jsx"></script>
+<script type="text/babel" src="inbox-v2-extras.jsx"></script>
+<script type="text/babel" src="inbox-v2-ai.jsx"></script>
+<script type="text/babel" src="inbox-v2-cur.jsx"></script>
+<script type="text/babel" src="inbox-v2-out.jsx"></script>
+<script type="text/babel" src="equipe-page.jsx"></script>
+<script type="text/babel" src="kb-page.jsx"></script>
+<script type="text/babel" src="kb-extras.jsx"></script>
+<script type="text/babel" src="kb-paths.jsx"></script>
+<script type="text/babel" src="kb-trouble-lib.jsx"></script>
+<script type="text/babel" src="kb-trouble-editor.jsx"></script>
+<script type="text/babel" src="kb-images-print.jsx"></script>
+<script type="text/babel" src="laravel-panel.jsx"></script>
+<script type="text/babel" src="app.jsx"></script>
+</body>
+</html>

--- a/prototipo-ui/app.jsx
+++ b/prototipo-ui/app.jsx
@@ -1,0 +1,550 @@
+// app.jsx — orquestra rotas Chat / Tarefas / Módulo legado
+const { useState: useStateA, useEffect: useEffectA } = React;
+
+// ─────────────────────────────────────────────────────────────────
+// Nota: módulos antigos (Financeiro, Boletos, Compras, Oficina Auto)
+// foram migrados de HTMLs standalone para páginas React nativas dentro
+// deste shell (financeiro-app.jsx, boleto-contas-app.jsx, compras-page.jsx,
+// oficina-page.jsx). Não usamos mais iframes — ROUTE_HTML/IframeView removidos.
+// ─────────────────────────────────────────────────────────────────
+
+function ChatPage({ company, activeConvId, onSelectConv, linkedCollapsed, onToggleLinked }) {
+  const conversations = (MOCK.CONV[company.id] || []);
+  const [convs, setConvs] = useStateA(conversations);
+  const [convTab, setConvTab] = useStateA(() => {
+    try { return localStorage.getItem("oimpresso.chat.tab") || "todas"; } catch (e) { return "todas"; }
+  });
+  const [convQuery, setConvQuery] = useStateA("");
+
+  useEffectA(() => { setConvs(MOCK.CONV[company.id] || []); }, [company.id]);
+  useEffectA(() => { try { localStorage.setItem("oimpresso.chat.tab", convTab); } catch (e) {} }, [convTab]);
+
+  const conv = convs.find(c => c.id === activeConvId) || convs[0];
+
+  useEffectA(() => {
+    if (!conv || !conv.unread) return;
+    setConvs(cs => cs.map(c => c.id === conv.id ? { ...c, unread: 0 } : c));
+  }, [conv?.id]);
+
+  const handleSend = (text, raw) => {
+    setConvs(cs => cs.map(c => {
+      if (c.id !== conv.id) return c;
+      const newMsg = raw || { d:"Hoje", who:"você", side:"me", t:text, time:"agora", read:false };
+      return { ...c, msgs: [...c.msgs, newMsg], time: "agora", preview: (raw?.who?raw.who+': ':'você: ') + (raw?.t||text||'') };
+    }));
+  };
+
+  return (
+    <div className="chat-page">
+      <div className="chat-main">
+        <ConvTabsBar tab={convTab} onTab={setConvTab} query={convQuery} onQuery={setConvQuery}/>
+        <Thread conv={conv} onSend={handleSend}/>
+      </div>
+      <LinkedAppsPanel conv={conv} collapsed={linkedCollapsed} onToggle={onToggleLinked}/>
+    </div>
+  );
+}
+
+function ConvTabsBar({ tab, onTab, query, onQuery }) {
+  const tabs = [
+    { id: "todas",  label: "Todos" },
+    { id: "os",     label: "OS" },
+    { id: "team",   label: "Equipe" },
+    { id: "client", label: "Clientes" },
+  ];
+  return (
+    <div className="chat-tabsbar">
+      <div className="chat-tabs">
+        {tabs.map(t => (
+          <button key={t.id}
+                  className={"chat-tab" + (tab === t.id ? " active" : "")}
+                  onClick={() => onTab(t.id)}>{t.label}</button>
+        ))}
+      </div>
+      <div className="chat-search">
+        <I.search size={12}/>
+        <input placeholder="Buscar nesta conversa..." value={query} onChange={e => onQuery(e.target.value)}/>
+      </div>
+    </div>
+  );
+}
+
+// Stub para módulos do menu — em produção, abre Inertia page do módulo
+// MIGRATION_INFO — auditoria dos 36 módulos do repo wagnerra23/oimpresso.com@main
+// Fonte canônica em AUDITORIA_MODULOS.md. fase 1=Inventário ✅, 2=Adapter menu, 3=Reescrita React, 4=Decommission.
+const MIGRATION_INFO = {
+  // ─────── OFFICEIMPRESSO ───────
+  os:           { phase: 2, status: "next",    blade: "Modules/Officeimpresso/Resources/views/os/", routes: ["/os","/os/create","/os/{id}"], priority: "Piloto", desc: "Núcleo do ERP. Listagem + form + detalhe da Ordem de Serviço.", actions:["Nova OS","Listar abertas","Fila de produção"] },
+  clientes:     { phase: 3, status: "queue",   blade: "Modules/Officeimpresso/Resources/views/clientes/", routes: ["/clientes"], priority: "Alta freq.", desc: "CRUD de clientes + histórico de compras + contatos.", actions:["Novo cliente","Importar","Aniversariantes"] },
+  produtos:     { phase: 3, status: "queue",   blade: "Modules/Officeimpresso/Resources/views/produtos/", routes: ["/produtos"], priority: "Alta freq.", desc: "Catálogo de produtos com preço, insumos e especificações técnicas.", actions:["Novo produto","Tabela de preço","Insumos"] },
+  orcamentos:   { phase: 3, status: "queue",   blade: "Modules/Officeimpresso/Resources/views/orcamentos/", routes: ["/orcamentos"], priority: "Alta freq.", desc: "Geração de orçamentos a partir do catálogo + envio por e-mail/WhatsApp.", actions:["Novo orçamento","Aprovados","A vencer"] },
+  vendas:       { phase: 3, status: "queue",   blade: "Modules/Officeimpresso/Resources/views/vendas/", routes: ["/vendas"], priority: "Alta freq.", desc: "Pedidos confirmados, faturamento e nota fiscal. Inclui Sells/Create P0.", actions:["Hoje","Mês","Por cliente"] },
+  cv:           { phase: 1, status: "queue",   blade: "Modules/ComunicacaoVisual/Resources/views/", routes: ["/cv"], priority: "Núcleo", desc: "Módulo Comunicação Visual: banners, lonas, adesivos, fachadas. Especialização do catálogo Officeimpresso.", actions:["Novo job CV","Templates","Histórico"] },
+  catalogue:    { phase: 1, status: "later",   blade: "Modules/ProductCatalogue/Resources/views/", routes: ["/catalogue"], priority: "Suporte", desc: "Catálogo umbrella reusável entre módulos. Especificações técnicas de insumos e produtos.", actions:["Famílias","Insumos","SKUs"] },
+  portalos:     { phase: 1, status: "later",   blade: "Modules/ConsultaOs/Resources/views/", routes: ["/portal/consulta"], priority: "Externo", desc: "Portal cliente-facing para acompanhar status de OS sem login no ERP.", actions:["Buscar OS","Histórico cliente","Configurar"] },
+
+  // ─────── COMERCIAL ───────
+  crm:          { phase: 1, status: "later",   blade: "Modules/Crm/Resources/views/", routes: ["/crm"], priority: "Comercial", desc: "Funil de leads, oportunidades, follow-ups. Integra com Tarefas (TaskProvider crm_ligar).", actions:["Leads","Oportunidades","Funil"] },
+  ads:          { phase: 1, status: "later",   blade: "Modules/ADS/Resources/views/", routes: ["/ads"], priority: "Marketing", desc: "Gestão de campanhas pagas: Google Ads, Meta. UTMs + atribuição a leads.", actions:["Campanhas","ROAS","UTMs"] },
+  grow:         { phase: 1, status: "later",   blade: "Modules/Grow/Resources/views/", routes: ["/grow"], priority: "Marketing", desc: "Growth & marketing orgânico: e-mail, automações, nutrição de leads.", actions:["Automações","E-mails","Segmentos"] },
+  inbox:        { phase: 1, status: "partial", blade: "Modules/Inbox/Resources/views/", routes: ["/inbox"], priority: "Comercial", desc: "Caixa unificada (omnichannel): WhatsApp Baileys ativo; Meta Cloud, Z-API, Instagram DM, Messenger, Email IMAP e Mercado Livre em homologação. Lista + thread + contexto ERP (OS, saldo, LTV) + broadcast cross-canal.", actions:["Conversas","Templates","Broadcast","Canais"] },
+  equipe:       { phase: 1, status: "partial", blade: "Modules/Equipe/Resources/views/", routes: ["/equipe"], priority: "Comercial", desc: "Comunicação interna: canais (#producao, #financeiro, #vendas, #motoboy, #geral) + DMs entre operadores. Distinto da Caixa unificada — não mistura SLA cliente com recado de colega.", actions:["Canais","DMs","Equipe"] },
+
+  // ─────── PRODUÇÃO ───────
+  fila:         { phase: 4, status: "later",   blade: "Modules/Officeimpresso/Resources/views/producao/fila/", routes: ["/fila"], priority: "Operacional", desc: "Fila de impressão por equipamento — sequenciamento e prioridade.", actions:["Roland 540","HP Latex","Plotter recorte"] },
+  acabamento:   { phase: 4, status: "later",   blade: "Modules/Officeimpresso/Resources/views/producao/acabamento/", routes: ["/acabamento"], priority: "Operacional", desc: "Pós-impressão: corte, laminação, aplicação.", actions:["Pendentes","Concluídos hoje"] },
+  expedicao:    { phase: 4, status: "later",   blade: "Modules/Officeimpresso/Resources/views/producao/expedicao/", routes: ["/expedicao"], priority: "Operacional", desc: "Embalagem, romaneio e entrega.", actions:["A entregar","Roteirizar","Concluídas"] },
+  manufacturing:{ phase: 1, status: "later",   blade: "Modules/Manufacturing/Resources/views/", routes: ["/manufacturing"], priority: "Industrial", desc: "Produção industrial UltimatePOS: BOM, ordens de fabricação, custo.", actions:["BOM","Ordens","Custo"] },
+  iproduction:  { phase: 1, status: "later",   blade: "Modules/IProduction/Resources/views/", routes: ["/iproduction"], priority: "Industrial", desc: "Variante extendida de produção. Complementa Manufacturing.", actions:["Receitas","Lotes"] },
+  brief:        { phase: 1, status: "later",   blade: "Modules/Brief/Resources/views/", routes: ["/brief"], priority: "Pré-produção", desc: "Briefings de design: questionário, aprovação de layout, anexos por OS.", actions:["Novo brief","Pendentes","Templates"] },
+
+  // ─────── VERTICAIS ───────
+  repair:       { phase: 1, status: "later",   blade: "Modules/Repair/Resources/views/", routes: ["/repair"], priority: "Vertical", desc: "Assistência técnica (eletrônicos). Módulo UltimatePOS de referência canônica (ADR 0011).", actions:["Nova OS Repair","Em andamento","Concluídas"] },
+  oficinaauto:  { phase: 1, status: "later",   blade: "Modules/OficinaAuto/Resources/views/", routes: ["/oficina"], priority: "Vertical", desc: "Vertical oficina automotiva: OS de manutenção veicular, peças, mão-de-obra.", actions:["Nova OS","Veículos","Catálogo peças"] },
+  vestuario:    { phase: 1, status: "later",   blade: "Modules/Vestuario/Resources/views/", routes: ["/vestuario"], priority: "Vertical", desc: "Vertical confecção: grades por tamanho/cor, estampas, peças.", actions:["Pedidos","Grades","Estampas"] },
+
+  // ─────── PESSOAS ───────
+  ponto:        { phase: 4, status: "partial", blade: "Modules/Ponto/Resources/views/", routes: ["/ponto","/ponto/espelho"], priority: "Núcleo RH", desc: "Ponto WR2 — Portaria MTP 671/2021. Bater ponto, espelho do mês, justificativas. Parcialmente React.", actions:["Bater ponto","Meu espelho","Justificar"] },
+  equipes:      { phase: 5, status: "later",   blade: "Modules/Officeimpresso/Resources/views/equipes/", routes: ["/equipes"], priority: "Baixa freq.", desc: "Times, escalas e responsáveis por etapas de produção.", actions:["Times","Escala da semana"] },
+
+  // ─────── FINANCEIRO ───────
+  financeiro:   { phase: 1, status: "done",    blade: "—", routes: ["/financeiro"], priority: "Concluído", desc: "Já migrado para React. Contas a pagar/receber, fluxo de caixa, conciliação Inter.", actions:["Contas a pagar","Contas a receber","Fluxo"] },
+  relatorios:   { phase: 5, status: "later",   blade: "Modules/Officeimpresso/Resources/views/relatorios/", routes: ["/relatorios"], priority: "Baixa freq.", desc: "BI: vendas por período, margem, produtividade.", actions:["Vendas","Margem","Produtividade"] },
+  nfse:         { phase: 1, status: "partial", blade: "Modules/NFSe/Resources/views/", routes: ["/nfse"], priority: "Fiscal", desc: "Nota Fiscal de Serviço Eletrônica — emissão, RPS, lote, prefeituras.", actions:["Emitir","Lote","Histórico"] },
+  nfe:          { phase: 1, status: "partial", blade: "Modules/NfeBrasil/Resources/views/", routes: ["/nfe"], priority: "Fiscal", desc: "NF-e Brasil (produto): emissão, transmissão SEFAZ, DANFE.", actions:["Emitir","Inutilizar","DANFE"] },
+  accounting:   { phase: 1, status: "later",   blade: "Modules/Accounting/Resources/views/", routes: ["/accounting"], priority: "Contábil", desc: "Plano de contas, lançamentos, balancete. Integra com Financeiro.", actions:["Plano","Balancete","DRE"] },
+  recurring:    { phase: 1, status: "later",   blade: "Modules/RecurringBilling/Resources/views/", routes: ["/recurring"], priority: "Financeiro", desc: "Cobrança recorrente: planos, assinaturas, geração automática de boletos.", actions:["Planos","Assinantes","Ciclos"] },
+
+  // ─────── PROJETOS & GESTÃO ───────
+  projects:     { phase: 1, status: "later",   blade: "Modules/ProjectMgmt/Resources/views/", routes: ["/projects"], priority: "Gestão", desc: "Gestão de projetos: tarefas, milestones, timesheet, gantt. Cliente-facing opcional.", actions:["Projetos","Tarefas","Timesheet"] },
+  assets:       { phase: 1, status: "later",   blade: "Modules/AssetManagement/Resources/views/", routes: ["/assets"], priority: "Gestão", desc: "Patrimônio: equipamentos (Roland, HP Latex, Plotter), manutenção, depreciação.", actions:["Inventário","Manutenção","Depreciação"] },
+  auditoria:    { phase: 1, status: "later",   blade: "Modules/Auditoria/Resources/views/", routes: ["/auditoria"], priority: "Compliance", desc: "Trilha de auditoria: quem alterou o quê e quando. LGPD + controles internos.", actions:["Logs","Filtros","Exportar"] },
+  governance:   { phase: 1, status: "later",   blade: "Modules/Governance/Resources/views/", routes: ["/governance"], priority: "Compliance", desc: "Políticas, controles, indicadores de governança corporativa.", actions:["Políticas","Indicadores","Aprovações"] },
+  kb:           { phase: 1, status: "done",    blade: "—", routes: ["/kb"], priority: "Conhecimento", desc: "Base de conhecimento interna em React: SOPs, tutoriais, troubleshooting de equipamentos, command palette ⌘K, decision tree.", actions:["Artigos","Categorias","Buscar"] },
+  spreadsheet:  { phase: 1, status: "later",   blade: "Modules/Spreadsheet/Resources/views/", routes: ["/spreadsheet"], priority: "Suporte", desc: "Planilhas internas para cálculos ad-hoc e imports/exports tabulares.", actions:["Nova planilha","Templates","Imports"] },
+
+  // ─────── OUTROS ───────
+  memcofre:     { phase: 1, status: "done",    blade: "—", routes: ["/memcofre"], priority: "Concluído", desc: "Já migrado para React. Cofre de senhas e credenciais (memória cofre).", actions:["Senhas","Cartões","Notas"] },
+  copiloto:     { phase: 1, status: "done",    blade: "—", routes: ["/copiloto"], priority: "Em iteração", desc: "Assistente IA — React + Inertia. Hoje em DRY_RUN; roadmap Vizra ADK + Meilisearch (ADRs 0035/0036).", actions:["Nova conversa","Histórico","LGPD memória"] },
+  site:         { phase: 1, status: "done",    blade: "—", routes: ["/site"], priority: "Concluído", desc: "Já migrado para React. CMS do site institucional (Modules/Cms).", actions:["Páginas","Posts","Mídia"] },
+  arquivos:     { phase: 5, status: "later",   blade: "Modules/Arquivos/Resources/views/", routes: ["/arquivos"], priority: "Baixa freq.", desc: "Drive interno por OS, cliente e projeto.", actions:["Recentes","Compartilhados","Lixeira"] },
+
+  // ─────── INTEGRAÇÕES ───────
+  connector:    { phase: 1, status: "later",   blade: "Modules/Connector/Resources/views/", routes: ["/connector"], priority: "Integração", desc: "Connector UltimatePOS: integrações via API, webhooks, importers.", actions:["Tokens API","Webhooks","Importers"] },
+  woocommerce:  { phase: 1, status: "later",   blade: "Modules/Woocommerce/Resources/views/", routes: ["/woocommerce"], priority: "Integração", desc: "Sincronização WooCommerce: produtos, estoque, pedidos.", actions:["Sync produtos","Pedidos","Logs"] },
+  teammcp:      { phase: 1, status: "later",   blade: "Modules/TeamMcp/Resources/views/", routes: ["/team-mcp"], priority: "Experimental", desc: "Team MCP: expor o ERP via Model Context Protocol para agentes (Claude Desktop, Cursor). Ver ADR 0035.", actions:["Tokens MCP","Recursos","Logs"] },
+  srs:          { phase: 1, status: "later",   blade: "Modules/SRS/Resources/views/", routes: ["/srs"], priority: "Interno", desc: "SRS — Software Requirement Specifications. Documentação interna de requisitos.", actions:["Specs","Versões"] },
+
+  // ─────── CONFIGURAÇÕES ───────
+  prefs:        { phase: 5, status: "later",   blade: "Modules/Essentials/Resources/views/prefs/", routes: ["/prefs"], priority: "Config.", desc: "Preferências do usuário e da empresa.", actions:["Pessoais","Empresa","Notificações"] },
+  users:        { phase: 5, status: "later",   blade: "Modules/Essentials/Resources/views/users/", routes: ["/usuarios"], priority: "Config.", desc: "Usuários, papéis e permissões.", actions:["Usuários","Papéis","Permissões"] },
+  admin:        { phase: 1, status: "later",   blade: "Modules/Admin/Resources/views/", routes: ["/admin"], priority: "Config.", desc: "Admin core do UltimatePOS: configurações de business, planos, módulos ativos.", actions:["Business","Módulos","Planos"] },
+  superadmin:   { phase: 1, status: "later",   blade: "Modules/Superadmin/Resources/views/", routes: ["/superadmin"], priority: "Suporte", desc: "Superadmin UltimatePOS: multi-business, suporte cross-tenant.", actions:["Tenants","Suporte","Logs"] },
+  jana:         { phase: 1, status: "later",   blade: "Modules/Jana/Resources/views/", routes: ["/jana"], priority: "Referência", desc: "Módulo de referência canônica do projeto (ADR 0011). Imitar a estrutura ao criar/ajustar módulos.", actions:["Ver código","Padrões"] },
+};
+
+const PHASE_LABEL = {
+  done:    { label: "Migrado",       cls: "ok"   },
+  partial: { label: "Parcial",        cls: "partial" },
+  next:    { label: "Próximo",       cls: "next" },
+  queue:   { label: "Fila",           cls: "queue" },
+  later:   { label: "Backlog",        cls: "muted" },
+};
+
+function ModuleStub({ routeId }) {
+  const flat = MOCK.MENU.flatMap(e => e.group ? e.items : [e]);
+  const item = flat.find(i => i.id === routeId);
+  const Icon = item ? I[item.icon] : I.folder;
+  const info = MIGRATION_INFO[routeId] || { phase: 5, status: "later", blade: "—", routes: ["/" + routeId], priority: "—", desc: "Tela legada do ERP. Será migrada conforme o roadmap MWART.", actions:[] };
+  const phase = PHASE_LABEL[info.status];
+
+  return (
+    <div className="mod-stub">
+      <div className="mod-stub-hero">
+        <div className="mod-stub-hero-l">
+          <div className="mod-stub-ico"><Icon size={28}/></div>
+          <div>
+            <div className="mod-stub-eyebrow">
+              <span>Módulo</span>
+              <span className="bc-sep">·</span>
+              <span>Fase {info.phase}</span>
+              <span className="bc-sep">·</span>
+              <span>{info.priority}</span>
+            </div>
+            <h1>{item?.label || routeId}</h1>
+            <p>{info.desc}</p>
+          </div>
+        </div>
+        <div className="mod-stub-hero-r">
+          <span className={`mod-stub-status ${phase.cls}`}>
+            <span className="dot"/>{phase.label}
+          </span>
+        </div>
+      </div>
+
+      <div className="mod-stub-grid">
+        <section className="mod-stub-card">
+          <h3>Ações típicas</h3>
+          {info.actions.length > 0 ? (
+            <div className="mod-stub-actions">
+              {info.actions.map((a, i) => (
+                <button key={i} className={"mod-stub-action" + (i===0 ? " primary" : "")}>
+                  {i === 0 && <I.plus size={12}/>}
+                  {a}
+                </button>
+              ))}
+            </div>
+          ) : <p className="mod-stub-empty">Sem ações definidas ainda.</p>}
+        </section>
+
+        <section className="mod-stub-card">
+          <h3>Stack atual</h3>
+          <dl className="mod-stub-dl">
+            <dt>Front</dt>
+            <dd>{info.status === "done" ? "React 19 + Inertia" : info.status === "partial" ? "Misto (Blade + React)" : "Blade legado"}</dd>
+            <dt>Backend</dt>
+            <dd>Laravel 13.6 + nWidart</dd>
+            <dt>Rotas</dt>
+            <dd className="mono">{info.routes.join(" · ")}</dd>
+            <dt>Origem Blade</dt>
+            <dd className="mono small">{info.blade}</dd>
+          </dl>
+        </section>
+
+        <section className="mod-stub-card span">
+          <h3>Roadmap MWART</h3>
+          <ol className="mod-stub-roadmap">
+            <li className={info.phase >= 1 ? "done" : ""}>
+              <span className="step">1</span>
+              <div><b>Inventário</b><small>Mapear views Blade, rotas e modelos</small></div>
+            </li>
+            <li className={info.phase >= 2 ? (info.status==="next"?"current":"done") : ""}>
+              <span className="step">2</span>
+              <div><b>Adapter de menu</b><small>LegacyMenuAdapter expõe item via shell.menu</small></div>
+            </li>
+            <li className={info.status === "done" ? "done" : info.status === "partial" ? "current" : ""}>
+              <span className="step">3</span>
+              <div><b>Reescrita React</b><small>Inertia page + componentes shared</small></div>
+            </li>
+            <li className={info.status === "done" ? "done" : ""}>
+              <span className="step">4</span>
+              <div><b>Decommission</b><small>Flip do flag inertia: true e remoção do Blade</small></div>
+            </li>
+          </ol>
+        </section>
+      </div>
+
+      <div className="mod-stub-foot">
+        <span className="mod-stub-tag"><span className="t-mute">rota:</span> <span className="mono">/{routeId}</span></span>
+        <span className="mod-stub-foot-spacer"/>
+        <button className="mod-stub-link">Ver no Blade atual ↗</button>
+        <button className="mod-stub-link">Ver issue de migração ↗</button>
+      </div>
+    </div>
+  );
+}
+
+function Header({ company, route, onSelectRoute, prodType, onProdType, chatTab, onChatTab }) {
+  const flat = MOCK.MENU.flatMap(e => e.group ? e.items.map(i=>({...i, group:e.group})) : [{...e, group:null}]);
+  const item = flat.find(i => i.id === route);
+  const group = MOCK.MENU.find(g => g.group && g.items.some(i => i.id === route));
+  const meta = group ? (MOCK.GROUP_META || {})[group.group] : null;
+  const hue = meta?.hue ?? 220;
+
+  // Quando dentro de área: mostra label da área à esquerda + pílulas das sub-telas
+  // Quando solta (chat/tarefas/roadmap): mostra só o nome da rota
+  const areaLabel = meta ? meta.label : (item?.label || "Chat");
+
+  // Topnav contextual: na página Produtos vira filtro de tipo (Todos/Produto/Serviço/Composição)
+  const isProdutos = route === "produtos";
+  const isChat = route === "chat";
+  const PROD_TYPES = [
+    { key: "all",        label: "Todos",       color: "oklch(0.55 0.02 250)" },
+    { key: "produto",    label: "Produto",     color: "oklch(0.42 0.10 250)" },
+    { key: "servico",    label: "Serviço",     color: "oklch(0.48 0.13 220)" },
+    { key: "composicao", label: "Composição",  color: "oklch(0.48 0.13 145)" },
+  ];
+  const CHAT_TABS = [
+    { key: "dashboard", label: "Dashboard",   icon: "📊", color: "oklch(0.42 0.10 250)" },
+    { key: "ia",        label: "Analista IA", icon: "🤖", color: "oklch(0.45 0.15 290)" },
+  ];
+
+  return (
+    <header className="topbar">
+      <div className="topbar-l">
+        {meta && <span className="topbar-dot" style={{background: `oklch(0.62 0.13 ${hue})`}}/>}
+        <span className="topbar-area-label">
+          {isProdutos ? "PRODUTOS" : isChat ? "JANA" : areaLabel}
+        </span>
+      </div>
+      {isProdutos ? (
+        <nav className="topbar-tabs" aria-label="Filtro de tipo">
+          {PROD_TYPES.map(t => {
+            const active = (prodType || "all") === t.key;
+            return (
+              <button key={t.key}
+                      className={"topbar-tab topbar-tab--type" + (active ? " active" : "")}
+                      onClick={() => onProdType?.(t.key)}
+                      style={active ? {borderBottomColor: t.color, color: t.color} : null}>
+                {t.key !== "all" && <span className="topbar-tab-dot" style={{background: t.color}}/>}
+                <span>{t.label}</span>
+              </button>
+            );
+          })}
+        </nav>
+      ) : isChat ? (
+        <nav className="topbar-tabs" aria-label="Modo do Jana">
+          {CHAT_TABS.map(t => {
+            const active = (chatTab || "dashboard") === t.key;
+            return (
+              <button key={t.key}
+                      className={"topbar-tab topbar-tab--chat" + (active ? " active" : "")}
+                      onClick={() => onChatTab?.(t.key)}
+                      style={active ? {borderBottomColor: t.color, color: t.color} : null}>
+                <span className="topbar-tab-emoji">{t.icon}</span>
+                <span>{t.label}</span>
+              </button>
+            );
+          })}
+        </nav>
+      ) : group ? (
+        <nav className="topbar-tabs" aria-label={areaLabel}>
+          {group.items.map(it => {
+            const Icon = I[it.icon];
+            const isActive = route === it.id;
+            return (
+              <button key={it.id}
+                      className={"topbar-tab" + (isActive ? " active" : "")}
+                      onClick={() => onSelectRoute(it.id)}
+                      style={isActive ? {borderBottomColor: `oklch(0.55 0.14 ${hue})`, color: `oklch(0.42 0.10 ${hue})`} : null}>
+                {Icon && <Icon size={12}/>}
+                <span>{it.label}</span>
+              </button>
+            );
+          })}
+        </nav>
+      ) : (
+        <div className="topbar-tabs topbar-tabs-empty"/>
+      )}
+      <div className="topbar-r">
+        <span className="topbar-tenant" title={company.name}>{company.initials}</span>
+        <button className="icon-btn" title="Buscar"><I.search size={14}/></button>
+        <button className="icon-btn" title="Notificações"><I.bell size={14}/></button>
+      </div>
+    </header>
+  );
+}
+
+function App() {
+  const [company, setCompany] = useStateA(() => {
+    try {
+      const id = localStorage.getItem("oimpresso.company");
+      return MOCK.COMPANIES.find(c => c.id === id) || MOCK.COMPANIES[0];
+    } catch (e) { return MOCK.COMPANIES[0]; }
+  });
+  const [tab, setTab] = useStateA(() => {
+    try { return localStorage.getItem("oimpresso.sidebar.tab") || "menu"; }
+    catch (e) { return "menu"; }
+  });
+  const [route, setRoute] = useStateA(() => {
+    try { return localStorage.getItem("oimpresso.route") || "chat"; }
+    catch (e) { return "chat"; }
+  });
+  const [activeConvId, setActiveConvId] = useStateA(() => {
+    try { return localStorage.getItem("oimpresso.conv") || "c1"; }
+    catch (e) { return "c1"; }
+  });
+  const [showLaravel, setShowLaravel] = useStateA(false);
+  const [linkedCollapsed, setLinkedCollapsed] = useStateA(() => {
+    try { return localStorage.getItem("oimpresso.linked.collapsed") === "1"; } catch (e) { return false; }
+  });
+  // Filtro de tipo de produto — controlado pelo topnav contextual
+  const [prodType, setProdType] = useStateA(() => {
+    try { return localStorage.getItem("oimpresso.prod.type") || "all"; } catch (e) { return "all"; }
+  });
+  useEffectA(() => {
+    try { localStorage.setItem("oimpresso.prod.type", prodType); } catch (e) {}
+  }, [prodType]);
+  // Tab do Chat (Dashboard | Analista IA)
+  const [chatTab, setChatTab] = useStateA(() => {
+    try { return localStorage.getItem("oimpresso.chat.tab") || "dashboard"; } catch (e) { return "dashboard"; }
+  });
+  useEffectA(() => {
+    try { localStorage.setItem("oimpresso.chat.tab", chatTab); } catch (e) {}
+  }, [chatTab]);
+  useEffectA(() => {
+    try { localStorage.setItem("oimpresso.linked.collapsed", linkedCollapsed ? "1" : "0"); } catch (e) {}
+  }, [linkedCollapsed]);
+
+  // ─── Sidebar: modo expanded | rail | hidden ───
+  const [sbMode, setSbMode] = useStateA(() => {
+    try {
+      const v = localStorage.getItem("oimpresso.sidebar.mode");
+      if (v === "rail" || v === "hidden" || v === "expanded") return v;
+    } catch (e) {}
+    // auto-rail em telas estreitas
+    return (typeof window !== "undefined" && window.innerWidth < 1280) ? "rail" : "expanded";
+  });
+  useEffectA(() => {
+    try { localStorage.setItem("oimpresso.sidebar.mode", sbMode); } catch (e) {}
+  }, [sbMode]);
+
+  // Atalhos: ⌘\ alterna expanded↔rail, ⌘⇧\ oculta
+  useEffectA(() => {
+    const onKey = (e) => {
+      const mod = e.metaKey || e.ctrlKey;
+      if (!mod) return;
+      if (e.key === "\\") {
+        e.preventDefault();
+        if (e.shiftKey) {
+          setSbMode(m => m === "hidden" ? "expanded" : "hidden");
+        } else {
+          setSbMode(m => m === "rail" ? "expanded" : "rail");
+        }
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  useEffectA(() => { localStorage.setItem("oimpresso.company", company.id); }, [company]);
+  useEffectA(() => { localStorage.setItem("oimpresso.sidebar.tab", tab); }, [tab]);
+  useEffectA(() => { localStorage.setItem("oimpresso.route", route); }, [route]);
+  useEffectA(() => { if (activeConvId) localStorage.setItem("oimpresso.conv", activeConvId); }, [activeConvId]);
+
+  // exposto p/ sidebar
+  window.__company = company;
+
+  // ─── Tweaks expressivos ───
+  const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+    "vibe": "workspace",
+    "density": 50,
+    "accentHue": 220,
+    "showLaravel": false
+  }/*EDITMODE-END*/;
+  const [tweaks, setTweak] = useTweaks(TWEAK_DEFAULTS);
+
+  // Aplica vibe no <html> + variáveis CSS
+  useEffectA(() => {
+    const root = document.documentElement;
+    root.dataset.vibe = tweaks.vibe;
+
+    // Density: 0 = skim (28px row), 50 = normal (32), 100 = briefing (40)
+    const rowH = 26 + (tweaks.density / 100) * 16;
+    root.style.setProperty("--row-h", `${rowH}px`);
+    root.style.setProperty("--card-pad",  `${8 + (tweaks.density/100)*8}px`);
+    root.style.setProperty("--card-gap",  `${(tweaks.density/100)*4}px`);
+    root.dataset.density = tweaks.density < 30 ? "skim" : tweaks.density > 70 ? "briefing" : "normal";
+
+    // Accent hue — repinta accent e origens harmonicamente
+    const h = tweaks.accentHue;
+    root.style.setProperty("--accent",      `oklch(0.58 0.12 ${h})`);
+    root.style.setProperty("--accent-2",    `oklch(0.66 0.12 ${h})`);
+    root.style.setProperty("--accent-soft", `oklch(0.94 0.04 ${h})`);
+    root.style.setProperty("--bubble-me",   `oklch(0.58 0.12 ${h})`);
+    // Origens: rotacionam proporcionalmente em torno do accent
+    root.style.setProperty("--origin-OS-bg",  `oklch(0.93 0.07 ${(h+210)%360})`);
+    root.style.setProperty("--origin-OS-fg",  `oklch(0.40 0.10 ${(h+210)%360})`);
+    root.style.setProperty("--origin-CRM-bg", `oklch(0.92 0.06 ${h})`);
+    root.style.setProperty("--origin-CRM-fg", `oklch(0.40 0.10 ${h})`);
+    root.style.setProperty("--origin-FIN-bg", `oklch(0.93 0.07 ${(h+285)%360})`);
+    root.style.setProperty("--origin-FIN-fg", `oklch(0.36 0.10 ${(h+285)%360})`);
+    root.style.setProperty("--origin-PNT-bg", `oklch(0.93 0.06 ${(h+75)%360})`);
+    root.style.setProperty("--origin-PNT-fg", `oklch(0.40 0.10 ${(h+75)%360})`);
+  }, [tweaks.vibe, tweaks.density, tweaks.accentHue]);
+
+  useEffectA(() => { setShowLaravel(tweaks.showLaravel); }, [tweaks.showLaravel]);
+
+  const handleSelectRoute = (r) => {
+    setRoute(r);
+    if (r === "chat") setTab("chat");
+    // persiste última rota visitada por área (pra "lean sidebar → goToGroup" funcionar)
+    const grp = MOCK.MENU.find(g => g.group && g.items.some(i => i.id === r));
+    if (grp) {
+      try { localStorage.setItem(`oimpresso.group.${grp.group}.route`, r); } catch (e) {}
+    }
+  };
+
+  const handleSelectConv = (id) => {
+    setActiveConvId(id);
+    setRoute("chat");
+  };
+
+  let content;
+  if (route === "chat")          content = <window.JanaCockpit company={company} tab={chatTab}/>;
+  else if (route === "tarefas")  content = <TasksPage/>;
+  else if (route === "os")       content = <OsListPage/>;
+  else if (route === "clientes") content = <CliListPage/>;
+  else if (route === "orcamentos") content = <OrcListPage/>;
+  else if (route === "produtos") content = <ProdListPage typeFilter={prodType} onTypeFilter={setProdType}/>;
+  else if (route === "vendas")    content = <VendasModule/>;
+  else if (route === "fila" || route === "acabamento" || route === "expedicao") content = <ProducaoPage/>;
+  else if (route === "financeiro") content = <window.FinanceiroPage initialTela="unified"/>;
+  else if (route === "fin-fluxo")  content = <window.FinanceiroPage initialTela="fluxo"/>;
+  else if (route === "fin-dre")    content = <window.FinanceiroPage initialTela="dre"/>;
+  else if (route === "boletos") content = <window.BoletosPage/>;
+  else if (route === "compras") content = <window.ComprasPage/>;
+  else if (route === "oficinaauto") content = <window.OficinaPage/>;
+  else if (route === "crm") content = <window.CrmPage/>;
+  else if (route === "inbox") content = <window.InboxPage/>;
+  else if (route === "equipe") content = <window.EquipePage/>;
+  else if (route === "kb") content = <window.KBPage/>;
+  else if ([
+    "crm", "inbox", "equipe", "cv", "relatorios", "fiscal", "nfe", "nfse", "assets", "recurring",
+    "catalogue", "brief", "repair", "manufacturing", "ads", "projects", "vestuario",
+    "portalos", "auditoria"
+  ].includes(route)) content = <window.MockupPage route={route === "nfe" || route === "nfse" ? "fiscal" : route}/>;
+  else                            content = <ModuleStub routeId={route}/>;
+
+  return (
+    <div className={"app app--sb-" + sbMode}>
+      {sbMode !== "hidden" && (
+        <Sidebar
+          company={company} onCompany={setCompany}
+          tab={tab} onTab={setTab}
+          activeConvId={activeConvId} onSelectConv={handleSelectConv}
+          activeRoute={route} onSelectRoute={handleSelectRoute}
+          mode={sbMode} onModeChange={setSbMode}/>
+      )}
+      {sbMode === "hidden" && (
+        <window.SidebarReopenHandle onOpen={() => setSbMode("expanded")}/>
+      )}
+      <div className="main">
+        <div className="main-body">{content}</div>
+      </div>
+      {showLaravel && <LaravelPanel onClose={() => setShowLaravel(false)}/>}
+      <TweaksPanel title="Tweaks">
+        <TweakSection label="Vibe"/>
+        <TweakRadio
+          label="Atmosfera"
+          value={tweaks.vibe}
+          options={["workspace","daylight","focus"]}
+          onChange={(v) => setTweak("vibe", v)}/>
+
+        <TweakSection label="Densidade"/>
+        <TweakSlider
+          label="Skim ↔ Briefing"
+          value={tweaks.density}
+          min={0} max={100} step={5}
+          unit="%"
+          onChange={(v) => setTweak("density", v)}/>
+
+        <TweakSection label="Cor"/>
+        <TweakSlider
+          label="Tom do accent"
+          value={tweaks.accentHue}
+          min={0} max={360} step={10}
+          unit="°"
+          onChange={(v) => setTweak("accentHue", v)}/>
+
+        <TweakSection label="Sistema"/>
+        <TweakToggle
+          label="Painel Laravel"
+          value={tweaks.showLaravel}
+          onChange={(v) => setTweak("showLaravel", v)}/>
+      </TweaksPanel>
+    </div>
+  );
+}
+
+ReactDOM.createRoot(document.getElementById("app")).render(<App/>);

--- a/prototipo-ui/data.jsx
+++ b/prototipo-ui/data.jsx
@@ -1,0 +1,349 @@
+// ────────────────────────────────────────────────────────────────────
+// MOCK DATA — Empresas, Menu (espelho AppShell), Conversas, Tarefas
+// ────────────────────────────────────────────────────────────────────
+
+const COMPANIES = [
+  { id: "oi",  name: "Oimpresso Matriz", initials: "OI", grad: "av-2" },
+  { id: "wr",  name: "WR Comunicação",    initials: "WR", grad: "av-1" },
+  { id: "gv",  name: "Gráfica Vértice",   initials: "GV", grad: "av-3" },
+];
+
+// ─── MENU (espelho fiel do AppShell.tsx atual) ───
+// Mesma ordem, labels e ícones que o sidebar.blade.php do sistema atual.
+// Backend devolve isso via shell.menu (LegacyMenuAdapter).
+// ─── MENU completo — 36 módulos do repo wagnerra23/oimpresso.com@main ───
+// Auditoria: AUDITORIA_MODULOS.md. Cada item.id casa com a chave em MIGRATION_INFO (app.jsx).
+const MENU = [
+  // Núcleo — sem agrupamento, no topo
+  { id: "chat",       icon: "chat",    label: "Jana · Analista",  badge: 3 },
+  { id: "tarefas",    icon: "inbox",   label: "Tarefas",          badge: 6 },
+
+  // Officeimpresso (módulo principal — núcleo do ERP)
+  { group: "OFFICEIMPRESSO", items: [
+    { id: "os",         icon: "orders",  label: "Ordens de Serviço" },
+    { id: "clientes",   icon: "clients", label: "Clientes" },
+    { id: "produtos",   icon: "product", label: "Produtos" },
+    { id: "orcamentos", icon: "quote",   label: "Orçamentos" },
+    { id: "vendas",     icon: "cash",    label: "Vendas" },
+    { id: "cv",         icon: "layers",  label: "Comunicação Visual" },
+    { id: "catalogue",  icon: "book",    label: "Catálogo de Produtos" },
+    { id: "portalos",   icon: "globe",   label: "Portal Consulta OS" },
+  ]},
+
+  // Comercial / Marketing
+  { group: "COMERCIAL", items: [
+    { id: "crm",        icon: "clients",   label: "CRM" },
+    { id: "ads",        icon: "megaphone", label: "ADS" },
+    { id: "grow",       icon: "rocket",    label: "Grow" },
+    { id: "inbox",      icon: "inbox",     label: "Caixa unificada" },
+    { id: "equipe",     icon: "users",     label: "Equipe" },
+  ]},
+
+  // Produção
+  { group: "PRODUÇÃO", items: [
+    { id: "fila",         icon: "print",   label: "Fila de impressão" },
+    { id: "acabamento",   icon: "scissor", label: "Acabamento" },
+    { id: "expedicao",    icon: "truck",   label: "Expedição" },
+    { id: "manufacturing",icon: "factory", label: "Manufacturing" },
+    { id: "iproduction",  icon: "factory", label: "IProduction" },
+    { id: "brief",        icon: "doc",     label: "Briefings" },
+  ]},
+
+  // Verticais (outras linhas de negócio)
+  { group: "VERTICAIS", items: [
+    { id: "repair",      icon: "wrench", label: "Repair" },
+    { id: "oficinaauto", icon: "car",    label: "Oficina Auto" },
+    { id: "vestuario",   icon: "shirt",  label: "Vestuário" },
+  ]},
+
+  // Pessoas
+  { group: "PESSOAS", items: [
+    { id: "ponto",    icon: "user",    label: "Ponto WR2" },
+    { id: "equipes",  icon: "clients", label: "Equipes" },
+  ]},
+
+  // Fiscal & Financeiro
+  { group: "FINANCEIRO", items: [
+    { id: "financeiro",    icon: "cash",    label: "Financeiro" },
+    { id: "fin-fluxo",     icon: "chart",   label: "Fluxo de caixa" },
+    { id: "fin-dre",       icon: "doc",     label: "DRE / Relatórios" },
+    { id: "boletos",    icon: "receipt", label: "Boleto · Inter" },
+    { id: "compras",    icon: "archive", label: "Compras" },
+    { id: "relatorios", icon: "chart",   label: "Relatórios" },
+    { id: "nfse",       icon: "receipt", label: "NFS-e" },
+    { id: "nfe",        icon: "receipt", label: "NF-e Brasil" },
+    { id: "accounting", icon: "calc",    label: "Contabilidade" },
+    { id: "recurring",  icon: "refresh", label: "Cobrança recorrente" },
+  ]},
+
+  // Projetos & Gestão
+  { group: "PROJETOS & GESTÃO", items: [
+    { id: "projects",    icon: "briefcase", label: "Projetos" },
+    { id: "assets",      icon: "archive",   label: "Patrimônio" },
+    { id: "auditoria",   icon: "audit",     label: "Auditoria" },
+    { id: "governance",  icon: "scale",     label: "Governança" },
+    { id: "kb",          icon: "book",      label: "Base de Conhecimento" },
+    { id: "spreadsheet", icon: "sheet",     label: "Planilhas" },
+  ]},
+
+  // Outros / Internos
+  { group: "OUTROS", items: [
+    { id: "memcofre", icon: "shield",  label: "MemCofre" },
+    { id: "copiloto", icon: "bot",     label: "Copiloto" },
+    { id: "site",     icon: "globe",   label: "Site (CMS)" },
+    { id: "arquivos", icon: "folder",  label: "Arquivos" },
+  ]},
+
+  // Integrações
+  { group: "INTEGRAÇÕES", items: [
+    { id: "connector",  icon: "plug",   label: "Connector" },
+    { id: "woocommerce",icon: "plug",   label: "WooCommerce" },
+    { id: "teammcp",    icon: "bot",    label: "Team MCP" },
+    { id: "srs",        icon: "map",    label: "SRS" },
+  ]},
+
+  // Configurações
+  { group: "CONFIGURAÇÕES", items: [
+    { id: "prefs",      icon: "cog",    label: "Preferências" },
+    { id: "users",      icon: "shield", label: "Usuários & Permissões" },
+    { id: "admin",      icon: "cog",    label: "Admin (UltimatePOS)" },
+    { id: "superadmin", icon: "shield", label: "Superadmin" },
+    { id: "jana",       icon: "layers", label: "Jana (módulo ref.)" },
+  ]},
+];
+
+// ─── CONVERSAS (mantido, levemente enxuto) ───
+const CONV = {
+  oi: [
+    { id:"c1", kind:"os", tag:"OS #4821", title:"Banner Loja Acme 3×2m", av:"AC", grad:"av-2",
+      preview:"Mateus: Arquivo final aprovado, liberando p/ impressão.",
+      time:"14:32", unread:2, pinned:true,
+      stage:"Em produção", os:"#4821", client:"Acme Comércio Ltda",
+      online:true,
+      msgs: [
+        { d:"Hoje", who:"Joana Lima", side:"them", grad:"av-1", t:"Bom dia! Acabei de subir a arte revisada do banner 3×2m no drive da OS.", time:"09:14" },
+        { d:"Hoje", who:"Joana Lima", side:"them", grad:"av-1", t:"Ajustamos o sangramento e aumentei a logo em 6%, conforme pedido pelo cliente ontem.", time:"09:14", continued:true },
+        { d:"Hoje", who:"você", side:"me", t:"Perfeito, recebi. Vou conferir o perfil ICC e te respondo em 10min.", time:"09:21", read:true },
+        { d:"Hoje", who:"você", side:"me", t:"Cor calibrada, sangria ok. Liberado.", time:"09:34", read:true },
+        { d:"Hoje", who:"Mateus PCP", side:"them", grad:"av-3", t:"Nota interna: Encaixei na próxima carga da Roland 540, sai hoje 16h.", time:"10:02", note:true },
+        { d:"Hoje", who:"Joana Lima", side:"them", grad:"av-1", file:{name:"banner-acme-final-v3.pdf", size:"24.7 MB"}, time:"13:55" },
+        { d:"Hoje", who:"Mateus PCP", side:"them", grad:"av-3", t:"Arquivo final aprovado, liberando p/ impressão.", time:"14:32" },
+      ]},
+    { id:"c2", kind:"team", tag:"#equipe", title:"Produção — Turno A", av:"PA", grad:"av-3",
+      preview:"você: Pessoal, lembrete da reunião 17h.",
+      time:"13:10", unread:0, pinned:true, online:true,
+      msgs: [
+        { d:"Hoje", who:"Carla Souza", side:"them", grad:"av-5", t:"Bom dia turma! Bobina nova da Avery chegou, já estoquei.", time:"08:02" },
+        { d:"Hoje", who:"você", side:"me", t:"Pessoal, lembrete da reunião 17h.", time:"13:10", read:true },
+      ]},
+    { id:"c3", kind:"client", tag:"cliente", title:"Padaria Estrela — Renato", av:"RE", grad:"av-4",
+      preview:"Renato: Posso passar pra retirar amanhã 9h?",
+      time:"11:48", unread:1,
+      stage:"Aguardando retirada", client:"Padaria Estrela",
+      msgs: [
+        { d:"Ontem", who:"você", side:"me", t:"Boa tarde Renato! Seu pedido de cardápios está pronto.", time:"16:20", read:true },
+        { d:"Hoje", who:"Renato Lopes", side:"them", grad:"av-4", t:"Posso passar pra retirar amanhã 9h?", time:"11:48" },
+      ]},
+    { id:"c4", kind:"os", tag:"OS #4807", title:"Adesivos Recortados — TechPro", av:"TP", grad:"av-6",
+      preview:"Felipe: Recorte testado, aprovado pelo cliente.",
+      time:"Ontem", unread:0,
+      stage:"Acabamento", os:"#4807", client:"TechPro Equipamentos",
+      msgs: [
+        { d:"Ontem", who:"Felipe Acab.", side:"them", grad:"av-6", t:"Recorte testado, aprovado pelo cliente.", time:"17:20" },
+      ]},
+    { id:"c5", kind:"team", tag:"#equipe", title:"Comercial", av:"CM", grad:"av-5",
+      preview:"Bruna: Orçamento da Acme renovado.",
+      time:"Ontem", unread:0,
+      msgs: [
+        { d:"Ontem", who:"Bruna Vendas", side:"them", grad:"av-5", t:"Orçamento da Acme renovado.", time:"15:00" },
+      ]},
+    { id:"c6", kind:"client", tag:"cliente", title:"Clínica Vida — Marcos", av:"MV", grad:"av-2",
+      preview:"você: Vou te enviar o mockup hoje.", time:"Seg", unread:0,
+      msgs: [{ d:"Seg", who:"você", side:"me", t:"Vou te enviar o mockup hoje.", time:"10:00", read:true }]},
+  ],
+  wr: [
+    { id:"w1", kind:"os", tag:"OS #112", title:"Fachada Mercado União", av:"MU", grad:"av-3",
+      preview:"João: Vou medir hoje à tarde.", time:"15:02", unread:1,
+      stage:"Medição", os:"#112", client:"Mercado União",
+      msgs: [{ d:"Hoje", who:"João Inst.", side:"them", grad:"av-3", t:"Vou medir hoje à tarde.", time:"15:02" }]},
+    { id:"w2", kind:"team", tag:"#equipe", title:"Atendimento", av:"AT", grad:"av-2",
+      preview:"Lia: Cliente novo na linha 1.", time:"14:10", unread:0,
+      msgs: [{ d:"Hoje", who:"Lia", side:"them", grad:"av-2", t:"Cliente novo na linha 1.", time:"14:10" }]},
+  ],
+  gv: [
+    { id:"g1", kind:"team", tag:"#equipe", title:"Produção", av:"PR", grad:"av-3",
+      preview:"Sem mensagens novas.", time:"Sex", unread:0,
+      msgs: [{ d:"Sex", who:"Pedro", side:"them", grad:"av-3", t:"Tudo certo por aqui.", time:"17:00" }]},
+  ],
+};
+
+// ─── ROTINAS (atalhos pinados estilo "Routines" do print) ───
+const ROUTINES = [
+  { id:"r1", title:"Banner Acme — aprovação diária", freq:"Diário" },
+  { id:"r2", title:"Cobrança Padaria Estrela",       freq:"Uma vez" },
+  { id:"r3", title:"Reunião PCP — 8h30",             freq:"Diário" },
+  { id:"r4", title:"Fechamento Caixa",                freq:"Diário" },
+];
+
+// ─── TASKS (inbox unificada — todas as tarefas atribuídas ao usuário) ───
+// Cada task tem: origem (módulo), tipo de viewer, dados específicos.
+// Em produção: TaskRegistry agrega de cada módulo via TaskProvider interface.
+const TASKS = [
+  // ── HOJE
+  {
+    id:"t1", origin:"OS",  color:"amber",  viewer:"os_aprovar_arte",
+    title:"Aprovar arte final — Banner Acme 3×2m",
+    subtitle:"OS #4821 · Acme Comércio",
+    when:"hoje 14:00", group:"hoje", urgent:true, unread:true,
+    assigned:"você", from:"Joana Lima",
+    data: {
+      os:"#4821", client:"Acme Comércio Ltda", contact:"Camila Diniz",
+      product:"Banner Lona 440g — 3×2m", quantity:1,
+      stage:"Aprovar arte final", deadline:"Hoje, 14:00",
+      art:{ filename:"banner-acme-final-v3.pdf", size:"24.7 MB", version:3 },
+      history:[
+        {who:"Joana Lima",  when:"13:55", what:"subiu versão v3"},
+        {who:"Mateus PCP",  when:"10:02", what:"alocou na Roland 540 (16h)"},
+        {who:"Camila (cli)",when:"ontem 17:30", what:"pediu logo +6%"},
+      ],
+      thread:"c1",
+    },
+  },
+  {
+    id:"t2", origin:"CRM", color:"blue", viewer:"crm_ligar",
+    title:"Ligar para Renato — Padaria Estrela",
+    subtitle:"Retirada agendada 9h amanhã",
+    when:"hoje 16:30", group:"hoje", urgent:false, unread:false,
+    assigned:"você", from:"workflow",
+    data: {
+      lead:"Renato Lopes", company:"Padaria Estrela",
+      phone:"+55 11 98712-3344", whatsapp:"+55 11 98712-3344",
+      lastTouch:"hoje 11:48 — perguntou se pode retirar 9h amanhã",
+      notes:[
+        "Cliente recorrente — 4ª compra.",
+        "Pedido pronto desde ontem 16:20.",
+      ],
+      thread:"c3",
+    },
+  },
+  {
+    id:"t3", origin:"FIN", color:"emerald", viewer:"fin_aprovar_boleto",
+    title:"Aprovar boleto NF 1240 — Fornecedor Avery",
+    subtitle:"R$ 12.480,00 · vence amanhã",
+    when:"hoje", group:"hoje", urgent:false, unread:true,
+    assigned:"você", from:"workflow",
+    data: {
+      nf:"1240", supplier:"Avery Brasil", amount:"R$ 12.480,00",
+      due:"amanhã, 24/04", category:"Insumos · Bobina vinil",
+      ref:"Reposição estoque turno A — solicitado por Carla S.",
+      account:"Banco Itaú · CC 12345-6",
+      attached:"NF-1240.pdf · 312 KB",
+    },
+  },
+  {
+    id:"t4", origin:"PNT", color:"violet", viewer:"pnt_justificar",
+    title:"Justificar marcação faltante — 22/04",
+    subtitle:"Saída do almoço não registrada",
+    when:"hoje", group:"hoje", urgent:false, unread:false,
+    assigned:"você", from:"sistema",
+    data: {
+      date:"22/04/2025 (terça)",
+      missing:"Saída — almoço",
+      recorded:[
+        {label:"Entrada",        time:"08:02"},
+        {label:"Saída almoço",   time:"—",     missing:true},
+        {label:"Retorno almoço", time:"13:05"},
+        {label:"Saída",          time:"18:00"},
+      ],
+      suggestions:["Esqueci de bater","Almoço fora do escritório","Reunião externa"],
+    },
+  },
+
+  // ── ATRASADAS
+  {
+    id:"t5", origin:"OS", color:"amber", viewer:"os_aprovar_arte",
+    title:"Revisar prova — Adesivos TechPro",
+    subtitle:"OS #4807 · prova enviada há 2 dias",
+    when:"atrasada 2d", group:"atrasadas", urgent:true, unread:true,
+    assigned:"você", from:"Felipe Acab.",
+    data: {
+      os:"#4807", client:"TechPro Equipamentos", contact:"Diego Vasconcellos",
+      product:"Adesivos recortados — 200un · 8×8cm",
+      stage:"Revisar prova de recorte", deadline:"21/04 (atrasada 2d)",
+      art:{ filename:"techpro-adesivo-prova.pdf", size:"4.1 MB", version:1 },
+      history:[
+        {who:"Felipe Acab.", when:"21/04 17:20", what:"recorte testado, aguarda aprovação"},
+      ],
+      thread:"c4",
+    },
+  },
+  {
+    id:"t6", origin:"FIN", color:"emerald", viewer:"fin_aprovar_boleto",
+    title:"Aprovar boleto luz — abril",
+    subtitle:"R$ 3.245,00 · venceu ontem",
+    when:"atrasada 1d", group:"atrasadas", urgent:true, unread:true,
+    assigned:"você", from:"workflow",
+    data: {
+      nf:"—", supplier:"CPFL Energia", amount:"R$ 3.245,00",
+      due:"22/04 (atrasada 1d)", category:"Despesa fixa · Energia",
+      ref:"Conta de luz matriz — abril/25",
+      account:"Banco Itaú · CC 12345-6",
+      attached:"conta-luz-abril.pdf · 89 KB",
+    },
+  },
+
+  // ── ESTA SEMANA
+  {
+    id:"t7", origin:"CRM", color:"blue", viewer:"crm_ligar",
+    title:"Follow-up Mercado União — orçamento",
+    subtitle:"Orçamento enviado segunda",
+    when:"sex 10:00", group:"semana", urgent:false, unread:false,
+    assigned:"você", from:"workflow",
+    data: {
+      lead:"João Inst.", company:"Mercado União",
+      phone:"+55 11 99812-7700", whatsapp:"+55 11 99812-7700",
+      lastTouch:"seg 14:00 — orçamento enviado por e-mail",
+      notes:["Aguardando aprovação da diretoria."],
+      thread:"w1",
+    },
+  },
+  {
+    id:"t8", origin:"OS", color:"amber", viewer:"os_aprovar_arte",
+    title:"Aprovar arte — Lona Posto BR",
+    subtitle:"OS #4790 · revisão final",
+    when:"qui 11:00", group:"semana", urgent:false, unread:false,
+    assigned:"você", from:"Joana Lima",
+    data: {
+      os:"#4790", client:"Posto BR Centro", contact:"Marcos Vinícius",
+      product:"Lona Front-Light — 5×3m", quantity:1,
+      stage:"Aprovar arte final", deadline:"Quinta, 11:00",
+      art:{ filename:"posto-br-lona-v2.pdf", size:"31.2 MB", version:2 },
+      history:[],
+    },
+  },
+];
+
+// Cores dos badges de origem (que módulo gerou a tarefa)
+const ORIGIN_COLORS = {
+  OS:  { bg:"oklch(0.93 0.07 70)",  fg:"oklch(0.40 0.10 60)",  bgD:"oklch(0.30 0.07 60)",  fgD:"oklch(0.85 0.07 60)" },
+  CRM: { bg:"oklch(0.92 0.06 220)", fg:"oklch(0.40 0.10 220)", bgD:"oklch(0.30 0.07 220)", fgD:"oklch(0.85 0.07 220)" },
+  FIN: { bg:"oklch(0.93 0.07 145)", fg:"oklch(0.36 0.10 145)", bgD:"oklch(0.30 0.07 145)", fgD:"oklch(0.85 0.07 145)" },
+  PNT: { bg:"oklch(0.93 0.06 295)", fg:"oklch(0.40 0.10 295)", bgD:"oklch(0.30 0.07 295)", fgD:"oklch(0.85 0.07 295)" },
+  MFG: { bg:"oklch(0.93 0.05 30)",  fg:"oklch(0.40 0.10 30)",  bgD:"oklch(0.30 0.07 30)",  fgD:"oklch(0.85 0.07 30)" },
+};
+
+// ─── GROUP_META: ícone/label/descrição/cor de cada grupo ───
+const GROUP_META = {
+  "OFFICEIMPRESSO":    { icon:"orders",    label:"Operação",    hue: 60,  desc:"OS, clientes, catálogo, orçamentos, vendas, CV" },
+  "COMERCIAL":         { icon:"megaphone", label:"Comercial",   hue: 220, desc:"CRM, ADS, Grow, Caixa unificada, Equipe" },
+  "PRODUÇÃO":          { icon:"factory",   label:"Produção",    hue: 30,  desc:"Fila, acabamento, expedição, manufatura, briefs" },
+  "VERTICAIS":         { icon:"layers",    label:"Verticais",   hue: 350, desc:"Repair, oficina auto, vestuário" },
+  "PESSOAS":           { icon:"clients",   label:"Pessoas",     hue: 295, desc:"Ponto WR2, equipes" },
+  "FINANCEIRO":        { icon:"cash",      label:"Financeiro",  hue: 145, desc:"Caixa, boletos, compras, NF, contabilidade" },
+  "PROJETOS & GESTÃO": { icon:"briefcase", label:"Gestão",      hue: 240, desc:"Projetos, patrimônio, auditoria, governança, KB" },
+  "OUTROS":            { icon:"folder",    label:"Outros",      hue: 80,  desc:"MemCofre, Copiloto, Site, Arquivos" },
+  "INTEGRAÇÕES":       { icon:"plug",      label:"Integrações", hue: 200, desc:"Connector, WooCommerce, Team MCP, SRS" },
+  "CONFIGURAÇÕES":     { icon:"cog",       label:"Config.",     hue: 270, desc:"Preferências, usuários, admin, módulo ref." },
+};
+
+window.MOCK = { COMPANIES, MENU, CONV, ROUTINES, TASKS, ORIGIN_COLORS, GROUP_META };

--- a/prototipo-ui/financeiro-ai.jsx
+++ b/prototipo-ui/financeiro-ai.jsx
@@ -1,0 +1,368 @@
+// financeiro-ai.jsx — Refino #2 KB-9.75 · IA dentro do fluxo (2026-05-18)
+// 4 ferramentas:
+// - finAiPartyHistory(name) → stats da contraparte (média, sazonalidade, atrasos)
+// - <FinAiAnomalia row> → detecta valor outlier vs histórico
+// - <FinAiPartyContext row> → "perguntar à IA" sobre fornecedor/cliente
+// - <FinAiMonthDigest> → overlay com resumo executivo do mês (Eliana 5min sexta)
+//
+// Reusa CSS .vd-ai-* já existente em styles.css
+
+(() => {
+  const { useState, useMemo, useEffect } = React;
+
+  const _fmt = (n) => (n || 0).toLocaleString("pt-BR", { style:"currency", currency:"BRL" });
+  const _fmtShort = (n) => n >= 1000 ? "R$ " + (n/1000).toFixed(1).replace(".",",") + "k" : _fmt(n);
+
+  // ─────────────────────────────────────────────────────────────
+  // ANALYTICS: histórico de uma contraparte (party)
+  // ─────────────────────────────────────────────────────────────
+  window.finAiPartyHistory = function finAiPartyHistory(partyName, currentRow) {
+    const list = (window.FIN_ROWS || []).filter(r => r.party === partyName);
+    const mine = currentRow ? list.filter(r => r.id !== currentRow.id) : list;
+    if (mine.length === 0) {
+      return { count: 0, total: 0, avg: 0, isNew: true };
+    }
+    const total = mine.reduce((s, r) => s + r.amount, 0);
+    const avg = total / mine.length;
+    const paid = mine.filter(r => r.paid_at);
+    const overdue = mine.filter(r => r.status === "atrasado");
+    const onTime = paid.filter(r => r.paid_at && r.due && r.paid_at <= r.due).length;
+    const onTimePct = paid.length ? Math.round(onTime / paid.length * 100) : null;
+    const lastDate = mine.reduce((max, r) => {
+      const d = r.paid_at || r.due;
+      return !max || d > max ? d : max;
+    }, null);
+    // categoria mais comum
+    const catCount = {};
+    mine.forEach(r => { catCount[r.category] = (catCount[r.category] || 0) + 1; });
+    const topCat = Object.entries(catCount).sort((a,b) => b[1]-a[1])[0]?.[0];
+
+    return {
+      count: mine.length, total, avg,
+      paidCount: paid.length, overdueCount: overdue.length,
+      onTimePct, lastDate, topCat,
+      isNew: mine.length === 1,
+      isRecurrent: mine.length >= 3,
+    };
+  };
+
+  // ─────────────────────────────────────────────────────────────
+  // ANOMALIA: detecta valor fora do padrão histórico
+  // ─────────────────────────────────────────────────────────────
+  window.finAiAnomalia = function finAiAnomalia(row) {
+    const h = window.finAiPartyHistory(row.party, row);
+    if (!h.isRecurrent) return null;
+    const diff = row.amount - h.avg;
+    const pct = (diff / h.avg) * 100;
+    if (Math.abs(pct) < 25) return null;
+    return {
+      kind: diff > 0 ? "high" : "low",
+      pct,
+      avg: h.avg,
+      desc: diff > 0
+        ? `${pct.toFixed(0)}% acima da média histórica`
+        : `${Math.abs(pct).toFixed(0)}% abaixo da média histórica`,
+    };
+  };
+
+  // ─────────────────────────────────────────────────────────────
+  // GENERIC AI BLOCK (reusa CSS .vd-ai-*)
+  // ─────────────────────────────────────────────────────────────
+  function FinAiBlock({ icon = "✦", title, hint, prompt, parseResult, idleCta = "Gerar com IA" }) {
+    const [state, setState] = useState("idle");
+    const [result, setResult] = useState(null);
+
+    const run = async () => {
+      if (!window.claude?.complete) {
+        setState("error");
+        setResult("Helper window.claude.complete não disponível neste ambiente.");
+        return;
+      }
+      setState("loading");
+      try {
+        const text = await window.claude.complete(prompt);
+        setResult(parseResult ? parseResult(text) : text);
+        setState("done");
+      } catch (e) {
+        setResult(String(e?.message || e));
+        setState("error");
+      }
+    };
+
+    return (
+      <div className={`vd-ai-block vd-ai-${state}`}>
+        <header className="vd-ai-block-h">
+          <span className="vd-ai-ic">{icon}</span>
+          <div className="vd-ai-block-tx">
+            <b>{title}</b>
+            {hint && <small>{hint}</small>}
+          </div>
+          {state === "idle" && (
+            <button className="vd-ai-cta" onClick={run}>{idleCta}</button>
+          )}
+          {state === "loading" && (
+            <span className="vd-ai-loader"><span/><span/><span/></span>
+          )}
+          {(state === "done" || state === "error") && (
+            <button className="vd-ai-retry" onClick={run} title="Refazer">↻</button>
+          )}
+        </header>
+        {state === "loading" && (
+          <div className="vd-ai-skel">
+            <div className="vd-ai-skel-line" style={{width:"92%"}}/>
+            <div className="vd-ai-skel-line" style={{width:"78%"}}/>
+            <div className="vd-ai-skel-line" style={{width:"45%"}}/>
+          </div>
+        )}
+        {(state === "done" || state === "error") && (
+          <div className={`vd-ai-out ${state === "error" ? "err" : ""}`}>{result}</div>
+        )}
+      </div>
+    );
+  }
+
+  // ─────────────────────────────────────────────────────────────
+  // 1) ANOMALIA BANNER (mostrado direto no topo do drawer)
+  // ─────────────────────────────────────────────────────────────
+  function FinAiAnomaliaBanner({ row }) {
+    const a = useMemo(() => window.finAiAnomalia(row), [row.id, row.amount]);
+    if (!a) return null;
+    return (
+      <div className={`fin-ai-anomalia fin-ai-anomalia-${a.kind}`}>
+        <span className="fin-ai-anomalia-ic">{a.kind === "high" ? "⚠" : "ℹ"}</span>
+        <div className="fin-ai-anomalia-body">
+          <b>{a.desc}</b>
+          <small>Média histórica de <i>{row.party}</i>: {_fmt(a.avg)} · este lançamento: {_fmt(row.amount)}</small>
+        </div>
+        <button className="fin-ai-anomalia-cta">Investigar</button>
+      </div>
+    );
+  }
+  window.FinAiAnomaliaBanner = FinAiAnomaliaBanner;
+
+  // ─────────────────────────────────────────────────────────────
+  // 2) PARTY CONTEXT — relacionamento com fornecedor/cliente
+  // ─────────────────────────────────────────────────────────────
+  function FinAiPartyContext({ row }) {
+    const h = useMemo(() => window.finAiPartyHistory(row.party, row), [row.party, row.id]);
+    const isIn = row.kind === "receivable";
+
+    if (h.count === 0) {
+      return (
+        <div className="vd-ai-block vd-ai-disabled">
+          <header className="vd-ai-block-h">
+            <span className="vd-ai-ic">✦</span>
+            <div className="vd-ai-block-tx">
+              <b>{isIn ? "Cliente" : "Fornecedor"} novo</b>
+              <small>Sem histórico ainda. IA precisa de 2+ lançamentos pra inferir padrão.</small>
+            </div>
+          </header>
+        </div>
+      );
+    }
+
+    const lastDateStr = h.lastDate ? h.lastDate.toLocaleDateString("pt-BR") : "—";
+    const prompt = `Você é assistente do Financeiro da Oimpresso (gráfica). Em 2-3 frases curtas, descreva o relacionamento com ${isIn ? "este cliente" : "este fornecedor"}: padrão de pagamento + nível de relacionamento + atenção pro próximo lançamento.
+
+${isIn ? "Cliente" : "Fornecedor"}: ${row.party}
+Lançamentos: ${h.count} (${h.paidCount} já liquidados)
+Total acumulado: ${_fmt(h.total)} · ticket médio ${_fmt(h.avg)}
+Categoria mais frequente: ${h.topCat}
+Última operação: ${lastDateStr}
+${h.onTimePct != null ? `Pontualidade: ${h.onTimePct}% pagam/recebem no prazo` : ""}
+${h.overdueCount > 0 ? `Atrasados: ${h.overdueCount} lançamento(s) em atraso` : ""}
+
+Lançamento atual: ${_fmt(row.amount)} · vence ${row.due.toLocaleDateString("pt-BR")}.`;
+
+    return (
+      <div className="fin-ai-party">
+        <div className="vd-ai-stats">
+          <div className="vd-ai-stat">
+            <small>Lançamentos</small>
+            <b>{h.count}</b>
+            {h.isRecurrent && <span className="vd-ai-tag new">recorrente</span>}
+          </div>
+          <div className="vd-ai-stat">
+            <small>Total acumulado</small>
+            <b>{_fmtShort(h.total)}</b>
+          </div>
+          <div className="vd-ai-stat">
+            <small>Ticket médio</small>
+            <b>{_fmtShort(h.avg)}</b>
+          </div>
+          <div className="vd-ai-stat">
+            <small>Pontualidade</small>
+            <b>{h.onTimePct != null ? `${h.onTimePct}%` : "—"}</b>
+            {h.overdueCount > 0 && <span className="vd-ai-tag warn">{h.overdueCount}× atrasou</span>}
+          </div>
+        </div>
+        <FinAiBlock
+          title={`Perguntar à IA sobre ${isIn ? "este cliente" : "este fornecedor"}`}
+          hint={`Padrão de ${isIn ? "recebimento" : "pagamento"} · relacionamento · próximos passos`}
+          prompt={prompt}
+          idleCta="✦ Perguntar"/>
+      </div>
+    );
+  }
+  window.FinAiPartyContext = FinAiPartyContext;
+
+  // ─────────────────────────────────────────────────────────────
+  // 3) PANEL — usado no Drawer
+  // ─────────────────────────────────────────────────────────────
+  function FinAiPanel({ row }) {
+    return (
+      <section className="fin-ai-panel">
+        <div className="vd-ai-banner">
+          <span className="vd-ai-banner-ic">✦</span>
+          <div>
+            <b>IA copiloto</b>
+            <small>Anomalia · relacionamento com contraparte · resumo executivo. IA propõe, Eliana decide.</small>
+          </div>
+        </div>
+        <h3>Contraparte · {row.party}</h3>
+        <FinAiPartyContext row={row}/>
+      </section>
+    );
+  }
+  window.FinAiPanel = FinAiPanel;
+
+  // ─────────────────────────────────────────────────────────────
+  // 4) MONTH DIGEST — overlay com resumo executivo do mês
+  // ─────────────────────────────────────────────────────────────
+  function FinAiMonthDigest({ open, onClose }) {
+    useEffect(() => {
+      if (!open) return;
+      const onKey = (e) => { if (e.key === "Escape") onClose(); };
+      window.addEventListener("keydown", onKey);
+      return () => window.removeEventListener("keydown", onKey);
+    }, [open, onClose]);
+
+    const rows = window.FIN_ROWS || [];
+    const today = window.FIN_TODAY;
+
+    // Snapshot do mês corrente
+    const monthStart = today ? new Date(today.getFullYear(), today.getMonth(), 1) : null;
+    const monthRows = monthStart ? rows.filter(r => (r.due >= monthStart) || (r.paid_at && r.paid_at >= monthStart)) : rows;
+    const totalIn = monthRows.filter(r => r.kind === "receivable").reduce((s, r) => s + r.amount, 0);
+    const totalOut = monthRows.filter(r => r.kind === "payable").reduce((s, r) => s + r.amount, 0);
+    const recebido = monthRows.filter(r => r.kind === "receivable" && r.paid_at).reduce((s, r) => s + r.amount, 0);
+    const pago = monthRows.filter(r => r.kind === "payable" && r.paid_at).reduce((s, r) => s + r.amount, 0);
+    const aReceber = totalIn - recebido;
+    const aPagar = totalOut - pago;
+    const saldo = recebido - pago;
+    const previsto = saldo + aReceber - aPagar;
+    const overdue = rows.filter(r => r.status === "atrasado");
+
+    // Top categorias
+    const byCat = {};
+    monthRows.filter(r => r.kind === "payable").forEach(r => {
+      byCat[r.category] = (byCat[r.category] || 0) + r.amount;
+    });
+    const topCats = Object.entries(byCat).sort((a,b) => b[1]-a[1]).slice(0, 5);
+    const totalGasto = Object.values(byCat).reduce((s, v) => s + v, 0);
+
+    // Anomalias
+    const anomalias = monthRows.map(r => ({ r, a: window.finAiAnomalia(r) })).filter(x => x.a);
+
+    const monthName = monthStart ? monthStart.toLocaleDateString("pt-BR", { month: "long", year: "numeric" }) : "Este mês";
+
+    const aiPrompt = `Você é assistente financeiro da Oimpresso (gráfica). Em 3 frases curtas, gere um RESUMO EXECUTIVO do mês pra Eliana ler em 30s antes da reunião com Wagner. Seja direto, sem floreio.
+
+Mês: ${monthName}
+Saldo atual: ${_fmt(saldo)} (recebido ${_fmt(recebido)} - pago ${_fmt(pago)})
+Saldo previsto fim mês: ${_fmt(previsto)} (+ ${_fmt(aReceber)} a receber, - ${_fmt(aPagar)} a pagar)
+Maior categoria de gasto: ${topCats[0]?.[0]} · ${_fmt(topCats[0]?.[1] || 0)}
+Lançamentos em atraso: ${overdue.length}
+Anomalias detectadas: ${anomalias.length}
+
+Comente em 3 frases:
+1. Saúde financeira do mês
+2. Onde está saindo mais dinheiro
+3. Atenção pra próxima semana`;
+
+    if (!open) return null;
+
+    return (
+      <div className="fin-digest-overlay" onClick={onClose}>
+        <div className="fin-digest" onClick={e => e.stopPropagation()}>
+          <header className="fin-digest-h">
+            <span className="fin-digest-eyebrow">Resumo executivo · IA</span>
+            <h2>{monthName.charAt(0).toUpperCase() + monthName.slice(1)}</h2>
+            <button className="fin-digest-x" onClick={onClose} aria-label="Fechar (Esc)">×</button>
+          </header>
+
+          <div className="fin-digest-body">
+            <section className="fin-digest-snapshot">
+              <div className="fin-digest-card primary">
+                <small>Saldo previsto fim do mês</small>
+                <b className={previsto < 0 ? "neg" : "pos"}>{_fmt(previsto)}</b>
+                <span>realizado {_fmt(saldo)} · pendente {_fmt(aReceber - aPagar)}</span>
+              </div>
+              <div className="fin-digest-card">
+                <small>A receber</small>
+                <b className="pos">{_fmt(aReceber)}</b>
+                <span>{monthRows.filter(r => r.kind === "receivable" && !r.paid_at).length} lançamentos</span>
+              </div>
+              <div className="fin-digest-card">
+                <small>A pagar</small>
+                <b className="neg">{_fmt(aPagar)}</b>
+                <span>{monthRows.filter(r => r.kind === "payable" && !r.paid_at).length} lançamentos</span>
+              </div>
+              <div className={`fin-digest-card ${overdue.length > 0 ? "warn" : ""}`}>
+                <small>Em atraso</small>
+                <b>{overdue.length}</b>
+                <span>{_fmt(overdue.reduce((s,r) => s + r.amount, 0))} · atenção</span>
+              </div>
+            </section>
+
+            <section className="fin-digest-section">
+              <h3>Onde está saindo dinheiro</h3>
+              <ul className="fin-digest-cats">
+                {topCats.map(([cat, val]) => {
+                  const pct = (val / totalGasto) * 100;
+                  return (
+                    <li key={cat}>
+                      <span className="fin-digest-cat-l">{cat}</span>
+                      <div className="fin-digest-cat-bar"><div style={{width: pct + "%"}}/></div>
+                      <span className="fin-digest-cat-r">{_fmt(val)} <small>{pct.toFixed(0)}%</small></span>
+                    </li>
+                  );
+                })}
+              </ul>
+            </section>
+
+            {anomalias.length > 0 && (
+              <section className="fin-digest-section">
+                <h3>Anomalias detectadas <span className="fin-digest-tag">{anomalias.length}</span></h3>
+                <ul className="fin-digest-anomalias">
+                  {anomalias.slice(0, 5).map(({ r, a }, i) => (
+                    <li key={i}>
+                      <span className={`fin-digest-anomalia-tag ${a.kind === "high" ? "high" : "low"}`}>
+                        {a.kind === "high" ? "↑" : "↓"} {Math.abs(a.pct).toFixed(0)}%
+                      </span>
+                      <div>
+                        <b>{r.party}</b>
+                        <small>{r.desc.slice(0, 60)}{r.desc.length > 60 ? "…" : ""} · {_fmt(r.amount)}</small>
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              </section>
+            )}
+
+            <section className="fin-digest-section">
+              <h3>Análise da IA</h3>
+              <FinAiBlock
+                title="Gerar resumo executivo"
+                hint="3 frases · saúde financeira · maior gasto · atenção pra próxima semana"
+                prompt={aiPrompt}
+                idleCta="✦ Gerar"/>
+            </section>
+          </div>
+        </div>
+      </div>
+    );
+  }
+  window.FinAiMonthDigest = FinAiMonthDigest;
+
+})();

--- a/prototipo-ui/financeiro-app.jsx
+++ b/prototipo-ui/financeiro-app.jsx
@@ -1,0 +1,1096 @@
+// Financeiro — unified ledger app.
+// Single screen: KPI strip → segmented filter → unified table (entrada ↑ / saída ↓ intermixed by date) → drawer detail.
+// Density tweak: compact / comfortable / spacious. Persona: Eliana [E].
+// IIFE: encapsula tudo, expõe só window.FinanceiroPage.
+(() => {
+const { useState, useMemo, useEffect, useRef, useCallback } = React;
+const I = window.FIN_I; // ícones próprios do Financeiro (coexistem com `I` global do shell)
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Format helpers
+ * ─────────────────────────────────────────────────────────────────────── */
+const fmtBRL = (n) =>
+  n.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+const fmtBRLshort = (n) => {
+  if (Math.abs(n) >= 1000) return "R$ " + (n / 1000).toLocaleString("pt-BR", { minimumFractionDigits: 1, maximumFractionDigits: 1 }) + "k";
+  return fmtBRL(n);
+};
+const fmtDate = (d) =>
+  d.toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit" });
+const fmtDateLong = (d) =>
+  d.toLocaleDateString("pt-BR", { day: "2-digit", month: "short", year: "numeric" });
+const dayLabel = (delta) => {
+  if (delta === 0) return "hoje";
+  if (delta === 1) return "amanhã";
+  if (delta === -1) return "ontem";
+  if (delta > 0) return `em ${delta} dias`;
+  return `há ${-delta} dias`;
+};
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Density spec — driven by tweak
+ * ─────────────────────────────────────────────────────────────────────── */
+const DENSITY = {
+  compact:    { rowH: 32, py: "py-1",   text: "text-[12.5px]", gap: "gap-2", iconBox: 22 },
+  comfortable:{ rowH: 44, py: "py-2.5", text: "text-sm",       gap: "gap-3", iconBox: 26 },
+  spacious:   { rowH: 56, py: "py-4",   text: "text-sm",       gap: "gap-4", iconBox: 30 },
+};
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Status badge
+ * ─────────────────────────────────────────────────────────────────────── */
+const STATUS_STYLES = {
+  recebido: { bg: "bg-emerald-50", fg: "text-emerald-700", dot: "bg-emerald-500", label: "Recebido" },
+  pago:     { bg: "bg-emerald-50", fg: "text-emerald-700", dot: "bg-emerald-500", label: "Pago" },
+  pendente: { bg: "bg-stone-100",  fg: "text-stone-600",   dot: "bg-stone-400",   label: "Pendente" },
+  vencendo: { bg: "bg-amber-50",   fg: "text-amber-700",   dot: "bg-amber-500",   label: "Vencendo" },
+  atrasado: { bg: "bg-rose-50",    fg: "text-rose-700",    dot: "bg-rose-500",    label: "Atrasado" },
+};
+const StatusBadge = ({ status, compact }) => {
+  const s = STATUS_STYLES[status];
+  return (
+    <span className={`inline-flex items-center gap-1.5 ${compact ? "px-1.5 py-px" : "px-2 py-0.5"} rounded-full ${s.bg} ${s.fg} text-[11px] font-medium`}>
+      <span className={`w-1.5 h-1.5 rounded-full ${s.dot}`} />
+      {s.label}
+    </span>
+  );
+};
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Sidebar (Cockpit V2)
+ * ─────────────────────────────────────────────────────────────────────── */
+const NAV = [
+  { id: "dash",    label: "Dashboard",  icon: I.LayoutDashboard },
+  { id: "sells",   label: "Vendas",     icon: I.ShoppingBag },
+  { id: "repair",  label: "Repair",     icon: I.Wrench },
+  { id: "fin",     label: "Financeiro", icon: I.Wallet, active: true },
+  { id: "clients", label: "Clientes",   icon: I.Users },
+  { id: "catalog", label: "Catálogo",   icon: I.Box },
+  { id: "fiscal",  label: "Fiscal",     icon: I.FileText },
+];
+const FIN_SUB = [
+  { id: "unified", label: "Visão unificada" },
+  { id: "fluxo",   label: "Fluxo de caixa" },
+  { id: "concil",  label: "Conciliação" },
+  { id: "dre",     label: "DRE / Relatórios" },
+  { id: "pcontas", label: "Plano de contas" },
+];
+const FIN_SUB_TITLES = {
+  unified: "Visão unificada",
+  fluxo:   "Fluxo de caixa",
+  concil:  "Conciliação",
+  dre:     "DRE / Relatórios",
+  pcontas: "Plano de contas",
+};
+
+// ──────────────────────────────────────────────────────────────────────────
+// FinHero — usa o padrão `.os-page` (canonical do shell) ao invés de Tailwind:
+//   .os-page-h  (H1 + p + ações)  +  faixa de sub-rotas com border-bottom.
+// ──────────────────────────────────────────────────────────────────────────
+const FinHero = ({ tela, setTela, onCmdK, onNew, onDigest, onFechamento, onPresent }) => (
+  <>
+    <div className="os-page-h">
+      <div className="os-page-h-l">
+        <h1>Financeiro <span className="fin-hero-title-sub">· {FIN_SUB_TITLES[tela] || "Visão unificada"}</span></h1>
+        <p>Maio 2026 · ROTA LIVRE · caixa unificado</p>
+      </div>
+      <div className="os-page-h-r">
+        <button className="os-btn ghost" onClick={onCmdK}>
+          <I.Search size={12}/> Buscar
+          <kbd style={{ fontFamily: "var(--font-mono)", fontSize: 10, color: "var(--text-mute)", marginLeft: 4 }}>⌘K</kbd>
+        </button>
+        <button
+          className="os-btn ghost fin-btn-ai"
+          onClick={onDigest}
+          title="Resumo executivo do mês — IA + snapshot">
+          ✦ Resumir mês
+        </button>
+        <button
+          className="os-btn ghost fin-btn-trilha"
+          onClick={onFechamento}
+          title="Trilha de fechamento mensal — 12 passos">
+          ☑ Fechamento
+        </button>
+        <button
+          className="os-btn ghost fin-btn-present"
+          onClick={onPresent}
+          title="Modo apresentação — reunião com sócio">
+          ▶ Apresentar
+        </button>
+        <button
+          className={"os-btn ghost" + (tela === "concil" ? " on" : "")}
+          onClick={() => setTela(tela === "concil" ? "unified" : "concil")}
+          title="Conciliação bancária (extrato Inter)">
+          <I.Refresh size={12}/> Conciliar
+        </button>
+        <button
+          className={"os-btn ghost" + (tela === "pcontas" ? " on" : "")}
+          onClick={() => setTela(tela === "pcontas" ? "unified" : "pcontas")}
+          title="Plano de contas — categorias contábeis">
+          <I.Folder size={12}/> Plano de contas
+        </button>
+        <button className="os-btn ghost" title="Exportar"><I.Download size={12}/></button>
+        <button className="os-btn primary" onClick={onNew}><I.Plus size={12}/> Novo lançamento</button>
+      </div>
+    </div>
+  </>
+);
+
+// ─── (mantido apenas como referência; não usado mais no shell unificado) ───
+const _FinSidebarStandalone = ({ tela, setTela }) => (
+  <aside className="w-[220px] shrink-0 bg-white border-r border-stone-200 flex flex-col h-screen sticky top-0">
+    <div className="px-4 h-14 flex items-center gap-2 border-b border-stone-200">
+      <div className="w-7 h-7 rounded-md bg-stone-900 text-white grid place-items-center font-semibold text-[13px] tracking-tight">o</div>
+      <div className="flex-1">
+        <div className="text-[13px] font-semibold leading-tight">oimpresso</div>
+        <div className="text-[11px] text-stone-500 leading-tight">ROTA LIVRE</div>
+      </div>
+      <button className="w-6 h-6 grid place-items-center text-stone-400 hover:text-stone-700 rounded">
+        <I.ChevronLeft size={14} />
+      </button>
+    </div>
+
+    <nav className="flex-1 nice-scroll overflow-y-auto py-2 text-[13px]">
+      {NAV.map((n) => {
+        const Icon = n.icon;
+        return (
+          <div key={n.id}>
+            <a
+              href="#"
+              className={`mx-2 px-2.5 h-8 flex items-center gap-2.5 rounded-md transition-colors duration-150 ${
+                n.active
+                  ? "bg-stone-100 text-stone-900 font-medium"
+                  : "text-stone-600 hover:bg-stone-50 hover:text-stone-900"
+              }`}
+            >
+              <Icon size={16} className={n.active ? "text-stone-900" : "text-stone-500"} />
+              <span>{n.label}</span>
+              {n.id === "sells" && <span className="ml-auto text-[10px] text-stone-400 num">12</span>}
+              {n.id === "repair" && <span className="ml-auto text-[10px] text-stone-400 num">3</span>}
+            </a>
+            {n.active && (
+              <div className="mt-0.5 mb-1.5 ml-7 mr-2 border-l border-stone-200">
+                {FIN_SUB.map((s) => (
+                  <button
+                    key={s.id}
+                    onClick={() => setTela(s.id)}
+                    className={`w-full text-left pl-3 pr-2 h-7 flex items-center rounded-r-md text-[12.5px] transition-colors duration-150 ${
+                      tela === s.id
+                        ? "text-stone-900 font-medium border-l-2 -ml-px border-stone-900 bg-stone-50/60"
+                        : "text-stone-500 hover:text-stone-800"
+                    }`}
+                  >
+                    {s.label}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </nav>
+
+    <div className="border-t border-stone-200 p-3 flex items-center gap-2.5">
+      <div className="w-7 h-7 rounded-full bg-stone-200 grid place-items-center text-[11px] font-semibold text-stone-700">EL</div>
+      <div className="flex-1 min-w-0">
+        <div className="text-[12.5px] font-medium truncate">Eliana Lopes</div>
+        <div className="text-[11px] text-stone-500 truncate">Financeiro</div>
+      </div>
+      <button className="w-7 h-7 grid place-items-center rounded text-stone-500 hover:bg-stone-100">
+        <I.Settings size={14} />
+      </button>
+    </div>
+  </aside>
+);
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Header (sticky)
+ * ─────────────────────────────────────────────────────────────────────── */
+const Header = ({ onCmdK, onNew, telaTitle }) => (
+  <header className="sticky top-0 z-30 bg-white/85 backdrop-blur border-b border-stone-200">
+    <div className="px-6 h-14 flex items-center gap-4">
+      <div className="flex items-center gap-1.5 text-[12px] text-stone-500 whitespace-nowrap">
+        <span>Financeiro</span>
+        <I.ChevronRight size={12} className="text-stone-400" />
+        <span className="text-stone-900 font-medium">{telaTitle}</span>
+      </div>
+
+      <div className="flex-1" />
+
+      <button
+        onClick={onCmdK}
+        className="h-8 px-3 flex items-center gap-2 rounded-md border border-stone-200 bg-white text-[12.5px] text-stone-500 hover:text-stone-800 hover:border-stone-300 transition-colors duration-150 w-[200px]"
+      >
+        <I.Search size={14} />
+        <span className="truncate">Buscar lançamento…</span>
+        <span className="ml-auto flex items-center gap-1 text-[11px] text-stone-400 font-mono">
+          <kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-stone-50">⌘</kbd>
+          <kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-stone-50">K</kbd>
+        </span>
+      </button>
+
+      <button className="h-8 w-8 grid place-items-center rounded-md text-stone-500 hover:bg-stone-100 relative shrink-0">
+        <I.Bell size={16} />
+        <span className="absolute top-1.5 right-1.5 w-1.5 h-1.5 rounded-full bg-rose-500" />
+      </button>
+
+      <div className="h-5 w-px bg-stone-200 shrink-0" />
+
+      <button className="h-8 px-3 flex items-center gap-1.5 rounded-md border border-stone-200 text-[12.5px] text-stone-700 hover:bg-stone-50 transition-colors duration-150 shrink-0 whitespace-nowrap">
+        <I.Refresh size={14} />
+        Conciliar
+      </button>
+      <button className="h-8 w-8 grid place-items-center rounded-md border border-stone-200 text-stone-700 hover:bg-stone-50 transition-colors duration-150 shrink-0" title="Exportar">
+        <I.Download size={14} />
+      </button>
+      <button
+        onClick={onNew}
+        className="h-8 px-3 flex items-center gap-1.5 rounded-md bg-stone-900 text-white text-[12.5px] hover:bg-stone-800 transition-colors duration-150 shrink-0 whitespace-nowrap"
+      >
+        <I.Plus size={14} />
+        Novo
+      </button>
+    </div>
+
+    <div className="px-6 pt-4 pb-3 flex items-baseline gap-3">
+      <h1 className="text-[24px] font-semibold tracking-tight leading-none whitespace-nowrap">Financeiro</h1>
+      <span className="text-[11px] uppercase tracking-widest text-stone-500 font-medium whitespace-nowrap">Maio 2026 · ROTA LIVRE</span>
+      <div className="ml-auto text-[12px] text-stone-500 flex items-center gap-1.5 whitespace-nowrap shrink-0">
+        <I.Calendar size={13} />
+        <button className="text-stone-700 hover:text-stone-900 underline-offset-2 hover:underline">09 mai 2026</button>
+      </div>
+    </div>
+  </header>
+);
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * KPI strip
+ * ─────────────────────────────────────────────────────────────────────── */
+// KPIStrip refeito no padrão `.os-stats` do shell.
+const KPIStrip = ({ rows }) => {
+  const k = useMemo(() => {
+    const recebido = rows.filter((r) => r.kind === "receivable" && r.paid_at).reduce((s, r) => s + r.amount, 0);
+    const pago     = rows.filter((r) => r.kind === "payable"    && r.paid_at).reduce((s, r) => s + r.amount, 0);
+    const aReceber = rows.filter((r) => r.kind === "receivable" && !r.paid_at).reduce((s, r) => s + r.amount, 0);
+    const aPagar   = rows.filter((r) => r.kind === "payable"    && !r.paid_at).reduce((s, r) => s + r.amount, 0);
+    const atrasadoRec = rows.filter((r) => r.kind === "receivable" && !r.paid_at && r.status === "atrasado").reduce((s, r) => s + r.amount, 0);
+    const saldoAtual = recebido - pago;
+    const saldoPrevisto = saldoAtual + aReceber - aPagar;
+    return { recebido, pago, aReceber, aPagar, atrasadoRec, saldoAtual, saldoPrevisto };
+  }, [rows]);
+
+  return (
+    <div className="os-stats fin-stats">
+      <div className="os-stat fin-stat-hero">
+        <small>Saldo previsto · maio</small>
+        <b className="mono">{fmtBRL(k.saldoPrevisto)}</b>
+        <span className="fin-stat-hint">
+          <b className="mono">{fmtBRL(k.saldoAtual)}</b> realizado · {fmtBRLshort(k.aReceber - k.aPagar)} pendente
+        </span>
+        {/* Sparkline 30d — saldo projetado até fim do mês */}
+        <svg className="fin-spark" viewBox="0 0 200 36" preserveAspectRatio="none" aria-hidden="true">
+          <defs>
+            <linearGradient id="finSparkG" x1="0" x2="0" y1="0" y2="1">
+              <stop offset="0%" stopColor="oklch(0.78 0.13 145)" stopOpacity="0.5"/>
+              <stop offset="100%" stopColor="oklch(0.78 0.13 145)" stopOpacity="0"/>
+            </linearGradient>
+          </defs>
+          <path d="M0,30 L15,26 L30,22 L45,20 L60,18 L75,22 L90,16 L105,18 L120,14 L135,12 L150,16 L165,10 L180,12 L200,8 L200,36 L0,36 Z" fill="url(#finSparkG)"/>
+          <path d="M0,30 L15,26 L30,22 L45,20 L60,18 L75,22 L90,16 L105,18 L120,14 L135,12 L150,16 L165,10 L180,12 L200,8" stroke="oklch(0.78 0.13 145)" strokeWidth="1.5" fill="none"/>
+          <line x1="0" y1="24" x2="200" y2="24" stroke="oklch(0.65 0.01 80)" strokeWidth="0.5" strokeDasharray="2 3" opacity="0.4"/>
+        </svg>
+      </div>
+      <div className="os-stat">
+        <small>Recebido</small>
+        <b className="mono fin-num-pos">{fmtBRL(k.recebido)}</b>
+        <span className="fin-stat-hint">{rows.filter((r) => r.kind === "receivable" && r.paid_at).length} entradas confirmadas</span>
+      </div>
+      <div className="os-stat">
+        <small>A receber</small>
+        <b className="mono">{fmtBRL(k.aReceber)}</b>
+        <span className="fin-stat-hint"><span className="fin-num-neg mono">{fmtBRL(k.atrasadoRec)}</span> em atraso</span>
+      </div>
+      <div className="os-stat">
+        <small>Pago</small>
+        <b className="mono fin-num-neg">{fmtBRL(k.pago)}</b>
+        <span className="fin-stat-hint">{rows.filter((r) => r.kind === "payable" && r.paid_at).length} saídas liquidadas</span>
+      </div>
+      <div className="os-stat">
+        <small>A pagar</small>
+        <b className="mono">{fmtBRL(k.aPagar)}</b>
+        <span className="fin-stat-hint">próx. <b>10 mai · Suprigraf</b></span>
+      </div>
+    </div>
+  );
+};
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Filters
+ * ─────────────────────────────────────────────────────────────────────── */
+/* Ageing visual de "A receber" — barra empilhada por janela de vencimento */
+const FinAgeing = ({ rows }) => {
+  const k = useMemo(() => {
+    const open = rows.filter(r => r.kind === "receivable" && !r.paid_at);
+    const total = open.reduce((s, r) => s + r.amount, 0);
+    const buckets = { d30: 0, d60: 0, d90: 0, late: 0 };
+    for (const r of open) {
+      const delta = window.FIN_DAYS_FROM_TODAY(r.due);
+      if (delta < 0)         buckets.late += r.amount;
+      else if (delta <= 30)  buckets.d30 += r.amount;
+      else if (delta <= 60)  buckets.d60 += r.amount;
+      else                   buckets.d90 += r.amount;
+    }
+    const pct = (v) => total > 0 ? Math.round((v / total) * 100) : 0;
+    return { total, ...buckets, pd30: pct(buckets.d30), pd60: pct(buckets.d60), pd90: pct(buckets.d90), plate: pct(buckets.late) };
+  }, [rows]);
+  if (k.total === 0) return null;
+  return (
+    <div className="fin-ageing">
+      <div className="fin-ageing-l">
+        <small>A receber · ageing</small>
+        <b className="mono">{fmtBRL(k.total)}</b>
+      </div>
+      <div className="fin-ageing-bar">
+        {k.plate > 0 && <div className="seg s4" style={{ flex: k.plate }}>{k.plate}% atraso</div>}
+        {k.pd30 > 0 && <div className="seg s1" style={{ flex: k.pd30 }}>{k.pd30}% 0-30d</div>}
+        {k.pd60 > 0 && <div className="seg s2" style={{ flex: k.pd60 }}>{k.pd60}% 31-60d</div>}
+        {k.pd90 > 0 && <div className="seg s3" style={{ flex: k.pd90 }}>{k.pd90}% 61d+</div>}
+      </div>
+    </div>
+  );
+};
+
+const TABS = [
+  { id: "all",      label: "Todas" },
+  { id: "open",     label: "Aberto" },
+  { id: "rec",      label: "Receber" },
+  { id: "pay",      label: "Pagar" },
+  { id: "received", label: "Recebidas" },
+  { id: "paid",     label: "Pagas" },
+  { id: "late",     label: "Atraso" },
+];
+
+// 3 dimensões do FilterBar refatorado (substitui o tabs antigo)
+const FILTER_KIND = [
+  { id: "all", label: "Todas" },
+  { id: "rec", label: "A receber" },
+  { id: "pay", label: "A pagar" },
+];
+const FILTER_STATE = [
+  { id: "any",      label: "Qualquer" },
+  { id: "open",     label: "Em aberto" },
+  { id: "received", label: "Recebidas" },
+  { id: "paid",     label: "Pagas" },
+];
+
+const PERIOD_OPTS = ["Maio 2026", "Abril 2026", "Últimos 30 dias", "Trimestre", "Personalizado"];
+const CATEGORIES = ["Banner", "Adesivo", "Fachada", "Placa", "Gráfica rápida", "Insumo", "Aluguel", "Utilidade", "Imposto", "Folha", "Serviço"];
+
+// FilterBar refeito no padrão `.os-toolbar` do shell + pills de filtro.
+const FilterPill = ({ icon: Icon, label, value }) => (
+  <button className="os-btn ghost" style={{ height: 30 }}>
+    {Icon && <Icon size={11}/>}
+    <span style={{ color: "var(--text-mute)" }}>{label}</span>
+    <b style={{ fontWeight: 500, color: "var(--text)" }}>· {value}</b>
+    <I.ChevronDown size={10} style={{ color: "var(--text-mute)" }}/>
+  </button>
+);
+
+const FilterBar = ({ states, setStates, late, setLate, query, setQuery, period, setPeriod, density, setDensity, counts }) => {
+  const FILTER_LIFECYCLE = [
+    { id: "rec",      label: "A receber",  hue: 145 },
+    { id: "received", label: "Recebidas",  hue: 145 },
+    { id: "pay",      label: "A pagar",    hue: 25  },
+    { id: "paid",     label: "Pagas",      hue: 240 },
+  ];
+  const allOn = states.size === 0 || states.size === FILTER_LIFECYCLE.length;
+  const toggle = (id) => {
+    setStates(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+  };
+  const clear = () => setStates(new Set());
+
+  return (
+  <div className="os-toolbar fin-toolbar">
+    <div className="fin-filter-group" role="group" aria-label="Estado do lançamento">
+      {FILTER_LIFECYCLE.map(s => {
+        const on = states.has(s.id);
+        return (
+          <label key={s.id} className={"fin-filter-cb" + (on ? " on" : "")} style={on ? { ["--cb-hue"]: s.hue } : null}>
+            <input type="checkbox" checked={on} onChange={() => toggle(s.id)}/>
+            <span className="fin-filter-cb-box"/>
+            <span>{s.label}</span>
+            {counts[s.id] != null && <span className="fin-filter-ct">{counts[s.id]}</span>}
+          </label>
+        );
+      })}
+      {!allOn && (
+        <button className="fin-filter-clear" onClick={clear} title="Mostrar todas">Limpar</button>
+      )}
+    </div>
+
+    <span className="fin-filter-sep"/>
+
+    <label className={"fin-filter-toggle" + (late ? " on warn" : "")}>
+      <input type="checkbox" checked={late} onChange={e => setLate(e.target.checked)}/>
+      <span>Só atrasados</span>
+      {counts.late != null && counts.late > 0 && <span className="fin-filter-ct">{counts.late}</span>}
+    </label>
+
+    <div className="os-toolbar-r">
+      <div className="fin-density" role="group" aria-label="Densidade">
+        <button className={density === "compact"     ? "on" : ""} onClick={() => setDensity("compact")}     title="Compacta — mais linhas visíveis" aria-label="Compacta">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><line x1="3" y1="4" x2="13" y2="4"/><line x1="3" y1="7" x2="13" y2="7"/><line x1="3" y1="10" x2="13" y2="10"/><line x1="3" y1="13" x2="13" y2="13"/></svg>
+        </button>
+        <button className={density === "comfortable" ? "on" : ""} onClick={() => setDensity("comfortable")} title="Confortável" aria-label="Confortável">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><line x1="3" y1="4.5" x2="13" y2="4.5"/><line x1="3" y1="8" x2="13" y2="8"/><line x1="3" y1="11.5" x2="13" y2="11.5"/></svg>
+        </button>
+        <button className={density === "spacious"    ? "on" : ""} onClick={() => setDensity("spacious")}    title="Espaçosa" aria-label="Espaçosa">
+          <svg width="14" height="14" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round"><line x1="3" y1="5" x2="13" y2="5"/><line x1="3" y1="11" x2="13" y2="11"/></svg>
+        </button>
+      </div>
+      <div className="os-search">
+        <I.Search size={12}/>
+        <input value={query} onChange={e => setQuery(e.target.value)} placeholder="Filtrar nesta lista…"/>
+      </div>
+    </div>
+  </div>
+  );
+};
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Unified table
+ * ─────────────────────────────────────────────────────────────────────── */
+const DirIcon = ({ kind, status, size = 14 }) => {
+  const isIn = kind === "receivable";
+  const Icon = isIn ? I.ArrowDownLeft : I.ArrowUpRight;
+  // Inverted geometry: receivable = arrow IN to wallet (down-left), payable = arrow OUT (up-right)
+  const tone = isIn
+    ? (status === "recebido" ? "bg-emerald-50 text-emerald-700" : "bg-emerald-50/60 text-emerald-700/80")
+    : (status === "pago" ? "bg-rose-50 text-rose-700" : "bg-rose-50/60 text-rose-700/80");
+  return (
+    <span className={`inline-grid place-items-center rounded ${tone}`} style={{ width: size + 8, height: size + 8 }}>
+      <Icon size={size} strokeWidth={2} />
+    </span>
+  );
+};
+
+const Row = ({ row, density, selected, onSelect, onOpen, onMark, dim }) => {
+  const isIn = row.kind === "receivable";
+  const dens = DENSITY[density];
+  const delta = window.FIN_DAYS_FROM_TODAY(row.due);
+  const settled = !!row.paid_at;
+
+  return (
+    <tr
+      className={`border-b border-stone-100 row-hover cursor-pointer ${selected ? "row-selected" : ""} ${dim ? "opacity-55" : ""}`}
+      style={{ height: dens.rowH }}
+      onClick={() => onOpen(row)}
+    >
+      <td className={`pl-6 pr-2 ${dens.py}`} onClick={(e) => { e.stopPropagation(); onSelect(row.id); }}>
+        <input
+          type="checkbox"
+          checked={selected}
+          readOnly
+          className="w-3.5 h-3.5 rounded border-stone-300 accent-stone-900"
+        />
+      </td>
+      <td className={`px-2 ${dens.py} ${dens.text} text-stone-700 num whitespace-nowrap`}>
+        <div className="flex items-center gap-2">
+          <span className="font-medium">{fmtDate(row.due)}</span>
+          <span className={`text-[11px] ${
+            settled ? "text-stone-400" :
+            row.status === "atrasado" ? "text-rose-600" :
+            row.status === "vencendo" ? "text-amber-600" :
+            "text-stone-400"
+          }`}>
+            {settled ? `pago ${fmtDate(row.paid_at)}` : dayLabel(delta)}
+          </span>
+        </div>
+      </td>
+      <td className={`px-2 ${dens.py}`}>
+        <DirIcon kind={row.kind} status={row.status} size={density === "compact" ? 12 : 14} />
+      </td>
+      <td className={`px-2 ${dens.py} ${dens.text}`}>
+        <div className="flex items-center gap-2">
+          <span className="font-medium text-stone-900 truncate max-w-[280px]">{row.desc}</span>
+          {row.invoice && <span className="text-[10.5px] text-stone-400 font-mono">{row.invoice}</span>}
+        </div>
+      </td>
+      <td className={`px-2 ${dens.py} ${dens.text} text-stone-700 truncate max-w-[180px]`}>
+        {row.party}
+      </td>
+      <td className={`px-2 ${dens.py} ${dens.text} text-stone-500`}>
+        <span className="inline-flex items-center gap-1.5">
+          <span className="w-1.5 h-1.5 rounded-full bg-stone-300" />
+          {row.category}
+        </span>
+      </td>
+      <td className={`px-2 ${dens.py} ${dens.text}`}>
+        <StatusBadge status={row.status} compact={density === "compact"} />
+      </td>
+      <td className={`px-2 ${dens.py} ${dens.text} text-right num font-medium whitespace-nowrap ${
+        isIn ? "text-emerald-700" : "text-stone-900"
+      }`}>
+        <span className="text-stone-400 mr-0.5">{isIn ? "+" : "−"}</span>
+        {fmtBRL(row.amount).replace("R$", "").trim()}
+      </td>
+      <td className={`pl-2 pr-4 ${dens.py} text-right`} onClick={(e) => e.stopPropagation()}>
+        <div className="inline-flex items-center gap-1">
+          {!settled && (
+            <button
+              onClick={() => onMark(row.id)}
+              title={isIn ? "Marcar como recebido" : "Marcar como pago"}
+              className="h-7 px-2 inline-flex items-center gap-1 rounded text-[11.5px] text-emerald-700 hover:bg-emerald-50 transition-colors duration-150"
+            >
+              <I.Check size={13} />
+              <span>{isIn ? "Recebi" : "Paguei"}</span>
+            </button>
+          )}
+          <button className="w-7 h-7 grid place-items-center rounded text-stone-400 hover:bg-stone-100 hover:text-stone-700">
+            <I.More size={14} />
+          </button>
+        </div>
+      </td>
+    </tr>
+  );
+};
+
+const Table = ({ rows, density, selected, setSelected, onOpen, onMark }) => {
+  const dens = DENSITY[density];
+  // Group by date for subtle date headers — only for comfortable/spacious; compact omits to save vertical space.
+  const showDateHeaders = density !== "compact";
+  const groups = useMemo(() => {
+    const m = new Map();
+    for (const r of rows) {
+      const key = r.due.toISOString().slice(0, 10);
+      if (!m.has(key)) m.set(key, []);
+      m.get(key).push(r);
+    }
+    return [...m.entries()];
+  }, [rows]);
+
+  return (
+    <div className="mx-6 mt-2 bg-white border border-stone-200 rounded-md shadow-sm overflow-hidden">
+      <table className="w-full border-collapse">
+        <thead>
+          <tr className="text-[10px] uppercase tracking-widest text-stone-500 border-b border-stone-200 bg-stone-50/40">
+            <th className="pl-6 pr-2 py-2 w-8 text-left">
+              <input
+                type="checkbox"
+                checked={selected.size > 0 && selected.size === rows.length}
+                ref={(el) => { if (el) el.indeterminate = selected.size > 0 && selected.size < rows.length; }}
+                onChange={() => {
+                  if (selected.size === rows.length) setSelected(new Set());
+                  else setSelected(new Set(rows.map((r) => r.id)));
+                }}
+                className="w-3.5 h-3.5 rounded border-stone-300 accent-stone-900"
+              />
+            </th>
+            <th className="px-2 py-2 text-left font-medium">Vencimento</th>
+            <th className="px-2 py-2 w-8 text-left font-medium"></th>
+            <th className="px-2 py-2 text-left font-medium">Lançamento</th>
+            <th className="px-2 py-2 text-left font-medium">Contraparte</th>
+            <th className="px-2 py-2 text-left font-medium">Categoria</th>
+            <th className="px-2 py-2 text-left font-medium">Status</th>
+            <th className="px-2 py-2 text-right font-medium">Valor</th>
+            <th className="pl-2 pr-4 py-2 w-[110px] text-right font-medium"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {showDateHeaders ? (
+            groups.map(([key, gr]) => {
+              const date = new Date(key + "T12:00:00");
+              const delta = window.FIN_DAYS_FROM_TODAY(date);
+              const todayish = delta === 0;
+              return (
+                <React.Fragment key={key}>
+                  <tr className="bg-stone-50/60 border-b border-stone-100">
+                    <td colSpan={10} className="px-6 py-1.5">
+                      <div className="text-[10.5px] uppercase tracking-widest text-stone-500 font-medium flex items-center gap-2">
+                        <span>{fmtDateLong(date)}</span>
+                        <span className="text-stone-400 normal-case tracking-normal text-[11px]">· {dayLabel(delta)}{todayish ? " · hoje" : ""}</span>
+                      </div>
+                    </td>
+                  </tr>
+                  {gr.map((r) => (
+                    <Row
+                      key={r.id}
+                      row={r}
+                      density={density}
+                      selected={selected.has(r.id)}
+                      onSelect={(id) => setSelected((s) => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; })}
+                      onOpen={onOpen}
+                      onMark={onMark}
+                      dim={!!r.paid_at}
+                    />
+                  ))}
+                </React.Fragment>
+              );
+            })
+          ) : (
+            rows.map((r) => (
+              <Row
+                key={r.id}
+                row={r}
+                density={density}
+                selected={selected.has(r.id)}
+                onSelect={(id) => setSelected((s) => { const n = new Set(s); n.has(id) ? n.delete(id) : n.add(id); return n; })}
+                onOpen={onOpen}
+                onMark={onMark}
+                dim={!!r.paid_at}
+              />
+            ))
+          )}
+        </tbody>
+      </table>
+
+      {rows.length === 0 && (
+        <div className="py-16 text-center text-stone-500 text-sm">
+          Nenhum lançamento bate com esses filtros.
+        </div>
+      )}
+    </div>
+  );
+};
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Footer (sticky) — batch actions + summary
+ * ─────────────────────────────────────────────────────────────────────── */
+const FooterBar = ({ rows, selected, onClearSelected, onMarkAll }) => {
+  const selRows = rows.filter((r) => selected.has(r.id));
+  const totalIn  = selRows.filter((r) => r.kind === "receivable").reduce((s, r) => s + r.amount, 0);
+  const totalOut = selRows.filter((r) => r.kind === "payable").reduce((s, r) => s + r.amount, 0);
+
+  return (
+    <div className="sticky bottom-0 z-20 mx-6 mb-4 mt-3 rounded-md border border-stone-200 bg-white shadow-sm flex items-center px-4 h-12 text-[12.5px]">
+      {selRows.length === 0 ? (
+        <>
+          <div className="flex items-center gap-4 text-stone-500">
+            <span><span className="text-stone-900 font-medium num">{rows.length}</span> lançamentos</span>
+            <span className="h-3 w-px bg-stone-200" />
+            <span>Total entrada: <span className="text-emerald-700 font-medium num">{fmtBRL(rows.filter((r) => r.kind === "receivable").reduce((s, r) => s + r.amount, 0))}</span></span>
+            <span>Total saída: <span className="text-stone-900 font-medium num">{fmtBRL(rows.filter((r) => r.kind === "payable").reduce((s, r) => s + r.amount, 0))}</span></span>
+          </div>
+          <div className="ml-auto text-[11.5px] text-stone-400 font-mono flex items-center gap-2">
+            <kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-stone-50 text-stone-600">J</kbd>
+            <kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-stone-50 text-stone-600">K</kbd>
+            <span>navegar</span>
+            <span className="text-stone-300">·</span>
+            <kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-stone-50 text-stone-600">␣</kbd>
+            <span>marcar pago/recebido</span>
+            <span className="text-stone-300">·</span>
+            <kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-stone-50 text-stone-600">/</kbd>
+            <span>buscar</span>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="flex items-center gap-3">
+            <span className="text-stone-900 font-medium num">{selRows.length} selecionados</span>
+            <span className="h-3 w-px bg-stone-200" />
+            {totalIn > 0 && <span className="text-emerald-700 num">+ {fmtBRL(totalIn)}</span>}
+            {totalOut > 0 && <span className="text-stone-900 num">− {fmtBRL(totalOut)}</span>}
+          </div>
+          <div className="ml-auto flex items-center gap-2">
+            <button onClick={onClearSelected} className="h-8 px-3 rounded-md border border-stone-200 text-stone-600 hover:bg-stone-50 transition-colors duration-150">Limpar</button>
+            <button className="h-8 px-3 rounded-md border border-stone-200 text-stone-700 hover:bg-stone-50 transition-colors duration-150">Editar em lote</button>
+            <button className="h-8 px-3 rounded-md border border-stone-200 text-stone-700 hover:bg-stone-50 transition-colors duration-150 inline-flex items-center gap-1.5"><I.Download size={13}/>Exportar</button>
+            <button onClick={onMarkAll} className="h-8 px-3 rounded-md bg-emerald-600 hover:bg-emerald-700 text-white transition-colors duration-150 inline-flex items-center gap-1.5">
+              <I.Check size={13} />
+              Liquidar selecionados
+            </button>
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Drawer — detail of one transaction
+ * ─────────────────────────────────────────────────────────────────────── */
+const Drawer = ({ row, onClose, onMark }) => {
+  const comments = window.useFinComments ? window.useFinComments() : null;
+  const conferido = window.useFinConferido ? window.useFinConferido() : null;
+  if (!row) return null;
+  const isIn = row.kind === "receivable";
+  const settled = !!row.paid_at;
+  const delta = window.FIN_DAYS_FROM_TODAY(row.due);
+  const Linkify = window.VdLinkify;
+  const isConferido = conferido && conferido.has(row.id);
+
+  return (
+    <>
+      <div onClick={onClose} className="fixed inset-0 z-40 bg-stone-900/20" />
+      <aside className="fixed top-0 right-0 z-50 h-screen w-[440px] bg-white border-l border-stone-200 shadow-md drawer-shown flex flex-col">
+        <div className="px-5 h-14 flex items-center gap-3 border-b border-stone-200">
+          <DirIcon kind={row.kind} status={row.status} size={16} />
+          <div className="flex-1 min-w-0">
+            <div className="text-[11px] uppercase tracking-widest text-stone-500 font-medium flex items-center gap-2">
+              {isIn ? "A receber" : "A pagar"} · {row.id}
+              {isConferido && <span className="fin-conf-pill-inline">✓ conferido</span>}
+            </div>
+            <div className="text-[14px] font-semibold truncate">
+              {Linkify ? <Linkify text={row.desc} onPick={(id) => console.log("→", id)}/> : row.desc}
+            </div>
+          </div>
+          <button onClick={onClose} className="w-8 h-8 grid place-items-center rounded text-stone-500 hover:bg-stone-100">
+            <I.X size={16} />
+          </button>
+        </div>
+
+        <div className="flex-1 overflow-y-auto nice-scroll px-5 py-4 space-y-5 text-[13px]">
+          {window.FinAiAnomaliaBanner && <window.FinAiAnomaliaBanner row={row}/>}
+          <div>
+            <div className={`text-[11px] uppercase tracking-widest font-medium ${
+              row.status === "atrasado" ? "text-rose-700" : row.status === "vencendo" ? "text-amber-700" : "text-stone-500"
+            }`}>
+              {settled ? "Liquidado" : "Vencimento"}
+            </div>
+            <div className="mt-1 flex items-baseline gap-2">
+              <div className="text-[22px] font-semibold tracking-tight num">{fmtDateLong(row.due)}</div>
+              <div className="text-[12px] text-stone-500">{settled ? `pago em ${fmtDateLong(row.paid_at)}` : dayLabel(delta)}</div>
+            </div>
+            <div className="mt-3 flex items-baseline gap-2">
+              <div className={`text-[34px] font-semibold tracking-tight num ${isIn ? "text-emerald-700" : "text-stone-900"}`}>
+                {isIn ? "+ " : "− "}{fmtBRL(row.amount)}
+              </div>
+              <StatusBadge status={row.status} />
+              {window.FinPillFrescor && <window.FinPillFrescor row={row}/>}
+            </div>
+            {conferido && window.FinConferidoToggle && (
+              <div className="mt-3">
+                <window.FinConferidoToggle row={row} conferido={conferido}/>
+              </div>
+            )}
+          </div>
+
+          <div className="border-t border-stone-100 pt-4 grid grid-cols-2 gap-y-3">
+            <div>
+              <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Contraparte</div>
+              <div className="mt-0.5 font-medium text-stone-900">{row.party}</div>
+            </div>
+            <div>
+              <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Categoria</div>
+              <div className="mt-0.5 text-stone-700">{row.category}</div>
+            </div>
+            <div>
+              <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Canal</div>
+              <div className="mt-0.5 text-stone-700">{row.channel}</div>
+            </div>
+            <div>
+              <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Documento</div>
+              <div className="mt-0.5 text-stone-700 font-mono text-[12px]">
+                {Linkify ? <Linkify text={row.invoice} onPick={(id) => console.log("→", id)}/> : row.invoice}
+              </div>
+            </div>
+            <div className="col-span-2">
+              <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Conta</div>
+              <div className="mt-0.5 text-stone-700 flex items-center gap-1.5"><I.Bank size={13} className="text-stone-400" />Itaú PJ · ag 0438 · cc 4521-7</div>
+            </div>
+          </div>
+
+          <div className="border-t border-stone-100 pt-4">
+            <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Conciliação extrato</div>
+            {settled ? (
+              <div className="mt-2 rounded-md border border-emerald-200 bg-emerald-50/60 px-3 py-2.5 flex items-start gap-2.5">
+                <I.Link size={14} className="text-emerald-700 mt-0.5" />
+                <div className="text-[12.5px]">
+                  <div className="text-emerald-800 font-medium">Conciliado com OFX 04392</div>
+                  <div className="text-emerald-700/80">{fmtDateLong(row.paid_at)} · {fmtBRL(row.amount)} · 100% match</div>
+                </div>
+              </div>
+            ) : (
+              <div className="mt-2 rounded-md border border-stone-200 px-3 py-2.5 text-[12.5px] text-stone-600 flex items-start gap-2.5">
+                <I.Sparkles size={14} className="text-stone-500 mt-0.5" />
+                <div>
+                  Sem match no extrato. Ao liquidar, o sistema procura linhas próximas (±R$ 5,00 e ±2 dias) e sugere conciliação automática.
+                </div>
+              </div>
+            )}
+          </div>
+
+          <div className="border-t border-stone-100 pt-4">
+            {window.FinAuditTrail
+              ? <window.FinAuditTrail row={row}/>
+              : (
+                <>
+                  <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Histórico</div>
+                  <ol className="mt-2 space-y-2.5 text-[12.5px]">
+                    <li>Sem registros</li>
+                  </ol>
+                </>
+              )}
+          </div>
+
+          {comments && window.FinCommentsThread && (
+            <div className="border-t border-stone-100 pt-4">
+              <window.FinCommentsThread rowId={row.id} comments={comments}/>
+            </div>
+          )}
+
+          {window.FinAiPanel && (
+            <div className="border-t border-stone-100 pt-4">
+              <window.FinAiPanel row={row}/>
+            </div>
+          )}
+        </div>
+
+        <div className="border-t border-stone-200 px-5 h-14 flex items-center gap-2">
+          {window.FinTroubleButton && <window.FinTroubleButton row={row}/>}
+          <button className="h-8 px-3 rounded-md border border-stone-200 text-[12.5px] text-stone-700 hover:bg-stone-50 transition-colors duration-150 inline-flex items-center gap-1.5">
+            <I.Eye size={13} />Ver NFe
+          </button>
+          <button className="h-8 px-3 rounded-md border border-stone-200 text-[12.5px] text-stone-700 hover:bg-stone-50 transition-colors duration-150 inline-flex items-center gap-1.5">
+            <I.Send size={13} />Cobrar
+          </button>
+          <div className="ml-auto" />
+          {!settled && (
+            <button
+              onClick={() => { onMark(row.id); onClose(); }}
+              className="h-8 px-3.5 rounded-md bg-emerald-600 hover:bg-emerald-700 text-white text-[12.5px] inline-flex items-center gap-1.5 transition-colors duration-150"
+            >
+              <I.Check size={13} />Marcar como {isIn ? "recebido" : "pago"}
+            </button>
+          )}
+        </div>
+      </aside>
+    </>
+  );
+};
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Cmd+K palette
+ * ─────────────────────────────────────────────────────────────────────── */
+const CmdK = ({ open, onClose, rows, onPick }) => {
+  const [q, setQ] = useState("");
+  const inputRef = useRef(null);
+  useEffect(() => { if (open) { setQ(""); setTimeout(() => inputRef.current?.focus(), 0); } }, [open]);
+
+  const ql = q.trim().toLowerCase();
+  const matches = !ql ? rows.slice(0, 8) : rows.filter((r) =>
+    r.desc.toLowerCase().includes(ql) ||
+    r.party.toLowerCase().includes(ql) ||
+    r.invoice.toLowerCase().includes(ql) ||
+    r.id.toLowerCase().includes(ql) ||
+    r.category.toLowerCase().includes(ql)
+  ).slice(0, 10);
+
+  if (!open) return null;
+  return (
+    <div className="fixed inset-0 z-[60] cp-backdrop bg-stone-900/30 grid place-items-start pt-24" onClick={onClose}>
+      <div onClick={(e) => e.stopPropagation()} className="w-[560px] bg-white rounded-lg border border-stone-200 shadow-md overflow-hidden">
+        <div className="flex items-center gap-3 px-4 h-12 border-b border-stone-200">
+          <I.Search size={15} className="text-stone-400" />
+          <input
+            ref={inputRef}
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Buscar lançamento, cliente, NFe, categoria…"
+            className="flex-1 outline-none text-[14px] placeholder:text-stone-400"
+          />
+          <kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-stone-50 text-[10.5px] text-stone-500 font-mono">Esc</kbd>
+        </div>
+        <div className="max-h-[360px] overflow-y-auto nice-scroll py-1.5">
+          {matches.length === 0 && (
+            <div className="px-4 py-8 text-center text-[13px] text-stone-500">Nada encontrado para "{q}".</div>
+          )}
+          {matches.map((r) => (
+            <button
+              key={r.id}
+              onClick={() => { onPick(r); onClose(); }}
+              className="w-full px-4 py-2 flex items-center gap-3 hover:bg-stone-50 text-left transition-colors duration-150"
+            >
+              <DirIcon kind={r.kind} status={r.status} size={14} />
+              <div className="flex-1 min-w-0">
+                <div className="text-[13px] font-medium text-stone-900 truncate">{r.desc}</div>
+                <div className="text-[11.5px] text-stone-500 truncate">{r.party} · {r.category} · {r.invoice}</div>
+              </div>
+              <div className={`text-[13px] num font-medium ${r.kind === "receivable" ? "text-emerald-700" : "text-stone-900"}`}>
+                {r.kind === "receivable" ? "+" : "−"} {fmtBRL(r.amount)}
+              </div>
+            </button>
+          ))}
+        </div>
+        <div className="border-t border-stone-200 px-4 h-9 flex items-center justify-between text-[11px] text-stone-500">
+          <div className="flex items-center gap-3">
+            <span className="flex items-center gap-1"><kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-stone-50 font-mono text-stone-500">↑↓</kbd> navegar</span>
+            <span className="flex items-center gap-1"><kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-stone-50 font-mono text-stone-500">↵</kbd> abrir</span>
+          </div>
+          <span>{matches.length} de {rows.length}</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * Tweaks panel
+ * ─────────────────────────────────────────────────────────────────────── */
+const TWEAK_DEFAULTS = /*EDITMODE-BEGIN*/{
+  "density": "comfortable",
+  "showWeekend": true,
+  "groupByDate": true
+}/*EDITMODE-END*/;
+
+const FinTweaks = ({ tweaks, setTweak }) => (
+  <TweaksPanel title="Tweaks">
+    <TweakSection label="Tabela">
+      <TweakRadio
+        label="Densidade"
+        value={tweaks.density}
+        onChange={(v) => setTweak("density", v)}
+        options={[
+          { value: "compact", label: "Compacta" },
+          { value: "comfortable", label: "Confortável" },
+          { value: "spacious", label: "Espaçosa" },
+        ]}
+      />
+      <TweakToggle
+        label="Agrupar por data"
+        value={tweaks.groupByDate}
+        onChange={(v) => setTweak("groupByDate", v)}
+      />
+    </TweakSection>
+  </TweaksPanel>
+);
+
+/* ─────────────────────────────────────────────────────────────────────────
+ * App
+ * ─────────────────────────────────────────────────────────────────────── */
+const FinanceiroPage = ({ initialTela = "unified" }) => {
+  const [rows, setRows] = useState(() => window.FIN_ROWS);
+  const [tab, setTab] = useState("all");
+  // Refino 2026-05-18: 4 checkboxes lifecycle + toggle late (substitui tab)
+  const [states, setStates] = useState(() => new Set(["rec","received","pay","paid"]));
+  const [late, setLate] = useState(false);
+  // Refino #2 IA — digest do mês
+  const [digestOpen, setDigestOpen] = useState(false);
+  // Refino #3 Guia + Saída
+  const [fechamentoOpen, setFechamentoOpen] = useState(false);
+  const [presentOpen, setPresentOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [period, setPeriod] = useState("Maio 2026");
+  const [selected, setSelected] = useState(new Set());
+  const [drawerRow, setDrawerRow] = useState(null);
+  const [cmdkOpen, setCmdkOpen] = useState(false);
+  // useState local em vez de useTweaks: o shell unificado já tem painel Tweaks próprio.
+  const [density, setDensity] = useState("compact");
+  const [groupByDate, setGroupByDate] = useState(true);
+  const t = { density, groupByDate };
+  const [tela, setTela] = useState(initialTela);
+  // refletir mudança de rota
+  useEffect(() => { setTela(initialTela); }, [initialTela]);
+
+  // counts per tab
+  const counts = useMemo(() => ({
+    all: rows.length,
+    open: rows.filter((r) => !r.paid_at).length,
+    rec: rows.filter((r) => r.kind === "receivable" && !r.paid_at).length,
+    pay: rows.filter((r) => r.kind === "payable" && !r.paid_at).length,
+    received: rows.filter((r) => r.kind === "receivable" && r.paid_at).length,
+    paid: rows.filter((r) => r.kind === "payable" && r.paid_at).length,
+    late: rows.filter((r) => !r.paid_at && r.status === "atrasado").length,
+  }), [rows]);
+
+  const filtered = useMemo(() => {
+    let r = rows;
+    // 4 checkboxes lifecycle: rec/received/pay/paid
+    if (states.size > 0 && states.size < 4) {
+      r = r.filter(x => {
+        const k = x.kind === "receivable"
+          ? (x.paid_at ? "received" : "rec")
+          : (x.paid_at ? "paid" : "pay");
+        return states.has(k);
+      });
+    } else if (states.size === 0) {
+      r = []; // nada marcado = nada exibido
+    }
+    if (late) r = r.filter(x => !x.paid_at && x.status === "atrasado");
+    if (tab === "open") r = r.filter((x) => !x.paid_at);
+    if (tab === "rec") r = r.filter((x) => x.kind === "receivable" && !x.paid_at);
+    if (tab === "pay") r = r.filter((x) => x.kind === "payable" && !x.paid_at);
+    if (tab === "received") r = r.filter((x) => x.kind === "receivable" && x.paid_at);
+    if (tab === "paid") r = r.filter((x) => x.kind === "payable" && x.paid_at);
+    if (tab === "late") r = r.filter((x) => !x.paid_at && x.status === "atrasado");
+    if (query.trim()) {
+      const q = query.toLowerCase();
+      r = r.filter((x) =>
+        x.desc.toLowerCase().includes(q) ||
+        x.party.toLowerCase().includes(q) ||
+        x.category.toLowerCase().includes(q) ||
+        x.invoice.toLowerCase().includes(q)
+      );
+    }
+    return r;
+  }, [rows, tab, query, states, late]);
+
+  const handleMark = useCallback((id) => {
+    setRows((rs) => rs.map((r) => r.id === id ? { ...r, paid_at: window.FIN_TODAY, status: r.kind === "receivable" ? "recebido" : "pago" } : r));
+  }, []);
+
+  const handleMarkAll = useCallback(() => {
+    setRows((rs) => rs.map((r) => selected.has(r.id) && !r.paid_at
+      ? { ...r, paid_at: window.FIN_TODAY, status: r.kind === "receivable" ? "recebido" : "pago" }
+      : r
+    ));
+    setSelected(new Set());
+  }, [selected]);
+
+  // Keyboard: ⌘K, /, Esc
+  useEffect(() => {
+    const onKey = (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault();
+        setCmdkOpen(true);
+      } else if (e.key === "/" && !["INPUT", "TEXTAREA"].includes(document.activeElement?.tagName)) {
+        e.preventDefault();
+        setCmdkOpen(true);
+      } else if (e.key === "Escape") {
+        setCmdkOpen(false);
+        setDrawerRow(null);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  const tableRowsDensity = density;
+
+  return (
+    <div className="os-page fin-root" data-screen-label="01 Financeiro">
+      <FinHero tela={tela} setTela={setTela}
+               onCmdK={() => setCmdkOpen(true)}
+               onNew={() => {}}
+               onDigest={() => setDigestOpen(true)}
+               onFechamento={() => setFechamentoOpen(true)}
+               onPresent={() => setPresentOpen(true)} />
+
+      <div className="fin-body">
+        {tela === "unified" && <>
+          <KPIStrip rows={rows} />
+          <FilterBar states={states} setStates={setStates} late={late} setLate={setLate} counts={counts} query={query} setQuery={setQuery} period={period} setPeriod={setPeriod} density={density} setDensity={setDensity} />
+          <Table rows={filtered} density={tableRowsDensity} selected={selected} setSelected={setSelected} onOpen={setDrawerRow} onMark={handleMark} />
+          <FooterBar rows={filtered} selected={selected} onClearSelected={() => setSelected(new Set())} onMarkAll={handleMarkAll} />
+        </>}
+        {tela === "fluxo"   && <window.TelaFluxo onBack={() => setTela("unified")} />}
+        {tela === "concil"  && <window.TelaConciliacao onBack={() => setTela("unified")} />}
+        {tela === "dre"     && <window.TelaDRE onBack={() => setTela("unified")} />}
+        {tela === "pcontas" && <window.TelaPContas onBack={() => setTela("unified")} />}
+      </div>
+
+      <Drawer row={drawerRow} onClose={() => setDrawerRow(null)} onMark={handleMark} />
+      <CmdK open={cmdkOpen} onClose={() => setCmdkOpen(false)} rows={rows} onPick={setDrawerRow} />
+      {window.FinAiMonthDigest && <window.FinAiMonthDigest open={digestOpen} onClose={() => setDigestOpen(false)} />}
+      {window.FinFechamentoTrilha && <window.FinFechamentoTrilha open={fechamentoOpen} onClose={() => setFechamentoOpen(false)} onNavigate={setTela} />}
+      {window.FinPresentationMode && <window.FinPresentationMode open={presentOpen} onClose={() => setPresentOpen(false)} />}
+    </div>
+  );
+};
+
+window.FinanceiroPage = FinanceiroPage;
+})();

--- a/prototipo-ui/financeiro-curation.jsx
+++ b/prototipo-ui/financeiro-curation.jsx
@@ -1,0 +1,262 @@
+// financeiro-curation.jsx — Refino #1 KB-9.75 · Curadoria (2026-05-18)
+// 4 features espelhando vendas-curation.jsx:
+// - useFinComments: thread de comentários por lançamento (Eliana ↔ produção)
+// - useFinConferido: marca paritária "já conferi" (toggle Eliana)
+// - finAuditTrail: histórico determinístico criação/edição/conciliação
+// - FinPillFrescor: pill de SLA (novo / a vencer / vencendo / atrasado / pago)
+
+(() => {
+  const { useState, useEffect, useMemo } = React;
+
+  // ─────────────────────────────────────────────────────────────
+  // 1) Comentários inline por lançamento
+  //   Storage: oimpresso.financeiro.comments = { rowId: [{author,text,when}] }
+  // ─────────────────────────────────────────────────────────────
+  const _finLoadComments = () => {
+    try { return JSON.parse(localStorage.getItem("oimpresso.financeiro.comments") || "{}"); }
+    catch (e) { return {}; }
+  };
+  const _finSaveComments = (m) => {
+    try { localStorage.setItem("oimpresso.financeiro.comments", JSON.stringify(m)); } catch (e) {}
+  };
+
+  function useFinComments() {
+    const [m, setM] = useState(_finLoadComments);
+    useEffect(() => { _finSaveComments(m); }, [m]);
+    return {
+      get: (rowId) => m[rowId] || [],
+      add: (rowId, text, author) => setM(prev => ({
+        ...prev,
+        [rowId]: [...(prev[rowId] || []), { author: author || "Eliana", text, when: new Date().toLocaleString("pt-BR", { day:"2-digit", month:"2-digit", hour:"2-digit", minute:"2-digit" }) }],
+      })),
+      remove: (rowId, idx) => setM(prev => {
+        const next = { ...prev };
+        next[rowId] = (next[rowId] || []).filter((_, i) => i !== idx);
+        if (next[rowId].length === 0) delete next[rowId];
+        return next;
+      }),
+      countFor: (rowId) => (m[rowId] || []).length,
+      hasAny: () => Object.keys(m).length > 0,
+    };
+  }
+  window.useFinComments = useFinComments;
+
+  // ─────────────────────────────────────────────────────────────
+  // 2) "Conferido" — toggle paritário de Eliana
+  //   Storage: oimpresso.financeiro.conferido = ["R-2641", ...]
+  // ─────────────────────────────────────────────────────────────
+  const _finLoadConferido = () => {
+    try { return new Set(JSON.parse(localStorage.getItem("oimpresso.financeiro.conferido") || "[]")); }
+    catch (e) { return new Set(); }
+  };
+  const _finSaveConferido = (s) => {
+    try { localStorage.setItem("oimpresso.financeiro.conferido", JSON.stringify([...s])); } catch (e) {}
+  };
+
+  function useFinConferido() {
+    const [set, setSet] = useState(_finLoadConferido);
+    useEffect(() => { _finSaveConferido(set); }, [set]);
+    return {
+      has: (id) => set.has(id),
+      toggle: (id, who) => {
+        setSet(prev => {
+          const next = new Set(prev);
+          if (next.has(id)) next.delete(id); else next.add(id);
+          return next;
+        });
+      },
+      count: set.size,
+    };
+  }
+  window.useFinConferido = useFinConferido;
+
+  // ─────────────────────────────────────────────────────────────
+  // 3) Audit trail determinístico (mock — em produção viria do backend)
+  // ─────────────────────────────────────────────────────────────
+  function finAuditTrail(row) {
+    const seed = (row.id || "").charCodeAt(row.id.length - 1) % 4;
+    const entries = [];
+    // Sempre: criação
+    const dueDate = row.due instanceof Date ? row.due.toLocaleDateString("pt-BR") : row.due;
+    entries.push({
+      when: `${row.due.toLocaleDateString("pt-BR", { day:"2-digit", month:"2-digit" })} ${row.kind === "receivable" ? "emitido" : "recebido"}`,
+      who: row.kind === "receivable" ? "Bruna Vendas" : "Suprigraf · NF",
+      kind: "create",
+      desc: `Lançamento ${row.id} · ${row.desc.slice(0, 48)}${row.desc.length > 48 ? "…" : ""}`,
+    });
+    // Categorização (sempre)
+    entries.push({
+      when: `${row.due.toLocaleDateString("pt-BR", { day:"2-digit", month:"2-digit" })} ${("0" + (row.due.getHours() + 1)).slice(-2)}:${("0" + row.due.getMinutes()).slice(-2)}`,
+      who: "Eliana Financeiro",
+      kind: "categorize",
+      desc: `Classificado em "${row.category}"`,
+    });
+    // Edição de valor — só se seed >= 2
+    if (seed >= 2) {
+      const oldAmount = Math.round(row.amount * 0.94 * 100) / 100;
+      const diff = row.amount - oldAmount;
+      entries.push({
+        when: `${row.due.toLocaleDateString("pt-BR", { day:"2-digit", month:"2-digit" })} ajuste`,
+        who: "Eliana Financeiro",
+        kind: "edit",
+        desc: `Valor revisado · R$ ${oldAmount.toFixed(2)} → R$ ${row.amount.toFixed(2)}`,
+        diff: { from: oldAmount, to: row.amount, pct: (diff / oldAmount * 100) },
+      });
+    }
+    // Conciliação — só se pago
+    if (row.paid_at) {
+      entries.push({
+        when: row.paid_at.toLocaleDateString("pt-BR"),
+        who: "Banco (Inter)",
+        kind: "concil",
+        desc: `Conciliado com extrato · ${row.channel || "—"}`,
+      });
+    }
+    // Atrasado
+    if (row.status === "atrasado") {
+      entries.push({
+        when: "agora",
+        who: "sistema",
+        kind: "alert",
+        desc: `⚠ Vencimento ultrapassou — em atraso`,
+      });
+    }
+    return entries;
+  }
+  window.finAuditTrail = finAuditTrail;
+
+  function FinAuditTrail({ row }) {
+    const entries = useMemo(() => finAuditTrail(row), [row.id, row.paid_at]);
+    const KIND_LABEL = { create: "criou", categorize: "categorizou", edit: "editou", concil: "conciliou", alert: "alerta" };
+    const KIND_IC = { create: "+", categorize: "▦", edit: "✎", concil: "≣", alert: "⚠" };
+    return (
+      <div className="fin-audit">
+        <div className="fin-audit-h">
+          <h4>Histórico</h4>
+          <small>{entries.length} eventos · auditoria contábil</small>
+        </div>
+        <ul className="fin-audit-list">
+          {entries.map((e, i) => (
+            <li key={i} className={`fin-audit-row fin-audit-${e.kind}`}>
+              <span className="fin-audit-ic">{KIND_IC[e.kind] || "·"}</span>
+              <div className="fin-audit-body">
+                <header>
+                  <b>{e.who}</b>
+                  <span className="fin-audit-action">{KIND_LABEL[e.kind] || ""}</span>
+                  <time>{e.when}</time>
+                </header>
+                <p>{e.desc}</p>
+                {e.diff && (
+                  <div className="fin-audit-diff">
+                    <span className="diff-from">R$ {e.diff.from.toFixed(2)}</span>
+                    <span className="diff-arr">→</span>
+                    <span className="diff-to">R$ {e.diff.to.toFixed(2)}</span>
+                    <span className={`diff-pct ${e.diff.pct < 0 ? "neg" : "pos"}`}>
+                      {e.diff.pct > 0 ? "+" : ""}{e.diff.pct.toFixed(1)}%
+                    </span>
+                  </div>
+                )}
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+  window.FinAuditTrail = FinAuditTrail;
+
+  // ─────────────────────────────────────────────────────────────
+  // 4) Pill de frescor (novo · a vencer · vencendo · atrasado · pago)
+  // ─────────────────────────────────────────────────────────────
+  function finFrescorInfo(row) {
+    if (row.paid_at) {
+      const days = Math.round((window.FIN_TODAY - row.paid_at) / 86400000);
+      return { kind: "paid", label: days === 0 ? "pago hoje" : `pago ${days}d atrás`, ic: "✓" };
+    }
+    const daysUntil = Math.round((row.due - window.FIN_TODAY) / 86400000);
+    if (daysUntil < 0) return { kind: "overdue", label: `${-daysUntil}d em atraso`, ic: "✕" };
+    if (daysUntil === 0) return { kind: "today", label: "vence hoje", ic: "●" };
+    if (daysUntil <= 3) return { kind: "warning", label: `${daysUntil}d`, ic: "▲" };
+    if (daysUntil <= 7) return { kind: "soon", label: `${daysUntil}d`, ic: "○" };
+    return { kind: "fresh", label: `${daysUntil}d`, ic: "○" };
+  }
+  window.finFrescorInfo = finFrescorInfo;
+
+  function FinPillFrescor({ row, compact }) {
+    const s = finFrescorInfo(row);
+    return (
+      <span className={`fin-frescor fin-frescor-${s.kind}`} title={s.label}>
+        <span className="fin-frescor-ic">{s.ic}</span>
+        {!compact && <span className="fin-frescor-lbl">{s.label}</span>}
+      </span>
+    );
+  }
+  window.FinPillFrescor = FinPillFrescor;
+
+  // ─────────────────────────────────────────────────────────────
+  // 5) FinConferidoToggle — botão grande no drawer
+  // ─────────────────────────────────────────────────────────────
+  function FinConferidoToggle({ row, conferido }) {
+    const isOn = conferido.has(row.id);
+    return (
+      <button
+        className={`fin-conferido-toggle ${isOn ? "on" : ""}`}
+        onClick={() => conferido.toggle(row.id, "Eliana")}
+        title={isOn ? "Desmarcar conferido (Eliana já bateu olho)" : "Marcar como conferido"}>
+        <span className="fin-conf-check">{isOn ? "✓" : ""}</span>
+        <span className="fin-conf-lbl">{isOn ? "Conferido" : "Conferir"}</span>
+        {!isOn && <small>Eliana valida</small>}
+      </button>
+    );
+  }
+  window.FinConferidoToggle = FinConferidoToggle;
+
+  // ─────────────────────────────────────────────────────────────
+  // 6) Comments thread (compact)
+  // ─────────────────────────────────────────────────────────────
+  function FinCommentsThread({ rowId, comments }) {
+    const [text, setText] = useState("");
+    const list = comments.get(rowId);
+    const submit = () => {
+      const t = text.trim();
+      if (!t) return;
+      comments.add(rowId, t, "Eliana");
+      setText("");
+    };
+    return (
+      <div className="fin-comments">
+        <div className="fin-comments-h">
+          <h4>Comentários</h4>
+          <small>{list.length} · visíveis pra Eliana · Wagner · Bruna</small>
+        </div>
+        {list.length > 0 && (
+          <ul className="fin-comments-list">
+            {list.map((c, i) => (
+              <li key={i} className="fin-comment">
+                <span className="fin-comment-av">{(c.author || "?").charAt(0).toUpperCase()}</span>
+                <div className="fin-comment-body">
+                  <header>
+                    <b>{c.author}</b>
+                    <time>{c.when}</time>
+                    <button className="fin-comment-x" onClick={() => comments.remove(rowId, i)} title="Remover">×</button>
+                  </header>
+                  <p>{c.text}</p>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+        <div className="fin-comment-new">
+          <textarea
+            value={text} rows={2}
+            onChange={e => setText(e.target.value)}
+            onKeyDown={e => { if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) { e.preventDefault(); submit(); } }}
+            placeholder='Ex: "Conferi com Bruna, valor correto" · "Anexar comprovante" · ⌘↵ envia'/>
+          <button onClick={submit} disabled={!text.trim()}>Comentar</button>
+        </div>
+      </div>
+    );
+  }
+  window.FinCommentsThread = FinCommentsThread;
+
+})();

--- a/prototipo-ui/financeiro-data.jsx
+++ b/prototipo-ui/financeiro-data.jsx
@@ -1,0 +1,67 @@
+// Mock data — ROTA LIVRE-style print/visual-comm shop, May 2026.
+// Entries mix Receivable (entrada ↑) and Payable (saída ↓) so the unified
+// table can intermix them by date — the way Wagner asked.
+
+const TODAY = new Date(2026, 4, 9); // 2026-05-09 (Sat) — matches "today" in env
+
+function d(yyyy_mm_dd) { return new Date(yyyy_mm_dd + "T12:00:00"); }
+function daysFromToday(date) {
+  return Math.round((date - TODAY) / 86400000);
+}
+function statusFor(row) {
+  if (row.kind === "receivable") {
+    if (row.paid_at) return "recebido";
+    const delta = daysFromToday(row.due);
+    if (delta < 0) return "atrasado";
+    if (delta <= 3) return "vencendo";
+    return "pendente";
+  } else {
+    if (row.paid_at) return "pago";
+    const delta = daysFromToday(row.due);
+    if (delta < 0) return "atrasado";
+    if (delta <= 3) return "vencendo";
+    return "pendente";
+  }
+}
+
+const RAW = [
+  // ── A RECEBER · entrada ↑ ────────────────────────────────────────────────
+  { id: "R-2641", kind: "receivable", desc: "Banner lona 4×1m — promo dia das mães · #V-7832 #OS-4831", party: "Padaria Pão Quente", category: "Banner", amount: 480.00, due: d("2026-05-12"), paid_at: null, channel: "PIX", invoice: "NF 4112", status: "vencendo" },
+  { id: "R-2641a", kind: "receivable", desc: "Banner anúncio venda Páscoa", party: "Padaria Pão Quente", category: "Banner", amount: 320.00, due: d("2026-03-22"), paid_at: d("2026-03-23"), channel: "PIX", invoice: "NF 4080", status: "recebido" },
+  { id: "R-2641b", kind: "receivable", desc: "Etiqueta adesiva 1000un", party: "Padaria Pão Quente", category: "Adesivo", amount: 290.00, due: d("2026-04-15"), paid_at: d("2026-04-16"), channel: "PIX", invoice: "NF 4096", status: "recebido" },
+  { id: "R-2641c", kind: "receivable", desc: "Banner promoção férias", party: "Padaria Pão Quente", category: "Banner", amount: 410.00, due: d("2026-01-20"), paid_at: d("2026-01-22"), channel: "PIX", invoice: "NF 4012", status: "recebido" },
+  { id: "R-2642", kind: "receivable", desc: "Adesivagem frota (12 veículos) · #V-7823 #OS-4833 #BL-4113", party: "Auto Posto Trevo", category: "Adesivo", amount: 2340.00, due: d("2026-05-15"), paid_at: null, channel: "Boleto", invoice: "NFe 8422" },
+  { id: "R-2643", kind: "receivable", desc: "Lona fachada 2×6m + instalação", party: "Loja Bella Moda", category: "Fachada", amount: 1890.00, due: d("2026-05-03"), paid_at: null, channel: "Boleto", invoice: "NFe 8418" },
+  { id: "R-2644", kind: "receivable", desc: "Placas de obra (8un + suporte)", party: "Construtora Vértice", category: "Placa", amount: 3200.00, due: d("2026-05-22"), paid_at: null, channel: "Boleto", invoice: "NFe 8425" },
+  { id: "R-2645", kind: "receivable", desc: "Cartão fidelidade laminado 1000un", party: "Farmácia Saúde Total", category: "Gráfica rápida", amount: 720.00, due: d("2026-05-06"), paid_at: d("2026-05-06"), channel: "PIX", invoice: "NFe 8419" },
+  { id: "R-2646", kind: "receivable", desc: "Cardápio menu plastificado 40un", party: "Restaurante Sabor & Cia", category: "Gráfica rápida", amount: 340.00, due: d("2026-05-18"), paid_at: null, channel: "PIX", invoice: "NFe 8426" },
+  { id: "R-2647", kind: "receivable", desc: "Banner 3×1m — show local · #V-7831", party: "Studio Foco", category: "Banner", amount: 380.00, due: d("2026-05-04"), paid_at: d("2026-05-04"), channel: "PIX", invoice: "NFe 8417" },
+  { id: "R-2648", kind: "receivable", desc: "Wind banner 2.5m + base", party: "Imobiliária Horizonte", category: "Banner", amount: 560.00, due: d("2026-05-20"), paid_at: null, channel: "Boleto", invoice: "NFe 8427" },
+  { id: "R-2649", kind: "receivable", desc: "Envelopamento veículo Hilux · #V-7829 #BL-4118", party: "Transporte Veloz Ltda", category: "Adesivo", amount: 4200.00, due: d("2026-04-28"), paid_at: null, channel: "Boleto", invoice: "NFe 8410" },
+  { id: "R-2650", kind: "receivable", desc: "Lona backdrop 3×2m + ilhós", party: "Academia Movimento", category: "Banner", amount: 290.00, due: d("2026-05-10"), paid_at: null, channel: "PIX", invoice: "NFe 8423" },
+  { id: "R-2651", kind: "receivable", desc: "Placa ACM fachada 1.5×0.6m", party: "Clínica Vida Plena", category: "Fachada", amount: 880.00, due: d("2026-05-07"), paid_at: d("2026-05-07"), channel: "PIX", invoice: "NFe 8420" },
+  { id: "R-2652", kind: "receivable", desc: "Faixa aniversário 5×0.7m", party: "Maria Aparecida (PF)", category: "Banner", amount: 120.00, due: d("2026-05-09"), paid_at: null, channel: "PIX", invoice: "NFe 8424" },
+  { id: "R-2653", kind: "receivable", desc: "Cartões de visita 4×4 — 4000un", party: "Imobiliária Horizonte", category: "Gráfica rápida", amount: 540.00, due: d("2026-05-25"), paid_at: null, channel: "Boleto", invoice: "NFe 8428" },
+  { id: "R-2654", kind: "receivable", desc: "Rótulo adesivo perolado 2000un", party: "Cervejaria Lupulada", category: "Adesivo", amount: 1640.00, due: d("2026-04-30"), paid_at: null, channel: "Boleto", invoice: "NFe 8412" },
+
+  // ── A PAGAR · saída ↓ ────────────────────────────────────────────────────
+  { id: "P-1882", kind: "payable", desc: "Papel couché 250g — 4 resmas · #PC-281 #BL-9982", party: "Suprigraf Distribuidora", category: "Insumo", amount: 2450.00, due: d("2026-05-10"), paid_at: null, channel: "Boleto", invoice: "NF 11402" },
+  { id: "P-1883", kind: "payable", desc: "Energia elétrica abril/2026", party: "Equatorial Energia", category: "Utilidade", amount: 1180.40, due: d("2026-05-14"), paid_at: null, channel: "Débito autom.", invoice: "Fat 9981" },
+  { id: "P-1884", kind: "payable", desc: "Aluguel galpão maio/2026", party: "Imobiliária Centro", category: "Aluguel", amount: 4500.00, due: d("2026-05-02"), paid_at: d("2026-05-02"), channel: "Transferência", invoice: "Recibo 045" },
+  { id: "P-1885", kind: "payable", desc: "Internet + telefonia maio", party: "Vivo Empresas", category: "Utilidade", amount: 320.00, due: d("2026-05-03"), paid_at: d("2026-05-03"), channel: "Débito autom.", invoice: "Fat 7711" },
+  { id: "P-1886", kind: "payable", desc: "IPTU 5ª parcela", party: "Prefeitura Municipal", category: "Imposto", amount: 890.00, due: d("2026-05-20"), paid_at: null, channel: "Boleto", invoice: "DAM 0058" },
+  { id: "P-1887", kind: "payable", desc: "Tinta solvente CMYK plotter", party: "Tinta Solvent BR", category: "Insumo", amount: 650.00, due: d("2026-05-16"), paid_at: null, channel: "PIX", invoice: "NF 03340" },
+  { id: "P-1888", kind: "payable", desc: "Laminação BOPP 200m", party: "Alphagraf Acabamento", category: "Serviço", amount: 1120.00, due: d("2026-05-05"), paid_at: d("2026-05-05"), channel: "PIX", invoice: "NF 02281" },
+  { id: "P-1889", kind: "payable", desc: "Manutenção plotter Roland", party: "TecPlot Assistência", category: "Serviço", amount: 780.00, due: d("2026-05-11"), paid_at: null, channel: "PIX", invoice: "OS 1144" },
+  { id: "P-1890", kind: "payable", desc: "Salário Larissa — abril (compl.)", party: "Folha — Larissa Souza", category: "Folha", amount: 2800.00, due: d("2026-05-05"), paid_at: d("2026-05-05"), channel: "Transferência", invoice: "Folha 04/26" },
+  { id: "P-1891", kind: "payable", desc: "Lona 440g blackout — 50m", party: "Suprigraf Distribuidora", category: "Insumo", amount: 1980.00, due: d("2026-05-19"), paid_at: null, channel: "Boleto", invoice: "NF 11418" },
+  { id: "P-1892", kind: "payable", desc: "Simples Nacional DAS abril", party: "Receita Federal", category: "Imposto", amount: 2110.00, due: d("2026-04-22"), paid_at: d("2026-04-22"), channel: "Boleto", invoice: "DAS 04/26" },
+  { id: "P-1893", kind: "payable", desc: "Recolhimento INSS abril", party: "Receita Federal", category: "Imposto", amount: 612.00, due: d("2026-05-21"), paid_at: null, channel: "Boleto", invoice: "GPS 04/26" },
+];
+
+const ROWS = RAW.map((r) => ({ ...r, status: statusFor(r) }))
+  .sort((a, b) => a.due - b.due);
+
+window.FIN_TODAY = TODAY;
+window.FIN_ROWS = ROWS;
+window.FIN_DAYS_FROM_TODAY = daysFromToday;

--- a/prototipo-ui/financeiro-icons.jsx
+++ b/prototipo-ui/financeiro-icons.jsx
@@ -1,0 +1,64 @@
+// Icon set — equivalent of lucide-react picks used here.
+// Stroke 1.75, size 16/18 default. All accept className + size.
+// IIFE para não vazar `const Icon` / `const I` no escopo global (coexiste com icons.jsx do shell).
+(() => {
+const Icon = ({ children, size = 16, className = "", strokeWidth = 1.75 }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    width={size}
+    height={size}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={strokeWidth}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    className={className}
+    aria-hidden="true"
+  >
+    {children}
+  </svg>
+);
+
+const I = {
+  Search: (p) => <Icon {...p}><circle cx="11" cy="11" r="7" /><path d="m21 21-4.3-4.3" /></Icon>,
+  Plus: (p) => <Icon {...p}><path d="M12 5v14M5 12h14" /></Icon>,
+  Filter: (p) => <Icon {...p}><path d="M3 6h18M6 12h12M10 18h4" /></Icon>,
+  Download: (p) => <Icon {...p}><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4" /><path d="M7 10l5 5 5-5" /><path d="M12 15V3" /></Icon>,
+  Check: (p) => <Icon {...p}><path d="M20 6 9 17l-5-5" /></Icon>,
+  X: (p) => <Icon {...p}><path d="M18 6 6 18M6 6l12 12" /></Icon>,
+  ChevronDown: (p) => <Icon {...p}><path d="m6 9 6 6 6-6" /></Icon>,
+  ChevronRight: (p) => <Icon {...p}><path d="m9 6 6 6-6 6" /></Icon>,
+  ChevronLeft: (p) => <Icon {...p}><path d="m15 18-6-6 6-6" /></Icon>,
+  More: (p) => <Icon {...p}><circle cx="12" cy="12" r="1" /><circle cx="19" cy="12" r="1" /><circle cx="5" cy="12" r="1" /></Icon>,
+  ArrowUp: (p) => <Icon {...p}><path d="M12 19V5M5 12l7-7 7 7" /></Icon>,
+  ArrowDown: (p) => <Icon {...p}><path d="M12 5v14M5 12l7 7 7-7" /></Icon>,
+  ArrowUpRight: (p) => <Icon {...p}><path d="M7 17 17 7M7 7h10v10" /></Icon>,
+  ArrowDownLeft: (p) => <Icon {...p}><path d="M17 7 7 17M17 17H7V7" /></Icon>,
+  Calendar: (p) => <Icon {...p}><rect x="3" y="4" width="18" height="18" rx="2" /><path d="M16 2v4M8 2v4M3 10h18" /></Icon>,
+  Building: (p) => <Icon {...p}><rect x="4" y="3" width="16" height="18" rx="1" /><path d="M9 7h.01M15 7h.01M9 11h.01M15 11h.01M9 15h.01M15 15h.01" /></Icon>,
+  User: (p) => <Icon {...p}><circle cx="12" cy="8" r="4" /><path d="M4 21a8 8 0 0 1 16 0" /></Icon>,
+  Tag: (p) => <Icon {...p}><path d="M20.6 13.4 13.4 20.6a2 2 0 0 1-2.8 0L2 12V2h10l8.6 8.6a2 2 0 0 1 0 2.8z" /><circle cx="7.5" cy="7.5" r=".5" fill="currentColor" /></Icon>,
+  Wallet: (p) => <Icon {...p}><path d="M19 7H5a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-2" /><path d="M3 9V6a2 2 0 0 1 2-2h12v5" /><path d="M19 13h.01" /></Icon>,
+  Bank: (p) => <Icon {...p}><path d="M3 21h18M5 21V11M19 21V11M3 11h18M12 3 3 8h18z" /></Icon>,
+  Cmd: (p) => <Icon {...p}><path d="M18 3a3 3 0 0 0-3 3v12a3 3 0 0 0 3 3 3 3 0 0 0 3-3 3 3 0 0 0-3-3H6a3 3 0 0 0-3 3 3 3 0 0 0 3 3 3 3 0 0 0 3-3V6a3 3 0 0 0-3-3 3 3 0 0 0-3 3 3 3 0 0 0 3 3h12a3 3 0 0 0 3-3 3 3 0 0 0-3-3z" /></Icon>,
+  Receipt: (p) => <Icon {...p}><path d="M4 2v20l3-2 3 2 3-2 3 2 3-2 1 2V2l-1 2-3-2-3 2-3-2-3 2-3-2z" /><path d="M8 7h8M8 11h8M8 15h5" /></Icon>,
+  Settings: (p) => <Icon {...p}><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 1 1-2.83 2.83l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 1 1-4 0v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 1 1-2.83-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 1 1 0-4h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 1 1 2.83-2.83l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 1 1 4 0v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 1 1 2.83 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 1 1 0 4h-.09a1.65 1.65 0 0 0-1.51 1z" /></Icon>,
+  Bell: (p) => <Icon {...p}><path d="M6 8a6 6 0 0 1 12 0c0 7 3 9 3 9H3s3-2 3-9" /><path d="M10.3 21a1.94 1.94 0 0 0 3.4 0" /></Icon>,
+  LayoutDashboard: (p) => <Icon {...p}><rect x="3" y="3" width="7" height="9" rx="1" /><rect x="14" y="3" width="7" height="5" rx="1" /><rect x="14" y="12" width="7" height="9" rx="1" /><rect x="3" y="16" width="7" height="5" rx="1" /></Icon>,
+  ShoppingBag: (p) => <Icon {...p}><path d="M6 2 3 6v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2V6l-3-4z" /><path d="M3 6h18M16 10a4 4 0 0 1-8 0" /></Icon>,
+  Wrench: (p) => <Icon {...p}><path d="M14.7 6.3a4 4 0 0 0-5.4 5.4l-6.3 6.3a1 1 0 0 0 0 1.4l1.4 1.4a1 1 0 0 0 1.4 0l6.3-6.3a4 4 0 0 0 5.4-5.4l-3 3-2-2 3-3a4 4 0 0 0-1.4 0z" /></Icon>,
+  Users: (p) => <Icon {...p}><path d="M16 21v-2a4 4 0 0 0-4-4H6a4 4 0 0 0-4 4v2" /><circle cx="9" cy="7" r="4" /><path d="M22 21v-2a4 4 0 0 0-3-3.87M16 3.13a4 4 0 0 1 0 7.75" /></Icon>,
+  Box: (p) => <Icon {...p}><path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z" /><path d="m3.3 7 8.7 5 8.7-5M12 22V12" /></Icon>,
+  FileText: (p) => <Icon {...p}><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z" /><path d="M14 2v6h6M16 13H8M16 17H8M10 9H8" /></Icon>,
+  Send: (p) => <Icon {...p}><path d="m22 2-7 20-4-9-9-4z" /><path d="M22 2 11 13" /></Icon>,
+  Sparkles: (p) => <Icon {...p}><path d="m12 3-1.5 4.5L6 9l4.5 1.5L12 15l1.5-4.5L18 9l-4.5-1.5z" /><path d="M5 17v4M3 19h4M19 14v4M17 16h4" /></Icon>,
+  Refresh: (p) => <Icon {...p}><path d="M21 12a9 9 0 0 1-15 6.7L3 16M3 12a9 9 0 0 1 15-6.7L21 8" /><path d="M21 3v5h-5M3 21v-5h5" /></Icon>,
+  Folder: (p) => <Icon {...p}><path d="M3 7a2 2 0 0 1 2-2h4l2 2h8a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V7z" /></Icon>,
+  Link: (p) => <Icon {...p}><path d="M10 13a5 5 0 0 0 7 0l3-3a5 5 0 0 0-7-7l-1 1" /><path d="M14 11a5 5 0 0 0-7 0l-3 3a5 5 0 0 0 7 7l1-1" /></Icon>,
+  Eye: (p) => <Icon {...p}><path d="M2 12s3-7 10-7 10 7 10 7-3 7-10 7-10-7-10-7" /><circle cx="12" cy="12" r="3" /></Icon>,
+};
+
+// Exposto como FIN_I para coexistir com o `I` do shell unificado.
+window.FIN_I = I;
+})();

--- a/prototipo-ui/financeiro-output.jsx
+++ b/prototipo-ui/financeiro-output.jsx
@@ -1,0 +1,398 @@
+// financeiro-output.jsx — Refino #3 KB-9.75 · Guia + Saída (2026-05-18)
+// 5 features espelhando vendas-output.jsx + vendas-curation.jsx:
+// - FIN_TROUBLES + FinTroubleButton (reuso KBTroubleshooterDialog)
+// - FinChecklistFechamento (12 passos do fechamento mensal · trilha)
+// - FinTranscriptPDF (lançamento como folha jurídica imprimível)
+// - FinPresentationMode (fullscreen pra reunião com sócio)
+// - useFinFavs (favoritos pessoais · atalho B)
+
+(() => {
+  const { useState, useEffect, useMemo, useCallback } = React;
+
+  const _fmt = (n) => (n || 0).toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+  const _date = (d) => d ? d.toLocaleDateString("pt-BR") : "—";
+  const _dateLong = (d) => d ? d.toLocaleDateString("pt-BR", { day:"2-digit", month:"long", year:"numeric" }) : "—";
+
+  // ═════════════════════════════════════════════════════════════
+  // 1) FIN_TROUBLES — árvore de decisão pra divergências comuns
+  //    Estrutura compatível com window.KBTroubleshooterDialog
+  // ═════════════════════════════════════════════════════════════
+  const FIN_TROUBLES = [
+    {
+      id: "tr-extrato-nao-bate",
+      title: "Saldo do extrato não bate com o caixa",
+      equip: "conciliação",
+      hue: 25,
+      when: "fim do dia · diferença entre OFX e contábil",
+      steps: [
+        { q: "A diferença é menor que R$ 5,00?",
+          yes: { fix: "Tolerância normal de arredondamento bancário. Aceite a conciliação automática. Anote a diferença em 'Outros' do plano de contas e siga." },
+          no: 1 },
+        { q: "Existe boleto pago hoje sem match no Financeiro?",
+          yes: { fix: "Provavelmente cliente pagou direto no banco e o sistema não baixou. Vai em Conciliação → linha pendente → 'Confirmar manual' apontando pra venda original. Atualiza paid_at." },
+          no: 2 },
+        { q: "Houve sangria ou suprimento de caixa hoje?",
+          yes: { fix: "Cheque se a sangria foi lançada como saída e o suprimento como entrada. Em Caixa do dia → 'Movimentos'. Se faltar, lance retroativo com motivo." },
+          no: 3 },
+        { q: "Cliente fez PIX direto pra conta pessoal do Wagner?",
+          yes: { fix: "Pessoa-jurídica ≠ pessoa-física. Wagner registra como 'aporte do sócio' e a venda fica em aberto. Pede o PIX correto pra conta da empresa." },
+          no: { fix: "Diferença não-trivial. Compare 3 últimos dias contra OFX, baixa de Inter (web), confronta cada linha. Se persistir, abre chamado com a contabilidade." } },
+      ],
+    },
+    {
+      id: "tr-boleto-pago-2x",
+      title: "Cliente pagou o mesmo boleto 2 vezes",
+      equip: "boleto",
+      hue: 240,
+      when: "cliente entrou em contato reclamando · duplicidade",
+      steps: [
+        { q: "As duas baixas estão visíveis no extrato Inter?",
+          yes: 1,
+          no: { fix: "Cliente diz que pagou 2× mas só 1 baixa apareceu — pode ser estorno automático do banco origem. Aguardar 24h. Se confirmar duplicidade no extrato dele (pedir comprovante), aí investiga." } },
+        { q: "O cliente quer estorno ou crédito pra próxima compra?",
+          yes: { fix: "Crédito: cria lançamento payable manual no Financeiro com a contraparte do cliente, marca 'crédito disponível' e abate na próxima venda. Não emite NF-e nova." },
+          no: 2 },
+        { q: "Foram menos de 24h da segunda baixa?",
+          yes: { fix: "Pede estorno via Inter API (módulo Boleto → boleto → 'Estornar'). SEFAZ não envolve porque a NF-e original está correta. Cliente recebe via PIX em algumas horas." },
+          no: { fix: "Após 24h, faz transferência manual TED/PIX devolvendo o valor a mais. Documenta no comentário do lançamento financeiro: 'Devolução por duplicidade · ref. PIX X'." } },
+      ],
+    },
+    {
+      id: "tr-fornecedor-cobrou-errado",
+      title: "Fornecedor cobrou diferente do pedido",
+      equip: "compras",
+      hue: 60,
+      when: "NF chegou maior que orçado · #PC-NNN",
+      steps: [
+        { q: "A diferença é menor que 5% do total do pedido?",
+          yes: { fix: "Tolerância normal de oscilação de insumo. Aceita, lança no payable normal, anota a diferença. Se for sistemática (mesmo fornecedor 3× seguidas), renegocia." },
+          no: 1 },
+        { q: "Houve mudança de quantidade ou produto não combinado?",
+          yes: { fix: "Recusa a NF (não dá entrada no estoque). Pede ao fornecedor pra emitir NF de DEVOLUÇÃO da diferença ou refazer a nota correta. Não paga até regularizar." },
+          no: 2 },
+        { q: "Frete ou ICMS-ST veio sem aviso?",
+          yes: { fix: "Cheque o pedido de compra original (#PC-NNN). Se frete não foi orçado, é discussão. Se foi 'FOB' (por conta do destinatário), você paga separado. ICMS-ST geralmente é repassado e ok." },
+          no: { fix: "Diferença não justificada. Abre conversa formal com fornecedor (e-mail, não WhatsApp). Suspende próximos pedidos até esclarecer. Se reincidente, troca de fornecedor." } },
+      ],
+    },
+    {
+      id: "tr-nfe-rejeitada-fin",
+      title: "Rejeição da SEFAZ chegou no Financeiro",
+      equip: "fiscal",
+      hue: 25,
+      when: "venda já pendurada · #V- + rejeição",
+      steps: [
+        { q: "Já abriu o drawer da venda original pra ver o motivo?",
+          yes: 1,
+          no: { fix: "Vai primeiro no drawer da venda (#V-NNNN no campo desc). Veja a aba Fiscal · status NF-e. Lá tem o código de rejeição SEFAZ específico." } },
+        { q: "É código 539 (duplicidade) ou 692 (IE inválida)?",
+          yes: { fix: "Esses são os 2 mais comuns. Há troubleshooter próprio no Vendas: drawer da venda → footer → '? Resolver: NF-e rejeitada'. Ele te leva pelo passo-a-passo." },
+          no: 2 },
+        { q: "O cliente já pagou antes da rejeição?",
+          yes: { fix: "Cliente recebe o produto/serviço, você recebe o dinheiro, mas a NF não está autorizada. Tem 24h pra inutilizar o número rejeitado e emitir o próximo. Avise a Eliana pra não conciliar até resolver." },
+          no: { fix: "Sem pagamento ainda, sem pressa. Vendedor resolve a rejeição na venda original e re-emite. Financeiro continua aguardando paid_at." } },
+      ],
+    },
+  ];
+  window.FIN_TROUBLES = FIN_TROUBLES;
+
+  function FinTroubleButton({ row }) {
+    const [open, setOpen] = useState(false);
+    // Sugere o trouble certo baseado no estado
+    const suggested = useMemo(() => {
+      if (!row) return null;
+      const desc = (row.desc || "").toLowerCase();
+      const channel = (row.channel || "").toLowerCase();
+      if (channel.includes("boleto") && !row.paid_at) return "tr-boleto-pago-2x";
+      if (row.kind === "payable" && desc.includes("#pc-")) return "tr-fornecedor-cobrou-errado";
+      if (desc.includes("#v-") && row.status === "atrasado") return "tr-nfe-rejeitada-fin";
+      return "tr-extrato-nao-bate";
+    }, [row]);
+    const sg = suggested ? FIN_TROUBLES.find(t => t.id === suggested) : null;
+
+    return (
+      <>
+        <button className="fin-trouble-btn" onClick={() => setOpen(true)}>
+          <span className="fin-trouble-ic">?</span>
+          <span className="fin-trouble-lbl">
+            {sg ? <>Resolver: <b>{sg.title}</b></> : "Guia de divergências"}
+          </span>
+          <span className="fin-trouble-ct">{FIN_TROUBLES.length} fluxos</span>
+        </button>
+        {open && window.KBTroubleshooterDialog && (
+          <window.KBTroubleshooterDialog
+            customTroubles={FIN_TROUBLES}
+            onClose={() => setOpen(false)}
+            onPickArticle={() => {}}
+            onCreateNew={() => {}}
+          />
+        )}
+      </>
+    );
+  }
+  window.FinTroubleButton = FinTroubleButton;
+
+  // ═════════════════════════════════════════════════════════════
+  // 2) FECHAMENTO MENSAL · 12 passos (trilha)
+  // ═════════════════════════════════════════════════════════════
+  const FECHAMENTO_STEPS = [
+    { id: 1, title: "Conciliar extrato Inter",
+      hint: "Importar OFX do mês · Conciliação automática · revisar pendências",
+      action: "Abrir Conciliação", actionRoute: "concil" },
+    { id: 2, title: "Marcar todos lançamentos como conferidos",
+      hint: "Eliana valida cada receivable + payable do mês (✓ Conferir)",
+      action: "Voltar pra Visão unificada", actionRoute: "unified" },
+    { id: 3, title: "Liquidar pendentes pagos fora do sistema",
+      hint: "PIX direto no app do banco · transferências manuais",
+      action: "Filtrar 'Só atrasados'" },
+    { id: 4, title: "Verificar boletos emitidos vs cobranças recorrentes",
+      hint: "Toda assinatura ativa deve ter boleto do mês emitido",
+      action: "Abrir Cobranças recorrentes" },
+    { id: 5, title: "Lançar despesas de cartão corporativo",
+      hint: "Fatura do cartão Wagner · separar por categoria · classificar plano de contas",
+      action: "Novo lançamento manual" },
+    { id: 6, title: "Categorizar lançamentos pendentes",
+      hint: "Qualquer 'Outros' ou 'Sem categoria' precisa receber plano de contas",
+      action: "Abrir Plano de contas", actionRoute: "pcontas" },
+    { id: 7, title: "Revisar anomalias detectadas pela IA",
+      hint: "Boletos 25%+ acima da média · fornecedores fora do padrão",
+      action: "Abrir resumo IA" },
+    { id: 8, title: "Conferir folha de pagamento + INSS + FGTS",
+      hint: "Lançamento manual com competência + vencimento separados",
+      action: "Verificar payables · categoria Folha" },
+    { id: 9, title: "Emitir DRE provisório do mês",
+      hint: "Receita - Despesa = Resultado. Compara com plano",
+      action: "Abrir DRE / Relatórios", actionRoute: "dre" },
+    { id: 10, title: "Bater saldo bancário com fechamento contábil",
+      hint: "Saldo Inter no último dia útil = soma de receivables liquidados - payables liquidados + saldo abertura",
+      action: "Conferir manualmente" },
+    { id: 11, title: "Exportar CSV/PDF para contabilidade externa",
+      hint: "Contador recebe planilha do mês até dia 5",
+      action: "Exportar" },
+    { id: 12, title: "Fechar competência no sistema",
+      hint: "Bloqueia edição retroativa do mês fechado · só superadmin reabre",
+      action: "Fechar mês" },
+  ];
+
+  function FinFechamentoTrilha({ open, onClose, onNavigate }) {
+    const [done, setDone] = useState(() => {
+      try { return new Set(JSON.parse(localStorage.getItem("oimpresso.financeiro.fechamento.done") || "[]")); }
+      catch (e) { return new Set(); }
+    });
+    useEffect(() => {
+      try { localStorage.setItem("oimpresso.financeiro.fechamento.done", JSON.stringify([...done])); } catch (e) {}
+    }, [done]);
+    useEffect(() => {
+      if (!open) return;
+      const onKey = (e) => { if (e.key === "Escape") onClose(); };
+      window.addEventListener("keydown", onKey);
+      return () => window.removeEventListener("keydown", onKey);
+    }, [open, onClose]);
+
+    const toggle = (id) => setDone(prev => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id); else next.add(id);
+      return next;
+    });
+    const pct = Math.round((done.size / FECHAMENTO_STEPS.length) * 100);
+    const reset = () => {
+      if (confirm("Reiniciar checklist? Todos os passos voltam pra 'não feito'.")) setDone(new Set());
+    };
+
+    if (!open) return null;
+    return (
+      <div className="fin-trilha-overlay" onClick={onClose}>
+        <div className="fin-trilha" onClick={e => e.stopPropagation()}>
+          <header className="fin-trilha-h">
+            <div>
+              <span className="fin-trilha-eyebrow">Trilha · Fechamento mensal</span>
+              <h2>Fechamento de {new Date().toLocaleDateString("pt-BR", { month: "long", year: "numeric" })}</h2>
+              <p>12 passos · checklist persistente · Eliana</p>
+            </div>
+            <div className="fin-trilha-progress">
+              <div className="fin-trilha-pct">{pct}%</div>
+              <small>{done.size}/{FECHAMENTO_STEPS.length}</small>
+            </div>
+            <button className="fin-trilha-x" onClick={onClose} aria-label="Fechar (Esc)">×</button>
+          </header>
+          <div className="fin-trilha-bar"><div style={{width: pct + "%"}}/></div>
+          <ol className="fin-trilha-list">
+            {FECHAMENTO_STEPS.map(s => {
+              const isDone = done.has(s.id);
+              return (
+                <li key={s.id} className={"fin-trilha-step" + (isDone ? " done" : "")}>
+                  <button
+                    className="fin-trilha-check"
+                    onClick={() => toggle(s.id)}
+                    aria-label={isDone ? "Desmarcar" : "Marcar feito"}>
+                    {isDone ? "✓" : s.id}
+                  </button>
+                  <div className="fin-trilha-body">
+                    <b>{s.title}</b>
+                    <small>{s.hint}</small>
+                  </div>
+                  {s.action && (
+                    <button className="fin-trilha-cta"
+                            onClick={() => { if (s.actionRoute && onNavigate) { onNavigate(s.actionRoute); onClose(); } }}>
+                      {s.action} →
+                    </button>
+                  )}
+                </li>
+              );
+            })}
+          </ol>
+          <footer className="fin-trilha-ft">
+            <button className="fin-trilha-reset" onClick={reset}>Reiniciar checklist</button>
+            <span>Salvo automaticamente em localStorage</span>
+          </footer>
+        </div>
+      </div>
+    );
+  }
+  window.FinFechamentoTrilha = FinFechamentoTrilha;
+
+  // ═════════════════════════════════════════════════════════════
+  // 3) FAVORITOS PESSOAIS (atalho B) — Eliana pina o que está acompanhando
+  // ═════════════════════════════════════════════════════════════
+  function useFinFavs() {
+    const [set, setSet] = useState(() => {
+      try { return new Set(JSON.parse(localStorage.getItem("oimpresso.financeiro.favs") || "[]")); }
+      catch (e) { return new Set(); }
+    });
+    useEffect(() => {
+      try { localStorage.setItem("oimpresso.financeiro.favs", JSON.stringify([...set])); } catch (e) {}
+    }, [set]);
+    return {
+      has: (id) => set.has(id),
+      toggle: (id) => setSet(prev => {
+        const next = new Set(prev);
+        if (next.has(id)) next.delete(id); else next.add(id);
+        return next;
+      }),
+      count: set.size,
+      all: [...set],
+    };
+  }
+  window.useFinFavs = useFinFavs;
+
+  // ═════════════════════════════════════════════════════════════
+  // 4) MODO APRESENTAÇÃO — fullscreen pra reunião com Wagner/sócio
+  //    Espelha VdPresentationMode (4 slides)
+  // ═════════════════════════════════════════════════════════════
+  function FinPresentationMode({ open, onClose }) {
+    const [slide, setSlide] = useState(0);
+    const slides = [
+      { id: "visao", label: "Visão do mês" },
+      { id: "fluxo", label: "Onde está o dinheiro" },
+      { id: "atencao", label: "Pontos de atenção" },
+      { id: "decisao", label: "Decisões pra tomar" },
+    ];
+
+    useEffect(() => {
+      if (!open) return;
+      const onKey = (e) => {
+        if (e.key === "Escape") onClose();
+        else if (e.key === "ArrowRight" || e.key === " ") setSlide(s => Math.min(slides.length - 1, s + 1));
+        else if (e.key === "ArrowLeft") setSlide(s => Math.max(0, s - 1));
+      };
+      window.addEventListener("keydown", onKey);
+      return () => window.removeEventListener("keydown", onKey);
+    }, [open, onClose]);
+
+    if (!open) return null;
+    const rows = window.FIN_ROWS || [];
+    const today = window.FIN_TODAY;
+    const monthStart = today ? new Date(today.getFullYear(), today.getMonth(), 1) : null;
+    const monthRows = monthStart ? rows.filter(r => (r.due >= monthStart) || (r.paid_at && r.paid_at >= monthStart)) : rows;
+    const recebido = monthRows.filter(r => r.kind === "receivable" && r.paid_at).reduce((s, r) => s + r.amount, 0);
+    const pago = monthRows.filter(r => r.kind === "payable" && r.paid_at).reduce((s, r) => s + r.amount, 0);
+    const aReceber = monthRows.filter(r => r.kind === "receivable" && !r.paid_at).reduce((s, r) => s + r.amount, 0);
+    const aPagar = monthRows.filter(r => r.kind === "payable" && !r.paid_at).reduce((s, r) => s + r.amount, 0);
+    const saldo = recebido - pago;
+    const previsto = saldo + aReceber - aPagar;
+    const overdue = rows.filter(r => r.status === "atrasado");
+    const byCat = {};
+    monthRows.filter(r => r.kind === "payable").forEach(r => { byCat[r.category] = (byCat[r.category] || 0) + r.amount; });
+    const topCats = Object.entries(byCat).sort((a,b) => b[1]-a[1]).slice(0, 4);
+    const totalGasto = Object.values(byCat).reduce((s, v) => s + v, 0);
+
+    return (
+      <div className="fin-pres-overlay">
+        <header className="fin-pres-top">
+          <span className="fin-pres-brand">OIMPRESSO · Financeiro · {(monthStart || new Date()).toLocaleDateString("pt-BR", { month: "long", year: "numeric" })}</span>
+          <span className="fin-pres-counter">{slide + 1} / {slides.length}</span>
+          <button className="fin-pres-close" onClick={onClose} title="Esc">×</button>
+        </header>
+        <main className="fin-pres-stage">
+          {slide === 0 && (
+            <div className="fin-pres-slide">
+              <small className="fin-pres-eyebrow">Saldo previsto fim do mês</small>
+              <div className={"fin-pres-amount " + (previsto < 0 ? "neg" : "pos")}>{_fmt(previsto)}</div>
+              <div className="fin-pres-row">
+                <div><span>Recebido</span><b className="pos">{_fmt(recebido)}</b></div>
+                <div><span>Pago</span><b className="neg">{_fmt(pago)}</b></div>
+                <div><span>A receber</span><b className="pos">{_fmt(aReceber)}</b></div>
+                <div><span>A pagar</span><b className="neg">{_fmt(aPagar)}</b></div>
+              </div>
+            </div>
+          )}
+          {slide === 1 && (
+            <div className="fin-pres-slide">
+              <small className="fin-pres-eyebrow">Onde o dinheiro está saindo</small>
+              <h1>Top {topCats.length} categorias</h1>
+              <ul className="fin-pres-cats">
+                {topCats.map(([cat, val]) => (
+                  <li key={cat}>
+                    <span className="fin-pres-cat-l">{cat}</span>
+                    <span className="fin-pres-cat-r">{_fmt(val)} <small>{Math.round(val/totalGasto*100)}%</small></span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {slide === 2 && (
+            <div className="fin-pres-slide">
+              <small className="fin-pres-eyebrow">{overdue.length} lançamentos em atraso</small>
+              <div className={"fin-pres-amount-mid " + (overdue.length > 0 ? "neg" : "pos")}>
+                {_fmt(overdue.reduce((s, r) => s + r.amount, 0))}
+              </div>
+              <ul className="fin-pres-late">
+                {overdue.slice(0, 5).map(r => (
+                  <li key={r.id}>
+                    <span className="fin-pres-late-l">{r.party}</span>
+                    <span className="fin-pres-late-m">{r.desc.slice(0, 38)}{r.desc.length > 38 ? "…" : ""}</span>
+                    <span className="fin-pres-late-r">{_fmt(r.amount)}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+          {slide === 3 && (
+            <div className="fin-pres-slide">
+              <small className="fin-pres-eyebrow">Pra próxima semana</small>
+              <h1>Decisões</h1>
+              <ol className="fin-pres-decisoes">
+                {previsto < 0 && <li>Saldo previsto fica <b>negativo em R$ {Math.abs(previsto).toFixed(0).replace(/\B(?=(\d{3})+(?!\d))/g, ".")}</b> — antecipar receitas ou empurrar pagamentos?</li>}
+                {overdue.length > 0 && <li>Cobrar os <b>{overdue.length} atrasados</b> antes de fim do mês</li>}
+                {aPagar > recebido && <li>A pagar excede o já recebido — <b>liberar próximo aporte</b>?</li>}
+                {topCats[0] && <li>Maior despesa: <b>{topCats[0][0]}</b> ({_fmt(topCats[0][1])}) · revisar fornecedores?</li>}
+                <li>Reunião próxima 6ª · 14h · pauta gerada</li>
+              </ol>
+            </div>
+          )}
+        </main>
+        <footer className="fin-pres-bot">
+          <button onClick={() => setSlide(s => Math.max(0, s - 1))} disabled={slide === 0}>←</button>
+          <div className="fin-pres-dots">
+            {slides.map((s, i) => (
+              <span key={i} className={"fin-pres-dot" + (i === slide ? " on" : "")} onClick={() => setSlide(i)}/>
+            ))}
+          </div>
+          <button onClick={() => setSlide(s => Math.min(slides.length - 1, s + 1))} disabled={slide === slides.length - 1}>→</button>
+        </footer>
+      </div>
+    );
+  }
+  window.FinPresentationMode = FinPresentationMode;
+
+})();

--- a/prototipo-ui/financeiro-telas-extras.jsx
+++ b/prototipo-ui/financeiro-telas-extras.jsx
@@ -1,0 +1,584 @@
+// Financeiro — Telas extras: Fluxo, Conciliação, DRE, Plano de contas.
+// All in compact density to match the unified screen aesthetic.
+// Tokens: BRIEFING §4 (emerald/amber/rose, rounded-md, shadow-sm, num tabular).
+// IIFE para não vazar `const I`/helpers no escopo global.
+(() => {
+const { useState, useMemo } = React;
+const I = window.FIN_I; // ícones do módulo Financeiro
+
+const fmtBRL2 = (n) =>
+  n.toLocaleString("pt-BR", { style: "currency", currency: "BRL" });
+const fmtBRL2k = (n) => {
+  const abs = Math.abs(n);
+  if (abs >= 1000) return (n < 0 ? "− " : "") + "R$ " + (abs / 1000).toLocaleString("pt-BR", { minimumFractionDigits: 1, maximumFractionDigits: 1 }) + "k";
+  return fmtBRL2(n);
+};
+const fmtDate2 = (d) => d.toLocaleDateString("pt-BR", { day: "2-digit", month: "2-digit" });
+const fmtDateLong2 = (d) => d.toLocaleDateString("pt-BR", { day: "2-digit", month: "short", year: "numeric" });
+
+// ── Breadcrumb compartilhado pelas sub-rotas (Refino 2026-05-18)
+const FinBcrumb = ({ here, onBack }) => (
+  <nav className="fin-bcrumb" aria-label="Voltar para Financeiro">
+    <button className="fin-bcrumb-back" onClick={onBack} title="Voltar pra visão unificada (esc)">
+      <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><polyline points="10,3 5,8 10,13"/></svg>
+      Financeiro
+    </button>
+    <span className="fin-bcrumb-sep">›</span>
+    <span className="fin-bcrumb-here">{here}</span>
+  </nav>
+);
+
+// Esc volta — só ativo quando há onBack
+const useFinBackEsc = (onBack) => {
+  useEffect(() => {
+    if (!onBack) return;
+    const onKey = (e) => {
+      if (e.key !== "Escape") return;
+      if (document.querySelector(".os-drawer-back, .fin-cmdk-back, .fin-cmdk-overlay")) return;
+      e.preventDefault();
+      onBack();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onBack]);
+};
+
+/* ═════════════════════════════════════════════════════════════════════════
+ * 1. FLUXO DE CAIXA — projeção dia-a-dia
+ * ═════════════════════════════════════════════════════════════════════════ */
+const TelaFluxo = () => {
+  const rows = window.FIN_ROWS;
+  const today = window.FIN_TODAY;
+
+  // Build day-by-day projection for next 30 days
+  const days = useMemo(() => {
+    const out = [];
+    let saldo = rows.filter((r) => r.kind === "receivable" && r.paid_at).reduce((s, r) => s + r.amount, 0)
+              - rows.filter((r) => r.kind === "payable" && r.paid_at).reduce((s, r) => s + r.amount, 0);
+    for (let i = -2; i < 35; i++) {
+      const date = new Date(today);
+      date.setDate(date.getDate() + i);
+      const key = date.toISOString().slice(0, 10);
+      const dayRows = rows.filter((r) => r.due.toISOString().slice(0, 10) === key && !r.paid_at);
+      const inSum = dayRows.filter((r) => r.kind === "receivable").reduce((s, r) => s + r.amount, 0);
+      const outSum = dayRows.filter((r) => r.kind === "payable").reduce((s, r) => s + r.amount, 0);
+      const net = inSum - outSum;
+      if (i >= 0) saldo += net; // historical doesn't change saldo (already reflected in paid_at)
+      out.push({ date, dayRows, inSum, outSum, net, saldo, isToday: i === 0, isPast: i < 0 });
+    }
+    return out;
+  }, [rows, today]);
+
+  const saldoHoje = days.find((d) => d.isToday)?.saldo ?? 0;
+  const proj30 = days[days.length - 1].saldo;
+  const minDay = days.filter((d) => !d.isPast).reduce((m, d) => d.saldo < m.saldo ? d : m, days[0]);
+  const maxSaldo = Math.max(...days.map((d) => d.saldo));
+  const minSaldo = Math.min(...days.map((d) => d.saldo), 0);
+
+  return (
+    <>
+      <div className="px-6 pt-4">
+        <div className="rounded-md bg-white border border-stone-200 shadow-sm flex divide-x divide-stone-200 overflow-hidden">
+          <div className="flex-1 px-5 py-4 bg-stone-900 text-stone-50">
+            <div className="text-[10px] uppercase tracking-widest font-medium text-stone-400">Saldo hoje · 09 mai</div>
+            <div className="mt-1 text-[28px] leading-none font-semibold tracking-tight num">{fmtBRL2(saldoHoje)}</div>
+            <div className="mt-2 text-[11.5px] text-stone-400">Itaú PJ · ag 0438 cc 4521-7</div>
+          </div>
+          <div className="flex-1 px-5 py-4">
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Projeção 30 dias</div>
+            <div className={`mt-1 text-[28px] leading-none font-semibold tracking-tight num ${proj30 >= saldoHoje ? "text-emerald-700" : "text-rose-700"}`}>{fmtBRL2(proj30)}</div>
+            <div className="mt-2 text-[11.5px] text-stone-500">{proj30 >= saldoHoje ? "alta" : "queda"} de {fmtBRL2k(Math.abs(proj30 - saldoHoje))} vs hoje</div>
+          </div>
+          <div className="flex-1 px-5 py-4">
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Pior dia previsto</div>
+            <div className="mt-1 text-[28px] leading-none font-semibold tracking-tight num text-amber-700">{fmtBRL2(minDay.saldo)}</div>
+            <div className="mt-2 text-[11.5px] text-stone-500">{fmtDateLong2(minDay.date)}</div>
+          </div>
+          <div className="flex-1 px-5 py-4">
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Margem mínima</div>
+            <div className="mt-1 text-[28px] leading-none font-semibold tracking-tight num text-stone-900">R$ 5.000</div>
+            <div className="mt-2 text-[11.5px] text-stone-500">limite definido · acima ✓</div>
+          </div>
+        </div>
+      </div>
+
+      {/* Chart */}
+      <div className="px-6 mt-4">
+        <div className="bg-white border border-stone-200 rounded-md shadow-sm p-5">
+          <div className="flex items-center justify-between mb-3">
+            <div>
+              <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Saldo projetado · próximos 35 dias</div>
+              <div className="text-[14px] font-semibold mt-0.5">linha laranja = limite mínimo · barras = movimento líquido do dia</div>
+            </div>
+            <div className="flex items-center gap-3 text-[11.5px] text-stone-500">
+              <span className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm bg-stone-900" /> saldo</span>
+              <span className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm bg-emerald-500" /> entrada</span>
+              <span className="flex items-center gap-1.5"><span className="w-2.5 h-2.5 rounded-sm bg-rose-500" /> saída</span>
+            </div>
+          </div>
+
+          {/* Chart area */}
+          <div className="relative h-[220px] border-b border-stone-200 mt-2">
+            {/* Limit line */}
+            <div className="absolute left-0 right-0 border-t border-dashed border-amber-400" style={{ top: `${(1 - (5000 - minSaldo) / (maxSaldo - minSaldo)) * 100}%` }}>
+              <span className="absolute -top-4 right-0 text-[10px] text-amber-700 font-medium bg-white px-1">R$ 5k mínimo</span>
+            </div>
+            {/* Bars */}
+            <div className="absolute inset-0 flex items-end gap-px">
+              {days.map((d, i) => {
+                const h = ((d.saldo - minSaldo) / (maxSaldo - minSaldo)) * 100;
+                const moveBar = Math.max(2, Math.abs(d.net) / Math.max(...days.map((x) => Math.abs(x.net) || 1), 1) * 50);
+                return (
+                  <div key={i} className="flex-1 h-full flex flex-col justify-end relative group">
+                    {/* saldo line column */}
+                    <div className={`w-full ${d.isPast ? "bg-stone-300" : d.isToday ? "bg-stone-900" : "bg-stone-700"} ${d.saldo < 5000 ? "!bg-amber-500" : ""}`} style={{ height: `${h}%` }}>
+                    </div>
+                    {/* hover info */}
+                    {d.dayRows.length > 0 && (
+                      <div className="hidden group-hover:block absolute -top-14 left-1/2 -translate-x-1/2 z-10 bg-stone-900 text-white text-[10.5px] rounded px-2 py-1 whitespace-nowrap num">
+                        {fmtDate2(d.date)} · {fmtBRL2k(d.saldo)}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Date axis */}
+          <div className="flex gap-px mt-1.5 text-[9.5px] text-stone-500 num">
+            {days.map((d, i) => (
+              <div key={i} className={`flex-1 text-center ${d.isToday ? "font-bold text-stone-900" : ""}`}>
+                {i % 5 === 0 || d.isToday ? fmtDate2(d.date) : ""}
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {/* Upcoming events */}
+      <div className="px-6 mt-4">
+        <div className="bg-white border border-stone-200 rounded-md shadow-sm overflow-hidden">
+          <div className="px-5 py-3 border-b border-stone-200 flex items-center gap-3">
+            <div className="min-w-0">
+              <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium whitespace-nowrap">Próximos eventos</div>
+              <div className="text-[14px] font-semibold mt-0.5 whitespace-nowrap">7 dias adiante</div>
+            </div>
+            <div className="ml-auto text-[11.5px] text-stone-500 whitespace-nowrap shrink-0">{days.filter((d) => !d.isPast && d.dayRows.length > 0).slice(0, 7).reduce((s, d) => s + d.dayRows.length, 0)} lançamentos</div>
+          </div>
+          <table className="w-full text-[12.5px] num">
+            <tbody>
+              {days.filter((d) => !d.isPast && d.dayRows.length > 0).slice(0, 7).flatMap((d) =>
+                d.dayRows.map((r, j) => (
+                  <tr key={r.id} className={`border-b border-stone-100 row-hover ${j === 0 ? "border-t-2 border-t-stone-100" : ""}`}>
+                    <td className="pl-6 pr-3 py-2 w-[110px] text-stone-700">{j === 0 ? fmtDateLong2(d.date) : ""}</td>
+                    <td className="px-2 py-2">
+                      <span className={`inline-grid place-items-center rounded ${r.kind === "receivable" ? "bg-emerald-50 text-emerald-700" : "bg-rose-50 text-rose-700"}`} style={{ width: 22, height: 22 }}>
+                        {r.kind === "receivable" ? "↓" : "↑"}
+                      </span>
+                    </td>
+                    <td className="px-2 py-2 font-medium text-stone-900 truncate">{r.desc}</td>
+                    <td className="px-2 py-2 text-stone-600">{r.party}</td>
+                    <td className="px-2 py-2 text-stone-500">{r.category}</td>
+                    <td className="pr-6 py-2 text-right font-medium">
+                      <span className={r.kind === "receivable" ? "text-emerald-700" : "text-stone-900"}>
+                        {r.kind === "receivable" ? "+" : "−"} {fmtBRL2(r.amount)}
+                      </span>
+                    </td>
+                    <td className="pr-6 py-2 text-right text-stone-700 font-medium w-[120px]">
+                      {j === d.dayRows.length - 1 ? fmtBRL2(d.saldo) : ""}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </>
+  );
+};
+
+/* ═════════════════════════════════════════════════════════════════════════
+ * 2. CONCILIAÇÃO — extrato OFX × lançamentos sistema
+ * ═════════════════════════════════════════════════════════════════════════ */
+const EXTRATO = [
+  { id: "OFX-04388", date: "2026-05-02", desc: "TED IMOBILIARIA CENTRO LTDA", amount: -4500.00, match: "P-1884" },
+  { id: "OFX-04389", date: "2026-05-03", desc: "DEB AUT VIVO EMPRESAS", amount: -320.00, match: "P-1885" },
+  { id: "OFX-04390", date: "2026-05-04", desc: "PIX RECEBIDO STUDIO FOCO", amount: 380.00, match: "R-2647" },
+  { id: "OFX-04391", date: "2026-05-05", desc: "TED FOLHA LARISSA", amount: -2800.00, match: "P-1890" },
+  { id: "OFX-04392", date: "2026-05-05", desc: "PIX ALPHAGRAF", amount: -1120.00, match: "P-1888" },
+  { id: "OFX-04393", date: "2026-05-06", desc: "PIX FARMACIA SAUDE TOTAL", amount: 720.00, match: "R-2645" },
+  { id: "OFX-04394", date: "2026-05-07", desc: "PIX CLINICA VIDA PLENA LTDA", amount: 880.00, match: "R-2651" },
+  { id: "OFX-04395", date: "2026-05-08", desc: "PIX PADARIA PAO QUENTE", amount: 480.00, match: null, suggest: "R-2641" },
+  { id: "OFX-04396", date: "2026-05-08", desc: "TARIFA CESTA CONTA PJ", amount: -89.90, match: null, suggest: null },
+  { id: "OFX-04397", date: "2026-05-09", desc: "PIX MARIA APARECIDA", amount: 120.00, match: null, suggest: "R-2652" },
+];
+
+const TelaConciliacao = ({ onBack }) => {
+  useFinBackEsc(onBack);
+  const [selected, setSelected] = useState(null);
+  const matched = EXTRATO.filter((e) => e.match).length;
+  const pending = EXTRATO.filter((e) => !e.match).length;
+  const totalIn = EXTRATO.filter((e) => e.amount > 0).reduce((s, e) => s + e.amount, 0);
+  const totalOut = EXTRATO.filter((e) => e.amount < 0).reduce((s, e) => s + e.amount, 0);
+
+  return (
+    <>
+      {onBack && <FinBcrumb here="Conciliação bancária" onBack={onBack}/>}
+      <div className="px-6 pt-4">
+        <div className="rounded-md bg-white border border-stone-200 shadow-sm flex divide-x divide-stone-200 overflow-hidden">
+          <div className="flex-1 px-5 py-4">
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Período</div>
+            <div className="mt-1 text-[16px] font-semibold tracking-tight">02 → 09 mai 2026</div>
+            <div className="mt-2 text-[11.5px] text-stone-500">Itaú PJ · OFX importado 09/05 14:32</div>
+          </div>
+          <div className="flex-1 px-5 py-4">
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Conciliados</div>
+            <div className="mt-1 text-[28px] leading-none font-semibold tracking-tight num text-emerald-700">{matched}<span className="text-stone-400 text-[18px]">/{EXTRATO.length}</span></div>
+            <div className="mt-2">
+              <div className="h-1 bg-stone-100 rounded-full overflow-hidden">
+                <div className="h-full bg-emerald-500" style={{ width: `${(matched / EXTRATO.length) * 100}%` }} />
+              </div>
+            </div>
+          </div>
+          <div className="flex-1 px-5 py-4">
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Pendente revisão</div>
+            <div className="mt-1 text-[28px] leading-none font-semibold tracking-tight num text-amber-700">{pending}</div>
+            <div className="mt-2 text-[11.5px] text-stone-500">com sugestão automática: {EXTRATO.filter((e) => !e.match && e.suggest).length}</div>
+          </div>
+          <div className="flex-1 px-5 py-4">
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Total no extrato</div>
+            <div className="mt-1 text-[18px] leading-tight font-semibold tracking-tight num text-emerald-700">+ {fmtBRL2(totalIn)}</div>
+            <div className="text-[18px] leading-tight font-semibold tracking-tight num text-rose-700">{fmtBRL2(totalOut)}</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="px-6 mt-4 mb-4">
+        <div className="bg-white border border-stone-200 rounded-md shadow-sm overflow-hidden">
+          <div className="grid grid-cols-2 border-b border-stone-200 text-[10px] uppercase tracking-widest text-stone-500 font-medium">
+            <div className="px-5 py-2.5 border-r border-stone-200 flex items-center gap-2">
+              Extrato Itaú PJ
+              <span className="text-stone-400 normal-case tracking-normal text-[11px]">· {EXTRATO.length} lançamentos</span>
+            </div>
+            <div className="px-5 py-2.5 flex items-center gap-2">
+              Sistema oimpresso
+              <span className="text-stone-400 normal-case tracking-normal text-[11px]">· match sugerido</span>
+            </div>
+          </div>
+
+          {EXTRATO.map((e) => {
+            const sysRow = window.FIN_ROWS.find((r) => r.id === (e.match || e.suggest));
+            const status = e.match ? "matched" : e.suggest ? "suggest" : "none";
+            return (
+              <div key={e.id} className={`grid grid-cols-2 border-b border-stone-100 text-[12.5px] num ${selected === e.id ? "bg-stone-50" : "row-hover"}`} onClick={() => setSelected(e.id)}>
+                {/* Left: extrato */}
+                <div className="px-5 py-3 border-r border-stone-200 flex items-center gap-3 cursor-pointer">
+                  <div className="text-stone-700 w-[60px]">{fmtDate2(new Date(e.date + "T12:00:00"))}</div>
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium text-stone-900 truncate">{e.desc}</div>
+                    <div className="text-[10.5px] text-stone-400 font-mono">{e.id}</div>
+                  </div>
+                  <div className={`font-semibold ${e.amount > 0 ? "text-emerald-700" : "text-stone-900"}`}>
+                    {e.amount > 0 ? "+" : "−"} {fmtBRL2(Math.abs(e.amount)).replace("R$", "").trim()}
+                  </div>
+                </div>
+
+                {/* Right: sistema */}
+                <div className="px-5 py-3 flex items-center gap-3">
+                  {status === "matched" && sysRow && (
+                    <>
+                      <span className="inline-flex items-center gap-1 text-emerald-700 text-[11px] font-medium px-2 py-0.5 rounded-full bg-emerald-50 whitespace-nowrap">
+                        <span className="w-1.5 h-1.5 rounded-full bg-emerald-500" />
+                        Conciliado
+                      </span>
+                      <div className="flex-1 min-w-0">
+                        <div className="font-medium text-stone-900 truncate">{sysRow.desc}</div>
+                        <div className="text-[10.5px] text-stone-400 font-mono">{sysRow.id} · {sysRow.invoice}</div>
+                      </div>
+                      <button className="w-7 h-7 grid place-items-center rounded text-stone-400 hover:text-stone-700 hover:bg-stone-100">×</button>
+                    </>
+                  )}
+                  {status === "suggest" && sysRow && (
+                    <>
+                      <span className="inline-flex items-center gap-1 text-amber-700 text-[11px] font-medium px-2 py-0.5 rounded-full bg-amber-50 whitespace-nowrap">
+                        <span className="w-1.5 h-1.5 rounded-full bg-amber-500" />
+                        Sugerido
+                      </span>
+                      <div className="flex-1 min-w-0">
+                        <div className="font-medium text-stone-900 truncate">{sysRow.desc}</div>
+                        <div className="text-[10.5px] text-stone-400 font-mono">{sysRow.id} · {sysRow.invoice} · 95% match</div>
+                      </div>
+                      <button className="h-7 px-2.5 text-[11.5px] rounded text-emerald-700 bg-emerald-50 hover:bg-emerald-100 font-medium whitespace-nowrap">✓ Aceitar</button>
+                    </>
+                  )}
+                  {status === "none" && (
+                    <>
+                      <span className="inline-flex items-center gap-1 text-stone-500 text-[11px] font-medium px-2 py-0.5 rounded-full bg-stone-100 whitespace-nowrap">
+                        <span className="w-1.5 h-1.5 rounded-full bg-stone-400" />
+                        Sem match
+                      </span>
+                      <div className="flex-1 text-stone-500 italic">Provável tarifa bancária — criar lançamento?</div>
+                      <button className="h-7 px-2.5 text-[11.5px] rounded border border-stone-200 hover:bg-stone-50 text-stone-700 whitespace-nowrap">+ Criar</button>
+                      <button className="h-7 px-2.5 text-[11.5px] rounded text-stone-500 hover:bg-stone-50 whitespace-nowrap">Buscar</button>
+                    </>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </>
+  );
+};
+
+/* ═════════════════════════════════════════════════════════════════════════
+ * 3. DRE / RELATÓRIOS
+ * ═════════════════════════════════════════════════════════════════════════ */
+const DRE_LINES = [
+  { type: "h", label: "Receita operacional bruta", v: 14860, prev: 12340, kind: "rec" },
+  { type: "i", label: "Banner / Lona / Adesivo",   v: 9580, prev: 7920, indent: 1 },
+  { type: "i", label: "Gráfica rápida",            v: 2940, prev: 2580, indent: 1 },
+  { type: "i", label: "Fachada / Placa",           v: 2340, prev: 1840, indent: 1 },
+  { type: "h", label: "(−) Deduções",              v: -1260, prev: -980, kind: "ded" },
+  { type: "i", label: "Impostos sobre vendas (Simples)", v: -1260, prev: -980, indent: 1 },
+  { type: "subtotal", label: "Receita líquida",    v: 13600, prev: 11360 },
+  { type: "h", label: "(−) Custos diretos",        v: -5180, prev: -4220, kind: "ded" },
+  { type: "i", label: "Insumos (papel, lona, tinta)", v: -3420, prev: -2680, indent: 1 },
+  { type: "i", label: "Acabamento terceirizado",  v: -1120, prev: -940, indent: 1 },
+  { type: "i", label: "Frete / Instalação",        v: -640, prev: -600, indent: 1 },
+  { type: "subtotal", label: "Lucro bruto",        v: 8420, prev: 7140 },
+  { type: "h", label: "(−) Despesas operacionais", v: -7042, prev: -6680, kind: "ded" },
+  { type: "i", label: "Folha + encargos",          v: -2800, prev: -2800, indent: 1 },
+  { type: "i", label: "Aluguel + IPTU",            v: -5390, prev: -5390, indent: 1 },
+  { type: "i", label: "Energia / água / internet", v: -1500, prev: -1480, indent: 1 },
+  { type: "i", label: "Manutenção equipamentos",  v: -780, prev: -260, indent: 1 },
+  { type: "subtotal", label: "Resultado operacional", v: 1378, prev: 460, highlight: true },
+];
+
+const TelaDRE = () => {
+  const [period, setPeriod] = useState("Maio 2026");
+  return (
+    <>
+      <div className="px-6 pt-4">
+        <div className="bg-white border border-stone-200 rounded-md shadow-sm overflow-hidden">
+          <div className="px-5 py-3 border-b border-stone-200 flex items-center gap-3">
+            <div className="min-w-0">
+              <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium whitespace-nowrap">Demonstração de Resultado</div>
+              <div className="text-[16px] font-semibold mt-0.5 whitespace-nowrap">{period}</div>
+            </div>
+            <div className="ml-auto flex items-center gap-2">
+              <div className="inline-flex bg-stone-100/80 rounded-md p-0.5 border border-stone-200">
+                {["Mês", "Trimestre", "Ano", "12m"].map((p) => (
+                  <button key={p} className={`h-7 px-3 rounded text-[12.5px] ${p === "Mês" ? "bg-white shadow-sm font-medium" : "text-stone-600"}`}>{p}</button>
+                ))}
+              </div>
+              <button className="h-8 px-3 rounded-md border border-stone-200 text-[12.5px] text-stone-700 hover:bg-stone-50">Exportar PDF</button>
+              <button className="h-8 px-3 rounded-md border border-stone-200 text-[12.5px] text-stone-700 hover:bg-stone-50">Excel</button>
+            </div>
+          </div>
+
+          <table className="w-full text-[12.5px] num">
+            <thead>
+              <tr className="text-[10px] uppercase tracking-widest text-stone-500 border-b border-stone-200 bg-stone-50/40">
+                <th className="pl-6 pr-2 py-2 text-left font-medium">Conta</th>
+                <th className="px-2 py-2 text-right font-medium w-[140px]">Mai/2026</th>
+                <th className="px-2 py-2 text-right font-medium w-[100px]">% RL</th>
+                <th className="px-2 py-2 text-right font-medium w-[140px]">Abr/2026</th>
+                <th className="px-2 py-2 text-right font-medium w-[80px]">Δ</th>
+                <th className="pl-2 pr-6 py-2 w-[160px]"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {DRE_LINES.map((l, i) => {
+                const rl = 13600;
+                const pct = (l.v / rl) * 100;
+                const delta = l.prev !== 0 ? ((l.v - l.prev) / Math.abs(l.prev)) * 100 : 0;
+                const positive = l.v >= 0;
+                if (l.type === "h") {
+                  return (
+                    <tr key={i} className="border-b border-stone-100">
+                      <td className="pl-6 pr-2 py-2 font-medium text-stone-900">{l.label}</td>
+                      <td className="px-2 py-2 text-right font-semibold">{fmtBRL2(l.v).replace("R$", "").trim()}</td>
+                      <td className="px-2 py-2 text-right text-stone-500">{pct.toFixed(1)}%</td>
+                      <td className="px-2 py-2 text-right text-stone-500">{fmtBRL2(l.prev).replace("R$", "").trim()}</td>
+                      <td className={`px-2 py-2 text-right ${delta > 0 ? "text-emerald-700" : delta < 0 ? "text-rose-700" : "text-stone-400"}`}>{delta > 0 ? "+" : ""}{delta.toFixed(0)}%</td>
+                      <td className="pl-2 pr-6"></td>
+                    </tr>
+                  );
+                }
+                if (l.type === "i") {
+                  return (
+                    <tr key={i} className="border-b border-stone-100 row-hover">
+                      <td className="pl-6 pr-2 py-1.5 text-stone-600" style={{ paddingLeft: 24 + (l.indent || 0) * 16 }}>{l.label}</td>
+                      <td className="px-2 py-1.5 text-right text-stone-700">{fmtBRL2(l.v).replace("R$", "").trim()}</td>
+                      <td className="px-2 py-1.5 text-right text-stone-400">{pct.toFixed(1)}%</td>
+                      <td className="px-2 py-1.5 text-right text-stone-400">{fmtBRL2(l.prev).replace("R$", "").trim()}</td>
+                      <td className={`px-2 py-1.5 text-right text-[11.5px] ${delta > 0 ? "text-emerald-600" : delta < 0 ? "text-rose-600" : "text-stone-400"}`}>{delta > 0 ? "+" : ""}{delta.toFixed(0)}%</td>
+                      <td className="pl-2 pr-6 py-1.5">
+                        <div className="h-1 bg-stone-100 rounded-full overflow-hidden">
+                          <div className={`h-full ${positive ? "bg-emerald-400" : "bg-rose-400"}`} style={{ width: `${Math.min(100, Math.abs(pct) * 3)}%` }} />
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                }
+                if (l.type === "subtotal") {
+                  return (
+                    <tr key={i} className={`border-y-2 border-stone-200 ${l.highlight ? "bg-stone-900 text-white" : "bg-stone-50"}`}>
+                      <td className={`pl-6 pr-2 py-2.5 font-semibold ${l.highlight ? "text-white" : ""}`}>{l.label}</td>
+                      <td className={`px-2 py-2.5 text-right font-bold text-[14px] ${l.highlight ? "text-white" : positive ? "text-emerald-700" : "text-rose-700"}`}>{fmtBRL2(l.v).replace("R$", "").trim()}</td>
+                      <td className={`px-2 py-2.5 text-right font-medium ${l.highlight ? "text-stone-300" : "text-stone-600"}`}>{pct.toFixed(1)}%</td>
+                      <td className={`px-2 py-2.5 text-right ${l.highlight ? "text-stone-400" : "text-stone-600"}`}>{fmtBRL2(l.prev).replace("R$", "").trim()}</td>
+                      <td className={`px-2 py-2.5 text-right font-semibold ${delta > 0 ? "text-emerald-400" : delta < 0 ? "text-rose-400" : ""}`}>{delta > 0 ? "+" : ""}{delta.toFixed(0)}%</td>
+                      <td className="pl-2 pr-6"></td>
+                    </tr>
+                  );
+                }
+                return null;
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      <div className="px-6 mt-4 mb-4 grid grid-cols-2 gap-4">
+        <div className="bg-white border border-stone-200 rounded-md shadow-sm p-5">
+          <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Margem operacional</div>
+          <div className="mt-1 text-[28px] font-semibold tracking-tight num">10.1%</div>
+          <div className="mt-2 text-[11.5px] text-stone-500">vs <span className="num">4.0%</span> em abr · <span className="text-emerald-700 font-medium">+6.1pp</span></div>
+          <div className="mt-4 h-2 bg-stone-100 rounded-full overflow-hidden">
+            <div className="h-full bg-stone-900" style={{ width: "10%" }} />
+          </div>
+          <div className="mt-1.5 flex justify-between text-[10.5px] text-stone-400">
+            <span>0%</span><span>meta 12%</span><span>100%</span>
+          </div>
+        </div>
+
+        <div className="bg-white border border-stone-200 rounded-md shadow-sm p-5">
+          <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">Top categorias receita · maio</div>
+          <div className="mt-3 space-y-2.5">
+            {[
+              { label: "Banner / Lona / Adesivo", v: 9580, pct: 64 },
+              { label: "Gráfica rápida", v: 2940, pct: 20 },
+              { label: "Fachada / Placa", v: 2340, pct: 16 },
+            ].map((c) => (
+              <div key={c.label}>
+                <div className="flex items-baseline justify-between text-[12.5px]">
+                  <span className="text-stone-700">{c.label}</span>
+                  <span className="num font-medium">{fmtBRL2(c.v)} <span className="text-stone-400">· {c.pct}%</span></span>
+                </div>
+                <div className="mt-1 h-1 bg-stone-100 rounded-full overflow-hidden">
+                  <div className="h-full bg-emerald-500" style={{ width: `${c.pct}%` }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+/* ═════════════════════════════════════════════════════════════════════════
+ * 4. PLANO DE CONTAS
+ * ═════════════════════════════════════════════════════════════════════════ */
+const PCONTAS = [
+  { code: "1", name: "Receitas", level: 0, type: "rec", saldo: 14860, count: 14, expand: true },
+  { code: "1.1", name: "Vendas de produtos", level: 1, type: "rec", saldo: 14260, count: 12 },
+  { code: "1.1.01", name: "Banner / Lona", level: 2, type: "rec", saldo: 6720, count: 5 },
+  { code: "1.1.02", name: "Adesivo / Envelopamento", level: 2, type: "rec", saldo: 8180, count: 4 },
+  { code: "1.1.03", name: "Fachada / ACM", level: 2, type: "rec", saldo: 2770, count: 3 },
+  { code: "1.1.04", name: "Gráfica rápida", level: 2, type: "rec", saldo: 1600, count: 4 },
+  { code: "1.2", name: "Receitas financeiras", level: 1, type: "rec", saldo: 0, count: 0 },
+  { code: "2", name: "Despesas", level: 0, type: "exp", saldo: -13482, count: 13, expand: true },
+  { code: "2.1", name: "Custos diretos", level: 1, type: "exp", saldo: -5180, count: 6 },
+  { code: "2.1.01", name: "Insumos gráficos", level: 2, type: "exp", saldo: -3420, count: 3 },
+  { code: "2.1.02", name: "Acabamento terceirizado", level: 2, type: "exp", saldo: -1120, count: 1 },
+  { code: "2.1.03", name: "Frete e instalação", level: 2, type: "exp", saldo: -640, count: 2 },
+  { code: "2.2", name: "Despesas administrativas", level: 1, type: "exp", saldo: -6190, count: 5 },
+  { code: "2.2.01", name: "Aluguel", level: 2, type: "exp", saldo: -4500, count: 1 },
+  { code: "2.2.02", name: "Utilidades (energia/internet)", level: 2, type: "exp", saldo: -1500, count: 2 },
+  { code: "2.2.03", name: "Impostos e taxas", level: 2, type: "exp", saldo: -190, count: 2 },
+  { code: "2.3", name: "Folha de pagamento", level: 1, type: "exp", saldo: -2800, count: 1 },
+  { code: "2.4", name: "Manutenção", level: 1, type: "exp", saldo: -780, count: 1 },
+];
+
+const TelaPContas = ({ onBack }) => {
+  useFinBackEsc(onBack);
+  return (
+    <>
+      {onBack && <FinBcrumb here="Plano de contas" onBack={onBack}/>}
+      <div className="px-6 pt-4 mb-4">
+        <div className="bg-white border border-stone-200 rounded-md shadow-sm overflow-hidden">
+          <div className="px-5 py-3 border-b border-stone-200 flex items-center gap-3">
+            <div className="min-w-0">
+              <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium whitespace-nowrap">Plano de contas</div>
+              <div className="text-[16px] font-semibold mt-0.5 whitespace-nowrap">Comunicação Visual · 2 níveis</div>
+            </div>
+            <div className="ml-auto flex items-center gap-2 shrink-0">
+              <input placeholder="Buscar conta…" className="h-8 px-3 w-[160px] rounded-md border border-stone-200 text-[12.5px] placeholder:text-stone-400 focus:border-stone-400" />
+              <button className="h-8 px-3 rounded-md border border-stone-200 text-[12.5px] text-stone-700 hover:bg-stone-50 whitespace-nowrap">Importar</button>
+              <button className="h-8 px-3 rounded-md bg-stone-900 text-white text-[12.5px] hover:bg-stone-800 whitespace-nowrap">+ Nova</button>
+            </div>
+          </div>
+
+          <table className="w-full text-[12.5px] num">
+            <thead>
+              <tr className="text-[10px] uppercase tracking-widest text-stone-500 border-b border-stone-200 bg-stone-50/40">
+                <th className="pl-6 pr-2 py-2 text-left font-medium w-[100px]">Código</th>
+                <th className="px-2 py-2 text-left font-medium">Conta</th>
+                <th className="px-2 py-2 text-left font-medium w-[120px]">Tipo</th>
+                <th className="px-2 py-2 text-right font-medium w-[80px]">Lanç. mês</th>
+                <th className="px-2 py-2 text-right font-medium w-[140px]">Saldo mês</th>
+                <th className="pl-2 pr-6 py-2 w-[80px]"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {PCONTAS.map((c) => (
+                <tr key={c.code} className={`border-b border-stone-100 row-hover ${c.level === 0 ? "bg-stone-50/40" : ""}`}>
+                  <td className="pl-6 pr-2 py-2 text-stone-500 font-mono text-[11.5px]">{c.code}</td>
+                  <td className="px-2 py-2" style={{ paddingLeft: 12 + c.level * 18 }}>
+                    <span className={`${c.level === 0 ? "font-semibold text-stone-900" : c.level === 1 ? "font-medium text-stone-800" : "text-stone-600"}`}>
+                      {c.level > 0 && <span className="text-stone-300 mr-1.5">└</span>}
+                      {c.name}
+                    </span>
+                  </td>
+                  <td className="px-2 py-2">
+                    <span className={`inline-flex items-center gap-1 text-[11px] font-medium px-2 py-0.5 rounded-full ${
+                      c.type === "rec" ? "bg-emerald-50 text-emerald-700" : "bg-rose-50 text-rose-700"
+                    }`}>
+                      <span className={`w-1.5 h-1.5 rounded-full ${c.type === "rec" ? "bg-emerald-500" : "bg-rose-500"}`} />
+                      {c.type === "rec" ? "Receita" : "Despesa"}
+                    </span>
+                  </td>
+                  <td className="px-2 py-2 text-right text-stone-600">{c.count > 0 ? c.count : <span className="text-stone-300">—</span>}</td>
+                  <td className={`px-2 py-2 text-right font-medium ${
+                    c.saldo === 0 ? "text-stone-300" :
+                    c.saldo > 0 ? "text-emerald-700" : "text-stone-900"
+                  }`}>
+                    {c.saldo === 0 ? "—" : <>
+                      <span className="text-stone-400 mr-0.5">{c.saldo > 0 ? "+" : "−"}</span>
+                      {fmtBRL2(Math.abs(c.saldo)).replace("R$", "").trim()}
+                    </>}
+                  </td>
+                  <td className="pl-2 pr-6 py-2 text-right">
+                    <button className="text-[11px] text-stone-500 hover:text-stone-900 underline-offset-2 hover:underline">editar</button>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </>
+  );
+};
+
+window.TelaFluxo = TelaFluxo;
+window.TelaConciliacao = TelaConciliacao;
+window.TelaDRE = TelaDRE;
+window.TelaPContas = TelaPContas;
+})();

--- a/prototipo-ui/styles.css
+++ b/prototipo-ui/styles.css
@@ -1,0 +1,8650 @@
+/* ───────────────────── Oimpresso ERP — Chat v2 ───────────────────── */
+:root{
+  /* Sidebar dark — espelho AppShell */
+  --sb-bg:        oklch(0.21 0 0);
+  --sb-bg-2:      oklch(0.18 0 0);
+  --sb-border:    oklch(0.28 0 0);
+  --sb-text:      oklch(0.78 0 0);
+  --sb-text-dim:  oklch(0.55 0 0);
+  --sb-text-hi:   oklch(0.96 0 0);
+  --sb-hover:     oklch(0.27 0 0);
+  --sb-active:    oklch(0.32 0 0);
+
+  /* Surface */
+  --bg:           oklch(0.985 0.003 90);
+  --bg-2:         oklch(0.965 0.004 90);
+  --surface:      #ffffff;
+  --border:       oklch(0.90 0.004 90);
+  --border-2:     oklch(0.93 0.004 90);
+  --text:         oklch(0.22 0.01 80);
+  --text-dim:     oklch(0.50 0.01 80);
+  --text-mute:    oklch(0.65 0.01 80);
+
+  --accent:       oklch(0.58 0.09 220);
+  --accent-2:     oklch(0.66 0.09 220);
+  --accent-soft:  oklch(0.94 0.025 220);
+  --accent-fg:    #ffffff;
+
+  --bubble-me:    oklch(0.58 0.09 220);
+  --bubble-me-fg: #ffffff;
+  --bubble-them:  oklch(0.96 0.003 90);
+  --bubble-them-fg: var(--text);
+
+  /* Origens (módulos que geram tarefas) */
+  --origin-OS-bg:  oklch(0.93 0.07 70);   --origin-OS-fg:  oklch(0.40 0.10 60);
+  --origin-CRM-bg: oklch(0.92 0.06 220);  --origin-CRM-fg: oklch(0.40 0.10 220);
+  --origin-FIN-bg: oklch(0.93 0.07 145);  --origin-FIN-fg: oklch(0.36 0.10 145);
+  --origin-PNT-bg: oklch(0.93 0.06 295);  --origin-PNT-fg: oklch(0.40 0.10 295);
+  --origin-MFG-bg: oklch(0.93 0.05 30);   --origin-MFG-fg: oklch(0.40 0.10 30);
+
+  --radius:       8px;
+  --radius-sm:    6px;
+  --radius-lg:    12px;
+
+  --shadow-pop:   0 6px 24px -8px rgba(0,0,0,.18), 0 2px 6px -2px rgba(0,0,0,.10);
+  --shadow-soft:  0 1px 2px rgba(0,0,0,.04);
+
+  --row-h:        30px;
+  --font-sans:    "IBM Plex Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono:    "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace;
+}
+
+[data-density="compact"]{ --row-h: 26px; }
+[data-density="comfy"]{   --row-h: 34px; }
+
+[data-theme="dark"]{
+  --bg:        oklch(0.16 0.003 240);
+  --bg-2:      oklch(0.14 0.003 240);
+  --surface:   oklch(0.19 0.003 240);
+  --border:    oklch(0.26 0.005 240);
+  --border-2:  oklch(0.23 0.005 240);
+  --text:      oklch(0.92 0.005 90);
+  --text-dim:  oklch(0.68 0.005 90);
+  --text-mute: oklch(0.55 0.005 90);
+  --bubble-them: oklch(0.24 0.005 240);
+  --accent-soft: oklch(0.30 0.04 220);
+
+  --origin-OS-bg:  oklch(0.30 0.07 60);   --origin-OS-fg:  oklch(0.85 0.07 60);
+  --origin-CRM-bg: oklch(0.30 0.07 220);  --origin-CRM-fg: oklch(0.85 0.07 220);
+  --origin-FIN-bg: oklch(0.30 0.07 145);  --origin-FIN-fg: oklch(0.85 0.07 145);
+  --origin-PNT-bg: oklch(0.30 0.07 295);  --origin-PNT-fg: oklch(0.85 0.07 295);
+  --origin-MFG-bg: oklch(0.30 0.07 30);   --origin-MFG-fg: oklch(0.85 0.07 30);
+}
+
+*{ box-sizing: border-box; }
+html, body, #app{ height: 100%; margin: 0; }
+body{
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  color: var(--text);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+
+/* ────────────────── App shell ────────────────── */
+.app{
+  display: grid;
+  grid-template-columns: var(--sb-w, 260px) 1fr;
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+  transition: grid-template-columns .18s ease-out;
+}
+.app.app--sb-rail     { --sb-w: 56px; }
+.app.app--sb-hidden   { --sb-w: 0px; }
+.main{
+  display: grid;
+  grid-template-rows: 1fr;
+  min-height: 0;
+  min-width: 0;
+}
+.main-body{
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+
+/* ────────────────── Topbar ────────────────── */
+.topbar{
+  height: 40px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  flex-shrink: 0;
+}
+.topbar-l{
+  display: flex; align-items: center; gap: 8px;
+  padding: 0 14px;
+  min-width: 160px;
+  border-right: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.topbar-dot{
+  width: 8px; height: 8px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.topbar-area-label{
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text);
+  white-space: nowrap;
+}
+.topbar-tabs{
+  flex: 1 1 auto;
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+  padding: 0 8px;
+  min-width: 0;
+}
+.topbar-tabs::-webkit-scrollbar { height: 4px; }
+.topbar-tabs::-webkit-scrollbar-thumb { background: var(--border); border-radius: 999px; }
+.topbar-tabs-empty{ flex: 1; }
+.topbar-tab{
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 10px;
+  border: 0;
+  background: transparent;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  color: var(--text-mute);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color .12s, border-color .12s;
+}
+.topbar-tab svg{ opacity: 0.6; }
+.topbar-tab:hover{ color: var(--text); }
+.topbar-tab:hover svg{ opacity: 0.85; }
+.topbar-tab.active{
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  font-weight: 600;
+}
+.topbar-tab.active svg{ opacity: 1; }
+.topbar-r{
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  flex-shrink: 0;
+  border-left: 1px solid var(--border);
+}
+.topbar-tenant{
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--text-mute);
+  font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
+  padding: 0 6px;
+}
+/* legados breadcrumb — manter caso algum ponto ainda use */
+.bc{ display: flex; align-items: center; gap: 8px; font-size: 12.5px; color: var(--text-dim); }
+.bc-tenant{ color: var(--text); font-weight: 600; }
+.bc-sep{ color: var(--text-mute); }
+.bc-up{ color: var(--text-dim); }
+.bc-cur{ color: var(--text); font-weight: 500; }
+
+/* ────────────────── Sidebar ────────────────── */
+.sb{
+  background: var(--sb-bg);
+  color: var(--sb-text);
+  border-right: 1px solid var(--sb-border);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+/* Topo: empresa */
+.sb-top{
+  padding: 10px 10px 8px;
+  border-bottom: 1px solid var(--sb-border);
+  position: relative;
+}
+.sb-cp{ position: relative; }
+.sb-cp-btn{
+  appearance: none;
+  border: 1px solid var(--sb-border);
+  background: var(--sb-bg-2);
+  color: var(--sb-text-hi);
+  height: 32px;
+  padding: 0 8px;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: default;
+  width: 100%;
+}
+.sb-cp-btn:hover{ background: var(--sb-hover); }
+.sb-cp-btn .avatar{
+  width: 20px; height: 20px;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  display: grid; place-items: center;
+  flex: 0 0 auto;
+}
+.sb-cp-btn .name{ flex: 1 1 auto; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-align: left; }
+.sb-cp-btn .chev{ width: 12px; height: 12px; opacity: .55; flex: 0 0 auto; }
+
+.sb-dd{
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0; right: 0;
+  background: oklch(0.20 0 0);
+  border: 1px solid var(--sb-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-pop);
+  padding: 6px;
+  z-index: 50;
+  font-size: 12.5px;
+}
+.sb-dd-h{
+  font-size: 10px; font-weight: 600;
+  letter-spacing: .08em; text-transform: uppercase;
+  color: var(--sb-text-dim);
+  padding: 6px 8px 4px;
+}
+.sb-dd-i{
+  display: flex; align-items: center; gap: 8px;
+  padding: 7px 8px;
+  border-radius: var(--radius-sm);
+  color: var(--sb-text-hi);
+  cursor: default;
+}
+.sb-dd-i:hover{ background: var(--sb-hover); }
+.sb-dd-i .check{ margin-left: auto; opacity: .85; }
+.sb-dd-sep{ height: 1px; background: var(--sb-border); margin: 4px 0; }
+.sb-dd-foot{
+  padding: 7px 8px;
+  border-radius: var(--radius-sm);
+  color: var(--sb-text-dim);
+  font-size: 12px;
+  cursor: default;
+}
+.sb-dd-foot:hover{ background: var(--sb-hover); color: var(--sb-text-hi); }
+
+/* Tabs Chat/Menu */
+.sb-tabs{
+  display: flex;
+  gap: 2px;
+  padding: 8px;
+  border-bottom: 1px solid var(--sb-border);
+}
+.sb-tab{
+  flex: 1 1 0;
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--sb-text-dim);
+  padding: 6px 8px;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: default;
+}
+.sb-tab:hover{ color: var(--sb-text-hi); background: var(--sb-hover); }
+.sb-tab.active{
+  background: var(--sb-active);
+  color: var(--sb-text-hi);
+}
+
+/* Body scrollable */
+.sb-body{
+  flex: 1 1 auto;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: oklch(0.32 0 0) transparent;
+}
+.sb-body::-webkit-scrollbar{ width: 8px; }
+.sb-body::-webkit-scrollbar-thumb{
+  background: oklch(0.32 0 0);
+  border-radius: 4px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+
+/* ── Aba CHAT ── */
+.sb-chat{ padding: 8px; }
+.sb-actions{ display: flex; flex-direction: column; gap: 1px; margin-bottom: 8px; }
+.sb-action{
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 10px;
+  height: 30px;
+  border-radius: var(--radius-sm);
+  color: var(--sb-text);
+  font-size: 13px;
+  cursor: default;
+}
+.sb-action:hover{ background: var(--sb-hover); color: var(--sb-text-hi); }
+.sb-action .ic{ width: 14px; height: 14px; opacity: .85; flex: 0 0 auto; }
+.sb-action span{ flex: 1 1 auto; }
+.sb-action .kbd{
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--sb-text-dim);
+}
+.sb-action .kbd-badge{
+  font-size: 10px; font-weight: 700;
+  background: oklch(0.55 0.15 30);
+  color: #fff;
+  padding: 1px 5px;
+  border-radius: 999px;
+  min-width: 16px;
+  text-align: center;
+}
+.sb-action .beta{
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--sb-text-dim);
+  border: 1px solid var(--sb-border);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+
+.sb-section-h{
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--sb-text-dim);
+  padding: 14px 10px 6px;
+}
+
+.sb-pin-empty{
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 10px;
+  font-size: 11.5px;
+  color: var(--sb-text-dim);
+  border: 1px dashed var(--sb-border);
+  border-radius: var(--radius-sm);
+  margin: 0 4px;
+}
+
+.sb-bullet{
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  margin-top: 1px;
+}
+.sb-bullet.outline{ border: 1.4px solid oklch(0.40 0 0); }
+.sb-bullet.filled{ background: oklch(0.78 0.16 75); border: 0; }
+
+.sb-conv{
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 10px;
+  height: 30px;
+  border-radius: var(--radius-sm);
+  color: var(--sb-text);
+  font-size: 13px;
+  cursor: default;
+}
+.sb-conv:hover{ background: var(--sb-hover); color: var(--sb-text-hi); }
+.sb-conv.active{ background: var(--sb-active); color: var(--sb-text-hi); font-weight: 500; }
+.sb-conv-t{
+  flex: 1 1 auto;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+
+.sb-routine{
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 10px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  color: var(--sb-text);
+  font-size: 12.5px;
+  cursor: default;
+}
+.sb-routine:hover{ background: var(--sb-hover); color: var(--sb-text-hi); }
+.sb-routine-t{
+  flex: 1 1 auto;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.sb-routine-f{
+  font-size: 10.5px;
+  color: var(--sb-text-dim);
+  flex: 0 0 auto;
+}
+
+/* ── Aba MENU ── */
+.sb-menu{ padding: 8px; }
+.sb-group-h{
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--sb-text-dim);
+  padding: 12px 10px 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: default;
+}
+.sb-group-h:hover{ color: var(--sb-text-hi); }
+.sb-group-h .chev{ width: 10px; height: 10px; opacity: .7; flex: 0 0 auto; }
+.sb-item{
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 10px;
+  height: var(--row-h);
+  border-radius: var(--radius-sm);
+  color: var(--sb-text);
+  font-size: 13px;
+  cursor: default;
+  position: relative;
+}
+.sb-item:hover{ background: var(--sb-hover); color: var(--sb-text-hi); }
+.sb-item.active{
+  background: var(--sb-active);
+  color: var(--sb-text-hi);
+  font-weight: 500;
+}
+.sb-item.active::before{
+  content: "";
+  position: absolute;
+  left: -8px; top: 6px; bottom: 6px;
+  width: 2px;
+  background: var(--accent-2);
+  border-radius: 2px;
+}
+.sb-item .ic{ width: 16px; height: 16px; flex: 0 0 auto; opacity: .85; }
+.sb-item .label{ flex: 1 1 auto; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.sb-item .badge{
+  font-size: 10.5px;
+  font-weight: 600;
+  background: var(--accent);
+  color: #fff;
+  border-radius: 999px;
+  padding: 1px 6px;
+  min-width: 18px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+
+/* Rodapé usuário */
+.sb-user{
+  border-top: 1px solid var(--sb-border);
+  padding: 10px;
+  position: relative;
+}
+.sb-user-btn{
+  appearance: none;
+  border: 0;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 8px;
+  border-radius: var(--radius);
+  cursor: default;
+  width: 100%;
+  color: inherit;
+  font: inherit;
+}
+.sb-user-btn:hover{ background: var(--sb-hover); }
+.sb-user-btn{ padding: 9px 10px; gap: 10px; }
+.sb-user-btn .avatar{
+  width: 32px; height: 32px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, oklch(0.65 0.12 30), oklch(0.55 0.15 10));
+  color: #fff;
+  font-size: 11.5px;
+  font-weight: 700;
+  display: grid; place-items: center;
+  flex: 0 0 auto;
+  position: relative;
+}
+.sb-user-btn .avatar::after{
+  content: "";
+  position: absolute;
+  right: -1px; bottom: -1px;
+  width: 9px; height: 9px;
+  background: oklch(0.72 0.18 145);
+  border: 2px solid var(--sb-bg);
+  border-radius: 50%;
+}
+.sb-user-btn .who{ flex: 1 1 auto; min-width: 0; text-align: left; }
+.sb-user-btn .who b{
+  display: block;
+  color: var(--sb-text-hi);
+  font-weight: 500;
+  font-size: 13px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.sb-user-btn .who small{
+  display: block;
+  color: var(--sb-text-dim);
+  font-size: 11px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.sb-user-btn .chev{ width: 14px; height: 14px; opacity: .6; flex: 0 0 auto; }
+
+.user-menu{
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 8px; right: 8px;
+  min-width: 220px;
+  background: oklch(0.22 0 0);
+  border: 1px solid var(--sb-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-pop);
+  padding: 6px;
+  z-index: 60;
+  font-size: 12.5px;
+}
+/* No rail, abre pra direita do botão (não pra dentro do sidebar) */
+.sb--rail .sb-user-rail .user-menu{
+  bottom: 0;
+  left: calc(100% + 8px);
+  right: auto;
+  width: 240px;
+}
+.user-menu-head{
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 10px 12px;
+  border-bottom: 1px solid var(--sb-border);
+  margin-bottom: 6px;
+}
+.user-menu-head .avatar{
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, oklch(0.65 0.12 30), oklch(0.55 0.15 10));
+  color: #fff;
+  font-weight: 700;
+  display: grid; place-items: center;
+}
+.user-menu-head .meta b{ display: block; color: var(--sb-text-hi); font-weight: 500; }
+.user-menu-head .meta small{ display: block; color: var(--sb-text-dim); font-size: 11.5px; }
+.um-item{
+  display: flex; align-items: center; gap: 10px;
+  padding: 7px 8px;
+  border-radius: var(--radius-sm);
+  color: var(--sb-text-hi);
+  cursor: default;
+}
+.um-item:hover{ background: var(--sb-hover); }
+.um-item .ic{ width: 14px; height: 14px; opacity: .8; flex: 0 0 auto; }
+.um-item .label{ flex: 1 1 auto; }
+.um-item .kbd{ font-family: var(--font-mono); font-size: 10.5px; color: var(--sb-text-dim); }
+.um-item .arrow{ font-size: 10px; color: var(--sb-text-dim); }
+.um-status{ display: inline-block; width: 7px; height: 7px; border-radius: 50%; }
+.um-sep{ height: 1px; background: var(--sb-border); margin: 4px 2px; }
+
+/* ────────────────── TAREFAS — master/detail ────────────────── */
+.tk-page{
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.tk-list{
+  background: var(--bg-2);
+  border-right: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  min-height: 0;
+}
+.tk-list-h{
+  padding: 16px 16px 10px;
+  display: flex; flex-direction: column; gap: 10px;
+  border-bottom: 1px solid var(--border);
+}
+.tk-list-h-row{
+  display: flex; align-items: baseline; gap: 8px;
+}
+.tk-list-h h2{
+  font-size: 16px; font-weight: 600; margin: 0;
+  letter-spacing: -0.01em;
+}
+.tk-list-h-sub{
+  margin: -6px 0 0;
+  font-size: 11.5px;
+  color: var(--text-dim);
+  line-height: 1.4;
+}
+.tk-mini-btn{
+  appearance: none; border: 0;
+  margin-left: auto;
+  width: 22px; height: 22px;
+  display: grid; place-items: center;
+  background: transparent;
+  color: var(--text-mute);
+  border-radius: 4px;
+  cursor: default;
+}
+.tk-mini-btn:hover{ background: var(--border-2); color: var(--text); }
+.tk-kpis{
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+}
+.tk-kpi{
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  display: flex; flex-direction: column; gap: 1px;
+}
+.tk-kpi b{
+  font-size: 18px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  line-height: 1.1;
+}
+.tk-kpi small{
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--text-mute);
+  font-weight: 600;
+}
+.tk-kpi.warn{
+  background: oklch(0.97 0.04 25);
+  border-color: oklch(0.85 0.08 25);
+}
+.tk-kpi.warn b{ color: oklch(0.50 0.18 25); }
+[data-theme="dark"] .tk-kpi.warn{
+  background: oklch(0.26 0.06 25);
+  border-color: oklch(0.40 0.10 25);
+}
+[data-theme="dark"] .tk-kpi.warn b{ color: oklch(0.78 0.16 25); }
+.tk-kpi.muted b{ color: var(--text-dim); }
+
+.tk-search{
+  display: flex; align-items: center; gap: 6px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 6px 9px;
+  color: var(--text-mute);
+}
+.tk-search input{
+  appearance: none; border: 0; background: transparent;
+  font: inherit; font-size: 12px;
+  color: var(--text);
+  flex: 1 1 auto; min-width: 0;
+  outline: none;
+}
+.tk-search:focus-within{ border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+
+.tk-count{
+  font-size: 12px;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.tk-filters{
+  display: flex; flex-wrap: wrap;
+  gap: 4px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+}
+.tk-filter{
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 11.5px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  cursor: default;
+}
+.tk-filter:hover{ background: var(--border-2); color: var(--text); }
+.tk-filter.active{ background: var(--text); color: var(--bg); font-weight: 500; }
+
+.tk-list-body{
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 6px 8px 12px;
+  scrollbar-width: thin;
+}
+.tk-list-body::-webkit-scrollbar{ width: 8px; }
+.tk-list-body::-webkit-scrollbar-thumb{
+  background: var(--border); border-radius: 4px;
+  border: 2px solid transparent; background-clip: content-box;
+}
+.tk-group{ margin-top: 6px; }
+.tk-group-h{
+  display: flex; align-items: center;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  padding: 10px 8px 6px;
+}
+.tk-group-c{
+  margin-left: 6px;
+  background: var(--border-2);
+  color: var(--text-dim);
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+
+.tk-card{
+  display: grid;
+  gap: 4px;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  cursor: default;
+  border: 1px solid transparent;
+  margin-bottom: 2px;
+}
+.tk-card:hover{ background: var(--border-2); }
+.tk-card.active{
+  background: var(--surface);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+[data-theme="dark"] .tk-card.active{ background: oklch(0.22 0.005 240); }
+.tk-card.urgent{
+  border-left: 3px solid oklch(0.62 0.18 25);
+  padding-left: 10px;
+}
+.tk-card-h{
+  display: flex; align-items: center; gap: 6px;
+  font-size: 10.5px;
+}
+.tk-origin{
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+.tk-origin.lg{
+  font-size: 11px;
+  padding: 3px 8px;
+  border-radius: 4px;
+}
+.tk-dot{
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: oklch(0.78 0.16 75);
+}
+.tk-when{
+  margin-left: auto;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.tk-card.urgent .tk-when{ color: oklch(0.55 0.18 25); font-weight: 600; }
+.tk-title{
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  line-height: 1.35;
+}
+.tk-sub{
+  font-size: 11.5px;
+  color: var(--text-dim);
+  line-height: 1.4;
+}
+.tk-foot{
+  display: flex; gap: 6px;
+  font-size: 10.5px;
+  color: var(--text-mute);
+  margin-top: 2px;
+}
+
+.tk-empty{
+  padding: 50px 20px;
+  text-align: center;
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  color: var(--text-mute);
+}
+.tk-empty b{ font-size: 13px; color: var(--text); }
+.tk-empty small{ font-size: 11.5px; color: var(--text-dim); }
+.tk-empty-ico{
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  display: grid; place-items: center;
+  color: var(--text-mute);
+  margin-bottom: 6px;
+}
+.tk-empty-ico.lg{ width: 56px; height: 56px; border-radius: 16px; }
+.tk-empty-ico.ok{
+  background: oklch(0.92 0.10 145);
+  color: oklch(0.40 0.16 145);
+}
+[data-theme="dark"] .tk-empty-ico.ok{
+  background: oklch(0.32 0.10 145);
+  color: oklch(0.85 0.16 145);
+}
+
+.tk-empty-state{
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  text-align: center; max-width: 320px;
+}
+.tk-empty-state b{ font-size: 15px; color: var(--text); margin-top: 6px; }
+.tk-empty-state small{ font-size: 12px; color: var(--text-dim); line-height: 1.5; }
+.tk-shortcuts{
+  margin-top: 18px;
+  display: flex; gap: 14px;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.tk-shortcuts kbd{
+  display: inline-block;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  padding: 1px 6px;
+  margin-right: 3px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text);
+}
+
+.tk-empty-old{
+  padding: 60px 20px;
+  text-align: center;
+  color: var(--text-mute);
+  font-size: 13px;
+}
+
+/* Detail */
+.tk-detail{
+  display: flex; flex-direction: column;
+  min-height: 0;
+  background: var(--bg);
+}
+.tk-detail.empty{ justify-content: center; align-items: center; }
+.tk-detail-h{
+  padding: 16px 24px 14px;
+  border-bottom: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 8px;
+  background: var(--surface);
+}
+.tk-detail-bc{
+  display: flex; align-items: center; gap: 6px;
+  font-size: 11px;
+  color: var(--text-mute);
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  font-weight: 600;
+}
+.tk-bc-step{ color: var(--text-dim); }
+.tk-bc-sep{ color: var(--text-mute); opacity: .5; }
+.tk-bc-spacer{ flex: 1 1 auto; }
+.tk-bc-pos{
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  padding: 2px 8px;
+  border-radius: 999px;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--text-dim);
+}
+.tk-detail-title-row{
+  display: flex; align-items: flex-start; gap: 14px;
+}
+.tk-detail-title-row h1{
+  flex: 1 1 auto;
+  margin: 0;
+  font-size: 19px;
+  font-weight: 600;
+  line-height: 1.25;
+  letter-spacing: -0.015em;
+  color: var(--text);
+}
+.tk-detail-actions{
+  display: flex; gap: 2px;
+  flex: 0 0 auto;
+  margin-top: 2px;
+}
+.tk-detail-meta{
+  display: flex; align-items: center; flex-wrap: wrap; gap: 8px;
+  font-size: 12px;
+  color: var(--text);
+}
+.tk-detail-meta .t-mute{ color: var(--text-mute); margin-right: 3px; }
+.tk-detail-meta b{ font-weight: 500; }
+.tk-detail-meta .urgent b{ color: oklch(0.55 0.18 25); font-weight: 600; }
+
+.tk-detail-body{
+  flex: 1 1 auto;
+  overflow-y: auto;
+  display: flex; flex-direction: column;
+  min-height: 0;
+}
+
+/* ────────────────── Viewers ────────────────── */
+.vw{
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 16px 20px 16px;
+  scrollbar-width: thin;
+}
+.vw::-webkit-scrollbar{ width: 10px; }
+.vw::-webkit-scrollbar-thumb{
+  background: var(--border); border-radius: 5px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+.vw-grid{
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.vw-card{
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  margin-bottom: 10px;
+}
+.vw-card.hi{
+  background: linear-gradient(135deg, var(--accent-soft), oklch(0.96 0.02 145));
+  border-color: var(--accent-soft);
+}
+[data-theme="dark"] .vw-card.hi{
+  background: linear-gradient(135deg, oklch(0.26 0.06 220), oklch(0.24 0.04 145));
+}
+.vw-card h3{
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin: 0 0 10px;
+}
+.vw-card h4{ font-size: 12px; margin: 10px 0 6px; color: var(--text); }
+.vw-card .vw-sub{
+  font-size: 10.5px; font-weight: 700; letter-spacing: .06em;
+  text-transform: uppercase; color: var(--text-mute);
+  margin: 12px 0 6px;
+}
+.vw-p{ margin: 0; font-size: 13px; line-height: 1.5; color: var(--text-dim); }
+
+.vw-dl{ display: grid; grid-template-columns: 100px 1fr; gap: 6px 10px; margin: 0; font-size: 12.5px; }
+.vw-dl dt{ color: var(--text-mute); font-weight: 500; }
+.vw-dl dd{ margin: 0; color: var(--text); }
+.vw-dl dd.mono{ font-family: var(--font-mono); }
+.vw-dl dd.urgent{ color: oklch(0.55 0.18 25); font-weight: 600; }
+
+.vw-stage{
+  display: inline-flex;
+  background: var(--origin-OS-bg);
+  color: var(--origin-OS-fg);
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.vw-art{
+  display: flex; gap: 12px; align-items: center;
+  padding: 10px;
+  background: var(--bg-2);
+  border-radius: var(--radius-sm);
+}
+.vw-art-thumb{
+  width: 56px; height: 56px;
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  display: grid; place-items: center;
+  color: var(--text-mute);
+  flex: 0 0 auto;
+}
+.vw-art-meta{ flex: 1 1 auto; min-width: 0; }
+.vw-art-meta b{ display: block; font-size: 13px; }
+.vw-art-meta small{ display: block; font-size: 11.5px; color: var(--text-dim); font-family: var(--font-mono); }
+.vw-art-actions{ display: flex; gap: 6px; margin-top: 6px; }
+
+.vw-hist{ list-style: none; margin: 0; padding: 0; font-size: 12.5px; }
+.vw-hist li{
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border-2);
+  display: flex; gap: 8px;
+}
+.vw-hist li:last-child{ border-bottom: 0; }
+.vw-hist .t{ color: var(--text-mute); font-variant-numeric: tabular-nums; }
+
+.vw-thread-mini{ display: flex; flex-direction: column; gap: 6px; }
+.mini-msg{ display: flex; gap: 8px; align-items: flex-end; }
+.mini-msg.me{ justify-content: flex-end; }
+.mini-av{
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  color: #fff; font-size: 9.5px; font-weight: 600;
+  flex: 0 0 auto;
+}
+.mini-bub{
+  background: var(--bubble-them);
+  padding: 6px 10px;
+  border-radius: 12px;
+  border-top-left-radius: 3px;
+  font-size: 12.5px;
+  max-width: 70%;
+}
+.mini-bub.me{
+  background: var(--bubble-me);
+  color: var(--bubble-me-fg);
+  border-top-left-radius: 12px;
+  border-top-right-radius: 3px;
+}
+.mini-input{
+  margin-top: 6px;
+  appearance: none;
+  width: 100%;
+  height: 32px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: 12.5px;
+  outline: none;
+}
+.mini-input:focus{ border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+
+/* CRM */
+.vw-contact{ display: flex; gap: 12px; align-items: center; margin-bottom: 12px; }
+.vw-contact-av{
+  width: 44px; height: 44px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  color: #fff; font-weight: 700;
+  flex: 0 0 auto;
+}
+.vw-contact b{ font-size: 14px; }
+.vw-contact small{ display: block; font-size: 12px; color: var(--text-dim); }
+.vw-contact-row{
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 10px;
+  background: var(--bg-2);
+  border-radius: var(--radius-sm);
+  margin-bottom: 6px;
+  font-size: 13px;
+}
+.vw-contact-row .ic{ color: var(--text-mute); }
+.vw-contact-row a{ flex: 1 1 auto; color: var(--text); }
+.vw-notes{ margin: 0; padding-left: 18px; font-size: 12.5px; color: var(--text-dim); line-height: 1.6; }
+
+/* Radio/Chips/Textarea reutilizáveis */
+.vw-radio-group{ display: flex; flex-direction: column; gap: 4px; margin-bottom: 8px; }
+.vw-radio{
+  display: flex; align-items: center; gap: 8px;
+  padding: 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: 12.5px;
+  cursor: default;
+}
+.vw-radio:hover{ background: var(--border-2); }
+.vw-radio input{ accent-color: var(--accent); }
+
+.vw-chips{ display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px; }
+.vw-chip{
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  padding: 5px 12px;
+  border-radius: 999px;
+  font: inherit;
+  font-size: 12px;
+  cursor: default;
+}
+.vw-chip:hover{ background: var(--border-2); }
+.vw-chip.on{
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.vw-textarea{
+  appearance: none;
+  width: 100%;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  font: inherit;
+  font-size: 12.5px;
+  resize: vertical;
+  outline: none;
+}
+.vw-textarea:focus{ border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.vw-check{ display: flex; align-items: center; gap: 8px; font-size: 12.5px; margin-top: 8px; color: var(--text-dim); }
+
+/* PNT */
+.vw-pnt-grid{
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 6px;
+}
+.vw-pnt-cell{
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px;
+  text-align: center;
+}
+.vw-pnt-cell small{ display: block; font-size: 10px; color: var(--text-mute); text-transform: uppercase; letter-spacing: .06em; }
+.vw-pnt-cell b{ display: block; font-size: 16px; font-weight: 600; font-family: var(--font-mono); margin-top: 4px; }
+.vw-pnt-cell.miss{
+  background: oklch(0.96 0.04 25);
+  border-color: oklch(0.85 0.08 25);
+  border-style: dashed;
+}
+.vw-pnt-cell.miss b{ color: oklch(0.55 0.18 25); }
+[data-theme="dark"] .vw-pnt-cell.miss{
+  background: oklch(0.26 0.06 25);
+  border-color: oklch(0.45 0.10 25);
+}
+
+/* FIN — money */
+.vw-money{ text-align: center; padding: 14px 8px; }
+.vw-money small{
+  display: block;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+.vw-money b{
+  display: block;
+  font-size: 32px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin: 6px 0 4px;
+  font-variant-numeric: tabular-nums;
+}
+.vw-due{ font-size: 12px; color: var(--text-dim); }
+.vw-due.urgent{ color: oklch(0.55 0.18 25); font-weight: 600; }
+
+/* Botões viewer */
+.vw-actions{
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  margin-top: 8px;
+}
+.vw-spacer{ flex: 1 1 auto; }
+.vw-btn{
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  height: 34px;
+  padding: 0 14px;
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: default;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.vw-btn:hover{ background: var(--border-2); }
+.vw-btn.primary{
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+.vw-btn.primary:hover{ background: var(--accent-2); border-color: var(--accent-2); }
+.vw-btn.danger{
+  background: oklch(0.55 0.18 25);
+  color: #fff;
+  border-color: oklch(0.55 0.18 25);
+}
+.vw-btn.danger:hover{ background: oklch(0.50 0.18 25); }
+.vw-btn.ghost{
+  background: transparent;
+  border-color: transparent;
+  color: var(--text-dim);
+}
+.vw-btn.ghost:hover{ background: var(--border-2); color: var(--text); }
+.vw-btn.sm{ height: 26px; padding: 0 10px; font-size: 11.5px; }
+
+/* ────────────────── Module stub (rich migration page) ────────────────── */
+.mod-stub{
+  flex: 1 1 auto;
+  display: flex; flex-direction: column;
+  min-height: 0;
+  overflow-y: auto;
+  background:
+    radial-gradient(1200px 600px at 100% 0%, var(--accent-soft) 0%, transparent 60%),
+    var(--bg);
+}
+[data-theme="dark"] .mod-stub{
+  background:
+    radial-gradient(1200px 600px at 100% 0%, oklch(0.26 0.06 var(--hue, 220)) 0%, transparent 60%),
+    var(--bg);
+}
+
+.mod-stub-hero{
+  padding: 32px 32px 28px;
+  display: flex; align-items: flex-start; gap: 24px;
+  border-bottom: 1px solid var(--border);
+}
+.mod-stub-hero-l{
+  display: flex; gap: 18px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.mod-stub-hero-l > div{ min-width: 0; flex: 1 1 auto; }
+.mod-stub-ico{
+  width: 56px; height: 56px;
+  border-radius: 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  display: grid; place-items: center;
+  color: var(--accent);
+  flex: 0 0 auto;
+  box-shadow: 0 1px 2px rgba(0,0,0,.04);
+}
+.mod-stub-eyebrow{
+  display: flex; align-items: center; gap: 6px;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin-bottom: 8px;
+}
+.mod-stub-hero-l h1{
+  margin: 0;
+  font-size: 30px;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  line-height: 1.1;
+  color: var(--text);
+}
+.mod-stub-hero-l p{
+  margin: 8px 0 0;
+  font-size: 14px;
+  line-height: 1.55;
+  max-width: 580px;
+  color: var(--text-dim);
+}
+.mod-stub-hero-r{ flex: 0 0 auto; }
+.mod-stub-status{
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+}
+.mod-stub-status .dot{
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--text-mute);
+}
+.mod-stub-status.ok{ background: oklch(0.95 0.05 145); color: oklch(0.36 0.10 145); border-color: oklch(0.85 0.06 145); }
+.mod-stub-status.ok .dot{ background: oklch(0.62 0.16 145); }
+.mod-stub-status.partial{ background: oklch(0.95 0.05 75); color: oklch(0.40 0.10 75); border-color: oklch(0.85 0.06 75); }
+.mod-stub-status.partial .dot{ background: oklch(0.72 0.16 75); }
+.mod-stub-status.next{ background: var(--accent-soft); color: var(--accent); border-color: var(--accent-soft); }
+.mod-stub-status.next .dot{ background: var(--accent); }
+.mod-stub-status.queue{ background: var(--surface); color: var(--text); border-color: var(--border); }
+.mod-stub-status.queue .dot{ background: var(--text-dim); }
+.mod-stub-status.muted{ color: var(--text-mute); }
+[data-theme="dark"] .mod-stub-status.ok{ background: oklch(0.30 0.07 145); color: oklch(0.85 0.10 145); }
+[data-theme="dark"] .mod-stub-status.partial{ background: oklch(0.30 0.07 75); color: oklch(0.85 0.10 75); }
+
+.mod-stub-grid{
+  padding: 28px 32px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  flex: 1 1 auto;
+}
+.mod-stub-card{
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 18px 20px;
+}
+.mod-stub-card.span{ grid-column: 1 / -1; }
+.mod-stub-card h3{
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin: 0 0 14px;
+}
+
+.mod-stub-actions{
+  display: flex; flex-wrap: wrap; gap: 6px;
+}
+.mod-stub-action{
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--bg-2);
+  color: var(--text);
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  padding: 7px 12px;
+  border-radius: var(--radius-sm);
+  cursor: default;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.mod-stub-action:hover{ background: var(--border-2); }
+.mod-stub-action.primary{
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+.mod-stub-action.primary:hover{ background: var(--accent-2); border-color: var(--accent-2); }
+.mod-stub-empty{ font-size: 12.5px; color: var(--text-mute); margin: 0; }
+
+.mod-stub-dl{
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 8px 12px;
+  margin: 0;
+  font-size: 12.5px;
+}
+.mod-stub-dl dt{ color: var(--text-mute); font-weight: 500; }
+.mod-stub-dl dd{ margin: 0; color: var(--text); }
+.mod-stub-dl dd.mono{ font-family: var(--font-mono); font-size: 12px; }
+.mod-stub-dl dd.mono.small{ font-size: 11px; color: var(--text-dim); word-break: break-all; }
+
+.mod-stub-roadmap{
+  list-style: none;
+  margin: 0; padding: 0;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  position: relative;
+}
+.mod-stub-roadmap li{
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  position: relative;
+  opacity: .7;
+}
+.mod-stub-roadmap li b{ display: block; font-size: 12.5px; font-weight: 600; color: var(--text); margin-bottom: 2px; }
+.mod-stub-roadmap li small{ display: block; font-size: 11px; color: var(--text-dim); line-height: 1.4; }
+.mod-stub-roadmap li .step{
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-mute);
+  display: grid; place-items: center;
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.mod-stub-roadmap li.done{ opacity: 1; background: oklch(0.97 0.03 145); border-color: oklch(0.85 0.06 145); }
+.mod-stub-roadmap li.done .step{ background: oklch(0.62 0.16 145); border-color: oklch(0.62 0.16 145); color: #fff; }
+.mod-stub-roadmap li.current{ opacity: 1; background: var(--accent-soft); border-color: var(--accent); }
+.mod-stub-roadmap li.current .step{ background: var(--accent); border-color: var(--accent); color: #fff; }
+[data-theme="dark"] .mod-stub-roadmap li.done{ background: oklch(0.28 0.05 145); border-color: oklch(0.45 0.10 145); }
+[data-theme="dark"] .mod-stub-roadmap li.current{ background: oklch(0.28 0.06 220); }
+
+.mod-stub-foot{
+  padding: 16px 32px 28px;
+  display: flex; align-items: center; gap: 8px;
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+}
+.mod-stub-foot-spacer{ flex: 1 1 auto; }
+.mod-stub-tag{
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 11.5px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 4px 10px;
+  border-radius: 999px;
+  color: var(--text);
+}
+.mod-stub-tag .mono{ font-family: var(--font-mono); }
+.mod-stub-link{
+  appearance: none;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  font-size: 12px;
+  color: var(--text-dim);
+  cursor: default;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+.mod-stub-link:hover{ background: var(--border-2); color: var(--text); }
+
+@media (max-width: 1100px){
+  .mod-stub-grid{ grid-template-columns: 1fr; }
+  .mod-stub-roadmap{ grid-template-columns: 1fr 1fr; }
+}
+
+/* ────────────────── Chat (thread) ────────────────── */
+.thread{
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  background: var(--bg);
+}
+.th-head{
+  height: 56px;
+  border-bottom: 1px solid var(--border);
+  padding: 0 18px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.th-head .av{
+  width: 34px; height: 34px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  color: #fff; font-weight: 600; font-size: 13px;
+}
+.th-head .who b{ display: block; font-size: 14px; font-weight: 600; letter-spacing: -0.01em; }
+.th-head .who small{ display: block; font-size: 11.5px; color: var(--text-dim); }
+.th-head .who small .dot{
+  display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+  background: oklch(0.72 0.18 145);
+  margin-right: 5px; vertical-align: middle;
+}
+.th-head .actions{ margin-left: auto; display: flex; gap: 4px; }
+.th-context{
+  background: var(--bg-2);
+  border-bottom: 1px solid var(--border);
+  padding: 8px 18px;
+  display: flex; align-items: center; gap: 14px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.th-context b{ color: var(--text); font-weight: 600; }
+.th-context .pill{
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text);
+}
+.th-context .stage{
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 2px 8px;
+  background: var(--origin-OS-bg);
+  color: var(--origin-OS-fg);
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+}
+
+.msgs{
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 18px 24px 12px;
+  scrollbar-width: thin;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.msgs::-webkit-scrollbar{ width: 10px; }
+.msgs::-webkit-scrollbar-thumb{
+  background: var(--border); border-radius: 5px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+.day-sep{
+  align-self: center;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  padding: 3px 10px;
+  border-radius: 999px;
+  margin: 12px 0 8px;
+}
+.row{ display: flex; gap: 10px; margin-top: 2px; max-width: 78%; }
+.row.me{ align-self: flex-end; flex-direction: row-reverse; }
+.row .av{
+  width: 28px; height: 28px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  flex: 0 0 auto;
+  margin-top: 2px;
+  align-self: flex-end;
+}
+.row.me .av{ display: none; }
+.row.continued .av{ visibility: hidden; }
+.bubble{
+  background: var(--bubble-them);
+  color: var(--bubble-them-fg);
+  padding: 8px 12px;
+  border-radius: 14px;
+  border-top-left-radius: 4px;
+  font-size: 13.5px;
+  line-height: 1.45;
+  max-width: 100%;
+  word-wrap: break-word;
+  position: relative;
+}
+.row.me .bubble{
+  background: var(--bubble-me);
+  color: var(--bubble-me-fg);
+  border-top-left-radius: 14px;
+  border-top-right-radius: 4px;
+}
+.row.continued .bubble{ border-top-left-radius: 14px; }
+.row.me.continued .bubble{ border-top-right-radius: 14px; }
+.bubble .meta{
+  display: block;
+  font-size: 10.5px;
+  margin-top: 3px;
+  opacity: .65;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+.row.me .bubble .meta{ color: rgba(255,255,255,.85); }
+.bubble .author{
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  margin-bottom: 2px;
+  color: var(--accent);
+}
+.bubble.note{
+  background: oklch(0.96 0.04 80);
+  color: oklch(0.32 0.06 70);
+  border: 1px dashed oklch(0.80 0.08 80);
+  font-size: 12.5px;
+}
+[data-theme="dark"] .bubble.note{
+  background: oklch(0.26 0.04 80);
+  color: oklch(0.88 0.05 80);
+  border-color: oklch(0.38 0.06 80);
+}
+.bubble.file{ display: flex; align-items: center; gap: 10px; padding: 10px 12px; }
+.bubble.file .fic{
+  width: 36px; height: 36px;
+  border-radius: 8px;
+  background: oklch(0.94 0.02 220);
+  color: oklch(0.40 0.10 220);
+  display: grid; place-items: center;
+  flex: 0 0 auto;
+}
+.bubble.file b{ display: block; font-size: 13px; }
+.bubble.file small{ display: block; font-size: 11.5px; opacity: .7; font-family: var(--font-mono); }
+
+.typing{
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 10px 14px;
+  background: var(--bubble-them);
+  border-radius: 14px;
+  border-top-left-radius: 4px;
+  margin-top: 4px;
+  align-self: flex-start;
+}
+.typing span{
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--text-mute);
+  animation: bounce 1.2s infinite ease-in-out;
+}
+.typing span:nth-child(2){ animation-delay: .15s; }
+.typing span:nth-child(3){ animation-delay: .3s; }
+@keyframes bounce{
+  0%, 60%, 100%{ transform: translateY(0); opacity: .5; }
+  30%{ transform: translateY(-4px); opacity: 1; }
+}
+
+.composer{
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+  padding: 12px 18px 14px;
+}
+.composer-inner{
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: 8px 10px 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: border-color .15s, box-shadow .15s;
+}
+.composer-inner:focus-within{
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.composer textarea{
+  appearance: none;
+  border: 0;
+  background: transparent;
+  resize: none;
+  outline: none;
+  width: 100%;
+  font: inherit;
+  font-size: 13.5px;
+  line-height: 1.45;
+  color: var(--text);
+  min-height: 22px;
+  max-height: 160px;
+  padding: 4px 2px;
+}
+.composer-toolbar{ display: flex; align-items: center; gap: 4px; }
+.composer-toolbar .icon-btn{
+  width: 26px; height: 26px;
+  border: 0;
+  background: transparent;
+}
+.composer-toolbar .icon-btn:hover{ background: var(--border-2); color: var(--text); }
+.composer-toolbar .spacer{ flex: 1 1 auto; }
+.composer-toolbar .hint{ font-size: 11px; color: var(--text-mute); margin-right: 4px; }
+.composer-toolbar .hint kbd{
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 0 4px;
+  margin: 0 1px;
+}
+.send-btn{
+  appearance: none;
+  border: 0;
+  background: var(--accent);
+  color: #fff;
+  height: 28px;
+  padding: 0 12px;
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: default;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.send-btn:hover{ background: var(--accent-2); }
+.send-btn:disabled{
+  background: var(--border);
+  color: var(--text-mute);
+  cursor: not-allowed;
+}
+
+.icon-btn{
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-dim);
+  width: 28px; height: 28px;
+  border-radius: var(--radius-sm);
+  display: grid; place-items: center;
+  cursor: default;
+}
+.icon-btn:hover{ color: var(--text); border-color: var(--text-mute); }
+
+/* Empty */
+.empty{
+  flex: 1 1 auto;
+  display: grid;
+  place-items: center;
+  color: var(--text-mute);
+  font-size: 13px;
+  text-align: center;
+  padding: 40px;
+}
+.empty .ico{
+  width: 48px; height: 48px;
+  border-radius: 12px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  display: grid; place-items: center;
+  margin: 0 auto 12px;
+  color: var(--text-mute);
+}
+
+/* Avatar palette helpers */
+.av-1{ background: linear-gradient(135deg, oklch(0.62 0.12 30),  oklch(0.50 0.15 10)); }
+.av-2{ background: linear-gradient(135deg, oklch(0.62 0.12 220), oklch(0.50 0.15 260)); }
+.av-3{ background: linear-gradient(135deg, oklch(0.62 0.12 145), oklch(0.50 0.15 175)); }
+.av-4{ background: linear-gradient(135deg, oklch(0.62 0.12 80),  oklch(0.50 0.15 50)); }
+.av-5{ background: linear-gradient(135deg, oklch(0.62 0.12 300), oklch(0.50 0.15 270)); }
+.av-6{ background: linear-gradient(135deg, oklch(0.62 0.12 180), oklch(0.50 0.15 200)); }
+
+/* Mono helper */
+.mono{ font-family: var(--font-mono); }
+
+/* ────────────────── Chat page (3 colunas) ────────────────── */
+.chat-page{
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.chat-page:has(.linked.collapsed){
+  grid-template-columns: 1fr 44px;
+}
+.chat-main{
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+
+/* Tabsbar interna do chat (Todos/OS/Equipe/Clientes) */
+.chat-tabsbar{
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+}
+.chat-tabs{
+  display: flex;
+  gap: 2px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 2px;
+}
+.chat-tab{
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 14px;
+  border-radius: 999px;
+  cursor: default;
+  letter-spacing: -0.005em;
+}
+.chat-tab:hover{ color: var(--text); }
+.chat-tab.active{
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 600;
+  box-shadow: var(--shadow-soft);
+}
+.chat-search{
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: 999px;
+  height: 28px;
+  padding: 0 10px 0 9px;
+  width: 240px;
+  color: var(--text-mute);
+}
+.chat-search input{
+  appearance: none;
+  border: 0;
+  outline: none;
+  background: transparent;
+  flex: 1 1 auto;
+  font: inherit;
+  font-size: 12px;
+  color: var(--text);
+  min-width: 0;
+}
+.chat-search:focus-within{
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+
+/* ────────────────── Linked Apps (coluna direita) ────────────────── */
+.linked{
+  border-left: 1px solid var(--border);
+  background: var(--bg-2);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  transition: width .15s;
+}
+.linked-h{
+  height: 44px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  background: var(--bg);
+}
+.linked-h b{
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+.linked-h .icon-btn{
+  width: 26px; height: 26px;
+  background: transparent;
+  border-color: transparent;
+}
+.linked-h .icon-btn:hover{ background: var(--border-2); }
+.linked-h .spacer{ flex: 1 1 auto; }
+
+.linked.collapsed .linked-h{
+  flex-direction: column;
+  height: auto;
+  padding: 8px 0;
+  gap: 6px;
+}
+.linked.collapsed .linked-h .spacer{ display: none; }
+
+.linked-body{
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 10px;
+  scrollbar-width: thin;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.linked-body::-webkit-scrollbar{ width: 8px; }
+.linked-body::-webkit-scrollbar-thumb{
+  background: var(--border); border-radius: 4px;
+  border: 2px solid transparent; background-clip: content-box;
+}
+.linked-empty{
+  flex: 1 1 auto;
+  display: grid;
+  place-content: center;
+  text-align: center;
+  color: var(--text-mute);
+  padding: 40px 16px;
+  gap: 8px;
+}
+.linked-empty p{ font-size: 12px; line-height: 1.45; margin: 0; }
+
+/* Bloco individual */
+.lblock{
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.lblock-h{
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  font-size: 12px;
+  cursor: default;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+.lblock.collapsed .lblock-h{ border-bottom: 0; }
+.lblock-h:hover{ background: var(--bg-2); }
+.lblock-h b{ font-weight: 600; font-size: 12px; color: var(--text); }
+.lblock-h .spacer{ flex: 1 1 auto; }
+.lblock-chev{
+  color: var(--text-mute);
+  transition: transform .15s;
+  transform: rotate(0deg);
+}
+.lblock-chev.open{ transform: rotate(90deg); }
+.lblock-b{
+  padding: 10px 12px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.origin-badge{
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+.origin-badge.o-OS{  background: var(--origin-OS-bg);  color: var(--origin-OS-fg); }
+.origin-badge.o-CRM{ background: var(--origin-CRM-bg); color: var(--origin-CRM-fg); }
+.origin-badge.o-FIN{ background: var(--origin-FIN-bg); color: var(--origin-FIN-fg); }
+.origin-badge.o-PNT{ background: var(--origin-PNT-bg); color: var(--origin-PNT-fg); }
+
+.lkv{
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+  padding: 2px 0;
+}
+.lkv span:first-child{
+  color: var(--text-mute);
+  font-size: 11px;
+  min-width: 76px;
+  flex: 0 0 auto;
+}
+.lkv b{ color: var(--text); font-weight: 500; flex: 1 1 auto; min-width: 0; }
+.lkv b.mono{ font-family: var(--font-mono); font-size: 11.5px; }
+.lkv.col{ flex-direction: column; gap: 2px; }
+.lstage{
+  display: inline-flex;
+  background: var(--origin-OS-bg);
+  color: var(--origin-OS-fg);
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+}
+.lhint{ font-size: 11.5px; color: var(--text-dim); line-height: 1.4; }
+
+.lrow-btns{
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+}
+.lbtn-sec{
+  flex: 1 1 0;
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--bg-2);
+  color: var(--text);
+  height: 26px;
+  padding: 0 10px;
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: 11.5px;
+  cursor: default;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+.lbtn-sec:hover{ background: var(--border-2); }
+
+.lblock-cta{
+  appearance: none;
+  border: 1px solid var(--accent-soft);
+  background: var(--accent-soft);
+  color: var(--accent);
+  height: 28px;
+  padding: 0 12px;
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: default;
+  margin-top: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  align-self: stretch;
+}
+.lblock-cta:hover{ background: var(--accent); color: #fff; }
+
+.lpunch{
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  margin-top: 4px;
+}
+.lpunch-row{
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 6px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.lpunch-row span{ font-size: 9.5px; color: var(--text-mute); text-transform: uppercase; letter-spacing: .04em; }
+.lpunch-row b{ font-size: 12.5px; }
+.lpunch-row.missing{
+  background: oklch(0.97 0.04 25);
+  border-color: oklch(0.85 0.08 25);
+  border-style: dashed;
+}
+.lpunch-row.missing b{ color: oklch(0.55 0.18 25); }
+[data-theme="dark"] .lpunch-row.missing{
+  background: oklch(0.26 0.05 25);
+  border-color: oklch(0.45 0.08 25);
+}
+
+.latts{ display: flex; flex-direction: column; gap: 4px; }
+.latt{
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 8px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+.latt-body{ flex: 1 1 auto; min-width: 0; }
+.latt-body b{ display: block; font-size: 11.5px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.latt-body small{ display: block; font-size: 10.5px; color: var(--text-mute); font-family: var(--font-mono); }
+
+.lhist{ list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 5px; }
+.lhist li{
+  display: flex;
+  gap: 8px;
+  font-size: 11.5px;
+  padding: 5px 0;
+  border-bottom: 1px solid var(--border-2);
+}
+.lhist li:last-child{ border-bottom: 0; }
+.lhist-when{
+  flex: 0 0 auto;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+  font-size: 10.5px;
+  padding-top: 1px;
+}
+.lhist-who{ flex: 1 1 auto; color: var(--text-dim); line-height: 1.35; }
+.lhist-who b{ color: var(--text); font-weight: 500; }
+
+
+/* ════════════════════════ OS LIST PAGE ════════════════════════ */
+.os-page{
+  flex: 1 1 auto;
+  display: flex; flex-direction: column;
+  min-height: 0;
+  overflow-y: auto;
+  background: var(--bg);
+  position: relative;
+}
+
+.os-page-h{
+  padding: 28px 32px 16px;
+  display: flex; align-items: flex-start; gap: 16px;
+  border-bottom: 1px solid var(--border);
+}
+.os-page-h-l{ flex: 1 1 auto; min-width: 0; }
+.os-page-h-l h1{
+  margin: 0 0 4px;
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+.os-page-h-l p{
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-dim);
+  line-height: 1.5;
+}
+.os-page-h-r{ display: flex; gap: 8px; flex: 0 0 auto; }
+
+/* Stats */
+.os-stats{
+  padding: 16px 32px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-2);
+}
+.os-stat{
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 14px;
+  display: flex; flex-direction: column; gap: 2px;
+}
+.os-stat small{
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+.os-stat b{
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+.os-stat.warn{
+  background: oklch(0.97 0.04 25);
+  border-color: oklch(0.85 0.08 25);
+}
+.os-stat.warn b{ color: oklch(0.50 0.18 25); }
+[data-theme="dark"] .os-stat.warn{
+  background: oklch(0.26 0.06 25);
+  border-color: oklch(0.40 0.10 25);
+}
+[data-theme="dark"] .os-stat.warn b{ color: oklch(0.78 0.16 25); }
+.os-stat.muted b{ color: var(--text-dim); font-size: 18px; }
+
+/* Toolbar */
+.os-toolbar{
+  padding: 10px 24px 8px 24px;
+  display: flex; align-items: center; gap: 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  flex-wrap: wrap;
+}
+.os-tabs{
+  display: flex; gap: 2px;
+  flex-wrap: wrap;
+}
+.os-tab{
+  appearance: none; border: 0;
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  padding: 6px 11px;
+  border-radius: var(--radius-sm);
+  cursor: default;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.os-tab:hover{ background: var(--border-2); color: var(--text); }
+.os-tab.active{
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 5px 10px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.04);
+}
+.os-tab.warn{ color: oklch(0.55 0.18 25); }
+.os-tab.warn.active{ border-color: oklch(0.85 0.08 25); }
+.os-tab-n{
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+  background: var(--border-2);
+  color: var(--text-dim);
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-weight: 600;
+}
+.os-tab.active .os-tab-n{ background: var(--accent-soft); color: var(--accent); }
+.os-tab.warn .os-tab-n{ background: oklch(0.93 0.07 25); color: oklch(0.50 0.18 25); }
+
+.os-toolbar-r{
+  margin-left: auto;
+  display: flex; align-items: center; gap: 8px;
+}
+.os-select{
+  appearance: none;
+  font: inherit;
+  font-size: 12px;
+  height: 30px;
+  padding: 0 26px 0 10px;
+  border: 1px solid var(--border);
+  background: var(--surface) url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2'><path d='m6 9 6 6 6-6'/></svg>") right 8px center/12px no-repeat;
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  outline: none;
+  cursor: default;
+}
+.os-select:focus{ border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.os-search{
+  display: flex; align-items: center; gap: 6px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 5px 10px;
+  color: var(--text-mute);
+  width: 280px;
+}
+.os-search input{
+  appearance: none; border: 0; background: transparent;
+  font: inherit; font-size: 12px;
+  color: var(--text);
+  flex: 1 1 auto; min-width: 0;
+  outline: none;
+}
+.os-search:focus-within{ border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+
+/* Bulk bar */
+.os-bulk{
+  padding: 8px 24px;
+  display: flex; align-items: center; gap: 8px;
+  background: var(--accent-soft);
+  border-bottom: 1px solid var(--accent-soft);
+  font-size: 12.5px;
+  color: var(--accent);
+}
+.os-bulk b{ color: var(--accent); }
+.os-bulk-spacer{ flex: 1 1 auto; }
+
+/* Buttons */
+.os-btn{
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  height: 30px;
+  padding: 0 12px;
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: default;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.os-btn:hover{ background: var(--border-2); }
+.os-btn.primary{ background: var(--accent); color: #fff; border-color: var(--accent); }
+.os-btn.primary:hover{ background: var(--accent-2); border-color: var(--accent-2); }
+.os-btn.ghost{ background: transparent; border-color: transparent; color: var(--text-dim); }
+.os-btn.ghost:hover{ background: var(--border-2); color: var(--text); }
+.os-btn.ghost.danger{ color: oklch(0.55 0.18 25); }
+.os-btn.ghost.danger:hover{ background: oklch(0.96 0.04 25); }
+.os-btn.sm{ height: 26px; padding: 0 10px; font-size: 11.5px; }
+
+/* Table */
+.os-table-wrap{
+  flex: 1 1 auto;
+  overflow: auto;
+  background: var(--bg);
+}
+.os-table{
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 13px;
+}
+.os-table thead th{
+  position: sticky; top: 0;
+  background: var(--bg-2);
+  border-bottom: 1px solid var(--border);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  padding: 10px 12px;
+  text-align: left;
+  white-space: nowrap;
+  z-index: 1;
+}
+.os-table .os-th-num{ width: 90px; }
+.os-table .os-th-val{ text-align: right; }
+
+.os-table tbody td{
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-2);
+  vertical-align: middle;
+  color: var(--text);
+}
+
+.os-row{ cursor: default; transition: background .08s; }
+.os-row:hover{ background: var(--bg-2); }
+.os-row.selected{ background: var(--accent-soft); }
+.os-row.selected td{ background: var(--accent-soft); }
+.os-row.urgent{ box-shadow: inset 3px 0 0 oklch(0.62 0.18 25); }
+
+.os-cell-check{ width: 32px; }
+.os-cell-check input{ accent-color: var(--accent); cursor: default; }
+.os-cell-num{
+  white-space: nowrap;
+  display: flex; align-items: center; gap: 6px;
+}
+.os-cell-num .mono{
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.os-urgent-dot{
+  display: inline-block;
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: oklch(0.62 0.18 25);
+}
+.os-cell-client b{
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  letter-spacing: -0.005em;
+}
+.os-cell-client small{
+  display: block;
+  font-size: 11.5px;
+  color: var(--text-dim);
+}
+.os-cell-product{
+  color: var(--text-dim);
+  font-size: 12.5px;
+  max-width: 320px;
+}
+.os-cell-resp{
+  display: flex; align-items: center; gap: 6px;
+  white-space: nowrap;
+}
+.os-resp-av{
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  color: #fff;
+  font-size: 9.5px;
+  font-weight: 600;
+  flex: 0 0 auto;
+}
+.os-resp-av.lg{ width: 36px; height: 36px; font-size: 12px; }
+.os-resp-name{ font-size: 12.5px; color: var(--text-dim); }
+.os-cell-deadline{
+  font-size: 12.5px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.os-cell-deadline.urgent{ color: oklch(0.55 0.18 25); font-weight: 600; }
+.os-cell-value{
+  text-align: right;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--text);
+}
+
+.os-table tfoot td{
+  border-top: 2px solid var(--border);
+  background: var(--bg-2);
+  padding: 12px 14px;
+  font-size: 12px;
+  font-weight: 600;
+}
+.os-foot-l{ text-align: right; color: var(--text-dim); }
+.os-foot-v{ text-align: right; color: var(--text); font-size: 14px; }
+
+/* Empty in table */
+.os-empty-row{ padding: 50px 20px !important; text-align: center; }
+.os-empty-state{
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  color: var(--text-mute);
+}
+.os-empty-state b{ color: var(--text); font-size: 13px; margin-top: 8px; }
+.os-empty-state small{ font-size: 11.5px; color: var(--text-dim); }
+
+/* Stage badge */
+.os-stage{
+  display: inline-flex; align-items: center;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.os-stage.muted{   background: var(--border-2); color: var(--text-dim); }
+.os-stage.blue{    background: oklch(0.93 0.06 240); color: oklch(0.40 0.12 240); }
+.os-stage.amber{   background: oklch(0.94 0.07 75);  color: oklch(0.42 0.12 70);  }
+.os-stage.violet{  background: oklch(0.93 0.07 295); color: oklch(0.42 0.12 295); }
+.os-stage.cyan{    background: oklch(0.94 0.06 200); color: oklch(0.42 0.10 200); }
+.os-stage.green{   background: oklch(0.94 0.06 145); color: oklch(0.40 0.12 145); }
+.os-stage.red{     background: oklch(0.95 0.05 25);  color: oklch(0.50 0.16 25);  }
+[data-theme="dark"] .os-stage.muted{   background: oklch(0.30 0 0);     color: oklch(0.78 0 0); }
+[data-theme="dark"] .os-stage.blue{    background: oklch(0.30 0.07 240); color: oklch(0.85 0.10 240); }
+[data-theme="dark"] .os-stage.amber{   background: oklch(0.30 0.07 75);  color: oklch(0.85 0.10 75);  }
+[data-theme="dark"] .os-stage.violet{  background: oklch(0.30 0.07 295); color: oklch(0.85 0.10 295); }
+[data-theme="dark"] .os-stage.cyan{    background: oklch(0.30 0.07 200); color: oklch(0.85 0.10 200); }
+[data-theme="dark"] .os-stage.green{   background: oklch(0.30 0.07 145); color: oklch(0.85 0.10 145); }
+[data-theme="dark"] .os-stage.red{     background: oklch(0.30 0.07 25);  color: oklch(0.85 0.16 25);  }
+
+/* ════════════════════════ OS DETAIL DRAWER ════════════════════════ */
+.os-drawer-back{
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,.18);
+  z-index: 8;
+  animation: fadein .15s ease-out;
+}
+[data-theme="dark"] .os-drawer-back{ background: rgba(0,0,0,.45); }
+@keyframes fadein{ from { opacity: 0; } to { opacity: 1; } }
+
+.os-drawer{
+  position: absolute;
+  top: 0; right: 0; bottom: 0;
+  width: min(540px, 100%);
+  background: var(--bg);
+  border-left: 1px solid var(--border);
+  z-index: 9;
+  display: flex; flex-direction: column;
+  overflow-y: auto;
+  box-shadow: -8px 0 32px rgba(0,0,0,.08);
+  animation: slidein .2s cubic-bezier(.2,.8,.2,1);
+}
+[data-theme="dark"] .os-drawer{ box-shadow: -8px 0 32px rgba(0,0,0,.4); }
+@keyframes slidein{ from { transform: translateX(20px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+
+.os-drawer-h{
+  padding: 16px 20px;
+  display: flex; align-items: center; gap: 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+.os-drawer-h-l{ display: flex; align-items: center; gap: 8px; flex: 1 1 auto; }
+.os-drawer-num{
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-dim);
+}
+.os-urgent-tag{
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  background: oklch(0.95 0.06 25);
+  color: oklch(0.50 0.18 25);
+  padding: 2px 7px;
+  border-radius: 4px;
+}
+
+.os-drawer-title{
+  padding: 18px 20px 8px;
+}
+.os-drawer-title h2{
+  margin: 0 0 4px;
+  font-size: 19px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  line-height: 1.3;
+}
+.os-drawer-title p{
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+.os-drawer-title b{ color: var(--text); font-weight: 500; }
+
+.os-drawer-meta{
+  padding: 8px 20px 16px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+.os-drawer-meta > div{
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+}
+.os-drawer-meta small{
+  display: block;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin-bottom: 2px;
+}
+.os-drawer-meta b{
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+.os-drawer-meta .urgent{ color: oklch(0.55 0.18 25); }
+.os-drawer-meta .mono{ font-family: var(--font-mono); }
+
+.os-drawer-section{
+  padding: 16px 20px;
+  border-top: 1px solid var(--border-2);
+}
+.os-drawer-section h3{
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin: 0 0 12px;
+}
+.os-drawer-resp{
+  display: flex; align-items: center; gap: 12px;
+}
+.os-drawer-resp b{ display: block; font-size: 13px; font-weight: 500; }
+.os-drawer-resp small{ display: block; font-size: 11.5px; color: var(--text-dim); }
+.os-drawer-resp button{ margin-left: auto; }
+
+/* Stages flow */
+.os-stages-flow{
+  display: flex; flex-wrap: wrap; gap: 8px 14px;
+  padding: 4px 0;
+}
+.os-stage-step{
+  display: flex; align-items: center; gap: 6px;
+  font-size: 11.5px;
+  color: var(--text-mute);
+  position: relative;
+}
+.os-stage-step .step-dot{
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--border);
+  border: 1px solid var(--border);
+}
+.os-stage-step.done .step-dot{ background: oklch(0.62 0.16 145); border-color: oklch(0.62 0.16 145); }
+.os-stage-step.done{ color: var(--text-dim); }
+.os-stage-step.current .step-dot{
+  background: var(--accent);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+.os-stage-step.current{ color: var(--accent); font-weight: 600; }
+
+/* Timeline */
+.os-timeline{
+  list-style: none;
+  margin: 0; padding: 0;
+  position: relative;
+}
+.os-timeline::before{
+  content: "";
+  position: absolute;
+  left: 6px; top: 6px; bottom: 6px;
+  width: 1px;
+  background: var(--border);
+}
+.os-tl-item{
+  position: relative;
+  padding: 6px 0 12px 22px;
+}
+.os-tl-dot{
+  position: absolute;
+  left: 2px; top: 12px;
+  width: 9px; height: 9px;
+  border-radius: 50%;
+  background: var(--surface);
+  border: 2px solid var(--text-mute);
+}
+.os-tl-item.create .os-tl-dot{ border-color: var(--text-dim); }
+.os-tl-item.client .os-tl-dot{ border-color: oklch(0.62 0.14 220); }
+.os-tl-item.art    .os-tl-dot{ border-color: oklch(0.65 0.16 75);  }
+.os-tl-item.prod   .os-tl-dot{ border-color: oklch(0.62 0.14 295); }
+.os-tl-item.pending .os-tl-dot{ border-color: var(--accent); background: var(--accent); }
+
+.os-tl-h{
+  display: flex; align-items: baseline; gap: 6px;
+  font-size: 12px;
+}
+.os-tl-h b{ font-weight: 600; color: var(--text); }
+.os-tl-h small{ color: var(--text-mute); }
+.os-tl-when{
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.os-tl-content p{
+  margin: 3px 0 0;
+  font-size: 12.5px;
+  color: var(--text-dim);
+  line-height: 1.5;
+}
+.os-tl-file{
+  display: inline-flex; align-items: center; gap: 5px;
+  margin-top: 5px;
+  font-size: 11.5px;
+  font-family: var(--font-mono);
+  color: var(--accent);
+  background: var(--accent-soft);
+  padding: 3px 8px;
+  border-radius: 4px;
+}
+
+.os-drawer-actions{
+  margin-top: auto;
+  padding: 14px 20px;
+  display: flex; gap: 8px; align-items: center;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  position: sticky; bottom: 0;
+}
+
+/* ════════════════════════ NOVA OS DRAWER ════════════════════════ */
+.os-drawer.wide{ width: min(820px, 100%); }
+.os-new-num{
+  background: oklch(from var(--accent) l c h / 0.12);
+  color: var(--accent);
+  border-radius: 4px;
+  padding: 3px 8px;
+  font-weight: 700;
+  letter-spacing: .02em;
+}
+
+.os-new-stepper{
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-2);
+}
+.os-step{
+  all: unset;
+  display: flex; align-items: center; gap: 10px;
+  padding: 12px 14px;
+  cursor: pointer;
+  border-right: 1px solid var(--border);
+  transition: background .12s;
+  position: relative;
+}
+.os-step:last-child{ border-right: 0; }
+.os-step:hover{ background: var(--bg-1); }
+.os-step.active{
+  background: var(--surface);
+  box-shadow: inset 0 -2px 0 var(--accent);
+}
+.os-step-bullet{
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  background: var(--bg-1);
+  border: 1.5px solid var(--border);
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+.os-step.done .os-step-bullet{
+  background: var(--accent);
+  border-color: var(--accent);
+  color: white;
+}
+.os-step-text{ display: flex; flex-direction: column; min-width: 0; }
+.os-step-text b{ font-size: 12px; font-weight: 600; color: var(--text); }
+.os-step-text small{
+  font-size: 11px; color: var(--text-dim);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  max-width: 160px;
+}
+
+.os-new-body{
+  padding: 22px 24px 90px;
+  flex: 1 1 auto;
+  overflow-y: auto;
+}
+.os-new-sec{ animation: fadein .15s ease-out; }
+.os-new-sec h3{
+  margin: 0 0 4px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+}
+.os-new-help{
+  margin: 0 0 16px;
+  font-size: 12.5px;
+  color: var(--text-dim);
+}
+
+.os-new-search{
+  display: flex; align-items: center; gap: 8px;
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 9px 12px;
+  margin-bottom: 10px;
+}
+.os-new-search input{
+  all: unset;
+  flex: 1; font-size: 13px; color: var(--text);
+}
+.os-new-search input::placeholder{ color: var(--text-dim); }
+
+.os-new-results{
+  list-style: none; margin: 0; padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--surface);
+}
+.os-new-results li{
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 14px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border-2);
+  transition: background .12s;
+}
+.os-new-results li:last-child{ border-bottom: 0; }
+.os-new-results li:hover{ background: var(--bg-2); }
+.os-new-results li b{ display: block; font-size: 13px; font-weight: 500; }
+.os-new-results li small{ display: block; font-size: 11.5px; color: var(--text-dim); margin-top: 2px; }
+.os-new-results li.empty{ cursor: default; color: var(--text-dim); justify-content: flex-start; }
+.os-new-results li.empty a{ color: var(--accent); cursor: pointer; margin-left: 6px; }
+.os-new-last{
+  font-size: 11px; color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+.os-new-price{ font-size: 12px; color: var(--text); font-weight: 500; }
+
+.os-new-client-card{
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-2);
+  padding: 14px 16px;
+}
+.os-new-client-h{
+  display: flex; justify-content: space-between; align-items: center;
+  margin-bottom: 14px;
+}
+.os-new-client-h b{ display: block; font-size: 14px; }
+.os-new-client-h small{ display: block; font-size: 11.5px; color: var(--text-dim); margin-top: 2px; font-family: var(--font-mono); }
+
+.os-new-row2{
+  display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+}
+.os-new-row2 label{ display: flex; flex-direction: column; gap: 5px; }
+.os-new-row2 small{ font-size: 11px; color: var(--text-dim); font-weight: 500; text-transform: uppercase; letter-spacing: .04em; }
+.os-new-row2 input{
+  all: unset;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 11px;
+  font-size: 13px; color: var(--text);
+  font-family: inherit;
+}
+.os-new-row2 input.mono{ font-family: var(--font-mono); }
+.os-new-row2 input:focus{ border-color: var(--accent); }
+
+.os-new-prod-pickers{
+  display: flex; flex-direction: column; gap: 8px; margin-bottom: 12px;
+}
+.os-new-cats{
+  display: flex; gap: 6px; flex-wrap: wrap;
+}
+.os-cat{
+  all: unset;
+  font-size: 11.5px;
+  padding: 5px 11px;
+  border-radius: 999px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: all .12s;
+}
+.os-cat:hover{ background: var(--bg-1); color: var(--text); }
+.os-cat.active{
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+
+.os-new-items{
+  margin-top: 16px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--surface);
+}
+.os-new-itable{
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.os-new-itable th{
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  color: var(--text-dim);
+  text-align: left;
+  padding: 10px 12px;
+  background: var(--bg-2);
+  border-bottom: 1px solid var(--border);
+}
+.os-new-itable th.r, .os-new-itable td.r{ text-align: right; }
+.os-new-itable td{
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-2);
+  vertical-align: top;
+}
+.os-new-itable tbody tr:last-child td{ border-bottom: 0; }
+.os-new-itable td b{ display: block; font-weight: 500; font-size: 13px; }
+.os-new-itable tfoot td{
+  background: var(--bg-2);
+  border-top: 1px solid var(--border);
+  font-size: 13px;
+  padding: 10px 12px;
+}
+.os-new-itable tfoot b{ font-size: 14px; }
+.os-new-itemnote{
+  all: unset;
+  display: block;
+  margin-top: 4px;
+  width: 100%;
+  font-size: 11.5px;
+  color: var(--text-dim);
+  border-bottom: 1px dashed transparent;
+}
+.os-new-itemnote:focus{ border-bottom-color: var(--border); color: var(--text); }
+.os-new-itemnote::placeholder{ color: var(--text-dim); opacity: .6; }
+.os-new-qty, .os-new-price-i{
+  all: unset;
+  width: 60px;
+  text-align: right;
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 6px;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+}
+.os-new-price-i{ width: 80px; }
+.os-new-qty:focus, .os-new-price-i:focus{ border-color: var(--accent); }
+.os-new-unit{
+  display: block;
+  font-size: 10px; color: var(--text-dim);
+  margin-top: 2px;
+  text-transform: lowercase;
+}
+
+.os-new-empty{
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--text-dim);
+  border: 1.5px dashed var(--border);
+  border-radius: 10px;
+}
+.os-new-empty b{ display: block; margin: 8px 0 2px; font-size: 13px; color: var(--text); }
+.os-new-empty small{ font-size: 12px; }
+
+.os-new-toggle{
+  display: flex !important; align-items: center; gap: 8px;
+  flex-direction: row !important;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px;
+  cursor: pointer;
+  align-self: end;
+}
+.os-new-toggle input{ width: auto !important; padding: 0 !important; }
+.os-new-toggle span{ font-size: 13px; color: var(--text); }
+
+.os-new-textarea{
+  display: flex; flex-direction: column; gap: 5px;
+  margin-top: 14px;
+}
+.os-new-textarea small{ font-size: 11px; color: var(--text-dim); font-weight: 500; text-transform: uppercase; letter-spacing: .04em; }
+.os-new-textarea textarea{
+  all: unset;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 13px; color: var(--text);
+  font-family: inherit;
+  line-height: 1.5;
+  resize: vertical;
+  min-height: 80px;
+}
+.os-new-textarea textarea:focus{ border-color: var(--accent); }
+
+.os-new-shortcuts{
+  display: flex; align-items: center; gap: 8px;
+  margin-top: 12px;
+}
+.os-new-shortcuts small{ font-size: 11px; color: var(--text-dim); }
+.os-chip{
+  all: unset;
+  font-size: 11.5px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  cursor: pointer;
+}
+.os-chip:hover{ background: var(--bg-1); border-color: var(--accent); }
+
+.os-new-resps{
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+}
+.os-new-resp{
+  all: unset;
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 12px;
+  border: 1.5px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  background: var(--surface);
+  transition: all .12s;
+}
+.os-new-resp:hover{ border-color: var(--text-dim); }
+.os-new-resp.active{
+  border-color: var(--accent);
+  background: oklch(from var(--accent) l c h / 0.08);
+}
+.os-new-resp b{ display: block; font-size: 13px; font-weight: 500; }
+.os-new-resp small{ display: block; font-size: 11.5px; color: var(--text-dim); margin-top: 2px; }
+
+.os-new-attach{
+  display: flex; gap: 8px; flex-wrap: wrap;
+  padding: 14px;
+  border: 1.5px dashed var(--border);
+  border-radius: 8px;
+  background: var(--bg-2);
+}
+.os-new-files{
+  list-style: none; margin: 12px 0 0; padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.os-new-files li{
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-2);
+  font-size: 12.5px;
+  background: var(--surface);
+}
+.os-new-files li:last-child{ border-bottom: 0; }
+.os-new-files li span{ flex: 1; }
+.os-new-fkind{
+  font-size: 10px; color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  background: var(--bg-2);
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+
+.os-new-foot{
+  flex-wrap: wrap;
+  gap: 12px !important;
+}
+.os-new-summary{
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  font-size: 12px; color: var(--text-dim);
+}
+.os-new-total{
+  font-size: 14px; color: var(--text); font-weight: 600;
+  margin-left: 6px;
+}
+.os-btn.disabled, .os-btn:disabled{
+  opacity: .45; cursor: not-allowed;
+}
+
+/* ════════════════════════ APROVAR ARTE — MODAL ════════════════════════ */
+.os-modal-back{
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,.45);
+  z-index: 90;
+  animation: fadein .15s ease-out;
+}
+[data-theme="dark"] .os-modal-back{ background: rgba(0,0,0,.6); }
+
+.os-modal{
+  position: absolute;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  z-index: 91;
+  display: flex; flex-direction: column;
+  max-height: 92%;
+  width: min(1080px, 96%);
+  box-shadow: 0 24px 80px rgba(0,0,0,.18);
+  animation: modalin .2s cubic-bezier(.2,.8,.2,1);
+  overflow: hidden;
+}
+[data-theme="dark"] .os-modal{ box-shadow: 0 24px 80px rgba(0,0,0,.6); }
+@keyframes modalin{
+  from { transform: translate(-50%, -48%); opacity: 0; }
+  to   { transform: translate(-50%, -50%); opacity: 1; }
+}
+
+.os-modal-h{
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 18px 22px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.os-modal-h h2{
+  margin: 0 0 3px;
+  font-size: 17px; font-weight: 600; color: var(--text);
+}
+.os-modal-h p{
+  margin: 0;
+  font-size: 12.5px; color: var(--text-dim);
+}
+.os-modal-h > div{ flex: 1; }
+.os-modal-h .icon-btn{ flex-shrink: 0; }
+
+.os-modal-foot{
+  padding: 14px 22px;
+  display: flex; align-items: center; gap: 8px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-2);
+}
+
+/* Body do modal de aprovação: 240px coluna versões + canvas */
+.os-approve-body{
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 0;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.os-approve-versions{
+  border-right: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  min-height: 0;
+  background: var(--bg-2);
+}
+.os-approve-modes{
+  display: flex; gap: 4px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border-2);
+}
+.os-version-list{
+  list-style: none; margin: 0; padding: 8px;
+  flex: 1 1 auto;
+  overflow-y: auto;
+}
+.os-version-list li{
+  padding: 11px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  border: 1.5px solid transparent;
+  transition: background .12s, border-color .12s;
+  margin-bottom: 4px;
+}
+.os-version-list li:hover{ background: var(--bg-1); }
+.os-version-list li.selected{
+  background: var(--surface);
+  border-color: var(--accent);
+}
+.os-version-list li.compare{
+  border-color: oklch(from var(--accent) l c h / .5);
+  border-style: dashed;
+}
+.os-version-h{
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 2px;
+}
+.os-version-h b{ font-size: 13px; font-weight: 600; }
+.os-version-tag{
+  font-size: 9.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  color: oklch(0.40 0.16 145);
+  background: oklch(0.92 0.06 145);
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+[data-theme="dark"] .os-version-tag{
+  color: oklch(0.85 0.18 145);
+  background: oklch(0.30 0.08 145);
+}
+.os-version-list small{
+  display: block;
+  font-size: 11px; color: var(--text-dim);
+  margin-bottom: 4px;
+}
+.os-version-list p{
+  margin: 0;
+  font-size: 11.5px; color: var(--text);
+  line-height: 1.45;
+}
+
+.os-approve-canvas{
+  display: flex; align-items: center; justify-content: center;
+  gap: 24px;
+  padding: 28px;
+  background: var(--bg-1);
+  min-height: 0;
+  overflow: auto;
+}
+.os-approve-canvas.compare{ gap: 18px; }
+.os-approve-vs{
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: .12em;
+  color: var(--text-dim);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.os-approve-vs span{
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 6px 14px;
+}
+
+/* Thumbs (placeholder gráfico colorido por versão) */
+.os-art-thumb{
+  display: flex; flex-direction: column; align-items: center; gap: 10px;
+}
+.os-art-thumb small{
+  font-size: 11.5px; color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+.os-art-frame{
+  width: 320px; height: 220px;
+  background: white;
+  border: 1px solid var(--border);
+  box-shadow: 0 6px 24px rgba(0,0,0,.08);
+  position: relative;
+  overflow: hidden;
+}
+[data-theme="dark"] .os-art-frame{
+  background: oklch(0.96 0.01 240);
+  box-shadow: 0 6px 24px rgba(0,0,0,.4);
+}
+.os-art-corner{
+  position: absolute;
+  width: 12px; height: 12px;
+  border: 1.5px solid oklch(0.45 0.04 240);
+  opacity: .35;
+}
+.os-art-corner.tl{ top: 6px; left: 6px; border-right: 0; border-bottom: 0; }
+.os-art-corner.tr{ top: 6px; right: 6px; border-left: 0; border-bottom: 0; }
+.os-art-corner.bl{ bottom: 6px; left: 6px; border-right: 0; border-top: 0; }
+.os-art-corner.br{ bottom: 6px; right: 6px; border-left: 0; border-top: 0; }
+.os-art-content{
+  position: absolute; inset: 18px;
+  display: flex; flex-direction: column; justify-content: flex-end;
+}
+.os-art-blob{
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(2px);
+  opacity: .85;
+}
+.os-art-thumb.art-v1 .os-art-blob.a{ background: #e8c468; top: -10px; right: 30px; width: 110px; height: 110px; }
+.os-art-thumb.art-v1 .os-art-blob.b{ background: #d97757; top: 50px; right: -20px; width: 90px; height: 90px; }
+.os-art-thumb.art-v1 .os-art-blob.c{ background: #a8a29e; bottom: 60px; right: 50px; width: 60px; height: 60px; opacity: .4; }
+
+.os-art-thumb.art-v2 .os-art-blob.a{ background: #e8c468; top: -14px; right: 24px; width: 130px; height: 130px; }
+.os-art-thumb.art-v2 .os-art-blob.b{ background: #d97757; top: 46px; right: -18px; width: 100px; height: 100px; }
+.os-art-thumb.art-v2 .os-art-blob.c{ background: #6c8ea4; bottom: 56px; right: 44px; width: 70px; height: 70px; }
+
+.os-art-thumb.art-v3 .os-art-blob.a{ background: #e8c468; top: -14px; right: 24px; width: 130px; height: 130px; }
+.os-art-thumb.art-v3 .os-art-blob.b{ background: #d97757; top: 46px; right: -18px; width: 100px; height: 100px; }
+.os-art-thumb.art-v3 .os-art-blob.c{ background: #4a6b85; bottom: 56px; right: 44px; width: 70px; height: 70px; }
+
+.os-art-text{
+  position: relative;
+  z-index: 2;
+}
+.os-art-text b{
+  display: block;
+  font-size: 16px; font-weight: 700;
+  color: oklch(0.20 0.04 240);
+  font-family: var(--font-display, var(--font-sans));
+  letter-spacing: -.01em;
+}
+.os-art-text span{
+  font-size: 11px;
+  color: oklch(0.45 0.04 240);
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+/* Decisão (aprovar/ajustar/rejeitar) */
+.os-approve-decision{
+  padding: 16px 22px;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+}
+.os-decision-options{
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+.os-decision{
+  all: unset;
+  display: flex; align-items: flex-start; gap: 10px;
+  padding: 12px 14px;
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  cursor: pointer;
+  background: var(--surface);
+  transition: all .12s;
+}
+.os-decision:hover{ border-color: var(--text-dim); background: var(--bg-2); }
+.os-decision b{ display: block; font-size: 13px; font-weight: 600; color: var(--text); }
+.os-decision small{ display: block; font-size: 11.5px; color: var(--text-dim); margin-top: 2px; line-height: 1.4; }
+.os-decision svg{ margin-top: 2px; flex-shrink: 0; opacity: .65; }
+
+.os-decision.approve.active{
+  border-color: oklch(0.55 0.16 145);
+  background: oklch(0.96 0.04 145);
+}
+[data-theme="dark"] .os-decision.approve.active{
+  background: oklch(0.28 0.06 145);
+}
+.os-decision.approve.active svg{ color: oklch(0.45 0.16 145); opacity: 1; }
+
+.os-decision.adjust.active{
+  border-color: oklch(0.62 0.14 75);
+  background: oklch(0.96 0.04 75);
+}
+[data-theme="dark"] .os-decision.adjust.active{
+  background: oklch(0.30 0.06 75);
+}
+.os-decision.adjust.active svg{ color: oklch(0.55 0.16 75); opacity: 1; }
+
+.os-decision.reject.active{
+  border-color: oklch(0.55 0.18 25);
+  background: oklch(0.96 0.04 25);
+}
+[data-theme="dark"] .os-decision.reject.active{
+  background: oklch(0.30 0.06 25);
+}
+.os-decision.reject.active svg{ color: oklch(0.55 0.18 25); opacity: 1; }
+
+.os-decision-comment{
+  display: block;
+  width: 100%;
+  margin-top: 10px;
+  padding: 10px 12px;
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 13px; color: var(--text);
+  font-family: inherit;
+  line-height: 1.5;
+  resize: vertical;
+  min-height: 70px;
+  box-sizing: border-box;
+}
+.os-decision-comment:focus{ outline: none; border-color: var(--accent); }
+
+.os-decision-confirm{
+  display: flex; align-items: center; gap: 8px;
+  margin-top: 10px;
+  padding: 10px 12px;
+  background: oklch(0.96 0.04 145);
+  border: 1px solid oklch(0.55 0.10 145 / 0.3);
+  border-radius: 6px;
+  font-size: 12.5px;
+  color: oklch(0.30 0.10 145);
+}
+[data-theme="dark"] .os-decision-confirm{
+  background: oklch(0.26 0.05 145);
+  color: oklch(0.85 0.10 145);
+  border-color: oklch(0.55 0.10 145 / 0.5);
+}
+.os-decision-confirm svg{ flex-shrink: 0; }
+.os-decision-confirm b{ font-weight: 600; }
+.os-kbd{
+  display: inline-block;
+  padding: 1px 5px;
+  font: 600 10px/1 "IBM Plex Mono", monospace;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: 3px;
+  color: var(--text-dim);
+  margin-left: 4px;
+  vertical-align: middle;
+}
+.os-decision.active .os-kbd{ border-color: currentColor; color: currentColor; opacity: .8; }
+
+/* ════════════════════════ PRINT (OS Detail) ════════════════════════ */
+@media print{
+  body { background: white !important; }
+  .app-shell, .sidebar, .chat-panel, .os-page-h-r, .os-toolbar, .os-bulk,
+  .os-table-wrap, .os-stats, .os-drawer-actions, .os-drawer-back,
+  .tweaks-panel, .os-modal-back, .os-modal { display: none !important; }
+  .os-drawer{
+    position: static !important;
+    width: 100% !important;
+    box-shadow: none !important;
+    border: none !important;
+    transform: none !important;
+  }
+  .os-drawer-h, .os-drawer-body { padding: 0 !important; }
+  @page { margin: 18mm 14mm; }
+}
+
+/* ════════════════════════ BULK MODAL ════════════════════════ */
+.os-bulk-modal{ width: min(560px, 96%); }
+.os-bulk-ids{
+  font-size: 11.5px;
+  color: var(--text-dim);
+}
+.os-bulk-body{
+  padding: 18px 22px;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  max-height: 60vh;
+}
+.os-bulk-stages{
+  display: flex; flex-direction: column; gap: 6px;
+  margin-bottom: 16px;
+}
+.os-bulk-stage{
+  all: unset;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 14px;
+  border: 1.5px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  background: var(--surface);
+  transition: all .12s;
+}
+.os-bulk-stage:hover{ border-color: var(--text-dim); background: var(--bg-2); }
+.os-bulk-stage.active{
+  border-color: var(--accent);
+  background: oklch(from var(--accent) l c h / 0.08);
+}
+.os-bulk-stage svg{ color: var(--accent); }
+
+.os-bulk-toggle{
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 12px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  margin-top: 14px;
+  font-size: 13px;
+  color: var(--text);
+}
+.os-bulk-toggle input{ margin: 0; }
+
+
+/* ════════════════════════ CLIENTES (Fase 3) ════════════════════════ */
+.cli-name{ font-weight: 600; color: var(--text); }
+.cli-sub{ font-size: 11.5px; color: var(--text-dim); margin-top: 2px; }
+.cli-seg{
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.cli-city{ font-size: 12px; color: var(--text-dim); }
+.cli-num{ font-variant-numeric: tabular-nums; font-weight: 500; }
+.cli-last{ font-size: 11.5px; color: var(--text-dim); }
+.cli-status{
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+.cli-status.ativo{ background: oklch(0.93 0.07 145); color: oklch(0.36 0.10 145); }
+.cli-status.inativo{ background: var(--bg-2); color: var(--text-dim); }
+
+.cli-kpis{
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  margin-bottom: 16px;
+}
+.cli-kpi{
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  display: flex; flex-direction: column;
+}
+.cli-kpi b{ font-size: 16px; font-weight: 600; color: var(--text); font-variant-numeric: tabular-nums; }
+.cli-kpi b.ok{ color: oklch(0.50 0.14 145); }
+.cli-kpi b.muted{ color: var(--text-dim); }
+.cli-kpi small{ font-size: 11px; color: var(--text-dim); margin-top: 2px; text-transform: uppercase; letter-spacing: 0.04em; }
+
+.cli-tabs{ margin: 8px 0 14px; }
+
+.cli-section{
+  display: flex; flex-direction: column; gap: 8px;
+}
+.cli-row{
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+.cli-row span{ color: var(--text-dim); }
+.cli-row b{ color: var(--text); font-weight: 500; }
+.cli-tags{ display: flex; flex-wrap: wrap; gap: 4px; }
+.cli-tag{
+  padding: 1px 7px;
+  border-radius: 8px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  font-size: 10.5px;
+  color: var(--text-dim);
+}
+.cli-empty{
+  margin-top: 12px;
+  padding: 16px;
+  background: var(--bg-2);
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  text-align: center;
+  color: var(--text-dim);
+}
+.cli-empty b{ display: block; color: var(--text); margin: 6px 0 2px; }
+.cli-empty small{ font-size: 11.5px; }
+.cli-empty svg{ opacity: 0.4; }
+
+.cli-contact{
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.cli-contact-av{
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: oklch(0.65 0.12 240);
+  color: white;
+  display: flex; align-items: center; justify-content: center;
+  font-weight: 600;
+  font-size: 13px;
+}
+.cli-contact b{ display: block; font-size: 13px; }
+.cli-contact small{ font-size: 11.5px; color: var(--text-dim); }
+
+/* ════════════════════════ ORÇAMENTOS ════════════════════════ */
+.orc-items{
+  font-size: 12px;
+  color: var(--text-dim);
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.orc-status{
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 1px solid;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: .02em;
+}
+.orc-os{
+  margin-left: 6px;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.orc-prob{
+  position: relative;
+  width: 56px;
+  height: 14px;
+  background: var(--bg-2);
+  border-radius: 3px;
+  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.orc-prob-fill{
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  background: oklch(0.55 0.14 240 / .35);
+}
+.orc-prob span{
+  position: relative;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text);
+}
+
+/* ════════════════════════ PRODUTOS ════════════════════════ */
+.prod-toggle{
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  font-size: 12px;
+  color: var(--text-dim);
+  cursor: pointer;
+  user-select: none;
+}
+.prod-toggle input{ accent-color: var(--accent); }
+
+.prod-grid{
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px;
+  padding: 12px 16px;
+}
+.prod-card{
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  cursor: pointer;
+  transition: border-color .12s, transform .12s;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  position: relative;
+}
+.prod-card:hover{ border-color: var(--accent); }
+.prod-card.selected{ border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
+.prod-card.inactive{ opacity: .55; }
+
+.prod-card-h{
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.prod-cat{
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.prod-inactive-badge{
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--bg-2);
+  color: var(--text-dim);
+}
+.prod-name{
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+  line-height: 1.3;
+  text-wrap: pretty;
+}
+.prod-id{
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.prod-foot{
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-top: auto;
+}
+.prod-price b{
+  font-size: 16px;
+  font-weight: 700;
+}
+.prod-price small{
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-left: 2px;
+}
+.prod-meta{
+  font-size: 11px;
+  color: var(--text-dim);
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.prod-meta span{ display: inline-flex; gap: 3px; align-items: center; }
+.prod-pop{
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  height: 2px;
+  background: var(--bg-2);
+  border-radius: 0 0 8px 8px;
+  overflow: hidden;
+}
+.prod-pop-fill{
+  height: 100%;
+  background: var(--accent);
+}
+.prod-bom-h{
+  font-size: 12px;
+  font-weight: 600;
+  margin: 12px 0 6px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: .04em;
+}
+.prod-bom-row{
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12.5px;
+  padding: 4px 0;
+  color: var(--text);
+}
+.prod-bom-row svg{ color: var(--accent); flex-shrink: 0; }
+
+
+/* ─── Produção: Fila / Acabamento / Expedição ─── */
+.prod-page{
+  display: flex; flex-direction: column;
+  height: 100%;
+  background: var(--bg);
+  overflow: hidden;
+}
+
+.prod-header{
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 18px 24px 14px;
+  border-bottom: 1px solid var(--border-2);
+  gap: 16px;
+}
+.prod-header-l h1{
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.prod-header-l p{
+  margin: 2px 0 0;
+  font-size: 12.5px;
+  color: var(--text-mute);
+}
+.prod-header-r{
+  display: flex; align-items: center; gap: 8px;
+}
+.prod-view-toggle{
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  margin-right: 4px;
+}
+.prod-view-toggle button{
+  appearance: none; background: var(--bg); border: 0;
+  padding: 6px 10px;
+  font: inherit; font-size: 12px;
+  display: inline-flex; align-items: center; gap: 5px;
+  color: var(--text-mute);
+  cursor: default;
+  border-right: 1px solid var(--border);
+}
+.prod-view-toggle button:last-child{ border-right: 0; }
+.prod-view-toggle button.active{
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+
+.prod-kpis{
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  gap: 12px;
+  padding: 14px 24px 0;
+}
+.prod-kpi{
+  background: var(--bg-2);
+  border: 1px solid var(--border-2);
+  border-radius: 8px;
+  padding: 12px 14px;
+  display: flex; flex-direction: column; gap: 2px;
+}
+.prod-kpi-label{
+  font-size: 11px; color: var(--text-mute);
+  text-transform: uppercase; letter-spacing: 0.04em;
+}
+.prod-kpi-value{
+  font-size: 22px; font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.prod-kpi-sub{
+  font-size: 11.5px; color: var(--text-mute);
+}
+.prod-kpi-urgent .prod-kpi-value{ color: oklch(0.55 0.18 25); }
+.prod-kpi-urgent{ border-color: oklch(0.85 0.10 25); background: oklch(0.97 0.04 25); }
+
+.prod-equip-filters{
+  display: flex; gap: 6px; flex-wrap: wrap;
+  padding: 14px 24px 0;
+}
+.prod-equip-tab{
+  appearance: none; background: var(--bg-2);
+  border: 1px solid var(--border-2);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font: inherit; font-size: 12px;
+  display: inline-flex; align-items: center; gap: 6px;
+  color: var(--text-mute);
+  cursor: default;
+}
+.prod-equip-tab .count{
+  font-size: 11px;
+  background: var(--bg-3, var(--bg));
+  padding: 1px 5px;
+  border-radius: 3px;
+  color: var(--text-mute);
+}
+.prod-equip-tab.active{
+  background: var(--bg);
+  color: var(--text);
+  border-color: var(--text-mute);
+}
+.prod-equip-tab.active .count{ background: var(--accent-soft); color: var(--accent); }
+.prod-equip-dot{
+  width: 6px; height: 6px; border-radius: 50%;
+  display: inline-block;
+}
+.prod-equip-dot.violet{ background: oklch(0.55 0.18 295); }
+.prod-equip-dot.blue{ background: oklch(0.55 0.16 230); }
+.prod-equip-dot.cyan{ background: oklch(0.60 0.13 200); }
+
+.prod-kanban{
+  display: grid; grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+  padding: 14px 24px 24px;
+  flex: 1 1 auto;
+  overflow: auto;
+  align-items: start;
+}
+
+.prod-col{
+  background: var(--bg-2);
+  border: 1px solid var(--border-2);
+  border-radius: 10px;
+  display: flex; flex-direction: column;
+  min-height: 240px;
+}
+.prod-col-head{
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-2);
+  gap: 8px;
+}
+.prod-col-head-l{
+  display: flex; align-items: center; gap: 8px;
+}
+.prod-col-head h3{
+  margin: 0; font-size: 13px; font-weight: 600;
+}
+.prod-col-count{
+  font-size: 11.5px;
+  background: var(--bg);
+  padding: 1px 7px;
+  border-radius: 10px;
+  color: var(--text-mute);
+  border: 1px solid var(--border-2);
+}
+.prod-col-cap{
+  font-size: 11px; color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.prod-col-dot{
+  width: 8px; height: 8px; border-radius: 50%;
+}
+.prod-col-dot.violet{ background: oklch(0.55 0.18 295); }
+.prod-col-dot.amber{ background: oklch(0.70 0.14 65); }
+.prod-col-dot.cyan{ background: oklch(0.60 0.13 200); }
+.prod-col-violet{ border-top: 2px solid oklch(0.65 0.14 295); }
+.prod-col-amber{ border-top: 2px solid oklch(0.75 0.12 65); }
+.prod-col-cyan{ border-top: 2px solid oklch(0.70 0.10 200); }
+
+.prod-col-ops{
+  display: flex; gap: 4px;
+}
+.prod-col-op-tag{
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--bg);
+  border: 1px solid var(--border-2);
+  color: var(--text-mute);
+}
+
+.prod-col-body{
+  display: flex; flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+}
+
+.prod-empty{
+  font-size: 12px;
+  color: var(--text-mute);
+  text-align: center;
+  padding: 24px 8px;
+  border: 1px dashed var(--border-2);
+  border-radius: 6px;
+}
+
+/* Cards */
+.prod-card{
+  background: var(--bg);
+  border: 1px solid var(--border-2);
+  border-radius: 8px;
+  padding: 10px 11px;
+  display: flex; flex-direction: column; gap: 6px;
+  cursor: default;
+  transition: border-color .12s, box-shadow .12s;
+}
+.prod-card:hover{
+  border-color: var(--text-mute);
+  box-shadow: 0 1px 3px rgba(0,0,0,.04);
+}
+.prod-card.urgent{
+  border-color: oklch(0.75 0.16 25);
+  box-shadow: 0 0 0 2px oklch(0.95 0.06 25);
+}
+.prod-card-top{
+  display: flex; align-items: center; gap: 6px;
+  font-size: 11px;
+}
+.prod-seq{
+  font-weight: 600;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.prod-os{
+  font-family: var(--mono, "IBM Plex Mono", monospace);
+  font-size: 11px;
+  color: var(--text);
+  font-weight: 500;
+}
+.prod-urgent{
+  margin-left: auto;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+  color: oklch(0.50 0.18 25);
+  background: oklch(0.95 0.06 25);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+.prod-card-title{
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.3;
+  text-wrap: pretty;
+}
+.prod-card-client{
+  font-size: 11.5px;
+  color: var(--text-mute);
+}
+.prod-equip-row{
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 6px;
+}
+.prod-equip-pill{
+  font-size: 11px;
+  padding: 2px 7px;
+  border-radius: 10px;
+  font-weight: 500;
+}
+.prod-equip-pill.violet{ background: oklch(0.94 0.05 295); color: oklch(0.40 0.14 295); }
+.prod-equip-pill.blue{ background: oklch(0.94 0.05 230); color: oklch(0.40 0.13 230); }
+.prod-equip-pill.cyan{ background: oklch(0.94 0.04 200); color: oklch(0.40 0.10 200); }
+.prod-eta{
+  font-size: 11px;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.prod-progress{
+  position: relative;
+  height: 6px;
+  background: var(--bg-2);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.prod-progress-bar{
+  height: 100%;
+  background: var(--accent);
+  border-radius: 3px;
+  transition: width .3s ease;
+}
+.prod-progress-label{
+  position: absolute;
+  right: 0; top: -16px;
+  font-size: 10px;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.prod-card-foot{
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 6px;
+  padding-top: 4px;
+}
+.prod-deadline{
+  font-size: 11px;
+  color: var(--text-mute);
+}
+.prod-card.urgent .prod-deadline{ color: oklch(0.50 0.18 25); font-weight: 500; }
+
+.prod-actions{
+  display: flex; gap: 4px;
+}
+.prod-act{
+  appearance: none;
+  background: var(--bg-2);
+  border: 1px solid var(--border-2);
+  border-radius: 4px;
+  padding: 3px 7px;
+  font: inherit; font-size: 11px;
+  color: var(--text-mute);
+  cursor: default;
+  display: inline-flex; align-items: center; gap: 3px;
+}
+.prod-act:hover{ color: var(--text); border-color: var(--text-mute); }
+.prod-act.primary{
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+.prod-act.primary:hover{ background: var(--accent-2); }
+
+.prod-op-pill{
+  font-size: 10.5px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: oklch(0.94 0.06 65);
+  color: oklch(0.42 0.12 65);
+  font-weight: 500;
+}
+.prod-route-pill{
+  font-size: 10.5px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: oklch(0.94 0.04 200);
+  color: oklch(0.40 0.10 200);
+  font-weight: 500;
+  display: inline-flex; align-items: center; gap: 3px;
+}
+
+.prod-pieces-row{
+  display: flex; align-items: center; justify-content: space-between;
+  font-size: 11.5px;
+}
+.prod-pieces{ color: var(--text); font-weight: 500; }
+.prod-pct{ color: var(--text-mute); font-variant-numeric: tabular-nums; }
+
+.prod-exp-meta{
+  display: grid; grid-template-columns: auto 1fr;
+  gap: 2px 8px;
+  margin: 2px 0 0;
+  font-size: 11px;
+}
+.prod-exp-meta dt{ color: var(--text-mute); }
+.prod-exp-meta dd{ margin: 0; color: var(--text); }
+
+/* Lista plana */
+.prod-list{
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 14px 24px 24px;
+}
+.prod-list .os-table tbody tr{ cursor: default; }
+.prod-list .os-table tbody tr:hover td{ background: var(--bg-2); }
+.row-urgent td:first-child{
+  border-left: 2px solid oklch(0.65 0.18 25);
+}
+.stage-pill{
+  font-size: 11px;
+  padding: 2px 7px;
+  border-radius: 10px;
+  font-weight: 500;
+}
+.stage-producao{ background: oklch(0.94 0.05 295); color: oklch(0.40 0.14 295); }
+.stage-acabamento{ background: oklch(0.94 0.06 65); color: oklch(0.42 0.12 65); }
+.stage-expedicao{ background: oklch(0.94 0.04 200); color: oklch(0.40 0.10 200); }
+.t-truncate{ max-width: 320px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.t-urgent{ color: oklch(0.50 0.18 25); font-weight: 500; }
+
+/* Drawer */
+.prod-drawer-backdrop{
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,.18);
+  z-index: 70;
+  display: flex; justify-content: flex-end;
+}
+.prod-drawer{
+  width: 480px; max-width: 92vw;
+  background: var(--bg);
+  border-left: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  box-shadow: -8px 0 24px rgba(0,0,0,.08);
+}
+.prod-drawer-head{
+  display: flex; align-items: flex-start; justify-content: space-between;
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--border-2);
+  gap: 12px;
+}
+.prod-drawer-eyebrow{
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-mute);
+}
+.prod-drawer-head h2{
+  margin: 4px 0 2px;
+  font-size: 17px;
+  font-weight: 600;
+}
+.prod-drawer-head p{
+  margin: 0;
+  font-size: 12.5px;
+  color: var(--text-mute);
+}
+.prod-drawer-body{
+  padding: 16px 20px;
+  flex: 1 1 auto;
+  overflow: auto;
+}
+.prod-drawer-meta{
+  display: grid; grid-template-columns: auto 1fr;
+  gap: 6px 14px;
+  margin: 0 0 18px;
+  font-size: 12.5px;
+}
+.prod-drawer-meta dt{ color: var(--text-mute); }
+.prod-drawer-meta dd{ margin: 0; color: var(--text); }
+.prod-drawer-actions{
+  display: flex; gap: 8px; flex-wrap: wrap;
+}
+
+
+/* ════════════════════════ CLIENTES PAGE ════════════════════════ */
+.cli-page .os-table th,
+.cli-page .os-table td { padding: 10px 12px; }
+
+.cli-name { display: flex; align-items: center; gap: 10px; }
+.cli-avatar {
+  width: 32px; height: 32px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 600; color: #fff; flex-shrink: 0;
+  letter-spacing: 0.02em;
+}
+.cli-avatar.lg { width: 48px; height: 48px; font-size: 16px; }
+.cli-avatar.grad-1 { background: linear-gradient(135deg, #5b6cff 0%, #8b5cf6 100%); }
+.cli-avatar.grad-2 { background: linear-gradient(135deg, #06b6d4 0%, #0ea5e9 100%); }
+.cli-avatar.grad-3 { background: linear-gradient(135deg, #f59e0b 0%, #ef4444 100%); }
+.cli-avatar.grad-4 { background: linear-gradient(135deg, #10b981 0%, #059669 100%); }
+.cli-avatar.grad-5 { background: linear-gradient(135deg, #ec4899 0%, #be185d 100%); }
+
+.cli-name-text { font-weight: 600; color: var(--ink-1); font-size: 13px; }
+.cli-doc { font-size: 11px; color: var(--ink-3); font-family: var(--font-mono); margin-top: 1px; }
+.cli-contact-line { font-weight: 500; color: var(--ink-2); font-size: 13px; }
+.cli-phone { font-size: 11px; color: var(--ink-3); font-family: var(--font-mono); margin-top: 1px; }
+
+.cli-table .num { text-align: right; font-variant-numeric: tabular-nums; }
+.cli-table .value { font-weight: 600; color: var(--ink-1); }
+
+.cli-status {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 8px; border-radius: 999px;
+  font-size: 11px; font-weight: 500;
+}
+.cli-status.late   { background: #fef2f2; color: #b91c1c; }
+.cli-status.active { background: #ecfdf5; color: #047857; }
+.cli-status.idle   { background: var(--bg-2); color: var(--ink-3); }
+
+/* Drawer */
+.cli-drawer { width: min(620px, 100%); }
+.cli-head { display: flex; align-items: center; gap: 14px; }
+.cli-head-name { font-size: 17px; font-weight: 600; color: var(--ink-1); }
+.cli-head-doc { font-size: 12px; color: var(--ink-3); font-family: var(--font-mono); margin-top: 2px; }
+
+.cli-kpis {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  gap: 8px; padding: 16px 20px;
+  border-bottom: 1px solid var(--line);
+}
+.cli-kpi {
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+.cli-kpi.danger { border-color: #fecaca; background: #fef2f2; }
+.cli-kpi-v { font-size: 18px; font-weight: 600; color: var(--ink-1); font-variant-numeric: tabular-nums; }
+.cli-kpi.danger .cli-kpi-v { color: #b91c1c; }
+.cli-kpi-l { font-size: 10px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.05em; margin-top: 2px; }
+
+.cli-section { padding: 18px 20px; border-bottom: 1px solid var(--line); }
+.cli-section:last-of-type { border-bottom: 0; }
+.cli-section-title {
+  font-size: 11px; font-weight: 600; text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--ink-3);
+  margin-bottom: 10px;
+}
+
+.cli-info-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 20px; }
+.cli-info-l { font-size: 11px; color: var(--ink-3); margin-bottom: 2px; }
+.cli-info-v { font-size: 13px; color: var(--ink-1); font-weight: 500; }
+
+.cli-history { display: flex; flex-direction: column; gap: 6px; }
+.cli-os {
+  display: grid;
+  grid-template-columns: 60px 1fr 110px 90px 90px;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 10px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font-size: 12px;
+}
+.cli-os-id { font-family: var(--font-mono); font-weight: 600; color: var(--ink-2); }
+.cli-os-prod { color: var(--ink-1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.cli-os-stage {
+  padding: 2px 8px; border-radius: 4px;
+  font-size: 10px; font-weight: 500; text-align: center;
+  background: var(--bg-2); color: var(--ink-2);
+}
+.cli-os-stage.stage-aprovacao { background: #fef3c7; color: #92400e; }
+.cli-os-stage.stage-producao,
+.cli-os-stage.stage-acabamento { background: #ede9fe; color: #5b21b6; }
+.cli-os-stage.stage-expedicao { background: #cffafe; color: #155e75; }
+.cli-os-stage.stage-entregue  { background: #d1fae5; color: #065f46; }
+.cli-os-stage.stage-orcado    { background: #dbeafe; color: #1e40af; }
+.cli-os-stage.stage-cancelado { background: #fee2e2; color: #991b1b; }
+.cli-os-deadline { color: var(--ink-3); font-size: 11px; }
+.cli-os-value { text-align: right; font-weight: 600; color: var(--ink-1); font-variant-numeric: tabular-nums; }
+
+.cli-fin { display: flex; flex-direction: column; gap: 4px; }
+.cli-fin-row {
+  display: flex; justify-content: space-between;
+  padding: 8px 10px;
+  font-size: 13px;
+  background: var(--bg-1);
+  border-radius: 6px;
+}
+.cli-fin-row b { font-variant-numeric: tabular-nums; }
+.cli-fin-row b.danger { color: #b91c1c; }
+
+.cli-empty {
+  text-align: center; padding: 24px;
+  color: var(--ink-3); font-size: 13px;
+  background: var(--bg-1); border-radius: 6px;
+}
+
+/* ════════════ VENDAS ════════════ */
+.vendas-page .vd-id{ font-family:var(--font-mono); font-size:12px; color:oklch(0.40 0.04 250); font-weight:600; }
+.vendas-page .vd-date{ font-size:11px; }
+.vendas-page .vd-time{ font-size:10px; color:oklch(0.55 0.02 250); }
+.vendas-page .vd-client-name{ font-weight:600; font-size:13px; }
+.vendas-page .vd-notes{ font-size:11px; color:oklch(0.50 0.02 250); }
+.vendas-page .vd-pay > div:first-child{ font-weight:500; font-size:12px; }
+
+.vendas-page .vd-transp{ font-size:11.5px; }
+.vendas-page .vd-transp-pill{
+  display:inline-flex; align-items:center; gap:4px;
+  font-size:11px; font-weight:500;
+  padding:2px 8px; border-radius:99px;
+  background:oklch(0.93 0.02 240);
+  color:oklch(0.38 0.07 240);
+  white-space:nowrap;
+}
+.vendas-page .vd-transp-pill.retira{
+  background:oklch(0.94 0.04 145);
+  color:oklch(0.38 0.10 145);
+}
+.vendas-page .vd-transp-pill.proprio{
+  background:oklch(0.94 0.04 60);
+  color:oklch(0.38 0.10 60);
+}
+.vendas-page .vd-inst{ font-size:10px; color:oklch(0.50 0.02 250); }
+.vendas-page .vd-items{ text-align:center; font-variant-numeric:tabular-nums; }
+.vendas-page .vd-total{ font-weight:600; font-variant-numeric:tabular-nums; font-size:13px; }
+.vendas-page .vd-os-pill{ display:inline-block; padding:1px 6px; border-radius:4px; background:oklch(0.95 0.01 250); font-family:var(--font-mono); font-size:10px; margin-right:3px; color:oklch(0.40 0.04 250); }
+.vendas-page .vd-no-os{ font-size:11px; color:oklch(0.55 0.02 250); font-style:italic; }
+.kbd-hint{ display:inline-block; padding:1px 5px; margin-left:4px; border:1px solid oklch(0.85 0.02 250); border-radius:3px; font-family:var(--font-mono); font-size:9px; color:oklch(0.40 0.04 250); background:#fff; }
+
+/* Drawer venda */
+.vd-section{ padding:14px 20px; border-bottom:1px solid oklch(0.95 0.01 250); }
+.vd-section:last-child{ border-bottom:none; }
+.vd-section h3{ font-size:12px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.45 0.02 250); margin:0 0 12px; font-weight:600; }
+.vd-meta{ display:grid; grid-template-columns:140px 1fr; gap:6px 16px; margin:0; font-size:13px; }
+.vd-meta dt{ color:oklch(0.50 0.02 250); }
+.vd-meta dd{ margin:0; }
+.vd-total-strong{ font-weight:600; font-size:15px; }
+.vd-os-list{ display:flex; flex-direction:column; gap:6px; }
+.vd-os-link{ display:flex; align-items:center; justify-content:space-between; padding:8px 12px; background:oklch(0.97 0.01 250); border-radius:6px; font-size:12px; cursor:pointer; }
+.vd-os-link:hover{ background:oklch(0.94 0.01 250); }
+.vd-docs{ display:flex; gap:8px; flex-wrap:wrap; }
+
+/* Stepper */
+.vd-stepper{ display:flex; align-items:center; gap:6px; padding:10px 20px; background:oklch(0.98 0.01 250); border-bottom:1px solid oklch(0.92 0.01 250); overflow-x:auto; }
+.vd-step{ display:flex; align-items:center; gap:6px; padding:6px 10px; background:transparent; border:none; cursor:pointer; font-size:12px; color:oklch(0.50 0.02 250); border-radius:4px; }
+.vd-step.active{ color:oklch(0.30 0.10 240); font-weight:600; background:#fff; box-shadow:0 1px 2px rgba(0,0,0,0.04); }
+.vd-step.done{ color:oklch(0.45 0.12 145); }
+.vd-step-num{ display:inline-flex; align-items:center; justify-content:center; width:20px; height:20px; border-radius:50%; background:oklch(0.92 0.01 250); font-size:11px; font-weight:600; }
+.vd-step.active .vd-step-num{ background:oklch(0.55 0.14 240); color:#fff; }
+.vd-step.done .vd-step-num{ background:oklch(0.55 0.14 145); color:#fff; }
+.vd-step-sep{ color:oklch(0.75 0.01 250); margin:0 2px; }
+
+/* Create body */
+.vd-create-body{ padding:0; }
+.vd-search-wrap{ display:flex; align-items:center; gap:8px; padding:8px 12px; background:#fff; border:1px solid oklch(0.88 0.01 250); border-radius:6px; }
+.vd-search-wrap input{ flex:1; border:none; outline:none; font-size:13px; }
+.vd-search-wrap input:focus{ outline:none; }
+.vd-walkin{ background:oklch(0.92 0.04 240); color:oklch(0.30 0.10 240); border:none; padding:4px 10px; border-radius:4px; font-size:11px; cursor:pointer; }
+.vd-walkin:hover{ background:oklch(0.88 0.05 240); }
+
+.vd-client-list{ display:grid; grid-template-columns:1fr 1fr; gap:6px; margin-top:10px; }
+.vd-client-card{ text-align:left; padding:10px 12px; border:1px solid oklch(0.92 0.01 250); border-radius:6px; background:#fff; cursor:pointer; }
+.vd-client-card:hover{ border-color:oklch(0.55 0.14 240); background:oklch(0.98 0.02 240); }
+.vd-client-card-name{ font-weight:600; font-size:13px; }
+.vd-client-card-meta{ font-size:11px; color:oklch(0.50 0.02 250); margin-top:2px; }
+.vd-client-selected{ display:flex; flex-direction:column; gap:12px; padding:12px; background:oklch(0.97 0.01 250); border-radius:6px; }
+.vd-fields{ display:grid; grid-template-columns:1fr 1fr; gap:10px; }
+.vd-fields label{ display:flex; flex-direction:column; gap:4px; font-size:11px; color:oklch(0.45 0.02 250); }
+.vd-fields input, .vd-fields select{ padding:6px 8px; border:1px solid oklch(0.88 0.01 250); border-radius:4px; font-size:13px; }
+
+/* Itens */
+.vd-prod-suggest{ margin-top:6px; background:#fff; border:1px solid oklch(0.92 0.01 250); border-radius:6px; max-height:240px; overflow:auto; }
+.vd-prod-row{ display:flex; justify-content:space-between; align-items:center; width:100%; padding:8px 12px; border:none; background:transparent; cursor:pointer; font-size:13px; text-align:left; border-bottom:1px solid oklch(0.96 0.01 250); }
+.vd-prod-row:hover{ background:oklch(0.97 0.01 250); }
+.vd-prod-row:last-child{ border-bottom:none; }
+.vd-prod-price{ color:oklch(0.45 0.12 145); font-weight:600; font-variant-numeric:tabular-nums; }
+.vd-empty-mini{ padding:10px 12px; font-size:12px; color:oklch(0.55 0.02 250); }
+.vd-empty-state{ padding:30px; text-align:center; color:oklch(0.55 0.02 250); font-size:13px; background:oklch(0.98 0.01 250); border-radius:6px; margin-top:10px; }
+
+.vd-items-table{ width:100%; margin-top:14px; border-collapse:collapse; font-size:12px; }
+.vd-items-table th{ text-align:left; font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); padding:6px 8px; border-bottom:1px solid oklch(0.92 0.01 250); }
+.vd-items-table td{ padding:6px 8px; border-bottom:1px solid oklch(0.96 0.01 250); }
+.vd-items-table input{ width:100%; padding:4px 6px; border:1px solid oklch(0.90 0.01 250); border-radius:3px; font-size:12px; }
+.vd-strong{ font-weight:600; font-variant-numeric:tabular-nums; }
+.vd-toggle{ display:flex; align-items:center; gap:6px; font-size:11px; }
+.vd-foot-l{ text-align:right; padding-top:10px !important; font-size:11px; color:oklch(0.45 0.02 250); }
+.vd-foot-r{ text-align:right; padding-top:10px !important; font-weight:700; font-size:14px; }
+
+/* Pagamento */
+.vd-pay-grid{ display:grid; grid-template-columns:repeat(3, 1fr); gap:8px; }
+.vd-pay-card{ display:flex; flex-direction:column; gap:2px; align-items:flex-start; padding:12px; border:1px solid oklch(0.92 0.01 250); border-radius:6px; background:#fff; cursor:pointer; text-align:left; }
+.vd-pay-card.active{ border-color:oklch(0.55 0.14 240); background:oklch(0.97 0.03 240); box-shadow:0 0 0 2px oklch(0.55 0.14 240 / 0.15); }
+.vd-pay-icon{ font-size:18px; }
+.vd-pay-label{ font-weight:600; font-size:13px; }
+.vd-pay-clear{ font-size:10px; color:oklch(0.50 0.02 250); }
+.vd-totals{ display:grid; grid-template-columns:1fr auto; gap:6px 16px; margin:14px 0 0; font-size:13px; }
+.vd-totals dt{ color:oklch(0.50 0.02 250); }
+.vd-totals dd{ margin:0; text-align:right; font-variant-numeric:tabular-nums; }
+.vd-total-row{ font-weight:700; font-size:16px; padding-top:6px; border-top:1px solid oklch(0.92 0.01 250); }
+
+/* Confirmar */
+.vd-confirm-grid{ display:grid; grid-template-columns:1fr 1fr; gap:10px; }
+.vd-confirm-block{ display:flex; flex-direction:column; gap:2px; padding:12px; background:oklch(0.97 0.01 250); border-radius:6px; }
+.vd-confirm-label{ font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); }
+.vd-confirm-block strong{ font-size:14px; }
+.vd-confirm-total{ background:oklch(0.55 0.14 145 / 0.08); }
+.vd-total-big{ font-size:22px; color:oklch(0.40 0.14 145); font-variant-numeric:tabular-nums; }
+.vd-callout{ margin-top:14px; padding:12px; background:oklch(0.95 0.05 240); border-left:3px solid oklch(0.55 0.14 240); border-radius:4px; font-size:12px; color:oklch(0.30 0.08 240); }
+.vd-callout-ok{ background:oklch(0.95 0.05 145); border-left-color:oklch(0.55 0.14 145); color:oklch(0.30 0.10 145); }
+
+/* Foot */
+.vd-foot{ display:flex; justify-content:space-between; align-items:center; }
+.vd-foot-summary{ display:flex; align-items:baseline; gap:10px; font-size:12px; color:oklch(0.50 0.02 250); }
+.vd-foot-total{ font-size:16px; font-weight:700; color:oklch(0.20 0.02 250); font-variant-numeric:tabular-nums; }
+.vd-foot-actions{ display:flex; gap:8px; }
+
+
+
+/* ════════════ VENDAS MODULE — sub-nav + extras ════════════ */
+.vendas-module{ display:flex; flex-direction:column; height:100%; }
+.vm-subnav{
+  display:flex; align-items:center; justify-content:space-between;
+  padding:0 20px; border-bottom:1px solid oklch(0.93 0.01 250);
+  background:#fff; flex-shrink:0;
+}
+.vm-subnav-tabs{ display:flex; gap:0; }
+.vm-subtab{
+  display:inline-flex; align-items:center; gap:6px;
+  padding:10px 14px; border:none; background:transparent; cursor:pointer;
+  font-size:12px; color:oklch(0.50 0.02 250); font-weight:500;
+  border-bottom:2px solid transparent; transition:all .12s;
+}
+.vm-subtab:hover{ color:oklch(0.30 0.02 250); }
+.vm-subtab.active{ color:var(--accent); border-bottom-color:var(--accent); }
+.vm-pdv-btn{
+  display:inline-flex; align-items:center; gap:8px;
+  padding:6px 12px; border:1px solid oklch(0.85 0.02 250);
+  border-radius:6px; background:#fff; cursor:pointer;
+  font-size:12px; color:oklch(0.30 0.02 250); font-weight:500;
+}
+.vm-pdv-btn:hover{ background:oklch(0.97 0.01 250); }
+.vm-pdv-btn kbd{
+  display:inline-block; padding:1px 5px; border:1px solid oklch(0.85 0.02 250);
+  border-radius:3px; font-family:var(--font-mono); font-size:9px;
+  color:oklch(0.40 0.04 250); background:oklch(0.97 0.01 250);
+}
+.vm-body{ flex:1; overflow:auto; }
+
+/* ──── CAIXA DO DIA ──── */
+.vc-page .vc-date{
+  padding:5px 8px; border:1px solid oklch(0.85 0.02 250); border-radius:6px;
+  font-size:12px; font-family:var(--font-mono);
+}
+.vc-grid{
+  display:grid; grid-template-columns:1.3fr 1fr; gap:14px;
+  padding:0 20px 20px;
+}
+.vc-grid > .vc-card:nth-child(3){ grid-column: 1 / -1; }
+.vc-card{
+  background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px;
+  overflow:hidden;
+}
+.vc-card-h{
+  display:flex; align-items:baseline; justify-content:space-between;
+  padding:12px 16px; border-bottom:1px solid oklch(0.95 0.01 250);
+}
+.vc-card-h h3{
+  margin:0; font-size:12px; text-transform:uppercase; letter-spacing:0.04em;
+  color:oklch(0.30 0.02 250); font-weight:600;
+}
+.vc-muted{ font-size:11px; color:oklch(0.55 0.02 250); }
+.vc-pay-table{ width:100%; border-collapse:collapse; font-size:13px; }
+.vc-pay-table th, .vc-pay-table td{
+  padding:9px 16px; text-align:left; border-bottom:1px solid oklch(0.96 0.01 250);
+}
+.vc-pay-table th{
+  font-weight:500; font-size:11px; color:oklch(0.50 0.02 250);
+  background:oklch(0.98 0.005 250);
+}
+.vc-pay-icon{ display:inline-block; margin-right:6px; }
+.vc-num{ font-variant-numeric:tabular-nums; text-align:right; }
+.vc-num.strong{ font-weight:600; }
+.vc-pay-table tfoot td{
+  font-weight:600; background:oklch(0.98 0.005 250);
+  border-top:2px solid oklch(0.90 0.01 250); border-bottom:none;
+}
+
+.vc-moves{ list-style:none; margin:0; padding:0; max-height:280px; overflow:auto; }
+.vc-move{
+  display:grid; grid-template-columns:50px 90px 1fr 110px;
+  align-items:center; gap:10px; padding:8px 16px;
+  border-bottom:1px solid oklch(0.96 0.01 250); font-size:12px;
+}
+.vc-move-time{ color:oklch(0.50 0.02 250); font-family:var(--font-mono); font-size:11px; }
+.vc-move-type{
+  text-transform:uppercase; font-size:10px; font-weight:600; letter-spacing:0.04em;
+}
+.vc-move-abertura .vc-move-type{ color:oklch(0.45 0.10 240); }
+.vc-move-suprimento .vc-move-type{ color:oklch(0.45 0.14 145); }
+.vc-move-sangria .vc-move-type{ color:oklch(0.50 0.16 25); }
+.vc-move-amount{ text-align:right; font-variant-numeric:tabular-nums; font-weight:600; }
+.vc-move-amount.pos{ color:oklch(0.45 0.14 145); }
+.vc-move-amount.neg{ color:oklch(0.50 0.16 25); }
+.vc-move-add{
+  display:grid; grid-template-columns:130px 110px 1fr auto;
+  gap:6px; padding:12px 16px; background:oklch(0.98 0.005 250);
+  border-top:1px solid oklch(0.93 0.01 250);
+}
+.vc-move-add input, .vc-move-add select{
+  padding:6px 10px; border:1px solid oklch(0.88 0.01 250);
+  border-radius:5px; font-size:12px; background:#fff;
+}
+
+.vc-counter{
+  display:grid; grid-template-columns:1fr 1.2fr 1fr; gap:24px;
+  padding:20px 16px; align-items:start;
+}
+.vc-counter label{ display:flex; flex-direction:column; gap:6px; font-size:11px; color:oklch(0.50 0.02 250); text-transform:uppercase; letter-spacing:0.04em; }
+.vc-counter input{
+  padding:8px 12px; border:1px solid oklch(0.88 0.01 250); border-radius:6px;
+  font-size:14px; font-variant-numeric:tabular-nums; background:#fff;
+}
+.vc-counter-big{ font-size:22px !important; font-weight:600; padding:12px !important; }
+.vc-counter-summary{ margin:0; display:grid; grid-template-columns:1fr auto; gap:6px 12px; font-size:12px; }
+.vc-counter-summary dt{ color:oklch(0.50 0.02 250); }
+.vc-counter-summary dd{ margin:0; font-variant-numeric:tabular-nums; text-align:right; }
+.vc-counter-summary .strong{ font-weight:600; font-size:14px; padding-top:6px; border-top:1px solid oklch(0.90 0.01 250); }
+
+/* ──── DEVOLUÇÕES ──── */
+.vd-dev-page .vdv-reason{ font-size:13px; margin:0; }
+.vdv-timeline{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:8px; font-size:12px; }
+.vdv-timeline li{ display:flex; align-items:center; gap:10px; }
+.vdv-tl-dot{ width:10px; height:10px; border-radius:50%; background:oklch(0.88 0.01 250); border:2px solid oklch(0.95 0.01 250); flex-shrink:0; }
+.vdv-tl-dot.ok{ background:oklch(0.55 0.14 145); }
+.vdv-tl-dot.active{ background:oklch(0.60 0.14 70); box-shadow:0 0 0 3px oklch(0.60 0.14 70 / 0.2); }
+
+.vdv-input{ width:100%; padding:8px 12px; border:1px solid oklch(0.85 0.02 250); border-radius:6px; font-size:13px; }
+.vdv-matches{ margin-top:8px; display:flex; flex-direction:column; gap:4px; }
+.vdv-match{ display:grid; grid-template-columns:80px 1fr 100px; gap:10px; padding:8px 12px; background:oklch(0.97 0.01 250); border:none; border-radius:6px; cursor:pointer; text-align:left; font-size:12px; align-items:center; }
+.vdv-match:hover{ background:oklch(0.93 0.02 250); }
+.vdv-selected{ display:flex; align-items:center; gap:14px; padding:12px; background:oklch(0.96 0.02 145); border-radius:6px; }
+.vdv-reasons{ display:flex; flex-wrap:wrap; gap:6px; margin-bottom:10px; }
+.vdv-reason-btn{ padding:6px 12px; border:1px solid oklch(0.85 0.02 250); border-radius:20px; background:#fff; cursor:pointer; font-size:12px; }
+.vdv-reason-btn.active{ background:var(--accent); border-color:var(--accent); color:#fff; }
+.vdv-textarea{ width:100%; min-height:60px; padding:8px 12px; border:1px solid oklch(0.85 0.02 250); border-radius:6px; font-family:inherit; font-size:12px; resize:vertical; }
+
+/* ──── COMISSÕES ──── */
+.vco-period{ display:inline-flex; border:1px solid oklch(0.85 0.02 250); border-radius:6px; overflow:hidden; }
+.vco-period button{ padding:6px 12px; border:none; background:#fff; cursor:pointer; font-size:12px; color:oklch(0.40 0.02 250); }
+.vco-period button.active{ background:var(--accent); color:#fff; }
+.vco-grid{ display:grid; grid-template-columns:repeat(auto-fill, minmax(340px, 1fr)); gap:14px; padding:0 20px 14px; }
+.vco-card{ background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px; padding:16px; position:relative; }
+.vco-card header{ display:grid; grid-template-columns:auto 1fr auto; gap:12px; align-items:center; margin-bottom:14px; }
+.vco-card header h3{ margin:0 0 2px; font-size:14px; }
+.vco-card header span{ font-size:11px; color:oklch(0.55 0.02 250); }
+.vco-avatar{
+  width:40px; height:40px; border-radius:50%;
+  background:oklch(0.94 0.04 var(--accent-h, 220));
+  color:var(--accent); display:flex; align-items:center; justify-content:center;
+  font-weight:600; font-size:14px;
+}
+.vco-rank{
+  font-family:var(--font-mono); font-size:14px; color:oklch(0.55 0.02 250);
+  font-weight:600;
+}
+.vco-bar{ height:8px; background:oklch(0.95 0.01 250); border-radius:4px; overflow:hidden; margin-bottom:12px; }
+.vco-bar-fill{ height:100%; background:linear-gradient(90deg, var(--accent), var(--accent-2)); }
+.vco-numbers{ display:grid; grid-template-columns:1fr 1fr; gap:10px; margin-bottom:12px; }
+.vco-numbers > div{ display:flex; flex-direction:column; gap:2px; }
+.vco-numbers span{ font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); }
+.vco-numbers strong{ font-size:18px; font-variant-numeric:tabular-nums; }
+.vco-com strong{ color:oklch(0.45 0.14 145); }
+.vco-mix{ display:flex; flex-wrap:wrap; gap:4px; }
+.vco-chip{ padding:2px 8px; background:oklch(0.96 0.01 250); border-radius:10px; font-size:10px; color:oklch(0.40 0.02 250); }
+.vco-chip em{ font-style:normal; font-weight:600; color:var(--accent); margin-left:2px; }
+.vco-table-card{ margin:0 20px 20px; padding:16px; background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px; }
+.vco-table-card h3{ margin:0 0 12px; font-size:12px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.30 0.02 250); }
+.vco-rules{ width:100%; border-collapse:collapse; font-size:13px; }
+.vco-rules th, .vco-rules td{ padding:8px 12px; text-align:left; border-bottom:1px solid oklch(0.96 0.01 250); }
+.vco-rules th{ font-size:11px; color:oklch(0.50 0.02 250); font-weight:500; }
+
+/* ──── RELATÓRIOS ──── */
+.vrep-tabs{ display:flex; gap:6px; padding:0 20px 12px; }
+.vrep-tabs button{ padding:6px 14px; border:1px solid oklch(0.88 0.01 250); border-radius:20px; background:#fff; cursor:pointer; font-size:12px; }
+.vrep-tabs button.active{ background:var(--accent); border-color:var(--accent); color:#fff; }
+.vrep-summary{
+  display:grid; grid-template-columns:repeat(4, 1fr); gap:10px;
+  padding:0 20px 14px;
+}
+.vrep-summary > div{
+  background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px;
+  padding:12px 14px; display:flex; flex-direction:column; gap:4px;
+}
+.vrep-summary span{ font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); }
+.vrep-summary strong{ font-size:18px; font-variant-numeric:tabular-nums; }
+
+.vrep-card{ margin:0 20px 14px; padding:16px; background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px; }
+.vrep-card h3{ margin:0 0 14px; font-size:12px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.30 0.02 250); }
+
+.vrep-bars{
+  display:flex; align-items:flex-end; gap:14px;
+  height:240px; padding-top:30px;
+}
+.vrep-bar-col{
+  flex:1; display:flex; flex-direction:column; align-items:center;
+  height:100%; min-width:40px; position:relative;
+}
+.vrep-bar{
+  width:100%; max-width:54px; min-height:2px;
+  background:linear-gradient(180deg, var(--accent), var(--accent-2));
+  border-radius:4px 4px 0 0; margin-top:auto;
+}
+.vrep-bar-val{
+  font-size:10px; font-variant-numeric:tabular-nums;
+  color:oklch(0.40 0.02 250); font-weight:600; margin-bottom:6px;
+}
+.vrep-bar-lbl{ font-size:11px; color:oklch(0.55 0.02 250); margin-top:6px; }
+
+.vrep-clients{ list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:6px; }
+.vrep-clients li{
+  display:grid; grid-template-columns:30px 1fr 80px 1fr 110px;
+  gap:12px; align-items:center; padding:8px 4px; font-size:12px;
+}
+.vrep-rank{ font-family:var(--font-mono); color:oklch(0.55 0.02 250); font-weight:600; }
+.vrep-cli-name{ font-weight:500; }
+.vrep-cli-n{ font-size:11px; color:oklch(0.55 0.02 250); }
+.vrep-cli-bar{ height:6px; background:oklch(0.95 0.01 250); border-radius:3px; overflow:hidden; }
+.vrep-cli-bar > div{ height:100%; background:var(--accent); }
+.vrep-cli-total{ text-align:right; font-variant-numeric:tabular-nums; font-weight:600; }
+
+.vrep-origin{ display:flex; gap:30px; align-items:center; padding:14px 0; }
+.vrep-donut{
+  width:160px; height:160px; border-radius:50%;
+  display:flex; flex-direction:column; align-items:center; justify-content:center;
+  position:relative;
+}
+.vrep-donut::after{
+  content:""; position:absolute; inset:25px; background:#fff; border-radius:50%;
+}
+.vrep-donut > *{ position:relative; z-index:1; }
+.vrep-donut span{ font-size:24px; font-weight:600; }
+.vrep-donut small{ font-size:11px; color:oklch(0.55 0.02 250); }
+.vrep-origin-legend{ margin:0; display:grid; grid-template-columns:auto 1fr; gap:8px 16px; font-size:13px; }
+.vrep-origin-legend dt{ display:flex; align-items:center; gap:8px; color:oklch(0.30 0.02 250); }
+.vrep-dot{ width:10px; height:10px; border-radius:50%; }
+
+/* ──── PDV BALCÃO (overlay) ──── */
+.pdv-overlay{
+  position:fixed; inset:0; background:oklch(0.18 0.02 250); z-index:1000;
+  display:flex; flex-direction:column; color:oklch(0.95 0.01 250);
+}
+.pdv-head{
+  display:flex; align-items:center; justify-content:space-between;
+  padding:10px 18px; background:oklch(0.14 0.02 250);
+  border-bottom:1px solid oklch(0.25 0.02 250); flex-shrink:0;
+}
+.pdv-head-l{ display:flex; align-items:center; gap:10px; font-size:13px; }
+.pdv-brand{ font-weight:700; letter-spacing:0.06em; color:var(--accent-2); }
+.pdv-sep{ color:oklch(0.50 0.02 250); }
+.pdv-head-r{ display:flex; align-items:center; gap:14px; }
+.pdv-shortcut{ font-size:11px; color:oklch(0.65 0.02 250); }
+.pdv-shortcut kbd{
+  display:inline-block; padding:2px 6px; margin-right:4px;
+  border:1px solid oklch(0.45 0.02 250); border-radius:3px;
+  font-family:var(--font-mono); font-size:10px;
+  background:oklch(0.22 0.02 250); color:oklch(0.95 0.01 250);
+}
+.pdv-close{
+  width:28px; height:28px; border-radius:50%;
+  background:oklch(0.25 0.02 250); border:none; color:#fff;
+  cursor:pointer; font-size:18px; line-height:1;
+}
+.pdv-grid{ display:grid; grid-template-columns:1fr 380px; flex:1; overflow:hidden; }
+.pdv-left{ display:flex; flex-direction:column; padding:20px; overflow:hidden; }
+.pdv-scan{ position:relative; flex-shrink:0; margin-bottom:16px; }
+.pdv-scan-label{ display:block; font-size:11px; color:oklch(0.65 0.02 250); text-transform:uppercase; letter-spacing:0.06em; margin-bottom:6px; }
+.pdv-scan-input{
+  width:100%; padding:18px 20px; font-size:24px;
+  background:oklch(0.95 0.01 250); border:3px solid var(--accent);
+  border-radius:10px; color:oklch(0.18 0.02 250); font-weight:500;
+  outline:none;
+}
+.pdv-suggest{
+  position:absolute; top:100%; left:0; right:0; z-index:10;
+  margin:4px 0 0; padding:0; list-style:none;
+  background:#fff; border-radius:8px; overflow:hidden;
+  box-shadow:0 8px 24px rgba(0,0,0,0.4);
+}
+.pdv-suggest li{
+  display:flex; justify-content:space-between; align-items:center;
+  padding:12px 16px; cursor:pointer; color:oklch(0.18 0.02 250);
+  border-bottom:1px solid oklch(0.95 0.01 250); font-size:14px;
+}
+.pdv-suggest li:hover{ background:oklch(0.94 0.02 var(--accent-h, 220)); }
+.pdv-items-wrap{ flex:1; overflow:auto; background:oklch(0.95 0.01 250); border-radius:8px; color:oklch(0.18 0.02 250); }
+.pdv-empty{ padding:80px 20px; text-align:center; color:oklch(0.50 0.02 250); }
+.pdv-empty-big{ font-size:18px; margin-bottom:6px; color:oklch(0.30 0.02 250); }
+.pdv-items{ width:100%; border-collapse:collapse; font-size:14px; }
+.pdv-items th{ padding:12px 14px; background:oklch(0.92 0.01 250); text-align:left; font-size:11px; color:oklch(0.40 0.02 250); text-transform:uppercase; letter-spacing:0.04em; }
+.pdv-items td{ padding:12px 14px; border-bottom:1px solid oklch(0.92 0.01 250); }
+.pdv-qty{ display:inline-flex; align-items:center; gap:6px; }
+.pdv-qty button{ width:24px; height:24px; border-radius:4px; border:1px solid oklch(0.85 0.02 250); background:#fff; cursor:pointer; font-weight:600; }
+.pdv-qty span{ min-width:24px; text-align:center; font-weight:600; }
+.pdv-prod{ font-weight:500; }
+.pdv-num{ text-align:right; font-variant-numeric:tabular-nums; }
+.pdv-num.strong{ font-weight:600; }
+.pdv-rm{ width:24px; height:24px; border-radius:4px; background:oklch(0.94 0.04 25); border:none; color:oklch(0.50 0.16 25); cursor:pointer; }
+
+.pdv-right{
+  background:oklch(0.20 0.02 250); padding:24px 20px;
+  display:flex; flex-direction:column; gap:16px;
+  border-left:1px solid oklch(0.25 0.02 250);
+}
+.pdv-r-label{ display:block; font-size:11px; color:oklch(0.65 0.02 250); text-transform:uppercase; letter-spacing:0.06em; margin-bottom:6px; }
+.pdv-client input{
+  width:100%; padding:10px 12px; border-radius:6px;
+  background:oklch(0.25 0.02 250); border:1px solid oklch(0.30 0.02 250);
+  color:#fff; font-size:14px;
+}
+.pdv-pay-grid{ display:grid; grid-template-columns:1fr 1fr; gap:6px; }
+.pdv-pay-btn{
+  padding:14px 8px; border-radius:8px;
+  background:oklch(0.25 0.02 250); border:2px solid oklch(0.30 0.02 250);
+  color:#fff; cursor:pointer; display:flex; flex-direction:column;
+  align-items:center; gap:4px; font-size:12px;
+}
+.pdv-pay-btn.active{ border-color:var(--accent); background:oklch(0.30 0.06 var(--accent-h, 220)); }
+.pdv-pay-icon{ font-size:20px; }
+.pdv-total-block{
+  margin-top:auto; padding:18px; border-radius:10px;
+  background:oklch(0.14 0.02 250); border:2px solid var(--accent);
+  text-align:right;
+}
+.pdv-total-label{ font-size:11px; color:oklch(0.65 0.02 250); letter-spacing:0.08em; }
+.pdv-total-value{ display:block; font-size:42px; font-weight:700; color:var(--accent-2); font-variant-numeric:tabular-nums; line-height:1.1; }
+.pdv-total-meta{ font-size:11px; color:oklch(0.65 0.02 250); }
+.pdv-finalize{
+  padding:18px; border-radius:8px; background:oklch(0.55 0.14 145);
+  color:#fff; border:none; cursor:pointer; font-size:16px; font-weight:600;
+  display:flex; align-items:center; justify-content:center; gap:10px;
+}
+.pdv-finalize:disabled{ opacity:0.4; cursor:not-allowed; }
+.pdv-finalize kbd{
+  padding:2px 6px; border:1px solid oklch(0.95 0.01 145 / 0.5);
+  border-radius:3px; font-family:var(--font-mono); font-size:11px;
+  background:rgba(0,0,0,0.2);
+}
+.pdv-cancel{ padding:10px; border-radius:6px; background:transparent; color:oklch(0.75 0.02 250); border:1px solid oklch(0.30 0.02 250); cursor:pointer; font-size:12px; }
+
+/* ──── RECIBO (térmica + A4) ──── */
+.pdv-recibo-overlay{ background:oklch(0.30 0.02 250); }
+.rec-stage{ flex:1; overflow:auto; display:flex; justify-content:center; padding:30px; }
+.rec-layout{ display:inline-flex; border:1px solid oklch(0.40 0.02 250); border-radius:6px; overflow:hidden; }
+.rec-layout button{ padding:6px 12px; border:none; background:transparent; color:oklch(0.85 0.02 250); cursor:pointer; font-size:12px; }
+.rec-layout button.active{ background:var(--accent); color:#fff; }
+.rec-paper{ background:#fff; color:#222; padding:20px; }
+.rec-termica{
+  width:300px; font-family:var(--font-mono);
+  font-size:12px; line-height:1.4;
+}
+.rec-tx-header{ text-align:center; margin-bottom:8px; }
+.rec-tx-title{ font-weight:700; font-size:13px; }
+.rec-tx-meta{ font-size:11px; }
+.rec-tx-divider{ text-align:center; color:#777; }
+.rec-tx-items{ width:100%; font-size:11px; }
+.rec-tx-prod{ padding-top:4px; font-weight:500; }
+.rec-tx-r{ text-align:right; font-weight:600; }
+.rec-tx-totals{ margin-top:8px; }
+.rec-tx-totals > div{ display:flex; justify-content:space-between; }
+.rec-tx-total{ font-weight:700; font-size:14px; padding-top:4px; border-top:1px dashed #999; margin-top:4px; }
+.rec-tx-pay{ margin-top:8px; }
+.rec-tx-foot{ text-align:center; font-size:10px; margin-top:12px; }
+.rec-tx-barcode{ margin-top:8px; font-size:14px; letter-spacing:1px; }
+
+.rec-a4{ width:794px; min-height:1100px; padding:60px 70px; font-family:var(--font-sans, sans-serif); }
+.rec-a4-h{ display:flex; justify-content:space-between; align-items:flex-start; padding-bottom:20px; border-bottom:2px solid #222; }
+.rec-a4-logo{ font-size:28px; font-weight:700; letter-spacing:0.04em; }
+.rec-a4-tag{ font-size:12px; color:#666; }
+.rec-a4-meta{ text-align:right; font-size:11px; line-height:1.6; color:#555; }
+.rec-a4-title{ display:flex; justify-content:space-between; align-items:baseline; margin:30px 0 24px; }
+.rec-a4-title h1{ margin:0; font-size:22px; }
+.rec-a4-title span{ color:#666; font-size:13px; }
+.rec-a4-block{ margin-bottom:24px; }
+.rec-a4-block h3{ margin:0 0 8px; font-size:11px; text-transform:uppercase; letter-spacing:0.06em; color:#888; }
+.rec-a4-items{ width:100%; border-collapse:collapse; font-size:13px; }
+.rec-a4-items th{ background:#f5f5f5; padding:10px 12px; text-align:left; font-size:11px; text-transform:uppercase; letter-spacing:0.04em; color:#555; }
+.rec-a4-items td{ padding:10px 12px; border-bottom:1px solid #eee; }
+.rec-a4-items th:nth-child(n+2), .rec-a4-items td:nth-child(n+2){ text-align:right; font-variant-numeric:tabular-nums; }
+.rec-a4-totals{ display:flex; justify-content:flex-end; margin-top:20px; }
+.rec-a4-totals dl{ display:grid; grid-template-columns:auto auto; gap:8px 30px; font-size:14px; }
+.rec-a4-totals dt{ color:#666; }
+.rec-a4-totals dd{ margin:0; text-align:right; font-variant-numeric:tabular-nums; }
+.rec-a4-total{ font-size:20px !important; font-weight:700 !important; padding-top:10px; border-top:2px solid #222; color:#222 !important; }
+.rec-a4-foot{ margin-top:50px; padding-top:20px; border-top:1px dashed #ccc; display:flex; justify-content:space-between; font-size:11px; color:#666; }
+
+/* ──── NF-e drawer extras ──── */
+.nfe-cfop{ display:grid; grid-template-columns:repeat(3, 1fr); gap:8px; margin-bottom:14px; }
+.nfe-cfop-btn, .nfe-transp-btn{
+  padding:12px; border:1.5px solid oklch(0.88 0.01 250); border-radius:8px;
+  background:#fff; cursor:pointer; text-align:left; display:flex; flex-direction:column; gap:3px;
+}
+.nfe-cfop-btn.active, .nfe-transp-btn.active{ border-color:var(--accent); background:oklch(0.97 0.04 var(--accent-h, 220)); }
+.nfe-cfop-btn strong{ font-size:13px; }
+.nfe-cfop-btn span, .nfe-transp-btn span{ font-size:11px; color:oklch(0.50 0.02 250); }
+.nfe-tax-grid{ display:grid; grid-template-columns:repeat(2, 1fr); gap:10px; }
+.nfe-tax-grid > div{ padding:10px 12px; background:oklch(0.97 0.01 250); border-radius:6px; display:flex; flex-direction:column; gap:2px; }
+.nfe-tax-grid span{ font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); }
+.nfe-tax-grid strong{ font-size:13px; }
+.nfe-transp{ display:grid; grid-template-columns:repeat(2, 1fr); gap:8px; margin-bottom:14px; }
+.nfe-review-grid{ display:grid; grid-template-columns:repeat(2, 1fr); gap:10px; }
+.nfe-review-card{ padding:12px 14px; background:oklch(0.97 0.01 250); border-radius:6px; display:flex; flex-direction:column; gap:3px; }
+.nfe-review-card.span{ grid-column:1 / -1; }
+.nfe-review-card span{ font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); }
+.nfe-review-card strong{ font-size:14px; }
+.nfe-review-card .mono{ font-family:var(--font-mono); }
+.nfe-review-card .small{ font-size:10px; word-break:break-all; line-height:1.4; }
+.nfe-callout{
+  margin-top:14px; padding:12px 14px; border-radius:6px;
+  background:oklch(0.96 0.06 70); border-left:3px solid oklch(0.65 0.14 70);
+  font-size:12px; color:oklch(0.30 0.06 70);
+}
+
+@media print{
+  body > *{ display:none !important; }
+  .pdv-overlay{ position:static; background:#fff; color:#000; }
+  .pdv-head, .rec-layout, .pdv-close, .os-btn{ display:none !important; }
+  .rec-stage{ padding:0; }
+  .rec-paper{ box-shadow:none; }
+}
+
+
+
+/* ════════════ OS-page chrome (used by vendas-* and others) ════════════ */
+.os-head{
+  display:flex; align-items:flex-start; justify-content:space-between;
+  gap:16px; padding:24px 24px 14px; flex-wrap:wrap;
+}
+.os-head-l h1{ margin:0 0 4px; font-size:22px; letter-spacing:-0.01em; color:var(--text); }
+.os-head-l p{ margin:0; font-size:13px; color:var(--text-dim); }
+.os-head-r{ display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+
+.os-kpis{
+  display:grid; grid-template-columns:repeat(auto-fit, minmax(180px, 1fr));
+  gap:10px; padding:0 24px 14px;
+}
+.os-kpi{
+  background:#fff; border:1px solid var(--border, oklch(0.93 0.01 250));
+  border-radius:8px; padding:12px 14px;
+  display:flex; flex-direction:column; gap:4px;
+}
+.os-kpi-label{ font-size:10px; text-transform:uppercase; letter-spacing:0.05em; color:var(--text-dim, oklch(0.50 0.02 250)); font-weight:600; }
+.os-kpi-value{ font-size:22px; font-weight:600; font-variant-numeric:tabular-nums; line-height:1.1; color:var(--text); }
+.os-kpi-sub{ font-size:11px; color:var(--text-dim, oklch(0.55 0.02 250)); }
+.os-kpi-alert{ border-color:oklch(0.75 0.14 70); background:oklch(0.985 0.02 70); }
+.os-kpi-alert .os-kpi-value{ color:oklch(0.50 0.14 70); }
+
+.os-tabs{
+  display:flex; align-items:center; gap:4px; flex-wrap:wrap;
+  padding:8px 24px 0; border-bottom:1px solid var(--border, oklch(0.93 0.01 250));
+}
+.os-tab{
+  display:inline-flex; align-items:center; gap:6px;
+  padding:8px 12px; border:none; background:transparent; cursor:pointer;
+  font-size:12px; color:var(--text-dim, oklch(0.50 0.02 250)); font-weight:500;
+  border-bottom:2px solid transparent; transition:all .12s;
+}
+.os-tab:hover{ color:var(--text); }
+.os-tab.active{ color:var(--accent); border-bottom-color:var(--accent); }
+.os-tab .count{
+  display:inline-block; padding:1px 6px; border-radius:8px;
+  background:oklch(0.95 0.01 250); font-size:10px; font-weight:600;
+  color:oklch(0.40 0.02 250);
+}
+.os-tab.active .count{ background:oklch(0.94 0.06 var(--accent-h, 220)); color:var(--accent); }
+.os-tabs-r{ margin-left:auto; padding:4px 0; display:flex; gap:8px; align-items:center; }
+.os-search{
+  display:inline-flex; align-items:center; gap:6px;
+  padding:5px 10px; border:1px solid var(--border, oklch(0.85 0.02 250));
+  border-radius:6px; background:#fff;
+}
+.os-search input{ border:none; outline:none; background:transparent; font-size:12px; min-width:200px; }
+
+.os-table-wrap{ padding:14px 24px 20px; overflow:auto; }
+.os-table{
+  width:100%; border-collapse:collapse;
+  background:#fff; border:1px solid var(--border, oklch(0.93 0.01 250));
+  border-radius:8px; overflow:hidden;
+}
+.os-table thead th{
+  padding:10px 12px; text-align:left;
+  font-size:11px; font-weight:600; text-transform:uppercase; letter-spacing:0.04em;
+  color:var(--text-dim, oklch(0.45 0.02 250));
+  background:oklch(0.98 0.005 250);
+  border-bottom:1px solid var(--border, oklch(0.93 0.01 250));
+}
+.os-table td{ padding:10px 12px; border-bottom:1px solid oklch(0.96 0.01 250); font-size:13px; vertical-align:top; }
+.os-table tbody tr:last-child td{ border-bottom:none; }
+.os-row{ cursor:pointer; transition:background .1s; }
+.os-row:hover{ background:oklch(0.98 0.01 var(--accent-h, 220)); }
+.os-row.urgent{ box-shadow:inset 3px 0 0 oklch(0.60 0.16 25); }
+.os-empty{ text-align:center; padding:40px; color:var(--text-dim); font-style:italic; }
+
+.os-stage{
+  display:inline-block; padding:2px 8px; border-radius:10px;
+  font-size:11px; font-weight:500;
+}
+
+.os-drawer-head{
+  display:flex; align-items:flex-start; justify-content:space-between;
+  gap:12px; padding:18px 20px; border-bottom:1px solid var(--border, oklch(0.93 0.01 250));
+  background:#fff;
+}
+.os-drawer-head-l{ flex:1; min-width:0; }
+.os-drawer-id{ font-family:var(--font-mono); font-size:11px; color:var(--text-dim); text-transform:uppercase; letter-spacing:0.06em; }
+.os-drawer-head-l h2{ margin:4px 0 4px; font-size:18px; }
+.os-drawer-head-l p{ margin:0; font-size:12px; color:var(--text-dim); }
+.os-drawer-head-r{ display:flex; align-items:center; gap:8px; }
+
+.os-drawer-body{ flex:1; overflow:auto; }
+.icon-btn{
+  width:28px; height:28px; border-radius:6px;
+  background:transparent; border:1px solid transparent; cursor:pointer;
+  display:inline-flex; align-items:center; justify-content:center;
+  color:var(--text-dim);
+}
+.icon-btn:hover{ background:var(--border-2, oklch(0.95 0.01 250)); color:var(--text); }
+
+/* Stepper for create/nfe drawers */
+.vd-stepper{
+  display:flex; align-items:center; gap:0; padding:14px 20px;
+  background:oklch(0.98 0.005 250); border-bottom:1px solid var(--border, oklch(0.93 0.01 250));
+}
+.vd-step{
+  display:inline-flex; align-items:center; gap:6px;
+  border:none; background:transparent; cursor:pointer;
+  font-size:12px; color:var(--text-dim);
+}
+.vd-step-num{
+  width:22px; height:22px; border-radius:50%;
+  background:oklch(0.92 0.01 250); color:oklch(0.40 0.02 250);
+  display:inline-flex; align-items:center; justify-content:center;
+  font-size:11px; font-weight:600;
+}
+.vd-step.active .vd-step-num{ background:var(--accent); color:#fff; }
+.vd-step.active{ color:var(--text); font-weight:600; }
+.vd-step.done .vd-step-num{ background:oklch(0.55 0.14 145); color:#fff; }
+.vd-step-sep{ margin:0 10px; color:var(--text-dim); }
+
+
+/* ────────────────── Embed (iframe consolidator) ────────────────── */
+.embed-view{
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--bg-2, #fafaf9);
+}
+.embed-view.embed-fs{
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: var(--bg, #fff);
+}
+.embed-toolbar{
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border, #e5e0d3);
+  background: var(--panel, #fff);
+  font-size: 11px;
+  color: var(--text-mute, #8b8580);
+  flex-shrink: 0;
+}
+.embed-toolbar-l, .embed-toolbar-r{
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.embed-label{
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  font-size: 10px;
+}
+.embed-src{
+  font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 11px;
+  color: var(--text, #1a1917);
+  background: var(--bg-2, #f6f4ef);
+  padding: 2px 6px;
+  border-radius: 3px;
+  border: 1px solid var(--border, #e5e0d3);
+}
+.embed-btn{
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--border, #e5e0d3);
+  background: var(--panel, #fff);
+  color: var(--text, #1a1917);
+  font-size: 11px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background .12s, border-color .12s;
+}
+.embed-btn:hover{
+  background: var(--bg-2, #f6f4ef);
+  border-color: var(--text-mute, #8b8580);
+}
+.embed-btn.on{
+  background: var(--accent-soft, #eaf0f7);
+  border-color: var(--accent, #1f3a5f);
+  color: var(--accent, #1f3a5f);
+}
+.embed-iframe{
+  flex: 1;
+  width: 100%;
+  border: 0;
+  background: #fff;
+  display: block;
+}
+
+
+/* ────────────────── Sidebar lean ────────────────── */
+.sb-menu-lean .sb-item {
+  margin: 1px 0;
+}
+.sb-divider {
+  height: 1px;
+  background: var(--border, #e5e0d3);
+  margin: 8px 8px 6px;
+  opacity: 0.6;
+}
+.sb-group-flat {
+  font-weight: 500;
+}
+.sb-item .badge.muted {
+  background: transparent;
+  color: var(--text-mute, #8b8580);
+  font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 10px;
+  font-weight: 400;
+  padding: 0;
+  min-width: auto;
+}
+
+/* ────────────────── TopNav (sub-telas da área ativa) ────────────────── */
+.topnav {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 6px 16px;
+  border-bottom: 1px solid var(--border, #e5e0d3);
+  background: var(--panel, #fff);
+  font-size: 12px;
+  flex-shrink: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border, #e5e0d3) transparent;
+  min-height: 38px;
+}
+.topnav::-webkit-scrollbar { height: 4px; }
+.topnav::-webkit-scrollbar-thumb { background: var(--border, #e5e0d3); border-radius: 999px; }
+.topnav-area {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  padding-right: 12px;
+  border-right: 1px solid var(--border, #e5e0d3);
+}
+.topnav-area-label {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: var(--text-mute, #8b8580);
+}
+.topnav-pills {
+  display: flex;
+  gap: 2px;
+  flex-wrap: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+.topnav-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 0;
+  background: transparent;
+  padding: 4px 10px;
+  border-radius: 4px;
+  color: var(--text-mute, #8b8580);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background .12s, color .12s;
+  position: relative;
+}
+.topnav-pill svg {
+  opacity: 0.7;
+}
+.topnav-pill:hover {
+  background: var(--bg-2, #f6f4ef);
+  color: var(--text, #1a1917);
+}
+.topnav-pill:hover svg { opacity: 1; }
+.topnav-pill.active {
+  color: var(--accent, #1f3a5f);
+  font-weight: 600;
+  background: var(--accent-soft, #eaf0f7);
+}
+.topnav-pill.active svg { opacity: 1; }
+
+
+/* ────────────────── Sidebar group — header com cor ────────────────── */
+.sb-group{
+  margin: 6px 0 2px;
+}
+.sb-group-h{
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+  border-radius: 4px;
+  user-select: none;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--sb-text);
+}
+.sb-group-h:hover{ background: var(--sb-hover); }
+.sb-group-dot{
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+.sb-group-l{
+  flex: 1 1 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.sb-group-n{
+  font-size: 9.5px;
+  font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
+  color: var(--text-mute);
+  font-weight: 500;
+  letter-spacing: 0;
+}
+.sb-group .chev{
+  width: 10px;
+  height: 10px;
+  opacity: 0.5;
+  flex-shrink: 0;
+}
+.sb-item.sb-sub{
+  border-left: 2px solid transparent;
+  padding-left: 18px;
+}
+.sb-item.sb-sub.active{
+  border-left-color: var(--accent);
+}
+/* esconde estilo lean antigo */
+.sb-divider, .sb-menu-lean .sb-divider { display: none; }
+.sb-group-flat { display: none; }
+
+/* ────────────────── Sidebar collapse / rail / hidden ────────────────── */
+.sb{ position: relative; overflow: visible; }
+
+/* Alça de colapsar na borda direita */
+.sb-collapse-handle{
+  position: absolute;
+  top: 50%;
+  right: -10px;
+  transform: translateY(-50%);
+  width: 20px;
+  height: 36px;
+  border-radius: 4px;
+  border: 1px solid var(--sb-border);
+  background: var(--sb-bg);
+  color: var(--sb-text-dim);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  z-index: 30;
+  opacity: 0;
+  transition: opacity .12s, color .12s, background .12s, transform .12s;
+  padding: 0;
+}
+.sb:hover .sb-collapse-handle,
+.sb-collapse-handle:focus-visible,
+.sb-collapse-handle:hover{
+  opacity: 1;
+}
+.sb-collapse-handle:hover{
+  background: var(--sb-active);
+  color: var(--sb-text-hi);
+}
+
+/* Alça flutuante para reabrir quando oculta */
+.sb-reopen-handle{
+  position: fixed;
+  top: 50%;
+  left: 0;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 64px;
+  border-radius: 0 6px 6px 0;
+  border: 1px solid var(--border);
+  border-left: 0;
+  background: var(--bg-elev, var(--bg, #fff));
+  color: var(--text-mute, #777);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  z-index: 40;
+  padding: 0;
+  box-shadow: 2px 0 8px oklch(0 0 0 / .06);
+}
+.sb-reopen-handle:hover{
+  width: 26px;
+  color: var(--text, #111);
+  background: var(--accent-soft, var(--sb-active));
+}
+
+/* ── Sidebar em modo RAIL ── */
+.sb--rail{
+  overflow: visible;
+}
+.sb--rail .sb-top{
+  padding: 8px 8px 6px;
+  display: grid;
+  place-items: center;
+}
+.sb--rail .sb-body{
+  padding: 4px 0;
+}
+.sb--rail .sb-user{
+  padding: 8px;
+  display: grid;
+  place-items: center;
+}
+.sb-menu-rail{
+  padding: 4px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+
+/* Botão genérico do rail (40x40 centrado em 56px) */
+.sb-rail-btn{
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--sb-text);
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  position: relative;
+  padding: 0;
+  transition: background .1s, color .1s;
+}
+.sb-rail-btn:hover{
+  background: var(--sb-hover);
+  color: var(--sb-text-hi);
+}
+.sb-rail-btn.active{
+  background: var(--sb-active);
+  color: var(--sb-text-hi);
+}
+.sb-rail-btn.active::before{
+  content: "";
+  position: absolute;
+  left: -8px;
+  top: 8px; bottom: 8px;
+  width: 3px;
+  border-radius: 0 2px 2px 0;
+  background: var(--accent);
+}
+.sb-rail-btn .ic{
+  width: 18px;
+  height: 18px;
+  opacity: .9;
+}
+.sb-rail-btn.active .ic{ opacity: 1; }
+
+.sb-rail-btn.sb-rail-group .ic{
+  width: 18px;
+  height: 18px;
+}
+.sb-rail-btn.sb-rail-group.active .ic,
+.sb-rail-btn.sb-rail-group.open .ic{
+  filter: brightness(1.15);
+}
+
+.sb-rail-group-pill{
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 9.5px;
+  font-weight: 700;
+  color: #fff;
+  letter-spacing: 0.02em;
+  width: 24px;
+  height: 22px;
+  border-radius: 5px;
+  display: grid;
+  place-items: center;
+}
+
+.sb-rail-dot-badge{
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: oklch(0.62 0.18 30);
+  box-shadow: 0 0 0 2px var(--sb-bg);
+}
+
+/* Avatar empresa / user no rail */
+.sb--rail .sb-cp-rail-btn .avatar,
+.sb--rail .sb-user-rail-btn .avatar{
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 700;
+  font-size: 11px;
+}
+.sb--rail .sb-user-rail-btn .avatar{
+  border-radius: 50%;
+}
+
+/* Dropdown de empresa quando em rail (alinhado à direita do rail) */
+.sb-dd-rail{
+  left: calc(100% + 8px);
+  top: 0;
+  right: auto;
+  width: 220px;
+  z-index: 50;
+}
+
+/* Tooltip via data-tip (somente no rail) */
+.sb--rail [data-tip]{
+  position: relative;
+}
+.sb--rail [data-tip]::after{
+  content: attr(data-tip);
+  position: absolute;
+  left: calc(100% + 12px);
+  top: 50%;
+  transform: translateY(-50%) translateX(-4px);
+  padding: 6px 10px;
+  background: oklch(0.18 0 0);
+  color: oklch(0.96 0 0);
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  border-radius: 6px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .12s .12s, transform .12s .12s;
+  z-index: 60;
+  box-shadow: 0 4px 14px oklch(0 0 0 / 0.22);
+}
+.sb--rail [data-tip]:hover::after{
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
+}
+
+/* Tooltip de GRUPO: maior, com a cor do grupo, e setinha */
+.sb--rail .sb-rail-group[data-tip]::after{
+  background: oklch(0.96 0.02 var(--gh, 220));
+  color: oklch(0.28 0.08 var(--gh, 220));
+  border: 1px solid oklch(0.72 0.10 var(--gh, 220) / 0.55);
+  border-left: 3px solid oklch(0.62 0.13 var(--gh, 220));
+  padding: 7px 12px 7px 11px;
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  box-shadow: 0 6px 18px oklch(0 0 0 / 0.18);
+}
+/* Esconde tooltip enquanto o flyout do grupo está aberto */
+.sb--rail .sb-rail-btn.open[data-tip]::after{
+  opacity: 0 !important;
+}
+
+/* Flyout do grupo no rail */
+.sb-rail-flyout{
+  position: fixed;
+  background: var(--sb-bg);
+  border: 1px solid var(--sb-border);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px oklch(0 0 0 / 0.28);
+  padding: 6px;
+  min-width: 220px;
+  max-width: 260px;
+  z-index: 60;
+  animation: sbFlyoutIn .14s ease-out;
+}
+@keyframes sbFlyoutIn{
+  from { opacity: 0; transform: translateX(-4px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+.sb-rail-flyout-h{
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px 6px;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+.sb-rail-flyout-h .sb-group-n{
+  margin-left: auto;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--sb-text-dim);
+  letter-spacing: 0;
+}
+.sb-rail-flyout .sb-item{
+  height: 30px;
+  padding: 0 10px;
+  border-radius: 6px;
+}
+.sb-rail-flyout .sb-item.sb-sub{
+  padding-left: 14px;
+  border-left-width: 2px;
+}
+
+/* No rail: oculta o handle interno (a alça basta) */
+.sb--rail .sb-collapse-handle{
+  /* permanece visível, mas roda 180° via SVG no JSX */
+}
+
+/* (auto-rail em viewports estreitas é feito no JS no mount inicial — */
+/*  não sobrescreve a escolha do usuário via CSS.) */
+
+
+/* ══════════════════════════════════════════════════════════════════
+   VENDAS A+ (2026-05-14) — refator pra 9.5
+   8 itens: identidade green · sparkline+ageing · stepper FSM · avatar
+            Vista toggle · ⌘K · saved views+bulk · NF-e+NFS-e
+   Namespace: .vendas-aplus  (escopo da Index Vendas)
+   ════════════════════════════════════════════════════════════════ */
+.vendas-aplus{
+  --vd-green:       oklch(0.45 0.11 155);
+  --vd-green-2:     oklch(0.55 0.11 155);
+  --vd-green-soft:  oklch(0.95 0.04 155);
+  --vd-green-hero:  oklch(0.21 0.025 155);
+  --vd-green-hero-2:oklch(0.27 0.03 155);
+  --vd-green-fg:    oklch(0.78 0.05 155);
+
+  --vd-ok:    oklch(0.55 0.13 145);
+  --vd-ok-soft: oklch(0.94 0.06 145);
+  --vd-warn:  oklch(0.62 0.13 70);
+  --vd-warn-soft: oklch(0.94 0.06 70);
+  --vd-bad:   oklch(0.55 0.18 25);
+  --vd-bad-soft: oklch(0.94 0.06 25);
+  --vd-neutral: oklch(0.55 0.01 80);
+  --vd-neutral-soft: oklch(0.94 0.005 80);
+}
+
+/* ── HEADER: ⌘K button no centro do .os-head ── */
+.vendas-aplus .os-head{ align-items:center; gap:12px; }
+.vendas-aplus .vd-cmdk{
+  flex: 0 1 360px; min-width: 220px;
+  display: flex; align-items: center; gap: 8px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 6px; padding: 6px 10px;
+  color: var(--text-mute); cursor: pointer;
+  font: inherit; font-size: 12.5px;
+  transition: border-color .12s;
+}
+.vendas-aplus .vd-cmdk:hover{ border-color: var(--text-mute); }
+.vendas-aplus .vd-cmdk span{ flex: 1; text-align: left; }
+.vendas-aplus .vd-cmdk kbd{
+  font-family: var(--font-mono); font-size: 9.5px; padding: 1px 5px;
+  border: 1px solid var(--border); border-bottom-width: 2px; border-radius: 3px;
+  background: var(--bg-2); color: var(--text-dim);
+}
+
+/* ── Vista segmented control ── */
+.vendas-aplus .vd-vista{
+  display: inline-flex; background: var(--bg-2);
+  border: 1px solid var(--border); border-radius: 6px; padding: 2px;
+}
+.vendas-aplus .vd-vista button{
+  border: 0; background: transparent;
+  padding: 4px 12px; font-size: 11.5px; font-weight: 600;
+  color: var(--text-mute); border-radius: 4px;
+  letter-spacing: 0.02em; cursor: pointer; font-family: inherit;
+  transition: all .15s;
+}
+.vendas-aplus .vd-vista button.on{
+  background: var(--surface); color: var(--vd-green);
+  box-shadow: 0 1px 2px rgba(0,0,0,.04);
+}
+
+/* ── Saved views dropdown ── */
+.vendas-aplus .vd-views{ position: relative; }
+.vendas-aplus .vd-views-btn{
+  background: var(--surface); border: 1px solid var(--border);
+  padding: 6px 10px; border-radius: 5px;
+  font-size: 12px; font-weight: 600; color: var(--text);
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit; cursor: pointer;
+}
+.vendas-aplus .vd-views-btn::after{ content: '▾'; font-size: 9px; color: var(--text-mute); }
+.vendas-aplus .vd-views-btn:hover{ border-color: var(--text-mute); }
+.vendas-aplus .vd-views-menu{
+  position: absolute; top: calc(100% + 4px); right: 0;
+  min-width: 240px; background: var(--surface);
+  border: 1px solid var(--border); border-radius: 8px;
+  box-shadow: 0 8px 24px -8px rgba(0,0,0,.18), 0 0 0 1px rgba(0,0,0,.02);
+  padding: 4px; z-index: 30;
+}
+.vendas-aplus .vd-views-item{
+  display: flex; align-items: center; gap: 8px;
+  padding: 7px 10px; font-size: 12.5px; cursor: pointer;
+  border-radius: 4px;
+}
+.vendas-aplus .vd-views-item:hover{ background: var(--bg-2); }
+.vendas-aplus .vd-views-item.active{ color: var(--vd-green); font-weight: 600; }
+.vendas-aplus .vd-views-item .ct{
+  margin-left: auto;
+  color: var(--text-mute); font-family: var(--font-mono); font-size: 10.5px;
+  background: var(--bg-2); padding: 1px 6px; border-radius: 99px;
+}
+.vendas-aplus .vd-views-item.active .ct{ background: var(--vd-green-soft); color: var(--vd-green); }
+.vendas-aplus .vd-views-sep{ height: 1px; background: var(--border-2); margin: 4px -4px; }
+
+/* ── KPIs ── */
+.vendas-aplus .vd-kpis{ grid-template-columns: repeat(4, 1fr); gap: 12px; }
+.vendas-aplus .vd-kpi-hero{
+  background: var(--vd-green-hero); color: oklch(0.92 0.01 155);
+  border-color: var(--vd-green-hero);
+}
+.vendas-aplus .vd-kpi-hero .os-kpi-label{ color: var(--vd-green-fg); }
+.vendas-aplus .vd-kpi-hero .os-kpi-value{ color: oklch(0.95 0.01 155); }
+.vendas-aplus .vd-kpi-hero .os-kpi-sub{ color: var(--vd-green-fg); }
+
+.vendas-aplus .vd-spark{ margin-top: 8px; height: 32px; }
+
+.vendas-aplus .vd-delta-up{ color: var(--vd-ok) !important; display: inline-flex; align-items: center; gap: 4px; }
+.vendas-aplus .vd-kpi-hero .vd-delta-up{ color: oklch(0.78 0.10 155) !important; }
+.vendas-aplus .os-kpi-value small{ font-size: 13px; color: var(--text-mute); font-weight: 500; margin-left: 2px; }
+.vendas-aplus .vd-kpi-hero .os-kpi-value small{ color: oklch(0.65 0.04 155); }
+
+/* ageing 3 bars */
+.vendas-aplus .vd-ageing{
+  margin-top: 10px;
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px;
+}
+.vendas-aplus .vd-ag-bar{
+  height: 4px; border-radius: 99px;
+  background: var(--border-2); position: relative; overflow: hidden;
+}
+.vendas-aplus .vd-ag-bar > div{
+  position: absolute; left: 0; top: 0; bottom: 0;
+  border-radius: 99px; min-width: 4px;
+}
+.vendas-aplus .vd-ag-bar.ok   > div{ background: var(--vd-ok); }
+.vendas-aplus .vd-ag-bar.warn > div{ background: var(--vd-warn); }
+.vendas-aplus .vd-ag-bar.bad  > div{ background: var(--vd-bad); }
+.vendas-aplus .vd-ag-lbls{
+  grid-column: 1 / -1;
+  display: flex; justify-content: space-between;
+  font-size: 9.5px; color: var(--text-mute);
+  margin-top: 2px; font-family: var(--font-mono);
+}
+
+/* PIX progress */
+.vendas-aplus .vd-pix-prog{
+  margin-top: 12px; height: 6px; background: var(--border-2);
+  border-radius: 99px; overflow: hidden;
+}
+.vendas-aplus .vd-pix-prog > div{
+  height: 100%;
+  background: linear-gradient(90deg, var(--vd-green), var(--vd-green-2));
+  border-radius: 99px;
+}
+
+/* Fiscal stacked bar */
+.vendas-aplus .vd-fiscal-bar{
+  margin-top: 10px; height: 6px; display: flex; gap: 2px;
+  border-radius: 99px; overflow: hidden; background: var(--border-2);
+}
+.vendas-aplus .vd-fiscal-bar > div{ min-width: 2px; }
+
+/* Ranking vendedores no KPI Comissão */
+.vendas-aplus .vd-rank{ padding: 12px 14px; }
+.vendas-aplus .vd-rank-row{
+  display: flex; align-items: center; gap: 8px;
+  margin-top: 6px;
+}
+.vendas-aplus .vd-rank-info{
+  flex: 1; font-size: 11.5px; line-height: 1.3;
+}
+.vendas-aplus .vd-rank-info > div:first-child{
+  display: flex; justify-content: space-between;
+  font-weight: 600; margin-bottom: 2px;
+}
+.vendas-aplus .vd-rank-info > div:first-child span:last-child{
+  font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); font-weight: 500;
+}
+.vendas-aplus .vd-rank-bar{
+  height: 3px; border-radius: 99px;
+  background: var(--border-2); overflow: hidden;
+}
+.vendas-aplus .vd-rank-bar > div{ height: 100%; border-radius: 99px; }
+
+/* ── Avatar vendedor ── */
+.vendas-aplus .vd-av{
+  display: inline-grid; place-items: center;
+  width: 24px; height: 24px; border-radius: 50%;
+  font-size: 10.5px; font-weight: 700; color: #fff;
+  font-family: var(--font-mono); letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+.vendas-aplus .vd-av-1{ background: oklch(0.55 0.12 30); }
+.vendas-aplus .vd-av-2{ background: oklch(0.50 0.13 200); }
+.vendas-aplus .vd-av-3{ background: oklch(0.55 0.13 290); }
+.vendas-aplus .vd-av-4{ background: oklch(0.50 0.13 120); }
+
+/* ── Table: tweaks A+ ── */
+.vendas-aplus .vd-aplus-table{ font-size: 12.5px; }
+.vendas-aplus .vd-aplus-table thead th{
+  background: var(--bg-2); color: var(--text-mute);
+  font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.06em;
+  font-weight: 600; padding: 9px 12px;
+}
+.vendas-aplus .vd-aplus-table tbody td{
+  padding: 10px 12px; vertical-align: middle;
+}
+.vendas-aplus .vd-aplus-table .vd-chk{ padding: 0 0 0 12px; width: 24px; }
+.vendas-aplus .vd-aplus-table .os-row.selected td{ background: var(--vd-green-soft); }
+.vendas-aplus .vd-aplus-table .os-row.urgent td:first-child{ box-shadow: inset 3px 0 0 var(--vd-bad); }
+
+.vendas-aplus .vd-seller-cell{ display: flex; align-items: center; gap: 8px; }
+.vendas-aplus .vd-seller-info{ display: flex; flex-direction: column; line-height: 1.2; min-width: 0; }
+.vendas-aplus .vd-seller-info b{ font-size: 12px; font-weight: 600; }
+.vendas-aplus .vd-seller-info small{
+  font-size: 10.5px; color: var(--text-mute);
+  font-family: var(--font-mono); text-transform: lowercase;
+}
+
+/* commission column shown only on vista=comissao */
+.vendas-aplus[data-vista="comissao"] .vd-col-commission{ display: table-cell; }
+.vendas-aplus .vd-col-commission{ display: none; }
+
+/* ── Mini-stepper FSM inline ── */
+.vendas-aplus .vd-stp{
+  display: inline-flex; align-items: center; gap: 3px;
+  padding: 3px 7px; border-radius: 99px;
+  background: var(--bg-2);
+}
+.vendas-aplus .vd-stp-dot{
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--border); transition: all .15s;
+}
+.vendas-aplus .vd-stp-dot.done{ background: var(--vd-green); }
+.vendas-aplus .vd-stp-dot.current{
+  background: var(--vd-green);
+  box-shadow: 0 0 0 2px var(--vd-green-soft);
+  transform: scale(1.3);
+}
+.vendas-aplus .vd-stp-lbl{
+  font-size: 10px; color: var(--text-mute); margin-left: 4px;
+  font-family: var(--font-mono); text-transform: uppercase;
+  letter-spacing: 0.04em; font-weight: 600;
+}
+
+/* ── Fiscal badges ── */
+.vendas-aplus .vd-fc{ display: inline-flex; gap: 4px; flex-wrap: wrap; }
+.vendas-aplus .vd-fb{
+  display: inline-flex; align-items: center; gap: 3px;
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  padding: 2px 6px; border-radius: 3px;
+  letter-spacing: 0.02em;
+  position: relative; cursor: help;
+}
+.vendas-aplus .vd-fb-ok   { background: var(--vd-ok-soft);     color: oklch(0.36 0.10 145); }
+.vendas-aplus .vd-fb-wait { background: var(--vd-warn-soft);   color: oklch(0.42 0.12 60); }
+.vendas-aplus .vd-fb-bad  { background: var(--vd-bad-soft);    color: oklch(0.42 0.13 20); }
+.vendas-aplus .vd-fb-canc { background: var(--vd-neutral-soft);color: var(--text-mute); }
+.vendas-aplus .vd-fb-na   { background: transparent; color: var(--text-mute); padding: 2px 4px; }
+.vendas-aplus .vd-fb-ic{ font-size: 9px; }
+
+.vendas-aplus .vd-fb-tip{
+  position: absolute; bottom: calc(100% + 6px); left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  background: var(--text); color: oklch(0.97 0.005 90);
+  padding: 5px 9px; border-radius: 5px;
+  font-size: 10px; font-family: var(--font-mono); font-weight: 500;
+  white-space: nowrap; pointer-events: none;
+  opacity: 0; transition: all .12s;
+  z-index: 20;
+  box-shadow: 0 4px 12px rgba(0,0,0,.20);
+}
+.vendas-aplus .vd-fb-tip::after{
+  content: ''; position: absolute; top: 100%; left: 50%; transform: translateX(-50%);
+  border: 4px solid transparent; border-top-color: var(--text);
+}
+.vendas-aplus .vd-fb:hover .vd-fb-tip{ opacity: 1; transform: translateX(-50%) translateY(0); }
+
+/* ── Bulk action bar (fixed bottom) ── */
+.vendas-aplus .vd-bulk{
+  position: fixed; bottom: 24px; left: 50%;
+  transform: translateX(-50%) translateY(120px);
+  background: var(--text); color: oklch(0.97 0.005 90);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px -8px rgba(0,0,0,.30);
+  padding: 10px 14px;
+  display: flex; align-items: center; gap: 6px;
+  z-index: 30; opacity: 0;
+  transition: all .22s ease-out;
+}
+.vendas-aplus .vd-bulk.on{
+  opacity: 1; transform: translateX(-50%) translateY(0);
+}
+.vendas-aplus .vd-bulk-ct{
+  font-size: 12px; font-weight: 600;
+  padding: 2px 8px; background: rgba(255,255,255,.12); border-radius: 99px;
+}
+.vendas-aplus .vd-bulk-btn{
+  background: transparent; color: oklch(0.97 0.005 90);
+  border: 1px solid rgba(255,255,255,.20);
+  padding: 5px 10px; border-radius: 5px;
+  font-size: 11.5px; font-weight: 500; font-family: inherit; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 5px;
+}
+.vendas-aplus .vd-bulk-btn:hover{ background: rgba(255,255,255,.10); }
+.vendas-aplus .vd-bulk-btn.primary{
+  background: var(--vd-green); border-color: var(--vd-green);
+}
+.vendas-aplus .vd-bulk-btn.primary:hover{ background: var(--vd-green-2); }
+.vendas-aplus .vd-bulk-close{
+  background: transparent; border: 0;
+  color: oklch(0.75 0.005 90); padding: 4px 6px;
+  cursor: pointer; font-size: 13px;
+}
+
+/* ── ⌘K Palette ── */
+.vendas-aplus .vd-pal-bd{
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,.34);
+  z-index: 60;
+  display: grid; place-items: start center;
+  padding-top: 12vh;
+  opacity: 0; pointer-events: none;
+  transition: opacity .14s;
+}
+.vendas-aplus .vd-pal-bd.on{ opacity: 1; pointer-events: auto; }
+.vendas-aplus .vd-pal{
+  width: 560px; max-width: 92vw;
+  background: var(--surface); border-radius: 12px;
+  box-shadow: 0 24px 64px -12px rgba(0,0,0,.40);
+  overflow: hidden;
+  transform: scale(0.96); transition: transform .14s;
+}
+.vendas-aplus .vd-pal-bd.on .vd-pal{ transform: scale(1); }
+.vendas-aplus .vd-pal-in{
+  display: flex; align-items: center; gap: 10px;
+  padding: 12px 16px; border-bottom: 1px solid var(--border);
+}
+.vendas-aplus .vd-pal-in input{
+  flex: 1; border: 0; background: transparent;
+  font: inherit; font-size: 15px;
+  color: var(--text); outline: none;
+}
+.vendas-aplus .vd-pal-in input::placeholder{ color: var(--text-mute); }
+.vendas-aplus .vd-pal-in kbd{
+  font-family: var(--font-mono); font-size: 10px; padding: 1px 5px;
+  border: 1px solid var(--border); border-bottom-width: 2px; border-radius: 3px;
+  background: var(--bg-2); color: var(--text-dim);
+}
+.vendas-aplus .vd-pal-list{ max-height: 50vh; overflow-y: auto; padding: 6px; }
+.vendas-aplus .vd-pal-grp{
+  padding: 6px 12px 4px; font-size: 9.5px;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--text-mute); font-weight: 700;
+}
+.vendas-aplus .vd-pal-it{
+  display: flex; align-items: center; gap: 12px;
+  padding: 8px 12px; border-radius: 6px; cursor: pointer;
+  font-size: 13px;
+}
+.vendas-aplus .vd-pal-it.sel{ background: var(--vd-green-soft); }
+.vendas-aplus .vd-pal-ic{
+  width: 28px; height: 28px; border-radius: 6px; background: var(--bg-2);
+  display: grid; place-items: center; color: var(--text-dim);
+  flex-shrink: 0;
+}
+.vendas-aplus .vd-pal-it.sel .vd-pal-ic{ background: var(--vd-green); color: #fff; }
+.vendas-aplus .vd-pal-tx{ flex: 1; min-width: 0; }
+.vendas-aplus .vd-pal-tx b{ display: block; font-weight: 600; }
+.vendas-aplus .vd-pal-tx small{ font-size: 11px; color: var(--text-mute); }
+.vendas-aplus .vd-pal-it kbd{
+  margin-left: auto;
+  font-family: var(--font-mono); font-size: 10px; padding: 1px 5px;
+  border: 1px solid var(--border); border-bottom-width: 2px; border-radius: 3px;
+  background: var(--bg-2); color: var(--text-dim);
+}
+.vendas-aplus .vd-pal-empty{
+  padding: 24px; text-align: center;
+  color: var(--text-mute); font-size: 12.5px;
+}
+.vendas-aplus .vd-pal-ft{
+  padding: 10px 16px; border-top: 1px solid var(--border);
+  display: flex; gap: 16px; font-size: 11px; color: var(--text-mute);
+}
+.vendas-aplus .vd-pal-ft span{
+  display: inline-flex; align-items: center; gap: 4px;
+}
+.vendas-aplus .vd-pal-ft kbd{
+  font-family: var(--font-mono); font-size: 9.5px; padding: 1px 4px;
+  border: 1px solid var(--border); border-bottom-width: 2px; border-radius: 3px;
+  background: var(--bg-2); color: var(--text-dim);
+}
+
+/* ══════════════════════════════════════════════════════════════════
+   VENDAS A+ — Detail drawer com Fiscal tab
+   ════════════════════════════════════════════════════════════════ */
+.vd-drawer-aplus.os-drawer.wide{ width: 720px; }
+.vd-drawer-aplus .os-drawer-head{
+  align-items: flex-start;
+}
+.vd-drawer-aplus .os-drawer-head-r{
+  display: flex; align-items: center; gap: 10px;
+}
+.vd-drawer-aplus .vd-drawer-total{
+  font-family: var(--font-mono); font-size: 18px;
+  font-weight: 700; letter-spacing: -0.01em;
+  color: var(--text);
+}
+
+/* drawer tabs */
+.vd-drawer-aplus .vd-drawer-tabs{
+  display: flex; gap: 0;
+  border-bottom: 1px solid var(--border);
+  padding: 0 24px;
+  background: var(--surface);
+}
+.vd-drawer-aplus .vd-drawer-tab{
+  border: 0; background: transparent;
+  padding: 10px 14px; margin-bottom: -1px;
+  font: inherit; cursor: pointer;
+  color: var(--text-mute); font-weight: 500; font-size: 12.5px;
+  border-bottom: 2px solid transparent;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.vd-drawer-aplus .vd-drawer-tab:hover{ color: var(--text); }
+.vd-drawer-aplus .vd-drawer-tab.on{
+  color: var(--vd-green);
+  border-bottom-color: var(--vd-green);
+  font-weight: 600;
+}
+.vd-drawer-aplus .vd-drawer-tab-ct{
+  font-family: var(--font-mono); font-size: 10px;
+  background: var(--bg-2); color: var(--text-mute);
+  padding: 1px 6px; border-radius: 99px; font-weight: 600;
+}
+.vd-drawer-aplus .vd-drawer-tab.on .vd-drawer-tab-ct{
+  background: var(--vd-green-soft); color: var(--vd-green);
+}
+
+.vd-drawer-aplus .vd-drawer-body{
+  background: var(--bg-2);
+}
+.vd-drawer-aplus .vd-drawer-body .vd-section h3{
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--text-dim); font-weight: 700; margin: 0 0 10px;
+}
+
+/* Itens cards */
+.vd-drawer-aplus .vd-items-cards{
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px; overflow: hidden;
+}
+.vd-drawer-aplus .vd-item-card{
+  display: grid; grid-template-columns: 1fr 50px 90px 110px;
+  align-items: center; gap: 12px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-2); font-size: 12.5px;
+}
+.vd-drawer-aplus .vd-item-card:last-child{ border-bottom: 0; }
+.vd-drawer-aplus .vd-item-c-l b{ display: block; font-weight: 600; }
+.vd-drawer-aplus .vd-item-c-l small{ font-size: 11px; color: var(--text-mute); }
+.vd-drawer-aplus .vd-item-c-qty,
+.vd-drawer-aplus .vd-item-c-unit,
+.vd-drawer-aplus .vd-item-c-sub{
+  text-align: right; font-family: var(--font-mono); font-variant-numeric: tabular-nums;
+}
+.vd-drawer-aplus .vd-item-c-sub{ font-weight: 700; }
+.vd-drawer-aplus .vd-items-foot{
+  display: flex; justify-content: flex-end; gap: 14px;
+  padding: 14px 4px 0;
+  font-family: var(--font-mono); font-size: 13px;
+}
+.vd-drawer-aplus .vd-items-foot span{ color: var(--text-mute); }
+.vd-drawer-aplus .vd-items-foot b{ font-weight: 700; font-size: 16px; letter-spacing: -0.01em; }
+
+/* Emit panel */
+.vd-drawer-aplus .vd-emit{
+  background: var(--vd-green-soft);
+  border: 1px dashed var(--vd-green);
+  border-radius: 8px; padding: 14px 16px;
+  display: flex; align-items: center; gap: 12px;
+  margin-bottom: 12px;
+}
+.vd-drawer-aplus .vd-emit > div b{ display: block; font-size: 13px; color: var(--vd-green); }
+.vd-drawer-aplus .vd-emit > div small{ font-size: 11.5px; color: var(--text-dim); }
+.vd-drawer-aplus .vd-emit .os-btn{ margin-left: auto; flex-shrink: 0; }
+
+/* Sub-tabs fiscal */
+.vd-drawer-aplus .vd-fsub{
+  display: inline-flex; gap: 2px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 6px; padding: 2px; margin-bottom: 12px;
+}
+.vd-drawer-aplus .vd-fsub button{
+  border: 0; background: transparent;
+  padding: 4px 10px; font-size: 11px; font-weight: 600;
+  border-radius: 4px; color: var(--text-mute);
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: inherit; cursor: pointer;
+}
+.vd-drawer-aplus .vd-fsub button.on{ background: var(--bg-2); color: var(--text); }
+.vd-drawer-aplus .vd-fsub button span{
+  font-family: var(--font-mono); font-size: 9.5px;
+  background: var(--border-2); padding: 0 4px; border-radius: 99px;
+}
+
+/* Fiscal card grid */
+.vd-drawer-aplus .vd-fcard-grid{
+  display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+}
+.vd-drawer-aplus .vd-fcard-grid.single{
+  grid-template-columns: 1fr; max-width: 500px;
+}
+
+/* Fiscal card */
+.vd-drawer-aplus .vd-fcard{
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px; padding: 14px 16px;
+}
+.vd-drawer-aplus .vd-fcard-h{
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 10px;
+}
+.vd-drawer-aplus .vd-fcard-h h4{
+  margin: 0; font-size: 13px; font-weight: 700;
+}
+.vd-drawer-aplus .vd-fcard-date{
+  margin-left: auto;
+  font-size: 11px; color: var(--text-mute);
+  font-family: var(--font-mono);
+}
+.vd-drawer-aplus .vd-fcard-date span{ margin-left: 4px; }
+
+.vd-drawer-aplus .vd-fcard-fail{
+  margin-bottom: 12px; padding: 10px 12px;
+  background: var(--vd-bad-soft); border-radius: 5px;
+  border-left: 3px solid var(--vd-bad);
+  font-size: 11.5px; color: oklch(0.32 0.12 25);
+}
+.vd-drawer-aplus .vd-fcard-fail.neutral{
+  background: var(--vd-neutral-soft);
+  border-left-color: var(--vd-neutral);
+  color: var(--text-dim);
+}
+.vd-drawer-aplus .vd-fcard-fail b{ display: block; margin-bottom: 2px; }
+
+.vd-drawer-aplus .vd-fcard-meta{
+  display: grid; grid-template-columns: 80px 1fr;
+  gap: 4px 12px; font-size: 11.5px; margin: 0;
+}
+.vd-drawer-aplus .vd-fcard-meta dt{ color: var(--text-mute); }
+.vd-drawer-aplus .vd-fcard-meta dd{ margin: 0; font-family: var(--font-mono); }
+
+.vd-drawer-aplus .vd-fcard-chave{
+  display: flex; align-items: center; gap: 6px;
+  margin-top: 12px; padding: 8px 10px;
+  background: var(--bg-2); border-radius: 5px;
+  font-family: var(--font-mono); font-size: 11px;
+  color: var(--text-dim);
+}
+.vd-drawer-aplus .vd-fcard-chave-num{
+  letter-spacing: 0.04em; flex: 1;
+  word-break: break-all;
+}
+.vd-drawer-aplus .vd-fcard-copy{
+  background: transparent; border: 1px solid var(--border);
+  padding: 3px 8px; border-radius: 4px; font-size: 10.5px;
+  color: var(--text-dim); font-family: var(--font-sans);
+  flex-shrink: 0; cursor: pointer;
+}
+.vd-drawer-aplus .vd-fcard-copy.copied{
+  background: var(--vd-ok-soft); color: oklch(0.36 0.10 145);
+  border-color: transparent;
+}
+
+/* Timeline SEFAZ horizontal */
+.vd-drawer-aplus .vd-fcard-tl{
+  margin-top: 12px;
+  display: flex; gap: 0; align-items: flex-start;
+  padding: 10px 0;
+}
+.vd-drawer-aplus .vd-fcard-step{
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; gap: 4px; position: relative;
+}
+.vd-drawer-aplus .vd-fcard-step::before{
+  content: ''; position: absolute; top: 9px; left: -50%; right: 50%;
+  height: 2px; background: var(--border-2); z-index: 0;
+}
+.vd-drawer-aplus .vd-fcard-step:first-child::before{ display: none; }
+.vd-drawer-aplus .vd-fcard-step-d{
+  width: 18px; height: 18px; border-radius: 50%;
+  background: var(--surface); border: 2px solid var(--border-2);
+  display: grid; place-items: center;
+  font-size: 9px; font-weight: 700; color: var(--text-mute);
+  z-index: 1;
+}
+.vd-drawer-aplus .vd-fcard-step.done .vd-fcard-step-d{
+  background: var(--vd-green); border-color: var(--vd-green); color: #fff;
+}
+.vd-drawer-aplus .vd-fcard-step.done::before{ background: var(--vd-green); }
+.vd-drawer-aplus .vd-fcard-step.failed .vd-fcard-step-d{
+  background: var(--vd-bad); border-color: var(--vd-bad); color: #fff;
+}
+.vd-drawer-aplus .vd-fcard-step-l{
+  font-size: 9.5px; color: var(--text-mute); text-align: center;
+  font-family: var(--font-mono);
+  text-transform: uppercase; letter-spacing: 0.02em;
+  line-height: 1.2;
+}
+.vd-drawer-aplus .vd-fcard.failed .vd-fcard-step.done .vd-fcard-step-d{ background: var(--vd-bad); border-color: var(--vd-bad); }
+.vd-drawer-aplus .vd-fcard.failed .vd-fcard-step.done::before{ background: var(--vd-bad); }
+
+.vd-drawer-aplus .vd-fcard-cce{
+  margin-top: 10px; padding-top: 10px;
+  border-top: 1px solid var(--border-2);
+}
+.vd-drawer-aplus .vd-fcard-cce summary{
+  cursor: pointer; font-size: 11px;
+  color: var(--vd-green); font-weight: 600;
+  user-select: none;
+}
+.vd-drawer-aplus .vd-fcard-cce summary:hover{ color: var(--vd-green-2); }
+.vd-drawer-aplus .vd-fcard-cce p{
+  margin: 8px 0 0; font-size: 11.5px; color: var(--text-dim);
+}
+
+.vd-drawer-aplus .vd-fcard-ctas{
+  display: flex; gap: 6px; margin-top: 14px;
+  padding-top: 12px; border-top: 1px solid var(--border-2);
+}
+.vd-drawer-aplus .vd-fcard-cta{
+  flex: 1; padding: 6px 8px; font-size: 11px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 4px; color: var(--text-dim);
+  display: inline-flex; align-items: center; justify-content: center; gap: 4px;
+  font-family: inherit; cursor: pointer;
+}
+.vd-drawer-aplus .vd-fcard-cta:hover{ border-color: var(--text-mute); color: var(--text); }
+
+/* Breakdown box */
+.vd-drawer-aplus .vd-fbreak{
+  margin-top: 16px; padding: 14px 16px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.vd-drawer-aplus .vd-fbreak h4{
+  margin: 0 0 8px;
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--text-dim); font-weight: 700;
+}
+.vd-drawer-aplus .vd-fbreak dl{
+  margin: 0; display: grid; grid-template-columns: 1fr auto;
+  gap: 4px 12px; font-size: 12.5px;
+}
+.vd-drawer-aplus .vd-fbreak dt{ color: var(--text-dim); }
+.vd-drawer-aplus .vd-fbreak dd{ margin: 0; font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+.vd-drawer-aplus .vd-fbreak dt.tot,
+.vd-drawer-aplus .vd-fbreak dd.tot{
+  border-top: 1px solid var(--border-2); padding-top: 8px; margin-top: 4px;
+  font-weight: 700; font-size: 13px;
+}
+.vd-drawer-aplus .vd-fbreak dd.tot{ color: var(--text); }
+
+/* Payment tab */
+.vd-drawer-aplus .vd-pay-meta{
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px; padding: 14px 16px;
+}
+.vd-drawer-aplus .vd-pay-meta dl{
+  display: grid; grid-template-columns: 100px 1fr;
+  gap: 6px 12px; margin: 0; font-size: 12.5px;
+}
+.vd-drawer-aplus .vd-pay-meta dt{ color: var(--text-mute); font-size: 11.5px; }
+.vd-drawer-aplus .vd-pay-meta dd{ margin: 0; }
+.vd-drawer-aplus .vd-pay-meta .vd-comm{
+  color: var(--vd-green); font-weight: 700; font-family: var(--font-mono);
+}
+.vd-drawer-aplus .vd-pay-meta .vd-comm small{ color: var(--text-mute); font-weight: 500; }
+
+/* Timeline tab */
+.vd-drawer-aplus .vd-tline{
+  position: relative; padding-left: 18px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px; padding: 14px 14px 14px 32px;
+}
+.vd-drawer-aplus .vd-tline::before{
+  content: ''; position: absolute; left: 20px; top: 22px; bottom: 22px;
+  width: 2px; background: var(--border-2);
+}
+.vd-drawer-aplus .vd-tline-it{
+  position: relative; padding: 6px 0;
+}
+.vd-drawer-aplus .vd-tline-it::before{
+  content: ''; position: absolute; left: -18px; top: 10px;
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--vd-green); border: 2px solid var(--surface);
+  box-shadow: 0 0 0 1px var(--vd-green);
+}
+.vd-drawer-aplus .vd-tline-it small{
+  color: var(--text-mute); font-size: 11px;
+  font-family: var(--font-mono);
+}
+.vd-drawer-aplus .vd-tline-it b{
+  display: block; font-size: 12.5px; font-weight: 600;
+}
+
+/* responsive — KPIs em 2 cols se viewport apertado */
+@media (max-width: 1180px){
+  .vendas-aplus .vd-kpis{ grid-template-columns: repeat(2, 1fr); }
+  .vendas-aplus .vd-cmdk{ display: none; }
+}
+@media (max-width: 980px){
+  .vd-drawer-aplus.os-drawer.wide{ width: 95vw; }
+}
+
+
+/* ── F1.5 iter1: Placa Mercosul (Oficina) ── */
+.vendas-aplus .vd-client-mec{ display: flex; align-items: center; gap: 10px; }
+.vendas-aplus .vd-plate{
+  display: inline-flex; flex-direction: column; align-items: stretch;
+  width: 78px; flex-shrink: 0;
+  background: #fff;
+  border: 1px solid oklch(0.30 0 0); border-radius: 3px;
+  overflow: hidden;
+  font-family: var(--font-mono);
+  box-shadow: 0 1px 0 rgba(0,0,0,.04);
+}
+.vendas-aplus .vd-plate-top{
+  background: oklch(0.30 0.12 240); color: #fff;
+  font-size: 6px; font-weight: 700;
+  text-align: center; padding: 1px 0;
+  letter-spacing: 0.04em;
+}
+.vendas-aplus .vd-plate-num{
+  font-size: 13px; font-weight: 700; color: oklch(0.18 0 0);
+  text-align: center; padding: 3px 0;
+  letter-spacing: 0.06em;
+}
+
+/* ── F1.5 iter1: Skeleton loading rows ── */
+.vendas-aplus .vd-sk-row td{
+  padding: 12px 14px !important;
+  border-bottom: 1px solid var(--border-2);
+}
+.vendas-aplus .vd-sk-bar{
+  height: 12px; border-radius: 3px;
+  background: linear-gradient(
+    90deg,
+    var(--bg-2) 0%,
+    var(--border-2) 50%,
+    var(--bg-2) 100%
+  );
+  background-size: 200% 100%;
+  animation: vdSk 1.2s ease-in-out infinite;
+}
+@keyframes vdSk {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+/* ── F1.5 iter1: empty state com kbd hints ── */
+.vendas-aplus .os-empty{
+  padding: 40px 20px; text-align: center;
+  color: var(--text-mute); font-size: 12.5px;
+}
+.vendas-aplus .os-empty kbd{
+  display: inline-block; padding: 1px 5px; margin: 0 2px;
+  border: 1px solid var(--border); border-bottom-width: 2px; border-radius: 3px;
+  font-family: var(--font-mono); font-size: 10px;
+  background: var(--bg-2); color: var(--text-dim);
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   VENDAS · REFINO #1 KB-9.75 · FUNDAÇÃO (2026-05-15)
+   SLA pill · J/K row-nav · tree-view · cheat-sheet · ⌘K prefixos
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* ── SLA pill ── (fresco · atrasando · estourado · paga) */
+.vendas-aplus .vd-sla{
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 7px; border-radius: 4px;
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.01em; white-space: nowrap;
+}
+.vendas-aplus .vd-sla .vd-sla-ic{ font-size: 9px; line-height: 1; }
+.vendas-aplus .vd-sla-fresh   { background: oklch(0.94 0.06 145); color: oklch(0.32 0.13 145); }
+.vendas-aplus .vd-sla-warning { background: oklch(0.96 0.06 70);  color: oklch(0.42 0.13 60); }
+.vendas-aplus .vd-sla-overdue { background: oklch(0.95 0.04 25);  color: oklch(0.50 0.18 25); }
+.vendas-aplus .vd-sla-paid    { background: var(--bg-2); color: var(--text-mute); }
+
+/* SLA mini-pills no KPI A receber */
+.vendas-aplus .vd-sla-counts{
+  display: inline-flex; gap: 6px; flex-wrap: wrap;
+  margin-top: 2px;
+}
+.vendas-aplus .vd-sla-mini{
+  display: inline-flex; align-items: center;
+  font-size: 10.5px; font-weight: 600;
+  padding: 0; line-height: 1.5;
+}
+.vendas-aplus .vd-sla-mini .ic{ font-size: 8px; line-height: 1; margin-right: 4px; }
+.vendas-aplus .vd-sla-mini.fresh   { color: oklch(0.45 0.13 145); }
+.vendas-aplus .vd-sla-mini.warning { color: oklch(0.50 0.13 60); }
+.vendas-aplus .vd-sla-mini.overdue { color: oklch(0.55 0.18 25); }
+.vendas-aplus .vd-sla-mini + .vd-sla-mini::before{
+  content: "·"; margin-right: 2px; color: var(--text-mute); font-weight: 400;
+}
+
+/* ── Coluna Pagamento com SLA inline ── */
+.vendas-aplus .vd-pay .vd-pay-top{
+  display: flex; align-items: center; gap: 6px; line-height: 1.3;
+}
+.vendas-aplus .vd-pay .vd-pay-top > span:first-child{ font-weight: 600; color: var(--text); }
+.vendas-aplus .vd-pay .vd-inst{
+  font-family: var(--font-mono); font-size: 10px;
+  background: var(--bg-2); color: var(--text-mute);
+  padding: 1px 5px; border-radius: 3px;
+}
+.vendas-aplus .vd-pay .vd-pay-sla{ margin-top: 3px; }
+
+/* ── Row focused (J/K) ── */
+.vendas-aplus .vd-aplus-table .os-row.row-focused{
+  background: oklch(0.97 0.025 155);
+  box-shadow: inset 3px 0 0 var(--vd-green), inset -3px 0 0 var(--vd-green);
+  outline: none;
+}
+.vendas-aplus .vd-aplus-table .os-row.row-focused td{
+  background: oklch(0.97 0.025 155);
+}
+.vendas-aplus .vd-aplus-table .os-row.row-focused.urgent td:first-child{
+  box-shadow: inset 3px 0 0 var(--vd-bad);
+}
+
+/* favorito ★ */
+.vendas-aplus .vd-fav{
+  color: oklch(0.65 0.16 70);
+  margin-right: 3px; font-size: 11px;
+}
+
+/* ── Tree-view saved views ── */
+.vendas-aplus .vd-views-menu.vd-tree{
+  min-width: 280px;
+  padding: 6px;
+}
+.vendas-aplus .vd-tree-row{
+  display: flex; align-items: center; gap: 6px;
+  padding: 5px 8px; border-radius: 4px;
+  font-size: 12.5px; cursor: pointer; user-select: none;
+}
+.vendas-aplus .vd-tree-row:hover{ background: var(--bg-2); }
+.vendas-aplus .vd-tree-row.l0{ font-weight: 500; }
+.vendas-aplus .vd-tree-row.l1{
+  padding-left: 28px; font-size: 11.5px; color: var(--text-dim);
+}
+.vendas-aplus .vd-tree-row.active{
+  background: var(--vd-green-soft); color: var(--vd-green); font-weight: 600;
+}
+.vendas-aplus .vd-tree-row.active .ct{ background: white; color: var(--vd-green); }
+.vendas-aplus .vd-tree-arr{
+  width: 12px; flex-shrink: 0; text-align: center;
+  font-size: 10px; color: var(--text-mute);
+  transition: transform 0.12s;
+  cursor: pointer;
+}
+.vendas-aplus .vd-tree-arr.open{ transform: rotate(90deg); }
+.vendas-aplus .vd-tree-arr.empty{ visibility: hidden; }
+.vendas-aplus .vd-tree-lbl{ flex: 1; }
+.vendas-aplus .vd-tree-row .ct{
+  font-family: var(--font-mono); font-size: 10.5px;
+  background: var(--bg-2); color: var(--text-mute);
+  padding: 1px 6px; border-radius: 99px;
+}
+
+/* ── Cheat-sheet overlay (?) ── */
+.vd-cheat-bd{
+  position: fixed; inset: 0; z-index: 1000;
+  background: oklch(0 0 0 / 0.5);
+  display: grid; place-items: center;
+  padding: 24px;
+  animation: vdCheatFadeIn 0.15s ease-out;
+}
+@keyframes vdCheatFadeIn { from { opacity: 0; } to { opacity: 1; } }
+.vd-cheat{
+  background: var(--surface);
+  border-radius: 12px;
+  box-shadow: 0 24px 60px rgba(0,0,0,0.18);
+  width: 100%; max-width: 760px;
+  max-height: 86vh; overflow: auto;
+  display: flex; flex-direction: column;
+  animation: vdCheatSlideUp 0.18s ease-out;
+}
+@keyframes vdCheatSlideUp { from { transform: translateY(12px); opacity: 0; } to { transform: none; opacity: 1; } }
+.vd-cheat-h{
+  padding: 22px 26px 18px;
+  border-bottom: 1px solid var(--border);
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  grid-template-areas: "ic title x" "ic sub x";
+  gap: 2px 14px;
+  align-items: center;
+}
+.vd-cheat-ic{
+  grid-area: ic;
+  display: grid; place-items: center;
+  width: 38px; height: 38px;
+  background: var(--vd-green); color: white;
+  border-radius: 8px;
+  font-size: 19px;
+  align-self: center;
+}
+.vd-cheat-h h2{
+  grid-area: title;
+  margin: 0; font-size: 17px; font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.vd-cheat-h p{
+  grid-area: sub;
+  margin: 0; font-size: 12.5px; color: var(--text-mute);
+}
+.vd-cheat-x{
+  grid-area: x;
+  background: transparent; border: 1px solid var(--border);
+  padding: 4px 10px; border-radius: 5px;
+  cursor: pointer; color: var(--text-mute);
+  align-self: center;
+}
+.vd-cheat-x kbd{
+  font-family: var(--font-mono); font-size: 10px;
+  border: none; padding: 0; background: transparent;
+}
+.vd-cheat-grid{
+  padding: 22px 26px;
+  display: grid; grid-template-columns: 1fr 1fr; gap: 22px 32px;
+}
+.vd-cheat-sec h4{
+  margin: 0 0 10px;
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--vd-green);
+}
+.vd-cs-row{
+  display: grid; grid-template-columns: 130px 1fr; gap: 12px;
+  padding: 5px 0; align-items: center;
+  font-size: 12px; color: var(--text-dim);
+}
+.vd-cs-row + .vd-cs-row{ border-top: 1px solid var(--border-2); }
+.vd-cs-keys{ display: flex; gap: 4px; align-items: center; }
+.vd-cs-keys kbd{
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 600;
+  background: var(--surface); color: var(--text);
+  border: 1px solid var(--border); border-bottom-width: 2px;
+  border-radius: 4px;
+  padding: 2px 7px; min-width: 24px; text-align: center;
+}
+.vd-cs-plus{ font-size: 10px; color: var(--text-mute); }
+.vd-cs-lbl b{ color: var(--text); font-weight: 600; }
+.vd-cs-lbl code{
+  font-family: var(--font-mono); font-size: 10.5px;
+  background: var(--bg-2); padding: 1px 4px;
+  border-radius: 3px; color: var(--vd-green);
+}
+.vd-cheat-ft{
+  padding: 14px 26px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-2);
+  font-size: 11px; color: var(--text-mute);
+  display: flex; justify-content: space-between; gap: 12px; flex-wrap: wrap;
+}
+
+/* ── ⌘K palette: prefix hint no footer ── */
+.vendas-aplus .vd-pal-prefix{
+  display: inline-flex; gap: 6px; flex-wrap: wrap;
+  color: var(--text-mute); font-size: 10.5px;
+}
+.vendas-aplus .vd-pal-prefix kbd{
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 600;
+  background: var(--bg-2); border: 1px solid var(--border);
+  border-radius: 3px; padding: 1px 5px;
+  margin-right: 2px;
+}
+
+/* ── Responsive ≤1100px (tablet balcão) — degradação progressiva ── */
+@media (max-width: 1100px) {
+  .vendas-aplus .vd-col-commission{ display: none; }
+  .vendas-aplus .vd-cmdk{ flex: 0 1 240px; min-width: 180px; }
+  .vendas-aplus .vd-cmdk span{ font-size: 11px; }
+  .vendas-aplus .vd-aplus-table .vd-seller-info small{ display: none; }
+  .vendas-aplus .vd-stp-lbl{ display: none; } /* só dots */
+  .vendas-aplus .os-kpis{ grid-template-columns: 1fr 1fr; }
+  .vendas-aplus .os-kpi.vd-kpi-hero{ grid-column: 1 / -1; }
+}
+@media (max-width: 900px) {
+  .vendas-aplus .vd-vista button:nth-child(3),
+  .vendas-aplus .vd-vista button:nth-child(2){ display: none; } /* só Caixa */
+  .vendas-aplus .vd-pay .vd-inst{ display: none; }
+  .vendas-aplus .os-kpis{ grid-template-columns: 1fr; }
+  .vd-cheat-grid{ grid-template-columns: 1fr; }
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   VENDAS · REFINO #2 KB-9.75 · IA DENTRO DO FLUXO (2026-05-15)
+   ✦ accent roxo · 3 blocos IA · palette empty-state IA
+   ═══════════════════════════════════════════════════════════════════ */
+
+:root {
+  --vd-ai: oklch(0.52 0.20 295);
+  --vd-ai-soft: oklch(0.96 0.04 295);
+  --vd-ai-border: oklch(0.86 0.10 295);
+  --vd-ai-text: oklch(0.32 0.18 295);
+}
+
+/* ── Tab IA no drawer ── */
+.vd-drawer-aplus .vd-drawer-tab.vd-tab-ai{
+  color: var(--vd-ai); font-weight: 600;
+}
+.vd-drawer-aplus .vd-drawer-tab.vd-tab-ai.on{
+  background: var(--vd-ai-soft);
+  border-bottom-color: var(--vd-ai);
+  color: var(--vd-ai-text);
+}
+
+/* ── Painel IA · banner topo ── */
+.vd-ai-panel h3{
+  margin: 18px 0 8px;
+  font-size: 11px; font-weight: 700;
+  letter-spacing: 0.07em; text-transform: uppercase;
+  color: var(--vd-ai); opacity: 0.85;
+}
+.vd-ai-panel h3:first-of-type{ margin-top: 8px; }
+.vd-ai-banner{
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 16px;
+  background: linear-gradient(135deg, var(--vd-ai-soft), oklch(0.985 0.015 295));
+  border: 1px solid var(--vd-ai-border);
+  border-radius: 8px;
+  margin-bottom: 8px;
+}
+.vd-ai-banner-ic{
+  display: grid; place-items: center;
+  width: 32px; height: 32px;
+  background: var(--vd-ai); color: white;
+  border-radius: 7px;
+  font-size: 17px;
+  flex-shrink: 0;
+}
+.vd-ai-banner b{ display: block; font-size: 13px; color: var(--vd-ai-text); }
+.vd-ai-banner small{ display: block; font-size: 11.5px; color: var(--text-dim); line-height: 1.4; }
+
+/* ── Bloco IA genérico ── */
+.vd-ai-block{
+  background: white;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--vd-ai);
+  border-radius: 8px;
+  padding: 12px 14px;
+  margin-bottom: 4px;
+}
+.vd-ai-block.vd-ai-disabled{
+  opacity: 0.6;
+  border-left-color: var(--border);
+}
+.vd-ai-block-h{
+  display: flex; align-items: center; gap: 10px;
+}
+.vd-ai-ic{
+  display: grid; place-items: center;
+  width: 26px; height: 26px;
+  background: var(--vd-ai-soft); color: var(--vd-ai);
+  border-radius: 6px;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+.vd-ai-block-tx{ flex: 1; min-width: 0; }
+.vd-ai-block-tx b{ display: block; font-size: 12.5px; font-weight: 600; }
+.vd-ai-block-tx small{
+  display: block; font-size: 11px; color: var(--text-dim);
+  line-height: 1.45;
+}
+.vd-ai-cta{
+  background: var(--vd-ai); color: white;
+  border: none; padding: 6px 12px;
+  border-radius: 5px; font-size: 11.5px; font-weight: 600;
+  cursor: pointer; flex-shrink: 0;
+  transition: background .1s;
+}
+.vd-ai-cta:hover{ background: oklch(0.46 0.20 295); }
+.vd-ai-retry{
+  background: transparent; border: 1px solid var(--border);
+  color: var(--vd-ai);
+  width: 26px; height: 26px; border-radius: 5px;
+  cursor: pointer; font-size: 14px;
+}
+.vd-ai-retry:hover{ background: var(--vd-ai-soft); }
+
+/* ── Loader dots ── */
+.vd-ai-loader{
+  display: inline-flex; gap: 3px; align-items: center;
+  padding: 6px 10px;
+}
+.vd-ai-loader span{
+  width: 5px; height: 5px; border-radius: 50%;
+  background: var(--vd-ai);
+  animation: vdAiPulse 1.2s ease-in-out infinite;
+}
+.vd-ai-loader span:nth-child(2){ animation-delay: 0.15s; }
+.vd-ai-loader span:nth-child(3){ animation-delay: 0.30s; }
+@keyframes vdAiPulse {
+  0%, 80%, 100% { opacity: 0.25; transform: scale(0.8); }
+  40% { opacity: 1; transform: scale(1); }
+}
+
+/* ── Skeleton ── */
+.vd-ai-skel{
+  margin-top: 10px; padding: 6px 0;
+}
+.vd-ai-skel-line{
+  height: 9px; margin: 6px 0;
+  background: linear-gradient(90deg, var(--bg-2) 0%, oklch(0.94 0.005 90) 50%, var(--bg-2) 100%);
+  background-size: 200% 100%;
+  animation: vdAiShimmer 1.4s linear infinite;
+  border-radius: 3px;
+}
+@keyframes vdAiShimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+
+/* ── Output da IA ── */
+.vd-ai-out{
+  margin-top: 10px; padding: 10px 12px;
+  background: var(--vd-ai-soft);
+  border-radius: 6px;
+  font-size: 12.5px; line-height: 1.55;
+  color: var(--text);
+  white-space: pre-wrap;
+}
+.vd-ai-out.err{
+  background: oklch(0.96 0.04 25); color: oklch(0.45 0.18 25);
+  font-family: var(--font-mono); font-size: 11.5px;
+}
+
+/* ── História: stats grid ── */
+.vd-ai-history{ margin-bottom: 4px; }
+.vd-ai-stats{
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px;
+  margin-bottom: 10px;
+}
+.vd-ai-stat{
+  background: var(--bg-2);
+  border-radius: 6px;
+  padding: 8px 10px;
+  position: relative;
+}
+.vd-ai-stat.full{ grid-column: 1 / -1; }
+.vd-ai-stat small{
+  display: block; font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.05em; text-transform: uppercase;
+  color: var(--text-mute); margin-bottom: 3px;
+}
+.vd-ai-stat b{
+  font-family: var(--font-mono);
+  font-size: 13.5px; font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.vd-ai-tag{
+  position: absolute; top: 6px; right: 6px;
+  font-size: 9px; font-weight: 700; letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 1px 5px; border-radius: 99px;
+}
+.vd-ai-tag.new{
+  background: var(--vd-ai); color: white;
+}
+
+.vd-ai-prods{
+  margin: 10px 0 12px;
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+}
+.vd-ai-prods > small{
+  display: block; font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.05em; text-transform: uppercase;
+  color: var(--text-mute); margin-bottom: 6px;
+}
+.vd-ai-prods ul{ list-style: none; margin: 0; padding: 0; }
+.vd-ai-prods li{
+  display: grid; grid-template-columns: 40px 1fr auto;
+  gap: 8px; padding: 4px 0; font-size: 12px;
+  border-top: 1px solid var(--border-2);
+  align-items: center;
+}
+.vd-ai-prods li:first-child{ border-top: none; }
+.vd-ai-prods .ct{
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  color: var(--vd-ai); background: var(--vd-ai-soft);
+  padding: 1px 6px; border-radius: 99px; text-align: center;
+}
+.vd-ai-prods .px{
+  font-family: var(--font-mono); font-size: 11px; color: var(--text-mute);
+}
+
+/* ── Sugestão parseada ── */
+.vd-ai-suggest{
+  display: flex; flex-direction: column; gap: 6px;
+}
+.vd-ai-suggest-h{
+  display: flex; align-items: center; gap: 10px;
+}
+.vd-ai-suggest-ic{
+  display: grid; place-items: center;
+  width: 30px; height: 30px;
+  background: var(--vd-ai); color: white;
+  border-radius: 6px; font-size: 15px;
+  flex-shrink: 0;
+}
+.vd-ai-suggest-h b{
+  display: block; font-size: 13.5px; font-weight: 700;
+}
+.vd-ai-suggest-h small{
+  display: block; font-family: var(--font-mono);
+  font-size: 11.5px; color: var(--vd-ai);
+}
+.vd-ai-suggest p{
+  margin: 4px 0 0; font-size: 12px; line-height: 1.5;
+  color: var(--text-dim);
+  padding-left: 40px;
+}
+.vd-ai-suggest-cta{
+  align-self: flex-start;
+  margin-left: 40px; margin-top: 6px;
+  background: white; color: var(--vd-ai);
+  border: 1px solid var(--vd-ai-border);
+  padding: 5px 10px; border-radius: 5px;
+  font-size: 11.5px; font-weight: 600; cursor: pointer;
+}
+.vd-ai-suggest-cta:hover{ background: var(--vd-ai-soft); }
+
+/* ── Empty-state IA no ⌘K palette ── */
+.vendas-aplus .vd-pal-ai-wrap{
+  padding: 8px;
+}
+.vendas-aplus .vd-pal-ai-cta{
+  width: 100%;
+  display: flex; align-items: center; gap: 12px;
+  padding: 14px 14px;
+  background: linear-gradient(135deg, var(--vd-ai-soft), oklch(0.985 0.015 295));
+  border: 1px dashed var(--vd-ai-border);
+  border-radius: 8px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all .12s;
+}
+.vendas-aplus .vd-pal-ai-cta:hover{
+  border-style: solid;
+  background: linear-gradient(135deg, oklch(0.93 0.06 295), oklch(0.96 0.04 295));
+}
+.vendas-aplus .vd-pal-ai-ic{
+  display: grid; place-items: center;
+  width: 30px; height: 30px;
+  background: var(--vd-ai); color: white;
+  border-radius: 7px; font-size: 15px;
+  flex-shrink: 0;
+}
+.vendas-aplus .vd-pal-ai-tx{ flex: 1; text-align: left; }
+.vendas-aplus .vd-pal-ai-tx b{
+  display: block; font-size: 13px; font-weight: 600;
+  color: var(--vd-ai-text);
+}
+.vendas-aplus .vd-pal-ai-tx small{
+  display: block; font-size: 11.5px; color: var(--text-dim);
+}
+.vendas-aplus .vd-pal-ai-tx i{ color: var(--vd-ai); font-style: normal; font-weight: 500; }
+.vendas-aplus .vd-pal-ai-cta kbd{
+  font-family: var(--font-mono); font-size: 10px;
+  background: white; border: 1px solid var(--vd-ai-border);
+  border-bottom-width: 2px; border-radius: 4px;
+  padding: 2px 7px; color: var(--vd-ai);
+}
+
+.vendas-aplus .vd-pal-ai-loading{
+  display: flex; align-items: center; gap: 10px;
+  padding: 14px;
+  background: var(--vd-ai-soft);
+  border-radius: 8px;
+  font-size: 12.5px; color: var(--vd-ai-text);
+}
+.vendas-aplus .vd-pal-ai-dots{
+  display: inline-flex; gap: 3px; margin-left: auto;
+}
+.vendas-aplus .vd-pal-ai-dots span{
+  width: 5px; height: 5px; border-radius: 50%;
+  background: var(--vd-ai);
+  animation: vdAiPulse 1.2s ease-in-out infinite;
+}
+.vendas-aplus .vd-pal-ai-dots span:nth-child(2){ animation-delay: 0.15s; }
+.vendas-aplus .vd-pal-ai-dots span:nth-child(3){ animation-delay: 0.30s; }
+
+.vendas-aplus .vd-pal-ai-answer{
+  background: white;
+  border: 1px solid var(--vd-ai-border);
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+.vendas-aplus .vd-pal-ai-answer header{
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 8px;
+}
+.vendas-aplus .vd-pal-ai-answer header .vd-pal-ai-ic{
+  width: 22px; height: 22px; font-size: 12px; border-radius: 5px;
+}
+.vendas-aplus .vd-pal-ai-answer header b{ color: var(--vd-ai-text); font-size: 12.5px; }
+.vendas-aplus .vd-pal-ai-answer header span{
+  font-size: 11px; color: var(--text-mute); margin-left: auto;
+}
+.vendas-aplus .vd-pal-ai-answer p{
+  margin: 0; font-size: 12.5px; line-height: 1.55;
+  color: var(--text);
+}
+.vendas-aplus .vd-pal-ai-answer small{
+  display: block; margin-top: 8px;
+  font-size: 10.5px; color: var(--text-mute);
+  border-top: 1px solid var(--border-2);
+  padding-top: 6px;
+}
+
+/* ── Responsive: stats grid IA cai pra 2 cols ── */
+@media (max-width: 900px) {
+  .vd-ai-stats{ grid-template-columns: 1fr 1fr; }
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   VENDAS · REFINO #3 KB-9.75 · CURADORIA + GUIA (2026-05-15)
+   Comentários inline · histórico edições · troubleshooter · cross-link
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* ── Header note linkificada ── */
+.vd-drawer-aplus .vd-drawer-note{
+  margin: 4px 0 6px !important;
+  font-size: 12.5px; color: var(--text-dim);
+  line-height: 1.45;
+}
+
+/* ── Tab counter comentários ── */
+.vd-drawer-aplus .vd-drawer-tab-cmt{
+  margin-left: 4px;
+  font-size: 10px; font-weight: 600;
+  background: oklch(0.94 0.06 240); color: oklch(0.36 0.13 240);
+  padding: 1px 5px; border-radius: 99px;
+}
+
+/* Item card com comentários inline */
+.vd-drawer-aplus .vd-item-cur{
+  display: flex; flex-direction: column;
+  background: white; border: 1px solid var(--border);
+  border-radius: 8px; overflow: hidden;
+  transition: border-color .12s;
+}
+.vd-drawer-aplus .vd-item-cur.has-comments{
+  border-color: oklch(0.82 0.10 240);
+  background: oklch(0.99 0.015 240);
+}
+.vd-drawer-aplus .vd-item-cur.has-edit{
+  border-left: 3px solid oklch(0.62 0.13 60);
+}
+.vd-drawer-aplus .vd-item-cur.editing{
+  border-color: oklch(0.62 0.13 60);
+  background: oklch(0.98 0.01 60);
+  box-shadow: 0 0 0 3px oklch(0.95 0.05 60);
+}
+.vd-drawer-aplus .vd-item-cur .vd-item-c-main{
+  display: grid;
+  grid-template-columns: 1fr 64px 100px 130px 76px;
+  gap: 10px; align-items: center;
+  padding: 10px 12px;
+}
+.vd-drawer-aplus .vd-item-edited{
+  color: oklch(0.50 0.13 60); font-weight: 600;
+}
+.vd-drawer-aplus .vd-item-c-acts{
+  display: inline-flex; gap: 3px; justify-content: flex-end;
+}
+.vd-drawer-aplus .vd-item-input{
+  width: 100%;
+  border: 1px solid oklch(0.82 0.10 60);
+  background: white;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-family: var(--font-mono); font-size: 12px;
+  text-align: right;
+  outline: none;
+}
+.vd-drawer-aplus .vd-item-input:focus{
+  border-color: oklch(0.55 0.14 60);
+  box-shadow: 0 0 0 2px oklch(0.94 0.06 60);
+}
+.vd-drawer-aplus .vd-item-c-edit,
+.vd-drawer-aplus .vd-item-c-reset{
+  width: 26px; height: 26px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 13px; cursor: pointer;
+  color: var(--text-mute);
+  display: inline-grid; place-items: center;
+  transition: all .12s;
+}
+.vd-drawer-aplus .vd-item-c-edit:hover{
+  border-color: oklch(0.62 0.13 60);
+  color: oklch(0.50 0.13 60);
+  background: oklch(0.96 0.05 60);
+}
+.vd-drawer-aplus .vd-item-c-edit.on{
+  background: oklch(0.62 0.13 60); color: white;
+  border-color: oklch(0.62 0.13 60);
+}
+.vd-drawer-aplus .vd-item-c-reset{
+  color: oklch(0.50 0.13 60); border-color: oklch(0.85 0.08 60);
+}
+.vd-drawer-aplus .vd-item-c-reset:hover{
+  background: oklch(0.94 0.06 60);
+}
+.vd-drawer-aplus .vd-item-diff{
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 10px; font-weight: 600;
+  margin-top: 2px;
+}
+.vd-drawer-aplus .vd-item-diff.pos{ color: oklch(0.50 0.13 145); }
+.vd-drawer-aplus .vd-item-diff.neg{ color: oklch(0.55 0.18 25); }
+
+/* Total com edição */
+.vd-drawer-aplus .vd-edits-tag{
+  margin-left: 6px;
+  font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  color: oklch(0.50 0.13 60);
+  background: oklch(0.96 0.05 60);
+  padding: 1px 6px; border-radius: 99px;
+}
+.vd-drawer-aplus .vd-total-orig{
+  color: var(--text-mute); font-weight: 500;
+  text-decoration: line-through;
+  margin-right: 8px;
+  font-size: 13px;
+}
+.vd-drawer-aplus .vd-total-new{ font-weight: 700; }
+.vd-drawer-aplus .vd-total-delta{
+  display: inline-block; margin-left: 8px;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  padding: 2px 7px; border-radius: 4px;
+}
+.vd-drawer-aplus .vd-total-delta.pos{ background: oklch(0.94 0.06 145); color: oklch(0.32 0.13 145); }
+.vd-drawer-aplus .vd-total-delta.neg{ background: oklch(0.95 0.04 25); color: oklch(0.50 0.18 25); }
+.vd-drawer-aplus .vd-item-c-comm{
+  width: 28px; height: 28px;
+  background: transparent; border: 1px solid var(--border);
+  border-radius: 5px;
+  font-size: 13px; cursor: pointer;
+  position: relative;
+  display: grid; place-items: center;
+  color: var(--text-mute);
+  transition: all .12s;
+}
+.vd-drawer-aplus .vd-item-c-comm:hover{
+  border-color: oklch(0.55 0.13 240);
+  color: oklch(0.55 0.13 240);
+  background: oklch(0.96 0.04 240);
+}
+.vd-drawer-aplus .vd-item-c-comm.on{
+  background: oklch(0.55 0.13 240); color: white;
+  border-color: oklch(0.55 0.13 240);
+}
+.vd-drawer-aplus .vd-item-c-comm.has{
+  background: oklch(0.94 0.06 240); color: oklch(0.36 0.13 240);
+  border-color: oklch(0.86 0.08 240);
+}
+.vd-drawer-aplus .vd-item-c-comm .ct{
+  position: absolute; top: -5px; right: -5px;
+  background: oklch(0.55 0.13 240); color: white;
+  font-size: 9px; font-weight: 700;
+  padding: 1px 4px; border-radius: 99px;
+  min-width: 14px; text-align: center;
+  line-height: 1.4;
+}
+.vd-drawer-aplus .vd-item-thread{
+  border-top: 1px solid var(--border-2);
+  background: oklch(0.985 0.012 240);
+  padding: 10px 14px;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.vd-drawer-aplus .vd-item-comment{
+  background: white; border: 1px solid var(--border-2);
+  border-radius: 6px; padding: 8px 10px;
+}
+.vd-drawer-aplus .vd-item-comment-h{
+  display: flex; align-items: center; gap: 6px;
+  margin-bottom: 4px;
+}
+.vd-drawer-aplus .vd-item-comment-av{
+  display: grid; place-items: center;
+  width: 18px; height: 18px;
+  background: oklch(0.55 0.13 240); color: white;
+  border-radius: 50%; font-size: 10px; font-weight: 700;
+}
+.vd-drawer-aplus .vd-item-comment-h b{ font-size: 12px; font-weight: 600; }
+.vd-drawer-aplus .vd-item-comment-when{
+  font-size: 10.5px; color: var(--text-mute);
+}
+.vd-drawer-aplus .vd-item-comment-x{
+  margin-left: auto;
+  background: transparent; border: none;
+  color: var(--text-mute); font-size: 14px;
+  cursor: pointer; padding: 0 4px;
+}
+.vd-drawer-aplus .vd-item-comment-x:hover{ color: var(--vd-bad); }
+.vd-drawer-aplus .vd-item-comment p{
+  margin: 0; font-size: 12px; line-height: 1.5;
+  color: var(--text);
+}
+.vd-drawer-aplus .vd-item-comment-new{
+  background: white; border: 1px solid oklch(0.82 0.10 240);
+  border-radius: 6px; padding: 8px;
+}
+.vd-drawer-aplus .vd-item-comment-new textarea{
+  width: 100%; border: none; outline: none; resize: vertical;
+  font-family: inherit; font-size: 12px; line-height: 1.5;
+  background: transparent;
+  min-height: 50px;
+}
+.vd-drawer-aplus .vd-item-comment-row{
+  display: flex; align-items: center; gap: 8px;
+  margin-top: 6px;
+}
+.vd-drawer-aplus .vd-item-comment-row small{
+  flex: 1; font-size: 10.5px; color: var(--text-mute);
+}
+
+/* ── Audit trail ── */
+.vd-drawer-aplus .vd-audit-h{
+  display: flex; align-items: baseline; gap: 10px;
+  margin-bottom: 14px;
+}
+.vd-drawer-aplus .vd-audit-h h4{
+  margin: 0; font-size: 14px; font-weight: 700;
+}
+.vd-drawer-aplus .vd-audit-h small{
+  font-size: 11px; color: var(--text-mute);
+}
+.vd-drawer-aplus .vd-audit-list{
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column;
+  gap: 0;
+}
+.vd-drawer-aplus .vd-audit-row{
+  display: grid; grid-template-columns: 28px 1fr;
+  gap: 10px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-2);
+  position: relative;
+}
+.vd-drawer-aplus .vd-audit-row:last-child{ border-bottom: none; }
+.vd-drawer-aplus .vd-audit-row::before{
+  content: ''; position: absolute;
+  left: 13px; top: 30px; bottom: -2px;
+  width: 2px; background: var(--border-2);
+}
+.vd-drawer-aplus .vd-audit-row:last-child::before{ display: none; }
+.vd-drawer-aplus .vd-audit-ic{
+  display: grid; place-items: center;
+  width: 26px; height: 26px;
+  border-radius: 50%;
+  background: var(--bg-2); color: var(--text-mute);
+  font-size: 12px; font-weight: 700;
+  position: relative; z-index: 1;
+}
+.vd-drawer-aplus .vd-audit-create .vd-audit-ic{ background: oklch(0.94 0.06 145); color: oklch(0.32 0.13 145); }
+.vd-drawer-aplus .vd-audit-edit   .vd-audit-ic{ background: oklch(0.94 0.06 240); color: oklch(0.36 0.13 240); }
+.vd-drawer-aplus .vd-audit-fiscal .vd-audit-ic{ background: oklch(0.96 0.05 70); color: oklch(0.42 0.13 60); }
+.vd-drawer-aplus .vd-audit-reject .vd-audit-ic{ background: oklch(0.96 0.05 25); color: var(--vd-bad); }
+.vd-drawer-aplus .vd-audit-body header{
+  display: flex; align-items: baseline; gap: 8px;
+  margin-bottom: 2px;
+}
+.vd-drawer-aplus .vd-audit-body header b{ font-size: 12.5px; font-weight: 600; }
+.vd-drawer-aplus .vd-audit-action{
+  font-size: 11px; color: var(--text-mute);
+}
+.vd-drawer-aplus .vd-audit-body header time{
+  margin-left: auto;
+  font-family: var(--font-mono); font-size: 10.5px;
+  color: var(--text-mute);
+}
+.vd-drawer-aplus .vd-audit-body p{
+  margin: 0; font-size: 12px; color: var(--text-dim); line-height: 1.45;
+}
+.vd-drawer-aplus .vd-audit-diff{
+  margin-top: 5px;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: 11px;
+  background: var(--bg-2); padding: 3px 8px; border-radius: 4px;
+}
+.vd-drawer-aplus .vd-audit-diff .diff-from{ color: var(--text-mute); text-decoration: line-through; }
+.vd-drawer-aplus .vd-audit-diff .diff-arr{ color: var(--text-mute); }
+.vd-drawer-aplus .vd-audit-diff .diff-to{ color: var(--text); font-weight: 600; }
+.vd-drawer-aplus .vd-audit-diff .diff-pct.pos{ color: oklch(0.50 0.13 145); }
+.vd-drawer-aplus .vd-audit-diff .diff-pct.neg{ color: var(--vd-bad); }
+
+/* ── Troubleshooter button ── */
+.vd-drawer-aplus .vd-trouble-btn{
+  display: inline-flex; align-items: center; gap: 8px;
+  background: oklch(0.96 0.06 60); color: oklch(0.42 0.13 60);
+  border: 1px solid oklch(0.85 0.10 60);
+  padding: 5px 10px 5px 5px; border-radius: 6px;
+  font-family: inherit; font-size: 11.5px; font-weight: 600;
+  cursor: pointer;
+  margin-right: auto;
+  transition: all .12s;
+}
+.vd-drawer-aplus .vd-trouble-btn:hover{
+  background: oklch(0.93 0.08 60);
+  border-color: oklch(0.72 0.13 60);
+}
+.vd-drawer-aplus .vd-trouble-ic{
+  display: grid; place-items: center;
+  width: 22px; height: 22px;
+  background: oklch(0.62 0.13 60); color: white;
+  border-radius: 4px;
+  font-size: 14px; font-weight: 700;
+}
+.vd-drawer-aplus .vd-trouble-lbl{ font-size: 12px; }
+.vd-drawer-aplus .vd-trouble-lbl b{ font-weight: 700; }
+.vd-drawer-aplus .vd-trouble-ct{
+  font-family: var(--font-mono); font-size: 9.5px;
+  background: white; color: var(--text-mute);
+  padding: 1px 6px; border-radius: 99px;
+}
+
+/* ── Cross-link pills (#V #OS #CLI #orc) ── */
+.vd-link{
+  display: inline-flex; align-items: center;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  padding: 1px 6px; border-radius: 4px;
+  text-decoration: none; line-height: 1.5;
+  transition: opacity .12s;
+}
+.vd-link:hover{ opacity: 0.75; }
+.vd-link-venda{ background: var(--vd-green-soft); color: var(--vd-green); }
+.vd-link-os   { background: oklch(0.94 0.06 240); color: oklch(0.36 0.13 240); }
+.vd-link-cli  { background: oklch(0.94 0.06 295); color: oklch(0.36 0.13 295); }
+.vd-link-orc  { background: oklch(0.96 0.05 70);  color: oklch(0.42 0.13 60); }
+.vd-link-bol  { background: oklch(0.95 0.05 200); color: oklch(0.38 0.13 200); }
+.vd-link-compra{ background: oklch(0.95 0.05 30); color: oklch(0.42 0.13 30); }
+.vd-link-fin-rec{ background: oklch(0.94 0.05 145); color: oklch(0.36 0.13 145); }
+.vd-link-fin-pay{ background: oklch(0.95 0.04 25); color: oklch(0.50 0.18 25); }
+.vd-link-ref  { background: var(--bg-2); color: var(--text); }
+
+/* ── Lançamentos financeiros vinculados (drawer venda) ── */
+.vd-drawer-aplus .vd-fin-list{
+  display: flex; flex-direction: column; gap: 6px;
+}
+.vd-drawer-aplus .vd-fin-link{
+  display: grid;
+  grid-template-columns: 100px 1fr 110px 90px;
+  align-items: center; gap: 10px;
+  padding: 8px 12px;
+  background: var(--bg-2);
+  border-radius: 6px;
+  border-left: 3px solid;
+  font-size: 12px;
+}
+.vd-drawer-aplus .vd-fin-link.rec{ border-left-color: oklch(0.55 0.13 145); }
+.vd-drawer-aplus .vd-fin-link.pay{ border-left-color: oklch(0.55 0.18 25); }
+.vd-drawer-aplus .vd-fin-link.paid{ opacity: 0.70; }
+.vd-drawer-aplus .vd-fin-pill{
+  display: inline-flex; align-items: center; gap: 3px;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 700;
+  padding: 2px 8px; border-radius: 4px;
+}
+.vd-drawer-aplus .vd-fin-pill.rec{ background: oklch(0.94 0.05 145); color: oklch(0.32 0.13 145); }
+.vd-drawer-aplus .vd-fin-pill.pay{ background: oklch(0.95 0.04 25); color: oklch(0.50 0.18 25); }
+.vd-drawer-aplus .vd-fin-meta{ font-size: 11.5px; color: var(--text-dim); }
+.vd-drawer-aplus .vd-fin-amount{
+  font-family: var(--font-mono); font-weight: 600;
+  text-align: right;
+}
+.vd-drawer-aplus .vd-fin-status{
+  font-family: var(--font-mono); font-size: 10.5px;
+  text-align: center; padding: 2px 8px; border-radius: 4px;
+}
+.vd-drawer-aplus .vd-fin-status.open{ background: oklch(0.96 0.06 60); color: oklch(0.42 0.13 60); }
+.vd-drawer-aplus .vd-fin-status.paid{ background: var(--bg-2); color: var(--text-mute); }
+.vd-drawer-aplus .vd-fin-status.late{ background: oklch(0.95 0.04 25); color: oklch(0.55 0.18 25); }
+
+/* ═══════════════════════════════════════════════════════════════════
+   VENDAS · REFINO #4 KB-9.75 · DISTRIBUIÇÃO (2026-05-15)
+   Transcript PDF · Modo apresentação · Mensagem variáveis · Favoritas
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* ── Favoritas no tree-view ── */
+.vendas-aplus .vd-tree-row.vd-tree-fav .vd-tree-lbl{
+  color: oklch(0.55 0.16 70);
+}
+.vendas-aplus .vd-tree-row.vd-tree-fav.active{
+  background: oklch(0.96 0.06 70);
+  color: oklch(0.42 0.13 60);
+}
+.vendas-aplus .vd-tree-row.vd-tree-fav.active .vd-tree-lbl{ color: oklch(0.42 0.13 60); }
+.vendas-aplus .vd-tree-row.vd-tree-fav small{
+  font-size: 10px; font-weight: 400;
+  color: var(--text-mute); margin-left: 4px;
+}
+
+/* ── Botão Apresentar no drawer footer ── */
+.vd-drawer-aplus .vd-btn-present{
+  color: oklch(0.42 0.13 295); font-weight: 600;
+}
+.vd-drawer-aplus .vd-btn-present:hover{
+  background: oklch(0.96 0.05 295);
+  color: oklch(0.32 0.18 295);
+}
+
+/* ══════════════════════════════════════════
+   TRANSCRIPT PDF — overlay + print layout
+   ══════════════════════════════════════════ */
+.vd-trans-bd{
+  position: fixed; inset: 0; z-index: 1100;
+  background: oklch(0.3 0.005 240 / 0.6);
+  overflow: auto; padding: 0;
+}
+.vd-trans-toolbar{
+  position: sticky; top: 0; z-index: 10;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 10px 18px;
+  display: flex; align-items: center; gap: 14px;
+}
+.vd-trans-toolbar .vd-trans-tag{
+  flex: 1; text-align: center;
+  font-size: 12px; color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+.vd-trans-page{
+  background: white; color: #1a1a1a;
+  width: 794px; /* A4 ~96dpi */
+  min-height: 1123px;
+  margin: 24px auto;
+  padding: 50px 60px 80px;
+  box-shadow: 0 8px 40px rgba(0,0,0,0.15);
+  font-family: var(--font-sans);
+  font-size: 12px; line-height: 1.55;
+}
+
+.vd-trans-h{
+  display: flex; justify-content: space-between;
+  align-items: flex-start;
+  padding-bottom: 18px;
+  border-bottom: 2px solid #1a1a1a;
+  margin-bottom: 22px;
+}
+.vd-trans-brand{
+  font-size: 22px; font-weight: 800; letter-spacing: -0.02em;
+}
+.vd-trans-brand-sub{
+  font-size: 11px; font-weight: 500; color: #555;
+  letter-spacing: 0.04em; text-transform: uppercase;
+}
+.vd-trans-meta-co{ text-align: right; font-size: 10.5px; color: #555; line-height: 1.5; }
+
+.vd-trans-title{ margin-bottom: 24px; }
+.vd-trans-title h1{
+  margin: 0 0 4px; font-size: 22px; font-weight: 700;
+  letter-spacing: -0.015em;
+}
+.vd-trans-title h1 small{
+  font-family: var(--font-mono);
+  font-size: 14px; color: #777;
+  margin-left: 8px;
+}
+.vd-trans-title span{ font-size: 10.5px; color: #777; }
+
+.vd-trans-grid{
+  display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px;
+  margin-bottom: 24px;
+}
+.vd-trans-block{
+  border: 1px solid #d8d8d8; border-radius: 4px;
+  padding: 10px 14px;
+}
+.vd-trans-block small{
+  display: block;
+  font-size: 9.5px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  color: #888; margin-bottom: 4px;
+}
+.vd-trans-block h3{
+  margin: 0 0 4px; font-size: 14px; font-weight: 700;
+}
+.vd-trans-block p{
+  margin: 0; font-size: 11px; color: #555;
+}
+.vd-trans-block.vd-trans-total{
+  background: #f4f4f0;
+  border-color: #1a1a1a;
+}
+.vd-trans-block.vd-trans-total h3{ font-family: var(--font-mono); font-size: 18px; }
+
+.vd-trans-section{
+  margin-bottom: 24px; page-break-inside: avoid;
+}
+.vd-trans-section h2{
+  margin: 0 0 10px;
+  font-size: 13px; font-weight: 700; letter-spacing: -0.005em;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #1a1a1a;
+}
+
+.vd-trans-items, .vd-trans-fiscal, .vd-trans-audit{
+  width: 100%; border-collapse: collapse; font-size: 11px;
+}
+.vd-trans-items th, .vd-trans-items td,
+.vd-trans-fiscal th, .vd-trans-fiscal td,
+.vd-trans-audit th, .vd-trans-audit td{
+  border-bottom: 1px solid #e8e8e8;
+  padding: 6px 8px; text-align: left; vertical-align: top;
+}
+.vd-trans-items thead th{
+  background: #f4f4f0;
+  font-size: 9.5px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.05em; color: #555;
+}
+.vd-trans-items .num, .vd-trans-fiscal .num{ text-align: right; font-variant-numeric: tabular-nums; }
+.vd-trans-items .strong, .vd-trans-fiscal .strong{ font-weight: 700; }
+.vd-trans-items .mono, .vd-trans-fiscal .mono, .vd-trans-audit .mono{ font-family: var(--font-mono); font-size: 10px; }
+.vd-trans-items tfoot td{ border-top: 2px solid #1a1a1a; padding-top: 8px; font-weight: 600; }
+
+.vd-trans-fiscal th{
+  width: 130px;
+  background: #f4f4f0;
+  font-weight: 600;
+  border-right: 1px solid #e8e8e8;
+}
+.vd-trans-fiscal .small{ font-size: 9.5px; color: #888; margin-top: 2px; }
+.vd-trans-fiscal .fail{ color: oklch(0.45 0.18 25); margin-top: 4px; }
+
+.vd-trans-comment-block{ margin-bottom: 12px; }
+.vd-trans-comment-item{
+  display: block; font-size: 11.5px; font-weight: 600; color: #1a1a1a;
+  background: #f4f4f0;
+  padding: 4px 8px; margin-bottom: 4px;
+  border-left: 3px solid #888;
+}
+.vd-trans-comment{
+  padding: 6px 12px; border-bottom: 1px dashed #e0e0e0;
+}
+.vd-trans-comment .mono{ font-family: var(--font-mono); font-size: 9.5px; color: #888; }
+.vd-trans-comment p{ margin: 2px 0 0; font-size: 11px; }
+
+.vd-trans-sign{
+  display: grid; grid-template-columns: 1fr 1fr; gap: 60px;
+  margin-top: 60px; margin-bottom: 24px;
+}
+.vd-trans-sign-line{
+  border-top: 1px solid #1a1a1a;
+  margin-bottom: 6px;
+}
+.vd-trans-sign small{
+  font-size: 10px; color: #555;
+}
+.vd-trans-foot{
+  text-align: center;
+  border-top: 1px solid #d8d8d8;
+  padding-top: 12px; margin-top: 20px;
+  font-size: 9.5px; color: #888;
+}
+
+/* @media print — só mostra o transcript */
+@media print {
+  body.vd-print-mode > *:not(.vd-trans-bd){ display: none !important; }
+  body.vd-print-mode .vd-trans-bd{
+    position: static !important; background: white !important; padding: 0 !important; overflow: visible !important;
+  }
+  body.vd-print-mode .vd-trans-toolbar{ display: none !important; }
+  body.vd-print-mode .vd-trans-page{
+    margin: 0 !important; box-shadow: none !important; width: 100% !important;
+    padding: 0 24px !important;
+  }
+}
+
+/* ══════════════════════════════════════════
+   MODO APRESENTAÇÃO — fullscreen
+   ══════════════════════════════════════════ */
+.vd-pres-overlay{
+  position: fixed; inset: 0; z-index: 1200;
+  background: linear-gradient(135deg, oklch(0.16 0.005 240), oklch(0.20 0.01 200));
+  color: white;
+  display: flex; flex-direction: column;
+  animation: vdPresFade 0.25s ease-out;
+}
+@keyframes vdPresFade { from { opacity: 0; } to { opacity: 1; } }
+
+.vd-pres-top{
+  display: flex; align-items: center; gap: 14px;
+  padding: 16px 28px;
+  border-bottom: 1px solid oklch(1 0 0 / 0.08);
+}
+.vd-pres-brand{
+  flex: 1;
+  font-size: 11px; font-weight: 700;
+  letter-spacing: 0.15em; text-transform: uppercase;
+  color: oklch(1 0 0 / 0.5);
+}
+.vd-pres-counter{
+  font-family: var(--font-mono);
+  font-size: 11.5px; color: oklch(1 0 0 / 0.5);
+}
+.vd-pres-close{
+  background: transparent; border: 1px solid oklch(1 0 0 / 0.2);
+  color: white; width: 32px; height: 32px;
+  border-radius: 6px; cursor: pointer;
+  font-size: 18px; line-height: 1;
+}
+.vd-pres-close:hover{ background: oklch(1 0 0 / 0.08); }
+
+.vd-pres-stage{
+  flex: 1;
+  display: grid; place-items: center;
+  padding: 40px 80px;
+}
+.vd-pres-slide{ max-width: 900px; width: 100%; text-align: center; }
+.vd-pres-eyebrow{
+  display: block;
+  font-size: 13px; font-weight: 600;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  color: oklch(0.65 0.13 145);
+  margin-bottom: 16px;
+}
+.vd-pres-slide h1{
+  font-size: 64px; font-weight: 700;
+  letter-spacing: -0.025em; line-height: 1.05;
+  margin: 0 0 18px;
+}
+.vd-pres-slide > p{
+  font-size: 22px; font-weight: 400; line-height: 1.45;
+  color: oklch(1 0 0 / 0.7); max-width: 700px; margin: 0 auto;
+}
+.vd-pres-chips{
+  display: flex; gap: 10px; justify-content: center; margin-top: 36px; flex-wrap: wrap;
+}
+.vd-pres-chip{
+  background: oklch(1 0 0 / 0.08);
+  border: 1px solid oklch(1 0 0 / 0.12);
+  border-radius: 99px;
+  padding: 8px 18px;
+  font-size: 14px; font-weight: 500;
+}
+.vd-pres-chip.primary{
+  background: oklch(0.50 0.14 155);
+  border-color: oklch(0.55 0.14 155);
+  color: white;
+}
+
+.vd-pres-items ul{
+  list-style: none; margin: 28px 0 0; padding: 0;
+  text-align: left;
+  display: flex; flex-direction: column; gap: 14px;
+}
+.vd-pres-items li{
+  display: flex; align-items: center; gap: 20px;
+  padding: 20px 26px;
+  background: oklch(1 0 0 / 0.05);
+  border: 1px solid oklch(1 0 0 / 0.08);
+  border-radius: 12px;
+}
+.vd-pres-item-l{ flex: 1; }
+.vd-pres-item-l b{ display: block; font-size: 22px; font-weight: 600; margin-bottom: 4px; }
+.vd-pres-item-l small{ font-size: 14px; color: oklch(1 0 0 / 0.55); }
+.vd-pres-item-r{
+  font-family: var(--font-mono);
+  font-size: 26px; font-weight: 700;
+}
+
+.vd-pres-amount{
+  font-family: var(--font-mono);
+  font-size: 96px; font-weight: 700;
+  letter-spacing: -0.03em; line-height: 1;
+  color: oklch(0.85 0.10 145);
+  margin: 12px 0 32px;
+}
+.vd-pres-payment{
+  display: flex; justify-content: space-between; align-items: center;
+  max-width: 500px; margin: 12px auto;
+  padding: 14px 24px;
+  background: oklch(1 0 0 / 0.05);
+  border-radius: 10px;
+  font-size: 18px;
+}
+.vd-pres-payment span{ color: oklch(1 0 0 / 0.5); }
+.vd-pres-payment b{ font-weight: 600; }
+
+.vd-pres-next ol{
+  text-align: left; max-width: 600px; margin: 28px auto 0;
+  padding: 0; list-style: none; counter-reset: pres;
+}
+.vd-pres-next li{
+  counter-increment: pres;
+  padding: 16px 0 16px 56px;
+  font-size: 22px;
+  border-top: 1px solid oklch(1 0 0 / 0.08);
+  position: relative;
+}
+.vd-pres-next li::before{
+  content: counter(pres);
+  position: absolute; left: 0; top: 14px;
+  width: 36px; height: 36px; border-radius: 50%;
+  background: oklch(0.50 0.14 155); color: white;
+  display: grid; place-items: center;
+  font-family: var(--font-mono); font-size: 14px; font-weight: 700;
+}
+.vd-pres-next li:first-child{ border-top: none; }
+.vd-pres-foot-note{
+  margin-top: 32px;
+  font-size: 14px; color: oklch(1 0 0 / 0.5);
+}
+
+.vd-pres-bot{
+  display: flex; align-items: center; gap: 18px; justify-content: center;
+  padding: 20px 28px;
+  border-top: 1px solid oklch(1 0 0 / 0.08);
+}
+.vd-pres-bot button{
+  background: oklch(1 0 0 / 0.08);
+  border: 1px solid oklch(1 0 0 / 0.12);
+  color: white;
+  width: 44px; height: 44px;
+  border-radius: 8px;
+  font-size: 18px; cursor: pointer;
+}
+.vd-pres-bot button:hover:not(:disabled){ background: oklch(1 0 0 / 0.16); }
+.vd-pres-bot button:disabled{ opacity: 0.3; cursor: not-allowed; }
+.vd-pres-dots{ display: flex; gap: 8px; }
+.vd-pres-dot{
+  width: 8px; height: 8px; border-radius: 50%;
+  background: oklch(1 0 0 / 0.2); cursor: pointer;
+  transition: all .15s;
+}
+.vd-pres-dot.on{ background: oklch(0.65 0.14 145); width: 24px; border-radius: 99px; }
+
+/* ══════════════════════════════════════════
+   MENSAGEM — variáveis live no Pagamento
+   ══════════════════════════════════════════ */
+.vd-drawer-aplus .vd-msg{
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px 16px;
+}
+.vd-drawer-aplus .vd-msg-h{
+  display: flex; align-items: baseline; gap: 12px;
+  margin-bottom: 12px;
+}
+.vd-drawer-aplus .vd-msg-h h4{ margin: 0; font-size: 14px; font-weight: 700; }
+.vd-drawer-aplus .vd-msg-tpls{
+  margin-left: auto;
+  display: flex; gap: 4px;
+}
+.vd-drawer-aplus .vd-msg-tpl{
+  background: var(--bg-2); border: 1px solid transparent;
+  padding: 4px 9px; border-radius: 4px;
+  font-family: inherit; font-size: 11px; cursor: pointer;
+  color: var(--text-dim);
+}
+.vd-drawer-aplus .vd-msg-tpl:hover{ background: var(--border-2); }
+.vd-drawer-aplus .vd-msg-tpl.on{
+  background: var(--vd-green-soft); color: var(--vd-green);
+  border-color: var(--vd-green); font-weight: 600;
+}
+
+.vd-drawer-aplus .vd-msg-vars{
+  display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
+  padding: 8px 0;
+  border-bottom: 1px dashed var(--border-2);
+  margin-bottom: 12px;
+}
+.vd-drawer-aplus .vd-msg-vars small{
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.05em; text-transform: uppercase;
+  color: var(--text-mute); margin-right: 4px;
+}
+.vd-drawer-aplus .vd-msg-var{
+  display: inline-flex; align-items: center; gap: 4px;
+  background: var(--bg-2);
+  padding: 2px 7px; border-radius: 4px;
+  font-size: 10.5px; line-height: 1.4;
+}
+.vd-drawer-aplus .vd-msg-var .k{
+  font-family: var(--font-mono);
+  color: oklch(0.36 0.13 295);
+  font-weight: 600;
+}
+.vd-drawer-aplus .vd-msg-var .arr{ color: var(--text-mute); }
+.vd-drawer-aplus .vd-msg-var .v{
+  color: var(--text); font-weight: 500;
+  max-width: 140px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+
+.vd-drawer-aplus .vd-msg-preview{
+  background: oklch(0.97 0.025 145);
+  padding: 14px; border-radius: 8px;
+  margin-bottom: 10px;
+}
+.vd-drawer-aplus .vd-msg-bubble{
+  background: oklch(0.95 0.05 145);
+  border-radius: 8px 8px 8px 2px;
+  padding: 10px 14px;
+  font-size: 12.5px; line-height: 1.55;
+  color: oklch(0.20 0.04 145);
+  max-width: 92%;
+  white-space: pre-wrap;
+}
+.vd-drawer-aplus .vd-msg-actions{
+  display: flex; gap: 8px; justify-content: flex-end;
+}
+
+/* ══════════════════════════════════════════
+   ART-SLOT (preview da arte por item)
+   ══════════════════════════════════════════ */
+.vd-art{
+  width: 56px; height: 56px;
+  border-radius: 6px;
+  background: var(--bg-2);
+  position: relative;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.vd-art.empty{
+  border: 1.5px dashed var(--border);
+}
+.vd-art.empty.drag{
+  border-color: var(--vd-green); background: var(--vd-green-soft);
+}
+.vd-art.has{
+  border: 1px solid var(--border);
+}
+.vd-art img{
+  width: 100%; height: 100%; object-fit: cover;
+  display: block;
+}
+.vd-art-empty{
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  width: 100%; height: 100%;
+  cursor: pointer;
+  color: var(--text-mute);
+}
+.vd-art-empty:hover{ background: var(--border-2); }
+.vd-art-ic{ font-size: 18px; opacity: 0.5; line-height: 1; }
+.vd-art-empty small{
+  font-size: 8.5px; line-height: 1.1;
+  padding: 0 4px; text-align: center;
+  margin-top: 3px;
+}
+.vd-art-empty input{ display: none; }
+.vd-art-rm{
+  position: absolute; top: 3px; right: 3px;
+  background: rgba(0,0,0,0.6); color: white;
+  border: none; width: 18px; height: 18px;
+  border-radius: 50%; font-size: 12px;
+  cursor: pointer; line-height: 1;
+  opacity: 0; transition: opacity .15s;
+}
+.vd-art:hover .vd-art-rm{ opacity: 1; }
+
+/* ── Refino #4 polish · Dropdown "Visões ▾" (substitui topnav) ── */
+.vendas-aplus .vd-visoes{ position: relative; }
+.vendas-aplus .vd-visoes-btn{
+  background: var(--surface); border: 1px solid var(--border);
+  padding: 6px 10px; border-radius: 5px;
+  font-family: inherit; font-size: 12px; font-weight: 500;
+  cursor: pointer; color: var(--text-dim);
+  display: inline-flex; align-items: center; gap: 5px;
+}
+.vendas-aplus .vd-visoes-btn::after{
+  content: '▾'; font-size: 9px; color: var(--text-mute); margin-left: 2px;
+}
+.vendas-aplus .vd-visoes-btn:hover{ border-color: var(--text-mute); color: var(--text); }
+
+.vendas-aplus .vd-visoes-menu{
+  position: absolute; top: calc(100% + 4px); right: 0;
+  min-width: 240px; background: var(--surface);
+  border: 1px solid var(--border); border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.08);
+  padding: 6px; z-index: 30;
+}
+.vendas-aplus .vd-visoes-grp{
+  font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--text-mute);
+  padding: 6px 10px 4px;
+}
+.vendas-aplus .vd-visoes-item{
+  display: flex; align-items: center; gap: 8px;
+  padding: 7px 10px; border-radius: 4px;
+  font-size: 12.5px; cursor: pointer;
+}
+.vendas-aplus .vd-visoes-item:hover{ background: var(--bg-2); }
+.vendas-aplus .vd-visoes-item.active{
+  background: var(--vd-green-soft); color: var(--vd-green); font-weight: 600;
+}
+.vendas-aplus .vd-visoes-dot{
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--vd-green);
+}
+.vendas-aplus .vd-visoes-dot.pdv{ background: oklch(0.55 0.13 240); }
+.vendas-aplus .vd-visoes-here{
+  margin-left: auto; font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--vd-green); opacity: 0.7;
+}
+.vendas-aplus .vd-visoes-sep{
+  height: 1px; background: var(--border-2); margin: 4px -6px;
+}
+.vendas-aplus .vd-visoes-item.primary{
+  color: oklch(0.36 0.13 240); font-weight: 600;
+}
+.vendas-aplus .vd-visoes-item.primary:hover{ background: oklch(0.96 0.04 240); }
+.vendas-aplus .vd-visoes-item kbd{
+  margin-left: auto;
+  font-family: var(--font-mono); font-size: 10px;
+  background: var(--bg-2); border: 1px solid var(--border);
+  border-bottom-width: 2px; border-radius: 3px;
+  padding: 1px 6px;
+}
+
+/* Esconder a antiga topnav (vendas-extras) — agora vive em "Visões ▾" */
+.vendas-module-no-subnav .vm-subnav{ display: none; }
+
+/* ── Vista → "Foco" label inline ── */
+.vendas-aplus .vd-vista{ display: inline-flex; align-items: center; }
+.vendas-aplus .vd-vista-lbl{
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--text-mute);
+  padding: 0 8px 0 4px;
+}
+
+/* ── Density toggle inline na FilterBar ── */
+.fin-toolbar .fin-density{
+  display: inline-flex; align-items: center;
+  background: var(--bg-2);
+  border-radius: 6px;
+  padding: 2px;
+  gap: 0;
+  margin-right: 8px;
+}
+.fin-toolbar .fin-density button{
+  border: none; background: transparent;
+  width: 30px; height: 26px;
+  border-radius: 4px;
+  color: var(--text-mute); cursor: pointer;
+  transition: all .12s;
+  display: inline-grid; place-items: center;
+}
+.fin-toolbar .fin-density button:hover{ color: var(--text); background: oklch(0 0 0 / 0.04); }
+.fin-toolbar .fin-density button.on{
+  background: var(--surface); color: var(--accent, oklch(0.50 0.13 220));
+  box-shadow: 0 1px 2px rgba(0,0,0,0.06);
+}
+.fin-toolbar .fin-density button svg{ display: block; }
+
+/* ── Filter checkbox (4 lifecycle states — multi-select) ── */
+.fin-toolbar .fin-filter-cb{
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 10px; border-radius: 5px;
+  border: 1px solid var(--border); background: var(--surface);
+  font-size: 12px; font-weight: 500; color: var(--text-dim);
+  cursor: pointer; user-select: none; transition: all .12s;
+  position: relative;
+}
+.fin-toolbar .fin-filter-cb:hover{
+  border-color: var(--text-mute); color: var(--text);
+}
+.fin-toolbar .fin-filter-cb input{
+  position: absolute; opacity: 0; pointer-events: none; width: 0; height: 0;
+}
+.fin-toolbar .fin-filter-cb-box{
+  width: 14px; height: 14px;
+  border: 1.5px solid var(--text-mute);
+  border-radius: 3px;
+  display: inline-grid; place-items: center;
+  transition: all .12s;
+  flex-shrink: 0;
+}
+.fin-toolbar .fin-filter-cb.on{
+  background: oklch(0.96 0.04 var(--cb-hue, 145));
+  border-color: oklch(0.55 0.13 var(--cb-hue, 145));
+  color: oklch(0.32 0.13 var(--cb-hue, 145));
+  font-weight: 600;
+}
+.fin-toolbar .fin-filter-cb.on .fin-filter-cb-box{
+  background: oklch(0.55 0.13 var(--cb-hue, 145));
+  border-color: oklch(0.55 0.13 var(--cb-hue, 145));
+}
+.fin-toolbar .fin-filter-cb.on .fin-filter-cb-box::after{
+  content: "";
+  width: 8px; height: 4px;
+  border-left: 1.5px solid white;
+  border-bottom: 1.5px solid white;
+  transform: rotate(-45deg) translate(0, -1px);
+}
+.fin-toolbar .fin-filter-cb.on .fin-filter-ct{
+  background: white;
+  color: oklch(0.42 0.13 var(--cb-hue, 145));
+}
+
+.fin-toolbar .fin-filter-clear{
+  margin-left: 4px;
+  background: transparent; border: none;
+  color: var(--text-mute); font-family: inherit; font-size: 11.5px;
+  cursor: pointer; padding: 5px 8px; border-radius: 4px;
+  text-decoration: underline; text-decoration-style: dotted;
+  text-underline-offset: 3px;
+}
+.fin-toolbar .fin-filter-clear:hover{
+  color: var(--text); background: var(--bg-2);
+}
+
+/* ── Breadcrumb pras sub-rotas do Financeiro (Conciliação, Plano de contas) ── */
+.fin-bcrumb{
+  display: flex; align-items: center; gap: 6px;
+  padding: 4px 24px 12px;
+  font-size: 12px; color: var(--text-mute);
+}
+.fin-bcrumb-back{
+  display: inline-flex; align-items: center; gap: 5px;
+  background: transparent; border: 1px solid transparent;
+  padding: 4px 9px 4px 6px; border-radius: 5px;
+  font-family: inherit; font-size: 12px; font-weight: 500;
+  color: oklch(0.42 0.13 145); cursor: pointer;
+  transition: all .12s;
+}
+.fin-bcrumb-back:hover{
+  background: oklch(0.94 0.05 145);
+  border-color: oklch(0.94 0.05 145);
+}
+.fin-bcrumb-back svg{ flex-shrink: 0; transition: transform .12s; }
+.fin-bcrumb-back:hover svg{ transform: translateX(-2px); }
+.fin-bcrumb-sep{ color: var(--text-mute); opacity: 0.5; font-size: 13px; }
+.fin-bcrumb-here{ font-weight: 500; color: var(--text); }
+
+/* ══════════════════════════════════════════
+   FINANCEIRO · REFINO #1 KB-9.75 · CURADORIA (2026-05-18)
+   ══════════════════════════════════════════ */
+
+/* Conferido inline (no header do drawer) */
+.fin-conf-pill-inline{
+  display: inline-flex; align-items: center; gap: 3px;
+  padding: 1px 7px; border-radius: 99px;
+  background: oklch(0.94 0.06 145); color: oklch(0.32 0.13 145);
+  font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.04em; text-transform: uppercase;
+}
+
+/* Conferido toggle (botão grande no body do drawer) */
+.fin-conferido-toggle{
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 6px 12px 6px 6px; border-radius: 6px;
+  border: 1.5px solid oklch(0.78 0.10 145); background: oklch(0.97 0.04 145);
+  font-family: inherit; font-size: 12.5px; font-weight: 600;
+  color: oklch(0.32 0.13 145);
+  cursor: pointer; transition: all .12s;
+}
+.fin-conferido-toggle:hover{ background: oklch(0.94 0.06 145); }
+.fin-conferido-toggle.on{
+  background: oklch(0.55 0.13 145); color: white;
+  border-color: oklch(0.55 0.13 145);
+}
+.fin-conferido-toggle .fin-conf-check{
+  display: inline-grid; place-items: center;
+  width: 22px; height: 22px; border-radius: 4px;
+  background: white; color: oklch(0.55 0.13 145);
+  border: 1.5px solid oklch(0.78 0.10 145);
+  font-size: 13px; font-weight: 700;
+}
+.fin-conferido-toggle.on .fin-conf-check{
+  background: white; color: oklch(0.55 0.13 145);
+  border-color: white;
+}
+.fin-conferido-toggle .fin-conf-lbl{ font-weight: 600; }
+.fin-conferido-toggle small{
+  font-size: 10.5px; font-weight: 400; opacity: 0.7;
+  margin-left: -3px;
+}
+.fin-conferido-toggle.on small{ display: none; }
+
+/* Pill de frescor (vence em Xd / atrasado / pago) */
+.fin-frescor{
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 7px; border-radius: 4px;
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.01em; white-space: nowrap;
+}
+.fin-frescor-ic{ font-size: 9px; line-height: 1; }
+.fin-frescor-fresh{ background: oklch(0.94 0.04 145); color: oklch(0.42 0.13 145); }
+.fin-frescor-soon{ background: oklch(0.95 0.03 145); color: oklch(0.45 0.10 145); }
+.fin-frescor-warning{ background: oklch(0.96 0.06 70); color: oklch(0.42 0.13 60); }
+.fin-frescor-today{ background: oklch(0.96 0.07 60); color: oklch(0.42 0.18 60); }
+.fin-frescor-overdue{ background: oklch(0.95 0.04 25); color: oklch(0.50 0.18 25); }
+.fin-frescor-paid{ background: oklch(0.94 0.005 240); color: var(--text-mute); }
+
+/* Audit trail */
+.fin-audit{ font-size: 12px; }
+.fin-audit-h{
+  display: flex; align-items: baseline; gap: 10px;
+  margin-bottom: 12px;
+}
+.fin-audit-h h4{ margin: 0; font-size: 13px; font-weight: 700; }
+.fin-audit-h small{ font-size: 11px; color: var(--text-mute); }
+.fin-audit-list{
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column;
+}
+.fin-audit-row{
+  display: grid; grid-template-columns: 26px 1fr;
+  gap: 10px; padding: 8px 0;
+  border-bottom: 1px solid oklch(0.93 0.005 90);
+  position: relative;
+}
+.fin-audit-row:last-child{ border-bottom: none; }
+.fin-audit-row::before{
+  content: ""; position: absolute;
+  left: 12px; top: 28px; bottom: -2px;
+  width: 2px; background: oklch(0.93 0.005 90);
+}
+.fin-audit-row:last-child::before{ display: none; }
+.fin-audit-ic{
+  display: grid; place-items: center;
+  width: 24px; height: 24px; border-radius: 50%;
+  background: var(--bg-2); color: var(--text-mute);
+  font-size: 11px; font-weight: 700;
+  position: relative; z-index: 1;
+}
+.fin-audit-create .fin-audit-ic{ background: oklch(0.94 0.06 145); color: oklch(0.32 0.13 145); }
+.fin-audit-categorize .fin-audit-ic{ background: oklch(0.95 0.04 240); color: oklch(0.36 0.13 240); }
+.fin-audit-edit .fin-audit-ic{ background: oklch(0.96 0.05 70); color: oklch(0.42 0.13 60); }
+.fin-audit-concil .fin-audit-ic{ background: oklch(0.94 0.04 145); color: oklch(0.32 0.13 145); }
+.fin-audit-alert .fin-audit-ic{ background: oklch(0.96 0.05 25); color: oklch(0.55 0.18 25); }
+.fin-audit-body header{
+  display: flex; align-items: baseline; gap: 8px;
+  margin-bottom: 2px;
+}
+.fin-audit-body header b{ font-size: 12px; font-weight: 600; }
+.fin-audit-action{
+  font-size: 11px; color: var(--text-mute);
+}
+.fin-audit-body header time{
+  margin-left: auto;
+  font-family: var(--font-mono); font-size: 10.5px;
+  color: var(--text-mute);
+}
+.fin-audit-body p{
+  margin: 0; font-size: 12px; color: var(--text-dim); line-height: 1.45;
+}
+.fin-audit-diff{
+  margin-top: 4px;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: 11px;
+  background: var(--bg-2); padding: 2px 7px; border-radius: 4px;
+}
+.fin-audit-diff .diff-from{ color: var(--text-mute); text-decoration: line-through; }
+.fin-audit-diff .diff-arr{ color: var(--text-mute); }
+.fin-audit-diff .diff-to{ color: var(--text); font-weight: 600; }
+.fin-audit-diff .diff-pct.pos{ color: oklch(0.50 0.13 145); }
+.fin-audit-diff .diff-pct.neg{ color: oklch(0.55 0.18 25); }
+
+/* Comments thread */
+.fin-comments-h{
+  display: flex; align-items: baseline; gap: 10px;
+  margin-bottom: 10px;
+}
+.fin-comments-h h4{ margin: 0; font-size: 13px; font-weight: 700; }
+.fin-comments-h small{ font-size: 11px; color: var(--text-mute); }
+.fin-comments-list{
+  list-style: none; margin: 0 0 12px; padding: 0;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.fin-comment{
+  display: grid; grid-template-columns: 28px 1fr;
+  gap: 8px;
+  background: oklch(0.985 0.012 240);
+  padding: 8px 10px; border-radius: 6px;
+  border: 1px solid oklch(0.93 0.02 240);
+}
+.fin-comment-av{
+  display: grid; place-items: center;
+  width: 22px; height: 22px; border-radius: 50%;
+  background: oklch(0.55 0.13 240); color: white;
+  font-size: 11px; font-weight: 700;
+  align-self: start; margin-top: 2px;
+}
+.fin-comment-body header{
+  display: flex; align-items: baseline; gap: 6px;
+  margin-bottom: 3px;
+}
+.fin-comment-body header b{ font-size: 12px; font-weight: 600; }
+.fin-comment-body header time{
+  font-family: var(--font-mono); font-size: 10.5px; color: var(--text-mute);
+}
+.fin-comment-x{
+  margin-left: auto;
+  background: transparent; border: none;
+  color: var(--text-mute); font-size: 14px;
+  cursor: pointer; padding: 0 4px;
+  line-height: 1;
+}
+.fin-comment-x:hover{ color: oklch(0.55 0.18 25); }
+.fin-comment-body p{
+  margin: 0; font-size: 12px; line-height: 1.5; color: var(--text);
+}
+
+.fin-comment-new{
+  display: flex; flex-direction: column; gap: 6px;
+  border: 1px solid oklch(0.82 0.10 240);
+  border-radius: 6px; padding: 8px;
+  background: white;
+}
+.fin-comment-new textarea{
+  width: 100%; border: none; outline: none; resize: vertical;
+  font-family: inherit; font-size: 12px; line-height: 1.5;
+  background: transparent;
+  min-height: 44px;
+}
+.fin-comment-new button{
+  align-self: flex-end;
+  background: oklch(0.55 0.13 145); color: white;
+  border: none; padding: 5px 12px; border-radius: 5px;
+  font-family: inherit; font-size: 11.5px; font-weight: 600;
+  cursor: pointer;
+}
+.fin-comment-new button:hover{ background: oklch(0.48 0.13 145); }
+.fin-comment-new button:disabled{ background: var(--text-mute); cursor: not-allowed; }
+
+/* ══════════════════════════════════════════
+   FINANCEIRO · REFINO #2 KB-9.75 · IA (2026-05-18)
+   ══════════════════════════════════════════ */
+
+/* Botão ✦ Resumir mês */
+.fin-root .fin-btn-ai{
+  color: oklch(0.42 0.13 295);
+}
+.fin-root .fin-btn-ai:hover{
+  background: oklch(0.96 0.04 295);
+  color: oklch(0.32 0.18 295);
+}
+
+/* Anomalia banner (no topo do drawer) */
+.fin-ai-anomalia{
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 14px; margin: 0 0 4px;
+  border-radius: 8px;
+  border-left: 4px solid;
+}
+.fin-ai-anomalia-high{
+  background: oklch(0.96 0.06 25);
+  border-color: oklch(0.55 0.18 25);
+  color: oklch(0.45 0.18 25);
+}
+.fin-ai-anomalia-low{
+  background: oklch(0.96 0.05 240);
+  border-color: oklch(0.55 0.13 240);
+  color: oklch(0.36 0.13 240);
+}
+.fin-ai-anomalia-ic{
+  display: grid; place-items: center;
+  width: 28px; height: 28px; border-radius: 50%;
+  background: white; font-size: 14px; font-weight: 700;
+  flex-shrink: 0;
+}
+.fin-ai-anomalia-body{ flex: 1; }
+.fin-ai-anomalia-body b{ display: block; font-size: 12.5px; font-weight: 600; }
+.fin-ai-anomalia-body small{ display: block; font-size: 11px; opacity: 0.85; }
+.fin-ai-anomalia-body i{ font-style: normal; font-weight: 500; }
+.fin-ai-anomalia-cta{
+  background: white; color: inherit;
+  border: 1px solid currentColor;
+  padding: 4px 10px; border-radius: 5px;
+  font-family: inherit; font-size: 11.5px; font-weight: 600;
+  cursor: pointer;
+}
+
+/* Painel IA dentro do drawer */
+.fin-ai-panel h3{
+  margin: 12px 0 8px;
+  font-size: 11px; font-weight: 700;
+  letter-spacing: 0.07em; text-transform: uppercase;
+  color: oklch(0.42 0.13 295); opacity: 0.85;
+}
+.fin-ai-party .vd-ai-stats{ margin-bottom: 12px; }
+
+/* ─── MONTH DIGEST OVERLAY ─── */
+.fin-digest-overlay{
+  position: fixed; inset: 0; z-index: 1100;
+  background: oklch(0.20 0.005 240 / 0.55);
+  display: grid; place-items: center;
+  padding: 20px;
+  animation: finDigestFade 0.18s ease-out;
+}
+@keyframes finDigestFade { from { opacity: 0; } to { opacity: 1; } }
+
+.fin-digest{
+  background: var(--surface);
+  border-radius: 14px;
+  width: 100%; max-width: 760px;
+  max-height: 88vh; overflow: auto;
+  box-shadow: 0 24px 80px rgba(0,0,0,0.18);
+  display: flex; flex-direction: column;
+  animation: finDigestUp 0.22s ease-out;
+}
+@keyframes finDigestUp { from { transform: translateY(16px); opacity: 0; } to { transform: none; opacity: 1; } }
+
+.fin-digest-h{
+  padding: 22px 26px 16px;
+  border-bottom: 1px solid var(--border);
+  position: relative;
+}
+.fin-digest-eyebrow{
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  color: oklch(0.42 0.13 295);
+}
+.fin-digest-h h2{
+  margin: 4px 0 0; font-size: 22px; font-weight: 700;
+  letter-spacing: -0.018em;
+}
+.fin-digest-x{
+  position: absolute; top: 18px; right: 22px;
+  background: transparent; border: 1px solid var(--border);
+  width: 32px; height: 32px; border-radius: 6px;
+  font-size: 18px; cursor: pointer; line-height: 1;
+  color: var(--text-mute);
+}
+.fin-digest-x:hover{ background: var(--bg-2); color: var(--text); }
+
+.fin-digest-body{
+  padding: 18px 26px 24px;
+  display: flex; flex-direction: column; gap: 18px;
+}
+
+/* Snapshot cards */
+.fin-digest-snapshot{
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px;
+}
+.fin-digest-card{
+  background: var(--bg-2);
+  border-radius: 8px;
+  padding: 10px 14px;
+}
+.fin-digest-card.primary{
+  grid-column: 1 / 3;
+  background: linear-gradient(135deg, oklch(0.97 0.025 145), oklch(0.985 0.012 145));
+  border: 1px solid oklch(0.86 0.06 145);
+}
+.fin-digest-card.warn{
+  background: oklch(0.96 0.06 25);
+  border: 1px solid oklch(0.82 0.10 25);
+}
+.fin-digest-card small{
+  display: block;
+  font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--text-mute); margin-bottom: 3px;
+}
+.fin-digest-card b{
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 22px; font-weight: 700;
+  letter-spacing: -0.015em; line-height: 1.1;
+}
+.fin-digest-card.primary b{ font-size: 26px; }
+.fin-digest-card b.pos{ color: oklch(0.42 0.13 145); }
+.fin-digest-card b.neg{ color: oklch(0.55 0.18 25); }
+.fin-digest-card span{
+  display: block; font-size: 10.5px;
+  color: var(--text-dim); margin-top: 3px;
+}
+
+.fin-digest-section{
+  display: flex; flex-direction: column; gap: 10px;
+}
+.fin-digest-section h3{
+  margin: 0; font-size: 11px; font-weight: 700;
+  letter-spacing: 0.07em; text-transform: uppercase;
+  color: var(--text-mute);
+  display: flex; align-items: center; gap: 8px;
+}
+.fin-digest-tag{
+  background: oklch(0.94 0.06 295); color: oklch(0.36 0.13 295);
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  padding: 1px 7px; border-radius: 99px;
+  letter-spacing: normal; text-transform: none;
+}
+
+/* Top categories */
+.fin-digest-cats{
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.fin-digest-cats li{
+  display: grid; grid-template-columns: 130px 1fr 130px;
+  align-items: center; gap: 12px;
+  font-size: 12px;
+}
+.fin-digest-cat-l{ color: var(--text); font-weight: 500; }
+.fin-digest-cat-r{
+  text-align: right; font-family: var(--font-mono); font-weight: 600;
+}
+.fin-digest-cat-r small{ color: var(--text-mute); font-weight: 500; margin-left: 4px; }
+.fin-digest-cat-bar{
+  height: 6px; background: var(--bg-2); border-radius: 99px; overflow: hidden;
+}
+.fin-digest-cat-bar > div{
+  height: 100%; background: oklch(0.55 0.13 145); border-radius: 99px;
+}
+
+/* Anomalias */
+.fin-digest-anomalias{
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.fin-digest-anomalias li{
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 6px;
+  background: var(--bg-2);
+}
+.fin-digest-anomalia-tag{
+  display: inline-flex; align-items: center; gap: 2px;
+  padding: 3px 8px; border-radius: 4px;
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 700;
+  flex-shrink: 0;
+}
+.fin-digest-anomalia-tag.high{ background: oklch(0.96 0.06 25); color: oklch(0.55 0.18 25); }
+.fin-digest-anomalia-tag.low{ background: oklch(0.96 0.05 240); color: oklch(0.36 0.13 240); }
+.fin-digest-anomalias b{ display: block; font-size: 12px; font-weight: 600; }
+.fin-digest-anomalias small{ display: block; font-size: 10.5px; color: var(--text-mute); }
+
+/* ══════════════════════════════════════════
+   FINANCEIRO · REFINO #3 KB-9.75 · GUIA + SAÍDA (2026-05-18)
+   ══════════════════════════════════════════ */
+
+/* Header buttons */
+.fin-root .fin-btn-trilha{ color: oklch(0.42 0.13 145); }
+.fin-root .fin-btn-trilha:hover{ background: oklch(0.96 0.05 145); color: oklch(0.32 0.13 145); }
+.fin-root .fin-btn-present{ color: oklch(0.42 0.13 240); }
+.fin-root .fin-btn-present:hover{ background: oklch(0.96 0.04 240); color: oklch(0.32 0.13 240); }
+
+/* Trouble button no footer do Drawer */
+.fin-trouble-btn{
+  display: inline-flex; align-items: center; gap: 8px;
+  background: oklch(0.96 0.06 60); color: oklch(0.42 0.13 60);
+  border: 1px solid oklch(0.85 0.10 60);
+  padding: 5px 10px 5px 5px; border-radius: 6px;
+  font-family: inherit; font-size: 11.5px; font-weight: 600;
+  cursor: pointer; margin-right: auto;
+  transition: all .12s;
+}
+.fin-trouble-btn:hover{ background: oklch(0.93 0.08 60); border-color: oklch(0.72 0.13 60); }
+.fin-trouble-ic{
+  display: grid; place-items: center;
+  width: 22px; height: 22px; border-radius: 4px;
+  background: oklch(0.62 0.13 60); color: white;
+  font-size: 14px; font-weight: 700;
+}
+.fin-trouble-lbl{ font-size: 12px; }
+.fin-trouble-lbl b{ font-weight: 700; }
+.fin-trouble-ct{
+  font-family: var(--font-mono); font-size: 9.5px;
+  background: white; color: var(--text-mute);
+  padding: 1px 6px; border-radius: 99px;
+}
+
+/* ─── Trilha de fechamento (overlay) ─── */
+.fin-trilha-overlay{
+  position: fixed; inset: 0; z-index: 1100;
+  background: oklch(0.20 0.005 240 / 0.55);
+  display: grid; place-items: center;
+  padding: 20px;
+}
+.fin-trilha{
+  background: var(--surface);
+  border-radius: 14px;
+  width: 100%; max-width: 760px;
+  max-height: 88vh; overflow: auto;
+  box-shadow: 0 24px 80px rgba(0,0,0,0.18);
+  display: flex; flex-direction: column;
+}
+.fin-trilha-h{
+  display: grid; grid-template-columns: 1fr auto auto;
+  align-items: center; gap: 18px;
+  padding: 22px 26px 18px;
+  border-bottom: 1px solid var(--border);
+}
+.fin-trilha-h > div:first-child{ min-width: 0; }
+.fin-trilha-eyebrow{
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  color: oklch(0.42 0.13 145);
+}
+.fin-trilha-h h2{
+  margin: 4px 0 2px; font-size: 20px; font-weight: 700;
+  letter-spacing: -0.018em;
+}
+.fin-trilha-h p{ margin: 0; font-size: 11.5px; color: var(--text-mute); }
+.fin-trilha-progress{
+  text-align: center;
+  background: var(--bg-2);
+  border-radius: 10px;
+  padding: 8px 16px;
+}
+.fin-trilha-pct{
+  font-family: var(--font-mono); font-size: 22px; font-weight: 700;
+  color: oklch(0.42 0.13 145); letter-spacing: -0.015em;
+}
+.fin-trilha-progress small{
+  display: block; font-size: 10px; color: var(--text-mute);
+}
+.fin-trilha-x{
+  background: transparent; border: 1px solid var(--border);
+  width: 32px; height: 32px; border-radius: 6px;
+  font-size: 18px; cursor: pointer; line-height: 1;
+  color: var(--text-mute);
+}
+.fin-trilha-x:hover{ background: var(--bg-2); color: var(--text); }
+.fin-trilha-bar{
+  height: 4px; background: var(--bg-2);
+  margin: 0;
+}
+.fin-trilha-bar > div{
+  height: 100%; background: oklch(0.55 0.13 145);
+  transition: width .2s;
+}
+.fin-trilha-list{
+  list-style: none; margin: 0; padding: 12px;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.fin-trilha-step{
+  display: grid;
+  grid-template-columns: 36px 1fr auto;
+  align-items: center; gap: 14px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  transition: background .12s;
+}
+.fin-trilha-step:hover{ background: var(--bg-2); }
+.fin-trilha-step.done{ opacity: 0.55; }
+.fin-trilha-check{
+  width: 30px; height: 30px;
+  border-radius: 50%;
+  border: 1.5px solid var(--border);
+  background: white;
+  font-family: var(--font-mono); font-size: 13px; font-weight: 700;
+  color: var(--text-mute);
+  cursor: pointer; transition: all .12s;
+  display: inline-grid; place-items: center;
+}
+.fin-trilha-check:hover{ border-color: oklch(0.55 0.13 145); color: oklch(0.42 0.13 145); }
+.fin-trilha-step.done .fin-trilha-check{
+  background: oklch(0.55 0.13 145); color: white;
+  border-color: oklch(0.55 0.13 145);
+}
+.fin-trilha-body b{ display: block; font-size: 13px; font-weight: 600; }
+.fin-trilha-body small{ display: block; font-size: 11.5px; color: var(--text-dim); margin-top: 2px; }
+.fin-trilha-step.done .fin-trilha-body b{ text-decoration: line-through; }
+.fin-trilha-cta{
+  background: transparent;
+  border: 1px solid var(--border);
+  padding: 4px 10px; border-radius: 5px;
+  font-family: inherit; font-size: 11px; font-weight: 500;
+  color: oklch(0.42 0.13 145); cursor: pointer;
+  transition: all .12s;
+  white-space: nowrap;
+}
+.fin-trilha-cta:hover{ background: oklch(0.96 0.05 145); border-color: oklch(0.55 0.13 145); }
+.fin-trilha-ft{
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 12px 22px;
+  border-top: 1px solid var(--border);
+  font-size: 11px; color: var(--text-mute);
+}
+.fin-trilha-reset{
+  background: transparent; border: none;
+  color: var(--text-mute); font-family: inherit; font-size: 11px;
+  cursor: pointer; text-decoration: underline; text-underline-offset: 3px;
+}
+.fin-trilha-reset:hover{ color: oklch(0.55 0.18 25); }
+
+/* ─── Modo apresentação fullscreen ─── */
+.fin-pres-overlay{
+  position: fixed; inset: 0; z-index: 1200;
+  background: linear-gradient(135deg, oklch(0.16 0.005 240), oklch(0.18 0.01 145));
+  color: white;
+  display: flex; flex-direction: column;
+}
+.fin-pres-top{
+  display: flex; align-items: center; gap: 14px;
+  padding: 16px 28px;
+  border-bottom: 1px solid oklch(1 0 0 / 0.08);
+}
+.fin-pres-brand{
+  flex: 1; font-size: 11px; font-weight: 700;
+  letter-spacing: 0.15em; text-transform: uppercase;
+  color: oklch(1 0 0 / 0.5);
+}
+.fin-pres-counter{
+  font-family: var(--font-mono); font-size: 11.5px;
+  color: oklch(1 0 0 / 0.5);
+}
+.fin-pres-close{
+  background: transparent; border: 1px solid oklch(1 0 0 / 0.2);
+  color: white; width: 32px; height: 32px;
+  border-radius: 6px; cursor: pointer;
+  font-size: 18px; line-height: 1;
+}
+.fin-pres-close:hover{ background: oklch(1 0 0 / 0.08); }
+.fin-pres-stage{
+  flex: 1;
+  display: grid; place-items: center;
+  padding: 40px 80px;
+}
+.fin-pres-slide{ max-width: 900px; width: 100%; text-align: center; }
+.fin-pres-eyebrow{
+  display: block; font-size: 13px; font-weight: 600;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  color: oklch(0.78 0.10 145); margin-bottom: 16px;
+}
+.fin-pres-slide h1{
+  font-size: 56px; font-weight: 700;
+  letter-spacing: -0.025em; line-height: 1.05;
+  margin: 0 0 24px;
+}
+.fin-pres-amount{
+  font-family: var(--font-mono); font-size: 96px; font-weight: 700;
+  letter-spacing: -0.03em; line-height: 1;
+  margin: 12px 0 36px;
+}
+.fin-pres-amount-mid{
+  font-family: var(--font-mono); font-size: 60px; font-weight: 700;
+  letter-spacing: -0.02em; line-height: 1;
+  margin: 12px 0 28px;
+}
+.fin-pres-amount.pos, .fin-pres-amount-mid.pos{ color: oklch(0.78 0.13 145); }
+.fin-pres-amount.neg, .fin-pres-amount-mid.neg{ color: oklch(0.72 0.17 25); }
+.fin-pres-row{
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px;
+  max-width: 800px; margin: 0 auto;
+}
+.fin-pres-row > div{
+  background: oklch(1 0 0 / 0.05);
+  border: 1px solid oklch(1 0 0 / 0.08);
+  border-radius: 12px; padding: 16px 20px;
+}
+.fin-pres-row span{
+  display: block; font-size: 11px;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: oklch(1 0 0 / 0.5); margin-bottom: 4px;
+}
+.fin-pres-row b{
+  display: block; font-family: var(--font-mono);
+  font-size: 20px; font-weight: 700;
+}
+.fin-pres-row b.pos{ color: oklch(0.85 0.10 145); }
+.fin-pres-row b.neg{ color: oklch(0.80 0.13 25); }
+.fin-pres-cats{ list-style: none; margin: 24px 0 0; padding: 0; text-align: left; }
+.fin-pres-cats li{
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 16px 24px;
+  background: oklch(1 0 0 / 0.05);
+  border: 1px solid oklch(1 0 0 / 0.08);
+  border-radius: 10px;
+  margin-bottom: 10px;
+}
+.fin-pres-cat-l{ font-size: 22px; font-weight: 500; }
+.fin-pres-cat-r{ font-family: var(--font-mono); font-size: 24px; font-weight: 700; }
+.fin-pres-cat-r small{ font-size: 14px; color: oklch(1 0 0 / 0.5); margin-left: 6px; font-weight: 500; }
+
+.fin-pres-late{ list-style: none; margin: 24px 0 0; padding: 0; text-align: left; }
+.fin-pres-late li{
+  display: grid; grid-template-columns: 1fr 2fr auto;
+  gap: 16px; padding: 12px 20px;
+  background: oklch(1 0 0 / 0.05);
+  border-left: 3px solid oklch(0.72 0.17 25);
+  border-radius: 6px;
+  margin-bottom: 8px;
+  font-size: 16px;
+}
+.fin-pres-late-l{ font-weight: 600; }
+.fin-pres-late-m{ color: oklch(1 0 0 / 0.6); }
+.fin-pres-late-r{ font-family: var(--font-mono); font-weight: 700; }
+
+.fin-pres-decisoes{ text-align: left; max-width: 700px; margin: 24px auto 0; padding: 0; list-style: none; counter-reset: pres; }
+.fin-pres-decisoes li{
+  counter-increment: pres;
+  padding: 14px 0 14px 52px;
+  font-size: 18px; line-height: 1.4;
+  border-top: 1px solid oklch(1 0 0 / 0.08);
+  position: relative;
+}
+.fin-pres-decisoes li::before{
+  content: counter(pres);
+  position: absolute; left: 0; top: 14px;
+  width: 34px; height: 34px; border-radius: 50%;
+  background: oklch(0.55 0.13 145); color: white;
+  display: grid; place-items: center;
+  font-family: var(--font-mono); font-size: 13px; font-weight: 700;
+}
+.fin-pres-decisoes li:first-child{ border-top: none; }
+.fin-pres-decisoes b{ color: oklch(0.85 0.10 145); }
+
+.fin-pres-bot{
+  display: flex; align-items: center; gap: 18px; justify-content: center;
+  padding: 20px 28px;
+  border-top: 1px solid oklch(1 0 0 / 0.08);
+}
+.fin-pres-bot button{
+  background: oklch(1 0 0 / 0.08);
+  border: 1px solid oklch(1 0 0 / 0.12);
+  color: white;
+  width: 44px; height: 44px;
+  border-radius: 8px;
+  font-size: 18px; cursor: pointer;
+}
+.fin-pres-bot button:hover:not(:disabled){ background: oklch(1 0 0 / 0.16); }
+.fin-pres-bot button:disabled{ opacity: 0.3; cursor: not-allowed; }
+.fin-pres-dots{ display: flex; gap: 8px; }
+.fin-pres-dot{
+  width: 8px; height: 8px; border-radius: 50%;
+  background: oklch(1 0 0 / 0.2); cursor: pointer; transition: all .15s;
+}
+.fin-pres-dot.on{ background: oklch(0.78 0.13 145); width: 24px; border-radius: 99px; }
+
+.fin-toolbar .fin-filter-toggle{
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 5px 10px; border-radius: 5px;
+  border: 1px dashed var(--border); background: var(--surface);
+  font-size: 12px; font-weight: 500; color: var(--text-dim);
+  cursor: pointer; user-select: none; transition: all .12s;
+}
+.fin-toolbar .fin-filter-toggle:hover{
+  border-color: var(--text-mute); color: var(--text);
+}
+.fin-toolbar .fin-filter-toggle input{
+  appearance: none; -webkit-appearance: none;
+  width: 13px; height: 13px;
+  border: 1.5px solid var(--text-mute);
+  border-radius: 3px; cursor: pointer;
+  display: inline-grid; place-items: center;
+  margin: 0;
+}
+.fin-toolbar .fin-filter-toggle input:checked{
+  background: oklch(0.55 0.18 25); border-color: oklch(0.55 0.18 25);
+}
+.fin-toolbar .fin-filter-toggle input:checked::after{
+  content: ""; width: 7px; height: 4px;
+  border-left: 1.5px solid white; border-bottom: 1.5px solid white;
+  transform: rotate(-45deg) translate(0, -1px);
+}
+.fin-toolbar .fin-filter-toggle.on.warn{
+  border-style: solid;
+  background: oklch(0.96 0.06 25);
+  border-color: oklch(0.55 0.18 25);
+  color: oklch(0.45 0.18 25); font-weight: 600;
+}
+
+/* Hero title sub + botões ativos no header */
+.fin-root .fin-hero-title-sub{
+  color: var(--text-mute); font-weight: 400;
+  font-size: 18px; margin-left: 4px;
+}
+.fin-root .os-page-h-r .os-btn.on{
+  background: oklch(0.94 0.05 145);
+  color: oklch(0.32 0.13 145);
+  border-color: oklch(0.78 0.10 145);
+}
+.fin-root .fin-subnav{ display: none; }
+.vd-subpage .vd-bcrumb{
+  display: flex; align-items: center; gap: 6px;
+  padding: 4px 0 12px;
+  font-size: 12px; color: var(--text-mute);
+  margin-bottom: 0;
+}
+.vd-subpage .vd-bcrumb-back{
+  display: inline-flex; align-items: center; gap: 5px;
+  background: transparent; border: 1px solid transparent;
+  padding: 4px 9px 4px 6px; border-radius: 5px;
+  font-family: inherit; font-size: 12px; font-weight: 500;
+  color: var(--vd-green, oklch(0.50 0.14 155)); cursor: pointer;
+  transition: all .12s;
+}
+.vd-subpage .vd-bcrumb-back:hover{
+  background: var(--vd-green-soft, oklch(0.94 0.05 155));
+  border-color: var(--vd-green-soft, oklch(0.94 0.05 155));
+}
+.vd-subpage .vd-bcrumb-back svg{ flex-shrink: 0; transition: transform .12s; }
+.vd-subpage .vd-bcrumb-back:hover svg{ transform: translateX(-2px); }
+.vd-subpage .vd-bcrumb-sep{
+  color: var(--text-mute); opacity: 0.5;
+  font-size: 13px;
+}
+.vd-subpage .vd-bcrumb-here{
+  font-weight: 500; color: var(--text);
+}
+
+/* ══════════════════════════════════════════
+   HEADER LIMPO + TOOLBAR EM LINHA SEPARADA
+   ══════════════════════════════════════════ */
+.vendas-aplus .vd-head-clean{
+  align-items: center; gap: 16px;
+}
+.vendas-aplus .vd-head-clean .os-head-l h1{
+  margin: 0; font-size: 22px; font-weight: 700;
+  letter-spacing: -0.018em;
+}
+.vendas-aplus .vd-head-clean .os-head-l p{
+  margin: 2px 0 0; font-size: 12px; color: var(--text-mute);
+}
+.vendas-aplus .vd-head-clean .os-head-r{
+  display: inline-flex; gap: 8px; align-items: center;
+}
+
+/* Toolbar limpa abaixo do header */
+.vendas-aplus .vd-toolbar{
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 0 14px;
+  border-bottom: 1px solid var(--border-2);
+  margin-bottom: 14px;
+}
+.vendas-aplus .vd-toolbar-l{
+  display: inline-flex; align-items: center; gap: 8px; flex: 1;
+}
+.vendas-aplus .vd-toolbar-r{
+  display: inline-flex; align-items: center; gap: 4px;
+}
+.vendas-aplus .vd-toolbar-sep{
+  width: 1px; height: 18px; background: var(--border);
+  margin: 0 4px;
+}
+.vendas-aplus .vd-toolbar-act{
+  display: inline-flex; align-items: center; gap: 5px;
+  background: transparent; border: none;
+  padding: 5px 9px; border-radius: 5px;
+  font-family: inherit; font-size: 12px; font-weight: 500;
+  color: var(--text-dim); cursor: pointer;
+  transition: all .12s;
+}
+.vendas-aplus .vd-toolbar-act:hover{
+  background: var(--bg-2); color: var(--text);
+}
+.vendas-aplus .vd-toolbar-act svg{ flex-shrink: 0; }
+
+/* Foco mais discreto na toolbar */
+.vendas-aplus .vd-toolbar .vd-vista{
+  background: var(--bg-2); border-radius: 6px;
+  padding: 2px; gap: 0;
+}
+.vendas-aplus .vd-toolbar .vd-vista-lbl{
+  padding: 0 8px 0 6px;
+  font-size: 9.5px;
+}
+.vendas-aplus .vd-toolbar .vd-vista button{
+  border: none; background: transparent;
+  padding: 4px 10px; border-radius: 4px;
+  font-family: inherit; font-size: 11.5px; font-weight: 500;
+  color: var(--text-dim); cursor: pointer;
+  transition: all .12s;
+}
+.vendas-aplus .vd-toolbar .vd-vista button:hover{ color: var(--text); }
+.vendas-aplus .vd-toolbar .vd-vista button.on{
+  background: var(--surface); color: var(--vd-green); font-weight: 600;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
+
+/* Views button na toolbar — sem botão "box" pesado */
+.vendas-aplus .vd-toolbar .vd-views{ position: relative; }
+.vendas-aplus .vd-toolbar .vd-views-btn{
+  background: transparent; border: 1px solid transparent;
+  padding: 5px 9px; border-radius: 5px;
+  font-family: inherit; font-size: 12px; font-weight: 500;
+  color: var(--text-dim); cursor: pointer;
+  transition: all .12s;
+}
+.vendas-aplus .vd-toolbar .vd-views-btn::after{
+  content: '▾'; font-size: 9px; color: var(--text-mute); margin-left: 4px;
+}
+.vendas-aplus .vd-toolbar .vd-views-btn:hover{
+  background: var(--bg-2); color: var(--text);
+}
+
+/* Visões button na toolbar (mais discreto que dropdown standalone) */
+.vendas-aplus .vd-toolbar .vd-toolbar-act.vd-visoes-btn{
+  border: 1px dashed var(--border);
+  color: var(--text-mute);
+}
+.vendas-aplus .vd-toolbar .vd-toolbar-act.vd-visoes-btn:hover{
+  border-color: var(--text-dim);
+  background: var(--bg-2);
+  color: var(--text);
+}
+
+/* ── Sticky table header ── */
+.vendas-aplus .vd-aplus-table thead th{
+  position: sticky; top: 0; z-index: 2;
+  background: var(--surface);
+  box-shadow: 0 1px 0 var(--border);
+}
+
+/* ── Hover-reveal row actions ── */
+.vendas-aplus .vd-row-actions{
+  display: inline-flex; gap: 2px;
+  margin-left: 6px;
+  opacity: 0; transform: translateX(-4px);
+  transition: opacity .12s, transform .12s;
+  vertical-align: middle;
+}
+.vendas-aplus .os-row:hover .vd-row-actions,
+.vendas-aplus .os-row.row-focused .vd-row-actions{
+  opacity: 1; transform: none;
+}
+.vendas-aplus .vd-row-act{
+  width: 22px; height: 22px;
+  background: transparent; border: 1px solid var(--border);
+  border-radius: 4px; cursor: pointer;
+  display: inline-grid; place-items: center;
+  color: var(--text-mute);
+  transition: all .12s;
+}
+.vendas-aplus .vd-row-act:hover{
+  border-color: var(--vd-green); color: var(--vd-green);
+  background: var(--vd-green-soft);
+}
+
+/* ═══════════════════════════════════════════════════════════════════
+   VENDAS · TWEAKS via data-attrs
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* Densidade */
+.vendas-aplus[data-vd-density="compact"]  .vd-aplus-table td{ padding: 5px 8px; font-size: 11.5px; }
+.vendas-aplus[data-vd-density="compact"]  .vd-aplus-table th{ padding: 5px 8px; }
+.vendas-aplus[data-vd-density="compact"]  .vd-item-cur .vd-item-c-main{ padding: 6px 10px; }
+.vendas-aplus[data-vd-density="spacious"] .vd-aplus-table td{ padding: 14px 14px; font-size: 13.5px; }
+.vendas-aplus[data-vd-density="spacious"] .vd-aplus-table th{ padding: 12px 14px; }
+.vendas-aplus[data-vd-density="spacious"] .vd-item-cur .vd-item-c-main{ padding: 14px 16px; }
+
+/* Drawer largura */
+.vendas-aplus[data-vd-drawer="largo"] ~ .os-drawer-back .os-drawer.wide,
+body:has(.vendas-aplus[data-vd-drawer="largo"]) .os-drawer.wide{ width: 720px; max-width: 92vw; }
+
+/* SLA visual variations */
+.vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla{
+  background: transparent !important;
+  padding: 0;
+  gap: 4px;
+}
+.vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla-ic{
+  width: 7px; height: 7px; border-radius: 50%;
+  font-size: 0;
+}
+.vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla-fresh   .vd-sla-ic{ background: oklch(0.55 0.13 145); }
+.vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla-warning .vd-sla-ic{ background: oklch(0.62 0.13 60); }
+.vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla-overdue .vd-sla-ic{ background: var(--vd-bad); }
+.vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla-lbl{
+  color: var(--text-dim); font-family: var(--font-mono); font-size: 10.5px; font-weight: 500;
+}
+
+.vendas-aplus[data-vd-sla="bar"] .vd-pay-sla{
+  display: block; margin-top: 4px;
+}
+.vendas-aplus[data-vd-sla="bar"] .vd-pay-sla .vd-sla{
+  display: block; background: transparent !important; padding: 0;
+}
+.vendas-aplus[data-vd-sla="bar"] .vd-pay-sla .vd-sla-ic{ display: none; }
+.vendas-aplus[data-vd-sla="bar"] .vd-pay-sla .vd-sla-lbl{
+  display: block; font-size: 10px; color: var(--text-mute); margin-bottom: 3px;
+}
+.vendas-aplus[data-vd-sla="bar"] .vd-pay-sla::after{
+  content: ''; display: block; height: 3px; border-radius: 99px;
+  background: linear-gradient(90deg, var(--vd-ok), var(--vd-warn), var(--vd-bad));
+  opacity: 0.4;
+}
+.vendas-aplus[data-vd-sla="bar"] .vd-pay-sla:has(.vd-sla-fresh)::after{ background: var(--vd-ok); opacity: 1; }
+.vendas-aplus[data-vd-sla="bar"] .vd-pay-sla:has(.vd-sla-warning)::after{ background: var(--vd-warn); opacity: 1; }
+.vendas-aplus[data-vd-sla="bar"] .vd-pay-sla:has(.vd-sla-overdue)::after{ background: var(--vd-bad); opacity: 1; }
+
+/* Paleta accent */
+.vendas-aplus[data-vd-palette="indigo"]{
+  --vd-green: oklch(0.45 0.18 270);
+  --vd-green-soft: oklch(0.95 0.05 270);
+}
+.vendas-aplus[data-vd-palette="slate"]{
+  --vd-green: oklch(0.42 0.04 240);
+  --vd-green-soft: oklch(0.94 0.005 240);
+}
+.vendas-aplus[data-vd-palette="amber"]{
+  --vd-green: oklch(0.52 0.14 60);
+  --vd-green-soft: oklch(0.95 0.06 60);
+}
+

--- a/prototipo-ui/vendas-ai.jsx
+++ b/prototipo-ui/vendas-ai.jsx
@@ -1,0 +1,334 @@
+// vendas-ai.jsx — Refino #2 KB-9.75 · IA dentro do fluxo (2026-05-15)
+// 3 componentes: <VdAiSummary> · <VdAiHistory> · <VdAiSuggest>
+// + helper vdAiClientHistory(name) que computa dados do cliente sobre VENDAS_LIST
+// + container <VdAiPanel venda/> usado na nova tab "✦ IA" do drawer
+//
+// Usa window.claude.complete (haiku 4.5, 1024 tokens). Defensivo: se indisponível,
+// rende um aviso visual mas não quebra.
+
+const { useState: useStateAi, useMemo: useMemoAi, useEffect: useEffectAi } = React;
+
+// ──────────────────────────────────────────────────────────────
+// HISTÓRICO DO CLIENTE — computa de VENDAS_LIST
+// ──────────────────────────────────────────────────────────────
+window.vdAiClientHistory = function vdAiClientHistory(clientName) {
+  const list = window.VENDAS_DATA?.VENDAS_LIST || [];
+  const mine = list.filter(v => v.client === clientName);
+  if (mine.length === 0) {
+    return {
+      count: 0, total: 0, avg: 0, lastDate: null,
+      preferredPayment: null, recurringProducts: [],
+      sellers: [], firstDate: null, isNew: true,
+    };
+  }
+  const total = mine.reduce((s, v) => s + v.totalNum, 0);
+  const avg = total / mine.length;
+  const dates = mine.map(v => v.date).sort();
+  const lastDate = dates[dates.length - 1];
+  const firstDate = dates[0];
+
+  // Forma de pagamento mais usada
+  const payCount = {};
+  mine.forEach(v => { payCount[v.payment] = (payCount[v.payment] || 0) + 1; });
+  const preferredPayment = Object.entries(payCount).sort((a,b) => b[1]-a[1])[0]?.[0] || null;
+
+  // Produtos recorrentes (por nome, top 3)
+  const prodCount = {};
+  mine.forEach(v => {
+    (v.itemsList || []).forEach(it => {
+      const key = it.name;
+      if (!prodCount[key]) prodCount[key] = { name: it.name, count: 0, lastPrice: it.unit };
+      prodCount[key].count += it.qty;
+      prodCount[key].lastPrice = it.unit;
+    });
+  });
+  const recurringProducts = Object.values(prodCount).sort((a,b) => b.count - a.count).slice(0, 3);
+
+  // Vendedores atendentes (top 2)
+  const sCount = {};
+  mine.forEach(v => {
+    const s = window.VENDAS_DATA?.VENDEDORES_MAP?.[v.sellerId]?.name || v.seller || "?";
+    sCount[s] = (sCount[s] || 0) + 1;
+  });
+  const sellers = Object.entries(sCount).sort((a,b) => b[1]-a[1]).map(([n,c]) => ({ name:n, count:c }));
+
+  return {
+    count: mine.length, total, avg, lastDate, firstDate,
+    preferredPayment, recurringProducts, sellers,
+    isNew: mine.length === 1,
+  };
+};
+
+// Helper format
+const _aiFmt = (n) => (n || 0).toLocaleString("pt-BR", { style:"currency", currency:"BRL" });
+const _aiDateBR = (d) => d ? d.split("-").reverse().join("/") : "—";
+
+// ──────────────────────────────────────────────────────────────
+// PROMPTS — curados, curtos, contexto explícito
+// ──────────────────────────────────────────────────────────────
+function _aiPromptSummary(v) {
+  const itemsTxt = (v.itemsList || []).map(it =>
+    `- ${it.name} (${it.qty}× · ${_aiFmt(it.unit)} = ${_aiFmt(it.qty * it.unit)})`
+  ).join("\n");
+  return `Você é um vendedor de balcão experiente da Oimpresso (gráfica). Resuma essa venda em 2 frases curtas, pra um colega pegar o pedido no meio do dia. Foque em: o que é, urgência/atenção. Não use bullets, fale natural.
+
+Cliente: ${v.client}
+Total: ${_aiFmt(v.totalNum)} · ${v.payment}${v.installments > 1 ? ` ${v.installments}×` : ""}
+Prazo: ${v.payTerm || 0} dias
+Itens (${(v.itemsList || []).length}):
+${itemsTxt}
+${v.clientNote ? `Nota: ${v.clientNote}` : ""}
+${v.urgent ? "⚠ Marcada como URGENTE." : ""}`;
+}
+
+function _aiPromptHistory(v, h) {
+  const prods = h.recurringProducts.map(p => `- ${p.name} (${p.count} vez${p.count>1?"es":""})`).join("\n");
+  return `Você é assistente da Oimpresso. Em 2-3 frases curtas, descreva o relacionamento com este cliente: padrão de compra + nível de relacionamento + atenção pro próximo atendimento.
+
+Cliente: ${v.client}
+${h.isNew
+    ? `Cliente novo — primeira venda em ${_aiDateBR(h.firstDate)}.`
+    : `${h.count} vendas de ${_aiDateBR(h.firstDate)} até ${_aiDateBR(h.lastDate)}.
+Valor total acumulado: ${_aiFmt(h.total)} · ticket médio ${_aiFmt(h.avg)}.
+Pagamento preferido: ${h.preferredPayment}.
+Atendido por: ${h.sellers.map(s => s.name).join(" e ")}.`}
+Produtos recorrentes:
+${prods || "(nenhum recorrência)"}
+
+Esta venda atual: ${_aiFmt(v.totalNum)} · ${v.payment}.`;
+}
+
+function _aiPromptSuggest(v, h) {
+  const prods = h.recurringProducts.map(p =>
+    `- ${p.name} · ${p.count}× comprado · último preço ${_aiFmt(p.lastPrice)}`
+  ).join("\n");
+  return `Você é vendedor da Oimpresso. Cliente "${v.client}" tem este histórico:
+
+${prods || "(sem histórico de produtos)"}
+
+Última compra em ${_aiDateBR(h.lastDate)}: ${(v.itemsList||[]).map(i=>i.name).join(", ")}.
+
+Sugira UM próximo produto que esse cliente provavelmente vai pedir nos próximos 30-60 dias. Responda APENAS no formato (3 linhas exatas):
+PRODUTO: <nome do produto>
+PREÇO: <preço estimado em R$>
+PORQUE: <1 frase justificando, máx 12 palavras>`;
+}
+
+// ──────────────────────────────────────────────────────────────
+// COMPONENTE BASE — botão IA com loading + result + retry
+// ──────────────────────────────────────────────────────────────
+function VdAiBlock({ icon = "✦", title, hint, prompt, parseResult, idleCta = "Gerar com IA" }) {
+  const [state, setState] = useStateAi("idle"); // idle | loading | done | error
+  const [result, setResult] = useStateAi(null);
+
+  const run = async () => {
+    if (!window.claude?.complete) {
+      setState("error");
+      setResult("Helper window.claude.complete não disponível neste ambiente.");
+      return;
+    }
+    setState("loading");
+    try {
+      const text = await window.claude.complete(prompt);
+      setResult(parseResult ? parseResult(text) : text);
+      setState("done");
+    } catch (e) {
+      setResult(String(e?.message || e));
+      setState("error");
+    }
+  };
+
+  return (
+    <div className={`vd-ai-block vd-ai-${state}`}>
+      <header className="vd-ai-block-h">
+        <span className="vd-ai-ic">{icon}</span>
+        <div className="vd-ai-block-tx">
+          <b>{title}</b>
+          {hint && <small>{hint}</small>}
+        </div>
+        {state === "idle" && (
+          <button className="vd-ai-cta" onClick={run}>{idleCta}</button>
+        )}
+        {state === "loading" && (
+          <span className="vd-ai-loader"><span/><span/><span/></span>
+        )}
+        {(state === "done" || state === "error") && (
+          <button className="vd-ai-retry" onClick={run} title="Refazer">↻</button>
+        )}
+      </header>
+      {state === "loading" && (
+        <div className="vd-ai-skel">
+          <div className="vd-ai-skel-line" style={{width:"92%"}}/>
+          <div className="vd-ai-skel-line" style={{width:"78%"}}/>
+          <div className="vd-ai-skel-line" style={{width:"45%"}}/>
+        </div>
+      )}
+      {(state === "done" || state === "error") && (
+        <div className={`vd-ai-out ${state === "error" ? "err" : ""}`}>
+          {typeof result === "string" ? result : result}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────
+// 1) RESUMIR PEDIDO — texto livre
+// ──────────────────────────────────────────────────────────────
+function VdAiSummary({ venda }) {
+  return (
+    <VdAiBlock
+      title="Resumir pedido"
+      hint={`${(venda.itemsList || []).length} itens · ${_aiFmt(venda.totalNum)} — TL;DR pra colega pegar no meio do dia`}
+      prompt={_aiPromptSummary(venda)}
+      idleCta="✦ Resumir"
+    />
+  );
+}
+
+// ──────────────────────────────────────────────────────────────
+// 2) HISTÓRICO DO CLIENTE — RAG mockado sobre VENDAS_LIST
+// ──────────────────────────────────────────────────────────────
+function VdAiHistory({ venda }) {
+  const h = useMemoAi(() => window.vdAiClientHistory(venda.client), [venda.client]);
+
+  return (
+    <div className="vd-ai-history">
+      {/* dados objetivos sempre visíveis */}
+      <div className="vd-ai-stats">
+        <div className="vd-ai-stat">
+          <small>Vendas</small>
+          <b>{h.count}</b>
+          {h.isNew && <span className="vd-ai-tag new">novo</span>}
+        </div>
+        <div className="vd-ai-stat">
+          <small>Total acumulado</small>
+          <b>{_aiFmt(h.total)}</b>
+        </div>
+        <div className="vd-ai-stat">
+          <small>Ticket médio</small>
+          <b>{_aiFmt(h.avg)}</b>
+        </div>
+        <div className="vd-ai-stat">
+          <small>Última compra</small>
+          <b>{_aiDateBR(h.lastDate)}</b>
+        </div>
+        {h.preferredPayment && (
+          <div className="vd-ai-stat full">
+            <small>Pagamento preferido</small>
+            <b>{h.preferredPayment}</b>
+          </div>
+        )}
+      </div>
+
+      {h.recurringProducts.length > 0 && (
+        <div className="vd-ai-prods">
+          <small>Produtos recorrentes</small>
+          <ul>
+            {h.recurringProducts.map((p, i) => (
+              <li key={i}>
+                <span className="ct">{p.count}×</span>
+                <span>{p.name}</span>
+                <span className="px">{_aiFmt(p.lastPrice)}</span>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      <VdAiBlock
+        title="Perguntar à IA sobre esse cliente"
+        hint="Padrão de compra · nível de relacionamento · o que olhar no próximo atendimento"
+        prompt={_aiPromptHistory(venda, h)}
+        idleCta="✦ Perguntar"
+      />
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────
+// 3) SUGERIR PRÓXIMA VENDA — parse PRODUTO/PREÇO/PORQUE
+// ──────────────────────────────────────────────────────────────
+function _parseSuggest(text) {
+  const lines = String(text || "").split(/\r?\n/);
+  const out = { produto: "", preco: "", porque: "" };
+  lines.forEach(ln => {
+    const m1 = ln.match(/^\s*PRODUTO:\s*(.+?)\s*$/i);
+    const m2 = ln.match(/^\s*PREÇO:\s*(.+?)\s*$/i) || ln.match(/^\s*PRECO:\s*(.+?)\s*$/i);
+    const m3 = ln.match(/^\s*PORQUE:\s*(.+?)\s*$/i) || ln.match(/^\s*POR\s*QUE:\s*(.+?)\s*$/i);
+    if (m1) out.produto = m1[1];
+    if (m2) out.preco = m2[1];
+    if (m3) out.porque = m3[1];
+  });
+  if (!out.produto && !out.preco) return <span>{String(text)}</span>;
+  return (
+    <div className="vd-ai-suggest">
+      <div className="vd-ai-suggest-h">
+        <span className="vd-ai-suggest-ic">✦</span>
+        <div>
+          <b>{out.produto || "—"}</b>
+          {out.preco && <small>{out.preco}</small>}
+        </div>
+      </div>
+      {out.porque && <p>{out.porque}</p>}
+      <button className="vd-ai-suggest-cta">Adicionar a novo orçamento →</button>
+    </div>
+  );
+}
+
+function VdAiSuggest({ venda }) {
+  const h = useMemoAi(() => window.vdAiClientHistory(venda.client), [venda.client]);
+  if (h.isNew) {
+    return (
+      <div className="vd-ai-block vd-ai-idle vd-ai-disabled">
+        <header className="vd-ai-block-h">
+          <span className="vd-ai-ic">✦</span>
+          <div className="vd-ai-block-tx">
+            <b>Sugerir próximo pedido</b>
+            <small>Cliente novo — IA precisa de pelo menos 2 vendas pra inferir padrão.</small>
+          </div>
+        </header>
+      </div>
+    );
+  }
+  return (
+    <VdAiBlock
+      title="Sugerir próximo pedido"
+      hint={`Baseado em ${h.count} vendas anteriores · ${h.recurringProducts.length} produtos recorrentes`}
+      prompt={_aiPromptSuggest(venda, h)}
+      parseResult={_parseSuggest}
+      idleCta="✦ Sugerir"
+    />
+  );
+}
+
+// ──────────────────────────────────────────────────────────────
+// PAINEL CONTAINER — usado na tab ✦ IA do drawer
+// ──────────────────────────────────────────────────────────────
+function VdAiPanel({ venda }) {
+  return (
+    <section className="vd-section vd-ai-panel">
+      <div className="vd-ai-banner">
+        <span className="vd-ai-banner-ic">✦</span>
+        <div>
+          <b>IA copiloto</b>
+          <small>3 ferramentas — IA propõe, você decide. Sempre cita fonte. Pode editar antes de aplicar.</small>
+        </div>
+      </div>
+
+      <h3>1 · Resumir pedido</h3>
+      <VdAiSummary venda={venda}/>
+
+      <h3>2 · Histórico do cliente</h3>
+      <VdAiHistory venda={venda}/>
+
+      <h3>3 · Sugerir próximo pedido</h3>
+      <VdAiSuggest venda={venda}/>
+    </section>
+  );
+}
+
+window.VdAiPanel    = VdAiPanel;
+window.VdAiSummary  = VdAiSummary;
+window.VdAiHistory  = VdAiHistory;
+window.VdAiSuggest  = VdAiSuggest;

--- a/prototipo-ui/vendas-curation.jsx
+++ b/prototipo-ui/vendas-curation.jsx
@@ -1,0 +1,459 @@
+// vendas-curation.jsx — Refino #3 KB-9.75 · Curadoria + Guia (2026-05-15)
+// 4 features: comentários inline · histórico edições · troubleshooter · cross-link
+// Reusa kb-trouble-lib (KBTroubleshooterDialog) com customTroubles de venda.
+
+const { useState: useStateCu, useEffect: useEffectCu, useMemo: useMemoCu } = React;
+
+// ──────────────────────────────────────────────────────────────
+// 1) COMENTÁRIOS INLINE POR LINHA DE ITEM
+//    Storage: oimpresso.vendas.itemComments = { vendaId: { itemIdx: [{author, text, when}] } }
+// ──────────────────────────────────────────────────────────────
+function _vdLoadComments() {
+  try { return JSON.parse(localStorage.getItem("oimpresso.vendas.itemComments") || "{}"); }
+  catch (e) { return {}; }
+}
+function _vdSaveComments(m) {
+  try { localStorage.setItem("oimpresso.vendas.itemComments", JSON.stringify(m)); } catch (e) {}
+}
+
+function useVdItemComments() {
+  const [m, setM] = useStateCu(_vdLoadComments);
+  useEffectCu(() => { _vdSaveComments(m); }, [m]);
+
+  const add = (vendaId, itemIdx, text, author) => {
+    setM(prev => {
+      const v = prev[vendaId] || {};
+      const it = v[itemIdx] || [];
+      const next = { ...v, [itemIdx]: [...it, { author: author || "você", text, when: "agora" }] };
+      return { ...prev, [vendaId]: next };
+    });
+  };
+  const remove = (vendaId, itemIdx, ci) => {
+    setM(prev => {
+      const v = prev[vendaId] || {};
+      const it = v[itemIdx] || [];
+      const nextIt = it.filter((_, i) => i !== ci);
+      const nextV = nextIt.length ? { ...v, [itemIdx]: nextIt } : { ...v };
+      if (!nextIt.length) delete nextV[itemIdx];
+      return { ...prev, [vendaId]: nextV };
+    });
+  };
+  const get = (vendaId, itemIdx) => (m[vendaId]?.[itemIdx]) || [];
+  const countFor = (vendaId) => {
+    const v = m[vendaId] || {};
+    return Object.values(v).reduce((s, l) => s + l.length, 0);
+  };
+  return { add, remove, get, countFor };
+}
+window.useVdItemComments = useVdItemComments;
+
+// ──────────────────────────────────────────────────────────────
+// EDIÇÃO INLINE DE ITENS — qty/preço/desconto persistidos
+// Storage: oimpresso.vendas.itemEdits = { vendaId: { itemIdx: {qty, unit} } }
+// ──────────────────────────────────────────────────────────────
+function _vdLoadEdits() {
+  try { return JSON.parse(localStorage.getItem("oimpresso.vendas.itemEdits") || "{}"); }
+  catch (e) { return {}; }
+}
+function _vdSaveEdits(m) {
+  try { localStorage.setItem("oimpresso.vendas.itemEdits", JSON.stringify(m)); } catch (e) {}
+}
+function useVdItemEdits() {
+  const [m, setM] = useStateCu(_vdLoadEdits);
+  useEffectCu(() => { _vdSaveEdits(m); }, [m]);
+
+  const set = (vendaId, itemIdx, patch) => {
+    setM(prev => {
+      const v = prev[vendaId] || {};
+      const it = { ...(v[itemIdx] || {}), ...patch };
+      return { ...prev, [vendaId]: { ...v, [itemIdx]: it } };
+    });
+  };
+  const get = (vendaId, itemIdx) => (m[vendaId]?.[itemIdx]) || null;
+  const reset = (vendaId, itemIdx) => {
+    setM(prev => {
+      const v = { ...(prev[vendaId] || {}) };
+      delete v[itemIdx];
+      return { ...prev, [vendaId]: v };
+    });
+  };
+  // aplica patches num item original e retorna novo
+  const applied = (vendaId, itemIdx, original) => {
+    const p = m[vendaId]?.[itemIdx];
+    if (!p) return original;
+    return { ...original, ...p };
+  };
+  const hasEdits = (vendaId) => {
+    const v = m[vendaId] || {};
+    return Object.keys(v).length > 0;
+  };
+  return { set, get, reset, applied, hasEdits, all: m };
+}
+window.useVdItemEdits = useVdItemEdits;
+
+// Componente — item row com comentário inline + edição inline (qty/preço)
+function VdItemRow({ venda, item, idx, comments, onAdd, onRemove, edits, onEdit, onResetEdit }) {
+  const [open, setOpen] = useStateCu(false);
+  const [editing, setEditing] = useStateCu(false);
+  const [text, setText] = useStateCu("");
+  const list = comments || [];
+
+  const submit = () => {
+    const t = text.trim();
+    if (!t) return;
+    onAdd(t);
+    setText("");
+    setOpen(false);
+  };
+
+  const _fmt = (n) => (n || 0).toLocaleString("pt-BR", { style:"currency", currency:"BRL" });
+  const hasComments = list.length > 0;
+  const hasEdit = !!edits;
+  const effectiveItem = hasEdit ? { ...item, ...edits } : item;
+  const effQty = +effectiveItem.qty || 0;
+  const effUnit = +effectiveItem.unit || 0;
+  const effSub = effQty * effUnit;
+  const origSub = item.qty * item.unit;
+  const subDiff = effSub - origSub;
+
+  return (
+    <div className={`vd-item-card vd-item-cur ${hasComments ? "has-comments" : ""} ${hasEdit ? "has-edit" : ""} ${editing ? "editing" : ""}`}>
+      <div className="vd-item-c-main">
+        <div className="vd-item-c-l">
+          <b>{item.name}</b>
+          <small>
+            {item.sku} · {item.type === "produto" ? "Produto (NF-e)" : "Serviço (NFS-e)"}
+            {hasEdit && <span className="vd-item-edited"> · editado</span>}
+          </small>
+        </div>
+        {editing ? (
+          <React.Fragment>
+            <input className="vd-item-input vd-item-input-qty"
+                   type="number" min="1" step="1"
+                   value={effQty}
+                   onChange={e => onEdit({ qty: parseInt(e.target.value) || 1 })}
+                   title="Quantidade"/>
+            <input className="vd-item-input vd-item-input-unit"
+                   type="number" min="0" step="0.01"
+                   value={effUnit}
+                   onChange={e => onEdit({ unit: parseFloat(e.target.value) || 0 })}
+                   title="Preço unitário"/>
+            <span className="vd-item-c-sub">
+              {_fmt(effSub)}
+              {hasEdit && Math.abs(subDiff) > 0.01 && (
+                <small className={`vd-item-diff ${subDiff > 0 ? "pos" : "neg"}`}>
+                  {subDiff > 0 ? "+" : ""}{_fmt(subDiff)}
+                </small>
+              )}
+            </span>
+          </React.Fragment>
+        ) : (
+          <React.Fragment>
+            <span className="vd-item-c-qty">{effQty}×</span>
+            <span className="vd-item-c-unit">{_fmt(effUnit)}</span>
+            <span className="vd-item-c-sub">
+              {_fmt(effSub)}
+              {hasEdit && Math.abs(subDiff) > 0.01 && (
+                <small className={`vd-item-diff ${subDiff > 0 ? "pos" : "neg"}`}>
+                  {subDiff > 0 ? "+" : ""}{_fmt(subDiff)}
+                </small>
+              )}
+            </span>
+          </React.Fragment>
+        )}
+        <div className="vd-item-c-acts">
+          <button
+            className={`vd-item-c-edit ${editing ? "on" : ""}`}
+            onClick={() => setEditing(e => !e)}
+            title={editing ? "Concluir edição" : "Editar quantidade e preço"}>
+            {editing ? "✓" : "✎"}
+          </button>
+          {hasEdit && !editing && (
+            <button className="vd-item-c-reset" onClick={onResetEdit} title="Desfazer edição (volta valores originais)">↺</button>
+          )}
+          <button
+            className={`vd-item-c-comm ${open ? "on" : ""} ${hasComments ? "has" : ""}`}
+            onClick={() => setOpen(o => !o)}
+            title={hasComments ? `${list.length} comentário${list.length>1?"s":""}` : "Comentar este item"}>
+            {open ? "×" : "💬"}
+            {hasComments && !open && <span className="ct">{list.length}</span>}
+          </button>
+        </div>
+      </div>
+
+      {(list.length > 0 || open) && (
+        <div className="vd-item-thread">
+          {list.map((c, ci) => (
+            <div key={ci} className="vd-item-comment">
+              <div className="vd-item-comment-h">
+                <span className="vd-item-comment-av">{(c.author || "?").charAt(0).toUpperCase()}</span>
+                <b>{c.author}</b>
+                <span className="vd-item-comment-when">{c.when}</span>
+                <button className="vd-item-comment-x" onClick={() => onRemove(ci)} title="Remover">×</button>
+              </div>
+              <p>{c.text}</p>
+            </div>
+          ))}
+          {open && (
+            <div className="vd-item-comment-new">
+              <textarea
+                autoFocus value={text} rows={2}
+                onChange={e => setText(e.target.value)}
+                onKeyDown={e => { if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) { e.preventDefault(); submit(); } }}
+                placeholder='Ex: "Cliente pediu material premium" · "Confirmar arte antes de imprimir" · ⌘↵ envia'/>
+              <div className="vd-item-comment-row">
+                <small>📌 visível pra Produção · Financeiro · Vendedor</small>
+                <button className="os-btn ghost" onClick={() => { setOpen(false); setText(""); }}>Cancelar</button>
+                <button className="os-btn primary" disabled={!text.trim()} onClick={submit}>Comentar</button>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+window.VdItemRow = VdItemRow;
+
+// ──────────────────────────────────────────────────────────────
+// 2) HISTÓRICO DE EDIÇÕES — auditoria de qty/preço/desconto
+//    Mock determinístico por venda.id pra demo.
+// ──────────────────────────────────────────────────────────────
+function vdAuditTrail(venda) {
+  // Gera entradas fake baseadas no v.id, payment e fsm — determinístico.
+  const seed = (venda.id || "").charCodeAt(venda.id.length - 1) % 4;
+  const entries = [];
+  // sempre: criação
+  entries.push({
+    when: `${venda.date.slice(8,10)}/${venda.date.slice(5,7)} ${venda.time}`,
+    who: venda.seller || venda.sellerId || "—",
+    kind: "create",
+    desc: "Venda registrada · " + (venda.itemsList?.length || 0) + " ite" + ((venda.itemsList?.length||0)>1?"ns":"m"),
+  });
+  // se seed >= 1, edita qty
+  if (seed >= 1 && venda.itemsList?.[0]) {
+    const it = venda.itemsList[0];
+    entries.push({
+      when: `${venda.date.slice(8,10)}/${venda.date.slice(5,7)} ${("0" + (parseInt(venda.time.slice(0,2))+1)).slice(-2)}:${venda.time.slice(3)}`,
+      who: venda.seller || venda.sellerId || "—",
+      kind: "edit",
+      desc: `Quantidade de "${it.name.slice(0,32)}" · ${Math.max(1,it.qty-1)} → ${it.qty}`,
+      field: "qty",
+    });
+  }
+  // se seed >= 2, ajuste de preço
+  if (seed >= 2 && venda.itemsList?.[0]) {
+    const it = venda.itemsList[0];
+    const oldUnit = Math.round(it.unit * 1.08);
+    entries.push({
+      when: `${venda.date.slice(8,10)}/${venda.date.slice(5,7)} ${("0" + (parseInt(venda.time.slice(0,2))+1)).slice(-2)}:${venda.time.slice(3)}`,
+      who: venda.seller || venda.sellerId || "—",
+      kind: "edit",
+      desc: `Preço unitário de "${it.name.slice(0,28)}" · R$ ${oldUnit.toFixed(2)} → R$ ${it.unit.toFixed(2)}`,
+      field: "unit",
+      diff: { from: oldUnit, to: it.unit, pct: ((it.unit - oldUnit)/oldUnit*100) },
+    });
+  }
+  // se faturada (fsm>=2), emissão fiscal
+  if (venda.fsm >= 2 && venda.fiscal?.nfe?.status === "ok") {
+    entries.push({
+      when: venda.fiscal.nfe.date.split("T")[0].split("-").reverse().join("/") + " " + (venda.fiscal.nfe.date.split("T")[1]||"").slice(0,5),
+      who: "sistema",
+      kind: "fiscal",
+      desc: `NF-e ${venda.fiscal.nfe.numero}/${venda.fiscal.nfe.serie} autorizada SEFAZ`,
+    });
+  }
+  if (venda.fiscal?.nfe?.status === "bad") {
+    entries.push({
+      when: venda.fiscal.nfe.date.split("T")[0].split("-").reverse().join("/") + " " + (venda.fiscal.nfe.date.split("T")[1]||"").slice(0,5),
+      who: "sistema",
+      kind: "reject",
+      desc: `NF-e rejeitada: ${venda.fiscal.nfe.failReason}`,
+    });
+  }
+  return entries;
+}
+window.vdAuditTrail = vdAuditTrail;
+
+function VdAuditTrail({ venda }) {
+  const entries = useMemoCu(() => vdAuditTrail(venda), [venda.id]);
+  const KIND_LABEL = { create:"criou", edit:"editou", fiscal:"fiscal", reject:"erro" };
+  const KIND_IC = { create:"+", edit:"✎", fiscal:"📄", reject:"⚠" };
+  return (
+    <div className="vd-audit">
+      <div className="vd-audit-h">
+        <h4>Histórico de edições</h4>
+        <small>{entries.length} entradas · auditoria fiscal</small>
+      </div>
+      <ul className="vd-audit-list">
+        {entries.map((e, i) => (
+          <li key={i} className={`vd-audit-row vd-audit-${e.kind}`}>
+            <span className="vd-audit-ic">{KIND_IC[e.kind] || "·"}</span>
+            <div className="vd-audit-body">
+              <header>
+                <b>{e.who}</b>
+                <span className="vd-audit-action">{KIND_LABEL[e.kind] || ""}</span>
+                <time>{e.when}</time>
+              </header>
+              <p>{e.desc}</p>
+              {e.diff && (
+                <div className="vd-audit-diff">
+                  <span className="diff-from">R$ {e.diff.from.toFixed(2)}</span>
+                  <span className="diff-arr">→</span>
+                  <span className="diff-to">R$ {e.diff.to.toFixed(2)}</span>
+                  <span className={`diff-pct ${e.diff.pct < 0 ? "neg" : "pos"}`}>
+                    {e.diff.pct > 0 ? "+" : ""}{e.diff.pct.toFixed(1)}%
+                  </span>
+                </div>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+window.VdAuditTrail = VdAuditTrail;
+
+// ──────────────────────────────────────────────────────────────
+// 3) TROUBLESHOOTER DE VENDA — reuso KBTroubleshooterDialog com customTroubles
+// ──────────────────────────────────────────────────────────────
+const VENDAS_TROUBLES = [
+  {
+    id: "tr-nfe-rejeitada",
+    title: "NF-e foi rejeitada pela SEFAZ",
+    equip: "fiscal",
+    hue: 25,
+    when: "código de rejeição apareceu no drawer Fiscal",
+    steps: [
+      { q: "É código 539 (duplicidade de número)?",
+        yes: { fix: "Você já emitiu esse número antes. Em Fiscal → consultar último número, use o PRÓXIMO da sequência. Antes de re-emitir, SEMPRE inutilize o número rejeitado pra não furar a sequência fiscal." },
+        no:  1 },
+      { q: "É código 692 (Inscrição Estadual inválida)?",
+        yes: { fix: "IE do destinatário está errada ou desativada. Consulte o cliente no SINTEGRA da UF dele. Atualize o cadastro em Clientes → CNPJ/IE → Re-validar. Reabra a venda e re-emita." },
+        no:  2 },
+      { q: "É código 778 (CFOP inválido)?",
+        yes: { fix: "Operação dentro do estado usa 5102 (venda mercadoria). Fora do estado usa 6102. Ajuste no item da venda ou no cadastro do produto, e re-emita." },
+        no:  3 },
+      { q: "É código 402 (origem da mercadoria)?",
+        yes: { fix: "Falta cadastrar origem do produto. Vai em Produtos → este item → Origem: 0 (Nacional) ou 1 (Estrangeira direto). Salva e re-emite a NF-e." },
+        no:  4 },
+      { q: "É código 539 ou 539 ou outro de NCM?",
+        yes: { fix: "NCM do produto diverge do cadastro SEFAZ. Confira a tabela NCM oficial (gov.br/receita) e corrija no produto. Mais em #a9." },
+        no:  { fix: "Código fora da lista comum. Abra o XML da rejeição (drawer Fiscal → Logs → última transmissão), copie o código e poste no canal #financeiro pra Eliana analisar. Não re-emita sem inutilizar." } },
+    ],
+  },
+  {
+    id: "tr-cliente-sem-cnpj",
+    title: "Cliente quer faturar mas não tem CNPJ",
+    equip: "balcão",
+    hue: 60,
+    when: "B2B sem documento — bloqueia NF-e",
+    steps: [
+      { q: "Cliente é pessoa física e quer só recibo?",
+        yes: { fix: "Emite NFC-e (cupom consumidor) com CPF na nota — opcional, mas vai pro programa Nota Premiada. Não emite NF-e modelo 55. O recibo térmica + a NFC-e atendem." },
+        no:  1 },
+      { q: "É empresa em formalização (MEI/ME novo)?",
+        yes: { fix: "Cliente tem 30 dias após registro pra emitir IE. Enquanto isso, emite com 'ISENTO' no campo IE. NF-e modelo 55 com CFOP 5102. Anota no clientNote o prazo final." },
+        no:  2 },
+      { q: "É órgão público / sem CNPJ próprio?",
+        yes: { fix: "Pode emitir nota com IE de Substituto Tributário OU pelo CNPJ da matriz. Pergunta no atendimento qual modelo a contabilidade do órgão exige." },
+        no:  { fix: "Sem CNPJ válido, só dá pra emitir NFC-e (cupom). Se o cliente exige NF-e, peça o CNPJ ou negue a venda nesse formato — não há saída fiscal." } },
+    ],
+  },
+  {
+    id: "tr-cliente-desistiu",
+    title: "Cliente desistiu depois de pagar",
+    equip: "atendimento",
+    hue: 320,
+    when: "venda paga + cliente pediu cancelamento",
+    steps: [
+      { q: "A NF-e já foi autorizada SEFAZ?",
+        yes: 1,
+        no:  { fix: "Ainda dá pra cancelar a venda sem complicação fiscal. Marque como 'Cancelada' no drawer e reembolse via PIX direto. Anote o motivo." } },
+      { q: "Faz menos de 24h da autorização?",
+        yes: { fix: "Use 'Cancelar NF-e' no drawer Fiscal. Justificativa obrigatória (mín 15 caracteres). SEFAZ autoriza em ~30s. Reembolse via PIX. Em Devoluções, registra com motivo 'desistencia'." },
+        no:  2 },
+      { q: "Produto foi entregue ou retirado?",
+        yes: { fix: "Cliente devolve o produto. Você emite NF-e de DEVOLUÇÃO (CFOP 1202/2202 dentro/fora estado). Reembolse após receber. Em Devoluções, motivo 'desistencia' + tipo 'estorno'." },
+        no:  { fix: "Após 24h, NF-e original não cancela mais. Emite NF-e de DEVOLUÇÃO (CFOP 1202/2202). Cliente assina termo de não-retirada. Reembolso via PIX em até 7 dias." } },
+    ],
+  },
+];
+window.VENDAS_TROUBLES = VENDAS_TROUBLES;
+
+// ──────────────────────────────────────────────────────────────
+// 4) CROSS-LINK — #V-7825 #OS-4831 #CLI-Cliente #orc-123
+// ──────────────────────────────────────────────────────────────
+function VdLinkify({ text, onPick }) {
+  if (!text || typeof text !== "string") return text;
+  // Padrões: #V-1234 (Venda), #OS-1234 (Ordem), #CLI-Nome, #orc-1234 (Orçamento),
+  //          #BL-1234 (Boleto), #PC-1234 (Pedido de Compra),
+  //          #R-NNNN/#P-NNNN (Lançamento Financeiro)
+  const re = /#(V-\d+|OS-\d+|CLI-[\wÀ-ÿ]+|orc-\d+|os\d+|cli\d+|BL-\d+|PC-\d+|R-\d+[a-z]?|P-\d+)/gi;
+  const parts = [];
+  let last = 0, m, i = 0;
+  while ((m = re.exec(text)) !== null) {
+    if (m.index > last) parts.push(text.slice(last, m.index));
+    const tok = m[0]; // ex "#V-7825"
+    const id = m[1];  // sem "#"
+    const upper = id.toUpperCase();
+    let cls;
+    if (upper.startsWith("V-")) cls = "venda";
+    else if (upper.startsWith("OS-") || upper.toLowerCase().startsWith("os")) cls = "os";
+    else if (upper.startsWith("CLI-") || upper.toLowerCase().startsWith("cli")) cls = "cli";
+    else if (upper.toLowerCase().startsWith("orc")) cls = "orc";
+    else if (upper.startsWith("BL-")) cls = "bol";
+    else if (upper.startsWith("PC-")) cls = "compra";
+    else if (upper.startsWith("R-")) cls = "fin-rec";
+    else if (upper.startsWith("P-")) cls = "fin-pay";
+    else cls = "ref";
+    parts.push(
+      <a key={"k" + i++}
+         className={`vd-link vd-link-${cls}`}
+         href="#"
+         onClick={e => { e.preventDefault(); onPick?.(id, cls); }}>
+        {tok}
+      </a>
+    );
+    last = m.index + tok.length;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return <React.Fragment>{parts}</React.Fragment>;
+}
+window.VdLinkify = VdLinkify;
+
+// ──────────────────────────────────────────────────────────────
+// BOTÃO LANÇADOR DO TROUBLESHOOTER (usado no drawer)
+// ──────────────────────────────────────────────────────────────
+function VdTroubleButton({ venda }) {
+  const [open, setOpen] = useStateCu(false);
+  // Sugere o trouble certo baseado no estado
+  const suggested = (() => {
+    if (venda.fiscal?.nfe?.status === "bad" || venda.fiscal?.nfse?.status === "bad") return "tr-nfe-rejeitada";
+    if (venda.client === "Consumidor Final" && venda.fsm < 4) return "tr-cliente-sem-cnpj";
+    return null;
+  })();
+  const sg = suggested ? VENDAS_TROUBLES.find(t => t.id === suggested) : null;
+
+  return (
+    <React.Fragment>
+      <button className="vd-trouble-btn" onClick={() => setOpen(true)}>
+        <span className="vd-trouble-ic">?</span>
+        <span className="vd-trouble-lbl">
+          {sg ? <>Resolver: <b>{sg.title}</b></> : "Guia de objeções"}
+        </span>
+        <span className="vd-trouble-ct">{VENDAS_TROUBLES.length} fluxos</span>
+      </button>
+      {open && window.KBTroubleshooterDialog && (
+        <window.KBTroubleshooterDialog
+          customTroubles={VENDAS_TROUBLES}
+          onClose={() => setOpen(false)}
+          onPickArticle={() => {}}
+          onCreateNew={() => {}}
+        />
+      )}
+    </React.Fragment>
+  );
+}
+window.VdTroubleButton = VdTroubleButton;

--- a/prototipo-ui/vendas-extras.jsx
+++ b/prototipo-ui/vendas-extras.jsx
@@ -1,0 +1,1269 @@
+// vendas-extras.jsx — Sub-páginas do módulo Vendas
+// Caixa do dia · Devoluções · Comissões · Relatórios · PDV balcão
+// Recibo (térmica + A4) · NF-e drawer
+// Compõe via VendasModule wrapper com sub-tabs
+
+const { useState: useStateVE, useMemo: useMemoVE, useEffect: useEffectVE, useRef: useRefVE } = React;
+
+// Helpers compartilhados ────────────────────────────────────────────
+const _fmtBRL = (n) => (n || 0).toLocaleString("pt-BR", { style:"currency", currency:"BRL" });
+const _parseBRL = (s) => {
+  if (typeof s === "number") return s;
+  return parseFloat(String(s||"0").replace(/[^\d,-]/g,"").replace(",",".")) || 0;
+};
+
+// ═══════════════════════════════════════════════════════════════════
+// VENDAS MODULE — wrapper com sub-rotas
+// ═══════════════════════════════════════════════════════════════════
+function VendasModule() {
+  const [sub, setSub] = useStateVE(() => {
+    try { return localStorage.getItem("oimpresso.vendas.sub") || "lista"; }
+    catch (e) { return "lista"; }
+  });
+  const [pdvOpen, setPdvOpen] = useStateVE(false);
+
+  useEffectVE(() => {
+    try { localStorage.setItem("oimpresso.vendas.sub", sub); } catch (e) {}
+  }, [sub]);
+
+  // Expor setter pra header dropdown "Visões ▾" (vendas-page.jsx)
+  useEffectVE(() => {
+    window.__vendasSubSetter = setSub;
+    window.__vendasCurrentSub = sub;
+    window.__vendasPdvOpen = () => setPdvOpen(true);
+    return () => {
+      delete window.__vendasSubSetter;
+      delete window.__vendasCurrentSub;
+      delete window.__vendasPdvOpen;
+    };
+  }, [sub]);
+
+  const SUBS = [
+    { id:"lista",       label:"Vendas",       icon:"list"     },
+    { id:"caixa",       label:"Caixa do dia", icon:"cash"     },
+    { id:"devolucoes",  label:"Devoluções",   icon:"refund"   },
+    { id:"comissoes",   label:"Comissões",    icon:"trending" },
+    { id:"relatorios",  label:"Relatórios",   icon:"chart"    },
+  ];
+  // Expor lista global pro dropdown
+  window.__vendasSubs = SUBS;
+
+  let body;
+  if (sub === "lista")            body = <VendasListPage/>;
+  else if (sub === "caixa")       body = <VendasCaixaPage/>;
+  else if (sub === "devolucoes")  body = <VendasDevolucoesPage/>;
+  else if (sub === "comissoes")   body = <VendasComissoesPage/>;
+  else if (sub === "relatorios")  body = <VendasRelatoriosPage/>;
+
+  return (
+    <div className="vendas-module vendas-module-no-subnav">
+      <div className="vm-body">{body}</div>
+      {pdvOpen && <VendasPDVOverlay onClose={() => setPdvOpen(false)}/>}
+    </div>
+  );
+}
+
+// Mini icon set (usa SVG inline pra não depender do icons.jsx)
+function VMIcon({ name, size = 13 }) {
+  const s = { width:size, height:size, fill:"none", stroke:"currentColor", strokeWidth:1.6, strokeLinecap:"round", strokeLinejoin:"round" };
+  switch (name) {
+    case "list":     return <svg viewBox="0 0 16 16" {...s}><line x1="3" y1="4" x2="13" y2="4"/><line x1="3" y1="8" x2="13" y2="8"/><line x1="3" y1="12" x2="13" y2="12"/></svg>;
+    case "cash":     return <svg viewBox="0 0 16 16" {...s}><rect x="2" y="4" width="12" height="8" rx="1"/><circle cx="8" cy="8" r="1.5"/></svg>;
+    case "refund":   return <svg viewBox="0 0 16 16" {...s}><path d="M3 8 a5 5 0 1 0 1.5-3.5"/><polyline points="3,3 3,5 5,5"/></svg>;
+    case "trending": return <svg viewBox="0 0 16 16" {...s}><polyline points="2,11 6,7 9,9 14,4"/><polyline points="11,4 14,4 14,7"/></svg>;
+    case "chart":    return <svg viewBox="0 0 16 16" {...s}><line x1="3" y1="13" x2="13" y2="13"/><rect x="4" y="8" width="2" height="5"/><rect x="7" y="5" width="2" height="8"/><rect x="10" y="9" width="2" height="4"/></svg>;
+    case "screen":   return <svg viewBox="0 0 16 16" {...s}><rect x="2" y="3" width="12" height="8" rx="1"/><line x1="6" y1="13" x2="10" y2="13"/></svg>;
+    default: return null;
+  }
+}
+
+// ──────────────────────────────────────────────────────────────
+// BREADCRUMB compartilhado pras 4 sub-páginas (Refino navegação 2026-05-17)
+// "← Vendas · Caixa do dia" — clicar volta pra Lista
+// ──────────────────────────────────────────────────────────────
+function VdSubBreadcrumb({ here }) {
+  const goLista = () => {
+    if (window.__vendasSubSetter) window.__vendasSubSetter("lista");
+  };
+  return (
+    <nav className="vd-bcrumb" aria-label="Navegação">
+      <button className="vd-bcrumb-back" onClick={goLista} title="Voltar pra lista de vendas (esc)">
+        <svg width="12" height="12" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"><polyline points="10,3 5,8 10,13"/></svg>
+        Vendas
+      </button>
+      <span className="vd-bcrumb-sep">›</span>
+      <span className="vd-bcrumb-here">{here}</span>
+    </nav>
+  );
+}
+window.VdSubBreadcrumb = VdSubBreadcrumb;
+
+// Atalho global Esc nas sub-rotas — volta pra lista
+function useVdSubEsc(active) {
+  useEffectVE(() => {
+    if (!active) return;
+    const onKey = (e) => {
+      if (e.key !== "Escape") return;
+      // se há overlay aberto, não captura
+      if (document.querySelector(".os-drawer-back, .vd-cheat-bd, .vd-trans-bd, .vd-pres-overlay, .pdv-overlay")) return;
+      if (window.__vendasSubSetter && window.__vendasCurrentSub !== "lista") {
+        e.preventDefault();
+        window.__vendasSubSetter("lista");
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [active]);
+}
+window.useVdSubEsc = useVdSubEsc;
+
+// ═══════════════════════════════════════════════════════════════════
+// 1) CAIXA DO DIA — fechamento, sangria, conferência
+// ═══════════════════════════════════════════════════════════════════
+function VendasCaixaPage() {
+  useVdSubEsc(true);
+  const { VENDAS_LIST, VENDAS_PAYMENTS } = window.VENDAS_DATA;
+  const [date, setDate] = useStateVE("2026-04-30");
+  const [openingCash, setOpeningCash] = useStateVE(200.00);
+  const [countedCash, setCountedCash] = useStateVE(580.00);
+  const [moves, setMoves] = useStateVE([
+    { id:1, time:"08:30", type:"abertura",   amount:200,   note:"Saldo inicial",       user:"Larissa" },
+    { id:2, time:"10:15", type:"suprimento", amount:300,   note:"Troco do cofre",      user:"Larissa" },
+    { id:3, time:"13:40", type:"sangria",    amount:-500,  note:"Depósito banco",      user:"Larissa" },
+    { id:4, time:"16:50", type:"sangria",    amount:-200,  note:"Pagamento fornecedor", user:"Larissa" },
+  ]);
+  const [moveDraft, setMoveDraft] = useStateVE({ type:"sangria", amount:"", note:"" });
+
+  const dayVendas = useMemoVE(() =>
+    VENDAS_LIST.filter(v => v.date === date && v.status !== "cancelada"),
+  [VENDAS_LIST, date]);
+
+  // Total por forma de pagamento
+  const byPayment = useMemoVE(() => {
+    const map = {};
+    VENDAS_PAYMENTS.forEach(p => { map[p.label] = { count:0, total:0, payment:p }; });
+    map["Boleto 30d"] = map["Boleto 30d"] || { count:0, total:0, payment:{ label:"Boleto 30d", icon:"📄", clearing:"30 dias" } };
+    map["Boleto 60d"] = map["Boleto 60d"] || { count:0, total:0, payment:{ label:"Boleto 60d", icon:"📄", clearing:"60 dias" } };
+    dayVendas.forEach(v => {
+      const k = v.payment;
+      if (!map[k]) map[k] = { count:0, total:0, payment:{ label:k, icon:"💰", clearing:"—" } };
+      map[k].count += 1;
+      map[k].total += _parseBRL(v.total);
+    });
+    return Object.values(map).filter(x => x.count > 0 || ["PIX","Dinheiro","Cartão"].includes(x.payment.label));
+  }, [dayVendas]);
+
+  const cashSales = byPayment.find(x => x.payment.label === "Dinheiro")?.total || 0;
+  const movesSum = moves.reduce((s,m) => s + m.amount, 0);
+  const expectedCash = movesSum + cashSales;
+  const diff = countedCash - expectedCash;
+
+  const totalDay = dayVendas.reduce((s,v) => s + _parseBRL(v.total), 0);
+
+  const addMove = () => {
+    if (!moveDraft.amount) return;
+    const sign = moveDraft.type === "sangria" ? -1 : 1;
+    setMoves(prev => [...prev, {
+      id: Date.now(),
+      time: new Date().toLocaleTimeString("pt-BR", { hour:"2-digit", minute:"2-digit" }),
+      type: moveDraft.type,
+      amount: sign * Math.abs(parseFloat(moveDraft.amount) || 0),
+      note: moveDraft.note || "—",
+      user: "Larissa",
+    }]);
+    setMoveDraft({ type:"sangria", amount:"", note:"" });
+  };
+
+  return (
+    <div className="os-page vc-page vd-subpage">
+      <VdSubBreadcrumb here="Caixa do dia"/>
+      <header className="os-head">
+        <div className="os-head-l">
+          <h1>Caixa do dia</h1>
+          <p>Conferência por forma de pagamento, sangrias e fechamento</p>
+        </div>
+        <div className="os-head-r">
+          <input type="date" className="vc-date" value={date} onChange={e => setDate(e.target.value)}/>
+          <button className="os-btn ghost"><VMIcon name="cash" size={11}/>Imprimir Z</button>
+          <button className="os-btn primary">Fechar caixa</button>
+        </div>
+      </header>
+
+      <div className="os-kpis">
+        <div className="os-kpi">
+          <span className="os-kpi-label">Faturado no dia</span>
+          <span className="os-kpi-value">{_fmtBRL(totalDay)}</span>
+          <span className="os-kpi-sub">{dayVendas.length} venda{dayVendas.length !== 1 ? "s" : ""}</span>
+        </div>
+        <div className="os-kpi">
+          <span className="os-kpi-label">Esperado em caixa</span>
+          <span className="os-kpi-value">{_fmtBRL(expectedCash)}</span>
+          <span className="os-kpi-sub">dinheiro + sangrias</span>
+        </div>
+        <div className="os-kpi">
+          <span className="os-kpi-label">Conferido</span>
+          <span className="os-kpi-value">{_fmtBRL(countedCash)}</span>
+          <span className="os-kpi-sub">contagem física</span>
+        </div>
+        <div className={"os-kpi" + (Math.abs(diff) > 0.01 ? " os-kpi-alert" : "")}>
+          <span className="os-kpi-label">Diferença</span>
+          <span className="os-kpi-value" style={{
+            color: Math.abs(diff) < 0.01 ? "oklch(0.50 0.14 145)" : (diff < 0 ? "oklch(0.55 0.18 25)" : "oklch(0.55 0.14 70)")
+          }}>{diff >= 0 ? "+" : ""}{_fmtBRL(diff)}</span>
+          <span className="os-kpi-sub">{Math.abs(diff) < 0.01 ? "ok" : (diff < 0 ? "falta" : "sobra")}</span>
+        </div>
+      </div>
+
+      <div className="vc-grid">
+        <section className="vc-card">
+          <header className="vc-card-h">
+            <h3>Por forma de pagamento</h3>
+            <span className="vc-muted">{date.split("-").reverse().join("/")}</span>
+          </header>
+          <table className="vc-pay-table">
+            <thead><tr><th>Forma</th><th>Compensação</th><th>Vendas</th><th>Total</th></tr></thead>
+            <tbody>
+              {byPayment.map(x => (
+                <tr key={x.payment.label}>
+                  <td><span className="vc-pay-icon">{x.payment.icon}</span> {x.payment.label}</td>
+                  <td className="vc-muted">{x.payment.clearing}</td>
+                  <td className="vc-num">{x.count}</td>
+                  <td className="vc-num strong">{_fmtBRL(x.total)}</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr><td colSpan="3">Total bruto</td><td className="vc-num strong">{_fmtBRL(totalDay)}</td></tr>
+            </tfoot>
+          </table>
+        </section>
+
+        <section className="vc-card">
+          <header className="vc-card-h">
+            <h3>Movimentos do caixa</h3>
+            <span className="vc-muted">{moves.length} lançamentos</span>
+          </header>
+          <ul className="vc-moves">
+            {moves.map(m => (
+              <li key={m.id} className={"vc-move vc-move-" + m.type}>
+                <span className="vc-move-time">{m.time}</span>
+                <span className="vc-move-type">{m.type}</span>
+                <span className="vc-move-note">{m.note}</span>
+                <span className={"vc-move-amount " + (m.amount < 0 ? "neg" : "pos")}>
+                  {m.amount >= 0 ? "+" : ""}{_fmtBRL(m.amount)}
+                </span>
+              </li>
+            ))}
+          </ul>
+          <div className="vc-move-add">
+            <select value={moveDraft.type} onChange={e => setMoveDraft({...moveDraft, type:e.target.value})}>
+              <option value="sangria">Sangria</option>
+              <option value="suprimento">Suprimento</option>
+            </select>
+            <input type="number" placeholder="Valor" value={moveDraft.amount}
+                   onChange={e => setMoveDraft({...moveDraft, amount:e.target.value})}/>
+            <input placeholder="Motivo" value={moveDraft.note}
+                   onChange={e => setMoveDraft({...moveDraft, note:e.target.value})}/>
+            <button className="os-btn primary" onClick={addMove}>Lançar</button>
+          </div>
+        </section>
+
+        <section className="vc-card">
+          <header className="vc-card-h">
+            <h3>Conferência física</h3>
+            <span className="vc-muted">conte e digite</span>
+          </header>
+          <div className="vc-counter">
+            <label>
+              <span>Saldo de abertura</span>
+              <input type="number" step="0.01" value={openingCash}
+                     onChange={e => setOpeningCash(parseFloat(e.target.value)||0)}/>
+            </label>
+            <label>
+              <span>Total contado em espécie</span>
+              <input type="number" step="0.01" className="vc-counter-big" value={countedCash}
+                     onChange={e => setCountedCash(parseFloat(e.target.value)||0)}/>
+            </label>
+            <dl className="vc-counter-summary">
+              <dt>+ Vendas em dinheiro</dt><dd>{_fmtBRL(cashSales)}</dd>
+              <dt>+ Suprimentos</dt><dd>{_fmtBRL(moves.filter(m=>m.amount>0).reduce((s,m)=>s+m.amount,0))}</dd>
+              <dt>− Sangrias</dt><dd>{_fmtBRL(Math.abs(moves.filter(m=>m.amount<0).reduce((s,m)=>s+m.amount,0)))}</dd>
+              <dt>= Esperado</dt><dd className="strong">{_fmtBRL(expectedCash)}</dd>
+            </dl>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 2) DEVOLUÇÕES — fluxo de cancelar venda paga
+// ═══════════════════════════════════════════════════════════════════
+const _MOCK_DEVOLUCOES = [
+  { id:"D-104", date:"2026-04-29", vendaId:"V-7818", client:"Café Aroma Doce",     reason:"defeito",   items:1, total:680,    refund:"PIX",      status:"concluida",  user:"Bruna Vendas"   },
+  { id:"D-105", date:"2026-04-30", vendaId:"V-7820", client:"Loja Mini Shopping",   reason:"erro_arte", items:2, total:1240,   refund:"crédito",  status:"em_analise", user:"Carlos Vendas"  },
+  { id:"D-106", date:"2026-04-30", vendaId:"V-7825", client:"Farmácia Vida Plena",  reason:"atraso",    items:1, total:1620,   refund:"estorno",  status:"em_analise", user:"Wagner"         },
+];
+
+function VendasDevolucoesPage() {
+  useVdSubEsc(true);
+  const { VENDAS_LIST } = window.VENDAS_DATA;
+  const [list, setList] = useStateVE(_MOCK_DEVOLUCOES);
+  const [openId, setOpenId] = useStateVE(null);
+  const [createOpen, setCreateOpen] = useStateVE(false);
+
+  const stats = {
+    pendentes: list.filter(d => d.status === "em_analise").length,
+    mes:       list.length,
+    valor:     list.reduce((s,d) => s + d.total, 0),
+  };
+
+  const open = openId ? list.find(d => d.id === openId) : null;
+  const STATUS = {
+    em_analise: { label:"Em análise", color:"oklch(0.60 0.14 70)"  },
+    concluida:  { label:"Concluída",  color:"oklch(0.50 0.14 145)" },
+    recusada:   { label:"Recusada",   color:"oklch(0.55 0.18 25)"  },
+  };
+  const REASONS = {
+    defeito:   "Defeito de impressão",
+    erro_arte: "Erro de arte / aprovação",
+    atraso:    "Atraso na entrega",
+    desistencia: "Desistência do cliente",
+    outro:     "Outro",
+  };
+
+  return (
+    <div className="os-page vd-dev-page vd-subpage">
+      <VdSubBreadcrumb here="Devoluções e trocas"/>
+      <header className="os-head">
+        <div className="os-head-l">
+          <h1>Devoluções e trocas</h1>
+          <p>Cancelamento de venda paga, geração de crédito e estorno</p>
+        </div>
+        <div className="os-head-r">
+          <button className="os-btn primary" onClick={() => setCreateOpen(true)}>+ Nova devolução</button>
+        </div>
+      </header>
+
+      <div className="os-kpis">
+        <div className={"os-kpi" + (stats.pendentes > 0 ? " os-kpi-alert" : "")}>
+          <span className="os-kpi-label">Pendentes</span>
+          <span className="os-kpi-value">{stats.pendentes}</span>
+          <span className="os-kpi-sub">aguardando análise</span>
+        </div>
+        <div className="os-kpi">
+          <span className="os-kpi-label">Devoluções no mês</span>
+          <span className="os-kpi-value">{stats.mes}</span>
+          <span className="os-kpi-sub">total registrado</span>
+        </div>
+        <div className="os-kpi">
+          <span className="os-kpi-label">Valor estornado</span>
+          <span className="os-kpi-value">{_fmtBRL(stats.valor)}</span>
+          <span className="os-kpi-sub">crédito + estorno</span>
+        </div>
+      </div>
+
+      <div className="os-table-wrap">
+        <table className="os-table">
+          <thead>
+            <tr>
+              <th style={{width:90}}>Devolução</th>
+              <th style={{width:100}}>Data</th>
+              <th style={{width:100}}>Venda orig.</th>
+              <th>Cliente</th>
+              <th>Motivo</th>
+              <th style={{width:120}}>Tipo retorno</th>
+              <th style={{width:120}}>Total</th>
+              <th style={{width:120}}>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {list.map(d => (
+              <tr key={d.id} className="os-row" onClick={() => setOpenId(d.id)}>
+                <td className="vd-id">#{d.id}</td>
+                <td>{d.date.slice(8,10)}/{d.date.slice(5,7)}</td>
+                <td className="vd-id">#{d.vendaId}</td>
+                <td><strong>{d.client}</strong></td>
+                <td>{REASONS[d.reason]}</td>
+                <td>{d.refund}</td>
+                <td className="vd-total">{_fmtBRL(d.total)}</td>
+                <td>
+                  <span className="os-stage" style={{ background: STATUS[d.status].color + "1f", color: STATUS[d.status].color }}>
+                    {STATUS[d.status].label}
+                  </span>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {open && (
+        <div className="os-drawer-back" onClick={() => setOpenId(null)}>
+          <aside className="os-drawer wide" onClick={e => e.stopPropagation()}>
+            <header className="os-drawer-head">
+              <div className="os-drawer-head-l">
+                <span className="os-drawer-id">Devolução #{open.id}</span>
+                <h2>{open.client}</h2>
+                <p>Venda original #{open.vendaId} · {open.date.split("-").reverse().join("/")} · solicitado por {open.user}</p>
+              </div>
+              <div className="os-drawer-head-r">
+                <span className="os-stage" style={{ background: STATUS[open.status].color + "1f", color: STATUS[open.status].color }}>
+                  {STATUS[open.status].label}
+                </span>
+                <button className="icon-btn" onClick={() => setOpenId(null)}>×</button>
+              </div>
+            </header>
+            <div className="os-drawer-body">
+              <section className="vd-section">
+                <h3>Motivo</h3>
+                <p className="vdv-reason">{REASONS[open.reason]}</p>
+              </section>
+              <section className="vd-section">
+                <h3>Resolução</h3>
+                <dl className="vd-meta">
+                  <dt>Itens devolvidos</dt><dd>{open.items}</dd>
+                  <dt>Tipo de retorno</dt><dd>{open.refund}</dd>
+                  <dt>Valor</dt><dd className="vd-total-strong">{_fmtBRL(open.total)}</dd>
+                </dl>
+              </section>
+              <section className="vd-section">
+                <h3>Linha do tempo</h3>
+                <ul className="vdv-timeline">
+                  <li><span className="vdv-tl-dot ok"/>Solicitação registrada · 08:42</li>
+                  <li><span className="vdv-tl-dot active"/>Análise pelo gestor · pendente</li>
+                  <li><span className="vdv-tl-dot"/>Estorno / crédito processado</li>
+                  <li><span className="vdv-tl-dot"/>NF-e de devolução emitida</li>
+                </ul>
+              </section>
+            </div>
+            <footer className="os-drawer-actions">
+              {open.status === "em_analise" && (
+                <>
+                  <button className="os-btn" style={{ color:"oklch(0.55 0.18 25)" }}>Recusar</button>
+                  <button className="os-btn primary">Aprovar e estornar</button>
+                </>
+              )}
+              <button className="os-btn ghost">Imprimir comprovante</button>
+            </footer>
+          </aside>
+        </div>
+      )}
+
+      {createOpen && <DevolucaoCreateDrawer onClose={() => setCreateOpen(false)} onSave={(d) => { setList(prev => [d, ...prev]); setCreateOpen(false); }}/>}
+    </div>
+  );
+}
+
+function DevolucaoCreateDrawer({ onClose, onSave }) {
+  const { VENDAS_LIST } = window.VENDAS_DATA;
+  const [vendaId, setVendaId] = useStateVE("");
+  const [reason, setReason] = useStateVE("defeito");
+  const [refund, setRefund] = useStateVE("PIX");
+  const [items, setItems] = useStateVE(1);
+  const [note, setNote] = useStateVE("");
+  const venda = VENDAS_LIST.find(v => v.id === vendaId);
+
+  const matches = vendaId.trim() ? VENDAS_LIST.filter(v =>
+    v.id.toLowerCase().includes(vendaId.toLowerCase()) ||
+    v.client.toLowerCase().includes(vendaId.toLowerCase())
+  ).slice(0,5) : [];
+
+  return (
+    <div className="os-drawer-back" onClick={onClose}>
+      <aside className="os-drawer" onClick={e => e.stopPropagation()}>
+        <header className="os-drawer-head">
+          <div className="os-drawer-head-l">
+            <span className="os-drawer-id">Nova devolução</span>
+            <h2>Selecione a venda original</h2>
+            <p>Apenas vendas <strong>pagas</strong> ou <strong>faturadas</strong> podem ser devolvidas</p>
+          </div>
+          <button className="icon-btn" onClick={onClose}>×</button>
+        </header>
+        <div className="os-drawer-body">
+          <section className="vd-section">
+            <h3>Venda</h3>
+            <input className="vdv-input" placeholder="Buscar por código ou cliente..."
+                   value={vendaId} onChange={e => setVendaId(e.target.value)}/>
+            {matches.length > 0 && !venda && (
+              <div className="vdv-matches">
+                {matches.map(v => (
+                  <button key={v.id} className="vdv-match" onClick={() => setVendaId(v.id)}>
+                    <span className="vd-id">#{v.id}</span>
+                    <span>{v.client}</span>
+                    <span className="vd-total">{v.total}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+            {venda && (
+              <div className="vdv-selected">
+                <strong>{venda.client}</strong>
+                <span className="vd-total">{venda.total}</span>
+                <span className="vd-meta">{venda.notes}</span>
+              </div>
+            )}
+          </section>
+          <section className="vd-section">
+            <h3>Motivo</h3>
+            <div className="vdv-reasons">
+              {["defeito","erro_arte","atraso","desistencia","outro"].map(r => (
+                <button key={r} className={"vdv-reason-btn" + (reason === r ? " active" : "")} onClick={() => setReason(r)}>
+                  {{defeito:"Defeito impressão",erro_arte:"Erro de arte",atraso:"Atraso entrega",desistencia:"Desistência",outro:"Outro"}[r]}
+                </button>
+              ))}
+            </div>
+            <textarea className="vdv-textarea" placeholder="Detalhes (opcional)..." value={note} onChange={e => setNote(e.target.value)}/>
+          </section>
+          <section className="vd-section">
+            <h3>Resolução</h3>
+            <div className="vd-fields">
+              <label>Itens a devolver
+                <input type="number" min="1" max={venda?.items || 99} value={items} onChange={e => setItems(parseInt(e.target.value)||1)}/>
+              </label>
+              <label>Tipo de retorno
+                <select value={refund} onChange={e => setRefund(e.target.value)}>
+                  <option>PIX</option>
+                  <option>Estorno cartão</option>
+                  <option>Crédito em conta</option>
+                  <option>Troca por outro produto</option>
+                </select>
+              </label>
+            </div>
+          </section>
+        </div>
+        <footer className="os-drawer-actions">
+          <button className="os-btn ghost" onClick={onClose}>Cancelar</button>
+          <button className="os-btn primary" disabled={!venda} onClick={() => {
+            onSave({
+              id:"D-" + (200 + Math.floor(Math.random()*100)),
+              date: new Date().toISOString().slice(0,10),
+              vendaId: venda.id,
+              client: venda.client,
+              reason, refund, items,
+              total: _parseBRL(venda.total) * (items / Math.max(1, venda.items)),
+              status:"em_analise",
+              user:"Larissa",
+            });
+          }}>Registrar devolução</button>
+        </footer>
+      </aside>
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 3) COMISSÕES — relatório por vendedor
+// ═══════════════════════════════════════════════════════════════════
+function VendasComissoesPage() {
+  useVdSubEsc(true);
+  const { VENDAS_LIST } = window.VENDAS_DATA;
+  const [period, setPeriod] = useStateVE("mes");
+
+  // Regras de comissão por forma de pagamento
+  const COM_RATES = { "PIX":3, "Dinheiro":3, "Cartão":2, "Boleto 30d":2.5, "Boleto 60d":2, "Transferência":2.5 };
+
+  const sellers = useMemoVE(() => {
+    const map = {};
+    VENDAS_LIST.filter(v => v.status !== "cancelada").forEach(v => {
+      const s = v.seller;
+      if (!map[s]) map[s] = { name:s, vendas:0, faturado:0, comissao:0, ticketMaior:0, formas:{} };
+      const total = _parseBRL(v.total);
+      const rate = COM_RATES[v.payment] || 2;
+      map[s].vendas += 1;
+      map[s].faturado += total;
+      map[s].comissao += total * (rate/100);
+      map[s].ticketMaior = Math.max(map[s].ticketMaior, total);
+      map[s].formas[v.payment] = (map[s].formas[v.payment] || 0) + 1;
+    });
+    return Object.values(map).sort((a,b) => b.faturado - a.faturado);
+  }, [VENDAS_LIST]);
+
+  const totalGeral = sellers.reduce((s,x) => s + x.faturado, 0);
+  const maxFat = Math.max(1, ...sellers.map(s => s.faturado));
+
+  return (
+    <div className="os-page vco-page vd-subpage">
+      <VdSubBreadcrumb here="Comissões"/>
+      <header className="os-head">
+        <div className="os-head-l">
+          <h1>Comissões</h1>
+          <p>Performance por vendedor · faturamento e comissão calculada por forma de pagamento</p>
+        </div>
+        <div className="os-head-r">
+          <div className="vco-period">
+            {[{id:"semana",l:"Semana"},{id:"mes",l:"Mês"},{id:"trimestre",l:"Trimestre"}].map(p => (
+              <button key={p.id} className={period === p.id ? "active" : ""} onClick={() => setPeriod(p.id)}>{p.l}</button>
+            ))}
+          </div>
+          <button className="os-btn ghost">Exportar CSV</button>
+        </div>
+      </header>
+
+      <div className="os-kpis">
+        <div className="os-kpi">
+          <span className="os-kpi-label">Faturamento</span>
+          <span className="os-kpi-value">{_fmtBRL(totalGeral)}</span>
+          <span className="os-kpi-sub">{period}</span>
+        </div>
+        <div className="os-kpi">
+          <span className="os-kpi-label">Comissão a pagar</span>
+          <span className="os-kpi-value">{_fmtBRL(sellers.reduce((s,x) => s + x.comissao, 0))}</span>
+          <span className="os-kpi-sub">total time</span>
+        </div>
+        <div className="os-kpi">
+          <span className="os-kpi-label">Vendedores ativos</span>
+          <span className="os-kpi-value">{sellers.length}</span>
+          <span className="os-kpi-sub">com vendas no período</span>
+        </div>
+        <div className="os-kpi">
+          <span className="os-kpi-label">Top vendedor</span>
+          <span className="os-kpi-value" style={{ fontSize:18 }}>{sellers[0]?.name.split(" ")[0] || "—"}</span>
+          <span className="os-kpi-sub">{_fmtBRL(sellers[0]?.faturado || 0)}</span>
+        </div>
+      </div>
+
+      <div className="vco-grid">
+        {sellers.map(s => (
+          <article key={s.name} className="vco-card">
+            <header>
+              <div className="vco-avatar">{s.name.split(" ").map(w => w[0]).slice(0,2).join("")}</div>
+              <div>
+                <h3>{s.name}</h3>
+                <span>{s.vendas} venda{s.vendas !== 1 ? "s" : ""} · ticket maior {_fmtBRL(s.ticketMaior)}</span>
+              </div>
+              <div className="vco-rank">#{sellers.indexOf(s)+1}</div>
+            </header>
+            <div className="vco-bar">
+              <div className="vco-bar-fill" style={{ width: (100*s.faturado/maxFat) + "%" }}/>
+            </div>
+            <div className="vco-numbers">
+              <div>
+                <span>Faturado</span>
+                <strong>{_fmtBRL(s.faturado)}</strong>
+              </div>
+              <div className="vco-com">
+                <span>Comissão</span>
+                <strong>{_fmtBRL(s.comissao)}</strong>
+              </div>
+            </div>
+            <div className="vco-mix">
+              {Object.entries(s.formas).map(([k,n]) => (
+                <span key={k} className="vco-chip">{k} <em>{n}</em></span>
+              ))}
+            </div>
+          </article>
+        ))}
+      </div>
+
+      <section className="vco-table-card">
+        <h3>Regras de comissão</h3>
+        <table className="vco-rules">
+          <thead><tr><th>Forma de pagamento</th><th>% comissão</th><th>Critério</th></tr></thead>
+          <tbody>
+            {Object.entries(COM_RATES).map(([k,v]) => (
+              <tr key={k}><td>{k}</td><td>{v.toFixed(1)}%</td><td className="vd-meta">sobre o total da venda</td></tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 4) RELATÓRIOS — gráficos + filtros + export
+// ═══════════════════════════════════════════════════════════════════
+function VendasRelatoriosPage() {
+  useVdSubEsc(true);
+  const { VENDAS_LIST } = window.VENDAS_DATA;
+  const [view, setView] = useStateVE("periodo");
+
+  // Por dia
+  const byDay = useMemoVE(() => {
+    const map = {};
+    VENDAS_LIST.filter(v => v.status !== "cancelada").forEach(v => {
+      map[v.date] = (map[v.date] || 0) + _parseBRL(v.total);
+    });
+    return Object.entries(map).sort((a,b) => a[0].localeCompare(b[0])).map(([d,t]) => ({ date:d, total:t }));
+  }, [VENDAS_LIST]);
+
+  const maxDay = Math.max(1, ...byDay.map(d => d.total));
+  const totalPeriodo = byDay.reduce((s,d) => s + d.total, 0);
+  const ticketMedio = totalPeriodo / Math.max(1, VENDAS_LIST.filter(v => v.status !== "cancelada").length);
+
+  // Por cliente
+  const byClient = useMemoVE(() => {
+    const map = {};
+    VENDAS_LIST.filter(v => v.status !== "cancelada").forEach(v => {
+      if (!map[v.client]) map[v.client] = { client:v.client, n:0, total:0 };
+      map[v.client].n += 1;
+      map[v.client].total += _parseBRL(v.total);
+    });
+    return Object.values(map).sort((a,b) => b.total - a.total);
+  }, [VENDAS_LIST]);
+  const maxClient = Math.max(1, ...byClient.map(c => c.total));
+
+  // Por origem
+  const byOrigin = useMemoVE(() => {
+    const map = { balcão:0, orçamento:0 };
+    VENDAS_LIST.filter(v => v.status !== "cancelada").forEach(v => {
+      map[v.origin] = (map[v.origin] || 0) + _parseBRL(v.total);
+    });
+    return map;
+  }, [VENDAS_LIST]);
+  const totalOrigin = byOrigin.balcão + byOrigin.orçamento;
+
+  return (
+    <div className="os-page vrep-page vd-subpage">
+      <VdSubBreadcrumb here="Relatórios de vendas"/>
+      <header className="os-head">
+        <div className="os-head-l">
+          <h1>Relatórios de vendas</h1>
+          <p>Vendas por período · cliente · origem · vendedor</p>
+        </div>
+        <div className="os-head-r">
+          <button className="os-btn ghost">Exportar CSV</button>
+          <button className="os-btn ghost">PDF</button>
+        </div>
+      </header>
+
+      <nav className="vrep-tabs">
+        {[
+          {id:"periodo",  l:"Por período"},
+          {id:"cliente",  l:"Por cliente"},
+          {id:"origem",   l:"Origem"},
+        ].map(t => (
+          <button key={t.id} className={view === t.id ? "active" : ""} onClick={() => setView(t.id)}>{t.l}</button>
+        ))}
+      </nav>
+
+      <div className="vrep-summary">
+        <div><span>Total no período</span><strong>{_fmtBRL(totalPeriodo)}</strong></div>
+        <div><span>Vendas</span><strong>{VENDAS_LIST.filter(v => v.status !== "cancelada").length}</strong></div>
+        <div><span>Ticket médio</span><strong>{_fmtBRL(ticketMedio)}</strong></div>
+        <div><span>Maior venda</span><strong>{_fmtBRL(Math.max(...VENDAS_LIST.map(v => _parseBRL(v.total))))}</strong></div>
+      </div>
+
+      {view === "periodo" && (
+        <section className="vrep-card">
+          <h3>Faturamento por dia</h3>
+          <div className="vrep-bars">
+            {byDay.map(d => (
+              <div key={d.date} className="vrep-bar-col">
+                <span className="vrep-bar-val">{_fmtBRL(d.total)}</span>
+                <div className="vrep-bar" style={{ height: (100*d.total/maxDay) + "%" }}/>
+                <span className="vrep-bar-lbl">{d.date.slice(8,10)}/{d.date.slice(5,7)}</span>
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {view === "cliente" && (
+        <section className="vrep-card">
+          <h3>Top clientes por faturamento</h3>
+          <ul className="vrep-clients">
+            {byClient.map((c,i) => (
+              <li key={c.client}>
+                <span className="vrep-rank">{i+1}</span>
+                <span className="vrep-cli-name">{c.client}</span>
+                <span className="vrep-cli-n">{c.n} venda{c.n !== 1 ? "s" : ""}</span>
+                <div className="vrep-cli-bar"><div style={{ width: (100*c.total/maxClient) + "%" }}/></div>
+                <span className="vrep-cli-total">{_fmtBRL(c.total)}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {view === "origem" && (
+        <section className="vrep-card">
+          <h3>Origem da venda</h3>
+          <div className="vrep-origin">
+            <div className="vrep-donut" style={{
+              background: `conic-gradient(
+                var(--accent) 0 ${360*byOrigin.balcão/totalOrigin}deg,
+                oklch(0.85 0.06 145) ${360*byOrigin.balcão/totalOrigin}deg 360deg)`
+            }}>
+              <span>{Math.round(100*byOrigin.balcão/totalOrigin)}%</span>
+              <small>balcão</small>
+            </div>
+            <dl className="vrep-origin-legend">
+              <dt><span className="vrep-dot" style={{ background:"var(--accent)" }}/>Balcão</dt>
+              <dd>{_fmtBRL(byOrigin.balcão)} · {Math.round(100*byOrigin.balcão/totalOrigin)}%</dd>
+              <dt><span className="vrep-dot" style={{ background:"oklch(0.65 0.10 145)" }}/>Orçamento</dt>
+              <dd>{_fmtBRL(byOrigin.orçamento)} · {Math.round(100*byOrigin.orçamento/totalOrigin)}%</dd>
+            </dl>
+          </div>
+        </section>
+      )}
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 5) PDV BALCÃO — overlay full-screen
+// ═══════════════════════════════════════════════════════════════════
+function VendasPDVOverlay({ onClose }) {
+  const { OS_PRODUCTS } = window.OS_DATA;
+  const { VENDAS_PAYMENTS } = window.VENDAS_DATA;
+  const [items, setItems] = useStateVE([]);
+  const [scan, setScan] = useStateVE("");
+  const [client, setClient] = useStateVE("Consumidor Final");
+  const [payment, setPayment] = useStateVE("pix");
+  const [recibo, setRecibo] = useStateVE(null);
+  const inputRef = useRefVE(null);
+
+  useEffectVE(() => {
+    const onKey = (e) => {
+      if (e.key === "Escape") { e.preventDefault(); onClose(); }
+      if (e.key === "F4") { e.preventDefault(); finalize(); }
+    };
+    window.addEventListener("keydown", onKey);
+    inputRef.current?.focus();
+    return () => window.removeEventListener("keydown", onKey);
+  // eslint-disable-next-line
+  }, [items, payment]);
+
+  const matches = scan.trim() ? OS_PRODUCTS.filter(p =>
+    (p.name || p.label || "").toLowerCase().includes(scan.toLowerCase())
+  ).slice(0,4) : [];
+
+  const addItem = (p) => {
+    const price = _parseBRL(p.price);
+    setItems(prev => {
+      const exists = prev.find(it => it.product === (p.name || p.label));
+      if (exists) return prev.map(it => it === exists ? { ...it, qty: it.qty + 1 } : it);
+      return [...prev, { key: Date.now()+Math.random(), product: p.name || p.label, qty:1, unitPrice: price }];
+    });
+    setScan("");
+    inputRef.current?.focus();
+  };
+
+  const total = items.reduce((s,it) => s + it.unitPrice * it.qty, 0);
+
+  const finalize = () => {
+    if (items.length === 0) return;
+    setRecibo({
+      id: "V-" + (8000 + Math.floor(Math.random()*999)),
+      date: new Date().toLocaleDateString("pt-BR"),
+      time: new Date().toLocaleTimeString("pt-BR", { hour:"2-digit", minute:"2-digit" }),
+      client, payment: VENDAS_PAYMENTS.find(p => p.id === payment)?.label || "PIX",
+      items, total, seller: "Larissa",
+    });
+  };
+
+  if (recibo) return <ReciboView recibo={recibo} onNew={() => { setItems([]); setRecibo(null); inputRef.current?.focus(); }} onClose={onClose}/>;
+
+  return (
+    <div className="pdv-overlay">
+      <header className="pdv-head">
+        <div className="pdv-head-l">
+          <span className="pdv-brand">PDV BALCÃO</span>
+          <span className="pdv-sep">·</span>
+          <span>{new Date().toLocaleDateString("pt-BR")} {new Date().toLocaleTimeString("pt-BR", { hour:"2-digit", minute:"2-digit" })}</span>
+          <span className="pdv-sep">·</span>
+          <span>op: Larissa</span>
+        </div>
+        <div className="pdv-head-r">
+          <span className="pdv-shortcut"><kbd>F4</kbd> finalizar</span>
+          <span className="pdv-shortcut"><kbd>Esc</kbd> sair</span>
+          <button className="pdv-close" onClick={onClose}>×</button>
+        </div>
+      </header>
+
+      <div className="pdv-grid">
+        <div className="pdv-left">
+          <div className="pdv-scan">
+            <span className="pdv-scan-label">Código ou nome do produto</span>
+            <input ref={inputRef} className="pdv-scan-input" value={scan}
+                   placeholder="Bipe ou digite..."
+                   onChange={e => setScan(e.target.value)}
+                   onKeyDown={e => { if (e.key === "Enter" && matches[0]) addItem(matches[0]); }}/>
+            {matches.length > 0 && (
+              <ul className="pdv-suggest">
+                {matches.map((p,i) => (
+                  <li key={i} onClick={() => addItem(p)}>
+                    <span>{p.name || p.label}</span>
+                    <strong>{p.price}</strong>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          <div className="pdv-items-wrap">
+            {items.length === 0 ? (
+              <div className="pdv-empty">
+                <div className="pdv-empty-big">Aguardando primeiro item</div>
+                <div>Bipe um código ou digite o nome no campo acima</div>
+              </div>
+            ) : (
+              <table className="pdv-items">
+                <thead><tr><th style={{width:60}}>Qtd</th><th>Produto</th><th style={{width:140}}>Unit.</th><th style={{width:140}}>Subtotal</th><th style={{width:40}}/></tr></thead>
+                <tbody>
+                  {items.map(it => (
+                    <tr key={it.key}>
+                      <td>
+                        <div className="pdv-qty">
+                          <button onClick={() => setItems(prev => prev.map(x => x.key === it.key ? {...x, qty: Math.max(1, x.qty-1)} : x))}>−</button>
+                          <span>{it.qty}</span>
+                          <button onClick={() => setItems(prev => prev.map(x => x.key === it.key ? {...x, qty: x.qty+1} : x))}>+</button>
+                        </div>
+                      </td>
+                      <td className="pdv-prod">{it.product}</td>
+                      <td className="pdv-num">{_fmtBRL(it.unitPrice)}</td>
+                      <td className="pdv-num strong">{_fmtBRL(it.unitPrice * it.qty)}</td>
+                      <td><button className="pdv-rm" onClick={() => setItems(prev => prev.filter(x => x.key !== it.key))}>×</button></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </div>
+
+        <aside className="pdv-right">
+          <div className="pdv-client">
+            <span className="pdv-r-label">Cliente</span>
+            <input value={client} onChange={e => setClient(e.target.value)}/>
+          </div>
+
+          <div className="pdv-pay">
+            <span className="pdv-r-label">Pagamento</span>
+            <div className="pdv-pay-grid">
+              {VENDAS_PAYMENTS.slice(0,4).map(p => (
+                <button key={p.id} className={"pdv-pay-btn" + (payment === p.id ? " active" : "")} onClick={() => setPayment(p.id)}>
+                  <span className="pdv-pay-icon">{p.icon}</span>
+                  <span>{p.label}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="pdv-total-block">
+            <span className="pdv-total-label">TOTAL</span>
+            <strong className="pdv-total-value">{_fmtBRL(total)}</strong>
+            <span className="pdv-total-meta">{items.reduce((s,it) => s + it.qty, 0)} itens</span>
+          </div>
+
+          <button className="pdv-finalize" disabled={items.length === 0} onClick={finalize}>
+            Finalizar venda <kbd>F4</kbd>
+          </button>
+          <button className="pdv-cancel" onClick={() => setItems([])}>Cancelar tudo</button>
+        </aside>
+      </div>
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 6) RECIBO / CUPOM (térmica + A4)
+// ═══════════════════════════════════════════════════════════════════
+function ReciboView({ recibo, onNew, onClose }) {
+  const [layout, setLayout] = useStateVE("termica");
+  return (
+    <div className="pdv-overlay pdv-recibo-overlay">
+      <header className="pdv-head">
+        <div className="pdv-head-l">
+          <span className="pdv-brand">RECIBO #{recibo.id}</span>
+          <span className="pdv-sep">·</span>
+          <span>{recibo.date} {recibo.time}</span>
+        </div>
+        <div className="pdv-head-r">
+          <div className="rec-layout">
+            <button className={layout === "termica" ? "active" : ""} onClick={() => setLayout("termica")}>Térmica 80mm</button>
+            <button className={layout === "a4" ? "active" : ""} onClick={() => setLayout("a4")}>A4</button>
+          </div>
+          <button className="os-btn ghost" onClick={() => window.print()}>Imprimir</button>
+          <button className="os-btn primary" onClick={onNew}>Nova venda</button>
+          <button className="pdv-close" onClick={onClose}>×</button>
+        </div>
+      </header>
+      <div className="rec-stage">
+        {layout === "termica" ? <ReciboTermica recibo={recibo}/> : <ReciboA4 recibo={recibo}/>}
+      </div>
+    </div>
+  );
+}
+
+function ReciboTermica({ recibo }) {
+  return (
+    <div className="rec-paper rec-termica">
+      <div className="rec-tx-header">
+        <div className="rec-tx-title">OIMPRESSO COMUNICAÇÃO VISUAL</div>
+        <div>CNPJ 12.345.678/0001-90</div>
+        <div>Rua das Gráficas, 123 — Centro</div>
+        <div>—————————————————</div>
+        <div>CUPOM NÃO FISCAL</div>
+        <div>—————————————————</div>
+      </div>
+      <div className="rec-tx-meta">
+        <div>Venda: <b>#{recibo.id}</b></div>
+        <div>Data: {recibo.date} {recibo.time}</div>
+        <div>Op.: {recibo.seller}</div>
+        <div>Cliente: {recibo.client}</div>
+      </div>
+      <div className="rec-tx-divider">— — — — — — — — — — — —</div>
+      <table className="rec-tx-items">
+        {recibo.items.map(it => (
+          <React.Fragment key={it.key}>
+            <tr><td colSpan="3" className="rec-tx-prod">{it.product}</td></tr>
+            <tr>
+              <td>{it.qty} × {_fmtBRL(it.unitPrice)}</td>
+              <td/>
+              <td className="rec-tx-r">{_fmtBRL(it.unitPrice * it.qty)}</td>
+            </tr>
+          </React.Fragment>
+        ))}
+      </table>
+      <div className="rec-tx-divider">— — — — — — — — — — — —</div>
+      <div className="rec-tx-totals">
+        <div><span>SUBTOTAL</span><span>{_fmtBRL(recibo.total)}</span></div>
+        <div className="rec-tx-total"><span>TOTAL</span><span>{_fmtBRL(recibo.total)}</span></div>
+      </div>
+      <div className="rec-tx-pay">Pagamento: <b>{recibo.payment}</b></div>
+      <div className="rec-tx-divider">— — — — — — — — — — — —</div>
+      <div className="rec-tx-foot">
+        <div>Obrigado pela preferência!</div>
+        <div>oimpresso.com</div>
+        <div className="rec-tx-barcode">||| | ||| || | || ||| | |</div>
+      </div>
+    </div>
+  );
+}
+
+function ReciboA4({ recibo }) {
+  return (
+    <div className="rec-paper rec-a4">
+      <header className="rec-a4-h">
+        <div>
+          <div className="rec-a4-logo">OIMPRESSO</div>
+          <div className="rec-a4-tag">Comunicação Visual</div>
+        </div>
+        <div className="rec-a4-meta">
+          <div>CNPJ 12.345.678/0001-90</div>
+          <div>Rua das Gráficas, 123 — Centro</div>
+          <div>(11) 4000-1234 · oimpresso.com</div>
+        </div>
+      </header>
+      <div className="rec-a4-title">
+        <h1>RECIBO DE VENDA #{recibo.id}</h1>
+        <span>{recibo.date} às {recibo.time}</span>
+      </div>
+      <section className="rec-a4-block">
+        <h3>Cliente</h3>
+        <div>{recibo.client}</div>
+      </section>
+      <section className="rec-a4-block">
+        <h3>Itens</h3>
+        <table className="rec-a4-items">
+          <thead><tr><th>Produto</th><th>Qtd</th><th>Unit.</th><th>Subtotal</th></tr></thead>
+          <tbody>
+            {recibo.items.map(it => (
+              <tr key={it.key}>
+                <td>{it.product}</td>
+                <td>{it.qty}</td>
+                <td>{_fmtBRL(it.unitPrice)}</td>
+                <td>{_fmtBRL(it.unitPrice * it.qty)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </section>
+      <div className="rec-a4-totals">
+        <dl>
+          <dt>Subtotal</dt><dd>{_fmtBRL(recibo.total)}</dd>
+          <dt>Pagamento</dt><dd>{recibo.payment}</dd>
+          <dt className="rec-a4-total">Total</dt><dd className="rec-a4-total">{_fmtBRL(recibo.total)}</dd>
+        </dl>
+      </div>
+      <footer className="rec-a4-foot">
+        <div>Atendido por {recibo.seller}</div>
+        <div>Obrigado pela preferência. Documento não fiscal.</div>
+      </footer>
+    </div>
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════
+// 7) NF-e DRAWER — emissão fiscal
+// ═══════════════════════════════════════════════════════════════════
+function NFeDrawer({ venda, onClose }) {
+  const [step, setStep] = useStateVE(1);
+  const [cfop, setCfop] = useStateVE("5102");
+  const [ncm, setNcm] = useStateVE("4911.99.00");
+  const [transp, setTransp] = useStateVE("propria");
+  const [obs, setObs] = useStateVE("");
+
+  const STEPS = ["Dados fiscais", "Transporte", "Revisão"];
+  const CFOPS = [
+    { code:"5102", label:"Venda mercadoria UF" },
+    { code:"5101", label:"Venda produção UF" },
+    { code:"6102", label:"Venda mercadoria fora UF" },
+  ];
+
+  const fakeNumber = "000.001." + (Math.floor(Math.random()*9000)+1000);
+  const fakeKey = "35260512345678000190550010000" + fakeNumber.replace(/\./g,"") + "180000001";
+
+  return (
+    <div className="os-drawer-back" onClick={onClose}>
+      <aside className="os-drawer wide" onClick={e => e.stopPropagation()}>
+        <header className="os-drawer-head">
+          <div className="os-drawer-head-l">
+            <span className="os-drawer-id">NF-e · Venda #{venda?.id || "—"}</span>
+            <h2>Emissão de Nota Fiscal Eletrônica</h2>
+            <p>Cliente: {venda?.client || "—"} · Total: {venda?.total || "—"}</p>
+          </div>
+          <button className="icon-btn" onClick={onClose}>×</button>
+        </header>
+
+        <nav className="vd-stepper">
+          {STEPS.map((s,i) => (
+            <button key={i} className={"vd-step" + (step === i+1 ? " active" : "") + (step > i+1 ? " done" : "")} onClick={() => setStep(i+1)}>
+              <span className="vd-step-num">{step > i+1 ? "✓" : i+1}</span>
+              <span>{s}</span>
+              {i < STEPS.length-1 && <span className="vd-step-sep">›</span>}
+            </button>
+          ))}
+        </nav>
+
+        <div className="os-drawer-body">
+          {step === 1 && (
+            <section className="vd-section">
+              <h3>Natureza da operação</h3>
+              <div className="nfe-cfop">
+                {CFOPS.map(c => (
+                  <button key={c.code} className={"nfe-cfop-btn" + (cfop === c.code ? " active" : "")} onClick={() => setCfop(c.code)}>
+                    <strong>CFOP {c.code}</strong>
+                    <span>{c.label}</span>
+                  </button>
+                ))}
+              </div>
+              <div className="vd-fields">
+                <label>NCM
+                  <input value={ncm} onChange={e => setNcm(e.target.value)}/>
+                </label>
+                <label>Origem mercadoria
+                  <select defaultValue="0">
+                    <option value="0">0 — Nacional</option>
+                    <option value="1">1 — Importação direta</option>
+                    <option value="2">2 — Importação adquirida no mercado interno</option>
+                  </select>
+                </label>
+              </div>
+              <h3>Tributação</h3>
+              <div className="nfe-tax-grid">
+                <div><span>ICMS</span><strong>Simples Nacional</strong></div>
+                <div><span>CSOSN</span><strong>102 — sem permissão crédito</strong></div>
+                <div><span>PIS / COFINS</span><strong>incluso no Simples</strong></div>
+                <div><span>IPI</span><strong>NT — não tributado</strong></div>
+              </div>
+            </section>
+          )}
+
+          {step === 2 && (
+            <section className="vd-section">
+              <h3>Modalidade de frete</h3>
+              <div className="nfe-transp">
+                {[
+                  { id:"propria",  l:"Por conta do emitente",  meta:"frete CIF — somos responsáveis"  },
+                  { id:"cliente",  l:"Por conta do destinatário", meta:"frete FOB — cliente retira"   },
+                  { id:"terceiro", l:"Por conta de terceiros",  meta:"transportadora cadastrada"      },
+                  { id:"sem",      l:"Sem frete",                meta:"entrega no balcão"              },
+                ].map(t => (
+                  <button key={t.id} className={"nfe-transp-btn" + (transp === t.id ? " active" : "")} onClick={() => setTransp(t.id)}>
+                    <strong>{t.l}</strong>
+                    <span>{t.meta}</span>
+                  </button>
+                ))}
+              </div>
+              {transp === "terceiro" && (
+                <div className="vd-fields">
+                  <label>Transportadora
+                    <select>
+                      <option>Logística Sul</option>
+                      <option>Expresso Rodoviário Brasil</option>
+                      <option>Mercúrio Cargas</option>
+                    </select>
+                  </label>
+                  <label>Veículo (placa)
+                    <input placeholder="ABC-1234"/>
+                  </label>
+                </div>
+              )}
+              <h3>Volume</h3>
+              <div className="vd-fields">
+                <label>Quantidade<input type="number" defaultValue="1"/></label>
+                <label>Espécie<input defaultValue="caixa"/></label>
+                <label>Peso bruto (kg)<input type="number" step="0.1" defaultValue="2.5"/></label>
+                <label>Peso líquido (kg)<input type="number" step="0.1" defaultValue="2.0"/></label>
+              </div>
+              <h3>Observações</h3>
+              <textarea className="vdv-textarea" placeholder="Informação complementar..." value={obs} onChange={e => setObs(e.target.value)}/>
+            </section>
+          )}
+
+          {step === 3 && (
+            <section className="vd-section nfe-review">
+              <h3>Revise antes de transmitir à SEFAZ</h3>
+              <div className="nfe-review-grid">
+                <div className="nfe-review-card">
+                  <span>Número provisório</span>
+                  <strong className="mono">{fakeNumber}</strong>
+                </div>
+                <div className="nfe-review-card">
+                  <span>CFOP</span>
+                  <strong>{cfop}</strong>
+                </div>
+                <div className="nfe-review-card">
+                  <span>NCM</span>
+                  <strong>{ncm}</strong>
+                </div>
+                <div className="nfe-review-card">
+                  <span>Frete</span>
+                  <strong>{ {propria:"Emitente",cliente:"Destinatário",terceiro:"Terceiros",sem:"Sem frete"}[transp] }</strong>
+                </div>
+                <div className="nfe-review-card span">
+                  <span>Chave de acesso (preview)</span>
+                  <strong className="mono small">{fakeKey}</strong>
+                </div>
+                <div className="nfe-review-card">
+                  <span>Total da nota</span>
+                  <strong className="vd-total-strong">{venda?.total || "—"}</strong>
+                </div>
+                <div className="nfe-review-card">
+                  <span>Cliente</span>
+                  <strong>{venda?.client || "—"}</strong>
+                </div>
+              </div>
+              <div className="nfe-callout">
+                A nota será transmitida em <strong>ambiente de produção</strong> e enviada por e-mail ao cliente. Cancelamento permitido em até 24h.
+              </div>
+            </section>
+          )}
+        </div>
+
+        <footer className="os-drawer-actions">
+          {step > 1 && <button className="os-btn ghost" onClick={() => setStep(step-1)}>← Voltar</button>}
+          {step < 3 && <button className="os-btn primary" onClick={() => setStep(step+1)}>Avançar →</button>}
+          {step === 3 && <button className="os-btn primary">Transmitir SEFAZ</button>}
+        </footer>
+      </aside>
+    </div>
+  );
+}
+
+// Expose globals
+Object.assign(window, {
+  VendasModule,
+  VendasCaixaPage,
+  VendasDevolucoesPage,
+  VendasComissoesPage,
+  VendasRelatoriosPage,
+  VendasPDVOverlay,
+  ReciboView,
+  NFeDrawer,
+});

--- a/prototipo-ui/vendas-output.jsx
+++ b/prototipo-ui/vendas-output.jsx
@@ -1,0 +1,484 @@
+// vendas-output.jsx — Refino #4 KB-9.75 · Distribuição (2026-05-15)
+// 4 features: Transcript PDF (jurídico) · Modo apresentação · Variáveis live · Art-slot
+// Render acionado pelos botões do drawer em vendas-page.jsx
+
+const { useState: useStateOut, useEffect: useEffectOut, useMemo: useMemoOut } = React;
+
+const _outFmt = (n) => (n || 0).toLocaleString("pt-BR", { style:"currency", currency:"BRL" });
+const _outDate = (d) => d ? d.split("T")[0].split("-").reverse().join("/") : "—";
+const _outTime = (d) => d ? d.split("T")[1]?.slice(0,5) || "" : "";
+
+// ──────────────────────────────────────────────────────────────
+// 1) TRANSCRIPT PDF — overlay full-page A4 imprimível
+//    Tudo: cabeçalho, cliente, itens, fiscal completo, timeline,
+//    comentários, audit, assinaturas. window.print() imprime só isso.
+// ──────────────────────────────────────────────────────────────
+function VdTranscriptPDF({ venda, onClose }) {
+  const v = venda;
+  const totalNum = v.totalNum || (v.itemsList || []).reduce((s, i) => s + i.qty * i.unit, 0);
+  const audit = window.vdAuditTrail ? window.vdAuditTrail(v) : [];
+  const comments = window.useVdItemComments ? window.useVdItemComments() : null;
+  const allComments = comments
+    ? (v.itemsList || []).map((it, idx) => ({ item: it, idx, list: comments.get(v.id, idx) || [] })).filter(x => x.list.length > 0)
+    : [];
+
+  useEffectOut(() => {
+    const onKey = (e) => { if (e.key === "Escape") { e.preventDefault(); onClose(); } };
+    window.addEventListener("keydown", onKey);
+    // marca body pra @media print esconder tudo menos o transcript
+    document.body.classList.add("vd-print-mode");
+    return () => {
+      window.removeEventListener("keydown", onKey);
+      document.body.classList.remove("vd-print-mode");
+    };
+  }, [onClose]);
+
+  return (
+    <div className="vd-trans-bd" onClick={onClose}>
+      <div className="vd-trans-toolbar">
+        <button className="os-btn ghost" onClick={onClose}>← Fechar</button>
+        <span className="vd-trans-tag">Transcript completo · venda #{v.id}</span>
+        <button className="os-btn primary" onClick={() => window.print()}>⎙ Imprimir / Salvar PDF</button>
+      </div>
+
+      <div className="vd-trans-page" onClick={e => e.stopPropagation()}>
+
+        {/* ────── HEADER ────── */}
+        <header className="vd-trans-h">
+          <div>
+            <div className="vd-trans-brand">OIMPRESSO</div>
+            <div className="vd-trans-brand-sub">Comunicação Visual</div>
+          </div>
+          <div className="vd-trans-meta-co">
+            <div>CNPJ 12.345.678/0001-90</div>
+            <div>Rua das Gráficas, 123 — Centro</div>
+            <div>(11) 4000-1234 · oimpresso.com</div>
+          </div>
+        </header>
+
+        <div className="vd-trans-title">
+          <h1>TRANSCRIPT DE VENDA <small>#{v.id}</small></h1>
+          <span>Documento jurídico-comercial · gerado em {new Date().toLocaleDateString("pt-BR")} às {new Date().toLocaleTimeString("pt-BR",{hour:"2-digit",minute:"2-digit"})}</span>
+        </div>
+
+        {/* ────── CLIENTE + DADOS ────── */}
+        <section className="vd-trans-grid">
+          <div className="vd-trans-block">
+            <small>Cliente</small>
+            <h3>{v.client}</h3>
+            {v.clientNote && <p>{v.clientNote}</p>}
+          </div>
+          <div className="vd-trans-block">
+            <small>Atendido por</small>
+            <h3>{v.seller || v.sellerId || "—"}</h3>
+            <p>{v.date.split("-").reverse().join("/")} às {v.time}</p>
+          </div>
+          <div className="vd-trans-block">
+            <small>Pagamento</small>
+            <h3>{v.payment}{v.installments > 1 ? ` · ${v.installments}×` : ""}</h3>
+            <p>Prazo: {v.payTerm || 0} dias</p>
+          </div>
+          <div className="vd-trans-block vd-trans-total">
+            <small>Total da venda</small>
+            <h3>{_outFmt(totalNum)}</h3>
+          </div>
+        </section>
+
+        {/* ────── ITENS ────── */}
+        <section className="vd-trans-section">
+          <h2>Itens</h2>
+          <table className="vd-trans-items">
+            <thead>
+              <tr><th>SKU</th><th>Descrição</th><th>Tipo</th><th className="num">Qtd</th><th className="num">Unitário</th><th className="num">Subtotal</th></tr>
+            </thead>
+            <tbody>
+              {(v.itemsList || []).map((it, i) => (
+                <tr key={i}>
+                  <td className="mono">{it.sku}</td>
+                  <td>{it.name}</td>
+                  <td>{it.type === "produto" ? "Produto (NF-e)" : "Serviço (NFS-e)"}</td>
+                  <td className="num">{it.qty}</td>
+                  <td className="num">{_outFmt(it.unit)}</td>
+                  <td className="num strong">{_outFmt(it.qty * it.unit)}</td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr><td colSpan={5} className="strong">Total</td><td className="num strong">{_outFmt(totalNum)}</td></tr>
+            </tfoot>
+          </table>
+        </section>
+
+        {/* ────── DOCUMENTOS FISCAIS ────── */}
+        {(v.fiscal?.nfe || v.fiscal?.nfse) && (
+          <section className="vd-trans-section">
+            <h2>Documentos fiscais</h2>
+            <table className="vd-trans-fiscal">
+              <tbody>
+                {v.fiscal?.nfe && (
+                  <tr>
+                    <th>NF-e modelo 55</th>
+                    <td>
+                      <div>Nº {v.fiscal.nfe.numero} · Série {v.fiscal.nfe.serie} · Status: <b>{v.fiscal.nfe.status === "ok" ? "Autorizada SEFAZ" : v.fiscal.nfe.status === "bad" ? "Rejeitada" : v.fiscal.nfe.status === "canc" ? "Cancelada" : "Processando"}</b></div>
+                      <div className="mono small">Chave: {v.fiscal.nfe.chave}</div>
+                      <div className="small">Emitida em {_outDate(v.fiscal.nfe.date)} às {_outTime(v.fiscal.nfe.date)}</div>
+                      {v.fiscal.nfe.failReason && <div className="small fail">⚠ {v.fiscal.nfe.failReason}</div>}
+                    </td>
+                  </tr>
+                )}
+                {v.fiscal?.nfse && (
+                  <tr>
+                    <th>NFS-e LC 214/25</th>
+                    <td>
+                      <div>Nº {v.fiscal.nfse.numero} · Status: <b>{v.fiscal.nfse.status === "ok" ? "Autorizada" : "Processando"}</b></div>
+                      <div className="mono small">Chave: {v.fiscal.nfse.chave}</div>
+                      <div className="small">Emitida em {_outDate(v.fiscal.nfse.date)} às {_outTime(v.fiscal.nfse.date)}</div>
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </section>
+        )}
+
+        {/* ────── HISTÓRICO DE EDIÇÕES (Auditoria) ────── */}
+        {audit.length > 0 && (
+          <section className="vd-trans-section">
+            <h2>Histórico de edições</h2>
+            <table className="vd-trans-audit">
+              <thead><tr><th>Quando</th><th>Quem</th><th>Ação</th></tr></thead>
+              <tbody>
+                {audit.map((e, i) => (
+                  <tr key={i}>
+                    <td className="mono small">{e.when}</td>
+                    <td>{e.who}</td>
+                    <td>{e.desc}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </section>
+        )}
+
+        {/* ────── COMENTÁRIOS INLINE (curadoria) ────── */}
+        {allComments.length > 0 && (
+          <section className="vd-trans-section">
+            <h2>Comentários da equipe</h2>
+            {allComments.map(({ item, idx, list }) => (
+              <div key={idx} className="vd-trans-comment-block">
+                <b className="vd-trans-comment-item">Item: {item.name}</b>
+                {list.map((c, ci) => (
+                  <div key={ci} className="vd-trans-comment">
+                    <span className="mono small">{c.author} · {c.when}</span>
+                    <p>{c.text}</p>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </section>
+        )}
+
+        {/* ────── ENTREGA/OS ────── */}
+        {v.osIds && v.osIds.length > 0 && (
+          <section className="vd-trans-section">
+            <h2>Vínculos com produção</h2>
+            <p>Ordens de serviço vinculadas: {v.osIds.map(id => `#OS-${id}`).join(" · ")}</p>
+          </section>
+        )}
+
+        {/* ────── ASSINATURAS ────── */}
+        <section className="vd-trans-sign">
+          <div>
+            <div className="vd-trans-sign-line"></div>
+            <small>{v.client}<br/>Cliente / responsável</small>
+          </div>
+          <div>
+            <div className="vd-trans-sign-line"></div>
+            <small>{v.seller || v.sellerId || "—"}<br/>Atendente Oimpresso</small>
+          </div>
+        </section>
+
+        <footer className="vd-trans-foot">
+          Documento emitido por Oimpresso ERP em {new Date().toLocaleString("pt-BR")} · pág 1 de 1
+        </footer>
+      </div>
+    </div>
+  );
+}
+window.VdTranscriptPDF = VdTranscriptPDF;
+
+// ──────────────────────────────────────────────────────────────
+// 2) MODO APRESENTAÇÃO — fullscreen, fonte gigante, read-only,
+//    sem IDs internos. Pra reunião com cliente / sócio.
+// ──────────────────────────────────────────────────────────────
+function VdPresentationMode({ venda, onClose }) {
+  const v = venda;
+  const totalNum = v.totalNum || (v.itemsList || []).reduce((s, i) => s + i.qty * i.unit, 0);
+  const [slide, setSlide] = useStateOut(0);
+  const slides = [
+    { id: "intro", label: "Visão geral" },
+    { id: "items", label: `Itens (${(v.itemsList||[]).length})` },
+    { id: "money", label: "Valor e prazo" },
+    { id: "next",  label: "Próximos passos" },
+  ];
+
+  useEffectOut(() => {
+    const onKey = (e) => {
+      if (e.key === "Escape") { e.preventDefault(); onClose(); }
+      else if (e.key === "ArrowRight" || e.key === " ") { e.preventDefault(); setSlide(s => Math.min(slides.length - 1, s + 1)); }
+      else if (e.key === "ArrowLeft") { e.preventDefault(); setSlide(s => Math.max(0, s - 1)); }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose, slides.length]);
+
+  const status = v.fsm >= 4 ? "Concluída" : v.fsm >= 2 ? "Em andamento" : "Aguardando confirmação";
+  const fiscalStatus = v.fiscal?.nfe?.status === "ok" || v.fiscal?.nfse?.status === "ok"
+    ? "Nota fiscal autorizada"
+    : v.fiscal?.nfe?.status === "wait" ? "Nota processando"
+    : "Sem nota emitida";
+
+  return (
+    <div className="vd-pres-overlay">
+      <header className="vd-pres-top">
+        <span className="vd-pres-brand">OIMPRESSO · Comunicação Visual</span>
+        <span className="vd-pres-counter">{slide + 1} / {slides.length}</span>
+        <button className="vd-pres-close" onClick={onClose} title="Esc">×</button>
+      </header>
+
+      <main className="vd-pres-stage">
+        {slide === 0 && (
+          <div className="vd-pres-slide vd-pres-intro">
+            <small className="vd-pres-eyebrow">Pedido para</small>
+            <h1>{v.client}</h1>
+            <p>{v.clientNote}</p>
+            <div className="vd-pres-chips">
+              <span className="vd-pres-chip">Atendido por {v.seller || v.sellerId}</span>
+              <span className="vd-pres-chip">{v.date.split("-").reverse().join("/")}</span>
+              <span className="vd-pres-chip primary">{status}</span>
+            </div>
+          </div>
+        )}
+
+        {slide === 1 && (
+          <div className="vd-pres-slide vd-pres-items">
+            <small className="vd-pres-eyebrow">{(v.itemsList||[]).length} ite{(v.itemsList||[]).length>1?"ns":"m"}</small>
+            <h1>O que está incluso</h1>
+            <ul>
+              {(v.itemsList || []).map((it, i) => (
+                <li key={i}>
+                  <div className="vd-pres-item-l">
+                    <b>{it.name}</b>
+                    <small>{it.type === "produto" ? "Produto" : "Serviço"} · {it.qty}× {_outFmt(it.unit)}</small>
+                  </div>
+                  <div className="vd-pres-item-r">{_outFmt(it.qty * it.unit)}</div>
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+
+        {slide === 2 && (
+          <div className="vd-pres-slide vd-pres-money">
+            <small className="vd-pres-eyebrow">Valor total</small>
+            <div className="vd-pres-amount">{_outFmt(totalNum)}</div>
+            <div className="vd-pres-payment">
+              <span>Pagamento</span>
+              <b>{v.payment}{v.installments > 1 ? ` · ${v.installments}× de ${_outFmt(totalNum / v.installments)}` : ""}</b>
+            </div>
+            <div className="vd-pres-payment">
+              <span>Prazo</span>
+              <b>{v.payTerm || 0} dias</b>
+            </div>
+          </div>
+        )}
+
+        {slide === 3 && (
+          <div className="vd-pres-slide vd-pres-next">
+            <small className="vd-pres-eyebrow">A partir daqui</small>
+            <h1>Próximos passos</h1>
+            <ol>
+              {v.fsm < 4 && <li>Confirmar pagamento</li>}
+              {(v.fsm < 2 || (!v.fiscal?.nfe && !v.fiscal?.nfse)) && <li>Emitir documento fiscal</li>}
+              {v.fsm < 3 && (v.osIds?.length > 0) && <li>Iniciar produção (OS {v.osIds.join(", ")})</li>}
+              {v.fsm < 3 && <li>Retirada / entrega ao cliente</li>}
+              {v.fsm >= 3 && v.fsm < 4 && <li>Confirmar recebimento e finalizar</li>}
+              {v.fsm >= 4 && <li>Pedido concluído ✓</li>}
+            </ol>
+            <p className="vd-pres-foot-note">{fiscalStatus}</p>
+          </div>
+        )}
+      </main>
+
+      <footer className="vd-pres-bot">
+        <button onClick={() => setSlide(s => Math.max(0, s - 1))} disabled={slide === 0}>←</button>
+        <div className="vd-pres-dots">
+          {slides.map((s, i) => (
+            <span key={i} className={`vd-pres-dot ${i === slide ? "on" : ""}`} onClick={() => setSlide(i)}/>
+          ))}
+        </div>
+        <button onClick={() => setSlide(s => Math.min(slides.length - 1, s + 1))} disabled={slide === slides.length - 1}>→</button>
+      </footer>
+    </div>
+  );
+}
+window.VdPresentationMode = VdPresentationMode;
+
+// ──────────────────────────────────────────────────────────────
+// 3) VARIÁVEIS LIVE — preview da mensagem de orçamento
+//    Template com {{cliente}}, {{id}}, {{total}}, {{forma}}, {{prazo}}
+//    Renderiza substituído + botão copiar + abrir WhatsApp
+// ──────────────────────────────────────────────────────────────
+const VD_MESSAGE_TEMPLATES = [
+  { id: "confirmacao", label: "Confirmação pedido",
+    text: "Olá {{cliente}}, sua venda #{{id}} de {{data}} no valor de {{total}} ficou {{status}}. Forma de pagamento: {{forma}}. Atendido por {{seller}}. Qualquer dúvida me chama!" },
+  { id: "retirada", label: "Pronto pra retirada",
+    text: "Oi {{cliente}}! Seu pedido #{{id}} ({{itens}} ite{{itens_plural}}) está pronto pra retirada na Oimpresso. Endereço: Rua das Gráficas, 123. Horário: 8h-18h. Total: {{total}} ({{forma}})." },
+  { id: "cobranca", label: "Lembrete pagamento",
+    text: "Olá {{cliente}}, passando pra lembrar do boleto da venda #{{id}} no valor de {{total}}, vencendo em {{vencimento}}. Qualquer coisa, manda mensagem aqui." },
+];
+
+function VdMessagePreview({ venda }) {
+  const v = venda;
+  const [tplId, setTplId] = useStateOut("confirmacao");
+  const [copied, setCopied] = useStateOut(false);
+
+  const totalNum = v.totalNum || (v.itemsList || []).reduce((s, i) => s + i.qty * i.unit, 0);
+  const itemsCount = (v.itemsList || []).length;
+
+  const vars = {
+    cliente:   v.client,
+    id:        v.id,
+    data:      v.date.split("-").reverse().join("/"),
+    total:     _outFmt(totalNum),
+    forma:     v.payment + (v.installments > 1 ? ` ${v.installments}×` : ""),
+    seller:    v.seller || v.sellerId || "—",
+    status:    v.fsm >= 4 ? "PAGA" : v.fsm >= 2 ? "FATURADA" : "PENDENTE",
+    prazo:     `${v.payTerm || 0} dias`,
+    itens:     itemsCount,
+    itens_plural: itemsCount > 1 ? "ns" : "m",
+    vencimento: (() => {
+      const [Y,M,D] = v.date.split("-").map(Number);
+      const d = new Date(Y, M-1, D); d.setDate(d.getDate() + (v.payTerm || 0));
+      return ("0"+d.getDate()).slice(-2) + "/" + ("0"+(d.getMonth()+1)).slice(-2) + "/" + d.getFullYear();
+    })(),
+  };
+
+  const tpl = VD_MESSAGE_TEMPLATES.find(t => t.id === tplId);
+  const rendered = tpl.text.replace(/\{\{(\w+)\}\}/g, (m, key) => {
+    if (vars[key] === undefined) return m;
+    return String(vars[key]);
+  });
+
+  // detecta variáveis usadas
+  const usedVars = useMemoOut(() => {
+    const set = new Set();
+    let m;
+    const re = /\{\{(\w+)\}\}/g;
+    while ((m = re.exec(tpl.text)) !== null) set.add(m[1]);
+    return [...set];
+  }, [tpl.text]);
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(rendered);
+      setCopied(true); setTimeout(() => setCopied(false), 1500);
+    } catch (e) {}
+  };
+
+  const wa = () => {
+    const url = `https://wa.me/?text=${encodeURIComponent(rendered)}`;
+    window.open(url, "_blank");
+  };
+
+  return (
+    <div className="vd-msg">
+      <header className="vd-msg-h">
+        <h4>Mensagem pra cliente</h4>
+        <div className="vd-msg-tpls">
+          {VD_MESSAGE_TEMPLATES.map(t => (
+            <button key={t.id}
+                    className={`vd-msg-tpl ${tplId === t.id ? "on" : ""}`}
+                    onClick={() => setTplId(t.id)}>
+              {t.label}
+            </button>
+          ))}
+        </div>
+      </header>
+
+      <div className="vd-msg-vars">
+        <small>Variáveis substituídas:</small>
+        {usedVars.map(k => (
+          <span key={k} className="vd-msg-var" title={vars[k]}>
+            <span className="k">{`{{${k}}}`}</span>
+            <span className="arr">→</span>
+            <span className="v">{String(vars[k] || "—").slice(0, 24)}</span>
+          </span>
+        ))}
+      </div>
+
+      <div className="vd-msg-preview">
+        <div className="vd-msg-bubble">{rendered}</div>
+      </div>
+
+      <div className="vd-msg-actions">
+        <button className="os-btn ghost" onClick={copy}>{copied ? "Copiado ✓" : "Copiar"}</button>
+        <button className="os-btn primary" onClick={wa}>↗ Abrir WhatsApp</button>
+      </div>
+    </div>
+  );
+}
+window.VdMessagePreview = VdMessagePreview;
+
+// ──────────────────────────────────────────────────────────────
+// 4) ART-SLOT POR ITEM — preview da arte/mockup anexa
+//    Drag-drop ou click → arquivo → dataURL → localStorage
+// ──────────────────────────────────────────────────────────────
+function _artLoad() {
+  try { return JSON.parse(localStorage.getItem("oimpresso.vendas.itemArt") || "{}"); }
+  catch (e) { return {}; }
+}
+function _artSave(m) {
+  try { localStorage.setItem("oimpresso.vendas.itemArt", JSON.stringify(m)); } catch (e) {}
+}
+
+function VdItemArt({ vendaId, itemIdx, itemName }) {
+  const key = `${vendaId}:${itemIdx}`;
+  const [art, setArt] = useStateOut(() => _artLoad()[key] || null);
+  const [drag, setDrag] = useStateOut(false);
+
+  const persist = (dataUrl) => {
+    setArt(dataUrl);
+    const m = _artLoad();
+    if (dataUrl) m[key] = dataUrl; else delete m[key];
+    _artSave(m);
+  };
+
+  const handleFile = (file) => {
+    if (!file || !file.type.startsWith("image/")) return;
+    const reader = new FileReader();
+    reader.onload = () => persist(reader.result);
+    reader.readAsDataURL(file);
+  };
+
+  return (
+    <div className={`vd-art ${art ? "has" : "empty"} ${drag ? "drag" : ""}`}
+         onDragOver={e => { e.preventDefault(); setDrag(true); }}
+         onDragLeave={() => setDrag(false)}
+         onDrop={e => { e.preventDefault(); setDrag(false); handleFile(e.dataTransfer.files?.[0]); }}>
+      {art ? (
+        <React.Fragment>
+          <img src={art} alt={itemName}/>
+          <button className="vd-art-rm" onClick={() => persist(null)} title="Remover arte">×</button>
+        </React.Fragment>
+      ) : (
+        <label className="vd-art-empty">
+          <span className="vd-art-ic">🖼</span>
+          <small>{drag ? "solte aqui" : "arraste arte/mockup"}</small>
+          <input type="file" accept="image/*" onChange={e => handleFile(e.target.files?.[0])}/>
+        </label>
+      )}
+    </div>
+  );
+}
+window.VdItemArt = VdItemArt;

--- a/prototipo-ui/vendas-page.jsx
+++ b/prototipo-ui/vendas-page.jsx
@@ -1,0 +1,1666 @@
+// vendas-page.jsx — Vendas/Index + Vendas/Create (P0 do protocolo PR #295)
+// 2026-05-14: refator A+ pra elevar 8.7 → 9.5
+// 8 itens: identidade green · sparkline+ageing · stepper FSM · avatar+comissão
+//          Vista toggle · ⌘K · saved views+bulk · NF-e+NFS-e vinculados
+const { useState: useStateV, useMemo: useMemoV, useEffect: useEffectV, useRef: useRefV } = React;
+
+// ──────────────────────────────────────────────────────────────
+// HELPERS — formatação e derivações
+// ──────────────────────────────────────────────────────────────
+const vdFmt      = (n) => n.toLocaleString("pt-BR", { style:"currency", currency:"BRL" });
+const vdFmtShort = (n) => n >= 1000 ? "R$ " + (n/1000).toFixed(1).replace(".",",") + "k" : vdFmt(n);
+const vdFmtChave = (k) => (k || "").replace(/(\d{4})/g, "$1 ").trim();
+
+const vdHasProduto = (v) => v.itemsList?.some(i => i.type === "produto");
+const vdHasServico = (v) => v.itemsList?.some(i => i.type === "servico");
+const vdIsToday    = (v) => v.date === "2026-05-14";
+
+// ──────────────────────────────────────────────────────────────
+// SUB-COMPONENTES VISUAIS
+// ──────────────────────────────────────────────────────────────
+function VdSparkline({ data, color = "currentColor", fill = true, h = 32, w = 240 }) {
+  if (!data?.length) return null;
+  const pad = 2;
+  const min = Math.min(...data), max = Math.max(...data);
+  const dx = (w - pad*2) / (data.length - 1);
+  const pts = data.map((v, i) => [pad + i*dx, h - pad - ((v - min) / (max - min || 1)) * (h - pad*2)]);
+  const line = "M" + pts.map(p => p.join(",")).join(" L");
+  const area = line + ` L${pts[pts.length-1][0]},${h} L${pts[0][0]},${h} Z`;
+  return (
+    <svg viewBox={`0 0 ${w} ${h}`} preserveAspectRatio="none" style={{width:"100%",height:h,display:"block"}}>
+      {fill && <path d={area} fill={color} opacity="0.18"/>}
+      <path d={line} fill="none" stroke={color} strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/>
+      <circle cx={pts[pts.length-1][0]} cy={pts[pts.length-1][1]} r="2.5" fill={color}/>
+    </svg>
+  );
+}
+
+function VdStepper({ fsm, vertical }) {
+  const { FSM_BY_VERTICAL } = window.VENDAS_DATA;
+  const set = FSM_BY_VERTICAL[vertical || "cv"] || FSM_BY_VERTICAL.cv;
+  return (
+    <span className="vd-stp" title={`${set.steps[fsm]} — etapa ${fsm+1} de 5`}>
+      {set.steps.map((_, i) => {
+        let cls = "vd-stp-dot";
+        if (i < fsm) cls += " done";
+        else if (i === fsm) cls += " current";
+        return <span key={i} className={cls}/>;
+      })}
+      <span className="vd-stp-lbl">{set.lbls[fsm]}</span>
+    </span>
+  );
+}
+
+// Placa Mercosul (Oficina Mìânica) — inline pequena
+function VdPlate({ value }) {
+  if (!value) return null;
+  return (
+    <span className="vd-plate">
+      <span className="vd-plate-top">BR·MERCOSUL</span>
+      <span className="vd-plate-num">{value}</span>
+    </span>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────
+// SLA — fresco · atrasando · estourado (Refino #1 KB-9.75)
+// Regra: due = v.date + payTerm. daysRem = due - hoje.
+//   fsm>=4  → paga (sem SLA)
+//   urgent || daysRem<0 → estourado
+//   daysRem<=7 → atrasando
+//   else → fresco
+// ──────────────────────────────────────────────────────────────
+const VD_TODAY = new Date("2026-05-14"); // mock today — alinhar com data-vendas
+function vdSlaInfo(v) {
+  if (v.fsm >= 4) return { kind: "paid", daysRem: 0, label: "paga", short: "✓" };
+  const [Y, M, D] = v.date.split("-").map(Number);
+  const due = new Date(Y, M - 1, D);
+  due.setDate(due.getDate() + (v.payTerm || 0));
+  const daysRem = Math.round((due - VD_TODAY) / 86400000);
+  if (v.urgent || daysRem < 0) {
+    const overdueDays = Math.max(0, -daysRem);
+    return { kind: "overdue", daysRem, label: `estourado · ${overdueDays}d`, short: `-${overdueDays}d` };
+  }
+  if (daysRem <= 7) return { kind: "warning", daysRem, label: `atrasando · ${daysRem}d`, short: `${daysRem}d` };
+  return { kind: "fresh", daysRem, label: `vence ${daysRem}d`, short: `${daysRem}d` };
+}
+
+const VD_SLA_ICON = { fresh: "●", warning: "▲", overdue: "✕", paid: "✓" };
+function VdSlaPill({ v, compact }) {
+  const s = vdSlaInfo(v);
+  return (
+    <span className={`vd-sla vd-sla-${s.kind}`} title={s.label}>
+      <span className="vd-sla-ic">{VD_SLA_ICON[s.kind]}</span>
+      <span className="vd-sla-lbl">{compact ? s.short : s.label}</span>
+    </span>
+  );
+}
+
+const VD_FBADGE_MAP = {
+  ok:   { cls: "ok",   ic: "✓" },
+  wait: { cls: "wait", ic: "⌛" },
+  bad:  { cls: "bad",  ic: "✕" },
+  canc: { cls: "canc", ic: "⊘" },
+  na:   { cls: "na",   ic: "—" },
+};
+function VdFBadge({ kind, status, doc }) {
+  const lbl = kind === "nfe" ? "NF-e" : "NFS-e";
+  const m = VD_FBADGE_MAP[status] || VD_FBADGE_MAP.na;
+  const tip = status === "ok"   && doc ? `Autorizada · ${doc.numero}/${doc.serie}`
+            : status === "wait"        ? "Transmitida · aguardando SEFAZ"
+            : status === "bad"         ? "Rejeitada SEFAZ"
+            : status === "canc"        ? "Cancelada"
+            : "Não emitida";
+  return (
+    <span className={`vd-fb vd-fb-${m.cls}`}>
+      <span className="vd-fb-ic">{m.ic}</span>{lbl}
+      <span className="vd-fb-tip">{tip}</span>
+    </span>
+  );
+}
+
+function VdFiscalCell({ v }) {
+  const f = v.fiscal || {};
+  const nfeS  = f.nfe  ? f.nfe.status  : (vdHasProduto(v) ? "na" : null);
+  const nfseS = f.nfse ? f.nfse.status : (vdHasServico(v) ? "na" : null);
+  return (
+    <span className="vd-fc">
+      {nfeS  && <VdFBadge kind="nfe"  status={nfeS}  doc={f.nfe}/>}
+      {nfseS && <VdFBadge kind="nfse" status={nfseS} doc={f.nfse}/>}
+      {!nfeS && !nfseS && <span className="vd-fb vd-fb-na"><span className="vd-fb-ic">—</span></span>}
+    </span>
+  );
+}
+
+// Avatar do vendedor ou mecânico
+function VdAv({ sid, mid }) {
+  const { VENDEDORES_MAP, MECANICOS_MAP } = window.VENDAS_DATA;
+  const s = (mid && MECANICOS_MAP[mid]) || VENDEDORES_MAP[sid];
+  if (!s) return null;
+  return <span className={`vd-av vd-av-${s.av}`}>{s.abbr}</span>;
+}
+
+// Card NF-e ou NFS-e dentro do drawer
+function VdFiscalCard({ kind, doc }) {
+  const [copied, setCopied] = useStateV(false);
+  const lbl = kind === "nfe" ? "NF-e" : "NFS-e";
+  const danfeLbl = kind === "nfe" ? "DANFE PDF" : "DANFS-e PDF";
+  const isFail = doc.status === "bad";
+  const isCanc = doc.status === "canc";
+
+  const tlSteps = [
+    { lbl: "Emitida",     done: true },
+    { lbl: "Transmitida", done: true },
+    { lbl: "Autorizada",  done: doc.status === "ok" || doc.status === "canc", failed: isFail },
+    { lbl: "E-mail OK",   done: doc.status === "ok" },
+    { lbl: isCanc ? "Cancelada" : "Aprovada", done: doc.status === "ok" || isCanc },
+  ];
+  const statusLbl = { ok:"Autorizada", wait:"Processando", bad:"Rejeitada", canc:"Cancelada" }[doc.status];
+
+  const copy = () => {
+    navigator.clipboard?.writeText(doc.chave);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 1200);
+  };
+
+  const dateStr = doc.date.split("T")[0].split("-").reverse().join("/");
+  const timeStr = doc.date.split("T")[1]?.slice(0,5) || "";
+
+  return (
+    <div className={`vd-fcard ${isFail ? "failed" : ""}`}>
+      <div className="vd-fcard-h">
+        <h4>{lbl}</h4>
+        <span className={`vd-fb vd-fb-${VD_FBADGE_MAP[doc.status].cls}`}>
+          <span className="vd-fb-ic">{VD_FBADGE_MAP[doc.status].ic}</span>{statusLbl}
+        </span>
+        <span className="vd-fcard-date">{dateStr} <span>{timeStr}</span></span>
+      </div>
+
+      {isFail && (
+        <div className="vd-fcard-fail">
+          <b>Motivo da rejeição SEFAZ</b>
+          {doc.failReason}
+        </div>
+      )}
+      {isCanc && doc.cancelReason && (
+        <div className="vd-fcard-fail neutral">
+          <b>Motivo do cancelamento</b>
+          {doc.cancelReason}
+        </div>
+      )}
+
+      <dl className="vd-fcard-meta">
+        <dt>Número</dt><dd>{doc.numero}</dd>
+        <dt>Série</dt><dd>{doc.serie}</dd>
+      </dl>
+
+      <div className="vd-fcard-chave">
+        <span className="vd-fcard-chave-num">{vdFmtChave(doc.chave)}</span>
+        <button className={`vd-fcard-copy ${copied ? "copied" : ""}`} onClick={copy}>
+          {copied ? "Copiado ✓" : "Copiar"}
+        </button>
+      </div>
+
+      <div className="vd-fcard-tl">
+        {tlSteps.map((s, i) => (
+          <div key={i} className={`vd-fcard-step ${s.done ? "done" : ""} ${s.failed ? "failed" : ""}`}>
+            <span className="vd-fcard-step-d">{s.failed ? "✕" : s.done ? "✓" : i+1}</span>
+            <span className="vd-fcard-step-l">{s.lbl}</span>
+          </div>
+        ))}
+      </div>
+
+      <details className="vd-fcard-cce">
+        <summary>+ CC-e (Carta de Correção)</summary>
+        <p>Nenhuma carta de correção emitida pra este documento.</p>
+      </details>
+
+      <div className="vd-fcard-ctas">
+        <button className="vd-fcard-cta"><I.archive size={11}/>{danfeLbl}</button>
+        <button className="vd-fcard-cta"><I.folder size={11}/>XML</button>
+        <button className="vd-fcard-cta"><I.message size={11}/>Enviar</button>
+      </div>
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────
+// INDEX — VendasListPage
+// ──────────────────────────────────────────────────────────────
+function VendasListPage() {
+  const { VENDAS_LIST, VENDAS_STATUS, VENDEDORES_MAP, VENDAS_SAVED_VIEWS } = window.VENDAS_DATA;
+
+  // UI state — persiste em localStorage onde fizer sentido
+  const lsGet = (k, d) => { try { return localStorage.getItem("oimpresso.sells."+k) ?? d; } catch(e) { return d; } };
+  const lsSet = (k, v) => { try { localStorage.setItem("oimpresso.sells."+k, v); } catch(e){} };
+
+  const [vista, setVista]         = useStateV(() => lsGet("vista", "caixa"));
+  const [savedView, setSavedView] = useStateV(() => lsGet("savedView", "hoje"));
+  const [viewsOpen, setViewsOpen] = useStateV(false);
+  const [statusF, setStatusF]     = useStateV(() => lsGet("statusF", "todas"));
+  const [query, setQuery]         = useStateV(() => lsGet("query", ""));
+  const [selected, setSelected]   = useStateV(() => new Set());
+  const [openId, setOpenId]       = useStateV(null);
+  const [createOpen, setCreateOpen] = useStateV(false);
+  const [palOpen, setPalOpen]     = useStateV(false);
+  const [palQ, setPalQ]           = useStateV("");
+  const [palSel, setPalSel]       = useStateV(0);
+  const [loading, setLoading]     = useStateV(false); // demo skeleton
+  // ── Refino #1 KB-9.75: cheat-sheet + row focus + tree expand
+  const [cheatOpen, setCheatOpen] = useStateV(false);
+  const [focusIdx, setFocusIdx]   = useStateV(-1);
+  const [viewsExpand, setViewsExpand] = useStateV({ pendentes: true, faturadas: false });
+  const [favSet, setFavSet]       = useStateV(() => {
+    try { return new Set(JSON.parse(localStorage.getItem("oimpresso.sells.favs") || "[]")); }
+    catch (e) { return new Set(); }
+  });
+  const rowsRef = useRefV([]);
+  // Refino #2 KB-9.75: estado da IA no palette
+  const [aiPalState, setAiPalState] = useStateV("idle"); // idle | loading | done
+  const [aiPalAnswer, setAiPalAnswer] = useStateV("");
+  // reset IA ao fechar/limpar palette
+  useEffectV(() => {
+    if (!palOpen) { setAiPalState("idle"); setAiPalAnswer(""); }
+  }, [palOpen]);
+  useEffectV(() => {
+    setAiPalState("idle"); setAiPalAnswer("");
+  }, [palQ]);
+  const askAi = async () => {
+    if (!window.claude?.complete || !palQ.trim()) { setAiPalState("done"); setAiPalAnswer("Helper IA não disponível."); return; }
+    setAiPalState("loading");
+    try {
+      const text = await window.claude.complete(
+        `Você é assistente do ERP Oimpresso (gráfica). Responda em 1-2 frases curtas, português, sobre vendas/clientes/notas fiscais. Se não tiver contexto, diga "Não consegui inferir disso, abre a venda direto".\n\nPergunta: ${palQ}`
+      );
+      setAiPalAnswer(text);
+    } catch (e) { setAiPalAnswer("Erro: " + (e?.message || e)); }
+    setAiPalState("done");
+  };
+
+  // persist
+  useEffectV(() => { lsSet("vista", vista); }, [vista]);
+  useEffectV(() => { lsSet("savedView", savedView); }, [savedView]);
+  useEffectV(() => { lsSet("statusF", statusF); }, [statusF]);
+  useEffectV(() => { lsSet("query", query); }, [query]);
+
+  // demo skeleton: simula 600ms de carga no mount inicial (cobre dim 5 estados)
+  useEffectV(() => {
+    if (lsGet("skipSkeleton", "0") === "1") return;
+    setLoading(true);
+    const t = setTimeout(() => setLoading(false), 600);
+    return () => clearTimeout(t);
+  }, []);
+
+  // shortcuts (Refino #1 KB-9.75 — J/K row-nav · R/F/B/E/X · ? cheat-sheet)
+  useEffectV(() => {
+    const onKey = (e) => {
+      const inField = ["INPUT","TEXTAREA","SELECT"].includes(e.target.tagName) || e.target.isContentEditable;
+
+      // sempre — palette e fechar
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
+        e.preventDefault(); setPalOpen(true); return;
+      }
+      if (e.key === "Escape") {
+        if (cheatOpen)       setCheatOpen(false);
+        else if (palOpen)    setPalOpen(false);
+        else if (viewsOpen)  setViewsOpen(false);
+        else if (openId)     setOpenId(null);
+        else if (createOpen) setCreateOpen(false);
+        else if (focusIdx >= 0) setFocusIdx(-1);
+        return;
+      }
+      // se digitando em campo, não captura nada além de Esc/⌘K
+      if (inField) return;
+      // se palette/drawer aberto, atalhos de linha desligados
+      if (palOpen || cheatOpen || openId || createOpen) return;
+
+      const total = (window.__vendasFiltered || []).length;
+      const cur = focusIdx;
+
+      if (e.key === "j" || e.key === "J" || e.key === "ArrowDown") {
+        e.preventDefault();
+        const next = Math.min(total - 1, cur < 0 ? 0 : cur + 1);
+        setFocusIdx(next);
+        rowsRef.current[next]?.scrollIntoView?.({ block: "nearest" });
+      } else if (e.key === "k" || e.key === "K" || e.key === "ArrowUp") {
+        e.preventDefault();
+        const next = Math.max(0, cur < 0 ? 0 : cur - 1);
+        setFocusIdx(next);
+        rowsRef.current[next]?.scrollIntoView?.({ block: "nearest" });
+      } else if (e.key === "Enter") {
+        if (cur >= 0 && window.__vendasFiltered?.[cur]) {
+          e.preventDefault(); setOpenId(window.__vendasFiltered[cur].id);
+        }
+      } else if (e.key === "n" || e.key === "N") {
+        e.preventDefault(); setCreateOpen(true);
+      } else if (e.key === "?") {
+        e.preventDefault(); setCheatOpen(true);
+      } else if (e.key === "/") {
+        e.preventDefault();
+        setPalOpen(true);
+      } else if (e.key === "F2") {
+        e.preventDefault();
+        if (window.__vendasPdvOpen) window.__vendasPdvOpen();
+      } else if ((e.key === "r" || e.key === "R") && cur >= 0) {
+        const v = window.__vendasFiltered?.[cur];
+        if (v) { e.preventDefault(); console.log("R · imprimir recibo", v.id); setOpenId(v.id); }
+      } else if ((e.key === "f" || e.key === "F") && cur >= 0) {
+        const v = window.__vendasFiltered?.[cur];
+        if (v) { e.preventDefault(); console.log("F · faturar", v.id); setOpenId(v.id); }
+      } else if ((e.key === "b" || e.key === "B") && cur >= 0) {
+        const v = window.__vendasFiltered?.[cur];
+        if (v) {
+          e.preventDefault();
+          setFavSet(prev => {
+            const next = new Set(prev);
+            if (next.has(v.id)) next.delete(v.id); else next.add(v.id);
+            try { localStorage.setItem("oimpresso.sells.favs", JSON.stringify([...next])); } catch (er){}
+            return next;
+          });
+        }
+      } else if ((e.key === "x" || e.key === "X") && cur >= 0) {
+        const v = window.__vendasFiltered?.[cur];
+        if (v) {
+          e.preventDefault();
+          setSelected(prev => {
+            const next = new Set(prev);
+            if (next.has(v.id)) next.delete(v.id); else next.add(v.id);
+            return next;
+          });
+        }
+      } else if ((e.key === "e" || e.key === "E") && cur >= 0) {
+        const v = window.__vendasFiltered?.[cur];
+        if (v) { e.preventDefault(); setOpenId(v.id); }
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [palOpen, viewsOpen, openId, createOpen, cheatOpen, focusIdx]);
+
+  // filtro composto: saved view (com sub-view "pendentes:bruna") → busca → status
+  const [topView, subView] = (savedView || "hoje").split(":");
+  const view = VENDAS_SAVED_VIEWS.find(v => v.id === topView) || VENDAS_SAVED_VIEWS[0];
+  const filtered = useMemoV(() => {
+    // Refino #4 — view especial "favoritas"
+    let out;
+    if (topView === "favoritas") {
+      out = VENDAS_LIST.filter(v => favSet.has(v.id));
+    } else {
+      out = VENDAS_LIST.filter(view.filter);
+    }
+    if (subView) {
+      if (topView === "pendentes") {
+        out = out.filter(v => {
+          const fn = (VENDEDORES_MAP[v.sellerId]?.name || "").split(" ")[0].toLowerCase();
+          return fn === subView;
+        });
+      } else if (topView === "faturadas") {
+        if (subView === "b2b") out = out.filter(v => v.client !== "Consumidor Final");
+        else if (subView === "b2c") out = out.filter(v => v.client === "Consumidor Final");
+      }
+    }
+    if (query.trim()) {
+      const q = query.toLowerCase();
+      out = out.filter(v =>
+        v.id.toLowerCase().includes(q) ||
+        v.client.toLowerCase().includes(q) ||
+        (v.clientNote || "").toLowerCase().includes(q) ||
+        (v.fiscal?.nfe?.chave  || "").includes(q.replace(/\s/g,"")) ||
+        (v.fiscal?.nfse?.chave || "").includes(q.replace(/\s/g,""))
+      );
+    }
+    if (statusF !== "todas") out = out.filter(v => v.status === statusF);
+    return out;
+  }, [VENDAS_LIST, view, topView, subView, query, statusF, VENDEDORES_MAP, favSet]);
+
+  // expor pra keyboard handler ler sem fechar sobre o closure
+  useEffectV(() => { window.__vendasFiltered = filtered; }, [filtered]);
+  // reset focus quando muda a lista
+  useEffectV(() => {
+    if (focusIdx >= filtered.length) setFocusIdx(filtered.length ? filtered.length - 1 : -1);
+  }, [filtered.length]);
+
+  // KPIs — hoje
+  const today      = VENDAS_LIST.filter(vdIsToday);
+  const kpi_total  = today.reduce((s,v) => s + v.totalNum, 0);
+  const kpi_count  = today.length;
+  const kpi_avg    = kpi_count ? kpi_total / kpi_count : 0;
+  const kpi_pix    = today.filter(v => v.payment === "PIX").reduce((s,v) => s + v.totalNum, 0);
+  const kpi_pixPct = kpi_total ? Math.round((kpi_pix / kpi_total) * 100) : 0;
+
+  // A receber (todas pendentes)
+  const arItems = VENDAS_LIST.filter(v => v.fsm < 4);
+  const kpi_ar  = arItems.reduce((s,v) => s + v.totalNum, 0);
+  const ar_ok   = arItems.filter(v => (v.payTerm||0) <= 30).reduce((s,v)=>s+v.totalNum,0);
+  const ar_w    = arItems.filter(v => (v.payTerm||0) > 30 && (v.payTerm||0) <= 60).reduce((s,v)=>s+v.totalNum,0);
+  const ar_b    = arItems.filter(v => (v.payTerm||0) > 60).reduce((s,v)=>s+v.totalNum,0);
+  const ar_tot  = ar_ok + ar_w + ar_b || 1;
+  // Refino #1 KB-9.75: contagem por SLA (fresco/atrasando/estourado)
+  const slaCounts = arItems.reduce((acc, v) => {
+    const k = vdSlaInfo(v).kind;
+    if (k === "overdue") acc.o++;
+    else if (k === "warning") acc.w++;
+    else if (k === "fresh") acc.f++;
+    return acc;
+  }, { f:0, w:0, o:0 });
+
+  // Faturamento KPIs
+  const fiscalCount = VENDAS_LIST.reduce((acc, v) => {
+    ["nfe","nfse"].forEach(k => {
+      if (v.fiscal?.[k]?.status === "ok")   acc.ok++;
+      if (v.fiscal?.[k]?.status === "wait") acc.wait++;
+      if (v.fiscal?.[k]?.status === "bad")  acc.bad++;
+    });
+    return acc;
+  }, { ok:0, wait:0, bad:0 });
+
+  // Sparkline 30d simulado
+  const sparkData = [3.2,2.8,4.1,3.6,4.8,5.2,3.9,4.4,5.8,4.6,5.1,6.3,5.4,4.9,6.8,7.2,5.9,6.4,7.8,6.2,7.5,8.4,6.9,7.8,9.1,8.2,7.6,8.9,9.4, kpi_total/1000];
+
+  // counts por status (do filtered)
+  const countBy = (s) => s === "todas" ? filtered.length : filtered.filter(v => v.status === s).length;
+
+  // selection
+  const toggleSel = (id) => setSelected(prev => {
+    const next = new Set(prev);
+    if (next.has(id)) next.delete(id); else next.add(id);
+    return next;
+  });
+  const toggleAll = () => {
+    if (selected.size === filtered.length) setSelected(new Set());
+    else setSelected(new Set(filtered.map(v => v.id)));
+  };
+
+  // dropdown close on outside click
+  const viewsRef = useRefV(null);
+  useEffectV(() => {
+    if (!viewsOpen) return;
+    const onClick = (e) => { if (viewsRef.current && !viewsRef.current.contains(e.target)) setViewsOpen(false); };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [viewsOpen]);
+
+  // Refino #4 polish — dropdown "Visões ▾" (sub-rotas Caixa/Devoluções/etc que saíram do topnav)
+  const [visoesOpen, setVisoesOpen] = useStateV(false);
+  const visoesRef = useRefV(null);
+  useEffectV(() => {
+    if (!visoesOpen) return;
+    const onClick = (e) => { if (visoesRef.current && !visoesRef.current.contains(e.target)) setVisoesOpen(false); };
+    document.addEventListener("mousedown", onClick);
+    return () => document.removeEventListener("mousedown", onClick);
+  }, [visoesOpen]);
+
+  // ⌘K palette items
+  const palAll = useMemoV(() => {
+    const recent = VENDAS_LIST.slice(0, 3).map(v => ({
+      grp: "Últimas vendas",
+      ico: <I.receipt size={14}/>,
+      title: `${v.id} · ${v.client}`,
+      sub: `${vdFmt(v.totalNum)} · ${v.payment}`,
+      action: () => { setOpenId(v.id); setPalOpen(false); setPalQ(""); },
+    }));
+    const shortcuts = [
+      { grp:"Ações", ico:<I.plus size={14}/>,     title:"Nova venda",                sub:"Drawer de cadastro completo", kbd:"N",  action:()=>{setCreateOpen(true);setPalOpen(false);} },
+      { grp:"Ações", ico:<I.folder size={14}/>,   title:"Emitir NF-e em lote",       sub:"Pra todas vendas selecionadas",        action:()=>{alert("Emit lote — placeholder");setPalOpen(false);} },
+      { grp:"Buscar",ico:<I.search size={14}/>,   title:"Buscar por chave SEFAZ",    sub:"44 dígitos da NF-e ou NFS-e",          action:()=>{setQuery("3526");setPalOpen(false);} },
+      { grp:"Buscar",ico:<I.search size={14}/>,   title:"Filtrar Rejeitadas SEFAZ",  sub:"Saved view",                            action:()=>{setSavedView("rejeitadas");setPalOpen(false);} },
+      { grp:"Navegar",ico:<I.folder size={14}/>,  title:"Ir pra Orçamentos",         sub:"Módulo Sells/Orçamentos",              action:()=>{alert("→ Orçamentos");setPalOpen(false);} },
+      { grp:"Navegar",ico:<I.folder size={14}/>,  title:"Ir pra Clientes",           sub:"Módulo Clientes",                       action:()=>{alert("→ Clientes");setPalOpen(false);} },
+    ];
+    return [...recent, ...shortcuts];
+  }, [VENDAS_LIST]);
+  const palFiltered = useMemoV(() => {
+    const raw = palQ.trim();
+    if (!raw) return palAll;
+
+    // chave SEFAZ — 20+ dígitos contínuos
+    const digits = raw.replace(/\D/g, "");
+    if (digits.length >= 20) {
+      return VENDAS_LIST.filter(v =>
+        (v.fiscal?.nfe?.chave  || "").includes(digits) ||
+        (v.fiscal?.nfse?.chave || "").includes(digits)
+      ).slice(0, 8).map(v => ({
+        grp: "Chave SEFAZ",
+        ico: <I.search size={14}/>,
+        title: `${v.id} · ${v.client}`,
+        sub: vdFmtChave(v.fiscal?.nfe?.chave || v.fiscal?.nfse?.chave || ""),
+        action: () => { setOpenId(v.id); setPalOpen(false); setPalQ(""); },
+      }));
+    }
+
+    // prefixo # — busca por ID de venda
+    if (raw.startsWith("#")) {
+      const q = raw.slice(1).toLowerCase();
+      return VENDAS_LIST.filter(v => v.id.toLowerCase().includes(q))
+        .slice(0, 12).map(v => ({
+          grp: "Vendas por ID",
+          ico: <I.receipt size={14}/>,
+          title: `${v.id} · ${v.client}`,
+          sub: `${vdFmt(v.totalNum)} · ${v.payment}`,
+          action: () => { setOpenId(v.id); setPalOpen(false); setPalQ(""); },
+        }));
+    }
+
+    // prefixo @ — vendedor
+    if (raw.startsWith("@")) {
+      const q = raw.slice(1).toLowerCase();
+      return VENDAS_LIST.filter(v => {
+        const name = (VENDEDORES_MAP[v.sellerId]?.name || "").toLowerCase();
+        return name.includes(q);
+      }).slice(0, 12).map(v => ({
+        grp: `Vendas por vendedor "${q || "…"}"`,
+        ico: <I.receipt size={14}/>,
+        title: `${v.id} · ${v.client}`,
+        sub: `${VENDEDORES_MAP[v.sellerId]?.name || "—"} · ${vdFmt(v.totalNum)}`,
+        action: () => { setOpenId(v.id); setPalOpen(false); setPalQ(""); },
+      }));
+    }
+
+    // prefixo $ — valor mínimo
+    if (raw.startsWith("$")) {
+      const min = parseFloat(raw.slice(1).replace(/\./g,"").replace(",","."));
+      if (isNaN(min)) return [];
+      return VENDAS_LIST.filter(v => v.totalNum >= min)
+        .sort((a,b) => b.totalNum - a.totalNum)
+        .slice(0, 12).map(v => ({
+          grp: `Vendas ≥ ${vdFmt(min)}`,
+          ico: <I.receipt size={14}/>,
+          title: `${v.id} · ${v.client}`,
+          sub: `${vdFmt(v.totalNum)} · ${v.payment}`,
+          action: () => { setOpenId(v.id); setPalOpen(false); setPalQ(""); },
+        }));
+    }
+
+    // prefixo / — só ações
+    if (raw.startsWith("/")) {
+      const q = raw.slice(1).toLowerCase();
+      return palAll.filter(it =>
+        it.grp === "Ações" &&
+        (it.title.toLowerCase().includes(q) || it.sub.toLowerCase().includes(q))
+      );
+    }
+
+    // default — fuzzy em palAll
+    const q = raw.toLowerCase();
+    return palAll.filter(it => it.title.toLowerCase().includes(q) || it.sub.toLowerCase().includes(q));
+  }, [palAll, palQ, VENDAS_LIST, VENDEDORES_MAP]);
+  const palGroups = useMemoV(() => {
+    const out = []; let last = null;
+    palFiltered.forEach((it, i) => {
+      if (it.grp !== last) { out.push({ header: it.grp }); last = it.grp; }
+      out.push({ item: it, idx: i });
+    });
+    return out;
+  }, [palFiltered]);
+  const runPal = (it) => it && it.action && it.action();
+
+  const open = openId ? VENDAS_LIST.find(v => v.id === openId) : null;
+
+  return (
+    <div className={`os-page vendas-page vendas-aplus`} data-vista={vista}>
+
+      {/* HEADER — linha 1: title + busca + CTA primário */}
+      <header className="os-head vd-head-clean">
+        <div className="os-head-l">
+          <h1>Vendas</h1>
+          <p>Pedidos · faturamento · NF-e/NFS-e</p>
+        </div>
+
+        <button className="vd-cmdk" onClick={() => setPalOpen(true)}>
+          <I.search size={12}/>
+          <span>Buscar venda, cliente, chave SEFAZ…</span>
+          <kbd>⌘K</kbd>
+        </button>
+
+        <div className="os-head-r">
+          <button className="os-btn primary" onClick={()=>setCreateOpen(true)}>
+            <I.plus size={11}/>Nova venda <kbd className="kbd-hint">N</kbd>
+          </button>
+        </div>
+      </header>
+
+      {/* TOOLBAR — linha 2: filtros + ações secundárias */}
+      <div className="vd-toolbar">
+        <div className="vd-toolbar-l">
+          <div className="vd-vista" role="group" aria-label="Foco">
+            <span className="vd-vista-lbl">Foco</span>
+            <button className={vista==="caixa"?"on":""}        onClick={()=>setVista("caixa")}>Caixa</button>
+            <button className={vista==="faturamento"?"on":""}  onClick={()=>setVista("faturamento")}>Faturamento</button>
+            <button className={vista==="comissao"?"on":""}     onClick={()=>setVista("comissao")}>Comissão</button>
+          </div>
+
+          <span className="vd-toolbar-sep"/>
+
+          <div className="vd-views" ref={viewsRef}>
+            <button className="vd-views-btn" onClick={()=>setViewsOpen(v=>!v)}>
+              {topView === "favoritas" ? `★ Favoritas (${favSet.size})` : (subView ? `${view.label} · ${subView}` : view.label)}
+            </button>
+            {viewsOpen && (
+              <div className="vd-views-menu vd-tree">
+                {favSet.size > 0 && (
+                  <React.Fragment>
+                    <div className={`vd-tree-row l0 vd-tree-fav ${savedView === "favoritas" ? "active" : ""}`}
+                         onClick={()=>{ setSavedView("favoritas"); setViewsOpen(false); }}>
+                      <span className="vd-tree-arr empty"/>
+                      <span className="vd-tree-lbl">★ Favoritas <small>(pessoais · atalho B)</small></span>
+                      <span className="ct">{favSet.size}</span>
+                    </div>
+                    <div className="vd-views-sep"/>
+                  </React.Fragment>
+                )}
+                {VENDAS_SAVED_VIEWS.map(sv => {
+                  const items = VENDAS_LIST.filter(sv.filter);
+                  const baseCt = items.length;
+                  const expandable = sv.id === "pendentes" || sv.id === "faturadas";
+                  const expanded = !!viewsExpand[sv.id];
+                  const itemActive = savedView === sv.id;
+                  // calcular filhos
+                  let children = [];
+                  if (sv.id === "pendentes") {
+                    const byS = {};
+                    items.forEach(v => {
+                      const fn = (VENDEDORES_MAP[v.sellerId]?.name || "—").split(" ")[0];
+                      const key = fn.toLowerCase();
+                      if (!byS[key]) byS[key] = { id: key, label: "por " + fn, ct: 0 };
+                      byS[key].ct++;
+                    });
+                    children = Object.values(byS).sort((a,b)=>b.ct-a.ct);
+                  } else if (sv.id === "faturadas") {
+                    const b2b = items.filter(v => v.client !== "Consumidor Final").length;
+                    const b2c = items.length - b2b;
+                    children = [
+                      { id: "b2b", label: "B2B (com CNPJ)", ct: b2b },
+                      { id: "b2c", label: "B2C (consumidor)", ct: b2c },
+                    ].filter(c => c.ct > 0);
+                  }
+                  return (
+                    <React.Fragment key={sv.id}>
+                      <div className={`vd-tree-row l0 ${itemActive ? "active" : ""}`}>
+                        {expandable
+                          ? <span className={`vd-tree-arr ${expanded ? "open" : ""}`}
+                                  onClick={e=>{e.stopPropagation(); setViewsExpand(p=>({...p, [sv.id]: !p[sv.id]}));}}>›</span>
+                          : <span className="vd-tree-arr empty"/>}
+                        <span className="vd-tree-lbl" onClick={()=>{ setSavedView(sv.id); setViewsOpen(false); }}>
+                          {sv.label}
+                        </span>
+                        <span className="ct">{baseCt}</span>
+                      </div>
+                      {expandable && expanded && children.map(ch => (
+                        <div key={ch.id}
+                             className={`vd-tree-row l1 ${savedView === sv.id + ":" + ch.id ? "active" : ""}`}
+                             onClick={()=>{ setSavedView(sv.id + ":" + ch.id); setViewsOpen(false); }}>
+                          <span className="vd-tree-arr empty"/>
+                          <span className="vd-tree-lbl">{ch.label}</span>
+                          <span className="ct">{ch.ct}</span>
+                        </div>
+                      ))}
+                    </React.Fragment>
+                  );
+                })}
+                <div className="vd-views-sep"/>
+                <div className="vd-views-item" style={{color:"var(--text-mute)",fontSize:11.5}}>
+                  <I.folder size={11}/> Salvar vista atual…
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="vd-toolbar-r">
+          <button className="vd-toolbar-act" title="Imprimir caixa do dia">
+            <I.printer size={11}/><span>Imprimir caixa</span>
+          </button>
+
+          {/* Visões ▾ — sub-rotas (Caixa/Devoluções/Comissões/Relatórios + PDV) */}
+          <div className="vd-visoes" ref={visoesRef}>
+            <button className="vd-toolbar-act vd-visoes-btn" onClick={() => setVisoesOpen(v => !v)} title="Outras visões deste módulo">
+              <I.folder size={11}/><span>Visões</span>
+            </button>
+            {visoesOpen && (
+              <div className="vd-visoes-menu">
+                <div className="vd-visoes-grp">Visões deste módulo</div>
+                {(window.__vendasSubs || [
+                  { id:"lista",      label:"Lista de vendas" },
+                  { id:"caixa",      label:"Caixa do dia" },
+                  { id:"devolucoes", label:"Devoluções" },
+                  { id:"comissoes",  label:"Comissões" },
+                  { id:"relatorios", label:"Relatórios" },
+                ]).map(s => {
+                  const isActive = (window.__vendasCurrentSub || "lista") === s.id;
+                  return (
+                    <div key={s.id}
+                         className={`vd-visoes-item ${isActive ? "active" : ""}`}
+                         onClick={() => {
+                           if (window.__vendasSubSetter) window.__vendasSubSetter(s.id);
+                           setVisoesOpen(false);
+                         }}>
+                      <span className="vd-visoes-dot"/>{s.label}
+                      {isActive && <span className="vd-visoes-here">aqui</span>}
+                    </div>
+                  );
+                })}
+                <div className="vd-visoes-sep"/>
+                <div className="vd-visoes-item primary" onClick={() => {
+                  if (window.__vendasPdvOpen) window.__vendasPdvOpen();
+                  setVisoesOpen(false);
+                }}>
+                  <span className="vd-visoes-dot pdv"/>Abrir PDV balcão
+                  <kbd>F2</kbd>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* KPIs */}
+      <div className="os-kpis vd-kpis">
+        {/* Hero faturado hoje + sparkline */}
+        <div className="os-kpi vd-kpi-hero">
+          <span className="os-kpi-label">Faturado hoje</span>
+          <span className="os-kpi-value">{vdFmtShort(kpi_total)}</span>
+          <span className="os-kpi-sub vd-delta-up">↑ +18% vs ontem · {kpi_count} vendas</span>
+          <div className="vd-spark"><VdSparkline data={sparkData} color="oklch(0.72 0.10 155)"/></div>
+        </div>
+
+        {/* Ticket médio */}
+        <div className="os-kpi">
+          <span className="os-kpi-label">Ticket médio</span>
+          <span className="os-kpi-value">{vdFmtShort(kpi_avg)}</span>
+          <span className="os-kpi-sub vd-delta-up">↑ 12% vs semana passada</span>
+        </div>
+
+        {/* A receber + ageing */}
+        <div className="os-kpi">
+          <span className="os-kpi-label">A receber</span>
+          <span className="os-kpi-value">{vdFmtShort(kpi_ar)}</span>
+          <span className="os-kpi-sub vd-sla-counts">
+            {slaCounts.o > 0 && <span className="vd-sla-mini overdue"><span className="ic">✕</span>{`${slaCounts.o} estourado${slaCounts.o>1?"s":""}`}</span>}
+            {slaCounts.w > 0 && <span className="vd-sla-mini warning"><span className="ic">▲</span>{`${slaCounts.w} atrasando`}</span>}
+            {slaCounts.f > 0 && <span className="vd-sla-mini fresh"><span className="ic">●</span>{`${slaCounts.f} fresco${slaCounts.f>1?"s":""}`}</span>}
+          </span>
+          <div className="vd-ageing">
+            <div className="vd-ag-bar ok"><div style={{width: (ar_ok/ar_tot*100)+"%"}}/></div>
+            <div className="vd-ag-bar warn"><div style={{width:(ar_w/ar_tot*100)+"%"}}/></div>
+            <div className="vd-ag-bar bad"><div style={{width: (ar_b/ar_tot*100)+"%"}}/></div>
+            <div className="vd-ag-lbls"><span>0–30d</span><span>31–60d</span><span>+60d</span></div>
+          </div>
+        </div>
+
+        {/* 4º card — varia por Vista */}
+        {vista === "caixa" && (
+          <div className="os-kpi">
+            <span className="os-kpi-label">PIX hoje</span>
+            <span className="os-kpi-value">{vdFmtShort(kpi_pix)}<small> / {vdFmtShort(kpi_total)}</small></span>
+            <span className="os-kpi-sub">{kpi_pixPct}% do faturamento — imediato</span>
+            <div className="vd-pix-prog"><div style={{width:kpi_pixPct+"%"}}/></div>
+          </div>
+        )}
+        {vista === "faturamento" && (
+          <div className="os-kpi">
+            <span className="os-kpi-label">Notas fiscais</span>
+            <span className="os-kpi-value">{fiscalCount.ok}<small>/{fiscalCount.ok+fiscalCount.wait+fiscalCount.bad}</small></span>
+            <span className="os-kpi-sub">autorizadas · {fiscalCount.wait} processando · {fiscalCount.bad} rejeitadas</span>
+            <div className="vd-fiscal-bar">
+              <div style={{flex:fiscalCount.ok,  background:"var(--vd-ok)"}}/>
+              <div style={{flex:fiscalCount.wait,background:"var(--vd-warn)"}}/>
+              <div style={{flex:fiscalCount.bad, background:"var(--vd-bad)"}}/>
+            </div>
+          </div>
+        )}
+        {vista === "comissao" && (
+          <div className="os-kpi vd-rank">
+            <span className="os-kpi-label">Ranking vendedores · mês</span>
+            {Object.values(VENDEDORES_MAP).slice(0,4).map((s, i) => {
+              const sales = VENDAS_LIST.filter(v => v.sellerId === s.id);
+              const total = sales.reduce((acc, v) => acc + v.totalNum, 0);
+              const pct = Math.min(100, (total / s.meta) * 100);
+              return (
+                <div key={s.id} className="vd-rank-row">
+                  <span className={`vd-av vd-av-${s.av}`}>{s.abbr}</span>
+                  <span className="vd-rank-info">
+                    <div><span>{s.name}</span><span>{vdFmtShort(total)}</span></div>
+                    <div className="vd-rank-bar"><div style={{width:pct+"%", background: pct >= 100 ? "var(--vd-ok)" : "var(--vd-green)"}}/></div>
+                  </span>
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {/* TABS */}
+      <div className="os-tabs">
+        {["todas","paga","pendente","faturada","cancelada"].map(s => (
+          <button key={s} className={"os-tab" + (statusF===s ? " active" : "")} onClick={()=>setStatusF(s)}>
+            {s === "todas" ? "Todas" : (VENDAS_STATUS[s]?.label || s.charAt(0).toUpperCase()+s.slice(1))}
+            <span className="os-tab-n">{countBy(s)}</span>
+          </button>
+        ))}
+      </div>
+
+      {/* TABLE */}
+      <div className="os-table-wrap">
+        <table className="os-table vendas-table vd-aplus-table">
+          <thead>
+            <tr>
+              <th style={{width:24,padding:"0 0 0 12px"}}>
+                <input type="checkbox"
+                       checked={filtered.length > 0 && selected.size === filtered.length}
+                       onChange={toggleAll}/>
+              </th>
+              <th style={{width:82}}>Venda</th>
+              <th style={{width:80}}>Data</th>
+              <th>Cliente</th>
+              <th style={{width:168}}>Atendido por</th>
+              <th style={{width:128}}>Pipeline</th>
+              <th style={{width:148}}>Fiscal</th>
+              <th style={{width:128}}>Pagamento</th>
+              <th style={{width:110}}>Total</th>
+              <th style={{width:90}} className="vd-col-commission">Comissão</th>
+              <th style={{width:88}}>Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading && Array.from({length:6}).map((_, i) => (
+              <tr key={"sk"+i} className="vd-sk-row">
+                <td colSpan={11}>
+                  <div className="vd-sk-bar" style={{animationDelay: (i*60)+"ms"}}/>
+                </td>
+              </tr>
+            ))}
+            {!loading && filtered.map((v, ri) => {
+              const sel = selected.has(v.id);
+              const isFocused = ri === focusIdx;
+              const isFav = favSet.has(v.id);
+              const s = VENDEDORES_MAP[v.sellerId] || {};
+              const comm = v.totalNum * (s.commissionPct || 0);
+              return (
+                <tr key={v.id}
+                    ref={el => { rowsRef.current[ri] = el; }}
+                    className={"os-row" + (v.urgent ? " urgent" : "") + (sel ? " selected" : "") + (isFocused ? " row-focused" : "")}
+                    onClick={() => { setFocusIdx(ri); setOpenId(v.id); }}>
+                  <td className="vd-chk" onClick={e=>e.stopPropagation()}>
+                    <input type="checkbox" checked={sel} onChange={()=>toggleSel(v.id)}/>
+                  </td>
+                  <td className="vd-id">
+                    {isFav && <span className="vd-fav" title="Favorita (B)">★</span>}
+                    #{v.id}
+                  </td>
+                  <td className="vd-date">
+                    <div>{v.date.slice(8,10)}/{v.date.slice(5,7)}</div>
+                    <div className="vd-time">{v.time}</div>
+                  </td>
+                  <td className="vd-client">
+                    {v.vertical === "mec" ? (
+                      <div className="vd-client-mec">
+                        <VdPlate value={v.plate}/>
+                        <div>
+                          <div className="vd-client-name">{v.vehicle}</div>
+                          <div className="vd-notes">{v.client} · km {v.km}</div>
+                        </div>
+                      </div>
+                    ) : (
+                      <React.Fragment>
+                        <div className="vd-client-name">{v.client}</div>
+                        <div className="vd-notes">{v.clientNote || v.notes}</div>
+                      </React.Fragment>
+                    )}
+                  </td>
+                  <td className="vd-seller-cell">
+                    {v.vertical === "mec" && v.mechanicId ? (
+                      <React.Fragment>
+                        <VdAv mid={v.mechanicId}/>
+                        <span className="vd-seller-info">
+                          <b>{(window.VENDAS_DATA.MECANICOS_MAP[v.mechanicId]?.name || "").split(" ")[0]}</b>
+                          <small>vend: {(s.abbr || "").toLowerCase()}</small>
+                        </span>
+                      </React.Fragment>
+                    ) : (
+                      <React.Fragment>
+                        <VdAv sid={v.sellerId}/>
+                        <span className="vd-seller-info">
+                          <b>{(s.name || v.seller || "").split(" ")[0]}</b>
+                          <small>{v.origin}</small>
+                        </span>
+                      </React.Fragment>
+                    )}
+                  </td>
+                  <td><VdStepper fsm={v.fsm} vertical={v.vertical}/></td>
+                  <td><VdFiscalCell v={v}/></td>
+                  <td className="vd-pay">
+                    <div className="vd-pay-top">
+                      <span>{v.payment}</span>
+                      {v.installments > 1 && <span className="vd-inst">{v.installments}×</span>}
+                    </div>
+                    <div className="vd-pay-sla"><VdSlaPill v={v} compact/></div>
+                  </td>
+                  <td className="vd-total">{v.total}</td>
+                  <td className="vd-total vd-col-commission" style={{color:"var(--vd-green)",fontWeight:700}}>
+                    {vdFmt(comm)}
+                  </td>
+                  <td>
+                    <span className="os-stage" style={{
+                      background: (VENDAS_STATUS[v.status]?.color || "#888") + "1f",
+                      color: VENDAS_STATUS[v.status]?.color || "#888"
+                    }}>
+                      {VENDAS_STATUS[v.status]?.label || v.status}
+                    </span>
+                    <div className="vd-row-actions" onClick={e=>e.stopPropagation()}>
+                      {v.fiscal?.nfe?.status === "ok" && (
+                        <button className="vd-row-act" title="Baixar DANFE PDF"><I.archive size={11}/></button>
+                      )}
+                      {v.fiscal?.nfe?.status === "ok" && (
+                        <button className="vd-row-act" title="Baixar XML"><I.folder size={11}/></button>
+                      )}
+                      <button className="vd-row-act" title="Imprimir recibo (R)"><I.printer size={11}/></button>
+                    </div>
+                  </td>
+                </tr>
+              );
+            })}
+            {!loading && filtered.length === 0 && (
+              <tr><td colSpan={11} className="os-empty">
+                {topView === "atrasadas" && <><b>Tudo dentro do prazo ✓</b><br/><small>Nenhuma venda atrasada. Bom trabalho.</small></>}
+                {topView === "rejeitadas" && <><b>Zero rejeições da SEFAZ ✓</b><br/><small>Todos os documentos fiscais autorizados.</small></>}
+                {topView === "favoritas" && <><b>Sem favoritas ainda</b><br/><small>Foque uma linha com J/K e aperte <kbd>B</kbd> pra pinar.</small></>}
+                {topView === "pendentes" && <><b>Tudo pago ✓</b><br/><small>Nada pendente nesta segmentação.</small></>}
+                {topView === "faturadas" && <><b>Nada faturado esta semana</b><br/><small>Vendas faturadas aparecem aqui após emissão de NF-e/NFS-e.</small></>}
+                {!["atrasadas","rejeitadas","favoritas","pendentes","faturadas"].includes(topView) && (
+                  <>Nenhuma venda encontrada. Use <kbd>N</kbd> pra criar ou <kbd>⌘K</kbd> pra buscar.</>
+                )}
+              </td></tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* BULK ACTION BAR */}
+      <div className={`vd-bulk ${selected.size > 0 ? "on" : ""}`}>
+        <span className="vd-bulk-ct">{selected.size} selecionadas</span>
+        <button className="vd-bulk-btn primary"><I.folder size={11}/>Emitir NF-e em lote</button>
+        <button className="vd-bulk-btn"><I.check size={11}/>Marcar como pagas</button>
+        <button className="vd-bulk-btn"><I.archive size={11}/>Exportar XML/PDF</button>
+        <button className="vd-bulk-btn"><I.message size={11}/>Lembrete interno</button>
+        <button className="vd-bulk-close" onClick={()=>setSelected(new Set())}>✕</button>
+      </div>
+
+      {/* DRAWERS */}
+      {open       && <VendaDetailDrawer venda={open} onClose={()=>setOpenId(null)}/>}
+      {createOpen && <VendaCreateDrawer onClose={()=>setCreateOpen(false)}/>}
+
+      {/* ⌘K PALETTE */}
+      <div className={`vd-pal-bd ${palOpen ? "on" : ""}`} onClick={()=>setPalOpen(false)}>
+        <div className="vd-pal" onClick={e=>e.stopPropagation()}>
+          <div className="vd-pal-in">
+            <I.search size={16}/>
+            <input autoFocus placeholder="Buscar venda, cliente, chave SEFAZ, ações…"
+                   value={palQ}
+                   onChange={e=>{ setPalQ(e.target.value); setPalSel(0); }}
+                   onKeyDown={e=>{
+                     if (e.key === "ArrowDown") { setPalSel(s => Math.min(s+1, palFiltered.length-1)); e.preventDefault(); }
+                     if (e.key === "ArrowUp")   { setPalSel(s => Math.max(s-1, 0));                   e.preventDefault(); }
+                     if (e.key === "Enter")     {
+                       if (palFiltered.length === 0 && palQ.trim() && aiPalState === "idle") {
+                         e.preventDefault(); askAi();
+                       } else {
+                         runPal(palFiltered[palSel]);
+                       }
+                     }
+                   }}/>
+            <kbd>esc</kbd>
+          </div>
+          <div className="vd-pal-list">
+            {palGroups.length === 0 && (
+              palQ.trim() ? (
+                <div className="vd-pal-ai-wrap">
+                  {aiPalState === "idle" && (
+                    <button className="vd-pal-ai-cta" onClick={askAi}>
+                      <span className="vd-pal-ai-ic">✦</span>
+                      <span className="vd-pal-ai-tx">
+                        <b>Perguntar à IA</b>
+                        <small>sobre "<i>{palQ}</i>"</small>
+                      </span>
+                      <kbd>↵</kbd>
+                    </button>
+                  )}
+                  {aiPalState === "loading" && (
+                    <div className="vd-pal-ai-loading">
+                      <span className="vd-pal-ai-ic">✦</span>
+                      <span>consultando IA…</span>
+                      <span className="vd-pal-ai-dots"><span/><span/><span/></span>
+                    </div>
+                  )}
+                  {aiPalState === "done" && (
+                    <div className="vd-pal-ai-answer">
+                      <header><span className="vd-pal-ai-ic">✦</span><b>IA</b><span>resposta sobre "{palQ}"</span></header>
+                      <p>{aiPalAnswer}</p>
+                      <small>Resposta gerada por IA — pode ter alucinações. Sempre confirme com a venda.</small>
+                    </div>
+                  )}
+                </div>
+              ) : <div className="vd-pal-empty">Nada encontrado.</div>
+            )}
+            {palGroups.map((g, i) =>
+              g.header
+                ? <div key={"h"+i} className="vd-pal-grp">{g.header}</div>
+                : (
+                  <div key={"i"+i} className={`vd-pal-it ${g.idx === palSel ? "sel" : ""}`}
+                       onMouseEnter={()=>setPalSel(g.idx)}
+                       onClick={()=>runPal(g.item)}>
+                    <span className="vd-pal-ic">{g.item.ico}</span>
+                    <span className="vd-pal-tx">
+                      <b>{g.item.title}</b>
+                      <small>{g.item.sub}</small>
+                    </span>
+                    {g.item.kbd && <kbd>{g.item.kbd}</kbd>}
+                  </div>
+                )
+            )}
+          </div>
+          <div className="vd-pal-ft">
+            <span><kbd>↑↓</kbd> navegar</span>
+            <span><kbd>↵</kbd> abrir</span>
+            <span className="vd-pal-prefix"><kbd>#</kbd> ID · <kbd>@</kbd> vendedor · <kbd>$</kbd> valor · <kbd>/</kbd> ações</span>
+            <span><kbd>esc</kbd> fechar</span>
+          </div>
+        </div>
+      </div>
+
+      {/* CHEAT-SHEET overlay (atalho ?) — Refino #1 KB-9.75 */}
+      {cheatOpen && window.VdCheatSheet && <window.VdCheatSheet onClose={() => setCheatOpen(false)}/>}
+
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────
+// DETAIL DRAWER (com Fiscal tab — A+)
+// ──────────────────────────────────────────────────────────────
+function VendaDetailDrawer({ venda, onClose }) {
+  const { VENDAS_STATUS, VENDEDORES_MAP } = window.VENDAS_DATA;
+  const v = venda;
+
+  const hasNFe  = !!v.fiscal?.nfe;
+  const hasNFSe = !!v.fiscal?.nfse;
+  const wantsNFe  = vdHasProduto(v);
+  const wantsNFSe = vdHasServico(v);
+
+  const [tab, setTab] = useStateV("itens");
+  const [fSub, setFSub] = useStateV(() => hasNFe && hasNFSe ? "ambos" : hasNFe ? "nfe" : "nfse");
+  // Refino #4 KB-9.75 — distribuição
+  const [transcriptOpen, setTranscriptOpen] = useStateV(false);
+  const [presentationOpen, setPresentationOpen] = useStateV(false);
+
+  // Refino #3 KB-9.75 — comentários inline por item (via vendas-curation.jsx)
+  const _useVdCom = window.useVdItemComments;
+  const comments = _useVdCom ? _useVdCom() : null;
+  // Editar venda — patches inline (via vendas-curation.jsx)
+  const _useVdEdits = window.useVdItemEdits;
+  const edits = _useVdEdits ? _useVdEdits() : null;
+  // Total recomputado com edits aplicados
+  const itemsEffective = (v.itemsList || []).map((it, i) =>
+    edits ? edits.applied(v.id, i, it) : it
+  );
+  const totalEffective = itemsEffective.reduce((s, it) => s + (+it.qty || 0) * (+it.unit || 0), 0);
+  const totalDelta = totalEffective - (v.totalNum || 0);
+
+  const s = VENDEDORES_MAP[v.sellerId] || {};
+  const comm = v.totalNum * (s.commissionPct || 0);
+
+  const dateBR = `${v.date.slice(8,10)}/${v.date.slice(5,7)}/${v.date.slice(0,4)}`;
+
+  return (
+    <div className="os-drawer-back" onClick={onClose}>
+      <aside className="os-drawer wide vd-drawer-aplus" onClick={e => e.stopPropagation()}>
+        <header className="os-drawer-head">
+          <div className="os-drawer-head-l">
+            <span className="os-drawer-id">#{v.id}</span>
+            <h2>{v.client}</h2>
+            {v.clientNote && (
+              <p className="vd-drawer-note">
+                {window.VdLinkify ? <window.VdLinkify text={v.clientNote} onPick={(id,kind)=>console.log("→",kind,id)}/> : v.clientNote}
+              </p>
+            )}
+            <p>{dateBR} às {v.time} · {s.name || v.seller}</p>
+          </div>
+          <div className="os-drawer-head-r">
+            <span className="vd-drawer-total">{v.total}</span>
+            <span className="os-stage" style={{
+              background: (VENDAS_STATUS[v.status]?.color || "#888") + "1f",
+              color: VENDAS_STATUS[v.status]?.color || "#888"
+            }}>{VENDAS_STATUS[v.status]?.label}</span>
+            <button className="icon-btn" onClick={onClose}><I.close size={14}/></button>
+          </div>
+        </header>
+
+        <nav className="vd-drawer-tabs">
+          {[
+            {k:"itens",    l:"Itens",     ct: v.itemsList?.length || 0},
+            {k:"fiscal",   l:"Fiscal",    ct: (hasNFe?1:0)+(hasNFSe?1:0)},
+            {k:"pagamento",l:"Pagamento", ct: null},
+            {k:"timeline", l:"Timeline",  ct: null},
+            {k:"ia",       l:"✦ IA",     ct: null, ai: true},
+          ].map(t => (
+            <button key={t.k}
+                    className={`vd-drawer-tab ${tab===t.k ? "on" : ""} ${t.ai ? "vd-tab-ai" : ""}`}
+                    onClick={()=>setTab(t.k)}>
+              {t.l}
+              {t.ct !== null && t.ct > 0 && <span className="vd-drawer-tab-ct">{t.ct}</span>}
+              {t.k === "itens" && comments?.countFor(v.id) > 0 && (
+                <span className="vd-drawer-tab-cmt" title={`${comments.countFor(v.id)} comentário(s) inline`}>💬{comments.countFor(v.id)}</span>
+              )}
+            </button>
+          ))}
+        </nav>
+
+        <div className="os-drawer-body vd-drawer-body">
+
+          {tab === "itens" && (
+            <section className="vd-section">
+              <h3>Itens da venda</h3>
+              <div className="vd-items-cards">
+                {(v.itemsList || []).map((it, i) => (
+                  window.VdItemRow && comments ? (
+                    <window.VdItemRow key={i}
+                      venda={v} item={it} idx={i}
+                      comments={comments.get(v.id, i)}
+                      onAdd={(t) => comments.add(v.id, i, t, s.name || "você")}
+                      onRemove={(ci) => comments.remove(v.id, i, ci)}
+                      edits={edits ? edits.get(v.id, i) : null}
+                      onEdit={(patch) => edits && edits.set(v.id, i, patch)}
+                      onResetEdit={() => edits && edits.reset(v.id, i)}/>
+                  ) : (
+                    <div key={i} className="vd-item-card">
+                      <div className="vd-item-c-l">
+                        <b>{it.name}</b>
+                        <small>{it.sku} · {it.type === "produto" ? "Produto (NF-e)" : "Serviço (NFS-e)"}</small>
+                      </div>
+                      <span className="vd-item-c-qty">{it.qty}×</span>
+                      <span className="vd-item-c-unit">{vdFmt(it.unit)}</span>
+                      <span className="vd-item-c-sub">{vdFmt(it.qty * it.unit)}</span>
+                    </div>
+                  )
+                ))}
+              </div>
+              <div className="vd-items-foot">
+                <span>Total {edits && edits.hasEdits(v.id) ? <small className="vd-edits-tag">com edições</small> : null}</span>
+                <b>
+                  {edits && Math.abs(totalDelta) > 0.01
+                    ? <React.Fragment>
+                        <s className="vd-total-orig">{v.total}</s>
+                        <span className="vd-total-new">{totalEffective.toLocaleString("pt-BR",{style:"currency",currency:"BRL"})}</span>
+                        <small className={`vd-total-delta ${totalDelta > 0 ? "pos" : "neg"}`}>
+                          {totalDelta > 0 ? "+" : ""}{totalDelta.toLocaleString("pt-BR",{style:"currency",currency:"BRL"})}
+                        </small>
+                      </React.Fragment>
+                    : v.total}
+                </b>
+              </div>
+            </section>
+          )}
+
+          {tab === "fiscal" && (
+            <section className="vd-section">
+              <h3>Documentos fiscais</h3>
+
+              {/* painel emitir quando falta */}
+              {((wantsNFe && !hasNFe) || (wantsNFSe && !hasNFSe)) && (
+                <div className="vd-emit">
+                  <div>
+                    <b>
+                      {!hasNFe && wantsNFe && !hasNFSe && wantsNFSe ? "Emitir NF-e e NFS-e"
+                      : !hasNFe && wantsNFe ? "Emitir NF-e"
+                      : "Emitir NFS-e"}
+                    </b>
+                    <small>
+                      Esta venda tem
+                      {wantsNFe  && !hasNFe  && " produto(s)"}
+                      {wantsNFe  && wantsNFSe && !hasNFe && !hasNFSe && " e "}
+                      {wantsNFSe && !hasNFSe && " serviço(s)"}
+                      {" "}sem documento fiscal.
+                    </small>
+                  </div>
+                  <button className="os-btn primary">
+                    {!hasNFe && wantsNFe && !hasNFSe && wantsNFSe ? "Emitir ambos" : !hasNFe ? "Emitir NF-e" : "Emitir NFS-e"}
+                  </button>
+                </div>
+              )}
+
+              {/* sub-tabs apenas se mista */}
+              {hasNFe && hasNFSe && (
+                <div className="vd-fsub">
+                  <button className={fSub==="nfe"?"on":""}   onClick={()=>setFSub("nfe")}>NF-e <span>1</span></button>
+                  <button className={fSub==="nfse"?"on":""}  onClick={()=>setFSub("nfse")}>NFS-e <span>1</span></button>
+                  <button className={fSub==="ambos"?"on":""} onClick={()=>setFSub("ambos")}>Ambos</button>
+                </div>
+              )}
+
+              <div className={`vd-fcard-grid ${(hasNFe && !hasNFSe) || (!hasNFe && hasNFSe) ? "single" : ""}`}>
+                {hasNFe  && fSub !== "nfse" && <VdFiscalCard kind="nfe"  doc={v.fiscal.nfe}/>}
+                {hasNFSe && fSub !== "nfe"  && <VdFiscalCard kind="nfse" doc={v.fiscal.nfse}/>}
+              </div>
+
+              {/* breakdown total se mista */}
+              {hasNFe && hasNFSe && (
+                <div className="vd-fbreak">
+                  <h4>Breakdown fiscal</h4>
+                  <dl>
+                    <dt>Produtos (NF-e {v.fiscal.nfe.numero})</dt>
+                    <dd>{vdFmt(v.itemsList.filter(i=>i.type==="produto").reduce((s,i)=>s+i.qty*i.unit,0))}</dd>
+                    <dt>Serviços (NFS-e {v.fiscal.nfse.numero})</dt>
+                    <dd>{vdFmt(v.itemsList.filter(i=>i.type==="servico").reduce((s,i)=>s+i.qty*i.unit,0))}</dd>
+                    <dt className="tot">Total da venda</dt>
+                    <dd className="tot">{v.total}</dd>
+                  </dl>
+                </div>
+              )}
+
+              {!hasNFe && !hasNFSe && !wantsNFe && !wantsNFSe && (
+                <div className="vd-empty-state">
+                  Esta venda não emite documento fiscal (Consumidor Final · dinheiro).
+                </div>
+              )}
+            </section>
+          )}
+
+          {tab === "pagamento" && (
+            <section className="vd-section">
+              <h3>Pagamento</h3>
+              <div className="vd-pay-meta">
+                <dl>
+                  <dt>Forma</dt><dd>{v.payment}</dd>
+                  <dt>Parcelas</dt><dd>{v.installments > 1 ? `${v.installments}×` : "À vista"}</dd>
+                  <dt>Prazo</dt><dd>{v.payTerm || 0} dias <VdSlaPill v={v}/></dd>
+                  <dt>Status</dt><dd><span className="os-stage" style={{
+                      background: (VENDAS_STATUS[v.status]?.color || "#888") + "1f",
+                      color: VENDAS_STATUS[v.status]?.color || "#888"
+                    }}>{VENDAS_STATUS[v.status]?.label}</span></dd>
+                  <dt>Comissão</dt><dd className="vd-comm">{vdFmt(comm)} <small>({((s.commissionPct||0)*100).toFixed(1)}%)</small></dd>
+                </dl>
+              </div>
+
+              {v.osIds?.length > 0 && (
+                <div style={{marginTop:16}}>
+                  <h3>Ordens de Serviço vinculadas</h3>
+                  <div className="vd-os-list">
+                    {v.osIds.map(id => (
+                      <div key={id} className="vd-os-link">
+                        <span className="vd-os-pill">#{id}</span>
+                        <span>Ver na produção →</span>
+                      </div>
+                    ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Lançamentos Financeiros vinculados — busca em FIN_ROWS por #V- no desc */}
+              {(() => {
+                const finRows = (window.FIN_ROWS || []).filter(r => (r.desc || "").includes("#" + v.id));
+                if (finRows.length === 0) return null;
+                return (
+                  <div style={{marginTop:16}}>
+                    <h3>Lançamentos financeiros vinculados</h3>
+                    <div className="vd-fin-list">
+                      {finRows.map(r => {
+                        const isRec = r.kind === "receivable";
+                        const isPaid = !!r.paid_at;
+                        return (
+                          <div key={r.id} className={"vd-fin-link " + (isRec ? "rec" : "pay") + (isPaid ? " paid" : "")}>
+                            <span className={`vd-fin-pill ${isRec ? "rec" : "pay"}`}>
+                              {isRec ? "↓" : "↑"} #{r.id}
+                            </span>
+                            <span className="vd-fin-meta">
+                              {isRec ? "A receber" : "A pagar"} · {r.channel || "—"}
+                            </span>
+                            <span className="vd-fin-amount">
+                              {(r.amount || 0).toLocaleString("pt-BR", { style:"currency", currency:"BRL" })}
+                            </span>
+                            <span className={`vd-fin-status ${isPaid ? "paid" : (r.status === "atrasado" ? "late" : "open")}`}>
+                              {isPaid ? "liquidado" : (r.status === "atrasado" ? "atrasado" : "em aberto")}
+                            </span>
+                          </div>
+                        );
+                      })}
+                    </div>
+                  </div>
+                );
+              })()}
+
+              {/* Refino #4 KB-9.75 — Mensagem pra cliente (variáveis live) */}
+              {window.VdMessagePreview && (
+                <div style={{marginTop:20}}>
+                  <window.VdMessagePreview venda={v}/>
+                </div>
+              )}
+            </section>
+          )}
+
+          {tab === "timeline" && (
+            <section className="vd-section">
+              {window.VdAuditTrail
+                ? <window.VdAuditTrail venda={v}/>
+                : <React.Fragment>
+                    <h3>Linha do tempo</h3>
+                    <div className="vd-tline">
+                      <div className="vd-tline-it"><small>{dateBR} {v.time}</small><b>Venda registrada por {s.name || v.seller}</b></div>
+                    </div>
+                  </React.Fragment>}
+            </section>
+          )}
+
+          {tab === "ia" && (
+            window.VdAiPanel
+              ? <window.VdAiPanel venda={v}/>
+              : <section className="vd-section vd-ai-fallback">
+                  <p>Módulo IA não carregado. Inclua <code>vendas-ai.jsx</code> no Chat.</p>
+                </section>
+          )}
+
+        </div>
+
+        <footer className="os-drawer-actions">
+          {window.VdTroubleButton && <window.VdTroubleButton venda={v}/>}
+          {v.status === "pendente" && <button className="os-btn primary"><I.check size={11}/>Confirmar pagamento</button>}
+          {v.status === "paga" && !hasNFe && wantsNFe && <button className="os-btn primary"><I.folder size={11}/>Faturar (NF-e)</button>}
+          <button className="os-btn ghost"><I.printer size={11}/>Imprimir recibo</button>
+          {window.VdTranscriptPDF && (
+            <button className="os-btn ghost" onClick={() => setTranscriptOpen(true)} title="Transcript completo (PDF jurídico)">
+              <I.archive size={11}/>Transcript
+            </button>
+          )}
+          {window.VdPresentationMode && (
+            <button className="os-btn ghost vd-btn-present" onClick={() => setPresentationOpen(true)} title="Modo apresentação · reunião com cliente">
+              ▶ Apresentar
+            </button>
+          )}
+        </footer>
+      </aside>
+
+      {/* Refino #4 — overlays */}
+      {transcriptOpen   && window.VdTranscriptPDF      && <window.VdTranscriptPDF      venda={v} onClose={() => setTranscriptOpen(false)}/>}
+      {presentationOpen && window.VdPresentationMode   && <window.VdPresentationMode   venda={v} onClose={() => setPresentationOpen(false)}/>}
+    </div>
+  );
+}
+
+// ──────────────────────────────────────────────────────────────
+// CREATE DRAWER (P0 — preservado do v1, sem mudanças)
+// ──────────────────────────────────────────────────────────────
+function VendaCreateDrawer({ onClose }) {
+  const { OS_CLIENTS, OS_PRODUCTS } = window.OS_DATA;
+  const { VENDAS_PAYMENTS } = window.VENDAS_DATA;
+
+  const [step, setStep] = useStateV(1);
+  const [clientQuery, setClientQuery] = useStateV("");
+  const [client, setClient] = useStateV(null);
+  const [contact, setContact] = useStateV("");
+  const [phone, setPhone] = useStateV("");
+
+  const clientMatches = useMemoV(() => {
+    if (!clientQuery.trim()) return OS_CLIENTS.slice(0, 6);
+    const q = clientQuery.toLowerCase();
+    return OS_CLIENTS.filter(c =>
+      c.name.toLowerCase().includes(q) ||
+      (c.cnpj || "").includes(q) ||
+      (c.contact || "").toLowerCase().includes(q)
+    ).slice(0, 8);
+  }, [clientQuery, OS_CLIENTS]);
+
+  const [items, setItems] = useStateV([]);
+  const [prodQuery, setProdQuery] = useStateV("");
+  const prodMatches = useMemoV(() => {
+    const q = prodQuery.trim().toLowerCase();
+    if (!q) return OS_PRODUCTS.slice(0, 6);
+    return OS_PRODUCTS.filter(p => (p.name || p.label || "").toLowerCase().includes(q)).slice(0, 6);
+  }, [prodQuery, OS_PRODUCTS]);
+
+  const fmtPrice = (n) => typeof n === "number"
+    ? n.toLocaleString("pt-BR", { style:"currency", currency:"BRL" })
+    : (n || "R$ 0,00");
+  const addItem = (p) => {
+    setItems(prev => [...prev, {
+      key: Date.now() + Math.random(),
+      product: p.name || p.label || "—",
+      qty: 1, unitPrice: fmtPrice(p.price),
+      generatesOs: !(p.readyStock || false),
+    }]);
+    setProdQuery("");
+  };
+  const updateItem = (k, patch) => setItems(prev => prev.map(it => it.key === k ? { ...it, ...patch } : it));
+  const removeItem = (k) => setItems(prev => prev.filter(it => it.key !== k));
+
+  const subtotal = useMemoV(() => items.reduce((s, it) => {
+    const p = parseFloat((it.unitPrice || "0").replace(/[^\d,]/g,"").replace(",","."));
+    return s + (isNaN(p) ? 0 : p) * (parseInt(it.qty) || 0);
+  }, 0), [items]);
+
+  const [payment, setPayment] = useStateV("pix");
+  const [installments, setInstallments] = useStateV(1);
+  const [discount, setDiscount] = useStateV(0);
+  const total = Math.max(0, subtotal - discount);
+  const fmt = (n) => n.toLocaleString("pt-BR", { style:"currency", currency:"BRL" });
+
+  const steps = [
+    { n:1, label:"Cliente",   ok: !!client },
+    { n:2, label:"Itens",     ok: items.length > 0 },
+    { n:3, label:"Pagamento", ok: !!payment },
+    { n:4, label:"Confirmar", ok: false },
+  ];
+  const canNext = steps[step-1].ok;
+  const generatesAnyOs = items.some(it => it.generatesOs);
+
+  return (
+    <div className="os-drawer-back" onClick={onClose}>
+      <aside className="os-drawer wide vd-create" onClick={e => e.stopPropagation()}>
+        <header className="os-drawer-head">
+          <div className="os-drawer-head-l">
+            <span className="os-drawer-id">Nova venda</span>
+            <h2>Balcão · {new Date().toLocaleDateString("pt-BR")}</h2>
+            <p>Atalho: <kbd>Esc</kbd> cancelar · <kbd>Enter</kbd> avançar</p>
+          </div>
+          <button className="icon-btn" onClick={onClose}><I.close size={14}/></button>
+        </header>
+
+        <nav className="vd-stepper">
+          {steps.map((s, i) => (
+            <button key={s.n}
+                    className={"vd-step" + (step === s.n ? " active" : "") + (s.ok ? " done" : "")}
+                    onClick={() => s.ok || step > s.n ? setStep(s.n) : null}>
+              <span className="vd-step-num">{s.ok && step !== s.n ? "✓" : s.n}</span>
+              <span>{s.label}</span>
+              {i < steps.length - 1 && <span className="vd-step-sep">›</span>}
+            </button>
+          ))}
+        </nav>
+
+        <div className="os-drawer-body vd-create-body">
+          {step === 1 && (
+            <section className="vd-section">
+              <h3>Cliente</h3>
+              {!client ? (
+                <React.Fragment>
+                  <div className="vd-search-wrap">
+                    <I.search size={12}/>
+                    <input autoFocus type="text" placeholder="Nome, CNPJ ou telefone..."
+                           value={clientQuery} onChange={e => setClientQuery(e.target.value)}/>
+                    <button className="vd-walkin"
+                            onClick={() => setClient({ id:"walkin", name:"Consumidor Final", cnpj:"—", contact:"—", phone:"" })}>
+                      Consumidor Final
+                    </button>
+                  </div>
+                  <div className="vd-client-list">
+                    {clientMatches.map(c => (
+                      <button key={c.id} className="vd-client-card"
+                              onClick={() => { setClient(c); setContact(c.contact || ""); setPhone(c.phone || ""); }}>
+                        <div className="vd-client-card-name">{c.name}</div>
+                        <div className="vd-client-card-meta">{c.cnpj || "—"} · {c.contact || "—"}</div>
+                      </button>
+                    ))}
+                  </div>
+                </React.Fragment>
+              ) : (
+                <div className="vd-client-selected">
+                  <div>
+                    <strong>{client.name}</strong>
+                    <div className="vd-meta">{client.cnpj || "—"}</div>
+                  </div>
+                  <div className="vd-fields">
+                    <label>Contato<input value={contact} onChange={e => setContact(e.target.value)}/></label>
+                    <label>Telefone<input value={phone} onChange={e => setPhone(e.target.value)}/></label>
+                  </div>
+                  <button className="os-btn ghost" onClick={() => setClient(null)}>Trocar cliente</button>
+                </div>
+              )}
+            </section>
+          )}
+
+          {step === 2 && (
+            <section className="vd-section">
+              <h3>Itens</h3>
+              <div className="vd-search-wrap">
+                <I.search size={12}/>
+                <input autoFocus type="text" placeholder="Adicionar produto do catálogo..."
+                       value={prodQuery} onChange={e => setProdQuery(e.target.value)}/>
+              </div>
+              {prodQuery && (
+                <div className="vd-prod-suggest">
+                  {prodMatches.map((p, i) => (
+                    <button key={i} className="vd-prod-row" onClick={() => addItem(p)}>
+                      <span>{p.name || p.label}</span>
+                      <span className="vd-prod-price">{p.price || "—"}</span>
+                    </button>
+                  ))}
+                  {prodMatches.length === 0 && <div className="vd-empty-mini">Nenhum produto</div>}
+                </div>
+              )}
+
+              {items.length === 0 ? (
+                <div className="vd-empty-state">Nenhum item adicionado. Use o campo acima para buscar do catálogo.</div>
+              ) : (
+                <table className="vd-items-table">
+                  <thead>
+                    <tr><th>Produto</th><th style={{width:80}}>Qtd</th><th style={{width:130}}>Unit.</th><th style={{width:130}}>Subtotal</th><th style={{width:100}}>Gera OS?</th><th style={{width:36}}></th></tr>
+                  </thead>
+                  <tbody>
+                    {items.map(it => {
+                      const p = parseFloat((it.unitPrice || "0").replace(/[^\d,]/g,"").replace(",","."));
+                      const sub = (isNaN(p) ? 0 : p) * (parseInt(it.qty) || 0);
+                      return (
+                        <tr key={it.key}>
+                          <td>{it.product}</td>
+                          <td><input type="number" min="1" value={it.qty} onChange={e => updateItem(it.key, { qty: e.target.value })}/></td>
+                          <td><input value={it.unitPrice} onChange={e => updateItem(it.key, { unitPrice: e.target.value })}/></td>
+                          <td className="vd-strong">{fmt(sub)}</td>
+                          <td>
+                            <label className="vd-toggle">
+                              <input type="checkbox" checked={it.generatesOs} onChange={e => updateItem(it.key, { generatesOs: e.target.checked })}/>
+                              <span>{it.generatesOs ? "Sim" : "Pronta-entrega"}</span>
+                            </label>
+                          </td>
+                          <td><button className="icon-btn" onClick={() => removeItem(it.key)}><I.close size={12}/></button></td>
+                        </tr>
+                      );
+                    })}
+                  </tbody>
+                  <tfoot>
+                    <tr><td colSpan={3} className="vd-foot-l">Subtotal</td><td colSpan={3} className="vd-foot-r">{fmt(subtotal)}</td></tr>
+                  </tfoot>
+                </table>
+              )}
+            </section>
+          )}
+
+          {step === 3 && (
+            <section className="vd-section">
+              <h3>Pagamento</h3>
+              <div className="vd-pay-grid">
+                {VENDAS_PAYMENTS.map(p => (
+                  <button key={p.id} className={"vd-pay-card" + (payment === p.id ? " active" : "")} onClick={() => setPayment(p.id)}>
+                    <span className="vd-pay-icon">{p.icon}</span>
+                    <span className="vd-pay-label">{p.label}</span>
+                    <span className="vd-pay-clear">{p.clearing}</span>
+                  </button>
+                ))}
+              </div>
+              {(payment === "cartao" || payment.startsWith("boleto")) && (
+                <div className="vd-fields">
+                  <label>Parcelas
+                    <select value={installments} onChange={e => setInstallments(parseInt(e.target.value))}>
+                      {[1,2,3,4,5,6,10,12].map(n => <option key={n} value={n}>{n}× de {fmt(total/n)}</option>)}
+                    </select>
+                  </label>
+                  <label>Desconto<input type="number" min="0" value={discount} onChange={e => setDiscount(parseFloat(e.target.value) || 0)}/></label>
+                </div>
+              )}
+              <dl className="vd-totals">
+                <dt>Subtotal</dt><dd>{fmt(subtotal)}</dd>
+                <dt>Desconto</dt><dd>-{fmt(discount)}</dd>
+                <dt className="vd-total-row">Total</dt><dd className="vd-total-row">{fmt(total)}</dd>
+              </dl>
+            </section>
+          )}
+
+          {step === 4 && (
+            <section className="vd-section vd-confirm">
+              <h3>Confirmar venda</h3>
+              <div className="vd-confirm-grid">
+                <div className="vd-confirm-block">
+                  <span className="vd-confirm-label">Cliente</span>
+                  <strong>{client?.name || "—"}</strong>
+                  <span className="vd-meta">{client?.cnpj || "—"}</span>
+                </div>
+                <div className="vd-confirm-block">
+                  <span className="vd-confirm-label">Itens</span>
+                  <strong>{items.length} {items.length === 1 ? "item" : "itens"}</strong>
+                  <span className="vd-meta">{items.filter(it => it.generatesOs).length} gera{items.filter(it => it.generatesOs).length === 1 ? "" : "m"} OS</span>
+                </div>
+                <div className="vd-confirm-block">
+                  <span className="vd-confirm-label">Pagamento</span>
+                  <strong>{(VENDAS_PAYMENTS.find(p => p.id === payment) || {}).label}</strong>
+                  <span className="vd-meta">{installments > 1 ? `${installments}× de ${fmt(total/installments)}` : "À vista"}</span>
+                </div>
+                <div className="vd-confirm-block vd-confirm-total">
+                  <span className="vd-confirm-label">Total</span>
+                  <strong className="vd-total-big">{fmt(total)}</strong>
+                </div>
+              </div>
+              {generatesAnyOs && (
+                <div className="vd-callout">
+                  <strong>Esta venda gerará {items.filter(it => it.generatesOs).length} OS</strong> automaticamente após confirmação. As OS irão para a fila de produção da etapa <em>Pré-impressão</em>.
+                </div>
+              )}
+              {!generatesAnyOs && items.length > 0 && (
+                <div className="vd-callout vd-callout-ok">
+                  <strong>Pronta-entrega.</strong> Nenhuma OS será gerada — entregue os itens ao cliente direto do estoque/balcão.
+                </div>
+              )}
+            </section>
+          )}
+        </div>
+
+        <footer className="os-drawer-actions vd-foot">
+          <div className="vd-foot-summary">
+            {items.length > 0 && (
+              <React.Fragment>
+                <span>{items.length} {items.length === 1 ? "item" : "itens"}</span>
+                <span className="vd-foot-total">{fmt(total)}</span>
+              </React.Fragment>
+            )}
+          </div>
+          <div className="vd-foot-actions">
+            {step > 1 && <button className="os-btn ghost" onClick={() => setStep(step-1)}>← Voltar</button>}
+            {step < 4 && <button className="os-btn primary" disabled={!canNext} onClick={() => setStep(step+1)}>Avançar →</button>}
+            {step === 4 && (
+              <button className="os-btn primary" onClick={() => { alert("Venda registrada (mock)"); onClose(); }}>
+                <I.check size={11}/>Confirmar venda
+              </button>
+            )}
+          </div>
+        </footer>
+      </aside>
+    </div>
+  );
+}
+
+window.VendasListPage = VendasListPage;

--- a/prototipo-ui/vendas-shortcuts.jsx
+++ b/prototipo-ui/vendas-shortcuts.jsx
@@ -1,0 +1,85 @@
+// vendas-shortcuts.jsx — Refino #1 KB-9.75 · cheat-sheet overlay
+// Acionado por "?" no módulo Vendas. Não captura atalhos — vendas-page.jsx faz isso.
+// Aqui só renderiza a folha de referência visual.
+
+const { useEffect: useEffectVS } = React;
+
+function VdCheatSheet({ onClose }) {
+  useEffectVS(() => {
+    const onKey = (e) => { if (e.key === "Escape") { e.preventDefault(); onClose(); } };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  return (
+    <div className="vd-cheat-bd" onClick={onClose}>
+      <div className="vd-cheat" onClick={e => e.stopPropagation()}>
+        <header className="vd-cheat-h">
+          <span className="vd-cheat-ic">⌨</span>
+          <h2>Atalhos do balcão</h2>
+          <p>Vendas opera sem mouse. Pressione qualquer combinação abaixo.</p>
+          <button className="vd-cheat-x" onClick={onClose}><kbd>esc</kbd></button>
+        </header>
+
+        <div className="vd-cheat-grid">
+          <section className="vd-cheat-sec">
+            <h4>Navegar</h4>
+            <VdCsRow keys={["J"]} lbl={<span>próxima venda <b>↓</b></span>}/>
+            <VdCsRow keys={["K"]} lbl={<span>anterior venda <b>↑</b></span>}/>
+            <VdCsRow keys={["↵"]} lbl="abrir drawer da venda focada"/>
+            <VdCsRow keys={["/"]} lbl="focar campo de busca"/>
+            <VdCsRow keys={["⌘","K"]} lbl="command palette (busca global + ações)"/>
+          </section>
+
+          <section className="vd-cheat-sec">
+            <h4>Ações na venda focada</h4>
+            <VdCsRow keys={["N"]} lbl="nova venda"/>
+            <VdCsRow keys={["R"]} lbl="imprimir recibo (térmica/A4)"/>
+            <VdCsRow keys={["F"]} lbl="faturar NF-e / NFS-e"/>
+            <VdCsRow keys={["B"]} lbl="favoritar (pessoal — atalho B)"/>
+            <VdCsRow keys={["X"]} lbl="selecionar pra ação em lote"/>
+            <VdCsRow keys={["E"]} lbl="editar venda (drawer Create)"/>
+          </section>
+
+          <section className="vd-cheat-sec">
+            <h4>⌘K prefixos</h4>
+            <VdCsRow keys={["/"]} lbl={<span>filtra <b>ações</b> · ex: <code>/faturar lote</code></span>}/>
+            <VdCsRow keys={["#"]} lbl={<span>busca por <b>ID</b> · ex: <code>#7825</code></span>}/>
+            <VdCsRow keys={["@"]} lbl={<span>filtra por <b>vendedor</b> · ex: <code>@bruna</code></span>}/>
+            <VdCsRow keys={["$"]} lbl={<span>valor <b>mínimo</b> · ex: <code>$2000</code></span>}/>
+            <VdCsRow keys={["…"]} lbl={<span>44 dígitos = <b>chave SEFAZ</b></span>}/>
+          </section>
+
+          <section className="vd-cheat-sec">
+            <h4>Sair / ajuda</h4>
+            <VdCsRow keys={["Esc"]} lbl="fechar palette · drawer · cheat-sheet"/>
+            <VdCsRow keys={["?"]} lbl="abrir este cheat-sheet"/>
+          </section>
+        </div>
+
+        <footer className="vd-cheat-ft">
+          <span>Atalhos persistem em toda sub-rota de Vendas (Lista · Caixa · Devoluções · Comissões · Relatórios).</span>
+          <span>Refino #1 · KB-9.75 fundação · maio/2026</span>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+function VdCsRow({ keys, lbl }) {
+  return (
+    <div className="vd-cs-row">
+      <div className="vd-cs-keys">
+        {keys.map((k, i) => (
+          <React.Fragment key={i}>
+            {i > 0 && <span className="vd-cs-plus">+</span>}
+            <kbd>{k}</kbd>
+          </React.Fragment>
+        ))}
+      </div>
+      <div className="vd-cs-lbl">{lbl}</div>
+    </div>
+  );
+}
+
+window.VdCheatSheet = VdCheatSheet;

--- a/prototipo-ui/vendas-tweaks.jsx
+++ b/prototipo-ui/vendas-tweaks.jsx
@@ -1,0 +1,110 @@
+// vendas-tweaks.jsx — Refino #4 polish · TweaksPanel pra Vendas (2026-05-15)
+// 4 dimensões: Densidade · Largura drawer · SLA visual · Paleta accent
+// Aplica via data-attrs + CSS vars no .vendas-aplus
+
+(function() {
+  const { useEffect } = React;
+
+  const TWEAK_DEFAULTS = {
+    density: "cozy",        // compact | cozy | spacious
+    drawerWidth: "padrao",  // padrao | largo
+    slaVisual: "pill",      // pill | dot | bar
+    palette: "green",       // green | indigo | slate | amber
+  };
+
+  function VendasTweaksPanel() {
+    if (!window.useTweaks || !window.TweaksPanel) return null;
+    const [t, setTweak] = window.useTweaks(TWEAK_DEFAULTS);
+
+    // Aplica em .vendas-aplus
+    useEffect(() => {
+      const el = document.querySelector(".vendas-aplus");
+      if (!el) return;
+      el.setAttribute("data-vd-density", t.density);
+      el.setAttribute("data-vd-drawer", t.drawerWidth);
+      el.setAttribute("data-vd-sla", t.slaVisual);
+      el.setAttribute("data-vd-palette", t.palette);
+    });
+
+    const {
+      TweaksPanel, TweakSection, TweakRadio, TweakSelect,
+    } = window;
+
+    return (
+      <TweaksPanel title="Tweaks · Vendas">
+        <TweakSection label="Densidade da tabela">
+          <TweakRadio
+            label="Espaçamento"
+            value={t.density}
+            options={[
+              { value: "compact",  label: "Compacta" },
+              { value: "cozy",     label: "Confortável" },
+              { value: "spacious", label: "Espaçosa" },
+            ]}
+            onChange={v => setTweak("density", v)}/>
+        </TweakSection>
+
+        <TweakSection label="Drawer detalhe">
+          <TweakRadio
+            label="Largura"
+            value={t.drawerWidth}
+            options={[
+              { value: "padrao", label: "Padrão" },
+              { value: "largo",  label: "Largo" },
+            ]}
+            onChange={v => setTweak("drawerWidth", v)}/>
+        </TweakSection>
+
+        <TweakSection label="SLA visual">
+          <TweakRadio
+            label="Como mostrar"
+            value={t.slaVisual}
+            options={[
+              { value: "pill", label: "Pill" },
+              { value: "dot",  label: "Dot+txt" },
+              { value: "bar",  label: "Barra" },
+            ]}
+            onChange={v => setTweak("slaVisual", v)}/>
+        </TweakSection>
+
+        <TweakSection label="Paleta accent">
+          <TweakSelect
+            label="Cor do módulo"
+            value={t.palette}
+            options={[
+              { value: "green",  label: "Forest green (padrão)" },
+              { value: "indigo", label: "Indigo" },
+              { value: "slate",  label: "Slate" },
+              { value: "amber",  label: "Amber" },
+            ]}
+            onChange={v => setTweak("palette", v)}/>
+        </TweakSection>
+      </TweaksPanel>
+    );
+  }
+
+  // Auto-mount num portal dedicado ao final do body
+  window.VendasTweaksPanel = VendasTweaksPanel;
+
+  // Helper: monta numa div dedicada (só quando vendas-aplus está na tela)
+  function mountIfVendas() {
+    if (!document.querySelector(".vendas-aplus")) return;
+    if (document.getElementById("__vd_tweaks_root")) return;
+    const host = document.createElement("div");
+    host.id = "__vd_tweaks_root";
+    document.body.appendChild(host);
+    ReactDOM.createRoot(host).render(<VendasTweaksPanel/>);
+  }
+  function unmountIfNotVendas() {
+    if (document.querySelector(".vendas-aplus")) return;
+    const host = document.getElementById("__vd_tweaks_root");
+    if (host) host.remove();
+  }
+  // Observer pra montar/desmontar conforme navega
+  const obs = new MutationObserver(() => {
+    mountIfVendas();
+    unmountIfNotVendas();
+  });
+  if (document.body) obs.observe(document.body, { childList: true, subtree: true });
+  else document.addEventListener("DOMContentLoaded", () => obs.observe(document.body, { childList: true, subtree: true }));
+})();


### PR DESCRIPTION
## Resumo

Aplicação do Método KB-9.75 em DOIS módulos completos.

### Vendas: 5,6 → 9,75 (4 refinos + polish)
- Refino #1 Fundação · SLA pill, J/K row-nav, ⌘K prefixos, tree saved-views, responsive
- Refino #2 IA · resumir pedido, histórico cliente, sugerir produto, palette empty IA
- Refino #3 Curadoria+Guia · comentários inline, audit trail, troubleshooter, linkify
- Refino #4 Distribuição · transcript PDF, apresentação fullscreen, mensagem, art-slot
- Polish · Foco/Visões, sticky header, empty states, hover-reveal actions, Tweaks panel

### Financeiro: 7,5 → 9,75 (3 refinos)
- Refino #1 Curadoria · Conferido toggle Eliana, comentários, audit, frescor pill
- Refino #2 IA · anomalia outlier, party context, month digest 4-card snapshot
- Refino #3 Guia+Saída · 4 troubleshooters, trilha fechamento 12 passos, modo apresentação

### Cross-link bidirecional
- `VdLinkify` estendido pra `#BL-` `#PC-` `#R-` `#P-`
- Drawer da venda ganha seção 'Lançamentos financeiros vinculados'
- Drawer do Financeiro tem `desc` com `#V-` clicável

### Reuso conseguido
- ~70% dos componentes do Financeiro vieram do Vendas
- `KBTroubleshooterDialog` reusado em ambos com customTroubles distintos
- CSS `.vd-ai-*` compartilhado entre módulos

### Arquivos
- 7 arquivos NOVOS (`vendas-{shortcuts,ai,curation,output,tweaks}.jsx`, `financeiro-{curation,ai,output}.jsx`)
- 11 arquivos modificados (vendas-page, vendas-extras, financeiro-app, financeiro-data, financeiro-icons, financeiro-telas-extras, data, app, styles.css, Chat.html)

### Testar
Abra `prototipo-ui/Oimpresso ERP - Chat.html` localmente. Navegue: Vendas → abre venda V-7821 → drawer com tab '✦ IA' funcional → footer com '? Resolver' e '▶ Apresentar' e 'Transcript'. Financeiro → '☑ Fechamento' abre trilha 12 passos.

Re: ADR-0114 (loop Cowork formalizado)
