### PR TITLE
refactor(financeiro/contas-bancarias): remover credenciais API do cadastro

### DIFF
--- a/Modules/Financeiro/Http/Controllers/ContaBancariaController.php
+++ b/Modules/Financeiro/Http/Controllers/ContaBancariaController.php
@@ -6,21 +6,21 @@ use App\Account;
 use App\Http\Controllers\Controller;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Crypt;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Http\Requests\UpsertContaBancariaRequest;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Strategies\CnabDirectStrategy;
-use Modules\RecurringBilling\Models\BoletoCredential;
 
 /**
  * Tela /financeiro/contas-bancarias.
  *
- * Lista accounts do business + complemento (fin_contas_bancarias) +
- * credenciais de gateway (rb_boleto_credentials). Permite configurar
- * dados de boleto e credenciais Inter/Asaas via Sheet.
+ * Lista accounts do business + complemento (fin_contas_bancarias) e permite
+ * configurar dados de boleto + beneficiário por conta. Credenciais API de
+ * gateway (Inter OAuth2/mTLS, Asaas token, C6 etc) vivem em
+ * /settings/payment-gateways desde 2026-05-19 (PR #1153/#1154) com FK canon
+ * payment_gateway_credentials.conta_bancaria_id.
  *
  * Pattern: ADR 0029 (Inertia + React + UPos).
  * Decisão schema: ADR TECH-0003, ADR ARQ-0008 (Asaas como conta virtual).
@@ -29,11 +29,11 @@ class ContaBancariaController extends Controller
 {
     use RendersMockCowork;
 
-    // Bancos que usam API de gateway (precisam de credenciais)
-    private const GATEWAY_BANKS = [
-        '077' => 'inter',
-        '274' => 'asaas',
-    ];
+    // Bancos gateway-only (sem CNAB tradicional). Asaas continua selecionável
+    // como conta destino aqui — a credencial é cadastrada em
+    // /settings/payment-gateways e referencia esta conta via FK
+    // payment_gateway_credentials.conta_bancaria_id.
+    private const GATEWAY_ONLY_BANKS = ['274'];
 
     public function index(Request $request): Response|\Illuminate\Http\Response
     {
@@ -46,7 +46,6 @@ class ContaBancariaController extends Controller
         $accounts = Account::where('accounts.business_id', $businessId)
             ->where('is_closed', 0)
             ->leftJoin('fin_contas_bancarias as cb', 'cb.account_id', '=', 'accounts.id')
-            ->leftJoin('rb_boleto_credentials as bc', 'bc.id', '=', 'cb.rb_gateway_credential_id')
             ->select([
                 'accounts.id',
                 'accounts.name',
@@ -69,35 +68,16 @@ class ContaBancariaController extends Controller
                 'cb.beneficiario_cep',
                 'cb.ativo_para_boleto',
                 'cb.tipo_conta',
-                'cb.rb_gateway_credential_id',
                 'cb.metadata',
-                // Dados públicos da credencial (sem segredos)
-                'bc.banco as gateway_banco',
-                'bc.ambiente as gateway_ambiente',
-                'bc.ativo as gateway_ativo',
-                'bc.config_json as gateway_config_json',
             ])
             ->orderBy('accounts.name')
             ->get()
             ->map(function ($a) {
-                // Extrai client_id do config_json (não-secreto) para pré-preencher form
-                $gatewayClientId = null;
-                if ($a->gateway_config_json) {
-                    $cfg = is_array($a->gateway_config_json)
-                        ? $a->gateway_config_json
-                        : json_decode($a->gateway_config_json, true);
-                    $gatewayClientId = $cfg['client_id'] ?? null;
-                }
-
                 // toArray(): converte Eloquent\Model corretamente em array plano.
                 // NÃO usar `(array) $a` aqui — PHP cast em Eloquent expõe propriedades protected
                 // com prefixo null-byte (`\x00*\x00attributes`...), quebra serialização Inertia
                 // (frontend recebe `Cc undefined` em vez do `name`).
-                $result = $a->toArray();
-                unset($result['gateway_config_json']); // nunca expõe segredos
-                $result['gateway_client_id'] = $gatewayClientId;
-
-                return $result;
+                return $a->toArray();
             });
 
         // array_values: força reindexação 0..N. Sem isso, Inertia serializa como
@@ -105,7 +85,7 @@ class ContaBancariaController extends Controller
         // com `bancos_suportados.join is not a function` (detectado 2026-05-10).
         $bancosSuportados = array_values(array_unique(array_merge(
             array_keys(CnabDirectStrategy::BANCO_MAP),
-            array_keys(self::GATEWAY_BANKS),
+            self::GATEWAY_ONLY_BANKS,
         )));
 
         return Inertia::render('Financeiro/ContasBancarias/Index', [
@@ -120,81 +100,18 @@ class ContaBancariaController extends Controller
 
         $account = Account::where('business_id', $businessId)->findOrFail($accountId);
 
-        // Campos do complemento fin_contas_bancarias
-        $complementoFields = $request->safe()->except([
-            'gateway_ambiente',
-            'gateway_client_id',
-            'gateway_client_secret',
-            'gateway_certificado_crt',
-            'gateway_certificado_key',
-            'gateway_api_key',
-        ]);
+        $complementoFields = $request->validated();
 
-        // Para Asaas (274) — conta virtual PJ
-        $bancoCodigo = $request->input('banco_codigo');
-        if ($bancoCodigo === '274') {
+        // Asaas (274) — conta virtual PJ
+        if (($request->input('banco_codigo')) === '274') {
             $complementoFields['tipo_conta'] = 'virtual_pj';
         }
 
-        $conta = ContaBancaria::updateOrCreate(
+        ContaBancaria::updateOrCreate(
             ['account_id' => $account->id],
-            $complementoFields->toArray() + ['business_id' => $businessId]
+            $complementoFields + ['business_id' => $businessId]
         );
 
-        // Salva credenciais de gateway quando banco usa API
-        if (isset(self::GATEWAY_BANKS[$bancoCodigo])) {
-            $this->saveGatewayCredential($request, $businessId, $conta, self::GATEWAY_BANKS[$bancoCodigo]);
-        }
-
         return back()->with('success', 'Boleto configurado com sucesso.');
-    }
-
-    private function saveGatewayCredential(
-        UpsertContaBancariaRequest $request,
-        int $businessId,
-        ContaBancaria $conta,
-        string $banco,
-    ): void {
-        $credencial = BoletoCredential::firstOrNew([
-            'business_id' => $businessId,
-            'banco'       => $banco,
-        ]);
-
-        $credencial->conta_bancaria_id = $conta->id;
-        $credencial->ambiente = $request->input('gateway_ambiente', $credencial->ambiente ?? 'production');
-        $credencial->ativo    = true;
-
-        $config = $credencial->config_json ?? [];
-
-        if ($banco === 'inter') {
-            if ($v = $request->input('gateway_client_id')) {
-                $config['client_id'] = $v;
-            }
-            if ($v = $request->input('gateway_client_secret')) {
-                $config['client_secret'] = Crypt::encryptString($v);
-            }
-            if ($v = $request->input('gateway_certificado_crt')) {
-                // Cert público — base64 puro (não-sensível)
-                $config['certificado_crt_b64'] = base64_encode($v);
-            }
-            if ($v = $request->input('gateway_certificado_key')) {
-                // Chave privada — criptografa o base64 (BoletoService::decryptConfig
-                // descriptografa antes de o driver fazer base64_decode)
-                $config['certificado_key_b64'] = Crypt::encryptString(base64_encode($v));
-            }
-        }
-
-        if ($banco === 'asaas') {
-            if ($v = $request->input('gateway_api_key')) {
-                $config['api_key'] = Crypt::encryptString($v);
-            }
-        }
-
-        $credencial->config_json = $config;
-        $credencial->save();
-
-        // Garante o FK inverso em fin_contas_bancarias
-        $conta->rb_gateway_credential_id = $credencial->id;
-        $conta->saveQuietly();
     }
 }

--- a/Modules/Financeiro/Http/Requests/UpsertContaBancariaRequest.php
+++ b/Modules/Financeiro/Http/Requests/UpsertContaBancariaRequest.php
@@ -45,14 +45,10 @@ class UpsertContaBancariaRequest extends FormRequest
             'ativo_para_boleto' => ['boolean'],
             'metadata'          => ['nullable', 'array'],
 
-            // Credenciais de gateway (Inter / Asaas) — todos nullable no request;
-            // o controller decide o que salvar
-            'gateway_ambiente'         => ['nullable', 'string', 'in:production,sandbox'],
-            'gateway_client_id'        => ['nullable', 'string', 'max:200'],
-            'gateway_client_secret'    => ['nullable', 'string', 'max:500'],
-            'gateway_certificado_crt'  => ['nullable', 'string'],
-            'gateway_certificado_key'  => ['nullable', 'string'],
-            'gateway_api_key'          => ['nullable', 'string', 'max:200'],
+            // Credenciais API (Inter OAuth2/mTLS, Asaas token, C6 etc) viviam
+            // aqui até 2026-05-19; migraram pra /settings/payment-gateways com
+            // FK canon payment_gateway_credentials.conta_bancaria_id
+            // (PR #1153/#1154 + ADR 0170).
         ];
     }
 }

--- a/resources/js/Pages/Financeiro/ContasBancarias/Index.charter.md
+++ b/resources/js/Pages/Financeiro/ContasBancarias/Index.charter.md
@@ -3,44 +3,46 @@ page: /financeiro/contas-bancarias
 component: resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-07
+last_validated: 2026-05-19
 parent_module: Financeiro
 parent_capterra: memory/requisitos/Financeiro/CAPTERRA-FICHA.md
-related_adrs: [0101]
+related_adrs: [0101, 0144, 0170]
 tier: A
-charter_version: 1
+charter_version: 2
 ---
 
-# Page Charter — /financeiro/contas-bancarias (stub F1)
+# Page Charter — /financeiro/contas-bancarias
 
-> **Status:** stub estruturado em F1. Detalhamento (testes reais sobre gateway flows) entra em F1.5/F2.
+> **Status:** live. v2 (2026-05-19) — credenciais API saíram daqui pra `/settings/payment-gateways` (PR #1153/#1154 + ADR 0170). Esta tela passa a cuidar SÓ de dados bancários + beneficiário pra boleto CNAB direto.
 
 ---
 
 ## Mission
 
-Listar contas bancárias do business + permitir configurar dados de boleto e gateway (Inter/Asaas) por conta.
+Listar contas bancárias do business + permitir configurar dados pra emissão de boleto (banco, agência, carteira, beneficiário) por conta. Credenciais de gateway (Inter, Asaas, C6 etc) NÃO ficam aqui — vivem em `/settings/payment-gateways` e referenciam a conta via FK `payment_gateway_credentials.conta_bancaria_id`.
 
 ---
 
 ## Goals — Features (faz)
 
 - Listar accounts com beneficiário + carteira + status
-- StatusBadge contextual: "Faltam dados" | "Inativo" | "Inter API · sandbox" | "Ativo · Cart. X"
-- Sheet "Configurar boleto" pra editar conta selecionada (`ConfigurarBoletoSheet`)
-- Suporte a 2 gateways: Inter API + Asaas
-- Distingue ambiente sandbox vs prod visualmente
+- StatusBadge contextual: "Faltam dados" | "Inativo" | "Ativo · Cart. X"
+- Sheet "Configurar boleto" pra editar dados bancários da conta (`ConfigurarBoletoSheet`)
+- Suporta bancos CNAB tradicionais (BB, Caixa, Sicoob, Inter etc) + conta virtual PJ (Asaas)
+- Link rápido pro cadastro de credenciais em `/settings/payment-gateways`
 - Multi-tenant: `business_id` global scope
 
 ---
 
 ## Non-Goals — Features (NÃO faz)
 
+- ❌ Cadastrar/editar credencial API de gateway (vai em `/settings/payment-gateways`)
+- ❌ Persistir `client_secret` / certificado mTLS / API token (foi removido em 2026-05-19; cofre vive em `payment_gateway_credentials`)
 - ❌ Criação de conta nova nesta tela (vem do flow de cadastro UltimatePOS)
 - ❌ Sincronizar saldo direto desta tela (`/financeiro/extrato/{id}` faz)
-- ❌ Emitir boleto avulso aqui (vai pra outras telas do RB)
+- ❌ Emitir boleto avulso aqui (vai pra outras telas do RB/Cobrança)
 - ❌ Configurar webhook (admin separado)
-- ❌ Trocar credencial gateway sem retest sandbox primeiro
+- ❌ Teste de conectividade gateway (botão "Testar" fica em Settings)
 
 ---
 
@@ -49,9 +51,9 @@ Listar contas bancárias do business + permitir configurar dados de boleto e gat
 - p95 first-paint < 1000ms
 - 0 erros JS console
 - Cabe em 1280px sem scroll horizontal
-- StatusBadge usa cores semânticas (amber=warning, emerald=ok, blue=sandbox)
+- StatusBadge usa cores semânticas (amber=warning, emerald=ok)
 - Sheet `ConfigurarBoletoSheet` carrega <300ms
-- Sandbox claramente diferenciado de prod (não confundir)
+- Subtítulo deixa claro que credenciais vivem em outro lugar (link direto)
 
 ---
 
@@ -60,34 +62,34 @@ Listar contas bancárias do business + permitir configurar dados de boleto e gat
 - ❌ Confirmação dupla pra abrir Sheet (low-risk, 1 click suficiente)
 - ❌ Modal sobre Sheet (anti-stack)
 - ❌ Status text-only (sempre badge com cor)
-- ❌ Sandbox e prod com mesma cor
+- ❌ Mostrar nome do gateway aqui (info pertence a `/settings/payment-gateways`)
 
 ---
 
 ## Automation Hooks
 
-- Endpoint controller carrega accounts + bancos_suportados
-- `ConfigurarBoletoSheet` faz PATCH em `/financeiro/contas-bancarias/{id}`
+- Endpoint controller carrega accounts + bancos_suportados (CNAB BANCO_MAP + Asaas 274)
+- `ConfigurarBoletoSheet` faz POST em `/financeiro/contas-bancarias/{id}` (upsert)
 - Validação dados beneficiário no save (CEP, UF, etc)
 
 ---
 
 ## Automation Anti-hooks
 
-- ❌ Não dispara teste de credencial gateway no abrir (custa requisição externa)
+- ❌ Não dispara teste de credencial gateway no abrir (gateway vive em `/settings/payment-gateways`)
 - ❌ Não emite boletos ao salvar (config-only)
 - ❌ Não acessa contas de outro `business_id`
-- ❌ Não persiste credencial em plain text (gateway_credential_id é FK pra cofre)
+- ❌ Não persiste credencial em plain text (responsabilidade movida pra módulo PaymentGateway)
+- ❌ Não chama driver Inter/Asaas/C6 daqui
 
 ---
 
-## Métricas vivas (Pest GUARD — completar em F1.5)
+## Métricas vivas (Pest GUARD)
 
-- `FinanceiroContasBancariasCharterTest::it_does_not_call_gateway_on_render()` (stub)
-- `FinanceiroContasBancariasCharterTest::it_isolates_by_business_id()` (stub)
-- `FinanceiroContasBancariasCharterTest::it_does_not_persist_credential_plaintext()` (stub)
-- `FinanceiroContasBancariasCharterTest::it_distinguishes_sandbox_from_prod_visually()` (stub)
-- TODO F1.5: testes integrados no flow do Sheet de Boleto
+- `FinanceiroContasBancariasCharterTest::it_isolates_by_business_id()` — Tier 0
+- `FinanceiroContasBancariasCharterTest::it_does_not_persist_credential_plaintext()` — após 2026-05-19, validar que request sem campos `gateway_*` ainda salva fin_contas_bancarias
+- `FinanceiroContasBancariasCharterTest::it_does_not_render_credentials_section()` — snapshot do Sheet
+- TODO F1.5: testes integrados upsert + reverse-lookup PaymentGatewayCredential pela conta
 
 ---
 
@@ -96,3 +98,4 @@ Listar contas bancárias do business + permitir configurar dados de boleto e gat
 | Data | Autor | Mudança |
 |---|---|---|
 | 2026-05-07 | Opus + Wagner | Stub criado em S6 F1. Detalhamento Pest GUARD pendente F1.5. |
+| 2026-05-19 | Opus + Wagner | v2 — removidos campos gateway_* (credencial API). PaymentGateway extraído (ADR 0170). FK canon agora é `payment_gateway_credentials.conta_bancaria_id` (PR #1154). Tela passa a ser CNAB-only + beneficiário. |

--- a/resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
@@ -4,7 +4,7 @@ import AppShellV2 from '@/Layouts/AppShellV2';
 import { useState } from 'react';
 import { Button } from '@/Components/ui/button';
 import { Card, CardContent } from '@/Components/ui/card';
-import { Settings, Plus, AlertTriangle, CheckCircle2, MinusCircle, Wifi } from 'lucide-react';
+import { Settings, Plus, AlertTriangle, CheckCircle2, MinusCircle } from 'lucide-react';
 import { ConfigurarBoletoSheet } from './components/ConfigurarBoletoSheet';
 
 interface Account {
@@ -29,11 +29,6 @@ interface Account {
   beneficiario_cep: string | null;
   ativo_para_boleto: boolean | null;
   tipo_conta: string | null;
-  rb_gateway_credential_id: number | null;
-  gateway_banco: string | null;
-  gateway_ambiente: string | null;
-  gateway_ativo: boolean | null;
-  gateway_client_id: string | null;
   metadata: Record<string, unknown> | null;
 }
 
@@ -41,8 +36,6 @@ interface Props {
   accounts: Account[];
   bancos_suportados: string[];
 }
-
-const GATEWAY_LABEL: Record<string, string> = { inter: 'Inter API', asaas: 'Asaas' };
 
 function StatusBadge({ account }: { account: Account }) {
   if (!account.complemento_id) {
@@ -59,18 +52,9 @@ function StatusBadge({ account }: { account: Account }) {
       </span>
     );
   }
-  if (account.gateway_banco) {
-    const label = GATEWAY_LABEL[account.gateway_banco] ?? account.gateway_banco;
-    const isSandbox = account.gateway_ambiente === 'sandbox';
-    return (
-      <span className={`inline-flex items-center gap-1 text-xs px-2 py-1 rounded ${isSandbox ? 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-300' : 'bg-emerald-100 text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200'}`}>
-        <Wifi className="h-3 w-3" /> {label}{isSandbox ? ' · sandbox' : ''}
-      </span>
-    );
-  }
   return (
     <span className="inline-flex items-center gap-1 text-xs px-2 py-1 rounded bg-emerald-100 text-emerald-900 dark:bg-emerald-900/30 dark:text-emerald-200">
-      <CheckCircle2 className="h-3 w-3" /> Ativo · Cart. {account.carteira}
+      <CheckCircle2 className="h-3 w-3" /> Ativo{account.carteira ? ` · Cart. ${account.carteira}` : ''}
     </span>
   );
 }
@@ -85,15 +69,24 @@ function Index({ accounts, bancos_suportados }: Props) {
           <div>
             <h1 className="text-2xl font-semibold tracking-tight">Contas Bancárias</h1>
             <p className="text-sm text-muted-foreground mt-1">
-              Configure os dados específicos para emissão de boleto.
-              Cadastro principal da conta continua no menu &quot;Contas de pagamento&quot; do POS.
+              Dados pra emissão de boleto (banco, agência, beneficiário). Cadastro
+              principal da conta continua em &quot;Contas de pagamento&quot; do POS;
+              credenciais API (Inter, Asaas, C6) ficam em{' '}
+              <a href="/settings/payment-gateways" className="underline underline-offset-2 hover:text-foreground">
+                Gateways de Pagamento
+              </a>.
             </p>
           </div>
-          <Button asChild variant="outline">
-            <a href="/account/account/create">
-              <Plus className="h-4 w-4 mr-2" /> Nova conta no POS
-            </a>
-          </Button>
+          <div className="flex gap-2">
+            <Button asChild variant="ghost">
+              <a href="/settings/payment-gateways">Gateways</a>
+            </Button>
+            <Button asChild variant="outline">
+              <a href="/account/account/create">
+                <Plus className="h-4 w-4 mr-2" /> Nova conta no POS
+              </a>
+            </Button>
+          </div>
         </div>
 
         <div className="rounded-md border">

--- a/resources/js/Pages/Financeiro/ContasBancarias/components/ConfigurarBoletoSheet.tsx
+++ b/resources/js/Pages/Financeiro/ContasBancarias/components/ConfigurarBoletoSheet.tsx
@@ -6,10 +6,8 @@ import { Input } from '@/Components/ui/input';
 import { Label } from '@/Components/ui/label';
 import { Switch } from '@/Components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
-import { Textarea } from '@/Components/ui/textarea';
-import { Badge } from '@/Components/ui/badge';
 import { toast } from 'sonner';
-import { Building2, KeyRound, Landmark, Wifi } from 'lucide-react';
+import { Building2, Landmark } from 'lucide-react';
 
 interface Account {
   id: number;
@@ -31,10 +29,6 @@ interface Account {
   beneficiario_cep: string | null;
   ativo_para_boleto: boolean | null;
   tipo_conta: string | null;
-  gateway_banco: string | null;
-  gateway_ambiente: string | null;
-  gateway_ativo: boolean | null;
-  gateway_client_id: string | null;
 }
 
 interface Props {
@@ -68,8 +62,10 @@ const BANCO_NOMES: Record<string, string> = {
   '756': 'Sicoob (Bancoob)',
 };
 
-const GATEWAY_BANKS = ['077', '274'];
-const GATEWAY_ONLY  = ['274']; // sem agência/carteira/CNAB
+// Bancos gateway-only (sem agência/carteira/CNAB). Credenciais API
+// (Inter / Asaas / C6 etc) vivem em /settings/payment-gateways — esta tela
+// cuida só dos dados pra emissão de boleto CNAB direto + beneficiário.
+const GATEWAY_ONLY = ['274'];
 
 // Asterisco vermelho dedicado pra campos obrigatórios. aria-hidden pq o
 // input usa aria-required (a11y via attribute, não texto do label).
@@ -119,19 +115,9 @@ export function ConfigurarBoletoSheet({ account, bancosSuportados, onClose }: Pr
     beneficiario_cep: account.beneficiario_cep ?? '',
     ativo_para_boleto: account.ativo_para_boleto ?? true,
     metadata: {} as Record<string, string>,
-    gateway_ambiente: (account.gateway_ambiente ?? 'production') as 'production' | 'sandbox',
-    gateway_client_id: account.gateway_client_id ?? '',
-    gateway_client_secret: '',
-    gateway_certificado_crt: '',
-    gateway_certificado_key: '',
-    gateway_api_key: '',
   });
 
-  const isGatewayBank = GATEWAY_BANKS.includes(form.data.banco_codigo);
   const isGatewayOnly = GATEWAY_ONLY.includes(form.data.banco_codigo);
-  const isInter = form.data.banco_codigo === '077';
-  const isAsaas = form.data.banco_codigo === '274';
-  const hasExistingCredential = Boolean(account.gateway_banco);
 
   const submit = (e: FormEvent) => {
     e.preventDefault();
@@ -353,134 +339,9 @@ export function ConfigurarBoletoSheet({ account, bancosSuportados, onClose }: Pr
             </div>
           </div>
 
-          {/* Credenciais API — gateway banks (Inter 077 / Asaas 274) */}
-          {isGatewayBank && (
-            <div className="border-t pt-5 space-y-4">
-              <SectionHeader
-                icon={KeyRound}
-                title="Credenciais API"
-                eyebrow={isInter ? 'OAuth2 + mTLS' : 'token API'}
-                action={
-                  hasExistingCredential && (
-                    <Badge variant="outline" className="border-emerald-500/30 text-emerald-700 dark:text-emerald-300 gap-1">
-                      <Wifi className="h-3 w-3" /> Configurado
-                    </Badge>
-                  )
-                }
-              />
-
-              <div>
-                <Label htmlFor="gateway_ambiente">Ambiente</Label>
-                <Select
-                  value={form.data.gateway_ambiente}
-                  onValueChange={(v) => form.setData('gateway_ambiente', v as 'production' | 'sandbox')}
-                >
-                  <SelectTrigger id="gateway_ambiente">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="sandbox">Sandbox (testes)</SelectItem>
-                    <SelectItem value="production">Produção</SelectItem>
-                  </SelectContent>
-                </Select>
-                <p className="text-[13px] text-muted-foreground mt-1.5 leading-relaxed">
-                  Comece em Sandbox pra validar o fluxo; troque pra Produção depois do primeiro boleto OK.
-                </p>
-              </div>
-
-              {isInter && (
-                <>
-                  <div className="grid grid-cols-2 gap-4">
-                    <div>
-                      <Label htmlFor="gateway_client_id">Client ID</Label>
-                      <Input
-                        id="gateway_client_id"
-                        value={form.data.gateway_client_id}
-                        onChange={(e) => form.setData('gateway_client_id', e.target.value)}
-                        placeholder="ex: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-                        className="font-mono text-[13px]"
-                      />
-                    </div>
-                    <div>
-                      <Label htmlFor="gateway_client_secret">
-                        Client Secret
-                        {hasExistingCredential && (
-                          <span className="text-muted-foreground font-normal ml-1">(deixe em branco para manter)</span>
-                        )}
-                      </Label>
-                      <Input
-                        id="gateway_client_secret"
-                        type="password"
-                        value={form.data.gateway_client_secret}
-                        onChange={(e) => form.setData('gateway_client_secret', e.target.value)}
-                        placeholder={hasExistingCredential ? '••••••••' : 'client_secret'}
-                        autoComplete="new-password"
-                      />
-                    </div>
-                  </div>
-
-                  <div>
-                    <Label htmlFor="gateway_certificado_crt">
-                      Certificado mTLS (.crt — PEM)
-                      {hasExistingCredential && (
-                        <span className="text-muted-foreground font-normal ml-1">(deixe em branco para manter)</span>
-                      )}
-                    </Label>
-                    <Textarea
-                      id="gateway_certificado_crt"
-                      rows={5}
-                      value={form.data.gateway_certificado_crt}
-                      onChange={(e) => form.setData('gateway_certificado_crt', e.target.value)}
-                      placeholder="-----BEGIN CERTIFICATE-----&#10;...&#10;-----END CERTIFICATE-----"
-                      className="font-mono text-[12px]"
-                    />
-                    <p className="text-[13px] text-muted-foreground mt-1.5 leading-relaxed">
-                      Certificado emitido pelo Banco Inter pra autenticação OAuth2 mTLS.
-                    </p>
-                  </div>
-
-                  <div>
-                    <Label htmlFor="gateway_certificado_key">
-                      Chave privada (.key — PEM)
-                      {hasExistingCredential && (
-                        <span className="text-muted-foreground font-normal ml-1">(deixe em branco para manter)</span>
-                      )}
-                    </Label>
-                    <Textarea
-                      id="gateway_certificado_key"
-                      rows={5}
-                      value={form.data.gateway_certificado_key}
-                      onChange={(e) => form.setData('gateway_certificado_key', e.target.value)}
-                      placeholder="-----BEGIN PRIVATE KEY-----&#10;...&#10;-----END PRIVATE KEY-----"
-                      className="font-mono text-[12px]"
-                    />
-                  </div>
-                </>
-              )}
-
-              {isAsaas && (
-                <div>
-                  <Label htmlFor="gateway_api_key">
-                    API Key
-                    {hasExistingCredential && (
-                      <span className="text-muted-foreground font-normal ml-1">(deixe em branco para manter)</span>
-                    )}
-                  </Label>
-                  <Input
-                    id="gateway_api_key"
-                    type="password"
-                    value={form.data.gateway_api_key}
-                    onChange={(e) => form.setData('gateway_api_key', e.target.value)}
-                    placeholder={hasExistingCredential ? '••••••••' : '$aact_...'}
-                    autoComplete="new-password"
-                  />
-                  <p className="text-[13px] text-muted-foreground mt-1.5 leading-relaxed">
-                    Token API gerado em sua conta Asaas → Configurações → Integrações.
-                  </p>
-                </div>
-              )}
-            </div>
-          )}
+          {/* Credenciais API (Inter OAuth2 + mTLS · Asaas token · etc) vivem em
+              /settings/payment-gateways desde 2026-05-19 (PR #1153/#1154).
+              Esta tela cuida só dos dados de boleto + beneficiário. */}
 
           {/* Toggle ativo — card destacado sem border duplicada (bg + radius bastam) */}
           <div className="border-t pt-5">

