### PR TITLE
ADR 0170 — Modules/PaymentGateway (Onda 0 — docs only)

### DIFF
--- a/Modules/Financeiro/SCOPE.md
+++ b/Modules/Financeiro/SCOPE.md
@@ -8,6 +8,7 @@ contains:
   - "ContaBancariaController"
   - "ContaPagarController"
   - "ContaReceberController"
+  - "CoworkSidebarController — endpoint JSON Mock Cowork (sidebar real via ShellMenuBuilder + 3 camadas habilitação, sem hardcode business_id; ADR 0093 Tier 0)"
   - "DashboardController"
   - "DataController"
   - "ExtratoController"

--- a/Modules/PaymentGateway/CONTRACTS.md
+++ b/Modules/PaymentGateway/CONTRACTS.md
@@ -1,0 +1,412 @@
+# Modules/PaymentGateway — Contratos públicos
+
+> Interfaces PHP, DTOs e eventos que módulos externos podem usar. **Nada fora desta lista é API pública.** Drivers, services internos e helpers são detalhe de implementação.
+
+Vinculado a [ADR 0170](../../memory/decisions/0170-paymentgateway-extracao-camada-cobranca.md). Versão deste contrato: **v0.1** (rascunho Onda 0 — pode mudar antes de Onda 1 fechar).
+
+---
+
+## 1. Contratos (interfaces)
+
+### `PaymentGatewayContract`
+
+API principal. Quem precisa cobrar usa só isso.
+
+```php
+<?php
+
+namespace Modules\PaymentGateway\Contracts;
+
+use App\Account;
+use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
+use Modules\PaymentGateway\Dto\CobrancaEmitidaResult;
+use Modules\PaymentGateway\Dto\CobrancaStatus;
+use Modules\PaymentGateway\Entities\Cobranca;
+use Modules\PaymentGateway\Dto\CardToken;
+
+interface PaymentGatewayContract
+{
+    /**
+     * Seleciona a credencial de gateway vinculada a esta conta.
+     * Lança PaymentGatewayException se não houver gateway ativo,
+     * ou se a credencial estiver com health_status != ok.
+     *
+     * Idempotente — pode ser chamado várias vezes na mesma request.
+     */
+    public function for(Account $account): self;
+
+    /**
+     * Emite um boleto único.
+     *
+     * Idempotência: se já existe Cobranca com mesmo $input->idempotencyKey
+     * em status emitida|paga, retorna o resultado anterior sem chamar gateway.
+     *
+     * @throws \Modules\PaymentGateway\Exceptions\GatewayUnavailableException quando gateway responde 5xx/timeout
+     * @throws \Modules\PaymentGateway\Exceptions\InvalidPayerException       quando dados do pagador são insuficientes
+     * @throws \Modules\PaymentGateway\Exceptions\CredentialMisconfiguredException
+     */
+    public function emitirBoleto(EmitirCobrancaInput $input): CobrancaEmitidaResult;
+
+    /**
+     * Emite PIX cobrança.
+     *
+     * @param string $tipo 'cob' (imediata, sem vencimento) | 'cobv' (com vencimento)
+     */
+    public function emitirPix(EmitirCobrancaInput $input, string $tipo = 'cob'): CobrancaEmitidaResult;
+
+    /**
+     * Emite PIX Automático (BCB recv) — mandato recorrente.
+     * Só driver bcb_pix suporta hoje (Asaas não tem; Inter está em homologação).
+     *
+     * @throws \Modules\PaymentGateway\Exceptions\DriverNotSupportedException
+     */
+    public function emitirPixAutomatico(EmitirCobrancaInput $input): CobrancaEmitidaResult;
+
+    /**
+     * Tokeniza (se ainda não) + cobra cartão.
+     *
+     * @throws \Modules\PaymentGateway\Exceptions\DriverNotSupportedException quando driver não tem cartão
+     * @throws \Modules\PaymentGateway\Exceptions\CardDeclinedException       quando emissor recusou
+     */
+    public function cobrarCartao(EmitirCobrancaInput $input, CardToken $token): CobrancaEmitidaResult;
+
+    /**
+     * Cancela cobrança ainda não paga.
+     * Lança se cobrança já foi paga (não é estorno — pra estorno use refund()).
+     */
+    public function cancelar(Cobranca $cobranca, string $motivo): void;
+
+    /**
+     * Estorna cobrança paga. Driver-dependent (PesaPal e Asaas suportam; Inter parcial).
+     *
+     * @throws \Modules\PaymentGateway\Exceptions\DriverNotSupportedException
+     */
+    public function refund(Cobranca $cobranca, ?int $valorCentavos, string $motivo): void;
+
+    /**
+     * Consulta status atualizado direto no gateway (bypass cache local).
+     * Útil pra reconciliação manual ou quando webhook está atrasado.
+     */
+    public function consultar(Cobranca $cobranca): CobrancaStatus;
+}
+```
+
+### `PaymentDriverContract`
+
+Interface dos drivers. **Não é pública** — listada aqui só pra documentar quem implementa o quê.
+
+```php
+<?php
+
+namespace Modules\PaymentGateway\Contracts;
+
+interface PaymentDriverContract
+{
+    public function key(): string; // 'inter' | 'c6' | 'asaas' | 'bcb_pix' | 'pesapal'
+
+    public function supports(string $tipo): bool; // 'boleto' | 'pix_cob' | 'pix_cobv' | 'pix_recv' | 'card'
+
+    public function emitirBoleto(EmitirCobrancaInput $input, PaymentGatewayCredential $cred): CobrancaEmitidaResult;
+    public function emitirPix(EmitirCobrancaInput $input, PaymentGatewayCredential $cred, string $tipo): CobrancaEmitidaResult;
+    public function emitirPixAutomatico(EmitirCobrancaInput $input, PaymentGatewayCredential $cred): CobrancaEmitidaResult;
+    public function cobrarCartao(EmitirCobrancaInput $input, PaymentGatewayCredential $cred, CardToken $token): CobrancaEmitidaResult;
+    public function cancelar(Cobranca $cobranca, PaymentGatewayCredential $cred, string $motivo): void;
+    public function refund(Cobranca $cobranca, PaymentGatewayCredential $cred, ?int $valorCentavos, string $motivo): void;
+    public function consultar(Cobranca $cobranca, PaymentGatewayCredential $cred): CobrancaStatus;
+    public function healthCheck(PaymentGatewayCredential $cred): DriverHealth;
+    public function processWebhook(array $payload, PaymentGatewayCredential $cred): ?Cobranca;
+}
+```
+
+---
+
+## 2. DTOs
+
+### `EmitirCobrancaInput`
+
+```php
+<?php
+
+namespace Modules\PaymentGateway\Dto;
+
+final class EmitirCobrancaInput
+{
+    public function __construct(
+        public readonly int $businessId,
+        public readonly int $contactId,            // FK pra contacts (pagador)
+        public readonly int $valorCentavos,
+        public readonly \DateTimeImmutable $vencimento,
+        public readonly string $descricao,
+        public readonly string $idempotencyKey,    // ex: "sale:1234" | "invoice:5678" | "subscription_license:99" | "avulsa:uuid"
+        public readonly ?string $origemType = null, // 'sale' | 'invoice' | 'subscription_license' | null
+        public readonly ?int $origemId = null,
+        public readonly array $multa = [],          // ['percentual' => 2.0, 'apos_dias' => 1]
+        public readonly array $juros = [],          // ['percentual_dia' => 0.033]
+        public readonly array $desconto = [],       // ['valor_centavos' => 1000, 'ate' => '2026-05-20']
+        public readonly ?string $instrucoesPagador = null,
+        public readonly ?string $callbackUrl = null,  // override do webhook padrão
+        public readonly array $meta = [],            // extra fields driver-specific (ex: split de pagamento)
+    ) {}
+}
+```
+
+### `CobrancaEmitidaResult`
+
+```php
+<?php
+
+namespace Modules\PaymentGateway\Dto;
+
+final class CobrancaEmitidaResult
+{
+    public function __construct(
+        public readonly int $cobrancaId,             // PK em cobrancas
+        public readonly string $gatewayExternalId,   // ID no Inter/Asaas/BCB
+        public readonly string $tipo,                // boleto | pix_cob | pix_cobv | pix_recv | card
+        public readonly ?string $linhaDigitavel = null,
+        public readonly ?string $codigoBarras = null,
+        public readonly ?string $pixEmv = null,       // BR Code copia-e-cola
+        public readonly ?string $pixQrCodePath = null, // path local do PNG do QR
+        public readonly ?string $boletoPdfUrl = null,
+        public readonly ?string $nossoNumero = null,
+        public readonly \DateTimeImmutable $emitidaEm,
+        public readonly array $payloadGateway = [],   // request/response brutos (audit)
+    ) {}
+}
+```
+
+### `CobrancaStatus`
+
+```php
+<?php
+
+namespace Modules\PaymentGateway\Dto;
+
+final class CobrancaStatus
+{
+    public function __construct(
+        public readonly string $status,            // pending | emitida | paga | vencida | cancelada | erro
+        public readonly ?\DateTimeImmutable $pagaEm = null,
+        public readonly ?int $valorPagoCentavos = null,
+        public readonly ?string $formaPagamento = null,
+        public readonly ?string $payerCpfCnpj = null,
+        public readonly array $payloadGateway = [],
+    ) {}
+}
+```
+
+### `CardToken`
+
+```php
+<?php
+
+namespace Modules\PaymentGateway\Dto;
+
+final class CardToken
+{
+    public function __construct(
+        public readonly string $token,        // token PCI-DSS no provedor (nunca PAN bruto)
+        public readonly string $brand,        // visa | master | elo | amex | hipercard
+        public readonly string $lastFour,
+        public readonly string $holderName,
+        public readonly string $expMonth,
+        public readonly string $expYear,
+    ) {}
+}
+```
+
+### `DriverHealth`
+
+```php
+<?php
+
+namespace Modules\PaymentGateway\Dto;
+
+final class DriverHealth
+{
+    public function __construct(
+        public readonly bool $ok,
+        public readonly string $status,       // ok | degraded | down
+        public readonly int $latencyMs,
+        public readonly \DateTimeImmutable $checkedAt,
+        public readonly ?string $errorMessage = null,
+    ) {}
+}
+```
+
+---
+
+## 3. Eventos broadcast
+
+Todos eventos têm payload:
+
+```php
+public readonly int $cobrancaId;
+public readonly int $businessId;
+public readonly ?string $origemType;
+public readonly ?int $origemId;
+public readonly \DateTimeImmutable $occurredAt;
+```
+
+Mais campos específicos por evento (abaixo). Disparados via `event()` standard Laravel — listeners registram via `EventServiceProvider`.
+
+### `CobrancaEmitida`
+
+```php
+public readonly string $tipo;
+public readonly int $valorCentavos;
+public readonly \DateTimeImmutable $vencimento;
+```
+
+**Listeners esperados:**
+- `RecurringBilling\Listeners\MarkInvoiceCobrancaEmitida` — popula `invoices.cobranca_id`
+- `Core\Listeners\MarkSalePaymentPending` — `sale.payment_status = 'aguardando_pagamento'`
+
+### `CobrancaPaga` ⭐ canônico
+
+Mais importante do módulo. **Múltiplos listeners.**
+
+```php
+public readonly int $valorPagoCentavos;
+public readonly \DateTimeImmutable $pagaEm;
+public readonly string $formaPagamento;     // boleto | pix | cartao
+public readonly ?string $payerCpfCnpj;
+```
+
+**Listeners esperados (em ordem de execução implícita por queue ou síncrono):**
+
+1. `RecurringBilling\Listeners\MarkInvoicePaid` — `invoices.paid_at = now()`, reagenda próxima fatura
+2. `NFSe\Listeners\EmitirNfseFromCobrancaPaga` — **US-RB-044 canônico irrevogável**. Emite NFSe automática
+3. `Core\Listeners\CreateAccountTransactionFromCobranca` — lança `AccountTransaction` de entrada na conta vinculada
+4. `Core\Listeners\MarkSalePaid` — `sale.payment_status = 'paid'` se origem='sale'
+5. `Superadmin\Listeners\RenovarLicencaTenant` — quando origem='subscription_license' (Onda 5), atualiza `business.subscription_end_date += 1 month`
+
+### `CobrancaVencida`
+
+```php
+public readonly int $diasVencido;          // 1, 2, 3, ...
+public readonly \DateTimeImmutable $vencimentoOriginal;
+```
+
+**Listeners esperados:**
+- `RecurringBilling\Listeners\SmartRetryRecurringInvoice` — reemite cobrança (até 3 retentativas, intervalo configurável)
+- `RecurringBilling\Listeners\SubscriptionOverdue` — assinatura vai pra status `overdue` se invoice principal
+- `Core\Listeners\NotifyContactPaymentOverdue` — dispara notificação automatizada
+
+### `CobrancaCancelada`
+
+```php
+public readonly string $motivo;
+public readonly int $canceladoPor;        // user_id
+```
+
+**Listeners esperados:**
+- `RecurringBilling\Listeners\CancelInvoice` — `invoices.status = 'canceled'`
+- `Core\Listeners\MarkSaleCancelled` — `sale.payment_status = 'cancelled'`
+
+### `CobrancaErro`
+
+```php
+public readonly string $exception;        // FQCN
+public readonly string $message;
+public readonly string $driverKey;
+public readonly array $context;           // payload sanitizado pra audit
+```
+
+**Listeners esperados:**
+- `Otel\Listeners\RecordCobrancaErro` — span + counter no Otel
+- `PaymentGateway\Listeners\AlertHealthCheck` — flag credencial pra próximo health check
+- `RecurringBilling\Listeners\StopRetryIfCredentialError` — pára retentativas se erro é de credencial (não rede)
+
+---
+
+## 4. Exceções públicas
+
+```
+Modules\PaymentGateway\Exceptions\PaymentGatewayException        (raiz)
+├── GatewayUnavailableException          (banco fora do ar, timeout, 5xx)
+├── CredentialMisconfiguredException     (cert vencido, secret inválido)
+├── InvalidPayerException                (CPF/CNPJ inválido, dados incompletos)
+├── DriverNotSupportedException          (operação não suportada pelo driver)
+├── CardDeclinedException                (emissor recusou)
+├── IdempotencyConflictException         (tentativa de reemitir com chave já paga/cancelada)
+└── WebhookSignatureInvalidException     (assinatura HMAC não confere)
+```
+
+---
+
+## 5. Comandos artisan
+
+```bash
+# Health check (cron-friendly)
+php artisan paymentgateway:health [--business=N] [--detail] [--json] [--alert]
+
+# Listar drivers suportados + status
+php artisan paymentgateway:drivers
+
+# Forçar consulta de status (reconciliação manual)
+php artisan paymentgateway:consultar {cobranca_id}
+
+# Reprocessar webhook (debug)
+php artisan paymentgateway:replay-webhook {gateway_webhook_event_id}
+
+# Migrar credencial de boleto_credentials → payment_gateway_credentials (Onda 2)
+php artisan paymentgateway:migrate-credentials [--dry-run]
+```
+
+---
+
+## 6. Rotas HTTP públicas
+
+```
+GET    /payment-gateway/credenciais                 → PaymentGatewayController@index
+POST   /payment-gateway/credenciais                 → PaymentGatewayController@store
+PUT    /payment-gateway/credenciais/{id}            → PaymentGatewayController@update
+DELETE /payment-gateway/credenciais/{id}            → PaymentGatewayController@destroy
+POST   /payment-gateway/credenciais/{id}/health     → PaymentGatewayController@runHealthCheck
+
+GET    /cobranca                                    → CobrancaController@index   (lista filtrada)
+GET    /cobranca/{id}                               → CobrancaController@show    (drawer)
+POST   /cobranca                                    → CobrancaController@store   (avulsa)
+POST   /cobranca/{id}/cancelar                      → CobrancaController@cancel
+POST   /cobranca/{id}/segunda-via                   → CobrancaController@resend
+POST   /cobranca/{id}/refund                        → CobrancaController@refund
+
+POST   /webhooks/inter                              → Webhooks\InterWebhookController
+POST   /webhooks/c6                                 → Webhooks\C6WebhookController
+POST   /webhooks/asaas                              → Webhooks\AsaasWebhookController
+POST   /webhooks/bcb-pix                            → Webhooks\BcbPixWebhookController
+```
+
+URLs antigas (de quando webhooks moravam em `Modules/RecurringBilling`) viram **301 redirect durante 30 dias** após cutover Onda 3.
+
+---
+
+## 7. Permissions (Spatie)
+
+Prefix `paymentgateway.*`:
+
+| Permission | Quem usa |
+|---|---|
+| `paymentgateway.credenciais.viewAny` | admin financeiro |
+| `paymentgateway.credenciais.create` | admin financeiro |
+| `paymentgateway.credenciais.update` | admin financeiro |
+| `paymentgateway.credenciais.delete` | admin financeiro |
+| `paymentgateway.cobranca.viewAny` | Larissa, Eliana[E], admin |
+| `paymentgateway.cobranca.emit` | Larissa, Eliana[E] |
+| `paymentgateway.cobranca.cancel` | Eliana[E], admin |
+| `paymentgateway.cobranca.refund` | admin financeiro (Tier escalado) |
+| `paymentgateway.webhook.replay` | superadmin (debug) |
+
+---
+
+## 8. Convenções de versionamento de contrato
+
+- **v0.x** — pré-Onda 1. Pode quebrar a qualquer momento.
+- **v1.0** — congela quando Onda 1 (esqueleto) mergeia.
+- **Mudanças quebradoras** após v1.0 exigem ADR filha de 0170 + deprecation window mínimo 60d.
+- DTOs marcados `readonly` — imutabilidade garante reuso seguro entre listeners.
+
+---
+
+**Última atualização:** 2026-05-19 · v0.1 rascunho Onda 0 · vinculado a [ADR 0170](../../memory/decisions/0170-paymentgateway-extracao-camada-cobranca.md)

