### PR TITLE
fix(financeiro-mock): SPA shell completo + injeta cowork route

### DIFF
--- a/Modules/Financeiro/Http/Controllers/Concerns/RendersMockCowork.php
+++ b/Modules/Financeiro/Http/Controllers/Concerns/RendersMockCowork.php
@@ -56,7 +56,15 @@ trait RendersMockCowork
         $routeName = optional(request()->route())->getName() ?? '';
         $mapping = (array) config('financeiro.mock_route_map', []);
 
-        $htmlFile = $mapping[$routeName] ?? 'Financeiro Unificado.html';
+        // Cada entry agora é array ['html' => ..., 'cowork_route' => ...].
+        // Back-compat: aceita string simples (cai em cowork_route='financeiro').
+        $entry = $mapping[$routeName] ?? ['html' => 'Oimpresso ERP - Chat.html', 'cowork_route' => 'financeiro'];
+        if (is_string($entry)) {
+            $entry = ['html' => $entry, 'cowork_route' => 'financeiro'];
+        }
+
+        $htmlFile = $entry['html'] ?? 'Oimpresso ERP - Chat.html';
+        $coworkRoute = $entry['cowork_route'] ?? 'financeiro';
         $path = public_path('cowork-preview/' . $htmlFile);
 
         if (! file_exists($path)) {
@@ -65,22 +73,35 @@ trait RendersMockCowork
 
         $html = (string) file_get_contents($path);
 
-        // Injeção CRÍTICA: <base href> faz paths relativos (styles.css,
+        // Injeção 1: <base href> faz paths relativos (styles.css,
         // financeiro-app.jsx, etc) resolverem pra /cowork-preview/<file>
-        // em vez de /financeiro/<file> (que dá 404). Sem isso, mock NÃO
-        // carrega assets quando servido fora de /cowork-preview/.
-        $baseTag = '<base href="/cowork-preview/" />';
+        // em vez de /financeiro/<file> (que dá 404).
+        //
+        // Injeção 2: <script> setando localStorage["oimpresso.route"] pra
+        // que app.jsx Cowork abra direto na tela correta (financeiro,
+        // fin-fluxo, fin-dre, boletos) em vez do default "chat".
+        $coworkRouteEscaped = htmlspecialchars($coworkRoute, ENT_QUOTES);
+        $injection = <<<HTML
+<base href="/cowork-preview/" />
+  <script>
+    // Mock Cowork Mode (Wagner 2026-05-18): abre tela direto baseada na URL Laravel
+    try {
+      localStorage.setItem('oimpresso.route', '{$coworkRouteEscaped}');
+    } catch (e) {}
+  </script>
+HTML;
+
         if (str_contains($html, '<head>')) {
             $html = preg_replace(
                 '/<head>/i',
-                "<head>\n  {$baseTag}",
+                "<head>\n  {$injection}",
                 $html,
                 1
             );
         } elseif (str_contains($html, '<head ')) {
             $html = preg_replace(
                 '/<head([^>]*)>/i',
-                "<head$1>\n  {$baseTag}",
+                "<head$1>\n  {$injection}",
                 $html,
                 1
             );
@@ -90,6 +111,7 @@ trait RendersMockCowork
             'Content-Type' => 'text/html; charset=utf-8',
             'X-Mock-Cowork' => '1',
             'X-Mock-Source' => $htmlFile,
+            'X-Mock-Route' => $coworkRoute,
             'Cache-Control' => 'no-cache, no-store, must-revalidate',
         ]);
     }

