### PR TITLE
fix(contact): Inertia partial reload x ajax legacy collision (8 branches)

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -44,6 +44,26 @@ class ContactController extends Controller
     }
 
     /**
+     * Detecta XHR LEGACY (DataTable Yajra, jQuery AJAX, autocomplete) — exclui
+     * Inertia partial reload que ALSO seta X-Requested-With: XMLHttpRequest.
+     *
+     * Bug pré-existente 2026-05-21: ativar MWART_CLIENTE_INDEX=true expôs collision —
+     * Inertia partial reload pra carregar Inertia::defer caía nos branches
+     * `if (request()->ajax())` retornando DataTable JSON cru → Inertia client erra
+     * "All Inertia requests must receive a valid Inertia response".
+     *
+     * Fix: usar este helper em vez de `request()->ajax()` direto em TODOS os
+     * branches que retornam JSON (DataTable/autocomplete/contact lookup). Inertia
+     * envia header `X-Inertia: true` que diferencia das XHR legacy.
+     *
+     * Ver: PR fix/contact-controller-inertia-ajax-collision (2026-05-21).
+     */
+    private function isLegacyAjax(): bool
+    {
+        return request()->ajax() && ! request()->hasHeader('X-Inertia');
+    }
+
+    /**
      * W1-B3 — Mascara CNPJ/CPF pra display client-side.
      * NUNCA enviar plain digits — ADR 0093 PII §LGPD Art.7.
      */
@@ -109,7 +129,7 @@ class ContactController extends Controller
             return redirect()->back();
         }
 
