### PR TITLE
chore(vite): remove hostname stale oi.wr2.com.br + cravar canon hostnames

### DIFF
--- a/memory/reference/_INDEX.md
+++ b/memory/reference/_INDEX.md
@@ -45,6 +45,7 @@
 - [tests-pest-canon.md](tests-pest-canon.md) — workflow Modules Pest, YAML traps, SQLite guard, dual-mode SQLite/MySQL, Event::fake bridge listeners, setup worktree, PowerShell env vars inline
 - [deploy-recovery-patterns.md](deploy-recovery-patterns.md) — composer install obrigatório, quick-sync fallback SSH, tela branca Inertia, recovery tabela órfã DDL, §2.1 checklist "tela nova não aparece pós-merge" (caso 2026-05-14 PRs #838/#839)
 - [branch-protection-admin-merge.md](branch-protection-admin-merge.md) — check "ADR frontmatter" só roda se PR toca decisions/, admin merge legítimo
+- [sandbox-hostnames.md](sandbox-hostnames.md) — prod=`oimpresso.com`, sem sandbox separado; hostname stale `oi.wr2.com.br` removido do vite.config.js 2026-05-20 (correção Wagner)
 
 ## Legacy & migração
 

--- a/memory/reference/sandbox-hostnames.md
+++ b/memory/reference/sandbox-hostnames.md
@@ -1,0 +1,55 @@
+---
+name: sandbox-hostnames
+description: Hostnames canônicos do oimpresso — prod único, sem sandbox separado. Evita Claude/dev pegar hostname stale de config files.
+type: reference
+---
+
+# Hostnames canônicos oimpresso
+
+> **Última auditoria:** 2026-05-20 (sessão Wave 7-C Timeline FSM — Wagner corrigiu Claude afirmando "oi.wr2.com.br" como sandbox).
+
+## Ambientes ativos
+
+| Ambiente | URL | Onde roda | Como deploya |
+|---|---|---|---|
+| **Produção** | `https://oimpresso.com/` | Hostinger shared hosting | Workflow GHA `quick-sync.yml` (push to main → SSH rsync) |
+| **Dev local** | `https://localhost:5173/` (Vite) + `http://localhost:8000/` (artisan serve) | Máquina do dev | `npm run dev` + `php artisan serve` |
+| **CT 100 Proxmox** | endpoints internos (Centrifugo/FrankenPHP/Reverb) | Container Docker | compose-managed, ver [INFRA.md](../../INFRA.md) §6 + [proxmox-docker-host skill](../../.claude/skills/proxmox-docker-host) |
+| **MCP server** | `mcp.oimpresso.com` | Hostinger subdomain | webhook GitHub→MCP sync |
+
+## Ambientes DESCONTINUADOS (não usar)
+
+| URL stale | Substituído por | Onde ainda aparece |
+|---|---|---|
+| ~~`oi.wr2.com.br`~~ | `oimpresso.com` | [vite.config.js](../../vite.config.js) (corrigido 2026-05-20) — antes era hostname legado da era WR2 Sistemas |
+| ~~`oficinaimpresso.com.br`~~ | `oimpresso.com` | possíveis docs antigos — sempre prefira `oimpresso.com` |
+
+## Não existe sandbox/staging separado
+
+Diferente do que vite.config.js sugeria, **não há ambiente sandbox** entre dev local e prod. O fluxo é:
+
+```
+dev local (npm run dev + php artisan serve)
+   ↓  git push branch
+GitHub PR + CI (Pest + Visual Regression Pest 4 Browser + 14 gates)
+   ↓  merge main
+quick-sync.yml SSH rsync → Hostinger
+   ↓
+prod biz=1 (oimpresso.com)
+```
+
+Smoke real pós-merge **roda em prod biz=1** (skill `tela-smoke-pos-merge` Tier B, browser MCP read-only). Multi-tenant Tier 0 ([ADR 0093](../decisions/0093-multi-tenant-isolation-tier-0.md)) garante que biz=1 (Wagner) é isolado de biz=4 (Larissa) etc.
+
+## Como aplicar
+
+- **Antes de afirmar "sandbox" ou "staging":** consulte este doc. Não infira de config files.
+- **Ao mexer em hostname:** atualize aqui se ambiente novo aparecer.
+- **Smoke pós-merge:** sempre contra `https://oimpresso.com/` com `business_id=1`, nunca `wr2.com.br` ou variantes.
+
+## Refs
+
+- [memory/reference/deploy-recovery-patterns.md](deploy-recovery-patterns.md) — checklist "tela não aparece em prod pós-merge"
+- [memory/reference/checklist-pos-merge.md](checklist-pos-merge.md) — 8 passos pós-merge incluso smoke
+- [.github/workflows/quick-sync.yml](../../.github/workflows/quick-sync.yml) — workflow deploy SSH
+- [INFRA.md](../../INFRA.md) — Hostinger vs CT 100 separação ([ADR 0062](../decisions/0062-separacao-runtime-hostinger-ct100.md))
+- [memory/decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md](../decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md) — ZERO auto-mem privada (este doc vai pro git canon, time enxerga via MCP)

--- a/vite.config.js
+++ b/vite.config.js
@@ -30,14 +30,17 @@ export default defineConfig({
       '@public': '/public',
     },
   },
+  // Dev server: usado só localmente via `npm run dev` (HMR).
+  // Prod canon = `https://oimpresso.com/` (Hostinger, deploy via quick-sync.yml).
+  // Não há sandbox separado — ver memory/reference/sandbox-hostnames.md.
   server: {
-    allowedHosts: ['oi.wr2.com.br', 'localhost'],
+    allowedHosts: ['oimpresso.com', 'localhost'],
     host: true,
     port: 5173,
     https: true,
     hmr: {
       protocol: 'wss',
-      host: 'oi.wr2.com.br',
+      host: 'oimpresso.com',
       port: 5173,
     },
   },


### PR DESCRIPTION
## Summary

Wagner corrigiu (sessão Wave 7-C Timeline FSM 2026-05-20) que **`oi.wr2.com.br` não é mais usado**. Hostname legado da era WR2 Sistemas estava no [vite.config.js](vite.config.js) desde antes do rename pra `oimpresso.com`. Claude pegou dali como fonte canônica sem cruzar com `memory/reference/` — falha de protocolo (skill `mcp-first`).

Esta PR mata o ghost em 2 frentes:

- **[vite.config.js](vite.config.js)** — substitui `oi.wr2.com.br` → `oimpresso.com` em `allowedHosts` + `hmr.host`, com comentário apontando pro canon.
- **[memory/reference/sandbox-hostnames.md](memory/reference/sandbox-hostnames.md)** — doc canon novo:
  - prod = `oimpresso.com` (Hostinger, deploy via `quick-sync.yml`)
  - dev local = `localhost` (Vite + `artisan serve`)
  - CT 100 = endpoints internos Centrifugo/FrankenPHP/Reverb
  - MCP = `mcp.oimpresso.com`
  - **NÃO há sandbox/staging separado** — smoke pós-merge roda em prod biz=1
- **[memory/reference/_INDEX.md](memory/reference/_INDEX.md)** — pointer pro doc novo na seção Tests & deploy.

## Test plan

- [ ] `npm run dev` continua subindo Vite com HMR (host=`oimpresso.com` quando dev via Hostinger reverse proxy; `localhost` continua funcionando como antes pelo allowedHosts)
- [ ] CI gates passam (vite build, memory schema, charter, mwart, module grades)
- [ ] Diff visual = 0 (mudança só em config + docs)
- [ ] Próximo Claude/dev que olhar `oi.wr2.com.br` é redirecionado pro doc canon

## Refs

- [memory/reference/deploy-recovery-patterns.md](memory/reference/deploy-recovery-patterns.md) — fluxo canon SSH Hostinger
- [memory/decisions/0093-multi-tenant-isolation-tier-0.md](memory/decisions/0093-multi-tenant-isolation-tier-0.md) — biz=1 isolation
- [memory/decisions/0062-separacao-runtime-hostinger-ct100.md](memory/decisions/0062-separacao-runtime-hostinger-ct100.md) — Hostinger vs CT 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)
