### PR TITLE
fix(crm): order 86→29 — Crm acima de Vendas (Wagner 2026-05-22)

### DIFF
--- a/Modules/Crm/Http/Controllers/DataController.php
+++ b/Modules/Crm/Http/Controllers/DataController.php
@@ -190,7 +190,9 @@ class DataController extends Controller
                                 ['key' => 'settings',       'label' => 'Configurações',  'href' => '/crm/settings'],
                             ],
                         ]
-                    )->order(86);
+                    )->order(29); // Wagner 2026-05-22: Crm ACIMA de Vendas core (order 30)
+                    // Antes order 86 — caía após Vendas. ADR 0180 sidebar v3 ordem canon
+                    // COMERCIAL: Crm primeiro, Vendas depois (mental model lead → conversão).
                 }
             );
 


### PR DESCRIPTION
## Summary

Wagner 2026-05-22: **"Crm deve ficar acima da vendas"**.

Crm DataController estava com `order(86)` — caía DEPOIS de Vendas core (order 30 no app/Http/Middleware/AdminSidebarMenu.php:436).

## Mudança (1 arquivo, +3 -1 LOC)

`Modules/Crm/Http/Controllers/DataController.php:193`:
- `->order(86)` → `->order(29)` (1 a menos que Vendas core)

## Resultado visual esperado

```
▼ COMERCIAL
  · Crm       ← agora primeiro
  · Vendas
```

Mental model: lead (Crm) → conversão (Vendas).

## Refs

- [ADR 0180](memory/decisions/0180-sidebar-v3-5-grupos-ghosts-header.md)
- Direção Wagner 2026-05-22

🤖 Generated with [Claude Code](https://claude.com/claude-code)