### PR TITLE
fix(financeiro): drawer Cowork V2.1 — canon align (3 abas + cores corretas)

### DIFF
--- a/Modules/Financeiro/Tests/Feature/DrawerCoworkV21CanonAlignTest.php
+++ b/Modules/Financeiro/Tests/Feature/DrawerCoworkV21CanonAlignTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Drawer Cowork v2.1 — canon align (Anthropic API design fetch 2026-05-18).
+ *
+ * Wagner reaplicou pacote v2 do prototipo-ui-patch/vendas-financeiro-completo/.
+ * Bundle real (styles.css 9054 LOC) revelou diffs:
+ *   - active state usa border-bottom 2px verde 145 (não box bg azul 240)
+ *   - IA hue = 295 (não 280)
+ *   - 3ª aba canônica "✎ Editar" amber 60 (substitui Sheet separado)
+ *   - .fin-drawer-tab-ct (count) substitui .fin-drawer-tab-badge
+ *   - .fin-drawer-tab-tag (red dot pra alerta)
+ *
+ * Multi-tenant Tier 0 preservado (UI-only, zero backend).
+ */
+
+const FIN_BASE_V21 = __DIR__ . '/../../../../resources/js/Pages/Financeiro/Unificado';
+const FIN_CSS_V21 = __DIR__ . '/../../../../resources/css/fin-output.css';
+
+describe('Drawer V2.1 — CSS canon align (Cowork bundle)', function () {
+    it('Active state: border-bottom 2px verde 145 (não box bg azul)', function () {
+        $css = file_get_contents(FIN_CSS_V21);
+        // Pega seção tabs canônica
+        expect($css)->toContain("border-bottom-color: oklch(0.55 0.13 145)");
+        // NÃO usa mais oklch 240 como active bg
+        expect($css)->not->toMatch('/\.fin-drawer-tab\.on\s*\{[^}]*background:\s*oklch\(0\.97\s+0\.02\s+240/');
+    });
+
+    it('IA hue = 295 (não 280) — canon Cowork', function () {
+        $css = file_get_contents(FIN_CSS_V21);
+        expect($css)->toContain('.fin-drawer-tab-ai');
+        expect($css)->toContain('oklch(0.42 0.13 295)');
+        expect($css)->toContain('oklch(0.55 0.13 295)');
+    });
+
+    it('3ª aba canon .fin-drawer-tab-edit (amber 60 + has-edits state)', function () {
+        $css = file_get_contents(FIN_CSS_V21);
+        expect($css)->toContain('.fin-drawer-tab-edit');
+        expect($css)->toContain('oklch(0.42 0.13 60)');
+        expect($css)->toContain('.fin-drawer-tab-edit.on');
+        expect($css)->toContain('.fin-drawer-tab-edit.has-edits');
+    });
+
+    it('Count badge canon .fin-drawer-tab-ct (não fin-drawer-tab-badge)', function () {
+        $css = file_get_contents(FIN_CSS_V21);
+        expect($css)->toContain('.fin-drawer-tab-ct');
+        // ui-monospace + pill background
+        expect($css)->toContain('ui-monospace');
+    });
+
+    it('Red dot canon .fin-drawer-tab-tag (alerta visual)', function () {
+        $css = file_get_contents(FIN_CSS_V21);
+        expect($css)->toContain('.fin-drawer-tab-tag');
+        expect($css)->toContain('oklch(0.55 0.18 25)'); // rose
+    });
+
+    it('Edit panel canon: gradient amber + animate finEditOpen + grid 3 col', function () {
+        $css = file_get_contents(FIN_CSS_V21);
+        expect($css)->toContain('@keyframes finEditOpen');
+        expect($css)->toContain('linear-gradient(135deg, oklch(0.98 0.025 60)');
+        expect($css)->toContain('.fin-edit-grid');
+        expect($css)->toContain('grid-template-columns: 1fr 1fr 1fr');
+        expect($css)->toContain('.fin-edit-wide');
+        expect($css)->toContain('.fin-edit-close');
+    });
+
+    it('Nav fin-drawer-tabs flush com bg-2 (não margin-bottom -6px velho)', function () {
+        $css = file_get_contents(FIN_CSS_V21);
+        // Canon: padding 0 18px + gap 0 + bg neutro
+        expect($css)->toMatch('/\.fin-drawer-tabs\s*\{[^}]*padding:\s*0\s+18px/');
+        expect($css)->toMatch('/\.fin-drawer-tabs\s*\{[^}]*gap:\s*0/');
+    });
+});
+
+describe('Drawer V2.1 — Index.tsx 3 abas + Editar inline', function () {
+    it('drawerTab type unifies 3 abas: detalhes | ia | editar', function () {
+        $src = file_get_contents(FIN_BASE_V21 . '/Index.tsx');
+        expect($src)->toContain("useState<'detalhes' | 'ia' | 'editar'>");
+    });
+
+    it('Nav renderiza 3 botões: Detalhes / ✦ IA / ✎ Editar', function () {
+        $src = file_get_contents(FIN_BASE_V21 . '/Index.tsx');
+        expect($src)->toContain("setDrawerTab('detalhes')");
+        expect($src)->toContain("setDrawerTab('ia')");
+        expect($src)->toContain("setDrawerTab('editar')");
+        expect($src)->toContain('fin-drawer-tab-ai');
+        expect($src)->toContain('fin-drawer-tab-edit');
+    });
+
+    it('Tab Detalhes usa fin-drawer-tab-ct (não badge antigo) + tag pra atrasado', function () {
+        $src = file_get_contents(FIN_BASE_V21 . '/Index.tsx');
+        expect($src)->toContain('fin-drawer-tab-ct');
+        expect($src)->toContain('fin-drawer-tab-tag');
+        expect($src)->toContain("selected.status === 'atrasado'");
+    });
+
+    it('Tab Editar respeita valor_mutavel (disabled + tooltip ADR fin-tech/0002)', function () {
+        $src = file_get_contents(FIN_BASE_V21 . '/Index.tsx');
+        expect($src)->toContain('disabled={!selected.valor_mutavel}');
+        expect($src)->toContain('ADR fin-tech/0002');
+    });
+
+    it('Aba Editar renderiza fin-edit-panel inline (não Sheet)', function () {
+        $src = file_get_contents(FIN_BASE_V21 . '/Index.tsx');
+        $start = strpos($src, "drawerTab === 'editar'");
+        $end = strpos($src, '</Sheet>');
+        $editPanel = substr($src, $start, $end - $start);
+        expect($editPanel)->toContain('fin-edit-panel');
+        expect($editPanel)->toContain('fin-edit-h');
+        expect($editPanel)->toContain('fin-edit-grid');
+        expect($editPanel)->toContain('fin-edit-footer');
+        // Botão "Abrir formulário completo" delega ao TituloEditSheet existente (preserva validação)
+        expect($editPanel)->toContain('Abrir formulário completo');
+    });
+
+    it('Caso valor_mutavel=false mostra empty state com mensagem ADR', function () {
+        $src = file_get_contents(FIN_BASE_V21 . '/Index.tsx');
+        expect($src)->toContain('!selected.valor_mutavel');
+        expect($src)->toContain('Valor não-mutável');
+    });
+});

