### PR TITLE
fix(paymentgateway): update/destroy retornam redirect pra Inertia (não JSON)

### DIFF
--- a/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
@@ -193,8 +193,11 @@ class PaymentGatewaysController extends Controller
 
     /**
      * Atualiza credencial existente. Pattern store — apenas campos enviados.
+     *
+     * Resposta dual: Inertia request → redirect (Inertia router espera 302).
+     * Plain JSON request → JSON {success, credential_id} (futuro API).
      */
-    public function update(Request $request, int $credentialId): JsonResponse
+    public function update(Request $request, int $credentialId): RedirectResponse|JsonResponse
     {
         $businessId = (int) $request->session()->get('user.business_id', $request->session()->get('business.id', 0));
 
@@ -247,6 +250,11 @@ class PaymentGatewaysController extends Controller
             'fields'        => array_keys($payload),
             'has_cert_upload' => $request->hasFile('cert_file') || $request->hasFile('key_file'),
         ]);
+
+        if ($request->header('X-Inertia') || !$request->expectsJson()) {
+            return redirect()->route('settings.payment-gateways.index')
+                ->with('status', ['success' => 1, 'msg' => 'Credencial atualizada']);
+        }
 
         return response()->json([
             'success' => true,
@@ -309,7 +317,7 @@ class PaymentGatewaysController extends Controller
      * Cobranças vinculadas continuam (FK cobrancas.payment_gateway_credential_id
      * permanece NULL após delete — não cascateia pra preservar histórico).
      */
-    public function destroy(Request $request, int $credentialId): JsonResponse
+    public function destroy(Request $request, int $credentialId): RedirectResponse|JsonResponse
     {
         $businessId = (int) $request->session()->get('user.business_id', $request->session()->get('business.id', 0));
 
@@ -336,6 +344,11 @@ class PaymentGatewaysController extends Controller
             'gateway_key'   => $cred->gateway_key,
             'ambiente'      => $cred->ambiente,
         ]);
+
+        if ($request->header('X-Inertia') || !$request->expectsJson()) {
+            return redirect()->route('settings.payment-gateways.index')
+                ->with('status', ['success' => 1, 'msg' => 'Credencial excluída']);
+        }
 
         return response()->json([
             'success' => true,


### PR DESCRIPTION
Wagner 2026-05-19 21:25: 'All Inertia requests must receive a valid Inertia response, however a plain JSON response was received. {success:true,credential_id:1}'

## Bug

`update` e `destroy` retornavam `JsonResponse` direto. Inertia router (`router.post` + `router.delete` no frontend) espera resposta Inertia (302 redirect com flash OR render).

## Fix

Detectar via `X-Inertia` header. Se Inertia → `redirect()->route('index')->with('status', ...)`. Se JSON puro (futuro API) → mantém `JsonResponse`.

Mesmo pattern já presente em `store` (`wantsJson()` check).

## Test plan

- [x] PHP lint verde
- [ ] Pós-deploy: Salvar credencial via DrawerGateway funciona (sem erro Inertia)
- [ ] Pós-deploy: Excluir credencial funciona

Refs: PR #1167 (drawer edit + delete que introduziu o bug)