### PR TITLE
feat(sidebar): Fase 4 Wave B OPERAR (Repair/OficinaAuto/Manufacturing/Compras) — declaram ghosts (ADR 0180)

### DIFF
--- a/Modules/Compras/Http/Controllers/DataController.php
+++ b/Modules/Compras/Http/Controllers/DataController.php
@@ -94,10 +94,30 @@ class DataController extends Controller
         }
 
         \Menu::modify('admin-sidebar-menu', function ($menu) {
+            // ADR 0180 Fase 4 Wave B (2026-05-21): entry principal declara
+            // atalho kbd + primary action + ghosts tabs.
+            //  - `shortcut` G S → atalho overlay (Suprimentos/Estoque)
+            //  - `primary`     → "Nova compra" (rota /compras/create chega na Wave 3
+            //    do scaffold — declarado pra contrato sidebar v3, frontend pode
+            //    exibir 404/coming-soon enquanto não migra)
+            //  - `ghosts`      → Lista (index Wave 1); demais sub-views (importar XML,
+            //    NF entrada, etc) entram nas Waves 3-6 do SPEC.
             $menu->url(
                 action([\Modules\Compras\Http\Controllers\ComprasController::class, 'index']),
                 'Compras',
-                ['icon' => 'fa fas fa-shopping-cart', 'active' => request()->is('compras*')]
+                [
+                    'icon'     => 'fa fas fa-shopping-cart',
+                    'active'   => request()->is('compras*'),
+                    'shortcut' => 'G S',
+                    'primary'  => [
+                        'label'    => 'Nova compra',
+                        'href'     => '/compras/create',
+                        'shortcut' => 'N',
+                    ],
+                    'ghosts'   => [
+                        ['key' => 'lista', 'label' => 'Lista', 'href' => '/compras'],
+                    ],
+                ]
             )->order(45);
         });
     }

--- a/Modules/Manufacturing/Http/Controllers/DataController.php
+++ b/Modules/Manufacturing/Http/Controllers/DataController.php
@@ -69,11 +69,32 @@ class DataController extends Controller
 
         if ($is_mfg_enabled && (auth()->user()->can('manufacturing.access_recipe') || auth()->user()->can('manufacturing.access_production'))) {
             Menu::modify('admin-sidebar-menu', function ($menu) {
+                // ADR 0180 Fase 4 Wave B (2026-05-21): entry principal declara
+                // atalho kbd + primary action + ghosts tabs.
+                //  - `shortcut` G P → atalho overlay (Produção)
+                //  - `primary`     → "Nova ordem de produção" via ProductionController@create
+                //  - `ghosts`      → Receitas, Produções, Relatório, Configurações
                 $menu->url(
-                        action([\Modules\Manufacturing\Http\Controllers\RecipeController::class, 'index']),
-                        __('manufacturing::lang.manufacturing'),
-                        ['icon' => 'fa fas fa-industry', 'style' => config('app.env') == 'demo' ? 'background-color: #ff851b;' : '', 'active' => request()->segment(1) == 'manufacturing']
-                    )
+                    action([\Modules\Manufacturing\Http\Controllers\RecipeController::class, 'index']),
+                    __('manufacturing::lang.manufacturing'),
+                    [
+                        'icon'     => 'fa fas fa-industry',
+                        'style'    => config('app.env') == 'demo' ? 'background-color: #ff851b;' : '',
+                        'active'   => request()->segment(1) == 'manufacturing',
+                        'shortcut' => 'G P',
+                        'primary'  => [
+                            'label'    => 'Nova ordem de produção',
+                            'href'     => '/manufacturing/production/create',
+                            'shortcut' => 'N',
+                        ],
+                        'ghosts'   => [
+                            ['key' => 'recipe',     'label' => 'Receitas',        'href' => '/manufacturing/recipe'],
+                            ['key' => 'production', 'label' => 'Produções',       'href' => '/manufacturing/production'],
+                            ['key' => 'report',     'label' => 'Relatório',       'href' => '/manufacturing/report'],
+                            ['key' => 'settings',   'label' => 'Configurações',   'href' => '/manufacturing/settings'],
+                        ],
+                    ]
+                )
                 ->order(21);
             });
         }

