### PR TITLE
feat(financeiro): Fase 5.5 — TituloAutoService auto-sync para type=expense (Observer cobre novas expenses)

### DIFF
--- a/Modules/Financeiro/Services/TituloAutoService.php
+++ b/Modules/Financeiro/Services/TituloAutoService.php
@@ -19,7 +19,13 @@ use Modules\Financeiro\Models\TituloBaixa;
  * Origens suportadas:
  *  - 'venda'   — Transaction type='sell'     + payment_status in ('due','partial')
  *  - 'compra'  — Transaction type='purchase' + payment_status in ('due','partial')
- *  - 'despesa' — Transaction type='expense'  (futuro / onda 3)
+ *  - 'despesa' — Transaction type='expense'  (Fase 5.5 deprecação legacy, 2026-05-21)
+ *
+ * Diferença EXPENSE vs SELL/PURCHASE no payment_status:
+ *  - sell/purchase com payment_status='paid' → cancelarSeExistir (não vira título)
+ *  - expense com payment_status='paid' → cria fin_titulo com status='quitado',
+ *    valor_aberto=0 (Eliana DRE precisa ver despesa histórica paga ou não).
+ *    Mesma filosofia do BridgeExpenseToTitulosCommand (Fase 5).
  *
  * Numeração: sequencial business-isolado com prefixo (R000001 receber / P000001 pagar),
  * gerado com lockForUpdate pra evitar dupla numeração em concorrência.
@@ -29,14 +35,19 @@ use Modules\Financeiro\Models\TituloBaixa;
  *
  * Onda 2 (2026-04-25): + suporte purchase + numeração R/P + baixa automática
  * via registrarPagamento/cancelarPagamento (TransactionPayment).
