### PR TITLE
hotfix(compras): /compras summary 500 — ambiguous business_id leftJoin

### DIFF
--- a/Modules/Compras/Services/ComprasService.php
+++ b/Modules/Compras/Services/ComprasService.php
@@ -76,21 +76,24 @@ class ComprasService
      */
     public function calcularSummary(int $businessId, array $filters = []): array
     {
-        $base = Transaction::where('business_id', $businessId)
-            ->where('type', 'purchase');
+        // Tier 0 ADR 0093 — prefix `transactions.` em todas colunas pra evitar
+        // "Column 'business_id' in where clause is ambiguous" no MySQL quando
+        // leftJoin com `transaction_payments` (tabela que também tem `business_id`).
+        $base = Transaction::where('transactions.business_id', $businessId)
+            ->where('transactions.type', 'purchase');
 
         // Aplica mesmos filtros que listarCompras (q + stage) pra coerência
         if (! empty($filters['q'])) {
             $q = $filters['q'];
             $base->where(function ($w) use ($q) {
-                $w->where('ref_no', 'like', "%{$q}%");
+                $w->where('transactions.ref_no', 'like', "%{$q}%");
             });
         }
         if (! empty($filters['stage']) && $filters['stage'] !== 'all') {
-            $base->where('status', $filters['stage']);
+            $base->where('transactions.status', $filters['stage']);
         }
 
-        $total = (clone $base)->sum('final_total');
+        $total = (clone $base)->sum('transactions.final_total');
 
         $totalPago = (float) (clone $base)
             ->leftJoin('transaction_payments AS TP', 'transactions.id', '=', 'TP.transaction_id')


### PR DESCRIPTION
## Bug

Smoke prod pós-merge #1315 (15:13 UTC, ~15min atrás) detectou via Chrome MCP:
- HTML inicial `/compras`: 200 ✓
- Inertia::defer prop `kpis`: 200 ✓ ({aberto:7, transito:1, mes:0, fornec:8})
- Inertia::defer prop `rows`: 200 ✓ (1 compra real biz=1)
- **Inertia::defer prop `summary`: 500 ✗**
- Inertia::defer prop `compra_detalhe`: 200 ✓ (null)

UI mostra KPIs e tabela carregando indefinidamente porque `<Deferred>` mantém skeleton se ALGUMA prop falha.

## Causa raiz

`ComprasService::calcularSummary` faz `Transaction::where('business_id', ...)` sem prefix, depois aplica `leftJoin('transaction_payments AS TP', ...)`. Como `transaction_payments` também tem coluna `business_id` (multi-tenant canon UPos), MySQL emite `SQLSTATE[23000] 1052: Column 'business_id' in where clause is ambiguous`.

## Fix

Prefixar `transactions.` em todas colunas do `$base` query: `business_id`, `type`, `ref_no`, `status`, `final_total`. Patch mínimo (+8/-5 linhas).

## Não toca

- `calcularKpis` — não usa leftJoin
- `listarCompras` — delega `TransactionUtil::getListPurchases` que já vem com prefix canon
- `buscarDetalhe` — usa Eloquent `with()` relations

## Smoke pós-deploy

```bash
# Fetch Inertia::defer summary direto
fetch('/compras', {
  headers: { 'X-Inertia': 'true', 'X-Inertia-Version': '<v>', 'X-Inertia-Partial-Component': 'Compras/Index', 'X-Inertia-Partial-Data': 'summary' }
})
# Esperado: HTTP 200 { props: { summary: { total: N, pago: N, a_pagar: N, reembolso: N } } }
```

## Tier 0 mantido

ADR 0093 multi-tenant business_id scope preservado — só explicitando prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)