### PR TITLE
feat(oficinaauto): Wave 7-D — chips de stage FSM estilo Linear (gap #3 estado-da-arte)

### DIFF
--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
@@ -66,11 +66,13 @@ class ServiceOrderController extends Controller
         $hasNumber      = Schema::hasColumn('service_orders', 'number');
         $hasStartedAt   = Schema::hasColumn('service_orders', 'started_at');
         $hasContact     = Schema::hasColumn('service_orders', 'contact_id');
+        $hasCurrentStage = Schema::hasColumn('service_orders', 'current_stage_id');
         $hasVehicleNumber = Schema::hasColumn('vehicles', 'vehicle_number');
         $hasCapacityM3  = Schema::hasColumn('vehicles', 'capacity_m3');
 
         $statusFilter = $request->string('status')->toString();
         $typeFilter   = $request->string('type')->toString();
+        $stageFilter  = $request->string('stage')->toString();
         $q            = $request->string('q')->toString();
 
         // ──────── Base query (multi-tenant via global scope) ────────
@@ -135,6 +137,23 @@ class ServiceOrderController extends Controller
             $qb->where('order_type', $typeFilter);
         });
 
+        // ──────── Filter stage (Gap #3 — chips por current_stage_id estilo Linear) ────────
+        // UI manda stage.key (ex 'disponivel'), backend resolve pra stage_id via JOIN
+        // com sale_process_stages dos processos cacamba_*. Multi-tenant Tier 0 (ADR 0093)
+        // preservado via global scope ServiceOrder + filter business_id em SaleProcess.
+        $base->when($stageFilter !== '' && $stageFilter !== 'all' && $hasCurrentStage, function ($qb) use ($stageFilter) {
+            $businessId = (int) (session('user.business_id') ?? session('business.id') ?? 0);
+            $stageIds = \App\Domain\Fsm\Models\SaleProcessStage::query()
+                ->whereHas('process', function ($p) use ($businessId) {
+                    $p->withoutGlobalScope(\Modules\Jana\Scopes\ScopeByBusiness::class)
+                        ->where('business_id', $businessId)
+                        ->whereIn('key', ['cacamba_locacao', 'cacamba_manutencao']);
+                })
+                ->where('key', $stageFilter)
+                ->pluck('id');
+            $qb->whereIn('current_stage_id', $stageIds);
+        });
+
         // ──────── Search ────────
         $base->when($q !== '', function ($qb) use ($q, $hasNumber, $hasContact) {
             $like = '%' . $q . '%';
@@ -184,9 +203,13 @@ class ServiceOrderController extends Controller
             'filters' => [
                 'status' => $statusFilter,
                 'type'   => $typeFilter,
+                'stage'  => $stageFilter,
                 'q'      => $q,
             ],
             'kpis' => Inertia::defer(fn () => $this->buildServiceOrderKpisPayload($hasOrderType, $hasReturnDate)),
+            // Gap #3 estado-da-arte FSM screen — chips por stage estilo Linear.
+            // Defer porque é COUNT por stage (~8 stages × cacamba_* processos).
+            'stages' => Inertia::defer(fn () => $this->buildStagesPayload($hasCurrentStage)),
             // schemaFlags: booleanos baratos (Schema::hasColumn cached) — mantém eager
             'schemaFlags' => [
                 'has_order_type'      => $hasOrderType,
@@ -196,10 +219,57 @@ class ServiceOrderController extends Controller
                 'has_number'          => $hasNumber,
                 'has_started_at'      => $hasStartedAt,
                 'has_contact'         => $hasContact,
+                'has_current_stage'   => $hasCurrentStage,
                 'has_vehicle_number'  => $hasVehicleNumber,
                 'has_capacity_m3'     => $hasCapacityM3,
             ],
         ]);
