### PR TITLE
fix(jana): mcp:sync-memory soft-delete restore — UNIQUE constraint 1062 ao re-aparecer arquivo

### DIFF
--- a/Modules/Jana/Services/Mcp/IndexarMemoryGitParaDb.php
+++ b/Modules/Jana/Services/Mcp/IndexarMemoryGitParaDb.php
@@ -296,9 +296,15 @@ class IndexarMemoryGitParaDb
         ['context' => $contextualContext, 'indexed' => $contextualIndexed]
             = $this->aplicarContextualRetrieval($contentRedacted);
 
-        // UPSERT
-        $doc = McpMemoryDocument::firstOrNew(['slug' => $info['slug']]);
+        // UPSERT — inclui soft-deleted (withTrashed) pra recuperar docs que
+        // foram soft-removidos por glob miss em sync anterior e reapareceram
+        // (ex: arquivo renomeado pro path antigo, .gitignore mudou, glob expandido).
+        // Sem withTrashed, firstOrNew ignora soft-deleted → create() viola UNIQUE
+        // (slug). Detectado em prod 2026-05-21: SQLSTATE[23000] 1062 Duplicate
+        // entry 'session-2026-05-13-agents-canonicos-meta-degradacao'.
+        $doc = McpMemoryDocument::withTrashed()->firstOrNew(['slug' => $info['slug']]);
         $novo = ! $doc->exists;
+        $estavaSoftDeletado = ! $novo && $doc->trashed();
 
         $tipadas = $this->extrairColunasTipadas($frontmatter, $piiCount);
 
