### PR TITLE
fix(cowork-preview): .htaccess força MIME .jsx + no-cache (Hostinger LiteSpeed)

### DIFF
--- a/public/cowork-preview/.htaccess
+++ b/public/cowork-preview/.htaccess
@@ -1,0 +1,30 @@
+# Cowork Preview — .htaccess
+# Garante Hostinger LiteSpeed serve .jsx como JavaScript (não text/plain).
+# Caso contrário Babel Standalone falha em transpilar em alguns browsers.
+
+# MIME types canônicos
+AddType application/javascript .jsx
+AddType application/javascript .js
+AddType text/css .css
+
+# Sem cache durante validação (Wagner está iterando o visual)
+<IfModule mod_headers.c>
+  <FilesMatch "\.(jsx|js|css|html)$">
+    Header set Cache-Control "no-cache, no-store, must-revalidate"
+    Header set Pragma "no-cache"
+    Header set Expires "0"
+  </FilesMatch>
+</IfModule>
+
+# CORS liberar fontes (Google Fonts já tem CORS, mas precaução)
+<IfModule mod_headers.c>
+  <FilesMatch "\.(css|js|jsx)$">
+    Header set Access-Control-Allow-Origin "*"
+  </FilesMatch>
+</IfModule>
+
+# Garante index.html como padrão da pasta
+DirectoryIndex index.html
+
+# Listing de diretório desabilitado por segurança (entra direto no index.html)
+Options -Indexes


### PR DESCRIPTION
## Bug

Wagner 2026-05-18 reportou preview \"sem componentes mau formatado\". Curl revelou:

\`\`\`
curl -sI https://oimpresso.com/cowork-preview/financeiro-app.jsx
Content-Type: text/plain   ← Hostinger LiteSpeed não conhece .jsx
\`\`\`

Babel Standalone com \`<script type=\"text/babel\" src=\"...jsx\">\` faz fetch que precisa retornar JavaScript válido. Alguns browsers tratam \`text/plain\` como inerte (não executável) → SPA monta parcial, perde componentes/formatação.

## Fix

`.htaccess` em `public/cowork-preview/`:

\`\`\`apache
AddType application/javascript .jsx
AddType application/javascript .js
AddType text/css .css

# Sem cache durante validação (Wagner está iterando visual)
<FilesMatch \"\.(jsx|js|css|html)\$\">
  Header set Cache-Control \"no-cache, no-store, must-revalidate\"
  Header set Pragma \"no-cache\"
  Header set Expires \"0\"
</FilesMatch>

DirectoryIndex index.html
Options -Indexes
\`\`\`

## Verificação pós-merge

\`\`\`
curl -sI https://oimpresso.com/cowork-preview/financeiro-app.jsx | grep Content-Type
# esperado: Content-Type: application/javascript
\`\`\`

## Tier 0

- ✅ Zero impacto fora de `public/cowork-preview/`
- ✅ Apache `.htaccess` honrado por LiteSpeed (Hostinger)

## Test plan

- [x] Curl confirmou bug
- [ ] Pós-merge: \`curl -sI .../financeiro-app.jsx\` deve mostrar \`Content-Type: application/javascript\`
- [ ] Smoke Chrome: tela `/cowork-preview/Oimpresso ERP - Chat.html` carrega completa

Refs: [feedback-cowork-bundle-aplicar-inteiro.md](memory/reference/feedback-cowork-bundle-aplicar-inteiro.md) — regra \"copia, merge, depois modifica\"
[PR #1096](https://github.com/wagnerra23/oimpresso.com/pull/1096) — bundle copy original

🤖 Generated with [Claude Code](https://claude.com/claude-code)