### PR TITLE
fix(financeiro/unificado): footer-tips inline + remover 'Densidade: comfortable' redundante

### DIFF
--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -331,23 +331,22 @@
 }
 .fin-cowork .fin-curadoria .fin-search-wrap input::placeholder { color: var(--fin-text-mute); }
 /* ─────────────────────────────────────────────────────────────
- * Footer tips (atalhos sticky bottom)
+ * Footer tips (inline ao final da página — Wagner 2026-05-19,
+ * comparação com canon REAL /cowork-preview/Oimpresso ERP - Chat.html
+ * mostrou footer inline rolando com o conteúdo, não fixed na viewport).
  * ───────────────────────────────────────────────────────────── */
 .fin-cowork .fin-curadoria .fin-footer-tips {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  padding: 6px 24px;
-  background: oklch(0.99 0.002 240 / 0.95);
-  backdrop-filter: blur(8px);
-  border-top: 1px solid var(--fin-line);
+  margin-top: 24px;
+  padding: 8px 16px;
+  background: oklch(0.99 0.002 240);
+  border: 1px solid var(--fin-line);
+  border-radius: 8px;
   font-size: 11px;
   color: var(--fin-text-mute);
   display: flex;
   align-items: center;
   gap: 14px;
-  z-index: 30;
+  flex-wrap: wrap;
 }
 .fin-cowork .fin-curadoria .fin-footer-tips kbd {
   font-family: ui-monospace, monospace;

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -955,9 +955,12 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
         <span><kbd>␣</kbd> marcar pago/recebido</span>
         <span><kbd>B</kbd> favoritar linha</span>
         <FinTroubleButton onClick={() => setTroubleOpen(true)} />
-        <span className="spacer" />
-        {favs.count > 0 && <span>{favs.count} favorito{favs.count === 1 ? '' : 's'} ★</span>}
-        <span>Densidade: <strong>{filters.densidade}</strong></span>
+        {favs.count > 0 && (
+          <>
+            <span className="spacer" />
+            <span>{favs.count} favorito{favs.count === 1 ? '' : 's'} ★</span>
+          </>
+        )}
       </div>
 
       {/* Onda 7b — Dialogs Troubleshooter + Presentation Mode */}


### PR DESCRIPTION
## Summary

Wagner comparou prod com canon REAL ([cowork-preview/Oimpresso ERP - Chat.html](https://oimpresso.com/cowork-preview/Oimpresso%20ERP%20-%20Chat.html)) e autorizou fix dos gaps 1+2 (sessão 2026-05-19 pós-revert [#1155](https://github.com/wagnerra23/oimpresso.com/pull/1155) e cleanup [#1156](https://github.com/wagnerra23/oimpresso.com/pull/1156)).

## Gap 1 — Remove string redundante `Densidade: comfortable`

[Index.tsx:960](resources/js/Pages/Financeiro/Unificado/Index.tsx#L960): tira `<span>Densidade: <strong>{filters.densidade}</strong></span>` do footer-tips. Toggle visual `.fin-density` (ícones ◰▦▤) já existe no toolbar — texto duplicado era ruído. Canon REAL não tem.

## Gap 2 — Footer inline (sem fixed)

[fin-cowork.css:336](resources/css/fin-cowork.css#L336):
- Removido: `position:fixed; bottom:0; left:0; right:0; backdrop-filter:blur(8px); z-index:30`
- Adicionado: `margin-top:24px; border:1px solid; border-radius:8px; flex-wrap:wrap`

Footer rola junto com a página agora.

## Diff

+15 / -13 em 2 arquivos.

## Tier 0

- ✅ CSS escopado em `.fin-cowork .fin-curadoria` — só Financeiro/Unificado
- ✅ Multi-tenant intacto
- ✅ Charter v5 inalterado

## Test plan

- [ ] CI verde
- [ ] Merge
- [ ] Deploy + `npm run build:inertia`
- [ ] Smoke Chrome MCP em https://oimpresso.com/financeiro/unificado:
  - confirma footer rola com página (não fixed)
  - confirma sem "Densidade: comfortable"
- [ ] Comparar com canon https://oimpresso.com/cowork-preview/Oimpresso%20ERP%20-%20Chat.html

## Próximos gaps (não nesse PR)

Restam 6 gaps reais p/ paridade 100% canon:
- #3 Download icon entre Plano contas e Novo
- #7 KPI hero card dark com sparkline em fundo
- #8 Resumo do mês colapsável (Onda 6 não-canon)
- #10 Summary numérica no footer
- #12 Emoji → lucide-react
- #14 FinMonthDigest sub-header (Onda 6 não-canon)

Decisão sobre cada um pendente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)