+ * Fase 5.5 (2026-05-21): + suporte expense → Observer cobre novas expenses
+ * automaticamente (F5 backfill cobre histórico via comando artisan).
  */
 class TituloAutoService
 {
     /**
-     * Cria ou atualiza Titulo a partir de Transaction (sell ou purchase).
-     * No-op se transaction não for sell/purchase ou se já estiver paga.
+     * Cria ou atualiza Titulo a partir de Transaction (sell, purchase ou expense).
+     * No-op se transaction não for sell/purchase/expense.
+     * Para sell/purchase quitada no caixa (payment_status='paid'), cancela o título.
+     * Para expense quitada, cria com status='quitado' (Eliana DRE precisa ver paga).
      *
      * Onda 2: este é o ponto de entrada canônico (renomeado de sincronizarDeVenda).
+     * Fase 5.5: + type='expense'.
      */
     public function sincronizarDeTransacao(Transaction $tx): ?Titulo
     {
@@ -55,6 +66,7 @@ class TituloAutoService
         $tipo = match ($tx->type) {
             'sell' => 'receber',
             'purchase' => 'pagar',
+            'expense' => 'pagar',
             default => null,
         };
 
@@ -62,15 +74,29 @@ class TituloAutoService
             return null;
         }
 
-        // Transação paga em dia (status='paid') não gera título financeiro.
-        if (! in_array($tx->payment_status, ['due', 'partial'], true)) {
+        // Filosofia divergente sell/purchase vs expense (Fase 5.5 2026-05-21):
+        //  - sell/purchase com payment_status='paid' → cancelarSeExistir (não vira título;
+        //    "pagou no caixa, não cria conta a receber/pagar pendente")
+        //  - expense com payment_status='paid' → cria fin_titulo com status='quitado'
+        //    pra Eliana ver DRE histórica (mesma regra do BridgeExpenseToTitulosCommand F5)
+        if ($tx->type !== 'expense' && ! in_array($tx->payment_status, ['due', 'partial'], true)) {
             return $this->cancelarSeExistir($tx, motivo: 'transação quitada no caixa');
         }
 
-        $origem = $tx->type === 'sell' ? 'venda' : 'compra';
+        $origem = match ($tx->type) {
+            'sell' => 'venda',
+            'purchase' => 'compra',
+            'expense' => 'despesa',
+        };
 
         $valorTotal = (float) $tx->final_total;
-        $valorAberto = (float) ($tx->total_remaining_amount ?? $tx->final_total);
+        // Pra expense paga: valor_aberto = 0 (mesma regra do bridge F5).
+        // Pra sell/purchase paga/parcial: usa total_remaining_amount.
+        if ($tx->type === 'expense' && $tx->payment_status === 'paid') {
+            $valorAberto = 0.0;
+        } else {
+            $valorAberto = (float) ($tx->total_remaining_amount ?? $tx->final_total);
+        }
         $valorPago = $valorTotal - $valorAberto;
 
         return DB::transaction(function () use ($tx, $tipo, $origem, $valorTotal, $valorAberto, $valorPago) {
@@ -87,13 +113,18 @@ class TituloAutoService
             $numero = $existing?->numero ?? $this->proximoNumero($tx->business_id, $tipo);
 
             // Onda Edit 2026-05-18 — cross-link auto-pop em `cliente_descricao`.
-            // Formato: "{ContactName} · #V-{txId}" (venda) ou "{ContactName} · #PC-{txId}" (compra).
+            // Formato: "{ContactName} · #V-{txId}" (venda), "{ContactName} · #PC-{txId}" (compra),
+            // "{ContactName} · #E-{txId}" (despesa, Fase 5.5).
             // FinCrossLinkify (frontend) parseia esses tokens e renderiza pills clicáveis
-            // que roteiam pro Sells/Compras de origem. Preserva edit manual do user:
+            // que roteiam pro Sells/Compras/Expenses de origem. Preserva edit manual do user:
             // se $existing já tem cliente_descricao preenchido, NÃO sobrescreve.
             $cliente = $tx->contact_id ? \App\Contact::find($tx->contact_id) : null;
             $contactName = $cliente?->name ?: ($cliente?->supplier_business_name ?: null);
-            $crossLinkPrefix = $tipo === 'receber' ? 'V' : 'PC';
+            $crossLinkPrefix = match ($tx->type) {
+                'sell' => 'V',
+                'purchase' => 'PC',
+                'expense' => 'E',
+            };
             $crossLink = sprintf('#%s-%d', $crossLinkPrefix, $tx->id);
             $descricaoSugerida = $contactName ? "{$contactName} · {$crossLink}" : $crossLink;
             $clienteDescricaoFinal = ($existing && ! empty($existing->cliente_descricao))
@@ -154,6 +185,7 @@ class TituloAutoService
         $origem = match ($tx->type) {
             'sell' => 'venda',
             'purchase' => 'compra',
+            'expense' => 'despesa',
             default => null,
         };
 

--- a/Modules/Financeiro/Tests/Feature/TituloAutoServiceExpenseTest.php
+++ b/Modules/Financeiro/Tests/Feature/TituloAutoServiceExpenseTest.php
@@ -1,0 +1,294 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\Transaction;
+use App\User;
+use Modules\Financeiro\Models\Concerns\BusinessScopeImpl;
+use Modules\Financeiro\Models\Titulo;
+use Modules\Financeiro\Services\TituloAutoService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Fase 5.5 deprecação legacy — TituloAutoService cobre type='expense'.
+ *
+ * Antes da Fase 5.5, TituloAutoService só cobria sell/purchase. Expenses NOVAS
+ * criadas via UI legacy /expenses/create não geravam fin_titulo automaticamente
+ * → Eliana abria expense e nada aparecia no Financeiro até alguém rodar
+ * `php artisan financeiro:bridge-expense-to-titulos` (Fase 5 batch).
+ *
+ * Fase 5.5 (2026-05-21) estende o Service:
+ *  - $tipo match() inclui 'expense' => 'pagar'
+ *  - $origem match() inclui 'expense' => 'despesa'
+ *  - cross-link prefix 'expense' => 'E' (#E-{txId})
+ *  - Filosofia divergente: expense com payment_status='paid' GERA fin_titulo
+ *    com status='quitado' (sell/purchase paga cancela título — pagou no caixa
+ *    não vira pendência; expense paga PRECISA aparecer pra Eliana ver DRE).
+ *  - Mesma regra do BridgeExpenseToTitulosCommand (F5) → consistência total.
+ *
+ * Cobertura:
+ *  1. expense due → fin_titulo aberto, valor_aberto = final_total
+ *  2. expense paid → fin_titulo quitado, valor_aberto = 0
+ *  3. expense partial → fin_titulo parcial, valor_aberto = total_remaining_amount
+ *  4. expense atualizada (final_total mudou) → fin_titulo atualizado (updateOrCreate)
+ *  5. expense deletada → fin_titulo cancelado
+ *  6. Tier 0 isolation: expense biz A não cria fin_titulo biz B
+ *  7. Idempotência: chamar service 2x não duplica
+ *
+ * Padrão skip gracioso (Financeiro convention) quando DB greenfield.
+ *
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see Modules/Financeiro/Console/Commands/BridgeExpenseToTitulosCommand.php (F5)
+ */
+
+function expenseBootstrap(): array
+{
+    try {
+        $business = Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: '.$e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco — rode seeder UltimatePOS antes.');
+    }
+
+    $user = User::where('business_id', $business->id)->first();
+    if (! $user) {
+        test()->markTestSkipped('Sem user no business.');
+    }
+
+    return ['business' => $business, 'user' => $user];
+}
+
+function expenseCriarTxDirect(int $businessId, int $userId, string $paymentStatus, float $total, ?float $remaining = null): Transaction
+{
+    /** @var Transaction $tx */
+    $tx = Transaction::create([
+        'business_id' => $businessId,
+        'location_id' => null,
+        'type' => 'expense',
+        'status' => 'final',
+        'payment_status' => $paymentStatus,
+        'contact_id' => null,
+        'invoice_no' => 'TEST-EXP-'.uniqid(),
+        'transaction_date' => '2026-05-20 12:00:00',
+        'total_before_tax' => $total,
+        'final_total' => $total,
+        'total_remaining_amount' => $remaining ?? ($paymentStatus === 'paid' ? 0.0 : $total),
+        'created_by' => $userId,
+    ]);
+
+    return $tx;
+}
+
+function expenseCleanup(Transaction $tx): void
+{
+    Titulo::query()
+        ->withoutGlobalScope(BusinessScopeImpl::class)
+        ->where('business_id', $tx->business_id)
+        ->where('origem_id', $tx->id)
+        ->where('origem', 'despesa')
+        ->forceDelete();
+
+    \DB::table('transactions')->where('id', $tx->id)->delete();
+}
+
+it('expense DUE gera fin_titulo aberto com valor_aberto=final_total', function () {
+    ['business' => $business, 'user' => $user] = expenseBootstrap();
+
+    config(['app.timezone' => 'America/Sao_Paulo']);
+
+    $tx = expenseCriarTxDirect($business->id, $user->id, 'due', 250.00);
+
+    try {
+        $service = app(TituloAutoService::class);
+        $titulo = $service->sincronizarDeTransacao($tx);
+
+        expect($titulo)->not->toBeNull();
+        expect($titulo->origem)->toBe('despesa');
+        expect($titulo->tipo)->toBe('pagar');
+        expect($titulo->status)->toBe('aberto');
+        expect((float) $titulo->valor_total)->toBe(250.00);
+        expect((float) $titulo->valor_aberto)->toBe(250.00);
+        expect($titulo->business_id)->toBe($business->id);
+        // Cross-link #E-{txId} (Fase 5.5 prefix)
+        expect($titulo->cliente_descricao)->toContain('#E-'.$tx->id);
+        // Numeração P (pagar)
+        expect($titulo->numero)->toStartWith('P');
+    } finally {
+        expenseCleanup($tx);
+    }
+})->group('fase5.5-expense');
+
+it('expense PAID gera fin_titulo quitado com valor_aberto=0 (divergência vs sell/purchase)', function () {
+    ['business' => $business, 'user' => $user] = expenseBootstrap();
+
+    config(['app.timezone' => 'America/Sao_Paulo']);
+
+    $tx = expenseCriarTxDirect($business->id, $user->id, 'paid', 300.00);
+
+    try {
+        $service = app(TituloAutoService::class);
+        $titulo = $service->sincronizarDeTransacao($tx);
+
+        // Crítico: expense paid GERA título (sell/purchase paid cancela)
+        expect($titulo)->not->toBeNull();
+        expect($titulo->origem)->toBe('despesa');
+        expect($titulo->status)->toBe('quitado');
+        expect((float) $titulo->valor_total)->toBe(300.00);
+        expect((float) $titulo->valor_aberto)->toBe(0.00);
+    } finally {
+        expenseCleanup($tx);
+    }
+})->group('fase5.5-expense');
+
+it('expense PARTIAL gera fin_titulo parcial com valor_aberto=total_remaining_amount', function () {
+    ['business' => $business, 'user' => $user] = expenseBootstrap();
+
+    config(['app.timezone' => 'America/Sao_Paulo']);
+
+    // 500 total, 200 remaining = 300 já pago
+    $tx = expenseCriarTxDirect($business->id, $user->id, 'partial', 500.00, 200.00);
+
+    try {
+        $service = app(TituloAutoService::class);
+        $titulo = $service->sincronizarDeTransacao($tx);
+
+        expect($titulo)->not->toBeNull();
+        expect($titulo->status)->toBe('parcial');
+        expect((float) $titulo->valor_total)->toBe(500.00);
+        expect((float) $titulo->valor_aberto)->toBe(200.00);
+    } finally {
+        expenseCleanup($tx);
+    }
+})->group('fase5.5-expense');
+
+it('expense atualizada (final_total novo) atualiza fin_titulo (updateOrCreate)', function () {
+    ['business' => $business, 'user' => $user] = expenseBootstrap();
+
+    config(['app.timezone' => 'America/Sao_Paulo']);
+
+    $tx = expenseCriarTxDirect($business->id, $user->id, 'due', 100.00);
+
+    try {
+        $service = app(TituloAutoService::class);
+        $t1 = $service->sincronizarDeTransacao($tx);
+        $numeroOriginal = $t1->numero;
+
+        // Edita a transaction — final_total dobra
+        $tx->final_total = 200.00;
+        $tx->total_remaining_amount = 200.00;
+        $tx->save();
+
+        $t2 = $service->sincronizarDeTransacao($tx);
+
+        // Mesmo título (idempotência por UNIQUE business_id, origem, origem_id, parcela_numero)
+        expect($t2->id)->toBe($t1->id);
+        // numero PRESERVADO (não regenera em updateOrCreate)
+        expect($t2->numero)->toBe($numeroOriginal);
+        // valores atualizados
+        expect((float) $t2->valor_total)->toBe(200.00);
+        expect((float) $t2->valor_aberto)->toBe(200.00);
+
+        // Apenas 1 fin_titulo no banco
+        $count = Titulo::query()
+            ->withoutGlobalScope(BusinessScopeImpl::class)
+            ->where('business_id', $business->id)
+            ->where('origem', 'despesa')
+            ->where('origem_id', $tx->id)
+            ->count();
+        expect($count)->toBe(1);
+    } finally {
+        expenseCleanup($tx);
+    }
+})->group('fase5.5-expense');
+
+it('expense deletada cancela fin_titulo (não hard-delete, append-only TECH-0002)', function () {
+    ['business' => $business, 'user' => $user] = expenseBootstrap();
+
+    config(['app.timezone' => 'America/Sao_Paulo']);
+
+    $tx = expenseCriarTxDirect($business->id, $user->id, 'due', 150.00);
+
+    try {
+        $service = app(TituloAutoService::class);
+        $titulo = $service->sincronizarDeTransacao($tx);
+        expect($titulo->status)->toBe('aberto');
+
+        // Simula deleção
+        $titulo2 = $service->cancelarSeExistir($tx, motivo: 'despesa excluída');
+
+        expect($titulo2)->not->toBeNull();
+        expect($titulo2->id)->toBe($titulo->id);
+        expect($titulo2->status)->toBe('cancelado');
+        expect($titulo2->observacoes)->toContain('despesa excluída');
+
+        // Titulo continua existindo (não foi hard-deleted)
+        $countAposCancel = Titulo::query()
+            ->withoutGlobalScope(BusinessScopeImpl::class)
+            ->where('business_id', $business->id)
+            ->where('origem', 'despesa')
+            ->where('origem_id', $tx->id)
+            ->count();
+        expect($countAposCancel)->toBe(1);
+    } finally {
+        expenseCleanup($tx);
+    }
+})->group('fase5.5-expense');
+
+it('Tier 0 IRREVOGÁVEL: expense biz=A não cria fin_titulo em biz=B', function () {
+    ['business' => $business, 'user' => $user] = expenseBootstrap();
+
+    config(['app.timezone' => 'America/Sao_Paulo']);
+
+    $tx = expenseCriarTxDirect($business->id, $user->id, 'due', 100.00);
+
+    try {
+        $service = app(TituloAutoService::class);
+        $titulo = $service->sincronizarDeTransacao($tx);
+
+        expect($titulo->business_id)->toBe($business->id);
+
+        // Garante que NENHUM fin_titulo foi criado em outro business_id
+        $countOutroBiz = Titulo::query()
+            ->withoutGlobalScope(BusinessScopeImpl::class)
+            ->where('business_id', '!=', $business->id)
+            ->where('origem', 'despesa')
+            ->where('origem_id', $tx->id)
+            ->count();
+        expect($countOutroBiz)->toBe(0);
+    } finally {
+        expenseCleanup($tx);
+    }
+})->group('fase5.5-expense');
+
+it('idempotência: chamar sincronizarDeTransacao 2x não duplica fin_titulo expense', function () {
+    ['business' => $business, 'user' => $user] = expenseBootstrap();
+
+    config(['app.timezone' => 'America/Sao_Paulo']);
+
+    $tx = expenseCriarTxDirect($business->id, $user->id, 'due', 175.00);
+
+    try {
+        $service = app(TituloAutoService::class);
+
+        $t1 = $service->sincronizarDeTransacao($tx);
+        $t2 = $service->sincronizarDeTransacao($tx);
+
+        expect($t1->id)->toBe($t2->id);
+        expect($t1->numero)->toBe($t2->numero);
+
+        $count = Titulo::query()
+            ->withoutGlobalScope(BusinessScopeImpl::class)
+            ->where('business_id', $business->id)
+            ->where('origem', 'despesa')
+            ->where('origem_id', $tx->id)
+            ->count();
+        expect($count)->toBe(1);
+    } finally {
+        expenseCleanup($tx);
+    }
+})->group('fase5.5-expense');


### PR DESCRIPTION
## Summary

Fase 5.5 da deprecação legacy `Modules/Financeiro` vs core UltimatePOS — **estende `TituloAutoService` pra cobrir `type='expense'`**, fechando o gap deixado pela Fase 5 (que cobriu só histórico via comando batch).

### Cadeia de PRs da deprecação

| Fase | PR | O que faz |
|---|---|---|
| F1 | #1282 | Esconde dropdowns Expense/Account do sidebar quando Modules/Financeiro habilitado |
| F2 | #1283 | 301 redirects `/expenses` + `/account/*` → telas Financeiro canônicas |
| F5 | #1284 | Comando artisan `financeiro:bridge-expense-to-titulos` (backfill histórico idempotente) |
| **F5.5** | **este PR** | **TituloAutoService cobre expenses NOVAS via Observer (cobre o gap forward)** |

### O problema F5.5 resolve

F5 cobre **histórico**. Mas expenses **NOVAS** criadas via UI legacy `/expenses/create` (ou via API) **continuavam sem fin_titulo correspondente** — `TituloAutoService::sincronizarDeTransacaoInternal()` tinha `default => null` no match `$tipo` pra `type='expense'`.

Resultado: após F5 backfill, Eliana abria uma expense legacy nova → não aparecia no Financeiro. Tinha que rodar comando F5 de novo. Não escalava.

### O que muda

**`Modules/Financeiro/Services/TituloAutoService.php`** (+22 linhas, cirúrgico):

1. `sincronizarDeTransacaoInternal()`:
   - Match `$tipo` ganha `'expense' => 'pagar'`
   - Match `$origem` ganha `'expense' => 'despesa'`
   - Cross-link prefix `'expense' => 'E'` → gera `#E-{txId}` (Fase 5.5)
   - **Filosofia divergente quando `payment_status='paid'`:**
     - `sell`/`purchase` paid → `cancelarSeExistir` (não vira título — pagou no caixa, sem pendência) ✅ **comportamento inalterado**
     - `expense` paid → cria com `status='quitado'`, `valor_aberto=0` (Eliana DRE precisa ver despesa histórica paga ou não — mesma regra do `BridgeExpenseToTitulosCommand` F5)
2. `cancelarSeExistir()`: match `$origem` ganha `'expense' => 'despesa'` (expense soft-deletada → fin_titulo cancelado)

**Garantia crítica:** `sell`/`purchase` continuam **idênticos** — a condição paid→cancelar agora aciona pra `$tx->type !== 'expense'`, e o match `$origem` preserva os mapeamentos antigos nas mesmas posições. Diff cirúrgico.

**Novo teste:** `Modules/Financeiro/Tests/Feature/TituloAutoServiceExpenseTest.php` (7 cases):

1. expense DUE → fin_titulo aberto, `valor_aberto = final_total`
2. expense PAID → fin_titulo quitado, `valor_aberto = 0`
3. expense PARTIAL → fin_titulo parcial, `valor_aberto = total_remaining_amount`
4. expense atualizada (final_total novo) → `updateOrCreate` atualiza (preserva numero)
5. expense deletada → fin_titulo cancelado (append-only TECH-0002)
6. **Tier 0 IRREVOGÁVEL ADR 0093:** expense biz=A não cria fin_titulo em biz=B
7. Idempotência: chamar service 2x não duplica

## Test plan

- [x] PHP lint (`php -l`) — Service + novo test
- [ ] Pest run CI — 7 cases novos + existing `TituloAutoServiceTest.php` (sell paid não cria, idempotência, timezone) continuam verde
- [ ] Module Grades Gate verde — sem regressão Financeiro
- [ ] Smoke pós-merge — abrir expense via `/expenses/create` em ambiente dev → conferir que fin_titulo aparece em `/financeiro/contas-pagar`

## Notas técnicas

- **Não toca**: middleware, routes, Kernel, .htaccess → sem Infra Contract gate
- **Service em uso em prod** — diff cuidadosamente minimal pra preservar sell/purchase
- **Idempotência** continua via UNIQUE `(business_id, origem, origem_id, parcela_numero)` no schema — sem lógica adicional
- **Observer** (`TransactionObserver`) já registrado no `FinanceiroServiceProvider::boot()`, não precisa mexer
- `TransactionObserver::deleted()` já tinha `default => 'transação excluída'` — agora `cancelarSeExistir` aceita expense corretamente

Refs F1 #1282, F2 #1283, F5 #1284

🤖 Generated with [Claude Code](https://claude.com/claude-code)