### PR TITLE
feat(paymentgateway): Onda 4d.1 BcbPixDriver — ADR 0170

### DIFF
--- a/Modules/PaymentGateway/SCOPE.md
+++ b/Modules/PaymentGateway/SCOPE.md
@@ -14,11 +14,12 @@ contains:
   - "Services/Drivers/InterDriver — Inter API v3 OAuth2+mTLS (boleto Onda 4a + pix_cob/pix_cobv Onda 4b/4c + refund PIX Onda 4c + cancelar + consultar + healthCheck + processWebhook). Refund de boleto Inter NÃO via API — exige TED reverso manual"
   - "Services/Drivers/AsaasDriver — Asaas REST v3 (boleto + pix_cob + card + refund parcial + cancelar + consultar + healthCheck + processWebhook); Onda 4b"
   - "Services/Drivers/C6Driver — C6 Open Banking PJ OAuth2 (boleto + pix_cob + cancelar + consultar + healthCheck + processWebhook); Onda 4b. CNAB legacy fallback fica em RB"
+  - "Services/Drivers/BcbPixDriver — PSP-agnóstico PIX Automático (Resolução BCB 380/2024) — pix_recv (mandato recorrente) + revogar + consultar + healthCheck + processWebhook; Onda 4d.1. base_url configurável via credential"
   - "BoletoService (Onda 4d alto-nível)"
   - "RemessaCnabService (Onda 4d)"
   - "RetornoCnabService (Onda 4d)"
   - "PaymentGatewayCredentialResolver (Onda 4d se realmente precisar)"
-  - "Drivers planejados: BcbPixDriver (4d — PIX Automático regulado), PesaPalDriver (deprecated Onda 5/6)"
+  - "Drivers planejados: PesaPalDriver (deprecated Onda 5/6)"
 not_contains:
   - "Plan / Assinatura / Invoice recorrente → Modules/RecurringBilling (consome este módulo)"
   - "Sale / Transaction de venda → app/ core (consome este módulo via PaymentGatewayContract)"

