### PR TITLE
feat(paymentgateway): Onda 5 SIMPLIFICADA — dogfooding SaaS + integração Financeiro — ADR 0170

### DIFF
--- a/Modules/Financeiro/Listeners/OnCobrancaPagaCreateFinanceiroTitulo.php
+++ b/Modules/Financeiro/Listeners/OnCobrancaPagaCreateFinanceiroTitulo.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Financeiro\Listeners;
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Modules\Financeiro\Models\ContaBancaria;
+use Modules\Financeiro\Models\Titulo;
+use Modules\Financeiro\Models\TituloBaixa;
+use Modules\PaymentGateway\Events\CobrancaPaga;
+use Modules\PaymentGateway\Models\Cobranca;
+
+/**
+ * Auto-baixa: cobrança paga → Titulo a receber + TituloBaixa quitada em fin_titulos.
+ *
+ * ADR 0170 Onda 5 SIMPLIFICADA — integração Financeiro pedida por Wagner
+ * 2026-05-19 ("fazer integrar com o financeiro").
+ *
+ * Escopo conservador (Onda 5 inicial):
+ *   - Processa SOMENTE cobrancas.business_id=1 (Wagner — dogfooding SaaS).
+ *     Cobranças de tenants emitidas para clientes finais deles entram em
+ *     ondas separadas (Sells/Invoice listener — fora de escopo aqui).
+ *   - Origem 'manual' (enum fin_titulos não inclui 'paymentgateway' — não
+ *     mexer no enum agora pra não migrar prod). metadata.source preserva trail.
+ *
+ * Idempotência:
+ *   - Listener verifica se Titulo já existe pra (business_id=1, origem='manual',
+ *     origem_id=cobrancaId) antes de inserir.
+ *   - TituloBaixa usa idempotency_key UUID derivado de cobranca_id (determinístico).
+ *
+ * Conta bancária resolver:
+ *   1. ContaBancaria.rb_gateway_credential_id == cobranca.payment_gateway_credential_id
+ *      (assume FK foi reusada na migração credentials — Onda 2 do roadmap PaymentGateway)
+ *   2. Fallback: ContaBancaria.business_id=1 + ativo_para_boleto=true (primeira)
+ *   3. Se nenhuma resolve: cria Titulo SEM Baixa + log warning (Wagner reconcilia)
+ *
+ * Multi-tenant Tier 0: somente biz=1 — sem cross-tenant write.
+ */
+final class OnCobrancaPagaCreateFinanceiroTitulo
+{
+    public function handle(CobrancaPaga $event): void
+    {
+        if ($event->businessId !== 1) {
+            return; // Onda 5 dogfooding processa só Wagner
+        }
+
+        $cobranca = Cobranca::withoutGlobalScopes()->find($event->cobrancaId);
+        if (!$cobranca) {
+            Log::error('[onda5][financeiro] CobrancaPaga sem registro Cobranca correspondente', [
+                'cobranca_id' => $event->cobrancaId,
+            ]);
+
+            return;
+        }
+
+        $tituloExistente = Titulo::where('business_id', 1)
+            ->where('origem', 'manual')
+            ->where('origem_id', $event->cobrancaId)
+            ->first();
+
+        if ($tituloExistente) {
+            return; // Idempotência — listener já processou
+        }
+
+        $contaBancariaId = $this->resolveContaBancaria($cobranca);
+
+        DB::transaction(function () use ($event, $cobranca, $contaBancariaId): void {
+            $valor = $cobranca->valor_centavos / 100;
+            $valorPago = ($cobranca->valor_pago_centavos ?? $cobranca->valor_centavos) / 100;
+            $pagaEm = $event->pagaEm;
+            $clienteDescricao = $cobranca->payer_name
+                ?? ($cobranca->descricao !== '' ? $cobranca->descricao : null);
+
+            $titulo = Titulo::create([
+                'business_id'        => 1,
+                'numero'             => 'PG-' . $event->cobrancaId,
+                'tipo'               => 'receber',
+                'status'             => $contaBancariaId ? 'quitado' : 'aberto',
+                'cliente_id'         => $cobranca->contact_id,
+                'cliente_descricao'  => $clienteDescricao,
+                'valor_total'        => $valor,
+                'valor_aberto'       => $contaBancariaId ? 0 : $valor,
+                'moeda'              => 'BRL',
+                'emissao'            => $cobranca->created_at?->toDateString() ?? $pagaEm->format('Y-m-d'),
+                'vencimento'         => $cobranca->vencimento?->toDateString() ?? $pagaEm->format('Y-m-d'),
+                'competencia_mes'    => $pagaEm->format('Y-m'),
+                'origem'             => 'manual',
+                'origem_id'          => $event->cobrancaId,
+                'observacoes'        => 'PaymentGateway cobrança #' . $event->cobrancaId
+                    . ($cobranca->origem_type === 'subscription_license'
+                        ? ' (Mensalidade SaaS)' : ''),
+                'metadata'           => [
+                    'source'                       => 'paymentgateway_cobranca',
+                    'cobranca_id'                  => $event->cobrancaId,
+                    'cobranca_origem_type'         => $cobranca->origem_type,
+                    'cobranca_origem_id'           => $cobranca->origem_id,
+                    'cobranca_tipo'                => $cobranca->tipo,
+                    'cobranca_forma_pagamento'     => $cobranca->forma_pagamento,
+                    'gateway_external_id'          => $cobranca->gateway_external_id,
+                    'payment_gateway_credential_id' => $cobranca->payment_gateway_credential_id,
+                ],
+                'created_by'         => 1, // Wagner — listener roda em contexto webhook
+            ]);
+
+            if (!$contaBancariaId) {
+                Log::warning('[onda5][financeiro] Titulo criado SEM Baixa (conta bancaria nao resolvida)', [
+                    'cobranca_id' => $event->cobrancaId,
+                    'titulo_id'   => $titulo->id,
+                    'payment_gateway_credential_id' => $cobranca->payment_gateway_credential_id,
+                ]);
+
+                return;
+            }
+
+            TituloBaixa::create([
+                'business_id'        => 1,
+                'titulo_id'          => $titulo->id,
+                'conta_bancaria_id'  => $contaBancariaId,
+                'valor_baixa'        => $valorPago,
+                'juros'              => 0,
+                'multa'              => 0,
+                'desconto'           => 0,
+                'data_baixa'         => $pagaEm->format('Y-m-d'),
+                'meio_pagamento'     => $this->mapMeioPagamento($cobranca->tipo, $cobranca->forma_pagamento),
+                'idempotency_key'    => $this->buildIdempotencyKey($event->cobrancaId),
+                'observacoes'        => 'Auto-baixa via PaymentGateway cobranca #' . $event->cobrancaId,
+                'created_by'         => 1,
+            ]);
+        });
+    }
+
+    /**
+     * Resolve a conta bancária que recebeu a cobrança.
+     *
+     * Estratégia em camadas — primeira que matchar ganha.
+     */
+    private function resolveContaBancaria(Cobranca $cobranca): ?int
+    {
+        if ($cobranca->payment_gateway_credential_id !== null) {
+            $conta = ContaBancaria::where('business_id', 1)
+                ->where('rb_gateway_credential_id', $cobranca->payment_gateway_credential_id)
+                ->first();
+            if ($conta) {
+                return (int) $conta->id;
+            }
+        }
+
+        $conta = ContaBancaria::where('business_id', 1)
+            ->where('ativo_para_boleto', true)
+            ->first();
+
+        return $conta ? (int) $conta->id : null;
+    }
+
+    private function mapMeioPagamento(?string $cobrancaTipo, ?string $formaPagamento): string
+    {
+        if ($formaPagamento === 'pix' || in_array($cobrancaTipo, ['pix_cob', 'pix_cobv', 'pix_recv'], true)) {
+            return 'pix';
+        }
+        if ($formaPagamento === 'boleto' || $cobrancaTipo === 'boleto') {
+            return 'boleto';
+        }
+        if ($formaPagamento === 'cartao' || $cobrancaTipo === 'card') {
+            return 'cartao_credito';
+        }
+
+        return 'outro';
+    }
+
+    /**
+     * UUID determinístico baseado em cobrancaId — garante idempotência
+     * mesmo se listener rodar 2x (uk_baixa_idempotency previne dupla baixa).
+     *
+     * Formato 36-char UUID derivado de md5 (não criptográfico — apenas anti-dupla
+     * dentro do mesmo business_id pelo (business_id, idempotency_key) unique).
+     */
+    private function buildIdempotencyKey(int $cobrancaId): string
+    {
+        $hash = md5('paymentgateway.onda5.cobranca-' . $cobrancaId);
+
+        return sprintf(
+            '%s-%s-%s-%s-%s',
+            substr($hash, 0, 8),
+            substr($hash, 8, 4),
+            substr($hash, 12, 4),
+            substr($hash, 16, 4),
+            substr($hash, 20, 12),
+        );
+    }
+}

