### PR TITLE
fix(sidebar): adicionar Contas Bancárias + Gateways de Pagamento (Onda 5 UX bloqueio)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/DataController.php
+++ b/Modules/Financeiro/Http/Controllers/DataController.php
@@ -151,6 +151,21 @@ class DataController extends Controller
                         'group'  => 'fin',
                     ]
                 )->order(85.3);
+
+                // 5. Contas Bancárias — Wagner 2026-05-19 reportou que /financeiro
+                // não permitia cadastrar conta + vincular credencial gateway.
+                // Página Inertia já existia (Modules/Financeiro/.../ContaBancariaController
+                // → Pages/Financeiro/ContasBancarias/Index.tsx) só faltava
+                // entrada no sidebar. Bloqueia Onda 5 dogfooding sem isso.
+                $menu->url(
+                    url('/financeiro/contas-bancarias'),
+                    'Contas Bancárias',
+                    [
+                        'icon'   => 'fa fas fa-university',
+                        'active' => $segmento_ativo && request()->segment(2) === 'contas-bancarias',
+                        'group'  => 'fin',
+                    ]
+                )->order(85.5);
             }
         );
     }

--- a/Modules/PaymentGateway/Http/Controllers/DataController.php
+++ b/Modules/PaymentGateway/Http/Controllers/DataController.php
@@ -2,20 +2,21 @@
 
 namespace Modules\PaymentGateway\Http\Controllers;
 
+use App\Utils\ModuleUtil;
 use Illuminate\Routing\Controller;
+use Menu;
 
 /**
- * DataController do módulo PaymentGateway — Onda 1 esqueleto.
+ * DataController do módulo PaymentGateway.
  *
  * Descoberto pelo middleware AdminSidebarMenu do core UltimatePOS.
  * Sidebar pattern canon: skill `sidebar-menu-arch`.
  *
- * Onda 1 (esta): apenas superadmin_package + user_permissions registrados
- * pra que Wagner possa habilitar nas 3 camadas (subscription package +
- * business.enabled_modules + Spatie permissions) antes de Onda 4 entregar
- * Page Inertia "Cobrança" no sidebar.
- *
- * modifyAdminMenu vazio nesta onda — ativa em Onda 4 quando tela existir.
+ * Onda 1: apenas superadmin_package + user_permissions registrados.
+ * Onda 5 (2026-05-19): modifyAdminMenu populado — Page Inertia
+ * /settings/payment-gateways entregue na Onda 4d F3 (PR #1135).
+ * Permission gate paymentgateway.access (registrada via
+ * `php artisan paymentgateway:register-permissions`).
  */
 class DataController extends Controller
 {
@@ -57,10 +58,54 @@ class DataController extends Controller
     }
 
     /**
-     * Camada visual sidebar — Onda 1 vazio. Onda 4 ativa quando Page Cobrança nascer.
+     * Camada visual sidebar — Onda 5 (2026-05-19): popular.
+     *
+     * Adiciona entrada "Gateways de Pagamento" apontando pra
+     * /settings/payment-gateways (Page Inertia Onda 4d F3, PR #1135).
+     *
+     * Pattern segue Financeiro DataController.modifyAdminMenu — guard
+     * via isModuleInstalled + permission `paymentgateway.access`.
+     * 'group' => 'fin' agrupa visualmente com Financeiro na sidebar
+     * (Sidebar.tsx SIDEBAR_GROUPS canon ADR sidebar-menu-arch).
      */
     public function modifyAdminMenu(): void
     {
-        // intencionalmente vazio — vide docblock.
+        $module_util = new ModuleUtil();
+
+        if (auth()->user() && auth()->user()->can('superadmin')) {
+            $is_enabled = $module_util->isModuleInstalled('PaymentGateway');
+        } else {
+            $business_id = session('user.business_id');
+            $is_enabled = $business_id
+                ? (bool) $module_util->hasThePermissionInSubscription(
+                    $business_id,
+                    'paymentgateway_module',
+                    'superadmin_package'
+                )
+                : false;
+        }
+
+        if (! $is_enabled) {
+            return;
+        }
+
+        if (! auth()->user()->can('superadmin') && ! auth()->user()->can('paymentgateway.access')) {
+            return;
+        }
+
+        $segmento_settings = request()->segment(1) === 'settings'
+            && request()->segment(2) === 'payment-gateways';
+
+        Menu::modify('admin-sidebar-menu', function ($menu) use ($segmento_settings) {
+            $menu->url(
+                url('/settings/payment-gateways'),
+                __('paymentgateway::paymentgateway.module_label'),
+                [
+                    'icon'   => 'fa fas fa-key',
+                    'active' => $segmento_settings,
+                    'group'  => 'fin',
+                ]
+            )->order(85.4);
+        });
     }
 }


