### PR TITLE
fix(financeiro/unificado): drawer CSS canon aplicar dentro do Sheet portal (Onda 22)

### DIFF
--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -173,28 +173,25 @@
   height: 36px;
   display: block;
 }
-/* Sparkline em fundo absoluto pro KPI hero (atrás do texto) */
-/* Onda 6 (2026-05-20): pointer-events none no SVG container PERMITE click-through
-   no hero card MAS hotspot circles por ponto têm pointer-events:auto inline,
-   ativam title nativo do browser ao hover (tooltip "DD/MM · saldo X · +in / -out"). */
+/* Onda 9 (2026-05-20 Wagner "encaixar melhor"): sparkline volta pro FLOW NORMAL
+   ABAIXO do hint (não mais absolute background). Match canon fin-boletos.css:96:
+     width calc(100% + 24px); margin-left -12px (sangra bordas card);
+     margin-top 8px; height 32px; opacity 0.85 (VISÍVEL como info-graphic).
+   Anterior era position absolute bottom 0 opacity 0.35 — escondido atrás do texto. */
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  margin-top: 0;
-  height: 56px;
-  opacity: 0.35;
-  pointer-events: none;
-  z-index: 0;
+  position: relative;
+  width: calc(100% + 24px);
+  margin: 8px -12px 0;
+  height: 32px;
+  opacity: 0.85;
+  display: block;
 }
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark circle {
   pointer-events: auto;
 }
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark:hover {
-  opacity: 0.55;
+  opacity: 1;
 }
-.fin-cowork .fin-curadoria .fin-stat-hero > * { position: relative; z-index: 1; }
 /* ─────────────────────────────────────────────────────────────
  * Toolbar (filter chips + density + search)
  * ───────────────────────────────────────────────────────────── */

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -1340,7 +1340,13 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
         {/* Onda 5 (2026-05-20): width 560px paridade canon (erp-shell/financeiro-app.jsx:738
             'w-[560px] max-w-[92vw]'). Era 460px — drawer mais espaçoso pra
             Histórico + Anexos + Conferido sem cortar texto. */}
-        <SheetContent side="right" className="fin-drawer-wide w-[560px] sm:max-w-[560px]">
+        {/* Onda 22 (2026-05-20) — Portal Sheet renderiza fora de .fin-cowork wrapper,
+            então CSS canon prefixado nao aplica (audit-trail, drawer-tabs, comments-thread,
+            conferido-toggle). Adicionar `fin-cowork` aqui ativa todas regras canon
+            DENTRO do drawer (CSS vars + grid layouts + spacing). Root cause descoberto
+            via JS check: drawerInsideFinCowork=false, audit-row display=list-item
+            (deveria ser grid). */}
+        <SheetContent side="right" className="fin-cowork fin-drawer-wide w-[560px] sm:max-w-[560px]">
           {selected && (
             <>
               <SheetHeader>
@@ -1692,7 +1698,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
       {/* Onda 15 (2026-05-20): Sheet modal pra bulk edit categoria em lote.
           Renderiza só quando bulkCategoriaOpen=true. */}
       <Sheet open={bulkCategoriaOpen} onOpenChange={(o) => !o && setBulkCategoriaOpen(false)}>
-        <SheetContent side="right" className="w-[440px] sm:max-w-[440px]">
+        <SheetContent side="right" className="fin-cowork w-[440px] sm:max-w-[440px]">
           <SheetHeader>
             <SheetTitle>Categorizar em lote</SheetTitle>
           </SheetHeader>


### PR DESCRIPTION
## Root cause
`<Sheet>` shadcn renderiza via Portal direto no `<body>` — fora do `.fin-cowork` wrapper. Todas as regras CSS canon prefixadas (`.fin-cowork .fin-audit-row`, `.fin-cowork .fin-drawer-tabs`, etc) **não aplicam dentro do drawer**.

## Sintomas em prod
- Histórico colado: "Vivo Empresariou13/05 recebido"
- Abas sem gap: "Detalhes✦ IA▸ Editar"
- Conferir + Per-user audit sem spacing
- Comentários "0 · visíveis pra Eliana · Wagner · Bruna" colado

## Fix
Adicionar `fin-cowork` no className do SheetContent (drawer detalhe + bulk Sheet Onda 15). Ativa CSS vars + box-sizing + font-family + todas regras prefixadas dentro do drawer.

## Telemetria pré-fix (via JS no prod)
```js
{
  drawerInsideFinCowork: false,
  audit_row_display: "list-item",  // deveria ser grid
  audit_row_grid_template_columns: "none"  // deveria ser "26px 1fr"
}
```

## Test plan
- [ ] Hard reload `/financeiro/unificado`
- [ ] Click linha → drawer abre
- [ ] Histórico: nome BOLD + ação cinza + data alinhada direita + spacing entre eventos
- [ ] Abas: gap entre "Detalhes" / "✦ IA" / "✎ Editar"
- [ ] Conferir + Per-user audit em linhas separadas
- [ ] Bulk select Onda 15 ainda funciona

Refs: Onda 22 (2026-05-20)