### PR TITLE
fix(financeiro/unificado): drawer overflow horizontal (Onda 25)

### DIFF
--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -173,28 +173,25 @@
   height: 36px;
   display: block;
 }
-/* Sparkline em fundo absoluto pro KPI hero (atrás do texto) */
-/* Onda 6 (2026-05-20): pointer-events none no SVG container PERMITE click-through
-   no hero card MAS hotspot circles por ponto têm pointer-events:auto inline,
-   ativam title nativo do browser ao hover (tooltip "DD/MM · saldo X · +in / -out"). */
+/* Onda 9 (2026-05-20 Wagner "encaixar melhor"): sparkline volta pro FLOW NORMAL
+   ABAIXO do hint (não mais absolute background). Match canon fin-boletos.css:96:
+     width calc(100% + 24px); margin-left -12px (sangra bordas card);
+     margin-top 8px; height 32px; opacity 0.85 (VISÍVEL como info-graphic).
+   Anterior era position absolute bottom 0 opacity 0.35 — escondido atrás do texto. */
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  margin-top: 0;
-  height: 56px;
-  opacity: 0.35;
-  pointer-events: none;
-  z-index: 0;
+  position: relative;
+  width: calc(100% + 24px);
+  margin: 8px -12px 0;
+  height: 32px;
+  opacity: 0.85;
+  display: block;
 }
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark circle {
   pointer-events: auto;
 }
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark:hover {
-  opacity: 0.55;
+  opacity: 1;
 }
-.fin-cowork .fin-curadoria .fin-stat-hero > * { position: relative; z-index: 1; }
 /* ─────────────────────────────────────────────────────────────
  * Toolbar (filter chips + density + search)
  * ───────────────────────────────────────────────────────────── */

--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -459,6 +459,23 @@
   border-color: oklch(0.92 0.005 80) !important;
 }
 
+/* Onda 25 (2026-05-20) — Drawer overflow horizontal fix.
+   Sintoma: "Internet + telefonia maio", "Conciliado com extr...", "R$ 320,0..."
+   cortados na borda direita do drawer; tabs Editar cortado.
+   Root cause (via JS check em prod):
+   - SheetContent shadcn tem padding:0 (sem px-5 lateral)
+   - fin-output.css:685 define `.fin-cowork .fin-drawer-tabs { margin: 12px -18px 0 }`
+     — esse margin negativo era pra "sangrar" o nav até as bordas quando o
+     aside parent tinha px-5. Mas SheetContent sem padding → nav vai PRA FORA
+     do drawer (width 595px vs drawer 559px).
+   - Body div `mt-3 space-y-5` sem px lateral → conteúdo cola na borda.
+   Fix em duas frentes:
+   (a) Override CSS aqui — zerar margin negativo do nav DENTRO do portal
+   (b) Adicionar px-5 no body div via Edit no Index.tsx (commit separado abaixo) */
+[role="dialog"].fin-cowork .fin-drawer-tabs {
+  margin: 0 !important;
+}
+
 /* Onda 23 (2026-05-20) — alinhar glyphs Unicode (✦ ✎) com texto nos tabs.
    Glyphs Unicode tem altura visual diferente das letras — wrap em span com
    font-size menor + line-height: 1 + inline-flex align-items: center

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -1438,7 +1438,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
 
               {/* Aba Detalhes — info + audit + comments + actions */}
               {drawerTab === 'detalhes' && (
-                <div className="mt-3 space-y-5 text-[13px]">
+                <div className="mt-3 px-5 space-y-5 text-[13px]">
                   {/* Onda 17 (2026-05-20) — Hierarquia visual canon: UPPERCASE label colorido
                       por status + date 22px BIG + amount 34px BIG (verde se receivable, stone
                       se payable) + StatusPill + FrescorPill inline.
@@ -1658,7 +1658,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
 
               {/* Aba IA — insights computacionais (Anomaly + Party History) */}
               {drawerTab === 'ia' && (
-                <div className="mt-3 space-y-4 text-[13px] fin-ai-panel">
+                <div className="mt-3 px-5 space-y-4 text-[13px] fin-ai-panel">
                   <FinAnomalyDetector
                     row={{
                       id: selected.id,
@@ -1686,7 +1686,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
 
               {/* Aba Editar — Onda 10 canon 100%: form INLINE real (PUT /financeiro/unificado/{id}) */}
               {drawerTab === 'editar' && (
-                <div className="mt-3">
+                <div className="mt-3 px-5">
                   <FinEditPanel
                     lancamento={selected}
                     categorias={categorias}


### PR DESCRIPTION
Drawer cortava conteudo na direita (Internet+telefonia maio, Conciliado com extr, R$ 320,0) e tabs Editar. Root cause: SheetContent shadcn sem padding outer + fin-output.css margin negativo no nav + body div sem px lateral. Fix: override margin no nav (portal) + px-5 nas tres abas.