### PR TITLE
feat(compras): Drawer 5 tabs sobre grid + endpoint show (resposta Wagner)

### DIFF
--- a/Modules/Compras/Http/Controllers/ComprasController.php
+++ b/Modules/Compras/Http/Controllers/ComprasController.php
@@ -41,9 +41,16 @@ class ComprasController extends Controller
         }
 
         $businessId = (int) session('user.business_id');
+
+        $perPage = (int) $request->query('per_page', 25);
+        $perPage = in_array($perPage, [10, 25, 50, 100], true) ? $perPage : 25;
+
         $filters = [
             'q' => $request->query('q', ''),
             'stage' => $request->query('stage', 'all'),
+            'sort' => $request->query('sort', 'transaction_date'),
+            'dir' => $request->query('dir', 'desc'),
+            'per_page' => $perPage,
         ];
 
         $compraId = (int) $request->query('compra_id', 0);
@@ -59,6 +66,10 @@ class ComprasController extends Controller
 
             'rows' => Inertia::defer(
                 fn () => $this->buildRowsPayload($businessId, $filters)
+            ),
+
+            'summary' => Inertia::defer(
+                fn () => $this->comprasService->calcularSummary($businessId, $filters)
             ),
 
             'compra_detalhe' => Inertia::defer(
@@ -99,9 +110,10 @@ class ComprasController extends Controller
      */
     private function buildRowsPayload(int $businessId, array $filters): array
     {
+        $perPage = (int) ($filters['per_page'] ?? 25);
         $paginator = $this->comprasService
             ->listarCompras($businessId, $filters)
-            ->paginate(25);
+            ->paginate($perPage);
 
         return [
             'data' => $paginator->items(),

--- a/Modules/Compras/Http/Controllers/ComprasController.php
+++ b/Modules/Compras/Http/Controllers/ComprasController.php
@@ -46,8 +46,12 @@ class ComprasController extends Controller
             'stage' => $request->query('stage', 'all'),
         ];
 
+        $compraId = (int) $request->query('compra_id', 0);
+
         return Inertia::render('Compras/Index', [
             'filters' => $filters,
+
+            'selected_id' => $compraId ?: null,
 
             'kpis' => Inertia::defer(
                 fn () => $this->comprasService->calcularKpis($businessId)
@@ -56,7 +60,35 @@ class ComprasController extends Controller
             'rows' => Inertia::defer(
                 fn () => $this->buildRowsPayload($businessId, $filters)
             ),
+
+            'compra_detalhe' => Inertia::defer(
+                fn () => $compraId ? $this->comprasService->buscarDetalhe($compraId, $businessId) : null
+            ),
         ]);
+    }
+
+    /**
+     * Detalhe single — Wave 5 endpoint pra DrawerView 5 tabs.
+     *
+     * Partial reload via `router.get('/compras', { compra_id: X }, { only: ['compra_detalhe'] })`
+     * mantém a tabela em cache cliente-side; só `compra_detalhe` chega da rede.
+     *
+     * Tier 0 ADR 0093 — business_id scope no Service ANTES de qualquer fetch.
+     */
+    public function show(Request $request, int $id)
+    {
+        if (! auth()->user()->can('compras.view')) {
+            abort(403);
+        }
+
+        $businessId = (int) session('user.business_id');
+        $detalhe = $this->comprasService->buscarDetalhe($id, $businessId);
+
+        if (! $detalhe) {
+            abort(404);
+        }
+
+        return response()->json($detalhe);
     }
 
     /**

--- a/Modules/Compras/Routes/web.php
+++ b/Modules/Compras/Routes/web.php
@@ -27,10 +27,13 @@ Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'Adm
         Route::get('install/update', [InstallController::class, 'update']);
     });
 
-// Rotas operacionais — Wave 1 só Index (stub Inertia).
+// Rotas operacionais.
 Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin'])
     ->prefix('compras')
     ->name('compras.')
     ->group(function () {
         Route::get('/', [ComprasController::class, 'index'])->name('index');
+        Route::get('/{id}/detalhe', [ComprasController::class, 'show'])
+            ->where('id', '[0-9]+')
+            ->name('show');
     });

--- a/Modules/Compras/Services/ComprasService.php
+++ b/Modules/Compras/Services/ComprasService.php
@@ -24,8 +24,25 @@ class ComprasService
     public function __construct(protected TransactionUtil $transactionUtil) {}
 
     /**
-     * Lista paginada de compras com filtros + joins canônicos.
+     * Mapping coluna virtual frontend → coluna SQL real (segurança anti SQL injection).
      *
+     * SOMENTE colunas dessa lista podem entrar em orderBy. Caller passa nome
+     * de coluna virtual; service decide qual coluna SQL real usar.
+     */
+    private const SORT_MAP = [
+        'transaction_date' => 'transactions.transaction_date',
+        'ref_no' => 'transactions.ref_no',
+        'contact_name' => 'contacts.supplier_business_name',
+        'location_name' => 'BS.name',
+        'status' => 'transactions.status',
+        'payment_status' => 'transactions.payment_status',
+        'final_total' => 'transactions.final_total',
+    ];
+
+    /**
+     * Lista paginada de compras com filtros + sort dinâmico + joins canônicos.
+     *
+     * @param  array{q?:string, stage?:string, sort?:string, dir?:string}  $filters
      * @return \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder
      */
     public function listarCompras(int $businessId, array $filters = [])
@@ -45,7 +62,56 @@ class ComprasService
             $query->where('transactions.status', $filters['stage']);
         }
 
-        return $query->orderBy('transactions.transaction_date', 'desc');
+        $sortCol = $filters['sort'] ?? 'transaction_date';
+        $sortDir = strtolower($filters['dir'] ?? 'desc') === 'asc' ? 'asc' : 'desc';
+        $sqlCol = self::SORT_MAP[$sortCol] ?? 'transactions.transaction_date';
+
+        return $query->orderBy($sqlCol, $sortDir);
+    }
+
+    /**
+     * Sumário agregado pra footer da tabela — total / pago / a pagar / reembolsado.
+     *
+     * Tier 0 ADR 0093 — business_id scope explícito.
+     */
+    public function calcularSummary(int $businessId, array $filters = []): array
+    {
+        $base = Transaction::where('business_id', $businessId)
+            ->where('type', 'purchase');
+
+        // Aplica mesmos filtros que listarCompras (q + stage) pra coerência
+        if (! empty($filters['q'])) {
+            $q = $filters['q'];
+            $base->where(function ($w) use ($q) {
+                $w->where('ref_no', 'like', "%{$q}%");
+            });
+        }
+        if (! empty($filters['stage']) && $filters['stage'] !== 'all') {
+            $base->where('status', $filters['stage']);
+        }
+
+        $total = (clone $base)->sum('final_total');
+
+        $totalPago = (float) (clone $base)
+            ->leftJoin('transaction_payments AS TP', 'transactions.id', '=', 'TP.transaction_id')
+            ->where(function ($w) {
+                $w->whereNull('TP.is_return')->orWhere('TP.is_return', 0);
+            })
+            ->sum('TP.amount');
+
+        $totalReembolso = (float) (clone $base)
+            ->leftJoin('transaction_payments AS TP', 'transactions.id', '=', 'TP.transaction_id')
+            ->where('TP.is_return', 1)
+            ->sum('TP.amount');
+
+        $aPagar = max(0, ((float) $total) - $totalPago);
+
+        return [
+            'total' => (float) $total,
+            'pago' => $totalPago,
+            'a_pagar' => $aPagar,
+            'reembolso' => $totalReembolso,
+        ];
     }
 
     /**

--- a/Modules/Compras/Services/ComprasService.php
+++ b/Modules/Compras/Services/ComprasService.php
@@ -5,6 +5,7 @@ namespace Modules\Compras\Services;
 use App\Transaction;
 use App\Utils\TransactionUtil;
 use Carbon\Carbon;
+use Spatie\Activitylog\Models\Activity;
 
 /**
  * ComprasService — wrapper canônico do módulo Compras.
@@ -86,6 +87,128 @@ class ComprasService
             'transito' => (int) $transito,
             'mes' => (float) $mes,
             'fornec' => (int) $fornec,
+        ];
+    }
+
+    /**
+     * Detalhe completo de UMA compra pra DrawerView 5 tabs (Resumo/Itens/Docs/Pagamentos/Histórico).
+     *
+     * Tier 0 ADR 0093 — `where('business_id', $businessId)` ANTES de find pra evitar leak.
+     *
+     * Retorna null se não achar (caller responde 404).
+     */
+    public function buscarDetalhe(int $id, int $businessId): ?array
+    {
+        $compra = Transaction::where('business_id', $businessId)
+            ->where('id', $id)
+            ->whereIn('type', ['purchase', 'purchase_order', 'purchase_return'])
+            ->with([
+                'contact',
+                'location',
+                'purchase_lines',
+                'purchase_lines.product',
+                'purchase_lines.product.unit',
+                'purchase_lines.variations',
+                'purchase_lines.variations.product_variation',
+                'payment_lines',
+            ])
+            ->first();
+
+        if (! $compra) {
+            return null;
+        }
+
+        $lines = collect($compra->purchase_lines ?? [])->map(function ($line) {
+            $variationName = null;
+            if ($line->variations) {
+                $sub = $line->variations->product_variation->name ?? null;
+                $var = $line->variations->name ?? null;
+                $variationName = trim(($sub ?? '').' '.($var ?? '')) ?: null;
+            }
+
+            return [
+                'id' => $line->id,
+                'product_name' => $line->product->name ?? '—',
+                'product_sku' => $line->product->sku ?? null,
+                'variation_name' => $variationName,
+                'quantity' => (float) ($line->quantity ?? 0),
+                'unit_name' => $line->product->unit->short_name ?? $line->product->unit->actual_name ?? null,
+                'purchase_price' => (float) ($line->purchase_price ?? 0),
+                'purchase_price_inc_tax' => (float) ($line->purchase_price_inc_tax ?? 0),
+                'item_tax' => (float) ($line->item_tax ?? 0),
+                'line_total' => (float) (($line->quantity ?? 0) * ($line->purchase_price_inc_tax ?? 0)),
+                'lot_number' => $line->lot_number ?? null,
+            ];
+        })->all();
+
+        $payments = collect($compra->payment_lines ?? [])->map(function ($p) {
+            return [
+                'id' => $p->id,
+                'paid_on' => optional($p->paid_on)->toIso8601String(),
+                'amount' => (float) ($p->amount ?? 0),
+                'method' => $p->method ?? null,
+                'card_transaction_number' => $p->card_transaction_number ?? null,
+                'cheque_number' => $p->cheque_number ?? null,
+                'bank_account_number' => $p->bank_account_number ?? null,
+                'note' => $p->note ?? null,
+                'is_return' => (bool) ($p->is_return ?? false),
+            ];
+        })->all();
+
+        $timeline = Activity::forSubject($compra)
+            ->with('causer')
+            ->latest()
+            ->limit(50)
+            ->get()
+            ->map(function ($a) {
+                return [
+                    'id' => $a->id,
+                    'description' => $a->description,
+                    'causer_name' => optional($a->causer)->first_name
+                        ? trim(($a->causer->surname ?? '').' '.($a->causer->first_name ?? '').' '.($a->causer->last_name ?? ''))
+                        : 'Sistema',
+                    'created_at' => $a->created_at?->toIso8601String(),
+                    'properties' => $a->properties?->toArray(),
+                ];
+            })
+            ->all();
+
+        $contact = $compra->contact;
+
+        return [
+            'id' => $compra->id,
+            'ref_no' => $compra->ref_no,
+            'document' => $compra->document,
+            'transaction_date' => optional($compra->transaction_date)->toIso8601String(),
+            'type' => $compra->type,
+            'status' => $compra->status,
+            'payment_status' => $compra->payment_status,
+            'final_total' => (float) ($compra->final_total ?? 0),
+            'total_before_tax' => (float) ($compra->total_before_tax ?? 0),
+            'tax_amount' => (float) ($compra->tax_amount ?? 0),
+            'discount_amount' => (float) ($compra->discount_amount ?? 0),
+            'shipping_charges' => (float) ($compra->shipping_charges ?? 0),
+            'pay_term_number' => $compra->pay_term_number,
+            'pay_term_type' => $compra->pay_term_type,
+            'additional_notes' => $compra->additional_notes,
+            'contact' => $contact ? [
+                'id' => $contact->id,
+                'name' => $contact->name,
+                'supplier_business_name' => $contact->supplier_business_name,
+                'tax_number' => $contact->tax_number,
+                'city' => $contact->city,
+                'mobile' => $contact->mobile,
+                'email' => $contact->email,
+            ] : null,
+            'location' => $compra->location ? [
+                'id' => $compra->location->id,
+                'name' => $compra->location->name,
+            ] : null,
+            'lines' => $lines,
+            'payments' => $payments,
+            'timeline' => $timeline,
+            'amount_paid' => array_sum(array_column($payments, 'amount')),
+            'amount_due' => max(0, ((float) $compra->final_total) - array_sum(array_column($payments, 'amount'))),
         ];
     }
 }

