### PR TITLE
fix(financeiro/css): border-stone-100 visivel em todo .fin-cowork (Onda 24)

### DIFF
--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -446,6 +446,19 @@
  * pega só drawers (Sheet shadcn portal). NÃO afeta .fin-cowork da página
  * principal (já tem vars vindos do .cockpit ancestor com inline style).
  * ============================================================================ */
+
+/* Onda 24 (2026-05-20) — Border bump global pra todas páginas Financeiro/*.
+   `border-stone-100` (oklch 0.97) era quase invisível contra bg-white. Usado
+   em 26 arquivos × 50 ocorrências do projeto inteiro — separador entre seções
+   drawer/grid/card/footer. Override pra oklch 0.92 (= stone-200) só dentro de
+   .fin-cowork wrapper, atinge: Conciliacao, PlanoContas, Unificado, Fluxo,
+   Cobranca, e drawers nestes módulos. Wagner aprovou escopo Financeiro/
+   via AskUser 2026-05-20. Outras áreas (Vendas/Produto/Purchase) decidem
+   caso a caso depois — risco de border-stone-100 ser intencional sutil. */
+.fin-cowork .border-stone-100 {
+  border-color: oklch(0.92 0.005 80) !important;
+}
+
 /* Onda 23 (2026-05-20) — alinhar glyphs Unicode (✦ ✎) com texto nos tabs.
    Glyphs Unicode tem altura visual diferente das letras — wrap em span com
    font-size menor + line-height: 1 + inline-flex align-items: center

--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -173,28 +173,25 @@
   height: 36px;
   display: block;
 }
-/* Sparkline em fundo absoluto pro KPI hero (atrás do texto) */
-/* Onda 6 (2026-05-20): pointer-events none no SVG container PERMITE click-through
-   no hero card MAS hotspot circles por ponto têm pointer-events:auto inline,
-   ativam title nativo do browser ao hover (tooltip "DD/MM · saldo X · +in / -out"). */
+/* Onda 9 (2026-05-20 Wagner "encaixar melhor"): sparkline volta pro FLOW NORMAL
+   ABAIXO do hint (não mais absolute background). Match canon fin-boletos.css:96:
+     width calc(100% + 24px); margin-left -12px (sangra bordas card);
+     margin-top 8px; height 32px; opacity 0.85 (VISÍVEL como info-graphic).
+   Anterior era position absolute bottom 0 opacity 0.35 — escondido atrás do texto. */
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  margin-top: 0;
-  height: 56px;
-  opacity: 0.35;
-  pointer-events: none;
-  z-index: 0;
+  position: relative;
+  width: calc(100% + 24px);
+  margin: 8px -12px 0;
+  height: 32px;
+  opacity: 0.85;
+  display: block;
 }
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark circle {
   pointer-events: auto;
 }
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark:hover {
-  opacity: 0.55;
+  opacity: 1;
 }
-.fin-cowork .fin-curadoria .fin-stat-hero > * { position: relative; z-index: 1; }
 /* ─────────────────────────────────────────────────────────────
  * Toolbar (filter chips + density + search)
  * ───────────────────────────────────────────────────────────── */


### PR DESCRIPTION
Border-stone-100 cronico em 50 lugares × 26 arquivos. Wagner aprovou override escopado a .fin-cowork via AskUser. Atinge todas paginas Financeiro/ (Conciliacao, PlanoContas, Unificado, Fluxo, Cobranca) + drawers.