### PR TITLE
docs(tier-0): eleva regra subscription packages pra Tier 0 IRREVOGÁVEL (junto com business_id)

### DIFF
--- a/memory/proibicoes.md
+++ b/memory/proibicoes.md
@@ -140,6 +140,7 @@
 - ⛔ **Job assíncrono SEMPRE passa `$businessId`** no constructor — `session()` não funciona em fila
 - ⛔ **Tabela de negócio nova obrigatoriamente** tem `business_id` indexado + FK
 - ⛔ **PII reais (CPF/CNPJ cliente) NUNCA em PR/commit/log** — use `[REDACTED]` ou `PiiRedactor`
+- ⛔ **NUNCA hardcode `if ($business_id === N) return` pra esconder/liberar módulo do sidebar.** Habilitar/desabilitar feature por business é SEMPRE via **subscription package** (UI `Modules/Superadmin/PackagesController` → marcar/desmarcar `X_module` no `package_details`). DataController consulta via `ModuleUtil::hasThePermissionInSubscription($business_id, 'X_module', 'superadmin_package')` — JÁ existe pattern canônico no UltimatePOS, NÃO improvisar. **Origem:** Wagner regra IRREVOGÁVEL 2026-05-18 *"Nuca faça isso, habilitar e desabilitar é compra de pacote no modulo superadmin"* após PR #1077 reverter 5 hardcodes errados (#1073/#1074/#1076). Pareia conceitualmente com `business_id` global scope — Wagner: *"Regra basica junto com Business_id acho que não porderia ser diferente"*. Detalhe + pattern correto + UI step-by-step em [`memory/reference/feedback-habilitar-modulo-por-business.md`](reference/feedback-habilitar-modulo-por-business.md). Pest anti-regressão: [`tests/Feature/Sidebar/Biz4RotaLivreSidebarTest.php`](../tests/Feature/Sidebar/Biz4RotaLivreSidebarTest.php) bloqueia patterns `=== N`/`!== N` em 5 arquivos canon.
 
 ## FSM Pipeline Canônico ([ADR 0143](decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md) — LIVE prod biz=1 desde 2026-05-12)
 

--- a/memory/reference/_INDEX.md
+++ b/memory/reference/_INDEX.md
@@ -86,7 +86,7 @@
 - [feedback-revert-isolar-client.md](feedback-revert-isolar-client.md) — Antes reverter PR em prod, isolar client-side primeiro
 - [feedback-tenancy-pest-local.md](feedback-tenancy-pest-local.md) — Mudanças tenancy exigem Pest verde local antes de PR
 - [feedback-test-biz-99-cross-tenant.md](feedback-test-biz-99-cross-tenant.md) — biz=1 default; biz=99 cross-tenant (não biz=4 cliente real)
-- [feedback-habilitar-modulo-por-business.md](feedback-habilitar-modulo-por-business.md) — Esconder/liberar item sidebar pra biz=N específico. Pattern guard `$business_id === N` no DataController OR AdminSidebarMenu — preserva Tier 0. PRs #1073-#1075 + este (Wagner ROTA LIVRE)
+- [feedback-habilitar-modulo-por-business.md](feedback-habilitar-modulo-por-business.md) — **Tier 0 IRREVOGÁVEL** (lado a lado com `business_id` global scope em [proibicoes.md](../proibicoes.md)). Habilitar/desabilitar módulo por business = SEMPRE subscription package via Modules/Superadmin/PackagesController. NUNCA `if ($business_id === N) return`. Wagner regra 2026-05-18.
 
 ## Workflow & triggers
 

--- a/memory/reference/feedback-habilitar-modulo-por-business.md
+++ b/memory/reference/feedback-habilitar-modulo-por-business.md
@@ -1,10 +1,12 @@
 ---
 name: feedback-habilitar-modulo-por-business
-description: Pra habilitar/desabilitar item do sidebar pra business específico, usar SEMPRE subscription package via Modules/Superadmin/PackagesController. NUNCA hardcode `if ($business_id === N) return` — Wagner regra 2026-05-18 IRREVOGÁVEL.
+description: Pra habilitar/desabilitar item do sidebar pra business específico, usar SEMPRE subscription package via Modules/Superadmin/PackagesController. NUNCA hardcode `if ($business_id === N) return` — Wagner regra 2026-05-18 IRREVOGÁVEL (Tier 0 lado a lado com business_id global scope).
 type: feedback
 ---
 
 # Habilitar/desabilitar módulo por business — SUBSCRIPTION PACKAGES, NÃO hardcode
+
+> **Status:** Tier 0 IRREVOGÁVEL — catalogada em [`memory/proibicoes.md`](../proibicoes.md) §"Multi-tenant Tier 0" lado a lado com `business_id` global scope (ADR 0093). Wagner palavras textuais 2026-05-18: *"Regra basica junto com Business_id acho que não porderia ser diferente"*.
 
 **Regra IRREVOGÁVEL Wagner 2026-05-18:** *"Nunca faça isso, habilitar e desabilitar é compra de pacote no modulo superadmin"*.
 


### PR DESCRIPTION
Wagner 2026-05-18: **"Regra basica junto com Business_id acho que não porderia ser diferente"**.

Eleva a regra do PR #1077 (subscription packages canon, não hardcode biz=N) pra **Tier 0 IRREVOGÁVEL** em `memory/proibicoes.md` — lado a lado com `business_id` global scope (ADR 0093).

Pareia conceitualmente:
- **business_id global scope** → protege **ISOLAMENTO de dados** entre tenants
- **Subscription packages** → protege **ISOLAMENTO de features/visibilidade** entre tenants

Ambas são fundações multi-tenant. Sem regra em Tier 0 visível, alguém vai cair no mesmo erro arquitetural (hardcode `if ($business_id === N) return` escondendo módulo).

## Changes

| File | Change |
|---|---|
| `memory/proibicoes.md` | +1 bullet em §"Multi-tenant Tier 0 IRREVOGÁVEL" — cita Wagner + cross-ref pra feedback canon e Pest anti-regressão |
| `memory/reference/feedback-habilitar-modulo-por-business.md` | Header reescrito: "Status: Tier 0 IRREVOGÁVEL — catalogada em proibicoes.md§Multi-tenant Tier 0" |
| `memory/reference/_INDEX.md` | Entrada feedback canon marcada como "Tier 0 IRREVOGÁVEL (lado a lado com business_id global scope)" |

## Por que importa pra time MCP

Time MCP (Felipe/Maiara/Eliana/Luiz) entra em breve. Memória canon comum (sem tier marcado) NÃO carrega no SessionStart de Claude por padrão; `proibicoes.md` SIM (via skill enforcement Tier A always-on). Elevar pra Tier 0 garante que regra IRREVOGÁVEL chega em TODA sessão automaticamente.

Re: PR #1077 (revert hardcode biz=4), Wagner regra 2026-05-18 IRREVOGÁVEL, ADR 0093 (multi-tenant Tier 0).