### PR TITLE
feat(financeiro/css): px-5 no .fin-curadoria (Onda 26)

### DIFF
--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -476,6 +476,17 @@
   margin: 0 !important;
 }
 
+/* Onda 26 (2026-05-20) — Páginas Financeiro/* respiram nas laterais.
+   Page wrapper .fin-curadoria estava com padding:0 — KPI strip, sparkline,
+   filters chips e tabela todos colando no edge esquerdo (sidebar) e direito
+   (viewport). Aplicar px-5 (20px) no .fin-curadoria igual ao que Wagner
+   aprovou no drawer (Onda 25). Wagner aprovou escopo .fin-curadoria via
+   AskUser 2026-05-20. */
+.fin-cowork .fin-curadoria {
+  padding-left: 20px;
+  padding-right: 20px;
+}
+
 /* Onda 23 (2026-05-20) — alinhar glyphs Unicode (✦ ✎) com texto nos tabs.
    Glyphs Unicode tem altura visual diferente das letras — wrap em span com
    font-size menor + line-height: 1 + inline-flex align-items: center

--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -173,28 +173,25 @@
   height: 36px;
   display: block;
 }
-/* Sparkline em fundo absoluto pro KPI hero (atrás do texto) */
-/* Onda 6 (2026-05-20): pointer-events none no SVG container PERMITE click-through
-   no hero card MAS hotspot circles por ponto têm pointer-events:auto inline,
-   ativam title nativo do browser ao hover (tooltip "DD/MM · saldo X · +in / -out"). */
+/* Onda 9 (2026-05-20 Wagner "encaixar melhor"): sparkline volta pro FLOW NORMAL
+   ABAIXO do hint (não mais absolute background). Match canon fin-boletos.css:96:
+     width calc(100% + 24px); margin-left -12px (sangra bordas card);
+     margin-top 8px; height 32px; opacity 0.85 (VISÍVEL como info-graphic).
+   Anterior era position absolute bottom 0 opacity 0.35 — escondido atrás do texto. */
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark {
-  position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  margin-top: 0;
-  height: 56px;
-  opacity: 0.35;
-  pointer-events: none;
-  z-index: 0;
+  position: relative;
+  width: calc(100% + 24px);
+  margin: 8px -12px 0;
+  height: 32px;
+  opacity: 0.85;
+  display: block;
 }
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark circle {
   pointer-events: auto;
 }
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark:hover {
-  opacity: 0.55;
+  opacity: 1;
 }
-.fin-cowork .fin-curadoria .fin-stat-hero > * { position: relative; z-index: 1; }
 /* ─────────────────────────────────────────────────────────────
  * Toolbar (filter chips + density + search)
  * ───────────────────────────────────────────────────────────── */


### PR DESCRIPTION
Pos Onda 25 drawer respirando, Wagner aprovou pattern pra pagina inteira. Padding 20px lateral no .fin-curadoria — KPI strip, sparkline, filters, tabela ganham respiro do edge.