### PR TITLE
hotfix(sidebar): MenuItem getAttributes() ignora non-scalar (prod 500 PR #1353)

### DIFF
--- a/app/Services/Menu/MenuItem.php
+++ b/app/Services/Menu/MenuItem.php
@@ -195,7 +195,18 @@ class MenuItem implements Arrayable
 
         $parts = [];
         foreach ($attributes as $k => $v) {
-            $parts[] = is_int($k) ? e($v) : sprintf('%s="%s"', $k, e($v));
+            // ADR 0180 Fase 4 (PR #1350/#1353): attributes vira bag misto — alguns
+            // valores (primary[], ghosts[], shortcut struct) existem só pro
+            // LegacyMenuAdapter→React Sidebar e não fazem sentido como atributo
+            // HTML no Blade legacy. Ignora não-escalares pra não estourar e()
+            // com htmlspecialchars(): TypeError quando $v é array.
+            if ($v === null || is_array($v) || is_object($v)) {
+                continue;
+            }
+            if (is_bool($v)) {
+                $v = $v ? '1' : '0';
+            }
+            $parts[] = is_int($k) ? e((string) $v) : sprintf('%s="%s"', $k, e((string) $v));
         }
         return $parts ? ' ' . implode(' ', $parts) : '';
     }

--- a/tests/Feature/Sidebar/MenuItemAttributesScalarRenderTest.php
+++ b/tests/Feature/Sidebar/MenuItemAttributesScalarRenderTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Services\Menu\MenuItem;
+
+/*
+|--------------------------------------------------------------------------
+| MenuItem::getAttributes() — render seguro de attributes mistos
+|--------------------------------------------------------------------------
+|
+| Hotfix anti-regressão: ADR 0180 Fase 4 (PR #1350/#1353) populou os
+| attributes dos menu items com keys `primary` (array) e `ghosts` (array of
+| arrays) consumidos pelo LegacyMenuAdapter→React Sidebar. O renderer Blade
+| legacy (AdminlteCustomPresenter::getMenuWithoutDropdownWrapper) chama
+| MenuItem::getAttributes() que iterava o bag aplicando htmlspecialchars()
+| em cada valor — estourava TypeError quando $v era array.
+|
+| Esses testes garantem que valores não-escalares são silenciosamente
+| ignorados pelo renderer HTML e que valores escalares continuam saindo
+| escapados.
+*/
+
+it('ignora attribute value array sem estourar TypeError (regressão PR #1353)', function () {
+    $item = new MenuItem([
+        'url'        => '/repair',
+        'title'      => 'Reparo',
+        'attributes' => [
+            'style'    => 'background-color:#fff',
+            'shortcut' => 'G O',
+            'primary'  => [
+                'label'    => 'Nova OS',
+                'href'     => '/sells/pos/create?sub_type=repair',
+                'shortcut' => 'N',
+            ],
+            'ghosts'   => [
+                ['key' => 'dashboard', 'label' => 'Dashboard', 'href' => '/repair/dashboard'],
+                ['key' => 'os',        'label' => 'OS',        'href' => '/repair/repair'],
+            ],
+        ],
+    ]);
+
+    $rendered = $item->getAttributes();
+
+    expect($rendered)->toBeString();
+    expect($rendered)->toContain('style="background-color:#fff"');
+    expect($rendered)->toContain('shortcut="G O"');
+    expect($rendered)->not->toContain('primary=');
+    expect($rendered)->not->toContain('ghosts=');
+});
+
+it('escapa valores escalares com htmlspecialchars()', function () {
+    $item = new MenuItem([
+        'url'        => '/x',
+        'title'      => 'X',
+        'attributes' => [
+            'data-label' => 'a"b<c>',
+        ],
+    ]);
+
+    expect($item->getAttributes())->toContain('data-label="a&quot;b&lt;c&gt;"');
+});
+
+it('booleans viram "1"/"0" em vez de quebrar e()', function () {
+    $item = new MenuItem([
+        'url'        => '/x',
+        'title'      => 'X',
+        'attributes' => [
+            'data-active' => true,
+            'data-empty'  => false,
+        ],
+    ]);
+
+    $rendered = $item->getAttributes();
+
+    expect($rendered)->toContain('data-active="1"');
+    expect($rendered)->toContain('data-empty="0"');
+});
+
+it('null values são pulados', function () {
+    $item = new MenuItem([
+        'url'        => '/x',
+        'title'      => 'X',
+        'attributes' => [
+            'style'     => 'color:red',
+            'data-null' => null,
+        ],
+    ]);
+
+    $rendered = $item->getAttributes();
+
+    expect($rendered)->toContain('style="color:red"');
+    expect($rendered)->not->toContain('data-null');
+});
+
+it('objetos são pulados (defensivo — não deveria acontecer mas not blow up)', function () {
+    $item = new MenuItem([
+        'url'        => '/x',
+        'title'      => 'X',
+        'attributes' => [
+            'style' => 'color:red',
+            'weird' => new stdClass(),
+        ],
+    ]);
+
+    $rendered = $item->getAttributes();
+
+    expect($rendered)->toContain('style="color:red"');
+    expect($rendered)->not->toContain('weird');
+});
+
+it('attributes vazio retorna string vazia', function () {
+    $item = new MenuItem([
+        'url'        => '/x',
+        'title'      => 'X',
+        'attributes' => [],
+    ]);
+
+    expect($item->getAttributes())->toBe('');
+});


