### PR TITLE
fix(financeiro-css): desativa imports Cowork não-escopados que quebram AppShellV2

### DIFF
--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -30,32 +30,45 @@
 @import "./sells-cowork-subscriptions.css";
 
 /* ============================================================================
- * FINANCEIRO — Design System Cowork
+ * FINANCEIRO — Design System Cowork — DESATIVADO 2026-05-18 noite (Plano B)
  *
- * Ordem de importação canônica (Wagner regra 2026-05-18, feedback-cowork-bundle-aplicar-inteiro.md):
- *   1. cowork-financeiro-bundle.css (BASE CANÔNICA — bundle integral 9054 LOC)
- *   2. fin-curadoria.css / fin-ia.css / fin-output.css / fin-cowork.css (OVERRIDES locais)
+ * Os 5 @import abaixo foram DESLIGADOS porque o bundle
+ * cowork-financeiro-bundle.css (9083 LOC) NÃO É ESCOPADO — define GLOBALS
+ * (`*`, `html`, `body`, `#app`, `:root`) nas linhas 31/103/104/105 que
+ * SOBRESCREVEM o grid 3-colunas do AppShellV2 (260+1fr+320) e quebram o
+ * layout de /financeiro/unificado quando rodando fora do mock.
  *
- * Bundle PRIMEIRO garante que TODAS as 123 classes .fin-* + 138 .vd-* + utilities
- * carregam. Overrides DEPOIS permitem cherry-picks históricos vencer onde diferem.
+ * Diferença com Sells: `sells-cowork*.css` é ESCOPADO em `.sells-cowork`
+ * prefix (script scripts/scope-sells-cowork-css.py). Bundle Financeiro
+ * chegou inteiro sem prefix por design — pra rodar dentro do mock literal
+ * que serve como SHELL próprio (`<base href="/cowork-preview/">`), não
+ * dentro do AppShellV2.
  *
- * Próxima onda: deprecar overrides locais conforme bundle absorve customizações.
+ * Plano B canon (memory/reference/feedback-cowork-bundle-aplicar-inteiro.md
+ * §Apêndice "Plano B canônico"): primeira aplicação Cowork no Financeiro
+ * fica em PR futuro quando estiver pronto pra:
+ *   (a) wrap script Python prefixar .fin-cowork em TODAS classes do bundle,
+ *   (b) wrap <div className="fin-cowork"> em todas Pages/Financeiro/*.tsx,
+ *   (c) smoke biz=1 + biz=4 validando AppShellV2 intacto.
+ *
+ * Por enquanto Pages/Financeiro/*.tsx renderizam com shadcn/Tailwind nativo
+ * (igual Modules/Crm, Cockpit) dentro do AppShellV2 canônico. Classes .fin-*
+ * usadas nos JSX (.fin-row, .fin-drawer-tabs, .fin-card-kpi etc) ficam sem
+ * estilo até o wrap escopado existir.
+ *
+ * Arquivos CSS preservados em resources/css/ (NÃO deletados):
+ *   - cowork-financeiro-bundle.css (9083 LOC bundle)
+ *   - fin-curadoria.css / fin-ia.css / fin-output.css / fin-cowork.css
+ *
+ * Reativação: descomentar os 5 @import abaixo + adicionar wrap escopado.
  * ============================================================================ */
 
