### PR TITLE
refine(financeiro/unificado): chip h1 + filtros pills coloridos sempre (Onda 12.1)

### DIFF
--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -30,10 +30,15 @@
   color: var(--fin-text);
   letter-spacing: -0.01em;
 }
+/* Onda 12 refine — chip "Visão unificada" estilo canon REAL (text-stone-500
+   discreto e menor que h1, não 19px que dominava visualmente). */
 .fin-cowork .fin-curadoria .fin-page-h-l .fin-hero-title-sub {
   font-weight: 400;
   color: var(--fin-text-mute);
-  font-size: 19px;
+  font-size: 13.5px;
+  margin-left: 6px;
+  letter-spacing: 0;
+  vertical-align: middle;
 }
 .fin-cowork .fin-curadoria .fin-page-h-l p {
   margin: 2px 0 0;
@@ -201,7 +206,10 @@
   padding: 3px 8px;
   height: 24px;
   border-radius: 99px;
-  border: 1px solid var(--fin-line);
+  /* Onda 12 refine — borda semântica com hue mesmo OFF (paridade canon REAL:
+     pill colorido fica visualmente identificável mesmo desligado, ajuda
+     scan rápido do user). */
+  border: 1px solid oklch(0.92 0.04 var(--cb-hue, 240));
   background: white;
   font-size: 11.5px;
   font-weight: 500;
@@ -211,13 +219,17 @@
   user-select: none;
   --cb-hue: 240;
 }
-.fin-cowork .fin-curadoria .fin-filter-cb:hover { background: var(--fin-bg-soft); }
+.fin-cowork .fin-curadoria .fin-filter-cb:hover {
+  background: oklch(0.98 0.02 var(--cb-hue, 240));
+  border-color: oklch(0.85 0.08 var(--cb-hue, 240));
+}
 .fin-cowork .fin-curadoria .fin-filter-cb input { display: none; }
 .fin-cowork .fin-curadoria .fin-filter-cb-box {
   width: 12px;
   height: 12px;
   border-radius: 3px;
-  border: 1.5px solid var(--fin-line);
+  /* Onda 12 refine — checkbox box também com hue */
+  border: 1.5px solid oklch(0.78 0.06 var(--cb-hue, 240));
   background: white;
   flex-shrink: 0;
 }

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -643,7 +643,9 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
               <label
                 key={lc.id}
                 className={'fin-filter-cb' + (on ? ' on' : '')}
-                style={on ? ({ ['--cb-hue' as string]: lc.hue } as React.CSSProperties) : undefined}
+                // Onda 12 refine — hue SEMPRE setada (mesmo OFF) pra borda semântica
+                // persistir (paridade canon REAL: pills coloridos mesmo desligados).
+                style={{ ['--cb-hue' as string]: lc.hue } as React.CSSProperties}
               >
                 <input
                   type="checkbox"
@@ -653,7 +655,8 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
                 />
                 <span className="fin-filter-cb-box" />
                 <span>{lc.label}</span>
-                {count > 0 && <span className="fin-filter-ct">{count}</span>}
+                {/* Onda 12 refine — count sempre visível (paridade canon: mostra 0 também). */}
+                <span className="fin-filter-ct">{count}</span>
               </label>
             );
           })}


### PR DESCRIPTION
Complemento do PR #1158 (paridade 100% Onda 12). Wagner pediu refinamentos pequenos:

1. Chip 'Visão unificada': 19px → 13.5px (discreto como canon)
2. Filtros lifecycle: `--cb-hue` sempre setada → bordas semânticas mesmo OFF
3. Counts: mostra `0` em vez de esconder (paridade canon REAL)

+22/-9 em 2 arquivos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)