### PR TITLE
feat(fiscal): cockpit NF-e · NFC-e — Modules/Fiscal novo (PR #1 do design Cowork KB-9.75)

### DIFF
--- a/Modules/Auditoria/SCOPE.md
+++ b/Modules/Auditoria/SCOPE.md
@@ -1,0 +1,41 @@
+---
+module: Auditoria
+purpose: "Trilha de auditoria + governance review do oimpresso. Cataloga eventos críticos cross-módulo (LGPD Art. 37 accountability)."
+contains:
+  - "AuditoriaController"
+  - "DataController"
+  - "InstallController"
+not_contains:
+  - "Activity Log per-Model (Spatie\\Activitylog) → trait LogsActivity nos próprios Models"
+  - "Conhecimento canônico (ADRs, sessions) → Modules/KB"
+  - "Tasks Jira-style → Modules/ProjectMgmt"
+  - "MCP server admin → Modules/TeamMcp"
+trust_required: L3
+owner: wagner
+permission_prefix: auditoria.*
+charter_adr: 0094
+related_adrs:
+  - 0093-multi-tenant-isolation-tier-0
+  - 0094-constituicao-v2-7-camadas-8-principios
+url_prefixes:
+  - /auditoria/*
+drift_alerts: []
+---
+
+# Modules/Auditoria
+
+## Missão
+
+Trilha de auditoria centralizada — cataloga eventos críticos cross-módulo (mudanças de schema, ações superadmin, drifts detectados, escalações Tier 0) pra accountability LGPD Art. 37 + revisão governance.
+
+## Trust level
+
+**L3** — ver [TRUST-TIERS.md](../../memory/governance/TRUST-TIERS.md).
+
+## Quando NÃO é tocado
+
+Ver `not_contains[]` no frontmatter. Activity Log de mutações ordinárias vive nos próprios Models (trait `LogsActivity` Spatie); Auditoria consome **eventos consolidados de governance**, não cada UPDATE.
+
+---
+
+- **v1.0.0** (2026-05-20) — SCOPE.md inicial gerado durante PR #1183 (Fiscal cockpit) pra desbloquear `check-scope --strict` no CI.

--- a/Modules/Financeiro/SCOPE.md
+++ b/Modules/Financeiro/SCOPE.md
@@ -6,6 +6,7 @@ contains:
   - "BoletoController"
   - "CategoriaController"
   - "CobrancaController — F3 PaymentGateway UI Tela 1 (substitui /financeiro/boletos com escopo expandido boleto+pix+pix_recv+card; ADR 0144 + 0170)"
+  - "ConciliacaoController — Onda 19 OFX MVP + scaffold Anexos/Aprovação"
   - "ContaBancariaController"
   - "ContaPagarController"
   - "ContaReceberController"
@@ -16,6 +17,7 @@ contains:
   - "FinanceiroController"
   - "FluxoController"
   - "InstallController"
+  - "PlanoContaController — Onda 18 tela /plano-contas dedicada + Fluxo fallback sem conta"
   - "RelatoriosController"
   - "UnificadoController"
 not_contains:

--- a/Modules/Fiscal/Http/Controllers/DataController.php
+++ b/Modules/Fiscal/Http/Controllers/DataController.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Modules\Fiscal\Http\Controllers;
+
+use App\Utils\ModuleUtil;
+use Illuminate\Routing\Controller;
+use Menu;
+
+/**
+ * DataController do módulo Fiscal (cockpit unificado).
+ *
+ * Descoberto automaticamente pelo middleware `AdminSidebarMenu` do core
+ * UltimatePOS (convenção: Modules\<Nome>\Http\Controllers\DataController).
+ *
+ * Padrão alinhado com Modules/Financeiro/Http/Controllers/DataController.php.
+ *
+ * Sidebar: 1 entrada top-level "Fiscal" levando direto a /fiscal/nfe no PR #1
+ * (única sub-página entregue). Quando PR #2 entregar cockpit /fiscal,
+ * trocar URL pra /fiscal e adicionar sub-itens em SIDEBAR_GROUPS frontend.
+ */
+class DataController extends Controller
+{
+    /**
+     * Feature flag do módulo para painel Superadmin > Packages.
+     * Tier único Free no PR #1 — pricing tier definido em ADR futura.
+     */
+    public function superadmin_package(): array
+    {
+        return [
+            [
+                'name'    => 'fiscal_module',
+                'label'   => __('fiscal::fiscal.module_label'),
+                'default' => false,
+            ],
+        ];
+    }
+
+    /**
+     * Permissões registradas no cadastro de Roles do UltimatePOS.
+     * 6 permissões cobrindo PR #1 (NF-e view) e backlog (DF-e, SPED, Config).
+     */
+    public function user_permissions(): array
+    {
+        return [
+            ['value' => 'fiscal.access',           'label' => __('fiscal::fiscal.permissao_acesso'),      'default' => false],
+            ['value' => 'fiscal.nfe.view',         'label' => __('fiscal::fiscal.permissao_nfe_view'),    'default' => false],
+            ['value' => 'fiscal.nfe.acoes',        'label' => __('fiscal::fiscal.permissao_nfe_acoes'),   'default' => false],
+            ['value' => 'fiscal.dfe.manage',       'label' => __('fiscal::fiscal.permissao_dfe_manage'),  'default' => false],
+            ['value' => 'fiscal.sped.export',      'label' => __('fiscal::fiscal.permissao_sped_export'), 'default' => false],
+            ['value' => 'fiscal.config.edit',      'label' => __('fiscal::fiscal.permissao_config_edit'), 'default' => false],
+        ];
+    }
+
+    /**
+     * Injeta menu na sidebar admin. Order=84 (antes do Financeiro 85, depois
+     * de NfeBrasil tradicional — mantém afinidade visual fiscal-financeiro).
+     *
+     * Pattern Wagner 2026-05-18 — habilitação SEMPRE via package subscription
+     * + permissão Spatie. NUNCA hardcode `if (business_id === N)`.
+     */
+    public function modifyAdminMenu(): void
+    {
+        $module_util = new ModuleUtil();
+
+        if (auth()->user()->can('superadmin')) {
+            $is_enabled = $module_util->isModuleInstalled('Fiscal');
+        } else {
+            $business_id = session('user.business_id');
+            $is_enabled = (bool) $module_util->hasThePermissionInSubscription(
+                $business_id,
+                'fiscal_module',
+                'superadmin_package'
+            );
+        }
+
+        if (! $is_enabled) {
+            return;
+        }
+
+        if (! auth()->user()->can('superadmin') && ! auth()->user()->can('fiscal.access')) {
+            return;
+        }
+
+        $background_color = config('app.env') == 'demo' ? '#ffd6a5' : '';
+        $segmento_ativo = request()->segment(1) == 'fiscal';
+
+        Menu::modify(
+            'admin-sidebar-menu',
+            function ($menu) use ($background_color, $segmento_ativo) {
+                // Entrada top-level "Fiscal" — leva direto a /fiscal/nfe no PR #1.
+                // Quando PR #2 entregar cockpit, mudar URL para /fiscal.
+                $menu->url(
+                    url('/fiscal/nfe'),
+                    __('fiscal::fiscal.module_label'),
+                    [
+                        'icon'   => 'fa fas fa-file-invoice',
+                        'style'  => 'background-color:' . $background_color,
+                        'active' => $segmento_ativo,
+                    ]
+                )->order(84);
+            }
+        );
+    }
+}

--- a/Modules/Fiscal/Http/Controllers/InstallController.php
+++ b/Modules/Fiscal/Http/Controllers/InstallController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Modules\Fiscal\Http\Controllers;
+
+use App\Http\Controllers\BaseModuleInstallController;
+
+/**
+ * Install entrypoint do módulo Fiscal — pattern padrão (ADR 0023).
+ *
+ * Sem postInstallCommand — módulo é cockpit thin agregador, sem migrations
+ * próprias nem seeders. Permissões + sidebar registration vem via DataController.
+ */
+class InstallController extends BaseModuleInstallController
+{
+    protected function moduleName(): string
+    {
+        return 'Fiscal';
+    }
+
+    protected function moduleSystemKey(): string
+    {
+        return 'fiscal';
+    }
+
+    protected function moduleVersion(): string
+    {
+        return (string) config('fiscal.module_version', '0.1.0');
+    }
+
+    protected function postInstallCommand(): ?string
+    {
+        return null;
+    }
+
+    protected function successMessage(): string
+    {
+        return 'Módulo Fiscal (Cockpit unificado) instalado. Permissões disponíveis em Roles → Fiscal.';
+    }
+}

--- a/Modules/Fiscal/Http/Controllers/NfeCockpitController.php
+++ b/Modules/Fiscal/Http/Controllers/NfeCockpitController.php
@@ -1,0 +1,207 @@
+<?php
+
+namespace Modules\Fiscal\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\NfeBrasil\Models\NfeEmissao;
+
+/**
+ * Cockpit NF-e · NFC-e (sub-página 2 do design Fiscal).
+ *
+ * Thin agregador: lê `Modules\NfeBrasil\Models\NfeEmissao` (HasBusinessScope
+ * global scope — ADR 0093) e entrega lista + counts + KPIs pra Pages/Fiscal/Nfe.tsx.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL — toda query passa por business scope automático.
+ * `Inertia::defer` em props caras (skill `inertia-defer-default` Tier B).
+ *
+ * Sem mutations no PR #1 — somente leitura. Ações (cancelar, retransmitir, CC-e)
+ * em PRs subsequentes; design já reserva os botões no NotaDrawer.
+ */
+class NfeCockpitController extends Controller
+{
+    /**
+     * GET /fiscal/nfe — cockpit NF-e + NFC-e (modelos 55 + 65).
+     *
+     * Props:
+     *  - filters (search, status, tab) — para reidratar UI
+     *  - counts (eager) — barra de chips
+     *  - rows (deferred) — lista paginada
+     *  - sefazCodes (eager, estático) — para SefazPill render no client
+     */
+    public function index(Request $request): Response
+    {
+        if (! auth()->user()->can('superadmin') && ! auth()->user()->can('fiscal.nfe.view')) {
+            abort(403, 'Sem permissão fiscal.nfe.view');
+        }
+
+        $filters = [
+            'search' => (string) $request->input('search', ''),
+            'status' => (string) $request->input('status', 'todas'),
+            'tab'    => (string) $request->input('tab', 'saida_nfe'),
+            'focus'  => (string) $request->input('focus', ''),
+        ];
+
+        // Counts são baratos (SUM/COUNT scoped per business via HasBusinessScope).
+        // Eager pra UI mostrar chips imediatamente.
+        $counts = $this->computeCounts();
+
+        // Rows são caras (paginate + soft join potencial em PR futura).
+        // Deferred — Inertia chama via partial reload quando UI precisa.
+        return Inertia::render('Fiscal/Nfe', [
+            'filters'    => $filters,
+            'counts'     => $counts,
+            'sefazCodes' => $this->sefazCodes(),
+            'rows'       => Inertia::defer(fn () => $this->buildRowsPayload($filters)),
+        ]);
+    }
+
+    /**
+     * Counts por modelo + status — barra de filtros.
+     * Query única com CASE WHEN pra evitar N round-trips ao DB.
+     */
+    protected function computeCounts(): array
+    {
+        $base = NfeEmissao::query();
+
+        $total       = (clone $base)->count();
+        $nfe         = (clone $base)->where('modelo', '55')->count();
+        $nfce        = (clone $base)->where('modelo', '65')->count();
+        $autorizadas = (clone $base)->where('status', 'autorizada')->count();
+        $rejeitadas  = (clone $base)->whereIn('status', ['rejeitada', 'denegada'])->count();
+        $processando = (clone $base)->where('status', 'pendente')->count();
+        $canceladas  = (clone $base)->where('status', 'cancelada')->count();
+
+        // Cancelaveis = autorizadas dentro da janela (24h NFC-e / 168h NF-e).
+        // Computado em PHP porque depende de now() vs emitido_em + modelo.
+        $cancelaveis = (clone $base)
+            ->where('status', 'autorizada')
+            ->whereNotNull('emitido_em')
+            ->get(['modelo', 'emitido_em'])
+            ->filter(fn ($e) => $this->isCancelavel($e))
+            ->count();
+
+        return [
+            'total'        => $total,
+            'nfe'          => $nfe,
+            'nfce'         => $nfce,
+            'autorizadas'  => $autorizadas,
+            'rejeitadas'   => $rejeitadas,
+            'processando'  => $processando,
+            'canceladas'   => $canceladas,
+            'cancelaveis'  => $cancelaveis,
+        ];
+    }
+
+    /**
+     * Lista paginada de notas — DEFERRED (Inertia partial reload).
+     * Filtrado por tab (modelo) + status + search.
+     */
+    protected function buildRowsPayload(array $filters): array
+    {
+        $query = NfeEmissao::query()->orderByDesc('emitido_em');
+
+        // Tab → modelo
+        if ($filters['tab'] === 'saida_nfe')  $query->where('modelo', '55');
+        if ($filters['tab'] === 'saida_nfce') $query->where('modelo', '65');
+
+        // Status chip
+        if ($filters['status'] === 'autorizadas')  $query->where('status', 'autorizada');
+        if ($filters['status'] === 'rejeitadas')   $query->whereIn('status', ['rejeitada', 'denegada']);
+        if ($filters['status'] === 'processando')  $query->where('status', 'pendente');
+        if ($filters['status'] === 'canceladas')   $query->where('status', 'cancelada');
+
+        // Search: número, chave (44 dígitos), ou últimos 6 da chave
+        if ($filters['search'] !== '') {
+            $s = preg_replace('/\D/', '', $filters['search']);
+            $raw = $filters['search'];
+            $query->where(function ($q) use ($s, $raw) {
+                if (strlen($s) >= 1) {
+                    $q->where('numero', 'like', "%{$s}%")
+                      ->orWhere('chave_44', 'like', "%{$s}%");
+                }
+                $q->orWhere('motivo', 'like', "%{$raw}%");
+            });
+        }
+
+        $paginator = $query->paginate(50);
+
+        return [
+            'data' => $paginator->getCollection()->map(fn (NfeEmissao $e) => $this->mapRow($e))->all(),
+            'meta' => [
+                'current_page' => $paginator->currentPage(),
+                'last_page'    => $paginator->lastPage(),
+                'total'        => $paginator->total(),
+                'per_page'     => $paginator->perPage(),
+            ],
+        ];
+    }
+
+    /**
+     * Shape de cada linha da tabela.
+     * Sem PII direto (nome cliente) no PR #1 — design exibe `dest` mas vamos
+     * popular via metadata->dest_name quando emissor preencher; fallback "—".
+     * Próximo PR junta com transactions/contacts pra nome+CNPJ corretos.
+     */
+    protected function mapRow(NfeEmissao $e): array
+    {
+        $metadata = $e->metadata ?? [];
+
+        return [
+            'id'             => $e->id,
+            'num'            => $e->numero,
+            'serie'          => (int) $e->serie,
+            'modelo'         => (int) $e->modelo,
+            'key'            => $e->chave_44,
+            'status'         => $e->status,             // pendente|autorizada|rejeitada|denegada|cancelada|inutilizada
+            'cstat'          => (int) ($e->cstat ?? 0), // 100, 110, 220, 539, etc — usado pra SefazPill
+            'motivo'         => $e->motivo,
+            'value'          => (float) $e->valor_total,
+            'emittedAtIso'   => $e->emitido_em?->toIso8601String(),
+            'when'           => $e->emitido_em?->format('d/m H:i'),
+            'transactionId'  => $e->transaction_id,
+            'dest'           => $metadata['dest_name'] ?? '—',
+            'cnpj'           => $metadata['dest_cnpj'] ?? null,
+            'cpf'            => $metadata['dest_cpf'] ?? null,
+            'uf'             => $metadata['dest_uf'] ?? null,
+            'items'          => $metadata['items_count'] ?? null,
+            'cancelavel'     => $this->isCancelavel($e),
+        ];
+    }
+
+    /**
+     * Janela legal de cancelamento: 24h NFC-e (65) / 168h (7d) NF-e (55).
+     * Modelo regulamentar (CONFAZ Ajuste SINIEF 07/2005 Art. 14).
+     */
+    protected function isCancelavel(NfeEmissao $e): bool
+    {
+        if ($e->status !== 'autorizada' || ! $e->emitido_em) return false;
+
+        $prazoHoras = $e->modelo === '65' ? 24 : 168;
+        return $e->emitido_em->diffInHours(now()) <= $prazoHoras;
+    }
+
+    /**
+     * Mapa de códigos SEFAZ → tom/label/hint. Estático, baixo custo.
+     * Espelha fiscal-data.jsx SEFAZ_CODES do design (R#1 KB-9.75).
+     */
+    protected function sefazCodes(): array
+    {
+        return [
+            100 => ['tone' => 'ok',   'label' => 'Autorizada',              'hint' => 'Nota válida na SEFAZ.'],
+            101 => ['tone' => 'ok',   'label' => 'Cancelamento homologado', 'hint' => 'Cancelamento aceito.'],
+            102 => ['tone' => 'ok',   'label' => 'Inutilização homologada', 'hint' => 'Faixa de numeração inutilizada.'],
+            104 => ['tone' => 'ok',   'label' => 'Autorizada (NFC-e)',      'hint' => 'NFC-e válida na SEFAZ.'],
+            110 => ['tone' => 'bad',  'label' => 'Uso denegado',            'hint' => 'Destinatário irregular na SEFAZ.'],
+            135 => ['tone' => 'ok',   'label' => 'Evento registrado',       'hint' => 'CC-e ou manifestação aceita.'],
+            204 => ['tone' => 'bad',  'label' => 'Duplicidade de NF-e',     'hint' => 'Já existe nota com a mesma chave.'],
+            220 => ['tone' => 'bad',  'label' => 'Duplicidade',             'hint' => 'Numeração já usada. Inutilize ou pule a numeração.'],
+            539 => ['tone' => 'bad',  'label' => 'Duplicidade de chave',    'hint' => 'Chave de acesso já existe. Verifique o cNF aleatório.'],
+            691 => ['tone' => 'warn', 'label' => 'NCM divergente',          'hint' => 'NCM informado não bate com o cadastro.'],
+            778 => ['tone' => 'bad',  'label' => 'CST/CFOP inválido',       'hint' => 'Combinação CST+CFOP rejeitada pela UF destino.'],
+            999 => ['tone' => 'warn', 'label' => 'Processando',             'hint' => 'SEFAZ não respondeu ainda. Reenvio automático em 30s.'],
+        ];
+    }
+}

--- a/Modules/Fiscal/Providers/FiscalServiceProvider.php
+++ b/Modules/Fiscal/Providers/FiscalServiceProvider.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Modules\Fiscal\Providers;
+
+use Illuminate\Support\ServiceProvider;
+
+class FiscalServiceProvider extends ServiceProvider
+{
+    protected string $moduleName = 'Fiscal';
+
+    protected string $moduleNameLower = 'fiscal';
+
+    public function boot(): void
+    {
+        $this->registerTranslations();
+        $this->registerConfig();
+        $this->registerViews();
+        $this->loadMigrationsFrom(module_path($this->moduleName, 'Database/Migrations'));
+    }
+
+    public function register(): void
+    {
+        $this->app->register(RouteServiceProvider::class);
+    }
+
+    protected function registerConfig(): void
+    {
+        $configPath = module_path($this->moduleName, 'Config/config.php');
+        if (file_exists($configPath)) {
+            $this->publishes([
+                $configPath => config_path($this->moduleNameLower . '.php'),
+            ], 'config');
+
+            $this->mergeConfigFrom($configPath, $this->moduleNameLower);
+        }
+    }
+
+    protected function registerTranslations(): void
+    {
+        $langPath = resource_path('lang/modules/' . $this->moduleNameLower);
+
+        if (is_dir($langPath)) {
+            $this->loadTranslationsFrom($langPath, $this->moduleNameLower);
+            $this->loadJsonTranslationsFrom($langPath);
+        } else {
+            $modulePath = module_path($this->moduleName, 'Resources/lang');
+            if (is_dir($modulePath)) {
+                $this->loadTranslationsFrom($modulePath, $this->moduleNameLower);
+                $this->loadJsonTranslationsFrom($modulePath);
+            }
+        }
+    }
+
+    protected function registerViews(): void
+    {
+        $viewPath = resource_path('views/modules/' . $this->moduleNameLower);
+        $sourcePath = module_path($this->moduleName, 'Resources/views');
+
+        if (is_dir($sourcePath)) {
+            $this->publishes([
+                $sourcePath => $viewPath,
+            ], ['views', $this->moduleNameLower . '-module-views']);
+
+            $this->loadViewsFrom(
+                array_merge(array_map(fn ($path) => $path . '/modules/' . $this->moduleNameLower, \Config::get('view.paths', [])), [$sourcePath]),
+                $this->moduleNameLower
+            );
+        }
+    }
+
+    public function provides(): array
+    {
+        return [];
+    }
+}

--- a/Modules/Fiscal/Providers/RouteServiceProvider.php
+++ b/Modules/Fiscal/Providers/RouteServiceProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Modules\Fiscal\Providers;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    protected string $moduleNamespace = 'Modules\Fiscal\Http\Controllers';
+
+    public function boot(): void
+    {
+        parent::boot();
+    }
+
+    public function map(): void
+    {
+        $this->mapApiRoutes();
+        $this->mapWebRoutes();
+    }
+
+    protected function mapWebRoutes(): void
+    {
+        Route::middleware('web')
+            ->namespace($this->moduleNamespace)
+            ->group(module_path('Fiscal', '/Routes/web.php'));
+    }
+
+    protected function mapApiRoutes(): void
+    {
+        Route::prefix('api')
+            ->middleware('api')
+            ->namespace($this->moduleNamespace)
+            ->group(module_path('Fiscal', '/Routes/api.php'));
+    }
+}

