### PR TITLE
feat(cliente): Fase 2 ativacao — ligar RedirectLegacyContacts middleware (todos businesses)

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -43,10 +43,11 @@ class Kernel extends HttpKernel
             // /expenses /account/* e 301 pra telas Financeiro canônicas.
             // Early return rápido em path desconhecido (99% dos requests).
             \App\Http\Middleware\RedirectLegacyFinanceiro::class,
-            // Wagner 2026-05-21 Fase 2 deprecação legacy Cliente — DESABILITADO
-            // INICIALMENTE. Middleware existe em app/Http/Middleware/RedirectLegacyContacts.php
-            // mas NÃO entra no pipeline até Wagner aprovar canary. Pra ativar, descomente:
-            // \App\Http\Middleware\RedirectLegacyContacts::class,
+            // Wagner 2026-05-21 Fase 2 deprecação legacy Cliente — ATIVADO pra todos
+            // os businesses (sem BIZ_IDS no .env = sem restrição). Espelha
+            // RedirectLegacyFinanceiro (PR #1283). Middleware short-circuita rápido
+            // em paths fora de /contacts/* (early return).
+            \App\Http\Middleware\RedirectLegacyContacts::class,
             \App\Http\Middleware\HandleInertiaRequests::class,
         ],
 


### PR DESCRIPTION
## Summary

- Descomenta `\App\Http\Middleware\RedirectLegacyContacts::class` no Kernel pra entrar no pipeline `web`.
- Continua Fase 2 da deprecacao legacy Cliente (PR #1289 deixou o codigo DORMENTE; este PR ativa o middleware).
- Wagner aprovou ativacao 2026-05-21 para **todos** os businesses (sem `BIZ_IDS` no .env = sem restricao).

## Estado prod no momento desta PR

- `.env` ja foi atualizado via SSH (Onda 1):
  - `MWART_CLIENTE_INDEX=true`
  - `MWART_CLIENTE_SHOW=true`
  - Sem `MWART_CLIENTE_INDEX_BIZ` / `MWART_CLIENTE_SHOW_BIZ` → vazio → todos businesses.
- `config:cache` ja rodou em prod. Runtime confirmado:
  ```json
  {"cliente_index":{"enabled":true,"business_ids":[]},
   "cliente_show":{"enabled":true,"business_ids":[]}}
  ```
- `/cliente` ja renderiza React (URL direta) PORQUE `ContactController@index` checa a flag e dispara `Inertia::render('Cliente/Index', ...)`.
- `/contacts?type=customer` AINDA cai no Blade legacy — esta PR fecha esse gap.

## Pos-deploy esperado

- `GET /contacts?type=customer` → 301 → `/cliente` (React)
- `GET /contacts/{id}` com contact customer/both → 301 → `/cliente/{id}` (React)
- `GET /contacts/{id}` com contact supplier → segue legacy (guard `whereIn customer/both` evita)
- `POST/PUT/DELETE` em `/contacts` → seguem legacy (read-only canary)

## Test plan

- [ ] Deploy via `gh workflow run deploy.yml`
- [ ] Smoke 1: logado em prod, abrir `https://oimpresso.com/contacts?type=customer` → URL final deve ser `/cliente` (React)
- [ ] Smoke 2: abrir `https://oimpresso.com/cliente` direto → React renderiza (ja funciona pos-Onda 1)
- [ ] Smoke 3: abrir `https://oimpresso.com/contacts?type=supplier` → segue Blade (supplier nao redireciona)
- [ ] Smoke 4: abrir um contact ID `customer` em /contacts/{id} → 301 → /cliente/{id}
- [ ] Smoke 5: abrir um contact ID `supplier` em /contacts/{id} → segue Blade (NAO redireciona)
- [ ] Pest: `php artisan test --filter=RedirectLegacyContactsTest` (8 cenarios)

## Rollback

Reverter este PR (1 linha) → middleware sai do pipeline. .env mantem flag ON mas so URL direta `/cliente` renderiza React; `/contacts?type=customer` volta a Blade.

Refs:
- PR #1289 (Fase 2 codigo middleware DORMENTE)
- PR #1283 (espelho RedirectLegacyFinanceiro)
- ADR 0093 (multi-tenant Tier 0)
- charter resources/js/Pages/Cliente/Index.charter.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)