### PR TITLE
fix(ci): smoke test strict + tail laravel.log on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -134,11 +134,35 @@ jobs:
       - name: Maintenance mode OFF
         run: /tmp/ssh_exec.sh "cd /home/u906587222/domains/oimpresso.com/public_html && php artisan up"
 
-      - name: Smoke test — HTTPS home
+      - name: Smoke test — HTTPS home (strict)
+        id: smoke
         run: |
+          set -uo pipefail
           echo "=== curl https://oimpresso.com/login ==="
-          curl -sL -o /dev/null -w "HTTP %{http_code} (%{time_total}s)\n" https://oimpresso.com/login
-          curl -sL https://oimpresso.com/login | grep -i "Login to your\|Bem-vindo\|Username" | head -3 || echo "⚠️  marker nao encontrado (pode ser redirect)"
+          HTTP_CODE=$(curl -sL -o /tmp/smoke.html -w "%{http_code}|%{time_total}" https://oimpresso.com/login)
+          CODE="${HTTP_CODE%%|*}"
+          TIME="${HTTP_CODE##*|}"
+          echo "HTTP $CODE (${TIME}s)"
+          echo "code=$CODE" >> "$GITHUB_OUTPUT"
+          if [ "$CODE" != "200" ] && [ "$CODE" != "302" ]; then
+            echo "::error::Smoke test FAILED — HTTP $CODE pra /login (esperado 200 ou 302)"
+            echo "smoke_failed=true" >> "$GITHUB_OUTPUT"
+            exit 0   # NÃO falhar aqui — deixa Tail laravel.log rodar primeiro pra dar contexto
+          fi
+          # Validação de marker (warn-only)
+          grep -i "Login to your\|Bem-vindo\|Username" /tmp/smoke.html | head -3 || echo "⚠️  marker nao encontrado (pode ser redirect)"
+
+      - name: Tail laravel.log (sempre — diagnose smoke + post-mortem)
+        if: always()
+        run: |
+          echo "=== Last 80 lines de storage/logs/laravel.log ==="
+          /tmp/ssh_exec.sh "cd /home/u906587222/domains/oimpresso.com/public_html && tail -80 storage/logs/laravel.log 2>&1 || echo '(log vazio ou ausente)'"
+
+      - name: Falha smoke (após log já visível)
+        if: steps.smoke.outputs.smoke_failed == 'true'
+        run: |
+          echo "::error::Smoke test FAILED — HTTP ${{ steps.smoke.outputs.code }}. Ver step 'Tail laravel.log' acima pra causa raiz."
+          exit 1
 
       - name: Verify Laravel version deployed
         run: /tmp/ssh_exec.sh "cd /home/u906587222/domains/oimpresso.com/public_html && php artisan --version"

--- a/.github/workflows/quick-sync.yml
+++ b/.github/workflows/quick-sync.yml
@@ -150,9 +150,19 @@ jobs:
         # cache:clear adicionado 2026-05-18 pós bug "Financeiro dropdown invisivel
         # apos sync biz=4" — DataController novo não era visto sem cache:clear.
 
-      - name: Smoke test
+      - name: Smoke test (strict + log tail on fail)
         run: |
-          curl -sL -o /dev/null -w "HTTP %{http_code} (%{time_total}s)\n" https://oimpresso.com/login
+          set -uo pipefail
+          HTTP_CODE=$(curl -sL -o /dev/null -w "%{http_code}|%{time_total}" https://oimpresso.com/login)
+          CODE="${HTTP_CODE%%|*}"
+          TIME="${HTTP_CODE##*|}"
+          echo "HTTP $CODE (${TIME}s)"
+          if [ "$CODE" != "200" ] && [ "$CODE" != "302" ]; then
+            echo "::error::Quick-sync smoke FAILED — HTTP $CODE pra /login"
+            echo "=== Last 60 lines de storage/logs/laravel.log ==="
+            /tmp/ssh_exec.sh "cd /home/u906587222/domains/oimpresso.com/public_html && tail -60 storage/logs/laravel.log 2>&1 || true"
+            exit 1
+          fi
 
       - name: Sync concluido
         run: echo "Quick sync deployado. Para mudancas pesadas use deploy.yml (backup + composer + migrate)."


### PR DESCRIPTION
Resolve false-positive crítico de ~10min prod 500 invisível durante rollout Pagar.me Onda 4e (2026-05-22 21:54-22:02).

- deploy.yml smoke valida HTTP code (200|302) + step always() tail 80 linhas laravel.log
- quick-sync.yml smoke similar + tail on fail