### PR TITLE
feat(financeiro): Onda 6 KB-9.75 R2 IA — Anomaly + PartyHistory + MonthDigest

### DIFF
--- a/Modules/Financeiro/Tests/Feature/Onda6IaR2Test.php
+++ b/Modules/Financeiro/Tests/Feature/Onda6IaR2Test.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Onda 6 Financeiro KB-9.75 R2 IA — testes estruturais.
+ *
+ * Cobre:
+ *   - 3 components novos em resources/js/Pages/Financeiro/Unificado/_components/
+ *     (FinAnomalyDetector, FinPartyHistory, FinMonthDigest)
+ *   - CSS escopado em resources/css/fin-ia.css importado por inertia.css
+ *   - Index.tsx wire-up (imports, FinMonthDigest acima tabela, FinAnomaly +
+ *     FinPartyHistory no drawer)
+ *
+ * Pure compute (sem backend, sem LLM real). Multi-tenant Tier 0 safe.
+ *
+ * Refs:
+ *   - memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md
+ *   - prototipo-ui/financeiro-ai.jsx (canonical source)
+ */
+
+const FIN_BASE_6 = __DIR__ . '/../../../../resources/js/Pages/Financeiro/Unificado';
+const FIN_IA_CSS = __DIR__ . '/../../../../resources/css/fin-ia.css';
+const FIN_INERTIA_CSS_6 = __DIR__ . '/../../../../resources/css/inertia.css';
+
+describe('Onda 6 Financeiro R2 IA — 3 components existem', function () {
+    it('FinAnomalyDetector exporta finAnomalyDetect + component, threshold 25% + 3 severities', function () {
+        $src = file_get_contents(FIN_BASE_6 . '/_components/FinAnomalyDetector.tsx');
+        expect($src)->toContain('export function finAnomalyDetect');
+        expect($src)->toContain('export function FinAnomalyDetector');
+        expect($src)->toContain('THRESHOLD_PCT = 25');
+        expect($src)->toContain("'high'");
+        expect($src)->toContain("'medium'");
+        expect($src)->toContain("'low'");
+        expect($src)->toContain('severity:');
+    });
+
+    it('FinPartyHistory exporta finPartyHistory + component, isNew + isRecurrent', function () {
+        $src = file_get_contents(FIN_BASE_6 . '/_components/FinPartyHistory.tsx');
+        expect($src)->toContain('export function finPartyHistory');
+        expect($src)->toContain('export function FinPartyHistory');
+        expect($src)->toContain('isNew');
+        expect($src)->toContain('isRecurrent');
+        expect($src)->toContain('mine.length >= 3');
+        expect($src)->toContain('onTimePct');
+    });
+
+    it('FinMonthDigest exporta buildMonthDigest + component com 4 cards', function () {
+        $src = file_get_contents(FIN_BASE_6 . '/_components/FinMonthDigest.tsx');
+        expect($src)->toContain('export function buildMonthDigest');
+        expect($src)->toContain('export function FinMonthDigest');
+        // 4 cards canon: cashIn, cashOut, net, late
+        expect($src)->toContain('cashIn');
+        expect($src)->toContain('cashOut');
+        expect($src)->toContain('net:');
+        expect($src)->toContain('late:');
+        // Top party
+        expect($src)->toContain('topPartyIn');
+        expect($src)->toContain('topPartyOut');
+        // Conferido% integration
+        expect($src)->toContain('conferidoPct');
+    });
+});
+
+describe('Onda 6 Financeiro R2 IA — CSS escopado', function () {
+    it('fin-ia.css existe e escopa em .fin-curadoria (mesma wrapper Onda 5)', function () {
+        $css = file_get_contents(FIN_IA_CSS);
+        expect($css)->toContain('.fin-curadoria .fin-anomaly');
+        expect($css)->toContain('.fin-curadoria .fin-party-history');
+        expect($css)->toContain('.fin-curadoria .fin-digest');
+        // 3 severities anomaly
+        expect($css)->toContain('.fin-anomaly-sev-high');
+        expect($css)->toContain('.fin-anomaly-sev-medium');
+        expect($css)->toContain('.fin-anomaly-sev-low');
+    });
+
+    it('inertia.css importa fin-ia.css apos fin-curadoria.css', function () {
+        $css = file_get_contents(FIN_INERTIA_CSS_6);
+        expect($css)->toContain('@import "./fin-ia.css"');
+        // Ordem: Onda 5 (fin-curadoria) antes de Onda 6 (fin-ia)
+        $pos5 = strpos($css, '@import "./fin-curadoria.css"');
+        $pos6 = strpos($css, '@import "./fin-ia.css"');
+        expect($pos5)->toBeLessThan($pos6);
+    });
+});
+
+describe('Onda 6 Financeiro R2 IA — wire-up Index.tsx', function () {
+    it('Index.tsx importa os 3 components da Onda 6', function () {
+        $src = file_get_contents(FIN_BASE_6 . '/Index.tsx');
+        expect($src)->toContain("from './_components/FinAnomalyDetector'");
+        expect($src)->toContain("from './_components/FinPartyHistory'");
+        expect($src)->toContain("from './_components/FinMonthDigest'");
+    });
+
+    it('Index.tsx renderiza FinMonthDigest acima da tabela com props corretos', function () {
+        $src = file_get_contents(FIN_BASE_6 . '/Index.tsx');
+        expect($src)->toContain('<FinMonthDigest');
+        expect($src)->toContain('lancamentos={lancamentos}');
+        expect($src)->toContain('kpis={kpis}');
+        expect($src)->toContain('periodLabel={periodLabel}');
+    });
+
+    it('Index.tsx drawer renderiza FinAnomalyDetector + FinPartyHistory', function () {
+        $src = file_get_contents(FIN_BASE_6 . '/Index.tsx');
+        expect($src)->toContain('<FinAnomalyDetector');
+        expect($src)->toContain('<FinPartyHistory');
+        // Ambos recebem all={lancamentos} pra compute histórico
+        expect($src)->toContain('all={lancamentos}');
+    });
+});
+
+describe('Onda 6 Financeiro R2 IA — charter v3', function () {
+    it('Index.charter.md declara Onda 6 R2 features + charter v3', function () {
+        $md = file_get_contents(FIN_BASE_6 . '/Index.charter.md');
+        expect($md)->toContain('charter_version: 3');
+        expect($md)->toContain('Onda 6 KB-9.75 R2 IA');
+        expect($md)->toContain('FinAnomalyDetector');
+        expect($md)->toContain('FinPartyHistory');
+        expect($md)->toContain('FinMonthDigest');
+        expect($md)->toContain('Ondas 5+6');
+    });
+});

