### PR TITLE
feat(paymentgateway): link CNAB 21 bancos no wizard (Opção B)

### DIFF
--- a/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
@@ -180,6 +180,31 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
                 <div className="text-[10px] text-stone-400 italic pt-1">
                   Valores REFERENCE 2026 (sites oficiais + docs públicas) — negociáveis com PSP em volume alto.
                 </div>
+
+                {/* Onda 4e.UI #6 (estado-da-arte 2026-05-23) — pointer pros 21 bancos eduardokum/CNAB.
+                    Backend já funciona via Modules/Financeiro/Strategies/CnabDirectStrategy.
+                    Cadastro vive em /financeiro/contas-bancarias (fluxo legado UPOS validado). */}
+                <a
+                  href="/financeiro/contas-bancarias"
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="w-full text-left rounded-md border border-dashed border-stone-300 p-3 transition flex items-start gap-3 hover:border-stone-500 hover:bg-stone-50"
+                >
+                  <span className="w-9 h-9 rounded-md grid place-items-center text-stone-700 text-[12px] font-bold shrink-0 bg-stone-100 border border-stone-300">BC</span>
+                  <div className="flex-1 min-w-0">
+                    <div className="flex items-center gap-2">
+                      <div className="text-[13px] font-semibold">Boleto bancário tradicional (CNAB)</div>
+                      <span className="text-[9px] uppercase tracking-widest font-bold px-1.5 py-0.5 rounded bg-stone-100 text-stone-600">21 bancos</span>
+                    </div>
+                    <div className="text-[10.5px] text-stone-600 mt-1.5 leading-snug">
+                      BB · Bradesco · Itaú · Sicredi · Sicoob · Cresol · Ailos · Caixa · Santander · Banrisul · BNB · BTG · Fibra · HSBC · Delbank · Rendimento · Pine · Ourinvest · Unicred · Inter · C6
+                    </div>
+                    <div className="text-[10px] text-stone-500 mt-1.5">
+                      Cadastrar via <span className="font-mono">/financeiro/contas-bancarias</span> (CNAB 240/400 · sem webhook real-time · settlement T+1 mín · upload/download arquivo)
+                    </div>
+                  </div>
+                  <ExternalLink className="h-3.5 w-3.5 text-stone-400 self-start mt-1" />
+                </a>
               </div>
             </div>
           )}


### PR DESCRIPTION
Wagner aprovou Opção B (link 30min vs driver wrapper 3-4h). 6º card no step 1 do SheetNovoGateway com pointer pra `/financeiro/contas-bancarias` (fluxo legado CNAB validado via `CnabDirectStrategy` eduardokum). 1 arquivo / ~25 LOC. Sem backend mudança.