### PR TITLE
feat(paymentgateway): Onda 2.5 backfill credentials — ADR 0170

### DIFF
--- a/Modules/PaymentGateway/Console/Commands/MigrateCredentialsCommand.php
+++ b/Modules/PaymentGateway/Console/Commands/MigrateCredentialsCommand.php
@@ -1,0 +1,176 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+
+/**
+ * Onda 2.5 — ADR 0170.
+ *
+ * Backfill conservador: lê `rb_boleto_credentials` (legacy RB) e popula
+ * `payment_gateway_credentials` (canon PaymentGateway) preservando
+ * `business_id`, `banco`→`gateway_key`, `ambiente`, `ativo`, `config_json`,
+ * `nome_display`, `conta_bancaria_id`.
+ *
+ * Vincula `fin_contas_bancarias.payment_gateway_credential_id` (FK nova
+ * adicionada na migration 130000) à credencial recém-criada.
+ *
+ * **DEFAULT É --dry-run** — comando seguro pra inspeção. Use `--apply`
+ * pra persistir. Wagner aprova manual antes de cada execução em prod.
+ *
+ * Idempotente — 2x apply mesmo input NÃO duplica (chave única
+ * payment_gateway_credentials(business_id, gateway_key, ambiente)).
+ *
+ * Multi-tenant Tier 0: opcional `--business={id}` pra restringir.
+ *
+ * NÃO toca `rb_boleto_credentials` (legado mantido até Onda 6 cleanup).
+ *
+ * Uso:
+ *   php artisan paymentgateway:migrate-credentials                 # dry-run, todos
+ *   php artisan paymentgateway:migrate-credentials --apply         # persiste, todos
+ *   php artisan paymentgateway:migrate-credentials --business=1    # dry-run só biz=1
+ *   php artisan paymentgateway:migrate-credentials --business=1 --apply
+ */
+class MigrateCredentialsCommand extends Command
+{
+    protected $signature = 'paymentgateway:migrate-credentials
+                            {--business= : Restringir a 1 business_id (default: todos)}
+                            {--apply : Persistir mudanças (default: dry-run)}';
+
+    protected $description = 'Backfill rb_boleto_credentials → payment_gateway_credentials (Onda 2.5 ADR 0170)';
+
+    public function handle(): int
+    {
+        $businessId = $this->option('business');
+        $apply = (bool) $this->option('apply');
+        $mode = $apply ? 'APPLY' : 'DRY-RUN';
+
+        $this->info("PaymentGateway migrate-credentials — modo {$mode}");
+        if ($businessId) {
+            $this->line("Restrito a business_id = {$businessId}");
+        }
+
+        $query = DB::table('rb_boleto_credentials');
+        if ($businessId) {
+            $query->where('business_id', $businessId);
+        }
+
+        $legacyRows = $query->get();
+        $this->info("Encontradas {$legacyRows->count()} credenciais legacy em rb_boleto_credentials.");
+
+        if ($legacyRows->isEmpty()) {
+            $this->warn('Nada a migrar.');
+
+            return self::SUCCESS;
+        }
+
+        $created = 0;
+        $skippedExisting = 0;
+        $linkedContas = 0;
+        $errors = [];
+
+        foreach ($legacyRows as $row) {
+            $gatewayKey = $this->mapBancoToGatewayKey($row->banco);
+            if ($gatewayKey === null) {
+                $errors[] = "[id={$row->id}] banco='{$row->banco}' não mapeável → pulando";
+
+                continue;
+            }
+
+            // Idempotência: tenta achar PG cred com mesma (business, gateway, ambiente).
+            $existing = PaymentGatewayCredential::query()
+                ->withoutGlobalScopes()
+                ->where('business_id', $row->business_id)
+                ->where('gateway_key', $gatewayKey)
+                ->where('ambiente', $row->ambiente)
+                ->first();
+
+            if ($existing) {
+                $skippedExisting++;
+                $this->line("· biz={$row->business_id} {$gatewayKey}/{$row->ambiente} — já existe (pg_cred_id={$existing->id})");
+            } else {
+                $this->line("· biz={$row->business_id} {$gatewayKey}/{$row->ambiente} — CRIAR (legacy rb_id={$row->id})");
+                if ($apply) {
+                    $existing = PaymentGatewayCredential::query()->create([
+                        'business_id'       => $row->business_id,
+                        'gateway_key'       => $gatewayKey,
+                        'ambiente'          => $row->ambiente,
+                        'ativo'             => (bool) $row->ativo,
+                        'nome_display'      => $row->nome_display,
+                        'config_json'       => $this->decodeConfig($row->config_json),
+                        'conta_bancaria_id' => $row->conta_bancaria_id,
+                        'health_status'     => 'unknown',
+                    ]);
+                    $created++;
+                }
+            }
+
+            // Vincula fin_contas_bancarias se aplicável.
+            if ($apply && $existing && $row->conta_bancaria_id) {
+                $linked = DB::table('fin_contas_bancarias')
+                    ->where('id', $row->conta_bancaria_id)
+                    ->where('business_id', $row->business_id) // Tier 0
+                    ->whereNull('payment_gateway_credential_id')
+                    ->update(['payment_gateway_credential_id' => $existing->id]);
+
+                if ($linked > 0) {
+                    $linkedContas++;
+                }
+            }
+        }
+
+        $this->newLine();
+        $this->info("Resumo {$mode}:");
+        $this->line("  · credenciais a criar / criadas: {$created}");
+        $this->line("  · já existentes (skip): {$skippedExisting}");
+        $this->line("  · fin_contas_bancarias vinculadas: {$linkedContas}");
+        if (! empty($errors)) {
+            $this->warn('  · erros:');
+            foreach ($errors as $err) {
+                $this->warn("      {$err}");
+            }
+        }
+
+        if (! $apply) {
+            $this->newLine();
+            $this->warn('Modo DRY-RUN — nada persistido. Rerun com --apply pra executar.');
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Mapeia `banco` legado RB pro `gateway_key` canônico PG.
+     */
+    private function mapBancoToGatewayKey(string $banco): ?string
+    {
+        return match ($banco) {
+            'inter' => 'inter',
+            'c6'    => 'c6',
+            'asaas' => 'asaas',
+            default => null,
+        };
+    }
+
+    /**
+     * Decodifica `config_json` do legacy. Pode vir string JSON OU
+     * array decodificado se Eloquent castou.
+     */
+    private function decodeConfig(mixed $raw): array
+    {
+        if (is_array($raw)) {
+            return $raw;
+        }
+        if (is_string($raw)) {
+            $decoded = json_decode($raw, true);
+
+            return is_array($decoded) ? $decoded : [];
+        }
+
+        return [];
+    }
+}

--- a/Modules/PaymentGateway/Database/Migrations/2026_05_19_130000_add_payment_gateway_credential_id_to_fin_contas_bancarias.php
+++ b/Modules/PaymentGateway/Database/Migrations/2026_05_19_130000_add_payment_gateway_credential_id_to_fin_contas_bancarias.php
@@ -1,0 +1,61 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Onda 2.5 — ADR 0170.
+ *
+ * Adiciona FK `payment_gateway_credential_id` em `fin_contas_bancarias`.
+ *
+ * NÃO REMOVE `rb_gateway_credential_id` (Onda 6 cleanup). As duas colunas
+ * coexistem; controller Onda 4+ passa a escrever em ambas durante
+ * transition window de 90d.
+ *
+ * Idempotente — checa `Schema::hasColumn` antes de adicionar.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('fin_contas_bancarias')) {
+            // fin_contas_bancarias não existe nesta instância — pular (módulo Financeiro não instalado).
+            return;
+        }
+
+        if (Schema::hasColumn('fin_contas_bancarias', 'payment_gateway_credential_id')) {
+            return;
+        }
+
+        Schema::table('fin_contas_bancarias', function (Blueprint $table) {
+            $table->unsignedBigInteger('payment_gateway_credential_id')
+                ->nullable()
+                ->after('rb_gateway_credential_id');
+
+            $table->foreign('payment_gateway_credential_id', 'fin_conta_pg_cred_fk')
+                ->references('id')
+                ->on('payment_gateway_credentials')
+                ->nullOnDelete();
+
+            $table->index('payment_gateway_credential_id', 'fin_conta_pg_cred_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('fin_contas_bancarias')) {
+            return;
+        }
+
+        if (! Schema::hasColumn('fin_contas_bancarias', 'payment_gateway_credential_id')) {
+            return;
+        }
+
+        Schema::table('fin_contas_bancarias', function (Blueprint $table) {
+            $table->dropForeign('fin_conta_pg_cred_fk');
+            $table->dropIndex('fin_conta_pg_cred_idx');
+            $table->dropColumn('payment_gateway_credential_id');
+        });
+    }
+};

--- a/Modules/PaymentGateway/Providers/PaymentGatewayServiceProvider.php
+++ b/Modules/PaymentGateway/Providers/PaymentGatewayServiceProvider.php
@@ -15,9 +15,22 @@ class PaymentGatewayServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
+        $this->registerCommands();
         $this->registerTranslations();
         $this->registerConfig();
         $this->loadMigrationsFrom(module_path($this->moduleName, 'Database/Migrations'));
+    }
+
+    /**
+     * Comandos artisan do módulo.
+     */
+    protected function registerCommands(): void
+    {
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                \Modules\PaymentGateway\Console\Commands\MigrateCredentialsCommand::class,
+            ]);
+        }
     }
 
     /**

--- a/Modules/PaymentGateway/Tests/Feature/MigrateCredentialsCommandTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/MigrateCredentialsCommandTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Onda 2.5 — ADR 0170.
+ *
+ * Testa o comando `paymentgateway:migrate-credentials` em 3 dimensões:
+ *   (1) DRY-RUN não persiste nada
+ *   (2) APPLY popula payment_gateway_credentials + vincula fin_contas_bancarias
+ *   (3) 2x APPLY idempotente (UNIQUE composta + skip existing)
+ *
+ * Princípio ADR 0101: business_id=1, nunca cliente real.
+ */
+
+beforeEach(function () {
+    // Seed legacy table — só se ela existir (RB instalado).
+    if (! Schema::hasTable('rb_boleto_credentials')) {
+        $this->markTestSkipped('rb_boleto_credentials ausente — RB não instalado neste env.');
+    }
+
+    DB::table('rb_boleto_credentials')->insert([
+        [
+            'business_id'       => 1,
+            'banco'             => 'inter',
+            'ambiente'          => 'production',
+            'ativo'             => true,
+            'config_json'       => json_encode(['token' => 'fake-inter']),
+            'nome_display'      => 'Inter Prod',
+            'conta_bancaria_id' => null,
+            'created_at'        => now(),
+            'updated_at'        => now(),
+        ],
+        [
+            'business_id'       => 1,
+            'banco'             => 'asaas',
+            'ambiente'          => 'sandbox',
+            'ativo'             => true,
+            'config_json'       => json_encode(['api_key' => 'fake-asaas']),
+            'nome_display'      => 'Asaas SB',
+            'conta_bancaria_id' => null,
+            'created_at'        => now(),
+            'updated_at'        => now(),
+        ],
+    ]);
+
+    session(['business.id' => 1]);
+});
+
+it('DRY-RUN não persiste em payment_gateway_credentials', function () {
+    expect(PaymentGatewayCredential::query()->withoutGlobalScopes()->count())->toBe(0);
+
+    $this->artisan('paymentgateway:migrate-credentials')
+        ->assertSuccessful();
+
+    expect(PaymentGatewayCredential::query()->withoutGlobalScopes()->count())
+        ->toBe(0); // dry-run não cria
+});
+
+it('APPLY popula payment_gateway_credentials preservando business_id + mapping banco→gateway_key', function () {
+    $this->artisan('paymentgateway:migrate-credentials', ['--apply' => true])
+        ->assertSuccessful();
+
+    $rows = PaymentGatewayCredential::query()->withoutGlobalScopes()->get();
+    expect($rows->count())->toBe(2);
+
+    $inter = $rows->firstWhere('gateway_key', 'inter');
+    expect($inter)->not->toBeNull();
+    expect($inter->business_id)->toBe(1);
+    expect($inter->ambiente)->toBe('production');
+    expect($inter->ativo)->toBeTrue();
+    expect($inter->config_json)->toMatchArray(['token' => 'fake-inter']);
+
+    $asaas = $rows->firstWhere('gateway_key', 'asaas');
+    expect($asaas)->not->toBeNull();
+    expect($asaas->ambiente)->toBe('sandbox');
+});
+
+it('2x APPLY é idempotente — não duplica credenciais', function () {
+    $this->artisan('paymentgateway:migrate-credentials', ['--apply' => true])
+        ->assertSuccessful();
+    expect(PaymentGatewayCredential::query()->withoutGlobalScopes()->count())->toBe(2);
+
+    // Segunda chamada deve detectar existência via UNIQUE composta.
+    $this->artisan('paymentgateway:migrate-credentials', ['--apply' => true])
+        ->assertSuccessful();
+    expect(PaymentGatewayCredential::query()->withoutGlobalScopes()->count())->toBe(2);
+});
+
+it('--business restringe escopo do backfill', function () {
+    // Inserir credencial em biz=99 também
+    DB::table('rb_boleto_credentials')->insert([
+        'business_id'  => 99,
+        'banco'        => 'c6',
+        'ambiente'     => 'production',
+        'ativo'        => true,
+        'config_json'  => json_encode(['key' => 'biz99']),
+        'nome_display' => 'C6 biz99',
+        'created_at'   => now(),
+        'updated_at'   => now(),
+    ]);
+
+    $this->artisan('paymentgateway:migrate-credentials', [
+        '--business' => 1,
+        '--apply'    => true,
+    ])->assertSuccessful();
+
+    // biz=99 NÃO deve ter sido tocado
+    $biz99Count = PaymentGatewayCredential::query()
+        ->withoutGlobalScopes()
+        ->where('business_id', 99)
+        ->count();
+    expect($biz99Count)->toBe(0);
+
+    // biz=1 tem as 2 credenciais
+    $biz1Count = PaymentGatewayCredential::query()
+        ->withoutGlobalScopes()
+        ->where('business_id', 1)
+        ->count();
+    expect($biz1Count)->toBe(2);
+});
+
+it('vincula fin_contas_bancarias.payment_gateway_credential_id se conta_bancaria_id presente', function () {
+    if (! Schema::hasTable('fin_contas_bancarias')) {
+        $this->markTestSkipped('fin_contas_bancarias ausente — Financeiro não instalado neste env.');
+    }
+
+    $contaId = DB::table('fin_contas_bancarias')->insertGetId([
+        'business_id'                  => 1,
+        'nome'                         => 'Conta Teste',
+        'created_at'                   => now(),
+        'updated_at'                   => now(),
+        'payment_gateway_credential_id' => null,
+    ]);
+
+    // Refazer seed legacy com FK pra essa conta
+    DB::table('rb_boleto_credentials')->where('business_id', 1)->delete();
+    DB::table('rb_boleto_credentials')->insert([
+        'business_id'       => 1,
+        'banco'             => 'inter',
+        'ambiente'          => 'production',
+        'ativo'             => true,
+        'config_json'       => json_encode(['token' => 'x']),
+        'nome_display'      => 'Inter+Conta',
+        'conta_bancaria_id' => $contaId,
+        'created_at'        => now(),
+        'updated_at'        => now(),
+    ]);
+
+    $this->artisan('paymentgateway:migrate-credentials', ['--apply' => true])
+        ->assertSuccessful();
+
+    $contaAfter = DB::table('fin_contas_bancarias')->where('id', $contaId)->first();
+    expect($contaAfter->payment_gateway_credential_id)->not->toBeNull();
+});


