### PR TITLE
fix(arch): revert hardcode biz=4 — usar subscription packages (Wagner regra IRREVOGÁVEL 2026-05-18)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/DataController.php
+++ b/Modules/Financeiro/Http/Controllers/DataController.php
@@ -77,18 +77,14 @@ class DataController extends Controller
             return;
         }
 
-        // Wagner 2026-05-18: liberar pra biz=4 (ROTA LIVRE Larissa, cliente piloto).
-        // Pre-2026-05-18 era SUPERADMIN-ONLY (em desenvolvimento, pedido 2026-04-25).
-        // Após Onda 7 KB-9.75 entregar Curadoria+IA+CrossLink, módulo está em
-        // estado piloto-ready. Larissa vai usar; outros businesses (que ainda
-        // não pediram explicitamente) seguem bloqueados pra evitar confusão.
-        $business_id = (int) session('user.business_id');
-        $piloto_rotalivre = ($business_id === 4);
-        if (
-            ! auth()->user()->can('superadmin')
-            && ! $piloto_rotalivre
-            && ! auth()->user()->can('financeiro.access')
-        ) {
+        // Wagner 2026-05-18: removido gate SUPERADMIN-ONLY (era "em desenvolvimento"
+        // 2026-04-25). Após Onda 7 KB-9.75 (Curadoria+IA+CrossLink) módulo está
+        // piloto-ready. Visibilidade agora controlada pelo pacote subscription
+        // do business (configurável via Modules/Superadmin/PackagesController) +
+        // permissão de usuário `financeiro.access` — pattern UltimatePOS canon
+        // (NÃO hardcode biz=N — Wagner 2026-05-18: "habilitar é compra de
+        // pacote no modulo superadmin").
+        if (! auth()->user()->can('superadmin') && ! auth()->user()->can('financeiro.access')) {
             return;
         }
 

--- a/Modules/Governance/Http/Controllers/DataController.php
+++ b/Modules/Governance/Http/Controllers/DataController.php
@@ -51,10 +51,8 @@ class DataController extends Controller
         $user = auth()->user();
         if (!$user->can('governance.dashboard.view')) return;
 
-        // Wagner 2026-05-18: esconder pra biz=4 (ROTA LIVRE Larissa). Ela não
-        // usa governance (audit log + module grade gate são features dev/ops).
-        $business_id = (int) session('user.business_id');
-        if ($business_id === 4) return;
+        // Visibilidade per-business é via subscription package
+        // (Modules/Superadmin/PackagesController). NUNCA hardcode biz=N.
 
         Menu::modify('admin-sidebar-menu', function ($menu) {
             $menu->url(

--- a/Modules/Woocommerce/Http/Controllers/DataController.php
+++ b/Modules/Woocommerce/Http/Controllers/DataController.php
@@ -128,15 +128,12 @@ class DataController extends Controller
     {
         $module_util = new ModuleUtil();
 
-        $business_id = (int) session()->get('user.business_id');
+        $business_id = session()->get('user.business_id');
 
-        // Wagner 2026-05-18: esconder pra biz=4 (ROTA LIVRE Larissa). Vestuário
-        // não tem integração WooCommerce ativa. Pattern unificado com
-        // Despesas + Tarefas + Governança + Pedidos.
-        if ($business_id === 4) {
-            return;
-        }
-
+        // Visibilidade per-business já é via subscription package abaixo
+        // (hasThePermissionInSubscription consulta woocommerce_module no
+        // pacote ativo da business). Pra esconder pra um business: desmarcar
+        // woocommerce_module no pacote via Modules/Superadmin/PackagesController.
         $is_woo_enabled = (bool) $module_util->hasThePermissionInSubscription($business_id, 'woocommerce_module', 'superadmin_package');
 
         if ($is_woo_enabled && (auth()->user()->can('woocommerce.syc_categories') || auth()->user()->can('woocommerce.sync_products') || auth()->user()->can('woocommerce.sync_orders') || auth()->user()->can('woocommerce.map_tax_rates') || auth()->user()->can('woocommerce.access_woocommerce_api_settings'))) {

--- a/app/Http/Middleware/AdminSidebarMenu.php
+++ b/app/Http/Middleware/AdminSidebarMenu.php
@@ -481,11 +481,9 @@ class AdminSidebarMenu
             }
 
             //Expense dropdown
-            // Wagner 2026-05-18: esconder pra biz=4 (ROTA LIVRE Larissa). Ela
-            // não usa "Despesas" — vestuário não tem regime fiscal com lançamento
-            // de despesa avulsa por aqui (preferencia Financeiro/Unificado).
-            $current_biz = (int) session('user.business_id');
-            if (in_array('expenses', $enabled_modules) && (auth()->user()->can('all_expense.access') || auth()->user()->can('view_own_expense')) && $current_biz !== 4) {
+            // Visibilidade per-business via $enabled_modules (vem do package
+            // subscription do business) + permission Spatie. NUNCA hardcode biz=N.
+            if (in_array('expenses', $enabled_modules) && (auth()->user()->can('all_expense.access') || auth()->user()->can('view_own_expense'))) {
                 $menu->dropdown(
                     __('expense.expenses'),
                     function ($sub) {
@@ -798,10 +796,9 @@ class AdminSidebarMenu
             }
 
             //Service Staff menu (Pedidos · restaurant module)
-            // Wagner 2026-05-18 (fix biz=4): "Pedidos" abre tela feia legacy do
-            // service_staff (restaurant); biz=4 ROTA LIVRE não usa restaurante.
-            // Esconde pra biz=4 (mesmo pattern de Despesas + Tarefas + Governança).
-            if (in_array('service_staff', $enabled_modules) && $current_biz !== 4) {
+            // Visibilidade per-business via $enabled_modules (package subscription).
+            // Pra esconder, desmarcar 'service_staff' no pacote da business.
+            if (in_array('service_staff', $enabled_modules)) {
                 $menu->url(action([\App\Http\Controllers\Restaurant\OrderController::class, 'index']), __('restaurant.orders'), ['icon' => 'fa fas fa-list-alt', 'active' => request()->segment(1) == 'modules' && request()->segment(2) == 'orders'])->order(75);
             }
 

--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -373,12 +373,12 @@ class HandleInertiaRequests extends Middleware
 
         // Tarefas: universal — MCP tasks system sempre disponível em prod
         // (`mcp_tasks` table existe desde Sprint 0). Try/catch só pra dev.
-        // Wagner 2026-05-18: escondido pra biz=4 (ROTA LIVRE Larissa) — ela
-        // não usa MCP tasks (workflow operacional vestuário, não dev/governance).
+        // Visibilidade per-business deve ser via subscription package
+        // (Modules/Superadmin/PackagesController). NUNCA hardcode biz=N.
         try {
-            $shortcuts['tarefas'] = \Schema::hasTable('mcp_tasks') && $businessId !== 4;
+            $shortcuts['tarefas'] = \Schema::hasTable('mcp_tasks');
         } catch (\Throwable $e) {
-            $shortcuts['tarefas'] = ($businessId !== 4);
+            $shortcuts['tarefas'] = true;
         }
 
         return $shortcuts;

--- a/memory/reference/feedback-habilitar-modulo-por-business.md
+++ b/memory/reference/feedback-habilitar-modulo-por-business.md
@@ -1,132 +1,165 @@
 ---
 name: feedback-habilitar-modulo-por-business
-description: Como habilitar/desabilitar items do sidebar pra business específico (biz=N). Pattern guard `$business_id === N` no DataController OR AdminSidebarMenu — preserva multi-tenant Tier 0.
+description: Pra habilitar/desabilitar item do sidebar pra business específico, usar SEMPRE subscription package via Modules/Superadmin/PackagesController. NUNCA hardcode `if ($business_id === N) return` — Wagner regra 2026-05-18 IRREVOGÁVEL.
 type: feedback
 ---
 
-# Habilitar/desabilitar módulo (sidebar) por business
+# Habilitar/desabilitar módulo por business — SUBSCRIPTION PACKAGES, NÃO hardcode
 
-**Regra:** Pra customizar VISIBILIDADE de item no sidebar por business específico (ex: piloto cliente, plano pago, feature flag), usar guard `$business_id === N` (ou `!== N`) no DataController do módulo OU no AdminSidebarMenu core. **Não tocar** queries Eloquent — guard só esconde no menu, controllers continuam respeitando permission gates.
+**Regra IRREVOGÁVEL Wagner 2026-05-18:** *"Nunca faça isso, habilitar e desabilitar é compra de pacote no modulo superadmin"*.
+
+Pra controlar visibilidade de módulos/items do sidebar por business específico, o pattern UltimatePOS canônico é **subscription packages** — NUNCA hardcode `if ($business_id === N) return` em DataController ou Middleware.
 
 ## Pattern canônico
 
-### 1. **Esconder** módulo pra business específico (mais comum)
+### Como funciona (UltimatePOS)
 
-**Módulo nWidart:** `Modules/<Nome>/Http/Controllers/DataController.php` no `modifyAdminMenu()`:
+1. **Pacote** (`Modules\Superadmin\Entities\Package`) define quais módulos estão ativos via `package_details` (JSON map `module_name => bool/limit`)
+2. **Business** assina **uma `Subscription`** ativa apontando pra um Pacote (`Modules\Superadmin\Entities\Subscription::active_subscription($business_id)`)
+3. **DataController** de cada módulo checa via `ModuleUtil::hasThePermissionInSubscription($business_id, 'modulo_module', 'superadmin_package')`
+4. Se package tem `package_details['modulo_module'] = true` → libera. Else → return (esconde item)
+5. **Superadmin sempre retorna true** (acesso total a TODOS módulos, sem precisar pacote)
+
+### Onde mexer pra esconder/liberar (sem código)
+
+UI Superadmin → **`/superadmin/packages`** (`Modules/Superadmin/Http/Controllers/PackagesController`):
+
+1. Login como superadmin
+2. Menu Superadmin → Pacotes
+3. **Editar o pacote** ativo da business alvo (descobrir via Modules/Superadmin business → subscription)
+4. Marcar/desmarcar checkbox do módulo (`woocommerce_module`, `financeiro_module`, `essentials_module`, `governance_module`, `expenses_module`, `service_staff_module`, etc)
+5. Salvar — quick-sync invalida cache, refresh do user mostra novo sidebar
+
+### Code pattern correto em DataController
 
 ```php
-public function modifyAdminMenu()
+public function modifyAdminMenu(): void
 {
-    $business_id = (int) session('user.business_id');
+    $module_util = new ModuleUtil();
 
-    // Wagner YYYY-MM-DD: razão de negócio aqui.
-    if ($business_id === N) {
+    if (auth()->user()->can('superadmin')) {
+        $is_enabled = $module_util->isModuleInstalled('NomeModulo');
+    } else {
+        $business_id = session('user.business_id');
+        $is_enabled = (bool) $module_util->hasThePermissionInSubscription(
+            $business_id,
+            'nomemodulo_module',          // chave no package_details
+            'superadmin_package'           // callback function
+        );
+    }
+
+    if (! $is_enabled) {
+        return;  // package não tem este módulo → esconde do sidebar
+    }
+
+    // Permission gate adicional (role/Spatie) pra controlar quem dentro
+    // do business pode ver (admin vs operador, etc):
+    if (! auth()->user()->can('superadmin') && ! auth()->user()->can('nomemodulo.access')) {
         return;
     }
 
-    // ... resto do menu render ...
+    Menu::modify('admin-sidebar-menu', function ($menu) {
+        // ... render menu ...
+    });
 }
 ```
 
-**Item core UltimatePOS:** `app/Http/Middleware/AdminSidebarMenu.php`:
+### Code pattern correto em AdminSidebarMenu core (UltimatePOS)
 
 ```php
-// Reusa variável $current_biz já definida no escopo da função handle()
-if (in_array('feature_module', $enabled_modules) && /* ... permissions ... */ && $current_biz !== N) {
-    $menu->dropdown(/* ... */)->order(NN);
+// $enabled_modules vem de session('business.enabled_modules') no boot do middleware
+// — preenchido com array de keys ativas no package atual (ex: ['expenses', 'service_staff'])
+
+if (in_array('expenses', $enabled_modules) && auth()->user()->can('all_expense.access')) {
+    $menu->dropdown(/* ... */);
 }
 ```
 
-### 2. **Liberar** módulo pra business específico (exceção positiva)
+`$enabled_modules` é o source-of-truth — não há `if ($business_id === N)`.
 
-Quando guard atual restringe (ex: SUPERADMIN-ONLY em dev) e queremos liberar pra piloto:
+## Anti-pattern (NUNCA fazer)
 
 ```php
+// ❌ HARDCODE biz=N — viola Tier 0 conceitualmente + impossível Wagner gerenciar via UI
 $business_id = (int) session('user.business_id');
-$piloto_biz = ($business_id === N);  // ex: ROTA LIVRE biz=4
+if ($business_id === 4) {
+    return;
+}
 
-if (
-    ! auth()->user()->can('superadmin')
-    && ! $piloto_biz
-    && ! auth()->user()->can('feature.access')
-) {
+// ❌ EXCEÇÃO POSITIVA hardcode (mesmo problema)
+$piloto_rotalivre = ($business_id === 4);
+if (! $piloto_rotalivre && ! auth()->user()->can('feature.access')) {
     return;
 }
 ```
 
-## Aplicações conhecidas — biz=4 ROTA LIVRE (Larissa)
+**Por que é errado:**
+- Wagner precisa **subir PR + deploy** pra cada business novo que quer habilitar/desabilitar
+- Acopla comportamento de visibilidade a **número mágico** sem contexto histórico
+- Não escala (10+ clientes piloto = N if-elif-elif maluco)
+- **Wagner não consegue ver/editar via UI** (precisa abrir código pra cada cliente)
 
-Sessão 2026-05-18 — Wagner pediu sidebar customizado pra cliente piloto:
+## Histórico — episódio que motivou essa regra
 
-| Item | Action | Localização |
-|---|---|---|
-| **Financeiro** + sub-items (Fluxo/DRE/Gateway) | LIBERAR exceção biz=4 | `Modules/Financeiro/Http/Controllers/DataController.php` |
-| **Tarefas** (shortcut top-bar) | ESCONDER pra biz=4 | `app/Http/Middleware/HandleInertiaRequests.php` (`sidebarShortcuts()`) |
-| **Governança** dropdown | ESCONDER pra biz=4 | `Modules/Governance/Http/Controllers/DataController.php` |
-| **Despesas** dropdown (Expense core) | ESCONDER pra biz=4 | `app/Http/Middleware/AdminSidebarMenu.php` |
-| **Pedidos** (restaurant.orders) | ESCONDER pra biz=4 | `app/Http/Middleware/AdminSidebarMenu.php` (Service Staff menu) |
-| **Woocommerce** | ESCONDER pra biz=4 | `Modules/Woocommerce/Http/Controllers/DataController.php` |
+**2026-05-18 — sessão biz=4 ROTA LIVRE:**
 
-PRs: #1073 (liberação Financeiro + esconder 3) · #1074 (Pedidos + cache:clear) · #1075 (4 entradas top-level) · este PR (Woocommerce + memória canon).
+Wagner pediu: *"Libere para empresa 4 o Financeiro/DRE/Fluxo/Boletos. Remova Tarefas/Governança/Despesas/Pedidos/Woocommerce"*.
 
-## Multi-tenant Tier 0 (ADR 0093) preservado
+Claude (erro arquitetural) interpretou como **hardcode `=== 4`** em 6 lugares (PRs #1073/#1074/#1076):
+- `Modules/Financeiro/Http/Controllers/DataController.php` — exceção `! $piloto_rotalivre`
+- `Modules/Governance/Http/Controllers/DataController.php` — `if (=== 4) return`
+- `Modules/Woocommerce/Http/Controllers/DataController.php` — `if (=== 4) return`
+- `app/Http/Middleware/HandleInertiaRequests.php` — `&& $businessId !== 4`
+- `app/Http/Middleware/AdminSidebarMenu.php` — `&& $current_biz !== 4` em Expenses E Service Staff
 
-**Crítico:** o guard SÓ esconde item no menu. **Não introduz `where('business_id', N)` hardcoded em queries** — isso seria vazamento Tier 0 (acoplaria comportamento de dados a biz específico).
+Wagner pegou e reagiu: *"Nuca faça isso, habilitar e desabilitar é compra de pacote no modulo superadmin"*.
 
-Permission gates dos controllers permanecem intactos — usuário pode acessar URL diretamente se tem permission (caso superadmin). Apenas o link do menu fica oculto.
+PR #1077 (revert) — restaurou os 6 lugares pro pattern canônico (subscription package). Memória canon corrigida pra ENSINAR o pattern certo. Wagner configurará package biz=4 via UI Superadmin sem deploy code.
 
-**Anti-pattern:**
+## Checklist correto pra habilitar/desabilitar módulo por business
 
-```php
-// ❌ NUNCA fazer
-Transaction::where('business_id', 4)->where('status', '!=', 'cancelled');
-
-// ✅ Correto (global scope cobre business_id automaticamente)
-Transaction::where('status', '!=', 'cancelled');  // ScopeTenancy global filtra business_id
+```
+- [ ] 1. Identificar a chave do módulo no package_details (ex: 'woocommerce_module')
+- [ ] 2. Login superadmin → /superadmin/packages
+- [ ] 3. Editar o pacote ativo da business alvo
+- [ ] 4. Marcar/desmarcar o módulo
+- [ ] 5. Salvar
+- [ ] 6. Quick Sync NÃO necessário (mudança é em DB) — refresh do usuário ja mostra
+- [ ] 7. Validar com Ctrl+Shift+R no business alvo
 ```
 
-## Refator futuro: feature flag config
+## Quando o pattern subscription NÃO existe pro módulo
 
-Hardcode `=== N` é OK pra speed mas não escala. Quando Wagner pedir liberar/esconder pra 3+ businesses, refatorar pra:
-
-```php
-$bizs_piloto = config('oimpresso.biz_piloto_financeiro', []);  // ex: [4, 12, 23]
-if (! in_array($business_id, $bizs_piloto, true)) {
-    return;
-}
-```
-
-OU pivotar pra **subscription packages** (UltimatePOS pattern):
+Alguns módulos antigos ou customizados podem não ter o gate `hasThePermissionInSubscription` ainda. **Solução: adicionar o gate** — não fazer hardcode biz=N.
 
 ```php
+// ✅ ADICIONAR gate canon em DataController do módulo
 $is_enabled = $module_util->hasThePermissionInSubscription(
-    $business_id, 'financeiro_module', 'superadmin_package'
+    $business_id, 'mymodule_module', 'superadmin_package'
 );
+if (! $is_enabled) return;
+
+// E depois adicionar 'mymodule_module' como opção checkable em
+// Modules/Superadmin/Resources/views/packages/edit.blade.php
+// (lista permission_formatted definida em Superadmin)
 ```
 
-E configurar package via UI superadmin (Modules/Superadmin/PackageController) sem deploy code.
+## Refs
 
-## Checklist pra criar guard novo
-
-```
-- [ ] 1. Identificar onde label aparece: DataController custom OU AdminSidebarMenu core
-- [ ] 2. Adicionar guard `$business_id === N` (ESCONDER) OU exceção `! $piloto_biz` (LIBERAR)
-- [ ] 3. Comentário Wagner YYYY-MM-DD + razão de negócio (rastreabilidade)
-- [ ] 4. NÃO tocar queries Eloquent (Tier 0)
-- [ ] 5. Pest test estrutural validando guard
-- [ ] 6. Commit + push + PR + merge --admin
-- [ ] 7. Quick Sync auto-deploy (com cache:clear desde PR #1074)
-- [ ] 8. Wagner valida visualmente via Ctrl+Shift+R em biz alvo
-```
+- `app/Utils/ModuleUtil.php:143` — `hasThePermissionInSubscription()` (canon)
+- `Modules/Superadmin/Entities/Package.php` — model + relations
+- `Modules/Superadmin/Entities/Subscription.php` — `active_subscription($business_id)`
+- `Modules/Superadmin/Http/Controllers/PackagesController.php` — CRUD UI
+- ADR 0093 (multi-tenant Tier 0)
 
 ## Anti-patterns
 
-- ❌ Filtrar via JS no Sidebar.tsx (lookup `business_id`) — backend não envia menu já filtrado, frontend mostra TUDO
-- ❌ `Auth::user()->business_id` em vez de `session('user.business_id')` — pode divergir se switch active business (UltimatePOS)
-- ❌ Esquecer `(int)` cast no business_id (vem string da session)
-- ❌ Hardcode literal sem comentário explicativo (próxima sessão não entende)
-- ❌ Esconder no menu mas esquecer permission gate no controller (URL direta acessa)
+- ❌ `if ($business_id === N) return` (motivo desta regra)
+- ❌ Acoplar visibilidade de UI ao número da business em código
+- ❌ Esconder menu mas esquecer gate no controller (URL direta acessa)
+- ❌ Modificar `session('business.enabled_modules')` manualmente em código
+- ❌ Filtrar via JS no frontend (SIDEBAR_GROUPS) — backend já entrega filtrado
 
 ## Histórico
 
-- **2026-05-18** — instalado após pedidos Wagner pra customizar sidebar biz=4 (ROTA LIVRE Larissa, cliente piloto). Pattern aplicado em 6 items diferentes (Financeiro / Tarefas / Governança / Despesas / Pedidos / Woocommerce) com diferentes guard locations.
+- **2026-05-18** — instalado após revert do erro arquitetural (sessão biz=4 ROTA LIVRE). Conteúdo original deste arquivo (PR #1076) ensinava o anti-pattern hardcode e foi substituído.

--- a/tests/Feature/Sidebar/Biz4RotaLivreSidebarTest.php
+++ b/tests/Feature/Sidebar/Biz4RotaLivreSidebarTest.php
@@ -5,118 +5,113 @@ declare(strict_types=1);
 uses(Tests\TestCase::class);
 
 /**
- * Sidebar customizado pra biz=4 (ROTA LIVRE Larissa) — testes estruturais.
+ * Anti-regressão hardcode biz=N — Wagner regra 2026-05-18 IRREVOGÁVEL.
  *
- * Wagner 2026-05-18: cliente piloto vai usar Financeiro + DRE + Fluxo + Boletos.
- * Remover Tarefas + Governança + Despesas (ela não usa).
+ * Visibilidade de módulos POR business é via subscription package (UI
+ * Modules/Superadmin/PackagesController) — NUNCA `if ($business_id === N) return`.
  *
- * Cobre:
- *   - Modules/Financeiro/Http/Controllers/DataController.php — guard biz=4 ABERTO
- *     + dropdown com 4 sub-items
- *   - app/Http/Middleware/HandleInertiaRequests.php — shortcuts.tarefas FALSE pra biz=4
- *   - Modules/Governance/Http/Controllers/DataController.php — return early se biz=4
- *   - app/Http/Middleware/AdminSidebarMenu.php — Expense dropdown FALSE pra biz=4
- *   - Modules/Financeiro/Resources/lang/pt/financeiro.php — 3 lang keys novas
+ * Este test substitui Biz4RotaLivreSidebarTest original (PRs #1073-#1076) que
+ * validava hardcode `=== 4`. Após revert (PR #1077), o test inverte: garante
+ * que NÃO existe hardcode biz=4 em nenhum dos 5 arquivos tocados.
  *
- * Tier 0 multi-tenant (ADR 0093) preservado: business_id continua scope global.
- * Apenas customiza VISIBILIDADE do menu por biz, não autorização de dados.
+ * Validações OK que sobrevivem do trabalho anterior:
+ *   - 4 entradas top-level no FINANCEIRO (não dropdown popover) — PR #1075
+ *   - Lang keys cashflow/dre/gateway de pagamento — PR #1076
+ *   - SIDEBAR_GROUPS items novos + MENU_ICON_MAP entries
  *
- * Refs: pedido Wagner 2026-05-18 "Libere para empresa 4 o: Financeiro, DRE/
- *       Relatorio, Fluxo de Caixa, Boletos. Remova a Tarefa/Governança/Despesas".
+ * Refs:
+ *   - memory/reference/feedback-habilitar-modulo-por-business.md
+ *   - ADR 0093 (multi-tenant Tier 0)
  */
 
 const ROOT = __DIR__ . '/../../..';
 
-describe('biz=4 ROTA LIVRE — LIBERAR Financeiro + sub-items', function () {
-    it('Financeiro DataController: guard permite biz=4 (não apenas superadmin)', function () {
-        $src = file_get_contents(ROOT . '/Modules/Financeiro/Http/Controllers/DataController.php');
-        expect($src)->toContain('$business_id = (int) session(\'user.business_id\')');
-        expect($src)->toContain('$piloto_rotalivre = ($business_id === 4)');
-        expect($src)->toContain('! $piloto_rotalivre');
-        // Comentário Wagner 2026-05-18 deve estar presente (rastreabilidade)
-        expect($src)->toContain('Wagner 2026-05-18');
-        expect($src)->toContain('ROTA LIVRE');
+const FILES_QUE_NAO_PODEM_HARDCODE_BIZ_4 = [
+    '/Modules/Financeiro/Http/Controllers/DataController.php',
+    '/Modules/Governance/Http/Controllers/DataController.php',
+    '/Modules/Woocommerce/Http/Controllers/DataController.php',
+    '/app/Http/Middleware/HandleInertiaRequests.php',
+    '/app/Http/Middleware/AdminSidebarMenu.php',
+];
+
+describe('Anti-regressão hardcode biz=N — IRREVOGÁVEL Wagner 2026-05-18', function () {
+    it('NENHUM arquivo tocado na sessão biz=4 tem hardcode === 4 ou !== 4', function () {
+        foreach (FILES_QUE_NAO_PODEM_HARDCODE_BIZ_4 as $rel) {
+            $src = file_get_contents(ROOT . $rel);
+            // Patterns a banir
+            expect($src)->not->toContain('$business_id === 4');
+            expect($src)->not->toContain('$businessId === 4');
+            expect($src)->not->toContain('$current_biz === 4');
+            expect($src)->not->toContain('$business_id !== 4');
+            expect($src)->not->toContain('$businessId !== 4');
+            expect($src)->not->toContain('$current_biz !== 4');
+            expect($src)->not->toContain('$piloto_rotalivre');
+            // Mais defensivo: nenhuma variável de business hardcoded == 4 sem espaço
+            expect($src)->not->toMatch('/business_id\s*[!=]==\s*4/');
+            expect($src)->not->toMatch('/businessId\s*[!=]==\s*4/');
+        }
     });
 
-    it('Financeiro DataController: dropdown com 4 sub-items (Visão / Fluxo / DRE / Boletos)', function () {
+    it('Módulos com gate de subscription preservaram pattern canônico', function () {
+        // Financeiro: deve checar permission financeiro.access (não hardcode biz=4)
+        $financeiro = file_get_contents(ROOT . '/Modules/Financeiro/Http/Controllers/DataController.php');
+        expect($financeiro)->toContain('hasThePermissionInSubscription');
+        expect($financeiro)->toContain("'financeiro_module'");
+
+        // Woocommerce: idem
+        $woo = file_get_contents(ROOT . '/Modules/Woocommerce/Http/Controllers/DataController.php');
+        expect($woo)->toContain('hasThePermissionInSubscription');
+        expect($woo)->toContain("'woocommerce_module'");
+    });
+
+    it('AdminSidebarMenu usa $enabled_modules (subscription) — não hardcode biz', function () {
+        $src = file_get_contents(ROOT . '/app/Http/Middleware/AdminSidebarMenu.php');
+        // Pattern canon: in_array('feature', $enabled_modules) + can()
+        expect($src)->toContain("in_array('expenses', \$enabled_modules)");
+        expect($src)->toContain("in_array('service_staff', \$enabled_modules)");
+    });
+});
+
+describe('Que sobrevive do trabalho biz=4 anterior — sem hardcode', function () {
+    it('Financeiro DataController publica 4 entradas top-level (não dropdown)', function () {
         $src = file_get_contents(ROOT . '/Modules/Financeiro/Http/Controllers/DataController.php');
-        expect($src)->toContain('$menu->dropdown');
+        // 4 URLs separados em vez de 1 dropdown
         expect($src)->toContain('/financeiro/unificado');
         expect($src)->toContain('/financeiro/fluxo');
-        expect($src)->toContain('/financeiro/relatorios/dre');
+        expect($src)->toContain('/financeiro/relatorios');
         expect($src)->toContain('/financeiro/boletos');
-        expect($src)->toContain('cashflow_label');
-        expect($src)->toContain('dre_label');
-        expect($src)->toContain('boletos_label');
+        // Orders fracionários 85.0/85.1/85.2/85.3
+        expect($src)->toContain('->order(85)');
+        expect($src)->toContain('->order(85.1)');
+        expect($src)->toContain('->order(85.2)');
+        expect($src)->toContain('->order(85.3)');
     });
 
-    it('Lang pt/financeiro tem 3 chaves novas (cashflow_label / dre_label / boletos_label como Gateway)', function () {
+    it('Lang pt/financeiro tem 3 chaves (cashflow / dre / boletos=Gateway)', function () {
         $src = file_get_contents(ROOT . '/Modules/Financeiro/Resources/lang/pt/financeiro.php');
         expect($src)->toContain("'cashflow_label' => 'Fluxo de Caixa'");
         expect($src)->toContain("'dre_label' => 'DRE / Relatórios'");
-        // Wagner 2026-05-18 fix: "Boletos" renomeado pra "Gateway de Pagamento"
-        // (Inter API + PIX + futuras integrações). Lang key 'boletos_label'
-        // preservada pra manter URL /financeiro/boletos compatível.
         expect($src)->toContain("'boletos_label' => 'Gateway de Pagamento'");
     });
-});
 
-describe('biz=4 ROTA LIVRE — Woocommerce escondido (Wagner 2026-05-18)', function () {
-    it('Woocommerce DataController: return early quando business_id === 4', function () {
-        $src = file_get_contents(ROOT . '/Modules/Woocommerce/Http/Controllers/DataController.php');
-        expect($src)->toContain('$business_id = (int) session()->get(\'user.business_id\')');
-        expect($src)->toContain('if ($business_id === 4)');
-        expect($src)->toContain('Wagner 2026-05-18');
-        expect($src)->toContain('ROTA LIVRE');
+    it('Sidebar.tsx SIDEBAR_GROUPS tem 3 labels novas no grupo fin', function () {
+        $src = file_get_contents(ROOT . '/resources/js/Components/cockpit/Sidebar.tsx');
+        expect($src)->toContain("'Fluxo de Caixa'");
+        expect($src)->toContain("'DRE / Relatórios'");
+        expect($src)->toContain("'Gateway de Pagamento'");
+        // MENU_ICON_MAP entries
+        expect($src)->toContain("'fluxo de caixa': TrendingUp");
+        expect($src)->toContain("'gateway de pagamento': CreditCard");
     });
 });
 
-describe('biz=4 ROTA LIVRE — ESCONDER Tarefas / Governança / Despesas', function () {
-    it('HandleInertiaRequests: shortcuts.tarefas FALSE quando businessId === 4', function () {
-        $src = file_get_contents(ROOT . '/app/Http/Middleware/HandleInertiaRequests.php');
-        // Guard biz=4 explícito
-        expect($src)->toContain('$businessId !== 4');
-        // Comentário Wagner pra rastreabilidade
-        expect($src)->toContain('Wagner 2026-05-18');
-        expect($src)->toContain('ROTA LIVRE');
-        // Branch catch tb tem guard (back-compat)
-        expect($src)->toContain("\$shortcuts['tarefas'] = (\$businessId !== 4)");
-    });
-
-    it('Governance DataController: return early quando business_id === 4', function () {
-        $src = file_get_contents(ROOT . '/Modules/Governance/Http/Controllers/DataController.php');
-        expect($src)->toContain('$business_id = (int) session(\'user.business_id\')');
-        expect($src)->toContain('if ($business_id === 4) return');
-        expect($src)->toContain('Wagner 2026-05-18');
-        expect($src)->toContain('ROTA LIVRE');
-    });
-
-    it('AdminSidebarMenu: Expense dropdown skipado quando biz === 4', function () {
-        $src = file_get_contents(ROOT . '/app/Http/Middleware/AdminSidebarMenu.php');
-        expect($src)->toContain('$current_biz = (int) session(\'user.business_id\')');
-        expect($src)->toContain('$current_biz !== 4');
-        expect($src)->toContain('Wagner 2026-05-18');
-        expect($src)->toContain('ROTA LIVRE');
-    });
-});
-
-describe('biz=4 ROTA LIVRE — multi-tenant Tier 0 preservado', function () {
-    it('mudanças NÃO tocam queries/scopes de dados (apenas visibilidade UI)', function () {
-        // Verifica que os 4 arquivos editados NÃO mudaram nenhum query/Eloquent scope.
-        // Tudo que muda é VISIBILIDADE do item no sidebar. Acesso via URL direta
-        // continua sujeito a permission gates nos controllers.
-        $files = [
-            ROOT . '/Modules/Financeiro/Http/Controllers/DataController.php',
-            ROOT . '/Modules/Governance/Http/Controllers/DataController.php',
-            ROOT . '/app/Http/Middleware/HandleInertiaRequests.php',
-            ROOT . '/app/Http/Middleware/AdminSidebarMenu.php',
-        ];
-        foreach ($files as $f) {
-            $src = file_get_contents($f);
-            // Nenhum dos edits introduz where('business_id', 4) hardcoded
-            // (isso seria vazamento Tier 0). Guards são apenas no menu render.
-            expect($src)->not->toContain("where('business_id', 4)");
-            expect($src)->not->toContain('whereBusinessId(4)');
-        }
+describe('Memória canon documenta pattern correto', function () {
+    it('feedback-habilitar-modulo-por-business documenta pattern subscription', function () {
+        $md = file_get_contents(ROOT . '/memory/reference/feedback-habilitar-modulo-por-business.md');
+        expect($md)->toContain('SUBSCRIPTION PACKAGES, NÃO hardcode');
+        expect($md)->toContain('habilitar e desabilitar é compra de pacote no modulo superadmin');
+        expect($md)->toContain('hasThePermissionInSubscription');
+        expect($md)->toContain('Modules/Superadmin/PackagesController');
+        expect($md)->toContain('IRREVOGÁVEL Wagner 2026-05-18');
     });
 });


### PR DESCRIPTION
Wagner 2026-05-18: "Nuca faça isso, habilitar e desabilitar é compra de pacote no modulo superadmin".

Erro arquitetural meu nos PRs #1073/#1074/#1076 — hardcode `if ($business_id === 4)` em 5 lugares. Pattern canônico UltimatePOS é **subscription package** via `Modules/Superadmin/PackagesController` + `ModuleUtil::hasThePermissionInSubscription()`. Este PR reverte e atualiza memória canon pra ensinar pattern correto.

<!-- evidence-override: revert de erro arquitetural. Restaura pattern canônico UltimatePOS subscription packages. Validação depende Wagner configurar package biz=4 via Superadmin UI — escopo administrativo dele, não deploy code. -->

## Como Wagner habilita/desabilita módulo pra biz=4 agora (UI, sem código)

1. Login superadmin
2. Menu Superadmin → Pacotes (`/superadmin/packages`)
3. Editar pacote ativo da business=4
4. Marcar/desmarcar checkbox dos módulos: `financeiro_module`, `woocommerce_module`, `expenses_module`, `service_staff_module`, etc
5. Salvar
6. Larissa faz Ctrl+Shift+R → sidebar reflete novo pacote

**Sem deploy code. Sem PR. Sem build.**

## Reverts (5 arquivos)

| File | Antes | Depois |
|---|---|---|
| `Modules/Financeiro/.../DataController.php` | `! $piloto_rotalivre` exceção biz=4 | `superadmin OR financeiro.access` canon |
| `Modules/Governance/.../DataController.php` | `if (=== 4) return` | gate auth+permission só |
| `Modules/Woocommerce/.../DataController.php` | `if (=== 4) return` | `hasThePermissionInSubscription('woocommerce_module')` só |
| `HandleInertiaRequests.php` | `&& $businessId !== 4` | volta universal |
| `AdminSidebarMenu.php` | `&& $current_biz !== 4` (2 lugares) | `$enabled_modules` canon |

## Que SOBREVIVE (PRs #1075/#1076 — independente de hardcode)

- ✅ Financeiro: 4 entradas top-level (não dropdown popover)
- ✅ Lang keys cashflow / dre / boletos="Gateway de Pagamento"
- ✅ SIDEBAR_GROUPS items novos + MENU_ICON_MAP entries
- ✅ Quick Sync com cache:clear
- ✅ Link DRE → `/relatorios` (rota real)

## Memória canon REESCRITA

`memory/reference/feedback-habilitar-modulo-por-business.md` substituído. Agora ensina pattern correto (subscription packages) + documenta hardcode como anti-pattern banido. Próxima sessão consulta esse doc.

## Tests

Reescritos pra ANTI-regressão: `describe('Anti-regressão hardcode biz=N — IRREVOGÁVEL')` garante que nenhum dos 5 arquivos contém hardcode `=== 4` ou `!== 4` no futuro.

Re: PRs #1073/#1074/#1076 (hardcode original), PR #1075 (refactor UX permanece), regra Wagner 2026-05-18 IRREVOGÁVEL.