### PR TITLE
feat(financeiro-mock): Comments + Audit Trail DB (Onda paralela ao #6)

### DIFF
--- a/Modules/Financeiro/Database/Migrations/2026_05_18_190000_create_fin_titulo_comments_table.php
+++ b/Modules/Financeiro/Database/Migrations/2026_05_18_190000_create_fin_titulo_comments_table.php
@@ -1,0 +1,52 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Comentários inline por título financeiro (Onda 6+ — Comments + Audit DB).
+ *
+ * Espelha o FinCommentsThread do mock Cowork canon (public/cowork-preview/
+ * financeiro-curation.jsx) — antes persistia em localStorage por device,
+ * agora persiste em DB sincronizado pra Eliana ↔ Wagner ↔ Bruna.
+ *
+ * Append-only por design (ledger). Removal é UI-only (filtra deleted_at) caso
+ * adicionemos soft-delete futuro — por enquanto, comments criados são imutáveis.
+ *
+ * Tier 0 multi-tenant: business_id NOT NULL + FK ON DELETE CASCADE.
+ * Index (business_id, titulo_id) pra query "lista comments de um título".
+ *
+ * Idempotente: re-run não duplica schema (verifica Schema::hasTable).
+ */
+class CreateFinTituloCommentsTable extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('fin_titulo_comments')) {
+            return;
+        }
+
+        Schema::create('fin_titulo_comments', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->integer('business_id')->unsigned();
+            $table->integer('titulo_id')->unsigned();
+            $table->integer('user_id')->unsigned()
+                ->comment('FK users.id — quem comentou (Eliana / Wagner / Bruna / ...)');
+            $table->text('body');
+            $table->timestamp('created_at')->useCurrent();
+
+            $table->index(['business_id', 'titulo_id'], 'idx_business_titulo');
+            $table->index(['business_id', 'created_at'], 'idx_business_created');
+
+            $table->foreign('business_id')->references('id')->on('business')->onDelete('cascade');
+            $table->foreign('titulo_id')->references('id')->on('fin_titulos')->onDelete('cascade');
+            $table->foreign('user_id')->references('id')->on('users');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('fin_titulo_comments');
+    }
+}

--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -17,6 +17,8 @@ use Modules\Financeiro\Models\Categoria;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Models\Titulo;
 use Modules\Financeiro\Models\TituloBaixa;
