### PR TITLE
feat(whatsapp): DataController v2 + rota /atendimento — sidebar v3 ADR 0180

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/DataController.php
+++ b/Modules/Whatsapp/Http/Controllers/DataController.php
@@ -2,19 +2,21 @@
 
 namespace Modules\Whatsapp\Http\Controllers;
 
+use App\Utils\ModuleUtil;
 use Illuminate\Routing\Controller;
+use Menu;
 
 /**
- * DataController do módulo Whatsapp.
+ * DataController do módulo Whatsapp (label visível: "Atendimento").
  *
  * Convenção UltimatePOS: middleware `AdminSidebarMenu` chama
  * `Modules\Whatsapp\Http\Controllers\DataController@modifyAdminMenu` em cada request
  * da sidebar admin (e os hooks superadmin_package/user_permissions na tela de Roles).
  *
- * Espelha o topnav declarativo em Modules/Whatsapp/Resources/menus/topnav.php.
- *
  * @see memory/requisitos/Whatsapp/SPEC.md
  * @see memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md
+ * @see memory/decisions/0135-omnichannel-arquitetura-whatsapp-base.md
+ * @see memory/decisions/0180-sidebar-v3-5-grupos-ghosts-header.md
  */
 class DataController extends Controller
 {
@@ -41,12 +43,156 @@ class DataController extends Controller
         ];
     }
 