--- a/resources/css/fin-output.css
+++ b/resources/css/fin-output.css
@@ -710,77 +710,90 @@
 }
 
 /* ========================================================================
- * Drawer Cowork v2 — gap report Wagner 2026-05-18
- * Nav tabs Detalhes/✦ IA dentro do <SheetContent>. Substitui scroll vertical
- * monolítico por 2 abas (info+actions vs insights IA).
+ * Drawer Cowork v2.1 — canon align com bundle vendas-financeiro-completo
+ * Anthropic API design fetch 2026-05-18 (Wagner reaplica pacote).
+ *
+ * 3 abas canônicas: Detalhes (verde 145) / ✦ IA (roxo 295) / ✎ Editar (amber 60).
+ * Active state: border-bottom 2px colorido (não box bg). Padding 12px 14px.
  * ======================================================================== */
 
-/* Nav de abas (sticky logo após SheetHeader) */
+/* Nav de abas (Cowork canon: bg-2 + border-bottom + flush, sem gap) */
 .fin-drawer-tabs {
   display: flex;
-  gap: 4px;
-  margin: 12px -6px 0;
-  padding: 0 6px 8px;
+  align-items: center;
+  padding: 0 18px;
+  gap: 0;
   border-bottom: 1px solid oklch(0.92 0.005 80);
-  position: sticky;
-  top: 0;
-  background: white;
-  z-index: 1;
+  background: oklch(0.98 0.003 80);
+  margin: 12px -18px 0;
 }
 
 .fin-drawer-tab {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  padding: 12px 14px;
+  font-family: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: oklch(0.50 0.01 80);
+  cursor: pointer;
+  transition: all .12s;
   display: inline-flex;
   align-items: center;
   gap: 6px;
-  padding: 7px 12px;
-  border-radius: 8px 8px 0 0;
-  border: none;
-  background: transparent;
-  color: oklch(0.45 0.01 80);
-  font-size: 12.5px;
-  font-weight: 500;
-  cursor: pointer;
-  transition: all .12s;
   position: relative;
 }
