### PR TITLE
feat(sells): SellsTabsVisao + feature-flag ?tabs=1 (Onda Unificação PR2/6)

### DIFF
--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -39,6 +39,7 @@ import SellsDateFilter, {
   type DateFilterPreset,
 } from './_components/SellsDateFilter';
 import SellsToggleViewMode, { type SellsViewMode } from './_components/SellsToggleViewMode';
+import SellsTabsVisao, { type SellsVisao } from './_components/SellsTabsVisao';
 import SellsGroupByDropdown, { type GroupByField } from './_components/SellsGroupByDropdown';
 import SellsGradeAvancada from './_components/SellsGradeAvancada';
 import type { SellsTotals } from './_components/SellsTotalsRow';
@@ -650,6 +651,18 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
   // "adicionar pagamentos como antigamente" (botão direto na linha sem abrir
   // drawer). Estado do modal QuickPayment compartilhado entre Lista e Grade.
   const [payDialog, setPayDialog] = useState<{ saleId: number; invoiceNo: string; dueAmount: number } | null>(null);
+
+  // Onda Unificação PR2/6 (ADR 0178) — tabs Visão Operacional/Financeira/Produção.
+  // Feature-flagged via URL `?tabs=1` — visível só pra Wagner em testes; default off
+  // não impacta Larissa biz=4. PR3 conecta visão → visibleColumns; PR4 faz cutover.
+  const tabsFlagOn = typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('tabs') === '1';
+  const [visao, setVisao] = useState<SellsVisao>(() => {
+    const v = ls.get('visao', 'operacional');
+    return (['operacional', 'financeira', 'producao'] as const).includes(v as SellsVisao)
+      ? (v as SellsVisao)
+      : 'operacional';
+  });
+  useEffect(() => ls.set('visao', visao), [visao]);
 
   // UI overlays.
   const [cheatOpen, setCheatOpen] = useState(false);
@@ -1279,6 +1292,9 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
             ))}
           </div>
           <div className="vd-tabs-actions">
+            {tabsFlagOn && (
+              <SellsTabsVisao visao={visao} onChange={setVisao} />
+            )}
             <SellsToggleViewMode viewMode={viewMode} onChange={setViewMode} />
             <button
               type="button"

