### PR TITLE
hotfix(oficinaauto): tela branca Index.tsx — kpis undefined no Inertia::defer

### DIFF
--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
@@ -93,9 +93,18 @@ interface SchemaFlags {
 interface Props {
   orders: PaginatedOrders;
   filters: Filters;
-  kpis: Kpis;
+  // kpis vem via Inertia::defer (Wave 26 D6) — undefined no primeiro render.
+  // Default value no destructuring evita crash até segundo request chegar.
+  kpis?: Kpis;
   schemaFlags: SchemaFlags;
 }
+
+const EMPTY_KPIS: Kpis = {
+  locacoes_ativas: 0,
+  manutencao_ativas: 0,
+  concluidas_mes: 0,
+  atrasadas: 0,
+};
 
 // ──────── Helpers ────────
 const STATUS_PILLS: Array<{ key: string; label: string }> = [
@@ -140,7 +149,7 @@ function isOverdueClient(o: ServiceOrder, flags: SchemaFlags): boolean {
 }
 
 // ──────── Component ────────
-export default function ServiceOrdersIndex({ orders, filters, kpis, schemaFlags }: Props) {
+export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS, schemaFlags }: Props) {
   const [q, setQ] = useState(filters.q ?? '');
 
   // Drawer ServiceOrder state — clicar row abre OS no drawer (US-OFICINA-OS-DRAWER).


### PR DESCRIPTION
## 🚨 Hotfix prod — tela branca toda OficinaAuto

Detectado via smoke browser MCP pós-deploy Wave 7-C: `https://oimpresso.com/oficina-auto/ordens-servico` retorna tela branca com:

```
TypeError: Cannot read properties of undefined (reading 'locacoes_ativas')
  at Index-76lXwXMW.js:0:7362
```

## Causa raiz

- Backend [ServiceOrderController.php:189](Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php#L189) usa `Inertia::defer` pro payload `kpis` (Wave 26 D6) — chega num **segundo request HTTP**.
- Frontend [Index.tsx:96](resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx#L96) tipava `kpis: Kpis` (não-opcional) e acessava `kpis.locacoes_ativas` direto em 5 lugares.
- **Primeiro render**: `kpis = undefined` → crash imediato → tela branca em **toda** OficinaAuto/ServiceOrders.

## Fix mínimo

- `kpis?: Kpis` (opcional refletindo `Inertia::defer` real behavior).
- Default `EMPTY_KPIS` no destructuring → componentes renderizam com `0` até segundo request popular `kpis` (transparente pra UX).

## Test plan

- [ ] Após merge + quick-sync deploy, `https://oimpresso.com/oficina-auto/ordens-servico` carrega normalmente
- [ ] KPIs começam com 0 e populam quando defer chega
- [ ] Drawer abre normalmente → Timeline FSM (Wave 7-C PR #1195) renderiza histórico
- [ ] CI verde (Pest + Vite build)

## Refs

- memory/reference/deploy-recovery-patterns.md §2.1
- PRs #1195 (Wave 7-C) + #1196 (chore vite)

🤖 Generated with Claude Code
