### PR TITLE
fix(financeiro): remove FinSubNav + FinAgeing do Index.tsx (duplicação Wagner)

### DIFF
--- a/Modules/Financeiro/Tests/Feature/Onda10Canon100PercentTest.php
+++ b/Modules/Financeiro/Tests/Feature/Onda10Canon100PercentTest.php
@@ -150,26 +150,28 @@ describe('Onda 10 — CSS canon (fin-ageing + fin-subnav)', function () {
     });
 });
 
-describe('Onda 10 — wire-up Index.tsx', function () {
-    it('Index.tsx importa 3 novos componentes', function () {
+describe('Onda 10 — wire-up Index.tsx (REVISADO 2026-05-18 Wagner: FinSubNav/FinAgeing removidos)', function () {
+    it('Index.tsx importa FinEditPanel (FinSubNav e FinAgeing REMOVIDOS — Wagner duplicação)', function () {
         $src = file_get_contents(FIN_BASE_10 . '/Index.tsx');
-        expect($src)->toContain("from './_components/FinSubNav'");
-        expect($src)->toContain("from './_components/FinAgeing'");
         expect($src)->toContain("from './_components/FinEditPanel'");
+        // Wagner pediu remoção: sidebar já navega + ageing é insight contextual
+        expect($src)->not->toContain("from './_components/FinSubNav'");
+        expect($src)->not->toContain("from './_components/FinAgeing'");
     });
 
-    it('FinSubNav renderizado ANTES do page header (active=unified)', function () {
+    it('FinSubNav NÃO renderizado no page (sidebar já cobre navegação)', function () {
         $src = file_get_contents(FIN_BASE_10 . '/Index.tsx');
-        expect($src)->toContain('<FinSubNav active="unified"');
-        // Ordem: FinSubNav vem antes de fin-page-h
-        $subnavPos = strpos($src, '<FinSubNav active="unified"');
-        $headerPos = strpos($src, 'fin-page-h');
-        expect($subnavPos)->toBeLessThan($headerPos);
+        expect($src)->not->toContain('<FinSubNav');
     });
 
-    it('FinAgeing renderizado APÓS KpiBar (lancamentos como prop)', function () {
+    it('FinAgeing NÃO renderizado no page (insight pertence ao drawer, não strip permanente)', function () {
         $src = file_get_contents(FIN_BASE_10 . '/Index.tsx');
-        expect($src)->toContain('<FinAgeing lancamentos={lancamentos} />');
+        expect($src)->not->toContain('<FinAgeing');
+    });
+
+    it('Componentes preservados em _components/ pra fallback (não deletados)', function () {
+        expect(file_exists(FIN_BASE_10 . '/_components/FinSubNav.tsx'))->toBeTrue();
+        expect(file_exists(FIN_BASE_10 . '/_components/FinAgeing.tsx'))->toBeTrue();
     });
 
     it('Aba Editar usa FinEditPanel (form real, não preview readOnly)', function () {

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -40,9 +40,9 @@ import { FinTranscriptPDF } from './_components/FinTranscriptPDF';
 import { useFinFavs, FinFavPin } from './_components/useFinFavs';
 // Onda 9 — Resumo executivo do mês (narrativa compute-based · plug LLM Fase 2).
 import { FinMonthResumeDialog } from './_components/FinMonthResume';
-// Onda 10 (canon 100%) — Sub-nav horizontal + ageing bar + edit panel inline real.
-import { FinSubNav } from './_components/FinSubNav';
-import { FinAgeing } from './_components/FinAgeing';
+// Onda 10 (canon 100%) — Edit panel inline real (FinSubNav + FinAgeing REMOVIDOS
+// 2026-05-18 Wagner: visualmente duplicados — sidebar já navega entre Fluxo/DRE/etc,
+// e ageing bar é insight contextual no drawer, não strip permanente).
 import { FinEditPanel } from './_components/FinEditPanel';
 // Onda Edit 2026-05-18 — Sheet inline pra editar título financeiro.
 import { TituloEditSheet } from './_components/TituloEditSheet';
@@ -518,9 +518,6 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
 
   return (
     <div className="fin-curadoria">
-      {/* Onda 10 Cowork canon: sub-nav horizontal (5 sub-rotas) ANTES do page header */}
-      <FinSubNav active="unified" />
-
       {/* Onda 8 Cowork: page header canon com h1 + breadcrumb + 7 botões.
           Substitui PageHeader shadcn legacy (mantido em _KpiBarLegacy + comentário). */}
       <div className="fin-page-h">
@@ -581,9 +578,6 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
       </div>
 
       <KpiBar kpis={kpis} onLifecycleSelect={(lifecycle) => aplicar({ lifecycle })} />
-
-      {/* Onda 10 Cowork canon — barra ageing A receber (vencido/0-30d/31-60d/61d+) */}
-      <FinAgeing lancamentos={lancamentos} />
 
       {/* Cowork KB-9.75 Onda 6 R2 IA — Resumo executivo do mês (Eliana 5min sexta) */}
       <FinMonthDigest


### PR DESCRIPTION
## Resumo

Wagner identificou **duplicação visual** na tela `/financeiro/unificado` após Onda 10 ([PR #1094](https://github.com/wagnerra23/oimpresso.com/pull/1094)):

\`\`\`
┌────────────────────────────────────────────────────────────┐
│ [Visão unificada][Fluxo][Conciliação][DRE]...             │ ← FinSubNav (REMOVER)
├────────────────────────────────────────────────────────────┤
│ Financeiro · Visão unificada  [Resumir][Fechamento]...    │ ← page header (manter)
├────────────────────────────────────────────────────────────┤
│ A RECEBER · AGEING R$ 6.843,28  ████ 100% atraso          │ ← FinAgeing (REMOVER)
├────────────────────────────────────────────────────────────┤
│ [A receber 20][Recebidas][A pagar 3][Pagas][Só atras.]    │ ← lifecycle chips (manter)
└────────────────────────────────────────────────────────────┘
\`\`\`

## Razões (canon Cowork v3 refinado)

| Componente | Razão remoção |
|---|---|
| `FinSubNav` 5 sub-rotas | Sidebar lateral já navega entre Visão/Fluxo/DRE/etc — **redundante** |
| `FinAgeing` barra ageing strip | Insight pertence ao **drawer contextual**, não strip permanente |

Header já tem todos os botões de ação (Resumir / Fechamento / Apresentar / Conciliar / Plano contas / Novo). Sub-nav e ageing strip são ruído visual.

## Mudanças

- `Index.tsx` — remover imports + render de `FinSubNav` + `FinAgeing`
- Componentes `.tsx` **preservados em `_components/`** (fallback — não deletados, ficam ali pra futura ativação se canon mudar)
- Pest test atualizado: testa AUSÊNCIA dos componentes no page + presença dos arquivos em `_components/`

## Tier 0

- ✅ Zero impacto multi-tenant (UI-only)
- ✅ TS check: 3 errors pre-existentes, 0 novos

## Test plan

- [x] TS check
- [x] Pest local pendente (CI roda)
- [ ] Smoke Chrome MCP pós-merge: tela `/financeiro/unificado` mostra Header → KPIs → lifecycle chips → tabela. SEM sub-nav horizontal, SEM ageing strip.

Refs: feedback Wagner 2026-05-18 — Frankenstein duplicação
[PR #1094](https://github.com/wagnerra23/oimpresso.com/pull/1094) introduziu — agora corrige

🤖 Generated with [Claude Code](https://claude.com/claude-code)