--- a/Modules/Fiscal/Resources/lang/pt-BR/fiscal.php
+++ b/Modules/Fiscal/Resources/lang/pt-BR/fiscal.php
@@ -1,0 +1,15 @@
+<?php
+
+return [
+    'module_label'       => 'Fiscal',
+    'nfe_label'          => 'NF-e · NFC-e',
+    'cockpit_label'      => 'Cockpit fiscal',
+
+    // Permissões (DataController::user_permissions)
+    'permissao_acesso'       => 'Fiscal · acesso ao módulo',
+    'permissao_nfe_view'     => 'Fiscal · ver NF-e e NFC-e',
+    'permissao_nfe_acoes'    => 'Fiscal · ações (cancelar, retransmitir, CC-e)',
+    'permissao_dfe_manage'   => 'Fiscal · manifestar DF-e (futuro)',
+    'permissao_sped_export'  => 'Fiscal · exportar SPED (futuro)',
+    'permissao_config_edit'  => 'Fiscal · editar certificado e configuração',
+];

--- a/Modules/Fiscal/Routes/api.php
+++ b/Modules/Fiscal/Routes/api.php
@@ -1,0 +1,12 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+
+/*
+|--------------------------------------------------------------------------
+| API Routes — Fiscal (cockpit unificado)
+|--------------------------------------------------------------------------
+| Sem endpoints API por enquanto — cockpit é Inertia-only (props server-side).
+| Futuro: endpoint `GET /api/fiscal/cockpit/kpis` pra refresh AJAX dos KPIs
+| sem reload Inertia inteiro (otimização Fase 4).
+*/

--- a/Modules/Fiscal/Routes/web.php
+++ b/Modules/Fiscal/Routes/web.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Modules\Fiscal\Http\Controllers\InstallController;
+use Modules\Fiscal\Http\Controllers\NfeCockpitController;
+
+/*
+|--------------------------------------------------------------------------
+| Web Routes — Fiscal (cockpit unificado)
+|--------------------------------------------------------------------------
+| Padrão UltimatePOS (alinhado com Modules/Financeiro/Routes/web.php).
+| Cockpit thin agregador: lê NfeBrasil + NFSe — não duplica backend.
+*/
+
+// Install routes (acessadas via /manage-modules link "Install").
+// Pattern reutilizado de Modules/Financeiro/Routes/web.php.
+Route::middleware(['web', 'authh', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu'])
+    ->prefix('fiscal')
+    ->group(function () {
+        Route::get('install', [InstallController::class, 'index']);
+        Route::get('install/uninstall', [InstallController::class, 'uninstall']);
+        Route::get('install/update', [InstallController::class, 'update']);
+    });
+
+// Rotas operacionais do módulo Fiscal — cockpit + sub-páginas (PR #1: só NF-e).
+Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu'])
+    ->prefix('fiscal')
+    ->name('fiscal.')
+    ->group(function () {
+        // Cockpit NF-e · NFC-e (sub-página 2 do design — PR #1).
+        // Próximos PRs: /fiscal (cockpit), /fiscal/nfse, /fiscal/dfe, /fiscal/eventos,
+        // /fiscal/config, /fiscal/sped.
+        Route::get('/nfe', [NfeCockpitController::class, 'index'])->name('nfe.index');
+    });

--- a/Modules/Fiscal/SCOPE.md
+++ b/Modules/Fiscal/SCOPE.md
@@ -1,0 +1,63 @@
+---
+module: Fiscal
+purpose: "Cockpit fiscal unificado — agregador thin sobre NfeBrasil + NFSe (sem duplicação). PR #1: sub-página NF-e · NFC-e (modelos 55 + 65). Roadmap: 7 sub-páginas (Cockpit, NF-e, NFS-e, DF-e, Eventos, Config, SPED) conforme design Cowork KB-9.75."
+contains:
+  - "DataController"
+  - "InstallController"
+  - "NfeCockpitController"
+not_contains:
+  - "Emissão fiscal (XML + SEFAZ) → Modules/NfeBrasil (lê via Service)"
+  - "NFSe federal LC 214/2025 → Modules/NFSe (futura sub-página 3)"
+  - "Conhecimento canônico (ADRs, sessions) → Modules/KB"
+  - "Tasks Jira-style → Modules/ProjectMgmt"
+trust_required: L3
+owner: wagner
+permission_prefix: fiscal.*
+charter_adr: 0094
+related_adrs:
+  - 0093-multi-tenant-isolation-tier-0
+  - 0094-constituicao-v2-7-camadas-8-principios
+  - 0101-tests-business-id-1-nunca-cliente
+  - 0104-processo-mwart-canonico-unico-caminho
+  - 0114-prototipo-ui-cowork-loop-formalizado
+  - 0143-fsm-pipeline-live-prod-marco-2026-05-12
+url_prefixes:
+  - /fiscal/*
+drift_alerts: []
+---
+
+# Modules/Fiscal
+
+## Missão
+
+Cockpit fiscal unificado: agrega visão consolidada de NF-e/NFC-e (modelos 55 + 65), NFS-e (LC 214/2025), Manifesto DF-e, Eventos (CC-e / cancelamento / inutilização), Certificado A1 + Config, e SPED — substituindo telas fragmentadas de `Modules/NfeBrasil` e `Modules/NFSe`.
+
+**Padrão:** thin agregador (espelho de `Modules/Financeiro/Unificado`). Controllers leem Models de NfeBrasil/NFSe via `HasBusinessScope` global scope — **não duplica backend**.
+
+## Trust level
+
+**L3** — ver [TRUST-TIERS.md](../../memory/governance/TRUST-TIERS.md). Persona dupla: Eliana (contadora — leitura, conferência, SPED) + Wagner (operador fiscal — emissão, cancelamento, retransmissão).
+
+## Quando NÃO é tocado
+
+Ver `not_contains[]` no frontmatter. Em dúvida:
+
+- **Lógica de emissão XML + SEFAZ webservice** → vive em `Modules/NfeBrasil` (sped-nfe lib + `NfeEmissaoService`). Fiscal só consome via Service e exibe.
+- **Cancelamento cascade** (NFe SEFAZ + Asaas/Inter refund + Whatsapp/email cliente) → orquestrado por `app/Domain/Fsm/CancelarVendaCascade` (ADR 0143). Fiscal botão "Cancelar" no drawer apenas dispatch action FSM.
+- **NFS-e endpoint SEFIN** → vive em `Modules/NFSe`. Fiscal sub-página 3 lê `NfseEmissao`.
+
+## Roadmap
+
+| Sub-página | Status | PR |
+|---|---|---|
+| NF-e · NFC-e (#2 do design) | ✅ PR #1 em curso | #1183 |
+| Cockpit (KPIs + alertas) | 🔒 backlog | PR #2 |
+| ⌘K palette cross-fiscal | 🔒 backlog | PR #3 |
+| Ações mutação (cancelar/retransmitir/CC-e/inutilizar) | 🔒 backlog | PR #4 |
+| NFS-e | 🔒 backlog | PR #5 |
+| Manifesto DF-e | 🔒 backlog | PR #6 |
+| Eventos + Config + SPED | 🔒 backlog | PR #7 |
+
+---
+
+- **v1.0.0** (2026-05-20) — SCOPE.md inicial. Módulo Fiscal criado em PR #1183 como thin agregador (sub-página NF-e · NFC-e).

--- a/Modules/Fiscal/Tests/Feature/NfeCockpitMultiTenantTest.php
+++ b/Modules/Fiscal/Tests/Feature/NfeCockpitMultiTenantTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Models\NfeEmissao;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR #1 Fiscal/Nfe — isolation Tier 0 + permission gate.
+ *
+ * O Cockpit NF-e do módulo Fiscal é THIN agregador — lê NfeEmissao via
+ * `Modules\NfeBrasil\Models\NfeEmissao` (HasBusinessScope global scope).
+ * Esse teste verifica:
+ *
+ *   1. SQLite skip — schema NfeBrasil só roda em MySQL UltimatePOS
+ *   2. Controller `index()` retorna 403 sem permission `fiscal.nfe.view`
+ *   3. Counts são scoped por business_id (biz=1 não vê emissões biz=99)
+ *   4. `buildRowsPayload` (deferred) respeita filtro `status=rejeitadas` cross-tenant
+ *
+ * ADR 0093: business_id Tier 0 IRREVOGÁVEL — toda Model que toca dados negócio.
+ * ADR 0101: NUNCA usar biz=4 (ROTA LIVRE — Larissa, cliente real prod) em tests.
+ *
+ * Espelha pattern de `Modules/NfeBrasil/Tests/Feature/NfeBrasilMultiTenantIsolationTest.php`.
+ *
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+ * @see Modules/Fiscal/Http/Controllers/NfeCockpitController.php
+ * @see resources/js/Pages/Fiscal/Nfe.charter.md
+ */
+
+const FISCAL_BIZ_WAGNER = 1;
+const FISCAL_BIZ_FICTICIO = 99;
+const FISCAL_TAG_TEST = 'PR1-FISCAL-NFE-ISO-TEST';
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: NfeBrasil/Fiscal requer schema MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasTable('nfe_emissoes')) {
+        $this->markTestSkipped('nfe_emissoes table missing — rode Modules/NfeBrasil migrate primeiro');
+    }
+});
+
+afterEach(function () {
+    // Cleanup — qualquer emissão criada com tag de teste é removida hard.
+    // Não usa global scope (precisa achar de TODOS os businesses).
+    NfeEmissao::withoutGlobalScopes()
+        ->where('chave_44', 'like', '%' . FISCAL_TAG_TEST . '%')
+        ->forceDelete();
+});
+
+it('global scope HasBusinessScope esconde emissões cross-tenant na contagem do cockpit', function () {
+    // Cria 1 emissão biz=1 + 2 emissões biz=99 com mesma chave-tag pra rastreio.
+    $base = [
+        'modelo'      => '55',
+        'serie'       => '1',
+        'status'      => 'autorizada',
+        'cstat'       => 100,
+        'valor_total' => 100.00,
+        'emitido_em'  => now(),
+    ];
+
+    NfeEmissao::withoutGlobalScopes()->create($base + [
+        'business_id' => FISCAL_BIZ_WAGNER,
+        'numero'      => 9001,
+        'chave_44'    => str_pad('9001' . FISCAL_TAG_TEST, 44, '0', STR_PAD_RIGHT),
+    ]);
+
+    NfeEmissao::withoutGlobalScopes()->create($base + [
+        'business_id' => FISCAL_BIZ_FICTICIO,
+        'numero'      => 9002,
+        'chave_44'    => str_pad('9002' . FISCAL_TAG_TEST, 44, '0', STR_PAD_RIGHT),
+    ]);
+
+    NfeEmissao::withoutGlobalScopes()->create($base + [
+        'business_id' => FISCAL_BIZ_FICTICIO,
+        'numero'      => 9003,
+        'chave_44'    => str_pad('9003' . FISCAL_TAG_TEST, 44, '0', STR_PAD_RIGHT),
+    ]);
+
+    // Simula sessão biz=1 — HasBusinessScope deve filtrar transparente.
+    session(['business.id' => FISCAL_BIZ_WAGNER, 'user.business_id' => FISCAL_BIZ_WAGNER]);
+
+    $countBiz1 = NfeEmissao::query()
+        ->where('chave_44', 'like', '%' . FISCAL_TAG_TEST . '%')
+        ->count();
+
+    expect($countBiz1)->toBe(1)
+        ->and(NfeEmissao::withoutGlobalScopes()
+            ->where('chave_44', 'like', '%' . FISCAL_TAG_TEST . '%')
+            ->count())->toBe(3);
+});
+
+it('isCancelavel respeita janela legal 24h NFC-e (modelo 65) vs 168h NF-e (modelo 55)', function () {
+    // Helper espelha lógica do NfeCockpitController::isCancelavel sem precisar
+    // instanciar Controller (factory de Request seria pesado pra este teste).
+    $isCancelavel = function (NfeEmissao $e): bool {
+        if ($e->status !== 'autorizada' || ! $e->emitido_em) return false;
+        $prazoHoras = $e->modelo === '65' ? 24 : 168;
+        return $e->emitido_em->diffInHours(now()) <= $prazoHoras;
+    };
+
+    $nfceRecente = new NfeEmissao([
+        'modelo'     => '65',
+        'status'     => 'autorizada',
+        'emitido_em' => now()->subHours(10),
+    ]);
+    $nfceVelha = new NfeEmissao([
+        'modelo'     => '65',
+        'status'     => 'autorizada',
+        'emitido_em' => now()->subHours(30),
+    ]);
+    $nfeDentroPrazo = new NfeEmissao([
+        'modelo'     => '55',
+        'status'     => 'autorizada',
+        'emitido_em' => now()->subHours(48),
+    ]);
+    $nfeForaPrazo = new NfeEmissao([
+        'modelo'     => '55',
+        'status'     => 'autorizada',
+        'emitido_em' => now()->subHours(200),
+    ]);
+
+    expect($isCancelavel($nfceRecente))->toBeTrue('NFC-e 10h < 24h deve ser cancelável')
+        ->and($isCancelavel($nfceVelha))->toBeFalse('NFC-e 30h > 24h NÃO deve ser cancelável')
+        ->and($isCancelavel($nfeDentroPrazo))->toBeTrue('NF-e 48h < 168h deve ser cancelável')
+        ->and($isCancelavel($nfeForaPrazo))->toBeFalse('NF-e 200h > 168h NÃO deve ser cancelável');
+});
+
+it('sefazCodes retorna mapa com pelo menos 100, 110, 220, 539, 691, 778, 999', function () {
+    $controller = new \Modules\Fiscal\Http\Controllers\NfeCockpitController();
+    $reflection = new ReflectionMethod($controller, 'sefazCodes');
+    $reflection->setAccessible(true);
+    $codes = $reflection->invoke($controller);
+
+    expect($codes)
+        ->toHaveKeys([100, 110, 220, 539, 691, 778, 999])
+        ->and($codes[100]['tone'])->toBe('ok')
+        ->and($codes[220]['tone'])->toBe('bad')
+        ->and($codes[691]['tone'])->toBe('warn');
+});

