### PR TITLE
feat(financeiro-mock): Onda #4b — sidebar real respeitando 3 camadas (universal, sem hardcode)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/CoworkSidebarController.php
+++ b/Modules/Financeiro/Http/Controllers/CoworkSidebarController.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Financeiro\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Services\ShellMenuBuilder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Endpoint JSON pro Mock Cowork — sidebar REAL respeitando 3 camadas
+ * habilitação (subscription_package + business.enabled_modules + Spatie
+ * permissions) via reuse do ShellMenuBuilder + AdminSidebarMenu middleware.
+ *
+ * Wagner 2026-05-18: "era para estar filtrando pela empresa selecionada?".
+ * Sim — bridge `_oimpresso-bridge-sidebar.js` agora fetcha esse endpoint
+ * em vez de hardcoded. UNIVERSAL pra todos os businesses — sem hardcode
+ * biz=4 (regra Tier 0 IRREVOGÁVEL ADR 0093).
+ *
+ * Tier 0 garantido por CONSTRUÇÃO:
+ *   - Reusa mesma cadeia do AppShellV2 oimpresso real
+ *   - 3 camadas implícitas via DataController::modifyAdminMenu de cada módulo
+ *   - business_id session-derived (sem confusão tenant)
+ *
+ * PEGADINHA CRÍTICA (catalogada em skill sidebar-menu-arch):
+ *
+ *   AdminSidebarMenu middleware pula `Menu::create()` em request AJAX que
+ *   NÃO tem header `X-Inertia: true`:
+ *
+ *     if ($request->ajax() && ! $request->header('X-Inertia')) {
+ *         return $next($request);  // ← MENU FICA VAZIO
+ *     }
+ *
+ *   Bridge JS precisa enviar `X-Inertia: true` no fetch pra middleware
+ *   popular o Menu antes do controller chamar ShellMenuBuilder.
+ *
+ * Rota: GET /financeiro/cowork-sidebar-data com middleware stack canon
+ * Financeiro `['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu']`.
+ */
+class CoworkSidebarController extends Controller
+{
+    public function __construct(protected ShellMenuBuilder $builder)
+    {
+        $this->middleware('auth');
+    }
+
+    /**
+     * GET /financeiro/cowork-sidebar-data
+     *
+     * Pré-requisito: bridge JS DEVE enviar `X-Inertia: true` no fetch (senão
+     * middleware AdminSidebarMenu pula criação do Menu e retorno vem vazio).
+     *
+     * @return JsonResponse{
+     *   business: array{ id: int, name: string },
+     *   user: array{ name: string, role: ?string },
+     *   menu: array<int, array<string, mixed>>,
+     *   active_module: string
+     * }
+     */
+    public function data(Request $request): JsonResponse
+    {
+        $user = $request->user();
+        $businessId = (int) session('user.business_id', 0);
+        $businessName = (string) session('business.name', '');
+
+        // ShellMenuBuilder reusa Menu populado pelo middleware AdminSidebarMenu
+        // que já rodou no stack da rota (canon). Cada DataController::modifyAdminMenu
+        // de módulo checou 3 camadas (subscription + enabled_modules + Spatie) ANTES
+        // de adicionar items ao Menu. Logo $menu já vem filtrado por business + user.
+        $menu = $this->builder->build($request);
+
+        $userName = '';
+        $userRole = null;
+        if ($user !== null) {
+            $first = (string) ($user->first_name ?? '');
+            $last = (string) ($user->last_name ?? '');
+            $userName = trim($first . ' ' . $last);
+            if ($userName === '') {
+                $userName = (string) ($user->username ?? $user->email ?? '—');
+            }
+            // Spatie role (pode ser sufixada com #biz_id: "Admin#4")
+            $userRole = method_exists($user, 'getRoleNames')
+                ? $user->getRoleNames()->first()
+                : null;
+        }
+
+        return response()->json([
+            'business' => [
+                'id'   => $businessId,
+                'name' => $businessName,
+            ],
+            'user' => [
+                'name' => $userName,
+                'role' => $userRole,
+            ],
+            'menu'          => $menu,
+            'active_module' => 'financeiro', // contexto do Mock Cowork Mode
+            'item_count'    => count($menu),
+        ], 200, [
+            'Cache-Control' => 'private, max-age=60',
+            'X-Mock-Source' => 'CoworkSidebarController::data',
+        ]);
+    }
+}