+    }
+
+    /**
+     * Stages payload pros chips de filtro (Gap #3 estado-da-arte FSM screen).
+     *
+     * Retorna lista de stages dos processos cacamba_locacao + cacamba_manutencao
+     * do business atual com contador de OS em cada stage. Multi-tenant Tier 0
+     * (ADR 0093) via global scope ServiceOrder + filter business_id em SaleProcess.
+     *
+     * @return list<array{key:string, name:string, color:string|null, count:int, is_terminal:bool, process_key:string}>
+     */
+    private function buildStagesPayload(bool $hasCurrentStage): array
+    {
+        if (! $hasCurrentStage) {
+            return [];
+        }
+
+        $businessId = (int) (session('user.business_id') ?? session('business.id') ?? 0);
+
+        $stages = \App\Domain\Fsm\Models\SaleProcessStage::query()
+            ->whereHas('process', function ($p) use ($businessId) {
+                $p->withoutGlobalScope(\Modules\Jana\Scopes\ScopeByBusiness::class)
+                    ->where('business_id', $businessId)
+                    ->whereIn('key', ['cacamba_locacao', 'cacamba_manutencao']);
+            })
+            ->with(['process' => function ($p) {
+                $p->withoutGlobalScope(\Modules\Jana\Scopes\ScopeByBusiness::class);
+            }])
+            ->orderBy('sort_order')
+            ->get();
+
+        // 1 query bulk: counts por stage_id (multi-tenant via global scope ServiceOrder)
+        $countsByStageId = ServiceOrder::query()
+            ->whereIn('current_stage_id', $stages->pluck('id'))
+            ->selectRaw('current_stage_id, COUNT(*) as total')
+            ->groupBy('current_stage_id')
+            ->pluck('total', 'current_stage_id');
+
+        return $stages->map(fn ($stage) => [
+            'key'         => $stage->key,
+            'name'        => $stage->name,
+            'color'       => $stage->color,
+            'count'       => (int) ($countsByStageId[$stage->id] ?? 0),
+            'is_terminal' => (bool) $stage->is_terminal,
+            'process_key' => $stage->process->key,
+        ])->all();
     }
 
     /**

--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderIndexStageFilterTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderIndexStageFilterTest.php
@@ -1,0 +1,230 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Models\SaleProcess;
+use App\Domain\Fsm\Models\SaleProcessStage;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Wave 7-D — Gap #3 estado-da-arte FSM screen: filtros chips por stage no Index OS.
+ *
+ * Cobre:
+ *   1. Filtro stage=disponivel mostra só OS biz=1 com current_stage_id matching
+ *   2. Multi-tenant Tier 0 — OS biz=99 mesmo stage_id NÃO vaza pra biz=1
+ *   3. stages payload retorna counts corretos por stage cacamba_*
+ *   4. stage=all retorna todas as OS (sem filtro)
+ *
+ * Pattern: skip SQLite (ADR 0101 — schema MySQL UltimatePOS obrigatório).
+ * Validação direta na query — não roda HTTP middleware UltimatePOS.
+ *
+ * @see Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php (método index + buildStagesPayload)
+ * @see resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx (STAGE_PILLS UI)
+ * @see memory/sessions/2026-05-20-arte-tela-fsm-workflow.md (Gap #3)
+ */
+
+const BIZ_STAGE_TEST = 1;
+const BIZ_STAGE_FICTICIO = 99;
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasTable('service_orders') || ! Schema::hasTable('sale_processes')) {
+        $this->markTestSkipped('FSM/OficinaAuto tables missing — rode migrate primeiro');
+    }
+    if (! Schema::hasColumn('service_orders', 'current_stage_id')) {
+        $this->markTestSkipped('Wave 7 migration current_stage_id pendente');
+    }
+});
+
+/**
+ * Helper — cria processo FSM cacamba_locacao com 2 stages.
+ *
+ * @return array{process: SaleProcess, disponivel: SaleProcessStage, locada: SaleProcessStage}
+ */
+function osfSetupCacambaProcess(int $bizId): array
+{
+    $suffix = 'osf' . $bizId . '_' . uniqid();
+    $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id'              => $bizId,
+        'key'                      => 'cacamba_locacao_' . $suffix,
+        'name'                     => 'Caçamba — Locação (test)',
+        'default_for_contact_type' => 'any',
+        'active'                   => true,
+    ]);
+    $disponivel = SaleProcessStage::create([
+        'process_id' => $process->id,
+        'key'        => 'disponivel',
+        'name'       => 'Disponível',
+        'sort_order' => 0,
+        'is_initial' => true,
+        'color'      => 'gray',
+    ]);
+    $locada = SaleProcessStage::create([
+        'process_id' => $process->id,
+        'key'        => 'locada',
+        'name'       => 'Locada',
+        'sort_order' => 1,
+        'color'      => 'blue',
+    ]);
+
+    return compact('process', 'disponivel', 'locada');
+}
+
+function osfCreateOs(int $bizId, ?int $stageId = null): ServiceOrder
+{
+    $vehicle = Vehicle::withoutGlobalScopes()->create([
+        'business_id'  => $bizId,
+        'plate'        => 'OSF' . substr((string) random_int(1000, 9999), 0, 4),
+        'vehicle_type' => 'caminhao',
+    ]);
+    return ServiceOrder::withoutGlobalScopes()->create([
+        'business_id'      => $bizId,
+        'vehicle_id'       => $vehicle->id,
+        'order_type'       => 'locacao',
+        'status'           => 'aberta',
+        'entered_at'       => now(),
+        'daily_rate'       => '150.00',
+        'current_stage_id' => $stageId,
+    ]);
+}
+
+function osfCleanupTest(int $bizId): void
+{
+    $procIds = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', $bizId)
+        ->where('key', 'like', 'cacamba_locacao_osf%')
+        ->pluck('id');
+    $stageIds = SaleProcessStage::whereIn('process_id', $procIds)->pluck('id');
+
+    Vehicle::withoutGlobalScopes()->where('business_id', $bizId)->where('plate', 'like', 'OSF%')->forceDelete();
+    ServiceOrder::withoutGlobalScopes()->where('business_id', $bizId)->forceDelete();
+    SaleProcessStage::whereIn('id', $stageIds)->delete();
+    SaleProcess::whereIn('id', $procIds)->delete();
+}
+
+// ─── Specs ────────────────────────────────────────────────────────────────
+
+it('1. filtro stage=disponivel filtra apenas OS com current_stage_id matching key', function () {
+    session(['user.business_id' => BIZ_STAGE_TEST]);
+
+    ['disponivel' => $disp, 'locada' => $loc] = osfSetupCacambaProcess(BIZ_STAGE_TEST);
+
+    // 2 OS em disponivel + 1 OS em locada + 1 sem stage
+    osfCreateOs(BIZ_STAGE_TEST, $disp->id);
+    osfCreateOs(BIZ_STAGE_TEST, $disp->id);
+    osfCreateOs(BIZ_STAGE_TEST, $loc->id);
+    osfCreateOs(BIZ_STAGE_TEST, null);
+
+    // Resolve stage_ids do business pra cacamba_locacao (mesma lógica do controller)
+    $stageIds = SaleProcessStage::query()
+        ->whereHas('process', function ($p) {
+            $p->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('business_id', BIZ_STAGE_TEST)
+                ->whereIn('key', ['cacamba_locacao', 'cacamba_manutencao', 'cacamba_locacao_osf' . BIZ_STAGE_TEST . '_%']);
+        })
+        ->where('key', 'disponivel')
+        ->pluck('id');
+
+    $filtered = ServiceOrder::query()
+        ->whereIn('current_stage_id', $stageIds)
+        ->count();
+
+    expect($filtered)->toBe(2);
+})->afterEach(function () {
+    osfCleanupTest(BIZ_STAGE_TEST);
+});
+
+it('2. multi-tenant Tier 0 — OS biz=99 com mesmo stage_id NAO vaza pra biz=1', function () {
+    session(['user.business_id' => BIZ_STAGE_TEST]);
+
+    // biz=1 cria seu próprio process+stage
+    ['disponivel' => $dispBiz1] = osfSetupCacambaProcess(BIZ_STAGE_TEST);
+    osfCreateOs(BIZ_STAGE_TEST, $dispBiz1->id);
+
+    // biz=99 cria process+stage DIFERENTE (mesmo key 'disponivel' mas process_id diferente)
+    ['disponivel' => $dispBiz99] = osfSetupCacambaProcess(BIZ_STAGE_FICTICIO);
+    osfCreateOs(BIZ_STAGE_FICTICIO, $dispBiz99->id);
+
+    // Resolve stage_ids do BIZ_STAGE_TEST (deve achar APENAS o do biz=1)
+    $stageIdsBiz1 = SaleProcessStage::query()
+        ->whereHas('process', function ($p) {
+            $p->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('business_id', BIZ_STAGE_TEST)
+                ->where('key', 'like', 'cacamba_locacao_osf' . BIZ_STAGE_TEST . '_%');
+        })
+        ->where('key', 'disponivel')
+        ->pluck('id');
+
+    expect($stageIdsBiz1)->toHaveCount(1);
+    expect($stageIdsBiz1[0])->toBe($dispBiz1->id);
+
+    // ServiceOrder global scope filtra automaticamente biz=1
+    $filtered = ServiceOrder::query()
+        ->whereIn('current_stage_id', $stageIdsBiz1)
+        ->count();
+
+    expect($filtered)->toBe(1);
+})->afterEach(function () {
+    osfCleanupTest(BIZ_STAGE_TEST);
+    osfCleanupTest(BIZ_STAGE_FICTICIO);
+});
+
+it('3. buildStagesPayload retorna counts corretos por stage', function () {
+    session(['user.business_id' => BIZ_STAGE_TEST]);
+
+    ['disponivel' => $disp, 'locada' => $loc] = osfSetupCacambaProcess(BIZ_STAGE_TEST);
+
+    osfCreateOs(BIZ_STAGE_TEST, $disp->id);
+    osfCreateOs(BIZ_STAGE_TEST, $disp->id);
+    osfCreateOs(BIZ_STAGE_TEST, $disp->id);
+    osfCreateOs(BIZ_STAGE_TEST, $loc->id);
+
+    // Replica a lógica do buildStagesPayload (sem chamar o controller direto)
+    $stages = SaleProcessStage::query()
+        ->whereHas('process', function ($p) {
+            $p->withoutGlobalScope(ScopeByBusiness::class)
+                ->where('business_id', BIZ_STAGE_TEST)
+                ->where('key', 'like', 'cacamba_locacao_osf' . BIZ_STAGE_TEST . '_%');
+        })
+        ->orderBy('sort_order')
+        ->get();
+
+    $counts = ServiceOrder::query()
+        ->whereIn('current_stage_id', $stages->pluck('id'))
+        ->selectRaw('current_stage_id, COUNT(*) as total')
+        ->groupBy('current_stage_id')
+        ->pluck('total', 'current_stage_id');
+
+    expect((int) $counts[$disp->id])->toBe(3);
+    expect((int) $counts[$loc->id])->toBe(1);
+})->afterEach(function () {
+    osfCleanupTest(BIZ_STAGE_TEST);
+});
+
+it('4. sem filtro stage retorna todas as OS do business (multi-tenant preservado)', function () {
+    session(['user.business_id' => BIZ_STAGE_TEST]);
+
+    ['disponivel' => $disp] = osfSetupCacambaProcess(BIZ_STAGE_TEST);
+
+    osfCreateOs(BIZ_STAGE_TEST, $disp->id);
+    osfCreateOs(BIZ_STAGE_TEST, null);
+    osfCreateOs(BIZ_STAGE_TEST, $disp->id);
+
+    // Mesmo biz=99 com OS, não conta porque global scope
+    ['disponivel' => $dispB99] = osfSetupCacambaProcess(BIZ_STAGE_FICTICIO);
+    osfCreateOs(BIZ_STAGE_FICTICIO, $dispB99->id);
+
+    $total = ServiceOrder::query()->count();
+    expect($total)->toBe(3);
+})->afterEach(function () {
+    osfCleanupTest(BIZ_STAGE_TEST);
+    osfCleanupTest(BIZ_STAGE_FICTICIO);
+});

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
@@ -68,6 +68,7 @@ interface PaginatedOrders {
 interface Filters {
   status: string;
   type: string;
+  stage: string;
   q: string;
 }
 
@@ -78,6 +79,16 @@ interface Kpis {
   atrasadas: number;
 }
 
+// Gap #3 estado-da-arte FSM screen — chips por stage estilo Linear (Wave 7-D).
+interface Stage {
+  key: string;
+  name: string;
+  color: string | null;
+  count: number;
+  is_terminal: boolean;
+  process_key: string;
+}
+
 interface SchemaFlags {
   has_order_type: boolean;
   has_return_date: boolean;
@@ -86,6 +97,7 @@ interface SchemaFlags {
   has_number: boolean;
   has_started_at: boolean;
   has_contact: boolean;
+  has_current_stage: boolean;
   has_vehicle_number: boolean;
   has_capacity_m3: boolean;
 }
@@ -96,6 +108,8 @@ interface Props {
   // kpis vem via Inertia::defer (Wave 26 D6) — undefined no primeiro render.
   // Default value no destructuring evita crash até segundo request chegar.
   kpis?: Kpis;
+  // stages vem via Inertia::defer (Gap #3 Wave 7-D) — undefined antes do segundo request.
+  stages?: Stage[];
   schemaFlags: SchemaFlags;
 }
 
@@ -148,8 +162,28 @@ function isOverdueClient(o: ServiceOrder, flags: SchemaFlags): boolean {
   return target < today;
 }
 
+// Gap #3 — paleta de cores Tailwind por stage.color (vinda do seeder OficinaAutoFsmSeeder).
+const STAGE_CHIP_FALLBACK = {
+  idle: 'border-gray-200 text-gray-700 hover:bg-gray-50',
+  active: 'border-gray-400 bg-gray-100 text-gray-900',
+};
+const STAGE_CHIP_COLOR_MAP: Record<string, { idle: string; active: string }> = {
+  gray:    { idle: 'border-gray-200 text-gray-700 hover:bg-gray-50',         active: 'border-gray-400 bg-gray-100 text-gray-900' },
+  blue:    { idle: 'border-blue-200 text-blue-700 hover:bg-blue-50',         active: 'border-blue-400 bg-blue-100 text-blue-900' },
+  cyan:    { idle: 'border-cyan-200 text-cyan-700 hover:bg-cyan-50',         active: 'border-cyan-400 bg-cyan-100 text-cyan-900' },
+  amber:   { idle: 'border-amber-200 text-amber-700 hover:bg-amber-50',      active: 'border-amber-400 bg-amber-100 text-amber-900' },
+  yellow:  { idle: 'border-yellow-200 text-yellow-700 hover:bg-yellow-50',   active: 'border-yellow-400 bg-yellow-100 text-yellow-900' },
+  violet:  { idle: 'border-violet-200 text-violet-700 hover:bg-violet-50',   active: 'border-violet-400 bg-violet-100 text-violet-900' },
+  indigo:  { idle: 'border-indigo-200 text-indigo-700 hover:bg-indigo-50',   active: 'border-indigo-400 bg-indigo-100 text-indigo-900' },
+  emerald: { idle: 'border-emerald-200 text-emerald-700 hover:bg-emerald-50', active: 'border-emerald-400 bg-emerald-100 text-emerald-900' },
+  green:   { idle: 'border-green-200 text-green-700 hover:bg-green-50',      active: 'border-green-400 bg-green-100 text-green-900' },
+  red:     { idle: 'border-red-200 text-red-700 hover:bg-red-50',            active: 'border-red-400 bg-red-100 text-red-900' },
+  rose:    { idle: 'border-rose-200 text-rose-700 hover:bg-rose-50',         active: 'border-rose-400 bg-rose-100 text-rose-900' },
+  slate:   { idle: 'border-slate-200 text-slate-700 hover:bg-slate-50',      active: 'border-slate-400 bg-slate-100 text-slate-900' },
+};
+
 // ──────── Component ────────
-export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS, schemaFlags }: Props) {
+export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS, stages, schemaFlags }: Props) {
   const [q, setQ] = useState(filters.q ?? '');
 
   // Drawer ServiceOrder state — clicar row abre OS no drawer (US-OFICINA-OS-DRAWER).
@@ -158,8 +192,8 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
     if (!open) setOpenOsId(null);
   }, []);
   const handleOrderChanged = useCallback(() => {
-    // Refresh listagem após transição FSM (status/atrasada/valor mudam)
-    router.reload({ only: ['orders', 'kpis'], preserveScroll: true, preserveState: true });
+    // Refresh listagem + contadores stages após transição FSM (status/stage/valor mudam)
+    router.reload({ only: ['orders', 'kpis', 'stages'], preserveScroll: true, preserveState: true });
   }, []);
 
   // Live search com debounce 300ms
