### PR TITLE
feat(financeiro): Onda 8c — sparkline com dados REAIS 30d (endpoint backend)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -3,9 +3,11 @@
 namespace Modules\Financeiro\Http\Controllers;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
@@ -290,6 +292,93 @@ class UnificadoController extends Controller
     }
 
     // ─────────── Helpers privados ───────────
+
+    /**
+     * Onda 8c 2026-05-18 — Endpoint JSON saldo sparkline 30d.
+     *
+     * Retorna array de 30 pontos com saldo cumulativo dia-a-dia (D-29 ... hoje).
+     * Algoritmo:
+     *  1. saldo_atual = SUM(ContaBancaria.saldo_cached)
+     *  2. delta_dia = SUM(receber baixas) - SUM(pagar baixas) por data_baixa
+     *  3. saldo[D-29] = saldo_atual - SUM(delta_dia[D-28..hoje]) + delta_dia[D-29]
+     *     (running sum a partir da baseline 30d atrás)
+     *
+     * Tier 0 Multi-tenant: filtra business_id explícito (não dependo do global scope
+     * via Auth — query é DB direto pra ser barata o suficiente pra request inline).
+     *
+     * Response: { points: [{date: "2026-04-19", saldo: 1234.56, in: 100, out: 50}, ...], saldo_atual: N }
+     */
+    public function saldoSparkline(Request $request): JsonResponse
+    {
+        $businessId = (int) session('user.business_id');
+        if ($businessId <= 0) {
+            return response()->json(['points' => [], 'saldo_atual' => 0.0], 400);
+        }
+
+        $hoje = now()->startOfDay();
+        $inicio = (clone $hoje)->subDays(29); // 30 pontos inclusivo
+        $inicioStr = $inicio->toDateString();
+        $hojeStr = $hoje->toDateString();
+
+        // 1) Saldo atual (snapshot agregado das contas ativas)
+        $saldoAtual = (float) ContaBancaria::where('business_id', $businessId)
+            ->whereNull('deleted_at')
+            ->sum('saldo_cached');
+
+        // 2) Deltas diários: agrega TituloBaixa por data_baixa + tipo Titulo
+        $rows = DB::table('fin_titulo_baixas as tb')
+            ->join('fin_titulos as t', 't.id', '=', 'tb.titulo_id')
+            ->where('tb.business_id', $businessId)
+            ->whereNull('tb.estorno_de_id')
+            ->whereBetween('tb.data_baixa', [$inicioStr, $hojeStr])
+            ->groupBy('tb.data_baixa', 't.tipo')
+            ->selectRaw('tb.data_baixa as d, t.tipo as tipo, SUM(tb.valor_baixa) as total')
+            ->get();
+
+        // Mapeia date => ['in' => x, 'out' => y]
+        $byDate = [];
+        foreach ($rows as $r) {
+            $date = (string) $r->d;
+            if (! isset($byDate[$date])) {
+                $byDate[$date] = ['in' => 0.0, 'out' => 0.0];
+            }
+            if ($r->tipo === 'receber') {
+                $byDate[$date]['in'] += (float) $r->total;
+            } else {
+                $byDate[$date]['out'] += (float) $r->total;
+            }
+        }
+
+        // 3) Constrói série 30 pontos forward — começamos da baseline (saldo virtual há 30d)
+        // saldoBaseline = saldoAtual - sumNetDelta30d
+        $sumNetDelta = 0.0;
+        foreach ($byDate as $v) {
+            $sumNetDelta += ($v['in'] - $v['out']);
+        }
+        $saldoBaseline = $saldoAtual - $sumNetDelta;
+
+        $points = [];
+        $running = $saldoBaseline;
+        for ($i = 0; $i < 30; $i++) {
+            $date = (clone $inicio)->addDays($i)->toDateString();
+            $in = $byDate[$date]['in'] ?? 0.0;
+            $out = $byDate[$date]['out'] ?? 0.0;
+            $running += ($in - $out);
+            $points[] = [
+                'date' => $date,
+                'saldo' => round($running, 2),
+                'in' => round($in, 2),
+                'out' => round($out, 2),
+            ];
+        }
+
+        return response()->json([
+            'points' => $points,
+            'saldo_atual' => round($saldoAtual, 2),
+            'saldo_baseline_30d' => round($saldoBaseline, 2),
+            'periodo' => ['inicio' => $inicioStr, 'fim' => $hojeStr],
+        ]);
+    }
 
     private function parseFilters(Request $request): array
     {

--- a/Modules/Financeiro/Routes/web.php
+++ b/Modules/Financeiro/Routes/web.php
@@ -69,6 +69,11 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
             ->whereNumber('id')
             ->name('unificado.unconferir');
 
+        // Onda 8c 2026-05-18 — sparkline endpoint (saldo dia-a-dia últimos 30d)
+        // Pure-read, JSON, Tier 0 multi-tenant via business_id global scope.
+        Route::get('/unificado/saldo-sparkline', [UnificadoController::class, 'saldoSparkline'])
+            ->name('unificado.saldo-sparkline');
+
         // Fluxo de caixa projetado — Cockpit V2 (US-FIN-014) — protótipo Cowork 2026-05-09
         // Q1-Q4 aprovadas [W] 2026-05-14. Read-only. Ver Index.charter.md + fluxo-visual-comparison.md.
         Route::get('/fluxo', [FluxoController::class, 'index'])->name('fluxo.index');

--- a/Modules/Financeiro/Tests/Feature/Onda8cSparklineRealTest.php
+++ b/Modules/Financeiro/Tests/Feature/Onda8cSparklineRealTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Onda 8c KB-9.75 — Sparkline com dados REAIS via endpoint backend.
+ *
+ * Substitui o path SVG estático (Onda 8) por dados agregados das baixas
+ * (TituloBaixa) dia-a-dia nos últimos 30d.
+ *
+ * Cobre:
+ *   - Rota GET /financeiro/unificado/saldo-sparkline registrada
+ *   - Método saldoSparkline retorna JSON shape canon (points, saldo_atual, saldo_baseline_30d, periodo)
+ *   - Algoritmo: 30 pontos × {date, saldo, in, out}
+ *   - Multi-tenant Tier 0: filtra business_id explícito
+ *   - SQL usa fin_titulo_baixas (não titulo_baixas)
+ *   - Frontend: useSparkline30d hook + FinSparkline aceita prop points
+ *   - Fallback placeholder quando points < 2 (loading/error/sem dados)
+ */
+
+const FIN_BASE_8C = __DIR__ . '/../../../../resources/js/Pages/Financeiro/Unificado';
+const FIN_CTRL_8C = __DIR__ . '/../../Http/Controllers/UnificadoController.php';
+const FIN_ROUTES_8C = __DIR__ . '/../../Routes/web.php';
+
+describe('Onda 8c — Endpoint backend saldoSparkline', function () {
+    it('Routes/web.php registra GET unificado/saldo-sparkline', function () {
+        $src = file_get_contents(FIN_ROUTES_8C);
+        expect($src)->toContain("Route::get('/unificado/saldo-sparkline'");
+        expect($src)->toContain("UnificadoController::class, 'saldoSparkline'");
+        expect($src)->toContain('unificado.saldo-sparkline');
+    });
+
+    it('UnificadoController::saldoSparkline existe + return JsonResponse', function () {
+        $src = file_get_contents(FIN_CTRL_8C);
+        expect($src)->toContain('public function saldoSparkline(Request $request): JsonResponse');
+        expect($src)->toContain('use Illuminate\Http\JsonResponse');
+    });
+
+    it('Algoritmo: 30 pontos com running sum, baseline 30d atrás', function () {
+        $src = file_get_contents(FIN_CTRL_8C);
+        // saldo atual de ContaBancaria
+        expect($src)->toContain("ContaBancaria::where('business_id', \$businessId)");
+        expect($src)->toContain("->sum('saldo_cached')");
+        // for de 30 pontos
+        expect($src)->toContain('for ($i = 0; $i < 30; $i++)');
+        // shape retornado
+        expect($src)->toContain("'points'");
+        expect($src)->toContain("'saldo_atual'");
+        expect($src)->toContain("'saldo_baseline_30d'");
+        expect($src)->toContain("'periodo'");
+    });
+
+    it('Multi-tenant Tier 0: filtra business_id explícito no SQL', function () {
+        $src = file_get_contents(FIN_CTRL_8C);
+        // Pega o trecho do método saldoSparkline pra checar isolamento
+        $start = strpos($src, 'public function saldoSparkline');
+        $end = strpos($src, 'private function parseFilters');
+        $methodSrc = substr($src, $start, $end - $start);
+
+        expect($methodSrc)->toContain("session('user.business_id')");
+        expect($methodSrc)->toContain("where('tb.business_id', \$businessId)");
+        // proteção: business_id <= 0 retorna 400 (não pode vazar)
+        expect($methodSrc)->toContain('businessId <= 0');
+    });
+
+    it('SQL usa tabela canônica fin_titulo_baixas (não titulo_baixas)', function () {
+        $src = file_get_contents(FIN_CTRL_8C);
+        $start = strpos($src, 'public function saldoSparkline');
+        $end = strpos($src, 'private function parseFilters');
+        $methodSrc = substr($src, $start, $end - $start);
+
+        expect($methodSrc)->toContain('fin_titulo_baixas as tb');
+        expect($methodSrc)->toContain('fin_titulos as t');
+        // garante NÃO existe o nome errado
+        expect($methodSrc)->not->toMatch('/[^\w_]titulo_baixas\b/');
+    });
+
+    it('Estornos não contam (whereNull estorno_de_id)', function () {
+        $src = file_get_contents(FIN_CTRL_8C);
+        $start = strpos($src, 'public function saldoSparkline');
+        $end = strpos($src, 'private function parseFilters');
+        $methodSrc = substr($src, $start, $end - $start);
+        expect($methodSrc)->toContain('whereNull(\'tb.estorno_de_id\')');
+    });
+});
+
+describe('Onda 8c — Frontend useSparkline30d + FinSparkline points', function () {
+    it('FinSparkline aceita prop points opcional', function () {
+        $src = file_get_contents(FIN_BASE_8C . '/Index.tsx');
+        expect($src)->toContain('interface SparkPoint');
+        expect($src)->toContain('points?: SparkPoint[] | null');
+        expect($src)->toContain("function FinSparkline({ tone = 'pos', points }:");
+    });
+
+    it('Hook useSparkline30d fetch /financeiro/unificado/saldo-sparkline', function () {
+        $src = file_get_contents(FIN_BASE_8C . '/Index.tsx');
+        expect($src)->toContain('function useSparkline30d()');
+        expect($src)->toContain("fetch('/financeiro/unificado/saldo-sparkline'");
+        expect($src)->toContain("'X-Requested-With': 'XMLHttpRequest'");
+        expect($src)->toContain("credentials: 'same-origin'");
+    });
+
+    it('Fallback placeholder quando points < 2 (loading/error/sem dados)', function () {
+        $src = file_get_contents(FIN_BASE_8C . '/Index.tsx');
+        expect($src)->toContain('!points || points.length < 2');
+    });
+
+    it('KpiBar instancia useSparkline30d + passa points pro FinSparkline', function () {
+        $src = file_get_contents(FIN_BASE_8C . '/Index.tsx');
+        expect($src)->toContain('const sparkPoints = useSparkline30d()');
+        expect($src)->toContain('points={sparkPoints}');
+    });
+
+    it('Algoritmo SVG path canon: normalização min/max + linePath/fillPath', function () {
+        $src = file_get_contents(FIN_BASE_8C . '/Index.tsx');
+        expect($src)->toContain('const minS = Math.min(...saldos)');
+        expect($src)->toContain('const maxS = Math.max(...saldos)');
+        expect($src)->toContain('const range = maxS - minS || 1');
+        expect($src)->toContain('linePath');
+        expect($src)->toContain('fillPath');
+    });
+});

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -178,40 +178,103 @@ function StatusPill({ s }: { s: LancamentoStatus }) {
  * Onda 8 KB-9.75 — KPI bar Cowork canon: hero "Saldo previsto" com sparkline
  * SVG inline + 4 cards secundários. Substitui shadcn KpiCard flat antigo.
  *
- * Sparkline mostra trajetória do saldo ao longo do mês (placeholder estático
- * agora — Onda 8b plugará dados reais via /api/financeiro/saldo-sparkline).
+ * Onda 8c (2026-05-18): plugado em dados reais via /financeiro/unificado/saldo-sparkline.
+ * Quando `points` recebido: gera path SVG normalizado pela faixa min/max. Fallback
+ * mantém placeholder estático (loading/error/sem dados).
  */
-function FinSparkline({ tone = 'pos' }: { tone?: 'pos' | 'neg' }) {
-  // Path placeholder estático — Onda 8b: data prop com 30d real.
+interface SparkPoint { date: string; saldo: number; in: number; out: number }
+
+function FinSparkline({ tone = 'pos', points }: { tone?: 'pos' | 'neg'; points?: SparkPoint[] | null }) {
   const color = tone === 'pos' ? 'oklch(0.78 0.13 145)' : 'oklch(0.65 0.18 25)';
+
+  // Sem dados → fallback placeholder estático (Onda 8 inicial)
+  if (!points || points.length < 2) {
+    return (
+      <svg className="fin-spark" viewBox="0 0 200 36" preserveAspectRatio="none" aria-hidden="true">
+        <defs>
+          <linearGradient id="finSparkG" x1="0" x2="0" y1="0" y2="1">
+            <stop offset="0%" stopColor={color} stopOpacity="0.5" />
+            <stop offset="100%" stopColor={color} stopOpacity="0" />
+          </linearGradient>
+        </defs>
+        <path d="M0,30 L15,26 L30,22 L45,20 L60,18 L75,22 L90,16 L105,18 L120,14 L135,12 L150,16 L165,10 L180,12 L200,8 L200,36 L0,36 Z" fill="url(#finSparkG)" />
+        <path d="M0,30 L15,26 L30,22 L45,20 L60,18 L75,22 L90,16 L105,18 L120,14 L135,12 L150,16 L165,10 L180,12 L200,8" stroke={color} strokeWidth="1.5" fill="none" />
+        <line x1="0" y1="24" x2="200" y2="24" stroke="oklch(0.65 0.01 80)" strokeWidth="0.5" strokeDasharray="2 3" opacity="0.4" />
+      </svg>
+    );
+  }
+
+  // Gera path a partir dos pontos reais. Normaliza Y entre [4, 32] pra margem visual.
+  const W = 200;
+  const H = 36;
+  const PADDING_Y = 4;
+  const innerH = H - PADDING_Y * 2;
+  const saldos = points.map((p) => p.saldo);
+  const minS = Math.min(...saldos);
+  const maxS = Math.max(...saldos);
+  const range = maxS - minS || 1;
+
+  const linePath = points
+    .map((p, i) => {
+      const x = (i / (points.length - 1)) * W;
+      const y = H - PADDING_Y - ((p.saldo - minS) / range) * innerH;
+      return `${i === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`;
+    })
+    .join(' ');
+
+  const fillPath = `${linePath} L${W},${H} L0,${H} Z`;
+  const firstSaldo = points[0]?.saldo ?? 0;
+  const baselineY = H - PADDING_Y - ((firstSaldo - minS) / range) * innerH;
+
   return (
-    <svg className="fin-spark" viewBox="0 0 200 36" preserveAspectRatio="none" aria-hidden="true">
+    <svg className="fin-spark" viewBox={`0 0 ${W} ${H}`} preserveAspectRatio="none" aria-hidden="true">
       <defs>
         <linearGradient id="finSparkG" x1="0" x2="0" y1="0" y2="1">
           <stop offset="0%" stopColor={color} stopOpacity="0.5" />
           <stop offset="100%" stopColor={color} stopOpacity="0" />
         </linearGradient>
       </defs>
-      <path
-        d="M0,30 L15,26 L30,22 L45,20 L60,18 L75,22 L90,16 L105,18 L120,14 L135,12 L150,16 L165,10 L180,12 L200,8 L200,36 L0,36 Z"
-        fill="url(#finSparkG)"
-      />
-      <path
-        d="M0,30 L15,26 L30,22 L45,20 L60,18 L75,22 L90,16 L105,18 L120,14 L135,12 L150,16 L165,10 L180,12 L200,8"
-        stroke={color}
-        strokeWidth="1.5"
-        fill="none"
-      />
-      <line x1="0" y1="24" x2="200" y2="24" stroke="oklch(0.65 0.01 80)" strokeWidth="0.5" strokeDasharray="2 3" opacity="0.4" />
+      <path d={fillPath} fill="url(#finSparkG)" />
+      <path d={linePath} stroke={color} strokeWidth="1.5" fill="none" strokeLinejoin="round" strokeLinecap="round" />
+      <line x1="0" y1={baselineY} x2={W} y2={baselineY} stroke="oklch(0.65 0.01 80)" strokeWidth="0.5" strokeDasharray="2 3" opacity="0.4" />
     </svg>
   );
+}
+
+/** Hook fetch sparkline 30d via endpoint backend (Tier 0 multi-tenant via session). */
+function useSparkline30d(): SparkPoint[] | null {
+  const [points, setPoints] = useState<SparkPoint[] | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const resp = await fetch('/financeiro/unificado/saldo-sparkline', {
+          headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+          credentials: 'same-origin',
+        });
+        if (!resp.ok) return;
+        const data = await resp.json();
+        if (!cancelled && Array.isArray(data?.points)) {
+          setPoints(data.points);
+        }
+      } catch {
+        // silencioso — sparkline fica em placeholder
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  return points;
 }
 
 function KpiBar({ kpis, onLifecycleSelect }: { kpis: Kpi; onLifecycleSelect: (lifecycle: LifecycleId[]) => void }) {
   // Onda 8 Cowork: hero card dark green com sparkline + 4 secundários canon.
   // Saldo previsto = posição final do mês (Recebido + AReceber - Pago - APagar).
   // Onda Polish: KPI clicável → lifecycle multi-select (não mais tab radio).
+  // Onda 8c: sparkline alimentado por endpoint backend (30d real).
   const pendente = kpis.a_receber.valor - kpis.a_pagar.valor;
+  const sparkPoints = useSparkline30d();
   return (
     <div className="fin-stats">
       <button type="button" className="fin-stat fin-stat-hero" onClick={() => onLifecycleSelect(['ar', 'ap'])} aria-label="Filtrar abertos (a receber + a pagar)">
@@ -220,7 +283,7 @@ function KpiBar({ kpis, onLifecycleSelect }: { kpis: Kpi; onLifecycleSelect: (li
         <span className="fin-stat-hint">
           <b className="mono">{brl(kpis.recebido.valor - kpis.pago.valor)}</b> realizado · <span className={pendente >= 0 ? 'fin-num-pos' : 'fin-num-neg'}>{brl(pendente)}</span> pendente
         </span>
-        <FinSparkline tone={kpis.saldo_previsto >= 0 ? 'pos' : 'neg'} />
+        <FinSparkline tone={kpis.saldo_previsto >= 0 ? 'pos' : 'neg'} points={sparkPoints} />
       </button>
 
       <button type="button" className="fin-stat" onClick={() => onLifecycleSelect(['re'])} aria-label="Filtrar recebidas">


### PR DESCRIPTION
## Resumo

Substitui o path SVG estático do KpiBar.FinSparkline (Onda 8 — [PR #1082](https://github.com/wagnerra23/oimpresso.com/pull/1082)) por trajetória REAL do saldo dia-a-dia nos últimos 30 dias, calculada a partir das baixas (TituloBaixa).

## Backend

**Novo endpoint** `GET /financeiro/unificado/saldo-sparkline` em [UnificadoController](Modules/Financeiro/Http/Controllers/UnificadoController.php).

Retorna JSON:
\`\`\`json
{
  \"points\": [{\"date\": \"2026-04-19\", \"saldo\": 1234.56, \"in\": 100, \"out\": 50}, ...],
  \"saldo_atual\": 5430.89,
  \"saldo_baseline_30d\": 4230.50,
  \"periodo\": {\"inicio\": \"2026-04-19\", \"fim\": \"2026-05-18\"}
}
\`\`\`

**Algoritmo:**
1. \`saldo_atual\` = SUM(\`ContaBancaria.saldo_cached\`) where business + active
2. \`delta_dia\` = SUM(receber baixas) − SUM(pagar baixas) groupBy \`data_baixa\`, \`tipo\`
3. \`baseline_30d\` = \`saldo_atual\` − \`sum_total_deltas\` (saldo virtual 30d atrás)
4. Running sum forward: \`saldo[D-29+i] = baseline + sum(deltas[0..i])\`

## Multi-tenant Tier 0

- ✅ \`business_id\` explícito via \`session('user.business_id')\`
- ✅ \`businessId <= 0\` → JSON 400 (não vaza dados)
- ✅ SQL join filtra \`tb.business_id\` em \`fin_titulo_baixas\` (tabela canônica)
- ✅ Estornos excluídos via \`whereNull(estorno_de_id)\`

## Frontend

- \`interface SparkPoint { date, saldo, in, out }\`
- \`useSparkline30d()\` hook com fetch + cancel safety
- \`FinSparkline\` aceita prop \`points\` opcional:
  - \`points < 2\` → fallback path estático (loading/error/sem dados)
  - \`points >= 2\` → normaliza min/max → \`linePath\` + \`fillPath\` + baseline ref dasharray
  - Cor oklch verde 145 (pos) ou rose 25 (neg) conforme tone

## Testes

[Onda8cSparklineRealTest.php](Modules/Financeiro/Tests/Feature/Onda8cSparklineRealTest.php) — 11 testes em 2 describes:
- **Backend**: rota registrada, método existe + JsonResponse, algoritmo, Tier 0, SQL canônico (\`fin_titulo_baixas\` não \`titulo_baixas\`), estorno excluído
- **Frontend**: prop points, hook fetch endpoint, fallback < 2 pontos, KpiBar wire-up, normalização SVG

## Test plan

- [x] Build TS check (9 erros pre-existentes, 0 novos)
- [x] Pest local pendente (vendor empty; CI roda)
- [ ] Smoke Chrome MCP pós-merge: hero card deve mostrar curva real (não path estático fixo). Devtools Network: GET /financeiro/unificado/saldo-sparkline 200 OK com JSON shape canônico.

Refs: Onda 8 ([PR #1082](https://github.com/wagnerra23/oimpresso.com/pull/1082))

🤖 Generated with [Claude Code](https://claude.com/claude-code)