### PR DESCRIPTION
## Bug UX detectado por Wagner 2026-05-19

> "tem que chegar a cadastrar as contas. Eu não tenho acesso por menu. https://oimpresso.com/financeiro deveria poder cadastrar aqui. e vincular em uma cobrança? Como se faz e como se acessa?"

**Causa:** 2 telas ENTREGUES mas SEM entrada de sidebar — bloqueia setup Onda 5 dogfooding.

| Tela Inertia | Rota | Sidebar antes | Sidebar agora |
|---|---|---|---|
| \`Pages/Financeiro/ContasBancarias/Index.tsx\` (já existia) | \`/financeiro/contas-bancarias\` | ❌ NÃO listada | ✅ "Contas Bancárias" |
| \`Pages/Settings/PaymentGateways/Index.tsx\` (PR #1135 Onda 4d F3) | \`/settings/payment-gateways\` | ❌ NÃO listada (modifyAdminMenu vazio Onda 1) | ✅ "Gateways de Pagamento" |

## Mudanças

### Modules/PaymentGateway/Http/Controllers/DataController.php

\`modifyAdminMenu\` vazio na Onda 1 esqueleto. Agora populado:
- Guard: \`isModuleInstalled('PaymentGateway')\` + permission \`paymentgateway.access\`
- Entrada "Gateways de Pagamento" → \`/settings/payment-gateways\`
- icon: \`fa fas fa-key\`
- group: \`fin\` (agrupa com Financeiro)
- order: 85.4 (entre Cobrança e Contas Bancárias)

### Modules/Financeiro/Http/Controllers/DataController.php

5ª entrada "Contas Bancárias" → \`/financeiro/contas-bancarias\`:
- icon: \`fa fas fa-university\`
- order: 85.5
- Label literal PT-BR (regra DataController canon — LegacyMenuAdapter lê literal)

## Caminho de uso Wagner pós-deploy

1. **Sidebar admin → "Contas Bancárias"** (Financeiro)
   - Cadastrar conta vinculada a Account UltimatePOS existente
   - Marcar \`ativo_para_boleto=true\`
2. **Sidebar admin → "Gateways de Pagamento"** (PaymentGateway)
   - Cadastrar credencial (\`gateway_key='inter'\` ou \`'bcb_pix'\`, \`ambiente='sandbox'\` pra teste)
   - Preencher \`config_json\` (client_id/client_secret/cert mTLS encrypted)
3. **Voltar em Contas Bancárias** → editar conta → vincular \`payment_gateway_credential_id\`
4. Auto-onboarding começa a funcionar (Observer Business::created da Onda 5.B)

## Test plan

- [x] PHP lint verde (2 arquivos)
- [ ] Pós-deploy: login Wagner → sidebar mostra "Contas Bancárias" + "Gateways de Pagamento" no grupo Financeiro
- [ ] Clicar nas entradas → telas Inertia carregam (sem erro 403/404)

## Refs

- PR #1135 — Onda 4d F3 UI 3 telas (Settings/PaymentGateways/Index entregue)
- PR #1148 — Onda 5 base
- PR #1149 — Onda 5.B auto-onboarding
- PR #1150 — hotfix schema canon
- Skill \`sidebar-menu-arch\` — DataController.modifyAdminMenu pattern canon

🤖 Generated with [Claude Code](https://claude.com/claude-code)