-.fin-drawer-tab:hover {
-  color: oklch(0.20 0.01 80);
-  background: oklch(0.97 0.005 80);
-}
+.fin-drawer-tab:hover { color: oklch(0.20 0 0); }
 .fin-drawer-tab.on {
-  color: oklch(0.20 0.05 240);
-  background: oklch(0.97 0.02 240);
-}
-.fin-drawer-tab.on::after {
-  content: '';
-  position: absolute;
-  left: 6px; right: 6px; bottom: -9px;
-  height: 2px;
-  background: oklch(0.40 0.13 240);
-  border-radius: 2px 2px 0 0;
+  color: oklch(0.20 0 0);
+  border-bottom-color: oklch(0.55 0.13 145);
+  background: white;
 }
 
-/* Hue IA (roxo 280) pra fin-drawer-tab-ai */
-.fin-drawer-tab-ai { color: oklch(0.45 0.10 280); }
-.fin-drawer-tab-ai:hover { color: oklch(0.30 0.13 280); background: oklch(0.97 0.04 280); }
-.fin-drawer-tab-ai.on {
-  color: oklch(0.32 0.13 280);
-  background: oklch(0.97 0.06 280);
-}
-.fin-drawer-tab-ai.on::after { background: oklch(0.42 0.18 280); }
-
-/* Badge "💬N" dentro do tab Detalhes */
-.fin-drawer-tab-badge {
-  display: inline-flex;
-  align-items: center;
-  font-size: 10.5px;
+/* Count badge canônico (.fin-drawer-tab-ct — substitui o badge antigo) */
+.fin-drawer-tab-ct {
+  font-family: ui-monospace, monospace;
+  font-size: 10px;
   font-weight: 600;
+  background: white;
+  color: oklch(0.50 0.01 80);
   padding: 1px 6px;
-  border-radius: 8px;
-  background: oklch(0.93 0.04 240);
-  color: oklch(0.42 0.13 240);
-  margin-left: 4px;
-  line-height: 1.2;
+  border-radius: 99px;
+}
+.fin-drawer-tab.on .fin-drawer-tab-ct {
+  background: oklch(0.94 0.05 145);
+  color: oklch(0.32 0.13 145);
+}
+
+/* Red dot pra alerta visual (ex: atrasado, anomalia detectada) */
+.fin-drawer-tab-tag {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: oklch(0.55 0.18 25);
+  display: inline-block;
+}
+
+/* Aba IA — canon roxo 295 (não 280) */
+.fin-drawer-tab-ai { color: oklch(0.42 0.13 295); }
+.fin-drawer-tab-ai:hover { color: oklch(0.32 0.18 295); }
+.fin-drawer-tab-ai.on {
+  border-bottom-color: oklch(0.55 0.13 295);
+  color: oklch(0.32 0.18 295);
+  background: oklch(0.98 0.015 295);
+}
+
+/* Aba Editar — canon amber 60 (3ª aba, substitui Sheet separado) */
+.fin-drawer-tab-edit { color: oklch(0.42 0.13 60); }
+.fin-drawer-tab-edit:hover { color: oklch(0.32 0.18 60); }
+.fin-drawer-tab-edit.on {
+  border-bottom-color: oklch(0.55 0.13 60);
+  color: oklch(0.42 0.13 60);
+  background: oklch(0.98 0.02 60);
+}
+.fin-drawer-tab-edit.has-edits:not(.on) {
+  background: oklch(0.96 0.04 60);
 }
 
 /* Drawer wide modifier (espaço pras abas + IA panel — preserva 460px atual) */
@@ -822,14 +835,68 @@
   border-radius: 8px;
 }
 