--- a/Modules/PaymentGateway/README.md
+++ b/Modules/PaymentGateway/README.md
@@ -1,0 +1,179 @@
+# Modules/PaymentGateway
+
+> Camada técnica de cobrança BR — drivers Inter / C6 / Asaas / PIX Automático BCB, webhooks, credenciais, CNAB. Consumida por Sell, RecurringBilling, NFSe, Superadmin.
+
+**Status:** Onda 0 (ADR 0170 proposto, módulo registrado mas não habilitado).
+**Live:** previsto biz=1 após Onda 4.
+**Origem:** extraído de `Modules/RecurringBilling` (drivers + webhooks + BoletoService).
+
+## Por que existe
+
+Antes do ADR 0170, drivers bancários e webhooks moravam em `Modules/RecurringBilling`. Quando `Modules/Financeiro` e `Modules/NfeBrasil` começaram a consumir `BoletoCredentialResolver` cross-module (Wave 23 D2), ficou claro que esses internals eram **infra**, não feature de recorrência.
+
+Este módulo é essa infra: **um único lugar pra falar com bancos**. Quem precisa cobrar (Sell avulso, Invoice recorrente, mensalidade SaaS) conversa com `PaymentGatewayContract` e ignora qual driver está embaixo.
+
+## Para o cliente final (Larissa, Eliana[E])
+
+### Cadastrar gateway
+
+1. `/payment-gateway/credenciais` (Settings → Gateways de Pagamento)
+2. "Adicionar gateway" → escolhe banco (Inter / C6 / Asaas / Pix BCB)
+3. Cola credenciais (Inter: certificado mTLS + client_id/secret; C6: agência/conta/codigo; Asaas: api_key; BCB Pix: certificado + CNPJ recebedor homologado)
+4. Vincula a **uma conta bancária** (FK pra `accounts.id`) — é onde o dinheiro vai cair
+5. Health check automático (consulta endpoint de status do banco)
+
+### Emitir cobrança
+
+Três pontos de entrada — **mesma lista de saída** em `/cobranca`:
+
+| Onde | Quem aciona | Como |
+|---|---|---|
+| **Drawer da Venda** | Larissa | Botão "Emitir cobrança" no `SaleSheet.tsx` (Sells/Index) → herda contato, valor, descrição |
+| **Faturamento automático** | Cron RecurringBilling | Job `recurring:gerar-invoices` daily 02:00 → Invoice gerada → chama `PaymentGateway::emitirBoleto()` |
+| **Cobrança avulsa** | Larissa | `/cobranca` → "Nova cobrança" → escolhe contato + valor + vencimento + tipo (boleto/PIX/cartão) |
+
+### Acompanhar
+
+`/cobranca` lista TUDO que foi emitido:
+- Filtros: status (aberta/paga/vencida/cancelada), gateway, conta, vencimento
+- KPIs: valor a receber, vencidas, ticket médio, taxa de inadimplência
+- Drawer: detalhe + linha digitável + QR code + remessa/retorno + payload bruto do gateway
+- Bulk actions: enviar 2ª via, cancelar, baixar manual
+
+### O que **não** muda
+
+- `Modules/RecurringBilling` continua tendo `/recurring-billing/planos` e `/recurring-billing/assinaturas` — só que internamente passa a chamar `PaymentGatewayContract` ao invés de `BoletoService` direto.
+- Tela Financeiro normal (`/financeiro`, fluxo de caixa, DRE) — só consome `Cobranca` como source-of-truth de "a receber".
+
+## Drivers suportados
+
+| Driver | Status | Tipos | Ambiente | Cred config |
+|---|---|---|---|---|
+| **InterDriver** | 🟡 Onda 3 (migrar de RB) | boleto + pix cob/cobv | sandbox + production | mTLS (cert+key) + client_id/secret |
+| **C6Driver** | 🟡 Onda 3 (migrar de RB) | boleto | production | agencia + conta + codigo_cliente |
+| **AsaasDriver** | 🟡 Onda 3 (migrar de RB) | boleto + pix + cartão | sandbox + production | api_key |
+| **PixAutomaticoBcbDriver** | 🔵 Onda 4 (novo) | pix recv (Pix Automático) | sandbox + production | mTLS BCB + CNPJ recebedor homologado |
+| **PesaPalDriver** | ⚪ vestigial (deprecated) | cartão internacional | production | api_key | substituído por Asaas em Onda 5 |
+
+Resolução via `PaymentGatewayCredentialResolver` (ex-`BoletoCredentialResolver` movido de RB).
+
+## Lifecycle Cobrança canônico
+
+```
+[criada] → emitida → paga
+              ↓
+            vencida → emitida (smart retry, até 3x) ou cancelada (após N dias)
+              ↓
+           cancelada (manual) | erro (gateway recusou)
+```
+
+States gerenciados pelo `CobrancaService` (ADR 0143 FSM pipeline pattern inspirado).
+
+## Multi-tenant Tier 0
+
+Toda `Cobranca` e `PaymentGatewayCredential` tem `business_id` global scope ([ADR 0093](../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)).
+
+Jobs (`ProcessInterWebhookJob`, `ProcessAsaasWebhookJob`, `ProcessBcbPixWebhookJob`, `CancelarCobrancaJob`) recebem `businessId` no constructor.
+
+Webhooks resolvem `business_id` via `external_reference` antes de qualquer query — nunca confiam só em headers/IP.
+
+## Eventos broadcast
+
+```
+CobrancaEmitida    → RB marca Invoice.boleto_id; Sell marca sale.payment_status='aguardando'
+CobrancaPaga       → RB marca Invoice.paid_at; NFSe emite NFSe (US-RB-044 canônico);
+                     Sell faz AccountTransaction; Superadmin renova subscription do tenant
+CobrancaVencida    → RB smart retry; Subscription overdue
+CobrancaCancelada  → RB Invoice canceled; Sell sale.payment_status='cancelled'
+CobrancaErro       → Otel alerta + retry handler decide reemitir ou parar
+```
+
+Quem se interessa, escuta. PaymentGateway **não conhece** RecurringBilling / Sell / NFSe / Superadmin.
+
+## OTel observability
+
+Métodos críticos wrap em `OtelHelper::spanBiz` (mesmo padrão D9 Wave 17 do RB):
+
+- `pg.cobranca.emitir.boleto` · `pg.cobranca.emitir.pix` · `pg.cobranca.emitir.pix_automatico` · `pg.cobranca.cobrar_cartao`
+- `pg.cobranca.cancelar` · `pg.cobranca.consultar`
+- `pg.webhook.processar.inter` · `pg.webhook.processar.c6` · `pg.webhook.processar.asaas` · `pg.webhook.processar.bcb_pix`
+- `pg.driver.health_check.{driver}`
+
+## Health check
+
+```bash
+php artisan paymentgateway:health
+php artisan paymentgateway:health --business=1 --detail
+php artisan paymentgateway:health --json --alert  # exit 0/1/2 pra cron
+```
+
+Sinais críticos (a definir em Onda 1, baseline 10 igual ao RB):
+
+- `payment_gateway.credentials_table` — schema OK
+- `cobrancas.table` — schema OK
+- `gateway_webhook_events.table` — schema OK
+- `credenciais_ativas` — pelo menos 1 credencial ativa por business com cobrança aberta
+- `driver_resolvidos` — 4 drivers respondem ao `health()` (inter, c6, asaas, bcb_pix)
+- `webhook_idempotency` — `gateway_webhook_events` sem duplicatas em última hora
+- `last_emitida_freshness` — última cobrança emitida há menos de 24h pra business ativos
+- `cobrancas_em_erro` — count de status=erro em última hora abaixo do threshold
+- `pix_recv_mandatos_ativos` — mandatos PIX Automático vigentes
+- `retention_policy` — payload_gateway em cobrancas concluídas há +90d sob retention
+
+## Tests
+
+```bash
+vendor/bin/pest Modules/PaymentGateway/Tests
+```
+
+Cobertura prevista (Onda 1+):
+- `PaymentGatewayService` — contrato com mock de cada driver
+- Drivers — sandbox real Inter/Asaas/BCB; mock C6 (sem sandbox)
+- Webhooks — idempotência multi-tenant + assinatura
+- `PaymentGatewayCredentialResolver` — escolha por business/account/tipo
+- `CobrancaService` — FSM transitions
+- OTel D9 — spans presentes
+- Customer Journey — Sell → emitir → webhook → marcar paga → AccountTransaction
+
+## ADRs referência
+
+- [ADR 0170](../../memory/decisions/0170-paymentgateway-extracao-camada-cobranca.md) — charter (este módulo)
+- [ADR 0017](../../memory/decisions/0017-officeimpresso-restaurado-superadmin-exclusivo.md) — emendado pela Onda 5 (Superadmin dogfooding)
+- [ADR 0093](../../memory/decisions/0093-multi-tenant-isolation-tier-0.md) — Tier 0 isolation
+- [ADR 0143](../../memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md) — FSM pattern
+- US-RB-044 — NFe-de-boleto-pago (vira listener de `CobrancaPaga`, canônico irrevogável)
+- Resolução BCB 380/2024 — PIX Automático (regulamentação do driver `bcb_pix`)
+
+## Anti-patterns proibidos
+
+- ⛔ NÃO importar driver concreto fora do módulo. Sempre via `app(PaymentGatewayContract::class)`
+- ⛔ NÃO instanciar `BoletoService` / `PixService` / `CardService` direto — só via contrato
+- ⛔ NÃO commit credenciais em `config` sem `Crypt::encryptString` em `client_secret` / `api_key` / `certificado_key_b64` / `certificado_senha` / `webhook_secret`
+- ⛔ NÃO `forceDelete` em Cobranca com status emitida/paga — use cancel + soft delete (audit LGPD D7.b)
+- ⛔ NÃO emitir cobrança avulsa sem `contact_id` (pagador) — viola LGPD (rastreabilidade do destinatário)
+- ⛔ NÃO bypass `PaymentGatewayCredentialResolver` direto via `PaymentGatewayCredential::find()` — use o resolver pra garantir `decryptConfig` correto
+- ⛔ NÃO processar webhook sem checar idempotência via `gateway_webhook_events.external_id` UNIQUE constraint
+- ⛔ NÃO reusar `external_id` entre `sandbox` e `production` — sempre escopo por `ambiente`
+
+## Migração de RecurringBilling (referência pra Onda 3)
+
+Mapa de arquivos:
+
+```
+ORIGEM (RecurringBilling)              →  DESTINO (PaymentGateway)
+─────────────────────────────────────     ────────────────────────────────────
+Services/Boleto/Drivers/InterDriver       Services/Drivers/InterDriver
+Services/Boleto/Drivers/C6Driver          Services/Drivers/C6Driver
+Services/Boleto/Drivers/AsaasDriver       Services/Drivers/AsaasDriver
+Services/Boleto/BoletoService             Services/BoletoService
+Services/Boleto/BoletoCredentialResolver  Services/PaymentGatewayCredentialResolver
+Entities/BoletoCredential                 Entities/PaymentGatewayCredential
+Http/Controllers/InterWebhookController   Http/Controllers/Webhooks/InterWebhookController
+Http/Controllers/AsaasWebhookController   Http/Controllers/Webhooks/AsaasWebhookController
+Jobs/ProcessInterWebhookJob               Jobs/ProcessInterWebhookJob
+Jobs/ProcessAsaasWebhookJob               Jobs/ProcessAsaasWebhookJob
+Jobs/CancelarCobrancaAsaasJob             Jobs/CancelarCobrancaJob (driver-agnostic)
+Jobs/RefundCobrancaAsaasJob               Services/Drivers/AsaasDriver::refund() (driver-internal)
+```
+
+URLs de webhook antigas viram 301 redirect durante 30 dias (padrão Onda 10 do próprio RB).

