### PR TITLE
feat(paymentgateway): seção Eventos webhook no DrawerGateway (Onda 4e.UI #2)

### DIFF
--- a/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
@@ -16,6 +16,7 @@ use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\PaymentGateway\Models\Cobranca;
+use Modules\PaymentGateway\Models\GatewayWebhookEvent;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\HealthCheckService;
 use Spatie\Activitylog\Models\Activity;
@@ -443,6 +444,61 @@ class PaymentGatewaysController extends Controller
         return response()->json([
             'entries' => $entries,
             'total'   => $entries->count(),
+        ]);
+    }
+
+    /**
+     * GET /settings/payment-gateways/{credentialId}/webhook-events
+     *
+     * Lista eventos de webhook recebidos pra esta credencial (últimos 50, DESC).
+     *
+     * Tier 0 (ADR 0093): credential precisa ser do business_id da sessão; eventos
+     * herdam mesmo filtro via FK payment_gateway_credential_id + business_id explícito.
+     *
+     * Shape (espelha contract HistoryEntry pra reuso UI pattern):
+     *   { events: [{ id, when, when_iso, evento, gateway_event_id, signature_valid,
+     *                processed_at, error_message, cobranca_id }], total }
+     *
+     * LGPD/PCI: payload completo NÃO retorna (pode conter PII redacted-via-PiiRedactor
+     * na hora de gravar, mas evita re-exposição). Só metadados.
+     *
+     * Onda 4e.UI #2 (gap P0 catalogado em estado-da-arte 2026-05-23) — fecha visibilidade
+     * do `gateway_webhook_events` que já existia no DB desde Onda 2 mas nunca foi exposto.
+     */
+    public function webhookEvents(Request $request, int $credentialId): JsonResponse
+    {
+        $businessId = (int) $request->session()->get('user.business_id', $request->session()->get('business.id', 0));
+
+        $credential = PaymentGatewayCredential::query()
+            ->where('business_id', $businessId)
+            ->find($credentialId);
+
+        if (! $credential) {
+            return response()->json(['events' => [], 'total' => 0], 404);
+        }
+
+        $rows = GatewayWebhookEvent::query()
+            ->where('business_id', $businessId)
+            ->where('payment_gateway_credential_id', $credentialId)
+            ->orderByDesc('created_at')
+            ->limit(50)
+            ->get();
+
+        $events = $rows->map(fn (GatewayWebhookEvent $e) => [
+            'id'                => $e->id,
+            'when'              => $e->created_at?->locale('pt_BR')->isoFormat('DD/MM HH:mm:ss'),
+            'when_iso'          => $e->created_at?->toIso8601String(),
+            'evento'            => $e->evento,
+            'gateway_event_id'  => $e->gateway_event_id,
+            'signature_valid'   => (bool) $e->signature_valid,
+            'processed_at'      => $e->processed_at?->toIso8601String(),
+            'error_message'     => $e->error_message,
+            'cobranca_id'       => $e->cobranca_id,
+        ]);
+
+        return response()->json([
+            'events' => $events,
+            'total'  => $events->count(),
         ]);
     }
 

--- a/Modules/PaymentGateway/Routes/web.php
+++ b/Modules/PaymentGateway/Routes/web.php
@@ -69,6 +69,11 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
         Route::get('payment-gateways/{credentialId}/history', [PaymentGatewaysController::class, 'history'])
             ->whereNumber('credentialId')
             ->name('payment-gateways.history');
+
+        // Onda 4e.UI #2 (gap P0 estado-da-arte 2026-05-23): webhook events per credential.
+        Route::get('payment-gateways/{credentialId}/webhook-events', [PaymentGatewaysController::class, 'webhookEvents'])
+            ->whereNumber('credentialId')
+            ->name('payment-gateways.webhook-events');
     });
 
 // ─── Webhooks (Onda 3) ───────────────────────────────────────────────────

