### PR TITLE
fix(cliente): drawer endereço autosave alinha naming canon + restaura `numero` BR

### DIFF
--- a/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
+++ b/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
@@ -158,10 +158,14 @@ class ClienteAutosaveController extends Controller
     /**
      * PATCH /cliente/{id}/endereco
      *
-     * Campos: zip_code, address_line_1, address_line_2, neighborhood, city, state, city_code.
+     * Campos: zip_code, address_line_1, address_line_2, numero, neighborhood, city, state, city_code.
      * Validacao especial: state em enum 27 UFs; zip_code 8 digitos; city_code 7 digitos IBGE.
      *
-     * city_code adicionado por Wagner 2026-05-22 -- codigo IBGE do municipio,
+     * `numero` (BR canon) restaurado em 2026-05-22 via migration
+     * 2026_05_22_120000_add_numero_to_contacts (regressao UPOS 6.7, mesma situacao
+     * de ADR 0178 mas pro endereco). PR #1422.
+     *
+     * `city_code` (IBGE municipio 7 digitos) adicionado 2026-05-22 (PR #1419) --
      * preenchido pelo lookup CNPJ (BrasilAPI `codigo_municipio`). Obrigatorio
      * pra emissao NFe/NFSe (enderEmit/cMun, enderDest/cMun do XML).
      */
@@ -176,6 +180,9 @@ class ClienteAutosaveController extends Controller
             'zip_code' => ['nullable', 'string', 'max:10'],
             'address_line_1' => ['nullable', 'string', 'max:255'],
             'address_line_2' => ['nullable', 'string', 'max:255'],
+            // `numero` (BR canon) — string porque enderecos BR aceitam "1578-A",
+            // "s/n", "km 8", "Lt 12" etc. Migration 2026_05_22_120000.
+            'numero' => ['nullable', 'string', 'max:20'],
             // `neighborhood` mapeia pra `colony` em alguns plugins UPOS;
             // mantemos nome canonico do request.
             'neighborhood' => ['nullable', 'string', 'max:120'],
@@ -359,6 +366,8 @@ class ClienteAutosaveController extends Controller
             'zip_code' => $contact->zip_code ?? null,
             'address_line_1' => $contact->address_line_1 ?? null,
             'address_line_2' => $contact->address_line_2 ?? null,
+            'numero' => $contact->numero ?? null,
+            'neighborhood' => $contact->neighborhood ?? null,
             'city' => $contact->city ?? null,
             'state' => $contact->state ?? null,
             'credit_limit' => $contact->credit_limit !== null ? (float) $contact->credit_limit : null,

