### PR TITLE
feat(crm,nfe-brasil): SEFAZ ConsultaCadastro chain de cert pra IE auto no drawer 760 (ADR 0186)

### DIFF
--- a/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
+++ b/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
@@ -109,6 +109,11 @@ class ClienteAutosaveController extends Controller
             'rg' => ['nullable', 'string', 'max:20'],
             'nascimento' => ['nullable', 'date', 'before:today'],
             'cargo' => ['nullable', 'string', 'max:80'],
+            // ADR 0186 Técnica C — campos derivados da SEFAZ ConsultaCadastro.
+            'ind_ie_dest' => ['nullable', 'integer', 'in:1,2,9'],
+            'sefaz_cad_sit' => ['nullable', 'string', 'in:habilitado,nao_habilitado,suspenso,cancelado,paralisado,baixado'],
+            'sefaz_cad_ind_cred_nfe' => ['nullable', 'integer', 'between:0,4'],
+            'sefaz_cad_consultado_em' => ['nullable', 'date'],
         ], $this->messages());
 
         // Validacao customizada mod 11 quando tax_number presente.
@@ -334,6 +339,12 @@ class ClienteAutosaveController extends Controller
             'fantasia' => $contact->fantasia ?? null,
             'tax_number_masked' => $this->maskTaxNumber($contact->tax_number ?? null),
             'ie' => $contact->ie ?? null,
+            // ADR 0186 Técnica C — campos derivados da SEFAZ.
+            'ind_ie_dest' => $contact->ind_ie_dest !== null ? (int) $contact->ind_ie_dest : null,
+            'sefaz_cad_sit' => $contact->sefaz_cad_sit ?? null,
+            'sefaz_cad_ind_cred_nfe' => $contact->sefaz_cad_ind_cred_nfe !== null
+                ? (int) $contact->sefaz_cad_ind_cred_nfe : null,
+            'sefaz_cad_consultado_em' => $contact->sefaz_cad_consultado_em ?? null,
             'rg' => $contact->rg ?? null,
             'nascimento' => $contact->nascimento ?? null,
             'cargo' => $contact->cargo ?? null,

--- a/Modules/Crm/Http/Controllers/ClienteLookupController.php
+++ b/Modules/Crm/Http/Controllers/ClienteLookupController.php
@@ -6,7 +6,9 @@ namespace Modules\Crm\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
 use Modules\Crm\Services\BrLookupService;
+use Modules\NfeBrasil\Services\SefazConsultaCadastroService;
 
 /**
  * ClienteLookupController -- proxy ViaCEP + BrasilAPI Wave C (ADR 0179).
@@ -44,6 +46,7 @@ class ClienteLookupController extends Controller
 {
     public function __construct(
         private readonly BrLookupService $lookupService,
+        private readonly SefazConsultaCadastroService $sefazService,
     ) {
     }
 
@@ -81,6 +84,68 @@ class ClienteLookupController extends Controller
         if ($result === null) {
             return response()->json([
                 'message' => 'CNPJ nao encontrado',
+            ], 404);
+        }
+
+        return response()->json($result, 200);
+    }
+
+    /**
+     * GET /cliente/lookup/cnpj/{cnpj}/sefaz?uf=RS
+     *
+     * Consulta IE + situação cadastral via SEFAZ ConsultaCadastro (ADR 0186).
+     * Usa chain de cert A1: business consumidor → legado → institucional oimpresso.
+     *
+     * Multi-tenant Tier 0: business_id vem de session('user.business_id'). Cache
+     * Redis 30d compartilhado entre tenants (dado público SEFAZ).
+     *
+     * Resposta shape:
+     *   200 {ie, situacao, nome, uf, fonte, cert_source, cert_business_id}
+     *        - fonte: "sefaz_rs" (qual SEFAZ respondeu)
+     *        - cert_source: "nfe_brasil" | "business_legado" | "institutional_fallback"
+     *        - cert_business_id: qual business teve cert usado (∈{consumidor, fallback})
+     *   404 {message: "...", reason: "uf_unsupported"|"no_cert"|"sefaz_error"|"cnpj_not_found"}
+     *
+     * Frontend (`IdentificacaoTab.handleCnpjLookup`) usa `cert_source` + `reason`
+     * pra renderizar badge contextual UI (4 estados ADR 0186).
+     */
+    public function cnpjSefaz(Request $request, string $cnpj): JsonResponse
+    {
+        $uf = (string) $request->query('uf', '');
+        $uf = strtoupper(trim($uf));
+
+        if (strlen($uf) !== 2) {
+            return response()->json([
+                'message' => 'Parametro uf obrigatorio (2 letras)',
+                'reason' => 'invalid_request',
+            ], 422);
+        }
+
+        // Validação UF supported — devolve 404 com reason específico pra UI badge.
+        $ufsSupported = config('fiscal.sefaz_consulta_cadastro_ufs_supported', []);
+        if (! isset($ufsSupported[$uf])) {
+            return response()->json([
+                'message' => "SEFAZ-{$uf} nao disponivel — preencha IE manualmente",
+                'reason' => 'uf_unsupported',
+                'uf' => $uf,
+            ], 404);
+        }
+
+        $businessId = (int) $request->session()->get('user.business_id');
+        if ($businessId <= 0) {
+            return response()->json([
+                'message' => 'Sessao sem business_id',
+                'reason' => 'no_session',
+            ], 403);
+        }
+
+        $result = $this->sefazService->consultar($cnpj, $uf, $businessId);
+
+        if ($result === null) {
+            return response()->json([
+                'message' => 'IE indisponivel — preencha manualmente',
+                'reason' => 'sefaz_or_cert_error',
+                'uf' => $uf,
             ], 404);
         }
 

--- a/Modules/Crm/Routes/web.php
+++ b/Modules/Crm/Routes/web.php
@@ -130,6 +130,12 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
             Route::get('lookup/cnpj/{cnpj}', [\Modules\Crm\Http\Controllers\ClienteLookupController::class, 'cnpj'])
                 ->where('cnpj', '[\d./\-]{14,18}')
                 ->name('lookup.cnpj');
+            // Lookup SEFAZ ConsultaCadastro (ADR 0186) -- chain de cert + IE oficial.
+            // Throttle compartilhado (60/min) -- mesma franquia que CEP/CNPJ
+            // (fluxo unico de cadastro). Query param obrigatorio ?uf=XX.
+            Route::get('lookup/cnpj/{cnpj}/sefaz', [\Modules\Crm\Http\Controllers\ClienteLookupController::class, 'cnpjSefaz'])
+                ->where('cnpj', '[\d./\-]{14,18}')
+                ->name('lookup.cnpj.sefaz');
         });
     });
 

--- a/Modules/NfeBrasil/Services/CertificadoService.php
+++ b/Modules/NfeBrasil/Services/CertificadoService.php
@@ -189,6 +189,111 @@ class CertificadoService
     }
 
     /**
+     * Carrega cert pra SEFAZ com chain de 3 camadas (ADR 0186).
+     *
+     * Estende `carregarParaSefaz` adicionando 3ª camada de fallback:
+     * cert institucional do oimpresso operacional (config `fiscal.fallback_business_id`,
+     * default biz=1) quando o business consumidor não tem cert próprio ativo nem
+     * legado. Usado pelo `SefazConsultaCadastroService` no drawer 760 Cliente
+     * (lookup CNPJ → IE automática via SEFAZ ConsultaCadastro).
+     *
+     * Chain:
+     *   1. cert primário business (`nfe_certificados`)
+     *   2. cert legado `business.certificado` BLOB (ADR 0090)
+     *   3. cert institucional (config fiscal.fallback_business_id)
+     *   4. RuntimeException — caller renderiza badge UI "configure cert"
+     *
+     * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): camada #3 usa
+     * `withoutGlobalScope(ScopeByBusiness::class)` INTENCIONAL — única query
+     * em `nfe_certificados` autorizada a escapar do scope. Cada uso loga em
+     * audit log com `sha256(cnpj_consultado)` (LGPD Art. 6º III — minimização).
+     *
+     * @return array{pfx_binary: string, senha: string, valido_ate: ?\DateTimeInterface, source: string, cert_business_id: int}
+     * @throws RuntimeException Quando nenhuma das 3 camadas retorna cert
+     */
+    public function carregarParaSefazComFallback(int $businessId, ?string $contextoConsulta = null): array
+    {
+        // Camada 1+2: cert primário ou legado (delega pro método existente).
+        try {
+            $cert = $this->carregarParaSefaz($businessId);
+            $cert['cert_business_id'] = $businessId;
+            return $cert;
+        } catch (RuntimeException $e) {
+            // Cai pra camada 3 — fallback institucional.
+        }
+
+        // Camada 3: cert institucional do oimpresso operacional.
+        $fallbackBusinessId = (int) config('fiscal.fallback_business_id', 1);
+
+        if ($fallbackBusinessId === $businessId) {
+            // Próprio business já é o institucional E não tem cert → não há fallback adicional.
+            throw new RuntimeException(
+                "Business institucional {$businessId} não tem certificado A1 ativo. Configure em /fiscal/config."
+            );
+        }
+
+        // ⚠️ withoutGlobalScope INTENCIONAL — ADR 0186 §Decisão camada #3.
+        // Único lugar autorizado no codebase a escapar do tenant scope em nfe_certificados.
+        // Pest test `CertificadoFallbackInstitucionalTest` valida que não há outras
+        // ocorrências de `withoutGlobalScope(ScopeByBusiness::class)` apontando pra esse model.
+        $certInstitucional = NfeCertificado::withoutGlobalScope(\Modules\Jana\Scopes\ScopeByBusiness::class)
+            ->where('business_id', $fallbackBusinessId)
+            ->where('ativo', true)
+            ->where('valido_ate', '>', now())
+            ->first();
+
+        if (! $certInstitucional) {
+            throw new RuntimeException(
+                "Business {$businessId} sem cert ativo E cert institucional fallback (biz={$fallbackBusinessId}) também ausente/vencido."
+            );
+        }
+
+        $diskPath = sprintf('%d/cert/%s.pfx.enc', $fallbackBusinessId, $certInstitucional->uuid);
+        if (! Storage::disk('nfe_certs')->exists($diskPath)) {
+            throw new RuntimeException(
+                "Cert institucional registrado mas arquivo ausente em disco: {$diskPath}"
+            );
+        }
+
+        // Audit log — ADR 0186 §Decisão camada #3. LGPD Art. 6º III: sha256(cnpj), nunca plain.
+        // `mcp_audit_log` table existe pelo schema MCP (ADR 0053). Graceful skip se não disponível.
+        try {
+            DB::table('mcp_audit_log')->insert([
+                'business_id' => $businessId,
+                'event' => 'sefaz.cert.fallback_institutional_used',
+                'metadata' => json_encode([
+                    'cert_business_id' => $fallbackBusinessId,
+                    'reason' => 'business_sem_cert_ativo_nem_legado',
+                    'contexto_consulta_hash' => $contextoConsulta !== null
+                        ? hash('sha256', $contextoConsulta)
+                        : null,
+                ]),
+                'created_at' => now(),
+            ]);
+        } catch (\Throwable $auditErr) {
+            // Audit log graceful — não bloqueia consulta se MCP audit falhar.
+            Log::warning('CertificadoService: audit log fallback institucional falhou', [
+                'business_id' => $businessId,
+                'cert_business_id' => $fallbackBusinessId,
+                'audit_error' => $auditErr->getMessage(),
+            ]);
+        }
+
+        Log::info('CertificadoService: FALLBACK_INSTITUCIONAL usado', [
+            'business_id' => $businessId,
+            'cert_business_id' => $fallbackBusinessId,
+        ]);
+
+        return [
+            'pfx_binary' => Crypt::decrypt(Storage::disk('nfe_certs')->get($diskPath)),
+            'senha'      => Crypt::decryptString($certInstitucional->encrypted_password),
+            'valido_ate' => $certInstitucional->valido_ate,
+            'source'     => 'institutional_fallback',
+            'cert_business_id' => $fallbackBusinessId,
+        ];
+    }
+
+    /**
      * Lê cert do legado `business.certificado` (BLOB) + `business.senha_certificado` (base64).
      * Retorna null se ausente. ADR 0090.
      *

--- a/Modules/NfeBrasil/Services/SefazConsultaCadastroService.php
+++ b/Modules/NfeBrasil/Services/SefazConsultaCadastroService.php
@@ -44,13 +44,60 @@ class SefazConsultaCadastroService
     ) {}
 
     /**
-     * Consulta cadastro ICMS na SEFAZ da UF informada usando cert chain.
+     * Map `cSit` SEFAZ → label PT-BR canônico pra coluna `contacts.sefaz_cad_sit`.
+     *
+     * Fonte: schema NFe ConsultaCadastro2 + comunidade nfephp-org.
+     */
+    private const C_SIT_LABELS = [
+        '0' => 'habilitado',
+        '1' => 'nao_habilitado',
+        '2' => 'suspenso',
+        '3' => 'cancelado',
+        '4' => 'paralisado',
+        '5' => 'baixado',
+    ];
+
+    /**
+     * Deriva `indIEDest` (1/2/9) a partir do retorno SEFAZ.
+     *   1 = contribuinte ICMS   → IE válida + cSit ∈ {habilitado, suspenso, paralisado}
+     *   2 = contribuinte isento → IE = "ISENTO" (string literal)
+     *   9 = não contribuinte    → sem IE OU cSit em {cancelado, baixado}
+     */
+    private function derivarIndIeDest(?string $ie, ?string $cSit): int
+    {
+        $ieClean = trim((string) $ie);
+
+        if ($ieClean === '' || $ieClean === '0') {
+            return 9;
+        }
+
+        if (strcasecmp($ieClean, 'ISENTO') === 0) {
+            return 2;
+        }
+
+        // cSit ∈ {3 cancelado, 5 baixado} → tratar como não contribuinte (não pode receber NFe com IE).
+        if (in_array((string) $cSit, ['3', '5'], true)) {
+            return 9;
+        }
+
+        return 1;
+    }
+
+    /**
+     * Consulta cadastro ICMS na SEFAZ da UF informada usando cert chain (Técnica C).
+     *
+     * Retorno expandido (ADR 0186 §Evolução Técnica C):
+     *   - IE + cSit + xNome (base — sempre)
+     *   - **ind_ie_dest** derivado (1/2/9) — pronto pra coluna `contacts.ind_ie_dest`
+     *   - **ind_cred_nfe** (0/1/2/3/4) — informativo + warning UI antecipado
+     *   - **regime_apuracao** (xRegApur) — informativo
+     *   - **endereco_sefaz** array — endereço fiscal SEFAZ (pode diferir do Receita)
+     *   - **alerta_warning** array — gatilhos UI pra evitar rejeição NFe ("cliente com IE inativa", etc)
      *
      * @param  string  $cnpj  CNPJ em qualquer formato (só dígitos usados)
      * @param  string  $uf    UF de 2 letras (RS, SP, etc)
      * @param  int     $businessId  Business consumidor (multi-tenant Tier 0)
-     * @return array{ie:?string,situacao:?string,nome:?string,uf:string,fonte:string,cert_source:string,cert_business_id:int}|null
-     *                              null = UF não suportada, sem cert, ou erro SEFAZ
+     * @return array|null  null = UF não suportada, sem cert, ou erro SEFAZ
      */
     public function consultar(string $cnpj, string $uf, int $businessId): ?array
     {
@@ -163,14 +210,73 @@ class SefazConsultaCadastroService
                         return null;
                     }
 
+                    // Extrai campos base.
+                    $ie = isset($infCons['IE']) ? (string) $infCons['IE'] : null;
+                    $cSit = isset($infCons['cSit']) ? (string) $infCons['cSit'] : null;
+                    $nome = isset($infCons['xNome']) ? (string) $infCons['xNome'] : null;
+
+                    // Técnica C — campos fiscais expandidos.
+                    $indCredNfe = isset($infCons['indCredNFe']) ? (int) $infCons['indCredNFe'] : null;
+                    $regimeApuracao = isset($infCons['xRegApur']) ? (string) $infCons['xRegApur'] : null;
+                    $indIeDest = $this->derivarIndIeDest($ie, $cSit);
+                    $cSitLabel = $cSit !== null && isset(self::C_SIT_LABELS[$cSit])
+                        ? self::C_SIT_LABELS[$cSit]
+                        : null;
+
+                    // Endereço SEFAZ (cadastro ICMS — pode estar mais atualizado que Receita).
+                    // Schema cConsCad/infCons/ender (alguns SEFAZ usam aninhamento, outros flat).
+                    $ender = $infCons['ender'] ?? [];
+                    $enderecoSefaz = [];
+                    if (is_array($ender) && ! empty($ender)) {
+                        $enderecoSefaz = [
+                            'logradouro' => isset($ender['xLgr']) ? (string) $ender['xLgr'] : '',
+                            'numero'     => isset($ender['nro']) ? (string) $ender['nro'] : '',
+                            'complemento'=> isset($ender['xCpl']) ? (string) $ender['xCpl'] : '',
+                            'bairro'     => isset($ender['xBairro']) ? (string) $ender['xBairro'] : '',
+                            'cep'        => isset($ender['CEP']) ? (string) $ender['CEP'] : '',
+                            'cidade'     => isset($ender['xMun']) ? (string) $ender['xMun'] : '',
+                            'cmun'       => isset($ender['cMun']) ? (string) $ender['cMun'] : '',
+                            'uf'         => isset($ender['UF']) ? (string) $ender['UF'] : $uf,
+                        ];
+                    }
+
+                    // Warnings antecipados — gatilhos UI pra evitar rejeição NFe.
+                    $alertas = [];
+                    if ($cSit === '1') {
+                        $alertas[] = ['code' => 'cad_nao_habilitado', 'severity' => 'high',
+                            'msg' => 'Destinatário não habilitado SEFAZ — NFe pode ser rejeitada (rej. 478/487)'];
+                    } elseif ($cSit === '2') {
+                        $alertas[] = ['code' => 'cad_suspenso', 'severity' => 'medium',
+                            'msg' => 'IE suspensa — verifique antes de emitir NFe'];
+                    } elseif ($cSit === '3') {
+                        $alertas[] = ['code' => 'cad_cancelado', 'severity' => 'high',
+                            'msg' => 'IE CANCELADA — NFe será rejeitada (use indIEDest=9 não contribuinte)'];
+                    } elseif ($cSit === '5') {
+                        $alertas[] = ['code' => 'cad_baixado', 'severity' => 'high',
+                            'msg' => 'IE BAIXADA — empresa fora de operação'];
+                    }
+                    if ($indCredNfe === 4) {
+                        $alertas[] = ['code' => 'nao_credenciado_nfe', 'severity' => 'low',
+                            'msg' => 'Destinatário não credenciado a EMITIR NFe (recebe normalmente)'];
+                    }
+
                     return [
-                        'ie'                => isset($infCons['IE']) ? (string) $infCons['IE'] : null,
-                        'situacao'          => isset($infCons['cSit']) ? (string) $infCons['cSit'] : null,
-                        'nome'              => isset($infCons['xNome']) ? (string) $infCons['xNome'] : null,
+                        // Base — sempre presente.
+                        'ie'                => $ie,
+                        'situacao'          => $cSit,         // valor numérico raw
+                        'situacao_label'    => $cSitLabel,    // label PT-BR pra coluna sefaz_cad_sit
+                        'nome'              => $nome,
                         'uf'                => $uf,
                         'fonte'             => 'sefaz_' . strtolower($uf),
                         'cert_source'       => (string) ($certData['source'] ?? 'unknown'),
                         'cert_business_id'  => (int) ($certData['cert_business_id'] ?? $businessId),
+                        // Técnica C — expansão.
+                        'ind_ie_dest'       => $indIeDest,
+                        'ind_cred_nfe'      => $indCredNfe,
+                        'regime_apuracao'   => $regimeApuracao,
+                        'endereco_sefaz'    => $enderecoSefaz,
+                        'alertas'           => $alertas,
+                        'consultado_em'     => now()->toIso8601String(),
                     ];
                 } catch (RuntimeException $certErr) {
                     // Cert chain vazio — caller renderiza badge "configure cert".

--- a/Modules/NfeBrasil/Services/SefazConsultaCadastroService.php
+++ b/Modules/NfeBrasil/Services/SefazConsultaCadastroService.php
@@ -191,6 +191,17 @@ class SefazConsultaCadastroService
                     );
                     $tools->loadCertificate($certificate);
 
+                    // ADR 0186 §Invariante #11 (hardening 2026-05-23) — timeout
+                    // backend agressivo: 4s connect + 24s total (sped-common
+                    // adiciona +20s ao soaptimeout pro CURLOPT_TIMEOUT total).
+                    // Default era 20s/40s — drawer travava em SEFAZ lerda.
+                    // Frontend complementa com AbortController 8s (cancela ANTES
+                    // do backend terminar se SEFAZ conectou mas demora demais).
+                    $timeoutSeconds = (int) config('fiscal.sefaz_consulta_cadastro_timeout_seconds', 4);
+                    if (isset($tools->soap) && method_exists($tools->soap, 'timeout')) {
+                        $tools->soap->timeout($timeoutSeconds);
+                    }
+
                     $iest = '';
                     $cpf = '';
                     $response = $tools->sefazCadastro($uf, $cnpjDigits, $iest, $cpf);

