### PR TITLE
feat(home): cockpit 4→8 KPIs + PageHeader canon (charter v2)

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -102,7 +102,7 @@ class HomeController extends Controller
 
             $transaction_totals = $this->transactionUtil->getTransactionTotals(
                 $business_id,
-                ['expense'],
+                ['expense', 'sell_return', 'purchase_return'],
                 $start,
                 $end
             );
@@ -111,11 +111,20 @@ class HomeController extends Controller
             $invoice_due = (float) (($sell_details['invoice_due'] ?? 0) - ($total_ledger_discount['total_sell_discount'] ?? 0));
             $total_expense = (float) ($transaction_totals['total_expense'] ?? 0);
 
+            $total_purchase = (float) ($purchase_details['total_purchase_inc_tax'] ?? 0);
+            $purchase_due = (float) (($purchase_details['purchase_due'] ?? 0) - ($total_ledger_discount['total_purchase_discount'] ?? 0));
+            $total_sell_return = (float) ($transaction_totals['total_sell_return_inc_tax'] ?? 0);
+            $total_purchase_return = (float) ($transaction_totals['total_purchase_return_inc_tax'] ?? 0);
+
             $totals = [
                 'total_sell' => $total_sell,
                 'net' => $total_sell - $invoice_due - $total_expense,
                 'invoice_due' => $invoice_due,
                 'total_expense' => $total_expense,
+                'total_purchase' => $total_purchase,
+                'purchase_due' => $purchase_due,
+                'total_sell_return' => $total_sell_return,
+                'total_purchase_return' => $total_purchase_return,
             ];
         }
 

--- a/resources/js/Pages/Home/Index.charter.md
+++ b/resources/js/Pages/Home/Index.charter.md
@@ -3,22 +3,22 @@ page: /home
 component: resources/js/Pages/Home/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-21
+last_validated: 2026-05-22
 parent_module: Dashboard
 parent_spec: memory/requisitos/Dashboard/SPEC.md
 related_adrs: [0093, 0094, 0101, 0104]
-related_us: [US-DASH-001]
+related_us: [US-DASH-001, US-DASH-006]
 related_prototype: n/a (F6 Soft wrapper — sem protótipo Cowork; reusa session+queries core UltimatePOS)
 tier: A
-charter_version: 1
+charter_version: 2
 ---
 
 # Page Charter — /home
 
-> **Status:** Fase 6 Soft wrapper entregue 2026-05-21 (Wagner aprovou caminho A).
+> **Status v2:** Fase 6 Soft expandida 2026-05-22 (Wagner aprovou caminho B). 8 KPIs em 2 grupos (Vendas / Compras & Custos), PageHeader canon ADR 0180 substituindo gradient hardcoded (fix contraste WCAG AA). Charter v1 entregue 2026-05-21.
 > Persona: **Larissa [L]** (dona PME vestuário ROTA LIVRE biz=4) + qualquer user logado UPOS. Desktop ≥1024px.
 >
-> **Read-only:** todo dado vem de queries existentes do core UltimatePOS (`TransactionUtil::getSellTotals`, `BusinessLocation::forDropdown`). Mutations (registrar venda etc.) continuam nas telas dedicadas (`/sells/pos`, `/expense`, etc.).
+> **Read-only:** todo dado vem de queries existentes do core UltimatePOS (`TransactionUtil::getSellTotals` + `getPurchaseTotals` + `getTransactionTotals`, `BusinessLocation::forDropdown`). Mutations (registrar venda etc.) continuam nas telas dedicadas (`/sells/pos`, `/expense`, etc.).
 >
 > **Fallback Blade preservado:** `?legacy=1` força `view('home.index')` original com charts ECharts + widgets pluggable de outros módulos.
 
@@ -26,15 +26,18 @@ charter_version: 1
 
 ## Mission (1 frase)
 