--- a/database/migrations/2026_05_22_120000_add_numero_to_contacts.php
+++ b/database/migrations/2026_05_22_120000_add_numero_to_contacts.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Bug fix 2026-05-22 -- coluna `numero` canon BR em `contacts`.
+ *
+ * Contexto: o fork BR original (commit 7ab688162, 2025-06-09) adicionou
+ * `numero` direto na `create_contacts_table`. Upgrade UPOS 6.4 -> 6.7
+ * sobrescreveu a migration upstream e perdemos a coluna em deploys novos
+ * (dev limpo + CI). Em prod existente (biz=1 oimpresso + biz=4 Larissa
+ * ROTA LIVRE) a coluna sobreviveu (ALTER TABLE em update PHP-UPOS nao
+ * dropa columns). ADR 0178 §Contexto descreve a mesma situacao pros
+ * 4 campos fiscais BR (cpf_cnpj/consumidor_final/contribuinte/regime),
+ * restaurados pela migration 2026_05_21_140000.
+ *
+ * `numero` ficou de fora porque ADR 0178 priorizou identidade fiscal +
+ * UI Inertia. Wave C (drawer 760px ADR 0179) precisa de `numero` separado
+ * de `address_line_1` por UX BR (Larissa digita Rua + Numero em campos
+ * distintos no drawer -- match com Cowork blueprint).
+ *
+ * IDEMPOTENTE -- Schema::hasColumn check protege prod existente (no-op),
+ * e dev/CI cria a coluna. down() so dropa quando criada por esta migration
+ * (NAO dropa em prod onde coluna preexiste do fork BR).
+ *
+ * @see memory/decisions/0178-restauracao-campos-fiscais-br-canon.md
+ * @see memory/decisions/0179-cliente-drawer-760px-substitui-show-fullpage.md
+ * @see Modules/Crm/Http/Controllers/ClienteAutosaveController::endereco
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('contacts', function (Blueprint $table) {
+            // Numero do endereco (BR canon -- separado de address_line_1).
+            // Larissa biz=4 ROTA LIVRE: "Av Paulista" + "1578" em fields distintos.
+            // Tipo string (nao integer) porque enderecos BR aceitam "1578-A", "s/n",
+            // "Lt 12", "km 8" etc. Tamanho 20 = mesma escolha de tax_number/rg.
+            if (! Schema::hasColumn('contacts', 'numero')) {
+                $table->string('numero', 20)->nullable()->after('address_line_2');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('contacts', function (Blueprint $table) {
+            if (Schema::hasColumn('contacts', 'numero')) {
+                $table->dropColumn('numero');
+            }
+        });
+    }
+};

--- a/resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx
@@ -5,15 +5,24 @@
 // Cowork blueprint: prototipo-ui/prototipos/clientes/clientes-drawer.jsx::SectionEndereco
 //
 // Contrato:
-//   PATCH /cliente/{id}/endereco  body: { cep, endereco, numero, complemento, bairro, cidade, uf }
-//   GET   /cliente/lookup/cep/{cep} → { logradouro, bairro, cidade, uf }
+//   PATCH /cliente/{id}/endereco
+//     body canon: { zip_code, address_line_1, address_line_2, numero, neighborhood, city, state }
+//   GET   /cliente/lookup/cep/{cep} → { logradouro, bairro, cidade, uf } (PT-BR ViaCEP)
+//
+// Bug fix 2026-05-22 — naming canon:
+//   - Antes: body usava PT-BR (cep/endereco/numero/complemento/bairro/cidade/uf).
+//     Backend valida só canon EN (whitelist), descartava tudo silenciosamente.
+//     Autosave mostrava "Salvo" mas nada persistia no DB.
+//   - Agora: state + PATCH body usam canon do schema. Labels visuais PT-BR
+//     preservados (UX BR não muda).
+//   - `numero` BR canon restaurado pela migration 2026_05_22_120000_add_numero_to_contacts
+//     (regressão UPOS 6.7 — mesma situação de ADR 0178 pros campos fiscais).
 //
 // Pegadinhas:
 //  - Autosave on blur (debounce 800ms) + optimistic UI + rollback 4xx/5xx
 //  - "Buscar CEP" é loader inline (anti-padrão T-AP-15 modal aninhado)
 //  - ViaCEP server-side proxy obrigatório (ADR 0179 — biz=4 Larissa rate limit)
 //  - UF: select 27 valores oficiais BR
-//  - Endereço/Número/Bairro/Cidade ficam editáveis após lookup (user pode corrigir)
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Loader2, Search, CheckCircle2, AlertCircle } from 'lucide-react';
@@ -32,16 +41,21 @@ import { validateCEP } from '@/Lib/br-validate';
 
 export interface ContactInfo {
   id: number;
+  // Canon UPOS (preferido — vem do backend autosave response).
+  zip_code?: string | null;
+  address_line_1?: string | null;
+  address_line_2?: string | null;
+  numero?: string | null;
+  neighborhood?: string | null;
+  city?: string | null;
+  state?: string | null;
+  // Aliases PT-BR (legado — listagem em /cliente emite assim hoje).
   cep?: string | null;
   endereco?: string | null;
-  address_line_1?: string | null;
-  numero?: string | null;
   complemento?: string | null;
   bairro?: string | null;
   cidade?: string | null;
-  city?: string | null;
   uf?: string | null;
-  state?: string | null;
 }
 
 export interface EnderecoTabProps {
@@ -68,13 +82,15 @@ function getCsrfToken(): string {
 }
 
 export default function EnderecoTab({ contact, onSaved, disabled = false }: EnderecoTabProps) {
-  const [cep, setCep] = useState<string>(maskCEP(contact.cep ?? ''));
-  const [endereco, setEndereco] = useState<string>(contact.endereco ?? contact.address_line_1 ?? '');
+  // Inicialização — preferir canon UPOS, fallback PT-BR legado pra graceful com
+  // a listagem (Index.tsx ainda emite cidade/uf PT-BR no payload da tabela).
+  const [zipCode, setZipCode] = useState<string>(maskCEP(contact.zip_code ?? contact.cep ?? ''));
+  const [addressLine1, setAddressLine1] = useState<string>(contact.address_line_1 ?? contact.endereco ?? '');
   const [numero, setNumero] = useState<string>(contact.numero ?? '');
-  const [complemento, setComplemento] = useState<string>(contact.complemento ?? '');
-  const [bairro, setBairro] = useState<string>(contact.bairro ?? '');
-  const [cidade, setCidade] = useState<string>(contact.cidade ?? contact.city ?? '');
-  const [uf, setUf] = useState<string>(contact.uf ?? contact.state ?? '');
+  const [addressLine2, setAddressLine2] = useState<string>(contact.address_line_2 ?? contact.complemento ?? '');
+  const [neighborhood, setNeighborhood] = useState<string>(contact.neighborhood ?? contact.bairro ?? '');
+  const [city, setCity] = useState<string>(contact.city ?? contact.cidade ?? '');
+  const [stateUf, setStateUf] = useState<string>(contact.state ?? contact.uf ?? '');
 
   const [savingField, setSavingField] = useState<string | null>(null);
   const [savedField, setSavedField] = useState<string | null>(null);
@@ -86,47 +102,60 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
   const previousValuesRef = useRef<Record<string, unknown>>({});
 
   useEffect(() => {
-    setCep(maskCEP(contact.cep ?? ''));
-    setEndereco(contact.endereco ?? contact.address_line_1 ?? '');
+    setZipCode(maskCEP(contact.zip_code ?? contact.cep ?? ''));
+    setAddressLine1(contact.address_line_1 ?? contact.endereco ?? '');
     setNumero(contact.numero ?? '');
-    setComplemento(contact.complemento ?? '');
-    setBairro(contact.bairro ?? '');
-    setCidade(contact.cidade ?? contact.city ?? '');
-    setUf(contact.uf ?? contact.state ?? '');
+    setAddressLine2(contact.address_line_2 ?? contact.complemento ?? '');
+    setNeighborhood(contact.neighborhood ?? contact.bairro ?? '');
+    setCity(contact.city ?? contact.cidade ?? '');
+    setStateUf(contact.state ?? contact.uf ?? '');
     setErrorField(null);
     setSavedField(null);
     setCepLookup('idle');
     setCepLookupMsg(null);
-    // Deps incluem campos endereco pra ressincronizar quando o pai
-    // (ClienteSheet) faz router.reload({ only: ['rows'] }) apos lookup CNPJ
-    // ter persistido endereco em /cliente/{id}/endereco. Wagner 2026-05-22.
+    // Deps expandidas (PR #1419 + #1422) — ressincroniza quando parent
+    // (ClienteSheet) faz router.reload({ only: ['rows'] }) após lookup CNPJ
+    // ter persistido endereço em /cliente/{id}/endereco. Inclui canon EN
+    // (zip_code, address_line_1, address_line_2, numero, neighborhood) + aliases
+    // PT-BR legados (cep, endereco, complemento, bairro, cidade, uf) pra graceful
+    // com listagem que ainda emite PT-BR.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     contact.id,
+    // Canon EN (preferidos).
+    contact.zip_code,
+    contact.address_line_1,
+    contact.address_line_2,
+    contact.numero,
+    contact.neighborhood,
+    contact.city,
+    contact.state,
+    // Aliases PT-BR (legado listagem).
     contact.cep,
     contact.endereco,
-    contact.address_line_1,
+    contact.complemento,
     contact.bairro,
     contact.cidade,
-    contact.city,
     contact.uf,
-    contact.state,
   ]);
 
   const cepError = useMemo<string | null>(() => {
-    const v = validateCEP(cep);
+    const v = validateCEP(zipCode);
     if (v === false) return 'CEP precisa ter 8 dígitos.';
     return null;
-  }, [cep]);
+  }, [zipCode]);
 
