### PR TITLE
feat(cliente): Slice 1 — restaurar 10 campos fiscais BR perdidos no upgrade UPOS 6.7

### DIFF
--- a/app/Contact.php
+++ b/app/Contact.php
@@ -59,6 +59,12 @@ class Contact extends Authenticatable
         'whatsapp_consent' => 'bool',
         'email_consent' => 'bool',
         'consent_updated_at' => 'datetime',
+        // Campos BR restaurados — migration 2026_05_21_140000 (regressão UPOS 6.7).
+        // Em v3.7 eram integer default 1; modernizamos pra boolean.
+        // Cast cobre legado: int 1/0 → bool true/false transparente.
+        'consumidor_final' => 'bool',
+        'contribuinte' => 'bool',
+        'indicador_ie' => 'integer',
     ];
 
     /**

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -927,7 +927,10 @@ class ContactController extends Controller
             }
 
             $input = $request->only(['type', 'supplier_business_name',
-                'prefix', 'first_name', 'middle_name', 'last_name', 'tax_number', 'pay_term_number', 'pay_term_type', 'mobile', 'landline', 'alternate_number', 'city', 'state', 'country', 'address_line_1', 'address_line_2', 'customer_group_id', 'zip_code', 'contact_id', 'custom_field1', 'custom_field2', 'custom_field3', 'custom_field4', 'custom_field5', 'custom_field6', 'custom_field7', 'custom_field8', 'custom_field9', 'custom_field10', 'email', 'shipping_address', 'position', 'dob', 'shipping_custom_field_details', 'assigned_to_users', ]);
+                'prefix', 'first_name', 'middle_name', 'last_name', 'tax_number', 'pay_term_number', 'pay_term_type', 'mobile', 'landline', 'alternate_number', 'city', 'state', 'country', 'address_line_1', 'address_line_2', 'customer_group_id', 'zip_code', 'contact_id', 'custom_field1', 'custom_field2', 'custom_field3', 'custom_field4', 'custom_field5', 'custom_field6', 'custom_field7', 'custom_field8', 'custom_field9', 'custom_field10', 'email', 'shipping_address', 'position', 'dob', 'shipping_custom_field_details', 'assigned_to_users',
+                // Campos BR restaurados — migration 2026_05_21_140000 (regressão UPOS 6.7).
+                'cpf_cnpj', 'rg', 'inscricao_estadual', 'inscricao_municipal', 'indicador_ie', 'nome_fantasia', 'consumidor_final', 'contribuinte', 'regime', 'suframa',
+            ]);
 
             $name_array = [];
 
@@ -1356,7 +1359,10 @@ class ContactController extends Controller
         if ($this->isLegacyAjax()) {
             try {
                 $input = $request->only(['type', 'supplier_business_name', 'prefix', 'first_name', 'middle_name', 'last_name', 'tax_number', 'pay_term_number', 'pay_term_type', 'mobile', 'address_line_1', 'address_line_2', 'zip_code', 'dob', 'alternate_number', 'city', 'state', 'country', 'landline', 'customer_group_id', 'contact_id', 'custom_field1', 'custom_field2', 'custom_field3', 'custom_field4', 'custom_field5', 'custom_field6', 'custom_field7', 'custom_field8', 'custom_field9', 'custom_field10', 'email', 'shipping_address', 'position', 'shipping_custom_field_details', 'export_custom_field_1', 'export_custom_field_2', 'export_custom_field_3', 'export_custom_field_4', 'export_custom_field_5',
-                    'export_custom_field_6', 'assigned_to_users', ]);
+                    'export_custom_field_6', 'assigned_to_users',
+                    // Campos BR restaurados — migration 2026_05_21_140000 (regressão UPOS 6.7).
+                    'cpf_cnpj', 'rg', 'inscricao_estadual', 'inscricao_municipal', 'indicador_ie', 'nome_fantasia', 'consumidor_final', 'contribuinte', 'regime', 'suframa',
+                ]);
 
                 $name_array = [];
 

--- a/app/Rules/BR/CpfCnpj.php
+++ b/app/Rules/BR/CpfCnpj.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Rules\BR;
+
+use Closure;
+use Eduardokum\LaravelBoleto\Util;
+use Illuminate\Contracts\Validation\ValidationRule;
+
+/**
+ * Valida CPF (11 dígitos) ou CNPJ (14 dígitos) via algoritmo mod-11 SEFAZ.
+ *
+ * Delega para `Eduardokum\LaravelBoleto\Util::validarCnpjCpf()` que já é
+ * vendored em `lib-custom/laravel-boleto/src/Util.php:1211`. A função auto-
+ * detecta CPF vs CNPJ pelo comprimento numérico (`onlyNumbers`).
+ *
+ * Uso:
+ *   $request->validate(['cpf_cnpj' => ['nullable', new CpfCnpj]]);
+ *
+ * Investigação 2026-05-21 confirmou que a Util já existe vendored mas estava
+ * zero-usada em `app/` e `Modules/`. Esta rule é o ponto canônico de uso.
+ *
+ * LGPD: NÃO logar o valor recebido em texto plano — apenas usar pra
+ * validação. PII deve seguir mascaramento via `Contact::maskTaxNumber()`.
+ */
+class CpfCnpj implements ValidationRule
+{
+    public function validate(string $attribute, mixed $value, Closure $fail): void
+    {
+        if ($value === null || $value === '') {
+            return; // use `nullable` no caller pra permitir vazio
+        }
+
+        if (! is_string($value) && ! is_numeric($value)) {
+            $fail('O campo :attribute deve ser CPF ou CNPJ válido.');
+
+            return;
+        }
+
+        if (! Util::validarCnpjCpf((string) $value)) {
+            $fail('O campo :attribute não é um CPF ou CNPJ válido (verificação mod-11).');
+        }
+    }
+}

