### PR TITLE
feat(sells): Index renderiza SellsTabelaUnificada com flag ?unificada=1 + visão→visibleColumns (Onda Unif PR4/6)

### DIFF
--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -40,6 +40,13 @@ import SellsDateFilter, {
 } from './_components/SellsDateFilter';
 import SellsToggleViewMode, { type SellsViewMode } from './_components/SellsToggleViewMode';
 import SellsTabsVisao, { type SellsVisao } from './_components/SellsTabsVisao';
+import SellsTabelaUnificada, {
+  COLUMNS_OPERACIONAL,
+  COLUMNS_FINANCEIRA,
+  COLUMNS_PRODUCAO,
+  type ColumnId,
+  type SaleRow as UnifiedSaleRow,
+} from './_components/SellsTabelaUnificada';
 import SellsGroupByDropdown, { type GroupByField } from './_components/SellsGroupByDropdown';
 import SellsGradeAvancada from './_components/SellsGradeAvancada';
 import type { SellsTotals } from './_components/SellsTotalsRow';
@@ -654,8 +661,12 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
 
   // Onda Unificação PR2/6 (ADR 0178) — tabs Visão Operacional/Financeira/Produção.
   // Feature-flagged via URL `?tabs=1` — visível só pra Wagner em testes; default off
-  // não impacta Larissa biz=4. PR3 conecta visão → visibleColumns; PR4 faz cutover.
-  const tabsFlagOn = typeof window !== 'undefined' && new URLSearchParams(window.location.search).get('tabs') === '1';
+  // não impacta Larissa biz=4. PR4 (este) introduz `?unificada=1` que troca a
+  // tabela inline da Lista pelo SellsTabelaUnificada quando ON, mapeando visão →
+  // visibleColumns. PR5 cutover; PR6 cleanup flags.
+  const search = typeof window !== 'undefined' ? new URLSearchParams(window.location.search) : null;
+  const tabsFlagOn = search?.get('tabs') === '1';
+  const unificadaFlagOn = search?.get('unificada') === '1';
   const [visao, setVisao] = useState<SellsVisao>(() => {
     const v = ls.get('visao', 'operacional');
     return (['operacional', 'financeira', 'producao'] as const).includes(v as SellsVisao)
@@ -663,6 +674,18 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
       : 'operacional';
   });
   useEffect(() => ls.set('visao', visao), [visao]);
+
+  // Connect visão → visibleColumns pra SellsTabelaUnificada (ADR 0178). Filtra
+  // 'commission' do preset quando setting business.sales_cmsn_agnt = 'disable'.
+  const visibleColumns = useMemo<ColumnId[]>(() => {
+    const preset =
+      visao === 'financeira' ? COLUMNS_FINANCEIRA :
+      visao === 'producao' ? COLUMNS_PRODUCAO :
+      COLUMNS_OPERACIONAL;
+    return props.coworkCommissionEnabled
+      ? preset
+      : preset.filter((c) => c !== 'commission');
+  }, [visao, props.coworkCommissionEnabled]);
 
   // UI overlays.
   const [cheatOpen, setCheatOpen] = useState(false);
@@ -1351,6 +1374,26 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
               onSort={handleSort}
               groupBy={groupBy}
               onGroupByChange={setGroupBy}
+              onPayClick={(saleId, invoiceNo, dueAmount) => setPayDialog({ saleId, invoiceNo, dueAmount })}
+            />
+          </div>
+        ) : unificadaFlagOn ? (
+          /* ADR 0178 PR4/6 — caminho unificado (flag ?unificada=1). Renderiza
+             SellsTabelaUnificada com visibleColumns derivado de visão. PR5
+             remove o ternário (caminho unificado vira default). */
+          <div className="os-table-wrap">
+            <SellsTabelaUnificada
+              rows={filtered as UnifiedSaleRow[]}
+              loading={loading}
+              visibleColumns={visibleColumns}
+              selectedIds={selectedIds}
+              favSet={favSet}
+              focusIdx={focusIdx}
+              filteredCount={filtered.length}
+              rowsRef={rowsRef}
+              onToggleSel={toggleSel}
+              onToggleAll={toggleAll}
+              onRowClick={(id, ri) => { setFocusIdx(ri); setOpenSaleId(id); }}
               onPayClick={(saleId, invoiceNo, dueAmount) => setPayDialog({ saleId, invoiceNo, dueAmount })}
             />
           </div>


### PR DESCRIPTION
## Summary
**Onda Unificação Sells — PR 4/6.** Introduce flag `?unificada=1` que substitui a tabela inline da Lista pelo `SellsTabelaUnificada` (PR3) com `visibleColumns` derivado da tab Visão ativa (PR2). **Larissa biz=4 não vê mudança** (flag default off).

## Diff (1 arquivo, 45+/2-)

`resources/js/Pages/Sells/Index.tsx`:
1. Import `SellsTabelaUnificada` + 3 presets + tipos
2. Detect `?unificada=1` via `URLSearchParams` (mesmo padrão que `?tabs=1`)
3. `useMemo visibleColumns` deriva preset baseado em `visao` + filtra `commission` quando setting off
4. JSX ternário aninhado: `viewMode=grade-avancada → SellsGradeAvancada` | `unificadaFlagOn → SellsTabelaUnificada` | `else → markup inline atual` (intocado pra rollback rápido)

## Matriz de combinações (todas flag-only)

| URL | Render | Observações |
|---|---|---|
| `/sells` | Lista inline atual | Larissa default — **zero mudança** |
| `/sells?tabs=1` | Lista inline + tabs visíveis | PR2 |
| `/sells?unificada=1` | `SellsTabelaUnificada` Operacional (preset default) | smoke alvo |
| `/sells?tabs=1&unificada=1` | `SellsTabelaUnificada` + tabs alteram visão | smoke alvo |
| toggle viewMode=grade-avancada | `SellsGradeAvancada` legacy | intocado |

## Test plan
- [x] TS check zero erros novos
- [ ] Smoke pós-deploy biz=1:
  1. `/sells` (sem flags) → markup inline atual, idêntico ao que está em prod ✅
  2. `/sells?unificada=1` → tabela renderiza idêntica (markup copy do PR3, css `vd-*`/`os-*` preservadas)
  3. `/sells?tabs=1&unificada=1` + click "Financeira" → colunas trocam pra `Total / Pago / A receber`
  4. Click "Operacional" → volta ao default

## Não cobre
- Cutover default (PR6) — flag fica off enquanto PR5 popover refinement merge não estabilizar
- Delete `SellsGradeAvancada.tsx` (PR6)
- Pest re-baseline (PR6)

## Conflito esperado com PR #1329 (PR5 popover)
PR5 remove state `payDialog`/`setPayDialog` e migra pra popover anchored. Este PR4 ainda passa `onPayClick → setPayDialog`. Após mergear PR4, o branch PR5 precisará rebase + ajustar `SellsTabelaUnificada` pra também usar popover (replico mesma migração que ele fez no `SellsGradeAvancada`).

## Refs
- [PR #1326](https://github.com/wagnerra23/oimpresso.com/pull/1326) — tabs flag
- [PR #1328](https://github.com/wagnerra23/oimpresso.com/pull/1328) — extract `SellsTabelaUnificada`
- [ADR 0178](memory/decisions/0178-sells-unified-tabs-visao-supersede-0136.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)