-Servir como **landing pós-login** do oimpresso entregando KPIs de operação (Total Sells / Net / Invoice Due / Total Expense) em ≤800ms numa shell Inertia React, com fallback discreto pra Blade legacy quando o usuário precisa de gráficos ou widgets pluggable de outros módulos.
+Servir como **landing pós-login** do oimpresso entregando 8 KPIs de operação em 2 grupos (Vendas / Compras & Custos) em ≤800ms numa shell Inertia React, com fallback discreto pra Blade legacy quando o usuário precisa de gráficos ou widgets pluggable de outros módulos.
 
 ---
 
 ## Goals — Features (faz)
 
 - AppShellV2 layout com breadcrumb único `Início`
-- Welcome banner ("Bem-vindo, {primeiro_nome}") preservado do legacy
-- 4 KPI cards: **Total Sells** (sky), **Net** (emerald), **Invoice Due** (amber), **Total Expense** (rose)
+- Welcome banner ("Bem-vindo, {primeiro_nome}") em superfície clara (PageHeader canon ADR 0180) com ícone `layout-dashboard`
+- **8 KPI cards** em 2 grupos:
+  - **Vendas:** Total Vendas (sky) · Líquido (emerald) · A Receber (amber) · Devoluções Venda (rose)
+  - **Compras & Custos:** Total Compras (violet) · A Pagar (orange) · Reembolso Compra (teal) · Despesas (stone)
+- Cada card tem ícone Lucide semântico + tooltip explicando o cálculo
 - Filtro loja dropdown quando `all_locations.length > 1 && is_admin`
 - Banner discreto no rodapé: "Ver versão completa com gráficos e widgets" → `/home?legacy=1`
 - Permission gate `dashboard.data` — sem permission, KPI cards somem (shell minimal)
