### PR TITLE
feat(paymentgateway): hint 'onde gerar credencial' + fix botão fantasma PesaPal (Onda 4e.UI #4+#5)

### DIFF
--- a/resources/js/Pages/Financeiro/Cobranca/_lib/cobranca-shared.ts
+++ b/resources/js/Pages/Financeiro/Cobranca/_lib/cobranca-shared.ts
@@ -112,6 +112,9 @@ export interface DriverToken {
   pricing?: DriverPricing;
   requirements?: string[];
   recommendedFor?: string;
+  // Onda 4e.UI #5 (gap P2 estado-da-arte): deep-link pro painel do PSP
+  // onde Wagner/Larissa gera a credencial. Reduz fricção do onboarding wizard.
+  credentialSource?: { url: string; label: string };
   deprecated?: boolean;
   deprecatedReason?: string;
 }
@@ -130,6 +133,7 @@ export const DRIVERS: Record<GatewayKey, DriverToken> = {
     },
     requirements: ['Conta PJ Inter ativa', 'mTLS ICP-Brasil + client_id/secret', 'Onboarding via app Inter Empresas'],
     recommendedFor: 'PJ que já tem Inter como banco principal · alta vazão boleto/PIX recebido',
+    credentialSource: { url: 'https://contadigital.inter.co', label: 'Inter Empresas → API Banking' },
   },
   c6: {
     key: 'c6', nome: 'C6 Bank', sigla: 'C6',
@@ -143,6 +147,7 @@ export const DRIVERS: Record<GatewayKey, DriverToken> = {
     },
     requirements: ['Conta PJ C6 ≥ 6 meses OU CNPJ ≥ 1 ano', 'Cadastro CNAB 240 via Web Banking', 'Sem PIX/cartão (só boleto)'],
     recommendedFor: 'Emissão massiva boleto via CNAB · sem cartão necessário',
+    credentialSource: { url: 'https://www.c6bank.com.br/boletocobranca/', label: 'C6 Bank → Boleto Cobrança → CNAB 240' },
   },
   asaas: {
     key: 'asaas', nome: 'Asaas', sigla: 'AS',
@@ -158,6 +163,7 @@ export const DRIVERS: Record<GatewayKey, DriverToken> = {
     },
     requirements: ['Cadastro online self-service (sem KYC enterprise)', 'Sem mensalidade · sem adesão'],
     recommendedFor: 'PME multi-meio (boleto + PIX + cartão) com setup rápido · sandbox público',
+    credentialSource: { url: 'https://www.asaas.com/customerApiAccessToken/index', label: 'Asaas → Integrações → API Access Token' },
   },
   bcb_pix: {
     key: 'bcb_pix', nome: 'BCB · PIX Automático', sigla: 'BC',
@@ -171,6 +177,7 @@ export const DRIVERS: Record<GatewayKey, DriverToken> = {
     },
     requirements: ['Homologação BCB recebedor (Res. 380/2024)', 'mTLS ICP-Brasil', 'Mandato autorizado pagador-a-pagador'],
     recommendedFor: 'Mensalidade recorrente PIX (SaaS, plano gym) · cobrança autorizada 1× pelo cliente',
+    credentialSource: { url: 'https://www.bcb.gov.br/estabilidadefinanceira/pix', label: 'BCB → PIX Automático → Homologação recebedor' },
   },
   pesapal: {
     key: 'pesapal', nome: 'PesaPal', sigla: 'PP',
@@ -195,6 +202,7 @@ export const DRIVERS: Record<GatewayKey, DriverToken> = {
     },
     requirements: ['KYC PJ Stone (1-3d homologação)', 'sk_test_* sandbox após approval', 'Webhook dashboard separado'],
     recommendedFor: 'Marketplace + parcelamento longo · grupo Stone · split de pagamentos',
+    credentialSource: { url: 'https://dashboard.pagar.me', label: 'Pagar.me Dashboard → Configurações → Chaves' },
   },
 };
 