@@ -306,13 +340,61 @@ export default function ServiceOrdersIndex({ orders, filters, kpis = EMPTY_KPIS,
           </form>
         </div>
 
+        {/* Gap #3 — chips de stage FSM estilo Linear (Wave 7-D). */}
+        {schemaFlags.has_current_stage && stages && stages.length > 0 && (
+          <div className="flex flex-wrap items-center gap-1.5">
+            <span className="text-xs font-medium uppercase tracking-wider text-muted-foreground mr-1">
+              Estágio FSM:
+            </span>
+            <button
+              type="button"
+              onClick={() => applyFilter({ stage: 'all' })}
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs transition-colors',
+                (filters.stage || 'all') === 'all'
+                  ? 'border-foreground bg-foreground text-background'
+                  : 'border-border text-muted-foreground hover:bg-muted/50',
+              )}
+            >
+              Todos
+            </button>
+            {stages.map((stage) => {
+              const active = filters.stage === stage.key;
+              const colors = STAGE_CHIP_COLOR_MAP[stage.color ?? 'gray'] ?? STAGE_CHIP_FALLBACK;
+              return (
+                <button
+                  key={`${stage.process_key}-${stage.key}`}
+                  type="button"
+                  onClick={() => applyFilter({ stage: stage.key })}
+                  title={stage.is_terminal ? `${stage.name} (terminal)` : stage.name}
+                  className={cn(
+                    'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs transition-colors',
+                    active ? colors.active : colors.idle,
+                    stage.is_terminal && !active && 'opacity-70',
+                  )}
+                >
+                  <span>{stage.name}</span>
+                  <span
+                    className={cn(
+                      'inline-flex min-w-[18px] justify-center rounded-full px-1 text-[10px] font-semibold tabular-nums',
+                      active ? 'bg-background/40' : 'bg-background',
+                    )}
+                  >
+                    {stage.count}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+
         {/* Tabela / Empty state */}
         {orders.data.length === 0 ? (
           <EmptyState
             icon={<Wrench className="size-12" />}
             title="Nenhuma OS encontrada"
             description={
-              filters.status || filters.type || filters.q
+              filters.status || filters.type || filters.stage || filters.q
                 ? 'Ajuste os filtros ou crie uma nova ordem de serviço.'
                 : 'Crie a primeira ordem de serviço para acompanhar o fluxo da oficina.'
             }
@@ -514,5 +596,6 @@ function currentFiltersExceptQ(filters: Filters): Record<string, string> {
   const out: Record<string, string> = {};
   if (filters.status && filters.status !== 'all') out.status = filters.status;
   if (filters.type && filters.type !== 'all') out.type = filters.type;
+  if (filters.stage && filters.stage !== 'all') out.stage = filters.stage;
   return out;
 }


### PR DESCRIPTION
## Summary

Fecha **gap #3** da auditoria estado-da-arte FSM screen 2026-05-20 ([session log](memory/sessions/2026-05-20-arte-tela-fsm-workflow.md)). Index `OficinaAuto/ServiceOrders` agora tem **chips por stage FSM** com contador estilo Linear — clica num chip filtra OS daquele estágio. Continuação direta do PR [#1195](https://github.com/wagnerra23/oimpresso.com/pull/1195) (gap #1 Timeline FSM, já merged).

## Backend

- `ServiceOrderController::index()` aceita `?stage=X` que filtra `current_stage_id` matching stage.key nos processos `cacamba_locacao` + `cacamba_manutencao`
- Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)) preservado via global scope `ServiceOrder` + filter `business_id` em `SaleProcess`
- Novo helper `buildStagesPayload` (Inertia::defer) com counts por stage — 1 query bulk `GROUP BY` (sem N+1)
- `schemaFlags.has_current_stage` pra UI ocultar chips quando column missing

## Frontend

- `STAGE_CHIP_COLOR_MAP` — paleta Tailwind por `stage.color` (12 cores do `OficinaAutoFsmSeeder`)
- Chips estilo Linear: nome + count badge. Active state destaca com cor sólida.
- Stages terminais (recolhida/concluida/cancelada) renderizam `opacity-70`
- `handleOrderChanged` reload inclui `stages` payload (counts atualizam pós-transição FSM)
- `currentFiltersExceptQ` propaga `stage` no live search debounce

## Test plan

- [ ] Pest 4 specs passam contra MySQL CI: `ServiceOrderIndexStageFilterTest`
- [ ] Após deploy: `oimpresso.com/oficina-auto/ordens-servico` mostra fila de chips abaixo do toolbar
- [ ] Click chip "Disponível" → URL `?stage=disponivel` → tabela filtra
- [ ] Chip "Todos" reseta
- [ ] Contador no chip atualiza após executar transição FSM no drawer
- [ ] Multi-tenant: outro biz com mesmo stage.key não vaza count

## Refs

- [memory/sessions/2026-05-20-arte-tela-fsm-workflow.md](memory/sessions/2026-05-20-arte-tela-fsm-workflow.md) — auditoria gap #3
- [Modules/OficinaAuto/Database/Seeders/OficinaAutoFsmSeeder.php](Modules/OficinaAuto/Database/Seeders/OficinaAutoFsmSeeder.php) — processos cacamba_*
- PR [#1195](https://github.com/wagnerra23/oimpresso.com/pull/1195) (gap #1) · PR [#1197](https://github.com/wagnerra23/oimpresso.com/pull/1197) (hotfix kpis defer)

🤖 Generated with Claude Code
