### PR TITLE
fix(cliente): SalesPaginator total_paid — subquery transaction_payments

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -76,6 +76,9 @@ class ContactController extends Controller
         $q = trim((string) $req->query('customer_sales_q', ''));
         $page = max(1, (int) $req->query('customer_sales_page', 1));
 
+        // FIX 2026-05-21: `transactions.total_paid` NÃO existe no schema UltimatePOS.
+        // Pagamentos vivem em `transaction_payments.amount` (1:N). Subquery scalar inline.
+        $totalPaidExpr = '(SELECT COALESCE(SUM(amount), 0) FROM transaction_payments WHERE transaction_payments.transaction_id = transactions.id)';
         $query = Transaction::where('transactions.business_id', $businessId)
             ->where('contact_id', $contactId)
             ->where('type', 'sell')
@@ -87,7 +90,7 @@ class ContactController extends Controller
                 'transactions.ref_no',
                 'transactions.transaction_date',
                 'transactions.final_total',
-                'transactions.total_paid',
+                DB::raw("{$totalPaidExpr} AS total_paid"),
                 'transactions.payment_status',
                 'transactions.status',
                 'bl.name as location_name',


### PR DESCRIPTION
Mesmo bug que PR #1300 mas em outro helper. `buildClienteSalesPaginator` (Wave 5 Show) tambem usa `transactions.total_paid` que nao existe no schema. Fix: DB::raw subquery scalar em `transaction_payments`.

Pos-merge: /cliente/{id} Show React renderiza 4 tabs funcional. SHOW=true ja ativo em prod.

Refs: PR #1300 (mesmo padrao de fix em buildClienteIndexKpis), PR #1298 (Wave 5 origem).

🤖 Generated with [Claude Code](https://claude.com/claude-code)