### PR TITLE
feat(financeiro): ADR 0183 PR C — tela /caixa status integração + backfill manual

### DIFF
--- a/Modules/Financeiro/Http/Controllers/CaixaController.php
+++ b/Modules/Financeiro/Http/Controllers/CaixaController.php
@@ -4,12 +4,15 @@ declare(strict_types=1);
 
 namespace Modules\Financeiro\Http\Controllers;
 
+use App\CashRegister;
 use App\Http\Controllers\Controller;
 use App\Util\OtelHelper;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Financeiro\Services\TituloAutoService;
 
 /**
  * Tela /financeiro/caixa — wrapper Inertia sobre cash_registers core UltimatePOS.
@@ -82,11 +85,24 @@ class CaixaController extends Controller
                 $query->where('cr.status', $statusFilter);
             }
 
+            // ADR 0183 PR C — pre-fetch fin_titulos gerados (origem='caixa') pra
+            // mostrar status integração ✅/⚠️ por caixa sem N+1. Single query
+            // agregada por business + IDs de caixas listados.
+            $caixaIds = $query->pluck('cr.id');
+            $titulosByCaixa = DB::table('fin_titulos')
+                ->where('business_id', $businessId)
+                ->where('origem', 'caixa')
+                ->whereIn('origem_id', $caixaIds)
+                ->whereNull('deleted_at')
+                ->select('id', 'origem_id', 'status', 'valor_total')
+                ->get()
+                ->keyBy('origem_id');
+
             $caixas = $query
                 ->orderByDesc('cr.created_at')
                 ->limit($limit)
                 ->get()
-                ->map(function ($row) {
+                ->map(function ($row) use ($titulosByCaixa) {
                     // Soma transações por método (consulta agregada — N+1 OK pra ≤200 rows).
                     //
                     // Fix Wagner 2026-05-21 (PR após #1373): `cash_register_transactions`
@@ -127,6 +143,16 @@ class CaixaController extends Controller
                         // com fallback '—' via default opcional no .tsx.
                         'location_id' => 0,
                         'location_name' => '—',
+                        // ADR 0183 PR C — status integração com fin_titulos
+                        'fin_titulo_id'      => isset($titulosByCaixa[$row->id]) ? (int) $titulosByCaixa[$row->id]->id : null,
+                        'fin_titulo_status'  => isset($titulosByCaixa[$row->id]) ? (string) $titulosByCaixa[$row->id]->status : null,
+                        'fin_titulo_valor'   => isset($titulosByCaixa[$row->id]) ? (float) $titulosByCaixa[$row->id]->valor_total : null,
+                        // 'lancado' = ✅ ja gerou fin_titulo
+                        // 'pendente' = ⚠️ caixa fechado mas sem fin_titulo (pre-Observer ou skip silencioso)
+                        // 'nao_aplicavel' = caixa aberto (lifecycle ainda não fechou)
+                        'integracao_status'  => isset($titulosByCaixa[$row->id])
+                            ? 'lancado'
+                            : ((string) $row->status === 'close' ? 'pendente' : 'nao_aplicavel'),
                     ];
                 });
 
@@ -158,5 +184,45 @@ class CaixaController extends Controller
                 ],
             ]);
         }, ['op' => 'index']);
+    }
+
+    /**
+     * ADR 0183 PR C — Backfill manual de caixas antigos pré-Observer.
+     *
+     * POST /financeiro/caixa/{id}/lancar
+     *
+     * Lança 1 fin_titulo retroativo pra um caixa específico que está fechado
+     * mas não foi processado pelo Observer (P5 — caixa pré-deploy do ADR 0183).
+     *
+     * Idempotente — re-clicar não duplica (TituloAutoService skip se já existe).
+     *
+     * Permission: financeiro.lancamentos.create (R7 do ADR).
+     */
+    public function lancar(Request $request, int $id, TituloAutoService $service): RedirectResponse
+    {
+        abort_unless(
+            auth()->user()->can('financeiro.lancamentos.create')
+            || auth()->user()->can('superadmin'),
+            403,
+            'Sem permissão pra lançar título manualmente'
+        );
+
+        $businessId = (int) session('user.business_id');
+
+        $cr = CashRegister::where('business_id', $businessId)
+            ->where('id', $id)
+            ->where('status', 'close')
+            ->first();
+
+        abort_unless($cr, 404, 'Caixa não encontrado ou não está fechado');
+
+        $titulo = $service->sincronizarDeCashRegister($cr);
+
+        return back()->with(
+            'success',
+            $titulo
+                ? "fin_titulo #{$titulo->id} criado/encontrado pra caixa #{$cr->id}"
+                : 'Caixa vazio ou sem movimentação — nenhum título gerado'
+        );
     }
 }

--- a/Modules/Financeiro/Routes/web.php
+++ b/Modules/Financeiro/Routes/web.php
@@ -176,6 +176,11 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
         // esta tela é só descoberta + histórico no Financeiro.
         // Permission gate `view_cash_register` no Controller.
         Route::get('/caixa', [CaixaController::class, 'index'])->name('caixa.index');
+        // ADR 0183 PR C — backfill manual: lança fin_titulo retroativo pra caixa
+        // fechado pré-Observer. Idempotente. Permission financeiro.lancamentos.create.
+        Route::post('/caixa/{id}/lancar', [CaixaController::class, 'lancar'])
+            ->whereNumber('id')
+            ->name('caixa.lancar');
 
         // Categorias livres (CRUD complementar ao plano de contas)
         Route::get('/categorias', [CategoriaController::class, 'index'])->name('categorias.index');