### PR DESCRIPTION
## Summary

- PR [#1353](https://github.com/wagnerra23/oimpresso.com/pull/1353) (merged 2026-05-21 16:58 BRT) adicionou `primary` (array) e `ghosts` (array of arrays) ao `attributes` dos menu items dos 4 DataControllers OPERAR (Repair/OficinaAuto/Manufacturing/Compras). Esses dados existem só pro LegacyMenuAdapter→React Sidebar — mas o renderer Blade legacy (`AdminlteCustomPresenter::getMenuWithoutDropdownWrapper`) chamava `MenuItem::getAttributes()`, que iterava o bag e fazia `htmlspecialchars($v)` em cada valor. Quando `$v` é array → `TypeError` → **500 em toda página Blade legacy desde 17:04 BRT**.
- Sintoma reportado: `GET /sells/25149/edit` (cai no Blade fallback `view('sell.edit')` quando URL aberta sem header `X-Inertia`).
- Fix defensivo único em [`app/Services/Menu/MenuItem.php:191`](app/Services/Menu/MenuItem.php#L191) — pula valores não-escalares antes de `e()`. Bool→"1"/"0". Comportamento de attributes escalares idêntico.

## Causa raiz

```
[2026-05-21 17:04:26] live.ERROR: htmlspecialchars(): Argument #1 ($string)
must be of type string, array given
#0 vendor/.../helpers.php(138): htmlspecialchars()
#1 app/Services/Menu/MenuItem.php(198): e()
#2 app/Http/AdminlteCustomPresenter.php(30): MenuItem->getAttributes()
#3 app/Services/Menu/MenuBuilder.php(223)
...
#7 resources/views/layouts/partials/sidebar.blade.php(18)
```

Páginas migradas pra AppShellV2 (React sidebar via DataController API) não passam por esse path → não foram afetadas.

## Test plan

- [x] `tests/Feature/Sidebar/MenuItemAttributesScalarRenderTest.php` — 6 testes verdes (array/object/null/bool/escape/empty)
- [x] `tests/Feature/Sidebar/SidebarMenuItemContractTest.php` — 24 verdes (zero regressão)
- [ ] Smoke prod pós-deploy: `curl -sv https://oimpresso.com/sells/25149/edit` cookie de Wagner → 200 (não 500)
- [ ] Conferir visualmente uma página Blade qualquer no browser

## Refs

- Causador: [#1353](https://github.com/wagnerra23/oimpresso.com/pull/1353) + [#1350](https://github.com/wagnerra23/oimpresso.com/pull/1350)
- ADR 0180 Fase 4

🤖 Generated with [Claude Code](https://claude.com/claude-code)