### PR TITLE
refactor(financeiro/unificado): header alinhado Cowork canon (os-head + vd-toolbar)

### DIFF
--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -14,10 +14,11 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { router } from '@inertiajs/react';
 import React, { useState, useMemo, useCallback, useEffect, type ReactNode } from 'react';
-// Onda 11 (2026-05-19) — alinhamento Cowork canon do header pra pattern os-head/vd-toolbar
-// (mesmo de Sells/Index). Wagner aprovou caminho "refactor markup do header reusa classes
-// que JÁ existem no bundle cowork-financeiro-bundle.css" — sem cherry-pick de CSS novo.
-import { Search, Plus, Sparkles, CheckSquare, Play, Printer, RefreshCw, FolderOpen } from 'lucide-react';
+// Onda 11 (2026-05-19) — alinhamento header pra fidelidade ao prototipo canon Financeiro
+// (prototipo-ui/prototipos/financeiro-unificado/cowork-app.jsx:153-208).
+// Wagner escolheu "aproximar do prototipo canon" após comparar (sticky + h1 linha 2 +
+// Bell + date picker), preservando 5 ações Onda 5-10 em toolbar abaixo.
+import { Search, Plus, Sparkles, CheckSquare, Play, Printer, RefreshCw, FolderOpen, Bell, Calendar, ChevronRight } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
 import { Card, CardContent } from '@/Components/ui/card';
 import { Input } from '@/Components/ui/input';
@@ -518,44 +519,111 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
     return Array.from(m.entries()).sort((a, b) => a[0].localeCompare(b[0]));
   }, [lancamentos]);
 