-/* Edit panel inline (futuro: input edit-mode in-drawer sem sheet separado) */
+/* Edit panel inline (Cowork canon: gradient amber + animate slide-down) */
 .fin-edit-panel {
-  padding: 12px;
-  border-radius: 8px;
-  background: oklch(0.97 0.04 240 / 0.5);
-  border: 1px dashed oklch(0.80 0.06 240);
-  margin-top: 8px;
+  background: linear-gradient(135deg, oklch(0.98 0.025 60), oklch(0.99 0.012 60));
+  border: 1px solid oklch(0.85 0.10 60);
+  border-radius: 10px;
+  padding: 14px 16px;
+  margin-top: 4px;
+  animation: finEditOpen 0.18s ease-out;
 }
+@keyframes finEditOpen {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: none; }
+}
+.fin-edit-h {
+  display: flex; align-items: baseline; justify-content: space-between;
+  margin-bottom: 12px;
+}
+.fin-edit-h h4 {
+  margin: 0; font-size: 13.5px; font-weight: 700;
+  color: oklch(0.32 0.18 60);
+}
+.fin-edit-h small { font-size: 11px; color: oklch(0.50 0.04 60); }
+.fin-edit-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 12px;
+}
+.fin-edit-wide { grid-column: 1 / -1; }
+.fin-edit-grid label {
+  display: block;
+  font-size: 11px; font-weight: 600;
+  color: oklch(0.40 0.04 60); margin-bottom: 4px;
+  text-transform: uppercase; letter-spacing: 0.04em;
+}
+.fin-edit-grid input, .fin-edit-grid select, .fin-edit-grid textarea {
+  width: 100%; padding: 6px 10px; border-radius: 6px;
+  border: 1px solid oklch(0.85 0.05 60);
+  background: white; font-size: 12.5px; font-family: inherit;
+  color: oklch(0.18 0 0);
+}
+.fin-edit-grid input:focus, .fin-edit-grid select:focus, .fin-edit-grid textarea:focus {
+  outline: none; border-color: oklch(0.55 0.13 60);
+  box-shadow: 0 0 0 3px oklch(0.55 0.13 60 / 0.15);
+}
+.fin-edit-footer {
+  display: flex; gap: 8px; justify-content: flex-end;
+  margin-top: 12px; padding-top: 12px;
+  border-top: 1px solid oklch(0.92 0.02 60);
+}
+.fin-edit-close {
+  background: oklch(0.55 0.13 145); color: white;
+  font-weight: 600;
+  padding: 6px 14px; border: none; border-radius: 6px;
+  font-size: 12.5px; cursor: pointer;
+}
+.fin-edit-close:hover { background: oklch(0.48 0.13 145); }
+.fin-edit-cancel {
+  background: white; color: oklch(0.40 0 0);
+  padding: 6px 14px; border: 1px solid oklch(0.85 0 0);
+  border-radius: 6px; font-size: 12.5px; cursor: pointer;
+}
+.fin-edit-cancel:hover { background: oklch(0.97 0 0); }
 
 /* Anomalia wrapper (Cowork v2 — substitui card flat) */
 .fin-ai-anomalia {

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -456,9 +456,11 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
   const favs = useFinFavs(businessName || 'default');
   // Cowork KB-9.75 Onda 9 — Resumir mês dialog (narrativa exec compute-based).
   const [resumoOpen, setResumoOpen] = useState(false);
-  // Drawer Cowork v2 (2026-05-18 gap report Wagner) — nav de abas Detalhes/IA
-  // dentro do drawer detalhe. Reseta pra 'detalhes' ao trocar de linha.
-  const [drawerTab, setDrawerTab] = useState<'detalhes' | 'ia'>('detalhes');
+  // Drawer Cowork v2.1 — canon align com bundle vendas-financeiro-completo
+  // (Anthropic API design fetch 2026-05-18). 3 abas canônicas:
+  //   detalhes (verde 145, default) / ia (roxo 295) / editar (amber 60, inline)
+  // Reset pra 'detalhes' ao trocar de linha.
+  const [drawerTab, setDrawerTab] = useState<'detalhes' | 'ia' | 'editar'>('detalhes');
   useEffect(() => { setDrawerTab('detalhes'); }, [selectedId]);
   // Onda Edit 2026-05-18 — Edit Sheet state (separate from detail drawer).
   const [editOpen, setEditOpen] = useState(false);
@@ -762,7 +764,7 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
                 </SheetTitle>
               </SheetHeader>
 
-              {/* Nav de abas — Cowork canon */}
+              {/* Nav de abas — Cowork canon V2.1 (3 abas: Detalhes/IA/Editar) */}
               <nav className="fin-drawer-tabs" role="tablist" aria-label="Visualização do título">
                 <button
                   type="button"
@@ -772,8 +774,11 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
                   onClick={() => setDrawerTab('detalhes')}
                 >
                   Detalhes
+                  {selected.status === 'atrasado' && (
+                    <span className="fin-drawer-tab-tag" aria-label="Atrasado" title="Lançamento atrasado" />
+                  )}
                   {comments.countFor(selected.id) > 0 && (
-                    <span className="fin-drawer-tab-badge">💬{comments.countFor(selected.id)}</span>
+                    <span className="fin-drawer-tab-ct">{comments.countFor(selected.id)}</span>
                   )}
                 </button>
                 <button
@@ -784,6 +789,17 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
                   onClick={() => setDrawerTab('ia')}
                 >
                   ✦ IA
+                </button>
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={drawerTab === 'editar'}
+                  className={'fin-drawer-tab fin-drawer-tab-edit' + (drawerTab === 'editar' ? ' on' : '')}
+                  onClick={() => setDrawerTab('editar')}
+                  disabled={!selected.valor_mutavel}
+                  title={!selected.valor_mutavel ? 'Valor não-mutável após baixa (ADR fin-tech/0002)' : 'Editar inline'}
+                >
+                  ✎ Editar
                 </button>
               </nav>
 
@@ -874,6 +890,69 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
 
                   <p className="text-[11.5px] text-stone-500 italic pt-2 border-t border-stone-100">
                     Insights computacionais · pure compute · Fase 2 plugará JanaService LLM
+                  </p>
+                </div>
+              )}
+
+              {/* Aba Editar — V2.1 canon: panel inline amber (substitui Sheet separado) */}
+              {drawerTab === 'editar' && selected.valor_mutavel && (
+                <div className="mt-3 fin-edit-panel">
+                  <div className="fin-edit-h">
+                    <h4>✎ Editar campos do título</h4>
+                    <small>Campos seguros · vencimento, descrição, categoria, observações</small>
+                  </div>
+                  <div className="fin-edit-grid">
+                    <div>
+                      <label htmlFor="fin-edit-vencimento">Vencimento</label>
+                      <input
+                        id="fin-edit-vencimento"
+                        type="date"
+                        defaultValue={selected.vencimento}
+                        readOnly
+                        title="Edição via Sheet separado (TituloEditSheet) — clique Editar para abrir formulário completo"
+                      />
+                    </div>
+                    <div>
+                      <label htmlFor="fin-edit-categoria">Categoria</label>
+                      <select id="fin-edit-categoria" defaultValue={selected.categoria_id ?? ''} disabled>
+                        <option value="">— sem categoria —</option>
+                        {categorias.map((c) => <option key={c.id} value={c.id}>{c.nome}</option>)}
+                      </select>
+                    </div>
+                    <div>
+                      <label htmlFor="fin-edit-valor">Valor (BRL)</label>
+                      <input id="fin-edit-valor" type="text" defaultValue={brl(selected.valor)} readOnly />
+                    </div>
+                    <div className="fin-edit-wide">
+                      <label htmlFor="fin-edit-desc">Descrição</label>
+                      <input id="fin-edit-desc" type="text" defaultValue={selected.descricao} readOnly />
+                    </div>
+                    <div className="fin-edit-wide">
+                      <label htmlFor="fin-edit-obs">Observações</label>
+                      <textarea id="fin-edit-obs" rows={2} defaultValue={selected.observacao ?? ''} readOnly />
+                    </div>
+                  </div>
+                  <div className="fin-edit-footer">
+                    <button type="button" className="fin-edit-cancel" onClick={() => setDrawerTab('detalhes')}>
+                      Cancelar
+                    </button>
+                    <button type="button" className="fin-edit-close" onClick={() => { setDrawerTab('detalhes'); setEditOpen(true); }}>
+                      Abrir formulário completo →
+                    </button>
+                  </div>
+                  <p className="mt-2 text-[11px] text-stone-500 italic">
+                    Preview inline · edição validada acontece no Sheet separado (TituloEditSheet)
+                  </p>
+                </div>
+              )}
+              {drawerTab === 'editar' && !selected.valor_mutavel && (
+                <div className="mt-3 fin-edit-panel" style={{ background: 'oklch(0.97 0.005 80)', border: '1px dashed oklch(0.85 0.005 80)' }}>
+                  <div className="fin-edit-h">
+                    <h4 style={{ color: 'oklch(0.40 0 0)' }}>Valor não-mutável</h4>
+                    <small>ADR fin-tech/0002</small>
+                  </div>
+                  <p className="text-[12.5px] text-stone-600">
+                    Este lançamento já recebeu uma baixa (parcial ou total). O valor não pode mais ser editado — preserva-se a integridade contábil pós-baixa. Para correções, lance um novo título de ajuste.
                   </p>
                 </div>
               )}


