### PR TITLE
feat(jana): rota /ia canon ADR 0180 sidebar v3 + redirect /jana → /ia

### DIFF
--- a/Modules/Jana/Http/Controllers/DataController.php
+++ b/Modules/Jana/Http/Controllers/DataController.php
@@ -226,7 +226,7 @@ class DataController extends Controller
                         'shortcut' => 'G I',
                         'primary'  => [
                             'label'    => 'Conversar com Jana',
-                            'href'     => '/jana',
+                            'href'     => '/ia',
                             'shortcut' => 'N',
                         ],
                         // ADR 0182 + GUIA-SIDEBAR-V3 Wagner 2026-05-21: hub IA com
@@ -234,17 +234,20 @@ class DataController extends Controller
                         // + ghosts internos Jana (Dashboard/Metas/Custos).
                         // Labels CURTOS (≤2 palavras). PageHeaderTabs auto-promove ghost
                         // ativo inline mesmo se index >= maxVisible.
+                        //
+                        // Wagner 2026-05-22: hrefs /jana → /ia (vertical-slice IA piloto
+                        // sidebar v3 — URL canon casa com label "IA" do topo).
                         'ghosts'   => [
                             // 5 destinos canon do guia
-                            ['key' => 'copiloto',  'label' => 'Copiloto',  'href' => '/jana'],
-                            ['key' => 'brief',     'label' => 'Brief',     'href' => '/jana/brief'],
-                            ['key' => 'memorias',  'label' => 'Memórias',  'href' => '/jana/memorias'],
-                            ['key' => 'kb',        'label' => 'KB',        'href' => '/jana/kb'],
-                            ['key' => 'regras',    'label' => 'Regras',    'href' => '/jana/regras'],
+                            ['key' => 'copiloto',  'label' => 'Copiloto',  'href' => '/ia'],
+                            ['key' => 'brief',     'label' => 'Brief',     'href' => '/ia/brief'],
+                            ['key' => 'memorias',  'label' => 'Memórias',  'href' => '/ia/memorias'],
+                            ['key' => 'kb',        'label' => 'KB',        'href' => '/ia/kb'],
+                            ['key' => 'regras',    'label' => 'Regras',    'href' => '/ia/regras'],
                             // Operacional interno (descoberta admin)
-                            ['key' => 'dashboard', 'label' => 'Dashboard', 'href' => '/jana/dashboard'],
-                            ['key' => 'metas',     'label' => 'Metas',     'href' => '/jana/metas'],
-                            ['key' => 'custos',    'label' => 'Custos',    'href' => '/jana/admin/custos'],
+                            ['key' => 'dashboard', 'label' => 'Dashboard', 'href' => '/ia/dashboard'],
+                            ['key' => 'metas',     'label' => 'Metas',     'href' => '/ia/metas'],
+                            ['key' => 'custos',    'label' => 'Custos',    'href' => '/ia/admin/custos'],
                         ],
                     ]
                 )->order(90); // Logo após PontoWr2 (88)

--- a/Modules/Jana/Http/routes.php
+++ b/Modules/Jana/Http/routes.php
@@ -13,17 +13,22 @@ use Illuminate\Support\Facades\Route;
 */
 
 // ===========================================================================
-// 1) Rotas web — prefixo /copiloto
+// 1) Rotas web — prefixo /ia (canon ADR 0180 sidebar v3 — label "IA" no topo)
 // ===========================================================================
 // D8.a (Wave 14 governance v3) — throttle:120,1 por user (auth) reforça defesa
 // abuse contra rotas Jana mesmo já sendo Tailscale-only no CT 100. 120 req/min
 // é folgado pra UX chat real (mensagens + sugestões + sidebar polling) e ainda
 // bloqueia bot scraping. Rotas SSE/stream pesadas têm throttle agressivo extra
 // inline abaixo (60,1). Referência: ADR 0093 + segurança fail-secure.
