### PR TITLE
feat(financeiro): Onda 5 KB-9.75 R1 Curadoria — Conferido + Comments + Audit + Frescor

### DIFF
--- a/Modules/Financeiro/Tests/Feature/Onda5CuradoriaR1Test.php
+++ b/Modules/Financeiro/Tests/Feature/Onda5CuradoriaR1Test.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Onda 5 Financeiro KB-9.75 R1 Curadoria — testes estruturais.
+ *
+ * Cobre:
+ *   - 4 components novos em resources/js/Pages/Financeiro/Unificado/_components/
+ *     (FinPillFrescor, FinConferidoToggle, FinCommentsThread, FinAuditTrail)
+ *   - CSS escopado em resources/css/fin-curadoria.css importado por inertia.css
+ *   - Index.tsx wire-up (imports, hooks, wrap .fin-curadoria, drawer enriquecido,
+ *     row badges silent)
+ *
+ * Multi-tenant Tier 0 (ADR 0093) — testes file_get_contents + regex (sem DB).
+ *
+ * Refs:
+ *   - memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md
+ *   - prototipo-ui/financeiro-curation.jsx (canonical source)
+ */
+
+const FIN_BASE = __DIR__ . '/../../../../resources/js/Pages/Financeiro/Unificado';
+const FIN_CSS_PATH = __DIR__ . '/../../../../resources/css/fin-curadoria.css';
+const FIN_INERTIA_CSS = __DIR__ . '/../../../../resources/css/inertia.css';
+
+describe('Onda 5 Financeiro R1 Curadoria — 4 components existem', function () {
+    it('FinPillFrescor existe e exporta finFrescorInfo + 6 kinds', function () {
+        $src = file_get_contents(FIN_BASE . '/_components/FinPillFrescor.tsx');
+        expect($src)->toContain('export function finFrescorInfo');
+        expect($src)->toContain('export function FinPillFrescor');
+        expect($src)->toContain("kind: 'paid'");
+        expect($src)->toContain("kind: 'overdue'");
+        expect($src)->toContain("kind: 'today'");
+        expect($src)->toContain("kind: 'warning'");
+        expect($src)->toContain("kind: 'soon'");
+        expect($src)->toContain("kind: 'fresh'");
+    });
+
+    it('FinConferidoToggle exporta useFinConferido hook + Toggle + Badge', function () {
+        $src = file_get_contents(FIN_BASE . '/_components/FinConferidoToggle.tsx');
+        expect($src)->toContain('export function useFinConferido');
+        expect($src)->toContain('export function FinConferidoToggle');
+        expect($src)->toContain('export function FinConferidoBadge');
+        expect($src)->toContain("'oimpresso.financeiro.conferido'");
+        expect($src)->toContain('localStorage');
+    });
+
+    it('FinCommentsThread exporta useFinComments hook + Thread + Badge', function () {
+        $src = file_get_contents(FIN_BASE . '/_components/FinCommentsThread.tsx');
+        expect($src)->toContain('export function useFinComments');
+        expect($src)->toContain('export function FinCommentsThread');
+        expect($src)->toContain('export function FinCommentsBadge');
+        expect($src)->toContain("'oimpresso.financeiro.comments'");
+    });
+
+    it('FinAuditTrail exporta finAuditTrail + componente com 5 kinds', function () {
+        $src = file_get_contents(FIN_BASE . '/_components/FinAuditTrail.tsx');
+        expect($src)->toContain('export function finAuditTrail');
+        expect($src)->toContain('export function FinAuditTrail');
+        expect($src)->toContain("kind: 'create'");
+        expect($src)->toContain("kind: 'categorize'");
+        expect($src)->toContain("kind: 'edit'");
+        expect($src)->toContain("kind: 'concil'");
+        expect($src)->toContain("kind: 'alert'");
+    });
+});
+
+describe('Onda 5 Financeiro R1 Curadoria — CSS escopado', function () {
+    it('fin-curadoria.css existe e escopa em .fin-curadoria', function () {
+        $css = file_get_contents(FIN_CSS_PATH);
+        expect($css)->toContain('.fin-curadoria .fin-conferido-toggle');
+        expect($css)->toContain('.fin-curadoria .fin-frescor');
+        expect($css)->toContain('.fin-curadoria .fin-audit');
+        expect($css)->toContain('.fin-curadoria .fin-comments');
+        // 6 estados de frescor com cores
+        expect($css)->toContain('.fin-frescor-paid');
+        expect($css)->toContain('.fin-frescor-overdue');
+        expect($css)->toContain('.fin-frescor-today');
+        expect($css)->toContain('.fin-frescor-warning');
+        expect($css)->toContain('.fin-frescor-soon');
+        expect($css)->toContain('.fin-frescor-fresh');
+    });
+
+    it('inertia.css importa fin-curadoria.css', function () {
+        $css = file_get_contents(FIN_INERTIA_CSS);
+        expect($css)->toContain('@import "./fin-curadoria.css"');
+    });
+});
+
+describe('Onda 5 Financeiro R1 Curadoria — wire-up Index.tsx', function () {
+    it('Index.tsx importa os 4 components da Onda 5', function () {
+        $src = file_get_contents(FIN_BASE . '/Index.tsx');
+        expect($src)->toContain("from './_components/FinPillFrescor'");
+        expect($src)->toContain("from './_components/FinConferidoToggle'");
+        expect($src)->toContain("from './_components/FinCommentsThread'");
+        expect($src)->toContain("from './_components/FinAuditTrail'");
+    });
+
+    it('Index.tsx wrap raiz com .fin-curadoria pra escopar CSS', function () {
+        $src = file_get_contents(FIN_BASE . '/Index.tsx');
+        expect($src)->toContain('<div className="fin-curadoria">');
+    });
+
+    it('Index.tsx instancia hooks useFinConferido + useFinComments no FinanceiroUnificado', function () {
+        $src = file_get_contents(FIN_BASE . '/Index.tsx');
+        expect($src)->toContain('const conferido = useFinConferido()');
+        expect($src)->toContain('const comments = useFinComments()');
+    });
+
+    it('Index.tsx passa hooks pro LinhaTabela (badges silent na linha)', function () {
+        $src = file_get_contents(FIN_BASE . '/Index.tsx');
+        expect($src)->toContain('conferido={conferido}');
+        expect($src)->toContain('comments={comments}');
+        expect($src)->toContain('<FinConferidoBadge');
+        expect($src)->toContain('<FinCommentsBadge');
+        expect($src)->toContain('<FinPillFrescor');
+    });
+
+    it('Index.tsx drawer enriquecido com Conferido toggle + Audit + Comments thread', function () {
+        $src = file_get_contents(FIN_BASE . '/Index.tsx');
+        expect($src)->toContain('<FinConferidoToggle rowId={selected.id}');
+        expect($src)->toContain('<FinAuditTrail row=');
+        expect($src)->toContain('<FinCommentsThread rowId={selected.id}');
+    });
+});
+
+describe('Onda 5 Financeiro R1 Curadoria — charter atualizado', function () {
+    it('Index.charter.md declara Onda 5 R1 features + canon_method KB-9.75', function () {
+        $md = file_get_contents(FIN_BASE . '/Index.charter.md');
+        expect($md)->toContain('canon_method: Cowork KB-9.75');
+        expect($md)->toContain('charter_version: 2');
+        expect($md)->toContain('last_validated: 2026-05-18');
+        expect($md)->toContain('Onda 5 KB-9.75 R1 Curadoria');
+        expect($md)->toContain('Conferido toggle');
+        expect($md)->toContain('Frescor pill');
+        expect($md)->toContain('Audit trail');
+    });
+});