### PR DESCRIPTION
> **Onda 2.5 mini-PR — backfill conservador.** Migration FK nova + comando artisan idempotente `paymentgateway:migrate-credentials` com **DEFAULT dry-run**. NÃO toca `rb_boleto_credentials` (legado preservado). NÃO mexe em `BoletoCredentialResolver` (Onda 3).

## O que entra

### Migration
- `add_payment_gateway_credential_id_to_fin_contas_bancarias` — coluna nullable + FK + index. Coexiste com `rb_gateway_credential_id` legacy (Onda 6 cleanup remove).
- Idempotente (`Schema::hasColumn` check) + safe (skip se Financeiro não instalado).

### Comando artisan
- `paymentgateway:migrate-credentials [--business=N] [--apply]`
- **DEFAULT dry-run** — Wagner aprova manual antes de cada execução em prod
- Lê `rb_boleto_credentials`, popula `payment_gateway_credentials` preservando `business_id`/`ambiente`/`ativo`/`config_json`/`nome_display`/`conta_bancaria_id`
- Mapeia `banco` (inter/c6/asaas) → `gateway_key` canônico
- Idempotente via UNIQUE composta `(business_id, gateway_key, ambiente)`
- Vincula `fin_contas_bancarias.payment_gateway_credential_id` quando conta_bancaria_id presente
- Tier 0 explícito: `--business={id}` restringe scope; `where business_id` no UPDATE de fin_contas_bancarias
- Saída human-readable + warn no fim de dry-run

