### PR TITLE
chore(adr): rename ADR 0178→0179 BR canon — resolve conflito de número com PR #1323

### DIFF
--- a/memory/decisions/0179-restauracao-campos-fiscais-br-canon.md
+++ b/memory/decisions/0179-restauracao-campos-fiscais-br-canon.md
@@ -1,6 +1,6 @@
 ---
-slug: 0178-restauracao-campos-fiscais-br-canon
-number: 178
+slug: 0179-restauracao-campos-fiscais-br-canon
+number: 179
 title: "Restauração dos campos fiscais BR em `contacts` (regressão UPOS 6.7)"
 type: adr
 status: aceito
@@ -15,7 +15,9 @@ related:
   - 0127-fsm-canonico
 ---
 
-# ADR 0178 — Restauração dos campos fiscais BR em `contacts` (regressão UPOS 6.7)
+# ADR 0179 — Restauração dos campos fiscais BR em `contacts` (regressão UPOS 6.7)
+
+> **Nota histórica:** originalmente criado como **0178** no PR #1324 (mergeado 2026-05-21). Em paralelo, o PR #1323 (Sells unified tabs Visão) mergeou ~2h antes reservando o número 0178 (`authority: canonical`). Renumerado pra 0179 neste PR pra resolver o drift preservando o canonical do Sells.
 
 ## Contexto
 


### PR DESCRIPTION
## Contexto

Em 2026-05-21 dois PRs mergeados em paralelo criaram ADR com o mesmo número **0178**:

| ADR | PR | Mergeado | Authority |
|---|---|---|---|
| 0178-sells-unified-tabs-visao-supersede-0136.md | #1323 | 14:36 UTC | **canonical** (supersede 0136) |
| 0178-restauracao-campos-fiscais-br-canon.md | #1324 | 16:48 UTC | reference |

Resultado: 2 arquivos diferentes com mesmo número em `memory/decisions/`. `decisions-search` MCP fica ambíguo e o linter de frontmatter pode reclamar de drift.

## Decisão

PR #1323 mergeou primeiro **e** é `authority: canonical` → mantém o número 0178. PR #1324 vira **0179** (próximo livre).

## Mudanças

- `git mv` `memory/decisions/0178-restauracao-campos-fiscais-br-canon.md` → `0179-restauracao-campos-fiscais-br-canon.md`
- Frontmatter atualizado: `slug: 0179-...`, `number: 179`
- H1 atualizado: "ADR 0178" → "ADR 0179"
- **Nota histórica** adicionada explicando o renumber (futura arqueologia agradece)

## Verificação de referências cruzadas

```bash
grep -r '0178-restauracao' D:\oimpresso.com```

Resultado: **só o próprio arquivo se autorreferenciava**. Zero impacto cross-module.

## Test plan

- [ ] ADR frontmatter linter passa (`tests/Feature/Memory/AdrFrontmatterLinterTest`)
- [ ] Append-only canon — git mv preserva history (`git log --follow`)
- [ ] Linter detecta APENAS 1 arquivo por número agora

🤖 Generated with [Claude Code](https://claude.com/claude-code)