-        if (request()->ajax()) {
+        if ($this->isLegacyAjax()) {
             if ($type == 'supplier') {
                 return $this->indexSupplier();
             } elseif ($type == 'customer') {
@@ -1000,7 +1020,7 @@ class ContactController extends Controller
             abort(403, 'Unauthorized action.');
         }
 
-        if (request()->ajax()) {
+        if ($this->isLegacyAjax()) {
             $business_id = request()->session()->get('user.business_id');
             $contact = Contact::where('business_id', $business_id)->find($id);
 
@@ -1116,7 +1136,7 @@ class ContactController extends Controller
             abort(403, 'Unauthorized action.');
         }
 
-        if (request()->ajax()) {
+        if ($this->isLegacyAjax()) {
             try {
                 $input = $request->only(['type', 'supplier_business_name', 'prefix', 'first_name', 'middle_name', 'last_name', 'tax_number', 'pay_term_number', 'pay_term_type', 'mobile', 'address_line_1', 'address_line_2', 'zip_code', 'dob', 'alternate_number', 'city', 'state', 'country', 'landline', 'customer_group_id', 'contact_id', 'custom_field1', 'custom_field2', 'custom_field3', 'custom_field4', 'custom_field5', 'custom_field6', 'custom_field7', 'custom_field8', 'custom_field9', 'custom_field10', 'email', 'shipping_address', 'position', 'shipping_custom_field_details', 'export_custom_field_1', 'export_custom_field_2', 'export_custom_field_3', 'export_custom_field_4', 'export_custom_field_5',
                     'export_custom_field_6', 'assigned_to_users', ]);
@@ -1193,7 +1213,7 @@ class ContactController extends Controller
             abort(403, 'Unauthorized action.');
         }
 
-        if (request()->ajax()) {
+        if ($this->isLegacyAjax()) {
             try {
                 $business_id = request()->user()->business_id;
 
@@ -1247,7 +1267,7 @@ class ContactController extends Controller
      */
     public function getCustomers()
     {
-        if (request()->ajax()) {
+        if ($this->isLegacyAjax()) {
             $term = request()->input('q', '');
 
             $business_id = request()->session()->get('user.business_id');
@@ -1963,7 +1983,7 @@ class ContactController extends Controller
             abort(403, 'Unauthorized action.');
         }
 
-        if (request()->ajax()) {
+        if ($this->isLegacyAjax()) {
             $business_id = request()->session()->get('user.business_id');
             $contact = Contact::where('business_id', $business_id)->find($id);
             $contact->contact_status = $contact->contact_status == 'active' ? 'inactive' : 'active';
@@ -2033,7 +2053,7 @@ class ContactController extends Controller
     public function getContactPayments($contact_id)
     {
         $business_id = request()->session()->get('user.business_id');
-        if (request()->ajax()) {
+        if ($this->isLegacyAjax()) {
             $payments = TransactionPayment::leftjoin('transactions as t', 'transaction_payments.transaction_id', '=', 't.id')
             ->leftjoin('transaction_payments as parent_payment', 'transaction_payments.parent_id', '=', 'parent_payment.id')
             ->where('transaction_payments.business_id', $business_id)
@@ -2073,7 +2093,7 @@ class ContactController extends Controller
 
     public function getContactDue($contact_id)
     {
-        if (request()->ajax()) {
+        if ($this->isLegacyAjax()) {
             $business_id = request()->session()->get('user.business_id');
             $due = $this->transactionUtil->getContactDue($contact_id, $business_id);
 

--- a/tests/Feature/Cliente/InertiaAjaxCollisionTest.php
+++ b/tests/Feature/Cliente/InertiaAjaxCollisionTest.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+// Fix 2026-05-21 — Inertia partial reload colidindo com `request()->ajax()` legacy.
+//
+// Contexto: ContactController@index linha 187 (e 7 outros métodos) tinham
+// `if (request()->ajax()) { return DataTable JSON }` ANTES do branch Inertia render.
+// Inertia partial reload (X-Inertia: true) também seta X-Requested-With: XMLHttpRequest,
+// fazendo request()->ajax() retornar true → caía no DataTable branch → JSON cru →
+// Inertia client erra "All Inertia requests must receive a valid Inertia response".
+//
+// Fix: helper privado `isLegacyAjax()` que adiciona `! request()->hasHeader('X-Inertia')`.
+
+test('ContactController — helper isLegacyAjax existe e exclui X-Inertia header', function () {
+    $controllerPath = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($controllerPath);
+
+    expect($contents)
+        ->toContain('private function isLegacyAjax(): bool')
+        ->toContain("hasHeader('X-Inertia')")
+        ->toContain('return request()->ajax() && ! request()->hasHeader');
+});
+
+test('ContactController — TODAS as chamadas ajax usam isLegacyAjax() (zero usos diretos)', function () {
+    $controllerPath = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($controllerPath);
+
+    // Remove comentários multi-line + single-line antes de procurar
+    $stripped = preg_replace('#/\*.*?\*/#s', '', $contents);
+    $stripped = preg_replace('#//.*$#m', '', $stripped);
+
+    // O ÚNICO uso direto permitido é dentro do helper isLegacyAjax() em si.
+    // Conta `request()->ajax()` no código stripped — deve ser exatamente 1.
+    $directCalls = substr_count($stripped, 'request()->ajax()');
+
+    expect($directCalls)->toBe(1, 'Esperado exatamente 1 uso direto de request()->ajax() (dentro do helper isLegacyAjax). Encontrado: ' . $directCalls);
+});
+
+test('ContactController — 8+ branches usam isLegacyAjax (paridade com legacy ajax checks)', function () {
+    $controllerPath = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($controllerPath);
+
+    // Conta chamadas $this->isLegacyAjax(). Pre-fix havia 8 branches `if (request()->ajax())`.
+    // Pós-fix devem virar 8 `if ($this->isLegacyAjax())`.
+    $helperCalls = substr_count($contents, '$this->isLegacyAjax()');
+
+    expect($helperCalls)->toBeGreaterThanOrEqual(8, "Esperado ≥8 usos de \$this->isLegacyAjax() (paridade com branches ajax legacy). Encontrado: {$helperCalls}");
+});


### PR DESCRIPTION
## Summary

Fix de bug **pré-existente** descoberto 2026-05-21 quando ativei `MWART_CLIENTE_INDEX=true` em prod via SSH. ContactController tinha 8 branches `if (request()->ajax())` que capturavam Inertia partial reloads (porque Inertia ALSO seta `X-Requested-With: XMLHttpRequest`) e retornavam DataTable JSON cru, quebrando o cliente Inertia com erro:

> All Inertia requests must receive a valid Inertia response, however a plain JSON response was received.

## Sintoma em prod

Screenshot: header + sidebar React carregavam (Wagner Rocha visível top-right, sidebar com Modules), mas main area mostrava texto cru:

```
{\"draw\":0,\"recordsTotal\":35,\"recordsFiltered\":35,\"data\":[{\"business_id\":1, ...
...Cliente padrão...Wager1111...
[Ações Toggle Dropdown]
Pagar / Pagar devolução de venda / Ver / Editar / Excluir / Deactivate
Ledger / Vendas / Documents & Note
```

Rollback emergencial aplicado: `MWART_CLIENTE_INDEX=false` no `.env` de prod via SSH → `/cliente` voltou a renderizar Blade legacy funcional (sem interrupção).

## Root cause

`request()->ajax()` retorna `true` quando header `X-Requested-With: XMLHttpRequest` está presente. **Inertia partial reloads enviam esse header**, fazendo o branch ajax capturar requests Inertia inadequadamente.

Pattern problemático:

```php
public function index()
{
    if (request()->ajax()) {
        return $this->indexCustomer();  // ← retorna DataTable JSON
    }

    // ↓ NUNCA chega quando Inertia faz partial reload pra carregar defer props
    if ($this->shouldRenderInertiaCliente('cliente_index', ...)) {
        return Inertia::render('Cliente/Index', [
            'kpis' => Inertia::defer(fn () => ...),
            'customers' => Inertia::defer(fn () => ...),
        ]);
    }
}
```

## Fix

Helper privado `isLegacyAjax()` que combina ambas as checks:

```php
private function isLegacyAjax(): bool
{
    return request()->ajax() && ! request()->hasHeader('X-Inertia');
}
```

Substituídas as **8 ocorrências** `if (request()->ajax())` por `if (\$this->isLegacyAjax())`:

| Linha | Método | Propósito |
|---|---|---|
| 132 | `index()` | DataTable customer/supplier list |
| 1023 | (anon) | contact lookup AJAX |
| 1139 | (anon) | contact CRUD AJAX |
| 1216 | (anon) | contact reward AJAX |
| 1270 | (anon) | contact autocomplete search |
| 1986 | (anon) | contact update status toggle |
| 2056 | `getContactPayments` | DataTable payments por contact |
| 2096 | `getContactDue` | AJAX get due value |

Inertia partial reload agora **falha** o `isLegacyAjax()` (porque tem header `X-Inertia: true`), segue pro branch `Inertia::render(...)` e responde correto.

## Test plan

- ✅ Pest `tests/Feature/Cliente/InertiaAjaxCollisionTest.php` (3 testes, 6 assertions):
  - Helper existe + verifica X-Inertia header
  - Zero usos diretos `request()->ajax()` (exceto dentro do helper)
  - ≥8 usos `\$this->isLegacyAjax()` (paridade)
- ✅ `php -l ContactController.php` syntax OK
- [ ] CI gates passam (modules-pest, mwart-gate, governance-gate)
- [ ] Pós-merge + deploy:
  1. SSH prod: `sed -i 's/MWART_CLIENTE_INDEX=false/MWART_CLIENTE_INDEX=true/' .env && php artisan config:cache`
  2. Smoke logado: `/cliente` renderiza Cliente/Index.tsx (React) com KPIs + DataTable customers
  3. Verificar via DevTools Network: requests pra defer props retornam Inertia JSON (não DataTable)
- [ ] Smoke /contacts?type=customer (legacy) continua funcionando

## Rollback

Reverter este PR (1 commit) → padrão volta ao anterior, INDEX flag tem que ficar OFF em prod indefinidamente.

## Refs

- PR #1289 — Fase 2 código Cliente DORMENTE (origem do bug exposto)
- PR #1298 — Wave 5 paralela paridade Show (depende deste fix pra reativar SHOW=true sem repetir o bug em outras telas)
- ADR 0093 — multi-tenant Tier 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)