### PR TITLE
feat(cliente): Slices 2+3 — UI campos BR em Create/Edit + bloco fiscais no Show

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -1069,6 +1069,18 @@ class ContactController extends Controller
                     'city' => $contact->city ?? null,
                     'state' => $contact->state ?? null,
                     'address_line_1' => $contact->address_line_1 ?? null,
+                    // Dados Fiscais BR (migration 2026_05_21_140000). cpf_cnpj formatado
+                    // via maskTaxNumber (canon Show.charter Automation Anti-hook) — NAO
+                    // entrega plain pro frontend.
+                    'cpf_cnpj_masked' => $this->maskTaxNumber($contact->cpf_cnpj ?? null),
+                    'inscricao_estadual' => $contact->inscricao_estadual ?? null,
+                    'inscricao_municipal' => $contact->inscricao_municipal ?? null,
+                    'indicador_ie' => $contact->indicador_ie ?? null,
+                    'nome_fantasia' => $contact->nome_fantasia ?? null,
+                    'consumidor_final' => (bool) ($contact->consumidor_final ?? false),
+                    'contribuinte' => (bool) ($contact->contribuinte ?? true),
+                    'regime' => $contact->regime ?? null,
+                    'suframa' => $contact->suframa ?? null,
                 ],
                 'initialTab' => in_array($tab, ['ledger', 'sales', 'payments', 'documents', 'activities', 'persons', 'subscriptions', 'rewards'], true) ? $tab : 'ledger',
                 'stats' => Inertia::defer(fn () => [

--- a/resources/js/Lib/format-br.ts
+++ b/resources/js/Lib/format-br.ts
@@ -1,0 +1,98 @@
+// Helpers de formatação BR — máscaras dinâmicas pra inputs.
+// Slice 2 da restauração dos campos fiscais BR (PR pós #1313).
+//
+// Não fazem validação mod-11 — Rule\BR\CpfCnpj cuida disso no backend.
+// Aqui só aplica/remove máscara visual.
+
+/**
+ * Retorna apenas dígitos do valor (remove pontuação, espaços, etc).
+ *   "123.456.789-09" → "12345678909"
+ */
+export function unmaskDigits(value: string | null | undefined): string {
+  if (!value) return '';
+  return value.replace(/\D/g, '');
+}
+
+/**
+ * Máscara dinâmica CPF (11 dígitos) ou CNPJ (14 dígitos).
+ *   "12345678909"     → "123.456.789-09"   (CPF)
+ *   "12345678000195"  → "12.345.678/0001-95" (CNPJ)
+ *   "123"             → "123"               (incomplete, no mask)
+ *
+ * Detecção pelo comprimento numérico:
+ *   ≤ 11 dígitos → formata progressivamente como CPF
+ *   > 11 dígitos → formata progressivamente como CNPJ (até 14)
+ *
+ * Trunca em 14 dígitos (máx CNPJ).
+ */
+export function formatCpfCnpj(value: string | null | undefined): string {
+  const digits = unmaskDigits(value).slice(0, 14);
+  if (digits.length === 0) return '';
+
+  // CPF: até 11 dígitos
+  if (digits.length <= 11) {
+    return digits
+      .replace(/^(\d{3})(\d)/, '$1.$2')
+      .replace(/^(\d{3})\.(\d{3})(\d)/, '$1.$2.$3')
+      .replace(/\.(\d{3})(\d{1,2})$/, '.$1-$2');
+  }
+
+  // CNPJ: 12 a 14 dígitos
+  return digits
+    .replace(/^(\d{2})(\d)/, '$1.$2')
+    .replace(/^(\d{2})\.(\d{3})(\d)/, '$1.$2.$3')
+    .replace(/\.(\d{3})(\d)/, '.$1/$2')
+    .replace(/(\d{4})(\d{1,2})$/, '$1-$2');
+}
+
+/**
+ * Máscara CEP — 8 dígitos → "00000-000"
+ */
+export function formatCep(value: string | null | undefined): string {
+  const digits = unmaskDigits(value).slice(0, 8);
+  if (digits.length === 0) return '';
+  if (digits.length <= 5) return digits;
+  return digits.replace(/^(\d{5})(\d)/, '$1-$2');
+}
+
+/**
+ * Máscara telefone BR — (XX) XXXX-XXXX ou (XX) 9XXXX-XXXX.
+ *
+ *   "11999998888"  → "(11) 99999-8888"   (celular 11d)
+ *   "1133334444"   → "(11) 3333-4444"    (fixo 10d)
+ *   "11"           → "(11) "
+ */
+export function formatPhone(value: string | null | undefined): string {
+  const digits = unmaskDigits(value).slice(0, 11);
+  if (digits.length === 0) return '';
+  if (digits.length <= 2) return `(${digits}`;
+  if (digits.length <= 6) return `(${digits.slice(0, 2)}) ${digits.slice(2)}`;
+  if (digits.length <= 10) {
+    return `(${digits.slice(0, 2)}) ${digits.slice(2, 6)}-${digits.slice(6)}`;
+  }
+  return `(${digits.slice(0, 2)}) ${digits.slice(2, 7)}-${digits.slice(7)}`;
+}
+
+/**
+ * Labels canônicos do `indicador_ie` (NFe SEFAZ).
+ * 1 = Contribuinte ICMS regularmente inscrito
+ * 2 = Contribuinte isento de inscrição estadual
+ * 9 = Não contribuinte (pessoa física, etc)
+ */
+export const INDICADOR_IE_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: '', label: '— Selecione —' },
+  { value: '1', label: '1 — Contribuinte ICMS' },
+  { value: '2', label: '2 — Contribuinte isento de inscrição' },
+  { value: '9', label: '9 — Não contribuinte' },
+];
+
+/**
+ * Labels canônicos do `regime` tributário.
+ */
+export const REGIME_TRIBUTARIO_OPTIONS: Array<{ value: string; label: string }> = [
+  { value: '', label: '— Selecione —' },
+  { value: 'simples', label: 'Simples Nacional' },
+  { value: 'presumido', label: 'Lucro Presumido' },
+  { value: 'real', label: 'Lucro Real' },
+  { value: 'mei', label: 'MEI' },
+];

