### PR TITLE
hotfix(sidebar): SIDEBAR_GROUPS sync label 'Cobrança' — Wagner prod

### DIFF
--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -139,10 +139,13 @@ const SIDEBAR_GROUPS: Array<{ key: string; label: string; items: string[] }> = [
   {
     key: 'fin',
     label: 'FINANCEIRO',
-    // Wagner 2026-05-18: 3 labels novas (Fluxo de Caixa / DRE / Gateway) saíram
+    // Wagner 2026-05-18: 3 labels novas (Fluxo de Caixa / DRE / Cobrança) saíram
     // do dropdown popover-2 pra entradas top-level — ficam visíveis sem click.
-    // "Boletos" renomeado pra "Gateway de Pagamento" (Inter API + PIX + futuro).
-    items: ['Despesas', 'Contas de pagamento', 'Accounting', 'Contabilidade', 'Financeiro', 'Fluxo de Caixa', 'DRE / Relatórios', 'Gateway de Pagamento', 'Cobrança Recorrente'],
+    // Wagner 2026-05-19: "Gateway de Pagamento" → "Cobrança" (F3 PaymentGateway
+    // UI Tela 1 entregue em /financeiro/cobranca — ADR 0144 + 0170). Posição
+    // acima de "Cobrança Recorrente" pra hierarquia visual (cobrança avulsa →
+    // cobrança recorrente RB).
+    items: ['Despesas', 'Contas de pagamento', 'Accounting', 'Contabilidade', 'Financeiro', 'Fluxo de Caixa', 'DRE / Relatórios', 'Cobrança', 'Cobrança Recorrente'],
   },
   {
     key: 'estoque',


### PR DESCRIPTION
Fix item órfão sidebar — SIDEBAR_GROUPS frontend ainda mapeava 'Gateway de Pagamento' (label antigo). Trocado pra 'Cobrança' acima de 'Cobrança Recorrente'. 1 arquivo, +6/-3 linhas. Wagner pediu prod 2026-05-19.