### PR TITLE
fix(tests): UserFactory campos canônicos UPos — drop coluna name inexistente

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -28,10 +28,17 @@ class UserFactory extends Factory
     {
         static $password;
 
+        // Schema UltimatePOS — sem coluna `name`. Surname é título (CHAR(10)
+        // em 2018_02_26_130519_modify_users_table_for_sales_cmmsn_agnt),
+        // first_name/last_name carregam o nome real.
         return [
-            'name' => $this->faker->name(),
+            'surname' => 'Mr',
+            'first_name' => $this->faker->firstName(),
+            'last_name' => $this->faker->lastName(),
+            'username' => $this->faker->unique()->userName(),
             'email' => $this->faker->unique()->safeEmail(),
             'password' => $password ?: $password = Hash::make('secret'),
+            'language' => 'en',
             'remember_token' => Str::random(10),
         ];
     }


### PR DESCRIPTION
## Summary

- Schema UltimatePOS `users` **não tem coluna `name`** — usa `surname` (CHAR(10) = titulo Mr./Mrs.) + `first_name` + `last_name` + `username` UNIQUE
- Factory legada gerava `'name' => $faker->name()` → `SQLSTATE[42S22] Unknown column 'name'` em qualquer test que rodasse `User::factory()->create()` contra MySQL
- Bug detectado pela Lane C Compras (2026-05-21) ao smoke `ComprasIndexTest`

## Diff

```diff
-            'name' => $this->faker->name(),
+            'surname' => 'Mr',
+            'first_name' => $this->faker->firstName(),
+            'last_name' => $this->faker->lastName(),
+            'username' => $this->faker->unique()->userName(),
             'email' => $this->faker->unique()->safeEmail(),
             'password' => $password ?: $password = Hash::make('secret'),
+            'language' => 'en',
             'remember_token' => Str::random(10),
```

## Validações

- [x] `php -l database/factories/UserFactory.php` — no syntax errors
- [x] Cross-check colunas vs `database/migrations/2014_10_12_000000_create_users_table.php` + `2018_02_26_130519_modify_users_table_for_sales_cmmsn_agnt.php` (surname CHAR(10) → fixei `'Mr'` 2 chars)
- [x] `User::factory()->raw()` em script ad-hoc — 9 fields canônicos, zero `name`
- [x] `User::factory()->create(['business_id' => 1])` real contra MySQL `oimpresso` local — INSERT OK, count 99→100, cleanup hard-delete OK
- [x] `grep "User::factory()->create(\[.*'name'"` — zero callers passam `name` explícito → remoção safe
- [x] 6 tests usam factory (`Modules/Compras`, `Modules/Financeiro`, `Modules/PaymentGateway`) — todos só passam `business_id` + opcionalmente `username` (uniqid), nenhum quebra

## Não validado neste PR (e por quê)

`php artisan test --filter=Compras` local falha em **pre-existing infra issues** não relacionados ao fix:
- `ComprasIndexTest` não usa `RefreshDatabase` → quebra em `Permission::firstOrCreate` linha 28 antes de chegar no factory
- Migration `2018_01_08_123327_modify_transactions_table_for_expenses.php` usa `ALTER TABLE ... MODIFY COLUMN` (MySQL-only) → incompatível com SQLite `:memory:` do `phpunit.xml`
- Constantes/funções redeclaradas entre `tests/Feature/Sells/` e `tests/Feature/Purchase/` Wave1/Wave2 EditBaselineTest

São bugs separados — não impactados por este PR. Validação real do fix foi feita via INSERT contra MySQL dev local.

## Test plan

- [ ] CI rodar Pest Compras suite contra MySQL CI — verificar `ComprasIndexTest` agora chega no factory sem erro de schema
- [ ] Smoke local de uma Lane que use `User::factory()->create()` direto contra `oimpresso` dev DB

## Refs

- Lane C report Compras (sessão 2026-05-21)
- Schema UPos canônico — `database/migrations/2014_10_12_000000_create_users_table.php`
- Hotfix relacionado: #1318