### PR TITLE
feat(sidebar): Fase 5 tweak2 Wagner — primary direita + actions overflow + label Financeiro

### DIFF
--- a/Modules/Financeiro/Http/Controllers/DataController.php
+++ b/Modules/Financeiro/Http/Controllers/DataController.php
@@ -164,7 +164,7 @@ class DataController extends Controller
                             'shortcut' => 'N',
                         ],
                         'ghosts'   => [
-                            ['key' => 'unificado',         'label' => 'Unificado',         'href' => '/financeiro/unificado'],
+                            ['key' => 'unificado',         'label' => 'Financeiro',        'href' => '/financeiro/unificado'],
                             ['key' => 'contas-receber',    'label' => 'Contas a Receber',  'href' => '/financeiro/contas-receber'],
                             ['key' => 'contas-pagar',      'label' => 'Contas a Pagar',    'href' => '/financeiro/contas-pagar'],
                             ['key' => 'fluxo',             'label' => 'Fluxo de Caixa',    'href' => '/financeiro/fluxo'],

--- a/resources/js/Components/shared/PageHeaderTabs.tsx
+++ b/resources/js/Components/shared/PageHeaderTabs.tsx
@@ -6,6 +6,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/Components/ui/dropdown-menu';
 import { SIDEBAR_GROUP_HUE } from '@/Components/cockpit/shared';
@@ -61,6 +62,22 @@ export interface PageHeaderGhost {
   href: string;
 }
 
+/**
+ * Item extra (não-navegacional) anexado ao overflow `⋯ Mais` depois dos ghosts
+ * excedentes. Pra ações features-específicas que não cabem inline no header
+ * (Wagner 2026-05-21 tweak Fase 5 — feature-buttons do Financeiro/Unificado).
+ *
+ * Renderiza-se como `<DropdownMenuItem onClick={...}>` (não link/href). Use
+ * pra ações que abrem dialog/sheet/modal, não pra navegação entre páginas.
+ */
+export interface PageHeaderOverflowItem {
+  key: string;
+  label: string;
+  icon?: React.ReactNode;
+  onClick: () => void;
+  title?: string;
+}
+
 interface Props {
   primary?: PageHeaderPrimary;
   ghosts?: PageHeaderGhost[];
@@ -71,6 +88,11 @@ interface Props {
   onGhostChange?: (key: string) => void;
   /** Quantos ghosts visíveis inline antes do overflow ⋯ Mais. Default 5. */
   maxVisible?: number;
+  /**
+   * Ações extras renderizadas dentro do overflow `⋯ Mais` (depois dos ghosts
+   * excedentes, separadas por divider). Wagner 2026-05-21 tweak Fase 5.
+   */
+  extraOverflowItems?: PageHeaderOverflowItem[];
   className?: string;
 }
 
@@ -81,6 +103,7 @@ export default function PageHeaderTabs({
   group,
   onGhostChange,
   maxVisible = 5,
+  extraOverflowItems = [],
   className,
 }: Props) {
   const hue = group ? SIDEBAR_GROUP_HUE[group] : undefined;
@@ -197,8 +220,8 @@ export default function PageHeaderTabs({
             );
           })}
 
-          {/* ── Overflow ⋯ Mais ── */}
-          {overflowGhosts.length > 0 && (
+          {/* ── Overflow ⋯ Mais (ghosts excedentes + ações extras) ── */}
+          {(overflowGhosts.length > 0 || extraOverflowItems.length > 0) && (
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
                 <button
@@ -208,15 +231,28 @@ export default function PageHeaderTabs({
                     'hover:bg-accent hover:text-accent-foreground shrink-0',
                     'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
                   )}
-                  aria-label={`Mais ${overflowGhosts.length} visões`}
+                  aria-label={`Mais ${overflowGhosts.length + extraOverflowItems.length} opções`}
                 >
                   <MoreHorizontal size={16} />
                 </button>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="min-w-40">
+              <DropdownMenuContent align="end" className="min-w-44">
                 {overflowGhosts.map((ghost) => (
                   <DropdownMenuItem key={ghost.key} asChild>
                     <Link href={ghost.href}>{ghost.label}</Link>
+                  </DropdownMenuItem>
+                ))}
+                {overflowGhosts.length > 0 && extraOverflowItems.length > 0 && (
+                  <DropdownMenuSeparator />
+                )}
+                {extraOverflowItems.map((item) => (
+                  <DropdownMenuItem
+                    key={item.key}
+                    onClick={item.onClick}
+                    title={item.title}
+                  >
+                    {item.icon && <span className="mr-2 inline-flex">{item.icon}</span>}
+                    {item.label}
                   </DropdownMenuItem>
                 ))}
               </DropdownMenuContent>

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -24,7 +24,7 @@ import { Input } from '@/Components/ui/input';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/Components/ui/sheet';
 import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/Components/ui/command';
 import PageHeader from '@/Components/shared/PageHeader';
-import PageHeaderTabs, { type PageHeaderGhost, type PageHeaderPrimary } from '@/Components/shared/PageHeaderTabs';
+import PageHeaderTabs, { type PageHeaderGhost, type PageHeaderPrimary, type PageHeaderOverflowItem } from '@/Components/shared/PageHeaderTabs';
 import KpiCard from '@/Components/shared/KpiCard';
 import { FinPillFrescor } from './_components/FinPillFrescor';
 import { FinConferidoToggle, FinConferidoBadge, useFinConferido, type UseFinConferidoApi } from './_components/FinConferidoToggle';
@@ -772,7 +772,15 @@ function LinhaTabela({ row, dens, selected, onSelect, onBaixar, conferido, comme
 // ContasPagar/Index.tsx quando essa tela adotar tbm). Fallback: nada renderiza
 // se shell.menu não tem entry "Financeiro" com ghosts (ex usuário sem permissão
 // financeiro.access ou Modules/Financeiro desinstalado).
-function FinanceiroSubNav({ active }: { active: string }) {
+interface FinanceiroSubNavProps {
+  active: string;
+  /** Ações features-específicas (Resumir/Fechamento/Apresentar/etc) que vão pro overflow `⋯ Mais` */
+  extraOverflowItems?: PageHeaderOverflowItem[];
+  /** Quando true, omite primary (renderiza só ghosts + overflow). Caller renderiza primary separado à direita. */
+  hidePrimary?: boolean;
+}
+
+function FinanceiroSubNav({ active, extraOverflowItems, hidePrimary }: FinanceiroSubNavProps) {
   const sharedShell = (usePage().props as any)?.shell as {
     menu?: Array<{ label: string; group?: string; primary?: PageHeaderPrimary; ghosts?: PageHeaderGhost[] }>;
   } | undefined;
@@ -783,16 +791,19 @@ function FinanceiroSubNav({ active }: { active: string }) {
 
   if (!finItem?.ghosts?.length) return null;
 
-  // ADR 0180 Fase 5 tweak Wagner 2026-05-21 — render INLINE no header `os-page-h-r`
-  // (sem padding/margin externa). PageHeaderTabs já é flex row interno; herda
-  // alinhamento do parent flex do `os-page-h-r`.
+  // ADR 0180 Fase 5 tweak2 Wagner 2026-05-21 — primary `+ Novo título` renderiza
+  // SEPARADO no canto direito do header pelo caller (`hidePrimary=true`); os
+  // botões action features-específicas (Resumir/Fechamento/Apresentar/Imprimir/
+  // Download/OCR/Buscar) entram NO overflow `⋯ Mais` (via `extraOverflowItems`).
+  // Resultado: única linha = ghost tabs (esquerda) + ⋯ Mais + primary (direita).
   return (
     <PageHeaderTabs
-      primary={finItem.primary}
+      primary={hidePrimary ? undefined : finItem.primary}
       ghosts={finItem.ghosts}
       activeGhostKey={active}
       group="financas"
       maxVisible={5}
+      extraOverflowItems={extraOverflowItems}
     />
   );
 }
@@ -998,77 +1009,29 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
           <p>{periodLabel}{businessName ? ` · ${businessName}` : ''} · caixa unificado</p>
         </div>
         <div className="os-page-h-r fin-page-h-r">
-          {/* ADR 0180 Fase 5 tweak Wagner 2026-05-21 — ghost tabs ARIA pra navegação
-              contextual entre 13 sub-views do Financeiro vão AGORA dentro do header
-              `os-page-h-r` (não numa row separada abaixo). Substitui botões action
-              redundantes (Conciliar/Plano de contas/Novo lançamento) — todos já são
-              ghosts ou primary do PageHeaderTabs. Botões features-específicas mantidos
-              (Buscar/Resumir mês/Fechamento/Apresentar/Imprimir/OCR boleto). */}
-          <FinanceiroSubNav active="unificado" />
-          <button type="button" className="os-btn ghost" onClick={() => setPaletteOpen(true)}>
-            <Search size={13} />
-            Buscar
-            <kbd>⌘K</kbd>
-          </button>
-          <button
-            type="button"
-            className="os-btn ghost fin-btn-ai"
-            title="Resumo executivo do mês (narrativa compute-based · Onda 9 v1)"
-            onClick={() => setResumoOpen(true)}
-          >
-            <Sparkles size={13} />
-            Resumir mês
-          </button>
-          <button
-            type="button"
-            className="os-btn ghost fin-btn-trilha"
-            onClick={() => setChecklistOpen(true)}
-            title="Trilha de 12 passos do fechamento mensal"
-          >
-            <CheckSquare size={13} />
-            Fechamento
-          </button>
-          <button
-            type="button"
-            className="os-btn ghost fin-btn-present"
-            title="Modo apresentação fullscreen (Esc fecha · 1/2/3 muda vista)"
-            onClick={() => setPresentOpen(true)}
-          >
-            <Play size={13} />
-            Apresentar
-          </button>
-          <button
-            type="button"
-            className="os-btn ghost"
-            title={`Folha jurídica imprimível${favs.count > 0 ? ` · ${favs.count} favorito${favs.count === 1 ? '' : 's'}` : ''}`}
-            onClick={() => { setTranscriptOnlyFavs(false); setTranscriptOpen(true); }}
-          >
-            <Printer size={13} />
-            Imprimir
-            {favs.count > 0 && <span className="fin-btn-badge">{favs.count}★</span>}
-          </button>
-          {/* Onda 12 — Download icon-only (paridade canon REAL — botão entre Plano contas e CTA Novo).
-              Onclick stub abre ⌘K palette por enquanto; handler real (Exportar XLSX/PDF) vira US futura. */}
-          <button
-            type="button"
-            className="os-btn ghost"
-            title="Exportar lançamentos do período (XLSX / PDF)"
-            aria-label="Exportar"
-            onClick={() => setPaletteOpen(true)}
-            style={{ padding: '0 8px' }}
-          >
-            <Download size={13} />
-          </button>
-          {/* US-FIN-029 (Onda 23) — KILLER OCR boleto: Eliana cola foto → IA extrai campos. */}
-          <button
-            type="button"
-            className="os-btn ghost"
-            title="Importar boleto via foto/PDF (OCR via IA)"
-            aria-label="Importar boleto OCR"
-            onClick={() => setOcrSheetOpen(true)}
-            style={{ padding: '0 8px' }}
-          >
-            📷 OCR boleto
+          {/* ADR 0180 Fase 5 tweak2 Wagner 2026-05-21 — header em UMA linha:
+                ghost tabs (esquerda) + ⋯ Mais (botões action features) + primary "+ Novo" (direita)
+              - Ghost tabs ARIA navegação entre 13 sub-views do Financeiro
+              - Primary "+ Novo título" SEPARADO no canto direito (Wagner pediu lado oposto)
+              - Botões action features-específicas (Buscar/Resumir/Fechamento/Apresentar/
+                Imprimir/Download/OCR) entram no overflow `⋯ Mais` (Wagner: "atuais entram no ⋯") */}
+          <FinanceiroSubNav
+            active="unificado"
+            hidePrimary
+            extraOverflowItems={[
+              { key: 'buscar',     label: 'Buscar (⌘K)',     icon: <Search size={13} />,      onClick: () => setPaletteOpen(true) },
+              { key: 'resumir',    label: 'Resumir mês',     icon: <Sparkles size={13} />,    onClick: () => setResumoOpen(true),                                  title: 'Resumo executivo do mês (narrativa compute-based · Onda 9 v1)' },
+              { key: 'fechamento', label: 'Fechamento',      icon: <CheckSquare size={13} />, onClick: () => setChecklistOpen(true),                               title: 'Trilha de 12 passos do fechamento mensal' },
+              { key: 'apresentar', label: 'Apresentar',      icon: <Play size={13} />,        onClick: () => setPresentOpen(true),                                 title: 'Modo apresentação fullscreen (Esc fecha · 1/2/3 muda vista)' },
+              { key: 'imprimir',   label: favs.count > 0 ? `Imprimir (${favs.count}★)` : 'Imprimir', icon: <Printer size={13} />, onClick: () => { setTranscriptOnlyFavs(false); setTranscriptOpen(true); }, title: 'Folha jurídica imprimível' },
+              { key: 'exportar',   label: 'Exportar XLSX/PDF',icon: <Download size={13} />,   onClick: () => setPaletteOpen(true),                                 title: 'Exportar lançamentos do período' },
+              { key: 'ocr',        label: 'OCR boleto',      icon: <span>📷</span>,            onClick: () => setOcrSheetOpen(true),                                title: 'Importar boleto via foto/PDF (OCR via IA)' },
+            ]}
+          />
+          {/* Primary "+ Novo título" — canto direito, separado dos ghosts (Wagner 2026-05-21) */}
+          <button type="button" className="os-btn primary" onClick={() => router.visit('/financeiro/unificado/novo')}>
+            <Plus size={13} />
+            Novo título
           </button>
         </div>
       </div>


### PR DESCRIPTION
## Resumo

Wagner 2026-05-21 review 2 do PR #1364: **3 ajustes**:

1. Primary `+ Novo título` no **outro lado** (canto direito)
2. Botões action atuais entram no `⋯ Mais` overflow
3. Label `Unificado` → `Financeiro` (no ghost canon)

## Layout final

```
Financeiro · Visão unificada    Financeiro | Contas a Receber | Contas a Pagar | Fluxo | Cobrança | ⋯Mais     [+ Novo título]
                                ▲ ghost tabs                                                ▲ overflow      ▲ primary direita
                                                                                            ↓
                                                                                            Caixa
                                                                                            Conciliação
                                                                                            DRE
                                                                                            Relatórios
                                                                                            Contas Bancárias
                                                                                            Plano de Contas
                                                                                            Categorias
                                                                                            Contador
                                                                                            ─────
                                                                                            Buscar (⌘K)
                                                                                            Resumir mês
                                                                                            Fechamento
                                                                                            Apresentar
                                                                                            Imprimir
                                                                                            Exportar
                                                                                            OCR boleto
```

## Mudanças (3 arquivos)

| Arquivo | LOC | O quê |
|---|---|---|
| `Components/shared/PageHeaderTabs.tsx` | +44 | Nova prop `extraOverflowItems` |
| `Modules/Financeiro/.../DataController.php` | -1/+1 | Label `'Unificado'` → `'Financeiro'` |
| `Pages/Financeiro/Unificado/Index.tsx` | -82/+31 | Header reestruturado (zonas: esquerda ghosts + ⋯ Mais, direita primary) |

## Densidade visual

- Antes (PR #1364): 1 ghost-tabs-bar + 7 botões action inline + primary
- Agora: 5 ghosts visíveis + ⋯ Mais + primary direita (12 → 3 elementos visuais)

## Test plan

- [ ] CI Vite build passa
- [ ] CI Pest passa
- [ ] Smoke browser MCP: `/financeiro/unificado` em biz=4
  - Ghost "Financeiro" ativo (não mais "Unificado")
  - `+ Novo título` canto direito
  - `⋯ Mais` abre dropdown com sub-views + 7 ações features
  - Click em ghost navega via Inertia
  - Click em ação features (ex "Resumir mês") abre dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)