### PR TITLE
feat(cliente): Slice 7 — FormRequest wirando Rule\BR\CpfCnpj no backend

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -22,6 +22,8 @@ use Illuminate\Http\Request;
 use Spatie\Activitylog\Models\Activity;
 use Yajra\DataTables\Facades\DataTables;
 use App\Events\ContactCreatedOrModified;
+use App\Http\Requests\Cliente\StoreContactRequest;
+use App\Http\Requests\Cliente\UpdateContactRequest;
 use Inertia\Inertia;
 
 class ContactController extends Controller
@@ -910,10 +912,14 @@ class ContactController extends Controller
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * Slice 7 — type-hint StoreContactRequest wira App\Rules\BR\CpfCnpj +
+     * regras canon BR (indicador_ie 1/2/9, regime simples/presumido/real/mei).
+     * Authorize já roda no FormRequest; abort(403) abaixo é defensividade legacy.
+     *
+     * @param  \App\Http\Requests\Cliente\StoreContactRequest  $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request)
+    public function store(StoreContactRequest $request)
     {
         if (! auth()->user()->can('supplier.create') && ! auth()->user()->can('customer.create') && ! auth()->user()->can('customer.view_own') && ! auth()->user()->can('supplier.view_own')) {
             abort(403, 'Unauthorized action.');
@@ -1358,11 +1364,16 @@ class ContactController extends Controller
     /**
      * Update the specified resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * Slice 7 — type-hint UpdateContactRequest wira App\Rules\BR\CpfCnpj.
+     * Cobre o path legacy (isLegacyAjax) e o futuro Inertia — validação roda
+     * antes da action, antes do branch isLegacyAjax. Authorize duplo (FormRequest
+     * + abort manual) por defensividade durante migração Wave 1.
+     *
+     * @param  \App\Http\Requests\Cliente\UpdateContactRequest  $request
      * @param  int  $id
      * @return \Illuminate\Http\Response
      */
-    public function update(Request $request, $id)
+    public function update(UpdateContactRequest $request, $id)
     {
         if (! auth()->user()->can('supplier.update') && ! auth()->user()->can('customer.update') && ! auth()->user()->can('customer.view_own') && ! auth()->user()->can('supplier.view_own')) {
             abort(403, 'Unauthorized action.');

--- a/app/Http/Requests/Cliente/StoreContactRequest.php
+++ b/app/Http/Requests/Cliente/StoreContactRequest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Cliente;
+
+use App\Rules\BR\CpfCnpj;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validação canon BR pra criação de cliente/fornecedor.
+ *
+ * Slice 7 — wira App\Rules\BR\CpfCnpj automaticamente em
+ * App\Http\Controllers\ContactController@store(StoreContactRequest $request).
+ *
+ * Antes deste FormRequest:
+ *   - `$request->only(['cpf_cnpj', 'indicador_ie', 'regime', ...])` aceitava qualquer string.
+ *   - A Rule existia mas era zero-usada (investigação 2026-05-21).
+ *
+ * Depois:
+ *   - cpf_cnpj passa por mod-11 SEFAZ (Eduardokum\LaravelBoleto\Util vendored).
+ *   - indicador_ie só aceita 1 (contribuinte) / 2 (isento) / 9 (não contribuinte) per layout SEFAZ.
+ *   - regime restrito a simples/presumido/real/mei.
+ *
+ * Authorize delega às permissions Spatie existentes — manter compat com
+ * legacy abort(403) no controller (defensividade dupla).
+ *
+ * LGPD (ADR 0127): mensagens NÃO ecoam o valor recebido — só descrevem o gabarito.
+ *
+ * Refs:
+ *   - memory/sessions/2026-05-21-investigar-campos-br-cliente.md
+ *   - ADR 0093 (multi-tenant Tier 0)
+ *   - ADR 0127 (LGPD redact em logs)
+ */
+class StoreContactRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+
+        if ($user === null) {
+            return false;
+        }
+
+        return $user->can('supplier.create')
+            || $user->can('customer.create')
+            || $user->can('customer.view_own')
+            || $user->can('supplier.view_own');
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            // Campos BR canon (Slice 1 migration 2026_05_21_140000).
+            'cpf_cnpj' => ['nullable', new CpfCnpj],
+            'rg' => ['nullable', 'string', 'max:20'],
+            'inscricao_estadual' => ['nullable', 'string', 'max:30'],
+            'inscricao_municipal' => ['nullable', 'string', 'max:30'],
+            'indicador_ie' => ['nullable', 'integer', 'in:1,2,9'],
+            'nome_fantasia' => ['nullable', 'string', 'max:150'],
+            'consumidor_final' => ['nullable', 'boolean'],
+            'contribuinte' => ['nullable', 'boolean'],
+            'regime' => ['nullable', 'string', 'in:simples,presumido,real,mei'],
+            'suframa' => ['nullable', 'string', 'max:20'],
+
+            // Campos UPOS upstream — manter compat com $request->only() do controller.
+            // Validação suave (nullable) — sem regressão pra fluxos legacy.
+            'type' => ['nullable', 'string', 'in:customer,supplier,both,lead'],
+            'tax_number' => ['nullable', 'string', 'max:255'],
+            'email' => ['nullable', 'email', 'max:120'],
+            'mobile' => ['nullable', 'string', 'max:50'],
+            'landline' => ['nullable', 'string', 'max:50'],
+            'alternate_number' => ['nullable', 'string', 'max:50'],
+            'first_name' => ['nullable', 'string', 'max:255'],
+            'middle_name' => ['nullable', 'string', 'max:255'],
+            'last_name' => ['nullable', 'string', 'max:255'],
+            'supplier_business_name' => ['nullable', 'string', 'max:255'],
+            'prefix' => ['nullable', 'string', 'max:20'],
+            'address_line_1' => ['nullable', 'string', 'max:255'],
+            'address_line_2' => ['nullable', 'string', 'max:255'],
+            'city' => ['nullable', 'string', 'max:255'],
+            'state' => ['nullable', 'string', 'max:255'],
+            'country' => ['nullable', 'string', 'max:255'],
+            'zip_code' => ['nullable', 'string', 'max:20'],
+            'contact_id' => ['nullable', 'string', 'max:255'],
+            'customer_group_id' => ['nullable', 'integer'],
+            'shipping_address' => ['nullable', 'string'],
+            'position' => ['nullable', 'string', 'max:255'],
+            'dob' => ['nullable', 'string', 'max:32'],
+            'pay_term_number' => ['nullable', 'integer'],
+            'pay_term_type' => ['nullable', 'string', 'in:days,months'],
+        ];
+    }
+
+    /**
+     * Mensagens custom — sem echo do valor recebido (LGPD ADR 0127).
+     *
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'cpf_cnpj' => 'O CPF/CNPJ informado não é válido (verificação mod-11 SEFAZ).',
+            'indicador_ie.in' => 'Indicador IE deve ser 1 (contribuinte), 2 (isento) ou 9 (não contribuinte).',
+            'regime.in' => 'Regime tributário deve ser: simples, presumido, real ou mei.',
+            'email.email' => 'Informe um e-mail válido.',
+            'type.in' => 'Tipo de contato deve ser: customer, supplier, both ou lead.',
+        ];
+    }
+}

--- a/app/Http/Requests/Cliente/UpdateContactRequest.php
+++ b/app/Http/Requests/Cliente/UpdateContactRequest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Requests\Cliente;
+
+use App\Rules\BR\CpfCnpj;
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * Validação canon BR pra atualização de cliente/fornecedor.
+ *
+ * Slice 7 — wira App\Rules\BR\CpfCnpj em
+ * App\Http\Controllers\ContactController@update(UpdateContactRequest $request, $id).
+ *
+ * Mesmas rules do Store; apenas authorize muda (permissions de update).
+ *
+ * Cobre os dois paths do controller:
+ *   - isLegacyAjax() (POST `/contacts/{id}` legacy)
+ *   - Path Inertia (post `/contacts/{id}` SPA)
+ * Como FormRequest valida ANTES da action, ambos passam pela mesma rede.
+ *
+ * Refs:
+ *   - memory/sessions/2026-05-21-investigar-campos-br-cliente.md
+ *   - ADR 0093 (multi-tenant Tier 0)
+ *   - ADR 0127 (LGPD redact em logs)
+ */
+class UpdateContactRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+
+        if ($user === null) {
+            return false;
+        }
+
+        return $user->can('supplier.update')
+            || $user->can('customer.update')
+            || $user->can('customer.view_own')
+            || $user->can('supplier.view_own');
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            // Campos BR canon (Slice 1 migration 2026_05_21_140000).
+            'cpf_cnpj' => ['nullable', new CpfCnpj],
+            'rg' => ['nullable', 'string', 'max:20'],
+            'inscricao_estadual' => ['nullable', 'string', 'max:30'],
+            'inscricao_municipal' => ['nullable', 'string', 'max:30'],
+            'indicador_ie' => ['nullable', 'integer', 'in:1,2,9'],
+            'nome_fantasia' => ['nullable', 'string', 'max:150'],
+            'consumidor_final' => ['nullable', 'boolean'],
+            'contribuinte' => ['nullable', 'boolean'],
+            'regime' => ['nullable', 'string', 'in:simples,presumido,real,mei'],
+            'suframa' => ['nullable', 'string', 'max:20'],
+
+            // Campos UPOS upstream — validação suave nullable pra preservar compat.
+            'type' => ['nullable', 'string', 'in:customer,supplier,both,lead'],
+            'tax_number' => ['nullable', 'string', 'max:255'],
+            'email' => ['nullable', 'email', 'max:120'],
+            'mobile' => ['nullable', 'string', 'max:50'],
+            'landline' => ['nullable', 'string', 'max:50'],
+            'alternate_number' => ['nullable', 'string', 'max:50'],
+            'first_name' => ['nullable', 'string', 'max:255'],
+            'middle_name' => ['nullable', 'string', 'max:255'],
+            'last_name' => ['nullable', 'string', 'max:255'],
+            'supplier_business_name' => ['nullable', 'string', 'max:255'],
+            'prefix' => ['nullable', 'string', 'max:20'],
+            'address_line_1' => ['nullable', 'string', 'max:255'],
+            'address_line_2' => ['nullable', 'string', 'max:255'],
+            'city' => ['nullable', 'string', 'max:255'],
+            'state' => ['nullable', 'string', 'max:255'],
+            'country' => ['nullable', 'string', 'max:255'],
+            'zip_code' => ['nullable', 'string', 'max:20'],
+            'contact_id' => ['nullable', 'string', 'max:255'],
+            'customer_group_id' => ['nullable', 'integer'],
+            'shipping_address' => ['nullable', 'string'],
+            'position' => ['nullable', 'string', 'max:255'],
+            'dob' => ['nullable', 'string', 'max:32'],
+            'pay_term_number' => ['nullable', 'integer'],
+            'pay_term_type' => ['nullable', 'string', 'in:days,months'],
+        ];
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function messages(): array
+    {
+        return [
+            'cpf_cnpj' => 'O CPF/CNPJ informado não é válido (verificação mod-11 SEFAZ).',
+            'indicador_ie.in' => 'Indicador IE deve ser 1 (contribuinte), 2 (isento) ou 9 (não contribuinte).',
+            'regime.in' => 'Regime tributário deve ser: simples, presumido, real ou mei.',
+            'email.email' => 'Informe um e-mail válido.',
+            'type.in' => 'Tipo de contato deve ser: customer, supplier, both ou lead.',
+        ];
+    }
+}

