### PR TITLE
fix(cliente): KPIs Index — total_paid não existe no schema (subquery)

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -195,10 +195,13 @@ class ContactController extends Controller
                   ->where('transactions.due_date', '<', now());
             })
             ->count();
+        // FIX 2026-05-21: `transactions.total_paid` NÃO existe no schema UltimatePOS.
+        // Pagamentos estão em `transaction_payments.amount` (1:N). Subquery scalar.
+        $totalPaidSub = '(SELECT COALESCE(SUM(amount), 0) FROM transaction_payments WHERE transaction_payments.transaction_id = transactions.id)';
         $valor_total_aberto = (float) Transaction::where('transactions.business_id', $business_id)
             ->where('transactions.type', 'sell')
             ->whereIn('transactions.payment_status', ['due', 'partial'])
-            ->sum(DB::raw('final_total - COALESCE(total_paid, 0)'));
+            ->sum(DB::raw("final_total - {$totalPaidSub}"));
 
         return [
             'total' => (int) $total,
@@ -239,7 +242,8 @@ class ContactController extends Controller
                 DB::raw('COUNT(*) AS total_os'),
                 DB::raw('SUM(CASE WHEN payment_status IN (\'due\',\'partial\') THEN 1 ELSE 0 END) AS os_abertas'),
                 DB::raw('SUM(CASE WHEN payment_status IN (\'due\',\'partial\') AND due_date IS NOT NULL AND due_date < NOW() THEN 1 ELSE 0 END) AS os_atrasadas'),
-                DB::raw('SUM(CASE WHEN payment_status IN (\'due\',\'partial\') THEN (final_total - COALESCE(total_paid, 0)) ELSE 0 END) AS valor_aberto'),
+                // FIX 2026-05-21: subquery em transaction_payments (total_paid NÃO existe no schema).
+                DB::raw('SUM(CASE WHEN payment_status IN (\'due\',\'partial\') THEN (final_total - (SELECT COALESCE(SUM(tp.amount), 0) FROM transaction_payments tp WHERE tp.transaction_id = transactions.id)) ELSE 0 END) AS valor_aberto'),
                 DB::raw('MAX(transaction_date) AS last_os_at'),
             )
             ->groupBy('contact_id')


### PR DESCRIPTION
## Summary

Bug pré-existente revelado 2026-05-21 ao ativar `MWART_CLIENTE_INDEX=true` em prod pós PR #1299 mergeado.

**Sintoma:** /cliente carrega shell React + título \"Clientes\" + botões \"Importar\" + \"Novo cliente\", mas main area exibe **500 Server Error**.

**Log Hostinger:**
```
PDOException SQLSTATE[42S22] Column not found: 1054 Unknown column 'total_paid' in 'SELECT'
at ContactController->buildClienteIndexKpis()
```

**Root cause:** schema UltimatePOS `transactions` NÃO tem coluna `total_paid`. Colunas paid/total existentes:
- `total_before_tax`
- `final_total`
- `total_amount_recovered`

Pagamentos vivem em `transaction_payments` (1:N). PR #1289 (Wave 1 Index) assumiu coluna que nunca existiu — código nunca executou em prod até hoje (flag estava OFF).

## Fix

Subquery scalar em `transaction_payments`:

```php
(SELECT COALESCE(SUM(amount), 0) FROM transaction_payments
 WHERE transaction_id = transactions.id)
```

2 substituições em `buildClienteIndexKpis()`:
- Linha 198-201: `valor_total_aberto` (KPI agregado)
- Linha 245: subquery por `contact_id` (KPI por cliente na tabela)

## Test plan

- [x] `php -l ContactController.php` syntax OK
- [ ] CI: modules-pest, mwart-gate, governance-gate
- [ ] Pós-merge + deploy:
  1. SSH prod: `MWART_CLIENTE_INDEX=true` já está ativo (Wagner ativou cedo)
  2. Smoke logado: /cliente renderiza Cliente/Index.tsx (React) sem 500
  3. KPIs cards mostram valor_total_aberto > R\$ 0,00 (se houver inadimplência)

## Rollback

`MWART_CLIENTE_INDEX=false` em prod restaura /cliente Blade legacy (já testado).

## Refs

- PR #1289 — Wave 1 Index (origem do bug)
- PR #1299 — fix Inertia ajax collision (precondição mergeada)
- ADR 0093 — multi-tenant Tier 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)