### PR TITLE
feat(sidebar): remove Superadmin top-level + Catálogo QR→COMERCIAL + SISTEMA cleanup

### DIFF
--- a/Modules/Superadmin/Http/Controllers/DataController.php
+++ b/Modules/Superadmin/Http/Controllers/DataController.php
@@ -116,14 +116,11 @@ class DataController extends Controller
      */
     public function modifyAdminMenu()
     {
-        if (auth()->user()->can('superadmin')) {
-            Menu::modify(
-                'admin-sidebar-menu',
-                function ($menu) {
-                    $menu->url(action([\Modules\Superadmin\Http\Controllers\SuperadminController::class, 'index']), __('superadmin::lang.superadmin'), ['icon' => 'fa fas fa-users-cog', 'active' => request()->segment(1) == 'superadmin'])->order(1);
-                }
-            );
-        }
+        // Wagner 2026-05-22: entry "Superadmin" top-level REMOVIDA do sidebar.
+        // Cascade Superadmin do user menu rodapé (PR #1401) já dá acesso a
+        // Módulos/Backup/CMS/Conector/Office Impresso/Personalizar. Manter
+        // 1 entry top-level era duplicação. Tela /superadmin acessível via
+        // URL direta.
 
         if (auth()->user()->can('superadmin.access_package_subscriptions') && auth()->user()->can('business_settings.access')) {
             $menu = Menu::instance('admin-sidebar-menu');

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -151,8 +151,8 @@ const SIDEBAR_GROUPS: Array<{ key: string; label: string; items: string[] }> = [
   {
     key: 'comercial',
     label: 'COMERCIAL',
-    // Wagner 2026-05-22: só Crm + Vendas (Woocommerce REMOVIDO).
-    items: ['Crm', 'CRM', 'Vendas'],
+    // Wagner 2026-05-22: Crm + Vendas + Catalogue QR (Woocommerce removido).
+    items: ['Crm', 'CRM', 'Vendas', 'Catalogue QR', 'Catálogo QR'],
   },
   {
     key: 'financas',
@@ -186,8 +186,14 @@ const SIDEBAR_GROUPS: Array<{ key: string; label: string; items: string[] }> = [
   {
     key: 'sistema',
     label: 'SISTEMA',
-    // Wagner 2026-05-22: Auditoria adicionada (era módulo solto em MAIS).
-    items: ['Governança', 'Plataforma', 'Auditoria'],
+    // Wagner 2026-05-22: Auditoria/Modelos de notificação/Relatórios/Dashboard
+    // adicionados (eram módulos soltos em MAIS).
+    items: ['Governança', 'Plataforma', 'Auditoria',
+            'Modelos de notificação', 'Modelo de notificação',
+            'Relatórios', 'Dashboard',
+            // Superadmin top-level entry removida (PR #1407) — mantém alias
+            // pra futuros DataControllers que ainda declarem com esse label.
+            'Superadmin'],
   },
 ];
 


### PR DESCRIPTION
Wagner 2026-05-22:
- Superadmin top-level entry removida (cascade rodapé já cobre)
- Catálogo QR adicionado em COMERCIAL
- Modelos de notificação + Relatórios + Dashboard movidos pra SISTEMA

Pendentes (aguardando decisão): Fabricação onde? Woocommerce volta sidebar?

🤖 Generated with [Claude Code](https://claude.com/claude-code)