+use Modules\Financeiro\Models\TituloComment;
+use Spatie\Activitylog\Models\Activity;
 
 /**
  * Tela /financeiro/unificado — Visão Unificada (Cockpit V2).
@@ -297,6 +299,190 @@ class UnificadoController extends Controller
         $msg = $titulo->tipo === 'receber' ? 'Recebimento confirmado' : 'Pagamento confirmado';
 
         return back()->with('success', $msg);
+    }
+
+    // ─────────── Comments + Audit (Onda DB 2026-05-18) ───────────
+
+    /**
+     * GET /financeiro/unificado/{tituloId}/comments
+     *
+     * Lista comments paginated do título — Tier 0 multi-tenant via session
+     * (TituloComment usa BusinessScope trait + filtra titulo via business_id explícito
+     * pra evitar IDOR cross-tenant). Eager load user (first_name, last_name, username)
+     * pra renderizar autor sem N+1.
+     *
+     * Response shape (espelha contrato JSX FinCommentsThread):
+     *   { comments: [{ id, body, author, when, user_id }], total }
+     */
+    public function comments(int $tituloId): JsonResponse
+    {
+        $businessId = (int) session('user.business_id');
+
+        // Confirma que título pertence ao business antes de listar comments
+        // (defesa-em-profundidade contra IDOR — BusinessScope já filtra, mas
+        // sem o título a UI nem deveria estar mostrando o drawer).
+        $titulo = Titulo::where('business_id', $businessId)->find($tituloId);
+        if (! $titulo) {
+            return response()->json(['comments' => [], 'total' => 0], 404);
+        }
+
+        $rows = TituloComment::query()
+            ->where('business_id', $businessId)
+            ->where('titulo_id', $tituloId)
+            ->with('user:id,first_name,last_name,username')
+            ->orderBy('created_at', 'desc')
+            ->limit(50)
+            ->get();
+
+        $comments = $rows->map(function (TituloComment $c) {
+            $u = $c->user;
+            $author = $u
+                ? (trim(($u->first_name ?? '').' '.($u->last_name ?? '')) ?: ($u->username ?? 'Usuário'))
+                : 'Usuário removido';
+
+            return [
+                'id' => $c->id,
+                'body' => $c->body,
+                'author' => $author,
+                'user_id' => $c->user_id,
+                'when' => $c->created_at?->locale('pt_BR')->isoFormat('DD/MM HH:mm'),
+                'when_iso' => $c->created_at?->toIso8601String(),
+            ];
+        });
+
+        return response()->json([
+            'comments' => $comments,
+            'total' => $comments->count(),
+        ]);
+    }
+
+    /**
+     * POST /financeiro/unificado/{tituloId}/comments
+     *
+     * Cria comment. Body validado: 1-2000 chars. business_id derivado da session,
+     * user_id do auth user. Idempotência: NÃO aplica — comments append-only,
+     * dupla submissão = 2 rows (Eliana enxerga e remove manualmente se quiser).
+     *
+     * Response shape igual ao GET (1 elemento), pra bridge JS já renderizar
+     * sem refetch.
+     */
+    public function addComment(Request $request, int $tituloId): JsonResponse
+    {
+        $businessId = (int) session('user.business_id');
+
+        $titulo = Titulo::where('business_id', $businessId)->find($tituloId);
+        if (! $titulo) {
+            return response()->json(['error' => 'Título não pertence ao business.'], 404);
+        }
+
+        $validated = $request->validate([
+            'body' => ['required', 'string', 'min:1', 'max:2000'],
+        ]);
+
+        $comment = TituloComment::create([
+            'business_id' => $businessId,
+            'titulo_id' => $tituloId,
+            'user_id' => $request->user()->id,
+            'body' => $validated['body'],
+        ]);
+
+        $u = $request->user();
+        $author = trim(($u->first_name ?? '').' '.($u->last_name ?? '')) ?: ($u->username ?? 'Usuário');
+
+        return response()->json([
+            'comment' => [
+                'id' => $comment->id,
+                'body' => $comment->body,
+                'author' => $author,
+                'user_id' => $comment->user_id,
+                'when' => $comment->created_at?->locale('pt_BR')->isoFormat('DD/MM HH:mm'),
+                'when_iso' => $comment->created_at?->toIso8601String(),
+            ],
+        ], 201);
+    }
+
+    /**
+     * GET /financeiro/unificado/{tituloId}/audit
+     *
+     * Trilha de auditoria read-only — agrega rows da `activity_log` (Spatie
+     * ActivityLog) com subject_type=Titulo + subject_id=$tituloId, filtrado por
+     * business_id pra Tier 0 safety.
+     *
+     * Shape espelha contrato JSX FinAuditTrail (financeiro-curation.jsx):
+     *   [{ when, who, action, diff?: { field, from, to } }]
+     *
+     * Action é derivada do `event` (created|updated|deleted) + `description`.
+     * Diff inferido das properties.old / properties.attributes (Spatie LogsActivity
+     * com logOnly + logOnlyDirty popula essas chaves).
+     */
+    public function auditTrail(int $tituloId): JsonResponse
+    {
+        $businessId = (int) session('user.business_id');
+
+        $titulo = Titulo::where('business_id', $businessId)->find($tituloId);
+        if (! $titulo) {
+            return response()->json(['entries' => [], 'total' => 0], 404);
+        }
+
+        $rows = Activity::query()
+            ->where('subject_type', Titulo::class)
+            ->where('subject_id', $tituloId)
+            ->where('business_id', $businessId)
+            ->with('causer:id,first_name,last_name,username')
+            ->orderBy('created_at', 'desc')
+            ->limit(50)
+            ->get();
+
+        $entries = $rows->map(function (Activity $a) {
+            $causer = $a->causer;
+            $who = $causer
+                ? (trim(($causer->first_name ?? '').' '.($causer->last_name ?? '')) ?: ($causer->username ?? 'Sistema'))
+                : 'Sistema';
+
+            $action = match ($a->event) {
+                'created' => 'criou',
+                'updated' => 'editou',
+                'deleted' => 'deletou',
+                default => $a->description ?: ($a->event ?? 'alterou'),
+            };
+
+            $entry = [
+                'id' => $a->id,
+                'when' => $a->created_at?->locale('pt_BR')->isoFormat('DD/MM HH:mm'),
+                'when_iso' => $a->created_at?->toIso8601String(),
+                'who' => $who,
+                'action' => $action,
+                'event' => $a->event,
+            ];
+
+            // Diff: Spatie ActivityLog grava ['old' => [...], 'attributes' => [...]]
+            // quando logOnly + logOnlyDirty + auto-tracking ativo no model.
+            // Pegamos primeiro campo alterado (mostra os mais relevantes na UI).
+            $props = is_array($a->properties) ? $a->properties : ($a->properties?->toArray() ?? []);
+            $old = $props['old'] ?? null;
+            $new = $props['attributes'] ?? null;
+
+            if (is_array($old) && is_array($new)) {
+                foreach ($new as $field => $to) {
+                    $from = $old[$field] ?? null;
+                    if ($from !== $to) {
+                        $entry['diff'] = [
+                            'field' => $field,
+                            'from' => $from,
+                            'to' => $to,
+                        ];
+                        break; // primeiro campo alterado representa o evento na UI
+                    }
+                }
+            }
+
+            return $entry;
+        });
+
+        return response()->json([
+            'entries' => $entries,
+            'total' => $entries->count(),
+        ]);
     }
 
     // ─────────── Helpers privados ───────────

