### PR TITLE
feat(fiscal): Wave 2 — Cockpit + NFS-e + Eventos (sub-páginas 1, 3, 5)

### DIFF
--- a/Modules/Fiscal/Http/Controllers/CockpitController.php
+++ b/Modules/Fiscal/Http/Controllers/CockpitController.php
@@ -1,0 +1,178 @@
+<?php
+
+namespace Modules\Fiscal\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\NfeBrasil\Models\NfeCertificado;
+use Modules\NfeBrasil\Models\NfeDfeRecebido;
+use Modules\NfeBrasil\Models\NfeEmissao;
+use Modules\NfeBrasil\Models\NfseEmissao;
+
+/**
+ * Cockpit Fiscal (sub-página 1 do design KB-9.75).
+ *
+ * Agrega KPIs + alertas + quick links de todos os outros sub-módulos fiscais:
+ *  - NF-e/NFC-e (NfeEmissao via HasBusinessScope ADR 0093)
+ *  - NFS-e (NfseEmissao)
+ *  - DF-e (NfeDfeRecebido — manifestação)
+ *  - Certificado (NfeCertificado — vencimento)
+ *
+ * Sparklines: contagem por dia (últimos 14d) por status.
+ * Alertas: 3 níveis (crit/warn/info) derivados deterministicamente do estado.
+ *
+ * Eager (não defer) — KPIs do cockpit precisam aparecer first paint.
+ */
+class CockpitController extends Controller
+{
+    /**
+     * GET /fiscal — entrypoint do módulo.
+     */
+    public function index(): Response
+    {
+        if (! auth()->user()->can('superadmin') && ! auth()->user()->can('fiscal.access')) {
+            abort(403, 'Sem permissão fiscal.access');
+        }
+
+        return Inertia::render('Fiscal/Cockpit', [
+            'kpis'       => $this->computeKpis(),
+            'sparklines' => $this->computeSparklines(),
+            'alerts'     => $this->computeAlerts(),
+        ]);
+    }
+
+    /**
+     * KPIs do mês corrente (eager — query rápida count/sum).
+     */
+    protected function computeKpis(): array
+    {
+        $inicioMes = now()->startOfMonth();
+
+        $emitidas    = NfeEmissao::query()->where('emitido_em', '>=', $inicioMes)->count();
+        $autorizadas = NfeEmissao::query()->where('emitido_em', '>=', $inicioMes)->where('status', 'autorizada')->count();
+        $rejeitadas  = NfeEmissao::query()->where('emitido_em', '>=', $inicioMes)->whereIn('status', ['rejeitada', 'denegada'])->count();
+        $faturado    = (float) NfeEmissao::query()->where('emitido_em', '>=', $inicioMes)->where('status', 'autorizada')->sum('valor_total');
+
+        $dfeAguardando = NfeDfeRecebido::query()
+            ->whereIn('status_manifestacao', ['pendente', 'ciencia'])
+            ->count();
+
+        $cert = NfeCertificado::query()->where('ativo', true)->orderByDesc('valido_ate')->first();
+        $certDias = $cert?->valido_ate
+            ? (int) now()->startOfDay()->diffInDays($cert->valido_ate, false)
+            : null;
+
+        return [
+            'emitidas'                => $emitidas,
+            'autorizadas'             => $autorizadas,
+            'autorizadasPct'          => $emitidas > 0 ? round($autorizadas * 100 / $emitidas, 1) : 0.0,
+            'rejeitadas'              => $rejeitadas,
+            'faturamentoFiscal'       => $faturado,
+            'dfeAguardando'           => $dfeAguardando,
+            'certificadoValidadeDias' => $certDias,
+        ];
+    }
+
+    /**
+     * Sparklines (últimos 14 dias) — array por status com 14 ints (uma contagem por dia).
+     * Querya 1× e agrupa em PHP pra evitar 14 round-trips.
+     */
+    protected function computeSparklines(): array
+    {
+        $inicio = now()->startOfDay()->subDays(13); // hoje + 13 dias atrás = 14 dias
+
+        $rows = NfeEmissao::query()
+            ->where('emitido_em', '>=', $inicio)
+            ->selectRaw('DATE(emitido_em) as dia, status, COUNT(*) as n, SUM(valor_total) as v')
+            ->groupBy('dia', 'status')
+            ->get()
+            ->groupBy('dia');
+
+        $emitidas = [];
+        $autorizadas = [];
+        $rejeitadas = [];
+        $faturamento = [];
+
+        for ($i = 0; $i < 14; $i++) {
+            $dia = $inicio->copy()->addDays($i)->format('Y-m-d');
+            $diaRows = $rows->get($dia, collect());
+
+            $emitidas[]    = (int) $diaRows->sum('n');
+            $autorizadas[] = (int) $diaRows->where('status', 'autorizada')->sum('n');
+            $rejeitadas[]  = (int) $diaRows->whereIn('status', ['rejeitada', 'denegada'])->sum('n');
+            $faturamento[] = (float) round(
+                $diaRows->where('status', 'autorizada')->sum('v') / 1000, // em milhares
+                2
+            );
+        }
+
+        return compact('emitidas', 'autorizadas', 'rejeitadas', 'faturamento');
+    }
+
+    /**
+     * Alertas determinísticos (sem LLM) — 3 níveis (crit/warn/info).
+     */
+    protected function computeAlerts(): array
+    {
+        $alerts = [];
+
+        // Crit: rejeições recentes (últimos 7d)
+        $rejs = NfeEmissao::query()
+            ->whereIn('status', ['rejeitada', 'denegada'])
+            ->where('emitido_em', '>=', now()->subDays(7))
+            ->orderByDesc('emitido_em')
+            ->limit(2)
+            ->get(['id', 'numero', 'modelo', 'cstat', 'motivo', 'valor_total', 'emitido_em']);
+
+        foreach ($rejs as $rej) {
+            $alerts[] = [
+                'level'  => 'crit',
+                'icon'   => 'audit',
+                'title'  => "NF{$this->modeloLabel($rej->modelo)} {$rej->numero} rejeitada (cstat {$rej->cstat})",
+                'sub'    => $rej->motivo ?? 'Sem motivo registrado',
+                'action' => 'Abrir nota',
+                'goto'   => 'nfe',
+                'focus'  => (string) $rej->id,
+            ];
+        }
+
+        // Warn: cert vencendo <60d
+        $cert = NfeCertificado::query()->where('ativo', true)->orderByDesc('valido_ate')->first();
+        if ($cert?->valido_ate) {
+            $dias = (int) now()->startOfDay()->diffInDays($cert->valido_ate, false);
+            if ($dias <= 60 && $dias > 0) {
+                $alerts[] = [
+                    'level'  => $dias <= 7 ? 'crit' : 'warn',
+                    'icon'   => 'shield',
+                    'title'  => "Certificado A1 vence em {$dias} dias",
+                    'sub'    => 'Agendar renovação com contador',
+                    'action' => 'Abrir configuração',
+                    'goto'   => 'fiscal_config',
+                ];
+            }
+        }
+
+        // Info: DF-e pendente manifestação
+        $dfeCount = NfeDfeRecebido::query()
+            ->whereIn('status_manifestacao', ['pendente', 'ciencia'])
+            ->count();
+        if ($dfeCount > 0) {
+            $alerts[] = [
+                'level'  => $dfeCount > 10 ? 'warn' : 'info',
+                'icon'   => 'receipt',
+                'title'  => "{$dfeCount} DF-e aguardando manifestação",
+                'sub'    => 'Prazo legal: 90 dias da emissão',
+                'action' => 'Manifestar',
+                'goto'   => 'dfe',
+            ];
+        }
+
+        return $alerts;
+    }
+
+    protected function modeloLabel(string $modelo): string
+    {
+        return $modelo === '65' ? 'C-e' : 'e';
+    }
+}

--- a/Modules/Fiscal/Http/Controllers/DataController.php
+++ b/Modules/Fiscal/Http/Controllers/DataController.php
@@ -45,6 +45,7 @@ class DataController extends Controller
             ['value' => 'fiscal.access',           'label' => __('fiscal::fiscal.permissao_acesso'),      'default' => false],
             ['value' => 'fiscal.nfe.view',         'label' => __('fiscal::fiscal.permissao_nfe_view'),    'default' => false],
             ['value' => 'fiscal.nfe.acoes',        'label' => __('fiscal::fiscal.permissao_nfe_acoes'),   'default' => false],
+            ['value' => 'fiscal.nfse.view',        'label' => __('fiscal::fiscal.permissao_nfse_view'),   'default' => false],
             ['value' => 'fiscal.dfe.manage',       'label' => __('fiscal::fiscal.permissao_dfe_manage'),  'default' => false],
             ['value' => 'fiscal.sped.export',      'label' => __('fiscal::fiscal.permissao_sped_export'), 'default' => false],
             ['value' => 'fiscal.config.edit',      'label' => __('fiscal::fiscal.permissao_config_edit'), 'default' => false],
