### PR TITLE
feat(sidebar): Fiscal hub canon (Notas·Manifestação) + COMERCIAL sem Woocommerce

### DIFF
--- a/Modules/Fiscal/Http/Controllers/DataController.php
+++ b/Modules/Fiscal/Http/Controllers/DataController.php
@@ -85,32 +85,14 @@ class DataController extends Controller
         $background_color = config('app.env') == 'demo' ? '#ffd6a5' : '';
         $segmento_ativo = request()->segment(1) == 'fiscal';
 
-        Menu::modify(
-            'admin-sidebar-menu',
-            function ($menu) use ($background_color, $segmento_ativo) {
-                // ADR 0180 Fase 4 Wave D FINANÇAS+PESSOAS (2026-05-21): entry Fiscal
-                // (cockpit unificado /fiscal) é ghost do módulo principal NfeBrasil
-                // (G X) — sem shortcut próprio. Primary "Ver NF-e" + ghost
-                // single-element pra mantér shape contratual (Wave A precedent).
-                // Entrada top-level "Fiscal" — leva ao Cockpit (PR #2 Wave consolidada).
-                $menu->url(
-                    url('/fiscal'),
-                    __('fiscal::fiscal.module_label'),
-                    [
-                        'icon'    => 'fa fas fa-file-invoice',
-                        'style'   => 'background-color:' . $background_color,
-                        'active'  => $segmento_ativo,
-                        'primary' => [
-                            'label'    => 'Ver NF-e',
-                            'href'     => '/fiscal/nfe',
-                            'shortcut' => 'N',
-                        ],
-                        'ghosts'  => [
-                            ['key' => 'cockpit', 'label' => 'Cockpit Fiscal', 'href' => '/fiscal'],
-                        ],
-                    ]
-                )->order(84);
-            }
-        );
+        // Wagner 2026-05-22: Modules/Fiscal entry REMOVIDA do sidebar. Hub
+        // canon "Fiscal" agora vem de Modules/NfeBrasil (consolidação ADR 0180
+        // — 1 entry + 2 ghosts Notas fiscais·Manifestação). Modules/Fiscal
+        // continua existindo (cockpit /fiscal acessível via URL direta), só
+        // não declara entry própria pra evitar duplicação visual.
+        //
+        // Retomar quando PR #2 Wave consolidada entregar cockpit real /fiscal
+        // — então renomear/promover entry pra principal e mover NfeBrasil pra
+        // ghost. Por ora, NfeBrasil é o canonical Fiscal hub.
     }
 }

--- a/Modules/NfeBrasil/Http/Controllers/DataController.php
+++ b/Modules/NfeBrasil/Http/Controllers/DataController.php
@@ -142,127 +142,25 @@ class DataController extends Controller
             return;
         }
 
-        // Agrupamento visual em "FISCAL" acontece no frontend (SIDEBAR_GROUPS
-        // em resources/js/Components/cockpit/Sidebar.tsx). DataController
-        // publica o dropdown standalone do módulo.
+        // Wagner 2026-05-22 direção canon: 1 entry "Fiscal" + 2 ghosts
+        // (Notas fiscais · Manifestação). Substitui 8 entries duplicadas.
+        // Sub-items (Emitir/SPED/Settings/Certificado/Tributação) ficam
+        // acessíveis via URL direta ou tabs internas das telas (TODO Fase 4).
         $background_color = config('app.env') == 'demo' ? '#a8d8ea' : '';