--- a/resources/js/Pages/Financeiro/Caixa/Index.tsx
+++ b/resources/js/Pages/Financeiro/Caixa/Index.tsx
@@ -23,6 +23,11 @@ interface CaixaRow {
   user_name: string;
   location_id: number;
   location_name: string;
+  // ADR 0183 PR C — ponte fin_titulos status integração
+  fin_titulo_id: number | null;
+  fin_titulo_status: string | null;
+  fin_titulo_valor: number | null;
+  integracao_status: 'lancado' | 'pendente' | 'nao_aplicavel';
 }
 
 interface Stats {
@@ -198,6 +203,7 @@ function Caixa({ caixas, stats, filters, links }: Props) {
                 <th className="px-4 py-2 font-medium text-right">Entradas</th>
                 <th className="px-4 py-2 font-medium text-right">Saídas</th>
                 <th className="px-4 py-2 font-medium text-right">Fechou em</th>
+                <th className="px-4 py-2 font-medium">Financeiro</th>
               </tr>
             </thead>
             <tbody>
@@ -225,6 +231,37 @@ function Caixa({ caixas, stats, filters, links }: Props) {
                     </td>
                     <td className="px-4 py-3 text-right font-medium">
                       {c.status === 'open' ? '—' : fmtMoney(c.closing_amount)}
+                    </td>
+                    {/* ADR 0183 PR C — status integração ponte fin_titulos */}
+                    <td className="px-4 py-3">
+                      {c.integracao_status === 'lancado' && c.fin_titulo_id && (
+                        <a
+                          href={`/financeiro/unificado?titulo=${c.fin_titulo_id}`}
+                          className="inline-flex items-center gap-1 text-emerald-700 hover:underline text-xs"
+                          title={`fin_titulo #${c.fin_titulo_id} · ${c.fin_titulo_status} · ${c.fin_titulo_valor ? fmtMoney(c.fin_titulo_valor) : '—'}`}
+                        >
+                          ✅ #{c.fin_titulo_id}
+                        </a>
+                      )}
+                      {c.integracao_status === 'pendente' && (
+                        <button
+                          type="button"
+                          onClick={() => {
+                            if (!confirm(`Lançar fin_titulo retroativo pra caixa #${c.id}? (idempotente — re-clicar não duplica)`)) return;
+                            router.post(`/financeiro/caixa/${c.id}/lancar`, {}, {
+                              preserveScroll: true,
+                              onSuccess: () => router.reload({ only: ['caixas'] }),
+                            });
+                          }}
+                          className="inline-flex items-center gap-1 text-amber-700 hover:bg-amber-50 px-2 py-1 rounded border border-amber-300 text-xs"
+                          title="Caixa fechado sem fin_titulo — clique pra lançar retroativo"
+                        >
+                          ⚠️ Lançar agora
+                        </button>
+                      )}
+                      {c.integracao_status === 'nao_aplicavel' && (
+                        <span className="text-stone-400 text-xs">—</span>
+                      )}
                     </td>
                   </tr>
                 );


### PR DESCRIPTION
## ADR 0183 PR C — UI status integração + backfill

Terceiro e último de 3 PRs sequenciais da [ADR 0183](memory/decisions/0183-caixa-fisico-bridge-financeiro-canon.md). Completa a ponte cash_registers → fin_titulos com UX visual.

Depende: [PR A #1376](https://github.com/wagnerra23/oimpresso.com/pull/1376) (schema) + [PR B #1377](https://github.com/wagnerra23/oimpresso.com/pull/1377) (Observer).

## Mudanças (109 LOC)

### Backend (CaixaController + Routes)

- `index()` pre-fetch `fin_titulos` via single query (sem N+1). Payload ganha 4 campos:
  - `fin_titulo_id` · `fin_titulo_status` · `fin_titulo_valor` · `integracao_status` (`lancado | pendente | nao_aplicavel`)
- `lancar()` endpoint POST `/financeiro/caixa/{id}/lancar` pra backfill manual (idempotente, perm gate `financeiro.lancamentos.create`)

### Frontend (Pages/Financeiro/Caixa/Index.tsx)

Nova coluna **Financeiro** na tabela renderiza:
- ✅ #1287 (link drill-down → `/financeiro/unificado?titulo=1287`)
- ⚠️ Lançar agora (botão Inertia POST com confirm — pra caixas pré-Observer)
- — (caixa ainda aberto)

## Workflow Larissa

| Cenário | UI |
|---|---|
| Caixa fechado pós-deploy | ✅ #N verde (link) — Observer já gerou |
| Caixa fechado pré-deploy (legado) | ⚠️ Lançar agora (click → backfill manual) |
| Caixa ainda aberto | — neutro |

## Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md))

Tudo scoped por `session('user.business_id')`. Inertia shared props filtram por tenant.

## Validação pós-deploy (Fase 5 skill pageheader-canon)

- C1 /financeiro/caixa renderiza sem 500 (bugs #1373/#1374 fixados)
- C2 Tabela mostra coluna 'Financeiro' com ✅/⚠️/—
- C3 Click ⚠️ Lançar agora → POST funcional → linha vira ✅
- C4 Click ✅ #N → abre /financeiro/unificado filtrado
- C5 Multi-caixa: 2 caixas mostram status independente

## Sequência canon completa (3 PRs)

| PR | O quê | Status |
|---|---|---|
| #1376 PR A | Migration: enum origem ADD 'caixa' + fin_contas_bancarias.tipo_conta + seed | ✅ merged |
| #1377 PR B | Observer + Event + Listener + Service + 6 Pest | ✅ merged |
| **#XXXX PR C** | **Tela /caixa status integração + backfill manual** | **este PR** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)