### PR TITLE
feat(pwa): Onda 30 — PWA básico Financeiro (manifest+sw+offline+install) (US-FIN-036)

### DIFF
--- a/public/img/pwa-icon-192.svg
+++ b/public/img/pwa-icon-192.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192" width="192" height="192">
+  <rect width="192" height="192" rx="32" fill="#1c1917"/>
+  <circle cx="96" cy="96" r="68" fill="#fafaf9"/>
+  <text x="96" y="124" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif" font-size="92" font-weight="700" text-anchor="middle" fill="#1c1917">F</text>
+</svg>

--- a/public/img/pwa-icon-512-maskable.svg
+++ b/public/img/pwa-icon-512-maskable.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <!-- Maskable: safe zone = circle de raio 102.4px (40%) no centro. Conteudo crítico
+       fica dentro desse circle pra sobreviver mascaras do Android (squircle, circle, etc). -->
+  <rect width="512" height="512" fill="#1c1917"/>
+  <circle cx="256" cy="256" r="128" fill="#fafaf9"/>
+  <text x="256" y="308" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif" font-size="172" font-weight="700" text-anchor="middle" fill="#1c1917">F</text>
+</svg>

--- a/public/img/pwa-icon-512.svg
+++ b/public/img/pwa-icon-512.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 512 512" width="512" height="512">
+  <rect width="512" height="512" rx="88" fill="#1c1917"/>
+  <circle cx="256" cy="256" r="180" fill="#fafaf9"/>
+  <text x="256" y="330" font-family="ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, sans-serif" font-size="244" font-weight="700" text-anchor="middle" fill="#1c1917">F</text>
+</svg>

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,0 +1,34 @@
+{
+  "name": "oimpresso Financeiro",
+  "short_name": "Financeiro",
+  "description": "Visao unificada AR/AP do oimpresso ERP — receber, pagar, conciliar e aprovar do celular.",
+  "start_url": "/financeiro/unificado",
+  "scope": "/financeiro/",
+  "display": "standalone",
+  "orientation": "portrait-primary",
+  "theme_color": "#1c1917",
+  "background_color": "#fafaf9",
+  "lang": "pt-BR",
+  "dir": "ltr",
+  "categories": ["business", "finance", "productivity"],
+  "icons": [
+    {
+      "src": "/img/pwa-icon-192.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/img/pwa-icon-512.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "any"
+    },
+    {
+      "src": "/img/pwa-icon-512-maskable.svg",
+      "sizes": "512x512",
+      "type": "image/svg+xml",
+      "purpose": "maskable"
+    }
+  ]
+}

