### PR TITLE
feat(oficinaauto): Wave 7-E — mini-grafo horizontal stages (gap #2 estado-da-arte)

### DIFF
--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderStagePipelineTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderStagePipelineTest.php
@@ -1,0 +1,208 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Domain\Fsm\Models\SaleProcess;
+use App\Domain\Fsm\Models\SaleProcessStage;
+use App\Http\Controllers\ServiceOrderFsmActionController;
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Gate;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Wave 7-E — Gap #2 estado-da-arte FSM screen: mini-grafo horizontal stages no drawer.
+ *
+ * Cobre:
+ *   1. actions() retorna stages_pipeline com lista ordenada por sort_order
+ *   2. Stage current marcado is_current=true; outros false
+ *   3. Multi-tenant Tier 0 — stages do process biz=99 NAO aparecem em request biz=1
+ *   4. Empty: OS sem current_stage_id retorna stages_pipeline vazio (in_pipeline=false)
+ *
+ * Pattern: skip SQLite (ADR 0101).
+ *
+ * @see app/Http/Controllers/ServiceOrderFsmActionController.php (método actions com stages_pipeline)
+ * @see resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderStagePipeline.tsx
+ * @see memory/sessions/2026-05-20-arte-tela-fsm-workflow.md (Gap #2)
+ */
+
+const BIZ_PIPELINE_TEST = 1;
+const BIZ_PIPELINE_FICTICIO = 99;
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasTable('service_orders') || ! Schema::hasTable('sale_processes')) {
+        $this->markTestSkipped('FSM/OficinaAuto tables missing');
+    }
+    if (! Schema::hasColumn('service_orders', 'current_stage_id')) {
+        $this->markTestSkipped('Wave 7 migration current_stage_id pendente');
+    }
+
+    // Auth stub
+    $user = new User();
+    $user->id = 1;
+    $user->username = 'pipeline-test-user';
+    $user->business_id = BIZ_PIPELINE_TEST;
+    $user->exists = true;
+    $this->actingAs($user);
+    Gate::before(fn () => true);
+});
+
+/**
+ * @return array{process: SaleProcess, stages: array<string, SaleProcessStage>}
+ */
+function ospSetupProcess(int $bizId): array
+{
+    $suffix = 'osp' . $bizId . '_' . uniqid();
+    $process = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)->create([
+        'business_id'              => $bizId,
+        'key'                      => 'cacamba_locacao_' . $suffix,
+        'name'                     => 'Caçamba — Locação (test)',
+        'default_for_contact_type' => 'any',
+        'active'                   => true,
+    ]);
+    $stages = [
+        'disponivel' => SaleProcessStage::create([
+            'process_id' => $process->id, 'key' => 'disponivel', 'name' => 'Disponível',
+            'sort_order' => 0, 'is_initial' => true, 'color' => 'gray',
+        ]),
+        'locada' => SaleProcessStage::create([
+            'process_id' => $process->id, 'key' => 'locada', 'name' => 'Locada',
+            'sort_order' => 1, 'color' => 'blue',
+        ]),
+        'recolhida' => SaleProcessStage::create([
+            'process_id' => $process->id, 'key' => 'recolhida', 'name' => 'Recolhida',
+            'sort_order' => 2, 'is_terminal' => true, 'color' => 'emerald',
+        ]),
+        'manutencao' => SaleProcessStage::create([
+            'process_id' => $process->id, 'key' => 'manutencao', 'name' => 'Em manutenção',
+            'sort_order' => 3, 'color' => 'yellow',
+        ]),
+    ];
+
+    return ['process' => $process, 'stages' => $stages];
+}
+
+function ospCreateOs(int $bizId, ?int $stageId = null): ServiceOrder
+{
+    $vehicle = Vehicle::withoutGlobalScopes()->create([
+        'business_id'  => $bizId,
+        'plate'        => 'OSP' . substr((string) random_int(1000, 9999), 0, 4),
+        'vehicle_type' => 'caminhao',
+    ]);
+    return ServiceOrder::withoutGlobalScopes()->create([
+        'business_id'      => $bizId,
+        'vehicle_id'       => $vehicle->id,
+        'order_type'       => 'locacao',
+        'status'           => 'aberta',
+        'entered_at'       => now(),
+        'current_stage_id' => $stageId,
+    ]);
+}
+
+function ospCleanup(int $bizId): void
+{
+    $procIds = SaleProcess::withoutGlobalScope(ScopeByBusiness::class)
+        ->where('business_id', $bizId)
+        ->where('key', 'like', 'cacamba_locacao_osp%')
+        ->pluck('id');
+    $stageIds = SaleProcessStage::whereIn('process_id', $procIds)->pluck('id');
+
+    Vehicle::withoutGlobalScopes()->where('business_id', $bizId)->where('plate', 'like', 'OSP%')->forceDelete();
+    ServiceOrder::withoutGlobalScopes()->where('business_id', $bizId)->forceDelete();
+    SaleProcessStage::whereIn('id', $stageIds)->delete();
+    SaleProcess::whereIn('id', $procIds)->delete();
+}
+
+// ─── Specs ────────────────────────────────────────────────────────────────
+
+it('1. actions retorna stages_pipeline ordenado por sort_order', function () {
+    session(['user.business_id' => BIZ_PIPELINE_TEST]);
+
+    ['stages' => $stages] = ospSetupProcess(BIZ_PIPELINE_TEST);
+    $os = ospCreateOs(BIZ_PIPELINE_TEST, $stages['locada']->id);
+
+    $controller = app(ServiceOrderFsmActionController::class);
+    $response = $controller->actions($os);
+    $payload = $response->getData(true);
+
+    expect($payload['in_pipeline'])->toBeTrue();
+    expect($payload['stages_pipeline'])->toHaveCount(4);
+    expect($payload['stages_pipeline'][0]['key'])->toBe('disponivel');
+    expect($payload['stages_pipeline'][1]['key'])->toBe('locada');
+    expect($payload['stages_pipeline'][2]['key'])->toBe('recolhida');
+    expect($payload['stages_pipeline'][3]['key'])->toBe('manutencao');
+})->afterEach(function () {
+    ospCleanup(BIZ_PIPELINE_TEST);
+});
+
+it('2. is_current=true apenas no stage atual', function () {
+    session(['user.business_id' => BIZ_PIPELINE_TEST]);
+
+    ['stages' => $stages] = ospSetupProcess(BIZ_PIPELINE_TEST);
+    $os = ospCreateOs(BIZ_PIPELINE_TEST, $stages['locada']->id);
+
+    $controller = app(ServiceOrderFsmActionController::class);
+    $payload = $controller->actions($os)->getData(true);
+
+    $currents = array_filter($payload['stages_pipeline'], fn ($s) => $s['is_current'] === true);
+    expect($currents)->toHaveCount(1);
+    expect(array_values($currents)[0]['key'])->toBe('locada');
+})->afterEach(function () {
+    ospCleanup(BIZ_PIPELINE_TEST);
+});
+
+it('3. multi-tenant Tier 0 — biz=99 process nao vaza stages pra biz=1 OS', function () {
+    session(['user.business_id' => BIZ_PIPELINE_TEST]);
+
+    // biz=1 cria process e OS no stage locada
+    ['stages' => $stagesB1] = ospSetupProcess(BIZ_PIPELINE_TEST);
+    $os = ospCreateOs(BIZ_PIPELINE_TEST, $stagesB1['locada']->id);
+
+    // biz=99 cria SEU próprio process — não deve aparecer no stages_pipeline da OS biz=1
+    ['stages' => $stagesB99] = ospSetupProcess(BIZ_PIPELINE_FICTICIO);
+
+    $controller = app(ServiceOrderFsmActionController::class);
+    $payload = $controller->actions($os)->getData(true);
+
+    expect($payload['stages_pipeline'])->toHaveCount(4); // só os 4 stages do process biz=1
+    $stageIds = array_column($payload['stages_pipeline'], 'key');
+    expect($stageIds)->toBe(['disponivel', 'locada', 'recolhida', 'manutencao']);
+
+    // Garantia extra: NENHUM stage do biz=99 aparece no payload (process_id diferente)
+    $biz99StageIds = collect($stagesB99)->pluck('id')->all();
+    foreach ($payload['stages_pipeline'] as $s) {
+        // Não vamos comparar IDs — payload não retorna id, só key.
+        // Aqui validamos que o process foi o do biz=1: cada stage do payload
+        // existe no array biz1 stages.
+        $matches = collect($stagesB1)->contains(fn ($stage) => $stage->key === $s['key']);
+        expect($matches)->toBeTrue();
+    }
+})->afterEach(function () {
+    ospCleanup(BIZ_PIPELINE_TEST);
+    ospCleanup(BIZ_PIPELINE_FICTICIO);
+});
+
+it('4. OS sem current_stage_id retorna in_pipeline=false e nao popula stages_pipeline', function () {
+    session(['user.business_id' => BIZ_PIPELINE_TEST]);
+
+    ospSetupProcess(BIZ_PIPELINE_TEST);
+    $os = ospCreateOs(BIZ_PIPELINE_TEST, null);
+
+    $controller = app(ServiceOrderFsmActionController::class);
+    $payload = $controller->actions($os)->getData(true);
+
+    expect($payload['in_pipeline'])->toBeFalse();
+    expect($payload['current_stage'])->toBeNull();
+    // stages_pipeline ausente OU vazio quando out-of-pipeline
+    expect($payload['stages_pipeline'] ?? [])->toBeArray()->toBeEmpty();
+})->afterEach(function () {
+    ospCleanup(BIZ_PIPELINE_TEST);
+});