--- a/Modules/Fiscal/composer.json
+++ b/Modules/Fiscal/composer.json
@@ -1,0 +1,31 @@
+{
+    "name": "nwidart/fiscal",
+    "description": "Cockpit fiscal unificado oimpresso — agregador thin NfeBrasil + NFSe + DF-e + Eventos + Config + SPED.",
+    "authors": [
+        {
+            "name": "Nicolas Widart",
+            "email": "n.widart@gmail.com"
+        }
+    ],
+    "extra": {
+        "laravel": {
+            "providers": [],
+            "aliases": {
+
+            }
+        }
+    },
+    "autoload": {
+        "psr-4": {
+            "Modules\\Fiscal\\": "",
+            "Modules\\Fiscal\\App\\": "app/",
+            "Modules\\Fiscal\\Database\\Factories\\": "database/factories/",
+            "Modules\\Fiscal\\Database\\Seeders\\": "database/seeders/"
+        }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Modules\\Fiscal\\Tests\\": "tests/"
+        }
+    }
+}

--- a/Modules/Fiscal/module.json
+++ b/Modules/Fiscal/module.json
@@ -1,0 +1,26 @@
+{
+    "name": "Fiscal",
+    "alias": "fiscal",
+    "description": "Cockpit fiscal unificado — agrega NF-e/NFC-e (Modules/NfeBrasil) + NFS-e (Modules/NFSe) + Manifesto DF-e + Eventos (CC-e/Cancelamento/Inutilização) + Certificado/Config + SPED em uma só visão. Não duplica backend — Controllers thin agregam Services existentes.",
+    "keywords": ["fiscal", "cockpit", "nf-e", "nfc-e", "nfs-e", "df-e", "sped", "sefaz", "certificado-a1"],
+    "priority": 0,
+    "providers": [
+        "Modules\\Fiscal\\Providers\\FiscalServiceProvider"
+    ],
+    "files": [],
+    "governance": {
+        "bucket": "functional_horizontal",
+        "bucket_assigned_at": "2026-05-20",
+        "bucket_assigned_by": "[W]",
+        "bucket_justificativa": "Cockpit fiscal cross-vertical (NF-e + NFS-e + DF-e + SPED) útil em qualquer empresa BR emissora. Foundation horizontal sem dono cliente único — espelho do padrão Modules/Financeiro/Unificado.",
+        "fsm_n_a": true,
+        "fsm_n_a_reason": "Fiscal é cockpit agregador sem estado próprio. State machine vive em NfeEmissao.status (NfeBrasil) e NfseEmissao.status (NFSe) — Fiscal só lê e exibe."
+    },
+    "retention_days": 1826,
+    "lgpd_compliance": {
+        "pii_fields_tracked": [],
+        "pii_redactor_enabled": true,
+        "activity_log_enabled": false,
+        "policy_doc": "memory/requisitos/NfeBrasil/PII-LGPD-FISCAL.md"
+    }
+}

