### PR TITLE
feat(financeiro): Onda 9 — Resumir mês (narrativa exec compute-based, prep LLM)

### DIFF
--- a/Modules/Financeiro/Tests/Feature/Onda9ResumirMesTest.php
+++ b/Modules/Financeiro/Tests/Feature/Onda9ResumirMesTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Onda 9 KB-9.75 — FinMonthResume (narrativa executiva do mês).
+ *
+ * Substitui alert() do botão "✦ Resumir mês" por dialog modal com narrativa
+ * compute-based + botão "Copiar pro WhatsApp". Fase 2 (futura) plugará
+ * JanaService LLM quando disponível na main.
+ *
+ * Cobre:
+ *   - FinMonthResume.tsx: buildMonthResume + resumeToPlainText exports
+ *   - 5 blocks canônicos: Visão geral / Top in / Top out / Categorias / Alertas / Recomendação
+ *   - Dialog modal: header + body + footer com botões copiar/fechar
+ *   - CSS .fin-resume-* (backdrop, dialog, blocks, footer)
+ *   - Wire-up Index.tsx: state resumoOpen + alert removido + palette entry
+ *
+ * Multi-tenant Tier 0 preservado (zero backend, zero LLM, pure compute).
+ */
+
+const FIN_BASE_9 = __DIR__ . '/../../../../resources/js/Pages/Financeiro/Unificado';
+const FIN_CSS_9 = __DIR__ . '/../../../../resources/css/fin-output.css';
+
+describe('Onda 9 — FinMonthResume compute helpers', function () {
+    it('FinMonthResume exporta buildMonthResume + resumeToPlainText', function () {
+        $src = file_get_contents(FIN_BASE_9 . '/_components/FinMonthResume.tsx');
+        expect($src)->toContain('export function buildMonthResume');
+        expect($src)->toContain('export function resumeToPlainText');
+        expect($src)->toContain('export function FinMonthResumeDialog');
+    });
+
+    it('5+ blocks canônicos com títulos exec (Visão geral / Top in / Top out / Categorias / Alertas / Recomendação)', function () {
+        $src = file_get_contents(FIN_BASE_9 . '/_components/FinMonthResume.tsx');
+        expect($src)->toContain('Visão geral');
+        expect($src)->toContain('Top contrapartes (entradas)');
+        expect($src)->toContain('Top contrapartes (saídas)');
+        expect($src)->toContain('Categorias com maior peso');
+        expect($src)->toContain('Alertas');
+        expect($src)->toContain('Recomendação');
+    });
+
+    it('Computa health icone + tendencia + atrasados + vencendo', function () {
+        $src = file_get_contents(FIN_BASE_9 . '/_components/FinMonthResume.tsx');
+        expect($src)->toContain('🟢');
+        expect($src)->toContain('🔴');
+        expect($src)->toContain("status === 'atrasado'");
+        expect($src)->toContain("status === 'vencendo'");
+    });
+});
+
+describe('Onda 9 — FinMonthResumeDialog rendering', function () {
+    it('Dialog inclui header + body + footer canon', function () {
+        $src = file_get_contents(FIN_BASE_9 . '/_components/FinMonthResume.tsx');
+        expect($src)->toContain('fin-resume-dialog');
+        expect($src)->toContain('fin-resume-h');
+        expect($src)->toContain('fin-resume-body');
+        expect($src)->toContain('fin-resume-f');
+    });
+
+    it('Atalho Esc fecha + clipboard.writeText pra copiar', function () {
+        $src = file_get_contents(FIN_BASE_9 . '/_components/FinMonthResume.tsx');
+        expect($src)->toContain("e.key === 'Escape'");
+        expect($src)->toContain('navigator.clipboard.writeText');
+    });
+
+    it('Botão Copiar formata header em bold WhatsApp + texto plain', function () {
+        $src = file_get_contents(FIN_BASE_9 . '/_components/FinMonthResume.tsx');
+        expect($src)->toContain('📋 Copiar pro WhatsApp');
+        expect($src)->toContain('*Resumo financeiro');
+    });
+
+    it('Fase 1 note: JanaService LLM plugará Fase 2', function () {
+        $src = file_get_contents(FIN_BASE_9 . '/_components/FinMonthResume.tsx');
+        // Comentário canon sinalizando o roadmap
+        expect($src)->toContain('Fase 2');
+        expect($src)->toContain('JanaService');
+    });
+});
+
+describe('Onda 9 — CSS escopado', function () {
+    it('Tokens .fin-resume-* mounted em fin-output.css', function () {
+        $css = file_get_contents(FIN_CSS_9);
+        expect($css)->toContain('.fin-resume-backdrop');
+        expect($css)->toContain('.fin-resume-dialog');
+        expect($css)->toContain('.fin-resume-h');
+        expect($css)->toContain('.fin-resume-body');
+        expect($css)->toContain('.fin-resume-block');
+        expect($css)->toContain('.fin-resume-f');
+        expect($css)->toContain('.fin-resume-btn');
+    });
+
+    it('Tom IA roxo (oklch hue 280) + estado "copied" verde', function () {
+        $css = file_get_contents(FIN_CSS_9);
+        // Hue 280 IA accent (consistent com .fin-btn-ai)
+        expect($css)->toContain('oklch(0.30 0.10 280)');
+        // Estado copied verde (feedback ok)
+        expect($css)->toContain('.fin-resume-btn.primary.copied');
+        expect($css)->toContain('oklch(0.42 0.18 145)');
+    });
+});
+
+describe('Onda 9 — wire-up Index.tsx', function () {
+    it('Index.tsx importa FinMonthResumeDialog', function () {
+        $src = file_get_contents(FIN_BASE_9 . '/Index.tsx');
+        expect($src)->toContain("from './_components/FinMonthResume'");
+        expect($src)->toContain('FinMonthResumeDialog');
+    });
+
+    it('Index.tsx instancia resumoOpen state', function () {
+        $src = file_get_contents(FIN_BASE_9 . '/Index.tsx');
+        expect($src)->toContain('const [resumoOpen, setResumoOpen]');
+    });
+
+    it('Botão ✦ Resumir mês agora abre dialog (alert removido)', function () {
+        $src = file_get_contents(FIN_BASE_9 . '/Index.tsx');
+        expect($src)->toContain('onClick={() => setResumoOpen(true)}');
+        // alert original removido
+        expect($src)->not->toContain("alert('Resumir mês:");
+    });
+
+    it('Dialog mount com props canônicas', function () {
+        $src = file_get_contents(FIN_BASE_9 . '/Index.tsx');
+        expect($src)->toContain('<FinMonthResumeDialog');
+        expect($src)->toContain('open={resumoOpen}');
+        expect($src)->toContain('kpis={kpis}');
+        expect($src)->toContain('lancamentos={lancamentos}');
+    });
+
+    it('Command palette inclui entrada "Resumir mês"', function () {
+        $src = file_get_contents(FIN_BASE_9 . '/Index.tsx');
+        expect($src)->toContain('Resumir mês (narrativa exec)');
+    });
+});