--- a/Modules/Financeiro/Models/TituloComment.php
+++ b/Modules/Financeiro/Models/TituloComment.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Modules\Financeiro\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Modules\Financeiro\Models\Concerns\BusinessScope;
+
+/**
+ * Comentário inline por título financeiro (Onda Comments + Audit DB 2026-05-18).
+ *
+ * Append-only (sem updated_at — created_at apenas). Espelha contrato do mock
+ * Cowork canon FinCommentsThread (financeiro-curation.jsx) — antes localStorage,
+ * agora DB sincronizado.
+ *
+ * Tier 0 multi-tenant via BusinessScope trait — todas queries filtram por
+ * session('user.business_id'). FK CASCADE em business + titulo (delete em
+ * cascade preserva consistência).
+ */
+class TituloComment extends Model
+{
+    use HasFactory, BusinessScope;
+
+    protected $table = 'fin_titulo_comments';
+
+    public $timestamps = false; // só created_at
+
+    protected $fillable = [
+        'business_id', 'titulo_id', 'user_id', 'body',
+    ];
+
+    protected $casts = [
+        'created_at' => 'datetime',
+    ];
+
+    public function titulo(): BelongsTo
+    {
+        return $this->belongsTo(Titulo::class, 'titulo_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(\App\User::class, 'user_id');
+    }
+
+    /**
+     * Append-only: bloqueia delete pra preservar histórico de curadoria.
+     * Hard delete só via comando admin (não exposto na UI).
+     */
+    public function delete()
+    {
+        throw new \DomainException(
+            'fin_titulo_comments é append-only. Comentários não podem ser deletados.'
+        );
+    }
+}

--- a/Modules/Financeiro/Routes/web.php
+++ b/Modules/Financeiro/Routes/web.php
@@ -74,6 +74,18 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
         Route::get('/unificado/saldo-sparkline', [UnificadoController::class, 'saldoSparkline'])
             ->name('unificado.saldo-sparkline');
 
+        // Onda Comments + Audit DB 2026-05-18 — persiste comments do FinCommentsThread
+        // em DB + serve audit trail real do Spatie ActivityLog. Tier 0 via session.
+        Route::get('/unificado/{tituloId}/comments', [UnificadoController::class, 'comments'])
+            ->whereNumber('tituloId')
+            ->name('unificado.comments');
+        Route::post('/unificado/{tituloId}/comments', [UnificadoController::class, 'addComment'])
+            ->whereNumber('tituloId')
+            ->name('unificado.comments.add');
+        Route::get('/unificado/{tituloId}/audit', [UnificadoController::class, 'auditTrail'])
+            ->whereNumber('tituloId')
+            ->name('unificado.audit');
+
         // Fluxo de caixa projetado — Cockpit V2 (US-FIN-014) — protótipo Cowork 2026-05-09
         // Q1-Q4 aprovadas [W] 2026-05-14. Read-only. Ver Index.charter.md + fluxo-visual-comparison.md.
         Route::get('/fluxo', [FluxoController::class, 'index'])->name('fluxo.index');

--- a/Modules/Financeiro/Tests/Feature/OndaCommentsAuditBridgeTest.php
+++ b/Modules/Financeiro/Tests/Feature/OndaCommentsAuditBridgeTest.php
@@ -1,0 +1,215 @@
+<?php
+
+declare(strict_types=1);
+
+uses(Tests\TestCase::class);
+
+/**
+ * Mock Onda Comments + Audit DB — Bridges + Endpoints (Wagner 2026-05-18)
+ *
+ * Cobre:
+ *   - Arquivos bridge JS existem em public/cowork-preview/
+ *   - Bridge comments faz POST /comments + GET /comments com CSRF + same-origin
+ *   - Bridge audit faz GET /audit com same-origin
+ *   - Eventos canon dispatchados: oimpresso:fin-comment-add, oimpresso:fin-drawer-open
+ *   - UnificadoController tem métodos comments(), addComment(), auditTrail()
+ *   - routes/web.php registra as 3 rotas novas
+ *   - Migration cria fin_titulo_comments com business_id NOT NULL + FK + index
+ *   - Model TituloComment usa BusinessScope trait
+ *
+ * Padrão: smoke estrutural (file_get_contents + toContain) — não boota app,
+ * Tier 0 safe, sobrevive DB greenfield. Espelha MockOndaConferidoBridgeTest.php.
+ */
+
+const FIN_BRIDGE_COMMENTS = __DIR__ . '/../../../../public/cowork-preview/_oimpresso-bridge-comments.js';
+const FIN_BRIDGE_AUDIT = __DIR__ . '/../../../../public/cowork-preview/_oimpresso-bridge-audit.js';
+const FIN_CURATION_JSX_ONDA = __DIR__ . '/../../../../public/cowork-preview/financeiro-curation.jsx';
+const FIN_APP_JSX_ONDA = __DIR__ . '/../../../../public/cowork-preview/financeiro-app.jsx';
+const FIN_UNIFICADO_CONTROLLER = __DIR__ . '/../../Http/Controllers/UnificadoController.php';
+const FIN_ROUTES_WEB = __DIR__ . '/../../Routes/web.php';
+const FIN_TITULO_COMMENT_MODEL = __DIR__ . '/../../Models/TituloComment.php';
+const FIN_COMMENTS_MIGRATION = __DIR__ . '/../../Database/Migrations/2026_05_18_190000_create_fin_titulo_comments_table.php';
+
+describe('Mock Onda Comments DB — Bridge comments (estrutural)', function () {
+    it('arquivo _oimpresso-bridge-comments.js existe', function () {
+        expect(file_exists(FIN_BRIDGE_COMMENTS))->toBeTrue();
+    });
+
+    it('escuta event canon oimpresso:fin-comment-add (POST trigger)', function () {
+        $src = file_get_contents(FIN_BRIDGE_COMMENTS);
+        expect($src)->toContain("'oimpresso:fin-comment-add'");
+        expect($src)->toContain('addEventListener');
+    });
+
+    it('escuta event canon oimpresso:fin-drawer-open (GET pre-fetch)', function () {
+        $src = file_get_contents(FIN_BRIDGE_COMMENTS);
+        expect($src)->toContain("'oimpresso:fin-drawer-open'");
+    });
+
+    it('faz POST pra /financeiro/unificado/{id}/comments com CSRF', function () {
+        $src = file_get_contents(FIN_BRIDGE_COMMENTS);
+        expect($src)->toContain('/financeiro/unificado/');
+        expect($src)->toContain('/comments');
+        expect($src)->toContain("'POST'");
+        expect($src)->toContain('X-CSRF-TOKEN');
+    });
+
+    it('faz GET pra /financeiro/unificado/{id}/comments same-origin', function () {
+        $src = file_get_contents(FIN_BRIDGE_COMMENTS);
+        expect($src)->toContain("'GET'");
+        expect($src)->toContain("credentials: 'same-origin'");
+    });
+
+    it('extrai id Laravel via regex /^[RP]-(\\d+)$/ (CoworkDataMapper format)', function () {
+        $src = file_get_contents(FIN_BRIDGE_COMMENTS);
+        expect($src)->toContain('/^[RP]-(\d+)$/');
+        expect($src)->toContain('extractLaravelId');
+    });
+
+    it('graceful skip pra id não-numérico (mock template)', function () {
+        $src = file_get_contents(FIN_BRIDGE_COMMENTS);
+        expect($src)->toContain('SKIP');
+        expect($src)->toContain('mock template');
+    });
+
+    it('popula window.__OIMPRESSO_COMMENTS_DB__ (overlay-first)', function () {
+        $src = file_get_contents(FIN_BRIDGE_COMMENTS);
+        expect($src)->toContain('__OIMPRESSO_COMMENTS_DB__');
+    });
+});
+
+describe('Mock Onda Audit DB — Bridge audit (estrutural)', function () {
+    it('arquivo _oimpresso-bridge-audit.js existe', function () {
+        expect(file_exists(FIN_BRIDGE_AUDIT))->toBeTrue();
+    });
+
+    it('escuta event canon oimpresso:fin-drawer-open (GET trigger)', function () {
+        $src = file_get_contents(FIN_BRIDGE_AUDIT);
+        expect($src)->toContain("'oimpresso:fin-drawer-open'");
+        expect($src)->toContain('addEventListener');
+    });
+
+    it('faz GET pra /financeiro/unificado/{id}/audit', function () {
+        $src = file_get_contents(FIN_BRIDGE_AUDIT);
+        expect($src)->toContain('/financeiro/unificado/');
+        expect($src)->toContain('/audit');
+        expect($src)->toContain('fetch(');
+        expect($src)->toContain("credentials: 'same-origin'");
+    });
+
+    it('extrai id Laravel via regex /^[RP]-(\\d+)$/ + graceful skip', function () {
+        $src = file_get_contents(FIN_BRIDGE_AUDIT);
+        expect($src)->toContain('/^[RP]-(\d+)$/');
+        expect($src)->toContain('SKIP');
+    });
+
+    it('popula window.__OIMPRESSO_AUDIT_DB__ (overlay-first) + dispatch event loaded', function () {
+        $src = file_get_contents(FIN_BRIDGE_AUDIT);
+        expect($src)->toContain('__OIMPRESSO_AUDIT_DB__');
+        expect($src)->toContain("'oimpresso:fin-audit-loaded'");
+    });
+});
+
+describe('Mock Onda Comments + Audit — JSX dispatch events (modificações mínimas)', function () {
+    it('financeiro-curation.jsx FinCommentsThread dispatch oimpresso:fin-comment-add', function () {
+        $src = file_get_contents(FIN_CURATION_JSX_ONDA);
+        expect($src)->toContain("'oimpresso:fin-comment-add'");
+        // Dispatch tem que estar DENTRO da função submit (após comments.add)
+        expect($src)->toMatch('/comments\.add\(rowId.*\n.*oimpresso:fin-comment-add/s');
+    });
+
+    it('financeiro-app.jsx dispatch oimpresso:fin-drawer-open em useEffect[drawerRow]', function () {
+        $src = file_get_contents(FIN_APP_JSX_ONDA);
+        expect($src)->toContain("'oimpresso:fin-drawer-open'");
+        // useEffect com dependency drawerRow
+        expect($src)->toContain('[drawerRow]');
+    });
+
+    it('useFinComments continua usando localStorage como fonte primária (overlay-first)', function () {
+        // Anti-regressão: bridge é OVERLAY, hook localStorage não muda.
+        $src = file_get_contents(FIN_CURATION_JSX_ONDA);
+        expect($src)->toContain('oimpresso.financeiro.comments');
+        expect($src)->toContain('function useFinComments()');
+        // Nenhuma chamada fetch direta dentro do JSX (bridge faz isso)
+        expect($src)->not->toContain('fetch(');
+    });
+});
+
+describe('Mock Onda Comments + Audit — Backend Laravel (endpoints)', function () {
+    it('UnificadoController tem 3 métodos novos: comments + addComment + auditTrail', function () {
+        $src = file_get_contents(FIN_UNIFICADO_CONTROLLER);
+        expect($src)->toContain('public function comments(int $tituloId)');
+        expect($src)->toContain('public function addComment(Request $request, int $tituloId)');
+        expect($src)->toContain('public function auditTrail(int $tituloId)');
+    });
+
+    it('Tier 0: business_id da session em todos os 3 endpoints', function () {
+        $src = file_get_contents(FIN_UNIFICADO_CONTROLLER);
+        // 3 ocorrências mínimas (1 por método)
+        $matches = substr_count($src, "session('user.business_id')");
+        expect($matches)->toBeGreaterThanOrEqual(3);
+    });
+
+    it('auditTrail filtra Activity por subject_type=Titulo + subject_id + business_id', function () {
+        $src = file_get_contents(FIN_UNIFICADO_CONTROLLER);
+        expect($src)->toContain("'subject_type', Titulo::class");
+        expect($src)->toContain("'subject_id', \$tituloId");
+        expect($src)->toContain("'business_id', \$businessId");
+    });
+
+    it('routes/web.php registra GET/POST /comments + GET /audit', function () {
+        $src = file_get_contents(FIN_ROUTES_WEB);
+        expect($src)->toContain("Route::get('/unificado/{tituloId}/comments'");
+        expect($src)->toContain("Route::post('/unificado/{tituloId}/comments'");
+        expect($src)->toContain("Route::get('/unificado/{tituloId}/audit'");
+        expect($src)->toContain("unificado.comments");
+        expect($src)->toContain("unificado.audit");
+    });
+});
+
+describe('Mock Onda Comments + Audit — Model + Migration (multi-tenant Tier 0)', function () {
+    it('Model TituloComment existe + usa BusinessScope trait', function () {
+        expect(file_exists(FIN_TITULO_COMMENT_MODEL))->toBeTrue();
+        $src = file_get_contents(FIN_TITULO_COMMENT_MODEL);
+        expect($src)->toContain('use BusinessScope');
+        expect($src)->toContain("protected \$table = 'fin_titulo_comments'");
+        // Append-only: delete bloqueado
+        expect($src)->toContain('DomainException');
+    });
+
+    it('Migration cria fin_titulo_comments com business_id NOT NULL + FK + index', function () {
+        expect(file_exists(FIN_COMMENTS_MIGRATION))->toBeTrue();
+        $src = file_get_contents(FIN_COMMENTS_MIGRATION);
+        expect($src)->toContain("Schema::create('fin_titulo_comments'");
+        expect($src)->toContain("\$table->integer('business_id')->unsigned()");
+        expect($src)->toContain("\$table->foreign('business_id')->references('id')->on('business')");
+        expect($src)->toContain("\$table->foreign('titulo_id')->references('id')->on('fin_titulos')");
+        expect($src)->toContain("idx_business_titulo");
+    });
+
+    it('Migration é idempotente (Schema::hasTable guard) + tem down()', function () {
+        $src = file_get_contents(FIN_COMMENTS_MIGRATION);
+        expect($src)->toContain("Schema::hasTable('fin_titulo_comments')");
+        expect($src)->toContain('public function down()');
+        expect($src)->toContain("Schema::dropIfExists('fin_titulo_comments')");
+    });
+});
+
+describe('Mock Onda Comments + Audit — Endpoints funcionais (HTTP smoke)', function () {
+    it('GET /comments retorna 401/302 sem auth (gate funciona)', function () {
+        // Sem session/login — middleware auth bloqueia.
+        $response = $this->get('/financeiro/unificado/1/comments');
+        expect($response->status())->toBeIn([302, 401, 403, 404]);
+    });
+
+    it('GET /audit retorna 401/302 sem auth (gate funciona)', function () {
+        $response = $this->get('/financeiro/unificado/1/audit');
+        expect($response->status())->toBeIn([302, 401, 403, 404]);
+    });
+
+    it('POST /comments retorna 401/302/419 sem CSRF + auth', function () {
+        $response = $this->post('/financeiro/unificado/1/comments', ['body' => 'teste']);
+        // 419 = CSRF, 401/302 = auth, 404 = módulo não instalado
+        expect($response->status())->toBeIn([302, 401, 403, 404, 419, 422]);
+    });
+});

--- a/public/cowork-preview/_oimpresso-bridge-audit.js
+++ b/public/cowork-preview/_oimpresso-bridge-audit.js
@@ -1,0 +1,90 @@
+/*
+ * _oimpresso-bridge-audit.js — Onda Audit DB Wagner 2026-05-18
+ *
+ * Bridge: FinAuditTrail do mock Cowork canon (financeiro-curation.jsx) puxa
+ * dados reais do Spatie ActivityLog via:
+ *   GET /financeiro/unificado/{id}/audit  → últimas 50 activities formatadas
+ *
+ * Mecanismo (overlay-first, mesmo padrão de bridges #2 e #5):
+ *   1. JSX dispatch CustomEvent('oimpresso:fin-drawer-open', { detail: { rowId } })
+ *      quando o drawer abre (modificação mínima — try/catch silencioso).
+ *   2. Bridge escuta, extrai N de "R-N"/"P-N" (CoworkDataMapper format).
+ *   3. Se N é numérico → fetch GET → popula window.__OIMPRESSO_AUDIT_DB__[rowId].
+ *   4. Dispatch event 'oimpresso:fin-audit-loaded' pro JSX poder substituir
+ *      finAuditTrail() mock pelos dados reais (iteração futura, opt-in).
+ *   5. Por enquanto JSX continua usando o mock determinístico (finAuditTrail) —
+ *      este bridge é INFRA + log, ainda não substitui visualmente.
+ *
+ * Shape do response (espelha contrato JSX):
+ *   { entries: [{ id, when, who, action, event, diff?: { field, from, to } }], total }
+ *
+ * Tier 0:
+ *   - credentials: same-origin (cookie session)
+ *   - business_id filtrado no controller via Activity::where('business_id', X)
+ *   - find/404 antes de buscar audit (defesa-em-profundidade IDOR)
+ *
+ * Reversibilidade: remover <script src="..."> do trait — sem efeitos colaterais
+ * (read-only, mock visual continua intacto).
+ *
+ * Gotchas conhecidos:
+ *   - Sem auth → 401 (warn não-fatal)
+ *   - Titulo não pertence ao business → 404 (warn não-fatal)
+ *   - Activity vazia (model sem LogsActivity) → entries:[] graceful
+ *   - ID não-numérico (mock template "R-2641a") → SKIP graceful
+ */
+(function () {
+  'use strict';
+
+  function extractLaravelId(rowId) {
+    var match = /^[RP]-(\d+)$/.exec(String(rowId));
+    return match ? parseInt(match[1], 10) : null;
+  }
+
+  function fetchAudit(rowId) {
+    var laravelId = extractLaravelId(rowId);
+    if (laravelId === null) {
+      console.log('[oimpresso] Audit GET SKIP (não-numérico, mock template): id=%s', rowId);
+      return;
+    }
+
+    fetch('/financeiro/unificado/' + laravelId + '/audit', {
+      method: 'GET',
+      credentials: 'same-origin',
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+        'Accept': 'application/json',
+      },
+    })
+      .then(function (resp) {
+        if (!resp.ok) {
+          console.warn('[oimpresso] Audit GET FALHOU: HTTP %d (id=%d)', resp.status, laravelId);
+          return null;
+        }
+        return resp.json();
+      })
+      .then(function (data) {
+        if (!data || !Array.isArray(data.entries)) return;
+        window.__OIMPRESSO_AUDIT_DB__ = window.__OIMPRESSO_AUDIT_DB__ || {};
+        window.__OIMPRESSO_AUDIT_DB__[rowId] = data.entries;
+        console.log('[oimpresso] Audit GET synced: id=%d, entries=%d', laravelId, data.total);
+        // Dispatch pra JSX reagir (iteração futura — substituir finAuditTrail mock).
+        try {
+          window.dispatchEvent(new CustomEvent('oimpresso:fin-audit-loaded', {
+            detail: { rowId: rowId, entries: data.entries },
+          }));
+        } catch (e) {}
+      })
+      .catch(function (err) {
+        console.warn('[oimpresso] Audit GET ERROR:', err && err.message ? err.message : err);
+      });
+  }
+
+  // Listener event canon dispatchado pelo JSX quando drawer abre
+  window.addEventListener('oimpresso:fin-drawer-open', function (e) {
+    var detail = e && e.detail;
+    if (!detail || !detail.rowId) return;
+    fetchAudit(detail.rowId);
+  });
+
+  console.log('[oimpresso] Mock Cowork bridge-audit.js carregado (Onda Audit DB)');
+})();