--- a/public/sw-financeiro.js
+++ b/public/sw-financeiro.js
@@ -1,0 +1,216 @@
+/**
+ * Service Worker — oimpresso Financeiro PWA
+ *
+ * Estratégia: stale-while-revalidate pra rotas GET /financeiro/* (read-only)
+ * com sanitização de response e fallback offline minimal.
+ *
+ * Tier 0 (US-FIN-036):
+ * - SOMENTE GET. POST/PUT/DELETE NUNCA cacheado.
+ * - Rotas write/mutate (`/baixar`, `/aprovar`, `/rejeitar`,
+ *   `/solicitar-aprovacao`, `/conciliacao/upload`) sempre network-first.
+ * - Response com `cache-control: private` ou `set-cookie` NÃO entra no cache
+ *   (LGPD — evita persistir sessão/CSRF).
+ * - Não toca dados de outros módulos (escopo isolado a /financeiro/*).
+ *
+ * Cache version: financeiro-v1 (bump pra invalidar tudo após mudanças
+ * arquiteturais — força clientes a baixar nova versão na próxima visita).
+ */
+
+const CACHE_NAME = 'financeiro-v1';
+
+// Rotas que NUNCA podem ser servidas do cache (mutate / side-effect / write).
+// Match por substring no pathname.
+const NETWORK_ONLY_PATTERNS = [
+    '/baixar',
+    '/aprovar',
+    '/rejeitar',
+    '/solicitar-aprovacao',
+    '/conciliacao/upload',
+    '/logout',
+    '/sanctum',
+    '/api/auth',
+];
+
+/**
+ * Decide se a request deve ser network-only (skip cache).
+ * - Method != GET → network-only
+ * - URL casa com NETWORK_ONLY_PATTERNS → network-only
+ * - URL fora de /financeiro/ → não intercepta (passa direto)
+ */
+function isNetworkOnly(request) {
+    if (request.method !== 'GET') return true;
+    const url = new URL(request.url);
+    if (!url.pathname.startsWith('/financeiro')) return true; // fora do scope
+    for (const pat of NETWORK_ONLY_PATTERNS) {
+        if (url.pathname.includes(pat)) return true;
+    }
+    return false;
+}
+
+/**
+ * Decide se response pode ser persistido em cache.
+ * - Status 200/304 apenas
+ * - SEM header `cache-control: private`
+ * - SEM `set-cookie` (sessão Laravel)
+ * - SEM `authorization` ecoado
+ * - Content-Type: text/html, application/json, image/*, font/*, text/css, application/javascript
+ */
+function isCacheable(response) {
+    if (!response || !response.ok) return false;
+    if (response.status !== 200) return false;
+    if (response.type !== 'basic' && response.type !== 'default') return false;
+
+    const cacheControl = (response.headers.get('cache-control') || '').toLowerCase();
+    if (cacheControl.includes('private')) return false;
+    if (cacheControl.includes('no-store')) return false;
+
+    if (response.headers.get('set-cookie')) return false;
+
+    const contentType = (response.headers.get('content-type') || '').toLowerCase();
+    const allowed = [
+        'text/html',
+        'application/json',
+        'application/javascript',
+        'text/css',
+        'image/',
+        'font/',
+        'application/font',
+    ];
+    return allowed.some((prefix) => contentType.startsWith(prefix));
+}
+
+/**
+ * Sanitiza response antes do cache.put — remove headers sensíveis defensivamente.
+ * (response.clone() é necessário porque body é stream consumível 1x.)
+ */
+async function sanitizeForCache(response) {
+    const cloned = response.clone();
+    const headers = new Headers(cloned.headers);
+    // Limpa headers sensíveis (defesa em profundidade — isCacheable já bloqueia
+    // a maioria, mas se algo passar, garantimos sanitização)
+    headers.delete('set-cookie');
+    headers.delete('authorization');
+    headers.delete('x-csrf-token');
+    headers.delete('x-xsrf-token');
+
+    const body = await cloned.blob();
+    return new Response(body, {
+        status: cloned.status,
+        statusText: cloned.statusText,
+        headers,
+    });
+}
+
+/**
+ * Fallback offline pra fetches de API/JSON.
+ * Pra HTML, devolve resposta HTML minimal com mensagem em PT-BR.
+ */
+function offlineFallback(request) {
+    const accept = request.headers.get('accept') || '';
+    if (accept.includes('application/json')) {
+        return new Response(
+            JSON.stringify({ offline: true, message: 'Sem conexão. Tente novamente quando voltar online.' }),
+            {
+                status: 503,
+                statusText: 'Offline',
+                headers: { 'Content-Type': 'application/json' },
+            }
+        );
+    }
+    return new Response(
+        '<!DOCTYPE html><html lang="pt-BR"><head><meta charset="utf-8"><title>Offline — Financeiro</title>' +
+            '<meta name="viewport" content="width=device-width,initial-scale=1">' +
+            '<style>body{font-family:ui-sans-serif,system-ui,sans-serif;background:#fafaf9;color:#1c1917;margin:0;padding:24px;display:flex;flex-direction:column;align-items:center;justify-content:center;min-height:100vh}h1{font-size:20px;margin:0 0 8px}p{color:#57534e;font-size:14px;text-align:center;max-width:320px}button{margin-top:16px;background:#1c1917;color:#fafaf9;border:none;padding:10px 20px;border-radius:8px;font-size:14px;cursor:pointer}</style>' +
+            '</head><body><h1>Sem conexão</h1><p>O Financeiro precisa de internet pra carregar dados novos. Tente de novo quando voltar online.</p><button onclick="location.reload()">Tentar novamente</button></body></html>',
+        {
+            status: 503,
+            statusText: 'Offline',
+            headers: { 'Content-Type': 'text/html; charset=utf-8' },
+        }
+    );
+}
+
+// ── INSTALL ────────────────────────────────────────────────────────────────
+self.addEventListener('install', (event) => {
+    // skipWaiting pra ativar nova versão imediatamente — combina com clients.claim
+    self.skipWaiting();
+    event.waitUntil(Promise.resolve());
+});
+
+// ── ACTIVATE ───────────────────────────────────────────────────────────────
+self.addEventListener('activate', (event) => {
+    event.waitUntil(
+        (async () => {
+            // Limpa caches de versões antigas (financeiro-v0, financeiro-vN-1 etc)
+            const keys = await caches.keys();
+            await Promise.all(
+                keys
+                    .filter((k) => k.startsWith('financeiro-') && k !== CACHE_NAME)
+                    .map((k) => caches.delete(k))
+            );
+            await self.clients.claim();
+        })()
+    );
+});
+
+// ── FETCH (stale-while-revalidate) ────────────────────────────────────────
+self.addEventListener('fetch', (event) => {
+    const { request } = event;
+
+    // Network-only: bypass total (POST/PUT/DELETE, rotas write, fora de /financeiro/)
+    if (isNetworkOnly(request)) {
+        // Fora do scope (/financeiro/): NÃO intercepta — deixa browser tratar.
+        const url = new URL(request.url);
+        if (!url.pathname.startsWith('/financeiro')) return;
+
+        // Dentro de /financeiro mas mutate: tenta network direto, fallback offline.
+        event.respondWith(
+            fetch(request).catch(() => offlineFallback(request))
+        );
+        return;
+    }
+
+    // Stale-while-revalidate
+    event.respondWith(
+        (async () => {
+            const cache = await caches.open(CACHE_NAME);
+            const cached = await cache.match(request);
+
+            const networkFetch = fetch(request)
+                .then(async (response) => {
+                    if (isCacheable(response)) {
+                        try {
+                            const sanitized = await sanitizeForCache(response);
+                            await cache.put(request, sanitized);
+                        } catch (e) {
+                            // Sanitize/put falhou — ignora silenciosamente, não quebra UX
+                        }
+                    }
+                    return response;
+                })
+                .catch(() => null);
+
+            // Se tem cache: devolve cache imediato + revalida em background
+            if (cached) {
+                event.waitUntil(networkFetch);
+                return cached;
+            }
+
+            // Sem cache: espera network ou fallback offline
+            const fresh = await networkFetch;
+            if (fresh) return fresh;
+            return offlineFallback(request);
+        })()
+    );
+});
+
+// ── MESSAGE (canal pra UI pedir skipWaiting / clear cache) ────────────────
+self.addEventListener('message', (event) => {
+    if (!event.data) return;
+    if (event.data.type === 'SKIP_WAITING') {
+        self.skipWaiting();
+    }
+    if (event.data.type === 'CLEAR_CACHE') {
+        event.waitUntil(caches.delete(CACHE_NAME));
+    }
+});