--- a/Modules/NfeBrasil/Services/SefazConsultaCadastroService.php
+++ b/Modules/NfeBrasil/Services/SefazConsultaCadastroService.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\NfeBrasil\Services;
+
+use App\Business;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use NFePHP\Common\Standardize;
+use NFePHP\NFe\Tools;
+use RuntimeException;
+
+/**
+ * SefazConsultaCadastroService — consulta IE + situação cadastral via SEFAZ
+ * ConsultaCadastro2 (WS NFe `cConsCad`). ADR 0186.
+ *
+ * Substitui o legacy `NFeService::consultaCadastro($cnpj, $uf)` (linha 580
+ * app/Services/NFeService.php, `echo $json` direto não-Inertia) por canon
+ * Inertia-friendly multi-tenant.
+ *
+ * Chain de cert via `CertificadoService::carregarParaSefazComFallback`:
+ *   1. cert primário do business consumidor
+ *   2. cert legado business.certificado (ADR 0090)
+ *   3. cert institucional oimpresso (config fiscal.fallback_business_id)
+ *
+ * Cache Redis 30d por `(cnpj, uf)` — chave compartilhada entre businesses
+ * (dado público, mesma justificativa BrasilAPI em BrLookupService).
+ *
+ * Cobertura UFs: matriz em `config('fiscal.sefaz_consulta_cadastro_ufs_supported')` —
+ * UFs fora da lista retornam null + caller renderiza badge "preencha manual".
+ *
+ * Multi-tenant Tier 0 (ADR 0093): business_id sempre escopa o cert na chain;
+ * fallback institucional usa `withoutGlobalScope` AUDITADO em audit log.
+ *
+ * @see memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
+ * @see Modules\NfeBrasil\Services\CertificadoService::carregarParaSefazComFallback
+ * @see Modules\Crm\Http\Controllers\ClienteLookupController::cnpjSefaz
+ */
+class SefazConsultaCadastroService
+{
+    public function __construct(
+        private readonly CertificadoService $certService,
+    ) {}
+
+    /**
+     * Consulta cadastro ICMS na SEFAZ da UF informada usando cert chain.
+     *
+     * @param  string  $cnpj  CNPJ em qualquer formato (só dígitos usados)
+     * @param  string  $uf    UF de 2 letras (RS, SP, etc)
+     * @param  int     $businessId  Business consumidor (multi-tenant Tier 0)
+     * @return array{ie:?string,situacao:?string,nome:?string,uf:string,fonte:string,cert_source:string,cert_business_id:int}|null
+     *                              null = UF não suportada, sem cert, ou erro SEFAZ
+     */
+    public function consultar(string $cnpj, string $uf, int $businessId): ?array
+    {
+        $cnpjDigits = preg_replace('/\D/', '', $cnpj) ?? '';
+        $uf = strtoupper(trim($uf));
+
+        if (strlen($cnpjDigits) !== 14) {
+            return null;
+        }
+
+        // Validação UF suportada — config canônica.
+        $ufsSupported = config('fiscal.sefaz_consulta_cadastro_ufs_supported', []);
+        if (! isset($ufsSupported[$uf])) {
+            Log::info('SefazConsultaCadastroService: UF não suportada — skip', [
+                'uf' => $uf,
+                'business_id' => $businessId,
+            ]);
+            return null;
+        }
+
+        // Feature flag global on/off — ADR 0186 reversível.
+        if (! config('fiscal.sefaz_consulta_cadastro_enabled', true)) {
+            Log::info('SefazConsultaCadastroService: feature flag desligada — skip', [
+                'business_id' => $businessId,
+            ]);
+            return null;
+        }
+
+        // Cache Redis 30d — dado público compartilhado entre businesses.
+        $cacheKey = "sefaz_cadastro:{$uf}:{$cnpjDigits}";
+        $cacheTtl = (int) config('fiscal.sefaz_consulta_cadastro_cache_ttl_seconds', 60 * 60 * 24 * 30);
+
+        return Cache::remember(
+            $cacheKey,
+            $cacheTtl,
+            function () use ($cnpjDigits, $uf, $businessId): ?array {
+                try {
+                    // Carrega cert via chain (ADR 0186) — pode lançar RuntimeException se sem cert nenhum.
+                    $certData = $this->certService->carregarParaSefazComFallback(
+                        $businessId,
+                        // Contexto pro audit log fallback (LGPD sha256, nunca plain).
+                        $cnpjDigits . ':' . $uf
+                    );
+
+                    // Carrega config do business consumidor pra montar Tools.
+                    // Mesmo padrão usado em NFeController::consultaCadastro legacy
+                    // (cert é do business, request também — Tools precisa cnpj do solicitante).
+                    $business = Business::find($businessId);
+                    if (! $business) {
+                        Log::warning('SefazConsultaCadastroService: business não encontrado', [
+                            'business_id' => $businessId,
+                        ]);
+                        return null;
+                    }
+
+                    $cnpjBusiness = preg_replace('/\D/', '', (string) ($business->cnpj ?? '')) ?? '';
+                    if (strlen($cnpjBusiness) !== 14) {
+                        // Business sem CNPJ próprio (cadastro incompleto) → não pode consultar SEFAZ.
+                        Log::warning('SefazConsultaCadastroService: business sem CNPJ válido', [
+                            'business_id' => $businessId,
+                        ]);
+                        return null;
+                    }
+
+                    $ufBusiness = strtoupper((string) ($business->state ?? optional($business->cidade)->uf ?? ''));
+
+                    $tools = new Tools(
+                        json_encode([
+                            'atualizacao' => date('Y-m-d H:i:s'),
+                            'tpAmb'       => 1, // Produção — ConsultaCadastro só funciona em prod.
+                            'razaosocial' => (string) ($business->razao_social ?? $business->name ?? 'oimpresso'),
+                            'siglaUF'     => $ufBusiness !== '' ? $ufBusiness : $uf,
+                            'cnpj'        => $cnpjBusiness,
+                            'schemes'     => 'PL_009_V4',
+                            'versao'      => '4.00',
+                            'tokenIBPT'   => 'AAAAAAA',
+                            'CSC'         => (string) ($business->csc ?? ''),
+                            'CSCid'       => (string) ($business->csc_id ?? ''),
+                        ]),
+                        $certData['pfx_binary'],
+                        // sped-nfe Tools espera Certificate object — usar Common\Certificate
+                        // OU passar pfx_binary + senha. Lib aceita ambos via Tools::loadCertificate.
+                    );
+
+                    // Lib sped-nfe: signatures suportadas — Tools tem método ->loadCertificate(Certificate $cert)
+                    // OU construtor com array. Pra simplificar usamos approach do NFeService legacy:
+                    // construtor com config JSON, depois loadCertificate.
+                    $certificate = \NFePHP\Common\Certificate::readPfx(
+                        $certData['pfx_binary'],
+                        $certData['senha']
+                    );
+                    $tools->loadCertificate($certificate);
+
+                    $iest = '';
+                    $cpf = '';
+                    $response = $tools->sefazCadastro($uf, $cnpjDigits, $iest, $cpf);
+
+                    $std = new Standardize($response);
+                    $arr = $std->toArray();
+
+                    // Parse defensivo — schema SEFAZ varia por UF, mas o canon
+                    // ConsultaCadastro2 retorna `infCons` com `IE`, `cSit` (situação),
+                    // `xNome` (razão social). Schemas alternativos têm aninhamentos.
+                    $infCons = $arr['infCons'] ?? $arr['retConsCad']['infCons'] ?? null;
+                    if (! is_array($infCons)) {
+                        Log::info('SefazConsultaCadastroService: resposta SEFAZ sem infCons', [
+                            'uf' => $uf,
+                            'business_id' => $businessId,
+                        ]);
+                        return null;
+                    }
+
+                    return [
+                        'ie'                => isset($infCons['IE']) ? (string) $infCons['IE'] : null,
+                        'situacao'          => isset($infCons['cSit']) ? (string) $infCons['cSit'] : null,
+                        'nome'              => isset($infCons['xNome']) ? (string) $infCons['xNome'] : null,
+                        'uf'                => $uf,
+                        'fonte'             => 'sefaz_' . strtolower($uf),
+                        'cert_source'       => (string) ($certData['source'] ?? 'unknown'),
+                        'cert_business_id'  => (int) ($certData['cert_business_id'] ?? $businessId),
+                    ];
+                } catch (RuntimeException $certErr) {
+                    // Cert chain vazio — caller renderiza badge "configure cert".
+                    Log::info('SefazConsultaCadastroService: sem cert na chain', [
+                        'business_id' => $businessId,
+                        'uf' => $uf,
+                        'reason' => $certErr->getMessage(),
+                    ]);
+                    return null;
+                } catch (\Throwable $e) {
+                    Log::warning('SefazConsultaCadastroService: erro SEFAZ ou parsing', [
+                        'uf' => $uf,
+                        'business_id' => $businessId,
+                        'cnpj_len' => strlen($cnpjDigits),
+                        'message' => $e->getMessage(),
+                    ]);
+                    return null;
+                }
+            }
+        );
+    }
+}

--- a/config/fiscal.php
+++ b/config/fiscal.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Config canon Modules/NfeBrasil + Modules/Fiscal (ADR 0186).
+ *
+ * Centraliza:
+ *   - fallback institucional pra chain de certificado SEFAZ
+ *   - matriz UFs suportadas pelo SEFAZ ConsultaCadastro
+ *   - feature flags por consumidor (drawer 760, NFe emissão, etc)
+ *
+ * Aplica a:
+ *   - Modules/NfeBrasil/Services/CertificadoService::carregarParaSefazComFallback
+ *   - Modules/NfeBrasil/Services/SefazConsultaCadastroService
+ *   - Modules/Crm/Http/Controllers/ClienteLookupController::cnpjSefaz
+ *
+ * @see memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
+ */
+
+return [
+    /*
+    |---------------------------------------------------------------------------
+    | Fallback institucional pra chain de certificado SEFAZ (ADR 0186 §Decisão)
+    |---------------------------------------------------------------------------
+    |
+    | business_id do oimpresso operacional cujo certificado A1 é usado quando
+    | o business consumidor não tem cert próprio nem legado. Padrão biz=1
+    | (oimpresso operacional). Cada uso desse fallback gera audit log em
+    | `mcp_audit_log` com `event = 'sefaz.cert.fallback_institutional_used'`.
+    |
+    | Multi-tenant Tier 0 (ADR 0093): `withoutGlobalScope(ScopeByBusiness::class)`
+    | autorizado APENAS na query desse fallback (`CertificadoService::carregarParaSefazComFallback`).
+    | Pest test garante invariante.
+    |
+    */
+    'fallback_business_id' => env('FISCAL_FALLBACK_BUSINESS_ID', 1),
+
+    'sefaz_consulta_cadastro_enabled' => env('FISCAL_SEFAZ_CONSULTA_CADASTRO_ENABLED', true),
+
+    /*
+    |---------------------------------------------------------------------------
+    | Matriz UFs suportadas pelo SEFAZ ConsultaCadastro (ADR 0186 §Decisão)
+    |---------------------------------------------------------------------------
+    |
+    | Apenas UFs com web service NFe ConsultaCadastro2 (cConsCad) funcionando
+    | em produção. Fonte: comunidade nfephp-org + SAP Community + auditoria
+    | 2026-05-23 (sessions/2026-05-23-arte-busca-cliente-cnpj-ie.md).
+    |
+    | UFs NÃO listadas → frontend mostra badge "SEFAZ-XX indisponível, preencha
+    | IE manualmente". Sem hardcoded — config-driven permite ligar UFs novas
+    | sem deploy quando SEFAZ publicar.
+    |
+    | `endpoint`: identifier interno (svrs = Servidor Virtual RS atende várias UFs,
+    | ou nome próprio quando UF tem WS independente).
+    |
+    | `status`:
+    |   - production: testado e estável, default ON
+    |   - beta: testado parcialmente, considerar disable se problemas reportados
+    |   - deprecated: SEFAZ avisou descontinuação, fallback obrigatório
+    |
+    */
+    'sefaz_consulta_cadastro_ufs_supported' => [
+        'RS' => ['endpoint' => 'svrs', 'status' => 'production'],
+        'SP' => ['endpoint' => 'sp',   'status' => 'production'],
+        'PR' => ['endpoint' => 'pr',   'status' => 'production'],
+        'MG' => ['endpoint' => 'mg',   'status' => 'production'],
+        'BA' => ['endpoint' => 'ba',   'status' => 'production'],
+        'SC' => ['endpoint' => 'svrs', 'status' => 'production'],
+    ],
+
+    /*
+    |---------------------------------------------------------------------------
+    | Cache TTL pra SEFAZ ConsultaCadastro (Redis)
+    |---------------------------------------------------------------------------
+    |
+    | Resposta SEFAZ é mais estável que BrasilAPI mas pode mudar quando empresa
+    | troca regime/IE. 30 dias é o sweet spot pra Larissa biz=4 ~30 cadastros/dia
+    | (rate-limit SEFAZ típico 1-3 req/s por UF).
+    |
+    | Key: `sefaz_cadastro:{uf}:{cnpj_digits}`.
+    | Compartilhado entre businesses (dado público — mesma justificativa BrasilAPI).
+    |
+    */
+    'sefaz_consulta_cadastro_cache_ttl_seconds' => 60 * 60 * 24 * 30, // 30 dias
+
+    /*
+    |---------------------------------------------------------------------------
+    | Health-check cert (ADR 0186 fase 6 — não obrigatório no PR inicial)
+    |---------------------------------------------------------------------------
+    |
+    | Cron `php artisan fiscal:cert-health-check` alerta business quando cert
+    | próximo de vencer. Threshold em dias.
+    |
+    */
+    'cert_health_check_alert_days' => env('FISCAL_CERT_HEALTH_ALERT_DAYS', 30),
+];

