### PR TITLE
feat(sidebar): restaura cascade Superadmin user menu (Wagner 2026-05-22)

### DIFF
--- a/resources/js/Components/cockpit/shared.ts
+++ b/resources/js/Components/cockpit/shared.ts
@@ -199,17 +199,29 @@ export function gradientFor(id: number): string {
   return `linear-gradient(135deg, oklch(0.55 0.15 ${hue}), oklch(0.65 0.15 ${(hue + 60) % 360}))`;
 }
 
-// DEPRECATED 2026-05-10 — cascata "Superadmin" do user dropdown footer foi
-// removida (Wagner). Admin de plataforma agora vive no sidebar principal:
-// Officeimpresso em ACESSOS RÁPIDOS, demais (CMS/Conector/Backup/Módulos) em
-// novo grupo "PLATAFORMA". SidebarMenu não filtra mais — itens caem no grupo
-// canônico via SIDEBAR_GROUPS. Set mantido vazio + isSuperadminMenu sempre
-// false pra preservar callers (SidebarMenu.principais filter, SidebarFooter
-// hasSuperadmin) sem quebrar até refactor remover o code path.
-export const SUPERADMIN_LABELS = new Set<string>();
+// Wagner 2026-05-22 REVIVED: cascata "Superadmin" do user dropdown footer
+// RESTAURADA. Admin de plataforma (Módulos/Backup/CMS/Conector/Office Impresso/
+// Personalizar) sai do menu principal e vai pra cascade no rodapé esquerdo
+// (avatar user). Mantém menu principal limpo + agrupa admin onde faz sentido.
+//
+// Histórico:
+// - 2026-04-27: SUPERADMIN_LABELS criado pra filtrar items pro user dropdown
+// - 2026-05-10: Wagner removeu (admin de plataforma virou grupo PLATAFORMA)
+// - 2026-05-22: Wagner reviveu (sidebar v3 — admin volta pra cascade rodapé)
+//
+// SidebarMenu.principais filter usa isSuperadminMenu() pra excluir esses
+// labels do menu principal. SidebarUserMenu renderiza cascade lateral.
+export const SUPERADMIN_LABELS = new Set<string>([
+  'Módulos', 'Modulos', 'Manage Modules',
+  'Backup',
+  'CMS', 'Cms',
+  'Conector', 'Connector',
+  'Office Impresso', 'Officeimpresso',
+  'Personalizar',
+]);
 
-export function isSuperadminMenu(_label: string): boolean {
-  return false;
+export function isSuperadminMenu(label: string): boolean {
+  return SUPERADMIN_LABELS.has(label.trim());
 }
 
 // Items que vão pro user dropdown footer (botão de avatar/usuário no rodapé)


### PR DESCRIPTION
Wagner 2026-05-22: "Grupo sistema Superadmin → [Módulos, Backup, CMS, Conector, Office Impresso] alem dos que ja existem".

Reverte deprecação 2026-05-10. Cascata Superadmin do user dropdown rodapé volta a ser populada — agrupa admin de plataforma (6 labels canon) num único ponto de acesso (cascade lateral do avatar usuário), em vez de poluir menu principal.

## Mudança (1 arquivo, ~15 LOC)

`shared.ts`:
- `SUPERADMIN_LABELS` repovoado: Módulos · Backup · CMS · Conector · Office Impresso · Personalizar
- `isSuperadminMenu()` volta a retornar `SUPERADMIN_LABELS.has(label.trim())`

## Resto cabeado automaticamente

- `AppShellV2` já filtra shell.menu → superadminItems → SidebarFooter
- `SidebarUserMenu` já renderiza cascade lateral "Superadmin"
- Telas Blade legacy funcionam normal (sidebar agrupa pelo shell.menu, independente do tipo da tela)

## Resultado visual esperado

```
Sidebar principal: menu fica MAIS LIMPO (perde 6 items)
Rodapé esquerdo (avatar Wagner) → clicar → user menu cascade
  ├ Meu perfil
  ├ Superadmin ▶          ← cascade lateral
  │  ├ Módulos
  │  ├ Backup
  │  ├ CMS
  │  ├ Conector
  │  ├ Office Impresso
  │  └ Personalizar
  ├ Disponível ▶
  ├ Aparência ▶
  └ Modo de trabalho ▶
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)