### PR TITLE
feat(sells): QuickPayment popover em-place (Onda Unificação PR5/6)

### DIFF
--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -31,7 +31,7 @@ import {
   X,
 } from 'lucide-react';
 import SaleSheet from './_components/SaleSheet';
-import QuickPaymentDialog from './_components/QuickPaymentDialog';
+import QuickPaymentPopover from './_components/QuickPaymentPopover';
 // PR follow-up Cowork — filtros legacy reintegrados via barra colapsável "Filtros avançados ▾".
 // Refs: Index.charter.md v2 Goals · feedback-design-literal-copy §How to apply #5.
 import SellsDateFilter, {
@@ -649,8 +649,9 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
 
   // US-SELL-042 — Larissa @ ROTA LIVRE biz=4 (ADR 0105) pediu 2026-05-21
   // "adicionar pagamentos como antigamente" (botão direto na linha sem abrir
-  // drawer). Estado do modal QuickPayment compartilhado entre Lista e Grade.
-  const [payDialog, setPayDialog] = useState<{ saleId: number; invoiceNo: string; dueAmount: number } | null>(null);
+  // drawer). Onda Unificação PR5 — Dialog modal full foi trocado por Popover
+  // anchored (em-place). Cada row renderiza seu próprio Popover; estado é
+  // local ao componente, sem lift-up (Grade idem).
 
   // Onda Unificação PR2/6 (ADR 0178) — tabs Visão Operacional/Financeira/Produção.
   // Feature-flagged via URL `?tabs=1` — visível só pra Wagner em testes; default off
@@ -1351,7 +1352,7 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
               onSort={handleSort}
               groupBy={groupBy}
               onGroupByChange={setGroupBy}
-              onPayClick={(saleId, invoiceNo, dueAmount) => setPayDialog({ saleId, invoiceNo, dueAmount })}
+              onPaySuccess={() => setRefetchToken((t) => t + 1)}
             />
           </div>
         ) : (
@@ -1493,20 +1494,24 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
                         <div className="vd-row-actions" onClick={(e) => e.stopPropagation()}>
                           {/* US-SELL-042 — botão "Pagar" inline (sem abrir drawer) pra
                               vendas com saldo devedor. Equivalente ao "Add Payment" do
-                              UltimatePOS Blade legacy que Larissa biz=4 sentiu falta. */}
+                              UltimatePOS Blade legacy que Larissa biz=4 sentiu falta.
+                              Onda Unificação PR5 — Popover em-place (modal full sumiu). */}
                           {v.payment_status !== 'paid' && (
-                            <button
-                              className="vd-row-act"
-                              title="Registrar pagamento"
-                              type="button"
-                              onClick={() => setPayDialog({
-                                saleId: v.id,
-                                invoiceNo: v.invoice_no,
-                                dueAmount: Math.max(0, v.final_total - v.total_paid),
-                              })}
-                            >
-                              <DollarSign size={11} />
-                            </button>
+                            <QuickPaymentPopover
+                              saleId={v.id}
+                              invoiceNo={v.invoice_no}
+                              dueAmount={Math.max(0, v.final_total - v.total_paid)}
+                              onSuccess={() => setRefetchToken((t) => t + 1)}
+                              trigger={
+                                <button
+                                  className="vd-row-act"
+                                  title="Registrar pagamento"
+                                  type="button"
+                                >
+                                  <DollarSign size={11} />
+                                </button>
+                              }
+                            />
                           )}
                           {v.fiscal_status === 'autorizada' && (
                             <button className="vd-row-act" title="Baixar DANFE PDF" type="button">
@@ -1764,16 +1769,10 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
         initialAiOpen={aiTriggered}
       />
 
-      {/* US-SELL-042 — modal "Registrar pagamento" inline (atalho rápido sem
-          abrir o drawer). Lista e Grade Avançada disparam via setPayDialog. */}
-      <QuickPaymentDialog
-        saleId={payDialog?.saleId ?? null}
-        invoiceNo={payDialog?.invoiceNo ?? ''}
-        dueAmount={payDialog?.dueAmount ?? 0}
-        open={payDialog !== null}
-        onClose={() => setPayDialog(null)}
-        onSuccess={() => setRefetchToken((t) => t + 1)}
-      />
+      {/* US-SELL-042 — Onda Unificação PR5: o antigo <QuickPaymentDialog>
+          global foi removido daqui. Cada row da Lista/Grade renderiza seu
+          próprio <QuickPaymentPopover> em-place (anchored ao botão DollarSign),
+          preservando contexto da linha sem overlay full. */}
     </div>
   );
 }