--- a/Modules/Financeiro/Routes/web.php
+++ b/Modules/Financeiro/Routes/web.php
@@ -74,6 +74,13 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
         Route::get('/unificado/saldo-sparkline', [UnificadoController::class, 'saldoSparkline'])
             ->name('unificado.saldo-sparkline');
 
+        // Onda #4b 2026-05-18 — sidebar REAL pro Mock Cowork (3 camadas universal).
+        // Bridge JS fetcha com header `X-Inertia: true` (senão middleware
+        // AdminSidebarMenu pula criação do Menu).
+        Route::get('/cowork-sidebar-data',
+            [\Modules\Financeiro\Http\Controllers\CoworkSidebarController::class, 'data']
+        )->name('cowork-sidebar-data');
+
         // Onda Comments + Audit DB 2026-05-18 — persiste comments do FinCommentsThread
         // em DB + serve audit trail real do Spatie ActivityLog. Tier 0 via session.
         Route::get('/unificado/{tituloId}/comments', [UnificadoController::class, 'comments'])

--- a/public/cowork-preview/_oimpresso-bridge-sidebar.js
+++ b/public/cowork-preview/_oimpresso-bridge-sidebar.js
@@ -89,24 +89,93 @@
     return node;
   }
 
-  // ─── Shell data: lê __OIMPRESSO_SHELL__ ou fallback ───────────────
+  // ─── Shell data: Onda #4b — fetch REAL respeitando 3 camadas ──────
 
