### PR TITLE
feat(jana): IA pageheader canon — ghosts do guia + JanaSubNav + PrimaryButton

### DIFF
--- a/Modules/Jana/Http/Controllers/DataController.php
+++ b/Modules/Jana/Http/Controllers/DataController.php
@@ -229,13 +229,22 @@ class DataController extends Controller
                             'href'     => '/jana',
                             'shortcut' => 'N',
                         ],
+                        // ADR 0182 + GUIA-SIDEBAR-V3 Wagner 2026-05-21: hub IA com
+                        // sub-views canon do guia (Copiloto/Brief/Memórias/KB/Regras)
+                        // + ghosts internos Jana (Dashboard/Metas/Custos).
+                        // Labels CURTOS (≤2 palavras). PageHeaderTabs auto-promove ghost
+                        // ativo inline mesmo se index >= maxVisible.
                         'ghosts'   => [
-                            ['key' => 'conversar',  'label' => 'Conversar',  'href' => '/jana'],
-                            ['key' => 'dashboard',  'label' => 'Dashboard',  'href' => '/jana/dashboard'],
-                            ['key' => 'metas',      'label' => 'Metas',      'href' => '/jana/metas'],
-                            ['key' => 'alertas',    'label' => 'Alertas',    'href' => '/jana/alertas'],
-                            ['key' => 'custos',     'label' => 'Custos IA',  'href' => '/jana/admin/custos'],
-                            ['key' => 'plataforma', 'label' => 'Plataforma', 'href' => '/jana/superadmin/metas'],
+                            // 5 destinos canon do guia
+                            ['key' => 'copiloto',  'label' => 'Copiloto',  'href' => '/jana'],
+                            ['key' => 'brief',     'label' => 'Brief',     'href' => '/jana/brief'],
+                            ['key' => 'memorias',  'label' => 'Memórias',  'href' => '/jana/memorias'],
+                            ['key' => 'kb',        'label' => 'KB',        'href' => '/jana/kb'],
+                            ['key' => 'regras',    'label' => 'Regras',    'href' => '/jana/regras'],
+                            // Operacional interno (descoberta admin)
+                            ['key' => 'dashboard', 'label' => 'Dashboard', 'href' => '/jana/dashboard'],
+                            ['key' => 'metas',     'label' => 'Metas',     'href' => '/jana/metas'],
+                            ['key' => 'custos',    'label' => 'Custos',    'href' => '/jana/admin/custos'],
                         ],
                     ]
                 )->order(90); // Logo após PontoWr2 (88)

--- a/resources/js/Pages/Jana/_shared/JanaPrimaryButton.tsx
+++ b/resources/js/Pages/Jana/_shared/JanaPrimaryButton.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { Plus } from 'lucide-react';
+import { SIDEBAR_GROUP_HUE } from '@/Components/cockpit/shared';
+
+/**
+ * JanaPrimaryButton — botão primary canon das telas do módulo IA (Jana).
+ *
+ * ADR 0182 + GUIA-SIDEBAR-V3: hue OKLCH 220 (azul — grupo `ia` topo)
+ * em vez do magenta canon UPOS legacy. Visualmente harmônico com ghost
+ * tabs ARIA do JanaSubNav + sidebar v3.
+ *
+ * Mesma API de `<button>` HTML — aceita `onClick`, `disabled`, etc.
+ *
+ * Uso:
+ *
+ *   <JanaPrimaryButton onClick={() => router.visit('/jana')}>
+ *     Conversar com Jana
+ *   </JanaPrimaryButton>
+ */
+interface Props extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  hideIcon?: boolean;
+}
+
+export default function JanaPrimaryButton({
+  children,
+  hideIcon,
+  className = '',
+  style,
+  ...rest
+}: Props) {
+  const hue = SIDEBAR_GROUP_HUE['ia'] ?? 220;
+  return (
+    <button
+      type="button"
+      className={`os-btn primary ${className}`.trim()}
+      style={{
+        backgroundColor: `oklch(0.55 0.15 ${hue})`,
+        color: 'oklch(0.99 0 0)',
+        ...style,
+      }}
+      {...rest}
+    >
+      {!hideIcon && <Plus size={13} />}
+      {children}
+    </button>
+  );
+}

