### PR TITLE
feat(financeiro): Fase 3 - Fluxo de Caixa tabs Projetado+Realizado (absorve Cash Flow legacy)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/FluxoController.php
+++ b/Modules/Financeiro/Http/Controllers/FluxoController.php
@@ -9,31 +9,38 @@ use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
 use Modules\Financeiro\Services\FluxoCaixaService;
+use Modules\Financeiro\Services\FluxoRealizadoService;
 
 /**
- * Tela /financeiro/fluxo — Fluxo de caixa projetado (Cockpit V2).
+ * Tela /financeiro/fluxo — Fluxo de caixa (Cockpit V2) com tabs Projetado + Realizado.
  *
  * Origem: protótipo Cowork "Fluxo de Caixa" aprovado por [W] 2026-05-09 +
  * decisões Q1-Q4 aprovadas por [W] 2026-05-14 (memory/requisitos/Financeiro/
  * fluxo-visual-comparison.md).
  *
- * Persona-foco: Eliana [E] (financeiro escritório) + Wagner [W] (dono).
- * Stories: US-FIN-014 (fluxo-caixa-projetado).
+ * Fase 3 deprecação legacy (2026-05-21): adiciona tab "Realizado" pra absorver
+ * o Cash Flow legacy do core UltimatePOS (`AccountController::cashFlow()`,
+ * `/account/cash-flow` → 301 → `/financeiro/fluxo` desde PR #1283). A tab
+ * "Projetado" preserva 100% o comportamento anterior (default).
  *
- * Read-only: NÃO faz mutação. Toda agregação acontece em FluxoCaixaService.
+ * Persona-foco: Eliana [E] (financeiro escritório) + Wagner [W] (dono).
+ * Stories: US-FIN-014 (fluxo-caixa-projetado), US-FIN-014c (fluxo-realizado).
+ *
+ * Read-only: NÃO faz mutação. Toda agregação acontece nos Services.
  *
  * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL):
  *  - business_id lido de session('user.business_id')
- *  - middleware can:financeiro.dashboard.view (granularidade financeiro.fluxo.view
- *    fica pra evolução; F1 reusa dashboard.view — mesma persona)
- *  - Service recebe businessId explicitamente como 1º arg
+ *  - middleware can:financeiro.dashboard.view
+ *  - Services recebem businessId explicitamente como 1º arg
  */
 class FluxoController extends Controller
 {
     use RendersMockCowork;
 
-    public function __construct(private FluxoCaixaService $service)
-    {
+    public function __construct(
+        private FluxoCaixaService $service,
+        private FluxoRealizadoService $realizadoService,
+    ) {
         $this->middleware('auth');
         $this->middleware('can:financeiro.dashboard.view');
     }
@@ -45,14 +52,28 @@ class FluxoController extends Controller
         }
 
         $businessId = (int) session('user.business_id');
+        $tab = $this->resolveTab($request);
         $dias = $this->resolveDias($request);
+        $meses = $this->resolveMeses($request);
 
         // Wave 17 D9 — projeção 35d agrega Titulo + TituloBaixa + ContaBancaria.saldo_cached;
         // pode ser pesada em business com volume alto. Span ajuda a detectar regressão.
-        return OtelHelper::spanBiz('financeiro.fluxo.projetar', function () use ($businessId, $dias) {
-            $shape = $this->service->projetar($businessId, $dias);
-            return Inertia::render('Financeiro/Fluxo/Index', $shape);
-        }, ['op' => 'projetar', 'dias' => $dias]);
+        return OtelHelper::spanBiz('financeiro.fluxo.render', function () use ($businessId, $tab, $dias, $meses) {
+            // Projetado: sempre presente no payload (default; props no shape canon
+            // pra preservar testes existentes e Pest GUARDs do charter).
+            $projetado = $this->service->projetar($businessId, $dias);
+
+            // Realizado: só carrega quando tab=realizado pra evitar query custosa
+            // em renders que não vão exibir. Estrutura ausente quando não carregada.
+            $realizado = $tab === 'realizado'
+                ? $this->realizadoService->buscar($businessId, $meses)
+                : null;
+
+            return Inertia::render('Financeiro/Fluxo/Index', array_merge($projetado, [
+                'tab' => $tab,
+                'realizado' => $realizado,
+            ]));
+        }, ['op' => 'render', 'tab' => $tab, 'dias' => $dias, 'meses' => $meses]);
     }
 
     /**
@@ -64,5 +85,28 @@ class FluxoController extends Controller
         $dias = (int) $request->integer('dias', 35);
 
         return max(7, min(60, $dias));
+    }
+
+    /**
+     * Fase 3: tab=projetado (default) ou tab=realizado. Qualquer outro valor
+     * cai pro default — clamp defensivo (anti-injection na querystring).
+     */
+    private function resolveTab(Request $request): string
+    {
+        $tab = (string) $request->query('tab', 'projetado');
+
+        return in_array($tab, ['projetado', 'realizado'], true)
+            ? $tab
+            : 'projetado';
+    }
+
+    /**
+     * Fase 3: janela do Realizado em meses. Default 12; clamp 1..36.
+     */
+    private function resolveMeses(Request $request): int
+    {
+        $meses = (int) $request->integer('meses', 12);
+
+        return max(1, min(36, $meses));
     }
 }

