### PR TITLE
fix(sidebar): paymentgateway label + remove NFSe entry + /governance→/ia

### DIFF
--- a/Modules/Governance/Http/routes.php
+++ b/Modules/Governance/Http/routes.php
@@ -24,10 +24,13 @@ Route::middleware(['web', 'authh', 'auth', 'SetSessionData', 'language', 'timezo
     ->prefix('governance')
     ->name('governance.')
     ->group(function () {
-        // Dashboard consolidado — throttle 60req/min (read-only, cheap cache)
-        Route::get('/', [DashboardController::class, 'index'])
+        // Wagner 2026-05-22: /governance redireciona pra /ia (entry-point
+        // canon do oimpresso é o hub IA/Jana — sidebar v3 ADR 0180).
+        // Dashboard governance original preservado em /governance/dashboard.
+        Route::get('/', fn () => redirect('/ia', 302))->name('admin.dashboard');
+        Route::get('/dashboard', [DashboardController::class, 'index'])
             ->middleware('throttle:60,1')
-            ->name('admin.dashboard');
+            ->name('admin.dashboard.legacy');
 
         // Policies CRUD (mcp_governance_rules) — throttle defensivo:
         // read 60/min, toggle 10/min (operação sensível afeta enforcement runtime)

--- a/Modules/NFSe/Http/Controllers/DataController.php
+++ b/Modules/NFSe/Http/Controllers/DataController.php
@@ -91,73 +91,11 @@ class DataController extends Controller
             return;
         }
 
-        // Agrupamento visual em "FISCAL" acontece no frontend (SIDEBAR_GROUPS
-        // em resources/js/Components/cockpit/Sidebar.tsx). DataController
-        // publica o dropdown standalone do módulo.
-        $background_color = config('app.env') == 'demo' ? '#a8d8ea' : '';
-        $segmento_ativo   = request()->segment(1) == 'nfse';
-
-        Menu::modify(
-            'admin-sidebar-menu',
-            function ($menu) use ($background_color, $segmento_ativo) {
-                // ADR 0180 Fase 4 Wave D FINANÇAS+PESSOAS (2026-05-21): entry NFSe
-                // é ghost do módulo principal Fiscal/NfeBrasil — sem shortcut próprio
-                // (apenas NfeBrasil G X). Primary action "Emitir NFSe" + ghosts
-                // espelham sub-views próprias declarados pro frontend Sidebar.tsx.
-                $menu->dropdown(
-                    'NFSe',
-                    function ($sub) {
-                        // Listagem (US-NFSE-008)
-                        $sub->url(
-                            url('/nfse'),
-                            'Notas Emitidas',
-                            [
-                                'icon'   => 'fa fas fa-list',
-                                'active' => request()->segment(1) == 'nfse' && ! request()->segment(2),
-                            ]
-                        );
-
-                        // Emissão (US-NFSE-009)
-                        if (auth()->user()->can('superadmin') || auth()->user()->can('nfse.emit')) {
-                            $sub->url(
-                                url('/nfse/emitir'),
-                                'Emitir NFSe',
-                                [
-                                    'icon'   => 'fa fas fa-plus-circle',
-                                    'active' => request()->segment(2) == 'emitir',
-                                ]
-                            );
-                        }
-
-                        // Configurações (US-NFSE-014)
-                        if (auth()->user()->can('superadmin') || auth()->user()->can('nfse.settings')) {
-                            $sub->url(
-                                url('/nfse/config'),
-                                'Configurações',
-                                [
-                                    'icon'   => 'fa fas fa-cog',
-                                    'active' => request()->segment(2) == 'config',
-                                ]
-                            );
-                        }
-                    },
-                    [
-                        'icon'    => 'fa fas fa-file-invoice',
-                        'style'   => 'background-color:' . $background_color,
-                        'active'  => $segmento_ativo,
-                        'primary' => [
-                            'label'    => 'Emitir NFSe',
-                            'href'     => '/nfse/emitir',
-                            'shortcut' => 'N',
-                        ],
-                        'ghosts'  => [
-                            ['key' => 'notas-emitidas', 'label' => 'Notas Emitidas', 'href' => '/nfse'],
-                            ['key' => 'emitir',         'label' => 'Emitir NFSe',    'href' => '/nfse/emitir'],
-                            ['key' => 'config',         'label' => 'Configurações',  'href' => '/nfse/config'],
-                        ],
-                    ]
-                )->order(96);
-            }
-        );
+        // Wagner 2026-05-22: NFSe entry REMOVIDA do sidebar. Hub canon "Fiscal"
+        // (Modules/NfeBrasil) cobre NF-e + NFSe via tabs internas na tela
+        // /nfebrasil. NFSe continua acessível via URL direta /nfse (rotas
+        // intactas) e em ghost futuro do hub Fiscal quando unificarmos telas.
+        //
+        // Pattern espelha Modules/Fiscal e Modules/RecurringBilling (anteriores).
     }
 }

--- a/Modules/PaymentGateway/Http/Controllers/DataController.php
+++ b/Modules/PaymentGateway/Http/Controllers/DataController.php
@@ -96,26 +96,27 @@ class DataController extends Controller
         $segmento_settings = request()->segment(1) === 'settings'
             && request()->segment(2) === 'payment-gateways';
 
+        // Wagner 2026-05-22 fix: label hardcoded literal pra resolver bug i18n
+        // que mostrava 'paymentgateway:paymentga...' no sidebar. Lang file existe
+        // mas namespace `paymentgateway::` não carregava (OPcache Hostinger ou
+        // module discovery). Hardcode é exceção pragmática à regra "frontend
+        // não hardcode label" — DataController PHP pode hardcode quando lang
+        // resolve quebra em prod. group: 'financas' canon v3.
         Menu::modify('admin-sidebar-menu', function ($menu) use ($segmento_settings) {
-            // ADR 0180 Fase 4 Wave D FINANÇAS+PESSOAS (2026-05-21): entry é ghost
-            // do módulo principal Financeiro (G F) — sem shortcut próprio. Primary
-            // "Conectar gateway" + ghost single-element pra mante shape contratual
-            // (Wave A ProductCatalogue precedent — Sidebar.tsx aceita array 1-elem).
-            // group: 'fin' legacy preservado — LEGACY_GROUP_MAP cobre fin→financas v3.
             $menu->url(
                 url('/settings/payment-gateways'),
-                __('paymentgateway::paymentgateway.module_label'),
+                'Gateway de Pagamento',
                 [
                     'icon'    => 'fa fas fa-key',
                     'active'  => $segmento_settings,
-                    'group'   => 'fin',
+                    'group'   => 'financas',
                     'primary' => [
                         'label'    => 'Conectar gateway',
                         'href'     => '/settings/payment-gateways',
                         'shortcut' => 'N',
                     ],
                     'ghosts'  => [
-                        ['key' => 'payment-gateways', 'label' => 'Gateways de Pagamento', 'href' => '/settings/payment-gateways'],
+                        ['key' => 'payment-gateways', 'label' => 'Gateway de Pagamento', 'href' => '/settings/payment-gateways'],
                     ],
                 ]
             )->order(85.4);


### PR DESCRIPTION
Wagner 2026-05-22 sessão final — 3 fixes cirúrgicos.

| # | Mudança |
|---|---|
| 1 | PaymentGateway label hardcode 'Gateway de Pagamento' (resolve bug i18n `paymentgateway:paymentga...`) |
| 2 | NFSe entry REMOVIDA do sidebar (URL /nfse intacta) |
| 3 | GET /governance → 302 redirect /ia (dashboard preservado em /governance/dashboard) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)