### PR TITLE
feat(financeiro): Fase 6 deprecação legacy — Caixa Soft wrapper Inertia (/financeiro/caixa read-only)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/CaixaController.php
+++ b/Modules/Financeiro/Http/Controllers/CaixaController.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Financeiro\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use App\Util\OtelHelper;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Inertia\Inertia;
+use Inertia\Response;
+
+/**
+ * Tela /financeiro/caixa — wrapper Inertia sobre cash_registers core UltimatePOS.
+ *
+ * Wagner 2026-05-21 Fase 6 deprecação legacy (Soft wrapper). NÃO migra dados —
+ * reusa tabela `cash_registers` + `cash_register_transactions` do core.
+ * Apenas adiciona view Inertia bonita + entrada no sidebar Financeiro pra Larissa
+ * descobrir histórico de fechamentos sem precisar voltar à tela POS.
+ *
+ * Lifecycle real (abrir/fechar caixa) CONTINUA na header POS (`/sells/pos/create`)
+ * via `CashRegisterController` core. Esta tela é READ-ONLY (histórico + atual).
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): `business_id` lido de
+ * `session('user.business_id')`, filtra SQL explícito.
+ *
+ * Permission gate: `view_cash_register` (mesmo do CashRegisterController core).
+ *
+ * Endpoints:
+ *  - GET /financeiro/caixa → Inertia render
+ *
+ * Reversibilidade: deletar este Controller + Page Inertia + rota + entrada
+ * sidebar não afeta NADA do POS/core. Nenhuma migration, nenhuma mudança em
+ * cash_registers table.
+ */
+class CaixaController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth');
+        $this->middleware('can:view_cash_register');
+    }
+
+    public function index(Request $request): Response
+    {
+        $businessId = (int) session('user.business_id');
+
+        return OtelHelper::spanBiz('financeiro.caixa.index', function () use ($businessId, $request) {
+            $statusFilter = $request->query('status'); // null|'open'|'close'
+            $limit = (int) ($request->query('limit') ?? 50);
+            $limit = max(10, min(200, $limit)); // clamp [10, 200]
+
+            $query = DB::table('cash_registers as cr')
+                ->where('cr.business_id', $businessId)
+                ->leftJoin('users as u', 'u.id', '=', 'cr.user_id')
+                ->leftJoin('business_locations as bl', 'bl.id', '=', 'cr.location_id')
+                ->select(
+                    'cr.id',
+                    'cr.status',
+                    'cr.created_at as open_time',
+                    'cr.closed_at as close_time',
+                    'cr.closing_amount',
+                    'cr.total_card_slips',
+                    'cr.total_cheques',
+                    'cr.closing_note',
+                    'cr.user_id',
+                    DB::raw("TRIM(CONCAT(COALESCE(u.first_name,''),' ',COALESCE(u.last_name,''))) as user_name"),
+                    'cr.location_id',
+                    'bl.name as location_name'
+                );
+
+            if ($statusFilter === 'open' || $statusFilter === 'close') {
+                $query->where('cr.status', $statusFilter);
+            }
+
+            $caixas = $query
+                ->orderByDesc('cr.created_at')
+                ->limit($limit)
+                ->get()
+                ->map(function ($row) {
+                    // Soma transações por método (consulta agregada — N+1 OK pra ≤200 rows)
+                    $totals = DB::table('cash_register_transactions')
+                        ->where('cash_register_id', $row->id)
+                        ->whereNull('parent_id') // ignora estornos
+                        ->selectRaw('
+                            SUM(CASE WHEN type="credit" THEN amount ELSE 0 END) as total_credit,
+                            SUM(CASE WHEN type="debit" THEN amount ELSE 0 END) as total_debit
+                        ')
+                        ->first();
+
+                    return [
+                        'id' => (int) $row->id,
+                        'status' => (string) $row->status,
+                        'open_time' => $row->open_time,
+                        'close_time' => $row->close_time,
+                        'closing_amount' => (float) $row->closing_amount,
+                        'total_credit' => (float) ($totals->total_credit ?? 0.0),
+                        'total_debit' => (float) ($totals->total_debit ?? 0.0),
+                        'total_card_slips' => (int) ($row->total_card_slips ?? 0),
+                        'total_cheques' => (int) ($row->total_cheques ?? 0),
+                        'closing_note' => $row->closing_note,
+                        'user_id' => (int) ($row->user_id ?? 0),
+                        'user_name' => trim((string) ($row->user_name ?? '')) ?: '—',
+                        'location_id' => (int) ($row->location_id ?? 0),
+                        'location_name' => $row->location_name ?? '—',
+                    ];
+                });
+
+            // Total agregado pra cards do topo
+            $stats = DB::table('cash_registers')
+                ->where('business_id', $businessId)
+                ->selectRaw('
+                    COUNT(*) as total_caixas,
+                    SUM(CASE WHEN status="open" THEN 1 ELSE 0 END) as caixas_abertos,
+                    SUM(CASE WHEN status="close" THEN closing_amount ELSE 0 END) as soma_fechamentos
+                ')
+                ->first();
+
+            return Inertia::render('Financeiro/Caixa/Index', [
+                'caixas' => $caixas->values(),
+                'stats' => [
+                    'total_caixas' => (int) ($stats->total_caixas ?? 0),
+                    'caixas_abertos' => (int) ($stats->caixas_abertos ?? 0),
+                    'soma_fechamentos' => (float) ($stats->soma_fechamentos ?? 0.0),
+                ],
+                'filters' => [
+                    'status' => $statusFilter,
+                    'limit' => $limit,
+                ],
+                'links' => [
+                    // Atalho pro POS legacy onde de fato abre/fecha caixa.
+                    'pos_create' => '/pos/create',
+                    'cash_register_legacy' => '/cash-register',
+                ],
+            ]);
+        }, ['op' => 'index']);
+    }
+}

--- a/Modules/Financeiro/Http/Controllers/DataController.php
+++ b/Modules/Financeiro/Http/Controllers/DataController.php
@@ -107,6 +107,7 @@ class DataController extends Controller
         //     85.20  Contas a Pagar        /financeiro/contas-pagar         ← novo no sidebar
         //     85.30  Fluxo de Caixa        /financeiro/fluxo
         //     85.40  Cobrança              /financeiro/cobranca
+        //     85.45  Caixa do turno        /financeiro/caixa (Fase 6 Soft)
         //   FINANCEIRO · ANÁLISE (fechado — mensal)
         //     85.50  Conciliação           /financeiro/conciliacao
         //     85.60  DRE                   /financeiro/dre
@@ -193,6 +194,23 @@ class DataController extends Controller
                         'group'  => 'fin-op',
                     ]
                 )->order(85.40);
