### PR TITLE
fix(financeiro): DRE — backend faltava pct_rl + delta_pct por linha (hotfix prod)

### DIFF
--- a/Modules/Financeiro/Services/DreService.php
+++ b/Modules/Financeiro/Services/DreService.php
@@ -246,6 +246,21 @@ class DreService
         $baseRL = (float) ($headerTotais['receita_liquida']['atual'] ?? 0.0);
         $baseRLPrev = (float) ($headerTotais['receita_liquida']['prev'] ?? 0.0);
 
+        // ───────── 6.5) Enriquecer linhas com pct_rl + delta_pct ─────────
+        // Hotfix 2026-05-20: frontend (Pages/Financeiro/Dre/Index.tsx) acessa
+        // `l.pct_rl.toFixed(1)` e `l.delta_pct.toFixed(0)` em CADA linha.
+        // `materializarLinhas()` só popula `v` + `prev` — sem isso, prod gera
+        // "TypeError: can't access property 'toFixed', t.pct_rl is undefined".
+        // Q2 (aprovada Wagner 2026-05-20): % RL com sinal preservado do numerador,
+        // base = Receita Líquida (subtotal). Q3: Δ% vs mês anterior literal.
+        foreach ($linhas as &$linha) {
+            $v = (float) ($linha['v'] ?? 0.0);
+            $prev = (float) ($linha['prev'] ?? 0.0);
+            $linha['pct_rl'] = $baseRL != 0.0 ? round(($v / $baseRL) * 100.0, 2) : 0.0;
+            $linha['delta_pct'] = $prev != 0.0 ? round((($v - $prev) / abs($prev)) * 100.0, 2) : 0.0;
+        }
+        unset($linha);
+
         // ───────── 7) Margem operacional ─────────
         $resOpAtual = (float) ($headerTotais['resultado_operacional']['atual'] ?? 0.0);
         $resOpPrev = (float) ($headerTotais['resultado_operacional']['prev'] ?? 0.0);

--- a/Modules/Financeiro/Tests/Feature/DreControllerTest.php
+++ b/Modules/Financeiro/Tests/Feature/DreControllerTest.php
@@ -256,3 +256,36 @@ it('aceita ?anchor=YYYY-MM e reflete em meta.anchor_mes', function () {
         ->where('meta.prev_mes', '2026-03')
     );
 });
+
+/**
+ * REGRESSION GUARD — hotfix 2026-05-20.
+ *
+ * Erro prod: "TypeError: can't access property 'toFixed', t.pct_rl is undefined"
+ * Causa: DreService::materializarLinhas() só populava `v` e `prev`. Frontend
+ * (Pages/Financeiro/Dre/Index.tsx) acessa `l.pct_rl.toFixed(1)` e `l.delta_pct.toFixed(0)`
+ * em CADA linha (header / item / subtotal). Faltava enrichment pós-baseRL.
+ *
+ * Este guard valida que TODA linha do payload tem `pct_rl` + `delta_pct` numéricos.
+ * Sem ele, a regressão pode voltar silenciosamente.
+ */
+it('cada linha do payload tem pct_rl e delta_pct numericos (regression guard)', function () {
+    $user = dreBootstrap();
+    $response = $this->actingAs($user)->get('/financeiro/dre');
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->has('linhas')
+        ->where('linhas', function (array $linhas) {
+            foreach ($linhas as $i => $linha) {
+                expect($linha)->toHaveKey('pct_rl', "linha[$i] sem pct_rl — frontend vai quebrar com toFixed undefined");
+                expect($linha)->toHaveKey('delta_pct', "linha[$i] sem delta_pct");
+                expect($linha['pct_rl'])->toBeNumeric("linha[$i].pct_rl deve ser numero (não null)");
+                expect($linha['delta_pct'])->toBeNumeric("linha[$i].delta_pct deve ser numero");
+            }
+            return true;
+        })
+    );
+});


### PR DESCRIPTION
## Bug em prod

Erro JS console reportado pelo Wagner via Firefox:

\`\`\`
Uncaught TypeError: can't access property \"toFixed\", t.pct_rl is undefined
    children https://oimpresso.com/build-inertia/assets/Index-xBZGz290.js:1
\`\`\`

Tela \`/financeiro/dre\` quebra ao renderizar tabela hierárquica.

## Causa raiz

\`DreService::materializarLinhas()\` (introduzido em #1276 wave DRE) só populava \`v\` + \`prev\` por linha (header/item/subtotal). Mas frontend \`Pages/Financeiro/Dre/Index.tsx\` acessa \`l.pct_rl.toFixed(1)\` e \`l.delta_pct.toFixed(0)\` em CADA linha. Faltava enrichment após o cálculo da base RL.

## Fix

Novo passo **6.5** no \`DreService::montar()\` — após calcular \`baseRL\`, itera \`linhas[]\` adicionando 2 campos por linha:

- **\`pct_rl\`** = \`(v / baseRL) * 100\` — com **sinal preservado do numerador** (Q2 aprovada Wagner 2026-05-20). Receitas em \`+\`, deduções/custos/despesas em \`-\`.
- **\`delta_pct\`** = \`((v - prev) / abs(prev)) * 100\` — vs mês anterior literal (Q3 aprovada).

Defensivos:
- divisor \`!= 0\` evita divisão por zero
- \`?? 0.0\` em \`v\`/\`prev\` tolera linha sem essas chaves (resiliência)

## Regression guard (Pest)

Novo teste em \`DreControllerTest\`:

\`\`\`php
it('cada linha do payload tem pct_rl e delta_pct numericos (regression guard)', function () {
    // ... assert every linha has pct_rl + delta_pct as numeric (toBeNumeric)
});
\`\`\`

Sem esse guard, a regressão pode voltar silenciosamente — o erro só aparece em browser (Pest CI sem DB faz skip gracioso, mas em prod com dados reais o erro reapareceria).

## Test plan

- [x] \`php -l\` no DreService → no syntax errors
- [x] Pest test adicionado (regression guard)
- [ ] **Smoke prod após merge:** Wagner reload \`/financeiro/dre\` → console limpo + tabela renderiza com % RL e Δ% visíveis

Refs: #1276 (PR B wave reaplicação DRE), Q2+Q3 aprovadas em [dre-visual-comparison.md](memory/requisitos/Financeiro/dre-visual-comparison.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)