--- a/app/Http/Controllers/ServiceOrderFsmActionController.php
+++ b/app/Http/Controllers/ServiceOrderFsmActionController.php
@@ -109,6 +109,26 @@ class ServiceOrderFsmActionController extends Controller
             ];
         });
 
+        // Gap #2 estado-da-arte FSM screen (Wave 7-E) — pipeline horizontal "você está aqui".
+        // Lista ordenada de todos stages do processo da OS pra renderizar mini-grafo no drawer.
+        // Multi-tenant Tier 0 (ADR 0093) via currentStage.process.business_id.
+        $stagesPipeline = collect();
+        if ($currentStage && $currentStage->process_id) {
+            $stagesPipeline = SaleProcessStage::query()
+                ->where('process_id', $currentStage->process_id)
+                ->orderBy('sort_order')
+                ->get(['id', 'key', 'name', 'color', 'sort_order', 'is_initial', 'is_terminal'])
+                ->map(fn ($s) => [
+                    'key'         => $s->key,
+                    'name'        => $s->name,
+                    'color'       => $s->color,
+                    'sort_order'  => (int) $s->sort_order,
+                    'is_initial'  => (bool) $s->is_initial,
+                    'is_terminal' => (bool) $s->is_terminal,
+                    'is_current'  => $s->id === $currentStageId,
+                ]);
+        }
+
         return response()->json([
             'service_order_id' => $order->id,
             'process_key'      => $processKey,
@@ -118,8 +138,9 @@ class ServiceOrderFsmActionController extends Controller
                 'color' => $currentStage?->color,
                 'is_terminal' => (bool) $currentStage?->is_terminal,
             ],
-            'actions'     => $payload,
-            'in_pipeline' => true,
+            'stages_pipeline' => $stagesPipeline,
+            'actions'         => $payload,
+            'in_pipeline'     => true,
         ]);
     }
 

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderSheet.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderSheet.tsx
@@ -32,6 +32,7 @@ import {
 } from '@/Components/ui/sheet';
 import { Button } from '@/Components/ui/button';
 import ServiceOrderFsmActionPanel from './ServiceOrderFsmActionPanel';