--- a/resources/js/Pages/Sells/_components/SellsTabsVisao.tsx
+++ b/resources/js/Pages/Sells/_components/SellsTabsVisao.tsx
@@ -1,0 +1,97 @@
+// SellsTabsVisao — 3 tabs de Visão (Operacional / Financeira / Produção) sobre
+// a tabela unificada de /sells. Substitui o conceito viewMode=lista|grade-avancada
+// do ADR 0136 por um modelo persona-aware ([ADR 0178](../../../../memory/decisions/0178-sells-unified-tabs-visao-supersede-0136.md)
+// supersede 0136).
+//
+// Renderiza padrão inline sem dependência nova (mesmo approach do
+// SellsToggleViewMode.tsx) — segmented control com 3 botões agrupados num
+// pill border arredondado, botão ativo com bg-background + sombra leve.
+//
+// Em PR2 da Onda Unificação, este componente é montado SOMENTE quando URL
+// inclui `?tabs=1` (feature-flag) — Larissa @ ROTA LIVRE biz=4 não vê
+// mudança até PR4 fazer cutover do default. PR3 conecta visão → visibleColumns
+// da tabela base.
+//
+// PT-BR enforce: labels "Operacional / Financeira / Produção" são UX visíveis.
+
+import { Briefcase, DollarSign, Factory } from 'lucide-react';
+
+export type SellsVisao = 'operacional' | 'financeira' | 'producao';
+
+interface SellsTabsVisaoProps {
+  visao: SellsVisao;
+  onChange: (v: SellsVisao) => void;
+  /** Desabilita as tabs (ex: durante fetch). Default: false. */
+  disabled?: boolean;
+}
+
+export default function SellsTabsVisao({
+  visao,
+  onChange,
+  disabled = false,
+}: SellsTabsVisaoProps) {
+  return (
+    <div
+      role="tablist"
+      aria-label="Visão da lista de vendas"
+      className="inline-flex items-center rounded-lg border border-border bg-muted/40 p-0.5"
+    >
+      <TabButton
+        active={visao === 'operacional'}
+        onClick={() => onChange('operacional')}
+        disabled={disabled}
+        icon={<Briefcase size={14} />}
+        label="Operacional"
+        title="Pipeline, fiscal, SLA, ações rápidas — visão do dia-a-dia (padrão ROTA LIVRE biz=4)"
+      />
+      <TabButton
+        active={visao === 'financeira'}
+        onClick={() => onChange('financeira')}
+        disabled={disabled}
+        icon={<DollarSign size={14} />}
+        label="Financeira"
+        title="Total, pago, a receber, comissão + multiseleção, totalizador, agrupamento"
+      />
+      <TabButton
+        active={visao === 'producao'}
+        onClick={() => onChange('producao')}
+        disabled={disabled}
+        icon={<Factory size={14} />}
+        label="Produção"
+        title="Localização, estágio FSM, sub-linha produtos — power-user OfficeImpresso migrado"
+      />
+    </div>
+  );
+}
+
+interface TabButtonProps {
+  active: boolean;
+  onClick: () => void;
+  disabled: boolean;
+  icon: React.ReactNode;
+  label: string;
+  title: string;
+}
+
+function TabButton({ active, onClick, disabled, icon, label, title }: TabButtonProps) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active}
+      aria-disabled={disabled}
+      onClick={onClick}
+      disabled={disabled}
+      title={title}
+      className={
+        'inline-flex items-center gap-1.5 rounded-md px-2.5 py-1 text-xs font-medium transition-all disabled:opacity-50 disabled:cursor-not-allowed ' +
+        (active
+          ? 'bg-background text-foreground shadow-sm'
+          : 'text-muted-foreground hover:text-foreground hover:bg-background/50')
+      }
+    >
+      {icon}
+      <span>{label}</span>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
**Onda Unificação Sells — PR 2/6.** Introduz componente `SellsTabsVisao` (Operacional / Financeira / Produção) ao lado do toggle `viewMode` legacy. **Default off** — só visível com URL `?tabs=1`. Larissa @ ROTA LIVRE biz=4 **não vê mudança**.

[ADR 0178](memory/decisions/0178-sells-unified-tabs-visao-supersede-0136.md) (mergeado PR #1323) define o destino. PR3 conecta visão → `visibleColumns`; PR4 faz cutover + delete dos componentes legacy.

## Diff (2 arquivos, 113+/0-)

1. **`SellsTabsVisao.tsx`** (novo, ~95 LOC) — 3 tabs no padrão segmented control inline (mesmo approach `SellsToggleViewMode` sem nova dep shadcn). Ícones `Briefcase` / `DollarSign` / `Factory`. `role="tablist"` + `aria-selected`. Tooltips PT-BR.
2. **`Sells/Index.tsx`** (~15 LOC) — import + state `visao` persist via `ls.set` (Tier 0 per-business — PR #1311). Detecta `?tabs=1` via `window.location.search` (sem dep Inertia pra evitar SSR hydration mismatch). Renderiza condicional ao lado de `<SellsToggleViewMode>` em `.vd-tabs-actions`.

## Test plan
- [x] TS check zero novos erros
- [ ] Smoke biz=1 (Wagner WR2):
  1. `/sells` (sem query) → tabs **NÃO** aparecem (default off) ✅
  2. `/sells?tabs=1` → 3 tabs aparecem ao lado de Lista/Grade Avançada
  3. Click em "Financeira" → `oimpresso.sells.b1.visao=financeira` no localStorage
  4. Refresh com `?tabs=1` → tab Financeira mantida (persistiu)
  5. Comportamento da Lista/Grade Avançada **inalterado** (toggle viewMode continua funcionando)

## Não cobre
- Visão → `visibleColumns` (PR3)
- Migração silenciosa localStorage `viewMode` → `visao` (PR4)
- Delete `SellsToggleViewMode` / `SellsGradeAvancada` (PR4)
- Pest snapshot re-baseline (PR6)

## Refs
- [ADR 0178](memory/decisions/0178-sells-unified-tabs-visao-supersede-0136.md) — canon ativo
- [PR #1323](https://github.com/wagnerra23/oimpresso.com/pull/1323) — fundação DOCS
- [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md) — Tier 0 localStorage

🤖 Generated with [Claude Code](https://claude.com/claude-code)