### PR TITLE
feat(paymentgateway): Onda 4c Inter refund + cobv — ADR 0170

### DIFF
--- a/Modules/PaymentGateway/SCOPE.md
+++ b/Modules/PaymentGateway/SCOPE.md
@@ -11,7 +11,7 @@ contains:
   - "Webhooks/AsaasWebhookController — POST /paymentgateway/webhooks/asaas/{businessId} (Onda 3 sem cutover)"
   - "Webhooks/BcbPixWebhookController — POST /paymentgateway/webhooks/bcb-pix/{businessId} (Onda 3 novo)"
   - "Services/PaymentGatewayService — implementa PaymentGatewayContract; for(Account) resolve credential; idempotência (Onda 4a); DRIVERS mapa atualizado Onda 4b com 3 drivers"
-  - "Services/Drivers/InterDriver — Inter API v3 OAuth2+mTLS (boleto Onda 4a + pix_cob Onda 4b + cancelar + consultar + healthCheck + processWebhook)"
+  - "Services/Drivers/InterDriver — Inter API v3 OAuth2+mTLS (boleto Onda 4a + pix_cob/pix_cobv Onda 4b/4c + refund PIX Onda 4c + cancelar + consultar + healthCheck + processWebhook). Refund de boleto Inter NÃO via API — exige TED reverso manual"
   - "Services/Drivers/AsaasDriver — Asaas REST v3 (boleto + pix_cob + card + refund parcial + cancelar + consultar + healthCheck + processWebhook); Onda 4b"
   - "Services/Drivers/C6Driver — C6 Open Banking PJ OAuth2 (boleto + pix_cob + cancelar + consultar + healthCheck + processWebhook); Onda 4b. CNAB legacy fallback fica em RB"
   - "BoletoService (Onda 4d alto-nível)"

--- a/Modules/PaymentGateway/Services/Drivers/InterDriver.php
+++ b/Modules/PaymentGateway/Services/Drivers/InterDriver.php
@@ -50,7 +50,7 @@ class InterDriver implements PaymentDriverContract
 
     public function supports(string $tipo): bool
     {
-        return in_array($tipo, ['boleto'], true);
+        return in_array($tipo, ['boleto', 'pix_cob', 'pix_cobv'], true);
     }
 
     public function emitirBoleto(EmitirCobrancaInput $input, object $cred): CobrancaEmitidaResult
