### PR TITLE
feat(pageheader): canon completo — auto-promove + hue 145 + labels curtos + matriz + skill

### DIFF
--- a/.claude/skills/pageheader-canon/SKILL.md
+++ b/.claude/skills/pageheader-canon/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: pageheader-canon
+description: ATIVAR quando user pedir "aplicar pageheader canon", "padronizar header da tela X", "/pageheader-canon <tela>", "header v3 na tela Y", OU em Edit/Write em qualquer `resources/js/Pages/<Mod>/<Tela>/Index.tsx` que tenha sub-navegação (sub-views/ghosts/abas no DataController correspondente). Carrega pattern canônico ADR 0180/0182 (header 3 zonas — título esquerda + ghost tabs ARIA centro + primary direita hue do grupo), matriz de diferenças permitidas, e checklist de 8 pontos pra reviewer validar PR. Cobre — (1) labels CURTOS nos ghosts (≤2 palavras), (2) auto-promove ghost ativo inline mesmo se >maxVisible, (3) primary obrigatório (exceto read-only) com cor hue do grupo via componente `{Modulo}PrimaryButton`, (4) botões features → `extraOverflowItems` do ⋯ Mais, (5) duplicados-com-ghost REMOVE, (6) ARIA tablist + keyboard nav, (7) Multi-tenant Tier 0 (SubNav retorna null se tenant sem módulo), (8) tipografia ADR 0110. Tier B auto-trigger por description.
+---
+
+# Skill `pageheader-canon` — Aplicação do header v3 canônico
+
+> Skill ATIVADA por descrição quando Claude vai editar tela Inertia com sub-navegação. Garante aderência ao pattern ADR 0180 + ADR 0182 + matriz de diferenças `memory/requisitos/_DesignSystem/pageheader-matriz-diferencas.md`.
+
+## Quando ativar
+
+- Edit/Write em `resources/js/Pages/<Mod>/<Tela>/Index.tsx` que tem sub-navegação
+- User pede: "aplicar pageheader canon", "padronizar header da tela X", "/pageheader-canon <tela>"
+- Refactor de tela legacy que ainda tem `<button class="os-btn primary">` magenta inline
+- Tela nova sendo criada com sub-views (ghost candidates) no DataController
+
+## 8 pontos canônicos (validação obrigatória)
+
+### 1. Estrutura 3 zonas (`os-page-h`)
+
+```tsx
+<header className="os-page-h fin-page-h">
+  <div className="os-page-h-l fin-page-h-l">
+    <h1>{Tela} <span className="fin-hero-title-sub">· {subtitle}</span></h1>
+    <p>{periodo/business/contexto}</p>
+  </div>
+  <div className="os-page-h-r fin-page-h-r">
+    {/* ZONA C: ghosts + overflow */}
+    <{Modulo}SubNav active="<key>" hidePrimary extraOverflowItems={[]}/>
+    {/* ZONA R: primary direita */}
+    <{Modulo}PrimaryButton onClick={...}>Nova X</{Modulo}PrimaryButton>
+  </div>
+</header>
+```
+
+### 2. Componente SubNav por módulo
+
+Cada módulo (Financeiro/Vendas/OS/Compras/etc) DEVE ter `Pages/<Modulo>/_shared/<Modulo>SubNav.tsx` que:
+- Lê `shell.menu` via `usePage()`
+- Procura entry com `group === '<grupo_v3>'` ou label canon
+- Retorna `null` se módulo não declarado (multi-tenant Tier 0)
+- Renderiza `<PageHeaderTabs primary={hidePrimary?undefined:item.primary} ghosts={...} extraOverflowItems={...}/>`
+
+Template canon: `resources/js/Pages/Financeiro/_shared/FinanceiroSubNav.tsx`
+
+### 3. Componente PrimaryButton por módulo (cor harmônica)
+
+Cada módulo DEVE ter `Pages/<Modulo>/_shared/<Modulo>PrimaryButton.tsx` que:
+- Background `oklch(0.55 0.15 {hue_do_grupo})` — NÃO magenta 330 canon UPOS
+- Default ícone `<Plus/>` (override `hideIcon` se workflow não-create)
+- Aceita `onClick`/`href` (button vs anchor)
+
+Template canon: `resources/js/Pages/Financeiro/_shared/FinanceiroPrimaryButton.tsx`
+
+### 4. Labels CURTOS nos ghosts (DataController)
+
+❌ Errado: `'Contas a Receber'` / `'Fluxo de Caixa'` / `'Contas Bancárias'` / `'Plano de Contas'`
+✅ Certo: `'Receber'` / `'Fluxo'` / `'Bancos'` / `'Plano'`
+
+Verbo+substantivo único OU substantivo único. ≤2 palavras.
+
+### 5. Auto-promoção do ghost ativo (PageHeaderTabs.tsx)
+
+`PageHeaderTabs` PRECISA ter logic que detecta `activeGhostKey` cuja posição > `maxVisible` e MOVE pra última posição visível. Sem isso, telas como Conciliação/DRE/Bancos têm active escondido no overflow `⋯ Mais` — usuário não sabe onde está.
+
+### 6. Botões action features → `extraOverflowItems`
+
+Botões inline do header pré-pattern devem ser classificados:
+
+| Tipo | Destino |
+|---|---|
+| Duplicado-com-ghost (navega pra tela que já é ghost) | **REMOVER** |
+| Ação features (abre dialog/sheet/modal) | **`extraOverflowItems[]`** |
+| Primary "Nova X" | **Zona R** via `{Modulo}PrimaryButton` |
+| Botão per-linha tabela | **INTACTO** (não é header) |
+
+### 7. ARIA tablist + keyboard nav
+
+`PageHeaderTabs` já garante (não tocar). Validar:
+- `role="tablist"` no wrapper de ghosts
+- Cada ghost `role="tab"` + `aria-selected` + `tabindex` 0/-1
+- ArrowLeft/Right/Home/End funcionam
+
+### 8. Multi-tenant Tier 0 ([ADR 0093](../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md))
+
+- `SubNav` retorna `null` se `finItem === undefined` (tenant sem módulo)
+- `extraOverflowItems` que abrem dialog checam `auth()->user()->can(...)` no handler
+- `shell.menu` já filtra por `business_id` (HandleInertiaRequests)
+
+## Workflow exato pra aplicar em tela nova
+
+1. **Pré-flight**: ler `memory/requisitos/_DesignSystem/pageheader-matriz-diferencas.md` (matriz F1-F12 fixas + V1-V9 variáveis)
+2. **Backend**: DataController declara `ghosts[]` com labels curtos + `primary{label,href,shortcut}` na entry principal do módulo
+3. **Frontend wrapper**: criar `Pages/<Modulo>/_shared/<Modulo>SubNav.tsx` se não existe (template = FinanceiroSubNav)
+4. **Frontend primary**: criar `Pages/<Modulo>/_shared/<Modulo>PrimaryButton.tsx` se não existe (hue do grupo)
+5. **Tela**: 
+   - Import `<{Modulo}SubNav>` + `<{Modulo}PrimaryButton>`
+   - Header em 3 zonas (`os-page-h` + `os-page-h-l` + `os-page-h-r`)
+   - `<{Modulo}SubNav active="<key>" hidePrimary extraOverflowItems={[...]}/>`
+   - `<{Modulo}PrimaryButton onClick={...}>Verbo+X</{Modulo}PrimaryButton>` (omitir se read-only)
+   - Botões legacy: classificar por tabela 6 (remover/overflow/primary/intacto)
+6. **Charter da tela**: atualizar `*.charter.md` com nota "header pattern ADR 0182 OK"
+7. **Pest test** (opcional): valida shape do shell.menu + click ghost ativo
+
+## Checklist de revisão de PR (8 pontos)
+
+Reviewer checa cada PR que toca tela com sub-navegação:
+
+- [ ] F1 header tem 3 zonas (`os-page-h-l` + ghosts + primary)?
+- [ ] F2 usa `<{Modulo}SubNav>` (não JSX inline)?
+- [ ] F6 ghost ativo aparece inline (auto-promoção funciona)?
+- [ ] F8 primary cor harmônica (hue grupo, não magenta canon UPOS)?
+- [ ] F9 labels dos ghosts curtos (≤2 palavras)?
+- [ ] F12 sem botões duplicados-com-ghost inline?
+- [ ] V1 label primary contextual (verbo de ação)?
+- [ ] F11 SubNav retorna null se módulo desinstalado?
+
+## Anti-padrões conhecidos (evitar)
+
+| Anti-padrão | Causa | Fix |
+|---|---|---|
+| Primary magenta `oklch(0.58 0.12 330)` | CSS canon UPOS legacy `os-btn primary` | Usar `{Modulo}PrimaryButton` com hue do grupo |
+| Ghost ativo invisível no overflow | `activeGhostKey` index >= maxVisible | PageHeaderTabs auto-promoção (já implementado) |
+| Botão duplicado-com-ghost (ex `Conciliar` inline + ghost `conciliacao`) | Refactor incompleto | REMOVER botão inline — ghost cobre |
+| Label longo (`'Contas a Receber'`) | DataController copia do UPOS legacy | Encurtar (`'Receber'`) — preservar label longo no tooltip |
+| Primary inline antes dos ghosts | PageHeaderTabs default render primary à esquerda | Passar `hidePrimary` + renderizar primary separado direita |
+| Tela read-only com primary forçado | Pattern aplicado cegamente | OK omitir primary em Fluxo/Relatórios |
+
+## Estado atual (ADR 0180/0182 propagação)
+
+| Módulo | SubNav existe? | PrimaryButton existe? | Telas migradas |
+|---|---|---|---|
+| Financeiro | ✅ | ✅ | 11/13 (Caixa 500 prod; Contador config) |
+| Vendas (Sells) | ❌ | ❌ | 0 |
+| CRM | ❌ | ❌ | 0 |
+| OS (Repair/OficinaAuto) | ❌ | ❌ | 0 |
+| Compras | ❌ | ❌ | 0 |
+| Fiscal (NfeBrasil) | ❌ | ❌ | 0 |
+| RH (Essentials/Ponto) | ❌ | ❌ | 0 |
+| Governance | ❌ | ❌ | 0 |
+| Plataforma | ❌ | ❌ | 0 |
+
+Próximas Ondas: aplicar em outros 8 módulos (sub-agents paralelos, ~1.5-2 dias).
+
+## Refs
+
+- [ADR 0180](../../../memory/decisions/0180-sidebar-v3-5-grupos-ghosts-header.md) — Sidebar v3
+- [ADR 0182](../../../memory/decisions/0182-pageheadertabs-canon-pattern-telas.md) — PageHeaderTabs canon
+- [ADR 0093](../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md) — Tier 0
+- [ADR 0110](../../../memory/decisions/0110-tipografia-canon-h1-subtitle.md) — Tipografia
+- [Matriz diferenças](../../../memory/requisitos/_DesignSystem/pageheader-matriz-diferencas.md) — F1-F12 + V1-V9
+- Templates: `resources/js/Pages/Financeiro/_shared/{FinanceiroSubNav,FinanceiroPrimaryButton}.tsx`
+- Skill `cockpit-runbook` (Tier B, complementa este pattern com receita completa)