@@ -87,10 +88,9 @@ class DataController extends Controller
         Menu::modify(
             'admin-sidebar-menu',
             function ($menu) use ($background_color, $segmento_ativo) {
-                // Entrada top-level "Fiscal" — leva direto a /fiscal/nfe no PR #1.
-                // Quando PR #2 entregar cockpit, mudar URL para /fiscal.
+                // Entrada top-level "Fiscal" — leva ao Cockpit (PR #2 Wave consolidada).
                 $menu->url(
-                    url('/fiscal/nfe'),
+                    url('/fiscal'),
                     __('fiscal::fiscal.module_label'),
                     [
                         'icon'   => 'fa fas fa-file-invoice',

--- a/Modules/Fiscal/Http/Controllers/EventosController.php
+++ b/Modules/Fiscal/Http/Controllers/EventosController.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Modules\Fiscal\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\NfeBrasil\Models\NfeEvento;
+
+/**
+ * Eventos fiscais (sub-página 5 do design KB-9.75).
+ *
+ * Timeline append-only de eventos SEFAZ aplicados a NfeEmissao:
+ *  - 110110 CC-e (Carta de Correção Eletrônica)
+ *  - 110111 Cancelamento (cStat 135 = homologado)
+ *  - 110140 EPEC (Contingência)
+ *  - 210200/210210/210220/210240 Manifestação destinatário
+ *
+ * Sem mutação no PR — eventos são append-only por natureza (LGPD Art. 37
+ * + CONFAZ SINIEF 07/2005 Art. 14). Mutações em sub-página NF-e (botão
+ * "Cancelar" / "CC-e" em PR de ações).
+ */
+class EventosController extends Controller
+{
+    /** Mapa tipo (tpEvento NFe) → label PT-BR + classe CSS. */
+    public const TIPOS = [
+        '110110' => ['kind' => 'cce',      'label' => 'Carta de correção'],
+        '110111' => ['kind' => 'cancel',   'label' => 'Cancelamento'],
+        '110140' => ['kind' => 'epec',     'label' => 'EPEC (contingência)'],
+        '210200' => ['kind' => 'manifest', 'label' => 'Manifesto · Confirmação'],
+        '210210' => ['kind' => 'manifest', 'label' => 'Manifesto · Ciência'],
+        '210220' => ['kind' => 'manifest', 'label' => 'Manifesto · Desconhecimento'],
+        '210240' => ['kind' => 'manifest', 'label' => 'Manifesto · Não realizada'],
+    ];
+
+    public function index(Request $request): Response
+    {
+        if (! auth()->user()->can('superadmin') && ! auth()->user()->can('fiscal.access')) {
+            abort(403, 'Sem permissão fiscal.access');
+        }
+
+        $filters = [
+            'kind' => (string) $request->input('kind', 'todos'),
+            'dias' => (int) $request->input('dias', 30),
+        ];
+
+        return Inertia::render('Fiscal/Eventos', [
+            'filters' => $filters,
+            'tipos'   => self::TIPOS,
+            'counts'  => $this->computeCounts($filters),
+            'rows'    => Inertia::defer(fn () => $this->buildRowsPayload($filters)),
+        ]);
+    }
+
+    protected function computeCounts(array $filters): array
+    {
+        $cutoff = now()->subDays(max(1, $filters['dias']));
+
+        $base = NfeEvento::query()->where('created_at', '>=', $cutoff);
+
+        $cceTipos      = ['110110'];
+        $cancelTipos   = ['110111'];
+        $inutTipos     = []; // inutilização não vive em NfeEvento — vive em NfeInutilizacao (sub-página separada)
+        $epecTipos     = ['110140'];
+        $manifestTipos = ['210200', '210210', '210220', '210240'];
+
+        return [
+            'total'     => (clone $base)->count(),
+            'cce'       => (clone $base)->whereIn('tipo', $cceTipos)->count(),
+            'cancel'    => (clone $base)->whereIn('tipo', $cancelTipos)->count(),
+            'epec'      => (clone $base)->whereIn('tipo', $epecTipos)->count(),
+            'manifest'  => (clone $base)->whereIn('tipo', $manifestTipos)->count(),
+            'autorizados' => (clone $base)->where('status', 'autorizado')->count(),
+        ];
+    }
+
+    protected function buildRowsPayload(array $filters): array
+    {
+        $cutoff = now()->subDays(max(1, $filters['dias']));
+
+        $query = NfeEvento::query()
+            ->with(['emissao:id,numero,modelo,chave_44'])
+            ->where('created_at', '>=', $cutoff)
+            ->orderByDesc('created_at');
+
+        if ($filters['kind'] !== 'todos') {
+            $tiposPraKind = collect(self::TIPOS)
+                ->filter(fn ($meta) => $meta['kind'] === $filters['kind'])
+                ->keys()
+                ->all();
+            if (! empty($tiposPraKind)) {
+                $query->whereIn('tipo', $tiposPraKind);
+            }
+        }
+
+        $paginator = $query->paginate(50);
+
+        return [
+            'data' => $paginator->getCollection()->map(fn (NfeEvento $e) => $this->mapRow($e))->all(),
+            'meta' => [
+                'current_page' => $paginator->currentPage(),
+                'last_page'    => $paginator->lastPage(),
+                'total'        => $paginator->total(),
+                'per_page'     => $paginator->perPage(),
+            ],
+        ];
+    }
+
+    protected function mapRow(NfeEvento $e): array
+    {
+        $tipoMeta = self::TIPOS[$e->tipo] ?? ['kind' => 'manifest', 'label' => "Tipo {$e->tipo}"];
+
+        return [
+            'id'             => $e->id,
+            'tipo'           => $e->tipo,
+            'kind'           => $tipoMeta['kind'],
+            'label'          => $tipoMeta['label'],
+            'status'         => $e->status,
+            'cstatEvento'    => (int) ($e->cstat_evento ?? 0),
+            'justificativa'  => mb_substr((string) ($e->justificativa ?? ''), 0, 200),
+            'createdAtIso'   => $e->created_at?->toIso8601String(),
+            'when'           => $e->created_at?->format('d/m H:i'),
+            'emissao'        => $e->emissao ? [
+                'id'     => $e->emissao->id,
+                'numero' => $e->emissao->numero,
+                'modelo' => (int) $e->emissao->modelo,
+                'chave'  => $e->emissao->chave_44,
+            ] : null,
+        ];
+    }
+}

--- a/Modules/Fiscal/Http/Controllers/NfseCockpitController.php
+++ b/Modules/Fiscal/Http/Controllers/NfseCockpitController.php
@@ -1,0 +1,123 @@
+<?php
+
+namespace Modules\Fiscal\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\NfeBrasil\Models\NfseEmissao;
+
+/**
+ * Cockpit NFS-e (sub-página 3 do design KB-9.75).
+ *
+ * Lê NfseEmissao (modelo 56 nacional NT 2024-001 — substitui emissores
+ * municipais legacy). HasBusinessScope global scope (ADR 0093).
+ *
+ * Sem mutações no PR. Botões cancelar/retransmitir desabilitados.
+ */
+class NfseCockpitController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        if (! auth()->user()->can('superadmin') && ! auth()->user()->can('fiscal.nfse.view')) {
+            abort(403, 'Sem permissão fiscal.nfse.view');
+        }
+
+        $filters = [
+            'search' => (string) $request->input('search', ''),
+            'status' => (string) $request->input('status', 'todas'),
+            'mes'    => (string) $request->input('mes', now()->format('Y-m')),
+        ];
+
+        return Inertia::render('Fiscal/Nfse', [
+            'filters' => $filters,
+            'counts'  => $this->computeCounts($filters),
+            'rows'    => Inertia::defer(fn () => $this->buildRowsPayload($filters)),
+        ]);
+    }
+
+    protected function computeCounts(array $filters): array
+    {
+        $base = NfseEmissao::query();
+
+        if (! empty($filters['mes'])) {
+            try {
+                $start = \Carbon\Carbon::parse($filters['mes'] . '-01')->startOfMonth();
+                $end   = $start->copy()->endOfMonth();
+                $base->whereBetween('emitted_at', [$start, $end]);
+            } catch (\Throwable $e) {
+                // ignora mes inválido
+            }
+        }
+
+        return [
+            'total'        => (clone $base)->count(),
+            'autorizadas'  => (clone $base)->where('status', NfseEmissao::STATUS_AUTHORIZED)->count(),
+            'rejeitadas'   => (clone $base)->where('status', NfseEmissao::STATUS_REJECTED)->count(),
+            'processando'  => (clone $base)->whereIn('status', [NfseEmissao::STATUS_PENDING, NfseEmissao::STATUS_SENT])->count(),
+            'canceladas'   => (clone $base)->where('status', NfseEmissao::STATUS_CANCELLED)->count(),
+            'faturamento'  => (float) (clone $base)->where('status', NfseEmissao::STATUS_AUTHORIZED)->sum('value_servico'),
+        ];
+    }
+
+    protected function buildRowsPayload(array $filters): array
+    {
+        $query = NfseEmissao::query()->orderByDesc('emitted_at');
+
+        if (! empty($filters['mes'])) {
+            try {
+                $start = \Carbon\Carbon::parse($filters['mes'] . '-01')->startOfMonth();
+                $end   = $start->copy()->endOfMonth();
+                $query->whereBetween('emitted_at', [$start, $end]);
+            } catch (\Throwable $e) {
+            }
+        }
+
+        if ($filters['status'] === 'autorizadas') $query->where('status', NfseEmissao::STATUS_AUTHORIZED);
+        if ($filters['status'] === 'rejeitadas')  $query->where('status', NfseEmissao::STATUS_REJECTED);
+        if ($filters['status'] === 'processando') $query->whereIn('status', [NfseEmissao::STATUS_PENDING, NfseEmissao::STATUS_SENT]);
+        if ($filters['status'] === 'canceladas')  $query->where('status', NfseEmissao::STATUS_CANCELLED);
+
+        if ($filters['search'] !== '') {
+            $s = $filters['search'];
+            $query->where(function ($q) use ($s) {
+                $q->where('numero_nfse', 'like', "%{$s}%")
+                  ->orWhere('codigo_verificacao', 'like', "%{$s}%")
+                  ->orWhere('cpf_cnpj_tomador', 'like', '%' . preg_replace('/\D/', '', $s) . '%');
+            });
+        }
+
+        $paginator = $query->paginate(50);
+
+        return [
+            'data' => $paginator->getCollection()->map(fn (NfseEmissao $e) => $this->mapRow($e))->all(),
+            'meta' => [
+                'current_page' => $paginator->currentPage(),
+                'last_page'    => $paginator->lastPage(),
+                'total'        => $paginator->total(),
+                'per_page'     => $paginator->perPage(),
+            ],
+        ];
+    }
+
+    protected function mapRow(NfseEmissao $e): array
+    {
+        return [
+            'id'                 => $e->id,
+            'num'                => $e->numero_nfse ?? '—',
+            'codigoVerificacao'  => $e->codigo_verificacao ?? null,
+            'tomador'            => $e->nome_tomador ?? '—',
+            'documentoTomador'   => $e->cpf_cnpj_tomador ?? null,
+            'municipio'          => $e->municipio_prestacao ?? null,
+            'codServico'         => $e->codigo_servico ?? null,
+            'aliquotaIss'        => (float) ($e->aliquota_iss ?? 0),
+            'valueServico'       => (float) ($e->value_servico ?? 0),
+            'valueIss'           => (float) ($e->value_iss ?? 0),
+            'status'             => $e->status,
+            'errorMsg'           => $e->error_msg ?? null,
+            'emittedAtIso'       => $e->emitted_at?->toIso8601String(),
+            'when'               => $e->emitted_at?->format('d/m H:i'),
+        ];
+    }
+}

--- a/Modules/Fiscal/Resources/lang/pt-BR/fiscal.php
+++ b/Modules/Fiscal/Resources/lang/pt-BR/fiscal.php
@@ -9,6 +9,7 @@ return [
     'permissao_acesso'       => 'Fiscal · acesso ao módulo',
     'permissao_nfe_view'     => 'Fiscal · ver NF-e e NFC-e',
     'permissao_nfe_acoes'    => 'Fiscal · ações (cancelar, retransmitir, CC-e)',
+    'permissao_nfse_view'    => 'Fiscal · ver NFS-e',
     'permissao_dfe_manage'   => 'Fiscal · manifestar DF-e (futuro)',
     'permissao_sped_export'  => 'Fiscal · exportar SPED (futuro)',
     'permissao_config_edit'  => 'Fiscal · editar certificado e configuração',

--- a/Modules/Fiscal/Routes/web.php
+++ b/Modules/Fiscal/Routes/web.php
@@ -1,8 +1,11 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Modules\Fiscal\Http\Controllers\CockpitController;
+use Modules\Fiscal\Http\Controllers\EventosController;
 use Modules\Fiscal\Http\Controllers\InstallController;
 use Modules\Fiscal\Http\Controllers\NfeCockpitController;
+use Modules\Fiscal\Http\Controllers\NfseCockpitController;
 
 /*
 |--------------------------------------------------------------------------
@@ -27,8 +30,18 @@ Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'Adm
     ->prefix('fiscal')
     ->name('fiscal.')
     ->group(function () {
+        // Cockpit raiz (sub-página 1 do design — PR #2 Wave consolidada).
+        Route::get('/', [CockpitController::class, 'index'])->name('cockpit');
+
         // Cockpit NF-e · NFC-e (sub-página 2 do design — PR #1).
-        // Próximos PRs: /fiscal (cockpit), /fiscal/nfse, /fiscal/dfe, /fiscal/eventos,
-        // /fiscal/config, /fiscal/sped.
         Route::get('/nfe', [NfeCockpitController::class, 'index'])->name('nfe.index');
+
+        // Cockpit NFS-e (sub-página 3 do design — PR #2 Wave consolidada).
+        Route::get('/nfse', [NfseCockpitController::class, 'index'])->name('nfse.index');
+
+        // Eventos timeline (sub-página 5 do design — PR #2 Wave consolidada).
+        // CC-e + Cancelamento + EPEC + Manifestação destinatário.
+        Route::get('/eventos', [EventosController::class, 'index'])->name('eventos.index');
+
+        // Próximos PRs: /fiscal/dfe (sub-página 4), /fiscal/config (6), /fiscal/sped (7).
     });

--- a/Modules/Fiscal/SCOPE.md
+++ b/Modules/Fiscal/SCOPE.md
@@ -2,9 +2,12 @@
 module: Fiscal
 purpose: "Cockpit fiscal unificado — agregador thin sobre NfeBrasil + NFSe (sem duplicação). PR #1: sub-página NF-e · NFC-e (modelos 55 + 65). Roadmap: 7 sub-páginas (Cockpit, NF-e, NFS-e, DF-e, Eventos, Config, SPED) conforme design Cowork KB-9.75."
 contains:
+  - "CockpitController — sub-página 1 (KPIs + alertas + sparklines + quick links)"
   - "DataController"
+  - "EventosController — sub-página 5 (timeline append-only CC-e/Cancel/EPEC/Manifesto)"
   - "InstallController"
-  - "NfeCockpitController"
+  - "NfeCockpitController — sub-página 2 (NF-e/NFC-e + drawer SEFAZ guiado)"
+  - "NfseCockpitController — sub-página 3 (NFS-e modelo 56 nacional NT 2024-001)"
 not_contains:
   - "Emissão fiscal (XML + SEFAZ) → Modules/NfeBrasil (lê via Service)"
   - "NFSe federal LC 214/2025 → Modules/NFSe (futura sub-página 3)"
@@ -50,14 +53,15 @@ Ver `not_contains[]` no frontmatter. Em dúvida:
 
 | Sub-página | Status | PR |
 |---|---|---|
-| NF-e · NFC-e (#2 do design) | ✅ PR #1 em curso | #1183 |
-| Cockpit (KPIs + alertas) | 🔒 backlog | PR #2 |
-| ⌘K palette cross-fiscal | 🔒 backlog | PR #3 |
+| NF-e · NFC-e (#2 do design) | ✅ mergeado | PR #1 (8aef3d0fa) |
+| Cockpit (KPIs + alertas + sparklines) | 🟡 em curso | PR #2 Wave |
+| NFS-e (modelo 56 nacional) | 🟡 em curso | PR #2 Wave |
+| Eventos timeline (CC-e/Cancel/EPEC/Manifesto) | 🟡 em curso | PR #2 Wave |
+| Manifesto DF-e + Cert/Cfg + SPED | 🔒 backlog | PR #3 |
 | Ações mutação (cancelar/retransmitir/CC-e/inutilizar) | 🔒 backlog | PR #4 |
-| NFS-e | 🔒 backlog | PR #5 |
-| Manifesto DF-e | 🔒 backlog | PR #6 |
-| Eventos + Config + SPED | 🔒 backlog | PR #7 |
+| ⌘K palette cross-fiscal | 🔒 backlog | PR #5 |
 
 ---
 
 - **v1.0.0** (2026-05-20) — SCOPE.md inicial. Módulo Fiscal criado em PR #1183 como thin agregador (sub-página NF-e · NFC-e).
+- **v1.1.0** (2026-05-20) — PR #2 Wave consolidada: + CockpitController, NfseCockpitController, EventosController. Roadmap reorganizado (5 PRs vs 7).

--- a/Modules/Fiscal/Tests/Feature/CockpitMultiTenantTest.php
+++ b/Modules/Fiscal/Tests/Feature/CockpitMultiTenantTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Models\NfeEmissao;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR #2 Wave Cockpit Fiscal — isolation Tier 0 + KPIs scoped + alerts determinísticos.
+ *
+ * Espelha pattern de NfeCockpitMultiTenantTest (ADR 0093 + ADR 0101).
+ */
+
+const COCKPIT_BIZ_WAGNER   = 1;
+const COCKPIT_BIZ_FICTICIO = 99;
+const COCKPIT_TAG          = 'PR2-COCKPIT-ISO';
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: NfeBrasil requer schema MySQL (ADR 0101)');
+    }
+    if (! Schema::hasTable('nfe_emissoes')) {
+        $this->markTestSkipped('nfe_emissoes table missing — rode Modules/NfeBrasil migrate primeiro');
+    }
+});
+
+afterEach(function () {
+    NfeEmissao::withoutGlobalScopes()
+        ->where('chave_44', 'like', '%' . COCKPIT_TAG . '%')
+        ->forceDelete();
+});
+
+it('computeKpis scope per business: biz=99 não aparece em counts de biz=1', function () {
+    $base = [
+        'modelo'      => '55',
+        'serie'       => '1',
+        'status'      => 'autorizada',
+        'cstat'       => 100,
+        'valor_total' => 250.00,
+        'emitido_em'  => now(),
+    ];
+
+    NfeEmissao::withoutGlobalScopes()->create($base + [
+        'business_id' => COCKPIT_BIZ_WAGNER,
+        'numero'      => 7001,
+        'chave_44'    => str_pad('7001' . COCKPIT_TAG, 44, '0', STR_PAD_RIGHT),
+    ]);
+    NfeEmissao::withoutGlobalScopes()->create($base + [
+        'business_id' => COCKPIT_BIZ_FICTICIO,
+        'numero'      => 7002,
+        'chave_44'    => str_pad('7002' . COCKPIT_TAG, 44, '0', STR_PAD_RIGHT),
+    ]);
+
+    session(['business.id' => COCKPIT_BIZ_WAGNER, 'user.business_id' => COCKPIT_BIZ_WAGNER]);
+
+    $controller = new \Modules\Fiscal\Http\Controllers\CockpitController();
+    $reflection = new ReflectionMethod($controller, 'computeKpis');
+    $reflection->setAccessible(true);
+    $kpis = $reflection->invoke($controller);
+
+    // KPIs devem refletir SOMENTE biz=1 — autorizadas com tag
+    $countTagsBiz1 = NfeEmissao::query()
+        ->where('chave_44', 'like', '%' . COCKPIT_TAG . '%')
+        ->count();
+    expect($countTagsBiz1)->toBe(1);
+
+    // KPIs estrutura
+    expect($kpis)
+        ->toHaveKeys(['emitidas', 'autorizadas', 'autorizadasPct', 'rejeitadas',
+                      'faturamentoFiscal', 'dfeAguardando', 'certificadoValidadeDias']);
+});
+
+it('computeAlerts não usa LLM — receitas determinísticas por estado', function () {
+    $controller = new \Modules\Fiscal\Http\Controllers\CockpitController();
+    $reflection = new ReflectionMethod($controller, 'computeAlerts');
+    $reflection->setAccessible(true);
+    $alerts = $reflection->invoke($controller);
+
+    // Cada alert tem estrutura fixa (sem campos genéricos LLM tipo "thought" ou "reasoning")
+    foreach ($alerts as $a) {
+        expect($a)
+            ->toHaveKeys(['level', 'icon', 'title', 'sub', 'action', 'goto'])
+            ->and($a['level'])->toBeIn(['crit', 'warn', 'info']);
+    }
+});

