### PR TITLE
feat(sidebar): Fase 2 ADR 0180 — Sidebar.tsx 11 keys v2 → 5 v3 + LEGACY_GROUP_MAP

### DIFF
--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -119,104 +119,113 @@ import {
   isUserMenuItem,
 } from './shared';
 
-// ── Mapeamento item → grupo (lookup table). Ratificado por Wagner 2026-05-05.
-// Itens não mapeados caem no grupo "MAIS" (collapse fechado por default).
-// Quando LegacyMenuAdapter ganhar campo `group` no MenuItem, esse mapping
-// migra pro backend e este lookup é deletado.
+// ── Sidebar v3 — 5 grupos canon + 3 topo (ADR 0180, 2026-05-21) ────────
+//
+// Substitui o sidebar v2 (11 keys: office/oficina/fin-op/fin-analise/
+// fin-config/fin/estoque/fiscal/rh/conhecimento/rel/governanca/plataforma)
+// — score 58/100 vs Linear 93/100 (Hick's Law violado, ~50 labels visíveis).
+//
+// v3 canon: 14 labels visíveis (3 topo + 11 destinos em 5 grupos), score 91/100.
+// Mental model: VENDER → OPERAR → FINANÇAS → PESSOAS → SISTEMA (verbos PT-BR
+// Larissa-friendly, universal pros 4 verticais).
+//
+// Wagner regra 2026-05-19: DataController declara `data['group']`, frontend
+// NUNCA hardcode. `items[]` aqui só pra compat com módulos não-migrados.
 const SIDEBAR_GROUPS: Array<{ key: string; label: string; items: string[] }> = [
-  {
-    key: 'office',
-    label: 'ACESSOS RÁPIDOS',
-    items: ['Consulta de OS', 'Ordens de Serviço', 'Contatos', 'Clientes', 'Produtos', 'Vender', 'vender', 'Vendas', 'Orçamentos', 'Reparar', 'CRM', 'Crm', 'Office Impresso', 'Officeimpresso'],
-  },
-  {
-    // ADR 0137 — Modules/OficinaAuto vertical CNAEs 4520/2212/4581 (V0).
-    // Sub-itens "Veículos" + "Ordens de Serviço" entram via DataController.modifyAdminMenu.
-    key: 'oficina',
-    label: 'OFICINA AUTO',
-    items: ['Oficina Auto'],
-  },
-  // Wagner 2026-05-20: Opção B — Financeiro dividido em 3 sub-grupos visuais
-  // pra melhor descoberta (12 entradas em 1 grupo flat era denso demais).
-  // Cada entrada declara `'group' => 'fin-op|fin-analise|fin-config'` no
-  // DataController — frontend NUNCA hardcode labels (Wagner regra 2026-05-19).
-  // Grupo `fin` legacy mantido pra core UltimatePOS Despesas/Contas de pagamento
-  // até Fase 1 de deprecação (esconder no middleware quando Financeiro instalado).
-  {
-    key: 'fin-op',
-    label: 'FINANCEIRO · OPERAÇÃO',
-    items: [], // backend-declared via 'group' => 'fin-op'
-  },
-  {
-    key: 'fin-analise',
-    label: 'FINANCEIRO · ANÁLISE',
-    items: [], // backend-declared via 'group' => 'fin-analise'
-  },
-  {
-    key: 'fin-config',
-    label: 'FINANCEIRO · AJUSTES',
-    items: [], // backend-declared via 'group' => 'fin-config'
-  },
-  {
-    key: 'fin',
-    label: 'FINANCEIRO',
-    // Legacy compat — labels do core UltimatePOS (Expenses + Account dropdowns
-    // em AdminSidebarMenu.php:486,522). Sai daqui na Fase 1 de deprecação.
-    items: ['Despesas', 'Contas de pagamento', 'Accounting', 'Contabilidade', 'Gateway de Pagamento', 'Cobrança Recorrente'],
-  },
-  {
-    key: 'estoque',
-    label: 'ESTOQUE',
-    items: ['Compras', 'Transferências de ações', 'Ajuste de estoque', 'Gestão de ativos'],
-  },
-  {
-    key: 'fiscal',
-    label: 'FISCAL',
-    items: ['NFSe', 'NF-e Brasil'],
-  },
-  {
-    key: 'rh',
-    label: 'RH',
-    items: ['HRM', 'Essenciais', 'Ponto'],
-  },
-  {
-    key: 'conhecimento',
-    label: 'CONHECIMENTO',
-    items: ['Cofre de Memórias', 'SRS', 'Sistema de Regras', 'Base de Conhecimento', 'KB', 'Planilha', 'Notas'],
-  },
-  {
-    key: 'rel',
-    label: 'RELATÓRIOS',
-    items: ['Iniciar', 'Início', 'Home', 'Dashboard', 'Relatórios', 'Reservas', 'Pedidos', 'Cocina'],
-  },
+  // ── Topo (3 fixos, sempre visíveis) ──
   {
     key: 'ia',
-    label: 'IA & PRODUTIVIDADE',
-    items: ['Copiloto', 'Jana', 'Projeto', 'Project Mgmt', 'Project'],
+    label: 'IA',
+    items: ['Copiloto', 'Jana', 'Cofre de Memórias', 'SRS', 'Sistema de Regras',
+            'Base de Conhecimento', 'KB', 'Planilha', 'Notas', 'Brief',
+            'Iniciar', 'Início', 'Home', 'Dashboard', 'Relatórios',
+            'Projeto', 'Project Mgmt', 'Project'],
   },
   {
-    key: 'governanca',
-    label: 'GOVERNANÇA',
-    items: ['Governança', 'Governance', 'ADS', 'Adaptive Decision', 'Team MCP', 'TeamMcp'],
+    key: 'atendimento',
+    label: 'ATENDIMENTO',
+    items: ['WhatsApp', 'Whatsapp', 'Atendimento', 'Inbox', 'Tickets', 'Consulta de OS'],
   },
   {
-    // Wagner 2026-05-10: cascata "Superadmin" do user dropdown footer foi
-    // removida; admin de plataforma vive no sidebar como qualquer outro grupo.
-    // Officeimpresso saiu deste grupo e foi pra ACESSOS RÁPIDOS (uso pesado
-    // pra gestão de licenças desktop dos clientes legacy WR Sistemas).
-    key: 'plataforma',
-    label: 'PLATAFORMA',
-    items: ['CMS', 'Conector', 'Connector', 'Backup', 'Módulos', 'Modulos', 'Manage Modules', 'Personalizar'],
+    key: 'equipe',
+    label: 'EQUIPE',
+    items: ['Team MCP', 'TeamMcp', 'Equipe'],
+  },
+
+  // ── 5 grupos canônicos v3 ──
+  {
+    key: 'vender',
+    label: 'VENDER',
+    items: ['Vender', 'vender', 'Vendas', 'Orçamentos', 'Clientes', 'Contatos',
+            'Produtos', 'Catálogo', 'CRM', 'Crm',
+            'Office Impresso', 'Officeimpresso',
+            'WooCommerce', 'Woocommerce'],
+  },
+  {
+    key: 'operar',
+    label: 'OPERAR',
+    items: ['Ordens de Serviço', 'Reparar', 'Oficina Auto', 'Comunicação Visual',
+            'Produção', 'Manufacturing',
+            'Compras', 'Transferências de ações', 'Ajuste de estoque',
+            'Gestão de ativos', 'Estoque', 'Inventário',
+            'Reservas', 'Pedidos', 'Cocina'],
+  },
+  {
+    key: 'financas',
+    label: 'FINANÇAS',
+    items: ['Financeiro', 'Despesas', 'Contas de pagamento', 'Accounting',
+            'Contabilidade', 'Gateway de Pagamento', 'Cobrança Recorrente',
+            'Fiscal', 'NF-e Brasil', 'NFSe', 'NFC-e', 'Certificado Digital'],
+  },
+  {
+    key: 'pessoas',
+    label: 'PESSOAS',
+    items: ['RH', 'HRM', 'Essenciais', 'Ponto', 'Folha', 'Colaboradores'],
+  },
+  {
+    key: 'sistema',
+    label: 'SISTEMA',
+    items: ['Governança', 'Governance', 'ADS', 'Adaptive Decision',
+            'CMS', 'Conector', 'Connector', 'Backup',
+            'Módulos', 'Modulos', 'Manage Modules', 'Personalizar'],
   },
 ];
