### PR TITLE
docs(memory): apêndice Plano B revert AppShellV2 nu + BRIEFING Financeiro

### DIFF
--- a/memory/reference/feedback-cowork-bundle-aplicar-inteiro.md
+++ b/memory/reference/feedback-cowork-bundle-aplicar-inteiro.md
@@ -77,4 +77,53 @@ Próxima vez que Wagner pedir aplicação Cowork de módulo NOVO:
 
 ---
 
-**Última atualização:** 2026-05-18 (Wagner)
+## Apêndice — Plano B canônico (revert pro shell nu) 2026-05-18 noite
+
+Quando cherry-pick Cowork falha 3+ vezes no mesmo módulo E não há tempo/disposição pra fazer bundle copy inteiro AGORA, a saída pragmática é **reverter pro `AppShellV2` nu + sidebar UltimatePOS canônico via DataController + flag default false no config**, até estar pronto pra fazer bundle copy direito.
+
+**Não é desistência** — é estancar a sangria visual de um módulo crítico (Financeiro tem Eliana usando dia a dia) sem se comprometer com 4ª/5ª tentativa cherry-pick que vai falhar igual.
+
+### Pattern do revert (validado PR [#1115](https://github.com/wagnerra23/oimpresso.com/pull/1115) Financeiro 2026-05-18 noite)
+
+1. **Flag canônica no config do módulo** — `config/<modulo>.php` tem 2 defaults:
+   - `mock_cowork_mode` (controllers retornam HTML literal do bundle Cowork via trait `RendersMockCowork`)
+   - `sidebar_wrap_enabled` (bridge JS injeta sidebar wrap no mock)
+2. **Revert = trocar defaults pra `false`** + manter env vars `FINANCEIRO_MOCK_COWORK` / `FINANCEIRO_SIDEBAR_WRAP` pra reversibilidade futura
+3. **Não deletar artefatos** — preserva `public/cowork-preview/*.html`, bridges JS, trait, `Pages/Financeiro/_components/Fin*.tsx`. Tudo dormente, ativável via `.env` quando bundle copy estiver pronto.
+4. **PR pequeno** — só `config/<modulo>.php` (Financeiro: +35/-8). Não mexer em Pages/Controllers (já compatíveis com ambos caminhos via trait `if-null-return`).
+5. **Comentário do config explica os 2 caminhos + 5 camadas de reversibilidade** — futuro Claude/dev entende decisão sem precisar reler 3 PRs falhos.
+
+### Reversibilidade 5 camadas (canon)
+
+1. `.env` produção: `FINANCEIRO_MOCK_COWORK=true` (volta mock literal)
+2. `.env` produção: `FINANCEIRO_SIDEBAR_WRAP=true` (volta wrap se mock on)
+3. localStorage runtime: `__OIMPRESSO_SIDEBAR_OFF__='1'` (kill switch JS — bridge respeita; linha 55 `_oimpresso-bridge-sidebar.js`)
+4. `git revert` do commit do revert
+5. Branch/tag snapshot pré-revert preservada
+
+### Critério de evidência (smoke pós-deploy)
+
+- `curl -sv https://oimpresso.com/<rota_modulo> 2>&1 | grep -iE '^< (HTTP|X-Mock)'`
+  - **Esperado:** ausência do header `X-Mock-Cowork: 1` (que o trait injetava quando ativo)
+  - Esperado: comportamento idêntico a rota Inertia não-mockada (ex: `/pos/sells` redirecionando 302 → `/login` quando não autenticado)
+- Validação `bootstrap/cache/config.php` literal: `'mock_cowork_mode' => false,`
+- Chrome MCP screenshot logado biz=4 (Larissa) + biz=1: AppShellV2 + sidebar UltimatePOS canônica renderiza
+
+### Quando ATIVAR Plano B vs insistir cherry-pick
+
+| Sinal | Decisão |
+|---|---|
+| 2 PRs cherry-pick falharam visualmente + Wagner reabriu gap | Insiste só se a 3ª falha for SÓ 1-2 classes faltando |
+| 3+ PRs cherry-pick falharam + Wagner pediu pausa | **ATIVAR Plano B** — não tentar 4ª. Bundle copy fica em PR separado |
+| Wagner diz "tira o css e me devolve o que funcionava" | **ATIVAR Plano B imediatamente** — não negociar mais cherry-pick |
+| Cliente piloto reporta "tela quebrada" e produção tá com mock on | **ATIVAR Plano B emergência** — `.env FINANCEIRO_MOCK_COWORK=false` + cache:clear até PR revert mergear |
+
+### Vínculo com outras regras
+
+- Regra principal deste arquivo (bundle copy inteiro 1ª vez): **continua valendo** — Plano B só pausa até estar pronto pra fazer bundle copy direito
+- Tier 0 universal preservado: sem hardcode `biz=N`. AppShellV2 + DataController + `package_details` + Spatie permissions decidem o que aparece (3 camadas — ver `proibicoes.md §Multi-tenant Tier 0`)
+- Não conflita com [ADR 0104 MWART canônico](../decisions/0104-processo-mwart-canonico-unico-caminho.md) — Pages MWART continuam onde estavam, só o caminho mock/wrap fica off
+
+---
+
+**Última atualização:** 2026-05-18 noite (Wagner) — Plano B canon após [PR #1115](https://github.com/wagnerra23/oimpresso.com/pull/1115) revert Financeiro

--- a/memory/requisitos/Financeiro/BRIEFING.md
+++ b/memory/requisitos/Financeiro/BRIEFING.md
@@ -2,7 +2,23 @@
 
 > Visão unificada de AR/AP (Contas a Receber / Contas a Pagar) + Fluxo de Caixa + Boletos + Conciliação. Cockpit V2 persona Eliana [E] (financeiro escritório, densidade alta, atalhos teclado).
 
-**Última atualização:** 2026-05-18 · Onda Edit PR #1086 (Edit Sheet inline + Conferido per-user DB + cross-links auto-pop) · Skill `brief-update` (Tier B)
+**Última atualização:** 2026-05-18 noite · **PR [#1115](https://github.com/wagnerra23/oimpresso.com/pull/1115) — Revert Plano B AppShellV2 nu** (default `mock_cowork_mode=false` + `sidebar_wrap_enabled=false`) · Skill `brief-update` (Tier B)
+
+## Estado UI 2026-05-18 noite — AppShellV2 nu (Plano B canon)
+
+`/financeiro/*` voltou pro **AppShellV2 + sidebar UltimatePOS canônico** via `DataController` + `package_details` + Spatie permissions (Tier 0 universal, zero hardcode biz). Pages Inertia `Pages/Financeiro/*.tsx` renderizam direto — controllers caem em `Inertia::render` normal porque trait `RendersMockCowork::tryRenderMockCowork()` retorna `null`.
+
+**Por que:** 3 PRs cherry-pick Cowork falhos (#1085 → #1091 → #1092) + tentativas 4-5 mock+wrap erraram layout 2026-05-18 inteiro. Regra Tier 0 nova (`proibicoes.md §Design System / Pacote Cowork novo`): primeira aplicação Cowork = bundle copy `styles.css` INTEIRO 1×, sem cherry-pick. Replanejamento Cowork Financeiro fica em PR separado quando estiver pronto pra bundle copy direito.
+
+**Reversibilidade 5 camadas** (canon em [feedback-cowork-bundle-aplicar-inteiro.md §Apêndice Plano B](../../reference/feedback-cowork-bundle-aplicar-inteiro.md)): env var `FINANCEIRO_MOCK_COWORK=true` / `FINANCEIRO_SIDEBAR_WRAP=true` / `localStorage __OIMPRESSO_SIDEBAR_OFF__='1'` / git revert / branch snapshot.
+
+**Smoke prod validado** (2026-05-18 noite pós-merge):
+- `bootstrap/cache/config.php` literal: `'mock_cowork_mode' => false,` + `'sidebar_wrap_enabled' => false,`
+- `curl -sv /financeiro/{unificado,fluxo,boletos}` → 302 `/login` **sem header `X-Mock-Cowork`** (antes era `X-Mock-Cowork: 1` injetado pelo trait)
+- Regression `/pos/sells` 302 → inalterado
+- Visual logado biz=4/biz=1: pendente Wagner (Chrome MCP ou validação manual)
+
+**Artefatos Cowork preservados** (dormentes, reativáveis): `public/cowork-preview/*.html`, bridges JS (`_oimpresso-bridge-*.js`), trait `RendersMockCowork`, componentes `Pages/Financeiro/_components/Fin*.tsx`. NÃO deletados — Plano B é pausa, não desistência.
 
 ## Estado consolidado (Wave 18 RETRY — saturação 68→97)
 


### PR DESCRIPTION
## Summary

Cataloga a decisão do PR #1115 (revert Financeiro `mock_cowork_mode` default false) como **pattern canônico reutilizável** pra futuros casos onde cherry-pick Cowork falha 3+ vezes e bundle copy inteiro não está pronto.

Wagner: *"lembre no memoria"*.

## Mudanças

### `memory/reference/feedback-cowork-bundle-aplicar-inteiro.md`

Novo **Apêndice "Plano B canônico (revert pro shell nu) 2026-05-18 noite"** — extensão natural do feedback principal (mesma origem, mesmo dia, Wagner mesmo cliente piloto Financeiro). Conteúdo:

- Pattern do revert validado em [PR #1115](https://github.com/wagnerra23/oimpresso.com/pull/1115) — 5 passos canônicos (flag no config, mudar 2 defaults, não deletar artefatos, PR pequeno só config, comentário explicativo)
- Reversibilidade 5 camadas formalizada (`.env × 2` / localStorage `__OIMPRESSO_SIDEBAR_OFF__` / git revert / branch snapshot)
- Critério de evidência canônico (curl `X-Mock-Cowork` ausente + `bootstrap/cache/config.php` literal `'mock_cowork_mode' => false,`)
- **Matriz "quando ATIVAR Plano B vs insistir cherry-pick"** — 4 sinais explícitos
- Regra principal (bundle copy inteiro 1ª vez) continua válida — Plano B só pausa até bundle copy direito

### `memory/requisitos/Financeiro/BRIEFING.md`

Nova seção **"Estado UI 2026-05-18 noite — AppShellV2 nu (Plano B canon)"** logo após a "Última atualização":

- Estado atual: AppShellV2 + sidebar UltimatePOS canônico via DataController (Tier 0 universal, zero hardcode biz)
- Por que (3 PRs falhos + regra Tier 0 nova proibições.md)
- Reversibilidade 5 camadas (ponteiro pro feedback canon)
- Smoke prod validado (config cache literal + curl 302 sem `X-Mock-Cowork` + regression `/pos/sells`)
- Artefatos Cowork preservados dormentes (`public/cowork-preview/`, bridges JS, trait, componentes Fin*.tsx — não deletados)

## Não afeta código

Só docs canônicos. Skill `memory-sync` (Tier B) propagam via webhook GitHub → MCP server (`mcp.oimpresso.com`), time inteiro (Felipe/Maiara/Eliana/Luiz) passa a enxergar via `mcp__oimpresso__decisions-search` etc.

## Test plan

- [ ] CI verde (governance-gate verifica memory/* não tem ADRs canon sendo editadas — só feedback + briefing, OK)
- [ ] Merge
- [ ] Webhook GitHub→MCP sincroniza `memory/reference/feedback-cowork-bundle-aplicar-inteiro.md` + `memory/requisitos/Financeiro/BRIEFING.md`

Refs: [PR #1115](https://github.com/wagnerra23/oimpresso.com/pull/1115), [proibicoes.md §"Design System / Pacote Cowork novo"](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/proibicoes.md)