### PR TITLE
fix(jana): redirect /jana/kb -> /kb (canon, evita tela branca Essentials)

### DIFF
--- a/Modules/Jana/Http/routes.php
+++ b/Modules/Jana/Http/routes.php
@@ -175,11 +175,16 @@ Route::middleware(['web'])->group(function () {
 });
 
 // Ghosts canon ADR 0182 — aliases pros destinos reais (Wagner 2026-05-22):
-//   /jana/memorias → /jana/memoria              (KB MemoriaController; já existe)
-//   /jana/kb       → /essentials/knowledge-base (Essentials KnowledgeBaseController; já existe)
+//   /jana/memorias → /jana/memoria  (KB MemoriaController; já existe)
+//   /jana/kb       → /kb            (Modules/KB canon ADR 0180 Wave C; 660+ docs sync via webhook GitHub)
 // Mantém ghost clicável + nome curto no header sem duplicar tela.
-Route::redirect('/jana/memorias', '/jana/memoria',              302);
-Route::redirect('/jana/kb',       '/essentials/knowledge-base', 302);
+//
+// 2026-05-22: /jana/kb mudou de `/essentials/knowledge-base` (Essentials legacy,
+// renderizava branco fora do pacote essentials_module) para `/kb` (canon Wave C).
+// Mesma decisão arquitetural do PR #1387 que escondeu a entrada Essentials no
+// sidebar quando KB canon está instalado.
+Route::redirect('/jana/memorias', '/jana/memoria', 302);
+Route::redirect('/jana/kb',       '/kb',           302);
 
 // ===========================================================================
 // 2) Rotas de instalação 1-clique — prefixo /jana/install (canônico após rename)


### PR DESCRIPTION
## Summary
- Ghost \`/jana/kb\` na PageHeaderTabs Jana aponta agora pra \`/kb\` (Modules/KB canon ADR 0180 Wave C) ao invés de \`/essentials/knowledge-base\` (Essentials legacy)
- Mesmo princípio arquitetural do PR #1387 (sidebar dedup): quando KB canon está disponível, ele é o destino. Essentials KB fica como fallback acessível via URL direta pra clientes legacy

## Antes vs Depois

**Antes (PR #1389):** \`/jana/kb\` → 302 → \`/essentials/knowledge-base\` → tela branca pra biz sem pacote \`essentials_module\` (KB Essentials legacy não renderiza)

**Depois (este PR):** \`/jana/kb\` → 302 → \`/kb\` (Modules/KB canon, 660+ docs vivos sincronizados via webhook GitHub, busca + filtros + preview)

## Test plan
- [ ] Smoke browser pós-deploy \`/jana/kb\` → deve aterrissar em \`/kb\` e renderizar lindo
- [ ] \`/essentials/knowledge-base\` continua acessível via URL direta (não removemos rota Essentials, só re-aim do ghost)

🤖 Generated with [Claude Code](https://claude.com/claude-code)