### PR TITLE
feat(paymentgateway): highlight bancos API REST no card CNAB (Onda 4e.UI #7)

### DIFF
--- a/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
@@ -199,6 +199,14 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
                     <div className="text-[10.5px] text-stone-600 mt-1.5 leading-snug">
                       BB · Bradesco · Itaú · Sicredi · Sicoob · Cresol · Ailos · Caixa · Santander · Banrisul · BNB · BTG · Fibra · HSBC · Delbank · Rendimento · Pine · Ourinvest · Unicred · Inter · C6
                     </div>
+
+                    {/* Onda 4e.UI #7 — destaque bancos com API REST moderna (futuros drivers nativos PaymentGateway Onda 4f).
+                        Tier S de maturidade Open Finance + Pix Cobrança REST, dados de WebSearch oficial 2026-05-23. */}
+                    <div className="mt-2 bg-amber-50/60 border border-amber-200 rounded px-2 py-1.5 text-[10px] text-amber-900 leading-snug">
+                      <span className="font-medium">Com API REST moderna disponível</span> (drivers nativos backlog Onda 4f):
+                      <div className="font-semibold mt-0.5">Bradesco · Itaú · BB · Sicredi · Sicoob · Santander · Caixa · BTG</div>
+                    </div>
+
                     <div className="text-[10px] text-stone-500 mt-1.5">
                       Cadastrar via <span className="font-mono">/financeiro/contas-bancarias</span> (CNAB 240/400 · sem webhook real-time · settlement T+1 mín · upload/download arquivo)
                     </div>


### PR DESCRIPTION
Sub-bloco amber no card CNAB destaca 8 bancos com API REST madura (Bradesco/Itaú/BB/Sicredi/Sicoob/Santander/Caixa/BTG) — sinaliza roadmap futuro Onda 4f drivers nativos. 1 file / 8 LOC.