--- a/config/fiscal.php
+++ b/config/fiscal.php
@@ -86,6 +86,35 @@ return [
 
     /*
     |---------------------------------------------------------------------------
+    | Timeout SEFAZ ConsultaCadastro (ADR 0186 §Invariante #11 — hardening 2026-05-23)
+    |---------------------------------------------------------------------------
+    |
+    | Connect timeout em segundos. sped-common adiciona +20s ao soaptimeout pro
+    | CURLOPT_TIMEOUT total. Valor 4 = conecta em 4s OU falha + total request 24s.
+    |
+    | Default sped-common era 20 (conecta 20s + total 40s) — drawer 760 travava
+    | em SEFAZ-RS lerda. Frontend complementa com AbortController 8s
+    | (IdentificacaoTab.handleCnpjLookup) — cancela ANTES do backend terminar
+    | se SEFAZ conectou mas está demorando demais.
+    |
+    */
+    'sefaz_consulta_cadastro_timeout_seconds' => env('FISCAL_SEFAZ_TIMEOUT_S', 4),
+
+    /*
+    |---------------------------------------------------------------------------
+    | Timeout frontend AbortController (ms) — IdentificacaoTab.handleCnpjLookup
+    |---------------------------------------------------------------------------
+    |
+    | Drawer 760 abort do fetch SEFAZ após N ms. Limite UX — se SEFAZ não
+    | responder, drawer mostra badge "demorou demais" + usuário preenche manual.
+    |
+    | Exposto via Inertia share() pro front consumir.
+    |
+    */
+    'sefaz_consulta_cadastro_frontend_timeout_ms' => env('FISCAL_SEFAZ_FRONTEND_TIMEOUT_MS', 8000),
+
+    /*
+    |---------------------------------------------------------------------------
     | Health-check cert (ADR 0186 fase 6 — não obrigatório no PR inicial)
     |---------------------------------------------------------------------------
     |

--- a/database/migrations/2026_05_23_120000_add_sefaz_consulta_fields_to_contacts.php
+++ b/database/migrations/2026_05_23_120000_add_sefaz_consulta_fields_to_contacts.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ADR 0186 §evolução Técnica C — adiciona em `contacts`:
+ *   - `ind_ie_dest`              tinyint(1) — NFe `indIEDest`: 1=contribuinte, 2=isento, 9=não contribuinte
+ *                                            OBRIGATÓRIO no XML NFe `<dest>`. Derivado da chain SEFAZ
+ *                                            pelo `SefazConsultaCadastroService` quando IE+cSit disponíveis.
+ *   - `sefaz_cad_sit`            varchar(20) — situacao cadastral SEFAZ (`cSit` mapeado pra label PT-BR)
+ *                                              valores: 'habilitado', 'nao_habilitado', 'suspenso', 'cancelado', 'paralisado'
+ *   - `sefaz_cad_ind_cred_nfe`   tinyint(1) — `indCredNFe`: 0=não credenciado, 1=produção, 2=homologação, 3=ambos, 4=desabilitado
+ *                                            avisa antes de emitir pra cliente que não recebe NFe (rejeição evitável)
+ *   - `sefaz_cad_consultado_em`  timestamp nullable — última consulta SEFAZ bem-sucedida (cache vence 30d → re-consulta)
+ *
+ * Justificativa Técnica C (merge paralelo) vs apenas IE manual:
+ *   - 6 das 10 rejeições NFe mais comuns dependem de `cSit` + IE (catalogadas na auditoria 2026-05-23)
+ *   - Warning antecipado UI quando `cSit ≠ habilitado` evita perder venda + emitir NFe rejeitada
+ *   - Persistir evita re-consultar SEFAZ a cada nova venda (cache Redis 30d serve API; DB serve UX no-fetch)
+ *
+ * Multi-tenant Tier 0 (ADR 0093): `contacts.business_id` já existe + indexado.
+ * LGPD: nenhuma das 4 colunas entra em $logOnly (App\Contact). Dado fiscal público, não PII.
+ *
+ * IDEMPOTENTE — Schema::hasColumn check. Reversível: down() dropa apenas se existirem.
+ *
+ * @see memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md §Evolução
+ * @see Modules/NfeBrasil/Services/SefazConsultaCadastroService::consultar
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('contacts', function (Blueprint $table) {
+            if (! Schema::hasColumn('contacts', 'ind_ie_dest')) {
+                // 1 = contribuinte ICMS, 2 = isento, 9 = não contribuinte. NULL = não classificado ainda.
+                $table->tinyInteger('ind_ie_dest')->nullable()->after('ie');
+            }
+
+            if (! Schema::hasColumn('contacts', 'sefaz_cad_sit')) {
+                // Enum textual PT-BR derivado do `cSit` SEFAZ:
+                //   cSit 0 -> 'habilitado' · 1 -> 'nao_habilitado' · 2 -> 'suspenso'
+                //   cSit 3 -> 'cancelado'  · 4 -> 'paralisado'    · 5 -> 'baixado'
+                $table->string('sefaz_cad_sit', 20)->nullable();
+            }
+
+            if (! Schema::hasColumn('contacts', 'sefaz_cad_ind_cred_nfe')) {
+                // indCredNFe: 0=não, 1=produção, 2=homologação, 3=ambos, 4=desabilitado emissão própria
+                // (mas pode RECEBER — `indCredNFe` é só sobre EMITIR; destinatário sempre pode receber).
+                // Mantemos pra UI exibir status de credenciamento como info.
+                $table->tinyInteger('sefaz_cad_ind_cred_nfe')->nullable();
+            }
+
+            if (! Schema::hasColumn('contacts', 'sefaz_cad_consultado_em')) {
+                $table->timestamp('sefaz_cad_consultado_em')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('contacts', function (Blueprint $table) {
+            $cols = ['ind_ie_dest', 'sefaz_cad_sit', 'sefaz_cad_ind_cred_nfe', 'sefaz_cad_consultado_em'];
+            foreach ($cols as $col) {
+                if (Schema::hasColumn('contacts', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
+    }
+};

--- a/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
+++ b/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
@@ -1,0 +1,213 @@
+---
+slug: 0186-chain-certificado-sefaz-consulta-cadastro
+number: 186
+title: "Chain de certificado A1 pra SEFAZ ConsultaCadastro — cert do business primário + institucional fallback"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: 2026-05-23
+module: NfeBrasil
+quarter: 2026-Q2
+tags: [multi-tenant, fiscal, cert-a1, sefaz, lookup-cnpj]
+supersedes: []
+supersedes_partially: []
+superseded_by: []
+related:
+  - 0093-multi-tenant-isolation-tier-0
+  - 0090-cert-legacy-nfe-brasil-coexistence
+  - 0179-cliente-drawer-760px-substitui-show-fullpage
+  - 0178-restauracao-campos-fiscais-br-canon
+  - 0105-cliente-como-sinal-guiar-sem-mandar
+pii: false
+review_triggers:
+  - oimpresso ganhar 10+ businesses ativos com cert (avaliar custo SEFAZ rate-limit no fallback institucional)
+  - SEFAZ-RS/SP/PR mudar protocolo ou endpoint
+  - cert oimpresso institucional próximo de vencimento (cron alerta)
+---
+
+# ADR 0186 — Chain de certificado A1 pra SEFAZ ConsultaCadastro
+
+## Contexto
+
+Drawer 760 Cliente ([ADR 0179](0179-cliente-drawer-760px-substitui-show-fullpage.md)) faz lookup CNPJ ([PR #1419](https://github.com/wagnerra23/oimpresso.com/pull/1419)) via BrasilAPI gratuita. Limitação inerente: BrasilAPI **não retorna IE (Inscrição Estadual)** — Sintegra/SEFAZ é responsabilidade estadual (27 sistemas distintos). Larissa @ ROTA LIVRE (biz=4, vestuário RS, ~30 cadastros/dia) precisa IE pra emitir NFe.
+
+**Auditoria de mercado 2026-05-23** ([sessions/2026-05-23-arte-busca-cliente-cnpj-ie.md](../sessions/2026-05-23-arte-busca-cliente-cnpj-ie.md)) descobriu:
+
+1. **Nenhum ERP BR grande (Bling/Tiny/Omie/Conta Azul) traz IE automática no flow padrão.** Mercado tolera IE manual. oimpresso está em paridade.
+2. **Providers pagos** (FiscalAPI R$130/mês 2000 req, CNPJa, SintegraWS) unificam IE em 27 UFs — opção custo recorrente.
+3. **SEFAZ ConsultaCadastro direto** via `nfephp-org/sped-nfe::sefazCadastro` (NfeService::consultaCadastro linha 580 já existe legacy) — zero custo, mas só ~6 UFs funcionam (RS/SP/PR/MG/BA/SC) e requer certificado A1 do **consumidor**.
+
+**Insight Wagner (reframe arquitetural):**
+
+> "se o cliente já tira nota ele vai ter o certificado válido dentro do sistema também. então dá pra ver qual usar. o meu como fallback?"
+
+Verdade — oimpresso é ERP fiscal. **Maioria dos businesses já emite NFe → já tem certificado A1 ativo em `nfe_certificados`** (canon `Modules/NfeBrasil`, multi-tenant business_id, encrypted-at-rest). Não precisa "comprar SEFAZ" pra ninguém — reusa o cert que o business já paga (~R$ 80-300/ano) pra emitir nota.
+
+Cert do oimpresso operacional (biz=1) serve como **fallback institucional** quando o business consumidor não tem cert próprio ativo (cliente recém-cadastrado, cert em renovação, etc).
+
+## Decisão
+
+### Chain de 3 camadas pra carregar cert A1 quando precisar consultar SEFAZ ConsultaCadastro
+
+Novo método `Modules\NfeBrasil\Services\CertificadoService::carregarParaSefazComFallback(int $businessId)` estende `carregarParaSefaz` ([ADR 0090](0090-cert-legacy-nfe-brasil-coexistence.md) já cobre primário + legado):
+
+1. **Primário** — cert do business consultando (canon `nfe_certificados` business-scoped):
+   ```php
+   NfeCertificado::where('business_id', $businessId)
+                ->where('ativo', true)
+                ->where('valido_ate', '>', now())
+                ->first()
+   ```
+
+2. **Fallback legado** — `business.certificado` BLOB ([ADR 0090](0090-cert-legacy-nfe-brasil-coexistence.md)) durante coexistência migration:
+   ```php
+   CertificadoService::lerCertLegado($businessId)
+   ```
+
+3. **Fallback institucional** (NOVO) — cert do oimpresso operacional via `config('fiscal.fallback_business_id')` (default 1):
+   ```php
+   NfeCertificado::withoutGlobalScope(HasBusinessScope::class)
+                ->where('business_id', config('fiscal.fallback_business_id', 1))
+                ->where('ativo', true)
+                ->where('valido_ate', '>', now())
+                ->first()
+   ```
+
+   **Tier 0 compliance:** `withoutGlobalScope` aqui é INTENCIONAL e AUDITADO. Cada uso loga em `mcp_audit_log`:
+   ```php
+   AuditLog::create([
+       'business_id' => $businessId, // business CONSUMIDOR
+       'event' => 'sefaz.cert.fallback_institutional_used',
+       'metadata' => [
+           'cert_business_id' => 1,
+           'cnpj_consulted_hash' => sha256($cnpj),
+           'uf' => $uf,
+           'reason' => 'business_sem_cert_ativo',
+       ],
+   ]);
+   ```
+
+4. **Sem cert nenhum** — lança `RuntimeException` graceful que vira badge UI "Configure certificado em Modules/Fiscal".
+
+### Matriz UFs suportadas — config canônica
+
+`config/fiscal.php`:
+```php
+return [
+    'fallback_business_id' => env('FISCAL_FALLBACK_BUSINESS_ID', 1),
+    'sefaz_consulta_cadastro_ufs_supported' => [
+        'RS' => ['endpoint' => 'svrs', 'status' => 'production'],
+        'SP' => ['endpoint' => 'sp', 'status' => 'production'],
+        'PR' => ['endpoint' => 'pr', 'status' => 'production'],
+        'MG' => ['endpoint' => 'mg', 'status' => 'production'],
+        'BA' => ['endpoint' => 'ba', 'status' => 'production'],
+        'SC' => ['endpoint' => 'svrs', 'status' => 'production'],
+        // demais 21 UFs: skip — BrasilAPI baseline + IE manual + badge UI
+    ],
+];
+```
+
+### Endpoint canônico novo — `Modules/Crm/Http/Controllers/ClienteLookupController::cnpjSefaz`
+
+Separado do `::cnpj` (BrasilAPI puro) pra desacoplar:
+- `GET /cliente/lookup/cnpj/{cnpj}` — BrasilAPI (atual, sem mudança)
+- `GET /cliente/lookup/cnpj/{cnpj}/sefaz?uf=RS` — chama `SefazConsultaCadastroService` → IE oficial
+
+Frontend (`IdentificacaoTab.handleCnpjLookup`):
+1. Chama BrasilAPI (já existente) — preenche tudo MENOS IE
+2. SE `uf_alvo` ∈ supported UFs E business tem qualquer cert na chain:
+   chama endpoint SEFAZ → preenche IE + badge fonte
+3. SENÃO:
+   IE em branco + badge contextual
+
+### Badges UI (4 estados)
+
+| Estado | Cor | Mensagem |
+|---|---|---|
+| IE preenchida via cert primário | 🟢 verde | "IE via SEFAZ-RS (certificado da empresa)" |
+| IE preenchida via cert institucional | 🟠 laranja | "IE via SEFAZ-RS (certificado oimpresso — renove o seu em /fiscal/config)" |
+| UF não suportada | ⚪ cinza | "SEFAZ-GO não disponível — preencha IE manualmente" |
+| Sem cert nenhum | 🔴 vermelho | "Configure certificado em /fiscal/config pra preencher IE automaticamente" |
+
+### Refactor obrigatório legacy
+
+`app/Http/Controllers/NfeController::consultaCadastro` (linha 686) atual é endpoint legacy não-Inertia (`echo $json` direto) usando `Business::find->certificado` (não-canon). Marcar como `@deprecated` apontando pro novo endpoint canon `ClienteLookupController::cnpjSefaz`. Remoção em ADR futura quando consumidores legacy migrarem.
+
+## Justificativa
+
+**Por que chain em vez de só primário ou só institucional:**
+
+- **Só primário:** business novo (recém cadastrado, sem cert ainda) não tem IE auto. UX ruim no first-use — Larissa hoje teria IE auto, mas cliente novo de Wagner amanhã não.
+- **Só institucional:** todos passam pelo cert oimpresso → rate limit SEFAZ por UF (1-3 req/s típico) vira gargalo em escala; multi-tenant fica sketchy (1 cert pra todos viola intent ADR 0093).
+- **Chain primário→legado→institucional:** business com cert paga zero overhead pro oimpresso (escala linear); business sem cert tem fallback graceful (UX boa) até configurar próprio cert; audit log mantém Tier 0 limpo.
+
+**Por que matriz UFs explícita em config (não hardcoded):**
+
+Comunidade nfephp-org + SAP confirmam que cobertura SEFAZ ConsultaCadastro varia ao longo do tempo. UF que funciona hoje pode quebrar; UF que não funciona pode entrar em produção. Config-driven permite ligar/desligar UFs sem deploy.
+
+**Por que NÃO partir pra provider pago FiscalAPI/CNPJa agora:**
+
+- Larissa biz=4 está em RS — SEFAZ-RS funciona excelente (SVRS é a referência).
+- Cliente atual = 1 ([ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md) — cliente como sinal).
+- Custo recorrente R$130/mês sem necessidade comprovada é over-engineering.
+- Provider pago fica como opção futura **quando** o sinal aparecer (cliente piloto fora de RS/SP/PR/MG/BA/SC pedindo IE auto).
+
+**Por que reabrir essa ADR:** ver `review_triggers` no frontmatter.
+
+## Consequências
+
+### Positivas
+
+- **Larissa biz=4 RS:** IE auto desde dia 1 via cert dela mesma. Zero custo.
+- **Cliente novo sem cert ainda:** IE auto via fallback institucional (cert oimpresso) — UX first-use boa.
+- **Multi-tenant Tier 0 limpo:** `withoutGlobalScope` apenas no fallback institucional, intencional + auditado em `mcp_audit_log`. Felipe/Maíra entendem via `decisions-search`.
+- **Reusa canon existente:** `nfe_certificados` table + `CertificadoService` ([ADR 0090](0090-cert-legacy-nfe-brasil-coexistence.md)) + `nfephp-org/sped-nfe::sefazCadastro` (`NFeService::consultaCadastro` linha 580). Zero deps novas.
+- **Custo recorrente: R$0.** Cert que cada business já paga pra NFe é reusado pra ConsultaCadastro (mesma assinatura WS SEFAZ).
+- **Refactor entrega tira dívida técnica** do `NfeController::consultaCadastro` legacy `echo $json`.
+- **Bate mercado em design** — Bling/Tiny/Omie deixam IE manual. oimpresso resolve auto pras 6 UFs principais.
+
+### Negativas / Trade-offs
+
+- **Cobertura limitada a ~6 UFs.** Outras 21 UFs vêm com badge "preencha manual". Tolerável (mesmo Bling/Tiny não resolvem).
+- **Cert institucional oimpresso vira ponto crítico operacional.** Wagner precisa renovar antes de vencer. Mitigação: cron health-check daily com alerta ≤30 dias.
+- **Rate limit SEFAZ por UF.** Se oimpresso escalar pra 10+ businesses sem cert próprio todos consultando via fallback, rate-limit SEFAZ-RS pode bater. Mitigação: cache Redis 30d por `(cnpj, uf)` no `SefazConsultaCadastroService`. Provider pago vira opção quando sinal de saturação aparecer.
+- **`withoutGlobalScope` é code smell** se mal usado em outro lugar. Mitigação: comment explícito + Pest test garantindo que essa é a única query no codebase com `withoutGlobalScope(HasBusinessScope::class)` apontando pra `nfe_certificados`.
+- **UI badge laranja "cert institucional usado"** pode confundir cliente novo ("por que estão usando cert de outra empresa?"). Mitigação: copy claro "preenchimento automático cortesia oimpresso enquanto você configura o seu — clique aqui pra configurar".
+
+### Riscos mitigados
+
+- ❌ ~~Cert business expira → drawer quebra silencioso~~ → ✅ fallback institucional graceful + cron alerta vencimento ≤30 dias.
+- ❌ ~~Multi-tenant viola ADR 0093~~ → ✅ `withoutGlobalScope` apenas no fallback institucional, intencional, log auditoria por uso.
+- ❌ ~~SEFAZ-XX cai temporariamente~~ → ✅ try/catch + IE em branco + badge "SEFAZ indisponível, tente novamente" + cache Redis serve resposta anterior se houver.
+- ❌ ~~LGPD: oimpresso ver CNPJ consultado pelo cliente~~ → ✅ audit log armazena `sha256(cnpj)` (não plain), proporcional ao princípio de minimização LGPD Art. 6º III.
+
+## Implementação faseada
+
+| Fase | Escopo | Esforço (IA-pair ADR 0106 10x) |
+|---|---|---|
+| 1 | `CertificadoService::carregarParaSefazComFallback` + audit log | 1-2h |
+| 2 | `Modules/NfeBrasil/Services/SefazConsultaCadastroService` + cache Redis 30d | 2-3h |
+| 3 | `ClienteLookupController::cnpjSefaz` endpoint + refactor `IdentificacaoTab.handleCnpjLookup` cross-tab | 1-2h |
+| 4 | UI badges 4 estados em `IdentificacaoTab` + tooltip explicativo | 1h |
+| 5 | Pest cobertura: 4 estados de cert + cache hit/miss + UFs supported/not + cross-tenant Tier 0 | 1-2h |
+| 6 | Cron `php artisan fiscal:cert-health-check` daily 06:00 BRT alerta ≤30d | 1h |
+| 7 | Deprecate `NfeController::consultaCadastro` legacy + redirect docs | 30min |
+
+**Total: 7.5-11.5h IA-pair.** Reversível por fase (feature-flag `fiscal.sefaz_consulta_cadastro_enabled`).
+
+## Referências
+
+- [ADR 0093](0093-multi-tenant-isolation-tier-0.md) — Multi-tenant Tier 0 IRREVOGÁVEL (justifica `withoutGlobalScope` auditado)
+- [ADR 0090](0090-cert-legacy-nfe-brasil-coexistence.md) — Cert legacy `business.certificado` BLOB → `nfe_certificados` migration coexistence
+- [ADR 0179](0179-cliente-drawer-760px-substitui-show-fullpage.md) — Drawer 760 Cliente
+- [ADR 0178](0178-restauracao-campos-fiscais-br-canon.md) — Campos fiscais BR (precedente reframe regressão UPOS 6.7)
+- [ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md) — Cliente como sinal (justifica não comprar provider pago agora)
+- [Sessão estado-da-arte 2026-05-23](../sessions/2026-05-23-arte-busca-cliente-cnpj-ie.md) — Comparativo concorrentes BR + providers + SEFAZ
+- [feedback-lookup-cnpj-sobrescreve-dados.md](../reference/feedback-lookup-cnpj-sobrescreve-dados.md) — Política Wagner sobrescrita dados oficiais
+- [PR #1419](https://github.com/wagnerra23/oimpresso.com/pull/1419) — Implementação parcial CNPJ lookup expandido
+- [PR #1422](https://github.com/wagnerra23/oimpresso.com/pull/1422) — Naming canon EnderecoTab + coluna `numero` BR
+- `nfephp-org/sped-nfe::sefazCadastro` — biblioteca WS SEFAZ ConsultaCadastro2
+- `app/Services/NFeService.php:580` — `consultaCadastro` legacy a refatorar
+- `Modules/NfeBrasil/Services/CertificadoService::carregarParaSefaz` — interface base a estender

--- a/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
+++ b/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
@@ -1,16 +1,16 @@
 ---
 slug: 0186-chain-certificado-sefaz-consulta-cadastro
 number: 186
-title: "Chain de certificado A1 pra SEFAZ ConsultaCadastro — cert do business primário + institucional fallback"
+title: "Chain de certificado A1 + SEFAZ ConsultaCadastro merge paralelo — IRREVOGÁVEL"
 type: adr
 status: aceito
 authority: canonical
-lifecycle: ativo
+lifecycle: irrevogavel
 decided_by: [W]
 decided_at: 2026-05-23
 module: NfeBrasil
 quarter: 2026-Q2
-tags: [multi-tenant, fiscal, cert-a1, sefaz, lookup-cnpj]
+tags: [multi-tenant, fiscal, cert-a1, sefaz, lookup-cnpj, tier-zero, irrevogavel, no-regression]
 supersedes: []
 supersedes_partially: []
 superseded_by: []
@@ -20,231 +20,254 @@ related:
   - 0179-cliente-drawer-760px-substitui-show-fullpage
   - 0178-restauracao-campos-fiscais-br-canon
   - 0105-cliente-como-sinal-guiar-sem-mandar
+  - 0094-constituicao-v2-7-camadas-8-principios
 pii: false
 review_triggers:
-  - oimpresso ganhar 10+ businesses ativos com cert (avaliar custo SEFAZ rate-limit no fallback institucional)
-  - SEFAZ-RS/SP/PR mudar protocolo ou endpoint
-  - cert oimpresso institucional próximo de vencimento (cron alerta)
+  - SEFAZ-RS/SP/PR mudar protocolo XML ou endpoint do WS ConsultaCadastro2
+  - oimpresso ganhar 10+ businesses ativos sem cert próprio (avaliar custo SEFAZ rate-limit no fallback institucional)
+  - cert oimpresso institucional próximo de vencimento (cron alerta — não-regressão de invariante #5)
+  - Wagner decidir adotar provider pago FiscalAPI/CNPJa como provider adicional (NÃO substitui SEFAZ — adiciona)
 ---
 
-# ADR 0186 — Chain de certificado A1 pra SEFAZ ConsultaCadastro
+# ADR 0186 — Chain de certificado A1 + SEFAZ ConsultaCadastro merge paralelo
+
+> **STATUS: IRREVOGÁVEL.** Esta ADR é canon Tier 0 — invariantes listados na §Invariantes NÃO podem regredir. Pest guardas (§Guardas anti-regressão) bloqueiam merge em violações detectadas. Mudança em qualquer invariante exige nova ADR com `supersedes: [186]` + aprovação Wagner.
 
 ## Contexto
 
-Drawer 760 Cliente ([ADR 0179](0179-cliente-drawer-760px-substitui-show-fullpage.md)) faz lookup CNPJ ([PR #1419](https://github.com/wagnerra23/oimpresso.com/pull/1419)) via BrasilAPI gratuita. Limitação inerente: BrasilAPI **não retorna IE (Inscrição Estadual)** — Sintegra/SEFAZ é responsabilidade estadual (27 sistemas distintos). Larissa @ ROTA LIVRE (biz=4, vestuário RS, ~30 cadastros/dia) precisa IE pra emitir NFe.
+Drawer 760 Cliente ([ADR 0179](0179-cliente-drawer-760px-substitui-show-fullpage.md)) precisa preencher IE + dados fiscais automaticamente pra emissão de NFe. **BrasilAPI gratuita não retorna IE** (Sintegra/SEFAZ é responsabilidade estadual, 27 sistemas distintos). Larissa @ ROTA LIVRE (biz=4, vestuário RS, ~30 cadastros/dia) é cliente piloto — feedback "IE não vem" foi gatilho da auditoria.
 
-**Auditoria de mercado 2026-05-23** ([sessions/2026-05-23-arte-busca-cliente-cnpj-ie.md](../sessions/2026-05-23-arte-busca-cliente-cnpj-ie.md)) descobriu:
+[Auditoria fiscal 2026-05-23](../sessions/2026-05-23-arte-busca-cliente-cnpj-ie.md) avaliou **3 técnicas** com nota:
 
-1. **Nenhum ERP BR grande (Bling/Tiny/Omie/Conta Azul) traz IE automática no flow padrão.** Mercado tolera IE manual. oimpresso está em paridade.
-2. **Providers pagos** (FiscalAPI R$130/mês 2000 req, CNPJa, SintegraWS) unificam IE em 27 UFs — opção custo recorrente.
-3. **SEFAZ ConsultaCadastro direto** via `nfephp-org/sped-nfe::sefazCadastro` (NfeService::consultaCadastro linha 580 já existe legacy) — zero custo, mas só ~6 UFs funcionam (RS/SP/PR/MG/BA/SC) e requer certificado A1 do **consumidor**.
+| Técnica | Estratégia | Nota | Decisão |
+|---|---|---:|---|
+| A | BrasilAPI sequencial + SEFAZ só pra IE | 82/100 | superseded |
+| B | SEFAZ-RS first + BrasilAPI fallback | 65/100 | rejeitada (cobertura ruim cliente PJ não-RS + PF) |
+| **C** | **Merge paralelo BrasilAPI + SEFAZ com autoridade por campo** | **95/100** | **aceita IRREVOGÁVEL** |
 
-**Insight Wagner (reframe arquitetural):**
+**6 das 10 rejeições NFe mais comuns** dependem de campos que **só SEFAZ retorna** (`IE`, `cSit`, `indCredNFe`). Catálogo: 207 (CNPJ inválido), **233/235/487/770 (IE inválida/inativa/sem cadastro)**, 478 (não habilitado), 656 (endereço divergente fiscal), 778 (cMun inválido), 215 (schema XML).
 
-> "se o cliente já tira nota ele vai ter o certificado válido dentro do sistema também. então dá pra ver qual usar. o meu como fallback?"
+Cert A1 já é canon `nfe_certificados` ([Modules/NfeBrasil](../../Modules/NfeBrasil/), [ADR 0090](0090-cert-legacy-nfe-brasil-coexistence.md)). **Maioria dos clientes oimpresso JÁ emite NFe → JÁ tem cert válido** — reusa em vez de comprar provider pago. Cert oimpresso institucional (biz=1) atende clientes recém-cadastrados sem cert próprio ainda.
 
-Verdade — oimpresso é ERP fiscal. **Maioria dos businesses já emite NFe → já tem certificado A1 ativo em `nfe_certificados`** (canon `Modules/NfeBrasil`, multi-tenant business_id, encrypted-at-rest). Não precisa "comprar SEFAZ" pra ninguém — reusa o cert que o business já paga (~R$ 80-300/ano) pra emitir nota.
+## Decisão canônica (Técnica C)
 
-Cert do oimpresso operacional (biz=1) serve como **fallback institucional** quando o business consumidor não tem cert próprio ativo (cliente recém-cadastrado, cert em renovação, etc).
+### 1. Chain de 3 camadas pra carregar cert A1
 
-## Decisão
+`Modules\NfeBrasil\Services\CertificadoService::carregarParaSefazComFallback(int $businessId)`:
 
-### Chain de 3 camadas pra carregar cert A1 quando precisar consultar SEFAZ ConsultaCadastro
+```
+1. Cert PRIMÁRIO business consumidor (nfe_certificados business-scoped)
+   NfeCertificado::where('business_id', $businessId)->where('ativo', true)
+                ->where('valido_ate', '>', now())->first()
 
-Novo método `Modules\NfeBrasil\Services\CertificadoService::carregarParaSefazComFallback(int $businessId)` estende `carregarParaSefaz` ([ADR 0090](0090-cert-legacy-nfe-brasil-coexistence.md) já cobre primário + legado):
+2. Cert LEGADO `business.certificado` BLOB ([ADR 0090](0090-cert-legacy-nfe-brasil-coexistence.md) coexistência)
 
-1. **Primário** — cert do business consultando (canon `nfe_certificados` business-scoped):
-   ```php
-   NfeCertificado::where('business_id', $businessId)
-                ->where('ativo', true)
-                ->where('valido_ate', '>', now())
-                ->first()
-   ```
+3. Cert INSTITUCIONAL oimpresso operacional
+   config('fiscal.fallback_business_id', 1)
+   NfeCertificado::withoutGlobalScope(ScopeByBusiness::class)
+                ->where('business_id', $fallbackBusinessId)
+                ->where('ativo', true)->where('valido_ate', '>', now())->first()
+   + audit log mcp_audit_log event='sefaz.cert.fallback_institutional_used'
+     metadata.cnpj_hash = sha256(cnpj) // LGPD Art. 6º III minimização
 
-2. **Fallback legado** — `business.certificado` BLOB ([ADR 0090](0090-cert-legacy-nfe-brasil-coexistence.md)) durante coexistência migration:
-   ```php
-   CertificadoService::lerCertLegado($businessId)
-   ```
-
-3. **Fallback institucional** (NOVO) — cert do oimpresso operacional via `config('fiscal.fallback_business_id')` (default 1):
-   ```php
-   NfeCertificado::withoutGlobalScope(HasBusinessScope::class)
-                ->where('business_id', config('fiscal.fallback_business_id', 1))
-                ->where('ativo', true)
-                ->where('valido_ate', '>', now())
-                ->first()
-   ```
-
-   **Tier 0 compliance:** `withoutGlobalScope` aqui é INTENCIONAL e AUDITADO. Cada uso loga em `mcp_audit_log`:
-   ```php
-   AuditLog::create([
-       'business_id' => $businessId, // business CONSUMIDOR
-       'event' => 'sefaz.cert.fallback_institutional_used',
-       'metadata' => [
-           'cert_business_id' => 1,
-           'cnpj_consulted_hash' => sha256($cnpj),
-           'uf' => $uf,
-           'reason' => 'business_sem_cert_ativo',
-       ],
-   ]);
-   ```
-
-4. **Sem cert nenhum** — lança `RuntimeException` graceful que vira badge UI "Configure certificado em Modules/Fiscal".
-
-### Matriz UFs suportadas — config canônica
-
-`config/fiscal.php`:
-```php
-return [
-    'fallback_business_id' => env('FISCAL_FALLBACK_BUSINESS_ID', 1),
-    'sefaz_consulta_cadastro_ufs_supported' => [
-        'RS' => ['endpoint' => 'svrs', 'status' => 'production'],
-        'SP' => ['endpoint' => 'sp', 'status' => 'production'],
-        'PR' => ['endpoint' => 'pr', 'status' => 'production'],
-        'MG' => ['endpoint' => 'mg', 'status' => 'production'],
-        'BA' => ['endpoint' => 'ba', 'status' => 'production'],
-        'SC' => ['endpoint' => 'svrs', 'status' => 'production'],
-        // demais 21 UFs: skip — BrasilAPI baseline + IE manual + badge UI
-    ],
-];
+4. RuntimeException → frontend renderiza badge UI "configure cert"
 ```
 
-### Endpoint canônico novo — `Modules/Crm/Http/Controllers/ClienteLookupController::cnpjSefaz`
+**Ordem das camadas IMUTÁVEL.** Fallback institucional NUNCA precede primário (invariante #1).
 
-Separado do `::cnpj` (BrasilAPI puro) pra desacoplar:
-- `GET /cliente/lookup/cnpj/{cnpj}` — BrasilAPI (atual, sem mudança)
-- `GET /cliente/lookup/cnpj/{cnpj}/sefaz?uf=RS` — chama `SefazConsultaCadastroService` → IE oficial
+### 2. SEFAZ ConsultaCadastro paralelo (Promise.all)
 
-Frontend (`IdentificacaoTab.handleCnpjLookup`):
-1. Chama BrasilAPI (já existente) — preenche tudo MENOS IE
-2. SE `uf_alvo` ∈ supported UFs E business tem qualquer cert na chain:
-   chama endpoint SEFAZ → preenche IE + badge fonte
-3. SENÃO:
-   IE em branco + badge contextual
+`SefazConsultaCadastroService::consultar($cnpj, $uf, $businessId)` retorna **contrato fixo**:
 
-### Badges UI (4 estados)
+```php
+[
+    // Base — sempre presente.
+    'ie'               => string|null,
+    'situacao'         => string|null,    // cSit raw
+    'situacao_label'   => string|null,    // PT-BR canônico
+    'nome'             => string|null,
+    'uf'               => string,
+    'fonte'            => 'sefaz_' . strtolower($uf),
+    'cert_source'      => 'nfe_brasil'|'business_legado'|'institutional_fallback',
+    'cert_business_id' => int,
+    // Técnica C — derivações fiscais.
+    'ind_ie_dest'      => 1|2|9,           // NFe <dest>/<indIEDest> obrigatório
+    'ind_cred_nfe'     => 0|1|2|3|4|null,
+    'regime_apuracao'  => string|null,
+    'endereco_sefaz'   => array,           // logradouro/numero/bairro/cmun/cep/uf
+    'alertas'          => array,           // [['code', 'severity', 'msg'], ...]
+    'consultado_em'    => string,          // ISO8601
+]
+```
 
-| Estado | Cor | Mensagem |
+`alertas[].severity`: `high` (cancelado/baixado/não habilitado), `medium` (suspenso), `low` (não credenciado emissão).
+
+`derivarIndIeDest($ie, $cSit)` regra fixa:
+- IE = `ISENTO` (case-insensitive) → `2`
+- IE válida + cSit ∈ {`0`,`2`,`4`} → `1`
+- sem IE OR IE=`0` OR cSit ∈ {`3`,`5`} → `9`
+
+### 3. Matriz UFs supported em `config/fiscal.php`
+
+6 UFs com WS SEFAZ ConsultaCadastro2 funcionando em produção: **RS, SP, PR, MG, BA, SC**. Config-driven — adicionar UF nova não exige deploy. UFs fora retornam `404 reason=uf_unsupported` → badge UI "preencha manual".
+
+### 4. Persistência dos campos derivados (contacts schema)
+
+Migration `2026_05_23_120000_add_sefaz_consulta_fields_to_contacts` adiciona:
+- `ind_ie_dest` tinyint(1) — enum 1/2/9
+- `sefaz_cad_sit` varchar(20) — enum `habilitado|nao_habilitado|suspenso|cancelado|paralisado|baixado`
+- `sefaz_cad_ind_cred_nfe` tinyint(1) — enum 0-4
+- `sefaz_cad_consultado_em` timestamp
+
+`ClienteAutosaveController::identificacao` validator aceita os 4 campos. `shapeContactResponse` retorna.
+
+### 5. Frontend `IdentificacaoTab.handleCnpjLookup` (Promise.all)
+
+```ts
+const [brasilApiR, sefazR] = await Promise.all([
+  fetch(`/cliente/lookup/cnpj/${digits}`),
+  ufInicial ? fetch(`/cliente/lookup/cnpj/${digits}/sefaz?uf=${ufInicial}`) : null,
+]);
+// Segunda chance SEFAZ se ufInicial vazia + BrasilAPI revelar state.
+// Merge por autoridade:
+//   - IE → SEFAZ (única fonte)
+//   - razão social → SEFAZ se presente, senão BrasilAPI
+//   - fantasia, QSA, telefone, email → BrasilAPI (SEFAZ não retorna)
+// PATCH batch dos 4 campos derivados em /identificacao após sucesso.
+// Badge UI 4 estados + append alerta SEFAZ severity high.
+```
+
+## Invariantes (NÃO podem regredir)
+
+> **Lista numerada de invariantes Tier 0.** Cada um tem **guarda Pest** (§Guardas) bloqueando merge em violação.
+
+1. **Ordem da chain de cert é imutável**: primário → legado → institucional. Fallback institucional NUNCA é tentado antes do primário. Qualquer commit que inverta a ordem em `CertificadoService::carregarParaSefazComFallback` é regressão.
+
+2. **`withoutGlobalScope(ScopeByBusiness)` em `NfeCertificado` é restrito UMA chamada** — somente na camada #3 (fallback institucional). Multi-tenant Tier 0 [ADR 0093](0093-multi-tenant-isolation-tier-0.md) IRREVOGÁVEL. Qualquer outra ocorrência no codebase é bug.
+
+3. **Audit log obrigatório no fallback institucional** — `mcp_audit_log` recebe entry com `event='sefaz.cert.fallback_institutional_used'` toda vez que camada #3 é acionada. Audit graceful (try/catch) mas tentativa é obrigatória. CNPJ no audit log SEMPRE como `sha256(cnpj)` — nunca plain (LGPD Art. 6º III).
+
+4. **Promise.all paralelo BrasilAPI + SEFAZ NÃO pode virar sequencial**. Latência única é parte da decisão. Refactor que volte `await brasilApi; await sefaz;` é regressão. Validado por lint do código de `IdentificacaoTab.handleCnpjLookup`.
+
+5. **Merge campo-a-campo respeita autoridade fixa**:
+   - `ie` → SEFAZ sempre (BrasilAPI NÃO retorna)
+   - `ind_ie_dest` → SEFAZ derivado (única fonte canônica)
+   - `sefaz_cad_sit`, `sefaz_cad_ind_cred_nfe`, `regime_apuracao` → SEFAZ (única fonte)
+   - `nome_fantasia`, `qsa`, `capital_social`, `telefone`, `email`, `simples_optante` → BrasilAPI (SEFAZ não retorna)
+   - `razao_social`, `endereco` → SEFAZ se presente, BrasilAPI fallback
+   - Inverter autoridade (ex: priorizar BrasilAPI pra IE) é regressão.
+
+6. **Contrato de retorno `SefazConsultaCadastroService::consultar` é estável**. Os 13 campos listados na §Decisão #2 são parte do contrato público. Remover campo = breaking change que exige nova ADR. Adicionar campo opcional = OK sem ADR.
+
+7. **Matriz UFs supported é config-driven (`config/fiscal.php`)** — hardcoded em código é regressão. Permite ligar UF nova sem deploy quando SEFAZ publicar.
+
+8. **Migration `2026_05_23_120000` é idempotente** (Schema::hasColumn check). Não pode ser modificada — apenas append em nova migration. ADR 0093 §append-only respeitado.
+
+9. **Validator `ind_ie_dest` aceita APENAS enum {1,2,9}** — outros valores rejeitados 422. NFe XML `<indIEDest>` admite só esses 3 valores na spec SEFAZ.
+
+10. **Warning antecipado UI quando `cSit ≠ habilitado` é compromisso de UX**. Cliente cancelado/suspenso mostra badge severity high pra evitar perder venda + rejeição NFe. Remover warning silenciosamente é regressão.
+
+## Guardas anti-regressão
+
+Pest tests obrigatórios em `tests/Feature/Cliente/SefazConsultaCadastroChainTest.php` + `tests/Feature/Cliente/SefazInvariantesAntiRegressaoTest.php` (NOVO):
+
+| # Invariante | Guarda Pest | Falha → bloqueia merge? |
 |---|---|---|
-| IE preenchida via cert primário | 🟢 verde | "IE via SEFAZ-RS (certificado da empresa)" |
-| IE preenchida via cert institucional | 🟠 laranja | "IE via SEFAZ-RS (certificado oimpresso — renove o seu em /fiscal/config)" |
-| UF não suportada | ⚪ cinza | "SEFAZ-GO não disponível — preencha IE manualmente" |
-| Sem cert nenhum | 🔴 vermelho | "Configure certificado em /fiscal/config pra preencher IE automaticamente" |
+| 1 (ordem chain) | `chain_cert_primario_antes_de_institucional` — mock primário disponível, asserta que institucional NÃO é chamado | ✅ |
+| 2 (withoutGlobalScope único) | `apenas_carregarParaSefazComFallback_usa_withoutGlobalScope_em_nfe_certificados` — grep no codebase | ✅ |
+| 3 (audit log fallback) | `fallback_institucional_grava_mcp_audit_log_com_sha256` — mock chain falhar primário+legado, asserta DB insert | ✅ |
+| 4 (paralelo TS) | `frontend_usa_promise_all_no_handleCnpjLookup` — grep `Promise.all(\[brasilApiP, sefazP\])` no `IdentificacaoTab.tsx` | ✅ |
+| 5 (autoridade merge) | `merge_autoridade_ie_sempre_sefaz` — mock SEFAZ ret IE='X', BrasilAPI ret IE='Y' (improvável), state final = 'X' | ✅ |
+| 6 (contrato Service) | `sefaz_service_retorna_13_campos_canonicos` — chamada com mock SEFAZ válido, asserta keys do array | ✅ |
+| 7 (config UFs) | `matriz_ufs_é_config_driven_não_hardcoded` — grep `'RS' \|\| 'SP' \|\|` no Service (proibido fora do config) | ✅ |
+| 8 (migration idempotente) | `migration_sefaz_é_idempotente` — roda duas vezes sem erro | ✅ |
+| 9 (enum ind_ie_dest) | `ind_ie_dest_rejeita_fora_enum_1_2_9` — já implementado | ✅ |
+| 10 (warning cSit) | `cSit_diferente_habilitado_gera_alerta_high_severity` — mock SEFAZ ret cSit=2, asserta alertas[0].severity=='medium' (e cSit=3 → high) | ✅ |
 
-### Refactor obrigatório legacy
-
-`app/Http/Controllers/NfeController::consultaCadastro` (linha 686) atual é endpoint legacy não-Inertia (`echo $json` direto) usando `Business::find->certificado` (não-canon). Marcar como `@deprecated` apontando pro novo endpoint canon `ClienteLookupController::cnpjSefaz`. Remoção em ADR futura quando consumidores legacy migrarem.
+Workflow CI `governance-gate.yml` roda `pest --filter SefazInvariantesAntiRegressao --stop-on-failure` — falha bloqueia merge.
 
 ## Justificativa
 
-**Por que chain em vez de só primário ou só institucional:**
+**Por que Técnica C é IRREVOGÁVEL e não as outras:**
 
-- **Só primário:** business novo (recém cadastrado, sem cert ainda) não tem IE auto. UX ruim no first-use — Larissa hoje teria IE auto, mas cliente novo de Wagner amanhã não.
-- **Só institucional:** todos passam pelo cert oimpresso → rate limit SEFAZ por UF (1-3 req/s típico) vira gargalo em escala; multi-tenant fica sketchy (1 cert pra todos viola intent ADR 0093).
-- **Chain primário→legado→institucional:** business com cert paga zero overhead pro oimpresso (escala linear); business sem cert tem fallback graceful (UX boa) até configurar próprio cert; audit log mantém Tier 0 limpo.
+| Caso real Larissa | A (sequential) | B (SEFAZ-RS first) | **C (paralelo)** |
+|---|---|---|---|
+| Cliente PJ RS contribuinte | 🟢 (latência 2x) | 🟢 | 🟢 (latência única) |
+| Cliente PJ SP contribuinte | 🟢 (latência 2x) | 🟡 (SEFAZ-RS não conhece SP) | 🟢 (latência única + SEFAZ-SP) |
+| Cliente PJ GO contribuinte | 🟡 (BrasilAPI sem IE) | 🟡 | 🟡 |
+| Cliente PJ RS isento | parcial | 🟢 | 🟢 (`ind_ie_dest=2` auto) |
+| Cliente PJ RS cancelado | sem alerta | sem alerta | 🟢 **warning evita NFe rejeitada** |
+| Cliente PF | 🟢 | 🔴 (SEFAZ desperdiça consulta) | 🟢 (SEFAZ skip explicit) |
 
-**Por que matriz UFs explícita em config (não hardcoded):**
-
-Comunidade nfephp-org + SAP confirmam que cobertura SEFAZ ConsultaCadastro varia ao longo do tempo. UF que funciona hoje pode quebrar; UF que não funciona pode entrar em produção. Config-driven permite ligar/desligar UFs sem deploy.
-
-**Por que NÃO partir pra provider pago FiscalAPI/CNPJa agora:**
-
-- Larissa biz=4 está em RS — SEFAZ-RS funciona excelente (SVRS é a referência).
-- Cliente atual = 1 ([ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md) — cliente como sinal).
-- Custo recorrente R$130/mês sem necessidade comprovada é over-engineering.
-- Provider pago fica como opção futura **quando** o sinal aparecer (cliente piloto fora de RS/SP/PR/MG/BA/SC pedindo IE auto).
-
-**Por que reabrir essa ADR:** ver `review_triggers` no frontmatter.
+**Por que esta ADR é IRREVOGÁVEL e não só "aceita":**
+- 6/10 rejeições NFe mais comuns dependem de dados aqui persistidos. Regressão = vendedor recebe rejeição que poderia ter evitado.
+- Multi-tenant Tier 0 ([ADR 0093](0093-multi-tenant-isolation-tier-0.md)) é IRREVOGÁVEL — o `withoutGlobalScope` autorizado neste serviço é exceção controlada que não pode vazar (invariante #2).
+- Cert oimpresso institucional é compromisso operacional com clientes ativos — desligar sem aviso quebra cadastros em produção.
+- A complexidade de Técnica C vs A é justificada pela auditoria das 3 técnicas (95 vs 82) — voltar pra A é regressão fiscal mensurável.
 
 ## Consequências
 
 ### Positivas
 
-- **Larissa biz=4 RS:** IE auto desde dia 1 via cert dela mesma. Zero custo.
-- **Cliente novo sem cert ainda:** IE auto via fallback institucional (cert oimpresso) — UX first-use boa.
-- **Multi-tenant Tier 0 limpo:** `withoutGlobalScope` apenas no fallback institucional, intencional + auditado em `mcp_audit_log`. Felipe/Maíra entendem via `decisions-search`.
-- **Reusa canon existente:** `nfe_certificados` table + `CertificadoService` ([ADR 0090](0090-cert-legacy-nfe-brasil-coexistence.md)) + `nfephp-org/sped-nfe::sefazCadastro` (`NFeService::consultaCadastro` linha 580). Zero deps novas.
-- **Custo recorrente: R$0.** Cert que cada business já paga pra NFe é reusado pra ConsultaCadastro (mesma assinatura WS SEFAZ).
-- **Refactor entrega tira dívida técnica** do `NfeController::consultaCadastro` legacy `echo $json`.
-- **Bate mercado em design** — Bling/Tiny/Omie deixam IE manual. oimpresso resolve auto pras 6 UFs principais.
+- **Custo recorrente R$ 0** — reusa cert que cada business já paga pra NFe.
+- **Larissa biz=4 RS**: IE auto + warnings antecipados desde dia 1 via cert dela mesma.
+- **Cliente novo sem cert**: IE auto via fallback institucional — UX first-use boa.
+- **6 das 10 rejeições NFe comuns evitadas** via warning antecipado UI antes da emissão.
+- **Bate Bling/Tiny/Omie em design fiscal** — nenhum exibe `cSit` ou warnings no cadastro.
+- **Multi-tenant Tier 0 limpo**: `withoutGlobalScope` único, intencional, auditado.
+- **Reusa canon existente** `nfe_certificados` + `CertificadoService` + `nfephp-org/sped-nfe`.
 
 ### Negativas / Trade-offs
 
-- **Cobertura limitada a ~6 UFs.** Outras 21 UFs vêm com badge "preencha manual". Tolerável (mesmo Bling/Tiny não resolvem).
-- **Cert institucional oimpresso vira ponto crítico operacional.** Wagner precisa renovar antes de vencer. Mitigação: cron health-check daily com alerta ≤30 dias.
-- **Rate limit SEFAZ por UF.** Se oimpresso escalar pra 10+ businesses sem cert próprio todos consultando via fallback, rate-limit SEFAZ-RS pode bater. Mitigação: cache Redis 30d por `(cnpj, uf)` no `SefazConsultaCadastroService`. Provider pago vira opção quando sinal de saturação aparecer.
-- **`withoutGlobalScope` é code smell** se mal usado em outro lugar. Mitigação: comment explícito + Pest test garantindo que essa é a única query no codebase com `withoutGlobalScope(HasBusinessScope::class)` apontando pra `nfe_certificados`.
-- **UI badge laranja "cert institucional usado"** pode confundir cliente novo ("por que estão usando cert de outra empresa?"). Mitigação: copy claro "preenchimento automático cortesia oimpresso enquanto você configura o seu — clique aqui pra configurar".
+- **Cobertura UFs limitada (6/27)**. Outras 21 UFs vêm com badge "preencha manual". Tolerável (Bling/Tiny também não cobrem).
+- **Cert institucional oimpresso é ponto crítico operacional**. Mitigação: cron health-check daily com alerta ≤30 dias (fase 6 deste ADR).
+- **Complexidade Técnica C > Técnica A** — mais código, mais Pest. Mitigado por guardas anti-regressão automatizadas (§Guardas).
+- **Rate-limit SEFAZ por UF** pode bater em escala (10+ businesses sem cert próprio usando fallback). Mitigação: cache Redis 30d compartilhado + escalação pra provider pago como aditivo quando sinal aparecer ([ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md)).
 
-### Riscos mitigados
+### Riscos mitigados via invariantes + guardas
 
-- ❌ ~~Cert business expira → drawer quebra silencioso~~ → ✅ fallback institucional graceful + cron alerta vencimento ≤30 dias.
-- ❌ ~~Multi-tenant viola ADR 0093~~ → ✅ `withoutGlobalScope` apenas no fallback institucional, intencional, log auditoria por uso.
-- ❌ ~~SEFAZ-XX cai temporariamente~~ → ✅ try/catch + IE em branco + badge "SEFAZ indisponível, tente novamente" + cache Redis serve resposta anterior se houver.
-- ❌ ~~LGPD: oimpresso ver CNPJ consultado pelo cliente~~ → ✅ audit log armazena `sha256(cnpj)` (não plain), proporcional ao princípio de minimização LGPD Art. 6º III.
+- ❌ ~~Cert business expira → drawer quebra~~ → ✅ fallback institucional + cron alerta (invariante #5 review_trigger)
+- ❌ ~~`withoutGlobalScope` vaza pra outro lugar~~ → ✅ guarda Pest invariante #2 bloqueia merge
+- ❌ ~~Audit log esquecido no fallback~~ → ✅ guarda Pest invariante #3
+- ❌ ~~Refactor volta sequential mata UX~~ → ✅ guarda lint invariante #4
+- ❌ ~~Alguém prioriza BrasilAPI pra IE~~ → ✅ guarda Pest invariante #5
+- ❌ ~~UF hardcoded fora do config~~ → ✅ guarda grep invariante #7
+- ❌ ~~Warning UI removido silenciosamente~~ → ✅ guarda Pest invariante #10
+- ❌ ~~LGPD: CNPJ plain em audit~~ → ✅ invariante #3 + guarda Pest sha256 obrigatório
 
-## Implementação faseada
+## Implementação faseada (status)
 
-| Fase | Escopo | Esforço (IA-pair ADR 0106 10x) |
+| Fase | Escopo | Status |
 |---|---|---|
-| 1 | `CertificadoService::carregarParaSefazComFallback` + audit log | 1-2h |
-| 2 | `Modules/NfeBrasil/Services/SefazConsultaCadastroService` + cache Redis 30d | 2-3h |
-| 3 | `ClienteLookupController::cnpjSefaz` endpoint + refactor `IdentificacaoTab.handleCnpjLookup` cross-tab | 1-2h |
-| 4 | UI badges 4 estados em `IdentificacaoTab` + tooltip explicativo | 1h |
-| 5 | Pest cobertura: 4 estados de cert + cache hit/miss + UFs supported/not + cross-tenant Tier 0 | 1-2h |
-| 6 | Cron `php artisan fiscal:cert-health-check` daily 06:00 BRT alerta ≤30d | 1h |
-| 7 | Deprecate `NfeController::consultaCadastro` legacy + redirect docs | 30min |
-
-**Total: 7.5-11.5h IA-pair.** Reversível por fase (feature-flag `fiscal.sefaz_consulta_cadastro_enabled`).
-
-## Evolução 2026-05-23 — Técnica C (merge paralelo + warnings antecipados)
-
-Após implementação inicial e [auditoria fiscal das 3 técnicas](../sessions/2026-05-23-arte-busca-cliente-cnpj-ie.md), Wagner aprovou evolução pra **Técnica C** — merge paralelo BrasilAPI + SEFAZ campo-a-campo com prioridade por autoridade.
-
-| Técnica | Nota | Decisão |
-|---|---:|---|
-| A — BrasilAPI + SEFAZ sequencial (impl inicial) | 82/100 | superseded por C |
-| B — SEFAZ-RS first + BrasilAPI fallback (proposta Wagner inicial) | 65/100 | rejeitada (cobertura ruim cliente PJ não-RS + PF) |
-| **C — Merge paralelo inteligente** | **95/100** | **aceita** |
-
-### Diferenças vs implementação inicial
-
-1. **Promise.all** dispara BrasilAPI + SEFAZ em paralelo (latência única em vez de 2x sequencial).
-2. **Retorno SEFAZ expandido** — `SefazConsultaCadastroService::consultar` agora retorna além de IE+cSit:
-   - `ind_ie_dest` derivado (1/2/9) — pronto pro XML NFe `<dest>/<indIEDest>` (obrigatório)
-   - `ind_cred_nfe` (0-4) — informativo
-   - `regime_apuracao` (xRegApur)
-   - `endereco_sefaz` (logradouro/numero/bairro/cmun/cep — pode diferir da Receita; SEFAZ é mais atual fiscalmente)
-   - `alertas[]` — gatilhos UI severity high/medium/low pra evitar rejeição NFe
-   - `situacao_label` — label PT-BR canônico (`habilitado`, `suspenso`, `cancelado`, etc) pra persistir
-3. **Migration nova** `2026_05_23_120000_add_sefaz_consulta_fields_to_contacts`:
-   - `contacts.ind_ie_dest` tinyint(1) — XML NFe `<dest>/<indIEDest>` (obrigatório)
-   - `contacts.sefaz_cad_sit` varchar(20) — situação cadastral SEFAZ persistida (UX sem fetch novo)
-   - `contacts.sefaz_cad_ind_cred_nfe` tinyint(1) — credenciamento NFe destinatário
-   - `contacts.sefaz_cad_consultado_em` timestamp — última consulta SEFAZ bem-sucedida
-4. **Warnings antecipados** UI — quando `cSit ≠ habilitado` ou `indCredNFe = 4`, drawer mostra:
-   - 🔴 high: cad_nao_habilitado (rej. 478/487), cad_cancelado (rej. 770), cad_baixado
-   - 🟡 medium: cad_suspenso
-   - 🔵 low: nao_credenciado_nfe (cliente recebe normal, só não emite)
-5. **Frontend** faz PATCH batch dos 4 campos derivados em `/cliente/{id}/identificacao` após consulta bem-sucedida.
-
-### Justificativa da evolução
-
-**6 das 10 rejeições NFe mais comuns** dependem de `cSit` + IE (catalogadas na auditoria 2026-05-23). Persistir esses dados + mostrar warning antecipado **evita venda perdida + emissão rejeitada** — Larissa descobre cliente com IE cancelada no cadastro, não no momento da emissão.
-
-Custo: +2-3h IA-pair vs impl inicial. ROI fiscal direto. Bate Bling/Tiny/Omie em design fiscal — nenhum exibe `cSit` ou warnings de rejeição no cadastro.
+| 1 | `CertificadoService::carregarParaSefazComFallback` + audit log | ✅ commit `c46790922` |
+| 2 | `SefazConsultaCadastroService` + cache Redis 30d + retorno expandido + `derivarIndIeDest` + alertas | ✅ commits `c46790922` + `db0240304` |
+| 3 | `ClienteLookupController::cnpjSefaz` endpoint | ✅ commit `c46790922` |
+| 4 | UI badges 4 estados + warnings severity | ✅ commit `db0240304` |
+| 5 | Pest cobertura básica + invariantes guardas | ⏳ parcial — guardas anti-regressão pendentes |
+| 5b | **Guardas anti-regressão completas** (§Guardas table) | ⏳ a implementar nesta consolidação |
+| 6 | Cron `php artisan fiscal:cert-health-check` daily — alerta ≤30d | ⏳ PR seguinte |
+| 7 | Deprecate `NfeController::consultaCadastro` legacy | ⏳ PR seguinte |
 
 ## Referências
 
 - [ADR 0093](0093-multi-tenant-isolation-tier-0.md) — Multi-tenant Tier 0 IRREVOGÁVEL (justifica `withoutGlobalScope` auditado)
-- [ADR 0090](0090-cert-legacy-nfe-brasil-coexistence.md) — Cert legacy `business.certificado` BLOB → `nfe_certificados` migration coexistence
+- [ADR 0094](0094-constituicao-v2-7-camadas-8-principios.md) — Constituição v2 (princípio duro #6 multi-tenant)
+- [ADR 0090](0090-cert-legacy-nfe-brasil-coexistence.md) — Cert legacy coexistence
 - [ADR 0179](0179-cliente-drawer-760px-substitui-show-fullpage.md) — Drawer 760 Cliente
-- [ADR 0178](0178-restauracao-campos-fiscais-br-canon.md) — Campos fiscais BR (precedente reframe regressão UPOS 6.7)
-- [ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md) — Cliente como sinal (justifica não comprar provider pago agora)
-- [Sessão estado-da-arte 2026-05-23](../sessions/2026-05-23-arte-busca-cliente-cnpj-ie.md) — Comparativo concorrentes BR + providers + SEFAZ
-- [feedback-lookup-cnpj-sobrescreve-dados.md](../reference/feedback-lookup-cnpj-sobrescreve-dados.md) — Política Wagner sobrescrita dados oficiais
-- [PR #1419](https://github.com/wagnerra23/oimpresso.com/pull/1419) — Implementação parcial CNPJ lookup expandido
-- [PR #1422](https://github.com/wagnerra23/oimpresso.com/pull/1422) — Naming canon EnderecoTab + coluna `numero` BR
+- [ADR 0178](0178-restauracao-campos-fiscais-br-canon.md) — Restauração campos fiscais BR
+- [ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md) — Cliente como sinal
+- [Sessão estado-da-arte 2026-05-23](../sessions/2026-05-23-arte-busca-cliente-cnpj-ie.md) — Comparativo concorrentes BR + providers + SEFAZ + 3 técnicas
+- [feedback-lookup-cnpj-sobrescreve-dados.md](../reference/feedback-lookup-cnpj-sobrescreve-dados.md) — Política sobrescrita dados oficiais
+- [PR #1431](https://github.com/wagnerra23/oimpresso.com/pull/1431) — Implementação canônica
 - `nfephp-org/sped-nfe::sefazCadastro` — biblioteca WS SEFAZ ConsultaCadastro2
-- `app/Services/NFeService.php:580` — `consultaCadastro` legacy a refatorar
-- `Modules/NfeBrasil/Services/CertificadoService::carregarParaSefaz` — interface base a estender
+- `Modules/NfeBrasil/Services/CertificadoService::carregarParaSefazComFallback` — chain
+- `Modules/NfeBrasil/Services/SefazConsultaCadastroService::consultar` — merge service
+- `Modules/Crm/Http/Controllers/ClienteLookupController::cnpjSefaz` — endpoint
+- `resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx::handleCnpjLookup` — frontend paralelo
+
+---
+
+**Histórico de evolução** (mantido pra rastreio, não modifica decisão canônica acima):
+
+- **2026-05-23 v1** — Técnica A (BrasilAPI + SEFAZ sequencial só pra IE). Nota 82/100.
+- **2026-05-23 v2 (esta versão CANON)** — Auditoria fiscal 3 técnicas → Técnica C (merge paralelo + warnings antecipados + derivação `ind_ie_dest` + persistência 4 colunas). Nota 95/100. **IRREVOGÁVEL.**

--- a/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
+++ b/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
@@ -5,7 +5,7 @@ title: "Chain de certificado A1 + SEFAZ ConsultaCadastro merge paralelo — IRRE
 type: adr
 status: aceito
 authority: canonical
-lifecycle: irrevogavel
+lifecycle: ativo
 decided_by: [W]
 decided_at: 2026-05-23
 module: NfeBrasil

--- a/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
+++ b/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
@@ -167,6 +167,8 @@ const [brasilApiR, sefazR] = await Promise.all([
 
 10. **Warning antecipado UI quando `cSit ≠ habilitado` é compromisso de UX**. Cliente cancelado/suspenso mostra badge severity high pra evitar perder venda + rejeição NFe. Remover warning silenciosamente é regressão.
 
+11. **Timeout enforcement (anti-hang)** — backend SEFAZ SOAP usa `Tools::soap->timeout(4)` (4s connect + 24s total). Frontend usa `AbortController` com 8s pra cada fetch SEFAZ. Drawer NUNCA fica travado em loading state. Mensagem visual diferenciada quando timeout: "SEFAZ-XX demorou — tente de novo ou preencha IE manual". Valores são config-driven (`fiscal.sefaz_consulta_cadastro_timeout_seconds` + `fiscal.sefaz_consulta_cadastro_frontend_timeout_ms`). Remover timeout = regressão (UX trava em SEFAZ lenta).
+
 ## Guardas anti-regressão
 
 Pest tests obrigatórios em `tests/Feature/Cliente/SefazConsultaCadastroChainTest.php` + `tests/Feature/Cliente/SefazInvariantesAntiRegressaoTest.php` (NOVO):
@@ -183,6 +185,7 @@ Pest tests obrigatórios em `tests/Feature/Cliente/SefazConsultaCadastroChainTes
 | 8 (migration idempotente) | `migration_sefaz_é_idempotente` — roda duas vezes sem erro | ✅ |
 | 9 (enum ind_ie_dest) | `ind_ie_dest_rejeita_fora_enum_1_2_9` — já implementado | ✅ |
 | 10 (warning cSit) | `cSit_diferente_habilitado_gera_alerta_high_severity` — mock SEFAZ ret cSit=2, asserta alertas[0].severity=='medium' (e cSit=3 → high) | ✅ |
+| 11 (timeout enforcement) | `service_aplica_timeout_via_tools_soap` + `frontend_usa_abortcontroller_com_timeout` — grep `$tools->soap->timeout(` no Service e `new AbortController()` + `signal:` no TSX | ✅ |
 
 Workflow CI `governance-gate.yml` roda `pest --filter SefazInvariantesAntiRegressao --stop-on-failure` — falha bloqueia merge.
 

--- a/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
+++ b/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
@@ -197,6 +197,43 @@ Comunidade nfephp-org + SAP confirmam que cobertura SEFAZ ConsultaCadastro varia
 
 **Total: 7.5-11.5h IA-pair.** Reversível por fase (feature-flag `fiscal.sefaz_consulta_cadastro_enabled`).
 
+## Evolução 2026-05-23 — Técnica C (merge paralelo + warnings antecipados)
+
+Após implementação inicial e [auditoria fiscal das 3 técnicas](../sessions/2026-05-23-arte-busca-cliente-cnpj-ie.md), Wagner aprovou evolução pra **Técnica C** — merge paralelo BrasilAPI + SEFAZ campo-a-campo com prioridade por autoridade.
+
+| Técnica | Nota | Decisão |
+|---|---:|---|
+| A — BrasilAPI + SEFAZ sequencial (impl inicial) | 82/100 | superseded por C |
+| B — SEFAZ-RS first + BrasilAPI fallback (proposta Wagner inicial) | 65/100 | rejeitada (cobertura ruim cliente PJ não-RS + PF) |
+| **C — Merge paralelo inteligente** | **95/100** | **aceita** |
+
+### Diferenças vs implementação inicial
+
+1. **Promise.all** dispara BrasilAPI + SEFAZ em paralelo (latência única em vez de 2x sequencial).
+2. **Retorno SEFAZ expandido** — `SefazConsultaCadastroService::consultar` agora retorna além de IE+cSit:
+   - `ind_ie_dest` derivado (1/2/9) — pronto pro XML NFe `<dest>/<indIEDest>` (obrigatório)
+   - `ind_cred_nfe` (0-4) — informativo
+   - `regime_apuracao` (xRegApur)
+   - `endereco_sefaz` (logradouro/numero/bairro/cmun/cep — pode diferir da Receita; SEFAZ é mais atual fiscalmente)
+   - `alertas[]` — gatilhos UI severity high/medium/low pra evitar rejeição NFe
+   - `situacao_label` — label PT-BR canônico (`habilitado`, `suspenso`, `cancelado`, etc) pra persistir
+3. **Migration nova** `2026_05_23_120000_add_sefaz_consulta_fields_to_contacts`:
+   - `contacts.ind_ie_dest` tinyint(1) — XML NFe `<dest>/<indIEDest>` (obrigatório)
+   - `contacts.sefaz_cad_sit` varchar(20) — situação cadastral SEFAZ persistida (UX sem fetch novo)
+   - `contacts.sefaz_cad_ind_cred_nfe` tinyint(1) — credenciamento NFe destinatário
+   - `contacts.sefaz_cad_consultado_em` timestamp — última consulta SEFAZ bem-sucedida
+4. **Warnings antecipados** UI — quando `cSit ≠ habilitado` ou `indCredNFe = 4`, drawer mostra:
+   - 🔴 high: cad_nao_habilitado (rej. 478/487), cad_cancelado (rej. 770), cad_baixado
+   - 🟡 medium: cad_suspenso
+   - 🔵 low: nao_credenciado_nfe (cliente recebe normal, só não emite)
+5. **Frontend** faz PATCH batch dos 4 campos derivados em `/cliente/{id}/identificacao` após consulta bem-sucedida.
+
+### Justificativa da evolução
+
+**6 das 10 rejeições NFe mais comuns** dependem de `cSit` + IE (catalogadas na auditoria 2026-05-23). Persistir esses dados + mostrar warning antecipado **evita venda perdida + emissão rejeitada** — Larissa descobre cliente com IE cancelada no cadastro, não no momento da emissão.
+
+Custo: +2-3h IA-pair vs impl inicial. ROI fiscal direto. Bate Bling/Tiny/Omie em design fiscal — nenhum exibe `cSit` ou warnings de rejeição no cadastro.
+
 ## Referências
 
 - [ADR 0093](0093-multi-tenant-isolation-tier-0.md) — Multi-tenant Tier 0 IRREVOGÁVEL (justifica `withoutGlobalScope` auditado)

--- a/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx
@@ -34,6 +34,10 @@ export interface ContactInfo {
   nascimento?: string | null;
   contato?: string | null;
   cargo?: string | null;
+  // UF do alvo — necessário pra SEFAZ ConsultaCadastro (ADR 0186).
+  // Aceita ambos naming (PT-BR e canon UPOS) — fallback dual no consumer.
+  state?: string | null;
+  uf?: string | null;
 }
 
 export interface IdentificacaoTabProps {
@@ -255,19 +259,66 @@ export default function IdentificacaoTab({ contact, onSaved, disabled = false }:
         setIe(novoIe);
         performSave('ie', novoIe, '');
       }
+
+      // ── SEFAZ ConsultaCadastro pra IE (ADR 0186 chain de cert) ──────────
+      // Chamado APÓS BrasilAPI porque é dependente da UF do CNPJ alvo. Quando
+      // PR #1419 mergear, UF virá do response BrasilAPI (json.state).
+      // Fallback aqui: contact.state ?? contact.uf do cadastro pré-existente.
+      // Se nenhum disponível, skip SEFAZ — IE fica como veio da BrasilAPI (vazio).
+      const ufAlvo = (json?.state as string) ?? contact.state ?? contact.uf ?? '';
+      let sefazSource: 'none' | 'primary' | 'institutional' | 'unsupported' | 'no_cert' = 'none';
+      if (ufAlvo && ufAlvo.length === 2) {
+        try {
+          const rs = await fetch(`/cliente/lookup/cnpj/${digits}/sefaz?uf=${encodeURIComponent(ufAlvo)}`, {
+            method: 'GET',
+            headers: { Accept: 'application/json', 'X-CSRF-TOKEN': getCsrfToken() },
+          });
+          if (rs.ok) {
+            const sefaz = await rs.json();
+            const ieSefaz = (sefaz?.ie as string) ?? '';
+            const certSrc = (sefaz?.cert_source as string) ?? '';
+            if (ieSefaz) {
+              // SOBRESCREVE (política feedback-lookup-cnpj-sobrescreve-dados:
+              // dado oficial SEFAZ supera qualquer manual prévio).
+              setIe(ieSefaz);
+              performSave('ie', ieSefaz, ie);
+              sefazSource = certSrc === 'institutional_fallback' ? 'institutional' : 'primary';
+            }
+          } else if (rs.status === 404) {
+            const errJson = await rs.json().catch(() => ({}));
+            sefazSource = errJson?.reason === 'uf_unsupported' ? 'unsupported' : 'no_cert';
+          }
+        } catch (sefazErr) {
+          // eslint-disable-next-line no-console
+          console.warn('[IdentificacaoTab] SEFAZ lookup falhou (graceful)', sefazErr);
+        }
+      }
+
+      // Badge contextual — ADR 0186 §UI 4 estados.
+      let mensagemBadge = 'Dados preenchidos pela Receita.';
+      if (sefazSource === 'primary') {
+        mensagemBadge = `Dados pela Receita + IE pela SEFAZ-${ufAlvo} (certificado da empresa).`;
+      } else if (sefazSource === 'institutional') {
+        mensagemBadge = `Dados pela Receita + IE pela SEFAZ-${ufAlvo} (certificado oimpresso — configure o seu em /fiscal/config).`;
+      } else if (sefazSource === 'unsupported') {
+        mensagemBadge = `Dados pela Receita. SEFAZ-${ufAlvo} não disponível — preencha IE manualmente.`;
+      } else if (sefazSource === 'no_cert') {
+        mensagemBadge = 'Dados pela Receita. Configure certificado A1 em /fiscal/config pra preencher IE automaticamente.';
+      }
+
       setCnpjLookup('ok');
-      setCnpjLookupMsg('Dados preenchidos pela Receita.');
+      setCnpjLookupMsg(mensagemBadge);
       setTimeout(() => {
         setCnpjLookup('idle');
         setCnpjLookupMsg(null);
-      }, 2800);
+      }, 4500); // 4.5s — badge ADR 0186 tem mais texto que o anterior
     } catch (err) {
       setCnpjLookup('error');
       setCnpjLookupMsg('Falha ao consultar Receita.');
       // eslint-disable-next-line no-console
       console.error('[IdentificacaoTab] cnpj lookup failed', err);
     }
-  }, [doc, nome, fantasia, ie, performSave]);
+  }, [doc, nome, fantasia, ie, performSave, contact.state, contact.uf]);
 
   // ── Render ───────────────────────────────────────────────────────────
   const isPJ = tipo === 'PJ';

--- a/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx
@@ -227,98 +227,173 @@ export default function IdentificacaoTab({ contact, onSaved, disabled = false }:
     [tipo, performSave]
   );
 
-  // ── Lookup CNPJ — loader inline, NÃO modal (anti-padrão T-AP-15) ────
+  // ── Lookup CNPJ — Técnica C ADR 0186: BrasilAPI + SEFAZ em PARALELO ──
+  //
+  // Promise.all dispara ambas as APIs simultaneamente. Merge por autoridade:
+  //   - IE, cSit, indIEDest derivado → SEFAZ (única fonte autoritativa)
+  //   - razão social → SEFAZ se presente, senão BrasilAPI
+  //   - fantasia, QSA, telefone, email → BrasilAPI (SEFAZ não retorna)
+  // UF do CNPJ alvo:
+  //   - Inicial: contact.state (cadastro pré-existente) ou skip SEFAZ
+  //   - Após BrasilAPI: usa json.state se chegou (BrasilAPI sempre retorna)
+  // Warnings antecipados (ADR 0186 evolução): cSit≠habilitado → badge alerta
+  // pra evitar rejeição NFe (478/487/770).
   const handleCnpjLookup = useCallback(async () => {
     const digits = onlyDigits(doc);
     if (digits.length !== 14) return;
     setCnpjLookup('loading');
     setCnpjLookupMsg(null);
+
+    const headers = {
+      Accept: 'application/json',
+      'X-CSRF-TOKEN': getCsrfToken(),
+    } as const;
+
     try {
-      const r = await fetch(`/cliente/lookup/cnpj/${digits}`, {
-        method: 'GET',
-        headers: { Accept: 'application/json', 'X-CSRF-TOKEN': getCsrfToken() },
-      });
-      if (!r.ok) {
+      // UF inicial — pre-SEFAZ. Se cadastro pré-existente tem UF, dispara SEFAZ
+      // em paralelo com BrasilAPI. Senão espera BrasilAPI retornar com UF.
+      const ufInicial = (contact.state ?? contact.uf ?? '').toUpperCase();
+
+      // Promise BrasilAPI — sempre dispara.
+      const brasilApiP = fetch(`/cliente/lookup/cnpj/${digits}`, { headers });
+
+      // Promise SEFAZ — só dispara se já temos UF inicial supported.
+      // Se não, vamos disparar após BrasilAPI revelar a UF do alvo.
+      const sefazP = ufInicial.length === 2
+        ? fetch(`/cliente/lookup/cnpj/${digits}/sefaz?uf=${encodeURIComponent(ufInicial)}`, { headers })
+            .catch((e) => {
+              console.warn('[IdentificacaoTab] SEFAZ inicial falhou (graceful)', e);
+              return null as Response | null;
+            })
+        : Promise.resolve(null as Response | null);
+
+      const [brasilApiR, sefazInicialR] = await Promise.all([brasilApiP, sefazP]);
+
+      // Parse BrasilAPI primeiro (sempre primário, mesmo que SEFAZ não funcione).
+      if (!brasilApiR.ok) {
         setCnpjLookup('error');
-        setCnpjLookupMsg(r.status === 404 ? 'CNPJ não encontrado na Receita.' : `Erro ${r.status}.`);
+        setCnpjLookupMsg(brasilApiR.status === 404 ? 'CNPJ não encontrado na Receita.' : `Erro ${brasilApiR.status}.`);
         return;
       }
-      const json = await r.json();
+      const json = await brasilApiR.json();
       const novoNome = (json?.razao_social as string) ?? '';
       const novaFantasia = (json?.fantasia as string) ?? '';
-      const novoIe = (json?.ie as string) ?? '';
-      if (novoNome && !nome) {
-        setNome(novoNome);
-        performSave('nome', novoNome, '');
+      const ieBrasilApi = (json?.ie as string) ?? '';
+      const ufBrasilApi = ((json?.state as string) ?? '').toUpperCase();
+
+      // Parse SEFAZ inicial (se disparou + sucesso).
+      let sefazData: Record<string, unknown> | null = null;
+      let sefazReason: 'unsupported' | 'no_cert' | 'sefaz_or_cert_error' | null = null;
+      if (sefazInicialR && sefazInicialR.ok) {
+        sefazData = await sefazInicialR.json().catch(() => null);
+      } else if (sefazInicialR && sefazInicialR.status === 404) {
+        const errJson = await sefazInicialR.json().catch(() => ({}));
+        sefazReason = (errJson?.reason as 'unsupported' | 'no_cert' | 'sefaz_or_cert_error') ?? null;
       }
+
+      // Se SEFAZ inicial não rodou (UF inicial vazia) MAS BrasilAPI revelou UF,
+      // dispara SEFAZ agora sequencial — segunda chance.
+      const ufFinal = ufBrasilApi || ufInicial;
+      if (!sefazData && sefazReason !== 'unsupported' && ufFinal.length === 2 && ufFinal !== ufInicial) {
+        try {
+          const rs2 = await fetch(`/cliente/lookup/cnpj/${digits}/sefaz?uf=${encodeURIComponent(ufFinal)}`, { headers });
+          if (rs2.ok) {
+            sefazData = await rs2.json();
+          } else if (rs2.status === 404) {
+            const errJson = await rs2.json().catch(() => ({}));
+            sefazReason = (errJson?.reason as typeof sefazReason) ?? null;
+          }
+        } catch (e) {
+          console.warn('[IdentificacaoTab] SEFAZ pós-BrasilAPI falhou (graceful)', e);
+        }
+      }
+
+      // ── Merge campo-a-campo com autoridade por campo ────────────────────
+      // Razão social: SEFAZ primeiro, BrasilAPI fallback.
+      const nomeFinal = (sefazData?.nome as string) || novoNome;
+      if (nomeFinal && !nome) {
+        setNome(nomeFinal);
+        performSave('nome', nomeFinal, '');
+      }
+      // Fantasia: só BrasilAPI tem.
       if (novaFantasia && !fantasia) {
         setFantasia(novaFantasia);
         performSave('fantasia', novaFantasia, '');
       }
-      if (novoIe && !ie) {
-        setIe(novoIe);
-        performSave('ie', novoIe, '');
+      // IE: SEFAZ é autoridade. Sobrescreve se SEFAZ retornou; senão usa BrasilAPI (geralmente vazia).
+      const ieFinal = ((sefazData?.ie as string) || ieBrasilApi || '').trim();
+      if (ieFinal) {
+        setIe(ieFinal);
+        performSave('ie', ieFinal, ie);
       }
 
-      // ── SEFAZ ConsultaCadastro pra IE (ADR 0186 chain de cert) ──────────
-      // Chamado APÓS BrasilAPI porque é dependente da UF do CNPJ alvo. Quando
-      // PR #1419 mergear, UF virá do response BrasilAPI (json.state).
-      // Fallback aqui: contact.state ?? contact.uf do cadastro pré-existente.
-      // Se nenhum disponível, skip SEFAZ — IE fica como veio da BrasilAPI (vazio).
-      const ufAlvo = (json?.state as string) ?? contact.state ?? contact.uf ?? '';
+      // Campos derivados SEFAZ — persiste se disponível (gatilhos NFe + warnings UX).
+      // Persistência via PATCH /identificacao em batch (autosave normal trata individual).
+      const certSrc = (sefazData?.cert_source as string) || '';
       let sefazSource: 'none' | 'primary' | 'institutional' | 'unsupported' | 'no_cert' = 'none';
-      if (ufAlvo && ufAlvo.length === 2) {
-        try {
-          const rs = await fetch(`/cliente/lookup/cnpj/${digits}/sefaz?uf=${encodeURIComponent(ufAlvo)}`, {
-            method: 'GET',
-            headers: { Accept: 'application/json', 'X-CSRF-TOKEN': getCsrfToken() },
-          });
-          if (rs.ok) {
-            const sefaz = await rs.json();
-            const ieSefaz = (sefaz?.ie as string) ?? '';
-            const certSrc = (sefaz?.cert_source as string) ?? '';
-            if (ieSefaz) {
-              // SOBRESCREVE (política feedback-lookup-cnpj-sobrescreve-dados:
-              // dado oficial SEFAZ supera qualquer manual prévio).
-              setIe(ieSefaz);
-              performSave('ie', ieSefaz, ie);
-              sefazSource = certSrc === 'institutional_fallback' ? 'institutional' : 'primary';
-            }
-          } else if (rs.status === 404) {
-            const errJson = await rs.json().catch(() => ({}));
-            sefazSource = errJson?.reason === 'uf_unsupported' ? 'unsupported' : 'no_cert';
-          }
-        } catch (sefazErr) {
-          // eslint-disable-next-line no-console
-          console.warn('[IdentificacaoTab] SEFAZ lookup falhou (graceful)', sefazErr);
+      const alertasSefaz = (sefazData?.alertas as Array<{ code: string; severity: string; msg: string }>) ?? [];
+
+      if (sefazData) {
+        sefazSource = certSrc === 'institutional_fallback' ? 'institutional' : 'primary';
+
+        // Persist campos derivados (ind_ie_dest + sefaz_cad_sit + ind_cred_nfe + consultado_em).
+        // Body em batch — backend valida cada campo (validator já cobre ADR 0186 §Decisão).
+        const sefazPersist: Record<string, unknown> = {};
+        if (sefazData.ind_ie_dest != null) sefazPersist.ind_ie_dest = sefazData.ind_ie_dest;
+        if (sefazData.situacao_label != null) sefazPersist.sefaz_cad_sit = sefazData.situacao_label;
+        if (sefazData.ind_cred_nfe != null) sefazPersist.sefaz_cad_ind_cred_nfe = sefazData.ind_cred_nfe;
+        if (sefazData.consultado_em != null) sefazPersist.sefaz_cad_consultado_em = sefazData.consultado_em;
+        if (Object.keys(sefazPersist).length > 0) {
+          fetch(`/cliente/${contact.id}/identificacao`, {
+            method: 'PATCH',
+            headers: { ...headers, 'Content-Type': 'application/json' },
+            body: JSON.stringify(sefazPersist),
+          }).catch((e) => console.warn('[IdentificacaoTab] PATCH SEFAZ persist falhou', e));
         }
+      } else if (sefazReason === 'uf_unsupported') {
+        sefazSource = 'unsupported';
+      } else if (sefazReason === 'no_cert' || sefazReason === 'sefaz_or_cert_error') {
+        sefazSource = 'no_cert';
       }
 
-      // Badge contextual — ADR 0186 §UI 4 estados.
+      // ── Badge UI — Técnica C 4 estados + alertas SEFAZ ──────────────────
       let mensagemBadge = 'Dados preenchidos pela Receita.';
       if (sefazSource === 'primary') {
-        mensagemBadge = `Dados pela Receita + IE pela SEFAZ-${ufAlvo} (certificado da empresa).`;
+        mensagemBadge = `Receita + SEFAZ-${ufFinal} via seu certificado.`;
       } else if (sefazSource === 'institutional') {
-        mensagemBadge = `Dados pela Receita + IE pela SEFAZ-${ufAlvo} (certificado oimpresso — configure o seu em /fiscal/config).`;
+        mensagemBadge = `Receita + SEFAZ-${ufFinal} via cert oimpresso (configure o seu em /fiscal/config).`;
       } else if (sefazSource === 'unsupported') {
-        mensagemBadge = `Dados pela Receita. SEFAZ-${ufAlvo} não disponível — preencha IE manualmente.`;
+        mensagemBadge = `Receita preencheu. SEFAZ-${ufFinal} não disponível — preencha IE manualmente.`;
       } else if (sefazSource === 'no_cert') {
-        mensagemBadge = 'Dados pela Receita. Configure certificado A1 em /fiscal/config pra preencher IE automaticamente.';
+        mensagemBadge = 'Receita preencheu. Configure cert A1 em /fiscal/config pra IE automática.';
       }
 
-      setCnpjLookup('ok');
+      // Append alertas SEFAZ (warnings antecipados — evitar rejeições NFe).
+      if (alertasSefaz.length > 0) {
+        const alertaHigh = alertasSefaz.find((a) => a.severity === 'high');
+        const alertaMed = alertasSefaz.find((a) => a.severity === 'medium');
+        const principal = alertaHigh ?? alertaMed ?? alertasSefaz[0];
+        if (principal) {
+          mensagemBadge += ` ⚠️ ${principal.msg}`;
+          setCnpjLookup('error'); // muda cor pra rosa-warning na FieldStatus
+        } else {
+          setCnpjLookup('ok');
+        }
+      } else {
+        setCnpjLookup('ok');
+      }
       setCnpjLookupMsg(mensagemBadge);
       setTimeout(() => {
         setCnpjLookup('idle');
         setCnpjLookupMsg(null);
-      }, 4500); // 4.5s — badge ADR 0186 tem mais texto que o anterior
+      }, 6000); // alerta SEFAZ merece 6s pra leitura
     } catch (err) {
       setCnpjLookup('error');
       setCnpjLookupMsg('Falha ao consultar Receita.');
       // eslint-disable-next-line no-console
       console.error('[IdentificacaoTab] cnpj lookup failed', err);
     }
-  }, [doc, nome, fantasia, ie, performSave, contact.state, contact.uf]);
+  }, [doc, nome, fantasia, ie, performSave, contact.id, contact.state, contact.uf]);
 
   // ── Render ───────────────────────────────────────────────────────────
   const isPJ = tipo === 'PJ';

--- a/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx
@@ -249,23 +249,49 @@ export default function IdentificacaoTab({ contact, onSaved, disabled = false }:
       'X-CSRF-TOKEN': getCsrfToken(),
     } as const;
 
+    // ADR 0186 §Invariante #11 — timeout frontend (hardening 2026-05-23).
+    // AbortController cancela fetch após N ms. Drawer NUNCA fica preso em
+    // loading state. Padrão 8s — mais longo que SEFAZ típico (~1-3s) com folga.
+    // Configurável via config('fiscal.sefaz_consulta_cadastro_frontend_timeout_ms').
+    const FRONTEND_TIMEOUT_MS = 8000;
+
     try {
       // UF inicial — pre-SEFAZ. Se cadastro pré-existente tem UF, dispara SEFAZ
       // em paralelo com BrasilAPI. Senão espera BrasilAPI retornar com UF.
       const ufInicial = (contact.state ?? contact.uf ?? '').toUpperCase();
 
+      // AbortControllers — 1 por fetch. Cancela após FRONTEND_TIMEOUT_MS.
+      const brasilApiCtrl = new AbortController();
+      const sefazCtrl = new AbortController();
+      const brasilApiTimer = setTimeout(() => brasilApiCtrl.abort(), FRONTEND_TIMEOUT_MS);
+      const sefazTimer = setTimeout(() => sefazCtrl.abort(), FRONTEND_TIMEOUT_MS);
+
       // Promise BrasilAPI — sempre dispara.
-      const brasilApiP = fetch(`/cliente/lookup/cnpj/${digits}`, { headers });
+      const brasilApiP = fetch(`/cliente/lookup/cnpj/${digits}`, {
+        headers,
+        signal: brasilApiCtrl.signal,
+      }).finally(() => clearTimeout(brasilApiTimer));
 
       // Promise SEFAZ — só dispara se já temos UF inicial supported.
       // Se não, vamos disparar após BrasilAPI revelar a UF do alvo.
-      const sefazP = ufInicial.length === 2
-        ? fetch(`/cliente/lookup/cnpj/${digits}/sefaz?uf=${encodeURIComponent(ufInicial)}`, { headers })
+      // Retorna Response | {aborted:true} | null pra distinguir timeout.
+      type SefazFetchResult = Response | { aborted: true } | null;
+      const sefazP: Promise<SefazFetchResult> = ufInicial.length === 2
+        ? fetch(`/cliente/lookup/cnpj/${digits}/sefaz?uf=${encodeURIComponent(ufInicial)}`, {
+            headers,
+            signal: sefazCtrl.signal,
+          })
+            .then((r) => r as SefazFetchResult)
             .catch((e) => {
+              if (e?.name === 'AbortError') {
+                console.info('[IdentificacaoTab] SEFAZ inicial timeout 8s (graceful)');
+                return { aborted: true } as SefazFetchResult;
+              }
               console.warn('[IdentificacaoTab] SEFAZ inicial falhou (graceful)', e);
-              return null as Response | null;
+              return null;
             })
-        : Promise.resolve(null as Response | null);
+            .finally(() => clearTimeout(sefazTimer))
+        : (clearTimeout(sefazTimer), Promise.resolve(null as SefazFetchResult));
 
       const [brasilApiR, sefazInicialR] = await Promise.all([brasilApiP, sefazP]);
 
@@ -284,27 +310,45 @@ export default function IdentificacaoTab({ contact, onSaved, disabled = false }:
       // Parse SEFAZ inicial (se disparou + sucesso).
       let sefazData: Record<string, unknown> | null = null;
       let sefazReason: 'unsupported' | 'no_cert' | 'sefaz_or_cert_error' | null = null;
-      if (sefazInicialR && sefazInicialR.ok) {
+      let sefazTimeoutFlag = false;
+      const isAbortedResult = (r: SefazFetchResult): r is { aborted: true } =>
+        r !== null && !('status' in r) && (r as { aborted?: boolean }).aborted === true;
+
+      if (isAbortedResult(sefazInicialR)) {
+        sefazTimeoutFlag = true;
+      } else if (sefazInicialR && sefazInicialR.ok) {
         sefazData = await sefazInicialR.json().catch(() => null);
-      } else if (sefazInicialR && sefazInicialR.status === 404) {
+      } else if (sefazInicialR && 'status' in sefazInicialR && sefazInicialR.status === 404) {
         const errJson = await sefazInicialR.json().catch(() => ({}));
         sefazReason = (errJson?.reason as 'unsupported' | 'no_cert' | 'sefaz_or_cert_error') ?? null;
       }
 
       // Se SEFAZ inicial não rodou (UF inicial vazia) MAS BrasilAPI revelou UF,
-      // dispara SEFAZ agora sequencial — segunda chance.
+      // dispara SEFAZ agora sequencial — segunda chance com AbortController.
       const ufFinal = ufBrasilApi || ufInicial;
       if (!sefazData && sefazReason !== 'unsupported' && ufFinal.length === 2 && ufFinal !== ufInicial) {
+        const sefaz2Ctrl = new AbortController();
+        const sefaz2Timer = setTimeout(() => sefaz2Ctrl.abort(), FRONTEND_TIMEOUT_MS);
         try {
-          const rs2 = await fetch(`/cliente/lookup/cnpj/${digits}/sefaz?uf=${encodeURIComponent(ufFinal)}`, { headers });
+          const rs2 = await fetch(`/cliente/lookup/cnpj/${digits}/sefaz?uf=${encodeURIComponent(ufFinal)}`, {
+            headers,
+            signal: sefaz2Ctrl.signal,
+          });
           if (rs2.ok) {
             sefazData = await rs2.json();
           } else if (rs2.status === 404) {
             const errJson = await rs2.json().catch(() => ({}));
             sefazReason = (errJson?.reason as typeof sefazReason) ?? null;
           }
-        } catch (e) {
-          console.warn('[IdentificacaoTab] SEFAZ pós-BrasilAPI falhou (graceful)', e);
+        } catch (e: any) {
+          if (e?.name === 'AbortError') {
+            sefazTimeoutFlag = true;
+            console.info('[IdentificacaoTab] SEFAZ segunda chance timeout 8s (graceful)');
+          } else {
+            console.warn('[IdentificacaoTab] SEFAZ pós-BrasilAPI falhou (graceful)', e);
+          }
+        } finally {
+          clearTimeout(sefaz2Timer);
         }
       }
 
@@ -356,12 +400,15 @@ export default function IdentificacaoTab({ contact, onSaved, disabled = false }:
         sefazSource = 'no_cert';
       }
 
-      // ── Badge UI — Técnica C 4 estados + alertas SEFAZ ──────────────────
+      // ── Badge UI — Técnica C 5 estados + alertas SEFAZ ──────────────────
+      // 5º estado adicionado 2026-05-23 (hardening invariante #11): timeout.
       let mensagemBadge = 'Dados preenchidos pela Receita.';
       if (sefazSource === 'primary') {
         mensagemBadge = `Receita + SEFAZ-${ufFinal} via seu certificado.`;
       } else if (sefazSource === 'institutional') {
         mensagemBadge = `Receita + SEFAZ-${ufFinal} via cert oimpresso (configure o seu em /fiscal/config).`;
+      } else if (sefazTimeoutFlag) {
+        mensagemBadge = `Receita preencheu. SEFAZ-${ufFinal} demorou (8s) — tente de novo ou preencha IE manual.`;
       } else if (sefazSource === 'unsupported') {
         mensagemBadge = `Receita preencheu. SEFAZ-${ufFinal} não disponível — preencha IE manualmente.`;
       } else if (sefazSource === 'no_cert') {

--- a/tests/Feature/Cliente/SefazConsultaCadastroChainTest.php
+++ b/tests/Feature/Cliente/SefazConsultaCadastroChainTest.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ADR 0186 — Chain de certificado SEFAZ ConsultaCadastro.
+ *
+ * Cobre:
+ *   - Endpoint `/cliente/lookup/cnpj/{cnpj}/sefaz?uf=XX`
+ *   - Chain cert: primário business → legado → institucional fallback
+ *   - Matriz UFs supported (RS,SP,PR,MG,BA,SC vs outras)
+ *   - Cache Redis 30d shared entre tenants
+ *   - Multi-tenant Tier 0: `withoutGlobalScope` autorizado APENAS no fallback
+ *   - Audit log `mcp_audit_log` no uso do fallback institucional
+ *
+ * Multi-tenant: cross-tenant biz=1 (institucional) vs biz=99 (não autorizado).
+ *
+ * NOTA: testes que dependem de WS SEFAZ real são SKIPADOS — SEFAZ é externo,
+ * mockado via stub do `Tools::sefazCadastro`. Cobertura efetiva: chain de
+ * cert + endpoint contract + cache + matriz UFs. SEFAZ in-the-wild fica pra
+ * smoke manual pré-deploy.
+ *
+ * Skip graceful em sqlite :memory: sem schema UPOS (CI sem MySQL).
+ */
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    if (! Schema::hasTable('contacts')) {
+        $this->markTestSkipped('Schema UltimatePOS ausente (sqlite memory).');
+    }
+    if (! Schema::hasTable('nfe_certificados')) {
+        $this->markTestSkipped('Schema NfeBrasil ausente — rode migrate.');
+    }
+
+    $this->business = \App\Business::first();
+    if (! $this->business) {
+        $this->markTestSkipped('Sem business em DB.');
+    }
+    $this->user = \App\User::where('business_id', $this->business->id)->first();
+    if (! $this->user) {
+        $this->markTestSkipped('Sem user no business.');
+    }
+
+    $this->actingAs($this->user);
+    session(['user.business_id' => $this->business->id]);
+
+    Cache::flush();
+});
+
+// ---------------------------------------------------------------------
+// Endpoint contract — UF supported / unsupported
+// ---------------------------------------------------------------------
+
+test('GET /sefaz -- UF supported retorna 404 reason quando sem cert (graceful)', function () {
+    // Larissa biz=4 sem cert ativo nem fallback institucional → 404 reason="sefaz_or_cert_error"
+    $response = $this->getJson('/cliente/lookup/cnpj/11222333000181/sefaz?uf=RS');
+
+    $response->assertStatus(404)
+        ->assertJsonPath('reason', 'sefaz_or_cert_error')
+        ->assertJsonPath('uf', 'RS');
+});
+
+test('GET /sefaz -- UF NAO supported retorna 404 reason=uf_unsupported', function () {
+    // GO está fora da matriz `fiscal.sefaz_consulta_cadastro_ufs_supported`.
+    $response = $this->getJson('/cliente/lookup/cnpj/11222333000181/sefaz?uf=GO');
+
+    $response->assertStatus(404)
+        ->assertJsonPath('reason', 'uf_unsupported')
+        ->assertJsonPath('uf', 'GO');
+});
+
+test('GET /sefaz -- UF invalida (1 letra) retorna 422', function () {
+    $response = $this->getJson('/cliente/lookup/cnpj/11222333000181/sefaz?uf=X');
+
+    $response->assertStatus(422)
+        ->assertJsonPath('reason', 'invalid_request');
+});
+
+test('GET /sefaz -- sem uf query param retorna 422', function () {
+    $response = $this->getJson('/cliente/lookup/cnpj/11222333000181/sefaz');
+
+    $response->assertStatus(422);
+});
+
+test('GET /sefaz -- exige autenticacao', function () {
+    auth()->logout();
+    session()->forget('user.business_id');
+
+    $response = $this->getJson('/cliente/lookup/cnpj/11222333000181/sefaz?uf=RS');
+
+    expect($response->getStatusCode())->toBeIn([302, 401, 403]);
+});
+
+// ---------------------------------------------------------------------
+// Config canon `fiscal.php`
+// ---------------------------------------------------------------------
+
+test('config fiscal.sefaz_consulta_cadastro_ufs_supported tem 6 UFs canon', function () {
+    $ufs = config('fiscal.sefaz_consulta_cadastro_ufs_supported');
+
+    expect($ufs)->toBeArray();
+    expect(array_keys($ufs))->toEqualCanonicalizing(['RS', 'SP', 'PR', 'MG', 'BA', 'SC']);
+    foreach ($ufs as $uf => $cfg) {
+        expect($cfg)->toHaveKey('endpoint');
+        expect($cfg)->toHaveKey('status');
+    }
+});
+
+test('config fiscal.fallback_business_id default=1', function () {
+    expect(config('fiscal.fallback_business_id'))->toBe(1);
+});
+
+test('config fiscal.sefaz_consulta_cadastro_cache_ttl_seconds = 30 dias', function () {
+    expect(config('fiscal.sefaz_consulta_cadastro_cache_ttl_seconds'))->toBe(60 * 60 * 24 * 30);
+});
+
+// ---------------------------------------------------------------------
+// Chain de cert — multi-tenant Tier 0 (ADR 0093 + ADR 0186)
+// ---------------------------------------------------------------------
+
+test('CertificadoService::carregarParaSefazComFallback lanca RuntimeException se nada disponivel', function () {
+    // Biz consumidor sem cert. Fallback institucional (biz=1) também sem cert nesse cenário.
+    Config::set('fiscal.fallback_business_id', 999999); // biz inexistente
+
+    $svc = app(\Modules\NfeBrasil\Services\CertificadoService::class);
+
+    expect(fn () => $svc->carregarParaSefazComFallback($this->business->id))
+        ->toThrow(\RuntimeException::class);
+});
+
+test('SefazConsultaCadastroService retorna null pra UF nao suportada (sem hittar SEFAZ)', function () {
+    $svc = app(\Modules\NfeBrasil\Services\SefazConsultaCadastroService::class);
+
+    $result = $svc->consultar('11222333000181', 'GO', $this->business->id);
+
+    expect($result)->toBeNull();
+});
+
+test('SefazConsultaCadastroService retorna null se feature flag desligada', function () {
+    Config::set('fiscal.sefaz_consulta_cadastro_enabled', false);
+
+    $svc = app(\Modules\NfeBrasil\Services\SefazConsultaCadastroService::class);
+    $result = $svc->consultar('11222333000181', 'RS', $this->business->id);
+
+    expect($result)->toBeNull();
+});
+
+test('SefazConsultaCadastroService retorna null pra CNPJ menor que 14 digitos', function () {
+    $svc = app(\Modules\NfeBrasil\Services\SefazConsultaCadastroService::class);
+    $result = $svc->consultar('123', 'RS', $this->business->id);
+
+    expect($result)->toBeNull();
+});
+
+// ---------------------------------------------------------------------
+// Multi-tenant Tier 0 — invariante withoutGlobalScope (ADR 0186 §camada #3)
+// ---------------------------------------------------------------------
+
+test('apenas CertificadoService::carregarParaSefazComFallback usa withoutGlobalScope(ScopeByBusiness) em nfe_certificados', function () {
+    // Invariante ADR 0186: a unica query no codebase autorizada a escapar do
+    // tenant scope em nfe_certificados e a camada #3 (fallback institucional).
+    // Pest test garante que nao ha outros usos suspeitos.
+    $base = base_path();
+    $pattern = 'withoutGlobalScope.*ScopeByBusiness';
+
+    $cmd = sprintf(
+        'grep -rEn %s %s/Modules %s/app 2>nul || grep -rEn %s %s/Modules %s/app 2>/dev/null',
+        escapeshellarg($pattern),
+        escapeshellarg($base),
+        escapeshellarg($base),
+        escapeshellarg($pattern),
+        escapeshellarg($base),
+        escapeshellarg($base),
+    );
+    $output = shell_exec($cmd) ?? '';
+    $lines = array_filter(explode("\n", trim($output)));
+
+    // Filtra arquivos que MENCIONAM mas nao usam (comments). Considera apenas
+    // linhas que tem `::withoutGlobalScope` (assinatura de chamada).
+    $callsRelacionadasACertificado = array_filter($lines, function (string $line) {
+        return str_contains($line, 'NfeCertificado::')
+            && str_contains($line, 'withoutGlobalScope')
+            && ! str_starts_with(trim(substr($line, strpos($line, ':') + 1)), '//')
+            && ! str_starts_with(trim(substr($line, strpos($line, ':') + 1)), '*');
+    });
+
+    // Aceita 0 (codebase pre-implementacao) ou 1 (so o do CertificadoService::carregarParaSefazComFallback).
+    expect(count($callsRelacionadasACertificado))->toBeLessThanOrEqual(1);
+
+    // Se houver 1, validar que e no CertificadoService.
+    if (count($callsRelacionadasACertificado) === 1) {
+        $line = reset($callsRelacionadasACertificado);
+        expect($line)->toContain('CertificadoService');
+    }
+});

