### PR TITLE
feat(paymentgateway): upload cert.crt + key via wizard Inter mTLS (Onda 5)

### DIFF
--- a/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
@@ -9,7 +9,9 @@ use Carbon\CarbonImmutable;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Financeiro\Models\ContaBancaria;
@@ -115,6 +117,9 @@ class PaymentGatewaysController extends Controller
             'conta_bancaria_id' => 'nullable|integer|exists:accounts,id',
             'config_json'      => 'required|array',
             'ativo'            => 'sometimes|boolean',
+            'cert_file'        => 'sometimes|file|mimes:crt,pem,cer|max:32',
+            'key_file'         => 'sometimes|file|mimes:key,pem|max:32',
+            'cert_password'    => 'sometimes|nullable|string|max:191',
         ]);
 
         // Tier 0: garantir conta_bancaria_id pertence ao business_id session
@@ -142,23 +147,36 @@ class PaymentGatewaysController extends Controller
             ], 422);
         }
 
+        $configJson = $validated['config_json'];
+
         $cred = PaymentGatewayCredential::create([
             'business_id'        => $businessId,
             'gateway_key'        => $validated['gateway_key'],
             'ambiente'           => $validated['ambiente'],
             'nome_display'       => $validated['nome_display'] ?? null,
             'conta_bancaria_id'  => $validated['conta_bancaria_id'] ?? null,
-            'config_json'        => $validated['config_json'],
+            'config_json'        => $configJson,
             'ativo'              => (bool) ($validated['ativo'] ?? true),
             'health_status'      => 'unknown',
         ]);
+
+        if ($request->hasFile('cert_file') || $request->hasFile('key_file')) {
+            $certPaths = $this->storeCertFiles($request, $cred, $businessId);
+            if (!empty($certPaths)) {
+                $configJson = array_merge($configJson, $certPaths);
+                if (!empty($validated['cert_password'])) {
+                    $configJson['cert_password'] = $validated['cert_password'];
+                }
+                $cred->update(['config_json' => $configJson]);
+            }
+        }
 
         Log::info('[paymentgateway.credential.created]', [
             'business_id'   => $businessId,
             'credential_id' => $cred->id,
             'gateway_key'   => $cred->gateway_key,
             'ambiente'      => $cred->ambiente,
-            // NÃO loga config_json (secrets — LGPD/PCI)
+            'has_cert'      => isset($configJson['certificado_crt']),
         ]);
 
         if ($request->wantsJson()) {
@@ -190,6 +208,9 @@ class PaymentGatewaysController extends Controller
             'config_json'       => 'sometimes|array',
             'ambiente'          => 'sometimes|string|in:production,sandbox',
             'ativo'             => 'sometimes|boolean',
+            'cert_file'         => 'sometimes|file|mimes:crt,pem,cer|max:32',
+            'key_file'          => 'sometimes|file|mimes:key,pem|max:32',
+            'cert_password'     => 'sometimes|nullable|string|max:191',
         ]);
 
         if (!empty($validated['conta_bancaria_id'])) {
@@ -201,18 +222,74 @@ class PaymentGatewaysController extends Controller
             }
         }
 
-        $cred->update($validated);
+        $payload = array_diff_key($validated, array_flip(['cert_file', 'key_file', 'cert_password']));
+
+        if (array_key_exists('config_json', $payload)) {
+            $payload['config_json'] = array_merge($cred->config_json ?? [], $payload['config_json']);
+        }
+
+        if ($request->hasFile('cert_file') || $request->hasFile('key_file')) {
+            $certPaths = $this->storeCertFiles($request, $cred, $businessId);
+            if (!empty($certPaths)) {
+                $existing = $payload['config_json'] ?? ($cred->config_json ?? []);
+                $payload['config_json'] = array_merge($existing, $certPaths);
+                if (!empty($validated['cert_password'])) {
+                    $payload['config_json']['cert_password'] = $validated['cert_password'];
+                }
+            }
+        }
+
+        $cred->update($payload);
 
         Log::info('[paymentgateway.credential.updated]', [
             'business_id'   => $businessId,
             'credential_id' => $cred->id,
-            'fields'        => array_keys($validated),
+            'fields'        => array_keys($payload),
+            'has_cert_upload' => $request->hasFile('cert_file') || $request->hasFile('key_file'),
         ]);
 
         return response()->json([
             'success' => true,
             'credential_id' => $cred->id,
         ]);