--- a/resources/js/Pages/Settings/PaymentGateways/_components/DrawerGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/DrawerGateway.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useRef, useState } from 'react';
 import { router } from '@inertiajs/react';
 import {
-  X, Copy, Shield, RefreshCw, Zap, Check, Trash2, History, Plus, Minus,
+  X, Copy, Shield, RefreshCw, Zap, Check, Trash2, History, Plus, Minus, ExternalLink,
 } from 'lucide-react';
 import { Btn, KpiCard } from '../../../Financeiro/Cobranca/_components/atoms';
 import {
@@ -302,6 +302,22 @@ export default function DrawerGateway({ gateway, accounts, onClose, onToggle }: 
               <div className="text-[10.5px] text-stone-500 bg-stone-50 border border-stone-200 rounded px-3 py-2 leading-snug">
                 {d.cred} <strong>Deixe em branco pra manter o valor atual</strong> — só campos preenchidos são atualizados.
               </div>
+
+              {/* Onda 4e.UI #5 — deep-link pro painel do PSP onde gerar/rotacionar */}
+              {d.credentialSource && !d.deprecated && (
+                <a
+                  href={d.credentialSource.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-start gap-2 bg-sky-50 border border-sky-200 rounded p-2.5 text-[11px] text-sky-900 hover:bg-sky-100 hover:border-sky-300 transition"
+                >
+                  <ExternalLink className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                  <div className="flex-1">
+                    <div className="font-medium">Onde gerar/rotacionar a credencial</div>
+                    <div className="text-sky-700">{d.credentialSource.label}</div>
+                  </div>
+                </a>
+              )}
               {d.key === 'inter' && (
                 <>
                   <Field label="Client ID (atualizar)">
@@ -426,8 +442,14 @@ export default function DrawerGateway({ gateway, accounts, onClose, onToggle }: 
               {d.key === 'pesapal' && (
                 <div className="bg-amber-50 border border-amber-200 rounded p-3 text-[11.5px] text-amber-900">
                   <div className="font-medium mb-1">Driver deprecated</div>
-                  <p>PesaPal foi UltimatePOS legacy pra cartão internacional. Hoje recomenda-se <strong>Asaas</strong> (BR nativo + 3DS + PIX). Migração: criar Asaas → desativar PesaPal → backfill subscriptions ativas.</p>
-                  <Btn variant="outline" size="xs" className="mt-2 !border-amber-300 !text-amber-800">Iniciar migração</Btn>
+                  <p className="mb-2">PesaPal foi UltimatePOS legacy pra cartão internacional. Hoje recomenda-se <strong>Asaas</strong> (BR nativo + 3DS + PIX).</p>
+                  <div className="font-medium text-[11px] mt-2 mb-1">Migrar manualmente:</div>
+                  <ol className="list-decimal list-inside space-y-0.5 text-[11px]">
+                    <li>Clique em <strong>+ Novo gateway</strong> na tela principal → escolha <strong>Asaas</strong></li>
+                    <li>Cadastre credencial Asaas (sandbox primeiro, depois production)</li>
+                    <li>Reaponte Subscriptions/cobranças ativas pra Asaas no módulo Recurring</li>
+                    <li>Desative este PesaPal aqui (toggle no header)</li>
+                  </ol>
                 </div>
               )}
               {d.key === 'pagarme' && (

--- a/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
@@ -3,7 +3,7 @@
 import { useEffect, useState } from 'react';
 import { router } from '@inertiajs/react';
 import {
-  X, ChevronRight, ChevronLeft, Plus, Check, Shield,
+  X, ChevronRight, ChevronLeft, Plus, Check, Shield, ExternalLink,
 } from 'lucide-react';
 import { Btn } from '../../../Financeiro/Cobranca/_components/atoms';
 import { DriverChip, FileField, Field } from './atoms-settings';
@@ -197,6 +197,22 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
               <div className="bg-stone-50 border border-stone-200 rounded p-3 text-[11px] text-stone-700 mb-3">
                 <strong>{d.nome}:</strong> {d.cred}
               </div>
+
+              {/* Onda 4e.UI #5 — deep-link pro painel do PSP onde gerar credencial */}
+              {d.credentialSource && (
+                <a
+                  href={d.credentialSource.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="flex items-start gap-2 bg-sky-50 border border-sky-200 rounded p-2.5 text-[11px] text-sky-900 hover:bg-sky-100 hover:border-sky-300 transition mb-3"
+                >
+                  <ExternalLink className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                  <div className="flex-1">
+                    <div className="font-medium">Onde gerar a credencial</div>
+                    <div className="text-sky-700">{d.credentialSource.label}</div>
+                  </div>
+                </a>
+              )}
               {d.key === 'inter' && <>
                 <Field label="Client ID">
                   <input


### PR DESCRIPTION
Fecha gaps #4 P1 + #5 P2 do estado-da-arte 2026-05-23. Frontend puro (3 arquivos / ~50 LOC). PesaPal vira instruções honestas em vez de botão fantasma. Wizard step 2 + tab Credenciais ganham banner deep-link pro painel do PSP de cada driver. **Top 5 do roadmap estado-da-arte concluído** (PRs #1427, #1428, #1429, este).