### PR TITLE
feat(financeiro): Fase 1 deprecação legacy — esconder Expense + Account dropdowns quando Modules/Financeiro habilitado

### DIFF
--- a/app/Http/Middleware/AdminSidebarMenu.php
+++ b/app/Http/Middleware/AdminSidebarMenu.php
@@ -32,6 +32,23 @@ class AdminSidebarMenu
             $common_settings = !empty(session('business.common_settings')) ? session('business.common_settings') : [];
             $pos_settings = !empty(session('business.pos_settings')) ? json_decode(session('business.pos_settings'), true) : [];
 
+            // Wagner 2026-05-20 Fase 1 deprecação legacy — quando Modules/Financeiro
+            // está habilitado pro business + user tem permission, esconde dropdowns
+            // core "Despesas" (L498) e "Contas de pagamento" (L534) pra evitar
+            // duplicação de domínio. Dados não somem, deeplinks /expenses e /account
+            // continuam funcionando. Mesmo pattern de gate usado em
+            // Modules/Financeiro/Http/Controllers/DataController::modifyAdminMenu().
+            $financeiro_module_util = new ModuleUtil();
+            if (auth()->user()->can('superadmin')) {
+                $financeiro_enabled = $financeiro_module_util->isModuleInstalled('Financeiro');
+            } else {
+                $financeiro_enabled = (bool) $financeiro_module_util->hasThePermissionInSubscription(
+                    session('user.business_id'),
+                    'financeiro_module',
+                    'superadmin_package'
+                ) && auth()->user()->can('financeiro.access');
+            }
+
             $is_admin = auth()->user()->hasRole('Admin#' . session('business.id')) ? true : false;
             //Home
             //     $menu->url(action([\App\Http\Controllers\HomeController::class, 'index']), __('home.home'), ['icon' => '<svg aria-hidden="true" class="tw-size-5 tw-shrink-0" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
@@ -483,7 +500,9 @@ class AdminSidebarMenu
             //Expense dropdown
             // Visibilidade per-business via $enabled_modules (vem do package
             // subscription do business) + permission Spatie. NUNCA hardcode biz=N.
