### PR TITLE
feat(sidebar): Fase 4 piloto Financeiro ADR 0180 — propaga shortcut/primary/ghosts

### DIFF
--- a/Modules/Crm/SCOPE.md
+++ b/Modules/Crm/SCOPE.md
@@ -4,6 +4,8 @@ purpose: "UltimatePOS herdado (CRM core)."
 contains:
   - "CallLogController"
   - "CampaignController"
+  - "ClienteAuditoriaController"   # Wave F LGPD (#1344 merged 2026-05-21)
+  - "ClienteIaController"          # Wave E IA cards (#1344 merged 2026-05-21)
   - "ContactBookingController"
   - "ContactLoginController"
   - "CrmDashboardController"

--- a/Modules/Financeiro/Http/Controllers/DataController.php
+++ b/Modules/Financeiro/Http/Controllers/DataController.php
@@ -133,14 +133,51 @@ class DataController extends Controller
                 // ═══════════════════════════════════════════════════════════
 
                 // Visão Unificada — cockpit AR+AP (entrada principal).
+                //
+                // ADR 0180 Fase 4 piloto Financeiro (2026-05-21): entry principal
+                // declara atributos extras que LegacyMenuAdapter propaga pro frontend:
+                //  - `shortcut` G F → atalho kbd canônico (overlay visual em Fase 8)
+                //  - `primary`     → botão "+ Novo título" colorido (PageHeaderTabs)
+                //  - `ghosts`      → 13 tabs ARIA da tela /financeiro/unificado
+                //
+                // As outras 12 entries continuam exibidas no sidebar (Wagner Opção B
+                // 2026-05-20 — sub-grupos visuais Operação/Análise/Ajustes preservada).
+                // Quando Fase 5 entregar PageHeaderTabs nas telas, a navegação
+                // contextual entre sub-views vai espelhar este shape — sidebar pode
+                // então enxugar pras 1 entry canon em PR futuro sem quebrar UX.
+                //
+                // hrefs dos ghosts usam path absoluto (url() seria interpretado pelo
+                // LegacyMenuAdapter::toRelative). Espelha contrato
+                // App\Sidebar\SidebarGhost (kebab-case key + label + path absoluto).
                 $menu->url(
                     url('/financeiro/unificado'),
                     __('financeiro::financeiro.module_label'),
                     [
-                        'icon'   => 'fa fas fa-coins',
-                        'style'  => 'background-color:' . $background_color,
-                        'active' => $segmento_ativo && (request()->segment(2) == 'unificado' || request()->segment(2) == null),
-                        'group'  => 'fin-op',
+                        'icon'     => 'fa fas fa-coins',
+                        'style'    => 'background-color:' . $background_color,
+                        'active'   => $segmento_ativo && (request()->segment(2) == 'unificado' || request()->segment(2) == null),
+                        'group'    => 'fin-op',
+                        'shortcut' => 'G F',
+                        'primary'  => [
+                            'label'    => 'Novo título',
+                            'href'     => '/financeiro/lancamentos/create',
+                            'shortcut' => 'N',
+                        ],
+                        'ghosts'   => [
+                            ['key' => 'unificado',         'label' => 'Unificado',         'href' => '/financeiro/unificado'],
+                            ['key' => 'contas-receber',    'label' => 'Contas a Receber',  'href' => '/financeiro/contas-receber'],
+                            ['key' => 'contas-pagar',      'label' => 'Contas a Pagar',    'href' => '/financeiro/contas-pagar'],
+                            ['key' => 'fluxo',             'label' => 'Fluxo de Caixa',    'href' => '/financeiro/fluxo'],
+                            ['key' => 'cobranca',          'label' => 'Cobrança',          'href' => '/financeiro/cobranca'],
+                            ['key' => 'caixa',             'label' => 'Caixa do turno',    'href' => '/financeiro/caixa'],
+                            ['key' => 'conciliacao',       'label' => 'Conciliação',       'href' => '/financeiro/conciliacao'],
+                            ['key' => 'dre',               'label' => 'DRE',               'href' => '/financeiro/dre'],
+                            ['key' => 'relatorios',        'label' => 'Relatórios',        'href' => '/financeiro/relatorios'],
+                            ['key' => 'contas-bancarias',  'label' => 'Contas Bancárias',  'href' => '/financeiro/contas-bancarias'],
+                            ['key' => 'plano-contas',      'label' => 'Plano de Contas',   'href' => '/financeiro/plano-contas'],
+                            ['key' => 'categorias',        'label' => 'Categorias',        'href' => '/financeiro/categorias'],
+                            ['key' => 'contador',          'label' => 'Contador',          'href' => '/financeiro/configuracoes/contador'],
+                        ],
                     ]
                 )->order(85.00);
 