--- a/Modules/PaymentGateway/Tests/Feature/Settings/PaymentGatewaysWebhookEventsTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/Settings/PaymentGatewaysWebhookEventsTest.php
@@ -1,0 +1,193 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\Role;
+use App\User;
+use Modules\PaymentGateway\Models\GatewayWebhookEvent;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+
+/**
+ * Pest GUARDs — GET /settings/payment-gateways/{id}/webhook-events (Onda 4e.UI #2).
+ *
+ * 4 GUARDs:
+ *   1) retorna 200 + events[] no shape esperado pra credencial do biz da sessão
+ *   2) NÃO expõe payload (PII guard — só metadados)
+ *   3) Tier 0 IRREVOGÁVEL: credencial de outro business → 404
+ *   4) limita a 50 events DESC por created_at + filtra por credential_id
+ *
+ * Gap fechado: estado-da-arte 2026-05-23 catalogou "Webhook delivery log invisível"
+ * como #2 P0. Tabela gateway_webhook_events existia desde Onda 2 mas UI não consumia.
+ *
+ * Refs: ADR 0093 (Tier 0), ADR 0170 Onda 4e.UI.
+ */
+
+beforeEach(function () {
+    setPermissionsTeamId(1);
+
+    $this->business = Business::query()->firstOrCreate(
+        ['id' => 1],
+        ['name' => 'Test HQ', 'currency_id' => 1],
+    );
+
+    $role = Role::firstOrCreate(
+        ['name' => "Admin#{$this->business->id}", 'business_id' => $this->business->id, 'guard_name' => 'web'],
+    );
+
+    $this->user = User::factory()->create([
+        'business_id' => $this->business->id,
+        'username' => 'gwe_test_'.uniqid(),
+    ]);
+    $this->user->assignRole($role);
+
+    $this->credential = PaymentGatewayCredential::create([
+        'business_id'   => $this->business->id,
+        'gateway_key'   => 'asaas',
+        'ambiente'      => 'sandbox',
+        'nome_display'  => 'Asaas Sandbox Test',
+        'config_json'   => ['api_key' => 'fake'],
+        'ativo'         => true,
+        'health_status' => 'unknown',
+    ]);
+});
+
+it('retorna 200 + events[] no shape esperado', function () {
+    GatewayWebhookEvent::create([
+        'business_id'                   => $this->business->id,
+        'payment_gateway_credential_id' => $this->credential->id,
+        'gateway_key'                   => 'asaas',
+        'evento'                        => 'PAYMENT_RECEIVED',
+        'gateway_event_id'              => 'evt_abc123',
+        'cobranca_id'                   => null,
+        'payload'                       => ['payment' => ['id' => 'pay_xyz'], 'event' => 'PAYMENT_RECEIVED'],
+        'signature_valid'               => true,
+        'processed_at'                  => now(),
+        'error_message'                 => null,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->withSession([
+            'user.business_id' => $this->business->id,
+            'business.id'      => $this->business->id,
+        ])
+        ->getJson("/settings/payment-gateways/{$this->credential->id}/webhook-events");
+
+    $response->assertOk()
+        ->assertJsonStructure([
+            'events' => [
+                '*' => ['id', 'when', 'when_iso', 'evento', 'gateway_event_id', 'signature_valid', 'processed_at', 'error_message', 'cobranca_id'],
+            ],
+            'total',
+        ])
+        ->assertJsonPath('events.0.evento', 'PAYMENT_RECEIVED')
+        ->assertJsonPath('events.0.signature_valid', true);
+});
+
+it('NÃO expõe payload completo (LGPD/PCI guard)', function () {
+    GatewayWebhookEvent::create([
+        'business_id'                   => $this->business->id,
+        'payment_gateway_credential_id' => $this->credential->id,
+        'gateway_key'                   => 'asaas',
+        'evento'                        => 'PAYMENT_RECEIVED',
+        'gateway_event_id'              => 'evt_secret_payload',
+        'payload'                       => ['secret_data' => 'must_not_leak', 'cpf' => '12345678900'],
+        'signature_valid'               => true,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->withSession([
+            'user.business_id' => $this->business->id,
+            'business.id'      => $this->business->id,
+        ])
+        ->getJson("/settings/payment-gateways/{$this->credential->id}/webhook-events");
+
+    $response->assertOk();
+    $body = $response->getContent();
+    expect($body)->not->toContain('must_not_leak');
+    expect($body)->not->toContain('12345678900');
+    expect($body)->not->toContain('payload'); // Field name não deve aparecer
+});
+
+it('Tier 0: credencial de outro business → 404', function () {
+    $otherBiz = Business::query()->firstOrCreate(
+        ['id' => 2],
+        ['name' => 'Other HQ', 'currency_id' => 1],
+    );
+    $otherCred = PaymentGatewayCredential::withoutGlobalScopes()->create([
+        'business_id'   => $otherBiz->id,
+        'gateway_key'   => 'asaas',
+        'ambiente'      => 'sandbox',
+        'config_json'   => ['api_key' => 'fake_other'],
+        'ativo'         => true,
+        'health_status' => 'unknown',
+    ]);
+
+    // Cria evento em outro business pra garantir que nem com query direta vaza
+    GatewayWebhookEvent::withoutGlobalScopes()->create([
+        'business_id'                   => $otherBiz->id,
+        'payment_gateway_credential_id' => $otherCred->id,
+        'gateway_key'                   => 'asaas',
+        'evento'                        => 'PAYMENT_RECEIVED',
+        'gateway_event_id'              => 'evt_other',
+        'payload'                       => ['event' => 'PAYMENT_RECEIVED'],
+        'signature_valid'               => true,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->withSession([
+            'user.business_id' => $this->business->id,
+            'business.id'      => $this->business->id,
+        ])
+        ->getJson("/settings/payment-gateways/{$otherCred->id}/webhook-events");
+
+    $response->assertNotFound()
+        ->assertJson(['events' => [], 'total' => 0]);
+});
+
+it('limita a 50 events DESC por created_at + filtra por credential_id', function () {
+    // 60 eventos pra esta credencial
+    for ($i = 0; $i < 60; $i++) {
+        GatewayWebhookEvent::create([
+            'business_id'                   => $this->business->id,
+            'payment_gateway_credential_id' => $this->credential->id,
+            'gateway_key'                   => 'asaas',
+            'evento'                        => 'PAYMENT_RECEIVED',
+            'gateway_event_id'              => "evt_{$i}",
+            'payload'                       => ['i' => $i],
+            'signature_valid'               => true,
+        ]);
+    }
+
+    // Outra credencial mesmo biz com 1 evento — não deve aparecer
+    $otherCred = PaymentGatewayCredential::create([
+        'business_id'   => $this->business->id,
+        'gateway_key'   => 'inter',
+        'ambiente'      => 'sandbox',
+        'config_json'   => ['client_id' => 'fake'],
+        'ativo'         => true,
+        'health_status' => 'unknown',
+    ]);
+    GatewayWebhookEvent::create([
+        'business_id'                   => $this->business->id,
+        'payment_gateway_credential_id' => $otherCred->id,
+        'gateway_key'                   => 'inter',
+        'evento'                        => 'NAO_DEVE_APARECER',
+        'gateway_event_id'              => 'evt_outra_cred',
+        'payload'                       => [],
+        'signature_valid'               => true,
+    ]);
+
+    $response = $this->actingAs($this->user)
+        ->withSession([
+            'user.business_id' => $this->business->id,
+            'business.id'      => $this->business->id,
+        ])
+        ->getJson("/settings/payment-gateways/{$this->credential->id}/webhook-events");
+
+    $response->assertOk();
+    $events = $response->json('events');
+    expect(count($events))->toBe(50);
+    // Garante que NÃO contém evento de outra credential
+    expect(collect($events)->pluck('evento')->contains('NAO_DEVE_APARECER'))->toBeFalse();
+});

--- a/resources/js/Pages/Settings/PaymentGateways/_components/DrawerGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/DrawerGateway.tsx
@@ -26,6 +26,18 @@ interface HistoryEntry {
   diff?: { field: string; from: unknown; to: unknown };
 }
 
+interface WebhookEvent {
+  id: number;
+  when: string;
+  when_iso: string;
+  evento: string | null;
+  gateway_event_id: string | null;
+  signature_valid: boolean;
+  processed_at: string | null;
+  error_message: string | null;
+  cobranca_id: number | null;
+}
+
 interface Props {
   gateway: SettingsGateway;
   accounts: Account[];
@@ -58,6 +70,31 @@ export default function DrawerGateway({ gateway, accounts, onClose, onToggle }: 
   const [historyEntries, setHistoryEntries] = useState<HistoryEntry[] | null>(null);
   const [historyLoading, setHistoryLoading] = useState(false);
   const [historyError, setHistoryError] = useState<string | null>(null);
+
+  // Onda 4e.UI #2: eventos webhook recebidos (lista read-only — replay em backlog)
+  const [webhookEvents, setWebhookEvents] = useState<WebhookEvent[] | null>(null);
+  const [webhookEventsLoading, setWebhookEventsLoading] = useState(false);
+  const [webhookEventsError, setWebhookEventsError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (tab !== 'webhook' || webhookEvents !== null || webhookEventsLoading) return;
+    setWebhookEventsLoading(true);
+    setWebhookEventsError(null);
+    fetch(`/settings/payment-gateways/${gateway.id}/webhook-events`, {
+      headers: { Accept: 'application/json' },
+      credentials: 'same-origin',
+    })
+      .then(r => r.ok ? r.json() : Promise.reject(`HTTP ${r.status}`))
+      .then((data: { events: WebhookEvent[] }) => {
+        setWebhookEvents(data.events ?? []);
+        setWebhookEventsLoading(false);
+      })
+      .catch(err => {
+        setWebhookEventsError(String(err));
+        setWebhookEvents([]);
+        setWebhookEventsLoading(false);
+      });
+  }, [tab, gateway.id, webhookEvents, webhookEventsLoading]);
 
   useEffect(() => {
     if (tab !== 'historico' || historyEntries !== null || historyLoading) return;
@@ -439,7 +476,63 @@ export default function DrawerGateway({ gateway, accounts, onClose, onToggle }: 
                 </div>
               </div>
 
-              <div className="pt-2 text-[10.5px] text-stone-500">Estatísticas de eventos recebidos em backlog (Onda 5).</div>
+              <div className="pt-3 border-t border-stone-200">
+                <div className="text-[10px] uppercase tracking-widest text-stone-500 font-medium mb-2">Eventos recebidos (últimos 50)</div>
+
+                {webhookEventsLoading && (
+                  <div className="bg-stone-50 border border-stone-200 rounded p-3 text-[11.5px] text-stone-600 flex items-center gap-2">
+                    <RefreshCw className="h-3 w-3 animate-spin" /> Carregando eventos…
+                  </div>
+                )}
+
+                {webhookEventsError && (
+                  <div className="bg-rose-50 border border-rose-200 rounded p-3 text-[11.5px] text-rose-900">
+                    Erro ao carregar eventos: {webhookEventsError}
+                  </div>
+                )}
+
+                {!webhookEventsLoading && !webhookEventsError && webhookEvents && webhookEvents.length === 0 && (
+                  <div className="bg-stone-50 border border-stone-200 rounded p-4 text-center text-[11.5px] text-stone-500">
+                    Nenhum evento recebido ainda. Quando o {d.nome} enviar webhook, aparecerá aqui.
+                  </div>
+                )}
+
+                {!webhookEventsLoading && webhookEvents && webhookEvents.length > 0 && (
+                  <ol className="space-y-1.5">
+                    {webhookEvents.map((e) => (
+                      <li key={e.id} className="bg-white border border-stone-200 rounded px-2.5 py-1.5 text-[11.5px]">
+                        <div className="flex items-center gap-2">
+                          <span className={cn(
+                            'inline-flex items-center justify-center w-4 h-4 rounded-full text-white text-[9px] shrink-0',
+                            e.processed_at && !e.error_message ? 'bg-emerald-500'
+                              : e.error_message ? 'bg-rose-500'
+                              : 'bg-amber-500',
+                          )} title={e.processed_at && !e.error_message ? 'Processado' : e.error_message ? 'Erro' : 'Pendente'}>
+                            {e.processed_at && !e.error_message ? <Check className="h-2.5 w-2.5" /> : e.error_message ? <X className="h-2.5 w-2.5" /> : '·'}
+                          </span>
+                          <span className="font-mono text-stone-900 truncate flex-1">{e.evento ?? '(unknown)'}</span>
+                          {!e.signature_valid && (
+                            <span className="text-[10px] bg-amber-50 text-amber-700 px-1 rounded shrink-0" title="HMAC signature inválida ou ausente">!HMAC</span>
+                          )}
+                          {e.cobranca_id && (
+                            <span className="text-[10px] text-stone-400 shrink-0 font-mono">cob #{e.cobranca_id}</span>
+                          )}
+                          <span className="text-[10px] text-stone-400 tabular-nums shrink-0" title={e.when_iso}>{e.when}</span>
+                        </div>
+                        {e.error_message && (
+                          <div className="mt-1 ml-6 text-[10.5px] text-rose-700 truncate" title={e.error_message}>
+                            {e.error_message}
+                          </div>
+                        )}
+                      </li>
+                    ))}
+                  </ol>
+                )}
+
+                <div className="mt-2 text-[10px] text-stone-400">
+                  Replay individual em backlog Onda 4e.UI #3 — necessita orquestração de dispatch CobrancaPaga.
+                </div>
+              </div>
             </div>
           )}
 


### PR DESCRIPTION
Fecha gap #2 P0 do estado-da-arte 2026-05-23. Backend lista `gateway_webhook_events` filtrado Tier 0 + LGPD guard (payload não vaza). Frontend extende tab Webhook com seção compacta read-only. 4 Pest GUARDs. Replay individual fica em backlog Onda 4e.UI #3.