### PR TITLE
feat(sells): coluna "Pagamento" na tabela HTML default da Grade Avançada

### DIFF
--- a/resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx
+++ b/resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx
@@ -289,6 +289,11 @@ export default function SellsGradeAvancada({
                 <SortableTh sortKey="final_total" current={sortKey} dir={sortDir} onSort={onSort} align="right" className="w-28">Total</SortableTh>
                 <Th className="text-right w-28">Pago</Th>
                 <Th className="text-right w-28">A receber</Th>
+                {/* US-SELL-041 follow-up #1314 — Larissa @ ROTA LIVRE biz=4 reportou
+                    2026-05-21 (ADR 0105) método de pagamento sumindo da Grade Avançada.
+                    PR #1314 cobriu o path TanStack (com agrupamento); aqui cobrimos
+                    a tabela HTML default (sem agrupamento) — o caminho mais visto. */}
+                <Th className="w-32">Pagamento</Th>
                 <SortableTh sortKey="payment_status" current={sortKey} dir={sortDir} onSort={onSort} className="w-32">Status</SortableTh>
                 {/* US-SELL-023 — coluna "Produção" badge FSM (Grade Avançada only,
                     Lista mode é enxuto e não mostra esta coluna). Default visível. */}
@@ -298,14 +303,14 @@ export default function SellsGradeAvancada({
             <tbody>
               {loading ? (
                 <tr>
-                  <td colSpan={10} className="text-center py-12 text-muted-foreground text-xs">
+                  <td colSpan={11} className="text-center py-12 text-muted-foreground text-xs">
                     <Loader2 className="inline-block mr-2 h-3.5 w-3.5 animate-spin" />
                     Carregando…
                   </td>
                 </tr>
               ) : rows.length === 0 ? (
                 <tr>
-                  <td colSpan={10} className="text-center py-12 text-muted-foreground text-xs">
+                  <td colSpan={11} className="text-center py-12 text-muted-foreground text-xs">
                     Nenhuma venda encontrada nesse filtro.
                   </td>
                 </tr>
@@ -364,6 +369,14 @@ export default function SellsGradeAvancada({
                       <td className="px-3 py-2.5 text-right tabular-nums text-foreground">{formatBRL(row.final_total)}</td>
                       <td className="px-3 py-2.5 text-right tabular-nums text-emerald-700 dark:text-emerald-300">{formatBRL(row.total_paid)}</td>
                       <td className="px-3 py-2.5 text-right tabular-nums text-amber-700 dark:text-amber-300">{formatBRL(due)}</td>
+                      {/* US-SELL-041 follow-up #1314 — método de pagamento + parcelas
+                          (PIX/Cartão/Boleto/Dinheiro/...). NULL/empty cai em "—" silencioso. */}
+                      <td className="px-3 py-2.5 text-xs text-muted-foreground whitespace-nowrap">
+                        {row.payment_method_label ?? '—'}
+                        {row.installments > 1 && (
+                          <span className="ml-1 text-muted-foreground/70">· {row.installments}×</span>
+                        )}
+                      </td>
                       <td className="px-3 py-2.5">
                         <PaymentStatusBadge status={row.payment_status} overdue={row.is_overdue} />
                       </td>


### PR DESCRIPTION
## Summary
Follow-up do PR [#1314](https://github.com/wagnerra23/oimpresso.com/pull/1314) (US-SELL-041). **Smoke real pós-deploy 2026-05-21 detectou** que #1314 só portou a coluna no path TanStack (usado quando há agrupamento `groupBy !== 'none'`). A tabela HTML default — caminho mais comum sem agrupamento — seguia sem a coluna. Larissa @ ROTA LIVRE biz=4 continuaria sem ver o método de pagamento se não agrupasse ([ADR 0105](memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) sinal qualificado).

## Diff (1 file, 17 LOC)
`resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx`:
- Header HTML manual (entre `A receber` e `Status`): novo `<Th className="w-32">Pagamento</Th>`
- Tbody `<td>` correspondente: `row.payment_method_label ?? '—'` + `· Nx` quando `installments > 1`
- `colSpan` loading + empty state: `10` → `11`

Ordem das colunas agora: Data | Nº fatura | Cliente | Localização | Total | Pago | A receber | **Pagamento** | Status | Produção

Zero mudança backend (payload já vinha completo via #1314).

## Test plan
- [x] TS check zero novos erros
- [ ] Smoke pós-deploy: `/sells` → toggle "Grade Avançada" → confirma coluna "Pagamento" entre "A receber" e "Status" com valores reais (Dinheiro/PIX/Cartão/...)
- [ ] Estados loading/empty mantém centralização (colSpan 11)
- [ ] Coluna ainda renderiza quando agrupado (caminho TanStack do #1314)

## Refs
- [PR #1314](https://github.com/wagnerra23/oimpresso.com/pull/1314) (commit `80bcef760`) — coluna no path TanStack
- [US-SELL-041](memory/requisitos/Sells/SPEC.md)
- [ADR 0136](memory/decisions/0136-sells-split-lista-grade-avancada.md) — Sells split

🤖 Generated with [Claude Code](https://claude.com/claude-code)