--- a/resources/js/Components/shared/PwaInstallBanner.tsx
+++ b/resources/js/Components/shared/PwaInstallBanner.tsx
@@ -1,0 +1,166 @@
+// @memcofre
+//   componente: PwaInstallBanner
+//   us: US-FIN-036 (Onda 30) — PWA Financeiro
+//   nota: Banner fixo topo só na rota /financeiro/* quando não está em standalone.
+//         Captura beforeinstallprompt → expõe botão "Instalar app". Botão "Mais
+//         tarde" esconde por 30 dias via localStorage. PT-BR.
+
+import { useEffect, useState } from 'react';
+
+const DISMISS_KEY = 'pwa_install_banner_dismissed_until';
+const DISMISS_DAYS = 30;
+
+interface BeforeInstallPromptEvent extends Event {
+    readonly platforms: ReadonlyArray<string>;
+    readonly userChoice: Promise<{ outcome: 'accepted' | 'dismissed'; platform: string }>;
+    prompt(): Promise<void>;
+}
+
+/**
+ * Banner sutil topo de tela que oferece "Instalar app" quando:
+ * - Browser suporta PWA install (capturou beforeinstallprompt)
+ * - Rota atual começa com /financeiro
+ * - Não está em standalone (já instalado)
+ * - Usuário não dispensou nos últimos 30 dias
+ */
+export default function PwaInstallBanner() {
+    const [deferredPrompt, setDeferredPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+    const [visible, setVisible] = useState(false);
+
+    useEffect(() => {
+        if (typeof window === 'undefined') return;
+
+        // Não mostra se já está em standalone (PWA instalado e aberto)
+        const isStandalone =
+            window.matchMedia('(display-mode: standalone)').matches ||
+            // iOS Safari não suporta display-mode standalone — usa navigator.standalone
+            (window.navigator as unknown as { standalone?: boolean }).standalone === true;
+        if (isStandalone) return;
+
+        // Não mostra fora de /financeiro/*
+        if (!window.location.pathname.startsWith('/financeiro')) return;
+
+        // Verifica se foi dispensado recentemente
+        try {
+            const until = localStorage.getItem(DISMISS_KEY);
+            if (until && Date.now() < parseInt(until, 10)) return;
+        } catch {
+            // localStorage indisponível (modo privado, quota) — ignora, mostra banner
+        }
+
+        const handler = (e: Event) => {
+            e.preventDefault();
+            setDeferredPrompt(e as BeforeInstallPromptEvent);
+            setVisible(true);
+        };
+
+        window.addEventListener('beforeinstallprompt', handler as EventListener);
+
+        // Se o app for instalado durante a sessão, esconde
+        const onInstalled = () => {
+            setVisible(false);
+            setDeferredPrompt(null);
+        };
+        window.addEventListener('appinstalled', onInstalled);
+
+        return () => {
+            window.removeEventListener('beforeinstallprompt', handler as EventListener);
+            window.removeEventListener('appinstalled', onInstalled);
+        };
+    }, []);
+
+    if (!visible || !deferredPrompt) return null;
+
+    const handleInstall = async () => {
+        try {
+            await deferredPrompt.prompt();
+            const choice = await deferredPrompt.userChoice;
+            if (choice.outcome === 'accepted') {
+                setVisible(false);
+            }
+        } catch {
+            // prompt() falhou (ex.: já foi chamado) — só esconde
+            setVisible(false);
+        } finally {
+            setDeferredPrompt(null);
+        }
+    };
+
+    const handleDismiss = () => {
+        try {
+            const until = Date.now() + DISMISS_DAYS * 24 * 60 * 60 * 1000;
+            localStorage.setItem(DISMISS_KEY, String(until));
+        } catch {
+            // ignora — fecha mesmo sem persistir
+        }
+        setVisible(false);
+        setDeferredPrompt(null);
+    };
+
+    return (
+        <div
+            role="region"
+            aria-label="Instalar aplicativo Financeiro"
+            style={{
+                position: 'fixed',
+                top: 12,
+                left: '50%',
+                transform: 'translateX(-50%)',
+                zIndex: 9999,
+                width: '92%',
+                maxWidth: 448,
+                background: '#fafaf9',
+                color: '#1c1917',
+                border: '1px solid #e7e5e4',
+                borderRadius: 10,
+                boxShadow: '0 4px 20px rgba(0,0,0,0.08)',
+                padding: '10px 14px',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 12,
+                fontSize: 13.5,
+                lineHeight: 1.35,
+            }}
+        >
+            <div style={{ flex: 1, minWidth: 0 }}>
+                <div style={{ fontWeight: 600 }}>Instalar Financeiro</div>
+                <div style={{ color: '#57534e', fontSize: 12.5 }}>
+                    Acesso rápido do celular, mesmo sem o navegador aberto.
+                </div>
+            </div>
+            <button
+                type="button"
+                onClick={handleDismiss}
+                style={{
+                    background: 'transparent',
+                    border: 'none',
+                    color: '#78716c',
+                    cursor: 'pointer',
+                    padding: '6px 10px',
+                    borderRadius: 6,
+                    fontSize: 12.5,
+                    fontWeight: 500,
+                }}
+            >
+                Mais tarde
+            </button>
+            <button
+                type="button"
+                onClick={handleInstall}
+                style={{
+                    background: '#1c1917',
+                    color: '#fafaf9',
+                    border: 'none',
+                    cursor: 'pointer',
+                    padding: '7px 14px',
+                    borderRadius: 6,
+                    fontSize: 12.5,
+                    fontWeight: 600,
+                    whiteSpace: 'nowrap',
+                }}
+            >
+                Instalar app
+            </button>
+        </div>
+    );
+}

--- a/resources/js/Layouts/AppShellV2.tsx
+++ b/resources/js/Layouts/AppShellV2.tsx
@@ -78,6 +78,7 @@ const TOPNAV_ICON_MAP: Record<string, LucideIcon> = {
 
 import { useAutoModuleNav } from '@/Hooks/usePageProps';
 import CommandPalette from '@/Components/CommandPalette';
+import PwaInstallBanner from '@/Components/shared/PwaInstallBanner';
 
 import '../../css/cockpit.css';
 
@@ -389,6 +390,9 @@ export default function AppShellV2({
   return (
     <>
       {title && <Head title={title} />}
+      {/* PWA install banner (US-FIN-036) — auto-detecta rota /financeiro/* e
+          beforeinstallprompt; fora desse contexto renderiza null. */}
+      <PwaInstallBanner />
       <div
         className="cockpit"
         data-linked={!conversaFoco || linkedCollapsed ? 'off' : 'on'}

--- a/resources/js/app.tsx
+++ b/resources/js/app.tsx
@@ -40,3 +40,23 @@ createInertiaApp({
     showSpinner: false,
   },
 });
+
+// ── PWA Service Worker registration (US-FIN-036, Onda 30) ─────────────────
+// Registra sw-financeiro.js APENAS quando o usuário está em /financeiro/*.
+// Lazy load no DOMContentLoaded pra não bloquear hydration. Falha silenciosa
+// (PWA é progressivo — desktop/browser velho continua funcionando normal).
+if (typeof window !== 'undefined' && 'serviceWorker' in navigator) {
+    const registerSw = () => {
+        if (!window.location.pathname.startsWith('/financeiro')) return;
+        navigator.serviceWorker
+            .register('/sw-financeiro.js', { scope: '/financeiro/' })
+            .catch(() => {
+                // Falha silenciosa — UX não pode quebrar por causa de PWA
+            });
+    };
+    if (document.readyState === 'complete' || document.readyState === 'interactive') {
+        registerSw();
+    } else {
+        window.addEventListener('DOMContentLoaded', registerSw, { once: true });
+    }
+}

--- a/tests/Feature/PwaManifestTest.php
+++ b/tests/Feature/PwaManifestTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * US-FIN-036 (Onda 30) — PWA Financeiro
+ *
+ * Valida que manifest + sw + icons estão presentes em public/ com forma canônica.
+ * Static assets servidos direto pelo web server (LiteSpeed/Apache/Nginx) — não
+ * passam por roteamento Laravel; teste valida no FS + parse semântico.
+ */
+
+it('manifest.webmanifest existe em public/ com forma canônica', function () {
+    $path = public_path('manifest.webmanifest');
+    expect(file_exists($path))->toBeTrue('manifest.webmanifest deve existir em public/');
+
+    $raw = file_get_contents($path);
+    expect($raw)->not->toBeFalse();
+
+    $manifest = json_decode($raw, true);
+    expect(json_last_error())->toBe(JSON_ERROR_NONE, 'manifest deve ser JSON válido');
+    expect($manifest)->toBeArray();
+
+    // Campos obrigatórios W3C Web App Manifest
+    foreach (['name', 'short_name', 'start_url', 'display', 'icons'] as $field) {
+        expect($manifest)->toHaveKey($field, "manifest deve ter '$field'");
+    }
+
+    expect($manifest['name'])->toBe('oimpresso Financeiro');
+    expect($manifest['short_name'])->toBe('Financeiro');
+    expect($manifest['start_url'])->toBe('/financeiro/unificado');
+    expect($manifest['display'])->toBe('standalone');
+    expect($manifest['theme_color'])->toBe('#1c1917'); // stone-900
+    expect($manifest['background_color'])->toBe('#fafaf9'); // stone-50
+    expect($manifest['lang'])->toBe('pt-BR');
+});
+
+it('manifest tem 3 icons (192, 512, 512 maskable)', function () {
+    $manifest = json_decode(file_get_contents(public_path('manifest.webmanifest')), true);
+
+    expect($manifest['icons'])->toBeArray()->toHaveCount(3);
+
+    $sizes = array_map(fn ($icon) => $icon['sizes'], $manifest['icons']);
+    expect($sizes)->toContain('192x192');
+    expect($sizes)->toContain('512x512');
+
+    // Deve ter pelo menos 1 maskable
+    $purposes = array_map(fn ($icon) => $icon['purpose'] ?? 'any', $manifest['icons']);
+    expect($purposes)->toContain('maskable');
+
+    // Todos arquivos de icon existem em public/
+    foreach ($manifest['icons'] as $icon) {
+        $iconPath = public_path(ltrim($icon['src'], '/'));
+        expect(file_exists($iconPath))->toBeTrue(
+            "icon '{$icon['src']}' deve existir em public/"
+        );
+    }
+});
+
+it('service worker sw-financeiro.js existe em public/ com sanitização obrigatória', function () {
+    $path = public_path('sw-financeiro.js');
+    expect(file_exists($path))->toBeTrue('sw-financeiro.js deve existir em public/');
+
+    $sw = file_get_contents($path);
+    expect($sw)->not->toBeFalse();
+
+    // Sanidade: cache versionado
+    expect($sw)->toContain("'financeiro-v1'");
+
+    // Tier 0 — rotas write nunca cacheadas (LGPD + segurança)
+    expect($sw)->toContain('/baixar');
+    expect($sw)->toContain('/aprovar');
+    expect($sw)->toContain('/rejeitar');
+    expect($sw)->toContain('/solicitar-aprovacao');
+    expect($sw)->toContain('/conciliacao/upload');
+
+    // Sanitização: cache-control private bloqueia put, set-cookie idem
+    expect($sw)->toContain('cache-control');
+    expect($sw)->toContain('private');
+    expect($sw)->toContain('set-cookie');
+
+    // Lifecycle moderno (skipWaiting + clients.claim)
+    expect($sw)->toContain('skipWaiting');
+    expect($sw)->toContain('clients.claim');
+});
+
+it('app.tsx registra service worker condicional a /financeiro/*', function () {
+    $appTsx = file_get_contents(resource_path('js/app.tsx'));
+
+    expect($appTsx)->toContain("serviceWorker' in navigator");
+    expect($appTsx)->toContain('/sw-financeiro.js');
+    expect($appTsx)->toContain("startsWith('/financeiro')");
+});
+
+it('PwaInstallBanner component existe e detecta standalone + dismiss 30d', function () {
+    $banner = file_get_contents(resource_path('js/Components/shared/PwaInstallBanner.tsx'));
+
+    expect($banner)->toContain('beforeinstallprompt');
+    expect($banner)->toContain('display-mode: standalone');
+    expect($banner)->toContain("startsWith('/financeiro')");
+    expect($banner)->toContain('Instalar app');
+    expect($banner)->toContain('Mais tarde');
+    expect($banner)->toContain('pwa_install_banner_dismissed_until');
+});


### PR DESCRIPTION
PWA mata gap mobile (4/10 vs Conta Azul 9/10) sem app nativo. Manifest W3C + sw stale-while-revalidate cache 'financeiro-v1' com sanitização LGPD (bloqueia private/cookie/non-200), bypass POST + rotas críticas, banner install dismiss 30d. ~370 LOC. Smoke prod Wagner instala no celular Larissa biz=4. Refs: CAPTERRA bucket A2. <!-- no-ui-smoke: PWA precisa HTTPS real --> 🤖 Claude Code