-/* Cowork bundle integral — base canônica do Design System (123 .fin-* classes) */
-@import "./cowork-financeiro-bundle.css";
-
-/* Override Onda 5 R1 Curadoria — escopado em .fin-curadoria (Conferido + Comments + Audit + Frescor) */
-@import "./fin-curadoria.css";
-
-/* Override Onda 6 R2 IA — escopado em .fin-curadoria (Anomaly + PartyHistory + MonthDigest) */
-@import "./fin-ia.css";
-
-/* Override Onda 7/7b/7c/9 — dialogs (CrossLinkify + Checklist Fechamento + Troubleshooter + PresentationMode + TranscriptPDF + Resume) */
-@import "./fin-output.css";
-
-/* Override Onda 8/8b — F1 page rewrite (header + hero KPI sparkline + filter chips + footer atalhos) */
-@import "./fin-cowork.css";
+/* DESATIVADO 2026-05-18 noite — bundle não-escopado quebra AppShellV2 */
+/* @import "./cowork-financeiro-bundle.css"; */
+/* @import "./fin-curadoria.css"; */
+/* @import "./fin-ia.css"; */
+/* @import "./fin-output.css"; */
+/* @import "./fin-cowork.css"; */
 
 @theme {
   --font-sans: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;


### PR DESCRIPTION
## Summary

**Plano B Parte 2** — após [PR #1115](https://github.com/wagnerra23/oimpresso.com/pull/1115) reverter `mock_cowork_mode=false`, `/financeiro/unificado` renderizava Inertia normal MAS com **layout quebrado**: bundle Cowork financeiro tem GLOBALS sem escopo que sobrescrevem o grid do AppShellV2.

Wagner reportou: *"esta errado o layout. deve ter alguma conflito ou o SIdeBar ou o Financeiro fica quebrado. https://oimpresso.com/financeiro/unificado — o Mock fica perfeito."*

## Diagnóstico

`resources/css/cowork-financeiro-bundle.css` (9083 LOC) define **CSS GLOBAL sem escopo**:

| Linha | Seletor | Efeito |
|---|---|---|
| 31 | `:root { ... }` | redefine CSS vars do projeto |
| 103 | `*{ box-sizing: border-box; }` | reset universal (já no Tailwind, mas conflita) |
| 104 | `html, body, #app { height: 100%; margin: 0; }` | **força body 100% — quebra grid AppShellV2** |
| 105 | `body { background, font, layout }` | sobrescreve theme do AppShellV2 |
| 6381 | `:root { ... }` | segundo override |

`inertia.css` importava o bundle SEM wrap `.fin-cowork`. **Diferença com Sells:** `sells-cowork*.css` é ESCOPADO em `.sells-cowork` prefix (`scripts/scope-sells-cowork-css.py`). Bundle Financeiro chegou inteiro sem prefix por design — pra rodar **dentro do mock literal** que é shell próprio (`<base href=\"/cowork-preview/\">`), não dentro do AppShellV2.

Por isso o **mock fica perfeito** (não usa inertia.css) e o **AppShellV2 nu quebra** (recebe os globals).

## Fix (1 arquivo, +34/-21)

`resources/css/inertia.css`: comenta os 5 `@import` do bloco Financeiro:

\`\`\`css
/* DESATIVADO 2026-05-18 noite — bundle não-escopado quebra AppShellV2 */
/* @import \"./cowork-financeiro-bundle.css\"; */
/* @import \"./fin-curadoria.css\"; */
/* @import \"./fin-ia.css\"; */
/* @import \"./fin-output.css\"; */
/* @import \"./fin-cowork.css\"; */
\`\`\`

Comentário extenso explicando causa raiz + reativação no futuro (Plano B canon).

## Efeito

✅ Pages/Financeiro/*.tsx renderizam com shadcn/Tailwind nativo (igual `Modules/Crm`, Cockpit) dentro do AppShellV2 canônico — sidebar UltimatePOS via DataController, layout 3-colunas intacto.

⚠️ Classes `.fin-row`, `.fin-drawer-tabs`, `.fin-card-kpi` etc usadas nos JSX ficam **SEM estilo** até bundle ser reescopado. **Funcional mas visual incompleto** — Wagner aceita explicitamente.

✅ **Mock Cowork preservado** (env var `FINANCEIRO_MOCK_COWORK=true` continua servindo HTML literal — mock segue perfeito).

✅ Sells (`sells-cowork*.css` escopados) — inalterados.

✅ Arquivos CSS preservados em `resources/css/` — não deletados, reativáveis.

## Reativação futura (Plano B canon §Apêndice)

1. Wrap script Python prefixar `.fin-cowork` em todas ~261 classes do bundle
2. Wrap `<div className=\"fin-cowork\">` em todas Pages/Financeiro/*.tsx
3. Smoke biz=1 + biz=4 validando AppShellV2 intacto
4. Descomentar os 5 `@import` deste arquivo

## Infra Contract (smoke pós-deploy)

| Hop | Esperado | Status |
|---|---|---|
| CI Vite build | rebuilda CSS sem os 5 imports | ⏳ |
| SSH Hostinger: `git pull && npm run build && php artisan config:cache` | dist/ atualizado | ⏳ Wagner ou eu |
| `curl -sv https://oimpresso.com/financeiro/unificado` (logado biz=4) | HTTP 200 sem `X-Mock-Cowork` | ⏳ |
| Chrome MCP screenshot | sidebar UltimatePOS 260px + main 1fr renderizados | ⏳ |
| Regression `/pos/sells` (Sells Cowork escopado) | inalterado | ⏳ |

## Test plan

- [ ] CI Pest + Vite build verde
- [ ] Merge admin
- [ ] SSH Hostinger build + cache clear
- [ ] curl smoke + Chrome MCP screenshot biz=4 (Larissa)

Refs: [PR #1115](https://github.com/wagnerra23/oimpresso.com/pull/1115), [feedback-cowork-bundle-aplicar-inteiro.md §Apêndice Plano B](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/reference/feedback-cowork-bundle-aplicar-inteiro.md)