### PR TITLE
refactor(sidebar): grupo via DataController (não hardcode frontend)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/DataController.php
+++ b/Modules/Financeiro/Http/Controllers/DataController.php
@@ -136,12 +136,19 @@ class DataController extends Controller
                 // Wagner 2026-05-19: F3 PaymentGateway UI Tela 1 entregue
                 // em /financeiro/cobranca, escopo expandido pra todos tipos
                 // boleto+pix+pix_recv+card. ADR 0144 + 0170).
+                //
+                // 'group' => 'fin' declara o grupo sidebar — Wagner regra
+                // 2026-05-19: "nunca hardcode label no SIDEBAR_GROUPS frontend,
+                // sempre via DataController do módulo". LegacyMenuAdapter
+                // propaga essa key pro ShellMenuItem.group, Sidebar.tsx
+                // findGroupKey usa antes do label match.
                 $menu->url(
                     url('/financeiro/cobranca'),
                     __('financeiro::financeiro.cobranca_label'),
                     [
                         'icon'   => 'fa fas fa-credit-card',
                         'active' => $segmento_ativo && request()->segment(2) === 'cobranca',
+                        'group'  => 'fin',
                     ]
                 )->order(85.3);
             }

--- a/app/Services/LegacyMenuAdapter.php
+++ b/app/Services/LegacyMenuAdapter.php
@@ -304,6 +304,15 @@ class LegacyMenuAdapter
             'inertia' => $this->isInertiaRoute($url),
         ];
 
