### PR TITLE
docs(feedback): registra reincidencia 2026-05-18 regra brave-mcp-primeiro

### DIFF
--- a/memory/reference/feedback-brave-mcp-primeiro-sempre.md
+++ b/memory/reference/feedback-brave-mcp-primeiro-sempre.md
@@ -26,3 +26,4 @@ type: feedback
 
 **Histórico:**
 - 2026-05-15 — Wagner instalou regra após sessão Caixa Unificada V4 onde Claude pediu print 3× em vez de olhar direto.
+- 2026-05-18 — REINCIDÊNCIA. Após merge PR #1064 (sync KB-9.75 Vendas+Financeiro) + #1065 (docs follow-up), Claude reportou "mergeado" sem abrir Chrome MCP no `prototipo-ui/Oimpresso ERP - Chat.html` pra Wagner ver render. Wagner: *"confere o resultado no crome, lembre isso é outra reclamação sempre solicitando a mesma coisa"*. Regra aplica TAMBÉM a mockup local (HTML standalone do Cowork), não só prod Hostinger.


### PR DESCRIPTION
Anexa 1 linha de historico em `memory/reference/feedback-brave-mcp-primeiro-sempre.md` documentando reincidencia detectada hoje (apos PRs #1064 e #1065 declarados "pronto" sem smoke Chrome, regressao real foi detectada por #1066).

Wagner: *"confere o resultado no crome, lembre isso é outra reclamação sempre solicitando a mesma coisa"*.

Regra cobre TAMBEM mockup local servido via `python -m http.server`, nao so prod Hostinger.

Sem mudanca em codigo de producao.