### PR TITLE
feat(fiscal): Wave 3 — DF-e + Cert/Cfg + SPED (fecha 7 sub-páginas design KB-9.75)

### DIFF
--- a/Modules/Fiscal/Http/Controllers/ConfigController.php
+++ b/Modules/Fiscal/Http/Controllers/ConfigController.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Modules\Fiscal\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\NfeBrasil\Models\NfeBusinessConfig;
+use Modules\NfeBrasil\Models\NfeCertificado;
+
+/**
+ * Cert/Cfg fiscal (sub-página 6 do design KB-9.75).
+ *
+ * Status do certificado A1 + ambiente (homolog/prod) + regime tributário
+ * + tributação default (NCM/CST/CSOSN cascata).
+ *
+ * Apenas leitura no PR. Edits via Modules/NfeBrasil/Pages/NfeBrasil/Configuracao/Certificado.tsx
+ * existente. HasBusinessScope ADR 0093.
+ */
+class ConfigController extends Controller
+{
+    public function index(): Response
+    {
+        if (! auth()->user()->can('superadmin') && ! auth()->user()->can('fiscal.config.edit')) {
+            abort(403, 'Sem permissão fiscal.config.edit');
+        }
+
+        $cert = NfeCertificado::query()
+            ->where('ativo', true)
+            ->orderByDesc('valido_ate')
+            ->first();
+
+        $config = NfeBusinessConfig::query()->first();
+
+        return Inertia::render('Fiscal/Config', [
+            'certificado' => $cert ? [
+                'uuid'         => $cert->uuid,
+                'cnpjTitular'  => $cert->cnpj_titular,
+                'validoAteIso' => $cert->valido_ate?->toIso8601String(),
+                'validoAteBr'  => $cert->valido_ate?->format('d/m/Y'),
+                'diasRestantes'=> $cert->valido_ate
+                    ? (int) now()->startOfDay()->diffInDays($cert->valido_ate, false)
+                    : null,
+                'ativo'        => (bool) $cert->ativo,
+            ] : null,
+            'config' => $config ? [
+                'regime'             => $config->regime ?? 'lucro_presumido',
+                'autoEmissionEnabled'=> (bool) ($config->auto_emission_enabled ?? false),
+                'tributacaoDefault'  => $config->tributacao_default ?? [],
+            ] : null,
+        ]);
+    }
+}

--- a/Modules/Fiscal/Http/Controllers/DfeController.php
+++ b/Modules/Fiscal/Http/Controllers/DfeController.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Modules\Fiscal\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\NfeBrasil\Models\NfeDfeRecebido;
+
+/**
+ * Manifesto DF-e (sub-página 4 do design KB-9.75).
+ *
+ * Lista NF-e emitidas CONTRA nosso CNPJ (recebidas via NSU SEFAZ). Prazo
+ * legal 90 dias pra manifestação (confirmar/desconhecer/não-realizada/ciência).
+ *
+ * HasBusinessScope (ADR 0093). Mutações (ações manifestar) em PR futuro
+ * — esta PR é leitura + filtros only.
+ */
+class DfeController extends Controller
+{
+    public function index(Request $request): Response
+    {
+        if (! auth()->user()->can('superadmin') && ! auth()->user()->can('fiscal.dfe.manage')) {
+            abort(403, 'Sem permissão fiscal.dfe.manage');
+        }
+
+        $filters = [
+            'status' => (string) $request->input('status', 'pendentes'),
+            'search' => (string) $request->input('search', ''),
+        ];
+
+        return Inertia::render('Fiscal/Dfe', [
+            'filters' => $filters,
+            'counts'  => $this->computeCounts(),
+            'rows'    => Inertia::defer(fn () => $this->buildRowsPayload($filters)),
+        ]);
+    }
+
+    protected function computeCounts(): array
+    {
+        $base = NfeDfeRecebido::query();
+
+        return [
+            'total'        => (clone $base)->count(),
+            'pendentes'    => (clone $base)->whereIn('status_manifestacao', [
+                NfeDfeRecebido::STATUS_PENDENTE,
+                NfeDfeRecebido::STATUS_CIENCIA,
+            ])->count(),
+            'confirmadas'  => (clone $base)->where('status_manifestacao', NfeDfeRecebido::STATUS_CONFIRMADA)->count(),
+            'desconhecidas'=> (clone $base)->where('status_manifestacao', NfeDfeRecebido::STATUS_DESCONHECIDA)->count(),
+            'naoRealizadas'=> (clone $base)->where('status_manifestacao', NfeDfeRecebido::STATUS_NAO_REALIZADA)->count(),
+            'valorPendente'=> (float) (clone $base)
+                ->whereIn('status_manifestacao', [NfeDfeRecebido::STATUS_PENDENTE, NfeDfeRecebido::STATUS_CIENCIA])
+                ->sum('valor_total'),
+        ];
+    }
+
+    protected function buildRowsPayload(array $filters): array
+    {
+        $query = NfeDfeRecebido::query()->orderByDesc('data_emissao');
+
+        match ($filters['status']) {
+            'pendentes'      => $query->whereIn('status_manifestacao', [
+                NfeDfeRecebido::STATUS_PENDENTE,
+                NfeDfeRecebido::STATUS_CIENCIA,
+            ]),
+            'confirmadas'    => $query->where('status_manifestacao', NfeDfeRecebido::STATUS_CONFIRMADA),
+            'desconhecidas'  => $query->where('status_manifestacao', NfeDfeRecebido::STATUS_DESCONHECIDA),
+            'nao_realizadas' => $query->where('status_manifestacao', NfeDfeRecebido::STATUS_NAO_REALIZADA),
+            'todas'          => $query,
+            default          => $query,
+        };
+
+        if ($filters['search'] !== '') {
+            $s = preg_replace('/\D/', '', $filters['search']);
+            $raw = $filters['search'];
+            $query->where(function ($q) use ($s, $raw) {
+                $q->where('chave_44', 'like', "%{$s}%")
+                  ->orWhere('cnpj_emitente', 'like', "%{$s}%")
+                  ->orWhere('nome_emitente', 'like', "%{$raw}%");
+            });
+        }
+
+        $paginator = $query->paginate(50);
+        $hoje = now()->startOfDay();
+
+        return [
+            'data' => $paginator->getCollection()->map(function (NfeDfeRecebido $d) use ($hoje) {
+                $prazoDias = $d->prazo_confirmacao_em
+                    ? (int) $hoje->diffInDays($d->prazo_confirmacao_em, false)
+                    : null;
+
+                return [
+                    'id'                  => $d->id,
+                    'chave'               => $d->chave_44,
+                    'nsu'                 => $d->nsu,
+                    'cnpjEmitente'        => $d->cnpj_emitente,
+                    'nomeEmitente'        => $d->nome_emitente,
+                    'valor'               => (float) $d->valor_total,
+                    'numProtocolo'        => $d->num_protocolo,
+                    'dataEmissaoIso'      => $d->data_emissao?->toIso8601String(),
+                    'when'                => $d->data_emissao?->format('d/m H:i'),
+                    'statusManifestacao'  => $d->status_manifestacao,
+                    'manifestadoEmIso'    => $d->manifestado_em?->toIso8601String(),
+                    'prazoDias'           => $prazoDias,
+                ];
+            })->all(),
+            'meta' => [
+                'current_page' => $paginator->currentPage(),
+                'last_page'    => $paginator->lastPage(),
+                'total'        => $paginator->total(),
+                'per_page'     => $paginator->perPage(),
+            ],
+        ];
+    }
+}

--- a/Modules/Fiscal/Http/Controllers/SpedController.php
+++ b/Modules/Fiscal/Http/Controllers/SpedController.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace Modules\Fiscal\Http\Controllers;
+
+use Illuminate\Routing\Controller;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\NfeBrasil\Models\NfeEmissao;
+
+/**
+ * SPED & Livros (sub-página 7 do design KB-9.75).
+ *
+ * Placeholder no PR — implementação completa exige integração com gerador
+ * SPED Fiscal/EFD (Modules/NfeBrasil futuro). Por agora exibe panorama
+ * dos períodos com contagens de notas autorizadas (substituto cru de
+ * "competências fechadas").
+ */
+class SpedController extends Controller
+{
+    public function index(): Response
+    {
+        if (! auth()->user()->can('superadmin') && ! auth()->user()->can('fiscal.sped.export')) {
+            abort(403, 'Sem permissão fiscal.sped.export');
+        }
+
+        // 5 últimos meses — contagem agregada de notas autorizadas
+        $periodos = [];
+        for ($i = 0; $i < 5; $i++) {
+            $start = now()->startOfMonth()->subMonths($i);
+            $end   = $start->copy()->endOfMonth();
+
+            $count = NfeEmissao::query()
+                ->where('status', 'autorizada')
+                ->whereBetween('emitido_em', [$start, $end])
+                ->count();
+            $valor = (float) NfeEmissao::query()
+                ->where('status', 'autorizada')
+                ->whereBetween('emitido_em', [$start, $end])
+                ->sum('valor_total');
+
+            $periodos[] = [
+                'mes'           => $start->format('m/Y'),
+                'mesIso'        => $start->format('Y-m'),
+                'notasAutorizadas' => $count,
+                'valorAutorizado'  => $valor,
+                'status'        => $i === 0 ? 'aberto' : ($i === 1 ? 'pronto' : 'entregue'),
+                'prazoEntrega'  => $i === 0 ? null : $start->copy()->addMonth()->day(15)->format('d/m/Y'),
+            ];
+        }
+
+        return Inertia::render('Fiscal/Sped', [
+            'periodos' => $periodos,
+            'notice'   => 'SPED Fiscal (EFD ICMS-IPI) + PIS/COFINS · gerador completo em desenvolvimento. Dados agregados de NfeEmissao mostrados como referência.',
+        ]);
+    }
+}

