### PR TITLE
feat(paymentgateway): HttpClientFactory + retry exponential + 429 handler (Onda 4e gap #1+#2)

### DIFF
--- a/Modules/PaymentGateway/Console/Commands/RetryOrphanWebhookCommand.php
+++ b/Modules/PaymentGateway/Console/Commands/RetryOrphanWebhookCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Console\Commands;
+
+use Illuminate\Console\Command;
+use Modules\PaymentGateway\Jobs\RetryOrphanWebhookJob;
+use Modules\PaymentGateway\Models\GatewayWebhookEvent;
+
+/**
+ * ADR 0170 Onda 4e — Cron entry-point pra RetryOrphanWebhookJob.
+ *
+ * Schedule (app/Console/Kernel.php):
+ *   $schedule->command('paymentgateway:retry-orphan-webhooks')
+ *       ->everyFiveMinutes()
+ *       ->withoutOverlapping(10);
+ *
+ * Race condition coberta: webhook chegou antes da Cobranca ser gravada.
+ * Detalhes na PHPDoc de `RetryOrphanWebhookJob`.
+ *
+ * `--dry-run` lista o que faria sem dispatchar Job (útil pra Wagner inspecionar
+ * antes de cutover prod).
+ */
+class RetryOrphanWebhookCommand extends Command
+{
+    protected $signature = 'paymentgateway:retry-orphan-webhooks
+                            {--dry-run : Mostra o que faria sem dispatchar}';
+
+    protected $description = 'Re-processa gateway_webhook_events órfãos (processed_at NULL após 1h, dentro de 24h)';
+
+    public function handle(): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        if ($dryRun) {
+            $this->warn('[dry-run] Nenhum CobrancaPaga será dispatchado.');
+
+            $orphans = GatewayWebhookEvent::query()
+                ->withoutGlobalScopes()
+                ->whereNull('processed_at')
+                ->where('created_at', '>', now()->subDay())
+                ->where('created_at', '<', now()->subHour())
+                ->orderBy('created_at')
+                ->limit(50)
+                ->get();
+
+            $this->line(sprintf('%d órfão(s) na janela 1h..24h.', $orphans->count()));
+
+            foreach ($orphans as $orphan) {
+                $this->line(sprintf(
+                    '  #%d biz=%d gateway=%s evento=%s cobranca_id=%s created_at=%s',
+                    $orphan->id,
+                    $orphan->business_id,
+                    $orphan->gateway_key,
+                    $orphan->evento,
+                    $orphan->cobranca_id ?? 'NULL',
+                    $orphan->created_at->toIso8601String(),
+                ));
+            }
+
+            return self::SUCCESS;
+        }
+
+        // Dispatch Job na queue paymentgateway (mesma queue do ProcessarWebhookPixInterJob).
+        // RetryOrphanWebhookJob::dispatch() em vez de inline pra não bloquear cron tick.
+        RetryOrphanWebhookJob::dispatch();
+        $this->info('RetryOrphanWebhookJob dispatched (queue=paymentgateway).');
+
+        return self::SUCCESS;
+    }
+}

--- a/Modules/PaymentGateway/Jobs/RetryOrphanWebhookJob.php
+++ b/Modules/PaymentGateway/Jobs/RetryOrphanWebhookJob.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Log;
+use Modules\PaymentGateway\Events\CobrancaPaga;
+use Modules\PaymentGateway\Models\Cobranca;
+use Modules\PaymentGateway\Models\GatewayWebhookEvent;
+
+/**
+ * ADR 0170 Onda 4e — Retry scheduled de webhook órfão.
+ *
+ * Race condition coberta: WebhookProcessor persiste em gateway_webhook_events
+ * (idempotência at-DB) + retorna 200, MAS o dispatch real do CobrancaPaga
+ * acontece em outro fluxo. Se o webhook chega ANTES da Cobranca ser gravada
+ * (emissão ainda em curso), o event row fica com `processed_at IS NULL` +
+ * `cobranca_id NULL` ou apontando pra nada — orphan.
+ *
+ * Estratégia:
+ *   - Janela: created_at > now()-24h (mais antigo é tarde demais — Wagner reconcilia)
+ *   - Espera mínima: created_at < now()-1h (dá tempo do fluxo original gravar Cobranca)
+ *   - Ordem cronológica + limit 50 por run (evita run lento travar próximo tick 5min)
+ *
+ * Per evento órfão:
+ *   1. Se `cobranca_id` NOT NULL E Cobranca exists → re-dispatch evento canônico
+ *      (CobrancaPaga só se evento matches paid/received/confirmed regex conservador)
+ *      → marca processed_at + error_message=null + log info `orphan_replayed`
+ *   2. Se `cobranca_id` NULL OU Cobranca não encontrada → log warn `still_orphan`,
+ *      processed_at PERMANECE NULL pra próximo run tentar até cutoff 24h
+ *   3. Se evento NÃO matches mapping conservador (ex: cob.created/error genérico) →
+ *      log warn + marca processed_at sem dispatch (Wagner reconcilia manual)
+ *
+ * Multi-tenant Tier 0 (ADR 0093): Job roda em background SEM sessão →
+ * `withoutGlobalScopes()` consciente + log explícito do business_id por evento.
+ *
+ * Mapping conservador event_type → CobrancaPaga (MVP):
+ *   /paid/i, /received/i, /confirmed/i, /payment_received/i, /cob\.paid/i
+ *
+ * NÃO dispatcha CobrancaErro automaticamente — risk de side-effects em
+ * listeners ainda não-idempotentes. Wagner manualmente reconcilia errors via
+ * inspeção do gateway_webhook_events.payload.
+ *
+ * Idempotência: re-rodar mesmo evento já processed_at != NULL → query exclui
+ * automaticamente. Listener CobrancaPaga (OnCobrancaPagaCreateFinanceiroTitulo
+ * Onda 5) deve ser idempotente — se não, dispatch 2x cria 2 Titulos. Risco
+ * catalogado no return-report.
+ *
+ * Custo: zero LLM, zero HTTP externo. Pure SQL + dispatch interno → latência
+ * ~10-50ms por evento × 50 max = ~2.5s worst case.
+ */
+class RetryOrphanWebhookJob implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    /**
+     * Padrões de evento que mapeiam pra CobrancaPaga (regex case-insensitive).
+     *
+     * Conservador propositalmente: prefere "deixa órfão pra Wagner ver"
+     * a "dispatcha falso-positivo que cria Titulo errado".
+     */
+    private const PAID_EVENT_PATTERNS = [
+        '/paid/i',
+        '/received/i',
+        '/confirmed/i',
+        '/payment_received/i',
+        '/cob\.paid/i',
+        '/pix_recebido/i',
+    ];
+
+    public int $tries = 1; // cron re-roda em 5min — sem ponto fazer retry exponential interno
+
+    public int $timeout = 120; // 2min cap (cron everyFiveMinutes com withoutOverlapping 10min)
+
+    public function __construct()
+    {
+        // $queue é property do trait Queueable — atribuímos no constructor
+        // pra evitar conflito de redeclaração de property (PHP 8.4 strict).
+        $this->onQueue('paymentgateway');
+    }
+
+    public function handle(): void
+    {
+        // Janela: órfãos entre 1h e 24h (espera fluxo original + cutoff manual)
+        $orphans = GatewayWebhookEvent::query()
+            ->withoutGlobalScopes() // Job sem sessão — ADR 0093 explicit
+            ->whereNull('processed_at')
+            ->where('created_at', '>', now()->subDay())
+            ->where('created_at', '<', now()->subHour())
+            ->orderBy('created_at')
+            ->limit(50)
+            ->get();
+
+        if ($orphans->isEmpty()) {
+            Log::info('paymentgateway.webhook.orphan_scan', [
+                'found' => 0,
+                'window' => '1h..24h',
+            ]);
+
+            return;
+        }
+
+        $replayed = 0;
+        $stillOrphan = 0;
+        $markedNoDispatch = 0;
+
+        foreach ($orphans as $orphan) {
+            $this->processOrphan($orphan, $replayed, $stillOrphan, $markedNoDispatch);
+        }
+
+        Log::info('paymentgateway.webhook.orphan_scan', [
+            'found' => $orphans->count(),
+            'replayed' => $replayed,
+            'still_orphan' => $stillOrphan,
+            'marked_no_dispatch' => $markedNoDispatch,
+            'window' => '1h..24h',
+        ]);
+    }
+
+    private function processOrphan(
+        GatewayWebhookEvent $orphan,
+        int &$replayed,
+        int &$stillOrphan,
+        int &$markedNoDispatch,
+    ): void {
+        $businessId = (int) $orphan->business_id;
+        $evento = (string) $orphan->evento;
+
+        // Caso 1: ainda sem cobranca_id ou cobranca não encontrada
+        if (! $orphan->cobranca_id) {
+            $this->logStillOrphan($orphan, $businessId, 'cobranca_id_null');
+            $stillOrphan++;
+
+            return;
+        }
+
+        $cobranca = Cobranca::withoutGlobalScopes()
+            ->where('id', $orphan->cobranca_id)
+            ->where('business_id', $businessId)
+            ->first();
+
+        if (! $cobranca) {
+            $this->logStillOrphan($orphan, $businessId, 'cobranca_not_found');
+            $stillOrphan++;
+
+            return;
+        }
+
+        // Caso 2: evento NÃO matches mapping conservador → marca processed_at sem dispatch
+        if (! $this->isPaidEvent($evento)) {
+            $orphan->update([
+                'processed_at' => now(),
+                'error_message' => 'orphan_event_not_mapped_to_dispatch: ' . substr($evento, 0, 100),
+            ]);
+            Log::warning('paymentgateway.webhook.orphan_marked_no_dispatch', [
+                'webhook_row_id' => $orphan->id,
+                'business_id' => $businessId,
+                'gateway_key' => $orphan->gateway_key,
+                'evento' => $evento,
+                'cobranca_id' => $cobranca->id,
+                'reason' => 'event_type_not_in_paid_patterns',
+            ]);
+            $markedNoDispatch++;
+
+            return;
+        }
+
+        // Caso 3: dispatch CobrancaPaga + marca processed
+        $this->replay($orphan, $cobranca, $businessId);
+        $replayed++;
+    }
+
+    private function replay(
+        GatewayWebhookEvent $orphan,
+        Cobranca $cobranca,
+        int $businessId,
+    ): void {
+        $pagaEm = $cobranca->paga_em
+            ? \DateTimeImmutable::createFromMutable($cobranca->paga_em->toDateTime())
+            : new \DateTimeImmutable();
+
+        $valorPagoCentavos = $cobranca->valor_pago_centavos ?? $cobranca->valor_centavos ?? 0;
+
+        event(new CobrancaPaga(
+            cobrancaId: (int) $cobranca->id,
+            businessId: (int) $cobranca->business_id,
+            valorPagoCentavos: (int) $valorPagoCentavos,
+            pagaEm: $pagaEm,
+            formaPagamento: (string) ($cobranca->forma_pagamento ?? 'pix'),
+            occurredAt: new \DateTimeImmutable(),
+            payerCpfCnpj: $cobranca->payer_cpf_cnpj,
+            origemType: $cobranca->origem_type,
+            origemId: $cobranca->origem_id,
+        ));
+
+        $orphan->update([
+            'processed_at' => now(),
+            'error_message' => null,
+        ]);
+
+        Log::info('paymentgateway.webhook.orphan_replayed', [
+            'webhook_row_id' => $orphan->id,
+            'business_id' => $businessId,
+            'gateway_key' => $orphan->gateway_key,
+            'evento' => $orphan->evento,
+            'cobranca_id' => $cobranca->id,
+            'replay_delay_minutes' => (int) now()->diffInMinutes($orphan->created_at),
+        ]);
+    }
+
+    private function logStillOrphan(
+        GatewayWebhookEvent $orphan,
+        int $businessId,
+        string $reason,
+    ): void {
+        // NÃO altera processed_at — próximo run tenta de novo até cutoff 24h
+        $orphan->update([
+            'error_message' => 'still_orphan: ' . $reason,
+        ]);
+
+        Log::warning('paymentgateway.webhook.still_orphan', [
+            'webhook_row_id' => $orphan->id,
+            'business_id' => $businessId,
+            'gateway_key' => $orphan->gateway_key,
+            'evento' => $orphan->evento,
+            'reason' => $reason,
+            'age_minutes' => (int) now()->diffInMinutes($orphan->created_at),
+        ]);
+    }
+
+    private function isPaidEvent(string $evento): bool
+    {
+        foreach (self::PAID_EVENT_PATTERNS as $pattern) {
+            if (preg_match($pattern, $evento) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/Modules/PaymentGateway/Providers/PaymentGatewayServiceProvider.php
+++ b/Modules/PaymentGateway/Providers/PaymentGatewayServiceProvider.php
@@ -31,6 +31,7 @@ class PaymentGatewayServiceProvider extends ServiceProvider
                 \Modules\PaymentGateway\Console\Commands\MigrateCredentialsCommand::class,
                 \Modules\PaymentGateway\Console\Commands\RegisterPermissionsCommand::class,
                 \Modules\PaymentGateway\Console\Commands\EmitTrialExpiredCobrancasCommand::class,
+                \Modules\PaymentGateway\Console\Commands\RetryOrphanWebhookCommand::class,
             ]);
         }
     }

