### PR TITLE
feat(sells): coluna "Pagamento" na Grade Avançada (US-SELL-041)

### DIFF
--- a/resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx
+++ b/resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx
@@ -60,6 +60,12 @@ interface SaleRow {
     | string | null;
   // US-SELL-024 — boolean explícito "venda agrupada" (Delphi CODFINANCEIRO_GRUPO).
   is_grouped_invoice: boolean;
+  // US-SELL-041 — método de pagamento + parcelas (regressão Cowork KB-9.75:
+  // info estava na grade Lista mas sumiu da Grade Avançada). Larissa @ ROTA
+  // LIVRE biz=4 reportou 2026-05-21 (ADR 0105 sinal qualificado).
+  // Backend popula via SellController::inertiaList (match cases linha 1287-1298).
+  payment_method_label: string | null;
+  installments: number;
 }
 
 // US-SELL-023 — Mapping stage_key FSM → badge PT-BR + cor semantic.
@@ -431,6 +437,22 @@ function GroupedTable({
       accessorFn: (row) => row.payment_status,
       header: 'Status',
       cell: ({ getValue }) => PAYMENT_STATUS_LABEL[String(getValue())] ?? String(getValue()),
+      aggregationFn: 'count',
+    },
+    {
+      // US-SELL-041 — Larissa @ ROTA LIVRE biz=4 reportou 2026-05-21 (ADR 0105)
+      // que método de pagamento sumiu da Grade Avançada. A coluna existe na
+      // Lista (Index.tsx <td vd-pay>) desde Cowork KB-9.75 mas faltou portar
+      // pra esta view alternativa. Mostra label PT-BR (Dinheiro/PIX/Cartão/...)
+      // + Nx quando parcelado (installments > 1).
+      id: 'payment_method_label',
+      accessorFn: (row) => row.payment_method_label ?? '—',
+      header: 'Pagamento',
+      cell: ({ row }) => {
+        const label = row.original.payment_method_label ?? '—';
+        const inst = row.original.installments;
+        return inst > 1 ? `${label} · ${inst}×` : label;
+      },
       aggregationFn: 'count',
     },
     {


### PR DESCRIPTION
## Summary
Larissa @ ROTA LIVRE biz=4 reportou via Wagner 2026-05-21 que método de pagamento "sumiu da venda como era antes" — sinal qualificado [ADR 0105](memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md). Após investigação, o gap real é a **Grade Avançada** (não a Lista, nem o backend).

## Diagnóstico

| Camada | Estado |
|---|---|
| Backend `SellController::inertiaList` linha 1287-1298 | ✅ 9 match cases (cash, card, bank_transfer, cheque, other, custom_pay_1=PIX, custom_pay_2=Boleto, custom_pay_3=Crediário, default `ucfirst`) |
| `Sells/Index.tsx` Grade Lista linha 1352 (`<th>`) + 1449 (`<td vd-pay>`) | ✅ Renderiza `payment_method_label ?? '—'` + `Nx` parcelas |
| `Sells/_components/SellsGradeAvancada.tsx` ColumnDefs | ❌ **Gap real** — interface `SaleRow` sem o campo, sem entry no `columns useMemo` |

Quando Larissa troca pra `viewMode='grade-avancada'`, perde a info de método de pagamento. [ADR 0136](memory/decisions/0136-sells-split-lista-grade-avancada.md) split Lista/Grade Avançada deixou a coluna pra trás.

## Diff (1 file, 22 LOC)
`resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx`:
- Interface `SaleRow` estendida: `+payment_method_label: string | null` + `+installments: number` (shape já existente no payload — zero mudança backend)
- Nova coluna `payment_method_label` no `columns useMemo`, posição entre Status e Mês emissão (ordem lógica: Cliente → Status → **Pagamento** → Mês → Nº → Data → Total → Pago)
- Cell: label PT-BR (Dinheiro/PIX/Cartão/Boleto/Cheque/Transferência/Crediário/Outro) + `· Nx` quando `installments > 1`
- `aggregationFn: 'count'` consistente com outras colunas categóricas

## Test plan
- [x] TS check: zero erros novos em `SellsGradeAvancada.tsx` (371 erros pré-existentes intocados)
- [ ] Smoke pós-merge biz=1 (skill `smoke-prod-evidence`):
  1. Abrir `/sells` → toggle viewMode "Grade Avançada"
  2. Confirmar coluna "Pagamento" entre "Status" e "Mês emissão"
  3. Conferir venda com `installments > 1` mostra "Cartão · 3×" (etc)
  4. Conferir venda sem método mostra "—" silencioso

## Não cobre
- Coluna na grade Lista: já existe (linha 1449 do Index.tsx)
- Match cases não cobertos no backend: nenhum reportado (default `ucfirst` cobre legacy)

## Refs
- [US-SELL-041](memory/requisitos/Sells/SPEC.md)
- [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md) — Tier 0 intocado
- [ADR 0105](memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — cliente-sinal
- [ADR 0136](memory/decisions/0136-sells-split-lista-grade-avancada.md) — Sells split

🤖 Generated with [Claude Code](https://claude.com/claude-code)