+
+                // Caixa do turno — Wagner 2026-05-21 Fase 6 Soft (wrapper Inertia).
+                // Tela read-only sobre cash_registers core UltimatePOS; lifecycle
+                // abrir/fechar continua na header POS. Larissa descobre histórico
+                // de fechamentos sem precisar voltar à tela POS.
+                // Permission gate `view_cash_register` enforce no CaixaController.
+                if (auth()->user()->can('view_cash_register')) {
+                    $menu->url(
+                        url('/financeiro/caixa'),
+                        'Caixa do turno',
+                        [
+                            'icon'   => 'fa fas fa-cash-register',
+                            'active' => $segmento_ativo && request()->segment(2) === 'caixa',
+                            'group'  => 'fin-op',
+                        ]
+                    )->order(85.45);
+                }
 
                 // ═══════════════════════════════════════════════════════════
                 // SUB-GRUPO 2: FINANCEIRO · ANÁLISE (fechado por default)

--- a/Modules/Financeiro/Routes/web.php
+++ b/Modules/Financeiro/Routes/web.php
@@ -6,6 +6,7 @@ use Modules\Financeiro\Http\Controllers\Advisor\AdvisorPortalController;
 use Modules\Financeiro\Http\Controllers\AdvisorAccessController;
 use Modules\Financeiro\Http\Controllers\AssinaturaController;
 use Modules\Financeiro\Http\Controllers\BoletoController;
+use Modules\Financeiro\Http\Controllers\CaixaController;
 use Modules\Financeiro\Http\Controllers\CategoriaController;
 use Modules\Financeiro\Http\Controllers\CobrancaController;
 use Modules\Financeiro\Http\Controllers\ConciliacaoController;
@@ -169,6 +170,12 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
 
         // Alias canonical: /financeiro/dashboard → /financeiro (URL canônica é a raiz)
         Route::redirect('/dashboard', '/financeiro', 301)->name('dashboard.alias');
+
+        // Wagner 2026-05-21 Fase 6 Soft (wrapper Inertia) — caixa do turno read-only.
+        // Lifecycle (abrir/fechar) continua na header POS via CashRegisterController core;
+        // esta tela é só descoberta + histórico no Financeiro.
+        // Permission gate `view_cash_register` no Controller.
+        Route::get('/caixa', [CaixaController::class, 'index'])->name('caixa.index');
 
         // Categorias livres (CRUD complementar ao plano de contas)
         Route::get('/categorias', [CategoriaController::class, 'index'])->name('categorias.index');

--- a/Modules/Financeiro/SCOPE.md
+++ b/Modules/Financeiro/SCOPE.md
@@ -7,6 +7,7 @@ contains:
   - "Advisor/AdvisorPortalController — Onda 31 US-FIN-037 dashboard /advisor (cards Meus clientes)"
   - "AssinaturaController — FIN-004 atualizar cobrança recorrente (multi-tenant Tier 0, gateway delegado a AssinaturaCobrancaService)"
   - "BoletoController"
+  - "CaixaController — F6 Soft wrapper Inertia /financeiro/caixa read-only sobre cash_registers core UltimatePOS (não migra dados; lifecycle abrir/fechar continua na header POS via CashRegisterController core)"
   - "CategoriaController"
   - "CobrancaController — F3 PaymentGateway UI Tela 1 (substitui /financeiro/boletos com escopo expandido boleto+pix+pix_recv+card; ADR 0144 + 0170)"
   - "ConciliacaoController — Onda 19 OFX MVP + scaffold Anexos/Aprovação"