--- a/Modules/PaymentGateway/Services/Drivers/AsaasDriver.php
+++ b/Modules/PaymentGateway/Services/Drivers/AsaasDriver.php
@@ -6,7 +6,6 @@ namespace Modules\PaymentGateway\Services\Drivers;
 
 use Carbon\Carbon;
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
 use Modules\PaymentGateway\Contracts\PaymentDriverContract;
 use Modules\PaymentGateway\Dto\CardToken;
 use Modules\PaymentGateway\Dto\CobrancaEmitidaResult;
@@ -19,6 +18,7 @@ use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
 use Modules\PaymentGateway\Exceptions\GatewayUnavailableException;
 use Modules\PaymentGateway\Exceptions\InvalidPayerException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+use Modules\PaymentGateway\Services\HttpClientFactory;
 
 /**
  * Driver Asaas — API REST v3.
@@ -75,7 +75,7 @@ class AsaasDriver implements PaymentDriverContract
 
         $customerId = $this->resolveCustomer($input, $cred);
 
-        $response = $this->client($cred)
+        $response = HttpClientFactory::send(fn () => $this->client($cred)
             ->post('/payments', [
                 'customer'           => $customerId,
                 'billingType'        => 'CREDIT_CARD',
@@ -90,7 +90,7 @@ class AsaasDriver implements PaymentDriverContract
                     'expiryYear'  => $token->expYear,
                 ],
                 'creditCardToken' => $token->token,
-            ]);
+            ]));
 
         if ($response->status() === 400) {
             throw new CardDeclinedException(
@@ -122,7 +122,7 @@ class AsaasDriver implements PaymentDriverContract
             throw new InvalidPayerException('Cobranca sem gateway_external_id pra cancelar no Asaas');
         }
 
-        $response = $this->client($cred)->delete("/payments/{$extId}");
+        $response = HttpClientFactory::send(fn () => $this->client($cred)->delete("/payments/{$extId}"));
         if ($response->failed()) {
             throw new GatewayUnavailableException(
                 "Asaas cancelar falhou ({$response->status()}): " . substr($response->body(), 0, 200)
@@ -143,7 +143,7 @@ class AsaasDriver implements PaymentDriverContract
             $payload['value'] = round($valorCentavos / 100, 2);
         }
 
-        $response = $this->client($cred)->post("/payments/{$extId}/refund", $payload);
+        $response = HttpClientFactory::send(fn () => $this->client($cred)->post("/payments/{$extId}/refund", $payload));
         if ($response->failed()) {
             throw new GatewayUnavailableException(
                 "Asaas refund falhou ({$response->status()}): " . substr($response->body(), 0, 200)
@@ -159,7 +159,7 @@ class AsaasDriver implements PaymentDriverContract
             throw new InvalidPayerException('Cobranca sem gateway_external_id pra consultar no Asaas');
         }
 
-        $response = $this->client($cred)->get("/payments/{$extId}");
+        $response = HttpClientFactory::send(fn () => $this->client($cred)->get("/payments/{$extId}"));
         if ($response->failed()) {
             throw new GatewayUnavailableException(
                 "Asaas consultar falhou ({$response->status()}): " . substr($response->body(), 0, 200)
@@ -183,7 +183,7 @@ class AsaasDriver implements PaymentDriverContract
         $start = microtime(true);
 
         try {
-            $response = $this->client($cred)->get('/finance/balance');
+            $response = $this->clientHealth($cred)->get('/finance/balance');
             $latencyMs = (int) round((microtime(true) - $start) * 1000);
 
             if ($response->successful()) {
@@ -234,7 +234,7 @@ class AsaasDriver implements PaymentDriverContract
         $this->assertCredential($cred);
         $customerId = $this->resolveCustomer($input, $cred);
 
-        $response = $this->client($cred)
+        $response = HttpClientFactory::send(fn () => $this->client($cred)
             ->post('/payments', [
                 'customer'           => $customerId,
                 'billingType'        => $billingType, // BOLETO | PIX
@@ -243,7 +243,7 @@ class AsaasDriver implements PaymentDriverContract
                 'description'        => $input->descricao,
                 'externalReference'  => $input->idempotencyKey,
                 'postalService'      => false,
-            ]);
+            ]));
 
         if ($response->failed()) {
             throw new GatewayUnavailableException(
@@ -265,7 +265,7 @@ class AsaasDriver implements PaymentDriverContract
         $pixEmv = null;
 
         if ($billingType === 'BOLETO') {
-            $bankSlip = $this->client($cred)->get("/payments/{$id}/identificationField");
+            $bankSlip = HttpClientFactory::send(fn () => $this->client($cred)->get("/payments/{$id}/identificationField"));
             if ($bankSlip->successful()) {
                 $bs = $bankSlip->json() ?? [];
                 $linhaDigitavel = (string) ($bs['identificationField'] ?? '');
@@ -275,7 +275,7 @@ class AsaasDriver implements PaymentDriverContract
         }
 
         if ($billingType === 'PIX') {
-            $pixData = $this->client($cred)->get("/payments/{$id}/pixQrCode");
+            $pixData = HttpClientFactory::send(fn () => $this->client($cred)->get("/payments/{$id}/pixQrCode"));
             if ($pixData->successful()) {
                 $pd = $pixData->json() ?? [];
                 $pixEmv = (string) ($pd['payload'] ?? '');
@@ -306,7 +306,7 @@ class AsaasDriver implements PaymentDriverContract
         $email = $input->meta['payer_email'] ?? null;
 
         // Procura por externalReference primeiro
-        $existing = $this->client($cred)->get('/customers', ['externalReference' => $externalRef]);
+        $existing = HttpClientFactory::send(fn () => $this->client($cred)->get('/customers', ['externalReference' => $externalRef]));
         if ($existing->successful()) {
             $data = $existing->json() ?? [];
             if (! empty($data['data'][0]['id'])) {
@@ -315,12 +315,12 @@ class AsaasDriver implements PaymentDriverContract
         }
 
         // Cria novo
-        $created = $this->client($cred)->post('/customers', array_filter([
+        $created = HttpClientFactory::send(fn () => $this->client($cred)->post('/customers', array_filter([
             'name'              => $name,
             'cpfCnpj'           => $cpfCnpj,
             'email'             => $email,
             'externalReference' => $externalRef,
-        ]));
+        ])));
 
         if ($created->failed()) {
             throw new InvalidPayerException(
@@ -360,18 +360,40 @@ class AsaasDriver implements PaymentDriverContract
             : self::API_BASE_PRODUCTION;
     }
 
+    /**
+     * Cliente principal — com retry + 429 handler via HttpClientFactory
+     * (Auditoria 2026-05-23 Onda 4e gap #1+#2).
+     */
     private function client(PaymentGatewayCredential $cred): PendingRequest
     {
         $config = $cred->config_json ?? [];
 
-        return Http::baseUrl($this->baseUrl($cred))
-            ->withHeaders([
+        return HttpClientFactory::make(
+            baseUrl: $this->baseUrl($cred),
+            headers: [
                 'access_token' => (string) ($config['api_key'] ?? ''),
                 'Accept'       => 'application/json',
-            ])
-            ->acceptJson()
-            ->asJson()
-            ->timeout(30);
+            ],
+            timeoutSec: 30,
+        );
+    }
+
+    /**
+     * Cliente healthcheck — SEM retry (1 fail = down).
+     */
+    private function clientHealth(PaymentGatewayCredential $cred): PendingRequest
+    {
+        $config = $cred->config_json ?? [];
+
+        return HttpClientFactory::make(
+            baseUrl: $this->baseUrl($cred),
+            headers: [
+                'access_token' => (string) ($config['api_key'] ?? ''),
+                'Accept'       => 'application/json',
+            ],
+            timeoutSec: 30,
+            withRetry: false,
+        );
     }
 
     private function mapStatus(string $asaasStatus): string

