### PR TITLE
feat(financeiro): canon em AssinaturaAtualizar + Relatorios (Onda 14)

### DIFF
--- a/resources/js/Pages/Financeiro/AssinaturaAtualizar.tsx
+++ b/resources/js/Pages/Financeiro/AssinaturaAtualizar.tsx
@@ -6,7 +6,7 @@ import AppShellV2 from '@/Layouts/AppShellV2';
 import { router } from '@inertiajs/react';
 import { useMemo, useState } from 'react';
 import { Button } from '@/Components/ui/button';
-import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
+import { Card, CardContent } from '@/Components/ui/card';
 import { Input } from '@/Components/ui/input';
 import { Label } from '@/Components/ui/label';
 import {
@@ -83,12 +83,16 @@ export default function AssinaturaAtualizar({ assinaturas }: Props) {
   return (
     <AppShellV2 title="Atualizar Cobranca">
       <div className="fin-cowork">
-      <div className="container mx-auto max-w-2xl py-6">
+      <div className="fin-curadoria vendas-aplus container mx-auto max-w-2xl py-6">
+        {/* Onda 14 (2026-05-19) — header canon */}
+        <header className="os-page-h fin-page-h">
+          <div className="os-page-h-l fin-page-h-l">
+            <h1>Atualizar cobrança <span className="fin-hero-title-sub">· Assinatura</span></h1>
+            <p>Mude a data de vencimento ou plano de uma assinatura ativa</p>
+          </div>
+        </header>
         <Card>
-          <CardHeader>
-            <CardTitle>Atualizar cobranca de assinatura</CardTitle>
-          </CardHeader>
-          <CardContent className="space-y-4">
+          <CardContent className="space-y-4 pt-6">
             <div className="space-y-2">
               <Label htmlFor="assinatura">Assinatura</Label>
               <Select value={selectedId} onValueChange={setSelectedId}>

--- a/resources/js/Pages/Financeiro/Relatorios/Index.tsx
+++ b/resources/js/Pages/Financeiro/Relatorios/Index.tsx
@@ -14,7 +14,7 @@ import { Button } from '@/Components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/Components/ui/card';
 import { Input } from '@/Components/ui/input';
 import { Badge } from '@/Components/ui/badge';
-import PageHeader from '@/Components/shared/PageHeader';
+// Onda 14 — PageHeader removido (canon os-page-h direto)
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
 
@@ -117,19 +117,19 @@ function FinanceiroRelatorios({ filters, dre, fluxo, resumo }: Props) {
   }, [filters.data_de, filters.data_ate, tab]);
 
   return (
-    <>
-      <PageHeader
-        icon="bar-chart-3"
-        title="Relatórios"
-        description="DRE gerencial, fluxo de caixa projetado vs realizado e resumo do período"
-        action={
-          <a href={csvHref} target="_blank" rel="noopener noreferrer">
-            <Button size="sm" variant="outline">
-              Exportar CSV
-            </Button>
+    <div className="fin-curadoria vendas-aplus">
+      {/* Onda 14 (2026-05-19) — header canon paridade Unificado */}
+      <header className="os-page-h fin-page-h">
+        <div className="os-page-h-l fin-page-h-l">
+          <h1>Relatórios <span className="fin-hero-title-sub">· Financeiro</span></h1>
+          <p>DRE gerencial, fluxo de caixa projetado vs realizado e resumo do período</p>
+        </div>
+        <div className="os-page-h-r fin-page-h-r">
+          <a href={csvHref} target="_blank" rel="noopener noreferrer" className="os-btn ghost">
+            Exportar CSV
           </a>
-        }
-      />
+        </div>
+      </header>
 
       {/* Filtros de período */}
       <Card className="mt-6 mb-4">
@@ -175,7 +175,7 @@ function FinanceiroRelatorios({ filters, dre, fluxo, resumo }: Props) {
       {tab === 'dre'    && <DrePanel dre={dre} />}
       {tab === 'fluxo'  && <FluxoPanel fluxo={fluxo} />}
       {tab === 'resumo' && <ResumoPanel resumo={resumo} />}
-    </>
+    </div>
   );
 }
 


### PR DESCRIPTION
Header canon em 2 telas pendentes. KpiCard shadcn de Relatorios/Dashboard/Fluxo + Cobranca pg-shell-scope ficam pra Onda C/15. +/-30 LOC.