### PR TITLE
feat(financeiro): Onda 7c — FinTranscriptPDF (folha jurídica) + useFinFavs (atalho B)

### DIFF
--- a/Modules/Financeiro/Tests/Feature/Onda7cTranscriptFavsTest.php
+++ b/Modules/Financeiro/Tests/Feature/Onda7cTranscriptFavsTest.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Onda 7c KB-9.75 — FinTranscriptPDF + useFinFavs hook.
+ *
+ * Substitui ausência de impressão estruturada (Eliana hoje screenshot/printscreen)
+ * por folha jurídica imprimível com @media print + favoritos pessoais
+ * (localStorage, multi-tenant-safe via prefixo business).
+ *
+ * Cobre:
+ *   - useFinFavs.tsx: hook localStorage prefixo oimpresso.fin.favs.<biz>
+ *   - FinTranscriptPDF.tsx: overlay fullscreen + @print isolation + folha A4
+ *   - CSS: .fin-transcript-* + @media print + .fin-fav-pin
+ *   - Wire-up Index.tsx: state transcriptOpen + FinFavPin + atalho B
+ *
+ * Multi-tenant Tier 0 preservado (zero backend, prefixo localStorage por business).
+ */
+
+const FIN_BASE_7C = __DIR__ . '/../../../../resources/js/Pages/Financeiro/Unificado';
+const FIN_OUTPUT_CSS_7C = __DIR__ . '/../../../../resources/css/fin-output.css';
+const FIN_COWORK_CSS_7C = __DIR__ . '/../../../../resources/css/fin-cowork.css';
+
+describe('Onda 7c — useFinFavs hook (favoritos pessoais localStorage)', function () {
+    it('useFinFavs.tsx exports hook + FinFavPin component', function () {
+        $src = file_get_contents(FIN_BASE_7C . '/_components/useFinFavs.tsx');
+        expect($src)->toContain('export function useFinFavs');
+        expect($src)->toContain('export function FinFavPin');
+    });
+
+    it('prefixa localStorage com business key (Tier 0 isolation)', function () {
+        $src = file_get_contents(FIN_BASE_7C . '/_components/useFinFavs.tsx');
+        expect($src)->toContain("STORAGE_PREFIX = 'oimpresso.fin.favs.'");
+        // O hook recebe businessKey e usa no key — não pode haver tenant leak
+        expect($src)->toContain('businessKey');
+        expect($src)->toContain('STORAGE_VERSION');
+    });
+
+    it('expõe API completa: toggle/has/clear/count + favs Set', function () {
+        $src = file_get_contents(FIN_BASE_7C . '/_components/useFinFavs.tsx');
+        expect($src)->toContain('interface UseFinFavsApi');
+        expect($src)->toContain('toggle:');
+        expect($src)->toContain('has:');
+        expect($src)->toContain('clear:');
+        expect($src)->toContain('count:');
+    });
+});
+
+describe('Onda 7c — FinTranscriptPDF (folha jurídica imprimível)', function () {
+    it('FinTranscriptPDF exporta componente + props canon', function () {
+        $src = file_get_contents(FIN_BASE_7C . '/_components/FinTranscriptPDF.tsx');
+        expect($src)->toContain('export function FinTranscriptPDF');
+        expect($src)->toContain('open:');
+        expect($src)->toContain('onClose:');
+        expect($src)->toContain('lancamentos:');
+        expect($src)->toContain('periodLabel:');
+        expect($src)->toContain('onlyFavs');
+    });
+
+    it('Atalho Esc fecha + window.print integrado', function () {
+        $src = file_get_contents(FIN_BASE_7C . '/_components/FinTranscriptPDF.tsx');
+        expect($src)->toContain("e.key === 'Escape'");
+        expect($src)->toContain('window.print()');
+    });
+
+    it('Folha A4: header empresa + tabela + tfoot totals + 2 assinaturas', function () {
+        $src = file_get_contents(FIN_BASE_7C . '/_components/FinTranscriptPDF.tsx');
+        expect($src)->toContain('fin-transcript-page');
+        expect($src)->toContain('fin-transcript-h');
+        expect($src)->toContain('fin-transcript-tbl');
+        expect($src)->toContain('Entradas');
+        expect($src)->toContain('Saídas');
+        expect($src)->toContain('Saldo líquido');
+        expect($src)->toContain('fin-transcript-sig'); // assinaturas
+    });
+
+    it('Filtro onlyFavs limita lançamentos quando Set não-vazio', function () {
+        $src = file_get_contents(FIN_BASE_7C . '/_components/FinTranscriptPDF.tsx');
+        expect($src)->toContain('onlyFavs');
+        expect($src)->toContain('onlyFavs.has(l.id)');
+    });
+});
+
+describe('Onda 7c — CSS escopado @media print isolation', function () {
+    it('Tokens .fin-transcript-* mounted em fin-output.css', function () {
+        $css = file_get_contents(FIN_OUTPUT_CSS_7C);
+        expect($css)->toContain('.fin-transcript-overlay');
+        expect($css)->toContain('.fin-transcript-page');
+        expect($css)->toContain('.fin-transcript-tbl');
+        expect($css)->toContain('.fin-transcript-bar');
+        expect($css)->toContain('.fin-fav-pin');
+    });
+
+    it('@media print isola .fin-transcript-page (esconde overlay/bar/header app)', function () {
+        $css = file_get_contents(FIN_OUTPUT_CSS_7C);
+        expect($css)->toContain('@media print');
+        expect($css)->toContain('body * { visibility: hidden; }');
+        // Folha visível no print
+        expect($css)->toContain('.fin-transcript-overlay,');
+        // @page A4
+        expect($css)->toContain('@page { size: A4');
+    });
+
+    it('Badge .fin-btn-badge no fin-cowork.css (count favoritos no botão Imprimir)', function () {
+        $css = file_get_contents(FIN_COWORK_CSS_7C);
+        expect($css)->toContain('.fin-curadoria .fin-btn-badge');
+    });
+});
+
+describe('Onda 7c — wire-up Index.tsx', function () {
+    it('Index.tsx importa FinTranscriptPDF + useFinFavs + FinFavPin', function () {
+        $src = file_get_contents(FIN_BASE_7C . '/Index.tsx');
+        expect($src)->toContain("from './_components/FinTranscriptPDF'");
+        expect($src)->toContain("from './_components/useFinFavs'");
+        expect($src)->toContain('useFinFavs');
+        expect($src)->toContain('FinFavPin');
+    });
+
+    it('Index.tsx instancia transcriptOpen + transcriptOnlyFavs + favs', function () {
+        $src = file_get_contents(FIN_BASE_7C . '/Index.tsx');
+        expect($src)->toContain('const [transcriptOpen, setTranscriptOpen]');
+        expect($src)->toContain('const [transcriptOnlyFavs, setTranscriptOnlyFavs]');
+        expect($src)->toContain('const favs = useFinFavs(');
+    });
+
+    it('Atalho B toggle fav da linha selecionada', function () {
+        $src = file_get_contents(FIN_BASE_7C . '/Index.tsx');
+        expect($src)->toContain("e.key === 'b'");
+        expect($src)->toContain('favs.toggle(selectedId)');
+    });
+
+    it('LinhaTabela renderiza FinFavPin com isFav prop', function () {
+        $src = file_get_contents(FIN_BASE_7C . '/Index.tsx');
+        expect($src)->toContain('isFav');
+        expect($src)->toContain('<FinFavPin');
+        expect($src)->toContain('favs.has(r.id)');
+    });
+
+    it('Botão Imprimir no header + entradas no command palette', function () {
+        $src = file_get_contents(FIN_BASE_7C . '/Index.tsx');
+        expect($src)->toContain('📄 Imprimir');
+        expect($src)->toContain('setTranscriptOpen(true)');
+        // Palette: 1 entrada normal + 1 condicional (só favoritos)
+        expect($src)->toContain('Imprimir período');
+        expect($src)->toContain('Imprimir só favoritos');
+    });
+
+    it('Drawer detalhe inclui botão Favoritar (★/☆)', function () {
+        $src = file_get_contents(FIN_BASE_7C . '/Index.tsx');
+        expect($src)->toContain('favs.toggle(selected.id)');
+        expect($src)->toContain('Favoritado');
+    });
+
+    it('FinTranscriptPDF mount com props canônicas', function () {
+        $src = file_get_contents(FIN_BASE_7C . '/Index.tsx');
+        expect($src)->toContain('<FinTranscriptPDF');
+        expect($src)->toContain('onlyFavs={transcriptOnlyFavs ? favs.favs : null}');
+    });
+
+    it('Footer-tips mostra atalho B + count de favoritos quando >0', function () {
+        $src = file_get_contents(FIN_BASE_7C . '/Index.tsx');
+        expect($src)->toContain('<kbd>B</kbd> favoritar linha');
+        expect($src)->toContain('favs.count > 0');
+    });
+});

