### PR TITLE
feat(financeiro): Onda 7b — FinTroubleshooter (4 árvores) + FinPresentationMode (fullscreen reunião)

### DIFF
--- a/Modules/Financeiro/Tests/Feature/Onda7bTroubleshootPresentTest.php
+++ b/Modules/Financeiro/Tests/Feature/Onda7bTroubleshootPresentTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Onda 7b KB-9.75 — FinTroubleshooter + FinPresentationMode.
+ *
+ * Substitui alert() de "▶ Apresentar" por componente real fullscreen + adiciona
+ * "? Resolver" button no footer com 4 árvores de decisão (extrato não bate /
+ * boleto pago 2x / fornecedor cobrou errado / NFe rejeitada).
+ *
+ * Cobre:
+ *   - FinTroubleshooter.tsx: 4 árvores FIN_TROUBLES + componente dialog
+ *   - FinPresentationMode.tsx: 3 views (overview / parties / categories) + atalhos
+ *   - CSS escopado em fin-output.css (Onda 7 wrapper)
+ *   - Wire-up Index.tsx: 2 states + render dialogs + trigger button no footer
+ *
+ * Multi-tenant Tier 0 preservado (zero backend).
+ */
+
+const FIN_BASE_7B = __DIR__ . '/../../../../resources/js/Pages/Financeiro/Unificado';
+const FIN_OUTPUT_CSS_7B = __DIR__ . '/../../../../resources/css/fin-output.css';
+
+describe('Onda 7b — FinTroubleshooter (4 árvores de decisão)', function () {
+    it('FinTroubleshooter.tsx exporta FIN_TROUBLES com 4 árvores canônicas', function () {
+        $src = file_get_contents(FIN_BASE_7B . '/_components/FinTroubleshooter.tsx');
+        expect($src)->toContain('export const FIN_TROUBLES');
+        expect($src)->toContain("'tr-extrato-nao-bate'");
+        expect($src)->toContain("'tr-boleto-pago-2x'");
+        expect($src)->toContain("'tr-fornecedor-cobrou-errado'");
+        expect($src)->toContain("'tr-nfe-rejeitada-fin'");
+    });
+
+    it('FinTroubleshooterDialog component renderiza lista + flow + resolution', function () {
+        $src = file_get_contents(FIN_BASE_7B . '/_components/FinTroubleshooter.tsx');
+        expect($src)->toContain('export function FinTroubleshooterDialog');
+        // 3 estados: list (4 cards) → flow (Q/A) → resolution (fix)
+        expect($src)->toContain('fin-trouble-list');
+        expect($src)->toContain('fin-trouble-flow');
+        expect($src)->toContain('fin-trouble-resolution');
+        // Sugestão automática via suggestedId
+        expect($src)->toContain('suggestedId');
+    });
+
+    it('FinTroubleButton trigger pra footer/drawer', function () {
+        $src = file_get_contents(FIN_BASE_7B . '/_components/FinTroubleshooter.tsx');
+        expect($src)->toContain('export function FinTroubleButton');
+        expect($src)->toContain('fin-trouble-trigger');
+        expect($src)->toContain('fin-trouble-count');
+    });
+});
+
+describe('Onda 7b — FinPresentationMode (fullscreen reunião)', function () {
+    it('FinPresentationMode component com 3 views', function () {
+        $src = file_get_contents(FIN_BASE_7B . '/_components/FinPresentationMode.tsx');
+        expect($src)->toContain('export function FinPresentationMode');
+        expect($src)->toContain("type ViewMode = 'overview' | 'parties' | 'categories'");
+    });
+
+    it('Atalhos teclado canon (Esc fecha, 1/2/3 muda view)', function () {
+        $src = file_get_contents(FIN_BASE_7B . '/_components/FinPresentationMode.tsx');
+        expect($src)->toContain("e.key === 'Escape'");
+        expect($src)->toContain("e.key === '1'");
+        expect($src)->toContain("e.key === '2'");
+        expect($src)->toContain("e.key === '3'");
+    });
+
+    it('Views renderizam: hero KPI big + parties table + categories table', function () {
+        $src = file_get_contents(FIN_BASE_7B . '/_components/FinPresentationMode.tsx');
+        expect($src)->toContain('fin-present-hero');
+        expect($src)->toContain('fin-present-grid');
+        expect($src)->toContain('Top 10 contrapartes');
+        expect($src)->toContain('Top 10 categorias');
+    });
+});
+
+describe('Onda 7b — CSS escopado em fin-output.css', function () {
+    it('Tokens CSS Troubleshooter + Presentation mounted', function () {
+        $css = file_get_contents(FIN_OUTPUT_CSS_7B);
+        // Troubleshooter
+        expect($css)->toContain('.fin-curadoria .fin-trouble-backdrop');
+        expect($css)->toContain('.fin-curadoria .fin-trouble-dialog');
+        expect($css)->toContain('.fin-curadoria .fin-trouble-card');
+        expect($css)->toContain('.fin-curadoria .fin-trouble-flow');
+        expect($css)->toContain('.fin-curadoria .fin-trouble-fix');
+        // Presentation Mode (NOT escopado em .fin-curadoria — é fullscreen)
+        expect($css)->toContain('.fin-present');
+        expect($css)->toContain('.fin-present-hero');
+        expect($css)->toContain('.fin-present-grid');
+        expect($css)->toContain('.fin-present-table');
+    });
+});
+
+describe('Onda 7b — wire-up Index.tsx', function () {
+    it('Index.tsx importa FinTroubleshooter + FinPresentationMode', function () {
+        $src = file_get_contents(FIN_BASE_7B . '/Index.tsx');
+        expect($src)->toContain("from './_components/FinTroubleshooter'");
+        expect($src)->toContain("from './_components/FinPresentationMode'");
+    });
+
+    it('Index.tsx instancia troubleOpen + presentOpen states', function () {
+        $src = file_get_contents(FIN_BASE_7B . '/Index.tsx');
+        expect($src)->toContain('const [troubleOpen, setTroubleOpen]');
+        expect($src)->toContain('const [presentOpen, setPresentOpen]');
+    });
+
+    it('Botão ▶ Apresentar agora abre PresentationMode (não alert)', function () {
+        $src = file_get_contents(FIN_BASE_7B . '/Index.tsx');
+        expect($src)->toContain('onClick={() => setPresentOpen(true)}');
+        // alert removido
+        expect($src)->not->toContain("alert('Apresentar:");
+    });
+
+    it('FinTroubleButton renderizado no footer com onClick setTroubleOpen', function () {
+        $src = file_get_contents(FIN_BASE_7B . '/Index.tsx');
+        expect($src)->toContain('<FinTroubleButton');
+        expect($src)->toContain('setTroubleOpen(true)');
+    });
+
+    it('FinTroubleshooterDialog + FinPresentationMode renderizados', function () {
+        $src = file_get_contents(FIN_BASE_7B . '/Index.tsx');
+        expect($src)->toContain('<FinTroubleshooterDialog');
+        expect($src)->toContain('<FinPresentationMode');
+        // PresentationMode recebe kpis + lancamentos + periodLabel + businessName
+        expect($src)->toContain('kpis={kpis}');
+        expect($src)->toContain('lancamentos={lancamentos}');
+        expect($src)->toContain('periodLabel={periodLabel}');
+    });
+});

