### PR TITLE
feat(sidebar): Fase 5 refine -- botoes action movem pro overflow Mais (4 telas Financeiro)

### DIFF
--- a/resources/js/Pages/Financeiro/Cobranca/Index.tsx
+++ b/resources/js/Pages/Financeiro/Cobranca/Index.tsx
@@ -184,17 +184,17 @@ function CobrancaPage({ cobrancas, kpis, funil, accounts = [], gateways = [], fi
             <p>{kpis.aberto.qtd} em aberto · gestão de remessa/retorno + gateways</p>
           </div>
           <div className="os-page-h-r fin-page-h-r">
-            {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
-            <FinanceiroSubNav active="cobranca" hidePrimary />
-            <button type="button" className="os-btn ghost fin-btn-ai" onClick={() => setAiOpen(true)} title="Resumir cobranças deste mês — IA">
-              <span>✦</span> Resumir mês
-            </button>
-            <button type="button" className="os-btn ghost" onClick={() => router.visit('/settings/payment-gateways')} title="Configurar gateways">
-              <Settings size={13} /> Gateways
-            </button>
-            <button type="button" className="os-btn ghost" onClick={() => setRemessaOpen(true)}>
-              <Upload size={13} /> Remessa/Retorno
-            </button>
+            {/* ADR 0180 Fase 5 refine Wagner 2026-05-21 — botões action movem pra ⋯ Mais;
+                primary "Nova cobrança" fica separado no canto direito (canon Unificado) */}
+            <FinanceiroSubNav
+              active="cobranca"
+              hidePrimary
+              extraOverflowItems={[
+                { key: 'resumir',  label: 'Resumir mês',     icon: <span>✦</span>,         onClick: () => setAiOpen(true),                            title: 'Resumir cobranças deste mês — IA' },
+                { key: 'gateways', label: 'Gateways',        icon: <Settings size={13} />, onClick: () => router.visit('/settings/payment-gateways'), title: 'Configurar gateways' },
+                { key: 'remessa',  label: 'Remessa/Retorno', icon: <Upload size={13} />,   onClick: () => setRemessaOpen(true) },
+              ]}
+            />
             <button type="button" className="os-btn primary" onClick={() => setNovaOpen(true)}>
               <Plus size={13} /> Nova cobrança
             </button>

--- a/resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
@@ -76,9 +76,15 @@ function Index({ accounts, bancos_suportados }: Props) {
             </p>
           </div>
           <div className="os-page-h-r fin-page-h-r">
-            {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
-            <FinanceiroSubNav active="contas-bancarias" hidePrimary />
-            <a href="/settings/payment-gateways" className="os-btn ghost">Gateways</a>
+            {/* ADR 0180 Fase 5 refine Wagner 2026-05-21 — botão "Gateways" vai pro ⋯ Mais;
+                primary "Nova conta no POS" mantém-se canto direito (canon Unificado) */}
+            <FinanceiroSubNav
+              active="contas-bancarias"
+              hidePrimary
+              extraOverflowItems={[
+                { key: 'gateways', label: 'Gateways', icon: <Settings size={13} />, onClick: () => { window.location.href = '/settings/payment-gateways'; }, title: 'Credenciais API gateways de pagamento' },
+              ]}
+            />
             <a href="/account/account/create" className="os-btn primary">
               <Plus size={13} /> Nova conta no POS
             </a>

--- a/resources/js/Pages/Financeiro/Dre/Index.tsx
+++ b/resources/js/Pages/Financeiro/Dre/Index.tsx
@@ -22,8 +22,6 @@ import {
   Sparkles,
   CheckSquare,
   Play,
-  RefreshCw,
-  FolderOpen,
   Download,
   Plus,
 } from 'lucide-react';
@@ -202,81 +200,20 @@ function FinanceiroDre({
           </p>
         </div>
         <div className="os-page-h-r fin-page-h-r">
-          {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
-          <FinanceiroSubNav active="dre" hidePrimary />
-          <button
-            type="button"
-            className="os-btn ghost"
-            // TODO US-FIN-TOPNAV-COMPONENT: integrar Cmd palette compartilhada.
-            onClick={() => {
-              /* stub F1 — Cmd palette compartilhada vira F2 */
-            }}
-          >
-            <Search size={13} /> Buscar <kbd>⌘K</kbd>
-          </button>
-          <button
-            type="button"
-            className="os-btn ghost fin-btn-ai"
-            title="Resumo executivo do mês (narrativa DRE compute-based)"
-            // TODO US-FIN-DRE-RESUMO: extender FinMonthResumeDialog pra payload DRE.
-            onClick={() => {
-              /* stub F1 — narrativa DRE vira F2 */
-            }}
-          >
-            <Sparkles size={13} /> Resumir mês
-          </button>
-          <button
-            type="button"
-            className="os-btn ghost fin-btn-trilha"
-            title="Trilha de 12 passos do fechamento mensal"
-            // TODO US-FIN-DRE-FECHAMENTO: integrar FinChecklistFechamento.
-            onClick={() => {
-              /* stub F1 — checklist fechamento vira F2 */
-            }}
-          >
-            <CheckSquare size={13} /> Fechamento
-          </button>
-          <button
-            type="button"
-            className="os-btn ghost fin-btn-present"
-            title="Modo apresentação fullscreen (Esc fecha)"
-            // TODO US-FIN-DRE-PRESENT: integrar FinPresentationMode com payload DRE.
-            onClick={() => {
-              /* stub F1 — modo apresentação vira F2 */
-            }}
-          >
-            <Play size={13} /> Apresentar
-          </button>
-          <button
-            type="button"
-            className="os-btn ghost"
-            title="Conciliação OFX — upload extrato + match com títulos"
-            onClick={() => router.visit('/financeiro/conciliacao')}
-          >
-            <RefreshCw size={13} /> Conciliar
-          </button>
-          <button
-            type="button"
-            className="os-btn ghost"
-            title="Plano de contas hierárquico BR (Receita Federal/DCASP)"
-            onClick={() => router.visit('/financeiro/plano-contas')}
-          >
-            <FolderOpen size={13} /> Plano de contas
-          </button>
-          <button
-            type="button"
-            className="os-btn ghost"
-            title="Exportar DRE (XLSX / PDF)"
-            aria-label="Exportar"
-            // Atalho rápido — duplica os botões Exportar do Card pro padrão canon
-            // (stub F1; F2 abre Cmd palette com opções de export).
-            onClick={() => {
-              /* stub F1 */
-            }}
-            style={{ padding: '0 8px' }}
-          >
-            <Download size={13} />
-          </button>
+          {/* ADR 0180 Fase 5 refine Wagner 2026-05-21 — botões action features → ⋯ Mais;
+              "Conciliar" + "Plano de contas" REMOVIDOS (duplicados com ghosts);
+              primary "Novo lançamento" fica no canto direito (canon Unificado) */}
+          <FinanceiroSubNav
+            active="dre"
+            hidePrimary
+            extraOverflowItems={[
+              { key: 'buscar',     label: 'Buscar (⌘K)', icon: <Search size={13} />,     onClick: () => { /* stub F1 — Cmd palette compartilhada vira F2 */ } },
+              { key: 'resumir',    label: 'Resumir mês', icon: <Sparkles size={13} />,   onClick: () => { /* stub F1 — narrativa DRE vira F2 */ },                title: 'Resumo executivo do mês (narrativa DRE compute-based)' },
+              { key: 'fechamento', label: 'Fechamento',  icon: <CheckSquare size={13} />, onClick: () => { /* stub F1 — checklist fechamento vira F2 */ },        title: 'Trilha de 12 passos do fechamento mensal' },
+              { key: 'apresentar', label: 'Apresentar',  icon: <Play size={13} />,        onClick: () => { /* stub F1 — modo apresentação vira F2 */ },           title: 'Modo apresentação fullscreen (Esc fecha)' },
+              { key: 'exportar',   label: 'Exportar',    icon: <Download size={13} />,    onClick: () => { /* stub F1 */ },                                       title: 'Exportar DRE (XLSX / PDF)' },
+            ]}
+          />
           <button
             type="button"
             className="os-btn primary"

--- a/resources/js/Pages/Financeiro/Relatorios/Index.tsx
+++ b/resources/js/Pages/Financeiro/Relatorios/Index.tsx
@@ -14,6 +14,7 @@ import { Button } from '@/Components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/Components/ui/card';
 import { Input } from '@/Components/ui/input';
 import { Badge } from '@/Components/ui/badge';
+import { Download } from 'lucide-react';
 // Onda 14 — PageHeader removido (canon os-page-h direto)
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 
@@ -95,11 +96,15 @@ function FinanceiroRelatorios({ filters, fluxo, resumo }: Props) {
           <p>DRE gerencial, fluxo de caixa projetado vs realizado e resumo do período</p>
         </div>
         <div className="os-page-h-r fin-page-h-r">
-          {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
-          <FinanceiroSubNav active="relatorios" hidePrimary />
-          <a href={csvHref} target="_blank" rel="noopener noreferrer" className="os-btn ghost">
-            Exportar CSV
-          </a>
+          {/* ADR 0180 Fase 5 refine Wagner 2026-05-21 — "Exportar CSV" move pra ⋯ Mais;
+              tela não tem primary "Novo X" (Relatorios é só leitura) */}
+          <FinanceiroSubNav
+            active="relatorios"
+            hidePrimary
+            extraOverflowItems={[
+              { key: 'export-csv', label: 'Exportar CSV', icon: <Download size={13} />, onClick: () => { window.open(csvHref, '_blank', 'noopener,noreferrer'); }, title: 'Exportar relatório do período em CSV' },
+            ]}
+          />
         </div>
       </header>
 


### PR DESCRIPTION
## Resumo

Wagner 2026-05-21: **"ja tem botoes na tela deve ir para `...` se nao forem duplicados"**

Refatora 4 telas Financeiro que tinham botoes action visiveis no header pra mover acoes-features pro overflow `... Mais` do `FinanceiroSubNav`, alinhando com o canon `Unificado/Index.tsx` (PR #1365 mergeado).

**Pattern aplicado:**
- Botoes action features (Resumir/Gateways/Remessa/Exportar/Apresentar/etc) vao pra `extraOverflowItems` do `PageHeaderTabs` (onClick preservado).
- Botoes **duplicados com ghosts existentes** (Conciliar / Plano de contas) sao **REMOVIDOS** -- o ghost ja cobre a navegacao.
- Primary "Nova X" / "Novo Y" fica **SEPARADO** no canto direito do header, usando classe canon `os-btn primary` (canon Unificado).

## Telas alteradas (4)

### 1. `Cobranca/Index.tsx`

**Antes (header inline):**
- `[Resumir mes]` `[Gateways]` `[Remessa/Retorno]` `[+ Nova cobranca primary]`

**Depois:**
- Ghost tabs + `[... Mais]` (= Resumir mes, Gateways, Remessa/Retorno) + `[+ Nova cobranca]` canto direito

### 2. `ContasBancarias/Index.tsx`

**Antes:** `[Gateways]` `[+ Nova conta no POS primary]`
**Depois:** Ghost tabs + `[... Mais]` (= Gateways) + `[+ Nova conta no POS]` canto direito

### 3. `Dre/Index.tsx`

**Antes (header inline, 7 botoes action + primary):**
- `[Buscar (Cmd+K)]` `[Resumir mes]` `[Fechamento]` `[Apresentar]` `[Conciliar]` `[Plano de contas]` `[Exportar download]` `[+ Novo lancamento primary]`

**Depois:**
- Ghost tabs + `[... Mais]` (= Buscar / Resumir mes / Fechamento / Apresentar / Exportar) + `[+ Novo lancamento]` canto direito.
- **REMOVIDOS por duplicacao com ghost:** `Conciliar` (ghost `conciliacao`), `Plano de contas` (ghost `plano-contas`).
- Imports `RefreshCw` + `FolderOpen` removidos (orfaos apos remocao).

### 4. `Relatorios/Index.tsx`

**Antes:** `[Exportar CSV]`
**Depois:** Ghost tabs + `[... Mais]` (= Exportar CSV). Tela nao tem primary "Novo X" (so leitura). Import `Download` adicionado.

## Telas SEM mudanca

Estas 6 telas ja estavam corretas (so FinanceiroSubNav + opcional primary canon):

- `Categorias/Index.tsx` (primary "Nova categoria" ja separado)
- `Conciliacao/Index.tsx` (so FinanceiroSubNav)
- `ContasPagar/Index.tsx` (so FinanceiroSubNav)
- `ContasReceber/Index.tsx` (so FinanceiroSubNav)
- `Fluxo/Index.tsx` (so FinanceiroSubNav)
- `PlanoContas/Index.tsx` (so FinanceiroSubNav)

Tela `Caixa/Index.tsx` foi **pulada** (Wagner: 500 server error em prod, fora do escopo).

## Restricoes preservadas

- **Multi-tenant Tier 0 (ADR 0093):** nenhum permission gate `can()` alterado.
- **Funcionalidade:** onClick handlers preservados -- so MOVE de visual location, NAO remove acao.
- **Backend:** `DataController`, `LegacyMenuAdapter` NAO tocados.
- **Shared components:** `FinanceiroSubNav.tsx`, `PageHeaderTabs.tsx`, `Unificado/Index.tsx` NAO tocados.

## Refs

- ADR 0180 (sidebar v3 -- Fase 5 refine)
- PR #1365 (Unificado piloto canon -- pattern de origem)
- PRs #1366, #1367 (Fase 5 propagacao -- hidePrimary nas 11 telas)
- Wagner 2026-05-21 ("ja tem botoes na tela deve ir para `...` se nao forem duplicados")

## Test plan

- [ ] Login biz=1, abrir /financeiro/cobranca -- ghost tabs visiveis, `... Mais` mostra "Resumir mes / Gateways / Remessa/Retorno", primary "Nova cobranca" canto direito
- [ ] /financeiro/contas-bancarias -- `... Mais` mostra "Gateways"
- [ ] /financeiro/dre -- `... Mais` mostra Buscar/Resumir/Fechamento/Apresentar/Exportar; botoes "Conciliar" e "Plano de contas" NAO visiveis (cobertos pelos ghosts)
- [ ] /financeiro/relatorios -- `... Mais` mostra "Exportar CSV"
- [ ] Build front: `npm run build` passa sem erros (imports RefreshCw/FolderOpen removidos em Dre, Download adicionado em Relatorios)
- [ ] Verificar overflow clicavel -- onClick handlers preservados (sem regressao funcional)

Generated with [Claude Code](https://claude.com/claude-code)