--- a/Modules/Financeiro/Services/FluxoRealizadoService.php
+++ b/Modules/Financeiro/Services/FluxoRealizadoService.php
@@ -1,0 +1,175 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Financeiro\Services;
+
+use App\Util\OtelHelper;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+use Modules\Financeiro\Models\TituloBaixa;
+
+/**
+ * FluxoRealizadoService — visão histórica do fluxo de caixa realizado.
+ *
+ * Agrega `fin_titulo_baixas` por YYYY-MM nos últimos N meses:
+ *   - entradas = SUM(valor_baixa) WHERE titulo.tipo = 'receber'
+ *   - saidas   = SUM(valor_baixa) WHERE titulo.tipo = 'pagar'
+ *   - saldo    = entradas - saidas
+ *
+ * Origem: Fase 3 deprecação legacy — absorve Cash Flow legacy do core
+ * UltimatePOS (`/account/cash-flow` → `AccountController::cashFlow()`),
+ * já redirecionado pra `/financeiro/fluxo` via PR #1283 (Fase 2).
+ *
+ * Read-only, sem mutação. Sem schema novo.
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL):
+ *   - business_id explícito em TODAS queries (defesa em profundidade)
+ *   - TituloBaixa usa BusinessScope global scope; ainda assim explicitamos
+ *   - Estornos ignorados (estorno_de_id IS NULL) — preserva ledger style
+ *
+ * Decisões Fase 3 (Wagner aprovou 2026-05-21):
+ *   - Janela = 12 meses (hardcode F3; opt-in via ?meses=N range 1..36)
+ *   - Granularidade = mês (não diário; Realizado é visão histórica/contábil)
+ *   - Ignora estornos (consistente com FluxoCaixaService)
+ *   - Inclui mês atual (mes corrente acumula até hoje)
+ */
+class FluxoRealizadoService
+{
+    /**
+     * Busca movimentações realizadas agrupadas por mês.
+     *
+     * @return array{
+     *   meta: array{
+     *     meses_janela: int,
+     *     primeiro_mes: string,
+     *     ultimo_mes: string,
+     *     business_id: int
+     *   },
+     *   totais: array{
+     *     entradas: float,
+     *     saidas: float,
+     *     saldo: float,
+     *     qtd_baixas: int
+     *   },
+     *   meses: array<int, array{
+     *     mes: string,
+     *     mes_label: string,
+     *     ano: int,
+     *     entradas: float,
+     *     saidas: float,
+     *     saldo: float,
+     *     qtd_baixas: int,
+     *     is_current: bool
+     *   }>
+     * }
+     */
+    public function buscar(int $businessId, int $meses = 12): array
+    {
+        return OtelHelper::spanBiz('financeiro.fluxo_realizado.buscar', function () use ($businessId, $meses): array {
+            return $this->buscarInternal($businessId, $meses);
+        }, [
+            'business_id' => $businessId,
+            'meses' => $meses,
+        ]);
+    }
+
+    private function buscarInternal(int $businessId, int $meses): array
+    {
+        $hoje = CarbonImmutable::today();
+        $inicio = $hoje->startOfMonth()->subMonths($meses - 1);
+        $fim = $hoje->endOfMonth();
+
+        // ───────────────────── Query agregada por mês × tipo ─────────────────────
+        // JOIN baixa → titulo (pra ler tipo receber/pagar) com filtro business_id
+        // duplicado em ambas tabelas (defesa em profundidade).
+        // GROUP BY YEAR(data_baixa), MONTH(data_baixa), titulo.tipo.
+        //
+        // Estornos (estorno_de_id IS NOT NULL) ficam de fora — consistente com
+        // FluxoCaixaService.projetar() histórico.
+        $rows = TituloBaixa::query()
+            ->from('fin_titulo_baixas as b')
+            ->join('fin_titulos as t', function ($join) use ($businessId) {
+                $join->on('t.id', '=', 'b.titulo_id')
+                     ->where('t.business_id', '=', $businessId);
+            })
+            ->where('b.business_id', $businessId)
+            ->whereBetween('b.data_baixa', [$inicio->toDateString(), $fim->toDateString()])
+            ->whereNull('b.estorno_de_id')
+            ->whereNull('t.deleted_at')
+            ->select([
+                DB::raw('YEAR(b.data_baixa) as ano'),
+                DB::raw('MONTH(b.data_baixa) as mes_num'),
+                't.tipo as tipo',
+                DB::raw('SUM(b.valor_baixa) as total'),
+                DB::raw('COUNT(*) as qtd'),
+            ])
+            ->groupBy('ano', 'mes_num', 't.tipo')
+            ->orderBy('ano')
+            ->orderBy('mes_num')
+            ->get();
+
+        // ─────────────────── Indexa rows por chave 'YYYY-MM' ───────────────────
+        $idx = [];
+        foreach ($rows as $row) {
+            $key = sprintf('%04d-%02d', (int) $row->ano, (int) $row->mes_num);
+            if (! isset($idx[$key])) {
+                $idx[$key] = ['entradas' => 0.0, 'saidas' => 0.0, 'qtd' => 0];
+            }
+            $valor = (float) $row->total;
+            $qtd = (int) $row->qtd;
+            if ($row->tipo === 'receber') {
+                $idx[$key]['entradas'] += $valor;
+            } else {
+                $idx[$key]['saidas'] += $valor;
+            }
+            $idx[$key]['qtd'] += $qtd;
+        }
+
+        // ─────────────────── Materializa janela completa (zera meses vazios) ───────────────────
+        $mesesArray = [];
+        $totaisEntradas = 0.0;
+        $totaisSaidas = 0.0;
+        $totaisQtd = 0;
+
+        for ($m = $inicio; $m->lte($fim); $m = $m->addMonth()) {
+            $key = $m->format('Y-m');
+            $entry = $idx[$key] ?? ['entradas' => 0.0, 'saidas' => 0.0, 'qtd' => 0];
+            $entradas = round((float) $entry['entradas'], 2);
+            $saidas = round((float) $entry['saidas'], 2);
+            $saldo = round($entradas - $saidas, 2);
+            $qtdBaixas = (int) $entry['qtd'];
+
+            $mesesArray[] = [
+                'mes' => $key,
+                'mes_label' => $m->locale('pt_BR')->isoFormat('MMM/YY'),
+                'ano' => (int) $m->year,
+                'entradas' => $entradas,
+                'saidas' => $saidas,
+                'saldo' => $saldo,
+                'qtd_baixas' => $qtdBaixas,
+                'is_current' => $m->isSameMonth($hoje),
+            ];
+
+            $totaisEntradas += $entradas;
+            $totaisSaidas += $saidas;
+            $totaisQtd += $qtdBaixas;
+        }
+
+        return [
+            'meta' => [
+                'meses_janela' => $meses,
+                'primeiro_mes' => $inicio->format('Y-m'),
+                'ultimo_mes' => $fim->format('Y-m'),
+                'business_id' => $businessId,
+            ],
+            'totais' => [
+                'entradas' => round($totaisEntradas, 2),
+                'saidas' => round($totaisSaidas, 2),
+                'saldo' => round($totaisEntradas - $totaisSaidas, 2),
+                'qtd_baixas' => $totaisQtd,
+            ],
+            'meses' => $mesesArray,
+        ];
+    }
+}

