### PR TITLE
feat(sidebar): Fase 5 propagação Financeiro — 11 telas + extract FinanceiroSubNav (ADR 0180)

### DIFF
--- a/resources/js/Pages/Financeiro/Caixa/Index.tsx
+++ b/resources/js/Pages/Financeiro/Caixa/Index.tsx
@@ -6,6 +6,7 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { router, usePage } from '@inertiajs/react';
 import { ReactNode, useMemo } from 'react';
+import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 
 interface CaixaRow {
   id: number;
@@ -93,6 +94,10 @@ function Caixa({ caixas, stats, filters, links }: Props) {
             </a>
             .
           </p>
+        </div>
+        <div className="os-page-h-r fin-page-h-r">
+          {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
+          <FinanceiroSubNav active="caixa" />
         </div>
       </header>
 

--- a/resources/js/Pages/Financeiro/Categorias/Index.tsx
+++ b/resources/js/Pages/Financeiro/Categorias/Index.tsx
@@ -8,6 +8,7 @@ import { Card, CardContent } from '@/Components/ui/card';
 import { Tag, Plus, Pencil, Trash2, Power, PowerOff } from 'lucide-react';
 import { toast } from 'sonner';
 import { CategoriaSheet } from './components/CategoriaSheet';
+import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 
 interface Categoria {
   id: number;
@@ -77,6 +78,8 @@ function Index({ categorias, planos_conta }: Props) {
             <p>Complementam o plano de contas (que é fixo/contábil) — organizam lançamentos pra relatórios</p>
           </div>
           <div className="os-page-h-r fin-page-h-r">
+            {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
+            <FinanceiroSubNav active="categorias" />
             <button type="button" className="os-btn primary" onClick={() => setCreating(true)}>
               <Plus size={13} /> Nova categoria
             </button>

--- a/resources/js/Pages/Financeiro/Cobranca/Index.tsx
+++ b/resources/js/Pages/Financeiro/Cobranca/Index.tsx
@@ -21,6 +21,7 @@ import {
   Check, AlertCircle, Receipt, Zap, Building,
 } from 'lucide-react';
 import { Btn, StatusBadge, GatewayTipoChip, OrigemChip, KpiCard} from './_components/atoms';
+import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 import FunnelStrip from './_components/FunnelStrip';
 import DrawerCobranca from './_components/DrawerCobranca';
 import SheetNovaCobranca from './_components/SheetNovaCobranca';
@@ -183,6 +184,8 @@ function CobrancaPage({ cobrancas, kpis, funil, accounts = [], gateways = [], fi
             <p>{kpis.aberto.qtd} em aberto · gestão de remessa/retorno + gateways</p>
           </div>
           <div className="os-page-h-r fin-page-h-r">
+            {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
+            <FinanceiroSubNav active="cobranca" />
             <button type="button" className="os-btn ghost fin-btn-ai" onClick={() => setAiOpen(true)} title="Resumir cobranças deste mês — IA">
               <span>✦</span> Resumir mês
             </button>

--- a/resources/js/Pages/Financeiro/Conciliacao/Index.tsx
+++ b/resources/js/Pages/Financeiro/Conciliacao/Index.tsx
@@ -10,6 +10,7 @@ import AppShellV2 from '@/Layouts/AppShellV2';
 import { useForm, router } from '@inertiajs/react';
 import { type ReactNode, type FormEvent, useState } from 'react';
 import { Upload, Check, X, Search } from 'lucide-react';
+import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 
 interface Linha {
   id: number;
@@ -89,6 +90,10 @@ function FinanceiroConciliacao({ linhas, stats, contas }: Props) {
         <div className="os-page-h-l fin-page-h-l">
           <h1>Conciliação <span className="fin-hero-title-sub">· OFX bancário</span></h1>
           <p>Importe extrato OFX → parser detecta transações → fuzzy match com títulos abertos → aprovar manualmente</p>
+        </div>
+        <div className="os-page-h-r fin-page-h-r">
+          {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
+          <FinanceiroSubNav active="conciliacao" />
         </div>
       </header>
 

--- a/resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/Components/ui/button';
 import { Card, CardContent } from '@/Components/ui/card';
 import { Settings, Plus, AlertTriangle, CheckCircle2, MinusCircle } from 'lucide-react';
 import { ConfigurarBoletoSheet } from './components/ConfigurarBoletoSheet';
+import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 
 interface Account {
   id: number;
@@ -75,6 +76,8 @@ function Index({ accounts, bancos_suportados }: Props) {
             </p>
           </div>
           <div className="os-page-h-r fin-page-h-r">
+            {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
+            <FinanceiroSubNav active="contas-bancarias" />
             <a href="/settings/payment-gateways" className="os-btn ghost">Gateways</a>
             <a href="/account/account/create" className="os-btn primary">
               <Plus size={13} /> Nova conta no POS

--- a/resources/js/Pages/Financeiro/ContasPagar/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasPagar/Index.tsx
@@ -12,6 +12,7 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Textarea } from '@/Components/ui/textarea';
 import { CreditCard, AlertTriangle, CheckCircle2, Circle, Hourglass } from 'lucide-react';
 import { toast } from 'sonner';
+import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 
 interface Titulo {
   id: number;
@@ -166,6 +167,10 @@ function Index({ titulos, contas_bancarias, filtros }: Props) {
           <div className="os-page-h-l fin-page-h-l">
             <h1>Contas a Pagar <span className="fin-hero-title-sub">· Títulos</span></h1>
             <p>Compras, despesas, contratos</p>
+          </div>
+          <div className="os-page-h-r fin-page-h-r">
+            {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
+            <FinanceiroSubNav active="contas-pagar" />
           </div>
         </header>
 

--- a/resources/js/Pages/Financeiro/ContasReceber/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasReceber/Index.tsx
@@ -6,6 +6,7 @@ import { Button } from '@/Components/ui/button';
 import { Card, CardContent } from '@/Components/ui/card';
 import { Receipt, AlertTriangle, CheckCircle2, Circle, Hourglass } from 'lucide-react';
 import { toast } from 'sonner';
+import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 
 interface BoletoInfo {
   id: number;
@@ -92,6 +93,10 @@ function Index({ titulos, filtros }: Props) {
           <div className="os-page-h-l fin-page-h-l">
             <h1>Contas a Receber <span className="fin-hero-title-sub">· Títulos</span></h1>
             <p>Gerados de vendas (auto) ou cadastrados manualmente</p>
+          </div>
+          <div className="os-page-h-r fin-page-h-r">
+            {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
+            <FinanceiroSubNav active="contas-receber" />
           </div>
         </header>
 

--- a/resources/js/Pages/Financeiro/Dre/Index.tsx
+++ b/resources/js/Pages/Financeiro/Dre/Index.tsx
@@ -29,6 +29,7 @@ import {
 } from 'lucide-react';
 import { BalancoView, type BalancoData } from './_components/BalancoView';
 import { BalanceteView, type BalanceteData } from './_components/BalanceteView';
+import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 
 // ---------- Tipos das linhas (espelha DRE_LINES canon TelaDRE) ----------
 
@@ -201,6 +202,8 @@ function FinanceiroDre({
           </p>
         </div>
         <div className="os-page-h-r fin-page-h-r">
+          {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
+          <FinanceiroSubNav active="dre" />
           <button
             type="button"
             className="os-btn ghost"

--- a/resources/js/Pages/Financeiro/Fluxo/Index.tsx
+++ b/resources/js/Pages/Financeiro/Fluxo/Index.tsx
@@ -16,6 +16,7 @@ import AppShellV2 from '@/Layouts/AppShellV2';
 import { Card } from '@/Components/ui/card';
 import { router } from '@inertiajs/react';
 import { useMemo, type ReactNode } from 'react';
+import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 
 interface Dia {
   data: string;
@@ -520,6 +521,10 @@ function FinanceiroFluxo(props: Props) {
               ? 'Entradas e saídas confirmadas, agrupadas por mês'
               : 'Saldo, entradas e saídas dia-a-dia'}
           </p>
+        </div>
+        <div className="os-page-h-r fin-page-h-r">
+          {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
+          <FinanceiroSubNav active="fluxo" />
         </div>
       </header>
 

--- a/resources/js/Pages/Financeiro/PlanoContas/Index.tsx
+++ b/resources/js/Pages/Financeiro/PlanoContas/Index.tsx
@@ -10,6 +10,7 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { type ReactNode, useMemo, useState } from 'react';
 import { Lock, FileText, Search } from 'lucide-react';
+import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 
 interface PlanoConta {
   id: number;
@@ -69,6 +70,10 @@ function FinanceiroPlanoContas({ planos, stats }: Props) {
         <div className="os-page-h-l fin-page-h-l">
           <h1>Plano de Contas <span className="fin-hero-title-sub">· Estrutura contábil BR</span></h1>
           <p>{stats.total} contas hierárquicas (Receita Federal/DCASP) — Eliana classifica lançamentos pelo plano</p>
+        </div>
+        <div className="os-page-h-r fin-page-h-r">
+          {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
+          <FinanceiroSubNav active="plano-contas" />
         </div>
       </header>
 

--- a/resources/js/Pages/Financeiro/Relatorios/Index.tsx
+++ b/resources/js/Pages/Financeiro/Relatorios/Index.tsx
@@ -15,6 +15,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/Com
 import { Input } from '@/Components/ui/input';
 import { Badge } from '@/Components/ui/badge';
 // Onda 14 — PageHeader removido (canon os-page-h direto)
+import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 
 type TabId = 'fluxo' | 'resumo';
 
@@ -94,6 +95,8 @@ function FinanceiroRelatorios({ filters, fluxo, resumo }: Props) {
           <p>DRE gerencial, fluxo de caixa projetado vs realizado e resumo do período</p>
         </div>
         <div className="os-page-h-r fin-page-h-r">
+          {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
+          <FinanceiroSubNav active="relatorios" />
           <a href={csvHref} target="_blank" rel="noopener noreferrer" className="os-btn ghost">
             Exportar CSV
           </a>

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -24,7 +24,7 @@ import { Input } from '@/Components/ui/input';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/Components/ui/sheet';
 import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/Components/ui/command';
 import PageHeader from '@/Components/shared/PageHeader';
-import PageHeaderTabs, { type PageHeaderGhost, type PageHeaderPrimary, type PageHeaderOverflowItem } from '@/Components/shared/PageHeaderTabs';
+import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 import KpiCard from '@/Components/shared/KpiCard';
 import { FinPillFrescor } from './_components/FinPillFrescor';
 import { FinConferidoToggle, FinConferidoBadge, useFinConferido, type UseFinConferidoApi } from './_components/FinConferidoToggle';
@@ -761,54 +761,8 @@ function LinhaTabela({ row, dens, selected, onSelect, onBaixar, conferido, comme
   );
 }
 
-// ---------- FinanceiroSubNav (ADR 0180 Fase 5 piloto) ----------
-//
-// Lê primary/ghosts da entry "Financeiro" do shell.menu (Inertia shared prop
-// populado via LegacyMenuAdapter — Fase 4 piloto declarou attrs no
-// Modules/Financeiro/Http/Controllers/DataController). Renderiza ghost tabs
-// ARIA tablist abaixo do header `os-page-h` custom da tela.
-//
-// Active prop = key do ghost atual (ex 'unificado' nesta tela, 'pagar' em
-// ContasPagar/Index.tsx quando essa tela adotar tbm). Fallback: nada renderiza
-// se shell.menu não tem entry "Financeiro" com ghosts (ex usuário sem permissão
-// financeiro.access ou Modules/Financeiro desinstalado).
-interface FinanceiroSubNavProps {
-  active: string;
-  /** Ações features-específicas (Resumir/Fechamento/Apresentar/etc) que vão pro overflow `⋯ Mais` */
-  extraOverflowItems?: PageHeaderOverflowItem[];
-  /** Quando true, omite primary (renderiza só ghosts + overflow). Caller renderiza primary separado à direita. */
-  hidePrimary?: boolean;
-}
-
-function FinanceiroSubNav({ active, extraOverflowItems, hidePrimary }: FinanceiroSubNavProps) {
-  const sharedShell = (usePage().props as any)?.shell as {
-    menu?: Array<{ label: string; group?: string; primary?: PageHeaderPrimary; ghosts?: PageHeaderGhost[] }>;
-  } | undefined;
-
-  const finItem = sharedShell?.menu?.find(
-    (m) => m.group === 'fin-op' || m.group === 'financas' || m.label?.toLowerCase() === 'financeiro',
-  );
-
-  if (!finItem?.ghosts?.length) return null;
-
-  // ADR 0180 Fase 5 tweak2 Wagner 2026-05-21 — primary `+ Novo título` renderiza
-  // SEPARADO no canto direito do header pelo caller (`hidePrimary=true`); os
-  // botões action features-específicas (Resumir/Fechamento/Apresentar/Imprimir/
-  // Download/OCR/Buscar) entram NO overflow `⋯ Mais` (via `extraOverflowItems`).
-  // Resultado: única linha = ghost tabs (esquerda) + ⋯ Mais + primary (direita).
-  return (
-    <PageHeaderTabs
-      primary={hidePrimary ? undefined : finItem.primary}
-      ghosts={finItem.ghosts}
-      activeGhostKey={active}
-      group="financas"
-      maxVisible={5}
-      extraOverflowItems={extraOverflowItems}
-    />
-  );
-}
-
 // ---------- Página principal ----------
+// (FinanceiroSubNav extraído pra `_shared/FinanceiroSubNav.tsx` 2026-05-21 — ADR 0180 Fase 5 propagação)
 
 function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, categorias, planosConta, periodLabel, businessName }: Props) {
   // US-FIN-028 (Onda 22) — gate Spatie pra aprovar/rejeitar.

--- a/resources/js/Pages/Financeiro/_shared/FinanceiroSubNav.tsx
+++ b/resources/js/Pages/Financeiro/_shared/FinanceiroSubNav.tsx
@@ -1,0 +1,57 @@
+// FinanceiroSubNav (ADR 0180 Fase 5 — extraído como shared 2026-05-21)
+//
+// Lê primary/ghosts da entry "Financeiro" do shell.menu (Inertia shared prop
+// populado via LegacyMenuAdapter — Fase 4 piloto declarou attrs no
+// Modules/Financeiro/Http/Controllers/DataController). Renderiza ghost tabs
+// ARIA tablist abaixo do header `os-page-h` custom da tela.
+//
+// Active prop = key do ghost atual (ex 'unificado' em Unificado/Index.tsx,
+// 'contas-receber' em ContasReceber/Index.tsx, etc). Fallback: nada renderiza
+// se shell.menu não tem entry "Financeiro" com ghosts (ex usuário sem permissão
+// financeiro.access ou Modules/Financeiro desinstalado).
+//
+// Pattern aprovado por Wagner 2026-05-21 (PR #1365 — Unificado piloto):
+// ghost tabs (esquerda) + ⋯ Mais (overflow) + primary `+ Novo título` (direita).
+// Caller pode passar `hidePrimary` pra renderizar o primary separadamente.
+
+import { usePage } from '@inertiajs/react';
+import PageHeaderTabs, {
+  type PageHeaderGhost,
+  type PageHeaderPrimary,
+  type PageHeaderOverflowItem,
+} from '@/Components/shared/PageHeaderTabs';
+
+export interface FinanceiroSubNavProps {
+  active: string;
+  /** Ações features-específicas (Resumir/Fechamento/Apresentar/etc) que vão pro overflow `⋯ Mais` */
+  extraOverflowItems?: PageHeaderOverflowItem[];
+  /** Quando true, omite primary (renderiza só ghosts + overflow). Caller renderiza primary separado à direita. */
+  hidePrimary?: boolean;
+}
+
+export default function FinanceiroSubNav({ active, extraOverflowItems, hidePrimary }: FinanceiroSubNavProps) {
+  const sharedShell = (usePage().props as any)?.shell as {
+    menu?: Array<{ label: string; group?: string; primary?: PageHeaderPrimary; ghosts?: PageHeaderGhost[] }>;
+  } | undefined;
+
+  const finItem = sharedShell?.menu?.find(
+    (m) => m.group === 'fin-op' || m.group === 'financas' || m.label?.toLowerCase() === 'financeiro',
+  );
+
+  if (!finItem?.ghosts?.length) return null;
+
+  // ADR 0180 Fase 5 tweak2 Wagner 2026-05-21 — primary `+ Novo título` pode
+  // renderizar SEPARADO no canto direito do header pelo caller (`hidePrimary=true`);
+  // os botões action features-específicas (Resumir/Fechamento/Apresentar/etc)
+  // entram NO overflow `⋯ Mais` (via `extraOverflowItems`).
+  return (
+    <PageHeaderTabs
+      primary={hidePrimary ? undefined : finItem.primary}
+      ghosts={finItem.ghosts}
+      activeGhostKey={active}
+      group="financas"
+      maxVisible={5}
+      extraOverflowItems={extraOverflowItems}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

ADR 0180 Fase 5 — propaga o pattern aprovado por Wagner em PR #1365 (ghost tabs + overflow + primary `+ Novo título`) pras 11 telas restantes do Financeiro, com extração do componente `FinanceiroSubNav` pra arquivo shared.

### Etapa 1 — extract shared

- **Novo:** `resources/js/Pages/Financeiro/_shared/FinanceiroSubNav.tsx` (57 LOC)
- `Unificado/Index.tsx`: remove definição inline (linhas 764-809) e imports `PageHeaderGhost`/`PageHeaderPrimary`/`PageHeaderOverflowItem` órfãos (-46 LOC). Importa componente shared.

### Etapa 2 — propagação 11 telas

Pattern uniforme: insere `<FinanceiroSubNav active=\"<key>\"/>` dentro do `<div className=\"os-page-h-r fin-page-h-r\">` do header.

| Tela | active |
|---|---|
| ContasReceber/Index.tsx | `contas-receber` |
| ContasPagar/Index.tsx | `contas-pagar` |
| Fluxo/Index.tsx | `fluxo` |
| Cobranca/Index.tsx | `cobranca` |
| Caixa/Index.tsx | `caixa` |
| Conciliacao/Index.tsx | `conciliacao` |
| Dre/Index.tsx | `dre` |
| Relatorios/Index.tsx | `relatorios` |
| ContasBancarias/Index.tsx | `contas-bancarias` |
| PlanoContas/Index.tsx | `plano-contas` |
| Categorias/Index.tsx | `categorias` |

**Casos especiais:**
- 5 telas já tinham `os-page-h-r` populado (Cobranca, Dre, Relatorios, ContasBancarias, Categorias) → SubNav inserido **antes** dos botões action existentes
- 6 telas só tinham `os-page-h-l` (ContasReceber, ContasPagar, Fluxo, Caixa, Conciliacao, PlanoContas) → adicionada `<div className=\"os-page-h-r fin-page-h-r\">` nova
- Sem props `extraOverflowItems` nem `hidePrimary` (refinements caso-a-caso depois)
- Botões \"Novo X\" próprios preservados sem mexer (Wagner refina depois)

### Restrições respeitadas

- ✅ Multi-tenant Tier 0 ADR 0093 — backend intocado
- ✅ Não toca LegacyMenuAdapter / DataController / PageHeaderTabs (já prontos)
- ✅ commit-discipline: +104 / -48 LOC = ~152 (limite 500)
- ✅ publication-policy: NÃO mergeado — aguarda Wagner

## LOC

```
 13 files changed, 104 insertions(+), 48 deletions(-)
```

## Test plan

- [ ] Build vite local OK (sem erro TS novo — pre-existentes ignorados)
- [ ] Smoke /financeiro/contas-receber → ghost tabs aparecem + ⋯ Mais + primary direita
- [ ] Smoke /financeiro/dre → SubNav antes dos botões action existentes
- [ ] Click ghost tab \"Cobrança\" em qualquer tela → router.visit /financeiro/cobranca
- [ ] activeGhostKey marca tab correta da tela atual
- [ ] Visual: header em uma linha (não quebra)
- [ ] Wagner approve screenshot antes de merge

Refs: ADR 0180 sidebar v3 · PR #1365 piloto Wagner approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)