### PR TITLE
feat(paymentgateway): comparativo drivers no SheetNovoGateway step 1 (Onda 4e.UI #3)

### DIFF
--- a/resources/js/Pages/Financeiro/Cobranca/_lib/cobranca-shared.ts
+++ b/resources/js/Pages/Financeiro/Cobranca/_lib/cobranca-shared.ts
@@ -89,6 +89,13 @@ export interface CobrancaFiltros {
   busca: string | null;
 }
 
+export interface DriverPricing {
+  boleto?: string;
+  pix?: string;
+  card?: string;
+  settlement?: string;
+}
+
 export interface DriverToken {
   key: GatewayKey;
   nome: string;
@@ -100,6 +107,11 @@ export interface DriverToken {
   tipos: CobrancaTipo[];
   ambientes: Array<'sandbox' | 'production'>;
   cred: string;
+  // Onda 4e.UI #3 (gap P0 estado-da-arte 2026-05-23): comparativo drivers no wizard.
+  // Valores REFERENCE 2026 (sites oficiais + docs públicas). Negociáveis com PSP.
+  pricing?: DriverPricing;
+  requirements?: string[];
+  recommendedFor?: string;
   deprecated?: boolean;
   deprecatedReason?: string;
 }
@@ -111,6 +123,13 @@ export const DRIVERS: Record<GatewayKey, DriverToken> = {
     tipos: ['boleto', 'pix_cob', 'pix_cobv'],
     ambientes: ['sandbox', 'production'],
     cred: 'mTLS · client_id+secret · cert.crt + cert.key',
+    pricing: {
+      boleto: '250 grátis/mês · depois R$ 1,99',
+      pix: 'grátis (chave) · QR dinâmico pode ter tarifa',
+      settlement: 'D+0 (mesma data útil)',
+    },
+    requirements: ['Conta PJ Inter ativa', 'mTLS ICP-Brasil + client_id/secret', 'Onboarding via app Inter Empresas'],
+    recommendedFor: 'PJ que já tem Inter como banco principal · alta vazão boleto/PIX recebido',
   },
   c6: {
     key: 'c6', nome: 'C6 Bank', sigla: 'C6',
@@ -118,6 +137,12 @@ export const DRIVERS: Record<GatewayKey, DriverToken> = {
     tipos: ['boleto'],
     ambientes: ['production'],
     cred: 'agência + conta + código_cliente · CNAB 240',
+    pricing: {
+      boleto: '200 grátis Web · 2.000 grátis CNAB',
+      settlement: 'D+0 (até 13h30)',
+    },
+    requirements: ['Conta PJ C6 ≥ 6 meses OU CNPJ ≥ 1 ano', 'Cadastro CNAB 240 via Web Banking', 'Sem PIX/cartão (só boleto)'],
+    recommendedFor: 'Emissão massiva boleto via CNAB · sem cartão necessário',
   },
   asaas: {
     key: 'asaas', nome: 'Asaas', sigla: 'AS',
@@ -125,6 +150,14 @@ export const DRIVERS: Record<GatewayKey, DriverToken> = {
     tipos: ['boleto', 'pix_cob', 'card'],
     ambientes: ['sandbox', 'production'],
     cred: 'api_key + webhook_secret',
+    pricing: {
+      boleto: 'R$ 0,99 (3 meses) · depois R$ 1,99',
+      pix: '100 grátis/mês · depois R$ 0,99 → R$ 1,99',
+      card: '1,99% + R$ 0,49 (3 meses) · depois 2,99%',
+      settlement: 'PIX imediato · cartão D+30',
+    },
+    requirements: ['Cadastro online self-service (sem KYC enterprise)', 'Sem mensalidade · sem adesão'],
+    recommendedFor: 'PME multi-meio (boleto + PIX + cartão) com setup rápido · sandbox público',
   },
   bcb_pix: {
     key: 'bcb_pix', nome: 'BCB · PIX Automático', sigla: 'BC',
@@ -132,6 +165,12 @@ export const DRIVERS: Record<GatewayKey, DriverToken> = {
     tipos: ['pix_recv'],
     ambientes: ['sandbox', 'production'],
     cred: 'mTLS BCB + CNPJ recebedor homologado · Resolução BCB 380/2024',
+    pricing: {
+      pix: 'Pagador: grátis (regulado) · Recebedor: free agreement c/ PSP',
+      settlement: 'Imediato',
+    },
+    requirements: ['Homologação BCB recebedor (Res. 380/2024)', 'mTLS ICP-Brasil', 'Mandato autorizado pagador-a-pagador'],
+    recommendedFor: 'Mensalidade recorrente PIX (SaaS, plano gym) · cobrança autorizada 1× pelo cliente',
   },
   pesapal: {
     key: 'pesapal', nome: 'PesaPal', sigla: 'PP',
@@ -148,6 +187,14 @@ export const DRIVERS: Record<GatewayKey, DriverToken> = {
     tipos: ['boleto', 'pix_cob', 'card'],
     ambientes: ['sandbox', 'production'],
     cred: 'secret_key + webhook_secret · HMAC SHA256 (X-Hub-Signature-256)',
+    pricing: {
+      boleto: 'R$ 3,49 por boleto pago',
+      pix: '1,19% por transação',
+      card: '4,39% à vista · até 25,29% parcelado 12×',
+      settlement: 'PIX imediato · cartão D+30',
+    },
+    requirements: ['KYC PJ Stone (1-3d homologação)', 'sk_test_* sandbox após approval', 'Webhook dashboard separado'],
+    recommendedFor: 'Marketplace + parcelamento longo · grupo Stone · split de pagamentos',
   },
 };
 

--- a/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
@@ -132,11 +132,14 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
                     opt.deprecated && 'opacity-70',
                   )}>
                     <span className={cn('w-9 h-9 rounded-md grid place-items-center text-white text-[13px] font-bold shrink-0', opt.dot)}>{opt.sigla}</span>
-                    <div className="flex-1">
+                    <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">
                         <div className="text-[13px] font-semibold">{opt.nome}</div>
                         {opt.deprecated && <span className="text-[9px] uppercase tracking-widest font-bold px-1.5 py-0.5 rounded bg-amber-100 text-amber-800">deprecated</span>}
+                        {opt.key === 'bcb_pix' && <span className="text-[9px] uppercase tracking-widest font-bold text-violet-700">novo</span>}
+                        {opt.key === 'pagarme' && <span className="text-[9px] uppercase tracking-widest font-bold text-rose-700">Onda 4e</span>}
                       </div>
+
                       <div className="flex flex-wrap gap-1 mt-1.5">
                         {opt.tipos.map(t => {
                           const tp = TIPOS[t];
@@ -144,11 +147,39 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
                         })}
                         <span className="text-[10px] text-stone-400 ml-1">· {opt.ambientes.join(' / ')}</span>
                       </div>
-                      <div className="text-[10.5px] text-stone-500 mt-1.5">{opt.cred}</div>
+
+                      {/* Onda 4e.UI #3: comparativo drivers (taxa/settlement/requirements) */}
+                      {opt.pricing && !opt.deprecated && (
+                        <div className="mt-2 grid grid-cols-1 sm:grid-cols-2 gap-x-3 gap-y-0.5 text-[10.5px]">
+                          {opt.pricing.boleto && (
+                            <div className="flex gap-1"><span className="text-stone-400 shrink-0">Boleto:</span><span className="text-stone-700 truncate" title={opt.pricing.boleto}>{opt.pricing.boleto}</span></div>
+                          )}
+                          {opt.pricing.pix && (
+                            <div className="flex gap-1"><span className="text-stone-400 shrink-0">PIX:</span><span className="text-stone-700 truncate" title={opt.pricing.pix}>{opt.pricing.pix}</span></div>
+                          )}
+                          {opt.pricing.card && (
+                            <div className="flex gap-1"><span className="text-stone-400 shrink-0">Cartão:</span><span className="text-stone-700 truncate" title={opt.pricing.card}>{opt.pricing.card}</span></div>
+                          )}
+                          {opt.pricing.settlement && (
+                            <div className="flex gap-1"><span className="text-stone-400 shrink-0">Liquidação:</span><span className="text-stone-700 truncate" title={opt.pricing.settlement}>{opt.pricing.settlement}</span></div>
+                          )}
+                        </div>
+                      )}
+
+                      {opt.recommendedFor && !opt.deprecated && (
+                        <div className="mt-1.5 text-[10px] text-stone-500 italic">
+                          ↳ {opt.recommendedFor}
+                        </div>
+                      )}
+
+                      <div className="text-[10px] text-stone-400 mt-1.5 font-mono truncate" title={opt.cred}>{opt.cred}</div>
                     </div>
-                    {opt.key === 'bcb_pix' && <span className="text-[9px] uppercase tracking-widest font-bold text-violet-700 self-start">novo</span>}
                   </button>
                 ))}
+
+                <div className="text-[10px] text-stone-400 italic pt-1">
+                  Valores REFERENCE 2026 (sites oficiais + docs públicas) — negociáveis com PSP em volume alto.
+                </div>
               </div>
             </div>
           )}


### PR DESCRIPTION
Fecha gap #3 P1 do estado-da-arte 2026-05-23 — Wagner/Larissa agora escolhem driver COM dado de taxa/settlement/requirements em vez de "no escuro". 2 arquivos / 81 LOC. Frontend puro (sem backend), DRIVERS centralizadas em cobranca-shared.ts pra reuso entre Settings e Financeiro/Cobranca.