### PR TITLE
feat(financeiro/unificado): bundle copy canon CSS inteiro (Onda 12.3 — regra Tier 0)

### DIFF
--- a/resources/css/cowork-canon-financeiro-bundle.css
+++ b/resources/css/cowork-canon-financeiro-bundle.css
@@ -1,0 +1,8630 @@
+/* SCOPED-OK */ - escopo .fin-cowork aplicado por scripts/scope-fin-cowork-css.py
+/* ───────────────────── Oimpresso ERP — Chat v2 ───────────────────── */
+.fin-cowork {
+  /* Sidebar dark — espelho AppShell */
+  --sb-bg:        oklch(0.21 0 0);
+  --sb-bg-2:      oklch(0.18 0 0);
+  --sb-border:    oklch(0.28 0 0);
+  --sb-text:      oklch(0.78 0 0);
+  --sb-text-dim:  oklch(0.55 0 0);
+  --sb-text-hi:   oklch(0.96 0 0);
+  --sb-hover:     oklch(0.27 0 0);
+  --sb-active:    oklch(0.32 0 0);
+
+  /* Surface */
+  --bg:           oklch(0.985 0.003 90);
+  --bg-2:         oklch(0.965 0.004 90);
+  --surface:      #ffffff;
+  --border:       oklch(0.90 0.004 90);
+  --border-2:     oklch(0.93 0.004 90);
+  --text:         oklch(0.22 0.01 80);
+  --text-dim:     oklch(0.50 0.01 80);
+  --text-mute:    oklch(0.65 0.01 80);
+
+  --accent:       oklch(0.58 0.09 220);
+  --accent-2:     oklch(0.66 0.09 220);
+  --accent-soft:  oklch(0.94 0.025 220);
+  --accent-fg:    #ffffff;
+
+  --bubble-me:    oklch(0.58 0.09 220);
+  --bubble-me-fg: #ffffff;
+  --bubble-them:  oklch(0.96 0.003 90);
+  --bubble-them-fg: var(--text);
+
+  /* Origens (módulos que geram tarefas) */
+  --origin-OS-bg:  oklch(0.93 0.07 70);   --origin-OS-fg:  oklch(0.40 0.10 60);
+  --origin-CRM-bg: oklch(0.92 0.06 220);  --origin-CRM-fg: oklch(0.40 0.10 220);
+  --origin-FIN-bg: oklch(0.93 0.07 145);  --origin-FIN-fg: oklch(0.36 0.10 145);
+  --origin-PNT-bg: oklch(0.93 0.06 295);  --origin-PNT-fg: oklch(0.40 0.10 295);
+  --origin-MFG-bg: oklch(0.93 0.05 30);   --origin-MFG-fg: oklch(0.40 0.10 30);
+
+  --radius:       8px;
+  --radius-sm:    6px;
+  --radius-lg:    12px;
+
+  --shadow-pop:   0 6px 24px -8px rgba(0,0,0,.18), 0 2px 6px -2px rgba(0,0,0,.10);
+  --shadow-soft:  0 1px 2px rgba(0,0,0,.04);
+
+  --row-h:        30px;
+  --font-sans:    "IBM Plex Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono:    "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace;
+}
+.fin-cowork [data-density="compact"] { --row-h: 26px; }
+.fin-cowork [data-density="comfy"] {   --row-h: 34px; }
+.fin-cowork [data-theme="dark"] {
+  --bg:        oklch(0.16 0.003 240);
+  --bg-2:      oklch(0.14 0.003 240);
+  --surface:   oklch(0.19 0.003 240);
+  --border:    oklch(0.26 0.005 240);
+  --border-2:  oklch(0.23 0.005 240);
+  --text:      oklch(0.92 0.005 90);
+  --text-dim:  oklch(0.68 0.005 90);
+  --text-mute: oklch(0.55 0.005 90);
+  --bubble-them: oklch(0.24 0.005 240);
+  --accent-soft: oklch(0.30 0.04 220);
+
+  --origin-OS-bg:  oklch(0.30 0.07 60);   --origin-OS-fg:  oklch(0.85 0.07 60);
+  --origin-CRM-bg: oklch(0.30 0.07 220);  --origin-CRM-fg: oklch(0.85 0.07 220);
+  --origin-FIN-bg: oklch(0.30 0.07 145);  --origin-FIN-fg: oklch(0.85 0.07 145);
+  --origin-PNT-bg: oklch(0.30 0.07 295);  --origin-PNT-fg: oklch(0.85 0.07 295);
+  --origin-MFG-bg: oklch(0.30 0.07 30);   --origin-MFG-fg: oklch(0.85 0.07 30);
+}
+.fin-cowork { box-sizing: border-box; }
+.fin-cowork, .fin-cowork, .fin-cowork { height: 100%; margin: 0; }
+.fin-cowork {
+  font-family: var(--font-sans);
+  font-size: 13.5px;
+  color: var(--text);
+  background: var(--bg);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+}
+/* ────────────────── App shell ────────────────── */
+.fin-cowork .app {
+  display: grid;
+  grid-template-columns: var(--sb-w, 260px) 1fr;
+  height: 100vh;
+  width: 100vw;
+  overflow: hidden;
+  transition: grid-template-columns .18s ease-out;
+}
+.fin-cowork .app.app--sb-rail { --sb-w: 56px; }
+.fin-cowork .app.app--sb-hidden { --sb-w: 0px; }
+.fin-cowork .main {
+  display: grid;
+  grid-template-rows: 1fr;
+  min-height: 0;
+  min-width: 0;
+}
+.fin-cowork .main-body {
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+}
+/* ────────────────── Topbar ────────────────── */
+.fin-cowork .topbar {
+  height: 40px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  flex-shrink: 0;
+}
+.fin-cowork .topbar-l {
+  display: flex; align-items: center; gap: 8px;
+  padding: 0 14px;
+  min-width: 160px;
+  border-right: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.fin-cowork .topbar-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  flex-shrink: 0;
+}
+.fin-cowork .topbar-area-label {
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--text);
+  white-space: nowrap;
+}
+.fin-cowork .topbar-tabs {
+  flex: 1 1 auto;
+  display: flex;
+  align-items: stretch;
+  gap: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border) transparent;
+  padding: 0 8px;
+  min-width: 0;
+}
+.fin-cowork .topbar-tabs::-webkit-scrollbar { height: 4px; }
+.fin-cowork .topbar-tabs::-webkit-scrollbar-thumb { background: var(--border); border-radius: 999px; }
+.fin-cowork .topbar-tabs-empty { flex: 1; }
+.fin-cowork .topbar-tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 0 10px;
+  border: 0;
+  background: transparent;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  color: var(--text-mute);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color .12s, border-color .12s;
+}
+.fin-cowork .topbar-tab svg { opacity: 0.6; }
+.fin-cowork .topbar-tab:hover { color: var(--text); }
+.fin-cowork .topbar-tab:hover svg { opacity: 0.85; }
+.fin-cowork .topbar-tab.active {
+  color: var(--accent);
+  border-bottom-color: var(--accent);
+  font-weight: 600;
+}
+.fin-cowork .topbar-tab.active svg { opacity: 1; }
+.fin-cowork .topbar-r {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px;
+  flex-shrink: 0;
+  border-left: 1px solid var(--border);
+}
+.fin-cowork .topbar-tenant {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--text-mute);
+  font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
+  padding: 0 6px;
+}
+/* legados breadcrumb — manter caso algum ponto ainda use */
+.fin-cowork .bc { display: flex; align-items: center; gap: 8px; font-size: 12.5px; color: var(--text-dim); }
+.fin-cowork .bc-tenant { color: var(--text); font-weight: 600; }
+.fin-cowork .bc-sep { color: var(--text-mute); }
+.fin-cowork .bc-up { color: var(--text-dim); }
+.fin-cowork .bc-cur { color: var(--text); font-weight: 500; }
+/* ────────────────── Sidebar ────────────────── */
+.fin-cowork .sb {
+  background: var(--sb-bg);
+  color: var(--sb-text);
+  border-right: 1px solid var(--sb-border);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+/* Topo: empresa */
+.fin-cowork .sb-top {
+  padding: 10px 10px 8px;
+  border-bottom: 1px solid var(--sb-border);
+  position: relative;
+}
+.fin-cowork .sb-cp { position: relative; }
+.fin-cowork .sb-cp-btn {
+  appearance: none;
+  border: 1px solid var(--sb-border);
+  background: var(--sb-bg-2);
+  color: var(--sb-text-hi);
+  height: 32px;
+  padding: 0 8px;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: default;
+  width: 100%;
+}
+.fin-cowork .sb-cp-btn:hover { background: var(--sb-hover); }
+.fin-cowork .sb-cp-btn .avatar {
+  width: 20px; height: 20px;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  display: grid; place-items: center;
+  flex: 0 0 auto;
+}
+.fin-cowork .sb-cp-btn .name { flex: 1 1 auto; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; text-align: left; }
+.fin-cowork .sb-cp-btn .chev { width: 12px; height: 12px; opacity: .55; flex: 0 0 auto; }
+.fin-cowork .sb-dd {
+  position: absolute;
+  top: calc(100% + 2px);
+  left: 0; right: 0;
+  background: oklch(0.20 0 0);
+  border: 1px solid var(--sb-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-pop);
+  padding: 6px;
+  z-index: 50;
+  font-size: 12.5px;
+}
+.fin-cowork .sb-dd-h {
+  font-size: 10px; font-weight: 600;
+  letter-spacing: .08em; text-transform: uppercase;
+  color: var(--sb-text-dim);
+  padding: 6px 8px 4px;
+}
+.fin-cowork .sb-dd-i {
+  display: flex; align-items: center; gap: 8px;
+  padding: 7px 8px;
+  border-radius: var(--radius-sm);
+  color: var(--sb-text-hi);
+  cursor: default;
+}
+.fin-cowork .sb-dd-i:hover { background: var(--sb-hover); }
+.fin-cowork .sb-dd-i .check { margin-left: auto; opacity: .85; }
+.fin-cowork .sb-dd-sep { height: 1px; background: var(--sb-border); margin: 4px 0; }
+.fin-cowork .sb-dd-foot {
+  padding: 7px 8px;
+  border-radius: var(--radius-sm);
+  color: var(--sb-text-dim);
+  font-size: 12px;
+  cursor: default;
+}
+.fin-cowork .sb-dd-foot:hover { background: var(--sb-hover); color: var(--sb-text-hi); }
+/* Tabs Chat/Menu */
+.fin-cowork .sb-tabs {
+  display: flex;
+  gap: 2px;
+  padding: 8px;
+  border-bottom: 1px solid var(--sb-border);
+}
+.fin-cowork .sb-tab {
+  flex: 1 1 0;
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--sb-text-dim);
+  padding: 6px 8px;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: default;
+}
+.fin-cowork .sb-tab:hover { color: var(--sb-text-hi); background: var(--sb-hover); }
+.fin-cowork .sb-tab.active {
+  background: var(--sb-active);
+  color: var(--sb-text-hi);
+}
+/* Body scrollable */
+.fin-cowork .sb-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: oklch(0.32 0 0) transparent;
+}
+.fin-cowork .sb-body::-webkit-scrollbar { width: 8px; }
+.fin-cowork .sb-body::-webkit-scrollbar-thumb {
+  background: oklch(0.32 0 0);
+  border-radius: 4px;
+  border: 2px solid transparent;
+  background-clip: content-box;
+}
+/* ── Aba CHAT ── */
+.fin-cowork .sb-chat { padding: 8px; }
+.fin-cowork .sb-actions { display: flex; flex-direction: column; gap: 1px; margin-bottom: 8px; }
+.fin-cowork .sb-action {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 10px;
+  height: 30px;
+  border-radius: var(--radius-sm);
+  color: var(--sb-text);
+  font-size: 13px;
+  cursor: default;
+}
+.fin-cowork .sb-action:hover { background: var(--sb-hover); color: var(--sb-text-hi); }
+.fin-cowork .sb-action .ic { width: 14px; height: 14px; opacity: .85; flex: 0 0 auto; }
+.fin-cowork .sb-action span { flex: 1 1 auto; }
+.fin-cowork .sb-action .kbd {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--sb-text-dim);
+}
+.fin-cowork .sb-action .kbd-badge {
+  font-size: 10px; font-weight: 700;
+  background: oklch(0.55 0.15 30);
+  color: #fff;
+  padding: 1px 5px;
+  border-radius: 999px;
+  min-width: 16px;
+  text-align: center;
+}
+.fin-cowork .sb-action .beta {
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--sb-text-dim);
+  border: 1px solid var(--sb-border);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+.fin-cowork .sb-section-h {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--sb-text-dim);
+  padding: 14px 10px 6px;
+}
+.fin-cowork .sb-pin-empty {
+  display: flex; align-items: center; gap: 8px;
+  padding: 8px 10px;
+  font-size: 11.5px;
+  color: var(--sb-text-dim);
+  border: 1px dashed var(--sb-border);
+  border-radius: var(--radius-sm);
+  margin: 0 4px;
+}
+.fin-cowork .sb-bullet {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  flex: 0 0 auto;
+  margin-top: 1px;
+}
+.fin-cowork .sb-bullet.outline { border: 1.4px solid oklch(0.40 0 0); }
+.fin-cowork .sb-bullet.filled { background: oklch(0.78 0.16 75); border: 0; }
+.fin-cowork .sb-conv {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 10px;
+  height: 30px;
+  border-radius: var(--radius-sm);
+  color: var(--sb-text);
+  font-size: 13px;
+  cursor: default;
+}
+.fin-cowork .sb-conv:hover { background: var(--sb-hover); color: var(--sb-text-hi); }
+.fin-cowork .sb-conv.active { background: var(--sb-active); color: var(--sb-text-hi); font-weight: 500; }
+.fin-cowork .sb-conv-t {
+  flex: 1 1 auto;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.fin-cowork .sb-routine {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 10px;
+  height: 28px;
+  border-radius: var(--radius-sm);
+  color: var(--sb-text);
+  font-size: 12.5px;
+  cursor: default;
+}
+.fin-cowork .sb-routine:hover { background: var(--sb-hover); color: var(--sb-text-hi); }
+.fin-cowork .sb-routine-t {
+  flex: 1 1 auto;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.fin-cowork .sb-routine-f {
+  font-size: 10.5px;
+  color: var(--sb-text-dim);
+  flex: 0 0 auto;
+}
+/* ── Aba MENU ── */
+.fin-cowork .sb-menu { padding: 8px; }
+.fin-cowork .sb-group-h {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--sb-text-dim);
+  padding: 12px 10px 6px;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  cursor: default;
+}
+.fin-cowork .sb-group-h:hover { color: var(--sb-text-hi); }
+.fin-cowork .sb-group-h .chev { width: 10px; height: 10px; opacity: .7; flex: 0 0 auto; }
+.fin-cowork .sb-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 0 10px;
+  height: var(--row-h);
+  border-radius: var(--radius-sm);
+  color: var(--sb-text);
+  font-size: 13px;
+  cursor: default;
+  position: relative;
+}
+.fin-cowork .sb-item:hover { background: var(--sb-hover); color: var(--sb-text-hi); }
+.fin-cowork .sb-item.active {
+  background: var(--sb-active);
+  color: var(--sb-text-hi);
+  font-weight: 500;
+}
+.fin-cowork .sb-item.active::before {
+  content: "";
+  position: absolute;
+  left: -8px; top: 6px; bottom: 6px;
+  width: 2px;
+  background: var(--accent-2);
+  border-radius: 2px;
+}
+.fin-cowork .sb-item .ic { width: 16px; height: 16px; flex: 0 0 auto; opacity: .85; }
+.fin-cowork .sb-item .label { flex: 1 1 auto; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.fin-cowork .sb-item .badge {
+  font-size: 10.5px;
+  font-weight: 600;
+  background: var(--accent);
+  color: #fff;
+  border-radius: 999px;
+  padding: 1px 6px;
+  min-width: 18px;
+  text-align: center;
+  font-variant-numeric: tabular-nums;
+}
+/* Rodapé usuário */
+.fin-cowork .sb-user {
+  border-top: 1px solid var(--sb-border);
+  padding: 10px;
+  position: relative;
+}
+.fin-cowork .sb-user-btn {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 7px 8px;
+  border-radius: var(--radius);
+  cursor: default;
+  width: 100%;
+  color: inherit;
+  font: inherit;
+}
+.fin-cowork .sb-user-btn:hover { background: var(--sb-hover); }
+.fin-cowork .sb-user-btn { padding: 9px 10px; gap: 10px; }
+.fin-cowork .sb-user-btn .avatar {
+  width: 32px; height: 32px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, oklch(0.65 0.12 30), oklch(0.55 0.15 10));
+  color: #fff;
+  font-size: 11.5px;
+  font-weight: 700;
+  display: grid; place-items: center;
+  flex: 0 0 auto;
+  position: relative;
+}
+.fin-cowork .sb-user-btn .avatar::after {
+  content: "";
+  position: absolute;
+  right: -1px; bottom: -1px;
+  width: 9px; height: 9px;
+  background: oklch(0.72 0.18 145);
+  border: 2px solid var(--sb-bg);
+  border-radius: 50%;
+}
+.fin-cowork .sb-user-btn .who { flex: 1 1 auto; min-width: 0; text-align: left; }
+.fin-cowork .sb-user-btn .who b {
+  display: block;
+  color: var(--sb-text-hi);
+  font-weight: 500;
+  font-size: 13px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.fin-cowork .sb-user-btn .who small {
+  display: block;
+  color: var(--sb-text-dim);
+  font-size: 11px;
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+}
+.fin-cowork .sb-user-btn .chev { width: 14px; height: 14px; opacity: .6; flex: 0 0 auto; }
+.fin-cowork .user-menu {
+  position: absolute;
+  bottom: calc(100% + 6px);
+  left: 8px; right: 8px;
+  min-width: 220px;
+  background: oklch(0.22 0 0);
+  border: 1px solid var(--sb-border);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow-pop);
+  padding: 6px;
+  z-index: 60;
+  font-size: 12.5px;
+}
+/* No rail, abre pra direita do botão (não pra dentro do sidebar) */
+.fin-cowork .sb--rail .sb-user-rail .user-menu {
+  bottom: 0;
+  left: calc(100% + 8px);
+  right: auto;
+  width: 240px;
+}
+.fin-cowork .user-menu-head {
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 10px 12px;
+  border-bottom: 1px solid var(--sb-border);
+  margin-bottom: 6px;
+}
+.fin-cowork .user-menu-head .avatar {
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: linear-gradient(135deg, oklch(0.65 0.12 30), oklch(0.55 0.15 10));
+  color: #fff;
+  font-weight: 700;
+  display: grid; place-items: center;
+}
+.fin-cowork .user-menu-head .meta b { display: block; color: var(--sb-text-hi); font-weight: 500; }
+.fin-cowork .user-menu-head .meta small { display: block; color: var(--sb-text-dim); font-size: 11.5px; }
+.fin-cowork .um-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 7px 8px;
+  border-radius: var(--radius-sm);
+  color: var(--sb-text-hi);
+  cursor: default;
+}
+.fin-cowork .um-item:hover { background: var(--sb-hover); }
+.fin-cowork .um-item .ic { width: 14px; height: 14px; opacity: .8; flex: 0 0 auto; }
+.fin-cowork .um-item .label { flex: 1 1 auto; }
+.fin-cowork .um-item .kbd { font-family: var(--font-mono); font-size: 10.5px; color: var(--sb-text-dim); }
+.fin-cowork .um-item .arrow { font-size: 10px; color: var(--sb-text-dim); }
+.fin-cowork .um-status { display: inline-block; width: 7px; height: 7px; border-radius: 50%; }
+.fin-cowork .um-sep { height: 1px; background: var(--sb-border); margin: 4px 2px; }
+/* ────────────────── TAREFAS — master/detail ────────────────── */
+.fin-cowork .tk-page {
+  display: grid;
+  grid-template-columns: 360px 1fr;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.fin-cowork .tk-list {
+  background: var(--bg-2);
+  border-right: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  min-height: 0;
+}
+.fin-cowork .tk-list-h {
+  padding: 16px 16px 10px;
+  display: flex; flex-direction: column; gap: 10px;
+  border-bottom: 1px solid var(--border);
+}
+.fin-cowork .tk-list-h-row {
+  display: flex; align-items: baseline; gap: 8px;
+}
+.fin-cowork .tk-list-h h2 {
+  font-size: 16px; font-weight: 600; margin: 0;
+  letter-spacing: -0.01em;
+}
+.fin-cowork .tk-list-h-sub {
+  margin: -6px 0 0;
+  font-size: 11.5px;
+  color: var(--text-dim);
+  line-height: 1.4;
+}
+.fin-cowork .tk-mini-btn {
+  appearance: none; border: 0;
+  margin-left: auto;
+  width: 22px; height: 22px;
+  display: grid; place-items: center;
+  background: transparent;
+  color: var(--text-mute);
+  border-radius: 4px;
+  cursor: default;
+}
+.fin-cowork .tk-mini-btn:hover { background: var(--border-2); color: var(--text); }
+.fin-cowork .tk-kpis {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 6px;
+}
+.fin-cowork .tk-kpi {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  display: flex; flex-direction: column; gap: 1px;
+}
+.fin-cowork .tk-kpi b {
+  font-size: 18px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  line-height: 1.1;
+}
+.fin-cowork .tk-kpi small {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  color: var(--text-mute);
+  font-weight: 600;
+}
+.fin-cowork .tk-kpi.warn {
+  background: oklch(0.97 0.04 25);
+  border-color: oklch(0.85 0.08 25);
+}
+.fin-cowork .tk-kpi.warn b { color: oklch(0.50 0.18 25); }
+.fin-cowork [data-theme="dark"] .tk-kpi.warn {
+  background: oklch(0.26 0.06 25);
+  border-color: oklch(0.40 0.10 25);
+}
+.fin-cowork [data-theme="dark"] .tk-kpi.warn b { color: oklch(0.78 0.16 25); }
+.fin-cowork .tk-kpi.muted b { color: var(--text-dim); }
+.fin-cowork .tk-search {
+  display: flex; align-items: center; gap: 6px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 6px 9px;
+  color: var(--text-mute);
+}
+.fin-cowork .tk-search input {
+  appearance: none; border: 0; background: transparent;
+  font: inherit; font-size: 12px;
+  color: var(--text);
+  flex: 1 1 auto; min-width: 0;
+  outline: none;
+}
+.fin-cowork .tk-search:focus-within { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.fin-cowork .tk-count {
+  font-size: 12px;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.fin-cowork .tk-filters {
+  display: flex; flex-wrap: wrap;
+  gap: 4px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+}
+.fin-cowork .tk-filter {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 11.5px;
+  padding: 3px 9px;
+  border-radius: 999px;
+  cursor: default;
+}
+.fin-cowork .tk-filter:hover { background: var(--border-2); color: var(--text); }
+.fin-cowork .tk-filter.active { background: var(--text); color: var(--bg); font-weight: 500; }
+.fin-cowork .tk-list-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 6px 8px 12px;
+  scrollbar-width: thin;
+}
+.fin-cowork .tk-list-body::-webkit-scrollbar { width: 8px; }
+.fin-cowork .tk-list-body::-webkit-scrollbar-thumb {
+  background: var(--border); border-radius: 4px;
+  border: 2px solid transparent; background-clip: content-box;
+}
+.fin-cowork .tk-group { margin-top: 6px; }
+.fin-cowork .tk-group-h {
+  display: flex; align-items: center;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  padding: 10px 8px 6px;
+}
+.fin-cowork .tk-group-c {
+  margin-left: 6px;
+  background: var(--border-2);
+  color: var(--text-dim);
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-size: 10px;
+  font-variant-numeric: tabular-nums;
+}
+.fin-cowork .tk-card {
+  display: grid;
+  gap: 4px;
+  padding: 10px 12px;
+  border-radius: var(--radius);
+  cursor: default;
+  border: 1px solid transparent;
+  margin-bottom: 2px;
+}
+.fin-cowork .tk-card:hover { background: var(--border-2); }
+.fin-cowork .tk-card.active {
+  background: var(--surface);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.fin-cowork [data-theme="dark"] .tk-card.active { background: oklch(0.22 0.005 240); }
+.fin-cowork .tk-card.urgent {
+  border-left: 3px solid oklch(0.62 0.18 25);
+  padding-left: 10px;
+}
+.fin-cowork .tk-card-h {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 10.5px;
+}
+.fin-cowork .tk-origin {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  padding: 1px 6px;
+  border-radius: 3px;
+}
+.fin-cowork .tk-origin.lg {
+  font-size: 11px;
+  padding: 3px 8px;
+  border-radius: 4px;
+}
+.fin-cowork .tk-dot {
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: oklch(0.78 0.16 75);
+}
+.fin-cowork .tk-when {
+  margin-left: auto;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.fin-cowork .tk-card.urgent .tk-when { color: oklch(0.55 0.18 25); font-weight: 600; }
+.fin-cowork .tk-title {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: -0.005em;
+  line-height: 1.35;
+}
+.fin-cowork .tk-sub {
+  font-size: 11.5px;
+  color: var(--text-dim);
+  line-height: 1.4;
+}
+.fin-cowork .tk-foot {
+  display: flex; gap: 6px;
+  font-size: 10.5px;
+  color: var(--text-mute);
+  margin-top: 2px;
+}
+.fin-cowork .tk-empty {
+  padding: 50px 20px;
+  text-align: center;
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  color: var(--text-mute);
+}
+.fin-cowork .tk-empty b { font-size: 13px; color: var(--text); }
+.fin-cowork .tk-empty small { font-size: 11.5px; color: var(--text-dim); }
+.fin-cowork .tk-empty-ico {
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  display: grid; place-items: center;
+  color: var(--text-mute);
+  margin-bottom: 6px;
+}
+.fin-cowork .tk-empty-ico.lg { width: 56px; height: 56px; border-radius: 16px; }
+.fin-cowork .tk-empty-ico.ok {
+  background: oklch(0.92 0.10 145);
+  color: oklch(0.40 0.16 145);
+}
+.fin-cowork [data-theme="dark"] .tk-empty-ico.ok {
+  background: oklch(0.32 0.10 145);
+  color: oklch(0.85 0.16 145);
+}
+.fin-cowork .tk-empty-state {
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  text-align: center; max-width: 320px;
+}
+.fin-cowork .tk-empty-state b { font-size: 15px; color: var(--text); margin-top: 6px; }
+.fin-cowork .tk-empty-state small { font-size: 12px; color: var(--text-dim); line-height: 1.5; }
+.fin-cowork .tk-shortcuts {
+  margin-top: 18px;
+  display: flex; gap: 14px;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.fin-cowork .tk-shortcuts kbd {
+  display: inline-block;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  padding: 1px 6px;
+  margin-right: 3px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  color: var(--text);
+}
+.fin-cowork .tk-empty-old {
+  padding: 60px 20px;
+  text-align: center;
+  color: var(--text-mute);
+  font-size: 13px;
+}
+/* Detail */
+.fin-cowork .tk-detail {
+  display: flex; flex-direction: column;
+  min-height: 0;
+  background: var(--bg);
+}
+.fin-cowork .tk-detail.empty { justify-content: center; align-items: center; }
+.fin-cowork .tk-detail-h {
+  padding: 16px 24px 14px;
+  border-bottom: 1px solid var(--border);
+  display: flex; flex-direction: column; gap: 8px;
+  background: var(--surface);
+}
+.fin-cowork .tk-detail-bc {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 11px;
+  color: var(--text-mute);
+  text-transform: uppercase;
+  letter-spacing: .06em;
+  font-weight: 600;
+}
+.fin-cowork .tk-bc-step { color: var(--text-dim); }
+.fin-cowork .tk-bc-sep { color: var(--text-mute); opacity: .5; }
+.fin-cowork .tk-bc-spacer { flex: 1 1 auto; }
+.fin-cowork .tk-bc-pos {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  padding: 2px 8px;
+  border-radius: 999px;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--text-dim);
+}
+.fin-cowork .tk-detail-title-row {
+  display: flex; align-items: flex-start; gap: 14px;
+}
+.fin-cowork .tk-detail-title-row h1 {
+  flex: 1 1 auto;
+  margin: 0;
+  font-size: 19px;
+  font-weight: 600;
+  line-height: 1.25;
+  letter-spacing: -0.015em;
+  color: var(--text);
+}
+.fin-cowork .tk-detail-actions {
+  display: flex; gap: 2px;
+  flex: 0 0 auto;
+  margin-top: 2px;
+}
+.fin-cowork .tk-detail-meta {
+  display: flex; align-items: center; flex-wrap: wrap; gap: 8px;
+  font-size: 12px;
+  color: var(--text);
+}
+.fin-cowork .tk-detail-meta .t-mute { color: var(--text-mute); margin-right: 3px; }
+.fin-cowork .tk-detail-meta b { font-weight: 500; }
+.fin-cowork .tk-detail-meta .urgent b { color: oklch(0.55 0.18 25); font-weight: 600; }
+.fin-cowork .tk-detail-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  display: flex; flex-direction: column;
+  min-height: 0;
+}
+/* ────────────────── Viewers ────────────────── */
+.fin-cowork .vw {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 16px 20px 16px;
+  scrollbar-width: thin;
+}
+.fin-cowork .vw::-webkit-scrollbar { width: 10px; }
+.fin-cowork .vw::-webkit-scrollbar-thumb {
+  background: var(--border); border-radius: 5px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+.fin-cowork .vw-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 10px;
+}
+.fin-cowork .vw-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px 16px;
+  margin-bottom: 10px;
+}
+.fin-cowork .vw-card.hi {
+  background: linear-gradient(135deg, var(--accent-soft), oklch(0.96 0.02 145));
+  border-color: var(--accent-soft);
+}
+.fin-cowork [data-theme="dark"] .vw-card.hi {
+  background: linear-gradient(135deg, oklch(0.26 0.06 220), oklch(0.24 0.04 145));
+}
+.fin-cowork .vw-card h3 {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin: 0 0 10px;
+}
+.fin-cowork .vw-card h4 { font-size: 12px; margin: 10px 0 6px; color: var(--text); }
+.fin-cowork .vw-card .vw-sub {
+  font-size: 10.5px; font-weight: 700; letter-spacing: .06em;
+  text-transform: uppercase; color: var(--text-mute);
+  margin: 12px 0 6px;
+}
+.fin-cowork .vw-p { margin: 0; font-size: 13px; line-height: 1.5; color: var(--text-dim); }
+.fin-cowork .vw-dl { display: grid; grid-template-columns: 100px 1fr; gap: 6px 10px; margin: 0; font-size: 12.5px; }
+.fin-cowork .vw-dl dt { color: var(--text-mute); font-weight: 500; }
+.fin-cowork .vw-dl dd { margin: 0; color: var(--text); }
+.fin-cowork .vw-dl dd.mono { font-family: var(--font-mono); }
+.fin-cowork .vw-dl dd.urgent { color: oklch(0.55 0.18 25); font-weight: 600; }
+.fin-cowork .vw-stage {
+  display: inline-flex;
+  background: var(--origin-OS-bg);
+  color: var(--origin-OS-fg);
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+}
+.fin-cowork .vw-art {
+  display: flex; gap: 12px; align-items: center;
+  padding: 10px;
+  background: var(--bg-2);
+  border-radius: var(--radius-sm);
+}
+.fin-cowork .vw-art-thumb {
+  width: 56px; height: 56px;
+  border-radius: var(--radius-sm);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  display: grid; place-items: center;
+  color: var(--text-mute);
+  flex: 0 0 auto;
+}
+.fin-cowork .vw-art-meta { flex: 1 1 auto; min-width: 0; }
+.fin-cowork .vw-art-meta b { display: block; font-size: 13px; }
+.fin-cowork .vw-art-meta small { display: block; font-size: 11.5px; color: var(--text-dim); font-family: var(--font-mono); }
+.fin-cowork .vw-art-actions { display: flex; gap: 6px; margin-top: 6px; }
+.fin-cowork .vw-hist { list-style: none; margin: 0; padding: 0; font-size: 12.5px; }
+.fin-cowork .vw-hist li {
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border-2);
+  display: flex; gap: 8px;
+}
+.fin-cowork .vw-hist li:last-child { border-bottom: 0; }
+.fin-cowork .vw-hist .t { color: var(--text-mute); font-variant-numeric: tabular-nums; }
+.fin-cowork .vw-thread-mini { display: flex; flex-direction: column; gap: 6px; }
+.fin-cowork .mini-msg { display: flex; gap: 8px; align-items: flex-end; }
+.fin-cowork .mini-msg.me { justify-content: flex-end; }
+.fin-cowork .mini-av {
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  color: #fff; font-size: 9.5px; font-weight: 600;
+  flex: 0 0 auto;
+}
+.fin-cowork .mini-bub {
+  background: var(--bubble-them);
+  padding: 6px 10px;
+  border-radius: 12px;
+  border-top-left-radius: 3px;
+  font-size: 12.5px;
+  max-width: 70%;
+}
+.fin-cowork .mini-bub.me {
+  background: var(--bubble-me);
+  color: var(--bubble-me-fg);
+  border-top-left-radius: 12px;
+  border-top-right-radius: 3px;
+}
+.fin-cowork .mini-input {
+  margin-top: 6px;
+  appearance: none;
+  width: 100%;
+  height: 32px;
+  padding: 0 12px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  background: var(--surface);
+  color: var(--text);
+  font: inherit;
+  font-size: 12.5px;
+  outline: none;
+}
+.fin-cowork .mini-input:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+/* CRM */
+.fin-cowork .vw-contact { display: flex; gap: 12px; align-items: center; margin-bottom: 12px; }
+.fin-cowork .vw-contact-av {
+  width: 44px; height: 44px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  color: #fff; font-weight: 700;
+  flex: 0 0 auto;
+}
+.fin-cowork .vw-contact b { font-size: 14px; }
+.fin-cowork .vw-contact small { display: block; font-size: 12px; color: var(--text-dim); }
+.fin-cowork .vw-contact-row {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 10px;
+  background: var(--bg-2);
+  border-radius: var(--radius-sm);
+  margin-bottom: 6px;
+  font-size: 13px;
+}
+.fin-cowork .vw-contact-row .ic { color: var(--text-mute); }
+.fin-cowork .vw-contact-row a { flex: 1 1 auto; color: var(--text); }
+.fin-cowork .vw-notes { margin: 0; padding-left: 18px; font-size: 12.5px; color: var(--text-dim); line-height: 1.6; }
+/* Radio/Chips/Textarea reutilizáveis */
+.fin-cowork .vw-radio-group { display: flex; flex-direction: column; gap: 4px; margin-bottom: 8px; }
+.fin-cowork .vw-radio {
+  display: flex; align-items: center; gap: 8px;
+  padding: 7px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  font-size: 12.5px;
+  cursor: default;
+}
+.fin-cowork .vw-radio:hover { background: var(--border-2); }
+.fin-cowork .vw-radio input { accent-color: var(--accent); }
+.fin-cowork .vw-chips { display: flex; flex-wrap: wrap; gap: 6px; margin-bottom: 8px; }
+.fin-cowork .vw-chip {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  padding: 5px 12px;
+  border-radius: 999px;
+  font: inherit;
+  font-size: 12px;
+  cursor: default;
+}
+.fin-cowork .vw-chip:hover { background: var(--border-2); }
+.fin-cowork .vw-chip.on {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+.fin-cowork .vw-textarea {
+  appearance: none;
+  width: 100%;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+  font: inherit;
+  font-size: 12.5px;
+  resize: vertical;
+  outline: none;
+}
+.fin-cowork .vw-textarea:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.fin-cowork .vw-check { display: flex; align-items: center; gap: 8px; font-size: 12.5px; margin-top: 8px; color: var(--text-dim); }
+/* PNT */
+.fin-cowork .vw-pnt-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 6px;
+}
+.fin-cowork .vw-pnt-cell {
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px;
+  text-align: center;
+}
+.fin-cowork .vw-pnt-cell small { display: block; font-size: 10px; color: var(--text-mute); text-transform: uppercase; letter-spacing: .06em; }
+.fin-cowork .vw-pnt-cell b { display: block; font-size: 16px; font-weight: 600; font-family: var(--font-mono); margin-top: 4px; }
+.fin-cowork .vw-pnt-cell.miss {
+  background: oklch(0.96 0.04 25);
+  border-color: oklch(0.85 0.08 25);
+  border-style: dashed;
+}
+.fin-cowork .vw-pnt-cell.miss b { color: oklch(0.55 0.18 25); }
+.fin-cowork [data-theme="dark"] .vw-pnt-cell.miss {
+  background: oklch(0.26 0.06 25);
+  border-color: oklch(0.45 0.10 25);
+}
+/* FIN — money */
+.fin-cowork .vw-money { text-align: center; padding: 14px 8px; }
+.fin-cowork .vw-money small {
+  display: block;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+.fin-cowork .vw-money b {
+  display: block;
+  font-size: 32px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  margin: 6px 0 4px;
+  font-variant-numeric: tabular-nums;
+}
+.fin-cowork .vw-due { font-size: 12px; color: var(--text-dim); }
+.fin-cowork .vw-due.urgent { color: oklch(0.55 0.18 25); font-weight: 600; }
+/* Botões viewer */
+.fin-cowork .vw-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+  margin-top: 8px;
+}
+.fin-cowork .vw-spacer { flex: 1 1 auto; }
+.fin-cowork .vw-btn {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  height: 34px;
+  padding: 0 14px;
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: default;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.fin-cowork .vw-btn:hover { background: var(--border-2); }
+.fin-cowork .vw-btn.primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+.fin-cowork .vw-btn.primary:hover { background: var(--accent-2); border-color: var(--accent-2); }
+.fin-cowork .vw-btn.danger {
+  background: oklch(0.55 0.18 25);
+  color: #fff;
+  border-color: oklch(0.55 0.18 25);
+}
+.fin-cowork .vw-btn.danger:hover { background: oklch(0.50 0.18 25); }
+.fin-cowork .vw-btn.ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--text-dim);
+}
+.fin-cowork .vw-btn.ghost:hover { background: var(--border-2); color: var(--text); }
+.fin-cowork .vw-btn.sm { height: 26px; padding: 0 10px; font-size: 11.5px; }
+/* ────────────────── Module stub (rich migration page) ────────────────── */
+.fin-cowork .mod-stub {
+  flex: 1 1 auto;
+  display: flex; flex-direction: column;
+  min-height: 0;
+  overflow-y: auto;
+  background:
+    radial-gradient(1200px 600px at 100% 0%, var(--accent-soft) 0%, transparent 60%),
+    var(--bg);
+}
+.fin-cowork [data-theme="dark"] .mod-stub {
+  background:
+    radial-gradient(1200px 600px at 100% 0%, oklch(0.26 0.06 var(--hue, 220)) 0%, transparent 60%),
+    var(--bg);
+}
+.fin-cowork .mod-stub-hero {
+  padding: 32px 32px 28px;
+  display: flex; align-items: flex-start; gap: 24px;
+  border-bottom: 1px solid var(--border);
+}
+.fin-cowork .mod-stub-hero-l {
+  display: flex; gap: 18px;
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.fin-cowork .mod-stub-hero-l > div { min-width: 0; flex: 1 1 auto; }
+.fin-cowork .mod-stub-ico {
+  width: 56px; height: 56px;
+  border-radius: 14px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  display: grid; place-items: center;
+  color: var(--accent);
+  flex: 0 0 auto;
+  box-shadow: 0 1px 2px rgba(0,0,0,.04);
+}
+.fin-cowork .mod-stub-eyebrow {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin-bottom: 8px;
+}
+.fin-cowork .mod-stub-hero-l h1 {
+  margin: 0;
+  font-size: 30px;
+  font-weight: 600;
+  letter-spacing: -0.025em;
+  line-height: 1.1;
+  color: var(--text);
+}
+.fin-cowork .mod-stub-hero-l p {
+  margin: 8px 0 0;
+  font-size: 14px;
+  line-height: 1.55;
+  max-width: 580px;
+  color: var(--text-dim);
+}
+.fin-cowork .mod-stub-hero-r { flex: 0 0 auto; }
+.fin-cowork .mod-stub-status {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 500;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+}
+.fin-cowork .mod-stub-status .dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--text-mute);
+}
+.fin-cowork .mod-stub-status.ok { background: oklch(0.95 0.05 145); color: oklch(0.36 0.10 145); border-color: oklch(0.85 0.06 145); }
+.fin-cowork .mod-stub-status.ok .dot { background: oklch(0.62 0.16 145); }
+.fin-cowork .mod-stub-status.partial { background: oklch(0.95 0.05 75); color: oklch(0.40 0.10 75); border-color: oklch(0.85 0.06 75); }
+.fin-cowork .mod-stub-status.partial .dot { background: oklch(0.72 0.16 75); }
+.fin-cowork .mod-stub-status.next { background: var(--accent-soft); color: var(--accent); border-color: var(--accent-soft); }
+.fin-cowork .mod-stub-status.next .dot { background: var(--accent); }
+.fin-cowork .mod-stub-status.queue { background: var(--surface); color: var(--text); border-color: var(--border); }
+.fin-cowork .mod-stub-status.queue .dot { background: var(--text-dim); }
+.fin-cowork .mod-stub-status.muted { color: var(--text-mute); }
+.fin-cowork [data-theme="dark"] .mod-stub-status.ok { background: oklch(0.30 0.07 145); color: oklch(0.85 0.10 145); }
+.fin-cowork [data-theme="dark"] .mod-stub-status.partial { background: oklch(0.30 0.07 75); color: oklch(0.85 0.10 75); }
+.fin-cowork .mod-stub-grid {
+  padding: 28px 32px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 14px;
+  flex: 1 1 auto;
+}
+.fin-cowork .mod-stub-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 18px 20px;
+}
+.fin-cowork .mod-stub-card.span { grid-column: 1 / -1; }
+.fin-cowork .mod-stub-card h3 {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin: 0 0 14px;
+}
+.fin-cowork .mod-stub-actions {
+  display: flex; flex-wrap: wrap; gap: 6px;
+}
+.fin-cowork .mod-stub-action {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--bg-2);
+  color: var(--text);
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  padding: 7px 12px;
+  border-radius: var(--radius-sm);
+  cursor: default;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.fin-cowork .mod-stub-action:hover { background: var(--border-2); }
+.fin-cowork .mod-stub-action.primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+.fin-cowork .mod-stub-action.primary:hover { background: var(--accent-2); border-color: var(--accent-2); }
+.fin-cowork .mod-stub-empty { font-size: 12.5px; color: var(--text-mute); margin: 0; }
+.fin-cowork .mod-stub-dl {
+  display: grid;
+  grid-template-columns: 110px 1fr;
+  gap: 8px 12px;
+  margin: 0;
+  font-size: 12.5px;
+}
+.fin-cowork .mod-stub-dl dt { color: var(--text-mute); font-weight: 500; }
+.fin-cowork .mod-stub-dl dd { margin: 0; color: var(--text); }
+.fin-cowork .mod-stub-dl dd.mono { font-family: var(--font-mono); font-size: 12px; }
+.fin-cowork .mod-stub-dl dd.mono.small { font-size: 11px; color: var(--text-dim); word-break: break-all; }
+.fin-cowork .mod-stub-roadmap {
+  list-style: none;
+  margin: 0; padding: 0;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  position: relative;
+}
+.fin-cowork .mod-stub-roadmap li {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 12px 14px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  position: relative;
+  opacity: .7;
+}
+.fin-cowork .mod-stub-roadmap li b { display: block; font-size: 12.5px; font-weight: 600; color: var(--text); margin-bottom: 2px; }
+.fin-cowork .mod-stub-roadmap li small { display: block; font-size: 11px; color: var(--text-dim); line-height: 1.4; }
+.fin-cowork .mod-stub-roadmap li .step {
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text-mute);
+  display: grid; place-items: center;
+  font-size: 11px;
+  font-weight: 600;
+  font-variant-numeric: tabular-nums;
+}
+.fin-cowork .mod-stub-roadmap li.done { opacity: 1; background: oklch(0.97 0.03 145); border-color: oklch(0.85 0.06 145); }
+.fin-cowork .mod-stub-roadmap li.done .step { background: oklch(0.62 0.16 145); border-color: oklch(0.62 0.16 145); color: #fff; }
+.fin-cowork .mod-stub-roadmap li.current { opacity: 1; background: var(--accent-soft); border-color: var(--accent); }
+.fin-cowork .mod-stub-roadmap li.current .step { background: var(--accent); border-color: var(--accent); color: #fff; }
+.fin-cowork [data-theme="dark"] .mod-stub-roadmap li.done { background: oklch(0.28 0.05 145); border-color: oklch(0.45 0.10 145); }
+.fin-cowork [data-theme="dark"] .mod-stub-roadmap li.current { background: oklch(0.28 0.06 220); }
+.fin-cowork .mod-stub-foot {
+  padding: 16px 32px 28px;
+  display: flex; align-items: center; gap: 8px;
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+}
+.fin-cowork .mod-stub-foot-spacer { flex: 1 1 auto; }
+.fin-cowork .mod-stub-tag {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 11.5px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 4px 10px;
+  border-radius: 999px;
+  color: var(--text);
+}
+.fin-cowork .mod-stub-tag .mono { font-family: var(--font-mono); }
+.fin-cowork .mod-stub-link {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  font: inherit;
+  font-size: 12px;
+  color: var(--text-dim);
+  cursor: default;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+.fin-cowork .mod-stub-link:hover { background: var(--border-2); color: var(--text); }
+@media (max-width: 1100px) {
+.fin-cowork .mod-stub-grid { grid-template-columns: 1fr; }
+.fin-cowork .mod-stub-roadmap { grid-template-columns: 1fr 1fr; }
+}
+/* ────────────────── Chat (thread) ────────────────── */
+.fin-cowork .thread {
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+  min-height: 0;
+  background: var(--bg);
+}
+.fin-cowork .th-head {
+  height: 56px;
+  border-bottom: 1px solid var(--border);
+  padding: 0 18px;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.fin-cowork .th-head .av {
+  width: 34px; height: 34px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  color: #fff; font-weight: 600; font-size: 13px;
+}
+.fin-cowork .th-head .who b { display: block; font-size: 14px; font-weight: 600; letter-spacing: -0.01em; }
+.fin-cowork .th-head .who small { display: block; font-size: 11.5px; color: var(--text-dim); }
+.fin-cowork .th-head .who small .dot {
+  display: inline-block; width: 6px; height: 6px; border-radius: 50%;
+  background: oklch(0.72 0.18 145);
+  margin-right: 5px; vertical-align: middle;
+}
+.fin-cowork .th-head .actions { margin-left: auto; display: flex; gap: 4px; }
+.fin-cowork .th-context {
+  background: var(--bg-2);
+  border-bottom: 1px solid var(--border);
+  padding: 8px 18px;
+  display: flex; align-items: center; gap: 14px;
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.fin-cowork .th-context b { color: var(--text); font-weight: 600; }
+.fin-cowork .th-context .pill {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text);
+}
+.fin-cowork .th-context .stage {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 2px 8px;
+  background: var(--origin-OS-bg);
+  color: var(--origin-OS-fg);
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+}
+.fin-cowork .msgs {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 18px 24px 12px;
+  scrollbar-width: thin;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.fin-cowork .msgs::-webkit-scrollbar { width: 10px; }
+.fin-cowork .msgs::-webkit-scrollbar-thumb {
+  background: var(--border); border-radius: 5px;
+  border: 3px solid transparent; background-clip: content-box;
+}
+.fin-cowork .day-sep {
+  align-self: center;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  padding: 3px 10px;
+  border-radius: 999px;
+  margin: 12px 0 8px;
+}
+.fin-cowork .row { display: flex; gap: 10px; margin-top: 2px; max-width: 78%; }
+.fin-cowork .row.me { align-self: flex-end; flex-direction: row-reverse; }
+.fin-cowork .row .av {
+  width: 28px; height: 28px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+  flex: 0 0 auto;
+  margin-top: 2px;
+  align-self: flex-end;
+}
+.fin-cowork .row.me .av { display: none; }
+.fin-cowork .row.continued .av { visibility: hidden; }
+.fin-cowork .bubble {
+  background: var(--bubble-them);
+  color: var(--bubble-them-fg);
+  padding: 8px 12px;
+  border-radius: 14px;
+  border-top-left-radius: 4px;
+  font-size: 13.5px;
+  line-height: 1.45;
+  max-width: 100%;
+  word-wrap: break-word;
+  position: relative;
+}
+.fin-cowork .row.me .bubble {
+  background: var(--bubble-me);
+  color: var(--bubble-me-fg);
+  border-top-left-radius: 14px;
+  border-top-right-radius: 4px;
+}
+.fin-cowork .row.continued .bubble { border-top-left-radius: 14px; }
+.fin-cowork .row.me.continued .bubble { border-top-right-radius: 14px; }
+.fin-cowork .bubble .meta {
+  display: block;
+  font-size: 10.5px;
+  margin-top: 3px;
+  opacity: .65;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+.fin-cowork .row.me .bubble .meta { color: rgba(255,255,255,.85); }
+.fin-cowork .bubble .author {
+  display: block;
+  font-size: 11px;
+  font-weight: 600;
+  margin-bottom: 2px;
+  color: var(--accent);
+}
+.fin-cowork .bubble.note {
+  background: oklch(0.96 0.04 80);
+  color: oklch(0.32 0.06 70);
+  border: 1px dashed oklch(0.80 0.08 80);
+  font-size: 12.5px;
+}
+.fin-cowork [data-theme="dark"] .bubble.note {
+  background: oklch(0.26 0.04 80);
+  color: oklch(0.88 0.05 80);
+  border-color: oklch(0.38 0.06 80);
+}
+.fin-cowork .bubble.file { display: flex; align-items: center; gap: 10px; padding: 10px 12px; }
+.fin-cowork .bubble.file .fic {
+  width: 36px; height: 36px;
+  border-radius: 8px;
+  background: oklch(0.94 0.02 220);
+  color: oklch(0.40 0.10 220);
+  display: grid; place-items: center;
+  flex: 0 0 auto;
+}
+.fin-cowork .bubble.file b { display: block; font-size: 13px; }
+.fin-cowork .bubble.file small { display: block; font-size: 11.5px; opacity: .7; font-family: var(--font-mono); }
+.fin-cowork .typing {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 10px 14px;
+  background: var(--bubble-them);
+  border-radius: 14px;
+  border-top-left-radius: 4px;
+  margin-top: 4px;
+  align-self: flex-start;
+}
+.fin-cowork .typing span {
+  width: 6px; height: 6px;
+  border-radius: 50%;
+  background: var(--text-mute);
+  animation: bounce 1.2s infinite ease-in-out;
+}
+.fin-cowork .typing span:nth-child(2) { animation-delay: .15s; }
+.fin-cowork .typing span:nth-child(3) { animation-delay: .3s; }
+@keyframes bounce {
+  0%, 60%, 100%{ transform: translateY(0); opacity: .5; }
+  30%{ transform: translateY(-4px); opacity: 1; }
+}
+.fin-cowork .composer {
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+  padding: 12px 18px 14px;
+}
+.fin-cowork .composer-inner {
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  padding: 8px 10px 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  transition: border-color .15s, box-shadow .15s;
+}
+.fin-cowork .composer-inner:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.fin-cowork .composer textarea {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  resize: none;
+  outline: none;
+  width: 100%;
+  font: inherit;
+  font-size: 13.5px;
+  line-height: 1.45;
+  color: var(--text);
+  min-height: 22px;
+  max-height: 160px;
+  padding: 4px 2px;
+}
+.fin-cowork .composer-toolbar { display: flex; align-items: center; gap: 4px; }
+.fin-cowork .composer-toolbar .icon-btn {
+  width: 26px; height: 26px;
+  border: 0;
+  background: transparent;
+}
+.fin-cowork .composer-toolbar .icon-btn:hover { background: var(--border-2); color: var(--text); }
+.fin-cowork .composer-toolbar .spacer { flex: 1 1 auto; }
+.fin-cowork .composer-toolbar .hint { font-size: 11px; color: var(--text-mute); margin-right: 4px; }
+.fin-cowork .composer-toolbar .hint kbd {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 3px;
+  padding: 0 4px;
+  margin: 0 1px;
+}
+.fin-cowork .send-btn {
+  appearance: none;
+  border: 0;
+  background: var(--accent);
+  color: #fff;
+  height: 28px;
+  padding: 0 12px;
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 600;
+  cursor: default;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.fin-cowork .send-btn:hover { background: var(--accent-2); }
+.fin-cowork .send-btn:disabled {
+  background: var(--border);
+  color: var(--text-mute);
+  cursor: not-allowed;
+}
+.fin-cowork .icon-btn {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text-dim);
+  width: 28px; height: 28px;
+  border-radius: var(--radius-sm);
+  display: grid; place-items: center;
+  cursor: default;
+}
+.fin-cowork .icon-btn:hover { color: var(--text); border-color: var(--text-mute); }
+/* Empty */
+.fin-cowork .empty {
+  flex: 1 1 auto;
+  display: grid;
+  place-items: center;
+  color: var(--text-mute);
+  font-size: 13px;
+  text-align: center;
+  padding: 40px;
+}
+.fin-cowork .empty .ico {
+  width: 48px; height: 48px;
+  border-radius: 12px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  display: grid; place-items: center;
+  margin: 0 auto 12px;
+  color: var(--text-mute);
+}
+/* Avatar palette helpers */
+.fin-cowork .av-1 { background: linear-gradient(135deg, oklch(0.62 0.12 30),  oklch(0.50 0.15 10)); }
+.fin-cowork .av-2 { background: linear-gradient(135deg, oklch(0.62 0.12 220), oklch(0.50 0.15 260)); }
+.fin-cowork .av-3 { background: linear-gradient(135deg, oklch(0.62 0.12 145), oklch(0.50 0.15 175)); }
+.fin-cowork .av-4 { background: linear-gradient(135deg, oklch(0.62 0.12 80),  oklch(0.50 0.15 50)); }
+.fin-cowork .av-5 { background: linear-gradient(135deg, oklch(0.62 0.12 300), oklch(0.50 0.15 270)); }
+.fin-cowork .av-6 { background: linear-gradient(135deg, oklch(0.62 0.12 180), oklch(0.50 0.15 200)); }
+/* Mono helper */
+.fin-cowork .mono { font-family: var(--font-mono); }
+/* ────────────────── Chat page (3 colunas) ────────────────── */
+.fin-cowork .chat-page {
+  display: grid;
+  grid-template-columns: 1fr 320px;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.fin-cowork .chat-page:has(.linked.collapsed) {
+  grid-template-columns: 1fr 44px;
+}
+.fin-cowork .chat-main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+/* Tabsbar interna do chat (Todos/OS/Equipe/Clientes) */
+.fin-cowork .chat-tabsbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 18px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+}
+.fin-cowork .chat-tabs {
+  display: flex;
+  gap: 2px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 2px;
+}
+.fin-cowork .chat-tab {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 500;
+  padding: 4px 14px;
+  border-radius: 999px;
+  cursor: default;
+  letter-spacing: -0.005em;
+}
+.fin-cowork .chat-tab:hover { color: var(--text); }
+.fin-cowork .chat-tab.active {
+  background: var(--surface);
+  color: var(--text);
+  font-weight: 600;
+  box-shadow: var(--shadow-soft);
+}
+.fin-cowork .chat-search {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  border-radius: 999px;
+  height: 28px;
+  padding: 0 10px 0 9px;
+  width: 240px;
+  color: var(--text-mute);
+}
+.fin-cowork .chat-search input {
+  appearance: none;
+  border: 0;
+  outline: none;
+  background: transparent;
+  flex: 1 1 auto;
+  font: inherit;
+  font-size: 12px;
+  color: var(--text);
+  min-width: 0;
+}
+.fin-cowork .chat-search:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+/* ────────────────── Linked Apps (coluna direita) ────────────────── */
+.fin-cowork .linked {
+  border-left: 1px solid var(--border);
+  background: var(--bg-2);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  min-width: 0;
+  overflow: hidden;
+  transition: width .15s;
+}
+.fin-cowork .linked-h {
+  height: 44px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  background: var(--bg);
+}
+.fin-cowork .linked-h b {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+.fin-cowork .linked-h .icon-btn {
+  width: 26px; height: 26px;
+  background: transparent;
+  border-color: transparent;
+}
+.fin-cowork .linked-h .icon-btn:hover { background: var(--border-2); }
+.fin-cowork .linked-h .spacer { flex: 1 1 auto; }
+.fin-cowork .linked.collapsed .linked-h {
+  flex-direction: column;
+  height: auto;
+  padding: 8px 0;
+  gap: 6px;
+}
+.fin-cowork .linked.collapsed .linked-h .spacer { display: none; }
+.fin-cowork .linked-body {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  padding: 10px;
+  scrollbar-width: thin;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.fin-cowork .linked-body::-webkit-scrollbar { width: 8px; }
+.fin-cowork .linked-body::-webkit-scrollbar-thumb {
+  background: var(--border); border-radius: 4px;
+  border: 2px solid transparent; background-clip: content-box;
+}
+.fin-cowork .linked-empty {
+  flex: 1 1 auto;
+  display: grid;
+  place-content: center;
+  text-align: center;
+  color: var(--text-mute);
+  padding: 40px 16px;
+  gap: 8px;
+}
+.fin-cowork .linked-empty p { font-size: 12px; line-height: 1.45; margin: 0; }
+/* Bloco individual */
+.fin-cowork .lblock {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  overflow: hidden;
+}
+.fin-cowork .lblock-h {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  font-size: 12px;
+  cursor: default;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+}
+.fin-cowork .lblock.collapsed .lblock-h { border-bottom: 0; }
+.fin-cowork .lblock-h:hover { background: var(--bg-2); }
+.fin-cowork .lblock-h b { font-weight: 600; font-size: 12px; color: var(--text); }
+.fin-cowork .lblock-h .spacer { flex: 1 1 auto; }
+.fin-cowork .lblock-chev {
+  color: var(--text-mute);
+  transition: transform .15s;
+  transform: rotate(0deg);
+}
+.fin-cowork .lblock-chev.open { transform: rotate(90deg); }
+.fin-cowork .lblock-b {
+  padding: 10px 12px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.fin-cowork .origin-badge {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+.fin-cowork .origin-badge.o-OS {  background: var(--origin-OS-bg);  color: var(--origin-OS-fg); }
+.fin-cowork .origin-badge.o-CRM { background: var(--origin-CRM-bg); color: var(--origin-CRM-fg); }
+.fin-cowork .origin-badge.o-FIN { background: var(--origin-FIN-bg); color: var(--origin-FIN-fg); }
+.fin-cowork .origin-badge.o-PNT { background: var(--origin-PNT-bg); color: var(--origin-PNT-fg); }
+.fin-cowork .lkv {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  font-size: 12px;
+  padding: 2px 0;
+}
+.fin-cowork .lkv span:first-child {
+  color: var(--text-mute);
+  font-size: 11px;
+  min-width: 76px;
+  flex: 0 0 auto;
+}
+.fin-cowork .lkv b { color: var(--text); font-weight: 500; flex: 1 1 auto; min-width: 0; }
+.fin-cowork .lkv b.mono { font-family: var(--font-mono); font-size: 11.5px; }
+.fin-cowork .lkv.col { flex-direction: column; gap: 2px; }
+.fin-cowork .lstage {
+  display: inline-flex;
+  background: var(--origin-OS-bg);
+  color: var(--origin-OS-fg);
+  padding: 1px 7px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+}
+.fin-cowork .lhint { font-size: 11.5px; color: var(--text-dim); line-height: 1.4; }
+.fin-cowork .lrow-btns {
+  display: flex;
+  gap: 6px;
+  margin-top: 4px;
+}
+.fin-cowork .lbtn-sec {
+  flex: 1 1 0;
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--bg-2);
+  color: var(--text);
+  height: 26px;
+  padding: 0 10px;
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: 11.5px;
+  cursor: default;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+}
+.fin-cowork .lbtn-sec:hover { background: var(--border-2); }
+.fin-cowork .lblock-cta {
+  appearance: none;
+  border: 1px solid var(--accent-soft);
+  background: var(--accent-soft);
+  color: var(--accent);
+  height: 28px;
+  padding: 0 12px;
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: default;
+  margin-top: 4px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  align-self: stretch;
+}
+.fin-cowork .lblock-cta:hover { background: var(--accent); color: #fff; }
+.fin-cowork .lpunch {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 4px;
+  margin-top: 4px;
+}
+.fin-cowork .lpunch-row {
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 6px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.fin-cowork .lpunch-row span { font-size: 9.5px; color: var(--text-mute); text-transform: uppercase; letter-spacing: .04em; }
+.fin-cowork .lpunch-row b { font-size: 12.5px; }
+.fin-cowork .lpunch-row.missing {
+  background: oklch(0.97 0.04 25);
+  border-color: oklch(0.85 0.08 25);
+  border-style: dashed;
+}
+.fin-cowork .lpunch-row.missing b { color: oklch(0.55 0.18 25); }
+.fin-cowork [data-theme="dark"] .lpunch-row.missing {
+  background: oklch(0.26 0.05 25);
+  border-color: oklch(0.45 0.08 25);
+}
+.fin-cowork .latts { display: flex; flex-direction: column; gap: 4px; }
+.fin-cowork .latt {
+  display: flex; align-items: center; gap: 8px;
+  padding: 6px 8px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+}
+.fin-cowork .latt-body { flex: 1 1 auto; min-width: 0; }
+.fin-cowork .latt-body b { display: block; font-size: 11.5px; font-weight: 500; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.fin-cowork .latt-body small { display: block; font-size: 10.5px; color: var(--text-mute); font-family: var(--font-mono); }
+.fin-cowork .lhist { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 5px; }
+.fin-cowork .lhist li {
+  display: flex;
+  gap: 8px;
+  font-size: 11.5px;
+  padding: 5px 0;
+  border-bottom: 1px solid var(--border-2);
+}
+.fin-cowork .lhist li:last-child { border-bottom: 0; }
+.fin-cowork .lhist-when {
+  flex: 0 0 auto;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+  font-size: 10.5px;
+  padding-top: 1px;
+}
+.fin-cowork .lhist-who { flex: 1 1 auto; color: var(--text-dim); line-height: 1.35; }
+.fin-cowork .lhist-who b { color: var(--text); font-weight: 500; }
+/* ════════════════════════ OS LIST PAGE ════════════════════════ */
+.fin-cowork .os-page {
+  flex: 1 1 auto;
+  display: flex; flex-direction: column;
+  min-height: 0;
+  overflow-y: auto;
+  background: var(--bg);
+  position: relative;
+}
+.fin-cowork .os-page-h {
+  padding: 28px 32px 16px;
+  display: flex; align-items: flex-start; gap: 16px;
+  border-bottom: 1px solid var(--border);
+}
+.fin-cowork .os-page-h-l { flex: 1 1 auto; min-width: 0; }
+.fin-cowork .os-page-h-l h1 {
+  margin: 0 0 4px;
+  font-size: 24px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  color: var(--text);
+}
+.fin-cowork .os-page-h-l p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-dim);
+  line-height: 1.5;
+}
+.fin-cowork .os-page-h-r { display: flex; gap: 8px; flex: 0 0 auto; }
+/* Stats */
+.fin-cowork .os-stats {
+  padding: 16px 32px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-2);
+}
+.fin-cowork .os-stat {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 14px;
+  display: flex; flex-direction: column; gap: 2px;
+}
+.fin-cowork .os-stat small {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+}
+.fin-cowork .os-stat b {
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text);
+  font-variant-numeric: tabular-nums;
+}
+.fin-cowork .os-stat.warn {
+  background: oklch(0.97 0.04 25);
+  border-color: oklch(0.85 0.08 25);
+}
+.fin-cowork .os-stat.warn b { color: oklch(0.50 0.18 25); }
+.fin-cowork [data-theme="dark"] .os-stat.warn {
+  background: oklch(0.26 0.06 25);
+  border-color: oklch(0.40 0.10 25);
+}
+.fin-cowork [data-theme="dark"] .os-stat.warn b { color: oklch(0.78 0.16 25); }
+.fin-cowork .os-stat.muted b { color: var(--text-dim); font-size: 18px; }
+/* Toolbar */
+.fin-cowork .os-toolbar {
+  padding: 10px 24px 8px 24px;
+  display: flex; align-items: center; gap: 12px;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  flex-wrap: wrap;
+}
+.fin-cowork .os-tabs {
+  display: flex; gap: 2px;
+  flex-wrap: wrap;
+}
+.fin-cowork .os-tab {
+  appearance: none; border: 0;
+  background: transparent;
+  color: var(--text-dim);
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  padding: 6px 11px;
+  border-radius: var(--radius-sm);
+  cursor: default;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.fin-cowork .os-tab:hover { background: var(--border-2); color: var(--text); }
+.fin-cowork .os-tab.active {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  color: var(--text);
+  padding: 5px 10px;
+  box-shadow: 0 1px 2px rgba(0,0,0,.04);
+}
+.fin-cowork .os-tab.warn { color: oklch(0.55 0.18 25); }
+.fin-cowork .os-tab.warn.active { border-color: oklch(0.85 0.08 25); }
+.fin-cowork .os-tab-n {
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+  background: var(--border-2);
+  color: var(--text-dim);
+  padding: 1px 6px;
+  border-radius: 999px;
+  font-weight: 600;
+}
+.fin-cowork .os-tab.active .os-tab-n { background: var(--accent-soft); color: var(--accent); }
+.fin-cowork .os-tab.warn .os-tab-n { background: oklch(0.93 0.07 25); color: oklch(0.50 0.18 25); }
+.fin-cowork .os-toolbar-r {
+  margin-left: auto;
+  display: flex; align-items: center; gap: 8px;
+}
+.fin-cowork .os-select {
+  appearance: none;
+  font: inherit;
+  font-size: 12px;
+  height: 30px;
+  padding: 0 26px 0 10px;
+  border: 1px solid var(--border);
+  background: var(--surface) url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%23999' stroke-width='2'><path d='m6 9 6 6 6-6'/></svg>") right 8px center/12px no-repeat;
+  border-radius: var(--radius-sm);
+  color: var(--text);
+  outline: none;
+  cursor: default;
+}
+.fin-cowork .os-select:focus { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.fin-cowork .os-search {
+  display: flex; align-items: center; gap: 6px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 5px 10px;
+  color: var(--text-mute);
+  width: 280px;
+}
+.fin-cowork .os-search input {
+  appearance: none; border: 0; background: transparent;
+  font: inherit; font-size: 12px;
+  color: var(--text);
+  flex: 1 1 auto; min-width: 0;
+  outline: none;
+}
+.fin-cowork .os-search:focus-within { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+/* Bulk bar */
+.fin-cowork .os-bulk {
+  padding: 8px 24px;
+  display: flex; align-items: center; gap: 8px;
+  background: var(--accent-soft);
+  border-bottom: 1px solid var(--accent-soft);
+  font-size: 12.5px;
+  color: var(--accent);
+}
+.fin-cowork .os-bulk b { color: var(--accent); }
+.fin-cowork .os-bulk-spacer { flex: 1 1 auto; }
+/* Buttons */
+.fin-cowork .os-btn {
+  appearance: none;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  height: 30px;
+  padding: 0 12px;
+  border-radius: var(--radius-sm);
+  font: inherit;
+  font-size: 12.5px;
+  font-weight: 500;
+  cursor: default;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.fin-cowork .os-btn:hover { background: var(--border-2); }
+.fin-cowork .os-btn.primary { background: var(--accent); color: #fff; border-color: var(--accent); }
+.fin-cowork .os-btn.primary:hover { background: var(--accent-2); border-color: var(--accent-2); }
+.fin-cowork .os-btn.ghost { background: transparent; border-color: transparent; color: var(--text-dim); }
+.fin-cowork .os-btn.ghost:hover { background: var(--border-2); color: var(--text); }
+.fin-cowork .os-btn.ghost.danger { color: oklch(0.55 0.18 25); }
+.fin-cowork .os-btn.ghost.danger:hover { background: oklch(0.96 0.04 25); }
+.fin-cowork .os-btn.sm { height: 26px; padding: 0 10px; font-size: 11.5px; }
+/* Table */
+.fin-cowork .os-table-wrap {
+  flex: 1 1 auto;
+  overflow: auto;
+  background: var(--bg);
+}
+.fin-cowork .os-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 13px;
+}
+.fin-cowork .os-table thead th {
+  position: sticky; top: 0;
+  background: var(--bg-2);
+  border-bottom: 1px solid var(--border);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  padding: 10px 12px;
+  text-align: left;
+  white-space: nowrap;
+  z-index: 1;
+}
+.fin-cowork .os-table .os-th-num { width: 90px; }
+.fin-cowork .os-table .os-th-val { text-align: right; }
+.fin-cowork .os-table tbody td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-2);
+  vertical-align: middle;
+  color: var(--text);
+}
+.fin-cowork .os-row { cursor: default; transition: background .08s; }
+.fin-cowork .os-row:hover { background: var(--bg-2); }
+.fin-cowork .os-row.selected { background: var(--accent-soft); }
+.fin-cowork .os-row.selected td { background: var(--accent-soft); }
+.fin-cowork .os-row.urgent { box-shadow: inset 3px 0 0 oklch(0.62 0.18 25); }
+.fin-cowork .os-cell-check { width: 32px; }
+.fin-cowork .os-cell-check input { accent-color: var(--accent); cursor: default; }
+.fin-cowork .os-cell-num {
+  white-space: nowrap;
+  display: flex; align-items: center; gap: 6px;
+}
+.fin-cowork .os-cell-num .mono {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-dim);
+}
+.fin-cowork .os-urgent-dot {
+  display: inline-block;
+  width: 7px; height: 7px;
+  border-radius: 50%;
+  background: oklch(0.62 0.18 25);
+}
+.fin-cowork .os-cell-client b {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: var(--text);
+  letter-spacing: -0.005em;
+}
+.fin-cowork .os-cell-client small {
+  display: block;
+  font-size: 11.5px;
+  color: var(--text-dim);
+}
+.fin-cowork .os-cell-product {
+  color: var(--text-dim);
+  font-size: 12.5px;
+  max-width: 320px;
+}
+.fin-cowork .os-cell-resp {
+  display: flex; align-items: center; gap: 6px;
+  white-space: nowrap;
+}
+.fin-cowork .os-resp-av {
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  display: grid; place-items: center;
+  color: #fff;
+  font-size: 9.5px;
+  font-weight: 600;
+  flex: 0 0 auto;
+}
+.fin-cowork .os-resp-av.lg { width: 36px; height: 36px; font-size: 12px; }
+.fin-cowork .os-resp-name { font-size: 12.5px; color: var(--text-dim); }
+.fin-cowork .os-cell-deadline {
+  font-size: 12.5px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.fin-cowork .os-cell-deadline.urgent { color: oklch(0.55 0.18 25); font-weight: 600; }
+.fin-cowork .os-cell-value {
+  text-align: right;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--text);
+}
+.fin-cowork .os-table tfoot td {
+  border-top: 2px solid var(--border);
+  background: var(--bg-2);
+  padding: 12px 14px;
+  font-size: 12px;
+  font-weight: 600;
+}
+.fin-cowork .os-foot-l { text-align: right; color: var(--text-dim); }
+.fin-cowork .os-foot-v { text-align: right; color: var(--text); font-size: 14px; }
+/* Empty in table */
+.fin-cowork .os-empty-row { padding: 50px 20px !important; text-align: center; }
+.fin-cowork .os-empty-state {
+  display: flex; flex-direction: column; align-items: center; gap: 4px;
+  color: var(--text-mute);
+}
+.fin-cowork .os-empty-state b { color: var(--text); font-size: 13px; margin-top: 8px; }
+.fin-cowork .os-empty-state small { font-size: 11.5px; color: var(--text-dim); }
+/* Stage badge */
+.fin-cowork .os-stage {
+  display: inline-flex; align-items: center;
+  padding: 3px 9px;
+  border-radius: 999px;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.fin-cowork .os-stage.muted {   background: var(--border-2); color: var(--text-dim); }
+.fin-cowork .os-stage.blue {    background: oklch(0.93 0.06 240); color: oklch(0.40 0.12 240); }
+.fin-cowork .os-stage.amber {   background: oklch(0.94 0.07 75);  color: oklch(0.42 0.12 70);  }
+.fin-cowork .os-stage.violet {  background: oklch(0.93 0.07 295); color: oklch(0.42 0.12 295); }
+.fin-cowork .os-stage.cyan {    background: oklch(0.94 0.06 200); color: oklch(0.42 0.10 200); }
+.fin-cowork .os-stage.green {   background: oklch(0.94 0.06 145); color: oklch(0.40 0.12 145); }
+.fin-cowork .os-stage.red {     background: oklch(0.95 0.05 25);  color: oklch(0.50 0.16 25);  }
+.fin-cowork [data-theme="dark"] .os-stage.muted {   background: oklch(0.30 0 0);     color: oklch(0.78 0 0); }
+.fin-cowork [data-theme="dark"] .os-stage.blue {    background: oklch(0.30 0.07 240); color: oklch(0.85 0.10 240); }
+.fin-cowork [data-theme="dark"] .os-stage.amber {   background: oklch(0.30 0.07 75);  color: oklch(0.85 0.10 75);  }
+.fin-cowork [data-theme="dark"] .os-stage.violet {  background: oklch(0.30 0.07 295); color: oklch(0.85 0.10 295); }
+.fin-cowork [data-theme="dark"] .os-stage.cyan {    background: oklch(0.30 0.07 200); color: oklch(0.85 0.10 200); }
+.fin-cowork [data-theme="dark"] .os-stage.green {   background: oklch(0.30 0.07 145); color: oklch(0.85 0.10 145); }
+.fin-cowork [data-theme="dark"] .os-stage.red {     background: oklch(0.30 0.07 25);  color: oklch(0.85 0.16 25);  }
+/* ════════════════════════ OS DETAIL DRAWER ════════════════════════ */
+.fin-cowork .os-drawer-back {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,.18);
+  z-index: 8;
+  animation: fadein .15s ease-out;
+}
+.fin-cowork [data-theme="dark"] .os-drawer-back { background: rgba(0,0,0,.45); }
+@keyframes fadein { from { opacity: 0; } to { opacity: 1; } }
+.fin-cowork .os-drawer {
+  position: absolute;
+  top: 0; right: 0; bottom: 0;
+  width: min(540px, 100%);
+  background: var(--bg);
+  border-left: 1px solid var(--border);
+  z-index: 9;
+  display: flex; flex-direction: column;
+  overflow-y: auto;
+  box-shadow: -8px 0 32px rgba(0,0,0,.08);
+  animation: slidein .2s cubic-bezier(.2,.8,.2,1);
+}
+.fin-cowork [data-theme="dark"] .os-drawer { box-shadow: -8px 0 32px rgba(0,0,0,.4); }
+@keyframes slidein { from { transform: translateX(20px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+.fin-cowork .os-drawer-h {
+  padding: 16px 20px;
+  display: flex; align-items: center; gap: 10px;
+  border-bottom: 1px solid var(--border);
+  background: var(--surface);
+}
+.fin-cowork .os-drawer-h-l { display: flex; align-items: center; gap: 8px; flex: 1 1 auto; }
+.fin-cowork .os-drawer-num {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--text-dim);
+}
+.fin-cowork .os-urgent-tag {
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  background: oklch(0.95 0.06 25);
+  color: oklch(0.50 0.18 25);
+  padding: 2px 7px;
+  border-radius: 4px;
+}
+.fin-cowork .os-drawer-title {
+  padding: 18px 20px 8px;
+}
+.fin-cowork .os-drawer-title h2 {
+  margin: 0 0 4px;
+  font-size: 19px;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  line-height: 1.3;
+}
+.fin-cowork .os-drawer-title p {
+  margin: 0;
+  font-size: 13px;
+  color: var(--text-dim);
+}
+.fin-cowork .os-drawer-title b { color: var(--text); font-weight: 500; }
+.fin-cowork .os-drawer-meta {
+  padding: 8px 20px 16px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+}
+.fin-cowork .os-drawer-meta > div {
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 8px 10px;
+}
+.fin-cowork .os-drawer-meta small {
+  display: block;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin-bottom: 2px;
+}
+.fin-cowork .os-drawer-meta b {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text);
+}
+.fin-cowork .os-drawer-meta .urgent { color: oklch(0.55 0.18 25); }
+.fin-cowork .os-drawer-meta .mono { font-family: var(--font-mono); }
+.fin-cowork .os-drawer-section {
+  padding: 16px 20px;
+  border-top: 1px solid var(--border-2);
+}
+.fin-cowork .os-drawer-section h3 {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+  color: var(--text-mute);
+  margin: 0 0 12px;
+}
+.fin-cowork .os-drawer-resp {
+  display: flex; align-items: center; gap: 12px;
+}
+.fin-cowork .os-drawer-resp b { display: block; font-size: 13px; font-weight: 500; }
+.fin-cowork .os-drawer-resp small { display: block; font-size: 11.5px; color: var(--text-dim); }
+.fin-cowork .os-drawer-resp button { margin-left: auto; }
+/* Stages flow */
+.fin-cowork .os-stages-flow {
+  display: flex; flex-wrap: wrap; gap: 8px 14px;
+  padding: 4px 0;
+}
+.fin-cowork .os-stage-step {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 11.5px;
+  color: var(--text-mute);
+  position: relative;
+}
+.fin-cowork .os-stage-step .step-dot {
+  width: 8px; height: 8px;
+  border-radius: 50%;
+  background: var(--border);
+  border: 1px solid var(--border);
+}
+.fin-cowork .os-stage-step.done .step-dot { background: oklch(0.62 0.16 145); border-color: oklch(0.62 0.16 145); }
+.fin-cowork .os-stage-step.done { color: var(--text-dim); }
+.fin-cowork .os-stage-step.current .step-dot {
+  background: var(--accent);
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+.fin-cowork .os-stage-step.current { color: var(--accent); font-weight: 600; }
+/* Timeline */
+.fin-cowork .os-timeline {
+  list-style: none;
+  margin: 0; padding: 0;
+  position: relative;
+}
+.fin-cowork .os-timeline::before {
+  content: "";
+  position: absolute;
+  left: 6px; top: 6px; bottom: 6px;
+  width: 1px;
+  background: var(--border);
+}
+.fin-cowork .os-tl-item {
+  position: relative;
+  padding: 6px 0 12px 22px;
+}
+.fin-cowork .os-tl-dot {
+  position: absolute;
+  left: 2px; top: 12px;
+  width: 9px; height: 9px;
+  border-radius: 50%;
+  background: var(--surface);
+  border: 2px solid var(--text-mute);
+}
+.fin-cowork .os-tl-item.create .os-tl-dot { border-color: var(--text-dim); }
+.fin-cowork .os-tl-item.client .os-tl-dot { border-color: oklch(0.62 0.14 220); }
+.fin-cowork .os-tl-item.art    .os-tl-dot { border-color: oklch(0.65 0.16 75);  }
+.fin-cowork .os-tl-item.prod   .os-tl-dot { border-color: oklch(0.62 0.14 295); }
+.fin-cowork .os-tl-item.pending .os-tl-dot { border-color: var(--accent); background: var(--accent); }
+.fin-cowork .os-tl-h {
+  display: flex; align-items: baseline; gap: 6px;
+  font-size: 12px;
+}
+.fin-cowork .os-tl-h b { font-weight: 600; color: var(--text); }
+.fin-cowork .os-tl-h small { color: var(--text-mute); }
+.fin-cowork .os-tl-when {
+  margin-left: auto;
+  font-size: 11px;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.fin-cowork .os-tl-content p {
+  margin: 3px 0 0;
+  font-size: 12.5px;
+  color: var(--text-dim);
+  line-height: 1.5;
+}
+.fin-cowork .os-tl-file {
+  display: inline-flex; align-items: center; gap: 5px;
+  margin-top: 5px;
+  font-size: 11.5px;
+  font-family: var(--font-mono);
+  color: var(--accent);
+  background: var(--accent-soft);
+  padding: 3px 8px;
+  border-radius: 4px;
+}
+.fin-cowork .os-drawer-actions {
+  margin-top: auto;
+  padding: 14px 20px;
+  display: flex; gap: 8px; align-items: center;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+  position: sticky; bottom: 0;
+}
+/* ════════════════════════ NOVA OS DRAWER ════════════════════════ */
+.fin-cowork .os-drawer.wide { width: min(820px, 100%); }
+.fin-cowork .os-new-num {
+  background: oklch(from var(--accent) l c h / 0.12);
+  color: var(--accent);
+  border-radius: 4px;
+  padding: 3px 8px;
+  font-weight: 700;
+  letter-spacing: .02em;
+}
+.fin-cowork .os-new-stepper {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-2);
+}
+.fin-cowork .os-step {
+  all: unset;
+  display: flex; align-items: center; gap: 10px;
+  padding: 12px 14px;
+  cursor: pointer;
+  border-right: 1px solid var(--border);
+  transition: background .12s;
+  position: relative;
+}
+.fin-cowork .os-step:last-child { border-right: 0; }
+.fin-cowork .os-step:hover { background: var(--bg-1); }
+.fin-cowork .os-step.active {
+  background: var(--surface);
+  box-shadow: inset 0 -2px 0 var(--accent);
+}
+.fin-cowork .os-step-bullet {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 22px; height: 22px;
+  border-radius: 50%;
+  background: var(--bg-1);
+  border: 1.5px solid var(--border);
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+.fin-cowork .os-step.done .os-step-bullet {
+  background: var(--accent);
+  border-color: var(--accent);
+  color: white;
+}
+.fin-cowork .os-step-text { display: flex; flex-direction: column; min-width: 0; }
+.fin-cowork .os-step-text b { font-size: 12px; font-weight: 600; color: var(--text); }
+.fin-cowork .os-step-text small {
+  font-size: 11px; color: var(--text-dim);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  max-width: 160px;
+}
+.fin-cowork .os-new-body {
+  padding: 22px 24px 90px;
+  flex: 1 1 auto;
+  overflow-y: auto;
+}
+.fin-cowork .os-new-sec { animation: fadein .15s ease-out; }
+.fin-cowork .os-new-sec h3 {
+  margin: 0 0 4px;
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text);
+}
+.fin-cowork .os-new-help {
+  margin: 0 0 16px;
+  font-size: 12.5px;
+  color: var(--text-dim);
+}
+.fin-cowork .os-new-search {
+  display: flex; align-items: center; gap: 8px;
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 9px 12px;
+  margin-bottom: 10px;
+}
+.fin-cowork .os-new-search input {
+  all: unset;
+  flex: 1; font-size: 13px; color: var(--text);
+}
+.fin-cowork .os-new-search input::placeholder { color: var(--text-dim); }
+.fin-cowork .os-new-results {
+  list-style: none; margin: 0; padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  background: var(--surface);
+}
+.fin-cowork .os-new-results li {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 14px;
+  cursor: pointer;
+  border-bottom: 1px solid var(--border-2);
+  transition: background .12s;
+}
+.fin-cowork .os-new-results li:last-child { border-bottom: 0; }
+.fin-cowork .os-new-results li:hover { background: var(--bg-2); }
+.fin-cowork .os-new-results li b { display: block; font-size: 13px; font-weight: 500; }
+.fin-cowork .os-new-results li small { display: block; font-size: 11.5px; color: var(--text-dim); margin-top: 2px; }
+.fin-cowork .os-new-results li.empty { cursor: default; color: var(--text-dim); justify-content: flex-start; }
+.fin-cowork .os-new-results li.empty a { color: var(--accent); cursor: pointer; margin-left: 6px; }
+.fin-cowork .os-new-last {
+  font-size: 11px; color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+.fin-cowork .os-new-price { font-size: 12px; color: var(--text); font-weight: 500; }
+.fin-cowork .os-new-client-card {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: var(--bg-2);
+  padding: 14px 16px;
+}
+.fin-cowork .os-new-client-h {
+  display: flex; justify-content: space-between; align-items: center;
+  margin-bottom: 14px;
+}
+.fin-cowork .os-new-client-h b { display: block; font-size: 14px; }
+.fin-cowork .os-new-client-h small { display: block; font-size: 11.5px; color: var(--text-dim); margin-top: 2px; font-family: var(--font-mono); }
+.fin-cowork .os-new-row2 {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+}
+.fin-cowork .os-new-row2 label { display: flex; flex-direction: column; gap: 5px; }
+.fin-cowork .os-new-row2 small { font-size: 11px; color: var(--text-dim); font-weight: 500; text-transform: uppercase; letter-spacing: .04em; }
+.fin-cowork .os-new-row2 input {
+  all: unset;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 11px;
+  font-size: 13px; color: var(--text);
+  font-family: inherit;
+}
+.fin-cowork .os-new-row2 input.mono { font-family: var(--font-mono); }
+.fin-cowork .os-new-row2 input:focus { border-color: var(--accent); }
+.fin-cowork .os-new-prod-pickers {
+  display: flex; flex-direction: column; gap: 8px; margin-bottom: 12px;
+}
+.fin-cowork .os-new-cats {
+  display: flex; gap: 6px; flex-wrap: wrap;
+}
+.fin-cowork .os-cat {
+  all: unset;
+  font-size: 11.5px;
+  padding: 5px 11px;
+  border-radius: 999px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: all .12s;
+}
+.fin-cowork .os-cat:hover { background: var(--bg-1); color: var(--text); }
+.fin-cowork .os-cat.active {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+.fin-cowork .os-new-items {
+  margin-top: 16px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  overflow: hidden;
+  background: var(--surface);
+}
+.fin-cowork .os-new-itable {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 13px;
+}
+.fin-cowork .os-new-itable th {
+  font-size: 10.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  color: var(--text-dim);
+  text-align: left;
+  padding: 10px 12px;
+  background: var(--bg-2);
+  border-bottom: 1px solid var(--border);
+}
+.fin-cowork .os-new-itable th.r, .fin-cowork .os-new-itable td.r { text-align: right; }
+.fin-cowork .os-new-itable td {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-2);
+  vertical-align: top;
+}
+.fin-cowork .os-new-itable tbody tr:last-child td { border-bottom: 0; }
+.fin-cowork .os-new-itable td b { display: block; font-weight: 500; font-size: 13px; }
+.fin-cowork .os-new-itable tfoot td {
+  background: var(--bg-2);
+  border-top: 1px solid var(--border);
+  font-size: 13px;
+  padding: 10px 12px;
+}
+.fin-cowork .os-new-itable tfoot b { font-size: 14px; }
+.fin-cowork .os-new-itemnote {
+  all: unset;
+  display: block;
+  margin-top: 4px;
+  width: 100%;
+  font-size: 11.5px;
+  color: var(--text-dim);
+  border-bottom: 1px dashed transparent;
+}
+.fin-cowork .os-new-itemnote:focus { border-bottom-color: var(--border); color: var(--text); }
+.fin-cowork .os-new-itemnote::placeholder { color: var(--text-dim); opacity: .6; }
+.fin-cowork .os-new-qty, .fin-cowork .os-new-price-i {
+  all: unset;
+  width: 60px;
+  text-align: right;
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 4px 6px;
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+}
+.fin-cowork .os-new-price-i { width: 80px; }
+.fin-cowork .os-new-qty:focus, .fin-cowork .os-new-price-i:focus { border-color: var(--accent); }
+.fin-cowork .os-new-unit {
+  display: block;
+  font-size: 10px; color: var(--text-dim);
+  margin-top: 2px;
+  text-transform: lowercase;
+}
+.fin-cowork .os-new-empty {
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--text-dim);
+  border: 1.5px dashed var(--border);
+  border-radius: 10px;
+}
+.fin-cowork .os-new-empty b { display: block; margin: 8px 0 2px; font-size: 13px; color: var(--text); }
+.fin-cowork .os-new-empty small { font-size: 12px; }
+.fin-cowork .os-new-toggle {
+  display: flex !important; align-items: center; gap: 8px;
+  flex-direction: row !important;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 12px;
+  cursor: pointer;
+  align-self: end;
+}
+.fin-cowork .os-new-toggle input { width: auto !important; padding: 0 !important; }
+.fin-cowork .os-new-toggle span { font-size: 13px; color: var(--text); }
+.fin-cowork .os-new-textarea {
+  display: flex; flex-direction: column; gap: 5px;
+  margin-top: 14px;
+}
+.fin-cowork .os-new-textarea small { font-size: 11px; color: var(--text-dim); font-weight: 500; text-transform: uppercase; letter-spacing: .04em; }
+.fin-cowork .os-new-textarea textarea {
+  all: unset;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 13px; color: var(--text);
+  font-family: inherit;
+  line-height: 1.5;
+  resize: vertical;
+  min-height: 80px;
+}
+.fin-cowork .os-new-textarea textarea:focus { border-color: var(--accent); }
+.fin-cowork .os-new-shortcuts {
+  display: flex; align-items: center; gap: 8px;
+  margin-top: 12px;
+}
+.fin-cowork .os-new-shortcuts small { font-size: 11px; color: var(--text-dim); }
+.fin-cowork .os-chip {
+  all: unset;
+  font-size: 11.5px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  color: var(--text);
+  cursor: pointer;
+}
+.fin-cowork .os-chip:hover { background: var(--bg-1); border-color: var(--accent); }
+.fin-cowork .os-new-resps {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 8px;
+}
+.fin-cowork .os-new-resp {
+  all: unset;
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 12px;
+  border: 1.5px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  background: var(--surface);
+  transition: all .12s;
+}
+.fin-cowork .os-new-resp:hover { border-color: var(--text-dim); }
+.fin-cowork .os-new-resp.active {
+  border-color: var(--accent);
+  background: oklch(from var(--accent) l c h / 0.08);
+}
+.fin-cowork .os-new-resp b { display: block; font-size: 13px; font-weight: 500; }
+.fin-cowork .os-new-resp small { display: block; font-size: 11.5px; color: var(--text-dim); margin-top: 2px; }
+.fin-cowork .os-new-attach {
+  display: flex; gap: 8px; flex-wrap: wrap;
+  padding: 14px;
+  border: 1.5px dashed var(--border);
+  border-radius: 8px;
+  background: var(--bg-2);
+}
+.fin-cowork .os-new-files {
+  list-style: none; margin: 12px 0 0; padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+}
+.fin-cowork .os-new-files li {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 12px;
+  border-bottom: 1px solid var(--border-2);
+  font-size: 12.5px;
+  background: var(--surface);
+}
+.fin-cowork .os-new-files li:last-child { border-bottom: 0; }
+.fin-cowork .os-new-files li span { flex: 1; }
+.fin-cowork .os-new-fkind {
+  font-size: 10px; color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: .04em;
+  background: var(--bg-2);
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+.fin-cowork .os-new-foot {
+  flex-wrap: wrap;
+  gap: 12px !important;
+}
+.fin-cowork .os-new-summary {
+  display: flex; align-items: center; gap: 8px; flex-wrap: wrap;
+  font-size: 12px; color: var(--text-dim);
+}
+.fin-cowork .os-new-total {
+  font-size: 14px; color: var(--text); font-weight: 600;
+  margin-left: 6px;
+}
+.fin-cowork .os-btn.disabled, .fin-cowork .os-btn:disabled {
+  opacity: .45; cursor: not-allowed;
+}
+/* ════════════════════════ APROVAR ARTE — MODAL ════════════════════════ */
+.fin-cowork .os-modal-back {
+  position: absolute;
+  inset: 0;
+  background: rgba(0,0,0,.45);
+  z-index: 90;
+  animation: fadein .15s ease-out;
+}
+.fin-cowork [data-theme="dark"] .os-modal-back { background: rgba(0,0,0,.6); }
+.fin-cowork .os-modal {
+  position: absolute;
+  top: 50%; left: 50%;
+  transform: translate(-50%, -50%);
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  z-index: 91;
+  display: flex; flex-direction: column;
+  max-height: 92%;
+  width: min(1080px, 96%);
+  box-shadow: 0 24px 80px rgba(0,0,0,.18);
+  animation: modalin .2s cubic-bezier(.2,.8,.2,1);
+  overflow: hidden;
+}
+.fin-cowork [data-theme="dark"] .os-modal { box-shadow: 0 24px 80px rgba(0,0,0,.6); }
+@keyframes modalin {
+  from { transform: translate(-50%, -48%); opacity: 0; }
+  to   { transform: translate(-50%, -50%); opacity: 1; }
+}
+.fin-cowork .os-modal-h {
+  display: flex; align-items: flex-start; gap: 12px;
+  padding: 18px 22px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.fin-cowork .os-modal-h h2 {
+  margin: 0 0 3px;
+  font-size: 17px; font-weight: 600; color: var(--text);
+}
+.fin-cowork .os-modal-h p {
+  margin: 0;
+  font-size: 12.5px; color: var(--text-dim);
+}
+.fin-cowork .os-modal-h > div { flex: 1; }
+.fin-cowork .os-modal-h .icon-btn { flex-shrink: 0; }
+.fin-cowork .os-modal-foot {
+  padding: 14px 22px;
+  display: flex; align-items: center; gap: 8px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-2);
+}
+/* Body do modal de aprovação: 240px coluna versões + canvas */
+.fin-cowork .os-approve-body {
+  display: grid;
+  grid-template-columns: 260px 1fr;
+  gap: 0;
+  flex: 1 1 auto;
+  min-height: 0;
+}
+.fin-cowork .os-approve-versions {
+  border-right: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  min-height: 0;
+  background: var(--bg-2);
+}
+.fin-cowork .os-approve-modes {
+  display: flex; gap: 4px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border-2);
+}
+.fin-cowork .os-version-list {
+  list-style: none; margin: 0; padding: 8px;
+  flex: 1 1 auto;
+  overflow-y: auto;
+}
+.fin-cowork .os-version-list li {
+  padding: 11px 12px;
+  border-radius: 8px;
+  cursor: pointer;
+  border: 1.5px solid transparent;
+  transition: background .12s, border-color .12s;
+  margin-bottom: 4px;
+}
+.fin-cowork .os-version-list li:hover { background: var(--bg-1); }
+.fin-cowork .os-version-list li.selected {
+  background: var(--surface);
+  border-color: var(--accent);
+}
+.fin-cowork .os-version-list li.compare {
+  border-color: oklch(from var(--accent) l c h / .5);
+  border-style: dashed;
+}
+.fin-cowork .os-version-h {
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 2px;
+}
+.fin-cowork .os-version-h b { font-size: 13px; font-weight: 600; }
+.fin-cowork .os-version-tag {
+  font-size: 9.5px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: .05em;
+  color: oklch(0.40 0.16 145);
+  background: oklch(0.92 0.06 145);
+  padding: 2px 6px;
+  border-radius: 3px;
+}
+.fin-cowork [data-theme="dark"] .os-version-tag {
+  color: oklch(0.85 0.18 145);
+  background: oklch(0.30 0.08 145);
+}
+.fin-cowork .os-version-list small {
+  display: block;
+  font-size: 11px; color: var(--text-dim);
+  margin-bottom: 4px;
+}
+.fin-cowork .os-version-list p {
+  margin: 0;
+  font-size: 11.5px; color: var(--text);
+  line-height: 1.45;
+}
+.fin-cowork .os-approve-canvas {
+  display: flex; align-items: center; justify-content: center;
+  gap: 24px;
+  padding: 28px;
+  background: var(--bg-1);
+  min-height: 0;
+  overflow: auto;
+}
+.fin-cowork .os-approve-canvas.compare { gap: 18px; }
+.fin-cowork .os-approve-vs {
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: .12em;
+  color: var(--text-dim);
+  font-weight: 600;
+  flex-shrink: 0;
+}
+.fin-cowork .os-approve-vs span {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  padding: 6px 14px;
+}
+/* Thumbs (placeholder gráfico colorido por versão) */
+.fin-cowork .os-art-thumb {
+  display: flex; flex-direction: column; align-items: center; gap: 10px;
+}
+.fin-cowork .os-art-thumb small {
+  font-size: 11.5px; color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+.fin-cowork .os-art-frame {
+  width: 320px; height: 220px;
+  background: white;
+  border: 1px solid var(--border);
+  box-shadow: 0 6px 24px rgba(0,0,0,.08);
+  position: relative;
+  overflow: hidden;
+}
+.fin-cowork [data-theme="dark"] .os-art-frame {
+  background: oklch(0.96 0.01 240);
+  box-shadow: 0 6px 24px rgba(0,0,0,.4);
+}
+.fin-cowork .os-art-corner {
+  position: absolute;
+  width: 12px; height: 12px;
+  border: 1.5px solid oklch(0.45 0.04 240);
+  opacity: .35;
+}
+.fin-cowork .os-art-corner.tl { top: 6px; left: 6px; border-right: 0; border-bottom: 0; }
+.fin-cowork .os-art-corner.tr { top: 6px; right: 6px; border-left: 0; border-bottom: 0; }
+.fin-cowork .os-art-corner.bl { bottom: 6px; left: 6px; border-right: 0; border-top: 0; }
+.fin-cowork .os-art-corner.br { bottom: 6px; right: 6px; border-left: 0; border-top: 0; }
+.fin-cowork .os-art-content {
+  position: absolute; inset: 18px;
+  display: flex; flex-direction: column; justify-content: flex-end;
+}
+.fin-cowork .os-art-blob {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(2px);
+  opacity: .85;
+}
+.fin-cowork .os-art-thumb.art-v1 .os-art-blob.a { background: #e8c468; top: -10px; right: 30px; width: 110px; height: 110px; }
+.fin-cowork .os-art-thumb.art-v1 .os-art-blob.b { background: #d97757; top: 50px; right: -20px; width: 90px; height: 90px; }
+.fin-cowork .os-art-thumb.art-v1 .os-art-blob.c { background: #a8a29e; bottom: 60px; right: 50px; width: 60px; height: 60px; opacity: .4; }
+.fin-cowork .os-art-thumb.art-v2 .os-art-blob.a { background: #e8c468; top: -14px; right: 24px; width: 130px; height: 130px; }
+.fin-cowork .os-art-thumb.art-v2 .os-art-blob.b { background: #d97757; top: 46px; right: -18px; width: 100px; height: 100px; }
+.fin-cowork .os-art-thumb.art-v2 .os-art-blob.c { background: #6c8ea4; bottom: 56px; right: 44px; width: 70px; height: 70px; }
+.fin-cowork .os-art-thumb.art-v3 .os-art-blob.a { background: #e8c468; top: -14px; right: 24px; width: 130px; height: 130px; }
+.fin-cowork .os-art-thumb.art-v3 .os-art-blob.b { background: #d97757; top: 46px; right: -18px; width: 100px; height: 100px; }
+.fin-cowork .os-art-thumb.art-v3 .os-art-blob.c { background: #4a6b85; bottom: 56px; right: 44px; width: 70px; height: 70px; }
+.fin-cowork .os-art-text {
+  position: relative;
+  z-index: 2;
+}
+.fin-cowork .os-art-text b {
+  display: block;
+  font-size: 16px; font-weight: 700;
+  color: oklch(0.20 0.04 240);
+  font-family: var(--font-display, var(--font-sans));
+  letter-spacing: -.01em;
+}
+.fin-cowork .os-art-text span {
+  font-size: 11px;
+  color: oklch(0.45 0.04 240);
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+/* Decisão (aprovar/ajustar/rejeitar) */
+.fin-cowork .os-approve-decision {
+  padding: 16px 22px;
+  border-top: 1px solid var(--border);
+  background: var(--surface);
+}
+.fin-cowork .os-decision-options {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+}
+.fin-cowork .os-decision {
+  all: unset;
+  display: flex; align-items: flex-start; gap: 10px;
+  padding: 12px 14px;
+  border: 1.5px solid var(--border);
+  border-radius: 10px;
+  cursor: pointer;
+  background: var(--surface);
+  transition: all .12s;
+}
+.fin-cowork .os-decision:hover { border-color: var(--text-dim); background: var(--bg-2); }
+.fin-cowork .os-decision b { display: block; font-size: 13px; font-weight: 600; color: var(--text); }
+.fin-cowork .os-decision small { display: block; font-size: 11.5px; color: var(--text-dim); margin-top: 2px; line-height: 1.4; }
+.fin-cowork .os-decision svg { margin-top: 2px; flex-shrink: 0; opacity: .65; }
+.fin-cowork .os-decision.approve.active {
+  border-color: oklch(0.55 0.16 145);
+  background: oklch(0.96 0.04 145);
+}
+.fin-cowork [data-theme="dark"] .os-decision.approve.active {
+  background: oklch(0.28 0.06 145);
+}
+.fin-cowork .os-decision.approve.active svg { color: oklch(0.45 0.16 145); opacity: 1; }
+.fin-cowork .os-decision.adjust.active {
+  border-color: oklch(0.62 0.14 75);
+  background: oklch(0.96 0.04 75);
+}
+.fin-cowork [data-theme="dark"] .os-decision.adjust.active {
+  background: oklch(0.30 0.06 75);
+}
+.fin-cowork .os-decision.adjust.active svg { color: oklch(0.55 0.16 75); opacity: 1; }
+.fin-cowork .os-decision.reject.active {
+  border-color: oklch(0.55 0.18 25);
+  background: oklch(0.96 0.04 25);
+}
+.fin-cowork [data-theme="dark"] .os-decision.reject.active {
+  background: oklch(0.30 0.06 25);
+}
+.fin-cowork .os-decision.reject.active svg { color: oklch(0.55 0.18 25); opacity: 1; }
+.fin-cowork .os-decision-comment {
+  display: block;
+  width: 100%;
+  margin-top: 10px;
+  padding: 10px 12px;
+  background: var(--bg-1);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  font-size: 13px; color: var(--text);
+  font-family: inherit;
+  line-height: 1.5;
+  resize: vertical;
+  min-height: 70px;
+  box-sizing: border-box;
+}
+.fin-cowork .os-decision-comment:focus { outline: none; border-color: var(--accent); }
+.fin-cowork .os-decision-confirm {
+  display: flex; align-items: center; gap: 8px;
+  margin-top: 10px;
+  padding: 10px 12px;
+  background: oklch(0.96 0.04 145);
+  border: 1px solid oklch(0.55 0.10 145 / 0.3);
+  border-radius: 6px;
+  font-size: 12.5px;
+  color: oklch(0.30 0.10 145);
+}
+.fin-cowork [data-theme="dark"] .os-decision-confirm {
+  background: oklch(0.26 0.05 145);
+  color: oklch(0.85 0.10 145);
+  border-color: oklch(0.55 0.10 145 / 0.5);
+}
+.fin-cowork .os-decision-confirm svg { flex-shrink: 0; }
+.fin-cowork .os-decision-confirm b { font-weight: 600; }
+.fin-cowork .os-kbd {
+  display: inline-block;
+  padding: 1px 5px;
+  font: 600 10px/1 "IBM Plex Mono", monospace;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-bottom-width: 2px;
+  border-radius: 3px;
+  color: var(--text-dim);
+  margin-left: 4px;
+  vertical-align: middle;
+}
+.fin-cowork .os-decision.active .os-kbd { border-color: currentColor; color: currentColor; opacity: .8; }
+/* ════════════════════════ PRINT (OS Detail) ════════════════════════ */
+@media print {
+.fin-cowork { background: white !important; }
+.fin-cowork .app-shell, .fin-cowork .sidebar, .fin-cowork .chat-panel, .fin-cowork .os-page-h-r, .fin-cowork .os-toolbar, .fin-cowork .os-bulk, .fin-cowork .os-table-wrap, .fin-cowork .os-stats, .fin-cowork .os-drawer-actions, .fin-cowork .os-drawer-back, .fin-cowork .tweaks-panel, .fin-cowork .os-modal-back, .fin-cowork .os-modal { display: none !important; }
+.fin-cowork .os-drawer {
+    position: static !important;
+    width: 100% !important;
+    box-shadow: none !important;
+    border: none !important;
+    transform: none !important;
+  }
+.fin-cowork .os-drawer-h, .fin-cowork .os-drawer-body { padding: 0 !important; }
+@page { margin: 18mm 14mm; }
+}
+/* ════════════════════════ BULK MODAL ════════════════════════ */
+.fin-cowork .os-bulk-modal { width: min(560px, 96%); }
+.fin-cowork .os-bulk-ids {
+  font-size: 11.5px;
+  color: var(--text-dim);
+}
+.fin-cowork .os-bulk-body {
+  padding: 18px 22px;
+  flex: 1 1 auto;
+  overflow-y: auto;
+  max-height: 60vh;
+}
+.fin-cowork .os-bulk-stages {
+  display: flex; flex-direction: column; gap: 6px;
+  margin-bottom: 16px;
+}
+.fin-cowork .os-bulk-stage {
+  all: unset;
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 14px;
+  border: 1.5px solid var(--border);
+  border-radius: 8px;
+  cursor: pointer;
+  background: var(--surface);
+  transition: all .12s;
+}
+.fin-cowork .os-bulk-stage:hover { border-color: var(--text-dim); background: var(--bg-2); }
+.fin-cowork .os-bulk-stage.active {
+  border-color: var(--accent);
+  background: oklch(from var(--accent) l c h / 0.08);
+}
+.fin-cowork .os-bulk-stage svg { color: var(--accent); }
+.fin-cowork .os-bulk-toggle {
+  display: flex; align-items: center; gap: 8px;
+  padding: 10px 12px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  cursor: pointer;
+  margin-top: 14px;
+  font-size: 13px;
+  color: var(--text);
+}
+.fin-cowork .os-bulk-toggle input { margin: 0; }
+/* ════════════════════════ CLIENTES (Fase 3) ════════════════════════ */
+.fin-cowork .cli-name { font-weight: 600; color: var(--text); }
+.fin-cowork .cli-sub { font-size: 11.5px; color: var(--text-dim); margin-top: 2px; }
+.fin-cowork .cli-seg {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.fin-cowork .cli-city { font-size: 12px; color: var(--text-dim); }
+.fin-cowork .cli-num { font-variant-numeric: tabular-nums; font-weight: 500; }
+.fin-cowork .cli-last { font-size: 11.5px; color: var(--text-dim); }
+.fin-cowork .cli-status {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 10px;
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: capitalize;
+}
+.fin-cowork .cli-status.ativo { background: oklch(0.93 0.07 145); color: oklch(0.36 0.10 145); }
+.fin-cowork .cli-status.inativo { background: var(--bg-2); color: var(--text-dim); }
+.fin-cowork .cli-kpis {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  margin-bottom: 16px;
+}
+.fin-cowork .cli-kpi {
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 10px 12px;
+  display: flex; flex-direction: column;
+}
+.fin-cowork .cli-kpi b { font-size: 16px; font-weight: 600; color: var(--text); font-variant-numeric: tabular-nums; }
+.fin-cowork .cli-kpi b.ok { color: oklch(0.50 0.14 145); }
+.fin-cowork .cli-kpi b.muted { color: var(--text-dim); }
+.fin-cowork .cli-kpi small { font-size: 11px; color: var(--text-dim); margin-top: 2px; text-transform: uppercase; letter-spacing: 0.04em; }
+.fin-cowork .cli-tabs { margin: 8px 0 14px; }
+.fin-cowork .cli-section {
+  display: flex; flex-direction: column; gap: 8px;
+}
+.fin-cowork .cli-row {
+  display: grid;
+  grid-template-columns: 140px 1fr;
+  gap: 12px;
+  padding: 8px 0;
+  border-bottom: 1px solid var(--border);
+  font-size: 13px;
+}
+.fin-cowork .cli-row span { color: var(--text-dim); }
+.fin-cowork .cli-row b { color: var(--text); font-weight: 500; }
+.fin-cowork .cli-tags { display: flex; flex-wrap: wrap; gap: 4px; }
+.fin-cowork .cli-tag {
+  padding: 1px 7px;
+  border-radius: 8px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  font-size: 10.5px;
+  color: var(--text-dim);
+}
+.fin-cowork .cli-empty {
+  margin-top: 12px;
+  padding: 16px;
+  background: var(--bg-2);
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  text-align: center;
+  color: var(--text-dim);
+}
+.fin-cowork .cli-empty b { display: block; color: var(--text); margin: 6px 0 2px; }
+.fin-cowork .cli-empty small { font-size: 11.5px; }
+.fin-cowork .cli-empty svg { opacity: 0.4; }
+.fin-cowork .cli-contact {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+}
+.fin-cowork .cli-contact-av {
+  width: 36px; height: 36px;
+  border-radius: 50%;
+  background: oklch(0.65 0.12 240);
+  color: white;
+  display: flex; align-items: center; justify-content: center;
+  font-weight: 600;
+  font-size: 13px;
+}
+.fin-cowork .cli-contact b { display: block; font-size: 13px; }
+.fin-cowork .cli-contact small { font-size: 11.5px; color: var(--text-dim); }
+/* ════════════════════════ ORÇAMENTOS ════════════════════════ */
+.fin-cowork .orc-items {
+  font-size: 12px;
+  color: var(--text-dim);
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.fin-cowork .orc-status {
+  display: inline-block;
+  padding: 2px 8px;
+  border-radius: 4px;
+  border: 1px solid;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: .02em;
+}
+.fin-cowork .orc-os {
+  margin-left: 6px;
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.fin-cowork .orc-prob {
+  position: relative;
+  width: 56px;
+  height: 14px;
+  background: var(--bg-2);
+  border-radius: 3px;
+  overflow: hidden;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.fin-cowork .orc-prob-fill {
+  position: absolute;
+  left: 0; top: 0; bottom: 0;
+  background: oklch(0.55 0.14 240 / .35);
+}
+.fin-cowork .orc-prob span {
+  position: relative;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text);
+}
+/* ════════════════════════ PRODUTOS ════════════════════════ */
+.fin-cowork .prod-toggle {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+  font-size: 12px;
+  color: var(--text-dim);
+  cursor: pointer;
+  user-select: none;
+}
+.fin-cowork .prod-toggle input { accent-color: var(--accent); }
+.fin-cowork .prod-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 12px;
+  padding: 12px 16px;
+}
+.fin-cowork .prod-card {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 12px 14px;
+  cursor: pointer;
+  transition: border-color .12s, transform .12s;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  position: relative;
+}
+.fin-cowork .prod-card:hover { border-color: var(--accent); }
+.fin-cowork .prod-card.selected { border-color: var(--accent); box-shadow: 0 0 0 1px var(--accent); }
+.fin-cowork .prod-card.inactive { opacity: .55; }
+.fin-cowork .prod-card-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+.fin-cowork .prod-cat {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+  color: var(--text-dim);
+}
+.fin-cowork .prod-inactive-badge {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--bg-2);
+  color: var(--text-dim);
+}
+.fin-cowork .prod-name {
+  font-size: 14px;
+  font-weight: 600;
+  margin: 0;
+  line-height: 1.3;
+  text-wrap: pretty;
+}
+.fin-cowork .prod-id {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+.fin-cowork .prod-foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  margin-top: auto;
+}
+.fin-cowork .prod-price b {
+  font-size: 16px;
+  font-weight: 700;
+}
+.fin-cowork .prod-price small {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-left: 2px;
+}
+.fin-cowork .prod-meta {
+  font-size: 11px;
+  color: var(--text-dim);
+  display: flex;
+  gap: 8px;
+  align-items: center;
+}
+.fin-cowork .prod-meta span { display: inline-flex; gap: 3px; align-items: center; }
+.fin-cowork .prod-pop {
+  position: absolute;
+  left: 0; right: 0; bottom: 0;
+  height: 2px;
+  background: var(--bg-2);
+  border-radius: 0 0 8px 8px;
+  overflow: hidden;
+}
+.fin-cowork .prod-pop-fill {
+  height: 100%;
+  background: var(--accent);
+}
+.fin-cowork .prod-bom-h {
+  font-size: 12px;
+  font-weight: 600;
+  margin: 12px 0 6px;
+  color: var(--text-dim);
+  text-transform: uppercase;
+  letter-spacing: .04em;
+}
+.fin-cowork .prod-bom-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12.5px;
+  padding: 4px 0;
+  color: var(--text);
+}
+.fin-cowork .prod-bom-row svg { color: var(--accent); flex-shrink: 0; }
+/* ─── Produção: Fila / Acabamento / Expedição ─── */
+.fin-cowork .prod-page {
+  display: flex; flex-direction: column;
+  height: 100%;
+  background: var(--bg);
+  overflow: hidden;
+}
+.fin-cowork .prod-header {
+  display: flex; align-items: flex-end; justify-content: space-between;
+  padding: 18px 24px 14px;
+  border-bottom: 1px solid var(--border-2);
+  gap: 16px;
+}
+.fin-cowork .prod-header-l h1 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.fin-cowork .prod-header-l p {
+  margin: 2px 0 0;
+  font-size: 12.5px;
+  color: var(--text-mute);
+}
+.fin-cowork .prod-header-r {
+  display: flex; align-items: center; gap: 8px;
+}
+.fin-cowork .prod-view-toggle {
+  display: inline-flex;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  overflow: hidden;
+  margin-right: 4px;
+}
+.fin-cowork .prod-view-toggle button {
+  appearance: none; background: var(--bg); border: 0;
+  padding: 6px 10px;
+  font: inherit; font-size: 12px;
+  display: inline-flex; align-items: center; gap: 5px;
+  color: var(--text-mute);
+  cursor: default;
+  border-right: 1px solid var(--border);
+}
+.fin-cowork .prod-view-toggle button:last-child { border-right: 0; }
+.fin-cowork .prod-view-toggle button.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.fin-cowork .prod-kpis {
+  display: grid; grid-template-columns: repeat(5, 1fr);
+  gap: 12px;
+  padding: 14px 24px 0;
+}
+.fin-cowork .prod-kpi {
+  background: var(--bg-2);
+  border: 1px solid var(--border-2);
+  border-radius: 8px;
+  padding: 12px 14px;
+  display: flex; flex-direction: column; gap: 2px;
+}
+.fin-cowork .prod-kpi-label {
+  font-size: 11px; color: var(--text-mute);
+  text-transform: uppercase; letter-spacing: 0.04em;
+}
+.fin-cowork .prod-kpi-value {
+  font-size: 22px; font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.fin-cowork .prod-kpi-sub {
+  font-size: 11.5px; color: var(--text-mute);
+}
+.fin-cowork .prod-kpi-urgent .prod-kpi-value { color: oklch(0.55 0.18 25); }
+.fin-cowork .prod-kpi-urgent { border-color: oklch(0.85 0.10 25); background: oklch(0.97 0.04 25); }
+.fin-cowork .prod-equip-filters {
+  display: flex; gap: 6px; flex-wrap: wrap;
+  padding: 14px 24px 0;
+}
+.fin-cowork .prod-equip-tab {
+  appearance: none; background: var(--bg-2);
+  border: 1px solid var(--border-2);
+  border-radius: 6px;
+  padding: 6px 10px;
+  font: inherit; font-size: 12px;
+  display: inline-flex; align-items: center; gap: 6px;
+  color: var(--text-mute);
+  cursor: default;
+}
+.fin-cowork .prod-equip-tab .count {
+  font-size: 11px;
+  background: var(--bg-3, var(--bg));
+  padding: 1px 5px;
+  border-radius: 3px;
+  color: var(--text-mute);
+}
+.fin-cowork .prod-equip-tab.active {
+  background: var(--bg);
+  color: var(--text);
+  border-color: var(--text-mute);
+}
+.fin-cowork .prod-equip-tab.active .count { background: var(--accent-soft); color: var(--accent); }
+.fin-cowork .prod-equip-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  display: inline-block;
+}
+.fin-cowork .prod-equip-dot.violet { background: oklch(0.55 0.18 295); }
+.fin-cowork .prod-equip-dot.blue { background: oklch(0.55 0.16 230); }
+.fin-cowork .prod-equip-dot.cyan { background: oklch(0.60 0.13 200); }
+.fin-cowork .prod-kanban {
+  display: grid; grid-template-columns: repeat(3, 1fr);
+  gap: 14px;
+  padding: 14px 24px 24px;
+  flex: 1 1 auto;
+  overflow: auto;
+  align-items: start;
+}
+.fin-cowork .prod-col {
+  background: var(--bg-2);
+  border: 1px solid var(--border-2);
+  border-radius: 10px;
+  display: flex; flex-direction: column;
+  min-height: 240px;
+}
+.fin-cowork .prod-col-head {
+  display: flex; align-items: center; justify-content: space-between;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border-2);
+  gap: 8px;
+}
+.fin-cowork .prod-col-head-l {
+  display: flex; align-items: center; gap: 8px;
+}
+.fin-cowork .prod-col-head h3 {
+  margin: 0; font-size: 13px; font-weight: 600;
+}
+.fin-cowork .prod-col-count {
+  font-size: 11.5px;
+  background: var(--bg);
+  padding: 1px 7px;
+  border-radius: 10px;
+  color: var(--text-mute);
+  border: 1px solid var(--border-2);
+}
+.fin-cowork .prod-col-cap {
+  font-size: 11px; color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.fin-cowork .prod-col-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+}
+.fin-cowork .prod-col-dot.violet { background: oklch(0.55 0.18 295); }
+.fin-cowork .prod-col-dot.amber { background: oklch(0.70 0.14 65); }
+.fin-cowork .prod-col-dot.cyan { background: oklch(0.60 0.13 200); }
+.fin-cowork .prod-col-violet { border-top: 2px solid oklch(0.65 0.14 295); }
+.fin-cowork .prod-col-amber { border-top: 2px solid oklch(0.75 0.12 65); }
+.fin-cowork .prod-col-cyan { border-top: 2px solid oklch(0.70 0.10 200); }
+.fin-cowork .prod-col-ops {
+  display: flex; gap: 4px;
+}
+.fin-cowork .prod-col-op-tag {
+  font-size: 10px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  background: var(--bg);
+  border: 1px solid var(--border-2);
+  color: var(--text-mute);
+}
+.fin-cowork .prod-col-body {
+  display: flex; flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+}
+.fin-cowork .prod-empty {
+  font-size: 12px;
+  color: var(--text-mute);
+  text-align: center;
+  padding: 24px 8px;
+  border: 1px dashed var(--border-2);
+  border-radius: 6px;
+}
+/* Cards */
+.fin-cowork .prod-card {
+  background: var(--bg);
+  border: 1px solid var(--border-2);
+  border-radius: 8px;
+  padding: 10px 11px;
+  display: flex; flex-direction: column; gap: 6px;
+  cursor: default;
+  transition: border-color .12s, box-shadow .12s;
+}
+.fin-cowork .prod-card:hover {
+  border-color: var(--text-mute);
+  box-shadow: 0 1px 3px rgba(0,0,0,.04);
+}
+.fin-cowork .prod-card.urgent {
+  border-color: oklch(0.75 0.16 25);
+  box-shadow: 0 0 0 2px oklch(0.95 0.06 25);
+}
+.fin-cowork .prod-card-top {
+  display: flex; align-items: center; gap: 6px;
+  font-size: 11px;
+}
+.fin-cowork .prod-seq {
+  font-weight: 600;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.fin-cowork .prod-os {
+  font-family: var(--mono, "IBM Plex Mono", monospace);
+  font-size: 11px;
+  color: var(--text);
+  font-weight: 500;
+}
+.fin-cowork .prod-urgent {
+  margin-left: auto;
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  font-weight: 600;
+  color: oklch(0.50 0.18 25);
+  background: oklch(0.95 0.06 25);
+  padding: 1px 5px;
+  border-radius: 3px;
+}
+.fin-cowork .prod-card-title {
+  font-size: 13px;
+  font-weight: 500;
+  line-height: 1.3;
+  text-wrap: pretty;
+}
+.fin-cowork .prod-card-client {
+  font-size: 11.5px;
+  color: var(--text-mute);
+}
+.fin-cowork .prod-equip-row {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 6px;
+}
+.fin-cowork .prod-equip-pill {
+  font-size: 11px;
+  padding: 2px 7px;
+  border-radius: 10px;
+  font-weight: 500;
+}
+.fin-cowork .prod-equip-pill.violet { background: oklch(0.94 0.05 295); color: oklch(0.40 0.14 295); }
+.fin-cowork .prod-equip-pill.blue { background: oklch(0.94 0.05 230); color: oklch(0.40 0.13 230); }
+.fin-cowork .prod-equip-pill.cyan { background: oklch(0.94 0.04 200); color: oklch(0.40 0.10 200); }
+.fin-cowork .prod-eta {
+  font-size: 11px;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.fin-cowork .prod-progress {
+  position: relative;
+  height: 6px;
+  background: var(--bg-2);
+  border-radius: 3px;
+  overflow: hidden;
+}
+.fin-cowork .prod-progress-bar {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 3px;
+  transition: width .3s ease;
+}
+.fin-cowork .prod-progress-label {
+  position: absolute;
+  right: 0; top: -16px;
+  font-size: 10px;
+  color: var(--text-mute);
+  font-variant-numeric: tabular-nums;
+}
+.fin-cowork .prod-card-foot {
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 6px;
+  padding-top: 4px;
+}
+.fin-cowork .prod-deadline {
+  font-size: 11px;
+  color: var(--text-mute);
+}
+.fin-cowork .prod-card.urgent .prod-deadline { color: oklch(0.50 0.18 25); font-weight: 500; }
+.fin-cowork .prod-actions {
+  display: flex; gap: 4px;
+}
+.fin-cowork .prod-act {
+  appearance: none;
+  background: var(--bg-2);
+  border: 1px solid var(--border-2);
+  border-radius: 4px;
+  padding: 3px 7px;
+  font: inherit; font-size: 11px;
+  color: var(--text-mute);
+  cursor: default;
+  display: inline-flex; align-items: center; gap: 3px;
+}
+.fin-cowork .prod-act:hover { color: var(--text); border-color: var(--text-mute); }
+.fin-cowork .prod-act.primary {
+  background: var(--accent);
+  color: white;
+  border-color: var(--accent);
+}
+.fin-cowork .prod-act.primary:hover { background: var(--accent-2); }
+.fin-cowork .prod-op-pill {
+  font-size: 10.5px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: oklch(0.94 0.06 65);
+  color: oklch(0.42 0.12 65);
+  font-weight: 500;
+}
+.fin-cowork .prod-route-pill {
+  font-size: 10.5px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: oklch(0.94 0.04 200);
+  color: oklch(0.40 0.10 200);
+  font-weight: 500;
+  display: inline-flex; align-items: center; gap: 3px;
+}
+.fin-cowork .prod-pieces-row {
+  display: flex; align-items: center; justify-content: space-between;
+  font-size: 11.5px;
+}
+.fin-cowork .prod-pieces { color: var(--text); font-weight: 500; }
+.fin-cowork .prod-pct { color: var(--text-mute); font-variant-numeric: tabular-nums; }
+.fin-cowork .prod-exp-meta {
+  display: grid; grid-template-columns: auto 1fr;
+  gap: 2px 8px;
+  margin: 2px 0 0;
+  font-size: 11px;
+}
+.fin-cowork .prod-exp-meta dt { color: var(--text-mute); }
+.fin-cowork .prod-exp-meta dd { margin: 0; color: var(--text); }
+/* Lista plana */
+.fin-cowork .prod-list {
+  flex: 1 1 auto;
+  overflow: auto;
+  padding: 14px 24px 24px;
+}
+.fin-cowork .prod-list .os-table tbody tr { cursor: default; }
+.fin-cowork .prod-list .os-table tbody tr:hover td { background: var(--bg-2); }
+.fin-cowork .row-urgent td:first-child {
+  border-left: 2px solid oklch(0.65 0.18 25);
+}
+.fin-cowork .stage-pill {
+  font-size: 11px;
+  padding: 2px 7px;
+  border-radius: 10px;
+  font-weight: 500;
+}
+.fin-cowork .stage-producao { background: oklch(0.94 0.05 295); color: oklch(0.40 0.14 295); }
+.fin-cowork .stage-acabamento { background: oklch(0.94 0.06 65); color: oklch(0.42 0.12 65); }
+.fin-cowork .stage-expedicao { background: oklch(0.94 0.04 200); color: oklch(0.40 0.10 200); }
+.fin-cowork .t-truncate { max-width: 320px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.fin-cowork .t-urgent { color: oklch(0.50 0.18 25); font-weight: 500; }
+/* Drawer */
+.fin-cowork .prod-drawer-backdrop {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,.18);
+  z-index: 70;
+  display: flex; justify-content: flex-end;
+}
+.fin-cowork .prod-drawer {
+  width: 480px; max-width: 92vw;
+  background: var(--bg);
+  border-left: 1px solid var(--border);
+  display: flex; flex-direction: column;
+  box-shadow: -8px 0 24px rgba(0,0,0,.08);
+}
+.fin-cowork .prod-drawer-head {
+  display: flex; align-items: flex-start; justify-content: space-between;
+  padding: 18px 20px 14px;
+  border-bottom: 1px solid var(--border-2);
+  gap: 12px;
+}
+.fin-cowork .prod-drawer-eyebrow {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-mute);
+}
+.fin-cowork .prod-drawer-head h2 {
+  margin: 4px 0 2px;
+  font-size: 17px;
+  font-weight: 600;
+}
+.fin-cowork .prod-drawer-head p {
+  margin: 0;
+  font-size: 12.5px;
+  color: var(--text-mute);
+}
+.fin-cowork .prod-drawer-body {
+  padding: 16px 20px;
+  flex: 1 1 auto;
+  overflow: auto;
+}
+.fin-cowork .prod-drawer-meta {
+  display: grid; grid-template-columns: auto 1fr;
+  gap: 6px 14px;
+  margin: 0 0 18px;
+  font-size: 12.5px;
+}
+.fin-cowork .prod-drawer-meta dt { color: var(--text-mute); }
+.fin-cowork .prod-drawer-meta dd { margin: 0; color: var(--text); }
+.fin-cowork .prod-drawer-actions {
+  display: flex; gap: 8px; flex-wrap: wrap;
+}
+/* ════════════════════════ CLIENTES PAGE ════════════════════════ */
+.fin-cowork .cli-page .os-table th, .fin-cowork .cli-page .os-table td { padding: 10px 12px; }
+.fin-cowork .cli-name { display: flex; align-items: center; gap: 10px; }
+.fin-cowork .cli-avatar {
+  width: 32px; height: 32px; border-radius: 50%;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 11px; font-weight: 600; color: #fff; flex-shrink: 0;
+  letter-spacing: 0.02em;
+}
+.fin-cowork .cli-avatar.lg { width: 48px; height: 48px; font-size: 16px; }
+.fin-cowork .cli-avatar.grad-1 { background: linear-gradient(135deg, #5b6cff 0%, #8b5cf6 100%); }
+.fin-cowork .cli-avatar.grad-2 { background: linear-gradient(135deg, #06b6d4 0%, #0ea5e9 100%); }
+.fin-cowork .cli-avatar.grad-3 { background: linear-gradient(135deg, #f59e0b 0%, #ef4444 100%); }
+.fin-cowork .cli-avatar.grad-4 { background: linear-gradient(135deg, #10b981 0%, #059669 100%); }
+.fin-cowork .cli-avatar.grad-5 { background: linear-gradient(135deg, #ec4899 0%, #be185d 100%); }
+.fin-cowork .cli-name-text { font-weight: 600; color: var(--ink-1); font-size: 13px; }
+.fin-cowork .cli-doc { font-size: 11px; color: var(--ink-3); font-family: var(--font-mono); margin-top: 1px; }
+.fin-cowork .cli-contact-line { font-weight: 500; color: var(--ink-2); font-size: 13px; }
+.fin-cowork .cli-phone { font-size: 11px; color: var(--ink-3); font-family: var(--font-mono); margin-top: 1px; }
+.fin-cowork .cli-table .num { text-align: right; font-variant-numeric: tabular-nums; }
+.fin-cowork .cli-table .value { font-weight: 600; color: var(--ink-1); }
+.fin-cowork .cli-status {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 8px; border-radius: 999px;
+  font-size: 11px; font-weight: 500;
+}
+.fin-cowork .cli-status.late { background: #fef2f2; color: #b91c1c; }
+.fin-cowork .cli-status.active { background: #ecfdf5; color: #047857; }
+.fin-cowork .cli-status.idle { background: var(--bg-2); color: var(--ink-3); }
+/* Drawer */
+.fin-cowork .cli-drawer { width: min(620px, 100%); }
+.fin-cowork .cli-head { display: flex; align-items: center; gap: 14px; }
+.fin-cowork .cli-head-name { font-size: 17px; font-weight: 600; color: var(--ink-1); }
+.fin-cowork .cli-head-doc { font-size: 12px; color: var(--ink-3); font-family: var(--font-mono); margin-top: 2px; }
+.fin-cowork .cli-kpis {
+  display: grid; grid-template-columns: repeat(4, 1fr);
+  gap: 8px; padding: 16px 20px;
+  border-bottom: 1px solid var(--line);
+}
+.fin-cowork .cli-kpi {
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 10px 12px;
+}
+.fin-cowork .cli-kpi.danger { border-color: #fecaca; background: #fef2f2; }
+.fin-cowork .cli-kpi-v { font-size: 18px; font-weight: 600; color: var(--ink-1); font-variant-numeric: tabular-nums; }
+.fin-cowork .cli-kpi.danger .cli-kpi-v { color: #b91c1c; }
+.fin-cowork .cli-kpi-l { font-size: 10px; color: var(--ink-3); text-transform: uppercase; letter-spacing: 0.05em; margin-top: 2px; }
+.fin-cowork .cli-section { padding: 18px 20px; border-bottom: 1px solid var(--line); }
+.fin-cowork .cli-section:last-of-type { border-bottom: 0; }
+.fin-cowork .cli-section-title {
+  font-size: 11px; font-weight: 600; text-transform: uppercase;
+  letter-spacing: 0.06em; color: var(--ink-3);
+  margin-bottom: 10px;
+}
+.fin-cowork .cli-info-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 12px 20px; }
+.fin-cowork .cli-info-l { font-size: 11px; color: var(--ink-3); margin-bottom: 2px; }
+.fin-cowork .cli-info-v { font-size: 13px; color: var(--ink-1); font-weight: 500; }
+.fin-cowork .cli-history { display: flex; flex-direction: column; gap: 6px; }
+.fin-cowork .cli-os {
+  display: grid;
+  grid-template-columns: 60px 1fr 110px 90px 90px;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 10px;
+  background: var(--bg-1);
+  border: 1px solid var(--line);
+  border-radius: 6px;
+  font-size: 12px;
+}
+.fin-cowork .cli-os-id { font-family: var(--font-mono); font-weight: 600; color: var(--ink-2); }
+.fin-cowork .cli-os-prod { color: var(--ink-1); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.fin-cowork .cli-os-stage {
+  padding: 2px 8px; border-radius: 4px;
+  font-size: 10px; font-weight: 500; text-align: center;
+  background: var(--bg-2); color: var(--ink-2);
+}
+.fin-cowork .cli-os-stage.stage-aprovacao { background: #fef3c7; color: #92400e; }
+.fin-cowork .cli-os-stage.stage-producao, .fin-cowork .cli-os-stage.stage-acabamento { background: #ede9fe; color: #5b21b6; }
+.fin-cowork .cli-os-stage.stage-expedicao { background: #cffafe; color: #155e75; }
+.fin-cowork .cli-os-stage.stage-entregue { background: #d1fae5; color: #065f46; }
+.fin-cowork .cli-os-stage.stage-orcado { background: #dbeafe; color: #1e40af; }
+.fin-cowork .cli-os-stage.stage-cancelado { background: #fee2e2; color: #991b1b; }
+.fin-cowork .cli-os-deadline { color: var(--ink-3); font-size: 11px; }
+.fin-cowork .cli-os-value { text-align: right; font-weight: 600; color: var(--ink-1); font-variant-numeric: tabular-nums; }
+.fin-cowork .cli-fin { display: flex; flex-direction: column; gap: 4px; }
+.fin-cowork .cli-fin-row {
+  display: flex; justify-content: space-between;
+  padding: 8px 10px;
+  font-size: 13px;
+  background: var(--bg-1);
+  border-radius: 6px;
+}
+.fin-cowork .cli-fin-row b { font-variant-numeric: tabular-nums; }
+.fin-cowork .cli-fin-row b.danger { color: #b91c1c; }
+.fin-cowork .cli-empty {
+  text-align: center; padding: 24px;
+  color: var(--ink-3); font-size: 13px;
+  background: var(--bg-1); border-radius: 6px;
+}
+/* ════════════ VENDAS ════════════ */
+.fin-cowork .vendas-page .vd-id { font-family:var(--font-mono); font-size:12px; color:oklch(0.40 0.04 250); font-weight:600; }
+.fin-cowork .vendas-page .vd-date { font-size:11px; }
+.fin-cowork .vendas-page .vd-time { font-size:10px; color:oklch(0.55 0.02 250); }
+.fin-cowork .vendas-page .vd-client-name { font-weight:600; font-size:13px; }
+.fin-cowork .vendas-page .vd-notes { font-size:11px; color:oklch(0.50 0.02 250); }
+.fin-cowork .vendas-page .vd-pay > div:first-child { font-weight:500; font-size:12px; }
+.fin-cowork .vendas-page .vd-transp { font-size:11.5px; }
+.fin-cowork .vendas-page .vd-transp-pill {
+  display:inline-flex; align-items:center; gap:4px;
+  font-size:11px; font-weight:500;
+  padding:2px 8px; border-radius:99px;
+  background:oklch(0.93 0.02 240);
+  color:oklch(0.38 0.07 240);
+  white-space:nowrap;
+}
+.fin-cowork .vendas-page .vd-transp-pill.retira {
+  background:oklch(0.94 0.04 145);
+  color:oklch(0.38 0.10 145);
+}
+.fin-cowork .vendas-page .vd-transp-pill.proprio {
+  background:oklch(0.94 0.04 60);
+  color:oklch(0.38 0.10 60);
+}
+.fin-cowork .vendas-page .vd-inst { font-size:10px; color:oklch(0.50 0.02 250); }
+.fin-cowork .vendas-page .vd-items { text-align:center; font-variant-numeric:tabular-nums; }
+.fin-cowork .vendas-page .vd-total { font-weight:600; font-variant-numeric:tabular-nums; font-size:13px; }
+.fin-cowork .vendas-page .vd-os-pill { display:inline-block; padding:1px 6px; border-radius:4px; background:oklch(0.95 0.01 250); font-family:var(--font-mono); font-size:10px; margin-right:3px; color:oklch(0.40 0.04 250); }
+.fin-cowork .vendas-page .vd-no-os { font-size:11px; color:oklch(0.55 0.02 250); font-style:italic; }
+.fin-cowork .kbd-hint { display:inline-block; padding:1px 5px; margin-left:4px; border:1px solid oklch(0.85 0.02 250); border-radius:3px; font-family:var(--font-mono); font-size:9px; color:oklch(0.40 0.04 250); background:#fff; }
+/* Drawer venda */
+.fin-cowork .vd-section { padding:14px 20px; border-bottom:1px solid oklch(0.95 0.01 250); }
+.fin-cowork .vd-section:last-child { border-bottom:none; }
+.fin-cowork .vd-section h3 { font-size:12px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.45 0.02 250); margin:0 0 12px; font-weight:600; }
+.fin-cowork .vd-meta { display:grid; grid-template-columns:140px 1fr; gap:6px 16px; margin:0; font-size:13px; }
+.fin-cowork .vd-meta dt { color:oklch(0.50 0.02 250); }
+.fin-cowork .vd-meta dd { margin:0; }
+.fin-cowork .vd-total-strong { font-weight:600; font-size:15px; }
+.fin-cowork .vd-os-list { display:flex; flex-direction:column; gap:6px; }
+.fin-cowork .vd-os-link { display:flex; align-items:center; justify-content:space-between; padding:8px 12px; background:oklch(0.97 0.01 250); border-radius:6px; font-size:12px; cursor:pointer; }
+.fin-cowork .vd-os-link:hover { background:oklch(0.94 0.01 250); }
+.fin-cowork .vd-docs { display:flex; gap:8px; flex-wrap:wrap; }
+/* Stepper */
+.fin-cowork .vd-stepper { display:flex; align-items:center; gap:6px; padding:10px 20px; background:oklch(0.98 0.01 250); border-bottom:1px solid oklch(0.92 0.01 250); overflow-x:auto; }
+.fin-cowork .vd-step { display:flex; align-items:center; gap:6px; padding:6px 10px; background:transparent; border:none; cursor:pointer; font-size:12px; color:oklch(0.50 0.02 250); border-radius:4px; }
+.fin-cowork .vd-step.active { color:oklch(0.30 0.10 240); font-weight:600; background:#fff; box-shadow:0 1px 2px rgba(0,0,0,0.04); }
+.fin-cowork .vd-step.done { color:oklch(0.45 0.12 145); }
+.fin-cowork .vd-step-num { display:inline-flex; align-items:center; justify-content:center; width:20px; height:20px; border-radius:50%; background:oklch(0.92 0.01 250); font-size:11px; font-weight:600; }
+.fin-cowork .vd-step.active .vd-step-num { background:oklch(0.55 0.14 240); color:#fff; }
+.fin-cowork .vd-step.done .vd-step-num { background:oklch(0.55 0.14 145); color:#fff; }
+.fin-cowork .vd-step-sep { color:oklch(0.75 0.01 250); margin:0 2px; }
+/* Create body */
+.fin-cowork .vd-create-body { padding:0; }
+.fin-cowork .vd-search-wrap { display:flex; align-items:center; gap:8px; padding:8px 12px; background:#fff; border:1px solid oklch(0.88 0.01 250); border-radius:6px; }
+.fin-cowork .vd-search-wrap input { flex:1; border:none; outline:none; font-size:13px; }
+.fin-cowork .vd-search-wrap input:focus { outline:none; }
+.fin-cowork .vd-walkin { background:oklch(0.92 0.04 240); color:oklch(0.30 0.10 240); border:none; padding:4px 10px; border-radius:4px; font-size:11px; cursor:pointer; }
+.fin-cowork .vd-walkin:hover { background:oklch(0.88 0.05 240); }
+.fin-cowork .vd-client-list { display:grid; grid-template-columns:1fr 1fr; gap:6px; margin-top:10px; }
+.fin-cowork .vd-client-card { text-align:left; padding:10px 12px; border:1px solid oklch(0.92 0.01 250); border-radius:6px; background:#fff; cursor:pointer; }
+.fin-cowork .vd-client-card:hover { border-color:oklch(0.55 0.14 240); background:oklch(0.98 0.02 240); }
+.fin-cowork .vd-client-card-name { font-weight:600; font-size:13px; }
+.fin-cowork .vd-client-card-meta { font-size:11px; color:oklch(0.50 0.02 250); margin-top:2px; }
+.fin-cowork .vd-client-selected { display:flex; flex-direction:column; gap:12px; padding:12px; background:oklch(0.97 0.01 250); border-radius:6px; }
+.fin-cowork .vd-fields { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
+.fin-cowork .vd-fields label { display:flex; flex-direction:column; gap:4px; font-size:11px; color:oklch(0.45 0.02 250); }
+.fin-cowork .vd-fields input, .fin-cowork .vd-fields select { padding:6px 8px; border:1px solid oklch(0.88 0.01 250); border-radius:4px; font-size:13px; }
+/* Itens */
+.fin-cowork .vd-prod-suggest { margin-top:6px; background:#fff; border:1px solid oklch(0.92 0.01 250); border-radius:6px; max-height:240px; overflow:auto; }
+.fin-cowork .vd-prod-row { display:flex; justify-content:space-between; align-items:center; width:100%; padding:8px 12px; border:none; background:transparent; cursor:pointer; font-size:13px; text-align:left; border-bottom:1px solid oklch(0.96 0.01 250); }
+.fin-cowork .vd-prod-row:hover { background:oklch(0.97 0.01 250); }
+.fin-cowork .vd-prod-row:last-child { border-bottom:none; }
+.fin-cowork .vd-prod-price { color:oklch(0.45 0.12 145); font-weight:600; font-variant-numeric:tabular-nums; }
+.fin-cowork .vd-empty-mini { padding:10px 12px; font-size:12px; color:oklch(0.55 0.02 250); }
+.fin-cowork .vd-empty-state { padding:30px; text-align:center; color:oklch(0.55 0.02 250); font-size:13px; background:oklch(0.98 0.01 250); border-radius:6px; margin-top:10px; }
+.fin-cowork .vd-items-table { width:100%; margin-top:14px; border-collapse:collapse; font-size:12px; }
+.fin-cowork .vd-items-table th { text-align:left; font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); padding:6px 8px; border-bottom:1px solid oklch(0.92 0.01 250); }
+.fin-cowork .vd-items-table td { padding:6px 8px; border-bottom:1px solid oklch(0.96 0.01 250); }
+.fin-cowork .vd-items-table input { width:100%; padding:4px 6px; border:1px solid oklch(0.90 0.01 250); border-radius:3px; font-size:12px; }
+.fin-cowork .vd-strong { font-weight:600; font-variant-numeric:tabular-nums; }
+.fin-cowork .vd-toggle { display:flex; align-items:center; gap:6px; font-size:11px; }
+.fin-cowork .vd-foot-l { text-align:right; padding-top:10px !important; font-size:11px; color:oklch(0.45 0.02 250); }
+.fin-cowork .vd-foot-r { text-align:right; padding-top:10px !important; font-weight:700; font-size:14px; }
+/* Pagamento */
+.fin-cowork .vd-pay-grid { display:grid; grid-template-columns:repeat(3, 1fr); gap:8px; }
+.fin-cowork .vd-pay-card { display:flex; flex-direction:column; gap:2px; align-items:flex-start; padding:12px; border:1px solid oklch(0.92 0.01 250); border-radius:6px; background:#fff; cursor:pointer; text-align:left; }
+.fin-cowork .vd-pay-card.active { border-color:oklch(0.55 0.14 240); background:oklch(0.97 0.03 240); box-shadow:0 0 0 2px oklch(0.55 0.14 240 / 0.15); }
+.fin-cowork .vd-pay-icon { font-size:18px; }
+.fin-cowork .vd-pay-label { font-weight:600; font-size:13px; }
+.fin-cowork .vd-pay-clear { font-size:10px; color:oklch(0.50 0.02 250); }
+.fin-cowork .vd-totals { display:grid; grid-template-columns:1fr auto; gap:6px 16px; margin:14px 0 0; font-size:13px; }
+.fin-cowork .vd-totals dt { color:oklch(0.50 0.02 250); }
+.fin-cowork .vd-totals dd { margin:0; text-align:right; font-variant-numeric:tabular-nums; }
+.fin-cowork .vd-total-row { font-weight:700; font-size:16px; padding-top:6px; border-top:1px solid oklch(0.92 0.01 250); }
+/* Confirmar */
+.fin-cowork .vd-confirm-grid { display:grid; grid-template-columns:1fr 1fr; gap:10px; }
+.fin-cowork .vd-confirm-block { display:flex; flex-direction:column; gap:2px; padding:12px; background:oklch(0.97 0.01 250); border-radius:6px; }
+.fin-cowork .vd-confirm-label { font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); }
+.fin-cowork .vd-confirm-block strong { font-size:14px; }
+.fin-cowork .vd-confirm-total { background:oklch(0.55 0.14 145 / 0.08); }
+.fin-cowork .vd-total-big { font-size:22px; color:oklch(0.40 0.14 145); font-variant-numeric:tabular-nums; }
+.fin-cowork .vd-callout { margin-top:14px; padding:12px; background:oklch(0.95 0.05 240); border-left:3px solid oklch(0.55 0.14 240); border-radius:4px; font-size:12px; color:oklch(0.30 0.08 240); }
+.fin-cowork .vd-callout-ok { background:oklch(0.95 0.05 145); border-left-color:oklch(0.55 0.14 145); color:oklch(0.30 0.10 145); }
+/* Foot */
+.fin-cowork .vd-foot { display:flex; justify-content:space-between; align-items:center; }
+.fin-cowork .vd-foot-summary { display:flex; align-items:baseline; gap:10px; font-size:12px; color:oklch(0.50 0.02 250); }
+.fin-cowork .vd-foot-total { font-size:16px; font-weight:700; color:oklch(0.20 0.02 250); font-variant-numeric:tabular-nums; }
+.fin-cowork .vd-foot-actions { display:flex; gap:8px; }
+/* ════════════ VENDAS MODULE — sub-nav + extras ════════════ */
+.fin-cowork .vendas-module { display:flex; flex-direction:column; height:100%; }
+.fin-cowork .vm-subnav {
+  display:flex; align-items:center; justify-content:space-between;
+  padding:0 20px; border-bottom:1px solid oklch(0.93 0.01 250);
+  background:#fff; flex-shrink:0;
+}
+.fin-cowork .vm-subnav-tabs { display:flex; gap:0; }
+.fin-cowork .vm-subtab {
+  display:inline-flex; align-items:center; gap:6px;
+  padding:10px 14px; border:none; background:transparent; cursor:pointer;
+  font-size:12px; color:oklch(0.50 0.02 250); font-weight:500;
+  border-bottom:2px solid transparent; transition:all .12s;
+}
+.fin-cowork .vm-subtab:hover { color:oklch(0.30 0.02 250); }
+.fin-cowork .vm-subtab.active { color:var(--accent); border-bottom-color:var(--accent); }
+.fin-cowork .vm-pdv-btn {
+  display:inline-flex; align-items:center; gap:8px;
+  padding:6px 12px; border:1px solid oklch(0.85 0.02 250);
+  border-radius:6px; background:#fff; cursor:pointer;
+  font-size:12px; color:oklch(0.30 0.02 250); font-weight:500;
+}
+.fin-cowork .vm-pdv-btn:hover { background:oklch(0.97 0.01 250); }
+.fin-cowork .vm-pdv-btn kbd {
+  display:inline-block; padding:1px 5px; border:1px solid oklch(0.85 0.02 250);
+  border-radius:3px; font-family:var(--font-mono); font-size:9px;
+  color:oklch(0.40 0.04 250); background:oklch(0.97 0.01 250);
+}
+.fin-cowork .vm-body { flex:1; overflow:auto; }
+/* ──── CAIXA DO DIA ──── */
+.fin-cowork .vc-page .vc-date {
+  padding:5px 8px; border:1px solid oklch(0.85 0.02 250); border-radius:6px;
+  font-size:12px; font-family:var(--font-mono);
+}
+.fin-cowork .vc-grid {
+  display:grid; grid-template-columns:1.3fr 1fr; gap:14px;
+  padding:0 20px 20px;
+}
+.fin-cowork .vc-grid > .vc-card:nth-child(3) { grid-column: 1 / -1; }
+.fin-cowork .vc-card {
+  background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px;
+  overflow:hidden;
+}
+.fin-cowork .vc-card-h {
+  display:flex; align-items:baseline; justify-content:space-between;
+  padding:12px 16px; border-bottom:1px solid oklch(0.95 0.01 250);
+}
+.fin-cowork .vc-card-h h3 {
+  margin:0; font-size:12px; text-transform:uppercase; letter-spacing:0.04em;
+  color:oklch(0.30 0.02 250); font-weight:600;
+}
+.fin-cowork .vc-muted { font-size:11px; color:oklch(0.55 0.02 250); }
+.fin-cowork .vc-pay-table { width:100%; border-collapse:collapse; font-size:13px; }
+.fin-cowork .vc-pay-table th, .fin-cowork .vc-pay-table td {
+  padding:9px 16px; text-align:left; border-bottom:1px solid oklch(0.96 0.01 250);
+}
+.fin-cowork .vc-pay-table th {
+  font-weight:500; font-size:11px; color:oklch(0.50 0.02 250);
+  background:oklch(0.98 0.005 250);
+}
+.fin-cowork .vc-pay-icon { display:inline-block; margin-right:6px; }
+.fin-cowork .vc-num { font-variant-numeric:tabular-nums; text-align:right; }
+.fin-cowork .vc-num.strong { font-weight:600; }
+.fin-cowork .vc-pay-table tfoot td {
+  font-weight:600; background:oklch(0.98 0.005 250);
+  border-top:2px solid oklch(0.90 0.01 250); border-bottom:none;
+}
+.fin-cowork .vc-moves { list-style:none; margin:0; padding:0; max-height:280px; overflow:auto; }
+.fin-cowork .vc-move {
+  display:grid; grid-template-columns:50px 90px 1fr 110px;
+  align-items:center; gap:10px; padding:8px 16px;
+  border-bottom:1px solid oklch(0.96 0.01 250); font-size:12px;
+}
+.fin-cowork .vc-move-time { color:oklch(0.50 0.02 250); font-family:var(--font-mono); font-size:11px; }
+.fin-cowork .vc-move-type {
+  text-transform:uppercase; font-size:10px; font-weight:600; letter-spacing:0.04em;
+}
+.fin-cowork .vc-move-abertura .vc-move-type { color:oklch(0.45 0.10 240); }
+.fin-cowork .vc-move-suprimento .vc-move-type { color:oklch(0.45 0.14 145); }
+.fin-cowork .vc-move-sangria .vc-move-type { color:oklch(0.50 0.16 25); }
+.fin-cowork .vc-move-amount { text-align:right; font-variant-numeric:tabular-nums; font-weight:600; }
+.fin-cowork .vc-move-amount.pos { color:oklch(0.45 0.14 145); }
+.fin-cowork .vc-move-amount.neg { color:oklch(0.50 0.16 25); }
+.fin-cowork .vc-move-add {
+  display:grid; grid-template-columns:130px 110px 1fr auto;
+  gap:6px; padding:12px 16px; background:oklch(0.98 0.005 250);
+  border-top:1px solid oklch(0.93 0.01 250);
+}
+.fin-cowork .vc-move-add input, .fin-cowork .vc-move-add select {
+  padding:6px 10px; border:1px solid oklch(0.88 0.01 250);
+  border-radius:5px; font-size:12px; background:#fff;
+}
+.fin-cowork .vc-counter {
+  display:grid; grid-template-columns:1fr 1.2fr 1fr; gap:24px;
+  padding:20px 16px; align-items:start;
+}
+.fin-cowork .vc-counter label { display:flex; flex-direction:column; gap:6px; font-size:11px; color:oklch(0.50 0.02 250); text-transform:uppercase; letter-spacing:0.04em; }
+.fin-cowork .vc-counter input {
+  padding:8px 12px; border:1px solid oklch(0.88 0.01 250); border-radius:6px;
+  font-size:14px; font-variant-numeric:tabular-nums; background:#fff;
+}
+.fin-cowork .vc-counter-big { font-size:22px !important; font-weight:600; padding:12px !important; }
+.fin-cowork .vc-counter-summary { margin:0; display:grid; grid-template-columns:1fr auto; gap:6px 12px; font-size:12px; }
+.fin-cowork .vc-counter-summary dt { color:oklch(0.50 0.02 250); }
+.fin-cowork .vc-counter-summary dd { margin:0; font-variant-numeric:tabular-nums; text-align:right; }
+.fin-cowork .vc-counter-summary .strong { font-weight:600; font-size:14px; padding-top:6px; border-top:1px solid oklch(0.90 0.01 250); }
+/* ──── DEVOLUÇÕES ──── */
+.fin-cowork .vd-dev-page .vdv-reason { font-size:13px; margin:0; }
+.fin-cowork .vdv-timeline { list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:8px; font-size:12px; }
+.fin-cowork .vdv-timeline li { display:flex; align-items:center; gap:10px; }
+.fin-cowork .vdv-tl-dot { width:10px; height:10px; border-radius:50%; background:oklch(0.88 0.01 250); border:2px solid oklch(0.95 0.01 250); flex-shrink:0; }
+.fin-cowork .vdv-tl-dot.ok { background:oklch(0.55 0.14 145); }
+.fin-cowork .vdv-tl-dot.active { background:oklch(0.60 0.14 70); box-shadow:0 0 0 3px oklch(0.60 0.14 70 / 0.2); }
+.fin-cowork .vdv-input { width:100%; padding:8px 12px; border:1px solid oklch(0.85 0.02 250); border-radius:6px; font-size:13px; }
+.fin-cowork .vdv-matches { margin-top:8px; display:flex; flex-direction:column; gap:4px; }
+.fin-cowork .vdv-match { display:grid; grid-template-columns:80px 1fr 100px; gap:10px; padding:8px 12px; background:oklch(0.97 0.01 250); border:none; border-radius:6px; cursor:pointer; text-align:left; font-size:12px; align-items:center; }
+.fin-cowork .vdv-match:hover { background:oklch(0.93 0.02 250); }
+.fin-cowork .vdv-selected { display:flex; align-items:center; gap:14px; padding:12px; background:oklch(0.96 0.02 145); border-radius:6px; }
+.fin-cowork .vdv-reasons { display:flex; flex-wrap:wrap; gap:6px; margin-bottom:10px; }
+.fin-cowork .vdv-reason-btn { padding:6px 12px; border:1px solid oklch(0.85 0.02 250); border-radius:20px; background:#fff; cursor:pointer; font-size:12px; }
+.fin-cowork .vdv-reason-btn.active { background:var(--accent); border-color:var(--accent); color:#fff; }
+.fin-cowork .vdv-textarea { width:100%; min-height:60px; padding:8px 12px; border:1px solid oklch(0.85 0.02 250); border-radius:6px; font-family:inherit; font-size:12px; resize:vertical; }
+/* ──── COMISSÕES ──── */
+.fin-cowork .vco-period { display:inline-flex; border:1px solid oklch(0.85 0.02 250); border-radius:6px; overflow:hidden; }
+.fin-cowork .vco-period button { padding:6px 12px; border:none; background:#fff; cursor:pointer; font-size:12px; color:oklch(0.40 0.02 250); }
+.fin-cowork .vco-period button.active { background:var(--accent); color:#fff; }
+.fin-cowork .vco-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(340px, 1fr)); gap:14px; padding:0 20px 14px; }
+.fin-cowork .vco-card { background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px; padding:16px; position:relative; }
+.fin-cowork .vco-card header { display:grid; grid-template-columns:auto 1fr auto; gap:12px; align-items:center; margin-bottom:14px; }
+.fin-cowork .vco-card header h3 { margin:0 0 2px; font-size:14px; }
+.fin-cowork .vco-card header span { font-size:11px; color:oklch(0.55 0.02 250); }
+.fin-cowork .vco-avatar {
+  width:40px; height:40px; border-radius:50%;
+  background:oklch(0.94 0.04 var(--accent-h, 220));
+  color:var(--accent); display:flex; align-items:center; justify-content:center;
+  font-weight:600; font-size:14px;
+}
+.fin-cowork .vco-rank {
+  font-family:var(--font-mono); font-size:14px; color:oklch(0.55 0.02 250);
+  font-weight:600;
+}
+.fin-cowork .vco-bar { height:8px; background:oklch(0.95 0.01 250); border-radius:4px; overflow:hidden; margin-bottom:12px; }
+.fin-cowork .vco-bar-fill { height:100%; background:linear-gradient(90deg, var(--accent), var(--accent-2)); }
+.fin-cowork .vco-numbers { display:grid; grid-template-columns:1fr 1fr; gap:10px; margin-bottom:12px; }
+.fin-cowork .vco-numbers > div { display:flex; flex-direction:column; gap:2px; }
+.fin-cowork .vco-numbers span { font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); }
+.fin-cowork .vco-numbers strong { font-size:18px; font-variant-numeric:tabular-nums; }
+.fin-cowork .vco-com strong { color:oklch(0.45 0.14 145); }
+.fin-cowork .vco-mix { display:flex; flex-wrap:wrap; gap:4px; }
+.fin-cowork .vco-chip { padding:2px 8px; background:oklch(0.96 0.01 250); border-radius:10px; font-size:10px; color:oklch(0.40 0.02 250); }
+.fin-cowork .vco-chip em { font-style:normal; font-weight:600; color:var(--accent); margin-left:2px; }
+.fin-cowork .vco-table-card { margin:0 20px 20px; padding:16px; background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px; }
+.fin-cowork .vco-table-card h3 { margin:0 0 12px; font-size:12px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.30 0.02 250); }
+.fin-cowork .vco-rules { width:100%; border-collapse:collapse; font-size:13px; }
+.fin-cowork .vco-rules th, .fin-cowork .vco-rules td { padding:8px 12px; text-align:left; border-bottom:1px solid oklch(0.96 0.01 250); }
+.fin-cowork .vco-rules th { font-size:11px; color:oklch(0.50 0.02 250); font-weight:500; }
+/* ──── RELATÓRIOS ──── */
+.fin-cowork .vrep-tabs { display:flex; gap:6px; padding:0 20px 12px; }
+.fin-cowork .vrep-tabs button { padding:6px 14px; border:1px solid oklch(0.88 0.01 250); border-radius:20px; background:#fff; cursor:pointer; font-size:12px; }
+.fin-cowork .vrep-tabs button.active { background:var(--accent); border-color:var(--accent); color:#fff; }
+.fin-cowork .vrep-summary {
+  display:grid; grid-template-columns:repeat(4, 1fr); gap:10px;
+  padding:0 20px 14px;
+}
+.fin-cowork .vrep-summary > div {
+  background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px;
+  padding:12px 14px; display:flex; flex-direction:column; gap:4px;
+}
+.fin-cowork .vrep-summary span { font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); }
+.fin-cowork .vrep-summary strong { font-size:18px; font-variant-numeric:tabular-nums; }
+.fin-cowork .vrep-card { margin:0 20px 14px; padding:16px; background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px; }
+.fin-cowork .vrep-card h3 { margin:0 0 14px; font-size:12px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.30 0.02 250); }
+.fin-cowork .vrep-bars {
+  display:flex; align-items:flex-end; gap:14px;
+  height:240px; padding-top:30px;
+}
+.fin-cowork .vrep-bar-col {
+  flex:1; display:flex; flex-direction:column; align-items:center;
+  height:100%; min-width:40px; position:relative;
+}
+.fin-cowork .vrep-bar {
+  width:100%; max-width:54px; min-height:2px;
+  background:linear-gradient(180deg, var(--accent), var(--accent-2));
+  border-radius:4px 4px 0 0; margin-top:auto;
+}
+.fin-cowork .vrep-bar-val {
+  font-size:10px; font-variant-numeric:tabular-nums;
+  color:oklch(0.40 0.02 250); font-weight:600; margin-bottom:6px;
+}
+.fin-cowork .vrep-bar-lbl { font-size:11px; color:oklch(0.55 0.02 250); margin-top:6px; }
+.fin-cowork .vrep-clients { list-style:none; margin:0; padding:0; display:flex; flex-direction:column; gap:6px; }
+.fin-cowork .vrep-clients li {
+  display:grid; grid-template-columns:30px 1fr 80px 1fr 110px;
+  gap:12px; align-items:center; padding:8px 4px; font-size:12px;
+}
+.fin-cowork .vrep-rank { font-family:var(--font-mono); color:oklch(0.55 0.02 250); font-weight:600; }
+.fin-cowork .vrep-cli-name { font-weight:500; }
+.fin-cowork .vrep-cli-n { font-size:11px; color:oklch(0.55 0.02 250); }
+.fin-cowork .vrep-cli-bar { height:6px; background:oklch(0.95 0.01 250); border-radius:3px; overflow:hidden; }
+.fin-cowork .vrep-cli-bar > div { height:100%; background:var(--accent); }
+.fin-cowork .vrep-cli-total { text-align:right; font-variant-numeric:tabular-nums; font-weight:600; }
+.fin-cowork .vrep-origin { display:flex; gap:30px; align-items:center; padding:14px 0; }
+.fin-cowork .vrep-donut {
+  width:160px; height:160px; border-radius:50%;
+  display:flex; flex-direction:column; align-items:center; justify-content:center;
+  position:relative;
+}
+.fin-cowork .vrep-donut::after {
+  content:""; position:absolute; inset:25px; background:#fff; border-radius:50%;
+}
+.fin-cowork .vrep-donut > * { position:relative; z-index:1; }
+.fin-cowork .vrep-donut span { font-size:24px; font-weight:600; }
+.fin-cowork .vrep-donut small { font-size:11px; color:oklch(0.55 0.02 250); }
+.fin-cowork .vrep-origin-legend { margin:0; display:grid; grid-template-columns:auto 1fr; gap:8px 16px; font-size:13px; }
+.fin-cowork .vrep-origin-legend dt { display:flex; align-items:center; gap:8px; color:oklch(0.30 0.02 250); }
+.fin-cowork .vrep-dot { width:10px; height:10px; border-radius:50%; }
+/* ──── PDV BALCÃO (overlay) ──── */
+.fin-cowork .pdv-overlay {
+  position:fixed; inset:0; background:oklch(0.18 0.02 250); z-index:1000;
+  display:flex; flex-direction:column; color:oklch(0.95 0.01 250);
+}
+.fin-cowork .pdv-head {
+  display:flex; align-items:center; justify-content:space-between;
+  padding:10px 18px; background:oklch(0.14 0.02 250);
+  border-bottom:1px solid oklch(0.25 0.02 250); flex-shrink:0;
+}
+.fin-cowork .pdv-head-l { display:flex; align-items:center; gap:10px; font-size:13px; }
+.fin-cowork .pdv-brand { font-weight:700; letter-spacing:0.06em; color:var(--accent-2); }
+.fin-cowork .pdv-sep { color:oklch(0.50 0.02 250); }
+.fin-cowork .pdv-head-r { display:flex; align-items:center; gap:14px; }
+.fin-cowork .pdv-shortcut { font-size:11px; color:oklch(0.65 0.02 250); }
+.fin-cowork .pdv-shortcut kbd {
+  display:inline-block; padding:2px 6px; margin-right:4px;
+  border:1px solid oklch(0.45 0.02 250); border-radius:3px;
+  font-family:var(--font-mono); font-size:10px;
+  background:oklch(0.22 0.02 250); color:oklch(0.95 0.01 250);
+}
+.fin-cowork .pdv-close {
+  width:28px; height:28px; border-radius:50%;
+  background:oklch(0.25 0.02 250); border:none; color:#fff;
+  cursor:pointer; font-size:18px; line-height:1;
+}
+.fin-cowork .pdv-grid { display:grid; grid-template-columns:1fr 380px; flex:1; overflow:hidden; }
+.fin-cowork .pdv-left { display:flex; flex-direction:column; padding:20px; overflow:hidden; }
+.fin-cowork .pdv-scan { position:relative; flex-shrink:0; margin-bottom:16px; }
+.fin-cowork .pdv-scan-label { display:block; font-size:11px; color:oklch(0.65 0.02 250); text-transform:uppercase; letter-spacing:0.06em; margin-bottom:6px; }
+.fin-cowork .pdv-scan-input {
+  width:100%; padding:18px 20px; font-size:24px;
+  background:oklch(0.95 0.01 250); border:3px solid var(--accent);
+  border-radius:10px; color:oklch(0.18 0.02 250); font-weight:500;
+  outline:none;
+}
+.fin-cowork .pdv-suggest {
+  position:absolute; top:100%; left:0; right:0; z-index:10;
+  margin:4px 0 0; padding:0; list-style:none;
+  background:#fff; border-radius:8px; overflow:hidden;
+  box-shadow:0 8px 24px rgba(0,0,0,0.4);
+}
+.fin-cowork .pdv-suggest li {
+  display:flex; justify-content:space-between; align-items:center;
+  padding:12px 16px; cursor:pointer; color:oklch(0.18 0.02 250);
+  border-bottom:1px solid oklch(0.95 0.01 250); font-size:14px;
+}
+.fin-cowork .pdv-suggest li:hover { background:oklch(0.94 0.02 var(--accent-h, 220)); }
+.fin-cowork .pdv-items-wrap { flex:1; overflow:auto; background:oklch(0.95 0.01 250); border-radius:8px; color:oklch(0.18 0.02 250); }
+.fin-cowork .pdv-empty { padding:80px 20px; text-align:center; color:oklch(0.50 0.02 250); }
+.fin-cowork .pdv-empty-big { font-size:18px; margin-bottom:6px; color:oklch(0.30 0.02 250); }
+.fin-cowork .pdv-items { width:100%; border-collapse:collapse; font-size:14px; }
+.fin-cowork .pdv-items th { padding:12px 14px; background:oklch(0.92 0.01 250); text-align:left; font-size:11px; color:oklch(0.40 0.02 250); text-transform:uppercase; letter-spacing:0.04em; }
+.fin-cowork .pdv-items td { padding:12px 14px; border-bottom:1px solid oklch(0.92 0.01 250); }
+.fin-cowork .pdv-qty { display:inline-flex; align-items:center; gap:6px; }
+.fin-cowork .pdv-qty button { width:24px; height:24px; border-radius:4px; border:1px solid oklch(0.85 0.02 250); background:#fff; cursor:pointer; font-weight:600; }
+.fin-cowork .pdv-qty span { min-width:24px; text-align:center; font-weight:600; }
+.fin-cowork .pdv-prod { font-weight:500; }
+.fin-cowork .pdv-num { text-align:right; font-variant-numeric:tabular-nums; }
+.fin-cowork .pdv-num.strong { font-weight:600; }
+.fin-cowork .pdv-rm { width:24px; height:24px; border-radius:4px; background:oklch(0.94 0.04 25); border:none; color:oklch(0.50 0.16 25); cursor:pointer; }
+.fin-cowork .pdv-right {
+  background:oklch(0.20 0.02 250); padding:24px 20px;
+  display:flex; flex-direction:column; gap:16px;
+  border-left:1px solid oklch(0.25 0.02 250);
+}
+.fin-cowork .pdv-r-label { display:block; font-size:11px; color:oklch(0.65 0.02 250); text-transform:uppercase; letter-spacing:0.06em; margin-bottom:6px; }
+.fin-cowork .pdv-client input {
+  width:100%; padding:10px 12px; border-radius:6px;
+  background:oklch(0.25 0.02 250); border:1px solid oklch(0.30 0.02 250);
+  color:#fff; font-size:14px;
+}
+.fin-cowork .pdv-pay-grid { display:grid; grid-template-columns:1fr 1fr; gap:6px; }
+.fin-cowork .pdv-pay-btn {
+  padding:14px 8px; border-radius:8px;
+  background:oklch(0.25 0.02 250); border:2px solid oklch(0.30 0.02 250);
+  color:#fff; cursor:pointer; display:flex; flex-direction:column;
+  align-items:center; gap:4px; font-size:12px;
+}
+.fin-cowork .pdv-pay-btn.active { border-color:var(--accent); background:oklch(0.30 0.06 var(--accent-h, 220)); }
+.fin-cowork .pdv-pay-icon { font-size:20px; }
+.fin-cowork .pdv-total-block {
+  margin-top:auto; padding:18px; border-radius:10px;
+  background:oklch(0.14 0.02 250); border:2px solid var(--accent);
+  text-align:right;
+}
+.fin-cowork .pdv-total-label { font-size:11px; color:oklch(0.65 0.02 250); letter-spacing:0.08em; }
+.fin-cowork .pdv-total-value { display:block; font-size:42px; font-weight:700; color:var(--accent-2); font-variant-numeric:tabular-nums; line-height:1.1; }
+.fin-cowork .pdv-total-meta { font-size:11px; color:oklch(0.65 0.02 250); }
+.fin-cowork .pdv-finalize {
+  padding:18px; border-radius:8px; background:oklch(0.55 0.14 145);
+  color:#fff; border:none; cursor:pointer; font-size:16px; font-weight:600;
+  display:flex; align-items:center; justify-content:center; gap:10px;
+}
+.fin-cowork .pdv-finalize:disabled { opacity:0.4; cursor:not-allowed; }
+.fin-cowork .pdv-finalize kbd {
+  padding:2px 6px; border:1px solid oklch(0.95 0.01 145 / 0.5);
+  border-radius:3px; font-family:var(--font-mono); font-size:11px;
+  background:rgba(0,0,0,0.2);
+}
+.fin-cowork .pdv-cancel { padding:10px; border-radius:6px; background:transparent; color:oklch(0.75 0.02 250); border:1px solid oklch(0.30 0.02 250); cursor:pointer; font-size:12px; }
+/* ──── RECIBO (térmica + A4) ──── */
+.fin-cowork .pdv-recibo-overlay { background:oklch(0.30 0.02 250); }
+.fin-cowork .rec-stage { flex:1; overflow:auto; display:flex; justify-content:center; padding:30px; }
+.fin-cowork .rec-layout { display:inline-flex; border:1px solid oklch(0.40 0.02 250); border-radius:6px; overflow:hidden; }
+.fin-cowork .rec-layout button { padding:6px 12px; border:none; background:transparent; color:oklch(0.85 0.02 250); cursor:pointer; font-size:12px; }
+.fin-cowork .rec-layout button.active { background:var(--accent); color:#fff; }
+.fin-cowork .rec-paper { background:#fff; color:#222; padding:20px; }
+.fin-cowork .rec-termica {
+  width:300px; font-family:var(--font-mono);
+  font-size:12px; line-height:1.4;
+}
+.fin-cowork .rec-tx-header { text-align:center; margin-bottom:8px; }
+.fin-cowork .rec-tx-title { font-weight:700; font-size:13px; }
+.fin-cowork .rec-tx-meta { font-size:11px; }
+.fin-cowork .rec-tx-divider { text-align:center; color:#777; }
+.fin-cowork .rec-tx-items { width:100%; font-size:11px; }
+.fin-cowork .rec-tx-prod { padding-top:4px; font-weight:500; }
+.fin-cowork .rec-tx-r { text-align:right; font-weight:600; }
+.fin-cowork .rec-tx-totals { margin-top:8px; }
+.fin-cowork .rec-tx-totals > div { display:flex; justify-content:space-between; }
+.fin-cowork .rec-tx-total { font-weight:700; font-size:14px; padding-top:4px; border-top:1px dashed #999; margin-top:4px; }
+.fin-cowork .rec-tx-pay { margin-top:8px; }
+.fin-cowork .rec-tx-foot { text-align:center; font-size:10px; margin-top:12px; }
+.fin-cowork .rec-tx-barcode { margin-top:8px; font-size:14px; letter-spacing:1px; }
+.fin-cowork .rec-a4 { width:794px; min-height:1100px; padding:60px 70px; font-family:var(--font-sans, sans-serif); }
+.fin-cowork .rec-a4-h { display:flex; justify-content:space-between; align-items:flex-start; padding-bottom:20px; border-bottom:2px solid #222; }
+.fin-cowork .rec-a4-logo { font-size:28px; font-weight:700; letter-spacing:0.04em; }
+.fin-cowork .rec-a4-tag { font-size:12px; color:#666; }
+.fin-cowork .rec-a4-meta { text-align:right; font-size:11px; line-height:1.6; color:#555; }
+.fin-cowork .rec-a4-title { display:flex; justify-content:space-between; align-items:baseline; margin:30px 0 24px; }
+.fin-cowork .rec-a4-title h1 { margin:0; font-size:22px; }
+.fin-cowork .rec-a4-title span { color:#666; font-size:13px; }
+.fin-cowork .rec-a4-block { margin-bottom:24px; }
+.fin-cowork .rec-a4-block h3 { margin:0 0 8px; font-size:11px; text-transform:uppercase; letter-spacing:0.06em; color:#888; }
+.fin-cowork .rec-a4-items { width:100%; border-collapse:collapse; font-size:13px; }
+.fin-cowork .rec-a4-items th { background:#f5f5f5; padding:10px 12px; text-align:left; font-size:11px; text-transform:uppercase; letter-spacing:0.04em; color:#555; }
+.fin-cowork .rec-a4-items td { padding:10px 12px; border-bottom:1px solid #eee; }
+.fin-cowork .rec-a4-items th:nth-child(n+2), .fin-cowork .rec-a4-items td:nth-child(n+2) { text-align:right; font-variant-numeric:tabular-nums; }
+.fin-cowork .rec-a4-totals { display:flex; justify-content:flex-end; margin-top:20px; }
+.fin-cowork .rec-a4-totals dl { display:grid; grid-template-columns:auto auto; gap:8px 30px; font-size:14px; }
+.fin-cowork .rec-a4-totals dt { color:#666; }
+.fin-cowork .rec-a4-totals dd { margin:0; text-align:right; font-variant-numeric:tabular-nums; }
+.fin-cowork .rec-a4-total { font-size:20px !important; font-weight:700 !important; padding-top:10px; border-top:2px solid #222; color:#222 !important; }
+.fin-cowork .rec-a4-foot { margin-top:50px; padding-top:20px; border-top:1px dashed #ccc; display:flex; justify-content:space-between; font-size:11px; color:#666; }
+/* ──── NF-e drawer extras ──── */
+.fin-cowork .nfe-cfop { display:grid; grid-template-columns:repeat(3, 1fr); gap:8px; margin-bottom:14px; }
+.fin-cowork .nfe-cfop-btn, .fin-cowork .nfe-transp-btn {
+  padding:12px; border:1.5px solid oklch(0.88 0.01 250); border-radius:8px;
+  background:#fff; cursor:pointer; text-align:left; display:flex; flex-direction:column; gap:3px;
+}
+.fin-cowork .nfe-cfop-btn.active, .fin-cowork .nfe-transp-btn.active { border-color:var(--accent); background:oklch(0.97 0.04 var(--accent-h, 220)); }
+.fin-cowork .nfe-cfop-btn strong { font-size:13px; }
+.fin-cowork .nfe-cfop-btn span, .fin-cowork .nfe-transp-btn span { font-size:11px; color:oklch(0.50 0.02 250); }
+.fin-cowork .nfe-tax-grid { display:grid; grid-template-columns:repeat(2, 1fr); gap:10px; }
+.fin-cowork .nfe-tax-grid > div { padding:10px 12px; background:oklch(0.97 0.01 250); border-radius:6px; display:flex; flex-direction:column; gap:2px; }
+.fin-cowork .nfe-tax-grid span { font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); }
+.fin-cowork .nfe-tax-grid strong { font-size:13px; }
+.fin-cowork .nfe-transp { display:grid; grid-template-columns:repeat(2, 1fr); gap:8px; margin-bottom:14px; }
+.fin-cowork .nfe-review-grid { display:grid; grid-template-columns:repeat(2, 1fr); gap:10px; }
+.fin-cowork .nfe-review-card { padding:12px 14px; background:oklch(0.97 0.01 250); border-radius:6px; display:flex; flex-direction:column; gap:3px; }
+.fin-cowork .nfe-review-card.span { grid-column:1 / -1; }
+.fin-cowork .nfe-review-card span { font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); }
+.fin-cowork .nfe-review-card strong { font-size:14px; }
+.fin-cowork .nfe-review-card .mono { font-family:var(--font-mono); }
+.fin-cowork .nfe-review-card .small { font-size:10px; word-break:break-all; line-height:1.4; }
+.fin-cowork .nfe-callout {
+  margin-top:14px; padding:12px 14px; border-radius:6px;
+  background:oklch(0.96 0.06 70); border-left:3px solid oklch(0.65 0.14 70);
+  font-size:12px; color:oklch(0.30 0.06 70);
+}
+@media print {
+.fin-cowork body > * { display:none !important; }
+.fin-cowork .pdv-overlay { position:static; background:#fff; color:#000; }
+.fin-cowork .pdv-head, .fin-cowork .rec-layout, .fin-cowork .pdv-close, .fin-cowork .os-btn { display:none !important; }
+.fin-cowork .rec-stage { padding:0; }
+.fin-cowork .rec-paper { box-shadow:none; }
+}
+/* ════════════ OS-page chrome (used by vendas-* and others) ════════════ */
+.fin-cowork .os-head {
+  display:flex; align-items:flex-start; justify-content:space-between;
+  gap:16px; padding:24px 24px 14px; flex-wrap:wrap;
+}
+.fin-cowork .os-head-l h1 { margin:0 0 4px; font-size:22px; letter-spacing:-0.01em; color:var(--text); }
+.fin-cowork .os-head-l p { margin:0; font-size:13px; color:var(--text-dim); }
+.fin-cowork .os-head-r { display:flex; align-items:center; gap:8px; flex-wrap:wrap; }
+.fin-cowork .os-kpis {
+  display:grid; grid-template-columns:repeat(auto-fit, minmax(180px, 1fr));
+  gap:10px; padding:0 24px 14px;
+}
+.fin-cowork .os-kpi {
+  background:#fff; border:1px solid var(--border, oklch(0.93 0.01 250));
+  border-radius:8px; padding:12px 14px;
+  display:flex; flex-direction:column; gap:4px;
+}
+.fin-cowork .os-kpi-label { font-size:10px; text-transform:uppercase; letter-spacing:0.05em; color:var(--text-dim, oklch(0.50 0.02 250)); font-weight:600; }
+.fin-cowork .os-kpi-value { font-size:22px; font-weight:600; font-variant-numeric:tabular-nums; line-height:1.1; color:var(--text); }
+.fin-cowork .os-kpi-sub { font-size:11px; color:var(--text-dim, oklch(0.55 0.02 250)); }
+.fin-cowork .os-kpi-alert { border-color:oklch(0.75 0.14 70); background:oklch(0.985 0.02 70); }
+.fin-cowork .os-kpi-alert .os-kpi-value { color:oklch(0.50 0.14 70); }
+.fin-cowork .os-tabs {
+  display:flex; align-items:center; gap:4px; flex-wrap:wrap;
+  padding:8px 24px 0; border-bottom:1px solid var(--border, oklch(0.93 0.01 250));
+}
+.fin-cowork .os-tab {
+  display:inline-flex; align-items:center; gap:6px;
+  padding:8px 12px; border:none; background:transparent; cursor:pointer;
+  font-size:12px; color:var(--text-dim, oklch(0.50 0.02 250)); font-weight:500;
+  border-bottom:2px solid transparent; transition:all .12s;
+}
+.fin-cowork .os-tab:hover { color:var(--text); }
+.fin-cowork .os-tab.active { color:var(--accent); border-bottom-color:var(--accent); }
+.fin-cowork .os-tab .count {
+  display:inline-block; padding:1px 6px; border-radius:8px;
+  background:oklch(0.95 0.01 250); font-size:10px; font-weight:600;
+  color:oklch(0.40 0.02 250);
+}
+.fin-cowork .os-tab.active .count { background:oklch(0.94 0.06 var(--accent-h, 220)); color:var(--accent); }
+.fin-cowork .os-tabs-r { margin-left:auto; padding:4px 0; display:flex; gap:8px; align-items:center; }
+.fin-cowork .os-search {
+  display:inline-flex; align-items:center; gap:6px;
+  padding:5px 10px; border:1px solid var(--border, oklch(0.85 0.02 250));
+  border-radius:6px; background:#fff;
+}
+.fin-cowork .os-search input { border:none; outline:none; background:transparent; font-size:12px; min-width:200px; }
+.fin-cowork .os-table-wrap { padding:14px 24px 20px; overflow:auto; }
+.fin-cowork .os-table {
+  width:100%; border-collapse:collapse;
+  background:#fff; border:1px solid var(--border, oklch(0.93 0.01 250));
+  border-radius:8px; overflow:hidden;
+}
+.fin-cowork .os-table thead th {
+  padding:10px 12px; text-align:left;
+  font-size:11px; font-weight:600; text-transform:uppercase; letter-spacing:0.04em;
+  color:var(--text-dim, oklch(0.45 0.02 250));
+  background:oklch(0.98 0.005 250);
+  border-bottom:1px solid var(--border, oklch(0.93 0.01 250));
+}
+.fin-cowork .os-table td { padding:10px 12px; border-bottom:1px solid oklch(0.96 0.01 250); font-size:13px; vertical-align:top; }
+.fin-cowork .os-table tbody tr:last-child td { border-bottom:none; }
+.fin-cowork .os-row { cursor:pointer; transition:background .1s; }
+.fin-cowork .os-row:hover { background:oklch(0.98 0.01 var(--accent-h, 220)); }
+.fin-cowork .os-row.urgent { box-shadow:inset 3px 0 0 oklch(0.60 0.16 25); }
+.fin-cowork .os-empty { text-align:center; padding:40px; color:var(--text-dim); font-style:italic; }
+.fin-cowork .os-stage {
+  display:inline-block; padding:2px 8px; border-radius:10px;
+  font-size:11px; font-weight:500;
+}
+.fin-cowork .os-drawer-head {
+  display:flex; align-items:flex-start; justify-content:space-between;
+  gap:12px; padding:18px 20px; border-bottom:1px solid var(--border, oklch(0.93 0.01 250));
+  background:#fff;
+}
+.fin-cowork .os-drawer-head-l { flex:1; min-width:0; }
+.fin-cowork .os-drawer-id { font-family:var(--font-mono); font-size:11px; color:var(--text-dim); text-transform:uppercase; letter-spacing:0.06em; }
+.fin-cowork .os-drawer-head-l h2 { margin:4px 0 4px; font-size:18px; }
+.fin-cowork .os-drawer-head-l p { margin:0; font-size:12px; color:var(--text-dim); }
+.fin-cowork .os-drawer-head-r { display:flex; align-items:center; gap:8px; }
+.fin-cowork .os-drawer-body { flex:1; overflow:auto; }
+.fin-cowork .icon-btn {
+  width:28px; height:28px; border-radius:6px;
+  background:transparent; border:1px solid transparent; cursor:pointer;
+  display:inline-flex; align-items:center; justify-content:center;
+  color:var(--text-dim);
+}
+.fin-cowork .icon-btn:hover { background:var(--border-2, oklch(0.95 0.01 250)); color:var(--text); }
+/* Stepper for create/nfe drawers */
+.fin-cowork .vd-stepper {
+  display:flex; align-items:center; gap:0; padding:14px 20px;
+  background:oklch(0.98 0.005 250); border-bottom:1px solid var(--border, oklch(0.93 0.01 250));
+}
+.fin-cowork .vd-step {
+  display:inline-flex; align-items:center; gap:6px;
+  border:none; background:transparent; cursor:pointer;
+  font-size:12px; color:var(--text-dim);
+}
+.fin-cowork .vd-step-num {
+  width:22px; height:22px; border-radius:50%;
+  background:oklch(0.92 0.01 250); color:oklch(0.40 0.02 250);
+  display:inline-flex; align-items:center; justify-content:center;
+  font-size:11px; font-weight:600;
+}
+.fin-cowork .vd-step.active .vd-step-num { background:var(--accent); color:#fff; }
+.fin-cowork .vd-step.active { color:var(--text); font-weight:600; }
+.fin-cowork .vd-step.done .vd-step-num { background:oklch(0.55 0.14 145); color:#fff; }
+.fin-cowork .vd-step-sep { margin:0 10px; color:var(--text-dim); }
+/* ────────────────── Embed (iframe consolidator) ────────────────── */
+.fin-cowork .embed-view {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--bg-2, #fafaf9);
+}
+.fin-cowork .embed-view.embed-fs {
+  position: fixed;
+  inset: 0;
+  z-index: 200;
+  background: var(--bg, #fff);
+}
+.fin-cowork .embed-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 6px 12px;
+  border-bottom: 1px solid var(--border, #e5e0d3);
+  background: var(--panel, #fff);
+  font-size: 11px;
+  color: var(--text-mute, #8b8580);
+  flex-shrink: 0;
+}
+.fin-cowork .embed-toolbar-l, .fin-cowork .embed-toolbar-r {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.fin-cowork .embed-label {
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+  font-size: 10px;
+}
+.fin-cowork .embed-src {
+  font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 11px;
+  color: var(--text, #1a1917);
+  background: var(--bg-2, #f6f4ef);
+  padding: 2px 6px;
+  border-radius: 3px;
+  border: 1px solid var(--border, #e5e0d3);
+}
+.fin-cowork .embed-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 8px;
+  border-radius: 4px;
+  border: 1px solid var(--border, #e5e0d3);
+  background: var(--panel, #fff);
+  color: var(--text, #1a1917);
+  font-size: 11px;
+  cursor: pointer;
+  text-decoration: none;
+  transition: background .12s, border-color .12s;
+}
+.fin-cowork .embed-btn:hover {
+  background: var(--bg-2, #f6f4ef);
+  border-color: var(--text-mute, #8b8580);
+}
+.fin-cowork .embed-btn.on {
+  background: var(--accent-soft, #eaf0f7);
+  border-color: var(--accent, #1f3a5f);
+  color: var(--accent, #1f3a5f);
+}
+.fin-cowork .embed-iframe {
+  flex: 1;
+  width: 100%;
+  border: 0;
+  background: #fff;
+  display: block;
+}
+/* ────────────────── Sidebar lean ────────────────── */
+.fin-cowork .sb-menu-lean .sb-item {
+  margin: 1px 0;
+}
+.fin-cowork .sb-divider {
+  height: 1px;
+  background: var(--border, #e5e0d3);
+  margin: 8px 8px 6px;
+  opacity: 0.6;
+}
+.fin-cowork .sb-group-flat {
+  font-weight: 500;
+}
+.fin-cowork .sb-item .badge.muted {
+  background: transparent;
+  color: var(--text-mute, #8b8580);
+  font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 10px;
+  font-weight: 400;
+  padding: 0;
+  min-width: auto;
+}
+/* ────────────────── TopNav (sub-telas da área ativa) ────────────────── */
+.fin-cowork .topnav {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 6px 16px;
+  border-bottom: 1px solid var(--border, #e5e0d3);
+  background: var(--panel, #fff);
+  font-size: 12px;
+  flex-shrink: 0;
+  overflow-x: auto;
+  scrollbar-width: thin;
+  scrollbar-color: var(--border, #e5e0d3) transparent;
+  min-height: 38px;
+}
+.fin-cowork .topnav::-webkit-scrollbar { height: 4px; }
+.fin-cowork .topnav::-webkit-scrollbar-thumb { background: var(--border, #e5e0d3); border-radius: 999px; }
+.fin-cowork .topnav-area {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+  padding-right: 12px;
+  border-right: 1px solid var(--border, #e5e0d3);
+}
+.fin-cowork .topnav-area-label {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: var(--text-mute, #8b8580);
+}
+.fin-cowork .topnav-pills {
+  display: flex;
+  gap: 2px;
+  flex-wrap: nowrap;
+  flex: 1;
+  min-width: 0;
+}
+.fin-cowork .topnav-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  border: 0;
+  background: transparent;
+  padding: 4px 10px;
+  border-radius: 4px;
+  color: var(--text-mute, #8b8580);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background .12s, color .12s;
+  position: relative;
+}
+.fin-cowork .topnav-pill svg {
+  opacity: 0.7;
+}
+.fin-cowork .topnav-pill:hover {
+  background: var(--bg-2, #f6f4ef);
+  color: var(--text, #1a1917);
+}
+.fin-cowork .topnav-pill:hover svg { opacity: 1; }
+.fin-cowork .topnav-pill.active {
+  color: var(--accent, #1f3a5f);
+  font-weight: 600;
+  background: var(--accent-soft, #eaf0f7);
+}
+.fin-cowork .topnav-pill.active svg { opacity: 1; }
+/* ────────────────── Sidebar group — header com cor ────────────────── */
+.fin-cowork .sb-group {
+  margin: 6px 0 2px;
+}
+.fin-cowork .sb-group-h {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 10px;
+  cursor: pointer;
+  border-radius: 4px;
+  user-select: none;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--sb-text);
+}
+.fin-cowork .sb-group-h:hover { background: var(--sb-hover); }
+.fin-cowork .sb-group-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  opacity: 0.85;
+}
+.fin-cowork .sb-group-l {
+  flex: 1 1 auto;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.fin-cowork .sb-group-n {
+  font-size: 9.5px;
+  font-family: var(--mono, ui-monospace, SFMono-Regular, monospace);
+  color: var(--text-mute);
+  font-weight: 500;
+  letter-spacing: 0;
+}
+.fin-cowork .sb-group .chev {
+  width: 10px;
+  height: 10px;
+  opacity: 0.5;
+  flex-shrink: 0;
+}
+.fin-cowork .sb-item.sb-sub {
+  border-left: 2px solid transparent;
+  padding-left: 18px;
+}
+.fin-cowork .sb-item.sb-sub.active {
+  border-left-color: var(--accent);
+}
+/* esconde estilo lean antigo */
+.fin-cowork .sb-divider, .fin-cowork .sb-menu-lean .sb-divider { display: none; }
+.fin-cowork .sb-group-flat { display: none; }
+/* ────────────────── Sidebar collapse / rail / hidden ────────────────── */
+.fin-cowork .sb { position: relative; overflow: visible; }
+/* Alça de colapsar na borda direita */
+.fin-cowork .sb-collapse-handle {
+  position: absolute;
+  top: 50%;
+  right: -10px;
+  transform: translateY(-50%);
+  width: 20px;
+  height: 36px;
+  border-radius: 4px;
+  border: 1px solid var(--sb-border);
+  background: var(--sb-bg);
+  color: var(--sb-text-dim);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  z-index: 30;
+  opacity: 0;
+  transition: opacity .12s, color .12s, background .12s, transform .12s;
+  padding: 0;
+}
+.fin-cowork .sb:hover .sb-collapse-handle, .fin-cowork .sb-collapse-handle:focus-visible, .fin-cowork .sb-collapse-handle:hover {
+  opacity: 1;
+}
+.fin-cowork .sb-collapse-handle:hover {
+  background: var(--sb-active);
+  color: var(--sb-text-hi);
+}
+/* Alça flutuante para reabrir quando oculta */
+.fin-cowork .sb-reopen-handle {
+  position: fixed;
+  top: 50%;
+  left: 0;
+  transform: translateY(-50%);
+  width: 18px;
+  height: 64px;
+  border-radius: 0 6px 6px 0;
+  border: 1px solid var(--border);
+  border-left: 0;
+  background: var(--bg-elev, var(--bg, #fff));
+  color: var(--text-mute, #777);
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  z-index: 40;
+  padding: 0;
+  box-shadow: 2px 0 8px oklch(0 0 0 / .06);
+}
+.fin-cowork .sb-reopen-handle:hover {
+  width: 26px;
+  color: var(--text, #111);
+  background: var(--accent-soft, var(--sb-active));
+}
+/* ── Sidebar em modo RAIL ── */
+.fin-cowork .sb--rail {
+  overflow: visible;
+}
+.fin-cowork .sb--rail .sb-top {
+  padding: 8px 8px 6px;
+  display: grid;
+  place-items: center;
+}
+.fin-cowork .sb--rail .sb-body {
+  padding: 4px 0;
+}
+.fin-cowork .sb--rail .sb-user {
+  padding: 8px;
+  display: grid;
+  place-items: center;
+}
+.fin-cowork .sb-menu-rail {
+  padding: 4px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+}
+/* Botão genérico do rail (40x40 centrado em 56px) */
+.fin-cowork .sb-rail-btn {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  color: var(--sb-text);
+  width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  position: relative;
+  padding: 0;
+  transition: background .1s, color .1s;
+}
+.fin-cowork .sb-rail-btn:hover {
+  background: var(--sb-hover);
+  color: var(--sb-text-hi);
+}
+.fin-cowork .sb-rail-btn.active {
+  background: var(--sb-active);
+  color: var(--sb-text-hi);
+}
+.fin-cowork .sb-rail-btn.active::before {
+  content: "";
+  position: absolute;
+  left: -8px;
+  top: 8px; bottom: 8px;
+  width: 3px;
+  border-radius: 0 2px 2px 0;
+  background: var(--accent);
+}
+.fin-cowork .sb-rail-btn .ic {
+  width: 18px;
+  height: 18px;
+  opacity: .9;
+}
+.fin-cowork .sb-rail-btn.active .ic { opacity: 1; }
+.fin-cowork .sb-rail-btn.sb-rail-group .ic {
+  width: 18px;
+  height: 18px;
+}
+.fin-cowork .sb-rail-btn.sb-rail-group.active .ic, .fin-cowork .sb-rail-btn.sb-rail-group.open .ic {
+  filter: brightness(1.15);
+}
+.fin-cowork .sb-rail-group-pill {
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 9.5px;
+  font-weight: 700;
+  color: #fff;
+  letter-spacing: 0.02em;
+  width: 24px;
+  height: 22px;
+  border-radius: 5px;
+  display: grid;
+  place-items: center;
+}
+.fin-cowork .sb-rail-dot-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: oklch(0.62 0.18 30);
+  box-shadow: 0 0 0 2px var(--sb-bg);
+}
+/* Avatar empresa / user no rail */
+.fin-cowork .sb--rail .sb-cp-rail-btn .avatar, .fin-cowork .sb--rail .sb-user-rail-btn .avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 6px;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font-weight: 700;
+  font-size: 11px;
+}
+.fin-cowork .sb--rail .sb-user-rail-btn .avatar {
+  border-radius: 50%;
+}
+/* Dropdown de empresa quando em rail (alinhado à direita do rail) */
+.fin-cowork .sb-dd-rail {
+  left: calc(100% + 8px);
+  top: 0;
+  right: auto;
+  width: 220px;
+  z-index: 50;
+}
+/* Tooltip via data-tip (somente no rail) */
+.fin-cowork .sb--rail [data-tip] {
+  position: relative;
+}
+.fin-cowork .sb--rail [data-tip]::after {
+  content: attr(data-tip);
+  position: absolute;
+  left: calc(100% + 12px);
+  top: 50%;
+  transform: translateY(-50%) translateX(-4px);
+  padding: 6px 10px;
+  background: oklch(0.18 0 0);
+  color: oklch(0.96 0 0);
+  font-size: 12px;
+  font-weight: 500;
+  white-space: nowrap;
+  border-radius: 6px;
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity .12s .12s, transform .12s .12s;
+  z-index: 60;
+  box-shadow: 0 4px 14px oklch(0 0 0 / 0.22);
+}
+.fin-cowork .sb--rail [data-tip]:hover::after {
+  opacity: 1;
+  transform: translateY(-50%) translateX(0);
+}
+/* Tooltip de GRUPO: maior, com a cor do grupo, e setinha */
+.fin-cowork .sb--rail .sb-rail-group[data-tip]::after {
+  background: oklch(0.96 0.02 var(--gh, 220));
+  color: oklch(0.28 0.08 var(--gh, 220));
+  border: 1px solid oklch(0.72 0.10 var(--gh, 220) / 0.55);
+  border-left: 3px solid oklch(0.62 0.13 var(--gh, 220));
+  padding: 7px 12px 7px 11px;
+  font-size: 12.5px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+  box-shadow: 0 6px 18px oklch(0 0 0 / 0.18);
+}
+/* Esconde tooltip enquanto o flyout do grupo está aberto */
+.fin-cowork .sb--rail .sb-rail-btn.open[data-tip]::after {
+  opacity: 0 !important;
+}
+/* Flyout do grupo no rail */
+.fin-cowork .sb-rail-flyout {
+  position: fixed;
+  background: var(--sb-bg);
+  border: 1px solid var(--sb-border);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px oklch(0 0 0 / 0.28);
+  padding: 6px;
+  min-width: 220px;
+  max-width: 260px;
+  z-index: 60;
+  animation: sbFlyoutIn .14s ease-out;
+}
+@keyframes sbFlyoutIn {
+  from { opacity: 0; transform: translateX(-4px); }
+  to   { opacity: 1; transform: translateX(0); }
+}
+.fin-cowork .sb-rail-flyout-h {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px 6px;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+.fin-cowork .sb-rail-flyout-h .sb-group-n {
+  margin-left: auto;
+  font-family: var(--font-mono, ui-monospace, SFMono-Regular, monospace);
+  font-size: 10px;
+  font-weight: 500;
+  color: var(--sb-text-dim);
+  letter-spacing: 0;
+}
+.fin-cowork .sb-rail-flyout .sb-item {
+  height: 30px;
+  padding: 0 10px;
+  border-radius: 6px;
+}
+.fin-cowork .sb-rail-flyout .sb-item.sb-sub {
+  padding-left: 14px;
+  border-left-width: 2px;
+}
+/* No rail: oculta o handle interno (a alça basta) */
+.fin-cowork .sb--rail .sb-collapse-handle {
+  /* permanece visível, mas roda 180° via SVG no JSX */
+}
+/* (auto-rail em viewports estreitas é feito no JS no mount inicial — */
+/*  não sobrescreve a escolha do usuário via CSS.) */
+/* ══════════════════════════════════════════════════════════════════
+   VENDAS A+ (2026-05-14) — refator pra 9.5
+   8 itens: identidade green · sparkline+ageing · stepper FSM · avatar
+            Vista toggle · ⌘K · saved views+bulk · NF-e+NFS-e
+   Namespace: .vendas-aplus  (escopo da Index Vendas)
+   ════════════════════════════════════════════════════════════════ */
+.fin-cowork .vendas-aplus {
+  --vd-green:       oklch(0.45 0.11 155);
+  --vd-green-2:     oklch(0.55 0.11 155);
+  --vd-green-soft:  oklch(0.95 0.04 155);
+  --vd-green-hero:  oklch(0.21 0.025 155);
+  --vd-green-hero-2:oklch(0.27 0.03 155);
+  --vd-green-fg:    oklch(0.78 0.05 155);
+
+  --vd-ok:    oklch(0.55 0.13 145);
+  --vd-ok-soft: oklch(0.94 0.06 145);
+  --vd-warn:  oklch(0.62 0.13 70);
+  --vd-warn-soft: oklch(0.94 0.06 70);
+  --vd-bad:   oklch(0.55 0.18 25);
+  --vd-bad-soft: oklch(0.94 0.06 25);
+  --vd-neutral: oklch(0.55 0.01 80);
+  --vd-neutral-soft: oklch(0.94 0.005 80);
+}
+/* ── HEADER: ⌘K button no centro do .os-head ── */
+.fin-cowork .vendas-aplus .os-head { align-items:center; gap:12px; }
+.fin-cowork .vendas-aplus .vd-cmdk {
+  flex: 0 1 360px; min-width: 220px;
+  display: flex; align-items: center; gap: 8px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 6px; padding: 6px 10px;
+  color: var(--text-mute); cursor: pointer;
+  font: inherit; font-size: 12.5px;
+  transition: border-color .12s;
+}
+.fin-cowork .vendas-aplus .vd-cmdk:hover { border-color: var(--text-mute); }
+.fin-cowork .vendas-aplus .vd-cmdk span { flex: 1; text-align: left; }
+.fin-cowork .vendas-aplus .vd-cmdk kbd {
+  font-family: var(--font-mono); font-size: 9.5px; padding: 1px 5px;
+  border: 1px solid var(--border); border-bottom-width: 2px; border-radius: 3px;
+  background: var(--bg-2); color: var(--text-dim);
+}
+/* ── Vista segmented control ── */
+.fin-cowork .vendas-aplus .vd-vista {
+  display: inline-flex; background: var(--bg-2);
+  border: 1px solid var(--border); border-radius: 6px; padding: 2px;
+}
+.fin-cowork .vendas-aplus .vd-vista button {
+  border: 0; background: transparent;
+  padding: 4px 12px; font-size: 11.5px; font-weight: 600;
+  color: var(--text-mute); border-radius: 4px;
+  letter-spacing: 0.02em; cursor: pointer; font-family: inherit;
+  transition: all .15s;
+}
+.fin-cowork .vendas-aplus .vd-vista button.on {
+  background: var(--surface); color: var(--vd-green);
+  box-shadow: 0 1px 2px rgba(0,0,0,.04);
+}
+/* ── Saved views dropdown ── */
+.fin-cowork .vendas-aplus .vd-views { position: relative; }
+.fin-cowork .vendas-aplus .vd-views-btn {
+  background: var(--surface); border: 1px solid var(--border);
+  padding: 6px 10px; border-radius: 5px;
+  font-size: 12px; font-weight: 600; color: var(--text);
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: inherit; cursor: pointer;
+}
+.fin-cowork .vendas-aplus .vd-views-btn::after { content: '▾'; font-size: 9px; color: var(--text-mute); }
+.fin-cowork .vendas-aplus .vd-views-btn:hover { border-color: var(--text-mute); }
+.fin-cowork .vendas-aplus .vd-views-menu {
+  position: absolute; top: calc(100% + 4px); right: 0;
+  min-width: 240px; background: var(--surface);
+  border: 1px solid var(--border); border-radius: 8px;
+  box-shadow: 0 8px 24px -8px rgba(0,0,0,.18), 0 0 0 1px rgba(0,0,0,.02);
+  padding: 4px; z-index: 30;
+}
+.fin-cowork .vendas-aplus .vd-views-item {
+  display: flex; align-items: center; gap: 8px;
+  padding: 7px 10px; font-size: 12.5px; cursor: pointer;
+  border-radius: 4px;
+}
+.fin-cowork .vendas-aplus .vd-views-item:hover { background: var(--bg-2); }
+.fin-cowork .vendas-aplus .vd-views-item.active { color: var(--vd-green); font-weight: 600; }
+.fin-cowork .vendas-aplus .vd-views-item .ct {
+  margin-left: auto;
+  color: var(--text-mute); font-family: var(--font-mono); font-size: 10.5px;
+  background: var(--bg-2); padding: 1px 6px; border-radius: 99px;
+}
+.fin-cowork .vendas-aplus .vd-views-item.active .ct { background: var(--vd-green-soft); color: var(--vd-green); }
+.fin-cowork .vendas-aplus .vd-views-sep { height: 1px; background: var(--border-2); margin: 4px -4px; }
+/* ── KPIs ── */
+.fin-cowork .vendas-aplus .vd-kpis { grid-template-columns: repeat(4, 1fr); gap: 12px; }
+.fin-cowork .vendas-aplus .vd-kpi-hero {
+  background: var(--vd-green-hero); color: oklch(0.92 0.01 155);
+  border-color: var(--vd-green-hero);
+}
+.fin-cowork .vendas-aplus .vd-kpi-hero .os-kpi-label { color: var(--vd-green-fg); }
+.fin-cowork .vendas-aplus .vd-kpi-hero .os-kpi-value { color: oklch(0.95 0.01 155); }
+.fin-cowork .vendas-aplus .vd-kpi-hero .os-kpi-sub { color: var(--vd-green-fg); }
+.fin-cowork .vendas-aplus .vd-spark { margin-top: 8px; height: 32px; }
+.fin-cowork .vendas-aplus .vd-delta-up { color: var(--vd-ok) !important; display: inline-flex; align-items: center; gap: 4px; }
+.fin-cowork .vendas-aplus .vd-kpi-hero .vd-delta-up { color: oklch(0.78 0.10 155) !important; }
+.fin-cowork .vendas-aplus .os-kpi-value small { font-size: 13px; color: var(--text-mute); font-weight: 500; margin-left: 2px; }
+.fin-cowork .vendas-aplus .vd-kpi-hero .os-kpi-value small { color: oklch(0.65 0.04 155); }
+/* ageing 3 bars */
+.fin-cowork .vendas-aplus .vd-ageing {
+  margin-top: 10px;
+  display: grid; grid-template-columns: repeat(3, 1fr); gap: 6px;
+}
+.fin-cowork .vendas-aplus .vd-ag-bar {
+  height: 4px; border-radius: 99px;
+  background: var(--border-2); position: relative; overflow: hidden;
+}
+.fin-cowork .vendas-aplus .vd-ag-bar > div {
+  position: absolute; left: 0; top: 0; bottom: 0;
+  border-radius: 99px; min-width: 4px;
+}
+.fin-cowork .vendas-aplus .vd-ag-bar.ok   > div { background: var(--vd-ok); }
+.fin-cowork .vendas-aplus .vd-ag-bar.warn > div { background: var(--vd-warn); }
+.fin-cowork .vendas-aplus .vd-ag-bar.bad  > div { background: var(--vd-bad); }
+.fin-cowork .vendas-aplus .vd-ag-lbls {
+  grid-column: 1 / -1;
+  display: flex; justify-content: space-between;
+  font-size: 9.5px; color: var(--text-mute);
+  margin-top: 2px; font-family: var(--font-mono);
+}
+/* PIX progress */
+.fin-cowork .vendas-aplus .vd-pix-prog {
+  margin-top: 12px; height: 6px; background: var(--border-2);
+  border-radius: 99px; overflow: hidden;
+}
+.fin-cowork .vendas-aplus .vd-pix-prog > div {
+  height: 100%;
+  background: linear-gradient(90deg, var(--vd-green), var(--vd-green-2));
+  border-radius: 99px;
+}
+/* Fiscal stacked bar */
+.fin-cowork .vendas-aplus .vd-fiscal-bar {
+  margin-top: 10px; height: 6px; display: flex; gap: 2px;
+  border-radius: 99px; overflow: hidden; background: var(--border-2);
+}
+.fin-cowork .vendas-aplus .vd-fiscal-bar > div { min-width: 2px; }
+/* Ranking vendedores no KPI Comissão */
+.fin-cowork .vendas-aplus .vd-rank { padding: 12px 14px; }
+.fin-cowork .vendas-aplus .vd-rank-row {
+  display: flex; align-items: center; gap: 8px;
+  margin-top: 6px;
+}
+.fin-cowork .vendas-aplus .vd-rank-info {
+  flex: 1; font-size: 11.5px; line-height: 1.3;
+}
+.fin-cowork .vendas-aplus .vd-rank-info > div:first-child {
+  display: flex; justify-content: space-between;
+  font-weight: 600; margin-bottom: 2px;
+}
+.fin-cowork .vendas-aplus .vd-rank-info > div:first-child span:last-child {
+  font-family: var(--font-mono); font-size: 10.5px; color: var(--text-dim); font-weight: 500;
+}
+.fin-cowork .vendas-aplus .vd-rank-bar {
+  height: 3px; border-radius: 99px;
+  background: var(--border-2); overflow: hidden;
+}
+.fin-cowork .vendas-aplus .vd-rank-bar > div { height: 100%; border-radius: 99px; }
+/* ── Avatar vendedor ── */
+.fin-cowork .vendas-aplus .vd-av {
+  display: inline-grid; place-items: center;
+  width: 24px; height: 24px; border-radius: 50%;
+  font-size: 10.5px; font-weight: 700; color: #fff;
+  font-family: var(--font-mono); letter-spacing: 0.02em;
+  flex-shrink: 0;
+}
+.fin-cowork .vendas-aplus .vd-av-1 { background: oklch(0.55 0.12 30); }
+.fin-cowork .vendas-aplus .vd-av-2 { background: oklch(0.50 0.13 200); }
+.fin-cowork .vendas-aplus .vd-av-3 { background: oklch(0.55 0.13 290); }
+.fin-cowork .vendas-aplus .vd-av-4 { background: oklch(0.50 0.13 120); }
+/* ── Table: tweaks A+ ── */
+.fin-cowork .vendas-aplus .vd-aplus-table { font-size: 12.5px; }
+.fin-cowork .vendas-aplus .vd-aplus-table thead th {
+  background: var(--bg-2); color: var(--text-mute);
+  font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.06em;
+  font-weight: 600; padding: 9px 12px;
+}
+.fin-cowork .vendas-aplus .vd-aplus-table tbody td {
+  padding: 10px 12px; vertical-align: middle;
+}
+.fin-cowork .vendas-aplus .vd-aplus-table .vd-chk { padding: 0 0 0 12px; width: 24px; }
+.fin-cowork .vendas-aplus .vd-aplus-table .os-row.selected td { background: var(--vd-green-soft); }
+.fin-cowork .vendas-aplus .vd-aplus-table .os-row.urgent td:first-child { box-shadow: inset 3px 0 0 var(--vd-bad); }
+.fin-cowork .vendas-aplus .vd-seller-cell { display: flex; align-items: center; gap: 8px; }
+.fin-cowork .vendas-aplus .vd-seller-info { display: flex; flex-direction: column; line-height: 1.2; min-width: 0; }
+.fin-cowork .vendas-aplus .vd-seller-info b { font-size: 12px; font-weight: 600; }
+.fin-cowork .vendas-aplus .vd-seller-info small {
+  font-size: 10.5px; color: var(--text-mute);
+  font-family: var(--font-mono); text-transform: lowercase;
+}
+/* commission column shown only on vista=comissao */
+.fin-cowork .vendas-aplus[data-vista="comissao"] .vd-col-commission { display: table-cell; }
+.fin-cowork .vendas-aplus .vd-col-commission { display: none; }
+/* ── Mini-stepper FSM inline ── */
+.fin-cowork .vendas-aplus .vd-stp {
+  display: inline-flex; align-items: center; gap: 3px;
+  padding: 3px 7px; border-radius: 99px;
+  background: var(--bg-2);
+}
+.fin-cowork .vendas-aplus .vd-stp-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--border); transition: all .15s;
+}
+.fin-cowork .vendas-aplus .vd-stp-dot.done { background: var(--vd-green); }
+.fin-cowork .vendas-aplus .vd-stp-dot.current {
+  background: var(--vd-green);
+  box-shadow: 0 0 0 2px var(--vd-green-soft);
+  transform: scale(1.3);
+}
+.fin-cowork .vendas-aplus .vd-stp-lbl {
+  font-size: 10px; color: var(--text-mute); margin-left: 4px;
+  font-family: var(--font-mono); text-transform: uppercase;
+  letter-spacing: 0.04em; font-weight: 600;
+}
+/* ── Fiscal badges ── */
+.fin-cowork .vendas-aplus .vd-fc { display: inline-flex; gap: 4px; flex-wrap: wrap; }
+.fin-cowork .vendas-aplus .vd-fb {
+  display: inline-flex; align-items: center; gap: 3px;
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  padding: 2px 6px; border-radius: 3px;
+  letter-spacing: 0.02em;
+  position: relative; cursor: help;
+}
+.fin-cowork .vendas-aplus .vd-fb-ok { background: var(--vd-ok-soft);     color: oklch(0.36 0.10 145); }
+.fin-cowork .vendas-aplus .vd-fb-wait { background: var(--vd-warn-soft);   color: oklch(0.42 0.12 60); }
+.fin-cowork .vendas-aplus .vd-fb-bad { background: var(--vd-bad-soft);    color: oklch(0.42 0.13 20); }
+.fin-cowork .vendas-aplus .vd-fb-canc { background: var(--vd-neutral-soft);color: var(--text-mute); }
+.fin-cowork .vendas-aplus .vd-fb-na { background: transparent; color: var(--text-mute); padding: 2px 4px; }
+.fin-cowork .vendas-aplus .vd-fb-ic { font-size: 9px; }
+.fin-cowork .vendas-aplus .vd-fb-tip {
+  position: absolute; bottom: calc(100% + 6px); left: 50%;
+  transform: translateX(-50%) translateY(4px);
+  background: var(--text); color: oklch(0.97 0.005 90);
+  padding: 5px 9px; border-radius: 5px;
+  font-size: 10px; font-family: var(--font-mono); font-weight: 500;
+  white-space: nowrap; pointer-events: none;
+  opacity: 0; transition: all .12s;
+  z-index: 20;
+  box-shadow: 0 4px 12px rgba(0,0,0,.20);
+}
+.fin-cowork .vendas-aplus .vd-fb-tip::after {
+  content: ''; position: absolute; top: 100%; left: 50%; transform: translateX(-50%);
+  border: 4px solid transparent; border-top-color: var(--text);
+}
+.fin-cowork .vendas-aplus .vd-fb:hover .vd-fb-tip { opacity: 1; transform: translateX(-50%) translateY(0); }
+/* ── Bulk action bar (fixed bottom) ── */
+.fin-cowork .vendas-aplus .vd-bulk {
+  position: fixed; bottom: 24px; left: 50%;
+  transform: translateX(-50%) translateY(120px);
+  background: var(--text); color: oklch(0.97 0.005 90);
+  border-radius: 10px;
+  box-shadow: 0 12px 32px -8px rgba(0,0,0,.30);
+  padding: 10px 14px;
+  display: flex; align-items: center; gap: 6px;
+  z-index: 30; opacity: 0;
+  transition: all .22s ease-out;
+}
+.fin-cowork .vendas-aplus .vd-bulk.on {
+  opacity: 1; transform: translateX(-50%) translateY(0);
+}
+.fin-cowork .vendas-aplus .vd-bulk-ct {
+  font-size: 12px; font-weight: 600;
+  padding: 2px 8px; background: rgba(255,255,255,.12); border-radius: 99px;
+}
+.fin-cowork .vendas-aplus .vd-bulk-btn {
+  background: transparent; color: oklch(0.97 0.005 90);
+  border: 1px solid rgba(255,255,255,.20);
+  padding: 5px 10px; border-radius: 5px;
+  font-size: 11.5px; font-weight: 500; font-family: inherit; cursor: pointer;
+  display: inline-flex; align-items: center; gap: 5px;
+}
+.fin-cowork .vendas-aplus .vd-bulk-btn:hover { background: rgba(255,255,255,.10); }
+.fin-cowork .vendas-aplus .vd-bulk-btn.primary {
+  background: var(--vd-green); border-color: var(--vd-green);
+}
+.fin-cowork .vendas-aplus .vd-bulk-btn.primary:hover { background: var(--vd-green-2); }
+.fin-cowork .vendas-aplus .vd-bulk-close {
+  background: transparent; border: 0;
+  color: oklch(0.75 0.005 90); padding: 4px 6px;
+  cursor: pointer; font-size: 13px;
+}
+/* ── ⌘K Palette ── */
+.fin-cowork .vendas-aplus .vd-pal-bd {
+  position: fixed; inset: 0;
+  background: rgba(0,0,0,.34);
+  z-index: 60;
+  display: grid; place-items: start center;
+  padding-top: 12vh;
+  opacity: 0; pointer-events: none;
+  transition: opacity .14s;
+}
+.fin-cowork .vendas-aplus .vd-pal-bd.on { opacity: 1; pointer-events: auto; }
+.fin-cowork .vendas-aplus .vd-pal {
+  width: 560px; max-width: 92vw;
+  background: var(--surface); border-radius: 12px;
+  box-shadow: 0 24px 64px -12px rgba(0,0,0,.40);
+  overflow: hidden;
+  transform: scale(0.96); transition: transform .14s;
+}
+.fin-cowork .vendas-aplus .vd-pal-bd.on .vd-pal { transform: scale(1); }
+.fin-cowork .vendas-aplus .vd-pal-in {
+  display: flex; align-items: center; gap: 10px;
+  padding: 12px 16px; border-bottom: 1px solid var(--border);
+}
+.fin-cowork .vendas-aplus .vd-pal-in input {
+  flex: 1; border: 0; background: transparent;
+  font: inherit; font-size: 15px;
+  color: var(--text); outline: none;
+}
+.fin-cowork .vendas-aplus .vd-pal-in input::placeholder { color: var(--text-mute); }
+.fin-cowork .vendas-aplus .vd-pal-in kbd {
+  font-family: var(--font-mono); font-size: 10px; padding: 1px 5px;
+  border: 1px solid var(--border); border-bottom-width: 2px; border-radius: 3px;
+  background: var(--bg-2); color: var(--text-dim);
+}
+.fin-cowork .vendas-aplus .vd-pal-list { max-height: 50vh; overflow-y: auto; padding: 6px; }
+.fin-cowork .vendas-aplus .vd-pal-grp {
+  padding: 6px 12px 4px; font-size: 9.5px;
+  text-transform: uppercase; letter-spacing: 0.08em;
+  color: var(--text-mute); font-weight: 700;
+}
+.fin-cowork .vendas-aplus .vd-pal-it {
+  display: flex; align-items: center; gap: 12px;
+  padding: 8px 12px; border-radius: 6px; cursor: pointer;
+  font-size: 13px;
+}
+.fin-cowork .vendas-aplus .vd-pal-it.sel { background: var(--vd-green-soft); }
+.fin-cowork .vendas-aplus .vd-pal-ic {
+  width: 28px; height: 28px; border-radius: 6px; background: var(--bg-2);
+  display: grid; place-items: center; color: var(--text-dim);
+  flex-shrink: 0;
+}
+.fin-cowork .vendas-aplus .vd-pal-it.sel .vd-pal-ic { background: var(--vd-green); color: #fff; }
+.fin-cowork .vendas-aplus .vd-pal-tx { flex: 1; min-width: 0; }
+.fin-cowork .vendas-aplus .vd-pal-tx b { display: block; font-weight: 600; }
+.fin-cowork .vendas-aplus .vd-pal-tx small { font-size: 11px; color: var(--text-mute); }
+.fin-cowork .vendas-aplus .vd-pal-it kbd {
+  margin-left: auto;
+  font-family: var(--font-mono); font-size: 10px; padding: 1px 5px;
+  border: 1px solid var(--border); border-bottom-width: 2px; border-radius: 3px;
+  background: var(--bg-2); color: var(--text-dim);
+}
+.fin-cowork .vendas-aplus .vd-pal-empty {
+  padding: 24px; text-align: center;
+  color: var(--text-mute); font-size: 12.5px;
+}
+.fin-cowork .vendas-aplus .vd-pal-ft {
+  padding: 10px 16px; border-top: 1px solid var(--border);
+  display: flex; gap: 16px; font-size: 11px; color: var(--text-mute);
+}
+.fin-cowork .vendas-aplus .vd-pal-ft span {
+  display: inline-flex; align-items: center; gap: 4px;
+}
+.fin-cowork .vendas-aplus .vd-pal-ft kbd {
+  font-family: var(--font-mono); font-size: 9.5px; padding: 1px 4px;
+  border: 1px solid var(--border); border-bottom-width: 2px; border-radius: 3px;
+  background: var(--bg-2); color: var(--text-dim);
+}
+/* ══════════════════════════════════════════════════════════════════
+   VENDAS A+ — Detail drawer com Fiscal tab
+   ════════════════════════════════════════════════════════════════ */
+.fin-cowork .vd-drawer-aplus.os-drawer.wide { width: 720px; }
+.fin-cowork .vd-drawer-aplus .os-drawer-head {
+  align-items: flex-start;
+}
+.fin-cowork .vd-drawer-aplus .os-drawer-head-r {
+  display: flex; align-items: center; gap: 10px;
+}
+.fin-cowork .vd-drawer-aplus .vd-drawer-total {
+  font-family: var(--font-mono); font-size: 18px;
+  font-weight: 700; letter-spacing: -0.01em;
+  color: var(--text);
+}
+/* drawer tabs */
+.fin-cowork .vd-drawer-aplus .vd-drawer-tabs {
+  display: flex; gap: 0;
+  border-bottom: 1px solid var(--border);
+  padding: 0 24px;
+  background: var(--surface);
+}
+.fin-cowork .vd-drawer-aplus .vd-drawer-tab {
+  border: 0; background: transparent;
+  padding: 10px 14px; margin-bottom: -1px;
+  font: inherit; cursor: pointer;
+  color: var(--text-mute); font-weight: 500; font-size: 12.5px;
+  border-bottom: 2px solid transparent;
+  display: inline-flex; align-items: center; gap: 6px;
+}
+.fin-cowork .vd-drawer-aplus .vd-drawer-tab:hover { color: var(--text); }
+.fin-cowork .vd-drawer-aplus .vd-drawer-tab.on {
+  color: var(--vd-green);
+  border-bottom-color: var(--vd-green);
+  font-weight: 600;
+}
+.fin-cowork .vd-drawer-aplus .vd-drawer-tab-ct {
+  font-family: var(--font-mono); font-size: 10px;
+  background: var(--bg-2); color: var(--text-mute);
+  padding: 1px 6px; border-radius: 99px; font-weight: 600;
+}
+.fin-cowork .vd-drawer-aplus .vd-drawer-tab.on .vd-drawer-tab-ct {
+  background: var(--vd-green-soft); color: var(--vd-green);
+}
+.fin-cowork .vd-drawer-aplus .vd-drawer-body {
+  background: var(--bg-2);
+}
+.fin-cowork .vd-drawer-aplus .vd-drawer-body .vd-section h3 {
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--text-dim); font-weight: 700; margin: 0 0 10px;
+}
+/* Itens cards */
+.fin-cowork .vd-drawer-aplus .vd-items-cards {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px; overflow: hidden;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-card {
+  display: grid; grid-template-columns: 1fr 50px 90px 110px;
+  align-items: center; gap: 12px;
+  padding: 10px 14px;
+  border-bottom: 1px solid var(--border-2); font-size: 12.5px;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-card:last-child { border-bottom: 0; }
+.fin-cowork .vd-drawer-aplus .vd-item-c-l b { display: block; font-weight: 600; }
+.fin-cowork .vd-drawer-aplus .vd-item-c-l small { font-size: 11px; color: var(--text-mute); }
+.fin-cowork .vd-drawer-aplus .vd-item-c-qty, .fin-cowork .vd-drawer-aplus .vd-item-c-unit, .fin-cowork .vd-drawer-aplus .vd-item-c-sub {
+  text-align: right; font-family: var(--font-mono); font-variant-numeric: tabular-nums;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-c-sub { font-weight: 700; }
+.fin-cowork .vd-drawer-aplus .vd-items-foot {
+  display: flex; justify-content: flex-end; gap: 14px;
+  padding: 14px 4px 0;
+  font-family: var(--font-mono); font-size: 13px;
+}
+.fin-cowork .vd-drawer-aplus .vd-items-foot span { color: var(--text-mute); }
+.fin-cowork .vd-drawer-aplus .vd-items-foot b { font-weight: 700; font-size: 16px; letter-spacing: -0.01em; }
+/* Emit panel */
+.fin-cowork .vd-drawer-aplus .vd-emit {
+  background: var(--vd-green-soft);
+  border: 1px dashed var(--vd-green);
+  border-radius: 8px; padding: 14px 16px;
+  display: flex; align-items: center; gap: 12px;
+  margin-bottom: 12px;
+}
+.fin-cowork .vd-drawer-aplus .vd-emit > div b { display: block; font-size: 13px; color: var(--vd-green); }
+.fin-cowork .vd-drawer-aplus .vd-emit > div small { font-size: 11.5px; color: var(--text-dim); }
+.fin-cowork .vd-drawer-aplus .vd-emit .os-btn { margin-left: auto; flex-shrink: 0; }
+/* Sub-tabs fiscal */
+.fin-cowork .vd-drawer-aplus .vd-fsub {
+  display: inline-flex; gap: 2px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 6px; padding: 2px; margin-bottom: 12px;
+}
+.fin-cowork .vd-drawer-aplus .vd-fsub button {
+  border: 0; background: transparent;
+  padding: 4px 10px; font-size: 11px; font-weight: 600;
+  border-radius: 4px; color: var(--text-mute);
+  display: inline-flex; align-items: center; gap: 5px;
+  font-family: inherit; cursor: pointer;
+}
+.fin-cowork .vd-drawer-aplus .vd-fsub button.on { background: var(--bg-2); color: var(--text); }
+.fin-cowork .vd-drawer-aplus .vd-fsub button span {
+  font-family: var(--font-mono); font-size: 9.5px;
+  background: var(--border-2); padding: 0 4px; border-radius: 99px;
+}
+/* Fiscal card grid */
+.fin-cowork .vd-drawer-aplus .vd-fcard-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 12px;
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-grid.single {
+  grid-template-columns: 1fr; max-width: 500px;
+}
+/* Fiscal card */
+.fin-cowork .vd-drawer-aplus .vd-fcard {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px; padding: 14px 16px;
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-h {
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 10px;
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-h h4 {
+  margin: 0; font-size: 13px; font-weight: 700;
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-date {
+  margin-left: auto;
+  font-size: 11px; color: var(--text-mute);
+  font-family: var(--font-mono);
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-date span { margin-left: 4px; }
+.fin-cowork .vd-drawer-aplus .vd-fcard-fail {
+  margin-bottom: 12px; padding: 10px 12px;
+  background: var(--vd-bad-soft); border-radius: 5px;
+  border-left: 3px solid var(--vd-bad);
+  font-size: 11.5px; color: oklch(0.32 0.12 25);
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-fail.neutral {
+  background: var(--vd-neutral-soft);
+  border-left-color: var(--vd-neutral);
+  color: var(--text-dim);
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-fail b { display: block; margin-bottom: 2px; }
+.fin-cowork .vd-drawer-aplus .vd-fcard-meta {
+  display: grid; grid-template-columns: 80px 1fr;
+  gap: 4px 12px; font-size: 11.5px; margin: 0;
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-meta dt { color: var(--text-mute); }
+.fin-cowork .vd-drawer-aplus .vd-fcard-meta dd { margin: 0; font-family: var(--font-mono); }
+.fin-cowork .vd-drawer-aplus .vd-fcard-chave {
+  display: flex; align-items: center; gap: 6px;
+  margin-top: 12px; padding: 8px 10px;
+  background: var(--bg-2); border-radius: 5px;
+  font-family: var(--font-mono); font-size: 11px;
+  color: var(--text-dim);
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-chave-num {
+  letter-spacing: 0.04em; flex: 1;
+  word-break: break-all;
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-copy {
+  background: transparent; border: 1px solid var(--border);
+  padding: 3px 8px; border-radius: 4px; font-size: 10.5px;
+  color: var(--text-dim); font-family: var(--font-sans);
+  flex-shrink: 0; cursor: pointer;
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-copy.copied {
+  background: var(--vd-ok-soft); color: oklch(0.36 0.10 145);
+  border-color: transparent;
+}
+/* Timeline SEFAZ horizontal */
+.fin-cowork .vd-drawer-aplus .vd-fcard-tl {
+  margin-top: 12px;
+  display: flex; gap: 0; align-items: flex-start;
+  padding: 10px 0;
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-step {
+  flex: 1; display: flex; flex-direction: column;
+  align-items: center; gap: 4px; position: relative;
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-step::before {
+  content: ''; position: absolute; top: 9px; left: -50%; right: 50%;
+  height: 2px; background: var(--border-2); z-index: 0;
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-step:first-child::before { display: none; }
+.fin-cowork .vd-drawer-aplus .vd-fcard-step-d {
+  width: 18px; height: 18px; border-radius: 50%;
+  background: var(--surface); border: 2px solid var(--border-2);
+  display: grid; place-items: center;
+  font-size: 9px; font-weight: 700; color: var(--text-mute);
+  z-index: 1;
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-step.done .vd-fcard-step-d {
+  background: var(--vd-green); border-color: var(--vd-green); color: #fff;
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-step.done::before { background: var(--vd-green); }
+.fin-cowork .vd-drawer-aplus .vd-fcard-step.failed .vd-fcard-step-d {
+  background: var(--vd-bad); border-color: var(--vd-bad); color: #fff;
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-step-l {
+  font-size: 9.5px; color: var(--text-mute); text-align: center;
+  font-family: var(--font-mono);
+  text-transform: uppercase; letter-spacing: 0.02em;
+  line-height: 1.2;
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard.failed .vd-fcard-step.done .vd-fcard-step-d { background: var(--vd-bad); border-color: var(--vd-bad); }
+.fin-cowork .vd-drawer-aplus .vd-fcard.failed .vd-fcard-step.done::before { background: var(--vd-bad); }
+.fin-cowork .vd-drawer-aplus .vd-fcard-cce {
+  margin-top: 10px; padding-top: 10px;
+  border-top: 1px solid var(--border-2);
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-cce summary {
+  cursor: pointer; font-size: 11px;
+  color: var(--vd-green); font-weight: 600;
+  user-select: none;
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-cce summary:hover { color: var(--vd-green-2); }
+.fin-cowork .vd-drawer-aplus .vd-fcard-cce p {
+  margin: 8px 0 0; font-size: 11.5px; color: var(--text-dim);
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-ctas {
+  display: flex; gap: 6px; margin-top: 14px;
+  padding-top: 12px; border-top: 1px solid var(--border-2);
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-cta {
+  flex: 1; padding: 6px 8px; font-size: 11px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 4px; color: var(--text-dim);
+  display: inline-flex; align-items: center; justify-content: center; gap: 4px;
+  font-family: inherit; cursor: pointer;
+}
+.fin-cowork .vd-drawer-aplus .vd-fcard-cta:hover { border-color: var(--text-mute); color: var(--text); }
+/* Breakdown box */
+.fin-cowork .vd-drawer-aplus .vd-fbreak {
+  margin-top: 16px; padding: 14px 16px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px;
+}
+.fin-cowork .vd-drawer-aplus .vd-fbreak h4 {
+  margin: 0 0 8px;
+  font-size: 11px; text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--text-dim); font-weight: 700;
+}
+.fin-cowork .vd-drawer-aplus .vd-fbreak dl {
+  margin: 0; display: grid; grid-template-columns: 1fr auto;
+  gap: 4px 12px; font-size: 12.5px;
+}
+.fin-cowork .vd-drawer-aplus .vd-fbreak dt { color: var(--text-dim); }
+.fin-cowork .vd-drawer-aplus .vd-fbreak dd { margin: 0; font-family: var(--font-mono); font-variant-numeric: tabular-nums; }
+.fin-cowork .vd-drawer-aplus .vd-fbreak dt.tot, .fin-cowork .vd-drawer-aplus .vd-fbreak dd.tot {
+  border-top: 1px solid var(--border-2); padding-top: 8px; margin-top: 4px;
+  font-weight: 700; font-size: 13px;
+}
+.fin-cowork .vd-drawer-aplus .vd-fbreak dd.tot { color: var(--text); }
+/* Payment tab */
+.fin-cowork .vd-drawer-aplus .vd-pay-meta {
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px; padding: 14px 16px;
+}
+.fin-cowork .vd-drawer-aplus .vd-pay-meta dl {
+  display: grid; grid-template-columns: 100px 1fr;
+  gap: 6px 12px; margin: 0; font-size: 12.5px;
+}
+.fin-cowork .vd-drawer-aplus .vd-pay-meta dt { color: var(--text-mute); font-size: 11.5px; }
+.fin-cowork .vd-drawer-aplus .vd-pay-meta dd { margin: 0; }
+.fin-cowork .vd-drawer-aplus .vd-pay-meta .vd-comm {
+  color: var(--vd-green); font-weight: 700; font-family: var(--font-mono);
+}
+.fin-cowork .vd-drawer-aplus .vd-pay-meta .vd-comm small { color: var(--text-mute); font-weight: 500; }
+/* Timeline tab */
+.fin-cowork .vd-drawer-aplus .vd-tline {
+  position: relative; padding-left: 18px;
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: 8px; padding: 14px 14px 14px 32px;
+}
+.fin-cowork .vd-drawer-aplus .vd-tline::before {
+  content: ''; position: absolute; left: 20px; top: 22px; bottom: 22px;
+  width: 2px; background: var(--border-2);
+}
+.fin-cowork .vd-drawer-aplus .vd-tline-it {
+  position: relative; padding: 6px 0;
+}
+.fin-cowork .vd-drawer-aplus .vd-tline-it::before {
+  content: ''; position: absolute; left: -18px; top: 10px;
+  width: 8px; height: 8px; border-radius: 50%;
+  background: var(--vd-green); border: 2px solid var(--surface);
+  box-shadow: 0 0 0 1px var(--vd-green);
+}
+.fin-cowork .vd-drawer-aplus .vd-tline-it small {
+  color: var(--text-mute); font-size: 11px;
+  font-family: var(--font-mono);
+}
+.fin-cowork .vd-drawer-aplus .vd-tline-it b {
+  display: block; font-size: 12.5px; font-weight: 600;
+}
+/* responsive — KPIs em 2 cols se viewport apertado */
+@media (max-width: 1180px) {
+.fin-cowork .vendas-aplus .vd-kpis { grid-template-columns: repeat(2, 1fr); }
+.fin-cowork .vendas-aplus .vd-cmdk { display: none; }
+}
+@media (max-width: 980px) {
+.fin-cowork .vd-drawer-aplus.os-drawer.wide { width: 95vw; }
+}
+/* ── F1.5 iter1: Placa Mercosul (Oficina) ── */
+.fin-cowork .vendas-aplus .vd-client-mec { display: flex; align-items: center; gap: 10px; }
+.fin-cowork .vendas-aplus .vd-plate {
+  display: inline-flex; flex-direction: column; align-items: stretch;
+  width: 78px; flex-shrink: 0;
+  background: #fff;
+  border: 1px solid oklch(0.30 0 0); border-radius: 3px;
+  overflow: hidden;
+  font-family: var(--font-mono);
+  box-shadow: 0 1px 0 rgba(0,0,0,.04);
+}
+.fin-cowork .vendas-aplus .vd-plate-top {
+  background: oklch(0.30 0.12 240); color: #fff;
+  font-size: 6px; font-weight: 700;
+  text-align: center; padding: 1px 0;
+  letter-spacing: 0.04em;
+}
+.fin-cowork .vendas-aplus .vd-plate-num {
+  font-size: 13px; font-weight: 700; color: oklch(0.18 0 0);
+  text-align: center; padding: 3px 0;
+  letter-spacing: 0.06em;
+}
+/* ── F1.5 iter1: Skeleton loading rows ── */
+.fin-cowork .vendas-aplus .vd-sk-row td {
+  padding: 12px 14px !important;
+  border-bottom: 1px solid var(--border-2);
+}
+.fin-cowork .vendas-aplus .vd-sk-bar {
+  height: 12px; border-radius: 3px;
+  background: linear-gradient(
+    90deg,
+    var(--bg-2) 0%,
+    var(--border-2) 50%,
+    var(--bg-2) 100%
+  );
+  background-size: 200% 100%;
+  animation: vdSk 1.2s ease-in-out infinite;
+}
+@keyframes vdSk {
+  0%   { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+/* ── F1.5 iter1: empty state com kbd hints ── */
+.fin-cowork .vendas-aplus .os-empty {
+  padding: 40px 20px; text-align: center;
+  color: var(--text-mute); font-size: 12.5px;
+}
+.fin-cowork .vendas-aplus .os-empty kbd {
+  display: inline-block; padding: 1px 5px; margin: 0 2px;
+  border: 1px solid var(--border); border-bottom-width: 2px; border-radius: 3px;
+  font-family: var(--font-mono); font-size: 10px;
+  background: var(--bg-2); color: var(--text-dim);
+}
+/* ═══════════════════════════════════════════════════════════════════
+   VENDAS · REFINO #1 KB-9.75 · FUNDAÇÃO (2026-05-15)
+   SLA pill · J/K row-nav · tree-view · cheat-sheet · ⌘K prefixos
+   ═══════════════════════════════════════════════════════════════════ */
+/* ── SLA pill ── (fresco · atrasando · estourado · paga) */
+.fin-cowork .vendas-aplus .vd-sla {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 7px; border-radius: 4px;
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.01em; white-space: nowrap;
+}
+.fin-cowork .vendas-aplus .vd-sla .vd-sla-ic { font-size: 9px; line-height: 1; }
+.fin-cowork .vendas-aplus .vd-sla-fresh { background: oklch(0.94 0.06 145); color: oklch(0.32 0.13 145); }
+.fin-cowork .vendas-aplus .vd-sla-warning { background: oklch(0.96 0.06 70);  color: oklch(0.42 0.13 60); }
+.fin-cowork .vendas-aplus .vd-sla-overdue { background: oklch(0.95 0.04 25);  color: oklch(0.50 0.18 25); }
+.fin-cowork .vendas-aplus .vd-sla-paid { background: var(--bg-2); color: var(--text-mute); }
+/* SLA mini-pills no KPI A receber */
+.fin-cowork .vendas-aplus .vd-sla-counts {
+  display: inline-flex; gap: 6px; flex-wrap: wrap;
+  margin-top: 2px;
+}
+.fin-cowork .vendas-aplus .vd-sla-mini {
+  display: inline-flex; align-items: center;
+  font-size: 10.5px; font-weight: 600;
+  padding: 0; line-height: 1.5;
+}
+.fin-cowork .vendas-aplus .vd-sla-mini .ic { font-size: 8px; line-height: 1; margin-right: 4px; }
+.fin-cowork .vendas-aplus .vd-sla-mini.fresh { color: oklch(0.45 0.13 145); }
+.fin-cowork .vendas-aplus .vd-sla-mini.warning { color: oklch(0.50 0.13 60); }
+.fin-cowork .vendas-aplus .vd-sla-mini.overdue { color: oklch(0.55 0.18 25); }
+.fin-cowork .vendas-aplus .vd-sla-mini + .vd-sla-mini::before {
+  content: "·"; margin-right: 2px; color: var(--text-mute); font-weight: 400;
+}
+/* ── Coluna Pagamento com SLA inline ── */
+.fin-cowork .vendas-aplus .vd-pay .vd-pay-top {
+  display: flex; align-items: center; gap: 6px; line-height: 1.3;
+}
+.fin-cowork .vendas-aplus .vd-pay .vd-pay-top > span:first-child { font-weight: 600; color: var(--text); }
+.fin-cowork .vendas-aplus .vd-pay .vd-inst {
+  font-family: var(--font-mono); font-size: 10px;
+  background: var(--bg-2); color: var(--text-mute);
+  padding: 1px 5px; border-radius: 3px;
+}
+.fin-cowork .vendas-aplus .vd-pay .vd-pay-sla { margin-top: 3px; }
+/* ── Row focused (J/K) ── */
+.fin-cowork .vendas-aplus .vd-aplus-table .os-row.row-focused {
+  background: oklch(0.97 0.025 155);
+  box-shadow: inset 3px 0 0 var(--vd-green), inset -3px 0 0 var(--vd-green);
+  outline: none;
+}
+.fin-cowork .vendas-aplus .vd-aplus-table .os-row.row-focused td {
+  background: oklch(0.97 0.025 155);
+}
+.fin-cowork .vendas-aplus .vd-aplus-table .os-row.row-focused.urgent td:first-child {
+  box-shadow: inset 3px 0 0 var(--vd-bad);
+}
+/* favorito ★ */
+.fin-cowork .vendas-aplus .vd-fav {
+  color: oklch(0.65 0.16 70);
+  margin-right: 3px; font-size: 11px;
+}
+/* ── Tree-view saved views ── */
+.fin-cowork .vendas-aplus .vd-views-menu.vd-tree {
+  min-width: 280px;
+  padding: 6px;
+}
+.fin-cowork .vendas-aplus .vd-tree-row {
+  display: flex; align-items: center; gap: 6px;
+  padding: 5px 8px; border-radius: 4px;
+  font-size: 12.5px; cursor: pointer; user-select: none;
+}
+.fin-cowork .vendas-aplus .vd-tree-row:hover { background: var(--bg-2); }
+.fin-cowork .vendas-aplus .vd-tree-row.l0 { font-weight: 500; }
+.fin-cowork .vendas-aplus .vd-tree-row.l1 {
+  padding-left: 28px; font-size: 11.5px; color: var(--text-dim);
+}
+.fin-cowork .vendas-aplus .vd-tree-row.active {
+  background: var(--vd-green-soft); color: var(--vd-green); font-weight: 600;
+}
+.fin-cowork .vendas-aplus .vd-tree-row.active .ct { background: white; color: var(--vd-green); }
+.fin-cowork .vendas-aplus .vd-tree-arr {
+  width: 12px; flex-shrink: 0; text-align: center;
+  font-size: 10px; color: var(--text-mute);
+  transition: transform 0.12s;
+  cursor: pointer;
+}
+.fin-cowork .vendas-aplus .vd-tree-arr.open { transform: rotate(90deg); }
+.fin-cowork .vendas-aplus .vd-tree-arr.empty { visibility: hidden; }
+.fin-cowork .vendas-aplus .vd-tree-lbl { flex: 1; }
+.fin-cowork .vendas-aplus .vd-tree-row .ct {
+  font-family: var(--font-mono); font-size: 10.5px;
+  background: var(--bg-2); color: var(--text-mute);
+  padding: 1px 6px; border-radius: 99px;
+}
+/* ── Cheat-sheet overlay (?) ── */
+.fin-cowork .vd-cheat-bd {
+  position: fixed; inset: 0; z-index: 1000;
+  background: oklch(0 0 0 / 0.5);
+  display: grid; place-items: center;
+  padding: 24px;
+  animation: vdCheatFadeIn 0.15s ease-out;
+}
+@keyframes vdCheatFadeIn { from { opacity: 0; } to { opacity: 1; } }
+.fin-cowork .vd-cheat {
+  background: var(--surface);
+  border-radius: 12px;
+  box-shadow: 0 24px 60px rgba(0,0,0,0.18);
+  width: 100%; max-width: 760px;
+  max-height: 86vh; overflow: auto;
+  display: flex; flex-direction: column;
+  animation: vdCheatSlideUp 0.18s ease-out;
+}
+@keyframes vdCheatSlideUp { from { transform: translateY(12px); opacity: 0; } to { transform: none; opacity: 1; } }
+.fin-cowork .vd-cheat-h {
+  padding: 22px 26px 18px;
+  border-bottom: 1px solid var(--border);
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  grid-template-areas: "ic title x" "ic sub x";
+  gap: 2px 14px;
+  align-items: center;
+}
+.fin-cowork .vd-cheat-ic {
+  grid-area: ic;
+  display: grid; place-items: center;
+  width: 38px; height: 38px;
+  background: var(--vd-green); color: white;
+  border-radius: 8px;
+  font-size: 19px;
+  align-self: center;
+}
+.fin-cowork .vd-cheat-h h2 {
+  grid-area: title;
+  margin: 0; font-size: 17px; font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.fin-cowork .vd-cheat-h p {
+  grid-area: sub;
+  margin: 0; font-size: 12.5px; color: var(--text-mute);
+}
+.fin-cowork .vd-cheat-x {
+  grid-area: x;
+  background: transparent; border: 1px solid var(--border);
+  padding: 4px 10px; border-radius: 5px;
+  cursor: pointer; color: var(--text-mute);
+  align-self: center;
+}
+.fin-cowork .vd-cheat-x kbd {
+  font-family: var(--font-mono); font-size: 10px;
+  border: none; padding: 0; background: transparent;
+}
+.fin-cowork .vd-cheat-grid {
+  padding: 22px 26px;
+  display: grid; grid-template-columns: 1fr 1fr; gap: 22px 32px;
+}
+.fin-cowork .vd-cheat-sec h4 {
+  margin: 0 0 10px;
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--vd-green);
+}
+.fin-cowork .vd-cs-row {
+  display: grid; grid-template-columns: 130px 1fr; gap: 12px;
+  padding: 5px 0; align-items: center;
+  font-size: 12px; color: var(--text-dim);
+}
+.fin-cowork .vd-cs-row + .vd-cs-row { border-top: 1px solid var(--border-2); }
+.fin-cowork .vd-cs-keys { display: flex; gap: 4px; align-items: center; }
+.fin-cowork .vd-cs-keys kbd {
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 600;
+  background: var(--surface); color: var(--text);
+  border: 1px solid var(--border); border-bottom-width: 2px;
+  border-radius: 4px;
+  padding: 2px 7px; min-width: 24px; text-align: center;
+}
+.fin-cowork .vd-cs-plus { font-size: 10px; color: var(--text-mute); }
+.fin-cowork .vd-cs-lbl b { color: var(--text); font-weight: 600; }
+.fin-cowork .vd-cs-lbl code {
+  font-family: var(--font-mono); font-size: 10.5px;
+  background: var(--bg-2); padding: 1px 4px;
+  border-radius: 3px; color: var(--vd-green);
+}
+.fin-cowork .vd-cheat-ft {
+  padding: 14px 26px;
+  border-top: 1px solid var(--border);
+  background: var(--bg-2);
+  font-size: 11px; color: var(--text-mute);
+  display: flex; justify-content: space-between; gap: 12px; flex-wrap: wrap;
+}
+/* ── ⌘K palette: prefix hint no footer ── */
+.fin-cowork .vendas-aplus .vd-pal-prefix {
+  display: inline-flex; gap: 6px; flex-wrap: wrap;
+  color: var(--text-mute); font-size: 10.5px;
+}
+.fin-cowork .vendas-aplus .vd-pal-prefix kbd {
+  font-family: var(--font-mono); font-size: 9.5px; font-weight: 600;
+  background: var(--bg-2); border: 1px solid var(--border);
+  border-radius: 3px; padding: 1px 5px;
+  margin-right: 2px;
+}
+/* ── Responsive ≤1100px (tablet balcão) — degradação progressiva ── */
+@media (max-width: 1100px) {
+.fin-cowork .vendas-aplus .vd-col-commission { display: none; }
+.fin-cowork .vendas-aplus .vd-cmdk { flex: 0 1 240px; min-width: 180px; }
+.fin-cowork .vendas-aplus .vd-cmdk span { font-size: 11px; }
+.fin-cowork .vendas-aplus .vd-aplus-table .vd-seller-info small { display: none; }
+.fin-cowork .vendas-aplus .vd-stp-lbl { display: none; }
+/* só dots */
+.fin-cowork .vendas-aplus .os-kpis { grid-template-columns: 1fr 1fr; }
+.fin-cowork .vendas-aplus .os-kpi.vd-kpi-hero { grid-column: 1 / -1; }
+}
+@media (max-width: 900px) {
+.fin-cowork .vendas-aplus .vd-vista button:nth-child(3), .fin-cowork .vendas-aplus .vd-vista button:nth-child(2) { display: none; }
+/* só Caixa */
+.fin-cowork .vendas-aplus .vd-pay .vd-inst { display: none; }
+.fin-cowork .vendas-aplus .os-kpis { grid-template-columns: 1fr; }
+.fin-cowork .vd-cheat-grid { grid-template-columns: 1fr; }
+}
+/* ═══════════════════════════════════════════════════════════════════
+   VENDAS · REFINO #2 KB-9.75 · IA DENTRO DO FLUXO (2026-05-15)
+   ✦ accent roxo · 3 blocos IA · palette empty-state IA
+   ═══════════════════════════════════════════════════════════════════ */
+.fin-cowork {
+  --vd-ai: oklch(0.52 0.20 295);
+  --vd-ai-soft: oklch(0.96 0.04 295);
+  --vd-ai-border: oklch(0.86 0.10 295);
+  --vd-ai-text: oklch(0.32 0.18 295);
+}
+/* ── Tab IA no drawer ── */
+.fin-cowork .vd-drawer-aplus .vd-drawer-tab.vd-tab-ai {
+  color: var(--vd-ai); font-weight: 600;
+}
+.fin-cowork .vd-drawer-aplus .vd-drawer-tab.vd-tab-ai.on {
+  background: var(--vd-ai-soft);
+  border-bottom-color: var(--vd-ai);
+  color: var(--vd-ai-text);
+}
+/* ── Painel IA · banner topo ── */
+.fin-cowork .vd-ai-panel h3 {
+  margin: 18px 0 8px;
+  font-size: 11px; font-weight: 700;
+  letter-spacing: 0.07em; text-transform: uppercase;
+  color: var(--vd-ai); opacity: 0.85;
+}
+.fin-cowork .vd-ai-panel h3:first-of-type { margin-top: 8px; }
+.fin-cowork .vd-ai-banner {
+  display: flex; align-items: center; gap: 12px;
+  padding: 12px 16px;
+  background: linear-gradient(135deg, var(--vd-ai-soft), oklch(0.985 0.015 295));
+  border: 1px solid var(--vd-ai-border);
+  border-radius: 8px;
+  margin-bottom: 8px;
+}
+.fin-cowork .vd-ai-banner-ic {
+  display: grid; place-items: center;
+  width: 32px; height: 32px;
+  background: var(--vd-ai); color: white;
+  border-radius: 7px;
+  font-size: 17px;
+  flex-shrink: 0;
+}
+.fin-cowork .vd-ai-banner b { display: block; font-size: 13px; color: var(--vd-ai-text); }
+.fin-cowork .vd-ai-banner small { display: block; font-size: 11.5px; color: var(--text-dim); line-height: 1.4; }
+/* ── Bloco IA genérico ── */
+.fin-cowork .vd-ai-block {
+  background: white;
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--vd-ai);
+  border-radius: 8px;
+  padding: 12px 14px;
+  margin-bottom: 4px;
+}
+.fin-cowork .vd-ai-block.vd-ai-disabled {
+  opacity: 0.6;
+  border-left-color: var(--border);
+}
+.fin-cowork .vd-ai-block-h {
+  display: flex; align-items: center; gap: 10px;
+}
+.fin-cowork .vd-ai-ic {
+  display: grid; place-items: center;
+  width: 26px; height: 26px;
+  background: var(--vd-ai-soft); color: var(--vd-ai);
+  border-radius: 6px;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+.fin-cowork .vd-ai-block-tx { flex: 1; min-width: 0; }
+.fin-cowork .vd-ai-block-tx b { display: block; font-size: 12.5px; font-weight: 600; }
+.fin-cowork .vd-ai-block-tx small {
+  display: block; font-size: 11px; color: var(--text-dim);
+  line-height: 1.45;
+}
+.fin-cowork .vd-ai-cta {
+  background: var(--vd-ai); color: white;
+  border: none; padding: 6px 12px;
+  border-radius: 5px; font-size: 11.5px; font-weight: 600;
+  cursor: pointer; flex-shrink: 0;
+  transition: background .1s;
+}
+.fin-cowork .vd-ai-cta:hover { background: oklch(0.46 0.20 295); }
+.fin-cowork .vd-ai-retry {
+  background: transparent; border: 1px solid var(--border);
+  color: var(--vd-ai);
+  width: 26px; height: 26px; border-radius: 5px;
+  cursor: pointer; font-size: 14px;
+}
+.fin-cowork .vd-ai-retry:hover { background: var(--vd-ai-soft); }
+/* ── Loader dots ── */
+.fin-cowork .vd-ai-loader {
+  display: inline-flex; gap: 3px; align-items: center;
+  padding: 6px 10px;
+}
+.fin-cowork .vd-ai-loader span {
+  width: 5px; height: 5px; border-radius: 50%;
+  background: var(--vd-ai);
+  animation: vdAiPulse 1.2s ease-in-out infinite;
+}
+.fin-cowork .vd-ai-loader span:nth-child(2) { animation-delay: 0.15s; }
+.fin-cowork .vd-ai-loader span:nth-child(3) { animation-delay: 0.30s; }
+@keyframes vdAiPulse {
+  0%, 80%, 100% { opacity: 0.25; transform: scale(0.8); }
+  40% { opacity: 1; transform: scale(1); }
+}
+/* ── Skeleton ── */
+.fin-cowork .vd-ai-skel {
+  margin-top: 10px; padding: 6px 0;
+}
+.fin-cowork .vd-ai-skel-line {
+  height: 9px; margin: 6px 0;
+  background: linear-gradient(90deg, var(--bg-2) 0%, oklch(0.94 0.005 90) 50%, var(--bg-2) 100%);
+  background-size: 200% 100%;
+  animation: vdAiShimmer 1.4s linear infinite;
+  border-radius: 3px;
+}
+@keyframes vdAiShimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+/* ── Output da IA ── */
+.fin-cowork .vd-ai-out {
+  margin-top: 10px; padding: 10px 12px;
+  background: var(--vd-ai-soft);
+  border-radius: 6px;
+  font-size: 12.5px; line-height: 1.55;
+  color: var(--text);
+  white-space: pre-wrap;
+}
+.fin-cowork .vd-ai-out.err {
+  background: oklch(0.96 0.04 25); color: oklch(0.45 0.18 25);
+  font-family: var(--font-mono); font-size: 11.5px;
+}
+/* ── História: stats grid ── */
+.fin-cowork .vd-ai-history { margin-bottom: 4px; }
+.fin-cowork .vd-ai-stats {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px;
+  margin-bottom: 10px;
+}
+.fin-cowork .vd-ai-stat {
+  background: var(--bg-2);
+  border-radius: 6px;
+  padding: 8px 10px;
+  position: relative;
+}
+.fin-cowork .vd-ai-stat.full { grid-column: 1 / -1; }
+.fin-cowork .vd-ai-stat small {
+  display: block; font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.05em; text-transform: uppercase;
+  color: var(--text-mute); margin-bottom: 3px;
+}
+.fin-cowork .vd-ai-stat b {
+  font-family: var(--font-mono);
+  font-size: 13.5px; font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.fin-cowork .vd-ai-tag {
+  position: absolute; top: 6px; right: 6px;
+  font-size: 9px; font-weight: 700; letter-spacing: 0.05em;
+  text-transform: uppercase;
+  padding: 1px 5px; border-radius: 99px;
+}
+.fin-cowork .vd-ai-tag.new {
+  background: var(--vd-ai); color: white;
+}
+.fin-cowork .vd-ai-prods {
+  margin: 10px 0 12px;
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 8px 10px;
+}
+.fin-cowork .vd-ai-prods > small {
+  display: block; font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.05em; text-transform: uppercase;
+  color: var(--text-mute); margin-bottom: 6px;
+}
+.fin-cowork .vd-ai-prods ul { list-style: none; margin: 0; padding: 0; }
+.fin-cowork .vd-ai-prods li {
+  display: grid; grid-template-columns: 40px 1fr auto;
+  gap: 8px; padding: 4px 0; font-size: 12px;
+  border-top: 1px solid var(--border-2);
+  align-items: center;
+}
+.fin-cowork .vd-ai-prods li:first-child { border-top: none; }
+.fin-cowork .vd-ai-prods .ct {
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  color: var(--vd-ai); background: var(--vd-ai-soft);
+  padding: 1px 6px; border-radius: 99px; text-align: center;
+}
+.fin-cowork .vd-ai-prods .px {
+  font-family: var(--font-mono); font-size: 11px; color: var(--text-mute);
+}
+/* ── Sugestão parseada ── */
+.fin-cowork .vd-ai-suggest {
+  display: flex; flex-direction: column; gap: 6px;
+}
+.fin-cowork .vd-ai-suggest-h {
+  display: flex; align-items: center; gap: 10px;
+}
+.fin-cowork .vd-ai-suggest-ic {
+  display: grid; place-items: center;
+  width: 30px; height: 30px;
+  background: var(--vd-ai); color: white;
+  border-radius: 6px; font-size: 15px;
+  flex-shrink: 0;
+}
+.fin-cowork .vd-ai-suggest-h b {
+  display: block; font-size: 13.5px; font-weight: 700;
+}
+.fin-cowork .vd-ai-suggest-h small {
+  display: block; font-family: var(--font-mono);
+  font-size: 11.5px; color: var(--vd-ai);
+}
+.fin-cowork .vd-ai-suggest p {
+  margin: 4px 0 0; font-size: 12px; line-height: 1.5;
+  color: var(--text-dim);
+  padding-left: 40px;
+}
+.fin-cowork .vd-ai-suggest-cta {
+  align-self: flex-start;
+  margin-left: 40px; margin-top: 6px;
+  background: white; color: var(--vd-ai);
+  border: 1px solid var(--vd-ai-border);
+  padding: 5px 10px; border-radius: 5px;
+  font-size: 11.5px; font-weight: 600; cursor: pointer;
+}
+.fin-cowork .vd-ai-suggest-cta:hover { background: var(--vd-ai-soft); }
+/* ── Empty-state IA no ⌘K palette ── */
+.fin-cowork .vendas-aplus .vd-pal-ai-wrap {
+  padding: 8px;
+}
+.fin-cowork .vendas-aplus .vd-pal-ai-cta {
+  width: 100%;
+  display: flex; align-items: center; gap: 12px;
+  padding: 14px 14px;
+  background: linear-gradient(135deg, var(--vd-ai-soft), oklch(0.985 0.015 295));
+  border: 1px dashed var(--vd-ai-border);
+  border-radius: 8px;
+  cursor: pointer;
+  font-family: inherit;
+  transition: all .12s;
+}
+.fin-cowork .vendas-aplus .vd-pal-ai-cta:hover {
+  border-style: solid;
+  background: linear-gradient(135deg, oklch(0.93 0.06 295), oklch(0.96 0.04 295));
+}
+.fin-cowork .vendas-aplus .vd-pal-ai-ic {
+  display: grid; place-items: center;
+  width: 30px; height: 30px;
+  background: var(--vd-ai); color: white;
+  border-radius: 7px; font-size: 15px;
+  flex-shrink: 0;
+}
+.fin-cowork .vendas-aplus .vd-pal-ai-tx { flex: 1; text-align: left; }
+.fin-cowork .vendas-aplus .vd-pal-ai-tx b {
+  display: block; font-size: 13px; font-weight: 600;
+  color: var(--vd-ai-text);
+}
+.fin-cowork .vendas-aplus .vd-pal-ai-tx small {
+  display: block; font-size: 11.5px; color: var(--text-dim);
+}
+.fin-cowork .vendas-aplus .vd-pal-ai-tx i { color: var(--vd-ai); font-style: normal; font-weight: 500; }
+.fin-cowork .vendas-aplus .vd-pal-ai-cta kbd {
+  font-family: var(--font-mono); font-size: 10px;
+  background: white; border: 1px solid var(--vd-ai-border);
+  border-bottom-width: 2px; border-radius: 4px;
+  padding: 2px 7px; color: var(--vd-ai);
+}
+.fin-cowork .vendas-aplus .vd-pal-ai-loading {
+  display: flex; align-items: center; gap: 10px;
+  padding: 14px;
+  background: var(--vd-ai-soft);
+  border-radius: 8px;
+  font-size: 12.5px; color: var(--vd-ai-text);
+}
+.fin-cowork .vendas-aplus .vd-pal-ai-dots {
+  display: inline-flex; gap: 3px; margin-left: auto;
+}
+.fin-cowork .vendas-aplus .vd-pal-ai-dots span {
+  width: 5px; height: 5px; border-radius: 50%;
+  background: var(--vd-ai);
+  animation: vdAiPulse 1.2s ease-in-out infinite;
+}
+.fin-cowork .vendas-aplus .vd-pal-ai-dots span:nth-child(2) { animation-delay: 0.15s; }
+.fin-cowork .vendas-aplus .vd-pal-ai-dots span:nth-child(3) { animation-delay: 0.30s; }
+.fin-cowork .vendas-aplus .vd-pal-ai-answer {
+  background: white;
+  border: 1px solid var(--vd-ai-border);
+  border-radius: 8px;
+  padding: 12px 14px;
+}
+.fin-cowork .vendas-aplus .vd-pal-ai-answer header {
+  display: flex; align-items: center; gap: 8px;
+  margin-bottom: 8px;
+}
+.fin-cowork .vendas-aplus .vd-pal-ai-answer header .vd-pal-ai-ic {
+  width: 22px; height: 22px; font-size: 12px; border-radius: 5px;
+}
+.fin-cowork .vendas-aplus .vd-pal-ai-answer header b { color: var(--vd-ai-text); font-size: 12.5px; }
+.fin-cowork .vendas-aplus .vd-pal-ai-answer header span {
+  font-size: 11px; color: var(--text-mute); margin-left: auto;
+}
+.fin-cowork .vendas-aplus .vd-pal-ai-answer p {
+  margin: 0; font-size: 12.5px; line-height: 1.55;
+  color: var(--text);
+}
+.fin-cowork .vendas-aplus .vd-pal-ai-answer small {
+  display: block; margin-top: 8px;
+  font-size: 10.5px; color: var(--text-mute);
+  border-top: 1px solid var(--border-2);
+  padding-top: 6px;
+}
+/* ── Responsive: stats grid IA cai pra 2 cols ── */
+@media (max-width: 900px) {
+.fin-cowork .vd-ai-stats { grid-template-columns: 1fr 1fr; }
+}
+/* ═══════════════════════════════════════════════════════════════════
+   VENDAS · REFINO #3 KB-9.75 · CURADORIA + GUIA (2026-05-15)
+   Comentários inline · histórico edições · troubleshooter · cross-link
+   ═══════════════════════════════════════════════════════════════════ */
+/* ── Header note linkificada ── */
+.fin-cowork .vd-drawer-aplus .vd-drawer-note {
+  margin: 4px 0 6px !important;
+  font-size: 12.5px; color: var(--text-dim);
+  line-height: 1.45;
+}
+/* ── Tab counter comentários ── */
+.fin-cowork .vd-drawer-aplus .vd-drawer-tab-cmt {
+  margin-left: 4px;
+  font-size: 10px; font-weight: 600;
+  background: oklch(0.94 0.06 240); color: oklch(0.36 0.13 240);
+  padding: 1px 5px; border-radius: 99px;
+}
+/* Item card com comentários inline */
+.fin-cowork .vd-drawer-aplus .vd-item-cur {
+  display: flex; flex-direction: column;
+  background: white; border: 1px solid var(--border);
+  border-radius: 8px; overflow: hidden;
+  transition: border-color .12s;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-cur.has-comments {
+  border-color: oklch(0.82 0.10 240);
+  background: oklch(0.99 0.015 240);
+}
+.fin-cowork .vd-drawer-aplus .vd-item-cur.has-edit {
+  border-left: 3px solid oklch(0.62 0.13 60);
+}
+.fin-cowork .vd-drawer-aplus .vd-item-cur.editing {
+  border-color: oklch(0.62 0.13 60);
+  background: oklch(0.98 0.01 60);
+  box-shadow: 0 0 0 3px oklch(0.95 0.05 60);
+}
+.fin-cowork .vd-drawer-aplus .vd-item-cur .vd-item-c-main {
+  display: grid;
+  grid-template-columns: 1fr 64px 100px 130px 76px;
+  gap: 10px; align-items: center;
+  padding: 10px 12px;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-edited {
+  color: oklch(0.50 0.13 60); font-weight: 600;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-c-acts {
+  display: inline-flex; gap: 3px; justify-content: flex-end;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-input {
+  width: 100%;
+  border: 1px solid oklch(0.82 0.10 60);
+  background: white;
+  border-radius: 4px;
+  padding: 4px 8px;
+  font-family: var(--font-mono); font-size: 12px;
+  text-align: right;
+  outline: none;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-input:focus {
+  border-color: oklch(0.55 0.14 60);
+  box-shadow: 0 0 0 2px oklch(0.94 0.06 60);
+}
+.fin-cowork .vd-drawer-aplus .vd-item-c-edit, .fin-cowork .vd-drawer-aplus .vd-item-c-reset {
+  width: 26px; height: 26px;
+  background: transparent;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  font-size: 13px; cursor: pointer;
+  color: var(--text-mute);
+  display: inline-grid; place-items: center;
+  transition: all .12s;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-c-edit:hover {
+  border-color: oklch(0.62 0.13 60);
+  color: oklch(0.50 0.13 60);
+  background: oklch(0.96 0.05 60);
+}
+.fin-cowork .vd-drawer-aplus .vd-item-c-edit.on {
+  background: oklch(0.62 0.13 60); color: white;
+  border-color: oklch(0.62 0.13 60);
+}
+.fin-cowork .vd-drawer-aplus .vd-item-c-reset {
+  color: oklch(0.50 0.13 60); border-color: oklch(0.85 0.08 60);
+}
+.fin-cowork .vd-drawer-aplus .vd-item-c-reset:hover {
+  background: oklch(0.94 0.06 60);
+}
+.fin-cowork .vd-drawer-aplus .vd-item-diff {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 10px; font-weight: 600;
+  margin-top: 2px;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-diff.pos { color: oklch(0.50 0.13 145); }
+.fin-cowork .vd-drawer-aplus .vd-item-diff.neg { color: oklch(0.55 0.18 25); }
+/* Total com edição */
+.fin-cowork .vd-drawer-aplus .vd-edits-tag {
+  margin-left: 6px;
+  font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  color: oklch(0.50 0.13 60);
+  background: oklch(0.96 0.05 60);
+  padding: 1px 6px; border-radius: 99px;
+}
+.fin-cowork .vd-drawer-aplus .vd-total-orig {
+  color: var(--text-mute); font-weight: 500;
+  text-decoration: line-through;
+  margin-right: 8px;
+  font-size: 13px;
+}
+.fin-cowork .vd-drawer-aplus .vd-total-new { font-weight: 700; }
+.fin-cowork .vd-drawer-aplus .vd-total-delta {
+  display: inline-block; margin-left: 8px;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  padding: 2px 7px; border-radius: 4px;
+}
+.fin-cowork .vd-drawer-aplus .vd-total-delta.pos { background: oklch(0.94 0.06 145); color: oklch(0.32 0.13 145); }
+.fin-cowork .vd-drawer-aplus .vd-total-delta.neg { background: oklch(0.95 0.04 25); color: oklch(0.50 0.18 25); }
+.fin-cowork .vd-drawer-aplus .vd-item-c-comm {
+  width: 28px; height: 28px;
+  background: transparent; border: 1px solid var(--border);
+  border-radius: 5px;
+  font-size: 13px; cursor: pointer;
+  position: relative;
+  display: grid; place-items: center;
+  color: var(--text-mute);
+  transition: all .12s;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-c-comm:hover {
+  border-color: oklch(0.55 0.13 240);
+  color: oklch(0.55 0.13 240);
+  background: oklch(0.96 0.04 240);
+}
+.fin-cowork .vd-drawer-aplus .vd-item-c-comm.on {
+  background: oklch(0.55 0.13 240); color: white;
+  border-color: oklch(0.55 0.13 240);
+}
+.fin-cowork .vd-drawer-aplus .vd-item-c-comm.has {
+  background: oklch(0.94 0.06 240); color: oklch(0.36 0.13 240);
+  border-color: oklch(0.86 0.08 240);
+}
+.fin-cowork .vd-drawer-aplus .vd-item-c-comm .ct {
+  position: absolute; top: -5px; right: -5px;
+  background: oklch(0.55 0.13 240); color: white;
+  font-size: 9px; font-weight: 700;
+  padding: 1px 4px; border-radius: 99px;
+  min-width: 14px; text-align: center;
+  line-height: 1.4;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-thread {
+  border-top: 1px solid var(--border-2);
+  background: oklch(0.985 0.012 240);
+  padding: 10px 14px;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-comment {
+  background: white; border: 1px solid var(--border-2);
+  border-radius: 6px; padding: 8px 10px;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-comment-h {
+  display: flex; align-items: center; gap: 6px;
+  margin-bottom: 4px;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-comment-av {
+  display: grid; place-items: center;
+  width: 18px; height: 18px;
+  background: oklch(0.55 0.13 240); color: white;
+  border-radius: 50%; font-size: 10px; font-weight: 700;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-comment-h b { font-size: 12px; font-weight: 600; }
+.fin-cowork .vd-drawer-aplus .vd-item-comment-when {
+  font-size: 10.5px; color: var(--text-mute);
+}
+.fin-cowork .vd-drawer-aplus .vd-item-comment-x {
+  margin-left: auto;
+  background: transparent; border: none;
+  color: var(--text-mute); font-size: 14px;
+  cursor: pointer; padding: 0 4px;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-comment-x:hover { color: var(--vd-bad); }
+.fin-cowork .vd-drawer-aplus .vd-item-comment p {
+  margin: 0; font-size: 12px; line-height: 1.5;
+  color: var(--text);
+}
+.fin-cowork .vd-drawer-aplus .vd-item-comment-new {
+  background: white; border: 1px solid oklch(0.82 0.10 240);
+  border-radius: 6px; padding: 8px;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-comment-new textarea {
+  width: 100%; border: none; outline: none; resize: vertical;
+  font-family: inherit; font-size: 12px; line-height: 1.5;
+  background: transparent;
+  min-height: 50px;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-comment-row {
+  display: flex; align-items: center; gap: 8px;
+  margin-top: 6px;
+}
+.fin-cowork .vd-drawer-aplus .vd-item-comment-row small {
+  flex: 1; font-size: 10.5px; color: var(--text-mute);
+}
+/* ── Audit trail ── */
+.fin-cowork .vd-drawer-aplus .vd-audit-h {
+  display: flex; align-items: baseline; gap: 10px;
+  margin-bottom: 14px;
+}
+.fin-cowork .vd-drawer-aplus .vd-audit-h h4 {
+  margin: 0; font-size: 14px; font-weight: 700;
+}
+.fin-cowork .vd-drawer-aplus .vd-audit-h small {
+  font-size: 11px; color: var(--text-mute);
+}
+.fin-cowork .vd-drawer-aplus .vd-audit-list {
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column;
+  gap: 0;
+}
+.fin-cowork .vd-drawer-aplus .vd-audit-row {
+  display: grid; grid-template-columns: 28px 1fr;
+  gap: 10px;
+  padding: 10px 0;
+  border-bottom: 1px solid var(--border-2);
+  position: relative;
+}
+.fin-cowork .vd-drawer-aplus .vd-audit-row:last-child { border-bottom: none; }
+.fin-cowork .vd-drawer-aplus .vd-audit-row::before {
+  content: ''; position: absolute;
+  left: 13px; top: 30px; bottom: -2px;
+  width: 2px; background: var(--border-2);
+}
+.fin-cowork .vd-drawer-aplus .vd-audit-row:last-child::before { display: none; }
+.fin-cowork .vd-drawer-aplus .vd-audit-ic {
+  display: grid; place-items: center;
+  width: 26px; height: 26px;
+  border-radius: 50%;
+  background: var(--bg-2); color: var(--text-mute);
+  font-size: 12px; font-weight: 700;
+  position: relative; z-index: 1;
+}
+.fin-cowork .vd-drawer-aplus .vd-audit-create .vd-audit-ic { background: oklch(0.94 0.06 145); color: oklch(0.32 0.13 145); }
+.fin-cowork .vd-drawer-aplus .vd-audit-edit   .vd-audit-ic { background: oklch(0.94 0.06 240); color: oklch(0.36 0.13 240); }
+.fin-cowork .vd-drawer-aplus .vd-audit-fiscal .vd-audit-ic { background: oklch(0.96 0.05 70); color: oklch(0.42 0.13 60); }
+.fin-cowork .vd-drawer-aplus .vd-audit-reject .vd-audit-ic { background: oklch(0.96 0.05 25); color: var(--vd-bad); }
+.fin-cowork .vd-drawer-aplus .vd-audit-body header {
+  display: flex; align-items: baseline; gap: 8px;
+  margin-bottom: 2px;
+}
+.fin-cowork .vd-drawer-aplus .vd-audit-body header b { font-size: 12.5px; font-weight: 600; }
+.fin-cowork .vd-drawer-aplus .vd-audit-action {
+  font-size: 11px; color: var(--text-mute);
+}
+.fin-cowork .vd-drawer-aplus .vd-audit-body header time {
+  margin-left: auto;
+  font-family: var(--font-mono); font-size: 10.5px;
+  color: var(--text-mute);
+}
+.fin-cowork .vd-drawer-aplus .vd-audit-body p {
+  margin: 0; font-size: 12px; color: var(--text-dim); line-height: 1.45;
+}
+.fin-cowork .vd-drawer-aplus .vd-audit-diff {
+  margin-top: 5px;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: 11px;
+  background: var(--bg-2); padding: 3px 8px; border-radius: 4px;
+}
+.fin-cowork .vd-drawer-aplus .vd-audit-diff .diff-from { color: var(--text-mute); text-decoration: line-through; }
+.fin-cowork .vd-drawer-aplus .vd-audit-diff .diff-arr { color: var(--text-mute); }
+.fin-cowork .vd-drawer-aplus .vd-audit-diff .diff-to { color: var(--text); font-weight: 600; }
+.fin-cowork .vd-drawer-aplus .vd-audit-diff .diff-pct.pos { color: oklch(0.50 0.13 145); }
+.fin-cowork .vd-drawer-aplus .vd-audit-diff .diff-pct.neg { color: var(--vd-bad); }
+/* ── Troubleshooter button ── */
+.fin-cowork .vd-drawer-aplus .vd-trouble-btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  background: oklch(0.96 0.06 60); color: oklch(0.42 0.13 60);
+  border: 1px solid oklch(0.85 0.10 60);
+  padding: 5px 10px 5px 5px; border-radius: 6px;
+  font-family: inherit; font-size: 11.5px; font-weight: 600;
+  cursor: pointer;
+  margin-right: auto;
+  transition: all .12s;
+}
+.fin-cowork .vd-drawer-aplus .vd-trouble-btn:hover {
+  background: oklch(0.93 0.08 60);
+  border-color: oklch(0.72 0.13 60);
+}
+.fin-cowork .vd-drawer-aplus .vd-trouble-ic {
+  display: grid; place-items: center;
+  width: 22px; height: 22px;
+  background: oklch(0.62 0.13 60); color: white;
+  border-radius: 4px;
+  font-size: 14px; font-weight: 700;
+}
+.fin-cowork .vd-drawer-aplus .vd-trouble-lbl { font-size: 12px; }
+.fin-cowork .vd-drawer-aplus .vd-trouble-lbl b { font-weight: 700; }
+.fin-cowork .vd-drawer-aplus .vd-trouble-ct {
+  font-family: var(--font-mono); font-size: 9.5px;
+  background: white; color: var(--text-mute);
+  padding: 1px 6px; border-radius: 99px;
+}
+/* ── Cross-link pills (#V #OS #CLI #orc) ── */
+.fin-cowork .vd-link {
+  display: inline-flex; align-items: center;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 600;
+  padding: 1px 6px; border-radius: 4px;
+  text-decoration: none; line-height: 1.5;
+  transition: opacity .12s;
+}
+.fin-cowork .vd-link:hover { opacity: 0.75; }
+.fin-cowork .vd-link-venda { background: var(--vd-green-soft); color: var(--vd-green); }
+.fin-cowork .vd-link-os { background: oklch(0.94 0.06 240); color: oklch(0.36 0.13 240); }
+.fin-cowork .vd-link-cli { background: oklch(0.94 0.06 295); color: oklch(0.36 0.13 295); }
+.fin-cowork .vd-link-orc { background: oklch(0.96 0.05 70);  color: oklch(0.42 0.13 60); }
+.fin-cowork .vd-link-bol { background: oklch(0.95 0.05 200); color: oklch(0.38 0.13 200); }
+.fin-cowork .vd-link-compra { background: oklch(0.95 0.05 30); color: oklch(0.42 0.13 30); }
+.fin-cowork .vd-link-fin-rec { background: oklch(0.94 0.05 145); color: oklch(0.36 0.13 145); }
+.fin-cowork .vd-link-fin-pay { background: oklch(0.95 0.04 25); color: oklch(0.50 0.18 25); }
+.fin-cowork .vd-link-ref { background: var(--bg-2); color: var(--text); }
+/* ── Lançamentos financeiros vinculados (drawer venda) ── */
+.fin-cowork .vd-drawer-aplus .vd-fin-list {
+  display: flex; flex-direction: column; gap: 6px;
+}
+.fin-cowork .vd-drawer-aplus .vd-fin-link {
+  display: grid;
+  grid-template-columns: 100px 1fr 110px 90px;
+  align-items: center; gap: 10px;
+  padding: 8px 12px;
+  background: var(--bg-2);
+  border-radius: 6px;
+  border-left: 3px solid;
+  font-size: 12px;
+}
+.fin-cowork .vd-drawer-aplus .vd-fin-link.rec { border-left-color: oklch(0.55 0.13 145); }
+.fin-cowork .vd-drawer-aplus .vd-fin-link.pay { border-left-color: oklch(0.55 0.18 25); }
+.fin-cowork .vd-drawer-aplus .vd-fin-link.paid { opacity: 0.70; }
+.fin-cowork .vd-drawer-aplus .vd-fin-pill {
+  display: inline-flex; align-items: center; gap: 3px;
+  font-family: var(--font-mono); font-size: 11px; font-weight: 700;
+  padding: 2px 8px; border-radius: 4px;
+}
+.fin-cowork .vd-drawer-aplus .vd-fin-pill.rec { background: oklch(0.94 0.05 145); color: oklch(0.32 0.13 145); }
+.fin-cowork .vd-drawer-aplus .vd-fin-pill.pay { background: oklch(0.95 0.04 25); color: oklch(0.50 0.18 25); }
+.fin-cowork .vd-drawer-aplus .vd-fin-meta { font-size: 11.5px; color: var(--text-dim); }
+.fin-cowork .vd-drawer-aplus .vd-fin-amount {
+  font-family: var(--font-mono); font-weight: 600;
+  text-align: right;
+}
+.fin-cowork .vd-drawer-aplus .vd-fin-status {
+  font-family: var(--font-mono); font-size: 10.5px;
+  text-align: center; padding: 2px 8px; border-radius: 4px;
+}
+.fin-cowork .vd-drawer-aplus .vd-fin-status.open { background: oklch(0.96 0.06 60); color: oklch(0.42 0.13 60); }
+.fin-cowork .vd-drawer-aplus .vd-fin-status.paid { background: var(--bg-2); color: var(--text-mute); }
+.fin-cowork .vd-drawer-aplus .vd-fin-status.late { background: oklch(0.95 0.04 25); color: oklch(0.55 0.18 25); }
+/* ═══════════════════════════════════════════════════════════════════
+   VENDAS · REFINO #4 KB-9.75 · DISTRIBUIÇÃO (2026-05-15)
+   Transcript PDF · Modo apresentação · Mensagem variáveis · Favoritas
+   ═══════════════════════════════════════════════════════════════════ */
+/* ── Favoritas no tree-view ── */
+.fin-cowork .vendas-aplus .vd-tree-row.vd-tree-fav .vd-tree-lbl {
+  color: oklch(0.55 0.16 70);
+}
+.fin-cowork .vendas-aplus .vd-tree-row.vd-tree-fav.active {
+  background: oklch(0.96 0.06 70);
+  color: oklch(0.42 0.13 60);
+}
+.fin-cowork .vendas-aplus .vd-tree-row.vd-tree-fav.active .vd-tree-lbl { color: oklch(0.42 0.13 60); }
+.fin-cowork .vendas-aplus .vd-tree-row.vd-tree-fav small {
+  font-size: 10px; font-weight: 400;
+  color: var(--text-mute); margin-left: 4px;
+}
+/* ── Botão Apresentar no drawer footer ── */
+.fin-cowork .vd-drawer-aplus .vd-btn-present {
+  color: oklch(0.42 0.13 295); font-weight: 600;
+}
+.fin-cowork .vd-drawer-aplus .vd-btn-present:hover {
+  background: oklch(0.96 0.05 295);
+  color: oklch(0.32 0.18 295);
+}
+/* ══════════════════════════════════════════
+   TRANSCRIPT PDF — overlay + print layout
+   ══════════════════════════════════════════ */
+.fin-cowork .vd-trans-bd {
+  position: fixed; inset: 0; z-index: 1100;
+  background: oklch(0.3 0.005 240 / 0.6);
+  overflow: auto; padding: 0;
+}
+.fin-cowork .vd-trans-toolbar {
+  position: sticky; top: 0; z-index: 10;
+  background: var(--surface);
+  border-bottom: 1px solid var(--border);
+  padding: 10px 18px;
+  display: flex; align-items: center; gap: 14px;
+}
+.fin-cowork .vd-trans-toolbar .vd-trans-tag {
+  flex: 1; text-align: center;
+  font-size: 12px; color: var(--text-dim);
+  font-family: var(--font-mono);
+}
+.fin-cowork .vd-trans-page {
+  background: white; color: #1a1a1a;
+  width: 794px; /* A4 ~96dpi */
+  min-height: 1123px;
+  margin: 24px auto;
+  padding: 50px 60px 80px;
+  box-shadow: 0 8px 40px rgba(0,0,0,0.15);
+  font-family: var(--font-sans);
+  font-size: 12px; line-height: 1.55;
+}
+.fin-cowork .vd-trans-h {
+  display: flex; justify-content: space-between;
+  align-items: flex-start;
+  padding-bottom: 18px;
+  border-bottom: 2px solid #1a1a1a;
+  margin-bottom: 22px;
+}
+.fin-cowork .vd-trans-brand {
+  font-size: 22px; font-weight: 800; letter-spacing: -0.02em;
+}
+.fin-cowork .vd-trans-brand-sub {
+  font-size: 11px; font-weight: 500; color: #555;
+  letter-spacing: 0.04em; text-transform: uppercase;
+}
+.fin-cowork .vd-trans-meta-co { text-align: right; font-size: 10.5px; color: #555; line-height: 1.5; }
+.fin-cowork .vd-trans-title { margin-bottom: 24px; }
+.fin-cowork .vd-trans-title h1 {
+  margin: 0 0 4px; font-size: 22px; font-weight: 700;
+  letter-spacing: -0.015em;
+}
+.fin-cowork .vd-trans-title h1 small {
+  font-family: var(--font-mono);
+  font-size: 14px; color: #777;
+  margin-left: 8px;
+}
+.fin-cowork .vd-trans-title span { font-size: 10.5px; color: #777; }
+.fin-cowork .vd-trans-grid {
+  display: grid; grid-template-columns: repeat(2, 1fr); gap: 10px;
+  margin-bottom: 24px;
+}
+.fin-cowork .vd-trans-block {
+  border: 1px solid #d8d8d8; border-radius: 4px;
+  padding: 10px 14px;
+}
+.fin-cowork .vd-trans-block small {
+  display: block;
+  font-size: 9.5px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.06em;
+  color: #888; margin-bottom: 4px;
+}
+.fin-cowork .vd-trans-block h3 {
+  margin: 0 0 4px; font-size: 14px; font-weight: 700;
+}
+.fin-cowork .vd-trans-block p {
+  margin: 0; font-size: 11px; color: #555;
+}
+.fin-cowork .vd-trans-block.vd-trans-total {
+  background: #f4f4f0;
+  border-color: #1a1a1a;
+}
+.fin-cowork .vd-trans-block.vd-trans-total h3 { font-family: var(--font-mono); font-size: 18px; }
+.fin-cowork .vd-trans-section {
+  margin-bottom: 24px; page-break-inside: avoid;
+}
+.fin-cowork .vd-trans-section h2 {
+  margin: 0 0 10px;
+  font-size: 13px; font-weight: 700; letter-spacing: -0.005em;
+  padding-bottom: 4px;
+  border-bottom: 1px solid #1a1a1a;
+}
+.fin-cowork .vd-trans-items, .fin-cowork .vd-trans-fiscal, .fin-cowork .vd-trans-audit {
+  width: 100%; border-collapse: collapse; font-size: 11px;
+}
+.fin-cowork .vd-trans-items th, .fin-cowork .vd-trans-items td, .fin-cowork .vd-trans-fiscal th, .fin-cowork .vd-trans-fiscal td, .fin-cowork .vd-trans-audit th, .fin-cowork .vd-trans-audit td {
+  border-bottom: 1px solid #e8e8e8;
+  padding: 6px 8px; text-align: left; vertical-align: top;
+}
+.fin-cowork .vd-trans-items thead th {
+  background: #f4f4f0;
+  font-size: 9.5px; font-weight: 700;
+  text-transform: uppercase; letter-spacing: 0.05em; color: #555;
+}
+.fin-cowork .vd-trans-items .num, .fin-cowork .vd-trans-fiscal .num { text-align: right; font-variant-numeric: tabular-nums; }
+.fin-cowork .vd-trans-items .strong, .fin-cowork .vd-trans-fiscal .strong { font-weight: 700; }
+.fin-cowork .vd-trans-items .mono, .fin-cowork .vd-trans-fiscal .mono, .fin-cowork .vd-trans-audit .mono { font-family: var(--font-mono); font-size: 10px; }
+.fin-cowork .vd-trans-items tfoot td { border-top: 2px solid #1a1a1a; padding-top: 8px; font-weight: 600; }
+.fin-cowork .vd-trans-fiscal th {
+  width: 130px;
+  background: #f4f4f0;
+  font-weight: 600;
+  border-right: 1px solid #e8e8e8;
+}
+.fin-cowork .vd-trans-fiscal .small { font-size: 9.5px; color: #888; margin-top: 2px; }
+.fin-cowork .vd-trans-fiscal .fail { color: oklch(0.45 0.18 25); margin-top: 4px; }
+.fin-cowork .vd-trans-comment-block { margin-bottom: 12px; }
+.fin-cowork .vd-trans-comment-item {
+  display: block; font-size: 11.5px; font-weight: 600; color: #1a1a1a;
+  background: #f4f4f0;
+  padding: 4px 8px; margin-bottom: 4px;
+  border-left: 3px solid #888;
+}
+.fin-cowork .vd-trans-comment {
+  padding: 6px 12px; border-bottom: 1px dashed #e0e0e0;
+}
+.fin-cowork .vd-trans-comment .mono { font-family: var(--font-mono); font-size: 9.5px; color: #888; }
+.fin-cowork .vd-trans-comment p { margin: 2px 0 0; font-size: 11px; }
+.fin-cowork .vd-trans-sign {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 60px;
+  margin-top: 60px; margin-bottom: 24px;
+}
+.fin-cowork .vd-trans-sign-line {
+  border-top: 1px solid #1a1a1a;
+  margin-bottom: 6px;
+}
+.fin-cowork .vd-trans-sign small {
+  font-size: 10px; color: #555;
+}
+.fin-cowork .vd-trans-foot {
+  text-align: center;
+  border-top: 1px solid #d8d8d8;
+  padding-top: 12px; margin-top: 20px;
+  font-size: 9.5px; color: #888;
+}
+/* @media print — só mostra o transcript */
+@media print {
+.fin-cowork body.vd-print-mode > *:not(.vd-trans-bd) { display: none !important; }
+.fin-cowork body.vd-print-mode .vd-trans-bd {
+    position: static !important; background: white !important; padding: 0 !important; overflow: visible !important;
+  }
+.fin-cowork body.vd-print-mode .vd-trans-toolbar { display: none !important; }
+.fin-cowork body.vd-print-mode .vd-trans-page {
+    margin: 0 !important; box-shadow: none !important; width: 100% !important;
+    padding: 0 24px !important;
+  }
+}
+/* ══════════════════════════════════════════
+   MODO APRESENTAÇÃO — fullscreen
+   ══════════════════════════════════════════ */
+.fin-cowork .vd-pres-overlay {
+  position: fixed; inset: 0; z-index: 1200;
+  background: linear-gradient(135deg, oklch(0.16 0.005 240), oklch(0.20 0.01 200));
+  color: white;
+  display: flex; flex-direction: column;
+  animation: vdPresFade 0.25s ease-out;
+}
+@keyframes vdPresFade { from { opacity: 0; } to { opacity: 1; } }
+.fin-cowork .vd-pres-top {
+  display: flex; align-items: center; gap: 14px;
+  padding: 16px 28px;
+  border-bottom: 1px solid oklch(1 0 0 / 0.08);
+}
+.fin-cowork .vd-pres-brand {
+  flex: 1;
+  font-size: 11px; font-weight: 700;
+  letter-spacing: 0.15em; text-transform: uppercase;
+  color: oklch(1 0 0 / 0.5);
+}
+.fin-cowork .vd-pres-counter {
+  font-family: var(--font-mono);
+  font-size: 11.5px; color: oklch(1 0 0 / 0.5);
+}
+.fin-cowork .vd-pres-close {
+  background: transparent; border: 1px solid oklch(1 0 0 / 0.2);
+  color: white; width: 32px; height: 32px;
+  border-radius: 6px; cursor: pointer;
+  font-size: 18px; line-height: 1;
+}
+.fin-cowork .vd-pres-close:hover { background: oklch(1 0 0 / 0.08); }
+.fin-cowork .vd-pres-stage {
+  flex: 1;
+  display: grid; place-items: center;
+  padding: 40px 80px;
+}
+.fin-cowork .vd-pres-slide { max-width: 900px; width: 100%; text-align: center; }
+.fin-cowork .vd-pres-eyebrow {
+  display: block;
+  font-size: 13px; font-weight: 600;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  color: oklch(0.65 0.13 145);
+  margin-bottom: 16px;
+}
+.fin-cowork .vd-pres-slide h1 {
+  font-size: 64px; font-weight: 700;
+  letter-spacing: -0.025em; line-height: 1.05;
+  margin: 0 0 18px;
+}
+.fin-cowork .vd-pres-slide > p {
+  font-size: 22px; font-weight: 400; line-height: 1.45;
+  color: oklch(1 0 0 / 0.7); max-width: 700px; margin: 0 auto;
+}
+.fin-cowork .vd-pres-chips {
+  display: flex; gap: 10px; justify-content: center; margin-top: 36px; flex-wrap: wrap;
+}
+.fin-cowork .vd-pres-chip {
+  background: oklch(1 0 0 / 0.08);
+  border: 1px solid oklch(1 0 0 / 0.12);
+  border-radius: 99px;
+  padding: 8px 18px;
+  font-size: 14px; font-weight: 500;
+}
+.fin-cowork .vd-pres-chip.primary {
+  background: oklch(0.50 0.14 155);
+  border-color: oklch(0.55 0.14 155);
+  color: white;
+}
+.fin-cowork .vd-pres-items ul {
+  list-style: none; margin: 28px 0 0; padding: 0;
+  text-align: left;
+  display: flex; flex-direction: column; gap: 14px;
+}
+.fin-cowork .vd-pres-items li {
+  display: flex; align-items: center; gap: 20px;
+  padding: 20px 26px;
+  background: oklch(1 0 0 / 0.05);
+  border: 1px solid oklch(1 0 0 / 0.08);
+  border-radius: 12px;
+}
+.fin-cowork .vd-pres-item-l { flex: 1; }
+.fin-cowork .vd-pres-item-l b { display: block; font-size: 22px; font-weight: 600; margin-bottom: 4px; }
+.fin-cowork .vd-pres-item-l small { font-size: 14px; color: oklch(1 0 0 / 0.55); }
+.fin-cowork .vd-pres-item-r {
+  font-family: var(--font-mono);
+  font-size: 26px; font-weight: 700;
+}
+.fin-cowork .vd-pres-amount {
+  font-family: var(--font-mono);
+  font-size: 96px; font-weight: 700;
+  letter-spacing: -0.03em; line-height: 1;
+  color: oklch(0.85 0.10 145);
+  margin: 12px 0 32px;
+}
+.fin-cowork .vd-pres-payment {
+  display: flex; justify-content: space-between; align-items: center;
+  max-width: 500px; margin: 12px auto;
+  padding: 14px 24px;
+  background: oklch(1 0 0 / 0.05);
+  border-radius: 10px;
+  font-size: 18px;
+}
+.fin-cowork .vd-pres-payment span { color: oklch(1 0 0 / 0.5); }
+.fin-cowork .vd-pres-payment b { font-weight: 600; }
+.fin-cowork .vd-pres-next ol {
+  text-align: left; max-width: 600px; margin: 28px auto 0;
+  padding: 0; list-style: none; counter-reset: pres;
+}
+.fin-cowork .vd-pres-next li {
+  counter-increment: pres;
+  padding: 16px 0 16px 56px;
+  font-size: 22px;
+  border-top: 1px solid oklch(1 0 0 / 0.08);
+  position: relative;
+}
+.fin-cowork .vd-pres-next li::before {
+  content: counter(pres);
+  position: absolute; left: 0; top: 14px;
+  width: 36px; height: 36px; border-radius: 50%;
+  background: oklch(0.50 0.14 155); color: white;
+  display: grid; place-items: center;
+  font-family: var(--font-mono); font-size: 14px; font-weight: 700;
+}
+.fin-cowork .vd-pres-next li:first-child { border-top: none; }
+.fin-cowork .vd-pres-foot-note {
+  margin-top: 32px;
+  font-size: 14px; color: oklch(1 0 0 / 0.5);
+}
+.fin-cowork .vd-pres-bot {
+  display: flex; align-items: center; gap: 18px; justify-content: center;
+  padding: 20px 28px;
+  border-top: 1px solid oklch(1 0 0 / 0.08);
+}
+.fin-cowork .vd-pres-bot button {
+  background: oklch(1 0 0 / 0.08);
+  border: 1px solid oklch(1 0 0 / 0.12);
+  color: white;
+  width: 44px; height: 44px;
+  border-radius: 8px;
+  font-size: 18px; cursor: pointer;
+}
+.fin-cowork .vd-pres-bot button:hover:not(:disabled) { background: oklch(1 0 0 / 0.16); }
+.fin-cowork .vd-pres-bot button:disabled { opacity: 0.3; cursor: not-allowed; }
+.fin-cowork .vd-pres-dots { display: flex; gap: 8px; }
+.fin-cowork .vd-pres-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: oklch(1 0 0 / 0.2); cursor: pointer;
+  transition: all .15s;
+}
+.fin-cowork .vd-pres-dot.on { background: oklch(0.65 0.14 145); width: 24px; border-radius: 99px; }
+/* ══════════════════════════════════════════
+   MENSAGEM — variáveis live no Pagamento
+   ══════════════════════════════════════════ */
+.fin-cowork .vd-drawer-aplus .vd-msg {
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 14px 16px;
+}
+.fin-cowork .vd-drawer-aplus .vd-msg-h {
+  display: flex; align-items: baseline; gap: 12px;
+  margin-bottom: 12px;
+}
+.fin-cowork .vd-drawer-aplus .vd-msg-h h4 { margin: 0; font-size: 14px; font-weight: 700; }
+.fin-cowork .vd-drawer-aplus .vd-msg-tpls {
+  margin-left: auto;
+  display: flex; gap: 4px;
+}
+.fin-cowork .vd-drawer-aplus .vd-msg-tpl {
+  background: var(--bg-2); border: 1px solid transparent;
+  padding: 4px 9px; border-radius: 4px;
+  font-family: inherit; font-size: 11px; cursor: pointer;
+  color: var(--text-dim);
+}
+.fin-cowork .vd-drawer-aplus .vd-msg-tpl:hover { background: var(--border-2); }
+.fin-cowork .vd-drawer-aplus .vd-msg-tpl.on {
+  background: var(--vd-green-soft); color: var(--vd-green);
+  border-color: var(--vd-green); font-weight: 600;
+}
+.fin-cowork .vd-drawer-aplus .vd-msg-vars {
+  display: flex; align-items: center; gap: 6px; flex-wrap: wrap;
+  padding: 8px 0;
+  border-bottom: 1px dashed var(--border-2);
+  margin-bottom: 12px;
+}
+.fin-cowork .vd-drawer-aplus .vd-msg-vars small {
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.05em; text-transform: uppercase;
+  color: var(--text-mute); margin-right: 4px;
+}
+.fin-cowork .vd-drawer-aplus .vd-msg-var {
+  display: inline-flex; align-items: center; gap: 4px;
+  background: var(--bg-2);
+  padding: 2px 7px; border-radius: 4px;
+  font-size: 10.5px; line-height: 1.4;
+}
+.fin-cowork .vd-drawer-aplus .vd-msg-var .k {
+  font-family: var(--font-mono);
+  color: oklch(0.36 0.13 295);
+  font-weight: 600;
+}
+.fin-cowork .vd-drawer-aplus .vd-msg-var .arr { color: var(--text-mute); }
+.fin-cowork .vd-drawer-aplus .vd-msg-var .v {
+  color: var(--text); font-weight: 500;
+  max-width: 140px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+.fin-cowork .vd-drawer-aplus .vd-msg-preview {
+  background: oklch(0.97 0.025 145);
+  padding: 14px; border-radius: 8px;
+  margin-bottom: 10px;
+}
+.fin-cowork .vd-drawer-aplus .vd-msg-bubble {
+  background: oklch(0.95 0.05 145);
+  border-radius: 8px 8px 8px 2px;
+  padding: 10px 14px;
+  font-size: 12.5px; line-height: 1.55;
+  color: oklch(0.20 0.04 145);
+  max-width: 92%;
+  white-space: pre-wrap;
+}
+.fin-cowork .vd-drawer-aplus .vd-msg-actions {
+  display: flex; gap: 8px; justify-content: flex-end;
+}
+/* ══════════════════════════════════════════
+   ART-SLOT (preview da arte por item)
+   ══════════════════════════════════════════ */
+.fin-cowork .vd-art {
+  width: 56px; height: 56px;
+  border-radius: 6px;
+  background: var(--bg-2);
+  position: relative;
+  overflow: hidden;
+  flex-shrink: 0;
+}
+.fin-cowork .vd-art.empty {
+  border: 1.5px dashed var(--border);
+}
+.fin-cowork .vd-art.empty.drag {
+  border-color: var(--vd-green); background: var(--vd-green-soft);
+}
+.fin-cowork .vd-art.has {
+  border: 1px solid var(--border);
+}
+.fin-cowork .vd-art img {
+  width: 100%; height: 100%; object-fit: cover;
+  display: block;
+}
+.fin-cowork .vd-art-empty {
+  display: flex; flex-direction: column;
+  align-items: center; justify-content: center;
+  width: 100%; height: 100%;
+  cursor: pointer;
+  color: var(--text-mute);
+}
+.fin-cowork .vd-art-empty:hover { background: var(--border-2); }
+.fin-cowork .vd-art-ic { font-size: 18px; opacity: 0.5; line-height: 1; }
+.fin-cowork .vd-art-empty small {
+  font-size: 8.5px; line-height: 1.1;
+  padding: 0 4px; text-align: center;
+  margin-top: 3px;
+}
+.fin-cowork .vd-art-empty input { display: none; }
+.fin-cowork .vd-art-rm {
+  position: absolute; top: 3px; right: 3px;
+  background: rgba(0,0,0,0.6); color: white;
+  border: none; width: 18px; height: 18px;
+  border-radius: 50%; font-size: 12px;
+  cursor: pointer; line-height: 1;
+  opacity: 0; transition: opacity .15s;
+}
+.fin-cowork .vd-art:hover .vd-art-rm { opacity: 1; }
+/* ── Refino #4 polish · Dropdown "Visões ▾" (substitui topnav) ── */
+.fin-cowork .vendas-aplus .vd-visoes { position: relative; }
+.fin-cowork .vendas-aplus .vd-visoes-btn {
+  background: var(--surface); border: 1px solid var(--border);
+  padding: 6px 10px; border-radius: 5px;
+  font-family: inherit; font-size: 12px; font-weight: 500;
+  cursor: pointer; color: var(--text-dim);
+  display: inline-flex; align-items: center; gap: 5px;
+}
+.fin-cowork .vendas-aplus .vd-visoes-btn::after {
+  content: '▾'; font-size: 9px; color: var(--text-mute); margin-left: 2px;
+}
+.fin-cowork .vendas-aplus .vd-visoes-btn:hover { border-color: var(--text-mute); color: var(--text); }
+.fin-cowork .vendas-aplus .vd-visoes-menu {
+  position: absolute; top: calc(100% + 4px); right: 0;
+  min-width: 240px; background: var(--surface);
+  border: 1px solid var(--border); border-radius: 6px;
+  box-shadow: 0 8px 24px rgba(0,0,0,0.08);
+  padding: 6px; z-index: 30;
+}
+.fin-cowork .vendas-aplus .vd-visoes-grp {
+  font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--text-mute);
+  padding: 6px 10px 4px;
+}
+.fin-cowork .vendas-aplus .vd-visoes-item {
+  display: flex; align-items: center; gap: 8px;
+  padding: 7px 10px; border-radius: 4px;
+  font-size: 12.5px; cursor: pointer;
+}
+.fin-cowork .vendas-aplus .vd-visoes-item:hover { background: var(--bg-2); }
+.fin-cowork .vendas-aplus .vd-visoes-item.active {
+  background: var(--vd-green-soft); color: var(--vd-green); font-weight: 600;
+}
+.fin-cowork .vendas-aplus .vd-visoes-dot {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--vd-green);
+}
+.fin-cowork .vendas-aplus .vd-visoes-dot.pdv { background: oklch(0.55 0.13 240); }
+.fin-cowork .vendas-aplus .vd-visoes-here {
+  margin-left: auto; font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--vd-green); opacity: 0.7;
+}
+.fin-cowork .vendas-aplus .vd-visoes-sep {
+  height: 1px; background: var(--border-2); margin: 4px -6px;
+}
+.fin-cowork .vendas-aplus .vd-visoes-item.primary {
+  color: oklch(0.36 0.13 240); font-weight: 600;
+}
+.fin-cowork .vendas-aplus .vd-visoes-item.primary:hover { background: oklch(0.96 0.04 240); }
+.fin-cowork .vendas-aplus .vd-visoes-item kbd {
+  margin-left: auto;
+  font-family: var(--font-mono); font-size: 10px;
+  background: var(--bg-2); border: 1px solid var(--border);
+  border-bottom-width: 2px; border-radius: 3px;
+  padding: 1px 6px;
+}
+/* Esconder a antiga topnav (vendas-extras) — agora vive em "Visões ▾" */
+.fin-cowork .vendas-module-no-subnav .vm-subnav { display: none; }
+/* ── Vista → "Foco" label inline ── */
+.fin-cowork .vendas-aplus .vd-vista { display: inline-flex; align-items: center; }
+.fin-cowork .vendas-aplus .vd-vista-lbl {
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: var(--text-mute);
+  padding: 0 8px 0 4px;
+}
+/* ── Density toggle inline na FilterBar ── */
+.fin-cowork .fin-toolbar .fin-density {
+  display: inline-flex; align-items: center;
+  background: var(--bg-2);
+  border-radius: 6px;
+  padding: 2px;
+  gap: 0;
+  margin-right: 8px;
+}
+.fin-cowork .fin-toolbar .fin-density button {
+  border: none; background: transparent;
+  width: 30px; height: 26px;
+  border-radius: 4px;
+  color: var(--text-mute); cursor: pointer;
+  transition: all .12s;
+  display: inline-grid; place-items: center;
+}
+.fin-cowork .fin-toolbar .fin-density button:hover { color: var(--text); background: oklch(0 0 0 / 0.04); }
+.fin-cowork .fin-toolbar .fin-density button.on {
+  background: var(--surface); color: var(--accent, oklch(0.50 0.13 220));
+  box-shadow: 0 1px 2px rgba(0,0,0,0.06);
+}
+.fin-cowork .fin-toolbar .fin-density button svg { display: block; }
+/* ── Filter checkbox (4 lifecycle states — multi-select) ── */
+.fin-cowork .fin-toolbar .fin-filter-cb {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 5px 10px; border-radius: 5px;
+  border: 1px solid var(--border); background: var(--surface);
+  font-size: 12px; font-weight: 500; color: var(--text-dim);
+  cursor: pointer; user-select: none; transition: all .12s;
+  position: relative;
+}
+.fin-cowork .fin-toolbar .fin-filter-cb:hover {
+  border-color: var(--text-mute); color: var(--text);
+}
+.fin-cowork .fin-toolbar .fin-filter-cb input {
+  position: absolute; opacity: 0; pointer-events: none; width: 0; height: 0;
+}
+.fin-cowork .fin-toolbar .fin-filter-cb-box {
+  width: 14px; height: 14px;
+  border: 1.5px solid var(--text-mute);
+  border-radius: 3px;
+  display: inline-grid; place-items: center;
+  transition: all .12s;
+  flex-shrink: 0;
+}
+.fin-cowork .fin-toolbar .fin-filter-cb.on {
+  background: oklch(0.96 0.04 var(--cb-hue, 145));
+  border-color: oklch(0.55 0.13 var(--cb-hue, 145));
+  color: oklch(0.32 0.13 var(--cb-hue, 145));
+  font-weight: 600;
+}
+.fin-cowork .fin-toolbar .fin-filter-cb.on .fin-filter-cb-box {
+  background: oklch(0.55 0.13 var(--cb-hue, 145));
+  border-color: oklch(0.55 0.13 var(--cb-hue, 145));
+}
+.fin-cowork .fin-toolbar .fin-filter-cb.on .fin-filter-cb-box::after {
+  content: "";
+  width: 8px; height: 4px;
+  border-left: 1.5px solid white;
+  border-bottom: 1.5px solid white;
+  transform: rotate(-45deg) translate(0, -1px);
+}
+.fin-cowork .fin-toolbar .fin-filter-cb.on .fin-filter-ct {
+  background: white;
+  color: oklch(0.42 0.13 var(--cb-hue, 145));
+}
+.fin-cowork .fin-toolbar .fin-filter-clear {
+  margin-left: 4px;
+  background: transparent; border: none;
+  color: var(--text-mute); font-family: inherit; font-size: 11.5px;
+  cursor: pointer; padding: 5px 8px; border-radius: 4px;
+  text-decoration: underline; text-decoration-style: dotted;
+  text-underline-offset: 3px;
+}
+.fin-cowork .fin-toolbar .fin-filter-clear:hover {
+  color: var(--text); background: var(--bg-2);
+}
+/* ── Breadcrumb pras sub-rotas do Financeiro (Conciliação, Plano de contas) ── */
+.fin-cowork .fin-bcrumb {
+  display: flex; align-items: center; gap: 6px;
+  padding: 4px 24px 12px;
+  font-size: 12px; color: var(--text-mute);
+}
+.fin-cowork .fin-bcrumb-back {
+  display: inline-flex; align-items: center; gap: 5px;
+  background: transparent; border: 1px solid transparent;
+  padding: 4px 9px 4px 6px; border-radius: 5px;
+  font-family: inherit; font-size: 12px; font-weight: 500;
+  color: oklch(0.42 0.13 145); cursor: pointer;
+  transition: all .12s;
+}
+.fin-cowork .fin-bcrumb-back:hover {
+  background: oklch(0.94 0.05 145);
+  border-color: oklch(0.94 0.05 145);
+}
+.fin-cowork .fin-bcrumb-back svg { flex-shrink: 0; transition: transform .12s; }
+.fin-cowork .fin-bcrumb-back:hover svg { transform: translateX(-2px); }
+.fin-cowork .fin-bcrumb-sep { color: var(--text-mute); opacity: 0.5; font-size: 13px; }
+.fin-cowork .fin-bcrumb-here { font-weight: 500; color: var(--text); }
+/* ══════════════════════════════════════════
+   FINANCEIRO · REFINO #1 KB-9.75 · CURADORIA (2026-05-18)
+   ══════════════════════════════════════════ */
+/* Conferido inline (no header do drawer) */
+.fin-cowork .fin-conf-pill-inline {
+  display: inline-flex; align-items: center; gap: 3px;
+  padding: 1px 7px; border-radius: 99px;
+  background: oklch(0.94 0.06 145); color: oklch(0.32 0.13 145);
+  font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.04em; text-transform: uppercase;
+}
+/* Editado inline (no header do drawer) */
+.fin-cowork .fin-edit-pill-inline {
+  display: inline-flex; align-items: center; gap: 3px;
+  padding: 1px 7px; border-radius: 99px;
+  background: oklch(0.96 0.06 60); color: oklch(0.42 0.13 60);
+  font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.04em; text-transform: uppercase;
+}
+/* Row "Conferido + Editar" lado a lado */
+.fin-cowork .fin-toggles-row {
+  display: flex; align-items: center; gap: 10px; flex-wrap: wrap;
+}
+/* Botão "Editar campos" — colapsado */
+.fin-cowork .fin-edit-btn {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 12px 6px 8px; border-radius: 6px;
+  border: 1.5px solid oklch(0.85 0.10 60);
+  background: white;
+  font-family: inherit; font-size: 12.5px; font-weight: 600;
+  color: oklch(0.42 0.13 60);
+  cursor: pointer; transition: all .12s;
+}
+.fin-cowork .fin-edit-btn:hover { background: oklch(0.96 0.06 60); }
+.fin-cowork .fin-edit-btn.has-edits {
+  background: oklch(0.96 0.06 60);
+  border-color: oklch(0.62 0.13 60);
+}
+.fin-cowork .fin-edit-ic {
+  display: inline-grid; place-items: center;
+  width: 22px; height: 22px; border-radius: 4px;
+  background: oklch(0.62 0.13 60); color: white;
+  font-size: 13px; font-weight: 700;
+}
+.fin-cowork .fin-edit-tag {
+  margin-left: 2px;
+  width: 6px; height: 6px; border-radius: 50%;
+  background: oklch(0.55 0.18 25);
+  display: inline-block;
+}
+/* Painel de edição — expandido */
+.fin-cowork .fin-edit-panel {
+  background: oklch(0.97 0.025 60);
+  border: 1px solid oklch(0.85 0.10 60);
+  border-radius: 8px;
+  padding: 12px 14px;
+  margin: 8px 0 4px;
+}
+.fin-cowork .fin-edit-h {
+  display: flex; align-items: center; gap: 10px;
+  margin-bottom: 10px;
+}
+.fin-cowork .fin-edit-h h4 {
+  margin: 0; font-size: 13px; font-weight: 700;
+  color: oklch(0.42 0.13 60);
+}
+.fin-cowork .fin-edit-actions { margin-left: auto; display: flex; gap: 6px; }
+.fin-cowork .fin-edit-reset {
+  background: white; border: 1px solid var(--border);
+  padding: 4px 9px; border-radius: 5px;
+  font-family: inherit; font-size: 11px; font-weight: 500;
+  color: var(--text-mute); cursor: pointer;
+}
+.fin-cowork .fin-edit-reset:hover { background: var(--bg-2); color: oklch(0.55 0.18 25); }
+.fin-cowork .fin-edit-close {
+  background: oklch(0.55 0.13 145); border: none;
+  color: white;
+  padding: 4px 12px; border-radius: 5px;
+  font-family: inherit; font-size: 11.5px; font-weight: 600;
+  cursor: pointer;
+}
+.fin-cowork .fin-edit-close:hover { background: oklch(0.48 0.13 145); }
+.fin-cowork .fin-edit-grid {
+  display: grid; grid-template-columns: 1fr 1fr; gap: 10px;
+}
+.fin-cowork .fin-edit-grid label {
+  display: flex; flex-direction: column; gap: 4px;
+}
+.fin-cowork .fin-edit-grid label.fin-edit-wide { grid-column: 1 / -1; }
+.fin-cowork .fin-edit-grid label > span {
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--text-mute);
+}
+.fin-cowork .fin-edit-grid input, .fin-cowork .fin-edit-grid select {
+  background: white; border: 1px solid var(--border);
+  padding: 6px 9px; border-radius: 5px;
+  font-family: inherit; font-size: 12.5px;
+  color: var(--text);
+  outline: none;
+  transition: border-color .12s;
+}
+.fin-cowork .fin-edit-grid input[type="number"] { font-family: var(--font-mono); }
+.fin-cowork .fin-edit-grid input:focus, .fin-cowork .fin-edit-grid select:focus { border-color: oklch(0.62 0.13 60); box-shadow: 0 0 0 2px oklch(0.94 0.06 60); }
+.fin-cowork .fin-edit-grid label small {
+  font-size: 10.5px; line-height: 1.3;
+}
+.fin-cowork .fin-edit-grid label small.pos { color: oklch(0.42 0.13 145); font-weight: 600; }
+.fin-cowork .fin-edit-grid label small.neg { color: oklch(0.55 0.18 25); font-weight: 600; }
+.fin-cowork .fin-edit-grid label small.neu { color: var(--text-mute); font-style: italic; }
+/* ══════════════════════════════════════════
+   FSM STEPPER · genérico cross-módulo (2026-05-18)
+   3 variants: dots-inline · full-stepper · breadcrumb
+   ══════════════════════════════════════════ */
+.fin-cowork .fsm-stepper {
+  --fsm-color: oklch(0.55 0.13 var(--fsm-hue, 145));
+  --fsm-color-soft: oklch(0.94 0.05 var(--fsm-hue, 145));
+  --fsm-color-dim: oklch(0.42 0.13 var(--fsm-hue, 145));
+}
+/* ── Inline (5 bolinhas + label) ── */
+.fin-cowork .fsm-stepper.fsm-inline {
+  display: inline-flex; align-items: center; gap: 4px;
+}
+.fin-cowork .fsm-stepper.fsm-inline .fsm-dot {
+  width: 7px; height: 7px; border-radius: 50%;
+  background: var(--border);
+  transition: all .12s;
+  display: inline-block;
+}
+.fin-cowork .fsm-stepper.fsm-inline .fsm-dot.done { background: var(--fsm-color); }
+.fin-cowork .fsm-stepper.fsm-inline .fsm-dot.current {
+  background: var(--fsm-color);
+  box-shadow: 0 0 0 2px var(--fsm-color-soft);
+}
+.fin-cowork .fsm-stepper.fsm-inline .fsm-dot.term {
+  background: oklch(0.55 0.18 25);
+}
+.fin-cowork .fsm-stepper.fsm-inline .fsm-lbl {
+  margin-left: 4px;
+  font-family: var(--font-mono); font-size: 10px; font-weight: 600;
+  letter-spacing: 0.05em; text-transform: uppercase;
+  color: var(--fsm-color-dim);
+}
+/* ── Full stepper (drawer) ── */
+.fin-cowork .fsm-stepper.fsm-full {
+  list-style: none; margin: 0; padding: 0;
+  display: flex; align-items: flex-start; gap: 0;
+  background: var(--bg-2);
+  border-radius: 8px;
+  padding: 10px 14px;
+}
+.fin-cowork .fsm-stepper.fsm-full .fsm-step {
+  flex: 1;
+  display: flex; flex-direction: column;
+  align-items: center; gap: 4px;
+  position: relative;
+  font-size: 11px;
+}
+.fin-cowork .fsm-stepper.fsm-full .fsm-step-num {
+  display: grid; place-items: center;
+  width: 24px; height: 24px; border-radius: 50%;
+  background: var(--surface);
+  border: 1.5px solid var(--border);
+  color: var(--text-mute);
+  font-family: var(--font-mono); font-size: 11px; font-weight: 700;
+  z-index: 1; transition: all .12s;
+}
+.fin-cowork .fsm-stepper.fsm-full .fsm-step.done .fsm-step-num {
+  background: var(--fsm-color); color: white; border-color: var(--fsm-color);
+}
+.fin-cowork .fsm-stepper.fsm-full .fsm-step.current .fsm-step-num {
+  background: var(--surface); color: var(--fsm-color-dim);
+  border-color: var(--fsm-color);
+  box-shadow: 0 0 0 3px var(--fsm-color-soft);
+}
+.fin-cowork .fsm-stepper.fsm-full .fsm-step.term .fsm-step-num {
+  background: oklch(0.95 0.04 25); color: oklch(0.55 0.18 25);
+  border-color: oklch(0.55 0.18 25);
+}
+.fin-cowork .fsm-stepper.fsm-full .fsm-step-lbl {
+  font-size: 10.5px; font-weight: 600;
+  color: var(--text-mute);
+  text-align: center;
+  letter-spacing: 0.01em;
+}
+.fin-cowork .fsm-stepper.fsm-full .fsm-step.done .fsm-step-lbl, .fin-cowork .fsm-stepper.fsm-full .fsm-step.current .fsm-step-lbl {
+  color: var(--text);
+}
+.fin-cowork .fsm-stepper.fsm-full .fsm-step.current .fsm-step-lbl {
+  color: var(--fsm-color-dim);
+  font-weight: 700;
+}
+.fin-cowork .fsm-stepper.fsm-full .fsm-step-line {
+  position: absolute;
+  top: 11px; left: 50%; right: -50%;
+  height: 2px; background: var(--border);
+  z-index: 0;
+}
+.fin-cowork .fsm-stepper.fsm-full .fsm-step.done .fsm-step-line {
+  background: var(--fsm-color);
+}
+/* ── Breadcrumb ── */
+.fin-cowork .fsm-stepper.fsm-breadcrumb {
+  display: inline-flex; align-items: center; gap: 6px;
+  font-size: 11.5px;
+}
+.fin-cowork .fsm-stepper.fsm-breadcrumb .fsm-bc-past {
+  color: var(--text-mute);
+}
+.fin-cowork .fsm-stepper.fsm-breadcrumb .fsm-bc-current {
+  color: var(--fsm-color-dim);
+  font-weight: 600;
+}
+.fin-cowork .fsm-stepper.fsm-breadcrumb .fsm-bc-sep {
+  color: var(--text-mute); opacity: 0.5;
+}
+.fin-cowork .fsm-stepper.fsm-breadcrumb .fsm-bc-terminal {
+  color: oklch(0.55 0.18 25); font-weight: 600;
+}
+/* Wrapper no Financeiro Drawer */
+.fin-cowork .fin-fsm-wrap {
+  background: white;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 0;
+  overflow: hidden;
+}
+.fin-cowork .fin-fsm-wrap .fsm-stepper.fsm-full {
+  background: white;
+}
+/* ══════════════════════════════════════════
+   FINANCEIRO · Drawer wide refluido (2026-05-18)
+   ══════════════════════════════════════════ */
+/* Drawer mais largo (440→560px) + grid 2col em mais lugares */
+.fin-cowork .fin-drawer-wide { width: 560px !important; }
+.fin-cowork .fin-drawer-wide .grid-cols-2 { gap: 14px 24px; }
+.fin-cowork .fin-drawer-wide .fin-toggles-row {
+  flex-wrap: wrap; gap: 8px;
+}
+.fin-cowork .fin-drawer-wide .fin-edit-grid {
+  grid-template-columns: 1fr 1fr 1fr 1fr;
+}
+.fin-cowork .fin-drawer-wide .fin-edit-wide { grid-column: 1 / -1; }
+.fin-cowork .fin-drawer-wide .fsm-stepper.fsm-full { padding: 12px 20px; }
+.fin-cowork .fin-drawer-wide .fsm-stepper.fsm-full .fsm-step-lbl { font-size: 11px; }
+/* Footer reorganizado — botões iguais lado a lado */
+.fin-cowork .fin-drawer-footer {
+  gap: 6px !important;
+  padding: 0 14px !important;
+}
+.fin-cowork .fin-foot-icon-btn {
+  display: inline-flex; align-items: center; gap: 5px;
+  height: 32px; padding: 0 10px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: white;
+  font-family: inherit; font-size: 11.5px; font-weight: 500;
+  color: var(--text-dim); cursor: pointer;
+  transition: all .12s;
+  white-space: nowrap;
+}
+.fin-cowork .fin-foot-icon-btn:hover { background: var(--bg-2); color: var(--text); border-color: var(--text-mute); }
+.fin-cowork .fin-foot-mark-btn {
+  margin-left: auto;
+  display: inline-flex; align-items: center; gap: 6px;
+  height: 32px; padding: 0 14px;
+  border: none;
+  border-radius: 6px;
+  background: oklch(0.55 0.13 145); color: white;
+  font-family: inherit; font-size: 12px; font-weight: 600;
+  cursor: pointer; transition: background .12s;
+  white-space: nowrap;
+}
+.fin-cowork .fin-foot-mark-btn:hover { background: oklch(0.48 0.13 145); }
+/* Trouble button mais compacto quando footer apertado */
+.fin-cowork .fin-drawer-footer .fin-trouble-btn {
+  margin-right: 0;
+  padding: 4px 9px 4px 4px;
+  font-size: 11.5px;
+}
+.fin-cowork .fin-drawer-footer .fin-trouble-lbl {
+  max-width: 180px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  font-size: 11px;
+}
+.fin-cowork .fin-drawer-footer .fin-trouble-lbl b {
+  display: inline; max-width: 100%;
+}
+.fin-cowork .fin-drawer-footer .fin-trouble-ic { width: 20px; height: 20px; font-size: 12px; }
+.fin-cowork .fin-drawer-footer .fin-trouble-ct { display: none; }
+/* Histórico audit row — menos vertical, mais largo */
+.fin-cowork .fin-drawer-wide .fin-audit-row {
+  grid-template-columns: 24px 1fr;
+  gap: 12px; padding: 7px 0;
+}
+.fin-cowork .fin-drawer-wide .fin-audit-body header {
+  flex-wrap: wrap; gap: 4px 8px;
+}
+.fin-cowork .fin-drawer-wide .fin-audit-body header time {
+  font-size: 10px;
+}
+/* Conferir + Editar lado a lado em vez de empilhados */
+.fin-cowork .fin-drawer-wide .fin-conferido-toggle, .fin-cowork .fin-drawer-wide .fin-edit-btn {
+  flex: 1; max-width: 220px;
+  justify-content: flex-start;
+}
+/* ══════════════════════════════════════════
+   FINANCEIRO · Drawer com abas (2026-05-18)
+   ══════════════════════════════════════════ */
+.fin-cowork .fin-drawer-tabs {
+  display: flex; align-items: center;
+  padding: 0 18px; gap: 0;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg-2);
+}
+.fin-cowork .fin-drawer-tab {
+  background: transparent; border: none;
+  padding: 12px 14px; font-family: inherit;
+  font-size: 12.5px; font-weight: 500;
+  color: var(--text-mute); cursor: pointer;
+  border-bottom: 2px solid transparent;
+  transition: all .12s;
+  display: inline-flex; align-items: center; gap: 6px;
+  position: relative;
+}
+.fin-cowork .fin-drawer-tab:hover { color: var(--text); }
+.fin-cowork .fin-drawer-tab.on {
+  color: var(--text);
+  border-bottom-color: oklch(0.55 0.13 145);
+  background: var(--surface);
+}
+.fin-cowork .fin-drawer-tab-ct {
+  font-family: var(--font-mono); font-size: 10px; font-weight: 600;
+  background: var(--surface); color: var(--text-mute);
+  padding: 1px 6px; border-radius: 99px;
+}
+.fin-cowork .fin-drawer-tab.on .fin-drawer-tab-ct {
+  background: oklch(0.94 0.05 145); color: oklch(0.32 0.13 145);
+}
+.fin-cowork .fin-drawer-tab-tag {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: oklch(0.55 0.18 25);
+  display: inline-block;
+}
+.fin-cowork .fin-drawer-tab-ai { color: oklch(0.42 0.13 295); }
+.fin-cowork .fin-drawer-tab-ai:hover { color: oklch(0.32 0.18 295); }
+.fin-cowork .fin-drawer-tab-ai.on {
+  border-bottom-color: oklch(0.55 0.13 295);
+  color: oklch(0.32 0.18 295);
+  background: oklch(0.98 0.015 295);
+}
+.fin-cowork .fin-drawer-tab-edit { color: oklch(0.42 0.13 60); }
+.fin-cowork .fin-drawer-tab-edit:hover { color: oklch(0.32 0.18 60); }
+.fin-cowork .fin-drawer-tab-edit.on {
+  border-bottom-color: oklch(0.55 0.13 60);
+  color: oklch(0.42 0.13 60);
+  background: oklch(0.98 0.02 60);
+}
+.fin-cowork .fin-drawer-tab-edit.has-edits:not(.on) {
+  background: oklch(0.96 0.04 60);
+}
+/* Tab Editar — quando inline expandido, painel full-width fica bonito */
+.fin-cowork .fin-drawer-wide .fin-toggles-row {
+  flex-wrap: wrap; gap: 8px;
+}
+.fin-cowork .fin-drawer-wide .fin-toggles-row > * {
+  flex: 0 0 auto;
+}
+.fin-cowork .fin-drawer-wide .fin-edit-panel {
+  flex: 1 1 100%;
+  background: linear-gradient(135deg, oklch(0.98 0.025 60), oklch(0.99 0.012 60));
+  border: 1px solid oklch(0.85 0.10 60);
+  border-radius: 10px;
+  padding: 14px 16px;
+  margin-top: 4px;
+  animation: finEditOpen 0.18s ease-out;
+}
+@keyframes finEditOpen {
+  from { opacity: 0; transform: translateY(-4px); }
+  to { opacity: 1; transform: none; }
+}
+.fin-cowork .fin-drawer-wide .fin-edit-h h4 { font-size: 13.5px; color: oklch(0.32 0.18 60); }
+.fin-cowork .fin-drawer-wide .fin-edit-grid {
+  grid-template-columns: 1fr 1fr 1fr;
+  gap: 12px;
+}
+.fin-cowork .fin-drawer-wide .fin-edit-grid .fin-edit-wide { grid-column: 1 / -1; }
+.fin-cowork .fin-drawer-wide .fin-edit-close {
+  background: oklch(0.55 0.13 145); color: white;
+  font-weight: 600;
+}
+.fin-cowork .fin-drawer-wide .fin-edit-close:hover { background: oklch(0.48 0.13 145); }
+/* Conferido toggle (botão grande no body do drawer) */
+.fin-cowork .fin-conferido-toggle {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 6px 12px 6px 6px; border-radius: 6px;
+  border: 1.5px solid oklch(0.78 0.10 145); background: oklch(0.97 0.04 145);
+  font-family: inherit; font-size: 12.5px; font-weight: 600;
+  color: oklch(0.32 0.13 145);
+  cursor: pointer; transition: all .12s;
+}
+.fin-cowork .fin-conferido-toggle:hover { background: oklch(0.94 0.06 145); }
+.fin-cowork .fin-conferido-toggle.on {
+  background: oklch(0.55 0.13 145); color: white;
+  border-color: oklch(0.55 0.13 145);
+}
+.fin-cowork .fin-conferido-toggle .fin-conf-check {
+  display: inline-grid; place-items: center;
+  width: 22px; height: 22px; border-radius: 4px;
+  background: white; color: oklch(0.55 0.13 145);
+  border: 1.5px solid oklch(0.78 0.10 145);
+  font-size: 13px; font-weight: 700;
+}
+.fin-cowork .fin-conferido-toggle.on .fin-conf-check {
+  background: white; color: oklch(0.55 0.13 145);
+  border-color: white;
+}
+.fin-cowork .fin-conferido-toggle .fin-conf-lbl { font-weight: 600; }
+.fin-cowork .fin-conferido-toggle small {
+  font-size: 10.5px; font-weight: 400; opacity: 0.7;
+  margin-left: -3px;
+}
+.fin-cowork .fin-conferido-toggle.on small { display: none; }
+/* Pill de frescor (vence em Xd / atrasado / pago) */
+.fin-cowork .fin-frescor {
+  display: inline-flex; align-items: center; gap: 4px;
+  padding: 2px 7px; border-radius: 4px;
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 600;
+  letter-spacing: 0.01em; white-space: nowrap;
+}
+.fin-cowork .fin-frescor-ic { font-size: 9px; line-height: 1; }
+.fin-cowork .fin-frescor-fresh { background: oklch(0.94 0.04 145); color: oklch(0.42 0.13 145); }
+.fin-cowork .fin-frescor-soon { background: oklch(0.95 0.03 145); color: oklch(0.45 0.10 145); }
+.fin-cowork .fin-frescor-warning { background: oklch(0.96 0.06 70); color: oklch(0.42 0.13 60); }
+.fin-cowork .fin-frescor-today { background: oklch(0.96 0.07 60); color: oklch(0.42 0.18 60); }
+.fin-cowork .fin-frescor-overdue { background: oklch(0.95 0.04 25); color: oklch(0.50 0.18 25); }
+.fin-cowork .fin-frescor-paid { background: oklch(0.94 0.005 240); color: var(--text-mute); }
+/* Audit trail */
+.fin-cowork .fin-audit { font-size: 12px; }
+.fin-cowork .fin-audit-h {
+  display: flex; align-items: baseline; gap: 10px;
+  margin-bottom: 12px;
+}
+.fin-cowork .fin-audit-h h4 { margin: 0; font-size: 13px; font-weight: 700; }
+.fin-cowork .fin-audit-h small { font-size: 11px; color: var(--text-mute); }
+.fin-cowork .fin-audit-list {
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column;
+}
+.fin-cowork .fin-audit-row {
+  display: grid; grid-template-columns: 26px 1fr;
+  gap: 10px; padding: 8px 0;
+  border-bottom: 1px solid oklch(0.93 0.005 90);
+  position: relative;
+}
+.fin-cowork .fin-audit-row:last-child { border-bottom: none; }
+.fin-cowork .fin-audit-row::before {
+  content: ""; position: absolute;
+  left: 12px; top: 28px; bottom: -2px;
+  width: 2px; background: oklch(0.93 0.005 90);
+}
+.fin-cowork .fin-audit-row:last-child::before { display: none; }
+.fin-cowork .fin-audit-ic {
+  display: grid; place-items: center;
+  width: 24px; height: 24px; border-radius: 50%;
+  background: var(--bg-2); color: var(--text-mute);
+  font-size: 11px; font-weight: 700;
+  position: relative; z-index: 1;
+}
+.fin-cowork .fin-audit-create .fin-audit-ic { background: oklch(0.94 0.06 145); color: oklch(0.32 0.13 145); }
+.fin-cowork .fin-audit-categorize .fin-audit-ic { background: oklch(0.95 0.04 240); color: oklch(0.36 0.13 240); }
+.fin-cowork .fin-audit-edit .fin-audit-ic { background: oklch(0.96 0.05 70); color: oklch(0.42 0.13 60); }
+.fin-cowork .fin-audit-concil .fin-audit-ic { background: oklch(0.94 0.04 145); color: oklch(0.32 0.13 145); }
+.fin-cowork .fin-audit-alert .fin-audit-ic { background: oklch(0.96 0.05 25); color: oklch(0.55 0.18 25); }
+.fin-cowork .fin-audit-body header {
+  display: flex; align-items: baseline; gap: 8px;
+  margin-bottom: 2px;
+}
+.fin-cowork .fin-audit-body header b { font-size: 12px; font-weight: 600; }
+.fin-cowork .fin-audit-action {
+  font-size: 11px; color: var(--text-mute);
+}
+.fin-cowork .fin-audit-body header time {
+  margin-left: auto;
+  font-family: var(--font-mono); font-size: 10.5px;
+  color: var(--text-mute);
+}
+.fin-cowork .fin-audit-body p {
+  margin: 0; font-size: 12px; color: var(--text-dim); line-height: 1.45;
+}
+.fin-cowork .fin-audit-diff {
+  margin-top: 4px;
+  display: inline-flex; align-items: center; gap: 6px;
+  font-family: var(--font-mono); font-size: 11px;
+  background: var(--bg-2); padding: 2px 7px; border-radius: 4px;
+}
+.fin-cowork .fin-audit-diff .diff-from { color: var(--text-mute); text-decoration: line-through; }
+.fin-cowork .fin-audit-diff .diff-arr { color: var(--text-mute); }
+.fin-cowork .fin-audit-diff .diff-to { color: var(--text); font-weight: 600; }
+.fin-cowork .fin-audit-diff .diff-pct.pos { color: oklch(0.50 0.13 145); }
+.fin-cowork .fin-audit-diff .diff-pct.neg { color: oklch(0.55 0.18 25); }
+/* Comments thread */
+.fin-cowork .fin-comments-h {
+  display: flex; align-items: baseline; gap: 10px;
+  margin-bottom: 10px;
+}
+.fin-cowork .fin-comments-h h4 { margin: 0; font-size: 13px; font-weight: 700; }
+.fin-cowork .fin-comments-h small { font-size: 11px; color: var(--text-mute); }
+.fin-cowork .fin-comments-list {
+  list-style: none; margin: 0 0 12px; padding: 0;
+  display: flex; flex-direction: column; gap: 8px;
+}
+.fin-cowork .fin-comment {
+  display: grid; grid-template-columns: 28px 1fr;
+  gap: 8px;
+  background: oklch(0.985 0.012 240);
+  padding: 8px 10px; border-radius: 6px;
+  border: 1px solid oklch(0.93 0.02 240);
+}
+.fin-cowork .fin-comment-av {
+  display: grid; place-items: center;
+  width: 22px; height: 22px; border-radius: 50%;
+  background: oklch(0.55 0.13 240); color: white;
+  font-size: 11px; font-weight: 700;
+  align-self: start; margin-top: 2px;
+}
+.fin-cowork .fin-comment-body header {
+  display: flex; align-items: baseline; gap: 6px;
+  margin-bottom: 3px;
+}
+.fin-cowork .fin-comment-body header b { font-size: 12px; font-weight: 600; }
+.fin-cowork .fin-comment-body header time {
+  font-family: var(--font-mono); font-size: 10.5px; color: var(--text-mute);
+}
+.fin-cowork .fin-comment-x {
+  margin-left: auto;
+  background: transparent; border: none;
+  color: var(--text-mute); font-size: 14px;
+  cursor: pointer; padding: 0 4px;
+  line-height: 1;
+}
+.fin-cowork .fin-comment-x:hover { color: oklch(0.55 0.18 25); }
+.fin-cowork .fin-comment-body p {
+  margin: 0; font-size: 12px; line-height: 1.5; color: var(--text);
+}
+.fin-cowork .fin-comment-new {
+  display: flex; flex-direction: column; gap: 6px;
+  border: 1px solid oklch(0.82 0.10 240);
+  border-radius: 6px; padding: 8px;
+  background: white;
+}
+.fin-cowork .fin-comment-new textarea {
+  width: 100%; border: none; outline: none; resize: vertical;
+  font-family: inherit; font-size: 12px; line-height: 1.5;
+  background: transparent;
+  min-height: 44px;
+}
+.fin-cowork .fin-comment-new button {
+  align-self: flex-end;
+  background: oklch(0.55 0.13 145); color: white;
+  border: none; padding: 5px 12px; border-radius: 5px;
+  font-family: inherit; font-size: 11.5px; font-weight: 600;
+  cursor: pointer;
+}
+.fin-cowork .fin-comment-new button:hover { background: oklch(0.48 0.13 145); }
+.fin-cowork .fin-comment-new button:disabled { background: var(--text-mute); cursor: not-allowed; }
+/* ══════════════════════════════════════════
+   FINANCEIRO · REFINO #2 KB-9.75 · IA (2026-05-18)
+   ══════════════════════════════════════════ */
+/* Botão ✦ Resumir mês */
+.fin-cowork .fin-root .fin-btn-ai {
+  color: oklch(0.42 0.13 295);
+}
+.fin-cowork .fin-root .fin-btn-ai:hover {
+  background: oklch(0.96 0.04 295);
+  color: oklch(0.32 0.18 295);
+}
+/* Anomalia banner (no topo do drawer) */
+.fin-cowork .fin-ai-anomalia {
+  display: flex; align-items: center; gap: 10px;
+  padding: 10px 14px; margin: 0 0 4px;
+  border-radius: 8px;
+  border-left: 4px solid;
+}
+.fin-cowork .fin-ai-anomalia-high {
+  background: oklch(0.96 0.06 25);
+  border-color: oklch(0.55 0.18 25);
+  color: oklch(0.45 0.18 25);
+}
+.fin-cowork .fin-ai-anomalia-low {
+  background: oklch(0.96 0.05 240);
+  border-color: oklch(0.55 0.13 240);
+  color: oklch(0.36 0.13 240);
+}
+.fin-cowork .fin-ai-anomalia-ic {
+  display: grid; place-items: center;
+  width: 28px; height: 28px; border-radius: 50%;
+  background: white; font-size: 14px; font-weight: 700;
+  flex-shrink: 0;
+}
+.fin-cowork .fin-ai-anomalia-body { flex: 1; }
+.fin-cowork .fin-ai-anomalia-body b { display: block; font-size: 12.5px; font-weight: 600; }
+.fin-cowork .fin-ai-anomalia-body small { display: block; font-size: 11px; opacity: 0.85; }
+.fin-cowork .fin-ai-anomalia-body i { font-style: normal; font-weight: 500; }
+.fin-cowork .fin-ai-anomalia-cta {
+  background: white; color: inherit;
+  border: 1px solid currentColor;
+  padding: 4px 10px; border-radius: 5px;
+  font-family: inherit; font-size: 11.5px; font-weight: 600;
+  cursor: pointer;
+}
+/* Painel IA dentro do drawer */
+.fin-cowork .fin-ai-panel h3 {
+  margin: 12px 0 8px;
+  font-size: 11px; font-weight: 700;
+  letter-spacing: 0.07em; text-transform: uppercase;
+  color: oklch(0.42 0.13 295); opacity: 0.85;
+}
+.fin-cowork .fin-ai-party .vd-ai-stats { margin-bottom: 12px; }
+/* ─── MONTH DIGEST OVERLAY ─── */
+.fin-cowork .fin-digest-overlay {
+  position: fixed; inset: 0; z-index: 1100;
+  background: oklch(0.20 0.005 240 / 0.55);
+  display: grid; place-items: center;
+  padding: 20px;
+  animation: finDigestFade 0.18s ease-out;
+}
+@keyframes finDigestFade { from { opacity: 0; } to { opacity: 1; } }
+.fin-cowork .fin-digest {
+  background: var(--surface);
+  border-radius: 14px;
+  width: 100%; max-width: 760px;
+  max-height: 88vh; overflow: auto;
+  box-shadow: 0 24px 80px rgba(0,0,0,0.18);
+  display: flex; flex-direction: column;
+  animation: finDigestUp 0.22s ease-out;
+}
+@keyframes finDigestUp { from { transform: translateY(16px); opacity: 0; } to { transform: none; opacity: 1; } }
+.fin-cowork .fin-digest-h {
+  padding: 22px 26px 16px;
+  border-bottom: 1px solid var(--border);
+  position: relative;
+}
+.fin-cowork .fin-digest-eyebrow {
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  color: oklch(0.42 0.13 295);
+}
+.fin-cowork .fin-digest-h h2 {
+  margin: 4px 0 0; font-size: 22px; font-weight: 700;
+  letter-spacing: -0.018em;
+}
+.fin-cowork .fin-digest-x {
+  position: absolute; top: 18px; right: 22px;
+  background: transparent; border: 1px solid var(--border);
+  width: 32px; height: 32px; border-radius: 6px;
+  font-size: 18px; cursor: pointer; line-height: 1;
+  color: var(--text-mute);
+}
+.fin-cowork .fin-digest-x:hover { background: var(--bg-2); color: var(--text); }
+.fin-cowork .fin-digest-body {
+  padding: 18px 26px 24px;
+  display: flex; flex-direction: column; gap: 18px;
+}
+/* Snapshot cards */
+.fin-cowork .fin-digest-snapshot {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 10px;
+}
+.fin-cowork .fin-digest-card {
+  background: var(--bg-2);
+  border-radius: 8px;
+  padding: 10px 14px;
+}
+.fin-cowork .fin-digest-card.primary {
+  grid-column: 1 / 3;
+  background: linear-gradient(135deg, oklch(0.97 0.025 145), oklch(0.985 0.012 145));
+  border: 1px solid oklch(0.86 0.06 145);
+}
+.fin-cowork .fin-digest-card.warn {
+  background: oklch(0.96 0.06 25);
+  border: 1px solid oklch(0.82 0.10 25);
+}
+.fin-cowork .fin-digest-card small {
+  display: block;
+  font-size: 9.5px; font-weight: 700;
+  letter-spacing: 0.06em; text-transform: uppercase;
+  color: var(--text-mute); margin-bottom: 3px;
+}
+.fin-cowork .fin-digest-card b {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 22px; font-weight: 700;
+  letter-spacing: -0.015em; line-height: 1.1;
+}
+.fin-cowork .fin-digest-card.primary b { font-size: 26px; }
+.fin-cowork .fin-digest-card b.pos { color: oklch(0.42 0.13 145); }
+.fin-cowork .fin-digest-card b.neg { color: oklch(0.55 0.18 25); }
+.fin-cowork .fin-digest-card span {
+  display: block; font-size: 10.5px;
+  color: var(--text-dim); margin-top: 3px;
+}
+.fin-cowork .fin-digest-section {
+  display: flex; flex-direction: column; gap: 10px;
+}
+.fin-cowork .fin-digest-section h3 {
+  margin: 0; font-size: 11px; font-weight: 700;
+  letter-spacing: 0.07em; text-transform: uppercase;
+  color: var(--text-mute);
+  display: flex; align-items: center; gap: 8px;
+}
+.fin-cowork .fin-digest-tag {
+  background: oklch(0.94 0.06 295); color: oklch(0.36 0.13 295);
+  font-family: var(--font-mono); font-size: 10px; font-weight: 700;
+  padding: 1px 7px; border-radius: 99px;
+  letter-spacing: normal; text-transform: none;
+}
+/* Top categories */
+.fin-cowork .fin-digest-cats {
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.fin-cowork .fin-digest-cats li {
+  display: grid; grid-template-columns: 130px 1fr 130px;
+  align-items: center; gap: 12px;
+  font-size: 12px;
+}
+.fin-cowork .fin-digest-cat-l { color: var(--text); font-weight: 500; }
+.fin-cowork .fin-digest-cat-r {
+  text-align: right; font-family: var(--font-mono); font-weight: 600;
+}
+.fin-cowork .fin-digest-cat-r small { color: var(--text-mute); font-weight: 500; margin-left: 4px; }
+.fin-cowork .fin-digest-cat-bar {
+  height: 6px; background: var(--bg-2); border-radius: 99px; overflow: hidden;
+}
+.fin-cowork .fin-digest-cat-bar > div {
+  height: 100%; background: oklch(0.55 0.13 145); border-radius: 99px;
+}
+/* Anomalias */
+.fin-cowork .fin-digest-anomalias {
+  list-style: none; margin: 0; padding: 0;
+  display: flex; flex-direction: column; gap: 6px;
+}
+.fin-cowork .fin-digest-anomalias li {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 6px;
+  background: var(--bg-2);
+}
+.fin-cowork .fin-digest-anomalia-tag {
+  display: inline-flex; align-items: center; gap: 2px;
+  padding: 3px 8px; border-radius: 4px;
+  font-family: var(--font-mono); font-size: 10.5px; font-weight: 700;
+  flex-shrink: 0;
+}
+.fin-cowork .fin-digest-anomalia-tag.high { background: oklch(0.96 0.06 25); color: oklch(0.55 0.18 25); }
+.fin-cowork .fin-digest-anomalia-tag.low { background: oklch(0.96 0.05 240); color: oklch(0.36 0.13 240); }
+.fin-cowork .fin-digest-anomalias b { display: block; font-size: 12px; font-weight: 600; }
+.fin-cowork .fin-digest-anomalias small { display: block; font-size: 10.5px; color: var(--text-mute); }
+/* ══════════════════════════════════════════
+   FINANCEIRO · REFINO #3 KB-9.75 · GUIA + SAÍDA (2026-05-18)
+   ══════════════════════════════════════════ */
+/* Header buttons */
+.fin-cowork .fin-root .fin-btn-trilha { color: oklch(0.42 0.13 145); }
+.fin-cowork .fin-root .fin-btn-trilha:hover { background: oklch(0.96 0.05 145); color: oklch(0.32 0.13 145); }
+.fin-cowork .fin-root .fin-btn-present { color: oklch(0.42 0.13 240); }
+.fin-cowork .fin-root .fin-btn-present:hover { background: oklch(0.96 0.04 240); color: oklch(0.32 0.13 240); }
+/* Trouble button no footer do Drawer */
+.fin-cowork .fin-trouble-btn {
+  display: inline-flex; align-items: center; gap: 8px;
+  background: oklch(0.96 0.06 60); color: oklch(0.42 0.13 60);
+  border: 1px solid oklch(0.85 0.10 60);
+  padding: 5px 10px 5px 5px; border-radius: 6px;
+  font-family: inherit; font-size: 11.5px; font-weight: 600;
+  cursor: pointer; margin-right: auto;
+  transition: all .12s;
+}
+.fin-cowork .fin-trouble-btn:hover { background: oklch(0.93 0.08 60); border-color: oklch(0.72 0.13 60); }
+.fin-cowork .fin-trouble-ic {
+  display: grid; place-items: center;
+  width: 22px; height: 22px; border-radius: 4px;
+  background: oklch(0.62 0.13 60); color: white;
+  font-size: 14px; font-weight: 700;
+}
+.fin-cowork .fin-trouble-lbl { font-size: 12px; }
+.fin-cowork .fin-trouble-lbl b { font-weight: 700; }
+.fin-cowork .fin-trouble-ct {
+  font-family: var(--font-mono); font-size: 9.5px;
+  background: white; color: var(--text-mute);
+  padding: 1px 6px; border-radius: 99px;
+}
+/* ─── Trilha de fechamento (overlay) ─── */
+.fin-cowork .fin-trilha-overlay {
+  position: fixed; inset: 0; z-index: 1100;
+  background: oklch(0.20 0.005 240 / 0.55);
+  display: grid; place-items: center;
+  padding: 20px;
+}
+.fin-cowork .fin-trilha {
+  background: var(--surface);
+  border-radius: 14px;
+  width: 100%; max-width: 760px;
+  max-height: 88vh; overflow: auto;
+  box-shadow: 0 24px 80px rgba(0,0,0,0.18);
+  display: flex; flex-direction: column;
+}
+.fin-cowork .fin-trilha-h {
+  display: grid; grid-template-columns: 1fr auto auto;
+  align-items: center; gap: 18px;
+  padding: 22px 26px 18px;
+  border-bottom: 1px solid var(--border);
+}
+.fin-cowork .fin-trilha-h > div:first-child { min-width: 0; }
+.fin-cowork .fin-trilha-eyebrow {
+  font-size: 10px; font-weight: 700;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  color: oklch(0.42 0.13 145);
+}
+.fin-cowork .fin-trilha-h h2 {
+  margin: 4px 0 2px; font-size: 20px; font-weight: 700;
+  letter-spacing: -0.018em;
+}
+.fin-cowork .fin-trilha-h p { margin: 0; font-size: 11.5px; color: var(--text-mute); }
+.fin-cowork .fin-trilha-progress {
+  text-align: center;
+  background: var(--bg-2);
+  border-radius: 10px;
+  padding: 8px 16px;
+}
+.fin-cowork .fin-trilha-pct {
+  font-family: var(--font-mono); font-size: 22px; font-weight: 700;
+  color: oklch(0.42 0.13 145); letter-spacing: -0.015em;
+}
+.fin-cowork .fin-trilha-progress small {
+  display: block; font-size: 10px; color: var(--text-mute);
+}
+.fin-cowork .fin-trilha-x {
+  background: transparent; border: 1px solid var(--border);
+  width: 32px; height: 32px; border-radius: 6px;
+  font-size: 18px; cursor: pointer; line-height: 1;
+  color: var(--text-mute);
+}
+.fin-cowork .fin-trilha-x:hover { background: var(--bg-2); color: var(--text); }
+.fin-cowork .fin-trilha-bar {
+  height: 4px; background: var(--bg-2);
+  margin: 0;
+}
+.fin-cowork .fin-trilha-bar > div {
+  height: 100%; background: oklch(0.55 0.13 145);
+  transition: width .2s;
+}
+.fin-cowork .fin-trilha-list {
+  list-style: none; margin: 0; padding: 12px;
+  display: flex; flex-direction: column; gap: 4px;
+}
+.fin-cowork .fin-trilha-step {
+  display: grid;
+  grid-template-columns: 36px 1fr auto;
+  align-items: center; gap: 14px;
+  padding: 10px 14px;
+  border-radius: 8px;
+  transition: background .12s;
+}
+.fin-cowork .fin-trilha-step:hover { background: var(--bg-2); }
+.fin-cowork .fin-trilha-step.done { opacity: 0.55; }
+.fin-cowork .fin-trilha-check {
+  width: 30px; height: 30px;
+  border-radius: 50%;
+  border: 1.5px solid var(--border);
+  background: white;
+  font-family: var(--font-mono); font-size: 13px; font-weight: 700;
+  color: var(--text-mute);
+  cursor: pointer; transition: all .12s;
+  display: inline-grid; place-items: center;
+}
+.fin-cowork .fin-trilha-check:hover { border-color: oklch(0.55 0.13 145); color: oklch(0.42 0.13 145); }
+.fin-cowork .fin-trilha-step.done .fin-trilha-check {
+  background: oklch(0.55 0.13 145); color: white;
+  border-color: oklch(0.55 0.13 145);
+}
+.fin-cowork .fin-trilha-body b { display: block; font-size: 13px; font-weight: 600; }
+.fin-cowork .fin-trilha-body small { display: block; font-size: 11.5px; color: var(--text-dim); margin-top: 2px; }
+.fin-cowork .fin-trilha-step.done .fin-trilha-body b { text-decoration: line-through; }
+.fin-cowork .fin-trilha-cta {
+  background: transparent;
+  border: 1px solid var(--border);
+  padding: 4px 10px; border-radius: 5px;
+  font-family: inherit; font-size: 11px; font-weight: 500;
+  color: oklch(0.42 0.13 145); cursor: pointer;
+  transition: all .12s;
+  white-space: nowrap;
+}
+.fin-cowork .fin-trilha-cta:hover { background: oklch(0.96 0.05 145); border-color: oklch(0.55 0.13 145); }
+.fin-cowork .fin-trilha-ft {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 12px 22px;
+  border-top: 1px solid var(--border);
+  font-size: 11px; color: var(--text-mute);
+}
+.fin-cowork .fin-trilha-reset {
+  background: transparent; border: none;
+  color: var(--text-mute); font-family: inherit; font-size: 11px;
+  cursor: pointer; text-decoration: underline; text-underline-offset: 3px;
+}
+.fin-cowork .fin-trilha-reset:hover { color: oklch(0.55 0.18 25); }
+/* ─── Modo apresentação fullscreen ─── */
+.fin-cowork .fin-pres-overlay {
+  position: fixed; inset: 0; z-index: 1200;
+  background: linear-gradient(135deg, oklch(0.16 0.005 240), oklch(0.18 0.01 145));
+  color: white;
+  display: flex; flex-direction: column;
+}
+.fin-cowork .fin-pres-top {
+  display: flex; align-items: center; gap: 14px;
+  padding: 16px 28px;
+  border-bottom: 1px solid oklch(1 0 0 / 0.08);
+}
+.fin-cowork .fin-pres-brand {
+  flex: 1; font-size: 11px; font-weight: 700;
+  letter-spacing: 0.15em; text-transform: uppercase;
+  color: oklch(1 0 0 / 0.5);
+}
+.fin-cowork .fin-pres-counter {
+  font-family: var(--font-mono); font-size: 11.5px;
+  color: oklch(1 0 0 / 0.5);
+}
+.fin-cowork .fin-pres-close {
+  background: transparent; border: 1px solid oklch(1 0 0 / 0.2);
+  color: white; width: 32px; height: 32px;
+  border-radius: 6px; cursor: pointer;
+  font-size: 18px; line-height: 1;
+}
+.fin-cowork .fin-pres-close:hover { background: oklch(1 0 0 / 0.08); }
+.fin-cowork .fin-pres-stage {
+  flex: 1;
+  display: grid; place-items: center;
+  padding: 40px 80px;
+}
+.fin-cowork .fin-pres-slide { max-width: 900px; width: 100%; text-align: center; }
+.fin-cowork .fin-pres-eyebrow {
+  display: block; font-size: 13px; font-weight: 600;
+  letter-spacing: 0.10em; text-transform: uppercase;
+  color: oklch(0.78 0.10 145); margin-bottom: 16px;
+}
+.fin-cowork .fin-pres-slide h1 {
+  font-size: 56px; font-weight: 700;
+  letter-spacing: -0.025em; line-height: 1.05;
+  margin: 0 0 24px;
+}
+.fin-cowork .fin-pres-amount {
+  font-family: var(--font-mono); font-size: 96px; font-weight: 700;
+  letter-spacing: -0.03em; line-height: 1;
+  margin: 12px 0 36px;
+}
+.fin-cowork .fin-pres-amount-mid {
+  font-family: var(--font-mono); font-size: 60px; font-weight: 700;
+  letter-spacing: -0.02em; line-height: 1;
+  margin: 12px 0 28px;
+}
+.fin-cowork .fin-pres-amount.pos, .fin-cowork .fin-pres-amount-mid.pos { color: oklch(0.78 0.13 145); }
+.fin-cowork .fin-pres-amount.neg, .fin-cowork .fin-pres-amount-mid.neg { color: oklch(0.72 0.17 25); }
+.fin-cowork .fin-pres-row {
+  display: grid; grid-template-columns: repeat(4, 1fr); gap: 14px;
+  max-width: 800px; margin: 0 auto;
+}
+.fin-cowork .fin-pres-row > div {
+  background: oklch(1 0 0 / 0.05);
+  border: 1px solid oklch(1 0 0 / 0.08);
+  border-radius: 12px; padding: 16px 20px;
+}
+.fin-cowork .fin-pres-row span {
+  display: block; font-size: 11px;
+  letter-spacing: 0.08em; text-transform: uppercase;
+  color: oklch(1 0 0 / 0.5); margin-bottom: 4px;
+}
+.fin-cowork .fin-pres-row b {
+  display: block; font-family: var(--font-mono);
+  font-size: 20px; font-weight: 700;
+}
+.fin-cowork .fin-pres-row b.pos { color: oklch(0.85 0.10 145); }
+.fin-cowork .fin-pres-row b.neg { color: oklch(0.80 0.13 25); }
+.fin-cowork .fin-pres-cats { list-style: none; margin: 24px 0 0; padding: 0; text-align: left; }
+.fin-cowork .fin-pres-cats li {
+  display: flex; justify-content: space-between; align-items: center;
+  padding: 16px 24px;
+  background: oklch(1 0 0 / 0.05);
+  border: 1px solid oklch(1 0 0 / 0.08);
+  border-radius: 10px;
+  margin-bottom: 10px;
+}
+.fin-cowork .fin-pres-cat-l { font-size: 22px; font-weight: 500; }
+.fin-cowork .fin-pres-cat-r { font-family: var(--font-mono); font-size: 24px; font-weight: 700; }
+.fin-cowork .fin-pres-cat-r small { font-size: 14px; color: oklch(1 0 0 / 0.5); margin-left: 6px; font-weight: 500; }
+.fin-cowork .fin-pres-late { list-style: none; margin: 24px 0 0; padding: 0; text-align: left; }
+.fin-cowork .fin-pres-late li {
+  display: grid; grid-template-columns: 1fr 2fr auto;
+  gap: 16px; padding: 12px 20px;
+  background: oklch(1 0 0 / 0.05);
+  border-left: 3px solid oklch(0.72 0.17 25);
+  border-radius: 6px;
+  margin-bottom: 8px;
+  font-size: 16px;
+}
+.fin-cowork .fin-pres-late-l { font-weight: 600; }
+.fin-cowork .fin-pres-late-m { color: oklch(1 0 0 / 0.6); }
+.fin-cowork .fin-pres-late-r { font-family: var(--font-mono); font-weight: 700; }
+.fin-cowork .fin-pres-decisoes { text-align: left; max-width: 700px; margin: 24px auto 0; padding: 0; list-style: none; counter-reset: pres; }
+.fin-cowork .fin-pres-decisoes li {
+  counter-increment: pres;
+  padding: 14px 0 14px 52px;
+  font-size: 18px; line-height: 1.4;
+  border-top: 1px solid oklch(1 0 0 / 0.08);
+  position: relative;
+}
+.fin-cowork .fin-pres-decisoes li::before {
+  content: counter(pres);
+  position: absolute; left: 0; top: 14px;
+  width: 34px; height: 34px; border-radius: 50%;
+  background: oklch(0.55 0.13 145); color: white;
+  display: grid; place-items: center;
+  font-family: var(--font-mono); font-size: 13px; font-weight: 700;
+}
+.fin-cowork .fin-pres-decisoes li:first-child { border-top: none; }
+.fin-cowork .fin-pres-decisoes b { color: oklch(0.85 0.10 145); }
+.fin-cowork .fin-pres-bot {
+  display: flex; align-items: center; gap: 18px; justify-content: center;
+  padding: 20px 28px;
+  border-top: 1px solid oklch(1 0 0 / 0.08);
+}
+.fin-cowork .fin-pres-bot button {
+  background: oklch(1 0 0 / 0.08);
+  border: 1px solid oklch(1 0 0 / 0.12);
+  color: white;
+  width: 44px; height: 44px;
+  border-radius: 8px;
+  font-size: 18px; cursor: pointer;
+}
+.fin-cowork .fin-pres-bot button:hover:not(:disabled) { background: oklch(1 0 0 / 0.16); }
+.fin-cowork .fin-pres-bot button:disabled { opacity: 0.3; cursor: not-allowed; }
+.fin-cowork .fin-pres-dots { display: flex; gap: 8px; }
+.fin-cowork .fin-pres-dot {
+  width: 8px; height: 8px; border-radius: 50%;
+  background: oklch(1 0 0 / 0.2); cursor: pointer; transition: all .15s;
+}
+.fin-cowork .fin-pres-dot.on { background: oklch(0.78 0.13 145); width: 24px; border-radius: 99px; }
+.fin-cowork .fin-toolbar .fin-filter-toggle {
+  display: inline-flex; align-items: center; gap: 5px;
+  padding: 5px 10px; border-radius: 5px;
+  border: 1px dashed var(--border); background: var(--surface);
+  font-size: 12px; font-weight: 500; color: var(--text-dim);
+  cursor: pointer; user-select: none; transition: all .12s;
+}
+.fin-cowork .fin-toolbar .fin-filter-toggle:hover {
+  border-color: var(--text-mute); color: var(--text);
+}
+.fin-cowork .fin-toolbar .fin-filter-toggle input {
+  appearance: none; -webkit-appearance: none;
+  width: 13px; height: 13px;
+  border: 1.5px solid var(--text-mute);
+  border-radius: 3px; cursor: pointer;
+  display: inline-grid; place-items: center;
+  margin: 0;
+}
+.fin-cowork .fin-toolbar .fin-filter-toggle input:checked {
+  background: oklch(0.55 0.18 25); border-color: oklch(0.55 0.18 25);
+}
+.fin-cowork .fin-toolbar .fin-filter-toggle input:checked::after {
+  content: ""; width: 7px; height: 4px;
+  border-left: 1.5px solid white; border-bottom: 1.5px solid white;
+  transform: rotate(-45deg) translate(0, -1px);
+}
+.fin-cowork .fin-toolbar .fin-filter-toggle.on.warn {
+  border-style: solid;
+  background: oklch(0.96 0.06 25);
+  border-color: oklch(0.55 0.18 25);
+  color: oklch(0.45 0.18 25); font-weight: 600;
+}
+/* Hero title sub + botões ativos no header */
+.fin-cowork .fin-root .fin-hero-title-sub {
+  color: var(--text-mute); font-weight: 400;
+  font-size: 18px; margin-left: 4px;
+}
+.fin-cowork .fin-root .os-page-h-r .os-btn.on {
+  background: oklch(0.94 0.05 145);
+  color: oklch(0.32 0.13 145);
+  border-color: oklch(0.78 0.10 145);
+}
+.fin-cowork .fin-root .fin-subnav { display: none; }
+.fin-cowork .vd-subpage .vd-bcrumb {
+  display: flex; align-items: center; gap: 6px;
+  padding: 4px 0 12px;
+  font-size: 12px; color: var(--text-mute);
+  margin-bottom: 0;
+}
+.fin-cowork .vd-subpage .vd-bcrumb-back {
+  display: inline-flex; align-items: center; gap: 5px;
+  background: transparent; border: 1px solid transparent;
+  padding: 4px 9px 4px 6px; border-radius: 5px;
+  font-family: inherit; font-size: 12px; font-weight: 500;
+  color: var(--vd-green, oklch(0.50 0.14 155)); cursor: pointer;
+  transition: all .12s;
+}
+.fin-cowork .vd-subpage .vd-bcrumb-back:hover {
+  background: var(--vd-green-soft, oklch(0.94 0.05 155));
+  border-color: var(--vd-green-soft, oklch(0.94 0.05 155));
+}
+.fin-cowork .vd-subpage .vd-bcrumb-back svg { flex-shrink: 0; transition: transform .12s; }
+.fin-cowork .vd-subpage .vd-bcrumb-back:hover svg { transform: translateX(-2px); }
+.fin-cowork .vd-subpage .vd-bcrumb-sep {
+  color: var(--text-mute); opacity: 0.5;
+  font-size: 13px;
+}
+.fin-cowork .vd-subpage .vd-bcrumb-here {
+  font-weight: 500; color: var(--text);
+}
+/* ══════════════════════════════════════════
+   HEADER LIMPO + TOOLBAR EM LINHA SEPARADA
+   ══════════════════════════════════════════ */
+.fin-cowork .vendas-aplus .vd-head-clean {
+  align-items: center; gap: 16px;
+}
+.fin-cowork .vendas-aplus .vd-head-clean .os-head-l h1 {
+  margin: 0; font-size: 22px; font-weight: 700;
+  letter-spacing: -0.018em;
+}
+.fin-cowork .vendas-aplus .vd-head-clean .os-head-l p {
+  margin: 2px 0 0; font-size: 12px; color: var(--text-mute);
+}
+.fin-cowork .vendas-aplus .vd-head-clean .os-head-r {
+  display: inline-flex; gap: 8px; align-items: center;
+}
+/* Toolbar limpa abaixo do header */
+.fin-cowork .vendas-aplus .vd-toolbar {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 0 14px;
+  border-bottom: 1px solid var(--border-2);
+  margin-bottom: 14px;
+}
+.fin-cowork .vendas-aplus .vd-toolbar-l {
+  display: inline-flex; align-items: center; gap: 8px; flex: 1;
+}
+.fin-cowork .vendas-aplus .vd-toolbar-r {
+  display: inline-flex; align-items: center; gap: 4px;
+}
+.fin-cowork .vendas-aplus .vd-toolbar-sep {
+  width: 1px; height: 18px; background: var(--border);
+  margin: 0 4px;
+}
+.fin-cowork .vendas-aplus .vd-toolbar-act {
+  display: inline-flex; align-items: center; gap: 5px;
+  background: transparent; border: none;
+  padding: 5px 9px; border-radius: 5px;
+  font-family: inherit; font-size: 12px; font-weight: 500;
+  color: var(--text-dim); cursor: pointer;
+  transition: all .12s;
+}
+.fin-cowork .vendas-aplus .vd-toolbar-act:hover {
+  background: var(--bg-2); color: var(--text);
+}
+.fin-cowork .vendas-aplus .vd-toolbar-act svg { flex-shrink: 0; }
+/* Foco mais discreto na toolbar */
+.fin-cowork .vendas-aplus .vd-toolbar .vd-vista {
+  background: var(--bg-2); border-radius: 6px;
+  padding: 2px; gap: 0;
+}
+.fin-cowork .vendas-aplus .vd-toolbar .vd-vista-lbl {
+  padding: 0 8px 0 6px;
+  font-size: 9.5px;
+}
+.fin-cowork .vendas-aplus .vd-toolbar .vd-vista button {
+  border: none; background: transparent;
+  padding: 4px 10px; border-radius: 4px;
+  font-family: inherit; font-size: 11.5px; font-weight: 500;
+  color: var(--text-dim); cursor: pointer;
+  transition: all .12s;
+}
+.fin-cowork .vendas-aplus .vd-toolbar .vd-vista button:hover { color: var(--text); }
+.fin-cowork .vendas-aplus .vd-toolbar .vd-vista button.on {
+  background: var(--surface); color: var(--vd-green); font-weight: 600;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.05);
+}
+/* Views button na toolbar — sem botão "box" pesado */
+.fin-cowork .vendas-aplus .vd-toolbar .vd-views { position: relative; }
+.fin-cowork .vendas-aplus .vd-toolbar .vd-views-btn {
+  background: transparent; border: 1px solid transparent;
+  padding: 5px 9px; border-radius: 5px;
+  font-family: inherit; font-size: 12px; font-weight: 500;
+  color: var(--text-dim); cursor: pointer;
+  transition: all .12s;
+}
+.fin-cowork .vendas-aplus .vd-toolbar .vd-views-btn::after {
+  content: '▾'; font-size: 9px; color: var(--text-mute); margin-left: 4px;
+}
+.fin-cowork .vendas-aplus .vd-toolbar .vd-views-btn:hover {
+  background: var(--bg-2); color: var(--text);
+}
+/* Visões button na toolbar (mais discreto que dropdown standalone) */
+.fin-cowork .vendas-aplus .vd-toolbar .vd-toolbar-act.vd-visoes-btn {
+  border: 1px dashed var(--border);
+  color: var(--text-mute);
+}
+.fin-cowork .vendas-aplus .vd-toolbar .vd-toolbar-act.vd-visoes-btn:hover {
+  border-color: var(--text-dim);
+  background: var(--bg-2);
+  color: var(--text);
+}
+/* ── Sticky table header ── */
+.fin-cowork .vendas-aplus .vd-aplus-table thead th {
+  position: sticky; top: 0; z-index: 2;
+  background: var(--surface);
+  box-shadow: 0 1px 0 var(--border);
+}
+/* ── Hover-reveal row actions ── */
+.fin-cowork .vendas-aplus .vd-row-actions {
+  display: inline-flex; gap: 2px;
+  margin-left: 6px;
+  opacity: 0; transform: translateX(-4px);
+  transition: opacity .12s, transform .12s;
+  vertical-align: middle;
+}
+.fin-cowork .vendas-aplus .os-row:hover .vd-row-actions, .fin-cowork .vendas-aplus .os-row.row-focused .vd-row-actions {
+  opacity: 1; transform: none;
+}
+.fin-cowork .vendas-aplus .vd-row-act {
+  width: 22px; height: 22px;
+  background: transparent; border: 1px solid var(--border);
+  border-radius: 4px; cursor: pointer;
+  display: inline-grid; place-items: center;
+  color: var(--text-mute);
+  transition: all .12s;
+}
+.fin-cowork .vendas-aplus .vd-row-act:hover {
+  border-color: var(--vd-green); color: var(--vd-green);
+  background: var(--vd-green-soft);
+}
+/* ═══════════════════════════════════════════════════════════════════
+   VENDAS · TWEAKS via data-attrs
+   ═══════════════════════════════════════════════════════════════════ */
+/* Densidade */
+.fin-cowork .vendas-aplus[data-vd-density="compact"]  .vd-aplus-table td { padding: 5px 8px; font-size: 11.5px; }
+.fin-cowork .vendas-aplus[data-vd-density="compact"]  .vd-aplus-table th { padding: 5px 8px; }
+.fin-cowork .vendas-aplus[data-vd-density="compact"]  .vd-item-cur .vd-item-c-main { padding: 6px 10px; }
+.fin-cowork .vendas-aplus[data-vd-density="spacious"] .vd-aplus-table td { padding: 14px 14px; font-size: 13.5px; }
+.fin-cowork .vendas-aplus[data-vd-density="spacious"] .vd-aplus-table th { padding: 12px 14px; }
+.fin-cowork .vendas-aplus[data-vd-density="spacious"] .vd-item-cur .vd-item-c-main { padding: 14px 16px; }
+/* Drawer largura */
+.fin-cowork .vendas-aplus[data-vd-drawer="largo"] ~ .os-drawer-back .os-drawer.wide, .fin-cowork body:has(.vendas-aplus[data-vd-drawer="largo"]) .os-drawer.wide { width: 720px; max-width: 92vw; }
+/* SLA visual variations */
+.fin-cowork .vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla {
+  background: transparent !important;
+  padding: 0;
+  gap: 4px;
+}
+.fin-cowork .vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla-ic {
+  width: 7px; height: 7px; border-radius: 50%;
+  font-size: 0;
+}
+.fin-cowork .vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla-fresh   .vd-sla-ic { background: oklch(0.55 0.13 145); }
+.fin-cowork .vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla-warning .vd-sla-ic { background: oklch(0.62 0.13 60); }
+.fin-cowork .vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla-overdue .vd-sla-ic { background: var(--vd-bad); }
+.fin-cowork .vendas-aplus[data-vd-sla="dot"] .vd-pay-sla .vd-sla-lbl {
+  color: var(--text-dim); font-family: var(--font-mono); font-size: 10.5px; font-weight: 500;
+}
+.fin-cowork .vendas-aplus[data-vd-sla="bar"] .vd-pay-sla {
+  display: block; margin-top: 4px;
+}
+.fin-cowork .vendas-aplus[data-vd-sla="bar"] .vd-pay-sla .vd-sla {
+  display: block; background: transparent !important; padding: 0;
+}
+.fin-cowork .vendas-aplus[data-vd-sla="bar"] .vd-pay-sla .vd-sla-ic { display: none; }
+.fin-cowork .vendas-aplus[data-vd-sla="bar"] .vd-pay-sla .vd-sla-lbl {
+  display: block; font-size: 10px; color: var(--text-mute); margin-bottom: 3px;
+}
+.fin-cowork .vendas-aplus[data-vd-sla="bar"] .vd-pay-sla::after {
+  content: ''; display: block; height: 3px; border-radius: 99px;
+  background: linear-gradient(90deg, var(--vd-ok), var(--vd-warn), var(--vd-bad));
+  opacity: 0.4;
+}
+.fin-cowork .vendas-aplus[data-vd-sla="bar"] .vd-pay-sla:has(.vd-sla-fresh)::after { background: var(--vd-ok); opacity: 1; }
+.fin-cowork .vendas-aplus[data-vd-sla="bar"] .vd-pay-sla:has(.vd-sla-warning)::after { background: var(--vd-warn); opacity: 1; }
+.fin-cowork .vendas-aplus[data-vd-sla="bar"] .vd-pay-sla:has(.vd-sla-overdue)::after { background: var(--vd-bad); opacity: 1; }
+/* Paleta accent */
+.fin-cowork .vendas-aplus[data-vd-palette="indigo"] {
+  --vd-green: oklch(0.45 0.18 270);
+  --vd-green-soft: oklch(0.95 0.05 270);
+}
+.fin-cowork .vendas-aplus[data-vd-palette="slate"] {
+  --vd-green: oklch(0.42 0.04 240);
+  --vd-green-soft: oklch(0.94 0.005 240);
+}
+.fin-cowork .vendas-aplus[data-vd-palette="amber"] {
+  --vd-green: oklch(0.52 0.14 60);
+  --vd-green-soft: oklch(0.95 0.06 60);
+}

--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -60,6 +60,16 @@
  *  (re-rodar scripts/scope-fin-cowork-css.py é no-op).
  * ============================================================================ */
 
+/* Onda 12.3 (2026-05-19) — Bundle canon REAL CSS inteiro (9054 LOC originais,
+   8630 pós escopo .fin-cowork via scripts/scope-fin-cowork-css.py).
+   Copiado de public/cowork-preview/styles.css conforme regra Tier 0
+   feedback-cowork-bundle-aplicar-inteiro.md — Wagner autorizou após 3 falhas
+   de cherry-pick de classes Cowork sharedas (vd-toolbar*, os-btn*).
+   PRIMEIRO no import order pra ter base canon + overrides locais por cima. */
+@import "./cowork-canon-financeiro-bundle.css";
+
+/* Bundle Cowork antigo (Onda 8) — mantém pra preservar regras escopadas que
+   já validamos visualmente. Will be deprecated após validar paridade canon. */
 @import "./cowork-financeiro-bundle.css";
 @import "./fin-curadoria.css";
 @import "./fin-ia.css";

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -535,24 +535,25 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
 
   return (
     <div className="fin-curadoria">
-      {/* Onda 8 Cowork: page header canon com h1 + breadcrumb + 7 botões.
-          Substitui PageHeader shadcn legacy (mantido em _KpiBarLegacy + comentário). */}
-      <div className="fin-page-h">
-        <div className="fin-page-h-l">
+      {/* Onda 12.3 (2026-05-19) — markup canon EXATO `os-page-h` (DOM forensics
+          canon REAL). Bundle CSS canon inteiro importado em inertia.css garante
+          que classes existem (sem tree-shake como acontecia com cherry-pick). */}
+      <div className="os-page-h fin-page-h">
+        <div className="os-page-h-l fin-page-h-l">
           <h1>
             Financeiro <span className="fin-hero-title-sub">· Visão unificada</span>
           </h1>
           <p>{periodLabel}{businessName ? ` · ${businessName}` : ''} · caixa unificado</p>
         </div>
-        <div className="fin-page-h-r">
-          <button type="button" className="fin-btn" onClick={() => setPaletteOpen(true)}>
+        <div className="os-page-h-r fin-page-h-r">
+          <button type="button" className="os-btn ghost fin-btn" onClick={() => setPaletteOpen(true)}>
             <Search size={13} />
             Buscar
             <kbd>⌘K</kbd>
           </button>
           <button
             type="button"
-            className="fin-btn fin-btn-ai"
+            className="os-btn ghost fin-btn fin-btn-ai"
             title="Resumo executivo do mês (narrativa compute-based · Onda 9 v1)"
             onClick={() => setResumoOpen(true)}
           >
@@ -561,7 +562,7 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
           </button>
           <button
             type="button"
-            className="fin-btn fin-btn-trilha"
+            className="os-btn ghost fin-btn fin-btn-trilha"
             onClick={() => setChecklistOpen(true)}
             title="Trilha de 12 passos do fechamento mensal"
           >
@@ -570,7 +571,7 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
           </button>
           <button
             type="button"
-            className="fin-btn fin-btn-present"
+            className="os-btn ghost fin-btn fin-btn-present"
             title="Modo apresentação fullscreen (Esc fecha · 1/2/3 muda vista)"
             onClick={() => setPresentOpen(true)}
           >
@@ -579,7 +580,7 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
           </button>
           <button
             type="button"
-            className="fin-btn"
+            className="os-btn ghost fin-btn"
             title={`Folha jurídica imprimível${favs.count > 0 ? ` · ${favs.count} favorito${favs.count === 1 ? '' : 's'}` : ''}`}
             onClick={() => { setTranscriptOnlyFavs(false); setTranscriptOpen(true); }}
           >
@@ -587,11 +588,11 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
             Imprimir
             {favs.count > 0 && <span className="fin-btn-badge">{favs.count}★</span>}
           </button>
-          <button type="button" className="fin-btn" onClick={() => router.visit('/financeiro/extrato')}>
+          <button type="button" className="os-btn ghost fin-btn" onClick={() => router.visit('/financeiro/extrato')}>
             <RefreshCw size={13} />
             Conciliar
           </button>
-          <button type="button" className="fin-btn" onClick={() => router.visit('/financeiro/plano-contas')} title="Plano de contas — categorias contábeis">
+          <button type="button" className="os-btn ghost fin-btn" onClick={() => router.visit('/financeiro/plano-contas')} title="Plano de contas — categorias contábeis">
             <FolderOpen size={13} />
             Plano de contas
           </button>
@@ -599,7 +600,7 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
               Onclick stub abre ⌘K palette por enquanto; handler real (Exportar XLSX/PDF) vira US futura. */}
           <button
             type="button"
-            className="fin-btn"
+            className="os-btn ghost fin-btn"
             title="Exportar lançamentos do período (XLSX / PDF)"
             aria-label="Exportar"
             onClick={() => setPaletteOpen(true)}
@@ -607,7 +608,7 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
           >
             <Download size={13} />
           </button>
-          <button type="button" className="fin-btn primary" onClick={() => router.visit('/financeiro/unificado/novo')}>
+          <button type="button" className="os-btn primary fin-btn primary" onClick={() => router.visit('/financeiro/unificado/novo')}>
             <Plus size={13} />
             Novo lançamento
           </button>

--- a/scripts/scope-fin-cowork-css.py
+++ b/scripts/scope-fin-cowork-css.py
@@ -23,6 +23,11 @@ import sys
 from pathlib import Path
 
 FILES = [
+    # Onda 12.3 (2026-05-19) — bundle canon REAL inteiro (9054 LOC) copiado de
+    # public/cowork-preview/styles.css conforme regra Tier 0
+    # feedback-cowork-bundle-aplicar-inteiro.md (Wagner autorizou bundle copy
+    # após 3 tentativas falhas de cherry-pick de classes Cowork sharedas).
+    Path("resources/css/cowork-canon-financeiro-bundle.css"),
     Path("resources/css/cowork-financeiro-bundle.css"),
     Path("resources/css/fin-curadoria.css"),
     Path("resources/css/fin-ia.css"),


### PR DESCRIPTION
Wagner autorizou (sessão 2026-05-19) bundle copy inteiro após 3 cherry-picks falhos. Aplica regra Tier 0 [`feedback-cowork-bundle-aplicar-inteiro.md`](memory/reference/feedback-cowork-bundle-aplicar-inteiro.md).

## Ação

1. **Copiado** `public/cowork-preview/styles.css` (9054 LOC, 293KB — bundle canon REAL) para `resources/css/cowork-canon-financeiro-bundle.css`
2. **Escopo** via `scripts/scope-fin-cowork-css.py` (prefixa `.fin-cowork` em todos seletores top-level — 8630 LOC pós escopo)
3. **Importado** em `inertia.css` ANTES dos legacy
4. **Adaptado markup** Index.tsx: `os-page-h`, `os-btn ghost` adicionadas (preserva `fin-page-h`/`fin-btn` legacy pra back-compat)

## Por que vai funcionar (vs cherry-picks anteriores tree-shaken)

Vite tree-shake remove classes 'não usadas'. Bundle inteiro escopado em `.fin-cowork` é tratado como pacote único — Vite não shake. Mesma estratégia validada em Vendas/Pedidos/Cockpit.

## Diff

+8660 / -14 em 4 arquivos. Bundle canon REAL completo importado pela primeira vez.

🤖 Generated with [Claude Code](https://claude.com/claude-code)