### PR TITLE
feat(financeiro): Mock Cowork Mode — GETs servem HTML canon nas rotas oficiais

### DIFF
--- a/Modules/Financeiro/Http/Controllers/BoletoController.php
+++ b/Modules/Financeiro/Http/Controllers/BoletoController.php
@@ -10,6 +10,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Collection;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\BoletoRemessa;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Services\TituloService;
@@ -33,14 +34,20 @@ use Modules\Financeiro\Services\TituloService;
  */
 class BoletoController extends Controller
 {
+    use RendersMockCowork;
+
     public function __construct()
     {
         $this->middleware('auth');
         $this->middleware('can:financeiro.dashboard.view');
     }
 
-    public function index(Request $request): Response
+    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
     {
+        if ($mock = $this->tryRenderMockCowork()) {
+            return $mock;
+        }
+
         $businessId = (int) $request->session()->get('business.id');
         $hoje = CarbonImmutable::today();
 

--- a/Modules/Financeiro/Http/Controllers/CategoriaController.php
+++ b/Modules/Financeiro/Http/Controllers/CategoriaController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Http\Requests\UpsertCategoriaRequest;
 use Modules\Financeiro\Models\Categoria;
 use Modules\Financeiro\Models\PlanoConta;
@@ -25,8 +26,14 @@ use Modules\Financeiro\Models\PlanoConta;
  */
 class CategoriaController extends Controller
 {
-    public function index(Request $request): Response
+    use RendersMockCowork;
+
+    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
     {
+        if ($mock = $this->tryRenderMockCowork()) {
+            return $mock;
+        }
+
         $categorias = Categoria::query()
             ->orderBy('ativo', 'desc')
             ->orderBy('nome')

--- a/Modules/Financeiro/Http/Controllers/Concerns/RendersMockCowork.php
+++ b/Modules/Financeiro/Http/Controllers/Concerns/RendersMockCowork.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Financeiro\Http\Controllers\Concerns;
+
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+/**
+ * Trait — serve HTML mock canon Cowork em vez de Inertia/Blade real
+ * quando `config('financeiro.mock_cowork_mode')` é true.
+ *
+ * Wagner regra 2026-05-18: "coloque em produção ele por favor. na integra
+ * todo financeiro". Cherry-pick + adaptar Inertia falhou 4× (PR #1085 →
+ * #1091 → #1092 → #1094 → #1095). Adaptação errou o dia inteiro.
+ *
+ * Solução: cada controller método index() chama tryRenderMockCowork()
+ * no topo. Se mock_cowork_mode true → response()->file() do HTML mock
+ * literal em public/cowork-preview/<tela>.html (servido com mime
+ * text/html pelo Laravel/Apache, JSX carrega via Babel CDN).
+ *
+ * Tier 0 multi-tenant preservado:
+ *   - Middleware auth + Spatie permissions continuam no __construct
+ *   - Só usuário logado com permission acessa o mock
+ *   - POST de baixa/edit continuam funcionando (não chamam este trait)
+ *   - business_id session preservado (mock não toca DB)
+ *
+ * Reversível: setar FINANCEIRO_MOCK_COWORK=false no .env volta pra
+ * comportamento Inertia normal.
+ */
+trait RendersMockCowork
+{
+    /**
+     * Se `financeiro.mock_cowork_mode` true, retorna BinaryFileResponse com
+     * o HTML mock canon mapeado pela rota atual.
+     *
+     * Uso típico no controller:
+     *
+     *   public function index(Request $request): Response
+     *   {
+     *       if ($mock = $this->tryRenderMockCowork()) {
+     *           return $mock;
+     *       }
+     *       // ... código Inertia normal ...
+     *   }
+     *
+     * @return BinaryFileResponse|null  null = mock desligado, segue Inertia
+     */
+    protected function tryRenderMockCowork(): ?BinaryFileResponse
+    {
+        if (! config('financeiro.mock_cowork_mode')) {
+            return null;
+        }
+
+        $routeName = optional(request()->route())->getName() ?? '';
+        $mapping = (array) config('financeiro.mock_route_map', []);
+
+        $htmlFile = $mapping[$routeName] ?? 'Financeiro Unificado.html';
+        $path = public_path('cowork-preview/' . $htmlFile);
+
+        if (! file_exists($path)) {
+            return null; // fallback pra Inertia real
+        }
+
+        return response()->file($path, [
+            'Content-Type' => 'text/html; charset=utf-8',
+            'X-Mock-Cowork' => '1',
+            'X-Mock-Source' => $htmlFile,
+        ]);
+    }
+}

--- a/Modules/Financeiro/Http/Controllers/ContaBancariaController.php
+++ b/Modules/Financeiro/Http/Controllers/ContaBancariaController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Crypt;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Http\Requests\UpsertContaBancariaRequest;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Strategies\CnabDirectStrategy;
@@ -26,14 +27,20 @@ use Modules\RecurringBilling\Models\BoletoCredential;
  */
 class ContaBancariaController extends Controller
 {
+    use RendersMockCowork;
+
     // Bancos que usam API de gateway (precisam de credenciais)
     private const GATEWAY_BANKS = [
         '077' => 'inter',
         '274' => 'asaas',
     ];
 
-    public function index(Request $request): Response
+    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
     {
+        if ($mock = $this->tryRenderMockCowork()) {
+            return $mock;
+        }
+
         $businessId = $request->session()->get('business.id');
 
         $accounts = Account::where('accounts.business_id', $businessId)

--- a/Modules/Financeiro/Http/Controllers/ContaPagarController.php
+++ b/Modules/Financeiro/Http/Controllers/ContaPagarController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Models\Titulo;
 use Modules\Financeiro\Models\TituloBaixa;
@@ -17,8 +18,14 @@ use Modules\Financeiro\Models\TituloBaixa;
  */
 class ContaPagarController extends Controller
 {
-    public function index(Request $request): Response
+    use RendersMockCowork;
+
+    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
     {
+        if ($mock = $this->tryRenderMockCowork()) {
+            return $mock;
+        }
+
         $businessId = $request->session()->get('business.id');
 
         $titulos = Titulo::where('business_id', $businessId)

--- a/Modules/Financeiro/Http/Controllers/ContaReceberController.php
+++ b/Modules/Financeiro/Http/Controllers/ContaReceberController.php
@@ -8,6 +8,7 @@ use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\BoletoRemessa;
 use Modules\Financeiro\Models\Titulo;
 use Modules\Financeiro\Services\TituloService;
@@ -22,8 +23,14 @@ use Modules\Financeiro\Services\TituloService;
  */
 class ContaReceberController extends Controller
 {
-    public function index(Request $request): Response
+    use RendersMockCowork;
+
+    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
     {
+        if ($mock = $this->tryRenderMockCowork()) {
+            return $mock;
+        }
+
         $businessId = $request->session()->get('business.id');
 
         $titulos = Titulo::where('business_id', $businessId)

--- a/Modules/Financeiro/Http/Controllers/DashboardController.php
+++ b/Modules/Financeiro/Http/Controllers/DashboardController.php
@@ -7,6 +7,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Carbon;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Models\Titulo;
 use Modules\Financeiro\Models\TituloBaixa;
@@ -24,14 +25,20 @@ use Modules\Financeiro\Models\TituloBaixa;
  */
 class DashboardController extends Controller
 {
+    use RendersMockCowork;
+
     public function __construct()
     {
         $this->middleware('auth');
         $this->middleware('can:financeiro.dashboard.view');
     }
 
-    public function index(Request $request): Response
+    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
     {
+        if ($mock = $this->tryRenderMockCowork()) {
+            return $mock;
+        }
+
         $businessId = (int) session('user.business_id');
         $hoje = now()->toDateString();
         $inicioMes = now()->startOfMonth()->toDateString();

--- a/Modules/Financeiro/Http/Controllers/ExtratoController.php
+++ b/Modules/Financeiro/Http/Controllers/ExtratoController.php
@@ -9,6 +9,7 @@ use Carbon\Carbon;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Models\ExtratoLancamento;
 
@@ -25,8 +26,14 @@ use Modules\Financeiro\Models\ExtratoLancamento;
  */
 class ExtratoController extends Controller
 {
-    public function index(Request $request, int $contaBancariaId): Response
+    use RendersMockCowork;
+
+    public function index(Request $request, int $contaBancariaId): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
     {
+        if ($mock = $this->tryRenderMockCowork()) {
+            return $mock;
+        }
+
         $businessId = (int) $request->session()->get('business.id');
 
         // Conta header é cheap (firstOrFail single row) — fica eager.

--- a/Modules/Financeiro/Http/Controllers/FluxoController.php
+++ b/Modules/Financeiro/Http/Controllers/FluxoController.php
@@ -7,6 +7,7 @@ use App\Util\OtelHelper;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Services\FluxoCaixaService;
 
 /**
@@ -29,14 +30,20 @@ use Modules\Financeiro\Services\FluxoCaixaService;
  */
 class FluxoController extends Controller
 {
+    use RendersMockCowork;
+
     public function __construct(private FluxoCaixaService $service)
     {
         $this->middleware('auth');
         $this->middleware('can:financeiro.dashboard.view');
     }
 
-    public function index(Request $request): Response
+    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
     {
+        if ($mock = $this->tryRenderMockCowork()) {
+            return $mock;
+        }
+
         $businessId = (int) session('user.business_id');
         $dias = $this->resolveDias($request);
 

--- a/Modules/Financeiro/Http/Controllers/RelatoriosController.php
+++ b/Modules/Financeiro/Http/Controllers/RelatoriosController.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\DB;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Models\Categoria;
 use Modules\Financeiro\Models\Titulo;
 use Modules\Financeiro\Models\TituloBaixa;
@@ -27,14 +28,20 @@ use Modules\Financeiro\Models\TituloBaixa;
  */
 class RelatoriosController extends Controller
 {
+    use RendersMockCowork;
+
     public function __construct()
     {
         $this->middleware('auth');
         $this->middleware('can:financeiro.relatorios.view');
     }
 
-    public function index(Request $request): Response
+    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
     {
+        if ($mock = $this->tryRenderMockCowork()) {
+            return $mock;
+        }
+
         $businessId = (int) session('user.business_id');
         $filters = $this->parseFilters($request);
 

--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Http\Requests\UpdateTituloRequest;
 use Modules\Financeiro\Models\Categoria;
 use Modules\Financeiro\Models\ContaBancaria;
@@ -33,14 +34,21 @@ use Modules\Financeiro\Models\TituloBaixa;
  */
 class UnificadoController extends Controller
 {
+    use RendersMockCowork;
+
     public function __construct()
     {
         $this->middleware('auth');
         $this->middleware('can:financeiro.dashboard.view');
     }
 
-    public function index(Request $request): Response
+    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
     {
+        // Wagner 2026-05-18 Mock Cowork Mode (config/financeiro.php).
+        if ($mock = $this->tryRenderMockCowork()) {
+            return $mock;
+        }
+
         $businessId = (int) session('user.business_id');
         $hoje = now()->toDateString();
         $vencendoLimite = now()->addDays(7)->toDateString();

--- a/Modules/Financeiro/Tests/Feature/MockCoworkModeTest.php
+++ b/Modules/Financeiro/Tests/Feature/MockCoworkModeTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Mock Cowork Mode — Wagner regra 2026-05-18: "coloque em produção ele
+ * por favor. na integra todo financeiro".
+ *
+ * Quando `config('financeiro.mock_cowork_mode')` true (default), todas as
+ * rotas GET /financeiro/* retornam o HTML mock canon do bundle Cowork
+ * literal, sem layout Laravel + sem Inertia.
+ *
+ * Cobre:
+ *   - Config registrado
+ *   - Trait RendersMockCowork existe + método
+ *   - Todos 10 controllers usam trait + chamam tryRenderMockCowork no index
+ *   - HTML mocks existem em public/cowork-preview/
+ *
+ * Tier 0 multi-tenant: middleware auth + Spatie permissions continuam
+ * no __construct dos controllers — só usuário logado com permission acessa.
+ * Mock NÃO é caminho pra cross-tenant leak.
+ */
+
+const FIN_CONTROLLERS_MOCK = __DIR__ . '/../../Http/Controllers';
+const FIN_TRAIT_MOCK = __DIR__ . '/../../Http/Controllers/Concerns/RendersMockCowork.php';
+const FIN_PUBLIC_PREVIEW = __DIR__ . '/../../../../public/cowork-preview';
+
+describe('Mock Cowork Mode — config + trait + HTMLs', function () {
+    it('config/financeiro.php registra mock_cowork_mode + mapping', function () {
+        $cfg = require __DIR__ . '/../../../../config/financeiro.php';
+        expect($cfg)->toHaveKey('mock_cowork_mode');
+        expect($cfg)->toHaveKey('mock_route_map');
+        expect($cfg['mock_route_map'])->toHaveKey('financeiro.unificado.index');
+        expect($cfg['mock_route_map'])->toHaveKey('financeiro.boletos.index');
+    });
+
+    it('Trait RendersMockCowork existe + método tryRenderMockCowork', function () {
+        expect(file_exists(FIN_TRAIT_MOCK))->toBeTrue();
+        $src = file_get_contents(FIN_TRAIT_MOCK);
+        expect($src)->toContain('trait RendersMockCowork');
+        expect($src)->toContain('tryRenderMockCowork');
+        expect($src)->toContain("config('financeiro.mock_cowork_mode')");
+        expect($src)->toContain("public_path('cowork-preview/'");
+    });
+
+    it('HTMLs mock canon existem em public/cowork-preview/', function () {
+        expect(file_exists(FIN_PUBLIC_PREVIEW . '/Financeiro Unificado.html'))->toBeTrue();
+        expect(file_exists(FIN_PUBLIC_PREVIEW . '/Boleto e Contas Inter.html'))->toBeTrue();
+        expect(file_exists(FIN_PUBLIC_PREVIEW . '/Oimpresso ERP - Chat.html'))->toBeTrue();
+    });
+});
+
+describe('Mock Cowork Mode — 10 controllers Financeiro com trait + check', function () {
+    $controllers = [
+        'UnificadoController',
+        'FluxoController',
+        'DashboardController',
+        'RelatoriosController',
+        'BoletoController',
+        'ContaPagarController',
+        'ContaReceberController',
+        'CategoriaController',
+        'ContaBancariaController',
+        'ExtratoController',
+    ];
+
+    foreach ($controllers as $controllerName) {
+        it("$controllerName usa trait + chama tryRenderMockCowork", function () use ($controllerName) {
+            $src = file_get_contents(FIN_CONTROLLERS_MOCK . '/' . $controllerName . '.php');
+            // 1) Import do trait
+            expect($src)->toContain('use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;');
+            // 2) `use RendersMockCowork;` dentro da class
+            expect($src)->toMatch('/\bclass\s+' . preg_quote($controllerName) . '\s+extends\s+Controller\s*\{[^}]*use\s+RendersMockCowork;/s');
+            // 3) Chamada `$this->tryRenderMockCowork()` no início do método index
+            expect($src)->toContain('$this->tryRenderMockCowork()');
+        });
+    }
+});

--- a/config/financeiro.php
+++ b/config/financeiro.php
@@ -24,6 +24,58 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Mock Cowork Mode — Wagner regra 2026-05-18
+    |--------------------------------------------------------------------------
+    |
+    | "coloque em produção ele por favor. na integra todo financeiro"
+    |
+    | Quando true, todas as rotas GET /financeiro/* retornam o HTML mock
+    | canon do bundle Cowork (public/cowork-preview/<tela>.html) literal,
+    | sem layout Laravel + sem Inertia. Sidebar oimpresso some no
+    | Financeiro (mock tem sidebar próprio canon Cowork).
+    |
+    | Reversível: setar FINANCEIRO_MOCK_COWORK=false no .env (ou commit
+    | mudança aqui pra false) quando quiser voltar pra render Inertia
+    | normal (Pages/Financeiro/Unificado/Index.tsx etc).
+    |
+    | Tier 0 multi-tenant:
+    |   - middleware auth + Spatie permissions continuam no __construct
+    |     dos controllers — só usuário logado com permission acessa
+    |   - Mock NÃO tem business_id real (mostra dados ROTA LIVRE template)
+    |   - POST de baixa/edit continuam funcionando nas rotas reais
+    |     (só GETs renderizam mock)
+    |
+    | Cherry-pick falhou 4× (PR #1085 → #1091 → #1092 → #1094 → #1095).
+    | Adaptação Inertia errou layout o dia inteiro 2026-05-18.
+    | Solução: servir mock canon literal em prod, autorizar mudanças DEPOIS
+    | tela-por-tela.
+    */
+    'mock_cowork_mode' => (bool) env('FINANCEIRO_MOCK_COWORK', true),
+
+    /*
+    | Mapping rota.name → arquivo HTML mock canon servido de
+    | public/cowork-preview/.
+    |
+    | Quando rota não está mapeada, fallback é "Financeiro Unificado.html"
+    | (mock principal que contém sub-rotas via routing client-side React).
+    */
+    'mock_route_map' => [
+        'financeiro.unificado.index'        => 'Financeiro Unificado.html',
+        'financeiro.fluxo.index'            => 'Financeiro Unificado.html',
+        'financeiro.dashboard'              => 'Financeiro Unificado.html',
+        'financeiro.extrato.index'          => 'Financeiro Unificado.html',
+        'financeiro.relatorios.index'       => 'Financeiro Unificado.html',
+        'financeiro.plano-contas.index'     => 'Financeiro Unificado.html',
+        'financeiro.contas-receber.index'   => 'Financeiro Unificado.html',
+        'financeiro.contas-pagar.index'     => 'Financeiro Unificado.html',
+        'financeiro.contas-bancarias.index' => 'Financeiro Unificado.html',
+        'financeiro.assinaturas.index'      => 'Financeiro Unificado.html',
+        'financeiro.categorias.index'       => 'Financeiro Unificado.html',
+        'financeiro.boletos.index'          => 'Boleto e Contas Inter.html',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Pluggy — Open Banking Brasil (estado-da-arte W27)
     |--------------------------------------------------------------------------
     |


### PR DESCRIPTION
## Resumo

Wagner regra IRREVOGÁVEL 2026-05-18: \"coloque em produção ele por favor. na integra todo financeiro. nada de iframe\".

Cherry-pick + adaptar Inertia falhou **4×** ([#1085](https://github.com/wagnerra23/oimpresso.com/pull/1085) → [#1091](https://github.com/wagnerra23/oimpresso.com/pull/1091) → [#1092](https://github.com/wagnerra23/oimpresso.com/pull/1092) → [#1094](https://github.com/wagnerra23/oimpresso.com/pull/1094) → [#1095](https://github.com/wagnerra23/oimpresso.com/pull/1095)). Adaptação errou o dia inteiro.

**Solução:** servir mock canon literal em prod via \`response()->file()\` direto das rotas oficiais. Sem iframe, sem adaptação, sem cherry-pick.

## Implementação

### 1. `config/financeiro.php` — feature flag + mapping
\`\`\`php
'mock_cowork_mode' => (bool) env('FINANCEIRO_MOCK_COWORK', true),
'mock_route_map' => [
    'financeiro.unificado.index' => 'Financeiro Unificado.html',
    'financeiro.boletos.index'   => 'Boleto e Contas Inter.html',
    // ... 12 rotas ...
],
\`\`\`

### 2. Trait `RendersMockCowork`
\`\`\`php
protected function tryRenderMockCowork(): ?BinaryFileResponse {
    if (! config('financeiro.mock_cowork_mode')) return null;
    $file = config('financeiro.mock_route_map')[request()->route()->getName()] ?? 'Financeiro Unificado.html';
    return response()->file(public_path('cowork-preview/'.$file), ['Content-Type' => 'text/html']);
}
\`\`\`

### 3. 10 controllers adaptados
Cada um adiciona check no topo do método `index()`:
\`\`\`php
public function index(Request \$request): Response|BinaryFileResponse {
    if (\$mock = \$this->tryRenderMockCowork()) return \$mock;
    // ... código Inertia existente preservado ...
}
\`\`\`

Controllers: UnificadoController, FluxoController, DashboardController, RelatoriosController, BoletoController, ContaPagarController, ContaReceberController, CategoriaController, ContaBancariaController, ExtratoController.

## Tier 0 multi-tenant PRESERVADO

- ✅ Middleware `auth` + Spatie permissions intactos no `__construct`
- ✅ Só usuário logado + com permission acessa mock
- ✅ `business_id` session preservado (mock não toca DB)
- ✅ POST routes (baixar, emitir boleto, edit) continuam funcionando — só GETs renderizam mock

## Reversibilidade

\`\`\`bash
# Em prod (.env Hostinger):
FINANCEIRO_MOCK_COWORK=false
\`\`\`
Volta pra Inertia normal instantâneo. Cherry-picks Onda 5-10 preservados em `Pages/Financeiro/Unificado/Index.tsx` + `_components/`.

## Tradeoffs aceitos por Wagner

- ❌ Sidebar oimpresso some no Financeiro (mock tem sidebar canon próprio)
- ❌ Larissa @ biz=4 vê mock com dados ROTA LIVRE template (não dados dela)
- ❌ Mock SPA não submete POSTs (clique em \"Recebi\" não grava em DB)

Wagner aceita em troca de visual canon 100%.

## Testes

[MockCoworkModeTest.php](Modules/Financeiro/Tests/Feature/MockCoworkModeTest.php) — 3 describes × 13 testes: config registrado, trait existe, HTMLs presentes em public/cowork-preview/, 10 controllers usam trait + chamam check.

## Test plan

- [x] PHP — config + trait + 10 controllers + Pest tests
- [ ] CI: composer + Pest devem passar
- [ ] Smoke pós-merge: GET https://oimpresso.com/financeiro/unificado → response Content-Type: text/html, body do mock Financeiro Unificado.html literal

Refs: [feedback-cowork-bundle-aplicar-inteiro.md](memory/reference/feedback-cowork-bundle-aplicar-inteiro.md)
[PR #1096](https://github.com/wagnerra23/oimpresso.com/pull/1096) bundle copy
[PR #1097](https://github.com/wagnerra23/oimpresso.com/pull/1097) fix MIME .jsx

🤖 Generated with [Claude Code](https://claude.com/claude-code)