--- a/Modules/PaymentGateway/Services/Drivers/BcbPixDriver.php
+++ b/Modules/PaymentGateway/Services/Drivers/BcbPixDriver.php
@@ -8,6 +8,7 @@ use Carbon\Carbon;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Http;
 use Modules\PaymentGateway\Contracts\PaymentDriverContract;
+use Modules\PaymentGateway\Services\HttpClientFactory;
 use Modules\PaymentGateway\Dto\CardToken;
 use Modules\PaymentGateway\Dto\CobrancaEmitidaResult;
 use Modules\PaymentGateway\Dto\CobrancaStatus;
@@ -121,8 +122,8 @@ class BcbPixDriver implements PaymentDriverContract
             ],
         ];
 
-        $response = $this->client($cred)
-            ->put("/v2/rec/{$input->idempotencyKey}", $payload);
+        $response = HttpClientFactory::send(fn () => $this->client($cred)
+            ->put("/v2/rec/{$input->idempotencyKey}", $payload));
 
         if ($response->failed()) {
             throw new GatewayUnavailableException(
@@ -159,8 +160,8 @@ class BcbPixDriver implements PaymentDriverContract
             throw new InvalidPayerException('Cobranca sem gateway_external_id pra revogar mandato BcbPix');
         }
 
-        $response = $this->client($cred)
-            ->delete("/v2/rec/{$idRec}", ['motivo' => substr($motivo, 0, 140)]);
+        $response = HttpClientFactory::send(fn () => $this->client($cred)
+            ->delete("/v2/rec/{$idRec}", ['motivo' => substr($motivo, 0, 140)]));
 
         if ($response->failed()) {
             throw new GatewayUnavailableException(
@@ -185,7 +186,7 @@ class BcbPixDriver implements PaymentDriverContract
             throw new InvalidPayerException('Cobranca sem gateway_external_id pra consultar mandato BcbPix');
         }
 
-        $response = $this->client($cred)->get("/v2/rec/{$idRec}");
+        $response = HttpClientFactory::send(fn () => $this->client($cred)->get("/v2/rec/{$idRec}"));
         if ($response->failed()) {
             throw new GatewayUnavailableException(
                 "BcbPix consultar falhou ({$response->status()}): " . substr($response->body(), 0, 200)
@@ -299,13 +300,16 @@ class BcbPixDriver implements PaymentDriverContract
         return rtrim((string) ($cred->config_json['base_url'] ?? ''), '/');
     }
 
+    /**
+     * Cliente principal — com retry + 429 handler via HttpClientFactory
+     * (Auditoria 2026-05-23 Onda 4e gap #1+#2).
+     */
     private function client(PaymentGatewayCredential $cred): PendingRequest
     {
-        return Http::baseUrl($this->baseUrl($cred))
-            ->withToken($this->getAccessToken($cred))
-            ->acceptJson()
-            ->asJson()
-            ->timeout(30);
+        return HttpClientFactory::make(
+            baseUrl: $this->baseUrl($cred),
+            timeoutSec: 30,
+        )->withToken($this->getAccessToken($cred));
     }
 
     private function getAccessToken(PaymentGatewayCredential $cred): string

--- a/Modules/PaymentGateway/Services/Drivers/C6Driver.php
+++ b/Modules/PaymentGateway/Services/Drivers/C6Driver.php
@@ -18,6 +18,7 @@ use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
 use Modules\PaymentGateway\Exceptions\GatewayUnavailableException;
 use Modules\PaymentGateway\Exceptions\InvalidPayerException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+use Modules\PaymentGateway\Services\HttpClientFactory;
 
 /**
  * Driver C6 Bank — Open Banking C6 API.
@@ -64,8 +65,8 @@ class C6Driver implements PaymentDriverContract
     {
         $this->assertCredential($cred);
 
-        $response = $this->client($cred)
-            ->post('/cobrancas', $this->buildBoletoPayload($input));
+        $response = HttpClientFactory::send(fn () => $this->client($cred)
+            ->post('/cobrancas', $this->buildBoletoPayload($input)));
 
         if ($response->failed()) {
             throw new GatewayUnavailableException(
@@ -98,8 +99,8 @@ class C6Driver implements PaymentDriverContract
         }
         $this->assertCredential($cred);
 
-        $response = $this->client($cred)
-            ->post('/pix/cobrancas', $this->buildPixPayload($input));
+        $response = HttpClientFactory::send(fn () => $this->client($cred)
+            ->post('/pix/cobrancas', $this->buildPixPayload($input)));
 
         if ($response->failed()) {
             throw new GatewayUnavailableException(
@@ -145,8 +146,8 @@ class C6Driver implements PaymentDriverContract
             throw new InvalidPayerException('Cobranca sem gateway_external_id pra cancelar no C6');
         }
 
-        $response = $this->client($cred)
-            ->delete("/cobrancas/{$extId}", ['motivo' => $motivo]);
+        $response = HttpClientFactory::send(fn () => $this->client($cred)
+            ->delete("/cobrancas/{$extId}", ['motivo' => $motivo]));
 
         if ($response->failed()) {
             throw new GatewayUnavailableException(
@@ -170,7 +171,7 @@ class C6Driver implements PaymentDriverContract
             throw new InvalidPayerException('Cobranca sem gateway_external_id pra consultar no C6');
         }
 
-        $response = $this->client($cred)->get("/cobrancas/{$extId}");
+        $response = HttpClientFactory::send(fn () => $this->client($cred)->get("/cobrancas/{$extId}"));
         if ($response->failed()) {
             throw new GatewayUnavailableException(
                 "C6 consultar falhou ({$response->status()}): " . substr($response->body(), 0, 200)
@@ -274,13 +275,16 @@ class C6Driver implements PaymentDriverContract
             : self::API_BASE_PRODUCTION;
     }
 
+    /**
+     * Cliente principal — com retry + 429 handler via HttpClientFactory
+     * (Auditoria 2026-05-23 Onda 4e gap #1+#2).
+     */
     private function client(PaymentGatewayCredential $cred): PendingRequest
     {
-        return Http::baseUrl($this->baseUrl($cred))
-            ->withToken($this->getAccessToken($cred))
-            ->acceptJson()
-            ->asJson()
-            ->timeout(30);
+        return HttpClientFactory::make(
+            baseUrl: $this->baseUrl($cred),
+            timeoutSec: 30,
+        )->withToken($this->getAccessToken($cred));
     }
 
     private function getAccessToken(PaymentGatewayCredential $cred): string

--- a/Modules/PaymentGateway/Services/Drivers/InterDriver.php
+++ b/Modules/PaymentGateway/Services/Drivers/InterDriver.php
@@ -18,6 +18,7 @@ use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
 use Modules\PaymentGateway\Exceptions\GatewayUnavailableException;
 use Modules\PaymentGateway\Exceptions\InvalidPayerException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+use Modules\PaymentGateway\Services\HttpClientFactory;
 
 /**
  * Driver Banco Inter — API Cobrança v3 (OAuth2 + mTLS em prod).
@@ -60,8 +61,8 @@ class InterDriver implements PaymentDriverContract
 
         $payload = $this->buildEmitirBoletoPayload($input, $config);
 
-        $response = $this->client($cred)
-            ->post('/cobranca/v3/cobrancas', $payload);
+        $response = HttpClientFactory::send(fn () => $this->client($cred)
+            ->post('/cobranca/v3/cobrancas', $payload));
 
         if ($response->failed()) {
             throw new GatewayUnavailableException(
@@ -134,7 +135,7 @@ class InterDriver implements PaymentDriverContract
         }
 
         $endpoint = "/pix/v2/{$tipo}/{$input->idempotencyKey}";
-        $response = $this->client($cred)->put($endpoint, $payload);
+        $response = HttpClientFactory::send(fn () => $this->client($cred)->put($endpoint, $payload));
 
         if ($response->failed()) {
             throw new GatewayUnavailableException(
@@ -180,10 +181,10 @@ class InterDriver implements PaymentDriverContract
             throw new InvalidPayerException('Cobranca sem gateway_external_id pra cancelar no Inter');
         }
 
-        $response = $this->client($cred)
+        $response = HttpClientFactory::send(fn () => $this->client($cred)
             ->post("/cobranca/v3/cobrancas/{$nossoNumero}/cancelar", [
                 'motivoCancelamento' => $this->mapMotivoCancelar($motivo),
-            ]);
+            ]));
 
         if ($response->failed()) {
             throw new GatewayUnavailableException(
@@ -233,8 +234,8 @@ class InterDriver implements PaymentDriverContract
             $payload['descricao'] = substr($motivo, 0, 140);
         }
 
-        $response = $this->client($cred)
-            ->put("/pix/v2/cob/{$extId}/devolucao/{$idDevolucao}", $payload);
+        $response = HttpClientFactory::send(fn () => $this->client($cred)
+            ->put("/pix/v2/cob/{$extId}/devolucao/{$idDevolucao}", $payload));
 
         if ($response->failed()) {
             throw new GatewayUnavailableException(
@@ -251,8 +252,8 @@ class InterDriver implements PaymentDriverContract
             throw new InvalidPayerException('Cobranca sem gateway_external_id pra consultar no Inter');
         }
 
-        $response = $this->client($cred)
-            ->get("/cobranca/v3/cobrancas/{$nossoNumero}");
+        $response = HttpClientFactory::send(fn () => $this->client($cred)
+            ->get("/cobranca/v3/cobrancas/{$nossoNumero}"));
 
         if ($response->failed()) {
             throw new GatewayUnavailableException(
@@ -374,16 +375,20 @@ class InterDriver implements PaymentDriverContract
             : self::API_BASE_PRODUCTION;
     }
 
+    /**
+     * Cliente principal — com retry + 429 handler via HttpClientFactory
+     * (Auditoria 2026-05-23 Onda 4e gap #1+#2). mTLS preservado via withOptions.
+     */
     private function client(PaymentGatewayCredential $cred): PendingRequest
     {
         $config = $this->config($cred);
 
-        return Http::baseUrl($this->baseUrl($cred))
+        return HttpClientFactory::make(
+            baseUrl: $this->baseUrl($cred),
+            timeoutSec: 30,
+        )
             ->withToken($this->getAccessToken($cred))
-            ->withOptions($this->mtlsOptions($config))
-            ->acceptJson()
-            ->asJson()
-            ->timeout(30);
+            ->withOptions($this->mtlsOptions($config));
     }
 
     /**

--- a/Modules/PaymentGateway/Services/Drivers/PagarmeDriver.php
+++ b/Modules/PaymentGateway/Services/Drivers/PagarmeDriver.php
@@ -6,7 +6,6 @@ namespace Modules\PaymentGateway\Services\Drivers;
 
 use Carbon\Carbon;
 use Illuminate\Http\Client\PendingRequest;
-use Illuminate\Support\Facades\Http;
 use Modules\PaymentGateway\Contracts\PaymentDriverContract;
 use Modules\PaymentGateway\Dto\CardToken;
 use Modules\PaymentGateway\Dto\CobrancaEmitidaResult;
@@ -19,6 +18,7 @@ use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
 use Modules\PaymentGateway\Exceptions\GatewayUnavailableException;
 use Modules\PaymentGateway\Exceptions\InvalidPayerException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+use Modules\PaymentGateway\Services\HttpClientFactory;
 
 /**
  * Driver Pagar.me — API v5 (Stone group).
@@ -137,7 +137,7 @@ class PagarmeDriver implements PaymentDriverContract
             ],
         ]);
 
-        $response = $this->client($cred)->post('/orders', $payload);
+        $response = HttpClientFactory::send(fn () => $this->client($cred)->post('/orders', $payload));
 
         // Pagar.me v5: 400 = invalid_request (cartão recusado vem como
         // status='failed' na charge dentro de 200 OK também). Tratamos ambos.
@@ -186,7 +186,7 @@ class PagarmeDriver implements PaymentDriverContract
         }
 
         // DELETE /charges/{id} sem amount = cancela total
-        $response = $this->client($cred)->delete("/charges/{$extId}");
+        $response = HttpClientFactory::send(fn () => $this->client($cred)->delete("/charges/{$extId}"));
 
         if ($response->failed()) {
             throw new GatewayUnavailableException(
@@ -209,9 +209,9 @@ class PagarmeDriver implements PaymentDriverContract
             $payload['amount'] = $valorCentavos; // Pagar.me usa centavos como int
         }
 
-        $response = $this->client($cred)
+        $response = HttpClientFactory::send(fn () => $this->client($cred)
             ->withBody(json_encode($payload, JSON_UNESCAPED_UNICODE), 'application/json')
-            ->delete("/charges/{$extId}");
+            ->delete("/charges/{$extId}"));
 
         if ($response->failed()) {
             throw new GatewayUnavailableException(
@@ -228,7 +228,7 @@ class PagarmeDriver implements PaymentDriverContract
             throw new InvalidPayerException('Cobranca sem gateway_external_id pra consultar no Pagar.me');
         }
 
-        $response = $this->client($cred)->get("/charges/{$extId}");
+        $response = HttpClientFactory::send(fn () => $this->client($cred)->get("/charges/{$extId}"));
         if ($response->failed()) {
             throw new GatewayUnavailableException(
                 "Pagar.me consultar falhou ({$response->status()}): " . substr($response->body(), 0, 200)
@@ -253,7 +253,8 @@ class PagarmeDriver implements PaymentDriverContract
 
         try {
             // GET /balance é o ping canônico (endpoint barato, exige auth válida)
-            $response = $this->client($cred)->get('/balance');
+            // Usa clientHealth (sem retry) — 1 fail = down do dashboard
+            $response = $this->clientHealth($cred)->get('/balance');
             $latencyMs = (int) round((microtime(true) - $start) * 1000);
 
             if ($response->successful()) {
@@ -344,7 +345,7 @@ class PagarmeDriver implements PaymentDriverContract
         };
 
         $payload = $this->buildOrderPayload($input, [$paymentBlock]);
-        $response = $this->client($cred)->post('/orders', $payload);
+        $response = HttpClientFactory::send(fn () => $this->client($cred)->post('/orders', $payload));
 
         if ($response->failed()) {
             throw new GatewayUnavailableException(
@@ -453,15 +454,32 @@ class PagarmeDriver implements PaymentDriverContract
         }
     }
 
+    /**
+     * Cliente principal — com retry + 429 handler via HttpClientFactory
+     * (Auditoria 2026-05-23 Onda 4e gap #1+#2).
+     */
     private function client(PaymentGatewayCredential $cred): PendingRequest
     {
         $secret = (string) ($cred->config_json['secret_key'] ?? '');
 
-        return Http::baseUrl(self::API_BASE)
-            ->withBasicAuth($secret, '')
-            ->acceptJson()
-            ->asJson()
-            ->timeout(30);
+        return HttpClientFactory::make(
+            baseUrl: self::API_BASE,
+            timeoutSec: 30,
+        )->withBasicAuth($secret, '');
+    }
+
+    /**
+     * Cliente healthcheck — SEM retry (1 fail = down).
+     */
+    private function clientHealth(PaymentGatewayCredential $cred): PendingRequest
+    {
+        $secret = (string) ($cred->config_json['secret_key'] ?? '');
+
+        return HttpClientFactory::make(
+            baseUrl: self::API_BASE,
+            timeoutSec: 30,
+            withRetry: false,
+        )->withBasicAuth($secret, '');
     }
 
     /**

--- a/Modules/PaymentGateway/Services/HttpClientFactory.php
+++ b/Modules/PaymentGateway/Services/HttpClientFactory.php
@@ -1,0 +1,288 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Services;
+
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * Fábrica centralizada de PendingRequest pros drivers PaymentGateway.
+ *
+ * Onda 4e — Auditoria 2026-05-23 catalogou que os 5 drivers (Asaas, BcbPix,
+ * C6, Inter, Pagar.me) usam Http::baseUrl(...)->timeout(30) puro, sem `retry()`
+ * nem handler de rate-limit 429. Resultado: 502 transitório de banco quebra
+ * cobrança no relógio, sem nenhuma chance de recuperação automática.
+ *
+ * Esta fábrica resolve isso aplicando:
+ *
+ *  1. **Retry com 3 tentativas + sleep base 200ms** — implementado via
+ *     `Http::retry()` Laravel 13 com callback custom que sabe distinguir
+ *     ConnectionException + RequestException retryável (status 502/503/504/429).
+ *
+ *  2. **`throw: false`** no `retry()` — drivers continuam fazendo
+ *     `$response->failed()` check próprio + joguem GatewayUnavailableException
+ *     com mensagem específica. Preserva contrato dos drivers existentes.
+ *
+ *  3. **`throwIf(callable)`** com condição retryable status — força Laravel
+ *     a jogar RequestException SÓ pra status que valem retry, fazendo o
+ *     callback de retry ser invocado. Para 4xx não-retryável (400/401/422),
+ *     callable retorna false → Response retorna sem throw → drivers checam
+ *     `->failed()` normalmente.
+ *
+ *  4. **Sleep manual via `usleep`/`sleep`** no callback de retry quando
+ *     status = 429 — respeita header `Retry-After` (RFC 9110 §10.2.3,
+ *     formato segundos OU HTTP-date). Default 1s se ausente. Cap em 30s
+ *     pra não travar worker queue (RecurringBilling job timeout 300s).
+ *
+ *  5. **Wrapper `send(Closure)`** — depois de esgotar retries em status
+ *     retryável, Laravel ainda throw RequestException (engatilhado pelo
+ *     throwIf na última tentativa). O método estático `send()` captura
+ *     essa exception e devolve `$e->response`, preservando DX dos drivers
+ *     que esperam sempre receber Response (nunca tratar exception
+ *     RequestException direta).
+ *
+ * **Decisões catalogadas:**
+ *
+ *  - **Cap 30s no Retry-After**: alguns bancos podem mandar Retry-After: 3600
+ *    (1h) em rate-limit duro. Não queremos travar worker queue por isso.
+ *    Pior caso a cobrança vai pra retry job via JobsRunner (RecurringBilling).
+ *
+ *  - **3 tentativas não 5**: 3 × 30s pior caso = 90s. APIs bancárias 5xx
+ *    transitórios raramente resolvem além da 3ª tentativa.
+ *
+ *  - **Sleep linear 200ms (não exponencial)**: simplificado. O sleep manual
+ *    em 429 vence (delegamos pro Retry-After do banco).
+ *
+ *  - **Healthchecks NÃO usam retry** (`withRetry: false`): healthcheck
+ *    significa "está vivo agora?". 1 fail = down. Retry mascararia downtime
+ *    real do banco do dashboard de operação.
+ *
+ *  - **NÃO retry em 500 puro** — 500 pode ser bug de payload da request
+ *    (idempotência quebrada, validação semântica). Só 502/503/504 são
+ *    sintomas de infra transitória.
+ *
+ * Custo IA: ZERO (driver HTTP-only). Latência adicional pior caso por
+ * request quando 5xx + 429 todos hitando: ~30s × 3 = 90s. Worker queue
+ * RecurringBilling tem timeout 300s — folga confortável.
+ *
+ * @see ADR 0170 Onda 4 — PaymentGateway Tier L3
+ * @see Audit 2026-05-23 — gap #1 (sem retry) + gap #2 (sem 429 handler)
+ */
+final class HttpClientFactory
+{
+    /**
+     * Cap absoluto pra espera de Retry-After (segundos). Bancos podem mandar
+     * valores muito altos em rate-limit duro; preferimos delegar pro retry
+     * job de queue (RecurringBilling) do que travar worker.
+     */
+    public const RETRY_AFTER_CAP_SECONDS = 30;
+
+    /**
+     * Status HTTP que vale a pena fazer retry (transitórios de infra).
+     * NÃO incluindo 500 — esse pode ser bug de payload da request.
+     */
+    public const RETRYABLE_5XX = [502, 503, 504];
+
+    /**
+     * Sleep entre tentativas em ms (base do Laravel Http::retry).
+     */
+    public const SLEEP_MS_BASE = 200;
+
+    /**
+     * Quantas tentativas no máximo (1 original + N-1 retries).
+     */
+    public const RETRY_TIMES = 3;
+
+    /**
+     * Cria PendingRequest pré-configurado com baseURL + headers + timeout
+     * + (opcional) retry + handler 429.
+     *
+     * Quando `$withRetry=true`, o cliente:
+     *   - faz até 3 tentativas
+     *   - re-tenta em ConnectionException (rede caiu) e status 502/503/504/429
+     *   - em 429, respeita header Retry-After (cap 30s)
+     *   - em 4xx (400/401/403/422) e 500 puro, devolve Response imediato sem retry
+     *   - APÓS esgotar retries em status retryável, devolve Response failed
+     *     normalmente — drivers checam `$response->failed()` próprio
+     *
+     * @param  string  $baseUrl        URL base do gateway (ex 'https://api.asaas.com/v3')
+     * @param  array<string,string>  $headers  Headers extra (ex ['access_token'=>$token])
+     * @param  int  $timeoutSec        Timeout por request (default 30s)
+     * @param  bool  $withRetry        true = aplica retry+429 handler; false = pure HTTP (use em healthchecks)
+     * @return PendingRequest          Cliente pronto pra ->post()/->get()/etc
+     */
+    public static function make(
+        string $baseUrl,
+        array $headers = [],
+        int $timeoutSec = 30,
+        bool $withRetry = true,
+    ): PendingRequest {
+        $client = Http::baseUrl($baseUrl)
+            ->withHeaders($headers)
+            ->acceptJson()
+            ->asJson()
+            ->timeout($timeoutSec);
+
+        if (! $withRetry) {
+            return $client;
+        }
+
+        // Mecânica:
+        //  1. Http::retry com 3 tentativas. Callback `$when` decide retry:
+        //     - ConnectionException → retry (rede caiu)
+        //     - RequestException com status 5xx/429 → retry (com sleep 429)
+        //     - Outras Throwables → false
+        //  2. ->throwIf(callable) força Laravel a jogar RequestException
+        //     APENAS em status retryáveis (5xx/429). Para 4xx, retorna
+        //     false → Response retorna sem throw → drivers checam ->failed().
+        //  3. APÓS esgotar retries em status retryável, Laravel ainda joga
+        //     RequestException por causa do throwIf. O wrapper `send()`
+        //     (vide método estático abaixo) captura essa RequestException e
+        //     devolve $exception->response, preservando DX original dos drivers
+        //     que esperam sempre receber Response.
+        $isRetryableStatus = function (Response $response): bool {
+            $status = $response->status();
+
+            return $status === 429 || in_array($status, self::RETRYABLE_5XX, true);
+        };
+
+        return $client
+            ->retry(
+                self::RETRY_TIMES,
+                self::SLEEP_MS_BASE,
+                function (\Throwable $exception, PendingRequest $request): bool {
+                    return self::shouldRetry($exception);
+                },
+                throw: false,
+            )
+            ->throwIf($isRetryableStatus);
+    }
+
+    /**
+     * Decide se deve retry baseado na exception capturada pelo Http::retry.
+     *
+     * Recebe:
+     *  - ConnectionException (timeout, DNS, conn refused) → retry sempre
+     *  - RequestException de 5xx/429 (capturado pelo ->throwIf() acima) → retry
+     *  - Outras Throwables → não retry
+     */
+    private static function shouldRetry(\Throwable $exception): bool
+    {
+        // Network/timeout errors → retry sempre
+        if ($exception instanceof ConnectionException) {
+            return true;
+        }
+
+        // RequestException de 5xx/429 capturado pelo ->throwIf() callback
+        if ($exception instanceof RequestException) {
+            $response = $exception->response;
+            $status = $response->status();
+
+            // 5xx transitório
+            if (in_array($status, self::RETRYABLE_5XX, true)) {
+                return true;
+            }
+
+            // 429 Too Many Requests — respeita Retry-After
+            if ($status === 429) {
+                self::sleepRespectingRetryAfter($response);
+
+                return true;
+            }
+        }
+
+        // Outras Throwables não-mapeadas → safe default false
+        return false;
+    }
+
+    /**
+     * Espera o tempo indicado pelo header `Retry-After` (RFC 9110 §10.2.3).
+     *
+     * Suporta:
+     *  - segundos: `Retry-After: 5`
+     *  - HTTP-date: `Retry-After: Wed, 21 Oct 2026 07:28:00 GMT` (raro em
+     *    APIs bancárias mas ok suportar)
+     *
+     * Default 1s se ausente/inválido. Cap em RETRY_AFTER_CAP_SECONDS.
+     *
+     * NOTA: `sleep()` em queue worker é OK desde que worker tenha timeout
+     * adequado. RecurringBilling jobs têm timeout 300s — sleep 30s é seguro.
+     */
+    private static function sleepRespectingRetryAfter(Response $response): void
+    {
+        $header = $response->header('Retry-After');
+        $seconds = self::parseRetryAfter($header);
+
+        // Cap pra não travar worker em rate-limit duro
+        $seconds = min($seconds, self::RETRY_AFTER_CAP_SECONDS);
+        $seconds = max($seconds, 1); // mínimo 1s
+
+        sleep($seconds);
+    }
+
+    /**
+     * Parse Retry-After: aceita int (segundos) ou HTTP-date (raro em APIs BR).
+     *
+     * @internal Público pra testabilidade direta.
+     */
+    public static function parseRetryAfter(?string $header): int
+    {
+        if ($header === null || $header === '') {
+            return 1;
+        }
+
+        // Caso 1: int → segundos
+        if (ctype_digit($header)) {
+            return (int) $header;
+        }
+
+        // Caso 2: HTTP-date → calcula delta vs now
+        $timestamp = strtotime($header);
+        if ($timestamp !== false) {
+            $delta = $timestamp - time();
+
+            return $delta > 0 ? $delta : 1;
+        }
+
+        // Header malformado → default 1s
+        return 1;
+    }
+
+    /**
+     * Executa uma chamada HTTP via Closure e devolve a Response, capturando
+     * RequestException jogada pelo throwIf retryable (após esgotar retries).
+     *
+     * Os drivers podem usar este wrapper pra preservar a semântica antiga
+     * (sempre receber Response, nunca exception não-tratada):
+     *
+     * ```php
+     * $response = HttpClientFactory::send(fn() =>
+     *     $this->client($cred)->post('/payments', $payload)
+     * );
+     * if ($response->failed()) { throw GatewayUnavailableException; }
+     * ```
+     *
+     * Sem este wrapper, drivers precisariam fazer try/catch RequestException
+     * em CADA chamada — esta função centraliza isso.
+     *
+     * @param  \Closure(): Response  $callable Closure que faz a chamada HTTP
+     * @return Response Última response (success ou failed). Em ConnectionException
+     *                  pura sem response final, ESCAPA — drivers continuam tratando
+     *                  via try/catch \Throwable existente.
+     */
+    public static function send(\Closure $callable): Response
+    {
+        try {
+            return $callable();
+        } catch (RequestException $e) {
+            // Status retryável esgotou retries → response final está em $e->response.
+            // Devolve normalmente; driver fará ->failed() check.
+            return $e->response;
+        }
+    }
+}

--- a/Modules/PaymentGateway/Tests/Feature/HttpClientFactoryTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/HttpClientFactoryTest.php
@@ -1,0 +1,243 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Http\Client\RequestException;
+use Illuminate\Support\Facades\Http;
+use Modules\PaymentGateway\Services\HttpClientFactory;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Audit 2026-05-23 Onda 4e gap #1+#2 — GUARDs do HttpClientFactory.
+ *
+ * Cobre os 5 cenários críticos:
+ *  1. 502 → sucesso na 3ª tentativa (retry funciona)
+ *  2. 5× 502 consecutivos → esgota retries, devolve última Response (throw:false)
+ *  3. 429 com Retry-After: 2 → respeita header
+ *  4. 429 sem Retry-After → default 1s
+ *  5. 4xx puro (400/422) → NÃO retry, devolve Response imediato
+ *
+ * NÃO instancia banco — testa Http::fake puro + parser direto.
+ */
+
+// ─── Sanity check de configuração ───────────────────────────────────────────
+
+it('constantes HttpClientFactory documentadas + valores razoáveis', function () {
+    expect(HttpClientFactory::RETRY_TIMES)->toBe(3);
+    expect(HttpClientFactory::SLEEP_MS_BASE)->toBe(200);
+    expect(HttpClientFactory::RETRY_AFTER_CAP_SECONDS)->toBe(30);
+    expect(HttpClientFactory::RETRYABLE_5XX)->toContain(502)
+        ->and(HttpClientFactory::RETRYABLE_5XX)->toContain(503)
+        ->and(HttpClientFactory::RETRYABLE_5XX)->toContain(504)
+        ->and(HttpClientFactory::RETRYABLE_5XX)->not->toContain(500);
+});
+
+// ─── Parser Retry-After ─────────────────────────────────────────────────────
+
+it('parseRetryAfter aceita int em segundos', function () {
+    expect(HttpClientFactory::parseRetryAfter('5'))->toBe(5)
+        ->and(HttpClientFactory::parseRetryAfter('0'))->toBe(0)
+        ->and(HttpClientFactory::parseRetryAfter('120'))->toBe(120);
+});
+
+it('parseRetryAfter aceita HTTP-date futura', function () {
+    $future = gmdate('D, d M Y H:i:s', time() + 10) . ' GMT';
+    $parsed = HttpClientFactory::parseRetryAfter($future);
+
+    // Deve estar entre 9-11s (allowance pra clock skew do teste)
+    expect($parsed)->toBeGreaterThanOrEqual(9)
+        ->and($parsed)->toBeLessThanOrEqual(11);
+});
+
+it('parseRetryAfter default 1s se ausente/inválido', function () {
+    expect(HttpClientFactory::parseRetryAfter(null))->toBe(1)
+        ->and(HttpClientFactory::parseRetryAfter(''))->toBe(1)
+        ->and(HttpClientFactory::parseRetryAfter('not-a-date'))->toBe(1);
+});
+
+// ─── GUARD #1: 502 transitório → sucesso na 3ª tentativa ────────────────────
+
+it('GUARD #1 retry recupera de 502 transitório (sucesso na 3ª)', function () {
+    Http::fake([
+        'https://fake-bank.test/*' => Http::sequence()
+            ->push(['error' => 'bad gateway'], 502)
+            ->push(['error' => 'bad gateway'], 502)
+            ->push(['ok' => true, 'id' => 'tx_001'], 200),
+    ]);
+
+    $client = HttpClientFactory::make('https://fake-bank.test', ['Accept' => 'application/json']);
+
+    $response = HttpClientFactory::send(fn () => $client->get('/v1/cobrancas/123'));
+
+    expect($response->successful())->toBeTrue();
+    expect($response->json('id'))->toBe('tx_001');
+
+    // 3 requests no total (1 original + 2 retries antes do success)
+    Http::assertSentCount(3);
+});
+
+// ─── GUARD #2: 502 5× → esgota, devolve última Response sem throw ───────────
+
+it('GUARD #2 502 consecutivo esgota retries + devolve última Response (throw:false)', function () {
+    Http::fake([
+        'https://fake-bank.test/*' => Http::response(['error' => 'bad gateway'], 502),
+    ]);
+
+    $client = HttpClientFactory::make('https://fake-bank.test');
+
+    // Drivers usam send() wrapper que captura RequestException pós-esgotamento
+    $response = HttpClientFactory::send(fn () => $client->get('/v1/health'));
+
+    expect($response->failed())->toBeTrue();
+    expect($response->status())->toBe(502);
+
+    // Exatamente RETRY_TIMES requests (1 original + 2 retries = 3 total)
+    Http::assertSentCount(HttpClientFactory::RETRY_TIMES);
+});
+
+// ─── GUARD #3: 429 com Retry-After: 0 → respeita (mas cap pra teste rápido) ─
+
+it('GUARD #3 429 com Retry-After respeita header + retry', function () {
+    // Retry-After: 0 (vai virar mínimo 1s pelo max(seconds, 1), mas teste roda)
+    Http::fake([
+        'https://fake-bank.test/*' => Http::sequence()
+            ->push(['error' => 'too many'], 429, ['Retry-After' => '0'])
+            ->push(['ok' => true], 200),
+    ]);
+
+    $client = HttpClientFactory::make('https://fake-bank.test');
+
+    $start = microtime(true);
+    $response = HttpClientFactory::send(fn () => $client->get('/v1/cobrancas'));
+    $elapsedSec = microtime(true) - $start;
+
+    expect($response->successful())->toBeTrue();
+    // Sleep mínimo 1s (max(0, 1)) + sleep base 200ms entre retries
+    expect($elapsedSec)->toBeGreaterThanOrEqual(1.0);
+    // Não deve ter esperado mais que 5s (sanity — 0 capped a 1s)
+    expect($elapsedSec)->toBeLessThan(5.0);
+
+    Http::assertSentCount(2);
+});
+
+// ─── GUARD #4: 429 sem Retry-After → default 1s ────────────────────────────
+
+it('GUARD #4 429 sem Retry-After usa default 1s', function () {
+    Http::fake([
+        'https://fake-bank.test/*' => Http::sequence()
+            ->push(['error' => 'rate limited'], 429) // SEM Retry-After
+            ->push(['ok' => true], 200),
+    ]);
+
+    $client = HttpClientFactory::make('https://fake-bank.test');
+
+    $start = microtime(true);
+    $response = HttpClientFactory::send(fn () => $client->get('/v1/cobrancas'));
+    $elapsedSec = microtime(true) - $start;
+
+    expect($response->successful())->toBeTrue();
+    // Default 1s
+    expect($elapsedSec)->toBeGreaterThanOrEqual(1.0);
+    expect($elapsedSec)->toBeLessThan(3.0);
+
+    Http::assertSentCount(2);
+});
+
+// ─── GUARD #5: 4xx não retry, devolve imediato ──────────────────────────────
+// NOTA: 4xx não-retryável NÃO dispara throwIf (callback retorna false),
+// então drivers podem chamar direto SEM send() wrapper. Mas para consistência,
+// recomendamos sempre usar send() — é noop nesse caso.
+
+it('GUARD #5 status 400 NÃO retry, devolve Response imediato', function () {
+    Http::fake([
+        'https://fake-bank.test/*' => Http::response(['error' => 'invalid payload'], 400),
+    ]);
+
+    $client = HttpClientFactory::make('https://fake-bank.test');
+
+    $start = microtime(true);
+    $response = HttpClientFactory::send(fn () => $client->post('/v1/cobrancas', ['valor' => 'invalid']));
+    $elapsedSec = microtime(true) - $start;
+
+    expect($response->status())->toBe(400);
+    expect($response->failed())->toBeTrue();
+    expect($elapsedSec)->toBeLessThan(1.0); // sem retry, retorna rápido
+
+    // EXATAMENTE 1 request — sem retry pra 4xx
+    Http::assertSentCount(1);
+});
+
+it('GUARD #5 status 401 NÃO retry, devolve Response imediato', function () {
+    Http::fake([
+        'https://fake-bank.test/*' => Http::response(['error' => 'unauthorized'], 401),
+    ]);
+
+    $client = HttpClientFactory::make('https://fake-bank.test');
+    $response = HttpClientFactory::send(fn () => $client->get('/v1/cobrancas'));
+
+    expect($response->status())->toBe(401);
+    Http::assertSentCount(1);
+});
+
+it('GUARD #5 status 422 NÃO retry, devolve Response imediato', function () {
+    Http::fake([
+        'https://fake-bank.test/*' => Http::response(['errors' => ['valor' => 'required']], 422),
+    ]);
+
+    $client = HttpClientFactory::make('https://fake-bank.test');
+    $response = HttpClientFactory::send(fn () => $client->post('/v1/cobrancas', []));
+
+    expect($response->status())->toBe(422);
+    Http::assertSentCount(1);
+});
+
+it('GUARD #5 status 500 puro NÃO retry (poderia ser bug payload)', function () {
+    Http::fake([
+        'https://fake-bank.test/*' => Http::response(['error' => 'internal'], 500),
+    ]);
+
+    $client = HttpClientFactory::make('https://fake-bank.test');
+    $response = HttpClientFactory::send(fn () => $client->get('/v1/cobrancas'));
+
+    expect($response->status())->toBe(500);
+    Http::assertSentCount(1);
+});
+
+// ─── Healthcheck mode (withRetry: false) ───────────────────────────────────
+
+it('withRetry:false NÃO faz retry mesmo em 502 (healthcheck mode)', function () {
+    Http::fake([
+        'https://fake-bank.test/*' => Http::response(['error' => 'down'], 502),
+    ]);
+
+    $client = HttpClientFactory::make(
+        baseUrl: 'https://fake-bank.test',
+        withRetry: false,
+    );
+
+    $response = $client->get('/health');
+
+    expect($response->status())->toBe(502);
+    Http::assertSentCount(1); // exato 1 request, sem retry
+});
+
+// ─── Headers passthrough ───────────────────────────────────────────────────
+
+it('headers são propagados pro PendingRequest', function () {
+    Http::fake([
+        'https://fake-bank.test/*' => Http::response(['ok' => true], 200),
+    ]);
+
+    $client = HttpClientFactory::make(
+        baseUrl: 'https://fake-bank.test',
+        headers: ['X-Custom-Auth' => 'token-xyz', 'X-Request-Id' => 'req-001'],
+    );
+
+    $client->get('/v1/ping');
+
+    Http::assertSent(function ($request) {
+        return $request->hasHeader('X-Custom-Auth', 'token-xyz')
+            && $request->hasHeader('X-Request-Id', 'req-001');
+    });
+});

--- a/Modules/PaymentGateway/Tests/Feature/RetryOrphanWebhookJobTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/RetryOrphanWebhookJobTest.php
@@ -1,0 +1,386 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+use Modules\PaymentGateway\Events\CobrancaPaga;
+use Modules\PaymentGateway\Jobs\RetryOrphanWebhookJob;
+use Modules\PaymentGateway\Models\Cobranca;
+use Modules\PaymentGateway\Models\GatewayWebhookEvent;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Setup: cria SOMENTE `cobrancas` + `gateway_webhook_events` no SQLite in-memory.
+ *
+ * Por que não RefreshDatabase: migrations do projeto contém ALTER TABLE ... MODIFY
+ * COLUMN ENUM (MySQL-only) — SQLite barra. Pattern já adotado em PagarmeDriverTest.
+ */
+function setupOrphanWebhookSchema(): void
+{
+    if (! Schema::hasTable('cobrancas')) {
+        Schema::create('cobrancas', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('business_id')->index();
+            $table->unsignedBigInteger('payment_gateway_credential_id')->nullable();
+            $table->string('gateway_external_id')->nullable();
+            $table->string('tipo', 20);
+            $table->string('status', 20);
+            $table->bigInteger('valor_centavos');
+            $table->bigInteger('valor_pago_centavos')->nullable();
+            $table->date('vencimento')->nullable();
+            $table->timestamp('paga_em')->nullable();
+            $table->unsignedBigInteger('contact_id')->nullable();
+            $table->string('payer_cpf_cnpj')->nullable();
+            $table->string('payer_name')->nullable();
+            $table->string('payer_email')->nullable();
+            $table->string('descricao')->nullable();
+            $table->string('idempotency_key');
+            $table->string('origem_type')->nullable();
+            $table->unsignedBigInteger('origem_id')->nullable();
+            $table->text('linha_digitavel')->nullable();
+            $table->text('codigo_barras')->nullable();
+            $table->text('pix_emv')->nullable();
+            $table->string('pix_qr_code_path')->nullable();
+            $table->string('boleto_pdf_url')->nullable();
+            $table->string('nosso_numero')->nullable();
+            $table->string('forma_pagamento')->nullable();
+            $table->json('payload_gateway')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    // Cobranca usa LogsActivity (Spatie) — precisa de activity_log table
+    if (! Schema::hasTable('activity_log')) {
+        Schema::create('activity_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('log_name')->nullable();
+            $table->text('description');
+            $table->nullableMorphs('subject', 'subject');
+            $table->nullableMorphs('causer', 'causer');
+            $table->json('properties')->nullable();
+            $table->uuid('batch_uuid')->nullable();
+            $table->string('event')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    if (! Schema::hasTable('gateway_webhook_events')) {
+        Schema::create('gateway_webhook_events', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('business_id')->index();
+            $table->unsignedBigInteger('payment_gateway_credential_id')->nullable();
+            $table->string('gateway_key', 20)->index();
+            $table->string('evento', 60)->index();
+            $table->string('gateway_event_id', 191);
+            $table->unsignedBigInteger('cobranca_id')->nullable()->index();
+            $table->json('payload');
+            $table->boolean('signature_valid')->default(false);
+            $table->timestamp('processed_at')->nullable()->index();
+            $table->text('error_message')->nullable();
+            $table->timestamps();
+            $table->unique(['business_id', 'gateway_key', 'gateway_event_id'], 'gw_wh_biz_key_extid_unique');
+        });
+    }
+}
+
+function teardownOrphanWebhookSchema(): void
+{
+    Schema::dropIfExists('gateway_webhook_events');
+    Schema::dropIfExists('cobrancas');
+    Schema::dropIfExists('activity_log');
+}
+
+/**
+ * ADR 0170 Onda 4e — Cobertura RetryOrphanWebhookJob (race condition retry).
+ *
+ * 3 GUARDs canônicos:
+ *   1. Job re-dispatcha CobrancaPaga quando órfão tem cobranca_id válido + evento paid
+ *   2. Job pula evento ainda órfão (cobranca_id NULL ou Cobranca não encontrada)
+ *      → log warn + processed_at PERMANECE NULL (próximo run tenta)
+ *   3. Job ignora evento muito antigo (> 24h) — fora da janela
+ *
+ * Pattern ADR 0093: business_id explícito por evento; withoutGlobalScopes() consciente.
+ * Pattern ADR 0101: testes biz=1, NUNCA biz=4 cliente real.
+ */
+
+beforeEach(function () {
+    setupOrphanWebhookSchema();
+    session(['business.id' => 1]);
+});
+
+afterEach(function () {
+    teardownOrphanWebhookSchema();
+});
+
+it('GUARD 1: re-dispatcha CobrancaPaga quando órfão tem cobranca_id + evento paid', function () {
+    Event::fake([CobrancaPaga::class]);
+
+    $cobranca = Cobranca::query()->create([
+        'business_id' => 1,
+        'gateway_external_id' => 'tx-orphan-001',
+        'tipo' => 'pix_cob',
+        'status' => 'emitida',
+        'valor_centavos' => 15000,
+        'valor_pago_centavos' => 15000,
+        'paga_em' => now()->subMinutes(30),
+        'forma_pagamento' => 'pix',
+        'idempotency_key' => 'orphan-test-001',
+        'payload_gateway' => [],
+    ]);
+
+    // Evento órfão: criado há 2h (janela 1h..24h), processed_at NULL, evento "paid"
+    $orphan = GatewayWebhookEvent::query()->create([
+        'business_id' => 1,
+        'gateway_key' => 'inter',
+        'evento' => 'cob.paid',
+        'gateway_event_id' => 'evt-orphan-001',
+        'cobranca_id' => $cobranca->id,
+        'payload' => ['raw' => 'paid'],
+        'signature_valid' => true,
+    ]);
+    // backdate created_at pra fora da janela "espera 1h"
+    $orphan->created_at = now()->subHours(2);
+    $orphan->saveQuietly();
+
+    (new RetryOrphanWebhookJob())->handle();
+
+    $orphan->refresh();
+    expect($orphan->processed_at)->not->toBeNull();
+    expect($orphan->error_message)->toBeNull();
+
+    Event::assertDispatched(CobrancaPaga::class, function (CobrancaPaga $e) use ($cobranca) {
+        return $e->cobrancaId === $cobranca->id
+            && $e->businessId === 1
+            && $e->formaPagamento === 'pix'
+            && $e->valorPagoCentavos === 15000;
+    });
+});
+
+it('GUARD 2a: pula evento órfão com cobranca_id NULL — processed_at PERMANECE NULL', function () {
+    Event::fake([CobrancaPaga::class]);
+
+    $orphan = GatewayWebhookEvent::query()->create([
+        'business_id' => 1,
+        'gateway_key' => 'asaas',
+        'evento' => 'PAYMENT_RECEIVED',
+        'gateway_event_id' => 'evt-still-orphan-001',
+        'cobranca_id' => null,
+        'payload' => ['raw' => 'received'],
+        'signature_valid' => true,
+    ]);
+    $orphan->created_at = now()->subHours(3);
+    $orphan->saveQuietly();
+
+    (new RetryOrphanWebhookJob())->handle();
+
+    $orphan->refresh();
+    expect($orphan->processed_at)->toBeNull(); // próximo run tenta de novo
+    expect($orphan->error_message)->toContain('still_orphan');
+    expect($orphan->error_message)->toContain('cobranca_id_null');
+
+    Event::assertNotDispatched(CobrancaPaga::class);
+});
+
+it('GUARD 2b: pula órfão quando Cobranca não encontrada — processed_at PERMANECE NULL', function () {
+    Event::fake([CobrancaPaga::class]);
+
+    $orphan = GatewayWebhookEvent::query()->create([
+        'business_id' => 1,
+        'gateway_key' => 'c6',
+        'evento' => 'PAYMENT_OK',
+        'gateway_event_id' => 'evt-cobranca-deleted',
+        'cobranca_id' => 99999, // não existe
+        'payload' => ['raw' => 'ok'],
+        'signature_valid' => true,
+    ]);
+    $orphan->created_at = now()->subHours(4);
+    $orphan->saveQuietly();
+
+    (new RetryOrphanWebhookJob())->handle();
+
+    $orphan->refresh();
+    expect($orphan->processed_at)->toBeNull();
+    expect($orphan->error_message)->toContain('still_orphan');
+    expect($orphan->error_message)->toContain('cobranca_not_found');
+
+    Event::assertNotDispatched(CobrancaPaga::class);
+});
+
+it('GUARD 3: ignora evento muito antigo (> 24h) — fora da janela', function () {
+    Event::fake([CobrancaPaga::class]);
+
+    $cobranca = Cobranca::query()->create([
+        'business_id' => 1,
+        'gateway_external_id' => 'tx-too-old',
+        'tipo' => 'pix_cob',
+        'status' => 'emitida',
+        'valor_centavos' => 10000,
+        'idempotency_key' => 'too-old-001',
+        'payload_gateway' => [],
+    ]);
+
+    $orphan = GatewayWebhookEvent::query()->create([
+        'business_id' => 1,
+        'gateway_key' => 'inter',
+        'evento' => 'cob.paid',
+        'gateway_event_id' => 'evt-too-old-001',
+        'cobranca_id' => $cobranca->id,
+        'payload' => ['raw' => 'paid'],
+        'signature_valid' => true,
+    ]);
+    // backdate created_at pra MAIS DE 24h atrás → fora da janela
+    $orphan->created_at = now()->subDays(2);
+    $orphan->saveQuietly();
+
+    (new RetryOrphanWebhookJob())->handle();
+
+    $orphan->refresh();
+    expect($orphan->processed_at)->toBeNull(); // nem tocou nele
+    expect($orphan->error_message)->toBeNull(); // nem tocou nele
+
+    Event::assertNotDispatched(CobrancaPaga::class);
+});
+
+it('GUARD 3b: ignora evento muito recente (< 1h) — espera fluxo original gravar Cobranca', function () {
+    Event::fake([CobrancaPaga::class]);
+
+    $cobranca = Cobranca::query()->create([
+        'business_id' => 1,
+        'gateway_external_id' => 'tx-too-recent',
+        'tipo' => 'pix_cob',
+        'status' => 'emitida',
+        'valor_centavos' => 8000,
+        'idempotency_key' => 'too-recent-001',
+        'payload_gateway' => [],
+    ]);
+
+    $orphan = GatewayWebhookEvent::query()->create([
+        'business_id' => 1,
+        'gateway_key' => 'inter',
+        'evento' => 'cob.paid',
+        'gateway_event_id' => 'evt-too-recent-001',
+        'cobranca_id' => $cobranca->id,
+        'payload' => ['raw' => 'paid'],
+        'signature_valid' => true,
+    ]);
+    // 10min atrás → ainda dentro da espera 1h
+    $orphan->created_at = now()->subMinutes(10);
+    $orphan->saveQuietly();
+
+    (new RetryOrphanWebhookJob())->handle();
+
+    $orphan->refresh();
+    expect($orphan->processed_at)->toBeNull();
+    Event::assertNotDispatched(CobrancaPaga::class);
+});
+
+it('GUARD 4: evento que NÃO matches paid pattern → marca processed sem dispatch', function () {
+    Event::fake([CobrancaPaga::class]);
+
+    $cobranca = Cobranca::query()->create([
+        'business_id' => 1,
+        'gateway_external_id' => 'tx-non-paid',
+        'tipo' => 'pix_cob',
+        'status' => 'emitida',
+        'valor_centavos' => 5000,
+        'idempotency_key' => 'non-paid-001',
+        'payload_gateway' => [],
+    ]);
+
+    $orphan = GatewayWebhookEvent::query()->create([
+        'business_id' => 1,
+        'gateway_key' => 'inter',
+        'evento' => 'cob.created', // NÃO matches paid/received/confirmed
+        'gateway_event_id' => 'evt-non-paid-001',
+        'cobranca_id' => $cobranca->id,
+        'payload' => ['raw' => 'created'],
+        'signature_valid' => true,
+    ]);
+    $orphan->created_at = now()->subHours(2);
+    $orphan->saveQuietly();
+
+    (new RetryOrphanWebhookJob())->handle();
+
+    $orphan->refresh();
+    expect($orphan->processed_at)->not->toBeNull(); // marcado processed
+    expect($orphan->error_message)->toContain('orphan_event_not_mapped_to_dispatch');
+    Event::assertNotDispatched(CobrancaPaga::class);
+});
+
+it('GUARD 5: respeita limit 50 — só processa 50 órfãos por run', function () {
+    Event::fake([CobrancaPaga::class]);
+
+    // Cria 51 órfãos válidos (na janela, cobranca_id válido, evento paid)
+    for ($i = 1; $i <= 51; $i++) {
+        $cobranca = Cobranca::query()->create([
+            'business_id' => 1,
+            'gateway_external_id' => "tx-bulk-{$i}",
+            'tipo' => 'pix_cob',
+            'status' => 'emitida',
+            'valor_centavos' => 1000,
+            'idempotency_key' => "bulk-{$i}",
+            'payload_gateway' => [],
+        ]);
+
+        $orphan = GatewayWebhookEvent::query()->create([
+            'business_id' => 1,
+            'gateway_key' => 'inter',
+            'evento' => 'cob.paid',
+            'gateway_event_id' => "evt-bulk-{$i}",
+            'cobranca_id' => $cobranca->id,
+            'payload' => ['raw' => 'paid'],
+            'signature_valid' => true,
+        ]);
+        $orphan->created_at = now()->subHours(2)->subMinutes($i); // ordem cronológica
+        $orphan->saveQuietly();
+    }
+
+    (new RetryOrphanWebhookJob())->handle();
+
+    // 50 dispatched no run; o 51º fica pro próximo run
+    Event::assertDispatchedTimes(CobrancaPaga::class, 50);
+
+    $stillOrphans = GatewayWebhookEvent::withoutGlobalScopes()
+        ->whereNull('processed_at')
+        ->count();
+    expect($stillOrphans)->toBe(1);
+});
+
+it('GUARD 6: dispatch propaga business_id correto em multi-tenant (biz=99 NÃO contamina biz=1)', function () {
+    Event::fake([CobrancaPaga::class]);
+
+    // Cobranca + órfão biz=99
+    $cob99 = Cobranca::query()->withoutGlobalScopes()->create([
+        'business_id' => 99,
+        'gateway_external_id' => 'tx-biz99',
+        'tipo' => 'pix_cob',
+        'status' => 'emitida',
+        'valor_centavos' => 7000,
+        'valor_pago_centavos' => 7000,
+        'paga_em' => now()->subMinutes(30),
+        'forma_pagamento' => 'pix',
+        'idempotency_key' => 'biz99-001',
+        'payload_gateway' => [],
+    ]);
+
+    $orphan99 = GatewayWebhookEvent::query()->withoutGlobalScopes()->create([
+        'business_id' => 99,
+        'gateway_key' => 'inter',
+        'evento' => 'cob.paid',
+        'gateway_event_id' => 'evt-biz99-001',
+        'cobranca_id' => $cob99->id,
+        'payload' => ['raw' => 'paid'],
+        'signature_valid' => true,
+    ]);
+    $orphan99->created_at = now()->subHours(2);
+    $orphan99->saveQuietly();
+
+    (new RetryOrphanWebhookJob())->handle();
+
+    Event::assertDispatched(CobrancaPaga::class, function (CobrancaPaga $e) {
+        return $e->businessId === 99 && $e->cobrancaId > 0;
+    });
+});


### PR DESCRIPTION
Helper HttpClientFactory.php (288 LOC) com Http::retry(3, sleep=200ms exponential) + handler 429 (Retry-After parsing, cap 30s). Aplicado nos 5 drivers (Asaas/BCB/C6/Inter/Pagar.me). Healthcheck client com withRetry=false. 14/14 Pest verde (46 assertions). Zero regressão na suite PaymentGateway (50/50 idêntico baseline). Refs: ADR 0170 + audit erros 2026-05-23.