### PR TITLE
revert(financeiro/unificado): voltar layout original (Onda 11 errada de canon)

### DIFF
--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -331,22 +331,23 @@
 }
 .fin-cowork .fin-curadoria .fin-search-wrap input::placeholder { color: var(--fin-text-mute); }
 /* ─────────────────────────────────────────────────────────────
- * Footer tips (atalhos inline ao final da página — Wagner 2026-05-19,
- * Onda 11 PR seguinte: removido `position: fixed` que flutuava na
- * viewport e parecia desconectado. Agora rola junto com o conteúdo.)
+ * Footer tips (atalhos sticky bottom)
  * ───────────────────────────────────────────────────────────── */
 .fin-cowork .fin-curadoria .fin-footer-tips {
-  margin-top: 24px;
-  padding: 8px 16px;
-  background: oklch(0.99 0.002 240);
-  border: 1px solid var(--fin-line);
-  border-radius: 8px;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding: 6px 24px;
+  background: oklch(0.99 0.002 240 / 0.95);
+  backdrop-filter: blur(8px);
+  border-top: 1px solid var(--fin-line);
   font-size: 11px;
   color: var(--fin-text-mute);
   display: flex;
   align-items: center;
   gap: 14px;
-  flex-wrap: wrap;
+  z-index: 30;
 }
 .fin-cowork .fin-curadoria .fin-footer-tips kbd {
   font-family: ui-monospace, monospace;

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -620,62 +620,60 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
         </div>
       </header>
 
-      {/* Linha 3 — toolbar de ações secundárias com pattern Financeiro NATIVO.
-          Wagner 2026-05-19: "era para pegar do projeto o item do financeiro
-          compativel" — bug detectado em prod: classes `vd-toolbar*` (Sells)
-          foram tree-shaken pelo Vite (regras `.fin-cowork .vendas-aplus
-          .vd-toolbar*` removidas do build final). Trocado por `fin-btn` que é
-          o botão canon Financeiro JÁ ATIVO em prod (não tree-shaken). */}
-      <div className="flex items-center gap-2 flex-wrap px-6 pt-3 pb-3 mb-3 border-b border-stone-200">
-        <button
-          type="button"
-          className="fin-btn"
-          title="Resumo executivo do mês (narrativa compute-based · Onda 9 v1)"
-          onClick={() => setResumoOpen(true)}
-        >
-          <Sparkles size={12} />
-          Resumir mês
-        </button>
-        <button
-          type="button"
-          className="fin-btn"
-          title="Trilha de 12 passos do fechamento mensal"
-          onClick={() => setChecklistOpen(true)}
-        >
-          <CheckSquare size={12} />
-          Fechamento
-        </button>
-        <button
-          type="button"
-          className="fin-btn"
-          title="Modo apresentação fullscreen (Esc fecha · 1/2/3 muda vista)"
-          onClick={() => setPresentOpen(true)}
-        >
-          <Play size={12} />
-          Apresentar
-        </button>
+      {/* Linha 3 — vd-toolbar fora do sticky com 5 ações Onda 5-10.
+          Conciliar saiu daqui pra linha 1 (paridade prototipo canon). */}
+      <div className="vd-toolbar">
+        <div className="vd-toolbar-l">
+          <button
+            type="button"
+            className="vd-toolbar-act"
+            title="Resumo executivo do mês (narrativa compute-based · Onda 9 v1)"
+            onClick={() => setResumoOpen(true)}
+          >
+            <Sparkles size={11} />
+            <span>Resumir mês</span>
+          </button>
+          <button
+            type="button"
+            className="vd-toolbar-act"
+            title="Trilha de 12 passos do fechamento mensal"
+            onClick={() => setChecklistOpen(true)}
+          >
+            <CheckSquare size={11} />
+            <span>Fechamento</span>
+          </button>
+          <button
+            type="button"
+            className="vd-toolbar-act"
+            title="Modo apresentação fullscreen (Esc fecha · 1/2/3 muda vista)"
+            onClick={() => setPresentOpen(true)}
+          >
+            <Play size={11} />
+            <span>Apresentar</span>
+          </button>
+        </div>
 
-        <span className="flex-1" />
-
-        <button
-          type="button"
-          className="fin-btn"
-          title={`Folha jurídica imprimível${favs.count > 0 ? ` · ${favs.count} favorito${favs.count === 1 ? '' : 's'}` : ''}`}
-          onClick={() => { setTranscriptOnlyFavs(false); setTranscriptOpen(true); }}
-        >
-          <Printer size={12} />
-          Imprimir
-          {favs.count > 0 && <span className="fin-btn-badge">{favs.count}★</span>}
-        </button>
-        <button
-          type="button"
-          className="fin-btn"
-          title="Plano de contas — categorias contábeis"
-          onClick={() => router.visit('/financeiro/plano-contas')}
-        >
-          <FolderOpen size={12} />
-          Plano de contas
-        </button>
+        <div className="vd-toolbar-r">
+          <button
+            type="button"
+            className="vd-toolbar-act"
+            title={`Folha jurídica imprimível${favs.count > 0 ? ` · ${favs.count} favorito${favs.count === 1 ? '' : 's'}` : ''}`}
+            onClick={() => { setTranscriptOnlyFavs(false); setTranscriptOpen(true); }}
+          >
+            <Printer size={11} />
+            <span>Imprimir</span>
+            {favs.count > 0 && <kbd className="kbd-hint">{favs.count}★</kbd>}
+          </button>
+          <button
+            type="button"
+            className="vd-toolbar-act"
+            title="Plano de contas — categorias contábeis"
+            onClick={() => router.visit('/financeiro/plano-contas')}
+          >
+            <FolderOpen size={11} />
+            <span>Plano de contas</span>
+          </button>
+        </div>
       </div>
 
       <KpiBar kpis={kpis} onLifecycleSelect={(lifecycle) => aplicar({ lifecycle })} />
@@ -1048,10 +1046,7 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
         </CommandList>
       </CommandDialog>
 
-      {/* Onda 11 (2026-05-19) — footer atalhos inline. Wagner removeu "Densidade:
-          comfortable" (linha redundante — `fin-density` toggle já existe no
-          toolbar de filtros com ícones ◰▦▤). Densidade canon Financeiro é
-          TweaksPanel (prototipo cowork-app.jsx:831), não texto stale no rodapé. */}
+      {/* Onda 8 Cowork: footer atalhos canon (oklch tokens via .fin-footer-tips) */}
       <div className="fin-footer-tips">
         <span><kbd>⌘K</kbd> palette</span>
         <span><kbd>/</kbd> buscar</span>
@@ -1059,12 +1054,9 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
         <span><kbd>␣</kbd> marcar pago/recebido</span>
         <span><kbd>B</kbd> favoritar linha</span>
         <FinTroubleButton onClick={() => setTroubleOpen(true)} />
-        {favs.count > 0 && (
-          <>
-            <span className="spacer" />
-            <span>{favs.count} favorito{favs.count === 1 ? '' : 's'} ★</span>
-          </>
-        )}
+        <span className="spacer" />
+        {favs.count > 0 && <span>{favs.count} favorito{favs.count === 1 ? '' : 's'} ★</span>}
+        <span>Densidade: <strong>{filters.densidade}</strong></span>
       </div>
 
       {/* Onda 7b — Dialogs Troubleshooter + Presentation Mode */}

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -14,11 +14,6 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { router } from '@inertiajs/react';
 import React, { useState, useMemo, useCallback, useEffect, type ReactNode } from 'react';
-// Onda 11 (2026-05-19) — alinhamento header pra fidelidade ao prototipo canon Financeiro
-// (prototipo-ui/prototipos/financeiro-unificado/cowork-app.jsx:153-208).
-// Wagner escolheu "aproximar do prototipo canon" após comparar (sticky + h1 linha 2 +
-// Bell + date picker), preservando 5 ações Onda 5-10 em toolbar abaixo.
-import { Search, Plus, Sparkles, CheckSquare, Play, Printer, RefreshCw, FolderOpen, Bell, Calendar, ChevronRight } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
 import { Card, CardContent } from '@/Components/ui/card';
 import { Input } from '@/Components/ui/input';
@@ -519,159 +514,65 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
     return Array.from(m.entries()).sort((a, b) => a[0].localeCompare(b[0]));
   }, [lancamentos]);
 