--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -91,6 +91,21 @@
 .fin-curadoria .fin-btn-trilha { color: oklch(0.42 0.18 145); }
 .fin-curadoria .fin-btn-present { color: oklch(0.40 0.13 240); }
 
+/* Onda 7c — badge inline no botão (ex: "📄 Imprimir 3★") */
+.fin-curadoria .fin-btn-badge {
+  display: inline-flex;
+  align-items: center;
+  font-size: 10.5px;
+  font-weight: 600;
+  padding: 0 5px;
+  height: 16px;
+  border-radius: 8px;
+  background: oklch(0.93 0.10 75);
+  color: oklch(0.42 0.13 75);
+  margin-left: 4px;
+  line-height: 1;
+}
+
 /* ─────────────────────────────────────────────────────────────
  * KPI Stats grid (hero sparkline + 4 cards)
  * ───────────────────────────────────────────────────────────── */

--- a/resources/css/fin-output.css
+++ b/resources/css/fin-output.css
@@ -454,3 +454,141 @@
   padding: 1px 5px; border-radius: 3px;
   background: oklch(0.30 0.06 240); color: white; margin: 0 2px;
 }
+
+/* ========================================================================
+ * Onda 7c — FinTranscriptPDF + FinFavPin
+ * Folha jurídica imprimível + estrela favorito.
+ * @media print isola só a .fin-transcript-page quando user dá Ctrl+P.
+ * ======================================================================== */
+
+/* Pin estrela inline (lista + drawer) */
+.fin-fav-pin {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  color: oklch(0.72 0.16 75);
+  margin-left: 4px;
+  line-height: 1;
+}
+
+/* Overlay fullscreen com barra de ação fixa no topo */
+.fin-transcript-overlay {
+  position: fixed; inset: 0; z-index: 80;
+  background: oklch(0.95 0.005 80);
+  display: flex; flex-direction: column;
+  overflow-y: auto;
+}
+
+.fin-transcript-bar {
+  position: sticky; top: 0; z-index: 2;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 20px;
+  background: oklch(0.99 0 0); border-bottom: 1px solid oklch(0.90 0.005 80);
+  box-shadow: 0 1px 4px oklch(0 0 0 / 0.05);
+}
+.fin-transcript-bar-l { display: flex; align-items: baseline; gap: 8px; color: oklch(0.30 0.01 80); }
+.fin-transcript-bar-l strong { font-size: 13.5px; }
+.fin-transcript-bar-l small { font-size: 12px; color: oklch(0.50 0.01 80); }
+.fin-transcript-bar-r { display: flex; gap: 8px; }
+.fin-transcript-btn {
+  padding: 6px 14px; border-radius: 6px; font-size: 12.5px; font-weight: 500;
+  background: white; color: oklch(0.30 0.01 80); border: 1px solid oklch(0.85 0.005 80);
+  cursor: pointer; transition: all 0.12s;
+}
+.fin-transcript-btn:hover { background: oklch(0.97 0.005 80); border-color: oklch(0.75 0.005 80); }
+.fin-transcript-btn.primary { background: oklch(0.30 0.06 240); color: white; border-color: oklch(0.30 0.06 240); }
+.fin-transcript-btn.primary:hover { background: oklch(0.36 0.07 240); }
+
+/* Folha A4 simulada — sombra leve pra parecer papel */
+.fin-transcript-page {
+  background: white;
+  max-width: 760px;
+  margin: 24px auto;
+  padding: 40px 48px;
+  box-shadow: 0 4px 18px oklch(0 0 0 / 0.08);
+  font-family: ui-serif, Georgia, 'Times New Roman', serif;
+  color: oklch(0.18 0 0);
+  font-size: 12.5px;
+  line-height: 1.55;
+}
+
+.fin-transcript-h {
+  display: flex; justify-content: space-between; align-items: flex-end;
+  padding-bottom: 18px; margin-bottom: 24px;
+  border-bottom: 2px solid oklch(0.20 0 0);
+}
+.fin-transcript-h h1 {
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  font-size: 20px; font-weight: 700; margin: 0; letter-spacing: -0.01em;
+}
+.fin-transcript-h p { font-size: 11.5px; color: oklch(0.45 0 0); margin: 4px 0 0; font-family: ui-sans-serif, system-ui; }
+.fin-transcript-totals { text-align: right; }
+.fin-transcript-totals small { display: block; font-size: 10px; color: oklch(0.50 0 0); text-transform: uppercase; letter-spacing: 0.08em; font-family: ui-sans-serif, system-ui; }
+.fin-transcript-totals b {
+  font-size: 22px; font-weight: 700; font-family: ui-monospace, monospace;
+  color: oklch(0.18 0 0); letter-spacing: -0.02em;
+}
+
+/* Tabela jurídica clean */
+.fin-transcript-tbl {
+  width: 100%; border-collapse: collapse; margin-bottom: 32px;
+  font-size: 11.5px; font-family: ui-sans-serif, system-ui, sans-serif;
+}
+.fin-transcript-tbl thead th {
+  text-align: left; padding: 8px 6px; border-bottom: 1.5px solid oklch(0.20 0 0);
+  font-size: 10px; font-weight: 600; text-transform: uppercase; letter-spacing: 0.06em;
+  color: oklch(0.30 0 0);
+}
+.fin-transcript-tbl tbody td { padding: 7px 6px; border-bottom: 1px solid oklch(0.92 0 0); vertical-align: top; }
+.fin-transcript-tbl tbody tr:hover { background: oklch(0.98 0 0); }
+.fin-transcript-tbl tbody td b { font-weight: 600; }
+.fin-transcript-tbl .mono { font-family: ui-monospace, monospace; font-size: 11px; color: oklch(0.30 0 0); }
+.fin-transcript-tbl .right { text-align: right; }
+.fin-transcript-tbl .pos { color: oklch(0.40 0.13 145); }
+.fin-transcript-tbl .neg { color: oklch(0.50 0.18 25); }
+.fin-transcript-nfe { font-size: 10.5px; color: oklch(0.50 0 0); font-weight: 400; }
+
+.fin-transcript-tbl tfoot td {
+  padding: 8px 6px; border-bottom: none;
+  font-family: ui-sans-serif, system-ui, sans-serif; font-size: 11.5px;
+}
+.fin-transcript-tbl tfoot tr:last-child td {
+  border-top: 1.5px solid oklch(0.20 0 0); padding-top: 10px; font-size: 13px;
+}
+
+/* Rodapé com 2 assinaturas */
+.fin-transcript-f {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 60px;
+  margin-top: 60px; padding-top: 24px;
+}
+.fin-transcript-sig { text-align: center; }
+.fin-transcript-sig-line { height: 1px; background: oklch(0.30 0 0); margin-bottom: 6px; }
+.fin-transcript-sig small {
+  font-size: 11px; color: oklch(0.30 0 0); font-family: ui-sans-serif, system-ui;
+  text-transform: uppercase; letter-spacing: 0.08em;
+}
+
+.fin-transcript-foot-meta {
+  margin-top: 32px; padding-top: 12px;
+  text-align: center; font-size: 10px; color: oklch(0.55 0 0);
+  font-family: ui-sans-serif, system-ui;
+  border-top: 1px solid oklch(0.92 0 0);
+}
+
+/* Print isolation — esconde tudo exceto a folha */
+@media print {
+  body * { visibility: hidden; }
+  .fin-transcript-overlay,
+  .fin-transcript-overlay * { visibility: visible; }
+  .fin-transcript-bar { display: none; }
+  .fin-transcript-overlay {
+    position: static; background: white; overflow: visible;
+  }
+  .fin-transcript-page {
+    box-shadow: none; margin: 0; padding: 24mm 18mm;
+    max-width: none; width: 100%;
+  }
+  .fin-transcript-tbl tbody tr:hover { background: transparent; }
+  @page { size: A4; margin: 0; }
+}

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -35,6 +35,9 @@ import { FinChecklistFechamento } from './_components/FinChecklistFechamento';
 // Onda 7b — Troubleshooter dialog + PresentationMode fullscreen.
 import { FinTroubleshooterDialog, FinTroubleButton } from './_components/FinTroubleshooter';
 import { FinPresentationMode } from './_components/FinPresentationMode';
