### PR TITLE
chore(paymentgateway): alinhar composer.json com pattern canon — ADR 0170

### DIFF
--- a/Modules/PaymentGateway/composer.json
+++ b/Modules/PaymentGateway/composer.json
@@ -1,24 +1,15 @@
 {
-    "name": "nwidart/paymentgateway",
-    "description": "",
-    "authors": [
-        {
-            "name": "Nicolas Widart",
-            "email": "n.widart@gmail.com"
-        }
-    ],
+    "name": "oimpresso/paymentgateway",
+    "description": "Camada técnica de cobrança BR — drivers Inter/C6/Asaas/Pix Automático BCB, webhooks, CNAB, credenciais.",
+    "authors": [{"name": "Wagner", "email": "wagnerra@gmail.com"}],
     "extra": {
         "laravel": {
-            "providers": [],
-            "aliases": {}
+            "providers": ["Modules\\PaymentGateway\\Providers\\PaymentGatewayServiceProvider"]
         }
     },
     "autoload": {
         "psr-4": {
-            "Modules\\PaymentGateway\\": "",
-            "Modules\\PaymentGateway\\App\\": "app/",
-            "Modules\\PaymentGateway\\Database\\Factories\\": "database/factories/",
-            "Modules\\PaymentGateway\\Database\\Seeders\\": "database/seeders/"
+            "Modules\\PaymentGateway\\": ""
         }
     }
 }


### PR DESCRIPTION
## Summary

- Substitui scaffold genérico nWidart (`name: nwidart/paymentgateway`, author Nicolas Widart, autoload com 3 namespaces extras vazios) pelo **pattern canon** validado em [Modules/ConsultaOs/composer.json](Modules/ConsultaOs/composer.json) + [Modules/ADS/composer.json](Modules/ADS/composer.json)
- Origem: comparativo skill `criar-modulo` (referências canon validadas 2026-05-03/2026-05-04) + diff de 7 módulos

## Mudanças

| Campo | Antes (scaffold nWidart) | Depois (canon) |
|---|---|---|
| `name` | `nwidart/paymentgateway` | `oimpresso/paymentgateway` |
| `description` | _(vazio)_ | "Camada técnica de cobrança BR — drivers Inter/C6/Asaas/Pix Automático BCB, webhooks, CNAB, credenciais." |
| `authors` | Nicolas Widart | Wagner |
| `extra.laravel.providers` | `[]` | `["Modules\PaymentGateway\Providers\PaymentGatewayServiceProvider"]` |
| `autoload.psr-4` | 4 namespaces (3 vazios: `App\`, `Database\Factories\`, `Database\Seeders\`) | só `Modules\PaymentGateway\` |

## ⚠️ NÃO resolve o bug do botão Install com `#`

Diagnóstico completo na conversa que originou este PR:

1. **Card aparece** em `/manage-modules` porque `Module::toCollection()` (em [Install/ModulesController.php:44](app/Http/Controllers/Install/ModulesController.php#L44)) enumera todos os módulos com `module.json` válido
2. **Botão Install vai pra `#`** porque [Install/ModulesController.php:57](app/Http/Controllers/Install/ModulesController.php#L57) chama `action('\Modules\PaymentGateway\Http\Controllers\InstallController@index')` que lança exception quando a rota não está registrada
3. Rota só é registrada se o `PaymentGatewayServiceProvider` bootar, o que só acontece se nWidart enxergar `[Enabled]`
4. **Fix funcional é PR #1136** (`modules_statuses.json` com `"PaymentGateway": true`) — ainda OPEN, não-deployed

Este PR é **polish cosmético-canônico** — alinha o módulo com o que `criar-modulo` skill define como pattern certo. Não substitui o fix funcional do PR #1136.

## Test plan

- [x] JSON válido
- [x] `extra.laravel.providers` registrado (Laravel native auto-discovery vai bootar ServiceProvider em qualquer ambiente)
- [ ] Após merge + deploy + `composer dump-autoload --no-scripts` no Hostinger: PaymentGatewayServiceProvider auto-registrado via composer (não depende exclusivamente do nWidart manifest)
- [ ] Pós-deploy: validar `php artisan module:list | grep PaymentGateway` mostra `[Enabled]` (combinado com PR #1136)

## Refs

- ADR 0170
- Skill `criar-modulo` (referência canon)
- PR #1136 (fix funcional: ativar em modules_statuses.json)

🤖 Generated with [Claude Code](https://claude.com/claude-code)