### PR TITLE
feat(paymentgateway): Onda 1 esqueleto — ADR 0170

### DIFF
--- a/Modules/PaymentGateway/Config/config.php
+++ b/Modules/PaymentGateway/Config/config.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    'name' => 'PaymentGateway',
+    'module_version' => '0.1.0',
+];

--- a/Modules/PaymentGateway/Contracts/PaymentDriverContract.php
+++ b/Modules/PaymentGateway/Contracts/PaymentDriverContract.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Contracts;
+
+use Modules\PaymentGateway\Dto\CardToken;
+use Modules\PaymentGateway\Dto\CobrancaEmitidaResult;
+use Modules\PaymentGateway\Dto\CobrancaStatus;
+use Modules\PaymentGateway\Dto\DriverHealth;
+use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
+
+/**
+ * Interface dos drivers concretos (Inter/C6/Asaas/BCB Pix/PesaPal).
+ *
+ * NÃO é API pública — listada aqui só pra documentar contrato interno.
+ * Drivers reais chegam em Onda 4.
+ *
+ * Cobranca + PaymentGatewayCredential são tipados como object pois
+ * Entities concretas só nascem em Onda 2.
+ *
+ * ADR 0170 — CONTRACTS.md §1.
+ */
+interface PaymentDriverContract
+{
+    /**
+     * Chave única do driver (inter | c6 | asaas | bcb_pix | pesapal).
+     */
+    public function key(): string;
+
+    /**
+     * Driver suporta este tipo de operação?
+     *
+     * @param string $tipo boleto | pix_cob | pix_cobv | pix_recv | card
+     */
+    public function supports(string $tipo): bool;
+
+    public function emitirBoleto(EmitirCobrancaInput $input, object $cred): CobrancaEmitidaResult;
+
+    public function emitirPix(EmitirCobrancaInput $input, object $cred, string $tipo): CobrancaEmitidaResult;
+
+    public function emitirPixAutomatico(EmitirCobrancaInput $input, object $cred): CobrancaEmitidaResult;
+
+    public function cobrarCartao(EmitirCobrancaInput $input, object $cred, CardToken $token): CobrancaEmitidaResult;
+
+    public function cancelar(object $cobranca, object $cred, string $motivo): void;
+
+    public function refund(object $cobranca, object $cred, ?int $valorCentavos, string $motivo): void;
+
+    public function consultar(object $cobranca, object $cred): CobrancaStatus;
+
+    public function healthCheck(object $cred): DriverHealth;
+
+    /**
+     * Processa payload de webhook do gateway e retorna a Cobranca afetada
+     * (ou null se for evento ignorável). Validação HMAC é responsabilidade
+     * do driver.
+     */
+    public function processWebhook(array $payload, object $cred): ?object;
+}

--- a/Modules/PaymentGateway/Contracts/PaymentGatewayContract.php
+++ b/Modules/PaymentGateway/Contracts/PaymentGatewayContract.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Contracts;
+
+use App\Account;
+use Modules\PaymentGateway\Dto\CardToken;
+use Modules\PaymentGateway\Dto\CobrancaEmitidaResult;
+use Modules\PaymentGateway\Dto\CobrancaStatus;
+use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
+
+/**
+ * API pública do módulo PaymentGateway — quem precisa cobrar usa só isso.
+ *
+ * Implementação concreta + binding container chegam em Onda 4.
+ * Onda 1 (esta) define apenas a interface — drivers reais ainda em
+ * Modules/RecurringBilling.
+ *
+ * ADR 0170 — CONTRACTS.md §1.
+ */
+interface PaymentGatewayContract
+{
+    /**
+     * Seleciona a credencial de gateway vinculada à conta.
+     *
+     * Idempotente — pode ser chamado várias vezes na mesma request.
+     *
+     * @throws \Modules\PaymentGateway\Exceptions\CredentialMisconfiguredException
+     */
+    public function for(Account $account): self;
+
+    /**
+     * Emite boleto único.
+     *
+     * Idempotência via $input->idempotencyKey — se já existe Cobranca
+     * em status emitida|paga, retorna resultado anterior sem chamar gateway.
+     *
+     * @throws \Modules\PaymentGateway\Exceptions\GatewayUnavailableException
+     * @throws \Modules\PaymentGateway\Exceptions\InvalidPayerException
+     * @throws \Modules\PaymentGateway\Exceptions\CredentialMisconfiguredException
+     */
+    public function emitirBoleto(EmitirCobrancaInput $input): CobrancaEmitidaResult;
+
+    /**
+     * Emite PIX cobrança.
+     *
+     * @param string $tipo 'cob' (imediata) | 'cobv' (com vencimento)
+     */
+    public function emitirPix(EmitirCobrancaInput $input, string $tipo = 'cob'): CobrancaEmitidaResult;
+
+    /**
+     * Emite PIX Automático BCB (mandato recorrente).
+     *
+     * Suportado apenas por driver bcb_pix hoje.
+     *
+     * @throws \Modules\PaymentGateway\Exceptions\DriverNotSupportedException
+     */
+    public function emitirPixAutomatico(EmitirCobrancaInput $input): CobrancaEmitidaResult;
+
+    /**
+     * Tokeniza + cobra cartão.
+     *
+     * @throws \Modules\PaymentGateway\Exceptions\DriverNotSupportedException
+     * @throws \Modules\PaymentGateway\Exceptions\CardDeclinedException
+     */
+    public function cobrarCartao(EmitirCobrancaInput $input, CardToken $token): CobrancaEmitidaResult;
+
+    /**
+     * Cancela cobrança ainda não paga.
+     *
+     * Para estornar cobrança JÁ paga, use refund().
+     */
+    public function cancelar(object $cobranca, string $motivo): void;
+
+    /**
+     * Estorna cobrança paga. Driver-dependente.
+     *
+     * @throws \Modules\PaymentGateway\Exceptions\DriverNotSupportedException
+     */
+    public function refund(object $cobranca, ?int $valorCentavos, string $motivo): void;
+
+    /**
+     * Consulta status atualizado direto no gateway (bypass cache local).
+     */
+    public function consultar(object $cobranca): CobrancaStatus;
+}