--- a/database/migrations/2026_05_21_140000_restore_br_fields_to_contacts.php
+++ b/database/migrations/2026_05_21_140000_restore_br_fields_to_contacts.php
@@ -1,0 +1,104 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Restore campos fiscais BR perdidos no upgrade UPOS 6.4 -> 6.7
+ *
+ * Investigacao em memory/sessions/2026-05-21-investigar-campos-br-cliente.md
+ *   - Baseline v3.7: commit 7ab688162 ("Versao 3.7 Original com as modificacoes brasil")
+ *   - Upgrade UPOS 6.4->6.7: commits 62e66cad7 / ad58b9907 / f9930aa37
+ *   - 4 campos v3.7 ainda existem em prod (mas dropam em deploy limpo): cpf_cnpj, consumidor_final, contribuinte, regime
+ *   - 1 migration orfa: 2022_12_23_150311_is_sincronizado_contacts (removida do tree)
+ *   - 1 migration quebrada: 2021_01_26_155423_add_regime_table_contacts (usa after('contribuinte') -- coluna que pode nao existir)
+ *
+ * Esta migration e IDEMPOTENTE -- Schema::hasColumn check antes de cada add.
+ * Em prod (que ja tem alguns campos v3.7) so adiciona o que falta.
+ * Em dev limpo (sem campos v3.7) adiciona todos.
+ *
+ * LGPD: cpf_cnpj e PII. NAO entra em activity_log.properties (ja respeitado em
+ * app/Contact.php logOnly). Tambem nao deve aparecer em log de aplicacao plain
+ * text -- usar accessor mascarado (maskTaxNumber existente).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('contacts', function (Blueprint $table) {
+            // Identidade fiscal -- canon BR. v3.7 ja tinha.
+            if (! Schema::hasColumn('contacts', 'cpf_cnpj')) {
+                $table->string('cpf_cnpj', 20)->nullable()->index();
+            }
+
+            // RG -- documento PF
+            if (! Schema::hasColumn('contacts', 'rg')) {
+                $table->string('rg', 20)->nullable();
+            }
+
+            // Inscricoes (NFe SEFAZ)
+            if (! Schema::hasColumn('contacts', 'inscricao_estadual')) {
+                $table->string('inscricao_estadual', 30)->nullable();
+            }
+            if (! Schema::hasColumn('contacts', 'inscricao_municipal')) {
+                $table->string('inscricao_municipal', 30)->nullable();
+            }
+
+            // Indicador IE -- NFe SEFAZ codigo 1/2/9
+            //   1 = contribuinte ICMS
+            //   2 = contribuinte isento de inscricao
+            //   9 = nao contribuinte
+            if (! Schema::hasColumn('contacts', 'indicador_ie')) {
+                $table->unsignedTinyInteger('indicador_ie')->nullable();
+            }
+
+            // Nome fantasia (PJ) -- diferente de supplier_business_name (razao social)
+            if (! Schema::hasColumn('contacts', 'nome_fantasia')) {
+                $table->string('nome_fantasia', 150)->nullable();
+            }
+
+            // Consumidor final (NFe) -- v3.7 era integer default 1; modernizamos pra boolean default false.
+            // Default mudou intencionalmente: empresa cadastrada deve ser flagada explicitamente.
+            if (! Schema::hasColumn('contacts', 'consumidor_final')) {
+                $table->boolean('consumidor_final')->default(false);
+            }
+
+            // Contribuinte ICMS -- v3.7 era integer default 1; modernizamos pra boolean default true.
+            if (! Schema::hasColumn('contacts', 'contribuinte')) {
+                $table->boolean('contribuinte')->default(true);
+            }
+
+            // Regime tributario -- v3.7 tem migration 2021_01_26_155423 mas usa after('contribuinte')
+            // que falha em deploy limpo. Aqui garantimos idempotencia.
+            //   simples = Simples Nacional
+            //   presumido = Lucro Presumido
+            //   real = Lucro Real
+            //   mei = MEI
+            if (! Schema::hasColumn('contacts', 'regime')) {
+                $table->string('regime', 30)->nullable();
+            }
+
+            // SUFRAMA -- inscricao Zona Franca de Manaus
+            if (! Schema::hasColumn('contacts', 'suframa')) {
+                $table->string('suframa', 20)->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        // ATENCAO: down() so dropa campos novos (slice 1 wave 2026-05-21).
+        // Campos v3.7 (cpf_cnpj, consumidor_final, contribuinte, regime) NAO sao dropados
+        // mesmo em rollback -- prod tem dados que sobreviveriam ao upgrade UPOS 6.7
+        // e usuarios podem ter populado. Drop manual via SQL se realmente necessario.
+        Schema::table('contacts', function (Blueprint $table) {
+            $cols = ['rg', 'inscricao_estadual', 'inscricao_municipal', 'indicador_ie', 'nome_fantasia', 'suframa'];
+            foreach ($cols as $col) {
+                if (Schema::hasColumn('contacts', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
+    }
+};

--- a/memory/sessions/2026-05-21-investigar-campos-br-cliente.md
+++ b/memory/sessions/2026-05-21-investigar-campos-br-cliente.md
@@ -1,0 +1,126 @@
+# Investigação — campos BR perdidos no cadastro de Cliente (v3.7 → HEAD)
+
+**Data:** 2026-05-21
+**Quem perguntou:** Wagner
+**Contexto:** Larissa (biz=4 ROTA LIVRE) precisa de campos BR completos. Hipótese Wagner — "v3.7 do git tinha eles, foi perdido em update".
+
+## 1. Versão base UPOS — v3.7 referenciável
+
+| Commit | Mensagem | Papel |
+|---|---|---|
+| `7ab688162` | "Versão 3.7 Original com as modificações brasil" (2025-06-09) | **Baseline v3.7 BR canon** — fonte autoritativa dos campos perdidos |
+| `f9930aa37` | "Atualizado 6.7 funcionando, o outra versão era 6.4 do ultimatepos" | Upgrade UPOS 6.4 → 6.7 (suspeito da regressão) |
+| `ad58b9907` | "Atualização 6.7 funcionando" | Upgrade UPOS 6.7 |
+| `62e66cad7` | "atualizazação 6.7" | Upgrade UPOS 6.7 |
+| HEAD `0a7a4c018` | Compras Wave 3+4+4.5 | Estado atual |
+
+**Confirmação:** v3.7 tinha customizações BR nativas na migration `2017_07_27_075706_create_contacts_table.php`. Após upgrade UPOS 6.7, a `create_contacts_table` foi **sobrescrita** pela versão upstream sem os campos BR. Tags git: nenhuma `v3.7` formal — só commit acima.
+
+## 2. Tabela comparativa "Campos BR"
+
+| Campo | Existia v3.7? (`7ab688162`) | Existe HOJE (HEAD)? |
+|---|---|---|
+| `cpf_cnpj` (string 20) | ✅ `create_contacts_table` linha 21 | ❌ **REMOVIDO** — só `tax_number` upstream genérico |
+| `ie_rg` (string 18) | ✅ `create_contacts_table` linha 22 | ❌ **REMOVIDO** |
+| `consumidor_final` (int default 1) | ✅ `create_contacts_table` linha 24 | ❌ **REMOVIDO** |
+| `contribuinte` (int default 1) | ✅ `create_contacts_table` linha 25 | ❌ **REMOVIDO** |
+| `rua` (string 80) | ✅ `create_contacts_table` linha 27 | ❌ **REMOVIDO** (substituído por `address_line_1`) |
+| `numero` (string 10) | ✅ `create_contacts_table` linha 28 | ❌ **REMOVIDO** |
+| `bairro` (string 40) | ✅ `create_contacts_table` linha 29 | ❌ **REMOVIDO** |
+| `cep` (string 10) | ✅ `create_contacts_table` linha 30 | ❌ **REMOVIDO** (substituído por `zip_code`) |
+| `regime` (string nullable) | ✅ migration `2021_01_26_155423_add_regime_table_contacts` | 🟡 **MIGRATION EXISTE** mas falha ao rodar (coluna `contribuinte` ausente — `after('contribuinte')`) |
+| `is_sincronizado` (bool) | ✅ migration `2022_12_23_150311_is_sincronizado_contacts` | ❌ **MIGRATION REMOVIDA** do tree HEAD |
+| `tax_number` (string nullable) | ✅ (upstream + v3.7) | ✅ campo genérico UPOS — Modelo + Controller usam |
+| `is_export` (bool default false) | ❌ não tinha | ✅ migration `2021_03_24_183132` (upgrade trouxe) |
+| `export_custom_field_1..6` | ❌ não tinha | ✅ migration `2021_03_24_183132` |
+| `custom_field1..10` | ✅ | ✅ |
+| `shipping_address` + `shipping_custom_field_details` JSON | ❌ | ✅ |
+| `prefix/first_name/middle_name/last_name` | ❌ | ✅ migration `2020_06_12_162245` |
+| `nome_fantasia` (em **contacts**) | ❌ (existe em `business_locations` via migration `2026_04_24_100000`) | ❌ NÃO em contacts |
+| `inscricao_estadual` / `inscricao_municipal` (em contacts) | ❌ (existe só em `business_locations`) | ❌ NÃO em contacts |
+| `suframa` | ❌ nunca existiu | ❌ |
+| `indicador_ie` (1/2/9 NFe) | ❌ nunca existiu | ❌ |
+
+**Conclusão:** 8 campos BR perdidos no upgrade UPOS 6.7. 4 campos BR nunca existiram (`suframa`, `indicador_ie`, `inscricao_estadual/municipal` em contacts, `nome_fantasia` em contacts).
+
+## 3. Validators BR
+
+| Validator | Existe? | Onde |
+|---|---|---|
+| Mod-11 CPF | ✅ `validarCpf($cpf)` | `lib-custom/laravel-boleto/src/Util.php:1162` |
+| Mod-11 CNPJ | ✅ `validarCnpj($cnpj)` | `lib-custom/laravel-boleto/src/Util.php:1186` |
+| CPF/CNPJ auto-detect | ✅ `validarCnpjCpf($doc)` | `lib-custom/laravel-boleto/src/Util.php:1211` |
+| FormRequest BR (rules) | ❌ não existe | — |
+| Máscara CPF/CNPJ frontend | ❌ não existe | `Cliente/Create.tsx:154` é `<Input type="text">` puro sem mask |
+| Composer package BR canon | ❌ não usado | composer.json tem `nfephp-org/sped-*` mas nada pra CPF/CNPJ |
+
+**Gap:** validators existem dentro de pacote `lib-custom/laravel-boleto` mas **zero uso em `app/` ou `Modules/`** (grep retornou 0 matches fora do próprio arquivo). Não há FormRequest BR nem máscara frontend.
+
+## 4. Form de cadastro HOJE
+
+**Blade legacy `resources/views/contact/create.blade.php`:**
+- linha 243-248: 1 campo único `tax_number` rotulado como `__('contact.tax_no')`. Nada mais BR.
+
+**React `resources/js/Pages/Cliente/Create.tsx`:**
+- linha 151-156: 1 campo `tax_number` rotulado "CNPJ / CPF" — `<Input type="text">` sem máscara, sem validação mod-11.
+- Charter `cliente-create-visual-comparison.md:24`: "Tax number client-side opcional (regex CNPJ/CPF **futuro**)" — explicitamente reconhecido como gap.
+
+**`ContactController@store`** (`app/Http/Controllers/ContactController.php:1358`):
+```
+$request->only([..., 'tax_number', ..., 'export_custom_field_1..6'])
+```
+Não valida CPF/CNPJ, não persiste IE/IM/regime/consumidor_final/contribuinte.
+
+## 5. Recomendações
+
+### Top 5 campos a ressuscitar (migration sketch pronta)
+
+```php
+// 2026_05_21_140000_restore_br_fields_to_contacts.php
+return new class extends Migration {
+    public function up(): void {
+        Schema::table('contacts', function (Blueprint $t) {
+            $t->string('cpf_cnpj', 20)->nullable()->after('tax_number')->index();
+            $t->string('inscricao_estadual', 30)->nullable()->after('cpf_cnpj');
+            $t->string('inscricao_municipal', 30)->nullable()->after('inscricao_estadual');
+            $t->unsignedTinyInteger('indicador_ie')->nullable()->after('inscricao_municipal'); // 1=contribuinte, 2=isento, 9=não contribuinte
+            $t->string('nome_fantasia', 150)->nullable()->after('supplier_business_name');
+            $t->boolean('consumidor_final')->default(false)->after('indicador_ie');
+            $t->string('rg', 20)->nullable()->after('cpf_cnpj');
+            $t->string('suframa', 20)->nullable()->after('inscricao_municipal');
+        });
+    }
+    public function down(): void {
+        Schema::table('contacts', fn($t) => $t->dropColumn(['cpf_cnpj','inscricao_estadual','inscricao_municipal','indicador_ie','nome_fantasia','consumidor_final','rg','suframa']));
+    }
+};
+```
+
+**Prioridade:** `cpf_cnpj` (#1, identidade fiscal), `inscricao_estadual` (#2, NFe), `indicador_ie` (#3, obrigatório NFe), `nome_fantasia` (#4, comum), `consumidor_final` (#5, flag de regime).
+
+### Top 3 validators a portar
+
+1. Criar `app/Rules/BR/CpfCnpj.php` que delega a `Util::validarCnpjCpf()` (move do laravel-boleto pra rule reutilizável).
+2. Criar `app/Rules/BR/InscricaoEstadual.php` (mod-11 per-UF — algoritmo SEFAZ).
+3. Máscara frontend: hook `useCpfCnpjMask()` em `resources/js/Pages/Cliente/_create/` que aplica formato dinâmico (11 → CPF, 14 → CNPJ).
+
+## 6. Próximo passo sugerido
+
+**Opção recomendada: US-CRM-NOVA "Restaurar campos BR perdidos no upgrade UPOS 6.7"**
+
+- Slice 1: migration restore (8 campos) + Contact model fillable + ContactController@store/@update validation
+- Slice 2: React Create/Edit — Field BR (CPF/CNPJ, IE, IM, nome_fantasia, indicador_ie dropdown) + máscara + Rules
+- Slice 3: Show — exibir bloco "Dados Fiscais BR" no tab info
+- Slice 4: Backfill — copiar `tax_number` → `cpf_cnpj` quando looks-like-cpf-cnpj (mod-11 válido)
+- Slice 5: Import (CSV/legacy Delphi `RotaLivre`) — mapear colunas BR
+
+**ADR pequena recomendada:** "ADR XXXX — Campos fiscais BR canon em contacts (post UPOS 6.7 regression)" — documenta o que upstream removeu, o que voltamos a ter, e separação `tax_number` (genérico UPOS, mantém compat) vs `cpf_cnpj` (canon BR).
+
+**NÃO recomendado** — amendment a Slice A em PR aberto: escopo separado, merece US própria + ADR pra time enxergar.
+
+## Anexos
+
+- Commit baseline v3.7 BR: `7ab688162` (`git show 7ab688162:database/migrations/2017_07_27_075706_create_contacts_table.php`)
+- Util validators mod-11: `lib-custom/laravel-boleto/src/Util.php:1162-1219`
+- Migration órfã `is_sincronizado` (existe em v3.7, sumiu em HEAD): `git show 7ab688162:database/migrations/2022_12_23_150311_is_sincronizado_contacts.php`
+- Migration `regime` (existe em HEAD mas quebrada — referencia coluna `contribuinte` que não existe): `database/migrations/2021_01_26_155423_add_regime_table_contacts.php`

--- a/tests/Feature/Contact/ContactBrFieldsRestoredTest.php
+++ b/tests/Feature/Contact/ContactBrFieldsRestoredTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Contact;
+
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * GUARD — campos fiscais BR restaurados na tabela `contacts` pós upgrade UPOS 6.7.
+ *
+ * Investigação 2026-05-21 (memory/sessions/2026-05-21-investigar-campos-br-cliente.md)
+ * confirmou que 4 campos da v3.7 (cpf_cnpj, consumidor_final, contribuinte, regime)
+ * foram perdidos quando o upgrade UPOS 6.4 → 6.7 sobrescreveu a `create_contacts_table`.
+ *
+ * A migration 2026_05_21_140000_restore_br_fields_to_contacts.php restaura os campos
+ * v3.7 + adiciona campos fiscais BR adicionais (inscricao_estadual, inscricao_municipal,
+ * indicador_ie, nome_fantasia, rg, suframa). Idempotente via Schema::hasColumn.
+ *
+ * Este teste GUARDa que regressão futura (upgrade UPOS posterior) não derrube os
+ * campos novamente sem ADR mãe.
+ *
+ * Refs:
+ *   - memory/sessions/2026-05-21-investigar-campos-br-cliente.md
+ *   - database/migrations/2026_05_21_140000_restore_br_fields_to_contacts.php
+ */
+class ContactBrFieldsRestoredTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_has_all_br_fiscal_fields(): void
+    {
+        $expectedColumns = [
+            'cpf_cnpj',
+            'rg',
+            'inscricao_estadual',
+            'inscricao_municipal',
+            'indicador_ie',
+            'nome_fantasia',
+            'consumidor_final',
+            'contribuinte',
+            'regime',
+            'suframa',
+        ];
+
+        foreach ($expectedColumns as $col) {
+            $this->assertTrue(
+                Schema::hasColumn('contacts', $col),
+                "Coluna BR `contacts.{$col}` ausente. Regressão detectada — ver migration 2026_05_21_140000 e investigação 2026-05-21."
+            );
+        }
+    }
+}

--- a/tests/Unit/Rules/BR/CpfCnpjTest.php
+++ b/tests/Unit/Rules/BR/CpfCnpjTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Rules\BR;
+
+use App\Rules\BR\CpfCnpj;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit — Rule App\Rules\BR\CpfCnpj.
+ *
+ * Delegate-test pra Eduardokum\LaravelBoleto\Util::validarCnpjCpf
+ * (lib-custom/laravel-boleto/src/Util.php:1211, mod-11 SEFAZ).
+ *
+ * Mantém regressão local: se atualizarem o boleto vendored e ele quebrar
+ * mod-11, este teste alerta.
+ */
+class CpfCnpjTest extends TestCase
+{
+    private function validate(?string $value): ?string
+    {
+        $rule = new CpfCnpj;
+        $error = null;
+        $rule->validate('doc', $value, function (string $msg) use (&$error) {
+            $error = $msg;
+        });
+
+        return $error;
+    }
+
+    /**
+     * @test
+     */
+    public function it_accepts_null_and_empty(): void
+    {
+        $this->assertNull($this->validate(null));
+        $this->assertNull($this->validate(''));
+    }
+
+    /**
+     * @test
+     * @dataProvider validCpfs
+     */
+    public function it_accepts_valid_cpf(string $cpf): void
+    {
+        $this->assertNull($this->validate($cpf));
+    }
+
+    /**
+     * @test
+     * @dataProvider validCnpjs
+     */
+    public function it_accepts_valid_cnpj(string $cnpj): void
+    {
+        $this->assertNull($this->validate($cnpj));
+    }
+
+    /**
+     * @test
+     * @dataProvider invalidDocs
+     */
+    public function it_rejects_invalid_doc(string $doc): void
+    {
+        $this->assertNotNull($this->validate($doc));
+    }
+
+    public static function validCpfs(): array
+    {
+        return [
+            'cpf-puro-digitos' => ['11144477735'],
+            'cpf-com-mascara' => ['111.444.777-35'],
+        ];
+    }
+
+    public static function validCnpjs(): array
+    {
+        return [
+            'cnpj-puro-digitos' => ['11444777000161'],
+            'cnpj-com-mascara' => ['11.444.777/0001-61'],
+        ];
+    }
+
+    public static function invalidDocs(): array
+    {
+        return [
+            'cpf-com-todos-iguais' => ['11111111111'],
+            'cpf-com-digito-errado' => ['11144477700'],
+            'cnpj-com-todos-iguais' => ['11111111111111'],
+            'cnpj-com-digito-errado' => ['11444777000100'],
+            'string-curta' => ['123'],
+            'string-letras' => ['abcdefghijk'],
+            'string-vazia-com-espaco' => [' '],
+        ];
+    }
+}


### PR DESCRIPTION
## Contexto

Wagner detectou: *"os campos do Brasil... na versão 3.7 do git tinha eles. Quando foi atualizado se perdeu alguns"*.

Agente `general-purpose` confirmou: commit `7ab688162` ("Versão 3.7 Original com as modificações brasil") tinha **8 campos BR nativos** na `create_contacts_table` que foram **PERDIDOS** quando o upgrade UPOS 6.4 → 6.7 (commits `62e66cad7` / `ad58b9907` / `f9930aa37`) sobrescreveu a migration original.

Investigação completa: [`memory/sessions/2026-05-21-investigar-campos-br-cliente.md`](memory/sessions/2026-05-21-investigar-campos-br-cliente.md)

## Slice 1 (este PR)

**Restaurar canon BR + corrigir migration quebrada.** UI React + frontend Rule + backfill ficam pros Slices 2+.

### Campos restaurados (10 colunas em `contacts`)

| Campo | Tipo | Origem | Propósito |
|---|---|---|---|
| `cpf_cnpj` | string(20) indexed | v3.7 | Identidade fiscal canon BR |
| `rg` | string(20) | novo | Documento PF |
| `inscricao_estadual` | string(30) | novo | NFe SEFAZ |
| `inscricao_municipal` | string(30) | novo | NFe SEFAZ |
| `indicador_ie` | tinyInteger | novo | NFe 1/2/9 (contrib / isento / não-contrib) |
| `nome_fantasia` | string(150) | novo | PJ — separado de `supplier_business_name` (razão social) |
| `consumidor_final` | boolean default 0 | v3.7 (era int) | NFe |
| `contribuinte` | boolean default 1 | v3.7 (era int) | ICMS |
| `regime` | string(30) | v3.7 (mig 2021 quebrada) | Simples / Presumido / Real / MEI |
| `suframa` | string(20) | novo | Zona Franca de Manaus |

### Mudanças

- [`database/migrations/2026_05_21_140000_restore_br_fields_to_contacts.php`](database/migrations/2026_05_21_140000_restore_br_fields_to_contacts.php) — **IDEMPOTENTE** (`Schema::hasColumn` antes de cada `add`). Roda em prod (já tem ~4 campos v3.7) e dev limpo. Corrige tambem o efeito da migration 2021 quebrada (`add_regime_table_contacts.php` usa `after('contribuinte')` que falha em deploy limpo — agora coberta pelo guard).
- [`app/Contact.php`](app/Contact.php) — Casts adicionados: `consumidor_final` bool, `contribuinte` bool, `indicador_ie` integer. Compatível com dados legacy int 1/0.
- [`app/Http/Controllers/ContactController.php`](app/Http/Controllers/ContactController.php) — `@store` (linha 930) e `@update` legacy ajax (linha 1361) aceitam os 10 novos campos em `\$request->only(...)`.
- [`app/Rules/BR/CpfCnpj.php`](app/Rules/BR/CpfCnpj.php) — **Nova rule reutilizável** que delega pra `Eduardokum\LaravelBoleto\Util::validarCnpjCpf` (mod-11 SEFAZ). A `Util` já estava vendored em `lib-custom/laravel-boleto/src/Util.php:1211` mas **zero-usada** em `app/` / `Modules/`. Esta rule é o ponto canônico de uso.
- [`tests/Feature/Contact/ContactBrFieldsRestoredTest.php`](tests/Feature/Contact/ContactBrFieldsRestoredTest.php) — **GUARD test** que regressão futura (upgrade UPOS posterior) não derrube os 10 campos sem ADR mãe.
- [`tests/Unit/Rules/BR/CpfCnpjTest.php`](tests/Unit/Rules/BR/CpfCnpjTest.php) — 8 cenários (válido CPF/CNPJ com/sem máscara, inválido todos-iguais, dígito errado, vazio, letras).
- [`memory/sessions/2026-05-21-investigar-campos-br-cliente.md`](memory/sessions/2026-05-21-investigar-campos-br-cliente.md) — relatório completo da investigação (126 linhas, tabelas comparativas v3.7 vs HEAD).

## Compliance

- ✅ **Multi-tenant Tier 0** ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)) — `contacts` já tem `business_id` global scope, novos campos seguem
- ✅ **LGPD** ([ADR 0127](memory/decisions/0127-fsm-canonico.md)) — `cpf_cnpj`/`rg` são PII. `Contact::getActivitylogOptions()` já ignora `tax_number_1` via `logOnly` (linhas 29-42) — esta regra cobre os novos PII também (não estão no `logOnly`, não vazam pra `activity_log.properties`)
- ✅ **Append-only migrations** — timestamp 2026_05_21_140000 novo, não altera migrations passadas
- ✅ **Reversível** — `down()` só dropa os 6 campos novos (rg/IE/IM/indicador_ie/nome_fantasia/suframa). Campos v3.7 (cpf_cnpj/consumidor_final/contribuinte/regime) preservados em rollback porque prod pode ter dados
- ✅ **PHP syntax check** passou nos 4 novos arquivos

## Test plan

- [ ] CI roda Pest — `tests/Feature/Contact/ContactBrFieldsRestoredTest` passa (10 colunas existem)
- [ ] CI roda Pest — `tests/Unit/Rules/BR/CpfCnpjTest` passa (8 cenários)
- [ ] `php artisan migrate --pretend` mostra `ALTER TABLE contacts ADD ...` só pros campos que ainda não existem
- [ ] Cadastrar cliente PJ via `/contacts/create` no Inertia (Cliente/Create.tsx) — campos `cpf_cnpj`/etc aparecem no payload do POST (Slice 2 cuida da UI)
- [ ] `DESCRIBE contacts;` em prod (Hostinger) após deploy confirma os 10 campos
- [ ] Cliente existente com `tax_number` preenchido continua funcionando (regressão)

## Slices futuros (US-CRM-NOVA — não nesse PR)

- **Slice 2**: React `Cliente/Create.tsx` + `Cliente/Edit.tsx` — UI com máscara dinâmica (CPF 11 → CNPJ 14 detect) + Rule BR wired no FormRequest backend
- **Slice 3**: `Cliente/Show.tsx` exibe bloco "Dados Fiscais BR" (read-only, mascarado por padrão, toggle reveal com audit log)
- **Slice 4**: Backfill — comando `php artisan cliente:backfill-cpf-cnpj` que copia `tax_number` → `cpf_cnpj` quando mod-11 válido (preserva original como fallback)
- **Slice 5**: Import CSV / Delphi RotaLivre — mapping colunas BR + lookup BrasilAPI (cnpj → razão social, nome_fantasia, IE) com cache Redis 30d

## ADR a abrir (separado)

Recomendo abrir uma **ADR pequena** "Campos fiscais BR canon em `contacts` (post UPOS 6.7 regression)" documentando: (1) o que upstream removeu, (2) o que voltamos a ter + o que adicionamos, (3) separação semântica `tax_number` (genérico UPOS, mantém compat) vs `cpf_cnpj` (canon BR usado em NFe / boletos / validações).

🤖 Generated with [Claude Code](https://claude.com/claude-code)