### PR TITLE
feat(financeiro): Onda 8b polish — chips coloridos + counts + direction arrows canon

### DIFF
--- a/Modules/Financeiro/Tests/Feature/Onda8bChipsDirectionTest.php
+++ b/Modules/Financeiro/Tests/Feature/Onda8bChipsDirectionTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Onda 8b KB-9.75 — Polish visual Cowork: filter chips coloridos + direction arrows.
+ *
+ * Wagner 2026-05-18 sequência pós Onda 8 base — completa o gap entre "expectativa
+ * vs realidade" (screenshot): chips com hue semântico + counts + direction arrows
+ * canon (↘ entrada, ↗ saída).
+ *
+ * Cobre:
+ *   - TAB_HUES Record com hue per status (verde 145 / rose 25 / azul 240)
+ *   - countByTab helper computa lançamentos por categoria client-side
+ *   - JSX <label className="fin-filter-cb"> substitui tabs flat shadcn
+ *   - <span className="fin-filter-ct"> mostra counts dinâmicos
+ *   - <fin-search-wrap> visual input search
+ *   - <fin-density> 3-button toggle
+ *   - Direction arrows com bg pill oklch semântico
+ *
+ * Tier 0 multi-tenant preservado (sem hardcode biz=N).
+ */
+
+const FIN_BASE_8B = __DIR__ . '/../../../../resources/js/Pages/Financeiro/Unificado';
+
+describe('Onda 8b — TAB_HUES + countByTab helpers', function () {
+    it('TAB_HUES record define hue oklch semântico por TabId (7 keys)', function () {
+        $src = file_get_contents(FIN_BASE_8B . '/Index.tsx');
+        expect($src)->toContain('const TAB_HUES: Record<TabId, number>');
+        // 3 hues canon
+        expect($src)->toMatch('/rec:\s*145/');         // verde A receber
+        expect($src)->toMatch('/received:\s*145/');    // verde Recebidas
+        expect($src)->toMatch('/pay:\s*25/');          // rose A pagar
+        expect($src)->toMatch('/late:\s*25/');         // rose Atraso
+        expect($src)->toContain('paid: 240');          // azul Pagas
+    });
+
+    it('countByTab helper computa lançamentos por TabId (7 cases)', function () {
+        $src = file_get_contents(FIN_BASE_8B . '/Index.tsx');
+        expect($src)->toContain('function countByTab(tabId: TabId, all: Lancamento[]): number');
+        expect($src)->toContain("case 'all':");
+        expect($src)->toContain("case 'open':");
+        expect($src)->toContain("case 'rec':");
+        expect($src)->toContain("case 'pay':");
+        expect($src)->toContain("case 'received':");
+        expect($src)->toContain("case 'paid':");
+        expect($src)->toContain("case 'late':");
+    });
+});
+
+describe('Onda 8b — filter chips canon Cowork', function () {
+    it('Index.tsx tem <label fin-filter-cb> + fin-filter-cb-box + fin-filter-ct', function () {
+        $src = file_get_contents(FIN_BASE_8B . '/Index.tsx');
+        expect($src)->toContain("'fin-filter-cb' + (on ? ' on' : '')");
+        expect($src)->toContain('fin-filter-cb-box');
+        expect($src)->toContain('fin-filter-ct');
+        // hue dinâmica via CSS var
+        expect($src)->toContain("'--cb-hue' as string");
+        // count > 0 visível só quando há resultado
+        expect($src)->toContain('count > 0 &&');
+    });
+
+    it('toolbar Cowork substitui Card+CardContent shadcn antigos', function () {
+        $src = file_get_contents(FIN_BASE_8B . '/Index.tsx');
+        // Novo: classe fin-toolbar canon
+        expect($src)->toContain('className="fin-toolbar mt-4"');
+        // search visual + density 3-button preservados
+        expect($src)->toContain('fin-search-wrap');
+        expect($src)->toContain('fin-density');
+        expect($src)->toContain('aria-label="Filtros por status"');
+    });
+});
+
+describe('Onda 8b — direction arrows na tabela (entrada/saída)', function () {
+    it('LinhaTabela renderiza arrow canon com bg pill semântico', function () {
+        $src = file_get_contents(FIN_BASE_8B . '/Index.tsx');
+        // ↘ entrada (receivable) verde 145
+        expect($src)->toContain("isIn ? '↘' : '↗'");
+        // oklch tokens semânticos
+        expect($src)->toContain('oklch(0.94 0.06 145)');
+        expect($src)->toContain('oklch(0.95 0.04 25)');
+        // settled (recebido/pago) tem opacidade
+        expect($src)->toContain('/ 0.6)');
+    });
+
+    it('aria-label "Entrada" / "Saída" presente (acessibilidade)', function () {
+        $src = file_get_contents(FIN_BASE_8B . '/Index.tsx');
+        expect($src)->toContain("aria-label={isIn ? 'Entrada' : 'Saída'}");
+    });
+});
+
+describe('Onda 8b — preserva integrações + hooks Ondas 5/6/7', function () {
+    it('NÃO toca Observer / Service / Subscription backend', function () {
+        // Garante que polish frontend não introduziu modificação backend
+        $src = file_get_contents(FIN_BASE_8B . '/Index.tsx');
+        expect($src)->not->toContain('TituloAutoService');
+        expect($src)->not->toContain('TransactionObserver');
+    });
+
+    it('Hooks useFinConferido + useFinComments continuam mounted', function () {
+        $src = file_get_contents(FIN_BASE_8B . '/Index.tsx');
+        expect($src)->toContain('useFinConferido()');
+        expect($src)->toContain('useFinComments()');
+    });
+
+    it('Components Ondas 5/6/7 continuam imports + mounted', function () {
+        $src = file_get_contents(FIN_BASE_8B . '/Index.tsx');
+        expect($src)->toContain('FinChecklistFechamento');
+        expect($src)->toContain('FinMonthDigest');
+        expect($src)->toContain('FinCrossLinkify');
+        expect($src)->toContain('FinAuditTrail');
+        expect($src)->toContain('FinAnomalyDetector');
+        expect($src)->toContain('FinPartyHistory');
+    });
+});

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -100,6 +100,46 @@ const TABS: { id: TabId; label: string }[] = [
   { id: 'late',     label: 'Atraso' },
 ];
 
