### PR TITLE
feat(financeiro): Onda Edit — Edit Sheet inline + Conferido per-user DB + cross-links auto-pop

### DIFF
--- a/Modules/Financeiro/Database/Migrations/2026_05_18_180000_add_conferido_to_fin_titulos.php
+++ b/Modules/Financeiro/Database/Migrations/2026_05_18_180000_add_conferido_to_fin_titulos.php
@@ -1,0 +1,94 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Conferido per-user (Onda Edit 2026-05-18).
+ *
+ * Eliana confere ≠ Wagner confere — audit trail mostra QUEM marcou. Substitui
+ * persistência localStorage do FinConferidoToggle (Onda 5 R1) por DB sync MCP.
+ *
+ * Per-user (FK users.id ON DELETE SET NULL): user removido preserva audit do título,
+ * só desliga vínculo de identidade. Idempotente (`Schema::hasColumn`) — sobrevive re-run.
+ */
+class AddConferidoToFinTitulos extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('fin_titulos', function (Blueprint $table) {
+            if (! Schema::hasColumn('fin_titulos', 'conferido_by')) {
+                $table->integer('conferido_by')->unsigned()->nullable()
+                    ->after('updated_by')
+                    ->comment('FK users.id — quem marcou como conferido (per-user audit)');
+            }
+            if (! Schema::hasColumn('fin_titulos', 'conferido_at')) {
+                $table->timestamp('conferido_at')->nullable()
+                    ->after('conferido_by')
+                    ->comment('Timestamp da conferência');
+            }
+        });
+
+        // FK em bloco separado (idempotente — verifica se já existe pelo info schema).
+        // MySQL não tem IF NOT EXISTS pra FK; usa try/catch via raw query check.
+        $database = config('database.connections.'.config('database.default').'.database');
+        $fkExists = collect(\DB::select(
+            "SELECT CONSTRAINT_NAME FROM information_schema.KEY_COLUMN_USAGE
+             WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'fin_titulos'
+             AND COLUMN_NAME = 'conferido_by' AND REFERENCED_TABLE_NAME = 'users'",
+            [$database]
+        ))->isNotEmpty();
+
+        if (! $fkExists) {
+            Schema::table('fin_titulos', function (Blueprint $table) {
+                $table->foreign('conferido_by', 'fk_titulo_conferido_by')
+                    ->references('id')->on('users')
+                    ->onDelete('set null');
+            });
+        }
+
+        // Index pra queries "conferidos por user X" e "não conferidos do business".
+        if (! collect(\DB::select(
+            "SHOW INDEX FROM fin_titulos WHERE Key_name = 'idx_business_conferido'"
+        ))->isNotEmpty()) {
+            Schema::table('fin_titulos', function (Blueprint $table) {
+                $table->index(['business_id', 'conferido_by'], 'idx_business_conferido');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        Schema::table('fin_titulos', function (Blueprint $table) {
+            if (collect(\DB::select(
+                "SHOW INDEX FROM fin_titulos WHERE Key_name = 'idx_business_conferido'"
+            ))->isNotEmpty()) {
+                $table->dropIndex('idx_business_conferido');
+            }
+        });
+
+        $database = config('database.connections.'.config('database.default').'.database');
+        $fkExists = collect(\DB::select(
+            "SELECT CONSTRAINT_NAME FROM information_schema.KEY_COLUMN_USAGE
+             WHERE TABLE_SCHEMA = ? AND TABLE_NAME = 'fin_titulos'
+             AND CONSTRAINT_NAME = 'fk_titulo_conferido_by'",
+            [$database]
+        ))->isNotEmpty();
+
+        if ($fkExists) {
+            Schema::table('fin_titulos', function (Blueprint $table) {
+                $table->dropForeign('fk_titulo_conferido_by');
+            });
+        }
+
+        Schema::table('fin_titulos', function (Blueprint $table) {
+            if (Schema::hasColumn('fin_titulos', 'conferido_at')) {
+                $table->dropColumn('conferido_at');
+            }
+            if (Schema::hasColumn('fin_titulos', 'conferido_by')) {
+                $table->dropColumn('conferido_by');
+            }
+        });
+    }
+}

--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Carbon;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Financeiro\Http\Requests\UpdateTituloRequest;
 use Modules\Financeiro\Models\Categoria;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Models\Titulo;
@@ -53,6 +54,7 @@ class UnificadoController extends Controller
             ->whereIn('status', ['aberto', 'parcial', 'quitado'])
             ->with([
                 'categoria:id,nome',
+                'conferidoPor:id,first_name,last_name,username',
                 'baixas' => fn ($q) => $q->orderByDesc('data_baixa'),
                 'baixas.contaBancaria.account:id,name',
             ]);
@@ -139,6 +141,79 @@ class UnificadoController extends Controller
                 ['label' => 'Novo lançamento', 'href' => null],
             ],
         ]);
+    }
+
+    /**
+     * PUT /financeiro/unificado/{id}
+     * Edit Sheet inline (Onda Edit 2026-05-18). Campos seguros: descricao,
+     * observacoes, categoria_id, vencimento. valor_total mutável só se status
+     * aberto/parcial (ADR fin-tech/0002 imutabilidade pós-baixa).
+     */
+    public function update(UpdateTituloRequest $request, int $id): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+
+        $titulo = Titulo::where('business_id', $businessId)->findOrFail($id);
+        $request->assertValorMutavel($titulo);
+
+        $payload = [
+            'cliente_descricao' => $request->input('cliente_descricao'),
+            'observacoes' => $request->input('observacoes'),
+            'categoria_id' => $request->input('categoria_id') ?: null,
+            'vencimento' => $request->date('vencimento')->toDateString(),
+            'updated_by' => $request->user()->id,
+        ];
+
+        if ($request->has('valor_total')) {
+            $valorTotal = (float) $request->input('valor_total');
+            // Recalcula valor_aberto preservando baixas existentes.
+            $somaBaixas = (float) $titulo->baixas()->sum('valor_baixa');
+            $payload['valor_total'] = $valorTotal;
+            $payload['valor_aberto'] = max(0, $valorTotal - $somaBaixas);
+        }
+
+        $titulo->fill($payload)->save();
+
+        return back()->with('success', "Lançamento {$titulo->numero} atualizado.");
+    }
+
+    /**
+     * POST /financeiro/unificado/{id}/conferir
+     * Marca título como conferido pelo user atual (Eliana/Wagner — audit per-user).
+     * Idempotente: re-marcar não altera timestamp original.
+     */
+    public function conferir(Request $request, int $id): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+
+        $titulo = Titulo::where('business_id', $businessId)->findOrFail($id);
+
+        if ($titulo->conferido_by !== null) {
+            return back()->with('info', 'Lançamento já conferido.');
+        }
+
+        $titulo->conferido_by = $request->user()->id;
+        $titulo->conferido_at = now();
+        $titulo->save();
+
+        return back()->with('success', 'Lançamento conferido.');
+    }
+
+    /**
+     * DELETE /financeiro/unificado/{id}/conferir
+     * Desmarca conferido (caso usuário detecte que conferiu por engano).
+     */
+    public function unconferir(Request $request, int $id): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+
+        $titulo = Titulo::where('business_id', $businessId)->findOrFail($id);
+
+        $titulo->conferido_by = null;
+        $titulo->conferido_at = null;
+        $titulo->save();
+
+        return back()->with('success', 'Conferência removida.');
     }
 
     /**
@@ -288,6 +363,11 @@ class UnificadoController extends Controller
         $descricao = $t->cliente_descricao
             ?: ($metadata['descricao'] ?? "Titulo {$t->numero}");
 
+        $conferidoUser = $t->relationLoaded('conferidoPor') ? $t->conferidoPor : null;
+        $conferidoNome = $conferidoUser
+            ? trim(($conferidoUser->first_name ?? '').' '.($conferidoUser->last_name ?? '')) ?: ($conferidoUser->username ?? null)
+            : null;
+
         return [
             'id' => $t->id,
             'kind' => $kind,
@@ -296,6 +376,7 @@ class UnificadoController extends Controller
             'contraparte' => $t->cliente_descricao ?? '—',
             'contraparte_doc' => $metadata['cliente_documento'] ?? null,
             'categoria' => $t->categoria?->nome ?? 'Sem categoria',
+            'categoria_id' => $t->categoria_id,
             'conta_bancaria' => $contaBancariaNome,
             'vencimento' => $t->vencimento?->toDateString(),
             'vencimento_label' => $t->vencimento?->locale('pt_BR')->isoFormat('ddd, DD MMM'),
@@ -304,6 +385,10 @@ class UnificadoController extends Controller
             'nfe_numero' => $nfeNumero,
             'canal' => $canal,
             'observacao' => $t->observacoes,
+            'conferido_by' => $t->conferido_by,
+            'conferido_at' => $t->conferido_at?->toIso8601String(),
+            'conferido_user_nome' => $conferidoNome,
+            'valor_mutavel' => ! in_array($t->status, ['quitado', 'cancelado'], true),
         ];
     }
 

--- a/Modules/Financeiro/Http/Requests/UpdateTituloRequest.php
+++ b/Modules/Financeiro/Http/Requests/UpdateTituloRequest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Modules\Financeiro\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Modules\Financeiro\Models\Categoria;
+use Modules\Financeiro\Models\Titulo;
+
+/**
+ * Validação do Edit Sheet de título financeiro (Onda Edit 2026-05-18).
+ *
+ * Campos sempre editáveis (R-FIN-008): cliente_descricao, observacoes,
+ * categoria_id, vencimento — não afetam contabilidade.
+ *
+ * Campos com guard de imutabilidade (ADR fin-tech/0002): valor_total só pode
+ * ser editado se status='aberto' OR 'parcial' (sem baixa registrada). Pós-baixa
+ * (status='quitado' OR 'cancelado'), valor é READ-ONLY pra preservar histórico
+ * contábil/fiscal.
+ *
+ * Campos NUNCA editáveis (anti-corrupção): tipo, origem, origem_id, status,
+ * emissao, competencia_mes, business_id. Alterar requer cancelar+criar novo
+ * (workflow append-only).
+ */
+class UpdateTituloRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        // Permission gate já aplicada no Controller::__construct via
+        // can:financeiro.dashboard.view. Re-check explícito (defesa em profundidade).
+        return $this->user()?->can('financeiro.dashboard.view') ?? false;
+    }
+
+    public function rules(): array
+    {
+        $businessId = (int) session('user.business_id');
+
+        return [
+            'cliente_descricao' => ['nullable', 'string', 'max:255'],
+            'observacoes' => ['nullable', 'string', 'max:2000'],
+            'categoria_id' => [
+                'nullable', 'integer',
+                Rule::exists((new Categoria)->getTable(), 'id')
+                    ->where('business_id', $businessId)
+                    ->whereNull('deleted_at'),
+            ],
+            'vencimento' => ['required', 'date'],
+            'valor_total' => ['sometimes', 'numeric', 'min:0.01', 'max:9999999999.99'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'categoria_id.exists' => 'Categoria não pertence a este negócio.',
+            'vencimento.required' => 'Vencimento obrigatório.',
+            'valor_total.min' => 'Valor deve ser positivo.',
+        ];
+    }
+
+    /**
+     * Guard de imutabilidade: bloqueia valor_total se status quitado/cancelado.
+     * Chamado pelo Controller após validação básica passar.
+     */
+    public function assertValorMutavel(Titulo $titulo): void
+    {
+        if (! $this->has('valor_total')) {
+            return;
+        }
+        if (in_array($titulo->status, ['quitado', 'cancelado'], true)) {
+            abort(422, "Valor de título {$titulo->status} é imutável (preserva histórico contábil).");
+        }
+    }
+}