--- a/Modules/Financeiro/Tests/Feature/FluxoRealizadoControllerTest.php
+++ b/Modules/Financeiro/Tests/Feature/FluxoRealizadoControllerTest.php
@@ -1,0 +1,276 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Inertia\Testing\AssertableInertia;
+use Modules\Financeiro\Models\TituloBaixa;
+use Spatie\Permission\Models\Permission;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-FIN-014c — Pest GUARD da tab "Realizado" em /financeiro/fluxo.
+ *
+ * Fase 3 deprecação legacy (2026-05-21): tab Realizado absorve Cash Flow legacy
+ * (`/account/cash-flow` → 301 → `/financeiro/fluxo?tab=realizado` via PR #1283).
+ *
+ * Cobre:
+ *  - tab=projetado é default (omitido = projetado)
+ *  - tab=realizado retorna payload no shape canon (meta + totais + meses)
+ *  - tab inválido cai pra default
+ *  - Multi-tenant Tier 0 ADR 0093 IRREVOGÁVEL: TituloBaixa filtrada por business_id
+ *  - ?meses=N respeitado e clampado (1..36)
+ *  - GET é read-only (não cria/altera baixa)
+ *
+ * Skip gracioso quando DB greenfield ou subscription gate bloqueia env.
+ */
+function fluxoRealizadoBootstrap(): User
+{
+    try {
+        $business = Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: '.$e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco — rode seeder UltimatePOS antes.');
+    }
+
+    $user = User::where('business_id', $business->id)->first();
+
+    if (! $user) {
+        test()->markTestSkipped('Sem user no business.');
+    }
+
+    Permission::firstOrCreate(['name' => 'financeiro.dashboard.view', 'guard_name' => 'web']);
+    if (! $user->hasPermissionTo('financeiro.dashboard.view')) {
+        $user->givePermissionTo('financeiro.dashboard.view');
+    }
+
+    session([
+        'user.business_id'         => $business->id,
+        'user.id'                  => $user->id,
+        'business.id'              => $business->id,
+        'business.name'            => $business->name,
+        'business.currency_symbol' => 'R$',
+        'business'                 => [
+            'id'              => $business->id,
+            'name'            => $business->name,
+            'currency_symbol' => 'R$',
+        ],
+        'is_admin'                 => true,
+    ]);
+
+    return $user;
+}
+
+it('tab default = projetado (sem query string)', function () {
+    $user = fluxoRealizadoBootstrap();
+
+    $response = $this->actingAs($user)->get('/financeiro/fluxo');
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Financeiro/Fluxo/Index')
+        ->where('tab', 'projetado')
+        // shape Projetado preservado (props originais permanecem na raiz)
+        ->has('saldo_hoje')
+        ->has('dias')
+    );
+});
+
+it('tab=realizado expõe payload canon (meta + totais + meses)', function () {
+    $user = fluxoRealizadoBootstrap();
+
+    $response = $this->actingAs($user)->get('/financeiro/fluxo?tab=realizado');
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Financeiro/Fluxo/Index')
+        ->where('tab', 'realizado')
+        ->has('realizado.meta.meses_janela')
+        ->has('realizado.meta.primeiro_mes')
+        ->has('realizado.meta.ultimo_mes')
+        ->has('realizado.meta.business_id')
+        ->has('realizado.totais.entradas')
+        ->has('realizado.totais.saidas')
+        ->has('realizado.totais.saldo')
+        ->has('realizado.totais.qtd_baixas')
+        ->has('realizado.meses')
+    );
+});
+
+it('tab=realizado retorna exatamente 12 meses por default (janela canon)', function () {
+    $user = fluxoRealizadoBootstrap();
+
+    $response = $this->actingAs($user)->get('/financeiro/fluxo?tab=realizado');
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->where('realizado.meta.meses_janela', 12)
+        ->has('realizado.meses', 12)
+    );
+});
+
+it('cada mes do realizado tem shape esperado (mes, entradas, saidas, saldo, qtd_baixas, is_current)', function () {
+    $user = fluxoRealizadoBootstrap();
+
+    $response = $this->actingAs($user)->get('/financeiro/fluxo?tab=realizado');
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertInertia(function (AssertableInertia $page) {
+        $meses = $page->toArray()['props']['realizado']['meses'] ?? [];
+        expect($meses)->toBeArray()->not->toBeEmpty();
+
+        foreach ($meses as $i => $mes) {
+            expect($mes)->toHaveKeys([
+                'mes', 'mes_label', 'ano', 'entradas', 'saidas', 'saldo', 'qtd_baixas', 'is_current',
+            ], "mes[$i] sem chave canon");
+            expect($mes['entradas'])->toBeNumeric();
+            expect($mes['saidas'])->toBeNumeric();
+            // saldo = entradas - saidas (invariante matemática)
+            $delta = abs(($mes['entradas'] - $mes['saidas']) - $mes['saldo']);
+            expect($delta)->toBeLessThan(0.01, "mes[$i].saldo != entradas - saidas (delta R\$ {$delta})");
+        }
+
+        // Exatamente 1 mes_current = true (o atual)
+        $atuais = array_filter($meses, fn ($m) => $m['is_current'] === true);
+        expect(count($atuais))->toBe(1, 'deve ter exatamente 1 mes is_current = true');
+    });
+});
+
+it('tab inválido cai pra default projetado', function () {
+    $user = fluxoRealizadoBootstrap();
+
+    $response = $this->actingAs($user)->get('/financeiro/fluxo?tab=lixo');
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->where('tab', 'projetado')
+    );
+});
+
+it('?meses=N respeita clamp 1..36', function () {
+    $user = fluxoRealizadoBootstrap();
+
+    // 999 → clamp 36
+    $r1 = $this->actingAs($user)->get('/financeiro/fluxo?tab=realizado&meses=999');
+    if (in_array($r1->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+    $r1->assertInertia(fn (AssertableInertia $page) => $page
+        ->where('realizado.meta.meses_janela', 36)
+        ->has('realizado.meses', 36)
+    );
+
+    // 0 → clamp 1
+    $r2 = $this->actingAs($user)->get('/financeiro/fluxo?tab=realizado&meses=0');
+    $r2->assertInertia(fn (AssertableInertia $page) => $page
+        ->where('realizado.meta.meses_janela', 1)
+        ->has('realizado.meses', 1)
+    );
+});
+
+it('Tier 0 IRREVOGÁVEL: realizado respeita business_id (ADR 0093)', function () {
+    $user = fluxoRealizadoBootstrap();
+    $businessId = (int) $user->business_id;
+
+    $response = $this->actingAs($user)->get('/financeiro/fluxo?tab=realizado');
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    // meta.business_id casa com auth biz
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->where('realizado.meta.business_id', $businessId)
+    );
+
+    // Defensiva: se totais.qtd_baixas > 0, conferir que TituloBaixa retornadas
+    // pertencem ao biz auth (BusinessScope global scope + filtro explícito no
+    // service garantem; este guard verifica que não houve regressão removendo
+    // o scope).
+    $countDoBiz = TituloBaixa::query()
+        ->where('business_id', $businessId)
+        ->whereNull('estorno_de_id')
+        ->count();
+    $countTotal = TituloBaixa::query()
+        ->withoutGlobalScopes()
+        ->whereNull('estorno_de_id')
+        ->count();
+
+    // Se há baixas no DB de outros tenants, business scope tem que filtrar
+    if ($countTotal > $countDoBiz) {
+        expect($countDoBiz)->toBeLessThan($countTotal, 'BusinessScope deve filtrar cross-tenant');
+    }
+});
+
+it('tab=projetado não carrega payload realizado (perf — evita query custosa)', function () {
+    $user = fluxoRealizadoBootstrap();
+
+    $response = $this->actingAs($user)->get('/financeiro/fluxo?tab=projetado');
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->where('tab', 'projetado')
+        ->where('realizado', null)
+    );
+});
+
+it('não dispara mutação em GET /fluxo?tab=realizado (read-only puro)', function () {
+    $user = fluxoRealizadoBootstrap();
+
+    $baixaCountBefore = TituloBaixa::query()->count();
+    $response = $this->actingAs($user)->get('/financeiro/fluxo?tab=realizado');
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $baixaCountAfter = TituloBaixa::query()->count();
+    expect($baixaCountAfter)->toBe($baixaCountBefore);
+});
+
+it('totais.saldo = totais.entradas - totais.saidas (invariante contábil)', function () {
+    $user = fluxoRealizadoBootstrap();
+
+    $response = $this->actingAs($user)->get('/financeiro/fluxo?tab=realizado');
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertInertia(function (AssertableInertia $page) {
+        $totais = $page->toArray()['props']['realizado']['totais'] ?? null;
+        expect($totais)->not->toBeNull();
+        $delta = abs(($totais['entradas'] - $totais['saidas']) - $totais['saldo']);
+        expect($delta)->toBeLessThan(0.01, "totais.saldo inconsistente com entradas - saidas (delta R\$ {$delta})");
+
+        // totais.entradas = SUM(meses[].entradas) (consistência agregada)
+        $meses = $page->toArray()['props']['realizado']['meses'] ?? [];
+        $somaEnt = array_sum(array_column($meses, 'entradas'));
+        $somaSai = array_sum(array_column($meses, 'saidas'));
+        expect(abs($somaEnt - $totais['entradas']))->toBeLessThan(0.01, 'SUM(meses.entradas) != totais.entradas');
+        expect(abs($somaSai - $totais['saidas']))->toBeLessThan(0.01, 'SUM(meses.saidas) != totais.saidas');
+    });
+});

