### PR TITLE
revert(canon): CLAUDE.md L22+L37 voltam ao estado dormente (Wagner reverteu)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 
 1. `brief-fetch` → estado consolidado (~3k tokens) — Tier A always-on via hook `SessionStart`
 2. `my-work` → minhas tasks ativas
-3. `charter-fetch <page-id>` antes de editar `.tsx` que tenha `.charter.md` ao lado (ativo desde 2026-05-13 — Onda 4 C1)
+3. (S4+) `charter-fetch <page-id>` antes de editar `.tsx` que tenha `.charter.md` ao lado
 4. Trabalhar (ler código, edit, test)
 5. (S5+) `decide(domain, intent, payload)` se mudança custosa
 6. Commit conventional + `Refs: SPRINT-N PASSO M` (skill `commit-discipline` Tier A)
@@ -34,7 +34,7 @@
 - **commit-discipline** — 1 PR = 1 intent, ≤300 linhas, conventional commits
 - **mwart-process** — único caminho de migração Blade→Inertia (5 fases obrigatórias) — [ADR 0104](memory/decisions/0104-processo-mwart-canonico-unico-caminho.md)
 - **mwart-comparative V4** — gate visual F1.5 + F3 estado-da-arte + loop Cowork ↔ Claude Code formalizado em [`prototipo-ui/PROTOCOL.md`](prototipo-ui/PROTOCOL.md). Orquestra Claude Design plugin Anthropic (design-critique + design-system + design-handoff + ux-copy + accessibility-review + research-synthesis). 15 dimensões + Wagner aprova SCREENSHOT (não tabela) — [ADR 0114](memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md) + [ADR 0107](memory/decisions/0107-emendation-0104-visual-comparison-gate-f3.md) + [ADR 0109](memory/decisions/0109-claude-design-plugin-integrado-processo-mwart.md)
-- **charter-first** — ativo desde 2026-05-13 (Onda 4 C1) · tool MCP `charter-fetch` + hook `charter-validate` warning-mode · ver [CHARTER-S4-DOSSIER-2026-05-20.md](memory/requisitos/Jana/CHARTER-S4-DOSSIER-2026-05-20.md)
+- (dormente — S4) **charter-first**
 - (S5 antecipado pra ~30/maio/2026 — [ADR 0106](memory/decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md)) **ads-route**
 
 > **Estimates 2026-05-08+:** todos novos SPECs nascem recalibrados ([ADR 0106](memory/decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md)) — fator 10x em tarefas codáveis com IA-pair + margem 2x; tarefas humano-limitadas (canary 7d, monitor 30d, smoke real) mantém relógio do mundo real.


### PR DESCRIPTION
## Summary

**Revert cirúrgico** de [PR #1270](https://github.com/wagnerra23/oimpresso.com/pull/1270) commit `fc29c89b3` na parte CLAUDE.md (mantém SPEC.md US-COPI-109 fix).

**Por quê:** Wagner reverteu meu fix CLAUDE.md L22+L37 na worktree local sinalizando que não queria a mudança. Meu admin merge entrou antes da reversão ser vista — este PR propaga a reversão pra main.

## Diff (2 insertions / 2 deletions em 1 arquivo)

- [CLAUDE.md:22](CLAUDE.md#L22): `charter-fetch (ativo desde 2026-05-13 — Onda 4 C1)` → `(S4+) charter-fetch`
- [CLAUDE.md:37](CLAUDE.md#L37): `**charter-first** — ativo desde 2026-05-13 (Onda 4 C1) · tool + hook + dossier link` → `(dormente — S4) **charter-first**`

## Mantém em main

- [memory/requisitos/Jana/SPEC.md](memory/requisitos/Jana/SPEC.md) US-COPI-109 com bloco STATUS REAL (fato útil pro time — tool/skill/hook/Pest existem desde 2026-05-13, faltam só 4-6h não 12h)
- [memory/requisitos/Jana/CHARTER-S4-DOSSIER-2026-05-20.md](memory/requisitos/Jana/CHARTER-S4-DOSSIER-2026-05-20.md) intacto (PR #1271 mergeado limpo)

## Test plan

- [x] commit-discipline (2 insertions / 2 deletions)
- [x] `git show origin/main:CLAUDE.md | sed -n '22p;37p'` antes vs depois: confirma reversão precisa
- [ ] Pós-merge: worktree local + main em sync no estado dormente que Wagner quer

🤖 Generated with [Claude Code](https://claude.com/claude-code)