### PR TITLE
fix(sidebar+infra): esconder Pedidos pra biz=4 + cache:clear no Quick Sync

### DIFF
--- a/.github/workflows/quick-sync.yml
+++ b/.github/workflows/quick-sync.yml
@@ -138,14 +138,17 @@ jobs:
             npm run build 2>&1 | tail -10
           "
 
-      - name: Clear view + config + route caches
+      - name: Clear view + config + route + cache (force PHP DataController reload)
         run: |
           /tmp/ssh_exec.sh "
             cd /home/u906587222/domains/oimpresso.com/public_html &&
             php artisan view:clear &&
             php artisan config:clear &&
-            php artisan route:clear
+            php artisan route:clear &&
+            php artisan cache:clear
           "
+        # cache:clear adicionado 2026-05-18 pós bug "Financeiro dropdown invisivel
+        # apos sync biz=4" — DataController novo não era visto sem cache:clear.
 
       - name: Smoke test
         run: |

--- a/app/Http/Middleware/AdminSidebarMenu.php
+++ b/app/Http/Middleware/AdminSidebarMenu.php
@@ -797,8 +797,11 @@ class AdminSidebarMenu
                 $menu->url(action([\App\Http\Controllers\Restaurant\KitchenController::class, 'index']), __('restaurant.kitchen'), ['icon' => '<svg  xmlns="http://www.w3.org/2000/svg"  width="24"  height="24"  viewBox="0 0 24 24"  fill="none"  stroke="currentColor"  stroke-width="2"  stroke-linecap="round"  stroke-linejoin="round"  class="icon icon-tabler icons-tabler-outline icon-tabler-flame"><path stroke="none" d="M0 0h24v24H0z" fill="none"/><path d="M12 12c2 -2.96 0 -7 -1 -8c0 3.038 -1.773 4.741 -3 6c-1.226 1.26 -2 3.24 -2 5a6 6 0 1 0 12 0c0 -1.532 -1.056 -3.94 -2 -5c-1.786 3 -2.791 3 -4 2z" /></svg>', 'active' => request()->segment(1) == 'modules' && request()->segment(2) == 'kitchen'])->order(70);
             }
 
-            //Service Staff menu
-            if (in_array('service_staff', $enabled_modules)) {
+            //Service Staff menu (Pedidos · restaurant module)
+            // Wagner 2026-05-18 (fix biz=4): "Pedidos" abre tela feia legacy do
+            // service_staff (restaurant); biz=4 ROTA LIVRE não usa restaurante.
+            // Esconde pra biz=4 (mesmo pattern de Despesas + Tarefas + Governança).
+            if (in_array('service_staff', $enabled_modules) && $current_biz !== 4) {
                 $menu->url(action([\App\Http\Controllers\Restaurant\OrderController::class, 'index']), __('restaurant.orders'), ['icon' => 'fa fas fa-list-alt', 'active' => request()->segment(1) == 'modules' && request()->segment(2) == 'orders'])->order(75);
             }
 


### PR DESCRIPTION
Pedido Wagner 2026-05-18 pós screenshot biz=4:

1. **"Pedidos" abre tela feia** (service_staff/restaurant) — ROTA LIVRE não usa restaurante. Esconder pra biz=4.
2. **Financeiro dropdown não aparecia** em prod biz=4 mesmo após merge PR #1073 — provável cache Application servindo bytecode antigo. Quick Sync rodava apenas view+config+route clear; faltava `cache:clear`.

<!-- evidence-override: fix UI visibility per-biz em middleware (mesmo escopo PR #1073 já merged) + adição defensiva cache:clear no Quick Sync. Validação depende de session autenticada biz=4 (Wagner faz manual via Ctrl+Shift+R após auto-sync). -->

## Fix 1: Pedidos pra biz=4

`app/Http/Middleware/AdminSidebarMenu.php` — linha 802 (Service Staff menu `restaurant.orders` = label "Pedidos" PT-BR). Guard novo `&& $current_biz !== 4` reusa variável já existente (linha 487 do Expense dropdown). Pattern unificado com Despesas + Tarefas + Governança.

## Fix 2: cache:clear no Quick Sync

`.github/workflows/quick-sync.yml` — adicionado `php artisan cache:clear` após view/config/route. Sem ele, mudanças em DataController.php (chamados indiretamente via Menu::modify) podem não ser visíveis até Application cache expirar.

Pattern referência: skill `migrate-pos-deploy`. Deploy.yml full já tinha cache:clear; agora Quick Sync fica simétrico.

## Validação prod (manual pós-deploy)

**Cenário biz=4 ROTA LIVRE:**
- ✅ Sidebar grupo FINANCEIRO deve mostrar dropdown "Financeiro" com 4 sub-items: Visão / Fluxo / DRE / Boletos
- ❌ Sidebar grupo RELATÓRIOS NÃO deve mais mostrar "Pedidos"

**Cenário biz=1 (Wagner WR2):**
- ✅ Pedidos continua visível (caso ele use feature)

Re: pedido Wagner 2026-05-18 (screenshot biz=4 sidebar), PR #1073.