@@ -343,6 +349,16 @@ class IndexarMemoryGitParaDb
         if ($novo) {
             McpMemoryDocument::create(array_merge(['slug' => $info['slug']], $atributos));
             return ['novo' => true, 'atualizado' => false, 'redactions' => $piiCount];
+        }
+
+        // Soft-deleted row reapareceu — restaura e força update (mudou ou não).
+        // Contabilizado como 'atualizado' (mais útil pro operador que 'novo' falso).
+        if ($estavaSoftDeletado) {
+            DB::transaction(function () use ($doc, $atributos) {
+                $doc->restore();
+                $doc->snapshotEAtualizar($atributos, $this->userId, $this->reason);
+            });
+            return ['novo' => false, 'atualizado' => true, 'redactions' => $piiCount];
         }
 
         if ($contentMudou) {

--- a/Modules/Jana/Tests/Feature/Mcp/IndexarMemoryGitSoftDeleteRestoreTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/IndexarMemoryGitSoftDeleteRestoreTest.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Tests\Feature\Mcp;
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Entities\Mcp\McpMemoryDocument;
+use Modules\Jana\Services\Mcp\IndexarMemoryGitParaDb;
+
+uses(\Tests\TestCase::class);
+
+/**
+ * Regressão hotfix 2026-05-21:
+ *
+ * `IndexarMemoryGitParaDb::indexarArquivo()` usava `McpMemoryDocument::firstOrNew()`
+ * sem `withTrashed()`. Como o modelo usa `SoftDeletes`, rows soft-deletados eram
+ * ignorados → `$novo = true` → `create()` violava UNIQUE constraint do slug.
+ *
+ * Sintoma prod (cron mcp:sync-memory a cada 5min):
+ *   SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry
+ *   'session-2026-05-13-agents-canonicos-meta-degradacao'
+ *   for key 'mcp_memory_documents_slug_unique'
+ *
+ * Cenário: arquivo removido em sync prévio (soft-delete via whereNotIn linha 84),
+ * voltou ao filesystem em sync subsequente → deve RESTAURAR row existente, não
+ * tentar criar nova.
+ *
+ * @see Modules/Jana/Services/Mcp/IndexarMemoryGitParaDb.php@indexarArquivo
+ */
+
+beforeEach(function () {
+    // mcp_memory_documents (mesmo pattern do StalenessDetectorTest — manual create
+    // pra rodar em sqlite :memory: do phpunit.xml).
+    Schema::create('mcp_memory_documents', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id')->nullable();
+        $t->string('slug', 200)->unique();
+        $t->string('type', 30);
+        $t->string('module', 50)->nullable();
+        $t->string('title', 250);
+        $t->mediumText('content_md');
+        $t->mediumText('contextual_context')->nullable();
+        $t->boolean('contextual_indexed')->default(false);
+        $t->timestamp('contextualized_at')->nullable();
+        $t->string('scope_required', 100)->nullable();
+        $t->boolean('admin_only')->default(false);
+        $t->json('metadata')->nullable();
+        $t->string('git_sha', 40)->nullable();
+        $t->string('git_path', 300)->nullable();
+        $t->unsignedSmallInteger('pii_redactions_count')->default(0);
+        $t->binary('embedding')->nullable();
+        $t->timestamp('indexed_at')->nullable();
+        $t->string('status', 50)->nullable();
+        $t->string('authority', 50)->nullable();
+        $t->string('lifecycle', 50)->nullable();
+        $t->string('quarter', 10)->nullable();
+        $t->date('decided_at')->nullable();
+        $t->json('decided_by')->nullable();
+        $t->json('tags')->nullable();
+        $t->json('supersedes')->nullable();
+        $t->json('superseded_by')->nullable();
+        $t->json('related')->nullable();
+        $t->boolean('has_pii')->default(false);
+        $t->timestamps();
+        $t->softDeletes();
+    });
+
+    Schema::create('mcp_memory_documents_history', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedBigInteger('document_id');
+        $t->string('slug', 200);
+        $t->string('git_sha', 40)->nullable();
+        $t->string('title', 250);
+        $t->mediumText('content_md');
+        $t->json('metadata')->nullable();
+        $t->timestamp('changed_at');
+        $t->unsignedInteger('changed_by_user_id')->nullable();
+        $t->string('change_reason', 50);
+        $t->timestamps();
+    });
+});
+
+afterEach(function () {
+    Schema::dropIfExists('mcp_memory_documents_history');
+    Schema::dropIfExists('mcp_memory_documents');
+});
+
+/**
+ * Helper: cria filesystem tmp com um arquivo .md em memory/sessions/.
+ *
+ * @return array{base:string, cleanup:Closure}
+ */
+function montarRepoTmp(string $slugFile, string $conteudo): array
+{
+    $tmpBase = storage_path('app/test-indexar-' . uniqid());
+    @mkdir($tmpBase . '/memory/sessions', 0777, true);
+    file_put_contents($tmpBase . '/memory/sessions/' . $slugFile . '.md', $conteudo);
+
+    $cleanup = function () use ($tmpBase) {
+        if (is_dir($tmpBase)) {
+            foreach (glob($tmpBase . '/memory/sessions/*') ?: [] as $f) @unlink($f);
+            @rmdir($tmpBase . '/memory/sessions');
+            @rmdir($tmpBase . '/memory');
+            @rmdir($tmpBase);
+        }
+    };
+
+    return ['base' => $tmpBase, 'cleanup' => $cleanup];
+}
+
+it('restaura McpMemoryDocument soft-deletado em vez de violar UNIQUE constraint', function () {
+    // Setup: cria doc + soft-delete
+    $existente = McpMemoryDocument::create([
+        'slug'        => 'session-hotfix-restore-test',
+        'business_id' => 1,
+        'type'        => 'session',
+        'title'       => 'Conteúdo antigo',
+        'content_md'  => '# Antigo',
+        'git_path'    => 'memory/sessions/hotfix-restore-test.md',
+        'admin_only'  => false,
+        'metadata'    => [],
+        'pii_redactions_count' => 0,
+        'indexed_at'  => now(),
+    ]);
+    $existente->delete();
+
+    expect(McpMemoryDocument::withTrashed()->where('slug', 'session-hotfix-restore-test')->first()?->trashed())
+        ->toBeTrue('pre-condição: doc soft-deletado');
+
+    $repo = montarRepoTmp('hotfix-restore-test', "# Hotfix restore\n\nConteúdo NOVO após reaparecer.\n");
+
+    try {
+        $service = new IndexarMemoryGitParaDb($repo['base'], 'test-hotfix', null, 1);
+        $stats = $service->run();
+
+        // Antes do fix: aqui já teria lançado QueryException 1062.
+        expect($stats)->toBeArray();
+
+        $restaurada = McpMemoryDocument::where('slug', 'session-hotfix-restore-test')->first();
+        expect($restaurada)->not->toBeNull('doc restaurada aparece em query default');
+        expect($restaurada->trashed())->toBeFalse('soft-delete removido');
+        expect($restaurada->content_md)->toContain('NOVO');
+        expect($stats['atualizados'])->toBeGreaterThanOrEqual(1);
+    } finally {
+        $repo['cleanup']();
+    }
+});
+
+it('cria novo McpMemoryDocument quando slug não existe (path feliz)', function () {
+    $repo = montarRepoTmp('novo-doc-pristine', "# Doc novo pristine\n\nNunca foi sincronizado.\n");
+
+    try {
+        $service = new IndexarMemoryGitParaDb($repo['base'], 'test-novo', null, 1);
+        $stats = $service->run();
+
+        $novo = McpMemoryDocument::where('slug', 'session-novo-doc-pristine')->first();
+        expect($novo)->not->toBeNull();
+        expect($novo->trashed())->toBeFalse();
+        expect($stats['novos'])->toBeGreaterThanOrEqual(1);
+    } finally {
+        $repo['cleanup']();
+    }
+});