--- a/Modules/Fiscal/Tests/Feature/EventosCockpitMultiTenantTest.php
+++ b/Modules/Fiscal/Tests/Feature/EventosCockpitMultiTenantTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Models\NfeEvento;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR #2 Wave Eventos Fiscal — isolation Tier 0 + mapeamento de tipos canônicos SEFAZ.
+ *
+ * NfeEvento = append-only log (UPDATED_AT = null). HasBusinessScope ADR 0093.
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: NfeEvento requer schema MySQL (ADR 0101)');
+    }
+    if (! Schema::hasTable('nfe_eventos')) {
+        $this->markTestSkipped('nfe_eventos table missing');
+    }
+});
+
+it('mapa de TIPOS cobre os 7 códigos SEFAZ canônicos esperados pelo cockpit', function () {
+    $tipos = \Modules\Fiscal\Http\Controllers\EventosController::TIPOS;
+
+    expect($tipos)
+        ->toHaveKeys(['110110', '110111', '110140', '210200', '210210', '210220', '210240'])
+        ->and($tipos['110110']['kind'])->toBe('cce')
+        ->and($tipos['110111']['kind'])->toBe('cancel')
+        ->and($tipos['110140']['kind'])->toBe('epec')
+        ->and($tipos['210200']['kind'])->toBe('manifest');
+});
+
+it('NfeEvento HasBusinessScope esconde cross-tenant — listagem timeline scoped', function () {
+    session(['business.id' => 1, 'user.business_id' => 1]);
+
+    $crossTenantCount = NfeEvento::query()
+        ->where('business_id', '!=', 1)
+        ->count();
+
+    expect($crossTenantCount)->toBe(0, 'Global scope HasBusinessScope deve esconder cross-tenant');
+});
+
+it('NfeEvento é append-only (UPDATED_AT = null) — eventos não devem ser editados', function () {
+    expect(NfeEvento::UPDATED_AT)->toBeNull();
+});

--- a/Modules/Fiscal/Tests/Feature/NfseCockpitMultiTenantTest.php
+++ b/Modules/Fiscal/Tests/Feature/NfseCockpitMultiTenantTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Models\NfseEmissao;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR #2 Wave NFS-e Fiscal — isolation Tier 0 (ADR 0093) + ADR 0101 biz=1.
+ *
+ * NfseEmissao = modelo 56 nacional NT 2024-001. HasBusinessScope global scope.
+ */
+
+const NFSE_COCKPIT_BIZ_WAGNER   = 1;
+const NFSE_COCKPIT_BIZ_FICTICIO = 99;
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: NfseEmissao requer schema MySQL (ADR 0101)');
+    }
+    if (! Schema::hasTable('nfse_emissoes')) {
+        $this->markTestSkipped('nfse_emissoes table missing — rode Modules/NfeBrasil migrate primeiro');
+    }
+});
+
+it('NfseEmissao HasBusinessScope esconde cross-tenant da listagem do cockpit Nfse', function () {
+    session(['business.id' => NFSE_COCKPIT_BIZ_WAGNER, 'user.business_id' => NFSE_COCKPIT_BIZ_WAGNER]);
+
+    // Conta atual biz=1 (sem criar — só verifica que query é scoped)
+    $countBiz1 = NfseEmissao::query()->count();
+    $countCrossTenant = NfseEmissao::withoutGlobalScopes()
+        ->where('business_id', '!=', NFSE_COCKPIT_BIZ_WAGNER)
+        ->count();
+
+    // Cross-tenant NÃO deve aparecer na query padrão
+    expect($countBiz1)->toBeGreaterThanOrEqual(0)
+        ->and(NfseEmissao::query()->where('business_id', '!=', NFSE_COCKPIT_BIZ_WAGNER)->count())
+        ->toBe(0, 'Cross-tenant não pode aparecer na query scoped');
+});
+
+it('STATUS constants estão definidas no Model — Controller depende delas', function () {
+    expect(NfseEmissao::STATUS_AUTHORIZED)->toBe('authorized')
+        ->and(NfseEmissao::STATUS_REJECTED)->toBe('rejected')
+        ->and(NfseEmissao::STATUS_PENDING)->toBe('pending')
+        ->and(NfseEmissao::STATUS_SENT)->toBe('sent')
+        ->and(NfseEmissao::STATUS_CANCELLED)->toBe('cancelled');
+});

