### PR TITLE
feat(sells): botão "Pagar" inline na linha (Lista + Grade Avançada) US-SELL-042

### DIFF
--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -21,6 +21,7 @@ import {
   Archive,
   CheckCircle2,
   ChevronDown,
+  DollarSign,
   FileText,
   Folder,
   Plus,
@@ -30,6 +31,7 @@ import {
   X,
 } from 'lucide-react';
 import SaleSheet from './_components/SaleSheet';
+import QuickPaymentDialog from './_components/QuickPaymentDialog';
 // PR follow-up Cowork — filtros legacy reintegrados via barra colapsável "Filtros avançados ▾".
 // Refs: Index.charter.md v2 Goals · feedback-design-literal-copy §How to apply #5.
 import SellsDateFilter, {
@@ -643,6 +645,11 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
 
   // Refetch trigger (independente de filtros) — disparado por onSaleChanged do drawer.
   const [refetchToken, setRefetchToken] = useState(0);
+
+  // US-SELL-042 — Larissa @ ROTA LIVRE biz=4 (ADR 0105) pediu 2026-05-21
+  // "adicionar pagamentos como antigamente" (botão direto na linha sem abrir
+  // drawer). Estado do modal QuickPayment compartilhado entre Lista e Grade.
+  const [payDialog, setPayDialog] = useState<{ saleId: number; invoiceNo: string; dueAmount: number } | null>(null);
 
   // UI overlays.
   const [cheatOpen, setCheatOpen] = useState(false);
@@ -1328,6 +1335,7 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
               onSort={handleSort}
               groupBy={groupBy}
               onGroupByChange={setGroupBy}
+              onPayClick={(saleId, invoiceNo, dueAmount) => setPayDialog({ saleId, invoiceNo, dueAmount })}
             />
           </div>
         ) : (
@@ -1467,6 +1475,23 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
                           {ps.label}
                         </span>
                         <div className="vd-row-actions" onClick={(e) => e.stopPropagation()}>
+                          {/* US-SELL-042 — botão "Pagar" inline (sem abrir drawer) pra
+                              vendas com saldo devedor. Equivalente ao "Add Payment" do
+                              UltimatePOS Blade legacy que Larissa biz=4 sentiu falta. */}
+                          {v.payment_status !== 'paid' && (
+                            <button
+                              className="vd-row-act"
+                              title="Registrar pagamento"
+                              type="button"
+                              onClick={() => setPayDialog({
+                                saleId: v.id,
+                                invoiceNo: v.invoice_no,
+                                dueAmount: Math.max(0, v.final_total - v.total_paid),
+                              })}
+                            >
+                              <DollarSign size={11} />
+                            </button>
+                          )}
                           {v.fiscal_status === 'autorizada' && (
                             <button className="vd-row-act" title="Baixar DANFE PDF" type="button">
                               <Archive size={11} />
@@ -1721,6 +1746,17 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
         }}
         onSaleChanged={() => setRefetchToken((t) => t + 1)}
         initialAiOpen={aiTriggered}
+      />
+
+      {/* US-SELL-042 — modal "Registrar pagamento" inline (atalho rápido sem
+          abrir o drawer). Lista e Grade Avançada disparam via setPayDialog. */}
+      <QuickPaymentDialog
+        saleId={payDialog?.saleId ?? null}
+        invoiceNo={payDialog?.invoiceNo ?? ''}
+        dueAmount={payDialog?.dueAmount ?? 0}
+        open={payDialog !== null}
+        onClose={() => setPayDialog(null)}
+        onSuccess={() => setRefetchToken((t) => t + 1)}
       />
     </div>
   );

--- a/resources/js/Pages/Sells/_components/QuickPaymentDialog.tsx
+++ b/resources/js/Pages/Sells/_components/QuickPaymentDialog.tsx
@@ -1,0 +1,216 @@
+// QuickPaymentDialog — Modal pra registrar pagamento rápido inline na linha da
+// listagem de vendas. Reusa o endpoint POST /sells/{id}/quick-payment que já
+// alimenta o "Adicionar pagamento" inline do SaleSheet (drawer), evitando
+// duplicação. Larissa @ ROTA LIVRE biz=4 pediu 2026-05-21 "adicionar
+// pagamentos como antigamente" (UltimatePOS Blade legacy tinha botão "Add
+// Payment" na linha) — ADR 0105 sinal qualificado.
+//
+// Refs:
+//  - SaleSheet.tsx linhas 195-276 (padrão original do form inline)
+//  - ADR 0093 multi-tenant Tier 0 (saleId vem do payload do tenant logado)
+
+import { useEffect, useState, type FormEvent } from 'react';
+import { CheckCircle2, Loader2, X } from 'lucide-react';
+import { Button } from '@/Components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/Components/ui/dialog';
+import { Input } from '@/Components/ui/input';
+import { Label } from '@/Components/ui/label';
+import { Textarea } from '@/Components/ui/textarea';
+
+// Mesma fonte canônica de SaleSheet (UltimatePOS armazena chaves curtas
+// custom_pay_1=PIX/custom_pay_2=Boleto/custom_pay_3=Crediário — labels PT-BR
+// no SellController::inertiaList match cases linha 1287-1298).
+const PAYMENT_METHODS_OPTIONS = [
+  { value: 'cash', label: 'Dinheiro' },
+  { value: 'custom_pay_1', label: 'PIX' },
+  { value: 'card', label: 'Cartão' },
+  { value: 'bank_transfer', label: 'Transferência' },
+  { value: 'custom_pay_2', label: 'Boleto' },
+  { value: 'cheque', label: 'Cheque' },
+  { value: 'other', label: 'Outros' },
+];
+
+const todayISO = () => new Date().toISOString().slice(0, 10);
+
+function getCsrfToken(): string {
+  const meta = document.querySelector('meta[name="csrf-token"]');
+  return meta?.getAttribute('content') ?? '';
+}
+
+const formatBRL = (value: number) =>
+  new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
+
+interface QuickPaymentDialogProps {
+  saleId: number | null;
+  invoiceNo: string;
+  dueAmount: number;
+  open: boolean;
+  onClose: () => void;
+  onSuccess: () => void;
+}
+
+export default function QuickPaymentDialog({
+  saleId,
+  invoiceNo,
+  dueAmount,
+  open,
+  onClose,
+  onSuccess,
+}: QuickPaymentDialogProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const [paymentError, setPaymentError] = useState<string | null>(null);
+  const [draft, setDraft] = useState({
+    amount: dueAmount > 0 ? dueAmount.toFixed(2) : '',
+    method: 'custom_pay_1',
+    paid_on: todayISO(),
+    note: '',
+  });
+
+  // Reseta o draft toda vez que o modal abre — evita carregar valor de outra
+  // venda quando o user fechou sem submeter e abriu em outra linha.
+  useEffect(() => {
+    if (open) {
+      setDraft({
+        amount: dueAmount > 0 ? dueAmount.toFixed(2) : '',
+        method: 'custom_pay_1',
+        paid_on: todayISO(),
+        note: '',
+      });
+      setPaymentError(null);
+    }
+  }, [open, dueAmount]);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!saleId) return;
+    setSubmitting(true);
+    setPaymentError(null);
+    try {
+      const res = await fetch(`/sells/${saleId}/quick-payment`, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'X-Requested-With': 'XMLHttpRequest',
+          'X-CSRF-TOKEN': getCsrfToken(),
+        },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+          amount: Number(draft.amount.replace(',', '.')),
+          method: draft.method,
+          paid_on: draft.paid_on,
+          note: draft.note || null,
+        }),
+      });
+      const json = await res.json();
+      if (!res.ok || !json.success) {
+        const validation = json.errors
+          ? Object.values(json.errors).flat().join(' · ')
+          : json.msg || 'Falha ao registrar pagamento.';
+        setPaymentError(validation);
+        return;
+      }
+      onSuccess();
+      onClose();
+    } catch (err) {
+      setPaymentError(String((err as Error)?.message || err));
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-base">Registrar pagamento</DialogTitle>
+          <DialogDescription className="text-xs text-muted-foreground">
+            Venda #{invoiceNo} · saldo devedor{' '}
+            <span className="font-medium text-foreground tabular-nums">{formatBRL(dueAmount)}</span>
+          </DialogDescription>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <Label htmlFor="qpd-amount" className="text-xs">Valor</Label>
+              <Input
+                id="qpd-amount"
+                type="text"
+                inputMode="decimal"
+                value={draft.amount}
+                onChange={(e) => setDraft({ ...draft, amount: e.target.value })}
+                placeholder="0,00"
+                required
+                autoFocus
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="qpd-method" className="text-xs">Forma</Label>
+              <select
+                id="qpd-method"
+                value={draft.method}
+                onChange={(e) => setDraft({ ...draft, method: e.target.value })}
+                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm"
+              >
+                {PAYMENT_METHODS_OPTIONS.map((m) => (
+                  <option key={m.value} value={m.value}>{m.label}</option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="qpd-date" className="text-xs">Data</Label>
+            <Input
+              id="qpd-date"
+              type="date"
+              value={draft.paid_on}
+              onChange={(e) => setDraft({ ...draft, paid_on: e.target.value })}
+              required
+            />
+          </div>
+          <div className="space-y-1.5">
+            <Label htmlFor="qpd-note" className="text-xs">Observação (opcional)</Label>
+            <Textarea
+              id="qpd-note"
+              value={draft.note}
+              onChange={(e) => setDraft({ ...draft, note: e.target.value })}
+              rows={2}
+              className="text-sm"
+            />
+          </div>
+          {paymentError && (
+            <div className="rounded-md bg-rose-50 border border-rose-200 dark:bg-rose-950/40 dark:border-rose-900/40 px-2.5 py-2 text-xs text-rose-700 dark:text-rose-300">
+              {paymentError}
+            </div>
+          )}
+          <div className="flex items-center justify-end gap-2 pt-1">
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={onClose}
+              disabled={submitting}
+            >
+              <X size={14} className="mr-1" />
+              Cancelar
+            </Button>
+            <Button type="submit" size="sm" disabled={submitting || !draft.amount}>
+              {submitting ? (
+                <Loader2 size={14} className="mr-1 animate-spin" />
+              ) : (
+                <CheckCircle2 size={14} className="mr-1" />
+              )}
+              Registrar
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx
+++ b/resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx
@@ -20,6 +20,7 @@ import { useMemo, useState } from 'react';
 import {
   AlertTriangle, ArrowDown, ArrowUp, ArrowUpDown,
   ChevronDown, ChevronRight,
+  DollarSign,
   Layers, Loader2,
 } from 'lucide-react';
 import {
@@ -119,6 +120,10 @@ interface SellsGradeAvancadaProps {
   // US-SELL-019 — agrupamento (state lifted up).
   groupBy: GroupByField;
   onGroupByChange: (g: GroupByField) => void;
+  // US-SELL-042 — botão "Pagar" inline (opcional: views que querem expor a
+  // ação rápida de registrar pagamento sem abrir o drawer). Quando ausente,
+  // a coluna Ações simplesmente não renderiza o botão.
+  onPayClick?: (saleId: number, invoiceNo: string, dueAmount: number) => void;
 }
 
 const formatBRL = (value: number) =>
@@ -181,6 +186,7 @@ export default function SellsGradeAvancada({
   onSort,
   groupBy,
   onGroupByChange,
+  onPayClick,
 }: SellsGradeAvancadaProps) {
   const allRowsSelected = useMemo(() => {
     if (rows.length === 0) return false;
@@ -298,19 +304,21 @@ export default function SellsGradeAvancada({
                 {/* US-SELL-023 — coluna "Produção" badge FSM (Grade Avançada only,
                     Lista mode é enxuto e não mostra esta coluna). Default visível. */}
                 <Th className="w-32">Produção</Th>
+                {/* US-SELL-042 — coluna "Ações" rápidas (só renderiza se onPayClick passado). */}
+                {onPayClick && <Th className="w-12 text-center">·</Th>}
               </tr>
             </thead>
             <tbody>
               {loading ? (
                 <tr>
-                  <td colSpan={11} className="text-center py-12 text-muted-foreground text-xs">
+                  <td colSpan={onPayClick ? 12 : 11} className="text-center py-12 text-muted-foreground text-xs">
                     <Loader2 className="inline-block mr-2 h-3.5 w-3.5 animate-spin" />
                     Carregando…
                   </td>
                 </tr>
               ) : rows.length === 0 ? (
                 <tr>
-                  <td colSpan={11} className="text-center py-12 text-muted-foreground text-xs">
+                  <td colSpan={onPayClick ? 12 : 11} className="text-center py-12 text-muted-foreground text-xs">
                     Nenhuma venda encontrada nesse filtro.
                   </td>
                 </tr>
@@ -384,6 +392,23 @@ export default function SellsGradeAvancada({
                       <td className="px-3 py-2.5">
                         <ProducaoStageBadge stageKey={row.current_stage_key} />
                       </td>
+                      {/* US-SELL-042 — botão "Pagar" inline (Larissa biz=4 ADR 0105).
+                          Só renderiza pra vendas com saldo devedor. stopPropagation
+                          evita abrir o drawer ao clicar. */}
+                      {onPayClick && (
+                        <td className="px-2 py-2.5 text-center" onClick={(e) => e.stopPropagation()}>
+                          {row.payment_status !== 'paid' && (
+                            <button
+                              type="button"
+                              title="Registrar pagamento"
+                              onClick={() => onPayClick(row.id, row.invoice_no, Math.max(0, row.final_total - row.total_paid))}
+                              className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border bg-background hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                            >
+                              <DollarSign size={13} />
+                            </button>
+                          )}
+                        </td>
+                      )}
                     </tr>
                   );
                 })


### PR DESCRIPTION
## Summary
Larissa @ ROTA LIVRE biz=4 pediu via Wagner 2026-05-21 *"adicionar pagamentos como antigamente"* — sinal qualificado [ADR 0105](memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md). UltimatePOS Blade legacy tinha botão **"Add Payment"** inline na linha permitindo registrar pagamento sem abrir o detalhe da venda. Reintroduzimos isso reutilizando o endpoint `POST /sells/{id}/quick-payment` que já existe (alimentando hoje o "Adicionar pagamento" do `SaleSheet` drawer linhas 195-276) — **zero mudança backend**.

## Diff (3 arquivos, 279+/2-)

| Arquivo | Mudança |
|---|---|
| `_components/QuickPaymentDialog.tsx` (novo, ~195 LOC) | Modal standalone (shadcn Dialog) — form valor/forma/data/observação + 7 métodos PT-BR (mesma fonte canon que SaleSheet: Dinheiro/PIX/Cartão/Transferência/Boleto/Cheque/Outros) + POST `/sells/{id}/quick-payment` com CSRF + callback `onSuccess` pra refetch |
| `Sells/Index.tsx` | Botão `DollarSign` 11px em `vd-row-actions` (entre status badge e DANFE/XML/Imprimir), render condicional `payment_status !== 'paid'`. `stopPropagation` evita abrir drawer. Render do dialog ao final do JSX. |
| `SellsGradeAvancada.tsx` | Prop opcional `onPayClick`. Nova coluna "Ações" ao final (após Produção) — só renderiza se prop passado. Botão 7×7 `DollarSign`, mesmo guard de saldo. `colSpan` loading/empty adapta 11↔12. |

## Comportamento
- **Lista**: botão `$` aparece ao lado de DANFE/XML/Imprimir só pra vendas pendentes
- **Grade Avançada (default sem agrupamento)**: coluna `·` final com botão `$`
- Click → modal abre com `amount` pré-preenchido com saldo devedor, `method` default PIX, `paid_on` hoje
- Submit → POST → server cria `transaction_payments` (UltimatePOS core) + Listener `OnCobrancaPagaCreateFinanceiroTitulo` cria/atualiza `fin_titulos` (bridge Financeiro)
- `onSuccess` → `setRefetchToken` → listagem refresca com `payment_method_label` e `total_paid` atualizados

## Test plan
- [x] TS check: zero erros novos
- [ ] Smoke real biz=1 pós-merge (skill `smoke-prod-evidence`):
  1. `/sells` Lista → linha com saldo devedor → clica `$` → modal abre com valor pré-preenchido
  2. Submit `R$ 50,00` PIX → modal fecha → linha refresca mostrando `Dinheiro|PIX|Cartão` na coluna PAGAMENTO + `total_paid` aumentou
  3. Toggle Grade Avançada → confirma coluna "·" final → mesmo fluxo OK
  4. Venda já paga (`payment_status='paid'`): botão **NÃO** aparece (guard funciona)
  5. DevTools → Network → POST `/sells/{id}/quick-payment` status 200 + body `{success: true}`

## Não cobre
- Path Grade Avançada **com agrupamento** (TanStack GroupedTable): scope enxuto (`commit-discipline` 1 PR = 1 intent). Larissa usa default sem agrupamento. PR follow-up se sinal posterior.
- Action menu / right-click context: cogitar em redesign maior se for spawnar US-SELL-043 unificar Lista+Grade.

## Refs
- [US-SELL-042](memory/requisitos/Sells/SPEC.md)
- `SaleSheet.tsx:195-276` — padrão original do form inline (replica DRY no Dialog)
- `SellController` endpoint `quick-payment` — payload `{amount, method, paid_on, note?}`
- Listener `OnCobrancaPagaCreateFinanceiroTitulo` — bridge `transaction_payments → fin_titulos`
- [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md) (Tier 0 intocado), [ADR 0105](memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) (cliente-sinal), [ADR 0094](memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md) (commit-discipline)

🤖 Generated with [Claude Code](https://claude.com/claude-code)