--- a/Modules/PaymentGateway/Dto/CardToken.php
+++ b/Modules/PaymentGateway/Dto/CardToken.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Dto;
+
+/**
+ * Token de cartão PCI-DSS — referência opaca no provedor.
+ *
+ * NUNCA contém PAN bruto. lastFour + brand + holderName são metadados
+ * para UX (mascaramento) e auditoria. Imutável.
+ *
+ * ADR 0170 — CONTRACTS.md §2.
+ */
+final class CardToken
+{
+    public function __construct(
+        public readonly string $token,
+        public readonly string $brand,
+        public readonly string $lastFour,
+        public readonly string $holderName,
+        public readonly string $expMonth,
+        public readonly string $expYear,
+    ) {
+    }
+}

--- a/Modules/PaymentGateway/Dto/CobrancaEmitidaResult.php
+++ b/Modules/PaymentGateway/Dto/CobrancaEmitidaResult.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Dto;
+
+/**
+ * Resultado da emissão de cobrança — retornado pelo driver.
+ *
+ * Inclui artefatos PCI/LGPD-safe (linha digitável, EMV, QR path) +
+ * payload bruto pra auditoria. Imutável.
+ *
+ * ADR 0170 — CONTRACTS.md §2.
+ */
+final class CobrancaEmitidaResult
+{
+    public function __construct(
+        public readonly int $cobrancaId,
+        public readonly string $gatewayExternalId,
+        public readonly string $tipo,
+        public readonly \DateTimeImmutable $emitidaEm,
+        public readonly ?string $linhaDigitavel = null,
+        public readonly ?string $codigoBarras = null,
+        public readonly ?string $pixEmv = null,
+        public readonly ?string $pixQrCodePath = null,
+        public readonly ?string $boletoPdfUrl = null,
+        public readonly ?string $nossoNumero = null,
+        public readonly array $payloadGateway = [],
+    ) {
+    }
+}

--- a/Modules/PaymentGateway/Dto/CobrancaStatus.php
+++ b/Modules/PaymentGateway/Dto/CobrancaStatus.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Dto;
+
+/**
+ * Status consultado direto no gateway (bypass cache local).
+ *
+ * Útil pra reconciliação manual quando webhook atrasou ou foi perdido.
+ * Imutável.
+ *
+ * ADR 0170 — CONTRACTS.md §2.
+ */
+final class CobrancaStatus
+{
+    public function __construct(
+        public readonly string $status,
+        public readonly ?\DateTimeImmutable $pagaEm = null,
+        public readonly ?int $valorPagoCentavos = null,
+        public readonly ?string $formaPagamento = null,
+        public readonly ?string $payerCpfCnpj = null,
+        public readonly array $payloadGateway = [],
+    ) {
+    }
+}

--- a/Modules/PaymentGateway/Dto/DriverHealth.php
+++ b/Modules/PaymentGateway/Dto/DriverHealth.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Dto;
+
+/**
+ * Resultado de health check de driver (usado por
+ * paymentgateway:health cron + alertas).
+ *
+ * Imutável.
+ *
+ * ADR 0170 — CONTRACTS.md §2.
+ */
+final class DriverHealth
+{
+    public function __construct(
+        public readonly bool $ok,
+        public readonly string $status,
+        public readonly int $latencyMs,
+        public readonly \DateTimeImmutable $checkedAt,
+        public readonly ?string $errorMessage = null,
+    ) {
+    }
+}

--- a/Modules/PaymentGateway/Dto/EmitirCobrancaInput.php
+++ b/Modules/PaymentGateway/Dto/EmitirCobrancaInput.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Dto;
+
+/**
+ * Input pra emitir cobrança (boleto/PIX/cartão).
+ *
+ * Imutável — segura pra passar entre listeners + workers sem corrida.
+ * Idempotency: $idempotencyKey é o vínculo lógico entre tentativas.
+ *
+ * ADR 0170 — CONTRACTS.md §2.
+ */
+final class EmitirCobrancaInput
+{
+    public function __construct(
+        public readonly int $businessId,
+        public readonly int $contactId,
+        public readonly int $valorCentavos,
+        public readonly \DateTimeImmutable $vencimento,
+        public readonly string $descricao,
+        public readonly string $idempotencyKey,
+        public readonly ?string $origemType = null,
+        public readonly ?int $origemId = null,
+        public readonly array $multa = [],
+        public readonly array $juros = [],
+        public readonly array $desconto = [],
+        public readonly ?string $instrucoesPagador = null,
+        public readonly ?string $callbackUrl = null,
+        public readonly array $meta = [],
+    ) {
+    }
+}

