### PR TITLE
fix(financeiro): DRE — shadow variable $prev no loop quebra Carbon (hotfix prod #2)

### DIFF
--- a/Modules/Financeiro/Services/DreService.php
+++ b/Modules/Financeiro/Services/DreService.php
@@ -253,13 +253,18 @@ class DreService
         // "TypeError: can't access property 'toFixed', t.pct_rl is undefined".
         // Q2 (aprovada Wagner 2026-05-20): % RL com sinal preservado do numerador,
         // base = Receita Líquida (subtotal). Q3: Δ% vs mês anterior literal.
-        foreach ($linhas as &$linha) {
-            $v = (float) ($linha['v'] ?? 0.0);
-            $prev = (float) ($linha['prev'] ?? 0.0);
-            $linha['pct_rl'] = $baseRL != 0.0 ? round(($v / $baseRL) * 100.0, 2) : 0.0;
-            $linha['delta_pct'] = $prev != 0.0 ? round((($v - $prev) / abs($prev)) * 100.0, 2) : 0.0;
+        //
+        // Hotfix 2026-05-20 #2: variáveis locais com nome distinto pra NÃO
+        // shadow `$prev` (Carbon do escopo `montarInternal()`) e `$v` (caso
+        // seja usado depois). O bug "mesLabelPtBr float given" vinha de
+        // `$prev` ter sido sobrescrita pelo último iteration deste loop.
+        foreach ($linhas as &$linhaRef) {
+            $linhaV = (float) ($linhaRef['v'] ?? 0.0);
+            $linhaPrev = (float) ($linhaRef['prev'] ?? 0.0);
+            $linhaRef['pct_rl'] = $baseRL != 0.0 ? round(($linhaV / $baseRL) * 100.0, 2) : 0.0;
+            $linhaRef['delta_pct'] = $linhaPrev != 0.0 ? round((($linhaV - $linhaPrev) / abs($linhaPrev)) * 100.0, 2) : 0.0;
         }
-        unset($linha);
+        unset($linhaRef);
 
         // ───────── 7) Margem operacional ─────────
         $resOpAtual = (float) ($headerTotais['resultado_operacional']['atual'] ?? 0.0);

--- a/Modules/Financeiro/Tests/Feature/DreControllerTest.php
+++ b/Modules/Financeiro/Tests/Feature/DreControllerTest.php
@@ -287,5 +287,10 @@ it('cada linha do payload tem pct_rl e delta_pct numericos (regression guard)', 
             }
             return true;
         })
+        // Hotfix 2026-05-20 #2: também validar que meta.periodo_label* são
+        // strings (e não cast de float vazado por shadow `$prev` no loop
+        // de enrichment pct_rl). Erro original: "mesLabelPtBr float given".
+        ->where('meta.periodo_label', fn ($v) => is_string($v) && $v !== '')
+        ->where('meta.periodo_label_prev', fn ($v) => is_string($v) && $v !== '')
     );
 });


### PR DESCRIPTION
## Bug em prod

Erro 500 Server Error em \`/financeiro/dre\` (Wagner reportou via Firefox). Laravel.log mostrou:

\`\`\`
DreService::mesLabelPtBr(): Argument #1 (\$date) must be of type
Illuminate\Support\Carbon, float given, called in
DreService.php on line 290
\`\`\`

## Causa raiz

PR #1277 introduziu loop com **shadow variable**:

\`\`\`php
foreach (\$linhas as &\$linha) {
    \$v = (float) (\$linha['v'] ?? 0.0);
    \$prev = (float) (\$linha['prev'] ?? 0.0);  // <<<<< SHADOW
    \$linha['pct_rl'] = \$baseRL != 0.0 ? round((\$v / \$baseRL) * 100.0, 2) : 0.0;
    \$linha['delta_pct'] = \$prev != 0.0 ? round(((\$v - \$prev) / abs(\$prev)) * 100.0, 2) : 0.0;
}
unset(\$linha);
\`\`\`

Mas \`\$prev\` no escopo externo (\`montarInternal()\`) era um **Carbon** (mês anterior, calculado por \`resolverMeses()\` linha 211). PHP \`foreach\` sem prefixo único sobrescreve a variável do escopo externo. Após o loop, \`\$prev\` ficou com o float do último iteration. Quando linha 291 chamou \`\$this->mesLabelPtBr(\$prev)\` → TypeError.

## Fix

Renomear variáveis locais do loop pra \`\$linhaRef\` / \`\$linhaV\` / \`\$linhaPrev\` (unset \`\$linhaRef\` no final). Sem mais shadow.

## Pest guard reforçado

Além de validar \`pct_rl\`/\`delta_pct\` numéricos, agora valida que \`meta.periodo_label\` e \`meta.periodo_label_prev\` são **strings não-vazias**. Catch direto desse bug específico se voltar.

## Test plan

- [x] PHP syntax OK
- [x] Pest guard ampliado
- [ ] **Smoke prod após deploy:** Wagner Ctrl+Shift+R em \`/financeiro/dre\` → tela renderiza completa sem 500 e sem TypeError JS

Refs: #1277 (introduziu shadow), reverte regression mantendo Q2+Q3 comportamento

🤖 Generated with [Claude Code](https://claude.com/claude-code)