### PR TITLE
fix(sells): densidade v2 — corrige PR #1337 (regra .vendas-aplus venceu por especificidade)

### DIFF
--- a/resources/css/sells-cowork.css
+++ b/resources/css/sells-cowork.css
@@ -5306,7 +5306,10 @@
   font-weight: 600; padding: 9px 12px;
 }
 .sells-cowork .vendas-aplus .vd-aplus-table tbody td {
-  padding: 10px 12px; vertical-align: middle;
+  /* Wagner 2026-05-21 — densidade compacta v2 (era 10px). Esta regra com 3
+     classes vence em especificidade sobre .sells-cowork .os-table tbody td
+     (2 classes) do PR #1337 — fix de density. */
+  padding: 6px 12px; vertical-align: middle;
 }
 .sells-cowork .vendas-aplus .vd-aplus-table .vd-chk { padding: 0 0 0 12px; width: 24px; }
 .sells-cowork .vendas-aplus .vd-aplus-table .os-row.selected td { background: var(--vd-green-soft); }


### PR DESCRIPTION
PR #1337 mudou padding em `.sells-cowork .os-table tbody td` mas computed style permanecia em 10px. Investigação via CSSRules iteration revelou outra regra com **3 classes** (`.sells-cowork .vendas-aplus .vd-aplus-table tbody td`) vencendo sobre a de 2 classes. Fix: aplica 6px também na regra mais específica. Linha ~32px (de ~42px), estilo Linear/Notion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)