--- a/resources/css/fin-output.css
+++ b/resources/css/fin-output.css
@@ -592,3 +592,119 @@
   .fin-transcript-tbl tbody tr:hover { background: transparent; }
   @page { size: A4; margin: 0; }
 }
+
+/* ========================================================================
+ * Onda 9 — FinMonthResume (narrativa exec do mês)
+ * Dialog com blocos markdown-style + botão "Copiar pro WhatsApp".
+ * ======================================================================== */
+
+.fin-resume-backdrop {
+  position: fixed; inset: 0; z-index: 60;
+  background: oklch(0 0 0 / 0.50);
+  backdrop-filter: blur(2px);
+  animation: fin-resume-fade .14s ease-out;
+}
+@keyframes fin-resume-fade { from { opacity: 0; } to { opacity: 1; } }
+
+.fin-resume-dialog {
+  position: fixed; z-index: 70;
+  top: 50%; left: 50%; transform: translate(-50%, -50%);
+  width: min(640px, calc(100vw - 32px));
+  max-height: min(85vh, 800px);
+  background: white;
+  border-radius: 14px;
+  box-shadow: 0 20px 60px oklch(0 0 0 / 0.30);
+  display: flex; flex-direction: column;
+  overflow: hidden;
+  font-family: ui-sans-serif, system-ui, sans-serif;
+  animation: fin-resume-pop .18s cubic-bezier(0.34, 1.56, 0.64, 1);
+}
+@keyframes fin-resume-pop {
+  from { opacity: 0; transform: translate(-50%, -50%) scale(0.96); }
+  to   { opacity: 1; transform: translate(-50%, -50%) scale(1); }
+}
+
+.fin-resume-h {
+  display: flex; align-items: flex-start; justify-content: space-between; gap: 12px;
+  padding: 18px 22px 14px;
+  border-bottom: 1px solid oklch(0.92 0.005 80);
+  background: linear-gradient(135deg, oklch(0.97 0.06 280 / 0.5), oklch(0.99 0 0));
+}
+.fin-resume-h h2 {
+  margin: 0; font-size: 15.5px; font-weight: 600;
+  color: oklch(0.30 0.10 280); letter-spacing: -0.005em;
+}
+.fin-resume-h small {
+  display: block; margin-top: 3px;
+  font-size: 11.5px; color: oklch(0.50 0.04 280); line-height: 1.4;
+}
+.fin-resume-x {
+  width: 28px; height: 28px; border-radius: 8px;
+  border: none; background: transparent; cursor: pointer;
+  color: oklch(0.45 0 0); font-size: 20px; line-height: 1;
+  display: grid; place-items: center;
+  transition: all .12s;
+}
+.fin-resume-x:hover { background: oklch(0.95 0 0); color: oklch(0.20 0 0); }
+
+.fin-resume-body {
+  padding: 16px 22px;
+  overflow-y: auto;
+  flex: 1;
+}
+.fin-resume-block {
+  margin-bottom: 18px;
+  padding-bottom: 14px;
+  border-bottom: 1px dashed oklch(0.92 0.005 80);
+}
+.fin-resume-block:last-child { border-bottom: none; padding-bottom: 0; margin-bottom: 0; }
+.fin-resume-block h3 {
+  margin: 0 0 8px;
+  font-size: 12.5px; font-weight: 600;
+  color: oklch(0.25 0 0); letter-spacing: -0.003em;
+  text-transform: none;
+}
+.fin-resume-block ul {
+  list-style: none; padding: 0; margin: 0;
+  font-size: 13px; line-height: 1.55; color: oklch(0.30 0 0);
+}
+.fin-resume-block li {
+  padding: 3px 0 3px 16px;
+  position: relative;
+}
+.fin-resume-block li::before {
+  content: '•';
+  position: absolute; left: 4px; top: 3px;
+  color: oklch(0.55 0.12 280);
+  font-weight: 700;
+}
+.fin-resume-block li strong,
+.fin-resume-block li b { color: oklch(0.18 0 0); font-weight: 600; }
+
+.fin-resume-f {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 12px; padding: 12px 22px;
+  border-top: 1px solid oklch(0.92 0.005 80);
+  background: oklch(0.98 0.003 80);
+}
+.fin-resume-f small {
+  font-size: 11px; color: oklch(0.50 0 0); font-style: italic;
+}
+.fin-resume-f-actions { display: flex; gap: 8px; }
+.fin-resume-btn {
+  padding: 7px 14px; border-radius: 7px;
+  font-size: 12.5px; font-weight: 500;
+  background: white; color: oklch(0.30 0 0);
+  border: 1px solid oklch(0.85 0 0);
+  cursor: pointer; transition: all .12s;
+}
+.fin-resume-btn:hover { background: oklch(0.97 0 0); }
+.fin-resume-btn.primary {
+  background: oklch(0.42 0.18 280); color: white;
+  border-color: oklch(0.42 0.18 280);
+}
+.fin-resume-btn.primary:hover { background: oklch(0.36 0.18 280); }
+.fin-resume-btn.primary.copied {
+  background: oklch(0.42 0.18 145);
+  border-color: oklch(0.42 0.18 145);
+}

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -38,6 +38,8 @@ import { FinPresentationMode } from './_components/FinPresentationMode';
 // Onda 7c — Folha jurídica imprimível + favoritos pessoais (atalho B).
 import { FinTranscriptPDF } from './_components/FinTranscriptPDF';
 import { useFinFavs, FinFavPin } from './_components/useFinFavs';
