### PR TITLE
feat(financeiro-mock): Integração #2 — POSTs reais (Recebi/Paguei → /baixar Laravel)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/Concerns/RendersMockCowork.php
+++ b/Modules/Financeiro/Http/Controllers/Concerns/RendersMockCowork.php
@@ -103,17 +103,23 @@ trait RendersMockCowork
             }
         }
 
+        // Integração #2: CSRF token meta tag pra bridge-posts.js fazer POST autenticado
+        $csrfToken = csrf_token();
         $injectionHead = <<<HTML
 <base href="/cowork-preview/" />
+  <meta name="csrf-token" content="{$csrfToken}" />
   <script>
-    // Mock Cowork Mode (Wagner 2026-05-18 + Integração #1):
+    // Mock Cowork Mode (Wagner 2026-05-18 + Integrações #1+#2):
     // - localStorage.route abre tela correta
     // - __OIMPRESSO_FIN_REAL__ carrega dados Eloquent do business logado
+    // - meta csrf-token pra bridge-posts.js fazer POST baixa
     try {
       localStorage.setItem('oimpresso.route', '{$coworkRouteEscaped}');
     } catch (e) {}
     window.__OIMPRESSO_FIN_REAL__ = {$realDataJson};
   </script>
+  <!-- Integração #2 oimpresso: bridge POSTs reais (Recebi/Paguei → /financeiro/unificado/{id}/baixar) -->
+  <script src="/cowork-preview/_oimpresso-bridge-posts.js"></script>
 HTML;
 
         if (str_contains($html, '<head>')) {

--- a/public/cowork-preview/_oimpresso-bridge-posts.js
+++ b/public/cowork-preview/_oimpresso-bridge-posts.js
@@ -1,0 +1,82 @@
+/*
+ * _oimpresso-bridge-posts.js — Integração #2 Wagner 2026-05-18
+ *
+ * Bridge: botões "Recebi"/"Paguei" do mock Cowork canon disparam POST real
+ * Laravel /financeiro/unificado/{id}/baixar (cria TituloBaixa em DB).
+ *
+ * Mecanismo:
+ *   1. financeiro-app.jsx handleMark dispatch CustomEvent('oimpresso:fin-mark', { detail: { id } })
+ *      (modificação mínima de 1 linha — fallback try/catch silencioso)
+ *   2. Este bridge escuta o evento, extrai N de "R-N"/"P-N" (CoworkDataMapper format)
+ *   3. Se N é numérico (dados reais Eloquent) → fetch POST /financeiro/unificado/{N}/baixar
+ *   4. Se N é não-numérico (mock template "R-2641a") → só loga, não faz POST
+ *
+ * Tier 0:
+ *   - CSRF token incluso via meta tag
+ *   - Cookie session segue browser default (credentials: same-origin)
+ *   - business_id é session-derived no controller (não trafega)
+ *   - Optimistic UI mantida (mock já atualiza visual via setRows local)
+ *
+ * Reversibilidade: remover script tag inject no trait, comportamento volta
+ * a só localStorage local (sem persistência DB).
+ */
+(function () {
+  'use strict';
+
+  function getCsrfToken() {
+    var meta = document.querySelector('meta[name="csrf-token"]');
+    return meta ? meta.getAttribute('content') : null;
+  }
+
+  function extractLaravelId(rowId) {
+    // Formato CoworkDataMapper: "R-123" ou "P-123" (123 = Titulo.id Eloquent)
+    // Formato mock template: "R-2641a" ou "R-2641c" (não-numérico — não é DB id)
+    var match = /^[RP]-(\d+)$/.exec(String(rowId));
+    return match ? parseInt(match[1], 10) : null;
+  }
+
+  function postBaixar(rowId) {
+    var laravelId = extractLaravelId(rowId);
+    if (laravelId === null) {
+      console.log('[oimpresso] Mock Cowork baixar SKIP (não-numérico, mock template): id=%s', rowId);
+      return;
+    }
+
+    var csrf = getCsrfToken();
+    if (!csrf) {
+      console.warn('[oimpresso] Mock Cowork baixar FALHOU: CSRF token ausente');
+      return;
+    }
+
+    fetch('/financeiro/unificado/' + laravelId + '/baixar', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        'X-CSRF-TOKEN': csrf,
+        'X-Requested-With': 'XMLHttpRequest',
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    })
+    .then(function (resp) {
+      if (resp.ok || resp.status === 302) {
+        console.log('[oimpresso] Mock Cowork baixar OK: id=%s (Laravel id=%d)', rowId, laravelId);
+      } else {
+        console.warn('[oimpresso] Mock Cowork baixar FALHOU: HTTP %d (id=%s)', resp.status, rowId);
+      }
+    })
+    .catch(function (err) {
+      console.warn('[oimpresso] Mock Cowork baixar ERROR:', err && err.message ? err.message : err);
+    });
+  }
+
+  // Listener event canon dispatchado pelo financeiro-app.jsx
+  window.addEventListener('oimpresso:fin-mark', function (e) {
+    var id = e && e.detail && e.detail.id;
+    if (!id) return;
+    postBaixar(id);
+  });
+
+  console.log('[oimpresso] Mock Cowork bridge-posts.js carregado (Integração #2)');
+})();

--- a/public/cowork-preview/financeiro-app.jsx
+++ b/public/cowork-preview/financeiro-app.jsx
@@ -1068,6 +1068,8 @@ const FinanceiroPage = ({ initialTela = "unified" }) => {
 
   const handleMark = useCallback((id) => {
     setRows((rs) => rs.map((r) => r.id === id ? { ...r, paid_at: window.FIN_TODAY, status: r.kind === "receivable" ? "recebido" : "pago" } : r));
+    // Integração #2 oimpresso 2026-05-18: dispatch evento pra bridge fazer POST real Laravel
+    try { window.dispatchEvent(new CustomEvent('oimpresso:fin-mark', { detail: { id } })); } catch (e) {}
   }, []);
 
   const handleMarkAll = useCallback(() => {


### PR DESCRIPTION
## Resumo

Botões mock \"Recebi\"/\"Paguei\" agora disparam POST `/financeiro/unificado/{id}/baixar` real (cria TituloBaixa em DB) preservando UX optimistic.

## Fluxo

1. User clica \"Recebi\" no mock
2. handleMark dispatch CustomEvent('oimpresso:fin-mark', { detail: { id } })
3. Bridge JS escuta evento, extrai ID Laravel de \"R-N\"
4. Fetch POST com CSRF
5. Skip silencioso se ID não-numérico (mock template)

## Modificações

- **NOVO** `public/cowork-preview/_oimpresso-bridge-posts.js` (75 LOC)
- **+1 linha** `financeiro-app.jsx` linha 1070 (dispatch event try/catch)
- **+3 linhas** trait `RendersMockCowork.php` (CSRF meta + script tag)

## Tier 0

✅ CSRF · ✅ session business_id · ✅ Cookie auth · ✅ Skip silencioso ID não-numérico

## Onda paralela

Subagent em background trabalhando Onda #5 (Conferido bridge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)