--- a/Modules/Financeiro/Providers/FinanceiroServiceProvider.php
+++ b/Modules/Financeiro/Providers/FinanceiroServiceProvider.php
@@ -3,10 +3,18 @@
 namespace Modules\Financeiro\Providers;
 
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\ServiceProvider;
+use Modules\Financeiro\Listeners\OnCobrancaPagaCreateFinanceiroTitulo;
+use Modules\PaymentGateway\Events\CobrancaPaga;
 
 class FinanceiroServiceProvider extends ServiceProvider
 {
+    /**
+     * Guard contra duplicação do listener — nWidart pode rodar boot() 2x.
+     */
+    private static bool $paymentgatewayListenersRegistered = false;
+
     protected string $moduleName = 'Financeiro';
 
     protected string $moduleNameLower = 'financeiro';
@@ -23,6 +31,22 @@ class FinanceiroServiceProvider extends ServiceProvider
         $this->registerViews();
         $this->loadMigrationsFrom(module_path($this->moduleName, 'Database/Migrations'));
         $this->registerObservers();
+        $this->registerPaymentGatewayListeners();
+    }
+
+    /**
+     * ADR 0170 Onda 5 SIMPLIFICADA — auto-baixa de Titulo a receber em
+     * fin_titulos quando cobrança SaaS é paga. Apenas business_id=1 (Wagner).
+     */
+    protected function registerPaymentGatewayListeners(): void
+    {
+        if (self::$paymentgatewayListenersRegistered) {
+            return;
+        }
+
+        Event::listen(CobrancaPaga::class, [OnCobrancaPagaCreateFinanceiroTitulo::class, 'handle']);
+
+        self::$paymentgatewayListenersRegistered = true;
     }
 
     /**

--- a/Modules/Financeiro/Tests/Feature/OnCobrancaPagaCreateFinanceiroTituloTest.php
+++ b/Modules/Financeiro/Tests/Feature/OnCobrancaPagaCreateFinanceiroTituloTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Financeiro\Listeners\OnCobrancaPagaCreateFinanceiroTitulo;
+use Modules\Financeiro\Models\Titulo;
+use Modules\PaymentGateway\Events\CobrancaPaga;
+use Modules\PaymentGateway\Models\Cobranca;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Pest — ADR 0170 Onda 5 SIMPLIFICADA.
+ *
+ * Listener Financeiro escuta CobrancaPaga e cria Titulo a receber em biz=1
+ * (Wagner contabiliza receita SaaS). Cobranças de outros businesses são
+ * ignoradas (escopo conservador Onda 5).
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('Requer schema MySQL UltimatePOS + Financeiro + PaymentGateway.');
+    }
+    if (!Schema::hasTable('fin_titulos') || !Schema::hasTable('cobrancas')) {
+        $this->markTestSkipped('Schema Financeiro + PaymentGateway ausente.');
+    }
+});
+
+function onda5fin_makeCobranca(int $businessId, int $valorCentavos): Cobranca
+{
+    return Cobranca::create([
+        'business_id'                   => $businessId,
+        'payment_gateway_credential_id' => null,
+        'gateway_external_id'           => 'TEST-' . uniqid(),
+        'tipo'                          => 'pix_recv',
+        'status'                        => 'paga',
+        'valor_centavos'                => $valorCentavos,
+        'valor_pago_centavos'           => $valorCentavos,
+        'vencimento'                    => now()->toDateString(),
+        'paga_em'                       => now(),
+        'contact_id'                    => null,
+        'payer_cpf_cnpj'                => null,
+        'payer_name'                    => 'Tenant Test',
+        'payer_email'                   => null,
+        'descricao'                     => 'Test cobranca onda 5',
+        'idempotency_key'               => 'test-onda5fin-' . uniqid(),
+        'origem_type'                   => 'subscription_license',
+        'origem_id'                     => 12345,
+        'forma_pagamento'               => 'pix',
+    ]);
+}
+
+function onda5fin_cleanup(int $cobrancaId): void
+{
+    Titulo::withoutGlobalScopes()
+        ->where('business_id', 1)
+        ->where('origem', 'manual')
+        ->where('origem_id', $cobrancaId)
+        ->forceDelete();
+    Cobranca::withoutGlobalScopes()->where('id', $cobrancaId)->forceDelete();
+}
+
+it('CobrancaPaga business_id=1 cria Titulo a receber em fin_titulos', function () {
+    $cobranca = onda5fin_makeCobranca(1, 9990);
+
+    $event = new CobrancaPaga(
+        cobrancaId: $cobranca->id,
+        businessId: 1,
+        valorPagoCentavos: 9990,
+        pagaEm: new \DateTimeImmutable(),
+        formaPagamento: 'pix',
+        occurredAt: new \DateTimeImmutable(),
+        payerCpfCnpj: null,
+        origemType: 'subscription_license',
+        origemId: 12345,
+    );
+
+    (new OnCobrancaPagaCreateFinanceiroTitulo())->handle($event);
+
+    $titulo = Titulo::withoutGlobalScopes()
+        ->where('business_id', 1)
+        ->where('origem', 'manual')
+        ->where('origem_id', $cobranca->id)
+        ->first();
+
+    expect($titulo)->not->toBeNull();
+    expect($titulo->tipo)->toBe('receber');
+    expect((float) $titulo->valor_total)->toBe(99.90);
+    expect($titulo->metadata['source'] ?? null)->toBe('paymentgateway_cobranca');
+
+    onda5fin_cleanup($cobranca->id);
+});
+
+it('CobrancaPaga business_id!=1 é ignorada (escopo dogfooding)', function () {
+    $cobranca = onda5fin_makeCobranca(99, 5000);
+
+    $event = new CobrancaPaga(
+        cobrancaId: $cobranca->id,
+        businessId: 99,
+        valorPagoCentavos: 5000,
+        pagaEm: new \DateTimeImmutable(),
+        formaPagamento: 'pix',
+        occurredAt: new \DateTimeImmutable(),
+        payerCpfCnpj: null,
+        origemType: 'sale',
+        origemId: null,
+    );
+
+    (new OnCobrancaPagaCreateFinanceiroTitulo())->handle($event);
+
+    $count = Titulo::withoutGlobalScopes()
+        ->where('business_id', 1)
+        ->where('origem', 'manual')
+        ->where('origem_id', $cobranca->id)
+        ->count();
+
+    expect($count)->toBe(0);
+
+    onda5fin_cleanup($cobranca->id);
+});
+
+it('CobrancaPaga rodando 2x não duplica Titulo (idempotência)', function () {
+    $cobranca = onda5fin_makeCobranca(1, 9990);
+
+    $event = new CobrancaPaga(
+        cobrancaId: $cobranca->id,
+        businessId: 1,
+        valorPagoCentavos: 9990,
+        pagaEm: new \DateTimeImmutable(),
+        formaPagamento: 'pix',
+        occurredAt: new \DateTimeImmutable(),
+        payerCpfCnpj: null,
+        origemType: 'subscription_license',
+        origemId: 12345,
+    );
+
+    $listener = new OnCobrancaPagaCreateFinanceiroTitulo();
+    $listener->handle($event);
+    $listener->handle($event);
+
+    $count = Titulo::withoutGlobalScopes()
+        ->where('business_id', 1)
+        ->where('origem', 'manual')
+        ->where('origem_id', $cobranca->id)
+        ->count();
+
+    expect($count)->toBe(1);
+
+    onda5fin_cleanup($cobranca->id);
+});

--- a/Modules/PaymentGateway/Console/Commands/RegisterPermissionsCommand.php
+++ b/Modules/PaymentGateway/Console/Commands/RegisterPermissionsCommand.php
@@ -1,0 +1,234 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Console\Commands;
+
+use App\Business;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Modules\PaymentGateway\Http\Controllers\DataController;
+use Spatie\Permission\Models\Permission;
+use Spatie\Permission\Models\Role;
+use Spatie\Permission\PermissionRegistrar;
+
+/**
+ * Registra permissions canônicas `paymentgateway.*` (Spatie) + atribui ao
+ * role `Admin#{biz}` de cada business.
+ *
+ * Pattern espelhado de `whatsapp:register-permissions` (PR #665) — resolve
+ * o mesmo bug: permissions definidas em DataController nunca chegam à
+ * tabela `permissions` em prod até alguém atribuir via UI /roles, e Spatie
+ * cria on-demand. Comando força registry idempotente.
+ *
+ * ADR 0170 Onda 5 SIMPLIFICADA — pré-requisito pra Wagner conseguir marcar
+ * `paymentgateway.cobranca.emit` etc no role Admin#1 antes de cobrar tenants.
+ *
+ * Uso pós-deploy:
+ *   1) Preview:   php artisan paymentgateway:register-permissions --business=1 --dry-run
+ *   2) Apply:     php artisan paymentgateway:register-permissions --business=1
+ *   3) Rollout:   php artisan paymentgateway:register-permissions --business=all
+ *
+ * Tier 0 IRREVOGÁVEL (ADR 0093):
+ *   - Permissions são GLOBAIS (sem business_id) — guard `web`
+ *   - Role `Admin#{biz}` lookup com `business_id` filter (UltimatePOS pattern)
+ *   - `firstOrCreate` idempotente
+ *   - Logs sem PII (só IDs)
+ *
+ * @see DataController::user_permissions() — fonte canônica das 10 permissions
+ * @see memory/reference/whatsapp-permissions-spatie.md
+ */
+class RegisterPermissionsCommand extends Command
+{
+    protected $signature = 'paymentgateway:register-permissions
+                            {--business=all : business_id alvo (numeric) ou "all"}
+                            {--dry-run : Só conta + lista, não persiste}';
+
+    protected $description = 'Registra permissions paymentgateway.* (Spatie) + atribui ao Admin#{biz} (idempotente)';
+
+    public function handle(): int
+    {
+        $businessOpt = (string) $this->option('business');
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->warn('[dry-run] Nenhuma row será persistida.');
+        }
+
+        $permissionsDef = (new DataController())->user_permissions();
+        $permissionNames = array_map(static fn ($p) => $p['value'], $permissionsDef);
+
+        $this->line('Permissions canônicas (DataController::user_permissions):');
+        foreach ($permissionsDef as $p) {
+            $this->line(sprintf('  - %-48s %s', $p['value'], (string) $p['label']));
+        }
+        $this->newLine();
+
+        $registered = [];
+        $createdCount = 0;
+        foreach ($permissionsDef as $p) {
+            if ($dryRun) {
+                $exists = Permission::where('name', $p['value'])
+                    ->where('guard_name', 'web')
+                    ->exists();
+                if (!$exists) {
+                    $createdCount++;
+                }
+                continue;
+            }
+
+            $perm = Permission::firstOrCreate([
+                'name' => $p['value'],
+                'guard_name' => 'web',
+            ]);
+            if ($perm->wasRecentlyCreated) {
+                $createdCount++;
+            }
+            $registered[] = $perm;
+        }
+
+        $action = $dryRun ? 'WOULD register' : 'Permissions registradas';
+        $this->info(sprintf(
+            '%s: %d total · %d new · %d existing',
+            $action,
+            count($permissionsDef),
+            $createdCount,
+            count($permissionsDef) - $createdCount,
+        ));
+        $this->newLine();
+
+        $businessIds = $this->resolveBusinessIds($businessOpt);
+        if ($businessIds === null) {
+            return self::FAILURE;
+        }
+        if (empty($businessIds)) {
+            $this->warn('Nenhum business encontrado.');
+
+            return self::SUCCESS;
+        }
+
+        $totalAttached = 0;
+        $totalAlreadyHad = 0;
+        $totalSkipped = 0;
+
+        foreach ($businessIds as $bizId) {
+            $roleName = "Admin#{$bizId}";
+
+            $role = Role::where('name', $roleName)
+                ->where('business_id', $bizId)
+                ->where('guard_name', 'web')
+                ->first();
+
+            if (!$role) {
+                $this->warn(sprintf(
+                    '  Business #%d: %s não encontrado — skip',
+                    $bizId,
+                    $roleName,
+                ));
+                Log::warning('[paymentgateway.register_permissions.role_missing]', [
+                    'business_id' => $bizId,
+                    'role_name' => $roleName,
+                ]);
+                $totalSkipped++;
+                continue;
+            }
+
+            if ($dryRun) {
+                $alreadyHas = $role->permissions()
+                    ->whereIn('name', $permissionNames)
+                    ->count();
+                $wouldAttach = count($permissionNames) - $alreadyHas;
+                $this->line(sprintf(
+                    '  Business #%d: %s ← WOULD attach %d (já tem %d)',
+                    $bizId,
+                    $roleName,
+                    $wouldAttach,
+                    $alreadyHas,
+                ));
+                $totalAttached += $wouldAttach;
+                $totalAlreadyHad += $alreadyHas;
+                continue;
+            }
+
+            $beforeIds = $role->permissions()
+                ->whereIn('name', $permissionNames)
+                ->pluck('id')
+                ->all();
+
+            $role->givePermissionTo($registered);
+
+            $afterCount = $role->permissions()
+                ->whereIn('name', $permissionNames)
+                ->count();
+            $attached = $afterCount - count($beforeIds);
+            $alreadyHad = count($beforeIds);
+
+            $this->line(sprintf(
+                '  Business #%d: %s ← attached %d (já tinha %d)',
+                $bizId,
+                $roleName,
+                $attached,
+                $alreadyHad,
+            ));
+
+            $totalAttached += $attached;
+            $totalAlreadyHad += $alreadyHad;
+        }
+
+        if (!$dryRun) {
+            try {
+                app(PermissionRegistrar::class)->forgetCachedPermissions();
+            } catch (\Throwable $e) {
+                // tolerante a env sem cache configurado
+            }
+        }
+
+        $this->newLine();
+        $this->info(sprintf(
+            '✓ Resumo: %d business(es) processado(s) · %d skipped · %s %d permission(s) · %d já tinha(m)',
+            count($businessIds) - $totalSkipped,
+            $totalSkipped,
+            $dryRun ? 'WOULD attach' : 'attached',
+            $totalAttached,
+            $totalAlreadyHad,
+        ));
+
+        Log::info('[paymentgateway.register_permissions.completed]', [
+            'business_filter' => $businessOpt,
+            'dry_run' => $dryRun,
+            'permissions_total' => count($permissionsDef),
+            'permissions_created' => $createdCount,
+            'businesses_processed' => count($businessIds) - $totalSkipped,
+            'businesses_skipped' => $totalSkipped,
+            'attached_total' => $totalAttached,
+        ]);
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return array<int>|null
+     */
+    private function resolveBusinessIds(string $businessOpt): ?array
+    {
+        if ($businessOpt === 'all') {
+            return Business::query()->orderBy('id')->pluck('id')->all();
+        }
+
+        $bizId = (int) $businessOpt;
+        if ($bizId <= 0) {
+            $this->error("--business={$businessOpt} inválido (esperado inteiro > 0 ou 'all').");
+
+            return null;
+        }
+
+        $exists = Business::query()->whereKey($bizId)->exists();
+        if (!$exists) {
+            $this->error("Business #{$bizId} não encontrado.");
+
+            return null;
+        }
+
+        return [$bizId];
+    }
+}

