### PR TITLE
fix(financeiro/unificado/css): drawer bg branco + CSS vars no portal (Onda 22b)

### DIFF
--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -428,4 +428,51 @@
   border: 1px solid var(--fin-line);
   color: var(--fin-text);
 }
+
+/* ============================================================================
+ * Onda 22b (2026-05-20) — Drawer portal scope fix
+ *
+ * <Sheet> shadcn renderiza via Portal direto no <body> — fora do .fin-cowork
+ * wrapper da página. Quando adicionamos `fin-cowork` no SheetContent (Onda 22),
+ * descobrimos 2 problemas:
+ *   (1) CSS vars (--bg, --text, --accent, --border) definidos no
+ *       cowork-canon-financeiro-bundle.css NÃO sobreviveram ao build vite —
+ *       só .sells-cowork-show e .sells-cowork-edit têm essas vars no bundle.
+ *   (2) bg-background do Tailwind colide com .fin-cowork {background:#fff !important}
+ *       e o computed style ficou rgba(0,0,0,0) (transparent), deixando a
+ *       tabela atrás visível ATRAVÉS do drawer.
+ *
+ * Fix: redefinir os vars + bg branco com seletor de alta especificidade que
+ * pega só drawers (Sheet shadcn portal). NÃO afeta .fin-cowork da página
+ * principal (já tem vars vindos do .cockpit ancestor com inline style).
+ * ============================================================================ */
+[role="dialog"].fin-cowork {
+  /* Surface */
+  --bg:           oklch(0.985 0.003 90);
+  --bg-2:         oklch(0.965 0.004 90);
+  --surface:      #ffffff;
+  --border:       oklch(0.90 0.004 90);
+  --border-2:     oklch(0.93 0.004 90);
+  --text:         oklch(0.22 0.01 80);
+  --text-dim:     oklch(0.50 0.01 80);
+  --text-mute:    oklch(0.65 0.01 80);
+
+  --accent:       oklch(0.58 0.09 220);
+  --accent-2:     oklch(0.66 0.09 220);
+  --accent-soft:  oklch(0.94 0.025 220);
+  --accent-fg:    #ffffff;
+
+  --radius:       8px;
+  --radius-sm:    6px;
+  --shadow-pop:   0 6px 24px -8px rgba(0,0,0,.18), 0 2px 6px -2px rgba(0,0,0,.10);
+  --shadow-soft:  0 1px 2px rgba(0,0,0,.04);
+
+  --row-h:        30px;
+  --font-sans:    "IBM Plex Sans", ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
+  --font-mono:    "IBM Plex Mono", ui-monospace, "SF Mono", Menlo, monospace;
+
+  /* Force opaque white background — sobrescreve Tailwind bg-background colision */
+  background: #ffffff !important;
+  color: var(--text);
+}
 .fin-cowork .fin-curadoria .fin-footer-tips .spacer { flex: 1; }

--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -173,28 +173,25 @@
   height: 36px;
   display: block;
 }
-/* Sparkline em fundo absoluto pro KPI hero (atrás do texto) */
-/* Onda 6 (2026-05-20): pointer-events none no SVG container PERMITE click-through
-   no hero card MAS hotspot circles por ponto têm pointer-events:auto inline,
-   ativam title nativo do browser ao hover (tooltip "DD/MM · saldo X · +in / -out"). */
+/* Onda 9 (2026-05-20 Wagner "encaixar melhor"): sparkline volta pro FLOW NORMAL
+   ABAIXO do hint (não mais absolute background). Match canon fin-boletos.css:96:
+     width calc(100% + 24px); margin-left -12px (sangra bordas card);
+     margin-top 8px; height 32px; opacity 0.85 (VISÍVEL como info-graphic).
+   Anterior era position absolute bottom 0 opacity 0.35 — escondido atrás do texto. */
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  margin-top: 0;
-  height: 56px;
-  opacity: 0.35;
-  pointer-events: none;
-  z-index: 0;
+  position: relative;
+  width: calc(100% + 24px);
+  margin: 8px -12px 0;
+  height: 32px;
+  opacity: 0.85;
+  display: block;
 }
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark circle {
   pointer-events: auto;
 }
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark:hover {
-  opacity: 0.55;
+  opacity: 1;
 }
-.fin-cowork .fin-curadoria .fin-stat-hero > * { position: relative; z-index: 1; }
 /* ─────────────────────────────────────────────────────────────
  * Toolbar (filter chips + density + search)
  * ───────────────────────────────────────────────────────────── */


### PR DESCRIPTION
Root cause apos Onda 22: drawer com fin-cowork ficou semi-transparente (bg rgba(0,0,0,0)). 2 causas: (1) CSS vars sumiram do bundle compilado, (2) Tailwind bg-background colide com .fin-cowork bg !important. Fix: regra [role=dialog].fin-cowork no fin-cowork.css redefine vars + force bg #fff. Especificidade 0,0,2,0 - so pega drawers portal.