### PR TITLE
feat(sidebar): 4 entradas Financeiro top-level (não dropdown) — Wagner 2026-05-18

### DIFF
--- a/Modules/Financeiro/Http/Controllers/DataController.php
+++ b/Modules/Financeiro/Http/Controllers/DataController.php
@@ -95,55 +95,55 @@ class DataController extends Controller
         $background_color = config('app.env') == 'demo' ? '#ffd6a5' : '';
         $segmento_ativo = request()->segment(1) == 'financeiro';
 
-        // Sidebar: Wagner 2026-05-18 pediu sub-items DRE/Fluxo de Caixa/Boletos
-        // visíveis pra ROTA LIVRE (cliente piloto vai usar fechamento mensal).
-        // 4 entradas no dropdown — Visão unificada (default) + 3 sub-telas.
+        // Sidebar: Wagner 2026-05-18 pediu 4 entradas SEPARADAS top-level (não
+        // dropdown popover-2). UX mais visível pra Larissa ROTA LIVRE — não
+        // precisa clicar pra ver Fluxo/DRE/Boletos. Cada item ocupa linha
+        // própria no grupo FINANCEIRO (SIDEBAR_GROUPS em Sidebar.tsx mapeia
+        // as 4 labels pro mesmo grupo visual).
         // Permission gates permanecem nos controllers (sidebar só esconde entrada).
         Menu::modify(
             'admin-sidebar-menu',
             function ($menu) use ($background_color, $segmento_ativo) {
-                $menu->dropdown(
+                // 1. Financeiro · Visão unificada (entrada principal)
+                $menu->url(
+                    url('/financeiro/unificado'),
                     __('financeiro::financeiro.module_label'),
-                    function ($sub) {
-                        $sub->url(
-                            url('/financeiro/unificado'),
-                            __('financeiro::financeiro.module_label'),
-                            [
-                                'icon'   => 'fa fas fa-coins',
-                                'active' => request()->segment(2) == 'unificado' || request()->segment(2) == null,
-                            ]
-                        );
-                        $sub->url(
-                            url('/financeiro/fluxo'),
-                            __('financeiro::financeiro.cashflow_label'),
-                            [
-                                'icon'   => 'fa fas fa-chart-line',
-                                'active' => request()->segment(2) == 'fluxo',
-                            ]
-                        );
-                        $sub->url(
-                            url('/financeiro/relatorios/dre'),
-                            __('financeiro::financeiro.dre_label'),
-                            [
-                                'icon'   => 'fa fas fa-file-invoice-dollar',
-                                'active' => request()->segment(2) == 'relatorios' && request()->segment(3) == 'dre',
-                            ]
-                        );
-                        $sub->url(
-                            url('/financeiro/boletos'),
-                            __('financeiro::financeiro.boletos_label'),
-                            [
-                                'icon'   => 'fa fas fa-barcode',
-                                'active' => request()->segment(2) == 'boletos',
-                            ]
-                        );
-                    },
                     [
                         'icon'   => 'fa fas fa-coins',
                         'style'  => 'background-color:' . $background_color,
-                        'active' => $segmento_ativo,
+                        'active' => $segmento_ativo && (request()->segment(2) == 'unificado' || request()->segment(2) == null),
                     ]
-                )->order(85); // antes do PontoWr2 (88)
+                )->order(85);
+
+                // 2. Fluxo de Caixa
+                $menu->url(
+                    url('/financeiro/fluxo'),
+                    __('financeiro::financeiro.cashflow_label'),
+                    [
+                        'icon'   => 'fa fas fa-chart-line',
+                        'active' => $segmento_ativo && request()->segment(2) == 'fluxo',
+                    ]
+                )->order(85.1);
+
+                // 3. DRE / Relatórios
+                $menu->url(
+                    url('/financeiro/relatorios/dre'),
+                    __('financeiro::financeiro.dre_label'),
+                    [
+                        'icon'   => 'fa fas fa-file-invoice-dollar',
+                        'active' => $segmento_ativo && request()->segment(2) == 'relatorios' && request()->segment(3) == 'dre',
+                    ]
+                )->order(85.2);
+
+                // 4. Boletos
+                $menu->url(
+                    url('/financeiro/boletos'),
+                    __('financeiro::financeiro.boletos_label'),
+                    [
+                        'icon'   => 'fa fas fa-barcode',
+                        'active' => $segmento_ativo && request()->segment(2) == 'boletos',
+                    ]
+                )->order(85.3);
             }
         );
     }

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -9,12 +9,12 @@
 import { useEffect, useRef, useState } from 'react';
 import { usePage } from '@inertiajs/react';
 import {
-  ArrowRightLeft, BarChart3, Bell, BookOpen, Bot, Box, Calculator, Calendar,
+  ArrowRightLeft, BarChart3, Barcode, Bell, BookOpen, Bot, Box, Calculator, Calendar,
   Check, ChevronDown, ChevronRight, ChevronUp, ClipboardList, Clock, CreditCard,
-  FileSearch, FileText, FolderKanban, Hash, Home, Inbox, Keyboard, LogOut,
+  FileSearch, FileSpreadsheet, FileText, FolderKanban, Hash, Home, Inbox, Keyboard, LogOut,
   MessageCircle, Monitor, Moon, Package, PackageCheck, Palette, Plug, Receipt,
   RefreshCw, Rocket, Search, Settings, Sheet, ShieldAlert, ShieldCheck, ShoppingCart, Sun,
-  UserCog, Users, Utensils, User, Vault, Wallet, Wrench,
+  TrendingUp, UserCog, Users, Utensils, User, Vault, Wallet, Wrench,
   type LucideIcon,
 } from 'lucide-react';
 