--- a/resources/js/Pages/Sells/_components/QuickPaymentPopover.tsx
+++ b/resources/js/Pages/Sells/_components/QuickPaymentPopover.tsx
@@ -1,37 +1,40 @@
-// QuickPaymentDialog — Modal pra registrar pagamento rápido inline na linha da
-// listagem de vendas. Reusa o endpoint POST /sells/{id}/quick-payment que já
-// alimenta o "Adicionar pagamento" inline do SaleSheet (drawer), evitando
-// duplicação. Larissa @ ROTA LIVRE biz=4 pediu 2026-05-21 "adicionar
-// pagamentos como antigamente" (UltimatePOS Blade legacy tinha botão "Add
-// Payment" na linha) — ADR 0105 sinal qualificado.
+// QuickPaymentPopover — versão em-place (anchored ao botão "Pagar" na row)
+// do antigo QuickPaymentDialog (modal full). Onda Unificação PR5/6 — Wagner
+// pediu UX moderna estilo Linear/Notion: popover compacto ao lado da linha
+// preservando contexto da tabela (sem overlay full que tirava visibilidade
+// do row clicado).
 //
-// @deprecated Substituído por QuickPaymentPopover (Onda Unificação PR5/6) em
-// em-place anchored ao botão DollarSign. Modal full overlay tirava contexto
-// da linha. Mantido aqui como backup compat caso algum lugar referencie —
-// pode ser removido em onda futura quando sells/Index.tsx + Grade Avançada
-// estiverem 100% migrados pro Popover (confirmar grep no codebase).
+// Decisões de design:
+//  - Mesma fonte de verdade do POST /sells/{id}/quick-payment (idêntico ao
+//    Dialog antigo e ao SaleSheet inline) — zero mudança backend.
+//  - Trigger é injetado de fora via prop `trigger: React.ReactNode` pra
+//    permitir que cada call-site (Lista row-actions, Grade Avançada tbody)
+//    controle o estilo do botão. Wraps com PopoverTrigger asChild.
+//  - shadcn Popover (Radix primitive) já traz Esc-close + click-outside-close
+//    + focus trap default — não precisa lógica manual.
+//  - Lógica de submit/draft/error copiada 1:1 do QuickPaymentDialog antigo;
+//    QuickPaymentDialog.tsx fica marcado @deprecated mas não é removido
+//    (backup compat caso algum lugar referencie).
 //
 // Refs:
-//  - QuickPaymentPopover.tsx (substituto — em-place anchored)
-//  - SaleSheet.tsx linhas 195-276 (padrão original do form inline)
-//  - ADR 0093 multi-tenant Tier 0 (saleId vem do payload do tenant logado)
+//  - QuickPaymentDialog.tsx (predecessor — Onda Unificação PR3/6 #1320)
+//  - ADR 0178 Onda Unificação tabs Visão supersede 0136
+//  - ADR 0093 multi-tenant Tier 0 (saleId vem do payload tenant logado)
 
-import { useEffect, useState, type FormEvent } from 'react';
+import { useEffect, useState, type FormEvent, type ReactNode } from 'react';
 import { CheckCircle2, Loader2, X } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
 import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogHeader,
-  DialogTitle,
-} from '@/Components/ui/dialog';
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/Components/ui/popover';
 import { Input } from '@/Components/ui/input';
 import { Label } from '@/Components/ui/label';
 import { Textarea } from '@/Components/ui/textarea';
 
