### PR TITLE
feat(cliente): Fase 2 deprecacao legacy - codigo /cliente canon (middleware DORMENTE)

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -43,6 +43,10 @@ class Kernel extends HttpKernel
             // /expenses /account/* e 301 pra telas Financeiro canônicas.
             // Early return rápido em path desconhecido (99% dos requests).
             \App\Http\Middleware\RedirectLegacyFinanceiro::class,
+            // Wagner 2026-05-21 Fase 2 deprecação legacy Cliente — DESABILITADO
+            // INICIALMENTE. Middleware existe em app/Http/Middleware/RedirectLegacyContacts.php
+            // mas NÃO entra no pipeline até Wagner aprovar canary. Pra ativar, descomente:
+            // \App\Http\Middleware\RedirectLegacyContacts::class,
             \App\Http\Middleware\HandleInertiaRequests::class,
         ],
 

--- a/app/Http/Middleware/RedirectLegacyContacts.php
+++ b/app/Http/Middleware/RedirectLegacyContacts.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Contact;
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Redireciona rotas GET legacy de /contacts (Customer view) pras URLs canônicas
+ * /cliente. Wagner 2026-05-21 Fase 2 deprecação legacy Cliente — espelha
+ * RedirectLegacyFinanceiro (PR #1283).
+ *
+ * Escopo canary: APENAS INDEX e SHOW (read-only). Create/Edit/Import/Ledger/Map
+ * seguem legacy até G-CLI-02 (autosave) fechar.
+ *
+ * Comportamento:
+ *   1. Só intercepta GET (POST/PUT/DELETE seguem pro core).
+ *   2. Early return rápido se path não está nos casos mapeados (99% requests).
+ *   3. Só redireciona se flag mwart.cliente_* ON pro business atual.
+ *      Businesses fora do canary continuam usando legacy normalmente — regressão zero.
+ *   4. SHOW: lookup leve Contact::where('id')->whereIn('type', ['customer','both'])
+ *      pra evitar redirecionar supplier (que NÃO tem tela canon /cliente).
+ *
+ * Ver:
+ *   - config/mwart.php (flags cliente_index + cliente_show)
+ *   - app/Http/Controllers/ContactController.php@index linhas 132-142 (dual render JÁ pronto)
+ *   - ADR 0107 (gate F1.5 visual) — Wagner aprova screenshot ANTES de canary biz=1
+ */
+class RedirectLegacyContacts
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        // (1) Só GET.
+        if (! $request->isMethod('GET')) {
+            return $next($request);
+        }
+
+        $path = trim($request->path(), '/');
+
+        // (2) INDEX: /contacts?type=customer → /cliente
+        if ($path === 'contacts' && $request->query('type') === 'customer') {
+            if ($this->isClienteIndexEnabled()) {
+                return redirect('/cliente', 301);
+            }
+
+            return $next($request);
+        }
+
+        // (3) SHOW: /contacts/{id} → /cliente/{id} (apenas se contact é customer/both)
+        if (preg_match('#^contacts/(\d+)$#', $path, $m)) {
+            $id = (int) $m[1];
+            if ($this->isClienteShowEnabled() && $this->isContactCustomer($id)) {
+                return redirect("/cliente/{$id}", 301);
+            }
+
+            return $next($request);
+        }
+
+        return $next($request);
+    }
+
+    private function isClienteIndexEnabled(): bool
+    {
+        return $this->flagOnForCurrentBusiness('cliente_index');
+    }
+
+    private function isClienteShowEnabled(): bool
+    {
+        return $this->flagOnForCurrentBusiness('cliente_show');
+    }
+
+    private function flagOnForCurrentBusiness(string $flag): bool
+    {
+        if (! auth()->check()) {
+            return false;
+        }
+
+        if (! config("mwart.{$flag}.enabled")) {
+            return false;
+        }
+
+        $allowedBizIds = config("mwart.{$flag}.business_ids", []);
+        if (empty($allowedBizIds)) {
+            return true;
+        }
+
+        $businessId = (int) session('user.business_id');
+
+        return in_array($businessId, $allowedBizIds, true);
+    }
+
+    /**
+     * Confirma que o contact é customer (ou both), scoped por business_id
+     * (multi-tenant Tier 0 — ADR 0093). Supplier NUNCA redireciona.
+     */
+    private function isContactCustomer(int $id): bool
+    {
+        $businessId = (int) session('user.business_id');
+        if ($businessId <= 0) {
+            return false;
+        }
+
+        return Contact::where('business_id', $businessId)
+            ->where('id', $id)
+            ->whereIn('type', ['customer', 'both'])
+            ->exists();
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -191,6 +191,27 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     Route::get('/contacts/create-page', [ContactController::class, 'createPage']);
     Route::resource('contacts', ContactController::class);
 
+    // Wagner 2026-05-21 Fase 2 deprecação legacy Cliente — URLs canon /cliente.
+    // INDEX+SHOW canary (read-only). Wrappers thin que reusam ContactController.
+    // Multi-tenant Tier 0: type=customer injetado pra Index; guard customer/both
+    // pra Show (supplier NUNCA cai aqui). Ver app/Http/Middleware/RedirectLegacyContacts.php.
+    Route::get('/cliente', function (ContactController $c) {
+        request()->merge(['type' => 'customer']);
+        return $c->index();
+    })->name('cliente.index');
+
+    Route::get('/cliente/{id}', function (int $id, ContactController $c) {
+        $bizId = (int) session('user.business_id');
+        $ok = \App\Contact::where('business_id', $bizId)
+            ->where('id', $id)
+            ->whereIn('type', ['customer', 'both'])
+            ->exists();
+        if (! $ok) {
+            abort(404);
+        }
+        return $c->show($id);
+    })->name('cliente.show')->whereNumber('id');
+
     Route::get('taxonomies-ajax-index-page', [TaxonomyController::class, 'getTaxonomyIndexPage']);
     Route::resource('taxonomies', TaxonomyController::class);
 

--- a/tests/Feature/Cliente/RedirectLegacyContactsTest.php
+++ b/tests/Feature/Cliente/RedirectLegacyContactsTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Cliente;
+
+use App\Contact;
+use App\User;
+use Tests\TestCase;
+
+/**
+ * Wagner 2026-05-21 Fase 2 deprecação legacy Cliente — middleware espelha
+ * RedirectLegacyFinanceiro. Cobre 5 cenários canary INDEX+SHOW.
+ *
+ * Refs:
+ * - app/Http/Middleware/RedirectLegacyContacts.php
+ * - app/Http/Kernel.php linha 49 (registro)
+ * - routes/web.php (rotas canon /cliente + /cliente/{id})
+ * - config/mwart.php (flags cliente_index + cliente_show)
+ */
+class RedirectLegacyContactsTest extends TestCase
+{
+    private function actingAsBiz1User(): User
+    {
+        $user = User::where('business_id', 1)->first();
+
+        if (! $user) {
+            $this->markTestSkipped('biz=1 user não existe no DB de teste.');
+        }
+
+        session(['user.business_id' => 1]);
+        $this->actingAs($user);
+
+        return $user;
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function index_flag_off_segue_legacy_sem_redirect(): void
+    {
+        config(['mwart.cliente_index.enabled' => false]);
+
+        $this->actingAsBiz1User();
+
+        $response = $this->get('/contacts?type=customer');
+
+        // Não 301 — segue pro controller legacy.
+        $this->assertNotEquals(301, $response->getStatusCode());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function index_flag_on_business_match_redireciona_301_pra_cliente(): void
+    {
+        config([
+            'mwart.cliente_index.enabled' => true,
+            'mwart.cliente_index.business_ids' => [1],
+        ]);
+
+        $this->actingAsBiz1User();
+
+        $response = $this->get('/contacts?type=customer');
+
+        $response->assertRedirect('/cliente');
+        $this->assertEquals(301, $response->getStatusCode());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function index_flag_on_business_fora_canary_nao_redireciona(): void
+    {
+        config([
+            'mwart.cliente_index.enabled' => true,
+            'mwart.cliente_index.business_ids' => [999], // biz fora do canary
+        ]);
+
+        $this->actingAsBiz1User();
+
+        $response = $this->get('/contacts?type=customer');
+
+        $this->assertNotEquals(301, $response->getStatusCode());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function index_supplier_nao_redireciona_mesmo_com_flag_on(): void
+    {
+        config([
+            'mwart.cliente_index.enabled' => true,
+            'mwart.cliente_index.business_ids' => [],
+        ]);
+
+        $this->actingAsBiz1User();
+
+        $response = $this->get('/contacts?type=supplier');
+
+        // /contacts?type=supplier NUNCA redireciona — só customer.
+        $this->assertNotEquals(301, $response->getStatusCode());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function post_para_contacts_nunca_redireciona_apenas_get(): void
+    {
+        config([
+            'mwart.cliente_index.enabled' => true,
+            'mwart.cliente_index.business_ids' => [],
+        ]);
+
+        $this->actingAsBiz1User();
+
+        $response = $this->post('/contacts', ['type' => 'customer']);
+
+        // POST/PUT/DELETE passam direto pro core legacy.
+        $this->assertNotEquals(301, $response->getStatusCode());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function show_flag_on_customer_redireciona_para_cliente_id(): void
+    {
+        config([
+            'mwart.cliente_show.enabled' => true,
+            'mwart.cliente_show.business_ids' => [1],
+        ]);
+
+        $this->actingAsBiz1User();
+
+        $customer = Contact::where('business_id', 1)
+            ->whereIn('type', ['customer', 'both'])
+            ->first();
+
+        if (! $customer) {
+            $this->markTestSkipped('Sem customer em biz=1 — seed antes.');
+        }
+
+        $response = $this->get("/contacts/{$customer->id}");
+
+        $response->assertRedirect("/cliente/{$customer->id}");
+        $this->assertEquals(301, $response->getStatusCode());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function show_flag_on_supplier_nao_redireciona(): void
+    {
+        config([
+            'mwart.cliente_show.enabled' => true,
+            'mwart.cliente_show.business_ids' => [],
+        ]);
+
+        $this->actingAsBiz1User();
+
+        $supplier = Contact::where('business_id', 1)
+            ->where('type', 'supplier')
+            ->first();
+
+        if (! $supplier) {
+            $this->markTestSkipped('Sem supplier em biz=1 — seed antes.');
+        }
+
+        $response = $this->get("/contacts/{$supplier->id}");
+
+        // Supplier NÃO redireciona pra /cliente — tela canon é só customer.
+        $this->assertNotEquals(301, $response->getStatusCode());
+    }
+
+    #[\PHPUnit\Framework\Attributes\Test]
+    public function show_cross_tenant_contact_nao_redireciona(): void
+    {
+        config([
+            'mwart.cliente_show.enabled' => true,
+            'mwart.cliente_show.business_ids' => [],
+        ]);
+
+        $this->actingAsBiz1User();
+
+        // Contact de outro business (Tier 0 isolation).
+        $crossTenantContact = Contact::where('business_id', '!=', 1)
+            ->whereIn('type', ['customer', 'both'])
+            ->first();
+
+        if (! $crossTenantContact) {
+            $this->markTestSkipped('Sem customer cross-tenant pra testar.');
+        }
+
+        $response = $this->get("/contacts/{$crossTenantContact->id}");
+
+        // Lookup do middleware NÃO encontra (scoped por business_id) → segue legacy.
+        $this->assertNotEquals(301, $response->getStatusCode());
+    }
+}


### PR DESCRIPTION
## Resumo

Middleware espelha [`RedirectLegacyFinanceiro`](app/Http/Middleware/RedirectLegacyFinanceiro.php) (PR #1283) pra redirecionar `/contacts?type=customer` → `/cliente` e `/contacts/{id}` → `/cliente/{id}` (301), mas **fica DORMENTE no Kernel** até Wagner aprovar canary.

Wave 1 B3 entregou `Pages/Cliente/Index.tsx` + 6 telas correlatas com charter + dual render em `ContactController`. Faltava só o redirect canon URL (espelho da Fase 2 do Financeiro).

## Estado pós-merge (DOUBLE-SAFETY)

| Camada | Estado | Pra ativar canary |
|---|---|---|
| Middleware code | ✅ existe | — |
| Pest tests (8 cenários) | ✅ existe | — |
| Routes `/cliente` + `/cliente/{id}` | ✅ ativas | — |
| **Kernel registration** | ❌ **COMENTADA intencionalmente** | Descomentar 1 linha |
| Env flags `MWART_CLIENTE_*` | ❌ default FALSE | Setar em `.env` prod |

**Resultado:** após merge + deploy, **NADA de 301 acontece**. Pra ligar canary é necessário **AMBOS** os passos (env + Kernel).

## Tier 0 multi-tenant (ADR 0093)

- Middleware usa `session('user.business_id')` + `where('business_id')` scoped no lookup customer
- Supplier nunca cai em `/cliente/{id}` (guard no route closure + middleware lookup)
- Cross-tenant: Contact de outro biz não 301-redireciona (lookup scoped)
- POST/PUT/DELETE intactos (apenas GET intercepta)

## Pest coverage

8 cenários em [tests/Feature/Cliente/RedirectLegacyContactsTest.php](tests/Feature/Cliente/RedirectLegacyContactsTest.php):

- flag off → segue legacy
- flag on + biz match → 301 /cliente
- flag on + biz fora canary → segue legacy
- supplier nunca redireciona
- POST nunca redireciona
- show flag on customer → 301 /cliente/{id}
- show flag on supplier → não redireciona
- show cross-tenant → não redireciona (Tier 0)

## Test plan

- [ ] CI Pest passa
- [ ] Após merge + deploy: `curl -I https://oimpresso.com/cliente` → 302 /login (rota existe + auth)
- [ ] Wagner ativa canary (env flag + descomenta Kernel) → smoke biz=1 WR2
- [ ] Larissa biz=4 ROTA LIVRE segue legacy (`business_ids: [1]` exclui biz=4)

## Sequência canary (3 passos pós-merge)

1. Deploy prod (composer install + cache:clear)
2. Setar em `.env` prod:
   ```
   MWART_CLIENTE_INDEX=true
   MWART_CLIENTE_INDEX_BIZ=1
   MWART_CLIENTE_SHOW=true
   MWART_CLIENTE_SHOW_BIZ=1
   ```
3. Descomentar `RedirectLegacyContacts::class` em [app/Http/Kernel.php](app/Http/Kernel.php)
4. `php artisan config:clear && route:clear`
5. Smoke /cliente logado biz=1

## Refs

- ADR 0093 (multi-tenant Tier 0)
- ADR 0107 (gate F1.5 visual)
- charter [resources/js/Pages/Cliente/Index.charter.md](resources/js/Pages/Cliente/Index.charter.md)
- config/mwart.php (flags cliente_index + cliente_show ja presentes W1-B3)
- PR #1283 (espelho Financeiro Fase 2)

## Smoke local (parcial)

- ✅ Rota `/cliente` registrada (`php artisan route:list --path=cliente`)
- ✅ Sem auth: 302 → /login (middleware auth funciona)
- ✅ Com auth biz=1 + flags temp on: AppShellV2 + PageHeader + 4 KPI cards skeleton + 4 filter pills canon (rounded-full ADR 0110) + search renderizam
- ⚠️ KPIs/tabela ficam loading no Herd local por warning PHP OpenTelemetry (pre-existente ambiente — em prod deve resolver)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Infra Contract

> PR toca `app/Http/Kernel.php` (registra middleware — comentado intencionalmente DORMENTE) + `app/Http/Middleware/RedirectLegacyContacts.php` (novo) + `routes/web.php`. Cole de smoke prod obrigatório pós-deploy + canary activation.

### 1. Happy path — middleware DORMENTE pós-merge (estado default)

Pós-merge + deploy, **NENHUM redirect 301 deve acontecer** — Kernel registration está comentada e env flags default FALSE.

```bash
$ curl -sv https://oimpresso.com/contacts?type=customer 2>&1 | grep '^< HTTP\|^< Location'
< HTTP/1.1 302
< Location: https://oimpresso.com/login    # se não autenticado (esperado)
# Autenticado: 200 com tela legacy de contacts (sem 301 pra /cliente)

$ curl -sv https://oimpresso.com/cliente 2>&1 | grep '^< HTTP'
< HTTP/1.1 302
< Location: https://oimpresso.com/login    # rota canon ativa, login redirect normal
```

### 2. Happy path — canary ativado (Wagner liga env flags + descomenta Kernel)

```bash
# Após Wagner editar .env com MWART_CLIENTE_CANARY_BIZ=4 + descomentar
# \App\Http\Middleware\RedirectLegacyContacts::class no Kernel.php $middlewareGroups['web']
# E rodar php artisan config:clear:

$ curl -sv https://oimpresso.com/contacts?type=customer -H 'Cookie: <sessao biz=4>' 2>&1 | grep '^< HTTP\|^< Location'
< HTTP/1.1 301
< Location: https://oimpresso.com/cliente

$ curl -sv https://oimpresso.com/contacts/123 -H 'Cookie: <sessao biz=4>' 2>&1 | grep '^< HTTP\|^< Location'
< HTTP/1.1 301    # customer
< Location: https://oimpresso.com/cliente/123
```

### 3. Regression adjacent — rotas que NÃO devem mudar

```bash
$ curl -sv https://oimpresso.com/contacts?type=supplier -H 'Cookie: <sessao biz=4>' 2>&1 | grep '^< HTTP'
< HTTP/1.1 200    # supplier nunca redireciona (mesmo com canary ativo)

$ curl -sv https://oimpresso.com/contacts -X POST -H 'Cookie: <sessao>' 2>&1 | grep '^< HTTP'
< HTTP/1.1 200 ou 419 csrf    # POST não interceptado (early-return)

# Business fora do canary (ex biz=1):
$ curl -sv https://oimpresso.com/contacts?type=customer -H 'Cookie: <sessao biz=1>' 2>&1 | grep '^< HTTP'
< HTTP/1.1 200    # legacy preservado pra biz fora da onda
```

### 4. Environment delta — Pest local cobre, prod precisa supervisão

- [ ] Pest local: 8 cenários cobrem flag on/off × biz canary/fora × customer/supplier × GET/POST
- [ ] OPcache Hostinger: limpar pós-deploy (`php artisan optimize:clear` + bootstrap reset)
- [ ] LSCache LiteSpeed: purge `/contacts*` URLs se ativo
- [ ] Ordem middleware no `$middlewareGroups['web']`: precisa **depois** de StartSession + SubstituteBindings (Wagner conferir ao descomentar)
- [ ] **DOUBLE-SAFETY funciona:** Kernel descomentado SEM env flags ainda não dispara redirect (e vice-versa)

**Pest local + smoke Herd NÃO provam prod. Validação em prod via curl -sv obrigatória pós-canary activation.**

### 5. Smoke prod pós-deploy DORMENTE (preencher após merge + deploy SSH)

```bash
# (timestamp + cole real)
$ curl -sv https://oimpresso.com/contacts?type=customer 2>&1 | grep '^< HTTP\|^< Location'
$ curl -sv https://oimpresso.com/cliente 2>&1 | grep '^< HTTP'
```

| Caso | Esperado | Observado | OK |
|---|---|---|---|
| `/contacts?type=customer` sem flags (DORMENTE) | `200` ou `302 → /login` (sem 301) | _pendente_ | ⏳ |
| `/cliente` (rota canon ativa) | `302 → /login` | _pendente_ | ⏳ |
| Kernel.php tem linha comentada `// \App\Http\Middleware\RedirectLegacyContacts::class` | verificar SSH | _pendente_ | ⏳ |
| Env `MWART_CLIENTE_*` = FALSE default | `php artisan tinker → env(...)` | _pendente_ | ⏳ |

### 6. Canary activation (futuro — Wagner aprova)

```bash
# Quando Wagner decidir ligar:
ssh hostinger 'cd ~/oimpresso.com && sed -i "s|// \\App\\Http\\Middleware\\RedirectLegacyContacts|\\App\\Http\\Middleware\\RedirectLegacyContacts|" app/Http/Kernel.php'
ssh hostinger 'cd ~/oimpresso.com && echo "MWART_CLIENTE_CANARY_BIZ=4" >> .env && php artisan config:clear && php artisan optimize:clear'
# Smoke imediato:
curl -sv https://oimpresso.com/contacts?type=customer -H 'Cookie: <sessao biz=4>' | grep '^< HTTP\|^< Location'
# Esperado: 301 → /cliente
```

> **DOUBLE-SAFETY explicitamente preservado** — mesmo que alguém descomente Kernel sem env, ou setar env sem descomentar Kernel, **redirect não dispara**.