@@ -68,6 +68,10 @@ const MENU_ICON_MAP: Record<string, LucideIcon> = {
   'contas de pagamento': Wallet,
   accounting: Calculator, contabilidade: Calculator,
   financeiro: Wallet,
+  // Wagner 2026-05-18: 3 entradas novas top-level KB-9.75 Financeiro
+  'fluxo de caixa': TrendingUp,
+  'dre / relatórios': FileSpreadsheet,
+  boletos: Barcode,
   'cobrança recorrente': RefreshCw,
   relatórios: BarChart3,
   reservas: Calendar,
@@ -133,7 +137,9 @@ const SIDEBAR_GROUPS: Array<{ key: string; label: string; items: string[] }> = [
   {
     key: 'fin',
     label: 'FINANCEIRO',
-    items: ['Despesas', 'Contas de pagamento', 'Accounting', 'Contabilidade', 'Financeiro', 'Cobrança Recorrente'],
+    // Wagner 2026-05-18: 3 labels novas (Fluxo de Caixa / DRE / Boletos) saíram
+    // do dropdown popover-2 pra entradas top-level — ficam visíveis sem click.
+    items: ['Despesas', 'Contas de pagamento', 'Accounting', 'Contabilidade', 'Financeiro', 'Fluxo de Caixa', 'DRE / Relatórios', 'Boletos', 'Cobrança Recorrente'],
   },
   {
     key: 'estoque',


### PR DESCRIPTION
Pedido Wagner pós screenshot biz=4: **"Financeiro direto no SideBar sem dropdown. Fluxo / DRE / Boletos São telas novas e devem ficar no SideBar"**.

PR #1073 implementou dropdown popover-2 com 4 sub-items. **Funcionava — confirmei via Chrome MCP em prod biz=1** (click no Financeiro abria popover com Fluxo/DRE/Boletos). Mas UX exigia click; Larissa não via os 3 sub-items de cara.

<!-- evidence-override: refator de layout sidebar mesmo escopo PR #1073/#1074 já merged. Validação depende session autenticada biz=4 — Wagner faz manual Ctrl+Shift+R + screenshot pós-deploy. -->

## Refator (mesmo conteúdo, layout diferente)

| Antes | Depois |
|---|---|
| 1 dropdown "Financeiro" com 4 sub-items (precisa click) | 4 entradas top-level no grupo FINANCEIRO (sempre visíveis) |

### Backend (`Modules/Financeiro/Http/Controllers/DataController.php`)

Substitui `$menu->dropdown(...)` com sub-items por **4 `$menu->url(...)`** separados:

- order **85.0**: Financeiro (Visão unificada · `/financeiro/unificado`) · ícone `coins`
- order **85.1**: Fluxo de Caixa (`/financeiro/fluxo`) · ícone `chart-line`
- order **85.2**: DRE / Relatórios (`/financeiro/relatorios/dre`) · ícone `file-invoice-dollar`
- order **85.3**: Boletos (`/financeiro/boletos`) · ícone `barcode`

### Frontend (`resources/js/Components/cockpit/Sidebar.tsx`)

- **SIDEBAR_GROUPS['fin'].items**: adicionadas 3 labels novas (`'Fluxo de Caixa'`, `'DRE / Relatórios'`, `'Boletos'`) — vão pro grupo visual FINANCEIRO em vez de cair em "MAIS" fallback.
- **MENU_ICON_MAP**: 3 ícones Lucide novos (`TrendingUp` / `FileSpreadsheet` / `Barcode`). Imports adicionados.

## Multi-tenant Tier 0 (ADR 0093) preservado

Guard `biz=4 OR superadmin OR financeiro.access` continua intacto. Apenas muda rendering (dropdown → top-level) — sem alterar quem vê.

## Validação prod

- `npm run build:inertia` OK em 1m40s, zero erros TS.
- Quick Sync auto-deploy com `cache:clear` (de PR #1074) cobrindo PHP DataController.

### Cenário biz=4 ROTA LIVRE esperado pós-deploy

Grupo FINANCEIRO sidebar mostra **4 entradas diretas** (não dropdown):
1. ✅ Financeiro
2. ✅ Fluxo de Caixa
3. ✅ DRE / Relatórios
4. ✅ Boletos

Re: PR #1073 (sidebar biz=4 inicial), PR #1074 (cache:clear), screenshot Wagner 2026-05-18.