### PR TITLE
fix(whatsapp): registrar RetryRecentMediaDownloadsCommand no ServiceProvider

### DIFF
--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -29,6 +29,7 @@ use Modules\Whatsapp\Console\Commands\LidBackfillCommand;
 use Modules\Whatsapp\Console\Commands\MetricsAggregateCommand;
 use Modules\Whatsapp\Console\Commands\RegisterWhatsappPermissionsCommand;
 use Modules\Whatsapp\Console\Commands\ReparseMediaFromPayloadCommand;
+use Modules\Whatsapp\Console\Commands\RetryRecentMediaDownloadsCommand;
 use Modules\Whatsapp\Console\Commands\ScanMediaDriftCommand;
 use Modules\Whatsapp\Console\Commands\SlaScanCommand;
 use Modules\Whatsapp\Entities\Message;
@@ -96,6 +97,7 @@ class WhatsappServiceProvider extends ServiceProvider
                 ScanMediaDriftCommand::class,           // Camada 5 — scan drift daily
                 BackfillMediaDownloadCommand::class,    // Bonus — backfill one-shot
                 ReparseMediaFromPayloadCommand::class,  // Bonus — extrai meta de payload pré-PR #664
+                RetryRecentMediaDownloadsCommand::class, // PR #882 — cron horário retry mídia recente (cron em app/Console/Kernel.php:657)
                 AutoLinkConversationContactsCommand::class, // US-WA-078 — backfill auto-link Contact CRM
                 ImportHistoryCommand::class,            // US-WA-080 — import histórico Baileys 90d
                 LidBackfillCommand::class,              // US-WA-093 P1 — backfill LID→phone de messages.payload histórico


### PR DESCRIPTION
## Sintoma (prod)

Cron horário \`whatsapp:retry-recent-media-downloads\` falha a cada execução (15min de cada hora) desde PR #882 mergeado.

Log Hostinger:
\`\`\`
[2026-05-21 02:15:56] live.ERROR: Command "whatsapp:retry-recent-media-downloads" is not defined.
[2026-05-21 02:15:56] live.ERROR: Schedule whatsapp:retry-recent-media-downloads FALHOU — mídia recente pode atrasar no Inbox
\`\`\`

Mesma falha em 00:15, 01:15, 02:15 — pattern de cada hora.

## Causa

PR #882 (\`feat(whatsapp): comando retry-recent-media-downloads + cron horario\`) adicionou:

1. ✅ Command class: \`Modules/Whatsapp/Console/Commands/RetryRecentMediaDownloadsCommand.php\`
2. ✅ Schedule registration: [\`app/Console/Kernel.php:657\`](app/Console/Kernel.php#L657)
3. ❌ **FALTOU**: Adicionar \`RetryRecentMediaDownloadsCommand::class\` à lista \`\$this->commands([...])\` em [\`Modules/Whatsapp/Providers/WhatsappServiceProvider.php\`](Modules/Whatsapp/Providers/WhatsappServiceProvider.php#L91)

\`WhatsappServiceProvider\` registra explicitamente cada command (não usa auto-discovery por glob). Sem o entry, Laravel não conhece o command → \`Command "..." is not defined\`.

## Fix

1 use statement + 1 entrada no array \`commands([])\`. 2 linhas.

## Impacto

Cron Camada 6 (retry mídia recente órfã) ficou inativo desde PR #882. Mascarado pelas Camadas 1-5 do Guardião 6 anti-mídia-perdida (ScanMediaDriftCommand daily 03:30 + outras) que cobrem o gap parcialmente.

## Verificação

\`\`\`bash
php artisan list whatsapp | grep retry
# Antes: vazio
# Depois: whatsapp:retry-recent-media-downloads
\`\`\`

## Test plan

- [x] \`php artisan list whatsapp | grep retry-recent\` → mostra o command
- [ ] Após merge + deploy: próximo cron horário (HH:15) não loga ERROR
- [ ] \`grep "retry-recent-media-downloads" storage/logs/laravel.log\` deve mostrar apenas INFO completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)