+// Onda 7c — Folha jurídica imprimível + favoritos pessoais (atalho B).
+import { FinTranscriptPDF } from './_components/FinTranscriptPDF';
+import { useFinFavs, FinFavPin } from './_components/useFinFavs';
 // Onda Edit 2026-05-18 — Sheet inline pra editar título financeiro.
 import { TituloEditSheet } from './_components/TituloEditSheet';
 
@@ -298,10 +301,11 @@ function _KpiBarLegacy({ kpis, onTabClick }: { kpis: Kpi; onTabClick: (tab: TabI
   );
 }
 
-function LinhaTabela({ row, dens, selected, onSelect, onBaixar, conferido, comments }: {
+function LinhaTabela({ row, dens, selected, onSelect, onBaixar, conferido, comments, isFav }: {
   row: Lancamento; dens: typeof DENSITY[keyof typeof DENSITY]; selected: boolean;
   onSelect: () => void; onBaixar: () => void;
   conferido: UseFinConferidoApi; comments: UseFinCommentsApi;
+  isFav: boolean;
 }) {
   const isIn = row.kind === 'receivable';
   const settled = row.status === 'recebido' || row.status === 'pago';
@@ -340,6 +344,7 @@ function LinhaTabela({ row, dens, selected, onSelect, onBaixar, conferido, comme
       <td className="px-2">
         <div className="font-medium text-stone-900 truncate max-w-[260px] flex items-center gap-1.5">
           <FinCrossLinkify text={row.descricao} className="truncate" />
+          <FinFavPin active={isFav} />
           <FinConferidoBadge rowId={row.id} conferido={conferido} />
           <FinCommentsBadge rowId={row.id} comments={comments} />
         </div>
@@ -380,6 +385,10 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
   // Cowork KB-9.75 Onda 7b — Troubleshooter + Presentation Mode states.
   const [troubleOpen, setTroubleOpen] = useState(false);
   const [presentOpen, setPresentOpen] = useState(false);
+  // Cowork KB-9.75 Onda 7c — Folha imprimível + favoritos pessoais (localStorage).
+  const [transcriptOpen, setTranscriptOpen] = useState(false);
+  const [transcriptOnlyFavs, setTranscriptOnlyFavs] = useState(false);
+  const favs = useFinFavs(businessName || 'default');
   // Onda Edit 2026-05-18 — Edit Sheet state (separate from detail drawer).
   const [editOpen, setEditOpen] = useState(false);
 
@@ -396,17 +405,24 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
     });
   };
 
-  // Atalhos: Cmd+K → palette, / → busca
+  // Atalhos: Cmd+K → palette, / → busca, B → toggle favorito da linha selecionada
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'k') { e.preventDefault(); setPaletteOpen(true); }
-      if (e.key === '/' && (e.target as HTMLElement)?.tagName !== 'INPUT') {
-        e.preventDefault(); document.getElementById('fin-search-input')?.focus();
+      const target = e.target as HTMLElement;
+      const inEditable = target?.tagName === 'INPUT' || target?.tagName === 'TEXTAREA' || target?.isContentEditable;
+      if ((e.metaKey || e.ctrlKey) && e.key === 'k') { e.preventDefault(); setPaletteOpen(true); return; }
+      if (e.key === '/' && !inEditable) {
+        e.preventDefault(); document.getElementById('fin-search-input')?.focus(); return;
+      }
+      // Onda 7c — B (bookmark) toggle favorito da linha atualmente selecionada
+      if (e.key === 'b' && !inEditable && selectedId !== null) {
+        e.preventDefault();
+        favs.toggle(selectedId);
       }
     };
     window.addEventListener('keydown', onKey);
     return () => window.removeEventListener('keydown', onKey);
-  }, []);
+  }, [selectedId, favs]);
 
   // Agrupamento por data de vencimento
   const grupos = useMemo(() => {
@@ -460,6 +476,15 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
             onClick={() => setPresentOpen(true)}
           >
             ▶ Apresentar
+          </button>
+          <button
+            type="button"
+            className="fin-btn"
+            title={`Folha jurídica imprimível${favs.count > 0 ? ` · ${favs.count} favorito${favs.count === 1 ? '' : 's'}` : ''}`}
+            onClick={() => { setTranscriptOnlyFavs(false); setTranscriptOpen(true); }}
+          >
+            📄 Imprimir
+            {favs.count > 0 && <span className="fin-btn-badge">{favs.count}★</span>}
           </button>
           <button type="button" className="fin-btn" onClick={() => router.visit('/financeiro/extrato')}>
             ↺ Conciliar
@@ -627,6 +652,7 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
                         onBaixar={() => onBaixar(r.id)}
                         conferido={conferido}
                         comments={comments}
+                        isFav={favs.has(r.id)}
                       />
                     ))}
                   </React.Fragment>