--- a/Modules/Financeiro/Models/Titulo.php
+++ b/Modules/Financeiro/Models/Titulo.php
@@ -45,6 +45,7 @@ class Titulo extends Model
         'plano_conta_id', 'categoria_id',
         'observacoes', 'metadata',
         'created_by', 'updated_by',
+        'conferido_by', 'conferido_at',
     ];
 
     protected $casts = [
@@ -53,7 +54,13 @@ class Titulo extends Model
         'emissao' => 'date',
         'vencimento' => 'date',
         'metadata' => 'array',
+        'conferido_at' => 'datetime',
     ];
+
+    public function conferidoPor(): BelongsTo
+    {
+        return $this->belongsTo(\App\User::class, 'conferido_by');
+    }
 
     public function planoConta(): BelongsTo
     {

--- a/Modules/Financeiro/Routes/web.php
+++ b/Modules/Financeiro/Routes/web.php
@@ -58,6 +58,16 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
         Route::post('/unificado/{id}/baixar', [UnificadoController::class, 'baixar'])
             ->whereNumber('id')
             ->name('unificado.baixar');
+        // Onda Edit 2026-05-18 — edit Sheet inline + conferido per-user DB.
+        Route::put('/unificado/{id}', [UnificadoController::class, 'update'])
+            ->whereNumber('id')
+            ->name('unificado.update');
+        Route::post('/unificado/{id}/conferir', [UnificadoController::class, 'conferir'])
+            ->whereNumber('id')
+            ->name('unificado.conferir');
+        Route::delete('/unificado/{id}/conferir', [UnificadoController::class, 'unconferir'])
+            ->whereNumber('id')
+            ->name('unificado.unconferir');
 
         // Fluxo de caixa projetado — Cockpit V2 (US-FIN-014) — protótipo Cowork 2026-05-09
         // Q1-Q4 aprovadas [W] 2026-05-14. Read-only. Ver Index.charter.md + fluxo-visual-comparison.md.

--- a/Modules/Financeiro/Services/TituloAutoService.php
+++ b/Modules/Financeiro/Services/TituloAutoService.php
@@ -86,6 +86,20 @@ class TituloAutoService
 
             $numero = $existing?->numero ?? $this->proximoNumero($tx->business_id, $tipo);
 
+            // Onda Edit 2026-05-18 — cross-link auto-pop em `cliente_descricao`.
+            // Formato: "{ContactName} · #V-{txId}" (venda) ou "{ContactName} · #PC-{txId}" (compra).
+            // FinCrossLinkify (frontend) parseia esses tokens e renderiza pills clicáveis
+            // que roteiam pro Sells/Compras de origem. Preserva edit manual do user:
+            // se $existing já tem cliente_descricao preenchido, NÃO sobrescreve.
+            $cliente = $tx->contact_id ? \App\Contact::find($tx->contact_id) : null;
+            $contactName = $cliente?->name ?: ($cliente?->supplier_business_name ?: null);
+            $crossLinkPrefix = $tipo === 'receber' ? 'V' : 'PC';
+            $crossLink = sprintf('#%s-%d', $crossLinkPrefix, $tx->id);
+            $descricaoSugerida = $contactName ? "{$contactName} · {$crossLink}" : $crossLink;
+            $clienteDescricaoFinal = ($existing && ! empty($existing->cliente_descricao))
+                ? $existing->cliente_descricao
+                : $descricaoSugerida;
+
             // SUPERADMIN: idem Observer — updateOrCreate com business_id da Transaction
             return Titulo::query()
                 ->withoutGlobalScope(BusinessScopeImpl::class)
@@ -101,6 +115,7 @@ class TituloAutoService
                         'tipo' => $tipo,
                         'status' => $valorAberto > 0 ? ($valorPago > 0 ? 'parcial' : 'aberto') : 'quitado',
                         'cliente_id' => $tx->contact_id,
+                        'cliente_descricao' => $clienteDescricaoFinal,
                         'valor_total' => $valorTotal,
                         'valor_aberto' => $valorAberto,
                         'moeda' => 'BRL',
@@ -112,6 +127,7 @@ class TituloAutoService
                         'metadata' => [
                             'auto_created' => true,
                             'transaction_invoice_no' => $tx->invoice_no,
+                            'cross_link' => $crossLink,
                         ],
                     ]
                 );

--- a/Modules/Financeiro/Tests/Feature/UnificadoControllerTest.php
+++ b/Modules/Financeiro/Tests/Feature/UnificadoControllerTest.php
@@ -151,3 +151,142 @@ it('Non-Goal: rota /unificado é GET-only — POST/PUT/DELETE retornam 405', fun
         expect($r->status())->toBeIn([405, 419, 404]);
     }
 });
+
+// ─────────────────────── Onda Edit 2026-05-18 — Edit Sheet + Conferido per-user ───────────────────────
+
+it('Edit Sheet: PUT /unificado/{id} atualiza campos seguros', function () {
+    $user = unificadoBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    $titulo = \Modules\Financeiro\Models\Titulo::where('business_id', $businessId)
+        ->where('status', 'aberto')
+        ->first();
+
+    if (! $titulo) {
+        test()->markTestSkipped('Sem título aberto pra editar neste env.');
+    }
+
+    $payload = [
+        'cliente_descricao' => 'Descrição editada Pest',
+        'observacoes' => 'Editado via test '.now()->toIso8601String(),
+        'categoria_id' => null,
+        'vencimento' => now()->addDays(15)->toDateString(),
+    ];
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/unificado')
+        ->put("/financeiro/unificado/{$titulo->id}", $payload);
+
+    expect($response->status())->toBeIn([302, 303]);
+
+    $titulo->refresh();
+    expect($titulo->cliente_descricao)->toBe('Descrição editada Pest');
+    expect($titulo->vencimento->toDateString())->toBe(now()->addDays(15)->toDateString());
+});
+
+it('Edit Sheet: valor_total mutável só se status aberto/parcial (ADR fin-tech/0002)', function () {
+    $user = unificadoBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    $quitado = \Modules\Financeiro\Models\Titulo::where('business_id', $businessId)
+        ->where('status', 'quitado')
+        ->first();
+
+    if (! $quitado) {
+        test()->markTestSkipped('Sem título quitado pra testar imutabilidade.');
+    }
+
+    $valorOriginal = (float) $quitado->valor_total;
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/unificado')
+        ->put("/financeiro/unificado/{$quitado->id}", [
+            'cliente_descricao' => $quitado->cliente_descricao,
+            'observacoes' => $quitado->observacoes,
+            'categoria_id' => $quitado->categoria_id,
+            'vencimento' => $quitado->vencimento->toDateString(),
+            'valor_total' => 99999.99,
+        ]);
+
+    // Espera 422 (abort no assertValorMutavel) ou redirect com error flash
+    expect($response->status())->toBeIn([422, 302, 303]);
+
+    $quitado->refresh();
+    expect((float) $quitado->valor_total)->toBe($valorOriginal);
+});
+
+it('Tier 0: PUT /unificado/{id} retorna 404 quando título pertence a outro business', function () {
+    $user = unificadoBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    // Título de outro business (qualquer ID inexistente neste tenant)
+    $outroTitulo = \Modules\Financeiro\Models\Titulo::query()
+        ->withoutGlobalScope(\Modules\Financeiro\Models\Concerns\BusinessScopeImpl::class)
+        ->where('business_id', '!=', $businessId)
+        ->first();
+
+    if (! $outroTitulo) {
+        test()->markTestSkipped('Apenas 1 business no DB — não há cross-tenant pra testar.');
+    }
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/unificado')
+        ->put("/financeiro/unificado/{$outroTitulo->id}", [
+            'cliente_descricao' => 'tentativa cross-tenant',
+            'observacoes' => null,
+            'categoria_id' => null,
+            'vencimento' => now()->addDays(7)->toDateString(),
+        ]);
+
+    expect($response->status())->toBe(404);
+});
+
+it('Conferir: POST /unificado/{id}/conferir marca user + timestamp', function () {
+    $user = unificadoBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    $titulo = \Modules\Financeiro\Models\Titulo::where('business_id', $businessId)
+        ->whereNull('conferido_by')
+        ->first();
+
+    if (! $titulo) {
+        test()->markTestSkipped('Todos títulos já conferidos neste env.');
+    }
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/unificado')
+        ->post("/financeiro/unificado/{$titulo->id}/conferir");
+
+    expect($response->status())->toBeIn([302, 303]);
+
+    $titulo->refresh();
+    expect($titulo->conferido_by)->toBe($user->id);
+    expect($titulo->conferido_at)->not()->toBeNull();
+});
+
+it('Unconferir: DELETE /unificado/{id}/conferir limpa user + timestamp', function () {
+    $user = unificadoBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    $titulo = \Modules\Financeiro\Models\Titulo::where('business_id', $businessId)
+        ->first();
+
+    if (! $titulo) {
+        test()->markTestSkipped('Sem título neste env.');
+    }
+
+    // Marca primeiro pra ter o que limpar.
+    $titulo->conferido_by = $user->id;
+    $titulo->conferido_at = now();
+    $titulo->save();
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/unificado')
+        ->delete("/financeiro/unificado/{$titulo->id}/conferir");
+
+    expect($response->status())->toBeIn([302, 303]);
+
+    $titulo->refresh();
+    expect($titulo->conferido_by)->toBeNull();
+    expect($titulo->conferido_at)->toBeNull();
+});

--- a/memory/requisitos/Financeiro/BRIEFING.md
+++ b/memory/requisitos/Financeiro/BRIEFING.md
@@ -2,7 +2,7 @@
 
 > Visão unificada de AR/AP (Contas a Receber / Contas a Pagar) + Fluxo de Caixa + Boletos + Conciliação. Cockpit V2 persona Eliana [E] (financeiro escritório, densidade alta, atalhos teclado).
 
-**Última atualização:** 2026-05-16 · Wave 18 RETRY saturação 68→97 · Skill `brief-update` (Tier B)
+**Última atualização:** 2026-05-18 · Onda Edit PR #1086 (Edit Sheet inline + Conferido per-user DB + cross-links auto-pop) · Skill `brief-update` (Tier B)
 
 ## Estado consolidado (Wave 18 RETRY — saturação 68→97)
 
@@ -24,6 +24,9 @@
 - **Extrato** — `fin_extrato_lancamentos` para conciliação OFX/CSV (US-FIN futuros).
 - **Plano de Contas BR** — Seeder pronto (`PlanoContasBrSeeder`) + categorização hierárquica `fin_categorias`.
 - **Integrações** — `TransactionObserver` + `TransactionPaymentObserver` propagam vendas core UltimatePOS → Títulos; `CriarTituloDeVendaJob` assíncrono.