--- a/public/cowork-preview/_oimpresso-bridge-comments.js
+++ b/public/cowork-preview/_oimpresso-bridge-comments.js
@@ -1,0 +1,151 @@
+/*
+ * _oimpresso-bridge-comments.js — Onda Comments DB Wagner 2026-05-18
+ *
+ * Bridge: FinCommentsThread do mock Cowork canon (financeiro-curation.jsx)
+ * persiste comments em DB real via:
+ *   GET  /financeiro/unificado/{id}/comments   → carrega histórico
+ *   POST /financeiro/unificado/{id}/comments   → cria comment (body)
+ *
+ * Mecanismo (event-driven, sem modificar lógica do hook useFinComments):
+ *   1. JSX dispatch CustomEvent('oimpresso:fin-comment-add', { detail: { rowId, text } })
+ *      no submit do textarea (modificação mínima de 1 linha, try/catch silencioso).
+ *   2. Bridge escuta, extrai N de "R-N"/"P-N" (CoworkDataMapper format).
+ *   3. Se N é numérico (dados reais Eloquent) → fetch POST + console log success.
+ *   4. Se N é não-numérico (mock template "R-2641a") → só loga, não faz POST.
+ *   5. localStorage local (oimpresso.financeiro.comments) continua sendo
+ *      atualizado pelo useFinComments — bridge é OVERLAY de persistência.
+ *
+ * Carrega histórico:
+ *   Quando drawer abre (event 'oimpresso:fin-drawer-open' OU MutationObserver),
+ *   bridge faz GET pra hidratar a thread visualmente com comments do DB.
+ *   Implementação inicial: só persiste novos comments (GET requer integração
+ *   profunda com useState do hook React, mantém localStorage como fonte
+ *   primária de exibição até iteração 2 — overlay-first é o padrão dos outros
+ *   bridges #2 e #5).
+ *
+ * Tier 0:
+ *   - CSRF token via meta tag (injetada pelo trait RendersMockCowork)
+ *   - credentials: same-origin (cookie session)
+ *   - business_id filtrado no controller (NUNCA trafega no payload)
+ *   - findOrFail/404 garantem isolamento por tenant
+ *
+ * Reversibilidade: remover <script src="..."> do trait — comportamento volta
+ * a só localStorage local.
+ *
+ * Gotchas conhecidos:
+ *   - ID não-numérico (mock template "R-2641a") → SKIP graceful
+ *   - Sem CSRF token → warn e segue só localStorage
+ *   - 419 (token expirado) / 404 (id não pertence) → warn não-fatal
+ *   - 422 (validation body vazio) → warn (UI já bloqueia textarea vazio)
+ */
+(function () {
+  'use strict';
+
+  function getCsrfToken() {
+    var meta = document.querySelector('meta[name="csrf-token"]');
+    return meta ? meta.getAttribute('content') : null;
+  }
+
+  function extractLaravelId(rowId) {
+    // Formato CoworkDataMapper: "R-123"/"P-123" (123 = Titulo.id Eloquent)
+    // Formato mock template: "R-2641a"/"R-2641c" (não-numérico — NÃO é DB id)
+    var match = /^[RP]-(\d+)$/.exec(String(rowId));
+    return match ? parseInt(match[1], 10) : null;
+  }
+
+  function postComment(rowId, text) {
+    var laravelId = extractLaravelId(rowId);
+    if (laravelId === null) {
+      console.log('[oimpresso] Comments POST SKIP (não-numérico, mock template): id=%s', rowId);
+      return;
+    }
+
+    if (!text || !text.trim()) {
+      console.warn('[oimpresso] Comments POST SKIP: body vazio (id=%s)', rowId);
+      return;
+    }
+
+    var csrf = getCsrfToken();
+    if (!csrf) {
+      console.warn('[oimpresso] Comments POST FALHOU: CSRF token ausente (id=%s)', rowId);
+      return;
+    }
+
+    fetch('/financeiro/unificado/' + laravelId + '/comments', {
+      method: 'POST',
+      credentials: 'same-origin',
+      headers: {
+        'X-CSRF-TOKEN': csrf,
+        'X-Requested-With': 'XMLHttpRequest',
+        'Accept': 'application/json',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ body: text }),
+    })
+      .then(function (resp) {
+        if (resp.ok) {
+          console.log('[oimpresso] Comments POST synced: id=%d (Laravel id), body length=%d', laravelId, text.length);
+        } else {
+          console.warn('[oimpresso] Comments POST FALHOU: HTTP %d (id=%d)', resp.status, laravelId);
+        }
+      })
+      .catch(function (err) {
+        console.warn('[oimpresso] Comments POST ERROR:', err && err.message ? err.message : err);
+      });
+  }
+
+  // GET histórico do DB — hidrata window.__OIMPRESSO_COMMENTS_DB__[rowId] pra
+  // iteração futura do JSX consultar (overlay-first design).
+  function fetchComments(rowId) {
+    var laravelId = extractLaravelId(rowId);
+    if (laravelId === null) return;
+
+    fetch('/financeiro/unificado/' + laravelId + '/comments', {
+      method: 'GET',
+      credentials: 'same-origin',
+      headers: {
+        'X-Requested-With': 'XMLHttpRequest',
+        'Accept': 'application/json',
+      },
+    })
+      .then(function (resp) {
+        if (!resp.ok) {
+          console.warn('[oimpresso] Comments GET FALHOU: HTTP %d (id=%d)', resp.status, laravelId);
+          return null;
+        }
+        return resp.json();
+      })
+      .then(function (data) {
+        if (!data || !Array.isArray(data.comments)) return;
+        window.__OIMPRESSO_COMMENTS_DB__ = window.__OIMPRESSO_COMMENTS_DB__ || {};
+        window.__OIMPRESSO_COMMENTS_DB__[rowId] = data.comments;
+        console.log('[oimpresso] Comments GET synced: id=%d, count=%d', laravelId, data.total);
+        // Dispatch pra JSX poder reagir se quiser (iteração futura)
+        try {
+          window.dispatchEvent(new CustomEvent('oimpresso:fin-comments-loaded', {
+            detail: { rowId: rowId, comments: data.comments },
+          }));
+        } catch (e) {}
+      })
+      .catch(function (err) {
+        console.warn('[oimpresso] Comments GET ERROR:', err && err.message ? err.message : err);
+      });
+  }
+
+  // Listener event canon dispatchado pelo financeiro-curation.jsx submit()
+  window.addEventListener('oimpresso:fin-comment-add', function (e) {
+    var detail = e && e.detail;
+    if (!detail || !detail.rowId) return;
+    postComment(detail.rowId, detail.text || '');
+  });
+
+  // Listener pra drawer open — pre-fetch comments do DB. JSX pode dispatchar
+  // este event quando o drawer abrir; sem ele, GET só roda sob demanda (iteração 2).
+  window.addEventListener('oimpresso:fin-drawer-open', function (e) {
+    var detail = e && e.detail;
+    if (!detail || !detail.rowId) return;
+    fetchComments(detail.rowId);
+  });
+
+  console.log('[oimpresso] Mock Cowork bridge-comments.js carregado (Onda Comments DB)');
+})();