--- a/resources/js/Pages/Compras/Index.tsx
+++ b/resources/js/Pages/Compras/Index.tsx
@@ -7,6 +7,7 @@ import { Deferred, router } from '@inertiajs/react';
 import { ReactNode, useMemo, useState } from 'react';
 
 import '../../../css/cowork-compras-bundle.css';
+import Drawer, { type CompraDetalhe } from './components/Drawer';
 
 type Stage = 'rascunho' | 'pedido' | 'transito' | 'recebido' | 'conferido' | 'pago' | 'cancelada';
 
@@ -46,8 +47,10 @@ interface Props {
     q: string;
     stage: string;
   };
+  selected_id: number | null;
   kpis: Kpis | null;
   rows: RowsPayload | null;
+  compra_detalhe: CompraDetalhe | null;
 }
 
 const STAGES: { id: Stage; l: string; ic: string }[] = [
@@ -72,9 +75,36 @@ function dueAmount(row: Row): number {
   return Math.max(0, Number(row.final_total ?? 0) - Number(row.amount_paid ?? 0));
 }
 
-function ComprasIndex({ filters, kpis, rows }: Props) {
-  const [selected, setSelected] = useState<Row | null>(null);
+function ComprasIndex({ filters, selected_id, kpis, rows, compra_detalhe }: Props) {
   const [localFilter, setLocalFilter] = useState<string>(filters.stage || 'all');
+
+  const openDrawer = (row: Row) => {
+    router.get(
+      '/compras',
+      { q: filters.q, stage: filters.stage, compra_id: row.id },
+      {
+        only: ['compra_detalhe', 'selected_id'],
+        preserveState: true,
+        preserveScroll: true,
+        replace: true,
+      }
+    );
+  };
+
+  const closeDrawer = () => {
+    router.get(
+      '/compras',
+      { q: filters.q, stage: filters.stage },
+      {
+        only: ['compra_detalhe', 'selected_id'],
+        preserveState: true,
+        preserveScroll: true,
+        replace: true,
+      }
+    );
+  };
+
+  const drawerOpen = selected_id != null;
 
   const filteredRows = useMemo<Row[]>(() => {
     if (!rows) return [];
@@ -172,7 +202,7 @@ function ComprasIndex({ filters, kpis, rows }: Props) {
         </nav>
 
         {/* BODY */}
-        <div className={`bd ${selected ? 'with-drawer' : ''}`}>
+        <div className={`bd ${drawerOpen ? 'with-drawer' : ''}`}>
           {/* LISTA */}
           <main className="list">
             <Deferred data="kpis" fallback={<KpisSkeleton />}>
@@ -181,19 +211,23 @@ function ComprasIndex({ filters, kpis, rows }: Props) {
 
             <Deferred data="rows" fallback={<TableSkeleton />}>
               {rows ? (
-                <TableCompras
-                  rows={filteredRows}
-                  selectedId={selected?.id ?? null}
-                  onSelect={setSelected}
-                />
+                <TableCompras rows={filteredRows} selectedId={selected_id} onSelect={openDrawer} />
               ) : (
                 <TableSkeleton />
               )}
             </Deferred>
           </main>
 
-          {/* DRAWER */}
-          {selected && <DrawerSimple row={selected} onClose={() => setSelected(null)} />}
+          {/* DRAWER 5 tabs sobre grid */}
+          {drawerOpen && (
+            <Deferred data="compra_detalhe" fallback={<DrawerSkeleton onClose={closeDrawer} />}>
+              {compra_detalhe ? (
+                <Drawer compra={compra_detalhe} onClose={closeDrawer} />
+              ) : (
+                <DrawerSkeleton onClose={closeDrawer} />
+              )}
+            </Deferred>
+          )}
         </div>
 
         {/* FOOTER */}
@@ -343,71 +377,27 @@ function TableSkeleton() {
   );
 }
 
-function DrawerSimple({ row, onClose }: { row: Row; onClose: () => void }) {
-  const due = dueAmount(row);
-  const stageInfo = STAGES.find((x) => x.id === row.status);
-
+function DrawerSkeleton({ onClose }: { onClose: () => void }) {
   return (
     <aside className="drawer">
       <div className="drw-head">
         <div>
-          <h2>{row.supplier_business_name || row.name || 'Sem fornecedor'}</h2>
-          <div style={{ fontSize: 11.5, color: 'var(--cmp-ink-3)', marginTop: 2 }}>
-            {row.location_name} · {fmtDate(row.transaction_date)}
-          </div>
-          <span className="mono">
-            #{row.id}
-            {row.ref_no ? ` · ${row.ref_no}` : ''}
-          </span>
+          <h2 style={{ color: 'var(--cmp-ink-3)' }}>Carregando…</h2>
+          <span className="mono">aguarde</span>
         </div>
         <button className="x" onClick={onClose} aria-label="Fechar">
           ✕
         </button>
       </div>
-
       <div className="drw-body">
         <div className="sec">
-          <h4>Resumo</h4>
-          <div className="card">
-            <div className="field-grid">
-              <div className="f">
-                <label>Estágio</label>
-                <span>{stageInfo?.l ?? row.status}</span>
-              </div>
-              <div className="f">
-                <label>Status pagamento</label>
-                <span>{row.payment_status}</span>
-              </div>
-              <div className="f">
-                <label>Total</label>
-                <span className="mono">{fmtMoney(row.final_total)}</span>
-              </div>
-              <div className="f">
-                <label>A pagar</label>
-                <span className="mono" style={{ color: due > 0 ? 'var(--cmp-warn)' : 'var(--cmp-ok)' }}>
-                  {fmtMoney(due)}
-                </span>
-              </div>
-            </div>
+          <div
+            className="card"
+            style={{ textAlign: 'center', color: 'var(--cmp-ink-3)', padding: 24 }}
+          >
+            Buscando detalhe da compra…
           </div>
         </div>
-
-        <div className="sec">
-          <h4>Detalhe completo</h4>
-          <div className="card" style={{ color: 'var(--cmp-ink-3)', fontSize: 11.5 }}>
-            Itens, pagamentos e timeline chegam na Wave 6 (endpoint <span className="mono">show</span> + DrawerView 5 tabs).
-          </div>
-        </div>
-      </div>
-
-      <div className="drw-foot">
-        <div className="total">
-          Total
-          <b>{fmtMoney(row.final_total)}</b>
-        </div>
-        <button className="btn ghost" onClick={onClose}>
-          Fechar
-        </button>
       </div>
     </aside>
   );

--- a/resources/js/Pages/Compras/Index.tsx
+++ b/resources/js/Pages/Compras/Index.tsx
@@ -7,6 +7,7 @@ import { Deferred, router } from '@inertiajs/react';
 import { ReactNode, useMemo, useState } from 'react';
 
 import '../../../css/cowork-compras-bundle.css';
+import AcoesDropdown from './components/AcoesDropdown';
 import Drawer, { type CompraDetalhe } from './components/Drawer';
 
 type Stage = 'rascunho' | 'pedido' | 'transito' | 'recebido' | 'conferido' | 'pago' | 'cancelada';
@@ -77,11 +78,13 @@ function dueAmount(row: Row): number {
 
 function ComprasIndex({ filters, selected_id, kpis, rows, compra_detalhe }: Props) {
   const [localFilter, setLocalFilter] = useState<string>(filters.stage || 'all');
+  const [drawerInitialTab, setDrawerInitialTab] = useState<'resumo' | 'pagamentos'>('resumo');
 
-  const openDrawer = (row: Row) => {
+  const openDrawer = (compraId: number, tab: 'resumo' | 'pagamentos' = 'resumo') => {
+    setDrawerInitialTab(tab);
     router.get(
       '/compras',
-      { q: filters.q, stage: filters.stage, compra_id: row.id },
+      { q: filters.q, stage: filters.stage, compra_id: compraId },
       {
         only: ['compra_detalhe', 'selected_id'],
         preserveState: true,
@@ -90,6 +93,8 @@ function ComprasIndex({ filters, selected_id, kpis, rows, compra_detalhe }: Prop
       }
     );
   };
+
+  const openDrawerFromRow = (row: Row) => openDrawer(row.id, 'resumo');
 
   const closeDrawer = () => {
     router.get(
@@ -211,7 +216,12 @@ function ComprasIndex({ filters, selected_id, kpis, rows, compra_detalhe }: Prop
 
             <Deferred data="rows" fallback={<TableSkeleton />}>
               {rows ? (
-                <TableCompras rows={filteredRows} selectedId={selected_id} onSelect={openDrawer} />
+                <TableCompras
+                  rows={filteredRows}
+                  selectedId={selected_id}
+                  onSelect={openDrawerFromRow}
+                  onOpenDrawer={openDrawer}
+                />
               ) : (
                 <TableSkeleton />
               )}
@@ -222,7 +232,7 @@ function ComprasIndex({ filters, selected_id, kpis, rows, compra_detalhe }: Prop
           {drawerOpen && (
             <Deferred data="compra_detalhe" fallback={<DrawerSkeleton onClose={closeDrawer} />}>
               {compra_detalhe ? (
-                <Drawer compra={compra_detalhe} onClose={closeDrawer} />
+                <Drawer compra={compra_detalhe} onClose={closeDrawer} initialTab={drawerInitialTab} />
               ) : (
                 <DrawerSkeleton onClose={closeDrawer} />
               )}
@@ -296,10 +306,12 @@ function TableCompras({
   rows,
   selectedId,
   onSelect,
+  onOpenDrawer,
 }: {
   rows: Row[];
   selectedId: number | null;
   onSelect: (r: Row) => void;
+  onOpenDrawer: (compraId: number, tab?: 'resumo' | 'pagamentos') => void;
 }) {
   if (rows.length === 0) {
     return (
@@ -314,6 +326,7 @@ function TableCompras({
       <table className="purchases">
         <thead>
           <tr>
+            <th style={{ width: '90px' }}>Ação</th>
             <th style={{ width: '100px' }}>Compra</th>
             <th>Fornecedor</th>
             <th style={{ width: '95px' }}>Data</th>
@@ -330,8 +343,20 @@ function TableCompras({
               <tr
                 key={p.id}
                 className={selectedId === p.id ? 'sel' : ''}
-                onClick={() => onSelect(p)}
+                onClick={(e) => {
+                  // Click no body da linha abre drawer — botões internos chamam stopPropagation
+                  if ((e.target as HTMLElement).closest('button')) return;
+                  onSelect(p);
+                }}
               >
+                <td onClick={(e) => e.stopPropagation()} style={{ cursor: 'default' }}>
+                  <AcoesDropdown
+                    compraId={p.id}
+                    status={p.status}
+                    paymentStatus={p.payment_status}
+                    onOpenDrawer={onOpenDrawer}
+                  />
+                </td>
                 <td className="mono">
                   <b>#{p.id}</b>
                   {p.ref_no && <small>{p.ref_no}</small>}

--- a/resources/js/Pages/Compras/Index.tsx
+++ b/resources/js/Pages/Compras/Index.tsx
@@ -9,6 +9,7 @@ import { ReactNode, useMemo, useState } from 'react';
 import '../../../css/cowork-compras-bundle.css';
 import AcoesDropdown from './components/AcoesDropdown';
 import Drawer, { type CompraDetalhe } from './components/Drawer';
+import VisibilidadeColunas, { type ColumnDef, useColumnVisibility } from './components/VisibilidadeColunas';
 
 type Stage = 'rascunho' | 'pedido' | 'transito' | 'recebido' | 'conferido' | 'pago' | 'cancelada';
 
@@ -43,16 +44,47 @@ interface RowsPayload {
   };
 }
 
+interface Summary {
+  total: number;
+  pago: number;
+  a_pagar: number;
+  reembolso: number;
+}
+
 interface Props {
   filters: {
     q: string;
     stage: string;
+    sort: string;
+    dir: 'asc' | 'desc';
+    per_page: number;
   };
   selected_id: number | null;
   kpis: Kpis | null;
   rows: RowsPayload | null;
+  summary: Summary | null;
   compra_detalhe: CompraDetalhe | null;
 }
+
+const COLUMNS: ColumnDef[] = [
+  { id: 'acao', label: 'Ação', required: true },
+  { id: 'compra', label: 'Compra (ref)', required: true },
+  { id: 'fornecedor', label: 'Fornecedor' },
+  { id: 'data', label: 'Data' },
+  { id: 'estagio', label: 'Estágio' },
+  { id: 'total', label: 'Total' },
+  { id: 'a_pagar', label: 'A pagar' },
+];
+
+const DEFAULT_COL_VISIBILITY: Record<string, boolean> = {
+  acao: true,
+  compra: true,
+  fornecedor: true,
+  data: true,
+  estagio: true,
+  total: true,
+  a_pagar: true,
+};
 
 const STAGES: { id: Stage; l: string; ic: string }[] = [
   { id: 'rascunho', l: 'Rascunho', ic: '○' },
@@ -76,9 +108,48 @@ function dueAmount(row: Row): number {
   return Math.max(0, Number(row.final_total ?? 0) - Number(row.amount_paid ?? 0));
 }
 
-function ComprasIndex({ filters, selected_id, kpis, rows, compra_detalhe }: Props) {
+function ComprasIndex({ filters, selected_id, kpis, rows, summary, compra_detalhe }: Props) {
   const [localFilter, setLocalFilter] = useState<string>(filters.stage || 'all');
   const [drawerInitialTab, setDrawerInitialTab] = useState<'resumo' | 'pagamentos'>('resumo');
+  const [colVisibility, setColVisibility] = useColumnVisibility('compras-cols-v1', DEFAULT_COL_VISIBILITY);
+
+  const navigateWithFilters = (overrides: Record<string, string | number | undefined>) => {
+    const next = {
+      q: filters.q,
+      stage: filters.stage,
+      sort: filters.sort,
+      dir: filters.dir,
+      per_page: filters.per_page,
+      ...overrides,
+    };
+    // Limpa keys undefined pra não poluir URL
+    const cleaned: Record<string, string | number> = {};
+    for (const [k, v] of Object.entries(next)) {
+      if (v !== undefined && v !== '' && v !== null) cleaned[k] = v;
+    }
+    router.get('/compras', cleaned, {
+      preserveState: true,
+      preserveScroll: true,
+      replace: true,
+    });
+  };
+
+  const handleSort = (col: string) => {
+    const isCurrent = filters.sort === col;
+    const nextDir = isCurrent && filters.dir === 'asc' ? 'desc' : 'asc';
+    navigateWithFilters({ sort: col, dir: nextDir });
+  };
+
+  const handlePerPage = (value: number) => {
+    navigateWithFilters({ per_page: value });
+  };
+
+  const openExportBlade = (_format: 'csv' | 'excel' | 'pdf' | 'print') => {
+    // Bridge mode — Blade legacy DataTables tem exports nativos via buttons plugin.
+    // PR seguinte substitui por endpoints Compras nativos respeitando filtros.
+    // _format ignorado: Blade legacy mostra todos os 4 botões na mesma tela.
+    window.open('/purchases', '_blank', 'noopener,noreferrer');
+  };
 
   const openDrawer = (compraId: number, tab: 'resumo' | 'pagamentos' = 'resumo') => {
     setDrawerInitialTab(tab);
@@ -214,6 +285,15 @@ function ComprasIndex({ filters, selected_id, kpis, rows, compra_detalhe }: Prop
               {kpis ? <KpisGrid k={kpis} /> : <KpisSkeleton />}
             </Deferred>
 
+            <Toolbar
+              perPage={filters.per_page}
+              total={rows?.meta.total ?? 0}
+              colVisibility={colVisibility}
+              setColVisibility={setColVisibility}
+              onPerPageChange={handlePerPage}
+              onExport={openExportBlade}
+            />
+
             <Deferred data="rows" fallback={<TableSkeleton />}>
               {rows ? (
                 <TableCompras
@@ -221,10 +301,20 @@ function ComprasIndex({ filters, selected_id, kpis, rows, compra_detalhe }: Prop
                   selectedId={selected_id}
                   onSelect={openDrawerFromRow}
                   onOpenDrawer={openDrawer}
+                  sortCol={filters.sort}
+                  sortDir={filters.dir}
+                  onSort={handleSort}
+                  colVisibility={colVisibility}
                 />
               ) : (
                 <TableSkeleton />
               )}
+            </Deferred>
+
+            <Deferred data="summary" fallback={null}>
+              {summary && rows ? (
+                <SummaryFooter summary={summary} meta={rows.meta} onPageChange={(p) => navigateWithFilters({ page: p })} />
+              ) : null}
             </Deferred>
           </main>
 
@@ -302,16 +392,55 @@ function KpisSkeleton() {
   );
 }
 
+function SortHeader({
+  col,
+  label,
+  sortCol,
+  sortDir,
+  onSort,
+  align = 'left',
+  style,
+}: {
+  col: string;
+  label: string;
+  sortCol: string;
+  sortDir: 'asc' | 'desc';
+  onSort: (col: string) => void;
+  align?: 'left' | 'right';
+  style?: React.CSSProperties;
+}) {
+  const active = sortCol === col;
+  const arrow = active ? (sortDir === 'asc' ? '↑' : '↓') : '⇅';
+  return (
+    <th
+      style={{ ...style, cursor: 'pointer', textAlign: align, userSelect: 'none' }}
+      onClick={() => onSort(col)}
+      title={`Ordenar por ${label}`}
+    >
+      {label}{' '}
+      <span style={{ opacity: active ? 1 : 0.4, fontSize: 11, marginLeft: 2 }}>{arrow}</span>
+    </th>
+  );
+}
+
 function TableCompras({
   rows,
   selectedId,
   onSelect,
   onOpenDrawer,
+  sortCol,
+  sortDir,
+  onSort,
+  colVisibility,
 }: {
   rows: Row[];
   selectedId: number | null;
   onSelect: (r: Row) => void;
   onOpenDrawer: (compraId: number, tab?: 'resumo' | 'pagamentos') => void;
+  sortCol: string;
+  sortDir: 'asc' | 'desc';
+  onSort: (col: string) => void;
+  colVisibility: Record<string, boolean>;
 }) {
   if (rows.length === 0) {
     return (
@@ -321,18 +450,75 @@ function TableCompras({
     );
   }
 
+  const v = colVisibility;
+
   return (
     <div className="tbl">
       <table className="purchases">
         <thead>
           <tr>
-            <th style={{ width: '90px' }}>Ação</th>
-            <th style={{ width: '100px' }}>Compra</th>
-            <th>Fornecedor</th>
-            <th style={{ width: '95px' }}>Data</th>
-            <th style={{ width: '100px' }}>Estágio</th>
-            <th style={{ width: '100px', textAlign: 'right' }}>Total</th>
-            <th style={{ width: '100px', textAlign: 'right' }}>A pagar</th>
+            {v.acao && <th style={{ width: '90px' }}>Ação</th>}
+            {v.compra && (
+              <SortHeader
+                col="ref_no"
+                label="Compra"
+                sortCol={sortCol}
+                sortDir={sortDir}
+                onSort={onSort}
+                style={{ width: '100px' }}
+              />
+            )}
+            {v.fornecedor && (
+              <SortHeader
+                col="contact_name"
+                label="Fornecedor"
+                sortCol={sortCol}
+                sortDir={sortDir}
+                onSort={onSort}
+              />
+            )}
+            {v.data && (
+              <SortHeader
+                col="transaction_date"
+                label="Data"
+                sortCol={sortCol}
+                sortDir={sortDir}
+                onSort={onSort}
+                style={{ width: '95px' }}
+              />
+            )}
+            {v.estagio && (
+              <SortHeader
+                col="status"
+                label="Estágio"
+                sortCol={sortCol}
+                sortDir={sortDir}
+                onSort={onSort}
+                style={{ width: '100px' }}
+              />
+            )}
+            {v.total && (
+              <SortHeader
+                col="final_total"
+                label="Total"
+                sortCol={sortCol}
+                sortDir={sortDir}
+                onSort={onSort}
+                align="right"
+                style={{ width: '100px', textAlign: 'right' }}
+              />
+            )}
+            {v.a_pagar && (
+              <SortHeader
+                col="payment_status"
+                label="A pagar"
+                sortCol={sortCol}
+                sortDir={sortDir}
+                onSort={onSort}
+                align="right"
+                style={{ width: '100px', textAlign: 'right' }}
+              />
+            )}
           </tr>
         </thead>
         <tbody>
@@ -349,47 +535,252 @@ function TableCompras({
                   onSelect(p);
                 }}
               >
-                <td onClick={(e) => e.stopPropagation()} style={{ cursor: 'default' }}>
-                  <AcoesDropdown
-                    compraId={p.id}
-                    status={p.status}
-                    paymentStatus={p.payment_status}
-                    onOpenDrawer={onOpenDrawer}
-                  />
-                </td>
-                <td className="mono">
-                  <b>#{p.id}</b>
-                  {p.ref_no && <small>{p.ref_no}</small>}
-                </td>
-                <td>
-                  <b>{p.supplier_business_name || p.name || '—'}</b>
-                  <small>{p.location_name}</small>
-                </td>
-                <td className="mono">{fmtDate(p.transaction_date)}</td>
-                <td>
-                  {stageInfo ? (
-                    <span className={`pill ${p.status}`}>{stageInfo.l}</span>
-                  ) : (
-                    <span className="pill">{p.status}</span>
-                  )}
-                </td>
-                <td className="num">
-                  <b>{fmtMoney(p.final_total)}</b>
-                </td>
-                <td
-                  className="num"
-                  style={{
-                    color: due > 0 ? 'var(--cmp-warn)' : 'var(--cmp-ok)',
-                    fontWeight: 600,
-                  }}
-                >
-                  {due > 0 ? fmtMoney(due) : '✓'}
-                </td>
+                {v.acao && (
+                  <td onClick={(e) => e.stopPropagation()} style={{ cursor: 'default' }}>
+                    <AcoesDropdown
+                      compraId={p.id}
+                      status={p.status}
+                      paymentStatus={p.payment_status}
+                      onOpenDrawer={onOpenDrawer}
+                    />
+                  </td>
+                )}
+                {v.compra && (
+                  <td className="mono">
+                    <b>#{p.id}</b>
+                    {p.ref_no && <small>{p.ref_no}</small>}
+                  </td>
+                )}
+                {v.fornecedor && (
+                  <td>
+                    <b>{p.supplier_business_name || p.name || '—'}</b>
+                    <small>{p.location_name}</small>
+                  </td>
+                )}
+                {v.data && <td className="mono">{fmtDate(p.transaction_date)}</td>}
+                {v.estagio && (
+                  <td>
+                    {stageInfo ? (
+                      <span className={`pill ${p.status}`}>{stageInfo.l}</span>
+                    ) : (
+                      <span className="pill">{p.status}</span>
+                    )}
+                  </td>
+                )}
+                {v.total && (
+                  <td className="num">
+                    <b>{fmtMoney(p.final_total)}</b>
+                  </td>
+                )}
+                {v.a_pagar && (
+                  <td
+                    className="num"
+                    style={{
+                      color: due > 0 ? 'var(--cmp-warn)' : 'var(--cmp-ok)',
+                      fontWeight: 600,
+                    }}
+                  >
+                    {due > 0 ? fmtMoney(due) : '✓'}
+                  </td>
+                )}
               </tr>
             );
           })}
         </tbody>
       </table>
+    </div>
+  );
+}
+
+function Toolbar({
+  perPage,
+  total,
+  colVisibility,
+  setColVisibility,
+  onPerPageChange,
+  onExport,
+}: {
+  perPage: number;
+  total: number;
+  colVisibility: Record<string, boolean>;
+  setColVisibility: (next: Record<string, boolean>) => void;
+  onPerPageChange: (n: number) => void;
+  onExport: (format: 'csv' | 'excel' | 'pdf' | 'print') => void;
+}) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        marginBottom: 10,
+        padding: '8px 12px',
+        background: '#fff',
+        border: '1px solid var(--cmp-line)',
+        borderRadius: 5,
+        flexWrap: 'wrap',
+      }}
+    >
+      <label style={{ fontSize: 11.5, color: 'var(--cmp-ink-2)', display: 'flex', alignItems: 'center', gap: 6 }}>
+        Mostrar
+        <select
+          value={perPage}
+          onChange={(e) => onPerPageChange(Number(e.target.value))}
+          style={{
+            padding: '3px 6px',
+            border: '1px solid var(--cmp-line)',
+            borderRadius: 4,
+            background: '#fbf9f3',
+            fontSize: 11.5,
+          }}
+        >
+          {[10, 25, 50, 100].map((n) => (
+            <option key={n} value={n}>
+              {n}
+            </option>
+          ))}
+        </select>
+        entradas
+      </label>
+
+      <span style={{ color: 'var(--cmp-ink-3)', fontSize: 11.5, fontFamily: 'var(--cmp-mono)' }}>
+        · {total} total
+      </span>
+
+      <div style={{ flex: 1 }}></div>
+
+      <button className="btn sm" onClick={() => onExport('csv')} title="Exportar CSV (Blade legacy nova aba)">
+        ↓ CSV
+      </button>
+      <button className="btn sm" onClick={() => onExport('excel')} title="Exportar Excel (Blade legacy nova aba)">
+        ↓ Excel
+      </button>
+      <button className="btn sm" onClick={() => onExport('print')} title="Imprimir (Blade legacy nova aba)">
+        ⎙ Imprimir
+      </button>
+      <VisibilidadeColunas columns={COLUMNS} value={colVisibility} onChange={setColVisibility} />
+      <button className="btn sm" onClick={() => onExport('pdf')} title="Exportar PDF (Blade legacy nova aba)">
+        ↓ PDF
+      </button>
+    </div>
+  );
+}
+
+function SummaryFooter({
+  summary,
+  meta,
+  onPageChange,
+}: {
+  summary: Summary;
+  meta: RowsPayload['meta'];
+  onPageChange: (page: number) => void;
+}) {
+  const start = (meta.current_page - 1) * meta.per_page + 1;
+  const end = Math.min(meta.current_page * meta.per_page, meta.total);
+
+  return (
+    <div
+      style={{
+        marginTop: 10,
+        padding: '10px 12px',
+        background: '#fff',
+        border: '1px solid var(--cmp-line)',
+        borderRadius: 5,
+        display: 'flex',
+        alignItems: 'center',
+        gap: 16,
+        flexWrap: 'wrap',
+      }}
+    >
+      <div style={{ display: 'flex', gap: 18, flexWrap: 'wrap' }}>
+        <SummaryCell label="Total" value={fmtMoney(summary.total)} />
+        <SummaryCell label="Pago" value={fmtMoney(summary.pago)} accent="ok" />
+        <SummaryCell label="A pagar" value={fmtMoney(summary.a_pagar)} accent="warn" />
+        <SummaryCell label="Reembolsado" value={fmtMoney(summary.reembolso)} accent="err" />
+      </div>
+
+      <div style={{ flex: 1 }}></div>
+
+      <div style={{ fontSize: 11.5, color: 'var(--cmp-ink-3)' }}>
+        Mostrando <b>{start}</b>–<b>{end}</b> de <b>{meta.total}</b>
+      </div>
+
+      <div style={{ display: 'flex', gap: 4 }}>
+        <button
+          className="btn sm"
+          disabled={meta.current_page <= 1}
+          onClick={() => onPageChange(meta.current_page - 1)}
+        >
+          ← Anterior
+        </button>
+        <span
+          style={{
+            padding: '3px 10px',
+            background: 'var(--cmp-accent-soft)',
+            border: '1px solid #c9d6e8',
+            borderRadius: 4,
+            fontSize: 11.5,
+            color: 'var(--cmp-accent)',
+            fontWeight: 600,
+            fontFamily: 'var(--cmp-mono)',
+          }}
+        >
+          {meta.current_page} / {meta.last_page}
+        </span>
+        <button
+          className="btn sm"
+          disabled={meta.current_page >= meta.last_page}
+          onClick={() => onPageChange(meta.current_page + 1)}
+        >
+          Próximo →
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function SummaryCell({
+  label,
+  value,
+  accent,
+}: {
+  label: string;
+  value: string;
+  accent?: 'ok' | 'warn' | 'err';
+}) {
+  const color =
+    accent === 'ok'
+      ? 'var(--cmp-ok)'
+      : accent === 'warn'
+        ? 'var(--cmp-warn)'
+        : accent === 'err'
+          ? 'var(--cmp-err)'
+          : 'var(--cmp-ink)';
+  return (
+    <div>
+      <div
+        style={{
+          fontSize: 9.5,
+          textTransform: 'uppercase',
+          letterSpacing: '.05em',
+          color: 'var(--cmp-ink-3)',
+          fontWeight: 600,
+          marginBottom: 2,
+        }}
+      >
+        {label}
+      </div>
+      <div
+        style={{
+          fontSize: 14,
+          fontWeight: 700,
+          fontFamily: 'var(--cmp-mono)',
+          fontVariantNumeric: 'tabular-nums',
+          color,
+        }}
+      >
+        {value}
+      </div>
     </div>
   );
 }

--- a/resources/js/Pages/Compras/components/AcoesDropdown.tsx
+++ b/resources/js/Pages/Compras/components/AcoesDropdown.tsx
@@ -1,0 +1,219 @@
+// AcoesDropdown.tsx — paridade Blade /purchases dropdown "Ações" (9 opções).
+// US-COM-001 — Wave 5b.
+//
+// Bridge mode: ações que JÁ EXISTEM no Inertia (Ver / Ver pagamentos / Excluir)
+// rodam nativo; ações que ainda dependem do Blade legacy (Editar, Imprimir,
+// Rótulos, Reembolso, Atualizar status, Notif. pendente) abrem rota Blade
+// preservando UX legacy enquanto migração progride.
+
+import { router } from '@inertiajs/react';
+import { useEffect, useRef, useState } from 'react';
+
+export interface AcaoVisibility {
+  canEdit: boolean;
+  canDelete: boolean;
+  canEmitirNotaFiscal?: boolean;
+  canRefund?: boolean;
+}
+
+interface AcoesDropdownProps {
+  compraId: number;
+  status: string;
+  /** Status pagamento (paid/partial/due) — reservado pra mostrar "Reembolso" só em paid */
+  paymentStatus?: string;
+  hasReturn?: boolean;
+  visibility?: AcaoVisibility;
+  onOpenDrawer: (compraId: number, tab?: 'resumo' | 'pagamentos') => void;
+}
+
+interface ActionItem {
+  id: string;
+  label: string;
+  icon: string;
+  onClick: () => void;
+  divider?: 'before' | 'after';
+  variant?: 'default' | 'danger';
+  hidden?: boolean;
+}
+
+export default function AcoesDropdown({
+  compraId,
+  status,
+  paymentStatus: _paymentStatus,
+  hasReturn = false,
+  visibility = { canEdit: true, canDelete: true, canRefund: true },
+  onOpenDrawer,
+}: AcoesDropdownProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  // Click-outside fecha o menu
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onEsc);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onEsc);
+    };
+  }, [open]);
+
+  const handleDelete = () => {
+    if (
+      window.confirm(
+        `Excluir compra #${compraId}? Esta ação não pode ser desfeita. O estoque será revertido.`
+      )
+    ) {
+      router.delete(`/purchases/${compraId}`, {
+        onSuccess: () => {
+          router.reload({ only: ['rows', 'kpis'] });
+        },
+      });
+    }
+    setOpen(false);
+  };
+
+  const openBladeNewTab = (url: string) => {
+    window.open(url, '_blank', 'noopener,noreferrer');
+    setOpen(false);
+  };
+
+  const navigateBlade = (url: string) => {
+    window.location.href = url;
+    setOpen(false);
+  };
+
+  const actions: ActionItem[] = [
+    {
+      id: 'ver',
+      label: 'Ver',
+      icon: '👁',
+      onClick: () => {
+        onOpenDrawer(compraId, 'resumo');
+        setOpen(false);
+      },
+    },
+    {
+      id: 'impressao',
+      label: 'Impressão',
+      icon: '🖨',
+      onClick: () => openBladeNewTab(`/purchases/print/${compraId}`),
+    },
+    {
+      id: 'editar',
+      label: 'Editar',
+      icon: '✎',
+      hidden: !visibility.canEdit,
+      onClick: () => navigateBlade(`/purchases/${compraId}/edit`),
+    },
+    {
+      id: 'excluir',
+      label: 'Excluir',
+      icon: '🗑',
+      variant: 'danger',
+      hidden: !visibility.canDelete,
+      onClick: handleDelete,
+    },
+    {
+      id: 'rotulos',
+      label: 'Rótulos',
+      icon: '🏷',
+      divider: 'after',
+      onClick: () => openBladeNewTab(`/labels/show?purchase_id=${compraId}`),
+    },
+    {
+      id: 'pagamentos',
+      label: 'Ver pagamentos',
+      icon: '💰',
+      onClick: () => {
+        onOpenDrawer(compraId, 'pagamentos');
+        setOpen(false);
+      },
+    },
+    {
+      id: 'reembolso',
+      label: 'Reembolso de compra',
+      icon: '↩',
+      hidden: !visibility.canRefund || hasReturn || status === 'rascunho',
+      onClick: () => navigateBlade(`/purchase-return/add/${compraId}`),
+    },
+    {
+      id: 'status',
+      label: 'Atualizar status',
+      icon: '↻',
+      onClick: () => {
+        // Wave 8 substitui por modal Inertia. Bridge: abre tela de edição
+        // que já tem o select de status no form Blade.
+        navigateBlade(`/purchases/${compraId}/edit#status`);
+      },
+    },
+    {
+      id: 'notify',
+      label: 'Elementos pendentes de notificação',
+      icon: '✉',
+      onClick: () => navigateBlade(`/purchases/${compraId}/edit#notify-pending`),
+    },
+  ];
+
+  const visibleActions = actions.filter((a) => !a.hidden);
+
+  return (
+    <div className="relative inline-block" ref={ref}>
+      <button
+        type="button"
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        className="inline-flex items-center gap-1 rounded-md bg-primary-600 px-2.5 py-1 text-xs font-medium text-white hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500"
+      >
+        Ações
+        <svg className="h-3 w-3" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <path d="M5.293 7.293a1 1 0 011.414 0L10 10.586l3.293-3.293a1 1 0 111.414 1.414l-4 4a1 1 0 01-1.414 0l-4-4a1 1 0 010-1.414z" />
+        </svg>
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute left-0 z-50 mt-1 w-56 rounded-md border border-stone-200 bg-white py-1 text-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none"
+        >
+          {visibleActions.map((action, i) => (
+            <div key={action.id}>
+              {action.divider === 'before' && i > 0 && (
+                <div className="my-1 h-px bg-stone-200" />
+              )}
+              <button
+                type="button"
+                role="menuitem"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  action.onClick();
+                }}
+                className={`flex w-full items-center gap-2.5 px-3 py-1.5 text-left hover:bg-stone-50 focus:bg-stone-50 focus:outline-none ${
+                  action.variant === 'danger' ? 'text-rose-700 hover:bg-rose-50' : 'text-stone-700'
+                }`}
+              >
+                <span className="w-4 text-center text-base">{action.icon}</span>
+                <span className="flex-1 truncate">{action.label}</span>
+              </button>
+              {action.divider === 'after' && (
+                <div className="my-1 h-px bg-stone-200" />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/resources/js/Pages/Compras/components/Drawer.tsx
+++ b/resources/js/Pages/Compras/components/Drawer.tsx
@@ -1,0 +1,606 @@
+// Drawer.tsx — DrawerView 5 tabs sobre grid (US-COM-001 Wave 5).
+// Pin literal do protótipo public/cowork-preview/erp-shell-v2/compras-page.jsx
+// (DrawerView linhas 195-431). Substitui DrawerSimple do Index.tsx.
+//
+// Tabs: Resumo / Itens / Documentos / Pagamentos / Histórico
+// FSM stepper 6 estágios highlight current.
+
+import { useMemo, useState } from 'react';
+
+type Stage = 'rascunho' | 'pedido' | 'transito' | 'recebido' | 'conferido' | 'pago' | 'cancelada';
+
+const STAGES: { id: Stage; l: string; ic: string }[] = [
+  { id: 'rascunho', l: 'Rascunho', ic: '○' },
+  { id: 'pedido', l: 'Pedido', ic: '✎' },
+  { id: 'transito', l: 'Em trânsito', ic: '⇨' },
+  { id: 'recebido', l: 'Recebido', ic: '⊞' },
+  { id: 'conferido', l: 'Conferido', ic: '✓' },
+  { id: 'pago', l: 'Pago', ic: '$' },
+];
+
+const TABS = [
+  { id: 'resumo', l: 'Resumo' },
+  { id: 'itens', l: 'Itens' },
+  { id: 'documentos', l: 'Documentos' },
+  { id: 'pagamentos', l: 'Pagamentos' },
+  { id: 'historico', l: 'Histórico' },
+] as const;
+
+type TabId = (typeof TABS)[number]['id'];
+
+export interface CompraDetalhe {
+  id: number;
+  ref_no: string | null;
+  document: string | null;
+  transaction_date: string | null;
+  type: string;
+  status: Stage | string;
+  payment_status: string;
+  final_total: number;
+  total_before_tax: number;
+  tax_amount: number;
+  discount_amount: number;
+  shipping_charges: number;
+  pay_term_number: number | null;
+  pay_term_type: string | null;
+  additional_notes: string | null;
+  amount_paid: number;
+  amount_due: number;
+  contact: {
+    id: number;
+    name: string | null;
+    supplier_business_name: string | null;
+    tax_number: string | null;
+    city: string | null;
+    mobile: string | null;
+    email: string | null;
+  } | null;
+  location: { id: number; name: string } | null;
+  lines: Array<{
+    id: number;
+    product_name: string;
+    product_sku: string | null;
+    variation_name: string | null;
+    quantity: number;
+    unit_name: string | null;
+    purchase_price: number;
+    purchase_price_inc_tax: number;
+    item_tax: number;
+    line_total: number;
+    lot_number: string | null;
+  }>;
+  payments: Array<{
+    id: number;
+    paid_on: string | null;
+    amount: number;
+    method: string | null;
+    card_transaction_number: string | null;
+    cheque_number: string | null;
+    bank_account_number: string | null;
+    note: string | null;
+    is_return: boolean;
+  }>;
+  timeline: Array<{
+    id: number;
+    description: string;
+    causer_name: string;
+    created_at: string | null;
+    properties: Record<string, unknown> | null;
+  }>;
+}
+
+interface DrawerProps {
+  compra: CompraDetalhe;
+  onClose: () => void;
+}
+
+function fmtMoney(v: number | null | undefined): string {
+  return 'R$ ' + Number(v ?? 0).toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function fmtDate(d: string | null): string {
+  if (!d) return '—';
+  return new Date(d).toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit', year: 'numeric' });
+}
+
+function fmtDateTime(d: string | null): string {
+  if (!d) return '—';
+  return new Date(d).toLocaleString('pt-BR', {
+    day: '2-digit',
+    month: '2-digit',
+    year: '2-digit',
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+}
+
+function stageIdx(s: string): number {
+  return STAGES.findIndex((x) => x.id === s);
+}
+
+function methodLabel(m: string | null): string {
+  if (!m) return '—';
+  const map: Record<string, string> = {
+    cash: 'Dinheiro',
+    card: 'Cartão',
+    cheque: 'Cheque',
+    bank_transfer: 'Transferência',
+    other: 'Outro',
+    pix: 'PIX',
+    advance: 'Adiantamento',
+    custom_pay_1: 'Boleto',
+    custom_pay_2: 'Crediário',
+    custom_pay_3: 'Outro',
+  };
+  return map[m.toLowerCase()] ?? m;
+}
+
+function methodAbbr(m: string | null): string {
+  if (!m) return '?';
+  const map: Record<string, string> = {
+    cash: '$',
+    pix: 'PIX',
+    card: 'C',
+    cheque: 'CHQ',
+    bank_transfer: 'TED',
+    custom_pay_1: 'BL',
+    custom_pay_2: 'CR',
+  };
+  return map[m.toLowerCase()] ?? m.slice(0, 3).toUpperCase();
+}
+
+export default function Drawer({ compra, onClose }: DrawerProps) {
+  const [tab, setTab] = useState<TabId>('resumo');
+  const idx = stageIdx(compra.status);
+
+  const supplierName = compra.contact?.supplier_business_name || compra.contact?.name || 'Sem fornecedor';
+  const itemCount = compra.lines.length;
+  const paid = compra.amount_paid;
+  const due = compra.amount_due;
+  const subtotal = compra.total_before_tax || compra.final_total;
+  const payTermLabel = compra.pay_term_number
+    ? `${compra.pay_term_number} ${compra.pay_term_type === 'months' ? 'meses' : 'dias'}`
+    : null;
+
+  const itemsTabs = useMemo(
+    () => [
+      { id: 'resumo' as TabId, l: 'Resumo', ct: null },
+      { id: 'itens' as TabId, l: 'Itens', ct: itemCount },
+      { id: 'documentos' as TabId, l: 'Documentos', ct: null },
+      { id: 'pagamentos' as TabId, l: 'Pagamentos', ct: compra.payments.length },
+      { id: 'historico' as TabId, l: 'Histórico', ct: compra.timeline.length },
+    ],
+    [itemCount, compra.payments.length, compra.timeline.length]
+  );
+
+  return (
+    <aside className="drawer">
+      <div className="drw-head">
+        <div>
+          <h2>{supplierName}</h2>
+          <div style={{ fontSize: 11.5, color: 'var(--cmp-ink-3)', marginTop: 2 }}>
+            {itemCount} ite{itemCount === 1 ? 'm' : 'ns'} · {compra.location?.name ?? '—'}
+            {payTermLabel ? ` · ${payTermLabel}` : ''}
+          </div>
+          <span className="mono">
+            #{compra.id}
+            {compra.ref_no ? ` · ${compra.ref_no}` : ''}
+          </span>
+        </div>
+        <button className="x" onClick={onClose} aria-label="Fechar drawer">
+          ✕
+        </button>
+      </div>
+
+      <div className="fsm">
+        <div className="fsm-track">
+          {STAGES.map((st, i) => (
+            <div
+              key={st.id}
+              className={`fsm-step ${i < idx ? 'done' : i === idx ? 'now' : ''}`}
+              title={st.l}
+            >
+              <span className="ic">{st.ic}</span>
+              {st.l}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="drw-tabs">
+        {itemsTabs.map((t) => (
+          <button
+            key={t.id}
+            className={tab === t.id ? 'active' : ''}
+            onClick={() => setTab(t.id)}
+          >
+            {t.l}
+            {t.ct != null && t.ct > 0 && <span className="ct">{t.ct}</span>}
+          </button>
+        ))}
+      </div>
+
+      <div className="drw-body">
+        {tab === 'resumo' && <ResumoTab compra={compra} subtotal={subtotal} paid={paid} due={due} />}
+        {tab === 'itens' && <ItensTab compra={compra} />}
+        {tab === 'documentos' && <DocumentosTab compra={compra} />}
+        {tab === 'pagamentos' && <PagamentosTab compra={compra} due={due} />}
+        {tab === 'historico' && <HistoricoTab compra={compra} />}
+      </div>
+
+      <div className="drw-foot">
+        <div className="total">
+          Total da compra
+          <b>{fmtMoney(compra.final_total)}</b>
+        </div>
+        <button className="btn ghost" onClick={onClose}>
+          Fechar
+        </button>
+      </div>
+    </aside>
+  );
+}
+
+function ResumoTab({
+  compra,
+  subtotal,
+  paid,
+  due,
+}: {
+  compra: CompraDetalhe;
+  subtotal: number;
+  paid: number;
+  due: number;
+}) {
+  return (
+    <>
+      <div className="sec">
+        <h4>Fornecedor</h4>
+        <div className="card">
+          {compra.contact ? (
+            <div className="field-grid">
+              <div className="f">
+                <label>CNPJ/CPF</label>
+                <span className="mono">{compra.contact.tax_number || '—'}</span>
+              </div>
+              <div className="f">
+                <label>Cidade</label>
+                <span>{compra.contact.city || '—'}</span>
+              </div>
+              {compra.contact.mobile && (
+                <div className="f">
+                  <label>Telefone</label>
+                  <span className="mono">{compra.contact.mobile}</span>
+                </div>
+              )}
+              {compra.contact.email && (
+                <div className="f">
+                  <label>E-mail</label>
+                  <span>{compra.contact.email}</span>
+                </div>
+              )}
+            </div>
+          ) : (
+            <div style={{ color: 'var(--cmp-ink-3)', fontSize: 12 }}>Sem fornecedor associado</div>
+          )}
+        </div>
+      </div>
+
+      <div className="sec">
+        <h4>Dados da compra</h4>
+        <div className="card">
+          <div className="field-grid">
+            <div className="f">
+              <label>Ref. interna</label>
+              <span className="mono">{compra.ref_no || '—'}</span>
+            </div>
+            <div className="f">
+              <label>Data emissão</label>
+              <span className="mono">{fmtDate(compra.transaction_date)}</span>
+            </div>
+            <div className="f">
+              <label>Local</label>
+              <span>{compra.location?.name ?? '—'}</span>
+            </div>
+            <div className="f">
+              <label>Cond. pagamento</label>
+              <span>
+                {compra.pay_term_number
+                  ? `${compra.pay_term_number} ${compra.pay_term_type === 'months' ? 'meses' : 'dias'}`
+                  : '—'}
+              </span>
+            </div>
+            <div className="f">
+              <label>Desconto</label>
+              <span className="mono">{fmtMoney(compra.discount_amount)}</span>
+            </div>
+            <div className="f">
+              <label>Frete</label>
+              <span className="mono">{fmtMoney(compra.shipping_charges)}</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      {compra.additional_notes && (
+        <div className="sec">
+          <h4>Observações</h4>
+          <div
+            className="card"
+            style={{ fontSize: 12, color: 'var(--cmp-ink-2)', lineHeight: 1.5, background: '#fff' }}
+          >
+            {compra.additional_notes}
+          </div>
+        </div>
+      )}
+
+      <div className="sec">
+        <h4>Resumo financeiro</h4>
+        <div className="card" style={{ padding: 0 }}>
+          <table style={{ width: '100%', fontSize: 12 }}>
+            <tbody>
+              <tr>
+                <td style={{ padding: '6px 13px', color: 'var(--cmp-ink-3)' }}>Subtotal</td>
+                <td style={{ padding: '6px 13px', textAlign: 'right', fontFamily: 'var(--cmp-mono)' }}>
+                  {fmtMoney(subtotal)}
+                </td>
+              </tr>
+              {compra.discount_amount > 0 && (
+                <tr>
+                  <td style={{ padding: '6px 13px', color: 'var(--cmp-ink-3)' }}>Desconto</td>
+                  <td
+                    style={{
+                      padding: '6px 13px',
+                      textAlign: 'right',
+                      fontFamily: 'var(--cmp-mono)',
+                      color: 'var(--cmp-err)',
+                    }}
+                  >
+                    −{fmtMoney(compra.discount_amount)}
+                  </td>
+                </tr>
+              )}
+              {compra.shipping_charges > 0 && (
+                <tr>
+                  <td style={{ padding: '6px 13px', color: 'var(--cmp-ink-3)' }}>Frete</td>
+                  <td style={{ padding: '6px 13px', textAlign: 'right', fontFamily: 'var(--cmp-mono)' }}>
+                    +{fmtMoney(compra.shipping_charges)}
+                  </td>
+                </tr>
+              )}
+              {compra.tax_amount > 0 && (
+                <tr>
+                  <td style={{ padding: '6px 13px', color: 'var(--cmp-ink-3)' }}>Impostos</td>
+                  <td style={{ padding: '6px 13px', textAlign: 'right', fontFamily: 'var(--cmp-mono)' }}>
+                    {fmtMoney(compra.tax_amount)}
+                  </td>
+                </tr>
+              )}
+              <tr style={{ borderTop: '1px solid var(--cmp-line)' }}>
+                <td style={{ padding: '8px 13px', fontWeight: 700 }}>Total da compra</td>
+                <td
+                  style={{
+                    padding: '8px 13px',
+                    textAlign: 'right',
+                    fontFamily: 'var(--cmp-mono)',
+                    fontWeight: 700,
+                    fontSize: 14,
+                  }}
+                >
+                  {fmtMoney(compra.final_total)}
+                </td>
+              </tr>
+              <tr>
+                <td style={{ padding: '6px 13px', color: 'var(--cmp-ok)' }}>Pago</td>
+                <td
+                  style={{
+                    padding: '6px 13px',
+                    textAlign: 'right',
+                    fontFamily: 'var(--cmp-mono)',
+                    color: 'var(--cmp-ok)',
+                  }}
+                >
+                  {fmtMoney(paid)}
+                </td>
+              </tr>
+              <tr>
+                <td style={{ padding: '6px 13px', color: 'var(--cmp-warn)', fontWeight: 600 }}>A pagar</td>
+                <td
+                  style={{
+                    padding: '6px 13px',
+                    textAlign: 'right',
+                    fontFamily: 'var(--cmp-mono)',
+                    fontWeight: 700,
+                    color: 'var(--cmp-warn)',
+                  }}
+                >
+                  {fmtMoney(due)}
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function ItensTab({ compra }: { compra: CompraDetalhe }) {
+  if (compra.lines.length === 0) {
+    return (
+      <div className="sec">
+        <h4>Itens recebidos</h4>
+        <div
+          className="card"
+          style={{ textAlign: 'center', color: 'var(--cmp-ink-3)', fontSize: 11.5, padding: 18 }}
+        >
+          Esta compra não tem linhas cadastradas.
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="sec">
+      <h4>
+        Itens recebidos <span className="badge">{compra.lines.length}</span>
+      </h4>
+      <table className="items-tbl">
+        <thead>
+          <tr>
+            <th>Produto</th>
+            <th className="num">Qtd</th>
+            <th className="num">Custo unit.</th>
+            <th className="num">Total</th>
+          </tr>
+        </thead>
+        <tbody>
+          {compra.lines.map((it) => (
+            <tr key={it.id}>
+              <td>
+                <b>{it.product_name}</b>
+                <small>
+                  {it.product_sku ? it.product_sku : '—'}
+                  {it.variation_name ? ` · ${it.variation_name}` : ''}
+                  {it.lot_number ? ` · lote ${it.lot_number}` : ''}
+                </small>
+              </td>
+              <td className="num">
+                {it.quantity}
+                {it.unit_name && (
+                  <small style={{ textAlign: 'right' }}>{it.unit_name}</small>
+                )}
+              </td>
+              <td className="num">{fmtMoney(it.purchase_price_inc_tax)}</td>
+              <td className="num">
+                <b>{fmtMoney(it.line_total)}</b>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function DocumentosTab({ compra }: { compra: CompraDetalhe }) {
+  const xmlChave = compra.document; // UPos guarda chave NF-e em `document` quando há
+
+  if (!xmlChave) {
+    return (
+      <div
+        className="card"
+        style={{ textAlign: 'center', padding: 24, color: 'var(--cmp-ink-3)' }}
+      >
+        <div style={{ fontSize: 24, marginBottom: 8 }}>⊠</div>
+        <b style={{ color: 'var(--cmp-ink-2)', fontSize: 13, display: 'block', marginBottom: 3 }}>
+          Nenhuma NF-e vinculada
+        </b>
+        <small style={{ fontSize: 11 }}>Importe o XML pela tela Fiscal (Wave 6 vai trazer atalho aqui)</small>
+      </div>
+    );
+  }
+
+  return (
+    <div className="sec">
+      <h4>NF-e de entrada</h4>
+      <div className="xml-badge">
+        <span style={{ fontSize: 18 }}>⊞</span>
+        <div style={{ flex: 1 }}>
+          <b>{compra.ref_no ? `NF-e ${compra.ref_no}` : 'NF-e vinculada'}</b>
+          <div style={{ fontSize: 10.5, marginTop: 3 }}>chave de acesso</div>
+          <div className="key">{xmlChave}</div>
+        </div>
+      </div>
+      <div
+        style={{ fontSize: 11, color: 'var(--cmp-ink-3)', marginTop: 8, lineHeight: 1.5 }}
+      >
+        Download de XML / DANFE e manifestação fiscal ficam na tela Fiscal. Wave 6 traz atalhos integrados aqui.
+      </div>
+    </div>
+  );
+}
+
+function PagamentosTab({ compra, due }: { compra: CompraDetalhe; due: number }) {
+  if (compra.payments.length === 0) {
+    return (
+      <div className="sec">
+        <h4>Pagamentos</h4>
+        <div className="card">
+          <div style={{ textAlign: 'center', color: 'var(--cmp-ink-3)', fontSize: 12, padding: 14 }}>
+            {due > 0 ? `Sem pagamentos lançados · resta ${fmtMoney(due)} a pagar` : 'Sem pagamentos lançados'}
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="sec">
+      <h4>Pagamentos</h4>
+      <div className="card">
+        {compra.payments.map((p) => (
+          <div key={p.id} className="pay-row">
+            <div
+              className="pay-icon"
+              style={{
+                background: p.is_return ? 'var(--cmp-err-soft)' : 'var(--cmp-ok-soft)',
+                color: p.is_return ? 'var(--cmp-err)' : 'var(--cmp-ok)',
+              }}
+            >
+              {methodAbbr(p.method)}
+            </div>
+            <div>
+              <b>
+                {p.is_return ? 'Estorno ' : ''}
+                {methodLabel(p.method)}
+              </b>
+              <small>
+                {fmtDateTime(p.paid_on)}
+                {p.cheque_number ? ` · cheque ${p.cheque_number}` : ''}
+                {p.bank_account_number ? ` · conta ${p.bank_account_number}` : ''}
+                {p.card_transaction_number ? ` · doc ${p.card_transaction_number}` : ''}
+              </small>
+              {p.note && (
+                <small style={{ marginTop: 2, color: 'var(--cmp-ink-2)' }}>{p.note}</small>
+              )}
+            </div>
+            <span className={`val ${p.is_return ? 'due' : 'paid'}`}>{fmtMoney(p.amount)}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function HistoricoTab({ compra }: { compra: CompraDetalhe }) {
+  if (compra.timeline.length === 0) {
+    return (
+      <div className="sec">
+        <h4>Linha do tempo</h4>
+        <div
+          className="card"
+          style={{ textAlign: 'center', color: 'var(--cmp-ink-3)', fontSize: 12, padding: 18 }}
+        >
+          Sem eventos registrados
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="sec">
+      <h4>Linha do tempo</h4>
+      <div className="tl">
+        {compra.timeline.map((e) => (
+          <div key={e.id} className="tl-item ok">
+            <b>{e.description}</b>
+            <div className="when">
+              {fmtDateTime(e.created_at)} · {e.causer_name}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/resources/js/Pages/Compras/components/Drawer.tsx
+++ b/resources/js/Pages/Compras/components/Drawer.tsx
@@ -92,6 +92,8 @@ export interface CompraDetalhe {
 interface DrawerProps {
   compra: CompraDetalhe;
   onClose: () => void;
+  /** Tab inicial. Default 'resumo'. Usado por "Ver pagamentos" pra abrir já no tab certo. */
+  initialTab?: TabId;
 }
 
 function fmtMoney(v: number | null | undefined): string {
@@ -149,8 +151,8 @@ function methodAbbr(m: string | null): string {
   return map[m.toLowerCase()] ?? m.slice(0, 3).toUpperCase();
 }
 
-export default function Drawer({ compra, onClose }: DrawerProps) {
-  const [tab, setTab] = useState<TabId>('resumo');
+export default function Drawer({ compra, onClose, initialTab = 'resumo' }: DrawerProps) {
+  const [tab, setTab] = useState<TabId>(initialTab);
   const idx = stageIdx(compra.status);
 
   const supplierName = compra.contact?.supplier_business_name || compra.contact?.name || 'Sem fornecedor';

--- a/resources/js/Pages/Compras/components/VisibilidadeColunas.tsx
+++ b/resources/js/Pages/Compras/components/VisibilidadeColunas.tsx
@@ -1,0 +1,116 @@
+// VisibilidadeColunas.tsx — dropdown checkbox pra mostrar/esconder colunas.
+// State persiste em localStorage por chave (`compras-cols-v1`).
+
+import { useEffect, useRef, useState } from 'react';
+
+export interface ColumnDef {
+  id: string;
+  label: string;
+  /** Coluna obrigatória (não pode esconder) */
+  required?: boolean;
+}
+
+interface VisibilidadeColunasProps {
+  storageKey?: string;
+  columns: ColumnDef[];
+  value: Record<string, boolean>;
+  onChange: (next: Record<string, boolean>) => void;
+}
+
+export default function VisibilidadeColunas({
+  columns,
+  value,
+  onChange,
+}: VisibilidadeColunasProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onClick = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    const onEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('mousedown', onClick);
+    document.addEventListener('keydown', onEsc);
+    return () => {
+      document.removeEventListener('mousedown', onClick);
+      document.removeEventListener('keydown', onEsc);
+    };
+  }, [open]);
+
+  const toggle = (id: string) => {
+    onChange({ ...value, [id]: !value[id] });
+  };
+
+  return (
+    <div className="relative inline-block" ref={ref}>
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className="btn"
+        title="Mostrar/esconder colunas"
+      >
+        ⊟ Visibilidade da coluna
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          className="absolute right-0 z-50 mt-1 w-56 rounded-md border border-stone-200 bg-white py-1 text-sm shadow-lg"
+        >
+          {columns.map((col) => (
+            <label
+              key={col.id}
+              className={`flex items-center gap-2 px-3 py-1.5 hover:bg-stone-50 ${
+                col.required ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'
+              }`}
+            >
+              <input
+                type="checkbox"
+                checked={col.required ? true : !!value[col.id]}
+                disabled={col.required}
+                onChange={() => !col.required && toggle(col.id)}
+                className="rounded border-stone-300 text-primary-600 focus:ring-primary-500"
+              />
+              <span className="flex-1 truncate text-stone-700">{col.label}</span>
+            </label>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/**
+ * Helper React hook — sincroniza state com localStorage.
+ */
+export function useColumnVisibility(
+  storageKey: string,
+  defaults: Record<string, boolean>
+): [Record<string, boolean>, (next: Record<string, boolean>) => void] {
+  const [value, setValue] = useState<Record<string, boolean>>(() => {
+    if (typeof window === 'undefined') return defaults;
+    try {
+      const raw = localStorage.getItem(storageKey);
+      if (!raw) return defaults;
+      const parsed = JSON.parse(raw) as Record<string, boolean>;
+      return { ...defaults, ...parsed };
+    } catch {
+      return defaults;
+    }
+  });
+
+  const setAndPersist = (next: Record<string, boolean>) => {
+    setValue(next);
+    try {
+      localStorage.setItem(storageKey, JSON.stringify(next));
+    } catch {
+      // ignore quota errors
+    }
+  };
+
+  return [value, setAndPersist];
+}


### PR DESCRIPTION
## Summary

Responde ao pedido Wagner ([screenshot anexa /purchases legacy](https://github.com/wagnerra23/oimpresso.com/pull/1310#issuecomment-x)) — "gostaria que abrisse sobre o grid como no resto do sistema". Implementa o **DrawerView 5 tabs** do protótipo Cowork canônico, sem navegar pra outra página.

**Base:** PR #1310 (Wave 1-4.5). Esse PR vai sobre `feat/compras-wave1-scaffold`, não main. Quando #1310 mergear, faço rebase pra main.

## O que entrega

### Backend
- `ComprasController::show($id)` endpoint JSON detalhe single
- `ComprasController::index?compra_id=N` injeta `compra_detalhe` como prop `Inertia::defer` — partial reload (`only=['compra_detalhe']`) não recarrega a tabela
- `ComprasService::buscarDetalhe(id, businessId)` retorna Transaction + contact + location + purchase_lines (com product/variations/unit) + payment_lines + Activity timeline (Spatie ActivityLog)
- Rota `GET /compras/{id}/detalhe`

### Frontend
- `Drawer.tsx` ~510 linhas — 5 tabs **(Resumo / Itens / Documentos / Pagamentos / Histórico)**
- FSM stepper 6 estágios (rascunho → pedido → trânsito → recebido → conferido → pago) com highlight current
- Skeleton enquanto `Inertia::defer` carrega
- `Index.tsx` reescrito: ao clicar linha, `router.get('/compras', { compra_id: N }, { only: ['compra_detalhe'] })` — state na URL, browser back fecha drawer

### Tabs implementadas

| Tab | Conteúdo |
|---|---|
| **Resumo** | Fornecedor (CNPJ/cidade/contato) · Dados (ref/data/local/pay term/desconto/frete) · Observações · Resumo financeiro completo (subtotal/desconto/frete/impostos/total/pago/a pagar) |
| **Itens** | Tabela: produto · SKU · variação · lote · qty · unidade · custo · total |
| **Documentos** | XML chave NF-e (se `transactions.document` preenchido). Wave 6 traz download/manifestação |
| **Pagamentos** | Lista `payment_lines` com método PT-BR · data · cheque/conta/doc · estorno |
| **Histórico** | Timeline `Activity` (Spatie ActivityLog) — description + causer_name + created_at |

## Tier 0 — invariantes

- ✅ Multi-tenant ADR 0093: `where('business_id', $businessId)` ANTES de `find` — impossível leak mesmo com id válido de outro tenant
- ✅ Permission gate `compras.view` (403 sem perm)
- ✅ `Inertia::defer` em `compra_detalhe` — partial reload não recarrega tabela
- ✅ Skeleton loading visível enquanto fetch
- ✅ Drawer state na URL (`?compra_id=N`) — browser back/forward respeita

## Não incluso

- Paridade Blade completa (exports CSV/Excel/PDF, ordenação coluna, Ações dropdown, Total summary footer) — PR seguinte
- Wave 6 bridge XML DFe + download/manifestação no tab Documentos
- Pest deep `ComprasShowTest` — PR seguinte
- Action buttons FSM no footer (marcar recebido, pagar, etc) — Wave 8

## Validação

- ✅ `php -l` em 3 arquivos PHP modificados — sem erros
- ✅ `npx tsc --noEmit` — 0 erros em Compras
- ✅ `npm run build:inertia` — built in 1m 47s ✓

## Infra Contract (smoke pós-merge)

```bash
# Index continua respondendo
curl -sv https://oimpresso.com/compras 2>&1 | grep '^< HTTP'

# Endpoint show novo (com auth)
curl -sv https://oimpresso.com/compras/1/detalhe 2>&1 | grep '^< HTTP'
# Esperado: HTTP 200 OK (ou 404 se id não existe, 403 sem perm)

# Partial reload na index
curl -sv -H "X-Inertia: true" -H "X-Inertia-Partial-Data: compra_detalhe" \
  "https://oimpresso.com/compras?compra_id=1" 2>&1 | grep '^< HTTP'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)