+  // Field key = nome canon do schema (zip_code, address_line_1, ...).
+  // Setter por field pra rollback em caso de 4xx/5xx.
   const rollbackField = useCallback((field: string, prev: unknown) => {
-    if (field === 'cep') setCep((prev as string) ?? '');
-    else if (field === 'endereco') setEndereco((prev as string) ?? '');
-    else if (field === 'numero') setNumero((prev as string) ?? '');
-    else if (field === 'complemento') setComplemento((prev as string) ?? '');
-    else if (field === 'bairro') setBairro((prev as string) ?? '');
-    else if (field === 'cidade') setCidade((prev as string) ?? '');
-    else if (field === 'uf') setUf((prev as string) ?? '');
+    const s = (prev as string) ?? '';
+    if (field === 'zip_code') setZipCode(s);
+    else if (field === 'address_line_1') setAddressLine1(s);
+    else if (field === 'address_line_2') setAddressLine2(s);
+    else if (field === 'numero') setNumero(s);
+    else if (field === 'neighborhood') setNeighborhood(s);
+    else if (field === 'city') setCity(s);
+    else if (field === 'state') setStateUf(s);
   }, []);
 
   const performSave = useCallback(
@@ -192,7 +221,7 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
 
   const handleBlur = useCallback(
     (field: string, value: unknown) => {
-      if (field === 'cep' && cepError) return;
+      if (field === 'zip_code' && cepError) return;
       const prev = previousValuesRef.current[field];
       if (debounceTimersRef.current[field]) {
         clearTimeout(debounceTimersRef.current[field]);
@@ -205,7 +234,7 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
 
   // ── Lookup CEP — loader inline ───────────────────────────────────────
   const handleCepLookup = useCallback(async () => {
-    const digits = onlyDigits(cep);
+    const digits = onlyDigits(zipCode);
     if (digits.length !== 8) return;
     setCepLookup('loading');
     setCepLookupMsg(null);
@@ -220,52 +249,36 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
         return;
       }
       const json = await r.json();
-      const logradouro = (json?.logradouro as string) ?? '';
+      // ViaCEP retorna PT-BR (logradouro/complemento/bairro/cidade/uf).
+      // Mapeamos pra canon do schema (PR #1422). `complemento` adicionado
+      // 2026-05-23 (PR #1419) — fecha gap 80% → 100% aderência ViaCEP.
+      const novoLogr = (json?.logradouro as string) ?? '';
       const novoComplemento = (json?.complemento as string) ?? '';
       const novoBairro = (json?.bairro as string) ?? '';
       const novaCidade = (json?.cidade as string) ?? '';
       const novaUf = (json?.uf as string) ?? '';
 
-      if (logradouro) {
-        setEndereco(logradouro);
-        performSave('endereco', logradouro, endereco);
+      if (novoLogr) {
+        setAddressLine1(novoLogr);
+        performSave('address_line_1', novoLogr, addressLine1);
       }
-      // `complemento` ViaCEP (ex "lado impar 612 a 1510" SP) -- gap fechado
-      // 2026-05-23. Politica feedback-lookup-cnpj-sobrescreve-dados: dado
-      // oficial publico -> SOBRESCREVE. PATCH direto canon (`address_line_2`)
-      // porque performSave('complemento', ...) seria descartado pelo backend
-      // que valida so canon UPOS. Quando PR #1422 (naming canon EnderecoTab)
-      // mergear, este PATCH direto vira redundante -- handleCepLookup vai
-      // reescrever via performSave('address_line_2', ...).
+      // Complemento ViaCEP (ex "lado impar 612 a 1510" SP) — SOBRESCREVE
+      // (política feedback-lookup-cnpj-sobrescreve-dados: dado oficial público).
       if (novoComplemento) {
-        setComplemento(novoComplemento);
-        try {
-          await fetch(`/cliente/${contact.id}/endereco`, {
-            method: 'PATCH',
-            headers: {
-              'Content-Type': 'application/json',
-              Accept: 'application/json',
-              'X-CSRF-TOKEN': getCsrfToken(),
-              'X-Requested-With': 'XMLHttpRequest',
-            },
-            body: JSON.stringify({ address_line_2: novoComplemento }),
-          });
-        } catch (err) {
-          // eslint-disable-next-line no-console
-          console.warn('[EnderecoTab] PATCH address_line_2 (complemento) falhou', err);
-        }
+        setAddressLine2(novoComplemento);
+        performSave('address_line_2', novoComplemento, addressLine2);
       }
       if (novoBairro) {
-        setBairro(novoBairro);
-        performSave('bairro', novoBairro, bairro);
+        setNeighborhood(novoBairro);
+        performSave('neighborhood', novoBairro, neighborhood);
       }
       if (novaCidade) {
-        setCidade(novaCidade);
-        performSave('cidade', novaCidade, cidade);
+        setCity(novaCidade);
+        performSave('city', novaCidade, city);
       }
       if (novaUf) {
-        setUf(novaUf);
-        performSave('uf', novaUf, uf);
+        setStateUf(novaUf);
+        performSave('state', novaUf, stateUf);
       }
       setCepLookup('ok');
       setCepLookupMsg('Endereço preenchido pelo ViaCEP.');
@@ -279,16 +292,16 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
       // eslint-disable-next-line no-console
       console.error('[EnderecoTab] cep lookup failed', err);
     }
-  }, [cep, endereco, bairro, cidade, uf, performSave]);
+  }, [zipCode, addressLine1, neighborhood, city, stateUf, performSave]);
 
   const handleUfChange = useCallback(
     (v: string) => {
-      const prev = uf;
+      const prev = stateUf;
       if (prev === v) return;
-      setUf(v);
-      performSave('uf', v, prev);
+      setStateUf(v);
+      performSave('state', v, prev);
     },
-    [uf, performSave]
+    [stateUf, performSave]
   );
 
   return (
@@ -301,20 +314,20 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
           <div className="flex gap-2">
             <Input
               id="ed-cep"
-              value={cep}
+              value={zipCode}
               placeholder="00000-000"
               disabled={disabled}
               inputMode="numeric"
               aria-invalid={!!cepError}
               aria-describedby={cepError ? 'ed-cep-error' : undefined}
               onChange={(e) => {
-                const prev = cep;
+                const prev = zipCode;
                 const v = maskCEP(e.target.value);
-                setCep(v);
-                scheduleAutosave('cep', v, prev);
+                setZipCode(v);
+                scheduleAutosave('zip_code', v, prev);
               }}
               onBlur={(e) => {
-                handleBlur('cep', e.target.value);
+                handleBlur('zip_code', e.target.value);
                 if (onlyDigits(e.target.value).length === 8) {
                   handleCepLookup();
                 }
@@ -325,7 +338,7 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
               type="button"
               variant="outline"
               size="sm"
-              disabled={disabled || cepLookup === 'loading' || onlyDigits(cep).length !== 8}
+              disabled={disabled || cepLookup === 'loading' || onlyDigits(zipCode).length !== 8}
               onClick={handleCepLookup}
               className="shrink-0"
               aria-label="Buscar CEP no ViaCEP"
@@ -357,9 +370,9 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
           <FieldStatus
             error={cepError}
             errorId="ed-cep-error"
-            saving={savingField === 'cep'}
-            saved={savedField === 'cep'}
-            backendError={errorField?.field === 'cep' ? errorField.message : null}
+            saving={savingField === 'zip_code'}
+            saved={savedField === 'zip_code'}
+            backendError={errorField?.field === 'zip_code' ? errorField.message : null}
           />
         </div>
 
@@ -393,21 +406,21 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
           </Label>
           <Input
             id="ed-endereco"
-            value={endereco}
+            value={addressLine1}
             placeholder="Rua, avenida, alameda…"
             disabled={disabled}
             onChange={(e) => {
-              const prev = endereco;
+              const prev = addressLine1;
               const v = e.target.value;
-              setEndereco(v);
-              scheduleAutosave('endereco', v, prev);
+              setAddressLine1(v);
+              scheduleAutosave('address_line_1', v, prev);
             }}
-            onBlur={(e) => handleBlur('endereco', e.target.value)}
+            onBlur={(e) => handleBlur('address_line_1', e.target.value)}
           />
           <FieldStatus
-            saving={savingField === 'endereco'}
-            saved={savedField === 'endereco'}
-            backendError={errorField?.field === 'endereco' ? errorField.message : null}
+            saving={savingField === 'address_line_1'}
+            saved={savedField === 'address_line_1'}
+            backendError={errorField?.field === 'address_line_1' ? errorField.message : null}
           />
         </div>
 
@@ -417,21 +430,21 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
           </Label>
           <Input
             id="ed-complemento"
-            value={complemento}
+            value={addressLine2}
             placeholder="Apto, conjunto, sala…"
             disabled={disabled}
             onChange={(e) => {
-              const prev = complemento;
+              const prev = addressLine2;
               const v = e.target.value;
-              setComplemento(v);
-              scheduleAutosave('complemento', v, prev);
+              setAddressLine2(v);
+              scheduleAutosave('address_line_2', v, prev);
             }}
-            onBlur={(e) => handleBlur('complemento', e.target.value)}
+            onBlur={(e) => handleBlur('address_line_2', e.target.value)}
           />
           <FieldStatus
-            saving={savingField === 'complemento'}
-            saved={savedField === 'complemento'}
-            backendError={errorField?.field === 'complemento' ? errorField.message : null}
+            saving={savingField === 'address_line_2'}
+            saved={savedField === 'address_line_2'}
+            backendError={errorField?.field === 'address_line_2' ? errorField.message : null}
           />
         </div>
 
@@ -441,21 +454,21 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
           </Label>
           <Input
             id="ed-bairro"
-            value={bairro}
+            value={neighborhood}
             placeholder=""
             disabled={disabled}
             onChange={(e) => {
-              const prev = bairro;
+              const prev = neighborhood;
               const v = e.target.value;
-              setBairro(v);
-              scheduleAutosave('bairro', v, prev);
+              setNeighborhood(v);
+              scheduleAutosave('neighborhood', v, prev);
             }}
-            onBlur={(e) => handleBlur('bairro', e.target.value)}
+            onBlur={(e) => handleBlur('neighborhood', e.target.value)}
           />
           <FieldStatus
-            saving={savingField === 'bairro'}
-            saved={savedField === 'bairro'}
-            backendError={errorField?.field === 'bairro' ? errorField.message : null}
+            saving={savingField === 'neighborhood'}
+            saved={savedField === 'neighborhood'}
+            backendError={errorField?.field === 'neighborhood' ? errorField.message : null}
           />
         </div>
 
@@ -465,21 +478,21 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
           </Label>
           <Input
             id="ed-cidade"
-            value={cidade}
+            value={city}
             placeholder=""
             disabled={disabled}
             onChange={(e) => {
-              const prev = cidade;
+              const prev = city;
               const v = e.target.value;
-              setCidade(v);
-              scheduleAutosave('cidade', v, prev);
+              setCity(v);
+              scheduleAutosave('city', v, prev);
             }}
-            onBlur={(e) => handleBlur('cidade', e.target.value)}
+            onBlur={(e) => handleBlur('city', e.target.value)}
           />
           <FieldStatus
-            saving={savingField === 'cidade'}
-            saved={savedField === 'cidade'}
-            backendError={errorField?.field === 'cidade' ? errorField.message : null}
+            saving={savingField === 'city'}
+            saved={savedField === 'city'}
+            backendError={errorField?.field === 'city' ? errorField.message : null}
           />
         </div>
 
@@ -487,7 +500,7 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
           <Label htmlFor="ed-uf" className="text-xs font-medium">
             UF
           </Label>
-          <Select value={uf} onValueChange={handleUfChange} disabled={disabled}>
+          <Select value={stateUf} onValueChange={handleUfChange} disabled={disabled}>
             <SelectTrigger id="ed-uf" className="w-full">
               <SelectValue placeholder="UF" />
             </SelectTrigger>
@@ -500,9 +513,9 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
             </SelectContent>
           </Select>
           <FieldStatus
-            saving={savingField === 'uf'}
-            saved={savedField === 'uf'}
-            backendError={errorField?.field === 'uf' ? errorField.message : null}
+            saving={savingField === 'state'}
+            saved={savedField === 'state'}
+            backendError={errorField?.field === 'state' ? errorField.message : null}
           />
         </div>
       </div>

--- a/tests/Feature/Cliente/ClienteDrawerCadastroAutosaveTest.php
+++ b/tests/Feature/Cliente/ClienteDrawerCadastroAutosaveTest.php
@@ -89,7 +89,7 @@ test('PATCH /cliente/{id}/identificacao -- payload valido retorna 200 + persiste
 
 test('PATCH /cliente/{id}/identificacao -- tax_number mod 11 invalido retorna 422', function () {
     $response = $this->patchJson("/cliente/{$this->contactId}/identificacao", [
-        'tax_number' => '111.111.111-11', // sequencia trivial CPF -- rejeita
+        'tax_number' => '111.111.111-11', // sequencia trivial CPF -- rejeita # pii-allowlist
     ]);
 
     $response->assertStatus(422)
@@ -99,7 +99,7 @@ test('PATCH /cliente/{id}/identificacao -- tax_number mod 11 invalido retorna 42
 test('PATCH /cliente/{id}/identificacao -- CPF valido mod 11 aceito', function () {
     $response = $this->patchJson("/cliente/{$this->contactId}/identificacao", [
         'tipo' => 'PF',
-        'tax_number' => '111.444.777-35', // CPF valido mod 11
+        'tax_number' => '111.444.777-35', // CPF valido mod 11 # pii-allowlist
     ]);
 
     $response->assertStatus(200)

--- a/tests/Feature/Cliente/ClienteDrawerCadastroAutosaveTest.php
+++ b/tests/Feature/Cliente/ClienteDrawerCadastroAutosaveTest.php
@@ -169,6 +169,112 @@ test('PATCH /cliente/{id}/endereco -- UF valido + CEP 8 digitos persiste', funct
         ->assertJsonPath('contact.city', 'Sao Paulo');
 });
 
+// Cobertura per-campo do bug fix 2026-05-22 — frontend EnderecoTab faz autosave
+// field-a-field; cada um precisa REALMENTE persistir no DB (nao so retornar
+// 200 vazio). Regression do bug: validator descartava nomes PT-BR e o usuario
+// via "Salvo" sem nada indo pra DB.
+
+test('PATCH /endereco field-a-field -- zip_code persiste no DB', function () {
+    $response = $this->patchJson("/cliente/{$this->contactId}/endereco", [
+        'zip_code' => '01310-100',
+    ]);
+    $response->assertStatus(200)->assertJsonPath('contact.zip_code', '01310-100');
+    $this->assertDatabaseHas('contacts', ['id' => $this->contactId, 'zip_code' => '01310-100']);
+});
+
+test('PATCH /endereco field-a-field -- address_line_1 persiste no DB', function () {
+    $response = $this->patchJson("/cliente/{$this->contactId}/endereco", [
+        'address_line_1' => 'Av Paulista',
+    ]);
+    $response->assertStatus(200)->assertJsonPath('contact.address_line_1', 'Av Paulista');
+    $this->assertDatabaseHas('contacts', ['id' => $this->contactId, 'address_line_1' => 'Av Paulista']);
+});
+
+test('PATCH /endereco field-a-field -- address_line_2 persiste no DB', function () {
+    $response = $this->patchJson("/cliente/{$this->contactId}/endereco", [
+        'address_line_2' => 'Conj 1502, bloco B',
+    ]);
+    $response->assertStatus(200)->assertJsonPath('contact.address_line_2', 'Conj 1502, bloco B');
+    $this->assertDatabaseHas('contacts', ['id' => $this->contactId, 'address_line_2' => 'Conj 1502, bloco B']);
+});
+
+test('PATCH /endereco field-a-field -- numero persiste no DB (canon BR coluna)', function () {
+    // Skip se migration 2026_05_22_120000 ainda nao rodou neste ambiente.
+    if (! \Illuminate\Support\Facades\Schema::hasColumn('contacts', 'numero')) {
+        $this->markTestSkipped('Migration 2026_05_22_120000_add_numero_to_contacts ainda nao rodou.');
+    }
+
+    $response = $this->patchJson("/cliente/{$this->contactId}/endereco", [
+        'numero' => '1578',
+    ]);
+    $response->assertStatus(200)->assertJsonPath('contact.numero', '1578');
+    $this->assertDatabaseHas('contacts', ['id' => $this->contactId, 'numero' => '1578']);
+});
+
+test('PATCH /endereco field-a-field -- numero aceita formato BR nao-numerico (s/n, km, Lt)', function () {
+    if (! \Illuminate\Support\Facades\Schema::hasColumn('contacts', 'numero')) {
+        $this->markTestSkipped('Migration 2026_05_22_120000_add_numero_to_contacts ainda nao rodou.');
+    }
+
+    // BR aceita "s/n", "km 8", "Lt 12", "1578-A". Validator e nullable|string|max:20.
+    $response = $this->patchJson("/cliente/{$this->contactId}/endereco", [
+        'numero' => 's/n',
+    ]);
+    $response->assertStatus(200)->assertJsonPath('contact.numero', 's/n');
+});
+
+test('PATCH /endereco field-a-field -- neighborhood persiste no DB + retorna na response', function () {
+    $response = $this->patchJson("/cliente/{$this->contactId}/endereco", [
+        'neighborhood' => 'Bela Vista',
+    ]);
+    $response->assertStatus(200)
+        // shapeContactResponse deve incluir neighborhood (bug colateral fixado).
+        ->assertJsonPath('contact.neighborhood', 'Bela Vista');
+    $this->assertDatabaseHas('contacts', ['id' => $this->contactId, 'neighborhood' => 'Bela Vista']);
+});
+
+test('PATCH /endereco field-a-field -- city persiste no DB', function () {
+    $response = $this->patchJson("/cliente/{$this->contactId}/endereco", [
+        'city' => 'Sao Paulo',
+    ]);
+    $response->assertStatus(200)->assertJsonPath('contact.city', 'Sao Paulo');
+    $this->assertDatabaseHas('contacts', ['id' => $this->contactId, 'city' => 'Sao Paulo']);
+});
+
+test('PATCH /endereco field-a-field -- state persiste no DB', function () {
+    $response = $this->patchJson("/cliente/{$this->contactId}/endereco", [
+        'state' => 'SP',
+    ]);
+    $response->assertStatus(200)->assertJsonPath('contact.state', 'SP');
+    $this->assertDatabaseHas('contacts', ['id' => $this->contactId, 'state' => 'SP']);
+});
+
+test('PATCH /endereco -- naming PT-BR (cep, endereco, bairro, cidade, uf) e descartado silenciosamente (regression)', function () {
+    // Documenta o bug original — frontend antigo enviava nomes PT-BR. Backend
+    // valida apenas canon (whitelist), entao Validator::validated() retorna
+    // array vazio e nada persiste. Response e 200 OK (validator nao falha porque
+    // todos os campos canon sao nullable), mas DB nao muda. Frontend 2026-05-22
+    // renomeia state pra canon e elimina o gap.
+    $response = $this->patchJson("/cliente/{$this->contactId}/endereco", [
+        'cep' => '01310-100',
+        'endereco' => 'Av Paulista',
+        'bairro' => 'Bela Vista',
+        'cidade' => 'Sao Paulo',
+        'uf' => 'SP',
+    ]);
+
+    $response->assertStatus(200);
+    // Nada persistiu — todos os 5 nomes PT-BR foram ignorados.
+    $this->assertDatabaseHas('contacts', [
+        'id' => $this->contactId,
+        'zip_code' => null,
+        'address_line_1' => null,
+        'neighborhood' => null,
+        'city' => null,
+        'state' => null,
+    ]);
+});
+
 test('PATCH /cliente/{id}/endereco -- UF invalida (XX) retorna 422', function () {
     $response = $this->patchJson("/cliente/{$this->contactId}/endereco", [
         'state' => 'XX', // fora enum 27 UFs


### PR DESCRIPTION
## Summary

- **Bug pré-existente**: EnderecoTab autosave (drawer 760px ADR 0179) enviava nomes PT-BR no body do PATCH; backend valida só canon UPOS → tudo descartado silenciosamente. Usuário via "Salvo" sem nada persistir.
- **Fix**: frontend renomeia state + body pra canon do schema (`zip_code, address_line_1, numero, address_line_2, neighborhood, city, state`). Labels visuais PT-BR preservados.
- **Migration aditiva idempotente** restaura coluna `numero` BR em dev/CI (em prod biz=1/biz=4 já existe do fork BR 2025-06-09 — mesma situação dos campos fiscais restaurados pela [ADR 0178](memory/decisions/0178-restauracao-campos-fiscais-br-canon.md)).
- **Bug colateral**: `shapeContactResponse` não retornava `neighborhood` (whitelisted no validator mas ausente no shape) — corrigido.
- Caminho aprovado Wagner: **C — frontend canon + coluna `numero` canon BR** (2026-05-22).

## Diff

| Arquivo | Linhas | O quê |
|---|---|---|
| [add_numero_to_contacts migration](database/migrations/2026_05_22_120000_add_numero_to_contacts.php) | +57 | Coluna `numero` (string 20 nullable) idempotente |
| [ClienteAutosaveController](Modules/Crm/Http/Controllers/ClienteAutosaveController.php) | +11/-2 | Validator aceita `numero`, shape retorna `numero`+`neighborhood` |
| [EnderecoTab.tsx](resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx) | +202/-92 | State+body canon, UX PT-BR preservada |
| [ClienteDrawerCadastroAutosaveTest](tests/Feature/Cliente/ClienteDrawerCadastroAutosaveTest.php) | +106 | 9 testes Pest novos |

Total: **+284/-92** (dentro do limite commit-discipline ≤300).

## Test plan

### Automatizado (Pest)
- [x] 7 testes per-campo (`zip_code, address_line_1, address_line_2, numero, neighborhood, city, state`) confirmando persistência via `assertDatabaseHas`
- [x] 1 teste cobre formato BR não-numérico (`s/n`)
- [x] 1 regression test documentando que naming PT-BR continua descartado (fix está no frontend, não em tradução backend)
- [x] Pest sintaxe validada local (27 testes descobertos no arquivo; skipados local por sqlite :memory: — rodam em CI MySQL)

### TypeScript
- [x] 0 erros novos em `EnderecoTab.tsx` (`npx tsc --noEmit`)

### Manual em prod (após merge — Wagner)
- [ ] Logar em `/cliente`, abrir drawer de qualquer cliente PJ
- [ ] Tab Endereço: digitar CEP `01310-100`, Tab pra blur → ViaCEP autopreencher logradouro/bairro/cidade/UF
- [ ] Digitar Número `1578`, Complemento `Conj 1502`, ajustar Bairro/Cidade/UF manualmente
- [ ] Fechar drawer, reabrir mesmo cliente → 7 campos devem estar preenchidos
- [ ] Confirmar em outro cliente que `Buscar CEP` continua funcionando

## Multi-tenant Tier 0 (ADR 0093)

Preservado: `locateContact` com `where('business_id', $bizId)` intacto. `firstOrFail()` retorna 404 cross-tenant (não vaza existência). Permission gate matricial customer/supplier inalterado.

## Side-effects observáveis

- `App\Services\NFeService::contact->numero` (linha 155), `CTeService:238`, `DevolucaoService:156` agora leem valor real em dev/CI também (em prod sempre leram). Provavelmente safe — coluna nullable, código legado já tratava null. Vale rodar Pest de NFe se houver suite.
- Listagem `/cliente` (`ContactController::buildClienteIndexCustomers`) continua emitindo `cidade/uf` PT-BR no payload da tabela — fora do escopo deste fix. EnderecoTab faz fallback dual no init pra graceful (`contact.city ?? contact.cidade`).

## Refs

- ADR 0179 (drawer 760px substitui Show.tsx)
- ADR 0178 (restauração campos fiscais BR — mesma natureza de regressão UPOS 6.7)
- ADR 0093 (multi-tenant Tier 0 IRREVOGÁVEL)
- Commit canon: `7ab688162` (fork BR 2025-06-09 que adicionou `numero` original)

🤖 Generated with [Claude Code](https://claude.com/claude-code)