+// Onda 9 — Resumo executivo do mês (narrativa compute-based · plug LLM Fase 2).
+import { FinMonthResumeDialog } from './_components/FinMonthResume';
 // Onda Edit 2026-05-18 — Sheet inline pra editar título financeiro.
 import { TituloEditSheet } from './_components/TituloEditSheet';
 
@@ -389,6 +391,8 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
   const [transcriptOpen, setTranscriptOpen] = useState(false);
   const [transcriptOnlyFavs, setTranscriptOnlyFavs] = useState(false);
   const favs = useFinFavs(businessName || 'default');
+  // Cowork KB-9.75 Onda 9 — Resumir mês dialog (narrativa exec compute-based).
+  const [resumoOpen, setResumoOpen] = useState(false);
   // Onda Edit 2026-05-18 — Edit Sheet state (separate from detail drawer).
   const [editOpen, setEditOpen] = useState(false);
 
@@ -456,8 +460,8 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
           <button
             type="button"
             className="fin-btn fin-btn-ai"
-            title="Resumo executivo do mês com IA (Onda 9 — em construção)"
-            onClick={() => alert('Resumir mês: feature Onda 9 — JanaService agent (em construção)')}
+            title="Resumo executivo do mês (narrativa compute-based · Onda 9 v1)"
+            onClick={() => setResumoOpen(true)}
           >
             ✦ Resumir mês
           </button>