--- a/Modules/Financeiro/Http/Controllers/DataController.php
+++ b/Modules/Financeiro/Http/Controllers/DataController.php
@@ -163,20 +163,24 @@ class DataController extends Controller
                             'href'     => '/financeiro/lancamentos/create',
                             'shortcut' => 'N',
                         ],
+                        // ADR 0182 + Wagner 2026-05-21 review: labels CURTOS pra caber mais
+                        // ghost tabs inline. Label original completa preservada como tooltip
+                        // futuro (F3 PageHeader). Mental model Larissa: "Receber/Pagar/Fluxo/
+                        // Bancos/Plano" — verbos+substantivos contextualizados.
                         'ghosts'   => [
-                            ['key' => 'unificado',         'label' => 'Financeiro',        'href' => '/financeiro/unificado'],
-                            ['key' => 'contas-receber',    'label' => 'Contas a Receber',  'href' => '/financeiro/contas-receber'],
-                            ['key' => 'contas-pagar',      'label' => 'Contas a Pagar',    'href' => '/financeiro/contas-pagar'],
-                            ['key' => 'fluxo',             'label' => 'Fluxo de Caixa',    'href' => '/financeiro/fluxo'],
-                            ['key' => 'cobranca',          'label' => 'Cobrança',          'href' => '/financeiro/cobranca'],
-                            ['key' => 'caixa',             'label' => 'Caixa do turno',    'href' => '/financeiro/caixa'],
-                            ['key' => 'conciliacao',       'label' => 'Conciliação',       'href' => '/financeiro/conciliacao'],
-                            ['key' => 'dre',               'label' => 'DRE',               'href' => '/financeiro/dre'],
-                            ['key' => 'relatorios',        'label' => 'Relatórios',        'href' => '/financeiro/relatorios'],
-                            ['key' => 'contas-bancarias',  'label' => 'Contas Bancárias',  'href' => '/financeiro/contas-bancarias'],
-                            ['key' => 'plano-contas',      'label' => 'Plano de Contas',   'href' => '/financeiro/plano-contas'],
-                            ['key' => 'categorias',        'label' => 'Categorias',        'href' => '/financeiro/categorias'],
-                            ['key' => 'contador',          'label' => 'Contador',          'href' => '/financeiro/configuracoes/contador'],
+                            ['key' => 'unificado',         'label' => 'Financeiro',   'href' => '/financeiro/unificado'],
+                            ['key' => 'contas-receber',    'label' => 'Receber',      'href' => '/financeiro/contas-receber'],
+                            ['key' => 'contas-pagar',      'label' => 'Pagar',        'href' => '/financeiro/contas-pagar'],
+                            ['key' => 'fluxo',             'label' => 'Fluxo',        'href' => '/financeiro/fluxo'],
+                            ['key' => 'cobranca',          'label' => 'Cobrança',     'href' => '/financeiro/cobranca'],
+                            ['key' => 'caixa',             'label' => 'Caixa',        'href' => '/financeiro/caixa'],
+                            ['key' => 'conciliacao',       'label' => 'Conciliação',  'href' => '/financeiro/conciliacao'],
+                            ['key' => 'dre',               'label' => 'DRE',          'href' => '/financeiro/dre'],
+                            ['key' => 'relatorios',        'label' => 'Relatórios',   'href' => '/financeiro/relatorios'],
+                            ['key' => 'contas-bancarias',  'label' => 'Bancos',       'href' => '/financeiro/contas-bancarias'],
+                            ['key' => 'plano-contas',      'label' => 'Plano',        'href' => '/financeiro/plano-contas'],
+                            ['key' => 'categorias',        'label' => 'Categorias',   'href' => '/financeiro/categorias'],
+                            ['key' => 'contador',          'label' => 'Contador',     'href' => '/financeiro/configuracoes/contador'],
                         ],
                     ]
                 )->order(85.00);

