### PR TITLE
feat(financeiro-mock): Onda 6 — Edit bridge (Drawer Save → PUT DB real)

### DIFF
--- a/Modules/Financeiro/Tests/Feature/MockOndaEditBridgeTest.php
+++ b/Modules/Financeiro/Tests/Feature/MockOndaEditBridgeTest.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Mock Onda 6 — Bridge Edit (Integração #6) — Wagner 2026-05-18
+ *
+ * Bridge JS espelha o "✓ Salvar" do FinEditPanel (mock Cowork canon
+ * financeiro-curation.jsx) em PUT Laravel real
+ *   PUT /financeiro/unificado/{id}   → atualiza Titulo via UpdateTituloRequest
+ *
+ * Cobre asserts ESTRUTURAIS do arquivo bridge (sem boot da app — Tier 0
+ * safe, smoke estático):
+ *   - Arquivo existe em public/cowork-preview/_oimpresso-bridge-edit.js
+ *   - Event listener registrado pra 'oimpresso:fin-edit' (CustomEvent)
+ *   - Faz fetch PUT /financeiro/unificado/{id}
+ *   - Inclui CSRF token via meta[name="csrf-token"]
+ *   - Console log diagnóstico canon "Edit bridge synced"
+ *   - Extrai id Laravel via regex /^[RP]-(\d+)$/ (CoworkDataMapper format)
+ *   - Graceful skip pra id não-numérico (mock template "R-2641a")
+ *   - Vencimento required guard (evita 422 ruidoso)
+ *   - Categoria nome→id NÃO enviado (gotcha Onda 7)
+ *
+ * JSX modificado em MÍNIMO (1 dispatch event canon no botão Salvar do
+ * FinEditPanel — financeiro-curation.jsx). Restante (panel inputs,
+ * useFinEdits localStorage, applied()) preservado intacto.
+ *
+ * Não toca trait RendersMockCowork.php (Wagner consolida bridge scripts
+ * num único PR depois).
+ */
+
+const FIN_BRIDGE_EDIT = __DIR__ . '/../../../../public/cowork-preview/_oimpresso-bridge-edit.js';
+const FIN_CURATION_JSX_ONDA6 = __DIR__ . '/../../../../public/cowork-preview/financeiro-curation.jsx';
+
+describe('Mock Onda 6 — Bridge Edit (estrutural)', function () {
+    it('arquivo _oimpresso-bridge-edit.js existe em public/cowork-preview/', function () {
+        expect(file_exists(FIN_BRIDGE_EDIT))->toBeTrue();
+    });
+
+    it('registra event listener pra oimpresso:fin-edit (CustomEvent)', function () {
+        $src = file_get_contents(FIN_BRIDGE_EDIT);
+        expect($src)->toContain("window.addEventListener('oimpresso:fin-edit'");
+    });
+
+    it('faz fetch PUT pra /financeiro/unificado/{id}', function () {
+        $src = file_get_contents(FIN_BRIDGE_EDIT);
+        expect($src)->toContain('/financeiro/unificado/');
+        expect($src)->toContain("method: 'PUT'");
+        expect($src)->toContain('fetch(');
+    });
+
+    it('inclui CSRF token via meta[name="csrf-token"]', function () {
+        $src = file_get_contents(FIN_BRIDGE_EDIT);
+        expect($src)->toContain("meta[name=\"csrf-token\"]");
+        expect($src)->toContain('X-CSRF-TOKEN');
+    });
+
+    it('usa credentials: same-origin (Tier 0 cookie session)', function () {
+        $src = file_get_contents(FIN_BRIDGE_EDIT);
+        expect($src)->toContain("credentials: 'same-origin'");
+    });
+
+    it('console log diagnóstico canon "Edit bridge synced"', function () {
+        $src = file_get_contents(FIN_BRIDGE_EDIT);
+        expect($src)->toContain('Edit bridge synced');
+    });
+
+    it('extrai id Laravel via regex /^[RP]-(\d+)$/ (CoworkDataMapper format)', function () {
+        $src = file_get_contents(FIN_BRIDGE_EDIT);
+        expect($src)->toContain('/^[RP]-(\d+)$/');
+        expect($src)->toContain('extractLaravelId');
+    });
+
+    it('graceful skip pra id não-numérico (mock template "R-2641a")', function () {
+        $src = file_get_contents(FIN_BRIDGE_EDIT);
+        expect($src)->toContain('SKIP');
+        expect($src)->toContain('mock template');
+    });
+
+    it('mapeia party → cliente_descricao e dueISO → vencimento (UpdateTituloRequest)', function () {
+        $src = file_get_contents(FIN_BRIDGE_EDIT);
+        expect($src)->toContain('cliente_descricao');
+        expect($src)->toContain('vencimento');
+        // amount → valor_total (preserva guard imutabilidade)
+        expect($src)->toContain('valor_total');
+    });
+
+    it('NÃO envia categoria nome→id (gotcha Onda 7 — backend exige integer ID)', function () {
+        $src = file_get_contents(FIN_BRIDGE_EDIT);
+        // Bridge documenta a omissão explicitamente (não há assignment categoria_id)
+        expect($src)->not->toMatch('/payload\.categoria_id\s*=/');
+    });
+
+    it('vencimento required guard (aborta antes do fetch se ausente)', function () {
+        $src = file_get_contents(FIN_BRIDGE_EDIT);
+        // Guarda anti-422 ruidoso pra payload sem vencimento
+        expect($src)->toContain('vencimento ausente');
+    });
+
+    it('FinEditPanel dispatch CustomEvent oimpresso:fin-edit no botão Salvar', function () {
+        // Modificação mínima JSX (1 linha try/catch) em financeiro-curation.jsx
+        $src = file_get_contents(FIN_CURATION_JSX_ONDA6);
+        expect($src)->toContain("'oimpresso:fin-edit'");
+        expect($src)->toContain('Integração #6 oimpresso 2026-05-18');
+        // Try/catch silencioso preserva comportamento mock se bridge ausente
+        expect($src)->toContain('try {');
+    });
+
+    it('NÃO faz fetch direto no JSX (bridge é overlay, não substitui localStorage)', function () {
+        $src = file_get_contents(FIN_CURATION_JSX_ONDA6);
+        // useFinEdits continua escrevendo no localStorage como fonte primária
+        expect($src)->toContain('oimpresso.financeiro.edits');
+        expect($src)->toContain('function useFinEdits()');
+        // Nenhuma chamada fetch dentro do JSX (overlay puro via event)
+        expect($src)->not->toContain('fetch(');
+    });
+});
+
+describe('Mock Onda 6 — Endpoint Laravel já existe (sanity)', function () {
+    it('UnificadoController tem método update()', function () {
+        $src = file_get_contents(__DIR__ . '/../../Http/Controllers/UnificadoController.php');
+        expect($src)->toContain('public function update(');
+        // Tier 0: session('user.business_id') filtra por tenant
+        expect($src)->toContain("session('user.business_id')");
+        // findOrFail garante isolamento por business
+        expect($src)->toContain('findOrFail');
+    });
+
+    it('routes/web.php registra PUT /unificado/{id}', function () {
+        $src = file_get_contents(__DIR__ . '/../../routes/web.php');
+        expect($src)->toContain("Route::put('/unificado/{id}'");
+        expect($src)->toContain("unificado.update");
+    });
+
+    it('UpdateTituloRequest valida cliente_descricao, observacoes, vencimento, valor_total', function () {
+        $src = file_get_contents(__DIR__ . '/../../Http/Requests/UpdateTituloRequest.php');
+        expect($src)->toContain('cliente_descricao');
+        expect($src)->toContain('observacoes');
+        expect($src)->toContain('vencimento');
+        expect($src)->toContain('valor_total');
+        // Guard de imutabilidade pós-baixa
+        expect($src)->toContain('assertValorMutavel');
+    });
+});

--- a/public/cowork-preview/_oimpresso-bridge-edit.js
+++ b/public/cowork-preview/_oimpresso-bridge-edit.js
@@ -1,0 +1,153 @@
+/*
+ * _oimpresso-bridge-edit.js — Integração #6 / Onda 6 Wagner 2026-05-18
+ *
+ * Bridge: Drawer "Editar campos" (FinEditPanel em financeiro-curation.jsx)
+ * dispara PUT real Laravel ao clicar "✓ Salvar":
+ *   PUT /financeiro/unificado/{id}   → atualiza Titulo via UpdateTituloRequest
+ *
+ * Mecanismo:
+ *   1. financeiro-curation.jsx (FinEditPanel) dispatch CustomEvent
+ *      'oimpresso:fin-edit' com detail = { id, fields, original } no Save
+ *      (modificação mínima de 1 linha — try/catch silencioso)
+ *   2. Este bridge escuta o evento, extrai id Laravel via /^[RP]-(\d+)$/
+ *   3. Se id numérico (dados reais Eloquent) + há campos alterados → PUT
+ *   4. Se id não-numérico (mock template "R-2641a") → loga e segue só localStorage
+ *
+ * Mapping fields (mock JSX → UpdateTituloRequest):
+ *   - party    → cliente_descricao (nullable string)
+ *   - dueISO   → vencimento (required date YYYY-MM-DD)
+ *   - amount   → valor_total (sometimes, numeric, min 0.01)
+ *                Backend guarda imutabilidade pós-baixa via assertValorMutavel()
+ *   - category → categoria_id  (nullable integer — UI tem NOME, backend espera ID)
+ *                Bridge NÃO envia category por padrão (gotcha resolvido no Onda 7).
+ *                Mapping nome→id exigiria endpoint extra ou injectar lista no window.
+ *   - channel  → ignorado (UpdateTituloRequest não aceita; canal é metadata,
+ *                guarda em localStorage local até Onda futura migrar.)
+ *
+ * Tier 0:
+ *   - CSRF token via meta tag (injetada pelo trait RendersMockCowork)
+ *   - credentials: same-origin (cookie session)
+ *   - business_id filtrado no controller (NUNCA trafega no payload)
+ *   - findOrFail garante que titulo pertence ao business da session
+ *
+ * Reversibilidade: remover script tag inject no trait — comportamento volta
+ * a só localStorage local (sem persistência DB). useFinEdits.applied() continua
+ * funcionando como overlay visual mesmo sem bridge.
+ *
+ * Gotchas conhecidos:
+ *   - ID não-numérico (mock template "R-2641a") → loga e segue só localStorage
+ *   - Sem CSRF token → warn e segue só localStorage
+ *   - 419 (token expirado) / 404 (id não pertence ao business) → warn não-fatal
+ *   - 422 valor imutável (status quitado/cancelado) → warn não-fatal
+ *   - Endpoint retorna RedirectResponse (302) — tratamos como sucesso
+ *   - Categoria por nome NÃO sincroniza (Onda 7 — exigirá mapping)
+ */
+(function () {
+  'use strict';
+
+  function getCsrfToken() {
+    var meta = document.querySelector('meta[name="csrf-token"]');
+    return meta ? meta.getAttribute('content') : null;
+  }
+
+  function extractLaravelId(rowId) {
+    // Formato CoworkDataMapper: "R-123" / "P-123" (123 = Titulo.id Eloquent)
+    // Formato mock template: "R-2641a" / "R-2641c" (não-numérico — NÃO é DB id)
+    var match = /^[RP]-(\d+)$/.exec(String(rowId));
+    return match ? parseInt(match[1], 10) : null;
+  }
+
+  // Constrói payload pra PUT /financeiro/unificado/{id} a partir do detail
+  // dispatched pelo JSX. Só inclui campo se VALOR ALTERADO vs original
+  // (minimiza writes; respeita imutabilidade no backend).
+  function buildPayload(fields, original) {
+    var payload = {};
+
+    // vencimento — required, YYYY-MM-DD
+    if (fields.dueISO && /^\d{4}-\d{2}-\d{2}$/.test(fields.dueISO)) {
+      payload.vencimento = fields.dueISO;
+    } else if (original && original.due instanceof Date) {
+      // Required: se user não editou, manda original (UpdateTituloRequest exige)
+      payload.vencimento = original.due.toISOString().slice(0, 10);
+    }
+
+    // cliente_descricao — opcional
+    if (fields.party !== undefined && fields.party !== null) {
+      payload.cliente_descricao = String(fields.party);
+    }
+
+    // valor_total — sometimes, só se alterado (preserva guard de imutabilidade)
+    if (fields.amount !== undefined && fields.amount !== null) {
+      var amount = parseFloat(fields.amount);
+      if (!isNaN(amount) && amount > 0 && (!original || amount !== original.amount)) {
+        payload.valor_total = amount;
+      }
+    }
+
+    // observacoes — opcional (não vem do mock JSX hoje, mas reservado pra evolução)
+    if (fields.observacoes !== undefined && fields.observacoes !== null) {
+      payload.observacoes = String(fields.observacoes);
+    }
+
+    // categoria_id NÃO incluído: mock tem nome ("Banner"), backend exige ID.
+    // Mapping nome→id seria gotcha futuro (Onda 7).
+
+    return payload;
+  }
+
+  function putEdit(rowId, fields, original) {
+    var laravelId = extractLaravelId(rowId);
+    if (laravelId === null) {
+      console.log('[oimpresso] Edit bridge SKIP (não-numérico, mock template): id=%s', rowId);
+      return;
+    }
+
+    var csrf = getCsrfToken();
+    if (!csrf) {
+      console.warn('[oimpresso] Edit bridge FALHOU: CSRF token ausente (id=%s)', rowId);
+      return;
+    }
+
+    var payload = buildPayload(fields || {}, original || null);
+    // Sanity: vencimento é required no backend — se faltou, abortar pra evitar 422 ruidoso
+    if (!payload.vencimento) {
+      console.warn('[oimpresso] Edit bridge SKIP: vencimento ausente (id=%s)', rowId);
+      return;
+    }
+
+    fetch('/financeiro/unificado/' + laravelId, {
+      method: 'PUT',
+      credentials: 'same-origin',
+      headers: {
+        'X-CSRF-TOKEN': csrf,
+        'X-Requested-With': 'XMLHttpRequest',
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    })
+      .then(function (resp) {
+        // Controller retorna RedirectResponse (302) em sucesso;
+        // 200/204 também tratados como ok.
+        if (resp.ok || resp.status === 302) {
+          console.log('[oimpresso] Edit bridge synced: id=%d, fields=%o', laravelId, Object.keys(payload));
+        } else if (resp.status === 422) {
+          console.warn('[oimpresso] Edit bridge 422 (validação ou imutabilidade): id=%d', laravelId);
+        } else {
+          console.warn('[oimpresso] Edit bridge FALHOU: HTTP %d (id=%d)', resp.status, laravelId);
+        }
+      })
+      .catch(function (err) {
+        console.warn('[oimpresso] Edit bridge ERROR:', err && err.message ? err.message : err);
+      });
+  }
+
+  // Listener event canon dispatchado pelo FinEditPanel
+  window.addEventListener('oimpresso:fin-edit', function (e) {
+    var detail = e && e.detail;
+    if (!detail || !detail.id) return;
+    putEdit(detail.id, detail.fields || {}, detail.original || null);
+  });
+
+  console.log('[oimpresso] Mock Cowork bridge-edit.js carregado (Integração #6 / Onda 6)');
+})();

--- a/public/cowork-preview/financeiro-curation.jsx
+++ b/public/cowork-preview/financeiro-curation.jsx
@@ -141,7 +141,13 @@
           <h4>Editar lançamento</h4>
           <div className="fin-edit-actions">
             {has && <button className="fin-edit-reset" onClick={() => edits.reset(row.id)}>↺ Desfazer</button>}
-            <button className="fin-edit-close" onClick={() => setOpen(false)}>
+            <button className="fin-edit-close" onClick={() => {
+              // Integração #6 oimpresso 2026-05-18 — dispatch evento canon pra bridge JS
+              // persistir via PUT /financeiro/unificado/{id} quando há edits válidos.
+              // Try/catch silencioso: bridge ausente não pode quebrar mock visual.
+              try { if (has) window.dispatchEvent(new CustomEvent('oimpresso:fin-edit', { detail: { id: row.id, fields: edits.get(row.id) || {}, original: row } })); } catch (e) {}
+              setOpen(false);
+            }}>
               {has ? "✓ Salvar" : "Fechar"}
             </button>
           </div>


### PR DESCRIPTION
## Summary

Onda 6 do plano canon Wagner 2026-05-18 — bridge JS espelha o "✓ Salvar" do `FinEditPanel` (mock Cowork canon) em `PUT /financeiro/unificado/{id}` real, persistindo edits no DB via `UpdateTituloRequest` existente.

Mesmo padrão das Ondas #2 (Recebi/Paguei — PR #1103) e #5 (Conferido — PR #1105):
- JSX modificação MÍNIMA (1 try/catch dispatch CustomEvent silencioso)
- Bridge JS standalone em `public/cowork-preview/_oimpresso-bridge-edit.js`
- Trait `RendersMockCowork.php` **não tocado** (Wagner consolida bridge scripts num PR único de inject depois)

## Mapping fields (mock JSX → UpdateTituloRequest)

| Mock (FinEditPanel) | UpdateTituloRequest | Notas |
|---|---|---|
| `party` | `cliente_descricao` | nullable string |
| `dueISO` | `vencimento` | required YYYY-MM-DD (guard anti-422) |
| `amount` | `valor_total` | sometimes — `assertValorMutavel()` bloqueia se quitado/cancelado |
| `channel` | _(ignorado)_ | metadata local, backend não aceita |
| `category` | _(NÃO enviado)_ | gotcha Onda 7 — UI tem NOME, backend exige integer ID |

## Tier 0 multi-tenant

- CSRF via `meta[name="csrf-token"]` (injetada pelo trait quando Wagner adicionar a tag bridge-edit no inject consolidado)
- `credentials: 'same-origin'` (cookie session)
- `business_id` **NUNCA trafega** — `findOrFail` no controller filtra por `session('user.business_id')`
- regex `/^[RP]-(\d+)$/` filtra mock template (graceful skip pra `R-2641a`)
- vencimento required guard aborta antes do fetch (evita 422 ruidoso)

## Reversibilidade

Removendo `<script src="_oimpresso-bridge-edit.js">` do trait, comportamento volta a só localStorage local. `useFinEdits.applied()` continua funcionando como overlay visual mesmo sem bridge — mock UX intacta.

## Gotcha reportado (Onda 7)

`category` no JSX é nome ("Banner", "Adesivo") mas `UpdateTituloRequest` exige `categoria_id` (integer existe-where business_id). Mapping nome→id exigiria endpoint extra OU injectar lista de categorias no window. Esta Onda 6 documenta a omissão explicitamente; resolução fica pra Onda 7.

## Test plan

- [x] `Modules/Financeiro/Tests/Feature/MockOndaEditBridgeTest.php` — 14 asserts estruturais (smoke estático, sem boot da app)
- [x] PHP lint sintaxe OK
- [x] Node `--check` sintaxe JS OK
- [ ] CI verde (Pest + lint)
- [ ] Wagner consolida bridge inject no trait (PR separado)
- [ ] Smoke real `/financeiro/unificado` em prod com biz=4 Larissa após inject

🤖 Generated with [Claude Code](https://claude.com/claude-code)