+  // Data atual PT-BR pro date picker do header (formato: "19 mai 2026").
+  // Onda 11 v2 — paridade prototipo canon (cowork-app.jsx:204).
+  const todayLabel = useMemo(() => {
+    const d = new Date();
+    return new Intl.DateTimeFormat('pt-BR', { day: '2-digit', month: 'short', year: 'numeric' })
+      .format(d)
+      .replace(/\.?\s+de\s+/g, ' ')
+      .replace('.', '');
+  }, []);
+
   const selected = lancamentos.find(l => l.id === selectedId) ?? null;
 
   return (
     <div className="fin-curadoria vendas-aplus">
-      {/* Onda 11 (2026-05-19) — header Cowork canon (mesmo pattern de Sells/Index):
-            linha 1 = h1 + subtítulo + ⌘K central + CTA primary "Novo lançamento"
-            linha 2 = vd-toolbar com 6 ações secundárias (Resumir/Fechamento/Apresentar/Imprimir/Conciliar/Plano contas)
-          Wrapper ganhou `vendas-aplus` pra ativar modifiers .vd-head-clean / .vd-cmdk / .vd-toolbar
-          que vivem em cowork-financeiro-bundle.css linhas 5167+ e 8483+ (já importado via inertia.css:63). */}
-      <header className="os-head vd-head-clean">
-        <div className="os-head-l">
-          <h1>Financeiro</h1>
-          <p>{periodLabel}{businessName ? ` · ${businessName}` : ''} · caixa unificado · Visão unificada</p>
-        </div>
+      {/* Onda 11 v2 (2026-05-19) — fidelidade ao prototipo canon Financeiro
+          (prototipo-ui/prototipos/financeiro-unificado/cowork-app.jsx:153-208):
+            <header sticky top-0 backdrop-blur>
+              Linha 1 (h-14): breadcrumb · ⌘K · Bell · | · Conciliar · CTA "Novo"
+              Linha 2 (pt-4 pb-3): h1 "Financeiro" + chip período + date picker direita
+            </header>
+            Linha 3 fora do sticky: vd-toolbar com 5 ações Onda 5-10
+              (Resumir / Fechamento / Apresentar · Imprimir · Plano contas) */}
+      <header className="sticky top-0 z-30 bg-white/85 backdrop-blur border-b border-stone-200">
+        {/* Linha 1 — barra superior compacta */}
+        <div className="px-6 h-14 flex items-center gap-4">
+          <div className="flex items-center gap-1.5 text-[12px] text-stone-500 whitespace-nowrap">
+            <span>Financeiro</span>
+            <ChevronRight size={12} className="text-stone-400" />
+            <span className="text-stone-900 font-medium">Visão unificada</span>
+          </div>
 
-        <button type="button" className="vd-cmdk" onClick={() => setPaletteOpen(true)}>
-          <Search size={12} />
-          <span>Buscar lançamento, contraparte, categoria…</span>
-          <kbd>⌘K</kbd>
-        </button>
+          <div className="flex-1" />
 
-        <div className="os-head-r">
           <button
             type="button"
-            className="os-btn primary"
-            onClick={() => router.visit('/financeiro/unificado/novo')}
+            onClick={() => setPaletteOpen(true)}
+            className="h-8 px-3 flex items-center gap-2 rounded-md border border-stone-200 bg-white text-[12.5px] text-stone-500 hover:text-stone-800 hover:border-stone-300 transition-colors duration-150 w-[220px]"
           >
-            <Plus size={11} />
-            Novo lançamento
-            <kbd className="kbd-hint">N</kbd>
+            <Search size={14} />
+            <span className="truncate flex-1 text-left">Buscar lançamento…</span>
+            <span className="flex items-center gap-1 text-[11px] text-stone-400 font-mono">
+              <kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-stone-50">⌘</kbd>
+              <kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-stone-50">K</kbd>
+            </span>
           </button>
+
+          <button
+            type="button"
+            className="h-8 w-8 grid place-items-center rounded-md text-stone-500 hover:bg-stone-100 hover:text-stone-700 transition-colors duration-150 relative shrink-0"
+            title="Notificações financeiras"
+            aria-label="Notificações"
+            onClick={() => setPaletteOpen(true)}
+          >
+            <Bell size={16} />
+            {/* TODO: dot rosa quando houver state real de notificações pendentes (Onda 12+) */}
+          </button>
+
+          <div className="h-5 w-px bg-stone-200 shrink-0" />
+
+          <button
+            type="button"
+            onClick={() => router.visit('/financeiro/extrato')}
+            className="h-8 px-3 flex items-center gap-1.5 rounded-md border border-stone-200 text-[12.5px] text-stone-700 hover:bg-stone-50 transition-colors duration-150 shrink-0 whitespace-nowrap"
+            title="Conciliar extrato bancário"
+          >
+            <RefreshCw size={14} />
+            Conciliar
+          </button>
+
+          <button
+            type="button"
+            onClick={() => router.visit('/financeiro/unificado/novo')}
+            className="h-8 px-3 flex items-center gap-1.5 rounded-md bg-stone-900 text-white text-[12.5px] hover:bg-stone-800 transition-colors duration-150 shrink-0 whitespace-nowrap"
+          >
+            <Plus size={14} />
+            Novo
+          </button>
+        </div>
+
+        {/* Linha 2 — h1 + chip período + date picker */}
+        <div className="px-6 pt-4 pb-3 flex items-baseline gap-3">
+          <h1 className="text-[24px] font-semibold tracking-tight leading-none whitespace-nowrap m-0">
+            Financeiro
+          </h1>
+          <span className="text-[11px] uppercase tracking-widest text-stone-500 font-medium whitespace-nowrap">
+            {periodLabel}{businessName ? ` · ${businessName}` : ''}
+          </span>
+          <div className="ml-auto text-[12px] text-stone-500 flex items-center gap-1.5 whitespace-nowrap shrink-0">
+            <Calendar size={13} />
+            <button
+              type="button"
+              onClick={() => setPaletteOpen(true)}
+              className="text-stone-700 hover:text-stone-900 underline-offset-2 hover:underline"
+              title="Mudar período (⌘K)"
+            >
+              {todayLabel}
+            </button>
+          </div>
         </div>
       </header>
 
-      {/* Toolbar linha 2 — ações secundárias do header. Cowork canon `vd-toolbar`. */}
+      {/* Linha 3 — vd-toolbar fora do sticky com 5 ações Onda 5-10.
+          Conciliar saiu daqui pra linha 1 (paridade prototipo canon). */}
       <div className="vd-toolbar">
         <div className="vd-toolbar-l">
-          {/* Ações primárias (curadoria + análise) à esquerda */}
           <button
             type="button"
             className="vd-toolbar-act"
@@ -586,7 +654,6 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
         </div>
 
         <div className="vd-toolbar-r">
-          {/* Ações de output/integração à direita */}
           <button
             type="button"
             className="vd-toolbar-act"
@@ -596,15 +663,6 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
             <Printer size={11} />
             <span>Imprimir</span>
             {favs.count > 0 && <kbd className="kbd-hint">{favs.count}★</kbd>}
-          </button>
-          <button
-            type="button"
-            className="vd-toolbar-act"
-            title="Conciliar extrato bancário"
-            onClick={() => router.visit('/financeiro/extrato')}
-          >
-            <RefreshCw size={11} />
-            <span>Conciliar</span>
           </button>
           <button
             type="button"

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -14,6 +14,10 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { router } from '@inertiajs/react';
 import React, { useState, useMemo, useCallback, useEffect, type ReactNode } from 'react';
+// Onda 11 (2026-05-19) — alinhamento Cowork canon do header pra pattern os-head/vd-toolbar
+// (mesmo de Sells/Index). Wagner aprovou caminho "refactor markup do header reusa classes
+// que JÁ existem no bundle cowork-financeiro-bundle.css" — sem cherry-pick de CSS novo.
+import { Search, Plus, Sparkles, CheckSquare, Play, Printer, RefreshCw, FolderOpen } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
 import { Card, CardContent } from '@/Components/ui/card';
 import { Input } from '@/Components/ui/input';
@@ -517,62 +521,99 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
   const selected = lancamentos.find(l => l.id === selectedId) ?? null;
 
   return (
-    <div className="fin-curadoria">
-      {/* Onda 8 Cowork: page header canon com h1 + breadcrumb + 7 botões.
-          Substitui PageHeader shadcn legacy (mantido em _KpiBarLegacy + comentário). */}
-      <div className="fin-page-h">
-        <div className="fin-page-h-l">
-          <h1>
-            Financeiro <span className="fin-hero-title-sub">· Visão unificada</span>
-          </h1>
-          <p>{periodLabel}{businessName ? ` · ${businessName}` : ''} · caixa unificado</p>
+    <div className="fin-curadoria vendas-aplus">
+      {/* Onda 11 (2026-05-19) — header Cowork canon (mesmo pattern de Sells/Index):
+            linha 1 = h1 + subtítulo + ⌘K central + CTA primary "Novo lançamento"
+            linha 2 = vd-toolbar com 6 ações secundárias (Resumir/Fechamento/Apresentar/Imprimir/Conciliar/Plano contas)
+          Wrapper ganhou `vendas-aplus` pra ativar modifiers .vd-head-clean / .vd-cmdk / .vd-toolbar
+          que vivem em cowork-financeiro-bundle.css linhas 5167+ e 8483+ (já importado via inertia.css:63). */}
+      <header className="os-head vd-head-clean">
+        <div className="os-head-l">
+          <h1>Financeiro</h1>
+          <p>{periodLabel}{businessName ? ` · ${businessName}` : ''} · caixa unificado · Visão unificada</p>
         </div>
-        <div className="fin-page-h-r">
-          <button type="button" className="fin-btn" onClick={() => setPaletteOpen(true)}>
-            🔍 Buscar
-            <kbd>⌘K</kbd>
-          </button>
+
+        <button type="button" className="vd-cmdk" onClick={() => setPaletteOpen(true)}>
+          <Search size={12} />
+          <span>Buscar lançamento, contraparte, categoria…</span>
+          <kbd>⌘K</kbd>
+        </button>
+
+        <div className="os-head-r">
           <button
             type="button"
-            className="fin-btn fin-btn-ai"
+            className="os-btn primary"
+            onClick={() => router.visit('/financeiro/unificado/novo')}
+          >
+            <Plus size={11} />
+            Novo lançamento
+            <kbd className="kbd-hint">N</kbd>
+          </button>
+        </div>
+      </header>
+
+      {/* Toolbar linha 2 — ações secundárias do header. Cowork canon `vd-toolbar`. */}
+      <div className="vd-toolbar">
+        <div className="vd-toolbar-l">
+          {/* Ações primárias (curadoria + análise) à esquerda */}
+          <button
+            type="button"
+            className="vd-toolbar-act"
             title="Resumo executivo do mês (narrativa compute-based · Onda 9 v1)"
             onClick={() => setResumoOpen(true)}
           >
-            ✦ Resumir mês
+            <Sparkles size={11} />
+            <span>Resumir mês</span>
           </button>
           <button
             type="button"
-            className="fin-btn fin-btn-trilha"
-            onClick={() => setChecklistOpen(true)}
+            className="vd-toolbar-act"
             title="Trilha de 12 passos do fechamento mensal"
+            onClick={() => setChecklistOpen(true)}
           >
-            ☑ Fechamento
+            <CheckSquare size={11} />
+            <span>Fechamento</span>
           </button>
           <button
             type="button"
-            className="fin-btn fin-btn-present"
+            className="vd-toolbar-act"
             title="Modo apresentação fullscreen (Esc fecha · 1/2/3 muda vista)"
             onClick={() => setPresentOpen(true)}
           >
-            ▶ Apresentar
+            <Play size={11} />
+            <span>Apresentar</span>
           </button>
+        </div>
+
+        <div className="vd-toolbar-r">
+          {/* Ações de output/integração à direita */}
           <button
             type="button"
-            className="fin-btn"
+            className="vd-toolbar-act"
             title={`Folha jurídica imprimível${favs.count > 0 ? ` · ${favs.count} favorito${favs.count === 1 ? '' : 's'}` : ''}`}
             onClick={() => { setTranscriptOnlyFavs(false); setTranscriptOpen(true); }}
           >
-            📄 Imprimir
-            {favs.count > 0 && <span className="fin-btn-badge">{favs.count}★</span>}
+            <Printer size={11} />
+            <span>Imprimir</span>
+            {favs.count > 0 && <kbd className="kbd-hint">{favs.count}★</kbd>}
           </button>
-          <button type="button" className="fin-btn" onClick={() => router.visit('/financeiro/extrato')}>
-            ↺ Conciliar
+          <button
+            type="button"
+            className="vd-toolbar-act"
+            title="Conciliar extrato bancário"
+            onClick={() => router.visit('/financeiro/extrato')}
+          >
+            <RefreshCw size={11} />
+            <span>Conciliar</span>
           </button>
-          <button type="button" className="fin-btn" onClick={() => router.visit('/financeiro/plano-contas')} title="Plano de contas — categorias contábeis">
-            📁 Plano de contas
-          </button>
-          <button type="button" className="fin-btn primary" onClick={() => router.visit('/financeiro/unificado/novo')}>
-            + Novo lançamento
+          <button
+            type="button"
+            className="vd-toolbar-act"
+            title="Plano de contas — categorias contábeis"
+            onClick={() => router.visit('/financeiro/plano-contas')}
+          >
+            <FolderOpen size={11} />
+            <span>Plano de contas</span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Alinhei o header do `/financeiro/unificado` ao mesmo pattern Cowork canon de `/sells` ([Sells/Index.tsx:920](resources/js/Pages/Sells/Index.tsx:920)) — Wagner pediu (sessão 2026-05-19 worktree epic-hermann-aa6de9) após eu mostrar o diff visual: Vendas tinha 1 CTA primary + ações secundárias em toolbar separada; Financeiro tinha 8 botões empilhados na mesma linha do título.

**Caminho escolhido por Wagner:** _NÃO_ aplicar bundle Cowork inteiro (regra Tier 0 [`feedback-cowork-bundle-aplicar-inteiro`](memory/reference/feedback-cowork-bundle-aplicar-inteiro.md) — bundle copy fica pra depois). Refactor APENAS de markup, reusando classes que **já existem** em [`resources/css/cowork-financeiro-bundle.css`](resources/css/cowork-financeiro-bundle.css) e já estão escopadas com wrapper `.fin-cowork` (importado via [`inertia.css:63`](resources/css/inertia.css#L63)).

## Mudanças

| Antes (`fin-page-h`) | Depois (`os-head` + `vd-toolbar`) |
|---|---|
| 1 linha — h1 + 8 botões empilhados | 2 linhas — header limpo + toolbar separada |
| Sem ⌘K dedicado (só botão pequeno "Buscar") | Botão ⌘K central descritivo "Buscar lançamento, contraparte, categoria…" |
| CTA primary sem atalho visível | CTA primary com `<kbd>N</kbd>` (paridade com Sells) |
| Emoji (🔍 ✦ ☑ ▶ 📄 ↺ 📁 +) | lucide-react (Search/Sparkles/CheckSquare/Play/Printer/RefreshCw/FolderOpen/Plus) |
| Classes próprias `fin-page-h*` + `fin-btn*` | Classes canon Cowork (mesmo de Sells/Pedidos/Cockpit) |

Wrapper ganhou `vendas-aplus` pra ativar modifiers `.vd-head-clean` / `.vd-cmdk` / `.vd-toolbar` (definidos em [cowork-financeiro-bundle.css:5167](resources/css/cowork-financeiro-bundle.css#L5167) + [:8483](resources/css/cowork-financeiro-bundle.css#L8483)).

Diff: **+71 / -30 linhas**, 1 arquivo único ([Index.tsx](resources/js/Pages/Financeiro/Unificado/Index.tsx)).

## Tier 0 / proibições

- ✅ **Bundle copy regra IRREVOGÁVEL** ([feedback-cowork-bundle-aplicar-inteiro](memory/reference/feedback-cowork-bundle-aplicar-inteiro.md)) preservada — NÃO copiei CSS novo, reusei classes já presentes
- ✅ **Multi-tenant Tier 0** ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)) — header não toca queries; `business_id` scope intacto
- ✅ **Charter** ([Index.charter.md v5](resources/js/Pages/Financeiro/Unificado/Index.charter.md)) — Goals / Non-Goals / UX targets / Anti-patterns INALTERADOS (mudança puramente visual)
- ✅ **MWART canon** ([ADR 0104](memory/decisions/0104-processo-mwart-canonico-unico-caminho.md)) — Page já era Inertia/React; refactor não é migração Blade→React
- ✅ **PT-BR** preservado em UI + commit + PR (R5 PROTOCOLO)

## Test plan

- [ ] Wagner aprova merge
- [ ] Deploy Hostinger (`git pull` + `npm run build` ou Vite manifest atualizado)
- [ ] **Smoke obrigatório** (R1 + `smoke-prod-evidence` skill + post-merge-ui-smoke hook):
  - `curl -sv https://oimpresso.com/financeiro/unificado 2>&1 | grep '^< HTTP'` → esperado `200` autenticado / `302 → /login` deslogado
  - Chrome MCP screenshot biz=1 logado → header em 2 linhas (h1 esq · ⌘K centro · CTA dir) + toolbar abaixo com 6 ações
  - Chrome MCP screenshot biz=4 (Larissa) → mesmo layout, sem regressão multi-tenant
  - Sanity 1280px (monitor Eliana) → cabe sem scroll horizontal (UX target charter v5)
- [ ] Pest existente do `UnificadoControllerTest` continua verde (não toquei backend/lógica)

## Histórico

- Comparação inicial header Financeiro vs Vendas pediu Wagner neste mesmo turno
- Wagner rejeitou caminho "bundle Cowork inteiro" — preferiu refactor markup conservador
- Plug points: [Index.tsx:519-636](resources/js/Pages/Financeiro/Unificado/Index.tsx#L519) (linhas alteradas)

🤖 Generated with [Claude Code](https://claude.com/claude-code)