### PR TITLE
feat(cliente): Onda Final.E+F - Reward Points + Ledger inline SPA

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -1067,7 +1067,7 @@ class ContactController extends Controller
                     'state' => $contact->state ?? null,
                     'address_line_1' => $contact->address_line_1 ?? null,
                 ],
-                'initialTab' => in_array($tab, ['ledger', 'sales', 'payments', 'documents', 'activities', 'persons', 'subscriptions'], true) ? $tab : 'ledger',
+                'initialTab' => in_array($tab, ['ledger', 'sales', 'payments', 'documents', 'activities', 'persons', 'subscriptions', 'rewards'], true) ? $tab : 'ledger',
                 'stats' => Inertia::defer(fn () => [
                     'total_invoice' => (float) ($contact->total_invoice ?? 0),
                     'invoice_due' => (float) (($contact->total_invoice ?? 0) - ($contact->invoice_paid ?? 0)),
@@ -1141,6 +1141,39 @@ class ContactController extends Controller
                         'designation' => $u->crm_designation,
                     ])
                     ->all()),
+                // Onda Final.E — Tab Reward Points: pontos fidelidade do contact.
+                // Condicional business.enable_rp (passa null se desligado).
+                'reward_points' => Inertia::defer(fn () => ($req->session()->get('business.enable_rp') == 1 && in_array($contact->type, ['customer', 'both'], true))
+                    ? [
+                        'enabled' => true,
+                        'rp_name' => (string) ($req->session()->get('business.rp_name') ?? 'Pontos'),
+                        'summary' => [
+                            'total_earned' => (int) ($contact->total_rp ?? 0),
+                            'total_used' => (int) ($contact->total_rp_used ?? 0),
+                            'total_expired' => (int) ($contact->total_rp_expired ?? 0),
+                            'balance' => (int) (((int) ($contact->total_rp ?? 0)) - ((int) ($contact->total_rp_used ?? 0)) - ((int) ($contact->total_rp_expired ?? 0))),
+                        ],
+                        'history' => Transaction::where('transactions.business_id', $business_id)
+                            ->where('transactions.contact_id', $contact->id)
+                            ->where(function ($q) {
+                                $q->where('transactions.rp_earned', '>', 0)
+                                  ->orWhere('transactions.rp_redeemed', '>', 0);
+                            })
+                            ->orderByDesc('transactions.transaction_date')
+                            ->limit(100)
+                            ->get(['id', 'invoice_no', 'transaction_date', 'final_total', 'rp_earned', 'rp_redeemed', 'rp_redeemed_amount'])
+                            ->map(fn ($tx) => [
+                                'id' => (int) $tx->id,
+                                'invoice_no' => (string) ($tx->invoice_no ?? ''),
+                                'transaction_date' => optional($tx->transaction_date)->toIso8601String(),
+                                'final_total' => (float) $tx->final_total,
+                                'rp_earned' => (int) ($tx->rp_earned ?? 0),
+                                'rp_redeemed' => (int) ($tx->rp_redeemed ?? 0),
+                                'rp_redeemed_amount' => (float) ($tx->rp_redeemed_amount ?? 0),
+                            ])
+                            ->all(),
+                    ]
+                    : ['enabled' => false, 'rp_name' => '', 'summary' => null, 'history' => []]),
                 // Onda Final.D — Tab Assinaturas: transactions is_recurring=1 do contact (recur_parent_id NULL = pai da série).
                 // Multi-tenant Tier 0 (ADR 0093): business_id + contact_id scope obrigatório.
                 'subscriptions' => Inertia::defer(fn () => Transaction::where('transactions.business_id', $business_id)

--- a/resources/js/Pages/Cliente/Show.tsx
+++ b/resources/js/Pages/Cliente/Show.tsx
@@ -20,6 +20,7 @@ import {
   CreditCard,
   Edit,
   FileText,
+  Gift,
   ListChecks,
   Mail,
   MapPin,
@@ -39,6 +40,7 @@ import ContactPicker, { type ContactDropdownItem } from './_show/ContactPicker';
 import ActivitiesTab, { type ActivityItem } from './_show/ActivitiesTab';
 import PessoasContatoTab, { type ContactPerson } from './_show/PessoasContatoTab';
 import SubscriptionsTab, { type SubscriptionItem } from './_show/SubscriptionsTab';
+import RewardPointsTab, { type RewardPointsPayload } from './_show/RewardPointsTab';
 
 interface ContactInfo {
   id: number;
@@ -75,7 +77,7 @@ interface Permissions {
   view_sell: boolean;
 }
 
-type TabKey = 'ledger' | 'sales' | 'payments' | 'documents' | 'activities' | 'persons' | 'subscriptions';
+type TabKey = 'ledger' | 'sales' | 'payments' | 'documents' | 'activities' | 'persons' | 'subscriptions' | 'rewards';
 
 interface ClienteShowPageProps {
   contact: ContactInfo;
@@ -88,6 +90,7 @@ interface ClienteShowPageProps {
   activities?: ActivityItem[];
   contact_persons?: ContactPerson[];
   subscriptions?: SubscriptionItem[];
+  reward_points?: RewardPointsPayload;
 }
 
 const formatBRL = (value: number) =>
@@ -105,6 +108,7 @@ export default function ClienteShow(props: ClienteShowPageProps) {
     { key: 'activities', label: 'Atividades', icon: Activity },
     { key: 'persons', label: 'Pessoas', icon: Users },
     { key: 'subscriptions', label: 'Assinaturas', icon: Recycle },
+    { key: 'rewards', label: 'Pontos', icon: Gift },
   ];
 
   return (
@@ -270,6 +274,11 @@ export default function ClienteShow(props: ClienteShowPageProps) {
               {activeTab === 'subscriptions' && (
                 <Deferred data="subscriptions" fallback={<TabSkeleton />}>
                   <SubscriptionsTab subscriptions={props.subscriptions} />
+                </Deferred>
+              )}
+              {activeTab === 'rewards' && (
+                <Deferred data="reward_points" fallback={<TabSkeleton />}>
+                  <RewardPointsTab reward_points={props.reward_points} />
                 </Deferred>
               )}
             </div>

--- a/resources/js/Pages/Cliente/_show/LedgerTab.tsx
+++ b/resources/js/Pages/Cliente/_show/LedgerTab.tsx
@@ -7,6 +7,7 @@
 // Pattern reuse: Cliente/Ledger.tsx (standalone) — versão inline simplificada pra tab.
 
 import { useState } from 'react';
+import { router } from '@inertiajs/react';
 import { Calendar, Download, Filter, Mail, Printer, FileText } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
 import { Input } from '@/Components/ui/input';
@@ -100,8 +101,11 @@ export default function LedgerTab({
     return `/contacts/ledger?${params.toString()}`;
   };
 
+  // Onda Final.F — usa Inertia router.visit em vez de window.location.href.
+  // Garante SPA navigation (mantém AppShellV2) e renderiza /contacts/ledger
+  // (Cliente/Ledger.tsx React, já validada em prod via Onda 1.D) com filtros aplicados.
   const applyFilters = () => {
-    window.location.href = buildUrl();
+    router.visit(buildUrl(), { preserveScroll: false });
   };
 
   const printPdf = () => {

--- a/resources/js/Pages/Cliente/_show/RewardPointsTab.tsx
+++ b/resources/js/Pages/Cliente/_show/RewardPointsTab.tsx
@@ -1,0 +1,144 @@
+// Onda Final.E — Tab Reward Points (pontos fidelidade).
+// Condicional business.enable_rp. Mostra saldo + histórico ganhos/resgates.
+
+import { Gift, ExternalLink } from 'lucide-react';
+
+export interface RewardSummary {
+  total_earned: number;
+  total_used: number;
+  total_expired: number;
+  balance: number;
+}
+
+export interface RewardHistoryItem {
+  id: number;
+  invoice_no: string;
+  transaction_date: string | null;
+  final_total: number;
+  rp_earned: number;
+  rp_redeemed: number;
+  rp_redeemed_amount: number;
+}
+
+export interface RewardPointsPayload {
+  enabled: boolean;
+  rp_name: string;
+  summary: RewardSummary | null;
+  history: RewardHistoryItem[];
+}
+
+export interface RewardPointsTabProps {
+  reward_points?: RewardPointsPayload;
+}
+
+const formatBRL = (v: number) =>
+  new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(v);
+
+const formatDate = (iso: string | null) => {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  return new Intl.DateTimeFormat('pt-BR', { day: '2-digit', month: '2-digit', year: 'numeric' }).format(d);
+};
+
+export default function RewardPointsTab({ reward_points }: RewardPointsTabProps) {
+  if (!reward_points) {
+    return (
+      <div className="p-8 text-center text-xs text-muted-foreground" data-testid="rewards-tab-skeleton">
+        Carregando pontos…
+      </div>
+    );
+  }
+
+  if (!reward_points.enabled) {
+    return (
+      <div className="p-8 text-center text-xs text-muted-foreground flex flex-col items-center gap-2" data-testid="rewards-tab-disabled">
+        <Gift size={24} className="text-muted-foreground/50" />
+        <div>Programa de pontos não habilitado neste negócio.</div>
+      </div>
+    );
+  }
+
+  const { rp_name, summary, history } = reward_points;
+  const label = rp_name || 'Pontos';
+
+  return (
+    <div className="p-4" data-testid="rewards-tab-root">
+      {summary && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-4">
+          <SummaryCard label={`${label} acumulados`} value={summary.total_earned} accent="default" />
+          <SummaryCard label="Resgatados" value={summary.total_used} accent="default" />
+          <SummaryCard label="Expirados" value={summary.total_expired} accent="muted" />
+          <SummaryCard label="Saldo disponível" value={summary.balance} accent={summary.balance > 0 ? 'success' : 'default'} />
+        </div>
+      )}
+
+      {history.length === 0 ? (
+        <div className="p-8 text-center text-xs text-muted-foreground" data-testid="rewards-tab-empty">
+          Nenhum histórico de {label.toLowerCase()} ainda.
+        </div>
+      ) : (
+        <div className="rounded-md border border-border overflow-hidden">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/50">
+              <tr className="border-b border-border">
+                <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Data</th>
+                <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Fatura</th>
+                <th className="text-right px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Total</th>
+                <th className="text-right px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Ganhos</th>
+                <th className="text-right px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Resgates</th>
+                <th className="text-right px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Desconto</th>
+                <th className="text-left px-4 py-2.5 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Ação</th>
+              </tr>
+            </thead>
+            <tbody>
+              {history.map((h) => (
+                <tr key={h.id} className="border-b border-border hover:bg-muted/40">
+                  <td className="px-4 py-3 text-xs text-muted-foreground tabular-nums whitespace-nowrap">
+                    {formatDate(h.transaction_date)}
+                  </td>
+                  <td className="px-4 py-3 text-xs font-medium text-foreground">{h.invoice_no || '—'}</td>
+                  <td className="px-4 py-3 text-xs text-right tabular-nums text-foreground">{formatBRL(h.final_total)}</td>
+                  <td className="px-4 py-3 text-xs text-right tabular-nums text-emerald-700 dark:text-emerald-400">
+                    {h.rp_earned > 0 ? `+${h.rp_earned}` : '—'}
+                  </td>
+                  <td className="px-4 py-3 text-xs text-right tabular-nums text-amber-700 dark:text-amber-400">
+                    {h.rp_redeemed > 0 ? `-${h.rp_redeemed}` : '—'}
+                  </td>
+                  <td className="px-4 py-3 text-xs text-right tabular-nums text-muted-foreground">
+                    {h.rp_redeemed_amount > 0 ? formatBRL(h.rp_redeemed_amount) : '—'}
+                  </td>
+                  <td className="px-4 py-3 text-xs">
+                    <a href={`/sells/${h.id}`} className="inline-flex items-center gap-1 text-blue-600 hover:underline">
+                      Ver <ExternalLink size={11} aria-hidden />
+                    </a>
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SummaryCard({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: number;
+  accent: 'default' | 'muted' | 'success';
+}) {
+  const tone = accent === 'success' ? 'text-emerald-700 dark:text-emerald-300' : accent === 'muted' ? 'text-muted-foreground' : 'text-foreground';
+  return (
+    <div className="rounded-md border border-border bg-background p-3">
+      <div className="text-[10px] font-semibold uppercase tracking-widest text-muted-foreground">{label}</div>
+      <div className={'text-lg font-semibold tabular-nums mt-1 ' + tone}>
+        {new Intl.NumberFormat('pt-BR').format(value)}
+      </div>
+    </div>
+  );
+}

--- a/tests/Feature/Cliente/Show/RewardPointsTabTest.php
+++ b/tests/Feature/Cliente/Show/RewardPointsTabTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+// Onda Final.E — Tab Reward Points (pontos fidelidade)
+// Teste estrutural: componente + integração + scope business_id + condicional enable_rp.
+
+test('RewardPointsTab.tsx — estrutura mínima componente', function () {
+    $path = __DIR__ . '/../../../../resources/js/Pages/Cliente/_show/RewardPointsTab.tsx';
+    expect($path)->toBeReadableFile();
+
+    $contents = file_get_contents($path);
+    expect($contents)
+        ->toContain('export default function RewardPointsTab')
+        ->toContain('data-testid="rewards-tab-root"')
+        ->toContain('data-testid="rewards-tab-empty"')
+        ->toContain('data-testid="rewards-tab-disabled"')
+        ->toContain('data-testid="rewards-tab-skeleton"')
+        ->not->toContain(': any');
+});
+
+test('RewardPointsTab.tsx — 4 summary cards + tabela 7 colunas', function () {
+    $path = __DIR__ . '/../../../../resources/js/Pages/Cliente/_show/RewardPointsTab.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain('acumulados')
+        ->toContain('Resgatados')
+        ->toContain('Expirados')
+        ->toContain('Saldo disponível')
+        ->toContain('>Data<')
+        ->toContain('>Fatura<')
+        ->toContain('>Total<')
+        ->toContain('>Ganhos<')
+        ->toContain('>Resgates<')
+        ->toContain('>Desconto<')
+        ->toContain('>Ação<');
+});
+
+test('Cliente/Show.tsx — integra RewardPointsTab como 8ª tab', function () {
+    $path = __DIR__ . '/../../../../resources/js/Pages/Cliente/Show.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("import RewardPointsTab")
+        ->toContain("'rewards'")
+        ->toContain("label: 'Pontos'")
+        ->toContain('<RewardPointsTab')
+        ->toContain('data="reward_points"');
+});
+
+test('ContactController — Show injeta reward_points defer condicional enable_rp', function () {
+    $path = __DIR__ . '/../../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("'reward_points' => Inertia::defer")
+        ->toContain("business.enable_rp")
+        ->toContain("total_rp")
+        ->toContain("rp_earned")
+        ->toContain("rp_redeemed");
+});
+
+test('LedgerTab.tsx — Onda Final.F usa router.visit (SPA navigation, sem window.location)', function () {
+    $path = __DIR__ . '/../../../../resources/js/Pages/Cliente/_show/LedgerTab.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain('router.visit')
+        ->toContain('@inertiajs/react');
+});


### PR DESCRIPTION
Duas sub-ondas finais em paralelo:

**Final.E - Tab Reward Points (8a tab):** backend defer condicional business.enable_rp, frontend 4 summary cards + tabela 7 cols. Icon Gift.

**Final.F - Ledger inline SPA:** LedgerTab applyFilters usa router.visit em vez de window.location, mantem AppShellV2. Cliente/Ledger.tsx React (ja validada Onda 1.D) renderiza inline.

Pest 5/31 verde. ADR 0093 multi-tenant Tier 0 preservado.