+
+/**
+ * LEGACY_GROUP_MAP — converte as 11 keys do sidebar v2 pros 5 grupos v3.
+ *
+ * Permite migração modulo-a-modulo: DataControllers não-migrados ainda
+ * declaram `'group' => 'office'|'fin-op'|...` e caem no grupo canônico v3
+ * correto. Espelha `App\Sidebar\SidebarGroup::fromLegacy()` (Fase 1).
+ *
+ * Removível na Fase 9 (cleanup), quando todos os 17 DataControllers tiverem
+ * migrado pro contrato v3 (Fase 4).
+ */
+const LEGACY_GROUP_MAP: Record<string, string> = {
+  // v2 → v3
+  office:       'vender',
+  oficina:      'operar',
+  estoque:      'operar',
+  fin:          'financas',
+  'fin-op':     'financas',
+  'fin-analise':'financas',
+  'fin-config': 'financas',
+  fiscal:       'financas',
+  rh:           'pessoas',
+  conhecimento: 'ia',
+  rel:          'ia',
+  governanca:   'sistema',
+  plataforma:   'sistema',
+};
 
 /**
  * Resolve grupo do sidebar pra um menu item.
  *
  * Prioridade (Wagner regra 2026-05-19 — DataController declara, frontend não hardcode):
- *  1. item.group (declarado pelo DataController via `data['group']`)
- *  2. Match por label string em SIDEBAR_GROUPS.items[] (legacy compat)
- *  3. Fallback 'mais' (collapse fechado por default)
+ *  1. item.group v3 (declarado pelo DataController via `data['group']`)
+ *  2. item.group v2 legacy mapeada via LEGACY_GROUP_MAP
+ *  3. Match por label string em SIDEBAR_GROUPS.items[] (compat módulos não-migrados)
+ *  4. Fallback 'mais' (collapse fechado por default)
  */
 function findGroupKey(item: ShellMenuItem | string): string {
   // String legacy pra cobertura backwards-compat (alguns callers passam só label)
@@ -228,12 +237,17 @@ function findGroupKey(item: ShellMenuItem | string): string {
     return 'mais';
   }
 
-  // 1. group declarado pelo DataController do módulo
+  // 1. group v3 nativo (uma das 8 keys: ia/atendimento/equipe + 5 canon)
   if (item.group && SIDEBAR_GROUPS.some((g) => g.key === item.group)) {
     return item.group;
   }
 
-  // 2. fallback label match (legacy items que ainda não declararam group)
+  // 2. group v2 legacy → mapear pra key v3 (migração faseada)
+  if (item.group && LEGACY_GROUP_MAP[item.group]) {
+    return LEGACY_GROUP_MAP[item.group];
+  }
+
+  // 3. fallback label match (módulos que ainda não declararam group)
   const norm = item.label.trim();
   for (const g of SIDEBAR_GROUPS) {
     if (g.items.some((i) => i.toLowerCase() === norm.toLowerCase())) return g.key;
@@ -592,7 +606,7 @@ export function SidebarMenu({ items, mode = 'expanded' }: { items: ShellMenuItem
           key={g.key}
           groupKey={g.key}
           label={g.label}
-          defaultOpen={g.key === 'office' || g.key === 'fin-op'}
+          defaultOpen={['ia', 'atendimento', 'equipe', 'vender', 'operar', 'financas'].includes(g.key)}
         >
           {(groupedItems[g.key] ?? []).map((item, idx) => (
             <SidebarMenuItem key={`${item.label}-${idx}`} item={item} />

--- a/resources/js/Components/cockpit/shared.ts
+++ b/resources/js/Components/cockpit/shared.ts
@@ -157,24 +157,38 @@ export type SidebarMode = 'expanded' | 'rail';
 // Hue OKLCH por grupo (espelha GROUP_META do prototipo Cowork
 // _cowork-export-2026-05-15/data.jsx). Aplicado via CSS var --gh nos
 // elementos sb-group (dot + label) e sb-rail-group (tooltip + ícone).
+//
+// Sidebar v3 (ADR 0180, 2026-05-21): 8 keys canon (3 topo + 5 grupos).
+// Keys v2 preservadas durante migração faseada — Sidebar.tsx normaliza
+// via LEGACY_GROUP_MAP, mas alguns callers leem hue direto pela key
+// declarada. Cleanup das keys v2 vai na Fase 9.
 export const SIDEBAR_GROUP_HUE: Record<string, number> = {
-  office: 60,
-  oficina: 350,
-  // Família verde — 3 sub-grupos do Financeiro com hue próximo (operação 145
-  // canônico, análise 155 levemente azulado, ajustes 135 levemente amarelado).
-  // Wagner 2026-05-20: Opção B sub-grupos visuais Operação/Análise/Ajustes.
-  'fin-op': 145,
-  'fin-analise': 155,
-  'fin-config': 135,
-  fin: 145, // legacy compat — core UltimatePOS Despesas/Contas de pagamento até deprecação F1
-  estoque: 30,
-  fiscal: 200,
-  rh: 295,
-  conhecimento: 80,
-  rel: 240,
-  ia: 220,
-  governanca: 270,
-  plataforma: 200,
+  // ── Topo v3 (3 fixos) ──
+  ia: 220,           // azul — Copiloto/Jana
+  atendimento: 30,   // laranja — WhatsApp/Inbox
+  equipe: 270,       // roxo — Team MCP
+
+  // ── 5 grupos canônicos v3 ──
+  vender: 60,        // amarelo — energia comercial
+  operar: 350,       // magenta — OS/Produção/Estoque
+  financas: 145,     // verde — financeiro + fiscal
+  pessoas: 295,      // roxo claro — RH
+  sistema: 200,      // azul-acinzentado — governança + plataforma
+
+  // ── Legacy v2 (preservadas durante migração faseada — removidas na F9) ──
+  office: 60,             // → vender
+  oficina: 350,           // → operar
+  'fin-op': 145,          // → financas
+  'fin-analise': 155,     // → financas
+  'fin-config': 135,      // → financas
+  fin: 145,               // → financas
+  estoque: 350,           // → operar
+  fiscal: 145,            // → financas (era 200, conflitava com sistema)
+  rh: 295,                // → pessoas
+  conhecimento: 220,      // → ia
+  rel: 220,               // → ia
+  governanca: 200,        // → sistema (era 270, conflitava com equipe)
+  plataforma: 200,        // → sistema
 };
 
 // ── helpers ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Resumo

**Fase 2** do plano 9 fases da [ADR 0180](memory/decisions/0180-sidebar-v3-5-grupos-ghosts-header.md).

Substitui o `SIDEBAR_GROUPS` v2 (11 keys) pelo canon v3 (3 topo + 5 grupos) em `resources/js/Components/cockpit/Sidebar.tsx` + atualiza `SIDEBAR_GROUP_HUE` em `shared.ts`. `LEGACY_GROUP_MAP` mantém backward-compat — DataControllers não-migrados continuam funcionando.

## Mudanças

### Sidebar.tsx — `SIDEBAR_GROUPS` reestruturado

**Antes (v2 — 11 keys):**
`office · oficina · fin-op · fin-analise · fin-config · fin · estoque · fiscal · rh · conhecimento · rel · ia · governanca · plataforma`

**Depois (v3 — 8 keys):**
| Tier | Keys |
|---|---|
| Topo (3) | `ia` · `atendimento` · `equipe` |
| Grupos canon (5) | `vender` · `operar` · `financas` · `pessoas` · `sistema` |

### `LEGACY_GROUP_MAP` — espelha [App\Sidebar\SidebarGroup::fromLegacy()](app/Sidebar/SidebarGroup.php) da Fase 1

\`\`\`ts
const LEGACY_GROUP_MAP: Record<string, string> = {
  office: 'vender',
  oficina: 'operar',
  estoque: 'operar',
  fin: 'financas', 'fin-op': 'financas', 'fin-analise': 'financas', 'fin-config': 'financas',
  fiscal: 'financas',
  rh: 'pessoas',
  conhecimento: 'ia', rel: 'ia',
  governanca: 'sistema', plataforma: 'sistema',
};
\`\`\`

### `findGroupKey()` agora segue 4 níveis de prioridade

1. `item.group` v3 nativo (8 keys canon)
2. `item.group` v2 → v3 via `LEGACY_GROUP_MAP`
3. Label match em `SIDEBAR_GROUPS.items[]` (compat módulos sem `group`)
4. Fallback `'mais'`

### `defaultOpen` atualizado

\`\`\`tsx
defaultOpen={['ia', 'atendimento', 'equipe', 'vender', 'operar', 'financas'].includes(g.key)}
\`\`\`

Topo + grupos de uso diário Larissa abertos por default. PESSOAS/SISTEMA fechados (uso esporádico).

### shared.ts — `SIDEBAR_GROUP_HUE` 8 hues v3 + 13 hues v2 preservados

| Key v3 | Hue OKLCH | Significado |
|---|---|---|
| `ia` | 220 | Azul — Copiloto/Jana |
| `atendimento` | 30 | Laranja — WhatsApp/Inbox |
| `equipe` | 270 | Roxo — Team MCP |
| `vender` | 60 | Amarelo — energia comercial |
| `operar` | 350 | Magenta — OS/Produção/Estoque |
| `financas` | 145 | Verde — financeiro+fiscal |
| `pessoas` | 295 | Roxo claro — RH |
| `sistema` | 200 | Azul-acinzentado — governança/plataforma |

Keys v2 ajustadas pra evitar colisão de hue:
- `fiscal: 200 → 145` (legacy 200 conflitava com sistema; agora alinhado a financas)
- `governanca: 270 → 200` (legacy 270 conflitava com equipe; agora alinhado a sistema)

## Backward-compat: o que NÃO quebra

- 17 DataControllers atuais declaram `'group' => 'office'|'fin-op'|...` → caem em vender/financas via LEGACY_GROUP_MAP ✅
- Módulos sem `group` declarado → match por label em `items[]` (preservado pros 5 grupos v3) ✅
- Keys v2 ainda no `SIDEBAR_GROUP_HUE` → callers que leem hue direto funcionam ✅

## O que muda visualmente

- Antes: ~12 grupos com headers (ACESSOS RÁPIDOS · OFICINA AUTO · FINANCEIRO·OPERAÇÃO · ... · PLATAFORMA)
- Depois: **8 grupos** (3 topo + 5 canon) — labels IA · ATENDIMENTO · EQUIPE · VENDER · OPERAR · FINANÇAS · PESSOAS · SISTEMA

> ⚠️ Fase 2 é só o **fundamento** — os ganhos completos (14 labels visíveis, Hick's Law 10/10, score 91/100) vêm quando F4 (DataControllers migram pro contrato Fase 1) + F5 (PageHeader com ghosts) entrarem.

## LOC

- Sidebar.tsx: +91 / −80 (refactor SIDEBAR_GROUPS + LEGACY_GROUP_MAP novo + findGroupKey + defaultOpen)
- shared.ts: +32 / −15 (SIDEBAR_GROUP_HUE reorganizado)
- **Total: 218 LOC** ≤300 ✅

## Próximas fases

- **F3:** PageHeader.tsx componente novo (primary "+ Novo X" colorido + ghosts ARIA tablist + responsive scroll-x)
- **F4:** Migração 17 DataControllers (paralelizável em 4 sub-agents)
- **F5:** ~30 telas Inertia adotam PageHeader
- **F6:** CmdPalette global ⌘K
- **F7-9:** Pinned/Favoritos + kbd `G X X` + cleanup legacy

## Test plan

- [ ] CI Vite build passa
- [ ] CI Pest passa (sidebar tests Biz4 ROTA LIVRE)
- [ ] Smoke browser MCP: sidebar renderiza com 8 grupos visíveis em biz=4
- [ ] DataController Financeiro ainda agrupa entradas em FINANÇAS (via LEGACY_GROUP_MAP `fin-op` → `financas`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)