### PR TITLE
fix(financeiro/unificado): classes os-btn ghost + hues exatos + KPI hero warm dark (Onda 12.2)

### DIFF
--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -86,13 +86,20 @@
   border: 1px solid var(--fin-line);
   margin-left: 4px;
 }
-/* Onda Polish 2026-05-18 — hues corrigidos conforme gap analysis Wagner:
-   - ai (✦ Resumir mês)  → roxo  oklch 280 (IA accent)
-   - trilha (☑ Fechamento) → verde-floresta oklch 145 (trilha persistente, antes 240 azul ❌)
-   - present (▶ Apresentar) → azul oklch 240 (read-only mode, antes 145 verde ❌) */
-.fin-cowork .fin-curadoria .fin-btn-ai { color: oklch(0.42 0.18 280); }
-.fin-cowork .fin-curadoria .fin-btn-trilha { color: oklch(0.42 0.18 145); }
-.fin-cowork .fin-curadoria .fin-btn-present { color: oklch(0.40 0.13 240); }
+/* Onda 12.2 (2026-05-19) — hues corrigidos pra match exato canon REAL
+   (DOM forensics: oklch(0.42 0.13 295/145/240) — chroma 0.13 não 0.18,
+   ai hue 295 não 280, trilha hue 145, present hue 240):
+   - ai (✦ Resumir mês)  → roxo  oklch 295 chroma 0.13 (era 280 0.18)
+   - trilha (☑ Fechamento) → verde oklch 145 chroma 0.13 (era 0.18)
+   - present (▶ Apresentar) → azul oklch 240 chroma 0.13 */
+.fin-cowork .fin-curadoria .fin-btn-ai { color: oklch(0.42 0.13 295); }
+.fin-cowork .fin-curadoria .fin-btn-trilha { color: oklch(0.42 0.13 145); }
+.fin-cowork .fin-curadoria .fin-btn-present { color: oklch(0.42 0.13 240); }
+/* Aplica também quando usado em .os-btn ghost (Onda 12.2 markup mudou pra
+   .os-btn ghost fin-btn-ai/trilha/present pra paridade canon). */
+.fin-cowork .fin-curadoria .os-btn.ghost.fin-btn-ai { color: oklch(0.42 0.13 295); }
+.fin-cowork .fin-curadoria .os-btn.ghost.fin-btn-trilha { color: oklch(0.42 0.13 145); }
+.fin-cowork .fin-curadoria .os-btn.ghost.fin-btn-present { color: oklch(0.42 0.13 240); }
 /* Onda 7c — badge inline no botão (ex: "📄 Imprimir 3★") */
 .fin-cowork .fin-curadoria .fin-btn-badge {
   display: inline-flex;
@@ -146,19 +153,20 @@
 }
 .fin-cowork .fin-curadoria .fin-num-pos { color: oklch(0.45 0.18 145); }
 .fin-cowork .fin-curadoria .fin-num-neg { color: oklch(0.50 0.18 25); }
-/* Onda 12 (2026-05-19) — KPI hero card DARK (paridade canon REAL).
-   Canon /cowork-preview/Oimpresso ERP - Chat.html tem card preto puro
-   com sparkline em fundo, não gradient verde. */
+/* Onda 12.2 (2026-05-19) — KPI hero "warm dark" (paridade EXATA canon REAL).
+   DOM forensics canon: oklch(0.22 0.01 80) — marrom/bege escuro warm com
+   leve chroma, dá tom "documento contábil tradicional" suave, não preto puro.
+   Wagner: "sombreamento" = essa tonalidade quente discreta. */
 .fin-cowork .fin-curadoria .fin-stat-hero {
   position: relative;
-  background: oklch(0.16 0.005 240);
+  background: oklch(0.22 0.01 80);
   color: white;
   border: 0;
   overflow: hidden;
 }
-.fin-cowork .fin-curadoria .fin-stat-hero small { color: oklch(0.75 0.005 240); opacity: 0.95; font-weight: 600; }
+.fin-cowork .fin-curadoria .fin-stat-hero small { color: oklch(0.75 0.01 80); opacity: 0.95; font-weight: 600; }
 .fin-cowork .fin-curadoria .fin-stat-hero b { color: white; font-size: 26px; }