@@ -732,6 +758,13 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
                     </Button>
                   )}
                   <Button variant="outline" onClick={() => setEditOpen(true)}>Editar</Button>
+                  <Button
+                    variant="outline"
+                    onClick={() => favs.toggle(selected.id)}
+                    title="Atalho: B (com a linha selecionada)"
+                  >
+                    {favs.has(selected.id) ? '★ Favoritado' : '☆ Favoritar'}
+                  </Button>
                   <Button variant="outline" className="ml-auto">Anexar</Button>
                 </div>
               </div>
@@ -749,6 +782,14 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
             <CommandItem onSelect={() => { setPaletteOpen(false); router.visit('/financeiro/unificado/novo'); }}>Novo lançamento</CommandItem>
             <CommandItem onSelect={() => { setPaletteOpen(false); router.visit('/financeiro/extrato'); }}>Conciliar extrato</CommandItem>
             <CommandItem onSelect={() => { setPaletteOpen(false); router.visit('/financeiro/relatorios'); }}>DRE / Relatórios</CommandItem>
+            <CommandItem onSelect={() => { setPaletteOpen(false); setTranscriptOnlyFavs(false); setTranscriptOpen(true); }}>
+              📄 Imprimir período (folha jurídica)
+            </CommandItem>
+            {favs.count > 0 && (
+              <CommandItem onSelect={() => { setPaletteOpen(false); setTranscriptOnlyFavs(true); setTranscriptOpen(true); }}>
+                ★ Imprimir só favoritos ({favs.count})
+              </CommandItem>
+            )}
           </CommandGroup>
           <CommandGroup heading="Lançamentos">
             {lancamentos.slice(0, 15).map(l => (
@@ -767,8 +808,10 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
         <span><kbd>/</kbd> buscar</span>
         <span><kbd>J</kbd>/<kbd>K</kbd> navegar</span>
         <span><kbd>␣</kbd> marcar pago/recebido</span>
+        <span><kbd>B</kbd> favoritar linha</span>
         <FinTroubleButton onClick={() => setTroubleOpen(true)} />
         <span className="spacer" />
+        {favs.count > 0 && <span>{favs.count} favorito{favs.count === 1 ? '' : 's'} ★</span>}
         <span>Densidade: <strong>{filters.densidade}</strong></span>
       </div>
 
@@ -781,6 +824,16 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
         lancamentos={lancamentos}
         periodLabel={periodLabel}
         businessName={businessName}
+      />
+
+      {/* Onda 7c — Folha jurídica imprimível (fullscreen overlay + @print) */}
+      <FinTranscriptPDF
+        open={transcriptOpen}
+        onClose={() => setTranscriptOpen(false)}
+        lancamentos={lancamentos}
+        periodLabel={periodLabel}
+        businessName={businessName}
+        onlyFavs={transcriptOnlyFavs ? favs.favs : null}
       />
 
       {/* Cowork KB-9.75 Onda 7 R3 — Trilha fechamento dialog */}

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinTranscriptPDF.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinTranscriptPDF.tsx
@@ -1,0 +1,200 @@
+// FinTranscriptPDF — Cowork KB-9.75 Financeiro Onda 7c
+// (folha jurídica imprimível — pra Eliana mandar pro escritório/contabilidade).
+//
+// Refs:
+//  - prototipo-ui/financeiro-output.jsx FinTranscriptPDF + @print media
+//
+// Render fullscreen overlay com "folha A4" simulada. Print CSS isola a folha
+// quando user dá Ctrl+P (esconde overlay + header + footer da página).
+//
+// Pure compute — zero backend, zero LLM. Gera HTML imprimível direto do
+// state atual (lancamentos + kpis filtrados pelo filtro corrente).
+//
+// Multi-tenant safe: só renderiza o que recebe via props (não toca queries).
+
+import { useEffect, useMemo } from 'react';
+
+interface LancamentoLite {
+  id: number;
+  kind?: 'receivable' | 'payable';
+  descricao: string;
+  contraparte: string;
+  contraparte_doc?: string | null;
+  categoria?: string;
+  valor: number;
+  vencimento: string;
+  vencimento_label?: string;
+  liquidacao?: string | null;
+  status?: string;
+  nfe_numero?: string | null;
+}
+
+interface FinTranscriptPDFProps {
+  open: boolean;
+  onClose: () => void;
+  lancamentos: LancamentoLite[];
+  periodLabel: string;
+  businessName?: string;
+  /** Quando true, mostra só os favoritados (passa o Set externamente). */
+  onlyFavs?: Set<number> | null;
+  /** Operador que está fechando — vai pro rodapé "Assinatura". */
+  operatorName?: string;
+}
+
+function brl(n: number): string {
+  return n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+function dateNow(): string {
+  const d = new Date();
+  return d.toLocaleDateString('pt-BR', { day: '2-digit', month: 'long', year: 'numeric' });
+}
+
+export function FinTranscriptPDF({
+  open,
+  onClose,
+  lancamentos,
+  periodLabel,
+  businessName,
+  onlyFavs = null,
+  operatorName,
+}: FinTranscriptPDFProps) {
+  // Atalho Esc fecha + Ctrl+P imprime
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+        return;
+      }
+      // Cmd/Ctrl+P já é nativo do browser — não interceptamos, só deixamos rolar
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
+  const rows = useMemo(() => {
+    if (!onlyFavs || onlyFavs.size === 0) return lancamentos;
+    return lancamentos.filter((l) => onlyFavs.has(l.id));
+  }, [lancamentos, onlyFavs]);
+
+  const totals = useMemo(() => {
+    let entradas = 0;
+    let saidas = 0;
+    for (const r of rows) {
+      if (r.kind === 'receivable') entradas += r.valor || 0;
+      else saidas += r.valor || 0;
+    }
+    return { entradas, saidas, saldo: entradas - saidas, qtd: rows.length };
+  }, [rows]);
+
+  if (!open) return null;
+
+  const handlePrint = () => {
+    window.print();
+  };
+
+  return (
+    <div className="fin-transcript-overlay" role="dialog" aria-label="Folha imprimível">
+      <div className="fin-transcript-bar">
+        <div className="fin-transcript-bar-l">
+          <strong>📄 Folha imprimível</strong>
+          <small>· {rows.length} lançamento{rows.length === 1 ? '' : 's'}{onlyFavs && onlyFavs.size > 0 ? ' (só favoritos)' : ''}</small>
+        </div>
+        <div className="fin-transcript-bar-r">
+          <button type="button" className="fin-transcript-btn primary" onClick={handlePrint} title="Ctrl+P">
+            🖨 Imprimir
+          </button>
+          <button type="button" className="fin-transcript-btn" onClick={onClose} title="Esc">
+            ✕ Fechar
+          </button>
+        </div>
+      </div>
+
+      <div className="fin-transcript-page">
+        <header className="fin-transcript-h">
+          <div>
+            <h1>Financeiro · Demonstrativo</h1>
+            <p>
+              {businessName && <span>{businessName} · </span>}
+              {periodLabel} · emitido em {dateNow()}
+            </p>
+          </div>
+          <div className="fin-transcript-totals">
+            <small>Total líquido</small>
+            <b>{brl(totals.saldo)}</b>
+          </div>
+        </header>
+
+        <table className="fin-transcript-tbl">
+          <thead>
+            <tr>
+              <th style={{ width: 80 }}>Vencimento</th>
+              <th>Descrição / NF-e</th>
+              <th>Contraparte</th>
+              <th>Categoria</th>
+              <th style={{ width: 70 }}>Status</th>
+              <th style={{ width: 110, textAlign: 'right' }}>Valor</th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.length === 0 && (
+              <tr><td colSpan={6} style={{ textAlign: 'center', padding: '32px 12px', color: '#777' }}>
+                Sem lançamentos no período.
+              </td></tr>
+            )}
+            {rows.map((r) => (
+              <tr key={r.id}>
+                <td className="mono">{r.vencimento_label || r.vencimento}</td>
+                <td>
+                  <b>{r.descricao}</b>
+                  {r.nfe_numero && <span className="fin-transcript-nfe"> · NF-e {r.nfe_numero}</span>}
+                </td>
+                <td>
+                  {r.contraparte}
+                  {r.contraparte_doc && <small style={{ display: 'block', color: '#777' }}>{r.contraparte_doc}</small>}
+                </td>
+                <td>{r.categoria || '—'}</td>
+                <td className="mono">{r.status || '—'}</td>
+                <td className={'mono right ' + (r.kind === 'receivable' ? 'pos' : 'neg')}>
+                  {r.kind === 'receivable' ? '+' : '−'} {brl(r.valor).replace('R$', '').trim()}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+          <tfoot>
+            <tr>
+              <td colSpan={4} style={{ textAlign: 'right' }}><strong>Entradas</strong></td>
+              <td className="mono right pos" colSpan={2}><b>{brl(totals.entradas)}</b></td>
+            </tr>
+            <tr>
+              <td colSpan={4} style={{ textAlign: 'right' }}><strong>Saídas</strong></td>
+              <td className="mono right neg" colSpan={2}><b>{brl(totals.saidas)}</b></td>
+            </tr>
+            <tr>
+              <td colSpan={4} style={{ textAlign: 'right' }}><strong>Saldo líquido</strong></td>
+              <td className="mono right" colSpan={2}><b>{brl(totals.saldo)}</b></td>
+            </tr>
+          </tfoot>
+        </table>
+
+        <footer className="fin-transcript-f">
+          <div className="fin-transcript-sig">
+            <div className="fin-transcript-sig-line" />
+            <small>{operatorName ? `${operatorName} · Financeiro` : 'Financeiro'}</small>
+          </div>
+          <div className="fin-transcript-sig">
+            <div className="fin-transcript-sig-line" />
+            <small>Contabilidade</small>
+          </div>
+        </footer>
+
+        <p className="fin-transcript-foot-meta">
+          Documento gerado automaticamente · oimpresso.com · {dateNow()}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export default FinTranscriptPDF;

--- a/resources/js/Pages/Financeiro/Unificado/_components/useFinFavs.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/useFinFavs.tsx
@@ -1,0 +1,89 @@
+// useFinFavs — Cowork KB-9.75 Financeiro Onda 7c
+// (favoritos pessoais por business_id + atalho B).
+//
+// Refs:
+//  - prototipo-ui/financeiro-output.jsx FinFavStar + bookmarkAtalho
+//
+// Hook localStorage-backed. Cada usuário/business tem seu próprio set de
+// lançamentos favoritados — útil pra Eliana marcar "olha mais tarde" sem
+// poluir DB (não muda business state, é só preferência pessoal de leitura).
+//
+// Multi-tenant safe: prefixo `oimpresso.fin.favs.<business_id>` evita
+// vazamento entre tenants quando user logout/login em conta diferente.
+//
+// Atalho `B` (de "bookmark") quando selectedId não-null → toggle.
+
+import { useState, useEffect, useCallback, useMemo } from 'react';
+
+const STORAGE_PREFIX = 'oimpresso.fin.favs.';
+const STORAGE_VERSION = 'v1';
+
+interface UseFinFavsApi {
+  favs: Set<number>;
+  toggle: (id: number) => void;
+  has: (id: number) => boolean;
+  clear: () => void;
+  count: number;
+}
+
+/**
+ * Hook de favoritos pessoais. businessKey deve ser estável durante a sessão
+ * (ex.: business_id ou nome canon) — quando muda, lê de outro slot.
+ */
+export function useFinFavs(businessKey: string | number = 'default'): UseFinFavsApi {
+  const storageKey = `${STORAGE_PREFIX}${businessKey}.${STORAGE_VERSION}`;
+
+  const [favs, setFavs] = useState<Set<number>>(() => {
+    if (typeof window === 'undefined') return new Set();
+    try {
+      const raw = window.localStorage.getItem(storageKey);
+      if (!raw) return new Set();
+      const arr: number[] = JSON.parse(raw);
+      return new Set(arr.filter((n) => Number.isFinite(n)));
+    } catch {
+      return new Set();
+    }
+  });
+
+  // Persiste sempre que muda
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    try {
+      window.localStorage.setItem(storageKey, JSON.stringify(Array.from(favs)));
+    } catch {
+      // ignora QuotaExceededError silencioso — não é crítico
+    }
+  }, [favs, storageKey]);
+
+  const toggle = useCallback((id: number) => {
+    setFavs((prev) => {
+      const next = new Set(prev);
+      if (next.has(id)) next.delete(id);
+      else next.add(id);
+      return next;
+    });
+  }, []);
+
+  const has = useCallback((id: number) => favs.has(id), [favs]);
+
+  const clear = useCallback(() => setFavs(new Set()), []);
+
+  return useMemo(() => ({ favs, toggle, has, clear, count: favs.size }), [favs, toggle, has, clear]);
+}
+
+/**
+ * Pin estrela inline (use na coluna 1 ou inline no nome do lançamento).
+ * Não-clicável por design — toggle acontece via atalho `B` ou drawer.
+ */
+export function FinFavPin({ active }: { active: boolean }) {
+  if (!active) return null;
+  return (
+    <span
+      className="fin-fav-pin"
+      title="Favoritado (pressione B com a linha selecionada pra remover)"
+      aria-label="Favoritado"
+    >
+      ★
+    </span>
+  );
+}


### PR DESCRIPTION
## Resumo

Implementa as 2 features pendentes pós-Onda 7b ([PR #1085](https://github.com/wagnerra23/oimpresso.com/pull/1085)) — folha jurídica imprimível + favoritos pessoais com atalho B.

## Features

### 1. Folha jurídica imprimível (`FinTranscriptPDF.tsx`)

Substitui o workflow atual (Eliana usa screenshot/printscreen → cola em e-mail pra contabilidade) por folha A4 estruturada com:

- Header empresa + período + total líquido destaque
- Tabela jurídica clean (vencimento / descrição / contraparte / categoria / status / valor)
- Tfoot computed: **Entradas** / **Saídas** / **Saldo líquido**
- 2 áreas de assinatura (Financeiro + Contabilidade)
- Rodapé com metadado de emissão

**Print isolation:** `@media print` esconde tudo exceto `.fin-transcript-page`. `@page A4` sem margem (folha controla padding). User dá Ctrl+P do browser e sai limpinho.

**Acessível via:**
- Botão `📄 Imprimir` no header (com badge `3★` quando há favoritos)
- Command palette `⌘K` → "Imprimir período" / "Imprimir só favoritos"

### 2. Favoritos pessoais (`useFinFavs.tsx`)

Hook localStorage para Eliana marcar lançamentos "olhar mais tarde" sem poluir DB nem afetar outros usuários:

- Prefixo `oimpresso.fin.favs.<business_key>.v1` (**multi-tenant safe** — previne leak entre tenants)
- API completa: `favs:Set / toggle / has / clear / count`
- Atalho **B** na linha selecionada → toggle fav (respeita INPUT/TEXTAREA/contentEditable)
- `FinFavPin` ⭐ inline na lista quando favoritado
- Botão Favoritar (☆/★) no drawer detalhe

## Tier 0 / Integrações

- ✅ Multi-tenant preservado (zero backend, prefixo por business)
- ✅ Zero novas queries Eloquent
- ✅ Compat TransactionObserver / TituloAutoService / BoletoRemessa (não toca)
- ✅ Cowork canon: tokens oklch + tipografia jurídica serif

## Testes

`Modules/Financeiro/Tests/Feature/Onda7cTranscriptFavsTest.php` — 5 describes × ~17 testes:
- useFinFavs hook: exports, prefixo Tier 0, API completa
- FinTranscriptPDF: props, atalho Esc + print, A4 layout, filtro onlyFavs
- CSS: @media print isolation, @page A4, .fin-fav-pin, .fin-btn-badge
- Wire-up Index.tsx: imports, states, atalho B, FinFavPin, command palette, drawer button, footer-tips

## Test plan

- [x] Build Vite (tailwind compila)
- [x] TS check (9 erros pre-existentes, 0 novos)
- [x] Pest local — pendente (vendor vazio no worktree; CI roda)
- [ ] Smoke Chrome MCP pós-merge: clicar `📄 Imprimir` → folha A4 abre; clicar linha + B → estrela aparece; `⌘K` → "Imprimir só favoritos" presente

Refs: prototipo-ui/financeiro-output.jsx FinTranscriptPDF + FinFavStar

🤖 Generated with [Claude Code](https://claude.com/claude-code)