+//
+// Rename /jana → /ia (Wagner 2026-05-22, ADR 0180 vertical-slice IA piloto):
+// label do sidebar v3 é "IA" → URL casa. Route names `jana.*` preservados
+// (route('jana.x') resolve automático pro novo prefix). Redirect 301
+// /jana/* → /ia/* no fim deste arquivo cobre bookmarks externos.
 Route::group(
     [
         'middleware' => ['web', 'SetSessionData', 'auth', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin', 'throttle:120,1'],
-        'prefix'     => 'jana',
+        'prefix'     => 'ia',
         'namespace'  => 'Modules\Jana\Http\Controllers',
     ],
     function () {
@@ -175,32 +180,32 @@ Route::middleware(['web'])->group(function () {
 });
 
 // Ghosts canon ADR 0182 — aliases pros destinos reais (Wagner 2026-05-22):
-//   /jana/memorias → /jana/memoria  (KB MemoriaController; já existe)
-//   /jana/kb       → /kb            (Modules/KB canon ADR 0180 Wave C; 660+ docs sync via webhook GitHub)
+//   /ia/memorias → /ia/memoria  (KB MemoriaController; já existe)
+//   /ia/kb       → /kb          (Modules/KB canon ADR 0180 Wave C; 660+ docs sync via webhook GitHub)
 // Mantém ghost clicável + nome curto no header sem duplicar tela.
 //
-// 2026-05-22: /jana/kb mudou de `/essentials/knowledge-base` (Essentials legacy,
+// 2026-05-22: /ia/kb mudou de `/essentials/knowledge-base` (Essentials legacy,
 // renderizava branco fora do pacote essentials_module) para `/kb` (canon Wave C).
 // Mesma decisão arquitetural do PR #1387 que escondeu a entrada Essentials no
 // sidebar quando KB canon está instalado.
-Route::redirect('/jana/memorias', '/jana/memoria', 302);
-Route::redirect('/jana/kb',       '/kb',           302);
+Route::redirect('/ia/memorias', '/ia/memoria', 302);
+Route::redirect('/ia/kb',       '/kb',         302);
 
 // ===========================================================================
-// 2) Rotas de instalação 1-clique — prefixo /jana/install (canônico após rename)
+// 2) Rotas de instalação 1-clique — prefixo /ia/install (canônico após rename)
 // ===========================================================================
 // Padrão BaseModuleInstallController + ADR memory/decisions/0023.
 // Disparado pelo /manage-modules (superadmin); roda migrations + seta version.
 //
 // Fix da regressão do PR #97 (Fase 3.7 PR-2): botão Install em /manage-modules
 // usa action(\Modules\Jana\...\InstallController), que precisa pegar o nome
-// novo /jana/install pra ficar consistente com o nome do módulo. URL antiga
-// /copiloto/install/* mantida via 301 redirect logo abaixo.
+// novo /ia/install pra ficar consistente com o sidebar v3 label "IA". URLs
+// antigas /copiloto/install/* e /jana/install/* mantidas via 301 redirect.
 Route::group(
     [
         'middleware' => ['web', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin'],
         'namespace'  => 'Modules\Jana\Http\Controllers',
-        'prefix'     => 'jana/install',
+        'prefix'     => 'ia/install',
     ],
     function () {
         Route::get('/',          'InstallController@index')->name('jana.install.index');
@@ -210,10 +215,13 @@ Route::group(
     }
 );
 
-// 301 das URLs antigas /copiloto/install/* → /jana/install/* (compat bookmarks)
-Route::redirect('/copiloto/install',           '/jana/install',           301);
-Route::redirect('/copiloto/install/uninstall', '/jana/install/uninstall', 301);
-Route::redirect('/copiloto/install/update',    '/jana/install/update',    301);
+// 301 das URLs antigas /copiloto/install/* → /ia/install/* (compat bookmarks)
+Route::redirect('/copiloto/install',           '/ia/install',           301);
+Route::redirect('/copiloto/install/uninstall', '/ia/install/uninstall', 301);
+Route::redirect('/copiloto/install/update',    '/ia/install/update',    301);
+Route::redirect('/jana/install',               '/ia/install',           301);
+Route::redirect('/jana/install/uninstall',     '/ia/install/uninstall', 301);
+Route::redirect('/jana/install/update',        '/ia/install/update',    301);
 
 // ===========================================================================
 // 3) MCP server endpoints (ADR 0053) — prefixo /api/mcp
@@ -276,14 +284,23 @@ if (config('mcp.tools_exposed')) {
 }
 
 // ===========================================================================
-// 1.c) Redirects 301 — /copiloto/* → /jana/* (Fase 2b Jana naming alignment)
+// 1.c) Redirects 301 — /copiloto/* e /jana/* → /ia/* (sidebar v3 ADR 0180)
 // ===========================================================================
-// Wagner 2026-05-09: rename URLs /copiloto → /jana com 301 pra preservar
-// bookmarks de users + zero-break em integrações externas.
+// Wagner 2026-05-09: rename /copiloto → /jana (Fase 2b Jana naming alignment).
+// Wagner 2026-05-22: rename /jana → /ia (vertical-slice IA piloto sidebar v3 —
+// label do topo é "IA" → URL canon casa).
 //
-// IMPORTANTE: este redirect generic vem APÓS os específicos do bloco 1.b
-// (TeamMcp, KB) — Laravel matching é first-wins; manter ordem.
+// Cadeia: /copiloto/X → 301 /jana/X → 301 /ia/X. Browser segue 2 hops apenas
+// pra bookmarks antigos do /copiloto; bookmarks /jana fazem 1 hop direto pro
+// canon /ia. Sem latency em URLs canon.
+//
+// IMPORTANTE: estes redirects genéricos vêm APÓS os específicos do bloco 1.b
+// (TeamMcp, KB) e dos ghost aliases — Laravel matching é first-wins; manter
+// ordem.
 //
 // `where('any', '.*')` permite path com qualquer profundidade incluindo barras.
 Route::redirect('/copiloto/{any?}', '/jana/{any?}', 301)
+    ->where('any', '.*');
+
+Route::redirect('/jana/{any?}', '/ia/{any?}', 301)
     ->where('any', '.*');

--- a/Modules/Jana/Resources/menus/topnav.php
+++ b/Modules/Jana/Resources/menus/topnav.php
@@ -11,25 +11,25 @@
  * - Ordem do array = ordem na barra horizontal (esquerda → direita)
  * - `can` opcional: se setado, Spatie filtra item por permissão do user
  * - `icon` usa nome Lucide
- * - `href` é path relativo (/copiloto/...)
+ * - `href` é path relativo (/ia/... — canon ADR 0180 sidebar v3 IA topo)
  */
 
 return [
     'label' => 'copiloto::copiloto.module_label',
     'icon'  => 'Compass',
     'items' => [
-        ['label' => 'copiloto::copiloto.menu.conversar',  'href' => '/jana',                  'icon' => 'MessageSquare',   'can' => 'jana.chat'],
-        ['label' => 'copiloto::copiloto.menu.dashboard',  'href' => '/jana/dashboard',        'icon' => 'LayoutDashboard', 'can' => 'jana.access'],
-        ['label' => 'copiloto::copiloto.menu.metas',      'href' => '/jana/metas',            'icon' => 'Target',          'can' => 'jana.metas.manage'],
-        ['label' => 'copiloto::copiloto.menu.alertas',    'href' => '/jana/alertas',          'icon' => 'Bell',            'can' => 'jana.access'],
-        ['label' => 'Governança MCP',                     'href' => '/jana/admin/governanca', 'icon' => 'ShieldCheck',     'can' => 'jana.mcp.usage.all'],
+        ['label' => 'copiloto::copiloto.menu.conversar',  'href' => '/ia',                  'icon' => 'MessageSquare',   'can' => 'jana.chat'],
+        ['label' => 'copiloto::copiloto.menu.dashboard',  'href' => '/ia/dashboard',        'icon' => 'LayoutDashboard', 'can' => 'jana.access'],
+        ['label' => 'copiloto::copiloto.menu.metas',      'href' => '/ia/metas',            'icon' => 'Target',          'can' => 'jana.metas.manage'],
+        ['label' => 'copiloto::copiloto.menu.alertas',    'href' => '/ia/alertas',          'icon' => 'Bell',            'can' => 'jana.access'],
+        ['label' => 'Governança MCP',                     'href' => '/ia/admin/governanca', 'icon' => 'ShieldCheck',     'can' => 'jana.mcp.usage.all'],
         // KB foi splitado pro módulo Modules/KB em 2026-05-03 (Etapa 2 modularização).
         // Link cross-module aqui pra continuidade visual.
-        ['label' => 'KB →',                               'href' => '/kb',                        'icon' => 'BookOpen',        'can' => 'jana.mcp.memory.manage'],
-        ['label' => 'Qualidade IA',                       'href' => '/jana/admin/qualidade',  'icon' => 'TrendingUp',      'can' => 'jana.mcp.usage.all'],
+        ['label' => 'KB →',                               'href' => '/kb',                      'icon' => 'BookOpen',        'can' => 'jana.mcp.memory.manage'],
+        ['label' => 'Qualidade IA',                       'href' => '/ia/admin/qualidade',  'icon' => 'TrendingUp',      'can' => 'jana.mcp.usage.all'],
         // Team MCP saiu do Copiloto e virou módulo próprio (split TeamMcp).
         // Mantém entry como atalho cross-module pra Wagner.
-        ['label' => 'Team MCP →',                         'href' => '/team-mcp/team',             'icon' => 'Users',           'can' => 'jana.mcp.usage.all'],
-        ['label' => 'copiloto::copiloto.menu.plataforma', 'href' => '/jana/superadmin/metas', 'icon' => 'Building2',       'can' => 'jana.superadmin'],
+        ['label' => 'Team MCP →',                         'href' => '/team-mcp/team',           'icon' => 'Users',           'can' => 'jana.mcp.usage.all'],
+        ['label' => 'copiloto::copiloto.menu.plataforma', 'href' => '/ia/superadmin/metas', 'icon' => 'Building2',       'can' => 'jana.superadmin'],
     ],
 ];

--- a/Modules/Jana/Tests/Feature/PainelControllerTest.php
+++ b/Modules/Jana/Tests/Feature/PainelControllerTest.php
@@ -11,7 +11,7 @@ uses(Tests\TestCase::class);
  * US-JANA-PAINEL-001 · Onda A1 smoke do PainelController.
  *
  * Valida que:
- *  - rota GET /jana/painel retorna 200 quando autenticado
+ *  - rota GET /ia/painel retorna 200 quando autenticado
  *  - Inertia component 'Jana/Painel' é resolvido
  *  - payload contém business + person + brief + 4 kpis + 6 analises + 4 acoes
  *  - business_id da sessão é honrado (multi-tenant Tier 0 — ADR 0093)
@@ -54,15 +54,15 @@ beforeEach(function () {
     ]);
 });
 
-it('GET /jana/painel retorna 200 com Inertia component Jana/Painel', function () {
-    $response = $this->get('/jana/painel');
+it('GET /ia/painel retorna 200 com Inertia component Jana/Painel', function () {
+    $response = $this->get('/ia/painel');
 
     $response->assertStatus(200);
     $response->assertInertia(fn ($page) => $page->component('Jana/Painel'));
 });
 
 it('payload contém estrutura canon: business + person + brief + 4 kpis + 6 analises + 4 acoes', function () {
-    $response = $this->get('/jana/painel');
+    $response = $this->get('/ia/painel');
 
     $response->assertInertia(fn ($page) => $page
         ->component('Jana/Painel')
@@ -82,7 +82,7 @@ it('payload contém estrutura canon: business + person + brief + 4 kpis + 6 anal
 });
 
 it('respeita business_id da sessão (Tier 0 multi-tenant)', function () {
-    $response = $this->get('/jana/painel');
+    $response = $this->get('/ia/painel');
 
     $response->assertInertia(fn ($page) => $page
         ->where('business.id', $this->business->id)

--- a/Modules/Jana/Tests/Feature/Roadmap/RoadmapControllerTest.php
+++ b/Modules/Jana/Tests/Feature/Roadmap/RoadmapControllerTest.php
@@ -90,7 +90,7 @@ afterEach(function () {
 
 it('redireciona pra login se usuário não estiver autenticado', function () {
     // Sem actingAs — request anônima
-    $response = $this->get('/jana/admin/roadmap');
+    $response = $this->get('/ia/admin/roadmap');
 
     // Padrão Laravel: 302 redirect pra /login
     expect($response->status())->toBeIn([302, 401]);
@@ -101,7 +101,7 @@ it('responde 403 pra usuário sem permission jana.mcp.tasks.read', function () {
     roadmapRevokePerm($user);
 
     $this->actingAs($user);
-    $response = $this->get('/jana/admin/roadmap');
+    $response = $this->get('/ia/admin/roadmap');
 
     expect($response->status())->toBe(403);
 });
@@ -119,7 +119,7 @@ it('responde 200 e renderiza Inertia component Jana/Admin/Roadmap com permission
         'X-Inertia'         => 'true',
         'X-Inertia-Version' => $version,
         'Accept'            => 'text/html',
-    ])->get('/jana/admin/roadmap');
+    ])->get('/ia/admin/roadmap');
 
     expect($response->status())->toBe(200);
 
@@ -188,7 +188,7 @@ it('aceita filtro por cycle_id via query param', function () {
         'X-Inertia'         => 'true',
         'X-Inertia-Version' => $version,
         'Accept'            => 'text/html',
-    ])->get('/jana/admin/roadmap?cycle='.$cycleId);
+    ])->get('/ia/admin/roadmap?cycle='.$cycleId);
 
     expect($response->status())->toBe(200);
 
@@ -240,7 +240,7 @@ it('filtra tasks por module via query param', function () {
         'X-Inertia'         => 'true',
         'X-Inertia-Version' => $version,
         'Accept'            => 'text/html',
-    ])->get('/jana/admin/roadmap?module=ModuloAlpha');
+    ])->get('/ia/admin/roadmap?module=ModuloAlpha');
 
     expect($response->status())->toBe(200);
 
@@ -283,7 +283,7 @@ it('respeita global scope multi-tenant (mcp_tasks é canon cross-business — n�
         'business.id'      => $outroBusiness->id,
     ]);
 
-    $response = $this->get('/jana/admin/roadmap');
+    $response = $this->get('/ia/admin/roadmap');
 
     // User de biz=outro sem permission → 403 (não vê roadmap canon)
     expect($response->status())->toBe(403);
@@ -303,7 +303,7 @@ it('renderiza com lista de tasks vazia sem quebrar (estado inicial DB limpo)', f
         'X-Inertia'         => 'true',
         'X-Inertia-Version' => $version,
         'Accept'            => 'text/html',
-    ])->get('/jana/admin/roadmap?owner=__nonexistent_owner_xyz__');
+    ])->get('/ia/admin/roadmap?owner=__nonexistent_owner_xyz__');
 
     expect($response->status())->toBe(200);
 

--- a/Modules/Jana/Tests/Feature/Wave14GovernanceV3Test.php
+++ b/Modules/Jana/Tests/Feature/Wave14GovernanceV3Test.php
@@ -38,7 +38,7 @@ uses(Tests\TestCase::class);
 // ---------- D8.c FormRequest tests ----------
 
 it('001. StoreMetaRequest aceita payload válido', function () {
-    $request = StoreMetaRequest::create('/jana/metas', 'POST', [
+    $request = StoreMetaRequest::create('/ia/metas', 'POST', [
         'slug' => 'receita-mensal',
         'nome' => 'Receita Mensal',
         'unidade' => 'R$',

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -458,7 +458,7 @@ function SidebarShortcuts({
         </a>
       )}
       {showIa && (
-        <a href="/jana" className="sb-shortcut">
+        <a href="/ia" className="sb-shortcut">
           <Bot size={13} />
           <span className="label">IA</span>
           {!!chatCount && <span className="badge">{chatCount}</span>}
@@ -676,7 +676,7 @@ function SidebarMenuRail({
       )}
       {showIa && (
         <a
-          href="/jana"
+          href="/ia"
           className="sb-rail-btn"
           data-tip="IA"
           onClick={() => setFlyout(null)}

--- a/resources/js/Components/jana/AssistantUiChat.tsx
+++ b/resources/js/Components/jana/AssistantUiChat.tsx
@@ -347,7 +347,7 @@ export function JanaAssistantUiChat({
       abortRef.current = ctrl;
 
       try {
-        const resp = await fetch(`/jana/conversas/${conversaId}/mensagens/stream`, {
+        const resp = await fetch(`/ia/conversas/${conversaId}/mensagens/stream`, {
           method: 'POST',
           signal: ctrl.signal,
           headers: {

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -1229,7 +1229,7 @@ function ActionsMenu({ row, onView }: { row: ClienteRow; onView: () => void }) {
 //   - Avatar grande (TODO Wave G: HSL hash deterministico)
 //   - Toggle PF/PJ + nome + "cadastrado ha Xd"
 //   - Badge Ativo/Inativo (status semantico Cockpit V2)
-//   - Botoes "Imprimir ficha" (window.print) + "Falar com Copiloto -> /jana/chat"
+//   - Botoes "Imprimir ficha" (window.print) + "Falar com Copiloto -> /ia/chat"
 //
 // KB-9.75 atalhos preservados (linhas 174-280, 892+) -- ClienteSheet nao
 // toca em key handlers globais; o Sheet Radix ja faz Esc-to-close nativo.
@@ -1410,7 +1410,7 @@ function ClienteSheet({
             </Button>
             <Button asChild size="sm" className="text-xs h-7">
               <a
-                href={contact ? `/jana/chat?context=cliente:${contact.id}` : '#'}
+                href={contact ? `/ia/chat?context=cliente:${contact.id}` : '#'}
                 title="Abre o Copiloto (Jana) com contexto deste cliente"
               >
                 Falar com Copiloto →

--- a/resources/js/Pages/Jana/Admin/Custos/Index.tsx
+++ b/resources/js/Pages/Jana/Admin/Custos/Index.tsx
@@ -194,7 +194,7 @@ function CustosIaIndex(props: Props) {
   );
 
   const aplicar = (patch: Partial<Filters>) => {
-    router.get('/jana/admin/custos', { ...filters, ...patch }, {
+    router.get('/ia/admin/custos', { ...filters, ...patch }, {
       preserveState: true,
       preserveScroll: true,
       replace: true,

--- a/resources/js/Pages/Jana/Admin/Governanca/Index.tsx
+++ b/resources/js/Pages/Jana/Admin/Governanca/Index.tsx
@@ -200,7 +200,7 @@ function GovernancaIndex(props: Props) {
   }, []);
 
   const aplicar = (patch: Partial<Filters>) => {
-    router.get('/jana/admin/governanca', { ...filters, ...patch }, {
+    router.get('/ia/admin/governanca', { ...filters, ...patch }, {
       preserveState: true,
       preserveScroll: true,
       replace: true,

--- a/resources/js/Pages/Jana/Admin/Qualidade/Index.tsx
+++ b/resources/js/Pages/Jana/Admin/Qualidade/Index.tsx
@@ -137,7 +137,7 @@ function QualidadeIndex(props: Props) {
   function applyFilter() {
     const params: Record<string, string | number> = { dias: Number(diasFilter) };
     if (businessFilter !== '__all__') params.business_id = Number(businessFilter);
-    router.get('/jana/admin/qualidade', params, { preserveScroll: true, preserveState: true });
+    router.get('/ia/admin/qualidade', params, { preserveScroll: true, preserveState: true });
   }
 
   const allMetrics = [

--- a/resources/js/Pages/Jana/Admin/Roadmap.tsx
+++ b/resources/js/Pages/Jana/Admin/Roadmap.tsx
@@ -1,5 +1,5 @@
 // @memcofre
-//   tela: /jana/admin/roadmap
+//   tela: /ia/admin/roadmap
 //   module: Jana
 //   ondas: Onda 5 V1 (Roadmap timeline UI)
 //   adrs: 0070 (Jira-style tasks), 0093 (multi-tenant Tier 0), 0110 (Cockpit V2)
@@ -352,7 +352,7 @@ function RoadmapIndex(props: Props) {
   const aplicarFiltro = useCallback(
     (patch: Partial<Filters>) => {
       router.get(
-        '/jana/admin/roadmap',
+        '/ia/admin/roadmap',
         { ...filters, ...patch },
         { preserveState: true, preserveScroll: true, replace: true },
       );

--- a/resources/js/Pages/Jana/Brief/Index.tsx
+++ b/resources/js/Pages/Jana/Brief/Index.tsx
@@ -1,4 +1,4 @@
-// Stub /jana/brief — ghost canon ADR 0182 + GUIA-SIDEBAR-V3 (Wagner 2026-05-21).
+// Stub /ia/brief — ghost canon ADR 0182 + GUIA-SIDEBAR-V3 (Wagner 2026-05-21).
 // Brief executive diário é gerado pelo BriefDiarioAgent + exposto via MCP tool
 // `brief-fetch`. UI dedicada vem em onda futura; este stub mantém o ghost
 // clicável e explica onde achar o brief enquanto isso.
@@ -57,13 +57,13 @@ export default function BriefIndex({ businessId }: Props) {
               e te explica em linguagem natural.
             </p>
             <div className="flex flex-wrap gap-2 pt-2">
-              <Link href="/jana">
+              <Link href="/ia">
                 <Button size="sm" className="gap-2">
                   <MessageSquare className="h-4 w-4" />
                   Pedir brief à Jana
                 </Button>
               </Link>
-              <Link href="/jana/painel">
+              <Link href="/ia/painel">
                 <Button size="sm" variant="outline" className="gap-2">
                   <FileText className="h-4 w-4" />
                   Ver painel V2

--- a/resources/js/Pages/Jana/Chat.tsx
+++ b/resources/js/Pages/Jana/Chat.tsx
@@ -140,7 +140,7 @@ function PropostaCard({ sugestao }: { sugestao: Sugestao }) {
   const dif = DIFICULDADE_CONFIG[p.dificuldade] ?? DIFICULDADE_CONFIG['realista']!;
 
   function escolher() {
-    router.post(`/jana/sugestoes/${sugestao.id}/escolher`, {}, {
+    router.post(`/ia/sugestoes/${sugestao.id}/escolher`, {}, {
       preserveScroll: true,
       preserveState: true,
       onSuccess: () => toast.success('Meta criada com sucesso!'),
@@ -149,7 +149,7 @@ function PropostaCard({ sugestao }: { sugestao: Sugestao }) {
   }
 
   function rejeitar() {
-    router.post(`/jana/sugestoes/${sugestao.id}/rejeitar`, {}, {
+    router.post(`/ia/sugestoes/${sugestao.id}/rejeitar`, {}, {
       preserveScroll: true,
       preserveState: true,
       onSuccess: () => toast.info('Proposta rejeitada.'),
@@ -233,7 +233,7 @@ export default function Chat({
   }), [conversa, mensagensCockpit]);
 
   function selectConv(id: string) {
-    router.get(`/jana/conversas/${id}`, {}, {
+    router.get(`/ia/conversas/${id}`, {}, {
       preserveScroll: true,
       preserveState: true,
     });
@@ -362,7 +362,7 @@ function ConvSidePanel({
         <button type="button" className="cs-iconbtn" title="Filtros" aria-label="Filtros">
           <SlidersHorizontal size={14} />
         </button>
-        <a href="/jana/conversas/nova" className="cs-iconbtn primary" title="Nova conversa · ⌘N" aria-label="Nova conversa">
+        <a href="/ia/conversas/nova" className="cs-iconbtn primary" title="Nova conversa · ⌘N" aria-label="Nova conversa">
           <Plus size={14} />
         </a>
       </header>

--- a/resources/js/Pages/Jana/Cockpit.tsx
+++ b/resources/js/Pages/Jana/Cockpit.tsx
@@ -1,5 +1,5 @@
 // @memcofre
-//   tela: /copiloto/cockpit (= /jana/cockpit)
+//   tela: /ia/cockpit (legacy: /copiloto/cockpit · /jana/cockpit — 301 redirects)
 //   stories: US-COPI-COCKPIT-002 (V2 Analista IA · pivot Cowork 2026-05-15)
 //   adrs: 0035 (stack IA), 0039 (Cockpit V2), 0094 (Constituição §IA), 0104 (MWART), 0107 (gate F1.5), 0114 (loop Cowork↔CC)
 //   status: live (pivot Cowork aceito · supersedes MVP-piloto WhatsApp anti-pattern)

--- a/resources/js/Pages/Jana/Dashboard.tsx
+++ b/resources/js/Pages/Jana/Dashboard.tsx
@@ -166,7 +166,7 @@ function MetaCard({ meta }: { meta: Meta }) {
         )}
 
         <Link
-          href={`/jana/metas/${meta.id}`}
+          href={`/ia/metas/${meta.id}`}
           className="inline-flex items-center gap-1 text-xs text-primary hover:underline"
         >
           Ver detalhe <ExternalLink className="h-3 w-3" />
@@ -240,7 +240,7 @@ function ProximaAcaoCard() {
           Quando houver sinal claro nas metas, a Jana vai sugerir aqui o próximo passo prático — sem você precisar perguntar.
         </p>
         <div className="mt-3">
-          <Link href="/jana">
+          <Link href="/ia">
             <Button size="sm" variant="outline" className="gap-2">
               <MessageSquare className="h-4 w-4" />
               Conversar agora
@@ -281,7 +281,7 @@ export default function Dashboard({ metas }: Props) {
             </div>
           </div>
 
-          <Link href="/jana">
+          <Link href="/ia">
             <Button className="gap-2">
               <MessageSquare className="h-4 w-4" />
               Conversar com a Jana
@@ -305,7 +305,7 @@ export default function Dashboard({ metas }: Props) {
                   Pergunte algo à Jana — ela aprende o que importa pro seu business e cria metas com base no que conversamos.
                 </p>
               </div>
-              <Link href="/jana">
+              <Link href="/ia">
                 <Button className="gap-2">
                   <MessageSquare className="h-4 w-4" />
                   Pergunte algo a Jana
@@ -322,7 +322,7 @@ export default function Dashboard({ metas }: Props) {
         )}
       </div>
 
-      <FabJana contextRoute="/jana/dashboard" />
+      <FabJana contextRoute="/ia/dashboard" />
     </>
   )
 }

--- a/resources/js/Pages/Jana/Memoria.tsx
+++ b/resources/js/Pages/Jana/Memoria.tsx
@@ -68,7 +68,7 @@ function FatoCard({ memoria }: { memoria: MemoriaFato }) {
   const rel = memoria.metadata?.relevancia as number | undefined
 
   const onSalvar = () => {
-    patch(`/jana/memoria/${memoria.id}`, {
+    patch(`/ia/memoria/${memoria.id}`, {
       preserveScroll: true,
       onSuccess: () => setEditando(false),
     })
@@ -76,7 +76,7 @@ function FatoCard({ memoria }: { memoria: MemoriaFato }) {
 
   const onEsquecer = () => {
     if (!confirm('Tem certeza? Essa memória será esquecida e não voltará.')) return
-    router.delete(`/jana/memoria/${memoria.id}`, { preserveScroll: true })
+    router.delete(`/ia/memoria/${memoria.id}`, { preserveScroll: true })
   }
 
   return (

--- a/resources/js/Pages/Jana/Painel.tsx
+++ b/resources/js/Pages/Jana/Painel.tsx
@@ -1,5 +1,5 @@
 // @memcofre
-//   tela: /jana/painel
+//   tela: /ia/painel
 //   stories: US-JANA-PAINEL-001 (Onda A1)
 //   adrs: 0035 stack-ai, 0039 ui-cockpit-pattern, 0093 multi-tenant, 0114 cowork-loop
 //   visual-canon: prototipo-ui/cowork-snapshot/chat-jana.jsx (491 ln IIFE window.JanaCockpit)

--- a/resources/js/Pages/Jana/Regras/Index.tsx
+++ b/resources/js/Pages/Jana/Regras/Index.tsx
@@ -1,7 +1,7 @@
-// Stub /jana/regras — ghost canon ADR 0182 + GUIA-SIDEBAR-V3 (Wagner 2026-05-21).
+// Stub /ia/regras — ghost canon ADR 0182 + GUIA-SIDEBAR-V3 (Wagner 2026-05-21).
 // "Regras" cobre policies do PolicyEngine ADS (ALLOW_BRAIN_A / REQUIRE_HUMAN_REVIEW
 // etc.) + governance MCP cross-team. UI dedicada vem em onda futura; este stub
-// mantém o ghost clicável e aponta pra /jana/admin/governanca enquanto isso.
+// mantém o ghost clicável e aponta pra /ia/admin/governanca enquanto isso.
 
 import React from 'react'
 import { Head, Link } from '@inertiajs/react'
@@ -56,7 +56,7 @@ export default function RegrasIndex({ businessId }: Props) {
               Enquanto a tela dedicada não está pronta, consulte o painel de Governança da Jana.
             </p>
             <div className="flex flex-wrap gap-2 pt-2">
-              <Link href="/jana/admin/governanca">
+              <Link href="/ia/admin/governanca">
                 <Button size="sm" className="gap-2">
                   <ScrollText className="h-4 w-4" />
                   Ver governança

--- a/resources/js/Pages/Jana/_shared/JanaPrimaryButton.tsx
+++ b/resources/js/Pages/Jana/_shared/JanaPrimaryButton.tsx
@@ -13,7 +13,7 @@ import { SIDEBAR_GROUP_HUE } from '@/Components/cockpit/shared';
  *
  * Uso:
  *
- *   <JanaPrimaryButton onClick={() => router.visit('/jana')}>
+ *   <JanaPrimaryButton onClick={() => router.visit('/ia')}>
  *     Conversar com Jana
  *   </JanaPrimaryButton>
  */

--- a/resources/js/Pages/Jana/components/FabJana.tsx
+++ b/resources/js/Pages/Jana/components/FabJana.tsx
@@ -7,8 +7,8 @@ interface Props {
 
 export default function FabJana({ contextRoute }: Props) {
   const href = contextRoute
-    ? `/copiloto?context=${encodeURIComponent(contextRoute)}`
-    : '/copiloto'
+    ? `/ia?context=${encodeURIComponent(contextRoute)}`
+    : '/ia'
 
   return (
     <Link

--- a/resources/js/Pages/Jana/components/JanaAreaHeader.tsx
+++ b/resources/js/Pages/Jana/components/JanaAreaHeader.tsx
@@ -80,7 +80,7 @@ export function JanaAreaHeader({ active }: { active: JanaAreaTab }): ReactNode {
 
       {/* Right — primary "Conversar" hue 220 azul (canon ADR 0182) */}
       <div className="shrink-0">
-        <JanaPrimaryButton onClick={() => router.visit('/jana')}>
+        <JanaPrimaryButton onClick={() => router.visit('/ia')}>
           Conversar
         </JanaPrimaryButton>
       </div>

--- a/resources/js/Pages/RecurringBilling/_components/useJanaAsk.ts
+++ b/resources/js/Pages/RecurringBilling/_components/useJanaAsk.ts
@@ -12,7 +12,7 @@ export async function askJana(query: string, _context?: string): Promise<{ ok: b
   };
   const body = JSON.stringify({ query, context: _context || '' });
 
-  for (const url of ['/api/jana/ask', '/jana/ask']) {
+  for (const url of ['/api/ia/ask', '/ia/ask']) {
     try {
       const res = await fetch(url, { method: 'POST', headers, body, credentials: 'same-origin' });
       if (!res.ok) continue;

--- a/tests/Feature/Cliente/ClienteIndexDrawer760CharterTest.php
+++ b/tests/Feature/Cliente/ClienteIndexDrawer760CharterTest.php
@@ -180,15 +180,16 @@ test('GUARD 8 — drawer header contem nome + toggle PF/PJ + "cadastrado"', func
 
 // ─── GUARD 9: botao "Falar com Copiloto" link Jana correto ───────────────────
 
-test('GUARD 9 — drawer header link "Falar com Copiloto" aponta /jana/chat?context=cliente:{id}', function () {
+test('GUARD 9 — drawer header link "Falar com Copiloto" aponta /ia/chat?context=cliente:{id}', function () {
     $tsxPath = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
     $contents = file_get_contents($tsxPath);
 
     expect($contents)
-        ->toContain('/jana/chat?context=cliente:')
+        ->toContain('/ia/chat?context=cliente:')
         ->toContain('Falar com Copiloto')
         ->toContain('Imprimir ficha')
-        ->not->toContain('/copiloto/'); // Modules/Copiloto NAO existe (ADR 0179)
+        ->not->toContain('/copiloto/') // Modules/Copiloto NAO existe (ADR 0179)
+        ->not->toContain('/jana/chat'); // Wagner 2026-05-22: rota canon /ia (ADR 0180 sidebar v3)
 });
 
 // ─── GUARD 10: migration aditiva contacts adiciona 16 colunas ─────────────────


### PR DESCRIPTION
## Summary

Vertical-slice **IA** piloto da sidebar v3 ([ADR 0180](memory/decisions/0180-sidebar-v3-5-grupos-ghosts-header.md)) — rename URL `/jana/*` → `/ia/*` pra label canon do topo "IA" casar com a URL. Demais 16 DataControllers (Sells/Crm/Financeiro/etc) seguem em PR separado.

- Route names PHP `jana.*` **preservados** — `route('jana.x')` resolve automático pro novo prefix
- Redirect chain `/copiloto → /jana → /ia` (zero break em bookmarks)
- Permissions `jana.*`, namespace TS `Pages/Jana/` **intactos**
- 25 arquivos · +110 -89 LOC (dentro do ≤300 commit-discipline)

## Mudanças

**PHP (6):** `routes.php` (prefix + redirect 301), `DataController.php` (primary + 8 ghosts), `topnav.php`, 3 Pest tests
**TSX/TS (19):** `Sidebar.tsx` (2 shortcuts topo), `JanaAreaHeader` + `JanaPrimaryButton` + `FabJana`, `Chat`, `Dashboard`, `Memoria`, `Painel`, `Cockpit`, `Brief`, `Regras`, `Admin/{Custos,Governanca,Qualidade,Roadmap}`, `Cliente`, `AssistantUiChat`, `useJanaAsk`

## Test plan

- [x] Pest local: 3 passes / 0 fails / 9 skip (DB env SQLite)
  - GUARD 9 confirma Cliente aponta `/ia/chat`
  - Wave14 valida `/ia/metas` payload
  - Roadmap 302→login confirma rota `/ia/admin/roadmap` existe
- [ ] CI Pest contra DB real
- [ ] CI build Vite (TSX hrefs)
- [ ] Smoke browser MCP em http://oimpresso.test/ia/* (Wagner manual pós-merge dev)
- [ ] Validar redirect 301: `curl -I /jana/dashboard` retorna 301 → `/ia/dashboard`

## Refs

- [ADR 0180](memory/decisions/0180-sidebar-v3-5-grupos-ghosts-header.md) — sidebar v3 (5 grupos + 3 topo + ghosts ARIA)
- [ADR 0182] PageHeader canon + JanaSubNav
- Skill `sidebar-menu-arch` — arquitetura DataController v2

🤖 Generated with [Claude Code](https://claude.com/claude-code)