-            if (in_array('expenses', $enabled_modules) && (auth()->user()->can('all_expense.access') || auth()->user()->can('view_own_expense'))) {
+            // Wagner 2026-05-20 Fase 1: escondido quando Modules/Financeiro habilitado
+            // (substituído por Contas a Pagar + Visão Unificada + Categorias do Financeiro).
+            if (in_array('expenses', $enabled_modules) && (auth()->user()->can('all_expense.access') || auth()->user()->can('view_own_expense')) && ! $financeiro_enabled) {
                 $menu->dropdown(
                     __('expense.expenses'),
                     function ($sub) {
@@ -519,7 +538,9 @@ class AdminSidebarMenu
                 )->order(45);
             }
             //Accounts dropdown
-            if (auth()->user()->can('account.access') && in_array('account', $enabled_modules)) {
+            // Wagner 2026-05-20 Fase 1: escondido quando Modules/Financeiro habilitado
+            // (substituído por Contas Bancárias + Fluxo de Caixa + DRE do Financeiro).
+            if (auth()->user()->can('account.access') && in_array('account', $enabled_modules) && ! $financeiro_enabled) {
                 $menu->dropdown(
                     __('lang_v1.payment_accounts'),
                     function ($sub) {


### PR DESCRIPTION
## Summary

Wagner 2026-05-20 aprovou **Fase 1** do roadmap de deprecação do legacy core UltimatePOS. Quando `Modules/Financeiro` está habilitado pro business (via subscription package + user com permission `financeiro.access`), esconde os 2 dropdowns core que duplicariam domínio.

## O que muda no sidebar

### Antes (com Financeiro habilitado)
```
└─ Despesas ▾ (core legacy)        ← duplicava Contas a Pagar + Categorias
└─ Contas de pagamento ▾ (core)    ← duplicava Contas Bancárias + Fluxo + DRE
└─ FINANCEIRO · OPERAÇÃO ▾         ← novo
└─ FINANCEIRO · ANÁLISE ▸
└─ FINANCEIRO · AJUSTES ▸
```

### Depois (com Financeiro habilitado)
```
└─ FINANCEIRO · OPERAÇÃO ▾  (5 entradas, aberto)
└─ FINANCEIRO · ANÁLISE ▸   (3 entradas)
└─ FINANCEIRO · AJUSTES ▸   (4 entradas)
```

Businesses **sem** `Modules/Financeiro` habilitado continuam vendo Despesas + Contas de pagamento legacy como antes (zero regressão pra clientes legacy).

## Mapeamento legacy → canônico

| Dropdown legacy escondido | Substituído por |
|---|---|
| `Despesas → Lista` | `/financeiro/contas-pagar` ou `/financeiro/unificado?tipo=pagar` |
| `Despesas → Adicionar` | `/financeiro/unificado/novo` |
| `Despesas → Categorias` | `/financeiro/categorias` |
| `Contas de pagamento → Lista (Accounts)` | `/financeiro/contas-bancarias` |
| `Contas de pagamento → Balance Sheet` | `/financeiro/dre` (parcial — Fase 4 absorve completo) |
| `Contas de pagamento → Trial Balance` | `/financeiro/dre` (parcial — Fase 4) |
| `Contas de pagamento → Cash Flow` | `/financeiro/fluxo` (Fase 3 unifica tabs Projetado+Realizado) |
| `Contas de pagamento → Payment Report` | `/financeiro/extrato/{contaBancariaId}` |

**DADOS NÃO SOMEM.** Deeplinks `/expenses` e `/account` continuam funcionando pra quem bookmarkou. Backlog Fase 2 faz redirects 301.

## Implementação

Variável `$financeiro_enabled` criada **uma vez** no escopo do `Menu::create` usando o **mesmo pattern** do `Modules/Financeiro/Http/Controllers/DataController::modifyAdminMenu()` (linhas 67-77 + 90) pra garantir consistência:

```php
$financeiro_module_util = new ModuleUtil();
if (auth()->user()->can('superadmin')) {
    $financeiro_enabled = $financeiro_module_util->isModuleInstalled('Financeiro');
} else {
    $financeiro_enabled = (bool) $financeiro_module_util->hasThePermissionInSubscription(
        session('user.business_id'),
        'financeiro_module',
        'superadmin_package'
    ) && auth()->user()->can('financeiro.access');
}
```

Cada `if` legacy ganha `&& ! \$financeiro_enabled` no final.

## Decisões técnicas

- **Tier 0 multi-tenant:** N/A — sidebar UI, sem query DB. Cada user vê seu próprio estado de \$financeiro_enabled (derivado de session+permission, multi-tenant-safe)
- **Blast radius:** muito baixo — apenas 2 dropdowns escondidos pra businesses com Financeiro habilitado; businesses sem Financeiro continuam vendo o legacy como antes
- **Reversível:** remover 1 linha (\`&& ! \$financeiro_enabled\`) reverte o gate
- **+23/-2 linhas** em 1 arquivo

## Test plan

- [ ] Business **com** Financeiro habilitado + user com \`financeiro.access\`: sidebar NÃO mostra "Despesas" nem "Contas de pagamento"
- [ ] Business **sem** Financeiro habilitado: sidebar continua mostrando "Despesas" + "Contas de pagamento" como hoje (regressão zero)
- [ ] Superadmin sem business: vê comportamento baseado em `isModuleInstalled('Financeiro')` (server-level)
- [ ] User com Financeiro mas SEM permission \`financeiro.access\`: vê o legacy (porque \$financeiro_enabled=false → gate não dispara). Esse user provavelmente NÃO tem permission \`account.access\` ou \`expense.access\` também, então não verá nada — pattern consistente
- [ ] Deeplink \`/expenses\` (URL direto) continua funcionando (rota não removida)
- [ ] Deeplink \`/account/cash-flow\` continua funcionando

## Próximas fases (backlog)

- **Fase 2:** redirects 301 \`/expenses/*\` → \`/financeiro/unificado\`, \`/account/cash-flow\` → \`/financeiro/fluxo\`, \`/account/balance-sheet\` → \`/financeiro/dre\`
- **Fase 3:** Fluxo de Caixa com tabs Projetado/Realizado (absorve Cash Flow legacy)
- **Fase 4:** DRE absorve Balance Sheet + Trial Balance via tabs
- **Fase 5:** Bridge SQL Eliana — migrar transactions tipo expense pra fin_titulos AP com categoria via Plano de Contas

Refs: roadmap Financeiro arquitetura-alvo Fase 1/5 (sessão Wagner 2026-05-20)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Infra Contract

> Mudança em `app/Http/Middleware/AdminSidebarMenu.php` — conditional render de sidebar (UI), não rota HTTP nova. Validação combinada: HTTP smoke (rotas legacy continuam vivas) + visual smoke (sidebar não mostra dropdowns escondidos).

### 1. Happy path — rotas legacy continuam respondendo (sem regressão de URL)

Esconder o menu NÃO remove as rotas; deeplinks bookmarkados precisam continuar funcionando.

```bash
$ curl -sv https://oimpresso.com/expenses 2>&1 | grep '^< HTTP\|^< Location'
< HTTP/1.1 302
< Location: https://oimpresso.com/login    # se não autenticado (esperado)

$ curl -sv https://oimpresso.com/account 2>&1 | grep '^< HTTP\|^< Location'
< HTTP/1.1 302
< Location: https://oimpresso.com/login

$ curl -sv https://oimpresso.com/account/cash-flow 2>&1 | grep '^< HTTP\|^< Location'
< HTTP/1.1 302
< Location: https://oimpresso.com/login
```

### 2. Regression adjacent — rotas Financeiro canônicas inalteradas

```bash
$ curl -sv https://oimpresso.com/financeiro/unificado 2>&1 | grep '^< HTTP'
< HTTP/1.1 302

$ curl -sv https://oimpresso.com/financeiro/contas-bancarias 2>&1 | grep '^< HTTP'
< HTTP/1.1 302

$ curl -sv https://oimpresso.com/home 2>&1 | grep '^< HTTP'
< HTTP/1.1 302   # rota não-financeiro, sidebar deve ficar intacta pra outros módulos
```

### 3. Environment delta — Pest local NÃO valida sidebar render

**Pest local + smoke Herd NÃO provam prod.** Mudança é em conditional render do Menu facade (`Menu::create('admin-sidebar-menu')`):

- [ ] Pest local não exercita o middleware `AdminSidebarMenu` via render Inertia autenticado real
- [ ] `Request::create()` em Pest não reproduz session `business.enabled_modules` + permission Spatie em conjunto
- [ ] OPcache no Hostinger pode cachear bytecode antigo — exigir `optimize:clear` + `opcache_reset` pós-deploy
- [ ] LSCache (LiteSpeed) pode servir HTML stale do dashboard — exigir purge ou aguardar TTL

Validação real exige login no Hostinger biz=4 ROTA LIVRE (Financeiro habilitado) + inspecionar HTML do sidebar:
- DEVE **não conter** texto `"Despesas"` no link/dropdown principal
- DEVE **não conter** texto `"Contas de pagamento"` no link/dropdown principal
- DEVE conter os 3 cabeçalhos `"FINANCEIRO · OPERAÇÃO"`, `"FINANCEIRO · ANÁLISE"`, `"FINANCEIRO · AJUSTES"`

### 4. Smoke prod pós-deploy (preencher após deploy SSH Hostinger)

```bash
# (preencher pós deploy com timestamp + saída real)
$ curl -sv https://oimpresso.com/expenses 2>&1 | grep '^< HTTP\|^< Location'
$ curl -sv https://oimpresso.com/financeiro/unificado 2>&1 | grep '^< HTTP'
```

| Caso | Esperado | Observado | OK |
|---|---|---|---|
| `/expenses` (rota legacy preservada) | `302 → /login` | _pendente_ | ⏳ |
| `/account/cash-flow` (rota legacy preservada) | `302 → /login` | _pendente_ | ⏳ |
| `/financeiro/unificado` (canon) | `302 → /login` | _pendente_ | ⏳ |
| Visual sidebar biz=4 logado | sem "Despesas" + sem "Contas de pagamento" + 3 sub-grupos Financeiro | _pendente_ | ⏳ |