--- a/resources/css/fin-curadoria.css
+++ b/resources/css/fin-curadoria.css
@@ -1,0 +1,306 @@
+/* fin-curadoria.css — Cowork KB-9.75 Financeiro Onda 5 R1 Curadoria
+ *
+ * Tokens visuais portados de prototipo-ui/styles.css (Refino #1).
+ * Escopados em .fin-curadoria pra não vazar pra outras telas Inertia.
+ *
+ * Refs:
+ *   - prototipo-ui/financeiro-curation.jsx (canonical components)
+ *   - prototipo-ui/styles.css linhas ~7700-7910 (canonical tokens)
+ */
+
+.fin-curadoria {
+  /* fallback caso var global ausente */
+  --fin-text: oklch(0.30 0.005 240);
+  --fin-text-mute: oklch(0.55 0.005 240);
+  --fin-line: oklch(0.92 0.005 240);
+  --fin-bg-soft: oklch(0.97 0.005 240);
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Conferido — toggle grande + badge silencioso + pill inline
+ * ───────────────────────────────────────────────────────────── */
+
+.fin-curadoria .fin-conferido-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px 6px 8px;
+  border-radius: 6px;
+  border: 1.5px solid oklch(0.78 0.10 145);
+  background: oklch(0.97 0.04 145);
+  font-family: inherit;
+  font-size: 12.5px;
+  font-weight: 600;
+  color: oklch(0.32 0.13 145);
+  cursor: pointer;
+  transition: all .12s;
+}
+.fin-curadoria .fin-conferido-toggle:hover { background: oklch(0.94 0.06 145); }
+.fin-curadoria .fin-conferido-toggle.on {
+  background: oklch(0.86 0.14 145);
+  border-color: oklch(0.55 0.18 145);
+  color: oklch(0.22 0.06 145);
+}
+.fin-curadoria .fin-conferido-toggle .fin-conf-check {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 4px;
+  background: white;
+  color: oklch(0.45 0.18 145);
+  border: 1px solid oklch(0.55 0.13 145);
+}
+.fin-curadoria .fin-conferido-toggle.on .fin-conf-check {
+  background: oklch(0.45 0.18 145);
+  color: white;
+  border-color: transparent;
+}
+.fin-curadoria .fin-conferido-toggle .fin-conf-lbl { font-weight: 600; }
+.fin-curadoria .fin-conferido-toggle small {
+  font-size: 10.5px;
+  font-weight: 500;
+  opacity: 0.75;
+}
+.fin-curadoria .fin-conferido-toggle.on small { display: none; }
+
+.fin-curadoria .fin-conferido-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: oklch(0.86 0.14 145);
+  color: oklch(0.22 0.06 145);
+  margin-left: 4px;
+  vertical-align: middle;
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Frescor — pill 6 estados (paid · overdue · today · warning · soon · fresh)
+ * ───────────────────────────────────────────────────────────── */
+
+.fin-curadoria .fin-frescor {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 7px;
+  border-radius: 99px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  line-height: 1;
+  vertical-align: middle;
+}
+.fin-curadoria .fin-frescor-ic { font-size: 9px; line-height: 1; }
+.fin-curadoria .fin-frescor-fresh   { background: oklch(0.94 0.04 145); color: oklch(0.42 0.13 145); }
+.fin-curadoria .fin-frescor-soon    { background: oklch(0.95 0.03 145); color: oklch(0.45 0.10 145); }
+.fin-curadoria .fin-frescor-warning { background: oklch(0.96 0.06 70);  color: oklch(0.42 0.13 60);  }
+.fin-curadoria .fin-frescor-today   { background: oklch(0.96 0.07 60);  color: oklch(0.42 0.18 60);  }
+.fin-curadoria .fin-frescor-overdue { background: oklch(0.95 0.04 25);  color: oklch(0.50 0.18 25);  }
+.fin-curadoria .fin-frescor-paid    { background: oklch(0.94 0.005 240); color: var(--fin-text-mute); }
+
+/* ─────────────────────────────────────────────────────────────
+ * Audit trail — lista de eventos derivados
+ * ───────────────────────────────────────────────────────────── */
+
+.fin-curadoria .fin-audit { font-size: 12px; }
+.fin-curadoria .fin-audit-h {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+.fin-curadoria .fin-audit-h h4 { margin: 0; font-size: 13px; font-weight: 700; }
+.fin-curadoria .fin-audit-h small { font-size: 11px; color: var(--fin-text-mute); }
+
+.fin-curadoria .fin-audit-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  position: relative;
+}
+.fin-curadoria .fin-audit-row {
+  display: flex;
+  gap: 8px;
+  padding: 8px 0;
+  border-bottom: 1px dashed var(--fin-line);
+  position: relative;
+}
+.fin-curadoria .fin-audit-row:last-child { border-bottom: none; }
+
+.fin-curadoria .fin-audit-ic {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border-radius: 50%;
+  font-size: 11px;
+  font-weight: 700;
+  flex-shrink: 0;
+  background: var(--fin-bg-soft);
+}
+.fin-curadoria .fin-audit-create     .fin-audit-ic { background: oklch(0.94 0.06 145); color: oklch(0.32 0.13 145); }
+.fin-curadoria .fin-audit-categorize .fin-audit-ic { background: oklch(0.95 0.04 240); color: oklch(0.36 0.13 240); }
+.fin-curadoria .fin-audit-edit       .fin-audit-ic { background: oklch(0.96 0.05 70);  color: oklch(0.42 0.13 60);  }
+.fin-curadoria .fin-audit-concil     .fin-audit-ic { background: oklch(0.94 0.04 145); color: oklch(0.32 0.13 145); }
+.fin-curadoria .fin-audit-alert      .fin-audit-ic { background: oklch(0.95 0.04 25);  color: oklch(0.50 0.18 25);  }
+
+.fin-curadoria .fin-audit-body { flex: 1; min-width: 0; }
+.fin-curadoria .fin-audit-body header {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 11.5px;
+}
+.fin-curadoria .fin-audit-body header b { font-weight: 600; color: var(--fin-text); }
+.fin-curadoria .fin-audit-action { color: var(--fin-text-mute); font-size: 11px; }
+.fin-curadoria .fin-audit-body time { margin-left: auto; color: var(--fin-text-mute); font-size: 10.5px; }
+.fin-curadoria .fin-audit-body p {
+  margin: 2px 0 0;
+  font-size: 12px;
+  color: var(--fin-text);
+  word-wrap: break-word;
+}
+
+.fin-curadoria .fin-audit-diff {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+  font-size: 11px;
+  font-family: ui-monospace, monospace;
+  background: var(--fin-bg-soft);
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+.fin-curadoria .fin-audit-diff .diff-arr { color: var(--fin-text-mute); }
+.fin-curadoria .fin-audit-diff .diff-from { color: var(--fin-text-mute); text-decoration: line-through; }
+.fin-curadoria .fin-audit-diff .diff-to { font-weight: 600; }
+.fin-curadoria .fin-audit-diff .diff-pct.pos { color: oklch(0.45 0.18 145); }
+.fin-curadoria .fin-audit-diff .diff-pct.neg { color: oklch(0.50 0.18 25); }
+
+/* ─────────────────────────────────────────────────────────────
+ * Comments — thread + new + badge silent
+ * ───────────────────────────────────────────────────────────── */
+
+.fin-curadoria .fin-comments { font-size: 12px; }
+.fin-curadoria .fin-comments-h {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+.fin-curadoria .fin-comments-h h4 { margin: 0; font-size: 13px; font-weight: 700; }
+.fin-curadoria .fin-comments-h small { font-size: 11px; color: var(--fin-text-mute); }
+
+.fin-curadoria .fin-comments-list {
+  list-style: none;
+  margin: 0 0 12px;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fin-curadoria .fin-comment {
+  display: flex;
+  gap: 8px;
+  padding: 8px;
+  background: var(--fin-bg-soft);
+  border-radius: 6px;
+}
+.fin-curadoria .fin-comment-av {
+  display: grid;
+  place-items: center;
+  width: 24px;
+  height: 24px;
+  border-radius: 50%;
+  background: oklch(0.95 0.04 240);
+  color: oklch(0.36 0.13 240);
+  font-size: 11px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.fin-curadoria .fin-comment-body { flex: 1; min-width: 0; }
+.fin-curadoria .fin-comment-body header {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  font-size: 11px;
+}
+.fin-curadoria .fin-comment-body header b { font-weight: 600; color: var(--fin-text); }
+.fin-curadoria .fin-comment-body time { color: var(--fin-text-mute); font-size: 10.5px; }
+.fin-curadoria .fin-comment-x {
+  margin-left: auto;
+  background: transparent;
+  border: 0;
+  color: var(--fin-text-mute);
+  cursor: pointer;
+  padding: 0 4px;
+  font-size: 14px;
+  line-height: 1;
+}
+.fin-curadoria .fin-comment-x:hover { color: oklch(0.50 0.18 25); }
+.fin-curadoria .fin-comment-body p {
+  margin: 2px 0 0;
+  font-size: 12px;
+  color: var(--fin-text);
+  word-wrap: break-word;
+}
+
+.fin-curadoria .fin-comment-new {
+  display: flex;
+  gap: 6px;
+  align-items: flex-end;
+}
+.fin-curadoria .fin-comment-new textarea {
+  flex: 1;
+  resize: vertical;
+  font-family: inherit;
+  font-size: 12px;
+  padding: 6px 8px;
+  border: 1px solid var(--fin-line);
+  border-radius: 4px;
+  background: white;
+  color: var(--fin-text);
+}
+.fin-curadoria .fin-comment-new textarea:focus {
+  outline: none;
+  border-color: oklch(0.55 0.13 240);
+}
+.fin-curadoria .fin-comment-new button {
+  padding: 6px 14px;
+  border: 0;
+  border-radius: 4px;
+  background: oklch(0.36 0.13 240);
+  color: white;
+  font-family: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.fin-curadoria .fin-comment-new button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.fin-curadoria .fin-comment-new button:not(:disabled):hover {
+  background: oklch(0.30 0.13 240);
+}
+
+.fin-curadoria .fin-comments-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  border-radius: 99px;
+  background: oklch(0.95 0.04 240);
+  color: oklch(0.36 0.13 240);
+  font-size: 10px;
+  font-weight: 600;
+  vertical-align: middle;
+}

--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -29,6 +29,9 @@
 /* Sells/Subscriptions Cowork — lista assinaturas recorrentes (extensões mínimas além da família Index) */
 @import "./sells-cowork-subscriptions.css";
 
+/* Financeiro/Unificado Cowork Onda 5 R1 Curadoria — escopado em .fin-curadoria (Conferido + Comments + Audit + Frescor) */
+@import "./fin-curadoria.css";
+
 @theme {
   --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 

--- a/resources/js/Pages/Financeiro/Unificado/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Unificado/Index.charter.md
@@ -3,13 +3,15 @@ page: /financeiro/unificado
 component: resources/js/Pages/Financeiro/Unificado/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-09
+last_validated: 2026-05-18
 parent_module: Financeiro
 parent_capterra: memory/requisitos/Financeiro/CAPTERRA-FICHA.md
 related_adrs: [arq/0005, ui/0002, ui/0114, 0093, 0094]
 related_us: [US-FIN-013, US-FIN-020]
 related_prototype: prototipo Cowork "Visao Unificada" (Financeiro.html), aprovado por Wagner 2026-05-09
+canon_method: Cowork KB-9.75 v2 — Onda 5 R1 Curadoria (PR #1064/#1066 + Onda 5 atual)
 tier: A
+charter_version: 2
 ---
 
 # Page Charter — /financeiro/unificado
@@ -27,6 +29,11 @@ Tela única de **fluxo financeiro do mês** que mistura **Pagar / Pagas / Recebe
 
 ## Goals — Features (faz)
 
+- **Onda 5 KB-9.75 R1 Curadoria** (2026-05-18):
+  - **Conferido toggle** por Eliana (localStorage `oimpresso.financeiro.conferido`) — pill grande no drawer + badge ✓ silent na linha
+  - **Comentários inline** thread Eliana ↔ Wagner ↔ Bruna (localStorage `oimpresso.financeiro.comments`) — textarea no drawer + badge 💬N silent na linha
+  - **Audit trail determinístico** (5 kinds: create / categorize / edit / concil / alert) derivado do row sem persistência — exibido no drawer
+  - **Frescor pill** 6 estados (paid · overdue · today · warning · soon · fresh) derivado de `vencimento`+`liquidacao` — compact ao lado do StatusPill na linha e full no drawer
 - 5 KPI cards: Saldo previsto · Recebido · A receber · Pago · A pagar (com qtd de baixas/títulos)
 - KPI cards **clicáveis** — cada um filtra a tabela pra tab correspondente (drill-down ADR ui/0002)
 - Filter chips: Todas, Aberto, Receber, Pagar, Recebidas, Pagas, Atraso

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -21,6 +21,10 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/Components/ui/sh
 import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/Components/ui/command';
 import PageHeader from '@/Components/shared/PageHeader';
 import KpiCard from '@/Components/shared/KpiCard';
+import { FinPillFrescor } from './_components/FinPillFrescor';
+import { FinConferidoToggle, FinConferidoBadge, useFinConferido, type UseFinConferidoApi } from './_components/FinConferidoToggle';
+import { FinCommentsThread, FinCommentsBadge, useFinComments, type UseFinCommentsApi } from './_components/FinCommentsThread';
+import { FinAuditTrail } from './_components/FinAuditTrail';
 
 // ---------- Tipos ----------
 
@@ -171,22 +175,36 @@ function KpiBar({ kpis, onTabClick }: { kpis: Kpi; onTabClick: (tab: TabId) => v
   );
 }
 
-function LinhaTabela({ row, dens, selected, onSelect, onBaixar }: {
+function LinhaTabela({ row, dens, selected, onSelect, onBaixar, conferido, comments }: {
   row: Lancamento; dens: typeof DENSITY[keyof typeof DENSITY]; selected: boolean;
   onSelect: () => void; onBaixar: () => void;
+  conferido: UseFinConferidoApi; comments: UseFinCommentsApi;
 }) {
   const isIn = row.kind === 'receivable';
   const settled = row.status === 'recebido' || row.status === 'pago';
+  // FinPillFrescor consome `due`/`paid_at` — adapta de `vencimento`/`liquidacao`.
+  const frescorRow = {
+    due: row.vencimento,
+    paid_at: settled ? row.liquidacao : null,
+    vencimento: row.vencimento,
+  };
   return (
     <tr
       className={`${dens.row} ${dens.text} border-b border-stone-100 hover:bg-stone-50/60 cursor-pointer ${selected ? 'bg-amber-50/40' : ''}`}
       onClick={onSelect}
     >
       <td className="pl-4 pr-2"><span className={`text-[14px] ${isIn ? 'text-emerald-600' : 'text-stone-500'}`}>{isIn ? '↑' : '↓'}</span></td>
-      <td className="px-2"><div className="font-medium text-stone-900 truncate max-w-[260px]">{row.descricao}</div>{row.nfe_numero && <div className="text-[11px] text-stone-500">NF-e {row.nfe_numero}</div>}</td>
+      <td className="px-2">
+        <div className="font-medium text-stone-900 truncate max-w-[260px] flex items-center gap-1.5">
+          <span className="truncate">{row.descricao}</span>
+          <FinConferidoBadge rowId={row.id} conferido={conferido} />
+          <FinCommentsBadge rowId={row.id} comments={comments} />
+        </div>
+        {row.nfe_numero && <div className="text-[11px] text-stone-500">NF-e {row.nfe_numero}</div>}
+      </td>
       <td className="px-2 text-stone-700 truncate max-w-[160px]">{row.contraparte}</td>
       <td className="px-2 text-stone-500 truncate max-w-[140px]">{row.categoria}</td>
-      <td className="px-2"><StatusPill s={row.status} /></td>
+      <td className="px-2"><div className="flex items-center gap-1.5"><StatusPill s={row.status} /><FinPillFrescor row={frescorRow} compact /></div></td>
       <td className={`px-2 text-right font-medium tabular-nums whitespace-nowrap ${isIn ? 'text-emerald-700' : 'text-stone-900'}`}>
         <span className="text-stone-400 mr-0.5">{isIn ? '+' : '−'}</span>{brl(row.valor).replace('R$', '').trim()}
       </td>
@@ -210,6 +228,10 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
   const [selectedId, setSelectedId] = useState<number | null>(null);
   const [paletteOpen, setPaletteOpen] = useState(false);
   const dens = DENSITY[filters.densidade ?? 'comfortable'];
+
+  // Cowork KB-9.75 Onda 5 R1 Curadoria — hooks localStorage compartilhados pela página.
+  const conferido = useFinConferido();
+  const comments = useFinComments();
 
   const aplicar = useCallback((patch: Partial<Filters>) => {
     router.get('/financeiro/unificado', { ...filters, ...patch }, {
@@ -250,7 +272,7 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
   const selected = lancamentos.find(l => l.id === selectedId) ?? null;
 
   return (
-    <>
+    <div className="fin-curadoria">
       <PageHeader
         icon="coins"
         title="Financeiro · Visão unificada"
@@ -346,6 +368,8 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
                         selected={selectedId === r.id}
                         onSelect={() => setSelectedId(r.id)}
                         onBaixar={() => onBaixar(r.id)}
+                        conferido={conferido}
+                        comments={comments}
                       />
                     ))}
                   </React.Fragment>
@@ -374,15 +398,21 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
 
       {/* Drawer detalhe */}
       <Sheet open={!!selected} onOpenChange={(o) => !o && setSelectedId(null)}>
-        <SheetContent side="right" className="w-[420px] sm:max-w-[420px]">
+        <SheetContent side="right" className="w-[460px] sm:max-w-[460px]">
           {selected && (
             <>
               <SheetHeader>
                 <SheetTitle className="text-[16px]">{selected.descricao}</SheetTitle>
               </SheetHeader>
               <div className="mt-4 space-y-4 text-[13px]">
-                <div className="flex items-center gap-2"><StatusPill s={selected.status} />
-                  <span className="ml-auto font-semibold tabular-nums text-[16px]">{brl(selected.valor)}</span></div>
+                <div className="flex items-center gap-2">
+                  <StatusPill s={selected.status} />
+                  <FinPillFrescor row={{ due: selected.vencimento, paid_at: (selected.status === 'recebido' || selected.status === 'pago') ? selected.liquidacao : null, vencimento: selected.vencimento }} />
+                  <span className="ml-auto font-semibold tabular-nums text-[16px]">{brl(selected.valor)}</span>
+                </div>
+
+                <FinConferidoToggle rowId={selected.id} conferido={conferido} />
+
                 <dl className="grid grid-cols-2 gap-y-2 text-[12.5px]">
                   <dt className="text-stone-500">Contraparte</dt><dd>{selected.contraparte}{selected.contraparte_doc && <span className="block text-stone-500">{selected.contraparte_doc}</span>}</dd>
                   <dt className="text-stone-500">Categoria</dt><dd>{selected.categoria}</dd>
@@ -395,6 +425,27 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
                 {selected.observacao && (
                   <div className="rounded-md border border-stone-200 bg-stone-50 p-3 text-[12.5px] text-stone-700">{selected.observacao}</div>
                 )}
+
+                <div className="border-t border-stone-200 pt-4">
+                  <FinAuditTrail row={{
+                    id: selected.id,
+                    descricao: selected.descricao,
+                    contraparte: selected.contraparte,
+                    categoria: selected.categoria,
+                    conta_bancaria: selected.conta_bancaria,
+                    canal: selected.canal ?? undefined,
+                    valor: selected.valor,
+                    status: selected.status,
+                    kind: selected.kind,
+                    paid_at: (selected.status === 'recebido' || selected.status === 'pago') ? selected.liquidacao : null,
+                    due: selected.vencimento,
+                  }} />
+                </div>
+
+                <div className="border-t border-stone-200 pt-4">
+                  <FinCommentsThread rowId={selected.id} comments={comments} />
+                </div>
+
                 <div className="flex gap-2 pt-2 border-t border-stone-200">
                   {(selected.status !== 'recebido' && selected.status !== 'pago') && (
                     <Button onClick={() => onBaixar(selected.id)}>
@@ -439,7 +490,7 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
         <span><kbd className="px-1 rounded border border-stone-200 bg-stone-50">␣</kbd> selecionar</span>
         <span className="ml-auto">Densidade: <strong>{filters.densidade}</strong></span>
       </div>
-    </>
+    </div>
   );
 }
 

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinAuditTrail.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinAuditTrail.tsx
@@ -1,0 +1,180 @@
+// FinAuditTrail — Cowork KB-9.75 Financeiro Onda 5 R1 Curadoria
+// (histórico determinístico de eventos derivado do row).
+//
+// Refs:
+//  - prototipo-ui/financeiro-curation.jsx — finAuditTrail + FinAuditTrail
+//  - SaleAuditTrail.tsx pattern (canon Sells Onda 3)
+//
+// Determinístico: SEM persistência. Deriva eventos do row (created/categorize/edit/concil/alert)
+// usando seed simples (charCode do último char do id) pra estabilidade visual.
+// Onda futura plugará em backend `audit_log` ou Spatie Activitylog real.
+
+import { useMemo } from 'react';
+
+export type FinAuditKind = 'create' | 'categorize' | 'edit' | 'concil' | 'alert';
+
+export interface FinAuditEntry {
+  when: string;
+  who: string;
+  kind: FinAuditKind;
+  desc: string;
+  diff?: { from: number; to: number; pct: number };
+}
+
+interface LancamentoLike {
+  id: string | number;
+  descricao?: string;
+  contraparte?: string;
+  categoria?: string;
+  conta_bancaria?: string;
+  canal?: string;
+  valor?: number;
+  status?: string;
+  kind?: 'receivable' | 'payable';
+  paid_at?: string | Date | null;
+  due?: string | Date | null;
+  vencimento?: string | Date | null;
+}
+
+function asDate(v: string | Date | null | undefined): Date | null {
+  if (!v) return null;
+  if (v instanceof Date) return v;
+  const d = new Date(v);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function fmtDate(d: Date | null): string {
+  if (!d) return '—';
+  return d.toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' });
+}
+
+function brl(n: number): string {
+  return n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+export function finAuditTrail(row: LancamentoLike): FinAuditEntry[] {
+  const id = String(row.id);
+  const seed = id.charCodeAt(id.length - 1) % 4;
+  const entries: FinAuditEntry[] = [];
+
+  const due = asDate(row.due ?? row.vencimento ?? null);
+  const paid = asDate(row.paid_at ?? null);
+  const isReceivable = row.kind === 'receivable';
+  const valor = row.valor || 0;
+  const desc = (row.descricao || '').slice(0, 48);
+  const descTrunc = (row.descricao || '').length > 48 ? '…' : '';
+
+  // 1) Criação — sempre
+  entries.push({
+    when: `${fmtDate(due)} ${isReceivable ? 'emitido' : 'recebido'}`,
+    who: isReceivable ? (row.contraparte || 'Vendas') : (row.contraparte || 'Fornecedor · NF'),
+    kind: 'create',
+    desc: `Lançamento #${id} · ${desc}${descTrunc}`,
+  });
+
+  // 2) Categorização — sempre se houver categoria
+  if (row.categoria) {
+    entries.push({
+      when: `${fmtDate(due)} ${('0' + (((due?.getHours() ?? 0) + 1) % 24)).slice(-2)}:${('0' + (due?.getMinutes() ?? 0)).slice(-2)}`,
+      who: 'Eliana Financeiro',
+      kind: 'categorize',
+      desc: `Classificado em "${row.categoria}"`,
+    });
+  }
+
+  // 3) Edição de valor — só se seed >= 2 (determinístico ~50% das linhas)
+  if (seed >= 2 && valor > 0) {
+    const oldAmount = Math.round(valor * 0.94 * 100) / 100;
+    const diff = valor - oldAmount;
+    entries.push({
+      when: `${fmtDate(due)} ajuste`,
+      who: 'Eliana Financeiro',
+      kind: 'edit',
+      desc: `Valor revisado · ${brl(oldAmount)} → ${brl(valor)}`,
+      diff: { from: oldAmount, to: valor, pct: (diff / oldAmount) * 100 },
+    });
+  }
+
+  // 4) Conciliação — só se pago
+  if (paid) {
+    entries.push({
+      when: fmtDate(paid),
+      who: 'Banco (Inter)',
+      kind: 'concil',
+      desc: `Conciliado com extrato · ${row.canal || '—'}`,
+    });
+  }
+
+  // 5) Alerta atrasado
+  if (row.status === 'atrasado' || row.status === 'overdue') {
+    entries.push({
+      when: 'agora',
+      who: 'sistema',
+      kind: 'alert',
+      desc: '⚠ Vencimento ultrapassou — em atraso',
+    });
+  }
+
+  return entries;
+}
+
+const KIND_LABEL: Record<FinAuditKind, string> = {
+  create: 'criou',
+  categorize: 'categorizou',
+  edit: 'editou',
+  concil: 'conciliou',
+  alert: 'alerta',
+};
+
+const KIND_IC: Record<FinAuditKind, string> = {
+  create: '+',
+  categorize: '▦',
+  edit: '✎',
+  concil: '≣',
+  alert: '⚠',
+};
+
+interface FinAuditTrailProps {
+  row: LancamentoLike;
+}
+
+export function FinAuditTrail({ row }: FinAuditTrailProps) {
+  const entries = useMemo(() => finAuditTrail(row), [row.id, row.paid_at, row.status, row.valor, row.categoria]);
+
+  return (
+    <div className="fin-audit">
+      <div className="fin-audit-h">
+        <h4>Histórico</h4>
+        <small>{entries.length} eventos · auditoria contábil</small>
+      </div>
+      <ul className="fin-audit-list">
+        {entries.map((e, i) => (
+          <li key={i} className={`fin-audit-row fin-audit-${e.kind}`}>
+            <span className="fin-audit-ic">{KIND_IC[e.kind] || '·'}</span>
+            <div className="fin-audit-body">
+              <header>
+                <b>{e.who}</b>
+                <span className="fin-audit-action">{KIND_LABEL[e.kind] || ''}</span>
+                <time>{e.when}</time>
+              </header>
+              <p>{e.desc}</p>
+              {e.diff && (
+                <div className="fin-audit-diff">
+                  <span className="diff-from">{brl(e.diff.from)}</span>
+                  <span className="diff-arr">→</span>
+                  <span className="diff-to">{brl(e.diff.to)}</span>
+                  <span className={`diff-pct ${e.diff.pct < 0 ? 'neg' : 'pos'}`}>
+                    {e.diff.pct > 0 ? '+' : ''}
+                    {e.diff.pct.toFixed(1)}%
+                  </span>
+                </div>
+              )}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+export default FinAuditTrail;

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinCommentsThread.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinCommentsThread.tsx
@@ -1,0 +1,180 @@
+// FinCommentsThread — Cowork KB-9.75 Financeiro Onda 5 R1 Curadoria
+// (thread de comentários por lançamento — Eliana ↔ Wagner ↔ Bruna).
+//
+// Refs:
+//  - prototipo-ui/financeiro-curation.jsx — useFinComments + FinCommentsThread
+//  - SaleItemComments.tsx pattern (canon localStorage Sells Onda 3)
+//
+// Storage: localStorage[oimpresso.financeiro.comments] = { rowId: [{author, text, when}] }
+// Onda futura plugará em backend `fin_comments` table com sync MCP.
+
+import { useCallback, useEffect, useState, type KeyboardEvent } from 'react';
+
+const LS_KEY = 'oimpresso.financeiro.comments';
+
+export interface FinComment {
+  author: string;
+  text: string;
+  when: string;
+}
+
+type CommentMap = Record<string, FinComment[]>;
+
+function loadComments(): CommentMap {
+  if (typeof window === 'undefined') return {};
+  try {
+    return JSON.parse(window.localStorage.getItem(LS_KEY) || '{}');
+  } catch (_) {
+    return {};
+  }
+}
+
+function saveComments(m: CommentMap): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(LS_KEY, JSON.stringify(m));
+  } catch (_) {
+    /* ls indisponível */
+  }
+}
+
+function ptBrStamp(d: Date = new Date()): string {
+  return d.toLocaleString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+export interface UseFinCommentsApi {
+  get: (rowId: string | number) => FinComment[];
+  add: (rowId: string | number, text: string, author?: string) => void;
+  remove: (rowId: string | number, idx: number) => void;
+  countFor: (rowId: string | number) => number;
+  hasAny: () => boolean;
+}
+
+export function useFinComments(): UseFinCommentsApi {
+  const [m, setM] = useState<CommentMap>(loadComments);
+
+  useEffect(() => {
+    saveComments(m);
+  }, [m]);
+
+  const get = useCallback((rowId: string | number) => m[String(rowId)] || [], [m]);
+
+  const add = useCallback((rowId: string | number, text: string, author = 'Eliana') => {
+    const t = text.trim();
+    if (!t) return;
+    setM((prev) => ({
+      ...prev,
+      [String(rowId)]: [...(prev[String(rowId)] || []), { author, text: t, when: ptBrStamp() }],
+    }));
+  }, []);
+
+  const remove = useCallback((rowId: string | number, idx: number) => {
+    setM((prev) => {
+      const key = String(rowId);
+      const next = { ...prev };
+      next[key] = (next[key] || []).filter((_, i) => i !== idx);
+      if (next[key].length === 0) delete next[key];
+      return next;
+    });
+  }, []);
+
+  const countFor = useCallback((rowId: string | number) => (m[String(rowId)] || []).length, [m]);
+  const hasAny = useCallback(() => Object.keys(m).length > 0, [m]);
+
+  return { get, add, remove, countFor, hasAny };
+}
+
+interface FinCommentsThreadProps {
+  rowId: string | number;
+  comments: UseFinCommentsApi;
+  author?: string;
+}
+
+export function FinCommentsThread({ rowId, comments, author = 'Eliana' }: FinCommentsThreadProps) {
+  const [text, setText] = useState('');
+  const list = comments.get(rowId);
+
+  const submit = () => {
+    if (!text.trim()) return;
+    comments.add(rowId, text, author);
+    setText('');
+  };
+
+  const onKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
+      e.preventDefault();
+      submit();
+    }
+  };
+
+  return (
+    <div className="fin-comments">
+      <div className="fin-comments-h">
+        <h4>Comentários</h4>
+        <small>
+          {list.length} · visíveis pra Eliana · Wagner · Bruna
+        </small>
+      </div>
+      {list.length > 0 && (
+        <ul className="fin-comments-list">
+          {list.map((c, i) => (
+            <li key={i} className="fin-comment">
+              <span className="fin-comment-av">{(c.author || '?').charAt(0).toUpperCase()}</span>
+              <div className="fin-comment-body">
+                <header>
+                  <b>{c.author}</b>
+                  <time>{c.when}</time>
+                  <button
+                    type="button"
+                    className="fin-comment-x"
+                    onClick={() => comments.remove(rowId, i)}
+                    title="Remover"
+                    aria-label="Remover comentário"
+                  >
+                    ×
+                  </button>
+                </header>
+                <p>{c.text}</p>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+      <div className="fin-comment-new">
+        <textarea
+          value={text}
+          rows={2}
+          onChange={(e) => setText(e.target.value)}
+          onKeyDown={onKeyDown}
+          placeholder='Ex: "Conferi com Bruna, valor correto" · "Anexar comprovante" · ⌘↵ envia'
+        />
+        <button type="button" onClick={submit} disabled={!text.trim()}>
+          Comentar
+        </button>
+      </div>
+    </div>
+  );
+}
+
+interface FinCommentsBadgeProps {
+  rowId: string | number;
+  comments: UseFinCommentsApi;
+}
+
+/** Indicador silent pra header da linha — mostra "💬 N" só quando há comentário. */
+export function FinCommentsBadge({ rowId, comments }: FinCommentsBadgeProps) {
+  const n = comments.countFor(rowId);
+  if (n === 0) return null;
+  return (
+    <span className="fin-comments-badge" title={`${n} comentário${n > 1 ? 's' : ''}`}>
+      💬 {n}
+    </span>
+  );
+}
+
+export default FinCommentsThread;

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinConferidoToggle.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinConferidoToggle.tsx
@@ -1,0 +1,105 @@
+// FinConferidoToggle — Cowork KB-9.75 Financeiro Onda 5 R1 Curadoria
+// (toggle "Conferido" persistido em localStorage — Eliana valida cada linha).
+//
+// Refs:
+//  - prototipo-ui/financeiro-curation.jsx — useFinConferido + FinConferidoToggle
+//  - SaleItemComments pattern (canon localStorage Sells)
+//
+// Storage: localStorage[oimpresso.financeiro.conferido] = ["R-2641", "P-3120", ...]
+// Multi-user: scope por device/user (mesma persona Eliana). Onda futura plugará em
+// backend `fin_review_log` table com sync MCP.
+
+import { useCallback, useEffect, useState } from 'react';
+import { CircleCheck } from 'lucide-react';
+
+const LS_KEY = 'oimpresso.financeiro.conferido';
+
+function loadConferidoSet(): Set<string> {
+  if (typeof window === 'undefined') return new Set();
+  try {
+    const raw = window.localStorage.getItem(LS_KEY);
+    if (!raw) return new Set();
+    const arr = JSON.parse(raw);
+    return new Set(Array.isArray(arr) ? arr : []);
+  } catch (_) {
+    return new Set();
+  }
+}
+
+function saveConferidoSet(s: Set<string>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(LS_KEY, JSON.stringify([...s]));
+  } catch (_) {
+    /* ls indisponível */
+  }
+}
+
+export interface UseFinConferidoApi {
+  has: (id: string | number) => boolean;
+  toggle: (id: string | number) => void;
+  count: number;
+}
+
+export function useFinConferido(): UseFinConferidoApi {
+  const [set, setSet] = useState<Set<string>>(loadConferidoSet);
+
+  useEffect(() => {
+    saveConferidoSet(set);
+  }, [set]);
+
+  const has = useCallback((id: string | number) => set.has(String(id)), [set]);
+
+  const toggle = useCallback((id: string | number) => {
+    setSet((prev) => {
+      const next = new Set(prev);
+      const key = String(id);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  return { has, toggle, count: set.size };
+}
+
+interface FinConferidoToggleProps {
+  rowId: string | number;
+  conferido: UseFinConferidoApi;
+}
+
+export function FinConferidoToggle({ rowId, conferido }: FinConferidoToggleProps) {
+  const isOn = conferido.has(rowId);
+  return (
+    <button
+      type="button"
+      className={`fin-conferido-toggle ${isOn ? 'on' : ''}`}
+      onClick={() => conferido.toggle(rowId)}
+      title={isOn ? 'Desmarcar conferido (Eliana já bateu olho)' : 'Marcar como conferido'}
+      aria-pressed={isOn}
+    >
+      <span className="fin-conf-check">
+        {isOn ? <CircleCheck size={14} strokeWidth={2.5} /> : null}
+      </span>
+      <span className="fin-conf-lbl">{isOn ? 'Conferido' : 'Conferir'}</span>
+      {!isOn && <small>Eliana valida</small>}
+    </button>
+  );
+}
+
+interface FinConferidoBadgeProps {
+  rowId: string | number;
+  conferido: UseFinConferidoApi;
+}
+
+/** Badge silencioso pra header da linha (mostra ✓ só quando conferido). */
+export function FinConferidoBadge({ rowId, conferido }: FinConferidoBadgeProps) {
+  if (!conferido.has(rowId)) return null;
+  return (
+    <span className="fin-conferido-badge" title="Conferido por Eliana">
+      <CircleCheck size={12} strokeWidth={2.5} />
+    </span>
+  );
+}
+
+export default FinConferidoToggle;

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinPillFrescor.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinPillFrescor.tsx
@@ -1,0 +1,86 @@
+// FinPillFrescor — Cowork KB-9.75 Financeiro Onda 5 R1 Curadoria
+// (pill de SLA derivado de due/paid_at — 5 estados).
+//
+// Refs:
+//  - prototipo-ui/financeiro-curation.jsx — finFrescorInfo + FinPillFrescor (canonical)
+//  - resources/css/fin-curadoria.css — .fin-frescor tokens
+//  - SaleSheet pattern (compact pill ao lado do total)
+//
+// Estados:
+//  - paid    "pago Xd atrás" / "pago hoje"  ✓
+//  - overdue "Xd em atraso"                  ✕
+//  - today   "vence hoje"                    ●
+//  - warning "Xd"  (≤3 dias)                 ▲
+//  - soon    "Xd"  (≤7 dias)                 ○
+//  - fresh   "Xd"  (>7 dias)                 ○
+//
+// Determinístico (não persiste, deriva de row). Sem backend.
+
+import { useMemo } from 'react';
+
+export type FinFrescorKind = 'paid' | 'overdue' | 'today' | 'warning' | 'soon' | 'fresh';
+
+export interface FinFrescorInfo {
+  kind: FinFrescorKind;
+  label: string;
+  ic: string;
+}
+
+interface LancamentoLike {
+  paid_at?: string | Date | null;
+  due?: string | Date | null;
+  vencimento?: string | Date | null;
+  vencimento_label?: string | null;
+}
+
+function asDate(v: string | Date | null | undefined): Date | null {
+  if (!v) return null;
+  if (v instanceof Date) return v;
+  const d = new Date(v);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function startOfDay(d: Date): Date {
+  return new Date(d.getFullYear(), d.getMonth(), d.getDate());
+}
+
+export function finFrescorInfo(row: LancamentoLike, today: Date = new Date()): FinFrescorInfo {
+  const t0 = startOfDay(today);
+  const paid = asDate(row.paid_at ?? null);
+  const due = asDate(row.due ?? row.vencimento ?? null);
+
+  if (paid) {
+    const days = Math.round((t0.getTime() - startOfDay(paid).getTime()) / 86_400_000);
+    if (days <= 0) return { kind: 'paid', label: 'pago hoje', ic: '✓' };
+    return { kind: 'paid', label: `pago ${days}d atrás`, ic: '✓' };
+  }
+
+  if (!due) {
+    return { kind: 'fresh', label: '—', ic: '○' };
+  }
+
+  const daysUntil = Math.round((startOfDay(due).getTime() - t0.getTime()) / 86_400_000);
+  if (daysUntil < 0) return { kind: 'overdue', label: `${-daysUntil}d em atraso`, ic: '✕' };
+  if (daysUntil === 0) return { kind: 'today', label: 'vence hoje', ic: '●' };
+  if (daysUntil <= 3) return { kind: 'warning', label: `${daysUntil}d`, ic: '▲' };
+  if (daysUntil <= 7) return { kind: 'soon', label: `${daysUntil}d`, ic: '○' };
+  return { kind: 'fresh', label: `${daysUntil}d`, ic: '○' };
+}
+
+interface FinPillFrescorProps {
+  row: LancamentoLike;
+  compact?: boolean;
+  today?: Date;
+}
+
+export function FinPillFrescor({ row, compact = false, today }: FinPillFrescorProps) {
+  const info = useMemo(() => finFrescorInfo(row, today), [row.paid_at, row.due, row.vencimento, today]);
+  return (
+    <span className={`fin-frescor fin-frescor-${info.kind}`} title={info.label} data-kind={info.kind}>
+      <span className="fin-frescor-ic">{info.ic}</span>
+      {!compact && <span className="fin-frescor-lbl">{info.label}</span>}
+    </span>
+  );
+}
+
+export default FinPillFrescor;


### PR DESCRIPTION
## Resumo

**Onda 5 — Financeiro KB-9.75 R1 Curadoria** (primeira de 3 ondas Financeiro pendentes).

### Auditoria revelou ondas Vendas já estavam done

Investigando estado real de `resources/js/Pages/Sells/_components/`:

| Onda original | Componente | LOC | Mount em SaleSheet |
|---|---|---|---|
| 2 — IA copiloto | SaleAiPanel.tsx | 273 | ✅ |
| 3 — Curadoria | SaleItemComments.tsx | 217 | ✅ |
| 3 — Curadoria | SaleAuditTrail.tsx | 278 | ✅ |
| 4 — Distribuição | SaleTranscriptPDF.tsx | 272 | ✅ |
| 4 — Distribuição | SalePresentationMode.tsx | 155 | ✅ |
| 4 — Distribuição | SaleMessagePreview.tsx | 167 | ✅ |
| 7 — Cross-link | SaleLinkifier.tsx | 115 | ✅ |

Roadmap original de 7 ondas vira **3 ondas restantes** (Financeiro R1/R2/R3 + cross-link integrado em R3).

### O que esta Onda 5 entrega

**4 components novos** em `resources/js/Pages/Financeiro/Unificado/_components/`:

- **FinPillFrescor.tsx** (90 LOC) — pill 6 estados derivado de `vencimento`+`liquidacao`:
  - `paid` ✓ pago Xd atrás
  - `overdue` ✕ Xd em atraso
  - `today` ● vence hoje
  - `warning` ▲ ≤3d
  - `soon` ○ ≤7d
  - `fresh` ○ >7d
- **FinConferidoToggle.tsx** (100 LOC) — toggle "Conferido" + badge silent na linha + hook `useFinConferido`. Storage `localStorage[oimpresso.financeiro.conferido]`.
- **FinCommentsThread.tsx** (170 LOC) — thread Eliana↔Wagner↔Bruna + badge `💬N` silent + hook `useFinComments`. Storage `localStorage[oimpresso.financeiro.comments]`.
- **FinAuditTrail.tsx** (160 LOC) — 5 kinds (create / categorize / edit / concil / alert) derivado determinístico do row.

**CSS escopado** em `resources/css/fin-curadoria.css` (260 LOC) — tokens portados de `prototipo-ui/styles.css` Refino #1 (oklch palette canônica), escopado em `.fin-curadoria` pra não vazar. Importado por `resources/css/inertia.css` após os 8 `sells-cowork-*.css`.

**Wire-up Index.tsx:**
- `<div className="fin-curadoria">` raiz
- Hooks instanciados no componente pai
- `LinhaTabela` extendida com badges silent + frescor compact
- Drawer `Sheet` enriquecido com Conferido toggle + Audit + Comments

**Charter v2** — `last_validated: 2026-05-18`, `canon_method: Cowork KB-9.75 v2 — Onda 5 R1 Curadoria`, Goals atualizado com 4 features explícitas.

### Backend: ZERO

Pattern localStorage canon do Sells Onda 3 (`SaleItemComments` referência). Multi-tenant Tier 0 (ADR 0093) preservado: rows continuam `business_id`-scoped via Eloquent. Onda futura poderá plugar em backend (`fin_review_log`, `fin_comments` tables) com sync MCP — nota deixada em todos os 4 components.

### Validação

- ✅ **Pest 12/12** (57 assertions) — `Modules/Financeiro/Tests/Feature/Onda5CuradoriaR1Test.php` — estrutural (file_get_contents + regex), sem DB
- ✅ **Vite build:inertia** OK em 1m49s, zero erros TS
- 🟡 Smoke Chrome ao vivo em `/financeiro/unificado` — será feito pós-merge em prod biz=1 (charter cita Eliana persona)

### Roadmap restante

- **Onda 6** (próxima) — Financeiro R2 IA: anomalia outlier + party history + month digest
- **Onda 7** — Financeiro R3 Guia+Saída + cross-link Vendas↔Financeiro

Re: PR #1064 (sync KB-9.75 v2), PR #1066 (fix shared files), ADR-0114 (loop Cowork formalizado).