-.fin-cowork .fin-curadoria .fin-stat-hero .fin-stat-hint { color: oklch(0.72 0.005 240); opacity: 0.85; }
+.fin-cowork .fin-curadoria .fin-stat-hero .fin-stat-hint { color: oklch(0.72 0.01 80); opacity: 0.85; }
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-num-neg { color: oklch(0.78 0.14 25); }
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-num-pos { color: oklch(0.78 0.14 145); }
 .fin-cowork .fin-curadoria .fin-spark {

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -545,14 +545,17 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
           <p>{periodLabel}{businessName ? ` · ${businessName}` : ''} · caixa unificado</p>
         </div>
         <div className="fin-page-h-r">
-          <button type="button" className="fin-btn" onClick={() => setPaletteOpen(true)}>
+          {/* Onda 12.2 — classes `os-btn ghost` (canon REAL: bg transparent, sem borda)
+              em vez de `fin-btn` (que tinha bg branco + borda visível, criando "cartões"
+              em vez de tabs/links discretos). DOM canon DOM forensics confirma. */}
+          <button type="button" className="os-btn ghost" onClick={() => setPaletteOpen(true)}>
             <Search size={13} />
             Buscar
             <kbd>⌘K</kbd>
           </button>
           <button
             type="button"
-            className="fin-btn fin-btn-ai"
+            className="os-btn ghost fin-btn-ai"
             title="Resumo executivo do mês (narrativa compute-based · Onda 9 v1)"
             onClick={() => setResumoOpen(true)}
           >
@@ -561,7 +564,7 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
           </button>
           <button
             type="button"
-            className="fin-btn fin-btn-trilha"
+            className="os-btn ghost fin-btn-trilha"
             onClick={() => setChecklistOpen(true)}
             title="Trilha de 12 passos do fechamento mensal"
           >
@@ -570,7 +573,7 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
           </button>
           <button
             type="button"
-            className="fin-btn fin-btn-present"
+            className="os-btn ghost fin-btn-present"
             title="Modo apresentação fullscreen (Esc fecha · 1/2/3 muda vista)"
             onClick={() => setPresentOpen(true)}
           >
@@ -579,7 +582,7 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
           </button>
           <button
             type="button"
-            className="fin-btn"
+            className="os-btn ghost"
             title={`Folha jurídica imprimível${favs.count > 0 ? ` · ${favs.count} favorito${favs.count === 1 ? '' : 's'}` : ''}`}
             onClick={() => { setTranscriptOnlyFavs(false); setTranscriptOpen(true); }}
           >
@@ -587,11 +590,11 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
             Imprimir
             {favs.count > 0 && <span className="fin-btn-badge">{favs.count}★</span>}
           </button>
-          <button type="button" className="fin-btn" onClick={() => router.visit('/financeiro/extrato')}>
+          <button type="button" className="os-btn ghost" onClick={() => router.visit('/financeiro/extrato')}>
             <RefreshCw size={13} />
             Conciliar
           </button>
-          <button type="button" className="fin-btn" onClick={() => router.visit('/financeiro/plano-contas')} title="Plano de contas — categorias contábeis">
+          <button type="button" className="os-btn ghost" onClick={() => router.visit('/financeiro/plano-contas')} title="Plano de contas — categorias contábeis">
             <FolderOpen size={13} />
             Plano de contas
           </button>
@@ -599,7 +602,7 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
               Onclick stub abre ⌘K palette por enquanto; handler real (Exportar XLSX/PDF) vira US futura. */}
           <button
             type="button"
-            className="fin-btn"
+            className="os-btn ghost"
             title="Exportar lançamentos do período (XLSX / PDF)"
             aria-label="Exportar"
             onClick={() => setPaletteOpen(true)}
@@ -607,7 +610,7 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
           >
             <Download size={13} />
           </button>
-          <button type="button" className="fin-btn primary" onClick={() => router.visit('/financeiro/unificado/novo')}>
+          <button type="button" className="os-btn primary" onClick={() => router.visit('/financeiro/unificado/novo')}>
             <Plus size={13} />
             Novo lançamento
           </button>


### PR DESCRIPTION
Wagner comparou tags React vs canon REAL ([cowork-preview/Oimpresso ERP - Chat.html](https://oimpresso.com/cowork-preview/Oimpresso%20ERP%20-%20Chat.html)) e encontrou 3 divergências críticas:

1. **Botões `fin-btn` → `os-btn ghost`** — bg branco + borda criavam 'cartões' em vez de 'tabs/links'. Canon usa transparente.
2. **Hues exatos**: ai 280→**295**, chromas 0.18→**0.13** (DOM forensics canon)
3. **KPI hero warm dark**: `oklch(0.22 0.01 80)` (hue 80 warm) em vez de `oklch(0.16 0.005 240)` (preto cool)

+33/-22 em 2 arquivos. Zero novo erro TS. `os-btn` class já existe em `cowork-financeiro-bundle.css` (sem cherry-pick novo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)