-  // Data atual PT-BR pro date picker do header (formato: "19 mai 2026").
-  // Onda 11 v2 — paridade prototipo canon (cowork-app.jsx:204).
-  const todayLabel = useMemo(() => {
-    const d = new Date();
-    return new Intl.DateTimeFormat('pt-BR', { day: '2-digit', month: 'short', year: 'numeric' })
-      .format(d)
-      .replace(/\.?\s+de\s+/g, ' ')
-      .replace('.', '');
-  }, []);
-
   const selected = lancamentos.find(l => l.id === selectedId) ?? null;
 
   return (
-    <div className="fin-curadoria vendas-aplus">
-      {/* Onda 11 v2 (2026-05-19) — fidelidade ao prototipo canon Financeiro
-          (prototipo-ui/prototipos/financeiro-unificado/cowork-app.jsx:153-208):
-            <header sticky top-0 backdrop-blur>
-              Linha 1 (h-14): breadcrumb · ⌘K · Bell · | · Conciliar · CTA "Novo"
-              Linha 2 (pt-4 pb-3): h1 "Financeiro" + chip período + date picker direita
-            </header>
-            Linha 3 fora do sticky: vd-toolbar com 5 ações Onda 5-10
-              (Resumir / Fechamento / Apresentar · Imprimir · Plano contas) */}
-      <header className="sticky top-0 z-30 bg-white/85 backdrop-blur border-b border-stone-200">
-        {/* Linha 1 — barra superior compacta */}
-        <div className="px-6 h-14 flex items-center gap-4">
-          <div className="flex items-center gap-1.5 text-[12px] text-stone-500 whitespace-nowrap">
-            <span>Financeiro</span>
-            <ChevronRight size={12} className="text-stone-400" />
-            <span className="text-stone-900 font-medium">Visão unificada</span>
-          </div>
-
-          <div className="flex-1" />
-
-          <button
-            type="button"
-            onClick={() => setPaletteOpen(true)}
-            className="h-8 px-3 flex items-center gap-2 rounded-md border border-stone-200 bg-white text-[12.5px] text-stone-500 hover:text-stone-800 hover:border-stone-300 transition-colors duration-150 w-[220px]"
-          >
-            <Search size={14} />
-            <span className="truncate flex-1 text-left">Buscar lançamento…</span>
-            <span className="flex items-center gap-1 text-[11px] text-stone-400 font-mono">
-              <kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-stone-50">⌘</kbd>
-              <kbd className="px-1.5 py-0.5 rounded border border-stone-200 bg-stone-50">K</kbd>
-            </span>
-          </button>
-
-          <button
-            type="button"
-            className="h-8 w-8 grid place-items-center rounded-md text-stone-500 hover:bg-stone-100 hover:text-stone-700 transition-colors duration-150 relative shrink-0"
-            title="Notificações financeiras"
-            aria-label="Notificações"
-            onClick={() => setPaletteOpen(true)}
-          >
-            <Bell size={16} />
-            {/* TODO: dot rosa quando houver state real de notificações pendentes (Onda 12+) */}
-          </button>
-
-          <div className="h-5 w-px bg-stone-200 shrink-0" />
-
-          <button
-            type="button"
-            onClick={() => router.visit('/financeiro/extrato')}
-            className="h-8 px-3 flex items-center gap-1.5 rounded-md border border-stone-200 text-[12.5px] text-stone-700 hover:bg-stone-50 transition-colors duration-150 shrink-0 whitespace-nowrap"
-            title="Conciliar extrato bancário"
-          >
-            <RefreshCw size={14} />
-            Conciliar
-          </button>
-
-          <button
-            type="button"
-            onClick={() => router.visit('/financeiro/unificado/novo')}
-            className="h-8 px-3 flex items-center gap-1.5 rounded-md bg-stone-900 text-white text-[12.5px] hover:bg-stone-800 transition-colors duration-150 shrink-0 whitespace-nowrap"
-          >
-            <Plus size={14} />
-            Novo
-          </button>
-        </div>
-
-        {/* Linha 2 — h1 + chip período + date picker */}
-        <div className="px-6 pt-4 pb-3 flex items-baseline gap-3">
-          <h1 className="text-[24px] font-semibold tracking-tight leading-none whitespace-nowrap m-0">
-            Financeiro
+    <div className="fin-curadoria">
+      {/* Onda 8 Cowork: page header canon com h1 + breadcrumb + 7 botões.
+          Substitui PageHeader shadcn legacy (mantido em _KpiBarLegacy + comentário). */}
+      <div className="fin-page-h">
+        <div className="fin-page-h-l">
+          <h1>
+            Financeiro <span className="fin-hero-title-sub">· Visão unificada</span>
           </h1>
-          <span className="text-[11px] uppercase tracking-widest text-stone-500 font-medium whitespace-nowrap">
-            {periodLabel}{businessName ? ` · ${businessName}` : ''}
-          </span>
-          <div className="ml-auto text-[12px] text-stone-500 flex items-center gap-1.5 whitespace-nowrap shrink-0">
-            <Calendar size={13} />
-            <button
-              type="button"
-              onClick={() => setPaletteOpen(true)}
-              className="text-stone-700 hover:text-stone-900 underline-offset-2 hover:underline"
-              title="Mudar período (⌘K)"
-            >
-              {todayLabel}
-            </button>
-          </div>
+          <p>{periodLabel}{businessName ? ` · ${businessName}` : ''} · caixa unificado</p>
         </div>
-      </header>
-
-      {/* Linha 3 — vd-toolbar fora do sticky com 5 ações Onda 5-10.
-          Conciliar saiu daqui pra linha 1 (paridade prototipo canon). */}
-      <div className="vd-toolbar">
-        <div className="vd-toolbar-l">
+        <div className="fin-page-h-r">
+          <button type="button" className="fin-btn" onClick={() => setPaletteOpen(true)}>
+            🔍 Buscar
+            <kbd>⌘K</kbd>
+          </button>
           <button
             type="button"
-            className="vd-toolbar-act"
+            className="fin-btn fin-btn-ai"
             title="Resumo executivo do mês (narrativa compute-based · Onda 9 v1)"
             onClick={() => setResumoOpen(true)}
           >
-            <Sparkles size={11} />
-            <span>Resumir mês</span>
+            ✦ Resumir mês
           </button>
           <button
             type="button"
-            className="vd-toolbar-act"
-            title="Trilha de 12 passos do fechamento mensal"
+            className="fin-btn fin-btn-trilha"
             onClick={() => setChecklistOpen(true)}
+            title="Trilha de 12 passos do fechamento mensal"
           >
-            <CheckSquare size={11} />
-            <span>Fechamento</span>
+            ☑ Fechamento
           </button>
           <button
             type="button"
-            className="vd-toolbar-act"
+            className="fin-btn fin-btn-present"
             title="Modo apresentação fullscreen (Esc fecha · 1/2/3 muda vista)"
             onClick={() => setPresentOpen(true)}
           >
-            <Play size={11} />
-            <span>Apresentar</span>
+            ▶ Apresentar
           </button>
-        </div>
-
-        <div className="vd-toolbar-r">
           <button
             type="button"
-            className="vd-toolbar-act"
+            className="fin-btn"
             title={`Folha jurídica imprimível${favs.count > 0 ? ` · ${favs.count} favorito${favs.count === 1 ? '' : 's'}` : ''}`}
             onClick={() => { setTranscriptOnlyFavs(false); setTranscriptOpen(true); }}
           >
-            <Printer size={11} />
-            <span>Imprimir</span>
-            {favs.count > 0 && <kbd className="kbd-hint">{favs.count}★</kbd>}
+            📄 Imprimir
+            {favs.count > 0 && <span className="fin-btn-badge">{favs.count}★</span>}
           </button>
-          <button
-            type="button"
-            className="vd-toolbar-act"
-            title="Plano de contas — categorias contábeis"
-            onClick={() => router.visit('/financeiro/plano-contas')}
-          >
-            <FolderOpen size={11} />
-            <span>Plano de contas</span>
+          <button type="button" className="fin-btn" onClick={() => router.visit('/financeiro/extrato')}>
+            ↺ Conciliar
+          </button>
+          <button type="button" className="fin-btn" onClick={() => router.visit('/financeiro/plano-contas')} title="Plano de contas — categorias contábeis">
+            📁 Plano de contas
+          </button>
+          <button type="button" className="fin-btn primary" onClick={() => router.visit('/financeiro/unificado/novo')}>
+            + Novo lançamento
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Summary

Wagner apontou (sessão 2026-05-19) que o protótipo canônico que usei como referência nos PRs [#1137](https://github.com/wagnerra23/oimpresso.com/pull/1137) e [#1152](https://github.com/wagnerra23/oimpresso.com/pull/1152) **estava errado**. O canon REAL é [`public/cowork-preview/Oimpresso ERP - Chat.html`](public/cowork-preview/Oimpresso%20ERP%20-%20Chat.html) (servido em prod em [/cowork-preview/Oimpresso ERP - Chat.html](https://oimpresso.com/cowork-preview/Oimpresso%20ERP%20-%20Chat.html)) — NÃO o `prototipo-ui/prototipos/financeiro-unificado/cowork-app.jsx` que peguei.

## Diferenças que o canon REAL tem (e PRs anteriores violaram)

| Elemento | Canon REAL | PR #1137+#1152 (errado) |
|---|---|---|
| Sticky header | ❌ não tem | ✅ tem (violou) |
| Bell notificações | ❌ não tem | ✅ tem (violou) |
| Date picker direita | ❌ não tem | ✅ tem (violou) |
| h1 linha 2 | ❌ não — h1 linha 1 com chip "Visão unificada" | ✅ linha 2 (violou) |
| ⌘K central | ❌ é botão direito como outros | ✅ central (violou) |
| Ações linha 1 | **8 botões empilhados** | 1 CTA + 5 ações linha abaixo (violou) |

## Estratégia

`git revert` de ambos squash merges → restaura layout `fin-page-h` original (mais próximo do canon real).

- Revert [#1152](https://github.com/wagnerra23/oimpresso.com/pull/1152) commit `2332c963d` — restaura `fin-footer-tips` fixed + linha "Densidade: comfortable" + `vd-toolbar` (broken)
- Revert [#1137](https://github.com/wagnerra23/oimpresso.com/pull/1137) commit `c5b3242de` — restaura `fin-page-h` com 8 botões + emoji + sem Bell/date picker/sticky

Diff total: -204 insertions / +97 deletions (limpa Onda 11 completa).

## Após merge

Quando você quiser **realmente** alinhar ao canon REAL (`Oimpresso ERP - Chat.html`), abrimos PR seguinte com:
- 8 botões lucide-react (não emoji)
- Summary numérica no rodapé inline (`N lançamentos · entrada R$ X · saída R$ Y`)
- Remover string redundante "Densidade: comfortable" (canon real tem só 3 ícones direita)

## Tier 0

- ✅ Multi-tenant intacto
- ✅ Charter v5 inalterado
- ✅ Cleanup honesto — não está empurrando workaround

## Test plan

- [ ] CI verde
- [ ] Merge
- [ ] Deploy
- [ ] Smoke Chrome MCP em https://oimpresso.com/financeiro/unificado — confirmar volta ao layout `fin-page-h` com 8 botões empilhados linha 1
- [ ] Comparar com canon REAL https://oimpresso.com/cowork-preview/Oimpresso%20ERP%20-%20Chat.html — confirmar paridade ≥ 80%

🤖 Generated with [Claude Code](https://claude.com/claude-code)