### PR TITLE
hotfix(financeiro): null guard pros 4 props deferred (kpis/contas/saldo_total além de titulos)

### DIFF
--- a/resources/js/Pages/Financeiro/Dashboard/Index.tsx
+++ b/resources/js/Pages/Financeiro/Dashboard/Index.tsx
@@ -89,23 +89,43 @@ interface ContaBancaria {
 }
 
 interface Props {
-  kpis: Kpis;
-  // Inertia::defer no DashboardController — undefined no primeiro paint, preenchido no partial reload.
+  // Wave 17 D6: kpis/titulos/contas/saldo_total são Inertia::defer no DashboardController.
+  // Chegam undefined no primeiro paint, preenchidos no partial reload — opcionais aqui pra
+  // não crashar antes do reload chegar.
+  kpis?: Kpis;
   titulos?: PaginatedTitulos;
   filters: Filters;
-  contas: ContaBancaria[];
-  saldo_total: number;
+  contas?: ContaBancaria[];
+  saldo_total?: number;
 }
+
+const EMPTY_KPI_ABERTO: KpiAberto = { valor: 0, qtd: 0, vencidos_qtd: 0, vencidos_valor: 0 };
+const EMPTY_KPI_MENSAL: KpiMensal = { valor: 0, qtd: 0 };
+const EMPTY_KPIS: Kpis = {
+  receber_aberto: EMPTY_KPI_ABERTO,
+  pagar_aberto: EMPTY_KPI_ABERTO,
+  recebido_mes: EMPTY_KPI_MENSAL,
+  pago_mes: EMPTY_KPI_MENSAL,
+};
 
 const brl = (v: number) =>
   new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(v ?? 0);
 
-function FinanceiroDashboard({ kpis, titulos: titulosProp, filters, contas, saldo_total }: Props) {
+function FinanceiroDashboard({
+  kpis: kpisProp,
+  titulos: titulosProp,
+  filters,
+  contas: contasProp,
+  saldo_total: saldoTotalProp,
+}: Props) {
   const [busca, setBusca] = useState(filters.busca ?? '');
 
-  // titulos vem como Inertia::defer no DashboardController — chega undefined no primeiro paint.
-  // Fallback vazio mantém a tela renderizada enquanto o partial reload preenche os dados.
+  // Wave 17 D6 — 4 props deferred no Controller chegam undefined no primeiro paint.
+  // Fallbacks mantêm a tela renderizada (com 0s/listas vazias) até o partial reload preencher.
+  const kpis: Kpis = kpisProp ?? EMPTY_KPIS;
   const titulos: PaginatedTitulos = titulosProp ?? { data: [], links: [] };
+  const contas: ContaBancaria[] = contasProp ?? [];
+  const saldo_total: number = saldoTotalProp ?? 0;
 
   // Inertia paginator pode vir achatado (current_page direto) ou em meta
   const meta = titulos.meta ?? {


### PR DESCRIPTION
## Continuação do PR #1120

Hotfix v1 (#1120, mergeado 10:48Z) só cobriu \`titulos\`. Smoke prod 10:52Z mostrou novo crash:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'receber_aberto')
  at R (https://oimpresso.com/build-inertia/assets/Index-CtvHsWA4.js:0:6030)
\`\`\`

Bundle hash mudou (`Index-DiQbZ1nr.js` → `Index-CtvHsWA4.js`) = deploy do v1 funcionou. Mas `kpis` também é undefined.

## Causa

[DashboardController.php:54-83](Modules/Financeiro/Http/Controllers/DashboardController.php#L54-L83) — **Wave 17 D6** marcou TODOS os 4 props pesados como `Inertia::defer`:

\`\`\`php
'kpis'        => Inertia::defer(...),
'titulos'     => Inertia::defer(...),
'contas'      => Inertia::defer(...),
'saldo_total' => Inertia::defer(...),
\`\`\`

Apenas `filters` é eager (UI state). Index.tsx só tinha guard pra `titulos` (PR #1120) — os outros 3 continuam vulneráveis.

## Fix completo

\`\`\`diff
+ const EMPTY_KPIS: Kpis = {
+   receber_aberto: { valor: 0, qtd: 0, vencidos_qtd: 0, vencidos_valor: 0 },
+   pagar_aberto:   { valor: 0, qtd: 0, vencidos_qtd: 0, vencidos_valor: 0 },
+   recebido_mes:   { valor: 0, qtd: 0 },
+   pago_mes:       { valor: 0, qtd: 0 },
+ };

  interface Props {
-   kpis: Kpis;
+   kpis?: Kpis;
    titulos?: PaginatedTitulos;
    filters: Filters;
-   contas: ContaBancaria[];
+   contas?: ContaBancaria[];
-   saldo_total: number;
+   saldo_total?: number;
  }

  function FinanceiroDashboard({
+   kpis: kpisProp,
    titulos: titulosProp,
    filters,
+   contas: contasProp,
+   saldo_total: saldoTotalProp,
  }: Props) {
+   const kpis: Kpis = kpisProp ?? EMPTY_KPIS;
    const titulos: PaginatedTitulos = titulosProp ?? { data: [], links: [] };
+   const contas: ContaBancaria[] = contasProp ?? [];
+   const saldo_total: number = saldoTotalProp ?? 0;
\`\`\`

JSX abaixo intacto. Re-render do React preenche valores quando partial reload chegar (KpiCards mostram R\$ 0 por ~100ms até atualizar — UX aceitável).

## Próximo passo (TODO separado)

Migrar pra `<Deferred data="kpis,titulos,contas,saldo_total" fallback={<DashboardSkeleton/>}>` canon per skill [inertia-defer-default](.claude/skills/inertia-defer-default/SKILL.md). Esses hotfixes destravam prod AGORA; skeleton fica como tarefa de polish.

## Escopo

- ✅ 1 arquivo, 27 inserções, 7 deleções
- ✅ Multi-tenant Tier 0 N/A
- ✅ Backward compat (props opcionais)

🤖 Generated with [Claude Code](https://claude.com/claude-code)