### PR TITLE
feat(sidebar): grupo FISCAL separado (8º grupo canon)

### DIFF
--- a/Modules/NfeBrasil/Http/Controllers/DataController.php
+++ b/Modules/NfeBrasil/Http/Controllers/DataController.php
@@ -160,7 +160,8 @@ class DataController extends Controller
                         'icon'     => 'fa fas fa-file-invoice-dollar',
                         'style'    => 'background-color:' . $background_color,
                         'active'   => $segmento_ativo,
-                        'group'    => 'financas',
+                        // Wagner 2026-05-22: FISCAL virou grupo próprio (era ghost de FINANÇAS).
+                        'group'    => 'fiscal',
                         'shortcut' => 'G X',
                         'primary'  => [
                             'label'    => 'Emitir NF-e',

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -114,6 +114,7 @@ const GROUP_ICON_MAP: Record<string, LucideIcon> = {
   cadastro:  BookOpen,      // cadastros/dados base
   comercial: ShoppingCart,  // vendas
   financas:  Wallet,        // dinheiro
+  fiscal:    FileText,      // NF-e/NFSe/SPED (Wagner 2026-05-22)
   producao:  Factory,       // fábrica/produção
   estoque:   Package,       // caixas/inventory
   pessoas:   Users,         // RH
@@ -173,7 +174,16 @@ const SIDEBAR_GROUPS: Array<{ key: string; label: string; items: string[] }> = [
   {
     key: 'financas',
     label: 'FINANÇAS',
-    items: ['Financeiro', 'Fiscal'],
+    // Wagner 2026-05-22: Fiscal SAI de FINANÇAS → vira grupo próprio FISCAL abaixo.
+    items: ['Financeiro'],
+  },
+  {
+    key: 'fiscal',
+    label: 'FISCAL',
+    // Wagner 2026-05-22: grupo FISCAL separado (8º grupo). Items via shell.menu
+    // do hub Fiscal (Modules/NfeBrasil declara group:'fiscal' agora).
+    items: ['Fiscal', 'Notas fiscais', 'NFSe', 'NF-e Brasil', 'NF-e',
+            'NFC-e', 'Manifestação', 'Certificado Digital'],
   },
   {
     key: 'producao',
@@ -661,7 +671,7 @@ export function SidebarMenu({ items, mode = 'expanded' }: { items: ShellMenuItem
           key={g.key}
           groupKey={g.key}
           label={g.label}
-          defaultOpen={['cadastro', 'comercial', 'estoque', 'producao', 'financas'].includes(g.key)}
+          defaultOpen={['cadastro', 'comercial', 'financas', 'fiscal', 'producao', 'estoque'].includes(g.key)}
         >
           {(groupedItems[g.key] ?? []).map((item, idx) => (
             <SidebarMenuItem key={`${item.label}-${idx}`} item={item} />

--- a/resources/js/Components/cockpit/shared.ts
+++ b/resources/js/Components/cockpit/shared.ts
@@ -175,10 +175,12 @@ export const SIDEBAR_GROUP_HUE: Record<string, number> = {
   pessoas: 295,      // roxo claro — RH (legacy key)
   sistema: 200,      // azul-acinzentado — governança + plataforma
 
-  // ── 7 grupos canon Wagner 2026-05-22 (CADASTRO·COMERCIAL·FINANÇAS·PRODUÇÃO·
-  //     ESTOQUE·RH·SISTEMA). Cores semanticamente mapeadas pra mental model PME-BR.
+  // ── 8 grupos canon Wagner 2026-05-22 (CADASTRO·COMERCIAL·FINANÇAS·FISCAL·
+  //     PRODUÇÃO·ESTOQUE·RH·SISTEMA). Cores semanticamente mapeadas pra mental
+  //     model PME-BR.
   cadastro: 220,     // azul — dados/registro
   comercial: 60,     // amarelo — energia comercial (= vender legacy)
+  fiscal: 165,       // verde-azulado — NF-e/NFSe/SPED (distinto de financas)
   producao: 350,     // magenta — fábrica/atividade (= operar legacy)
   estoque: 280,      // roxo profundo — caixas/inventory
 


### PR DESCRIPTION
Wagner 2026-05-22: "Acho que o grupo FISCAL não foi feito?" → cria grupo próprio (era item dentro de FINANÇAS).

| Aspecto | Valor |
|---|---|
| Hue OKLCH | 165 (verde-azulado) |
| Ícone | FileText |
| Items | Fiscal · Notas fiscais · NFSe · NF-e Brasil · NFC-e · Manifestação · Certificado Digital |
| Position | Entre FINANÇAS e PRODUÇÃO |

8 grupos canon: CADASTRO · COMERCIAL · FINANÇAS · **FISCAL** · PRODUÇÃO · ESTOQUE · RH · SISTEMA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)