--- a/resources/js/Pages/Jana/_shared/JanaSubNav.tsx
+++ b/resources/js/Pages/Jana/_shared/JanaSubNav.tsx
@@ -1,0 +1,54 @@
+import { usePage } from '@inertiajs/react';
+import PageHeaderTabs, {
+  type PageHeaderGhost,
+  type PageHeaderPrimary,
+  type PageHeaderOverflowItem,
+} from '@/Components/shared/PageHeaderTabs';
+
+/**
+ * JanaSubNav — ghost tabs ARIA do hub IA (ADR 0182 canon + GUIA-SIDEBAR-V3).
+ *
+ * 5 destinos canon do guia (Copiloto/Brief/Memórias/KB/Regras) + 3 operacionais
+ * internos (Dashboard/Metas/Custos). PageHeaderTabs auto-promove ghost ativo
+ * inline mesmo se index >= maxVisible.
+ *
+ * Hue OKLCH 220 (azul — grupo `ia` topo).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): retorna null se Modules/Jana desinstalado
+ * pro business (shell.menu não declara entry).
+ *
+ * Uso canon:
+ *
+ *   <JanaSubNav active="copiloto" hidePrimary extraOverflowItems={[...]}/>
+ *   <JanaPrimaryButton onClick={...}>Conversar</JanaPrimaryButton>
+ */
+interface JanaSubNavProps {
+  active: string;
+  extraOverflowItems?: PageHeaderOverflowItem[];
+  hidePrimary?: boolean;
+}
+
+export default function JanaSubNav({ active, extraOverflowItems, hidePrimary }: JanaSubNavProps) {
+  const sharedShell = (usePage().props as any)?.shell as {
+    menu?: Array<{ label: string; group?: string; primary?: PageHeaderPrimary; ghosts?: PageHeaderGhost[] }>;
+  } | undefined;
+
+  // Procura entry da Jana no shell.menu (declarada pelo DataController).
+  // Match por group='ia' OU label='Jana' (depending on DataController setup).
+  const janaItem = sharedShell?.menu?.find(
+    (m) => m.group === 'ia' || m.label?.toLowerCase() === 'jana',
+  );
+
+  if (!janaItem?.ghosts?.length) return null;
+
+  return (
+    <PageHeaderTabs
+      primary={hidePrimary ? undefined : janaItem.primary}
+      ghosts={janaItem.ghosts}
+      activeGhostKey={active}
+      group="ia"
+      maxVisible={5}
+      extraOverflowItems={extraOverflowItems}
+    />
+  );
+}

--- a/resources/js/Pages/Jana/components/JanaAreaHeader.tsx
+++ b/resources/js/Pages/Jana/components/JanaAreaHeader.tsx
@@ -1,36 +1,61 @@
-// JanaAreaHeader — header sticky compartilhado entre Chat.tsx e Dashboard.tsx.
+// JanaAreaHeader — header sticky compartilhado entre telas Jana (Chat / Dashboard /
+// Memoria / Cockpit / Admin/*).
 //
-// Espelha `prototipo-ui/_cowork-export-2026-05-15/app.jsx` Header function
-// (linhas 247-336 do protótipo Cockpit) — Wagner aprovou em PR #295 (ADR 0114).
-// Adaptações vs protótipo (documentadas em Chat-header-tabs-visual-comparison.md):
+// ADR 0182 + GUIA-SIDEBAR-V3 Wagner 2026-05-21: refatorado pra usar JanaSubNav
+// canon (ghosts ARIA tablist com auto-promoção do ativo + overflow ⋯ Mais)
+// em vez dos 2 tabs hardcoded antigos (Dashboard/Chat). Hue OKLCH 220 (grupo `ia`).
 //