+    }
+
+    /**
+     * Salva cert.crt + key.key em storage privado.
+     * Path: storage/app/private/payment-gateway/{biz}/{cred}/{cert,key}.{ext}
+     * Permissions: 0600. Tier 0: business_id no path previne leak.
+     * LGPD/PCI: log nunca emite conteúdo.
+     *
+     * @return array<string, string>
+     */
+    private function storeCertFiles(Request $request, PaymentGatewayCredential $cred, int $businessId): array
+    {
+        $paths = [];
+        $baseDir = 'payment-gateway/' . $businessId . '/' . $cred->id;
+
+        if ($request->hasFile('cert_file')) {
+            /** @var UploadedFile $certFile */
+            $certFile = $request->file('cert_file');
+            $certPath = $certFile->storeAs($baseDir, 'cert.' . $certFile->getClientOriginalExtension(), 'local');
+            $absPath = Storage::disk('local')->path($certPath);
+            if (is_file($absPath)) {
+                @chmod($absPath, 0600);
+            }
+            $paths['certificado_crt'] = $absPath;
+        }
+
+        if ($request->hasFile('key_file')) {
+            /** @var UploadedFile $keyFile */
+            $keyFile = $request->file('key_file');
+            $keyPath = $keyFile->storeAs($baseDir, 'key.' . $keyFile->getClientOriginalExtension(), 'local');
+            $absPath = Storage::disk('local')->path($keyPath);
+            if (is_file($absPath)) {
+                @chmod($absPath, 0600);
+            }
+            $paths['certificado_key'] = $absPath;
+        }
+
+        return $paths;
     }
 
     /**

--- a/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
@@ -30,6 +30,11 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
+  // Onda 5+: upload cert/key + senha
+  const [certFile, setCertFile] = useState<File | null>(null);
+  const [keyFile, setKeyFile] = useState<File | null>(null);
+  const [certPassword, setCertPassword] = useState('');
+
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
     document.addEventListener('keydown', onKey);
@@ -49,16 +54,22 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
     setError(null);
     setSubmitting(true);
 
-    const payload = {
-      gateway_key: driver,
-      ambiente,
-      nome_display: apelido || null,
-      conta_bancaria_id: contaId ? Number(contaId) : null,
-      config_json: config,
-      ativo,
-    };
+    const hasFiles = certFile !== null || keyFile !== null;
+    const fd = new FormData();
+    fd.append('gateway_key', driver);
+    fd.append('ambiente', ambiente);
+    if (apelido) fd.append('nome_display', apelido);
+    if (contaId) fd.append('conta_bancaria_id', contaId);
+    fd.append('ativo', ativo ? '1' : '0');
+    Object.entries(config).forEach(([k, v]) => {
+      if (v) fd.append(`config_json[${k}]`, v);
+    });
+    if (certFile) fd.append('cert_file', certFile);
+    if (keyFile) fd.append('key_file', keyFile);
+    if (certPassword) fd.append('cert_password', certPassword);
 
-    router.post('/settings/payment-gateways', payload, {
+    router.post('/settings/payment-gateways', fd, {
+      forceFormData: hasFiles,
       preserveScroll: true,
       onSuccess: () => {
         setSubmitting(false);
@@ -179,9 +190,25 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
                     className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
                   />
                 </Field>
-                <div className="bg-amber-50 border border-amber-200 rounded p-2.5 text-[10.5px] text-amber-800">
-                  Certificado mTLS (.crt + .key) ainda não pode ser feito upload pela UI.
-                  Pra sandbox sem mTLS funciona. Pra produção, suba via SSH em <span className="font-mono">storage/app/private/payment-gateway/</span> e referencie em <span className="font-mono">config_json.cert_path</span> manual (próxima onda terá UI de upload).
+                <div className="grid grid-cols-2 gap-3">
+                  <FileField
+                    label="Certificado .crt"
+                    accept=".crt,.pem,.cer"
+                    onFile={setCertFile}
+                    selectedFileName={certFile?.name}
+                    hint="Inter PJ A1 (32KB max)"
+                  />
+                  <FileField
+                    label="Chave .key"
+                    accept=".key,.pem"
+                    onFile={setKeyFile}
+                    selectedFileName={keyFile?.name}
+                    hint="Chave privada (32KB max)"
+                  />
+                </div>
+                <div className="bg-stone-50 border border-stone-200 rounded p-2.5 text-[10.5px] text-stone-700">
+                  Sandbox aceita sem mTLS. Production exige cert + key ICP-Brasil Inter PJ.
+                  Arquivos salvos em <span className="font-mono">storage/app/private/payment-gateway/{'{biz}/{cred_id}'}/</span> com chmod 0600.
                 </div>
               </>}
               {d.key === 'asaas' && <>
@@ -235,8 +262,30 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
                     className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px] font-mono"
                   />
                 </Field>
-                <div className="bg-amber-50 border border-amber-200 rounded p-2.5 text-[10.5px] text-amber-800">
-                  Certificado mTLS ICP-Brasil (.crt + .key + senha) precisa ser cadastrado manual via SSH em <span className="font-mono">storage/app/private/payment-gateway/</span> e referenciado em <span className="font-mono">config_json.cert_path</span> + <span className="font-mono">.cert_password</span>.
+                <div className="grid grid-cols-2 gap-3">
+                  <FileField
+                    label="Cert mTLS ICP-Brasil .crt"
+                    accept=".crt,.pem,.cer"
+                    onFile={setCertFile}
+                    selectedFileName={certFile?.name}
+                  />
+                  <FileField
+                    label="Chave .key"
+                    accept=".key,.pem"
+                    onFile={setKeyFile}
+                    selectedFileName={keyFile?.name}
+                  />
+                </div>
+                <Field label="Senha do certificado (opcional)">
+                  <input
+                    type="password"
+                    value={certPassword}
+                    onChange={e => setCertPassword(e.target.value)}
+                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px] font-mono"
+                  />
+                </Field>
+                <div className="bg-stone-50 border border-stone-200 rounded p-2.5 text-[10.5px] text-stone-700">
+                  Cert ICP-Brasil ⇄ CNPJ recebedor homologado no BCB. Resolução BCB 380/2024.
                 </div>
               </>}
               {d.key === 'pesapal' && <>

--- a/resources/js/Pages/Settings/PaymentGateways/_components/atoms-settings.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/atoms-settings.tsx
@@ -49,14 +49,38 @@ export function Toggle({ on, onConfirm, title }: { on: boolean; onConfirm: (newV
   );
 }
 
-export function FileField({ label, hint, accept }: { label: string; hint?: string; accept?: string }) {
+export function FileField({
+  label,
+  hint,
+  accept,
+  onFile,
+  selectedFileName,
+}: {
+  label: string;
+  hint?: string;
+  accept?: string;
+  onFile?: (file: File | null) => void;
+  selectedFileName?: string;
+}) {
+  const hasFile = !!selectedFileName;
   return (
-    <label className="block">
+    <label className="block cursor-pointer">
       <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium mb-1">{label}</div>
-      <div className="h-8 bg-white border border-stone-300 border-dashed rounded flex items-center gap-2 px-2 text-[11.5px] text-stone-500 hover:border-stone-500 cursor-pointer transition">
+      <div className={cn(
+        'h-8 border rounded flex items-center gap-2 px-2 text-[11.5px] transition',
+        hasFile
+          ? 'bg-emerald-50 border-emerald-300 text-emerald-700'
+          : 'bg-white border-stone-300 border-dashed text-stone-500 hover:border-stone-500',
+      )}>
         <Upload className="h-3 w-3" />
-        <span>arrastar arquivo {accept || ''} ou clicar</span>
+        <span className="truncate">{hasFile ? selectedFileName : `arrastar arquivo ${accept || ''} ou clicar`}</span>
       </div>
+      <input
+        type="file"
+        accept={accept}
+        className="hidden"
+        onChange={e => onFile?.(e.target.files?.[0] ?? null)}
+      />
       {hint && <div className="text-[10.5px] text-stone-500 mt-1">{hint}</div>}
     </label>
   );


### PR DESCRIPTION
Wagner 2026-05-19: 'eu tenho eles, so quero cadastrar na interface'.

## Backend
- store/update aceitam multipart cert_file (.crt/.pem/.cer) + key_file (.key/.pem) + cert_password
- helper storeCertFiles salva em storage/app/private/payment-gateway/{biz}/{cred}/ chmod 0600
- LGPD log: has_cert: bool (nunca conteúdo)

## Frontend
- SheetNovoGateway state files + FormData + forceFormData
- FileField com onFile/selectedFileName (controlled input file)
- Inter step 2: cert + key + visual feedback ao upload
- BCB Pix step 2: cert + key + password ICP-Brasil
- Disclaimers atualizados

## Tier 0
- Path com business_id previne leak cross-tenant
- Account check em update + store

Refs: PR #1148, #1153, #1163, ADR 0170