### PR TITLE
feat(cliente): Onda Final.A — Contact picker header Show

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -1092,6 +1092,21 @@ class ContactController extends Controller
                 // Inertia::defer roda em request separado (partial reload only:['sales']) — usa request() corrente, NÃO $req capturado.
                 'sales' => Inertia::defer(fn () => $this->buildClienteSalesPaginator((int) $contact->id, (int) $business_id, request())),
                 'locations' => $business_locations->map(fn ($name, $id) => ['id' => (int) $id, 'name' => (string) $name])->values()->all(),
+                // Onda Final.A — Contact picker header: lista clientes (customer+both) ativos do biz pro dropdown trocar contato sem voltar.
+                // Defer porque pode ser custoso em business com muitos contatos. Multi-tenant Tier 0 (ADR 0093).
+                'contact_dropdown' => Inertia::defer(fn () => Contact::where('contacts.business_id', $business_id)
+                    ->whereIn('contacts.type', ['customer', 'both'])
+                    ->where('contacts.contact_status', 'active')
+                    ->orderBy('name')
+                    ->limit(500)
+                    ->get(['id', 'name', 'contact_id', 'supplier_business_name'])
+                    ->map(fn ($c) => [
+                        'id' => (int) $c->id,
+                        'name' => (string) $c->name,
+                        'contact_id' => $c->contact_id,
+                        'supplier_business_name' => $c->supplier_business_name,
+                    ])
+                    ->all()),
                 'permissions' => [
                     'update' => $can_customer_update || $can_supplier_update,
                     'pay_due' => $user->can('purchase.payments') || $user->can('sell.payments'),

--- a/resources/js/Pages/Cliente/Show.tsx
+++ b/resources/js/Pages/Cliente/Show.tsx
@@ -32,6 +32,7 @@ import LedgerTab from './_show/LedgerTab';
 import SalesTab, { type SalesPaginator } from './_show/SalesTab';
 import DocumentsTab from './_show/DocumentsTab';
 import ActionsMenu from './_show/ActionsMenu';
+import ContactPicker, { type ContactDropdownItem } from './_show/ContactPicker';
 
 interface ContactInfo {
   id: number;
@@ -77,6 +78,7 @@ interface ClienteShowPageProps {
   sales?: SalesPaginator;
   locations: Array<{ id: number; name: string }>;
   permissions: Permissions;
+  contact_dropdown?: ContactDropdownItem[];
 }
 
 const formatBRL = (value: number) =>
@@ -97,7 +99,7 @@ export default function ClienteShow(props: ClienteShowPageProps) {
     <div className="-m-6 bg-muted/30 min-h-[calc(100vh-3rem)]">
       <div className="border-b border-border bg-background">
         <div className="container mx-auto px-8 pt-6 pb-4 max-w-6xl">
-          <div className="flex items-center gap-3 mb-2">
+          <div className="flex items-center justify-between gap-3 mb-2">
             <a
               href="/cliente"
               className="inline-flex items-center text-xs text-muted-foreground hover:text-foreground transition-colors"
@@ -105,6 +107,9 @@ export default function ClienteShow(props: ClienteShowPageProps) {
               <ChevronLeft size={14} className="mr-1" />
               Voltar para clientes
             </a>
+            <Deferred data="contact_dropdown" fallback={<ContactPicker currentContactId={contact.id} />}>
+              <ContactPicker currentContactId={contact.id} contacts={props.contact_dropdown} />
+            </Deferred>
           </div>
           <div className="flex items-start gap-4">
             <div className="h-14 w-14 rounded-md bg-gradient-to-br from-stone-100 to-stone-200 dark:from-stone-800 dark:to-stone-700 flex items-center justify-center text-lg font-semibold text-stone-700 dark:text-stone-200">

--- a/resources/js/Pages/Cliente/_show/ContactPicker.tsx
+++ b/resources/js/Pages/Cliente/_show/ContactPicker.tsx
@@ -1,0 +1,153 @@
+// Onda Final.A — Contact picker dropdown no header Show.
+// Permite trocar contato sem voltar pra listagem.
+// Paridade com Blade legacy: `<select id="sr_location_id">` que faz window.location = '/contacts/' + id.
+
+import { useState, useMemo } from 'react';
+import { router } from '@inertiajs/react';
+import { Search, ChevronDown } from 'lucide-react';
+
+export interface ContactDropdownItem {
+  id: number;
+  name: string;
+  contact_id: string | null;
+  supplier_business_name: string | null;
+}
+
+export interface ContactPickerProps {
+  currentContactId: number;
+  contacts?: ContactDropdownItem[];
+}
+
+export default function ContactPicker({ currentContactId, contacts }: ContactPickerProps) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+
+  const filtered = useMemo(() => {
+    if (!contacts) return [];
+    const q = query.trim().toLowerCase();
+    if (!q) return contacts.slice(0, 50);
+    return contacts
+      .filter((c) => {
+        const haystack = [c.name, c.supplier_business_name, c.contact_id].filter(Boolean).join(' ').toLowerCase();
+        return haystack.includes(q);
+      })
+      .slice(0, 50);
+  }, [contacts, query]);
+
+  const handleSelect = (id: number) => {
+    if (id === currentContactId) {
+      setOpen(false);
+      return;
+    }
+    router.visit(`/contacts/${id}`, { preserveScroll: false });
+  };
+
+  if (!contacts) {
+    return (
+      <button
+        type="button"
+        disabled
+        className="inline-flex items-center gap-1.5 rounded-md border border-border bg-muted/30 px-2.5 py-1.5 text-xs text-muted-foreground"
+        aria-label="Trocar contato (carregando)"
+        data-testid="contact-picker-loading"
+      >
+        Trocar contato
+        <ChevronDown size={12} className="opacity-50" />
+      </button>
+    );
+  }
+
+  return (
+    <div className="relative" data-testid="contact-picker-root">
+      <button
+        type="button"
+        onClick={() => setOpen(!open)}
+        className="inline-flex items-center gap-1.5 rounded-md border border-border bg-background px-2.5 py-1.5 text-xs text-foreground hover:bg-muted/40 transition-colors"
+        aria-label="Trocar contato"
+        aria-expanded={open}
+        data-testid="contact-picker-trigger"
+      >
+        Trocar contato
+        <ChevronDown size={12} className={open ? 'rotate-180 transition-transform' : 'transition-transform'} />
+      </button>
+
+      {open && (
+        <>
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setOpen(false)}
+            aria-hidden
+          />
+          <div
+            className="absolute right-0 top-full mt-1 z-50 w-80 rounded-md border border-border bg-background shadow-lg overflow-hidden"
+            role="dialog"
+            aria-label="Selecionar contato"
+            data-testid="contact-picker-dropdown"
+          >
+            <div className="border-b border-border p-2">
+              <div className="relative">
+                <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground" />
+                <input
+                  type="search"
+                  autoFocus
+                  value={query}
+                  onChange={(e) => setQuery(e.target.value)}
+                  placeholder="Buscar por nome ou código..."
+                  className="w-full rounded border border-border bg-background pl-8 pr-2 py-1.5 text-xs focus:outline-none focus:ring-1 focus:ring-blue-500"
+                  data-testid="contact-picker-search"
+                />
+              </div>
+            </div>
+            <div className="max-h-72 overflow-y-auto">
+              {filtered.length === 0 ? (
+                <div className="p-4 text-center text-xs text-muted-foreground" data-testid="contact-picker-empty">
+                  Nenhum contato encontrado.
+                </div>
+              ) : (
+                <ul className="py-1">
+                  {filtered.map((c) => {
+                    const isCurrent = c.id === currentContactId;
+                    return (
+                      <li key={c.id}>
+                        <button
+                          type="button"
+                          onClick={() => handleSelect(c.id)}
+                          disabled={isCurrent}
+                          className={
+                            'w-full text-left px-3 py-2 text-xs hover:bg-muted/40 transition-colors flex items-center justify-between ' +
+                            (isCurrent ? 'bg-blue-50 dark:bg-blue-950/30 cursor-default' : '')
+                          }
+                          data-testid={`contact-picker-item-${c.id}`}
+                        >
+                          <div className="flex-1 min-w-0">
+                            <div className="font-medium text-foreground truncate">
+                              {c.name}
+                              {c.supplier_business_name && (
+                                <span className="text-muted-foreground"> · {c.supplier_business_name}</span>
+                              )}
+                            </div>
+                            {c.contact_id && (
+                              <div className="text-[10px] text-muted-foreground">({c.contact_id})</div>
+                            )}
+                          </div>
+                          {isCurrent && (
+                            <span className="text-[10px] text-blue-700 dark:text-blue-400 font-semibold uppercase tracking-wider">
+                              atual
+                            </span>
+                          )}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+            <div className="border-t border-border px-3 py-1.5 text-[10px] text-muted-foreground">
+              {contacts.length > 50 ? `Exibindo 50 de ${contacts.length} contatos. Digite pra filtrar.` : `${contacts.length} contato${contacts.length === 1 ? '' : 's'}`}
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/tests/Feature/Cliente/Show/ContactPickerTest.php
+++ b/tests/Feature/Cliente/Show/ContactPickerTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+// Onda Final.A — Contact picker header Show
+// Teste estrutural: garante componente existe + Show.tsx integra + Controller injeta dropdown.
+
+test('ContactPicker.tsx — estrutura mínima componente', function () {
+    $path = __DIR__ . '/../../../../resources/js/Pages/Cliente/_show/ContactPicker.tsx';
+    expect($path)->toBeReadableFile();
+
+    $contents = file_get_contents($path);
+    expect($contents)
+        ->toContain('export default function ContactPicker')
+        ->toContain('data-testid="contact-picker-trigger"')
+        ->toContain('data-testid="contact-picker-search"')
+        ->toContain('data-testid="contact-picker-dropdown"')
+        ->toContain('data-testid="contact-picker-empty"')
+        ->toContain('router.visit')
+        ->not->toContain(': any');
+});
+
+test('ContactPicker.tsx — busca + cap 50 + handle current', function () {
+    $path = __DIR__ . '/../../../../resources/js/Pages/Cliente/_show/ContactPicker.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain('useMemo')
+        ->toContain('toLowerCase')
+        ->toContain('.slice(0, 50)')
+        ->toContain('isCurrent');
+});
+
+test('Cliente/Show.tsx — integra ContactPicker no header', function () {
+    $path = __DIR__ . '/../../../../resources/js/Pages/Cliente/Show.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("import ContactPicker")
+        ->toContain('<ContactPicker')
+        ->toContain('contact_dropdown')
+        ->toContain('data="contact_dropdown"');
+});
+
+test('ContactController — Show injeta contact_dropdown defer com scope business_id', function () {
+    $path = __DIR__ . '/../../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("'contact_dropdown' => Inertia::defer")
+        ->toContain("contacts.business_id")
+        ->toContain("'customer', 'both'");
+});


### PR DESCRIPTION
Novo dropdown no header de /cliente/{id} pra trocar contato sem voltar pra listagem.

Backend: novo defer 'contact_dropdown' (limit 500, customer+both ativos, scope business_id).
Frontend: novo componente ContactPicker.tsx (busca + cap 50 + badge atual + router.visit).
Pest: 4/20 verde.

Refs: ADR 0093 multi-tenant Tier 0. Paridade Blade contact/show.blade.php.