--- a/resources/js/Pages/Financeiro/Fluxo/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Fluxo/Index.charter.md
@@ -3,32 +3,43 @@ page: /financeiro/fluxo
 component: resources/js/Pages/Financeiro/Fluxo/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-14
+last_validated: 2026-05-21
 parent_module: Financeiro
 parent_capterra: memory/requisitos/Financeiro/CAPTERRA-FICHA.md
 related_adrs: [arq/0005, ui/0114, 0093, 0094, 0104]
-related_us: [US-FIN-014]
+related_us: [US-FIN-014, US-FIN-014c]
 related_prototype: prototipo Cowork "Fluxo de Caixa" (Financeiro.html), aprovado [W] 2026-05-09
 related_decisions: memory/requisitos/Financeiro/fluxo-visual-comparison.md (Q1-Q4 aprovadas [W] 2026-05-14)
 tier: A
-charter_version: 1
+charter_version: 2
 ---
 
 # Page Charter — /financeiro/fluxo
 
-> **Status:** F3 entregue (charter criado junto com Controller + Service + Page + Pest, sessão 2026-05-14).
+> **Status:** Fase 3 deprecação legacy entregue (tab Realizado adiciona visão histórica, sessão 2026-05-21).
 > Persona: **Eliana [E]** (financeiro escritório) + **Wagner [W]** (dono). Desktop ≥1024px. Decisão de caixa em <30s.