-        $segmento_ativo = request()->segment(1) == 'nfebrasil';
+        $segmento_ativo = request()->segment(1) == 'nfebrasil'
+            || request()->segment(1) == 'nfe-brasil';
 
         Menu::modify(
             'admin-sidebar-menu',
             function ($menu) use ($background_color, $segmento_ativo) {
-                // ADR 0180 Fase 4 Wave D FINANÇAS+PESSOAS (2026-05-21): entry
-                // principal NF-e Brasil (módulo principal do grupo FISCAL) declara
-                // atalho kbd + primary action + ghosts tabs no `attributes` do
-                // dropdown — LegacyMenuAdapter propaga pro frontend Sidebar.tsx.
-                //  - `shortcut` G X → atalho overlay (X = fisXal, evita conflito
-                //    com G F/G S/G C/G O/G Y/G P já usados em outras ondas)
-                //  - `primary`     → "Emitir NF-e / NFC-e" (ação canon do módulo)
-                //  - `ghosts`      → 8 sub-views da tela /nfebrasil/* + manifestação
-                //
-                // hrefs absolutos (LegacyMenuAdapter::toRelative espera path string).
-                // Permission gates específicos (nfebrasil.emit.manage, .consult.view,
-                // .sped.view, .settings.manage, .configuracao.manage, .tributacao.manage,
-                // .manifestacao.*) continuam enforce nos Controllers — gate global
-                // hasThePermissionInSubscription já cobre módulo on/off na entry.
-                $menu->dropdown(
-                    'NF-e Brasil',
-                    function ($sub) {
-                        $sub->url(
-                            url('/nfebrasil'),
-                            'Painel',
-                            [
-                                'icon'   => 'fa fas fa-tachometer-alt',
-                                'active' => request()->segment(1) == 'nfebrasil' && ! request()->segment(2),
-                            ]
-                        );
-
-                        if (auth()->user()->can('superadmin') || auth()->user()->can('nfebrasil.emit.manage')) {
-                            $sub->url(
-                                url('/nfebrasil/create'),
-                                'Emitir NF-e / NFC-e',
-                                [
-                                    'icon'   => 'fa fas fa-file-invoice-dollar',
-                                    'active' => request()->segment(2) == 'create',
-                                ]
-                            );
-                        }
-
-                        if (auth()->user()->can('superadmin') || auth()->user()->can('nfebrasil.consult.view')) {
-                            $sub->url(
-                                url('/nfebrasil?status=emitidas'),
-                                'Consultar Notas',
-                                [
-                                    'icon'   => 'fa fas fa-search',
-                                    'active' => false,
-                                ]
-                            );
-                        }
-
-                        if (auth()->user()->can('superadmin') || auth()->user()->can('nfebrasil.sped.view')) {
-                            $sub->url(
-                                url('/nfebrasil/sped'),
-                                'SPED Fiscal',
-                                [
-                                    'icon'   => 'fa fas fa-file-archive',
-                                    'active' => request()->segment(2) == 'sped',
-                                ]
-                            );
-                        }
-
-                        if (auth()->user()->can('superadmin') || auth()->user()->can('nfebrasil.settings.manage')) {
-                            $sub->url(
-                                url('/nfebrasil/settings'),
-                                'Configurações Fiscais',
-                                [
-                                    'icon'   => 'fa fas fa-cog',
-                                    'active' => request()->segment(2) == 'settings',
-                                ]
-                            );
-                        }
-
-                        if (auth()->user()->can('superadmin') || auth()->user()->can('nfe.configuracao.manage')) {
-                            $sub->url(
-                                url('/nfe-brasil/configuracao/certificado'),
-                                'Certificado A1',
-                                [
-                                    'icon'   => 'fa fas fa-key',
-                                    'active' => request()->is('nfe-brasil/configuracao/certificado*'),
-                                ]
-                            );
-                        }
-
-                        if (auth()->user()->can('superadmin') || auth()->user()->can('nfe.tributacao.manage')) {
-                            $sub->url(
-                                url('/nfe-brasil/tributacao'),
-                                'Tributação',
-                                [
-                                    'icon'   => 'fa fas fa-percent',
-                                    'active' => request()->is('nfe-brasil/tributacao*'),
-                                ]
-                            );
-                        }
-
-                        // US-NFE-052 (ADR 0116) — manifestação destinatário
-                        if (
-                            auth()->user()->can('superadmin')
-                            || auth()->user()->can('nfe.manifestacao.view')
-                            || auth()->user()->can('nfe.manifestacao.manage')
-                        ) {
-                            $sub->url(
-                                url('/nfe-brasil/manifestacao'),
-                                'Notas recebidas',
-                                [
-                                    'icon'   => 'fa fas fa-inbox',
-                                    'active' => request()->is('nfe-brasil/manifestacao*'),
-                                ]
-                            );
-                        }
-                    },
+                $menu->url(
+                    url('/nfebrasil'),
+                    'Fiscal',
                     [
                         'icon'     => 'fa fas fa-file-invoice-dollar',
                         'style'    => 'background-color:' . $background_color,
                         'active'   => $segmento_ativo,
+                        'group'    => 'financas',
                         'shortcut' => 'G X',
                         'primary'  => [
                             'label'    => 'Emitir NF-e',
@@ -270,14 +168,8 @@ class DataController extends Controller
                             'shortcut' => 'N',
                         ],
                         'ghosts'   => [
-                            ['key' => 'painel',        'label' => 'Painel',                'href' => '/nfebrasil'],
-                            ['key' => 'emitir',        'label' => 'Emitir NF-e / NFC-e',   'href' => '/nfebrasil/create'],
-                            ['key' => 'consultar',     'label' => 'Consultar Notas',       'href' => '/nfebrasil?status=emitidas'],
-                            ['key' => 'sped',          'label' => 'SPED Fiscal',           'href' => '/nfebrasil/sped'],
-                            ['key' => 'settings',      'label' => 'Configurações Fiscais', 'href' => '/nfebrasil/settings'],
-                            ['key' => 'certificado',   'label' => 'Certificado A1',        'href' => '/nfe-brasil/configuracao/certificado'],
-                            ['key' => 'tributacao',    'label' => 'Tributação',            'href' => '/nfe-brasil/tributacao'],
-                            ['key' => 'manifestacao',  'label' => 'Notas recebidas',       'href' => '/nfe-brasil/manifestacao'],
+                            ['key' => 'notas',         'label' => 'Notas fiscais', 'href' => '/nfebrasil'],
+                            ['key' => 'manifestacao',  'label' => 'Manifestação',  'href' => '/nfe-brasil/manifestacao'],
                         ],
                     ]
                 )->order(95);

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -148,8 +148,8 @@ const SIDEBAR_GROUPS: Array<{ key: string; label: string; items: string[] }> = [
   {
     key: 'comercial',
     label: 'COMERCIAL',
-    items: ['Crm', 'CRM', 'Vendas', 'Orçamentos',
-            'WooCommerce', 'Woocommerce'],
+    // Wagner 2026-05-22: só Crm + Vendas (Woocommerce REMOVIDO).
+    items: ['Crm', 'CRM', 'Vendas'],
   },
   {
     key: 'estoque',


### PR DESCRIPTION
## Summary

Wagner 2026-05-22 direção:
- COMERCIAL items[] = Crm + Vendas (**sem Woocommerce**)
- Hub Fiscal = 1 entry + 2 ghosts (**Notas fiscais · Manifestação**)

## Mudanças (3 arquivos, **-126 LOC líquido**)

| Arquivo | Mudança |
|---|---|
| Sidebar.tsx | COMERCIAL.items[] remove WooCommerce/Woocommerce |
| Modules/NfeBrasil/DataController | 8 ghosts → 2 canon (Notas·Manifestação) + label "Fiscal" |
| Modules/Fiscal/DataController | Remove entry sidebar (evita duplicação) |

## Resultado visual esperado

```
▼ FINANÇAS
  · Financeiro    (4 ghosts: Caixa·Cobrança·Financeiro·Relatório)
  · Fiscal        (2 ghosts: Notas fiscais·Manifestação)  ← reduzido de 8 ghosts!
```

```
▼ COMERCIAL
  · Crm
  · Vendas
  (Woocommerce REMOVIDO)
```

## Refs

- [ADR 0180](memory/decisions/0180-sidebar-v3-5-grupos-ghosts-header.md) sidebar v3
- Direção Wagner 2026-05-22: 1 hub por PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)