### PR TITLE
fix(p3): remove entry 'Compras' duplicada do middleware core

### DIFF
--- a/Modules/Governance/Http/Controllers/DataController.php
+++ b/Modules/Governance/Http/Controllers/DataController.php
@@ -88,12 +88,17 @@ class DataController extends Controller
             // ADR 0180 v3 — entry vive no grupo canon `sistema` (acoplado em Governança
             // visual no frontend). ADS/Auditoria/Cms/Connector/Officeimpresso são ghosts
             // virtuais agrupados pela Sidebar.tsx no mesmo cabeçalho `sistema`.
+            // Wagner 2026-05-22 P2: hub Governance canon entry em SISTEMA + ghost
+            // dashboard ajustado pra /governance/dashboard (legacy preservado), pq
+            // /governance raiz virou redirect pra /ia (PR #1403).
+            // URL principal volta a apontar /governance/dashboard pra evitar redirect.
             $menu->url(
-                action(['\\Modules\\Governance\\Http\\Controllers\\DashboardController', 'index']),
+                '/governance/dashboard',
                 __('governance::governance.governance'),
                 [
                     'icon'     => 'fa fa-shield',
                     'active'   => request()->is('governance*'),
+                    'group'    => 'sistema',
                     'shortcut' => 'G G',
                     'primary'  => [
                         'label'    => 'Gerenciar policies',
@@ -101,7 +106,7 @@ class DataController extends Controller
                         'shortcut' => 'P',
                     ],
                     'ghosts'   => [
-                        ['key' => 'dashboard',     'label' => 'Painel',          'href' => '/governance'],
+                        ['key' => 'dashboard',     'label' => 'Painel',          'href' => '/governance/dashboard'],
                         ['key' => 'policies',      'label' => 'Policies',        'href' => '/governance/policies'],
                         ['key' => 'audit',         'label' => 'Audit log',       'href' => '/governance/audit'],
                         ['key' => 'drift',         'label' => 'Drift alerts',    'href' => '/governance/drift'],

--- a/Modules/Jana/Http/Controllers/DataController.php
+++ b/Modules/Jana/Http/Controllers/DataController.php
@@ -250,6 +250,9 @@ class DataController extends Controller
                             ['key' => 'custos',    'label' => 'Custos',    'href' => '/ia/admin/custos'],
                             // Wagner 2026-05-22: ADS vai pra dentro da Jana (entry sidebar removida).
                             ['key' => 'ads',       'label' => 'ADS',       'href' => '/ads'],
+                            // Wagner 2026-05-22 P2: zera 2 órfãs (telas Jana Admin Governança + Qualidade).
+                            ['key' => 'governanca-jana', 'label' => 'Governança Jana', 'href' => '/ia/admin/governanca'],
+                            ['key' => 'qualidade-jana',  'label' => 'Qualidade IA',    'href' => '/ia/admin/qualidade'],
                         ],
                     ]
                 )->order(90); // Logo após PontoWr2 (88)

--- a/app/Http/Middleware/AdminSidebarMenu.php
+++ b/app/Http/Middleware/AdminSidebarMenu.php
@@ -282,13 +282,18 @@ class AdminSidebarMenu
                                 ['icon' => '', 'active' => request()->segment(1) == 'purchase-order']
                             );
                         }
-                        if (auth()->user()->can('purchase.view') || auth()->user()->can('view_own_purchase')) {
-                            $sub->url(
-                                action([\App\Http\Controllers\PurchaseController::class, 'index']),
-                                __('purchase.list_purchase'),
-                                ['icon' => '', 'active' => request()->segment(1) == 'purchases' && request()->segment(2) == null]
-                            );
-                        }
+                        // Wagner 2026-05-22 P3: entry "List Purchase" → /purchases REMOVIDA.
+                        // Duplicava com Modules/Compras canon (entry "Compras" → /compras).
+                        // Rota /purchases continua funcionando (tela Blade legacy + sub-rotas
+                        // create/edit/return/etc preservadas abaixo). Apenas o item no menu
+                        // some pra evitar 2 "Compras" no sidebar.
+                        // if (auth()->user()->can('purchase.view') || auth()->user()->can('view_own_purchase')) {
+                        //     $sub->url(
+                        //         action([\App\Http\Controllers\PurchaseController::class, 'index']),
+                        //         __('purchase.list_purchase'),
+                        //         ['icon' => '', 'active' => request()->segment(1) == 'purchases' && request()->segment(2) == null]
+                        //     );
+                        // }
                         if (auth()->user()->can('purchase.create')) {
                             $sub->url(
                                 action([\App\Http\Controllers\PurchaseController::class, 'create']),


### PR DESCRIPTION
Wagner P3: 2 entries Compras no sidebar (core /purchases + canon /compras). Comenta entry core. Rotas continuam funcionando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)