+    /**
+     * ADR 0180 Fase 4 Wave C TOPO (Wagner 2026-05-22): vertical-slice
+     * Atendimento piloto sidebar v3 — espelha pattern do Modules/Jana.
+     *
+     * Declara dropdown Atendimento com atributos extras propagados pelo
+     * LegacyMenuAdapter pro frontend Sidebar.tsx (v3 — grupo 'atendimento' no TOPO):
+     *  - `shortcut` G A → atalho kbd canônico (overlay Fase 8)
+     *  - `primary`     → "Nova conversa" (entry-point atendimento manual)
+     *  - `ghosts`      → 7 sub-views (caixa/canais/templates/macros/metricas/csat/time)
+     *
+     * group: 'atendimento' canon — LegacyMenuAdapter propaga pro Sidebar.tsx,
+     * que renderiza Atendimento no TOPO junto com IA (Jana) e Equipe (TeamMcp).
+     *
+     * Permission gate global hasThePermissionInSubscription já cobre módulo
+     * on/off na entry; sub-itens reusam `can:whatsapp.*` declaradas nas rotas.
+     */
     public function modifyAdminMenu(): void
     {
-        // Wagner 2026-05-11: entrada de sidebar removida — o shortcut fixo
-        // "WhatsApp" no topo do Sidebar.tsx (SidebarShortcuts) ja e o ponto
-        // de entrada unico pra /whatsapp/conversations. Sub-itens (Templates,
-        // Configuracoes) permanecem disponiveis via topnav declarativo em
-        // Resources/menus/topnav.php (montado pelo LegacyMenuAdapter::buildTopNavs).
+        $module_util = new ModuleUtil();
+
+        if (auth()->user()->can('superadmin')) {
+            $is_enabled = $module_util->isModuleInstalled('Whatsapp');
+        } else {
+            $business_id = session()->get('user.business_id');
+            $is_enabled = (bool) $module_util->hasThePermissionInSubscription(
+                $business_id,
+                'whatsapp_module',
+                'superadmin_package'
+            );
+        }
+
+        if (! $is_enabled) {
+            return;
+        }
+
+        if (! (auth()->user()->can('superadmin') || auth()->user()->can('whatsapp.access'))) {
+            return;
+        }
+
+        $background_color = config('app.env') == 'demo' ? '#a8d8ea' : '';
+        $segmento_ativo = request()->segment(1) === 'atendimento';
+
+        Menu::modify(
+            'admin-sidebar-menu',
+            function ($menu) use ($background_color, $segmento_ativo) {
+                $menu->dropdown(
+                    'Atendimento',
+                    function ($sub) {
+                        // Caixa Unificada V4 — entry-point operacional (default tab)
+                        $sub->url(
+                            route('atendimento.caixa-unificada.index'),
+                            'Caixa',
+                            [
+                                'icon'   => 'fa fas fa-inbox',
+                                'active' => request()->segment(2) === 'caixa-unificada',
+                            ]
+                        );
+
+                        // Canais (drivers Z-API/Meta/Baileys + ACL atendente↔canal)
+                        if (auth()->user()->can('superadmin') || auth()->user()->can('whatsapp.settings.manage')) {
+                            $sub->url(
+                                route('atendimento.channels.index'),
+                                'Canais',
+                                [
+                                    'icon'   => 'fa fas fa-plug',
+                                    'active' => request()->segment(2) === 'canais',
+                                ]
+                            );
+                        }
+
+                        // Templates HSM + Bot Jana (toggle)
+                        if (auth()->user()->can('superadmin') || auth()->user()->can('whatsapp.settings.manage')) {
+                            $sub->url(
+                                route('atendimento.canais.jana_templates.show'),
+                                'Templates',
+                                [
+                                    'icon'   => 'fa fas fa-file-alt',
+                                    'active' => request()->segment(3) === 'jana-templates',
+                                ]
+                            );
+                        }
+
+                        // Macros (quick replies + variantes A/B)
+                        if (auth()->user()->can('superadmin') || auth()->user()->can('whatsapp.settings.manage')) {
+                            $sub->url(
+                                route('atendimento.macros.index'),
+                                'Macros',
+                                [
+                                    'icon'   => 'fa fas fa-bolt',
+                                    'active' => request()->segment(2) === 'macros',
+                                ]
+                            );
+                        }
+
+                        // Métricas omnichannel
+                        $sub->url(
+                            route('atendimento.metricas.index'),
+                            'Métricas',
+                            [
+                                'icon'   => 'fa fas fa-chart-line',
+                                'active' => request()->segment(2) === 'metricas',
+                            ]
+                        );
+
+                        // CSAT (pesquisa pós-resolução)
+                        $sub->url(
+                            route('atendimento.csat.index'),
+                            'CSAT',
+                            [
+                                'icon'   => 'fa fas fa-smile',
+                                'active' => request()->segment(2) === 'csat',
+                            ]
+                        );
+
+                        // Time (ranking scorecards atendentes)
+                        $sub->url(
+                            route('atendimento.employee.scorecards'),
+                            'Time',
+                            [
+                                'icon'   => 'fa fas fa-trophy',
+                                'active' => request()->segment(2) === 'employee',
+                            ]
+                        );
+                    },
+                    [
+                        'icon'     => 'fa fas fa-comments',
+                        'style'    => 'background-color:' . $background_color,
+                        'active'   => $segmento_ativo,
+                        'group'    => 'atendimento',
+                        'shortcut' => 'G A',
+                        'primary'  => [
+                            'label'    => 'Nova conversa',
+                            'href'     => '/atendimento?new=1',
+                            'shortcut' => 'N',
+                        ],
+                        // ADR 0180 + GUIA-SIDEBAR-V3 Wagner 2026-05-22: hub Atendimento
+                        // com 7 ghosts canon. Labels CURTOS (≤2 palavras). PageHeaderTabs
+                        // auto-promove ghost ativo inline mesmo se index >= maxVisible.
+                        'ghosts'   => [
+                            ['key' => 'caixa',     'label' => 'Caixa',     'href' => '/atendimento/caixa-unificada'],
+                            ['key' => 'canais',    'label' => 'Canais',    'href' => '/atendimento/canais'],
+                            ['key' => 'templates', 'label' => 'Templates', 'href' => '/atendimento/canais/jana-templates'],
+                            ['key' => 'macros',    'label' => 'Macros',    'href' => '/atendimento/macros'],
+                            ['key' => 'metricas',  'label' => 'Métricas',  'href' => '/atendimento/metricas'],
+                            ['key' => 'csat',      'label' => 'CSAT',      'href' => '/atendimento/csat'],
+                            ['key' => 'time',      'label' => 'Time',      'href' => '/atendimento/employee/scorecards'],
+                        ],
+                    ]
+                )->order(89); // Logo antes de Jana (90) — Atendimento entra primeiro no TOPO.
+            }
+        );
     }
 }