--- a/config/financeiro.php
+++ b/config/financeiro.php
@@ -59,19 +59,30 @@ return [
     | Quando rota não está mapeada, fallback é "Financeiro Unificado.html"
     | (mock principal que contém sub-rotas via routing client-side React).
     */
+    /*
+    | Cada rota mapeia pra:
+    |   - html: arquivo em public/cowork-preview/ (Oimpresso ERP - Chat.html é
+    |     o SPA shell completo com app.jsx boot que monta TODOS módulos)
+    |   - cowork_route: valor que o trait injeta em localStorage["oimpresso.route"]
+    |     ANTES do app.jsx rodar, pra abrir a tela correta direto. Routes válidas
+    |     no app.jsx Cowork: financeiro / fin-fluxo / fin-dre / boletos
+    |
+    | Usar `Oimpresso ERP - Chat.html` (não Financeiro Unificado.html standalone)
+    | porque o standalone NÃO tem ReactDOM.createRoot() — só o Chat shell tem app.jsx.
+    */
     'mock_route_map' => [
-        'financeiro.unificado.index'        => 'Financeiro Unificado.html',
-        'financeiro.fluxo.index'            => 'Financeiro Unificado.html',
-        'financeiro.dashboard'              => 'Financeiro Unificado.html',
-        'financeiro.extrato.index'          => 'Financeiro Unificado.html',
-        'financeiro.relatorios.index'       => 'Financeiro Unificado.html',
-        'financeiro.plano-contas.index'     => 'Financeiro Unificado.html',
-        'financeiro.contas-receber.index'   => 'Financeiro Unificado.html',
-        'financeiro.contas-pagar.index'     => 'Financeiro Unificado.html',
-        'financeiro.contas-bancarias.index' => 'Financeiro Unificado.html',
-        'financeiro.assinaturas.index'      => 'Financeiro Unificado.html',
-        'financeiro.categorias.index'       => 'Financeiro Unificado.html',
-        'financeiro.boletos.index'          => 'Boleto e Contas Inter.html',
+        'financeiro.unificado.index'        => ['html' => 'Oimpresso ERP - Chat.html', 'cowork_route' => 'financeiro'],
+        'financeiro.fluxo.index'            => ['html' => 'Oimpresso ERP - Chat.html', 'cowork_route' => 'fin-fluxo'],
+        'financeiro.dashboard'              => ['html' => 'Oimpresso ERP - Chat.html', 'cowork_route' => 'financeiro'],
+        'financeiro.extrato.index'          => ['html' => 'Oimpresso ERP - Chat.html', 'cowork_route' => 'financeiro'],
+        'financeiro.relatorios.index'       => ['html' => 'Oimpresso ERP - Chat.html', 'cowork_route' => 'fin-dre'],
+        'financeiro.plano-contas.index'     => ['html' => 'Oimpresso ERP - Chat.html', 'cowork_route' => 'financeiro'],
+        'financeiro.contas-receber.index'   => ['html' => 'Oimpresso ERP - Chat.html', 'cowork_route' => 'financeiro'],
+        'financeiro.contas-pagar.index'     => ['html' => 'Oimpresso ERP - Chat.html', 'cowork_route' => 'financeiro'],
+        'financeiro.contas-bancarias.index' => ['html' => 'Oimpresso ERP - Chat.html', 'cowork_route' => 'financeiro'],
+        'financeiro.assinaturas.index'      => ['html' => 'Oimpresso ERP - Chat.html', 'cowork_route' => 'financeiro'],
+        'financeiro.categorias.index'       => ['html' => 'Oimpresso ERP - Chat.html', 'cowork_route' => 'financeiro'],
+        'financeiro.boletos.index'          => ['html' => 'Oimpresso ERP - Chat.html', 'cowork_route' => 'boletos'],
     ],
 
     /*


### PR DESCRIPTION
## Bug pós-PR #1099

PR #1099 fix base href OK mas mock servia \`Financeiro Unificado.html\` standalone — esse HTML **NÃO tem** \`ReactDOM.createRoot()\`. Só carrega 5 JSX sem montar React.

## Fix

1. **Troca pra \`Oimpresso ERP - Chat.html\`** (SPA shell completo com \`app.jsx\` boot que monta TODOS módulos).
2. **Injeta script localStorage** ANTES de app.jsx rodar:
\`\`\`html
<script>localStorage.setItem('oimpresso.route', 'financeiro');</script>
\`\`\`
Wagner abre \`/financeiro/unificado\` → mock abre direto na tela Financeiro (não no Chat default).

## Mapping novo

| Laravel route | cowork_route |
|---|---|
| `/financeiro/unificado` | `financeiro` |
| `/financeiro/fluxo` | `fin-fluxo` |
| `/financeiro/relatorios` | `fin-dre` |
| `/financeiro/boletos` | `boletos` |
| outras | `financeiro` (fallback) |

## Header X-Mock-Route adicionado pra debug

Co-Authored-By: Claude Opus 4.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)