--- a/tests/Feature/Cliente/StoreContactRequestTest.php
+++ b/tests/Feature/Cliente/StoreContactRequestTest.php
@@ -1,0 +1,134 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+
+/**
+ * Slice 7 — Feature test pro StoreContactRequest wirado em ContactController@store.
+ *
+ * Antes deste slice, $request->only(['cpf_cnpj', 'indicador_ie', ...]) aceitava
+ * qualquer string sem checar mod-11 SEFAZ. Agora o FormRequest valida.
+ *
+ * Cenários:
+ *   - CPF inválido (mod-11 fail) → 422 + erro em cpf_cnpj.
+ *   - CNPJ inválido → 422.
+ *   - indicador_ie fora de 1/2/9 → 422.
+ *   - regime fora do conjunto canônico → 422.
+ *   - CPF válido + payload base → segue (não 422 em cpf_cnpj).
+ *
+ * Skip-graceful em sqlite memory / sem schema UltimatePOS (CI).
+ * Validação real em mysql dev pre-merge.
+ */
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    try {
+        $this->business = Business::first();
+    } catch (\Throwable $e) {
+        $this->markTestSkipped('Schema UltimatePOS ausente — rode com DB_CONNECTION=mysql dev.');
+    }
+    if (! $this->business) {
+        $this->markTestSkipped('Sem business em DB.');
+    }
+
+    $this->user = User::where('business_id', $this->business->id)->first();
+    if (! $this->user) {
+        $this->markTestSkipped('Sem user no business.');
+    }
+
+    $this->actingAs($this->user);
+    session([
+        'user.business_id' => $this->business->id,
+        'user.id' => $this->user->id,
+    ]);
+});
+
+it('rejeita CPF inválido com 422 e erro em cpf_cnpj', function () {
+    $payload = [
+        'type' => 'customer',
+        'first_name' => 'Cliente Slice7 CPF inválido',
+        'cpf_cnpj' => '11144477700', // dígito verificador errado
+    ];
+
+    $response = $this->post('/contacts', $payload, ['X-Inertia' => 'true']);
+
+    $response->assertStatus(302); // Laravel redireciona em fail por padrão sem JSON
+    $response->assertSessionHasErrors(['cpf_cnpj']);
+});
+
+it('rejeita CNPJ inválido com 422 / redirect + erro em cpf_cnpj', function () {
+    $payload = [
+        'type' => 'supplier',
+        'supplier_business_name' => 'Fornecedor Slice7 CNPJ inválido',
+        'cpf_cnpj' => '11444777000100', // dígito verificador errado
+    ];
+
+    $response = $this->post('/contacts', $payload, ['X-Inertia' => 'true']);
+
+    $response->assertSessionHasErrors(['cpf_cnpj']);
+});
+
+it('rejeita indicador_ie fora de 1/2/9', function () {
+    $payload = [
+        'type' => 'customer',
+        'first_name' => 'Cliente Slice7 indicador',
+        'indicador_ie' => 5, // valor fora do enum SEFAZ
+    ];
+
+    $response = $this->post('/contacts', $payload, ['X-Inertia' => 'true']);
+
+    $response->assertSessionHasErrors(['indicador_ie']);
+});
+
+it('rejeita regime fora do conjunto canônico', function () {
+    $payload = [
+        'type' => 'customer',
+        'first_name' => 'Cliente Slice7 regime',
+        'regime' => 'lucro_arbitrado', // valor fora do enum
+    ];
+
+    $response = $this->post('/contacts', $payload, ['X-Inertia' => 'true']);
+
+    $response->assertSessionHasErrors(['regime']);
+});
+
+it('aceita CPF válido sem erro no campo cpf_cnpj', function () {
+    $payload = [
+        'type' => 'customer',
+        'first_name' => 'Cliente Slice7 CPF válido',
+        'cpf_cnpj' => '11144477735', // mod-11 ok
+        'indicador_ie' => 9,
+        'regime' => 'simples',
+    ];
+
+    $response = $this->post('/contacts', $payload, ['X-Inertia' => 'true']);
+
+    // Não validamos status final (pode haver outras regras UPOS desconhecidas),
+    // só garantimos que cpf_cnpj/indicador_ie/regime NÃO falharam validação.
+    $errors = session('errors');
+    if ($errors) {
+        $bag = $errors->getBag('default');
+        expect($bag->has('cpf_cnpj'))->toBeFalse('CPF válido não deve falhar mod-11');
+        expect($bag->has('indicador_ie'))->toBeFalse('indicador_ie=9 deve passar');
+        expect($bag->has('regime'))->toBeFalse('regime=simples deve passar');
+    }
+});
+
+it('aceita CNPJ válido sem erro no campo cpf_cnpj', function () {
+    $payload = [
+        'type' => 'supplier',
+        'supplier_business_name' => 'Fornecedor Slice7 CNPJ válido',
+        'cpf_cnpj' => '11444777000161', // mod-11 ok
+    ];
+
+    $response = $this->post('/contacts', $payload, ['X-Inertia' => 'true']);
+
+    $errors = session('errors');
+    if ($errors) {
+        expect($errors->getBag('default')->has('cpf_cnpj'))->toBeFalse('CNPJ válido não deve falhar mod-11');
+    }
+});

