### PR TITLE
hotfix(financeiro): null guard pra titulos undefined (tela branca em /financeiro)

### DIFF
--- a/resources/js/Pages/Financeiro/Dashboard/Index.tsx
+++ b/resources/js/Pages/Financeiro/Dashboard/Index.tsx
@@ -90,7 +90,8 @@ interface ContaBancaria {
 
 interface Props {
   kpis: Kpis;
-  titulos: PaginatedTitulos;
+  // Inertia::defer no DashboardController — undefined no primeiro paint, preenchido no partial reload.
+  titulos?: PaginatedTitulos;
   filters: Filters;
   contas: ContaBancaria[];
   saldo_total: number;
@@ -99,8 +100,12 @@ interface Props {
 const brl = (v: number) =>
   new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(v ?? 0);
 
-function FinanceiroDashboard({ kpis, titulos, filters, contas, saldo_total }: Props) {
+function FinanceiroDashboard({ kpis, titulos: titulosProp, filters, contas, saldo_total }: Props) {
   const [busca, setBusca] = useState(filters.busca ?? '');
+
+  // titulos vem como Inertia::defer no DashboardController — chega undefined no primeiro paint.
+  // Fallback vazio mantém a tela renderizada enquanto o partial reload preenche os dados.
+  const titulos: PaginatedTitulos = titulosProp ?? { data: [], links: [] };
 
   // Inertia paginator pode vir achatado (current_page direto) ou em meta
   const meta = titulos.meta ?? {


### PR DESCRIPTION
## Bug em produção

Tela branca em `/financeiro` (Dashboard Financeiro). Console:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'meta')
  at D (https://oimpresso.com/build-inertia/assets/Index-DiQbZ1nr.js:1:5769)
\`\`\`

Encontrado por smoke produção 2026-05-19 10:40 UTC após login pela primeira vez.

## Causa raiz

[Modules/Financeiro/Http/Controllers/DashboardController.php:63](Modules/Financeiro/Http/Controllers/DashboardController.php#L63) envia `titulos` via `Inertia::defer(...)`:

\`\`\`php
'titulos' => Inertia::defer(function () use ($businessId, $filters) {
    // ... query pesada com paginate(25)
}),
\`\`\`

[resources/js/Pages/Financeiro/Dashboard/Index.tsx:106](resources/js/Pages/Financeiro/Dashboard/Index.tsx#L106) acessa `titulos.meta` SEM null guard nem `<Deferred>` wrapper:

\`\`\`tsx
const meta = titulos.meta ?? { ... }; // ← titulos é undefined no first paint
\`\`\`

No primeiro paint, antes do partial reload chegar com dados, `titulos` chega `undefined` → crash → tela branca.

## Fix cirúrgico

\`\`\`diff
- function FinanceiroDashboard({ kpis, titulos, filters, ... }: Props) {
+ function FinanceiroDashboard({ kpis, titulos: titulosProp, filters, ... }: Props) {
+   // titulos é Inertia::defer — chega undefined no primeiro paint
+   const titulos: PaginatedTitulos = titulosProp ?? { data: [], links: [] };
\`\`\`

Mantém os 8 usos `titulos.*` no JSX intactos. Partial reload preenche normalmente quando chegar.

\`\`\`diff
  interface Props {
    kpis: Kpis;
-   titulos: PaginatedTitulos;
+   // Inertia::defer no Controller — undefined no primeiro paint
+   titulos?: PaginatedTitulos;
    filters: Filters;
\`\`\`

## Sem relação com PR #1119

| Arquivo afetado | Caminho |
|---|---|
| Bug em | \`resources/js/Pages/Financeiro/Dashboard/Index.tsx\` |
| Compilado para | \`build-inertia/assets/Index-*.js\` |
| PR #1119 só tocou | \`prototipo-ui/*\` (HTML+JSX prototype, fora do build Vite) |

PR #1119 mergeado 2026-05-19 10:35 UTC; bug aparece pela primeira vez ao logar agora. Bug é pré-existente, não causado pelo merge.

## Próximo passo (TODO separado, não neste PR)

Migrar pra `<Deferred data="titulos" fallback={skeleton}>` canônico per skill [inertia-defer-default](.claude/skills/inertia-defer-default/SKILL.md). Esse hotfix só destrava a tela branca AGORA; pattern canon fica como tarefa separada.

## Escopo

- ✅ 1 arquivo, 7 inserções, 2 deleções
- ✅ Multi-tenant Tier 0 N/A (sem mudança em query)
- ✅ Sem migration, sem rota, sem novo endpoint
- ✅ Backward compatible (prop opcional)

🤖 Generated with [Claude Code](https://claude.com/claude-code)