--- a/Modules/PaymentGateway/Events/CobrancaCancelada.php
+++ b/Modules/PaymentGateway/Events/CobrancaCancelada.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Cobrança foi cancelada antes de pagamento (boleto cancelado, PIX
+ * mandato revogado).
+ *
+ * Distinto de refund (que é estorno de cobrança JÁ paga).
+ *
+ * Listeners esperados (ADR 0170 CONTRACTS.md §3):
+ *   - RecurringBilling\Listeners\CancelInvoice
+ *   - Core\Listeners\MarkSaleCancelled
+ */
+class CobrancaCancelada
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly int $cobrancaId,
+        public readonly int $businessId,
+        public readonly string $motivo,
+        public readonly int $canceladoPor,
+        public readonly \DateTimeImmutable $occurredAt,
+        public readonly ?string $origemType = null,
+        public readonly ?int $origemId = null,
+    ) {
+    }
+}

--- a/Modules/PaymentGateway/Events/CobrancaEmitida.php
+++ b/Modules/PaymentGateway/Events/CobrancaEmitida.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Cobrança foi emitida no gateway (boleto gerado, PIX cob criado, etc).
+ *
+ * Listeners esperados (ADR 0170 CONTRACTS.md §3):
+ *   - RecurringBilling\Listeners\MarkInvoiceCobrancaEmitida
+ *   - Core\Listeners\MarkSalePaymentPending
+ *
+ * Onda 1 dispara em modo shadow (sem listeners reais ainda).
+ */
+class CobrancaEmitida
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly int $cobrancaId,
+        public readonly int $businessId,
+        public readonly string $tipo,
+        public readonly int $valorCentavos,
+        public readonly \DateTimeImmutable $vencimento,
+        public readonly \DateTimeImmutable $occurredAt,
+        public readonly ?string $origemType = null,
+        public readonly ?int $origemId = null,
+    ) {
+    }
+}

--- a/Modules/PaymentGateway/Events/CobrancaErro.php
+++ b/Modules/PaymentGateway/Events/CobrancaErro.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Erro durante tentativa de emissão/cancelamento/refund.
+ *
+ * Payload `context` DEVE ser sanitizado (sem PII bruta) — listeners
+ * usam para audit + Otel spans + retry-strategy.
+ *
+ * Listeners esperados (ADR 0170 CONTRACTS.md §3):
+ *   - Otel\Listeners\RecordCobrancaErro
+ *   - PaymentGateway\Listeners\AlertHealthCheck
+ *   - RecurringBilling\Listeners\StopRetryIfCredentialError
+ */
+class CobrancaErro
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly int $businessId,
+        public readonly string $exception,
+        public readonly string $message,
+        public readonly string $driverKey,
+        public readonly array $context,
+        public readonly \DateTimeImmutable $occurredAt,
+        public readonly ?int $cobrancaId = null,
+        public readonly ?string $origemType = null,
+        public readonly ?int $origemId = null,
+    ) {
+    }
+}

--- a/Modules/PaymentGateway/Events/CobrancaPaga.php
+++ b/Modules/PaymentGateway/Events/CobrancaPaga.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Cobrança foi paga — evento canônico do módulo.
+ *
+ * Listeners esperados em ordem (ADR 0170 CONTRACTS.md §3):
+ *   1. RecurringBilling\Listeners\MarkInvoicePaid
+ *   2. NFSe\Listeners\EmitirNfseFromCobrancaPaga   ⭐ US-RB-044 irrevogável
+ *   3. Core\Listeners\CreateAccountTransactionFromCobranca
+ *   4. Core\Listeners\MarkSalePaid
+ *   5. Superadmin\Listeners\RenovarLicencaTenant   (Onda 5)
+ */
+class CobrancaPaga
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly int $cobrancaId,
+        public readonly int $businessId,
+        public readonly int $valorPagoCentavos,
+        public readonly \DateTimeImmutable $pagaEm,
+        public readonly string $formaPagamento,
+        public readonly \DateTimeImmutable $occurredAt,
+        public readonly ?string $payerCpfCnpj = null,
+        public readonly ?string $origemType = null,
+        public readonly ?int $origemId = null,
+    ) {
+    }
+}

--- a/Modules/PaymentGateway/Events/CobrancaVencida.php
+++ b/Modules/PaymentGateway/Events/CobrancaVencida.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Events;
+
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+/**
+ * Cobrança passou da data de vencimento sem pagamento confirmado.
+ *
+ * Disparado por job diário (Onda 3+) que varre cobrancas WHERE
+ * status='emitida' AND vencimento < today.
+ *
+ * Listeners esperados (ADR 0170 CONTRACTS.md §3):
+ *   - RecurringBilling\Listeners\SmartRetryRecurringInvoice
+ *   - RecurringBilling\Listeners\SubscriptionOverdue
+ *   - Core\Listeners\NotifyContactPaymentOverdue
+ */
+class CobrancaVencida
+{
+    use Dispatchable;
+    use SerializesModels;
+
+    public function __construct(
+        public readonly int $cobrancaId,
+        public readonly int $businessId,
+        public readonly int $diasVencido,
+        public readonly \DateTimeImmutable $vencimentoOriginal,
+        public readonly \DateTimeImmutable $occurredAt,
+        public readonly ?string $origemType = null,
+        public readonly ?int $origemId = null,
+    ) {
+    }
+}