+>
+> **2 tabs:**
+> - `?tab=projetado` (default) — fluxo projetado dia-a-dia (35 dias, comportamento canon US-FIN-014)
+> - `?tab=realizado` — movimentações confirmadas agrupadas por mês (12 meses, US-FIN-014c — absorve Cash Flow legacy do core via PR #1283 Fase 2)
 
 ---
 
 ## Mission (1 frase)
 
-Mostrar **projeção de 35 dias de fluxo de caixa** (saldo, entradas e saídas dia-a-dia) numa view única — sem Eliana precisar abrir Contas a Receber + Contas a Pagar + Saldo bancário e somar de cabeça pra responder "vou conseguir pagar a folha dia 30?".
+Mostrar **fluxo de caixa em duas óticas** (Projetado dia-a-dia próximos 35d + Realizado mês-a-mês últimos 12m) numa view única com tabs — sem Eliana precisar abrir Contas a Receber + Contas a Pagar + Saldo bancário (Projetado) ou navegar pro Cash Flow legacy do core UltimatePOS (Realizado, agora absorvido).
 
 ---
 
 ## Goals — Features (faz)
 
+### Comum (header + navegação)
+- Pill segmented control no topo: "Projetado · próx 35 dias" | "Realizado · últ 12 meses" — pattern consistente com `Cobranca/Index.tsx`
+- URL preserva tab via `?tab=projetado|realizado` (deep-link funciona)
+- Tab inválido cai pra default `projetado` (clamp defensivo no Controller)
+- Subtítulo do header muda conforme tab ("Projeção 35 dias" vs "Realizado · últ 12 meses")
+
+### Tab Projetado (US-FIN-014, default)
 - 4 KPI cards: **Saldo hoje** (soma `ContaBancaria.saldo_cached`), **Projeção 30 dias** (com delta vs hoje + tone emerald/rose), **Pior dia previsto** (tone amber), **Margem mínima** (R$ 5.000 hardcode F1)
 - KPI "Saldo hoje" mostra caption com nome da conta principal (+ "outras N" se >1 conta)
 - Gráfico de barras 35 dias com linha tracejada amber pra margem mínima
@@ -43,8 +54,24 @@ Mostrar **projeção de 35 dias de fluxo de caixa** (saldo, entradas e saídas d
 - Valor com sinal `+`/`−` formatado BRL com `tabular-nums`
 - Histórico -2d aparece como parte da timeline (Q4 aprovado: contexto recente)
 - Empty state na tabela quando não há eventos próximos: "Nenhum evento programado nos próximos 7 dias."
+
+### Tab Realizado (US-FIN-014c, Fase 3 — 2026-05-21)
+- 4 KPI cards: **Saldo 12M** (entradas - saídas do período, tone emerald/rose), **Entradas** (verde), **Saídas** (rosa), **Baixas registradas** (contagem)
+- Gráfico de barras gemelhas por mês (entradas verde × saídas rosa lado-a-lado, 12 colunas)
+- Mês atual destacado com tom mais escuro (`bg-emerald-600` / `bg-rose-600`)
+- Hover na barra: tooltip com `mes_label · saldo do mês`
+- Tabela "Detalhe por mês" com colunas: mês | entradas | saídas | saldo | qtd baixas
+- Linha total no rodapé com SUM agregado dos 12 meses (preserva invariante contábil)
+- Mês atual recebe label "atual" + bg sutil + font-semibold
+- Empty state: "Nenhuma baixa registrada nos últimos N meses."
+- Query agregada `fin_titulo_baixas` × `fin_titulos` GROUP BY YEAR-MONTH × tipo (receber/pagar)
+- Ignora estornos (`estorno_de_id IS NULL`) — consistente com FluxoCaixaService histórico
+- Janela default 12 meses; `?meses=N` aceita 1..36 (clamp defensivo)
+
+### Universal
 - Multi-tenant Tier 0: `Titulo`, `TituloBaixa`, `ContaBancaria` filtrados por `business_id` global scope ([ADR 0093](../../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md))
 - Read-only: nenhuma mutação (sem botão de marcar baixa, sem editar, sem excluir)
+- Lazy load: tab Projetado NÃO carrega payload Realizado (perf — evita query mensal custosa quando não vai exibir)
 
 ---
 
@@ -52,18 +79,22 @@ Mostrar **projeção de 35 dias de fluxo de caixa** (saldo, entradas e saídas d
 
 > Anti-alucinação. Cada item vira Pest GUARD test (Non-Goal violado = CI quebra).
 
-- ❌ Dropdown período (7/15/30/35/60d) — F1 é fixo 35d (Q2 aprovado 2026-05-14); F2 entrega UI controle
+- ❌ Dropdown período Projetado (7/15/30/35/60d) — F1 é fixo 35d (Q2 aprovado 2026-05-14); F2 entrega UI controle
+- ❌ Dropdown janela Realizado (3M/6M/12M/24M) — Fase 3 fixo 12M; UI controle em backlog (querystring `?meses=N` 1..36 já funcional)
 - ❌ Margem mínima configurável por usuário — F1 hardcode R$ 5.000 (Q3); F2 via `business_settings.margem_minima_caixa`
-- ❌ Click linha tabela abre drawer detalhe — F1 não; F2 (US-FIN-019) abre Sheet com `Titulo` completo
+- ❌ Click linha tabela Realizado abre drilldown das baixas do mês — backlog (cobre via `/financeiro/extrato?from=X&to=Y`)
+- ❌ Click linha tabela Projetado abre drawer detalhe — F1 não; F2 (US-FIN-019) abre Sheet com `Titulo` completo
 - ❌ Atalhos teclado `J/K` navegação tabela — F1 não; F2 mesmo pattern Unificado
 - ❌ Export PDF/CSV/XLSX — backlog Eliana (US-FIN-021)
-- ❌ Comparativo "vs mês anterior" — escopo DRE
+- ❌ Comparativo Realizado "vs ano anterior" — escopo DRE (`/financeiro/dre` já mostra meta + período anterior)
 - ❌ Mobile responsive (cards stack) — F1 desktop only (Persona Eliana)
 - ❌ Filtro por conta bancária específica — F1 soma todas; futuro filtro conta como Unificado
-- ❌ Aging buckets <30 / 30-60 / 90+ — escopo Inadimplência
-- ❌ Cache Redis — F1 sem cache (dataset pequeno ~50-200 títulos)
+- ❌ Aging buckets <30 / 30-60 / 90+ no Realizado — escopo Inadimplência
+- ❌ Drilldown por categoria/plano-conta no Realizado — escopo DRE
+- ❌ Cache Redis — F1 sem cache (dataset pequeno; query agregada SQL `GROUP BY` rápida)
 - ❌ Mutação (registrar baixa, criar título) — read-only por design; mutações via `/financeiro/unificado` ou contas-receber/pagar
 - ❌ Notificação automática quando saldo cruzar margem mínima — backlog Onda 4 (job + email/whatsapp)
+- ❌ Tab Realizado NÃO inclui estornos (`estorno_de_id IS NOT NULL`) — visão "líquido confirmado" (consistente com FluxoCaixaService histórico)
 
 ---
 
@@ -93,12 +124,22 @@ Mostrar **projeção de 35 dias de fluxo de caixa** (saldo, entradas e saídas d
 
 ## Automation Hooks
 
-- Endpoint `FluxoController::index(Request $r): Response` lê `session('user.business_id')` + `?dias=N` (clamp 7..60, default 35)
-- Service `FluxoCaixaService::projetar(int $businessId, int $dias = 35): array` orquestra:
+- Endpoint `FluxoController::index(Request $r): Response` lê:
+  - `session('user.business_id')`
+  - `?tab=projetado|realizado` (clamp default projetado)
+  - `?dias=N` (clamp 7..60, default 35 — só tab Projetado)
+  - `?meses=N` (clamp 1..36, default 12 — só tab Realizado)
+- Service `FluxoCaixaService::projetar(int $businessId, int $dias = 35): array` (tab Projetado) orquestra:
   - `SUM(ContaBancaria.saldo_cached)` WHERE ativo (saldo hoje)
   - `Titulo` WHERE `business_id` AND `status IN (aberto,parcial)` AND `vencimento BETWEEN today AND today+N` (futuros)
   - `TituloBaixa` WHERE `business_id` AND `data_baixa BETWEEN today-2 AND today-1` AND `estorno_de_id IS NULL` (histórico)
-- Multi-tenant: `Titulo`, `TituloBaixa`, `ContaBancaria` usam `BusinessScope` global scope (defesa em profundidade — Service também explicita)
+- Service `FluxoRealizadoService::buscar(int $businessId, int $meses = 12): array` (tab Realizado, Fase 3) orquestra:
+  - `fin_titulo_baixas` JOIN `fin_titulos` GROUP BY `YEAR(data_baixa), MONTH(data_baixa), titulo.tipo`
+  - WHERE `b.business_id = ?` AND `t.business_id = ?` (filtro duplicado defensivo)
+  - WHERE `b.estorno_de_id IS NULL` AND `t.deleted_at IS NULL`
+  - Janela materializada (zera meses sem baixa pra UI consistente)
+- Lazy load: payload Realizado só carrega quando `tab=realizado` (props `realizado === null` quando tab=projetado)
+- Multi-tenant: `Titulo`, `TituloBaixa`, `ContaBancaria` usam `BusinessScope` global scope (defesa em profundidade — Services também explicitam business_id)
 - Permission canon: `financeiro.dashboard.view` (granularidade `financeiro.fluxo.view` em backlog F2)
 
 ---
@@ -116,8 +157,9 @@ Mostrar **projeção de 35 dias de fluxo de caixa** (saldo, entradas e saídas d
 
 ---
 
-## Métricas vivas (Pest GUARD em [FluxoControllerTest.php](../../../../Modules/Financeiro/Tests/Feature/FluxoControllerTest.php))
+## Métricas vivas
 
+### Pest GUARD Projetado (US-FIN-014) — [FluxoControllerTest.php](../../../../Modules/Financeiro/Tests/Feature/FluxoControllerTest.php)
 ```php
 it('renderiza Inertia component Financeiro/Fluxo/Index')
 it('expõe Props no shape esperado (saldo_hoje, saldo_30d, pior_dia, margem_minima, conta, dias)')
@@ -125,6 +167,20 @@ it('expõe margem_minima padrão R$ 5000 (Q3 hardcode aprovado 2026-05-14)')
 it('aplica clamp em ?dias=N (range 7..60, default 35)')
 it('Tier 0 IRREVOGÁVEL: query Titulo respeita business_id global scope (ADR 0093)')
 it('não dispara mutação em GET /fluxo (read-only puro)')
+```
+
+### Pest GUARD Realizado (US-FIN-014c, Fase 3) — [FluxoRealizadoControllerTest.php](../../../../Modules/Financeiro/Tests/Feature/FluxoRealizadoControllerTest.php)
+```php
+it('tab default = projetado (sem query string)')
+it('tab=realizado expõe payload canon (meta + totais + meses)')
+it('tab=realizado retorna exatamente 12 meses por default (janela canon)')
+it('cada mes do realizado tem shape esperado (mes, entradas, saidas, saldo, qtd_baixas, is_current)')
+it('tab inválido cai pra default projetado')
+it('?meses=N respeita clamp 1..36')
+it('Tier 0 IRREVOGÁVEL: realizado respeita business_id (ADR 0093)')
+it('tab=projetado não carrega payload realizado (perf — evita query custosa)')
+it('não dispara mutação em GET /fluxo?tab=realizado (read-only puro)')
+it('totais.saldo = totais.entradas - totais.saidas (invariante contábil)')
 ```
 
 ---
@@ -155,3 +211,4 @@ it('não dispara mutação em GET /fluxo (read-only puro)')
 | Data | Autor | Mudança |
 |---|---|---|
 | 2026-05-14 | Wagner [W] + Claude Code [CL] | F3 entregue — Service + Controller + Page + Pest + charter + route + topnav. Pre-flight `LICOES_F3_FINANCEIRO_REJEITADO.md` aplicado literalmente (Models reais, `session('user.business_id')`, middleware stack canon, `shape*()` helper, `whereNull('deleted_at')`, sem mock `rand()`, sem mutação NO-OP). Q1-Q4 aprovadas [W] 2026-05-14. |
+| 2026-05-21 | Wagner [W] + Claude Code [CL] | **Fase 3 deprecação legacy** — adiciona tab "Realizado" (US-FIN-014c) pra absorver Cash Flow legacy do core (já redirecionado por PR #1283). `FluxoRealizadoService` novo agrega `fin_titulo_baixas` × `fin_titulos` por YYYY-MM. URL preserva tab via `?tab=projetado|realizado`. Janela 12M default + clamp `?meses=N` 1..36. Lazy load payload Realizado (perf). 10 testes Pest novos cobrindo shape, clamp, multi-tenant Tier 0, invariante contábil, read-only. Comportamento Projetado preservado 100% (props raiz inalteradas). |

--- a/resources/js/Pages/Financeiro/Fluxo/Index.tsx
+++ b/resources/js/Pages/Financeiro/Fluxo/Index.tsx
@@ -2,16 +2,19 @@
 //   tela: /financeiro/fluxo
 //   module: Financeiro
 //   status: em-implementacao
-//   stories: US-FIN-014 (fluxo-caixa-projetado)
+//   stories: US-FIN-014 (fluxo-caixa-projetado), US-FIN-014c (fluxo-realizado)
 //   rules: R-FIN-001 (multi-tenant), R-FIN-008 (limite-minimo-caixa)
 //   adrs: ui/0114 (cockpit-v2), 0093 (multi-tenant Tier 0)
 //   tests: Modules/Financeiro/Tests/Feature/FluxoControllerTest
 //
 // Origem: prototipo Cowork "Fluxo de Caixa" aprovado [W] 2026-05-09.
 // Decisões Q1-Q4 aprovadas [W] 2026-05-14 (memory/requisitos/Financeiro/fluxo-visual-comparison.md).
+// Fase 3 deprecação legacy 2026-05-21: tab Realizado absorve Cash Flow legacy
+//  (`/account/cash-flow` → 301 → `/financeiro/fluxo?tab=realizado` via PR #1283).
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Card } from '@/Components/ui/card';
+import { router } from '@inertiajs/react';
 import { useMemo, type ReactNode } from 'react';
 
 interface Dia {
@@ -33,6 +36,35 @@ interface Dia {
   }[];
 }
 
+interface MesRealizado {
+  mes: string;
+  mes_label: string;
+  ano: number;
+  entradas: number;
+  saidas: number;
+  saldo: number;
+  qtd_baixas: number;
+  is_current: boolean;
+}
+
+interface Realizado {
+  meta: {
+    meses_janela: number;
+    primeiro_mes: string;
+    ultimo_mes: string;
+    business_id: number;
+  };
+  totais: {
+    entradas: number;
+    saidas: number;
+    saldo: number;
+    qtd_baixas: number;
+  };
+  meses: MesRealizado[];
+}
+
+type TabAtiva = 'projetado' | 'realizado';
+
 interface Props {
   saldo_hoje: number;
   saldo_30d: number;
@@ -40,6 +72,8 @@ interface Props {
   margem_minima: number;
   conta: string;
   dias: Dia[];
+  tab?: TabAtiva;
+  realizado?: Realizado | null;
 }
 
 const brl = (v: number) =>
@@ -47,7 +81,62 @@ const brl = (v: number) =>
 
 const brlNoSign = (v: number) => brl(Math.abs(v)).replace('R$', '').trim();
 
-function FinanceiroFluxo({ saldo_hoje, saldo_30d, pior_dia, margem_minima, conta, dias }: Props) {
+function TabSwitcher({ tab }: { tab: TabAtiva }) {
+  // Fase 3 — pill segmented control consistente com Cobranca/Index.tsx pattern.
+  // router.visit preserva scroll + replace na URL (?tab=X) pra deep-link funcionar.
+  const trocaTab = (alvo: TabAtiva) => {
+    if (alvo === tab) return;
+    router.visit(`/financeiro/fluxo?tab=${alvo}`, {
+      preserveScroll: true,
+      replace: true,
+    });
+  };
+
+  const items: { id: TabAtiva; label: string; hint: string }[] = [
+    { id: 'projetado', label: 'Projetado', hint: 'próx 35 dias' },
+    { id: 'realizado', label: 'Realizado', hint: 'últ 12 meses' },
+  ];
+
+  return (
+    <div className="px-6 pt-3 pb-1">
+      <div className="inline-flex bg-stone-100/80 rounded-md p-0.5 border border-stone-200">
+        {items.map((it) => (
+          <button
+            key={it.id}
+            type="button"
+            onClick={() => trocaTab(it.id)}
+            className={
+              'h-8 px-4 rounded text-[12.5px] flex items-center gap-2 transition tabular-nums ' +
+              (tab === it.id
+                ? 'bg-white shadow-sm font-medium text-stone-900'
+                : 'text-stone-600 hover:text-stone-800')
+            }
+            aria-pressed={tab === it.id}
+          >
+            <span>{it.label}</span>
+            <span
+              className={
+                'text-[10px] uppercase tracking-wider ' +
+                (tab === it.id ? 'text-stone-500' : 'text-stone-400')
+              }
+            >
+              {it.hint}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ProjetadoView({
+  saldo_hoje,
+  saldo_30d,
+  pior_dia,
+  margem_minima,
+  conta,
+  dias,
+}: Pick<Props, 'saldo_hoje' | 'saldo_30d' | 'pior_dia' | 'margem_minima' | 'conta' | 'dias'>) {
   const { minSaldo, maxSaldo } = useMemo(() => {
     const saldos = dias.map((d) => d.saldo_acumulado);
     return {
@@ -62,18 +151,8 @@ function FinanceiroFluxo({ saldo_hoje, saldo_30d, pior_dia, margem_minima, conta
   const proxEventos = dias.filter((d) => !d.is_past && d.eventos.length > 0).slice(0, 7);
 
   return (
-    <div className="fin-curadoria vendas-aplus">
-      {/* Onda 12.8 (2026-05-19) — header canon paridade Unificado (substitui PageHeader shared) */}
-      <header className="os-page-h fin-page-h">
-        <div className="os-page-h-l fin-page-h-l">
-          <h1>Fluxo de caixa <span className="fin-hero-title-sub">· Projeção 35 dias</span></h1>
-          <p>Saldo, entradas e saídas dia-a-dia</p>
-        </div>
-      </header>
-
-      {/* Onda 18 (2026-05-19) #47 — Fallback friendly quando biz sem ContaBancaria.
-          Antes mostrava "Sem conta cadastrada" em fonte cinza pequena — UX ruim.
-          Agora CTA pra cadastrar conta. */}
+    <>
+      {/* Onda 18 (2026-05-19) #47 — Fallback friendly quando biz sem ContaBancaria. */}
       {conta === 'Sem conta cadastrada' && (
         <div style={{
           background: 'oklch(0.96 0.04 70)',
@@ -230,6 +309,234 @@ function FinanceiroFluxo({ saldo_hoje, saldo_30d, pior_dia, margem_minima, conta
           </table>
         )}
       </Card>
+    </>
+  );
+}
+
+function RealizadoView({ realizado }: { realizado: Realizado | null | undefined }) {
+  // Hook ANTES do early return (Rules of Hooks). meses default [] pra evitar
+  // spread em undefined; Math.max([], 1) = 1 (safe).
+  const meses = realizado?.meses ?? [];
+  const maxAbs = useMemo(
+    () => Math.max(...meses.map((m) => Math.max(m.entradas, m.saidas)), 1),
+    [meses],
+  );
+
+  // Defensiva: tab=realizado deve sempre trazer payload, mas se Inertia partial
+  // reload pular, renderiza skeleton-like empty state.
+  if (!realizado) {
+    return (
+      <Card className="mx-6 mt-4 mb-4 p-8 text-center text-[13px] text-stone-500">
+        Carregando movimentações realizadas…
+      </Card>
+    );
+  }
+
+  const { totais, meta } = realizado;
+
+  return (
+    <>
+      {/* KPI grid Realizado — 4 cards: entradas/saidas/saldo do período + qtd baixas */}
+      <div className="fin-stats">
+        <div className="fin-stat fin-stat-hero">
+          <small>SALDO {meta.meses_janela}M</small>
+          <b className={totais.saldo >= 0 ? 'fin-num-pos' : 'fin-num-neg'}>{brl(totais.saldo)}</b>
+          <span className="fin-stat-hint">{meses[0]?.mes_label} → {meses[meses.length - 1]?.mes_label}</span>
+        </div>
+        <div className="fin-stat">
+          <small>ENTRADAS</small>
+          <b className="fin-num-pos">{brl(totais.entradas)}</b>
+          <span className="fin-stat-hint">recebimentos confirmados</span>
+        </div>
+        <div className="fin-stat">
+          <small>SAÍDAS</small>
+          <b className="fin-num-neg">{brl(totais.saidas)}</b>
+          <span className="fin-stat-hint">pagamentos confirmados</span>
+        </div>
+        <div className="fin-stat">
+          <small>BAIXAS REGISTRADAS</small>
+          <b>{totais.qtd_baixas}</b>
+          <span className="fin-stat-hint">no período</span>
+        </div>
+      </div>
+
+      {/* Gráfico de barras gemelhas por mês (entradas vs saídas lado-a-lado) */}
+      <Card className="mx-6 mt-4 p-5">
+        <div className="flex items-center justify-between mb-3">
+          <div>
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium">
+              Movimentações realizadas · últimos {meta.meses_janela} meses
+            </div>
+            <div className="text-[14px] font-semibold mt-0.5">
+              barra verde = entradas · barra rosa = saídas (escala R$)
+            </div>
+          </div>
+          <div className="flex items-center gap-3 text-[11.5px] text-stone-500">
+            <span className="flex items-center gap-1.5">
+              <span className="w-2.5 h-2.5 rounded-sm bg-emerald-500" /> entradas
+            </span>
+            <span className="flex items-center gap-1.5">
+              <span className="w-2.5 h-2.5 rounded-sm bg-rose-500" /> saídas
+            </span>
+          </div>
+        </div>
+
+        <div className="relative h-[200px] border-b border-stone-200 mt-2 flex items-end gap-1">
+          {meses.map((m) => {
+            const hEnt = (m.entradas / maxAbs) * 100;
+            const hSai = (m.saidas / maxAbs) * 100;
+            return (
+              <div key={m.mes} className="flex-1 h-full flex items-end gap-0.5 relative group">
+                <div
+                  className={`flex-1 ${m.is_current ? 'bg-emerald-600' : 'bg-emerald-500'}`}
+                  style={{ height: `${hEnt}%` }}
+                  title={`${m.mes_label}: entradas ${brl(m.entradas)}`}
+                />
+                <div
+                  className={`flex-1 ${m.is_current ? 'bg-rose-600' : 'bg-rose-500'}`}
+                  style={{ height: `${hSai}%` }}
+                  title={`${m.mes_label}: saídas ${brl(m.saidas)}`}
+                />
+                <div className="hidden group-hover:block absolute -top-16 left-1/2 -translate-x-1/2 z-10 bg-stone-900 text-white text-[10.5px] rounded px-2 py-1 whitespace-nowrap tabular-nums">
+                  {m.mes_label} · saldo {brl(m.saldo)}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="flex gap-1 mt-1.5 text-[9.5px] text-stone-500 tabular-nums">
+          {meses.map((m) => (
+            <div
+              key={m.mes}
+              className={`flex-1 text-center ${m.is_current ? 'font-bold text-stone-900' : ''}`}
+            >
+              {m.mes_label}
+            </div>
+          ))}
+        </div>
+      </Card>
+
+      {/* Tabela detalhada mês × entradas × saídas × saldo */}
+      <Card className="mx-6 mt-4 mb-4 overflow-hidden">
+        <div className="px-5 py-3 border-b border-stone-200 flex items-center gap-3">
+          <div className="min-w-0">
+            <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium whitespace-nowrap">
+              Detalhe por mês
+            </div>
+            <div className="text-[14px] font-semibold mt-0.5 whitespace-nowrap">
+              {meses.length} {meses.length === 1 ? 'mês' : 'meses'}
+            </div>
+          </div>
+          <div className="ml-auto text-[11.5px] text-stone-500 whitespace-nowrap shrink-0">
+            {totais.qtd_baixas} {totais.qtd_baixas === 1 ? 'baixa' : 'baixas'} registradas
+          </div>
+        </div>
+
+        {totais.qtd_baixas === 0 ? (
+          <div className="px-6 py-8 text-center text-[12.5px] text-stone-500">
+            Nenhuma baixa registrada nos últimos {meta.meses_janela} meses.
+          </div>
+        ) : (
+          <table className="w-full text-[12.5px] tabular-nums">
+            <thead>
+              <tr className="border-b border-stone-200 text-[10.5px] uppercase tracking-widest text-stone-500">
+                <th className="pl-6 pr-3 py-2 text-left font-medium">Mês</th>
+                <th className="px-3 py-2 text-right font-medium">Entradas</th>
+                <th className="px-3 py-2 text-right font-medium">Saídas</th>
+                <th className="px-3 py-2 text-right font-medium">Saldo</th>
+                <th className="pr-6 py-2 text-right font-medium">Baixas</th>
+              </tr>
+            </thead>
+            <tbody>
+              {meses.map((m) => (
+                <tr
+                  key={m.mes}
+                  className={`border-b border-stone-100 hover:bg-stone-50/60 ${
+                    m.is_current ? 'bg-stone-50/40' : ''
+                  }`}
+                >
+                  <td className={`pl-6 pr-3 py-2 ${m.is_current ? 'font-semibold text-stone-900' : 'text-stone-700'}`}>
+                    {m.mes_label}
+                    {m.is_current && (
+                      <span className="ml-2 text-[10px] uppercase tracking-wider text-stone-500">atual</span>
+                    )}
+                  </td>
+                  <td className="px-3 py-2 text-right text-emerald-700 font-medium">
+                    {m.entradas > 0 ? '+ ' + brlNoSign(m.entradas) : '—'}
+                  </td>
+                  <td className="px-3 py-2 text-right text-rose-700 font-medium">
+                    {m.saidas > 0 ? '− ' + brlNoSign(m.saidas) : '—'}
+                  </td>
+                  <td
+                    className={`px-3 py-2 text-right font-semibold ${
+                      m.saldo > 0 ? 'text-emerald-700' : m.saldo < 0 ? 'text-rose-700' : 'text-stone-700'
+                    }`}
+                  >
+                    {brl(m.saldo)}
+                  </td>
+                  <td className="pr-6 py-2 text-right text-stone-500">{m.qtd_baixas}</td>
+                </tr>
+              ))}
+              <tr className="border-t-2 border-t-stone-300 bg-stone-50/60 font-semibold">
+                <td className="pl-6 pr-3 py-2 text-stone-900">Total {meta.meses_janela}M</td>
+                <td className="px-3 py-2 text-right text-emerald-800">+ {brlNoSign(totais.entradas)}</td>
+                <td className="px-3 py-2 text-right text-rose-800">− {brlNoSign(totais.saidas)}</td>
+                <td
+                  className={`px-3 py-2 text-right ${
+                    totais.saldo >= 0 ? 'text-emerald-800' : 'text-rose-800'
+                  }`}
+                >
+                  {brl(totais.saldo)}
+                </td>
+                <td className="pr-6 py-2 text-right text-stone-700">{totais.qtd_baixas}</td>
+              </tr>
+            </tbody>
+          </table>
+        )}
+      </Card>
+    </>
+  );
+}
+
+function FinanceiroFluxo(props: Props) {
+  const tab: TabAtiva = props.tab ?? 'projetado';
+
+  const headerSub =
+    tab === 'realizado'
+      ? `Realizado · últ ${props.realizado?.meta.meses_janela ?? 12} meses`
+      : 'Projeção 35 dias';
+
+  return (
+    <div className="fin-curadoria vendas-aplus">
+      {/* Onda 12.8 (2026-05-19) — header canon paridade Unificado */}
+      <header className="os-page-h fin-page-h">
+        <div className="os-page-h-l fin-page-h-l">
+          <h1>
+            Fluxo de caixa <span className="fin-hero-title-sub">· {headerSub}</span>
+          </h1>
+          <p>
+            {tab === 'realizado'
+              ? 'Entradas e saídas confirmadas, agrupadas por mês'
+              : 'Saldo, entradas e saídas dia-a-dia'}
+          </p>
+        </div>
+      </header>
+
+      <TabSwitcher tab={tab} />
+
+      {tab === 'projetado' ? (
+        <ProjetadoView
+          saldo_hoje={props.saldo_hoje}
+          saldo_30d={props.saldo_30d}
+          pior_dia={props.pior_dia}
+          margem_minima={props.margem_minima}
+          conta={props.conta}
+          dias={props.dias}
+        />
+      ) : (
+        <RealizadoView realizado={props.realizado ?? null} />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Contexto

PR #1283 (Fase 2) redireciona `/account/cash-flow` -> `/financeiro/fluxo` via 301, mas o usuario que vinha do Cash Flow legacy do core UltimatePOS perdia a visao **historica** (Cash Flow legacy mostra movimentacoes confirmadas; o Fluxo atual so mostra projecao). Esta Fase 3 absorve a feature adicionando uma tab **Realizado** ao lado da tab **Projetado** existente.

Pre-requisitos ja em `main`:
- PR #1279 sidebar 9 entradas
- PR #1281 sub-grupos visuais
- PR #1282 esconde dropdowns legacy
- PR #1283 redireciona `/account/*` -> Financeiro
- PR #1284 ETL `expense` -> `fin_titulos`

## Summary

- US-FIN-014c **(nova)**: tab Realizado agrega `fin_titulo_baixas` por YYYY-MM nos ultimos 12 meses, mostrando entradas (receber) - saidas (pagar) = saldo do mes. KPIs do periodo + grafico de barras gemelhas + tabela detalhada com linha total.
- Comportamento **Projetado** (US-FIN-014) preservado **100%** nos props raiz - testes existentes (`FluxoControllerTest` + `FluxoCaixaServiceTest`) nao quebram.
- Tab default = `projetado`. URL preserva via `?tab=projetado|realizado`. Tab invalido cai pra default.
- Lazy load: payload Realizado so carrega quando `tab=realizado` (perf - evita query mensal custosa quando nao vai exibir).
- Janela default 12M; `?meses=N` aceita 1..36 (clamp defensivo).

## Backend

| Arquivo | Mudanca |
|---|---|
| `Modules/Financeiro/Services/FluxoRealizadoService.php` | **Novo** (175 linhas). Query agregada SQL `GROUP BY YEAR/MONTH x titulo.tipo`. JOIN baixa->titulo com `b.business_id` E `t.business_id` (duplicado defensivo). Ignora estornos (`estorno_de_id IS NULL`) consistente com `FluxoCaixaService` historico. Materializa janela completa (zera meses sem baixa pra UI consistente). |
| `Modules/Financeiro/Http/Controllers/FluxoController.php` | Aceita `?tab=projetado\|realizado` (clamp default), `?meses=N` (clamp 1..36). Constructor injeta `FluxoRealizadoService`. `Inertia::render` recebe merge de payload Projetado + `tab` + `realizado` (null quando tab=projetado). |

## Frontend

`resources/js/Pages/Financeiro/Fluxo/Index.tsx` refatorado em 3 componentes:
- **`TabSwitcher`** - pill segmented control consistente com `Cobranca/Index.tsx` pattern. URL preserva via `router.visit('?tab=X')` com `replace + preserveScroll`.
- **`ProjetadoView`** - extraido da implementacao original sem alteracoes funcionais.
- **`RealizadoView`** - 4 KPI cards + grafico barras gemelhas (entradas verde x saidas rosa) + tabela detalhada com linha total agregado. Skeleton fallback quando partial reload sem payload.

## Tier 0 IRREVOGAVEL (ADR 0093)

- `business_id` explicito em **AMBAS** `b.business_id` (baixa) E `t.business_id` (titulo) - filtro duplicado defensivo.
- `BusinessScope` global scope mantido em `TituloBaixa`.
- Pest GUARD valida que counts cross-tenant nao vazam (`withoutGlobalScopes()` count > scoped count quando ha dados de outros tenants).

## Tests

10 testes novos em `FluxoRealizadoControllerTest.php`:
- tab default = projetado / tab invalido cai pra default
- payload Realizado no shape canon (meta + totais + meses)
- 12 meses exatos por default + clamp `?meses=N` 1..36
- cada mes com shape esperado + **invariante saldo = entradas - saidas** (delta < R$ 0.01)
- Tier 0 multi-tenant business_id ADR 0093
- lazy load (tab=projetado NAO traz payload realizado)
- read-only (nao dispara mutacao em GET)
- SUM(meses) == totais (consistencia agregada)
- Skip gracioso em DB greenfield (padrao `Modules/Financeiro`)

## Charter atualizado

`Pages/Financeiro/Fluxo/Index.charter.md` v2 - historico apendado, Goals/Non-Goals separados por tab, Automation Hooks reflete novo Service, 10 testes Pest documentados. Anti-aluucinacao preservada (cada Non-Goal vira Pest GUARD).

## Diff stats

```
5 files changed, 899 insertions(+), 40 deletions(-)
```

Acima do alvo `commit-discipline` 300 linhas porque o escopo "absorver feature legacy" justificadamente toca Controller + Service novo + Page refatorada + charter + Pest. Sem split possivel sem deixar feature pela metade.

## Infra impact

- **NAO toca** middleware, routes/web.php, Kernel, ServiceProviders, .htaccess.
- **TOCA** apenas `Modules/Financeiro/**` e `resources/js/Pages/Financeiro/Fluxo/**`.
- Sem infra-contract gate ativado.

## Test plan

- [ ] CI rodar Pest suite Financeiro completa (FluxoControllerTest + FluxoRealizadoControllerTest + FluxoCaixaServiceTest devem passar).
- [ ] Visual smoke `/financeiro/fluxo` (tab Projetado preservado) + `/financeiro/fluxo?tab=realizado` (tab nova).
- [ ] Smoke 301 `/account/cash-flow` -> `/financeiro/fluxo` (PR #1283) continua funcionando.

Refs: PR #1279 #1281 #1282 #1283 #1284 (sequencia Fase 1->5 deprecacao legacy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)