-// Mesma fonte canônica de SaleSheet (UltimatePOS armazena chaves curtas
-// custom_pay_1=PIX/custom_pay_2=Boleto/custom_pay_3=Crediário — labels PT-BR
+// Mesma fonte canônica de SaleSheet + QuickPaymentDialog (UltimatePOS
+// armazena chaves curtas custom_pay_1=PIX/custom_pay_2=Boleto — labels PT-BR
 // no SellController::inertiaList match cases linha 1287-1298).
 const PAYMENT_METHODS_OPTIONS = [
   { value: 'cash', label: 'Dinheiro' },
@@ -53,23 +56,27 @@ function getCsrfToken(): string {
 const formatBRL = (value: number) =>
   new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(value);
 
-interface QuickPaymentDialogProps {
-  saleId: number | null;
+interface QuickPaymentPopoverProps {
+  saleId: number;
   invoiceNo: string;
   dueAmount: number;
-  open: boolean;
-  onClose: () => void;
   onSuccess: () => void;
+  /**
+   * Botão (ou qualquer trigger) que abre o popover. É clonado via Radix
+   * PopoverTrigger asChild — então precisa aceitar ref + onClick. Em geral
+   * um <button> simples já basta.
+   */
+  trigger: ReactNode;
 }
 
-export default function QuickPaymentDialog({
+export default function QuickPaymentPopover({
   saleId,
   invoiceNo,
   dueAmount,
-  open,
-  onClose,
   onSuccess,
-}: QuickPaymentDialogProps) {
+  trigger,
+}: QuickPaymentPopoverProps) {
+  const [open, setOpen] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [paymentError, setPaymentError] = useState<string | null>(null);
   const [draft, setDraft] = useState({
@@ -79,8 +86,8 @@ export default function QuickPaymentDialog({
     note: '',
   });
 
-  // Reseta o draft toda vez que o modal abre — evita carregar valor de outra
-  // venda quando o user fechou sem submeter e abriu em outra linha.
+  // Reseta o draft toda vez que o popover abre — evita carregar valor de
+  // outra venda quando o user fechou sem submeter e abriu em outra linha.
   useEffect(() => {
     if (open) {
       setDraft({
@@ -124,7 +131,7 @@ export default function QuickPaymentDialog({
         return;
       }
       onSuccess();
-      onClose();
+      setOpen(false);
     } catch (err) {
       setPaymentError(String((err as Error)?.message || err));
     } finally {
@@ -133,21 +140,28 @@ export default function QuickPaymentDialog({
   };
 
   return (
-    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle className="text-base">Registrar pagamento</DialogTitle>
-          <DialogDescription className="text-xs text-muted-foreground">
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>{trigger}</PopoverTrigger>
+      <PopoverContent
+        className="w-80 p-3"
+        align="end"
+        // stopPropagation evita que click no form abra o drawer da venda
+        // (row tem onClick que abre SaleSheet — ver Index.tsx vd-row).
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-2">
+          <div className="text-sm font-medium leading-none">Registrar pagamento</div>
+          <div className="mt-1 text-xs text-muted-foreground">
             Venda #{invoiceNo} · saldo devedor{' '}
             <span className="font-medium text-foreground tabular-nums">{formatBRL(dueAmount)}</span>
-          </DialogDescription>
-        </DialogHeader>
+          </div>
+        </div>
         <form onSubmit={handleSubmit} className="space-y-3">
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <Label htmlFor="qpd-amount" className="text-xs">Valor</Label>
+              <Label htmlFor="qpp-amount" className="text-xs">Valor</Label>
               <Input
-                id="qpd-amount"
+                id="qpp-amount"
                 type="text"
                 inputMode="decimal"
                 value={draft.amount}
@@ -155,15 +169,16 @@ export default function QuickPaymentDialog({
                 placeholder="0,00"
                 required
                 autoFocus
+                className="h-8 text-sm"
               />
             </div>
             <div className="space-y-1.5">
-              <Label htmlFor="qpd-method" className="text-xs">Forma</Label>
+              <Label htmlFor="qpp-method" className="text-xs">Forma</Label>
               <select
-                id="qpd-method"
+                id="qpp-method"
                 value={draft.method}
                 onChange={(e) => setDraft({ ...draft, method: e.target.value })}
-                className="flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm"
+                className="flex h-8 w-full rounded-md border border-input bg-background px-2 py-1 text-sm"
               >
                 {PAYMENT_METHODS_OPTIONS.map((m) => (
                   <option key={m.value} value={m.value}>{m.label}</option>
@@ -172,19 +187,20 @@ export default function QuickPaymentDialog({
             </div>
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="qpd-date" className="text-xs">Data</Label>
+            <Label htmlFor="qpp-date" className="text-xs">Data</Label>
             <Input
-              id="qpd-date"
+              id="qpp-date"
               type="date"
               value={draft.paid_on}
               onChange={(e) => setDraft({ ...draft, paid_on: e.target.value })}
               required
+              className="h-8 text-sm"
             />
           </div>
           <div className="space-y-1.5">
-            <Label htmlFor="qpd-note" className="text-xs">Observação (opcional)</Label>
+            <Label htmlFor="qpp-note" className="text-xs">Observação (opcional)</Label>
             <Textarea
-              id="qpd-note"
+              id="qpp-note"
               value={draft.note}
               onChange={(e) => setDraft({ ...draft, note: e.target.value })}
               rows={2}
@@ -201,7 +217,7 @@ export default function QuickPaymentDialog({
               type="button"
               variant="ghost"
               size="sm"
-              onClick={onClose}
+              onClick={() => setOpen(false)}
               disabled={submitting}
             >
               <X size={14} className="mr-1" />
@@ -217,7 +233,7 @@ export default function QuickPaymentDialog({
             </Button>
           </div>
         </form>
-      </DialogContent>
-    </Dialog>
+      </PopoverContent>
+    </Popover>
   );
 }

--- a/resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx
+++ b/resources/js/Pages/Sells/_components/SellsGradeAvancada.tsx
@@ -33,6 +33,7 @@ import {
   type ExpandedState,
 } from '@tanstack/react-table';
 import { Checkbox } from '@/Components/ui/checkbox';
+import QuickPaymentPopover from './QuickPaymentPopover';
 import SellsBulkActionsBar from './SellsBulkActionsBar';
 import SellsTotalsRow, { type SellsTotals } from './SellsTotalsRow';
 import SellsGroupByDropdown, { type GroupByField } from './SellsGroupByDropdown';
@@ -120,10 +121,11 @@ interface SellsGradeAvancadaProps {
   // US-SELL-019 — agrupamento (state lifted up).
   groupBy: GroupByField;
   onGroupByChange: (g: GroupByField) => void;
-  // US-SELL-042 — botão "Pagar" inline (opcional: views que querem expor a
-  // ação rápida de registrar pagamento sem abrir o drawer). Quando ausente,
+  // US-SELL-042 / Onda Unificação PR5 — quando passado, renderiza coluna
+  // Ações com botão "Pagar" inline (Popover em-place anchored). Callback
+  // dispara refetch da listagem após registrar com sucesso. Quando ausente,
   // a coluna Ações simplesmente não renderiza o botão.
-  onPayClick?: (saleId: number, invoiceNo: string, dueAmount: number) => void;
+  onPaySuccess?: () => void;
 }
 
 const formatBRL = (value: number) =>
@@ -186,7 +188,7 @@ export default function SellsGradeAvancada({
   onSort,
   groupBy,
   onGroupByChange,
-  onPayClick,
+  onPaySuccess,
 }: SellsGradeAvancadaProps) {
   const allRowsSelected = useMemo(() => {
     if (rows.length === 0) return false;
@@ -304,21 +306,21 @@ export default function SellsGradeAvancada({
                 {/* US-SELL-023 — coluna "Produção" badge FSM (Grade Avançada only,
                     Lista mode é enxuto e não mostra esta coluna). Default visível. */}
                 <Th className="w-32">Produção</Th>
-                {/* US-SELL-042 — coluna "Ações" rápidas (só renderiza se onPayClick passado). */}
-                {onPayClick && <Th className="w-12 text-center">·</Th>}
+                {/* US-SELL-042 — coluna "Ações" rápidas (só renderiza se onPaySuccess passado). */}
+                {onPaySuccess && <Th className="w-12 text-center">·</Th>}
               </tr>
             </thead>
             <tbody>
               {loading ? (
                 <tr>
-                  <td colSpan={onPayClick ? 12 : 11} className="text-center py-12 text-muted-foreground text-xs">
+                  <td colSpan={onPaySuccess ? 12 : 11} className="text-center py-12 text-muted-foreground text-xs">
                     <Loader2 className="inline-block mr-2 h-3.5 w-3.5 animate-spin" />
                     Carregando…
                   </td>
                 </tr>
               ) : rows.length === 0 ? (
                 <tr>
-                  <td colSpan={onPayClick ? 12 : 11} className="text-center py-12 text-muted-foreground text-xs">
+                  <td colSpan={onPaySuccess ? 12 : 11} className="text-center py-12 text-muted-foreground text-xs">
                     Nenhuma venda encontrada nesse filtro.
                   </td>
                 </tr>
@@ -393,19 +395,28 @@ export default function SellsGradeAvancada({
                         <ProducaoStageBadge stageKey={row.current_stage_key} />
                       </td>
                       {/* US-SELL-042 — botão "Pagar" inline (Larissa biz=4 ADR 0105).
-                          Só renderiza pra vendas com saldo devedor. stopPropagation
-                          evita abrir o drawer ao clicar. */}
-                      {onPayClick && (
+                          Onda Unificação PR5: Popover em-place anchored (modal full
+                          sumiu — não tira mais contexto da linha). Só renderiza pra
+                          vendas com saldo devedor. stopPropagation evita abrir o
+                          drawer ao clicar no botão/popover. */}
+                      {onPaySuccess && (
                         <td className="px-2 py-2.5 text-center" onClick={(e) => e.stopPropagation()}>
                           {row.payment_status !== 'paid' && (
-                            <button
-                              type="button"
-                              title="Registrar pagamento"
-                              onClick={() => onPayClick(row.id, row.invoice_no, Math.max(0, row.final_total - row.total_paid))}
-                              className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border bg-background hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
-                            >
-                              <DollarSign size={13} />
-                            </button>
+                            <QuickPaymentPopover
+                              saleId={row.id}
+                              invoiceNo={row.invoice_no}
+                              dueAmount={Math.max(0, row.final_total - row.total_paid)}
+                              onSuccess={onPaySuccess}
+                              trigger={
+                                <button
+                                  type="button"
+                                  title="Registrar pagamento"
+                                  className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-border bg-background hover:bg-muted text-muted-foreground hover:text-foreground transition-colors"
+                                >
+                                  <DollarSign size={13} />
+                                </button>
+                              }
+                            />
                           )}
                         </td>
                       )}


### PR DESCRIPTION
## Sumário

Onda Unificação PR5/6 — substitui `QuickPaymentDialog` (modal full overlay do PR #1320) por **`QuickPaymentPopover`** ancorado ao botão `DollarSign` da row-action. UX moderna estilo Linear/Notion: clica → popover compacto (~320px) abre ao lado da linha, preservando contexto da tabela sem overlay full-screen.

### O que muda exato

- **Novo:** `resources/js/Pages/Sells/_components/QuickPaymentPopover.tsx` (239 LOC) — shadcn Popover (Radix primitive) com mesma lógica de submit/draft/erro do Dialog antigo. `trigger` injetado por prop (PopoverTrigger asChild).
- **Mudou:** `Index.tsx` — lista row-actions e prop da Grade migrados pro novo componente; `payDialog`/`setPayDialog` state removido; `<QuickPaymentDialog>` render global removido.
- **Mudou:** `SellsGradeAvancada.tsx` — prop `onPayClick(id, invoice, due)` → `onPaySuccess()` (Popover encapsula state per-row, não precisa lift-up).
- **Deprecated:** `QuickPaymentDialog.tsx` marcado `@deprecated` (mantido como backup compat; remover em onda futura).

### Vantagens UX
- Linha continua visível atrás do popover (não overlay full).
- Esc fecha sem perder posição na tabela.
- Click-outside fecha (default Radix).
- Focus trap default (a11y Radix primitive).
- `align="end"` ancora popover ao lado do botão.

### Backend
Zero mudança. Mesmo endpoint `POST /sells/{id}/quick-payment`, mesma payload schema. Tier 0 multi-tenant intocado (`saleId` vem do payload tenant logado).

## Test plan

- [ ] CI verde (build + lint passando)
- [ ] Smoke real prod biz=1: abrir `/sells`, clicar botão `$` em venda com saldo devedor → popover abre ancorado, registra pagamento, refetch acontece, linha atualiza
- [ ] Smoke Grade Avançada: toggle Grade, clicar `$` em row → popover abre, mesma UX
- [ ] Smoke a11y: Esc fecha, Tab navega entre campos, click fora fecha
- [ ] Verificar que nenhum lugar ainda referencia `QuickPaymentDialog` (grep — file fica como backup compat)

Refs:
- ADR 0178 (Onda Unificação tabs Visão supersede 0136)
- PR #1320 (QuickPaymentDialog original — Onda PR3/6)
- ADR 0093 (multi-tenant Tier 0)
- ADR 0105 (sinal qualificado Larissa biz=4)

⚠️ **NÃO mergear** — Wagner aprova explicitamente após smoke da onda consolidada.

🤖 Generated with [Claude Code](https://claude.com/claude-code)