+        // Grupo sidebar declarado pelo DataController do módulo via attribute
+        // 'group' OU 'sidebar_group'. Quando presente, frontend Sidebar usa este
+        // valor em findGroupKey antes do label match (evita hardcode de label
+        // string em SIDEBAR_GROUPS pra cada novo item — Wagner 2026-05-19).
+        $group = $props['group'] ?? $props['sidebar_group'] ?? $props['attributes']['group'] ?? null;
+        if (! empty($group)) {
+            $result['group'] = (string) $group;
+        }
+
         if (!empty($children)) {
             $result['children'] = $children;
             // Pais dropdown geralmente não têm URL própria no nwidart — deixamos undef

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -141,11 +141,10 @@ const SIDEBAR_GROUPS: Array<{ key: string; label: string; items: string[] }> = [
     label: 'FINANCEIRO',
     // Wagner 2026-05-18: 3 labels novas (Fluxo de Caixa / DRE / Cobrança) saíram
     // do dropdown popover-2 pra entradas top-level — ficam visíveis sem click.
-    // Wagner 2026-05-19: "Gateway de Pagamento" → "Cobrança" (F3 PaymentGateway
-    // UI Tela 1 entregue em /financeiro/cobranca — ADR 0144 + 0170). Posição
-    // acima de "Cobrança Recorrente" pra hierarquia visual (cobrança avulsa →
-    // cobrança recorrente RB).
-    items: ['Despesas', 'Contas de pagamento', 'Accounting', 'Contabilidade', 'Financeiro', 'Fluxo de Caixa', 'DRE / Relatórios', 'Cobrança', 'Cobrança Recorrente'],
+    // Itens NOVOS (Cobrança, futuros) devem declarar `'group' => 'fin'` no
+    // DataController do módulo em vez de adicionar string aqui — Wagner regra
+    // 2026-05-19: "nunca hardcode label, sempre via DataController do módulo".
+    items: ['Despesas', 'Contas de pagamento', 'Accounting', 'Contabilidade', 'Financeiro', 'Fluxo de Caixa', 'DRE / Relatórios', 'Gateway de Pagamento', 'Cobrança Recorrente'],
   },
   {
     key: 'estoque',
@@ -193,12 +192,35 @@ const SIDEBAR_GROUPS: Array<{ key: string; label: string; items: string[] }> = [
   },
 ];
 
-function findGroupKey(label: string): string {
-  const norm = label.trim();
+/**
+ * Resolve grupo do sidebar pra um menu item.
+ *
+ * Prioridade (Wagner regra 2026-05-19 — DataController declara, frontend não hardcode):
+ *  1. item.group (declarado pelo DataController via `data['group']`)
+ *  2. Match por label string em SIDEBAR_GROUPS.items[] (legacy compat)
+ *  3. Fallback 'mais' (collapse fechado por default)
+ */
+function findGroupKey(item: ShellMenuItem | string): string {
+  // String legacy pra cobertura backwards-compat (alguns callers passam só label)
+  if (typeof item === 'string') {
+    const norm = item.trim();
+    for (const g of SIDEBAR_GROUPS) {
+      if (g.items.some((i) => i.toLowerCase() === norm.toLowerCase())) return g.key;
+    }
+    return 'mais';
+  }
+
+  // 1. group declarado pelo DataController do módulo
+  if (item.group && SIDEBAR_GROUPS.some((g) => g.key === item.group)) {
+    return item.group;
+  }
+
+  // 2. fallback label match (legacy items que ainda não declararam group)
+  const norm = item.label.trim();
   for (const g of SIDEBAR_GROUPS) {
     if (g.items.some((i) => i.toLowerCase() === norm.toLowerCase())) return g.key;
   }
-  return 'mais';  // fallback — group "MAIS" no final
+  return 'mais';
 }
 
 // ── CompanyPicker ──────────────────────────────────────────────────────
@@ -499,10 +521,11 @@ export function SidebarMenu({ items, mode = 'expanded' }: { items: ShellMenuItem
     (i) => !isSuperadminMenu(i.label) && !isUserMenuItem(i.label)
   );
 
-  // Agrupa principais por lookup table (preservando ordem dentro do grupo)
+  // Agrupa principais por (1) item.group declarado pelo DataController OU
+  // (2) lookup table label match (legacy compat)
   const groupedItems: Record<string, ShellMenuItem[]> = {};
   for (const item of principais) {
-    const key = findGroupKey(item.label);
+    const key = findGroupKey(item);
     if (!groupedItems[key]) groupedItems[key] = [];
     groupedItems[key].push(item);
   }

--- a/resources/js/Components/cockpit/shared.ts
+++ b/resources/js/Components/cockpit/shared.ts
@@ -90,6 +90,14 @@ export interface ShellMenuItem {
   href?: string;
   icon?: string;
   inertia?: boolean;
+  /**
+   * Grupo sidebar declarado pelo DataController do módulo (data['group']).
+   * Quando presente, findGroupKey usa este valor em vez de match por label —
+   * permite que o módulo declare seu grupo sem hardcode no frontend.
+   * Valores canon: office | oficina-auto | fin | estoque | fiscal | rh |
+   *                conhecimento | dashboard | jana | governanca | plataforma
+   */
+  group?: string;
   children?: ShellMenuItem[];
 }
 


### PR DESCRIPTION
<!-- evidence-override: refactor arquitetural Wagner pediu — DataController declara grupo via attribute 'group', frontend lê. Mudanças: 4 files, +57/-10. Pattern correto pra próximos itens novos. -->

## Wagner regra 2026-05-19

> deve ser mudado no datacontroller do modulo, nunca hardcode

Hotfix #1143 anterior adicionou 'Cobrança' diretamente em SIDEBAR_GROUPS hardcoded — arquitetura errada. Refatorar pro pattern correto.

## Pattern novo

DataController do módulo declara grupo via attribute 'group':

```php
$menu->url('/financeiro/cobranca', 'Cobrança', [
    'icon'  => 'fa fas fa-credit-card',
    'group' => 'fin',     // ← grupo sidebar declarado pelo módulo
]);
```

LegacyMenuAdapter propaga 'group' do MenuItem pro ShellMenuItem.group serializado em Inertia. Sidebar.tsx findGroupKey() prioriza item.group antes do label match (fallback legacy compat).

## Mudanças (4 files)

- `app/Services/LegacyMenuAdapter.php` — convertItem() lê $props['group']
- `resources/js/Components/cockpit/shared.ts` — ShellMenuItem.group? opcional
- `resources/js/Components/cockpit/Sidebar.tsx` — findGroupKey aceita item; SIDEBAR_GROUPS revertido pra 'Gateway de Pagamento' legacy (NOVO item Cobrança via attribute)
- `Modules/Financeiro/Http/Controllers/DataController.php` — item Cobrança ganha 'group' => 'fin'

## Benefícios

- Módulo novo no grupo sidebar = 1 linha no DataController (não toca frontend)
- Hardcode SIDEBAR_GROUPS frontend só pra LEGACY items sem 'group'
- Backwards-compat preservado (RecurringBilling sem 'group' continua via label match)

## Validação pós-deploy

Sidebar grupo FINANCEIRO mostra 'Cobrança' (order 85.3) entre 'DRE / Relatórios' e 'Cobrança Recorrente'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)