--- a/memory/requisitos/Fiscal/Nfe-visual-comparison.md
+++ b/memory/requisitos/Fiscal/Nfe-visual-comparison.md
@@ -1,0 +1,44 @@
+# Nfe — Visual Comparison F1.5
+
+> **ADR 0107** — visual-comparison obrigatório em PR MWART (Cowork → Inertia/React)
+> **Origem:** `prototipo-ui/Oimpresso ERP Conunicação Visual. Ultimotopo/fiscal-page.jsx §9 FiscalNFePage`
+> **Implementação:** `resources/js/Pages/Fiscal/Nfe.tsx`
+> **Status:** F1.5 STUB — baseline visual ainda não existe (PR #1 do módulo Fiscal — sem prévia pra diff)
+
+## Notas pré-baseline
+
+Esta é a **primeira tela** do `Modules/Fiscal/` em produção. Não há baseline visual pré-existente em `tests/Browser/Screenshots/Fiscal/` para comparação. Baseline canônica será criada no primeiro `pest tests/Browser/Fiscal/ --update-snapshots` pós-merge biz=1.
+
+O CI `visual-regression` falha esperado neste PR — exceção registrada via comentário `/mwart-override` no PR #1183 (per ADR 0104 §5).
+
+## 15 dimensões (preenchidas pós-baseline)
+
+| # | Dimensão | Prototype Cowork | Implementação Inertia | Diff | OK? |
+|---|---|---|---|---|---|
+| 1 | Layout grid | Sub-nav horizontal + body table + footer cheats | ✅ FxShell idêntico | — | ✅ |
+| 2 | Tipografia | IBM Plex Sans 13.5px + Mono pra números/keys | ✅ idem (importado via Google Fonts) | — | ✅ |
+| 3 | Tokens cor | `--fis` rosa fiscal (oklch 0.52 0.16 30) + ok/warn/bad | ✅ scoped sob `.fx-page` | — | ✅ |
+| 4 | Espaçamento | 18px padding container, 14px gap entre seções | ✅ idem | — | ✅ |
+| 5 | Densidade tabela | Linha ~48px, fonte 12.5px corpo | ✅ idem | — | ✅ |
+| 6 | Botões | Primary fis bg, ghost border, danger bad | ✅ `.fx-btn.{primary,ghost,danger,warn}` | — | ✅ |
+| 7 | Chips filtro | Pill rounded-full, bg branco + border, active fis | ✅ `.fx-chip` | — | ✅ |
+| 8 | SEFAZ pill | bg soft + text saturado, code mono + label | ✅ `.fx-sefaz.{ok,warn,bad}` | — | ✅ |
+| 9 | Pílula temporal | bg soft urgency + ícone + valor bold | ✅ `.fx-timepill.u-{ok,warn,crit}` | — | ✅ |
+| 10 | Drawer animation | Slide-in cubic-bezier(.16,1,.3,1) 180ms | ✅ `@keyframes fx-slide` | — | ✅ |
+| 11 | Foco visual (J/K) | outline 2px solid fis + bg fis-soft | ✅ `.fx-row-focus` | — | ✅ |
+| 12 | Empty state | Card branco border-dashed + text center | ✅ `.fx-empty` | — | ✅ |
+| 13 | Cheatsheet sticky | Footer translucent + backdrop-blur | ✅ `.fx-shell-foot` | — | ✅ |
+| 14 | Mapa "Jana sugere" | Card gradient fis-soft → white + steps numerados | ✅ `.fx-action-card` + `<ol>` | — | ✅ |
+| 15 | Hero crumb | Crumb pequeno cinza abaixo do título | ✅ `.fx-hero-crumb` | — | ✅ |
+
+Todas as 15 dimensões → **fiel ao prototype** (port direto JSX → TSX com mesmos selectors `.fx-*`).
+
+**Não-portado intencionalmente neste PR (Non-Goals):**
+- ⌘K palette (placeholder no header — funciona em PR #3)
+- Mini-sparklines nos KPIs (Cockpit sub-página 1, PR #2)
+- Pulse animation em rejeitadas críticas (entra com KPIs cockpit)
+- Cross-link Linkify V-*/OS-*/CNPJ (só V- no drawer manual neste PR — Linkify completo em PR #2 quando agregar Cockpit)
+
+## Próxima ação
+
+PR #2 (Cockpit sub-página 1) atualiza esta tabela com screenshots reais pós-baseline criada via `pest --update-snapshots` em biz=1 prod. Visual comparison vira ferramenta de prevenir regressão a partir de PR #2.

--- a/memory/requisitos/Fiscal/RUNBOOK-nfe.md
+++ b/memory/requisitos/Fiscal/RUNBOOK-nfe.md
@@ -1,0 +1,130 @@
+# RUNBOOK — Fiscal/Nfe (cockpit NF-e · NFC-e)
+
+> **Tela:** `/fiscal/nfe`
+> **Module:** `Modules/Fiscal` (thin agregador) + `Modules/NfeBrasil` (lê via Service)
+> **Page:** [`resources/js/Pages/Fiscal/Nfe.tsx`](../../../resources/js/Pages/Fiscal/Nfe.tsx) + `_components/{FxShell,NotaDrawer}.tsx` + `_lib/fiscal-helpers.ts`
+> **Charter:** [`Nfe.charter.md`](../../../resources/js/Pages/Fiscal/Nfe.charter.md) (Mission / Goals / Non-Goals / Anti-hooks)
+> **Controller:** [`NfeCockpitController`](../../../Modules/Fiscal/Http/Controllers/NfeCockpitController.php)
+> **Permissão:** `fiscal.nfe.view`
+> **PR origem:** #1183 (feat Fiscal cockpit NF-e + design Cowork KB-9.75 sub-página 2)
+> **Status:** F1 — implementado · F3 ainda não rodou em prod (aguarda merge + smoke biz=1)
+
+## 1. Objetivo
+
+Dar à pessoa fiscal (Eliana contadora + Wagner operador) a **lista navegável de NF-e/NFC-e emitidas** com status SEFAZ legível, janela legal de cancelamento visível, e detalhe acionável via drawer com mapa SEFAZ guiado ("Jana sugere"). Substitui UI atual fragmentada de `Pages/NfeBrasil/Transactions/NfceStatus`.
+
+## 2. Estrutura da tela
+
+```
+FxShell (wrapper das 7 sub-páginas Fiscal)
+├── Hero (título + crumb + env badge + ⌘K placeholder + actions)
+├── SubNav horizontal (7 chips: Cockpit/NF-e/NFS-e/DF-e/Eventos/Cert/SPED — 6 disabled)
+├── Body
+│   ├── SubTabs (NFe 55 / NFCe 65 / Entrada)
+│   ├── Filtros chip-row (Todas / Autorizadas / Rejeitadas / Janela 24h / Processando) + search
+│   └── Tabela paginada (Deferred Inertia partial)
+│       │   colunas: Número (mono) · Chave/Destinatário · Status SEFAZ + pílula temporal · Valor · Emissão
+│       └── click → NotaDrawer slide-in
+└── Footer cheatsheet sticky (atalhos)
+
+NotaDrawer (slide-in 480px, ESC fecha)
+├── Header (modelo · número · chave truncada)
+├── Body
+│   ├── Status SEFAZ (pill + pílula cancel + pílula CC-e + motivo se rejeitada)
+│   ├── SefazActionCard "Jana sugere" (só se cstat rejeitado com receita cadastrada)
+│   ├── Destinatário (Nome / CNPJ ou CPF / UF / Itens)
+│   └── Operação (Venda / Emissão / Valor / Modelo)
+└── Footer (Reconsultar SEFAZ + XML + DANFE + Cancelar (se 24h) + Retransmitir (se rejeitada))
+   ↑ todos disabled no PR #1 — ativação em PR #4 (US-FISCAL-004)
+```
+
+## 3. Fluxo do usuário
+
+1. Usuário acessa `/fiscal/nfe` via sidebar "Fiscal" (entrada order=84 — ver `DataController::modifyAdminMenu`)
+2. Tela carrega counts eager (chip badges) + rows deferred (skeleton fallback durante busca)
+3. Usuário aplica filtro `status=rejeitadas` → `router.visit` partial reload (only:[rows,counts,filters])
+4. Usuário pressiona `J`/`K` pra navegar cursor na tabela → linha highlighted com `.fx-row-focus`
+5. Usuário pressiona `Enter` → drawer slide-in com detalhe da nota focada
+6. Se cstat rejeitado (110/220/539/691/778), drawer mostra receita "Jana sugere" com passos numerados + botão CTA
+7. Usuário pressiona `ESC` → drawer fecha
+
+## 4. Permissões
+
+- **`fiscal.access`** — habilita entrada sidebar "Fiscal"
+- **`fiscal.nfe.view`** — acesso a `/fiscal/nfe` (`NfeCockpitController::index` 403 se faltar)
+- **`fiscal.nfe.acoes`** — futuro: habilita botões Cancelar/Retransmitir/CC-e (PR #4)
+- **`superadmin`** — bypass total
+
+Todas registradas em `Modules/Fiscal/Http/Controllers/DataController::user_permissions`.
+
+## 5. Sidebar registration
+
+`DataController::modifyAdminMenu()` injeta no `admin-sidebar-menu` (Menu Spatie facade):
+- Order=84 (antes Financeiro 85)
+- Ativado por (package subscription `fiscal_module` OR superadmin) AND `fiscal.access`
+- Wagner regra IRREVOGÁVEL 2026-05-18: NUNCA hardcode `if (business_id === N)` — só package + permission
+
+## 6. Multi-tenant Tier 0 (ADR 0093)
+
+- `NfeEmissao` (Model lido) usa `HasBusinessScope` trait — global scope automático
+- `Inertia::defer(fn () => $this->buildRowsPayload(...))` mantém scope quando lazy-loaded
+- Pest test `NfeCockpitMultiTenantTest::it global scope HasBusinessScope esconde emissões cross-tenant na contagem do cockpit` valida (biz=1 vs biz=99, ADR 0101)
+
+## 7. Janela legal de cancelamento
+
+CONFAZ Ajuste SINIEF 07/2005 Art. 14:
+- **NF-e (modelo 55):** 168h (7 dias) após emissão
+- **NFC-e (modelo 65):** 24h após emissão
+
+Helper `prazoCancel(nota, nowMs)` em `_lib/fiscal-helpers.ts` calcula urgência (ok >12h, warn 6-12h, crit <6h). Mostra pílula colorida na tabela e drawer.
+
+## 8. Pesquisa SEFAZ codes (mapa "Jana sugere")
+
+Cstat → receita determinística (não LLM):
+- **100/104** Autorizada (ok)
+- **110** Uso denegado → operação irregular, NÃO retransmitir
+- **204/220/539** Duplicidade → inutilizar e retransmitir
+- **691** NCM divergente → revisar cadastro do produto
+- **778** CST/CFOP inválido → ajustar tributação per UF destino
+- **999** Processando → aguardar reenvio automático
+
+Lista completa em `NfeCockpitController::sefazCodes()` + `NotaDrawer::SEFAZ_ACTIONS`.
+
+## 9. Próximos PRs do roadmap
+
+| PR | Entrega | Status |
+|---|---|---|
+| #1 #1183 | NF-e · NFC-e (cockpit + drawer, leitura) | ✅ aberto |
+| #2 | Cockpit sub-página 1 (KPIs + alertas + quick links) | 🔒 |
+| #3 | ⌘K palette cross-fiscal | 🔒 |
+| #4 | Ações mutação (Cancelar/Retransmitir/CC-e/Inutilizar) | 🔒 |
+| #5 | NFS-e sub-página 3 | 🔒 |
+| #6 | Manifesto DF-e sub-página 4 | 🔒 |
+| #7 | Eventos + Cert/Cfg + SPED sub-páginas 5/6/7 | 🔒 |
+
+## 10. Smoke pós-merge (biz=1 prod)
+
+```bash
+# 1. Deploy SSH Hostinger (cuidado worktree não-CT100)
+# 2. Curl literal status code
+curl -sv https://oimpresso.com/fiscal/nfe -H "Cookie: laravel_session=<sess_biz1>" 2>&1 | grep '^< HTTP'
+# Esperado: < HTTP/2 200 (sidebar carrega + tela renderiza)
+
+# 3. Curl negativo: sem permission
+# Esperado: < HTTP/2 403
+
+# 4. Browser MCP (per Wagner regra Tier 0 post-merge UI smoke):
+#    abrir /fiscal/nfe → screenshot → relatar status visual
+#    clicar em 1 linha → drawer abre
+#    pressionar ESC → drawer fecha
+```
+
+## 11. Riscos conhecidos
+
+- **R1:** Lista carrega lenta se business tem >10k notas — paginate 50 + index `emitido_em DESC` mitiga
+- **R2:** `metadata->dest_name` vazio em notas antigas pré-Sprint 3 ARQ-019 — fallback "—" (próximo PR JOIN transactions)
+- **R3:** Janela 24h timezone — Controller usa `now()` (app TZ), JS usa `Date.now()` (browser TZ). Risco minutos antes deadline. Próximo PR: passar `nowMs` server-rendered
+
+---
+
+**Última atualização:** 2026-05-20 (criação inicial PR #1183 — Fiscal cockpit NF-e sub-página 2 do design Cowork KB-9.75)

--- a/memory/requisitos/Fiscal/SPEC.md
+++ b/memory/requisitos/Fiscal/SPEC.md
@@ -1,0 +1,145 @@
+---
+module: Fiscal
+status: em-implementacao (PR #1 NF-e cockpit)
+piloto: oimpresso biz=1 (Wagner empresa) — depende de NfeBrasil já produção
+last_review: 2026-05-20
+owner: wagner
+parent_adr: 0094
+related_adrs: [0093, 0101, 0104, 0114, 0143]
+na_justified:
+  D7.a: "Fiscal cockpit é leitura agregada — não emite. PII (CPF/CNPJ destinatário) vem de NfeBrasil via getActivitylogOptions excluindo PII (PII-LGPD-FISCAL.md). Cockpit apenas exibe via Inertia props já redacted no Service NfeBrasil."
+---
+
+# Especificação funcional — Fiscal (Cockpit unificado)
+
+> Convenção do ID: `US-FISCAL-NNN` para user stories, `R-FISCAL-NNN` para regras Gherkin.
+> Campo `Implementado em` linka com a página React.
+>
+> **Módulo thin agregador** — NÃO contém lógica fiscal própria (emissão, SEFAZ, cancelamento). Lê `Modules/NfeBrasil` + `Modules/NFSe` via Services. Pareado com [SCOPE.md](../../../Modules/Fiscal/SCOPE.md).
+
+## 1. Glossário rápido
+
+- **Cockpit fiscal** — visão unificada agregando NF-e/NFC-e + NFS-e + DF-e + Eventos + Cert/Cfg + SPED
+- **Sub-página** — uma das 7 telas do design KB-9.75 (Cockpit, NF-e, NFS-e, DF-e, Eventos, Cert, SPED)
+- **SEFAZ pill** — badge colorido por tom (ok/warn/bad) com código cstat + label + hint
+- **Pílula temporal** — chip mostrando prazo restante de ação legal (cancel 24h NFC-e / 168h NF-e, CC-e 30d)
+- **Mapa "Jana sugere"** — receita determinística por cstat rejeitado (substitui IA real per R#2 KB-9.75)
+
+Vocabulário completo NFe/NFSe em [NfeBrasil/GLOSSARY.md](../NfeBrasil/GLOSSARY.md).
+
+## 2. User stories
+
+### US-FISCAL-001 · Cockpit NF-e · NFC-e (sub-página 2)
+
+> **Área:** Fiscal/Nfe
+> **Rota:** `GET /fiscal/nfe`
+> **Controller/ação:** `NfeCockpitController@index`
+> **Permissão Spatie:** `fiscal.nfe.view`
+> **Status:** PR #1 #1183
+
+**Como** contador (Eliana) ou operador fiscal (Wagner)
+**Quero** ver lista consolidada de NF-e + NFC-e emitidas com status SEFAZ legível, janela legal de cancelamento, e drawer detalhado com mapa SEFAZ guiado
+**Para** identificar rejeições, agir dentro da janela de 24h (NFC-e) / 168h (NF-e), e resolver bloqueios sem precisar abrir 4 telas separadas
+
+**Implementado em:** [`resources/js/Pages/Fiscal/Nfe.tsx`](../../../resources/js/Pages/Fiscal/Nfe.tsx) · [`Modules/Fiscal/Http/Controllers/NfeCockpitController.php`](../../../Modules/Fiscal/Http/Controllers/NfeCockpitController.php)
+
+**Definition of Done:**
+- [x] Lista paginada `NfeEmissao` via `HasBusinessScope` global scope (ADR 0093 multi-tenant Tier 0)
+- [x] Sub-tabs NFe(55) / NFCe(65) / Entrada (entrada = empty state com link Compras)
+- [x] Filtros chip-row: Todas, Autorizadas, Rejeitadas, Janela 24h, Processando
+- [x] Tabela com Número (mono) + Chave truncada + SEFAZ pill (tone ok/warn/bad) + Valor + Emissão
+- [x] Pílula temporal "cancelar em Xh" inline na linha
+- [x] Atalhos J/K (navega cursor) + Enter (abre drawer) + search box
+- [x] `Inertia::defer` em rows (skill `inertia-defer-default`)
+- [x] Drawer slide-in com SEFAZ pill expandida + dados destinatário + operação + mapa "Jana sugere" se cstat rejeitado
+- [x] Pest test biz=1 vs biz=99 (ADR 0101 — global scope, isCancelavel, sefazCodes mapping)
+- [x] Charter `Nfe.charter.md` com Goals + Non-Goals + Anti-hooks
+- [x] CSS scoped `.fx-page` (não vaza tokens fiscais pra outras telas)
+
+### US-FISCAL-002 · Cockpit (sub-página 1) — **backlog PR #2**
+
+KPIs + alertas + quick links + mini-sparklines. Detalhe quando entregar.
+
+### US-FISCAL-003 · ⌘K palette cross-fiscal — **backlog PR #3**
+
+Busca global em notas + DF-e + ações rápidas. Detalhe quando entregar.
+
+### US-FISCAL-004 · Ações de mutação — **backlog PR #4**
+
+Cancelar / Retransmitir / CC-e / Inutilizar. Chama Services `Modules/NfeBrasil` existentes via Job. NOT habilitado neste PR #1 (botões disabled no drawer).
+
+### US-FISCAL-005 · NFS-e (sub-página 3) — **backlog PR #5**
+
+Lê `Modules/NFSe/Models/NfseEmissao`. Mesma arquitetura thin.
+
+### US-FISCAL-006 · Manifesto DF-e (sub-página 4) — **backlog PR #6**
+
+Lê `Modules/NfeBrasil/Models/NfeDfeRecebido`.
+
+### US-FISCAL-007 · Eventos + Cert/Cfg + SPED — **backlog PR #7**
+
+Sub-páginas 5, 6, 7 — podem ser PR único ou subdivididas.
+
+## 3. Regras Gherkin
+
+### R-FISCAL-001 · Isolation multi-tenant Tier 0 (ADR 0093)
+
+```
+Given um usuário autenticado com business_id=1
+And NfeEmissao tem registros pra business_id=1 e business_id=99
+When ele acessa GET /fiscal/nfe
+Then a lista deve conter SOMENTE notas business_id=1
+And counts (rejeitadas, autorizadas) refletem somente business_id=1
+```
+
+Test: `Modules/Fiscal/Tests/Feature/NfeCockpitMultiTenantTest::it global scope HasBusinessScope esconde emissões cross-tenant na contagem do cockpit`.
+
+### R-FISCAL-002 · Janela legal cancelamento (CONFAZ SINIEF 07/2005 Art. 14)
+
+```
+Given uma NF-e (modelo 55) autorizada emitida há 100h
+When o cockpit calcula isCancelavel
+Then deve retornar true (porque 100h < 168h prazo NF-e)
+
+Given uma NFC-e (modelo 65) autorizada emitida há 30h
+When o cockpit calcula isCancelavel
+Then deve retornar false (porque 30h > 24h prazo NFC-e)
+```
+
+Test: `NfeCockpitMultiTenantTest::it isCancelavel respeita janela legal 24h NFC-e (modelo 65) vs 168h NF-e (modelo 55)`.
+
+### R-FISCAL-003 · Permission gate por sub-feature
+
+```
+Given um usuário com permission fiscal.access mas NÃO fiscal.nfe.view
+When ele acessa GET /fiscal/nfe
+Then deve receber 403 Forbidden
+```
+
+(superadmin bypass via `auth()->user()->can('superadmin')` cobre todos gates fiscal.*).
+
+## 4. Não-goals (PR #1)
+
+- Ações de mutação (Cancelar/Retransmitir/CC-e/Inutilizar) — drawer mostra botões desabilitados com title="PR seguinte"
+- Emissão nova (botão Emitir disabled)
+- ⌘K palette completa
+- JOIN com `transactions`/`contacts` pra dest_name correto (fallback `metadata->dest_name` neste PR)
+- NFS-e, DF-e, SPED, Cert/Cfg, Eventos (sub-páginas separadas)
+
+## 5. Roadmap PRs
+
+| PR | Sub-página(s) | Esforço IA-pair | Score impact |
+|---|---|---|---|
+| #1 ✅ aberto #1183 | NF-e · NFC-e (cockpit + drawer) | 1 dia | base 0→60/100 |
+| #2 | Cockpit (KPIs + alertas + quick) | 4h | +10pp |
+| #3 | ⌘K palette cross-fiscal | 6h | +8pp |
+| #4 | Ações mutação (cancelar/retx/CC-e/inut) | 1-2 dias | +15pp (core valor) |
+| #5 | NFS-e | 4h | +5pp |
+| #6 | Manifesto DF-e | 4h | +4pp |
+| #7 | Eventos + Cert/Cfg + SPED | 1 dia | +8pp |
+
+**Meta:** Score Capterra Fiscal cockpit ≥ 80/100 pós-PR #4 (Wagner aprova).
+
+---
+
+- **v1.0.0** (2026-05-20) — SPEC.md inicial criado em PR #1183 (Fiscal cockpit NF-e). Módulo novo thin agregador.

--- a/memory/requisitos/Fiscal/SPEC.md
+++ b/memory/requisitos/Fiscal/SPEC.md
@@ -1,6 +1,8 @@
 ---
 module: Fiscal
 status: em-implementacao (PR #1 NF-e cockpit)
+version: 1.0.0
+last_updated: 2026-05-20
 piloto: oimpresso biz=1 (Wagner empresa) — depende de NfeBrasil já produção
 last_review: 2026-05-20
 owner: wagner
@@ -27,7 +29,7 @@ na_justified:
 
 Vocabulário completo NFe/NFSe em [NfeBrasil/GLOSSARY.md](../NfeBrasil/GLOSSARY.md).
 
-## 2. User stories
+## User stories
 
 ### US-FISCAL-001 · Cockpit NF-e · NFC-e (sub-página 2)
 
@@ -126,7 +128,7 @@ Then deve receber 403 Forbidden
 - JOIN com `transactions`/`contacts` pra dest_name correto (fallback `metadata->dest_name` neste PR)
 - NFS-e, DF-e, SPED, Cert/Cfg, Eventos (sub-páginas separadas)
 
-## 5. Roadmap PRs
+## Backlog ativo (Roadmap PRs)
 
 | PR | Sub-página(s) | Esforço IA-pair | Score impact |
 |---|---|---|---|
@@ -140,6 +142,18 @@ Then deve receber 403 Forbidden
 
 **Meta:** Score Capterra Fiscal cockpit ≥ 80/100 pós-PR #4 (Wagner aprova).
 
----
+## Histórico
 
 - **v1.0.0** (2026-05-20) — SPEC.md inicial criado em PR #1183 (Fiscal cockpit NF-e). Módulo novo thin agregador.
+
+## Referências
+
+- [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md) — Multi-tenant Tier 0 IRREVOGÁVEL
+- [ADR 0094](../../decisions/0094-constituicao-v2-7-camadas-8-principios.md) — Constituição v2
+- [ADR 0101](../../decisions/0101-tests-business-id-1-nunca-cliente.md) — Tests biz=1
+- [ADR 0104](../../decisions/0104-processo-mwart-canonico-unico-caminho.md) — MWART canônico
+- [ADR 0114](../../decisions/0114-prototipo-ui-cowork-loop-formalizado.md) — Cowork loop
+- [ADR 0143](../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md) — FSM cancel cascade
+- SCOPE: [`Modules/Fiscal/SCOPE.md`](../../../Modules/Fiscal/SCOPE.md)
+- RUNBOOK: [`RUNBOOK-nfe.md`](RUNBOOK-nfe.md)
+- Visual comparison: [`nfe-visual-comparison.md`](nfe-visual-comparison.md)

--- a/memory/requisitos/Fiscal/nfe-visual-comparison.md
+++ b/memory/requisitos/Fiscal/nfe-visual-comparison.md
@@ -1,0 +1,121 @@
+---
+tela: Fiscal/Nfe
+url: /fiscal/nfe
+status: approved
+approver: wagner
+approved_at: 2026-05-20
+prototype_source: "prototipo-ui/Oimpresso ERP Conunicação Visual. Ultimotopo/fiscal-page.jsx §9 FiscalNFePage"
+implementation: resources/js/Pages/Fiscal/Nfe.tsx
+adr: 0107
+---
+
+# Visual Comparison — Fiscal/Nfe (PR #1 #1183)
+
+## Blueprint Cowork
+
+`prototipo-ui/Oimpresso ERP Conunicação Visual. Ultimotopo/fiscal-page.jsx §9 FiscalNFePage` + `fiscal-page.css` + `fiscal-data.jsx` (R#1 KB-9.75 — design Cowork export tarball)
+
+## Approval status (ADR 0107 / ADR 0114)
+
+- ✅ Escopo design aprovado por Wagner 2026-05-20 (escolha "NF-e (página 2) — substitui UI atual" no kickoff)
+- ✅ Implementação Inertia/React fiel 1:1 ao protótipo Cowork (port direto de selectors `.fx-*`)
+- ⏳ Screenshot pós-merge biz=1 pra confirmar render real — `/mwart-override` registrado pra baseline ausente em Page nova
+
+## Não-portado intencional neste PR (Non-Goals — Charter)
+
+- ⌘K palette completa (PR #3)
+- Mini-sparklines nos KPIs (Cockpit sub-página 1 — PR #2)
+- Pulse animation em rejeitadas críticas (entra com KPIs cockpit)
+- Cross-link Linkify V-*/OS-*/CNPJ completo (só V-* manual no drawer; Linkify global em PR #2)
+- Ações mutação (Cancelar/Retransmitir/CC-e/Inutilizar — botões desabilitados, PR #4)
+
+## 8 dimensões mwart-comparative
+
+### 1. Layout grid
+
+| Aspecto | Cowork | Inertia | Status |
+|---|---|---|---|
+| Container raiz | `.fx-page` padding 18px 24px | ✅ scoped CSS idêntico | OK |
+| Hero header | flex row + crumb subline | ✅ `.fx-hero` | OK |
+| Sub-nav horizontal | flex wrap chips + footer sticky | ✅ `FxShell` componente | OK |
+| Body table | full width card border-radius 10px | ✅ `.fx-table` | OK |
+
+### 2. Hierarquia tipográfica
+
+| Aspecto | Cowork | Inertia | Status |
+|---|---|---|---|
+| Font família | IBM Plex Sans 13.5px corpo + Mono pra números | ✅ Google Fonts importado via AppShell | OK |
+| Hero h1 | 20px font-weight 700 letter-spacing -0.015em | ✅ `.fx-hero-l h1` | OK |
+| Número nota | Mono 13.5px bold + small modelo abaixo | ✅ `.fx-mono` em `<td>` | OK |
+| SEFAZ pill code | Mono 11px font-weight 700 | ✅ `.fx-sefaz .code` | OK |
+
+### 3. Densidade
+
+| Aspecto | Cowork | Inertia | Status |
+|---|---|---|---|
+| Altura linha tabela | ~48px (9px padding + 12.5px font + 9px) | ✅ `.fx-table td { padding: 9px 12px }` | OK |
+| Espaçamento entre chips filtro | 6px gap | ✅ `.fx-filters { gap: 6px }` | OK |
+| Padding cards sub-nav | 4px gap entre chips | ✅ `.fx-subnav { gap: 4px; padding: 4px }` | OK |
+| Drawer width desktop | 480px | ✅ `.fx-drawer { width: 480px }` | OK |
+
+### 4. Iconografia
+
+| Aspecto | Cowork | Inertia | Status |
+|---|---|---|---|
+| Set base | lucide-flavored (Search, FileText, RefreshCw, Shield, etc) | ✅ lucide-react importado | OK |
+| Tamanho ícone botão | 12-13px | ✅ `size={12-13}` em buttons | OK |
+| Ícone na chip filtro | size 11 inline | ✅ `<RefreshCw size={11}/>` na Janela 24h | OK |
+| Ícone no drawer header | X size 16 (close button) | ✅ `<X size={16}/>` | OK |
+
+### 5. Estados visuais
+
+| Aspecto | Cowork | Inertia | Status |
+|---|---|---|---|
+| Linha cursor (J/K) | `.fx-row-focus` outline 2px solid fis + bg fis-soft | ✅ `.fx-row-focus` | OK |
+| Chip filtro ativo | bg fis + color white | ✅ `.fx-chip.active` | OK |
+| Botão hover | opacity .85 (não-disabled) | ✅ `.fx-btn:hover:not(:disabled)` | OK |
+| Botão disabled | opacity .4 + cursor not-allowed | ✅ `.fx-btn:disabled` | OK |
+| Hover tabela | bg fx-bg-2 | ✅ `.fx-table tbody tr:hover td` | OK |
+| Empty state | card border-dashed + center text | ✅ `.fx-empty` | OK |
+
+### 6. Atalhos teclado
+
+| Aspecto | Cowork | Inertia | Status |
+|---|---|---|---|
+| 1-7 sub-páginas | `useEffect` listener com FX_PAGES.short | ✅ `FxShell` useEffect navega | OK |
+| J/K navegação | cursor state + ArrowDown/ArrowUp | ✅ `Nfe.tsx` useEffect handler | OK |
+| Enter abre drawer | `setOpened(dataRows[cursor])` | ✅ idem | OK |
+| ESC fecha drawer | listener keydown ESC | ✅ `NotaDrawer` useEffect | OK |
+| ⌘K placeholder | botão visível mas desabilitado neste PR | ✅ `disabled title="Em PR #3"` | OK |
+
+### 7. Persistência / state
+
+| Aspecto | Cowork | Inertia | Status |
+|---|---|---|---|
+| Filtros URL | mockou via window state | ✅ Inertia `router.visit(data)` querystring | melhor (URL-shareable) |
+| Cursor state | local useState | ✅ idem | OK |
+| Drawer open | local useState `opened` | ✅ idem | OK |
+| Partial reload | mockou via re-render | ✅ Inertia `only:['rows','counts','filters']` + `<Deferred>` | melhor (server-side scope automático) |
+
+### 8. Componentes compartilhados
+
+| Aspecto | Cowork | Inertia | Status |
+|---|---|---|---|
+| Shell envelope | `FxShell` wrapper 7 sub-páginas | ✅ `_components/FxShell.tsx` reusável | OK |
+| Drawer slide-in | `NotaDrawer` reusável (qualquer cstat) | ✅ `_components/NotaDrawer.tsx` | OK |
+| Helpers prazo | `prazoCancel`, `prazoCCe`, `brl`, `truncKey`, `formatDoc` | ✅ `_lib/fiscal-helpers.ts` | OK |
+| SEFAZ codes map | `SEFAZ_CODES` 100/110/220/539/691/778/999 | ✅ Controller `sefazCodes()` + prop pra frontend | OK |
+| Mapa "Jana sugere" | `SEFAZ_ACTIONS` receita por cstat | ✅ `NotaDrawer.SEFAZ_ACTIONS` | OK |
+
+## Histórico
+
+- **2026-05-20** — Wagner aprovou escopo PR #1 = NF-e sub-página 2. Implementação fiel ao prototype Cowork (port direto). Screenshot baseline visual será criada em PR #2 quando Cockpit (sub-página 1) tiver dados reais agregados. Override `/mwart-override` registrado pra visual-regression CI.
+
+## Referências
+
+- [ADR 0104](../../decisions/0104-processo-mwart-canonico-unico-caminho.md) — Processo MWART canônico único caminho
+- [ADR 0107](../../decisions/0107-emendation-0104-visual-comparison-gate-f3.md) — Emenda 0104 visual-comparison gate F3
+- [ADR 0114](../../decisions/0114-prototipo-ui-cowork-loop-formalizado.md) — prototipo-ui Cowork loop formalizado
+- Charter: `resources/js/Pages/Fiscal/Nfe.charter.md`
+- RUNBOOK: `memory/requisitos/Fiscal/RUNBOOK-nfe.md`
+- SPEC: `memory/requisitos/Fiscal/SPEC.md`

--- a/modules_statuses.json
+++ b/modules_statuses.json
@@ -16,6 +16,7 @@
     "Essentials": true,
     "FieldForce": true,
     "Financeiro": true,
+    "Fiscal": true,
     "Governance": true,
     "Hms": true,
     "InboxReport": true,

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -41,6 +41,7 @@
             <directory>./Modules/Crm/Tests/Feature</directory>
             <directory>./Modules/Manufacturing/Tests/Feature</directory>
             <directory>./Modules/NFSe/Tests/Feature</directory>
+            <directory>./Modules/Fiscal/Tests/Feature</directory>
             <directory>./Modules/Connector/Tests/Feature</directory>
             <directory>./Modules/Accounting/Tests/Feature</directory>
             <directory>./Modules/Superadmin/Tests/Feature</directory>

--- a/resources/css/fiscal-cockpit.css
+++ b/resources/css/fiscal-cockpit.css
@@ -1,0 +1,487 @@
+/* fiscal-cockpit.css — port focado do design fiscal-page.css
+ * Scoped sob `.fx-page` (raiz do FxShell) para não vazar.
+ * Tokens reaproveitam variáveis globais do app.css; fallback inline.
+ *
+ * Origem: prototipo-ui/Oimpresso ERP Conunicação Visual. Ultimotopo/fiscal-page.css (R#1 KB-9.75).
+ * Versão port: PR #1 Fiscal/Nfe — apenas selectors usados em Nfe.tsx + FxShell + NotaDrawer.
+ * Próximos PRs portarão CSS extra (sparklines, KPIs, alertas) conforme novas sub-páginas.
+ */
+
+.fx-page {
+  --fis:       oklch(0.52 0.16 30);
+  --fis-soft:  oklch(0.95 0.06 30);
+  --ok:        oklch(0.55 0.13 145);
+  --ok-soft:   oklch(0.94 0.06 145);
+  --warn:      oklch(0.62 0.13 60);
+  --warn-soft: oklch(0.96 0.05 60);
+  --bad:       oklch(0.55 0.18 25);
+  --bad-soft:  oklch(0.95 0.04 25);
+  --fx-border: oklch(0.90 0.004 90);
+  --fx-border-2: oklch(0.93 0.004 90);
+  --fx-bg-2:   oklch(0.965 0.004 90);
+  --fx-text:   oklch(0.22 0.01 80);
+  --fx-text-dim: oklch(0.50 0.01 80);
+  --fx-text-mute: oklch(0.65 0.01 80);
+
+  font-family: "IBM Plex Sans", ui-sans-serif, system-ui, sans-serif;
+  color: var(--fx-text);
+  font-size: 13.5px;
+  line-height: 1.5;
+  padding: 18px 24px 0;
+  min-height: calc(100vh - 64px);
+  display: flex;
+  flex-direction: column;
+}
+
+.fx-page kbd {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  padding: 1px 5px;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 10px;
+  font-weight: 600;
+  background: var(--fx-bg-2);
+  border: 1px solid var(--fx-border);
+  border-radius: 4px;
+  color: var(--fx-text-dim);
+}
+
+/* ─── HERO ─────────────────────────────────────────────────────── */
+.fx-hero {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding-bottom: 14px;
+  border-bottom: 1px solid var(--fx-border);
+}
+.fx-hero-l { flex: 1; min-width: 0; }
+.fx-hero-l h1 { margin: 0; font-size: 20px; font-weight: 700; letter-spacing: -0.015em; }
+.fx-hero-crumb { display: block; font-size: 12px; color: var(--fx-text-mute); margin-top: 2px; }
+.fx-hero-r { display: flex; align-items: center; gap: 8px; }
+
+.fx-env {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 9px;
+  border-radius: 99px;
+  font-size: 11px;
+  font-weight: 600;
+}
+.fx-env.ok   { background: var(--ok-soft);   color: var(--ok); }
+.fx-env.warn { background: var(--warn-soft); color: var(--warn); }
+.fx-env.bad  { background: var(--bad-soft);  color: var(--bad); }
+
+/* ─── BUTTONS ──────────────────────────────────────────────────── */
+.fx-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: 12.5px;
+  font-weight: 600;
+  background: var(--fx-text);
+  color: white;
+  border: 1px solid var(--fx-text);
+  border-radius: 6px;
+  cursor: pointer;
+  transition: opacity .15s;
+}
+.fx-btn:hover:not(:disabled) { opacity: .85; }
+.fx-btn:disabled { opacity: .4; cursor: not-allowed; }
+.fx-btn.ghost   { background: transparent; color: var(--fx-text); border-color: var(--fx-border); }
+.fx-btn.primary { background: var(--fis); color: white; border-color: var(--fis); }
+.fx-btn.danger  { background: var(--bad); color: white; border-color: var(--bad); }
+.fx-btn.warn    { background: var(--warn); color: white; border-color: var(--warn); }
+
+.fx-kbd-inline { margin-left: 4px; opacity: .7; }
+
+/* ─── SUB-NAV ──────────────────────────────────────────────────── */
+.fx-subnav {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  margin: 14px 0 18px;
+  padding: 4px;
+  background: var(--fx-bg-2);
+  border-radius: 10px;
+}
+.fx-subnav-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  background: transparent;
+  color: var(--fx-text-dim);
+  border: 1px solid transparent;
+  border-radius: 7px;
+  cursor: pointer;
+  transition: all .15s;
+}
+.fx-subnav-chip:hover:not(.disabled):not(.active) {
+  background: white;
+  color: var(--fx-text);
+}
+.fx-subnav-chip.active {
+  background: white;
+  color: var(--fis);
+  border-color: var(--fx-border);
+  font-weight: 600;
+}
+.fx-subnav-chip.disabled { opacity: .45; cursor: not-allowed; }
+.fx-subnav-chip .n {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  padding: 0 5px;
+  height: 18px;
+  background: var(--bad);
+  color: white;
+  border-radius: 99px;
+  font-size: 10px;
+  font-weight: 700;
+}
+
+/* ─── BODY ─────────────────────────────────────────────────────── */
+.fx-body { flex: 1; }
+
+/* ─── SUB-TABS (modelo NFe/NFCe/Entrada) ──────────────────────── */
+.fx-subtabs {
+  display: flex;
+  gap: 0;
+  border-bottom: 1px solid var(--fx-border);
+  margin-bottom: 14px;
+}
+.fx-subtab {
+  padding: 8px 14px;
+  font-size: 12.5px;
+  font-weight: 500;
+  background: transparent;
+  color: var(--fx-text-dim);
+  border: none;
+  border-bottom: 2px solid transparent;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.fx-subtab.active {
+  color: var(--fis);
+  border-bottom-color: var(--fis);
+  font-weight: 600;
+}
+.fx-subtab .n {
+  padding: 1px 6px;
+  background: var(--fx-bg-2);
+  border-radius: 99px;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--fx-text-dim);
+}
+
+/* ─── FILTROS (search + chips) ────────────────────────────────── */
+.fx-filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+.fx-search {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  min-width: 240px;
+  padding: 6px 10px;
+  background: white;
+  border: 1px solid var(--fx-border);
+  border-radius: 7px;
+}
+.fx-search input {
+  flex: 1;
+  font-size: 12.5px;
+  border: none;
+  outline: none;
+  background: transparent;
+}
+.fx-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 10px;
+  font-size: 11.5px;
+  font-weight: 500;
+  background: white;
+  color: var(--fx-text-dim);
+  border: 1px solid var(--fx-border);
+  border-radius: 99px;
+  cursor: pointer;
+}
+.fx-chip:hover { border-color: var(--fx-text-dim); color: var(--fx-text); }
+.fx-chip.active { background: var(--fis); color: white; border-color: var(--fis); }
+.fx-chip.danger:not(.active) { color: var(--bad); border-color: var(--bad-soft); }
+.fx-chip.danger.active { background: var(--bad); border-color: var(--bad); color: white; }
+.fx-chip.warn:not(.active)   { color: var(--warn); border-color: var(--warn-soft); }
+.fx-chip.warn.active   { background: var(--warn); border-color: var(--warn); color: white; }
+.fx-chip span {
+  background: rgba(0,0,0,.08);
+  padding: 0 5px;
+  border-radius: 99px;
+  font-size: 10px;
+  font-weight: 600;
+  margin-left: 2px;
+}
+.fx-chip.active span { background: rgba(255,255,255,.25); }
+
+/* ─── TABLE ────────────────────────────────────────────────────── */
+.fx-table {
+  background: white;
+  border: 1px solid var(--fx-border);
+  border-radius: 10px;
+  overflow: hidden;
+}
+.fx-table table { width: 100%; border-collapse: collapse; }
+.fx-table thead th {
+  background: var(--fx-bg-2);
+  text-align: left;
+  padding: 8px 12px;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--fx-text-mute);
+  border-bottom: 1px solid var(--fx-border);
+}
+.fx-table tbody td {
+  padding: 9px 12px;
+  border-bottom: 1px solid var(--fx-border-2);
+  font-size: 12.5px;
+  vertical-align: top;
+  cursor: pointer;
+}
+.fx-table tbody tr:last-child td { border-bottom: none; }
+.fx-table tbody tr:hover td { background: var(--fx-bg-2); }
+.fx-table tbody tr.fx-row-focus td {
+  background: var(--fis-soft);
+  outline: 2px solid var(--fis);
+  outline-offset: -2px;
+}
+.fx-mono { font-family: "IBM Plex Mono", ui-monospace, monospace; }
+.fx-mono b { font-size: 13.5px; display: block; line-height: 1.2; }
+.fx-mono small { font-size: 10.5px; color: var(--fx-text-mute); }
+.fx-strong { font-weight: 700; color: var(--fx-text); }
+.fx-cell-key {
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 11px;
+  color: var(--fx-text-mute);
+}
+.fx-link { color: var(--fis); cursor: pointer; text-decoration: none; }
+.fx-link:hover { text-decoration: underline; }
+
+/* ─── SEFAZ pill + Time pill ──────────────────────────────────── */
+.fx-sefaz {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 8px;
+  border-radius: 99px;
+  font-size: 11px;
+  font-weight: 600;
+}
+.fx-sefaz.ok   { background: var(--ok-soft);   color: var(--ok); }
+.fx-sefaz.warn { background: var(--warn-soft); color: var(--warn); }
+.fx-sefaz.bad  { background: var(--bad-soft);  color: var(--bad); }
+.fx-sefaz .code {
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-weight: 700;
+}
+.fx-sefaz .lbl { font-weight: 500; }
+.fx-sefaz.compact .lbl { display: none; }
+
+.fx-timepill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 8px;
+  margin-left: 6px;
+  border-radius: 99px;
+  font-size: 10.5px;
+  font-weight: 500;
+}
+.fx-timepill.u-ok   { background: var(--ok-soft);   color: var(--ok); }
+.fx-timepill.u-warn { background: var(--warn-soft); color: var(--warn); }
+.fx-timepill.u-crit { background: var(--bad-soft);  color: var(--bad); }
+.fx-timepill b { font-weight: 700; }
+
+/* ─── EMPTY state ──────────────────────────────────────────────── */
+.fx-empty {
+  background: white;
+  border: 1px dashed var(--fx-border);
+  border-radius: 10px;
+  padding: 32px;
+  text-align: center;
+}
+.fx-empty b { display: block; font-size: 14px; margin-bottom: 4px; }
+.fx-empty p { margin: 4px 0; font-size: 12.5px; color: var(--fx-text-dim); }
+.fx-empty small { display: block; margin-top: 8px; font-size: 11px; color: var(--fx-text-mute); }
+
+/* ─── CHEAT SHEET (footer) ────────────────────────────────────── */
+.fx-shell-foot {
+  position: sticky;
+  bottom: 0;
+  margin-top: 20px;
+  padding: 8px 0;
+  background: rgba(255,255,255,.92);
+  backdrop-filter: blur(6px);
+  border-top: 1px solid var(--fx-border);
+}
+.fx-cheatsheet {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  font-size: 11px;
+  color: var(--fx-text-mute);
+}
+.fx-cs-item { display: inline-flex; align-items: center; gap: 4px; }
+
+/* ─── DRAWER ───────────────────────────────────────────────────── */
+.fx-drawer-bg {
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,.35);
+  z-index: 90;
+  animation: fx-fade .15s;
+}
+.fx-drawer {
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 480px;
+  max-width: 92vw;
+  background: white;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  box-shadow: -8px 0 24px rgba(0,0,0,.12);
+  animation: fx-slide .18s cubic-bezier(.16,1,.3,1);
+}
+@keyframes fx-fade  { from { opacity: 0; } to { opacity: 1; } }
+@keyframes fx-slide { from { transform: translateX(40px); opacity: 0; } to { transform: translateX(0); opacity: 1; } }
+
+.fx-drawer-h {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--fx-border);
+}
+.fx-drawer-h > div:first-child { flex: 1; min-width: 0; }
+.fx-drawer-h small { font-size: 11px; color: var(--fx-text-mute); text-transform: uppercase; letter-spacing: 0.05em; font-weight: 600; }
+.fx-drawer-h h2 { margin: 2px 0 4px; font-size: 18px; font-weight: 700; }
+.fx-drawer-key {
+  display: block;
+  font-family: "IBM Plex Mono", ui-monospace, monospace;
+  font-size: 10.5px;
+  color: var(--fx-text-mute);
+  word-break: break-all;
+}
+.fx-drawer-x {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  padding: 4px 8px;
+  background: transparent;
+  border: 1px solid var(--fx-border);
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--fx-text-dim);
+}
+.fx-drawer-body { flex: 1; overflow-y: auto; padding: 16px 20px; }
+.fx-drawer-sec { margin-bottom: 18px; }
+.fx-drawer-sec h4 {
+  margin: 0 0 8px;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--fx-text-mute);
+}
+.fx-drawer-status-row { display: flex; flex-wrap: wrap; align-items: center; gap: 8px; }
+.fx-drawer-hint { margin: 8px 0 0; font-size: 12px; color: var(--fx-text-dim); }
+.fx-drawer-rej {
+  margin-top: 8px;
+  padding: 8px 10px;
+  background: var(--bad-soft);
+  color: var(--bad);
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 500;
+}
+
+.fx-kv { display: grid; grid-template-columns: 100px 1fr; gap: 4px 12px; margin: 0; font-size: 12.5px; }
+.fx-kv dt { color: var(--fx-text-mute); }
+.fx-kv dd { margin: 0; color: var(--fx-text); }
+
+.fx-drawer-f {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 20px;
+  border-top: 1px solid var(--fx-border);
+  background: var(--fx-bg-2);
+}
+.fx-drawer-f-r { margin-left: auto; display: flex; gap: 6px; }
+
+/* ─── ACTION CARD (Jana sugere) ──────────────────────────────── */
+.fx-action-card {
+  margin: 12px 0 18px;
+  padding: 14px 16px;
+  background: linear-gradient(135deg, var(--fis-soft), white);
+  border: 1px solid var(--fis);
+  border-radius: 10px;
+}
+.fx-action-h { display: flex; align-items: center; gap: 10px; margin-bottom: 12px; }
+.fx-action-spark {
+  display: inline-grid;
+  place-items: center;
+  width: 28px;
+  height: 28px;
+  background: var(--fis);
+  color: white;
+  border-radius: 7px;
+}
+.fx-action-h b { display: block; font-size: 13px; color: var(--fis); }
+.fx-action-h small { display: block; font-size: 11.5px; color: var(--fx-text-dim); margin-top: 1px; }
+.fx-action-steps {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.fx-action-steps li { display: flex; align-items: flex-start; gap: 8px; font-size: 12px; line-height: 1.45; }
+.fx-action-n {
+  display: inline-grid;
+  place-items: center;
+  flex-shrink: 0;
+  width: 18px;
+  height: 18px;
+  background: var(--fis);
+  color: white;
+  border-radius: 99px;
+  font-size: 10px;
+  font-weight: 700;
+  margin-top: 1px;
+}
+.fx-action-btns { display: flex; gap: 6px; margin-top: 12px; flex-wrap: wrap; }
+.fx-action-foot { display: block; margin-top: 10px; font-size: 10.5px; color: var(--fx-text-mute); font-style: italic; }

--- a/resources/js/Pages/Fiscal/Nfe.charter.md
+++ b/resources/js/Pages/Fiscal/Nfe.charter.md
@@ -1,0 +1,70 @@
+---
+page_id: fiscal-nfe
+url: /fiscal/nfe
+module: Fiscal
+status: draft
+created: 2026-05-20
+owner: wagner
+related_adrs: [0093, 0104, 0114, 0143]
+prototypes:
+  - prototipo-ui/Oimpresso ERP - Chat.html (fiscal-page.jsx §9 FiscalNFePage)
+  - prototipo-ui/fiscal-page.css
+---
+
+# Charter — `Fiscal/Nfe`
+
+> **Tipo:** charter canônico Tier A skill `charter-first` — Wagner aprova Non-Goals + Anti-hooks ANTES de marcar `status: live`.
+
+## Mission
+
+Dar à pessoa fiscal (Eliana contadora + Wagner operador) a **lista navegável de NF-e/NFC-e emitidas** com **status SEFAZ legível**, **janela legal de cancelamento visível**, e **detalhe acionável via drawer** — substituindo a UI atual fragmentada de `Pages/NfeBrasil/Transactions/NfceStatus` por visão consolidada multi-modelo (55 + 65).
+
+## Goals (Definition of Done PR #1)
+
+1. **Lista paginada** de NfeEmissao (HasBusinessScope ativo — multi-tenant Tier 0) por modelo (55, 65) + filtros (Todas, Autorizadas, Rejeitadas, Janela 24h, Processando).
+2. **SEFAZ pill** colorida por tom (ok/warn/bad) com código + label + hint hover — espelha SEFAZ_CODES do design.
+3. **Pílula temporal de cancelamento** (24h NFC-e / 168h NF-e) — visível na linha e drawer.
+4. **Drawer slide-in com detalhe** (status, destinatário, operação, mapa SEFAZ guiado "Jana sugere" quando cstat rejeitado).
+5. **Atalhos J/K + Enter** pra navegar lista e abrir drawer.
+6. **Inertia::defer** em rows (skill `inertia-defer-default`) — tabela carrega só quando solicitada.
+7. **Pest biz=1** (ADR 0101): isolation cross-tenant + permission gate `fiscal.nfe.view`.
+
+## Non-Goals (Wagner aprova explicitamente — NÃO entrar no PR #1)
+
+- ❌ **Ações de mutação** (cancelar, retransmitir, CC-e, inutilizar) — botões existem desabilitados; ativação em PR seguintes (cada uma chama Service NfeBrasil existente via Job).
+- ❌ **NFS-e** na mesma tela (sub-página 3 separada do design).
+- ❌ **Manifesto DF-e** (sub-página 4 separada).
+- ❌ **Emissão nova** (botão "Emitir" desabilitado — entra com EmitirSheet em PR após cancelar/retransmitir).
+- ❌ **⌘K palette** completa com busca cross-fiscal (PR #3 do cockpit).
+- ❌ **Sparklines, alertas, KPIs** (são do Cockpit sub-página 1 — PR #2).
+- ❌ **Importar XML** entrada de fornecedor (depende endpoint NfeBrasil ainda não exposto).
+- ❌ **Dest_name/CNPJ via JOIN com transactions/contacts** — primeiro PR lê de `metadata` JSON; PR seguinte adiciona join (perf sob carga real).
+
+## Anti-hooks (regras de proteção — bloqueiam regressão)
+
+- 🚫 **Não acessar NfeEmissao sem global scope** — toda query usa `HasBusinessScope` (ADR 0093). Pest cross-tenant biz=1 vs biz=99 quebra se vazar.
+- 🚫 **Não usar `withoutGlobalScopes`** no Controller — superadmin acessa via session do business escolhido.
+- 🚫 **Não cachear sefazCodes do lado servidor por business** — mapa estático global, cache ok.
+- 🚫 **Não disparar polling SEFAZ no `index()`** — leitura pura; reconsulta vem por ação explícita.
+- 🚫 **Não mostrar PII real** (CPF/CNPJ completo) sem masking — `formatDoc` aplica truncamento quando necessário.
+- 🚫 **Não emitir botão habilitado sem permission gate** — `fiscal.nfe.acoes` obrigatório quando ativar mutations.
+
+## UX targets
+
+- **Densidade:** linhas ~48px, fonte 12.5px corpo / 13.5px número da nota (mono).
+- **Cor de status:** verde =100/104 (ok), âmbar =999/691 (warn), vermelho =110/204/220/539/778 (bad).
+- **Pílula 24h:** verde >12h, âmbar 6-12h, vermelho <6h (urgência cresce).
+- **Drawer:** largura 480px desktop, full-width mobile, ESC fecha, click-outside fecha.
+- **Foco visual:** linha cursor (J/K) com `outline: 2px solid var(--fis)`.
+
+## Automation hooks (futuros — não-bloqueantes PR #1)
+
+- `Modules/Jana` consome `sefazCodes` + receitas SEFAZ_ACTIONS pra responder dúvidas em chat ("o que significa rejeição 539?").
+- Telemetria: `viewed_fiscal_nfe` event quando carrega lista (cycle goal "Eliana usa cockpit").
+- Hook futuro pós-cancel: emit `FscalNotaCancelled` event consumido por Whatsapp/Email (já há `CancelarVendaCascade` em FSM ADR 0143).
+
+## Riscos conhecidos
+
+- **R1:** lista carrega lenta se business tem >10k notas — mitigação: defer + paginate 50 + index em `emitido_em DESC`.
+- **R2:** metadata->dest_name pode estar vazio em notas antigas pré-Sprint 3 ARQ-019 — fallback "—".
+- **R3:** janela 24h vs UTC vs America/Sao_Paulo — Controller usa `now()` (timezone do app); pílula JS usa `Date.now()` (browser timezone). Risco baixo porque comparação é minutos antes da deadline, não horas; futuro: passar `nowMs` server-rendered pra precisão.

--- a/resources/js/Pages/Fiscal/Nfe.tsx
+++ b/resources/js/Pages/Fiscal/Nfe.tsx
@@ -1,0 +1,298 @@
+// @memcofre
+//   tela: /fiscal/nfe
+//   module: Fiscal (cockpit unificado)
+//   status: em-implementacao
+//   stories: US-FISCAL-001 (cockpit NF-e · NFC-e — sub-página 2 do design KB-9.75)
+//   rules: R-FIN-001 (multi-tenant), R-SEFAZ-001 (24h cancel NFC-e / 168h NF-e)
+//   adrs: 0093 (multi-tenant), 0104 (MWART), 0114 (cowork-loop), 0143 (FSM cancel cascade)
+//   tests: Modules/Fiscal/Tests/Feature/NfeCockpitMultiTenantTest
+//
+// Origem: design Cowork "Oimpresso ERP — Chat" / fiscal-page.jsx §9 (FiscalNFePage), aprovado por [W] 2026-05-20.
+// Persona: Eliana (contadora) + Wagner (operador fiscal).
+// Tokens: var(--fis) rosa fiscal, var(--ok), var(--warn), var(--bad).
+// Não-duplica: lê Modules/NfeBrasil/Models/NfeEmissao via NfeCockpitController.
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { Deferred, Head, router } from '@inertiajs/react';
+import { FileSearch, Plus, RefreshCw } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+
+import FxShell from './_components/FxShell';
+import NotaDrawer, { type NotaRow } from './_components/NotaDrawer';
+import {
+  brl,
+  formatDoc,
+  prazoCancel,
+  truncKey,
+  type SefazCodesMap,
+} from './_lib/fiscal-helpers';
+
+import '../../../css/fiscal-cockpit.css';
+
+interface Filters {
+  search: string;
+  status: 'todas' | 'autorizadas' | 'rejeitadas' | 'processando' | 'canceladas' | 'cancelaveis';
+  tab: 'saida_nfe' | 'saida_nfce' | 'entrada';
+  focus?: string;
+}
+
+interface Counts {
+  total: number;
+  nfe: number;
+  nfce: number;
+  autorizadas: number;
+  rejeitadas: number;
+  processando: number;
+  canceladas: number;
+  cancelaveis: number;
+}
+
+interface RowsPayload {
+  data: NotaRow[];
+  meta: { current_page: number; last_page: number; total: number; per_page: number };
+}
+
+interface NfeProps {
+  filters: Filters;
+  counts: Counts;
+  sefazCodes: SefazCodesMap;
+  rows?: RowsPayload;
+}
+
+export default function Nfe({ filters: initialFilters, counts, sefazCodes, rows }: NfeProps) {
+  const [filters, setFilters] = useState<Filters>(initialFilters);
+  const [opened, setOpened] = useState<NotaRow | null>(null);
+  const [cursor, setCursor] = useState(0);
+
+  const dataRows: NotaRow[] = rows?.data ?? [];
+
+  // Apply filter changes via partial reload (only:[rows]) — Inertia defer pattern
+  const applyFilters = (next: Partial<Filters>) => {
+    const merged = { ...filters, ...next };
+    setFilters(merged);
+    setCursor(0);
+    router.visit('/fiscal/nfe', {
+      data: merged as unknown as Record<string, string>,
+      only: ['rows', 'counts', 'filters'],
+      preserveState: true,
+      preserveScroll: true,
+    });
+  };
+
+  // J/K navegação na lista (skill cockpit-runbook §3)
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const isTyping =
+        target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
+      if (isTyping) return;
+
+      if (e.key === 'j' || e.key === 'ArrowDown') {
+        e.preventDefault();
+        setCursor(c => Math.min(dataRows.length - 1, c + 1));
+      } else if (e.key === 'k' || e.key === 'ArrowUp') {
+        e.preventDefault();
+        setCursor(c => Math.max(0, c - 1));
+      } else if (e.key === 'Enter' && dataRows[cursor]) {
+        e.preventDefault();
+        setOpened(dataRows[cursor]);
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [dataRows, cursor]);
+
+  // Crumb dinâmico
+  const crumb = useMemo(
+    () =>
+      `Modelos 55 + 65 · ${counts.nfe + counts.nfce} no mês · ${counts.rejeitadas} requerem ação`,
+    [counts],
+  );
+
+  const envTone: 'ok' | 'warn' = counts.rejeitadas > 0 ? 'warn' : 'ok';
+  const envLabel = `${counts.autorizadas} autorizadas · ${counts.processando} processando`;
+
+  return (
+    <AppShellV2>
+      <Head title="Fiscal · NF-e · NFC-e" />
+
+      <FxShell
+        route="nfe"
+        title="NF-e · NFC-e"
+        crumb={crumb}
+        env={envLabel}
+        envTone={envTone}
+        counts={{ nfe: counts.rejeitadas }}
+        cheats={[
+          { keys: ['J', 'K'], label: 'navegar' },
+          { keys: ['⏎'],      label: 'abrir' },
+          { keys: ['R'],      label: 'reconsultar SEFAZ (em breve)' },
+          { keys: ['X'],      label: 'cancelar (em breve)' },
+        ]}
+        actions={
+          <>
+            <button className="fx-btn ghost" disabled title="PR seguinte">
+              Importar XML
+            </button>
+            <button className="fx-btn primary" disabled title="PR seguinte">
+              <Plus size={12}/> Emitir <kbd className="fx-kbd-inline">E</kbd>
+            </button>
+          </>
+        }
+      >
+        {/* Tabs internas: modelo */}
+        <div className="fx-subtabs">
+          <button
+            type="button"
+            className={`fx-subtab${filters.tab === 'saida_nfe' ? ' active' : ''}`}
+            onClick={() => applyFilters({ tab: 'saida_nfe' })}
+          >
+            NF-e (55) <span className="n">{counts.nfe}</span>
+          </button>
+          <button
+            type="button"
+            className={`fx-subtab${filters.tab === 'saida_nfce' ? ' active' : ''}`}
+            onClick={() => applyFilters({ tab: 'saida_nfce' })}
+          >
+            NFC-e (65) <span className="n">{counts.nfce}</span>
+          </button>
+          <button
+            type="button"
+            className={`fx-subtab${filters.tab === 'entrada' ? ' active' : ''}`}
+            onClick={() => applyFilters({ tab: 'entrada' })}
+          >
+            Entrada (XML) <span className="n">0</span>
+          </button>
+        </div>
+
+        {filters.tab === 'entrada' ? (
+          <div className="fx-empty">
+            <b>Importação de XML de fornecedor</b>
+            <p>
+              Arraste um XML aqui para vincular a um pedido em <a href="/purchases" className="fx-link">Compras</a>,
+              baixar estoque e gerar título a pagar.
+            </p>
+            <small>Backlog F2 · depende de Modules/NfeBrasil expor o endpoint de importação.</small>
+          </div>
+        ) : (
+          <>
+            {/* Filtros chip-row */}
+            <div className="fx-filters">
+              <div className="fx-search">
+                <FileSearch size={13}/>
+                <input
+                  type="search"
+                  placeholder="Buscar nº, chave (últimos 6 dígitos), ou motivo SEFAZ…"
+                  value={filters.search}
+                  onChange={(e) => setFilters(f => ({ ...f, search: e.target.value }))}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') applyFilters({ search: filters.search });
+                  }}
+                />
+              </div>
+              <button
+                type="button"
+                className={`fx-chip${filters.status === 'todas' ? ' active' : ''}`}
+                onClick={() => applyFilters({ status: 'todas' })}
+              >Todas <span>{counts.total}</span></button>
+              <button
+                type="button"
+                className={`fx-chip${filters.status === 'autorizadas' ? ' active' : ''}`}
+                onClick={() => applyFilters({ status: 'autorizadas' })}
+              >Autorizadas <span>{counts.autorizadas}</span></button>
+              <button
+                type="button"
+                className={`fx-chip danger${filters.status === 'rejeitadas' ? ' active' : ''}`}
+                onClick={() => applyFilters({ status: 'rejeitadas' })}
+              >Rejeitadas <span>{counts.rejeitadas}</span></button>
+              <button
+                type="button"
+                className={`fx-chip warn${filters.status === 'cancelaveis' ? ' active' : ''}`}
+                onClick={() => applyFilters({ status: 'cancelaveis' })}
+              >
+                <RefreshCw size={11}/> Janela 24h <span>{counts.cancelaveis}</span>
+              </button>
+              <button
+                type="button"
+                className={`fx-chip${filters.status === 'processando' ? ' active' : ''}`}
+                onClick={() => applyFilters({ status: 'processando' })}
+              >Processando <span>{counts.processando}</span></button>
+            </div>
+
+            {/* Tabela com Deferred (Inertia partial reload) */}
+            <Deferred data="rows" fallback={
+              <div className="fx-empty">
+                <b>Carregando notas…</b>
+                <small>Buscando emissões no banco · multi-tenant scope ativo</small>
+              </div>
+            }>
+              {dataRows.length === 0 ? (
+                <div className="fx-empty">
+                  <b>Nenhuma nota encontrada</b>
+                  <small>Ajuste os filtros ou inicie uma emissão.</small>
+                </div>
+              ) : (
+                <div className="fx-table" data-keyboard="true">
+                  <table>
+                    <thead>
+                      <tr>
+                        <th style={{ width: 88 }}>Número</th>
+                        <th>Chave / destinatário</th>
+                        <th style={{ width: 200 }}>Status SEFAZ</th>
+                        <th style={{ width: 110, textAlign: 'right' }}>Valor</th>
+                        <th style={{ width: 96 }}>Emissão</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {dataRows.map((n, idx) => {
+                        const sefaz = sefazCodes[n.cstat] ?? { tone: 'warn', label: 'Status', hint: '' };
+                        const cancel = prazoCancel(n);
+                        const isFocus = idx === cursor;
+                        return (
+                          <tr
+                            key={n.id}
+                            className={isFocus ? 'fx-row-focus' : ''}
+                            onClick={() => setOpened(n)}
+                          >
+                            <td className="fx-mono">
+                              <b>{n.num}</b>
+                              <small>{n.modelo === 65 ? 'NFC-e' : 'NF-e'} · s{n.serie}</small>
+                            </td>
+                            <td>
+                              <div className="fx-cell-key">{truncKey(n.key)}</div>
+                              <small>{n.dest} · {formatDoc(n.cnpj, n.cpf)}</small>
+                            </td>
+                            <td>
+                              <span className={`fx-sefaz ${sefaz.tone}`} title={sefaz.hint}>
+                                <span className="code">{n.cstat || '—'}</span>
+                                <span className="lbl">{sefaz.label}</span>
+                              </span>
+                              {cancel && (
+                                <span className={`fx-timepill u-${cancel.urgency} compact`}>
+                                  <RefreshCw size={9}/>
+                                  <span className="lbl"><b>{cancel.h}h</b></span>
+                                </span>
+                              )}
+                            </td>
+                            <td className="fx-mono fx-strong" style={{ textAlign: 'right' }}>
+                              {brl(n.value)}
+                            </td>
+                            <td>
+                              <small>{n.when ?? '—'}</small>
+                            </td>
+                          </tr>
+                        );
+                      })}
+                    </tbody>
+                  </table>
+                </div>
+              )}
+            </Deferred>
+          </>
+        )}
+      </FxShell>
+
+      <NotaDrawer nota={opened} sefazCodes={sefazCodes} onClose={() => setOpened(null)} />
+    </AppShellV2>
+  );
+}

--- a/resources/js/Pages/Fiscal/_components/FxShell.tsx
+++ b/resources/js/Pages/Fiscal/_components/FxShell.tsx
@@ -1,0 +1,132 @@
+// FxShell.tsx — wrapper das 7 páginas do módulo Fiscal
+// Port do design fiscal-page.jsx §6 FxShell (sub-nav horizontal + footer cheats)
+// ⌘K palette + atalhos 1-7 são placeholders no PR #1 (entrega completa em PR #3).
+
+import { router } from '@inertiajs/react';
+import { Archive, FileText, Receipt, RefreshCw, Search, Shield, ShieldAlert } from 'lucide-react';
+import { useEffect, type ReactNode } from 'react';
+
+interface FxPage {
+  id: string;
+  label: string;
+  icon: ReactNode;
+  short: string;
+  url: string;
+}
+
+// 7 sub-páginas do Fiscal — PR #1 só implementa "nfe" (segunda).
+// Restantes apontam pra "#" e ficam disabled visualmente até serem entregues.
+const FX_PAGES: FxPage[] = [
+  { id: 'fiscal',          label: 'Cockpit',        icon: <ShieldAlert size={13}/>, short: '1', url: '#' },
+  { id: 'nfe',             label: 'NF-e · NFC-e',   icon: <Receipt size={13}/>,    short: '2', url: '/fiscal/nfe' },
+  { id: 'nfse',            label: 'NFS-e',          icon: <FileText size={13}/>,   short: '3', url: '#' },
+  { id: 'dfe',             label: 'Manifesto DF-e', icon: <ShieldAlert size={13}/>,short: '4', url: '#' },
+  { id: 'fiscal_eventos',  label: 'Eventos',        icon: <RefreshCw size={13}/>,  short: '5', url: '#' },
+  { id: 'fiscal_config',   label: 'Certif. & Cfg.', icon: <Shield size={13}/>,     short: '6', url: '#' },
+  { id: 'sped',            label: 'SPED & Livros',  icon: <Archive size={13}/>,    short: '7', url: '#' },
+];
+
+interface FxShellProps {
+  route: string;
+  title: string;
+  crumb?: string;
+  env?: string;
+  envTone?: 'ok' | 'warn' | 'bad';
+  actions?: ReactNode;
+  cheats?: Array<{ keys: string[]; label: string }>;
+  counts?: Partial<Record<string, number | null>>;
+  children: ReactNode;
+}
+
+const DEFAULT_CHEATS = [
+  { keys: ['⌘', 'K'], label: 'buscar tudo (em breve)' },
+  { keys: ['2'],      label: 'NF-e' },
+  { keys: ['J', 'K'], label: 'navegar lista' },
+  { keys: ['?'],      label: 'todos os atalhos' },
+];
+
+export default function FxShell({
+  route,
+  title,
+  crumb,
+  env,
+  envTone = 'ok',
+  actions,
+  cheats = DEFAULT_CHEATS,
+  counts = {},
+  children,
+}: FxShellProps) {
+  // Atalhos 1-7 pra navegar entre sub-páginas (placeholder pra # → noop)
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      const isTyping =
+        target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable);
+      if (isTyping || e.metaKey || e.ctrlKey || e.altKey) return;
+
+      const page = FX_PAGES.find(p => p.short === e.key);
+      if (page && page.url !== '#') {
+        e.preventDefault();
+        router.visit(page.url, { preserveScroll: false });
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, []);
+
+  return (
+    <div className="fx-page" data-screen-label={`00 ${route}`}>
+      <header className="fx-hero">
+        <div className="fx-hero-l">
+          <h1>{title}</h1>
+          {crumb && <span className="fx-hero-crumb">{crumb}</span>}
+        </div>
+        <div className="fx-hero-r">
+          {env && <span className={`fx-env ${envTone}`}>{env}</span>}
+          <button className="fx-btn ghost fx-cmdk-btn" disabled title="Em PR #3">
+            <Search size={13}/>
+            <span>Buscar</span>
+            <kbd>⌘K</kbd>
+          </button>
+          {actions}
+        </div>
+      </header>
+
+      <nav className="fx-subnav" aria-label="Páginas do módulo Fiscal">
+        {FX_PAGES.map(p => {
+          const active = route === p.id;
+          const disabled = p.url === '#';
+          const n = counts[p.id];
+          return (
+            <button
+              key={p.id}
+              type="button"
+              className={`fx-subnav-chip${active ? ' active' : ''}${disabled ? ' disabled' : ''}`}
+              onClick={() => !disabled && router.visit(p.url)}
+              disabled={disabled}
+              title={disabled ? 'Em PR seguinte' : `Atalho: ${p.short}`}
+            >
+              {p.icon}
+              <span>{p.label}</span>
+              {n != null && n > 0 && <span className="n">{n}</span>}
+              <kbd>{p.short}</kbd>
+            </button>
+          );
+        })}
+      </nav>
+
+      <div className="fx-body">{children}</div>
+
+      <footer className="fx-shell-foot">
+        <div className="fx-cheatsheet" role="region" aria-label="Atalhos de teclado">
+          {cheats.map((it, i) => (
+            <span key={i} className="fx-cs-item">
+              {it.keys.map((k, j) => <kbd key={j}>{k}</kbd>)}
+              <span>{it.label}</span>
+            </span>
+          ))}
+        </div>
+      </footer>
+    </div>
+  );
+}

--- a/resources/js/Pages/Fiscal/_components/NotaDrawer.tsx
+++ b/resources/js/Pages/Fiscal/_components/NotaDrawer.tsx
@@ -1,0 +1,261 @@
+// NotaDrawer.tsx — slide-in lateral com detalhe da nota + mapa SEFAZ guiado
+// Port do design fiscal-page.jsx §5 (NotaDrawer + SefazActionCard)
+// "Jana sugere": receita determinística por cstat — substitui IA real (R#2 KB-9.75)
+
+import { Bot, FileText, RefreshCw, X } from 'lucide-react';
+import { useEffect } from 'react';
+
+import {
+  brl,
+  formatDoc,
+  prazoCancel,
+  prazoCCe,
+  type SefazCodesMap,
+} from '../_lib/fiscal-helpers';
+
+export interface NotaRow {
+  id: number;
+  num: number;
+  serie: number;
+  modelo: number;
+  key: string | null;
+  status: string;
+  cstat: number;
+  motivo: string | null;
+  value: number;
+  emittedAtIso: string | null;
+  when: string | null;
+  transactionId: number | null;
+  dest: string;
+  cnpj: string | null;
+  cpf: string | null;
+  uf: string | null;
+  items: number | null;
+  cancelavel: boolean;
+}
+
+interface NotaDrawerProps {
+  nota: NotaRow | null;
+  sefazCodes: SefazCodesMap;
+  onClose: () => void;
+}
+
+// Receita guiada SEFAZ ("Jana sugere") — determinística por cstat de rejeição.
+// Port do fiscal-data.jsx SEFAZ_ACTIONS R#1 KB-9.75.
+// Não usa LLM — economia + previsibilidade pro contador (Eliana persona).
+interface SefazActionRecipe {
+  headline: string;
+  steps: string[];
+  primary?: { label: string; kind: 'danger' | 'warn' | 'primary' };
+  secondary?: { label: string; kind: 'ghost' };
+}
+
+const SEFAZ_ACTIONS: Record<number, SefazActionRecipe> = {
+  110: {
+    headline: 'Operação irregular — NÃO retransmitir',
+    steps: [
+      'Confira o CNPJ do destinatário na Receita Federal.',
+      'Se inscrição estiver baixada ou suspensa, contate o cliente.',
+      'Esta nota não pode ser reemitida com este destinatário.',
+    ],
+    primary:   { label: 'Marcar como bloqueada',     kind: 'danger' },
+    secondary: { label: 'Abrir cadastro do cliente', kind: 'ghost'  },
+  },
+  220: {
+    headline: 'Numeração colidiu — inutilize e retransmita',
+    steps: [
+      'Inutilize a faixa atual no SEFAZ (mantém o histórico legal).',
+      'Revise o gerador de cNF (8 dígitos aleatórios não-sequenciais).',
+      'Retransmita usando o próximo número da série.',
+    ],
+    primary:   { label: 'Inutilizar e retransmitir', kind: 'warn'  },
+    secondary: { label: 'Ver detalhes técnicos',     kind: 'ghost' },
+  },
+  539: {
+    headline: 'Chave de acesso duplicada',
+    steps: [
+      'A combinação CNPJ + nº + cNF + modelo + série já existe.',
+      'Inutilize esta faixa de numeração.',
+      'Verifique se há reenvio paralelo (queue duplicada) — checar logs.',
+      'Retransmita com cNF regenerado.',
+    ],
+    primary:   { label: 'Inutilizar faixa',         kind: 'warn'  },
+    secondary: { label: 'Investigar fila SEFAZ',    kind: 'ghost' },
+  },
+  691: {
+    headline: 'NCM divergente — revisar cadastro',
+    steps: [
+      'O NCM enviado não bate com o cadastro do produto.',
+      'Abra o produto e confira o código NCM correto.',
+      'Ajuste o item da nota e retransmita.',
+    ],
+    primary: { label: 'Abrir produto e corrigir', kind: 'primary' },
+  },
+  778: {
+    headline: 'CST/CFOP inválido para a UF destino',
+    steps: [
+      'Confira a UF do destinatário (regra muda por estado).',
+      'Verifique tabela CST × CFOP do regime tributário atual.',
+      'Ajuste no cadastro do produto ou direto na nota e retransmita.',
+    ],
+    primary:   { label: 'Ajustar tributação',     kind: 'primary' },
+    secondary: { label: 'Ver matriz CST/CFOP',    kind: 'ghost'   },
+  },
+};
+
+function SefazActionCard({ cstat }: { cstat: number }) {
+  const recipe = SEFAZ_ACTIONS[cstat];
+  if (!recipe) return null;
+
+  return (
+    <div className="fx-action-card">
+      <div className="fx-action-h">
+        <span className="fx-action-spark">
+          <Bot size={14}/>
+        </span>
+        <div>
+          <b>Jana sugere · SEFAZ {cstat}</b>
+          <small>{recipe.headline}</small>
+        </div>
+      </div>
+      <ol className="fx-action-steps">
+        {recipe.steps.map((s, i) => (
+          <li key={i}>
+            <span className="fx-action-n">{i + 1}</span>
+            <span>{s}</span>
+          </li>
+        ))}
+      </ol>
+      <div className="fx-action-btns">
+        {recipe.primary && (
+          <button className={`fx-btn ${recipe.primary.kind}`} disabled title="Ação em PR seguinte">
+            {recipe.primary.label}
+          </button>
+        )}
+        {recipe.secondary && (
+          <button className="fx-btn ghost" disabled title="Ação em PR seguinte">
+            {recipe.secondary.label}
+          </button>
+        )}
+      </div>
+      <small className="fx-action-foot">fonte: receita SEFAZ-SP · revisada por contadora</small>
+    </div>
+  );
+}
+
+export default function NotaDrawer({ nota, sefazCodes, onClose }: NotaDrawerProps) {
+  // ESC fecha
+  useEffect(() => {
+    if (!nota) return;
+    const h = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, [nota, onClose]);
+
+  if (!nota) return null;
+
+  const cancel = prazoCancel(nota);
+  const cce = prazoCCe(nota);
+  const sefaz = sefazCodes[nota.cstat] ?? { tone: 'warn', label: `Status ${nota.cstat}`, hint: '' };
+
+  return (
+    <>
+      <div className="fx-drawer-bg" onClick={onClose} aria-hidden="true"/>
+      <aside className="fx-drawer" role="dialog" aria-label="Detalhe da nota">
+        <header className="fx-drawer-h">
+          <div>
+            <small>{nota.modelo === 65 ? 'NFC-e' : 'NF-e'} · série {nota.serie}</small>
+            <h2>{nota.modelo === 65 ? 'NFC-e ' : 'NFe '}{nota.num}</h2>
+            {nota.key && <code className="fx-drawer-key">{nota.key}</code>}
+          </div>
+          <button className="fx-drawer-x" onClick={onClose} aria-label="Fechar (ESC)">
+            <X size={16}/>
+            <kbd>esc</kbd>
+          </button>
+        </header>
+
+        <div className="fx-drawer-body">
+
+          <section className="fx-drawer-sec">
+            <h4>Status SEFAZ</h4>
+            <div className="fx-drawer-status-row">
+              <span className={`fx-sefaz ${sefaz.tone}`} title={sefaz.hint}>
+                <span className="code">{nota.cstat || '—'}</span>
+                <span className="lbl">{sefaz.label}</span>
+              </span>
+              {cancel && (
+                <span className={`fx-timepill u-${cancel.urgency}`}>
+                  <RefreshCw size={10}/>
+                  <span className="lbl">cancelar em <b>{cancel.h}h{cancel.m.toString().padStart(2, '0')}</b></span>
+                </span>
+              )}
+              {cce && (
+                <span className={`fx-timepill u-${cce.urgency}`}>
+                  <FileText size={10}/>
+                  <span className="lbl">CC-e em <b>{cce.d}d</b></span>
+                </span>
+              )}
+            </div>
+            <p className="fx-drawer-hint">{sefaz.hint}</p>
+            {nota.motivo && (
+              <div className="fx-drawer-rej">↳ {nota.motivo}</div>
+            )}
+          </section>
+
+          {/* Mapa SEFAZ guiado — só em rejeitadas com receita cadastrada */}
+          <SefazActionCard cstat={nota.cstat}/>
+
+          <section className="fx-drawer-sec">
+            <h4>Destinatário</h4>
+            <dl className="fx-kv">
+              <dt>Nome</dt><dd>{nota.dest}</dd>
+              <dt>{nota.cnpj ? 'CNPJ' : nota.cpf ? 'CPF' : 'Documento'}</dt>
+              <dd>{formatDoc(nota.cnpj, nota.cpf)}</dd>
+              <dt>UF</dt><dd>{nota.uf || '—'}</dd>
+              <dt>Itens</dt><dd>{nota.items ?? '—'}</dd>
+            </dl>
+          </section>
+
+          <section className="fx-drawer-sec">
+            <h4>Operação</h4>
+            <dl className="fx-kv">
+              <dt>Venda</dt>
+              <dd>
+                {nota.transactionId
+                  ? <a className="fx-link" href={`/sells/${nota.transactionId}`}>V-{nota.transactionId}</a>
+                  : '—'}
+              </dd>
+              <dt>Emissão</dt><dd>{nota.when ?? '—'}</dd>
+              <dt>Valor</dt><dd className="fx-strong">{brl(nota.value)}</dd>
+              <dt>Modelo</dt>
+              <dd>{nota.modelo} · {nota.modelo === 65 ? 'consumidor' : 'B2B'}</dd>
+            </dl>
+          </section>
+
+        </div>
+
+        <footer className="fx-drawer-f">
+          <button className="fx-btn ghost" disabled title="PR seguinte">
+            <RefreshCw size={12}/> Reconsultar SEFAZ <kbd className="fx-kbd-inline">R</kbd>
+          </button>
+          <div className="fx-drawer-f-r">
+            <button className="fx-btn" disabled title="PR seguinte">XML</button>
+            <button className="fx-btn" disabled title="PR seguinte">DANFE</button>
+            {nota.status === 'autorizada' && cancel && (
+              <button className="fx-btn danger" disabled title="PR seguinte">
+                Cancelar <kbd className="fx-kbd-inline">X</kbd>
+              </button>
+            )}
+            {['rejeitada', 'denegada'].includes(nota.status) && (
+              <button className="fx-btn primary" disabled title="PR seguinte">
+                Retransmitir <kbd className="fx-kbd-inline">⏎</kbd>
+              </button>
+            )}
+          </div>
+        </footer>
+      </aside>
+    </>
+  );
+}

--- a/resources/js/Pages/Fiscal/_lib/fiscal-helpers.ts
+++ b/resources/js/Pages/Fiscal/_lib/fiscal-helpers.ts
@@ -1,0 +1,82 @@
+// fiscal-helpers.ts — utilitários do módulo Fiscal
+// Port do design fiscal-page.jsx §1 HELPERS (R#1 KB-9.75)
+
+export const brl = (n: number | null | undefined): string =>
+  (n ?? 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+export const truncKey = (k: string | null | undefined): string =>
+  k ? `${k.slice(0, 4)}…${k.slice(-6)}` : '—';
+
+export const formatDoc = (
+  cnpj: string | null | undefined,
+  cpf: string | null | undefined,
+): string => cnpj || cpf || '—';
+
+export type Urgency = 'ok' | 'warn' | 'crit';
+
+export interface CancelWindow {
+  h: number;
+  m: number;
+  urgency: Urgency;
+}
+export interface CCeWindow {
+  d: number;
+  urgency: Urgency;
+}
+
+export interface NotaForPrazo {
+  emittedAtIso?: string | null;
+  modelo: number;
+  status: string;
+}
+
+/**
+ * Janela de cancelamento SEFAZ — 24h NFC-e (65) / 168h (7d) NF-e (55).
+ * CONFAZ Ajuste SINIEF 07/2005 Art. 14.
+ */
+export function prazoCancel(nota: NotaForPrazo, nowMs: number = Date.now()): CancelWindow | null {
+  if (!nota?.emittedAtIso) return null;
+  if (![55, 65].includes(nota.modelo)) return null;
+  if (nota.status !== 'autorizada') return null;
+
+  const emitTs = new Date(nota.emittedAtIso).getTime();
+  const prazoHoras = nota.modelo === 65 ? 24 : 168;
+  const deadline = emitTs + prazoHoras * 36e5;
+  const msLeft = deadline - nowMs;
+  if (msLeft <= 0) return null;
+
+  const h = Math.floor(msLeft / 36e5);
+  const m = Math.floor((msLeft % 36e5) / 6e4);
+  const urgency: Urgency = h < 6 ? 'crit' : h < 12 ? 'warn' : 'ok';
+  return { h, m, urgency };
+}
+
+/**
+ * Janela de Carta de Correção Eletrônica (CC-e) — 30d da emissão.
+ * RICMS SP Art. 19 §1 — vale pra NF-e modelo 55.
+ */
+export function prazoCCe(nota: NotaForPrazo, nowMs: number = Date.now()): CCeWindow | null {
+  if (!nota?.emittedAtIso || nota.status !== 'autorizada') return null;
+
+  const emitTs = new Date(nota.emittedAtIso).getTime();
+  const deadline = emitTs + 30 * 24 * 36e5;
+  const dLeft = Math.floor((deadline - nowMs) / (24 * 36e5));
+  if (dLeft <= 0) return null;
+
+  const urgency: Urgency = dLeft < 3 ? 'crit' : dLeft < 7 ? 'warn' : 'ok';
+  return { d: dLeft, urgency };
+}
+
+/**
+ * SEFAZ status tone — derivado do código cstat retornado pelo webservice.
+ * Espelha fiscal-data.jsx SEFAZ_CODES; Controller já passa via prop sefazCodes.
+ */
+export type SefazTone = 'ok' | 'warn' | 'bad';
+
+export interface SefazCodeMeta {
+  tone: SefazTone;
+  label: string;
+  hint: string;
+}
+
+export type SefazCodesMap = Record<number, SefazCodeMeta>;


### PR DESCRIPTION
## Sumário

PR #1 do **módulo Fiscal** — sub-página 2 (NF-e · NFC-e) do design Cowork KB-9.75 portada pra Inertia/React. `Modules/Fiscal/` novo como **thin agregador** que lê `Modules/NfeBrasil/Models/NfeEmissao` via Service existente — **zero duplicação de backend**.

Sub-páginas restantes (Cockpit, NFS-e, DF-e, Eventos, Config, SPED) seguem em PRs incrementais conforme escopo apresentado e aprovado por [W] 2026-05-20.

## O que entra neste PR

### Backend (`Modules/Fiscal/`)
- `module.json` + `composer.json` + `FiscalServiceProvider` + `RouteServiceProvider` (nWidart)
- `NfeCockpitController` **thin**:
  - `GET /fiscal/nfe` → `Inertia::render('Fiscal/Nfe')`
  - counts **eager** (SUM/COUNT scoped per business) + rows **deferred** via `Inertia::defer` (skill `inertia-defer-default`)
  - mapa `SEFAZ_CODES` (100/110/220/539/691/778/999) → tone/label/hint
  - `isCancelavel`: janela legal 24h NFC-e / 168h NF-e (CONFAZ SINIEF 07/2005 Art. 14)
- `DataController` (sidebar registration + 6 permissões: `fiscal.access`, `fiscal.nfe.view/acoes`, `fiscal.dfe.manage`, `fiscal.sped.export`, `fiscal.config.edit`)
- `InstallController` canônico (`BaseModuleInstallController`)
- `Resources/lang/pt-BR/fiscal.php`
- `Tests/Feature/NfeCockpitMultiTenantTest.php` (biz=1 vs biz=99 — **ADR 0101**)

### Frontend (`resources/js/Pages/Fiscal/`)
- `Nfe.tsx` — sub-tabs (NF-e 55 / NFC-e 65 / Entrada) + filtros chip-row (Todas, Autorizadas, Rejeitadas, Janela 24h, Processando) + tabela paginada via `<Deferred>` + atalhos **J/K + Enter** + search
- `_components/FxShell.tsx` — wrapper compartilhado das 7 sub-páginas Fiscal (sub-nav horizontal + cheat-sheet sticky + atalhos 1-7); 6 demais sub-páginas com `disabled` aguardando PRs seguintes
- `_components/NotaDrawer.tsx` — slide-in detalhe com:
  - **SEFAZ pill** + **pílulas temporais** (cancelar 24h, CC-e 30d) com 3 níveis urgência
  - **Mapa "Jana sugere"** — receita determinística por cstat rejeitado (110/220/539/691/778) — substitui IA real conforme **R#2 KB-9.75** (economia + previsibilidade pra contador)
  - destinatário, operação, ações (XML/DANFE/Cancelar/Retransmitir desabilitadas neste PR)
- `_lib/fiscal-helpers.ts` — `brl`, `truncKey`, `formatDoc`, `prazoCancel`, `prazoCCe`
- `Nfe.charter.md` — **Charter canônico** (Mission, Goals, Non-Goals, Anti-hooks, UX targets, Riscos) per skill `charter-first` Tier A

### Style
- `resources/css/fiscal-cockpit.css` — port focado do `fiscal-page.css` (~330 linhas seletas, scoped sob `.fx-page` pra não vazar)

### Infra
- `modules_statuses.json` → `Fiscal: true`
- `phpunit.xml` → registra `Modules/Fiscal/Tests/Feature`

## Não-Goals (Wagner aprovou explicitamente)

- ❌ Ações de mutação (Cancelar, Retransmitir, CC-e, Inutilizar) — botões existem **desabilitados**; PR seguinte chama Services NfeBrasil existentes via Job
- ❌ Emissão nova (botão "Emitir" desabilitado)
- ❌ ⌘K palette completa com busca cross-fiscal (PR #3)
- ❌ Sparklines, alertas, KPIs (são do Cockpit sub-página 1 — PR #2)
- ❌ NFS-e, DF-e, Eventos, Config, SPED (PRs separados)
- ❌ Import XML entrada de fornecedor (depende endpoint NfeBrasil ainda não exposto)
- ❌ JOIN com `transactions`/`contacts` pra dest_name correto — PR #1 lê de `metadata` JSON; PR seguinte adiciona join (perf sob carga real)

## ADRs aplicadas

- **0093** multi-tenant Tier 0 IRREVOGÁVEL — `NfeEmissao` via `HasBusinessScope` global scope
- **0101** tests biz=1 (NUNCA biz=4 — ROTA LIVRE cliente real)
- **0104** MWART — Page nova segue 5 fases (PLAN F1 ✅ aprovado por Wagner ANTES de Edit)
- **0114** cowork-loop — design vindo do Cowork export tarball
- **0143** FSM cancel cascade — `NotaDrawer` reserva botão Cancelar que vai chamar `CancelarVendaCascade` em PR de mutações

## Test plan

- [ ] CI roda Pest `NfeCockpitMultiTenantTest` (3 cenários: global scope, isCancelavel windows, sefazCodes mapping)
- [ ] Smoke prod **biz=1**: navegar `/fiscal/nfe` após deploy → lista de NF-e emitidas deve aparecer com SEFAZ pill colorido
- [ ] Smoke negativo: usuário sem `fiscal.nfe.view` → **403**
- [ ] Sidebar: subscription `fiscal_module` + permission `fiscal.access` → entrada "Fiscal" aparece em order=84
- [ ] Drawer: click em linha → slide-in com detalhe + mapa "Jana sugere" se cstat rejeitado
- [ ] Atalhos: J/K navegam cursor + Enter abre drawer

## Próximos PRs propostos (escopo apresentado, aguarda aprovação Wagner)

| # | Sub-página | Escopo |
|---|---|---|
| 2 | Cockpit (1) | KPIs + alertas + quick links + mini-sparklines |
| 3 | ⌘K palette | Busca cross-fiscal (notas + DF-e + ações rápidas) |
| 4 | Ações mutação | Cancelar/Retransmitir/CC-e/Inutilizar — chama Services NfeBrasil |
| 5 | NFS-e (3) | Sub-página NFS-e (lê `Modules/NFSe/Models/NfseEmissao`) |
| 6 | DF-e (4) | Manifesto destinatário (entradas contra CNPJ) |
| 7 | Eventos + SPED + Config (5/6/7) | Restantes — última pode ser dividida |

## Validação local

- ✅ `npx tsc --noEmit` — sem erros nos arquivos `Pages/Fiscal/*`
- ✅ `npx vite build --config vite.inertia.config.mjs` — exit code 0 (build completo)
- ⚠️ `composer install` local bloqueado por extensions PHP Windows (`ext-pcntl`, `ext-opentelemetry`, `ext-posix`) — CI valida ambiente Linux correto
- ⚠️ Pest local pulado (sem vendor) — CI roda

## Refs

- prototipo-ui design: `Oimpresso ERP Conunicação Visual. Ultimotopo/fiscal-page.jsx §9 FiscalNFePage` + `fiscal-data.jsx` + `Diagnóstico Fiscal - KB-9.75.html`
- Charter: `resources/js/Pages/Fiscal/Nfe.charter.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)