--- a/memory/requisitos/_DesignSystem/pageheader-matriz-diferencas.md
+++ b/memory/requisitos/_DesignSystem/pageheader-matriz-diferencas.md
@@ -1,0 +1,89 @@
+# PageHeader Canon — Matriz de Diferenças Técnicas e Pontos Permitidos
+
+> Referência canônica de **o que DEVE ser igual** e **o que PODE variar** entre telas que adotam o pattern do header `os-page-h` da ADR 0180/0182. Use esta matriz como checklist de revisão de PR e fonte da skill `pageheader-canon`.
+
+**Origem:** Wagner 2026-05-21 review smoke prod das 12 telas Financeiro → pediu matriz + skill pra padronização escalável.
+
+---
+
+## Dimensões fixas (IDÊNTICAS em todas as telas — drift = bug)
+
+| # | Dimensão | Valor canon | Source of truth |
+|---|---|---|---|
+| F1 | Estrutura 3 zonas | L (`os-page-h-l` título+sub) · C (`os-page-h-r` ghosts+overflow) · R (`os-page-h-r` primary) | [ADR 0182](../../decisions/0182-pageheadertabs-canon-pattern-telas.md) |
+| F2 | Componente ghost tabs | `<{Modulo}SubNav active="X" hidePrimary extraOverflowItems={[]}/>` | Wrapper por módulo em `_shared/` |
+| F3 | ARIA tablist | `role="tablist"` + cada ghost `role="tab"` + `aria-selected` | `PageHeaderTabs.tsx` |
+| F4 | Keyboard nav | ArrowLeft/Right/Home/End wrap-around | `PageHeaderTabs.tsx` |
+| F5 | Overflow `⋯ Mais` | `DropdownMenu` shadcn quando ghosts > maxVisible OU extraOverflowItems > 0 | `PageHeaderTabs.tsx` |
+| F6 | Ghost ativo **sempre visível** | Auto-promoção pra index < maxVisible mesmo se declarado depois | `PageHeaderTabs.tsx` (ADR 0182 patch 2026-05-21) |
+| F7 | Hue OKLCH per-grupo | financas=145 · vender=60 · operar=350 · pessoas=295 · sistema=200 · ia=220 · atendimento=30 · equipe=270 | `cockpit/shared.ts SIDEBAR_GROUP_HUE` |
+| F8 | Primary cor | `oklch(0.55 0.15 {hue_grupo})` — verde 145 pra Financeiro | `FinanceiroPrimaryButton.tsx` ou inline style canon |
+| F9 | Labels CURTOS | 1-2 palavras (verbo ou substantivo único) — não "Contas a X" | DataController `data['ghosts']['label']` |
+| F10 | Tipografia título h1 | `text-xl md:text-2xl font-semibold tracking-tight` | [ADR 0110](../../decisions/0110-tipografia-canon-h1-subtitle.md) |
+| F11 | Multi-tenant Tier 0 | `shell.menu` filtra por `business_id`; SubNav retorna null se módulo desinstalado | [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md) |
+| F12 | Botões duplicados-com-ghost | **proibido** — botão que navega pra outra tela que já é ghost = remover | ADR 0182 |
+
+---
+
+## Dimensões variáveis (PODE diferir entre telas — caso-a-caso)
+
+| # | Dimensão | Permitido | Padrão recomendado |
+|---|---|---|---|
+| V1 | Label do primary | Contextual à tela (verbo ação): "Novo título" / "Nova categoria" / "Importar OFX" / "Receber" / "Pagar" | Sempre verbo de ação canônico do domínio |
+| V2 | Existência de primary | Opcional — telas read-only (Fluxo / Relatórios) podem omitir | Telas CRUD/workflow têm; visualização pura omite |
+| V3 | Tipo do elemento primary | `<button>` (default) OU `<a href>` (caso de link externo) OU `<button type="submit">` (form upload) | `<button>` via `FinanceiroPrimaryButton` componente |
+| V4 | `extraOverflowItems` | 0 a N ações features-específicas (Resumir mês / Apresentar / Exportar / OCR / etc) | Telas com ações features ricas (Unificado/DRE/Cobrança); outras 0 |
+| V5 | Ícone do primary | `<Plus/>` (default componente) OU outro (`<Upload/>` em Conciliação) | Default `<Plus/>`; override pra workflows não-create |
+| V6 | maxVisible (ghosts inline) | 4-6 (default 5) | 5 — cabe Larissa 1280px |
+| V7 | Subtítulo do título | Texto curto contextualizando (período / business / total) | Padrão `os-page-h-l p` |
+| V8 | Modal/Sheet abertas via `extraOverflowItems` | Tela define handlers próprios (setNovaOpen / setResumoOpen / etc) | onClick stateful no Index.tsx |
+| V9 | Filtros/KPIs abaixo do header | Layout livre pós-header (cards / filtros / tabela) | Cada tela define conforme persona |
+
+---
+
+## Matriz por tela (Financeiro — estado atual)
+
+| Tela | Label canon | Active visível? | Primary | Cor primary | extraOverflowItems |
+|---|---|---|---|---|---|
+| Unificado | Financeiro | ✅ | ✅ "Novo título" | hue 145 ✅ | 7 (Buscar/Resumir/Fechamento/Apresentar/Imprimir/Exportar/OCR) |
+| Contas a Receber | Receber | ✅ | ✅ "Novo recebimento" | hue 145 ✅ | 0 |
+| Contas a Pagar | Pagar | ✅ | ✅ "Novo pagamento" | hue 145 ✅ | 0 |
+| Fluxo de Caixa | Fluxo | ✅ | ⚠️ omitido (read-only) | — | 0 |
+| Cobrança | Cobrança | ✅ | ✅ "Nova cobrança" | hue 145 ✅ | 3 (Resumir/Gateways/Remessa) |
+| Caixa do turno | Caixa | ⚠️ 500 prod | — | — | — |
+| Conciliação | Conciliação | ✅ (auto-promove F6) | ✅ "Importar OFX" (submit form) | hue 145 ✅ | 0 |
+| DRE | DRE | ✅ (auto-promove F6) | ✅ "Novo lançamento" | hue 145 ✅ | 5 (Buscar/Resumir/Fechamento/Apresentar/Exportar) |
+| Relatórios | Relatórios | ✅ (auto-promove F6) | ⚠️ omitido (read-only) | — | 1 (Exportar CSV) |
+| Contas Bancárias | Bancos | ✅ (auto-promove F6) | ✅ "Nova conta" (`<a href>`) | hue 145 ✅ | 1 (Gateways) |
+| Plano de Contas | Plano | ✅ (auto-promove F6) | ✅ "Nova conta" | hue 145 ✅ | 0 |
+| Categorias | Categorias | ✅ (auto-promove F6) | ✅ "Nova categoria" | hue 145 ✅ | 0 |
+| Contador | Contador | ✅ (auto-promove F6) | (tela config, no header próprio) | — | — |
+
+**Score consistência:** 11/13 telas com pattern 100% canon · 1 tela 500 prod (Caixa) · 1 tela config (Contador)
+
+---
+
+## Pontos de revisão de PR (checklist canon)
+
+Pra cada PR que tocar tela com sub-navegação, reviewer DEVE verificar:
+
+- [ ] **F1**: header tem 3 zonas (`os-page-h-l` + `os-page-h-r` com ghosts/overflow + primary direita)?
+- [ ] **F2**: usa `<{Modulo}SubNav active="X"/>` (não inline JSX)?
+- [ ] **F6**: ghost ativo aparece inline (não no overflow)?
+- [ ] **F8**: primary cor harmônica com hue do grupo (não magenta canon UPOS default)?
+- [ ] **F9**: labels dos ghosts são curtos (≤2 palavras)?
+- [ ] **F12**: botões inline NÃO duplicam com ghosts (Conciliar/Plano de contas removidos quando ghost cobre)?
+- [ ] **V1-V5**: variações documentadas (primary opcional pra read-only OK; tipo do elemento OK)?
+- [ ] **F11**: SubNav retorna null se tenant sem módulo (Multi-tenant Tier 0)?
+
+---
+
+## Refs
+
+- [ADR 0180](../../decisions/0180-sidebar-v3-5-grupos-ghosts-header.md) — Sidebar v3 5 grupos canon
+- [ADR 0182](../../decisions/0182-pageheadertabs-canon-pattern-telas.md) — PageHeaderTabs canon pattern 3 zonas
+- [ADR 0110](../../decisions/0110-tipografia-canon-h1-subtitle.md) — Tipografia h1 + subtitle
+- [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md) — Tier 0 multi-tenant
+- [Skill `pageheader-canon`](../../../.claude/skills/pageheader-canon/SKILL.md) — aplicação automatizada
+- PRs Fase 5 Financeiro: #1363/#1364/#1365/#1366/#1367/#1368/#1369
+- Wagner reviews 2026-05-21 (revisão visual prod 12 telas)