--- a/Modules/PaymentGateway/Services/Drivers/BcbPixDriver.php
+++ b/Modules/PaymentGateway/Services/Drivers/BcbPixDriver.php
@@ -1,0 +1,348 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Services\Drivers;
+
+use Carbon\Carbon;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Modules\PaymentGateway\Contracts\PaymentDriverContract;
+use Modules\PaymentGateway\Dto\CardToken;
+use Modules\PaymentGateway\Dto\CobrancaEmitidaResult;
+use Modules\PaymentGateway\Dto\CobrancaStatus;
+use Modules\PaymentGateway\Dto\DriverHealth;
+use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
+use Modules\PaymentGateway\Exceptions\CredentialMisconfiguredException;
+use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
+use Modules\PaymentGateway\Exceptions\GatewayUnavailableException;
+use Modules\PaymentGateway\Exceptions\InvalidPayerException;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+
+/**
+ * Driver PIX Automático regulado BCB — Resolução 380/2024.
+ *
+ * Onda 4d.1 — ADR 0170. Driver especializado em **PIX Recorrência** (recv):
+ * mandatos recorrentes onde o pagador autoriza cobranças automáticas no app
+ * do banco dele (out-of-band). Cobranças subsequentes vêm via webhook.
+ *
+ * **PSP-agnóstico** — Wagner pode rotear via Inter/C6/Asaas/PSP terceiro
+ * que implemente API Open Finance Pix Automático. URL base via config.
+ *
+ * Suporta:
+ *   ✓ emitirPixAutomatico (cria mandato via PUT /v2/rec/{txid})
+ *   ✓ cancelar (DELETE /v2/rec/{txid} = revogar mandato)
+ *   ✓ consultar (GET /v2/rec/{txid})
+ *   ✓ healthCheck (OAuth ping)
+ *   ✓ processWebhook (cobranças recorrentes notificadas pelo PSP)
+ *
+ * NÃO suporta (use outros drivers):
+ *   ✗ emitirBoleto, emitirPix(cob/cobv), cobrarCartao, refund
+ *
+ * Credenciais (config_json):
+ *   client_id:     OAuth2 PSP
+ *   client_secret: OAuth2 PSP
+ *   base_url:      URL PSP (sandbox/prod do parceiro escolhido)
+ *   ambiente:      'sandbox' | 'production'
+ *
+ * Fluxo PIX Automático (BCB):
+ *   1. Beneficiário (Wagner) cria mandato PUT /v2/rec/{txid} com pagador info
+ *   2. Pagador autoriza via app banco dele (out-of-band, manual)
+ *   3. Banco do pagador notifica BCB que aceitou
+ *   4. PSP do beneficiário notifica via webhook que mandato está ATIVO
+ *   5. PSP gera cobranças automáticas no ciclo definido (mensal/anual/etc)
+ *   6. Webhook chega a cada cobrança paga/falhada
+ */
+class BcbPixDriver implements PaymentDriverContract
+{
+    private array $tokenCache = [];
+
+    public function key(): string
+    {
+        return 'bcb_pix';
+    }
+
+    public function supports(string $tipo): bool
+    {
+        return $tipo === 'pix_recv';
+    }
+
+    public function emitirBoleto(EmitirCobrancaInput $input, object $cred): CobrancaEmitidaResult
+    {
+        throw new DriverNotSupportedException('BcbPix só faz pix_recv. Use inter/c6/asaas pra boleto.');
+    }
+
+    public function emitirPix(EmitirCobrancaInput $input, object $cred, string $tipo): CobrancaEmitidaResult
+    {
+        throw new DriverNotSupportedException(
+            "BcbPix só faz pix_recv (PIX Automático). Pra '{$tipo}' use inter/c6/asaas."
+        );
+    }
+
+    /**
+     * Cria mandato PIX Automático (recv).
+     *
+     * Pagador autoriza out-of-band depois. Retorna mandato em status PENDING
+     * (aguardando autorização do pagador no app do banco dele).
+     */
+    public function emitirPixAutomatico(EmitirCobrancaInput $input, object $cred): CobrancaEmitidaResult
+    {
+        $this->assertCredential($cred);
+
+        $cpfPagador = preg_replace('/\D/', '', $input->meta['payer_cpf_cnpj'] ?? '');
+        if ($cpfPagador === '') {
+            throw new InvalidPayerException('BcbPix mandato exige CPF/CNPJ do pagador em meta.payer_cpf_cnpj');
+        }
+
+        $pixKey = $input->meta['pix_key'] ?? null;
+        if ($pixKey === null) {
+            throw new InvalidPayerException('BcbPix mandato exige meta.pix_key (chave PIX do beneficiário)');
+        }
+
+        $payload = [
+            'vinculo' => [
+                'contrato'      => $input->idempotencyKey,
+                'objeto'        => substr($input->descricao, 0, 35),
+            ],
+            'calendario' => [
+                'dataInicial'   => Carbon::instance($input->vencimento)->toDateString(),
+                'periodicidade' => $input->meta['periodicidade'] ?? 'MENSAL', // SEMANAL/MENSAL/TRIMESTRAL/SEMESTRAL/ANUAL
+            ],
+            'valor' => [
+                'valorRec'      => number_format($input->valorCentavos / 100, 2, '.', ''),
+            ],
+            'pagador' => array_filter([
+                'cpf'           => strlen($cpfPagador) === 11 ? $cpfPagador : null,
+                'cnpj'          => strlen($cpfPagador) === 14 ? $cpfPagador : null,
+                'nome'          => $input->meta['payer_name'] ?? null,
+            ]),
+            'recebedor' => [
+                'chave'         => $pixKey,
+            ],
+        ];
+
+        $response = $this->client($cred)
+            ->put("/v2/rec/{$input->idempotencyKey}", $payload);
+
+        if ($response->failed()) {
+            throw new GatewayUnavailableException(
+                "BcbPix mandato falhou ({$response->status()}): " . substr($response->body(), 0, 200)
+            );
+        }
+
+        $data = $response->json() ?? [];
+        $idRec = (string) ($data['idRec'] ?? $data['txid'] ?? $input->idempotencyKey);
+
+        return new CobrancaEmitidaResult(
+            cobrancaId: 0,
+            gatewayExternalId: $idRec,
+            tipo: 'pix_recv',
+            emitidaEm: new \DateTimeImmutable(),
+            payloadGateway: $data,
+        );
+    }
+
+    public function cobrarCartao(EmitirCobrancaInput $input, object $cred, CardToken $token): CobrancaEmitidaResult
+    {
+        throw new DriverNotSupportedException('BcbPix não emite cartão. Use Asaas.');
+    }
+
+    /**
+     * Revoga mandato PIX Automático.
+     * Cobranças futuras param. Cobranças já efetivadas mantêm-se.
+     */
+    public function cancelar(object $cobranca, object $cred, string $motivo): void
+    {
+        $this->assertCredential($cred);
+        $idRec = (string) ($cobranca->gateway_external_id ?? '');
+        if ($idRec === '') {
+            throw new InvalidPayerException('Cobranca sem gateway_external_id pra revogar mandato BcbPix');
+        }
+
+        $response = $this->client($cred)
+            ->delete("/v2/rec/{$idRec}", ['motivo' => substr($motivo, 0, 140)]);
+
+        if ($response->failed()) {
+            throw new GatewayUnavailableException(
+                "BcbPix revogar mandato falhou ({$response->status()}): " . substr($response->body(), 0, 200)
+            );
+        }
+    }
+
+    public function refund(object $cobranca, object $cred, ?int $valorCentavos, string $motivo): void
+    {
+        throw new DriverNotSupportedException(
+            'BcbPix mandato não tem refund individual via API. ' .
+            'Revogue o mandato (cancelar) + faça devolução PIX manual da cobrança específica.'
+        );
+    }
+
+    public function consultar(object $cobranca, object $cred): CobrancaStatus
+    {
+        $this->assertCredential($cred);
+        $idRec = (string) ($cobranca->gateway_external_id ?? '');
+        if ($idRec === '') {
+            throw new InvalidPayerException('Cobranca sem gateway_external_id pra consultar mandato BcbPix');
+        }
+
+        $response = $this->client($cred)->get("/v2/rec/{$idRec}");
+        if ($response->failed()) {
+            throw new GatewayUnavailableException(
+                "BcbPix consultar falhou ({$response->status()}): " . substr($response->body(), 0, 200)
+            );
+        }
+
+        $data = $response->json() ?? [];
+        $status = (string) ($data['status'] ?? '');
+
+        return new CobrancaStatus(
+            status: $this->mapStatus($status),
+            payloadGateway: $data,
+        );
+    }
+
+    public function healthCheck(object $cred): DriverHealth
+    {
+        $this->assertCredential($cred);
+        $start = microtime(true);
+
+        try {
+            $response = Http::asForm()
+                ->timeout(10)
+                ->post($this->baseUrl($cred) . '/oauth/token', [
+                    'client_id'     => $cred->config_json['client_id'] ?? '',
+                    'client_secret' => $cred->config_json['client_secret'] ?? '',
+                    'grant_type'    => 'client_credentials',
+                    'scope'         => 'pix.recorrencia.read pix.recorrencia.write',
+                ]);
+
+            $latencyMs = (int) round((microtime(true) - $start) * 1000);
+
+            if ($response->successful() && ! empty($response->json('access_token'))) {
+                return new DriverHealth(
+                    ok: true,
+                    status: $latencyMs > 3000 ? 'degraded' : 'ok',
+                    latencyMs: $latencyMs,
+                    checkedAt: new \DateTimeImmutable(),
+                );
+            }
+
+            return new DriverHealth(
+                ok: false,
+                status: 'down',
+                latencyMs: $latencyMs,
+                checkedAt: new \DateTimeImmutable(),
+                errorMessage: "BcbPix OAuth failed ({$response->status()})",
+            );
+        } catch (\Throwable $e) {
+            return new DriverHealth(
+                ok: false,
+                status: 'down',
+                latencyMs: (int) round((microtime(true) - $start) * 1000),
+                checkedAt: new \DateTimeImmutable(),
+                errorMessage: $e->getMessage(),
+            );
+        }
+    }
+
+    public function processWebhook(array $payload, object $cred): ?object
+    {
+        // Webhook BCB padrão: pix[] (lista de cobranças confirmadas) OU
+        // rec[] (atualizações de mandato).
+        $idRec = (string) (
+            $payload['idRec']
+            ?? $payload['rec']['idRec']
+            ?? $payload['pix'][0]['infoPagador']['idRec']
+            ?? ''
+        );
+
+        if ($idRec === '') {
+            return null;
+        }
+
+        return (object) [
+            'gateway_external_id' => $idRec,
+            'gateway_key'         => $this->key(),
+            'raw_payload'         => $payload,
+        ];
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────
+
+    private function assertCredential(object $cred): void
+    {
+        if (! $cred instanceof PaymentGatewayCredential) {
+            throw new CredentialMisconfiguredException(
+                'Credential precisa ser PaymentGatewayCredential, recebeu: ' . get_class($cred)
+            );
+        }
+        if ($cred->gateway_key !== 'bcb_pix') {
+            throw new CredentialMisconfiguredException(
+                "Credential gateway_key='{$cred->gateway_key}' não bate com driver BcbPix"
+            );
+        }
+        $config = $cred->config_json ?? [];
+        if (empty($config['client_id']) || empty($config['client_secret'])) {
+            throw new CredentialMisconfiguredException(
+                'BcbPix credential precisa client_id + client_secret em config_json'
+            );
+        }
+        if (empty($config['base_url'])) {
+            throw new CredentialMisconfiguredException(
+                'BcbPix credential precisa base_url em config_json (PSP-agnóstico)'
+            );
+        }
+    }
+
+    private function baseUrl(PaymentGatewayCredential $cred): string
+    {
+        return rtrim((string) ($cred->config_json['base_url'] ?? ''), '/');
+    }
+
+    private function client(PaymentGatewayCredential $cred): PendingRequest
+    {
+        return Http::baseUrl($this->baseUrl($cred))
+            ->withToken($this->getAccessToken($cred))
+            ->acceptJson()
+            ->asJson()
+            ->timeout(30);
+    }
+
+    private function getAccessToken(PaymentGatewayCredential $cred): string
+    {
+        $key = $cred->id . ':' . $cred->ambiente;
+        if (isset($this->tokenCache[$key])) {
+            return $this->tokenCache[$key];
+        }
+
+        $config = $cred->config_json ?? [];
+        $response = Http::asForm()
+            ->timeout(10)
+            ->post($this->baseUrl($cred) . '/oauth/token', [
+                'client_id'     => $config['client_id'] ?? '',
+                'client_secret' => $config['client_secret'] ?? '',
+                'grant_type'    => 'client_credentials',
+                'scope'         => 'pix.recorrencia.read pix.recorrencia.write',
+            ]);
+
+        if (! $response->successful() || empty($response->json('access_token'))) {
+            throw new CredentialMisconfiguredException(
+                "BcbPix OAuth falhou ({$response->status()}): " . substr($response->body(), 0, 200)
+            );
+        }
+
+        return $this->tokenCache[$key] = (string) $response->json('access_token');
+    }
+
+    private function mapStatus(string $bcbStatus): string
+    {
+        return match (strtoupper($bcbStatus)) {
+            'ATIVA', 'ACTIVE'                          => 'emitida',
+            'CRIADA', 'CREATED', 'AGUARDANDO_PAGADOR'  => 'pending',
+            'REJEITADA', 'REJEITADA_PAGADOR'           => 'erro',
+            'CANCELADA', 'EXPIRADA', 'CANCELED'        => 'cancelada',
+            'CONCLUIDA', 'COMPLETED'                   => 'paga',
+            default                                    => 'pending',
+        };
+    }
+}

--- a/Modules/PaymentGateway/Services/PaymentGatewayService.php
+++ b/Modules/PaymentGateway/Services/PaymentGatewayService.php
@@ -18,6 +18,7 @@ use Modules\PaymentGateway\Exceptions\IdempotencyConflictException;
 use Modules\PaymentGateway\Models\Cobranca;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Drivers\AsaasDriver;
+use Modules\PaymentGateway\Services\Drivers\BcbPixDriver;
 use Modules\PaymentGateway\Services\Drivers\C6Driver;
 use Modules\PaymentGateway\Services\Drivers\InterDriver;
 
@@ -38,14 +39,15 @@ class PaymentGatewayService implements PaymentGatewayContract
      * Mapa gateway_key → FQCN do driver.
      *
      * Onda 4a: inter
-     * Onda 4b: + c6, asaas (este PR)
-     * Onda 4d: + bcb_pix
+     * Onda 4b: + c6, asaas
+     * Onda 4d.1: + bcb_pix (este PR — PIX Automático regulado BCB)
      * Onda 5/6: pesapal (deprecated → remoção)
      */
     private const DRIVERS = [
-        'inter' => InterDriver::class,
-        'c6'    => C6Driver::class,
-        'asaas' => AsaasDriver::class,
+        'inter'   => InterDriver::class,
+        'c6'      => C6Driver::class,
+        'asaas'   => AsaasDriver::class,
+        'bcb_pix' => BcbPixDriver::class,
     ];
 
     public function for(Account $account): self

--- a/Modules/PaymentGateway/Tests/Feature/BcbPixDriverTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/BcbPixDriverTest.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Modules\PaymentGateway\Dto\CardToken;
+use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
+use Modules\PaymentGateway\Exceptions\CredentialMisconfiguredException;
+use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
+use Modules\PaymentGateway\Exceptions\GatewayUnavailableException;
+use Modules\PaymentGateway\Exceptions\InvalidPayerException;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+use Modules\PaymentGateway\Services\Drivers\BcbPixDriver;
+use Modules\PaymentGateway\Services\PaymentGatewayService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Onda 4d.1 — ADR 0170.
+ *
+ * BcbPixDriver — PIX Automático regulado BCB Resolução 380/2024.
+ * Especializado em PIX recv (mandato recorrente). Demais tipos throw.
+ */
+
+beforeEach(function () {
+    session(['business.id' => 1]);
+    $this->cred = PaymentGatewayCredential::query()->create([
+        'business_id'  => 1,
+        'gateway_key'  => 'bcb_pix',
+        'ambiente'     => 'sandbox',
+        'ativo'        => true,
+        'nome_display' => 'BCB Pix Auto Test',
+        'config_json'  => [
+            'client_id'     => 'bcb-cli',
+            'client_secret' => 'bcb-sec',
+            'base_url'      => 'https://psp.fake.local',
+        ],
+    ]);
+});
+
+// ─── key/supports ────────────────────────────────────────────────────────
+
+it('key=bcb_pix e supports apenas pix_recv', function () {
+    $d = new BcbPixDriver();
+    expect($d->key())->toBe('bcb_pix');
+    expect($d->supports('pix_recv'))->toBeTrue();
+    expect($d->supports('boleto'))->toBeFalse();
+    expect($d->supports('pix_cob'))->toBeFalse();
+    expect($d->supports('pix_cobv'))->toBeFalse();
+    expect($d->supports('card'))->toBeFalse();
+});
+
+// ─── métodos não-supportados throw ───────────────────────────────────────
+
+it('emitirBoleto throw DriverNotSupportedException', function () {
+    expect(fn () => (new BcbPixDriver())->emitirBoleto(
+        new EmitirCobrancaInput(businessId: 1, contactId: 1, valorCentavos: 100, vencimento: new DateTimeImmutable(), descricao: 'x', idempotencyKey: 'k'),
+        $this->cred,
+    ))->toThrow(DriverNotSupportedException::class);
+});
+
+it('emitirPix cob/cobv throw', function () {
+    $d = new BcbPixDriver();
+    $input = new EmitirCobrancaInput(businessId: 1, contactId: 1, valorCentavos: 100, vencimento: new DateTimeImmutable(), descricao: 'x', idempotencyKey: 'k');
+    expect(fn () => $d->emitirPix($input, $this->cred, 'cob'))->toThrow(DriverNotSupportedException::class);
+    expect(fn () => $d->emitirPix($input, $this->cred, 'cobv'))->toThrow(DriverNotSupportedException::class);
+});
+
+it('cobrarCartao throw', function () {
+    expect(fn () => (new BcbPixDriver())->cobrarCartao(
+        new EmitirCobrancaInput(businessId: 1, contactId: 1, valorCentavos: 100, vencimento: new DateTimeImmutable(), descricao: 'x', idempotencyKey: 'k'),
+        $this->cred,
+        new CardToken(token: 't', brand: 'visa', lastFour: '4242', holderName: 'X', expMonth: '12', expYear: '2030'),
+    ))->toThrow(DriverNotSupportedException::class);
+});
+
+it('refund throw (revoga mandato em vez)', function () {
+    expect(fn () => (new BcbPixDriver())->refund(
+        (object) ['gateway_external_id' => 'x'],
+        $this->cred,
+        100,
+        'motivo',
+    ))->toThrow(DriverNotSupportedException::class);
+});
+
+// ─── emitirPixAutomatico ─────────────────────────────────────────────────
+
+it('emitirPixAutomatico OK via PUT /v2/rec/{id}', function () {
+    Http::fake([
+        '*/oauth/token' => Http::response(['access_token' => 'bcb-tk'], 200),
+        '*/v2/rec/*'    => Http::response([
+            'idRec'  => 'RR000000000000000000001',
+            'status' => 'CRIADA',
+        ], 201),
+    ]);
+
+    $account = (object) ['id' => 1, 'payment_gateway_credential_id' => $this->cred->id];
+    $result = (new PaymentGatewayService())->for($account)->emitirPixAutomatico(new EmitirCobrancaInput(
+        businessId: 1, contactId: 700, valorCentavos: 9990,
+        vencimento: new DateTimeImmutable('2026-06-01'),
+        descricao: 'Mensalidade Oimpresso Premium',
+        idempotencyKey: 'rec:wagner:tenant-99:2026-06',
+        origemType: 'subscription_license',
+        origemId: 99,
+        meta: [
+            'payer_cpf_cnpj' => '12345678901',
+            'payer_name'     => 'Tenant Cliente Wagner',
+            'pix_key'        => 'wagner@oimpresso.com.br',
+            'periodicidade'  => 'MENSAL',
+        ],
+    ));
+
+    expect($result->tipo)->toBe('pix_recv');
+    expect($result->gatewayExternalId)->toBe('RR000000000000000000001');
+
+    Http::assertSent(function ($r) {
+        return str_contains($r->url(), '/v2/rec/rec:wagner:tenant-99:2026-06')
+            && $r->method() === 'PUT'
+            && $r['calendario']['periodicidade'] === 'MENSAL'
+            && $r['pagador']['cpf'] === '12345678901'
+            && $r['recebedor']['chave'] === 'wagner@oimpresso.com.br';
+    });
+});
+
+it('emitirPixAutomatico aceita CNPJ pagador (14 dígitos)', function () {
+    Http::fake([
+        '*/oauth/token' => Http::response(['access_token' => 'tk'], 200),
+        '*/v2/rec/*'    => Http::response(['idRec' => 'r-pj', 'status' => 'CRIADA'], 201),
+    ]);
+
+    (new BcbPixDriver())->emitirPixAutomatico(new EmitirCobrancaInput(
+        businessId: 1, contactId: 1, valorCentavos: 50000,
+        vencimento: new DateTimeImmutable('+30 days'),
+        descricao: 'PJ recv',
+        idempotencyKey: 'rec:pj:001',
+        meta: [
+            'payer_cpf_cnpj' => '12345678000100', // CNPJ 14 dígitos
+            'payer_name'     => 'Empresa LTDA',
+            'pix_key'        => 'cnpj@empresa',
+        ],
+    ), $this->cred);
+
+    Http::assertSent(fn ($r) => $r['pagador']['cnpj'] === '12345678000100' && ! isset($r['pagador']['cpf']));
+});
+
+it('emitirPixAutomatico sem CPF/CNPJ pagador → InvalidPayerException', function () {
+    Http::fake(['*/oauth/token' => Http::response(['access_token' => 'tk'], 200)]);
+
+    expect(fn () => (new BcbPixDriver())->emitirPixAutomatico(
+        new EmitirCobrancaInput(
+            businessId: 1, contactId: 1, valorCentavos: 100,
+            vencimento: new DateTimeImmutable(),
+            descricao: 'x', idempotencyKey: 'k',
+            meta: ['pix_key' => 'x@y'], // sem payer_cpf_cnpj
+        ),
+        $this->cred,
+    ))->toThrow(InvalidPayerException::class);
+});
+
+it('emitirPixAutomatico sem pix_key → InvalidPayerException', function () {
+    Http::fake(['*/oauth/token' => Http::response(['access_token' => 'tk'], 200)]);
+
+    expect(fn () => (new BcbPixDriver())->emitirPixAutomatico(
+        new EmitirCobrancaInput(
+            businessId: 1, contactId: 1, valorCentavos: 100,
+            vencimento: new DateTimeImmutable(),
+            descricao: 'x', idempotencyKey: 'k',
+            meta: ['payer_cpf_cnpj' => '12345678901'],
+        ),
+        $this->cred,
+    ))->toThrow(InvalidPayerException::class);
+});
+
+it('emitirPixAutomatico API 422 → GatewayUnavailable', function () {
+    Http::fake([
+        '*/oauth/token' => Http::response(['access_token' => 'tk'], 200),
+        '*/v2/rec/*'    => Http::response(['erro' => 'periodicidade inválida'], 422),
+    ]);
+
+    expect(fn () => (new BcbPixDriver())->emitirPixAutomatico(
+        new EmitirCobrancaInput(
+            businessId: 1, contactId: 1, valorCentavos: 100,
+            vencimento: new DateTimeImmutable(),
+            descricao: 'x', idempotencyKey: 'k',
+            meta: ['payer_cpf_cnpj' => '12345678901', 'pix_key' => 'k@x'],
+        ),
+        $this->cred,
+    ))->toThrow(GatewayUnavailableException::class);
+});
+
+// ─── cancelar (revogar mandato) ─────────────────────────────────────────
+
+it('cancelar revoga mandato via DELETE /v2/rec/{id}', function () {
+    Http::fake([
+        '*/oauth/token' => Http::response(['access_token' => 'tk'], 200),
+        '*/v2/rec/RR000123' => Http::response(['status' => 'CANCELADA'], 200),
+    ]);
+
+    $cobranca = (object) ['gateway_external_id' => 'RR000123'];
+    (new BcbPixDriver())->cancelar($cobranca, $this->cred, 'Cliente cancelou contrato');
+
+    Http::assertSent(fn ($r) => $r->method() === 'DELETE'
+        && str_contains($r->url(), '/v2/rec/RR000123')
+        && $r['motivo'] === 'Cliente cancelou contrato');
+});
+
+it('cancelar sem gateway_external_id → InvalidPayer', function () {
+    $cobranca = (object) [];
+    expect(fn () => (new BcbPixDriver())->cancelar($cobranca, $this->cred, 'x'))
+        ->toThrow(InvalidPayerException::class);
+});
+
+// ─── consultar ───────────────────────────────────────────────────────────
+
+it('consultar mapeia status BCB canon', function () {
+    Http::fake([
+        '*/oauth/token' => Http::response(['access_token' => 'tk'], 200),
+        '*/v2/rec/RR-active' => Http::response([
+            'idRec'  => 'RR-active',
+            'status' => 'ATIVA',
+            'pagador' => ['cpf' => '***********'],
+        ], 200),
+    ]);
+
+    $status = (new BcbPixDriver())->consultar(
+        (object) ['gateway_external_id' => 'RR-active'],
+        $this->cred,
+    );
+
+    expect($status->status)->toBe('emitida');
+});
+
+// ─── healthCheck ─────────────────────────────────────────────────────────
+
+it('healthCheck OK', function () {
+    Http::fake(['*/oauth/token' => Http::response(['access_token' => 'tk'], 200)]);
+    expect((new BcbPixDriver())->healthCheck($this->cred)->ok)->toBeTrue();
+});
+
+it('healthCheck down 401', function () {
+    Http::fake(['*/oauth/token' => Http::response(['error' => 'bad'], 401)]);
+    expect((new BcbPixDriver())->healthCheck($this->cred)->ok)->toBeFalse();
+});
+
+// ─── processWebhook ──────────────────────────────────────────────────────
+
+it('processWebhook extrai idRec do payload BCB pix[].infoPagador.idRec', function () {
+    $d = new BcbPixDriver();
+
+    $r1 = $d->processWebhook([
+        'pix' => [
+            ['valor' => '99.90', 'infoPagador' => ['idRec' => 'RR-001']],
+        ],
+    ], $this->cred);
+    expect($r1->gateway_external_id)->toBe('RR-001');
+
+    $r2 = $d->processWebhook(['idRec' => 'RR-direct'], $this->cred);
+    expect($r2->gateway_external_id)->toBe('RR-direct');
+
+    expect($d->processWebhook(['no_id' => 'x'], $this->cred))->toBeNull();
+});
+
+// ─── credentials ─────────────────────────────────────────────────────────
+
+it('credential sem base_url → CredentialMisconfigured', function () {
+    $bad = PaymentGatewayCredential::query()->create([
+        'business_id' => 1, 'gateway_key' => 'bcb_pix',
+        'ambiente' => 'sandbox', 'ativo' => true,
+        'config_json' => ['client_id' => 'x', 'client_secret' => 'y'],
+        // sem base_url
+    ]);
+
+    expect(fn () => (new BcbPixDriver())->healthCheck($bad))
+        ->toThrow(CredentialMisconfiguredException::class);
+});
+
+it('credential gateway_key errado → CredentialMisconfigured', function () {
+    $bad = PaymentGatewayCredential::query()->create([
+        'business_id' => 1, 'gateway_key' => 'inter',
+        'ambiente' => 'sandbox', 'ativo' => true,
+        'config_json' => ['client_id' => 'x', 'client_secret' => 'y', 'base_url' => 'https://x'],
+    ]);
+
+    expect(fn () => (new BcbPixDriver())->healthCheck($bad))
+        ->toThrow(CredentialMisconfiguredException::class);
+});


### PR DESCRIPTION
> **Onda 4d.1 — BcbPixDriver isolado.** Driver PIX Automático regulado BCB (Resolução 380/2024). PSP-agnóstico via `base_url` config. CNAB Remessa/Retorno + BoletoService alto-nível ficam pra **Onda 4d.2 separada** (mantém PR enxuto).

## O que entra (643 LOC)

### `Services/Drivers/BcbPixDriver.php` (348 LOC)
Driver especializado em **PIX Recorrência (recv)** — mandato recorrente onde pagador autoriza cobranças automáticas no app do banco dele.

- ✓ `key()='bcb_pix'`
- ✓ `supports()` apenas `pix_recv`
- ✓ `emitirPixAutomatico` → `PUT /v2/rec/{txid}` cria mandato (status CRIADA → AGUARDANDO_PAGADOR)
  - Aceita CPF (11) ou CNPJ (14) pagador
  - Exige `meta.pix_key` (chave PIX beneficiário)
  - `meta.periodicidade` configurável (default `MENSAL`; opções: SEMANAL/MENSAL/TRIMESTRAL/SEMESTRAL/ANUAL)
- ✓ `cancelar` → `DELETE /v2/rec/{id}` revoga mandato (cobranças futuras param)
- ✓ `consultar` → `GET /v2/rec/{id}` + `mapStatus` BCB canon (ATIVA→emitida, CRIADA→pending, REJEITADA→erro etc)
- ✓ `healthCheck` → OAuth `/oauth/token` (ok/degraded/down)
- ✓ `processWebhook` → extrai `idRec` de `pix[].infoPagador.idRec` OU `root.idRec`
- ✗ `emitirBoleto/emitirPix(cob/cobv)/cobrarCartao` → `DriverNotSupportedException` (use inter/c6/asaas)
- ✗ `refund` → `DriverNotSupportedException` (mandato não tem refund individual via API; revogue + faça devolução PIX manual)

### PSP-agnóstico

Driver não amarra Inter/C6/Asaas. Wagner configura `config_json.base_url` apontando pro PSP escolhido (Inter, C6, Itaú, BB) — desde que o PSP implemente API Open Finance Pix Automático canônica.

### `PaymentGatewayService::DRIVERS` mapa
4 drivers ativos: `inter` + `c6` + `asaas` + `bcb_pix` (novo).

### `SCOPE.md`
- BcbPixDriver listado como concreto
- Removido de "Drivers planejados" (só PesaPalDriver fica como deprecated)

### Pest `BcbPixDriverTest` (18 testes biz=1 Http::fake)
- key/supports apenas pix_recv
- 4 métodos não-supportados throw
- `emitirPixAutomatico` OK com CPF
- `emitirPixAutomatico` aceita CNPJ (14 dígitos)
- Sem CPF/CNPJ → `InvalidPayerException`
- Sem `pix_key` → `InvalidPayerException`
- API 422 → `GatewayUnavailableException`
- `cancelar` revoga via DELETE
- `cancelar` sem `gateway_external_id` → `InvalidPayer`
- `consultar` ATIVA → emitida
- `healthCheck` ok/down 401
- `processWebhook` extrai `idRec` de 2 formatos BCB
- credential sem `base_url` → `CredentialMisconfigured`
- credential `gateway_key` errado → `CredentialMisconfigured`

## O que NÃO entra (Onda 4d.2)

- ❌ `RemessaCnabService` (CNAB 240/400 geração offline)
- ❌ `RetornoCnabService` (parse arquivo retorno banco)
- ❌ `BoletoService` alto-nível (facade orquestrador driver+persistência)

Razão: CNAB é caminho **legado** (boletos sem API). Hoje todos drivers HTTP cobrem o caso normal. CNAB só vale a pena se cliente real exigir. Separar mantém PR < 300 LOC efetivos.

## Cobertura matrix final (pós-4d.1)

| Operação | Inter | Asaas | C6 | **BcbPix** |
|---|---|---|---|---|
| `emitirBoleto` | ✅ | ✅ | ✅ | ❌ |
| `emitirPix(cob)` | ✅ | ✅ | ✅ | ❌ |
| `emitirPix(cobv)` | ✅ | ❌ | ❌ | ❌ |
| **`emitirPixAutomatico(recv)`** | ❌ | ❌ | ❌ | **✅ 4d.1** |
| `cobrarCartao` | ❌ | ✅ | ❌ | ❌ |
| `cancelar` | ✅ | ✅ | ✅ | ✅ |
| `refund` | ✅ PIX (4c) | ✅ | ❌ | ❌ (revoga mandato) |
| `consultar` | ✅ | ✅ | ✅ | ✅ |
| `healthCheck` | ✅ | ✅ | ✅ | ✅ |
| `processWebhook` | ✅ | ✅ | ✅ | ✅ |

## Validação pré-merge

- [x] `php -l` em 3 arquivos PHP — todos OK
- [x] PSP-agnóstico via config_json.base_url
- [x] CPF (11) vs CNPJ (14) detectado automaticamente
- [x] Validações `pix_key` + `payer_cpf_cnpj` obrigatórias
- [x] mapStatus BCB completo (ATIVA, CRIADA, AGUARDANDO_PAGADOR, REJEITADA, CANCELADA, EXPIRADA, CONCLUIDA)
- [x] Pest 18 testes cobrem todos os fluxos (incluindo edge cases sem CPF/key, API erro, credential errada)
- [x] Token OAuth cache in-memory per credential
- [x] SCOPE.md atualizado
- [x] Zero diff em outros módulos
- [ ] CI verde (vai validar)

## Próximas opções pós-merge

| | |
|---|---|
| **Onda 4d.2** | RemessaCnab + RetornoCnab + BoletoService alto-nível (se cliente exigir) |
| **Onda 3.5** cutover | Sua decisão sobre webhook Inter sandbox |
| **F1 Cowork** | Em paralelo — você gera 3 protótipos UI |
| **PaymentGateway está ~95% completo** | Camada técnica de cobrança canônica entregue. Falta só UI (depende F1 Cowork + F2 você aprova) |

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)