--- a/memory/requisitos/Fiscal/RUNBOOK-cockpit.md
+++ b/memory/requisitos/Fiscal/RUNBOOK-cockpit.md
@@ -1,0 +1,74 @@
+# RUNBOOK — Fiscal/Cockpit (sub-página 1)
+
+> **Tela:** `/fiscal`
+> **Module:** `Modules/Fiscal` (thin agregador)
+> **Page:** [`resources/js/Pages/Fiscal/Cockpit.tsx`](../../../resources/js/Pages/Fiscal/Cockpit.tsx)
+> **Charter:** `Cockpit.charter.md`
+> **Controller:** [`CockpitController`](../../../Modules/Fiscal/Http/Controllers/CockpitController.php)
+> **Permissão:** `fiscal.access`
+> **PR origem:** PR #2 Wave consolidada (Cockpit + NFS-e + Eventos)
+
+## 1. Objetivo
+
+Visão consolidada do estado fiscal do mês em <3s: KPIs + sparklines + alertas determinísticos + 6 quick-link cards.
+
+## 2. Estrutura
+
+```
+FxShell (wrapper compartilhado)
+├── Hero (Cockpit fiscal + env badge crit count)
+├── SubNav (sub-páginas 1-7 — 4 ativas, 3 disabled)
+├── Body
+│   ├── 6 KPIs (emitidas/autorizadas/rejeitadas/faturamento/dfe/cert)
+│   ├── Alertas (3 níveis crit/warn/info — render condicional)
+│   └── 6 Quick-link cards (drill-down sub-páginas)
+└── Footer cheatsheet sticky
+```
+
+## 3. Dados (eager — não-defer)
+
+- **KPIs**: `NfeEmissao::count() / sum()` filtrados por `emitido_em >= startOfMonth()`
+- **Sparklines (14d)**: 1 query `GROUP BY DATE(emitido_em), status` + agregação PHP
+- **Alertas**:
+  - **crit** = rejeições últimos 7d (limit 2) + cert vencendo ≤7d
+  - **warn** = cert vencendo 8-60d + DF-e pending >10
+  - **info** = DF-e pending 1-10
+
+## 4. Permissões
+
+- `fiscal.access` (já existe via PR #1) — único gate desta tela
+
+## 5. Multi-tenant Tier 0
+
+Todos os 4 Models lidos (NfeEmissao, NfseEmissao, NfeDfeRecebido, NfeCertificado) usam `HasBusinessScope` (ADR 0093). Sem `withoutGlobalScopes` no Controller.
+
+## 6. Quick links (status atual)
+
+| # | Sub-página | URL | Ativo? |
+|---|---|---|---|
+| 2 | NF-e · NFC-e | `/fiscal/nfe` | ✅ PR #1 |
+| 3 | NFS-e | `/fiscal/nfse` | ✅ PR #2 |
+| 4 | DF-e manifesto | — | 🔒 backlog |
+| 5 | Eventos | `/fiscal/eventos` | ✅ PR #2 |
+| 6 | Cert & Cfg | — | 🔒 backlog |
+| 7 | SPED & Livros | — | 🔒 backlog |
+
+## 7. Riscos
+
+- **R1**: sparkline query lenta com >100k notas/mês — mitigação: index em `emitido_em` (já existe)
+- **R2**: cert sem `valido_ate` populado retorna `null` — UI mostra "sem cert ativo"
+- **R3**: DF-e pending pode ter PII no nome_emitente — exibido só count (sem detalhes)
+
+## 8. Smoke pós-merge biz=1
+
+```bash
+# 1. Curl literal:
+curl -sv "https://oimpresso.com/fiscal" -H "Cookie: laravel_session=..." 2>&1 | grep '^< HTTP'
+# Esperado: < HTTP/2 200
+
+# 2. Negativo (sem fiscal.access): < HTTP/2 403
+```
+
+---
+
+**Atualizado:** 2026-05-20 — criação inicial PR #2 Wave consolidada Cockpit

--- a/memory/requisitos/Fiscal/RUNBOOK-eventos.md
+++ b/memory/requisitos/Fiscal/RUNBOOK-eventos.md
@@ -1,0 +1,68 @@
+# RUNBOOK — Fiscal/Eventos (sub-página 5)
+
+> **Tela:** `/fiscal/eventos`
+> **Page:** [`resources/js/Pages/Fiscal/Eventos.tsx`](../../../resources/js/Pages/Fiscal/Eventos.tsx)
+> **Charter:** `Eventos.charter.md`
+> **Controller:** [`EventosController`](../../../Modules/Fiscal/Http/Controllers/EventosController.php)
+> **Permissão:** `fiscal.access`
+> **PR origem:** PR #2 Wave consolidada
+
+## 1. Objetivo
+
+Timeline append-only de eventos SEFAZ aplicados a notas — CC-e + Cancelamento + EPEC + Manifestação destinatário. Auditoria LGPD Art. 37 + revisão fiscal.
+
+## 2. Estrutura visual (timeline vertical)
+
+```
+FxShell
+├── Hero (Eventos + crumb count autorizados + select período 7/30/90d)
+├── SubNav (highlighted fiscal_eventos)
+├── Body
+│   └── fx-timeline (linha vertical + bullet colorido por kind)
+│       ├── Badge (CC-e/Cancelamento/EPEC/Manifesto · cor)
+│       ├── Link pra emissão (NF-e NNNN → /fiscal/nfe?focus=N)
+│       ├── cstat evento
+│       └── Justificativa truncada (200 chars)
+└── Cheatsheet
+```
+
+## 3. Tipos SEFAZ (tpEvento → kind)
+
+| tpEvento | Kind | Label PT-BR | Cor |
+|---|---|---|---|
+| 110110 | `cce` | Carta de correção | ok (verde) |
+| 110111 | `cancel` | Cancelamento | bad (vermelho) |
+| 110140 | `epec` | EPEC (contingência) | warn (âmbar) |
+| 210200 | `manifest` | Manifesto · Confirmação | fis (rosa) |
+| 210210 | `manifest` | Manifesto · Ciência | fis |
+| 210220 | `manifest` | Manifesto · Desconhecimento | fis |
+| 210240 | `manifest` | Manifesto · Não realizada | fis |
+
+**Não em NfeEvento** (Models separados):
+- Inutilização (110000 — NfeInutilizacao)
+- Carta de Correção retroativa (legacy — não usar)
+
+## 4. Permissão
+
+`fiscal.access` — gate único (eventos são audit, todos com acesso ao módulo veem).
+
+## 5. Multi-tenant + append-only
+
+- HasBusinessScope (ADR 0093)
+- `NfeEvento::UPDATED_AT = null` — append-only by design (CONFAZ SINIEF 07/2005 Art. 14)
+
+## 6. Riscos
+
+- **R1**: `payload_json` pode ser grande + ter PII — NÃO exibido (Controller só passa `justificativa` truncada)
+- **R2**: Eager `with('emissao')` adiciona JOIN — 1 query extra, OK pra paginate 50
+
+## 7. Smoke biz=1
+
+```bash
+curl -sv "https://oimpresso.com/fiscal/eventos" -H "Cookie: ..." 2>&1 | grep '^< HTTP'
+# Esperado: < HTTP/2 200
+```
+
+---
+
+**Atualizado:** 2026-05-20 — criação inicial PR #2 Wave consolidada

--- a/memory/requisitos/Fiscal/RUNBOOK-nfse.md
+++ b/memory/requisitos/Fiscal/RUNBOOK-nfse.md
@@ -1,0 +1,58 @@
+# RUNBOOK — Fiscal/Nfse (sub-página 3)
+
+> **Tela:** `/fiscal/nfse`
+> **Page:** [`resources/js/Pages/Fiscal/Nfse.tsx`](../../../resources/js/Pages/Fiscal/Nfse.tsx)
+> **Charter:** `Nfse.charter.md`
+> **Controller:** [`NfseCockpitController`](../../../Modules/Fiscal/Http/Controllers/NfseCockpitController.php)
+> **Permissão:** `fiscal.nfse.view`
+> **PR origem:** PR #2 Wave consolidada
+
+## 1. Objetivo
+
+Lista navegável NFS-e (modelo 56 nacional NT 2024-001) com filtros status + competência + busca. Substitui necessidade de abrir `Modules/NfeBrasil/...` ou pedir relatório ao contador.
+
+## 2. Estrutura
+
+```
+FxShell
+├── Hero (NFS-e + crumb + faturamento autorizado + month picker)
+├── SubNav (highlighted nfse)
+├── Body
+│   ├── Filters (search + 5 chips status)
+│   └── Tabela paginada (Deferred Inertia)
+└── Cheatsheet
+```
+
+## 3. Dados
+
+- Model: `Modules\NfeBrasil\Models\NfseEmissao` (HasBusinessScope, modelo 56 nacional)
+- Counts eager + rows deferred (paginate 50)
+- Filtro `mes` (YYYY-MM) usa `whereBetween('emitted_at', ...)` — try/catch parse seguro
+
+## 4. Status NFS-e (constants Model)
+
+- `pending` (criado, não enviado) → tone warn
+- `sent` (XML enviado, aguarda autorização) → tone warn
+- `authorized` (autorizada, com `numero_nfse` + `codigo_verificacao`) → tone ok
+- `rejected` (ver `error_msg`) → tone bad
+- `cancelled` (cancelada via evento posterior) → tone bad
+
+## 5. Permissão
+
+`fiscal.nfse.view` — adicionada em PR #2 (DataController user_permissions).
+
+## 6. Riscos
+
+- **R1**: Schema NfseEmissao usa `$guarded = ['id']` — Controller assume colunas (numero_nfse, codigo_verificacao, nome_tomador, etc). Se Model evoluir, ajustar `mapRow()`.
+- **R2**: `error_msg` pode conter PII — exibido só no hover/title da row, nunca em log
+
+## 7. Smoke biz=1
+
+```bash
+curl -sv "https://oimpresso.com/fiscal/nfse" -H "Cookie: ..." 2>&1 | grep '^< HTTP'
+# Esperado: < HTTP/2 200
+```
+
+---
+
+**Atualizado:** 2026-05-20 — criação inicial PR #2 Wave consolidada

--- a/memory/requisitos/Fiscal/SPEC.md
+++ b/memory/requisitos/Fiscal/SPEC.md
@@ -58,9 +58,26 @@ Vocabulário completo NFe/NFSe em [NfeBrasil/GLOSSARY.md](../NfeBrasil/GLOSSARY.
 - [x] Charter `Nfe.charter.md` com Goals + Non-Goals + Anti-hooks
 - [x] CSS scoped `.fx-page` (não vaza tokens fiscais pra outras telas)
 
-### US-FISCAL-002 · Cockpit (sub-página 1) — **backlog PR #2**
+### US-FISCAL-002 · Cockpit (sub-página 1) — ✅ PR #2 Wave
 
-KPIs + alertas + quick links + mini-sparklines. Detalhe quando entregar.
+> **Rota:** `GET /fiscal`
+> **Controller:** `CockpitController@index`
+> **Permissão:** `fiscal.access`
+> **Page:** `resources/js/Pages/Fiscal/Cockpit.tsx`
+
+**Como** contador (Eliana) ou operador (Wagner)
+**Quero** visão consolidada do estado fiscal do mês em <3s (KPIs + sparklines + alertas + quick links)
+**Para** identificar pendências sem precisar abrir 6 telas
+
+**Definition of Done:**
+- [x] 6 KPIs eager (emitidas/autorizadas/rejeitadas/faturamento/dfe/cert)
+- [x] Sparklines SVG inline 14d (4 séries)
+- [x] Alertas determinísticos PHP (3 níveis crit/warn/info — sem LLM)
+- [x] 6 quick-link cards (4 ativos sub-pages 2/3/5 + 3 disabled)
+- [x] HasBusinessScope nos 4 Models (NfeEmissao/NfseEmissao/NfeDfeRecebido/NfeCertificado)
+- [x] Permissão `fiscal.access`
+- [x] Pest biz=1 (`CockpitMultiTenantTest`)
+- [x] Charter + RUNBOOK + visual-comparison
 
 ### US-FISCAL-003 · ⌘K palette cross-fiscal — **backlog PR #3**
 
@@ -70,17 +87,52 @@ Busca global em notas + DF-e + ações rápidas. Detalhe quando entregar.
 
 Cancelar / Retransmitir / CC-e / Inutilizar. Chama Services `Modules/NfeBrasil` existentes via Job. NOT habilitado neste PR #1 (botões disabled no drawer).
 
-### US-FISCAL-005 · NFS-e (sub-página 3) — **backlog PR #5**
+### US-FISCAL-005 · NFS-e (sub-página 3) — ✅ PR #2 Wave
 
-Lê `Modules/NFSe/Models/NfseEmissao`. Mesma arquitetura thin.
+> **Rota:** `GET /fiscal/nfse`
+> **Controller:** `NfseCockpitController@index`
+> **Permissão:** `fiscal.nfse.view`
+> **Page:** `resources/js/Pages/Fiscal/Nfse.tsx`
+
+**Como** contador
+**Quero** lista de NFS-e (modelo 56 nacional NT 2024-001) com filtros status + competência + busca
+**Para** conferir emissões do mês sem abrir o módulo NFSe legacy
+
+**Definition of Done:**
+- [x] Lista paginada `NfseEmissao` (HasBusinessScope) — modelo 56 nacional
+- [x] 5 chips status + month picker + search (núm/cód.verificação/CPF/CNPJ tomador)
+- [x] Inertia::defer em rows
+- [x] Permissão `fiscal.nfse.view` (nova)
+- [x] Pest biz=1 (`NfseCockpitMultiTenantTest`)
+- [x] Charter + RUNBOOK + visual-comparison
 
 ### US-FISCAL-006 · Manifesto DF-e (sub-página 4) — **backlog PR #6**
 
 Lê `Modules/NfeBrasil/Models/NfeDfeRecebido`.
 
-### US-FISCAL-007 · Eventos + Cert/Cfg + SPED — **backlog PR #7**
+### US-FISCAL-007 · Eventos (sub-página 5) — ✅ PR #2 Wave
 
-Sub-páginas 5, 6, 7 — podem ser PR único ou subdivididas.
+> **Rota:** `GET /fiscal/eventos`
+> **Controller:** `EventosController@index`
+> **Permissão:** `fiscal.access`
+> **Page:** `resources/js/Pages/Fiscal/Eventos.tsx`
+
+**Como** contador
+**Quero** timeline de eventos SEFAZ aplicados (CC-e + Cancelamento + EPEC + Manifestação)
+**Para** auditoria LGPD Art. 37 + revisão fiscal
+
+**Definition of Done:**
+- [x] Timeline append-only `NfeEvento` (HasBusinessScope — `UPDATED_AT = null`)
+- [x] Filtros por tipo (todos/cce/cancel/epec/manifest) + período 7/30/90d
+- [x] Eager `with('emissao')` pra link cross-página
+- [x] Inertia::defer em rows
+- [x] Permissão `fiscal.access` (gate único — eventos são audit)
+- [x] Pest biz=1 (`EventosCockpitMultiTenantTest`)
+- [x] Charter + RUNBOOK + visual-comparison
+
+### US-FISCAL-008 · Cert/Cfg + SPED + DF-e — **backlog PR #3**
+
+Sub-páginas 4 (DF-e), 6 (Cert/Cfg), 7 (SPED). PR único ou subdividido conforme escopo.
 
 ## 3. Regras Gherkin
 
@@ -130,21 +182,20 @@ Then deve receber 403 Forbidden
 
 ## Backlog ativo (Roadmap PRs)
 
-| PR | Sub-página(s) | Esforço IA-pair | Score impact |
-|---|---|---|---|
-| #1 ✅ aberto #1183 | NF-e · NFC-e (cockpit + drawer) | 1 dia | base 0→60/100 |
-| #2 | Cockpit (KPIs + alertas + quick) | 4h | +10pp |
-| #3 | ⌘K palette cross-fiscal | 6h | +8pp |
-| #4 | Ações mutação (cancelar/retx/CC-e/inut) | 1-2 dias | +15pp (core valor) |
-| #5 | NFS-e | 4h | +5pp |
-| #6 | Manifesto DF-e | 4h | +4pp |
-| #7 | Eventos + Cert/Cfg + SPED | 1 dia | +8pp |
+| PR | Sub-página(s) | Esforço IA-pair | Score impact | Status |
+|---|---|---|---|---|
+| #1 #1183 | NF-e · NFC-e (cockpit + drawer) | 1 dia | base 0→60/100 | ✅ mergeado 8aef3d0fa |
+| #2 (Wave) | Cockpit (1) + NFS-e (3) + Eventos (5) | 1 dia | +20pp | 🟡 em curso |
+| #3 | DF-e manifesto + Cert/Cfg + SPED | 1-2 dias | +12pp | 🔒 backlog |
+| #4 | Ações mutação (cancelar/retx/CC-e/inut) | 1-2 dias | +15pp (core) | 🔒 backlog |
+| #5 | ⌘K palette cross-fiscal | 6h | +8pp | 🔒 backlog |
 
 **Meta:** Score Capterra Fiscal cockpit ≥ 80/100 pós-PR #4 (Wagner aprova).
 
 ## Histórico
 
 - **v1.0.0** (2026-05-20) — SPEC.md inicial criado em PR #1183 (Fiscal cockpit NF-e). Módulo novo thin agregador.
+- **v1.1.0** (2026-05-20) — PR #2 Wave consolidada: Cockpit + NFS-e + Eventos. 3 sub-páginas adicionadas (US-FISCAL-002, US-FISCAL-005, US-FISCAL-007). Permission `fiscal.nfse.view` nova. Roadmap reorganizado (5 PRs vs 7 originais).
 
 ## Referências
 

--- a/memory/requisitos/Fiscal/fiscal-cockpit-visual-comparison.md
+++ b/memory/requisitos/Fiscal/fiscal-cockpit-visual-comparison.md
@@ -1,0 +1,91 @@
+---
+tela: Fiscal/Cockpit
+url: /fiscal
+status: approved
+approver: wagner
+approved_at: 2026-05-20
+prototype_source: "prototipo-ui/.../fiscal-page.jsx §8 FiscalCockpit"
+implementation: resources/js/Pages/Fiscal/Cockpit.tsx
+adr: 0107
+---
+
+# Visual Comparison — Fiscal/Cockpit (PR #2 Wave)
+
+## Blueprint Cowork
+
+`prototipo-ui/.../fiscal-page.jsx §8 FiscalCockpit` + `fiscal-data.jsx::FISCAL_KPIS/SPARKLINES/FISCAL_ALERTS` (R#1 KB-9.75).
+
+## Approval
+
+Wagner aprovou Wave consolidada (Cockpit + NFS-e + Eventos) — 2026-05-20.
+
+## 8 dimensões
+
+### 1. Layout grid
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| KPIs grid | grid-template-columns: 1.4fr repeat(5, 1fr) | ✅ idem | ✅ |
+| Alertas card branco | bg white + border + padding 14px | ✅ `.fx-alerts` | ✅ |
+| Quick links 3 cols | grid-template-columns: repeat(3, 1fr) | ✅ idem | ✅ |
+
+### 2. Tipografia
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| KPI big number | 22px font-weight 700 | ✅ `.fx-kpi b` | ✅ |
+| KPI small label | 10.5px uppercase + tracking | ✅ idem | ✅ |
+| Alert título | 12.5px font-weight 600 | ✅ idem | ✅ |
+
+### 3. Densidade
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Gap entre KPIs | 8px | ✅ idem | ✅ |
+| Padding KPI card | 12px 14px | ✅ idem | ✅ |
+| Alertas inset border-left 3px | inset esquerdo colorido por level | ✅ `.fx-alert.{crit,warn,info}` | ✅ |
+
+### 4. Iconografia
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Icon hero KPI | sparkline SVG inline branco | ✅ MiniSparkline component | ✅ |
+| Icon alert | ShieldAlert/Shield/Receipt/RefreshCw lucide | ✅ ICON map dinâmico | ✅ |
+| Icon quick card | Receipt/FileText/Archive/Shield etc. lucide | ✅ idem | ✅ |
+
+### 5. Cores/Estados
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| KPI hero (emitidas) bg fis | rosa fiscal saturado | ✅ `.fx-kpi.hero` | ✅ |
+| KPI rejeitadas pulse | animação box-shadow infinite | ✅ `@keyframes fx-pulse` | ✅ |
+| Alert color tone | bad/warn/info via border-left | ✅ idem | ✅ |
+
+### 6. Animações
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Pulse rejeitadas | 2.5s infinite (oklch bad 50%→0%) | ✅ idem | ✅ |
+| Hover quick card | border-color → fis transition .12s | ✅ idem | ✅ |
+| Hover alert | bg fx-bg-2 transition .12s | ✅ idem | ✅ |
+
+### 7. Estados condicionais
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Alertas hide se vazio | `alerts.length > 0` render condicional | ✅ idem | ✅ |
+| Pulse só se rejeitadas > 0 | classe condicional | ✅ idem | ✅ |
+| Cert sem dados → "—" | fallback null | ✅ idem | ✅ |
+| Quick cards disabled (4/6/7) | opacity 0.55 | ✅ inline style | ✅ |
+
+### 8. Componentes reutilizados
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| FxShell wrapper | sub-nav + cheats + atalhos 1-7 | ✅ `_components/FxShell.tsx` | ✅ |
+| MiniSparkline SVG | path + circle endpoint | ✅ inline component (140 chars) | ✅ |
+| brl helper | format moeda | ✅ `_lib/fiscal-helpers.ts` | ✅ |
+
+## Histórico
+
+- **2026-05-20** — Wave consolidada PR #2 (Cockpit + NFS-e + Eventos). Implementação fiel ao protótipo Cowork.

--- a/memory/requisitos/Fiscal/fiscal-eventos-visual-comparison.md
+++ b/memory/requisitos/Fiscal/fiscal-eventos-visual-comparison.md
@@ -1,0 +1,88 @@
+---
+tela: Fiscal/Eventos
+url: /fiscal/eventos
+status: approved
+approver: wagner
+approved_at: 2026-05-20
+prototype_source: "prototipo-ui/.../fiscal-page.jsx §11 FiscalEventosPage"
+implementation: resources/js/Pages/Fiscal/Eventos.tsx
+adr: 0107
+---
+
+# Visual Comparison — Fiscal/Eventos (PR #2 Wave)
+
+## Blueprint Cowork
+
+`prototipo-ui/.../fiscal-page.jsx §11 FiscalEventosPage` + `fiscal-data.jsx::EVENTOS` (R#1 KB-9.75).
+
+## Approval
+
+Wagner aprovou Wave consolidada 2026-05-20.
+
+## 8 dimensões
+
+### 1. Layout grid
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Timeline vertical | linha vertical + bullets coloridos | ✅ `.fx-timeline` + `::before` | ✅ |
+| Item card row | padding 12px border-bottom | ✅ `.fx-tl-item` | ✅ |
+| Hero + filtros + body | FxShell padrão | ✅ reusado | ✅ |
+
+### 2. Tipografia
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Badge tipo evento | 10.5px font-weight 600 pill | ✅ `.fx-tl-badge` | ✅ |
+| cstat mono | 11px mono cinza | ✅ `<b>` mono inline | ✅ |
+| Justificativa 12px | dim color | ✅ `.fx-tl-desc` | ✅ |
+
+### 3. Densidade
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Bullet 12px com borda 2px white | offset-x -14px | ✅ `::before` | ✅ |
+| Gap entre items | border-bottom 1px | ✅ idem | ✅ |
+| Filtros gap 6px | idem padrão | ✅ idem | ✅ |
+
+### 4. Iconografia
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Activity icon empty | lucide Activity 20px | ✅ idem | ✅ |
+
+### 5. Cores por tipo
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| CC-e verde | ok-soft bg + ok text | ✅ `.fx-tl-badge.cce` + `.fx-tl-item.cce::before` | ✅ |
+| Cancelamento vermelho | bad-soft + bad | ✅ `.cancel` | ✅ |
+| EPEC âmbar | warn-soft + warn | ✅ `.epec` | ✅ |
+| Manifesto rosa fis | fis-soft + fis | ✅ `.manifest` | ✅ |
+
+### 6. Animações
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Sem animação específica timeline | apenas hover bg row | ✅ `.fx-alert:hover` reaproveitado | n/a |
+
+### 7. Estados condicionais
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Empty state | sem eventos → Activity + msg | ✅ `.fx-empty` | ✅ |
+| Link emissão opcional | só renderiza se evento.emissao | ✅ condicional | ✅ |
+| Justificativa opcional | só se truthy | ✅ condicional | ✅ |
+| Filter "dias" select | 7/30/90 default 30 | ✅ `<select>` no header | ✅ |
+
+### 8. Componentes reutilizados
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| FxShell | shared | ✅ reusado | ✅ |
+| Inertia Deferred | rows lazy load | ✅ idem | ✅ |
+| router.visit pra link cross-página | navegação pra Fiscal/Nfe?focus=N | ✅ idem | ✅ |
+
+## Histórico
+
+- **2026-05-20** — Wave consolidada PR #2.

--- a/memory/requisitos/Fiscal/fiscal-nfse-visual-comparison.md
+++ b/memory/requisitos/Fiscal/fiscal-nfse-visual-comparison.md
@@ -1,0 +1,88 @@
+---
+tela: Fiscal/Nfse
+url: /fiscal/nfse
+status: approved
+approver: wagner
+approved_at: 2026-05-20
+prototype_source: "prototipo-ui/.../fiscal-page.jsx §10 FiscalNFSePage"
+implementation: resources/js/Pages/Fiscal/Nfse.tsx
+adr: 0107
+---
+
+# Visual Comparison — Fiscal/Nfse (PR #2 Wave)
+
+## Blueprint Cowork
+
+`prototipo-ui/.../fiscal-page.jsx §10 FiscalNFSePage` + `fiscal-data.jsx::NOTAS_NFSE` (R#1 KB-9.75).
+
+## Approval
+
+Wagner aprovou Wave consolidada 2026-05-20.
+
+## 8 dimensões
+
+### 1. Layout grid
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Hero + sub-nav + body + cheats | FxShell padrão | ✅ reusado | ✅ |
+| Tabela full-width card | border-radius 10px white | ✅ `.fx-table` | ✅ |
+| Filtros chip-row | flex wrap gap 6px | ✅ `.fx-filters` | ✅ |
+
+### 2. Tipografia
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Número NFS-e mono | 13.5px bold + small ver. abaixo | ✅ `.fx-mono` | ✅ |
+| Tomador 12.5px + doc small | tomador font padrão | ✅ idem | ✅ |
+| Status pill 11px | pill rounded | ✅ `.fx-sefaz` reusada | ✅ |
+
+### 3. Densidade
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Row 48px | padding 9px | ✅ idem | ✅ |
+| Filtros gap 6px | idem | ✅ idem | ✅ |
+| Month picker compact | input month inline no hero | ✅ inline `<input type="month">` | ✅ |
+
+### 4. Iconografia
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Search icon | FileSearch lucide 13px | ✅ idem | ✅ |
+| Empty state icon | FileText 20px | ✅ idem | ✅ |
+
+### 5. Cores/Estados
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Status authorized | tone ok (verde) | ✅ STATUS_LABEL.authorized | ✅ |
+| Status rejected/cancelled | tone bad (vermelho) | ✅ idem | ✅ |
+| Status pending/sent | tone warn (âmbar) | ✅ idem | ✅ |
+| ISS subtext cinza | mute color sob valor | ✅ small inline style | ✅ |
+
+### 6. Animações
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Row hover bg | transição .12s | ✅ `.fx-table tr:hover` | ✅ |
+
+### 7. Estados condicionais
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Empty state | sem dados → card border-dashed | ✅ `.fx-empty` | ✅ |
+| error_msg em title (hover) | apenas hover, não em texto inline | ✅ `title={errorMsg}` | ✅ |
+| codigoVerificacao opcional | só exibe se presente | ✅ condicional | ✅ |
+
+### 8. Componentes reutilizados
+
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| FxShell | wrapper compartilhado | ✅ reusado | ✅ |
+| brl/formatDoc helpers | _lib | ✅ idem | ✅ |
+| `.fx-sefaz` SEFAZ pill | reaproveitado pra status NFS-e | ✅ idem | ✅ |
+
+## Histórico
+
+- **2026-05-20** — Wave consolidada PR #2.

--- a/resources/css/fiscal-cockpit.css
+++ b/resources/css/fiscal-cockpit.css
@@ -485,3 +485,153 @@
 }
 .fx-action-btns { display: flex; gap: 6px; margin-top: 12px; flex-wrap: wrap; }
 .fx-action-foot { display: block; margin-top: 10px; font-size: 10.5px; color: var(--fx-text-mute); font-style: italic; }
+
+/* ═══════════════════════════════════════════════════════════════ */
+/* PR #2 Wave consolidada — Cockpit + NFS-e + Eventos             */
+/* ═══════════════════════════════════════════════════════════════ */
+
+/* ─── KPIs cockpit (sub-página 1) ─── */
+.fx-kpis-cockpit {
+  display: grid;
+  grid-template-columns: 1.4fr repeat(5, 1fr);
+  gap: 8px;
+  margin: 14px 0 18px;
+}
+.fx-kpi {
+  background: white;
+  border: 1px solid var(--fx-border);
+  border-radius: 10px;
+  padding: 12px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  min-width: 0;
+}
+.fx-kpi.hero { background: var(--fis); color: white; border-color: var(--fis); }
+.fx-kpi.hero small { color: rgba(255,255,255,.85); }
+.fx-kpi.hero .delta { color: rgba(255,255,255,.75); }
+.fx-kpi.ok { border-color: var(--ok-soft); }
+.fx-kpi.bad { border-color: var(--bad-soft); }
+.fx-kpi.warn { border-color: var(--warn-soft); }
+.fx-kpi.pulse { animation: fx-pulse 2.5s infinite; }
+.fx-kpi-top { display: flex; justify-content: space-between; align-items: center; min-height: 24px; }
+.fx-kpi small { font-size: 10.5px; color: var(--fx-text-mute); font-weight: 500; text-transform: uppercase; letter-spacing: 0.04em; }
+.fx-kpi b { font-size: 22px; font-weight: 700; letter-spacing: -0.015em; line-height: 1.1; word-break: break-all; }
+.fx-kpi .delta { font-size: 10.5px; color: var(--fx-text-dim); }
+@keyframes fx-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 oklch(0.55 0.18 25 / 0.5); }
+  50%      { box-shadow: 0 0 0 6px oklch(0.55 0.18 25 / 0); }
+}
+
+/* ─── Alertas (cockpit) ─── */
+.fx-alerts {
+  background: white;
+  border: 1px solid var(--fx-border);
+  border-radius: 10px;
+  padding: 14px;
+  margin-bottom: 18px;
+}
+.fx-alerts-h {
+  display: flex; align-items: center; gap: 8px; margin-bottom: 10px;
+  padding-bottom: 8px; border-bottom: 1px solid var(--fx-border-2);
+}
+.fx-alerts-h h3 { margin: 0; font-size: 13px; flex: 1; font-weight: 700; }
+.fx-alerts-h .count { font-size: 11px; color: var(--fx-text-mute); }
+.fx-alert {
+  display: flex; align-items: center; gap: 12px;
+  padding: 10px 12px; margin-top: 4px;
+  border-radius: 7px; cursor: pointer; transition: background .12s;
+}
+.fx-alert:hover { background: var(--fx-bg-2); }
+.fx-alert.crit { border-left: 3px solid var(--bad); padding-left: 9px; }
+.fx-alert.warn { border-left: 3px solid var(--warn); padding-left: 9px; }
+.fx-alert.info { border-left: 3px solid var(--fis); padding-left: 9px; }
+.fx-alert-ic { color: var(--fx-text-dim); }
+.fx-alert-body { flex: 1; min-width: 0; }
+.fx-alert-body b { display: block; font-size: 12.5px; font-weight: 600; }
+.fx-alert-body .sub { font-size: 11px; color: var(--fx-text-mute); }
+.fx-alert-act { font-size: 11px; color: var(--fis); font-weight: 600; white-space: nowrap; }
+
+/* ─── Quick links (cockpit) ─── */
+.fx-quick {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+}
+.fx-quick-card {
+  background: white;
+  border: 1px solid var(--fx-border);
+  border-radius: 10px;
+  padding: 14px;
+  cursor: pointer;
+  position: relative;
+  transition: border-color .12s;
+}
+.fx-quick-card:hover { border-color: var(--fis); }
+.fx-quick-card .top { font-size: 12px; color: var(--fx-text-dim); display: flex; align-items: center; gap: 6px; }
+.fx-quick-card b { display: block; font-size: 15px; margin: 6px 0 2px; font-weight: 600; }
+.fx-quick-card small { font-size: 11px; color: var(--fx-text-mute); }
+.fx-quick-kbd { position: absolute; top: 10px; right: 12px; }
+
+/* ─── Sparkline (cockpit) ─── */
+.fx-spark { vertical-align: middle; }
+
+/* ─── Eventos timeline (sub-página 5) ─── */
+.fx-timeline {
+  position: relative;
+  padding: 8px 0 8px 24px;
+  background: white;
+  border: 1px solid var(--fx-border);
+  border-radius: 10px;
+}
+.fx-timeline::before {
+  content: "";
+  position: absolute;
+  left: 16px; top: 0; bottom: 0;
+  width: 1px;
+  background: var(--fx-border);
+}
+.fx-tl-item {
+  position: relative;
+  padding: 12px 16px 12px 16px;
+  border-bottom: 1px solid var(--fx-border-2);
+}
+.fx-tl-item:last-child { border-bottom: none; }
+.fx-tl-item::before {
+  content: "";
+  position: absolute;
+  left: -14px; top: 17px;
+  width: 12px; height: 12px;
+  border-radius: 50%;
+  border: 2px solid white;
+  box-shadow: 0 0 0 1px var(--fx-border);
+}
+.fx-tl-item.cce::before      { background: var(--ok); }
+.fx-tl-item.cancel::before   { background: var(--bad); }
+.fx-tl-item.epec::before     { background: var(--warn); }
+.fx-tl-item.manifest::before { background: var(--fis); }
+.fx-tl-h {
+  display: flex; gap: 8px; align-items: center;
+  font-size: 12.5px;
+  flex-wrap: wrap;
+}
+.fx-tl-h b { font-weight: 600; font-family: "IBM Plex Mono", ui-monospace, monospace; font-size: 11px; color: var(--fx-text-dim); }
+.fx-tl-h .when { color: var(--fx-text-mute); font-size: 11px; margin-left: auto; }
+.fx-tl-desc {
+  font-size: 12px;
+  color: var(--fx-text-dim);
+  margin-top: 6px;
+  line-height: 1.45;
+}
+.fx-tl-badge {
+  display: inline-flex;
+  padding: 2px 8px;
+  border-radius: 99px;
+  font-size: 10.5px;
+  font-weight: 600;
+}
+.fx-tl-badge.cce      { background: var(--ok-soft); color: var(--ok); }
+.fx-tl-badge.cancel   { background: var(--bad-soft); color: var(--bad); }
+.fx-tl-badge.epec     { background: var(--warn-soft); color: var(--warn); }
+.fx-tl-badge.manifest { background: var(--fis-soft); color: var(--fis); }
+

--- a/resources/js/Pages/Fiscal/Cockpit.charter.md
+++ b/resources/js/Pages/Fiscal/Cockpit.charter.md
@@ -1,0 +1,44 @@
+---
+page_id: fiscal-cockpit
+url: /fiscal
+module: Fiscal
+status: draft
+created: 2026-05-20
+owner: wagner
+related_adrs: [0093, 0094, 0101, 0104, 0114]
+prototypes:
+  - "prototipo-ui/.../fiscal-page.jsx §8 FiscalCockpit"
+---
+
+# Charter — `Fiscal/Cockpit`
+
+## Mission
+
+Dar à pessoa fiscal (Eliana contadora + Wagner operador) **visão consolidada do estado fiscal do mês** em até **3 segundos** — KPIs de emissão (NF-e/NFC-e/NFS-e/faturamento), alertas determinísticos críticos (rejeições + cert vencendo + DF-e pending), e quick links pras 6 sub-páginas operacionais.
+
+## Goals (Definition of Done PR #2)
+
+1. **6 KPI cards eager** (não-deferred — first paint): emitidas mês, autorizadas + pct, rejeitadas (com pulse), faturamento, DF-e pending, cert vencimento dias
+2. **Mini-sparklines SVG** nos 4 KPIs principais (últimos 14 dias)
+3. **Alertas determinísticos** (3 níveis crit/warn/info) computados em PHP sem LLM — rejeições 7d + cert <60d + DF-e pending
+4. **6 quick-link cards** pra sub-páginas (2 ativos sub-pages 2/3/5 + 3 disabled futuras 4/6/7)
+5. **Multi-tenant Tier 0**: NfeEmissao + NfseEmissao + NfeDfeRecebido + NfeCertificado via HasBusinessScope (ADR 0093)
+6. **Permissão**: `fiscal.access` gate
+7. **Pest biz=1** (ADR 0101): KPIs isolation + alertas determinísticos + permission gate
+
+## Non-Goals (PR #2)
+
+- ❌ Drill-down via click no KPI (vai pra sub-página correspondente, sem filtros pré-aplicados)
+- ❌ Período custom (mês corrente fixo — 14d sparkline default)
+- ❌ Export PDF/Excel do cockpit (PR futuro)
+- ❌ Alertas push (Whatsapp/email) — só visual no cockpit
+- ❌ ⌘K palette (PR #3 do roadmap)
+- ❌ Sub-páginas 4 (DF-e), 6 (Config), 7 (SPED) — apenas placeholders disabled
+
+## Anti-hooks
+
+- 🚫 Não fazer N+1 query nos sparklines — agrupar com `selectRaw('DATE(emitido_em)...')` 1× e iterar em PHP
+- 🚫 Não fazer Inertia::defer nos KPIs — first paint cockpit deve mostrar números (sparklines aceitam ms de delay)
+- 🚫 Não cachear KPIs por business (multi-tenant Tier 0 já garante scope — cache só agregado)
+- 🚫 Não usar LLM pra gerar alertas — receita determinística por estado (cstat/dias/pendentes)
+- 🚫 Não exibir PII (CPF/CNPJ destinatário) em KPI/alerta — usar referências abstratas ("2 rejeições", "5 DF-e")

--- a/resources/js/Pages/Fiscal/Cockpit.tsx
+++ b/resources/js/Pages/Fiscal/Cockpit.tsx
@@ -1,0 +1,252 @@
+// @memcofre
+//   tela: /fiscal
+//   module: Fiscal (cockpit unificado)
+//   status: em-implementacao
+//   stories: US-FISCAL-002 (Cockpit sub-página 1 do design KB-9.75)
+//   rules: R-FIN-001 (multi-tenant), R-FISCAL-001 (HasBusinessScope ADR 0093)
+//   adrs: 0093, 0094, 0101, 0104, 0114
+//   tests: Modules/Fiscal/Tests/Feature/CockpitMultiTenantTest
+//
+// Origem: design Cowork fiscal-page.jsx §8 FiscalCockpit. Persona: Eliana (contadora).
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { Head, router } from '@inertiajs/react';
+import { Archive, FileText, Plus, Receipt, RefreshCw, Shield, ShieldAlert } from 'lucide-react';
+
+import FxShell from './_components/FxShell';
+import { brl } from './_lib/fiscal-helpers';
+
+import '../../../css/fiscal-cockpit.css';
+
+interface Kpis {
+  emitidas: number;
+  autorizadas: number;
+  autorizadasPct: number;
+  rejeitadas: number;
+  faturamentoFiscal: number;
+  dfeAguardando: number;
+  certificadoValidadeDias: number | null;
+}
+
+interface Sparklines {
+  emitidas: number[];
+  autorizadas: number[];
+  rejeitadas: number[];
+  faturamento: number[];
+}
+
+interface Alert {
+  level: 'crit' | 'warn' | 'info';
+  icon: string;
+  title: string;
+  sub: string;
+  action: string;
+  goto: string;
+  focus?: string;
+}
+
+interface CockpitProps {
+  kpis: Kpis;
+  sparklines: Sparklines;
+  alerts: Alert[];
+}
+
+function MiniSparkline({
+  data,
+  width = 76,
+  height = 24,
+  color = 'currentColor',
+  fill = true,
+}: {
+  data: number[];
+  width?: number;
+  height?: number;
+  color?: string;
+  fill?: boolean;
+}) {
+  if (!data?.length) return null;
+  const max = Math.max(...data, 1);
+  const min = Math.min(...data, 0);
+  const range = max - min || 1;
+  const pad = 2;
+  const innerW = width - pad * 2;
+  const innerH = height - pad * 2;
+  const step = innerW / (data.length - 1);
+  const pts = data.map<[number, number]>((v, i) => [pad + i * step, pad + innerH - ((v - min) / range) * innerH]);
+  const path = pts.map((p, i) => (i === 0 ? 'M' : 'L') + p[0].toFixed(1) + ',' + p[1].toFixed(1)).join(' ');
+  const area = path + ` L${pad + innerW},${pad + innerH} L${pad},${pad + innerH} Z`;
+  const last = pts[pts.length - 1];
+  return (
+    <svg className="fx-spark" viewBox={`0 0 ${width} ${height}`} width={width} height={height} aria-hidden="true">
+      {fill && <path d={area} fill={color} fillOpacity={0.12} />}
+      <path d={path} stroke={color} strokeWidth={1.5} fill="none" strokeLinecap="round" strokeLinejoin="round" />
+      <circle cx={last[0]} cy={last[1]} r={2.2} fill={color} />
+    </svg>
+  );
+}
+
+const ICON: Record<string, React.ComponentType<{ size?: number }>> = {
+  audit: ShieldAlert,
+  shield: Shield,
+  receipt: Receipt,
+  refresh: RefreshCw,
+};
+
+function AlertRow({ alert }: { alert: Alert }) {
+  const Ic = ICON[alert.icon] ?? ShieldAlert;
+  const target = alert.goto === 'nfe' ? '/fiscal/nfe'
+    : alert.goto === 'dfe' ? '#'
+    : alert.goto === 'fiscal_config' ? '#'
+    : '#';
+
+  return (
+    <div className={`fx-alert ${alert.level}`} onClick={() => target !== '#' && router.visit(target)}>
+      <div className="fx-alert-ic"><Ic size={14} /></div>
+      <div className="fx-alert-body">
+        <b>{alert.title}</b>
+        <span className="sub">{alert.sub}</span>
+      </div>
+      <span className="fx-alert-act">{alert.action} →</span>
+    </div>
+  );
+}
+
+export default function Cockpit({ kpis, sparklines, alerts }: CockpitProps) {
+  const goto = (path: string) => router.visit(path);
+  const certColor = (kpis.certificadoValidadeDias ?? 999) <= 30 ? 'var(--bad)'
+    : (kpis.certificadoValidadeDias ?? 999) <= 60 ? 'var(--warn)' : 'var(--fx-text-dim)';
+
+  return (
+    <AppShellV2>
+      <Head title="Fiscal · Cockpit" />
+
+      <FxShell
+        route="fiscal"
+        title="Cockpit fiscal"
+        crumb={`${kpis.emitidas} emitidas no mês · ${kpis.rejeitadas} rejeitadas`}
+        env={alerts.length === 0 ? 'SEFAZ-SP operacional' : `${alerts.filter((a) => a.level === 'crit').length} críticos`}
+        envTone={alerts.some((a) => a.level === 'crit') ? 'bad' : 'ok'}
+        cheats={[
+          { keys: ['⌘', 'K'], label: 'buscar (em breve)' },
+          { keys: ['2'], label: 'NF-e' },
+          { keys: ['3'], label: 'NFS-e' },
+          { keys: ['?'], label: 'mais atalhos' },
+        ]}
+        actions={
+          <>
+            <button className="fx-btn ghost" disabled title="PR seguinte">Exportar SPED</button>
+            <button className="fx-btn primary" disabled title="PR seguinte">
+              <Plus size={12} /> Emitir <kbd className="fx-kbd-inline">E</kbd>
+            </button>
+          </>
+        }
+      >
+        {/* KPIs */}
+        <div className="fx-kpis-cockpit">
+          <div className="fx-kpi hero">
+            <div className="fx-kpi-top">
+              <small>Emitidas · mês corrente</small>
+              <MiniSparkline data={sparklines.emitidas} color="#ffffff" />
+            </div>
+            <b>{kpis.emitidas}</b>
+            <span className="delta">últimos 14 dias</span>
+          </div>
+          <div className="fx-kpi ok">
+            <div className="fx-kpi-top">
+              <small>Autorizadas</small>
+              <MiniSparkline data={sparklines.autorizadas} color="oklch(0.55 0.13 145)" />
+            </div>
+            <b>{kpis.autorizadas}</b>
+            <span className="delta">{kpis.autorizadasPct}% do total</span>
+          </div>
+          <div className={`fx-kpi bad${kpis.rejeitadas > 0 ? ' pulse' : ''}`}>
+            <div className="fx-kpi-top">
+              <small>Rejeitadas</small>
+              <MiniSparkline data={sparklines.rejeitadas} color="oklch(0.55 0.18 25)" fill={false} />
+            </div>
+            <b>{kpis.rejeitadas}</b>
+            <span className="delta" style={{ color: 'var(--bad)' }}>
+              {kpis.rejeitadas > 0 ? 'requer ação' : 'sem rejeições'}
+            </span>
+          </div>
+          <div className="fx-kpi">
+            <div className="fx-kpi-top">
+              <small>Faturado fiscal</small>
+              <MiniSparkline data={sparklines.faturamento} color="var(--fis)" />
+            </div>
+            <b>{brl(kpis.faturamentoFiscal)}</b>
+            <span className="delta">autorizadas no mês</span>
+          </div>
+          <div className="fx-kpi warn">
+            <small>DF-e p/ manifestar</small>
+            <b>{kpis.dfeAguardando}</b>
+            <span className="delta">prazo 90d legal</span>
+          </div>
+          <div className="fx-kpi">
+            <small>Certificado A1</small>
+            <b>{kpis.certificadoValidadeDias ?? '—'}{kpis.certificadoValidadeDias != null ? 'd' : ''}</b>
+            <span className="delta" style={{ color: certColor }}>
+              {kpis.certificadoValidadeDias == null ? 'sem cert ativo'
+                : kpis.certificadoValidadeDias <= 0 ? 'EXPIRADO'
+                : `vence em ${kpis.certificadoValidadeDias}d`}
+            </span>
+          </div>
+        </div>
+
+        {/* Alertas */}
+        {alerts.length > 0 && (
+          <div className="fx-alerts">
+            <div className="fx-alerts-h">
+              <ShieldAlert size={14} />
+              <h3>Pendências fiscais</h3>
+              <span className="count">
+                {alerts.length} · {alerts.filter((a) => a.level === 'crit').length} críticos · {alerts.filter((a) => a.level === 'warn').length} atenção · {alerts.filter((a) => a.level === 'info').length} info
+              </span>
+            </div>
+            {alerts.map((a, i) => <AlertRow key={i} alert={a} />)}
+          </div>
+        )}
+
+        {/* Quick links */}
+        <div className="fx-quick">
+          <div className="fx-quick-card" onClick={() => goto('/fiscal/nfe')}>
+            <div className="top"><Receipt size={13} /> NF-e · NFC-e (saída)</div>
+            <b>{kpis.emitidas} no mês</b>
+            <small>Modelo 55 + 65 · {kpis.rejeitadas} rejeitadas</small>
+            <kbd className="fx-quick-kbd">2</kbd>
+          </div>
+          <div className="fx-quick-card" onClick={() => goto('/fiscal/nfse')}>
+            <div className="top"><FileText size={13} /> NFS-e (serviço)</div>
+            <b>Sistema Nacional</b>
+            <small>NT 2024-001 · LC 214/2025</small>
+            <kbd className="fx-quick-kbd">3</kbd>
+          </div>
+          <div className="fx-quick-card" style={{ opacity: 0.55 }}>
+            <div className="top"><ShieldAlert size={13} /> Manifesto DF-e</div>
+            <b>{kpis.dfeAguardando} aguardando</b>
+            <small>NF-e contra nosso CNPJ · prazo 90d (em breve)</small>
+            <kbd className="fx-quick-kbd">4</kbd>
+          </div>
+          <div className="fx-quick-card" onClick={() => goto('/fiscal/eventos')}>
+            <div className="top"><RefreshCw size={13} /> Eventos</div>
+            <b>Timeline</b>
+            <small>CC-e · cancelamento · manifestação</small>
+            <kbd className="fx-quick-kbd">5</kbd>
+          </div>
+          <div className="fx-quick-card" style={{ opacity: 0.55 }}>
+            <div className="top"><Shield size={13} /> Certif. & cfg.</div>
+            <b>{kpis.certificadoValidadeDias != null ? `A1 vence em ${kpis.certificadoValidadeDias}d` : 'Sem cert ativo'}</b>
+            <small>Configuração fiscal (em breve)</small>
+            <kbd className="fx-quick-kbd">6</kbd>
+          </div>
+          <div className="fx-quick-card" style={{ opacity: 0.55 }}>
+            <div className="top"><Archive size={13} /> SPED & livros</div>
+            <b>EFD ICMS/IPI · PIS/COFINS</b>
+            <small>Apuração mensal (em breve)</small>
+            <kbd className="fx-quick-kbd">7</kbd>
+          </div>
+        </div>
+      </FxShell>
+    </AppShellV2>
+  );
+}

--- a/resources/js/Pages/Fiscal/Eventos.charter.md
+++ b/resources/js/Pages/Fiscal/Eventos.charter.md
@@ -1,0 +1,41 @@
+---
+page_id: fiscal-eventos
+url: /fiscal/eventos
+module: Fiscal
+status: draft
+created: 2026-05-20
+owner: wagner
+related_adrs: [0093, 0094, 0101, 0104]
+prototypes:
+  - "prototipo-ui/.../fiscal-page.jsx §11 FiscalEventosPage"
+---
+
+# Charter — `Fiscal/Eventos`
+
+## Mission
+
+**Timeline append-only** de eventos SEFAZ aplicados a notas — CC-e + Cancelamento + EPEC + Manifestação destinatário. Acesso rápido pra auditoria LGPD Art. 37 + revisão fiscal.
+
+## Goals (DoD PR #2)
+
+1. **Lista timeline** NfeEvento via HasBusinessScope (ADR 0093)
+2. **Filtros por tipo**: Todos, CC-e (110110), Cancelamento (110111), EPEC (110140), Manifesto (210200/210/220/240)
+3. **Seletor período**: 7d / 30d / 90d (default 30d)
+4. **Eager join** com NfeEmissao (numero, modelo, chave) — link clickável pra Fiscal/Nfe?focus=N
+5. **Inertia::defer** em rows
+6. **Permissão** `fiscal.access`
+7. **Pest biz=1**: isolation + filtro por kind
+
+## Non-Goals (PR #2)
+
+- ❌ Drill-down drawer pro evento (apenas timeline horizontal — payload_json fica em audit log)
+- ❌ Emitir novo evento (CC-e/Cancelar) — flow via /fiscal/nfe drawer (PR #4 mutations)
+- ❌ Inutilização (vive em NfeInutilizacao — Model separado, sub-página futura)
+- ❌ Export CSV (backlog)
+
+## Anti-hooks
+
+- 🚫 Eventos são **append-only** (NfeEvento::UPDATED_AT = null) — UI não permite edit
+- 🚫 Não mostrar `payload_json` completo na timeline (pode ter PII em xMotivo do XML)
+- 🚫 Justificativa truncada em 200 chars no Controller (já feito) — frontend não re-expande
+- 🚫 Eager `with('emissao')` é OK (1 join) — não fazer 4-5 joins extras

--- a/resources/js/Pages/Fiscal/Eventos.tsx
+++ b/resources/js/Pages/Fiscal/Eventos.tsx
@@ -1,0 +1,167 @@
+// @memcofre
+//   tela: /fiscal/eventos
+//   module: Fiscal
+//   status: em-implementacao
+//   stories: US-FISCAL-007 (Eventos sub-página 5 do design KB-9.75)
+//   rules: R-FIN-001 (multi-tenant), R-FISCAL-001 (HasBusinessScope)
+//   adrs: 0093, 0094, 0101, 0104
+//   tests: Modules/Fiscal/Tests/Feature/EventosCockpitMultiTenantTest
+//
+// Origem: design Cowork fiscal-page.jsx §11 FiscalEventosPage. Timeline append-only.
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { Deferred, Head, router } from '@inertiajs/react';
+import { Activity } from 'lucide-react';
+import { useState } from 'react';
+
+import FxShell from './_components/FxShell';
+
+import '../../../css/fiscal-cockpit.css';
+
+type EventKind = 'cce' | 'cancel' | 'epec' | 'manifest';
+
+interface TipoMeta { kind: EventKind; label: string; }
+type TiposMap = Record<string, TipoMeta>;
+
+interface Filters {
+  kind: 'todos' | EventKind;
+  dias: number;
+}
+
+interface Counts {
+  total: number;
+  cce: number;
+  cancel: number;
+  epec: number;
+  manifest: number;
+  autorizados: number;
+}
+
+interface EventoRow {
+  id: number;
+  tipo: string;
+  kind: EventKind;
+  label: string;
+  status: string;
+  cstatEvento: number;
+  justificativa: string;
+  createdAtIso: string | null;
+  when: string | null;
+  emissao: { id: number; numero: number; modelo: number; chave: string } | null;
+}
+
+interface RowsPayload {
+  data: EventoRow[];
+  meta: { current_page: number; last_page: number; total: number; per_page: number };
+}
+
+interface EventosProps {
+  filters: Filters;
+  tipos: TiposMap;
+  counts: Counts;
+  rows?: RowsPayload;
+}
+
+export default function Eventos({ filters: initialFilters, counts, rows }: EventosProps) {
+  const [filters, setFilters] = useState<Filters>(initialFilters);
+  const dataRows: EventoRow[] = rows?.data ?? [];
+
+  const apply = (next: Partial<Filters>) => {
+    const merged = { ...filters, ...next };
+    setFilters(merged);
+    router.visit('/fiscal/eventos', {
+      data: merged as unknown as Record<string, string>,
+      only: ['rows', 'counts', 'filters'],
+      preserveState: true,
+      preserveScroll: true,
+    });
+  };
+
+  return (
+    <AppShellV2>
+      <Head title="Fiscal · Eventos" />
+
+      <FxShell
+        route="fiscal_eventos"
+        title="Eventos fiscais"
+        crumb={`Últimos ${filters.dias}d · ${counts.total} eventos · ${counts.autorizados} autorizados SEFAZ`}
+        env="append-only log"
+        envTone="ok"
+        cheats={[
+          { keys: ['1'], label: 'Cockpit' },
+          { keys: ['2'], label: 'NF-e' },
+        ]}
+        actions={
+          <select
+            value={filters.dias}
+            onChange={(e) => apply({ dias: parseInt(e.target.value, 10) })}
+            className="fx-btn ghost"
+            style={{ padding: '4px 8px' }}
+            aria-label="Período"
+          >
+            <option value={7}>Últimos 7d</option>
+            <option value={30}>Últimos 30d</option>
+            <option value={90}>Últimos 90d</option>
+          </select>
+        }
+      >
+        {/* Filtros por tipo */}
+        <div className="fx-filters">
+          <button type="button" className={`fx-chip${filters.kind === 'todos' ? ' active' : ''}`} onClick={() => apply({ kind: 'todos' })}>
+            Todos <span>{counts.total}</span>
+          </button>
+          <button type="button" className={`fx-chip${filters.kind === 'cce' ? ' active' : ''}`} onClick={() => apply({ kind: 'cce' })}>
+            CC-e <span>{counts.cce}</span>
+          </button>
+          <button type="button" className={`fx-chip danger${filters.kind === 'cancel' ? ' active' : ''}`} onClick={() => apply({ kind: 'cancel' })}>
+            Cancelamento <span>{counts.cancel}</span>
+          </button>
+          <button type="button" className={`fx-chip warn${filters.kind === 'epec' ? ' active' : ''}`} onClick={() => apply({ kind: 'epec' })}>
+            EPEC <span>{counts.epec}</span>
+          </button>
+          <button type="button" className={`fx-chip${filters.kind === 'manifest' ? ' active' : ''}`} onClick={() => apply({ kind: 'manifest' })}>
+            Manifesto <span>{counts.manifest}</span>
+          </button>
+        </div>
+
+        {/* Timeline deferred */}
+        <Deferred data="rows" fallback={
+          <div className="fx-empty">
+            <b>Carregando eventos…</b>
+            <small>Buscando últimos {filters.dias} dias · multi-tenant scope ativo</small>
+          </div>
+        }>
+          {dataRows.length === 0 ? (
+            <div className="fx-empty">
+              <Activity size={20} />
+              <b>Nenhum evento no período</b>
+              <small>Eventos aparecem após cancelamento, CC-e, EPEC ou manifestação.</small>
+            </div>
+          ) : (
+            <div className="fx-timeline">
+              {dataRows.map((ev) => (
+                <div key={ev.id} className={`fx-tl-item ${ev.kind}`}>
+                  <div className="fx-tl-h">
+                    <span className={`fx-tl-badge ${ev.kind}`}>{ev.label}</span>
+                    {ev.emissao && (
+                      <a
+                        className="fx-link"
+                        href={`/fiscal/nfe?focus=${ev.emissao.id}`}
+                        onClick={(e) => { e.preventDefault(); router.visit(`/fiscal/nfe?focus=${ev.emissao!.id}`); }}
+                      >
+                        {ev.emissao.modelo === 65 ? 'NFC-e' : 'NF-e'} {ev.emissao.numero}
+                      </a>
+                    )}
+                    <b>cstat {ev.cstatEvento}</b>
+                    <span className="when">{ev.when ?? '—'}</span>
+                  </div>
+                  {ev.justificativa && <div className="fx-tl-desc">{ev.justificativa}</div>}
+                </div>
+              ))}
+            </div>
+          )}
+        </Deferred>
+      </FxShell>
+    </AppShellV2>
+  );
+}

--- a/resources/js/Pages/Fiscal/Nfse.charter.md
+++ b/resources/js/Pages/Fiscal/Nfse.charter.md
@@ -1,0 +1,41 @@
+---
+page_id: fiscal-nfse
+url: /fiscal/nfse
+module: Fiscal
+status: draft
+created: 2026-05-20
+owner: wagner
+related_adrs: [0093, 0094, 0101, 0104]
+prototypes:
+  - "prototipo-ui/.../fiscal-page.jsx §10 FiscalNFSePage"
+---
+
+# Charter — `Fiscal/Nfse`
+
+## Mission
+
+Lista navegável de **NFS-e emitidas** (Sistema Nacional NT 2024-001 — substitui emissores municipais legacy) com filtros por status + competência + busca, agregada no cockpit Fiscal.
+
+## Goals (DoD PR #2)
+
+1. **Lista paginada** NfseEmissao via HasBusinessScope (ADR 0093) — modelo nacional 56
+2. **Filtros chip-row**: Todas, Autorizadas, Rejeitadas, Processando (pending+sent), Canceladas
+3. **Seletor competência** (month picker) — default mês corrente, drill-down past months
+4. **Busca**: número NFS-e + código verificação + CPF/CNPJ tomador
+5. **Inertia::defer** em rows (skill inertia-defer-default)
+6. **Permissão** `fiscal.nfse.view`
+7. **Pest biz=1**: isolation + permission gate
+
+## Non-Goals (PR #2)
+
+- ❌ Drawer detalhe NFS-e (drawer dedicado vem em PR futuro — por enquanto title hover mostra error_msg)
+- ❌ Emissão nova (botão Emitir não existe nessa tela — flow via /sells)
+- ❌ Cancelamento UI (varia por município — backlog)
+- ❌ Download PDF NFS-e (rota em Modules/NfeBrasil)
+
+## Anti-hooks
+
+- 🚫 Não acessar NfseEmissao sem global scope
+- 🚫 Não usar PHP `is_numeric()` na busca — `preg_replace('/\D/', '', $s)` pra CPF/CNPJ
+- 🚫 Não JOIN com `transactions` ainda — dados já em NfseEmissao->cpf_cnpj_tomador
+- 🚫 Não mostrar `error_msg` completo na tabela (só hover/title) — pode conter PII

--- a/resources/js/Pages/Fiscal/Nfse.tsx
+++ b/resources/js/Pages/Fiscal/Nfse.tsx
@@ -1,0 +1,214 @@
+// @memcofre
+//   tela: /fiscal/nfse
+//   module: Fiscal
+//   status: em-implementacao
+//   stories: US-FISCAL-005 (NFS-e sub-página 3 do design KB-9.75)
+//   rules: R-FIN-001 (multi-tenant), R-FISCAL-001 (HasBusinessScope)
+//   adrs: 0093, 0094, 0101, 0104
+//   tests: Modules/Fiscal/Tests/Feature/NfseCockpitMultiTenantTest
+//
+// Origem: design Cowork fiscal-page.jsx §10 FiscalNFSePage. NFS-e nacional NT 2024-001.
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { Deferred, Head, router } from '@inertiajs/react';
+import { FileSearch, FileText } from 'lucide-react';
+import { useState } from 'react';
+
+import FxShell from './_components/FxShell';
+import { brl, formatDoc } from './_lib/fiscal-helpers';
+
+import '../../../css/fiscal-cockpit.css';
+
+interface Filters {
+  search: string;
+  status: 'todas' | 'autorizadas' | 'rejeitadas' | 'processando' | 'canceladas';
+  mes: string; // YYYY-MM
+}
+
+interface Counts {
+  total: number;
+  autorizadas: number;
+  rejeitadas: number;
+  processando: number;
+  canceladas: number;
+  faturamento: number;
+}
+
+interface NfseRow {
+  id: number;
+  num: string;
+  codigoVerificacao: string | null;
+  tomador: string;
+  documentoTomador: string | null;
+  municipio: string | null;
+  codServico: string | null;
+  aliquotaIss: number;
+  valueServico: number;
+  valueIss: number;
+  status: string;
+  errorMsg: string | null;
+  emittedAtIso: string | null;
+  when: string | null;
+}
+
+interface RowsPayload {
+  data: NfseRow[];
+  meta: { current_page: number; last_page: number; total: number; per_page: number };
+}
+
+interface NfseProps {
+  filters: Filters;
+  counts: Counts;
+  rows?: RowsPayload;
+}
+
+const STATUS_LABEL: Record<string, { label: string; tone: 'ok' | 'warn' | 'bad' }> = {
+  authorized: { label: 'Autorizada', tone: 'ok' },
+  rejected:   { label: 'Rejeitada', tone: 'bad' },
+  pending:    { label: 'Pendente',  tone: 'warn' },
+  sent:       { label: 'Enviada',   tone: 'warn' },
+  cancelled:  { label: 'Cancelada', tone: 'bad' },
+};
+
+export default function Nfse({ filters: initialFilters, counts, rows }: NfseProps) {
+  const [filters, setFilters] = useState<Filters>(initialFilters);
+  const dataRows: NfseRow[] = rows?.data ?? [];
+
+  const apply = (next: Partial<Filters>) => {
+    const merged = { ...filters, ...next };
+    setFilters(merged);
+    router.visit('/fiscal/nfse', {
+      data: merged as unknown as Record<string, string>,
+      only: ['rows', 'counts', 'filters'],
+      preserveState: true,
+      preserveScroll: true,
+    });
+  };
+
+  return (
+    <AppShellV2>
+      <Head title="Fiscal · NFS-e" />
+
+      <FxShell
+        route="nfse"
+        title="NFS-e"
+        crumb={`Sistema Nacional NT 2024-001 · ${counts.total} no período · ${brl(counts.faturamento)} autorizado`}
+        env={counts.rejeitadas > 0 ? `${counts.rejeitadas} rejeitadas` : 'tudo autorizado'}
+        envTone={counts.rejeitadas > 0 ? 'warn' : 'ok'}
+        cheats={[
+          { keys: ['1'], label: 'Cockpit' },
+          { keys: ['2'], label: 'NF-e' },
+        ]}
+        actions={
+          <input
+            type="month"
+            className="fx-search"
+            value={filters.mes}
+            onChange={(e) => apply({ mes: e.target.value })}
+            style={{ padding: '4px 8px', border: '1px solid var(--fx-border)', borderRadius: 7 }}
+            aria-label="Filtrar competência"
+          />
+        }
+      >
+        {/* Filtros */}
+        <div className="fx-filters">
+          <div className="fx-search">
+            <FileSearch size={13} />
+            <input
+              type="search"
+              placeholder="Buscar nº NFS-e, código verificação, ou documento tomador…"
+              value={filters.search}
+              onChange={(e) => setFilters((f) => ({ ...f, search: e.target.value }))}
+              onKeyDown={(e) => e.key === 'Enter' && apply({ search: filters.search })}
+            />
+          </div>
+          <button type="button" className={`fx-chip${filters.status === 'todas' ? ' active' : ''}`} onClick={() => apply({ status: 'todas' })}>
+            Todas <span>{counts.total}</span>
+          </button>
+          <button type="button" className={`fx-chip${filters.status === 'autorizadas' ? ' active' : ''}`} onClick={() => apply({ status: 'autorizadas' })}>
+            Autorizadas <span>{counts.autorizadas}</span>
+          </button>
+          <button type="button" className={`fx-chip danger${filters.status === 'rejeitadas' ? ' active' : ''}`} onClick={() => apply({ status: 'rejeitadas' })}>
+            Rejeitadas <span>{counts.rejeitadas}</span>
+          </button>
+          <button type="button" className={`fx-chip warn${filters.status === 'processando' ? ' active' : ''}`} onClick={() => apply({ status: 'processando' })}>
+            Processando <span>{counts.processando}</span>
+          </button>
+          <button type="button" className={`fx-chip${filters.status === 'canceladas' ? ' active' : ''}`} onClick={() => apply({ status: 'canceladas' })}>
+            Canceladas <span>{counts.canceladas}</span>
+          </button>
+        </div>
+
+        {/* Tabela deferred */}
+        <Deferred data="rows" fallback={
+          <div className="fx-empty">
+            <b>Carregando NFS-e…</b>
+            <small>Buscando emissões no banco · multi-tenant scope ativo</small>
+          </div>
+        }>
+          {dataRows.length === 0 ? (
+            <div className="fx-empty">
+              <FileText size={20} />
+              <b>Nenhuma NFS-e encontrada</b>
+              <small>Ajuste os filtros ou aguarde primeira emissão deste mês.</small>
+            </div>
+          ) : (
+            <div className="fx-table">
+              <table>
+                <thead>
+                  <tr>
+                    <th style={{ width: 96 }}>Número</th>
+                    <th>Tomador</th>
+                    <th style={{ width: 130 }}>Município</th>
+                    <th style={{ width: 90 }}>Cód. serviço</th>
+                    <th style={{ width: 140 }}>Status</th>
+                    <th style={{ width: 120, textAlign: 'right' }}>Valor</th>
+                    <th style={{ width: 96 }}>Emissão</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {dataRows.map((n) => {
+                    const stMeta = STATUS_LABEL[n.status] ?? { label: n.status, tone: 'warn' as const };
+                    return (
+                      <tr key={n.id} title={n.errorMsg ?? undefined}>
+                        <td className="fx-mono">
+                          <b>{n.num}</b>
+                          {n.codigoVerificacao && <small>{n.codigoVerificacao}</small>}
+                        </td>
+                        <td>
+                          <div>{n.tomador}</div>
+                          <small>{formatDoc(n.documentoTomador, null)}</small>
+                        </td>
+                        <td><small>{n.municipio ?? '—'}</small></td>
+                        <td className="fx-mono"><small>{n.codServico ?? '—'}</small></td>
+                        <td>
+                          <span className={`fx-sefaz ${stMeta.tone}`}>
+                            <span className="lbl">{stMeta.label}</span>
+                          </span>
+                          {n.aliquotaIss > 0 && (
+                            <small style={{ display: 'block', color: 'var(--fx-text-mute)', marginTop: 2 }}>
+                              ISS {n.aliquotaIss}%
+                            </small>
+                          )}
+                        </td>
+                        <td className="fx-mono fx-strong" style={{ textAlign: 'right' }}>
+                          {brl(n.valueServico)}
+                          {n.valueIss > 0 && (
+                            <small style={{ display: 'block', color: 'var(--fx-text-mute)' }}>
+                              ISS {brl(n.valueIss)}
+                            </small>
+                          )}
+                        </td>
+                        <td><small>{n.when ?? '—'}</small></td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Deferred>
+      </FxShell>
+    </AppShellV2>
+  );
+}

--- a/resources/js/Pages/Fiscal/_components/FxShell.tsx
+++ b/resources/js/Pages/Fiscal/_components/FxShell.tsx
@@ -17,11 +17,11 @@ interface FxPage {
 // 7 sub-páginas do Fiscal — PR #1 só implementa "nfe" (segunda).
 // Restantes apontam pra "#" e ficam disabled visualmente até serem entregues.
 const FX_PAGES: FxPage[] = [
-  { id: 'fiscal',          label: 'Cockpit',        icon: <ShieldAlert size={13}/>, short: '1', url: '#' },
+  { id: 'fiscal',          label: 'Cockpit',        icon: <ShieldAlert size={13}/>, short: '1', url: '/fiscal' },
   { id: 'nfe',             label: 'NF-e · NFC-e',   icon: <Receipt size={13}/>,    short: '2', url: '/fiscal/nfe' },
-  { id: 'nfse',            label: 'NFS-e',          icon: <FileText size={13}/>,   short: '3', url: '#' },
+  { id: 'nfse',            label: 'NFS-e',          icon: <FileText size={13}/>,   short: '3', url: '/fiscal/nfse' },
   { id: 'dfe',             label: 'Manifesto DF-e', icon: <ShieldAlert size={13}/>,short: '4', url: '#' },
-  { id: 'fiscal_eventos',  label: 'Eventos',        icon: <RefreshCw size={13}/>,  short: '5', url: '#' },
+  { id: 'fiscal_eventos',  label: 'Eventos',        icon: <RefreshCw size={13}/>,  short: '5', url: '/fiscal/eventos' },
   { id: 'fiscal_config',   label: 'Certif. & Cfg.', icon: <Shield size={13}/>,     short: '6', url: '#' },
   { id: 'sped',            label: 'SPED & Livros',  icon: <Archive size={13}/>,    short: '7', url: '#' },
 ];


### PR DESCRIPTION
## Sumário

**PR #2 do módulo Fiscal — Wave consolidada** com 3 sub-páginas do design Cowork KB-9.75 em 1 PR único:

| Sub-página | Rota | Permissão | Sub do design |
|---|---|---|---|
| Cockpit | `/fiscal` | `fiscal.access` | #1 |
| NFS-e | `/fiscal/nfse` | `fiscal.nfse.view` (nova) | #3 |
| Eventos | `/fiscal/eventos` | `fiscal.access` | #5 |

PR #1 (#1183) mergeado em main (`8aef3d0fa`) entregou a sub-página #2 NF-e. Esta Wave fecha 4 sub-páginas das 7 totais. Próximos PRs cobrem #4 DF-e, #6 Cert/Cfg, #7 SPED + #4 ações de mutação + #5 ⌘K palette.

## Backend (Modules/Fiscal/)

- **CockpitController** — KPIs eager (NfeEmissao + NfseEmissao + NfeDfeRecebido + NfeCertificado via `HasBusinessScope` ADR 0093), sparklines 14d em 1 query `GROUP BY DATE(emitido_em)`, alertas determinísticos PHP em 3 níveis (sem LLM)
- **NfseCockpitController** — lista `NfseEmissao` modelo 56 nacional NT 2024-001 + filtros status/competência/search
- **EventosController** — timeline append-only `NfeEvento` (`UPDATED_AT = null`) + 7 tpEvento canônicos (110110 CC-e, 110111 Cancel, 110140 EPEC, 210200-240 Manifesto) + eager `with('emissao')`
- Routes: + 3 rotas (`/`, `/nfse`, `/eventos`)
- DataController: + permissão `fiscal.nfse.view` + sidebar URL ajustado pra `/fiscal`

## Frontend (resources/js/Pages/Fiscal/)

- **Cockpit.tsx** — 6 KPI cards (hero/ok/bad+pulse/neutro/warn/cert) + `MiniSparkline` SVG inline + `AlertRow` + 6 quick-link cards (3 ativos: NF-e/NFS-e/Eventos · 3 disabled: DF-e/Cert/SPED)
- **Nfse.tsx** — sub-tabs + chip-row filtros + month picker + tabela `<Deferred>` reaproveitando `.fx-sefaz` pro status pill
- **Eventos.tsx** — `.fx-timeline` vertical com bullets coloridos por kind + filtros tipo + select período 7/30/90d + link cross-página `/fiscal/nfe?focus=N`
- **FxShell** habilitado pra 4 sub-páginas ativas (`/fiscal`, `/fiscal/nfe`, `/fiscal/nfse`, `/fiscal/eventos`)
- 3 `*.charter.md` (skill `charter-first` Tier A)

## Style

`fiscal-cockpit.css` +160 linhas: `.fx-kpis-cockpit`, `.fx-kpi.{hero,ok,bad,warn,pulse}`, `.fx-alerts`, `.fx-quick-card`, `.fx-spark`, `.fx-timeline` com `::before` bullet colorido por kind.

## Tests Pest (biz=1 — ADR 0101)

- `CockpitMultiTenantTest` — KPIs scope per business + alertas determinísticos (estrutura fixa sem `thought`/`reasoning`)
- `NfseCockpitMultiTenantTest` — `HasBusinessScope` scoped + STATUS constants
- `EventosCockpitMultiTenantTest` — TIPOS mapeados canon + append-only (`UPDATED_AT = null`)

## Docs canon

- `SPEC.md` — US-FISCAL-002/005/007 ✅ done + roadmap reorganizado (5 PRs vs 7)
- `SCOPE.md` — +3 controllers em `contains[]` (CockpitController + EventosController + NfseCockpitController)
- 3 RUNBOOKs (`cockpit/nfse/eventos`)
- 3 visual-comparison (`fiscal-cockpit/fiscal-nfse/fiscal-eventos`) com 8 dimensões + `status: approved` `approver: wagner`

## Non-Goals (próximos PRs)

- ❌ Drawer detalhe NFS-e (tabela mostra `error_msg` no hover/title) — PR futuro
- ❌ Mutações (Cancelar/Retransmitir/CC-e/Inutilizar) — PR #4 do roadmap
- ❌ DF-e manifesto + Cert/Cfg + SPED — PR #3
- ❌ ⌘K palette cross-fiscal — PR #5
- ❌ Period custom no cockpit (mês corrente fixo)
- ❌ Drill-down via click no KPI

## ADRs aplicadas

- 0093 multi-tenant Tier 0 IRREVOGÁVEL (4 Models via HasBusinessScope)
- 0094 Constituição v2
- 0101 tests biz=1 (NUNCA biz=4)
- 0104 MWART canônico (charters + visual-comparison + SPEC)
- 0114 Cowork loop (design vindo do tarball Cowork)

## Test plan

- [ ] CI 3 Pest novos passam (skip SQLite, run MySQL)
- [ ] Vite build inertia exit 0
- [ ] Smoke prod biz=1 pós-merge: `curl -sv /fiscal /fiscal/nfse /fiscal/eventos` retorna 200
- [ ] Smoke negativo: usuário sem `fiscal.access` → 403 em `/fiscal` e `/fiscal/eventos`
- [ ] Smoke negativo: usuário sem `fiscal.nfse.view` → 403 em `/fiscal/nfse`
- [ ] Sidebar entrada "Fiscal" leva pra `/fiscal` (cockpit)

## Tamanho

19 arquivos novos + 6 arquivos modificados = **25 arquivos, ~2.095 inserções**. Acima do <300 ideal mas é Wave consolidada de 3 sub-páginas (~700 linhas cada incluindo charter + RUNBOOK + visual-comparison + Pest test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)