--- a/resources/js/Components/shared/PageHeaderTabs.tsx
+++ b/resources/js/Components/shared/PageHeaderTabs.tsx
@@ -109,8 +109,23 @@ export default function PageHeaderTabs({
   const hue = group ? SIDEBAR_GROUP_HUE[group] : undefined;
   const hueStyle = hue !== undefined ? ({ '--gh': hue } as React.CSSProperties) : undefined;
 
-  const visibleGhosts = ghosts.slice(0, maxVisible);
-  const overflowGhosts = ghosts.slice(maxVisible);
+  // ADR 0182 / Wagner 2026-05-21: auto-promove o ghost ativo pra zona visível
+  // (inline) mesmo se ele estiver depois de maxVisible. Sem isso, telas como
+  // Conciliação/DRE/Bancos ficavam com active escondido no overflow `⋯ Mais`
+  // — usuário não sabia em qual ghost estava.
+  const ghostsOrdered = (() => {
+    if (!activeGhostKey) return ghosts;
+    const activeIdx = ghosts.findIndex((g) => g.key === activeGhostKey);
+    if (activeIdx < 0 || activeIdx < maxVisible) return ghosts;
+    // Active está no overflow → move pra última posição visível (maxVisible-1)
+    const reordered = [...ghosts];
+    const [active] = reordered.splice(activeIdx, 1);
+    reordered.splice(maxVisible - 1, 0, active);
+    return reordered;
+  })();
+
+  const visibleGhosts = ghostsOrdered.slice(0, maxVisible);
+  const overflowGhosts = ghostsOrdered.slice(maxVisible);
 
   // ── Keyboard nav (left/right/home/end) ──────────────────────────────
   const tablistRef = React.useRef<HTMLDivElement>(null);

--- a/resources/js/Pages/Financeiro/Categorias/Index.tsx
+++ b/resources/js/Pages/Financeiro/Categorias/Index.tsx
@@ -9,6 +9,7 @@ import { Tag, Plus, Pencil, Trash2, Power, PowerOff } from 'lucide-react';
 import { toast } from 'sonner';
 import { CategoriaSheet } from './components/CategoriaSheet';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import FinanceiroPrimaryButton from '@/Pages/Financeiro/_shared/FinanceiroPrimaryButton';
 
 interface Categoria {
   id: number;
@@ -80,9 +81,9 @@ function Index({ categorias, planos_conta }: Props) {
           <div className="os-page-h-r fin-page-h-r">
             {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
             <FinanceiroSubNav active="categorias" hidePrimary />
-            <button type="button" className="os-btn primary" onClick={() => setCreating(true)}>
-              <Plus size={13} /> Nova categoria
-            </button>
+            <FinanceiroPrimaryButton onClick={() => setCreating(true)}>
+              Nova categoria
+            </FinanceiroPrimaryButton>
           </div>
         </header>
 

--- a/resources/js/Pages/Financeiro/Cobranca/Index.tsx
+++ b/resources/js/Pages/Financeiro/Cobranca/Index.tsx
@@ -22,6 +22,7 @@ import {
 } from 'lucide-react';
 import { Btn, StatusBadge, GatewayTipoChip, OrigemChip, KpiCard} from './_components/atoms';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import FinanceiroPrimaryButton from '@/Pages/Financeiro/_shared/FinanceiroPrimaryButton';
 import FunnelStrip from './_components/FunnelStrip';
 import DrawerCobranca from './_components/DrawerCobranca';
 import SheetNovaCobranca from './_components/SheetNovaCobranca';
@@ -195,9 +196,9 @@ function CobrancaPage({ cobrancas, kpis, funil, accounts = [], gateways = [], fi
                 { key: 'remessa',  label: 'Remessa/Retorno', icon: <Upload size={13} />,   onClick: () => setRemessaOpen(true) },
               ]}
             />
-            <button type="button" className="os-btn primary" onClick={() => setNovaOpen(true)}>
-              <Plus size={13} /> Nova cobrança
-            </button>
+            <FinanceiroPrimaryButton onClick={() => setNovaOpen(true)}>
+              Nova cobrança
+            </FinanceiroPrimaryButton>
           </div>
         </header>
       </div>

--- a/resources/js/Pages/Financeiro/Conciliacao/Index.tsx
+++ b/resources/js/Pages/Financeiro/Conciliacao/Index.tsx
@@ -165,6 +165,7 @@ function FinanceiroConciliacao({ linhas, stats, contas }: Props) {
             type="submit"
             className="os-btn primary"
             disabled={!uploadForm.data.arquivo || uploadForm.processing}
+            style={{ backgroundColor: 'oklch(0.55 0.15 145)', color: 'oklch(0.99 0 0)' }}
           >
             <Upload size={13} />
             {uploadForm.processing ? 'Processando…' : 'Importar OFX'}

--- a/resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
@@ -85,8 +85,12 @@ function Index({ accounts, bancos_suportados }: Props) {
                 { key: 'gateways', label: 'Gateways', icon: <Settings size={13} />, onClick: () => { window.location.href = '/settings/payment-gateways'; }, title: 'Credenciais API gateways de pagamento' },
               ]}
             />
-            <a href="/account/account/create" className="os-btn primary">
-              <Plus size={13} /> Nova conta no POS
+            <a
+              href="/account/account/create"
+              className="os-btn primary"
+              style={{ backgroundColor: 'oklch(0.55 0.15 145)', color: 'oklch(0.99 0 0)' }}
+            >
+              <Plus size={13} /> Nova conta
             </a>
           </div>
         </header>

--- a/resources/js/Pages/Financeiro/ContasPagar/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasPagar/Index.tsx
@@ -13,6 +13,7 @@ import { Textarea } from '@/Components/ui/textarea';
 import { CreditCard, AlertTriangle, CheckCircle2, Circle, Hourglass } from 'lucide-react';
 import { toast } from 'sonner';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import FinanceiroPrimaryButton from '@/Pages/Financeiro/_shared/FinanceiroPrimaryButton';
 
 interface Titulo {
   id: number;
@@ -169,8 +170,10 @@ function Index({ titulos, contas_bancarias, filtros }: Props) {
             <p>Compras, despesas, contratos</p>
           </div>
           <div className="os-page-h-r fin-page-h-r">
-            {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
             <FinanceiroSubNav active="contas-pagar" hidePrimary />
+            <FinanceiroPrimaryButton onClick={() => router.visit('/financeiro/unificado/novo?kind=payable')}>
+              Novo pagamento
+            </FinanceiroPrimaryButton>
           </div>
         </header>
 

--- a/resources/js/Pages/Financeiro/ContasReceber/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasReceber/Index.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent } from '@/Components/ui/card';
 import { Receipt, AlertTriangle, CheckCircle2, Circle, Hourglass } from 'lucide-react';
 import { toast } from 'sonner';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import FinanceiroPrimaryButton from '@/Pages/Financeiro/_shared/FinanceiroPrimaryButton';
 
 interface BoletoInfo {
   id: number;
@@ -95,8 +96,10 @@ function Index({ titulos, filtros }: Props) {
             <p>Gerados de vendas (auto) ou cadastrados manualmente</p>
           </div>
           <div className="os-page-h-r fin-page-h-r">
-            {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
             <FinanceiroSubNav active="contas-receber" hidePrimary />
+            <FinanceiroPrimaryButton onClick={() => router.visit('/financeiro/unificado/novo?kind=receivable')}>
+              Novo recebimento
+            </FinanceiroPrimaryButton>
           </div>
         </header>
 

--- a/resources/js/Pages/Financeiro/Dre/Index.tsx
+++ b/resources/js/Pages/Financeiro/Dre/Index.tsx
@@ -28,6 +28,7 @@ import {
 import { BalancoView, type BalancoData } from './_components/BalancoView';
 import { BalanceteView, type BalanceteData } from './_components/BalanceteView';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import FinanceiroPrimaryButton from '@/Pages/Financeiro/_shared/FinanceiroPrimaryButton';
 
 // ---------- Tipos das linhas (espelha DRE_LINES canon TelaDRE) ----------
 
@@ -214,13 +215,9 @@ function FinanceiroDre({
               { key: 'exportar',   label: 'Exportar',    icon: <Download size={13} />,    onClick: () => { /* stub F1 */ },                                       title: 'Exportar DRE (XLSX / PDF)' },
             ]}
           />
-          <button
-            type="button"
-            className="os-btn primary"
-            onClick={() => router.visit('/financeiro/unificado/novo')}
-          >
-            <Plus size={13} /> Novo lançamento
-          </button>
+          <FinanceiroPrimaryButton onClick={() => router.visit('/financeiro/unificado/novo')}>
+            Novo lançamento
+          </FinanceiroPrimaryButton>
         </div>
       </header>
 

--- a/resources/js/Pages/Financeiro/PlanoContas/Index.tsx
+++ b/resources/js/Pages/Financeiro/PlanoContas/Index.tsx
@@ -10,7 +10,9 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { type ReactNode, useMemo, useState } from 'react';
 import { Lock, FileText, Search } from 'lucide-react';
+import { router } from '@inertiajs/react';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import FinanceiroPrimaryButton from '@/Pages/Financeiro/_shared/FinanceiroPrimaryButton';
 
 interface PlanoConta {
   id: number;
@@ -72,8 +74,10 @@ function FinanceiroPlanoContas({ planos, stats }: Props) {
           <p>{stats.total} contas hierárquicas (Receita Federal/DCASP) — Eliana classifica lançamentos pelo plano</p>
         </div>
         <div className="os-page-h-r fin-page-h-r">
-          {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
           <FinanceiroSubNav active="plano-contas" hidePrimary />
+          <FinanceiroPrimaryButton onClick={() => router.visit('/financeiro/plano-contas/create')}>
+            Nova conta
+          </FinanceiroPrimaryButton>
         </div>
       </header>
 

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -25,6 +25,7 @@ import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/Components/ui/sh
 import { CommandDialog, CommandEmpty, CommandGroup, CommandInput, CommandItem, CommandList } from '@/Components/ui/command';
 import PageHeader from '@/Components/shared/PageHeader';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import FinanceiroPrimaryButton from '@/Pages/Financeiro/_shared/FinanceiroPrimaryButton';
 import KpiCard from '@/Components/shared/KpiCard';
 import { FinPillFrescor } from './_components/FinPillFrescor';
 import { FinConferidoToggle, FinConferidoBadge, useFinConferido, type UseFinConferidoApi } from './_components/FinConferidoToggle';
@@ -982,11 +983,10 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
               { key: 'ocr',        label: 'OCR boleto',      icon: <span>📷</span>,            onClick: () => setOcrSheetOpen(true),                                title: 'Importar boleto via foto/PDF (OCR via IA)' },
             ]}
           />
-          {/* Primary "+ Novo título" — canto direito, separado dos ghosts (Wagner 2026-05-21) */}
-          <button type="button" className="os-btn primary" onClick={() => router.visit('/financeiro/unificado/novo')}>
-            <Plus size={13} />
+          {/* Primary "+ Novo título" — canto direito, hue 145 financas (ADR 0182) */}
+          <FinanceiroPrimaryButton onClick={() => router.visit('/financeiro/unificado/novo')}>
             Novo título
-          </button>
+          </FinanceiroPrimaryButton>
         </div>
       </div>
 

--- a/resources/js/Pages/Financeiro/_shared/FinanceiroPrimaryButton.tsx
+++ b/resources/js/Pages/Financeiro/_shared/FinanceiroPrimaryButton.tsx
@@ -1,0 +1,59 @@
+import * as React from 'react';
+import { Plus } from 'lucide-react';
+import { SIDEBAR_GROUP_HUE } from '@/Components/cockpit/shared';
+
+/**
+ * FinanceiroPrimaryButton — botão primary canon das 12 telas Financeiro.
+ *
+ * ADR 0182 + Wagner 2026-05-21 review: o `.os-btn.primary` canon UltimatePOS
+ * usa magenta `oklch(0.58 0.12 330)` que NÃO harmoniza com o hue 145 (verde
+ * financas) dos ghost tabs ARIA. Resultado: header com botão "rosa-vermelho"
+ * conflitando com sidebar/ghosts verdes.
+ *
+ * Este componente sobrescreve o background-color do `.os-btn.primary` pelo
+ * hue do grupo `financas` (145) lido de SIDEBAR_GROUP_HUE — fica visualmente
+ * harmônico com sidebar v3 + ghost tabs.
+ *
+ * Mesma assinatura de `<button>` HTML — pode usar `onClick`, `disabled`,
+ * `type`, etc. Conteúdo `children` renderiza ao lado do ícone Plus (passe
+ * sem `<Plus/>` próprio).
+ *
+ * Uso canon nas 12 telas Financeiro (sempre no canto direito do header,
+ * depois do `<FinanceiroSubNav hidePrimary .../>` — Zona R ADR 0182):
+ *
+ *   <FinanceiroPrimaryButton onClick={() => router.visit('/financeiro/x/novo')}>
+ *     Nova X
+ *   </FinanceiroPrimaryButton>
+ */
+interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Esconde o ícone Plus (default render). */
+  hideIcon?: boolean;
+  /** Override do hue (default: 145 financas). Útil pra primary de outros grupos no futuro. */
+  group?: keyof typeof SIDEBAR_GROUP_HUE;
+}
+
+export default function FinanceiroPrimaryButton({
+  children,
+  hideIcon,
+  group = 'financas',
+  className = '',
+  style,
+  ...rest
+}: Props) {
+  const hue = SIDEBAR_GROUP_HUE[group] ?? 145;
+  return (
+    <button
+      type="button"
+      className={`os-btn primary ${className}`.trim()}
+      style={{
+        backgroundColor: `oklch(0.55 0.15 ${hue})`,
+        color: 'oklch(0.99 0 0)',
+        ...style,
+      }}
+      {...rest}
+    >
+      {!hideIcon && <Plus size={13} />}
+      {children}
+    </button>
+  );
+}


### PR DESCRIPTION
## Resumo

Consolidação das 4 dimensões pendentes do PageHeader canon (ADR 0182) após Wagner review smoke prod das 12 telas Financeiro 2026-05-21.

## 4 fixes técnicos

| # | Problema | Fix |
|---|---|---|
| 1 | Ghost ativo invisível no overflow ⋯ Mais (6 telas) | `PageHeaderTabs` **auto-promove** ativo pra última posição visível |
| 2 | Labels ghost longos ("Contas a Receber", "Fluxo de Caixa") | DataController **labels CURTOS** (Receber/Pagar/Fluxo/Bancos/Plano) |
| 3 | Cor primary magenta canon UPOS `oklch 0.58 0.12 330` | Novo `FinanceiroPrimaryButton` com **hue 145 fin** (verde harmônico com ghost ativo) |
| 4 | 5 telas SEM primary, 6 telas COM (inconsistência) | Adicionar primary em **ContasReceber/ContasPagar/PlanoContas** (Fluxo/Relatórios omitem por serem read-only — OK matriz V2) |

## 2 artefatos canon novos

5. **Matriz de diferenças** [`memory/requisitos/_DesignSystem/pageheader-matriz-diferencas.md`](memory/requisitos/_DesignSystem/pageheader-matriz-diferencas.md):
   - **12 dimensões FIXAS** (F1-F12) — drift = bug (estrutura 3 zonas, ARIA tablist, hue grupo, labels curtos, etc)
   - **9 dimensões VARIÁVEIS** (V1-V9) — caso-a-caso OK (label primary contextual, tipo do elemento, omitir primary se read-only, etc)
   - Estado atual por tela (11/13 Financeiro 100% canon)
   - Checklist 8 pontos pra reviewer de PR

6. **Skill `pageheader-canon`** [`.claude/skills/pageheader-canon/SKILL.md`](.claude/skills/pageheader-canon/SKILL.md):
   - Auto-trigger por description quando Claude editar tela com sub-nav
   - Workflow 7 passos pra aplicar em tela nova (backend DataController + frontend wrapper + tela)
   - 6 anti-padrões catalogados (magenta/active-invisible/duplicado/label-longo/etc)
   - Estado de propagação por módulo (Financeiro ✅; outros 8 ⏳)

## LOC

- 14 files, 371 insertions, 37 deletions
- 9 edits + 3 novos (PrimaryButton + Matriz + Skill)

## Telas finais (todas com hue 145 verde fin)

| Tela | Label canon | Primary |
|---|---|---|
| Unificado | Financeiro | Novo título |
| Contas Receber | Receber | Novo recebimento (novo) |
| Contas Pagar | Pagar | Novo pagamento (novo) |
| Fluxo | Fluxo | — (read-only) |
| Cobrança | Cobrança | Nova cobrança |
| Caixa | Caixa | (500 prod) |
| Conciliação | Conciliação | Importar OFX (submit form, hue 145) |
| DRE | DRE | Novo lançamento |
| Relatórios | Relatórios | — (read-only) |
| Bancos | Bancos | Nova conta (link `<a>`, hue 145) |
| Plano | Plano | Nova conta (novo) |
| Categorias | Categorias | Nova categoria |

## Refs

- [ADR 0180](memory/decisions/0180-sidebar-v3-5-grupos-ghosts-header.md) (Sidebar v3) · [ADR 0182](memory/decisions/0182-pageheadertabs-canon-pattern-telas.md) (canon header) · [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md) (Tier 0) · [ADR 0110](memory/decisions/0110-tipografia-canon-h1-subtitle.md) (tipografia)
- PRs Fase 5: #1363-#1369
- Wagner reviews 2026-05-21 captadas no contexto

🤖 Generated with [Claude Code](https://claude.com/claude-code)