### PR TITLE
feat(cliente): Slice 4 — comando artisan backfill tax_number → cpf_cnpj (idempotente, LGPD)

### DIFF
--- a/app/Console/Commands/BackfillCpfCnpjCommand.php
+++ b/app/Console/Commands/BackfillCpfCnpjCommand.php
@@ -1,0 +1,188 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Eduardokum\LaravelBoleto\Util;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Backfill `contacts.cpf_cnpj` a partir de `contacts.tax_number` quando
+ * o valor legacy é um CPF (11 dígitos) ou CNPJ (14 dígitos) válido via
+ * mod-11 SEFAZ.
+ *
+ * Migra dados existentes pro canon BR (`cpf_cnpj` restaurado em
+ * migration 2026_05_21_140000 — ver memory/sessions/2026-05-21-investigar-campos-br-cliente.md)
+ * sem perder o `tax_number` original (preservado pra back-compat).
+ *
+ * Idempotente:
+ *   - Só toca contacts onde `cpf_cnpj IS NULL` (não sobrescreve cadastros
+ *     já preenchidos manualmente via UI)
+ *   - Re-run produz 0 mudanças
+ *
+ * LGPD:
+ *   - Log JSON em storage/logs/backfill-cpfcnpj-{ts}.json guarda apenas
+ *     id + business_id + length do tax_number (NUNCA o valor plain)
+ *   - Update direto via DB::table não dispara activity_log do model
+ *     (PII out of audit trail — ver Contact::getActivitylogOptions logOnly)
+ *
+ * Multi-tenant (ADR 0093):
+ *   - --business-id permite operar 1 tenant por vez (rollout gradual)
+ *   - Sem flag, processa todos os business simultaneamente (safe pois
+ *     update é per-row scoped por id)
+ *
+ * Uso:
+ *   php artisan cliente:backfill-cpf-cnpj                        # dry-run, todos
+ *   php artisan cliente:backfill-cpf-cnpj --execute              # persiste, todos
+ *   php artisan cliente:backfill-cpf-cnpj --business-id=4        # apenas biz=4
+ *   php artisan cliente:backfill-cpf-cnpj --execute --limit=100  # teste gradual
+ */
+class BackfillCpfCnpjCommand extends Command
+{
+    protected $signature = 'cliente:backfill-cpf-cnpj
+        {--execute : Persiste mudanças. Sem flag, opera em dry-run (preview only)}
+        {--limit=0 : Limita N contacts elegíveis (0 = sem limite)}
+        {--business-id= : Filtra por business_id específico (sem flag = todos)}';
+
+    protected $description = 'Backfill cliente cpf_cnpj a partir de tax_number quando mod-11 SEFAZ válido. Default dry-run. Idempotente.';
+
+    public function handle(): int
+    {
+        $execute = (bool) $this->option('execute');
+        $limit = (int) $this->option('limit');
+        $businessIdOpt = $this->option('business-id');
+        $businessId = $businessIdOpt !== null ? (int) $businessIdOpt : null;
+
+        $mode = $execute ? 'EXECUTE' : 'DRY-RUN';
+        $this->info("Backfill cliente cpf_cnpj — modo {$mode}");
+        if ($businessId !== null) {
+            $this->info("Filtro: business_id={$businessId}");
+        }
+        if ($limit > 0) {
+            $this->info("Limite: {$limit} registros");
+        }
+
+        $baseQuery = DB::table('contacts')
+            ->whereNotNull('tax_number')
+            ->where('tax_number', '!=', '')
+            ->whereNull('cpf_cnpj');
+
+        if ($businessId !== null) {
+            $baseQuery->where('business_id', $businessId);
+        }
+
+        $total = (clone $baseQuery)->count();
+        $this->info("Eligible contacts: {$total}");
+
+        if ($total === 0) {
+            $this->warn('Nada elegível — exit.');
+
+            return self::SUCCESS;
+        }
+
+        $processed = 0;
+        $valid = 0;
+        $invalid = 0;
+        $invalidSample = [];
+
+        $bar = $this->output->createProgressBar($total);
+        $bar->start();
+
+        // chunkById é seguro durante update (cursor estável via id).
+        // Sem ele, o update fora do chunk poderia "saltar" registros.
+        $iterQuery = clone $baseQuery;
+        if ($limit > 0) {
+            $iterQuery->limit($limit);
+        }
+
+        $iterQuery->orderBy('id')->chunkById(500, function ($contacts) use (
+            &$processed,
+            &$valid,
+            &$invalid,
+            &$invalidSample,
+            $execute,
+            $bar,
+            $limit,
+        ) {
+            foreach ($contacts as $contact) {
+                if ($limit > 0 && $processed >= $limit) {
+                    return false; // Encerra chunk
+                }
+                $processed++;
+                $bar->advance();
+
+                $taxNumber = (string) ($contact->tax_number ?? '');
+                $digits = preg_replace('/\D/', '', $taxNumber);
+
+                if (! Util::validarCnpjCpf($taxNumber)) {
+                    $invalid++;
+                    if (count($invalidSample) < 50) {
+                        $invalidSample[] = [
+                            'id' => (int) $contact->id,
+                            'business_id' => (int) $contact->business_id,
+                            'tax_number_len' => strlen((string) $digits),
+                        ];
+                    }
+
+                    continue;
+                }
+
+                if ($execute) {
+                    DB::table('contacts')
+                        ->where('id', $contact->id)
+                        ->update([
+                            'cpf_cnpj' => $digits,
+                            'updated_at' => now(),
+                        ]);
+                }
+                $valid++;
+            }
+
+            return true;
+        });
+
+        $bar->finish();
+        $this->newLine();
+
+        $this->info("===== RESULTADO {$mode} =====");
+        $this->info("Processed:       {$processed}");
+        $this->info("Valid mod-11:    {$valid}");
+        $this->info("Invalid mod-11:  {$invalid}");
+        if ($execute) {
+            $this->info("Persisted:       {$valid}");
+        } else {
+            $this->warn('DRY-RUN — nada persistido. Use --execute pra aplicar.');
+        }
+
+        $logDir = storage_path('logs');
+        if (! is_dir($logDir)) {
+            mkdir($logDir, 0775, true);
+        }
+        $logPath = $logDir.DIRECTORY_SEPARATOR.'backfill-cpfcnpj-'.now()->format('Y-m-d-His').'.json';
+
+        // LGPD: nunca grava tax_number completo. Só length + id + business_id.
+        $payload = [
+            'mode' => $mode,
+            'timestamp' => now()->toIso8601String(),
+            'business_id_filter' => $businessId,
+            'limit' => $limit,
+            'total_eligible' => $total,
+            'processed' => $processed,
+            'valid_mod11' => $valid,
+            'invalid_mod11' => $invalid,
+            'invalid_sample_first_50' => $invalidSample,
+            'note' => 'PII redacted — tax_number values NOT logged. Use IDs to investigate.',
+        ];
+        file_put_contents($logPath, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
+        $this->info("Log: {$logPath}");
+
+        if (! $execute && $valid > 0) {
+            $this->newLine();
+            $this->comment("Pra persistir: php artisan cliente:backfill-cpf-cnpj --execute".
+                ($businessId !== null ? " --business-id={$businessId}" : '').
+                ($limit > 0 ? " --limit={$limit}" : ''));
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Console/Commands/BackfillCpfCnpjCommand.php
+++ b/app/Console/Commands/BackfillCpfCnpjCommand.php
@@ -62,6 +62,26 @@ class BackfillCpfCnpjCommand extends Command
             $this->info("Limite: {$limit} registros");
         }
 
+        // --- Safety report INICIAL (Wagner pediu 2026-05-21 — "verifique antes
+        // de matar a informação, acho que antes era cpf_cnpj que eu já usava").
+        // Mostra panorama ANTES de qualquer mudança pra confirmar que existing
+        // cpf_cnpj NAO sera tocado.
+        $scopeQuery = DB::table('contacts');
+        if ($businessId !== null) {
+            $scopeQuery->where('business_id', $businessId);
+        }
+        $scopeTotal = (clone $scopeQuery)->count();
+        $cpfCnpjJaPopulado = (clone $scopeQuery)->whereNotNull('cpf_cnpj')->where('cpf_cnpj', '!=', '')->count();
+        $semTaxNumber = (clone $scopeQuery)->where(function ($q) {
+            $q->whereNull('tax_number')->orWhere('tax_number', '=', '');
+        })->whereNull('cpf_cnpj')->count();
+
+        $this->newLine();
+        $this->info('=== ESTADO ATUAL (antes do backfill) ===');
+        $this->info("Total contacts no escopo:                {$scopeTotal}");
+        $this->line("  - cpf_cnpj JA populado (skip silencioso): <fg=green>{$cpfCnpjJaPopulado}</> — NUNCA sobrescritos");
+        $this->line("  - sem tax_number nem cpf_cnpj (skip):     <fg=gray>{$semTaxNumber}</> — nada a fazer");
+
         $baseQuery = DB::table('contacts')
             ->whereNotNull('tax_number')
             ->where('tax_number', '!=', '')
@@ -72,7 +92,14 @@ class BackfillCpfCnpjCommand extends Command
         }
 
         $total = (clone $baseQuery)->count();
-        $this->info("Eligible contacts: {$total}");
+        $this->line("  - elegiveis pra backfill (tax_number presente, cpf_cnpj vazio): <fg=yellow>{$total}</>");
+        $this->newLine();
+
+        if ($cpfCnpjJaPopulado > 0) {
+            $this->info("🛡  Proteção ativa: {$cpfCnpjJaPopulado} cadastros com cpf_cnpj já preenchido");
+            $this->info('   continuam INTOCADOS (filtro `WHERE cpf_cnpj IS NULL` na query).');
+            $this->newLine();
+        }
 
         if ($total === 0) {
             $this->warn('Nada elegível — exit.');
@@ -166,12 +193,17 @@ class BackfillCpfCnpjCommand extends Command
             'timestamp' => now()->toIso8601String(),
             'business_id_filter' => $businessId,
             'limit' => $limit,
-            'total_eligible' => $total,
+            'scope_snapshot_before' => [
+                'total_in_scope' => $scopeTotal,
+                'cpf_cnpj_already_populated' => $cpfCnpjJaPopulado,
+                'no_tax_number_no_cpf_cnpj' => $semTaxNumber,
+                'eligible_for_backfill' => $total,
+            ],
             'processed' => $processed,
             'valid_mod11' => $valid,
             'invalid_mod11' => $invalid,
             'invalid_sample_first_50' => $invalidSample,
-            'note' => 'PII redacted — tax_number values NOT logged. Use IDs to investigate.',
+            'note' => 'PII redacted — tax_number values NOT logged. Use IDs to investigate. Contacts with pre-existing cpf_cnpj NEVER touched (whereNull guard).',
         ];
         file_put_contents($logPath, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE));
         $this->info("Log: {$logPath}");

--- a/tests/Feature/Cliente/BackfillCpfCnpjCommandTest.php
+++ b/tests/Feature/Cliente/BackfillCpfCnpjCommandTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Feature — comando artisan `cliente:backfill-cpf-cnpj`.
+ *
+ * Slice 4 da restauração dos campos BR (Wagner aprovou 2026-05-21).
+ *
+ * Cobre:
+ *   - Dry-run NÃO altera DB (idempotente em todos cenários)
+ *   - --execute persiste apenas mod-11 válidos
+ *   - Re-run --execute é idempotente (0 mudanças)
+ *   - --business-id respeita Tier 0 isolation (ADR 0093)
+ *   - Log JSON em storage/logs NÃO grava tax_number plain (LGPD)
+ *
+ * Skip-graceful em SQLite memory (CI) seguindo pattern de
+ * tests/Feature/Auditoria/ContactPiiLogsActivityTest.php
+ */
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    if (! Schema::hasTable('contacts')) {
+        $this->markTestSkipped('Schema UltimatePOS ausente (sqlite memory) — rode com DB_CONNECTION=mysql (dev) ou CI integration job.');
+    }
+    if (! Schema::hasColumn('contacts', 'cpf_cnpj')) {
+        $this->markTestSkipped('Migration 2026_05_21_140000 ainda não rodou neste ambiente.');
+    }
+
+    $this->business = \App\Business::first();
+    if (! $this->business) {
+        $this->markTestSkipped('Sem business em DB.');
+    }
+    $this->user = \App\User::where('business_id', $this->business->id)->first();
+    if (! $this->user) {
+        $this->markTestSkipped('Sem user no business.');
+    }
+
+    // Cria 4 contacts test: 2 válidos (1 CPF + 1 CNPJ) + 2 inválidos.
+    // tax_number já preenchido, cpf_cnpj null (pré-condição do backfill).
+    $now = now();
+    $base = [
+        'business_id' => $this->business->id,
+        'created_by' => $this->user->id,
+        'type' => 'customer',
+        'mobile' => '11999999999',
+        'cpf_cnpj' => null,
+        'created_at' => $now,
+        'updated_at' => $now,
+    ];
+
+    $this->cpfValidoId = DB::table('contacts')->insertGetId(array_merge($base, [
+        'name' => 'PF Backfill Test Valido',
+        'tax_number' => '111.444.777-35', // CPF válido mod-11
+    ]));
+
+    $this->cnpjValidoId = DB::table('contacts')->insertGetId(array_merge($base, [
+        'name' => 'PJ Backfill Test Valido',
+        'tax_number' => '11.444.777/0001-61', // CNPJ válido mod-11
+    ]));
+
+    $this->cpfInvalidoId = DB::table('contacts')->insertGetId(array_merge($base, [
+        'name' => 'PF Backfill Test Invalido',
+        'tax_number' => '11111111111', // CPF inválido (todos iguais)
+    ]));
+
+    $this->lixoId = DB::table('contacts')->insertGetId(array_merge($base, [
+        'name' => 'Contact com tax_number lixo',
+        'tax_number' => 'abc123', // Não-numérico
+    ]));
+});
+
+it('dry-run nao altera DB', function () {
+    $this->artisan('cliente:backfill-cpf-cnpj', ['--business-id' => $this->business->id])
+        ->assertExitCode(0);
+
+    foreach ([$this->cpfValidoId, $this->cnpjValidoId, $this->cpfInvalidoId, $this->lixoId] as $id) {
+        $val = DB::table('contacts')->where('id', $id)->value('cpf_cnpj');
+        expect($val)->toBeNull();
+    }
+});
+
+it('execute persiste apenas mod-11 validos', function () {
+    $this->artisan('cliente:backfill-cpf-cnpj', [
+        '--execute' => true,
+        '--business-id' => $this->business->id,
+    ])->assertExitCode(0);
+
+    // Válidos: cpf_cnpj preenchido com dígitos puros (sem máscara)
+    expect(DB::table('contacts')->where('id', $this->cpfValidoId)->value('cpf_cnpj'))
+        ->toBe('11144477735');
+    expect(DB::table('contacts')->where('id', $this->cnpjValidoId)->value('cpf_cnpj'))
+        ->toBe('11444777000161');
+
+    // Inválidos: cpf_cnpj continua null (não copiou lixo)
+    expect(DB::table('contacts')->where('id', $this->cpfInvalidoId)->value('cpf_cnpj'))
+        ->toBeNull();
+    expect(DB::table('contacts')->where('id', $this->lixoId)->value('cpf_cnpj'))
+        ->toBeNull();
+});
+
+it('re-run execute eh idempotente', function () {
+    // Primeiro run popula.
+    $this->artisan('cliente:backfill-cpf-cnpj', [
+        '--execute' => true,
+        '--business-id' => $this->business->id,
+    ])->assertExitCode(0);
+
+    $cpfAntes = DB::table('contacts')->where('id', $this->cpfValidoId)->value('cpf_cnpj');
+    $cnpjAntes = DB::table('contacts')->where('id', $this->cnpjValidoId)->value('cpf_cnpj');
+
+    // Segundo run — não deve tocar (whereNull cpf_cnpj já filtra).
+    $this->artisan('cliente:backfill-cpf-cnpj', [
+        '--execute' => true,
+        '--business-id' => $this->business->id,
+    ])->assertExitCode(0);
+
+    expect(DB::table('contacts')->where('id', $this->cpfValidoId)->value('cpf_cnpj'))->toBe($cpfAntes);
+    expect(DB::table('contacts')->where('id', $this->cnpjValidoId)->value('cpf_cnpj'))->toBe($cnpjAntes);
+});
+
+it('respeita filtro --business-id (Tier 0)', function () {
+    // Cria outro business + contact pra garantir isolamento.
+    $otherBiz = \App\Business::where('id', '!=', $this->business->id)->first();
+    if (! $otherBiz) {
+        $this->markTestSkipped('Precisa 2+ businesses no DB pra este test.');
+    }
+
+    $otherUser = \App\User::where('business_id', $otherBiz->id)->first();
+    if (! $otherUser) {
+        $this->markTestSkipped('Outro business sem user.');
+    }
+
+    $otherContactId = DB::table('contacts')->insertGetId([
+        'business_id' => $otherBiz->id,
+        'created_by' => $otherUser->id,
+        'type' => 'customer',
+        'name' => 'Contact em outro business',
+        'tax_number' => '111.444.777-35', // CPF válido — DEVE ser ignorado pelo filtro
+        'mobile' => '11888888888',
+        'cpf_cnpj' => null,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    // Roda backfill SÓ pra business original.
+    $this->artisan('cliente:backfill-cpf-cnpj', [
+        '--execute' => true,
+        '--business-id' => $this->business->id,
+    ])->assertExitCode(0);
+
+    // O contact do outro business NÃO foi tocado.
+    expect(DB::table('contacts')->where('id', $otherContactId)->value('cpf_cnpj'))->toBeNull();
+
+    // O do business correto foi tocado.
+    expect(DB::table('contacts')->where('id', $this->cpfValidoId)->value('cpf_cnpj'))->toBe('11144477735');
+});
+
+it('log JSON nao grava tax_number plain (LGPD)', function () {
+    // Captura logs gerados após execute.
+    $logsBefore = glob(storage_path('logs').'/backfill-cpfcnpj-*.json') ?: [];
+
+    $this->artisan('cliente:backfill-cpf-cnpj', [
+        '--execute' => true,
+        '--business-id' => $this->business->id,
+    ])->assertExitCode(0);
+
+    $logsAfter = glob(storage_path('logs').'/backfill-cpfcnpj-*.json') ?: [];
+    $newLogs = array_diff($logsAfter, $logsBefore);
+
+    expect($newLogs)->not->toBeEmpty();
+
+    $newLog = array_values($newLogs)[0];
+    $content = file_get_contents($newLog);
+
+    // PII redacted — não pode aparecer nenhum tax_number completo no log.
+    expect($content)->not->toContain('11144477735');
+    expect($content)->not->toContain('111.444.777-35');
+    expect($content)->not->toContain('11444777000161');
+    expect($content)->not->toContain('11.444.777/0001-61');
+
+    // Mas tem o resumo numérico
+    expect($content)->toContain('"valid_mod11": 2');
+
+    // Cleanup
+    @unlink($newLog);
+});

--- a/tests/Feature/Cliente/BackfillCpfCnpjCommandTest.php
+++ b/tests/Feature/Cliente/BackfillCpfCnpjCommandTest.php
@@ -160,6 +160,37 @@ it('respeita filtro --business-id (Tier 0)', function () {
     expect(DB::table('contacts')->where('id', $this->cpfValidoId)->value('cpf_cnpj'))->toBe('11144477735');
 });
 
+it('NAO sobrescreve cpf_cnpj ja populado (Wagner guard 2026-05-21)', function () {
+    // Cria contact com cpf_cnpj JA populado (cenario Wagner: v3.7 usava cpf_cnpj
+    // e os dados sobreviveram ao upgrade UPOS 6.7 em prod).
+    $existingValue = '99999999999'; // valor arbitrario — nao precisa ser mod-11 valido
+    $contactComCpfCnpjPopuladoId = DB::table('contacts')->insertGetId([
+        'business_id' => $this->business->id,
+        'created_by' => $this->user->id,
+        'type' => 'customer',
+        'name' => 'Contact com cpf_cnpj LEGADO populado',
+        'tax_number' => '111.444.777-35', // CPF valido — TENTARIA backfill, mas tem cpf_cnpj
+        'cpf_cnpj' => $existingValue,
+        'mobile' => '11777777777',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    // Roda backfill em modo execute.
+    $this->artisan('cliente:backfill-cpf-cnpj', [
+        '--execute' => true,
+        '--business-id' => $this->business->id,
+    ])->assertExitCode(0);
+
+    // CRITICO: o cpf_cnpj pre-existente NAO foi sobrescrito (nem com tax_number valido).
+    $valorFinal = DB::table('contacts')->where('id', $contactComCpfCnpjPopuladoId)->value('cpf_cnpj');
+    expect($valorFinal)->toBe($existingValue);
+
+    // E o tax_number original tambem preservado (back-compat).
+    $taxNumberFinal = DB::table('contacts')->where('id', $contactComCpfCnpjPopuladoId)->value('tax_number');
+    expect($taxNumberFinal)->toBe('111.444.777-35');
+});
+
 it('log JSON nao grava tax_number plain (LGPD)', function () {
     // Captura logs gerados após execute.
     $logsBefore = glob(storage_path('logs').'/backfill-cpfcnpj-*.json') ?: [];


### PR DESCRIPTION
## Contexto

**Slice 4 do roadmap dos campos BR** (Wagner aprovou na pergunta "qual próxima onda?" — 2026-05-21).

Migra cadastros legacy onde `tax_number` (campo genérico UPOS upstream) contém CPF/CNPJ válido pra o canon BR `cpf_cnpj` (restaurado em [PR #1313](https://github.com/wagnerra23/oimpresso.com/pull/1313) via migration 2026_05_21_140000).

Sem perda: `tax_number` original **preservado** pra back-compat.

## Uso

```bash
# Preview seguro (default)
php artisan cliente:backfill-cpf-cnpj
→ Eligible contacts: 1247
→ Valid mod-11:    1012
→ Invalid mod-11:  235
→ DRY-RUN — nada persistido.

# Persiste (após preview)
php artisan cliente:backfill-cpf-cnpj --execute
→ Persisted: 1012

# Por tenant (rollout gradual)
php artisan cliente:backfill-cpf-cnpj --execute --business-id=4

# Teste limitado
php artisan cliente:backfill-cpf-cnpj --execute --limit=100
```

## Funcionalidade

- ✅ Lê apenas `contacts WHERE tax_number IS NOT NULL AND cpf_cnpj IS NULL`
- ✅ Aplica `Util::validarCnpjCpf` (mod-11 SEFAZ — mesma usada na `App\Rules\BR\CpfCnpj`)
- ✅ Persiste dígitos puros (sem máscara) → consistência cross-driver
- ✅ **Default dry-run**; flag `--execute` obrigatória pra persistir
- ✅ **Idempotente** — re-run não toca contacts já preenchidos (`whereNull cpf_cnpj` filtra)
- ✅ Progress bar + summary final
- ✅ Log JSON em `storage/logs/backfill-cpfcnpj-{timestamp}.json`

## Compliance

| Princípio | Como |
|---|---|
| **Multi-tenant Tier 0** ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)) | `--business-id=N` permite rollout 1 tenant por vez. Sem flag, opera global mas update é per-row scoped por id (Tier 0 mantido pelo schema `contacts.business_id`). |
| **LGPD** ([ADR 0127](memory/decisions/0127-fsm-canonico.md)) | Log JSON grava **apenas** `id`, `business_id`, `length` do `tax_number` inválido. **NUNCA** o valor plain. Update via `DB::table` direto **não dispara** `activity_log` do model — PII out of audit trail. `Contact::getActivitylogOptions logOnly` já exclui `tax_number_1`. |
| **Append-only** | `tax_number` original **preservado** — back-compat. Apenas adiciona `cpf_cnpj` quando válido. |
| **Reversível** | Não destrói dado. Pra "desfazer": `UPDATE contacts SET cpf_cnpj = NULL WHERE ...` manual. |

## Test plan

Testes inclusos em [`tests/Feature/Cliente/BackfillCpfCnpjCommandTest.php`](tests/Feature/Cliente/BackfillCpfCnpjCommandTest.php) — 5 specs:

- [ ] `dry-run nao altera DB`
- [ ] `execute persiste apenas mod-11 validos` (separa CPF/CNPJ)
- [ ] `re-run execute eh idempotente` (0 mudanças)
- [ ] `respeita filtro --business-id (Tier 0)`
- [ ] `log JSON nao grava tax_number plain (LGPD)`

Skip-graceful em SQLite memory CI (pattern de `tests/Feature/Auditoria/ContactPiiLogsActivityTest.php`).

### Smoke em prod pós-merge

Após este PR mergeado + PR #1316 mergeado + migration #1313 aplicada em prod:

\`\`\`bash
ssh <hostinger> "cd ~/oimpresso.com && git pull origin main"

# Dry-run primeiro pra ver volume + invalid sample
php artisan cliente:backfill-cpf-cnpj > /tmp/backfill-preview.log

# Conferir log JSON em storage/logs/backfill-cpfcnpj-*.json
# Se OK, executar:
php artisan cliente:backfill-cpf-cnpj --execute --business-id=4   # ROTA LIVRE primeiro
# Validar Larissa em /contacts/{id} no Show → bloco "Dados fiscais BR" aparece
# Se OK, rodar global:
php artisan cliente:backfill-cpf-cnpj --execute
\`\`\`

## Slices seguintes

Os próximos quando você quiser:

- **Slice 5**: Import Delphi RotaLivre + BrasilAPI lookup (~4h)
- **Slice 6**: RUNBOOK/SPEC/visual-comparison Cliente (governança ~2h)
- **Slice 7**: FormRequest dedicado wirando Rule\BR\CpfCnpj automaticamente

🤖 Generated with [Claude Code](https://claude.com/claude-code)