### PR TITLE
fix(financeiro/unificado): alinhar glyph tabs + bordas firmes (Onda 23)

### DIFF
--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -446,6 +446,26 @@
  * pega só drawers (Sheet shadcn portal). NÃO afeta .fin-cowork da página
  * principal (já tem vars vindos do .cockpit ancestor com inline style).
  * ============================================================================ */
+/* Onda 23 (2026-05-20) — alinhar glyphs Unicode (✦ ✎) com texto nos tabs.
+   Glyphs Unicode tem altura visual diferente das letras — wrap em span com
+   font-size menor + line-height: 1 + inline-flex align-items: center
+   normaliza baseline. Sem isso, "✦ IA" e "✎ Editar" sobem ~2px vs "Detalhes". */
+[role="dialog"].fin-cowork .fin-drawer-tab-glyph {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 12px;
+  line-height: 1;
+  min-width: 12px;
+}
+
+/* Onda 23 — borders mais firmes entre seções do drawer body (stone-200
+   em vez de stone-100 que ficava quase invisível). Match Cowork canon
+   prototype `border-stone-200`. */
+[role="dialog"].fin-cowork .border-stone-100 {
+  border-color: oklch(0.92 0.005 80) !important;
+}
+
 [role="dialog"].fin-cowork {
   /* Surface */
   --bg:           oklch(0.985 0.003 90);

--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -173,28 +173,25 @@
   height: 36px;
   display: block;
 }
-/* Sparkline em fundo absoluto pro KPI hero (atrás do texto) */
-/* Onda 6 (2026-05-20): pointer-events none no SVG container PERMITE click-through
-   no hero card MAS hotspot circles por ponto têm pointer-events:auto inline,
-   ativam title nativo do browser ao hover (tooltip "DD/MM · saldo X · +in / -out"). */
+/* Onda 9 (2026-05-20 Wagner "encaixar melhor"): sparkline volta pro FLOW NORMAL
+   ABAIXO do hint (não mais absolute background). Match canon fin-boletos.css:96:
+     width calc(100% + 24px); margin-left -12px (sangra bordas card);
+     margin-top 8px; height 32px; opacity 0.85 (VISÍVEL como info-graphic).
+   Anterior era position absolute bottom 0 opacity 0.35 — escondido atrás do texto. */
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  margin-top: 0;
-  height: 56px;
-  opacity: 0.35;
-  pointer-events: none;
-  z-index: 0;
+  position: relative;
+  width: calc(100% + 24px);
+  margin: 8px -12px 0;
+  height: 32px;
+  opacity: 0.85;
+  display: block;
 }
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark circle {
   pointer-events: auto;
 }
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark:hover {
-  opacity: 0.55;
+  opacity: 1;
 }
-.fin-cowork .fin-curadoria .fin-stat-hero > * { position: relative; z-index: 1; }
 /* ─────────────────────────────────────────────────────────────
  * Toolbar (filter chips + density + search)
  * ───────────────────────────────────────────────────────────── */

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -1403,7 +1403,8 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                   className={'fin-drawer-tab fin-drawer-tab-ai' + (drawerTab === 'ia' ? ' on' : '')}
                   onClick={() => setDrawerTab('ia')}
                 >
-                  ✦ IA
+                  <span className="fin-drawer-tab-glyph" aria-hidden>✦</span>
+                  <span>IA</span>
                   {/* Onda 14 (2026-05-20): badge ! na aba IA quando há anomalia detectada
                       (ticket alto vs media historica). Permite Eliana ver alerta sem
                       precisar trocar aba primeiro. */}
@@ -1430,7 +1431,8 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                   disabled={!selected.valor_mutavel}
                   title={!selected.valor_mutavel ? 'Valor não-mutável após baixa (ADR fin-tech/0002)' : 'Editar inline'}
                 >
-                  ✎ Editar
+                  <span className="fin-drawer-tab-glyph" aria-hidden>✎</span>
+                  <span>Editar</span>
                 </button>
               </nav>
 


### PR DESCRIPTION
Pos Ondas 17-21, user reportou (1) abas IA/Editar desalinhadas vs Detalhes (glyphs Unicode mais altos), (2) bordas entre secoes quase invisiveis (stone-100). Fix: glyph wrap span com inline-flex + font-size 12px + line-height 1. Bordas stone-100 -> stone-200 dentro do portal.