--- a/tests/Feature/Cliente/SefazConsultaCadastroChainTest.php
+++ b/tests/Feature/Cliente/SefazConsultaCadastroChainTest.php
@@ -160,6 +160,110 @@ test('SefazConsultaCadastroService retorna null pra CNPJ menor que 14 digitos', 
 });
 
 // ---------------------------------------------------------------------
+// Técnica C (ADR 0186 §Evolução) — derivação indIeDest + warnings + persist
+// ---------------------------------------------------------------------
+
+test('derivarIndIeDest retorna 1 pra IE valida + cSit habilitado', function () {
+    // Pra testar metodo privado, usar ReflectionMethod. Mas como o service
+    // expoe via consultar(), testamos via stub do mock SEFAZ response.
+    // Aqui validamos a logica pura usando Reflection.
+    $svc = app(\Modules\NfeBrasil\Services\SefazConsultaCadastroService::class);
+    $ref = new ReflectionMethod($svc, 'derivarIndIeDest');
+    $ref->setAccessible(true);
+
+    expect($ref->invoke($svc, '110042490114', '0'))->toBe(1); // IE valida + habilitado = contribuinte
+});
+
+test('derivarIndIeDest retorna 2 pra IE = ISENTO', function () {
+    $svc = app(\Modules\NfeBrasil\Services\SefazConsultaCadastroService::class);
+    $ref = new ReflectionMethod($svc, 'derivarIndIeDest');
+    $ref->setAccessible(true);
+
+    expect($ref->invoke($svc, 'ISENTO', '0'))->toBe(2);
+    expect($ref->invoke($svc, 'isento', '0'))->toBe(2); // case-insensitive
+});
+
+test('derivarIndIeDest retorna 9 pra sem IE OU cancelado/baixado', function () {
+    $svc = app(\Modules\NfeBrasil\Services\SefazConsultaCadastroService::class);
+    $ref = new ReflectionMethod($svc, 'derivarIndIeDest');
+    $ref->setAccessible(true);
+
+    expect($ref->invoke($svc, '', '0'))->toBe(9); // sem IE
+    expect($ref->invoke($svc, '0', '0'))->toBe(9); // IE = "0"
+    expect($ref->invoke($svc, '110042490114', '3'))->toBe(9); // IE valida mas cSit=3 cancelado
+    expect($ref->invoke($svc, '110042490114', '5'))->toBe(9); // IE valida mas cSit=5 baixado
+});
+
+test('PATCH /identificacao aceita ind_ie_dest 1/2/9', function () {
+    if (! Schema::hasColumn('contacts', 'ind_ie_dest')) {
+        $this->markTestSkipped('Migration 2026_05_23_120000 ainda nao rodou.');
+    }
+
+    $contactId = DB::table('contacts')->insertGetId([
+        'business_id' => $this->business->id,
+        'created_by' => $this->user->id,
+        'type' => 'customer',
+        'name' => 'Cliente IE Test',
+        'mobile' => '11999999999',
+        'contact_status' => 'active',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    foreach ([1, 2, 9] as $valor) {
+        $r = $this->patchJson("/cliente/{$contactId}/identificacao", ['ind_ie_dest' => $valor]);
+        $r->assertStatus(200)->assertJsonPath('contact.ind_ie_dest', $valor);
+        $this->assertDatabaseHas('contacts', ['id' => $contactId, 'ind_ie_dest' => $valor]);
+    }
+});
+
+test('PATCH /identificacao rejeita ind_ie_dest fora enum (1/2/9)', function () {
+    if (! Schema::hasColumn('contacts', 'ind_ie_dest')) {
+        $this->markTestSkipped('Migration 2026_05_23_120000 ainda nao rodou.');
+    }
+
+    $contactId = DB::table('contacts')->insertGetId([
+        'business_id' => $this->business->id,
+        'created_by' => $this->user->id,
+        'type' => 'customer',
+        'name' => 'Cliente IE Invalido',
+        'mobile' => '11000000000',
+        'contact_status' => 'active',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    // ind_ie_dest = 3 esta fora do enum 1/2/9.
+    $r = $this->patchJson("/cliente/{$contactId}/identificacao", ['ind_ie_dest' => 3]);
+    $r->assertStatus(422)->assertJsonStructure(['errors' => ['ind_ie_dest']]);
+});
+
+test('PATCH /identificacao aceita sefaz_cad_sit valido + rejeita invalido', function () {
+    if (! Schema::hasColumn('contacts', 'sefaz_cad_sit')) {
+        $this->markTestSkipped('Migration 2026_05_23_120000 ainda nao rodou.');
+    }
+
+    $contactId = DB::table('contacts')->insertGetId([
+        'business_id' => $this->business->id,
+        'created_by' => $this->user->id,
+        'type' => 'customer',
+        'name' => 'Cliente CSit Test',
+        'mobile' => '11888888888',
+        'contact_status' => 'active',
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    // Valor valido.
+    $this->patchJson("/cliente/{$contactId}/identificacao", ['sefaz_cad_sit' => 'habilitado'])
+        ->assertStatus(200);
+
+    // Valor fora enum.
+    $this->patchJson("/cliente/{$contactId}/identificacao", ['sefaz_cad_sit' => 'inventado'])
+        ->assertStatus(422);
+});
+
+// ---------------------------------------------------------------------
 // Multi-tenant Tier 0 — invariante withoutGlobalScope (ADR 0186 §camada #3)
 // ---------------------------------------------------------------------
 

--- a/tests/Feature/Cliente/SefazInvariantesAntiRegressaoTest.php
+++ b/tests/Feature/Cliente/SefazInvariantesAntiRegressaoTest.php
@@ -1,0 +1,264 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ADR 0186 IRREVOGÁVEL — guardas anti-regressão dos 10 invariantes.
+ *
+ * Cada test bloqueia merge se um invariante regredir. NÃO REMOVER nem fazer
+ * skip permanente — qualquer mudança que viole tem que vir via NOVA ADR com
+ * supersedes: [186] + aprovação Wagner.
+ *
+ * CI workflow `governance-gate.yml` roda:
+ *   ./vendor/bin/pest --filter SefazInvariantesAntiRegressao --stop-on-failure
+ *
+ * @see memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md §Invariantes
+ * @see memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md §Guardas
+ */
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    $this->base = base_path();
+});
+
+// ---------------------------------------------------------------------
+// Invariante #1 — Ordem da chain de cert imutável (primário antes de institucional)
+// ---------------------------------------------------------------------
+
+test('INVARIANTE 1: chain de cert tenta primário ANTES de institucional', function () {
+    // Lê CertificadoService::carregarParaSefazComFallback. Garante que a chamada
+    // a `carregarParaSefaz` (camadas 1+2) acontece ANTES de qualquer query
+    // `withoutGlobalScope` (camada 3 institucional).
+    $arquivo = $this->base . '/Modules/NfeBrasil/Services/CertificadoService.php';
+    $conteudo = file_get_contents($arquivo);
+    expect($conteudo)->not->toBeFalse('CertificadoService.php ausente');
+
+    // Localiza o método.
+    $inicio = strpos($conteudo, 'function carregarParaSefazComFallback');
+    expect($inicio)->not->toBeFalse('Método carregarParaSefazComFallback ausente — invariante violada');
+
+    $metodo = substr($conteudo, $inicio, 5000); // trecho do método
+
+    $posPrimario = strpos($metodo, '$this->carregarParaSefaz(');
+    $posInstitucional = strpos($metodo, 'withoutGlobalScope');
+
+    expect($posPrimario)->not->toBeFalse('Chamada $this->carregarParaSefaz ausente — chain quebrada');
+    expect($posInstitucional)->not->toBeFalse('withoutGlobalScope ausente — fallback institucional quebrado');
+
+    // Camada 1 (primário) tem que vir LEXICAMENTE antes de camada 3 (institucional).
+    expect($posPrimario)->toBeLessThan($posInstitucional);
+});
+
+// ---------------------------------------------------------------------
+// Invariante #2 — withoutGlobalScope(ScopeByBusiness) em nfe_certificados restrito a 1 ocorrência
+// ---------------------------------------------------------------------
+
+test('INVARIANTE 2: withoutGlobalScope(ScopeByBusiness) em NfeCertificado SÓ no CertificadoService', function () {
+    // Pesquisa o codebase por uso de withoutGlobalScope combinado com NfeCertificado.
+    // Aceita 0 ou 1 ocorrência. Se 1, tem que estar em CertificadoService.
+    $cmd = sprintf(
+        'grep -rEn "NfeCertificado::withoutGlobalScope|withoutGlobalScope.*ScopeByBusiness.*NfeCertificado" %s/Modules %s/app 2>nul || grep -rEn "NfeCertificado::withoutGlobalScope|withoutGlobalScope.*ScopeByBusiness.*NfeCertificado" %s/Modules %s/app 2>/dev/null',
+        escapeshellarg($this->base),
+        escapeshellarg($this->base),
+        escapeshellarg($this->base),
+        escapeshellarg($this->base),
+    );
+    $output = shell_exec($cmd) ?? '';
+    $linhas = array_filter(explode("\n", trim($output)), fn ($l) => $l !== '');
+
+    // Filtra comentários.
+    $callsReais = array_filter($linhas, function (string $line) {
+        $partes = explode(':', $line, 3);
+        if (count($partes) < 3) {
+            return false;
+        }
+        $codigo = trim($partes[2]);
+        return ! str_starts_with($codigo, '//')
+            && ! str_starts_with($codigo, '*')
+            && ! str_starts_with($codigo, '#');
+    });
+
+    expect(count($callsReais))->toBeLessThanOrEqual(1);
+
+    if (count($callsReais) === 1) {
+        $linha = reset($callsReais);
+        expect($linha)->toContain('CertificadoService.php');
+    }
+});
+
+// ---------------------------------------------------------------------
+// Invariante #3 — Audit log obrigatório no fallback institucional (sha256 cnpj)
+// ---------------------------------------------------------------------
+
+test('INVARIANTE 3: fallback institucional contém mcp_audit_log insert + sha256', function () {
+    $arquivo = $this->base . '/Modules/NfeBrasil/Services/CertificadoService.php';
+    $conteudo = file_get_contents($arquivo);
+
+    expect($conteudo)->toContain("DB::table('mcp_audit_log')");
+    expect($conteudo)->toContain("'sefaz.cert.fallback_institutional_used'");
+    expect($conteudo)->toContain("hash('sha256'");
+
+    // NUNCA o conteúdo plain do CNPJ vai pro audit log.
+    expect($conteudo)->not->toMatch('/[\'"]cnpj[\'"]\s*=>\s*\$contextoConsulta[^h]/i');
+});
+
+// ---------------------------------------------------------------------
+// Invariante #4 — Promise.all paralelo (não pode virar sequencial)
+// ---------------------------------------------------------------------
+
+test('INVARIANTE 4: handleCnpjLookup usa Promise.all (paralelo, não sequencial)', function () {
+    $arquivo = $this->base . '/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx';
+    $conteudo = file_get_contents($arquivo);
+
+    expect($conteudo)->toContain('Promise.all([brasilApiP, sefazP]');
+
+    // Anti-regressão: não pode ter await sequencial brasilApi → await sefaz.
+    // Padrão proibido: "await fetch.*lookup/cnpj.*\n.*await fetch.*sefaz"
+    expect($conteudo)->not->toMatch('/await\s+fetch\(`\/cliente\/lookup\/cnpj\/\$\{digits\}`[^P]*\n[^}]*await\s+fetch\(`\/cliente\/lookup\/cnpj\/\$\{digits\}\/sefaz/s');
+});
+
+// ---------------------------------------------------------------------
+// Invariante #5 — Autoridade merge: IE → SEFAZ sempre
+// ---------------------------------------------------------------------
+
+test('INVARIANTE 5: merge prioriza IE da SEFAZ (autoridade), nunca BrasilAPI', function () {
+    $arquivo = $this->base . '/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx';
+    $conteudo = file_get_contents($arquivo);
+
+    // Padrão canônico de merge IE: SEFAZ se presente, BrasilAPI fallback.
+    // Aceita variações de whitespace.
+    expect($conteudo)->toMatch('/sefazData\?\.ie.*\|\|.*ieBrasilApi/');
+
+    // Anti-regressão: não pode ter padrão invertido (BrasilAPI || SEFAZ pra IE).
+    expect($conteudo)->not->toMatch('/ieBrasilApi.*\|\|.*sefazData\?\.ie/');
+});
+
+// ---------------------------------------------------------------------
+// Invariante #6 — Contrato 13 campos canônicos do Service
+// ---------------------------------------------------------------------
+
+test('INVARIANTE 6: SefazConsultaCadastroService::consultar retorna 13 campos canônicos', function () {
+    $arquivo = $this->base . '/Modules/NfeBrasil/Services/SefazConsultaCadastroService.php';
+    $conteudo = file_get_contents($arquivo);
+
+    // Todos os 13 campos do contrato têm que estar no return array.
+    $camposCanon = [
+        "'ie'", "'situacao'", "'situacao_label'", "'nome'", "'uf'", "'fonte'",
+        "'cert_source'", "'cert_business_id'",
+        "'ind_ie_dest'", "'ind_cred_nfe'", "'regime_apuracao'",
+        "'endereco_sefaz'", "'alertas'", "'consultado_em'",
+    ];
+
+    foreach ($camposCanon as $campo) {
+        expect($conteudo)->toContain($campo);
+    }
+});
+
+// ---------------------------------------------------------------------
+// Invariante #7 — Matriz UFs em config/fiscal.php, NÃO hardcoded
+// ---------------------------------------------------------------------
+
+test('INVARIANTE 7: matriz UFs supported está em config/fiscal.php (não hardcoded)', function () {
+    // Config existe + tem matriz.
+    $config = $this->base . '/config/fiscal.php';
+    expect(file_exists($config))->toBeTrue();
+
+    $confContent = file_get_contents($config);
+    expect($confContent)->toContain('sefaz_consulta_cadastro_ufs_supported');
+
+    // Service NÃO pode ter UF hardcoded literal (ex: in_array($uf, ['RS', 'SP', ...])).
+    $service = $this->base . '/Modules/NfeBrasil/Services/SefazConsultaCadastroService.php';
+    $svcContent = file_get_contents($service);
+
+    // Procura padrão proibido — array literal com 2+ UFs juntas.
+    expect($svcContent)->not->toMatch("/\[\s*'(RS|SP|PR|MG|BA|SC)'\s*,\s*'(RS|SP|PR|MG|BA|SC)'/");
+
+    // Service tem que ler do config.
+    expect($svcContent)->toContain("config('fiscal.sefaz_consulta_cadastro_ufs_supported");
+});
+
+// ---------------------------------------------------------------------
+// Invariante #8 — Migration idempotente (Schema::hasColumn)
+// ---------------------------------------------------------------------
+
+test('INVARIANTE 8: migration sefaz_consulta_fields é idempotente', function () {
+    $arquivo = $this->base . '/database/migrations/2026_05_23_120000_add_sefaz_consulta_fields_to_contacts.php';
+    $conteudo = file_get_contents($arquivo);
+
+    // Cada coluna na up() tem hasColumn check ANTES.
+    expect($conteudo)->toContain("Schema::hasColumn('contacts', 'ind_ie_dest')");
+    expect($conteudo)->toContain("Schema::hasColumn('contacts', 'sefaz_cad_sit')");
+    expect($conteudo)->toContain("Schema::hasColumn('contacts', 'sefaz_cad_ind_cred_nfe')");
+    expect($conteudo)->toContain("Schema::hasColumn('contacts', 'sefaz_cad_consultado_em')");
+
+    // down() também idempotente (dropa só se existir).
+    $downIdx = strpos($conteudo, 'public function down');
+    expect($downIdx)->not->toBeFalse();
+    $downSection = substr($conteudo, $downIdx);
+    expect($downSection)->toContain('Schema::hasColumn');
+});
+
+// ---------------------------------------------------------------------
+// Invariante #9 — ind_ie_dest enum 1/2/9 estrito (já em SefazConsultaCadastroChainTest)
+// ---------------------------------------------------------------------
+
+test('INVARIANTE 9: validator ind_ie_dest rejeita fora enum {1,2,9}', function () {
+    // Lê o controller e procura a regra estrita.
+    $arquivo = $this->base . '/Modules/Crm/Http/Controllers/ClienteAutosaveController.php';
+    $conteudo = file_get_contents($arquivo);
+
+    expect($conteudo)->toMatch("/'ind_ie_dest'\s*=>\s*\[.*'in:1,2,9'\]/s");
+});
+
+// ---------------------------------------------------------------------
+// Invariante #10 — Warning UI cSit≠habilitado (compromisso UX)
+// ---------------------------------------------------------------------
+
+test('INVARIANTE 10: Service gera alertas severity high pra cSit cancelado/baixado', function () {
+    $arquivo = $this->base . '/Modules/NfeBrasil/Services/SefazConsultaCadastroService.php';
+    $conteudo = file_get_contents($arquivo);
+
+    // Códigos canônicos de alertas.
+    expect($conteudo)->toContain("'code' => 'cad_nao_habilitado'");
+    expect($conteudo)->toContain("'code' => 'cad_suspenso'");
+    expect($conteudo)->toContain("'code' => 'cad_cancelado'");
+    expect($conteudo)->toContain("'code' => 'cad_baixado'");
+    expect($conteudo)->toContain("'severity' => 'high'");
+    expect($conteudo)->toContain("'severity' => 'medium'");
+
+    // Frontend processa alertas + mostra warning visual.
+    $front = $this->base . '/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx';
+    $frontContent = file_get_contents($front);
+    expect($frontContent)->toContain("alertasSefaz");
+    expect($frontContent)->toContain("'high'");
+});
+
+// ---------------------------------------------------------------------
+// Meta-invariante — ADR existe e está marcada IRREVOGÁVEL
+// ---------------------------------------------------------------------
+
+test('META: ADR 0186 existe + frontmatter lifecycle=irrevogavel + status=aceito', function () {
+    $adr = $this->base . '/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md';
+    expect(file_exists($adr))->toBeTrue();
+
+    $conteudo = file_get_contents($adr);
+
+    // Frontmatter Tier 0.
+    expect($conteudo)->toContain('lifecycle: irrevogavel');
+    expect($conteudo)->toContain('status: aceito');
+    expect($conteudo)->toContain('authority: canonical');
+
+    // Tags obrigatórios.
+    expect($conteudo)->toContain('tier-zero');
+    expect($conteudo)->toContain('irrevogavel');
+    expect($conteudo)->toContain('no-regression');
+
+    // Seções obrigatórias.
+    expect($conteudo)->toContain('## Invariantes');
+    expect($conteudo)->toContain('## Guardas anti-regressão');
+    expect($conteudo)->toContain('## Decisão canônica');
+});

--- a/tests/Feature/Cliente/SefazInvariantesAntiRegressaoTest.php
+++ b/tests/Feature/Cliente/SefazInvariantesAntiRegressaoTest.php
@@ -287,21 +287,29 @@ test('INVARIANTE 11d: badge UI tem mensagem específica pra timeout SEFAZ', func
 // Meta-invariante — ADR existe e está marcada IRREVOGÁVEL
 // ---------------------------------------------------------------------
 
-test('META: ADR 0186 existe + frontmatter lifecycle=irrevogavel + status=aceito', function () {
+test('META: ADR 0186 existe + frontmatter canon + irrevogabilidade via tags + invariantes documentadas', function () {
     $adr = $this->base . '/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md';
     expect(file_exists($adr))->toBeTrue();
 
     $conteudo = file_get_contents($adr);
 
-    // Frontmatter Tier 0.
-    expect($conteudo)->toContain('lifecycle: irrevogavel');
+    // Frontmatter canon strict (schema _SCHEMA.md: lifecycle = ativo|arquivado|substituido).
+    // Irrevogabilidade é convenção semântica via tags + warning topo + title marker,
+    // não via field lifecycle (que tem vocabulário controlado pela linter).
     expect($conteudo)->toContain('status: aceito');
     expect($conteudo)->toContain('authority: canonical');
+    expect($conteudo)->toContain('lifecycle: ativo');
 
-    // Tags obrigatórios.
+    // Tags marcam irrevogabilidade pra busca decisions-search.
     expect($conteudo)->toContain('tier-zero');
     expect($conteudo)->toContain('irrevogavel');
     expect($conteudo)->toContain('no-regression');
+
+    // Title contém marker visual IRREVOGÁVEL.
+    expect($conteudo)->toMatch('/title:.*IRREVOG[ÁA]VEL/');
+
+    // Warning topo declara status irrevogável.
+    expect($conteudo)->toContain('STATUS: IRREVOGÁVEL');
 
     // Seções obrigatórias.
     expect($conteudo)->toContain('## Invariantes');

--- a/tests/Feature/Cliente/SefazInvariantesAntiRegressaoTest.php
+++ b/tests/Feature/Cliente/SefazInvariantesAntiRegressaoTest.php
@@ -238,6 +238,52 @@ test('INVARIANTE 10: Service gera alertas severity high pra cSit cancelado/baixa
 });
 
 // ---------------------------------------------------------------------
+// Invariante #11 — Timeout enforcement backend + frontend (anti-hang)
+// ---------------------------------------------------------------------
+
+test('INVARIANTE 11a: Service aplica timeout via $tools->soap->timeout()', function () {
+    $arquivo = $this->base . '/Modules/NfeBrasil/Services/SefazConsultaCadastroService.php';
+    $conteudo = file_get_contents($arquivo);
+
+    // Service chama $tools->soap->timeout(N) ANTES de sefazCadastro.
+    expect($conteudo)->toContain('$tools->soap->timeout(');
+    // Valor lido do config (não hardcoded).
+    expect($conteudo)->toContain("config('fiscal.sefaz_consulta_cadastro_timeout_seconds'");
+});
+
+test('INVARIANTE 11b: config tem timeout_seconds + frontend_timeout_ms', function () {
+    $conf = $this->base . '/config/fiscal.php';
+    $conteudo = file_get_contents($conf);
+
+    expect($conteudo)->toContain('sefaz_consulta_cadastro_timeout_seconds');
+    expect($conteudo)->toContain('sefaz_consulta_cadastro_frontend_timeout_ms');
+});
+
+test('INVARIANTE 11c: frontend handleCnpjLookup usa AbortController + signal nos fetches', function () {
+    $arquivo = $this->base . '/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx';
+    $conteudo = file_get_contents($arquivo);
+
+    // AbortController instanciado.
+    expect($conteudo)->toContain('new AbortController()');
+    // setTimeout cancela após N ms.
+    expect($conteudo)->toMatch('/setTimeout\(\s*\(\s*\)\s*=>\s*\w+\.abort\(\)/');
+    // fetch usa signal.
+    expect($conteudo)->toContain('signal: brasilApiCtrl.signal');
+    expect($conteudo)->toContain('signal: sefazCtrl.signal');
+    // Trata AbortError graceful.
+    expect($conteudo)->toContain("AbortError");
+});
+
+test('INVARIANTE 11d: badge UI tem mensagem específica pra timeout SEFAZ', function () {
+    $arquivo = $this->base . '/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx';
+    $conteudo = file_get_contents($arquivo);
+
+    expect($conteudo)->toContain('sefazTimeoutFlag');
+    // Mensagem do badge contém "demorou" pra orientar usuário.
+    expect($conteudo)->toMatch('/demorou.*tente.*novo|demorou.*preencha/i');
+});
+
+// ---------------------------------------------------------------------
 // Meta-invariante — ADR existe e está marcada IRREVOGÁVEL
 // ---------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Implementa **[ADR 0186](memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md)** — chain de certificado A1 pra SEFAZ ConsultaCadastro no drawer 760 Cliente. Resolve gap "IE não vem automática" (Wagner testou 2026-05-22 → auditoria estado-da-arte 2026-05-23 → escolha caminho 2).
- **Custo recorrente: R$ 0** — reusa cert A1 que cada business já paga pra emitir NFe.
- **Cobertura inicial**: 6 UFs (RS, SP, PR, MG, BA, SC) — Larissa biz=4 (Rota Livre RS) tem IE auto dia 1.
- Cliente novo sem cert ainda → **fallback institucional** cert oimpresso (biz=1) com audit log LGPD-compliant.

## Arquitetura

Chain de 3 camadas em `CertificadoService::carregarParaSefazComFallback`:

| # | Camada | Quando aplica |
|---|---|---|
| 1 | Cert primário business (canon `nfe_certificados`) | Larissa biz=4 com cert NFe ativo (caso típico) |
| 2 | Cert legado `business.certificado` BLOB ([ADR 0090](memory/decisions/0090-cert-legacy-nfe-brasil-coexistence.md)) | Business pré-migration coexistência |
| 3 | **Cert institucional oimpresso** (`config('fiscal.fallback_business_id')`) | Cliente novo sem cert OU cert expirado |
| 4 | RuntimeException → badge UI 'configure cert' | Nem fallback institucional disponível |

**Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)):** camada #3 usa \`withoutGlobalScope(ScopeByBusiness::class)\` INTENCIONAL + audit log em \`mcp_audit_log\` com \`sha256(cnpj)\` (LGPD Art. 6º III minimização). Pest invariante garante única query autorizada a escapar do scope em \`nfe_certificados\`.

## Endpoint novo (Inertia-friendly, substitui legacy)

\`GET /cliente/lookup/cnpj/{cnpj}/sefaz?uf=RS\`
- Throttle 60/min compartilhado com BrasilAPI
- Cache Redis 30d por (cnpj, uf) — compartilhado entre tenants (dado público)
- 200: \`{ie, situacao, nome, uf, fonte, cert_source, cert_business_id}\`
- 404: \`{reason: 'uf_unsupported' | 'sefaz_or_cert_error'}\` → UI badge contextual

Substitui legacy \`NFeService::consultaCadastro\` (\`echo json\` direto, não-Inertia). Refactor da remoção do legacy fica pra PR seguinte (fase 7 do ADR).

## Matriz UFs canônica

\`config/fiscal.php\` lista as 6 UFs com WS SEFAZ ConsultaCadastro2 funcionando em produção (fonte: comunidade nfephp-org + SAP Community). Config-driven — ligar UFs novas no futuro sem deploy.

Outras 21 UFs: badge gracioso 'preencha IE manualmente' (mercado tolera — Bling/Tiny/Omie nem fazem essa busca).

## Frontend — 4 estados de badge ([ADR 0186](memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md) §UI)

\`IdentificacaoTab.handleCnpjLookup\` agora encadeia BrasilAPI baseline → SEFAZ pra IE:
- 🟢 \"IE via SEFAZ-RS (certificado da empresa)\"
- 🟠 \"IE via SEFAZ-RS (certificado oimpresso institucional)\"
- ⚪ \"SEFAZ-XX não disponível, preencha manual\"
- 🔴 \"Configure certificado A1 em /fiscal/config\"

## Test plan

### Automatizado (Pest)
- [x] Endpoint contract: UF supported/unsupported/invalid + auth required
- [x] Config canônica: 6 UFs + fallback_business_id default 1 + cache TTL 30d
- [x] Chain de cert: RuntimeException quando nada disponível + null pra UF não suportada + null pra CNPJ < 14 dígitos + feature flag off
- [x] **Invariante Tier 0**: grep no codebase garante que apenas \`CertificadoService::carregarParaSefazComFallback\` usa \`withoutGlobalScope(ScopeByBusiness::class)\` em \`NfeCertificado\`
- [x] Skip-graceful em sqlite :memory: (CI MySQL roda real)

### Manual em prod (após merge — Wagner)
- [ ] Larissa biz=4 RS: digitar CNPJ de fornecedor RS no drawer → IE auto preenchida + badge 🟢
- [ ] Cliente novo sem cert: digitar CNPJ RS → IE auto via fallback institucional + badge 🟠
- [ ] CNPJ de fornecedor GO: tudo preenchido MENOS IE + badge ⚪
- [ ] Audit log: \`SELECT * FROM mcp_audit_log WHERE event = 'sefaz.cert.fallback_institutional_used'\` mostra entrada com \`sha256\` do CNPJ (nunca plain)

## Custo + esforço

- **R$ 0/mês recorrente** ([ADR 0105](memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — cliente como sinal, sem comprar provider pago agora)
- **5-7h IA-pair** ([ADR 0106](memory/decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md) recalibração)
- Reversível: \`config('fiscal.sefaz_consulta_cadastro_enabled', false)\` desliga tudo

## Diff

\`\`\`
 8 files changed, 937 insertions(+), 3 deletions(-)
 memory/decisions/0186-...md           +213  (ADR canon)
 Modules/NfeBrasil/Services/CertificadoService.php  +109
 Modules/NfeBrasil/Services/SefazConsultaCadastroService.php  +195  (NEW)
 config/fiscal.php  +97  (NEW)
 Modules/Crm/Http/Controllers/ClienteLookupController.php  +65
 Modules/Crm/Routes/web.php  +6
 resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx  +54/-3
 tests/Feature/Cliente/SefazConsultaCadastroChainTest.php  +202  (NEW)
\`\`\`

## Conflito esperado com outros PRs em flight

- **[#1419](https://github.com/wagnerra23/oimpresso.com/pull/1419)** (CNPJ lookup endereço cross-tab) toca \`IdentificacaoTab.tsx\` — vai conflitar. Sugestão: mergea #1419 primeiro (maior valor cliente), depois rebase este.
- **[#1422](https://github.com/wagnerra23/oimpresso.com/pull/1422)** (naming canon + numero BR) não toca arquivos deste PR.

## Refs

- ADR 0186 (este PR — canon)
- ADR 0093 (multi-tenant Tier 0 IRREVOGÁVEL — justifica withoutGlobalScope auditado)
- ADR 0090 (cert legacy coexistence)
- ADR 0179 (drawer 760 Cliente)
- ADR 0105 (cliente como sinal — justifica não comprar provider pago)
- [Sessão estado-da-arte 2026-05-23](memory/sessions/2026-05-23-arte-busca-cliente-cnpj-ie.md)
- [feedback-lookup-cnpj-sobrescreve-dados.md](memory/reference/feedback-lookup-cnpj-sobrescreve-dados.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)