--- a/Modules/Fiscal/Routes/web.php
+++ b/Modules/Fiscal/Routes/web.php
@@ -2,10 +2,13 @@
 
 use Illuminate\Support\Facades\Route;
 use Modules\Fiscal\Http\Controllers\CockpitController;
+use Modules\Fiscal\Http\Controllers\ConfigController;
+use Modules\Fiscal\Http\Controllers\DfeController;
 use Modules\Fiscal\Http\Controllers\EventosController;
 use Modules\Fiscal\Http\Controllers\InstallController;
 use Modules\Fiscal\Http\Controllers\NfeCockpitController;
 use Modules\Fiscal\Http\Controllers\NfseCockpitController;
+use Modules\Fiscal\Http\Controllers\SpedController;
 
 /*
 |--------------------------------------------------------------------------
@@ -43,5 +46,12 @@ Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'Adm
         // CC-e + Cancelamento + EPEC + Manifestação destinatário.
         Route::get('/eventos', [EventosController::class, 'index'])->name('eventos.index');
 
-        // Próximos PRs: /fiscal/dfe (sub-página 4), /fiscal/config (6), /fiscal/sped (7).
+        // Manifesto DF-e (sub-página 4 — PR #3 Wave final).
+        Route::get('/dfe', [DfeController::class, 'index'])->name('dfe.index');
+
+        // Cert/Cfg fiscal (sub-página 6 — PR #3 Wave final).
+        Route::get('/config', [ConfigController::class, 'index'])->name('config.index');
+
+        // SPED & Livros (sub-página 7 — PR #3 Wave final, placeholder).
+        Route::get('/sped', [SpedController::class, 'index'])->name('sped.index');
     });

--- a/Modules/Fiscal/SCOPE.md
+++ b/Modules/Fiscal/SCOPE.md
@@ -3,11 +3,14 @@ module: Fiscal
 purpose: "Cockpit fiscal unificado — agregador thin sobre NfeBrasil + NFSe (sem duplicação). PR #1: sub-página NF-e · NFC-e (modelos 55 + 65). Roadmap: 7 sub-páginas (Cockpit, NF-e, NFS-e, DF-e, Eventos, Config, SPED) conforme design Cowork KB-9.75."
 contains:
   - "CockpitController — sub-página 1 (KPIs + alertas + sparklines + quick links)"
+  - "ConfigController — sub-página 6 (Cert A1 + regime + tributação default read-only)"
   - "DataController"
+  - "DfeController — sub-página 4 (Manifesto DF-e + prazo 90d)"
   - "EventosController — sub-página 5 (timeline append-only CC-e/Cancel/EPEC/Manifesto)"
   - "InstallController"
   - "NfeCockpitController — sub-página 2 (NF-e/NFC-e + drawer SEFAZ guiado)"
   - "NfseCockpitController — sub-página 3 (NFS-e modelo 56 nacional NT 2024-001)"
+  - "SpedController — sub-página 7 (placeholder panorama mensal — gerador real backlog)"
 not_contains:
   - "Emissão fiscal (XML + SEFAZ) → Modules/NfeBrasil (lê via Service)"
   - "NFSe federal LC 214/2025 → Modules/NFSe (futura sub-página 3)"
@@ -53,15 +56,20 @@ Ver `not_contains[]` no frontmatter. Em dúvida:
 
 | Sub-página | Status | PR |
 |---|---|---|
-| NF-e · NFC-e (#2 do design) | ✅ mergeado | PR #1 (8aef3d0fa) |
-| Cockpit (KPIs + alertas + sparklines) | 🟡 em curso | PR #2 Wave |
-| NFS-e (modelo 56 nacional) | 🟡 em curso | PR #2 Wave |
-| Eventos timeline (CC-e/Cancel/EPEC/Manifesto) | 🟡 em curso | PR #2 Wave |
-| Manifesto DF-e + Cert/Cfg + SPED | 🔒 backlog | PR #3 |
+| NF-e · NFC-e (#2 do design) | ✅ mergeado | PR #1 `8aef3d0fa` |
+| Cockpit (KPIs + alertas + sparklines) | ✅ mergeado | PR #2 Wave `cabd29661` |
+| NFS-e (modelo 56 nacional) | ✅ mergeado | PR #2 Wave `cabd29661` |
+| Eventos timeline (CC-e/Cancel/EPEC/Manifesto) | ✅ mergeado | PR #2 Wave `cabd29661` |
+| Manifesto DF-e | 🟡 em curso | PR #3 Wave |
+| Cert/Cfg | 🟡 em curso | PR #3 Wave |
+| SPED placeholder | 🟡 em curso | PR #3 Wave |
+| **🎯 7 sub-páginas do design completas após PR #3** | | |
 | Ações mutação (cancelar/retransmitir/CC-e/inutilizar) | 🔒 backlog | PR #4 |
 | ⌘K palette cross-fiscal | 🔒 backlog | PR #5 |
+| Gerador SPED real (EFD ICMS/IPI + PIS/COFINS) | 🔒 backlog | PR #6 |
 
 ---
 
 - **v1.0.0** (2026-05-20) — SCOPE.md inicial. Módulo Fiscal criado em PR #1183 como thin agregador (sub-página NF-e · NFC-e).
 - **v1.1.0** (2026-05-20) — PR #2 Wave consolidada: + CockpitController, NfseCockpitController, EventosController. Roadmap reorganizado (5 PRs vs 7).
+- **v1.2.0** (2026-05-20) — PR #3 Wave final: + DfeController, ConfigController, SpedController. **7 sub-páginas do design concluídas**. Próximos PRs: mutações + ⌘K + SPED real.

--- a/Modules/Fiscal/Tests/Feature/ConfigControllerTest.php
+++ b/Modules/Fiscal/Tests/Feature/ConfigControllerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Models\NfeCertificado;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR #3 Wave Cert/Cfg Fiscal — isolation + senha hidden.
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: NfeCertificado requer schema MySQL (ADR 0101)');
+    }
+    if (! Schema::hasTable('nfe_certificados')) {
+        $this->markTestSkipped('nfe_certificados table missing');
+    }
+});
+
+it('NfeCertificado encrypted_password é hidden — não vaza no payload Inertia', function () {
+    $cert = new NfeCertificado([
+        'business_id'        => 1,
+        'cnpj_titular'       => '00000000000000',
+        'encrypted_password' => 'SECRET_NEVER_LEAK',
+        'ativo'              => true,
+    ]);
+
+    $json = $cert->toArray();
+    expect($json)
+        ->not->toHaveKey('encrypted_password', 'Senha encriptada DEVE estar em $hidden');
+});
+
+it('NfeCertificado HasBusinessScope esconde certs de outros tenants', function () {
+    session(['business.id' => 1, 'user.business_id' => 1]);
+
+    $crossTenantCount = NfeCertificado::query()
+        ->where('business_id', '!=', 1)
+        ->count();
+
+    expect($crossTenantCount)->toBe(0, 'Cross-tenant nunca vaza certs');
+});

--- a/Modules/Fiscal/Tests/Feature/DfeControllerTest.php
+++ b/Modules/Fiscal/Tests/Feature/DfeControllerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Models\NfeDfeRecebido;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR #3 Wave DF-e Fiscal — isolation Tier 0 (ADR 0093) + ADR 0101 biz=1.
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: NfeDfeRecebido requer schema MySQL (ADR 0101)');
+    }
+    if (! Schema::hasTable('nfe_dfe_recebidos')) {
+        $this->markTestSkipped('nfe_dfe_recebidos table missing');
+    }
+});
+
+it('NfeDfeRecebido HasBusinessScope esconde cross-tenant da listagem DF-e', function () {
+    session(['business.id' => 1, 'user.business_id' => 1]);
+
+    $crossTenantCount = NfeDfeRecebido::query()
+        ->where('business_id', '!=', 1)
+        ->count();
+
+    expect($crossTenantCount)->toBe(0, 'Global scope deve esconder cross-tenant');
+});
+
+it('STATUS constants estão definidas — Controller depende delas pra filtros', function () {
+    expect(NfeDfeRecebido::STATUS_PENDENTE)->toBe('pendente')
+        ->and(NfeDfeRecebido::STATUS_CIENCIA)->toBe('ciencia')
+        ->and(NfeDfeRecebido::STATUS_CONFIRMADA)->toBe('confirmada')
+        ->and(NfeDfeRecebido::STATUS_DESCONHECIDA)->toBe('desconhecida')
+        ->and(NfeDfeRecebido::STATUS_NAO_REALIZADA)->toBe('nao_realizada');
+});
+
+it('isPendenteManifestacao retorna true pra status PENDENTE e CIENCIA', function () {
+    $pendente = new NfeDfeRecebido(['status_manifestacao' => NfeDfeRecebido::STATUS_PENDENTE]);
+    $ciencia  = new NfeDfeRecebido(['status_manifestacao' => NfeDfeRecebido::STATUS_CIENCIA]);
+    $conf     = new NfeDfeRecebido(['status_manifestacao' => NfeDfeRecebido::STATUS_CONFIRMADA]);
+
+    expect($pendente->isPendenteManifestacao())->toBeTrue()
+        ->and($ciencia->isPendenteManifestacao())->toBeTrue()
+        ->and($conf->isPendenteManifestacao())->toBeFalse();
+});

--- a/Modules/Fiscal/Tests/Feature/SpedControllerTest.php
+++ b/Modules/Fiscal/Tests/Feature/SpedControllerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Models\NfeEmissao;
+
+uses(Tests\TestCase::class);
+
+/**
+ * PR #3 Wave SPED Fiscal — placeholder.
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: NfeEmissao requer schema MySQL (ADR 0101)');
+    }
+    if (! Schema::hasTable('nfe_emissoes')) {
+        $this->markTestSkipped('nfe_emissoes table missing');
+    }
+});
+
+it('agregação de períodos NfeEmissao respeita scope per business', function () {
+    session(['business.id' => 1, 'user.business_id' => 1]);
+
+    $crossTenantCount = NfeEmissao::query()
+        ->where('business_id', '!=', 1)
+        ->count();
+
+    expect($crossTenantCount)->toBe(0, 'Agregação SPED scoped — nunca vaza outros businesses');
+});
+
+it('Controller é placeholder — sem gerador SPED real ainda', function () {
+    // Defensa: garante que a classe NÃO tem método "exportSped" implementado
+    // (seria gerador real — não pode existir até PR dedicado).
+    $controller = new \Modules\Fiscal\Http\Controllers\SpedController();
+
+    expect(method_exists($controller, 'exportSped'))->toBeFalse(
+        'Gerador SPED real só em PR dedicado — anti-hook charter'
+    );
+    expect(method_exists($controller, 'gerarEFD'))->toBeFalse();
+});

--- a/memory/requisitos/Fiscal/RUNBOOK-config.md
+++ b/memory/requisitos/Fiscal/RUNBOOK-config.md
@@ -1,0 +1,42 @@
+# RUNBOOK — Fiscal/Config (sub-página 6)
+
+> **Tela:** `/fiscal/config` · **Permissão:** `fiscal.config.edit` · **PR origem:** PR #3 Wave final
+
+## 1. Objetivo
+
+Visão **read-only** consolidada de cert A1 + regime tributário + tributação default. Edição vive em `Modules/NfeBrasil/.../Configuracao/Certificado.tsx` canon (link no header).
+
+## 2. Estrutura
+
+```
+FxShell route="fiscal_config"
+└── Body
+    ├── Section Cert A1 (`NfeCertificado::ativos()->first()`)
+    │   └── cnpj_titular / valido_ate / dias / status / uuid
+    ├── Section Regime + Emissão (`NfeBusinessConfig::first()`)
+    │   └── regime / autoEmissionEnabled / tributacao_default JSON
+    └── Notice rodapé link pra NfeBrasil edição
+```
+
+## 3. Dados
+
+- `NfeCertificado` (HasBusinessScope) — `$hidden = ['encrypted_password']` 🔒
+- `NfeBusinessConfig` (1 por business) — regime/tributacao default cascata
+- Tone cert: bad ≤7d, warn ≤60d, ok >60d
+
+## 4. Permissão
+
+`fiscal.config.edit` — pré-existente PR #1.
+
+## 5. Riscos
+
+- **R1**: `encrypted_password` NUNCA pode vazar — `$hidden` no Model garante
+- **R2**: Edits via UI desta tela NÃO existem (read-only by design — anti-hook charter)
+- **R3**: Se cert expirar, todas emissões falham — alerta visual obrigatório (já implementado pelo tone bad)
+
+## 6. Smoke biz=1
+
+```bash
+curl -sv "https://oimpresso.com/fiscal/config" -H "Cookie: ..." | grep '^< HTTP'
+# Esperado: < HTTP/2 200 (ou 403 sem fiscal.config.edit)
+```

--- a/memory/requisitos/Fiscal/RUNBOOK-dfe.md
+++ b/memory/requisitos/Fiscal/RUNBOOK-dfe.md
@@ -1,0 +1,40 @@
+# RUNBOOK — Fiscal/Dfe (sub-página 4)
+
+> **Tela:** `/fiscal/dfe` · **Permissão:** `fiscal.dfe.manage` · **PR origem:** PR #3 Wave final
+
+## 1. Objetivo
+
+Lista de NF-e emitidas CONTRA o CNPJ Oimpresso (manifesto destinatário). Prazo legal 90d para manifestar (confirmar/desconhecer/não-realizada/ciência).
+
+## 2. Estrutura
+
+```
+FxShell route="dfe"
+└── Body
+    ├── Filtros (search + 5 chips status)
+    └── Tabela paginada (Deferred)
+        colunas: Emitente · Chave · Status pill · Prazo pílula · Valor · Emissão
+```
+
+## 3. Dados
+
+- Model: `Modules\NfeBrasil\Models\NfeDfeRecebido` (HasBusinessScope)
+- 5 STATUS constants (pendente/ciencia/confirmada/desconhecida/nao_realizada)
+- counts eager + rows deferred (paginate 50)
+- prazoDias = `now()->diffInDays(prazo_confirmacao_em, false)` (negativo = vencido)
+
+## 4. Permissão
+
+`fiscal.dfe.manage` — adicionada em PR #1. Pré-existente, não muda.
+
+## 5. Riscos
+
+- **R1**: Notas DFe podem ter `nome_emitente` PII de terceiros — exibidos legalmente (compliance) mas sem agregação cruzada
+- **R2**: Prazo 90d é SEFAZ-driven (`prazo_confirmacao_em` no Model) — não calcular UI-side
+
+## 6. Smoke biz=1
+
+```bash
+curl -sv "https://oimpresso.com/fiscal/dfe" -H "Cookie: ..." | grep '^< HTTP'
+# Esperado: < HTTP/2 200 (ou 403 sem fiscal.dfe.manage)
+```

--- a/memory/requisitos/Fiscal/RUNBOOK-sped.md
+++ b/memory/requisitos/Fiscal/RUNBOOK-sped.md
@@ -1,0 +1,47 @@
+# RUNBOOK — Fiscal/Sped (sub-página 7)
+
+> **Tela:** `/fiscal/sped` · **Permissão:** `fiscal.sped.export` · **PR origem:** PR #3 Wave final (placeholder)
+
+## 1. Objetivo
+
+**Placeholder consciente** — gerador SPED Fiscal real (EFD ICMS/IPI + EFD-Contribuições) é integração complexa pra PR dedicado. Esta tela mostra **panorama** dos 5 últimos meses com contagem agregada de `NfeEmissao` autorizadas como referência cru.
+
+## 2. Estrutura
+
+```
+FxShell route="sped"
+└── Body
+    ├── Notice warning gradient "em desenvolvimento"
+    ├── Tabela períodos (5 últimos meses)
+    │   colunas: Competência · Status · Notas auth · Valor auth · Prazo · Export (disabled)
+    └── Empty Livros (apuração ICMS/ISS — placeholder)
+```
+
+## 3. Dados
+
+- Agregação `NfeEmissao` autorizadas por mês (5 últimos)
+- Status heurístico: M = aberto, M-1 = pronto, M-2+ = entregue
+- Prazo entrega = M.startOfMonth()->addMonth()->day(15)
+- Sem geração de TXT SPED real (anti-hook)
+
+## 4. Permissão
+
+`fiscal.sped.export` — pré-existente PR #1.
+
+## 5. Riscos
+
+- **R1**: NÃO emitir SPED TXT real até implementação canônica (formato CONFAZ é crítico — gerar TXT inválido pode causar penalidade fiscal)
+- **R2**: Heurística de status (aberto/pronto/entregue) é APROXIMAÇÃO — quem decide entrega final é contador via portal SEFIN
+
+## 6. Smoke biz=1
+
+```bash
+curl -sv "https://oimpresso.com/fiscal/sped" -H "Cookie: ..." | grep '^< HTTP'
+# Esperado: < HTTP/2 200 (ou 403 sem fiscal.sped.export)
+```
+
+## 7. Próximo PR
+
+- Gerador EFD ICMS/IPI: parser TXT layout CONFAZ + queries reais (livros entrada/saída/apuração)
+- Gerador EFD-Contribuições: PIS/COFINS cumulativo/não-cumulativo
+- Workflow validação contador → entrega SEFIN

--- a/memory/requisitos/Fiscal/SPEC.md
+++ b/memory/requisitos/Fiscal/SPEC.md
@@ -130,9 +130,54 @@ Lê `Modules/NfeBrasil/Models/NfeDfeRecebido`.
 - [x] Pest biz=1 (`EventosCockpitMultiTenantTest`)
 - [x] Charter + RUNBOOK + visual-comparison
 
-### US-FISCAL-008 · Cert/Cfg + SPED + DF-e — **backlog PR #3**
+### US-FISCAL-008 · DF-e manifesto (sub-página 4) — ✅ PR #3 Wave
 
-Sub-páginas 4 (DF-e), 6 (Cert/Cfg), 7 (SPED). PR único ou subdividido conforme escopo.
+> **Rota:** `GET /fiscal/dfe` · **Permissão:** `fiscal.dfe.manage`
+
+**Como** contador
+**Quero** lista de NF-e emitidas CONTRA o CNPJ com filtros + pílula de prazo 90d
+**Para** manifestar dentro do prazo legal (CONFAZ)
+
+**DoD:**
+- [x] Lista paginada NfeDfeRecebido (HasBusinessScope)
+- [x] 5 chips status + busca chave/CNPJ/nome
+- [x] Pílula temporal prazo (crit <7d / warn <30d / ok)
+- [x] Pest biz=1 (`DfeControllerTest`) + Charter + RUNBOOK + visual-comparison
+
+### US-FISCAL-009 · Cert/Cfg fiscal (sub-página 6) — ✅ PR #3 Wave
+
+> **Rota:** `GET /fiscal/config` · **Permissão:** `fiscal.config.edit`
+
+**Como** admin
+**Quero** visão consolidada do cert A1 + regime + tributação default
+**Para** confirmar status sem abrir múltiplas telas NfeBrasil
+
+**DoD:**
+- [x] Status cert A1 (NfeCertificado — `encrypted_password` $hidden)
+- [x] Regime + auto_emission + tributacao_default
+- [x] Tone urgência cert (bad ≤7d, warn ≤60d)
+- [x] Read-only by design (link "Editar" → NfeBrasil canon)
+- [x] Pest biz=1 (`ConfigControllerTest`) + Charter + RUNBOOK + visual-comparison
+
+### US-FISCAL-010 · SPED & Livros (sub-página 7) — ✅ PR #3 Wave (placeholder)
+
+> **Rota:** `GET /fiscal/sped` · **Permissão:** `fiscal.sped.export`
+
+**Como** contador
+**Quero** panorama dos últimos 5 meses com status apuração + contagem agregada
+**Para** ter referência cru enquanto gerador SPED canônico não existe
+
+**DoD:**
+- [x] Tabela 5 últimos meses (NfeEmissao autorizadas agregadas)
+- [x] Status heurístico (aberto/pronto/entregue) + prazo entrega
+- [x] Notice claro "em desenvolvimento"
+- [x] Export buttons disabled (anti-hook charter)
+- [x] Pest biz=1 (`SpedControllerTest` — anti-hook: gerador real NÃO existe)
+- [x] Charter + RUNBOOK + visual-comparison
+
+### US-FISCAL-011 · Gerador SPED real — **backlog PR #4+**
+
+EFD ICMS/IPI + EFD-Contribuições reais (TXT layout CONFAZ). PR dedicado pós-MVP fiscal.
 
 ## 3. Regras Gherkin
 
@@ -184,11 +229,12 @@ Then deve receber 403 Forbidden
 
 | PR | Sub-página(s) | Esforço IA-pair | Score impact | Status |
 |---|---|---|---|---|
-| #1 #1183 | NF-e · NFC-e (cockpit + drawer) | 1 dia | base 0→60/100 | ✅ mergeado 8aef3d0fa |
-| #2 (Wave) | Cockpit (1) + NFS-e (3) + Eventos (5) | 1 dia | +20pp | 🟡 em curso |
-| #3 | DF-e manifesto + Cert/Cfg + SPED | 1-2 dias | +12pp | 🔒 backlog |
+| #1 #1183 | NF-e · NFC-e (cockpit + drawer) | 1 dia | base 0→60/100 | ✅ mergeado `8aef3d0fa` |
+| #2 #1185 (Wave) | Cockpit (1) + NFS-e (3) + Eventos (5) | 1 dia | +20pp | ✅ mergeado `cabd29661` |
+| #3 (Wave) | DF-e (4) + Cert/Cfg (6) + SPED (7) | 1 dia | +12pp | 🟡 em curso |
 | #4 | Ações mutação (cancelar/retx/CC-e/inut) | 1-2 dias | +15pp (core) | 🔒 backlog |
 | #5 | ⌘K palette cross-fiscal | 6h | +8pp | 🔒 backlog |
+| #6 | Gerador SPED real (EFD ICMS-IPI + PIS/COFINS) | 1+ semana | +10pp | 🔒 backlog |
 
 **Meta:** Score Capterra Fiscal cockpit ≥ 80/100 pós-PR #4 (Wagner aprova).
 
@@ -196,6 +242,7 @@ Then deve receber 403 Forbidden
 
 - **v1.0.0** (2026-05-20) — SPEC.md inicial criado em PR #1183 (Fiscal cockpit NF-e). Módulo novo thin agregador.
 - **v1.1.0** (2026-05-20) — PR #2 Wave consolidada: Cockpit + NFS-e + Eventos. 3 sub-páginas adicionadas (US-FISCAL-002, US-FISCAL-005, US-FISCAL-007). Permission `fiscal.nfse.view` nova. Roadmap reorganizado (5 PRs vs 7 originais).
+- **v1.2.0** (2026-05-20) — PR #3 Wave final: DF-e + Cert/Cfg + SPED placeholder. **7 sub-páginas do design Cowork concluídas**. US-FISCAL-008/009/010 adicionadas + US-FISCAL-011 backlog (gerador SPED real). FxShell habilita todos 7 chips. Próximo PR foco em ações de mutação (cancelar/CC-e/etc).
 
 ## Referências
 

--- a/memory/requisitos/Fiscal/fiscal-config-visual-comparison.md
+++ b/memory/requisitos/Fiscal/fiscal-config-visual-comparison.md
@@ -1,0 +1,73 @@
+---
+tela: Fiscal/Config
+url: /fiscal/config
+status: approved
+approver: wagner
+approved_at: 2026-05-20
+prototype_source: "prototipo-ui/.../fiscal-data.jsx CONFIG"
+implementation: resources/js/Pages/Fiscal/Config.tsx
+adr: 0107
+---
+
+# Visual Comparison — Fiscal/Config (PR #3 Wave)
+
+## Blueprint Cowork
+
+`prototipo-ui/.../fiscal-data.jsx::CONFIG` (certificado + ambiente + séries + regime).
+
+## Approval
+
+Wagner aprovou Wave 3 final 2026-05-20.
+
+## 8 dimensões
+
+### 1. Layout grid
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| 2 cards (cert + config) | seções stacked | ✅ `.fx-drawer-sec` reaproveitada como card | ✅ |
+
+### 2. Tipografia
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| h4 section title uppercase | letter-spacing 0.05em | ✅ `.fx-drawer-sec h4` | ✅ |
+| `.fx-kv` dt mute / dd text | 100px grid | ✅ idem | ✅ |
+
+### 3. Densidade
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Card padding 18px | spacious | ✅ inline style | ✅ |
+
+### 4. Iconografia
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Shield icon section title | lucide 13px | ✅ idem | ✅ |
+| Edit3 ação editar | lucide 12px | ✅ idem | ✅ |
+
+### 5. Cores cert
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Validade bg pill por urgência | crit/warn/ok | ✅ `.fx-sefaz.{ok,warn,bad}` | ✅ |
+
+### 6. Estados condicionais
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Sem cert → empty state | inline empty | ✅ `.fx-empty` no card | ✅ |
+| Sem config → empty | inline empty | ✅ idem | ✅ |
+| EXPIRADO se diasRestantes ≤0 | label diferente | ✅ ternário inline | ✅ |
+
+### 7. Link edição
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Editar → /nfe-brasil/configuracao | botão primary header | ✅ `<a>` com class `.fx-btn.primary` | ✅ |
+| Notice "edição vive em NfeBrasil" | rodapé | ✅ `.fx-empty` rodapé | ✅ |
+
+### 8. Reuso
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| FxShell | shared | ✅ | ✅ |
+| `.fx-kv` dt/dd grid | reaproveitado de drawer | ✅ | ✅ |
+| Read-only por design | nenhum form/input | ✅ confirmed (sem `<form>`) | ✅ |
+
+## Histórico
+
+- **2026-05-20** — Wave 3 final.

--- a/memory/requisitos/Fiscal/fiscal-dfe-visual-comparison.md
+++ b/memory/requisitos/Fiscal/fiscal-dfe-visual-comparison.md
@@ -1,0 +1,75 @@
+---
+tela: Fiscal/Dfe
+url: /fiscal/dfe
+status: approved
+approver: wagner
+approved_at: 2026-05-20
+prototype_source: "prototipo-ui/.../fiscal-data.jsx DFE_PENDENTE"
+implementation: resources/js/Pages/Fiscal/Dfe.tsx
+adr: 0107
+---
+
+# Visual Comparison — Fiscal/Dfe (PR #3 Wave)
+
+## Blueprint Cowork
+
+`prototipo-ui/.../fiscal-page.jsx PÁGINA 4` + `fiscal-data.jsx::DFE_PENDENTE/DFE_HISTORICO`.
+
+## Approval
+
+Wagner aprovou Wave 3 final 2026-05-20.
+
+## 8 dimensões
+
+### 1. Layout grid
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Tabela emissor + chave + status | colunas estendidas pra prazo+valor | ✅ idem | ✅ |
+
+### 2. Tipografia
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Emitente bold + CNPJ small | row primary | ✅ idem | ✅ |
+| Chave truncada mono | últimos 6 dígitos | ✅ truncKey helper | ✅ |
+
+### 3. Densidade
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Row 48px padrão | idem outras tabelas | ✅ `.fx-table` | ✅ |
+
+### 4. Iconografia
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Empty state ShieldAlert | lucide | ✅ idem | ✅ |
+| Search icon | FileSearch | ✅ idem | ✅ |
+
+### 5. Status pill
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Pendente/Ciência warn | warn-soft + warn | ✅ STATUS_META mapping | ✅ |
+| Confirmada ok | ok-soft + ok | ✅ idem | ✅ |
+| Desconhecida/NãoRealizada bad | bad-soft + bad | ✅ idem | ✅ |
+
+### 6. Pílula temporal prazo
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| 3 níveis urgência | crit <7d, warn <30d, ok | ✅ prazoUrgency inline | ✅ |
+| Mostra "vencido" se ≤0 | fallback | ✅ ternário inline | ✅ |
+
+### 7. Estados condicionais
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Empty state nenhum DFe | ShieldAlert + msg | ✅ `.fx-empty` | ✅ |
+| Search vazio | hint placeholder | ✅ idem | ✅ |
+
+### 8. Componentes reutilizados
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| FxShell | shared | ✅ | ✅ |
+| formatDoc/brl/truncKey | _lib | ✅ | ✅ |
+| `.fx-sefaz` SEFAZ pill | reaproveitado pra status DFe | ✅ | ✅ |
+| `.fx-timepill u-{ok,warn,crit}` | reaproveitado pra prazo | ✅ | ✅ |
+
+## Histórico
+
+- **2026-05-20** — Wave 3 final PR.

--- a/memory/requisitos/Fiscal/fiscal-sped-visual-comparison.md
+++ b/memory/requisitos/Fiscal/fiscal-sped-visual-comparison.md
@@ -1,0 +1,73 @@
+---
+tela: Fiscal/Sped
+url: /fiscal/sped
+status: approved
+approver: wagner
+approved_at: 2026-05-20
+prototype_source: "prototipo-ui/.../fiscal-data.jsx SPED_PERIODOS/LIVROS"
+implementation: resources/js/Pages/Fiscal/Sped.tsx
+adr: 0107
+---
+
+# Visual Comparison — Fiscal/Sped (PR #3 Wave)
+
+## Blueprint Cowork
+
+`prototipo-ui/.../fiscal-data.jsx::SPED_PERIODOS/LIVROS`. **PR #3 entrega placeholder** — gerador SPED real em PR dedicado.
+
+## Approval
+
+Wagner aprovou Wave 3 final 2026-05-20 — placeholder consciente, notice claro "em desenvolvimento".
+
+## 8 dimensões
+
+### 1. Layout grid
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Notice banner topo | warn gradient bg | ✅ inline style | ✅ |
+| Tabela períodos | comp/status/notas/valor/prazo/export | ✅ `.fx-table` | ✅ |
+
+### 2. Tipografia
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Competência mono bold | format MM/YYYY | ✅ `.fx-mono.fx-strong` | ✅ |
+| Valor mono right-aligned | brl helper | ✅ idem | ✅ |
+
+### 3. Densidade
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Row padding default | igual outras tabelas | ✅ `.fx-table` | ✅ |
+
+### 4. Iconografia
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Download icon export disabled | lucide 11px | ✅ idem | ✅ |
+| Archive icon livros section | lucide 20px | ✅ idem | ✅ |
+
+### 5. Status pill
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Aberto warn | warn-soft + warn | ✅ STATUS_META | ✅ |
+| Pronto/Entregue ok | ok-soft + ok | ✅ idem | ✅ |
+
+### 6. Notice "em desenvolvimento"
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Banner warn gradient | linear-gradient warn-soft → white | ✅ inline style | ✅ |
+| Texto explicativo | ref MemCofre/NfeBrasil SPEC futuro | ✅ idem | ✅ |
+
+### 7. Export disabled
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| Button download disabled | title hover | ✅ `<button disabled title="...">` | ✅ |
+
+### 8. Reuso
+| Aspecto | Cowork | Inertia | OK? |
+|---|---|---|---|
+| FxShell | shared | ✅ | ✅ |
+| `.fx-table` + `.fx-sefaz` + `.fx-empty` | reaproveitados | ✅ | ✅ |
+| brl helper | _lib | ✅ | ✅ |
+
+## Histórico
+
+- **2026-05-20** — Wave 3 final, **placeholder consciente**. Gerador SPED EFD ICMS/IPI + PIS/COFINS em PR dedicado pós-MVP fiscal.

--- a/resources/js/Pages/Fiscal/Cockpit.tsx
+++ b/resources/js/Pages/Fiscal/Cockpit.tsx
@@ -221,10 +221,10 @@ export default function Cockpit({ kpis, sparklines, alerts }: CockpitProps) {
             <small>NT 2024-001 · LC 214/2025</small>
             <kbd className="fx-quick-kbd">3</kbd>
           </div>
-          <div className="fx-quick-card" style={{ opacity: 0.55 }}>
+          <div className="fx-quick-card" onClick={() => goto('/fiscal/dfe')}>
             <div className="top"><ShieldAlert size={13} /> Manifesto DF-e</div>
             <b>{kpis.dfeAguardando} aguardando</b>
-            <small>NF-e contra nosso CNPJ · prazo 90d (em breve)</small>
+            <small>NF-e contra nosso CNPJ · prazo 90d</small>
             <kbd className="fx-quick-kbd">4</kbd>
           </div>
           <div className="fx-quick-card" onClick={() => goto('/fiscal/eventos')}>
@@ -233,16 +233,16 @@ export default function Cockpit({ kpis, sparklines, alerts }: CockpitProps) {
             <small>CC-e · cancelamento · manifestação</small>
             <kbd className="fx-quick-kbd">5</kbd>
           </div>
-          <div className="fx-quick-card" style={{ opacity: 0.55 }}>
+          <div className="fx-quick-card" onClick={() => goto('/fiscal/config')}>
             <div className="top"><Shield size={13} /> Certif. & cfg.</div>
             <b>{kpis.certificadoValidadeDias != null ? `A1 vence em ${kpis.certificadoValidadeDias}d` : 'Sem cert ativo'}</b>
-            <small>Configuração fiscal (em breve)</small>
+            <small>Status read-only · edição via NfeBrasil</small>
             <kbd className="fx-quick-kbd">6</kbd>
           </div>
-          <div className="fx-quick-card" style={{ opacity: 0.55 }}>
+          <div className="fx-quick-card" onClick={() => goto('/fiscal/sped')}>
             <div className="top"><Archive size={13} /> SPED & livros</div>
             <b>EFD ICMS/IPI · PIS/COFINS</b>
-            <small>Apuração mensal (em breve)</small>
+            <small>Panorama mensal (gerador em dev)</small>
             <kbd className="fx-quick-kbd">7</kbd>
           </div>
         </div>

--- a/resources/js/Pages/Fiscal/Config.charter.md
+++ b/resources/js/Pages/Fiscal/Config.charter.md
@@ -1,0 +1,38 @@
+---
+page_id: fiscal-config
+url: /fiscal/config
+module: Fiscal
+status: draft
+created: 2026-05-20
+owner: wagner
+related_adrs: [0093, 0094, 0101, 0104]
+prototypes:
+  - "prototipo-ui/.../fiscal-data.jsx CONFIG"
+---
+
+# Charter — `Fiscal/Config`
+
+## Mission
+
+Visão consolidada do estado **read-only** de cert A1 + regime tributário + tributação default. Edição completa via `Modules/NfeBrasil/.../Configuracao/Certificado.tsx` existente (link no header).
+
+## Goals (DoD PR #3)
+
+1. Status cert A1 (`NfeCertificado::ativos()`) — valido_ate + dias restantes + cnpj titular
+2. Regime tributário (`NfeBusinessConfig.regime`)
+3. Tributação default cascata (JSON resumido)
+4. Pílula temporal de vencimento (crit ≤7d, warn ≤60d)
+5. Link "Editar" → `/nfe-brasil/configuracao/certificado` (módulo emissor canon)
+6. Permissão `fiscal.config.edit`
+
+## Non-Goals (PR #3)
+
+- ❌ Edição inline (upload novo cert, mudar regime, editar tributação) — vive em NfeBrasil canon
+- ❌ Renovação automática de cert (backlog ADR futuro)
+- ❌ Histórico de certs (apenas atual ativo)
+
+## Anti-hooks
+
+- 🚫 `encrypted_password` está em `$hidden` no Model — NUNCA expor no payload Inertia
+- 🚫 Não criar UPDATE Controller — esta tela é read-only por design
+- 🚫 `cnpj_titular` exibido OK (admin do business já tem acesso a esse dado)

--- a/resources/js/Pages/Fiscal/Config.tsx
+++ b/resources/js/Pages/Fiscal/Config.tsx
@@ -1,0 +1,133 @@
+// @memcofre
+//   tela: /fiscal/config
+//   module: Fiscal
+//   stories: US-FISCAL-009 (Cert/Cfg sub-página 6 do design KB-9.75)
+//   adrs: 0093, 0094, 0101, 0104
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { Head } from '@inertiajs/react';
+import { Edit3, Shield } from 'lucide-react';
+
+import FxShell from './_components/FxShell';
+
+import '../../../css/fiscal-cockpit.css';
+
+interface Certificado {
+  uuid: string;
+  cnpjTitular: string | null;
+  validoAteIso: string | null;
+  validoAteBr: string | null;
+  diasRestantes: number | null;
+  ativo: boolean;
+}
+
+interface Config {
+  regime: string;
+  autoEmissionEnabled: boolean;
+  tributacaoDefault: Record<string, unknown>;
+}
+
+interface ConfigProps {
+  certificado: Certificado | null;
+  config: Config | null;
+}
+
+const REGIME_LABEL: Record<string, string> = {
+  simples_nacional: 'Simples Nacional',
+  lucro_presumido: 'Lucro Presumido',
+  lucro_real: 'Lucro Real',
+  mei: 'MEI',
+};
+
+export default function Config({ certificado, config }: ConfigProps) {
+  const certTone = certificado?.diasRestantes == null ? 'bad'
+    : certificado.diasRestantes <= 7 ? 'bad'
+    : certificado.diasRestantes <= 60 ? 'warn' : 'ok';
+
+  return (
+    <AppShellV2>
+      <Head title="Fiscal · Certificado & Configuração" />
+
+      <FxShell
+        route="fiscal_config"
+        title="Certificado & configuração"
+        crumb={certificado
+          ? `Cert A1 ${certificado.diasRestantes != null && certificado.diasRestantes > 0 ? `vence em ${certificado.diasRestantes}d` : 'EXPIRADO'}`
+          : 'Sem certificado ativo'}
+        env={certificado ? 'A1 ativo' : 'config pendente'}
+        envTone={certTone === 'bad' ? 'bad' : certTone === 'warn' ? 'warn' : 'ok'}
+        actions={
+          <a href="/nfe-brasil/configuracao/certificado" className="fx-btn primary">
+            <Edit3 size={12} /> Editar (NfeBrasil)
+          </a>
+        }
+      >
+        {/* Cert section */}
+        <section className="fx-drawer-sec" style={{ background: 'white', border: '1px solid var(--fx-border)', borderRadius: 10, padding: 18, marginBottom: 14 }}>
+          <h4>
+            <Shield size={13} style={{ marginRight: 6, verticalAlign: 'text-bottom' }} />
+            Certificado digital A1
+          </h4>
+          {certificado ? (
+            <dl className="fx-kv">
+              <dt>CNPJ titular</dt>
+              <dd>{certificado.cnpjTitular ?? '—'}</dd>
+              <dt>Validade</dt>
+              <dd>
+                <span className={`fx-sefaz ${certTone}`}>
+                  <span className="code">{certificado.validoAteBr ?? '—'}</span>
+                  <span className="lbl">
+                    {certificado.diasRestantes != null && certificado.diasRestantes > 0
+                      ? `${certificado.diasRestantes}d restantes`
+                      : 'EXPIRADO'}
+                  </span>
+                </span>
+              </dd>
+              <dt>Status</dt>
+              <dd>{certificado.ativo ? '✅ Ativo' : '🔒 Inativo'}</dd>
+              <dt>UUID</dt>
+              <dd className="fx-mono"><small>{certificado.uuid}</small></dd>
+            </dl>
+          ) : (
+            <div className="fx-empty" style={{ background: 'transparent', border: 'none', padding: '12px 0' }}>
+              <b>Nenhum certificado A1 ativo</b>
+              <small>Upload via /nfe-brasil/configuracao/certificado</small>
+            </div>
+          )}
+        </section>
+
+        {/* Config section */}
+        <section className="fx-drawer-sec" style={{ background: 'white', border: '1px solid var(--fx-border)', borderRadius: 10, padding: 18, marginBottom: 14 }}>
+          <h4>Regime tributário & emissão</h4>
+          {config ? (
+            <dl className="fx-kv">
+              <dt>Regime</dt>
+              <dd>{REGIME_LABEL[config.regime] ?? config.regime}</dd>
+              <dt>Emissão auto</dt>
+              <dd>{config.autoEmissionEnabled ? '✅ Habilitada (emite NFCe ao finalizar venda)' : '🔒 Manual (emite apenas via botão)'}</dd>
+              <dt>Tributação default</dt>
+              <dd>
+                {Object.keys(config.tributacaoDefault).length > 0
+                  ? <code className="fx-mono">{JSON.stringify(config.tributacaoDefault).slice(0, 200)}</code>
+                  : <small>nenhum default configurado</small>}
+              </dd>
+            </dl>
+          ) : (
+            <div className="fx-empty" style={{ background: 'transparent', border: 'none', padding: '12px 0' }}>
+              <b>Configuração não inicializada</b>
+              <small>Edite via /nfe-brasil/tributacao</small>
+            </div>
+          )}
+        </section>
+
+        <div className="fx-empty" style={{ background: 'var(--fx-bg-2)', border: 'none' }}>
+          <small>
+            Edição completa de certificado + tributação cascata em
+            {' '}<a href="/nfe-brasil/configuracao/certificado" className="fx-link">Configuração NfeBrasil</a>{' '}
+            (módulo emissor). Esta tela do Fiscal Cockpit mostra status read-only consolidado.
+          </small>
+        </div>
+      </FxShell>
+    </AppShellV2>
+  );
+}