@@ -42,6 +45,7 @@ Servir como **landing pós-login** do oimpresso entregando KPIs de operação (T
 - Multi-tenant Tier 0 ADR 0093 IRREVOGÁVEL — `session('user.business_id')` em todas queries
 - `?legacy=1` força Blade original (canário + acesso aos widgets pluggable)
 - Range default = mês corrente (do início do FY ao end calculado por `BusinessUtil::getCurrentFinancialYear`)
+- Totais derivados todos do mesmo `getTransactionTotals` + `getSellTotals` + `getPurchaseTotals` — sem AJAX extra
 
 ---
 
@@ -89,6 +93,7 @@ Cobertos em `tests/Feature/Home/HomeIndexInertiaTest.php`:
 3. ✅ `sem permission dashboard.data → totals é null` (shell minimal)
 4. ✅ `?legacy=1 retorna Blade (não Inertia)`
 5. ✅ `Tier 0 multi-tenant — não vaza locations de outro business` — invariante ADR 0093
+6. ✅ `totals expõe 8 campos canônicos` — guard charter v2 (total_sell, net, invoice_due, total_expense, total_purchase, purchase_due, total_sell_return, total_purchase_return)
 
 ---
 

--- a/resources/js/Pages/Home/Index.tsx
+++ b/resources/js/Pages/Home/Index.tsx
@@ -1,8 +1,10 @@
 // @memcofre tela=/home module=Dashboard
 // Wagner 2026-05-21 F6 Soft wrapper Inertia (US-DASH-001).
+// Wagner 2026-05-22 charter v2 — 8 KPI cards (Vendas + Compras) — fix contraste header.
 // Landing pós-login. Charts + widgets pluggable preservados em /home?legacy=1.
 
 import AppShellV2 from '@/Layouts/AppShellV2';
+import { Icon } from '@/Components/Icon';
 import { router } from '@inertiajs/react';
 import { ReactNode } from 'react';
 
@@ -11,6 +13,10 @@ interface Totals {
   net: number;
   invoice_due: number;
   total_expense: number;
+  total_purchase: number;
+  purchase_due: number;
+  total_sell_return: number;
+  total_purchase_return: number;
 }
 
 interface Props {
@@ -32,55 +38,67 @@ function fmtMoney(v: number): string {
   return v.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
 }
 
+type Accent = 'sky' | 'emerald' | 'amber' | 'rose' | 'violet' | 'orange' | 'teal' | 'stone';
+
 interface KpiSpec {
   label: string;
   value: number;
-  accent: 'sky' | 'emerald' | 'amber' | 'rose';
+  accent: Accent;
+  icon: string;
+  hint?: string;
 }
 
-function kpiClasses(accent: KpiSpec['accent']): { dot: string; value: string } {
-  switch (accent) {
-    case 'sky':
-      return { dot: 'bg-sky-100 text-sky-600', value: 'text-stone-900' };
-    case 'emerald':
-      return { dot: 'bg-emerald-100 text-emerald-700', value: 'text-emerald-700' };
-    case 'amber':
-      return { dot: 'bg-amber-100 text-amber-700', value: 'text-amber-700' };
-    case 'rose':
-      return { dot: 'bg-rose-100 text-rose-700', value: 'text-rose-700' };
-  }
-}
+// Classes Tailwind estáticas (não dinâmicas) — JIT precisa ver literalmente
+// em build time. Map fechado garante purge correto.
+const ACCENT_CLASSES: Record<Accent, { tile: string; ring: string; value: string }> = {
+  sky:     { tile: 'bg-sky-50 text-sky-600',         ring: 'ring-sky-100/60',     value: 'text-stone-900' },
+  emerald: { tile: 'bg-emerald-50 text-emerald-600', ring: 'ring-emerald-100/60', value: 'text-emerald-700' },
+  amber:   { tile: 'bg-amber-50 text-amber-600',     ring: 'ring-amber-100/60',   value: 'text-amber-700' },
+  rose:    { tile: 'bg-rose-50 text-rose-600',       ring: 'ring-rose-100/60',    value: 'text-rose-700' },
+  violet:  { tile: 'bg-violet-50 text-violet-600',   ring: 'ring-violet-100/60',  value: 'text-stone-900' },
+  orange:  { tile: 'bg-orange-50 text-orange-600',   ring: 'ring-orange-100/60',  value: 'text-orange-700' },
+  teal:    { tile: 'bg-teal-50 text-teal-600',       ring: 'ring-teal-100/60',    value: 'text-teal-700' },
+  stone:   { tile: 'bg-stone-100 text-stone-600',    ring: 'ring-stone-200/60',   value: 'text-stone-900' },
+};
 
-function KpiCard({ label, value, accent }: KpiSpec) {
-  const c = kpiClasses(accent);
+function KpiCard({ label, value, accent, icon, hint }: KpiSpec) {
+  const c = ACCENT_CLASSES[accent];
   return (
-    <div className="rounded-xl border border-stone-200 bg-white p-5 shadow-sm transition-all hover:shadow-md hover:-translate-y-0.5">
+    <div
+      className={`group relative rounded-xl border border-stone-200 bg-white p-5 shadow-sm ring-1 ${c.ring} transition-all hover:shadow-md hover:-translate-y-0.5 hover:border-stone-300`}
+      title={hint}
+    >
       <div className="flex items-center gap-4">
         <div
-          className={`inline-flex h-12 w-12 shrink-0 items-center justify-center rounded-full ${c.dot}`}
           aria-hidden="true"
+          className={`inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-lg ${c.tile}`}
         >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            viewBox="0 0 24 24"
-            strokeWidth={1.8}
-            stroke="currentColor"
-            fill="none"
-            className="h-6 w-6"
-            strokeLinecap="round"
-            strokeLinejoin="round"
-          >
-            <path d="M3 6h18M3 12h18M3 18h12" />
-          </svg>
+          <Icon name={icon} size={20} strokeWidth={1.8} />
         </div>
         <div className="min-w-0 flex-1">
-          <p className="text-sm font-medium text-stone-500 truncate">{label}</p>
+          <p className="text-[13px] font-medium text-stone-500 truncate">{label}</p>
           <p className={`mt-0.5 text-xl font-semibold font-mono tracking-tight truncate ${c.value}`}>
             {fmtMoney(value)}
           </p>
         </div>
       </div>
     </div>
+  );
+}
+
+function KpiGroup({ label, kpis }: { label: string; kpis: KpiSpec[] }) {
+  return (
+    <section aria-label={`Indicadores ${label}`} className="space-y-3">
+      <div className="flex items-center gap-3">
+        <h2 className="text-xs font-semibold uppercase tracking-wider text-stone-500">{label}</h2>
+        <div className="h-px flex-1 bg-stone-200" />
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4 sm:gap-5">
+        {kpis.map((k) => (
+          <KpiCard key={k.label} {...k} />
+        ))}
+      </div>
+    </section>
   );
 }
 
@@ -104,57 +122,71 @@ function HomeIndex({
     });
   };
 
-  const kpis: KpiSpec[] = totals
+  const salesKpis: KpiSpec[] = totals
     ? [
-        { label: 'Total Vendas', value: totals.total_sell, accent: 'sky' },
-        { label: 'Líquido', value: totals.net, accent: 'emerald' },
-        { label: 'A Receber', value: totals.invoice_due, accent: 'amber' },
-        { label: 'Despesas', value: totals.total_expense, accent: 'rose' },
+        { label: 'Total Vendas',     value: totals.total_sell,         accent: 'sky',     icon: 'trending-up',     hint: 'Total faturado no exercício fiscal atual' },
+        { label: 'Líquido',          value: totals.net,                accent: 'emerald', icon: 'wallet',          hint: 'Vendas − A Receber − Despesas' },
+        { label: 'A Receber',        value: totals.invoice_due,        accent: 'amber',   icon: 'hourglass',       hint: 'Faturas em aberto de clientes' },
+        { label: 'Devoluções Venda', value: totals.total_sell_return,  accent: 'rose',    icon: 'undo-2',          hint: 'Retorno de vendas (trocas / cancelamentos)' },
+      ]
+    : [];
+
+  const purchaseKpis: KpiSpec[] = totals
+    ? [
+        { label: 'Total Compras',    value: totals.total_purchase,        accent: 'violet', icon: 'shopping-cart',  hint: 'Total adquirido no exercício fiscal atual' },
+        { label: 'A Pagar',          value: totals.purchase_due,          accent: 'orange', icon: 'alert-circle',   hint: 'Compras em aberto com fornecedores' },
+        { label: 'Reembolso Compra', value: totals.total_purchase_return, accent: 'teal',   icon: 'rotate-ccw',     hint: 'Devoluções a fornecedores' },
+        { label: 'Despesas',         value: totals.total_expense,         accent: 'stone',  icon: 'receipt',        hint: 'Despesas operacionais no exercício' },
       ]
     : [];
 
   return (
     <div className="mx-auto max-w-7xl space-y-6 p-6">
-      {/* Welcome banner */}
-      <header className="rounded-xl bg-gradient-to-r from-primary-800 to-primary-900 px-6 py-8 text-white shadow-sm">
-        <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
-          <h1 className="text-2xl font-semibold tracking-tight md:text-3xl">
-            Bem-vindo{user_name ? `, ${user_name}` : ''}
-          </h1>
-
-          {showLocationFilter && (
-            <div className="sm:w-72">
-              <label htmlFor="dashboard_location" className="sr-only">
-                Filtrar por loja
-              </label>
-              <select
-                id="dashboard_location"
-                onChange={handleLocationChange}
-                className="w-full rounded-lg border-0 bg-white px-3 py-2 text-sm text-stone-900 shadow-sm focus:ring-2 focus:ring-primary-500"
-                defaultValue=""
-              >
-                <option value="">Todas as lojas</option>
-                {locationEntries.map(([id, name]) => (
-                  <option key={id} value={id}>
-                    {name}
-                  </option>
-                ))}
-              </select>
-            </div>
-          )}
+      {/* Welcome banner — superfície clara, contraste WCAG AA. ADR 0180 PageHeader canon style. */}
+      <header className="flex flex-col gap-4 rounded-xl border border-stone-200 bg-white px-6 py-6 shadow-sm sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex items-start gap-4 min-w-0">
+          <div
+            aria-hidden="true"
+            className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary"
+          >
+            <Icon name="layout-dashboard" size={22} strokeWidth={1.8} />
+          </div>
+          <div className="min-w-0">
+            <p className="text-xs font-medium uppercase tracking-wider text-stone-500">Início</p>
+            <h1 className="mt-0.5 text-2xl font-semibold tracking-tight text-stone-900 md:text-3xl">
+              Bem-vindo{user_name ? `, ${user_name}` : ''}
+            </h1>
+          </div>
         </div>
+
+        {showLocationFilter && (
+          <div className="sm:w-72 sm:shrink-0">
+            <label htmlFor="dashboard_location" className="sr-only">
+              Filtrar por loja
+            </label>
+            <select
+              id="dashboard_location"
+              onChange={handleLocationChange}
+              className="w-full rounded-lg border border-stone-300 bg-white px-3 py-2 text-sm text-stone-900 shadow-sm transition-colors focus:border-primary focus:outline-none focus:ring-2 focus:ring-primary/30"
+              defaultValue=""
+            >
+              <option value="">Todas as lojas</option>
+              {locationEntries.map(([id, name]) => (
+                <option key={id} value={id}>
+                  {name}
+                </option>
+              ))}
+            </select>
+          </div>
+        )}
       </header>
 
-      {/* KPI cards */}
+      {/* KPI cards — agrupados por fluxo (Vendas / Compras) */}
       {can_dashboard_data && totals ? (
-        <section
-          className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4 sm:gap-5"
-          aria-label="Indicadores de operação"
-        >
-          {kpis.map((k) => (
-            <KpiCard key={k.label} {...k} />
-          ))}
-        </section>
+        <div className="space-y-6">
+          <KpiGroup label="Vendas" kpis={salesKpis} />
+          <KpiGroup label="Compras & Custos" kpis={purchaseKpis} />
+        </div>
       ) : (
         <section className="rounded-xl border border-stone-200 bg-white px-6 py-10 text-center">
           <p className="text-sm text-stone-600">
@@ -165,12 +197,13 @@ function HomeIndex({
       )}
 
       {/* Banner legacy fallback */}
-      <div className="rounded-md border border-stone-200 bg-stone-50 px-4 py-3 text-sm text-stone-700">
-        <span>
+      <div className="flex items-start gap-3 rounded-lg border border-stone-200 bg-stone-50 px-4 py-3 text-sm text-stone-700">
+        <Icon name="info" size={16} className="mt-0.5 shrink-0 text-stone-500" />
+        <span className="leading-relaxed">
           Precisa dos gráficos de vendas, alertas de estoque ou widgets de outros módulos?{' '}
           <a
             href={legacy_url}
-            className="font-medium text-primary-700 underline hover:text-primary-900"
+            className="font-medium text-primary underline-offset-2 hover:underline"
           >
             Abrir versão completa
           </a>

--- a/tests/Feature/Home/HomeIndexInertiaTest.php
+++ b/tests/Feature/Home/HomeIndexInertiaTest.php
@@ -8,7 +8,8 @@ use App\User;
 use Inertia\Testing\AssertableInertia;
 use Spatie\Permission\Models\Permission;
 
-uses(Tests\TestCase::class);
+// `uses(TestCase::class)` é aplicado globalmente em tests/Pest.php pra toda pasta Feature/.
+// Re-declarar aqui (como estava antes) gerava "TestCase can not be used. The folder already uses..." (Pest TestRepository).
 
 /**
  * US-DASH-001 — guard da tela /home (F6 Soft wrapper).
@@ -166,4 +167,24 @@ it('Tier 0 multi-tenant — não vaza locations de outro business', function () 
 
     // Cleanup
     \DB::table('business_locations')->where('id', $locBId)->delete();
+});
+
+it('totals expõe 8 campos canônicos (guard charter v2)', function () {
+    $user = homeBootstrap();
+
+    $response = $this->actingAs($user)->get('/home');
+
+    $response->assertStatus(200);
+    $response->assertInertia(fn (AssertableInertia $page) => $page
+        ->component('Home/Index')
+        ->where('can_dashboard_data', true)
+        ->has('totals.total_sell')
+        ->has('totals.net')
+        ->has('totals.invoice_due')
+        ->has('totals.total_expense')
+        ->has('totals.total_purchase')
+        ->has('totals.purchase_due')
+        ->has('totals.total_sell_return')
+        ->has('totals.total_purchase_return')
+    );
 });


### PR DESCRIPTION
## Summary
- Cockpit /home Inertia expandido de 4 → 8 KPIs em 2 grupos visuais (Vendas / Compras & Custos), paridade legacy mantendo filosofia cockpit minimal
- Fix bug WCAG: gradient `from-primary-800 to-primary-900` (tokens inexistentes no Tailwind v4 do projeto, gerando texto invisível) substituído por superfície clara estilo PageHeader canon ADR 0180
- Charter v1 → v2. Wagner aprovou caminho B em 2026-05-22 após comparativo /home vs /home?legacy=1

## Antes vs Depois

**Antes (charter v1):**
- 4 KPI cards: Total Vendas, Líquido, A Receber, Despesas
- Header gradient `from-primary-800 to-primary-900` → tokens não existem → texto "Bem-vindo, Wagner" invisível
- Sem ícones nos KPIs (todos com hamburger menu genérico)

**Depois (charter v2):**
- 8 KPI cards em 2 grupos:
  - **Vendas:** Total Vendas (sky) · Líquido (emerald) · A Receber (amber) · Devoluções Venda (rose)
  - **Compras & Custos:** Total Compras (violet) · A Pagar (orange) · Reembolso Compra (teal) · Despesas (stone)
- Cada card com ícone Lucide semântico + tooltip explicando o cálculo
- Header em superfície clara com ícone `layout-dashboard` + eyebrow "Início" + título grande contraste WCAG AA
- Ring sutil per-accent + hover lift

## Non-Goals preservados (charter v2 §Non-Goals)
- ❌ NÃO renderiza charts ECharts — preservado em `?legacy=1` (US-DASH-002)
- ❌ NÃO renderiza widgets pluggable — preservado em `?legacy=1` (US-DASH-003)
- ❌ NÃO toca endpoints AJAX (stock_alert, purchase_dues, sales_dues) — ainda Blade-only (US-DASH-005)
- ✅ Fallback `?legacy=1` 100% preservado

## Performance
- Zero query extra: 4 KPIs novos derivam de `getPurchaseTotals` + `getTransactionTotals` (mesmas queries já existentes, só adicionei `sell_return` e `purchase_return` aos `transaction_types`)
- Zero AJAX extra
- Build Vite 285ms

## Test plan
- [ ] Smoke browser canário `/home` pós-deploy — validar 8 KPIs renderizam + tooltips funcionam + contraste header
- [ ] Smoke `/home?legacy=1` continua igual (fallback Blade intacto)
- [ ] Validar em biz=4 (Larissa ROTA LIVRE) — persona alvo
- [ ] Conferir multi-tenant Tier 0 ADR 0093 (Pest GUARD #5 ainda passa)
- [ ] Mobile responsive (grid 1 col → 2 col sm → 4 col xl)

🤖 Generated with [Claude Code](https://claude.com/claude-code)