-  function getShellData() {
-    var s = window.__OIMPRESSO_SHELL__ || {};
-    return {
-      business: s.business || { nome: 'Oimpresso', id: 0 },
-      user: s.user || { nome: 'Usuário', cargo: 'Operador' },
-      // Items hardcoded simplificados — Wagner valida visual primeiro,
-      // depois Onda 4b lê s.menu completo via LegacyMenuAdapter.
-      items: s.items || [
-        { label: 'Dashboard', href: '/home', icon: 'home' },
-        { label: 'Vendas',    href: '/sells', icon: 'cart' },
-        { label: 'Compras',   href: '/purchases', icon: 'truck' },
-        { label: 'Financeiro', href: '/financeiro/unificado', icon: 'wallet', active: true },
-        { label: 'CRM',       href: '/crm', icon: 'users' },
-        { label: 'Cadastros', href: '/contacts', icon: 'folder' },
-      ],
-    };
+  /**
+   * Detecta ícone por keyword no label (heurística — Cowork tem ícones limitados).
+   * Mapeia pros 6 SVG inline definidos abaixo. Default: folder.
+   */
+  function iconForLabel(label) {
+    var l = String(label || '').toLowerCase();
+    if (/financeiro|fluxo|dre|boleto|gateway|recorrent|despesa|conta/.test(l)) return 'wallet';
+    if (/cart|vend|venda|orcament|pos/.test(l)) return 'cart';
+    if (/compr|fornec|estoque/.test(l)) return 'truck';
+    if (/cliente|contat|crm|lead/.test(l)) return 'users';
+    if (/dashboard|home|inicio/.test(l)) return 'home';
+    return 'folder';
+  }
+
+  /**
+   * Mapeia ShellMenuItem (LegacyMenuAdapter) pro shape do bridge.
+   * Item canon: { label, icon, href?, inertia, children? }
+   * Vira: { label, href, icon, active }
+   */
+  function mapMenuItem(item, activeModule) {
+    var label = item.label || '';
+    var href = item.href || (item.children && item.children[0] && item.children[0].href) || '#';
+    var icon = iconForLabel(label);
+    var active = false;
+    if (activeModule && /financeiro/i.test(label) && /financeiro/i.test(activeModule)) {
+      active = true;
+    }
+    return { label: label, href: href, icon: icon, active: active };
+  }
+
+  /**
+   * Onda #4b: fetch endpoint Laravel real que respeita 3 camadas:
+   *   (1) subscription_package via ModuleUtil::hasThePermissionInSubscription
+   *   (2) business.enabled_modules
+   *   (3) Spatie permissions auth()->user()->can('X.access')
+   *
+   * CRÍTICO: precisa header `X-Inertia: true` senão middleware AdminSidebarMenu
+   * pula criação do Menu (skill canon `sidebar-menu-arch` documenta pegadinha).
+   *
+   * Retorna Promise<{ business, user, items[] }>.
+   * Em caso de erro, cai pra fallback hardcoded mínimo (não bloqueia render).
+   */
+  function fetchShellData() {
+    return fetch('/financeiro/cowork-sidebar-data', {
+      method: 'GET',
+      credentials: 'same-origin',
+      headers: {
+        'Accept': 'application/json',
+        'X-Inertia': 'true',
+        'X-Requested-With': 'XMLHttpRequest',
+      },
+    })
+    .then(function (resp) {
+      if (!resp.ok) throw new Error('HTTP ' + resp.status);
+      return resp.json();
+    })
+    .then(function (data) {
+      var menu = Array.isArray(data.menu) ? data.menu : [];
+      var items = menu.map(function (m) {
+        return mapMenuItem(m, data.active_module);
+      }).filter(function (i) { return i.label && i.href !== '#'; });
+      return {
+        business: { nome: data.business && data.business.name || 'Oimpresso', id: data.business && data.business.id || 0 },
+        user: { nome: data.user && data.user.name || 'Usuário', cargo: data.user && data.user.role || 'Operador' },
+        items: items.length > 0 ? items : fallbackItems(),
+        fromServer: true,
+      };
+    })
+    .catch(function (err) {
+      console.warn('[oimpresso] Sidebar fetch FALHOU, usando fallback:', err && err.message ? err.message : err);
+      return {
+        business: { nome: 'Oimpresso', id: 0 },
+        user: { nome: 'Usuário', cargo: 'Operador' },
+        items: fallbackItems(),
+        fromServer: false,
+      };
+    });
+  }
+
+  function fallbackItems() {
+    return [
+      { label: 'Dashboard', href: '/home', icon: 'home' },
+      { label: 'Vendas',    href: '/sells', icon: 'cart' },
+      { label: 'Financeiro', href: '/financeiro/unificado', icon: 'wallet', active: true },
+    ];
   }
 
   // ─── Icons SVG inline (cinco ícones, simples) ─────────────────────
@@ -211,34 +280,44 @@
 
   // ─── Mount ────────────────────────────────────────────────────────
 
-  function mount() {
+  function mountAsync() {
     // Defensive: já montado?
     if (document.querySelector('.oim-sidebar')) {
       console.log('[oimpresso] Sidebar wrapper já montado, skip duplicate');
       return;
     }
 
-    var data = getShellData();
-    var aside = buildSidebar(data);
+    // Onda #4b: fetch async dos dados REAIS respeitando 3 camadas
+    fetchShellData().then(function (data) {
+      // Re-check defensive (pode ter sido montado durante o fetch)
+      if (document.querySelector('.oim-sidebar')) return;
 
-    // Insere como primeiro filho do body (antes do #app Cowork)
-    if (document.body.firstChild) {
-      document.body.insertBefore(aside, document.body.firstChild);
-    } else {
-      document.body.appendChild(aside);
-    }
+      var aside = buildSidebar(data);
 
-    // Ativa CSS wrapper — html.oim-sidebar-on
-    document.documentElement.classList.add('oim-sidebar-on');
+      // Insere como primeiro filho do body (antes do #app Cowork)
+      if (document.body.firstChild) {
+        document.body.insertBefore(aside, document.body.firstChild);
+      } else {
+        document.body.appendChild(aside);
+      }
 
-    console.log('[oimpresso] Sidebar wrapper montado (Integração #4 / Onda 4): business=%s, items=%d', data.business.nome, data.items.length);
+      // Ativa CSS wrapper — html.oim-sidebar-on
+      document.documentElement.classList.add('oim-sidebar-on');
+
+      console.log(
+        '[oimpresso] Sidebar wrapper montado (Onda #4b): business=%s, items=%d, source=%s',
+        data.business.nome,
+        data.items.length,
+        data.fromServer ? 'server' : 'fallback'
+      );
+    });
   }
 
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', mount);
+    document.addEventListener('DOMContentLoaded', mountAsync);
   } else {
-    mount();
+    mountAsync();
   }
 
-  console.log('[oimpresso] Mock Cowork bridge-sidebar.js carregado (Integração #4 / Onda 4)');
+  console.log('[oimpresso] Mock Cowork bridge-sidebar.js carregado (Onda #4b — fetch real 3 camadas)');
 })();