--- a/app/Services/LegacyMenuAdapter.php
+++ b/app/Services/LegacyMenuAdapter.php
@@ -313,6 +313,19 @@ class LegacyMenuAdapter
             $result['group'] = (string) $group;
         }
 
+        // ADR 0180 Fase 4 — propaga atalho kbd + primary action + ghosts tabs
+        // declarados pelo DataController do módulo. Lidos quando MenuItem.tsx
+        // (sidebar) usa shortcut como dica visual, e quando PageHeaderTabs
+        // (Components/shared, Fase 3) consome primary+ghosts pra renderizar
+        // tabs no header da tela. Não é propagada estrutura — apenas pass-through
+        // do payload exatamente como o backend declarou.
+        foreach (['shortcut', 'primary', 'ghosts'] as $extraKey) {
+            $value = $props[$extraKey] ?? $props['attributes'][$extraKey] ?? null;
+            if ($value !== null && $value !== '' && $value !== []) {
+                $result[$extraKey] = $value;
+            }
+        }
+
         if (!empty($children)) {
             $result['children'] = $children;
             // Pais dropdown geralmente não têm URL própria no nwidart — deixamos undef

--- a/tests/Feature/Services/LegacyMenuAdapterSidebarV3Test.php
+++ b/tests/Feature/Services/LegacyMenuAdapterSidebarV3Test.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest test — LegacyMenuAdapter propaga shortcut/primary/ghosts (ADR 0180 Fase 4).
+ *
+ * Garante que os 3 campos novos do contrato Sidebar v3 (declarados pelo
+ * DataController via attributes) são propagados intactos pelo adapter pro
+ * shape consumido pelo frontend (PageHeaderTabs + Cmd+K em fases futuras).
+ *
+ * Não toca banco. Usa Menu::create direto pra montar instância em memória.
+ */
+
+use App\Services\LegacyMenuAdapter;
+use Illuminate\Support\Facades\Facade;
+
+beforeEach(function () {
+    // Reset da instância do menu entre testes (Menu é facade singleton).
+    if (\Menu::instance('sidebar-v3-test')) {
+        Facade::clearResolvedInstance('menu');
+    }
+});
+
+it('propaga shortcut/primary/ghosts quando declarados nos attributes', function () {
+    \Menu::create('admin-sidebar-menu', function ($menu) {
+        $menu->url('/financeiro/unificado', 'Financeiro', [
+            'icon'     => 'fa fa-coins',
+            'group'    => 'fin-op',
+            'shortcut' => 'G F',
+            'primary'  => [
+                'label'    => 'Novo título',
+                'href'     => '/financeiro/lancamentos/create',
+                'shortcut' => 'N',
+            ],
+            'ghosts'   => [
+                ['key' => 'unificado',      'label' => 'Unificado',      'href' => '/financeiro/unificado'],
+                ['key' => 'contas-receber', 'label' => 'Contas a Receber','href' => '/financeiro/contas-receber'],
+                ['key' => 'contas-pagar',   'label' => 'Contas a Pagar', 'href' => '/financeiro/contas-pagar'],
+            ],
+        ])->order(85);
+    });
+
+    $built = (new LegacyMenuAdapter())->build();
+
+    expect($built)->toHaveCount(1);
+
+    $item = $built[0];
+
+    expect($item['label'])->toBe('Financeiro')
+        ->and($item['href'])->toBe('/financeiro/unificado')
+        ->and($item['group'])->toBe('fin-op')
+        ->and($item['shortcut'])->toBe('G F');
+
+    expect($item['primary'])->toBe([
+        'label'    => 'Novo título',
+        'href'     => '/financeiro/lancamentos/create',
+        'shortcut' => 'N',
+    ]);
+
+    expect($item['ghosts'])->toHaveCount(3)
+        ->and($item['ghosts'][0])->toBe([
+            'key' => 'unificado', 'label' => 'Unificado', 'href' => '/financeiro/unificado',
+        ])
+        ->and($item['ghosts'][2]['key'])->toBe('contas-pagar');
+});
+
+it('omite shortcut/primary/ghosts quando não declarados (backward-compat)', function () {
+    \Menu::create('admin-sidebar-menu', function ($menu) {
+        $menu->url('/financeiro/relatorios', 'Relatórios', [
+            'icon' => 'fa fa-chart-pie',
+            'group' => 'fin-analise',
+        ])->order(85);
+    });
+
+    $item = (new LegacyMenuAdapter())->build()[0];
+
+    expect($item)->toHaveKey('label', 'Relatórios')
+        ->toHaveKey('group', 'fin-analise')
+        ->not->toHaveKey('shortcut')
+        ->not->toHaveKey('primary')
+        ->not->toHaveKey('ghosts');
+});
+
+it('aceita os 3 atributos novos via aninhamento attributes[] (alternativa)', function () {
+    \Menu::create('admin-sidebar-menu', function ($menu) {
+        $menu->url('/x', 'X', [
+            'attributes' => [
+                'shortcut' => 'G X',
+                'ghosts'   => [['key' => 'foo', 'label' => 'Foo', 'href' => '/x?tab=foo']],
+            ],
+        ]);
+    });
+
+    $item = (new LegacyMenuAdapter())->build()[0];
+
+    expect($item['shortcut'])->toBe('G X')
+        ->and($item['ghosts'])->toHaveCount(1)
+        ->and($item['ghosts'][0]['key'])->toBe('foo');
+});
+
+it('ignora ghosts vazios (array vazio NÃO entra no payload)', function () {
+    \Menu::create('admin-sidebar-menu', function ($menu) {
+        $menu->url('/x', 'X', [
+            'group'  => 'sistema',
+            'ghosts' => [],
+        ]);
+    });
+
+    $item = (new LegacyMenuAdapter())->build()[0];
+
+    expect($item)->not->toHaveKey('ghosts');
+});


### PR DESCRIPTION
## Resumo

**Fase 4 (piloto Financeiro)** do plano 9 fases da [ADR 0180](memory/decisions/0180-sidebar-v3-5-grupos-ghosts-header.md).

Estende o pipeline backend → Inertia shared pra propagar os 3 campos novos do contrato Sidebar v3 (`shortcut`, `primary`, `ghosts`) **sem quebrar UX atual**. Piloto valida o fluxo end-to-end Modules → LegacyMenuAdapter → frontend antes de paralelizar os 16 DataControllers restantes.

## Mudanças cirúrgicas (low-risk)

### 1. `LegacyMenuAdapter::convertItem()` — propaga 3 campos novos

\`\`\`php
foreach (['shortcut', 'primary', 'ghosts'] as $extraKey) {
    $value = $props[$extraKey] ?? $props['attributes'][$extraKey] ?? null;
    if ($value !== null && $value !== '' && $value !== []) {
        $result[$extraKey] = $value;
    }
}
\`\`\`

- Backward-compat 100%: null/vazio/array vazio não entram no payload
- Aceita declaração direta OU aninhada em `attributes[]`

### 2. `Modules/Financeiro/DataController` — entry "Visão Unificada" ganha attrs novos

A entry principal declara:
- **shortcut:** `'G F'`
- **primary:** `{label: 'Novo título', href: '/financeiro/lancamentos/create', shortcut: 'N'}`
- **ghosts[]:** 13 sub-views

\`\`\`php
'ghosts' => [
    ['key' => 'unificado',        'label' => 'Unificado',         'href' => '/financeiro/unificado'],
    ['key' => 'contas-receber',   'label' => 'Contas a Receber',  'href' => '/financeiro/contas-receber'],
    ['key' => 'contas-pagar',     'label' => 'Contas a Pagar',    'href' => '/financeiro/contas-pagar'],
    ['key' => 'fluxo',            'label' => 'Fluxo de Caixa',    'href' => '/financeiro/fluxo'],
    ['key' => 'cobranca',         'label' => 'Cobrança',          'href' => '/financeiro/cobranca'],
    ['key' => 'caixa',            'label' => 'Caixa do turno',    'href' => '/financeiro/caixa'],
    ['key' => 'conciliacao',      'label' => 'Conciliação',       'href' => '/financeiro/conciliacao'],
    ['key' => 'dre',              'label' => 'DRE',               'href' => '/financeiro/dre'],
    ['key' => 'relatorios',       'label' => 'Relatórios',        'href' => '/financeiro/relatorios'],
    ['key' => 'contas-bancarias', 'label' => 'Contas Bancárias',  'href' => '/financeiro/contas-bancarias'],
    ['key' => 'plano-contas',     'label' => 'Plano de Contas',   'href' => '/financeiro/plano-contas'],
    ['key' => 'categorias',       'label' => 'Categorias',        'href' => '/financeiro/categorias'],
    ['key' => 'contador',         'label' => 'Contador',          'href' => '/financeiro/configuracoes/contador'],
],
\`\`\`

> **As outras 12 entries do sidebar Financeiro CONTINUAM exibidas** — Wagner Opção B (sub-grupos visuais Operação/Análise/Ajustes) preservada integralmente. Quando F5 entregar `PageHeaderTabs` nas telas, a navegação contextual usa o `ghosts[]` daqui — sidebar pode enxugar em PR futuro sem quebrar UX.

### 3. `Pest LegacyMenuAdapterSidebarV3Test` — 4 testes

| Teste | O que valida |
|---|---|
| propaga shortcut/primary/ghosts quando declarados | shape correto no payload |
| omite quando não declarados (backward-compat) | módulos antigos não quebram |
| aceita aninhamento via `attributes[]` | 2 formas de declaração |
| ignora ghosts vazios | `[]` não entra no payload |

## Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md))

DataController já filtra por `business_id` via `ModuleUtil.isModuleInstalled` + `financeiro_module` subscription package (linhas 67-92 do DataController). Ghosts respeitam o mesmo gate — tenant sem Financeiro não vê nem entry nem ghosts.

## O que NÃO muda nesta Fase

- Layout do sidebar (Wagner Opção B preservada)
- Comportamento de qualquer tela existente
- API pública das 13 rotas Financeiro
- Permission gates ou multi-tenant filtering

## Próximas fases

- **F4 paralela (16 DataControllers restantes)** — paralelizável em 4 sub-agents quando piloto Financeiro validar
- **F5 piloto Financeiro** — `Pages/Financeiro/Unificado/Index.tsx` adota `<PageHeaderTabs />` consumindo `ghosts[]` exportado por esta F4
- **F6-9** — CmdPalette ⌘K · Pinned · Atalhos kbd · Cleanup legacy

## LOC

- DataController.php: +45 / −1 (entry com ghosts/primary/shortcut)
- LegacyMenuAdapter.php: +13 (propagação 3 campos)
- Pest novo: +110 (4 testes)
- **Total: 167 LOC** ≤300 ✅

## Test plan

- [x] Pest novo passa local (4 testes)
- [ ] CI Pest passa (regressão completa Pest)
- [ ] CI Vite build passa (sem refs frontend mudaram)
- [ ] Smoke: sidebar Financeiro em biz=4 ROTA LIVRE renderiza igual ao pré-merge (Wagner Opção B preservada)

🤖 Generated with [Claude Code](https://claude.com/claude-code)