--- a/resources/js/Pages/Financeiro/ContasBancarias/components/ConfigurarBoletoSheet.tsx
+++ b/resources/js/Pages/Financeiro/ContasBancarias/components/ConfigurarBoletoSheet.tsx
@@ -266,7 +266,7 @@ export function ConfigurarBoletoSheet({ account, bancosSuportados, onClose }: Pr
                 <Input
                   id="beneficiario_documento"
                   aria-required="true"
-                  placeholder="12.345.678/0001-99"
+                  placeholder="XX.XXX.XXX/XXXX-XX"
                   value={form.data.beneficiario_documento}
                   onChange={(e) => form.setData('beneficiario_documento', e.target.value)}
                 />


### PR DESCRIPTION
## Summary

Cadastro de Contas Bancárias (`/financeiro/contas-bancarias`) passa a cuidar **só de dados pra emissão de boleto CNAB direto + beneficiário**. Credenciais API (Inter OAuth2/mTLS, Asaas token, C6 etc) já vivem em `/settings/payment-gateways` desde 2026-05-19 ([#1153](https://github.com/wagnerra23/oimpresso.com/pull/1153) + [#1154](https://github.com/wagnerra23/oimpresso.com/pull/1154) + ADR 0170) com FK canon `payment_gateway_credentials.conta_bancaria_id` (invertida — credencial referencia conta destino).

## Wagner — palavras textuais

> "arrume o cadastro de contas bancarias, acho que não vai ter mais os dados — Credenciais API · OAuth2 + mTLS · Produção · client_secret · -----BEGIN CERTIFICATE----- · -----BEGIN PRIVATE KEY-----"

## Mudanças (5 arquivos · -240 linhas líquidas)

| Arquivo | Mudança |
|---|---|
| `resources/js/Pages/Financeiro/ContasBancarias/components/ConfigurarBoletoSheet.tsx` | Remove seção "Credenciais API" inteira + 6 form fields `gateway_*` + imports Textarea/Badge/KeyRound/Wifi + state `hasExistingCredential`/`isInter`/`isAsaas`/`isGatewayBank` |
| `resources/js/Pages/Financeiro/ContasBancarias/Index.tsx` | Limpa 5 props gateway_* da interface Account; `StatusBadge` sem "Inter API · sandbox/produção"; remove `GATEWAY_LABEL`/`Wifi`; novo link rápido pra Settings → Gateways no header |
| `Modules/Financeiro/Http/Controllers/ContaBancariaController.php` | Remove `leftJoin('rb_boleto_credentials')` + select `bc.*` + map `gateway_config_json` + `saveGatewayCredential()` inteiro + imports `Crypt`/`BoletoCredential`. Upsert simplificado |
| `Modules/Financeiro/Http/Requests/UpsertContaBancariaRequest.php` | Remove 6 regras `gateway_*` |
| `resources/js/Pages/Financeiro/ContasBancarias/Index.charter.md` | v2 — Mission/Goals/Non-Goals refletem nova divisão (Contas = CNAB; Settings = credenciais) |

## Comportamento depois

| Antes | Depois |
|---|---|
| Sheet "Configurar boleto" pedia Client ID + Client Secret + cert .crt + chave .key (Inter) ou API Key (Asaas) | Sheet só pede banco, agência, carteira, beneficiário |
| StatusBadge mostrava "Inter API · sandbox" (vermelho/azul) | StatusBadge só "Faltam dados / Inativo / Ativo · Cart. X" |
| Controller persistia em `rb_boleto_credentials` (criptografando secret/cert/key) | Controller persiste só em `fin_contas_bancarias` |
| Credenciais espalhadas (2 telas) | Credenciais 1 lugar (`/settings/payment-gateways`) |

## Schema/legacy preservado

- Coluna `fin_contas_bancarias.rb_gateway_credential_id` segue na tabela (legacy `BoletoService` antigo do RecurringBilling). Limpeza schema/Model é PR separada (fora do escopo: Wagner pediu "arrumar o cadastro", não refactor de schema).
- Model `Modules/Financeiro/Models/ContaBancaria.php` mantém `fillable` + relation `gatewayCredential()` pra não quebrar BoletoService legado em cobranças antigas.

## Tier 0 preservado

- ✅ Multi-tenant: `Account::where('accounts.business_id', $businessId)` + `BusinessScope` no Model `ContaBancaria` (ADR 0093)
- ✅ Append-only audit `LogsActivity` em `ContaBancaria` continua logando mudanças
- ✅ Asaas (274) mantido no select como banco virtual-PJ (calibrado com Wagner antes da execução)
- ✅ PT-BR em todo conteúdo

## Test plan

- [ ] CI roda Pest verde (Pest local não rodou nesta sessão — vendor/ principal vazio, pegadinha junction Windows; CI cobre)
- [ ] `tests/Feature/Modules/Financeiro/UpsertContaBancariaRequestTest.php` (3 testes — rules nunca testaram gateway_*, deve passar verde)
- [ ] `tests/Feature/Modules/Financeiro/ContaBancariaIndexTest.php` (2 testes — 200 + shape; deve passar verde)
- [ ] Smoke manual pós-merge (Wagner em prod): abrir `/financeiro/contas-bancarias` → editar 1 conta Inter → ver sheet só com banco/agência/beneficiário (sem KeyRound/textarea cert)
- [ ] Smoke regressão: `/settings/payment-gateways` continua mostrando gateways cadastrados

## Refs

- ADR 0170 (PaymentGateway módulo extraído)
- ADR 0144 (PaymentGateway canon)
- ADR 0093 (Multi-tenant Tier 0)
- PR #1153 (endpoint store credencial + wizard SheetNovoGateway)
- PR #1154 (FK canon `payment_gateway_credentials.conta_bancaria_id`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)