--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -84,6 +84,14 @@ Route::group([
     'middleware' => ['web', 'SetSessionData', 'auth', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin'],
     'prefix'     => 'atendimento',
 ], function () {
+    // Rota raiz /atendimento — entry-point canon do hub Atendimento (ADR 0180
+    // sidebar v3 — shortcut topo "Atendimento" aponta /atendimento zero-hop).
+    // Alias pra CaixaUnificadaController@index pra evitar 1 redirect extra.
+    // Wagner 2026-05-22: vertical-slice Atendimento piloto sidebar v3.
+    Route::get('/', [CaixaUnificadaController::class, 'index'])
+        ->middleware('can:whatsapp.access')
+        ->name('atendimento.index');
+
     // CUTOVER 2026-05-15: GET /inbox redireciona pra Caixa Unificada V4 (301 permanent).
     // Inventário §6 do INVENTARIO-CUTOVER-CAIXA-UNIFICADA-V4.md.
     // - Route name `atendimento.inbox.index` preservado (compat Pest + frontend legacy)

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -465,7 +465,7 @@ function SidebarShortcuts({
         </a>
       )}
       {showAtendimento && (
-        <a href="/atendimento/inbox" className="sb-shortcut">
+        <a href="/atendimento" className="sb-shortcut">
           <MessageCircle size={13} />
           <span className="label">Atendimento</span>
           {!!atendimentoCount && <span className="badge">{atendimentoCount}</span>}
@@ -687,7 +687,7 @@ function SidebarMenuRail({
       )}
       {showAtendimento && (
         <a
-          href="/atendimento/inbox"
+          href="/atendimento"
           className="sb-rail-btn"
           data-tip="Atendimento"
           onClick={() => setFlyout(null)}


### PR DESCRIPTION
## Summary

Vertical-slice **Atendimento** piloto sidebar v3 ([ADR 0180](memory/decisions/0180-sidebar-v3-5-grupos-ghosts-header.md)) — espelha pattern do PR #1391 (IA/Jana). Atendimento agora declara contrato v2 canon com 7 ghosts no header e rota raiz `/atendimento` zero-hop pro shortcut topo.

- **Modules/Whatsapp DataController** `modifyAdminMenu()` estava vazio (Wagner 2026-05-11 removeu) → agora declara `group:'atendimento'`, `shortcut:'G A'`, `primary:'Nova conversa'`, **7 ghosts**
- **Rota raiz `GET /atendimento`** adicionada (alias `CaixaUnificadaController@index`) — shortcut topo Sidebar.tsx aponta zero-hop em vez de `/atendimento/inbox` que fazia 301
- **Pages/Atendimento/* intactas** — escopo mínimo aprovado; telas mantêm header próprio V4 (hideTopbar canônico)

3 arquivos · +164 -10 LOC (dentro do ≤300 commit-discipline).

## Mudanças

```
Modules/Whatsapp/Http/Controllers/DataController.php   162 ++++++  ← modifyAdminMenu() v2
Modules/Whatsapp/Routes/web.php                          8 ++++++  ← Route::get('/')
resources/js/Components/cockpit/Sidebar.tsx              4 ++--    ← 2 shortcuts zero-hop
```

## 7 ghosts canon Atendimento

| key | label | href | permission |
|---|---|---|---|
| `caixa` | Caixa | `/atendimento/caixa-unificada` | whatsapp.access (default) |
| `canais` | Canais | `/atendimento/canais` | whatsapp.settings.manage |
| `templates` | Templates | `/atendimento/canais/jana-templates` | whatsapp.settings.manage |
| `macros` | Macros | `/atendimento/macros` | whatsapp.settings.manage |
| `metricas` | Métricas | `/atendimento/metricas` | whatsapp.access |
| `csat` | CSAT | `/atendimento/csat` | whatsapp.access |
| `time` | Time | `/atendimento/employee/scorecards` | whatsapp.access |

## Test plan

- [x] `php artisan route:list --path=atendimento` confirma rota `atendimento.index` registrada
- [ ] CI Pest contra DB real
- [ ] CI build Vite
- [ ] Smoke browser MCP em http://oimpresso.test/atendimento (pós-merge)
- [ ] Validar shell.menu Inertia shared expõe `group:'atendimento'` + ghosts pro frontend
- [ ] Validar Sidebar.tsx renderiza dropdown Atendimento sem duplicação com shortcut topo

## Status sidebar v3 — 3 topos

| Topo | Shortcut Sidebar | DataController v2 | Ghosts |
|---|---|---|---|
| ✅ **IA** (Jana) | `/ia` | ✅ group:'ia' G I + primary | ✅ 8 |
| ✅ **Atendimento** (Whatsapp) | `/atendimento` (este PR) | ✅ group:'atendimento' G A + primary (este PR) | ✅ 7 (este PR) |
| ⚠️ **Equipe** (TeamMcp) | ❌ não existe shortcut topo | ✅ group:'equipe' G E | ✅ 3 (sem primary) |

## Refs

- [ADR 0180](memory/decisions/0180-sidebar-v3-5-grupos-ghosts-header.md) — sidebar v3 canon
- [ADR 0135](memory/decisions/0135-omnichannel-arquitetura-whatsapp-base.md) — Atendimento omnichannel
- [ADR 0096](memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md) — drivers WhatsApp
- PR #1391 — pattern referência (IA/Jana vertical-slice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)