--- a/resources/css/fin-output.css
+++ b/resources/css/fin-output.css
@@ -250,3 +250,207 @@
   font-size: 10px;
   font-weight: 700;
 }
+
+/* ─────────────────────────────────────────────────────────────
+ * FinTroubleshooter — Onda 7b (4 árvores decisão)
+ * ───────────────────────────────────────────────────────────── */
+
+.fin-curadoria .fin-trouble-backdrop {
+  position: fixed; inset: 0;
+  background: oklch(0.20 0.005 240 / 0.55);
+  z-index: 100;
+}
+.fin-curadoria .fin-trouble-dialog {
+  position: fixed;
+  inset: 50% auto auto 50%;
+  transform: translate(-50%, -50%);
+  width: min(680px, 92vw); max-height: 88vh;
+  background: white; border-radius: 12px;
+  box-shadow: 0 24px 64px oklch(0.20 0.005 240 / 0.25);
+  z-index: 101; display: flex; flex-direction: column; overflow: hidden;
+}
+.fin-curadoria .fin-trouble-h {
+  display: flex; align-items: flex-start;
+  padding: 16px 20px 12px; border-bottom: 1px solid var(--fin-line);
+}
+.fin-curadoria .fin-trouble-h h2 { margin: 0; font-size: 16px; font-weight: 700; }
+.fin-curadoria .fin-trouble-h small { display: block; margin-top: 2px; font-size: 11.5px; color: var(--fin-text-mute); }
+.fin-curadoria .fin-trouble-x {
+  margin-left: auto; background: transparent; border: 0;
+  font-size: 20px; color: var(--fin-text-mute); cursor: pointer; padding: 0 8px; line-height: 1;
+}
+.fin-curadoria .fin-trouble-list {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 10px;
+  padding: 16px 20px 20px; overflow-y: auto;
+}
+.fin-curadoria .fin-trouble-card {
+  --tr-hue: 240;
+  position: relative; text-align: left;
+  background: white;
+  border: 1px solid oklch(0.92 0.04 var(--tr-hue));
+  border-radius: 8px; padding: 14px 16px; cursor: pointer;
+  transition: all .15s; display: flex; flex-direction: column; gap: 6px;
+}
+.fin-curadoria .fin-trouble-card:hover {
+  background: oklch(0.98 0.02 var(--tr-hue));
+  border-color: oklch(0.78 0.10 var(--tr-hue));
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px oklch(0.55 0.13 var(--tr-hue) / 0.10);
+}
+.fin-curadoria .fin-trouble-card-equip {
+  font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em;
+  color: oklch(0.45 0.18 var(--tr-hue));
+}
+.fin-curadoria .fin-trouble-card h3 { margin: 2px 0 0; font-size: 13.5px; font-weight: 600; line-height: 1.3; }
+.fin-curadoria .fin-trouble-card small { font-size: 11px; color: var(--fin-text-mute); font-style: italic; }
+.fin-curadoria .fin-trouble-card-arrow {
+  position: absolute; right: 12px; bottom: 12px;
+  color: oklch(0.55 0.13 var(--tr-hue));
+  font-size: 14px; opacity: 0.7;
+}
+
+.fin-curadoria .fin-trouble-flow,
+.fin-curadoria .fin-trouble-resolution { padding: 16px 20px 20px; overflow-y: auto; }
+.fin-curadoria .fin-trouble-flow-h {
+  display: flex; align-items: center; gap: 12px;
+  margin-bottom: 12px; border-bottom: 1px dashed var(--fin-line); padding-bottom: 10px;
+}
+.fin-curadoria .fin-trouble-flow-h h3 { margin: 0; font-size: 14px; font-weight: 600; color: oklch(0.36 0.13 var(--tr-hue, 240)); flex: 1; }
+.fin-curadoria .fin-trouble-flow-h small { font-size: 11px; color: var(--fin-text-mute); }
+.fin-curadoria .fin-trouble-back {
+  appearance: none; background: transparent; border: 0;
+  color: oklch(0.36 0.13 240); font-family: inherit; font-size: 12px; font-weight: 600; cursor: pointer; padding: 0;
+}
+.fin-curadoria .fin-trouble-back:hover { text-decoration: underline; }
+
+.fin-curadoria .fin-trouble-step {
+  background: var(--fin-bg-soft); border-radius: 8px;
+  padding: 20px; text-align: center;
+}
+.fin-curadoria .fin-trouble-q { margin: 0 0 16px; font-size: 15px; font-weight: 600; line-height: 1.4; }
+.fin-curadoria .fin-trouble-answers { display: flex; gap: 10px; justify-content: center; }
+.fin-curadoria .fin-trouble-answer {
+  appearance: none; background: white; border: 2px solid var(--fin-line);
+  border-radius: 6px; padding: 8px 32px;
+  font-family: inherit; font-size: 13px; font-weight: 600; cursor: pointer; transition: all .12s;
+}
+.fin-curadoria .fin-trouble-answer.yes { border-color: oklch(0.55 0.18 145); color: oklch(0.32 0.13 145); }
+.fin-curadoria .fin-trouble-answer.yes:hover { background: oklch(0.96 0.05 145); }
+.fin-curadoria .fin-trouble-answer.no { border-color: oklch(0.55 0.18 25); color: oklch(0.42 0.13 25); }
+.fin-curadoria .fin-trouble-answer.no:hover { background: oklch(0.96 0.05 25); }
+
+.fin-curadoria .fin-trouble-fix {
+  display: flex; gap: 12px; padding: 16px;
+  background: oklch(0.96 0.05 145); border: 1px solid oklch(0.65 0.13 145);
+  border-radius: 8px; align-items: flex-start;
+}
+.fin-curadoria .fin-trouble-fix-ic {
+  --tr-hue: 145;
+  display: grid; place-items: center;
+  width: 32px; height: 32px; border-radius: 50%;
+  background: oklch(0.55 0.18 var(--tr-hue));
+  color: white; font-size: 16px; font-weight: 700; flex-shrink: 0;
+}
+.fin-curadoria .fin-trouble-fix p { margin: 0; flex: 1; font-size: 13px; line-height: 1.5; color: oklch(0.22 0.06 145); }
+.fin-curadoria .fin-trouble-footer { display: flex; gap: 10px; margin-top: 12px; padding-top: 12px; border-top: 1px dashed var(--fin-line); }
+.fin-curadoria .fin-trouble-restart {
+  appearance: none; background: var(--fin-bg-soft); border: 1px solid var(--fin-line);
+  padding: 6px 12px; border-radius: 4px; font-family: inherit; font-size: 12px; cursor: pointer;
+}
+.fin-curadoria .fin-trouble-trigger {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 4px 10px; height: 26px; border-radius: 4px;
+  border: 1px solid oklch(0.78 0.10 60); background: oklch(0.97 0.04 60);
+  color: oklch(0.42 0.13 60); font-family: inherit; font-size: 11.5px; font-weight: 600; cursor: pointer;
+}
+.fin-curadoria .fin-trouble-trigger:hover { background: oklch(0.94 0.06 60); }
+.fin-curadoria .fin-trouble-count {
+  font-family: ui-monospace, monospace; font-size: 10px;
+  padding: 1px 5px; border-radius: 99px;
+  background: oklch(0.55 0.13 60); color: white;
+}
+
+/* ─────────────────────────────────────────────────────────────
+ * FinPresentationMode — Onda 7b (fullscreen reunião sócio)
+ * ───────────────────────────────────────────────────────────── */
+
+.fin-present {
+  position: fixed; inset: 0; z-index: 200;
+  background: linear-gradient(135deg, oklch(0.15 0.04 240) 0%, oklch(0.22 0.06 240) 100%);
+  color: white; display: flex; flex-direction: column; overflow: hidden;
+}
+.fin-present-h {
+  display: flex; align-items: center; gap: 20px;
+  padding: 20px 32px; border-bottom: 1px solid oklch(0.40 0.06 240 / 0.4);
+}
+.fin-present-h h1 { margin: 0; font-size: 22px; font-weight: 600; letter-spacing: -0.01em; }
+.fin-present-h p { margin: 2px 0 0; font-size: 13px; color: oklch(0.85 0.04 240); }
+.fin-present-nav { margin-left: auto; display: flex; gap: 4px; }
+.fin-present-nav button {
+  appearance: none; background: transparent;
+  border: 1px solid oklch(0.45 0.08 240); color: oklch(0.85 0.04 240);
+  padding: 6px 14px; border-radius: 6px; font-family: inherit; font-size: 12px; font-weight: 500; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.fin-present-nav button:hover { background: oklch(0.30 0.06 240); }
+.fin-present-nav button.on { background: white; color: oklch(0.22 0.06 240); border-color: white; }
+.fin-present-nav button kbd {
+  font-family: ui-monospace, monospace; font-size: 10px; padding: 0 4px;
+  border-radius: 3px; background: oklch(0.40 0.06 240); color: white; border: 0;
+}
+.fin-present-nav button.on kbd { background: oklch(0.92 0.04 240); color: oklch(0.22 0.06 240); }
+.fin-present-close {
+  appearance: none; background: transparent; border: 0;
+  color: white; font-size: 24px; cursor: pointer; padding: 0 8px; line-height: 1; opacity: 0.7;
+}
+.fin-present-close:hover { opacity: 1; }
+.fin-present-body { flex: 1; overflow-y: auto; padding: 40px 32px; }
+.fin-present-overview { max-width: 1100px; margin: 0 auto; display: flex; flex-direction: column; gap: 32px; }
+.fin-present-hero {
+  text-align: center; padding: 32px;
+  background: oklch(0.30 0.06 240 / 0.5); border: 1px solid oklch(0.45 0.08 240); border-radius: 16px;
+}
+.fin-present-hero small {
+  display: block; font-size: 13px; text-transform: uppercase; letter-spacing: 0.1em;
+  color: oklch(0.85 0.04 240); margin-bottom: 8px;
+}
+.fin-present-hero h2 {
+  margin: 0; font-size: 64px; font-weight: 700;
+  font-family: ui-monospace, monospace; letter-spacing: -0.02em;
+}
+.fin-present-hero h2.pos { color: oklch(0.85 0.18 145); }
+.fin-present-hero h2.neg { color: oklch(0.78 0.20 25); }
+.fin-present-hero p { margin: 16px 0 0; font-size: 16px; color: oklch(0.92 0.02 240); }
+.fin-present-hero b.pos { color: oklch(0.85 0.18 145); }
+.fin-present-hero b.neg { color: oklch(0.78 0.20 25); }
+.fin-present-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px; }
+.fin-present-card {
+  background: oklch(0.30 0.06 240 / 0.5); border: 1px solid oklch(0.45 0.08 240);
+  border-radius: 12px; padding: 20px; display: flex; flex-direction: column; gap: 6px;
+}
+.fin-present-card small { font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; color: oklch(0.85 0.04 240); }
+.fin-present-card b { font-size: 32px; font-weight: 700; font-family: ui-monospace, monospace; }
+.fin-present-card i { font-style: normal; font-size: 12px; color: oklch(0.85 0.04 240); }
+.fin-present-card.in b { color: oklch(0.85 0.18 145); }
+.fin-present-card.open b { color: oklch(0.92 0.02 240); }
+.fin-present-card.out b { color: oklch(0.85 0.10 240); }
+.fin-present-card.late b { color: oklch(0.78 0.20 25); }
+.fin-present-table { max-width: 1100px; margin: 0 auto; }
+.fin-present-table h2 { margin: 0 0 20px; font-size: 24px; font-weight: 600; }
+.fin-present-table table { width: 100%; border-collapse: collapse; font-size: 14px; }
+.fin-present-table th {
+  text-align: left; padding: 10px 14px; background: oklch(0.30 0.06 240 / 0.5);
+  font-size: 11px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em;
+  color: oklch(0.85 0.04 240); border-bottom: 1px solid oklch(0.45 0.08 240);
+}
+.fin-present-table td { padding: 12px 14px; border-bottom: 1px solid oklch(0.40 0.06 240 / 0.4); font-family: ui-monospace, monospace; }
+.fin-present-table td b { font-family: ui-sans-serif, system-ui, sans-serif; font-weight: 600; }
+.fin-present-table td.pos { color: oklch(0.85 0.18 145); }
+.fin-present-table td.neg { color: oklch(0.78 0.20 25); }
+.fin-present-f { padding: 12px 32px; border-top: 1px solid oklch(0.40 0.06 240 / 0.4); text-align: center; }
+.fin-present-f small { font-size: 11.5px; color: oklch(0.75 0.04 240); }
+.fin-present-f kbd {
+  font-family: ui-monospace, monospace; font-size: 10px;
+  padding: 1px 5px; border-radius: 3px;
+  background: oklch(0.30 0.06 240); color: white; margin: 0 2px;
+}

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -32,6 +32,9 @@ import { FinMonthDigest } from './_components/FinMonthDigest';
 // Onda 7 R3 Output — cross-link + checklist fechamento.
 import { FinCrossLinkify } from './_components/FinCrossLinkify';
 import { FinChecklistFechamento } from './_components/FinChecklistFechamento';
