### PR TITLE
feat(financeiro-mock): Integração #5 — Conferido bridge (toggle → DB)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/Concerns/RendersMockCowork.php
+++ b/Modules/Financeiro/Http/Controllers/Concerns/RendersMockCowork.php
@@ -120,6 +120,8 @@ trait RendersMockCowork
   </script>
   <!-- Integração #2 oimpresso: bridge POSTs reais (Recebi/Paguei → /financeiro/unificado/{id}/baixar) -->
   <script src="/cowork-preview/_oimpresso-bridge-posts.js"></script>
+  <!-- Integração #5 oimpresso: bridge Conferido (toggle → POST/DELETE /financeiro/unificado/{id}/conferir) -->
+  <script src="/cowork-preview/_oimpresso-bridge-conferido.js"></script>
 HTML;
 
         if (str_contains($html, '<head>')) {

--- a/Modules/Financeiro/Tests/Feature/MockOndaConferidoBridgeTest.php
+++ b/Modules/Financeiro/Tests/Feature/MockOndaConferidoBridgeTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Mock Onda 5 — Bridge Conferido (Integração #3) — Wagner 2026-05-18
+ *
+ * Bridge JS espelha o toggle "Conferido" do mock Cowork canon
+ * (FinConferidoToggle em financeiro-curation.jsx) em POST/DELETE Laravel real
+ *   POST   /financeiro/unificado/{id}/conferir   → marca conferido_by/at
+ *   DELETE /financeiro/unificado/{id}/conferir   → limpa conferido_by/at
+ *
+ * Cobre asserts ESTRUTURAIS do arquivo bridge (sem boot da app — Tier 0
+ * safe, smoke estático):
+ *   - Arquivo existe em public/cowork-preview/_oimpresso-bridge-conferido.js
+ *   - Event listener click registrado no document (event delegation)
+ *   - Match seletor .fin-conferido-toggle (CSS class do toggle no JSX)
+ *   - Faz fetch pra /financeiro/unificado/{id}/conferir
+ *   - Inclui CSRF token via meta[name="csrf-token"]
+ *   - Console log diagnóstico canon "Conferido toggle synced"
+ *   - Extrai id Laravel via regex /^[RP]-(\d+)$/ (CoworkDataMapper format)
+ *   - Não toca financeiro-curation.jsx (restrição Tier 0 Wagner)
+ *
+ * Não toca trait RendersMockCowork.php (Wagner consolida bridge scripts
+ * num único PR depois).
+ */
+
+const FIN_BRIDGE_CONFERIDO = __DIR__ . '/../../../../public/cowork-preview/_oimpresso-bridge-conferido.js';
+const FIN_CURATION_JSX = __DIR__ . '/../../../../public/cowork-preview/financeiro-curation.jsx';
+
+describe('Mock Onda 5 — Bridge Conferido (estrutural)', function () {
+    it('arquivo _oimpresso-bridge-conferido.js existe em public/cowork-preview/', function () {
+        expect(file_exists(FIN_BRIDGE_CONFERIDO))->toBeTrue();
+    });
+
+    it('registra event listener click no document (event delegation, capture)', function () {
+        $src = file_get_contents(FIN_BRIDGE_CONFERIDO);
+        expect($src)->toContain("document.addEventListener('click'");
+        // capture: true garante interceptar antes de React rerenderizar
+        expect($src)->toContain('true');
+    });
+
+    it('filtra alvos via .fin-conferido-toggle (CSS class do toggle no JSX)', function () {
+        $src = file_get_contents(FIN_BRIDGE_CONFERIDO);
+        expect($src)->toContain('.fin-conferido-toggle');
+        // closest() é o padrão event-delegation canônico
+        expect($src)->toContain('.closest(');
+    });
+
+    it('faz fetch pra /financeiro/unificado/{id}/conferir', function () {
+        $src = file_get_contents(FIN_BRIDGE_CONFERIDO);
+        expect($src)->toContain('/financeiro/unificado/');
+        expect($src)->toContain('/conferir');
+        expect($src)->toContain('fetch(');
+    });
+
+    it('usa POST pra marcar e DELETE pra desmarcar', function () {
+        $src = file_get_contents(FIN_BRIDGE_CONFERIDO);
+        expect($src)->toContain("'POST'");
+        expect($src)->toContain("'DELETE'");
+        expect($src)->toContain('marcar');
+        expect($src)->toContain('desmarcar');
+    });
+
+    it('inclui CSRF token via meta[name="csrf-token"]', function () {
+        $src = file_get_contents(FIN_BRIDGE_CONFERIDO);
+        expect($src)->toContain("meta[name=\"csrf-token\"]");
+        expect($src)->toContain('X-CSRF-TOKEN');
+    });
+
+    it('usa credentials: same-origin (Tier 0 cookie session)', function () {
+        $src = file_get_contents(FIN_BRIDGE_CONFERIDO);
+        expect($src)->toContain("credentials: 'same-origin'");
+    });
+
+    it('console log diagnóstico canon "Conferido toggle synced"', function () {
+        $src = file_get_contents(FIN_BRIDGE_CONFERIDO);
+        expect($src)->toContain('Conferido toggle synced');
+        expect($src)->toContain('action=%s');
+    });
+
+    it('extrai id Laravel via regex /^[RP]-(\d+)$/ (CoworkDataMapper format)', function () {
+        $src = file_get_contents(FIN_BRIDGE_CONFERIDO);
+        // Regex canônico — extractLaravelId
+        expect($src)->toContain('/^[RP]-(\d+)$/');
+        expect($src)->toContain('extractLaravelId');
+    });
+
+    it('graceful skip pra id não-numérico (mock template "R-2641a")', function () {
+        $src = file_get_contents(FIN_BRIDGE_CONFERIDO);
+        // Loga e retorna sem fetch quando id não bate regex
+        expect($src)->toContain('SKIP');
+        expect($src)->toContain('mock template');
+    });
+
+    it('NÃO modifica financeiro-curation.jsx (restrição Tier 0 Wagner Onda 5)', function () {
+        // Garantia anti-regressão: useFinConferido continua usando localStorage
+        // como fonte primária. Bridge é overlay de persistência, não substitui.
+        $src = file_get_contents(FIN_CURATION_JSX);
+        expect($src)->toContain('oimpresso.financeiro.conferido');
+        expect($src)->toContain('function useFinConferido()');
+        // Nenhuma referência ao endpoint Laravel dentro do JSX
+        expect($src)->not->toContain('/unificado/');
+        expect($src)->not->toContain('fetch(');
+    });
+});
+
+describe('Mock Onda 5 — Endpoints Laravel já existem (sanity)', function () {
+    it('UnificadoController tem método conferir() + unconferir()', function () {
+        $src = file_get_contents(__DIR__ . '/../../Http/Controllers/UnificadoController.php');
+        expect($src)->toContain('public function conferir(');
+        expect($src)->toContain('public function unconferir(');
+        // Tier 0: session('user.business_id') filtra por tenant
+        expect($src)->toContain("session('user.business_id')");
+    });
+
+    it('routes/web.php registra POST/DELETE /unificado/{id}/conferir', function () {
+        $src = file_get_contents(__DIR__ . '/../../routes/web.php');
+        expect($src)->toContain("Route::post('/unificado/{id}/conferir'");
+        expect($src)->toContain("Route::delete('/unificado/{id}/conferir'");
+        expect($src)->toContain("unificado.conferir");
+        expect($src)->toContain("unificado.unconferir");
+    });
+});

--- a/public/cowork-preview/_oimpresso-bridge-conferido.js
+++ b/public/cowork-preview/_oimpresso-bridge-conferido.js
@@ -1,0 +1,128 @@
+/*
+ * _oimpresso-bridge-conferido.js — Integração #3 / Onda 5 Wagner 2026-05-18
+ *
+ * Bridge: toggle "Conferido" do mock Cowork canon (FinConferidoToggle em
+ * financeiro-curation.jsx) dispara POST/DELETE real Laravel
+ *   POST   /financeiro/unificado/{id}/conferir   → marca conferido_by/at
+ *   DELETE /financeiro/unificado/{id}/conferir   → limpa conferido_by/at
+ *
+ * Mecanismo (event delegation, sem modificar JSX):
+ *   1. Listener click no document, filtra alvos com class .fin-conferido-toggle
+ *   2. Lê estado ATUAL (presença de .on) — usuário vai INVERTER esse estado
+ *      - currentlyOn=true  → ação = unmarcar → DELETE
+ *      - currentlyOn=false → ação = marcar   → POST
+ *   3. Extrai row id do drawer ancestral (`.fin-drawer-wide` header tem "R-N" ou "P-N")
+ *      - Match /^[RP]-(\d+)$/ → id Laravel numérico (dados reais Eloquent)
+ *      - Mock template tem IDs tipo "R-2641a" (não-numéricos) → graceful skip
+ *   4. Fetch com CSRF + credentials same-origin (Tier 0 multi-tenant
+ *      preservado: controller filtra por session('user.business_id'))
+ *   5. localStorage local (oimpresso.financeiro.conferido) continua sendo
+ *      atualizado pelo useFinConferido — bridge é OVERLAY de persistência,
+ *      não substitui o estado React local
+ *
+ * Tier 0:
+ *   - CSRF token via meta tag (injetada pelo trait RendersMockCowork)
+ *   - credentials: same-origin (cookie session)
+ *   - business_id filtrado no controller (NUNCA trafega no payload)
+ *   - findOrFail garante que titulo pertence ao business da session
+ *
+ * Reversibilidade: remover script tag inject no trait — comportamento volta
+ * a só localStorage local (sem persistência DB).
+ *
+ * Gotchas conhecidos:
+ *   - ID não-numérico (mock template "R-2641a") → loga e segue só localStorage
+ *   - Sem CSRF token → warn e segue só localStorage
+ *   - 419 (token expirado) / 404 (id não pertence ao business) → warn não-fatal
+ *   - Endpoint retorna RedirectResponse (302) — tratamos como sucesso
+ */
+(function () {
+  'use strict';
+
+  function getCsrfToken() {
+    var meta = document.querySelector('meta[name="csrf-token"]');
+    return meta ? meta.getAttribute('content') : null;
+  }
+
+  function extractLaravelId(rowId) {
+    // Formato CoworkDataMapper: "R-123" / "P-123" (123 = Titulo.id Eloquent)
+    // Formato mock template: "R-2641a" / "R-2641c" (não-numérico — NÃO é DB id)
+    var match = /^[RP]-(\d+)$/.exec(String(rowId));
+    return match ? parseInt(match[1], 10) : null;
+  }
+
+  // Heurística pra ler o row.id da drawer aberta:
+  // O header do drawer tem texto "A receber · R-123" ou "A pagar · P-45".
+  // Pegamos o último token tipo /[RP]-\w+/ visível dentro do drawer ancestral.
+  function findRowIdFromDom(button) {
+    var drawer = button.closest('.fin-drawer-wide, aside[class*="drawer-shown"]');
+    if (!drawer) return null;
+    var headerText = (drawer.textContent || '').slice(0, 400); // só o topo, evita falsos
+    // Procura o primeiro padrão R-N ou P-N (alfanumérico) no header
+    var match = /\b([RP]-[A-Za-z0-9]+)\b/.exec(headerText);
+    return match ? match[1] : null;
+  }
+
+  function syncConferido(rowId, action) {
+    // action: 'marcar' (POST) ou 'desmarcar' (DELETE)
+    var laravelId = extractLaravelId(rowId);
+    if (laravelId === null) {
+      console.log('[oimpresso] Conferido toggle SKIP (não-numérico, mock template): id=%s, action=%s', rowId, action);
+      return;
+    }
+
+    var csrf = getCsrfToken();
+    if (!csrf) {
+      console.warn('[oimpresso] Conferido toggle FALHOU: CSRF token ausente (id=%s)', rowId);
+      return;
+    }
+
+    var method = action === 'marcar' ? 'POST' : 'DELETE';
+
+    fetch('/financeiro/unificado/' + laravelId + '/conferir', {
+      method: method,
+      credentials: 'same-origin',
+      headers: {
+        'X-CSRF-TOKEN': csrf,
+        'X-Requested-With': 'XMLHttpRequest',
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({}),
+    })
+      .then(function (resp) {
+        // Controller retorna RedirectResponse (302) em sucesso;
+        // 200/204 também tratados como ok.
+        if (resp.ok || resp.status === 302) {
+          console.log('[oimpresso] Conferido toggle synced: id=%d, action=%s', laravelId, action);
+        } else {
+          console.warn('[oimpresso] Conferido toggle FALHOU: HTTP %d (id=%d, action=%s)', resp.status, laravelId, action);
+        }
+      })
+      .catch(function (err) {
+        console.warn('[oimpresso] Conferido toggle ERROR:', err && err.message ? err.message : err);
+      });
+  }
+
+  // Event delegation: captura click ANTES do React processar (capture: true).
+  // Estado ATUAL .on reflete pre-click; ação do usuário inverte esse estado.
+  document.addEventListener('click', function (e) {
+    var target = e.target;
+    if (!target || typeof target.closest !== 'function') return;
+
+    var button = target.closest('.fin-conferido-toggle');
+    if (!button) return;
+
+    var currentlyOn = button.classList.contains('on');
+    var action = currentlyOn ? 'desmarcar' : 'marcar';
+
+    var rowId = findRowIdFromDom(button);
+    if (!rowId) {
+      console.log('[oimpresso] Conferido toggle SKIP: row.id não encontrado no drawer DOM');
+      return;
+    }
+
+    syncConferido(rowId, action);
+  }, true);
+
+  console.log('[oimpresso] Mock Cowork bridge-conferido.js carregado (Integração #3 / Onda 5)');
+})();


### PR DESCRIPTION
Consolida PR #1104 (draft subagent): bridge JS + trait inject + Pest. Toggle Conferido do mock agora persiste em DB real via POST/DELETE /financeiro/unificado/{id}/conferir.

Co-Authored-By: Claude Opus 4.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)