--- a/Modules/OficinaAuto/Http/Controllers/DataController.php
+++ b/Modules/OficinaAuto/Http/Controllers/DataController.php
@@ -130,6 +130,12 @@ class DataController extends Controller
         Menu::modify(
             'admin-sidebar-menu',
             function ($menu) use ($segmento_ativo) {
+                // ADR 0180 Fase 4 Wave B (2026-05-21): dropdown principal declara
+                // atalho kbd + primary action + ghosts tabs no `attributes`.
+                //  - `shortcut` G Y → atalho overlay (não-conflito com Repair G O)
+                //  - `primary`     → "Nova OS" via ServiceOrderController@create
+                //  - `ghosts`      → Veículos, Ordens de Serviço, Produção (Kanban
+                //    caçambas Martinho 2026-05-13)
                 $menu->dropdown(
                     'Oficina Auto',
                     function ($sub) {
@@ -146,8 +152,19 @@ class DataController extends Controller
                         ]);
                     },
                     [
-                        'icon'   => 'fa fas fa-wrench',
-                        'active' => $segmento_ativo,
+                        'icon'     => 'fa fas fa-wrench',
+                        'active'   => $segmento_ativo,
+                        'shortcut' => 'G Y',
+                        'primary'  => [
+                            'label'    => 'Nova OS',
+                            'href'     => '/oficina-auto/ordens-servico/create',
+                            'shortcut' => 'N',
+                        ],
+                        'ghosts'   => [
+                            ['key' => 'veiculos',          'label' => 'Veículos',           'href' => '/oficina-auto/veiculos'],
+                            ['key' => 'ordens-servico',    'label' => 'Ordens de Serviço',  'href' => '/oficina-auto/ordens-servico'],
+                            ['key' => 'producao-oficina',  'label' => 'Produção',           'href' => '/oficina-auto/producao-oficina'],
+                        ],
                     ]
                 )->order(56);
             }

--- a/Modules/Repair/Http/Controllers/DataController.php
+++ b/Modules/Repair/Http/Controllers/DataController.php
@@ -168,11 +168,38 @@ class DataController extends Controller
 
         if ($is_repair_enabled && (auth()->user()->can('superadmin') || auth()->user()->can('repair.view') || auth()->user()->can('job_sheet.view_assigned') || auth()->user()->can('job_sheet.view_all'))) {
             Menu::modify('admin-sidebar-menu', function ($menu) use ($background_color) {
+                // ADR 0180 Fase 4 Wave B (2026-05-21): entry principal declara
+                // atalho kbd + primary action + ghosts tabs.
+                //  - `shortcut` G O → atalho overlay (Fase 8)
+                //  - `primary`     → "Nova OS" via SellPosController (sub_type=repair)
+                //  - `ghosts`      → sub-views da tela /repair/* (Dashboard, OS, Job Sheets,
+                //    Producao Oficina Kanban, Status, Settings)
+                //
+                // hrefs absolutos (LegacyMenuAdapter::toRelative espera path string).
                 $menu->url(
-                            action([\Modules\Repair\Http\Controllers\DashboardController::class, 'index']),
-                            __('repair::lang.repair'),
-                            ['icon' => 'fa fas fa-wrench', 'active' => request()->segment(1) == 'repair', 'style' => 'background-color:'.$background_color]
-                        )
+                    action([\Modules\Repair\Http\Controllers\DashboardController::class, 'index']),
+                    __('repair::lang.repair'),
+                    [
+                        'icon'     => 'fa fas fa-wrench',
+                        'active'   => request()->segment(1) == 'repair',
+                        'style'    => 'background-color:'.$background_color,
+                        'shortcut' => 'G O',
+                        'primary'  => [
+                            'label'    => 'Nova OS',
+                            'href'     => '/sells/pos/create?sub_type=repair',
+                            'shortcut' => 'N',
+                        ],
+                        'ghosts'   => [
+                            ['key' => 'dashboard',        'label' => 'Dashboard',         'href' => '/repair/dashboard'],
+                            ['key' => 'os',               'label' => 'OS de Reparo',      'href' => '/repair/repair'],
+                            ['key' => 'job-sheets',       'label' => 'Job Sheets',        'href' => '/repair/job-sheet'],
+                            ['key' => 'producao',         'label' => 'Produção',          'href' => '/repair/producao-oficina'],
+                            ['key' => 'status',           'label' => 'Status',            'href' => '/repair/status'],
+                            ['key' => 'device-models',    'label' => 'Modelos',           'href' => '/repair/device-models'],
+                            ['key' => 'settings',         'label' => 'Configurações',     'href' => '/repair/repair-settings'],
+                        ],
+                    ]
+                )
                 ->order(24);
             });
         }


