### PR TITLE
feat(paymentgateway): re-rollforward Pagar.me Onda 4e + UI (após smoke fix safety net)

### DIFF
--- a/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
@@ -111,7 +111,7 @@ class PaymentGatewaysController extends Controller
         }
 
         $validated = $request->validate([
-            'gateway_key'      => 'required|string|in:inter,c6,asaas,bcb_pix,pesapal',
+            'gateway_key'      => 'required|string|in:inter,c6,asaas,bcb_pix,pesapal,pagarme',
             'ambiente'         => 'required|string|in:production,sandbox',
             'nome_display'     => 'nullable|string|max:191',
             'conta_bancaria_id' => 'nullable|integer|exists:accounts,id',

--- a/Modules/PaymentGateway/Http/Controllers/Webhooks/PagarmeWebhookController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Webhooks/PagarmeWebhookController.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Http\Controllers\Webhooks;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+
+/**
+ * Recebe webhooks Pagar.me v5.
+ *
+ * Rota: POST /paymentgateway/webhooks/pagarme/{businessId}
+ * Sem auth middleware (chamado pelo Pagar.me externamente).
+ *
+ * Onda 4e — ADR 0170.
+ *
+ * Pagar.me v5 webhook signature:
+ *   - Header: X-Hub-Signature-256
+ *   - Formato: "sha256=<hex>" (igual GitHub)
+ *   - Algoritmo: HMAC-SHA256(raw_body, webhook_secret)
+ *   - Secret configurado por endpoint no dashboard Pagar.me
+ *
+ * Identificadores Pagar.me:
+ *   - id: ID do evento ("hook_xxx") — usado pra idempotência
+ *   - type: "charge.paid" | "charge.payment_failed" | "charge.refunded" |
+ *           "charge.partial_canceled" | "charge.pending" | "charge.chargedback"
+ *   - data.id: ID da charge afetada ("ch_xxx") — fallback pro event_id
+ *
+ * Fail-secure: se credencial não tem webhook_secret cadastrado OU
+ * signature inválida → 401 e não persiste evento (anti-spoofing).
+ */
+class PagarmeWebhookController extends Controller
+{
+    public function __construct(private WebhookProcessor $processor)
+    {
+    }
+
+    public function handle(Request $request, int $businessId): JsonResponse
+    {
+        // 1. Resolve credencial Pagar.me ATIVA do business (withoutGlobalScopes —
+        //    webhook não tem sessão autenticada).
+        $credential = PaymentGatewayCredential::withoutGlobalScopes()
+            ->where('business_id', $businessId)
+            ->where('gateway_key', 'pagarme')
+            ->where('ativo', true)
+            ->orderByDesc('id')
+            ->first();
+
+        if (! $credential) {
+            Log::warning('paymentgateway.pagarme.webhook.credential_not_found', [
+                'business_id' => $businessId,
+            ]);
+            return response()->json([
+                'ok'    => false,
+                'error' => 'credential_not_found',
+            ], 404);
+        }
+
+        // 2. Valida HMAC signature (X-Hub-Signature-256)
+        if (! $this->validateSignature($request, $credential)) {
+            Log::warning('paymentgateway.pagarme.webhook.signature_invalid', [
+                'business_id'   => $businessId,
+                'credential_id' => $credential->id,
+            ]);
+            return response()->json([
+                'ok'    => false,
+                'error' => 'signature_invalid',
+            ], 401);
+        }
+
+        // 3. Extrai metadata pro WebhookProcessor (idempotência + log)
+        $eventName = (string) $request->input('type', 'unknown');
+        $eventId = (string) (
+            $request->input('id')
+            ?? ($request->input('data.id') !== null ? $eventName . ':' . $request->input('data.id') : md5($eventName . json_encode($request->all())))
+        );
+
+        return $this->processor->handle(
+            gatewayKey: 'pagarme',
+            request: $request,
+            businessId: $businessId,
+            eventName: $eventName,
+            eventId: $eventId,
+        );
+    }
+
+    /**
+     * HMAC-SHA256 do raw body com secret em config_json.webhook_secret.
+     *
+     * Pagar.me v5: header `X-Hub-Signature-256` formato "sha256=<hex>".
+     * Comparação timing-safe via hash_equals.
+     *
+     * Fail-secure: se credencial NÃO tem webhook_secret cadastrado → false
+     * (Wagner configura via wizard /settings/payment-gateways step 4).
+     */
+    private function validateSignature(Request $request, PaymentGatewayCredential $credential): bool
+    {
+        $secret = (string) ($credential->config_json['webhook_secret'] ?? '');
+        if ($secret === '') {
+            return false;
+        }
+
+        $providedHeader = (string) $request->header('X-Hub-Signature-256', '');
+        if ($providedHeader === '' || ! str_starts_with($providedHeader, 'sha256=')) {
+            return false;
+        }
+
+        $providedHex = substr($providedHeader, 7); // strip 'sha256='
+        $rawBody = $request->getContent();
+        $expectedHex = hash_hmac('sha256', $rawBody, $secret);
+
+        return hash_equals($expectedHex, $providedHex);
+    }
+}

--- a/Modules/PaymentGateway/Routes/web.php
+++ b/Modules/PaymentGateway/Routes/web.php
@@ -8,6 +8,7 @@ use Modules\PaymentGateway\Http\Controllers\Webhooks\BcbPixWebhookController;
 use Modules\PaymentGateway\Http\Controllers\Webhooks\C6WebhookController;
 use Modules\PaymentGateway\Http\Controllers\Webhooks\InterPixWebhookController;
 use Modules\PaymentGateway\Http\Controllers\Webhooks\InterWebhookController;
+use Modules\PaymentGateway\Http\Controllers\Webhooks\PagarmeWebhookController;
 
 /*
 |--------------------------------------------------------------------------
@@ -86,6 +87,12 @@ Route::middleware(['web'])
         Route::post('bcb-pix/{businessId}', [BcbPixWebhookController::class, 'handle'])
             ->whereNumber('businessId')
             ->name('paymentgateway.webhooks.bcb-pix');
+
+        // Onda 4e — driver Pagar.me v5 (Stone group)
+        // HMAC signature X-Hub-Signature-256 validada no controller.
+        Route::post('pagarme/{businessId}', [PagarmeWebhookController::class, 'handle'])
+            ->whereNumber('businessId')
+            ->name('paymentgateway.webhooks.pagarme');
     });
 
 // ─── Webhook PIX Inter US-FIN-032 (Onda 26) ──────────────────────────────

--- a/Modules/PaymentGateway/SCOPE.md
+++ b/Modules/PaymentGateway/SCOPE.md
@@ -12,11 +12,13 @@ contains:
   - "Webhooks/AsaasWebhookController — POST /paymentgateway/webhooks/asaas/{businessId} (Onda 3 sem cutover)"
   - "Webhooks/BcbPixWebhookController — POST /paymentgateway/webhooks/bcb-pix/{businessId} (Onda 3 novo)"
   - "Webhooks/InterPixWebhookController — POST /webhooks/inter/{credentialId} (Onda 26 US-FIN-032 PIX recebido → titulo auto-pago)"
+  - "Webhooks/PagarmeWebhookController — POST /paymentgateway/webhooks/pagarme/{businessId} (Onda 4e) — HMAC-SHA256 via header X-Hub-Signature-256"
   - "Services/PaymentGatewayService — implementa PaymentGatewayContract; for(Account) resolve credential; idempotência (Onda 4a); DRIVERS mapa atualizado Onda 4b com 3 drivers"
   - "Services/Drivers/InterDriver — Inter API v3 OAuth2+mTLS (boleto Onda 4a + pix_cob/pix_cobv Onda 4b/4c + refund PIX Onda 4c + cancelar + consultar + healthCheck + processWebhook). Refund de boleto Inter NÃO via API — exige TED reverso manual"
   - "Services/Drivers/AsaasDriver — Asaas REST v3 (boleto + pix_cob + card + refund parcial + cancelar + consultar + healthCheck + processWebhook); Onda 4b"
   - "Services/Drivers/C6Driver — C6 Open Banking PJ OAuth2 (boleto + pix_cob + cancelar + consultar + healthCheck + processWebhook); Onda 4b. CNAB legacy fallback fica em RB"
   - "Services/Drivers/BcbPixDriver — PSP-agnóstico PIX Automático (Resolução BCB 380/2024) — pix_recv (mandato recorrente) + revogar + consultar + healthCheck + processWebhook; Onda 4d.1. base_url configurável via credential"
+  - "Services/Drivers/PagarmeDriver — Pagar.me v5 REST (boleto + pix_cob + card + refund parcial + cancelar + consultar + healthCheck + processWebhook); Onda 4e. HTTP Basic Auth via secret_key, sandbox via prefixo sk_test_*"
   - "BoletoService (Onda 4d alto-nível)"
   - "RemessaCnabService (Onda 4d)"
   - "RetornoCnabService (Onda 4d)"
@@ -46,6 +48,7 @@ url_prefixes:
   - /webhooks/c6 (migrado)
   - /webhooks/asaas (migrado)
   - /webhooks/bcb-pix (novo)
+  - /webhooks/pagarme (Onda 4e)
 db_tables_owned:
   - payment_gateway_credentials
   - cobrancas

--- a/Modules/PaymentGateway/Services/Drivers/PagarmeDriver.php
+++ b/Modules/PaymentGateway/Services/Drivers/PagarmeDriver.php
@@ -1,0 +1,491 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Services\Drivers;
+
+use Carbon\Carbon;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Support\Facades\Http;
+use Modules\PaymentGateway\Contracts\PaymentDriverContract;
+use Modules\PaymentGateway\Dto\CardToken;
+use Modules\PaymentGateway\Dto\CobrancaEmitidaResult;
+use Modules\PaymentGateway\Dto\CobrancaStatus;
+use Modules\PaymentGateway\Dto\DriverHealth;
+use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
+use Modules\PaymentGateway\Exceptions\CardDeclinedException;
+use Modules\PaymentGateway\Exceptions\CredentialMisconfiguredException;
+use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
+use Modules\PaymentGateway\Exceptions\GatewayUnavailableException;
+use Modules\PaymentGateway\Exceptions\InvalidPayerException;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+
+/**
+ * Driver Pagar.me — API v5 (Stone group).
+ *
+ * Onda 4e — ADR 0170. Driver Pagar.me espelha estrutura do AsaasDriver
+ * pra boleto+pix_cob+card; também suporta cancelar/refund/consultar/health/webhook.
+ *
+ * Suporta:
+ *   ✓ boleto, pix_cob, card
+ *   ✓ cancelar, refund (parcial OK via amount), consultar, healthCheck, processWebhook
+ * NÃO suporta (use outros drivers):
+ *   ✗ pix_cobv (PIX com vencimento regulado — Asaas/Inter)
+ *   ✗ pix_recv (PIX Automático mandato — BcbPix driver dedicado)
+ *
+ * ── DECISÕES DE PESQUISA (WebSearch 2026-05-22) ───────────────────────────
+ *
+ * 1. Endpoint base: `https://api.pagar.me/core/v5` (mesma URL pra sandbox + prod;
+ *    sandbox é determinado pelo prefixo da secret_key `sk_test_...`).
+ *    Fonte: https://docs.pagar.me/reference/autenticação-2
+ *
+ * 2. Auth: HTTP Basic Auth, username = secret_key, password vazio.
+ *    Header: `Authorization: Basic base64(secret_key:)`.
+ *    Laravel: `Http::withBasicAuth($secret, '')`.
+ *
+ * 3. Modelo:
+ *    - **Order** (POST /orders) contém items + customer + payments[]
+ *    - **Charge** é gerada dentro do order (1 charge por payment_method)
+ *    - Boleto/PIX/CC todos via Order. Resposta retorna `charges[0].id` (ch_xxx)
+ *      que é o id pra cancelar/refund/consultar.
+ *    Fonte: https://docs.pagar.me/reference/criar-pedido-2
+ *
+ * 4. Cancelar / Refund: `DELETE /charges/{charge_id}` body opcional {"amount":xxx}
+ *    pra refund parcial (cartão; boleto cancelado é só mudança de status).
+ *    Fonte: https://docs.pagar.me/reference/cancelar-cobrança
+ *
+ * 5. Status enum Pagar.me v5 charges:
+ *    `pending` (boleto não pago / pix não pago / card autorizado não capturado)
+ *    `paid` (pago/capturado)
+ *    `failed` (recusado / não confirmado)
+ *    `canceled` (estornado / cancelado)
+ *    `processing`, `overpaid`, `underpaid`, `chargedback`
+ *    Mapping → enum interno (paga/emitida/vencida/cancelada/pending).
+ *    Fonte: https://docs.pagar.me/page/chargeback-novo-status-na-cobrança
+ *
+ * 6. Webhook signature: header `X-Hub-Signature-256` formato `sha256=<hex>`
+ *    HMAC-SHA256(raw_body, webhook_secret) — secret configurado por endpoint
+ *    no dashboard Pagar.me. Comparação timing-safe via hash_equals.
+ *    Fonte: https://docs.pagar.me/reference/visão-geral-sobre-webhooks
+ *
+ * 7. Webhook events relevantes: `charge.paid`, `charge.payment_failed`,
+ *    `charge.refunded`, `charge.partial_canceled`, `charge.pending`,
+ *    `charge.chargedback`. Payload tem `data.id` (charge id), `type` (evento).
+ *
+ * 8. Health check: `GET /balance` (saldo da conta) — endpoint barato, exige
+ *    auth válida; retorna 200 ok ou 401 unauthorized. Boa pra ping.
+ *
+ * Credenciais (config_json):
+ *   secret_key:     "sk_test_..." (sandbox) | "sk_live_..." (prod)
+ *   ambiente:       'sandbox' | 'production' (informativo — endpoint igual)
+ *   webhook_secret: "..." (pra validar HMAC X-Hub-Signature-256)
+ *
+ * Custo IA: Driver NÃO chama LLM. Apenas HTTP REST Pagar.me. Latência média ~300ms
+ * em produção (Stone CDN), pode chegar a 2-3s em horário de pico de boletos.
+ */
+class PagarmeDriver implements PaymentDriverContract
+{
+    /**
+     * Pagar.me v5 — sandbox e prod usam a mesma URL.
+     * O que muda é o prefixo da secret_key ('sk_test_' vs 'sk_live_').
+     */
+    private const API_BASE = 'https://api.pagar.me/core/v5';
+
+    public function key(): string
+    {
+        return 'pagarme';
+    }
+
+    public function supports(string $tipo): bool
+    {
+        return in_array($tipo, ['boleto', 'pix_cob', 'card'], true);
+    }
+
+    public function emitirBoleto(EmitirCobrancaInput $input, object $cred): CobrancaEmitidaResult
+    {
+        return $this->emitirOrder($input, $cred, 'boleto');
+    }
+
+    public function emitirPix(EmitirCobrancaInput $input, object $cred, string $tipo): CobrancaEmitidaResult
+    {
+        if ($tipo !== 'cob') {
+            throw new DriverNotSupportedException("Pagar.me só suporta PIX cob; recebido '{$tipo}'");
+        }
+
+        return $this->emitirOrder($input, $cred, 'pix');
+    }
+
+    public function emitirPixAutomatico(EmitirCobrancaInput $input, object $cred): CobrancaEmitidaResult
+    {
+        throw new DriverNotSupportedException(
+            'Pagar.me não suporta PIX Automático (recv) via Open Finance Pix Automático regulado. ' .
+            'Use bcb_pix driver dedicado (Onda 4d).'
+        );
+    }
+
+    public function cobrarCartao(EmitirCobrancaInput $input, object $cred, CardToken $token): CobrancaEmitidaResult
+    {
+        $this->assertCredential($cred);
+
+        $payload = $this->buildOrderPayload($input, [
+            [
+                'payment_method' => 'credit_card',
+                'credit_card'    => [
+                    'card_token'   => $token->token, // tokenizado client-side (PCI)
+                    'installments' => (int) ($input->meta['installments'] ?? 1),
+                ],
+            ],
+        ]);
+
+        $response = $this->client($cred)->post('/orders', $payload);
+
+        // Pagar.me v5: 400 = invalid_request (cartão recusado vem como
+        // status='failed' na charge dentro de 200 OK também). Tratamos ambos.
+        if ($response->status() === 400 || $response->status() === 422) {
+            throw new CardDeclinedException(
+                'Pagar.me recusou cartão: ' . substr($response->body(), 0, 200)
+            );
+        }
+        if ($response->failed()) {
+            throw new GatewayUnavailableException(
+                "Pagar.me cartão falhou ({$response->status()}): " . substr($response->body(), 0, 200)
+            );
+        }
+
+        $data = $response->json() ?? [];
+        $charge = $data['charges'][0] ?? [];
+        $chargeId = (string) ($charge['id'] ?? '');
+
+        if ($chargeId === '') {
+            throw new InvalidPayerException('Pagar.me cartão retornou sem charge.id');
+        }
+
+        // Status 'failed' dentro do 200 OK = recusa do emissor.
+        if (($charge['status'] ?? '') === 'failed') {
+            throw new CardDeclinedException(
+                'Pagar.me cartão recusado pelo emissor: ' .
+                ($charge['last_transaction']['acquirer_message'] ?? 'sem mensagem')
+            );
+        }
+
+        return new CobrancaEmitidaResult(
+            cobrancaId: 0,
+            gatewayExternalId: $chargeId,
+            tipo: 'card',
+            emitidaEm: new \DateTimeImmutable(),
+            payloadGateway: $data,
+        );
+    }
+
+    public function cancelar(object $cobranca, object $cred, string $motivo): void
+    {
+        $this->assertCredential($cred);
+        $extId = (string) ($cobranca->gateway_external_id ?? '');
+        if ($extId === '') {
+            throw new InvalidPayerException('Cobranca sem gateway_external_id pra cancelar no Pagar.me');
+        }
+
+        // DELETE /charges/{id} sem amount = cancela total
+        $response = $this->client($cred)->delete("/charges/{$extId}");
+
+        if ($response->failed()) {
+            throw new GatewayUnavailableException(
+                "Pagar.me cancelar falhou ({$response->status()}): " . substr($response->body(), 0, 200)
+            );
+        }
+    }
+
+    public function refund(object $cobranca, object $cred, ?int $valorCentavos, string $motivo): void
+    {
+        $this->assertCredential($cred);
+        $extId = (string) ($cobranca->gateway_external_id ?? '');
+        if ($extId === '') {
+            throw new InvalidPayerException('Cobranca sem gateway_external_id pra estornar no Pagar.me');
+        }
+
+        // Pagar.me v5: refund = DELETE /charges/{id} com body {amount} pra parcial
+        $payload = [];
+        if ($valorCentavos !== null) {
+            $payload['amount'] = $valorCentavos; // Pagar.me usa centavos como int
+        }
+
+        $response = $this->client($cred)
+            ->withBody(json_encode($payload, JSON_UNESCAPED_UNICODE), 'application/json')
+            ->delete("/charges/{$extId}");
+
+        if ($response->failed()) {
+            throw new GatewayUnavailableException(
+                "Pagar.me refund falhou ({$response->status()}): " . substr($response->body(), 0, 200)
+            );
+        }
+    }
+
+    public function consultar(object $cobranca, object $cred): CobrancaStatus
+    {
+        $this->assertCredential($cred);
+        $extId = (string) ($cobranca->gateway_external_id ?? '');
+        if ($extId === '') {
+            throw new InvalidPayerException('Cobranca sem gateway_external_id pra consultar no Pagar.me');
+        }
+
+        $response = $this->client($cred)->get("/charges/{$extId}");
+        if ($response->failed()) {
+            throw new GatewayUnavailableException(
+                "Pagar.me consultar falhou ({$response->status()}): " . substr($response->body(), 0, 200)
+            );
+        }
+
+        $data = $response->json() ?? [];
+
+        return new CobrancaStatus(
+            status: $this->mapStatus((string) ($data['status'] ?? '')),
+            pagaEm: ! empty($data['paid_at']) ? new \DateTimeImmutable($data['paid_at']) : null,
+            valorPagoCentavos: isset($data['paid_amount']) ? (int) $data['paid_amount'] : null,
+            formaPagamento: $this->mapPaymentMethod((string) ($data['payment_method'] ?? '')),
+            payloadGateway: $data,
+        );
+    }
+
+    public function healthCheck(object $cred): DriverHealth
+    {
+        $this->assertCredential($cred);
+        $start = microtime(true);
+
+        try {
+            // GET /balance é o ping canônico (endpoint barato, exige auth válida)
+            $response = $this->client($cred)->get('/balance');
+            $latencyMs = (int) round((microtime(true) - $start) * 1000);
+
+            if ($response->successful()) {
+                return new DriverHealth(
+                    ok: true,
+                    status: $latencyMs > 3000 ? 'degraded' : 'ok',
+                    latencyMs: $latencyMs,
+                    checkedAt: new \DateTimeImmutable(),
+                );
+            }
+
+            return new DriverHealth(
+                ok: false,
+                status: 'down',
+                latencyMs: $latencyMs,
+                checkedAt: new \DateTimeImmutable(),
+                errorMessage: "Pagar.me {$response->status()}: " . substr($response->body(), 0, 120),
+            );
+        } catch (\Throwable $e) {
+            return new DriverHealth(
+                ok: false,
+                status: 'down',
+                latencyMs: (int) round((microtime(true) - $start) * 1000),
+                checkedAt: new \DateTimeImmutable(),
+                errorMessage: $e->getMessage(),
+            );
+        }
+    }
+
+    /**
+     * Processa payload de webhook Pagar.me — chamado pelo PagarmeWebhookController.
+     *
+     * Pagar.me v5 envia eventos no shape:
+     *   {
+     *     "id": "hook_xxx",
+     *     "type": "charge.paid" | "charge.payment_failed" | "charge.refunded" | ...,
+     *     "data": { "id": "ch_xxx", "status": "paid", ... }   // a charge afetada
+     *   }
+     *
+     * Validação HMAC é responsabilidade do controller (precisa raw body).
+     * Aqui só extraímos charge_id pra resolver Cobranca.
+     */
+    public function processWebhook(array $payload, object $cred): ?object
+    {
+        $extId = (string) (
+            $payload['data']['id']
+            ?? $payload['data']['charge']['id']
+            ?? ''
+        );
+
+        if ($extId === '') {
+            return null;
+        }
+
+        return (object) [
+            'gateway_external_id' => $extId,
+            'gateway_key'         => $this->key(),
+            'event_type'          => (string) ($payload['type'] ?? ''),
+            'raw_payload'         => $payload,
+        ];
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────
+
+    /**
+     * Cria order com payment_method especificado (boleto|pix).
+     * Para 'card', use cobrarCartao (precisa CardToken).
+     */
+    private function emitirOrder(EmitirCobrancaInput $input, object $cred, string $paymentMethod): CobrancaEmitidaResult
+    {
+        $this->assertCredential($cred);
+
+        $paymentBlock = match ($paymentMethod) {
+            'boleto' => [
+                'payment_method' => 'boleto',
+                'boleto'         => [
+                    'instructions' => $input->instrucoesPagador ?: 'Pagar até a data de vencimento',
+                    'due_at'       => Carbon::instance($input->vencimento)->toIso8601String(),
+                ],
+            ],
+            'pix' => [
+                'payment_method' => 'pix',
+                'pix'            => [
+                    'expires_in' => $this->expiresInSecondsFrom($input->vencimento),
+                ],
+            ],
+            default => throw new DriverNotSupportedException("emitirOrder não suporta '{$paymentMethod}'")
+        };
+
+        $payload = $this->buildOrderPayload($input, [$paymentBlock]);
+        $response = $this->client($cred)->post('/orders', $payload);
+
+        if ($response->failed()) {
+            throw new GatewayUnavailableException(
+                "Pagar.me {$paymentMethod} falhou ({$response->status()}): " . substr($response->body(), 0, 200)
+            );
+        }
+
+        $data = $response->json() ?? [];
+        $charge = $data['charges'][0] ?? [];
+        $chargeId = (string) ($charge['id'] ?? '');
+        if ($chargeId === '') {
+            throw new InvalidPayerException('Pagar.me retornou sem charge.id — payload incompleto');
+        }
+
+        $lastTx = $charge['last_transaction'] ?? [];
+
+        $linhaDigitavel = null;
+        $codigoBarras = null;
+        $boletoPdfUrl = null;
+        $pixEmv = null;
+        $pixQrCodePath = null;
+
+        if ($paymentMethod === 'boleto') {
+            $linhaDigitavel = (string) ($lastTx['line'] ?? '') ?: null;
+            $codigoBarras   = (string) ($lastTx['barcode'] ?? '') ?: null;
+            $boletoPdfUrl   = (string) ($lastTx['pdf'] ?? $lastTx['url'] ?? '') ?: null;
+        }
+
+        if ($paymentMethod === 'pix') {
+            $pixEmv        = (string) ($lastTx['qr_code'] ?? '') ?: null;
+            $pixQrCodePath = (string) ($lastTx['qr_code_url'] ?? '') ?: null;
+        }
+
+        return new CobrancaEmitidaResult(
+            cobrancaId: 0,
+            gatewayExternalId: $chargeId,
+            tipo: $paymentMethod === 'boleto' ? 'boleto' : 'pix_cob',
+            emitidaEm: new \DateTimeImmutable(),
+            linhaDigitavel: $linhaDigitavel,
+            codigoBarras: $codigoBarras,
+            pixEmv: $pixEmv,
+            pixQrCodePath: $pixQrCodePath,
+            boletoPdfUrl: $boletoPdfUrl,
+            payloadGateway: $data,
+        );
+    }
+
+    /**
+     * Monta payload base do POST /orders compartilhado por boleto/pix/card.
+     */
+    private function buildOrderPayload(EmitirCobrancaInput $input, array $payments): array
+    {
+        $cpfCnpj = preg_replace('/\D/', '', $input->meta['payer_cpf_cnpj'] ?? '');
+        $name = (string) ($input->meta['payer_name'] ?? "Pagador {$input->contactId}");
+        $email = (string) ($input->meta['payer_email'] ?? '');
+
+        if ($cpfCnpj === '') {
+            throw new InvalidPayerException('Pagar.me exige CPF/CNPJ do pagador em meta.payer_cpf_cnpj');
+        }
+
+        $customer = array_filter([
+            'name'           => $name,
+            'email'          => $email !== '' ? $email : null,
+            'document'       => $cpfCnpj,
+            'document_type'  => strlen($cpfCnpj) === 11 ? 'CPF' : 'CNPJ',
+            'type'           => strlen($cpfCnpj) === 11 ? 'individual' : 'company',
+            'code'           => 'contact:' . $input->contactId,
+        ]);
+
+        return [
+            'code'      => $input->idempotencyKey,
+            'customer'  => $customer,
+            'items'     => [[
+                'amount'      => $input->valorCentavos,
+                'description' => substr($input->descricao, 0, 254),
+                'quantity'    => 1,
+                'code'        => 'item:' . $input->idempotencyKey,
+            ]],
+            'payments'  => $payments,
+        ];
+    }
+
+    private function expiresInSecondsFrom(\DateTimeInterface $vencimento): int
+    {
+        $diff = $vencimento->getTimestamp() - time();
+        // Pagar.me PIX exige expires_in > 0. Default 1h se já passou.
+        return $diff > 0 ? $diff : 3600;
+    }
+
+    private function assertCredential(object $cred): void
+    {
+        if (! $cred instanceof PaymentGatewayCredential) {
+            throw new CredentialMisconfiguredException(
+                'Credential precisa ser PaymentGatewayCredential, recebeu: ' . get_class($cred)
+            );
+        }
+        if ($cred->gateway_key !== 'pagarme') {
+            throw new CredentialMisconfiguredException(
+                "Credential gateway_key='{$cred->gateway_key}' não bate com driver Pagar.me"
+            );
+        }
+        if (empty($cred->config_json['secret_key'])) {
+            throw new CredentialMisconfiguredException(
+                'Pagar.me credential precisa secret_key em config_json (sk_test_* ou sk_live_*)'
+            );
+        }
+    }
+
+    private function client(PaymentGatewayCredential $cred): PendingRequest
+    {
+        $secret = (string) ($cred->config_json['secret_key'] ?? '');
+
+        return Http::baseUrl(self::API_BASE)
+            ->withBasicAuth($secret, '')
+            ->acceptJson()
+            ->asJson()
+            ->timeout(30);
+    }
+
+    /**
+     * Mapeia status Pagar.me v5 → enum canon interno
+     * (paga | emitida | vencida | cancelada | pending | erro).
+     */
+    private function mapStatus(string $pagarmeStatus): string
+    {
+        return match (strtolower($pagarmeStatus)) {
+            'paid', 'overpaid'                    => 'paga',
+            'pending', 'processing', 'underpaid'  => 'emitida',
+            'canceled', 'refunded', 'partial_canceled' => 'cancelada',
+            'failed', 'chargedback'               => 'erro',
+            default                               => 'pending',
+        };
+    }
+
+    private function mapPaymentMethod(string $method): ?string
+    {
+        return match (strtolower($method)) {
+            'boleto'                    => 'boleto',
+            'pix'                       => 'pix',
+            'credit_card', 'debit_card' => 'cartao',
+            default                     => null,
+        };
+    }
+}

--- a/Modules/PaymentGateway/Services/PaymentGatewayService.php
+++ b/Modules/PaymentGateway/Services/PaymentGatewayService.php
@@ -21,6 +21,7 @@ use Modules\PaymentGateway\Services\Drivers\AsaasDriver;
 use Modules\PaymentGateway\Services\Drivers\BcbPixDriver;
 use Modules\PaymentGateway\Services\Drivers\C6Driver;
 use Modules\PaymentGateway\Services\Drivers\InterDriver;
+use Modules\PaymentGateway\Services\Drivers\PagarmeDriver;
 
 /**
  * Implementação do PaymentGatewayContract — coordena drivers + persistência.
@@ -40,7 +41,8 @@ class PaymentGatewayService implements PaymentGatewayContract
      *
      * Onda 4a: inter
      * Onda 4b: + c6, asaas
-     * Onda 4d.1: + bcb_pix (este PR — PIX Automático regulado BCB)
+     * Onda 4d.1: + bcb_pix (PIX Automático regulado BCB)
+     * Onda 4e: + pagarme (Pagar.me v5 — Stone group — boleto/pix_cob/card)
      * Onda 5/6: pesapal (deprecated → remoção)
      */
     private const DRIVERS = [
@@ -48,6 +50,7 @@ class PaymentGatewayService implements PaymentGatewayContract
         'c6'      => C6Driver::class,
         'asaas'   => AsaasDriver::class,
         'bcb_pix' => BcbPixDriver::class,
+        'pagarme' => PagarmeDriver::class,
     ];
 
     /**

--- a/Modules/PaymentGateway/Tests/Feature/PagarmeDriverTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/PagarmeDriverTest.php
@@ -1,0 +1,419 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Modules\PaymentGateway\Dto\CardToken;
+use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
+use Modules\PaymentGateway\Exceptions\CardDeclinedException;
+use Modules\PaymentGateway\Exceptions\CredentialMisconfiguredException;
+use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
+use Modules\PaymentGateway\Exceptions\GatewayUnavailableException;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+use Modules\PaymentGateway\Services\Drivers\PagarmeDriver;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Helper: cria PaymentGatewayCredential in-memory (sem save) — testes do
+ * driver isoladamente NÃO precisam do registro persistido em DB. Isso evita
+ * dependência de `RefreshDatabase` que, neste worktree, tropeça em migrations
+ * MySQL-only do projeto (ALTER TABLE MODIFY COLUMN) incompatíveis com SQLite.
+ */
+function makeCred(array $configOverride = []): PaymentGatewayCredential
+{
+    $cred = new PaymentGatewayCredential();
+    $cred->setRawAttributes([
+        'id'           => 99,
+        'business_id'  => 1,
+        'gateway_key'  => 'pagarme',
+        'ambiente'     => 'sandbox',
+        'ativo'        => true,
+        'nome_display' => 'Pagar.me Test',
+        'config_json'  => json_encode(array_merge([
+            'secret_key'     => 'sk_test_fake_pagarme_token',
+            'webhook_secret' => 'whsec_fake_pagarme',
+        ], $configOverride)),
+    ], true);
+    $cred->exists = true;
+
+    return $cred;
+}
+
+beforeEach(function () {
+    $this->cred = makeCred();
+});
+
+// ─── (1) key + supports ──────────────────────────────────────────────────
+
+it('PagarmeDriver key=pagarme e supports boleto/pix_cob/card', function () {
+    $d = new PagarmeDriver();
+    expect($d->key())->toBe('pagarme');
+    expect($d->supports('boleto'))->toBeTrue();
+    expect($d->supports('pix_cob'))->toBeTrue();
+    expect($d->supports('card'))->toBeTrue();
+    expect($d->supports('pix_cobv'))->toBeFalse();
+    expect($d->supports('pix_recv'))->toBeFalse();
+});
+
+// ─── (2) emitirBoleto ────────────────────────────────────────────────────
+
+it('emitirBoleto Pagar.me pipeline OK', function () {
+    Http::fake([
+        '*/orders' => Http::response([
+            'id'      => 'or_001',
+            'code'    => 'sale:pagarme-boleto-001',
+            'status'  => 'pending',
+            'charges' => [[
+                'id'             => 'ch_boleto_001',
+                'status'         => 'pending',
+                'payment_method' => 'boleto',
+                'last_transaction' => [
+                    'line'    => '03399.65656 12345.678901 12345.678901 1 99990000010000',
+                    'barcode' => '03399999900000100001234567890123456789012345',
+                    'pdf'     => 'https://api.pagar.me/core/v5/transactions/tr_001/pdf',
+                    'url'     => 'https://pagar.me/boleto/visualizar/ch_boleto_001',
+                ],
+            ]],
+        ], 200),
+    ]);
+
+    $d = new PagarmeDriver();
+    $result = $d->emitirBoleto(new EmitirCobrancaInput(
+        businessId: 1,
+        contactId: 200,
+        valorCentavos: 15000,
+        vencimento: new DateTimeImmutable('+5 days'),
+        descricao: 'Pagar.me teste boleto',
+        idempotencyKey: 'sale:pagarme-boleto-001',
+        meta: ['payer_cpf_cnpj' => '12345678900', 'payer_name' => 'João Pagador', 'payer_email' => 'joao@x.com'],
+    ), $this->cred);
+
+    expect($result->tipo)->toBe('boleto');
+    expect($result->gatewayExternalId)->toBe('ch_boleto_001');
+    expect($result->linhaDigitavel)->toContain('03399');
+    expect($result->codigoBarras)->toContain('03399');
+    expect($result->boletoPdfUrl)->toContain('pdf');
+
+    // Garante shape do payload enviado (auth basic, items, customer, payment_method)
+    Http::assertSent(function ($r) {
+        return str_contains($r->url(), '/core/v5/orders')
+            && $r->method() === 'POST'
+            && $r['customer']['document'] === '12345678900'
+            && $r['customer']['document_type'] === 'CPF'
+            && $r['items'][0]['amount'] === 15000
+            && $r['payments'][0]['payment_method'] === 'boleto'
+            && ! empty($r['payments'][0]['boleto']['due_at']);
+    });
+});
+
+// ─── (3) emitirPix tipo=cob ──────────────────────────────────────────────
+
+it('emitirPix Pagar.me tipo=cob OK', function () {
+    Http::fake([
+        '*/orders' => Http::response([
+            'id'      => 'or_pix_001',
+            'status'  => 'pending',
+            'charges' => [[
+                'id'             => 'ch_pix_001',
+                'status'         => 'pending',
+                'payment_method' => 'pix',
+                'last_transaction' => [
+                    'qr_code'     => '00020126830014br.gov.bcb.pix...PAGARME-EMV-fake...6304A1B2',
+                    'qr_code_url' => 'https://api.pagar.me/qr/ch_pix_001.png',
+                ],
+            ]],
+        ], 200),
+    ]);
+
+    $d = new PagarmeDriver();
+    $result = $d->emitirPix(new EmitirCobrancaInput(
+        businessId: 1, contactId: 200, valorCentavos: 5000,
+        vencimento: new DateTimeImmutable('+1 day'),
+        descricao: 'PIX Pagar.me', idempotencyKey: 'sale:pagarme-pix-001',
+        meta: ['payer_cpf_cnpj' => '12345678900', 'payer_name' => 'João Pix'],
+    ), $this->cred, 'cob');
+
+    expect($result->tipo)->toBe('pix_cob');
+    expect($result->gatewayExternalId)->toBe('ch_pix_001');
+    expect($result->pixEmv)->toContain('00020126');
+    expect($result->pixQrCodePath)->toContain('qr/ch_pix_001');
+});
+
+it('emitirPix tipo=cobv → DriverNotSupportedException no Pagar.me', function () {
+    $d = new PagarmeDriver();
+    expect(fn () => $d->emitirPix(
+        new EmitirCobrancaInput(
+            businessId: 1, contactId: 1, valorCentavos: 100,
+            vencimento: new DateTimeImmutable(), descricao: 'x', idempotencyKey: 'k',
+            meta: ['payer_cpf_cnpj' => '12345678900', 'payer_name' => 'X'],
+        ),
+        $this->cred,
+        'cobv',
+    ))->toThrow(DriverNotSupportedException::class);
+});
+
+it('emitirPixAutomatico → DriverNotSupportedException no Pagar.me', function () {
+    $d = new PagarmeDriver();
+    expect(fn () => $d->emitirPixAutomatico(
+        new EmitirCobrancaInput(
+            businessId: 1, contactId: 1, valorCentavos: 100,
+            vencimento: new DateTimeImmutable(), descricao: 'x', idempotencyKey: 'k',
+            meta: ['payer_cpf_cnpj' => '12345678900', 'payer_name' => 'X'],
+        ),
+        $this->cred,
+    ))->toThrow(DriverNotSupportedException::class);
+});
+
+// ─── (4) cobrarCartao ───────────────────────────────────────────────────
+
+it('cobrarCartao Pagar.me com card_token → CobrancaEmitida', function () {
+    Http::fake([
+        '*/orders' => Http::response([
+            'id'      => 'or_card_001',
+            'status'  => 'paid',
+            'charges' => [[
+                'id'             => 'ch_card_001',
+                'status'         => 'paid',
+                'payment_method' => 'credit_card',
+            ]],
+        ], 200),
+    ]);
+
+    $d = new PagarmeDriver();
+    $token = new CardToken(
+        token: 'card_token_abc',
+        brand: 'visa',
+        lastFour: '4242',
+        holderName: 'João Cartão',
+        expMonth: '12',
+        expYear: '2030',
+    );
+    $result = $d->cobrarCartao(new EmitirCobrancaInput(
+        businessId: 1, contactId: 200, valorCentavos: 9999,
+        vencimento: new DateTimeImmutable('+1 day'),
+        descricao: 'card teste', idempotencyKey: 'card:001',
+        meta: ['payer_cpf_cnpj' => '12345678900', 'payer_name' => 'João', 'installments' => 3],
+    ), $this->cred, $token);
+
+    expect($result->tipo)->toBe('card');
+    expect($result->gatewayExternalId)->toBe('ch_card_001');
+
+    Http::assertSent(fn ($r) => $r['payments'][0]['payment_method'] === 'credit_card'
+        && $r['payments'][0]['credit_card']['card_token'] === 'card_token_abc'
+        && $r['payments'][0]['credit_card']['installments'] === 3);
+});
+
+it('cobrarCartao 400 → CardDeclinedException', function () {
+    Http::fake([
+        '*/orders' => Http::response(['errors' => [['message' => 'invalid_card']]], 400),
+    ]);
+
+    $d = new PagarmeDriver();
+    $token = new CardToken(token: 'tok_x', brand: 'visa', lastFour: '4242', holderName: 'X', expMonth: '12', expYear: '2030');
+
+    expect(fn () => $d->cobrarCartao(
+        new EmitirCobrancaInput(
+            businessId: 1, contactId: 200, valorCentavos: 9999,
+            vencimento: new DateTimeImmutable('+1 day'), descricao: 'card', idempotencyKey: 'card:002',
+            meta: ['payer_cpf_cnpj' => '12345678900', 'payer_name' => 'X'],
+        ),
+        $this->cred,
+        $token,
+    ))->toThrow(CardDeclinedException::class);
+});
+
+it('cobrarCartao charge.status=failed → CardDeclinedException', function () {
+    Http::fake([
+        '*/orders' => Http::response([
+            'id'      => 'or_x',
+            'charges' => [[
+                'id'              => 'ch_failed',
+                'status'          => 'failed',
+                'last_transaction' => ['acquirer_message' => 'Cartão recusado pelo emissor'],
+            ]],
+        ], 200),
+    ]);
+
+    $d = new PagarmeDriver();
+    $token = new CardToken(token: 'tok_x', brand: 'visa', lastFour: '4242', holderName: 'X', expMonth: '12', expYear: '2030');
+
+    expect(fn () => $d->cobrarCartao(
+        new EmitirCobrancaInput(
+            businessId: 1, contactId: 200, valorCentavos: 100,
+            vencimento: new DateTimeImmutable('+1 day'), descricao: 'card', idempotencyKey: 'card:003',
+            meta: ['payer_cpf_cnpj' => '12345678900', 'payer_name' => 'X'],
+        ),
+        $this->cred,
+        $token,
+    ))->toThrow(CardDeclinedException::class);
+});
+
+// ─── (5) consultar ───────────────────────────────────────────────────────
+
+it('consultar Pagar.me mapeia status canon', function () {
+    Http::fake([
+        '*/charges/ch_paga' => Http::response([
+            'id'             => 'ch_paga',
+            'status'         => 'paid',
+            'paid_at'        => '2026-05-19T12:34:56Z',
+            'paid_amount'    => 14500,
+            'payment_method' => 'boleto',
+        ], 200),
+    ]);
+
+    $cobranca = (object) ['gateway_external_id' => 'ch_paga'];
+    $status = (new PagarmeDriver())->consultar($cobranca, $this->cred);
+
+    expect($status->status)->toBe('paga');
+    expect($status->valorPagoCentavos)->toBe(14500);
+    expect($status->formaPagamento)->toBe('boleto');
+});
+
+it('consultar Pagar.me status=failed → erro', function () {
+    Http::fake([
+        '*/charges/ch_fail' => Http::response([
+            'id'             => 'ch_fail',
+            'status'         => 'failed',
+            'payment_method' => 'credit_card',
+        ], 200),
+    ]);
+
+    $cobranca = (object) ['gateway_external_id' => 'ch_fail'];
+    $status = (new PagarmeDriver())->consultar($cobranca, $this->cred);
+    expect($status->status)->toBe('erro');
+});
+
+// ─── (6) cancelar + refund ───────────────────────────────────────────────
+
+it('cancelar Pagar.me chama DELETE /charges/{id}', function () {
+    Http::fake(['*/charges/ch_cancel' => Http::response(['id' => 'ch_cancel', 'status' => 'canceled'], 200)]);
+
+    $cobranca = (object) ['gateway_external_id' => 'ch_cancel'];
+    (new PagarmeDriver())->cancelar($cobranca, $this->cred, 'Cliente desistiu');
+
+    Http::assertSent(fn ($r) => $r->method() === 'DELETE' && str_contains($r->url(), '/charges/ch_cancel'));
+});
+
+it('refund Pagar.me parcial envia amount em centavos', function () {
+    Http::fake(['*/charges/ch_refund' => Http::response(['status' => 'partial_canceled'], 200)]);
+
+    $cobranca = (object) ['gateway_external_id' => 'ch_refund'];
+    (new PagarmeDriver())->refund($cobranca, $this->cred, 5000, 'Estorno parcial');
+
+    Http::assertSent(function ($r) {
+        if ($r->method() !== 'DELETE' || ! str_contains($r->url(), '/charges/ch_refund')) {
+            return false;
+        }
+        $body = json_decode($r->body(), true) ?? [];
+        return ($body['amount'] ?? null) === 5000;
+    });
+});
+
+it('refund Pagar.me total NÃO envia amount no body', function () {
+    Http::fake(['*/charges/ch_refund_total' => Http::response(['status' => 'canceled'], 200)]);
+
+    $cobranca = (object) ['gateway_external_id' => 'ch_refund_total'];
+    (new PagarmeDriver())->refund($cobranca, $this->cred, null, 'Total');
+
+    Http::assertSent(function ($r) {
+        if ($r->method() !== 'DELETE' || ! str_contains($r->url(), 'ch_refund_total')) {
+            return false;
+        }
+        $body = json_decode($r->body(), true) ?? [];
+        return ! array_key_exists('amount', $body);
+    });
+});
+
+// ─── (7) healthCheck ─────────────────────────────────────────────────────
+
+it('healthCheck OK quando GET /balance retorna 200', function () {
+    Http::fake(['*/balance' => Http::response(['available_amount' => 100000, 'currency' => 'BRL'], 200)]);
+
+    $h = (new PagarmeDriver())->healthCheck($this->cred);
+    expect($h->ok)->toBeTrue();
+    expect($h->status)->toBeIn(['ok', 'degraded']);
+});
+
+it('healthCheck down em 401', function () {
+    Http::fake(['*/balance' => Http::response(['errors' => ['unauthorized']], 401)]);
+
+    $h = (new PagarmeDriver())->healthCheck($this->cred);
+    expect($h->ok)->toBeFalse();
+    expect($h->status)->toBe('down');
+});
+
+// ─── (8) processWebhook ──────────────────────────────────────────────────
+
+it('processWebhook lê data.id (charge id) e type', function () {
+    $d = new PagarmeDriver();
+
+    $r1 = $d->processWebhook([
+        'id'   => 'hook_001',
+        'type' => 'charge.paid',
+        'data' => ['id' => 'ch_paid_001', 'status' => 'paid'],
+    ], $this->cred);
+    expect($r1->gateway_external_id)->toBe('ch_paid_001');
+    expect($r1->event_type)->toBe('charge.paid');
+    expect($r1->gateway_key)->toBe('pagarme');
+
+    $r2 = $d->processWebhook([
+        'id'   => 'hook_002',
+        'type' => 'charge.refunded',
+        'data' => ['charge' => ['id' => 'ch_002']],
+    ], $this->cred);
+    expect($r2->gateway_external_id)->toBe('ch_002');
+
+    $r3 = $d->processWebhook(['type' => 'foo.bar'], $this->cred);
+    expect($r3)->toBeNull();
+});
+
+// ─── (9) error paths ────────────────────────────────────────────────────
+
+it('emitirBoleto 500 → GatewayUnavailableException', function () {
+    Http::fake(['*/orders' => Http::response(['error' => 'internal'], 500)]);
+
+    $d = new PagarmeDriver();
+    expect(fn () => $d->emitirBoleto(
+        new EmitirCobrancaInput(
+            businessId: 1, contactId: 1, valorCentavos: 100,
+            vencimento: new DateTimeImmutable('+1 day'), descricao: 'x', idempotencyKey: 'k',
+            meta: ['payer_cpf_cnpj' => '12345678900', 'payer_name' => 'X'],
+        ),
+        $this->cred,
+    ))->toThrow(GatewayUnavailableException::class);
+});
+
+it('credential gateway_key errado → CredentialMisconfigured', function () {
+    $bad = new PaymentGatewayCredential();
+    $bad->setRawAttributes([
+        'id' => 88, 'business_id' => 1, 'gateway_key' => 'asaas',
+        'ambiente' => 'sandbox', 'ativo' => true,
+        'config_json' => json_encode(['api_key' => 'x']),
+    ], true);
+    expect(fn () => (new PagarmeDriver())->healthCheck($bad))
+        ->toThrow(CredentialMisconfiguredException::class);
+});
+
+it('credential sem secret_key → CredentialMisconfigured', function () {
+    $bad = new PaymentGatewayCredential();
+    $bad->setRawAttributes([
+        'id' => 87, 'business_id' => 1, 'gateway_key' => 'pagarme',
+        'ambiente' => 'sandbox', 'ativo' => true,
+        'config_json' => json_encode(['webhook_secret' => 'x']), // sem secret_key
+    ], true);
+    expect(fn () => (new PagarmeDriver())->healthCheck($bad))
+        ->toThrow(CredentialMisconfiguredException::class);
+});
+
+it('Pagar.me exige payer_cpf_cnpj → InvalidPayerException', function () {
+    $d = new PagarmeDriver();
+    expect(fn () => $d->emitirBoleto(
+        new EmitirCobrancaInput(
+            businessId: 1, contactId: 1, valorCentavos: 100,
+            vencimento: new DateTimeImmutable('+1 day'), descricao: 'x', idempotencyKey: 'k',
+            meta: [],
+        ),
+        $this->cred,
+    ))->toThrow(\Modules\PaymentGateway\Exceptions\InvalidPayerException::class);
+});

--- a/resources/js/Pages/Financeiro/Cobranca/_lib/cobranca-shared.ts
+++ b/resources/js/Pages/Financeiro/Cobranca/_lib/cobranca-shared.ts
@@ -4,7 +4,7 @@
 export type CobrancaTipo = 'boleto' | 'pix_cob' | 'pix_cobv' | 'pix_recv' | 'card';
 export type CobrancaStatus = 'emitida' | 'paga' | 'vencida' | 'cancelada' | 'erro' | 'pending';
 export type OrigemType = 'sale' | 'invoice' | 'subscription_license';
-export type GatewayKey = 'inter' | 'c6' | 'asaas' | 'bcb_pix' | 'pesapal';
+export type GatewayKey = 'inter' | 'c6' | 'asaas' | 'bcb_pix' | 'pesapal' | 'pagarme';
 
 export interface Cobranca {
   id: number;
@@ -141,6 +141,13 @@ export const DRIVERS: Record<GatewayKey, DriverToken> = {
     cred: 'api_key + consumer_secret',
     deprecated: true,
     deprecatedReason: 'Migrar pra Asaas (cartão BR nativo + 3DS)',
+  },
+  pagarme: {
+    key: 'pagarme', nome: 'Pagar.me', sigla: 'PG',
+    dot: 'bg-rose-500', bg: 'bg-rose-50', fg: 'text-rose-700', border: 'border-rose-200',
+    tipos: ['boleto', 'pix_cob', 'card'],
+    ambientes: ['sandbox', 'production'],
+    cred: 'secret_key + webhook_secret · HMAC SHA256 (X-Hub-Signature-256)',
   },
 };
 

--- a/resources/js/Pages/Settings/PaymentGateways/_components/DrawerGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/DrawerGateway.tsx
@@ -357,6 +357,28 @@ export default function DrawerGateway({ gateway, accounts, onClose, onToggle }: 
                   <Btn variant="outline" size="xs" className="mt-2 !border-amber-300 !text-amber-800">Iniciar migração</Btn>
                 </div>
               )}
+              {d.key === 'pagarme' && (
+                <>
+                  <Field label="Secret Key (atualizar)">
+                    <input
+                      type="password"
+                      value={config.secret_key ?? ''}
+                      onChange={e => setConfigField('secret_key', e.target.value)}
+                      placeholder="sk_test_••• ou sk_live_••• (digite novo pra trocar)"
+                      className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
+                    />
+                  </Field>
+                  <Field label="Webhook Secret (atualizar)">
+                    <input
+                      type="password"
+                      value={config.webhook_secret ?? ''}
+                      onChange={e => setConfigField('webhook_secret', e.target.value)}
+                      placeholder="whsec_••• (HMAC X-Hub-Signature-256)"
+                      className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
+                    />
+                  </Field>
+                </>
+              )}
             </div>
           )}
 

