### PR TITLE
revert(financeiro): default mock_cowork_mode + sidebar_wrap = false (volta AppShellV2 nu)

### DIFF
--- a/config/financeiro.php
+++ b/config/financeiro.php
@@ -47,22 +47,49 @@ return [
     |
     | Cherry-pick falhou 4× (PR #1085 → #1091 → #1092 → #1094 → #1095).
     | Adaptação Inertia errou layout o dia inteiro 2026-05-18.
-    | Solução: servir mock canon literal em prod, autorizar mudanças DEPOIS
-    | tela-por-tela.
+    | Solução tentada: servir mock canon literal em prod (default true).
+    |
+    | === REVERT 2026-05-18 noite — DEFAULT FALSE ===
+    |
+    | Wagner pediu volta pro AppShellV2 + sidebar antigo (UltimatePOS canônico),
+    | sem o CSS Cowork novo — "para mim ja funcionaria". 3 PRs falhos cherry-pick
+    | (#1085 → #1091 → #1092) + nova Tier 0 hoje "primeira aplicação Cowork =
+    | copiar styles.css INTEIRO, NUNCA cherry-pick" tornaram caminho mock+wrap
+    | inviável até replanejamento.
+    |
+    | Default false ⇒ controllers caem em Inertia::render normal ⇒ Pages/Financeiro/
+    | *.tsx renderizam dentro de AppShellV2 + sidebar UltimatePOS via DataController
+    | (Tier 0 universal — package_details + Spatie permissions decidem o que aparece,
+    | zero hardcode biz). Larissa @ biz=4 vê módulos do package dela; Felipe @ biz=X
+    | vê conforme dele.
+    |
+    | Reversibilidade 5 camadas (se quebrar):
+    |   1. .env Hostinger: FINANCEIRO_MOCK_COWORK=true (volta mock literal)
+    |   2. .env Hostinger: FINANCEIRO_SIDEBAR_WRAP=true (volta wrap se mock on)
+    |   3. localStorage runtime: __OIMPRESSO_SIDEBAR_OFF__='1' (kill switch JS)
+    |   4. git revert deste commit
+    |   5. Branch claude/financeiro-mock-cowork-mode (snapshot pré-revert)
+    |
+    | Quando voltar pro caminho Cowork: regra Tier 0 nova (proibicoes.md §"Design
+    | System / Pacote Cowork novo") — copiar styles.css INTEIRO 1× + customizar
+    | DEPOIS. Cherry-pick incremental: banido.
     */
-    'mock_cowork_mode' => (bool) env('FINANCEIRO_MOCK_COWORK', true),
+    'mock_cowork_mode' => (bool) env('FINANCEIRO_MOCK_COWORK', false),
 
     /*
     | Sidebar wrap (Onda #4b — sidebar REAL respeitando 3 camadas via
-    | ShellMenuBuilder + AdminSidebarMenu canon). Wagner ativou 2026-05-18.
+    | ShellMenuBuilder + AdminSidebarMenu canon). Wagner ativou 2026-05-18
+    | manhã (PR #1113), DESATIVOU 2026-05-18 noite junto com mock_cowork_mode
+    | (revert pro AppShellV2 nu — ver bloco acima).
     |
-    | Default TRUE em prod desde Onda #4b (PR #1113). Bridge JS fetcha
-    | /financeiro/cowork-sidebar-data e renderiza sidebar oimpresso filtrado
-    | por business + user + Spatie permissions.
+    | Default FALSE: bridge JS sidebar wrap NÃO é injetado (controllers nem
+    | servem mock canon). Pages/Financeiro/*.tsx renderizam dentro de
+    | AppShellV2 que já tem sidebar canônico via DataController.
     |
-    | Kill-switch IRREVOGÁVEL pra reverter:
+    | Kill-switch (quando default era true):
     |   1. FINANCEIRO_SIDEBAR_WRAP=false no .env Hostinger
     |   2. localStorage.setItem('__OIMPRESSO_SIDEBAR_OFF__', '1') runtime
+    |      (linha 55 _oimpresso-bridge-sidebar.js)
     */
     'sidebar_wrap_enabled' => (bool) env('FINANCEIRO_SIDEBAR_WRAP', false),
 


### PR DESCRIPTION
## Summary

Volta `/financeiro/*` pro **AppShellV2 nu** (sidebar UltimatePOS canônico via DataController) — abandona mock+wrap até replanejamento.

Wagner pediu: *"se colocar o appshellv2 novamente com o side antigo. para mim ja funcionaria. sem o css e corrigir o que faltar"*.

## Por que

- **3 PRs cherry-pick falhos** (#1085 → #1091 → #1092) deixaram drawer/painéis quebrados (cores erradas, abas faltando, textos colados).
- Tentativas 4+5 (mock cowork mode + adaptação Inertia) erraram layout 2026-05-18 inteiro.
- **Regra Tier 0 nova hoje** ([proibicoes.md §"Design System / Pacote Cowork novo"](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/proibicoes.md)): primeira aplicação Cowork = **copiar `styles.css` INTEIRO 1×** + customizar DEPOIS. Cherry-pick incremental: banido. Replanejamento Financeiro vai em PR separado.

## O que muda (1 arquivo, +35/-8)

`config/financeiro.php`:

- `mock_cowork_mode` default `true` → `false` (trait `RendersMockCowork` retorna `null`, controllers caem em `Inertia::render` normal → `Pages/Financeiro/*.tsx` dentro de `AppShellV2`)
- `sidebar_wrap_enabled` default `true` → `false` (bridge JS sidebar wrap não injetado; órfão sem mock anyway — só pra higiene)

## Tier 0 multi-tenant — universal

- Zero hardcode `biz=N`.
- Larissa @ biz=4 vê módulos do package dela via `DataController` + `package_details` + Spatie permissions (3 camadas canônicas).
- Felipe @ biz=X idem conforme dele.
- Compliance [ADR 0093 Multi-tenant Tier 0](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0093-multi-tenant-isolation-tier-0.md).

## Reversibilidade (5 camadas)

1. `.env` Hostinger: `FINANCEIRO_MOCK_COWORK=true` (volta mock literal)
2. `.env` Hostinger: `FINANCEIRO_SIDEBAR_WRAP=true` (volta wrap se mock on)
3. localStorage runtime: `__OIMPRESSO_SIDEBAR_OFF__='1'` (kill switch JS — linha 55 `_oimpresso-bridge-sidebar.js`)
4. `git revert` deste commit
5. Branch origem antes deste commit (snapshot pré-revert)

## NÃO afeta

- **POST** `/financeiro/unificado/{id}/baixar|conferir|edit` — bridges JS não passam pelo trait. Continuam funcionando.
- **Mock Cowork** (`public/cowork-preview/*.html` + bridges) — preservados pra reativação futura via env var.
- **Pest** `MockCoworkModeTest` + `MockOnda*` — validam config key + trait existe; não validam valor default → verde.

## Infra Contract (smoke prod pós-deploy)

| Hop | Esperado | Status |
|---|---|---|
| `curl -sv https://oimpresso.com/financeiro/unificado` (Larissa biz=4 logada) | `HTTP/2 200`, ausência de `X-Mock-Cowork` header, HTML contém `<div id="app">` Inertia (não `<base href="/cowork-preview/">`) | ⏳ pós-deploy Wagner |
| `curl -sv https://oimpresso.com/financeiro/fluxo` (Wagner biz=1) | idem + sidebar UltimatePOS no HTML | ⏳ pós-deploy Wagner |
| Chrome MCP screenshot `/financeiro/unificado` biz=4 | layout AppShellV2 3-colunas + sidebar real | ⏳ pós-deploy Wagner |
| Regression adjacent: `/cockpit`, `/pos/sells` | inalterados | ⏳ pós-deploy Wagner |

**Smoke prod fica condicionado a Wagner pós-merge+deploy SSH** — R1 do protocolo: não declaro "funcionando" sem `curl -sv` real. CI roda Pest no GitHub Actions (gate Module Grades + governance + mwart-gate aplicam).

## Test plan

- [ ] CI Pest verde (MockCoworkModeTest + MockOnda* + Module Grades baseline)
- [ ] Wagner merge + `git pull` Hostinger
- [ ] `php artisan optimize:clear` + `php artisan config:cache` em prod
- [ ] curl -sv `https://oimpresso.com/financeiro/unificado` retorna 200 sem `X-Mock-Cowork`
- [ ] Chrome MCP screenshot Larissa biz=4 → confirma AppShellV2 + sidebar UltimatePOS

Refs: [proibicoes.md §"Design System / Pacote Cowork novo"](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/proibicoes.md) 2026-05-18