### PR DESCRIPTION
## Resumo

Wagner 2026-05-18: "para todos por favor nada de biz=4, não pode hardcode".

Sidebar Onda #4 anterior tinha items hardcoded — violava Tier 0 visual. Onda #4b cria endpoint Laravel real que **REUSA** mesma cadeia do AppShellV2 oimpresso:

```
Bridge JS fetch /financeiro/cowork-sidebar-data (header X-Inertia: true)
  ↓
Middleware AdminSidebarMenu (canon do stack Financeiro)
  ↓
DataController::modifyAdminMenu de cada módulo (3 camadas filter)
  ↓
ShellMenuBuilder::build() → LegacyMenuAdapter
  ↓
CoworkSidebarController retorna JSON
  ↓
Bridge renderiza sidebar filtrado por business + user
```

## Pegadinha catalogada (skill sidebar-menu-arch)

`AdminSidebarMenu` middleware pula `Menu::create()` em request AJAX sem header `X-Inertia: true`. Bridge envia esse header pra middleware popular o Menu antes do controller chamar ShellMenuBuilder.

## Tier 0 universal (sem hardcode biz=N)

- ✅ business_id via session (qualquer business)
- ✅ Spatie permissions via `auth()->user()->can()`
- ✅ 3 camadas: subscription_package + business.enabled_modules + role permissions
- ✅ Larissa @ biz=4 só vê módulos do package dela
- ✅ Wagner @ biz=1 vê o que tem permissão
- ✅ Felipe @ biz=X verá conforme subscription dele

## Reversibilidade preservada (5 camadas)

1. Feature flag `FINANCEIRO_SIDEBAR_WRAP=false` (default OFF) — bridge nem carrega
2. Kill-switch runtime: `localStorage.setItem('__OIMPRESSO_SIDEBAR_OFF__', '1')`
3. Fallback hardcoded mínimo se fetch falhar (Dashboard/Vendas/Financeiro)
4. `gh pr revert 1111` → ~2min
5. Delete bridge file

## Test plan

- [ ] CI: composer + Pest verde
- [ ] Smoke pós-merge com `FINANCEIRO_SIDEBAR_WRAP=true`:
  - Sidebar mostra business name real (não "Oimpresso Matriz")
  - User real (não "Wagner Rocha" hardcoded)
  - Items filtrados por 3 camadas
  - Larissa @ biz=4 vê só módulos contratados

Co-Authored-By: Claude Opus 4.7

🤖 Generated with [Claude Code](https://claude.com/claude-code)