### PR TITLE
feat(governance): adiciona gate subscription canon — governance_module configurável via UI Superadmin

### DIFF
--- a/Modules/Governance/Http/Controllers/DataController.php
+++ b/Modules/Governance/Http/Controllers/DataController.php
@@ -2,6 +2,7 @@
 
 namespace Modules\Governance\Http\Controllers;
 
+use App\Utils\ModuleUtil;
 use Illuminate\Routing\Controller;
 use Menu;
 
@@ -9,6 +10,11 @@ use Menu;
  * DataController do módulo Governance — descoberto via AdminSidebarMenu.
  *
  * ADR 0086 MVP — UI única `/governance` (dashboard consolidado).
+ *
+ * Visibilidade per-business via subscription package (`governance_module`
+ * em `package_details`). Configurável via `/superadmin/packages` UI.
+ * NUNCA hardcode `if ($business_id === N) return` — Wagner regra
+ * IRREVOGÁVEL Tier 0 2026-05-18 (`memory/proibicoes.md`).
  */
 class DataController extends Controller
 {
@@ -48,11 +54,30 @@ class DataController extends Controller
     {
         if (!auth()->check()) return;
 
+        $module_util = new ModuleUtil();
+
+        // Gate 1: pacote subscription (configurável via UI Superadmin/Packages).
+        // Superadmin: módulo instalado é suficiente (acesso total).
+        // Usuário comum: depende do business ter `governance_module` ativo
+        // no pacote — Wagner pode marcar/desmarcar via UI sem deploy code.
+        if (auth()->user()->can('superadmin')) {
+            $is_enabled = $module_util->isModuleInstalled('Governance');
+        } else {
+            $business_id = session()->get('user.business_id');
+            $is_enabled  = (bool) $module_util->hasThePermissionInSubscription(
+                $business_id,
+                'governance_module',
+                'superadmin_package'
+            );
+        }
+
+        if (! $is_enabled) {
+            return;
+        }
+
+        // Gate 2: permission Spatie do usuário (role-based dentro do business).
         $user = auth()->user();
         if (!$user->can('governance.dashboard.view')) return;
-
-        // Visibilidade per-business é via subscription package
-        // (Modules/Superadmin/PackagesController). NUNCA hardcode biz=N.
 
         Menu::modify('admin-sidebar-menu', function ($menu) {
             $menu->url(

--- a/Modules/Governance/Tests/Feature/GovernanceModuleSubscriptionGateTest.php
+++ b/Modules/Governance/Tests/Feature/GovernanceModuleSubscriptionGateTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Governance: gate subscription canon — `governance_module` configurável via
+ * UI Superadmin/Packages.
+ *
+ * Wagner regra IRREVOGÁVEL 2026-05-18: visibilidade de módulos é via
+ * subscription package — NUNCA hardcode `if ($business_id === N) return`.
+ *
+ * Cobre:
+ *   - superadmin_package() declara 'governance_module' permission
+ *   - user_permissions() declara 'governance.dashboard.view'
+ *   - modifyAdminMenu() consulta hasThePermissionInSubscription (não hardcode)
+ *
+ * Multi-tenant Tier 0 (ADR 0093) preservado.
+ *
+ * Refs:
+ *   - memory/proibicoes.md §"Multi-tenant Tier 0 IRREVOGÁVEL"
+ *   - memory/reference/feedback-habilitar-modulo-por-business.md
+ *   - tests/Feature/Sidebar/Biz4RotaLivreSidebarTest.php (anti-regressão geral)
+ */
+
+const GOV_DC = __DIR__ . '/../../Http/Controllers/DataController.php';
+
+describe('Governance — subscription package canon', function () {
+    it('superadmin_package() declara governance_module permission', function () {
+        $src = file_get_contents(GOV_DC);
+        expect($src)->toContain("'name'    => 'governance_module'");
+        expect($src)->toContain('superadmin_package');
+    });
+
+    it('user_permissions() declara governance.dashboard.view', function () {
+        $src = file_get_contents(GOV_DC);
+        expect($src)->toContain("'value'   => 'governance.dashboard.view'");
+        expect($src)->toContain('user_permissions');
+    });
+
+    it('modifyAdminMenu() consulta hasThePermissionInSubscription (gate canon)', function () {
+        $src = file_get_contents(GOV_DC);
+        expect($src)->toContain('hasThePermissionInSubscription');
+        expect($src)->toContain("'governance_module'");
+        expect($src)->toContain("'superadmin_package'");
+        // Superadmin bypass canon
+        expect($src)->toContain("isModuleInstalled('Governance')");
+    });
+
+    it('modifyAdminMenu() preserva permission user Spatie (gate 2)', function () {
+        $src = file_get_contents(GOV_DC);
+        expect($src)->toContain("can('governance.dashboard.view')");
+    });
+});
+
+describe('Governance — anti-regressão hardcode biz=N', function () {
+    it('NÃO contém hardcode `$business_id === N` ou similar (Wagner regra Tier 0)', function () {
+        $src = file_get_contents(GOV_DC);
+        expect($src)->not->toMatch('/business_id\s*[!=]==\s*\d+/');
+        expect($src)->not->toContain('$piloto_rotalivre');
+        expect($src)->not->toContain('=== 4');
+        expect($src)->not->toContain('!== 4');
+    });
+
+    it('Cita regra Tier 0 IRREVOGÁVEL no docblock (rastreabilidade)', function () {
+        $src = file_get_contents(GOV_DC);
+        expect($src)->toContain('IRREVOGÁVEL');
+        expect($src)->toContain('2026-05-18');
+    });
+});

--- a/memory/reference/feedback-habilitar-modulo-por-business.md
+++ b/memory/reference/feedback-habilitar-modulo-por-business.md
@@ -146,6 +146,116 @@ if (! $is_enabled) return;
 // (lista permission_formatted definida em Superadmin)
 ```
 
+## Lista de módulos com gate canônico (descoberta em prod 2026-05-18)
+
+24+ chaves consultáveis via UI Superadmin/Packages:
+
+| Módulo | Chave package_details | Permission Spatie principal |
+|---|---|---|
+| Accounting (Contabilidade) | `accounting_module` | `accounting.view_account_summary` |
+| ADS | `ads_module` | `ads.access` |
+| Asset Management (Gestão de Ativos) | `assetmanagement_module` | `asset_management.view_asset` |
+| Auditoria | `auditoria_module` | `auditoria.view` |
+| CRM | `crm_module` | `crm.access` |
+| Comunicação Visual | `comunicacaovisual_module` | `comunicacaovisual.access` |
+| Connector | `connector_module` | `connector.access` |
+| Consulta OS (Portal) | `consultaos_module` | `consultaos.access` |
+| Essentials (Tarefas/Mensagens/Docs) | `essentials_module` | `essentials.access` |
+| Financeiro | `financeiro_module` | `financeiro.access` |
+| **Governance** ★ novo PR #1079 | `governance_module` | `governance.dashboard.view` |
+| Jana / Copiloto | `copiloto_module` | `copiloto.access` |
+| Knowledge Base (KB) | `kb_module` | `kb.access` |
+| Manufacturing (Fabricação) | `manufacturing_module` | `manufacturing.view` |
+| NF-e Brasil | `nfebrasil_module` | `nfebrasil.access` |
+| NFS-e | `nfse_module` | `nfse.access` |
+| Oficina Auto | `oficinaauto_module` | `oficinaauto.access` |
+| Ponto | `ponto_module` | `ponto.access` |
+| Product Catalogue | `productcatalogue_module` | `productcatalogue.access` |
+| Project Mgmt | `projectmgmt_module` | `projectmgmt.access` |
+| Recurring Billing (Cobrança Recorrente) | `recurringbilling_module` | `recurringbilling.access` |
+| Repair (Reparar) | `repair_module` | `repair.access` |
+| WhatsApp | `whatsapp_module` | `whatsapp.access` |
+| Woocommerce | `woocommerce_module` | `woocommerce.access_*` |
+
+**Core UltimatePOS** (gate via `session('business.enabled_modules')` array, configurável também no Package):
+- `expenses` (Despesas)
+- `service_staff` (Pedidos / Restaurant Orders)
+- `kitchen` (Cocina)
+- `tables` (Mesas)
+- `booking` (Reservas)
+- `modifiers` (Modificadores)
+
+## Caso o módulo NÃO tenha gate canônico — como criar (pattern PR #1079)
+
+Se ao auditar um módulo você descobrir que ele **não tem** `superadmin_package()` registrando uma `_module` permission, **adicione** seguindo este pattern (caso Governance PR #1079):
+
+```php
+// Modules/<Nome>/Http/Controllers/DataController.php
+
+use App\Utils\ModuleUtil;
+
+class DataController extends Controller
+{
+    // 1. Registrar permission package — aparece como checkbox em /superadmin/packages
+    public function superadmin_package(): array
+    {
+        return [
+            [
+                'name'    => 'nomemodulo_module',
+                'label'   => __('nomemodulo::nomemodulo.module_label'),
+                'default' => false,  // false = pacotes novos não vêm com módulo ativo
+            ],
+        ];
+    }
+
+    // 2. (opcional) Permissions Spatie do usuário — role-based dentro do business
+    public function user_permissions(): array
+    {
+        return [
+            [ 'value' => 'nomemodulo.access', 'label' => '...', 'default' => false ],
+        ];
+    }
+
+    // 3. modifyAdminMenu() com 3 gates em ordem
+    public function modifyAdminMenu(): void
+    {
+        if (! auth()->check()) return;
+        $module_util = new ModuleUtil();
+
+        // Gate 1: pacote subscription
+        if (auth()->user()->can('superadmin')) {
+            $is_enabled = $module_util->isModuleInstalled('NomeModulo');
+        } else {
+            $business_id = session()->get('user.business_id');
+            $is_enabled = (bool) $module_util->hasThePermissionInSubscription(
+                $business_id, 'nomemodulo_module', 'superadmin_package'
+            );
+        }
+        if (! $is_enabled) return;
+
+        // Gate 2: permission Spatie do usuário
+        if (! auth()->user()->can('superadmin') && ! auth()->user()->can('nomemodulo.access')) {
+            return;
+        }
+
+        // Gate 3: render menu
+        Menu::modify('admin-sidebar-menu', function ($menu) { /* ... */ });
+    }
+}
+```
+
+E **registrar Pest estrutural** garantindo que NÃO há hardcode (template em `Modules/Governance/Tests/Feature/GovernanceModuleSubscriptionGateTest.php`).
+
+## Defesas técnicas que previnem reincidência
+
+| Camada | Onde | O que faz |
+|---|---|---|
+| 1. Memória canônica | [`memory/proibicoes.md`](../proibicoes.md) §Multi-tenant Tier 0 IRREVOGÁVEL | Carrega em TODA sessão Claude via SessionStart hook |
+| 2. Memória detalhada | Este arquivo + cross-link em `_INDEX.md` | Time MCP (Felipe/Maiara/Eliana/Luiz) consulta via tools MCP |
+| 3. Pest anti-regressão geral | [`tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest.php`](../../tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest.php) | Varre TODOS DataControllers + Middlewares + Controllers em CI. Bloqueia merge se qualquer um introduzir `$business_id === N` hardcode |
+| 4. Pest test específico biz=4 | [`tests/Feature/Sidebar/Biz4RotaLivreSidebarTest.php`](../../tests/Feature/Sidebar/Biz4RotaLivreSidebarTest.php) | Anti-regressão histórica dos 5 arquivos tocados na sessão 2026-05-18 |
+| 5. Pest test específico Governance | `Modules/Governance/Tests/Feature/GovernanceModuleSubscriptionGateTest.php` | Garante que gate canônico permanece + sem hardcode |
+
 ## Refs
 
 - `app/Utils/ModuleUtil.php:143` — `hasThePermissionInSubscription()` (canon)
@@ -153,6 +263,8 @@ if (! $is_enabled) return;
 - `Modules/Superadmin/Entities/Subscription.php` — `active_subscription($business_id)`
 - `Modules/Superadmin/Http/Controllers/PackagesController.php` — CRUD UI
 - ADR 0093 (multi-tenant Tier 0)
+- `memory/proibicoes.md` §"Multi-tenant Tier 0 IRREVOGÁVEL" (Tier 0)
+- `Modules/Auditoria/Http/Controllers/DataController.php` — template canônico de referência
 
 ## Anti-patterns
 

--- a/tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest.php
+++ b/tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest.php
@@ -1,0 +1,200 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * ARCHITECTURE TEST — Anti-regressão GLOBAL hardcode business_id.
+ *
+ * Wagner regra IRREVOGÁVEL Tier 0 2026-05-18:
+ *   "Nuca faça isso, habilitar e desabilitar é compra de pacote no modulo
+ *    superadmin"
+ *   "Regra basica junto com Business_id acho que não porderia ser diferente"
+ *
+ * Visibilidade de módulos por business é via **subscription package** (UI
+ * Modules/Superadmin/PackagesController) — NUNCA hardcode
+ * `if ($business_id === N) return` em DataController ou Middleware.
+ *
+ * Este test varre TODOS os arquivos canônicos (não só os 5 da sessão
+ * 2026-05-18) — proteção defense-in-depth contra reincidência futura.
+ *
+ * Catalogado pós-erro arquitetural Claude (PRs #1073/#1074/#1076 revertidos
+ * pelo PR #1077, regra elevada Tier 0 pelo PR #1078).
+ *
+ * Refs:
+ *   - memory/proibicoes.md §"Multi-tenant Tier 0 IRREVOGÁVEL"
+ *   - memory/reference/feedback-habilitar-modulo-por-business.md
+ *   - tests/Feature/Sidebar/Biz4RotaLivreSidebarTest.php (anti-regressão específica)
+ *   - Modules/Governance/Tests/Feature/GovernanceModuleSubscriptionGateTest.php
+ *
+ * @group architecture
+ */
+
+const PROJECT_ROOT = __DIR__ . '/../../..';
+
+/**
+ * Patterns proibidos (regex). Cada match em arquivo canônico = falha.
+ *
+ * Foco em comparações IDENTITY (===, !==) ou equality (==, !=) com número
+ * literal de business_id. Variáveis cobertas: $business_id, $businessId,
+ * $bizId, $current_biz.
+ */
+const PATTERNS_BANIDOS = [
+    '/\$business_id\s*[!=]==?\s*\d+/',
+    '/\$businessId\s*[!=]==?\s*\d+/',
+    '/\$bizId\s*[!=]==?\s*\d+/',
+    '/\$current_biz\s*[!=]==?\s*\d+/',
+    // Variantes especiais de nomes que apareceram no incidente original
+    '/\$piloto_rotalivre/',
+    '/\$piloto_biz/',
+];
+
+/**
+ * Globs de arquivos canônicos a auditar. Critério: qualquer caminho onde
+ * código se beneficiaria do gate canônico `hasThePermissionInSubscription`
+ * em vez de hardcode.
+ */
+const GLOBS_CANONICOS = [
+    '/Modules/*/Http/Controllers/DataController.php',
+    '/Modules/*/Http/Controllers/*Controller.php',
+    '/app/Http/Middleware/AdminSidebarMenu.php',
+    '/app/Http/Middleware/HandleInertiaRequests.php',
+];
+
+function collectCanonicalFiles(): array
+{
+    $files = [];
+    foreach (GLOBS_CANONICOS as $glob) {
+        $matches = glob(PROJECT_ROOT . $glob);
+        if ($matches !== false) {
+            $files = array_merge($files, $matches);
+        }
+    }
+    return array_values(array_unique($files));
+}
+
+describe('Arquitetura — anti-regressão hardcode business_id Tier 0 IRREVOGÁVEL', function () {
+
+    it('coleciona arquivos canônicos suficientes pra auditoria (sanity check)', function () {
+        $files = collectCanonicalFiles();
+        // Esperamos pelo menos ~30 arquivos (20+ DataControllers + 2 middlewares + Modules/*/Http/Controllers)
+        expect(count($files))->toBeGreaterThan(30);
+    });
+
+    it('nenhum arquivo canônico contém pattern hardcode `$business_id === N`', function () {
+        $files = collectCanonicalFiles();
+        $violacoes = [];
+
+        foreach ($files as $file) {
+            $relative = str_replace(PROJECT_ROOT, '', $file);
+            $src = file_get_contents($file);
+            if ($src === false) continue;
+
+            foreach (PATTERNS_BANIDOS as $pattern) {
+                if (preg_match_all($pattern, $src, $matches, PREG_OFFSET_CAPTURE) > 0) {
+                    foreach ($matches[0] as $match) {
+                        $linha = substr_count(substr($src, 0, $match[1]), "\n") + 1;
+                        $violacoes[] = "{$relative}:{$linha} → {$match[0]}";
+                    }
+                }
+            }
+        }
+
+        if (! empty($violacoes)) {
+            $msg = "Hardcode `\$business_id === N` detectado em " . count($violacoes) . " local(is):\n  - "
+                . implode("\n  - ", $violacoes)
+                . "\n\nWagner regra Tier 0 IRREVOGÁVEL 2026-05-18: visibilidade per-business é via\n"
+                . "subscription package (UI Modules/Superadmin/PackagesController). NUNCA hardcode.\n"
+                . "Pattern correto: ModuleUtil::hasThePermissionInSubscription(\$biz, 'X_module', 'superadmin_package').\n"
+                . "Ver memory/reference/feedback-habilitar-modulo-por-business.md pra guia completo.";
+            $this->fail($msg);
+        }
+
+        expect(true)->toBeTrue(); // explicit pass
+    });
+
+    it('nenhum arquivo canônico contém variável $piloto_rotalivre ou $piloto_biz', function () {
+        $files = collectCanonicalFiles();
+        $violacoes = [];
+
+        foreach ($files as $file) {
+            $relative = str_replace(PROJECT_ROOT, '', $file);
+            $src = file_get_contents($file);
+            if ($src === false) continue;
+
+            if (preg_match('/\$piloto_rotalivre|\$piloto_biz/', $src)) {
+                $violacoes[] = $relative;
+            }
+        }
+
+        if (! empty($violacoes)) {
+            $this->fail(
+                "Variável \$piloto_* (exceção positiva hardcode biz=N) detectada em:\n  - "
+                . implode("\n  - ", $violacoes)
+                . "\n\nWagner regra Tier 0: use subscription package, NÃO exceção hardcode."
+            );
+        }
+
+        expect(true)->toBeTrue();
+    });
+
+    it('test de auto-validação: regex captura o pattern banido corretamente', function () {
+        // Sanity: garantir que os patterns capturam casos óbvios
+        // (proteção contra regex quebrado passando falso-positivo)
+        $exemplos_banidos = [
+            '$business_id === 4',
+            '$business_id !== 4',
+            '$businessId === 12',
+            '$businessId !== 99',
+            '$bizId === 1',
+            '$current_biz !== 4',
+            'if ($business_id === 4) return;',
+            'if (! $piloto_rotalivre) {',
+        ];
+
+        foreach ($exemplos_banidos as $exemplo) {
+            $detectado = false;
+            foreach (PATTERNS_BANIDOS as $pattern) {
+                if (preg_match($pattern, $exemplo)) {
+                    $detectado = true;
+                    break;
+                }
+            }
+            expect($detectado)->toBeTrue("Regex deveria detectar: {$exemplo}");
+        }
+    });
+
+    it('test de auto-validação: regex NÃO captura uso legítimo de business_id', function () {
+        // Sanity: garantir que casos LEGÍTIMOS não disparam falso-positivo
+        $exemplos_ok = [
+            "\$business_id = session('user.business_id');",
+            "\$business_id = (int) \$request->business_id;",
+            "where('business_id', \$business_id)",
+            "session()->get('user.business_id')",
+            "Transaction::where('business_id', \$business_id)->get()",
+            "\$user->business_id",
+            "if (auth()->user()->can('superadmin'))",
+            "Modules\\Whatsapp\\...",  // namespaces
+        ];
+
+        foreach ($exemplos_ok as $exemplo) {
+            $detectado = false;
+            foreach (PATTERNS_BANIDOS as $pattern) {
+                if (preg_match($pattern, $exemplo)) {
+                    $detectado = true;
+                    break;
+                }
+            }
+            expect($detectado)->toBeFalse("Regex disparou falso-positivo em: {$exemplo}");
+        }
+    });
+
+    it('memory/proibicoes.md cita a regra Tier 0 com referência cruzada', function () {
+        $src = file_get_contents(PROJECT_ROOT . '/memory/proibicoes.md');
+        expect($src)->toContain('NUNCA hardcode');
+        expect($src)->toContain('compra de pacote no modulo superadmin');
+        expect($src)->toContain('hasThePermissionInSubscription');
+        expect($src)->toContain('feedback-habilitar-modulo-por-business.md');
+    });
+});


### PR DESCRIPTION
Pedido Wagner 2026-05-18: "Vai ter que ter Governaça. crie."

Pré-PR #1077, Governance NÃO tinha gate canônico — só permission Spatie. Wagner não conseguia esconder/liberar via UI sem mexer em código. Este PR adiciona o gate (pattern dos 20+ módulos existentes).

<!-- evidence-override: gate canônico DataController (mesmo pattern dos módulos existentes). Smoke depende session autenticada biz=4 — Wagner configura via UI Superadmin/Packages e Larissa valida via Ctrl+Shift+R. -->

## Mudança

`Modules/Governance/Http/Controllers/DataController.php`:

`superadmin_package()` JÁ existia retornando `governance_module` permission (default false). `modifyAdminMenu()` agora consulta via:

```php
$is_enabled = $module_util->hasThePermissionInSubscription(
    $business_id, 'governance_module', 'superadmin_package'
);
```

3 gates (em ordem):
1. **Superadmin bypass:** `isModuleInstalled('Governance')` — Wagner sempre vê
2. **Pacote subscription:** consulta package_details do pacote ativo
3. **Permission Spatie:** `can('governance.dashboard.view')` preservado

## Como Wagner habilita/desabilita pra biz=4 agora (UI, sem deploy)

1. Login superadmin → `/superadmin/packages`
2. Editar pacote ativo de biz=4
3. **Desmarcar** checkbox "Modulo Governance" (governance_module)
4. Salvar
5. Larissa faz Ctrl+Shift+R → sidebar não mostra mais Governança

Pra reverter: marcar de volta.

## Tests

`Modules/Governance/Tests/Feature/GovernanceModuleSubscriptionGateTest.php` — 6 testes (15 assertions). Pest **PASS 6/6 in 1.89s** local. Inclui anti-regressão garantindo zero hardcode `$business_id === N`.

## Multi-tenant Tier 0 (ADR 0093 + regra Wagner Tier 0 2026-05-18)

Mudança 100% canônica. Zero hardcode biz=N. Cita regra IRREVOGÁVEL no docblock.

Re: PR #1077 (revert hardcode), regra Wagner 2026-05-18 Tier 0 IRREVOGÁVEL (memory/proibicoes.md).