--- a/resources/js/Pages/Fiscal/Dfe.charter.md
+++ b/resources/js/Pages/Fiscal/Dfe.charter.md
@@ -1,0 +1,39 @@
+---
+page_id: fiscal-dfe
+url: /fiscal/dfe
+module: Fiscal
+status: draft
+created: 2026-05-20
+owner: wagner
+related_adrs: [0093, 0094, 0101, 0104, 0116]
+prototypes:
+  - "prototipo-ui/.../fiscal-data.jsx DFE_PENDENTE/DFE_HISTORICO"
+---
+
+# Charter — `Fiscal/Dfe`
+
+## Mission
+
+Lista de NF-e emitidas **CONTRA o CNPJ Oimpresso** (manifesto destinatário SEFAZ), com filtros por status + pílula temporal do prazo legal 90d. Prepara terreno pra UI de ação manifestar em PR futuro.
+
+## Goals (DoD PR #3)
+
+1. Lista paginada `NfeDfeRecebido` via HasBusinessScope (ADR 0093)
+2. 5 chips status (pendentes/confirmadas/desconhecidas/não-realizadas/todas)
+3. Busca por chave 44d + CNPJ + nome emitente
+4. Pílula temporal de prazo (`prazo_confirmacao_em - now`) com 3 níveis urgência (crit <7d, warn <30d, ok)
+5. Permissão `fiscal.dfe.manage`
+6. Inertia::defer em rows
+
+## Non-Goals (PR #3)
+
+- ❌ Ações manifestar (Confirmar/Desconhecer/Não-realizada/Ciência) — UI prepara, mas dispatch real em PR #4 mutações
+- ❌ Drawer detalhe com itens da NF-e (NfeDfeItem) — só tabela flat
+- ❌ XML viewer da NF-e recebida
+- ❌ Bulk manifestar — backlog
+
+## Anti-hooks
+
+- 🚫 NfeDfeRecebido tem `HasBusinessScope` — não usar `withoutGlobalScopes`
+- 🚫 `nome_emitente` e `cnpj_emitente` SÃO PII de terceiros — exibidos OK (legalmente devemos saber quem emitiu contra nós), mas sem agregação em log
+- 🚫 Prazo 90d hard-coded — fonte de verdade é `prazo_confirmacao_em` no Model (calculado por SEFAZ)