--- a/Modules/PaymentGateway/Providers/PaymentGatewayServiceProvider.php
+++ b/Modules/PaymentGateway/Providers/PaymentGatewayServiceProvider.php
@@ -29,6 +29,7 @@ class PaymentGatewayServiceProvider extends ServiceProvider
         if ($this->app->runningInConsole()) {
             $this->commands([
                 \Modules\PaymentGateway\Console\Commands\MigrateCredentialsCommand::class,
+                \Modules\PaymentGateway\Console\Commands\RegisterPermissionsCommand::class,
             ]);
         }
     }

--- a/Modules/PaymentGateway/Tests/Feature/RegisterPermissionsCommandTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/RegisterPermissionsCommandTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Spatie\Permission\Models\Permission;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Pest — paymentgateway:register-permissions command.
+ *
+ * ADR 0170 Onda 5 SIMPLIFICADA — espelhado de whatsapp:register-permissions.
+ * Garante que rodar o command popula tabela `permissions` Spatie pra que
+ * Wagner possa marcar paymentgateway.* no UI /roles depois.
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('Requer schema MySQL com Spatie permissions table.');
+    }
+    if (!Schema::hasTable('permissions') || !Schema::hasTable('roles')) {
+        $this->markTestSkipped('Schema Spatie ausente — rode migrations primeiro.');
+    }
+});
+
+it('--dry-run não persiste permissions', function () {
+    Permission::where('name', 'like', 'paymentgateway.%')->delete();
+
+    $this->artisan('paymentgateway:register-permissions', ['--business' => '1', '--dry-run' => true])
+        ->assertExitCode(0);
+
+    $count = Permission::where('name', 'like', 'paymentgateway.%')->count();
+    expect($count)->toBe(0);
+});
+
+it('apply registra 10 permissions paymentgateway.*', function () {
+    Permission::where('name', 'like', 'paymentgateway.%')->delete();
+
+    $this->artisan('paymentgateway:register-permissions', ['--business' => '1'])
+        ->assertExitCode(0);
+
+    $names = Permission::where('name', 'like', 'paymentgateway.%')->pluck('name')->all();
+    expect($names)->toContain('paymentgateway.access');
+    expect($names)->toContain('paymentgateway.cobranca.emit');
+    expect($names)->toContain('paymentgateway.webhook.replay');
+    expect(count($names))->toBeGreaterThanOrEqual(10);
+
+    Permission::where('name', 'like', 'paymentgateway.%')->delete();
+});
+
+it('apply é idempotente — rodar 2x não duplica', function () {
+    Permission::where('name', 'like', 'paymentgateway.%')->delete();
+
+    $this->artisan('paymentgateway:register-permissions', ['--business' => '1'])->assertExitCode(0);
+    $countFirst = Permission::where('name', 'like', 'paymentgateway.%')->count();
+
+    $this->artisan('paymentgateway:register-permissions', ['--business' => '1'])->assertExitCode(0);
+    $countSecond = Permission::where('name', 'like', 'paymentgateway.%')->count();
+
+    expect($countSecond)->toBe($countFirst);
+
+    Permission::where('name', 'like', 'paymentgateway.%')->delete();
+});
+
+it('business inválido retorna FAILURE', function () {
+    $this->artisan('paymentgateway:register-permissions', ['--business' => 'abc'])
+        ->assertExitCode(1);
+});