+- **Edit Sheet inline (Onda Edit 2026-05-18, PR #1086)** — `TituloEditSheet.tsx` drawer canon edita campos seguros (`cliente_descricao`, `observacoes`, `categoria_id`, `vencimento`, `valor_total` pré-baixa). PUT `/financeiro/unificado/{id}` via `useForm` Inertia. Guard `assertValorMutavel` bloqueia valor pós-baixa (ADR fin-tech/0002). Substitui STUB `<Button>Editar</Button>` linha 706 do Index.tsx.
+- **Conferido per-user DB (Onda Edit, substitui Onda 5 R1 localStorage)** — `fin_titulos.conferido_by` (FK users.id) + `conferido_at` (TIMESTAMP) + index `idx_business_conferido`. Eliana confere ≠ Wagner confere = audit per-user. Routes POST/DELETE `/unificado/{id}/conferir`. `FinConferidoToggle` rewrite: `useFinConferido(lancamentos)` consulta DB-backed via prop array.
+- **Cross-links auto-pop #V-/#PC-** — `TituloAutoService::sincronizarDeTransacaoInternal` enriquece `cliente_descricao` com `{ContactName} · #V-{tx_id}` (vendas) ou `#PC-{tx_id}` (compras) no afterCreate. FinCrossLinkify renderiza pills clicáveis route → Sells/Compras. Preserva edit manual user (não sobrescreve se já preenchido).
 
 ## Multi-tenant Tier 0 (ADR 0093)
 
@@ -38,11 +41,11 @@ Todas Models usam `BusinessScope` trait (`Modules/Financeiro/Models/Concerns/Bus
 
 ## Arquitetura
 
-- **Controllers (13):** Boleto, Categoria, ContaBancaria, ContaPagar, ContaReceber, Dashboard, Data, Extrato, Financeiro, Fluxo, Install, Relatorios, Unificado
-- **Services (4):** FluxoCaixaService (projeção read-side), TituloService (boleto lifecycle), TituloAutoService (origem auto vendas/compras), UnificadoService (facade KPIs cockpit)
+- **Controllers (13):** Boleto, Categoria, ContaBancaria, ContaPagar, ContaReceber, Dashboard, Data, Extrato, Financeiro, Fluxo, Install, Relatorios, Unificado (com `update`+`conferir`+`unconferir` Onda Edit)
+- **Services (4):** FluxoCaixaService (projeção read-side), TituloService (boleto lifecycle), TituloAutoService (origem auto vendas/compras + cross-links #V-/#PC- Onda Edit), UnificadoService (facade KPIs cockpit)
 - **Repositories (2):** TituloRepository (Wave 18), BaixaRepository (Wave 18 RETRY) — singleton, type-safe `businessId:int` 1º param
-- **Models (10):** Titulo, TituloBaixa, CaixaMovimento, Categoria, ContaBancaria, BoletoRemessa, ExtratoLancamento, PlanoConta, AccountsLegacyMap
-- **FormRequests (6):** UpsertCategoriaRequest, UpsertContaBancariaRequest, StoreTransactionRequest, UpdateTransactionRequest, StoreAccountRequest, FluxoFiltroRequest, StoreBaixaRequest (Wave 18 RETRY), UpdateAccountRequest (Wave 18 RETRY)
+- **Models (10):** Titulo (Onda Edit: +`conferidoPor()` BelongsTo App\User), TituloBaixa, CaixaMovimento, Categoria, ContaBancaria, BoletoRemessa, ExtratoLancamento, PlanoConta, AccountsLegacyMap
+- **FormRequests (7):** UpsertCategoriaRequest, UpsertContaBancariaRequest, StoreTransactionRequest, UpdateTransactionRequest, StoreAccountRequest, FluxoFiltroRequest, StoreBaixaRequest, UpdateAccountRequest, UpdateTituloRequest (Onda Edit — guard imutabilidade pós-baixa)
 - **Strategies:** `CnabDirectStrategy` (default boleto via CNAB 240)
 - **Observers:** TransactionObserver, TransactionPaymentObserver (sync vendas core → Títulos)
 - **Pages Inertia (13 charters):** Cockpit V2 padrão; Fluxo, Unificado, ContasReceber, ContasPagar, Boletos validados visualmente

--- a/memory/sessions/2026-05-18-understand-financeiro-edit-8-gaps.md
+++ b/memory/sessions/2026-05-18-understand-financeiro-edit-8-gaps.md
@@ -1,0 +1,306 @@
+---
+slug: 2026-05-18-understand-financeiro-edit-8-gaps
+title: "wagner-understand — implementar Edit do Financeiro (drawer Sheet) + 8 gaps Cowork"
+type: understand-decode
+date: 2026-05-18
+session: youthful-matsumoto-21811c
+spawned_by: claude-pai
+status: ready-for-execution
+related_module: Financeiro
+related_adrs: [0093, 0094, 0104, 0107, 0114, 0143, 'fin-ui/0002', 'fin-ui/0003', 'fin-tech/0001', 'fin-tech/0002']
+related_us: [US-FIN-013, US-FIN-020, US-FIN-021]
+referenced_prototype: prototipo-ui/prototipos/financeiro-unificado/visual-source.html
+---
+
+# Decodificação
+
+## Pedido cru de Wagner (texto exato)
+
+> "acesso a rquivos se precisar
+> Fetch this design file, read its readme, and implement the relevant aspects of the design. https://api.anthropic.com/v1/design/h/NBcYUr1FsA-CvD_xJ82Jaw?open_file=Oimpresso+ERP+-+Chat.html
+> Implement: Oimpresso ERP - Chat.html
+> teria que implemnetar o edit do financeiro"
+
+> Antes desse texto, Wagner colou doc inline `GAPS_FINANCEIRO_PRA_CODE.md` listando **8 gaps** entre Financeiro prod e padrão Cowork:
+> 1. Filtros multi-select com lifecycle states (a vencer / em atraso / pago / sem categoria)
+> 2. Categorias reais cadastradas + `desc` com #V-NNNN / #OS-NNNN / #PC-NNNN
+> 3. Cross-links #V-/#OS-/#PC- (já existe `FinCrossLinkify`)
+> 4. `FinPillFrescor` 6 estados (já existe)
+> 5. Classes `.fin-btn-ai`/`.fin-btn-trilha`/`.fin-btn-present` (já existem)
+> 6. **"Conferido"** (curadoria Eliana) vs **"Paguei"** (estado FSM) como conceitos distintos
+> 7. **Drawer detalhe completo** (anomalia + party history + audit + comentários — já existe)
+> 8. Migration `conferido_by` + `conferido_at` na tabela `fin_titulos` (curadoria backend, não localStorage)
+
+## Decodificação refinada
+
+| Campo | Inferência |
+|---|---|
+| **Objetivo principal cirúrgico** | **Implementar o "edit do financeiro"** = drawer Sheet com botão "Editar" funcional. Hoje o botão `<Button variant="outline">Editar</Button>` em `Index.tsx:706` é stub sem onClick. |
+| **Objetivo secundário** | Promover **`conferido`** de localStorage → tabela (gap 6 + gap 8) — é a única dívida estrutural genuína. Resto dos 8 gaps Wagner já está implementado parcialmente ou totalmente. |
+| **Gap fantasma** | Wagner listou 8 gaps mas **6 deles já estão implementados na branch atual** (FinCrossLinkify, FinPillFrescor, FinAnomalyDetector, FinPartyHistory, FinAuditTrail, FinCommentsThread, classes `.fin-btn-*`). O documento `GAPS_FINANCEIRO_PRA_CODE.md` que Wagner colou parece desatualizado (pré-Ondas 5/6/7/7b/8/8b mergeadas em PRs #1064-#1085). |
+| **Critério de pronto cirúrgico** | (a) clicar "Editar" no drawer abre form preenchido com `Titulo` real; (b) salvar atualiza `cliente_descricao`/`categoria_id`/`vencimento`/`observacoes` (campos editáveis seguros pré-baixa); (c) Pest cross-tenant biz=1 vs biz=99 + idempotência; (d) smoke Brave em prod logado biz=1 mostra drawer abre e save funciona. |
+| **Critério de pronto expandido (8 gaps)** | drawer edit + migration `conferido_by`/`conferido_at` + POST `/unificado/{id}/conferir` (com auth + business_id scope) + FinConferidoToggle reescrito pra Inertia POST em vez de localStorage. |
+| **Persona alvo** | **Eliana [E]** (advogada+financeiro, escritório, densidade alta, monitor desktop — não mobile). Charter confirma. |
+| **Implícitos** | (1) Edit NÃO substitui rotas legacy `/contas-receber/{id}` e `/contas-pagar/{id}` — coexistem; (2) Edit NÃO é cancelamento/estorno (não-goal explícito do charter); (3) campos imutáveis pós-baixa (`valor_total`, `tipo`, `origem`) ficam read-only no drawer; (4) idempotência (ADR fin-tech/0001) — `updated_by` + auditoria. |
+| **Ambiguidades a confirmar** | (a) Wagner quer **modal/sheet inline** ou usar **rotas legacy** `/contas-receber/{id}/edit`? Charter Non-Goal #2 diz "drawer leva pra rotas de edição existentes" — Wagner quer mudar essa decisão? (b) `conferido` é per-user (Eliana ≠ Wagner ≠ Bruna) ou per-business único? (c) URL design API: `https://api.anthropic.com/v1/design/h/NBcYUr1FsA-CvD_xJ82Jaw` — Wagner colou link de "Oimpresso ERP - Chat.html" que sugere uma tela "Chat" — relevância pro Financeiro/Edit? Confirmar antes de codar. |
+
+---
+
+# Regras protocolo aplicáveis (R1-R11)
+
+| Regra | Aplica? | O que exige neste pedido |
+|---|---|---|
+| **R1 Smoke real** | ✅ | Pós-merge edit drawer: abrir Brave/Chrome MCP em `oimpresso.com/financeiro/unificado` logado biz=1, clicar linha, clicar Editar, salvar, screenshot + console clean. Sem isso, não é "feito". |
+| **R2 Cópia literal design** | 🟡 parcial | Se Wagner aprovou screenshot de "Oimpresso ERP - Chat.html" mostrando drawer edit específico, cópia integral. Se não, drawer edit segue padrão `CategoriaSheet.tsx` (existente no projeto, mesmo módulo). Confirmar com Wagner ANTES de inflar. |
+| **R3 Workflow 3 fases** | ✅ obrigatório | PRE-FLIGHT: ler `memory/requisitos/Financeiro/SPEC.md` + `RUNBOOK-transaction-payment.md` + `ADR fin-ui/0002` + `ADR fin-ui/0003` (amendment unificado) + `ADR fin-tech/0001` (idempotência) + `ADR fin-tech/0002` (soft-delete imutabilidade). DURING: commits incrementais. POST: PR + CI verde + smoke + brief-update Tier B. |
+| **R4 Multi-tenant Tier 0** | ✅ obrigatório | (a) Migration `conferido_by`/`conferido_at` em `fin_titulos` — não precisa adicionar `business_id` (tabela já tem); (b) UPDATE no controller `Titulo::where('business_id', $businessId)->findOrFail($id)`; (c) Pest cross-tenant biz=1 vs biz=99 atualiza só do próprio tenant. |
+| **R5 PT-BR + economia** | ✅ | Form labels PT-BR ("Descrição", "Categoria", "Vencimento", "Salvar", "Cancelar"). **Confirmar escopo ANTES de codar** (8 gaps ≈ 600+ LOC; só drawer edit ≈ 200 LOC + migration). Wagner ambiguidades 3 itens acima precisam responder. |
+| **R6 biz=1 não biz=4** | ✅ | Pest fixtures biz=1. Smoke Brave logado Wagner (biz=1 ou biz=164), nunca Larissa (biz=4 ROTA LIVRE prod). |
+| **R7 Charter + visual-comparison** | ✅ obrigatório | Charter `Index.charter.md` v4 existe — **PRECISA EVOLUIR PRA v5** adicionando US-FIN-021 (Form Edit) saindo do Backlog e indo pra Goals; Non-Goal #2 ("drawer leva pra rotas de edição existentes") será removido. Visual-comparison.md já existe (`financeiro-unificado-visual-comparison.md`) — atualizar com diff drawer edit. |
+| **R8 Branch + worktree** | ✅ | Trabalho em worktree `D:\oimpresso.com\.claude\worktrees\youthful-matsumoto-21811c\` — paths absolutos do worktree em todo Edit. |
+| **R9 Zero auto-mem** | ✅ | Este doc (`memory/sessions/`) vai pro git canon, não pra `~/.claude/projects/`. |
+| **R10 Aprovação humana commit/push/merge** | ✅ | Wagner aprovar caminho ANTES de Claude pai começar implementação massiva. As 3 ambiguidades acima precisam resposta primeiro. |
+| **R11 Continuar autonomamente até desfecho** | ✅ | Quando Wagner aprovar caminho, Claude pai executa até smoke Brave pós-merge + brief-update sem pausa. |
+
+---
+
+# Inventário no projeto (estado real 2026-05-18)
+
+## O que JÁ EXISTE (não duplicar)
+
+| Item | Path | Status |
+|---|---|---|
+| Controller principal | `Modules/Financeiro/Http/Controllers/UnificadoController.php` | ✅ multi-tenant ok, biz_id session, can:permission middleware, `shapeTitulo()` helper canon |
+| Tabela `fin_titulos` | `Modules/Financeiro/Database/Migrations/2026_04_24_140004_create_fin_titulos_table.php` | ✅ tem business_id FK, soft-delete, idempotency UNIQUE constraint, `metadata` JSON |
+| Page Unificado | `resources/js/Pages/Financeiro/Unificado/Index.tsx` (777 linhas) | ✅ KPIs hero + sparkline, filter chips coloridos, drawer detalhe com Sheet, CmdK palette, atalhos, FinPillFrescor inline |
+| **Botão "Editar" drawer** | `Index.tsx:706` `<Button variant="outline">Editar</Button>` | 🔴 **STUB sem onClick** — este é o gap real foco do pedido |
+| Charter | `resources/js/Pages/Financeiro/Unificado/Index.charter.md` v4 | ✅ canônico, `status: live`, US-FIN-021 listada no Backlog futuro |
+| FinCrossLinkify (#V- #OS- #PC-) | `_components/FinCrossLinkify.tsx` | ✅ regex parser completo, 6 patterns, Inertia router.visit, renderiza pills coloridas |
+| FinPillFrescor 6 estados | `_components/FinPillFrescor.tsx` | ✅ paid/overdue/today/warning/soon/fresh derivado de vencimento+liquidacao |
+| FinConferidoToggle | `_components/FinConferidoToggle.tsx` | 🟡 funciona via localStorage `oimpresso.financeiro.conferido`. Wagner gap 8 quer promover pra tabela. Já há TODO inline: "Onda futura plugará em backend `fin_review_log` table" |
+| FinCommentsThread / Badge | `_components/FinCommentsThread.tsx` | ✅ localStorage Eliana↔Wagner↔Bruna |
+| FinAuditTrail | `_components/FinAuditTrail.tsx` | ✅ 5 kinds derivado (create/categorize/edit/concil/alert) |
+| FinAnomalyDetector | `_components/FinAnomalyDetector.tsx` | ✅ outlier vs média histórica contraparte (Onda 6 R2) |
+| FinPartyHistory | `_components/FinPartyHistory.tsx` | ✅ stats contraparte (count, total, média, on-time%, isNew, isRecurrent) |
+| FinMonthDigest | `_components/FinMonthDigest.tsx` | ✅ digest mensal Eliana 5min sexta |
+| FinChecklistFechamento | `_components/FinChecklistFechamento.tsx` | ✅ 12 passos fechamento mensal + localStorage |
+| FinTroubleshooter / PresentationMode | `_components/FinTroubleshooter.tsx` / `FinPresentationMode.tsx` | ✅ Onda 7b |
+| Classes `.fin-btn-ai`/`.fin-btn-trilha`/`.fin-btn-present` | CSS canon `resources/css/cockpit.css` ou `fin-*.css` | ✅ Onda 8b filter chips coloridos polish |
+| Categorias seeder + tabela | `Modules/Financeiro/Database/Seeders/PlanoContasBrSeeder.php` + `fin_categorias` table | ✅ tabela existe, seeder existe |
+| Auto-criação Titulo a partir de Venda | `Modules/Financeiro/Services/TituloAutoService.php` + `Observers/TransactionObserver.php` | ✅ canônico — `origem='venda'`, `origem_id=transaction.id`, idempotente, ADR fin-tech/0001 |
+| Pattern Sheet sibling (referência canon) | `resources/js/Pages/Financeiro/Categorias/_components/CategoriaSheet.tsx` | ✅ copiar pattern (form + validation + Inertia POST) |
+| Rotas Financeiro | `Modules/Financeiro/Routes/web.php` | ✅ stack canônico `['web','auth','language','timezone','AdminSidebarMenu']` |
+
+## O que NÃO EXISTE (gap real)
+
+| Item | Path destino | Esforço |
+|---|---|---|
+| **Edit drawer/modal funcional do Titulo** | criar `_components/TituloEditSheet.tsx` + handler `Index.tsx:706` | ~200 LOC TSX |
+| **Method `UnificadoController::update(int $id, UpdateTituloRequest)`** | adicionar em `UnificadoController.php` | ~40 LOC PHP |
+| **FormRequest `UpdateTituloRequest`** | criar `Modules/Financeiro/Http/Requests/UpdateTituloRequest.php` | ~30 LOC PHP |
+| **Rota PUT `/financeiro/unificado/{id}`** | adicionar em `Routes/web.php` | 3 linhas |
+| **Migration `add_conferido_to_fin_titulos`** | criar `2026_05_18_HHMMSS_add_conferido_to_fin_titulos_table.php` | ~30 LOC PHP — 2 columns nullable: `conferido_by` (FK users), `conferido_at` (timestamp) |
+| **Method `UnificadoController::conferir(int $id)`** | adicionar em `UnificadoController.php` | ~25 LOC PHP |
+| **Rota POST `/financeiro/unificado/{id}/conferir`** | adicionar em `Routes/web.php` | 3 linhas |
+| **FinConferidoToggle reescrito Inertia POST** | atualizar `_components/FinConferidoToggle.tsx` substituindo localStorage por router.post + Eloquent persist | ~30 LOC diff |
+| **Pest test `UnificadoEditTest`** | criar `Modules/Financeiro/Tests/Feature/UnificadoEditTest.php` | ~120 LOC PHP — cobre auth, biz scope, idempotência, soft-delete imutabilidade |
+| **Charter `Index.charter.md` v5** | atualizar v4→v5 movendo US-FIN-021 de Backlog→Goals; remover Non-Goal #2 | ~10 linhas diff |
+| **Visual-comparison.md update** | append section "Drawer edit" em `memory/requisitos/Financeiro/financeiro-unificado-visual-comparison.md` | ~30 linhas |
+
+## ADRs canon relacionadas (leitura obrigatória PRE-FLIGHT)
+
+- [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md) Multi-tenant Tier 0 IRREVOGÁVEL
+- [ADR 0094](memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md) Constituição v2
+- [ADR 0104](memory/decisions/0104-processo-mwart-canonico-unico-caminho.md) MWART canônico
+- [ADR 0107](memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md) Visual-comparison gate F3
+- [ADR 0114](memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md) Cowork loop formalizado
+- [ADR fin-arq/0005](memory/requisitos/Financeiro/adr/arq/0005-financeiro-vs-accounting-paralelo.md) Módulo Financeiro paralelo
+- [ADR fin-ui/0002](memory/requisitos/Financeiro/adr/ui/0002-dashboard-unificado-4-estados.md) Dashboard unificado
+- [ADR fin-ui/0003](memory/requisitos/Financeiro/adr/ui/0003-amendment-0002-visao-unificada-cockpit-v2.md) Amendment Cockpit V2
+- [ADR fin-tech/0001](memory/requisitos/Financeiro/adr/tech/0001-idempotencia-em-toda-mutacao-financeira.md) Idempotência mutação financeira
+- [ADR fin-tech/0002](memory/requisitos/Financeiro/adr/tech/0002-soft-delete-com-trava-historico.md) Soft-delete + trava histórico
+
+---
+
+# Pegadinhas conhecidas (alertas Tier 0)
+
+- **[Tier 0]** `business_id` global scope obrigatório em `UnificadoController::update()` — `Titulo::where('business_id', $businessId)->findOrFail($id)`, nunca `findOrFail($id)` direto (vaza cross-tenant)
+- **[Tier 0 fin-tech/0002]** Pós-baixa `status='quitado'`: campos `valor_total`, `tipo`, `origem`, `origem_id` ficam **imutáveis** (trava histórico). Drawer edit deve renderizar read-only nesses campos quando `status === 'quitado'`. Não é Non-Goal — é regra de imutabilidade legal/contábil
+- **[Tier 0 fin-tech/0001]** Mutação financeira tem `idempotency_key UUID`. Pra UPDATE de título (não baixa), basta `updated_by` + `updated_at` (Laravel auto). Não inventar coluna nova
+- **[LICOES_F3]** M-AP-1 Auto-aprendizado ignorado sob pressão delivery — Wagner já queimou bateria com batch F3 Financeiro rejeitado 2026-05-09 (5 controllers stub). **Antes de criar `_components/TituloEditSheet.tsx`, ler `Modules/Financeiro/Resources/js/Pages/Financeiro/Categorias/_components/CategoriaSheet.tsx` (pattern Sheet sibling do mesmo módulo)** e copiar literal
+- **[LICOES_F3 T-AP-1]** Models inventados — usar `Titulo` (NÃO `FinancialEntry`), `Categoria` (NÃO `Category`), `ContaBancaria` (NÃO `BankAccount`)
+- **[LICOES_F3 T-AP-2]** Tenant scope ausente — `session('user.business_id')`, NÃO `auth()->user()->business_id`
+- **[LICOES_F3 T-AP-8]** `auth()->user()->business_id` quebra em jobs/CLI. UPOS canon = `session('user.business_id')`
+- **[LICOES_F3 T-AP-13]** Mutação NO-OP — endpoint update DEVE implementar ou `abort(501)`, nunca `return back()` silencioso
+- **[Pegadinha Windows]** PowerShell 5.1 `Set-Content -Encoding utf8` grava BOM → quebra PHP. Migration nova via `[System.IO.File]::WriteAllText(...UTF8Encoding $false)` OU Python `python -c`
+- **[Worktree]** Trabalhando em `D:\oimpresso.com\.claude\worktrees\youthful-matsumoto-21811c\` — todo Edit path absoluto do worktree
+- **[charter-first]** Editar Page Index.tsx exige ler `Index.charter.md` ANTES (já feito neste decode)
+- **[Inertia::defer]** Index controller já é rápido (~50ms com `limit(500)` + eager-load + KPI aggregations pequenas). NÃO precisa deferir o payload base. Mas se adicionar prop nova com query cara (ex: stats histórico contraparte server-side futuro), usar `Inertia::defer()`
+- **[Sheet shadcn componente]** Já importado em `Index.tsx:20` — reusar. Pattern `<Sheet open={editOpen}><SheetContent side="right">...</SheetContent></Sheet>` segue padrão drawer detalhe atual
+- **[FinConferidoToggle migração localStorage → DB]** Backward compat: ler localStorage existente no mount, fazer **migration one-shot** via POST batch pro backend, depois operar só backend. Detalhe técnico — propor abordagem ao Wagner antes
+
+---
+
+# Plug-points exatos (caminhos arquivo:linha)
+
+## Foco principal — Edit drawer
+
+| Camada | Arquivo:linha | Mudança |
+|---|---|---|
+| **Frontend handler** | `resources/js/Pages/Financeiro/Unificado/Index.tsx:706` | substituir stub `<Button variant="outline">Editar</Button>` por `<Button variant="outline" onClick={() => setEditOpen(true)}>Editar</Button>` |
+| **Frontend state** | `Index.tsx:381-385` (zona useState) | adicionar `const [editOpen, setEditOpen] = useState(false);` |
+| **Frontend novo Sheet** | `Index.tsx:765` (depois do PresentationMode) | adicionar `<TituloEditSheet open={editOpen} onClose={() => setEditOpen(false)} titulo={selected} categorias={categorias} contas={contas} />` |
+| **Frontend novo componente** | NEW `_components/TituloEditSheet.tsx` | Sheet com form `descricao` / `categoria_id` / `vencimento` / `observacoes` editáveis + read-only `valor_total` / `tipo` / `numero` quando settled. Pattern: copiar `Categorias/_components/CategoriaSheet.tsx` |
+| **Frontend Index.tsx imports** | `Index.tsx:37` (zona _components imports) | adicionar `import { TituloEditSheet } from './_components/TituloEditSheet';` |
+| **Backend Controller** | `Modules/Financeiro/Http/Controllers/UnificadoController.php:190` (depois de `baixar()`) | adicionar method `update(UpdateTituloRequest $request, int $id): RedirectResponse` |
+| **Backend FormRequest** | NEW `Modules/Financeiro/Http/Requests/UpdateTituloRequest.php` | rules: `descricao` string max 255 nullable, `categoria_id` exists fin_categorias filtered biz, `vencimento` date pós ou igual `emissao`, `observacoes` string nullable |
+| **Backend Route** | `Modules/Financeiro/Routes/web.php:60` (depois da rota baixar) | adicionar `Route::put('/unificado/{id}', [UnificadoController::class, 'update'])->whereNumber('id')->name('unificado.update');` |
+| **Pest** | NEW `Modules/Financeiro/Tests/Feature/UnificadoEditTest.php` | 8 testes: auth required, biz scope (biz=99 não edita biz=1), categoria_id cross-tenant rejeitada, vencimento date validation, imutabilidade pós-baixa (valor_total/tipo readonly), observacoes update ok, audit log (updated_by set), Sheet smoke estrutural |
+| **Charter** | `Index.charter.md` v4→v5 | mover US-FIN-021 de §Backlog futuro pra §Goals; remover Non-Goal #2 ("Edição inline de título — drawer leva pra rotas de edição existentes") |
+| **Visual-comparison** | `memory/requisitos/Financeiro/financeiro-unificado-visual-comparison.md` | append section "Drawer Edit (US-FIN-021)" com screenshot Cowork vs prod |
+
+## Foco secundário — Conferido DB-backed (gap 8 do doc Wagner)
+
+| Camada | Arquivo:linha | Mudança |
+|---|---|---|
+| **Migration** | NEW `Modules/Financeiro/Database/Migrations/2026_05_18_HHMMSS_add_conferido_to_fin_titulos_table.php` | `ALTER TABLE fin_titulos ADD conferido_by INT UNSIGNED NULL FK users, ADD conferido_at TIMESTAMP NULL, ADD INDEX (business_id, conferido_at)` |
+| **Model** | `Modules/Financeiro/Models/Titulo.php` | adicionar `conferido_by` + `conferido_at` em `$fillable` + casts `'conferido_at' => 'datetime'` |
+| **Backend Controller** | `UnificadoController.php` | adicionar method `conferir(int $id): RedirectResponse` (toggle on/off, set conferido_by=auth()->id() / conferido_at=now() ou NULL) |
+| **Backend Route** | `Routes/web.php` | `Route::post('/unificado/{id}/conferir', [UnificadoController::class, 'conferir'])->whereNumber('id')->name('unificado.conferir');` |
+| **Backend shape** | `UnificadoController::shapeTitulo()` | adicionar campos `conferido: bool`, `conferido_by_name: string\|null`, `conferido_at_label: string\|null` no payload |
+| **Frontend FinConferidoToggle** | `_components/FinConferidoToggle.tsx` | substituir localStorage `useFinConferido()` por prop `conferido` do row + `router.post('/financeiro/unificado/{id}/conferir')` |
+| **Pest** | `UnificadoEditTest.php` (mesmo arquivo) | +4 testes: conferir toggle on, toggle off (UPDATE conferido_by=NULL), biz scope, conferido_at set |
+
+---
+
+# Tasks atômicas + estimate (fator 10x ADR 0106)
+
+## Caminho A — Cirúrgico (recomendado se Wagner confirmar ambiguidades)
+
+| # | Task | LOC est | Tempo IA-pair | Bloqueia? |
+|---|---|---|---|---|
+| **A1** | Migration `add_conferido_to_fin_titulos` + Model fillable + Pest migration up/down idempotente | 60 LOC | ~20min | base de A3, A5 |
+| **A2** | FormRequest `UpdateTituloRequest` + Pest validation rules | 80 LOC | ~25min | base de A3 |
+| **A3** | Method `UnificadoController::update()` + `conferir()` + shape ajustado + Route PUT/POST | 100 LOC | ~30min | depende A1, A2 |
+| **A4** | Frontend `TituloEditSheet.tsx` novo componente | 200 LOC | ~45min | depende A3 |
+| **A5** | Frontend `FinConferidoToggle.tsx` rewrite localStorage→Inertia POST | 80 LOC | ~25min | depende A1, A3 |
+| **A6** | Index.tsx wire-up edit button + state + import + render TituloEditSheet | 30 LOC | ~10min | depende A4 |
+| **A7** | Pest `UnificadoEditTest.php` (12 testes: edit + conferir + cross-tenant + imutabilidade) | 250 LOC | ~50min | depende A1-A6 |
+| **A8** | TypeScript check + ESLint + Pest local verde | — | ~15min | depende A1-A7 |
+| **A9** | Charter v4→v5 + visual-comparison.md update | 50 LOC | ~15min | paralelo A1-A8 |
+| **A10** | PR open + CI watch verde + Wagner aprovação merge (R10) | — | ~20min wait | depende A1-A9 |
+| **A11** | Merge + deploy SSH Hostinger + curl smoke real (R1) | — | ~15min | depende A10 |
+| **A12** | Brave/Chrome MCP smoke pos-merge prod biz=1 — clicar Editar, salvar, screenshot + console clean (R1) | — | ~15min | depende A11 |
+| **A13** | brief-update Tier B atualiza `memory/requisitos/Financeiro/BRIEFING.md` | 20 LOC | ~5min | depende A12 |
+| **TOTAL** | | ~870 LOC | **~4h30 IA-pair** | 1 PR único (override design-literal-copy se Wagner aprovou Sheet do Cowork) OU 2 PRs separados (edit / conferido) |
+
+**Decomposição em PRs ≤300 LOC** (skill commit-discipline):
+
+- **PR 1 — Backend Edit** (A1+A2+A3+A7-parte-edit): ~430 LOC PHP → tirar pra ≤300 separando migration em PR independente
+  - **PR 1a:** Migration `add_conferido` (60 LOC) — sem dependência, deploy primeiro
+  - **PR 1b:** Backend update endpoint (220 LOC) — depois de 1a
+- **PR 2 — Frontend Edit Sheet** (A4+A6+A9): ~280 LOC TSX+MD → ok ≤300
+- **PR 3 — Conferido DB-backed** (A5+A7-parte-conferir): ~130 LOC → ok ≤300
+
+**Ordem sequencial estrita:** 1a → 1b → 2 → 3 (devido a dependências de migration deployada + endpoint disponível).
+
+## Caminho B — 8 gaps inteiros (caso Wagner confirme escopo expandido)
+
+| Gap | Status real | Trabalho |
+|---|---|---|
+| Gap 1 Filtros multi-select lifecycle | parcial (filter chips existem mas single-select tab) | ~3h — refator chips→multi-select + KPI cards drill com OR-state |
+| Gap 2 Categorias reais + `desc` #V-/#OS- | seeder existe mas só núcleo. Auto-criação Titulo a partir de venda já adiciona `cliente_descricao` baseado em customer name | ~30min — adicionar prefix `#V-{tx.id}` em `cliente_descricao` no TituloAutoService linha ~118 |
+| Gap 3 Cross-links #V-/#OS-/#PC- | ✅ implementado (FinCrossLinkify) | 0 |
+| Gap 4 FinPillFrescor 6 estados | ✅ implementado | 0 |
+| Gap 5 Classes fin-btn-ai/trilha/present | ✅ implementado Onda 8b | 0 |
+| Gap 6 Conferido vs Paguei conceitos | parcial (Conferido localStorage, Paguei FSM ok) | mesmo trabalho A1+A5 (~1h30) |
+| Gap 7 Drawer detalhe completo | ✅ implementado (anomaly+history+audit+comments) | 0 |
+| Gap 8 Migration conferido_by/conferido_at | falta | mesmo trabalho A1 (~20min) |
+| **TOTAL B** | | **~4h30 cirúrgico + ~3h gaps adicionais reais = ~7h30** |
+
+---
+
+# Recomendação pro Claude pai
+
+## Caminho recomendado
+
+**Caminho A cirúrgico** (4h30 IA-pair) + decomposição em **3 PRs sequenciais** (≤300 LOC cada).
+
+**Justificativa:**
+1. **6 dos 8 gaps já estão implementados** nas Ondas 5-8b mergeadas (PRs #1064-#1085). O doc `GAPS_FINANCEIRO_PRA_CODE.md` que Wagner colou está desatualizado.
+2. Gap 6+8 (Conferido DB-backed) + "edit do financeiro" são o **trabalho real único**.
+3. Wagner palavras textuais: *"teria que implemnetar o edit do financeiro"* — pedido cirúrgico, não scope expandido.
+4. Caminho B (8 gaps inteiros) adiciona Gap 1 (filtros multi-select lifecycle) e Gap 2 (prefix #V- em desc) que valem mas **não foram pedidos explicitamente** — propor como follow-up.
+
+## O que confirmar com Wagner ANTES de codar
+
+| # | Pergunta | Razão |
+|---|---|---|
+| **Q1** | Edit é **drawer Sheet inline** (recomendado pela URL "Oimpresso ERP - Chat.html" sugerir drawer) ou redirecionamento pras rotas legacy `/contas-receber/{id}/edit`? | Charter Non-Goal #2 atual diz "drawer leva pra rotas existentes" — mudança de Non-Goal exige confirmação |
+| **Q2** | `conferido_by` é **per-user** (Eliana ≠ Wagner ≠ Bruna conferem separadamente) ou **per-business único** (qualquer user do business confere e fica visível pra todos)? | Default proposto: per-business único (FK users, qualquer user que conferir conta). Migração de localStorage só faz sentido assim |
+| **Q3** | URL design `api.anthropic.com/v1/design/h/NBcYUr1FsA-CvD_xJ82Jaw?open_file=Oimpresso+ERP+-+Chat.html` — Wagner aprovou esse "Chat.html" como referência visual do drawer Edit, ou é doc de outra feature (módulo Chat?) que ele colou por engano junto? | Se for design canon de Edit Financeiro, R2 cópia literal aplica (1 PR override design-literal-copy). Se for outra feature, edit segue pattern `CategoriaSheet.tsx` |
+| **Q4** | OK incluir gap secundário **#V-/#OS- prefix em `cliente_descricao`** (Gap 2 do doc) como PR 4 follow-up? É ~30min, melhora cross-link já existente | Pequeno mas valioso pra fechar loop Financeiro↔Vendas |
+| **Q5** | Backward compat de `FinConferidoToggle` localStorage existente — descartar dados antigos ou fazer migration one-shot? Eliana já marcou N títulos como conferidos no dispositivo dela | Decisão de UX |
+
+## Skills que DEVEM ativar (auto-trigger pelo path)
+
+- **brief-first** Tier A always-on (já carregado SessionStart)
+- **multi-tenant-patterns** Tier A always-on — Eloquent Model + Controller + Migration novos
+- **commit-discipline** Tier A always-on — 1 PR = 1 intent, ≤300 LOC, conventional commits
+- **mwart-process** Tier A always-on — Edit em `Modules/<X>/` (toca módulo)
+- **charter-first** Tier A always-on — Edit em Page `.tsx` com `.charter.md` ao lado
+- **inertia-defer-default** Tier B auto-trigger — Index.tsx render com props caras (já validado no atual; novo update endpoint não adiciona props caras, mas se vier prop de stats contraparte server-side, deferir)
+- **preflight-modulo** Tier B auto-trigger — Edit em `Modules/Financeiro/Http/Controllers/`
+- **smoke-prod-evidence** Tier B auto-trigger — pré-merge + pós-merge curl/screenshot evidência
+- **brief-update** Tier B auto-trigger — pós-merge atualiza `memory/requisitos/Financeiro/BRIEFING.md`
+- **tela-smoke-pos-merge** Tier B auto-trigger — Brave MCP screenshot pos-deploy
+
+## Hook bloqueadores ativos a considerar
+
+- `block-mwart-violation.ps1` — exige `RUNBOOK-<tela-kebab>.md` antes de Edit `Pages/<Mod>/<Tela>.tsx`. **CHECAR:** existe `memory/requisitos/Financeiro/RUNBOOK-unificado.md` ou só `RUNBOOK-transaction-payment.md`? Provavelmente precisa criar RUNBOOK ou override `/mwart-override <razão>` em PR body
+- `block-automem.ps1` — não aplica (sem Write em ~/.claude/projects/*/memory/)
+- `post-merge-ui-smoke-required.ps1` — pós-merge bloqueia próximas declarações "pronto/funcionando" até screenshot MCP. Garantir smoke Brave automático
+- `block-claim-without-evidence.ps1` — `gh pr create` em branch que toca infra crítica exige Infra Contract — **NÃO se aplica** (Routes web.php mexe, mas nova rota não muda runtime — só add endpoint)
+
+---
+
+# Sumário compacto pro Claude pai (~30 linhas)
+
+**Pedido decodificado:** Wagner quer drawer Edit funcional em `/financeiro/unificado` + promover Conferido de localStorage→DB. Os outros 6 dos 8 gaps do doc colado já estão implementados nas Ondas 5-8b mergeadas (Wagner doc está desatualizado).
+
+**Estado atual:**
+- `Index.tsx:706` tem `<Button variant="outline">Editar</Button>` STUB sem onClick — gap real
+- `FinConferidoToggle` funciona via localStorage com TODO inline "Onda futura plugará em backend `fin_review_log`"
+- Tabela `fin_titulos` migration existe, multi-tenant ok, soft-delete + idempotency UNIQUE
+- Charter `Index.charter.md` v4 lista US-FIN-021 (Form Edit) no Backlog — precisa promover pra Goals v5
+- Pattern Sheet sibling canônico: `Categorias/_components/CategoriaSheet.tsx` — copiar
+
+**Plug-points cirúrgicos:**
+- Frontend: NEW `_components/TituloEditSheet.tsx` + wire em `Index.tsx:706` + state
+- Backend: `UnificadoController::update()` + `conferir()` + `UpdateTituloRequest` + 2 Routes
+- Migration: `add_conferido_to_fin_titulos` (conferido_by FK users + conferido_at + index)
+- Pest: `UnificadoEditTest.php` ~12 testes (cross-tenant, imutabilidade pós-baixa, validation, conferido toggle)
+- Charter v4→v5 + visual-comparison.md update
+
+**Pegadinhas Tier 0:**
+- LICOES_F3_FINANCEIRO_REJEITADO catalogou 15 anti-padrões — usar `Titulo`/`Categoria`/`ContaBancaria` (PT-BR), `session('user.business_id')`, stack middleware canônica, sem mutação NO-OP
+- Pós-baixa `status='quitado'`: campos `valor_total`/`tipo`/`origem`/`origem_id` imutáveis (fin-tech/0002)
+- PowerShell BOM mata PHP — usar UTF8Encoding $false ou Python pra Write
+- Worktree: paths absolutos `D:\oimpresso.com\.claude\worktrees\youthful-matsumoto-21811c\...`
+
+**Tasks atômicas:** 13 (~870 LOC, ~4h30 IA-pair) → 3 PRs sequenciais ≤300 LOC:
+- PR 1a Migration conferido (60 LOC) → deploy
+- PR 1b Backend update endpoint (220 LOC) → depende 1a
+- PR 2 Frontend TituloEditSheet (280 LOC) → depende 1b
+- PR 3 Conferido DB-backed FinConferidoToggle rewrite (130 LOC) → depende 1a+1b
+
+**ANTES de codar — confirmar com Wagner 5 perguntas:**
+1. Drawer Sheet inline OU redirecionar pra rotas legacy `/contas-receber/{id}/edit`? (Charter Non-Goal #2)
+2. `conferido_by` per-user OU per-business único?
+3. URL design "Oimpresso ERP - Chat.html" — esse é canon do Edit drawer ou doc de outra feature colado por engano?
+4. OK incluir PR 4 follow-up Gap 2 (#V- prefix em cliente_descricao)? +30min
+5. Backward compat localStorage→DB Conferido — descartar antigos ou migration one-shot?
+
+**R10/R11:** Wagner aprovar caminho UMA vez ("sim faz caminho A com Q1=Sheet inline / Q2=per-business / Q3=ignora link / Q4=sim PR 4 / Q5=descartar antigos") → Claude pai executa 3 PRs sequenciais até desfecho final (smoke Brave pós-merge + brief-update) sem pausa interna.
+
+**ADRs canon leitura obrigatória PRE-FLIGHT:** ADR 0093 + 0094 + 0104 + 0107 + 0114 + fin-arq/0005 + fin-ui/0002 + fin-ui/0003 + fin-tech/0001 + fin-tech/0002 + LICOES_F3_FINANCEIRO_REJEITADO.md + Index.charter.md v4 + RUNBOOK-transaction-payment.md.

--- a/resources/js/Pages/Financeiro/Unificado/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Unificado/Index.charter.md
@@ -11,7 +11,7 @@ related_us: [US-FIN-013, US-FIN-020]
 related_prototype: prototipo Cowork "Visao Unificada" (Financeiro.html), aprovado por Wagner 2026-05-09
 canon_method: Cowork KB-9.75 v2 — Ondas 5+6+7 (R1 Curadoria + R2 IA + R3 Output · PR #1064/#1066/#1068/#1069 + Onda 7 atual)
 tier: A
-charter_version: 4
+charter_version: 5
 ---
 
 # Page Charter — /financeiro/unificado
@@ -28,6 +28,11 @@ Tela única de **fluxo financeiro do mês** que mistura **Pagar / Pagas / Recebe
 ---
 
 ## Goals — Features (faz)
+
+- **Onda Edit** (2026-05-18, charter v5):
+  - **TituloEditSheet** — Sheet drawer inline edita campos seguros do título: `cliente_descricao` (texto livre + cross-links `#V-/#OS-/#PC-`), `observacoes`, `categoria_id`, `vencimento`. `valor_total` mutável SOMENTE se `status` aberto/parcial (ADR fin-tech/0002 imutabilidade pós-baixa). PUT `/financeiro/unificado/{id}` via `useForm` Inertia. Wire-up no botão "Editar" do drawer de detalhe.
+  - **Conferido per-user DB** — `FinConferidoToggle` migrado de localStorage para `conferido_by` (FK users.id) + `conferido_at` (timestamp). Substitui Onda 5 R1 storage. Eliana confere ≠ Wagner confere → audit per-user. Routes POST/DELETE `/unificado/{id}/conferir`.
+  - **Cross-links auto-pop** — `TituloAutoService` sintetiza `#V-{transaction_id}` (vendas) e `#PC-{transaction_id}` (compras) em `cliente_descricao` no `afterCreate`. FinCrossLinkify renderiza pills clicáveis.
 
 - **Onda 7 KB-9.75 R3 Output + Cross-link** (2026-05-18):
   - **FinCrossLinkify** — regex parser detecta `#V-` `#BL-` `#PC-` `#OS-` `#R-` `#P-` no `desc` do row → pills coloridas clicáveis que `router.visit` para o módulo apropriado (Sells / Boletos / Compras / Repair / Contas-Receber legacy / Contas-Pagar legacy). Fecha o loop "do Financeiro pra origem do lançamento".
@@ -63,8 +68,8 @@ Tela única de **fluxo financeiro do mês** que mistura **Pagar / Pagas / Recebe
 > Anti-alucinação. Cada item vira Pest GUARD test (Non-Goal violado = CI quebra).
 
 - ❌ Form unificado de novo lançamento inline — F1 é stub picker (Receber/Pagar) em `/unificado/novo`. Roadmap entrega form modal/sheet futuramente
-- ❌ Edição inline de título (cliente/valor/categoria) — drawer leva pra rotas de edição existentes
-- ❌ Cancelamento/estorno — vai por rotas dedicadas
+- ❌ Cancelamento/estorno — vai por rotas dedicadas (`status='cancelado'` via append-only, não delete)
+- ❌ Edição de `tipo`, `origem`, `origem_id`, `status`, `emissao` — imutáveis (anti-corrupção contábil; alterar requer cancelar+criar novo). Onda Edit edita só campos seguros + valor pré-baixa.
 - ❌ Pagination explícita (default `limit(200)` no controller) — paginar quando 1000+ títulos virar dor
 - ❌ Aging buckets <30 / 30-60 / 60-90 / 90+ — ADR ui/0002 previa, F1 simplifica pra status `atrasado` único
 - ❌ Comparação `+12% vs mês anterior` — ADR ui/0002 previa `delta_pct`, F1 não calcula
@@ -105,6 +110,8 @@ Tela única de **fluxo financeiro do mês** que mistura **Pagar / Pagas / Recebe
 - Multi-tenant: `Titulo::where('business_id', $businessId)` em todas as queries
 - 1-clique baixa: POST `/unificado/{id}/baixar` chama método `baixar()` que aplica `TituloBaixaService` (R-FIN-002 audit)
 - Stub `/unificado/novo` redireciona pra `/contas-receber` ou `/contas-pagar` (não implementa form unificado ainda)
+- **Edit Sheet** (Onda Edit 2026-05-18): PUT `/unificado/{id}` → `UnificadoController::update(UpdateTituloRequest)` → guard `assertValorMutavel` se status quitado/cancelado
+- **Conferir per-user**: POST/DELETE `/unificado/{id}/conferir` → `conferido_by` (FK users.id) + `conferido_at` timestamp
 
 ---
 

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -35,6 +35,8 @@ import { FinChecklistFechamento } from './_components/FinChecklistFechamento';
 // Onda 7b — Troubleshooter dialog + PresentationMode fullscreen.
 import { FinTroubleshooterDialog, FinTroubleButton } from './_components/FinTroubleshooter';
 import { FinPresentationMode } from './_components/FinPresentationMode';
+// Onda Edit 2026-05-18 — Sheet inline pra editar título financeiro.
+import { TituloEditSheet } from './_components/TituloEditSheet';
 
 // ---------- Tipos ----------
 
@@ -49,6 +51,7 @@ interface Lancamento {
   contraparte: string;
   contraparte_doc: string | null;
   categoria: string;
+  categoria_id: number | null;
   conta_bancaria: string;
   vencimento: string;            // ISO yyyy-mm-dd
   vencimento_label: string;      // "qua, 14 mai"
@@ -57,6 +60,11 @@ interface Lancamento {
   nfe_numero: string | null;
   canal: string | null;
   observacao: string | null;
+  // Onda Edit 2026-05-18 — conferido per-user (DB-backed) + valor_mutavel pós-baixa.
+  conferido_by: number | null;
+  conferido_at: string | null;
+  conferido_user_nome: string | null;
+  valor_mutavel: boolean;
 }
 
 interface Kpi {
@@ -374,14 +382,16 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
   const [paletteOpen, setPaletteOpen] = useState(false);
   const dens = DENSITY[filters.densidade ?? 'comfortable'];
 
-  // Cowork KB-9.75 Onda 5 R1 Curadoria — hooks localStorage compartilhados pela página.
-  const conferido = useFinConferido();
+  // Cowork KB-9.75 Onda Edit (2026-05-18) — conferido per-user DB (substitui Onda 5 localStorage).
+  const conferido = useFinConferido(lancamentos);
   const comments = useFinComments();
   // Cowork KB-9.75 Onda 7 R3 — trilha fechamento dialog state.
   const [checklistOpen, setChecklistOpen] = useState(false);
   // Cowork KB-9.75 Onda 7b — Troubleshooter + Presentation Mode states.
   const [troubleOpen, setTroubleOpen] = useState(false);
   const [presentOpen, setPresentOpen] = useState(false);
+  // Onda Edit 2026-05-18 — Edit Sheet state (separate from detail drawer).
+  const [editOpen, setEditOpen] = useState(false);
 
   const aplicar = useCallback((patch: Partial<Filters>) => {
     router.get('/financeiro/unificado', { ...filters, ...patch }, {
@@ -703,7 +713,7 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
                       {selected.kind === 'receivable' ? 'Marcar recebido' : 'Marcar pago'}
                     </Button>
                   )}
-                  <Button variant="outline">Editar</Button>
+                  <Button variant="outline" onClick={() => setEditOpen(true)}>Editar</Button>
                   <Button variant="outline" className="ml-auto">Anexar</Button>
                 </div>
               </div>
@@ -761,6 +771,16 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
         open={checklistOpen}
         onClose={() => setChecklistOpen(false)}
       />
+
+      {/* Onda Edit 2026-05-18 — Sheet inline pra editar título */}
+      {selected && (
+        <TituloEditSheet
+          open={editOpen}
+          onClose={() => setEditOpen(false)}
+          lancamento={selected}
+          categorias={categorias}
+        />
+      )}
     </div>
   );
 }

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinConferidoToggle.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinConferidoToggle.tsx
@@ -1,66 +1,70 @@
-// FinConferidoToggle — Cowork KB-9.75 Financeiro Onda 5 R1 Curadoria
-// (toggle "Conferido" persistido em localStorage — Eliana valida cada linha).
+// FinConferidoToggle — Cowork KB-9.75 Financeiro Onda Edit (2026-05-18)
+// (toggle "Conferido" persistido em DB per-user — substitui localStorage da Onda 5 R1).
 //
-// Refs:
-//  - prototipo-ui/financeiro-curation.jsx — useFinConferido + FinConferidoToggle
-//  - SaleItemComments pattern (canon localStorage Sells)
+// Fonte de verdade: `lancamento.conferido_by` (FK users.id) + `lancamento.conferido_at`.
+// Toggle envia Inertia POST/DELETE /financeiro/unificado/{id}/conferir e a página
+// re-render via preserveScroll com props atualizadas (back-end flash success/info).
 //
-// Storage: localStorage[oimpresso.financeiro.conferido] = ["R-2641", "P-3120", ...]
-// Multi-user: scope por device/user (mesma persona Eliana). Onda futura plugará em
-// backend `fin_review_log` table com sync MCP.
+// Migration de dados: Onda 5 R1 (localStorage) tinha volume baixo — backward-compat
+// descartado conforme aprovação Wagner 2026-05-18. Toggles antigos viram inativos
+// silenciosamente (localStorage cleanup opcional no future garbage-collect).
 
-import { useCallback, useEffect, useState } from 'react';
+import { router } from '@inertiajs/react';
+import { useCallback, useMemo } from 'react';
 import { CircleCheck } from 'lucide-react';
 
-const LS_KEY = 'oimpresso.financeiro.conferido';
-
-function loadConferidoSet(): Set<string> {
-  if (typeof window === 'undefined') return new Set();
-  try {
-    const raw = window.localStorage.getItem(LS_KEY);
-    if (!raw) return new Set();
-    const arr = JSON.parse(raw);
-    return new Set(Array.isArray(arr) ? arr : []);
-  } catch (_) {
-    return new Set();
-  }
-}
-
-function saveConferidoSet(s: Set<string>): void {
-  if (typeof window === 'undefined') return;
-  try {
-    window.localStorage.setItem(LS_KEY, JSON.stringify([...s]));
-  } catch (_) {
-    /* ls indisponível */
-  }
+interface ConferidoStateRow {
+  id: number;
+  conferido_by: number | null;
+  conferido_at: string | null;
+  conferido_user_nome: string | null;
 }
 
 export interface UseFinConferidoApi {
   has: (id: string | number) => boolean;
   toggle: (id: string | number) => void;
   count: number;
+  userNome: (id: string | number) => string | null;
+  conferidoAt: (id: string | number) => string | null;
 }
 
-export function useFinConferido(): UseFinConferidoApi {
-  const [set, setSet] = useState<Set<string>>(loadConferidoSet);
+export function useFinConferido(lancamentos: ConferidoStateRow[] = []): UseFinConferidoApi {
+  const indexed = useMemo(() => {
+    const m = new Map<string, ConferidoStateRow>();
+    for (const l of lancamentos) m.set(String(l.id), l);
+    return m;
+  }, [lancamentos]);
 
-  useEffect(() => {
-    saveConferidoSet(set);
-  }, [set]);
-
-  const has = useCallback((id: string | number) => set.has(String(id)), [set]);
+  const has = useCallback((id: string | number) => {
+    const row = indexed.get(String(id));
+    return !!row && row.conferido_by !== null;
+  }, [indexed]);
 
   const toggle = useCallback((id: string | number) => {
-    setSet((prev) => {
-      const next = new Set(prev);
-      const key = String(id);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  }, []);
+    const row = indexed.get(String(id));
+    const isOn = !!row && row.conferido_by !== null;
+    const url = `/financeiro/unificado/${id}/conferir`;
+    if (isOn) {
+      router.delete(url, { preserveScroll: true, preserveState: true });
+    } else {
+      router.post(url, {}, { preserveScroll: true, preserveState: true });
+    }
+  }, [indexed]);
 
-  return { has, toggle, count: set.size };
+  const userNome = useCallback((id: string | number) => {
+    return indexed.get(String(id))?.conferido_user_nome ?? null;
+  }, [indexed]);
+
+  const conferidoAt = useCallback((id: string | number) => {
+    return indexed.get(String(id))?.conferido_at ?? null;
+  }, [indexed]);
+
+  const count = useMemo(
+    () => lancamentos.filter((l) => l.conferido_by !== null).length,
+    [lancamentos]
+  );
+
+  return { has, toggle, count, userNome, conferidoAt };
 }
 
 interface FinConferidoToggleProps {
@@ -70,19 +74,21 @@ interface FinConferidoToggleProps {
 
 export function FinConferidoToggle({ rowId, conferido }: FinConferidoToggleProps) {
   const isOn = conferido.has(rowId);
+  const userNome = conferido.userNome(rowId);
+  const titleOn = userNome ? `Conferido por ${userNome} · clique pra desmarcar` : 'Conferido · clique pra desmarcar';
   return (
     <button
       type="button"
       className={`fin-conferido-toggle ${isOn ? 'on' : ''}`}
       onClick={() => conferido.toggle(rowId)}
-      title={isOn ? 'Desmarcar conferido (Eliana já bateu olho)' : 'Marcar como conferido'}
+      title={isOn ? titleOn : 'Marcar como conferido (audit per-user)'}
       aria-pressed={isOn}
     >
       <span className="fin-conf-check">
         {isOn ? <CircleCheck size={14} strokeWidth={2.5} /> : null}
       </span>
-      <span className="fin-conf-lbl">{isOn ? 'Conferido' : 'Conferir'}</span>
-      {!isOn && <small>Eliana valida</small>}
+      <span className="fin-conf-lbl">{isOn ? `Conferido${userNome ? ' · '+userNome : ''}` : 'Conferir'}</span>
+      {!isOn && <small>Per-user audit</small>}
     </button>
   );
 }
@@ -95,8 +101,9 @@ interface FinConferidoBadgeProps {
 /** Badge silencioso pra header da linha (mostra ✓ só quando conferido). */
 export function FinConferidoBadge({ rowId, conferido }: FinConferidoBadgeProps) {
   if (!conferido.has(rowId)) return null;
+  const userNome = conferido.userNome(rowId);
   return (
-    <span className="fin-conferido-badge" title="Conferido por Eliana">
+    <span className="fin-conferido-badge" title={userNome ? `Conferido por ${userNome}` : 'Conferido'}>
       <CircleCheck size={12} strokeWidth={2.5} />
     </span>
   );

--- a/resources/js/Pages/Financeiro/Unificado/_components/TituloEditSheet.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/TituloEditSheet.tsx
@@ -1,0 +1,208 @@
+// TituloEditSheet — Cowork KB-9.75 Financeiro Onda Edit (2026-05-18)
+// Sheet drawer inline pra editar campos seguros do título financeiro.
+//
+// Campos editáveis (R-FIN-008):
+//   - cliente_descricao (texto livre — pode renomear/anotar contraparte)
+//   - observacoes (texto livre)
+//   - categoria_id (dropdown de Categoria do business)
+//   - vencimento (date)
+//   - valor_total (number — SOMENTE se status aberto/parcial; bloqueado se quitado/cancelado)
+//
+// Imutabilidade (ADR fin-tech/0002): tipo, origem, status, emissao NUNCA editáveis aqui.
+// PUT /financeiro/unificado/{id} via Inertia useForm — back() + flash success do controller.
+
+import { useForm } from '@inertiajs/react';
+import { useEffect } from 'react';
+import { Button } from '@/Components/ui/button';
+import { Input } from '@/Components/ui/input';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetDescription } from '@/Components/ui/sheet';
+
+interface Categoria {
+  id: number;
+  nome: string;
+}
+
+interface Lancamento {
+  id: number;
+  descricao: string;
+  contraparte: string;
+  categoria: string;
+  categoria_id: number | null;
+  vencimento: string;
+  valor: number;
+  observacao: string | null;
+  valor_mutavel: boolean;
+  status: string;
+}
+
+interface TituloEditSheetProps {
+  open: boolean;
+  onClose: () => void;
+  lancamento: Lancamento;
+  categorias: Categoria[];
+}
+
+export function TituloEditSheet({ open, onClose, lancamento, categorias }: TituloEditSheetProps) {
+  const form = useForm({
+    cliente_descricao: lancamento.contraparte === '—' ? '' : lancamento.contraparte,
+    observacoes: lancamento.observacao ?? '',
+    categoria_id: lancamento.categoria_id ?? '',
+    vencimento: lancamento.vencimento,
+    valor_total: lancamento.valor,
+  });
+
+  // Reset form quando trocar de lançamento sem fechar.
+  useEffect(() => {
+    form.setData({
+      cliente_descricao: lancamento.contraparte === '—' ? '' : lancamento.contraparte,
+      observacoes: lancamento.observacao ?? '',
+      categoria_id: lancamento.categoria_id ?? '',
+      vencimento: lancamento.vencimento,
+      valor_total: lancamento.valor,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [lancamento.id]);
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    // Remove valor_total do payload se imutável (back-end também rejeita por defesa).
+    const data: Record<string, unknown> = {
+      cliente_descricao: form.data.cliente_descricao || null,
+      observacoes: form.data.observacoes || null,
+      categoria_id: form.data.categoria_id === '' ? null : form.data.categoria_id,
+      vencimento: form.data.vencimento,
+    };
+    if (lancamento.valor_mutavel) {
+      data.valor_total = form.data.valor_total;
+    }
+    form.put(`/financeiro/unificado/${lancamento.id}`, {
+      ...({ data } as any),
+      preserveScroll: true,
+      onSuccess: () => onClose(),
+    });
+  };
+
+  return (
+    <Sheet open={open} onOpenChange={(o) => !o && onClose()}>
+      <SheetContent side="right" className="w-[460px] sm:max-w-[460px] flex flex-col">
+        <SheetHeader>
+          <SheetTitle className="text-[15px]">Editar lançamento</SheetTitle>
+          <SheetDescription className="text-[12px] text-stone-500">
+            #{lancamento.id} · {lancamento.status === 'quitado' ? 'Já quitado — valor imutável' : 'Campos seguros editáveis'}
+          </SheetDescription>
+        </SheetHeader>
+
+        <form onSubmit={submit} className="mt-4 space-y-4 text-[13px] flex-1 overflow-y-auto pr-1">
+          <div className="space-y-1.5">
+            <label htmlFor="ed-desc" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+              Descrição / contraparte
+            </label>
+            <Input
+              id="ed-desc"
+              value={form.data.cliente_descricao}
+              onChange={(e) => form.setData('cliente_descricao', e.target.value)}
+              placeholder="Ex: Banner lona 4×1m · #V-7832"
+              maxLength={255}
+            />
+            <p className="text-[11px] text-stone-500">
+              Tokens <code>#V-</code> <code>#OS-</code> <code>#PC-</code> <code>#BL-</code> viram links clicáveis na lista.
+            </p>
+            {form.errors.cliente_descricao && (
+              <p className="text-[11px] text-rose-600">{form.errors.cliente_descricao}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="ed-cat" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+              Categoria
+            </label>
+            <select
+              id="ed-cat"
+              value={form.data.categoria_id as string | number}
+              onChange={(e) => form.setData('categoria_id', e.target.value as unknown as number | '')}
+              className="w-full h-9 rounded-md border border-stone-300 bg-white px-3 text-[13px]"
+            >
+              <option value="">(Sem categoria)</option>
+              {categorias.map((c) => (
+                <option key={c.id} value={c.id}>{c.nome}</option>
+              ))}
+            </select>
+            {form.errors.categoria_id && (
+              <p className="text-[11px] text-rose-600">{form.errors.categoria_id}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="ed-venc" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+              Vencimento
+            </label>
+            <Input
+              id="ed-venc"
+              type="date"
+              value={form.data.vencimento}
+              onChange={(e) => form.setData('vencimento', e.target.value)}
+            />
+            {form.errors.vencimento && (
+              <p className="text-[11px] text-rose-600">{form.errors.vencimento}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="ed-valor" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+              Valor
+              {!lancamento.valor_mutavel && (
+                <span className="ml-2 normal-case text-[10px] text-amber-700">🔒 imutável pós-baixa</span>
+              )}
+            </label>
+            <Input
+              id="ed-valor"
+              type="number"
+              step="0.01"
+              min="0.01"
+              value={form.data.valor_total}
+              onChange={(e) => form.setData('valor_total', parseFloat(e.target.value) || 0)}
+              disabled={!lancamento.valor_mutavel}
+              className={!lancamento.valor_mutavel ? 'bg-stone-100 cursor-not-allowed' : ''}
+            />
+            {!lancamento.valor_mutavel && (
+              <p className="text-[11px] text-stone-500">
+                Valor de título quitado/cancelado preserva histórico contábil. Pra corrigir, cancele e crie novo.
+              </p>
+            )}
+            {form.errors.valor_total && (
+              <p className="text-[11px] text-rose-600">{form.errors.valor_total}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="ed-obs" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+              Observações
+            </label>
+            <textarea
+              id="ed-obs"
+              value={form.data.observacoes}
+              onChange={(e) => form.setData('observacoes', e.target.value)}
+              maxLength={2000}
+              rows={4}
+              className="w-full rounded-md border border-stone-300 bg-white px-3 py-2 text-[13px] resize-none"
+            />
+            {form.errors.observacoes && (
+              <p className="text-[11px] text-rose-600">{form.errors.observacoes}</p>
+            )}
+          </div>
+
+          <div className="flex gap-2 pt-3 border-t border-stone-200 mt-auto">
+            <Button type="submit" disabled={form.processing}>
+              {form.processing ? 'Salvando…' : 'Salvar'}
+            </Button>
+            <Button type="button" variant="outline" onClick={onClose} disabled={form.processing}>
+              Cancelar
+            </Button>
+          </div>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export default TituloEditSheet;


### PR DESCRIPTION
## Summary

Implementa o **edit do Financeiro** (`/financeiro/unificado`) atendendo gap analysis 2026-05-18: STUB botão "Editar" no drawer ([Index.tsx:706](resources/js/Pages/Financeiro/Unificado/Index.tsx)) virou Sheet drawer funcional + Conferido localStorage→DB per-user audit + cross-links `#V-`/`#PC-` auto-pop.

3 entregas atômicas:

1. **Edit Sheet inline** (`TituloEditSheet.tsx` + `UnificadoController::update` + `UpdateTituloRequest`)
2. **Conferido per-user DB** (migration `conferido_by`/`conferido_at` + `FinConferidoToggle` rewrite + POST/DELETE `/conferir`)
3. **Cross-links auto-pop** (`TituloAutoService` enriquece `cliente_descricao` com `#V-{tx_id}`/`#PC-{tx_id}`)

## Test plan

- [ ] CI Pest verde (5 it's novos em `UnificadoControllerTest.php`)
- [ ] Smoke local: `/financeiro/unificado` lista lançamentos com conferido DB-backed
- [ ] Smoke local: clicar linha → drawer → Editar → Sheet abre → salvar → flash success + back
- [ ] Smoke local: título quitado → Sheet desabilita campo valor (lock 🔒)
- [ ] **Smoke prod Brave (R1 obrigatório pós-merge)** — `oimpresso.com/financeiro/unificado` biz=1
- [ ] **brief-update** `Modules/Financeiro/BRIEFING.md` (R7 skill `brief-update` Tier B)

## Design link

Wagner colou `https://api.anthropic.com/v1/design/h/NBcYUr1FsA-CvD_xJ82Jaw?open_file=Oimpresso+ERP+-+Chat.html` como referência. WebFetch retornou 404 (link não-público). Seguido padrão Cowork canon do próprio projeto: Sheet drawer com tokens `oklch` já aplicados ao módulo (Ondas 5-8b).

## Cobertura LICOES_F3_FINANCEIRO_REJEITADO.md (anti-padrões)

- ✅ T-AP-2 tenant scope: `session('user.business_id')` + `findOrFail` em business
- ✅ T-AP-5 shape mapping: `shapeTitulo` expandido com `conferido_*` + `valor_mutavel` + `categoria_id`
- ✅ T-AP-9 `can:` middleware preservado (`can:financeiro.dashboard.view`)
- ✅ T-AP-10 idempotência: `conferir()` checa `conferido_by !== null` antes de marcar
- ✅ T-AP-11 `whereNull('deleted_at')` preservado em queries existentes
- ✅ T-AP-13 mutação real (não NO-OP): `update`/`conferir`/`unconferir` aplicam persistência
- ✅ Models reais (`Titulo`/`Categoria`), sem invenção (`FinancialEntry` etc)
- ✅ Sem `rand()` mock, sem service inventado
- ✅ Append-only preservado (status='cancelado' não delete)

## Tier 0 IRREVOGÁVEL

- ✅ `business_id` scope via `session('user.business_id')` ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md))
- ✅ Pest cross-tenant: PUT em título de outro business retorna 404
- ✅ Migration idempotente (`Schema::hasColumn` + FK guard)
- ✅ FK reversível em `down()`
- ✅ Sem PII em logs/commits
- ✅ Sem BOM em PHP/TSX (validado UTF-8 puro via `[System.IO.File]::ReadAllBytes`)

## Charter v4 → v5

`Index.charter.md` charter_version bumped. Non-Goal #66 "Edição inline" removido (agora é Goal); substituído pelo Non-Goal mais granular "Edição de tipo/origem/status/emissão (imutáveis)".

## ADRs respeitadas

- [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md) Multi-tenant Tier 0
- [ADR fin-tech/0002](memory/requisitos/Financeiro/adr/tech/0002-soft-delete-com-trava-historico.md) Imutabilidade pós-baixa
- [ADR 0104](memory/decisions/0104-processo-mwart-canonico-unico-caminho.md) Processo MWART canônico
- [ADR 0114](memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md) Loop Cowork formalizado
- [ADR ui/0114](memory/requisitos/Financeiro/adr/ui/0114-cockpit-v2-financeiro-visao-unificada.md) Cockpit V2

## Origem

Wagner colou `GAPS_FINANCEIRO_PRA_CODE.md` (2026-05-18) listando 8 gaps. wagner-understand subagent identificou que 6 já foram entregues nas Ondas 5-8b (PRs #1064-#1085); essa Onda Edit fecha os 2 restantes (Edit drawer funcional + Conferido DB) + bonus Gap 2 (cross-links auto-pop).

Decoder session log: `memory/sessions/2026-05-18-understand-financeiro-edit-8-gaps.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)