### PR DESCRIPTION
## Summary

Continua o piloto Financeiro (#1350) propagando `shortcut` + `primary` + `ghosts` nos 4 DataControllers do grupo **OPERAR** do sidebar v3 (ADR 0180).

- **Backend-only.** Apenas attributes nas entries principais — nenhum frontend tocado.
- **`LegacyMenuAdapter`** (já em main via #1350) lê os 3 campos das properties → propaga pro shape consumido pelo `Sidebar.tsx` (Fase 2) e `PageHeaderTabs.tsx` (Fase 3).
- **Grupo legacy preservado** (NÃO mexido) — frontend `LEGACY_GROUP_MAP` cobre `oficina→operar` / `estoque→operar`.

## Módulos migrados

| Módulo | File | Shortcut | Primary | Ghosts |
|---|---|---|---|---|
| **Repair** | `Modules/Repair/Http/Controllers/DataController.php` | `G O` | "Nova OS" → `/sells/pos/create?sub_type=repair` | 7 (Dashboard, OS, Job Sheets, Produção, Status, Modelos, Settings) |
| **OficinaAuto** | `Modules/OficinaAuto/Http/Controllers/DataController.php` | `G Y` | "Nova OS" → `/oficina-auto/ordens-servico/create` | 3 (Veículos, Ordens de Serviço, Produção) |
| **Manufacturing** | `Modules/Manufacturing/Http/Controllers/DataController.php` | `G P` | "Nova ordem de produção" → `/manufacturing/production/create` | 4 (Receitas, Produções, Relatório, Configurações) |
| **Compras** | `Modules/Compras/Http/Controllers/DataController.php` | `G S` | "Nova compra" → `/compras/create` (Wave 3 placeholder) | 1 (Lista — Wave 1 scaffold) |

## Decisões

- **Shortcut `G Y` pra OficinaAuto** (não `G O`) — evita colisão com Repair, que tem precedência por ser módulo mais antigo + maior tráfego (~31 clientes Repair vs piloto OficinaAuto).
- **Shortcut `G S` pra Compras** (Suprimentos/Estoque) — alinhado com o atalho do grupo `operar` que já abriga Estoque.
- **OficinaAuto usa `dropdown()`** em vez de `url()` — attrs vão como 3º arg do dropdown (MenuBuilder linha 150 aceita esse shape: `dropdown(title, closure, attributes)`).
- **Compras `/compras/create` ainda não existe** — Wave 3 scaffold (SPEC.md). Declarado pra contrato sidebar v3 ficar pronto; frontend pode exibir 404/coming-soon enquanto não migra.
- **Ghosts de Repair** mapeiam 1:1 com o `nav.blade.php` legacy (Dashboard, OS, Job Sheets, Status, Modelos, Settings) + Produção Kanban (rota nova).

## Multi-tenant Tier 0 preservado

TODOS os gates `auth()->user()->can(...)` + `ModuleUtil::isModuleInstalled(...)` + `hasThePermissionInSubscription(...)` mantidos intactos em cada `modifyAdminMenu()`. Diff é puramente additive nos attributes de menu.

## Test plan

- [ ] CI verde (PHP CS Fixer + Pest)
- [ ] Sidebar v3 renderiza shortcut `G O / G Y / G P / G S` no hover dos 4 módulos
- [ ] PageHeaderTabs renderiza ghosts ao abrir Repair/OficinaAuto/Manufacturing/Compras
- [ ] Primary action "+ Nova X" navega pro href correto em cada módulo
- [ ] Multi-tenant: usuário sem permissão `repair.view` não vê entry Repair (gate intacto)
- [ ] Compras `/compras/create` → 404 (esperado até Wave 3); ghosts "Lista" funciona

## Refs

- ADR 0180 `memory/decisions/0180-sidebar-v3-5-grupos-ghosts-header.md`
- Fase 4 piloto Financeiro #1350
- Fase 1/2/3 sidebar v3 (DTOs + Sidebar.tsx + PageHeaderTabs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)