--- a/Modules/PaymentGateway/Exceptions/CardDeclinedException.php
+++ b/Modules/PaymentGateway/Exceptions/CardDeclinedException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Modules\PaymentGateway\Exceptions;
+
+/**
+ * Emissor recusou cobrança em cartão (saldo, antifraude, validade).
+ * NÃO é retry imediato — humano tenta outro cartão ou método.
+ */
+class CardDeclinedException extends PaymentGatewayException
+{
+}

--- a/Modules/PaymentGateway/Exceptions/CredentialMisconfiguredException.php
+++ b/Modules/PaymentGateway/Exceptions/CredentialMisconfiguredException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Modules\PaymentGateway\Exceptions;
+
+/**
+ * Credencial de gateway está em estado inválido: cert vencido, secret
+ * rotacionado, escopo OAuth insuficiente. NÃO é retry-safe — humano resolve.
+ */
+class CredentialMisconfiguredException extends PaymentGatewayException
+{
+}

--- a/Modules/PaymentGateway/Exceptions/DriverNotSupportedException.php
+++ b/Modules/PaymentGateway/Exceptions/DriverNotSupportedException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Modules\PaymentGateway\Exceptions;
+
+/**
+ * Driver atual não suporta a operação pedida (ex: PIX Automático em Asaas,
+ * cartão em Inter sandbox). NÃO é retry — chame Service::supports() antes.
+ */
+class DriverNotSupportedException extends PaymentGatewayException
+{
+}

--- a/Modules/PaymentGateway/Exceptions/GatewayUnavailableException.php
+++ b/Modules/PaymentGateway/Exceptions/GatewayUnavailableException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Modules\PaymentGateway\Exceptions;
+
+/**
+ * Gateway externo respondeu 5xx, timeout, ou conexão recusada.
+ * Operação pode ser retry-safe (depende do contexto — ver listener).
+ */
+class GatewayUnavailableException extends PaymentGatewayException
+{
+}

--- a/Modules/PaymentGateway/Exceptions/IdempotencyConflictException.php
+++ b/Modules/PaymentGateway/Exceptions/IdempotencyConflictException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Modules\PaymentGateway\Exceptions;
+
+/**
+ * Tentativa de reemitir cobrança com idempotency_key já registrada em
+ * status paga|cancelada — terminal, não pode ser sobrescrito.
+ * Retorne a Cobranca existente em vez de criar nova.
+ */
+class IdempotencyConflictException extends PaymentGatewayException
+{
+}

--- a/Modules/PaymentGateway/Exceptions/InvalidPayerException.php
+++ b/Modules/PaymentGateway/Exceptions/InvalidPayerException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Modules\PaymentGateway\Exceptions;
+
+/**
+ * Dados do pagador insuficientes ou inválidos: CPF/CNPJ malformado,
+ * endereço ausente quando obrigatório pelo driver, e-mail inválido.
+ * NÃO é retry-safe — humano corrige cadastro.
+ */
+class InvalidPayerException extends PaymentGatewayException
+{
+}

--- a/Modules/PaymentGateway/Exceptions/PaymentGatewayException.php
+++ b/Modules/PaymentGateway/Exceptions/PaymentGatewayException.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Modules\PaymentGateway\Exceptions;
+
+use RuntimeException;
+
+/**
+ * Raiz da hierarquia de exceções públicas do módulo PaymentGateway.
+ *
+ * Qualquer subclasse extends desta — listeners podem fazer catch genérico
+ * sem precisar conhecer cada driver-specific exception.
+ *
+ * ADR 0170 — CONTRACTS.md §4.
+ */
+class PaymentGatewayException extends RuntimeException
+{
+}

--- a/Modules/PaymentGateway/Exceptions/WebhookSignatureInvalidException.php
+++ b/Modules/PaymentGateway/Exceptions/WebhookSignatureInvalidException.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Modules\PaymentGateway\Exceptions;
+
+/**
+ * Assinatura HMAC do webhook não confere com secret esperado.
+ * Sinal forte de tentativa de spoofing — log + alerta SOC.
+ * NUNCA processar payload de webhook que jogou essa exceção.
+ */
+class WebhookSignatureInvalidException extends PaymentGatewayException
+{
+}