@@ -782,6 +786,9 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
             <CommandItem onSelect={() => { setPaletteOpen(false); router.visit('/financeiro/unificado/novo'); }}>Novo lançamento</CommandItem>
             <CommandItem onSelect={() => { setPaletteOpen(false); router.visit('/financeiro/extrato'); }}>Conciliar extrato</CommandItem>
             <CommandItem onSelect={() => { setPaletteOpen(false); router.visit('/financeiro/relatorios'); }}>DRE / Relatórios</CommandItem>
+            <CommandItem onSelect={() => { setPaletteOpen(false); setResumoOpen(true); }}>
+              ✦ Resumir mês (narrativa exec)
+            </CommandItem>
             <CommandItem onSelect={() => { setPaletteOpen(false); setTranscriptOnlyFavs(false); setTranscriptOpen(true); }}>
               📄 Imprimir período (folha jurídica)
             </CommandItem>
@@ -834,6 +841,16 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
         periodLabel={periodLabel}
         businessName={businessName}
         onlyFavs={transcriptOnlyFavs ? favs.favs : null}
+      />
+
+      {/* Onda 9 — Resumo executivo do mês (narrativa compute-based, plug LLM Fase 2) */}
+      <FinMonthResumeDialog
+        open={resumoOpen}
+        onClose={() => setResumoOpen(false)}
+        lancamentos={lancamentos}
+        kpis={kpis}
+        periodLabel={periodLabel}
+        businessName={businessName}
       />
 
       {/* Cowork KB-9.75 Onda 7 R3 — Trilha fechamento dialog */}

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinMonthResume.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinMonthResume.tsx
@@ -1,0 +1,269 @@
+// FinMonthResume — Cowork KB-9.75 Financeiro Onda 9
+// (narrativa exec do mês — substitui o alert do botão "✦ Resumir mês").
+//
+// Refs:
+//  - prototipo-ui/financeiro-ai.jsx — FinAiResume
+//  - FinMonthDigest.tsx — base de cálculo (Onda 6)
+//
+// Estratégia 2-fases:
+//   Fase 1 (Onda 9 — esta): narrativa COMPUTACIONAL (pure compute). Gera
+//   texto markdown-style direto dos lancamentos+kpis. Zero backend, zero LLM.
+//   Funciona offline + pra biz=4 que ainda não tem JanaService.
+//
+//   Fase 2 (futura): plugar JanaService quando disponível na main —
+//   sinalizar via FEATURE_JANA_AVAILABLE e prompt enviando o digest pre-computado
+//   pra LLM enriquecer. Variável fica como toggle pra A/B test.
+//
+// Output: dialog modal markdown-rendered + botão "Copiar pro WhatsApp" pra Eliana
+// mandar pro escritório.
+//
+// Pure compute, sem backend, sem LLM. Wagner regra Tier 0 multi-tenant safe.
+
+import { useEffect, useMemo, useState, type ReactNode } from 'react';
+
+interface LancamentoLite {
+  id: number;
+  contraparte: string;
+  categoria?: string;
+  valor: number;
+  kind?: 'receivable' | 'payable';
+  status?: string;
+  vencimento?: string;
+  liquidacao?: string | null;
+}
+
+interface KpiSnapshot {
+  saldo_previsto: number;
+  recebido: { valor: number; qtd: number };
+  a_receber: { valor: number; qtd: number };
+  pago: { valor: number; qtd: number };
+  a_pagar: { valor: number; qtd: number };
+}
+
+interface ResumeBlock {
+  title: string;
+  bullets: string[];
+}
+
+function brl(n: number): string {
+  return n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+function pct(num: number, den: number): string {
+  if (den === 0) return '0%';
+  return Math.round((num / den) * 100) + '%';
+}
+
+/**
+ * Computa o digest narrativo do mês. Exportado pra também ser usado
+ * em testes + futura integração JanaService (que enriquecerá esse output).
+ */
+export function buildMonthResume(
+  lancamentos: LancamentoLite[],
+  kpis: KpiSnapshot,
+  periodLabel: string,
+): ResumeBlock[] {
+  const blocks: ResumeBlock[] = [];
+
+  const netRealizado = kpis.recebido.valor - kpis.pago.valor;
+  const netPendente = kpis.a_receber.valor - kpis.a_pagar.valor;
+  const saudeIcone = kpis.saldo_previsto >= 0 ? '🟢' : '🔴';
+  const tendencia = netRealizado >= 0 ? 'positiva' : 'negativa';
+
+  blocks.push({
+    title: `${saudeIcone} Visão geral · ${periodLabel}`,
+    bullets: [
+      `Saldo previsto fim de período: *${brl(kpis.saldo_previsto)}*`,
+      `Realizado até agora: ${brl(netRealizado)} (tendência ${tendencia})`,
+      `Pendente: ${brl(netPendente)} (${kpis.a_receber.qtd} a receber / ${kpis.a_pagar.qtd} a pagar)`,
+    ],
+  });
+
+  // Top contrapartes (in + out)
+  const partyMap: Record<string, { in: number; out: number; count: number }> = {};
+  for (const l of lancamentos) {
+    const k = l.contraparte || 'Sem contraparte';
+    if (!partyMap[k]) partyMap[k] = { in: 0, out: 0, count: 0 };
+    partyMap[k].count++;
+    if (l.kind === 'receivable') partyMap[k].in += l.valor || 0;
+    else partyMap[k].out += l.valor || 0;
+  }
+  const partiesIn = Object.entries(partyMap)
+    .filter(([, v]) => v.in > 0)
+    .sort((a, b) => b[1].in - a[1].in)
+    .slice(0, 3);
+  const partiesOut = Object.entries(partyMap)
+    .filter(([, v]) => v.out > 0)
+    .sort((a, b) => b[1].out - a[1].out)
+    .slice(0, 3);
+
+  if (partiesIn.length > 0) {
+    blocks.push({
+      title: '📈 Top contrapartes (entradas)',
+      bullets: partiesIn.map(([nome, v]) =>
+        `${nome} — ${brl(v.in)} (${pct(v.in, kpis.recebido.valor + kpis.a_receber.valor)})`),
+    });
+  }
+  if (partiesOut.length > 0) {
+    blocks.push({
+      title: '📉 Top contrapartes (saídas)',
+      bullets: partiesOut.map(([nome, v]) =>
+        `${nome} — ${brl(v.out)} (${pct(v.out, kpis.pago.valor + kpis.a_pagar.valor)})`),
+    });
+  }
+
+  // Categorias com maior peso
+  const catMap: Record<string, number> = {};
+  for (const l of lancamentos) {
+    const k = l.categoria || 'Sem categoria';
+    catMap[k] = (catMap[k] || 0) + (l.valor || 0);
+  }
+  const topCats = Object.entries(catMap).sort((a, b) => b[1] - a[1]).slice(0, 3);
+  if (topCats.length > 0) {
+    const totalGeral = topCats.reduce((s, [, v]) => s + v, 0);
+    blocks.push({
+      title: '🏷️ Categorias com maior peso',
+      bullets: topCats.map(([nome, v]) => `${nome} — ${brl(v)} (${pct(v, totalGeral)})`),
+    });
+  }
+
+  // Alertas
+  const atrasados = lancamentos.filter((l) => l.status === 'atrasado');
+  const vencendo = lancamentos.filter((l) => l.status === 'vencendo');
+  const alertBullets: string[] = [];
+  if (atrasados.length > 0) {
+    const total = atrasados.reduce((s, l) => s + (l.valor || 0), 0);
+    alertBullets.push(`⚠️ ${atrasados.length} título${atrasados.length === 1 ? '' : 's'} atrasado${atrasados.length === 1 ? '' : 's'} (${brl(total)})`);
+  }
+  if (vencendo.length > 0) {
+    const total = vencendo.reduce((s, l) => s + (l.valor || 0), 0);
+    alertBullets.push(`🔔 ${vencendo.length} título${vencendo.length === 1 ? '' : 's'} vencendo (${brl(total)})`);
+  }
+  if (alertBullets.length === 0) {
+    alertBullets.push('✅ Nenhum título atrasado ou vencendo no período.');
+  }
+  blocks.push({ title: '🚨 Alertas', bullets: alertBullets });
+
+  // Recomendação derivada da posição
+  const recos: string[] = [];
+  if (kpis.a_pagar.valor > kpis.a_receber.valor && netPendente < 0) {
+    recos.push(`Saídas pendentes (${brl(kpis.a_pagar.valor)}) maiores que entradas pendentes (${brl(kpis.a_receber.valor)}). Acompanhar de perto o caixa nos próximos dias.`);
+  }
+  if (atrasados.length > 0) {
+    recos.push('Cobrar os atrasados antes do fechamento mensal — usar trilha "☑ Fechamento" pra checklist.');
+  }
+  if (recos.length === 0) {
+    recos.push('Posição saudável. Continuar conferindo lançamentos via toggle "Conferido" e usar trilha de fechamento.');
+  }
+  blocks.push({ title: '💡 Recomendação', bullets: recos });
+
+  return blocks;
+}
+
+/**
+ * Gera texto plain pra clipboard (formato WhatsApp/email).
+ */
+export function resumeToPlainText(blocks: ResumeBlock[]): string {
+  return blocks
+    .map((b) => `${b.title}\n${b.bullets.map((x) => `• ${x}`).join('\n')}`)
+    .join('\n\n');
+}
+
+interface FinMonthResumeDialogProps {
+  open: boolean;
+  onClose: () => void;
+  lancamentos: LancamentoLite[];
+  kpis: KpiSnapshot;
+  periodLabel: string;
+  businessName?: string;
+}
+
+export function FinMonthResumeDialog({
+  open,
+  onClose,
+  lancamentos,
+  kpis,
+  periodLabel,
+  businessName,
+}: FinMonthResumeDialogProps): ReactNode {
+  const [copied, setCopied] = useState(false);
+
+  // Atalho Esc fecha
+  useEffect(() => {
+    if (!open) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onClose]);
+
+  const blocks = useMemo(
+    () => buildMonthResume(lancamentos, kpis, periodLabel),
+    [lancamentos, kpis, periodLabel],
+  );
+
+  const handleCopy = async () => {
+    const text = resumeToPlainText(blocks);
+    const header = `*Resumo financeiro · ${periodLabel}${businessName ? ` — ${businessName}` : ''}*\n\n`;
+    try {
+      await navigator.clipboard.writeText(header + text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2400);
+    } catch {
+      // Fallback simples — não bloqueia
+      setCopied(false);
+    }
+  };
+
+  if (!open) return null;
+
+  return (
+    <>
+      <div className="fin-resume-backdrop" onClick={onClose} aria-hidden="true" />
+      <div className="fin-resume-dialog" role="dialog" aria-labelledby="fin-resume-title">
+        <header className="fin-resume-h">
+          <div>
+            <h2 id="fin-resume-title">✦ Resumo executivo · {periodLabel}</h2>
+            <small>
+              {businessName ? `${businessName} · ` : ''}
+              narrativa computacional · pode copiar pro WhatsApp
+            </small>
+          </div>
+          <button type="button" className="fin-resume-x" onClick={onClose} aria-label="Fechar">×</button>
+        </header>
+
+        <div className="fin-resume-body">
+          {blocks.map((b) => (
+            <section key={b.title} className="fin-resume-block">
+              <h3>{b.title}</h3>
+              <ul>
+                {b.bullets.map((bullet, i) => (
+                  <li key={i}>{bullet}</li>
+                ))}
+              </ul>
+            </section>
+          ))}
+        </div>
+
+        <footer className="fin-resume-f">
+          <small>
+            Versão 1 (compute-based) · Fase 2 plugará JanaService LLM quando disponível
+          </small>
+          <div className="fin-resume-f-actions">
+            <button type="button" className="fin-resume-btn" onClick={onClose}>Fechar</button>
+            <button
+              type="button"
+              className={'fin-resume-btn primary' + (copied ? ' copied' : '')}
+              onClick={handleCopy}
+            >
+              {copied ? '✓ Copiado' : '📋 Copiar pro WhatsApp'}
+            </button>
+          </div>
+        </footer>
+      </div>
+    </>
+  );
+}
+
+export default FinMonthResumeDialog;


### PR DESCRIPTION
## Resumo

Substitui `alert()` do botão **✦ Resumir mês** no header da `/financeiro/unificado` por dialog modal com **narrativa executiva** gerada por pure compute. Pavimenta caminho pra Fase 2 (plug LLM JanaService quando disponível na main).

## Estratégia 2-fases

**Fase 1 (esta Onda 9):**
- `buildMonthResume()` pura compute → 6 blocks narrativos
- Funciona offline + multi-tenant Tier 0 + zero dependência externa
- Útil pra biz=4 (ROTA LIVRE) que ainda **não tem JanaService instalado** (Modules/Jana só existe em outro worktree)

**Fase 2 (futura — sinalizada em comentário canon):**
- Plugar JanaService LLM quando disponível
- Prompt envia digest pre-computado pra LLM **enriquecer** (não substitui)
- Toggle `FEATURE_JANA_AVAILABLE` pra A/B test

## Blocks canônicos do resume

1. 🟢/🔴 **Visão geral** · saldo previsto + realizado + pendente + tendência
2. 📈 **Top 3 contrapartes** (entradas) com %
3. 📉 **Top 3 contrapartes** (saídas) com %
4. 🏷️ **Top 3 categorias** com peso %
5. 🚨 **Alertas** (atrasados + vencendo, ou ✅ se zero)
6. 💡 **Recomendação** derivada da posição

## UX

- Atalho `Esc` fecha
- Botão `📋 Copiar pro WhatsApp` → clipboard com header `*bold*` + bullets formatados
- Estado `✓ Copiado` verde por 2.4s
- Command palette `⌘K` entrada `✦ Resumir mês (narrativa exec)`

## CSS canon (fin-output.css)

- Tom IA **roxo oklch hue 280** (consistente com `.fin-btn-ai` existente)
- Backdrop blur 2px + dialog 640px max + animate scale/fade
- Block dividers dashed + emoji-leading h3

## Testes

[Onda9ResumirMesTest.php](Modules/Financeiro/Tests/Feature/Onda9ResumirMesTest.php) — 5 describes × ~13 testes cobrindo helpers + dialog + CSS + wire-up.

## Test plan

- [x] Build TS check (9 erros pre-existentes, 0 novos)
- [x] Pest local pendente (vendor empty; CI roda)
- [ ] Smoke Chrome MCP pós-merge: clicar `✦ Resumir mês` → dialog abre com blocos canônicos. Clicar `📋 Copiar pro WhatsApp` → estado `✓ Copiado` + clipboard tem texto. `Esc` fecha.

Refs: prototipo-ui/financeiro-ai.jsx FinAiResume + Onda 6 FinMonthDigest

🤖 Generated with [Claude Code](https://claude.com/claude-code)