--- a/Modules/Superadmin/Http/Controllers/BaseController.php
+++ b/Modules/Superadmin/Http/Controllers/BaseController.php
@@ -53,6 +53,13 @@ class BaseController extends Controller
             $gateways['pesapal'] = 'PesaPal';
         }
 
+        // ADR 0170 Onda 5 — PaymentGateway entra como gateway adicional pra
+        // mensalidade SaaS Oimpresso. Ativo SE há credencial BCB ativa em biz=1
+        // E há conta bancária Financeiro vinculada. Pattern: 6º gateway.
+        if ($this->isPaymentGatewayPixAutomaticoConfigured()) {
+            $gateways['paymentgateway_pix_automatico'] = 'PIX Automático BCB';
+        }
+
         //check if Paystack is configured or not
         $system = System::getCurrency();
         if (in_array($system->country, ['Nigeria', 'Ghana']) && (config('paystack.publicKey') && config('paystack.secretKey'))) {
@@ -135,6 +142,45 @@ class BaseController extends Controller
         }
 
         return $subscription;
+    }
+
+    /**
+     * Verifica se PaymentGateway PIX Automático BCB está configurado pra biz=1.
+     *
+     * ADR 0170 Onda 5 — requer (1) módulo PaymentGateway enabled, (2) credencial
+     * BCB ativa em biz=1, (3) ContaBancaria Financeiro vinculada à credencial.
+     * Falta de qualquer 1 → gateway omitido da listagem (Wagner vê só Pesapal/Stripe/etc).
+     */
+    protected function isPaymentGatewayPixAutomaticoConfigured(): bool
+    {
+        if (!class_exists(\Modules\PaymentGateway\Models\PaymentGatewayCredential::class)) {
+            return false;
+        }
+
+        try {
+            $hasCredencial = \Modules\PaymentGateway\Models\PaymentGatewayCredential::query()
+                ->withoutGlobalScopes()
+                ->where('business_id', 1)
+                ->where('driver', 'bcb_pix')
+                ->where('ativo', true)
+                ->exists();
+
+            if (!$hasCredencial) {
+                return false;
+            }
+
+            return \Modules\Financeiro\Models\ContaBancaria::query()
+                ->withoutGlobalScopes()
+                ->where('business_id', 1)
+                ->whereNotNull('rb_gateway_credential_id')
+                ->exists();
+        } catch (\Throwable $e) {
+            \Illuminate\Support\Facades\Log::warning('[onda5] isPaymentGatewayPixAutomaticoConfigured threw', [
+                'exception' => $e->getMessage(),
+            ]);
+
+            return false;
+        }
     }
 
     /**

--- a/Modules/Superadmin/Http/Controllers/SubscriptionController.php
+++ b/Modules/Superadmin/Http/Controllers/SubscriptionController.php
@@ -211,6 +211,13 @@ class SubscriptionController extends BaseController
                 return $this->confirm_pesapal($package_id, $request);
             }
 
+            // ADR 0170 Onda 5 — PaymentGateway PIX Automático é assíncrono
+            // (mandato BCB + webhook posterior). Cria Subscription waiting +
+            // emite cobrança, mostra mensagem "aguardando autorização mandato".
+            if (request()->gateway === 'paymentgateway_pix_automatico') {
+                return $this->confirm_paymentgateway($package_id, $request);
+            }
+
             DB::beginTransaction();
 
             $business_id = request()->session()->get('user.business_id');
@@ -247,6 +254,134 @@ class SubscriptionController extends BaseController
         return redirect()
             ->action([\Modules\Superadmin\Http\Controllers\SubscriptionController::class, 'index'])
             ->with('status', $output);
+    }
+
+    /**
+     * Confirma cobrança via PaymentGateway PIX Automático BCB.
+     *
+     * ADR 0170 Onda 5 SIMPLIFICADA — assíncrono (mandato + webhook):
+     *   1. Cria Subscription status='waiting' (igual Pesapal)
+     *   2. Resolve credencial BCB + Account de Wagner
+     *   3. Emite PIX Automático via PaymentGatewayContract->emitirPixAutomatico
+     *   4. Salva payment_transaction_id (cobranca.id)
+     *   5. Redireciona com "Cobrança enviada — autorize mandato no app banco"
+     *
+     * Webhook BCB posterior dispara CobrancaPaga → OnCobrancaPagaUpdateSubscription
+     * muda status pra 'approved' e desbloqueia business se inadimplente.
+     */
+    protected function confirm_paymentgateway($package_id, $request)
+    {
+        $business_id = request()->session()->get('user.business_id');
+        $business_name = request()->session()->get('business.name');
+        $user_id = request()->session()->get('user.id');
+        $package = Package::active()->find($package_id);
+
+        if (!$package) {
+            return redirect()
+                ->action([\Modules\Superadmin\Http\Controllers\SubscriptionController::class, 'index'])
+                ->with('status', ['success' => 0, 'msg' => __('superadmin::lang.package_not_found') ?? 'Pacote nao encontrado']);
+        }
+
+        try {
+            DB::beginTransaction();
+
+            // 1. Cria Subscription waiting (pattern Pesapal — dates null)
+            $subscription = $this->_add_subscription(
+                $business_id,
+                $package,
+                'paymentgateway_pix_automatico',
+                null,
+                $user_id,
+            );
+
+            // _add_subscription pode ter aprovado direto (price=0 / lookup). Pra
+            // garantir waiting, força refresh.
+            if ($subscription->status !== 'waiting') {
+                $subscription->status = 'waiting';
+                $subscription->start_date = null;
+                $subscription->end_date = null;
+                $subscription->trial_end_date = null;
+                $subscription->save();
+            }
+
+            // 2. Resolve ContaBancaria + Account Wagner em biz=1
+            $contaBancaria = \Modules\Financeiro\Models\ContaBancaria::query()
+                ->withoutGlobalScopes()
+                ->where('business_id', 1)
+                ->whereNotNull('rb_gateway_credential_id')
+                ->where('ativo_para_boleto', true)
+                ->first();
+
+            if (!$contaBancaria) {
+                throw new \RuntimeException('ContaBancaria com gateway credencial nao configurada em biz=1');
+            }
+
+            $account = \App\Account::find($contaBancaria->account_id);
+            if (!$account) {
+                throw new \RuntimeException('Account UltimatePOS nao encontrada pra ContaBancaria #' . $contaBancaria->id);
+            }
+
+            // 3. Emite PIX Automático (mandato recorrente BCB)
+            $contact = $this->resolveTenantPayerContact($business_id);
+            $input = new \Modules\PaymentGateway\Dto\EmitirCobrancaInput(
+                businessId: 1, // Wagner é dono da cobrança (ADR 0170 §G)
+                contactId: $contact?->id ?? 0,
+                valorCentavos: (int) round(((float) $package->price) * 100),
+                vencimento: new \DateTimeImmutable('+7 days'),
+                descricao: 'Mensalidade SaaS — ' . $package->name . ' — ' . ($business_name ?: 'Tenant'),
+                idempotencyKey: 'onda5-sub-' . $subscription->id,
+                origemType: 'subscription_license',
+                origemId: $subscription->id,
+                meta: ['target_business_id' => $business_id, 'subscription_id' => $subscription->id],
+            );
+
+            $result = app(\Modules\PaymentGateway\Contracts\PaymentGatewayContract::class)
+                ->for($account)
+                ->emitirPixAutomatico($input);
+
+            // 4. Salva referência da cobrança na Subscription
+            $subscription->payment_transaction_id = (string) ($result->cobrancaId ?? '');
+            $subscription->save();
+
+            DB::commit();
+
+            return redirect()
+                ->action([\Modules\Superadmin\Http\Controllers\SubscriptionController::class, 'index'])
+                ->with('status', [
+                    'success' => 1,
+                    'msg' => 'Cobrança PIX Automático enviada. Autorize o mandato BCB no app do banco em até 7 dias — a renovação acontece automaticamente todo mês.',
+                ]);
+        } catch (\Throwable $e) {
+            DB::rollBack();
+            $this->_log_emergency_redacted($e, 'SubscriptionController.confirm_paymentgateway');
+
+            return redirect()
+                ->action([\Modules\Superadmin\Http\Controllers\SubscriptionController::class, 'index'])
+                ->with('status', ['success' => 0, 'msg' => 'Falha ao emitir cobrança PIX Automático: ' . $e->getMessage()]);
+        }
+    }
+
+    /**
+     * Resolve Contact em biz=1 que representa o tenant pagador (best-effort).
+     * Onda 5 SIMPLIFICADA NÃO faz backfill massivo — se contact não existe,
+     * retorna null e cobrança emite com payer_* derivado de business.name/owner.
+     */
+    protected function resolveTenantPayerContact(int $tenantBusinessId): ?\App\Contact
+    {
+        $business = \App\Business::withoutGlobalScopes()->find($tenantBusinessId);
+        if (!$business) {
+            return null;
+        }
+
+        $tax = $business->tax_number_1 ?? null;
+        if (!$tax) {
+            return null;
+        }
+
+        return \App\Contact::withoutGlobalScopes()
+            ->where('business_id', 1)
+            ->where('tax_number', $tax)
+            ->first();
     }
 
     /**

--- a/Modules/Superadmin/Listeners/OnCobrancaPagaUpdateSubscription.php
+++ b/Modules/Superadmin/Listeners/OnCobrancaPagaUpdateSubscription.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Superadmin\Listeners;
+
+use App\Business;
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Log;
+use Modules\PaymentGateway\Events\CobrancaPaga;
+use Modules\Superadmin\Entities\Package;
+use Modules\Superadmin\Entities\Subscription;
+
+/**
+ * Renova licença SaaS quando cobrança 'subscription_license' é paga.
+ *
+ * ADR 0170 Onda 5 SIMPLIFICADA — PaymentGateway entra como gateway adicional
+ * em Superadmin::Subscription. Pattern imitado de
+ * PesaPalController::pesaPalPaymentConfirmation 1:1, com fonte de trigger
+ * trocada (evento canônico vs callback HTTP).
+ *
+ * Fluxo:
+ *   webhook BCB → CobrancaPaga(origemType='subscription_license') →
+ *   este listener → Subscription.status='approved' + dates set →
+ *   desbloqueia business.officeimpresso_bloqueado=false se estava true →
+ *   próximo /oauth/token Delphi do tenant passa.
+ *
+ * Multi-tenant Tier 0 (ADR 0093):
+ *   - Cobranca.business_id = 1 (Wagner — dono da cobrança)
+ *   - Subscription.business_id = <tenant_id> (cross-tenant Wagner-only,
+ *     pattern legacy UltimatePOS documentado em Subscription.php:30)
+ *   - Business update usa withoutGlobalScopes() pra cross-tenant explícito.
+ *
+ * Idempotência: se Subscription.status === 'approved' → return (não duplica).
+ * Race: se Subscription.id no event não bate em DB → log + return (Wagner
+ * reconcilia manualmente).
+ */
+final class OnCobrancaPagaUpdateSubscription
+{
+    public function handle(CobrancaPaga $event): void
+    {
+        if ($event->origemType !== 'subscription_license') {
+            return;
+        }
+
+        if ($event->origemId === null) {
+            Log::warning('[onda5] CobrancaPaga origem_type=subscription_license sem origem_id', [
+                'cobranca_id' => $event->cobrancaId,
+            ]);
+
+            return;
+        }
+
+        $subscription = Subscription::find($event->origemId);
+        if (!$subscription) {
+            Log::error('[onda5] CobrancaPaga sem Subscription correspondente', [
+                'cobranca_id' => $event->cobrancaId,
+                'origem_id' => $event->origemId,
+            ]);
+
+            return;
+        }
+
+        if ($subscription->status === 'approved') {
+            return;
+        }
+
+        $package = Package::find($subscription->package_id);
+        if (!$package) {
+            Log::error('[onda5] Subscription aponta pra Package inexistente', [
+                'subscription_id' => $subscription->id,
+                'package_id' => $subscription->package_id,
+            ]);
+
+            return;
+        }
+
+        $dates = $this->calcPackageDates((int) $subscription->business_id, $package);
+
+        $subscription->status = 'approved';
+        $subscription->start_date = $dates['start'];
+        $subscription->end_date = $dates['end'];
+        $subscription->trial_end_date = $dates['trial'];
+        $subscription->paid_via = 'paymentgateway_pix_automatico';
+        $subscription->payment_transaction_id = (string) $event->cobrancaId;
+        $subscription->save();
+        // Spatie LogsActivity append-only registra mudança (LGPD D7.b CC Art. 206)
+
+        $business = Business::withoutGlobalScopes()->find($subscription->business_id);
+        if ($business && (bool) $business->officeimpresso_bloqueado === true) {
+            $business->officeimpresso_bloqueado = false;
+            $business->save();
+            Log::info('[onda5] business desbloqueado por pagamento SaaS', [
+                'business_id' => $business->id,
+                'cobranca_id' => $event->cobrancaId,
+                'subscription_id' => $subscription->id,
+            ]);
+        }
+    }
+
+    /**
+     * Calcula dates do package — pattern BaseController::_get_package_dates
+     * inlined (BaseController é instance method, listener é stateless).
+     *
+     * @return array{start: string, end: string, trial: \Carbon\Carbon}
+     */
+    private function calcPackageDates(int $businessId, Package $package): array
+    {
+        $start = Subscription::end_date($businessId);
+        if (!$start instanceof Carbon) {
+            $start = Carbon::parse($start);
+        }
+
+        $output = ['start' => $start->toDateString(), 'end' => '', 'trial' => null];
+
+        if ($package->interval === 'days') {
+            $output['end'] = (clone $start)->addDays((int) $package->interval_count)->toDateString();
+        } elseif ($package->interval === 'months') {
+            $output['end'] = (clone $start)->addMonths((int) $package->interval_count)->toDateString();
+        } elseif ($package->interval === 'years') {
+            $output['end'] = (clone $start)->addYears((int) $package->interval_count)->toDateString();
+        }
+
+        $output['trial'] = (clone $start)->addDays((int) ($package->trial_days ?? 0));
+
+        return $output;
+    }
+}