--- a/Modules/PaymentGateway/Http/Controllers/DataController.php
+++ b/Modules/PaymentGateway/Http/Controllers/DataController.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Modules\PaymentGateway\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+
+/**
+ * DataController do módulo PaymentGateway — Onda 1 esqueleto.
+ *
+ * Descoberto pelo middleware AdminSidebarMenu do core UltimatePOS.
+ * Sidebar pattern canon: skill `sidebar-menu-arch`.
+ *
+ * Onda 1 (esta): apenas superadmin_package + user_permissions registrados
+ * pra que Wagner possa habilitar nas 3 camadas (subscription package +
+ * business.enabled_modules + Spatie permissions) antes de Onda 4 entregar
+ * Page Inertia "Cobrança" no sidebar.
+ *
+ * modifyAdminMenu vazio nesta onda — ativa em Onda 4 quando tela existir.
+ */
+class DataController extends Controller
+{
+    /**
+     * Camada 1 — registro no Superadmin Package.
+     * Wagner marca em /superadmin/packages/{id}/edit pra liberar pra business.
+     */
+    public function superadmin_package(): array
+    {
+        return [
+            [
+                'name'    => 'paymentgateway_module',
+                'label'   => __('paymentgateway::paymentgateway.module_label'),
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Camada 3 — Permissions Spatie granulares.
+     *
+     * `paymentgateway.access` é raiz (vê Page + sidebar item).
+     * Demais granulares per CONTRACTS.md §7 — separação Tier escalado pra refund.
+     */
+    public function user_permissions(): array
+    {
+        return [
+            ['value' => 'paymentgateway.access',                  'label' => __('paymentgateway::paymentgateway.permissao_acesso'),                  'default' => false],
+            ['value' => 'paymentgateway.credenciais.viewAny',     'label' => __('paymentgateway::paymentgateway.permissao_credenciais_viewAny'),     'default' => false],
+            ['value' => 'paymentgateway.credenciais.create',      'label' => __('paymentgateway::paymentgateway.permissao_credenciais_create'),      'default' => false],
+            ['value' => 'paymentgateway.credenciais.update',      'label' => __('paymentgateway::paymentgateway.permissao_credenciais_update'),      'default' => false],
+            ['value' => 'paymentgateway.credenciais.delete',      'label' => __('paymentgateway::paymentgateway.permissao_credenciais_delete'),      'default' => false],
+            ['value' => 'paymentgateway.cobranca.viewAny',        'label' => __('paymentgateway::paymentgateway.permissao_cobranca_viewAny'),        'default' => false],
+            ['value' => 'paymentgateway.cobranca.emit',           'label' => __('paymentgateway::paymentgateway.permissao_cobranca_emit'),           'default' => false],
+            ['value' => 'paymentgateway.cobranca.cancel',         'label' => __('paymentgateway::paymentgateway.permissao_cobranca_cancel'),         'default' => false],
+            ['value' => 'paymentgateway.cobranca.refund',         'label' => __('paymentgateway::paymentgateway.permissao_cobranca_refund'),         'default' => false],
+            ['value' => 'paymentgateway.webhook.replay',          'label' => __('paymentgateway::paymentgateway.permissao_webhook_replay'),          'default' => false],
+        ];
+    }
+
+    /**
+     * Camada visual sidebar — Onda 1 vazio. Onda 4 ativa quando Page Cobrança nascer.
+     */
+    public function modifyAdminMenu(): void
+    {
+        // intencionalmente vazio — vide docblock.
+    }
+}

--- a/Modules/PaymentGateway/Http/Controllers/InstallController.php
+++ b/Modules/PaymentGateway/Http/Controllers/InstallController.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Modules\PaymentGateway\Http\Controllers;
+
+use App\Http\Controllers\BaseModuleInstallController;
+
+class InstallController extends BaseModuleInstallController
+{
+    protected function moduleName(): string
+    {
+        return 'PaymentGateway';
+    }
+
+    protected function moduleSystemKey(): string
+    {
+        return 'paymentgateway';
+    }
+
+    protected function moduleVersion(): string
+    {
+        return (string) config('paymentgateway.module_version', '0.1.0');
+    }
+
+    protected function successMessage(): string
+    {
+        return 'Módulo PaymentGateway (esqueleto) instalado. Drivers/credenciais/webhooks chegam em ondas futuras (ADR 0170).';
+    }
+}

--- a/Modules/PaymentGateway/Providers/PaymentGatewayServiceProvider.php
+++ b/Modules/PaymentGateway/Providers/PaymentGatewayServiceProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Modules\PaymentGateway\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class PaymentGatewayServiceProvider extends ServiceProvider
+{
+    protected string $moduleName = 'PaymentGateway';
+
+    protected string $moduleNameLower = 'paymentgateway';
+
+    /**
+     * Boot the application events.
+     */
+    public function boot(): void
+    {
+        $this->registerTranslations();
+        $this->registerConfig();
+        $this->loadMigrationsFrom(module_path($this->moduleName, 'Database/Migrations'));
+    }
+
+    /**
+     * Register the service provider.
+     */
+    public function register(): void
+    {
+        $this->app->register(RouteServiceProvider::class);
+    }
+
+    /**
+     * Register config.
+     */
+    protected function registerConfig(): void
+    {
+        $this->publishes([
+            module_path($this->moduleName, 'Config/config.php') => config_path($this->moduleNameLower.'.php'),
+        ], 'config');
+
+        $this->mergeConfigFrom(
+            module_path($this->moduleName, 'Config/config.php'), $this->moduleNameLower
+        );
+    }
+
+    /**
+     * Register translations.
+     */
+    public function registerTranslations(): void
+    {
+        $langPath = resource_path('lang/modules/'.$this->moduleNameLower);
+
+        if (is_dir($langPath)) {
+            $this->loadTranslationsFrom($langPath, $this->moduleNameLower);
+            $this->loadJsonTranslationsFrom($langPath);
+        } else {
+            $this->loadTranslationsFrom(module_path($this->moduleName, 'Resources/lang'), $this->moduleNameLower);
+            $this->loadJsonTranslationsFrom(module_path($this->moduleName, 'Resources/lang'));
+        }
+    }
+
+    /**
+     * Get the services provided by the provider.
+     */
+    public function provides(): array
+    {
+        return [];
+    }
+}

--- a/Modules/PaymentGateway/Providers/RouteServiceProvider.php
+++ b/Modules/PaymentGateway/Providers/RouteServiceProvider.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Modules\PaymentGateway\Providers;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    /**
+     * The module namespace to assume when generating URLs to actions.
+     */
+    protected string $moduleNamespace = 'Modules\PaymentGateway\Http\Controllers';
+
+    /**
+     * Called before routes are registered.
+     */
+    public function boot(): void
+    {
+        parent::boot();
+    }
+
+    /**
+     * Define the routes for the application.
+     */
+    public function map(): void
+    {
+        $this->mapWebRoutes();
+    }
+
+    /**
+     * Define the "web" routes for the application.
+     */
+    protected function mapWebRoutes(): void
+    {
+        Route::middleware('web')
+            ->namespace($this->moduleNamespace)
+            ->group(module_path('PaymentGateway', '/Routes/web.php'));
+    }
+}

--- a/Modules/PaymentGateway/Resources/lang/pt-BR/paymentgateway.php
+++ b/Modules/PaymentGateway/Resources/lang/pt-BR/paymentgateway.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'module_label' => 'Gateway de Cobrança',
+    'permissao_acesso'                  => 'Gateway de Cobrança: Acesso ao módulo',
+    'permissao_credenciais_viewAny'     => 'Gateway de Cobrança: Listar credenciais',
+    'permissao_credenciais_create'      => 'Gateway de Cobrança: Criar credencial',
+    'permissao_credenciais_update'      => 'Gateway de Cobrança: Editar credencial',
+    'permissao_credenciais_delete'      => 'Gateway de Cobrança: Excluir credencial',
+    'permissao_cobranca_viewAny'        => 'Gateway de Cobrança: Listar cobranças',
+    'permissao_cobranca_emit'           => 'Gateway de Cobrança: Emitir cobrança',
+    'permissao_cobranca_cancel'         => 'Gateway de Cobrança: Cancelar cobrança',
+    'permissao_cobranca_refund'         => 'Gateway de Cobrança: Estornar cobrança (Tier escalado)',
+    'permissao_webhook_replay'          => 'Gateway de Cobrança: Reprocessar webhook (debug)',
+];

--- a/Modules/PaymentGateway/Routes/web.php
+++ b/Modules/PaymentGateway/Routes/web.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\PaymentGateway\Http\Controllers\InstallController;
+
+/*
+|--------------------------------------------------------------------------
+| Web Routes — PaymentGateway (Onda 1 esqueleto)
+|--------------------------------------------------------------------------
+|
+| ADR 0170 Onda 1: só Install routes. Ondas 3-4 adicionam webhooks + CRUD
+| cobrança + credenciais.
+|
+*/
+
+Route::middleware(['web', 'authh', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu'])
+    ->prefix('paymentgateway')
+    ->group(function () {
+        Route::get('install', [InstallController::class, 'index']);
+        Route::get('install/uninstall', [InstallController::class, 'uninstall']);
+        Route::get('install/update', [InstallController::class, 'update']);
+    });

--- a/Modules/PaymentGateway/Tests/Feature/OndaUmEsqueletoTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/OndaUmEsqueletoTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\PaymentGateway\Contracts\PaymentDriverContract;
+use Modules\PaymentGateway\Contracts\PaymentGatewayContract;
+use Modules\PaymentGateway\Dto\CardToken;
+use Modules\PaymentGateway\Dto\CobrancaEmitidaResult;
+use Modules\PaymentGateway\Dto\CobrancaStatus;
+use Modules\PaymentGateway\Dto\DriverHealth;
+use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
+use Modules\PaymentGateway\Events\CobrancaCancelada;
+use Modules\PaymentGateway\Events\CobrancaEmitida;
+use Modules\PaymentGateway\Events\CobrancaErro;
+use Modules\PaymentGateway\Events\CobrancaPaga;
+use Modules\PaymentGateway\Events\CobrancaVencida;
+use Modules\PaymentGateway\Exceptions\CardDeclinedException;
+use Modules\PaymentGateway\Exceptions\CredentialMisconfiguredException;
+use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
+use Modules\PaymentGateway\Exceptions\GatewayUnavailableException;
+use Modules\PaymentGateway\Exceptions\IdempotencyConflictException;
+use Modules\PaymentGateway\Exceptions\InvalidPayerException;
+use Modules\PaymentGateway\Exceptions\PaymentGatewayException;
+use Modules\PaymentGateway\Exceptions\WebhookSignatureInvalidException;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke esqueleto Onda 1 — ADR 0170.
+ *
+ * Garante que o módulo carrega + 2 Contracts + 5 DTOs + 5 Events +
+ * 8 Exceptions estão tipados corretos antes de Onda 2 começar a usar.
+ */
+
+it('config do módulo carrega', function () {
+    expect(config('paymentgateway.name'))->toBe('PaymentGateway');
+    expect(config('paymentgateway.module_version'))->toBe('0.1.0');
+});
+
+it('PaymentGatewayContract é interface (não classe)', function () {
+    $reflection = new ReflectionClass(PaymentGatewayContract::class);
+    expect($reflection->isInterface())->toBeTrue();
+});
+
+it('PaymentDriverContract é interface (não classe)', function () {
+    $reflection = new ReflectionClass(PaymentDriverContract::class);
+    expect($reflection->isInterface())->toBeTrue();
+});
+
+it('Contracts ainda NÃO têm binding no container (Onda 4 amarra)', function () {
+    expect(app()->bound(PaymentGatewayContract::class))->toBeFalse();
+});
+
+it('DTOs são readonly e instanciáveis', function () {
+    $input = new EmitirCobrancaInput(
+        businessId: 1,
+        contactId: 100,
+        valorCentavos: 10000,
+        vencimento: new DateTimeImmutable('2026-06-01'),
+        descricao: 'Teste',
+        idempotencyKey: 'test:smoke-1',
+    );
+    expect($input->valorCentavos)->toBe(10000);
+    expect($input->idempotencyKey)->toBe('test:smoke-1');
+
+    $result = new CobrancaEmitidaResult(
+        cobrancaId: 1,
+        gatewayExternalId: 'ext-1',
+        tipo: 'boleto',
+        emitidaEm: new DateTimeImmutable(),
+    );
+    expect($result->tipo)->toBe('boleto');
+
+    $status = new CobrancaStatus(status: 'pending');
+    expect($status->status)->toBe('pending');
+
+    $token = new CardToken(token: 't', brand: 'visa', lastFour: '4242', holderName: 'X', expMonth: '12', expYear: '2030');
+    expect($token->lastFour)->toBe('4242');
+
+    $health = new DriverHealth(ok: true, status: 'ok', latencyMs: 123, checkedAt: new DateTimeImmutable());
+    expect($health->ok)->toBeTrue();
+});
+
+it('DTOs immutability — set em readonly prop joga erro', function () {
+    $input = new EmitirCobrancaInput(
+        businessId: 1,
+        contactId: 100,
+        valorCentavos: 100,
+        vencimento: new DateTimeImmutable('2026-06-01'),
+        descricao: 'x',
+        idempotencyKey: 'k',
+    );
+    expect(fn () => $input->valorCentavos = 999)->toThrow(Error::class);
+});
+
+it('Eventos têm trait Dispatchable + SerializesModels', function () {
+    foreach ([
+        CobrancaEmitida::class,
+        CobrancaPaga::class,
+        CobrancaVencida::class,
+        CobrancaCancelada::class,
+        CobrancaErro::class,
+    ] as $eventClass) {
+        $traits = class_uses_recursive($eventClass);
+        expect($traits)->toHaveKey(Illuminate\Foundation\Events\Dispatchable::class);
+        expect($traits)->toHaveKey(Illuminate\Queue\SerializesModels::class);
+    }
+});
+
+it('Exceções específicas extendem PaymentGatewayException raiz', function () {
+    foreach ([
+        GatewayUnavailableException::class,
+        CredentialMisconfiguredException::class,
+        InvalidPayerException::class,
+        DriverNotSupportedException::class,
+        CardDeclinedException::class,
+        IdempotencyConflictException::class,
+        WebhookSignatureInvalidException::class,
+    ] as $exceptionClass) {
+        expect(is_subclass_of($exceptionClass, PaymentGatewayException::class))->toBeTrue();
+    }
+});
+
+it('PaymentGatewayException extends RuntimeException', function () {
+    expect(is_subclass_of(PaymentGatewayException::class, RuntimeException::class))->toBeTrue();
+});

--- a/Modules/PaymentGateway/composer.json
+++ b/Modules/PaymentGateway/composer.json
@@ -1,0 +1,24 @@
+{
+    "name": "nwidart/paymentgateway",
+    "description": "",
+    "authors": [
+        {
+            "name": "Nicolas Widart",
+            "email": "n.widart@gmail.com"
+        }
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [],
+            "aliases": {}
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\PaymentGateway\\": "",
+            "Modules\\PaymentGateway\\App\\": "app/",
+            "Modules\\PaymentGateway\\Database\\Factories\\": "database/factories/",
+            "Modules\\PaymentGateway\\Database\\Seeders\\": "database/seeders/"
+        }
+    }
+}

--- a/Modules/PaymentGateway/module.json
+++ b/Modules/PaymentGateway/module.json
@@ -1,0 +1,34 @@
+{
+    "name": "PaymentGateway",
+    "alias": "paymentgateway",
+    "description": "Camada técnica de cobrança BR — drivers Inter/C6/Asaas/Pix Automático BCB, webhooks, CNAB, credenciais. Consumida por Sell, RecurringBilling, NFSe, Superadmin.",
+    "keywords": ["payment", "gateway", "boleto", "pix", "pix-automatico", "cnab", "webhook", "bcb"],
+    "priority": 0,
+    "providers": [
+        "Modules\\PaymentGateway\\Providers\\PaymentGatewayServiceProvider"
+    ],
+    "files": [],
+    "governance": {
+        "bucket": "functional_horizontal",
+        "bucket_assigned_at": "2026-05-19",
+        "bucket_assigned_by": "[W]",
+        "bucket_justificativa": "Camada técnica de cobrança consumida cross-vertical (Sell de qualquer vertical, RecurringBilling, NFSe, Superadmin SaaS). Padrão Service/Driver/Job horizontal sem regra de domínio específica.",
+        "fsm_n_a": true,
+        "fsm_n_a_reason": "Cobrança status (pending/emitida/paga/vencida/cancelada/erro) é state machine simples linear gerida pelo Cobranca model + listeners. NÃO usa FSM canon (ADR 0143) — granularidade 11 stages × 21 actions × roles é overkill pra ciclo de cobrança."
+    },
+    "retention_days": 1825,
+    "retention_config": "Modules/PaymentGateway/Config/retention.php",
+    "lgpd_compliance": {
+        "pii_fields_tracked": [
+            "cobrancas.payer_cpf_cnpj",
+            "cobrancas.payer_name",
+            "cobrancas.payer_email",
+            "cobrancas.description",
+            "payment_gateway_credentials.config_json",
+            "gateway_webhook_events.payload"
+        ],
+        "pii_redactor_enabled": true,
+        "activity_log_enabled": true,
+        "policy_doc": "Modules/PaymentGateway/Config/retention.php"
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,6 +19,7 @@
             <directory>./Modules/Cms/Tests/Feature</directory>
             <directory>./Modules/Jana/Tests/Feature</directory>
             <directory>./Modules/RecurringBilling/Tests/Feature</directory>
+            <directory>./Modules/PaymentGateway/Tests/Feature</directory>
             <directory>./Modules/Financeiro/Tests/Feature</directory>
             <directory>./Modules/Financeiro/Tests/Unit</directory>
             <directory>./Modules/NfeBrasil/Tests/Feature</directory>


### PR DESCRIPTION
> **Onda 1 do roadmap ADR 0170 — esqueleto seguro.** PR mínimo aprovado (opção "Mínimo seguro"): apenas estrutura nWidart canônica + interfaces + DTOs + Events declarados. **Zero implementação de driver, zero migration, zero mudança em RB.** Drivers reais Onda 4.

## O que entra

### Estrutura nWidart (9 arquivos)
- `module.json` (governance bucket `functional_horizontal` + LGPD pii_fields declarados + retention 5y)
- `composer.json` (psr-4 autoload)
- `Config/config.php` (name + version 0.1.0)
- `Resources/lang/pt-BR/paymentgateway.php` (11 strings: module_label + 10 permissions)
- `Providers/PaymentGatewayServiceProvider.php` (register config + lang + migrations stub)
- `Providers/RouteServiceProvider.php` (mapWebRoutes)
- `Routes/web.php` (3 rotas Install — install/uninstall/update)
- `Http/Controllers/DataController.php` (3 hooks UltimatePOS: superadmin_package + user_permissions com 10 entries + modifyAdminMenu vazio)
- `Http/Controllers/InstallController.php` (extends BaseModuleInstallController)

### Camada técnica de cobrança (22 arquivos)
- `Exceptions/` (8) — `PaymentGatewayException` raiz + 7 sub (GatewayUnavailable, CredentialMisconfigured, InvalidPayer, DriverNotSupported, CardDeclined, IdempotencyConflict, WebhookSignatureInvalid)
- `Dto/` (5 readonly POPOs) — EmitirCobrancaInput, CobrancaEmitidaResult, CobrancaStatus, CardToken, DriverHealth
- `Events/` (5) — CobrancaEmitida, CobrancaPaga, CobrancaVencida, CobrancaCancelada, CobrancaErro (Dispatchable + SerializesModels)
- `Contracts/` (2 interfaces) — PaymentGatewayContract (API pública, 8 métodos) + PaymentDriverContract (interno, 10 métodos)

### Tests + CI
- `Tests/Feature/OndaUmEsqueletoTest.php` — Pest smoke 8 testes (config carrega, interfaces são interfaces, DTOs readonly immutability, Events têm traits Dispatchable/SerializesModels, Exceptions extendem raiz)
- `phpunit.xml` — registra `./Modules/PaymentGateway/Tests/Feature` (regra proibições.md "Tests sem registrar = falsa cobertura")

## O que NÃO entra (próximas ondas)

- ❌ Migrations (Onda 2 — `payment_gateway_credentials` + `cobrancas` + `gateway_webhook_events`)
- ❌ Entities (Cobranca, PaymentGatewayCredential — Onda 2)
- ❌ Drivers reais (InterDriver, AsaasDriver — Onda 4)
- ❌ Webhooks Controllers (Onda 3)
- ❌ UI Controllers (PaymentGatewayController, CobrancaController — Onda 4)
- ❌ Listeners reais (Onda 3+)
- ❌ Binding container (`bind(PaymentGatewayContract::class, ...)` — Onda 4 quando driver real existir)
- ❌ Shadow events em RB (mencionado no ADR 0170 mas adiado pra mini-PR separado — reduz blast radius)

## Validação pré-merge

- [x] `php -l` (lint sintaxe) em 28 arquivos PHP — todos OK
- [x] Padrão nWidart respeitado (module.json com providers + composer.json psr-4 + ServiceProvider canônico)
- [x] DataController declara superadmin_package + user_permissions (3 camadas habilitação Tier 0 IRREVOGÁVEL prep)
- [x] InstallController extends BaseModuleInstallController
- [x] phpunit.xml inclui novo path Tests
- [x] PT-BR em lang + commit message + docblock
- [ ] CI Pest verde (vai validar)
- [ ] CI check-scope verde (PaymentGateway tem 2 controllers: Data + Install — ambos cobertos por `contains[]` no SCOPE.md de Onda 0)

## Decisão Wagner (esta sessão)

Wagner escolheu "Mínimo seguro (Recomendado)" pra escopo Onda 1 — sem shadow events em RB, sem Pest abrangente, sem ADR filho prévio. Justificativa: blast radius zero (não mexe em prod), valida estrutura cedo, Onda 2 destrava em sequência.

## Após merge

- Branch deletada (remote auto via gh; local fica residual neste worktree)
- Próximo PR: **Onda 2 (DB + Entities)** — `payment_gateway_credentials` table + Cobranca entity + GatewayWebhookEvent entity + backfill `accounts.gateway_*` columns

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)