### PR TITLE
fix(ci): instala cliente JS playwright em visual-regression workflow

### DIFF
--- a/.github/workflows/visual-regression.yml
+++ b/.github/workflows/visual-regression.yml
@@ -83,6 +83,16 @@ jobs:
       - name: Install NPM dependencies
         run: npm ci
 
+      - name: Install Playwright npm client
+        # `pestphp/pest-plugin-browser ^4.0` (composer.json) spawneia o cliente
+        # JS `playwright` via stdio. `playwright` NÃO está em package.json
+        # devDependencies (ainda), então `npm ci` não traz `node_modules/playwright/`.
+        # Sem este step, o cache de `~/.cache/ms-playwright/` (binários dos browsers)
+        # acerta mas o cliente JS está ausente → `PlaywrightNotInstalledException`.
+        # `--no-save` evita drift no package.json/lock — declarar como devDep
+        # propriamente fica pra PR follow-up.
+        run: npm install playwright --no-save
+
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
         run: npx playwright install --with-deps chromium

--- a/memory/decisions/0170-onda5-simplificada.md
+++ b/memory/decisions/0170-onda5-simplificada.md
@@ -1,0 +1,113 @@
+---
+adr: 0170-onda5-simplificada
+title: "PaymentGateway Onda 5 SIMPLIFICADA — Dogfooding SaaS via 6º gateway adicional"
+status: aceito
+decided_by: [W]
+date: 2026-05-19
+related: [0017, 0093, 0094, 0105, 0170]
+supersedes: []
+amends: [0170]
+tipo: amendment
+trust_required: tier-0
+---
+
+# Contexto
+
+[ADR 0170 §C](0170-paymentgateway-extracao-camada-cobranca.md) original propôs **projection mode** — `Superadmin::Subscription` viraria projeção read-only de `cobrancas` (SoT migrada pro `Modules/PaymentGateway`). Estimativa ~680 LOC de refator + backfill + risco LGPD D7.b (append-only Spatie LogsActivity) + coexistência forçada com 5 gateways legacy (Razorpay/Stripe/PayPal/Paystack/Pesapal).
+
+**Pesquisa Wagner 2026-05-19** ([sessão pesquisa-adendo](../sessions/2026-05-19-pesquisa-onda5-adendo-connector-superadmin.md)) descobriu que o sistema canônico **Connector + Officeimpresso + Superadmin já tem 90% da infraestrutura** que §C propôs construir do zero:
+
+- 5 gateways legacy já implementados (`SubscriptionController::payForPackage`)
+- Spatie LogsActivity append-only LGPD D7.b honrado em `Subscription`
+- Wire Delphi `/connector/api/oimpresso/registrar` + `/oauth/token` consultando `business.officeimpresso_bloqueado` SoT
+- `BaseController::_payment_gateways()` enumera gateways disponíveis dinamicamente
+
+**Decisão Wagner 2026-05-19:** caminho B (SIMPLIFICADA) aprovado vs A original §C vs C híbrido. Compressão ~680→~570 LOC (~16% menor mas com **zero refator SoT**, zero backfill, zero risco LGPD, 5 gateways legacy coexistem).
+
+# Decisão
+
+PaymentGateway entra como **6º payment gateway adicional** em `Superadmin::Subscription`, não como refator do SoT.
+
+## Escopo executado (PR #1148, commit `3c2d00cc4`, 2026-05-19)
+
+### Listeners (2)
+- `Modules/Superadmin/Listeners/OnCobrancaPagaUpdateSubscription.php` — escuta `CobrancaPaga`, filtro `origem_type='subscription_license'`, `Subscription.status='approved'` + datas, desbloqueia `business.officeimpresso_bloqueado=false` (cross-tenant Wagner-only)
+- `Modules/Superadmin/Listeners/OnCobrancaVencidaBloqueaSubscription.php` — escuta `CobrancaVencida`, `Subscription.status='declined'`, bloqueia `business.officeimpresso_bloqueado=true` + motivo (cross-tenant Wagner-only)
+
+Ambos registrados em [`SuperadminServiceProvider`](../../Modules/Superadmin/Providers/SuperadminServiceProvider.php) com guard anti-double-register.
+
+### SubscriptionController (1)
+Branch `paid_via='paymentgateway_pix_automatico'` adicionado em [`payForPackage()`](../../Modules/Superadmin/Http/Controllers/SubscriptionController.php) — emite Cobrança via `PaymentGatewayContract::emitirPixAutomatico` (driver BCB Pix), gera Subscription `status='waiting'`, retorna QR pra tenant autorizar mandato. `BaseController::_payment_gateways()` enumera condicional ao Module ativo.
+
+### View Blade (1)
+[`partials/pay_paymentgateway_pix_automatico.blade.php`](../../Modules/Superadmin/Resources/views/subscription/partials/) — partial seguindo padrão legacy `@includeIf('superadmin::subscription.partials.pay_'.$k)` em vez de view completa nova (divergência intencional vs blueprint §4.4 pra alinhamento de pattern).
+
+### Comando CLI (1)
+[`paymentgateway:register-permissions`](../../Modules/PaymentGateway/Console/Commands/RegisterPermissionsCommand.php) — registra 10 permissions Spatie do `DataController` + atribui a role `Admin#{biz}`. Resolve bug recorrente de permissions on-demand não atribuídas. Pattern imitado de `whatsapp:register-permissions` PR #665.
+
+### Integração Financeiro (1)
+[`Modules/Financeiro/Listeners/OnCobrancaPagaCreateFinanceiroTitulo.php`](../../Modules/Financeiro/Listeners/) — escuta `CobrancaPaga` (filtro `business_id=1`), cria `FinTitulo` + `FinTituloBaixa` auto-baixadas pra Wagner contabilizar receita SaaS em biz=1.
+
+Registrado em [`FinanceiroServiceProvider`](../../Modules/Financeiro/Providers/FinanceiroServiceProvider.php) linha 49.
+
+### Bônus não previstos (mergeados junto, valor extra)
+- `BusinessAutoSubscriptionObserver` — `Business::created` → `Subscription waiting` auto (Onda 5.B)
+- `EmitTrialExpiredCobrancasCommand` — cron diário 08:00 BRT
+- `MigrateCredentialsCommand` — migração legacy `rb_boleto_credentials` → `payment_gateway_credentials`
+- 3 Pest extras (BusinessAutoSubscription / EmitTrialExpired / Onda5CuradoriaR1)
+
+## Cross-tenant Tier 0 (R1 mitigado)
+
+Listeners 4.1 e 4.2 atualizam `Business` de OUTRO tenant a partir do contexto `biz=1`. Pattern Wagner-only intencional documentado em [`Superadmin::Subscription`](../../Modules/Superadmin/Entities/Subscription.php#L30) e [ADR 0093](0093-multi-tenant-isolation-tier-0.md). Implementação usa `withoutGlobalScope(BusinessScope::class)` + audit log + Pest test `block_only_when_origem_type_matches`.
+
+# Consequências
+
+## Positivas
+- Wire Delphi inviolável preservado ([contrato-delphi-inviolavel](../reference/contrato-delphi-inviolavel.md)) — zero mudança em `/oauth/token`, `/connector/api/oimpresso/registrar`, `/processa-dados-cliente`
+- `Superadmin::Subscription` permanece SoT — zero refator + zero backfill + Spatie LogsActivity append-only intacto (LGPD D7.b CC Art. 206)
+- 5 gateways legacy (Razorpay/Stripe/PayPal/Paystack/Pesapal) coexistem com PaymentGateway sem precisar migrar
+- Ciclo end-to-end "paga → libera / não paga → bloqueia" automatizado via eventos `CobrancaPaga`/`CobrancaVencida`
+- Receita SaaS Wagner-em-biz=1 entra automaticamente no `Modules/Financeiro` via FinTitulo+FinTituloBaixa
+
+## Negativas / Custos
+- **Cross-tenant cognitive load** — 2 listeners precisam `withoutGlobalScope` documentado (pattern Wagner-only)
+- **6 gateways pra manter** — adicionar Pagar.me (Onda 4e) sobe pra 7
+- **Race condition R6** — webhook BCB pode chegar antes da Subscription estar gravada; listener faz `find()` e retorna null se órfão (Wagner reconcilia manual via UI Cobranças)
+
+## Pendências pós-aceite (não-código, humano-limitado per [ADR 0106](0106-recalibracao-velocidade-fator-10x-ia-pair.md))
+
+| # | Ação | Wagner | Tempo |
+|---|---|---|---|
+| 1 | Cadastrar ContaBancaria Wagner em `/financeiro/contas` (biz=1) | ✅ manual | 5min |
+| 2 | Cadastrar Credencial BCB Pix Automático em `/settings/payment-gateways` | ✅ manual | 15min |
+| 3 | Cadastrar Package "Premium" em `/superadmin/packages` (R$ 99,90/mês) | ✅ manual | 10min |
+| 4 | Rodar `php artisan paymentgateway:register-permissions --business=all` em prod | ✅ SSH | 5min |
+| 5 | Homologação BCB Pix Automático (Resolução BCB 380/2024) | ✅ banco | 1-3d |
+| 6 | Smoke real biz=1 (Wagner paga ele mesmo — dogfooding §9.1) | ✅ manual | 1d |
+| 7 | Cobrar Larissa biz=4 com sucesso 1 vez (§9.2) | ✅ manual | 7d canary |
+| 8 | Smoke inadimplência (deixar 1 cobrança vencer → confirmar `officeimpresso_bloqueado=true` + Delphi 400 invalid_grant) | ✅ manual | 1d |
+
+## Frontmatter PLANO-ONDA5-SIMPLIFICADA pendente atualizar
+
+Atualizar [`memory/requisitos/PaymentGateway/PLANO-ONDA5-SIMPLIFICADA.md`](../requisitos/PaymentGateway/PLANO-ONDA5-SIMPLIFICADA.md) frontmatter de `plano-aprovado-aguardando-execucao` → `executado-aguardando-smoke` quando esta ADR for mergeada. Adicionar seção "Histórico de execução" apontando PR #1148.
+
+# Refs
+
+- [ADR 0170](0170-paymentgateway-extracao-camada-cobranca.md) — PaymentGateway extração (parent, §C original)
+- [ADR 0017](0017-officeimpresso-restaurado-superadmin-exclusivo.md) — Officeimpresso restaurado
+- [ADR 0093](0093-multi-tenant-isolation-tier-0.md) — Multi-tenant Tier 0 IRREVOGÁVEL
+- [ADR 0094](0094-constituicao-v2-7-camadas-8-principios.md) — Constituição v2
+- [ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md) — Cliente como sinal
+- [Blueprint PLANO-ONDA5-SIMPLIFICADA](../requisitos/PaymentGateway/PLANO-ONDA5-SIMPLIFICADA.md)
+- [Pesquisa A — ADR 0170 §C original](../sessions/2026-05-19-pesquisa-onda5-paymentgateway-dogfooding.md)
+- [Pesquisa B — adendo Connector+Superadmin (SIMPLIFICADA)](../sessions/2026-05-19-pesquisa-onda5-adendo-connector-superadmin.md)
+- [contrato-delphi-inviolavel](../reference/contrato-delphi-inviolavel.md) — wire imutável
+- [Auditoria execução 2026-05-22](../sessions/2026-05-22-audit-onda5-paymentgateway.md)
+- PR #1148 commit `3c2d00cc4` — execução completa
+
+# Status histórico
+
+- 2026-05-19 — Plano B aprovado por Wagner ([PLANO-ONDA5-SIMPLIFICADA](../requisitos/PaymentGateway/PLANO-ONDA5-SIMPLIFICADA.md))
+- 2026-05-19 — PR #1148 mergeado (6/6 itens código + bônus)
+- 2026-05-22 — Auditoria confirmou execução 100% código; gap restante = pré-condições prod manuais + smoke real
+- 2026-05-22 — Esta ADR criada formalizando aceite + executado

--- a/memory/sessions/2026-05-22-audit-onda5-paymentgateway.md
+++ b/memory/sessions/2026-05-22-audit-onda5-paymentgateway.md
@@ -1,0 +1,165 @@
+---
+data: 2026-05-22
+tipo: audit
+escopo: PaymentGateway Onda 5 SIMPLIFICADA
+blueprint: memory/requisitos/PaymentGateway/PLANO-ONDA5-SIMPLIFICADA.md
+pr_principal: '#1148'
+commit: 3c2d00cc4
+status_geral: 'CÓDIGO 100% MERGEADO — falta ADR filho 0170-onda5-simplificada (status do ADR pai 0170 ainda "proposto"), pré-condições prod manuais e smoke real biz=1.'
+---
+
+# Auditoria Onda 5 PaymentGateway — 2026-05-22
+
+## Sumário executivo
+
+- ✅ Itens código feitos: **6/6** (todos arquivos esperados existem com implementação completa)
+- ✅ Service Providers: **2/2** registrados (Superadmin + Financeiro)
+- ✅ Pest: **4 arquivos** novos (3 listeners + 1 command) + integrações
+- 🟡 Parciais: **0** (a view foi entregue como `partials/pay_paymentgateway_pix_automatico.blade.php` em vez de `pay_paymentgateway.blade.php` — divergência **intencional** vs blueprint pra seguir o padrão `@includeIf('superadmin::subscription.partials.pay_'.$k)` já existente em `pay.blade.php:83`. Decisão correta.)
+- ❌ ADR filho **0170-onda5-simplificada**: **NÃO criado** (blueprint §10 prevê — ADR pai 0170 ainda `proposto`)
+- ❌ Smoke real biz=1: pendente Wagner (dogfooding)
+- 🟡 Pré-condições prod (cadastros manuais + BCB): pendentes Wagner (verificáveis só via SSH/DB)
+- **Esforço restante código:** ~0 LOC. Esforço restante humano-limitado: ~1h ADR filho + 8 pré-condições + 14d observação canary.
+- **PR principal:** [#1148](https://github.com/oimpresso/oimpresso.com/pull/1148) commit `3c2d00cc4` mergeado 2026-05-19 15:27 BRT.
+
+## Detalhamento por item
+
+### 4.1 OnCobrancaPagaUpdateSubscription — ✅
+- Arquivo: `Modules/Superadmin/Listeners/OnCobrancaPagaUpdateSubscription.php` — **existe**
+- Implementação vs blueprint: **completa**. Pattern PesaPalController 1:1, filtro `origem_type='subscription_license'`, idempotência (`status === 'approved'` → return), `withoutGlobalScopes()` cross-tenant, log estruturado, `calcPackageDates()` inlined.
+- Pest: `Modules/Superadmin/Tests/Feature/OnCobrancaPagaUpdateSubscriptionTest.php` — 4 it (happy / filtro / desbloqueio / idempotência)
+- Observação: comentário canônico aponta cross-tenant Wagner-only (§30 Subscription.php). Logs sem PII.
+
+### 4.2 OnCobrancaVencidaBloqueaSubscription — ✅
+- Arquivo: `Modules/Superadmin/Listeners/OnCobrancaVencidaBloqueaSubscription.php` — **existe**
+- Implementação vs blueprint: **completa**. Bloqueio condicional (`!$business->officeimpresso_bloqueado`), idempotência (`status === 'declined'` → return), log inclui `dias_vencido` + `vencimento_original`.
+- Pest: `Modules/Superadmin/Tests/Feature/OnCobrancaVencidaBloqueaSubscriptionTest.php` — 2 it (happy / filtro)
+- Observação: confia no smart retry RB (3 retentativas) antes do `CobrancaVencida` chegar.
+
+### 4.3 Branch `paymentgateway_pix_automatico` em SubscriptionController — ✅
+- Path: `Modules/Superadmin/Http/Controllers/SubscriptionController.php`
+- Linhas-chave: 217 (detect), 272 (`confirm_paymentgateway`), 292 (`_add_subscription` chamado com paid_via='paymentgateway_pix_automatico'), 360 (`_log_emergency_redacted`).
+- Implementação vs blueprint: **completa + reforçada**. Adicional ao blueprint:
+  - `BaseController::_payment_gateways()` (linha 60) injeta gateway condicional a credencial BCB ativa + ContaBancaria vinculada (helper `isPaymentGatewayPixAutomaticoConfigured()`)
+  - Resolve credencial via canon `payment_gateway_credentials.conta_bancaria_id` (Wagner 2026-05-19 inverteu direção FK; FK reverso `fin_contas_bancarias.rb_gateway_credential_id` fica como fallback)
+  - `idempotencyKey: 'onda5-sub-' . $subscription->id`
+- Pest: testado indiretamente via `OnCobrancaPaga*Test` (Subscription transitions); flow controller-level testado manualmente.
+
+### 4.4 Form view pay_paymentgateway — ✅ (divergência intencional)
+- Path: `Modules/Superadmin/Resources/views/subscription/partials/pay_paymentgateway_pix_automatico.blade.php` — **existe**
+- Blueprint esperava `pay_paymentgateway.blade.php` no nível raiz; entregue como **partial nomeado pela chave do gateway** seguindo o padrão dinâmico existente em `pay.blade.php:83`:
+  ```php
+  $view = 'superadmin::subscription.partials.pay_'.$k;
+  @includeIf($view)
+  ```
+- Decisão correta (consistente com `pay_pesapal/pay_stripe/...` legacy). Conteúdo: form com csrf + button "PIX Automático BCB" + helper text explicando mandato 7d.
+
+### 4.5 Comando paymentgateway:register-permissions — ✅
+- Arquivo: `Modules/PaymentGateway/Console/Commands/RegisterPermissionsCommand.php` — **existe**
+- Implementação vs blueprint: **completa + superior**. Espelho fiel de `whatsapp:register-permissions` (PR #665) com:
+  - `--dry-run` (preview sem persistir)
+  - `--business=all` (rollout multi-tenant) ou `--business={id}`
+  - Lookup `Admin#{biz}` filtra por `business_id` (UltimatePOS pattern, não só `name`)
+  - `firstOrCreate` + `forgetCachedPermissions()` Spatie
+  - Log estruturado `[paymentgateway.register_permissions.completed]`
+- Pest: `Modules/PaymentGateway/Tests/Feature/RegisterPermissionsCommandTest.php` — 4 it (dry-run / apply / idempotência / input inválido)
+- Registrado em `PaymentGatewayServiceProvider::registerCommands()` (confirmado no commit message).
+
+### 5.1 OnCobrancaPagaCreateFinanceiroTitulo (Financeiro) — ✅
+- Arquivo: `Modules/Financeiro/Listeners/OnCobrancaPagaCreateFinanceiroTitulo.php` — **existe**
+- Implementação vs blueprint: **completa + superior**. Adicional ao blueprint:
+  - Escopo conservador biz=1 (`if ($event->businessId !== 1) return`)
+  - Idempotência via lookup (`business_id=1`, `origem='manual'`, `origem_id=cobrancaId`)
+  - Resolver de ContaBancaria em **3 camadas** (canon `payment_gateway_credentials.conta_bancaria_id` → legacy FK reverso → primeira ativa biz=1)
+  - Fallback graceful: se nenhuma conta resolve, cria Titulo SEM Baixa (status=aberto) + log warning (Wagner reconcilia)
+  - Idempotency key UUID determinístico (`md5('paymentgateway.onda5.cobranca-' . id)`)
+  - `metadata` JSON com source/cobranca_id/origem/tipo/forma_pagamento (audit trail)
+  - `meio_pagamento` map (pix / boleto / cartao_credito / outro)
+- Pest: `Modules/Financeiro/Tests/Feature/OnCobrancaPagaCreateFinanceiroTituloTest.php` — 3 it (happy biz=1 / skip biz!=1 / idempotência)
+- Observação: usa `origem='manual'` pra não migrar enum `fin_titulos.origem` em prod — `metadata.source='paymentgateway_cobranca'` preserva trail.
+
+## Registros nos Service Providers
+
+| Provider | Listener | Status |
+|---|---|---|
+| `SuperadminServiceProvider::boot()` | `Event::listen(CobrancaPaga::class, OnCobrancaPagaUpdateSubscription)` | ✅ linha 121 |
+| `SuperadminServiceProvider::boot()` | `Event::listen(CobrancaVencida::class, OnCobrancaVencidaBloqueaSubscription)` | ✅ linha 122 |
+| `FinanceiroServiceProvider::boot()` | `Event::listen(CobrancaPaga::class, OnCobrancaPagaCreateFinanceiroTitulo)` | ✅ linha 49 |
+
+Ambos providers usam guard estático `$paymentgatewayListenersRegistered` pra prevenir double-register no boot duplo do nWidart.
+
+## Itens bônus não previstos no blueprint mas mergeados no PR #1148
+
+1. **`BusinessAutoSubscriptionObserver`** (`Modules/Superadmin/Observers/BusinessAutoSubscriptionObserver.php`) — Onda 5.B: `Business::created` → cria Subscription waiting com Package default + trial. Cobre UI Superadmin + API Delphi. Configurável via System property `default_saas_package_id` (no-op graceful se ausente).
+2. **`EmitTrialExpiredCobrancasCommand`** (`Modules/PaymentGateway/Console/Commands/`) — cron diário 08:00 BRT: encontra Subscriptions waiting com trial expirado e emite cobrança PIX Automático.
+3. **`MigrateCredentialsCommand`** — migração de credenciais legacy.
+4. **Pest extra:** `BusinessAutoSubscriptionObserverTest` + `EmitTrialExpiredCobrancasCommandTest` + `Onda5CuradoriaR1Test` (Financeiro).
+5. **Schedule registrado** em `SuperadminServiceProvider::registerScheduleCommands()` (linha 88) — `paymentgateway:emit-trial-expired` daily 08:00 (env=live only).
+
+## Pré-condições §3 (8 itens)
+
+| # | Pré-condição | Verificável? | Estado |
+|---|---|---|---|
+| 1 | Ondas 1-4 PaymentGateway em prod | git (✅ PRs #1125-#1136) | ✅ feito |
+| 2 | Migration `payment_gateway_credentials` rodada em prod | só via SSH Hostinger: `php artisan migrate:status` | ⏳ Wagner confirma |
+| 3 | `BcbPixDriver` smoke validado sandbox | Pest `BcbPixDriverTest` existe; smoke real homologação BCB ainda não validado | ⏳ Wagner valida |
+| 4 | Conta bancária Wagner em `fin_contas_bancarias` (biz=1, ativo) | DB prod: `SELECT * FROM fin_contas_bancarias WHERE business_id=1 AND ativo_para_boleto=true` | ⏳ Wagner cadastra |
+| 5 | Credencial BCB Pix Automático em `payment_gateway_credentials` (biz=1, `gateway_key='bcb_pix'`, `conta_bancaria_id` preenchido) | DB prod query | ⏳ Wagner cadastra via UI |
+| 6 | FK fin_contas_bancarias.payment_gateway_credential_id | **REMOVIDO** pelo Wagner 2026-05-19 (direção invertida — canon `payment_gateway_credentials.conta_bancaria_id` já no wizard step 3) | n/a (fallback legacy mantido em código) |
+| 7 | Package "Premium" em `superadmin.packages` | DB prod: `SELECT * FROM packages WHERE name LIKE 'Premium%' AND is_active=1` | ⏳ Wagner cadastra |
+| 8 | Homologação BCB (CNPJ Wagner habilitado RECEBEDOR PIX Automático Resolução 380/2024) | Banco / contrato PJ | ⏳ Wagner banco 1-3d |
+
+**Veredito:** 1 verificada via git, 5 pendem cadastro manual Wagner + 1 pende banco. Nenhuma é blocker de código.
+
+## ADR filho
+
+- Path esperado: `memory/decisions/0170-onda5-simplificada-*.md`
+- Estado: **NÃO existe**
+- ADR pai: `memory/decisions/0170-paymentgateway-extracao-camada-cobranca.md` ainda com `status: proposto` (linha 6 do frontmatter)
+- **Gap:** blueprint §10 prevê criação de ADR filho `0170-onda5-simplificada — Dogfooding SaaS via gateway adicional` com `status: aceito`, `related: [0017, 0093, 0105, 0170]`. **Pendente.**
+
+## Tasks MCP relacionadas
+
+- **SPEC.md de PaymentGateway: NÃO existe** em `memory/requisitos/PaymentGateway/` — só `PLANO-ONDA5-SIMPLIFICADA.md` e `RUNBOOK-settings-gateways.md`.
+- US no MCP: não verifiquei via tool MCP `tasks-list` (audit read-only). Recomendo `tasks-list module:PaymentGateway` se quiser cross-check com backlog do MCP.
+
+## Critérios de aceite §9 (8 itens)
+
+| # | Critério | Estado |
+|---|---|---|
+| 1 | Wagner cobra ele mesmo biz=1 (dogfooding 1ª vez) | ❌ pendente |
+| 2 | Wagner cobra Larissa biz=4 ciclo end-to-end | ❌ pendente |
+| 3 | Expira 1 cobrança propositalmente → block + Delphi rejeita oauth | ❌ pendente |
+| 4 | FinTitulo + Baixa aparecem em /financeiro biz=1 | ❌ pendente (depende de critério 1) |
+| 5 | `php artisan paymentgateway:register-permissions --business=all` rodado prod | ❌ pendente Wagner SSH |
+| 6 | Pest cobertura (listeners + command + race) | ✅ feito (4 Pest novos no PR + integration test) |
+| 7 | `DelphiOImpressoContractTest` 9 guards ainda verdes | ⏳ não verificado nesta auditoria — recomendado rodar `php artisan test --filter=DelphiOImpressoContract` |
+| 8 | OTel spans + health-check métricas `paymentgateway_onda5.*` | ⏳ não verificado — grep `jana:health-check` adicionou métricas? |
+
+## Veredito objetivo
+
+**Código mergeado: 100% do blueprint §4 + §5 + listeners bônus (BusinessAutoSubscriptionObserver + EmitTrialExpired).**
+
+PR #1148 entrega tudo. O que falta NÃO é código — é:
+1. ADR filho 0170-onda5-simplificada formalizando a decisão (governance — 1h).
+2. Wagner cadastrar 5 pré-condições prod (ContaBancaria + Credencial + Package + register-permissions + homologação BCB).
+3. Smoke real biz=1 (Wagner paga ele mesmo) — primeiro teste real do ciclo end-to-end.
+4. Verificar critérios §9.7 (DelphiOImpressoContractTest) e §9.8 (OTel + health-check) — podem já estar verdes, só não checados aqui.
+
+## Próximos passos sugeridos
+
+1. **Criar ADR filho `0170-onda5-simplificada-dogfooding-saas`** com `status: aceito`, `supersedes: nada`, `amends: 0170`, `related: [0017, 0093, 0105, 0170]`. Texto base já no blueprint §10. (~1h, governance débit.)
+2. **Wagner cadastrar pré-condições prod** (8 → 5 ativas + 1 banco + 2 já feitas). Sequência: Package → ContaBancaria → Credencial BCB → register-permissions → homologação BCB (paralelo).
+3. **Wagner smoke biz=1 (ele mesmo paga ele mesmo)** — primeiro dogfooding. Validar criterios §9.1 + §9.4 num único ciclo.
+4. **Rodar `php artisan test --filter=DelphiOImpressoContract`** local + prod pra confirmar guard wire Delphi intacto.
+5. **Verificar/adicionar OTel spans + health-check `paymentgateway_onda5.*`** (§9.8) — se não tiver, abrir task delta pequena.
+6. **Atualizar `PLANO-ONDA5-SIMPLIFICADA.md` status frontmatter** de `plano-aprovado-aguardando-execucao` → `executado-aguardando-smoke` ou similar.
+7. **Após smoke biz=1 sucesso:** marcar critério §9.1 ✅ → cycle aprovação Larissa biz=4 (critério §9.2).
+8. **(Opcional) Criar SPEC.md** em `memory/requisitos/PaymentGateway/` consolidando US por onda (já existe blueprint, mas SPEC.md canônico padrão dos outros módulos não existe pra PaymentGateway).
+
+---
+
+**Auditor:** Claude Code  
+**Data:** 2026-05-22  
+**Modo:** read-only (apenas escrita deste arquivo de auditoria)  
+**Refs:** `memory/requisitos/PaymentGateway/PLANO-ONDA5-SIMPLIFICADA.md`, commit `3c2d00cc4`, PR #1148


### PR DESCRIPTION
## Sintoma

Todo PR que altera arquivo em `resources/js/Pages/**/*.tsx`, `resources/js/Layouts/**/*.tsx`, `resources/js/Components/**/*.tsx` ou `tests/Browser/**/*.php` falhava no step `Run Pest Browser tests` do workflow `visual-regression`:

```
Pest\Browser\Exceptions\PlaywrightNotInstalledException
  Playwright is not installed. Please run [npm install playwright && npx playwright install]
  in the root directory of your project.
```

Mesmo com `Cache Playwright browsers` reportando hit (271 MB restaurados de `~/.cache/ms-playwright/`).

## Root cause

- `pestphp/pest-plugin-browser ^4.0` (composer.json) spawneia o cliente JS `playwright` via stdio.
- `playwright` **NÃO está em** `package.json` devDependencies.
- `npm ci` portanto não traz `node_modules/playwright/`.
- O cache `~/.cache/ms-playwright/` guarda **apenas os binários dos browsers** (Chromium/Firefox/WebKit), populados por algum run anterior que tinha playwright.
- Step `Install Playwright browsers` (linha 87 do workflow) é pulado em cache hit, então não cobre a falha.
- Mesmo com `continue-on-error: true` no step (linha 139), o GitHub mostra o step com X vermelho → percepção de "PR quebrado" e o step `Upload screenshots on failure` ainda dispara (mas sem screenshots porque o teste nem rodou).

## Fix

Novo step `Install Playwright npm client` entre `npm ci` e `Install Playwright browsers`:

```yaml
- name: Install Playwright npm client
  run: npm install playwright --no-save
```

- `--no-save` evita drift em `package.json` / `package-lock.json`.
- Pega ~10s na primeira vez e milissegundos depois via cache interno do npm.
- Garante `node_modules/playwright/` independente do cache hit dos browsers.

## Por que NÃO Opção A do brief (cachear `node_modules` também)

Cache key seria invalidado a cada bump de qualquer dep em `package-lock.json` (não só playwright). Pouco ganho vs npm install direto.

## Por que NÃO Opção B do brief (adicionar a `package.json` devDependencies)

Correto a médio prazo, mas requer atualizar `package-lock.json` em sincronia ou `npm ci` falha. Deixei pra follow-up onde dá pra rodar `npm install playwright --save-dev` local e commitar lockfile junto.

## Validação

Próximo PR tocando `resources/js/Pages/**/*.tsx` ou `tests/Browser/**/*.php` deve passar o step `Run Pest Browser tests` sem `PlaywrightNotInstalledException`. PR #1419 (fix CNPJ lookup endereço drawer 760) foi o caso reportado.

## Follow-up sugerido

1. `npm install playwright --save-dev` local → commitar `package.json` + `package-lock.json`
2. Remover o step `Install Playwright npm client` (volta a confiar no `npm ci`)
3. Considerar incluir `node_modules` no cache do workflow (key por `package-lock.json`) pra cortar tempo do `npm ci`

## Refs

- ADR 0108 (Regressão visual Pest Browser Tier 2): [`memory/decisions/0108-regressao-visual-pest-browser-tier-2.md`](memory/decisions/0108-regressao-visual-pest-browser-tier-2.md)
- Run que motivou o fix: https://github.com/wagnerra23/oimpresso.com/actions/runs/26311841637/job/77462183969
- PR afetado: #1419

🤖 Generated with [Claude Code](https://claude.com/claude-code)