### ServiceProvider
- `registerCommands()` habilitado registrando MigrateCredentialsCommand

### Pest (5 testes biz=1 ADR 0101)
1. dry-run não persiste
2. apply popula com mapping correto `banco→gateway_key`
3. 2× apply idempotente (sem duplicação)
4. `--business=1` não toca biz=99
5. vincula `fin_contas_bancarias.payment_gateway_credential_id`

## O que NÃO entra

- ❌ Patch no `BoletoCredentialResolver` pra ler nova tabela (Onda 3 + dual-write)
- ❌ Cleanup `rb_boleto_credentials` ou `rb_gateway_credential_id` (Onda 6)
- ❌ Deprecation warning UI no controller existente (decide depois)
- ❌ Auto-execute em deploy — Wagner roda manual

## Validação pré-merge

- [x] `php -l` em 4 arquivos PHP novos — todos OK
- [x] Migration idempotente (`hasColumn` check)
- [x] Migration safe sem Financeiro instalado (`hasTable` early return)
- [x] Command idempotente (UNIQUE constraint + `whereNull` no UPDATE)
- [x] Tier 0 explícito (filter business_id no UPDATE)
- [x] Default dry-run (não executa nada sem `--apply` explícito)
- [x] Pest cobre 5 cenários incluindo cross-tenant
- [ ] CI verde (vai validar)

## Como usar pós-merge (Wagner)

```bash
# 1) Inspecionar (default dry-run)
php artisan paymentgateway:migrate-credentials --business=1

# 2) Se output OK, aplicar
php artisan paymentgateway:migrate-credentials --business=1 --apply

# 3) Confirmar
php artisan tinker
>>> \Modules\PaymentGateway\Models\PaymentGatewayCredential::withoutGlobalScopes()->where('business_id', 1)->count()
```

Cada business migra individualmente — sem mass-apply automático.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)