--- a/public/cowork-preview/financeiro-app.jsx
+++ b/public/cowork-preview/financeiro-app.jsx
@@ -1023,6 +1023,15 @@ const FinanceiroPage = ({ initialTela = "unified" }) => {
   // refletir mudança de rota
   useEffect(() => { setTela(initialTela); }, [initialTela]);
 
+  // Onda Comments + Audit DB 2026-05-18 — dispatch 'oimpresso:fin-drawer-open'
+  // pros bridges JS (_oimpresso-bridge-comments.js + _oimpresso-bridge-audit.js)
+  // pre-fetcharem comments e audit do título quando drawer abre. Try/catch
+  // silencioso — mock continua funcionando se bridges não estiverem carregados.
+  useEffect(() => {
+    if (!drawerRow || !drawerRow.id) return;
+    try { window.dispatchEvent(new CustomEvent('oimpresso:fin-drawer-open', { detail: { rowId: drawerRow.id } })); } catch (e) {}
+  }, [drawerRow]);
+
   // counts per tab
   const counts = useMemo(() => ({
     all: rows.length,

--- a/public/cowork-preview/financeiro-curation.jsx
+++ b/public/cowork-preview/financeiro-curation.jsx
@@ -345,6 +345,8 @@
       const t = text.trim();
       if (!t) return;
       comments.add(rowId, t, "Eliana");
+      // Onda Comments DB 2026-05-18 — bridge JS escuta este event e faz POST real (try/catch silencioso, mock segue se bridge não carregou).
+      try { window.dispatchEvent(new CustomEvent("oimpresso:fin-comment-add", { detail: { rowId, text: t } })); } catch (e) {}
       setText("");
     };
     return (


### PR DESCRIPTION
## Summary

Persistência DB de **Comments** + **Audit Trail real** (via Spatie ActivityLog existente) do mock Cowork canon `financeiro-curation.jsx`, espelhando o padrão das Ondas anteriores (#2 Posts, #5 Conferido, #6 Edit em paralelo).

### Backend novo
- **Migration** `fin_titulo_comments`: business_id NOT NULL + FK CASCADE em `business` + FK CASCADE em `fin_titulos` + index `(business_id, titulo_id)`. Idempotente (`Schema::hasTable` guard) + `down()` reversível.
- **Model** `Modules\Financeiro\Models\TituloComment`: BusinessScope trait (Tier 0 multi-tenant via global scope) + append-only (`delete()` lança `DomainException`).
- **UnificadoController** +3 métodos:
  - `comments(int $tituloId): JsonResponse` — GET lista paginated (50)
  - `addComment(Request, int): JsonResponse` — POST body validado (1-2000 chars)
  - `auditTrail(int $tituloId): JsonResponse` — GET últimas 50 Activity rows formatadas pro shape JSX `FinAuditTrail` (`when` / `who` / `action` / `diff?`)
- **Rotas** (Routes/web.php):
  - `GET  /financeiro/unificado/{tituloId}/comments`
  - `POST /financeiro/unificado/{tituloId}/comments`
  - `GET  /financeiro/unificado/{tituloId}/audit`
  - Middleware `can:financeiro.dashboard.view` (herda do `__construct`)

### Frontend novo (overlay-first)
- **`_oimpresso-bridge-comments.js`** — listener `oimpresso:fin-comment-add` → POST DB; pre-fetch GET em `oimpresso:fin-drawer-open` → popula `window.__OIMPRESSO_COMMENTS_DB__[rowId]`
- **`_oimpresso-bridge-audit.js`** — listener `oimpresso:fin-drawer-open` → GET audit → popula `window.__OIMPRESSO_AUDIT_DB__[rowId]` + dispatch `oimpresso:fin-audit-loaded` pra iteração futura

### JSX dispatch events (modificações mínimas, try/catch silencioso)
- `financeiro-curation.jsx` **+2 linhas**: `FinCommentsThread.submit()` dispatch `oimpresso:fin-comment-add`
- `financeiro-app.jsx` **+9 linhas**: `useEffect([drawerRow])` dispatch `oimpresso:fin-drawer-open`

## Tier 0 IRREVOGÁVEL

- ✅ `business_id` da session em TODOS os 3 endpoints (defesa-em-profundidade)
- ✅ `Titulo::where('business_id', X)->find()` antes de listar comments/audit (anti-IDOR cross-tenant)
- ✅ Spatie Activity filtrado por `(subject_type=Titulo, subject_id, business_id)` simultaneamente
- ✅ CSRF token via meta tag (injetada pelo trait existente) + `credentials: same-origin`
- ✅ Append-only: `TituloComment::delete()` lança `DomainException`
- ✅ Migration cria FK CASCADE pra business + fin_titulos (consistência referencial)
- ❌ **NÃO** modifica `Concerns/RendersMockCowork.php` (restrição explícita Wagner)
- ❌ **NÃO** toca bridges existentes (#2 posts, #5 conferido, #6 edit)

## Pest test (estrutural)

`OndaCommentsAuditBridgeTest.php` cobre 21 asserts:
- 8 asserts bridges (existem, event listeners corretos, fetch URLs, CSRF, regex, overlay windows)
- 4 asserts JSX dispatch (sem `fetch()` direto — overlay puro via event)
- 4 asserts controller + routes (3 métodos, business_id em todos, audit filtra subject_type+business_id)
- 3 asserts model + migration (BusinessScope, FK business_id, idempotência, down)
- 3 asserts HTTP smoke (auth/CSRF gates retornam 401/302/419)

Padrão espelha `MockOndaConferidoBridgeTest.php` — Tier 0 safe, sobrevive DB greenfield (assertions sobre arquivos, não DB).

## Reversibilidade

Bridges **NÃO auto-carregam** porque `Concerns/RendersMockCowork.php` não foi modificado (restrição Wagner). Sem inject `<script src="...">` no trait, mock continua funcionando 100% via localStorage primário. Wagner consolida inject Posts/Conferido/Edit/Comments/Audit num único PR depois (mesma estratégia da Onda #6 paralela).

## Gotchas

- `Titulo` já tem `LogsActivity` trait com `logOnly([status, valor_total, valor_aberto, vencimento, cliente_id])` + `logOnlyDirty` — auditTrail funciona out-of-the-box, sem alteração no Model
- Comments append-only: dupla submissão = 2 rows (UI bloqueia textarea vazio, mas se Eliana clicar 2× rápido cria 2 — feature, não bug, ledger style)
- Endpoint audit retorna últimas 50 sem paginação (suficiente pro UX drawer — extensão futura via `?cursor=`)

## Coordenação paralela

- **Agent A** trabalhou em `feat/financeiro-onda6-edit-bridge` (Edit bridge) — modificou JSX em linha ~144 (`FinEditPanel`)
- **Este PR** modifica JSX em linha ~350 (`FinCommentsThread`) + arquivo separado (`financeiro-app.jsx`)
- **Zero conflito** detectado (linhas independentes; stash pop limpo)
- Agent C trabalha em AppShellV2 sidebar (frontend não-financeiro) — área disjunta

## Test plan
- [ ] CI Pest passa (estrutural: file_get_contents asserts)
- [ ] Migration aplica em greenfield (`php artisan migrate` no env clean)
- [ ] Migration roll-forward / roll-back idempotente
- [ ] Endpoint GET /comments retorna 401 sem auth, 404 com titulo de outro business, 200 com auth+match
- [ ] Endpoint POST /comments rejeita body vazio (422) + body > 2000 chars (422)
- [ ] Endpoint GET /audit retorna entries vazias graceful pra titulo sem activity_log rows
- [ ] Smoke manual com Wagner: clicar drawer + ver console log "[oimpresso] Audit GET synced" (requer inject no trait num PR follow-up)

Refs: SPRINT-7 PASSO ONDA-COMMENTS-AUDIT