### PR DESCRIPTION
## Sintoma (prod)

Cron \`mcp:sync-memory --reason=cron\` falha a cada 5min desde algum sync anterior:

\`\`\`
[2026-05-21 02:45:24] live.ERROR: Scheduled command [... mcp:sync-memory --reason=cron] failed with exit code [1].
\`\`\`

Rodando o command manualmente expõe a causa real (ocultada pelo wrapper Schedule):

\`\`\`
Sync falhou: SQLSTATE[23000]: Integrity constraint violation: 1062
  Duplicate entry 'session-2026-05-13-agents-canonicos-meta-degradacao'
  for key 'mcp_memory_documents_slug_unique'
  (Connection: mysql, ..., SQL: insert into \`mcp_memory_documents\` (\`slug\`, ...) values (...))
\`\`\`

## Causa

[IndexarMemoryGitParaDb.php:300](Modules/Jana/Services/Mcp/IndexarMemoryGitParaDb.php#L300):

\`\`\`php
\$doc = McpMemoryDocument::firstOrNew(['slug' => \$info['slug']]);
\$novo = ! \$doc->exists;
// ...
if (\$novo) {
    McpMemoryDocument::create(array_merge(['slug' => \$info['slug']], \$atributos));  // 1062 aqui
}
\`\`\`

\`McpMemoryDocument\` usa \`SoftDeletes\`. Sequência que causa o bug:

1. Sync N-1: \`coletarArquivos()\` não pegou o arquivo (glob miss / arquivo removido temporariamente)
2. \`McpMemoryDocument::whereNotIn('slug', \$slugsVistos)->delete()\` (linha 84) → **soft-deleta** a row
3. Sync N: arquivo voltou ao filesystem
4. \`firstOrNew\` ignora soft-deleted → retorna instance nova → \`\$novo = true\`
5. \`create()\` tenta INSERT com slug — viola UNIQUE constraint porque a row soft-deletada **ainda existe** no DB

## Fix

\`\`\`php
\$doc = McpMemoryDocument::withTrashed()->firstOrNew(['slug' => \$info['slug']]);
\$novo = ! \$doc->exists;
\$estavaSoftDeletado = ! \$novo && \$doc->trashed();
// ...
if (\$estavaSoftDeletado) {
    DB::transaction(function () use (\$doc, \$atributos) {
        \$doc->restore();
        \$doc->snapshotEAtualizar(\$atributos, \$this->userId, \$this->reason);
    });
    return ['novo' => false, 'atualizado' => true, ...];
}
\`\`\`

\`snapshotEAtualizar\` preserva a versão antiga em \`mcp_memory_documents_history\` antes de atualizar (audit trail intacto). Restore + update contado como 'atualizado' (mais semântico que 'novo' falso pro operador).

## Pest

\`Modules/Jana/Tests/Feature/Mcp/IndexarMemoryGitSoftDeleteRestoreTest.php\` — 2 testes, 11 assertions, ambos verdes:

1. **Regressão**: soft-deleted reaparece → restaura, não viola UNIQUE
2. **Path feliz**: slug novo → cria normalmente

SQLite-friendly via \`Schema::create\` manual no \`beforeEach\` (pattern \`StalenessDetectorTest\`).

## Test plan

- [x] \`php artisan test Modules/Jana/Tests/Feature/Mcp/IndexarMemoryGitSoftDeleteRestoreTest.php\` → 2 passed
- [ ] Após merge + deploy: \`php artisan mcp:sync-memory --reason=manual-debug\` em prod retorna SUCCESS
- [ ] \`grep "mcp:sync-memory.*failed" storage/logs/laravel.log\` para de aparecer no próximo ciclo de 5min

## Impacto

Sync MCP server quebrado desde o sync que soft-deletou o arquivo afetado. Significa que docs novos/atualizados em \`memory/\` NÃO chegam ao MCP server (\`mcp.oimpresso.com\`) — time (Felipe/Maiara/Eliana) lê estado parado dos últimos commits sincronizados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)