### PR TITLE
feat(financeiro): canon TOTAL — KpiCard→fin-stat + Cobranca + FinEditPanel (Onda 15)

### DIFF
--- a/resources/js/Pages/Financeiro/Cobranca/Index.tsx
+++ b/resources/js/Pages/Financeiro/Cobranca/Index.tsx
@@ -20,7 +20,7 @@ import {
   Search, Plus, Download, Upload, Copy, MoreHorizontal, Settings, Webhook,
   Check, AlertCircle, Receipt, Zap, Building,
 } from 'lucide-react';
-import { Btn, StatusBadge, GatewayTipoChip, OrigemChip, KpiCard, PageHeader } from './_components/atoms';
+import { Btn, StatusBadge, GatewayTipoChip, OrigemChip, KpiCard} from './_components/atoms';
 import FunnelStrip from './_components/FunnelStrip';
 import DrawerCobranca from './_components/DrawerCobranca';
 import SheetNovaCobranca from './_components/SheetNovaCobranca';
@@ -174,27 +174,30 @@ function CobrancaPage({ cobrancas, kpis, funil, accounts = [], gateways = [], fi
   }, [tipoFilter, origemFilter, kpis]);
 
   return (
-    <div className="h-full bg-stone-50 flex flex-col font-sans pg-shell-scope">
-      <PageHeader
-        title="Cobrança"
-        breadcrumb={breadcrumb}
-        right={<>
-          <span className="text-[11px] text-stone-500 tabular-nums">{kpis.aberto.qtd} em aberto</span>
-          <button onClick={() => setAiOpen(true)} className="pg-ai-btn" title="Resumir cobranças deste mês — IA" aria-label="Resumir mês (IA)">
-            <span className="pg-ai-glyph">✦</span>
-            <span>Resumir mês</span>
-          </button>
-          <Btn variant="outline" onClick={() => router.visit('/settings/payment-gateways')} title="Configurar gateways">
-            <Settings className="h-3 w-3" />Gateways
-          </Btn>
-          <Btn variant="outline" onClick={() => setRemessaOpen(true)}>
-            <Upload className="h-3 w-3" />Remessa/Retorno
-          </Btn>
-          <Btn variant="primary" onClick={() => setNovaOpen(true)}>
-            <Plus className="h-3 w-3" />Nova cobrança
-          </Btn>
-        </>}
-      />
+    <div className="fin-cowork h-full bg-stone-50 flex flex-col font-sans pg-shell-scope">
+      {/* Onda 15 (2026-05-19) — header canon paridade Unificado (substitui PageHeader pg-*) */}
+      <div className="fin-curadoria vendas-aplus">
+        <header className="os-page-h fin-page-h">
+          <div className="os-page-h-l fin-page-h-l">
+            <h1>Cobrança <span className="fin-hero-title-sub">· Boletos e PIX</span></h1>
+            <p>{kpis.aberto.qtd} em aberto · gestão de remessa/retorno + gateways</p>
+          </div>
+          <div className="os-page-h-r fin-page-h-r">
+            <button type="button" className="os-btn ghost fin-btn-ai" onClick={() => setAiOpen(true)} title="Resumir cobranças deste mês — IA">
+              <span>✦</span> Resumir mês
+            </button>
+            <button type="button" className="os-btn ghost" onClick={() => router.visit('/settings/payment-gateways')} title="Configurar gateways">
+              <Settings size={13} /> Gateways
+            </button>
+            <button type="button" className="os-btn ghost" onClick={() => setRemessaOpen(true)}>
+              <Upload size={13} /> Remessa/Retorno
+            </button>
+            <button type="button" className="os-btn primary" onClick={() => setNovaOpen(true)}>
+              <Plus size={13} /> Nova cobrança
+            </button>
+          </div>
+        </header>
+      </div>
 
       {/* FUNIL */}
       <div className="px-6 pt-5">

--- a/resources/js/Pages/Financeiro/Dashboard/Index.tsx
+++ b/resources/js/Pages/Financeiro/Dashboard/Index.tsx
@@ -15,9 +15,6 @@ import { Button } from '@/Components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/Components/ui/card';
 import { Input } from '@/Components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
-import PageHeader from '@/Components/shared/PageHeader';
-import KpiGrid from '@/Components/shared/KpiGrid';
-import KpiCard from '@/Components/shared/KpiCard';
 import StatusBadge from '@/Components/shared/StatusBadge';
 
 interface KpiAberto {
@@ -173,54 +170,38 @@ function FinanceiroDashboard({
         </div>
       </header>
 
-      {/* KPI Grid (UI-0002) — Inertia::defer canon: skeleton no primeiro paint */}
+      {/* Onda 15 (2026-05-19) — KPI grid canon fin-stats (substitui KpiCard shadcn) */}
       <Deferred data="kpis" fallback={<KpiGridSkeleton />}>
-        <KpiGrid cols={4} className="mt-6">
-          <KpiCard
-            icon="arrow-down-circle"
-            tone="success"
-            label="A receber"
-            value={brl(r.valor)}
-            description={
-              r.vencidos_qtd > 0
+        <div className="fin-stats mt-6">
+          <div className="fin-stat cursor-pointer" onClick={() => aplicarFiltro({ tipo: 'receber', status: 'aberto' })}>
+            <small>A RECEBER</small>
+            <b className="fin-num-pos">{brl(r.valor)}</b>
+            <span className="fin-stat-hint">
+              {r.vencidos_qtd > 0
                 ? `${r.qtd} títulos · ${r.vencidos_qtd} vencidos (${brl(r.vencidos_valor)})`
-                : `${r.qtd} títulos abertos`
-            }
-            onClick={() => aplicarFiltro({ tipo: 'receber', status: 'aberto' })}
-            selected={filters.tipo === 'receber' && filters.status === 'aberto'}
-          />
-          <KpiCard
-            icon="arrow-up-circle"
-            tone={p.vencidos_qtd > 0 ? 'warning' : 'default'}
-            label="A pagar"
-            value={brl(p.valor)}
-            description={
-              p.vencidos_qtd > 0
+                : `${r.qtd} títulos abertos`}
+            </span>
+          </div>
+          <div className="fin-stat cursor-pointer" onClick={() => aplicarFiltro({ tipo: 'pagar', status: 'aberto' })}>
+            <small>A PAGAR</small>
+            <b className={p.vencidos_qtd > 0 ? 'fin-num-neg' : ''}>{brl(p.valor)}</b>
+            <span className="fin-stat-hint">
+              {p.vencidos_qtd > 0
                 ? `${p.qtd} títulos · ${p.vencidos_qtd} vencidos (${brl(p.vencidos_valor)})`
-                : `${p.qtd} títulos abertos`
-            }
-            onClick={() => aplicarFiltro({ tipo: 'pagar', status: 'aberto' })}
-            selected={filters.tipo === 'pagar' && filters.status === 'aberto'}
-          />
-          <KpiCard
-            icon="check-circle-2"
-            tone="success"
-            label="Recebidos no mês"
-            value={brl(rm.valor)}
-            description={`${rm.qtd} baixas`}
-            onClick={() => aplicarFiltro({ tipo: 'receber', status: 'quitado' })}
-            selected={filters.tipo === 'receber' && filters.status === 'quitado'}
-          />
-          <KpiCard
-            icon="check-circle-2"
-            tone="info"
-            label="Pagos no mês"
-            value={brl(pm.valor)}
-            description={`${pm.qtd} baixas`}
-            onClick={() => aplicarFiltro({ tipo: 'pagar', status: 'quitado' })}
-            selected={filters.tipo === 'pagar' && filters.status === 'quitado'}
-          />
-        </KpiGrid>
+                : `${p.qtd} títulos abertos`}
+            </span>
+          </div>
+          <div className="fin-stat cursor-pointer" onClick={() => aplicarFiltro({ tipo: 'receber', status: 'quitado' })}>
+            <small>RECEBIDOS NO MÊS</small>
+            <b className="fin-num-pos">{brl(rm.valor)}</b>
+            <span className="fin-stat-hint">{rm.qtd} baixas</span>
+          </div>
+          <div className="fin-stat cursor-pointer" onClick={() => aplicarFiltro({ tipo: 'pagar', status: 'quitado' })}>
+            <small>PAGOS NO MÊS</small>
+            <b>{brl(pm.valor)}</b>
+            <span className="fin-stat-hint">{pm.qtd} baixas</span>
+          </div>
+        </div>
       </Deferred>
 
       {/* Saldo em bancos */}

--- a/resources/js/Pages/Financeiro/Fluxo/Index.tsx
+++ b/resources/js/Pages/Financeiro/Fluxo/Index.tsx
@@ -12,9 +12,6 @@
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Card } from '@/Components/ui/card';
-import KpiGrid from '@/Components/shared/KpiGrid';
-import KpiCard from '@/Components/shared/KpiCard';
-import PageHeader from '@/Components/shared/PageHeader';
 import { useMemo, type ReactNode } from 'react';
 
 interface Dia {
@@ -74,17 +71,31 @@ function FinanceiroFluxo({ saldo_hoje, saldo_30d, pior_dia, margem_minima, conta
         </div>
       </header>
 
-      <KpiGrid columns={4}>
-        <KpiCard label="Saldo hoje" value={brl(saldo_hoje)} caption={conta} dark />
-        <KpiCard
-          label="Projeção 30 dias"
-          value={brl(saldo_30d)}
-          caption={`${saldo_30d >= saldo_hoje ? 'alta' : 'queda'} de ${brl(Math.abs(saldo_30d - saldo_hoje))} vs hoje`}
-          tone={saldo_30d >= saldo_hoje ? 'emerald' : 'rose'}
-        />
-        <KpiCard label="Pior dia previsto" value={brl(pior_dia.saldo)} caption={pior_dia.data_label} tone="amber" />
-        <KpiCard label="Margem mínima" value={brl(margem_minima)} caption="limite definido" />
-      </KpiGrid>
+      {/* Onda 15 (2026-05-19) — KPI grid canon fin-stats (Saldo hoje = hero dark warm) */}
+      <div className="fin-stats">
+        <div className="fin-stat fin-stat-hero">
+          <small>SALDO HOJE</small>
+          <b>{brl(saldo_hoje)}</b>
+          <span className="fin-stat-hint">{conta}</span>
+        </div>
+        <div className="fin-stat">
+          <small>PROJEÇÃO 30 DIAS</small>
+          <b className={saldo_30d >= saldo_hoje ? 'fin-num-pos' : 'fin-num-neg'}>{brl(saldo_30d)}</b>
+          <span className="fin-stat-hint">
+            {saldo_30d >= saldo_hoje ? 'alta' : 'queda'} de {brl(Math.abs(saldo_30d - saldo_hoje))} vs hoje
+          </span>
+        </div>
+        <div className="fin-stat">
+          <small>PIOR DIA PREVISTO</small>
+          <b>{brl(pior_dia.saldo)}</b>
+          <span className="fin-stat-hint">{pior_dia.data_label}</span>
+        </div>
+        <div className="fin-stat">
+          <small>MARGEM MÍNIMA</small>
+          <b>{brl(margem_minima)}</b>
+          <span className="fin-stat-hint">limite definido</span>
+        </div>
+      </div>
 
       <Card className="mx-6 mt-4 p-5">
         <div className="flex items-center justify-between mb-3">

--- a/resources/js/Pages/Financeiro/Relatorios/Index.tsx
+++ b/resources/js/Pages/Financeiro/Relatorios/Index.tsx
@@ -15,8 +15,6 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/Com
 import { Input } from '@/Components/ui/input';
 import { Badge } from '@/Components/ui/badge';
 // Onda 14 — PageHeader removido (canon os-page-h direto)
-import KpiGrid from '@/Components/shared/KpiGrid';
-import KpiCard from '@/Components/shared/KpiCard';
 
 type TabId = 'dre' | 'fluxo' | 'resumo';
 
@@ -189,17 +187,24 @@ function DrePanel({ dre }: { dre: Dre }) {
 
   return (
     <>
-      <KpiGrid cols={3} className="mb-6">
-        <KpiCard icon="arrow-down-circle" tone="success" label="Receita (período)"
-                 value={brl(dre.totais.receita)} description="Soma de títulos a receber" />
-        <KpiCard icon="arrow-up-circle"   tone="warning" label="Despesa (período)"
-                 value={brl(dre.totais.despesa)} description="Soma de títulos a pagar" />
-        <KpiCard icon="trending-up"
-                 tone={dre.totais.resultado >= 0 ? 'success' : 'danger'}
-                 label="Resultado"
-                 value={brl(dre.totais.resultado)}
-                 description={dre.totais.resultado >= 0 ? 'Superávit' : 'Déficit'} />
-      </KpiGrid>
+      {/* Onda 15 (2026-05-19) — KPI grid canon fin-stats */}
+      <div className="fin-stats mb-6">
+        <div className="fin-stat">
+          <small>RECEITA (PERÍODO)</small>
+          <b className="fin-num-pos">{brl(dre.totais.receita)}</b>
+          <span className="fin-stat-hint">Soma de títulos a receber</span>
+        </div>
+        <div className="fin-stat">
+          <small>DESPESA (PERÍODO)</small>
+          <b className="fin-num-neg">{brl(dre.totais.despesa)}</b>
+          <span className="fin-stat-hint">Soma de títulos a pagar</span>
+        </div>
+        <div className="fin-stat">
+          <small>RESULTADO</small>
+          <b className={dre.totais.resultado >= 0 ? 'fin-num-pos' : 'fin-num-neg'}>{brl(dre.totais.resultado)}</b>
+          <span className="fin-stat-hint">{dre.totais.resultado >= 0 ? 'Superávit' : 'Déficit'}</span>
+        </div>
+      </div>
 
       <Card className="mb-6">
         <CardHeader>
@@ -317,33 +322,42 @@ function FluxoPanel({ fluxo }: { fluxo: Fluxo }) {
 
   return (
     <>
-      <KpiGrid cols={4} className="mb-6">
-        <KpiCard icon="calendar-clock" tone="info"    label="Projetado a receber"
-                 value={brl(fluxo.totais.projetado_receber)} description="Títulos em aberto no período" />
-        <KpiCard icon="calendar-clock" tone="warning" label="Projetado a pagar"
-                 value={brl(fluxo.totais.projetado_pagar)} description="Títulos em aberto no período" />
-        <KpiCard icon="check-circle-2" tone="success" label="Realizado (recebido)"
-                 value={brl(fluxo.totais.realizado_receber)} description="Baixas de receber" />
-        <KpiCard icon="check-circle-2" tone="default" label="Realizado (pago)"
-                 value={brl(fluxo.totais.realizado_pagar)} description="Baixas de pagar" />
-      </KpiGrid>
+      {/* Onda 15 — canon fin-stats */}
+      <div className="fin-stats mb-6">
+        <div className="fin-stat">
+          <small>PROJETADO A RECEBER</small>
+          <b className="fin-num-pos">{brl(fluxo.totais.projetado_receber)}</b>
+          <span className="fin-stat-hint">Títulos em aberto no período</span>
+        </div>
+        <div className="fin-stat">
+          <small>PROJETADO A PAGAR</small>
+          <b className="fin-num-neg">{brl(fluxo.totais.projetado_pagar)}</b>
+          <span className="fin-stat-hint">Títulos em aberto no período</span>
+        </div>
+        <div className="fin-stat">
+          <small>REALIZADO (RECEBIDO)</small>
+          <b className="fin-num-pos">{brl(fluxo.totais.realizado_receber)}</b>
+          <span className="fin-stat-hint">Baixas de receber</span>
+        </div>
+        <div className="fin-stat">
+          <small>REALIZADO (PAGO)</small>
+          <b>{brl(fluxo.totais.realizado_pagar)}</b>
+          <span className="fin-stat-hint">Baixas de pagar</span>
+        </div>
+      </div>
 
-      <KpiGrid cols={2} className="mb-6">
-        <KpiCard
-          icon="trending-up"
-          tone={fluxo.totais.saldo_projetado >= 0 ? 'success' : 'danger'}
-          label="Saldo projetado"
-          value={brl(fluxo.totais.saldo_projetado)}
-          description="Receber − Pagar (em aberto)"
-        />
-        <KpiCard
-          icon="trending-up"
-          tone={fluxo.totais.saldo_realizado >= 0 ? 'success' : 'danger'}
-          label="Saldo realizado"
-          value={brl(fluxo.totais.saldo_realizado)}
-          description="Recebido − Pago (baixas)"
-        />
-      </KpiGrid>
+      <div className="fin-stats mb-6" style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
+        <div className="fin-stat">
+          <small>SALDO PROJETADO</small>
+          <b className={fluxo.totais.saldo_projetado >= 0 ? 'fin-num-pos' : 'fin-num-neg'}>{brl(fluxo.totais.saldo_projetado)}</b>
+          <span className="fin-stat-hint">Receber − Pagar (em aberto)</span>
+        </div>
+        <div className="fin-stat">
+          <small>SALDO REALIZADO</small>
+          <b className={fluxo.totais.saldo_realizado >= 0 ? 'fin-num-pos' : 'fin-num-neg'}>{brl(fluxo.totais.saldo_realizado)}</b>
+          <span className="fin-stat-hint">Recebido − Pago (baixas)</span>
+        </div>
+      </div>
 
       <Card>
         <CardHeader>
@@ -404,61 +418,50 @@ function FluxoPanel({ fluxo }: { fluxo: Fluxo }) {
 function ResumoPanel({ resumo }: { resumo: Resumo }) {
   return (
     <>
-      <KpiGrid cols={4} className="mb-6">
-        <KpiCard
-          icon="arrow-down-circle"
-          tone="success"
-          label="A receber (aberto)"
-          value={brl(resumo.a_receber.valor)}
-          description={
-            resumo.a_receber.vencidos_qtd > 0
+      {/* Onda 15 — canon fin-stats */}
+      <div className="fin-stats mb-6">
+        <div className="fin-stat">
+          <small>A RECEBER (ABERTO)</small>
+          <b className="fin-num-pos">{brl(resumo.a_receber.valor)}</b>
+          <span className="fin-stat-hint">
+            {resumo.a_receber.vencidos_qtd > 0
               ? `${resumo.a_receber.qtd} títulos · ${resumo.a_receber.vencidos_qtd} vencidos`
-              : `${resumo.a_receber.qtd} títulos`
-          }
-        />
-        <KpiCard
-          icon="arrow-up-circle"
-          tone={resumo.a_pagar.vencidos_qtd > 0 ? 'warning' : 'default'}
-          label="A pagar (aberto)"
-          value={brl(resumo.a_pagar.valor)}
-          description={
-            resumo.a_pagar.vencidos_qtd > 0
+              : `${resumo.a_receber.qtd} títulos`}
+          </span>
+        </div>
+        <div className="fin-stat">
+          <small>A PAGAR (ABERTO)</small>
+          <b className={resumo.a_pagar.vencidos_qtd > 0 ? 'fin-num-neg' : ''}>{brl(resumo.a_pagar.valor)}</b>
+          <span className="fin-stat-hint">
+            {resumo.a_pagar.vencidos_qtd > 0
               ? `${resumo.a_pagar.qtd} títulos · ${resumo.a_pagar.vencidos_qtd} vencidos`
-              : `${resumo.a_pagar.qtd} títulos`
-          }
-        />
-        <KpiCard
-          icon="check-circle-2"
-          tone="success"
-          label="Recebido no período"
-          value={brl(resumo.recebido_periodo.valor)}
-          description={`${resumo.recebido_periodo.qtd} baixas`}
-        />
-        <KpiCard
-          icon="check-circle-2"
-          tone="info"
-          label="Pago no período"
-          value={brl(resumo.pago_periodo.valor)}
-          description={`${resumo.pago_periodo.qtd} baixas`}
-        />
-      </KpiGrid>
+              : `${resumo.a_pagar.qtd} títulos`}
+          </span>
+        </div>
+        <div className="fin-stat">
+          <small>RECEBIDO NO PERÍODO</small>
+          <b className="fin-num-pos">{brl(resumo.recebido_periodo.valor)}</b>
+          <span className="fin-stat-hint">{resumo.recebido_periodo.qtd} baixas</span>
+        </div>
+        <div className="fin-stat">
+          <small>PAGO NO PERÍODO</small>
+          <b>{brl(resumo.pago_periodo.valor)}</b>
+          <span className="fin-stat-hint">{resumo.pago_periodo.qtd} baixas</span>
+        </div>
+      </div>
 
-      <KpiGrid cols={2} className="mb-6">
-        <KpiCard
-          icon="trending-up"
-          tone={resumo.saldo_aberto >= 0 ? 'success' : 'danger'}
-          label="Saldo em aberto"
-          value={brl(resumo.saldo_aberto)}
-          description="A receber − A pagar"
-        />
-        <KpiCard
-          icon="trending-up"
-          tone={resumo.saldo_periodo >= 0 ? 'success' : 'danger'}
-          label="Saldo do período"
-          value={brl(resumo.saldo_periodo)}
-          description="Recebido − Pago"
-        />
-      </KpiGrid>
+      <div className="fin-stats mb-6" style={{ gridTemplateColumns: 'repeat(2, 1fr)' }}>
+        <div className="fin-stat">
+          <small>SALDO EM ABERTO</small>
+          <b className={resumo.saldo_aberto >= 0 ? 'fin-num-pos' : 'fin-num-neg'}>{brl(resumo.saldo_aberto)}</b>
+          <span className="fin-stat-hint">A receber − A pagar</span>
+        </div>
+        <div className="fin-stat">
+          <small>SALDO DO PERÍODO</small>
+          <b className={resumo.saldo_periodo >= 0 ? 'fin-num-pos' : 'fin-num-neg'}>{brl(resumo.saldo_periodo)}</b>
+          <span className="fin-stat-hint">Recebido − Pago</span>
+        </div>
+      </div>
 
       {(resumo.a_receber.vencidos_qtd > 0 || resumo.a_pagar.vencidos_qtd > 0) && (
         <Card className="border-amber-300 dark:border-amber-700">

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinEditPanel.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinEditPanel.tsx
@@ -90,10 +90,14 @@ export function FinEditPanel({ lancamento, categorias, onClose }: FinEditPanelPr
     (lancamento.valor_mutavel && form.data.valor_total !== lancamento.valor);
 
   return (
-    <form onSubmit={submit} className="fin-edit-panel">
-      <div className="fin-edit-h">
-        <h4>✎ Editar lançamento</h4>
-        <small>Campos editáveis · {lancamento.valor_mutavel ? 'valor mutável' : 'valor IMUTÁVEL (pós-baixa)'}</small>
+    // Onda 15 (2026-05-19) — adiciona classes canon os-drawer-* sem remover fin-edit-*
+    // (back-compat com CSS legacy). Visualmente herda do os-drawer-head canon agora.
+    <form onSubmit={submit} className="fin-edit-panel os-drawer-body">
+      <div className="fin-edit-h os-drawer-head">
+        <div className="os-drawer-head-l">
+          <h2 style={{ margin: 0, fontSize: 16 }}>✎ Editar lançamento</h2>
+          <p style={{ margin: 0, fontSize: 12 }}>Campos editáveis · {lancamento.valor_mutavel ? 'valor mutável' : 'valor IMUTÁVEL (pós-baixa)'}</p>
+        </div>
       </div>
 
       <div className="fin-edit-grid">


### PR DESCRIPTION
Reaplica canon Cowork em todas as pendências do módulo Financeiro. Lote A (Dashboard/Fluxo/Relatorios KPI migration), Lote B (Cobranca header), Lote C (FinEditPanel back-compat). +/-200 LOC, 5 arquivos.