--- a/Modules/PaymentGateway/SCOPE.md
+++ b/Modules/PaymentGateway/SCOPE.md
@@ -1,0 +1,73 @@
+---
+module: PaymentGateway
+purpose: "Camada técnica de cobrança BR — drivers Inter/C6/Asaas/Pix Automático BCB, webhooks, CNAB, credenciais. Consumida por Sell, RecurringBilling, NFSe, Superadmin license."
+contains:
+  - "PaymentGatewayController"
+  - "CobrancaController"
+  - "InterWebhookController"
+  - "C6WebhookController"
+  - "AsaasWebhookController"
+  - "BcbPixWebhookController"
+  - "BoletoService"
+  - "PixService"
+  - "CardService"
+  - "RemessaCnabService"
+  - "RetornoCnabService"
+  - "PaymentGatewayCredentialResolver"
+  - "Drivers: InterDriver, C6Driver, AsaasDriver, PixAutomaticoBcbDriver, PesaPalDriver (deprecated)"
+not_contains:
+  - "Plan / Assinatura / Invoice recorrente → Modules/RecurringBilling (consome este módulo)"
+  - "Sale / Transaction de venda → app/ core (consome este módulo via PaymentGatewayContract)"
+  - "NFSe / NFe emissão → Modules/NFSe / Modules/NfeBrasil (escuta evento CobrancaPaga)"
+  - "Subscription SaaS Wagner→tenants → Plan em RecurringBilling biz=1 + handler Superadmin"
+  - "Plano de contas contábil → Modules/Accounting"
+  - "Account (saldo bancário) → app/Account.php (core); só recebe FK das credenciais"
+trust_required: L3
+owner: wagner
+permission_prefix: paymentgateway.*
+charter_adr: 0170
+related_adrs:
+  - 0079-constituicao-oimpresso-7-camadas-governanca
+  - 0080-trust-tiers-operacional-audit-findings
+  - 0093-multi-tenant-isolation-tier-0
+  - 0094-constituicao-v2-7-camadas-8-principios
+  - 0143-fsm-pipeline-live-prod-marco-2026-05-12
+url_prefixes:
+  - /payment-gateway/*
+  - /cobranca/*
+  - /webhooks/inter (migrado de RecurringBilling, redirect 301 das URLs antigas durante 30d)
+  - /webhooks/c6 (migrado)
+  - /webhooks/asaas (migrado)
+  - /webhooks/bcb-pix (novo)
+drift_alerts: []
+---
+
+# Modules/PaymentGateway
+
+## Missão
+
+Camada técnica de cobrança BR — drivers Inter/C6/Asaas/Pix Automático BCB, webhooks, CNAB, credenciais. Consumida por Sell, RecurringBilling, NFSe, Superadmin license.
+
+Extraído de `Modules/RecurringBilling` (ADR 0170) pra desacoplar **infra de cobrança** (este módulo) de **lógica de recorrência** (RecurringBilling).
+
+## Trust level
+
+**L3** — toca dinheiro, dados de pagador (LGPD), credenciais de API bancária (segredos), regulação CMN/BCB. Ver [TRUST-TIERS.md](../../memory/governance/TRUST-TIERS.md).
+
+## Quando NÃO é tocado
+
+Ver `not_contains[]` no frontmatter. Em dúvida, consulte [ARCHITECTURE.md](../../memory/governance/ARCHITECTURE.md).
+
+Regra de ouro: **se a operação envolve "quando cobrar / com que frequência", é RecurringBilling. Se envolve "como falar com banco pra emitir/cancelar", é PaymentGateway.**
+
+## Contrato público
+
+Quem consome este módulo (Sell, RecurringBilling, NFSe, Superadmin) **só conhece** [`PaymentGatewayContract`](Contracts/PaymentGatewayContract.php) e os 5 eventos broadcast (`CobrancaEmitida`, `CobrancaPaga`, `CobrancaVencida`, `CobrancaCancelada`, `CobrancaErro`).
+
+Drivers concretos (`InterDriver`, `AsaasDriver`, etc) **nunca aparecem fora do módulo**.
+
+Ver [CONTRACTS.md](CONTRACTS.md) pra interface + DTOs + payloads de evento.
+
+---
+
+- **v0.1.0** (2026-05-19) — SCOPE.md inicial, ADR 0170 proposto. Módulo registrado mas **não habilitado** (Onda 0 do roadmap).

--- a/memory/decisions/0170-paymentgateway-extracao-camada-cobranca.md
+++ b/memory/decisions/0170-paymentgateway-extracao-camada-cobranca.md
@@ -18,7 +18,7 @@ related:
   - '0101'
   - '0114'
   - '0143'
-emends:
+amends:
   - '0017'
 pii: false
 ---
@@ -331,7 +331,7 @@ Cada onda = PR isolada + ADR per-onda (filha desta) + smoke test biz=1 antes de 
 
 2. **Cowork next:** primeira tela F1 `Cobrança` (UI no Cockpit) — substitui `boletos` na sidebar do protótipo, com badges Inter/C6/Asaas/PIX. Pedido entra em `COWORK_NOTES.md` depois deste ADR mergeado.
 
-3. **Próximo ADR (0116):** detalhamento Onda 1 (esqueleto Module + ServiceProvider + Contracts) com critérios de sucesso e checklist de migração.
+3. **Próximo ADR (filho desta — Onda 1):** detalhamento esqueleto Module + ServiceProvider + Contracts com critérios de sucesso e checklist de migração. Número será atribuído na criação (próximo livre após 0170, evitar colisão como aconteceu com 0115/0144).
 
 4. **Health checks:** adicionar `payment_gateway` em `jana:health-check` quando Onda 1 mergear:
    - `payment_gateway.credentials_ativas`

--- a/memory/decisions/0170-paymentgateway-extracao-camada-cobranca.md
+++ b/memory/decisions/0170-paymentgateway-extracao-camada-cobranca.md
@@ -1,0 +1,359 @@
+---
+slug: 0170-paymentgateway-extracao-camada-cobranca
+number: 170
+title: "Modules/PaymentGateway — extração da camada técnica de cobrança"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+decided_by:
+  - W
+decided_at: '2026-05-19'
+quarter: 2026-Q2
+related:
+  - '0079'
+  - '0080'
+  - '0093'
+  - '0094'
+  - '0101'
+  - '0114'
+  - '0143'
+emends:
+  - '0017'
+pii: false
+---
+
+# ADR 0170 — `Modules/PaymentGateway`: extração da camada técnica de cobrança
+
+**Status:** 🟡 Proposto (F0 brief — aguarda revisão Claude Code antes de virar aceito)
+**Data:** 2026-05-19
+**Decisão por:** Wagner Rocha (Cowork F0)
+**Emenda:** ADR 0017 (Officeimpresso superadmin) — substitui modelo `Superadmin::Subscription` por dogfooding via RecurringBilling
+**Não supersede:** ADRs 0093 (multi-tenant Tier 0), 0094 (constituição V2), 0143 (FSM pipeline)
+
+---
+
+## Contexto
+
+Hoje a camada técnica de cobrança (drivers bancários, webhooks, credenciais, CNAB, retry) vive **dentro de `Modules/RecurringBilling`** — module cujo SCOPE.md se autodeclara "Cobrança recorrente BR — Pix Automático, smart retries, NFSe automática". Live biz=1 prod, 3 drivers (Inter / C6 / Asaas), Wave 23 D2.
+
+Isso funcionou enquanto cobrança recorrente era o único cliente da camada. **Não funciona mais** porque:
+
+1. **Cross-module reuse já está acontecendo informalmente.** O README do RecurringBilling diz literalmente:
+   > "Resolução via `BoletoCredentialResolver` (Wave 23 D2 reuse cross-module Financeiro/NfeBrasil)."
+
+   Ou seja: `Modules/Financeiro` e `Modules/NfeBrasil` já consomem internals de `Modules/RecurringBilling`. Isso fere encapsulamento — `RecurringBilling` deixou de ser um módulo de produto e virou bibliotecão de infra.
+
+2. **Sells/PR drawer precisa emitir cobrança avulsa.** Sem refactor, Sell teria que importar `Modules\RecurringBilling\Services\Boleto\BoletoService` — coupling errado (Sell não vende assinatura, vende banner).
+
+3. **Credenciais moram na tabela errada.** Campos `rb_gateway_credential_id`, `gateway_banco`, `gateway_ambiente`, `gateway_client_id` estão **coladas na tabela `accounts`** (vide `boleto-contas-app.jsx` e schema). Conta financeira e credencial de gateway são responsabilidades diferentes — conta é "onde dinheiro entra/sai", credencial é "como o ERP fala com banco".
+
+4. **Conflito de nome com Superadmin.** `Modules/Superadmin/Entities/Subscription` ("venda de pacotes SaaS Oimpresso pra tenants") e `Modules/RecurringBilling/Entities/Subscription` ("assinatura recorrente que tenant vende pro cliente dele") são **duas tabelas com o mesmo nome**, mesmo significante, sujeitos diferentes. Comentário literal no `Superadmin/Subscription.php`:
+   > "Subscriptions tocam pagamento de TODOS tenants (cross-tenant intencional Wagner-only)."
+
+   Cada um tem fluxo de pagamento próprio: Superadmin usa `PesaPalController` (vestigial UltimatePOS pra cartão internacional) + `paid_via` manual; RecurringBilling usa Inter/C6/Asaas. **Dois caminhos para a mesma coisa** (cobrar mensalidade).
+
+5. **PIX Automático BCB.** Wagner decidiu (F0 brief 2026-05-19) que PIX Automático será **driver direto BCB**, não passa por Inter/Asaas como abstração. Isso adiciona um 4º driver com regras próprias (Resolução BCB sobre PIX Automático, mandatos, CNPJ recebedor homologado) — peso suficiente pra justificar camada própria.
+
+## Decisão
+
+### A — Criar `Modules/PaymentGateway`
+
+Módulo novo, Trust L3 (toca dinheiro + LGPD + regulação BCB), permission prefix `paymentgateway.*`.
+
+**Conteúdo (extraído de `Modules/RecurringBilling`):**
+
+```
+Modules/PaymentGateway/
+├── Entities/
+│   ├── Cobranca.php                     ← nova (entity da cobrança, separada de Invoice)
+│   ├── PaymentGatewayCredential.php     ← ex-BoletoCredential (renomeada + movida)
+│   └── GatewayWebhookEvent.php          ← log idempotência
+├── Services/
+│   ├── Drivers/
+│   │   ├── InterDriver.php              ← movido de RB
+│   │   ├── C6Driver.php                 ← movido de RB
+│   │   ├── AsaasDriver.php              ← movido de RB
+│   │   ├── PixAutomaticoBcbDriver.php   ← NOVO (decisão Wagner #1)
+│   │   └── PesaPalDriver.php            ← movido de Superadmin (vestigial,
+│   │                                       deprecated, substituído por Inter+Pix)
+│   ├── BoletoService.php                ← movido
+│   ├── PixService.php                   ← NOVO (cob, cobv, recv)
+│   ├── CardService.php                  ← NOVO
+│   ├── RemessaCnabService.php           ← extraído se existir
+│   ├── RetornoCnabService.php           ← extraído se existir
+│   └── PaymentGatewayCredentialResolver.php  ← ex-BoletoCredentialResolver
+├── Http/Controllers/
+│   ├── PaymentGatewayController.php          ← UI Settings › Gateways
+│   ├── CobrancaController.php                ← UI Financeiro › Cobrança
+│   └── Webhooks/
+│       ├── InterWebhookController.php        ← movido de RB
+│       ├── C6WebhookController.php           ← movido de RB
+│       ├── AsaasWebhookController.php        ← movido de RB
+│       └── BcbPixWebhookController.php       ← NOVO
+├── Events/
+│   ├── CobrancaEmitida.php
+│   ├── CobrancaPaga.php                 ← consumido por RecurringBilling + Sell + NFSe
+│   ├── CobrancaVencida.php
+│   ├── CobrancaCancelada.php
+│   └── CobrancaErro.php
+├── Contracts/
+│   ├── PaymentGatewayContract.php       ← API pública do módulo
+│   └── PaymentDriverContract.php        ← interface dos drivers
+├── Dto/
+│   ├── EmitirCobrancaInput.php
+│   ├── CobrancaEmitidaResult.php
+│   └── WebhookPayload.php
+├── Jobs/
+│   ├── ProcessInterWebhookJob.php       ← movido
+│   ├── ProcessAsaasWebhookJob.php       ← movido
+│   ├── ProcessBcbPixWebhookJob.php      ← NOVO
+│   └── CancelarCobrancaJob.php
+├── Database/Migrations/
+│   ├── XXXX_create_payment_gateway_credentials_table.php
+│   ├── XXXX_create_cobrancas_table.php
+│   ├── XXXX_create_gateway_webhook_events_table.php
+│   └── XXXX_migrate_boleto_credentials_to_payment_gateway_credentials.php
+└── module.json + SCOPE.md + README.md + CONTRACTS.md
+```
+
+### B — `Modules/RecurringBilling` fica enxuto
+
+**Permanece:**
+- `Plan`, `Assinatura` (rename de `Subscription` pra evitar conflito), `Invoice`
+- Lifecycle FSM (active/paused/canceled/overdue)
+- Geração de Invoice via cron
+- MRR/churn dashboards
+- US-RB-044 NFe-de-boleto-pago (handler que escuta `CobrancaPaga` → emite NFSe)
+
+**Sai:**
+- Drivers Inter/C6/Asaas → PaymentGateway
+- Webhooks → PaymentGateway
+- BoletoService → PaymentGateway
+- BoletoCredential → PaymentGateway (renomeada)
+- BoletoCredentialResolver → PaymentGateway
+
+**Vira consumidor** via `app(PaymentGatewayContract::class)`:
+```php
+// Antes (acoplado):
+app(BoletoService::class)->emit($credencial, $titulo);
+
+// Depois (contrato):
+app(PaymentGatewayContract::class)
+    ->for($account)
+    ->emitirBoleto($cobrancaDto);
+```
+
+E escuta `CobrancaPaga` pra marcar Invoice como `paid` + atualizar `next_due_date`.
+
+### C — Eliminar `Modules/Superadmin/Entities/Subscription` como source-of-truth
+
+Wagner decisão #2 (F0 2026-05-19):
+> "deveria entrar na empresa 1 que é a minha e ficar integrado com minha mensalidade, no meu caso empresa1 os clientes vão poder usar separado, isso é uma saas"
+
+**Modelagem nova (dogfooding):**
+
+- `business_id=1` é a Empresa "Oimpresso ERP" (Wagner) — tenant raiz.
+- Tenants (Larissa, demais clientes SaaS) são **simultaneamente** `Business` (têm seu próprio ERP isolado, Tier 0) **E** `Contact` dentro de `business_id=1` (representam "este tenant é meu cliente SaaS").
+- Wagner cadastra `Plan` "SaaS Premium R$ 99,90/mês" em RecurringBilling **dentro do `business_id=1`**.
+- Pra cada tenant ativo, cria `Assinatura(business_id=1, contact_id={tenant_como_contact}, plan_id={saas_premium})`.
+- Cron gera `Invoice` mensal → emite cobrança via `PaymentGateway` (PIX Automático BCB, decisão #1) → tenant paga.
+- Webhook BCB → `CobrancaPaga` evento → handler **`SuperadminLicenseObserver`** (fica no Superadmin) escuta e atualiza `business.subscription_end_date += 1 month`.
+- `Modules/Superadmin/Entities/Subscription` **vira view materializada** (projection alimentada por eventos), não source-of-truth. Mantida pra read-side (dashboard cross-tenant Wagner) + auditoria LGPD D7.b já existente.
+- `PesaPalController` deprecated — substituído por PaymentGateway (decisão #3 Wagner: "pode substituir, desde que tenha as funções"). PesaPalDriver fica no módulo durante transição pra honrar Subscriptions antigas em sandbox.
+
+**Bônus:** Wagner usa o próprio ERP pra cobrar o ERP. Bug em Plan/Invoice/Cobrança aparece pra ele primeiro (porque é cliente do seu próprio produto). Dogfooding sério.
+
+### D — Contrato público `PaymentGatewayContract`
+
+```php
+namespace Modules\PaymentGateway\Contracts;
+
+interface PaymentGatewayContract
+{
+    /** Seleciona account+credencial. Lança se não houver gateway ativo. */
+    public function for(Account $account): self;
+
+    /** Emite boleto avulso. Idempotente por chave (Sell ID, Invoice ID, etc). */
+    public function emitirBoleto(EmitirCobrancaInput $input): CobrancaEmitidaResult;
+
+    /** Emite PIX cobrança imediata (cob) ou com vencimento (cobv). */
+    public function emitirPix(EmitirCobrancaInput $input, string $tipo = 'cob'): CobrancaEmitidaResult;
+
+    /** Emite PIX Automático (recv) — mandato BCB. Só driver BcbPix. */
+    public function emitirPixAutomatico(EmitirCobrancaInput $input): CobrancaEmitidaResult;
+
+    /** Tokeniza + cobra cartão. Driver-dependent. */
+    public function cobrarCartao(EmitirCobrancaInput $input, CardToken $token): CobrancaEmitidaResult;
+
+    /** Cancela cobrança em aberto. */
+    public function cancelar(Cobranca $cobranca, string $motivo): void;
+
+    /** Consulta status no provedor (force refresh). */
+    public function consultar(Cobranca $cobranca): CobrancaStatus;
+}
+```
+
+Quem consome (Sell, RecurringBilling, Superadmin licensing) **só conhece este contrato** — drivers concretos nunca aparecem fora do módulo.
+
+### E — Eventos broadcast
+
+```
+CobrancaEmitida   → RecurringBilling marca Invoice.boleto_id
+                   → Sell marca sale.payment_status='aguardando_pagamento'
+
+CobrancaPaga      → RecurringBilling marca Invoice.paid_at + reagenda
+                   → NFSe escuta (US-RB-044) e emite NFSe automática (canônico irrevogável)
+                   → Sell marca sale.payment_status='paid' + AccountTransaction
+                   → Superadmin (handler license) renova subscription_end_date do tenant
+
+CobrancaVencida   → RecurringBilling smart retry (3 retentativas)
+                   → Subscription → overdue
+
+CobrancaCancelada → RecurringBilling Invoice → canceled
+                   → Sell sale.payment_status='cancelled'
+
+CobrancaErro      → Otel alerta + healthcheck
+                   → handler de retry decide se reemite ou para
+```
+
+### F — Multi-tenant Tier 0 herdado
+
+PaymentGateway é Tier 0 ([ADR 0093](0093-multi-tenant-isolation-tier-0.md)) por construção:
+- `payment_gateway_credentials.business_id` global scope
+- `cobrancas.business_id` global scope
+- Jobs recebem `businessId` no constructor (mesmo padrão dos jobs do RB)
+- Webhooks resolvem `business_id` via `external_reference` ou domínio do callback URL antes de qualquer query
+
+### G — Tabela `payment_gateway_credentials`
+
+```php
+Schema::create('payment_gateway_credentials', function (Blueprint $t) {
+    $t->id();
+    $t->unsignedInteger('business_id');
+    $t->foreign('business_id')->references('id')->on('business')->onDelete('cascade');
+    $t->unsignedInteger('account_id')->nullable();
+    $t->foreign('account_id')->references('id')->on('accounts')->onDelete('set null');
+    $t->string('driver');  // inter | c6 | asaas | bcb_pix | pesapal
+    $t->string('ambiente'); // sandbox | production
+    $t->boolean('ativo')->default(true);
+    $t->string('nome');  // ex: "Inter PJ Operacional"
+    $t->json('config'); // client_id, client_secret(encrypted), mTLS cert(encrypted), webhook_secret(encrypted)
+    $t->timestamp('last_health_check_at')->nullable();
+    $t->string('last_health_status')->nullable();
+    $t->softDeletes();
+    $t->timestamps();
+    $t->index(['business_id', 'driver', 'ativo']);
+});
+```
+
+Migration de backfill: lê campos `rb_gateway_credential_id`, `gateway_*` da tabela `accounts`, popula `payment_gateway_credentials`, deixa `accounts.payment_gateway_credential_id` apontando pra novo PK. Colunas antigas em `accounts` viram nullable, depreciated em PR separado, removidas em onda futura.
+
+### H — Tabela `cobrancas`
+
+Entity separada de `transactions` e `invoices`. Razão: cobrança é "intent de receber dinheiro através de gateway" — tem ciclo de vida próprio (emitida → registrada → paga | vencida | cancelada | erro) e pode existir sem Sell (cobrança avulsa) e sem Invoice recorrente. Sell e Invoice **referenciam** `cobranca_id`, não o contrário.
+
+```php
+Schema::create('cobrancas', function (Blueprint $t) {
+    $t->id();
+    $t->unsignedInteger('business_id');
+    $t->unsignedBigInteger('payment_gateway_credential_id');
+    $t->string('origem_type')->nullable();  // 'sale' | 'invoice' | 'subscription_license' | null (avulsa)
+    $t->unsignedBigInteger('origem_id')->nullable();
+    $t->unsignedInteger('contact_id');  // pagador
+    $t->decimal('valor', 22, 4);
+    $t->date('vencimento');
+    $t->string('tipo'); // boleto | pix_cob | pix_cobv | pix_recv | card
+    $t->string('status'); // pending | emitida | paga | vencida | cancelada | erro
+    $t->string('nosso_numero')->nullable();
+    $t->string('linha_digitavel')->nullable();
+    $t->string('codigo_barras')->nullable();
+    $t->string('pix_emv')->nullable();
+    $t->string('pix_qr_code_path')->nullable();
+    $t->string('gateway_external_id')->nullable(); // ID no Inter/Asaas/BCB
+    $t->timestamp('emitida_em')->nullable();
+    $t->timestamp('paga_em')->nullable();
+    $t->timestamp('cancelada_em')->nullable();
+    $t->text('cancelamento_motivo')->nullable();
+    $t->json('payload_gateway')->nullable(); // request/response do gateway
+    $t->softDeletes();
+    $t->timestamps();
+    $t->index(['business_id', 'status', 'vencimento']);
+    $t->index(['business_id', 'origem_type', 'origem_id']);
+    $t->unique(['business_id', 'gateway_external_id']);
+});
+```
+
+## Roadmap — 6 ondas
+
+| Onda | O quê | Pode quebrar prod? | Reversível? |
+|---|---|---|---|
+| **0 · ADR + SCOPE** (este PR) | ADR 0170 + SCOPE.md + README.md + CONTRACTS.md em `Modules/PaymentGateway/` (vazio, só docs) | Não | Trivial |
+| **1 · Esqueleto** | `Modules/PaymentGateway/` com module.json + ServiceProvider + Contracts + DTOs + Events. Eventos disparados em modo "shadow" (a partir do RB existente) | Não | Sim, flag |
+| **2 · Migrar credentials** | Cria `payment_gateway_credentials`. Backfill de `accounts.*gateway*`. RB lê da nova tabela via Resolver. Colunas antigas em `accounts` viram nullable + deprecated | Médio (DDL) | Reverte migration + restaurar `rb_gateway_credential_id` |
+| **3 · Migrar webhooks** | `InterWebhookController` / `C6Webhook` / `AsaasWebhook` movem. URLs antigas → 301 redirect (padrão Onda 10 RB). Eventos disparados | Alto risco — testar sandbox **antes** | Manter rotas duplicadas durante 30d |
+| **4 · Mover domínio** | `BoletoService` / `BoletoCredentialResolver` movem. `PixService` + `PixAutomaticoBcbDriver` novos. Tela `Financeiro › Cobrança` (Cockpit) lê de `cobrancas`. Sell drawer ganha botão "Emitir cobrança" | Alto — Larissa vê tela nova | Flag `feature.cobranca_v2` rollback rota antiga |
+| **5 · Dogfooding Superadmin** | `Plan` "SaaS Oimpresso Premium" em biz=1. Tenants viram Contact em biz=1. `Superadmin::Subscription` vira projection. PesaPal deprecated | Médio — afeta cobrança SaaS de Wagner ↔ tenants | Manter Subscription source-of-truth via flag |
+| **6 · Cleanup** | Remover colunas `rb_gateway_credential_id`, `gateway_*` de `accounts`. Remover `PesaPalController` legacy. Remover redirects 301 | Baixo se ondas 2-5 estáveis 90d | Apenas DDL forward |
+
+Cada onda = PR isolada + ADR per-onda (filha desta) + smoke test biz=1 antes de promover.
+
+## Consequências
+
+### Boas
+
+- **Encapsulamento real** — Sell/NFSe/Financeiro/RB/Superadmin consomem contrato, não internals
+- **PIX Automático BCB** — driver dedicado, regulação isolada (Resolução BCB 380/2024 sobre PIX Automático)
+- **Dogfooding** — Wagner usa próprio ERP pra cobrar o ERP. Bug aparece pra ele primeiro
+- **Eliminação de duplicação semântica** — só existe um `Subscription` (em RB, renomeado pra `Assinatura`). Superadmin::Subscription vira projection
+- **Auditoria mais simples** — uma só tabela `cobrancas` registra TUDO que foi cobrado, independente de origem (Sell, Invoice recorrente, mensalidade SaaS)
+- **Compliance isolada** — PCI-DSS (cartão) + LGPD (CPF pagador) + segredos de API moram num módulo, audit fica em escopo conhecido
+- **Driver per banco** — Inter v3 quebra → mexe só em `InterDriver`. Hoje muda em RB inteiro
+
+### Ruins / mitigações
+
+- **6 ondas = trabalho denso de 8-12 semanas.** Mitigação: cada onda tem valor isolado (Onda 2 já desacopla credencial de `accounts`). Pode pausar entre ondas
+- **US-RB-044 NFSe-de-boleto-pago é canônico irrevogável** ([README RB](../../Modules/RecurringBilling/README.md)). Mitigação: virar listener de evento `CobrancaPaga` no módulo NFSe (passive coupling), contrato preservado
+- **Sell hoje não tem cobrança avulsa.** Mitigação: feature nova na Onda 4, opt-in via flag; comportamento antigo permanece
+- **Risco de Onda 3 (webhooks) em produção.** Mitigação: deploy em modo shadow primeiro (webhook duplicado, RB ignora se já processado), 7d observação, depois cutover
+- **Superadmin::Subscription como projection** quebra invariantes existentes da auditoria LGPD. Mitigação: append-only mantido via `superadmin.subscription` activity_log no handler de evento
+
+## Plano de aplicação (Onda 0 — este PR)
+
+1. **PR atual:**
+   - [ ] `Modules/PaymentGateway/SCOPE.md`
+   - [ ] `Modules/PaymentGateway/README.md`
+   - [ ] `Modules/PaymentGateway/CONTRACTS.md` (interfaces + events + DTOs)
+   - [ ] `Modules/PaymentGateway/module.json` (não habilitado ainda — apenas registrado)
+   - [ ] `memory/decisions/0170` (este arquivo)
+   - [ ] CLAUDE.md adiciona Modules/PaymentGateway ao mapa
+   - [ ] AUDITORIA_MODULOS.md adiciona PaymentGateway / F1 / phase=2 status=later
+
+2. **Cowork next:** primeira tela F1 `Cobrança` (UI no Cockpit) — substitui `boletos` na sidebar do protótipo, com badges Inter/C6/Asaas/PIX. Pedido entra em `COWORK_NOTES.md` depois deste ADR mergeado.
+
+3. **Próximo ADR (0116):** detalhamento Onda 1 (esqueleto Module + ServiceProvider + Contracts) com critérios de sucesso e checklist de migração.
+
+4. **Health checks:** adicionar `payment_gateway` em `jana:health-check` quando Onda 1 mergear:
+   - `payment_gateway.credentials_ativas`
+   - `payment_gateway.last_emitida_freshness`
+   - `payment_gateway.webhook_idempotency`
+   - `payment_gateway.driver_resolvidos` (4 drivers responsivos no health check)
+
+## Refs
+
+- [ADR 0017](0017-officeimpresso-restaurado-superadmin-exclusivo.md) — Superadmin exclusivo (emendado por este)
+- [ADR 0079](0079-constituicao-oimpresso-7-camadas-governanca.md) — 7 camadas governança
+- [ADR 0080](0080-trust-tiers-operacional-audit-findings.md) — Trust tiers L1-L4
+- [ADR 0093](0093-multi-tenant-isolation-tier-0.md) — Multi-tenant Tier 0
+- [ADR 0094](0094-constituicao-v2-7-camadas-8-principios.md) — Constituição V2
+- [ADR 0101](0101-tests-business-id-1-nunca-cliente.md) — Tests biz=1
+- [ADR 0114](0114-prototipo-ui-cowork-loop-formalizado.md) — Loop Cowork formal
+- [ADR 0143](0143-fsm-pipeline-live-prod-marco-2026-05-12.md) — FSM pipeline pattern
+- [Modules/RecurringBilling/README.md](../../Modules/RecurringBilling/README.md) — origem da extração
+- [Modules/RecurringBilling/SCOPE.md](../../Modules/RecurringBilling/SCOPE.md)
+- [Modules/Superadmin/Entities/Subscription.php](../../Modules/Superadmin/Entities/Subscription.php) — eliminada como source-of-truth
+- Resolução BCB 380/2024 — PIX Automático (regulamentação driver `bcb_pix`)
+
+---
+
+**Última atualização:** 2026-05-19 · F0 brief Wagner+Cowork

--- a/memory/what-oimpresso.md
+++ b/memory/what-oimpresso.md
@@ -54,6 +54,7 @@ oimpresso (núcleo comum)
 ├── Modules/Financeiro    (visão unificada AR/AP)
 ├── Modules/NfeBrasil     (NFe/NFC-e/NFSe)
 ├── Modules/RecurringBilling (assinaturas + boletos)
+├── Modules/PaymentGateway   (🟡 Onda 0 docs only — ADR 0170 proposto — drivers Inter/C6/Asaas/PixAuto/CNAB, extração de RecurringBilling, status: later phase=2)
 ├── Modules/MemCofre      (cofre senhas)
 ├── Modules/Repair        (Kanban OS — shared infrastructure entre verticais)
 └── Modules/<Vertical>    ← ESPECIALIZAÇÕES PROFUNDAS

--- a/prototipo-ui/_cowork-export-2026-05-15/AUDITORIA_MODULOS.md
+++ b/prototipo-ui/_cowork-export-2026-05-15/AUDITORIA_MODULOS.md
@@ -54,7 +54,7 @@
 | `ponto` | `Ponto` (PontoWr2) | partial | F4 |
 | `equipes` | `Officeimpresso/equipes` | later | F5 |
 
-### FINANCEIRO (6)
+### FINANCEIRO (7)
 | Id | Módulo no repo | Status | Fase |
 |---|---|---|---|
 | `financeiro` | `Financeiro` | **done** | F1 ✅ |
@@ -63,6 +63,7 @@
 | `nfe` | `NfeBrasil` | partial | F1 |
 | `accounting` | `Accounting` | later | F1 |
 | `recurring` | `RecurringBilling` | later | F1 |
+| `paymentgateway` | `PaymentGateway` | later | F1 (Onda 0 — ADR 0170 proposto, só docs) |
 
 ### PROJETOS & GESTÃO (6)
 | Id | Módulo no repo | Status | Fase |

--- a/prototipo-ui/_cowork-export-2026-05-15/AUDITORIA_MODULOS.md
+++ b/prototipo-ui/_cowork-export-2026-05-15/AUDITORIA_MODULOS.md
@@ -7,7 +7,9 @@
 
 | Total no repo | No menu antes | No menu agora | Migrados (React) | Em iteração |
 |---|---|---|---|---|
-| **36** | 14 | **36** | 4 (Financeiro, MemCofre, Copiloto, Cms/Site) | 3 (Ponto WR2, NFSe, NfeBrasil) parciais |
+| **37** | 14 | **36** | 4 (Financeiro, MemCofre, Copiloto, Cms/Site) | 3 (Ponto WR2, NFSe, NfeBrasil) parciais |
+
+> **+1 desde 2026-05-13:** `Modules/PaymentGateway` adicionado em 2026-05-19 (Onda 0 — docs only, ADR 0170). Ainda não no menu (não habilitado).
 
 ## Por grupo no shell
 


### PR DESCRIPTION
> **Onda 0 — só docs.** Este PR registra **`Modules/PaymentGateway`** no repo via 4 arquivos canônicos (ADR + SCOPE + README + CONTRACTS) + mapa CLAUDE.md + linha auditoria. **Nenhum código de aplicação.** Ondas 1-6 cada uma será PR/ADR filho separado.

## Numeração — renumerado 0115 → 0144 → 0170

Cowork F0 propôs 0115. Já ocupado por `0115-recuperacao-cliente-gold-via-bundle-oimpresso.md` (canon, aceito). Wagner sugeriu fallback 0144 — também ocupado por `0144-tasks-db-canonico-spec-template.md`. Próximo livre = **0170** (último = 0169). Aplicado `sed s/0144/0170/g` nos 4 arquivos + rename filename.

Refs ADRs citadas todas existem no repo: 0017, 0079, 0080, 0093, 0094, 0101, 0114, 0143. ✓

## Decisão

### A — Criar `Modules/PaymentGateway`

Módulo novo, Trust L3 (toca dinheiro + LGPD + regulação BCB), permission prefix `paymentgateway.*`. Conteúdo (extraído de `Modules/RecurringBilling`):

- **Entities:** `Cobranca`, `PaymentGatewayCredential`, `GatewayWebhookEvent`
- **Drivers:** `InterDriver`, `C6Driver`, `AsaasDriver`, `PixAutomaticoBcbDriver` (novo — Resolução BCB 380/2024), `PesaPalDriver` (deprecated, vestigial)
- **Services:** `BoletoService`, `PixService` (novo — cob/cobv/recv), `CardService` (novo), `RemessaCnabService`, `RetornoCnabService`, `PaymentGatewayCredentialResolver` (ex-`BoletoCredentialResolver`)
- **Controllers:** `PaymentGatewayController` (Settings › Gateways), `CobrancaController` (Financeiro › Cobrança), webhooks Inter/C6/Asaas/BcbPix
- **Events:** `CobrancaEmitida`, `CobrancaPaga`, `CobrancaVencida`, `CobrancaCancelada`, `CobrancaErro`
- **Contracts:** `PaymentGatewayContract` (API pública) + `PaymentDriverContract`

### B — `Modules/RecurringBilling` fica enxuto

Permanece: `Plan`, `Assinatura` (rename), `Invoice`, FSM lifecycle, cron geração Invoice, MRR/churn dashboards, US-RB-044 NFSe-de-boleto-pago (vira listener de `CobrancaPaga`).

Sai: drivers, webhooks bancários, CNAB, credenciais, lógica de emissão técnica.

## Roadmap — 6 ondas

| Onda | O quê | Pode quebrar prod? | Reversível? |
|---|---|---|---|
| **0 · ADR + SCOPE** (este PR) | ADR 0170 + SCOPE/README/CONTRACTS em `Modules/PaymentGateway/` (vazio, só docs) | Não | Trivial |
| **1 · Esqueleto** | module.json + ServiceProvider + Contracts + DTOs + Events. Eventos shadow do RB | Não | Sim, flag |
| **2 · Migrar credentials** | Cria `payment_gateway_credentials`. Backfill `accounts.*gateway*`. RB lê via Resolver. Colunas antigas nullable + deprecated | Médio (DDL) | Reverte migration + restaura FK |
| **3 · Migrar webhooks** | InterWebhook/C6/Asaas movem. URLs antigas → 301 redirect. Eventos disparados | Alto — testar sandbox antes | Manter rotas duplicadas 30d |
| **4 · Mover domínio** | BoletoService/Resolver movem. PixService + PixAutomaticoBcbDriver novos. Tela Financeiro › Cobrança (Cockpit). Sell drawer ganha "Emitir cobrança" | Alto — Larissa vê tela nova | Flag `feature.cobranca_v2` rollback |
| **5 · Dogfooding Superadmin** | Plan "SaaS Oimpresso Premium" em biz=1. Tenants viram Contact biz=1. `Superadmin::Subscription` vira projection. PesaPal deprecated | Médio — afeta cobrança SaaS Wagner ↔ tenants | Manter Subscription source-of-truth via flag |
| **6 · Cleanup** | Remove colunas legacy de `accounts`. Remove `PesaPalController`. Remove redirects 301 | Baixo se 2-5 estáveis 90d | DDL forward |

Cada onda = PR isolada + ADR per-onda (filha de 0170) + smoke biz=1 antes de promover.

## Decisões Wagner F0 (2026-05-19)

1. **PIX Automático BCB direto** — driver dedicado (`PixAutomaticoBcbDriver`), não via Inter/C6. Razão: Resolução BCB 380/2024 + regulação isolada
2. **Subscription Superadmin vira projection** — eliminação de duplicação semântica. Source-of-truth única em `Modules/RecurringBilling::Assinatura` (rename)
3. **PesaPal deprecated** — vestigial, será substituído por Inter + PIX Automático (Onda 5)

## Files

- `memory/decisions/0170-paymentgateway-extracao-camada-cobranca.md` — ADR canônico (status: proposto)
- `Modules/PaymentGateway/SCOPE.md` — 73 linhas, formato Modules/RecurringBilling
- `Modules/PaymentGateway/README.md` — 179 linhas, onboarding consumer
- `Modules/PaymentGateway/CONTRACTS.md` — 412 linhas, interfaces + DTOs + payloads
- `memory/what-oimpresso.md` — mapa módulos atualizado (próximo a RecurringBilling)
- `prototipo-ui/_cowork-export-2026-05-15/AUDITORIA_MODULOS.md` — linha PaymentGateway em FINANCEIRO (7)

## Não inclui

- ❌ Nenhum `.php` runtime (zero código)
- ❌ Nenhuma migration
- ❌ Nenhum teste Pest (não há código pra testar)
- ❌ Nenhuma rota
- ❌ `module.json` (será Onda 1)

## Validação pré-merge

- [x] ADR refs (0017/0079/0080/0093/0094/0101/0114/0143) todas existem
- [x] SCOPE format alinhado com `Modules/RecurringBilling/SCOPE.md`
- [x] Frontmatter funcional (usa `emends`, convenção mista no repo — 0107-0114 usam `emends`, 0116+ usam `amends`; preservado conforme baixado)
- [x] Numeração 0170 livre, último ADR = 0169
- [ ] Review humano da Decisão (status: proposto → aceito pelo Wagner)

## Próxima ação após merge

ADR 0170 vira `aceito`. Próximo PR/ADR filho = **Onda 1 (esqueleto)** — module.json + ServiceProvider + Contracts + DTOs + Events (sem driver real ainda).

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)