### PR TITLE
chore(workflows): run-financeiro-demo-seeder dispatchavel

### DIFF
--- a/.claude/skills/inertia-defer-default/SKILL.md
+++ b/.claude/skills/inertia-defer-default/SKILL.md
@@ -136,6 +136,60 @@ function resolveDeferProp(mixed $value): mixed
 
 E use `resolveDeferProp($props['items'])['data']` em vez de `$props['items']['data']`.
 
+## ⚠️ Antipattern: defer no backend SEM handling no frontend = tela branca
+
+**Sintoma reproduzido (Wave 7-C 2026-05-20, hotfix PR #1197):**
+- Backend usa `Inertia::defer(fn () => $this->buildKpisPayload(...))` corretamente
+- Frontend tipa prop como obrigatória: `interface Props { kpis: Kpis }` e acessa direto: `kpis.locacoes_ativas`
+- Primeiro render: `kpis = undefined` (defer ainda não chegou) → `TypeError: Cannot read properties of undefined` → **tela branca em prod afetando cliente piloto**
+
+**Caso real:** [`Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php:189`](../../Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php) deferia `kpis`; [`resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx`](../../resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx) acessava `kpis.locacoes_ativas` em 5 lugares sem guard. Detectado via skill `smoke-prod-evidence` browser MCP pós-deploy.
+
+**Duas formas válidas de evitar (escolha 1, NUNCA nenhuma):**
+
+### Opção A — `<Deferred>` wrapper (idiomático Inertia v3, recomendado)
+
+```tsx
+import { Deferred } from '@inertiajs/react';
+
+interface Props {
+  kpis?: Kpis;  // ?: obrigatório porque defer
+}
+
+export default function Page({ kpis }: Props) {
+  return (
+    <Deferred data="kpis" fallback={<KpiSkeleton />}>
+      {/* dentro do Deferred, kpis garantido populado */}
+      <KpiGrid>
+        <KpiCard value={kpis!.locacoes_ativas} />
+      </KpiGrid>
+    </Deferred>
+  );
+}
+```
+
+### Opção B — Default value no destructuring (fallback rápido, hotfix-friendly)
+
+```tsx
+interface Props {
+  kpis?: Kpis;  // ?: obrigatório
+}
+
+const EMPTY_KPIS: Kpis = {
+  locacoes_ativas: 0,
+  manutencao_ativas: 0,
+  concluidas_mes: 0,
+  atrasadas: 0,
+};
+
+export default function Page({ kpis = EMPTY_KPIS }: Props) {
+  // kpis sempre populado — componentes filhos rendam 0 até defer chegar
+  return <KpiCard value={kpis.locacoes_ativas} />;
+}
+```
+
+**Use Opção A** quando há skeleton visual claro a oferecer (KPIs vazios chama atenção). **Use Opção B** quando "0" é estado válido aceitável (contadores que naturalmente começam zerados). NUNCA `kpis: Kpis` (sem `?`) acessando direto.
+
 ## Exceções legítimas (NÃO aplicar defer)
 
 - **Initial paint requirements críticos** — login screen, error 500, splash

--- a/.github/workflows/run-financeiro-demo-seeder.yml
+++ b/.github/workflows/run-financeiro-demo-seeder.yml
@@ -1,0 +1,73 @@
+name: Run FinanceiroDemoSeeder (one-shot)
+
+# Workflow_dispatch dedicado pra rodar `FinanceiroDemoSeeder` no Hostinger.
+# Criado porque `deploy.yml --extra_artisan='db:seed --class=...'` não funciona
+# por escape de backslash/slash em FQCN namespaced. Aqui o comando é literal
+# entre aspas simples — sem interpolação de shell.
+#
+# Wagner 2026-05-20: poppular biz=1 com 29 titulos mock.
+
+on:
+  workflow_dispatch:
+    inputs:
+      biz_id:
+        description: 'business_id alvo (1=WR2 Sistemas, 4=ROTA LIVRE — CUIDADO biz=4 é prod)'
+        required: true
+        default: '1'
+        type: string
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
+jobs:
+  seed:
+    name: Run FinanceiroDemoSeeder biz=${{ inputs.biz_id }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Setup SSH
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -p ${{ secrets.SSH_PORT }} -H ${{ secrets.SSH_HOST }} >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: SSH helper
+        run: |
+          cat > /tmp/ssh_exec.sh <<'EOF'
+          #!/bin/bash
+          ssh -i ~/.ssh/id_ed25519 -p ${{ secrets.SSH_PORT }} \
+              -o StrictHostKeyChecking=accept-new \
+              -o ConnectTimeout=20 \
+              ${{ secrets.SSH_USER }}@${{ secrets.SSH_HOST }} \
+              "$@"
+          EOF
+          chmod +x /tmp/ssh_exec.sh
+
+      - name: Pre-run check
+        run: |
+          /tmp/ssh_exec.sh "
+            cd /home/u906587222/domains/oimpresso.com/public_html &&
+            php artisan --version &&
+            ls -la Modules/Financeiro/Database/Seeders/FinanceiroDemoSeeder.php
+          "
+
+      - name: Run seeder
+        # FQCN entre aspas simples ao redor do --class — bash preserva backslash literais.
+        # 2>&1 | tail -50 pra ver output do seeder (categorias + titulos count).
+        run: |
+          /tmp/ssh_exec.sh "
+            cd /home/u906587222/domains/oimpresso.com/public_html &&
+            BIZ_ID=${{ inputs.biz_id }} php artisan db:seed --class='Modules\Financeiro\Database\Seeders\FinanceiroDemoSeeder' --force 2>&1 | tail -50
+          "
+
+      - name: Verify count
+        run: |
+          /tmp/ssh_exec.sh "
+            cd /home/u906587222/domains/oimpresso.com/public_html &&
+            php artisan tinker --execute=\"echo 'Titulos demo biz=${{ inputs.biz_id }}: ' . \Modules\Financeiro\Models\Titulo::withoutGlobalScopes()->where('business_id', ${{ inputs.biz_id }})->where('observacoes', 'LIKE', 'SEEDER_DEMO%')->count();\"
+          "
+
+      - name: Done
+        run: echo "Seeder concluido pra biz=${{ inputs.biz_id }}. Verificar /financeiro/unificado em prod."

--- a/memory/reference/deploy-recovery-patterns.md
+++ b/memory/reference/deploy-recovery-patterns.md
@@ -109,6 +109,51 @@ gh run list --workflow=quick-sync.yml --limit 5
 
 **Lição:** após qualquer merge importante que cria tela nova / adiciona entry topnav / modifica controller, **sempre verificar `gh run list --workflow=quick-sync.yml --limit 1` ANTES** de dizer "tá em prod" pro Wagner. Falha silenciosa do workflow é o pattern dominante de "tela não aparece".
 
+### 2.2 Quick-sync vs Deploy: quando precisa composer install em prod
+
+**Disparo:** PR mergeado, `quick-sync.yml` rodou success, mas rotas do módulo afetado retornam **500 Server Error**. Outras rotas funcionam normalmente.
+
+**Causa raiz:** `quick-sync.yml` **NÃO roda** `composer install` nem `php artisan migrate` — só faz `git pull` + `npm run build:inertia` + `optimize:clear`. Quando PR adiciona método novo em Controller existente, classe nova, ou novo binding de FQCN, o **composer autoload** de prod fica desatualizado → Laravel não consegue resolver classes → ServiceProvider crash → 500 cascateando em todo módulo.
+
+**Sintomas catalogados (Wave 7-C 2026-05-20):**
+- `oimpresso.com/oficina-auto/ordens-servico` → 500
+- `oimpresso.com/oficina-auto/veiculos` → 500
+- `oimpresso.com/home` → 200 (rotas que não dependem do método novo continuam)
+- `Force Clean Rebuild` workflow falha em `view:cache` com erro `Symfony\Component\Finder\DirectoryNotFoundException` (sintoma secundário do autoload quebrado)
+
+**Fix canônico:**
+
+```bash
+# Disparar Deploy to Hostinger workflow_dispatch (full deploy: composer + migrate + cache)
+gh workflow run "Deploy to Hostinger" --ref main
+
+# Aguardar com watch
+$run = (gh run list --workflow=deploy.yml --limit 1 --json databaseId | ConvertFrom-Json).databaseId
+gh run watch $run --interval 20
+```
+
+**Quando usar Deploy vs Quick-sync — matriz de decisão:**
+
+| Mudança do PR | Quick-sync basta? | Por quê |
+|---|---|---|
+| Só `.tsx`/`.ts`/`.css` frontend | ✅ Sim | npm run build:inertia regenera bundles |
+| `.blade.php` view edit | ✅ Sim | view:clear no quick-sync |
+| Controller — método novo OU classe nova OU trait composition | ❌ **Não** — usar Deploy | composer autoload precisa regenerar |
+| Adicionar dependency em `composer.json` | ❌ **Não** — usar Deploy | composer install obrigatório |
+| Migration nova (`*_create_*.php` em Database/Migrations) | ❌ **Não** — usar Deploy | artisan migrate obrigatório |
+| ServiceProvider/binding/Module.json alteração | ❌ **Não** — usar Deploy | package:discover + composer dump-autoload |
+| Documentação `memory/*.md` puramente | ✅ Sim (irrelevante — não muda runtime) | git pull basta |
+
+**Lição executiva:** **toda PR `feat()` que adiciona método novo em Controller existente DEVE ser deployada via `Deploy to Hostinger` workflow_dispatch**, não confiar no quick-sync auto-trigger. Quick-sync é OK pra hotfix `.tsx` puro ou docs. Validar via matriz acima antes de declarar "tá em prod".
+
+**Caso real 2026-05-20 (Wave 7-C):**
+- PR #1195 adicionou `ServiceOrderFsmActionController::history()` (método novo)
+- Quick-sync trigger automático mergou → SSH `git reset --hard` → tentou recompor índice
+- Erro: `unable to create file ServiceOrderSheet.tsx: File exists` (filesystem Linux case-sensitive vs Windows case-insensitive — bug secundário)
+- Mesmo após chore-vite quick-sync subsequente "limpar" o estado git, autoload Composer ficou stale
+- Todo `Modules/OficinaAuto/*` 500 até `Deploy to Hostinger` rodar composer install + migrate + cache rebuild
+- Skill `smoke-prod-evidence` detectou via browser MCP — sem ela, falha silenciosa porque quick-sync workflow reportava success
+
 ## 3. Tela branca Inertia pós optimize:clear = cache stale do bundle
 
 **Não é regressão real** — tab Chrome com bundle JS antigo trava após `optimize:clear`.

--- a/memory/requisitos/OficinaAuto/BRIEFING.md
+++ b/memory/requisitos/OficinaAuto/BRIEFING.md
@@ -3,8 +3,9 @@ module: OficinaAuto
 status: em-construcao
 cnae_principal: "4520-0/01"
 piloto: Martinho Caçambas (locação) + Vargas Recapagem (manutenção complexa)
-ultima_atualizacao: 2026-05-16
+ultima_atualizacao: 2026-05-20
 nota_capterra: 63 (Bom)
+nota_fsm_screen: 80 (estado-da-arte gaps #1+#2+#3 LIVE 2026-05-20)
 related_adrs: [0137, 0121, 0129, 0143, 0093, 0094, 0101]
 owner: [W]
 ---
@@ -19,6 +20,12 @@ Vertical especializado pra **oficinas mecânicas + locação de equipamentos aut
 
 ## Capacidades atuais (V0 — done)
 
+- **FSM screen tríade MVP Martinho LIVE 2026-05-20** ([RUNBOOK-fsm-pipeline.md](RUNBOOK-fsm-pipeline.md)):
+  - **Timeline auditável** drawer ServiceOrderSheet (gap #1 — PR #1195) — quem/quando/motivo/side-effects via `GET /history`
+  - **Mini-grafo horizontal stages** (gap #2 — PR #1205) — bullets conectados estilo Linear, current ring + passados check + variantes laterais (manutencao/cancelada)
+  - **Chips por stage Index** (gap #3 — PR #1203) — filtro `?stage=X` com contador bulk `GROUP BY`
+  - 12 Pest specs novos (history, stages, pipeline) com cobertura multi-tenant Tier 0
+  - Grade 15 dimensões FSM screen evoluiu **65→~80/100** (auditoria estado-da-arte [memory/sessions/2026-05-20-arte-tela-fsm-workflow.md](../../sessions/2026-05-20-arte-tela-fsm-workflow.md))
 - **8 peças nWidart canônicas** (module.json, ServiceProvider, RouteServiceProvider, InstallController, DataController, Routes, Config, composer)
 - **Wave 18 saturação D4/D9** — 2 Services novos stateless (`VehicleQueryService`, `ServiceOrderSummaryService`) com OtelHelper canon (9 spans `oficinaauto.*` mensurados em prod) + spans D9.a em `AprovacaoOsService` (gerar_token/validar_token/validar_pin); 2 Pest novos (ServicesObservabilityTest 8 cenários + AprovacaoOsTokenTest 8 cenários edge); README.md público; CHANGELOG.md canônico; module.json com bloco `governance.fsm_canonico=true` apontando ADR 0143.
 - **Schema multi-tenant Tier 0** (ADR 0093) — `vehicles` (multi-placa nullable, legacy_id pra mapping Firebird) + `service_orders` (vehicle_id FK + transaction_id nullable UltimatePOS + order_type locacao/manutencao)

--- a/memory/requisitos/OficinaAuto/CHANGELOG.md
+++ b/memory/requisitos/OficinaAuto/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 Formato: [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/) · [Semver](https://semver.org/).
 
+## [Unreleased] - 2026-05-20 — Wave 7-C/D/E tríade MVP Martinho LIVE (FSM screen 65→~80)
+
+Fecha os 3 gaps urgentes da auditoria estado-da-arte FSM screen ([memory/sessions/2026-05-20-arte-tela-fsm-workflow.md](../../sessions/2026-05-20-arte-tela-fsm-workflow.md)) — pré-ativação Martinho. Nota agregada na grade 15 dimensões: **65/100 → ~80/100**.
+
+### Added
+
+- **Wave 7-C — Timeline FSM auditável** ([PR #1195](https://github.com/wagnerra23/oimpresso.com/pull/1195) `84a585951`):
+  - `ServiceOrderFsmActionController::history()` (+90 linhas) — método novo no controller existente
+  - Rota `GET /oficina-auto/service-orders/{order}/history` (named `oficinaauto.service_orders.history`)
+  - `ServiceOrderTimeline.tsx` — port de `SaleTimeline.tsx` (US-SELL-035 LIVE)
+  - Wire no `ServiceOrderSheet.tsx` substituindo placeholder "Em breve..."
+  - 4 Pest specs (`ServiceOrderHistoryControllerTest`) — happy path, startPipeline action_id=NULL, discriminação process_key cacamba_*, multi-tenant Tier 0
+- **Wave 7-D — Chips por stage Linear-style com contador** ([PR #1203](https://github.com/wagnerra23/oimpresso.com/pull/1203) `627c008e2`):
+  - `ServiceOrderController::index()` aceita `?stage=X` (filtra `current_stage_id` via stage.key)
+  - `buildStagesPayload` (Inertia::defer) — 1 query bulk `GROUP BY` counts por stage
+  - `STAGE_CHIP_COLOR_MAP` Tailwind (12 cores) + UI chips no Index.tsx
+  - 4 Pest specs (`ServiceOrderIndexStageFilterTest`) — filter key, multi-tenant, counts bulk, sem filtro
+- **Wave 7-E — Mini-grafo horizontal stages no drawer** ([PR #1205](https://github.com/wagnerra23/oimpresso.com/pull/1205) `5f924b6ff`):
+  - `actions()` endpoint ganha campo `stages_pipeline` (lista ordenada por `sort_order`)
+  - `ServiceOrderStagePipeline.tsx` (+227 linhas) — componente novo: bullets conectados + check passados + ring atual + variantes laterais
+  - Heurística separa pipeline principal vs laterais (manutencao/cancelada ficam abaixo)
+  - 4 Pest specs (`ServiceOrderStagePipelineTest`) — ordem sort_order, is_current único, multi-tenant Tier 0, OS sem stage
+- **[RUNBOOK-fsm-pipeline.md](RUNBOOK-fsm-pipeline.md)** — doc canon novo: arquitetura, 2 processos cacamba_*, polimorfismo `sale_stage_history`, endpoints REST, UI canon 3 componentes, pegadinhas CI/deploy
+
+### Fixed
+
+- **Hotfix tela branca Index.tsx** ([PR #1197](https://github.com/wagnerra23/oimpresso.com/pull/1197) `ac84ac8d1`): `kpis: Kpis` (não-opcional) crashava com `Inertia::defer`. Fix: `kpis?: Kpis` + `EMPTY_KPIS` default no destructuring. Pattern catalogado em [skill inertia-defer-default §Antipattern](../../../.claude/skills/inertia-defer-default/SKILL.md).
+
+### Operational lessons (canon — todos módulos)
+
+- **`quick-sync.yml` NÃO regenera composer autoload** — PR #1195 (método novo) deu 500 em todo módulo até `Deploy to Hostinger` rodar `composer install`. Matriz de decisão quick-sync vs deploy em [memory/reference/deploy-recovery-patterns.md §2.2](../../reference/deploy-recovery-patterns.md#22-quick-sync-vs-deploy-quando-precisa-composer-install-em-prod).
+- **Hostname canon** ([PR #1196](https://github.com/wagnerra23/oimpresso.com/pull/1196) `50d9695ab`): `oimpresso.com` (não `oi.wr2.com.br` legado). Doc canon em [memory/reference/sandbox-hostnames.md](../../reference/sandbox-hostnames.md).
+
+### Preserved (Tier 0 IRREVOGÁVEL)
+
+- Multi-tenant Tier 0 ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md)) — todos endpoints history/actions/stages_pipeline filtram `business_id` via global scope + filter explicit em SaleProcess
+- FSM Orchestrator global ([app/Domain/Fsm/](../../../app/Domain/Fsm/)) — ServiceOrder reusa `sale_stage_history` polimorficamente via `transaction_id` carrying `$order->id`
+- Pest skip SQLite ([ADR 0101](../../decisions/0101-tests-business-id-1-nunca-cliente.md)) — todos novos tests rodam só MySQL CI
+
 ## [Unreleased] - 2026-05-16 — Wave 23 saturação bucket vertical_client_facing
 
 ### Added

--- a/memory/requisitos/OficinaAuto/RUNBOOK-fsm-pipeline.md
+++ b/memory/requisitos/OficinaAuto/RUNBOOK-fsm-pipeline.md
@@ -1,0 +1,154 @@
+# RUNBOOK — FSM Pipeline OficinaAuto (cacamba_locacao + cacamba_manutencao)
+
+> **Atualizado:** 2026-05-20 (Wave 7-C/D/E — tríade MVP Martinho LIVE em prod biz=1)
+> **Status:** PIPELINE LIVE — [ADR 0143](../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md)
+> **Substitui leitura de:** ADR 0129 + ADR 0143 + 4 PRs (#1195, #1197, #1203, #1205) quando trabalhar em FSM OS
+
+## TL;DR
+
+OficinaAuto reusa o **FSM Orchestrator global** (`app/Domain/Fsm/*`) para gerenciar 2 processos canônicos por business:
+
+- **`cacamba_locacao`** — 4 stages (Disponível → Locada → Recolhida; lateral Em manutenção)
+- **`cacamba_manutencao`** — 4 stages (Aberta → Em serviço → Concluída; lateral Cancelada)
+
+UI canon no drawer `ServiceOrderSheet`: **Timeline** (gap #1) + **StagePipeline** mini-grafo (gap #2) + **ações FSM** (Wave 7-A). Index OS tem **StageChips** com contador (gap #3).
+
+## Arquitetura — onde mora cada peça
+
+| Peça | Path | Função |
+|---|---|---|
+| FSM Orchestrator (genérico) | [`app/Domain/Fsm/`](../../../app/Domain/Fsm/) | Models, Services, Policies, SideEffects compartilhados (Sells também usa) |
+| ServiceOrder Entity | [`Modules/OficinaAuto/Entities/ServiceOrder.php`](../../../Modules/OficinaAuto/Entities/ServiceOrder.php) | Campo `current_stage_id` (FK lógica → `sale_process_stages.id`) |
+| FSM Seeder | [`Modules/OficinaAuto/Database/Seeders/OficinaAutoFsmSeeder.php`](../../../Modules/OficinaAuto/Database/Seeders/OficinaAutoFsmSeeder.php) | Cria processos+stages+actions+roles per-business idempotente |
+| Action Controller | [`app/Http/Controllers/ServiceOrderFsmActionController.php`](../../../app/Http/Controllers/ServiceOrderFsmActionController.php) | Endpoints `/fsm/actions`, `/fsm/execute`, `/fsm/start-pipeline`, `/history` |
+| Drawer Sheet | [`resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderSheet.tsx`](../../../resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderSheet.tsx) | Container drawer lateral pattern Cockpit V2 |
+| UI canon — Timeline | `_components/ServiceOrderTimeline.tsx` | Histórico transições (gap #1 — PR #1195) |
+| UI canon — StagePipeline | `_components/ServiceOrderStagePipeline.tsx` | Mini-grafo "você está aqui" (gap #2 — PR #1205) |
+| UI canon — StageChips | `_components/ServiceOrderFsmActionPanel.tsx` + Index.tsx | Chips Linear-style com count (gap #3 — PR #1203) |
+| Side-effects | [`app/Domain/Fsm/SideEffects/*Cacamba.php`](../../../app/Domain/Fsm/SideEffects/) | `IniciarLocacaoCacamba`, `RecolherCacamba`, `EnviarCacambaManutencao`, etc |
+
+## Os 2 processos cacamba — fluxo + actions
+
+### 1. `cacamba_locacao` (caso Martinho — locação avulsa)
+
+```
+[Disponível ●]  ──iniciar_locacao──▶  [Locada]  ──recolher──▶  [Recolhida ✓ terminal]
+      ▲                                                                 │
+      │                                                                 │
+      │  voltar_disponivel  (de recolhida)                              │
+      ╞══════════════════════════════════════════════════════════════════
+      │
+      │  enviar_manutencao  (de disponivel OU recolhida)
+      ▼
+[Em manutenção]  ──voltar_disponivel──▶  [Disponível]
+```
+
+**Roles canon (Spatie suffix `#{biz}`):** `mecanico`, `gerente`
+- `iniciar_locacao` is_critical (gerente OU mecanico)
+- `recolher` (gerente OU mecanico)
+- `enviar_manutencao` is_critical (gerente only)
+- `voltar_disponivel` (gerente OU mecanico)
+
+### 2. `cacamba_manutencao` (oficina simples)
+
+```
+[Aberta ●]  ──iniciar_servico──▶  [Em serviço]  ──concluir──▶  [Concluída ✓ terminal]
+    │              │
+    └──cancelar────┴──cancelar──▶  [Cancelada ✓ terminal lateral]
+```
+
+**Roles canon:** `mecanico`, `gerente`
+- `iniciar_servico` (mecanico)
+- `concluir` is_critical (gerente OU mecanico)
+- `cancelar` is_critical (gerente only)
+
+## Pegadinha CRÍTICA — `transaction_id` polimórfico em `sale_stage_history`
+
+> **História append-only de todas transições FSM grava em `sale_stage_history` — table compartilhada com Sells (transactions).** ServiceOrder reusa esse table armazenando `$order->id` no campo `transaction_id` (subject_id polimórfico). NÃO há campo `entity_type` físico.
+
+**Discriminação obrigatória** ao consultar history de OS:
+
+1. **Via `action.stage.process.key`** quando `action_id` é não-nulo — filtrar `IN ('cacamba_locacao', 'cacamba_manutencao')`
+2. **Via `payload_snapshot.pipeline_started=true`** quando `action_id IS NULL` (entries do `startPipeline()`)
+
+Sem essa discriminação, há risco real de colisão: `transactions.id=42` (sale Sells) e `service_orders.id=42` (OS OficinaAuto) gerariam history misturado se filtrarmos só por `transaction_id`.
+
+Ver implementação canon: [`ServiceOrderFsmActionController::history()` linha ~290](../../../app/Http/Controllers/ServiceOrderFsmActionController.php).
+
+## Endpoints REST canon
+
+| Verb | Path | Função | Auth permission |
+|---|---|---|---|
+| `GET` | `/oficina-auto/service-orders/{order}/fsm/actions` | Lista actions disponíveis + current_stage + **stages_pipeline** | `oficinaauto.service_order.view` |
+| `POST` | `/oficina-auto/service-orders/{order}/fsm/execute` | Executa transição (action_key + payload com motivo) | `oficinaauto.service_order.update` |
+| `POST` | `/oficina-auto/service-orders/{order}/fsm/start-pipeline` | Inicializa OS legada (sem current_stage_id) no processo correto via `order_type` | `oficinaauto.service_order.update` |
+| `GET` | `/oficina-auto/service-orders/{order}/history` | Timeline auditável (filtrada por process_key cacamba_*) | `oficinaauto.service_order.view` |
+| `GET` | `/oficina-auto/ordens-servico?stage=X` | Index OS filtrado por stage.key (chips Linear) | `oficinaauto.service_order.view` |
+
+**Multi-tenant Tier 0** ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md)) em TODOS endpoints — `ServiceOrder` global scope + `SaleProcess.business_id` filter explicit no controller.
+
+## Como iniciar pipeline FSM numa OS legada
+
+OS criadas antes de Wave 5/6/7 podem ter `current_stage_id IS NULL`. O `ServiceOrderFsmActionPanel` mostra empty state com botão "Iniciar pipeline FSM" que chama:
+
+```http
+POST /oficina-auto/service-orders/{order}/fsm/start-pipeline
+Body: {}  (ou { "process_key": "cacamba_locacao" } pra override superadmin)
+```
+
+O backend resolve `process_key` via `$order->order_type`:
+- `order_type=locacao` → `cacamba_locacao` (stage inicial: `disponivel`)
+- `order_type=manutencao` → `cacamba_manutencao` (stage inicial: `aberta`)
+
+Audit entry registrada em `sale_stage_history` com `action_id=NULL` + `payload.pipeline_started=true` + `payload.subject_type='Modules\\OficinaAuto\\Entities\\ServiceOrder'`.
+
+## UI canon — 3 componentes que ficam no drawer
+
+```
+┌─────────────────────────────────────────┐  ServiceOrderSheet (drawer lateral pattern Cockpit)
+│ [OS-00001] [Locação] [Atrasada]         │  ← Header
+│ Locação #001                            │
+│ Cliente: Martinho Caçambas              │
+├─────────────────────────────────────────┤
+│ 3 KPIs (Diárias / Diária / A receber)   │
+├─────────────────────────────────────────┤
+│ Detalhes (veículo + cliente + datas)    │
+├─────────────────────────────────────────┤
+│ § Pipeline                              │  ← Gap #2 (Wave 7-E)
+│   ● ─── ○ ─── ○   ServiceOrderStage    │
+│   Disp  Locada Recolh  Pipeline.tsx    │
+│   Variantes: ○ Em manutenção            │
+├─────────────────────────────────────────┤
+│ § Ações disponíveis                     │  ← Wave 7-A backend canon
+│   [Iniciar locação]  [Enviar manuten.]  │  FsmActionPanel.tsx
+├─────────────────────────────────────────┤
+│ § Histórico                             │  ← Gap #1 (Wave 7-C)
+│   ○ 2026-05-12 14:23  Wagner WR23      │  ServiceOrderTimeline.tsx
+│     Pipeline iniciado → Disponível      │
+└─────────────────────────────────────────┘
+```
+
+## CI/Deploy — pegadinhas catalogadas desta sessão
+
+- **`quick-sync.yml` NÃO regenera composer autoload** — método novo em `ServiceOrderFsmActionController` (Wave 7-C) deu 500 em todo módulo até `Deploy to Hostinger` (workflow_dispatch) rodar `composer install`. Detalhe em [memory/reference/deploy-recovery-patterns.md §2.2](../../reference/deploy-recovery-patterns.md#22-quick-sync-vs-deploy-quando-precisa-composer-install-em-prod).
+- **`Inertia::defer` no payload `kpis`/`stages` exige frontend tipar opcional + default** — sem isso `kpis.locacoes_ativas` no primeiro render crasha tela branca. Hotfix PR #1197. Detalhe em [skill inertia-defer-default §Antipattern](../../../.claude/skills/inertia-defer-default/SKILL.md).
+
+## Pest tests canon
+
+| Spec | Path | Cobre |
+|---|---|---|
+| FsmTransitionTest | `Modules/OficinaAuto/Tests/Feature/FsmTransitionTest.php` | Transições válidas/inválidas + accessors |
+| ServiceOrderHistoryControllerTest | `Modules/OficinaAuto/Tests/Feature/ServiceOrderHistoryControllerTest.php` | 4 specs Timeline (cacamba_*, startPipeline, discriminação process_key, Tier 0) |
+| ServiceOrderIndexStageFilterTest | `Modules/OficinaAuto/Tests/Feature/ServiceOrderIndexStageFilterTest.php` | 4 specs chips filter + counts + Tier 0 |
+| ServiceOrderStagePipelineTest | `Modules/OficinaAuto/Tests/Feature/ServiceOrderStagePipelineTest.php` | 4 specs stages_pipeline payload + Tier 0 |
+
+Todos skipam em SQLite ([ADR 0101](../../decisions/0101-tests-business-id-1-nunca-cliente.md)) — CI roda contra MySQL.
+
+## Refs canon
+
+- [memory/sessions/2026-05-20-arte-tela-fsm-workflow.md](../../sessions/2026-05-20-arte-tela-fsm-workflow.md) — auditoria estado-da-arte FSM screen (origem dos 3 gaps)
+- [memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md](../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md) — FSM Pipeline LIVE
+- [memory/decisions/0129-state-machine-canonica-fsm-rbac.md](../../decisions/0129-state-machine-canonica-fsm-rbac.md) — FSM pattern canônico
+- [memory/decisions/0137-modules-oficinaauto-qualificada.md](../../decisions/0137-modules-oficinaauto-qualificada.md) — OficinaAuto vertical
+- [memory/decisions/0093-multi-tenant-isolation-tier-0.md](../../decisions/0093-multi-tenant-isolation-tier-0.md) — Tier 0 IRREVOGÁVEL
+- PRs canon: [#1195](https://github.com/wagnerra23/oimpresso.com/pull/1195) (gap #1 Timeline) · [#1203](https://github.com/wagnerra23/oimpresso.com/pull/1203) (gap #3 chips) · [#1205](https://github.com/wagnerra23/oimpresso.com/pull/1205) (gap #2 pipeline) · [#1197](https://github.com/wagnerra23/oimpresso.com/pull/1197) (hotfix kpis defer)


### PR DESCRIPTION
Workflow dispatchavel pra rodar FinanceiroDemoSeeder com biz_id input. Por que dedicado: php artisan db:seed --class=FQCN com escape via shell input GH Actions vira Modules concatenado sem separador. Aqui o comando e literal em aspas simples no YAML.