### PR TITLE
fix(paymentgateway): expõe Pagar.me na UI /settings/payment-gateways

### DIFF
--- a/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
@@ -111,7 +111,7 @@ class PaymentGatewaysController extends Controller
         }
 
         $validated = $request->validate([
-            'gateway_key'      => 'required|string|in:inter,c6,asaas,bcb_pix,pesapal',
+            'gateway_key'      => 'required|string|in:inter,c6,asaas,bcb_pix,pesapal,pagarme',
             'ambiente'         => 'required|string|in:production,sandbox',
             'nome_display'     => 'nullable|string|max:191',
             'conta_bancaria_id' => 'nullable|integer|exists:accounts,id',

--- a/resources/js/Pages/Financeiro/Cobranca/_lib/cobranca-shared.ts
+++ b/resources/js/Pages/Financeiro/Cobranca/_lib/cobranca-shared.ts
@@ -4,7 +4,7 @@
 export type CobrancaTipo = 'boleto' | 'pix_cob' | 'pix_cobv' | 'pix_recv' | 'card';
 export type CobrancaStatus = 'emitida' | 'paga' | 'vencida' | 'cancelada' | 'erro' | 'pending';
 export type OrigemType = 'sale' | 'invoice' | 'subscription_license';
-export type GatewayKey = 'inter' | 'c6' | 'asaas' | 'bcb_pix' | 'pesapal';
+export type GatewayKey = 'inter' | 'c6' | 'asaas' | 'bcb_pix' | 'pesapal' | 'pagarme';
 
 export interface Cobranca {
   id: number;
@@ -141,6 +141,13 @@ export const DRIVERS: Record<GatewayKey, DriverToken> = {
     cred: 'api_key + consumer_secret',
     deprecated: true,
     deprecatedReason: 'Migrar pra Asaas (cartão BR nativo + 3DS)',
+  },
+  pagarme: {
+    key: 'pagarme', nome: 'Pagar.me', sigla: 'PG',
+    dot: 'bg-rose-500', bg: 'bg-rose-50', fg: 'text-rose-700', border: 'border-rose-200',
+    tipos: ['boleto', 'pix_cob', 'card'],
+    ambientes: ['sandbox', 'production'],
+    cred: 'secret_key + webhook_secret · HMAC SHA256 (X-Hub-Signature-256)',
   },
 };
 

--- a/resources/js/Pages/Settings/PaymentGateways/_components/DrawerGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/DrawerGateway.tsx
@@ -357,6 +357,28 @@ export default function DrawerGateway({ gateway, accounts, onClose, onToggle }: 
                   <Btn variant="outline" size="xs" className="mt-2 !border-amber-300 !text-amber-800">Iniciar migração</Btn>
                 </div>
               )}
+              {d.key === 'pagarme' && (
+                <>
+                  <Field label="Secret Key (atualizar)">
+                    <input
+                      type="password"
+                      value={config.secret_key ?? ''}
+                      onChange={e => setConfigField('secret_key', e.target.value)}
+                      placeholder="sk_test_••• ou sk_live_••• (digite novo pra trocar)"
+                      className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
+                    />
+                  </Field>
+                  <Field label="Webhook Secret (atualizar)">
+                    <input
+                      type="password"
+                      value={config.webhook_secret ?? ''}
+                      onChange={e => setConfigField('webhook_secret', e.target.value)}
+                      placeholder="whsec_••• (HMAC X-Hub-Signature-256)"
+                      className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
+                    />
+                  </Field>
+                </>
+              )}
             </div>
           )}
 

--- a/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
@@ -306,6 +306,29 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
                   />
                 </Field>
               </>}
+              {d.key === 'pagarme' && <>
+                <Field label="Secret Key">
+                  <input
+                    type="password"
+                    value={config.secret_key ?? ''}
+                    onChange={e => setConfigField('secret_key', e.target.value)}
+                    placeholder="sk_test_... ou sk_live_..."
+                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
+                  />
+                </Field>
+                <Field label="Webhook Secret">
+                  <input
+                    type="password"
+                    value={config.webhook_secret ?? ''}
+                    onChange={e => setConfigField('webhook_secret', e.target.value)}
+                    placeholder="whsec_••• (validação HMAC X-Hub-Signature-256)"
+                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
+                  />
+                </Field>
+                <div className="bg-stone-50 border border-stone-200 rounded p-2.5 text-[10.5px] text-stone-700">
+                  Sandbox via prefixo <span className="font-mono">sk_test_</span> · Production via <span className="font-mono">sk_live_</span>. Webhook secret é configurado no dashboard Pagar.me em Integrações → Webhooks.
+                </div>
+              </>}
 
               <div className="pt-2 border-t border-stone-200 mt-3 flex items-center gap-2">
                 <Btn variant="outline" disabled><Shield className="h-3 w-3" />Testar conexão</Btn>


### PR DESCRIPTION
## Summary
Hotfix do PR #1420 (commit `a909dd5ba`) que mergeou o driver backend Pagar.me mas esqueceu de plumar a UI.

Sintoma: `/settings/payment-gateways` não mostrava Pagar.me como opção no wizard "Novo gateway", e mesmo com workaround tentando submeter, o backend rejeitava 422 (validator `in:` não aceitava 'pagarme').

## Files changed (4)
| Arquivo | LOC |
|---|---|
| `resources/js/Pages/Financeiro/Cobranca/_lib/cobranca-shared.ts` | +9 |
| `resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx` | +24 |
| `resources/js/Pages/Settings/PaymentGateways/_components/DrawerGateway.tsx` | +21 |
| `Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php` | +1/-1 |

## Test plan
- [x] `composer module-grades-check` — não regredi (4 mudanças mínimas)
- [x] Pest existente (`PaymentGatewaysControllerStoreTest`) NÃO testa 'pagarme' — não bloqueia
- [ ] Post-merge: quick-sync.yml auto-builds frontend (Vite) + sync prod
- [ ] Smoke prod: abrir `/settings/payment-gateways` → "Novo gateway" → confirmar Pagar.me aparece com sigla "PG" rosa

Refs: ADR 0170 Onda 4e (PR #1420 a909dd5ba)

🤖 Generated with [Claude Code](https://claude.com/claude-code)