-// - Tabs viram Inertia <Link> (não <button>) → navegação canônica entre rotas
-// - Emojis 📊 🤖 → ícones lucide (LayoutDashboard + MessageSquare)
-//   (Charter §UX Anti-patterns: "Avatar circular emoji-style")
-// - Active state via data-active attribute + Tailwind utilities (não inline style)
-// - Sticky `top-0 z-10 backdrop-blur` (Charter §UX Targets — referência visual
-//   durante scroll thread)
-// - Search/bell buttons à direita: omitidos (Charter §UX Anti-patterns + dupes
-//   com Tarefas shortcut + composer `/` shortcut existentes)
+// Pattern canon (espelha FinanceiroSubNav usado em /financeiro/*).
+//
+// Map de retrocompat:
+//   active="chat"      → ghost `copiloto` (canon)
+//   active="dashboard" → ghost `dashboard`
+//   active="memoria"   → ghost `memorias`
+//   active="cockpit"   → ghost `copiloto` (Cockpit = visão consolidada)
+//   active="custos"    → ghost `custos`
+//   (qualquer string) → passada direta como activeGhostKey
 //
 // Refs:
-// - Chat.charter.md (charter_version: 2)
-// - Dashboard.charter.md (charter_version: 2)
-// - memory/requisitos/Jana/Chat-header-tabs-visual-comparison.md (gate F1.5)
-// - PR #1053 (Fase 1+2 sidebar reordenada)
+// - ADR 0180/0182 (sidebar v3 + pageheader canon)
+// - GUIA-SIDEBAR-V3-PASSO-A-PASSO (Wagner 2026-05-21)
+// - JanaSubNav.tsx (componente filho que lê shell.menu)
+// - PR #1053 (Fase 1 anterior, este supersede)
 
-import { Link } from '@inertiajs/react';
-import { LayoutDashboard, MessageSquare } from 'lucide-react';
 import type { ReactNode } from 'react';
+import JanaSubNav from '@/Pages/Jana/_shared/JanaSubNav';
+import JanaPrimaryButton from '@/Pages/Jana/_shared/JanaPrimaryButton';
+import { router } from '@inertiajs/react';
 
-const TABS = [
-  { key: 'dashboard', href: '/jana/dashboard', label: 'Dashboard', Icon: LayoutDashboard },
-  { key: 'chat',      href: '/jana',           label: 'Chat',      Icon: MessageSquare   },
-] as const;
+export type JanaAreaTab =
+  | 'chat'      // = copiloto
+  | 'dashboard'
+  | 'memoria'   // = memorias
+  | 'cockpit'   // = copiloto (consolidado)
+  | 'custos'
+  | 'metas'
+  | 'brief'
+  | 'kb'
+  | 'regras'
+  | 'copiloto'
+  | 'memorias';
 