+import ServiceOrderStagePipeline from './ServiceOrderStagePipeline';
 import ServiceOrderTimeline from './ServiceOrderTimeline';
 
 type OrderType = 'locacao' | 'manutencao' | null;
@@ -338,8 +339,17 @@ export default function ServiceOrderSheet({
                 </Section>
               )}
 
-              {/* Pipeline FSM — ações disponíveis (Wave 7-A backend) */}
-              <Section title="Pipeline FSM" icon={CheckCircle2}>
+              {/* Mini-grafo horizontal stages (Wave 7-E — gap #2 estado-da-arte). */}
+              <Section title="Pipeline" icon={CheckCircle2}>
+                <ServiceOrderStagePipeline
+                  serviceOrderId={data.id}
+                  enabled={open}
+                  refreshKey={historyVersion}
+                />
+              </Section>
+
+              {/* Ações FSM (Wave 7-A backend) */}
+              <Section title="Ações disponíveis" icon={CheckCircle2}>
                 <ServiceOrderFsmActionPanel
                   serviceOrderId={data.id}
                   enabled={open}

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderStagePipeline.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderStagePipeline.tsx
@@ -1,0 +1,227 @@
+// Mini-grafo horizontal de stages FSM (Wave 7-E — gap #2 estado-da-arte FSM screen).
+// Render "você está aqui" pictórico no drawer ServiceOrderSheet — bullets conectados,
+// stage atual destacado, passados com check, futuros opacos. Lateral stages (manutencao
+// no fluxo locacao) renderizam abaixo como variantes.
+//
+// Refs: memory/sessions/2026-05-20-arte-tela-fsm-workflow.md gap #2,
+//       app/Http/Controllers/ServiceOrderFsmActionController::actions() (payload stages_pipeline)
+
+import { useEffect, useState } from 'react';
+import { Check, Circle, Loader2 } from 'lucide-react';
+import { cn } from '@/Lib/utils';
+
+interface StageNode {
+  key: string;
+  name: string;
+  color: string | null;
+  sort_order: number;
+  is_initial: boolean;
+  is_terminal: boolean;
+  is_current: boolean;
+}
+
+interface ActionsResponse {
+  service_order_id: number;
+  process_key: string | null;
+  current_stage: { key: string | null; name: string | null; color: string | null; is_terminal: boolean } | null;
+  stages_pipeline?: StageNode[];
+  actions: unknown[];
+  in_pipeline: boolean;
+}
+
+interface Props {
+  serviceOrderId: number;
+  enabled: boolean;
+  /** Bump pra forçar re-fetch (incrementado pelo Sheet pós-FSM transition). */
+  refreshKey?: number;
+}
+
+// Paleta Tailwind por stage.color (mesma do STAGE_CHIP_COLOR_MAP do Index).
+const STAGE_DOT_COLOR_MAP: Record<string, { current: string; past: string; future: string }> = {
+  gray:    { current: 'bg-gray-500 ring-gray-200',       past: 'bg-gray-400',    future: 'bg-gray-200' },
+  blue:    { current: 'bg-blue-500 ring-blue-200',       past: 'bg-blue-400',    future: 'bg-blue-200' },
+  cyan:    { current: 'bg-cyan-500 ring-cyan-200',       past: 'bg-cyan-400',    future: 'bg-cyan-200' },
+  amber:   { current: 'bg-amber-500 ring-amber-200',     past: 'bg-amber-400',   future: 'bg-amber-200' },
+  yellow:  { current: 'bg-yellow-500 ring-yellow-200',   past: 'bg-yellow-400',  future: 'bg-yellow-200' },
+  violet:  { current: 'bg-violet-500 ring-violet-200',   past: 'bg-violet-400',  future: 'bg-violet-200' },
+  indigo:  { current: 'bg-indigo-500 ring-indigo-200',   past: 'bg-indigo-400',  future: 'bg-indigo-200' },
+  emerald: { current: 'bg-emerald-500 ring-emerald-200', past: 'bg-emerald-400', future: 'bg-emerald-200' },
+  green:   { current: 'bg-green-500 ring-green-200',     past: 'bg-green-400',   future: 'bg-green-200' },
+  red:     { current: 'bg-red-500 ring-red-200',         past: 'bg-red-400',     future: 'bg-red-200' },
+  rose:    { current: 'bg-rose-500 ring-rose-200',       past: 'bg-rose-400',    future: 'bg-rose-200' },
+  slate:   { current: 'bg-slate-500 ring-slate-200',     past: 'bg-slate-400',   future: 'bg-slate-200' },
+};
+
+const FALLBACK_COLOR = { current: 'bg-gray-500 ring-gray-200', past: 'bg-gray-400', future: 'bg-gray-200' };
+
+export default function ServiceOrderStagePipeline({ serviceOrderId, enabled, refreshKey }: Props) {
+  const [data, setData] = useState<ActionsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !serviceOrderId) return;
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    fetch(`/oficina-auto/service-orders/${serviceOrderId}/fsm/actions`, {
+      headers: { Accept: 'application/json' },
+      credentials: 'same-origin',
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          // 403 sem permission OU OS sem stage — silencia (FsmActionPanel já trata)
+          if (!cancelled) setData(null);
+          return null;
+        }
+        return (await res.json()) as ActionsResponse;
+      })
+      .then((json) => {
+        if (cancelled || !json) return;
+        setData(json);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        setError(e instanceof Error ? e.message : 'Erro ao carregar pipeline');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [serviceOrderId, enabled, refreshKey]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-xs text-muted-foreground">
+        <Loader2 size={12} className="animate-spin" />
+        Carregando pipeline…
+      </div>
+    );
+  }
+
+  if (error) {
+    return <p className="text-xs text-destructive">{error}</p>;
+  }
+
+  if (!data || !data.in_pipeline || !data.stages_pipeline || data.stages_pipeline.length === 0) {
+    // Quiet — empty state já tratado em FsmActionPanel ("Iniciar pipeline FSM")
+    return null;
+  }
+
+  const stages = data.stages_pipeline;
+  const currentIdx = stages.findIndex((s) => s.is_current);
+
+  // Separa pipeline principal (não-lateral) de stages laterais
+  // Lateral = stage não-inicial, não-terminal, com sort_order > último terminal canonical
+  // Heurística: pega os 3 primeiros (initial+canonical) e separa o resto se houver mais de 3.
+  // Pra cacamba_locacao: disponivel(0) → locada(1) → recolhida(2 terminal); manutencao(3) lateral.
+  // Pra cacamba_manutencao: aberta(0) → em_servico(1) → concluida(2 terminal); cancelada(3) lateral.
+  const mainPath: StageNode[] = [];
+  const lateral: StageNode[] = [];
+  let foundTerminal = false;
+  for (const s of stages) {
+    if (foundTerminal && !s.is_terminal) {
+      lateral.push(s); // stage não-terminal após terminal = lateral (ex manutencao)
+    } else if (foundTerminal && s.is_terminal) {
+      lateral.push(s); // 2º terminal (ex cancelada) também lateral
+    } else {
+      mainPath.push(s);
+      if (s.is_terminal) foundTerminal = true;
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      {/* Pipeline principal — horizontal bullets+linha */}
+      <div className="relative flex items-center justify-between">
+        {/* Linha de fundo cobrindo todo o range */}
+        <div className="absolute top-3 left-3 right-3 h-0.5 bg-border" aria-hidden="true" />
+        {/* Linha de progresso até o stage atual */}
+        {currentIdx > 0 && (
+          <div
+            className="absolute top-3 left-3 h-0.5 bg-foreground/40 transition-all"
+            style={{
+              width: `calc(${(Math.min(currentIdx, mainPath.length - 1) / Math.max(mainPath.length - 1, 1)) * 100}% - ${currentIdx === mainPath.length - 1 ? '0.75rem' : '0px'})`,
+            }}
+            aria-hidden="true"
+          />
+        )}
+        {mainPath.map((stage, idx) => {
+          const idxInMain = idx;
+          const currentIdxInMain = mainPath.findIndex((s) => s.is_current);
+          const isPast = currentIdxInMain >= 0 && idxInMain < currentIdxInMain;
+          const isCurrent = stage.is_current;
+          const colors = STAGE_DOT_COLOR_MAP[stage.color ?? 'gray'] ?? FALLBACK_COLOR;
+
+          return (
+            <div key={stage.key} className="relative z-10 flex flex-col items-center gap-1.5">
+              <div
+                className={cn(
+                  'flex h-6 w-6 items-center justify-center rounded-full ring-4 transition-colors',
+                  isCurrent
+                    ? colors.current
+                    : isPast
+                      ? colors.past
+                      : colors.future,
+                  isCurrent && 'ring-offset-1',
+                )}
+                title={stage.is_terminal ? `${stage.name} (terminal)` : stage.name}
+              >
+                {isPast || (isCurrent && stage.is_terminal) ? (
+                  <Check size={12} className="text-white" />
+                ) : isCurrent ? (
+                  <Circle size={8} className="fill-white text-white" />
+                ) : null}
+              </div>
+              <span
+                className={cn(
+                  'max-w-[80px] text-center text-[10px] leading-tight',
+                  isCurrent ? 'font-semibold text-foreground' : 'text-muted-foreground',
+                )}
+              >
+                {stage.name}
+              </span>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Stages laterais (manutencao / cancelada) — renderizam abaixo como variantes */}
+      {lateral.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 pl-1 pt-1 border-t border-border/50">
+          <span className="text-[10px] uppercase tracking-wider text-muted-foreground">
+            Variantes:
+          </span>
+          {lateral.map((stage) => {
+            const isCurrent = stage.is_current;
+            const colors = STAGE_DOT_COLOR_MAP[stage.color ?? 'gray'] ?? FALLBACK_COLOR;
+            return (
+              <span
+                key={stage.key}
+                className={cn(
+                  'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px]',
+                  isCurrent
+                    ? 'border-foreground bg-foreground text-background font-semibold'
+                    : 'border-border text-muted-foreground opacity-70',
+                )}
+                title={stage.is_terminal ? `${stage.name} (terminal)` : stage.name}
+              >
+                <span
+                  className={cn(
+                    'inline-block h-1.5 w-1.5 rounded-full',
+                    isCurrent ? 'bg-background' : colors.future.replace('bg-', 'bg-'),
+                  )}
+                />
+                {stage.name}
+              </span>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Fecha **gap #2** da auditoria estado-da-arte FSM screen 2026-05-20 ([session log](memory/sessions/2026-05-20-arte-tela-fsm-workflow.md)) — completa a **tríade MVP Martinho**:

| Gap | PR | Status |
|---|---|---|
| #1 Timeline FSM auditável | [#1195](https://github.com/wagnerra23/oimpresso.com/pull/1195) | ✅ merged + live |
| #3 Chips por stage Linear-style | [#1203](https://github.com/wagnerra23/oimpresso.com/pull/1203) | ✅ merged + live |
| **#2 Mini-grafo horizontal stages** | **este PR** | 🟡 pending |

Drawer `ServiceOrderSheet` agora mostra **"você está aqui" pictórico**: bullets conectados por linha (estilo Linear), stage atual destacado, passados com check, futuros opacos. Stages laterais (manutenção no fluxo locação; cancelada no manutenção) renderizam abaixo como variantes.

## Backend

`ServiceOrderFsmActionController::actions()` endpoint existente ganha campo `stages_pipeline` com lista ordenada por `sort_order`. Cada stage: `{key, name, color, sort_order, is_initial, is_terminal, is_current}`. Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)) herdado via `currentStage.process_id`.

## Frontend

[`ServiceOrderStagePipeline.tsx`](resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderStagePipeline.tsx) — componente novo:

- **Bullets conectados** por linha de fundo + progresso até stage atual
- **Stage atual**: ring colorido + label bold
- **Passados**: bullet cheio cor escura + check icon
- **Futuros**: bullet claro + nome opaco
- **Heurística separa pipeline principal vs laterais** (manutencao/cancelada ficam abaixo numa linha "Variantes")
- Paleta 12 cores Tailwind por `stage.color` do seeder
- `refreshKey` prop pra re-fetch pós-FSM transition

`ServiceOrderSheet.tsx` — Section "Pipeline" (mini-grafo) **acima** de "Ações disponíveis" (FsmActionPanel). Hierarquia clara: **ver pipeline → executar ação**.

## Test plan

- [ ] Pest 4 specs passam contra MySQL CI: `ServiceOrderStagePipelineTest`
- [ ] Após deploy, abrir drawer de OS Martinho — mini-grafo renderiza: `[Disponível ●] → [Locada ○] → [Recolhida ○]`
- [ ] Atual destacado, recolhida com check (se concluída)
- [ ] Click "Iniciar locação" no FsmActionPanel → mini-grafo atualiza pra `[Disponível ✓] → [Locada ●] → [Recolhida ○]`
- [ ] Variante "Em manutenção" aparece linha abaixo

## Refs

- [memory/sessions/2026-05-20-arte-tela-fsm-workflow.md](memory/sessions/2026-05-20-arte-tela-fsm-workflow.md) — auditoria gap #2
- [memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md](memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md) — FSM Pipeline LIVE
- PRs #1195 (gap #1) · #1203 (gap #3) · #1197 (hotfix kpis defer)

🤖 Generated with Claude Code
