### PR TITLE
fix(financeiro/unificado): links 404 'Conciliar' e 'Plano de contas' (Onda 16)

### DIFF
--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -600,11 +600,16 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
             Imprimir
             {favs.count > 0 && <span className="fin-btn-badge">{favs.count}★</span>}
           </button>
-          <button type="button" className="os-btn ghost" onClick={() => router.visit('/financeiro/extrato')}>
+          {/* Onda 16 (2026-05-19) — fix links 404:
+              - "Conciliar" /financeiro/extrato (404) → /financeiro/contas-bancarias
+                (lista de contas → usuário escolhe → vai pro extrato/{id})
+              - "Plano de contas" /financeiro/plano-contas (rota não existe) →
+                /financeiro/categorias (que já vincula plano via CategoriaSheet) */}
+          <button type="button" className="os-btn ghost" onClick={() => router.visit('/financeiro/contas-bancarias')} title="Conciliar extrato bancário — escolha uma conta">
             <RefreshCw size={13} />
             Conciliar
           </button>
-          <button type="button" className="os-btn ghost" onClick={() => router.visit('/financeiro/plano-contas')} title="Plano de contas — categorias contábeis">
+          <button type="button" className="os-btn ghost" onClick={() => router.visit('/financeiro/categorias')} title="Categorias contábeis (vínculo opcional ao plano de contas)">
             <FolderOpen size={13} />
             Plano de contas
           </button>
@@ -982,8 +987,9 @@ function FinanceiroUnificado({ kpis, lancamentos, filters, contas, categorias, p
           <CommandEmpty>Sem resultados.</CommandEmpty>
           <CommandGroup heading="Ações">
             <CommandItem onSelect={() => { setPaletteOpen(false); router.visit('/financeiro/unificado/novo'); }}>Novo lançamento</CommandItem>
-            <CommandItem onSelect={() => { setPaletteOpen(false); router.visit('/financeiro/extrato'); }}>Conciliar extrato</CommandItem>
+            <CommandItem onSelect={() => { setPaletteOpen(false); router.visit('/financeiro/contas-bancarias'); }}>Conciliar extrato</CommandItem>
             <CommandItem onSelect={() => { setPaletteOpen(false); router.visit('/financeiro/relatorios'); }}>DRE / Relatórios</CommandItem>
+            <CommandItem onSelect={() => { setPaletteOpen(false); router.visit('/financeiro/categorias'); }}>Plano de contas / Categorias</CommandItem>
             <CommandItem onSelect={() => { setPaletteOpen(false); setResumoOpen(true); }}>
               ✦ Resumir mês (narrativa exec)
             </CommandItem>

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinSubNav.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinSubNav.tsx
@@ -25,9 +25,10 @@ interface FinSubItem {
 const FIN_SUB: FinSubItem[] = [
   { id: 'unified', label: 'Visão unificada', href: '/financeiro/unificado' },
   { id: 'fluxo',   label: 'Fluxo de caixa',  href: '/financeiro/fluxo' },
-  { id: 'concil',  label: 'Conciliação',     href: '/financeiro/extrato' },
+  // Onda 16 (2026-05-19) — fix 404: extrato exige conta_id; plano-contas não existe.
+  { id: 'concil',  label: 'Conciliação',      href: '/financeiro/contas-bancarias' },
   { id: 'dre',     label: 'DRE / Relatórios', href: '/financeiro/relatorios' },
-  { id: 'pcontas', label: 'Plano de contas', href: '/financeiro/plano-contas' },
+  { id: 'pcontas', label: 'Plano de contas',  href: '/financeiro/categorias' },
 ];
 
 export function FinSubNav({ active }: { active: FinSubItem['id'] }) {


### PR DESCRIPTION
Fix urgente — botões 'Conciliar' e 'Plano de contas' apontavam pra rotas 404. Apontados pra contas-bancarias e categorias. +/-12 LOC. Bloqueia perda de cliente.