### PR TITLE
feat(paymentgateway): endpoint store credencial + wizard SheetNovoGateway funcional

### DIFF
--- a/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
@@ -7,7 +7,9 @@ namespace Modules\PaymentGateway\Http\Controllers\Settings;
 use App\Http\Controllers\Controller;
 use Carbon\CarbonImmutable;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Financeiro\Models\ContaBancaria;
@@ -83,6 +85,134 @@ class PaymentGatewaysController extends Controller
         $results = $svc->checkAll($businessId);
 
         return response()->json(['results' => $results]);
+    }
+
+    /**
+     * Cria nova credencial PaymentGateway.
+     *
+     * Onda 5 (2026-05-19) — completa o wizard SheetNovoGateway (frontend
+     * F3 PR #1135 entregou UI, faltava endpoint backend).
+     *
+     * Trust L3 — secrets em config_json. NÃO cifra automaticamente nesta
+     * onda (config_json cast 'array' — armazena JSON literal). Encryption
+     * automática por field fica em ondas futuras (atualmente .env do prod
+     * é fonte primária; credencial é gestão UI complementar).
+     *
+     * Multi-tenant Tier 0 — business_id derivado de session, NUNCA do payload.
+     */
+    public function store(Request $request): RedirectResponse|JsonResponse
+    {
+        $businessId = (int) $request->session()->get('user.business_id', $request->session()->get('business.id', 0));
+
+        if ($businessId <= 0) {
+            return response()->json(['success' => false, 'msg' => 'Sessão sem business_id'], 403);
+        }
+
+        $validated = $request->validate([
+            'gateway_key'      => 'required|string|in:inter,c6,asaas,bcb_pix,pesapal',
+            'ambiente'         => 'required|string|in:production,sandbox',
+            'nome_display'     => 'nullable|string|max:191',
+            'conta_bancaria_id' => 'nullable|integer|exists:accounts,id',
+            'config_json'      => 'required|array',
+            'ativo'            => 'sometimes|boolean',
+        ]);
+
+        // Tier 0: garantir conta_bancaria_id pertence ao business_id session
+        if (!empty($validated['conta_bancaria_id'])) {
+            $ownsAccount = \App\Account::where('id', $validated['conta_bancaria_id'])
+                ->where('business_id', $businessId)
+                ->exists();
+            if (!$ownsAccount) {
+                return response()->json(['success' => false, 'msg' => 'Conta não pertence ao business'], 403);
+            }
+        }
+
+        // Anti-dupla — (business_id, gateway_key, ambiente) é unique no schema
+        $duplicate = PaymentGatewayCredential::query()
+            ->withoutGlobalScopes()
+            ->where('business_id', $businessId)
+            ->where('gateway_key', $validated['gateway_key'])
+            ->where('ambiente', $validated['ambiente'])
+            ->exists();
+
+        if ($duplicate) {
+            return response()->json([
+                'success' => false,
+                'msg' => sprintf('Já existe credencial %s (%s) em biz=%d. Edite a existente.', $validated['gateway_key'], $validated['ambiente'], $businessId),
+            ], 422);
+        }
+
+        $cred = PaymentGatewayCredential::create([
+            'business_id'        => $businessId,
+            'gateway_key'        => $validated['gateway_key'],
+            'ambiente'           => $validated['ambiente'],
+            'nome_display'       => $validated['nome_display'] ?? null,
+            'conta_bancaria_id'  => $validated['conta_bancaria_id'] ?? null,
+            'config_json'        => $validated['config_json'],
+            'ativo'              => (bool) ($validated['ativo'] ?? true),
+            'health_status'      => 'unknown',
+        ]);
+
+        Log::info('[paymentgateway.credential.created]', [
+            'business_id'   => $businessId,
+            'credential_id' => $cred->id,
+            'gateway_key'   => $cred->gateway_key,
+            'ambiente'      => $cred->ambiente,
+            // NÃO loga config_json (secrets — LGPD/PCI)
+        ]);
+
+        if ($request->wantsJson()) {
+            return response()->json([
+                'success' => true,
+                'credential_id' => $cred->id,
+                'gateway_key' => $cred->gateway_key,
+            ], 201);
+        }
+
+        return redirect()->route('settings.payment-gateways.index')
+            ->with('status', ['success' => 1, 'msg' => 'Credencial criada: ' . ($cred->nome_display ?: $cred->gateway_key)]);
+    }
+
+    /**
+     * Atualiza credencial existente. Pattern store — apenas campos enviados.
+     */
+    public function update(Request $request, int $credentialId): JsonResponse
+    {
+        $businessId = (int) $request->session()->get('user.business_id', $request->session()->get('business.id', 0));
+
+        $cred = PaymentGatewayCredential::query()
+            ->where('business_id', $businessId)
+            ->findOrFail($credentialId);
+
+        $validated = $request->validate([
+            'nome_display'      => 'sometimes|nullable|string|max:191',
+            'conta_bancaria_id' => 'sometimes|nullable|integer|exists:accounts,id',
+            'config_json'       => 'sometimes|array',
+            'ambiente'          => 'sometimes|string|in:production,sandbox',
+            'ativo'             => 'sometimes|boolean',
+        ]);
+
+        if (!empty($validated['conta_bancaria_id'])) {
+            $ownsAccount = \App\Account::where('id', $validated['conta_bancaria_id'])
+                ->where('business_id', $businessId)
+                ->exists();
+            if (!$ownsAccount) {
+                return response()->json(['success' => false, 'msg' => 'Conta não pertence ao business'], 403);
+            }
+        }
+
+        $cred->update($validated);
+
+        Log::info('[paymentgateway.credential.updated]', [
+            'business_id'   => $businessId,
+            'credential_id' => $cred->id,
+            'fields'        => array_keys($validated),
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'credential_id' => $cred->id,
+        ]);
     }
 
     /**

--- a/Modules/PaymentGateway/Routes/web.php
+++ b/Modules/PaymentGateway/Routes/web.php
@@ -40,6 +40,14 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
         Route::get('payment-gateways', [PaymentGatewaysController::class, 'index'])
             ->name('payment-gateways.index');
 
+        // Onda 5 (2026-05-19) — completa wizard SheetNovoGateway (UI F3 PR #1135).
+        Route::post('payment-gateways', [PaymentGatewaysController::class, 'store'])
+            ->name('payment-gateways.store');
+
+        Route::put('payment-gateways/{credentialId}', [PaymentGatewaysController::class, 'update'])
+            ->whereNumber('credentialId')
+            ->name('payment-gateways.update');
+
         Route::post('payment-gateways/health-check', [PaymentGatewaysController::class, 'healthCheck'])
             ->name('payment-gateways.health-check.all');
 

--- a/Modules/PaymentGateway/Tests/Feature/PaymentGatewaysControllerStoreTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/PaymentGatewaysControllerStoreTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Account;
+use App\Business;
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Pest — POST /settings/payment-gateways store endpoint (Onda 5 completar wizard).
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('Requer schema MySQL UltimatePOS + PaymentGateway.');
+    }
+    if (!Schema::hasTable('payment_gateway_credentials') || !Schema::hasTable('accounts')) {
+        $this->markTestSkipped('Schema PaymentGateway/accounts ausente.');
+    }
+});
+
+it('store cria credencial Inter sandbox com sucesso', function () {
+    $user = User::factory()->create(['business_id' => 1]);
+
+    $payload = [
+        'gateway_key' => 'inter',
+        'ambiente'    => 'sandbox',
+        'nome_display' => 'Inter Sandbox Test ' . uniqid(),
+        'conta_bancaria_id' => null,
+        'config_json' => [
+            'client_id'     => 'test-client-id',
+            'client_secret' => 'test-secret',
+        ],
+        'ativo' => true,
+    ];
+
+    $response = $this->actingAs($user)
+        ->withSession(['user.business_id' => 1])
+        ->postJson('/settings/payment-gateways', $payload);
+
+    $response->assertCreated();
+    $response->assertJsonStructure(['success', 'credential_id', 'gateway_key']);
+
+    $credId = $response->json('credential_id');
+    $cred = PaymentGatewayCredential::withoutGlobalScopes()->find($credId);
+    expect($cred)->not->toBeNull();
+    expect($cred->business_id)->toBe(1);
+    expect($cred->gateway_key)->toBe('inter');
+    expect($cred->ambiente)->toBe('sandbox');
+    expect($cred->config_json['client_id'])->toBe('test-client-id');
+
+    PaymentGatewayCredential::withoutGlobalScopes()->where('id', $credId)->forceDelete();
+});
+
+it('store rejeita duplicate (business_id, gateway_key, ambiente)', function () {
+    $user = User::factory()->create(['business_id' => 1]);
+    $existing = PaymentGatewayCredential::create([
+        'business_id' => 1,
+        'gateway_key' => 'asaas',
+        'ambiente' => 'sandbox',
+        'nome_display' => 'pre-existing',
+        'config_json' => ['api_key' => 'pre'],
+        'ativo' => true,
+        'health_status' => 'unknown',
+    ]);
+
+    $response = $this->actingAs($user)
+        ->withSession(['user.business_id' => 1])
+        ->postJson('/settings/payment-gateways', [
+            'gateway_key' => 'asaas',
+            'ambiente' => 'sandbox',
+            'nome_display' => 'dup test',
+            'config_json' => ['api_key' => 'dup'],
+        ]);
+
+    $response->assertStatus(422);
+
+    $existing->forceDelete();
+});
+
+it('store rejeita conta_bancaria_id de outro business (Tier 0)', function () {
+    $user = User::factory()->create(['business_id' => 1]);
+    $otherBiz = Business::firstOrCreate(['id' => 99999], ['name' => 'Outro Tenant', 'currency_id' => 1]);
+    $otherAccount = Account::create([
+        'business_id' => 99999,
+        'name' => 'Conta de outro biz',
+        'account_number' => 'DUMMY-' . uniqid(),
+        'created_by' => 1,
+    ]);
+
+    $response = $this->actingAs($user)
+        ->withSession(['user.business_id' => 1])
+        ->postJson('/settings/payment-gateways', [
+            'gateway_key' => 'inter',
+            'ambiente' => 'sandbox',
+            'nome_display' => 'tier-0 cross-tenant attempt',
+            'conta_bancaria_id' => $otherAccount->id,
+            'config_json' => ['client_id' => 'x', 'client_secret' => 'y'],
+        ]);
+
+    $response->assertStatus(403);
+
+    $otherAccount->forceDelete();
+});
+
+it('store valida gateway_key enum', function () {
+    $user = User::factory()->create(['business_id' => 1]);
+
+    $response = $this->actingAs($user)
+        ->withSession(['user.business_id' => 1])
+        ->postJson('/settings/payment-gateways', [
+            'gateway_key' => 'foobar_invalid',
+            'ambiente' => 'sandbox',
+            'config_json' => ['x' => 'y'],
+        ]);
+
+    $response->assertStatus(422);
+});

--- a/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
@@ -1,5 +1,7 @@
 // SheetNovoGateway.tsx — wizard 3 steps (Driver → Credenciais → Vínculo)
+// Onda 5 (2026-05-19): wiring backend POST /settings/payment-gateways
 import { useEffect, useState } from 'react';
+import { router } from '@inertiajs/react';
 import {
   X, ChevronRight, ChevronLeft, Plus, Check, Shield,
 } from 'lucide-react';
@@ -19,6 +21,15 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
   const [step, setStep] = useState(1);
   const [driver, setDriver] = useState<GatewayKey | null>(null);
 
+  // Onda 5: state controlado dos campos
+  const [apelido, setApelido] = useState('');
+  const [config, setConfig] = useState<Record<string, string>>({});
+  const [contaId, setContaId] = useState<string>('');
+  const [ambiente, setAmbiente] = useState<'production' | 'sandbox'>('sandbox');
+  const [ativo, setAtivo] = useState(true);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
     document.addEventListener('keydown', onKey);
@@ -28,6 +39,38 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
   const d = driver ? DRIVERS[driver] : null;
   const canNext = step === 1 ? !!driver : true;
   const isLast = step === STEPS.length;
+
+  function setConfigField(key: string, value: string): void {
+    setConfig(prev => ({ ...prev, [key]: value }));
+  }
+
+  function handleSubmit(): void {
+    if (!driver) return;
+    setError(null);
+    setSubmitting(true);
+
+    const payload = {
+      gateway_key: driver,
+      ambiente,
+      nome_display: apelido || null,
+      conta_bancaria_id: contaId ? Number(contaId) : null,
+      config_json: config,
+      ativo,
+    };
+
+    router.post('/settings/payment-gateways', payload, {
+      preserveScroll: true,
+      onSuccess: () => {
+        setSubmitting(false);
+        onClose();
+      },
+      onError: (errors) => {
+        setSubmitting(false);
+        const firstError = Object.values(errors)[0];
+        setError(typeof firstError === 'string' ? firstError : 'Erro ao criar credencial');
+      },
+    });
+  }
 
   return (
     <div className="fixed inset-0 z-30 flex justify-end" onClick={onClose} role="dialog" aria-modal="true" aria-label="Novo gateway">
@@ -102,44 +145,122 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
           {step === 2 && d && (
             <div className="space-y-3">
               <Field label="Apelido">
-                <input placeholder={`ex: ${d.nome} · Operacional`} className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px]" />
+                <input
+                  value={apelido}
+                  onChange={e => setApelido(e.target.value)}
+                  placeholder={`ex: ${d.nome} · Operacional`}
+                  className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px]"
+                />
               </Field>
               <div className="bg-stone-50 border border-stone-200 rounded p-3 text-[11px] text-stone-700 mb-3">
                 <strong>{d.nome}:</strong> {d.cred}
               </div>
               {d.key === 'inter' && <>
-                <Field label="Client ID"><input className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono" /></Field>
-                <Field label="Client Secret"><input type="password" className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono" /></Field>
-                <div className="grid grid-cols-2 gap-3">
-                  <FileField label="Certificado .crt" />
-                  <FileField label="Chave .key" />
+                <Field label="Client ID">
+                  <input
+                    value={config.client_id ?? ''}
+                    onChange={e => setConfigField('client_id', e.target.value)}
+                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
+                  />
+                </Field>
+                <Field label="Client Secret">
+                  <input
+                    type="password"
+                    value={config.client_secret ?? ''}
+                    onChange={e => setConfigField('client_secret', e.target.value)}
+                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
+                  />
+                </Field>
+                <Field label="Webhook secret (opcional)">
+                  <input
+                    type="password"
+                    value={config.webhook_secret ?? ''}
+                    onChange={e => setConfigField('webhook_secret', e.target.value)}
+                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
+                  />
+                </Field>
+                <div className="bg-amber-50 border border-amber-200 rounded p-2.5 text-[10.5px] text-amber-800">
+                  Certificado mTLS (.crt + .key) ainda não pode ser feito upload pela UI.
+                  Pra sandbox sem mTLS funciona. Pra produção, suba via SSH em <span className="font-mono">storage/app/private/payment-gateway/</span> e referencie em <span className="font-mono">config_json.cert_path</span> manual (próxima onda terá UI de upload).
                 </div>
               </>}
               {d.key === 'asaas' && <>
-                <Field label="API Key"><input type="password" placeholder="$aact_..." className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono" /></Field>
-                <Field label="Webhook secret"><input type="password" className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono" /></Field>
+                <Field label="API Key">
+                  <input
+                    type="password"
+                    value={config.api_key ?? ''}
+                    onChange={e => setConfigField('api_key', e.target.value)}
+                    placeholder="$aact_..."
+                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
+                  />
+                </Field>
+                <Field label="Webhook secret">
+                  <input
+                    type="password"
+                    value={config.webhook_secret ?? ''}
+                    onChange={e => setConfigField('webhook_secret', e.target.value)}
+                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
+                  />
+                </Field>
               </>}
               {d.key === 'c6' && <div className="grid grid-cols-3 gap-3">
-                <Field label="Agência"><input className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px] font-mono" /></Field>
-                <Field label="Conta"><input className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px] font-mono" /></Field>
-                <Field label="Código cliente"><input className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px] font-mono" /></Field>
+                <Field label="Agência">
+                  <input
+                    value={config.agencia ?? ''}
+                    onChange={e => setConfigField('agencia', e.target.value)}
+                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px] font-mono"
+                  />
+                </Field>
+                <Field label="Conta">
+                  <input
+                    value={config.conta ?? ''}
+                    onChange={e => setConfigField('conta', e.target.value)}
+                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px] font-mono"
+                  />
+                </Field>
+                <Field label="Código cliente">
+                  <input
+                    value={config.codigo_cliente ?? ''}
+                    onChange={e => setConfigField('codigo_cliente', e.target.value)}
+                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px] font-mono"
+                  />
+                </Field>
               </div>}
               {d.key === 'bcb_pix' && <>
-                <Field label="CNPJ recebedor"><input placeholder="apenas números" className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px] font-mono" /></Field>
-                <div className="grid grid-cols-2 gap-3">
-                  <FileField label="Cert mTLS ICP-Brasil .crt" />
-                  <FileField label="Chave mTLS .key" />
+                <Field label="CNPJ recebedor">
+                  <input
+                    value={config.cnpj_recebedor ?? ''}
+                    onChange={e => setConfigField('cnpj_recebedor', e.target.value)}
+                    placeholder="apenas números"
+                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px] font-mono"
+                  />
+                </Field>
+                <div className="bg-amber-50 border border-amber-200 rounded p-2.5 text-[10.5px] text-amber-800">
+                  Certificado mTLS ICP-Brasil (.crt + .key + senha) precisa ser cadastrado manual via SSH em <span className="font-mono">storage/app/private/payment-gateway/</span> e referenciado em <span className="font-mono">config_json.cert_path</span> + <span className="font-mono">.cert_password</span>.
                 </div>
-                <Field label="Senha do certificado"><input type="password" className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px] font-mono" /></Field>
               </>}
               {d.key === 'pesapal' && <>
-                <Field label="API Key"><input type="password" className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono" /></Field>
-                <Field label="Consumer Secret"><input type="password" className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono" /></Field>
+                <Field label="Consumer Key">
+                  <input
+                    type="password"
+                    value={config.consumer_key ?? ''}
+                    onChange={e => setConfigField('consumer_key', e.target.value)}
+                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
+                  />
+                </Field>
+                <Field label="Consumer Secret">
+                  <input
+                    type="password"
+                    value={config.consumer_secret ?? ''}
+                    onChange={e => setConfigField('consumer_secret', e.target.value)}
+                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
+                  />
+                </Field>
               </>}
 
               <div className="pt-2 border-t border-stone-200 mt-3 flex items-center gap-2">
-                <Btn variant="outline"><Shield className="h-3 w-3" />Testar conexão</Btn>
-                <span className="text-[10.5px] text-stone-500">verifica credenciais antes de salvar</span>
+                <Btn variant="outline" disabled><Shield className="h-3 w-3" />Testar conexão</Btn>
+                <span className="text-[10.5px] text-stone-500">teste de conexão chega em onda futura — salve e use health check no card</span>
               </div>
             </div>
           )}
@@ -147,7 +268,11 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
           {step === 3 && d && (
             <div className="space-y-3">
               <Field label="Conta destino (FK accounts)">
-                <select className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px]">
+                <select
+                  value={contaId}
+                  onChange={e => setContaId(e.target.value)}
+                  className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px]"
+                >
                   <option value="">— sem vínculo —</option>
                   {accounts.map(a => <option key={a.id} value={a.id}>{a.name}</option>)}
                 </select>
@@ -155,15 +280,25 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
               <Field label="Ambiente inicial">
                 <div className="inline-flex bg-stone-100 rounded p-0.5 border border-stone-200">
                   {d.ambientes.map(a => (
-                    <button key={a} className={cn(
-                      'h-7 px-3 rounded text-[11.5px] transition',
-                      a === d.ambientes[0] ? 'bg-white shadow-sm font-medium' : 'text-stone-600',
-                    )}>{a === 'production' ? 'produção' : 'sandbox'}</button>
+                    <button
+                      key={a}
+                      type="button"
+                      onClick={() => setAmbiente(a as 'production' | 'sandbox')}
+                      className={cn(
+                        'h-7 px-3 rounded text-[11.5px] transition',
+                        ambiente === a ? 'bg-white shadow-sm font-medium' : 'text-stone-600',
+                      )}
+                    >{a === 'production' ? 'produção' : 'sandbox'}</button>
                   ))}
                 </div>
               </Field>
               <label className="flex items-center gap-3 py-1.5">
-                <input type="checkbox" defaultChecked className="accent-stone-900 w-4 h-4" />
+                <input
+                  type="checkbox"
+                  checked={ativo}
+                  onChange={e => setAtivo(e.target.checked)}
+                  className="accent-stone-900 w-4 h-4"
+                />
                 <div>
                   <div className="text-[12.5px] text-stone-800">Ativar imediatamente</div>
                   <div className="text-[10.5px] text-stone-500">se desligado, gateway fica cadastrado mas não emite cobrança</div>
@@ -173,6 +308,11 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
                 Ao confirmar, será criada uma linha em <span className="font-mono">payment_gateway_credentials</span> com <span className="font-mono">business_id</span> do business logado.
                 Webhook URL será gerada automaticamente — cole no painel do {d.nome} após criação.
               </div>
+              {error && (
+                <div className="bg-rose-50 border border-rose-200 rounded p-2.5 text-[11px] text-rose-800">
+                  {error}
+                </div>
+              )}
             </div>
           )}
         </div>
@@ -187,8 +327,8 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
             </Btn>
           )}
           {isLast && (
-            <Btn variant="primary" onClick={onClose}>
-              <Plus className="h-3 w-3" />Criar gateway
+            <Btn variant="primary" onClick={handleSubmit} disabled={submitting}>
+              <Plus className="h-3 w-3" />{submitting ? 'Criando…' : 'Criar gateway'}
             </Btn>
           )}
         </div>


### PR DESCRIPTION
## Wagner desbloqueio 2026-05-19

> "pode fazer, configure"

UI SheetNovoGateway (PR #1135 Onda 4d F3) tinha 3-step wizard montado mas:
- Botão "Criar gateway" só fechava o sheet (\`onClick={onClose}\`)
- Backend não tinha endpoint POST \`/settings/payment-gateways\`
- Wagner não conseguia cadastrar credencial Inter sandbox sem isso

## Mudanças

### Backend

| Arquivo | Mudança |
|---|---|
| \`Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php\` | + \`store(Request)\` + \`update(Request, $credentialId)\` |
| \`Modules/PaymentGateway/Routes/web.php\` | + \`POST /settings/payment-gateways\` + \`PUT /settings/payment-gateways/{credentialId}\` |

### Frontend

| Arquivo | Mudança |
|---|---|
| \`resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx\` | State controlado (apelido + config + contaId + ambiente + ativo + error) + \`handleSubmit\` chamando \`router.post('/settings/payment-gateways')\` + inputs ligados a state + disclaimers cert mTLS via SSH |

### Pest tests (4 it)

\`Modules/PaymentGateway/Tests/Feature/PaymentGatewaysControllerStoreTest.php\`:
- store cria credencial Inter sandbox com sucesso
- rejeita duplicate (business_id, gateway_key, ambiente) — unique constraint
- **rejeita conta_bancaria_id de outro business (Tier 0 cross-tenant)** — Wagner regra ADR 0093
- valida gateway_key enum

## Tier 0 preservado

- \`business_id\` SEMPRE derivado de \`session->user.business_id\`, NUNCA do payload
- \`conta_bancaria_id\` validado: deve pertencer ao business_id da session
- Log NÃO emite \`config_json\` (LGPD/PCI — secrets em payload)

## Caminho Wagner pós-deploy

1. Sidebar admin → "Gateways de Pagamento" → "Novo gateway"
2. **Step 1:** escolher driver (Inter / C6 / Asaas / BCB Pix / Pesapal)
3. **Step 2:** preencher credenciais
   - Inter: client_id + client_secret + webhook_secret (opcional)
   - Asaas: api_key + webhook_secret
   - C6: agência + conta + código_cliente
   - BCB Pix: cnpj_recebedor (cert mTLS via SSH manual nesta onda)
4. **Step 3:** vincular Conta destino (FK Account UPOS) + ambiente sandbox/production + marcar ativo
5. Clicar "Criar gateway" → salva em \`payment_gateway_credentials\` biz=1

## NÃO entregue nesta onda (backlog)

- Upload certificado mTLS (.crt + .key + senha) via UI — fica SSH manual em \`storage/app/private/payment-gateway/\` + path em \`config_json.cert_path\`
- "Testar conexão" no wizard (chama HealthCheckService com creds pendentes — chega em próxima onda)
- Encryption automática de \`config_json\` fields sensíveis (client_secret etc) — hoje JSON literal, encryption por field requer Eloquent custom cast (backlog)

## Test plan

- [x] PHP lint verde
- [x] Vite build OK (\`npm run build:inertia\`)
- [ ] CI verde (Pest + bucket + module-grades)
- [ ] Pós-deploy: tela /settings/payment-gateways → Novo gateway → preencher Inter sandbox → submit → tabela payment_gateway_credentials tem nova row biz=1

## Refs

- PR #1135 — UI F3 SheetNovoGateway (entregou layout sem submit)
- PR #1148 — Onda 5 base (listeners + flow)
- PR #1151 — sidebar fix
- ADR 0170 — PaymentGateway extração
- ADR 0093 — Multi-tenant Tier 0 IRREVOGÁVEL

🤖 Generated with [Claude Code](https://claude.com/claude-code)