### PR DESCRIPTION
## Origem

Wagner reaplicou pacote v2 do `prototipo-ui-patch/vendas-financeiro-completo/` via Anthropic API design fetch (8.2MB tarball, 667 arquivos, `styles.css` real com 9054 LOC).

Comparando com minha implementação V2 ([PR #1091](https://github.com/wagnerra23/oimpresso.com/pull/1091)), encontrei diffs canon que precisavam alinhamento.

## Diffs canon corrigidos

| # | Era (minha V2) | Canon Cowork V2 |
|---|---|---|
| 1 | active = box bg azul 240 | **border-bottom 2px verde 145** |
| 2 | IA hue = 280 | **295** (matching Cowork) |
| 3 | 2 abas | **3 abas**: Detalhes / ✦ IA / **✎ Editar** |
| 4 | `.fin-drawer-tab-badge` | **`.fin-drawer-tab-ct`** (count canon) |
| 5 | sem alerta visual | **`.fin-drawer-tab-tag`** red dot |
| 6 | `.fin-edit-panel` dashed | **gradient amber + finEditOpen animate** |

## Tab Editar (nova 3ª aba)

- Renderiza `.fin-edit-panel` inline (substitui Sheet TituloEditSheet separado pra **preview**)
- Respeita `valor_mutavel` — `disabled` + tooltip ADR fin-tech/0002
- Empty state quando `valor_mutavel=false` (mensagem "Valor não-mutável pós-baixa")
- Botão **"Abrir formulário completo →"** delega ao `TituloEditSheet` existente (preserva validação Laravel form request)
- `.has-edits` visual state quando user fez mudanças não-salvas (futuro)

## Tab Detalhes ganhou

- `.fin-drawer-tab-tag` red dot quando `status === 'atrasado'` (alerta visual canon)
- `.fin-drawer-tab-ct` count badge canônico (mono 10px pill verde quando active)

## CSS canon adicionado

- `@keyframes finEditOpen` (slide-down animate)
- `linear-gradient(135deg, oklch(0.98 0.025 60) → 0.99 0.012 60)` panel amber
- `.fin-edit-h / .fin-edit-grid (3 col) / .fin-edit-wide / .fin-edit-footer / .fin-edit-close / .fin-edit-cancel`

## Tier 0

- ✅ Zero novas queries Eloquent
- ✅ Zero backend (UI-only realign)
- ✅ Multi-tenant preservado

## Testes

[DrawerCoworkV21CanonAlignTest.php](Modules/Financeiro/Tests/Feature/DrawerCoworkV21CanonAlignTest.php) — 2 describes × 13 testes (CSS canon + 3 abas + valor_mutavel guard + edit panel inline).

## Test plan

- [x] Build TS check (9 erros pre-existentes, 0 novos)
- [x] Pest local pendente (vendor empty; CI roda)
- [ ] Smoke Chrome MCP pós-merge: drawer abre com 3 abas; click Editar com lançamento mutável → painel amber gradient anima; click Editar com lançamento já baixado → empty state ADR.

Refs: `prototipo-ui-patch/vendas-financeiro-completo/styles.css` (bundle Anthropic API fetch)
README_F3.md (origem protótipo Cowork 2026-05-09)

🤖 Generated with [Claude Code](https://claude.com/claude-code)