+// Onda 7b — Troubleshooter dialog + PresentationMode fullscreen.
+import { FinTroubleshooterDialog, FinTroubleButton } from './_components/FinTroubleshooter';
+import { FinPresentationMode } from './_components/FinPresentationMode';
 
 // ---------- Tipos ----------
 
@@ -376,6 +379,9 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
   const comments = useFinComments();
   // Cowork KB-9.75 Onda 7 R3 — trilha fechamento dialog state.
   const [checklistOpen, setChecklistOpen] = useState(false);
+  // Cowork KB-9.75 Onda 7b — Troubleshooter + Presentation Mode states.
+  const [troubleOpen, setTroubleOpen] = useState(false);
+  const [presentOpen, setPresentOpen] = useState(false);
 
   const aplicar = useCallback((patch: Partial<Filters>) => {
     router.get('/financeiro/unificado', { ...filters, ...patch }, {
@@ -450,8 +456,8 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
           <button
             type="button"
             className="fin-btn fin-btn-present"
-            title="Modo apresentação fullscreen (Onda 7b — em construção)"
-            onClick={() => alert('Apresentar: feature Onda 7b — FinPresentationMode (em construção)')}
+            title="Modo apresentação fullscreen (Esc fecha · 1/2/3 muda vista)"
+            onClick={() => setPresentOpen(true)}
           >
             ▶ Apresentar
           </button>
@@ -733,9 +739,21 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
         <span><kbd>/</kbd> buscar</span>
         <span><kbd>J</kbd>/<kbd>K</kbd> navegar</span>
         <span><kbd>␣</kbd> marcar pago/recebido</span>
+        <FinTroubleButton onClick={() => setTroubleOpen(true)} />
         <span className="spacer" />
         <span>Densidade: <strong>{filters.densidade}</strong></span>
       </div>
+
+      {/* Onda 7b — Dialogs Troubleshooter + Presentation Mode */}
+      <FinTroubleshooterDialog open={troubleOpen} onClose={() => setTroubleOpen(false)} />
+      <FinPresentationMode
+        open={presentOpen}
+        onClose={() => setPresentOpen(false)}
+        kpis={kpis}
+        lancamentos={lancamentos}
+        periodLabel={periodLabel}
+        businessName={businessName}
+      />
 
       {/* Cowork KB-9.75 Onda 7 R3 — Trilha fechamento dialog */}
       <FinChecklistFechamento

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinPresentationMode.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinPresentationMode.tsx
@@ -1,0 +1,229 @@
+// FinPresentationMode — Cowork KB-9.75 Financeiro Onda 7b
+// (fullscreen pra reunião com sócio).
+//
+// Refs:
+//  - prototipo-ui/financeiro-output.jsx FinPresentationMode
+//  - Sells SalePresentationMode (pattern parecido)
+//
+// Render minimalista pra apresentar dados Fin em reunião:
+//   - Background dark gradient + KPIs gigantes
+//   - Tab navigation entre views (Resumo / Por contraparte / Por categoria)
+//   - Atalho Esc fecha
+//   - Sem dependência externa (zero backend)
+
+import { useEffect, useMemo, useState } from 'react';
+
+interface KpiSnapshot {
+  saldo_previsto: number;
+  recebido: { valor: number; qtd: number };
+  a_receber: { valor: number; qtd: number };
+  pago: { valor: number; qtd: number };
+  a_pagar: { valor: number; qtd: number };
+}
+
+interface LancamentoLite {
+  id: number;
+  contraparte: string;
+  categoria?: string;
+  valor: number;
+  kind?: 'receivable' | 'payable';
+  status?: string;
+}
+
+type ViewMode = 'overview' | 'parties' | 'categories';
+
+interface FinPresentationModeProps {
+  open: boolean;
+  onClose: () => void;
+  kpis: KpiSnapshot;
+  lancamentos: LancamentoLite[];
+  periodLabel: string;
+  businessName?: string;
+}
+
+function brl(n: number): string {
+  return n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+function brlBig(n: number): string {
+  if (Math.abs(n) >= 1_000_000) return 'R$ ' + (n / 1_000_000).toFixed(2).replace('.', ',') + 'M';
+  if (Math.abs(n) >= 1_000) return 'R$ ' + (n / 1_000).toFixed(1).replace('.', ',') + 'k';
+  return brl(n);
+}
+
+export function FinPresentationMode({ open, onClose, kpis, lancamentos, periodLabel, businessName }: FinPresentationModeProps) {
+  const [view, setView] = useState<ViewMode>('overview');
+
+  // Atalho Esc fecha
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+      else if (e.key === '1') setView('overview');
+      else if (e.key === '2') setView('parties');
+      else if (e.key === '3') setView('categories');
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
+  const parties = useMemo(() => {
+    if (view !== 'parties') return [];
+    const m: Record<string, { recebido: number; pago: number; count: number }> = {};
+    for (const l of lancamentos) {
+      const key = l.contraparte || 'Sem contraparte';
+      if (!m[key]) m[key] = { recebido: 0, pago: 0, count: 0 };
+      m[key].count++;
+      if (l.kind === 'receivable') m[key].recebido += l.valor || 0;
+      else m[key].pago += l.valor || 0;
+    }
+    return Object.entries(m)
+      .map(([nome, v]) => ({ nome, ...v, total: v.recebido + v.pago }))
+      .sort((a, b) => b.total - a.total)
+      .slice(0, 10);
+  }, [view, lancamentos]);
+
+  const cats = useMemo(() => {
+    if (view !== 'categories') return [];
+    const m: Record<string, { total: number; count: number }> = {};
+    for (const l of lancamentos) {
+      const key = l.categoria || 'Sem categoria';
+      if (!m[key]) m[key] = { total: 0, count: 0 };
+      m[key].count++;
+      m[key].total += l.valor || 0;
+    }
+    return Object.entries(m)
+      .map(([nome, v]) => ({ nome, ...v }))
+      .sort((a, b) => b.total - a.total)
+      .slice(0, 10);
+  }, [view, lancamentos]);
+
+  if (!open) return null;
+
+  const net = kpis.recebido.valor - kpis.pago.valor;
+
+  return (
+    <div className="fin-present" role="dialog" aria-label="Modo apresentação">
+      <header className="fin-present-h">
+        <div>
+          <h1>Financeiro · {periodLabel}</h1>
+          {businessName && <p>{businessName}</p>}
+        </div>
+        <nav className="fin-present-nav">
+          <button
+            type="button"
+            className={view === 'overview' ? 'on' : ''}
+            onClick={() => setView('overview')}
+          >
+            <kbd>1</kbd> Resumo
+          </button>
+          <button
+            type="button"
+            className={view === 'parties' ? 'on' : ''}
+            onClick={() => setView('parties')}
+          >
+            <kbd>2</kbd> Contrapartes
+          </button>
+          <button
+            type="button"
+            className={view === 'categories' ? 'on' : ''}
+            onClick={() => setView('categories')}
+          >
+            <kbd>3</kbd> Categorias
+          </button>
+        </nav>
+        <button type="button" className="fin-present-close" onClick={onClose} title="Fechar (Esc)">×</button>
+      </header>
+
+      <main className="fin-present-body">
+        {view === 'overview' && (
+          <div className="fin-present-overview">
+            <div className="fin-present-hero">
+              <small>Saldo previsto</small>
+              <h2 className={kpis.saldo_previsto >= 0 ? 'pos' : 'neg'}>{brl(kpis.saldo_previsto)}</h2>
+              <p>
+                Realizado <b className={net >= 0 ? 'pos' : 'neg'}>{brl(net)}</b>
+                {' · '}
+                Pendente <b>{brl(kpis.a_receber.valor - kpis.a_pagar.valor)}</b>
+              </p>
+            </div>
+            <div className="fin-present-grid">
+              <div className="fin-present-card in">
+                <small>↑ Recebido</small>
+                <b>{brlBig(kpis.recebido.valor)}</b>
+                <i>{kpis.recebido.qtd} baixas</i>
+              </div>
+              <div className="fin-present-card open">
+                <small>⏰ A Receber</small>
+                <b>{brlBig(kpis.a_receber.valor)}</b>
+                <i>{kpis.a_receber.qtd} títulos</i>
+              </div>
+              <div className="fin-present-card out">
+                <small>↓ Pago</small>
+                <b>{brlBig(kpis.pago.valor)}</b>
+                <i>{kpis.pago.qtd} baixas</i>
+              </div>
+              <div className="fin-present-card late">
+                <small>⚠ A Pagar</small>
+                <b>{brlBig(kpis.a_pagar.valor)}</b>
+                <i>{kpis.a_pagar.qtd} títulos</i>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {view === 'parties' && (
+          <div className="fin-present-table">
+            <h2>Top 10 contrapartes</h2>
+            <table>
+              <thead>
+                <tr><th>Contraparte</th><th>Recebido</th><th>Pago</th><th>Saldo</th><th>Trans</th></tr>
+              </thead>
+              <tbody>
+                {parties.length === 0 && <tr><td colSpan={5}>Sem dados no período.</td></tr>}
+                {parties.map((p) => (
+                  <tr key={p.nome}>
+                    <td><b>{p.nome}</b></td>
+                    <td className="pos">{brl(p.recebido)}</td>
+                    <td className="neg">{brl(p.pago)}</td>
+                    <td><b>{brl(p.recebido - p.pago)}</b></td>
+                    <td>{p.count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {view === 'categories' && (
+          <div className="fin-present-table">
+            <h2>Top 10 categorias</h2>
+            <table>
+              <thead>
+                <tr><th>Categoria</th><th>Total</th><th>Transações</th></tr>
+              </thead>
+              <tbody>
+                {cats.length === 0 && <tr><td colSpan={3}>Sem dados no período.</td></tr>}
+                {cats.map((c) => (
+                  <tr key={c.nome}>
+                    <td><b>{c.nome}</b></td>
+                    <td><b>{brl(c.total)}</b></td>
+                    <td>{c.count}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </main>
+
+      <footer className="fin-present-f">
+        <small>
+          <kbd>Esc</kbd> sair · <kbd>1</kbd> resumo · <kbd>2</kbd> contrapartes · <kbd>3</kbd> categorias
+        </small>
+      </footer>
+    </div>
+  );
+}
+
+export default FinPresentationMode;

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinTroubleshooter.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinTroubleshooter.tsx
@@ -1,0 +1,285 @@
+// FinTroubleshooter — Cowork KB-9.75 Financeiro Onda 7b
+// (dialog modal árvore de decisão pra divergências comuns).
+//
+// Refs:
+//  - prototipo-ui/financeiro-output.jsx FIN_TROUBLES + FinTroubleButton
+//
+// 4 troubleshooters canônicos:
+//   1. Saldo do extrato não bate com o caixa (conciliação)
+//   2. Cliente pagou o mesmo boleto 2 vezes (boleto)
+//   3. Fornecedor cobrou diferente do pedido (compras)
+//   4. Rejeição da SEFAZ chegou no Financeiro (fiscal)
+//
+// Pure compute, sem backend, sem LLM. Wagner regra Tier 0 multi-tenant safe
+// (não toca queries Eloquent, só renderiza guia).
+
+import { useState, useEffect, useMemo, useCallback, type ReactNode } from 'react';
+
+type TroubleHue = 25 | 60 | 145 | 240;
+
+interface Fix {
+  fix: string;
+}
+
+interface StepNode {
+  q: string;
+  yes: Fix | number; // number = índice do próximo step
+  no: Fix | number;
+}
+
+export interface TroubleTree {
+  id: string;
+  title: string;
+  equip: string;
+  hue: TroubleHue;
+  when: string;
+  steps: StepNode[];
+}
+
+// Árvores de decisão canônicas (espelhadas do protótipo Cowork)
+export const FIN_TROUBLES: TroubleTree[] = [
+  {
+    id: 'tr-extrato-nao-bate',
+    title: 'Saldo do extrato não bate com o caixa',
+    equip: 'conciliação',
+    hue: 25,
+    when: 'fim do dia · diferença entre OFX e contábil',
+    steps: [
+      {
+        q: 'A diferença é menor que R$ 5,00?',
+        yes: { fix: "Tolerância normal de arredondamento bancário. Aceite a conciliação automática. Anote a diferença em 'Outros' do plano de contas e siga." },
+        no: 1,
+      },
+      {
+        q: 'Existe boleto pago hoje sem match no Financeiro?',
+        yes: { fix: "Provavelmente cliente pagou direto no banco e o sistema não baixou. Vai em Conciliação → linha pendente → 'Confirmar manual' apontando pra venda original. Atualiza paid_at." },
+        no: 2,
+      },
+      {
+        q: 'Houve sangria ou suprimento de caixa hoje?',
+        yes: { fix: "Cheque se a sangria foi lançada como saída e o suprimento como entrada. Em Caixa do dia → 'Movimentos'. Se faltar, lance retroativo com motivo." },
+        no: 3,
+      },
+      {
+        q: 'Cliente fez PIX direto pra conta pessoal do Wagner?',
+        yes: { fix: "Pessoa-jurídica ≠ pessoa-física. Wagner registra como 'aporte do sócio' e a venda fica em aberto. Pede o PIX correto pra conta da empresa." },
+        no: { fix: 'Diferença não-trivial. Compare 3 últimos dias contra OFX, baixa de Inter (web), confronta cada linha. Se persistir, abre chamado com a contabilidade.' },
+      },
+    ],
+  },
+  {
+    id: 'tr-boleto-pago-2x',
+    title: 'Cliente pagou o mesmo boleto 2 vezes',
+    equip: 'boleto',
+    hue: 240,
+    when: 'cliente entrou em contato reclamando · duplicidade',
+    steps: [
+      {
+        q: 'As duas baixas estão visíveis no extrato Inter?',
+        yes: 1,
+        no: { fix: 'Cliente diz que pagou 2× mas só 1 baixa apareceu — pode ser estorno automático do banco origem. Aguardar 24h. Se confirmar duplicidade no extrato dele (pedir comprovante), aí investiga.' },
+      },
+      {
+        q: 'O cliente quer estorno ou crédito pra próxima compra?',
+        yes: { fix: "Crédito: cria lançamento payable manual no Financeiro com a contraparte do cliente, marca 'crédito disponível' e abate na próxima venda. Não emite NF-e nova." },
+        no: 2,
+      },
+      {
+        q: 'Foram menos de 24h da segunda baixa?',
+        yes: { fix: "Pede estorno via Inter API (módulo Boleto → boleto → 'Estornar'). SEFAZ não envolve porque a NF-e original está correta. Cliente recebe via PIX em algumas horas." },
+        no: { fix: "Após 24h, faz transferência manual TED/PIX devolvendo o valor a mais. Documenta no comentário do lançamento financeiro: 'Devolução por duplicidade · ref. PIX X'." },
+      },
+    ],
+  },
+  {
+    id: 'tr-fornecedor-cobrou-errado',
+    title: 'Fornecedor cobrou diferente do pedido',
+    equip: 'compras',
+    hue: 60,
+    when: 'NF chegou maior que orçado · #PC-NNN',
+    steps: [
+      {
+        q: 'A diferença é menor que 5% do total do pedido?',
+        yes: { fix: 'Tolerância normal de oscilação de insumo. Aceita, lança no payable normal, anota a diferença. Se for sistemática (mesmo fornecedor 3× seguidas), renegocia.' },
+        no: 1,
+      },
+      {
+        q: 'Houve mudança de quantidade ou produto não combinado?',
+        yes: { fix: 'Recusa a NF (não dá entrada no estoque). Pede ao fornecedor pra emitir NF de DEVOLUÇÃO da diferença ou refazer a nota correta. Não paga até regularizar.' },
+        no: 2,
+      },
+      {
+        q: 'Frete ou ICMS-ST veio sem aviso?',
+        yes: { fix: "Cheque o pedido de compra original (#PC-NNN). Se frete não foi orçado, é discussão. Se foi 'FOB' (por conta do destinatário), você paga separado. ICMS-ST geralmente é repassado e ok." },
+        no: { fix: 'Diferença não justificada. Abre conversa formal com fornecedor (e-mail, não WhatsApp). Suspende próximos pedidos até esclarecer. Se reincidente, troca de fornecedor.' },
+      },
+    ],
+  },
+  {
+    id: 'tr-nfe-rejeitada-fin',
+    title: 'Rejeição da SEFAZ chegou no Financeiro',
+    equip: 'fiscal',
+    hue: 25,
+    when: 'venda já pendurada · #V- + rejeição',
+    steps: [
+      {
+        q: 'Já abriu o drawer da venda original pra ver o motivo?',
+        yes: 1,
+        no: { fix: 'Vai primeiro no drawer da venda (#V-NNNN no campo desc). Veja a aba Fiscal · status NF-e. Lá tem o código de rejeição SEFAZ específico.' },
+      },
+      {
+        q: 'É código 539 (duplicidade) ou 692 (IE inválida)?',
+        yes: { fix: "Esses são os 2 mais comuns. Há troubleshooter próprio no Vendas: drawer da venda → footer → '? Resolver: NF-e rejeitada'. Ele te leva pelo passo-a-passo." },
+        no: 2,
+      },
+      {
+        q: 'O cliente já pagou antes da rejeição?',
+        yes: { fix: 'Cliente recebe o produto/serviço, você recebe o dinheiro, mas a NF não está autorizada. Tem 24h pra inutilizar o número rejeitado e emitir o próximo. Avise a Eliana pra não conciliar até resolver.' },
+        no: { fix: 'Sem pagamento ainda, sem pressa. Vendedor resolve a rejeição na venda original e re-emite. Financeiro continua aguardando paid_at.' },
+      },
+    ],
+  },
+];
+
+interface FinTroubleshooterDialogProps {
+  open: boolean;
+  onClose: () => void;
+  suggestedId?: string | null;
+}
+
+export function FinTroubleshooterDialog({ open, onClose, suggestedId = null }: FinTroubleshooterDialogProps) {
+  const [activeId, setActiveId] = useState<string | null>(null);
+  const [stepIdx, setStepIdx] = useState(0);
+  const [resolution, setResolution] = useState<string | null>(null);
+
+  const active = useMemo(() => FIN_TROUBLES.find((t) => t.id === activeId), [activeId]);
+
+  // Sugere automaticamente quando abre com suggestedId
+  useEffect(() => {
+    if (open && suggestedId) {
+      setActiveId(suggestedId);
+      setStepIdx(0);
+      setResolution(null);
+    }
+    if (!open) {
+      setActiveId(null);
+      setStepIdx(0);
+      setResolution(null);
+    }
+  }, [open, suggestedId]);
+
+  const handleAnswer = useCallback((answer: 'yes' | 'no') => {
+    if (!active) return;
+    const step = active.steps[stepIdx];
+    const next = answer === 'yes' ? step.yes : step.no;
+    if (typeof next === 'number') {
+      setStepIdx(next);
+    } else {
+      setResolution(next.fix);
+    }
+  }, [active, stepIdx]);
+
+  const handleRestart = useCallback(() => {
+    setStepIdx(0);
+    setResolution(null);
+  }, []);
+
+  const handleBackToList = useCallback(() => {
+    setActiveId(null);
+    setStepIdx(0);
+    setResolution(null);
+  }, []);
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div className="fin-trouble-backdrop" onClick={onClose} aria-hidden="true" />
+      <div className="fin-trouble-dialog" role="dialog" aria-labelledby="fin-trouble-title">
+        <header className="fin-trouble-h">
+          <div>
+            <h2 id="fin-trouble-title">? Resolver problemas comuns</h2>
+            <small>4 fluxos de decisão · troubleshooter financeiro</small>
+          </div>
+          <button type="button" className="fin-trouble-x" onClick={onClose} aria-label="Fechar">×</button>
+        </header>
+
+        {!active && (
+          <div className="fin-trouble-list">
+            {FIN_TROUBLES.map((t) => (
+              <button
+                key={t.id}
+                type="button"
+                className="fin-trouble-card"
+                style={{ '--tr-hue': t.hue } as React.CSSProperties}
+                onClick={() => { setActiveId(t.id); setStepIdx(0); setResolution(null); }}
+              >
+                <div className="fin-trouble-card-h">
+                  <span className="fin-trouble-card-equip">{t.equip}</span>
+                  <h3>{t.title}</h3>
+                </div>
+                <small>{t.when}</small>
+                <span className="fin-trouble-card-arrow" aria-hidden="true">→</span>
+              </button>
+            ))}
+          </div>
+        )}
+
+        {active && !resolution && (
+          <div className="fin-trouble-flow">
+            <div className="fin-trouble-flow-h">
+              <button type="button" className="fin-trouble-back" onClick={handleBackToList}>← Voltar</button>
+              <h3 style={{ '--tr-hue': active.hue } as React.CSSProperties}>{active.title}</h3>
+              <small>Passo {stepIdx + 1} de {active.steps.length}</small>
+            </div>
+            <div className="fin-trouble-step">
+              <p className="fin-trouble-q">{active.steps[stepIdx].q}</p>
+              <div className="fin-trouble-answers">
+                <button type="button" className="fin-trouble-answer yes" onClick={() => handleAnswer('yes')}>Sim</button>
+                <button type="button" className="fin-trouble-answer no" onClick={() => handleAnswer('no')}>Não</button>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {active && resolution && (
+          <div className="fin-trouble-resolution">
+            <div className="fin-trouble-flow-h">
+              <button type="button" className="fin-trouble-back" onClick={handleBackToList}>← Lista</button>
+              <h3 style={{ '--tr-hue': active.hue } as React.CSSProperties}>{active.title}</h3>
+            </div>
+            <div className="fin-trouble-fix">
+              <span className="fin-trouble-fix-ic" style={{ '--tr-hue': active.hue } as React.CSSProperties}>✓</span>
+              <p>{resolution}</p>
+            </div>
+            <div className="fin-trouble-footer">
+              <button type="button" className="fin-trouble-restart" onClick={handleRestart}>↻ Refazer este fluxo</button>
+              <button type="button" className="fin-trouble-back" onClick={handleBackToList}>← Outro problema</button>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+/** Botão "? Resolver" pra pôr no footer ou drawer. */
+interface FinTroubleButtonProps {
+  onClick: () => void;
+  label?: string;
+}
+export function FinTroubleButton({ onClick, label = '? Resolver' }: FinTroubleButtonProps): ReactNode {
+  return (
+    <button
+      type="button"
+      className="fin-trouble-trigger"
+      onClick={onClick}
+      title={`Troubleshooter: ${FIN_TROUBLES.length} fluxos de decisão`}
+    >
+      {label}
+      <span className="fin-trouble-count">{FIN_TROUBLES.length}</span>
+    </button>
+  );
+}
+
+export default FinTroubleshooterDialog;


### PR DESCRIPTION
Substitui `alert()` do botão "▶ Apresentar" + adiciona "? Resolver" no footer com 4 árvores de decisão canônicas.

## 2 components novos

### FinTroubleshooter.tsx (~210 LOC)
Dialog modal com 4 árvores Q/A canônicas:
1. **Saldo extrato não bate** (conciliação) — 4 steps
2. **Cliente pagou boleto 2×** (boleto) — 3 steps
3. **Fornecedor cobrou diferente** (compras) — 3 steps
4. **Rejeição SEFAZ no Financeiro** (fiscal) — 3 steps

3 UI states: lista (4 cards coloridos por hue) → flow (Q/Sim/Não) → resolution (✓ fix).

### FinPresentationMode.tsx (~180 LOC)
Fullscreen modal dark blue pra reunião sócio:
- Overview: hero KPI 64px + 4 cards big abreviados (R$ 5,4M)
- Parties: top 10 contrapartes (recebido / pago / saldo / count)
- Categories: top 10 categorias (total + count)

Atalhos: `Esc` fecha, `1`/`2`/`3` muda view.

## CSS escopado fin-output.css (+450 LOC)

- `.fin-trouble-*` (backdrop / dialog / list / flow / resolution / trigger)
- `.fin-present-*` (header / nav / hero / grid / table / footer)

## Tests

`Modules/Financeiro/Tests/Feature/Onda7bTroubleshootPresentTest.php` — 12 testes (45 assertions). Pest **PASS 12/12 in 4.93s**.

## Out of scope (Onda 7c)
- ❌ FinTranscriptPDF (folha jurídica imprimível)
- ❌ useFinFavs hook (favoritos atalho B)

Re: Wagner screenshot biz=4 "deu certo" 2026-05-18, Onda 8 PR #1082, Onda 8b PR #1084.