@@ -89,29 +89,30 @@ class InterDriver implements PaymentDriverContract
     }
 
     /**
-     * Inter PIX cobrança imediata (cob) via API Pix v2.
+     * Inter PIX cobrança via API Pix v2.
      *
-     * Onda 4b: apenas tipo 'cob' (imediata, sem vencimento). 'cobv' (com
-     * vencimento) fica pra evolução condicional Onda 4c se cliente pedir.
+     * Onda 4b: tipo 'cob' (imediata).
+     * Onda 4c: tipo 'cobv' (com vencimento) via PUT /pix/v2/cobv/{txid}.
+     *
+     * Diferenças:
+     *   - cob:  calendario.expiracao em segundos (TTL curto, ex 1h)
+     *   - cobv: calendario.dataDeVencimento + validadeAposVencimento (dias)
      */
     public function emitirPix(EmitirCobrancaInput $input, object $cred, string $tipo): CobrancaEmitidaResult
     {
-        if ($tipo !== 'cob') {
+        if (! in_array($tipo, ['cob', 'cobv'], true)) {
             throw new DriverNotSupportedException(
-                "Inter só suporta PIX 'cob' nesta onda (recebido '{$tipo}'). cobv chega em 4c."
+                "Inter PIX suporta 'cob' ou 'cobv', recebido '{$tipo}'"
             );
         }
         $this->assertCredential($cred);
 
         $pixKey = $input->meta['pix_key'] ?? null;
         if ($pixKey === null) {
-            throw new InvalidPayerException('Inter PIX cob exige meta.pix_key (chave PIX do beneficiário)');
+            throw new InvalidPayerException("Inter PIX {$tipo} exige meta.pix_key (chave PIX do beneficiário)");
         }
 
         $payload = [
-            'calendario' => [
-                'expiracao' => 3600, // 1h padrão
-            ],
             'devedor' => array_filter([
                 'cpf'  => preg_replace('/\D/', '', $input->meta['payer_cpf_cnpj'] ?? '') ?: null,
                 'nome' => $input->meta['payer_name'] ?? null,
@@ -123,12 +124,21 @@ class InterDriver implements PaymentDriverContract
             'solicitacaoPagador' => substr($input->descricao, 0, 140),
         ];
 
-        $response = $this->client($cred)
-            ->put("/pix/v2/cob/{$input->idempotencyKey}", $payload);
+        if ($tipo === 'cob') {
+            $payload['calendario'] = ['expiracao' => 3600]; // 1h padrão
+        } else { // cobv
+            $payload['calendario'] = [
+                'dataDeVencimento'         => Carbon::instance($input->vencimento)->toDateString(),
+                'validadeAposVencimento'   => $input->meta['validade_apos_vencimento'] ?? 30,
+            ];
+        }
+
+        $endpoint = "/pix/v2/{$tipo}/{$input->idempotencyKey}";
+        $response = $this->client($cred)->put($endpoint, $payload);
 
         if ($response->failed()) {
             throw new GatewayUnavailableException(
-                "Inter PIX cob falhou ({$response->status()}): " . substr($response->body(), 0, 200)
+                "Inter PIX {$tipo} falhou ({$response->status()}): " . substr($response->body(), 0, 200)
             );
         }
 
@@ -137,13 +147,13 @@ class InterDriver implements PaymentDriverContract
         $emv = (string) ($data['pixCopiaECola'] ?? '');
 
         if ($emv === '') {
-            throw new InvalidPayerException('Inter PIX retornou sem pixCopiaECola');
+            throw new InvalidPayerException("Inter PIX {$tipo} retornou sem pixCopiaECola");
         }
 
         return new CobrancaEmitidaResult(
             cobrancaId: 0,
             gatewayExternalId: $txid,
-            tipo: 'pix_cob',
+            tipo: $tipo === 'cob' ? 'pix_cob' : 'pix_cobv',
             emitidaEm: new \DateTimeImmutable(),
             pixEmv: $emv,
             payloadGateway: $data,
@@ -182,11 +192,55 @@ class InterDriver implements PaymentDriverContract
         }
     }
 
+    /**
+     * Inter refund — Onda 4c.
+     *
+     * **PIX cob/cobv:** suportado via POST /pix/v2/cob/{txid}/devolucao/{idDev}
+     * (BCB padrão Pix devolução). Valor opcional pra refund parcial.
+     *
+     * **Boleto:** NÃO suportado via API Inter — banco exige estorno via PIX
+     * recebimento (TED reverso operado pelo operador da conta). Throw
+     * DriverNotSupportedException com mensagem clara.
+     *
+     * O tipo é inferido pelo cobranca->tipo (preenchido pelo Service quando
+     * criou a Cobranca). Se ausente, throw.
+     */
     public function refund(object $cobranca, object $cred, ?int $valorCentavos, string $motivo): void
     {
-        throw new DriverNotSupportedException(
-            'Inter refund parcial chega em Onda 4c. Hoje cancelar antes do pagamento OU manual via UI Inter.'
-        );
+        $this->assertCredential($cred);
+        $tipo = (string) ($cobranca->tipo ?? '');
+        $extId = (string) ($cobranca->gateway_external_id ?? '');
+
+        if ($extId === '') {
+            throw new InvalidPayerException('Cobranca sem gateway_external_id pra refund no Inter');
+        }
+
+        if (! in_array($tipo, ['pix_cob', 'pix_cobv'], true)) {
+            throw new DriverNotSupportedException(
+                "Inter refund só funciona pra PIX (cob/cobv). Tipo recebido '{$tipo}'. " .
+                'Refund de boleto Inter precisa ser feito manualmente via PIX recebimento ' .
+                '(TED reverso operado pelo titular da conta).'
+            );
+        }
+
+        $idDevolucao = (string) ($cobranca->refund_idempotency_key ?? 'devolucao-' . substr(md5($extId . microtime()), 0, 20));
+        $valorReais = $valorCentavos !== null
+            ? number_format($valorCentavos / 100, 2, '.', '')
+            : null;
+
+        $payload = ['valor' => $valorReais ?? '0.00'];
+        if ($motivo !== '') {
+            $payload['descricao'] = substr($motivo, 0, 140);
+        }
+
+        $response = $this->client($cred)
+            ->put("/pix/v2/cob/{$extId}/devolucao/{$idDevolucao}", $payload);
+
+        if ($response->failed()) {
+            throw new GatewayUnavailableException(
+                "Inter PIX devolução falhou ({$response->status()}): " . substr($response->body(), 0, 200)
+            );
+        }
     }
 
     public function consultar(object $cobranca, object $cred): CobrancaStatus

--- a/Modules/PaymentGateway/Tests/Feature/InterRefundCobvTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/InterRefundCobvTest.php
@@ -1,0 +1,217 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
+use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
+use Modules\PaymentGateway\Exceptions\GatewayUnavailableException;
+use Modules\PaymentGateway\Exceptions\InvalidPayerException;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+use Modules\PaymentGateway\Services\Drivers\InterDriver;
+use Modules\PaymentGateway\Services\PaymentGatewayService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Onda 4c — ADR 0170.
+ *
+ * InterDriver agora suporta:
+ *   - refund PIX cob/cobv (POST /pix/v2/cob/{txid}/devolucao/{idDev})
+ *   - emitirPix tipo=cobv (PUT /pix/v2/cobv/{txid} com dataDeVencimento)
+ *
+ * NÃO suporta:
+ *   - refund de boleto (Inter exige TED reverso manual via PIX recebimento)
+ */
+
+beforeEach(function () {
+    session(['business.id' => 1]);
+    $this->cred = PaymentGatewayCredential::query()->create([
+        'business_id'  => 1,
+        'gateway_key'  => 'inter',
+        'ambiente'     => 'sandbox',
+        'ativo'        => true,
+        'config_json'  => ['client_id' => 'inter-4c', 'client_secret' => 'sec-4c'],
+    ]);
+});
+
+// ─── supports() ──────────────────────────────────────────────────────────
+
+it('supports inclui boleto + pix_cob + pix_cobv na Onda 4c', function () {
+    $d = new InterDriver();
+    expect($d->supports('boleto'))->toBeTrue();
+    expect($d->supports('pix_cob'))->toBeTrue();
+    expect($d->supports('pix_cobv'))->toBeTrue();
+    expect($d->supports('pix_recv'))->toBeFalse();
+    expect($d->supports('card'))->toBeFalse();
+});
+
+// ─── emitirPix cobv ──────────────────────────────────────────────────────
+
+it('emitirPix tipo=cobv OK via PUT /pix/v2/cobv/{txid}', function () {
+    Http::fake([
+        '*/oauth/v2/token'   => Http::response(['access_token' => 'tk-cobv'], 200),
+        '*/pix/v2/cobv/*'    => Http::response([
+            'txid'          => 'pix:cobv-001',
+            'pixCopiaECola' => '00020126...cobv-emv...6304ABCD',
+        ], 200),
+    ]);
+
+    $account = (object) ['id' => 1, 'payment_gateway_credential_id' => $this->cred->id];
+    $result = (new PaymentGatewayService())->for($account)->emitirPix(new EmitirCobrancaInput(
+        businessId: 1, contactId: 500, valorCentavos: 30000,
+        vencimento: new DateTimeImmutable('+30 days'),
+        descricao: 'PIX com vencimento',
+        idempotencyKey: 'pix:cobv-001',
+        meta: [
+            'payer_cpf_cnpj' => '99988877766',
+            'payer_name'     => 'Ana',
+            'pix_key'        => 'cnpj@empresa',
+            'validade_apos_vencimento' => 60,
+        ],
+    ), 'cobv');
+
+    expect($result->tipo)->toBe('pix_cobv');
+    expect($result->gatewayExternalId)->toBe('pix:cobv-001');
+    expect($result->pixEmv)->toContain('00020126');
+
+    // Verificar payload tem dataDeVencimento + validadeAposVencimento
+    Http::assertSent(function ($r) {
+        return str_contains($r->url(), '/pix/v2/cobv/pix:cobv-001')
+            && $r->method() === 'PUT'
+            && isset($r['calendario']['dataDeVencimento'])
+            && $r['calendario']['validadeAposVencimento'] === 60;
+    });
+});
+
+it('emitirPix tipo=cobv usa validade default 30 dias quando não especificado', function () {
+    Http::fake([
+        '*/oauth/v2/token' => Http::response(['access_token' => 'tk'], 200),
+        '*/pix/v2/cobv/*'  => Http::response(['txid' => 'k', 'pixCopiaECola' => '00020126x'], 200),
+    ]);
+
+    (new InterDriver())->emitirPix(new EmitirCobrancaInput(
+        businessId: 1, contactId: 1, valorCentavos: 100,
+        vencimento: new DateTimeImmutable('+30 days'),
+        descricao: 'x', idempotencyKey: 'k',
+        meta: ['payer_cpf_cnpj' => '11122233344', 'payer_name' => 'X', 'pix_key' => 'k@x'],
+    ), $this->cred, 'cobv');
+
+    Http::assertSent(fn ($r) => $r['calendario']['validadeAposVencimento'] === 30);
+});
+
+it('emitirPix tipo=recv → DriverNotSupportedException (Onda 4d BcbPix)', function () {
+    expect(fn () => (new InterDriver())->emitirPix(
+        new EmitirCobrancaInput(businessId: 1, contactId: 1, valorCentavos: 100, vencimento: new DateTimeImmutable(), descricao: 'x', idempotencyKey: 'k'),
+        $this->cred,
+        'recv',
+    ))->toThrow(DriverNotSupportedException::class);
+});
+
+it('emitirPix cobv ainda valida pix_key obrigatório', function () {
+    Http::fake(['*/oauth/v2/token' => Http::response(['access_token' => 'tk'], 200)]);
+
+    expect(fn () => (new InterDriver())->emitirPix(
+        new EmitirCobrancaInput(
+            businessId: 1, contactId: 1, valorCentavos: 100,
+            vencimento: new DateTimeImmutable(),
+            descricao: 'x', idempotencyKey: 'k',
+            meta: ['payer_cpf_cnpj' => '12345678900'],
+        ),
+        $this->cred,
+        'cobv',
+    ))->toThrow(InvalidPayerException::class);
+});
+
+// ─── refund ──────────────────────────────────────────────────────────────
+
+it('refund PIX cob OK via PUT /pix/v2/cob/{txid}/devolucao/{idDev}', function () {
+    Http::fake([
+        '*/oauth/v2/token'              => Http::response(['access_token' => 'tk'], 200),
+        '*/pix/v2/cob/pix-tx-001/devolucao/*' => Http::response([
+            'id'     => 'devolucao-uuid-001',
+            'rtrId'  => 'inter-rtr-001',
+            'valor'  => '50.00',
+            'status' => 'DEVOLVIDO',
+        ], 201),
+    ]);
+
+    $cobranca = (object) [
+        'gateway_external_id' => 'pix-tx-001',
+        'tipo'                => 'pix_cob',
+    ];
+
+    (new InterDriver())->refund($cobranca, $this->cred, 5000, 'Cliente desistiu');
+
+    Http::assertSent(function ($r) {
+        return str_contains($r->url(), '/pix/v2/cob/pix-tx-001/devolucao/')
+            && $r->method() === 'PUT'
+            && $r['valor'] === '50.00'
+            && $r['descricao'] === 'Cliente desistiu';
+    });
+});
+
+it('refund PIX cobv OK (mesmo endpoint, tipo aceito)', function () {
+    Http::fake([
+        '*/oauth/v2/token' => Http::response(['access_token' => 'tk'], 200),
+        '*/pix/v2/cob/pix-tx-cobv/devolucao/*' => Http::response(['status' => 'DEVOLVIDO'], 201),
+    ]);
+
+    $cobranca = (object) [
+        'gateway_external_id' => 'pix-tx-cobv',
+        'tipo'                => 'pix_cobv',
+    ];
+
+    (new InterDriver())->refund($cobranca, $this->cred, null, 'Total');
+
+    Http::assertSent(function ($r) {
+        // valor=0.00 quando $valorCentavos é null (devolução total — Inter usa valor original do cob)
+        return $r['valor'] === '0.00';
+    });
+});
+
+it('refund de boleto → DriverNotSupportedException com mensagem clara', function () {
+    $cobranca = (object) [
+        'gateway_external_id' => '00012345',
+        'tipo'                => 'boleto',
+    ];
+
+    expect(fn () => (new InterDriver())->refund($cobranca, $this->cred, 5000, 'Cliente'))
+        ->toThrow(DriverNotSupportedException::class);
+});
+
+it('refund sem gateway_external_id → InvalidPayer', function () {
+    $cobranca = (object) ['tipo' => 'pix_cob'];
+
+    expect(fn () => (new InterDriver())->refund($cobranca, $this->cred, 1000, 'x'))
+        ->toThrow(InvalidPayerException::class);
+});
+
+it('refund Inter API 422 → GatewayUnavailableException', function () {
+    Http::fake([
+        '*/oauth/v2/token' => Http::response(['access_token' => 'tk'], 200),
+        '*/pix/v2/cob/*/devolucao/*' => Http::response(['error' => 'valor inválido'], 422),
+    ]);
+
+    $cobranca = (object) ['gateway_external_id' => 'pix-tx-err', 'tipo' => 'pix_cob'];
+
+    expect(fn () => (new InterDriver())->refund($cobranca, $this->cred, 5000, 'x'))
+        ->toThrow(GatewayUnavailableException::class);
+});
+
+it('refund usa refund_idempotency_key da cobranca se presente', function () {
+    Http::fake([
+        '*/oauth/v2/token' => Http::response(['access_token' => 'tk'], 200),
+        '*/pix/v2/cob/pix-id/devolucao/my-custom-idem' => Http::response(['status' => 'OK'], 201),
+    ]);
+
+    $cobranca = (object) [
+        'gateway_external_id'     => 'pix-id',
+        'tipo'                    => 'pix_cob',
+        'refund_idempotency_key' => 'my-custom-idem',
+    ];
+
+    (new InterDriver())->refund($cobranca, $this->cred, 1000, 'test');
+
+    Http::assertSent(fn ($r) => str_contains($r->url(), '/devolucao/my-custom-idem'));
+});


### PR DESCRIPTION
> **Onda 4c — Inter refund + cobv.** InterDriver agora suporta refund PIX (cob/cobv) via endpoint BCB padrão e emite PIX com vencimento (cobv). Refund de boleto Inter intencionalmente NÃO suportado (Inter exige TED reverso manual).

## O que entra (290 LOC)

### `InterDriver::refund` (substitui throw Onda 4a)
- ✓ **PIX cob/cobv** → `PUT /pix/v2/cob/{txid}/devolucao/{idDev}` (BCB padrão Pix devolução)
- ✓ Valor opcional para refund parcial (`null` → total)
- ✓ Usa `cobranca->refund_idempotency_key` se presente (idempotência custom)
- ✗ **Boleto** → `DriverNotSupportedException` com mensagem clara: Inter exige TED reverso manual via PIX recebimento, não tem API
- ✗ Cobranca sem `gateway_external_id` → `InvalidPayerException`
- ✗ API 422 → `GatewayUnavailableException`

### `InterDriver::emitirPix` expandido (substitui throw cobv Onda 4b)
- ✓ `tipo='cob'` continua igual (PIX imediato com `calendario.expiracao`)
- ✓ `tipo='cobv'` novo → `PUT /pix/v2/cobv/{txid}` com `calendario.dataDeVencimento` + `validadeAposVencimento` (default 30 dias, configurável via `meta.validade_apos_vencimento`)
- ✗ `tipo='recv'` ainda throw (Onda 4d BcbPix dedicado)
- 📌 Ainda exige `meta.pix_key` (chave PIX do beneficiário)

### `InterDriver::supports` atualizado
- Onda 4a: `['boleto']`
- Onda 4c: `['boleto', 'pix_cob', 'pix_cobv']`

### `SCOPE.md` atualizado
Inter agora documentado: boleto + pix_cob/cobv + refund PIX. Caveat boleto refund explicado.

### Pest `InterRefundCobvTest` (11 testes biz=1 com `Http::fake`)
1. `supports` inclui `pix_cobv`
2. `emitirPix cobv` OK via `PUT /pix/v2/cobv/{txid}` com `dataDeVencimento`
3. `validade_apos_vencimento` default 30 quando não especificada
4. `tipo='recv'` throw `DriverNotSupportedException`
5. `emitirPix cobv` ainda valida `pix_key` obrigatório
6. `refund PIX cob` OK com valor parcial
7. `refund PIX cobv` OK total (`valor=0.00`)
8. `refund boleto` throw `DriverNotSupportedException` com msg clara
9. `refund` sem `gateway_external_id` throw `InvalidPayerException`
10. `refund` API 422 throw `GatewayUnavailableException`
11. `refund` usa `refund_idempotency_key` custom da cobranca

## O que NÃO entra

| Item | Razão |
|---|---|
| Asaas `cobv` | Asaas usa `billingType=PIX` + `dueDate` — já cobre conceito, prioridade baixa |
| C6 `refund` | CNAB-based assíncrono, decisão de produto |
| Onda 4d BcbPix + CNAB | Próxima onda |
| Onda 3.5 cutover | Sua decisão sobre URL Inter sandbox |

## Validação pré-merge

- [x] `php -l` em 2 arquivos PHP — todos OK
- [x] Refund usa idempotência via `refund_idempotency_key` ou fallback md5
- [x] Boleto refund throw com explicação clara (operador humano)
- [x] cobv valida `pix_key` (sem ela, `InvalidPayerException`)
- [x] cobv valida tipo (apenas `cob`, `cobv` aceitos)
- [x] Pest 11 testes cobrem refund + cobv + edge cases (sem id, sem key, API erro)
- [x] Zero diff em `Modules/RecurringBilling/`
- [ ] CI verde (vai validar)

## Inter completo pós-4c

| Operação | Onda |
|---|---|
| `emitirBoleto` | 4a ✅ |
| `emitirPix(cob)` | 4b ✅ |
| `emitirPix(cobv)` | 4c ✅ |
| `emitirPixAutomatico` | ❌ Onda 4d (BcbPix dedicado) |
| `cobrarCartao` | ❌ Inter não emite |
| `cancelar` | 4a ✅ |
| `refund` PIX | 4c ✅ |
| `refund` boleto | ❌ Inter não suporta via API (TED reverso manual) |
| `consultar` | 4a ✅ |
| `healthCheck` | 4a ✅ |
| `processWebhook` | 4a ✅ |

## Próximas opções pós-merge

| | |
|---|---|
| **Onda 4d** BcbPix + CNAB | Próxima natural (PIX Automático regulado BCB 380/2024 + Remessa/Retorno CNAB legacy + BoletoService alto-nível) |
| **Onda 3.5** cutover sandbox | Você aponta webhook Inter sandbox → `/paymentgateway/webhooks/inter/{biz}` |
| `pause` | Você revisa main + 10 PRs |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)