### PR TITLE
fix(sidebar): Fase 5 hidePrimary nas 11 telas Financeiro — remove primary duplicado

### DIFF
--- a/resources/js/Pages/Financeiro/Caixa/Index.tsx
+++ b/resources/js/Pages/Financeiro/Caixa/Index.tsx
@@ -97,7 +97,7 @@ function Caixa({ caixas, stats, filters, links }: Props) {
         </div>
         <div className="os-page-h-r fin-page-h-r">
           {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
-          <FinanceiroSubNav active="caixa" />
+          <FinanceiroSubNav active="caixa" hidePrimary />
         </div>
       </header>
 

--- a/resources/js/Pages/Financeiro/Categorias/Index.tsx
+++ b/resources/js/Pages/Financeiro/Categorias/Index.tsx
@@ -79,7 +79,7 @@ function Index({ categorias, planos_conta }: Props) {
           </div>
           <div className="os-page-h-r fin-page-h-r">
             {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
-            <FinanceiroSubNav active="categorias" />
+            <FinanceiroSubNav active="categorias" hidePrimary />
             <button type="button" className="os-btn primary" onClick={() => setCreating(true)}>
               <Plus size={13} /> Nova categoria
             </button>

--- a/resources/js/Pages/Financeiro/Cobranca/Index.tsx
+++ b/resources/js/Pages/Financeiro/Cobranca/Index.tsx
@@ -185,7 +185,7 @@ function CobrancaPage({ cobrancas, kpis, funil, accounts = [], gateways = [], fi
           </div>
           <div className="os-page-h-r fin-page-h-r">
             {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
-            <FinanceiroSubNav active="cobranca" />
+            <FinanceiroSubNav active="cobranca" hidePrimary />
             <button type="button" className="os-btn ghost fin-btn-ai" onClick={() => setAiOpen(true)} title="Resumir cobranças deste mês — IA">
               <span>✦</span> Resumir mês
             </button>

--- a/resources/js/Pages/Financeiro/Conciliacao/Index.tsx
+++ b/resources/js/Pages/Financeiro/Conciliacao/Index.tsx
@@ -93,7 +93,7 @@ function FinanceiroConciliacao({ linhas, stats, contas }: Props) {
         </div>
         <div className="os-page-h-r fin-page-h-r">
           {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
-          <FinanceiroSubNav active="conciliacao" />
+          <FinanceiroSubNav active="conciliacao" hidePrimary />
         </div>
       </header>
 

--- a/resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
@@ -77,7 +77,7 @@ function Index({ accounts, bancos_suportados }: Props) {
           </div>
           <div className="os-page-h-r fin-page-h-r">
             {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
-            <FinanceiroSubNav active="contas-bancarias" />
+            <FinanceiroSubNav active="contas-bancarias" hidePrimary />
             <a href="/settings/payment-gateways" className="os-btn ghost">Gateways</a>
             <a href="/account/account/create" className="os-btn primary">
               <Plus size={13} /> Nova conta no POS

--- a/resources/js/Pages/Financeiro/ContasPagar/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasPagar/Index.tsx
@@ -170,7 +170,7 @@ function Index({ titulos, contas_bancarias, filtros }: Props) {
           </div>
           <div className="os-page-h-r fin-page-h-r">
             {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
-            <FinanceiroSubNav active="contas-pagar" />
+            <FinanceiroSubNav active="contas-pagar" hidePrimary />
           </div>
         </header>
 

--- a/resources/js/Pages/Financeiro/ContasReceber/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasReceber/Index.tsx
@@ -96,7 +96,7 @@ function Index({ titulos, filtros }: Props) {
           </div>
           <div className="os-page-h-r fin-page-h-r">
             {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
-            <FinanceiroSubNav active="contas-receber" />
+            <FinanceiroSubNav active="contas-receber" hidePrimary />
           </div>
         </header>
 

--- a/resources/js/Pages/Financeiro/Dre/Index.tsx
+++ b/resources/js/Pages/Financeiro/Dre/Index.tsx
@@ -203,7 +203,7 @@ function FinanceiroDre({
         </div>
         <div className="os-page-h-r fin-page-h-r">
           {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
-          <FinanceiroSubNav active="dre" />
+          <FinanceiroSubNav active="dre" hidePrimary />
           <button
             type="button"
             className="os-btn ghost"

--- a/resources/js/Pages/Financeiro/Fluxo/Index.tsx
+++ b/resources/js/Pages/Financeiro/Fluxo/Index.tsx
@@ -524,7 +524,7 @@ function FinanceiroFluxo(props: Props) {
         </div>
         <div className="os-page-h-r fin-page-h-r">
           {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
-          <FinanceiroSubNav active="fluxo" />
+          <FinanceiroSubNav active="fluxo" hidePrimary />
         </div>
       </header>
 

--- a/resources/js/Pages/Financeiro/PlanoContas/Index.tsx
+++ b/resources/js/Pages/Financeiro/PlanoContas/Index.tsx
@@ -73,7 +73,7 @@ function FinanceiroPlanoContas({ planos, stats }: Props) {
         </div>
         <div className="os-page-h-r fin-page-h-r">
           {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
-          <FinanceiroSubNav active="plano-contas" />
+          <FinanceiroSubNav active="plano-contas" hidePrimary />
         </div>
       </header>
 

--- a/resources/js/Pages/Financeiro/Relatorios/Index.tsx
+++ b/resources/js/Pages/Financeiro/Relatorios/Index.tsx
@@ -96,7 +96,7 @@ function FinanceiroRelatorios({ filters, fluxo, resumo }: Props) {
         </div>
         <div className="os-page-h-r fin-page-h-r">
           {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
-          <FinanceiroSubNav active="relatorios" />
+          <FinanceiroSubNav active="relatorios" hidePrimary />
           <a href={csvHref} target="_blank" rel="noopener noreferrer" className="os-btn ghost">
             Exportar CSV
           </a>


### PR DESCRIPTION
## Resumo

Wagner 2026-05-21 review smoke prod: o `+ Novo título` primary do PageHeaderTabs (cor + posição erradas) estava **duplicando** com os botões "Nova X" próprios de cada tela, que já têm nomes contextualizados.

## Fix

Passa `hidePrimary` em todos os 11 `<FinanceiroSubNav active="X"/>` das telas Financeiro propagadas no PR #1366. Ghost tabs + overflow continuam funcionando; primary duplicado some.

Botões originais de cada tela preservados:
- Categorias → "Nova categoria"
- ContasBancarias → "Nova conta" + "Gateways"
- Cobranca → "Resumir" + "Gateways" + "Remessa" + "Nova"
- ContasReceber → "Emitir boleto"
- ContasPagar → "Pagar"
- DRE/Fluxo/Conciliacao → botões features-específicas

## NÃO altera

- `Unificado/Index.tsx` — já tem `hidePrimary` + botão custom no canto direito (PR #1365 pattern canon)
- `FinanceiroSubNav.tsx` shared — sem mudança
- `PageHeaderTabs.tsx` — sem mudança

## LOC

11 arquivos, 1 linha cada (`+11 -11` líquido).

🤖 Generated with [Claude Code](https://claude.com/claude-code)