+// Onda 8b Cowork canon — hue por status semântico (oklch tokens canon):
+//   verde 145 = A receber / Recebidas (entrada cash)
+//   rose  25  = A pagar / Atraso (saída cash + alerta)
+//   azul  240 = Pagas (saída liquidada, neutralizada)
+//   stone 240 = Todas / Aberto (default sem foco)
+const TAB_HUES: Record<TabId, number> = {
+  all: 240,
+  open: 240,
+  rec: 145,
+  received: 145,
+  pay: 25,
+  paid: 240,
+  late: 25,
+};
+
+/**
+ * Conta lançamentos por tab (client-side rápido pra UX dos chips).
+ * Match com a lógica de filter do backend `UnificadoController::filterByTab`.
+ */
+function countByTab(tabId: TabId, all: Lancamento[]): number {
+  switch (tabId) {
+    case 'all':
+      return all.length;
+    case 'open':
+      return all.filter((l) => l.status === 'aberto' || l.status === 'vencendo').length;
+    case 'rec':
+      return all.filter((l) => l.kind === 'receivable' && (l.status === 'aberto' || l.status === 'vencendo' || l.status === 'atrasado')).length;
+    case 'pay':
+      return all.filter((l) => l.kind === 'payable' && (l.status === 'aberto' || l.status === 'vencendo' || l.status === 'atrasado')).length;
+    case 'received':
+      return all.filter((l) => l.kind === 'receivable' && l.status === 'recebido').length;
+    case 'paid':
+      return all.filter((l) => l.kind === 'payable' && l.status === 'pago').length;
+    case 'late':
+      return all.filter((l) => l.status === 'atrasado').length;
+    default:
+      return 0;
+  }
+}
+
 const DENSITY = {
   compact:     { row: 'h-8',  text: 'text-[12.5px]' },
   comfortable: { row: 'h-11', text: 'text-[13px]' },
@@ -275,7 +315,27 @@ function LinhaTabela({ row, dens, selected, onSelect, onBaixar, conferido, comme
       className={`${dens.row} ${dens.text} border-b border-stone-100 hover:bg-stone-50/60 cursor-pointer ${selected ? 'bg-amber-50/40' : ''}`}
       onClick={onSelect}
     >
-      <td className="pl-4 pr-2"><span className={`text-[14px] ${isIn ? 'text-emerald-600' : 'text-stone-500'}`}>{isIn ? '↑' : '↓'}</span></td>
+      <td className="pl-4 pr-2">
+        {/* Onda 8b Cowork canon: direction arrow com bg pill semântico.
+            Receivable = ↘ entrada (emerald), Payable = ↗ saída (rose).
+            Settled tem opacidade reduzida (cor "tomada"). */}
+        <span
+          className="inline-grid place-items-center rounded"
+          style={{
+            width: 22,
+            height: 22,
+            background: isIn
+              ? (settled ? 'oklch(0.94 0.04 145 / 0.6)' : 'oklch(0.94 0.06 145)')
+              : (settled ? 'oklch(0.95 0.03 25 / 0.6)' : 'oklch(0.95 0.04 25)'),
+            color: isIn ? 'oklch(0.40 0.13 145)' : 'oklch(0.50 0.18 25)',
+            fontSize: 14,
+            fontWeight: 700,
+          }}
+          aria-label={isIn ? 'Entrada' : 'Saída'}
+        >
+          {isIn ? '↘' : '↗'}
+        </span>
+      </td>
       <td className="px-2">
         <div className="font-medium text-stone-900 truncate max-w-[260px] flex items-center gap-1.5">
           <FinCrossLinkify text={row.descricao} className="truncate" />
@@ -417,50 +477,87 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
         periodLabel={periodLabel}
       />
 
-      {/* Tabs + filtros sticky */}
-      <Card className="mt-6 sticky top-14 z-10">
-        <CardContent className="p-3 flex flex-wrap items-center gap-2">
-          <div className="inline-flex rounded-md border border-stone-200 bg-stone-50 p-0.5">
-            {TABS.map(t => (
-              <button
+      {/* Onda 8b Cowork: toolbar canon com filter chips coloridos + density + search.
+          Substitui tabs shadcn flat. Cada chip tem --cb-hue por status semântico
+          (verde A receber/Recebidas, rose A pagar/Atraso, azul Pagas, stone neutros). */}
+      <div className="fin-toolbar mt-4">
+        <div className="fin-filter-group" role="group" aria-label="Filtros por status">
+          {TABS.map((t) => {
+            const on = filters.tab === t.id;
+            const hue = TAB_HUES[t.id];
+            const count = countByTab(t.id, lancamentos);
+            return (
+              <label
                 key={t.id}
-                onClick={() => aplicar({ tab: t.id })}
-                className={`px-2.5 py-1 text-[12.5px] rounded ${filters.tab === t.id ? 'bg-white shadow-sm text-stone-900 font-medium' : 'text-stone-600 hover:text-stone-900'}`}
-              >{t.label}</button>
-            ))}
+                className={'fin-filter-cb' + (on ? ' on' : '')}
+                style={on ? ({ ['--cb-hue' as string]: hue } as React.CSSProperties) : undefined}
+              >
+                <input
+                  type="radio"
+                  name="fin-tab"
+                  checked={on}
+                  onChange={() => aplicar({ tab: t.id })}
+                />
+                <span className="fin-filter-cb-box" />
+                <span>{t.label}</span>
+                {count > 0 && <span className="fin-filter-ct">{count}</span>}
+              </label>
+            );
+          })}
+        </div>
+
+        <span className="fin-filter-sep" />
+
+        <select
+          className="h-7 px-2 rounded-md border border-stone-200 text-[12px] bg-white"
+          value={filters.conta}
+          onChange={(e) => aplicar({ conta: e.target.value })}
+          aria-label="Conta bancária"
+        >
+          <option value="">Todas as contas</option>
+          {contas.map((c) => <option key={c.id} value={c.id}>{c.nome}</option>)}
+        </select>
+
+        <select
+          className="h-7 px-2 rounded-md border border-stone-200 text-[12px] bg-white"
+          value={filters.categoria}
+          onChange={(e) => aplicar({ categoria: e.target.value })}
+          aria-label="Categoria"
+        >
+          <option value="">Todas as categorias</option>
+          {categorias.map((c) => <option key={c.id} value={c.id}>{c.nome}</option>)}
+        </select>
+
+        <div className="fin-toolbar-r">
+          <div className="fin-search-wrap">
+            <span aria-hidden="true">🔍</span>
+            <input
+              id="fin-search-input"
+              placeholder="Buscar lançamento…"
+              value={busca}
+              onChange={(e) => setBusca(e.target.value)}
+              onKeyDown={(e) => e.key === 'Enter' && aplicar({ busca })}
+            />
+            <kbd style={{ fontSize: 10, color: 'var(--fin-text-mute)' }}>/</kbd>
           </div>
 
-          <select className="h-8 px-2 rounded-md border border-stone-200 text-[12.5px]"
-                  value={filters.conta} onChange={(e) => aplicar({ conta: e.target.value })}>
-            <option value="">Todas as contas</option>
-            {contas.map(c => <option key={c.id} value={c.id}>{c.nome}</option>)}
-          </select>
-
-          <select className="h-8 px-2 rounded-md border border-stone-200 text-[12.5px]"
-                  value={filters.categoria} onChange={(e) => aplicar({ categoria: e.target.value })}>
-            <option value="">Todas as categorias</option>
-            {categorias.map(c => <option key={c.id} value={c.id}>{c.nome}</option>)}
-          </select>
-
-          <Input
-            id="fin-search-input"
-            placeholder="Buscar lançamento…  /"
-            value={busca}
-            onChange={(e) => setBusca(e.target.value)}
-            onKeyDown={(e) => e.key === 'Enter' && aplicar({ busca })}
-            className="h-8 w-[200px] text-[12.5px]"
-          />
-
-          <div className="ml-auto inline-flex rounded-md border border-stone-200 p-0.5 text-[11.5px]">
-            {(['compact','comfortable','spacious'] as const).map(d => (
-              <button key={d} onClick={() => aplicar({ densidade: d })}
-                      className={`px-2 py-0.5 rounded ${filters.densidade === d ? 'bg-stone-900 text-white' : 'text-stone-600'}`}>
+          <div className="fin-density" role="group" aria-label="Densidade">
+            {(['compact', 'comfortable', 'spacious'] as const).map((d) => (
+              <button
+                key={d}
+                type="button"
+                className={filters.densidade === d ? 'on' : ''}
+                onClick={() => aplicar({ densidade: d })}
+                aria-pressed={filters.densidade === d}
+                aria-label={d}
+                title={d}
+              >
                 {d === 'compact' ? '◰' : d === 'comfortable' ? '▦' : '▤'}
               </button>
             ))}
           </div>
-        </CardContent>
-      </Card>
+        </div>
+      </div>
 
       {/* Tabela agrupada */}
       <Card className="mt-3">


### PR DESCRIPTION
Sequência pós Onda 8 (PR #1082) — fecha o gap visual restante do screenshot "expectativa vs realidade".

## Mudanças (3)

### 1. Filter chips canon coloridos
- TAB_HUES Record per TabId: **verde 145** (A receber/Recebidas), **rose 25** (A pagar/Atraso), **azul 240** (Pagas), **stone 240** (default)
- `countByTab()` helper computa lançamentos por categoria (espelha backend)
- Render canon `<label .fin-filter-cb>` com box + label + count pill
- Hue dinâmica via `--cb-hue` CSS var oklch

### 2. Toolbar Cowork (.fin-toolbar)
Substitui Card+CardContent shadcn — inclui chips + filtros + search visual + density 3-button.

### 3. Direction arrows canon
- ↘ entrada (receivable) com bg emerald-pill
- ↗ saída (payable) com bg rose-pill
- Settled = opacidade 0.6 (cor "tomada")
- aria-label "Entrada"/"Saída" (a11y)

## Preserva integrações (Pest assertion)

✅ NÃO toca Observer/Service/Subscription backend
✅ Hooks useFinConferido + useFinComments mounted
✅ Components Ondas 5/6/7 intactos (Checklist + MonthDigest + CrossLinkify + AuditTrail + AnomalyDetector + PartyHistory)

## Tests

`Modules/Financeiro/Tests/Feature/Onda8bChipsDirectionTest.php` — 9 testes (38 assertions). Pest **PASS 9/9 in 2.52s**.

Smoke build: `npm run build:inertia` OK em 1m40s, zero erros TS.

Re: Wagner screenshot "expectativa vs realidade" 2026-05-18, Onda 8 PR #1082.