### PR TITLE
fix(canon): alinhar CLAUDE.md + SPEC ao estado real Charter S4 (Onda 4 C1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 
 1. `brief-fetch` → estado consolidado (~3k tokens) — Tier A always-on via hook `SessionStart`
 2. `my-work` → minhas tasks ativas
-3. (S4+) `charter-fetch <page-id>` antes de editar `.tsx` que tenha `.charter.md` ao lado
+3. `charter-fetch <page-id>` antes de editar `.tsx` que tenha `.charter.md` ao lado (ativo desde 2026-05-13 — Onda 4 C1)
 4. Trabalhar (ler código, edit, test)
 5. (S5+) `decide(domain, intent, payload)` se mudança custosa
 6. Commit conventional + `Refs: SPRINT-N PASSO M` (skill `commit-discipline` Tier A)
@@ -34,7 +34,7 @@
 - **commit-discipline** — 1 PR = 1 intent, ≤300 linhas, conventional commits
 - **mwart-process** — único caminho de migração Blade→Inertia (5 fases obrigatórias) — [ADR 0104](memory/decisions/0104-processo-mwart-canonico-unico-caminho.md)
 - **mwart-comparative V4** — gate visual F1.5 + F3 estado-da-arte + loop Cowork ↔ Claude Code formalizado em [`prototipo-ui/PROTOCOL.md`](prototipo-ui/PROTOCOL.md). Orquestra Claude Design plugin Anthropic (design-critique + design-system + design-handoff + ux-copy + accessibility-review + research-synthesis). 15 dimensões + Wagner aprova SCREENSHOT (não tabela) — [ADR 0114](memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md) + [ADR 0107](memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md) + [ADR 0109](memory/decisions/0109-claude-design-plugin-integrado-processo-mwart.md)
-- (dormente — S4) **charter-first**
+- **charter-first** — ativo desde 2026-05-13 (Onda 4 C1) · tool MCP `charter-fetch` + hook `charter-validate` warning-mode · ver [CHARTER-S4-DOSSIER-2026-05-20.md](memory/requisitos/Jana/CHARTER-S4-DOSSIER-2026-05-20.md)
 - (S5 antecipado pra ~30/maio/2026 — [ADR 0106](memory/decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md)) **ads-route**
 
 > **Estimates 2026-05-08+:** todos novos SPECs nascem recalibrados ([ADR 0106](memory/decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md)) — fator 10x em tarefas codáveis com IA-pair + margem 2x; tarefas humano-limitadas (canary 7d, monitor 30d, smoke real) mantém relógio do mundo real.

--- a/memory/requisitos/Jana/SPEC.md
+++ b/memory/requisitos/Jana/SPEC.md
@@ -950,8 +950,9 @@ Entregar Jana V2 demo navegável (goal #4 CYCLE-06 — alvo: 1 cliente piloto ap
 
 ### US-COPI-109 · Onda 4 C1 — Charters S4 ativos (charter-fetch tool + Tier A)
 
-> owner: wagner · priority: p0 · estimate: 12h IA-pair (1.5d) · status: todo · type: story · sprint: CYCLE-06
+> owner: wagner · priority: p0 · estimate: ~~12h~~ **4-6h restantes** IA-pair · status: **em-implementacao 75%** · type: story · sprint: CYCLE-06
 > blocked_by: — · spawned_from: JANA-10X-018 (GAP-ANALYSIS-91-100 §2 + ONDA-5-DOSSIER §4)
+> **STATUS REAL (descoberto 2026-05-20 audit-senior-expert):** `CharterFetchTool.php` (415 linhas, registrada `OimpressoMcpServer.php:124`) + skill `charter-first` promovida `tier:A enabled:true` + hook `charter-validate.{ps1,sh}` registrado + 10 Pest + RUNBOOK existem desde **2026-05-13**. **Falta:** (a) fix CLAUDE.md:37 que ainda diz "dormente" — desalinhamento Tier 0 doc bloqueia adoção · (b) `memory/requisitos/_DesignSystem/CHARTERS-INDEX.md` listando 112 charters · (c) ADR amendment proposta NNNN. Ver **[CHARTER-S4-DOSSIER-2026-05-20.md](CHARTER-S4-DOSSIER-2026-05-20.md)** (587 linhas, decomposição 3 PRs ≤200 linhas).
 
 **Como** Claude (agent) + time MCP (Felipe/Maira/Eliana)
 **Quero** tool MCP `charter-fetch <page-id>` exposta + skill `charter-first` Tier A ativa via hook SessionStart, BLOQUEANDO Edit/Write em `resources/js/Pages/**/*.tsx` que tenha `.charter.md` correspondente sem carregar charter primeiro


### PR DESCRIPTION
## Summary — 🚨 Quick-win Tier 0

**Descoberta audit-senior-expert 2026-05-20:** US-COPI-109 (Onda 4 C1 Charters S4) foi **75% implementada em 2026-05-13** mas [CLAUDE.md:37](CLAUDE.md#L37) (Tier 0 doc lido em TODA sessão via @import) ainda declara `(dormente — S4) **charter-first**`. Todos PRs/agents leem isso primeiro, **inferem skill dormente, NUNCA chamam tool charter-fetch**.

**ROI 0% real desde 2026-05-13** mesmo com infra pronta:
- `CharterFetchTool.php` (415 linhas, registrada `OimpressoMcpServer.php:124`)
- Skill `charter-first` promovida `tier:A enabled:true plena_ativacao:2026-05-13`
- Hook `charter-validate.{ps1,sh}` registrado `.claude/settings.json:54`
- 10 Pest cobertura + RUNBOOK-charters-s4-ativacao

**Single-line fix destrava entrega Onda 4 C1 inteira.**

## Diff (2 arquivos, 4 insertions/3 deletions)

- [CLAUDE.md:22](CLAUDE.md#L22): `(S4+) charter-fetch` → `charter-fetch (ativo desde 2026-05-13 — Onda 4 C1)`
- [CLAUDE.md:37](CLAUDE.md#L37): `(dormente — S4) **charter-first**` → `**charter-first** — ativo desde 2026-05-13 (Onda 4 C1) · tool MCP charter-fetch + hook charter-validate warning-mode · ver CHARTER-S4-DOSSIER`
- [memory/requisitos/Jana/SPEC.md](memory/requisitos/Jana/SPEC.md) US-COPI-109: bloco **STATUS REAL** apontando 75% pronto + esforço refinado **4-6h restantes** (não 12h) + link pro dossier

## NÃO mexe

Código (Tool / skill SKILL.md / hook script / Pest) — só alinhamento canônico dos docs Tier 0 com realidade já implementada. Dossier completo `CHARTER-S4-DOSSIER-2026-05-20.md` (587 linhas) vai em PR #2 separado pra respeitar commit-discipline ≤300.

## Tier 0 sign-off

CLAUDE.md raiz é Tier 0 doc — mudança aqui pede sign-off Wagner. Por isso PR explicita: **correção factual** (skill JÁ tier:A no SKILL.md desde 2026-05-13), não decisão arquitetural nova.

## Test plan

- [x] `bash .github/scripts/validate-memory-schema.sh spec memory/requisitos/Jana/SPEC.md` — 0 erros
- [x] commit-discipline ≤300 (4 insertions / 3 deletions)
- [ ] Pós-merge: próxima sessão Claude lê CLAUDE.md novo → skill `charter-first` aparece como Tier A ativa → tool `charter-fetch` é chamada ao editar `.tsx`

🤖 Generated with [Claude Code](https://claude.com/claude-code)