--- a/resources/js/Pages/Fiscal/Dfe.tsx
+++ b/resources/js/Pages/Fiscal/Dfe.tsx
@@ -1,0 +1,176 @@
+// @memcofre
+//   tela: /fiscal/dfe
+//   module: Fiscal
+//   stories: US-FISCAL-008 (DF-e manifesto sub-página 4 do design KB-9.75)
+//   adrs: 0093, 0094, 0101, 0104
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { Deferred, Head, router } from '@inertiajs/react';
+import { FileSearch, ShieldAlert } from 'lucide-react';
+import { useState } from 'react';
+
+import FxShell from './_components/FxShell';
+import { brl, formatDoc, truncKey } from './_lib/fiscal-helpers';
+
+import '../../../css/fiscal-cockpit.css';
+
+type StatusManifestacao = 'pendente' | 'ciencia' | 'confirmada' | 'desconhecida' | 'nao_realizada';
+
+interface Filters {
+  status: 'pendentes' | 'confirmadas' | 'desconhecidas' | 'nao_realizadas' | 'todas';
+  search: string;
+}
+
+interface Counts {
+  total: number;
+  pendentes: number;
+  confirmadas: number;
+  desconhecidas: number;
+  naoRealizadas: number;
+  valorPendente: number;
+}
+
+interface DfeRow {
+  id: number;
+  chave: string;
+  nsu: string | null;
+  cnpjEmitente: string | null;
+  nomeEmitente: string;
+  valor: number;
+  numProtocolo: string | null;
+  dataEmissaoIso: string | null;
+  when: string | null;
+  statusManifestacao: StatusManifestacao;
+  manifestadoEmIso: string | null;
+  prazoDias: number | null;
+}
+
+interface DfeProps {
+  filters: Filters;
+  counts: Counts;
+  rows?: { data: DfeRow[]; meta: { total: number; current_page: number; last_page: number } };
+}
+
+const STATUS_META: Record<StatusManifestacao, { label: string; tone: 'ok' | 'warn' | 'bad' }> = {
+  pendente:      { label: 'Pendente',         tone: 'warn' },
+  ciencia:       { label: 'Ciência dada',     tone: 'warn' },
+  confirmada:    { label: 'Confirmada',       tone: 'ok' },
+  desconhecida:  { label: 'Desconhecida',     tone: 'bad' },
+  nao_realizada: { label: 'Não realizada',    tone: 'bad' },
+};
+
+export default function Dfe({ filters: initialFilters, counts, rows }: DfeProps) {
+  const [filters, setFilters] = useState<Filters>(initialFilters);
+  const dataRows = rows?.data ?? [];
+
+  const apply = (next: Partial<Filters>) => {
+    const merged = { ...filters, ...next };
+    setFilters(merged);
+    router.visit('/fiscal/dfe', {
+      data: merged as unknown as Record<string, string>,
+      only: ['rows', 'counts', 'filters'],
+      preserveState: true,
+      preserveScroll: true,
+    });
+  };
+
+  return (
+    <AppShellV2>
+      <Head title="Fiscal · DF-e" />
+
+      <FxShell
+        route="dfe"
+        title="Manifesto DF-e"
+        crumb={`${counts.pendentes} pendentes · ${brl(counts.valorPendente)} aguardando · prazo legal 90d`}
+        env={counts.pendentes > 0 ? `${counts.pendentes} aguardando` : 'tudo manifestado'}
+        envTone={counts.pendentes > 10 ? 'warn' : counts.pendentes > 0 ? 'ok' : 'ok'}
+      >
+        <div className="fx-filters">
+          <div className="fx-search">
+            <FileSearch size={13} />
+            <input
+              type="search"
+              placeholder="Buscar chave (44d), CNPJ ou nome emitente…"
+              value={filters.search}
+              onChange={(e) => setFilters((f) => ({ ...f, search: e.target.value }))}
+              onKeyDown={(e) => e.key === 'Enter' && apply({ search: filters.search })}
+            />
+          </div>
+          <button type="button" className={`fx-chip warn${filters.status === 'pendentes' ? ' active' : ''}`} onClick={() => apply({ status: 'pendentes' })}>
+            Pendentes <span>{counts.pendentes}</span>
+          </button>
+          <button type="button" className={`fx-chip${filters.status === 'confirmadas' ? ' active' : ''}`} onClick={() => apply({ status: 'confirmadas' })}>
+            Confirmadas <span>{counts.confirmadas}</span>
+          </button>
+          <button type="button" className={`fx-chip danger${filters.status === 'desconhecidas' ? ' active' : ''}`} onClick={() => apply({ status: 'desconhecidas' })}>
+            Desconhecidas <span>{counts.desconhecidas}</span>
+          </button>
+          <button type="button" className={`fx-chip danger${filters.status === 'nao_realizadas' ? ' active' : ''}`} onClick={() => apply({ status: 'nao_realizadas' })}>
+            Não realizadas <span>{counts.naoRealizadas}</span>
+          </button>
+          <button type="button" className={`fx-chip${filters.status === 'todas' ? ' active' : ''}`} onClick={() => apply({ status: 'todas' })}>
+            Todas <span>{counts.total}</span>
+          </button>
+        </div>
+
+        <Deferred data="rows" fallback={
+          <div className="fx-empty"><b>Carregando DF-e…</b><small>Busca em NfeDfeRecebido scoped</small></div>
+        }>
+          {dataRows.length === 0 ? (
+            <div className="fx-empty">
+              <ShieldAlert size={20} />
+              <b>Nenhuma DF-e encontrada</b>
+              <small>NF-e emitidas contra o CNPJ são captadas via NSU SEFAZ (job periódico).</small>
+            </div>
+          ) : (
+            <div className="fx-table">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Emitente</th>
+                    <th style={{ width: 220 }}>Chave</th>
+                    <th style={{ width: 140 }}>Status</th>
+                    <th style={{ width: 90, textAlign: 'center' }}>Prazo</th>
+                    <th style={{ width: 120, textAlign: 'right' }}>Valor</th>
+                    <th style={{ width: 96 }}>Emissão</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {dataRows.map((d) => {
+                    const stMeta = STATUS_META[d.statusManifestacao] ?? STATUS_META.pendente;
+                    const prazoUrgency = d.prazoDias == null ? 'ok'
+                      : d.prazoDias < 7 ? 'crit'
+                      : d.prazoDias < 30 ? 'warn' : 'ok';
+                    return (
+                      <tr key={d.id}>
+                        <td>
+                          <b>{d.nomeEmitente || '—'}</b>
+                          <small>{formatDoc(d.cnpjEmitente, null)}</small>
+                        </td>
+                        <td className="fx-mono"><small>{truncKey(d.chave)}</small></td>
+                        <td>
+                          <span className={`fx-sefaz ${stMeta.tone}`}>
+                            <span className="lbl">{stMeta.label}</span>
+                          </span>
+                        </td>
+                        <td style={{ textAlign: 'center' }}>
+                          {d.prazoDias != null && (
+                            <span className={`fx-timepill u-${prazoUrgency}`}>
+                              <b>{d.prazoDias > 0 ? `${d.prazoDias}d` : 'vencido'}</b>
+                            </span>
+                          )}
+                        </td>
+                        <td className="fx-mono fx-strong" style={{ textAlign: 'right' }}>{brl(d.valor)}</td>
+                        <td><small>{d.when ?? '—'}</small></td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </Deferred>
+      </FxShell>
+    </AppShellV2>
+  );
+}

--- a/resources/js/Pages/Fiscal/Sped.charter.md
+++ b/resources/js/Pages/Fiscal/Sped.charter.md
@@ -1,0 +1,38 @@
+---
+page_id: fiscal-sped
+url: /fiscal/sped
+module: Fiscal
+status: draft
+created: 2026-05-20
+owner: wagner
+related_adrs: [0093, 0094, 0101, 0104]
+prototypes:
+  - "prototipo-ui/.../fiscal-data.jsx SPED_PERIODOS/LIVROS"
+---
+
+# Charter — `Fiscal/Sped`
+
+## Mission
+
+**Placeholder no PR #3** — gerador SPED Fiscal (EFD ICMS/IPI + EFD-Contribuições) é integração complexa que merece PR dedicado. Esta tela apresenta panorama dos 5 últimos meses com contagens de notas autorizadas como referência cru, e botões de export desabilitados.
+
+## Goals (DoD PR #3)
+
+1. 5 últimos meses → contagem `NfeEmissao` autorizadas + valor
+2. Status estimado (mês atual = aberto · M-1 = pronto · M-2+ = entregue) — visual apenas
+3. Notice claro "em desenvolvimento"
+4. Permissão `fiscal.sped.export`
+5. Export buttons desabilitados (PR futuro)
+
+## Non-Goals (PR #3)
+
+- ❌ Gerador SPED real (TXT layout SPED Fiscal) — PR dedicado
+- ❌ EFD-Contribuições (PIS/COFINS) — PR dedicado
+- ❌ Livros fiscais (Apuração ICMS/ISS, Conciliação SEFAZ × ERP) — backlog
+- ❌ Workflow de validação contador → entrega SEFIN — backlog
+
+## Anti-hooks
+
+- 🚫 NÃO emitir SPED real até implementação canônica (formato CONFAZ é crítico — gerar TXT inválido pode causar penalidade fiscal)
+- 🚫 NÃO sugerir prazo de entrega via cron auto (legal/contador decide)
+- 🚫 Notice visual obrigatório — deixar claro que é placeholder

--- a/resources/js/Pages/Fiscal/Sped.tsx
+++ b/resources/js/Pages/Fiscal/Sped.tsx
@@ -1,0 +1,112 @@
+// @memcofre
+//   tela: /fiscal/sped
+//   module: Fiscal
+//   stories: US-FISCAL-010 (SPED & Livros sub-página 7 do design KB-9.75)
+//   adrs: 0093, 0094, 0101, 0104
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { Head } from '@inertiajs/react';
+import { Archive, Download } from 'lucide-react';
+
+import FxShell from './_components/FxShell';
+import { brl } from './_lib/fiscal-helpers';
+
+import '../../../css/fiscal-cockpit.css';
+
+interface Periodo {
+  mes: string;       // 05/2026
+  mesIso: string;    // 2026-05
+  notasAutorizadas: number;
+  valorAutorizado: number;
+  status: 'aberto' | 'pronto' | 'entregue';
+  prazoEntrega: string | null;
+}
+
+interface SpedProps {
+  periodos: Periodo[];
+  notice: string;
+}
+
+const STATUS_META: Record<Periodo['status'], { label: string; tone: 'ok' | 'warn' | 'bad' }> = {
+  aberto:   { label: 'Em curso',  tone: 'warn' },
+  pronto:   { label: 'Pronto',    tone: 'ok' },
+  entregue: { label: 'Entregue',  tone: 'ok' },
+};
+
+export default function Sped({ periodos, notice }: SpedProps) {
+  return (
+    <AppShellV2>
+      <Head title="Fiscal · SPED & Livros" />
+
+      <FxShell
+        route="sped"
+        title="SPED & Livros"
+        crumb="Apuração mensal · EFD ICMS-IPI · PIS/COFINS"
+        env="em desenvolvimento"
+        envTone="warn"
+      >
+        <div className="fx-empty" style={{
+          background: 'linear-gradient(135deg, var(--warn-soft), white)',
+          border: '1px solid var(--warn)',
+          textAlign: 'left',
+          padding: 18,
+          marginBottom: 18,
+        }}>
+          <b style={{ color: 'var(--warn)' }}>⚠️ Gerador SPED em desenvolvimento</b>
+          <p style={{ fontSize: 12 }}>{notice}</p>
+          <small>
+            Próxima entrega: SPED Fiscal EFD-Reinf + PIS/COFINS via Modules/NfeBrasil.
+            Acompanhe em <code className="fx-mono">memory/requisitos/NfeBrasil/SPEC.md</code> US futuras.
+          </small>
+        </div>
+
+        <div className="fx-table">
+          <table>
+            <thead>
+              <tr>
+                <th style={{ width: 110 }}>Competência</th>
+                <th style={{ width: 140 }}>Status</th>
+                <th style={{ textAlign: 'right' }}>Notas autorizadas</th>
+                <th style={{ textAlign: 'right', width: 160 }}>Valor autorizado</th>
+                <th style={{ width: 120 }}>Prazo entrega</th>
+                <th style={{ width: 80, textAlign: 'center' }}>Export</th>
+              </tr>
+            </thead>
+            <tbody>
+              {periodos.map((p) => {
+                const stMeta = STATUS_META[p.status];
+                return (
+                  <tr key={p.mesIso}>
+                    <td className="fx-mono fx-strong">{p.mes}</td>
+                    <td>
+                      <span className={`fx-sefaz ${stMeta.tone}`}>
+                        <span className="lbl">{stMeta.label}</span>
+                      </span>
+                    </td>
+                    <td className="fx-mono" style={{ textAlign: 'right' }}>{p.notasAutorizadas}</td>
+                    <td className="fx-mono fx-strong" style={{ textAlign: 'right' }}>{brl(p.valorAutorizado)}</td>
+                    <td><small>{p.prazoEntrega ?? '—'}</small></td>
+                    <td style={{ textAlign: 'center' }}>
+                      <button className="fx-btn ghost" disabled title="Gerador em desenvolvimento">
+                        <Download size={11} />
+                      </button>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="fx-empty" style={{ marginTop: 18 }}>
+          <Archive size={20} />
+          <b>Livros fiscais</b>
+          <small>
+            Apuração ICMS · Apuração ISS · Conciliação SEFAZ × ERP — em desenvolvimento.
+            Por enquanto, conferir manualmente via relatórios em /financeiro/relatorios.
+          </small>
+        </div>
+      </FxShell>
+    </AppShellV2>
+  );
+}

--- a/resources/js/Pages/Fiscal/_components/FxShell.tsx
+++ b/resources/js/Pages/Fiscal/_components/FxShell.tsx
@@ -20,10 +20,10 @@ const FX_PAGES: FxPage[] = [
   { id: 'fiscal',          label: 'Cockpit',        icon: <ShieldAlert size={13}/>, short: '1', url: '/fiscal' },
   { id: 'nfe',             label: 'NF-e · NFC-e',   icon: <Receipt size={13}/>,    short: '2', url: '/fiscal/nfe' },
   { id: 'nfse',            label: 'NFS-e',          icon: <FileText size={13}/>,   short: '3', url: '/fiscal/nfse' },
-  { id: 'dfe',             label: 'Manifesto DF-e', icon: <ShieldAlert size={13}/>,short: '4', url: '#' },
+  { id: 'dfe',             label: 'Manifesto DF-e', icon: <ShieldAlert size={13}/>,short: '4', url: '/fiscal/dfe' },
   { id: 'fiscal_eventos',  label: 'Eventos',        icon: <RefreshCw size={13}/>,  short: '5', url: '/fiscal/eventos' },
-  { id: 'fiscal_config',   label: 'Certif. & Cfg.', icon: <Shield size={13}/>,     short: '6', url: '#' },
-  { id: 'sped',            label: 'SPED & Livros',  icon: <Archive size={13}/>,    short: '7', url: '#' },
+  { id: 'fiscal_config',   label: 'Certif. & Cfg.', icon: <Shield size={13}/>,     short: '6', url: '/fiscal/config' },
+  { id: 'sped',            label: 'SPED & Livros',  icon: <Archive size={13}/>,    short: '7', url: '/fiscal/sped' },
 ];
 
 interface FxShellProps {


### PR DESCRIPTION
## Sumário

**PR final do roadmap visual** — Wave 3 entrega DF-e (sub-página 4) + Cert/Cfg (6) + SPED placeholder (7). Após merge: **as 7 sub-páginas do design Cowork ficam todas navegáveis** no FxShell.

| Sub-página | Rota | Permissão |
|---|---|---|
| Manifesto DF-e | `/fiscal/dfe` | `fiscal.dfe.manage` |
| Certif. & Cfg | `/fiscal/config` | `fiscal.config.edit` |
| SPED & Livros | `/fiscal/sped` | `fiscal.sped.export` |

PRs anteriores: #1183 mergeado (`8aef3d0fa` NF-e), #1185 mergeado (`cabd29661` Cockpit+NFS-e+Eventos).

## Backend (Modules/Fiscal/)

- **DfeController** — lista `NfeDfeRecebido` (HasBusinessScope ADR 0093) + 5 chips status + pílula prazo legal 90d (3 níveis urgência)
- **ConfigController** — status **read-only** de `NfeCertificado` (com `encrypted_password` $hidden 🔒) + `NfeBusinessConfig` (regime + tributação default). Link "Editar" → `/nfe-brasil/configuracao/certificado` canon
- **SpedController** — **placeholder consciente**: panorama 5 últimos meses com `NfeEmissao` autorizadas agregadas + notice "em desenvolvimento". Gerador SPED real (EFD ICMS-IPI + PIS/COFINS) backlog PR #6
- Routes: + 3 rotas

## Frontend (resources/js/Pages/Fiscal/)

- **Dfe.tsx** — tabela paginada + filtros + pílula temporal prazo (reaproveita `.fx-timepill u-{ok,warn,crit}`)
- **Config.tsx** — 2 seções (cert + config) read-only + link edição NfeBrasil
- **Sped.tsx** — notice warning + tabela períodos heurística (aberto/pronto/entregue) + Download disabled
- **FxShell** — 3 chips finalmente habilitados (#4 dfe, #6 config, #7 sped)
- **Cockpit** — 3 quick-link cards finais habilitados (removeu opacity disabled stubs)
- 3 `*.charter.md` (skill `charter-first` Tier A)

## Tests Pest (biz=1 — ADR 0101)

- `DfeControllerTest` — HasBusinessScope cross-tenant + 5 STATUS constants + `isPendenteManifestacao`
- `ConfigControllerTest` — `encrypted_password` $hidden NÃO vaza no `toArray()` + HasBusinessScope certs
- `SpedControllerTest` — agregação scoped + **anti-hook**: verifica que `exportSped` / `gerarEFD` NÃO existem (garante que placeholder não vira gerador real sem PR dedicado)

## Docs canon

- `SPEC.md` — US-FISCAL-008/009/010 ✅ + US-FISCAL-011 backlog SPED real + roadmap reorganizado
- `SCOPE.md` — +3 controllers em `contains[]` + roadmap "7 sub-páginas completas"
- 3 RUNBOOKs lean (`dfe/config/sped`) + 3 visual-comparison 8 dimensões (`status: approved`)

## Non-Goals (próximos PRs)

- ❌ Ações manifestar (Confirmar/Desconhecer/Não-realizada/Ciência) DF-e — PR #4 mutações
- ❌ Edição UI cert + tributação (vive em NfeBrasil canon)
- ❌ Gerador SPED real (TXT layout CONFAZ) — PR #6 dedicado
- ❌ Workflow validação contador → entrega SEFIN — backlog

## ADRs aplicadas

- 0093 multi-tenant Tier 0 IRREVOGÁVEL (3 Models via HasBusinessScope)
- 0101 tests biz=1
- 0104 MWART canônico
- 0114 Cowork loop

## Test plan

- [ ] CI 3 Pest novos passam
- [ ] Vite build inertia exit 0
- [ ] Smoke prod biz=1: `curl -sv /fiscal/dfe /fiscal/config /fiscal/sped` → 200
- [ ] Smoke negativo: 403 sem permission respectiva
- [ ] FxShell mostra todos 7 chips clicáveis (nenhum disabled)

## Tamanho

23 arquivos = **~1.335 inserções** (lean comparado a Wave 2 porque shared CSS/FxShell já estabelecidos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)