### PR TITLE
fix(jana): redirect /jana/kb -> /essentials/knowledge-base

### DIFF
--- a/Modules/Jana/Http/routes.php
+++ b/Modules/Jana/Http/routes.php
@@ -175,11 +175,11 @@ Route::middleware(['web'])->group(function () {
 });
 
 // Ghosts canon ADR 0182 — aliases pros destinos reais (Wagner 2026-05-22):
-//   /jana/memorias → /jana/memoria (KB MemoriaController; já existe)
-//   /jana/kb       → /knowledge-base (Essentials KnowledgeBaseController; já existe)
+//   /jana/memorias → /jana/memoria              (KB MemoriaController; já existe)
+//   /jana/kb       → /essentials/knowledge-base (Essentials KnowledgeBaseController; já existe)
 // Mantém ghost clicável + nome curto no header sem duplicar tela.
-Route::redirect('/jana/memorias', '/jana/memoria',   302);
-Route::redirect('/jana/kb',       '/knowledge-base', 302);
+Route::redirect('/jana/memorias', '/jana/memoria',              302);
+Route::redirect('/jana/kb',       '/essentials/knowledge-base', 302);
 
 // ===========================================================================
 // 2) Rotas de instalação 1-clique — prefixo /jana/install (canônico após rename)


### PR DESCRIPTION
Fix follow-up PR #1388. Redirect /jana/kb apontava pra /knowledge-base que retorna 404. Rota Essentials canon e /essentials/knowledge-base (prefixada). 3 outros ghosts (Brief, Memorias, Regras) ja OK pos-merge #1388.