### PR TITLE
fix(financeiro-mock): injeta base href + return type Response

### DIFF
--- a/Modules/Financeiro/Http/Controllers/BoletoController.php
+++ b/Modules/Financeiro/Http/Controllers/BoletoController.php
@@ -42,7 +42,7 @@ class BoletoController extends Controller
         $this->middleware('can:financeiro.dashboard.view');
     }
 
-    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
+    public function index(Request $request): Response|\Illuminate\Http\Response
     {
         if ($mock = $this->tryRenderMockCowork()) {
             return $mock;

--- a/Modules/Financeiro/Http/Controllers/CategoriaController.php
+++ b/Modules/Financeiro/Http/Controllers/CategoriaController.php
@@ -28,7 +28,7 @@ class CategoriaController extends Controller
 {
     use RendersMockCowork;
 
-    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
+    public function index(Request $request): Response|\Illuminate\Http\Response
     {
         if ($mock = $this->tryRenderMockCowork()) {
             return $mock;

--- a/Modules/Financeiro/Http/Controllers/Concerns/RendersMockCowork.php
+++ b/Modules/Financeiro/Http/Controllers/Concerns/RendersMockCowork.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Modules\Financeiro\Http\Controllers\Concerns;
 
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Illuminate\Http\Response;
 
 /**
  * Trait — serve HTML mock canon Cowork em vez de Inertia/Blade real
@@ -15,9 +15,9 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
  * #1091 → #1092 → #1094 → #1095). Adaptação errou o dia inteiro.
  *
  * Solução: cada controller método index() chama tryRenderMockCowork()
- * no topo. Se mock_cowork_mode true → response()->file() do HTML mock
- * literal em public/cowork-preview/<tela>.html (servido com mime
- * text/html pelo Laravel/Apache, JSX carrega via Babel CDN).
+ * no topo. Se mock_cowork_mode true → response() com conteúdo HTML mock
+ * + injeção `<base href="/cowork-preview/">` pra paths relativos resolverem
+ * pros assets corretos (styles.css, financeiro-app.jsx, etc).
  *
  * Tier 0 multi-tenant preservado:
  *   - Middleware auth + Spatie permissions continuam no __construct
@@ -31,8 +31,9 @@ use Symfony\Component\HttpFoundation\BinaryFileResponse;
 trait RendersMockCowork
 {
     /**
-     * Se `financeiro.mock_cowork_mode` true, retorna BinaryFileResponse com
-     * o HTML mock canon mapeado pela rota atual.
+     * Se `financeiro.mock_cowork_mode` true, retorna Response com o HTML
+     * mock canon mapeado pela rota atual, com `<base href>` injetado pros
+     * assets relativos resolverem corretamente.
      *
      * Uso típico no controller:
      *
@@ -44,9 +45,9 @@ trait RendersMockCowork
      *       // ... código Inertia normal ...
      *   }
      *
-     * @return BinaryFileResponse|null  null = mock desligado, segue Inertia
+     * @return Response|null  null = mock desligado, segue Inertia
      */
-    protected function tryRenderMockCowork(): ?BinaryFileResponse
+    protected function tryRenderMockCowork(): ?Response
     {
         if (! config('financeiro.mock_cowork_mode')) {
             return null;
@@ -62,10 +63,34 @@ trait RendersMockCowork
             return null; // fallback pra Inertia real
         }
 
-        return response()->file($path, [
+        $html = (string) file_get_contents($path);
+
+        // Injeção CRÍTICA: <base href> faz paths relativos (styles.css,
+        // financeiro-app.jsx, etc) resolverem pra /cowork-preview/<file>
+        // em vez de /financeiro/<file> (que dá 404). Sem isso, mock NÃO
+        // carrega assets quando servido fora de /cowork-preview/.
+        $baseTag = '<base href="/cowork-preview/" />';
+        if (str_contains($html, '<head>')) {
+            $html = preg_replace(
+                '/<head>/i',
+                "<head>\n  {$baseTag}",
+                $html,
+                1
+            );
+        } elseif (str_contains($html, '<head ')) {
+            $html = preg_replace(
+                '/<head([^>]*)>/i',
+                "<head$1>\n  {$baseTag}",
+                $html,
+                1
+            );
+        }
+
+        return response($html, 200, [
             'Content-Type' => 'text/html; charset=utf-8',
             'X-Mock-Cowork' => '1',
             'X-Mock-Source' => $htmlFile,
+            'Cache-Control' => 'no-cache, no-store, must-revalidate',
         ]);
     }
 }

--- a/Modules/Financeiro/Http/Controllers/ContaBancariaController.php
+++ b/Modules/Financeiro/Http/Controllers/ContaBancariaController.php
@@ -35,7 +35,7 @@ class ContaBancariaController extends Controller
         '274' => 'asaas',
     ];
 
-    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
+    public function index(Request $request): Response|\Illuminate\Http\Response
     {
         if ($mock = $this->tryRenderMockCowork()) {
             return $mock;

--- a/Modules/Financeiro/Http/Controllers/ContaPagarController.php
+++ b/Modules/Financeiro/Http/Controllers/ContaPagarController.php
@@ -20,7 +20,7 @@ class ContaPagarController extends Controller
 {
     use RendersMockCowork;
 
-    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
+    public function index(Request $request): Response|\Illuminate\Http\Response
     {
         if ($mock = $this->tryRenderMockCowork()) {
             return $mock;

--- a/Modules/Financeiro/Http/Controllers/ContaReceberController.php
+++ b/Modules/Financeiro/Http/Controllers/ContaReceberController.php
@@ -25,7 +25,7 @@ class ContaReceberController extends Controller
 {
     use RendersMockCowork;
 
-    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
+    public function index(Request $request): Response|\Illuminate\Http\Response
     {
         if ($mock = $this->tryRenderMockCowork()) {
             return $mock;

--- a/Modules/Financeiro/Http/Controllers/DashboardController.php
+++ b/Modules/Financeiro/Http/Controllers/DashboardController.php
@@ -33,7 +33,7 @@ class DashboardController extends Controller
         $this->middleware('can:financeiro.dashboard.view');
     }
 
-    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
+    public function index(Request $request): Response|\Illuminate\Http\Response
     {
         if ($mock = $this->tryRenderMockCowork()) {
             return $mock;

--- a/Modules/Financeiro/Http/Controllers/ExtratoController.php
+++ b/Modules/Financeiro/Http/Controllers/ExtratoController.php
@@ -28,7 +28,7 @@ class ExtratoController extends Controller
 {
     use RendersMockCowork;
 
-    public function index(Request $request, int $contaBancariaId): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
+    public function index(Request $request, int $contaBancariaId): Response|\Illuminate\Http\Response
     {
         if ($mock = $this->tryRenderMockCowork()) {
             return $mock;

--- a/Modules/Financeiro/Http/Controllers/FluxoController.php
+++ b/Modules/Financeiro/Http/Controllers/FluxoController.php
@@ -38,7 +38,7 @@ class FluxoController extends Controller
         $this->middleware('can:financeiro.dashboard.view');
     }
 
-    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
+    public function index(Request $request): Response|\Illuminate\Http\Response
     {
         if ($mock = $this->tryRenderMockCowork()) {
             return $mock;

--- a/Modules/Financeiro/Http/Controllers/RelatoriosController.php
+++ b/Modules/Financeiro/Http/Controllers/RelatoriosController.php
@@ -36,7 +36,7 @@ class RelatoriosController extends Controller
         $this->middleware('can:financeiro.relatorios.view');
     }
 
-    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
+    public function index(Request $request): Response|\Illuminate\Http\Response
     {
         if ($mock = $this->tryRenderMockCowork()) {
             return $mock;

--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -42,7 +42,7 @@ class UnificadoController extends Controller
         $this->middleware('can:financeiro.dashboard.view');
     }
 
-    public function index(Request $request): Response|\Symfony\Component\HttpFoundation\BinaryFileResponse
+    public function index(Request $request): Response|\Illuminate\Http\Response
     {
         // Wagner 2026-05-18 Mock Cowork Mode (config/financeiro.php).
         if ($mock = $this->tryRenderMockCowork()) {


### PR DESCRIPTION
## Bug

PR #1098 servia HTML mock literal via response()->file() mas paths relativos não resolviam: browser fazia GET /financeiro/styles.css (404) em vez de /cowork-preview/styles.css. React não montava.

## Fix

1. Trait lê HTML via file_get_contents(), injeta \`<base href="/cowork-preview/" />\` após \`<head>\`, retorna response() com Cache-Control no-cache.
2. Return type: \`Response|\Illuminate\Http\Response\` (não BinaryFileResponse — precisamos HTML mutável).
3. Headers X-Mock-Cowork=1 + X-Mock-Source=<arquivo> pra debug.

## Test plan

- [ ] Pós-merge: curl https://oimpresso.com/financeiro/unificado deve retornar HTML com <base href>
- [ ] Chrome MCP smoke: React monta, sidebar canon, sem 404 em network

🤖 Generated with [Claude Code](https://claude.com/claude-code)