-export type JanaAreaTab = (typeof TABS)[number]['key'];
+// Map retrocompat — telas antigas passam 'chat'/'memoria'/etc; convertemos pro
+// ghost key canon do DataController Jana.
+function mapActiveToGhostKey(active: JanaAreaTab): string {
+  switch (active) {
+    case 'chat':
+    case 'cockpit':
+      return 'copiloto';
+    case 'memoria':
+      return 'memorias';
+    default:
+      return active;
+  }
+}
 
 export function JanaAreaHeader({ active }: { active: JanaAreaTab }): ReactNode {
+  const ghostKey = mapActiveToGhostKey(active);
+
   return (
     <header
       className="sticky top-0 z-10 flex items-center gap-4 border-b border-border bg-card/95 px-4 py-2 backdrop-blur"
@@ -48,32 +73,17 @@ export function JanaAreaHeader({ active }: { active: JanaAreaTab }): ReactNode {
         </span>
       </div>
 
-      {/* Center — tabs (Inertia navigation) */}
-      <nav className="flex flex-1 items-center gap-1" aria-label="Modo do Jana">
-        {TABS.map((t) => {
-          const isActive = active === t.key;
-          return (
-            <Link
-              key={t.key}
-              href={t.href}
-              data-active={isActive}
-              aria-current={isActive ? 'page' : undefined}
-              className={
-                'inline-flex items-center gap-1.5 border-b-2 px-3 py-1.5 text-[13px] font-medium transition-colors ' +
-                (isActive
-                  ? 'border-primary text-primary'
-                  : 'border-transparent text-muted-foreground hover:border-border hover:text-foreground')
-              }
-            >
-              <t.Icon size={13} aria-hidden />
-              <span>{t.label}</span>
-            </Link>
-          );
-        })}
-      </nav>
+      {/* Center — JanaSubNav canon (ghost tabs ARIA + overflow ⋯ Mais) */}
+      <div className="flex-1 min-w-0">
+        <JanaSubNav active={ghostKey} hidePrimary />
+      </div>
 
-      {/* Right — placeholder (search/bell omitidos conforme Charter Non-Goals) */}
-      <div className="shrink-0" aria-hidden />
+      {/* Right — primary "Conversar" hue 220 azul (canon ADR 0182) */}
+      <div className="shrink-0">
+        <JanaPrimaryButton onClick={() => router.visit('/jana')}>
+          Conversar
+        </JanaPrimaryButton>
+      </div>
     </header>
   );
 }


### PR DESCRIPTION
## Módulo IA aplicando pattern canon ADR 0182

Wagner 2026-05-21: *"pode fazer o modulo IA? quero ver"*.

Primeiro módulo após Financeiro adotando o pattern PageHeader canon completo (seguindo Ondas 1+2 do [GUIA-SIDEBAR-V3](memory/requisitos/_DesignSystem/GUIA-SIDEBAR-V3-PASSO-A-PASSO.md)).

## Mudanças

### Backend — Modules/Jana DataController

Ghosts canon do guia (5 destinos) + 3 operacionais internos:

```
Copiloto · Brief · Memórias · KB · Regras + Dashboard · Metas · Custos
```

Substituiu os 6 ghosts internos antigos (Conversar/Dashboard/Metas/Alertas/Custos/Plataforma).

### Frontend — Components shared + JanaAreaHeader refatorado

| Arquivo | O quê |
|---|---|
| `Pages/Jana/_shared/JanaSubNav.tsx` (novo) | Template FinanceiroSubNav adaptado pra hue 220 azul |
| `Pages/Jana/_shared/JanaPrimaryButton.tsx` (novo) | Botão primary hue 220 (não magenta canon UPOS) |
| `Pages/Jana/components/JanaAreaHeader.tsx` (refatorado) | Em vez de 2 tabs hardcoded, usa JanaSubNav canon + JanaPrimaryButton |

## Retrocompat

Map preserva chamadas existentes em telas que já passam `active='chat'`/`active='dashboard'`:
- `active='chat'` → ghost `copiloto`
- `active='memoria'` → ghost `memorias`
- `active='cockpit'` → ghost `copiloto` (visão consolidada)

## Resultado visual

Telas Chat.tsx + Dashboard.tsx (já usam JanaAreaHeader) automaticamente mostram:
- Header sticky com dot azul 220 + label JANA
- Ghost tabs ARIA: **Copiloto · Brief · Memórias · KB · Regras** + overflow ⋯ Mais 3 (Dashboard/Metas/Custos)
- Primary **"Conversar"** azul hue 220 canto direito

## ⚠️ Bloqueio conhecido

Ghosts **Brief/KB/Regras** apontam pra rotas FUTURAS (`/jana/brief`, `/jana/kb`, `/jana/regras`) que **NÃO existem hoje**. Click vai dar 404. Próxima sessão decide:
- Criar endpoints Inertia stub OU
- Remover esses ghosts do DataController até existirem rotas reais

## LOC

174 insertions / 54 deletions (4 files).

## Refs

- [ADR 0180](memory/decisions/0180-sidebar-v3-5-grupos-ghosts-header.md) · [ADR 0182](memory/decisions/0182-pageheadertabs-canon-pattern-telas.md)
- [GUIA-SIDEBAR-V3-PASSO-A-PASSO](memory/requisitos/_DesignSystem/GUIA-SIDEBAR-V3-PASSO-A-PASSO.md)
- PR #1370 (template Financeiro reusado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)