--- a/tests/Unit/Http/Requests/Cliente/StoreContactRequestRulesTest.php
+++ b/tests/Unit/Http/Requests/Cliente/StoreContactRequestRulesTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Http\Requests\Cliente;
+
+use App\Http\Requests\Cliente\StoreContactRequest;
+use App\Http\Requests\Cliente\UpdateContactRequest;
+use App\Rules\BR\CpfCnpj;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Slice 7 — sanity check do shape do FormRequest sem booting o framework.
+ *
+ * Garante que as keys canon BR estão no array rules() e que cpf_cnpj usa
+ * a Rule canônica App\Rules\BR\CpfCnpj (e não validação inline ad-hoc).
+ *
+ * Smoke pre-merge — não substitui o Feature test que exercita validação real.
+ */
+class StoreContactRequestRulesTest extends TestCase
+{
+    /** @test */
+    public function it_has_br_canon_keys_on_store(): void
+    {
+        $rules = (new StoreContactRequest)->rules();
+
+        foreach ([
+            'cpf_cnpj', 'rg', 'inscricao_estadual', 'inscricao_municipal',
+            'indicador_ie', 'nome_fantasia', 'consumidor_final',
+            'contribuinte', 'regime', 'suframa',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $rules, "Store rule missing key: {$key}");
+        }
+    }
+
+    /** @test */
+    public function it_has_br_canon_keys_on_update(): void
+    {
+        $rules = (new UpdateContactRequest)->rules();
+
+        foreach ([
+            'cpf_cnpj', 'rg', 'inscricao_estadual', 'inscricao_municipal',
+            'indicador_ie', 'nome_fantasia', 'consumidor_final',
+            'contribuinte', 'regime', 'suframa',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $rules, "Update rule missing key: {$key}");
+        }
+    }
+
+    /** @test */
+    public function cpf_cnpj_uses_canonical_rule_on_store(): void
+    {
+        $rules = (new StoreContactRequest)->rules();
+
+        $this->assertArrayHasKey('cpf_cnpj', $rules);
+        $this->assertContains('nullable', $rules['cpf_cnpj']);
+
+        $hasCpfCnpjRule = false;
+        foreach ($rules['cpf_cnpj'] as $r) {
+            if ($r instanceof CpfCnpj) {
+                $hasCpfCnpjRule = true;
+                break;
+            }
+        }
+        $this->assertTrue($hasCpfCnpjRule, 'cpf_cnpj deve usar App\\Rules\\BR\\CpfCnpj');
+    }
+
+    /** @test */
+    public function cpf_cnpj_uses_canonical_rule_on_update(): void
+    {
+        $rules = (new UpdateContactRequest)->rules();
+
+        $this->assertArrayHasKey('cpf_cnpj', $rules);
+
+        $hasCpfCnpjRule = false;
+        foreach ($rules['cpf_cnpj'] as $r) {
+            if ($r instanceof CpfCnpj) {
+                $hasCpfCnpjRule = true;
+                break;
+            }
+        }
+        $this->assertTrue($hasCpfCnpjRule, 'cpf_cnpj deve usar App\\Rules\\BR\\CpfCnpj');
+    }
+
+    /** @test */
+    public function indicador_ie_restricted_to_1_2_9(): void
+    {
+        $rules = (new StoreContactRequest)->rules();
+        $this->assertContains('in:1,2,9', $rules['indicador_ie']);
+        $this->assertContains('integer', $rules['indicador_ie']);
+    }
+
+    /** @test */
+    public function regime_restricted_to_canonical_set(): void
+    {
+        $rules = (new StoreContactRequest)->rules();
+        $this->assertContains('in:simples,presumido,real,mei', $rules['regime']);
+    }
+
+    /** @test */
+    public function messages_do_not_leak_recived_value(): void
+    {
+        $messages = (new StoreContactRequest)->messages();
+
+        // Defensividade LGPD ADR 0127 — mensagens não devem ter placeholders pro valor recebido.
+        foreach ($messages as $key => $msg) {
+            $this->assertStringNotContainsString(':input', $msg, "msg {$key} não pode ecoar :input");
+            $this->assertStringNotContainsString(':value', $msg, "msg {$key} não pode ecoar :value");
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Slice 7 do roadmap dos campos BR no oimpresso (Laravel 13). Cria `StoreContactRequest` e `UpdateContactRequest` em `App\Http\Requests\Cliente\` e type-hinta em `ContactController@store` e `@update`. Esta é a primeira vez que `App\Rules\BR\CpfCnpj` (mod-11 SEFAZ) é efetivamente wirado em produção — antes existia zero-usada.

## Antes vs depois

| Antes (Slices 1-4) | Depois (este PR) |
|---|---|
| `$request->only(['cpf_cnpj', ...])` aceitava qualquer string | FormRequest valida mod-11 SEFAZ antes do DB |
| Frontend máscara visual ≠ guardrail | Backend rejeita CPF/CNPJ inválido com `assertSessionHasErrors` |
| `indicador_ie` aceitava qualquer integer | `in:1,2,9` (contribuinte / isento / não contribuinte SEFAZ) |
| `regime` aceitava qualquer string | `in:simples,presumido,real,mei` |

## Validação canon BR

- `cpf_cnpj` → `nullable | new CpfCnpj` (Eduardokum vendored mod-11)
- `indicador_ie` → `nullable | integer | in:1,2,9`
- `regime` → `nullable | string | in:simples,presumido,real,mei`
- `consumidor_final`, `contribuinte` → `nullable | boolean`
- `nome_fantasia` → `nullable | string | max:150`
- `rg`, `suframa`, `inscricao_estadual`, `inscricao_municipal` → `nullable | string | max:N`
- Campos UPOS upstream → `nullable` suave (sem regressão em fluxos legacy)

## Cobertura dual path (legacy + Inertia)

FormRequest valida ANTES do branch `isLegacyAjax()` — cobre simultaneamente:
- POST legacy (jQuery ajax sem `X-Inertia`)
- Path futuro Inertia SPA

Authorize roda no FormRequest **e** mantém `abort(403)` manual no controller — defensividade dupla durante Wave 1.

## LGPD (ADR 0127)

Mensagens custom **não ecoam** `:input` / `:value` — apenas descrevem o gabarito. Unit test asserta isso.

## Tests

- `tests/Unit/Http/Requests/Cliente/StoreContactRequestRulesTest.php` (framework-free, ~110 LOC)
  - keys BR presentes no Store + Update
  - `cpf_cnpj` usa `App\Rules\BR\CpfCnpj` (não validação inline)
  - `indicador_ie` restrita a 1/2/9
  - `regime` restrita ao conjunto canônico
  - mensagens sem leak PII (`:input`, `:value`)

- `tests/Feature/Cliente/StoreContactRequestTest.php` (HTTP, ~135 LOC)
  - CPF inválido → `assertSessionHasErrors(['cpf_cnpj'])`
  - CNPJ inválido → mesma asserção
  - `indicador_ie=5` → rejeita
  - `regime=lucro_arbitrado` → rejeita
  - CPF válido `11144477735` → não falha em `cpf_cnpj`
  - CNPJ válido `11444777000161` → não falha em `cpf_cnpj`
  - Skip-graceful em sqlite memory (pattern `ContactPiiLogsActivityTest`)

## Test plan

- [ ] CI verde (Pest + lint + Module Grades Gate)
- [ ] Manual: payload com CPF `11144477700` em `POST /contacts` redireciona com erro session
- [ ] Manual: payload com CPF `11144477735` segue normalmente
- [ ] Smoke prod pós-merge: criar cliente via UI com CPF inválido — UI mostra erro de validação Laravel

## Arquivos

- `app/Http/Requests/Cliente/StoreContactRequest.php` (novo, 113 LOC)
- `app/Http/Requests/Cliente/UpdateContactRequest.php` (novo, 103 LOC)
- `app/Http/Controllers/ContactController.php` (+19 -4 — use statements + 2 type-hints + docblocks)
- `tests/Unit/Http/Requests/Cliente/StoreContactRequestRulesTest.php` (novo, 111 LOC)
- `tests/Feature/Cliente/StoreContactRequestTest.php` (novo, 134 LOC)

**Total:** 5 arquivos, 476 inserções, 4 deleções.

## Refs

- `memory/sessions/2026-05-21-investigar-campos-br-cliente.md`
- ADR 0093 (multi-tenant Tier 0)
- ADR 0127 (LGPD redact em logs)
- Slice 1 (`migration 2026_05_21_140000` restaurou 10 campos BR)

Wagner pediu paralelização 2026-05-21 — este é Slice 7 standalone (sem dependência cross-PR).

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>