### PR TITLE
fix(financeiro/unificado): filtros default ON + 'Só atrasados' classe correta (Onda 12.5)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -582,7 +582,13 @@ class UnificadoController extends Controller
         $periodosValidos = ['mes_atual', 'mes_anterior', '30d', '90d'];
 
         // Onda Polish 2026-05-18 — lifecycle aceita array OR string CSV ("ar,re").
-        $lifecycleRaw = $request->input('lifecycle', []);
+        // Onda 12.5 (2026-05-19) — default canon REAL: TODOS lifecycle ATIVOS (canon
+        // /cowork-preview/Oimpresso ERP - Chat.html mostra 4 pills `fin-filter-cb on`
+        // por default). Antes era array vazio (todos OFF) — não-paridade visual.
+        // Se request explicit `?lifecycle=` (vazio) — respeitar intenção do user.
+        $lifecycleRaw = $request->has('lifecycle')
+            ? $request->input('lifecycle', [])
+            : ['ar', 're', 'ap', 'pa'];
         if (is_string($lifecycleRaw)) {
             $lifecycleRaw = $lifecycleRaw === '' ? [] : explode(',', $lifecycleRaw);
         }

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -665,10 +665,11 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
 
         <span className="fin-filter-sep" />
 
-        {/* Toggle "Só atrasados" — separado dos checkboxes lifecycle. AND multiplicativo. */}
+        {/* Onda 12.5 (2026-05-19) — Toggle "Só atrasados" usa classe `fin-filter-toggle`
+            (canon REAL DOM forensics) em vez de `fin-filter-cb` que é dos lifecycle.
+            Toggle = on/off independente; lifecycle = multi-select pill colorido. */}
         <label
-          className={'fin-filter-cb' + (filters.overdue ? ' on' : '')}
-          style={filters.overdue ? ({ ['--cb-hue' as string]: 25 } as React.CSSProperties) : undefined}
+          className={'fin-filter-toggle' + (filters.overdue ? ' on' : '')}
           title="AND multiplicativo: combina com lifecycle ativos"
         >
           <input
@@ -677,9 +678,8 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
             checked={filters.overdue}
             onChange={() => aplicar({ overdue: !filters.overdue })}
           />
-          <span className="fin-filter-cb-box" />
           <span>Só atrasados</span>
-          {countOverdue(lancamentos) > 0 && <span className="fin-filter-ct">{countOverdue(lancamentos)}</span>}
+          <span className="fin-filter-ct">{countOverdue(lancamentos)}</span>
         </label>
 
         <span className="fin-filter-sep" />


### PR DESCRIPTION
Corrige 2 bugs reais reportados via DOM forensics canon vs prod:
1. Controller default lifecycle vazio → ['ar','re','ap','pa'] (canon mostra todos ON)
2. Toggle overdue: fin-filter-cb → fin-filter-toggle (canon usa classe diferente)

Botão Novo rosa (hue 330) é localStorage do user, não bug. Veja message body do PR.

+/-15 LOC em 2 arquivos.