--- a/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
@@ -306,6 +306,29 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
                   />
                 </Field>
               </>}
+              {d.key === 'pagarme' && <>
+                <Field label="Secret Key">
+                  <input
+                    type="password"
+                    value={config.secret_key ?? ''}
+                    onChange={e => setConfigField('secret_key', e.target.value)}
+                    placeholder="sk_test_... ou sk_live_..."
+                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
+                  />
+                </Field>
+                <Field label="Webhook Secret">
+                  <input
+                    type="password"
+                    value={config.webhook_secret ?? ''}
+                    onChange={e => setConfigField('webhook_secret', e.target.value)}
+                    placeholder="whsec_••• (validação HMAC X-Hub-Signature-256)"
+                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
+                  />
+                </Field>
+                <div className="bg-stone-50 border border-stone-200 rounded p-2.5 text-[10.5px] text-stone-700">
+                  Sandbox via prefixo <span className="font-mono">sk_test_</span> · Production via <span className="font-mono">sk_live_</span>. Webhook secret é configurado no dashboard Pagar.me em Integrações → Webhooks.
+                </div>
+              </>}
 
               <div className="pt-2 border-t border-stone-200 mt-3 flex items-center gap-2">
                 <Btn variant="outline" disabled><Shield className="h-3 w-3" />Testar conexão</Btn>


### PR DESCRIPTION
Re-introduz PR #1420 (driver+webhook+Pest+route+service) e PR #1423 (UI+validator) após revert emergencial 2026-05-22 22:01 (site 500 invisível devido smoke false-positive). Agora com PR #1424 smoke strict + tail laravel.log on fail (PR #1424 já em main), se 500 voltar, deploy CI captura logs imediatamente.