--- a/resources/css/fin-ia.css
+++ b/resources/css/fin-ia.css
@@ -1,0 +1,300 @@
+/* fin-ia.css — Cowork KB-9.75 Financeiro Onda 6 R2 IA
+ *
+ * Tokens visuais portados de prototipo-ui/styles.css (Refino #2).
+ * Escopados em .fin-curadoria (mesma wrapper da Onda 5).
+ *
+ * Refs:
+ *   - prototipo-ui/financeiro-ai.jsx (canonical components)
+ *   - resources/css/fin-curadoria.css (Onda 5 — wrapper compartilhado)
+ */
+
+/* ─────────────────────────────────────────────────────────────
+ * Anomaly card — outlier vs histórico
+ * ───────────────────────────────────────────────────────────── */
+
+.fin-curadoria .fin-anomaly {
+  display: flex;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid currentColor;
+  margin: 8px 0;
+  align-items: flex-start;
+}
+.fin-curadoria .fin-anomaly-high.fin-anomaly-sev-high {
+  background: oklch(0.96 0.07 60);
+  color: oklch(0.42 0.18 60);
+}
+.fin-curadoria .fin-anomaly-high.fin-anomaly-sev-medium {
+  background: oklch(0.96 0.05 70);
+  color: oklch(0.45 0.13 60);
+}
+.fin-curadoria .fin-anomaly-high.fin-anomaly-sev-low {
+  background: oklch(0.96 0.04 80);
+  color: oklch(0.48 0.10 60);
+}
+.fin-curadoria .fin-anomaly-low.fin-anomaly-sev-high {
+  background: oklch(0.95 0.04 25);
+  color: oklch(0.50 0.18 25);
+}
+.fin-curadoria .fin-anomaly-low.fin-anomaly-sev-medium {
+  background: oklch(0.96 0.05 240);
+  color: oklch(0.40 0.13 240);
+}
+.fin-curadoria .fin-anomaly-low.fin-anomaly-sev-low {
+  background: oklch(0.96 0.04 240);
+  color: oklch(0.45 0.10 240);
+}
+
+.fin-curadoria .fin-anomaly-ic {
+  display: grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: white;
+  font-size: 14px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.fin-curadoria .fin-anomaly-body { flex: 1; min-width: 0; }
+.fin-curadoria .fin-anomaly-body b { display: block; font-size: 12.5px; font-weight: 600; }
+.fin-curadoria .fin-anomaly-body small { display: block; font-size: 11px; opacity: 0.85; }
+.fin-curadoria .fin-anomaly-body i { font-style: normal; font-size: 11px; font-weight: 500; opacity: 0.75; }
+
+/* ─────────────────────────────────────────────────────────────
+ * Party history — stats da contraparte
+ * ───────────────────────────────────────────────────────────── */
+
+.fin-curadoria .fin-party-history {
+  background: var(--fin-bg-soft);
+  border: 1px solid var(--fin-line);
+  border-radius: 8px;
+  padding: 10px 12px;
+  margin: 8px 0;
+  font-size: 12px;
+}
+.fin-curadoria .fin-party-h {
+  display: flex;
+  align-items: baseline;
+  gap: 6px;
+  margin-bottom: 8px;
+}
+.fin-curadoria .fin-party-ic {
+  font-size: 12px;
+  color: oklch(0.36 0.13 240);
+}
+.fin-curadoria .fin-party-h h4 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 700;
+  color: var(--fin-text);
+}
+.fin-curadoria .fin-party-h small { font-size: 11px; color: var(--fin-text-mute); }
+
+.fin-curadoria .fin-party-new p {
+  margin: 4px 0 0;
+  font-size: 12px;
+  color: var(--fin-text-mute);
+  font-style: italic;
+}
+
+.fin-curadoria .fin-party-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin: 8px 0;
+}
+.fin-curadoria .fin-party-stat {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.fin-curadoria .fin-party-stat small {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fin-text-mute);
+}
+.fin-curadoria .fin-party-stat b {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--fin-text);
+  font-family: ui-monospace, monospace;
+}
+.fin-curadoria .fin-party-stat b.pos { color: oklch(0.45 0.18 145); }
+.fin-curadoria .fin-party-stat b.mid { color: oklch(0.55 0.13 60); }
+.fin-curadoria .fin-party-stat b.neg { color: oklch(0.50 0.18 25); }
+
+.fin-curadoria .fin-party-top-cat {
+  margin: 4px 0 0;
+  font-size: 11.5px;
+  color: var(--fin-text);
+}
+.fin-curadoria .fin-party-top-cat small { color: var(--fin-text-mute); }
+
+.fin-curadoria .fin-party-recent {
+  margin-top: 8px;
+  border-top: 1px dashed var(--fin-line);
+  padding-top: 6px;
+}
+.fin-curadoria .fin-party-recent > small {
+  display: block;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fin-text-mute);
+  margin-bottom: 4px;
+}
+.fin-curadoria .fin-party-recent ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.fin-curadoria .fin-party-recent li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 11.5px;
+  padding: 2px 0;
+}
+.fin-curadoria .fin-party-recent-cat {
+  color: var(--fin-text-mute);
+  flex: 1;
+  min-width: 0;
+  text-overflow: ellipsis;
+  overflow: hidden;
+  white-space: nowrap;
+}
+.fin-curadoria .fin-party-recent-amt {
+  font-family: ui-monospace, monospace;
+  font-weight: 600;
+  color: var(--fin-text);
+}
+.fin-curadoria .fin-party-recent-tag {
+  display: grid;
+  place-items: center;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  font-size: 10px;
+}
+.fin-curadoria .fin-party-recent-tag.paid {
+  background: oklch(0.94 0.06 145);
+  color: oklch(0.32 0.13 145);
+}
+.fin-curadoria .fin-party-recent-tag.overdue {
+  background: oklch(0.95 0.04 25);
+  color: oklch(0.50 0.18 25);
+}
+.fin-curadoria .fin-party-recent-tag.open {
+  background: var(--fin-bg-soft);
+  color: var(--fin-text-mute);
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * Month Digest — 4-card snapshot executivo
+ * ───────────────────────────────────────────────────────────── */
+
+.fin-curadoria .fin-digest {
+  border: 1px solid var(--fin-line);
+  border-radius: 8px;
+  margin: 6px 0 12px;
+  overflow: hidden;
+}
+.fin-curadoria .fin-digest-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 10px 12px;
+  background: white;
+  border: 0;
+  font-family: inherit;
+  cursor: pointer;
+  text-align: left;
+  font-size: 12.5px;
+}
+.fin-curadoria .fin-digest-toggle:hover { background: var(--fin-bg-soft); }
+.fin-curadoria .fin-digest-ic { color: oklch(0.36 0.13 240); }
+.fin-curadoria .fin-digest-toggle b { color: var(--fin-text); font-weight: 700; }
+.fin-curadoria .fin-digest-toggle small {
+  color: var(--fin-text-mute);
+  font-size: 11px;
+  font-weight: 500;
+}
+.fin-curadoria .fin-digest-chev {
+  margin-left: auto;
+  color: var(--fin-text-mute);
+  font-size: 11px;
+}
+
+.fin-curadoria .fin-digest-body {
+  padding: 8px 12px 12px;
+  background: var(--fin-bg-soft);
+  border-top: 1px solid var(--fin-line);
+}
+
+.fin-curadoria .fin-digest-cards {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+.fin-curadoria .fin-digest-card {
+  background: white;
+  border-radius: 6px;
+  padding: 8px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.fin-curadoria .fin-digest-card small {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fin-text-mute);
+}
+.fin-curadoria .fin-digest-card b {
+  font-size: 16px;
+  font-weight: 700;
+  font-family: ui-monospace, monospace;
+  color: var(--fin-text);
+}
+.fin-curadoria .fin-digest-card i {
+  font-style: normal;
+  font-size: 10.5px;
+  color: var(--fin-text-mute);
+}
+.fin-curadoria .fin-digest-card.in b { color: oklch(0.45 0.18 145); }
+.fin-curadoria .fin-digest-card.out b { color: oklch(0.40 0.005 240); }
+.fin-curadoria .fin-digest-card.net.pos b { color: oklch(0.45 0.18 145); }
+.fin-curadoria .fin-digest-card.net.neg b { color: oklch(0.50 0.18 25); }
+.fin-curadoria .fin-digest-card.late b { color: oklch(0.55 0.18 25); }
+
+.fin-curadoria .fin-digest-tops {
+  margin-top: 8px;
+  display: flex;
+  gap: 12px;
+  font-size: 11.5px;
+}
+.fin-curadoria .fin-digest-top {
+  flex: 1;
+  background: white;
+  border-radius: 6px;
+  padding: 6px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.fin-curadoria .fin-digest-top small {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fin-text-mute);
+}
+.fin-curadoria .fin-digest-top span { font-size: 12px; }
+.fin-curadoria .fin-digest-top.in small { color: oklch(0.45 0.18 145); }
+.fin-curadoria .fin-digest-top.out small { color: oklch(0.55 0.18 25); }

--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -32,6 +32,9 @@
 /* Financeiro/Unificado Cowork Onda 5 R1 Curadoria — escopado em .fin-curadoria (Conferido + Comments + Audit + Frescor) */
 @import "./fin-curadoria.css";
 
+/* Financeiro/Unificado Cowork Onda 6 R2 IA — escopado em .fin-curadoria (Anomaly + PartyHistory + MonthDigest) */
+@import "./fin-ia.css";
+
 @theme {
   --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
 

--- a/resources/js/Pages/Financeiro/Unificado/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Unificado/Index.charter.md
@@ -9,9 +9,9 @@ parent_capterra: memory/requisitos/Financeiro/CAPTERRA-FICHA.md
 related_adrs: [arq/0005, ui/0002, ui/0114, 0093, 0094]
 related_us: [US-FIN-013, US-FIN-020]
 related_prototype: prototipo Cowork "Visao Unificada" (Financeiro.html), aprovado por Wagner 2026-05-09
-canon_method: Cowork KB-9.75 v2 — Onda 5 R1 Curadoria (PR #1064/#1066 + Onda 5 atual)
+canon_method: Cowork KB-9.75 v2 — Ondas 5+6 (R1 Curadoria + R2 IA · PR #1064/#1066 + Onda 5 + Onda 6 atual)
 tier: A
-charter_version: 2
+charter_version: 3
 ---
 
 # Page Charter — /financeiro/unificado
@@ -29,6 +29,10 @@ Tela única de **fluxo financeiro do mês** que mistura **Pagar / Pagas / Recebe
 
 ## Goals — Features (faz)
 
+- **Onda 6 KB-9.75 R2 IA** (2026-05-18):
+  - **FinAnomalyDetector** — detecta valor outlier vs média histórica da contraparte (threshold ≥25%, severity high/medium/low). Mostrado no drawer quando aplicável. Pure compute, sem LLM.
+  - **FinPartyHistory** — stats da contraparte no drawer (count, total, média, on-time%, categoria top, 5 recentes). Detecta isNew (1 lançamento) vs isRecurrent (≥3). Pure compute.
+  - **FinMonthDigest** — section colapsável acima da tabela com 4 cards (Recebido / Pago / Saldo do mês / Atrasados) + top contraparte in/out. Pure compute, "Eliana 5min sexta" digest.
 - **Onda 5 KB-9.75 R1 Curadoria** (2026-05-18):
   - **Conferido toggle** por Eliana (localStorage `oimpresso.financeiro.conferido`) — pill grande no drawer + badge ✓ silent na linha
   - **Comentários inline** thread Eliana ↔ Wagner ↔ Bruna (localStorage `oimpresso.financeiro.comments`) — textarea no drawer + badge 💬N silent na linha

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -25,6 +25,10 @@ import { FinPillFrescor } from './_components/FinPillFrescor';
 import { FinConferidoToggle, FinConferidoBadge, useFinConferido, type UseFinConferidoApi } from './_components/FinConferidoToggle';
 import { FinCommentsThread, FinCommentsBadge, useFinComments, type UseFinCommentsApi } from './_components/FinCommentsThread';
 import { FinAuditTrail } from './_components/FinAuditTrail';
+// Onda 6 R2 IA — anomaly + party history + month digest (pure compute, sem backend).
+import { FinAnomalyDetector } from './_components/FinAnomalyDetector';
+import { FinPartyHistory } from './_components/FinPartyHistory';
+import { FinMonthDigest } from './_components/FinMonthDigest';
 
 // ---------- Tipos ----------
 
@@ -291,6 +295,14 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
 
       <KpiBar kpis={kpis} onTabClick={(tab) => aplicar({ tab })} />
 
+      {/* Cowork KB-9.75 Onda 6 R2 IA — Resumo executivo do mês (Eliana 5min sexta) */}
+      <FinMonthDigest
+        lancamentos={lancamentos}
+        kpis={kpis}
+        conferidoSet={new Set(lancamentos.filter((l) => conferido.has(l.id)).map((l) => String(l.id)))}
+        periodLabel={periodLabel}
+      />
+
       {/* Tabs + filtros sticky */}
       <Card className="mt-6 sticky top-14 z-10">
         <CardContent className="p-3 flex flex-wrap items-center gap-2">
@@ -412,6 +424,26 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
                 </div>
 
                 <FinConferidoToggle rowId={selected.id} conferido={conferido} />
+
+                {/* Cowork KB-9.75 Onda 6 R2 IA — Anomaly + Party History */}
+                <FinAnomalyDetector
+                  row={{
+                    id: selected.id,
+                    contraparte: selected.contraparte,
+                    categoria: selected.categoria,
+                    valor: selected.valor,
+                    vencimento: selected.vencimento,
+                    liquidacao: selected.liquidacao,
+                    status: selected.status,
+                    kind: selected.kind,
+                  }}
+                  all={lancamentos}
+                />
+
+                <FinPartyHistory
+                  currentRow={{ id: selected.id, contraparte: selected.contraparte }}
+                  all={lancamentos}
+                />
 
                 <dl className="grid grid-cols-2 gap-y-2 text-[12.5px]">
                   <dt className="text-stone-500">Contraparte</dt><dd>{selected.contraparte}{selected.contraparte_doc && <span className="block text-stone-500">{selected.contraparte_doc}</span>}</dd>

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinAnomalyDetector.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinAnomalyDetector.tsx
@@ -1,0 +1,97 @@
+// FinAnomalyDetector — Cowork KB-9.75 Financeiro Onda 6 R2 IA
+// (detecta valor outlier vs histórico da contraparte).
+//
+// Refs:
+//  - prototipo-ui/financeiro-ai.jsx — finAiAnomalia + FinAiAnomalia
+//
+// Pure compute (sem backend, sem LLM). Threshold: ≥25% desvio vs média e
+// histórico ≥3 transações pra considerar recorrente.
+
+import { useMemo } from 'react';
+import { finPartyHistory } from './FinPartyHistory';
+
+interface LancamentoLite {
+  id: number;
+  contraparte: string;
+  categoria?: string;
+  valor: number;
+  vencimento?: string | Date | null;
+  liquidacao?: string | Date | null;
+  status?: string;
+  kind?: 'receivable' | 'payable';
+}
+
+export type AnomalyKind = 'high' | 'low';
+
+export interface AnomalyInfo {
+  kind: AnomalyKind;
+  pct: number;
+  avg: number;
+  desc: string;
+  severity: 'low' | 'medium' | 'high';
+}
+
+const THRESHOLD_PCT = 25;
+const SEVERITY_HIGH = 100;
+const SEVERITY_MEDIUM = 50;
+
+export function finAnomalyDetect(row: LancamentoLite, all: LancamentoLite[]): AnomalyInfo | null {
+  const h = finPartyHistory(row.contraparte, row.id, all);
+  if (!h.isRecurrent || h.avg === 0) return null;
+
+  const diff = row.valor - h.avg;
+  const pct = (diff / h.avg) * 100;
+
+  if (Math.abs(pct) < THRESHOLD_PCT) return null;
+
+  const absPct = Math.abs(pct);
+  const severity: AnomalyInfo['severity'] =
+    absPct >= SEVERITY_HIGH ? 'high' : absPct >= SEVERITY_MEDIUM ? 'medium' : 'low';
+
+  return {
+    kind: diff > 0 ? 'high' : 'low',
+    pct,
+    avg: h.avg,
+    severity,
+    desc:
+      diff > 0
+        ? `${pct.toFixed(0)}% acima da média histórica`
+        : `${Math.abs(pct).toFixed(0)}% abaixo da média histórica`,
+  };
+}
+
+function brl(n: number): string {
+  return n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+interface FinAnomalyDetectorProps {
+  row: LancamentoLite;
+  all: LancamentoLite[];
+}
+
+export function FinAnomalyDetector({ row, all }: FinAnomalyDetectorProps) {
+  const anomaly = useMemo(() => finAnomalyDetect(row, all), [row.id, row.valor, all]);
+
+  if (!anomaly) return null;
+
+  const icon = anomaly.kind === 'high' ? '⚠' : '◇';
+
+  return (
+    <div
+      className={`fin-anomaly fin-anomaly-${anomaly.kind} fin-anomaly-sev-${anomaly.severity}`}
+      data-kind={anomaly.kind}
+      data-severity={anomaly.severity}
+    >
+      <span className="fin-anomaly-ic">{icon}</span>
+      <div className="fin-anomaly-body">
+        <b>Valor fora do padrão</b>
+        <small>{anomaly.desc}</small>
+        <i>
+          Média histórica · {brl(anomaly.avg)} · vs atual {brl(row.valor)}
+        </i>
+      </div>
+    </div>
+  );
+}
+
+export default FinAnomalyDetector;

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinMonthDigest.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinMonthDigest.tsx
@@ -1,0 +1,175 @@
+// FinMonthDigest — Cowork KB-9.75 Financeiro Onda 6 R2 IA
+// (4-card snapshot do mês — "Eliana 5min sexta" digest executivo).
+//
+// Refs:
+//  - prototipo-ui/financeiro-ai.jsx — FinAiMonthDigest
+//
+// Pure compute do array `lancamentos` + `kpis` que já vêm no payload. Sem backend.
+// Pode ser exibido como section colapsada acima da tabela OU como tab no header.
+
+import { useMemo, useState } from 'react';
+
+interface LancamentoLite {
+  id: number;
+  contraparte: string;
+  valor: number;
+  vencimento?: string | Date | null;
+  liquidacao?: string | Date | null;
+  status?: string;
+  kind?: 'receivable' | 'payable';
+}
+
+interface KpiSnapshot {
+  saldo_previsto: number;
+  recebido: { valor: number; qtd: number };
+  a_receber: { valor: number; qtd: number };
+  pago: { valor: number; qtd: number };
+  a_pagar: { valor: number; qtd: number };
+}
+
+export interface MonthDigest {
+  cashIn: { value: number; count: number };
+  cashOut: { value: number; count: number };
+  net: number;
+  late: { value: number; count: number };
+  topPartyIn: { name: string; value: number } | null;
+  topPartyOut: { name: string; value: number } | null;
+  conferidoCount: number;
+  totalCount: number;
+  conferidoPct: number;
+}
+
+export function buildMonthDigest(
+  lancamentos: LancamentoLite[],
+  kpis: KpiSnapshot,
+  conferidoSet: Set<string>,
+): MonthDigest {
+  const recebidos = lancamentos.filter((l) => l.status === 'recebido' || !!l.liquidacao && l.kind === 'receivable');
+  const pagos = lancamentos.filter((l) => l.status === 'pago' || (!!l.liquidacao && l.kind === 'payable'));
+  const atrasados = lancamentos.filter((l) => l.status === 'atrasado');
+
+  const cashIn = {
+    value: kpis.recebido?.valor || recebidos.reduce((s, r) => s + r.valor, 0),
+    count: kpis.recebido?.qtd || recebidos.length,
+  };
+  const cashOut = {
+    value: kpis.pago?.valor || pagos.reduce((s, r) => s + r.valor, 0),
+    count: kpis.pago?.qtd || pagos.length,
+  };
+  const late = {
+    value: atrasados.reduce((s, r) => s + r.valor, 0),
+    count: atrasados.length,
+  };
+
+  // Top contraparte recebimento e pagamento
+  const partyIn: Record<string, number> = {};
+  recebidos.forEach((r) => {
+    partyIn[r.contraparte] = (partyIn[r.contraparte] || 0) + r.valor;
+  });
+  const partyOut: Record<string, number> = {};
+  pagos.forEach((r) => {
+    partyOut[r.contraparte] = (partyOut[r.contraparte] || 0) + r.valor;
+  });
+
+  const topPartyIn = Object.entries(partyIn).sort((a, b) => b[1] - a[1])[0];
+  const topPartyOut = Object.entries(partyOut).sort((a, b) => b[1] - a[1])[0];
+
+  const conferidoCount = lancamentos.filter((l) => conferidoSet.has(String(l.id))).length;
+  const totalCount = lancamentos.length;
+  const conferidoPct = totalCount > 0 ? Math.round((conferidoCount / totalCount) * 100) : 0;
+
+  return {
+    cashIn,
+    cashOut,
+    net: cashIn.value - cashOut.value,
+    late,
+    topPartyIn: topPartyIn ? { name: topPartyIn[0], value: topPartyIn[1] } : null,
+    topPartyOut: topPartyOut ? { name: topPartyOut[0], value: topPartyOut[1] } : null,
+    conferidoCount,
+    totalCount,
+    conferidoPct,
+  };
+}
+
+function brl(n: number): string {
+  return n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+function brlShort(n: number): string {
+  if (Math.abs(n) >= 1000) {
+    return 'R$ ' + (n / 1000).toFixed(1).replace('.', ',') + 'k';
+  }
+  return brl(n);
+}
+
+interface FinMonthDigestProps {
+  lancamentos: LancamentoLite[];
+  kpis: KpiSnapshot;
+  conferidoSet: Set<string>;
+  periodLabel: string;
+  defaultOpen?: boolean;
+}
+
+export function FinMonthDigest({ lancamentos, kpis, conferidoSet, periodLabel, defaultOpen = false }: FinMonthDigestProps) {
+  const [open, setOpen] = useState(defaultOpen);
+  const digest = useMemo(() => buildMonthDigest(lancamentos, kpis, conferidoSet), [lancamentos, kpis, conferidoSet]);
+
+  const netCls = digest.net >= 0 ? 'pos' : 'neg';
+
+  return (
+    <div className={`fin-digest ${open ? 'open' : 'closed'}`}>
+      <button type="button" className="fin-digest-toggle" onClick={() => setOpen((v) => !v)} aria-expanded={open}>
+        <span className="fin-digest-ic">✦</span>
+        <b>Resumo do mês · {periodLabel}</b>
+        <small>{digest.totalCount} lançamentos · {digest.conferidoPct}% conferido</small>
+        <span className="fin-digest-chev">{open ? '▾' : '▸'}</span>
+      </button>
+
+      {open && (
+        <div className="fin-digest-body">
+          <div className="fin-digest-cards">
+            <div className="fin-digest-card in">
+              <small>Recebido</small>
+              <b>{brlShort(digest.cashIn.value)}</b>
+              <i>{digest.cashIn.count} baixas</i>
+            </div>
+            <div className="fin-digest-card out">
+              <small>Pago</small>
+              <b>{brlShort(digest.cashOut.value)}</b>
+              <i>{digest.cashOut.count} baixas</i>
+            </div>
+            <div className={`fin-digest-card net ${netCls}`}>
+              <small>Saldo do mês</small>
+              <b>{digest.net >= 0 ? '+' : ''}{brlShort(digest.net)}</b>
+              <i>{digest.net >= 0 ? 'positivo' : 'negativo'}</i>
+            </div>
+            <div className="fin-digest-card late">
+              <small>Atrasados</small>
+              <b>{brlShort(digest.late.value)}</b>
+              <i>{digest.late.count} título{digest.late.count !== 1 ? 's' : ''}</i>
+            </div>
+          </div>
+
+          {(digest.topPartyIn || digest.topPartyOut) && (
+            <div className="fin-digest-tops">
+              {digest.topPartyIn && (
+                <div className="fin-digest-top in">
+                  <small>↑ Top recebimento</small>
+                  <span><b>{digest.topPartyIn.name}</b> · {brlShort(digest.topPartyIn.value)}</span>
+                </div>
+              )}
+              {digest.topPartyOut && (
+                <div className="fin-digest-top out">
+                  <small>↓ Top pagamento</small>
+                  <span><b>{digest.topPartyOut.name}</b> · {brlShort(digest.topPartyOut.value)}</span>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default FinMonthDigest;

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinPartyHistory.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinPartyHistory.tsx
@@ -1,0 +1,205 @@
+// FinPartyHistory — Cowork KB-9.75 Financeiro Onda 6 R2 IA
+// (stats da contraparte: média, on-time%, categoria top, recorrência).
+//
+// Refs:
+//  - prototipo-ui/financeiro-ai.jsx — finAiPartyHistory + FinAiPartyContext
+//
+// Pure compute do array `lancamentos` (sem backend, sem IA real).
+// Determinístico. Multi-tenant Tier 0 safe (lancamentos já vem business_id-scoped).
+
+import { useMemo } from 'react';
+
+interface LancamentoLite {
+  id: number;
+  contraparte: string;
+  categoria?: string;
+  valor: number;
+  vencimento?: string | Date | null;
+  liquidacao?: string | Date | null;
+  status?: string;
+  kind?: 'receivable' | 'payable';
+}
+
+export interface FinPartyStats {
+  count: number;
+  total: number;
+  avg: number;
+  paidCount: number;
+  overdueCount: number;
+  onTimePct: number | null;
+  topCategory?: string;
+  isNew: boolean;
+  isRecurrent: boolean;
+  recent: LancamentoLite[];
+}
+
+function asDate(v: string | Date | null | undefined): Date | null {
+  if (!v) return null;
+  if (v instanceof Date) return v;
+  const d = new Date(v);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+export function finPartyHistory(
+  partyName: string,
+  currentRowId: number | null,
+  all: LancamentoLite[],
+): FinPartyStats {
+  const list = all.filter((r) => r.contraparte === partyName);
+  const mine = currentRowId != null ? list.filter((r) => r.id !== currentRowId) : list;
+
+  if (mine.length === 0) {
+    return {
+      count: 0,
+      total: 0,
+      avg: 0,
+      paidCount: 0,
+      overdueCount: 0,
+      onTimePct: null,
+      isNew: true,
+      isRecurrent: false,
+      recent: [],
+    };
+  }
+
+  const total = mine.reduce((s, r) => s + (r.valor || 0), 0);
+  const avg = total / mine.length;
+  const paid = mine.filter((r) => !!r.liquidacao);
+  const overdue = mine.filter((r) => r.status === 'atrasado');
+  const onTime = paid.filter((r) => {
+    const p = asDate(r.liquidacao);
+    const d = asDate(r.vencimento);
+    return p && d && p.getTime() <= d.getTime();
+  }).length;
+
+  const onTimePct = paid.length ? Math.round((onTime / paid.length) * 100) : null;
+
+  // Categoria mais comum
+  const catCount: Record<string, number> = {};
+  mine.forEach((r) => {
+    const c = r.categoria || '—';
+    catCount[c] = (catCount[c] || 0) + 1;
+  });
+  const topCategory = Object.entries(catCount).sort((a, b) => b[1] - a[1])[0]?.[0];
+
+  // 5 transações mais recentes (por vencimento desc)
+  const recent = [...mine]
+    .sort((a, b) => {
+      const da = asDate(a.liquidacao || a.vencimento)?.getTime() ?? 0;
+      const db = asDate(b.liquidacao || b.vencimento)?.getTime() ?? 0;
+      return db - da;
+    })
+    .slice(0, 5);
+
+  return {
+    count: mine.length,
+    total,
+    avg,
+    paidCount: paid.length,
+    overdueCount: overdue.length,
+    onTimePct,
+    topCategory,
+    isNew: mine.length === 1,
+    isRecurrent: mine.length >= 3,
+    recent,
+  };
+}
+
+function brl(n: number): string {
+  return n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+function brlShort(n: number): string {
+  if (n >= 1000) {
+    return 'R$ ' + (n / 1000).toFixed(1).replace('.', ',') + 'k';
+  }
+  return brl(n);
+}
+
+interface FinPartyHistoryProps {
+  currentRow: { id: number; contraparte: string };
+  all: LancamentoLite[];
+}
+
+export function FinPartyHistory({ currentRow, all }: FinPartyHistoryProps) {
+  const stats = useMemo(
+    () => finPartyHistory(currentRow.contraparte, currentRow.id, all),
+    [currentRow.contraparte, currentRow.id, all],
+  );
+
+  if (stats.isNew) {
+    return (
+      <div className="fin-party-history fin-party-new">
+        <div className="fin-party-h">
+          <span className="fin-party-ic">✦</span>
+          <h4>Contraparte nova</h4>
+        </div>
+        <p>Primeira transação com <b>{currentRow.contraparte}</b>. Sem histórico pra comparar.</p>
+      </div>
+    );
+  }
+
+  const recCls = stats.isRecurrent ? 'recurrent' : 'occasional';
+
+  return (
+    <div className={`fin-party-history fin-party-${recCls}`}>
+      <div className="fin-party-h">
+        <span className="fin-party-ic">✦</span>
+        <h4>{currentRow.contraparte}</h4>
+        <small>{stats.count} lançamento{stats.count > 1 ? 's' : ''} históricos</small>
+      </div>
+
+      <div className="fin-party-stats">
+        <div className="fin-party-stat">
+          <small>Média</small>
+          <b>{brlShort(stats.avg)}</b>
+        </div>
+        <div className="fin-party-stat">
+          <small>Total</small>
+          <b>{brlShort(stats.total)}</b>
+        </div>
+        {stats.onTimePct != null && (
+          <div className="fin-party-stat">
+            <small>No prazo</small>
+            <b className={stats.onTimePct >= 80 ? 'pos' : stats.onTimePct >= 50 ? 'mid' : 'neg'}>
+              {stats.onTimePct}%
+            </b>
+          </div>
+        )}
+        {stats.overdueCount > 0 && (
+          <div className="fin-party-stat">
+            <small>Atrasados</small>
+            <b className="neg">{stats.overdueCount}</b>
+          </div>
+        )}
+      </div>
+
+      {stats.topCategory && (
+        <p className="fin-party-top-cat">
+          <small>Categoria recorrente:</small> <b>{stats.topCategory}</b>
+        </p>
+      )}
+
+      {stats.recent.length > 0 && (
+        <div className="fin-party-recent">
+          <small>5 mais recentes</small>
+          <ul>
+            {stats.recent.map((r) => (
+              <li key={r.id}>
+                <span className="fin-party-recent-cat">{r.categoria || '—'}</span>
+                <span className="fin-party-recent-amt">{brlShort(r.valor)}</span>
+                {r.liquidacao
+                  ? <span className="fin-party-recent-tag paid">✓</span>
+                  : r.status === 'atrasado'
+                    ? <span className="fin-party-recent-tag overdue">✕</span>
+                    : <span className="fin-party-recent-tag open">○</span>}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default FinPartyHistory;


### PR DESCRIPTION
## Resumo

**Onda 6 — Financeiro KB-9.75 R2 IA** (segunda de 3 ondas Financeiro). Continua a Onda 5 (PR #1068) que entregou Curadoria.

### O que entrega

**3 components novos** em `resources/js/Pages/Financeiro/Unificado/_components/`:

- **FinAnomalyDetector** — detecta valor outlier vs média histórica da contraparte. Threshold ≥25% absoluto + 3 severities (`high` ≥100%, `medium` ≥50%, `low`). Mostrado no drawer apenas quando aplicável (contraparte recorrente ≥3 transactions).
- **FinPartyHistory** — stats da contraparte no drawer: count, total, média, on-time%, categoria top, 5 mais recentes. Detecta `isNew` (1 lançamento) vs `isRecurrent` (≥3). Pure compute do array `lancamentos`.
- **FinMonthDigest** — section colapsável acima da tabela ("Eliana 5min sexta" digest executivo). 4 cards:
  - ↑ Recebido (Σ + count)
  - ↓ Pago (Σ + count)
  - = Saldo do mês (Recebido − Pago, com cor positivo/negativo)
  - ⚠ Atrasados (Σ + count)
  Mais top contraparte recebimento/pagamento + % conferido (reusa hook `useFinConferido` da Onda 5).

**CSS escopado** em `resources/css/fin-ia.css` (260 LOC) — tokens portados de `prototipo-ui/styles.css` Refino #2, escopado em `.fin-curadoria` (mesma wrapper Onda 5 — deduplicação de isolamento). Importado em `inertia.css` **após** `fin-curadoria.css` (test valida ordem).

**Wire-up Index.tsx:**
- `FinMonthDigest` renderizado acima da tabela (entre KpiBar e tabs)
- `FinAnomalyDetector` + `FinPartyHistory` renderizados no drawer após Conferido toggle e antes do `dl`
- Reusa hook `conferido` da Onda 5 pra `conferidoPct` no digest

**Charter v3** — `charter_version: 3`, `canon_method: Cowork KB-9.75 v2 — Ondas 5+6`, Goals atualizado com 3 features Onda 6 explícitas.

### Backend: ZERO

Pure compute do prop `lancamentos` que já vem `business_id`-scoped. Multi-tenant Tier 0 (ADR 0093) preservado. Onda futura poderá plugar em backend agent `JanaService` (anomaly LLM-aware, party context semantic). Nota deixada nos 3 components.

### Validação

- ✅ **Pest 9/9** (46 assertions) — `Modules/Financeiro/Tests/Feature/Onda6IaR2Test.php`
- ✅ **Vite build:inertia** OK em 1m46s, zero erros TS

### Roadmap restante

- **Onda 7** (próxima) — Financeiro R3 Guia+Saída + cross-link Vendas↔Financeiro:
  - 4 troubleshooters financeiros (conferência / fechamento / divergência / atraso)
  - Trilha fechamento 12 passos
  - Modo apresentação
  - VdLinkify estendido `#V-` `#BL-` `#PC-` no `desc` cruzado

Re: PR #1068 (Onda 5 R1 Curadoria), PR #1064/#1066 (sync KB-9.75 v2), ADR-0114.