--- a/resources/js/Pages/Cliente/Create.tsx
+++ b/resources/js/Pages/Cliente/Create.tsx
@@ -9,6 +9,8 @@ import { ChevronLeft, Save, User2 } from 'lucide-react';
 import { Input } from '@/Components/ui/input';
 import { Button } from '@/Components/ui/button';
 import { Label } from '@/Components/ui/label';
+import DadosFiscaisBRSection, { type DadosFiscaisBRData } from './_form/DadosFiscaisBRSection';
+import { unmaskDigits } from '@/Lib/format-br';
 
 interface ClienteCreatePageProps {
   types: Record<string, string>;
@@ -21,7 +23,7 @@ interface ClienteCreatePageProps {
   };
 }
 
-type ClienteFormData = {
+type ClienteFormData = DadosFiscaisBRData & {
   type: string;
   contact_type_radio: string;
   prefix: string;
@@ -43,7 +45,7 @@ type ClienteFormData = {
 };
 
 export default function ClienteCreate(props: ClienteCreatePageProps) {
-  const { data, setData, post, processing, errors } = useForm<ClienteFormData>({
+  const { data, setData, post, processing, errors, transform } = useForm<ClienteFormData>({
     type: props.selected_type ?? 'customer',
     contact_type_radio: 'person',
     prefix: '',
@@ -62,7 +64,28 @@ export default function ClienteCreate(props: ClienteCreatePageProps) {
     customer_group_id: '',
     opening_balance: '0',
     credit_limit: '',
+    // Dados Fiscais BR — migration 2026_05_21_140000.
+    cpf_cnpj: '',
+    rg: '',
+    inscricao_estadual: '',
+    inscricao_municipal: '',
+    indicador_ie: '',
+    nome_fantasia: '',
+    consumidor_final: false,
+    contribuinte: true,
+    regime: '',
+    suframa: '',
   });
+
+  const isJuridica = data.contact_type_radio === 'business';
+
+  // Normaliza cpf_cnpj pra dígitos puros antes do submit — backend Rule\BR\CpfCnpj
+  // já chama Util::onlyNumbers internamente mas mandamos limpo pra evitar
+  // pontuação persistida no banco (consistência cross-driver).
+  transform((payload) => ({
+    ...payload,
+    cpf_cnpj: unmaskDigits(payload.cpf_cnpj),
+  }));
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -148,16 +171,23 @@ export default function ClienteCreate(props: ClienteCreatePageProps) {
                   maxLength={100}
                 />
               </Field>
-              <Field label="CNPJ / CPF" error={errors.tax_number}>
+              <Field label="Tax number (legado UPOS)" error={errors.tax_number}>
                 <Input
                   type="text"
                   value={data.tax_number}
                   onChange={(e) => setData('tax_number', e.target.value)}
-                  placeholder="00.000.000/0000-00"
+                  placeholder="Use CPF / CNPJ abaixo (este campo é legacy)"
                 />
               </Field>
             </div>
           </Section>
+
+          <DadosFiscaisBRSection<ClienteFormData>
+            data={data}
+            setData={setData}
+            errors={errors}
+            isJuridica={isJuridica}
+          />
 
           <Section title="Contato">
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/resources/js/Pages/Cliente/Edit.tsx
+++ b/resources/js/Pages/Cliente/Edit.tsx
@@ -9,6 +9,8 @@ import { ChevronLeft, Save, User2 } from 'lucide-react';
 import { Input } from '@/Components/ui/input';
 import { Button } from '@/Components/ui/button';
 import { Label } from '@/Components/ui/label';
+import DadosFiscaisBRSection, { type DadosFiscaisBRData } from './_form/DadosFiscaisBRSection';
+import { unmaskDigits } from '@/Lib/format-br';
 
 interface ContactInfo {
   id: number;
@@ -30,6 +32,17 @@ interface ContactInfo {
   zip_code: string | null;
   customer_group_id: number | null;
   credit_limit: string | null;
+  // Campos BR (migration 2026_05_21_140000). Backend pode mandar null em legacy.
+  cpf_cnpj?: string | null;
+  rg?: string | null;
+  inscricao_estadual?: string | null;
+  inscricao_municipal?: string | null;
+  indicador_ie?: number | null;
+  nome_fantasia?: string | null;
+  consumidor_final?: boolean | null;
+  contribuinte?: boolean | null;
+  regime?: string | null;
+  suframa?: string | null;
 }
 
 interface ClienteEditPageProps {
@@ -39,7 +52,7 @@ interface ClienteEditPageProps {
   opening_balance: string;
 }
 
-type ClienteFormData = {
+type ClienteFormData = DadosFiscaisBRData & {
   type: string;
   contact_type_radio: string;
   first_name: string;
@@ -61,7 +74,7 @@ type ClienteFormData = {
 
 export default function ClienteEdit(props: ClienteEditPageProps) {
   const c = props.contact;
-  const { data, setData, put, processing, errors } = useForm<ClienteFormData>({
+  const { data, setData, put, processing, errors, transform } = useForm<ClienteFormData>({
     type: c.type ?? 'customer',
     contact_type_radio: c.contact_type ?? 'person',
     first_name: c.first_name ?? c.name ?? '',
@@ -79,7 +92,26 @@ export default function ClienteEdit(props: ClienteEditPageProps) {
     customer_group_id: c.customer_group_id ? String(c.customer_group_id) : '',
     opening_balance: props.opening_balance ?? '0',
     credit_limit: c.credit_limit ?? '',
+    // Dados Fiscais BR — pré-preenchidos do contact carregado pelo backend.
+    cpf_cnpj: c.cpf_cnpj ?? '',
+    rg: c.rg ?? '',
+    inscricao_estadual: c.inscricao_estadual ?? '',
+    inscricao_municipal: c.inscricao_municipal ?? '',
+    indicador_ie: c.indicador_ie != null ? String(c.indicador_ie) : '',
+    nome_fantasia: c.nome_fantasia ?? '',
+    consumidor_final: c.consumidor_final === true,
+    contribuinte: c.contribuinte !== false, // default true se null/undefined (legacy)
+    regime: c.regime ?? '',
+    suframa: c.suframa ?? '',
   });
+
+  const isJuridica = data.contact_type_radio === 'business';
+
+  // Mesma normalização de Create — backend Rule\BR\CpfCnpj re-aplica onlyNumbers.
+  transform((payload) => ({
+    ...payload,
+    cpf_cnpj: unmaskDigits(payload.cpf_cnpj),
+  }));
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -152,11 +184,18 @@ export default function ClienteEdit(props: ClienteEditPageProps) {
               <Field label="Sobrenome" error={errors.last_name}>
                 <Input value={data.last_name} onChange={(e) => setData('last_name', e.target.value)} maxLength={100} />
               </Field>
-              <Field label="CNPJ / CPF" error={errors.tax_number}>
-                <Input value={data.tax_number} onChange={(e) => setData('tax_number', e.target.value)} />
+              <Field label="Tax number (legado UPOS)" error={errors.tax_number}>
+                <Input value={data.tax_number} onChange={(e) => setData('tax_number', e.target.value)} placeholder="Use CPF / CNPJ abaixo (este campo é legacy)" />
               </Field>
             </div>
           </Section>
+
+          <DadosFiscaisBRSection<ClienteFormData>
+            data={data}
+            setData={setData}
+            errors={errors}
+            isJuridica={isJuridica}
+          />
 
           <Section title="Contato">
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">

--- a/resources/js/Pages/Cliente/Show.tsx
+++ b/resources/js/Pages/Cliente/Show.tsx
@@ -55,6 +55,17 @@ interface ContactInfo {
   city: string | null;
   state: string | null;
   address_line_1: string | null;
+  // Dados Fiscais BR — payload do backend (migration 2026_05_21_140000).
+  // cpf_cnpj entregue MASCARADO via maskTaxNumber (Show.charter Anti-hook LGPD).
+  cpf_cnpj_masked?: string | null;
+  inscricao_estadual?: string | null;
+  inscricao_municipal?: string | null;
+  indicador_ie?: number | null;
+  nome_fantasia?: string | null;
+  consumidor_final?: boolean;
+  contribuinte?: boolean;
+  regime?: string | null;
+  suframa?: string | null;
 }
 
 interface ContactStats {
@@ -203,6 +214,8 @@ export default function ClienteShow(props: ClienteShowPageProps) {
                 />
               </dl>
             </div>
+
+            <DadosFiscaisBRCard contact={contact} />
           </aside>
 
           <section className="md:col-span-2">
@@ -356,6 +369,117 @@ function ContactRow({ icon: Icon, label, value }: { icon: typeof Phone; label: s
         <dt className="text-xs text-muted-foreground">{label}</dt>
         <dd className="text-sm text-foreground truncate">{value ?? '—'}</dd>
       </div>
+    </div>
+  );
+}
+
+/**
+ * Bloco "Dados Fiscais BR" — Slice 3 da restauração dos campos BR.
+ *
+ * Charter Show.tsx Anti-hook LGPD: cpf_cnpj exibido MASCARADO via
+ * `cpf_cnpj_masked` (backend aplica `maskTaxNumber`). Frontend nunca recebe
+ * `cpf_cnpj` plain.
+ *
+ * Não renderiza se contato não tem nenhum campo BR populado (mantém UI
+ * limpa pra clientes legacy que ainda só têm tax_number genérico).
+ */
+function DadosFiscaisBRCard({ contact }: { contact: ContactInfo }) {
+  const hasAnyField =
+    contact.cpf_cnpj_masked ||
+    contact.inscricao_estadual ||
+    contact.inscricao_municipal ||
+    contact.indicador_ie != null ||
+    contact.nome_fantasia ||
+    contact.regime ||
+    contact.suframa;
+
+  if (!hasAnyField) return null;
+
+  const indicadorIeLabel: Record<number, string> = {
+    1: 'Contribuinte ICMS',
+    2: 'Isento de IE',
+    9: 'Não contribuinte',
+  };
+
+  const regimeLabel: Record<string, string> = {
+    simples: 'Simples Nacional',
+    presumido: 'Lucro Presumido',
+    real: 'Lucro Real',
+    mei: 'MEI',
+  };
+
+  return (
+    <div className="rounded-lg border border-border bg-background p-5">
+      <h3 className="text-xs font-semibold uppercase tracking-wider text-muted-foreground mb-3">
+        Dados fiscais BR
+      </h3>
+      <dl className="space-y-2 text-sm">
+        {contact.cpf_cnpj_masked && (
+          <FiscalRow label="CPF / CNPJ" value={contact.cpf_cnpj_masked} mono />
+        )}
+        {contact.nome_fantasia && (
+          <FiscalRow label="Nome fantasia" value={contact.nome_fantasia} />
+        )}
+        {contact.inscricao_estadual && (
+          <FiscalRow label="IE" value={contact.inscricao_estadual} mono />
+        )}
+        {contact.inscricao_municipal && (
+          <FiscalRow label="IM" value={contact.inscricao_municipal} mono />
+        )}
+        {contact.indicador_ie != null && (
+          <FiscalRow
+            label="Indicador IE"
+            value={`${contact.indicador_ie} — ${indicadorIeLabel[contact.indicador_ie] ?? '—'}`}
+          />
+        )}
+        {contact.regime && (
+          <FiscalRow label="Regime" value={regimeLabel[contact.regime] ?? contact.regime} />
+        )}
+        {contact.suframa && <FiscalRow label="SUFRAMA" value={contact.suframa} mono />}
+        <FiscalFlags
+          contribuinte={contact.contribuinte ?? true}
+          consumidorFinal={contact.consumidor_final ?? false}
+        />
+      </dl>
+    </div>
+  );
+}
+
+function FiscalRow({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="flex items-start justify-between gap-3">
+      <dt className="text-xs text-muted-foreground flex-shrink-0">{label}</dt>
+      <dd className={'text-sm text-foreground text-right truncate ' + (mono ? 'tabular-nums' : '')}>
+        {value}
+      </dd>
+    </div>
+  );
+}
+
+function FiscalFlags({
+  contribuinte,
+  consumidorFinal,
+}: {
+  contribuinte: boolean;
+  consumidorFinal: boolean;
+}) {
+  return (
+    <div className="pt-2 mt-2 border-t border-border flex flex-wrap gap-2">
+      <span
+        className={
+          'inline-flex items-center rounded-full border px-2 py-0.5 text-[10px] font-medium ' +
+          (contribuinte
+            ? 'border-sky-200 bg-sky-50 text-sky-700 dark:border-sky-900/40 dark:bg-sky-950/30 dark:text-sky-300'
+            : 'border-stone-200 bg-stone-50 text-stone-700 dark:border-stone-700 dark:bg-stone-900/60 dark:text-stone-300')
+        }
+      >
+        {contribuinte ? '✓ Contribuinte ICMS' : '✗ Não contribuinte'}
+      </span>
+      {consumidorFinal && (
+        <span className="inline-flex items-center rounded-full border border-amber-200 bg-amber-50 px-2 py-0.5 text-[10px] font-medium text-amber-700 dark:border-amber-900/40 dark:bg-amber-950/30 dark:text-amber-300">
+          Consumidor final
+        </span>
+      )}
     </div>
   );
 }

--- a/resources/js/Pages/Cliente/_form/DadosFiscaisBRSection.tsx
+++ b/resources/js/Pages/Cliente/_form/DadosFiscaisBRSection.tsx
@@ -1,0 +1,221 @@
+// Seção "Dados Fiscais BR" — compartilhada entre Cliente/Create.tsx e Cliente/Edit.tsx.
+// Slice 2 da restauração dos campos BR (PRs #1313 backend → este PR UI).
+//
+// Recebe a tipagem mínima necessária via genéricos pra ambos os forms
+// (Create usa post '/contacts', Edit usa put '/contacts/{id}') sem
+// duplicação visual.
+//
+// Charter compliance:
+//   - Cliente/Create.charter.md: PT-BR labels, Non-Goal "Validação CNPJ via Receita
+//     Federal" → aqui só faz máscara visual + Rule BR mod-11 server-side
+//   - LGPD: máscara visual no input não é display de PII (input value é o que
+//     o user digitou, não dado retornado de banco)
+
+import { Input } from '@/Components/ui/input';
+import { Label } from '@/Components/ui/label';
+import { FileText } from 'lucide-react';
+import { type ReactNode } from 'react';
+import { formatCpfCnpj, INDICADOR_IE_OPTIONS, REGIME_TRIBUTARIO_OPTIONS } from '@/Lib/format-br';
+
+/**
+ * Campos BR usados nos dois forms (Create + Edit). Espelha colunas da
+ * migration 2026_05_21_140000_restore_br_fields_to_contacts.php.
+ */
+export interface DadosFiscaisBRData {
+  cpf_cnpj: string;
+  rg: string;
+  inscricao_estadual: string;
+  inscricao_municipal: string;
+  indicador_ie: string; // '' | '1' | '2' | '9'
+  nome_fantasia: string;
+  consumidor_final: boolean;
+  contribuinte: boolean;
+  regime: string;
+  suframa: string;
+}
+
+/**
+ * Erros tipados (chave string -> mensagem) — Inertia useForm errors object.
+ */
+export type DadosFiscaisBRErrors = Partial<Record<keyof DadosFiscaisBRData, string>>;
+
+interface Props<T extends DadosFiscaisBRData> {
+  data: T;
+  setData: <K extends keyof T>(key: K, value: T[K]) => void;
+  errors: DadosFiscaisBRErrors;
+  /** Quando o tipo do contato é 'PF' a UI esconde campos PJ-only (IE, IM, suframa, nome fantasia). */
+  isJuridica: boolean;
+}
+
+export default function DadosFiscaisBRSection<T extends DadosFiscaisBRData>({
+  data,
+  setData,
+  errors,
+  isJuridica,
+}: Props<T>) {
+  return (
+    <section className="rounded-lg border border-border bg-background p-5">
+      <h3 className="text-sm font-semibold text-foreground mb-4 flex items-center gap-2">
+        <FileText size={16} className="text-muted-foreground" />
+        Dados fiscais BR
+      </h3>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <Field
+          label={isJuridica ? 'CNPJ' : 'CPF'}
+          error={errors.cpf_cnpj}
+        >
+          <Input
+            type="text"
+            inputMode="numeric"
+            value={formatCpfCnpj(data.cpf_cnpj)}
+            onChange={(e) => {
+              // Persiste sempre formatado pro re-render manter máscara consistente.
+              // Backend normaliza com Util::onlyNumbers via Rule BR\CpfCnpj.
+              setData('cpf_cnpj' as keyof T, formatCpfCnpj(e.target.value) as T[keyof T]);
+            }}
+            placeholder={isJuridica ? '00.000.000/0000-00' : '000.000.000-00'}
+            maxLength={18}
+            autoComplete="off"
+          />
+        </Field>
+
+        {!isJuridica && (
+          <Field label="RG" error={errors.rg}>
+            <Input
+              type="text"
+              value={data.rg}
+              onChange={(e) => setData('rg' as keyof T, e.target.value as T[keyof T])}
+              maxLength={20}
+              autoComplete="off"
+            />
+          </Field>
+        )}
+
+        {isJuridica && (
+          <>
+            <Field label="Nome fantasia" error={errors.nome_fantasia} colSpan={2}>
+              <Input
+                type="text"
+                value={data.nome_fantasia}
+                onChange={(e) => setData('nome_fantasia' as keyof T, e.target.value as T[keyof T])}
+                maxLength={150}
+                placeholder="Como aparece na fachada (opcional)"
+              />
+            </Field>
+
+            <Field label="Inscrição estadual (IE)" error={errors.inscricao_estadual}>
+              <Input
+                type="text"
+                value={data.inscricao_estadual}
+                onChange={(e) =>
+                  setData('inscricao_estadual' as keyof T, e.target.value as T[keyof T])
+                }
+                maxLength={30}
+                placeholder="ISENTO se for o caso"
+              />
+            </Field>
+
+            <Field label="Inscrição municipal (IM)" error={errors.inscricao_municipal}>
+              <Input
+                type="text"
+                value={data.inscricao_municipal}
+                onChange={(e) =>
+                  setData('inscricao_municipal' as keyof T, e.target.value as T[keyof T])
+                }
+                maxLength={30}
+              />
+            </Field>
+
+            <Field label="Indicador IE (NFe)" error={errors.indicador_ie}>
+              <select
+                value={data.indicador_ie}
+                onChange={(e) =>
+                  setData('indicador_ie' as keyof T, e.target.value as T[keyof T])
+                }
+                className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm"
+              >
+                {INDICADOR_IE_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </Field>
+
+            <Field label="Regime tributário" error={errors.regime}>
+              <select
+                value={data.regime}
+                onChange={(e) => setData('regime' as keyof T, e.target.value as T[keyof T])}
+                className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm"
+              >
+                {REGIME_TRIBUTARIO_OPTIONS.map((o) => (
+                  <option key={o.value} value={o.value}>
+                    {o.label}
+                  </option>
+                ))}
+              </select>
+            </Field>
+
+            <Field label="SUFRAMA" error={errors.suframa}>
+              <Input
+                type="text"
+                value={data.suframa}
+                onChange={(e) => setData('suframa' as keyof T, e.target.value as T[keyof T])}
+                maxLength={20}
+                placeholder="Apenas Zona Franca"
+              />
+            </Field>
+          </>
+        )}
+
+        <Field label="Flags" colSpan={2}>
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-2 h-9">
+            <label className="inline-flex items-center gap-1.5 text-sm">
+              <input
+                type="checkbox"
+                checked={data.contribuinte}
+                onChange={(e) =>
+                  setData('contribuinte' as keyof T, e.target.checked as T[keyof T])
+                }
+              />
+              Contribuinte ICMS
+            </label>
+            <label className="inline-flex items-center gap-1.5 text-sm">
+              <input
+                type="checkbox"
+                checked={data.consumidor_final}
+                onChange={(e) =>
+                  setData('consumidor_final' as keyof T, e.target.checked as T[keyof T])
+                }
+              />
+              Consumidor final (NFe)
+            </label>
+          </div>
+        </Field>
+      </div>
+    </section>
+  );
+}
+
+// ─── Subcomponents ──────────────────────────────────────────────────────────
+
+function Field({
+  label,
+  children,
+  error,
+  colSpan,
+}: {
+  label: string;
+  children: ReactNode;
+  error?: string;
+  colSpan?: number;
+}) {
+  return (
+    <div className={colSpan === 2 ? 'sm:col-span-2' : ''}>
+      <Label className="text-xs font-medium text-muted-foreground mb-1.5 block">{label}</Label>
+      {children}
+      {error && <p className="text-xs text-rose-600 mt-1">{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Contexto

Continuação do trabalho dos campos BR perdidos no upgrade UPOS 6.7. Backend já entregue no PR mergeado [#1313](https://github.com/wagnerra23/oimpresso.com/pull/1313) (migration 2026_05_21_140000 + Rule App\Rules\BR\CpfCnpj). Este PR wires os campos na **UI Inertia/React** — Larissa (biz=4 ROTA LIVRE) já pode cadastrar e visualizar dados fiscais BR depois desse merge + deploy migration.

Wagner aprovou opção (c) "implementar já o Slice 1" (mergeado) seguido de "merge e faça" → este PR.

## O que entrega

### Slice 2 — Create + Edit (input)

**Novo helper** [`resources/js/Lib/format-br.ts`](resources/js/Lib/format-br.ts)
- `formatCpfCnpj(v)` — máscara dinâmica: ≤11 dígitos formata como CPF, >11 como CNPJ
- `unmaskDigits(v)` — só dígitos, usado no `transform` antes do submit
- `formatCep`, `formatPhone` — helpers extras pra slices futuras
- `INDICADOR_IE_OPTIONS`, `REGIME_TRIBUTARIO_OPTIONS` — canon SEFAZ

**Novo componente** [`resources/js/Pages/Cliente/_form/DadosFiscaisBRSection.tsx`](resources/js/Pages/Cliente/_form/DadosFiscaisBRSection.tsx)
- Section única reusada em Create + Edit (DRY)
- Generic typed via `DadosFiscaisBRData` mixin no `useForm`
- `isJuridica` esconde campos PJ-only (IE, IM, suframa, nome fantasia, indicador IE, regime)
- Input `cpf_cnpj` com máscara visual aplicada no `onChange`
- Selects `indicador_ie` (1/2/9 NFe) + `regime` (simples/presumido/real/mei)
- Checkboxes `contribuinte` (default true) + `consumidor_final` (default false)

**Wiring em** [`Cliente/Create.tsx`](resources/js/Pages/Cliente/Create.tsx) **e** [`Cliente/Edit.tsx`](resources/js/Pages/Cliente/Edit.tsx)
- `ClienteFormData & DadosFiscaisBRData`
- 10 campos BR adicionados ao initial state (Create defaults vazios, Edit pre-preenchido com `c.cpf_cnpj`/etc)
- `useForm.transform()` normaliza `cpf_cnpj` para dígitos antes do POST/PUT (backend `Rule\BR\CpfCnpj` faz `Util::onlyNumbers` mas mandamos limpo pra consistência cross-driver no banco)
- Section plugada após \"Identificação\"
- `tax_number` renomeado pra "Tax number (legado UPOS)" — sinaliza claramente que o canon BR agora é `cpf_cnpj`

### Slice 3 — Show (display LGPD-friendly)

**Backend** [`app/Http/Controllers/ContactController.php`](app/Http/Controllers/ContactController.php) `@show` payload
- `cpf_cnpj_masked` via `maskTaxNumber()` — canon Show.charter Anti-hook LGPD (nunca envia cpf_cnpj plain pro frontend)
- 9 outros campos BR exportados (inscricao_estadual/municipal, indicador_ie, nome_fantasia, consumidor_final/contribuinte como `bool`, regime, suframa)

**Frontend** [`Cliente/Show.tsx`](resources/js/Pages/Cliente/Show.tsx)
- `ContactInfo` estendida com campos BR opcionais + `cpf_cnpj_masked`
- Novo componente local `<DadosFiscaisBRCard>` no aside, abaixo de "Contato"
- **Não renderiza** se contato não tem nenhum campo BR populado — UI limpa pra clientes legacy que ainda só têm `tax_number`
- Labels canon: `indicador_ie` 1/2/9, `regime` mapeado pra "Simples Nacional"/"Lucro Presumido"/etc
- Flags pill: "✓ Contribuinte ICMS" / "✗ Não contribuinte" / "Consumidor final" — cores semânticas Cockpit V2 (sky/stone/amber)

## Mockup visual

```
┌─ /contacts/123 — Larissa Modas Ltda ──────────────────────────────┐
│ [aside]                                       [main: 8 tabs]      │
│ ┌─ Contato ───────────────────────┐  ledger | sales | payments... │
│ │ Celular: (47) 99999-...         │                               │
│ │ Email:   contato@larissa....    │  (área de tabs já existente)  │
│ │ Endereço: Rua X, Joinville/SC   │                               │
│ └─────────────────────────────────┘                               │
│ ┌─ Dados fiscais BR ──────────────┐  ← NOVO BLOCO                 │
│ │ CPF / CNPJ:    12.345.678/0001-90 (mascarado via backend)       │
│ │ Nome fantasia: Larissa Modas                                    │
│ │ IE:            123.456.789.012                                  │
│ │ Indicador IE:  1 — Contribuinte ICMS                            │
│ │ Regime:        Simples Nacional                                 │
│ │ ──────────────                                                  │
│ │ [✓ Contribuinte ICMS]  [Consumidor final]                       │
│ └─────────────────────────────────┘                               │
└────────────────────────────────────────────────────────────────────┘
```

## Compliance

- ✅ **Charter Cliente/Create.charter.md** — Non-Goal "Validação CNPJ via Receita Federal" respeitado (só máscara visual + Rule mod-11 server)
- ✅ **Charter Cliente/Show.charter.md** — Anti-hook LGPD "CPF/CNPJ mascarado via maskTaxNumber" respeitado (backend mascara, frontend recebe `cpf_cnpj_masked` nunca plain)
- ✅ **Multi-tenant Tier 0** ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)) — ContactController já filtra por `business_id`
- ✅ **Backwards compatible** — contatos legacy sem campos BR populados continuam funcionando. Card só renderiza se há dado. Defaults seguros pro `useForm` Edit (contribuinte=true / consumidor_final=false).
- ✅ **DRY** — DadosFiscaisBRSection reusada em Create + Edit via generic typing
- ✅ **PHP syntax** validado em `ContactController.php`
- 🟡 TS check não rodado local (worktree sem `node_modules`) — CI valida tudo no PR

## Test plan

- [ ] CI passa (Pest + Vite build + charter-gate + module-grades-gate + visual-regression)
- [ ] Após deploy da migration #1313 em prod, cadastrar cliente PJ via `/contacts/create?type=customer`:
  - [ ] Selecionar "Jurídica" → mostra campos IE, IM, indicador IE, regime, suframa
  - [ ] Selecionar "Física" → esconde campos PJ-only, mostra RG
  - [ ] Digitar CPF `12345678909` → vira `123.456.789-09` no onChange
  - [ ] Digitar CNPJ `12345678000195` → vira `12.345.678/0001-95`
  - [ ] Submit com CPF inválido (mod-11 fail) retorna erro (Rule\BR\CpfCnpj — wiring no FormRequest fica pra Slice futuro, mas a Rule existe)
- [ ] Editar cliente existente em `/contacts/{id}/edit`:
  - [ ] Campos BR pre-preenchidos quando contato tem `cpf_cnpj` populado
  - [ ] PUT submit normaliza dígitos do CPF/CNPJ
- [ ] Ver cliente em `/contacts/{id}` (Show):
  - [ ] Aside mostra bloco "Dados fiscais BR" se houver dado
  - [ ] CPF/CNPJ vem mascarado (canon Show.charter)
  - [ ] Pill "Contribuinte ICMS" verde / "Não contribuinte" stone
- [ ] Cliente legacy só com `tax_number` (sem campos BR populados): bloco BR NÃO aparece (regressão visual OK)

## Slices futuros (US-CRM-NOVA, fora deste PR)

- **Slice 4**: Backfill — comando `php artisan cliente:backfill-cpf-cnpj` que copia `tax_number` → `cpf_cnpj` quando mod-11 válido (preserva original)
- **Slice 5**: Import CSV / Delphi RotaLivre — mapping de colunas BR + lookup BrasilAPI (CNPJ → razão social, IE) com cache Redis
- **Slice 6 (opcional)**: ADR pequena documentando regressão UPOS 6.7 e canon BR em `contacts`
- **Slice 7 (opcional)**: FormRequest dedicado pra ContactController com Rule\BR\CpfCnpj wired (substitui `\$request->only` por validated payload)

## Deploy pós-merge

Após este PR mergeado + PR #1313 já em main, prod precisa:

\`\`\`bash
ssh <hostinger> "cd ~/oimpresso.com && git pull origin main && php artisan migrate --force"
\`\`\`

Migration #1313 é IDEMPOTENTE (\`Schema::hasColumn\` guards) — segura.

🤖 Generated with [Claude Code](https://claude.com/claude-code)