--- a/Modules/Financeiro/Tests/Feature/CaixaControllerTest.php
+++ b/Modules/Financeiro/Tests/Feature/CaixaControllerTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Inertia\Testing\AssertableInertia;
+use Spatie\Permission\Models\Permission;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-FIN-CAIXA — guard da tela /financeiro/caixa (F6 Soft wrapper).
+ *
+ * Cobre invariantes:
+ *  1. Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): business B não vê caixas de A
+ *  2. Permission gate `view_cash_register` enforce
+ *  3. Inertia component path + shape esperado (caixas[], stats, filters, links)
+ *  4. Filtro `?status=open|close` aplica
+ *  5. `?limit` clamped em [10, 200]
+ *
+ * Skip gracioso (Financeiro convention) quando DB greenfield ou subscription gate.
+ */
+function caixaBootstrap(): User
+{
+    try {
+        $business = Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: '.$e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco.');
+    }
+
+    $user = User::where('business_id', $business->id)->first();
+    if (! $user) {
+        test()->markTestSkipped('Sem user no business.');
+    }
+
+    Permission::firstOrCreate(['name' => 'view_cash_register', 'guard_name' => 'web']);
+    if (! $user->hasPermissionTo('view_cash_register')) {
+        $user->givePermissionTo('view_cash_register');
+    }
+
+    session([
+        'user.id' => $user->id,
+        'user.business_id' => $business->id,
+        'business.id' => $business->id,
+    ]);
+
+    return $user;
+}
+
+it('renderiza Inertia component Financeiro/Caixa/Index com shape esperado', function () {
+    $user = caixaBootstrap();
+
+    $response = $this->actingAs($user)->get('/financeiro/caixa');
+
+    $response->assertStatus(200);
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Financeiro/Caixa/Index')
+        ->has('caixas')
+        ->has('stats.total_caixas')
+        ->has('stats.caixas_abertos')
+        ->has('stats.soma_fechamentos')
+        ->has('filters.status')
+        ->has('filters.limit')
+        ->has('links.pos_create')
+    );
+});
+
+it('bloqueia user sem permission view_cash_register (403)', function () {
+    $business = Business::first();
+    if (! $business) {
+        $this->markTestSkipped('Sem business.');
+    }
+    $user = User::where('business_id', $business->id)->first();
+    if (! $user) {
+        $this->markTestSkipped('Sem user.');
+    }
+
+    // Garante que NÃO tem a permission
+    if ($user->hasPermissionTo('view_cash_register')) {
+        $user->revokePermissionTo('view_cash_register');
+    }
+
+    session([
+        'user.id' => $user->id,
+        'user.business_id' => $business->id,
+        'business.id' => $business->id,
+    ]);
+
+    $response = $this->actingAs($user)->get('/financeiro/caixa');
+
+    expect($response->status())->toBeIn([403, 302]); // 403 forbidden ou redirect login
+});
+
+it('aplica filtro ?status=open na query', function () {
+    $user = caixaBootstrap();
+
+    $response = $this->actingAs($user)->get('/financeiro/caixa?status=open');
+
+    $response->assertStatus(200);
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->where('filters.status', 'open')
+    );
+});
+
+it('clamp ?limit acima de 200 vira 200', function () {
+    $user = caixaBootstrap();
+
+    $response = $this->actingAs($user)->get('/financeiro/caixa?limit=9999');
+
+    $response->assertStatus(200);
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->where('filters.limit', 200)
+    );
+});
+
+it('clamp ?limit abaixo de 10 vira 10', function () {
+    $user = caixaBootstrap();
+
+    $response = $this->actingAs($user)->get('/financeiro/caixa?limit=1');
+
+    $response->assertStatus(200);
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->where('filters.limit', 10)
+    );
+});
+
+it('Tier 0 multi-tenant — não vaza caixa de outro business', function () {
+    $userA = caixaBootstrap();
+    $businessA = Business::find($userA->business_id);
+    $businessB = Business::where('id', '!=', $businessA->id)->first();
+
+    if (! $businessB) {
+        $this->markTestSkipped('Precisa 2+ businesses no banco.');
+    }
+    $userBExists = User::where('business_id', $businessB->id)->exists();
+    if (! $userBExists) {
+        $this->markTestSkipped('Sem user no businessB.');
+    }
+
+    // Inserir cash_register no businessB e confirmar que userA NÃO vê
+    $crBId = \DB::table('cash_registers')->insertGetId([
+        'business_id' => $businessB->id,
+        'user_id' => User::where('business_id', $businessB->id)->value('id'),
+        'status' => 'open',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $response = $this->actingAs($userA)->get('/financeiro/caixa');
+
+    $response->assertStatus(200);
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->where('caixas', function ($caixas) use ($crBId) {
+            foreach ($caixas as $c) {
+                if ((int) $c['id'] === $crBId) {
+                    return false; // VAZAMENTO!
+                }
+            }
+            return true;
+        })
+    );
+
+    // Cleanup
+    \DB::table('cash_registers')->where('id', $crBId)->delete();
+});

--- a/memory/requisitos/Financeiro/RUNBOOK-index.md
+++ b/memory/requisitos/Financeiro/RUNBOOK-index.md
@@ -1,0 +1,72 @@
+# RUNBOOK — Pages Financeiro Index
+
+> **Tipo:** RUNBOOK MWART (ADR 0104 §F1 PLAN) — índice das Pages Inertia do módulo Financeiro
+> **Status:** vivo (consolidado 2026-05-21 após Fases 1-6 deprecação legacy)
+> **Refs:** ADR 0080 module charter Financeiro, ADR 0093 multi-tenant Tier 0, ADR 0104 MWART canônico, ADR 0107 visual-comparison gate F1.5
+
+## Pages cobertas por este RUNBOOK
+
+Hook `block-mwart-violation.ps1` matcha pelo nome do arquivo. Pages atuais no módulo:
+
+### Sub-grupo OPERAÇÃO (sidebar `fin-op`, uso diário)
+
+1. `resources/js/Pages/Financeiro/Unificado/Index.tsx` — **Visão Unificada** AR+AP (cockpit principal)
+2. `resources/js/Pages/Financeiro/ContasReceber/Index.tsx` — **Contas a Receber** (recorte dedicado, mental model BR)
+3. `resources/js/Pages/Financeiro/ContasPagar/Index.tsx` — **Contas a Pagar** (recorte dedicado)
+4. `resources/js/Pages/Financeiro/Fluxo/Index.tsx` — **Fluxo de Caixa** tabs Projetado+Realizado (F3 absorve Cash Flow legacy)
+5. `resources/js/Pages/Financeiro/Cobranca/Index.tsx` — **Cobrança** (F3 PaymentGateway UI Tela 1)
+6. `resources/js/Pages/Financeiro/Caixa/Index.tsx` — **Caixa do turno** (F6 Soft wrapper read-only sobre `cash_registers` core) ← novo 2026-05-21
+
+### Sub-grupo ANÁLISE (sidebar `fin-analise`, uso mensal)
+
+7. `resources/js/Pages/Financeiro/Conciliacao/Index.tsx` — **Conciliação OFX** (Onda 19)
+8. `resources/js/Pages/Financeiro/Dre/Index.tsx` — **DRE Gerencial** com tabs Demonstrativo+Balanço+Balancete (F4 absorve Balance Sheet + Trial Balance legacy)
+9. `resources/js/Pages/Financeiro/Relatorios/Index.tsx` — **Relatórios** legacy (cleanup PR D)
+
+### Sub-grupo AJUSTES (sidebar `fin-config`, setup)
+
+10. `resources/js/Pages/Financeiro/ContasBancarias/Index.tsx` — **Contas Bancárias** (CRUD)
+11. `resources/js/Pages/Financeiro/PlanoContas/Index.tsx` — **Plano de Contas** BR (Onda 18)
+12. `resources/js/Pages/Financeiro/Categorias/Index.tsx` — **Categorias** livres (CRUD)
+13. `resources/js/Pages/Financeiro/Configuracoes/Contador.tsx` — **Contador Parceiro** (Onda 31 US-FIN-037)
+
+### Outras (não-sidebar)
+
+- `resources/js/Pages/Financeiro/Unificado/Novo.tsx` — form de criar título (acessada via botão dentro da Unificada)
+- `resources/js/Pages/Financeiro/Extrato/Index.tsx` — extrato bancário com `?contaBancariaId=` (deeplink)
+- `resources/js/Pages/Financeiro/AssinaturaAtualizar.tsx` — fluxo HITL pontual
+- `resources/js/Pages/Financeiro/Advisor/Dashboard.tsx` — portal contador parceiro (guard `web-advisor` isolado)
+- `resources/js/Pages/Financeiro/Advisor/Login.tsx` — login advisor
+
+## Contratos canônicos por tela
+
+> Cada tela tem seu próprio `.charter.md` ao lado do `.tsx` com Mission/Goals/Non-Goals/UX targets/Anti-hooks completos. Este RUNBOOK lista apenas o índice + sub-grupo sidebar.
+
+### Caixa do turno (F6 Soft, 2026-05-21)
+
+- **Props:** `caixas: CaixaRow[]`, `stats: Stats`, `filters: { status, limit }`, `links: { pos_create, cash_register_legacy }`
+- **Componentes:** AppShellV2 + 4 KPI cards + Pill segmented filter + tabela read-only
+- **Ações:** ❌ nenhuma (lifecycle abrir/fechar continua na header POS via `CashRegisterController` core)
+- **Filtros:** `?status=open|close`, `?limit` clamped [10, 200]
+- **Multi-tenant:** `business_id` explícito em todas queries (`cash_registers` core não tem global scope Eloquent — usa DB facade direto)
+- **Permission:** `view_cash_register` (mesma do core) em DUAS camadas (sidebar + Controller middleware)
+- **Charter:** [resources/js/Pages/Financeiro/Caixa/Index.charter.md](../../../resources/js/Pages/Financeiro/Caixa/Index.charter.md)
+- **Visual comparison:** [caixa-visual-comparison.md](caixa-visual-comparison.md) — F6 Soft sem protótipo Cowork (decisão Wagner 2026-05-21)
+- **Pest GUARD:** `Modules/Financeiro/Tests/Feature/CaixaControllerTest.php` — 6 cases
+
+## Padrões transversais (todas Pages)
+
+- **AppShellV2** layout com breadcrumbs
+- **Multi-tenant Tier 0** ADR 0093 IRREVOGÁVEL — `business_id` propagado em todas queries
+- **Permissão** controllers via middleware `can:financeiro.*` exceto Caixa que reusa `view_cash_register` core
+- **Inertia render** sem global state — cada tela recebe seus props
+- **Read-only por padrão** — mutações sempre via POST/PUT/DELETE explícitos (não inline edit a não ser quando charter declara)
+
+## Refs
+
+- [SCOPE.md](../../../Modules/Financeiro/SCOPE.md) — declaração canônica do módulo + Controllers
+- [CAPTERRA-FICHA.md](CAPTERRA-FICHA.md) — comparativo de mercado + score
+- [CAPTERRA-INVENTARIO.md](CAPTERRA-INVENTARIO.md) — buckets ✅/🟡/❌ por feature
+- [SPEC.md](SPEC.md) — User Stories US-FIN-*
+- [ADR 0104](../../decisions/0104-processo-mwart-canonico-unico-caminho.md) — processo MWART canônico
+- [ADR 0107](../../decisions/0107-emendation-0104-visual-comparison-gate-f3.md) — visual-comparison gate F1.5

--- a/memory/requisitos/Financeiro/caixa-visual-comparison.md
+++ b/memory/requisitos/Financeiro/caixa-visual-comparison.md
@@ -1,0 +1,117 @@
+---
+slug: caixa-visual-comparison
+title: "Financeiro — Comparativo visual da tela Caixa do turno (F6 Soft wrapper)"
+type: visual-comparison
+module: Financeiro
+status: approved
+date: 2026-05-21
+canon_reference: n/a (F6 Soft wrapper — sem protótipo Cowork; reusa cash_registers core UltimatePOS)
+blade_source: resources/views/cash_register/index.blade.php (legacy UltimatePOS — só listagem básica)
+inertia_target: resources/js/Pages/Financeiro/Caixa/Index.tsx
+service_new: n/a (sem service novo; CaixaController query direto via DB facade)
+controller_new: Modules/Financeiro/Http/Controllers/CaixaController::index()
+stories: US-FIN-CAIXA-F6-SOFT
+related_adrs: [0093, 0094, 0104]
+---
+
+# Comparativo visual — Financeiro · Caixa do turno (F6 Soft)
+
+> **Tipo de tela:** lista read-only com filtros + KPIs (histórico de fechamentos de turno)
+> **Persona alvo:** Larissa [L] (dona PME vestuário ROTA LIVRE biz=4) + Eliana [E] (financeiro escritório). Desktop ≥1024px.
+> **Refs:**
+> - Blade legacy: `resources/views/cash_register/index.blade.php` — tela core UltimatePOS, listagem simples sem KPIs nem banner explicativo
+> - Canon Cockpit: ❌ **n/a** — F6 Soft é wrapper sem protótipo Cowork. Decisão Wagner 2026-05-21: "Soft (wrapper Inertia)" → não vale investir tempo desenhando Cowork pra uma tela que pode ser deprecada se F6 Hard for aprovada
+> - Charter: [resources/js/Pages/Financeiro/Caixa/Index.charter.md](../../../resources/js/Pages/Financeiro/Caixa/Index.charter.md)
+> - ADRs: [0093 multi-tenant Tier 0](../../decisions/0093-multi-tenant-isolation-tier-0.md), [0094 Constituição v2](../../decisions/0094-constituicao-v2-7-camadas-8-principios.md), [0104 MWART canônico](../../decisions/0104-processo-mwart-canonico-unico-caminho.md)
+
+## Resumo executivo
+
+Wagner 2026-05-21 perguntou "onde ficou o caixa?". Resposta: Cash Register UltimatePOS **nunca esteve no sidebar lateral** — acesso era só via header POS. Após F1+F2 esconder/redirecionar legacy, Caixa ficou ainda menos descobrível.
+
+**F6 Soft (wrapper Inertia):** cria `/financeiro/caixa` Inertia bonito com **dados da tabela `cash_registers` core inalterada**. Sidebar entry visível em FINANCEIRO · OPERAÇÃO (order 85.45). Lifecycle abrir/fechar **continua na header POS** — não há mutação aqui.
+
+**Por que Soft e não Hard:** sem demanda de cliente reportada, refator pesado (migrar `cash_registers` → `fin_caixa_turnos` + Controller + Views + POS integrations) é over-engineering. Soft é reversível com 5 arquivos.
+
+## Tabela comparativa — 8 dimensões
+
+### 1. Layout
+
+| Aspecto | Hoje (Blade legacy `/cash-register`) | F6 Soft (`/financeiro/caixa`) | Decisão |
+|---|---|---|---|
+| Header | `<h1>Caixa registradora</h1>` simples | `<PageHeader>` Cockpit V2 com título "Caixa do turno · Histórico e fechamentos" + sub explicativa + link pra POS | F6 Soft — pattern Cockpit V2 consistente com Fluxo F3 |
+| Body grid | Tabela DataTables + botão "Abrir caixa" | Banner explicativo + KPI grid 4 cols + Pill filter + Tabela read-only | F6 Soft — KPIs novos + banner anti-confusão |
+| Banner explicativo | ❌ ausente | ✅ "Fluxo de Caixa (mensal) ≠ Caixa do turno (POS). Lifecycle continua na tela POS." | F6 Soft adiciona — anti-alucinação Larissa |
+
+### 2. Conteúdo informacional
+
+| Aspecto | Hoje | F6 Soft | Decisão |
+|---|---|---|---|
+| Listagem caixas | Sim, datatables com `#, abertura, fechamento, fechou em` | Mesmas colunas + `Operador, Loja, Status badge, Entradas, Saídas` | F6 Soft expande — adiciona operador e loja (gerencial PME) |
+| KPI cards | ❌ ausente | 4 KPIs: total caixas registrados, abertos agora, soma de fechamentos, saldo recente | F6 Soft adiciona — visão macro |
+| Filtros | ❌ ausente | Pill `Todos|Abertos|Fechados` + `?limit` clamped [10,200] | F6 Soft adiciona |
+| Drilldown | `?id=N` mostra `cash_register/register_details` Blade | ❌ não implementado F6 Soft — backlog US-FIN-CAIXA-DETAIL | Backlog |
+
+### 3. Ações disponíveis (CRUD)
+
+| Ação | Hoje | F6 Soft | Decisão |
+|---|---|---|---|
+| Abrir caixa | Sim, botão "Abrir caixa" → `CashRegisterController::store` | ❌ delegado pra POS (`/pos/create`) | F6 Soft — lifecycle POS-only |
+| Fechar caixa | Sim, botão "Fechar caixa" → modal `close_register_modal.blade` | ❌ delegado pra POS header | F6 Soft — lifecycle POS-only |
+| Editar valores | Sim, edit `closing_amount` `closing_note` | ❌ ausente | F6 Soft — read-only |
+| Sangria/Reforço | Sim via POS modal | ❌ ausente | Backlog US-FIN-CAIXA-SANGRIA-UI |
+
+### 4. Multi-tenant Tier 0
+
+| Aspecto | Hoje | F6 Soft | Decisão |
+|---|---|---|---|
+| Filter `business_id` | Sim, hardcode `WHERE business_id = session('user.business_id')` | Sim — `DB::table('cash_registers')->where('cr.business_id', $businessId)` em todas queries | ✅ ADR 0093 IRREVOGÁVEL respeitado |
+| Pest test cross-business | ❌ ausente | ✅ case "Tier 0 multi-tenant — não vaza caixa de outro business" | F6 Soft adiciona GUARD |
+
+### 5. Permissões
+
+| Permissão | Hoje | F6 Soft | Decisão |
+|---|---|---|---|
+| Gate view | `view_cash_register` core | **Mesma** `view_cash_register` — reusa permission core | ✅ não cria duplicação |
+| Gate sidebar | n/a (sem entrada sidebar) | `DataController::modifyAdminMenu` esconde entry se `! can('view_cash_register')` | F6 Soft adiciona — defesa em camadas |
+
+### 6. Banner explicativo (anti-confusão)
+
+| Aspecto | Hoje | F6 Soft | Decisão |
+|---|---|---|---|
+| Diferença Fluxo vs Caixa | ❌ ausente — user confunde | ✅ banner azul no topo explicando os 2 conceitos + links | F6 Soft — anti-alucinação UI |
+
+### 7. Acessibilidade & Mobile
+
+| Aspecto | Hoje | F6 Soft | Decisão |
+|---|---|---|---|
+| Layout responsivo | Parcial (Bootstrap default) | `max-w-7xl mx-auto`, grid responsivo `md:grid-cols-4` | F6 Soft melhora em desktop ≥1024px |
+| Mobile | Tabela datatables com scroll | Tabela com overflow horizontal | Equivalente |
+
+### 8. Reversibilidade
+
+| Aspecto | F6 Soft | F6 Hard (backlog) |
+|---|---|---|
+| Migração de dados | ❌ não há | ✅ `cash_registers` → `fin_caixa_turnos` |
+| Rollback | Deletar 5 arquivos | Migration reversa + restaurar Controller core |
+| Tempo de implementação | ~2h | 3-4 PRs, múltiplas sessões |
+| Quando vale fazer Hard | Backlog — aguarda sinal cliente | — |
+
+---
+
+## Decisões aprovadas (Wagner 2026-05-21)
+
+1. **Q1 — Soft vs Hard:** Soft (wrapper Inertia) ✅ **aprovado**. Hard fica backlog até sinal de cliente real.
+2. **Q2 — Read-only ou mutação?** Read-only ✅ — lifecycle continua POS-only
+3. **Q3 — Sidebar grupo:** FINANCEIRO · OPERAÇÃO (order 85.45) ✅ — depois de Cobrança, antes de ANÁLISE
+4. **Q4 — Permission gate:** `view_cash_register` (mesma do core) ✅ — não duplica permission
+5. **Q5 — Banner explicativo:** Sim ✅ — anti-confusão entre Fluxo de Caixa (mensal) vs Caixa do turno (POS)
+
+---
+
+## Refs
+
+- `Modules/Financeiro/Http/Controllers/CaixaController.php` — Controller wrapper
+- `resources/js/Pages/Financeiro/Caixa/Index.tsx` — Page Inertia
+- `resources/js/Pages/Financeiro/Caixa/Index.charter.md` — Charter F6
+- `app/Http/Controllers/CashRegisterController.php` — Controller core inalterado
+- `database/migrations/2018_01_30_181442_create_cash_registers_table.php` — schema fonte

--- a/resources/js/Pages/Financeiro/Caixa/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Caixa/Index.charter.md
@@ -1,0 +1,112 @@
+---
+page: /financeiro/caixa
+component: resources/js/Pages/Financeiro/Caixa/Index.tsx
+owner: wagner
+status: live
+last_validated: 2026-05-21
+parent_module: Financeiro
+parent_capterra: memory/requisitos/Financeiro/CAPTERRA-FICHA.md
+related_adrs: [0093, 0094, 0104]
+related_us: [US-FIN-CAIXA-F6-SOFT]
+related_prototype: n/a (F6 Soft wrapper — sem protótipo Cowork; reusa tabela cash_registers core UltimatePOS)
+related_decisions: memory/requisitos/Financeiro/caixa-visual-comparison.md (F6 Soft 2026-05-21)
+tier: B
+charter_version: 1
+---
+
+# Page Charter — /financeiro/caixa
+
+> **Status:** Fase 6 deprecação legacy entregue 2026-05-21 (Wagner pergunta "onde ficou o caixa?" → Soft wrapper aprovado).
+> Persona: **Larissa [L]** (dona PME vestuário ROTA LIVRE biz=4) + **Eliana [E]** (financeiro escritório). Desktop ≥1024px.
+>
+> **Read-only:** lifecycle abrir/fechar caixa **continua na header POS** (`/sells/pos/create` → `CashRegisterController` core). Esta tela só lista histórico de turnos pra descoberta no Financeiro.
+
+---
+
+## Mission (1 frase)
+
+Permitir que Larissa @ ROTA LIVRE encontre o **histórico de fechamentos de caixa** (turnos do vendedor) navegando pelo menu Financeiro, sem precisar abrir a tela POS — diferenciando claramente **Fluxo de Caixa (mensal, business)** vs **Caixa do turno (por usuário+POS)**.
+
+---
+
+## Goals — Features (faz)
+
+- 4 KPI cards: **Caixas registrados** (count all), **Caixas abertos agora** (count status=open), **Soma de fechamentos** (SUM closing_amount), **Saldo nos últimos N** (SUM credit - debit dos rows exibidos)
+- Tabela read-only com colunas: `#`, Status badge (Aberto/Fechado), Operador, Loja (location_name), Abertura, Fechamento, Entradas (verde), Saídas (vermelho), Fechou em (closing_amount)
+- Pill segmented control no topo: **Todos | Abertos | Fechados** (preserva via `?status=open|close` query param)
+- Filtro `?limit=N` clamped em **[10, 200]** (default 50)
+- Banner explicativo no topo: "Fluxo de Caixa (mensal) ≠ Caixa do turno (POS)" — anti-confusão pro usuário
+- Links pro POS preservados (botão "abrir caixa via POS" no empty state + footer)
+- Permission gate `view_cash_register` (mesma do CashRegisterController core) — enforce em DUAS camadas:
+  1. `DataController::modifyAdminMenu` esconde sidebar entry pra user sem permission
+  2. `CaixaController` middleware `can:view_cash_register` retorna 403 pra deeplink direto
+- Multi-tenant Tier 0 ADR 0093 IRREVOGÁVEL: `business_id` explícito em todas queries SQL
+- Stats agregados via 1 query separada (SUM em `cash_registers` direto, sem JOIN N+1)
+
+---
+
+## Non-Goals — Features (NÃO faz)
+
+> Anti-alucinação. Cada item vira Pest GUARD test (Non-Goal violado = CI quebra).
+
+- ❌ **NÃO permite abrir caixa** — botão "Abrir caixa" leva pro POS (`/pos/create`), não cria registro aqui
+- ❌ **NÃO permite fechar caixa** — botão "Fechar caixa registradora" continua só na header POS (`CashRegisterController::getCloseRegister` core)
+- ❌ **NÃO permite editar valores** — sem update de `closing_amount`, `closing_note`, sangria/reforço (continua via POS)
+- ❌ **NÃO migra dados** — tabela `cash_registers` e `cash_register_transactions` permanecem intocadas. Backlog F6 Hard se houver demanda
+- ❌ **NÃO substitui Fluxo de Caixa** — Fluxo é mensal/macro, Caixa do turno é por turno/POS. Banner UI deixa explícito
+- ❌ **NÃO exporta PDF/CSV** — backlog **US-FIN-CAIXA-EXPORT**
+- ❌ **NÃO mostra detalhes individuais de cada cash_register_transaction** — só agregação (SUM credit/debit) por turno. Drilldown vai pro `/cash-register/{id}` legacy se necessário (deeplink)
+
+---
+
+## UX targets (mensuráveis)
+
+- **Larissa descobre Caixa pelo menu em ≤ 5s** (entrada visível em FINANCEIRO · OPERAÇÃO, order 85.45, ícone `fa-cash-register`)
+- **Diferenciação Fluxo vs Caixa entendida em ≤ 30s** (banner explicativo no topo da tela)
+- **Encontrar último fechamento em ≤ 10s** (tabela ordenada DESC por `created_at`, status badge visível)
+- **Carregamento da tela ≤ 200ms** com 50 caixas (query indexed por `business_id` em `cash_registers`)
+
+---
+
+## Anti-hooks (sinais de drift)
+
+> Quando esta tela "ganhar" funcionalidade, suspeite — fica fácil escorregar pra F6 Hard sem ADR.
+
+- ⚠️ Aparecer **botão de mutação** (Abrir/Fechar/Editar caixa) — drift pra F6 Hard
+- ⚠️ Aparecer **edit inline em `closing_amount`** — mesma coisa
+- ⚠️ Aparecer **link "criar fin_titulo a partir do caixa"** — drift pra integração contábil que precisa ADR
+- ⚠️ Aparecer **sangria/reforço UI** — vira US-FIN-CAIXA-SANGRIA-UI separada
+- ⚠️ Quebrar contrato "POS continua sendo source of truth" — qualquer dependência onde Modules/Financeiro tem que ser consultado pra ABRIR caixa via POS é red flag
+
+---
+
+## Test plan (Pest GUARD)
+
+Cobertos em `Modules/Financeiro/Tests/Feature/CaixaControllerTest.php` (6 cases):
+
+1. ✅ `renderiza Inertia component Financeiro/Caixa/Index com shape esperado` (caixas[], stats, filters, links)
+2. ✅ `bloqueia user sem permission view_cash_register (403)` — permission gate
+3. ✅ `aplica filtro ?status=open na query`
+4. ✅ `clamp ?limit acima de 200 vira 200`
+5. ✅ `clamp ?limit abaixo de 10 vira 10`
+6. ✅ `Tier 0 multi-tenant — não vaza caixa de outro business` — invariante ADR 0093
+
+---
+
+## Backlog (não no escopo F6 Soft)
+
+- **F6 Hard** — full migrate: tabela `fin_caixa_turnos`, migration de dados, novo Controller, deprecar core. Aguarda sinal de cliente.
+- **US-FIN-CAIXA-SANGRIA-UI** — botões "Sangria" / "Reforço" no Modules/Financeiro (hoje só via POS modal)
+- **US-FIN-CAIXA-EXPORT** — PDF/CSV do histórico de turnos
+- **US-FIN-CAIXA-DETAIL** — `/financeiro/caixa/{id}` page com timeline de transações do turno (drilldown próprio em vez de redirecionar pro legacy)
+
+---
+
+## Refs
+
+- [memory/requisitos/Financeiro/caixa-visual-comparison.md](../../../../memory/requisitos/Financeiro/caixa-visual-comparison.md) — visual-comparison F6 Soft
+- [ADR 0093](../../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md) — Multi-tenant Tier 0 IRREVOGÁVEL
+- [ADR 0094](../../../../memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md) — Constituição v2
+- [ADR 0104](../../../../memory/decisions/0104-processo-mwart-canonico-unico-caminho.md) — Processo MWART canônico
+- `app/Http/Controllers/CashRegisterController.php` — Controller core (lifecycle abrir/fechar — não tocado)
+- `database/migrations/2018_01_30_181442_create_cash_registers_table.php` — schema `cash_registers`

--- a/resources/js/Pages/Financeiro/Caixa/Index.tsx
+++ b/resources/js/Pages/Financeiro/Caixa/Index.tsx
@@ -1,0 +1,252 @@
+// @memcofre tela=/financeiro/caixa module=Financeiro
+// Wagner 2026-05-21 Fase 6 deprecação legacy Soft (wrapper Inertia).
+// Tela read-only sobre cash_registers core UltimatePOS. Lifecycle (abrir/fechar)
+// continua na header POS — esta tela é descoberta + histórico no Financeiro.
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { router, usePage } from '@inertiajs/react';
+import { ReactNode, useMemo } from 'react';
+
+interface CaixaRow {
+  id: number;
+  status: 'open' | 'close';
+  open_time: string | null;
+  close_time: string | null;
+  closing_amount: number;
+  total_credit: number;
+  total_debit: number;
+  total_card_slips: number;
+  total_cheques: number;
+  closing_note: string | null;
+  user_id: number;
+  user_name: string;
+  location_id: number;
+  location_name: string;
+}
+
+interface Stats {
+  total_caixas: number;
+  caixas_abertos: number;
+  soma_fechamentos: number;
+}
+
+interface Props {
+  caixas: CaixaRow[];
+  stats: Stats;
+  filters: { status: string | null; limit: number };
+  links: { pos_create: string; cash_register_legacy: string };
+}
+
+function fmtMoney(v: number): string {
+  return v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+function fmtDateTime(s: string | null): string {
+  if (!s) return '—';
+  try {
+    const d = new Date(s);
+    return d.toLocaleString('pt-BR', { dateStyle: 'short', timeStyle: 'short' });
+  } catch {
+    return s;
+  }
+}
+
+function statusBadge(status: 'open' | 'close'): { label: string; className: string } {
+  if (status === 'open') {
+    return {
+      label: 'Aberto',
+      className: 'bg-emerald-100 text-emerald-900 border border-emerald-300',
+    };
+  }
+  return {
+    label: 'Fechado',
+    className: 'bg-stone-100 text-stone-800 border border-stone-300',
+  };
+}
+
+function Caixa({ caixas, stats, filters, links }: Props) {
+  const saldoAtual = useMemo(
+    () => caixas.reduce((acc, c) => acc + (c.total_credit - c.total_debit), 0),
+    [caixas]
+  );
+
+  const setStatusFilter = (s: 'open' | 'close' | null) => {
+    router.visit('/financeiro/caixa', {
+      data: s ? { status: s } : {},
+      preserveScroll: true,
+      replace: true,
+    });
+  };
+
+  return (
+    <div className="fin-curadoria p-6 max-w-7xl mx-auto space-y-6">
+      <header className="os-page-h fin-page-h">
+        <div className="os-page-h-l fin-page-h-l">
+          <h1>
+            Caixa do turno <span className="fin-hero-title-sub">· Histórico e fechamentos</span>
+          </h1>
+          <p>
+            Visão read-only dos turnos de caixa (abertura e fechamento) feitos pela equipe via tela
+            POS. Para abrir ou fechar um caixa, use os botões na header da{' '}
+            <a href={links.pos_create} className="underline text-emerald-700">
+              tela de venda
+            </a>
+            .
+          </p>
+        </div>
+      </header>
+
+      {/* Banner explicativo — esta tela é WRAPPER, não substitui POS */}
+      <div className="rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">
+        <strong>ℹ️ Por que essa tela existe?</strong>
+        <span className="ml-1">
+          Fluxo de Caixa (mensal) ≠ Caixa do turno (POS). Esta é uma vista do Financeiro pros
+          fechamentos de turno feitos no balcão. O ciclo abre/vende/fecha continua na{' '}
+          <a href={links.pos_create} className="underline">
+            tela POS
+          </a>
+          . Versão legacy:{' '}
+          <a href={links.cash_register_legacy} className="underline">
+            {links.cash_register_legacy}
+          </a>
+          .
+        </span>
+      </div>
+
+      {/* KPI cards */}
+      <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+        <div className="rounded-md border bg-white p-4">
+          <div className="text-xs text-stone-500 uppercase tracking-wide">Caixas registrados</div>
+          <div className="text-2xl font-semibold mt-1">{stats.total_caixas}</div>
+        </div>
+        <div className="rounded-md border bg-white p-4">
+          <div className="text-xs text-stone-500 uppercase tracking-wide">Caixas abertos agora</div>
+          <div className="text-2xl font-semibold mt-1 text-emerald-700">
+            {stats.caixas_abertos}
+          </div>
+        </div>
+        <div className="rounded-md border bg-white p-4">
+          <div className="text-xs text-stone-500 uppercase tracking-wide">
+            Soma de fechamentos
+          </div>
+          <div className="text-2xl font-semibold mt-1">{fmtMoney(stats.soma_fechamentos)}</div>
+        </div>
+        <div className="rounded-md border bg-white p-4">
+          <div className="text-xs text-stone-500 uppercase tracking-wide">
+            Saldo nos últimos {caixas.length} mostrados
+          </div>
+          <div className="text-2xl font-semibold mt-1">{fmtMoney(saldoAtual)}</div>
+        </div>
+      </div>
+
+      {/* Filtros — pill segmented control */}
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-stone-600">Filtrar:</span>
+        <div className="inline-flex rounded-md border bg-white p-1 text-sm">
+          <button
+            type="button"
+            onClick={() => setStatusFilter(null)}
+            className={`px-3 py-1 rounded ${!filters.status ? 'bg-stone-900 text-white' : 'text-stone-700 hover:bg-stone-100'}`}
+          >
+            Todos
+          </button>
+          <button
+            type="button"
+            onClick={() => setStatusFilter('open')}
+            className={`px-3 py-1 rounded ${filters.status === 'open' ? 'bg-stone-900 text-white' : 'text-stone-700 hover:bg-stone-100'}`}
+          >
+            Abertos
+          </button>
+          <button
+            type="button"
+            onClick={() => setStatusFilter('close')}
+            className={`px-3 py-1 rounded ${filters.status === 'close' ? 'bg-stone-900 text-white' : 'text-stone-700 hover:bg-stone-100'}`}
+          >
+            Fechados
+          </button>
+        </div>
+        <span className="ml-auto text-xs text-stone-500">
+          Mostrando últimos {caixas.length} (limite {filters.limit})
+        </span>
+      </div>
+
+      {/* Tabela */}
+      <section className="rounded-md border bg-white overflow-hidden">
+        {caixas.length === 0 ? (
+          <div className="px-5 py-12 text-center text-sm text-stone-500">
+            Nenhum caixa encontrado{filters.status ? ' com este filtro' : ''}.{' '}
+            <a href={links.pos_create} className="text-emerald-700 underline">
+              Abra um caixa via POS
+            </a>{' '}
+            pra começar.
+          </div>
+        ) : (
+          <table className="w-full text-sm">
+            <thead className="bg-stone-50 text-xs text-stone-600">
+              <tr className="text-left">
+                <th className="px-4 py-2 font-medium">#</th>
+                <th className="px-4 py-2 font-medium">Status</th>
+                <th className="px-4 py-2 font-medium">Operador</th>
+                <th className="px-4 py-2 font-medium">Loja</th>
+                <th className="px-4 py-2 font-medium">Abertura</th>
+                <th className="px-4 py-2 font-medium">Fechamento</th>
+                <th className="px-4 py-2 font-medium text-right">Entradas</th>
+                <th className="px-4 py-2 font-medium text-right">Saídas</th>
+                <th className="px-4 py-2 font-medium text-right">Fechou em</th>
+              </tr>
+            </thead>
+            <tbody>
+              {caixas.map((c) => {
+                const badge = statusBadge(c.status);
+                return (
+                  <tr key={c.id} className="border-t hover:bg-stone-50">
+                    <td className="px-4 py-3 font-mono text-xs text-stone-500">#{c.id}</td>
+                    <td className="px-4 py-3">
+                      <span className={`inline-block rounded px-2 py-0.5 text-xs ${badge.className}`}>
+                        {badge.label}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3">{c.user_name}</td>
+                    <td className="px-4 py-3 text-stone-700">{c.location_name}</td>
+                    <td className="px-4 py-3 text-stone-700">{fmtDateTime(c.open_time)}</td>
+                    <td className="px-4 py-3 text-stone-700">
+                      {c.status === 'open' ? '—' : fmtDateTime(c.close_time)}
+                    </td>
+                    <td className="px-4 py-3 text-right text-emerald-700">
+                      {fmtMoney(c.total_credit)}
+                    </td>
+                    <td className="px-4 py-3 text-right text-red-700">
+                      {fmtMoney(c.total_debit)}
+                    </td>
+                    <td className="px-4 py-3 text-right font-medium">
+                      {c.status === 'open' ? '—' : fmtMoney(c.closing_amount)}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </section>
+
+      <div className="text-xs text-stone-500">
+        💡 Para fechar um caixa aberto, clique no botão "Fechar caixa registradora" na header da{' '}
+        <a href={links.pos_create} className="underline">
+          tela POS
+        </a>
+        .
+      </div>
+    </div>
+  );
+}
+
+Caixa.layout = (page: ReactNode) => (
+  <AppShellV2
+    title="Financeiro — Caixa do turno"
+    breadcrumbItems={[{ label: 'Financeiro', href: '/financeiro' }, { label: 'Caixa do turno' }]}
+  >
+    {page}
+  </AppShellV2>
+);
+
+export default Caixa;


### PR DESCRIPTION
## Summary

Wagner 2026-05-21 perguntou "onde ficou o caixa?". Resposta: Caixa registradora (`cash_register`) nunca esteve no sidebar — acesso era só via botões na header POS. Wagner aprovou **Fase 6 Soft (wrapper Inertia)** pra trazer caixa do turno como atalho visível no sidebar do Financeiro, **sem migrar dados** (reusa tabela `cash_registers` core).

## Conceito (banner explicativo na tela)

| | **Fluxo de Caixa** | **Caixa do turno** |
|---|---|---|
| Pergunta | "Quanto dinheiro entra/sai e quando?" | "Dinheiro físico bate com vendas do turno?" |
| Granularidade | Mensal, business inteiro | Por turno + usuário + POS |
| Esta tela | `/financeiro/fluxo` (Projetado+Realizado F3) | `/financeiro/caixa` (read-only F6) |

## Implementação (5 arquivos, +586/0)

| Arquivo | Linhas | O que |
|---|---|---|
| `Modules/Financeiro/Http/Controllers/CaixaController.php` | +139 | index() query cash_registers + filtros + stats agregados |
| `resources/js/Pages/Financeiro/Caixa/Index.tsx` | +252 | Tabela read-only + 4 KPI cards + pill filter + banner |
| `Modules/Financeiro/Tests/Feature/CaixaControllerTest.php` | +170 | 6 cases Pest (Inertia shape, permission, filtros, Tier 0) |
| `Modules/Financeiro/Http/Controllers/DataController.php` | +18 | Entrada sidebar 'Caixa do turno' em FINANCEIRO · OPERAÇÃO (order 85.45) |
| `Modules/Financeiro/Routes/web.php` | +7 | Rota `/financeiro/caixa` + import |

## Decisões técnicas

- **Read-only:** lifecycle abrir/fechar caixa **continua na header POS**. Tela Financeiro só mostra histórico + filtros.
- **Zero migration:** tabela `cash_registers` core inalterada. Apenas query.
- **Reversibilidade total:** deletar 5 arquivos + 18+7 linhas = volta ao estado anterior. **Sem rollback de dados.**
- **Tier 0 multi-tenant (ADR 0093 IRREVOGÁVEL):** `business_id` explícito em todas queries. Pest test cobre não-vazamento cross-business.
- **Permission gate:** `view_cash_register` (mesma do CashRegisterController core). Aplicado tanto no Controller (middleware) quanto no DataController (esconde sidebar entry).
- **Filtros:** `?status=open|close`, `?limit` clamped em [10, 200].
- **KPIs:** total caixas, caixas abertos agora, soma de fechamentos, saldo nos últimos N mostrados.

## Sidebar resultante (FINANCEIRO · OPERAÇÃO)

```
FINANCEIRO · OPERAÇÃO   ▾  aberto por default
  📊 Visão Unificada        /financeiro/unificado     (85.00)
  💰 Contas a Receber       /financeiro/contas-receber (85.10)
  💸 Contas a Pagar         /financeiro/contas-pagar  (85.20)
  📈 Fluxo de Caixa         /financeiro/fluxo         (85.30)
  💳 Cobrança               /financeiro/cobranca      (85.40)
  💵 Caixa do turno         /financeiro/caixa         (85.45) ← NOVO F6
```

## Test plan

- [ ] Sidebar mostra "Caixa do turno" pra user com `view_cash_register`
- [ ] User sem `view_cash_register` não vê entrada nem acessa `/financeiro/caixa`
- [ ] Tela mostra tabela com histórico de cash_registers do business
- [ ] Filtro Todos/Abertos/Fechados funciona via query string
- [ ] KPI cards somam corretamente
- [ ] Banner explicativo "Fluxo de Caixa ≠ Caixa do turno" visível
- [ ] Link "abrir caixa via POS" leva pra `/pos/create`
- [ ] Header POS continua mostrando botões "Fechar caixa" / "Ver caixa" (não afetado)
- [ ] Tier 0: user de business A não vê caixas de business B (Pest cobre)

## Backlog deixado

- **F6 Hard (full migrate)** — migrar `cash_registers` → `fin_caixa_turnos`, reescrever Controller no Modules/Financeiro, deprecar core. Aguarda sinal de cliente real.
- **US-FIN-CAIXA-SANGRIA-UI** — botão "Sangria" / "Reforço" na tela Financeiro/Caixa (hoje só via POS)
- **US-FIN-CAIXA-EXPORT** — PDF/CSV do histórico de turnos

Refs: Wagner pergunta "onde ficou o caixa?" + decisão Soft 2026-05-21.

🤖 Generated with [Claude Code](https://claude.com/claude-code)