### PR TITLE
hotfix(paymentgateway): F3 tela branca prod — null-guard Inertia::defer

### DIFF
--- a/resources/js/Pages/Financeiro/Cobranca/Index.tsx
+++ b/resources/js/Pages/Financeiro/Cobranca/Index.tsx
@@ -62,7 +62,10 @@ const FUNIL_FALLBACK: CobrancaFunil = {
   mandatos_cancelados: 0,
 };
 
-function CobrancaPage({ cobrancas, kpis, funil, accounts, gateways, filtros, isSaasBusiness, today }: Props) {
+function CobrancaPage({ cobrancas, kpis, funil, accounts = [], gateways = [], filtros, isSaasBusiness, today }: Props) {
+  // Hotfix Inertia::defer first paint: kpis/funil podem ser undefined até resolver.
+  kpis = kpis ?? KPI_FALLBACK;
+  funil = funil ?? FUNIL_FALLBACK;
   // Persistência localStorage namespace oimpresso.financeiro.cobranca.*
   const [tabStatus, setTabStatus] = useState(() => lsGet<string>('tab', filtros.status || 'all'));
   const [tipoFilter, setTipoFilter] = useState(() => lsGet<string>('tipo', filtros.tipo || 'all'));
@@ -91,8 +94,10 @@ function CobrancaPage({ cobrancas, kpis, funil, accounts, gateways, filtros, isS
     return t === tipoFilter;
   }, [tipoFilter]);
 
+  // Hotfix: cobrancas é Inertia::defer — undefined no primeiro paint até resolver.
+  // Sem o ?? [] o useMemo crasha com "Cannot read properties of undefined (reading 'filter')".
   const filtered = useMemo(() => {
-    return cobrancas.filter(c => {
+    return (cobrancas ?? []).filter(c => {
       if (tabStatus !== 'all' && c.status !== tabStatus) return false;
       if (!tipoMatch(c.tipo)) return false;
       if (gatewayFilter !== 'all' && c.gateway !== gatewayFilter) return false;
@@ -108,9 +113,10 @@ function CobrancaPage({ cobrancas, kpis, funil, accounts, gateways, filtros, isS
   }, [cobrancas, tabStatus, tipoMatch, gatewayFilter, accountFilter, origemFilter, busca]);
 
   const statusCounts = useMemo(() => {
-    const out: Record<string, number> = { all: cobrancas.length };
+    const list = cobrancas ?? [];
+    const out: Record<string, number> = { all: list.length };
     (['emitida', 'paga', 'vencida', 'cancelada', 'erro'] as const).forEach(s => {
-      out[s] = cobrancas.filter(c => c.status === s).length;
+      out[s] = list.filter(c => c.status === s).length;
     });
     return out;
   }, [cobrancas]);
@@ -391,7 +397,7 @@ function CobrancaPage({ cobrancas, kpis, funil, accounts, gateways, filtros, isS
       {novaOpen && <SheetNovaCobranca accounts={accounts} onClose={() => setNovaOpen(false)} />}
       {remessaOpen && <SheetRemessaRetorno onClose={() => setRemessaOpen(false)} />}
       {cheatOpen && <CheatSheet onClose={() => setCheatOpen(false)} />}
-      {aiOpen && <AiResumoMes kpis={kpis ?? KPI_FALLBACK} cobs={cobrancas ?? []} onClose={() => setAiOpen(false)} />}
+      {aiOpen && <AiResumoMes kpis={kpis} cobs={cobrancas ?? []} onClose={() => setAiOpen(false)} />}
     </div>
   );
 }

--- a/resources/js/Pages/Settings/PaymentGateways/Index.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/Index.tsx
@@ -39,7 +39,11 @@ interface Props {
 
 const KPI_FALLBACK: SettingsKpis = { ativos: 0, total: 0, fail: 0, cobs_hoje: 0 };
 
-function PaymentGatewaysPage({ gateways = [], accounts = [], kpis = KPI_FALLBACK, today }: Props) {
+function PaymentGatewaysPage({ gateways, accounts, kpis, today }: Props) {
+  // Hotfix Inertia::defer first paint — props deferred chegam undefined.
+  gateways = gateways ?? [];
+  accounts = accounts ?? [];
+  kpis = kpis ?? KPI_FALLBACK;
   const [drawer, setDrawer] = useState<SettingsGateway | null>(null);
   const [novoOpen, setNovoOpen] = useState(false);
   const [confirmToggle, setConfirmToggle] = useState<{ gateway: SettingsGateway; newValue: boolean } | null>(null);


### PR DESCRIPTION
## Bug confirmado prod biz=WR2

Wagner reportou tela completamente branca em \`/financeiro/cobranca\` após instalar módulo PaymentGateway.

## Causa-raiz

Chrome MCP console logs:
\`\`\`
TypeError: Cannot read properties of undefined (reading 'filter')
  at Be (build-inertia/assets/Index-bfwwWTo5.js:0:4106)
  at Object.useMemo (...)
\`\`\`

Props \`cobrancas\`/\`kpis\`/\`funil\` são \`Inertia::defer\` — chegam **undefined** no first paint até promise resolver. \`useMemo\` + \`statusCounts\` chamavam \`.filter()\` direto sem null-guard.

## Fix

### Cobrança Index.tsx
- \`(cobrancas ?? []).filter(...)\` em useMemo filtered + statusCounts
- props defaults: \`gateways = []\`, \`accounts = []\`
- body fallback: \`kpis = kpis ?? KPI_FALLBACK\`, \`funil = funil ?? FUNIL_FALLBACK\`

### Settings/PaymentGateways Index.tsx
- Remove defaults inline (não cobrem null explícito)
- Adiciona null-guards body: \`gateways/accounts/kpis ?? fallback\`

## Infra Contract

PR só edita 2 .tsx files. Zero mudança em routes/middleware/Controller. Frontend Vite build vai recompilar.

Validação pós-deploy:
\`\`\`
curl -sv https://oimpresso.com/financeiro/cobranca   # autenticado → tela renderizada
\`\`\`

Chrome MCP screenshot confirmação após Wagner mergear + Vite build deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)