--- a/Modules/Superadmin/Listeners/OnCobrancaVencidaBloqueaSubscription.php
+++ b/Modules/Superadmin/Listeners/OnCobrancaVencidaBloqueaSubscription.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Superadmin\Listeners;
+
+use App\Business;
+use Illuminate\Support\Facades\Log;
+use Modules\PaymentGateway\Events\CobrancaVencida;
+use Modules\Superadmin\Entities\Subscription;
+
+/**
+ * Bloqueia tenant SaaS quando cobrança 'subscription_license' vence sem pagamento.
+ *
+ * ADR 0170 Onda 5 SIMPLIFICADA — par do OnCobrancaPagaUpdateSubscription.
+ * Wagner regra: "se não paga, bloqueia. paga, libera."
+ *
+ * Multi-tenant Tier 0:
+ *   - Business update usa withoutGlobalScopes() (cross-tenant intencional)
+ *   - Pattern documentado em Subscription.php:30 "Subscriptions tocam
+ *     pagamento de TODOS tenants (cross-tenant intencional Wagner-only)"
+ *
+ * Enforcement canônico subsequente (não precisa código novo):
+ *   - User::validateForPassportPasswordGrant rejeita /oauth/token quando
+ *     officeimpresso_bloqueado=true → Delphi recebe HTTP 400 invalid_grant
+ *   - OImpressoRegistroController retorna autorizado='N', message='Empresa bloqueada'
+ *     quando registrar é chamado por business bloqueado
+ *
+ * RecurringBilling responsibility — RB faz smart retry 3 retentativas
+ * antes de disparar CobrancaVencida (ADR 0170 §contratos). Quando chega
+ * aqui, já houve 3 tentativas falhas. Bloqueio é decisão final.
+ */
+final class OnCobrancaVencidaBloqueaSubscription
+{
+    public function handle(CobrancaVencida $event): void
+    {
+        if ($event->origemType !== 'subscription_license') {
+            return;
+        }
+
+        if ($event->origemId === null) {
+            Log::warning('[onda5] CobrancaVencida origem_type=subscription_license sem origem_id', [
+                'cobranca_id' => $event->cobrancaId,
+            ]);
+
+            return;
+        }
+
+        $subscription = Subscription::find($event->origemId);
+        if (!$subscription) {
+            Log::error('[onda5] CobrancaVencida sem Subscription correspondente', [
+                'cobranca_id' => $event->cobrancaId,
+                'origem_id' => $event->origemId,
+            ]);
+
+            return;
+        }
+
+        if ($subscription->status === 'declined') {
+            return;
+        }
+
+        $subscription->status = 'declined';
+        $subscription->save();
+
+        $business = Business::withoutGlobalScopes()->find($subscription->business_id);
+        if ($business && (bool) $business->officeimpresso_bloqueado === false) {
+            $business->officeimpresso_bloqueado = true;
+            $business->save();
+            Log::warning('[onda5] business bloqueado por inadimplencia SaaS', [
+                'business_id' => $business->id,
+                'cobranca_id' => $event->cobrancaId,
+                'subscription_id' => $subscription->id,
+                'dias_vencido' => $event->diasVencido,
+                'vencimento_original' => $event->vencimentoOriginal->format('Y-m-d'),
+            ]);
+        }
+    }
+}

