### PR TITLE
fix: reverte PR #1399 — Cobrança Recorrente FICA no sidebar (Wagner esclareceu)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/DataController.php
+++ b/Modules/Financeiro/Http/Controllers/DataController.php
@@ -134,12 +134,10 @@ class DataController extends Controller
                             'shortcut' => 'N',
                         ],
                         'ghosts'   => [
-                            ['key' => 'caixa',              'label' => 'Caixa',              'href' => '/financeiro/caixa'],
-                            ['key' => 'cobranca',           'label' => 'Cobrança',           'href' => '/financeiro/cobranca'],
-                            ['key' => 'financeiro',         'label' => 'Financeiro',         'href' => '/financeiro/unificado'],
-                            ['key' => 'relatorio',          'label' => 'Relatório',          'href' => '/financeiro/relatorios'],
-                            // Wagner 2026-05-22: Cobrança Recorrente vai pro ÚLTIMO no Financeiro.
-                            ['key' => 'cobranca-recorrente','label' => 'Cobrança Recorrente','href' => '/recurring-billing'],
+                            ['key' => 'caixa',      'label' => 'Caixa',      'href' => '/financeiro/caixa'],
+                            ['key' => 'cobranca',   'label' => 'Cobrança',   'href' => '/financeiro/cobranca'],
+                            ['key' => 'financeiro', 'label' => 'Financeiro', 'href' => '/financeiro/unificado'],
+                            ['key' => 'relatorio',  'label' => 'Relatório',  'href' => '/financeiro/relatorios'],
                         ],
                     ]
                 )->order(85.00);

--- a/Modules/RecurringBilling/Http/Controllers/DataController.php
+++ b/Modules/RecurringBilling/Http/Controllers/DataController.php
@@ -91,9 +91,34 @@ class DataController extends Controller
             return;
         }
 
-        // Wagner 2026-05-22: Cobrança Recorrente vira ÚLTIMO ghost do hub
-        // Financeiro (5º ghost: Caixa·Cobrança·Financeiro·Relatório·Cobrança
-        // Recorrente). Entry própria REMOVIDA do sidebar pra evitar duplicação.
-        // Acessível via Financeiro→ghost ou URL direta /recurring-billing.
+        $background_color = config('app.env') == 'demo' ? '#ffd6a5' : '';
+        $segmento_ativo = request()->segment(1) === 'recurring-billing';
+
+        // Wagner 2026-05-22: Cobrança Recorrente FICA no sidebar como entry
+        // própria. Revertido erro do PR #1399 (havia movido pra ghost do
+        // Financeiro, mas Wagner esclareceu que deve permanecer entry separada).
+        Menu::modify(
+            'admin-sidebar-menu',
+            function ($menu) use ($background_color, $segmento_ativo) {
+                $menu->url(
+                    route('recurring-billing.index'),
+                    'Cobrança Recorrente',
+                    [
+                        'icon'    => 'fa fas fa-sync-alt',
+                        'style'   => 'background-color:' . $background_color,
+                        'active'  => $segmento_ativo,
+                        'group'   => 'financas',
+                        'primary' => [
+                            'label'    => 'Nova assinatura',
+                            'href'     => '/recurring-billing/create',
+                            'shortcut' => 'N',
+                        ],
+                        'ghosts'  => [
+                            ['key' => 'recurring-billing', 'label' => 'Cobrança Recorrente', 'href' => '/recurring-billing'],
+                        ],
+                    ]
+                )->order(86);
+            }
+        );
     }
 }


### PR DESCRIPTION
Wagner 2026-05-22 esclareceu: "Cobrança Recorrente fica no sidebar, é o Tradução".

Reverte interpretação errada do PR #1399. Cobrança Recorrente volta a ser entry própria no grupo FINANÇAS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)