--- a/Modules/Superadmin/Providers/SuperadminServiceProvider.php
+++ b/Modules/Superadmin/Providers/SuperadminServiceProvider.php
@@ -5,13 +5,24 @@ namespace Modules\Superadmin\Providers;
 use App\System;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Database\Eloquent\Factory;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\View;
 use Illuminate\Support\ServiceProvider;
+use Modules\PaymentGateway\Events\CobrancaPaga;
+use Modules\PaymentGateway\Events\CobrancaVencida;
 use Modules\Superadmin\Entities\Subscription;
 use Modules\Superadmin\Entities\SuperadminFrontendPage;
+use Modules\Superadmin\Listeners\OnCobrancaPagaUpdateSubscription;
+use Modules\Superadmin\Listeners\OnCobrancaVencidaBloqueaSubscription;
 
 class SuperadminServiceProvider extends ServiceProvider
 {
+    /**
+     * Guard contra duplicação do listener — nWidart pode rodar boot() 2x.
+     * Pattern documentado em memory/reference/project-officeimpresso-modulo.md.
+     */
+    private static bool $paymentgatewayListenersRegistered = false;
+
     /**
      * Boot the application events.
      *
@@ -25,6 +36,7 @@ class SuperadminServiceProvider extends ServiceProvider
         $this->registerFactories();
         $this->loadMigrationsFrom(__DIR__.'/../Database/Migrations');
         $this->registerScheduleCommands();
+        $this->registerPaymentGatewayListeners();
 
         view::composer('superadmin::layouts.partials.active_subscription', function ($view) {
             $business_id = session()->get('user.business_id');
@@ -65,6 +77,26 @@ class SuperadminServiceProvider extends ServiceProvider
                 $schedule->command('pos:sendSubscriptionExpiryAlert')->daily();
             });
         }
+    }
+
+    /**
+     * ADR 0170 Onda 5 SIMPLIFICADA — escuta eventos canônicos do PaymentGateway
+     * pra renovar/bloquear Superadmin::Subscription do tenant. Cross-tenant
+     * intencional Wagner-only (pattern Subscription.php:30).
+     *
+     * Guard `$paymentgatewayListenersRegistered` evita registro duplicado em
+     * boot() chamado 2x (pegadinha nWidart catalogada).
+     */
+    protected function registerPaymentGatewayListeners(): void
+    {
+        if (self::$paymentgatewayListenersRegistered) {
+            return;
+        }
+
+        Event::listen(CobrancaPaga::class, [OnCobrancaPagaUpdateSubscription::class, 'handle']);
+        Event::listen(CobrancaVencida::class, [OnCobrancaVencidaBloqueaSubscription::class, 'handle']);
+
+        self::$paymentgatewayListenersRegistered = true;
     }
 
     /**

--- a/Modules/Superadmin/Resources/views/subscription/partials/pay_paymentgateway_pix_automatico.blade.php
+++ b/Modules/Superadmin/Resources/views/subscription/partials/pay_paymentgateway_pix_automatico.blade.php
@@ -1,0 +1,29 @@
+{{--
+    ADR 0170 Onda 5 SIMPLIFICADA — partial PIX Automático BCB.
+
+    Submete pra confirm() com gateway='paymentgateway_pix_automatico'.
+    confirm() detecta a chave e delega pra confirm_paymentgateway() — que
+    cria Subscription waiting + emite Cobranca via PaymentGatewayContract.
+    Mandato BCB precisa autorização do tenant no app banco em até 7 dias.
+--}}
+<div class="col-md-12">
+    <form action="{{ action([\Modules\Superadmin\Http\Controllers\SubscriptionController::class, 'confirm'], [$package->id]) }}" method="POST">
+        {{ csrf_field() }}
+        <input type="hidden" name="gateway" value="{{ $k }}">
+
+        <button type="submit" class="btn btn-success">
+            <i class="fas fa-qrcode"></i> {{ $v }}
+        </button>
+    </form>
+
+    <p class="help-block">
+        <i class="fas fa-info-circle"></i>
+        <strong>PIX Automático BCB (recomendado):</strong>
+        autoriza o mandato uma vez no app do seu banco, depois a mensalidade é
+        debitada automaticamente todo mês. Sem boleto, sem cartão expirando.
+    </p>
+    <p class="help-block">
+        Resolução BCB 380/2024. CNPJ recebedor precisa estar homologado.
+        Após clicar, você terá 7 dias pra autorizar o mandato no app do banco.
+    </p>
+</div>

--- a/Modules/Superadmin/Tests/Feature/OnCobrancaPagaUpdateSubscriptionTest.php
+++ b/Modules/Superadmin/Tests/Feature/OnCobrancaPagaUpdateSubscriptionTest.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\PaymentGateway\Events\CobrancaPaga;
+use Modules\Superadmin\Entities\Package;
+use Modules\Superadmin\Entities\Subscription;
+use Modules\Superadmin\Listeners\OnCobrancaPagaUpdateSubscription;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Pest — ADR 0170 Onda 5 SIMPLIFICADA.
+ *
+ * Listener Superadmin escuta CobrancaPaga(origem_type='subscription_license')
+ * e marca Subscription do tenant como approved + desbloqueia officeimpresso_bloqueado.
+ *
+ * Tier 0: cross-tenant (cobranca.business_id=1, subscription.business_id=tenant).
+ * Pattern documentado em Subscription.php:30 "cross-tenant intencional Wagner-only".
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('Requer schema MySQL UltimatePOS + Superadmin + PaymentGateway.');
+    }
+    if (!Schema::hasTable('subscriptions') || !Schema::hasTable('packages') || !Schema::hasTable('business')) {
+        $this->markTestSkipped('Schema Superadmin ausente.');
+    }
+});
+
+const ONDA5_BIZ_TENANT_TEST = 99;
+
+function onda5_makeTestPackage(): Package
+{
+    return Package::create([
+        'name'           => 'Pacote Onda 5 Test',
+        'description'    => 'pacote teste listener pago',
+        'location_count' => 1,
+        'user_count'     => 5,
+        'product_count'  => 100,
+        'invoice_count'  => 1000,
+        'interval'       => 'months',
+        'interval_count' => 1,
+        'trial_days'     => 0,
+        'price'          => 99.90,
+        'is_active'      => 1,
+        'sort_order'     => 999,
+        'is_private'     => 0,
+        'is_one_time'    => 0,
+    ]);
+}
+
+function onda5_makeTestSubscription(int $packageId, int $businessId, string $status = 'waiting'): Subscription
+{
+    return Subscription::create([
+        'business_id'             => $businessId,
+        'package_id'              => $packageId,
+        'paid_via'                => 'paymentgateway_pix_automatico',
+        'payment_transaction_id'  => null,
+        'start_date'              => null,
+        'end_date'                => null,
+        'trial_end_date'          => null,
+        'status'                  => $status,
+        'package_price'           => 99.90,
+        'package_details'         => ['name' => 'Pacote Onda 5 Test'],
+        'created_id'              => 1,
+    ]);
+}
+
+function onda5_cleanup(): void
+{
+    Subscription::where('package_id', '!=', null)
+        ->whereHas('package', fn ($q) => $q->where('name', 'Pacote Onda 5 Test'))
+        ->forceDelete();
+    Package::where('name', 'Pacote Onda 5 Test')->forceDelete();
+    Business::withoutGlobalScopes()->where('id', ONDA5_BIZ_TENANT_TEST)->update(['officeimpresso_bloqueado' => false]);
+}
+
+it('CobrancaPaga origem subscription_license aprova Subscription waiting do tenant', function () {
+    $package = onda5_makeTestPackage();
+    Business::firstOrCreate(['id' => ONDA5_BIZ_TENANT_TEST], ['name' => 'Tenant Onda 5 Test', 'currency_id' => 1]);
+    $subscription = onda5_makeTestSubscription($package->id, ONDA5_BIZ_TENANT_TEST, 'waiting');
+
+    $event = new CobrancaPaga(
+        cobrancaId: 9999001,
+        businessId: 1,
+        valorPagoCentavos: 9990,
+        pagaEm: new \DateTimeImmutable(),
+        formaPagamento: 'pix',
+        occurredAt: new \DateTimeImmutable(),
+        payerCpfCnpj: null,
+        origemType: 'subscription_license',
+        origemId: $subscription->id,
+    );
+
+    (new OnCobrancaPagaUpdateSubscription())->handle($event);
+
+    $subscription->refresh();
+    expect($subscription->status)->toBe('approved');
+    expect($subscription->start_date)->not->toBeNull();
+    expect($subscription->end_date)->not->toBeNull();
+    expect($subscription->paid_via)->toBe('paymentgateway_pix_automatico');
+    expect((string) $subscription->payment_transaction_id)->toBe('9999001');
+
+    onda5_cleanup();
+});
+
+it('CobrancaPaga origem diferente NÃO toca Subscription', function () {
+    $package = onda5_makeTestPackage();
+    Business::firstOrCreate(['id' => ONDA5_BIZ_TENANT_TEST], ['name' => 'Tenant Onda 5 Test', 'currency_id' => 1]);
+    $subscription = onda5_makeTestSubscription($package->id, ONDA5_BIZ_TENANT_TEST, 'waiting');
+
+    $event = new CobrancaPaga(
+        cobrancaId: 9999002,
+        businessId: 1,
+        valorPagoCentavos: 5000,
+        pagaEm: new \DateTimeImmutable(),
+        formaPagamento: 'boleto',
+        occurredAt: new \DateTimeImmutable(),
+        payerCpfCnpj: null,
+        origemType: 'sale',
+        origemId: $subscription->id,
+    );
+
+    (new OnCobrancaPagaUpdateSubscription())->handle($event);
+
+    $subscription->refresh();
+    expect($subscription->status)->toBe('waiting');
+    expect($subscription->start_date)->toBeNull();
+
+    onda5_cleanup();
+});
+
+it('CobrancaPaga desbloqueia business officeimpresso_bloqueado quando aprova', function () {
+    $package = onda5_makeTestPackage();
+    $business = Business::firstOrCreate(['id' => ONDA5_BIZ_TENANT_TEST], ['name' => 'Tenant Onda 5 Test', 'currency_id' => 1]);
+    Business::withoutGlobalScopes()->where('id', ONDA5_BIZ_TENANT_TEST)->update(['officeimpresso_bloqueado' => true]);
+
+    $subscription = onda5_makeTestSubscription($package->id, ONDA5_BIZ_TENANT_TEST, 'waiting');
+
+    $event = new CobrancaPaga(
+        cobrancaId: 9999003,
+        businessId: 1,
+        valorPagoCentavos: 9990,
+        pagaEm: new \DateTimeImmutable(),
+        formaPagamento: 'pix',
+        occurredAt: new \DateTimeImmutable(),
+        payerCpfCnpj: null,
+        origemType: 'subscription_license',
+        origemId: $subscription->id,
+    );
+
+    (new OnCobrancaPagaUpdateSubscription())->handle($event);
+
+    $business->refresh();
+    expect((bool) $business->officeimpresso_bloqueado)->toBeFalse();
+
+    onda5_cleanup();
+});
+
+it('CobrancaPaga em Subscription já approved é idempotente (return sem touch)', function () {
+    $package = onda5_makeTestPackage();
+    Business::firstOrCreate(['id' => ONDA5_BIZ_TENANT_TEST], ['name' => 'Tenant Onda 5 Test', 'currency_id' => 1]);
+    $subscription = onda5_makeTestSubscription($package->id, ONDA5_BIZ_TENANT_TEST, 'approved');
+    $subscription->start_date = now()->subDays(1)->toDateString();
+    $subscription->end_date = now()->addMonth()->toDateString();
+    $subscription->save();
+    $originalStart = $subscription->start_date->toDateString();
+
+    $event = new CobrancaPaga(
+        cobrancaId: 9999004,
+        businessId: 1,
+        valorPagoCentavos: 9990,
+        pagaEm: new \DateTimeImmutable(),
+        formaPagamento: 'pix',
+        occurredAt: new \DateTimeImmutable(),
+        payerCpfCnpj: null,
+        origemType: 'subscription_license',
+        origemId: $subscription->id,
+    );
+
+    (new OnCobrancaPagaUpdateSubscription())->handle($event);
+
+    $subscription->refresh();
+    expect($subscription->start_date->toDateString())->toBe($originalStart);
+    onda5_cleanup();
+});

--- a/Modules/Superadmin/Tests/Feature/OnCobrancaVencidaBloqueaSubscriptionTest.php
+++ b/Modules/Superadmin/Tests/Feature/OnCobrancaVencidaBloqueaSubscriptionTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\PaymentGateway\Events\CobrancaVencida;
+use Modules\Superadmin\Entities\Package;
+use Modules\Superadmin\Entities\Subscription;
+use Modules\Superadmin\Listeners\OnCobrancaVencidaBloqueaSubscription;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Pest — ADR 0170 Onda 5 SIMPLIFICADA. Par do listener Paga.
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('Requer schema MySQL UltimatePOS + Superadmin + PaymentGateway.');
+    }
+    if (!Schema::hasTable('subscriptions') || !Schema::hasTable('packages') || !Schema::hasTable('business')) {
+        $this->markTestSkipped('Schema Superadmin ausente.');
+    }
+});
+
+const ONDA5V_BIZ_TENANT = 99;
+
+function onda5v_makeSub(int $packageId, int $businessId, string $status = 'approved'): Subscription
+{
+    return Subscription::create([
+        'business_id'             => $businessId,
+        'package_id'              => $packageId,
+        'paid_via'                => 'paymentgateway_pix_automatico',
+        'payment_transaction_id'  => 'OLD-1',
+        'start_date'              => now()->subMonth()->toDateString(),
+        'end_date'                => now()->subDays(5)->toDateString(),
+        'trial_end_date'          => null,
+        'status'                  => $status,
+        'package_price'           => 99.90,
+        'package_details'         => ['name' => 'Pkg Vencida Test'],
+        'created_id'              => 1,
+    ]);
+}
+
+function onda5v_cleanup(): void
+{
+    Subscription::whereHas('package', fn ($q) => $q->where('name', 'Pkg Vencida Test'))->forceDelete();
+    Package::where('name', 'Pkg Vencida Test')->forceDelete();
+    Business::withoutGlobalScopes()->where('id', ONDA5V_BIZ_TENANT)->update(['officeimpresso_bloqueado' => false]);
+}
+
+it('CobrancaVencida subscription_license marca declined + bloqueia business', function () {
+    $package = Package::create([
+        'name' => 'Pkg Vencida Test', 'description' => '...',
+        'location_count' => 0, 'user_count' => 0, 'product_count' => 0, 'invoice_count' => 0,
+        'interval' => 'months', 'interval_count' => 1, 'trial_days' => 0,
+        'price' => 99.90, 'is_active' => 1, 'sort_order' => 999, 'is_private' => 0, 'is_one_time' => 0,
+    ]);
+    $business = Business::firstOrCreate(['id' => ONDA5V_BIZ_TENANT], ['name' => 'Tenant Vencida', 'currency_id' => 1]);
+    Business::withoutGlobalScopes()->where('id', ONDA5V_BIZ_TENANT)->update(['officeimpresso_bloqueado' => false]);
+    $subscription = onda5v_makeSub($package->id, ONDA5V_BIZ_TENANT, 'approved');
+
+    $event = new CobrancaVencida(
+        cobrancaId: 9998001,
+        businessId: 1,
+        diasVencido: 5,
+        vencimentoOriginal: new \DateTimeImmutable('-5 days'),
+        occurredAt: new \DateTimeImmutable(),
+        origemType: 'subscription_license',
+        origemId: $subscription->id,
+    );
+
+    (new OnCobrancaVencidaBloqueaSubscription())->handle($event);
+
+    $subscription->refresh();
+    $business->refresh();
+    expect($subscription->status)->toBe('declined');
+    expect((bool) $business->officeimpresso_bloqueado)->toBeTrue();
+
+    onda5v_cleanup();
+});
+
+it('CobrancaVencida origem diferente NÃO bloqueia business', function () {
+    $package = Package::create([
+        'name' => 'Pkg Vencida Test', 'description' => '...',
+        'location_count' => 0, 'user_count' => 0, 'product_count' => 0, 'invoice_count' => 0,
+        'interval' => 'months', 'interval_count' => 1, 'trial_days' => 0,
+        'price' => 99.90, 'is_active' => 1, 'sort_order' => 999, 'is_private' => 0, 'is_one_time' => 0,
+    ]);
+    $business = Business::firstOrCreate(['id' => ONDA5V_BIZ_TENANT], ['name' => 'Tenant Vencida', 'currency_id' => 1]);
+    Business::withoutGlobalScopes()->where('id', ONDA5V_BIZ_TENANT)->update(['officeimpresso_bloqueado' => false]);
+    $subscription = onda5v_makeSub($package->id, ONDA5V_BIZ_TENANT, 'approved');
+
+    $event = new CobrancaVencida(
+        cobrancaId: 9998002,
+        businessId: 1,
+        diasVencido: 5,
+        vencimentoOriginal: new \DateTimeImmutable('-5 days'),
+        occurredAt: new \DateTimeImmutable(),
+        origemType: 'invoice',
+        origemId: $subscription->id,
+    );
+
+    (new OnCobrancaVencidaBloqueaSubscription())->handle($event);
+
+    $subscription->refresh();
+    $business->refresh();
+    expect($subscription->status)->toBe('approved');
+    expect((bool) $business->officeimpresso_bloqueado)->toBeFalse();
+
+    onda5v_cleanup();
+});


### PR DESCRIPTION
## Summary

Wagner aprovou caminho B (Onda 5 SIMPLIFICADA) + "pode fazer" em 2026-05-19. Implementa PaymentGateway como **6º payment gateway** em `Superadmin::Subscription` (pattern Pesapal 1:1) + integração com `Modules/Financeiro` pra auto-baixa Titulo + enforcement automático bloqueio/desbloqueio cliente.

**Plano completo:** [memory/requisitos/PaymentGateway/PLANO-ONDA5-SIMPLIFICADA.md](memory/requisitos/PaymentGateway/PLANO-ONDA5-SIMPLIFICADA.md) (PR #1146 mergeado).

**Wire Delphi inviolável preservado** ([memory/reference/contrato-delphi-inviolavel.md](memory/reference/contrato-delphi-inviolavel.md)) — zero mudança em Connector / Officeimpresso / oauth/token / /processa-dados-cliente / /oimpresso/registrar / /salvar-cliente / /salvar-equipamento / /check-update.

## Arquivos novos (9)

### Listeners (3)

| Arquivo | Função |
|---|---|
| `Modules/Superadmin/Listeners/OnCobrancaPagaUpdateSubscription.php` | Filtra `origem_type='subscription_license'`. Marca Subscription approved + set dates. Desbloqueia `business.officeimpresso_bloqueado=false` (cross-tenant intencional). |
| `Modules/Superadmin/Listeners/OnCobrancaVencidaBloqueaSubscription.php` | Par. Subscription declined + bloqueia. Enforcement Delphi via `User::validateForPassportPasswordGrant` (já live). |
| `Modules/Financeiro/Listeners/OnCobrancaPagaCreateFinanceiroTitulo.php` | Cria Titulo a receber + TituloBaixa quitada em biz=1 (Wagner contabiliza receita SaaS). Idempotência via `(business_id, origem, origem_id)` lookup. |

### Command (1)

| Arquivo | Função |
|---|---|
| `Modules/PaymentGateway/Console/Commands/RegisterPermissionsCommand.php` | Espelho de `whatsapp:register-permissions` (PR #665). Registra 10 permissions `paymentgateway.*` na tabela Spatie + atribui a `Admin#{biz}`. Idempotente. |

### View Blade (1)

| Arquivo | Função |
|---|---|
| `Modules/Superadmin/Resources/views/subscription/partials/pay_paymentgateway_pix_automatico.blade.php` | Botão "PIX Automático BCB" na tela `/superadmin/subscriptions/{pkg}/pay`. |

### Pest tests (4)

| Arquivo | Casos |
|---|---|
| `OnCobrancaPagaUpdateSubscriptionTest` | 4 it (happy / filtro origem / desbloqueio / idempotência) |
| `OnCobrancaVencidaBloqueaSubscriptionTest` | 2 it (happy / filtro) |
| `OnCobrancaPagaCreateFinanceiroTituloTest` | 3 it (happy biz=1 / skip biz!=1 / idempotência) |
| `RegisterPermissionsCommandTest` | 4 it (dry-run / apply / idempotência / input inválido) |

## Arquivos modificados (5)

| Arquivo | Mudança |
|---|---|
| `Modules/Superadmin/Http/Controllers/BaseController.php` | + key `paymentgateway_pix_automatico` em `_payment_gateways()` condicional + helper `isPaymentGatewayPixAutomaticoConfigured()` (checa credencial BCB + ContaBancaria FK) |
| `Modules/Superadmin/Http/Controllers/SubscriptionController.php` | + branch em `confirm()` pra delegar a `confirm_paymentgateway()` + método novo (Subscription waiting + `emitirPixAutomatico`) + helper `resolveTenantPayerContact()` |
| `Modules/Superadmin/Providers/SuperadminServiceProvider.php` | + `Event::listen` CobrancaPaga + CobrancaVencida (guard `$paymentgatewayListenersRegistered`) |
| `Modules/Financeiro/Providers/FinanceiroServiceProvider.php` | + `Event::listen` CobrancaPaga (guard) |
| `Modules/PaymentGateway/Providers/PaymentGatewayServiceProvider.php` | + `RegisterPermissionsCommand` em `registerCommands()` |

## Fluxo end-to-end (resposta Wagner sobre business_id)

| Record | `business_id` | Wagner vê em |
|---|---|---|
| `payment_gateway_credentials` | **1** | `/paymentgateway/credenciais` |
| `fin_contas_bancarias` | **1** | `/financeiro/contas` |
| `cobrancas` | **1** | `/paymentgateway/cobrancas` |
| `superadmin.subscriptions` | **<tenant_id>** | `/superadmin/business/{tenant}/subscriptions` (cross-tenant Wagner-only) |
| `fin_titulos` | **1** | `/financeiro/titulos` |
| `fin_titulo_baixas` | **1** | `/financeiro` |

## Multi-tenant Tier 0 (ADR 0093)

- `Cobranca.business_id = 1` — Wagner é dono da cobrança
- `Subscription.business_id = <tenant_id>` — cross-tenant intencional Wagner-only (pattern legacy [Subscription.php:30](Modules/Superadmin/Entities/Subscription.php))
- `FinTitulo.business_id = 1` — Wagner contabiliza receita
- Business update no listener usa `withoutGlobalScopes()` — Tier 0 cross-tenant intencional pra enforcement bloqueio/desbloqueio

## Pré-condições Wagner manual (ANTES de testar em prod)

- [ ] Onda 2 migration `payment_gateway_credentials` rodada (`ssh hostinger 'php artisan migrate:status \| grep payment_gateway'`)
- [ ] ContaBancaria Wagner em `/financeiro/contas` (biz=1, `ativo_para_boleto=true`)
- [ ] Credencial BCB em `/paymentgateway/credenciais` (biz=1, `driver='bcb_pix'`)
- [ ] `ContaBancaria.rb_gateway_credential_id = credencial.id` (FK vinculada)
- [ ] Package "Premium" em `/superadmin/packages` (price=99.90, interval=months)
- [ ] `php artisan paymentgateway:register-permissions --business=1` (pós-deploy)
- [ ] Homologação BCB PIX Automático (CNPJ recebedor — Resolução BCB 380/2024)

## Test plan

- [x] PHP lint verde (9 arquivos PHP modificados/novos)
- [x] Pest tests cobrindo 13 cenários (4 + 2 + 3 + 4)
- [ ] Pós-merge: CI verde (Pest Feature + Module Grade gate)
- [ ] Pós-deploy: `php artisan paymentgateway:register-permissions --business=1 --dry-run` rodado em Hostinger
- [ ] Smoke biz=1: Wagner cria Subscription pra ele mesmo + paga + verifica desbloqueio
- [ ] Smoke biz=4 (Larissa beta) — antes de promover universal

## Refs

- ADR 0170 — PaymentGateway extração (Onda 5)
- ADR 0017 / 0018 / 0019 / 0020 / 0021 — sistema canônico Delphi/Officeimpresso (inviolável)
- ADR 0093 — Multi-tenant Tier 0 IRREVOGÁVEL
- ADR 0105 — Cliente como sinal qualificado
- [PLANO-ONDA5-SIMPLIFICADA.md](memory/requisitos/PaymentGateway/PLANO-ONDA5-SIMPLIFICADA.md)
- [contrato-delphi-inviolavel.md](memory/reference/contrato-delphi-inviolavel.md)
- [whatsapp-permissions-spatie.md](memory/reference/whatsapp-permissions-spatie.md) (pattern register-permissions)
- PRs #1136 #1138 #1146 (Onda 5 docs canon + ativação módulo)

🤖 Generated with [Claude Code](https://claude.com/claude-code)