### PR TITLE
feat(paymentgateway): quota tracking MVP (Onda 4e gap #3)

### DIFF
--- a/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
@@ -503,6 +503,78 @@ class PaymentGatewaysController extends Controller
     }
 
     /**
+     * GET /settings/payment-gateways/{credentialId}/quota
+     *
+     * Quota tracking MVP — contagem de cobranças emitidas no mês corrente,
+     * agrupada por `tipo` (boleto / pix_cob / pix_cobv / pix_recv / card).
+     *
+     * Gap P1 catalogado em auditoria 2026-05-23: Wagner só descobre que
+     * estourou cota grátis do banco (Inter 250 boletos/mês, C6 200/2000)
+     * quando vê tarifa cobrada. UI passa a mostrar "Cota usada: X" no
+     * DrawerGateway tab Health.
+     *
+     * MVP: query agregada em `cobrancas` (sem contador persistido). OK até
+     * ~10k cobranças/mês per credencial — índice
+     * `(business_id, payment_gateway_credential_id)` em created_at via
+     * `cobrancas_biz_status_venc` cobre prefix da query.
+     *
+     * Tier 0 (ADR 0093): credencial precisa ser do business_id da sessão;
+     * count herda mesmo filtro via FK + business_id explícito (defense in
+     * depth, mesmo com HasBusinessScope no model).
+     *
+     * Limite per driver (Inter 250 / C6 200|2000) NÃO é avaliado aqui —
+     * UI mostra apenas total + breakdown; warning amber/rose fica em
+     * follow-up (parse complexo de DRIVERS[*].pricing).
+     *
+     * Shape:
+     *   {
+     *     "month": "2026-05",
+     *     "counts": {"boleto": 142, "pix_cob": 8, "card": 0},
+     *     "total": 150,
+     *     "gateway_key": "inter"
+     *   }
+     *
+     * Onda 4e gap #3 — Refs: ADR 0170 + audit 2026-05-23.
+     */
+    public function quota(Request $request, int $credentialId): JsonResponse
+    {
+        $businessId = (int) $request->session()->get('user.business_id', $request->session()->get('business.id', 0));
+
+        $credential = PaymentGatewayCredential::query()
+            ->where('business_id', $businessId)
+            ->find($credentialId);
+
+        if (! $credential) {
+            return response()->json([
+                'month'       => CarbonImmutable::now()->format('Y-m'),
+                'counts'      => [],
+                'total'       => 0,
+                'gateway_key' => null,
+            ], 404);
+        }
+
+        $now = CarbonImmutable::now();
+
+        $counts = Cobranca::query()
+            ->where('business_id', $businessId)
+            ->where('payment_gateway_credential_id', $credentialId)
+            ->whereYear('created_at', $now->year)
+            ->whereMonth('created_at', $now->month)
+            ->selectRaw('tipo, COUNT(*) as total')
+            ->groupBy('tipo')
+            ->pluck('total', 'tipo')
+            ->map(fn ($v) => (int) $v)
+            ->toArray();
+
+        return response()->json([
+            'month'       => $now->format('Y-m'),
+            'counts'      => $counts,
+            'total'       => array_sum($counts),
+            'gateway_key' => $credential->gateway_key,
+        ]);
+    }
+
+    /**
      * Toggle ativo/inativo da credencial (Trust L3 — confirma front-end).
      */
     public function toggle(Request $request, int $credentialId): JsonResponse

--- a/Modules/PaymentGateway/Routes/web.php
+++ b/Modules/PaymentGateway/Routes/web.php
@@ -74,6 +74,12 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
         Route::get('payment-gateways/{credentialId}/webhook-events', [PaymentGatewaysController::class, 'webhookEvents'])
             ->whereNumber('credentialId')
             ->name('payment-gateways.webhook-events');
+
+        // Onda 4e gap #3 (audit 2026-05-23): quota tracking MVP — count
+        // cobrancas/mês per credencial agrupado por tipo. Sem contador persistido.
+        Route::get('payment-gateways/{credentialId}/quota', [PaymentGatewaysController::class, 'quota'])
+            ->whereNumber('credentialId')
+            ->name('payment-gateways.quota');
     });
 
 // ─── Webhooks (Onda 3) ───────────────────────────────────────────────────

--- a/Modules/PaymentGateway/Tests/Feature/Settings/PaymentGatewaysQuotaTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/Settings/PaymentGatewaysQuotaTest.php
@@ -1,0 +1,170 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\Role;
+use App\User;
+use Carbon\CarbonImmutable;
+use Modules\PaymentGateway\Models\Cobranca;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+
+/**
+ * Pest GUARDs — GET /settings/payment-gateways/{id}/quota (Onda 4e gap #3).
+ *
+ * 3 GUARDs:
+ *   1) retorna 200 + counts agrupados por tipo quando credencial tem cobranças no mês
+ *   2) Tier 0 IRREVOGÁVEL: credencial de outro business → 404 (zero vaza count cross-tenant)
+ *   3) mês anterior NÃO conta (só created_at do mês corrente)
+ *
+ * Gap fechado: estado-da-arte 2026-05-23 catalogou "Quota tracking" como gap P1 —
+ * Wagner descobre quota Inter (250 grátis) ou C6 (200 grátis) estourada só quando
+ * vê tarifa cobrada. MVP é só contagem real-time (query agregada, sem contador
+ * persistido).
+ *
+ * Refs: ADR 0093 (Tier 0), ADR 0170 (PaymentGateway), audit 2026-05-23.
+ */
+
+beforeEach(function () {
+    setPermissionsTeamId(1);
+
+    $this->business = Business::query()->firstOrCreate(
+        ['id' => 1],
+        ['name' => 'Test HQ', 'currency_id' => 1],
+    );
+
+    $role = Role::firstOrCreate(
+        ['name' => "Admin#{$this->business->id}", 'business_id' => $this->business->id, 'guard_name' => 'web'],
+    );
+
+    $this->user = User::factory()->create([
+        'business_id' => $this->business->id,
+        'username'    => 'gwq_test_'.uniqid(),
+    ]);
+    $this->user->assignRole($role);
+
+    $this->credential = PaymentGatewayCredential::create([
+        'business_id'   => $this->business->id,
+        'gateway_key'   => 'inter',
+        'ambiente'      => 'sandbox',
+        'nome_display'  => 'Inter Sandbox Quota Test',
+        'config_json'   => ['client_id' => 'fake', 'client_secret' => 'fake'],
+        'ativo'         => true,
+        'health_status' => 'unknown',
+    ]);
+});
+
+/**
+ * Helper: cria cobranças mockadas no DB pra credencial dada.
+ * Bypassa requirement de gateway real — Cobranca::create() não chama API.
+ */
+function mkCobranca(int $businessId, int $credentialId, string $tipo, ?CarbonImmutable $createdAt = null): Cobranca
+{
+    $cob = Cobranca::create([
+        'business_id'                   => $businessId,
+        'payment_gateway_credential_id' => $credentialId,
+        'tipo'                          => $tipo,
+        'status'                        => 'emitida',
+        'valor_centavos'                => 10000,
+        'vencimento'                    => CarbonImmutable::now()->addDays(7)->toDateString(),
+        'descricao'                     => 'Teste quota tracking',
+        'idempotency_key'               => 'quota-test-'.uniqid('', true),
+    ]);
+
+    if ($createdAt !== null) {
+        // Forçar created_at em mês anterior — bypassa $timestamps automáticos
+        Cobranca::query()->where('id', $cob->id)->update(['created_at' => $createdAt]);
+    }
+
+    return $cob;
+}
+
+it('retorna 200 + counts agrupados por tipo quando credencial tem cobranças no mês', function () {
+    mkCobranca($this->business->id, $this->credential->id, 'boleto');
+    mkCobranca($this->business->id, $this->credential->id, 'boleto');
+    mkCobranca($this->business->id, $this->credential->id, 'boleto');
+    mkCobranca($this->business->id, $this->credential->id, 'pix_cob');
+    mkCobranca($this->business->id, $this->credential->id, 'pix_cob');
+
+    $response = $this->actingAs($this->user)
+        ->withSession([
+            'user.business_id' => $this->business->id,
+            'business.id'      => $this->business->id,
+        ])
+        ->getJson("/settings/payment-gateways/{$this->credential->id}/quota");
+
+    $response->assertOk()
+        ->assertJsonStructure(['month', 'counts', 'total', 'gateway_key']);
+
+    $payload = $response->json();
+    expect($payload['gateway_key'])->toBe('inter');
+    expect($payload['month'])->toBe(CarbonImmutable::now()->format('Y-m'));
+    expect($payload['total'])->toBe(5);
+    expect($payload['counts']['boleto'] ?? 0)->toBe(3);
+    expect($payload['counts']['pix_cob'] ?? 0)->toBe(2);
+});
+
+it('Tier 0: credencial de outro business → 404 (não vaza count cross-tenant)', function () {
+    // Cria business 2 + credencial nele
+    $otherBiz = Business::query()->firstOrCreate(
+        ['id' => 2],
+        ['name' => 'Other HQ', 'currency_id' => 1],
+    );
+
+    $otherCred = PaymentGatewayCredential::withoutGlobalScopes()->create([
+        'business_id'   => $otherBiz->id,
+        'gateway_key'   => 'c6',
+        'ambiente'      => 'sandbox',
+        'config_json'   => ['api_key' => 'fake_other'],
+        'ativo'         => true,
+        'health_status' => 'unknown',
+    ]);
+
+    // Cria cobranças no business 2 sem global scope
+    Cobranca::withoutGlobalScopes()->create([
+        'business_id'                   => $otherBiz->id,
+        'payment_gateway_credential_id' => $otherCred->id,
+        'tipo'                          => 'boleto',
+        'status'                        => 'emitida',
+        'valor_centavos'                => 10000,
+        'vencimento'                    => CarbonImmutable::now()->addDays(7)->toDateString(),
+        'descricao'                     => 'biz2 cobranca',
+        'idempotency_key'               => 'quota-cross-'.uniqid('', true),
+    ]);
+
+    // User do biz=1 tenta acessar quota da credencial do biz=2
+    $response = $this->actingAs($this->user)
+        ->withSession([
+            'user.business_id' => $this->business->id,
+            'business.id'      => $this->business->id,
+        ])
+        ->getJson("/settings/payment-gateways/{$otherCred->id}/quota");
+
+    $response->assertNotFound()
+        ->assertJson(['counts' => [], 'total' => 0, 'gateway_key' => null]);
+});
+
+it('mês anterior NÃO conta (só created_at do mês corrente)', function () {
+    // 2 cobranças no mês corrente
+    mkCobranca($this->business->id, $this->credential->id, 'boleto');
+    mkCobranca($this->business->id, $this->credential->id, 'pix_cob');
+
+    // 5 cobranças backdated pro mês anterior — NÃO devem contar
+    $lastMonth = CarbonImmutable::now()->subMonthNoOverflow()->setDay(15)->setTime(12, 0);
+    for ($i = 0; $i < 5; $i++) {
+        mkCobranca($this->business->id, $this->credential->id, 'boleto', $lastMonth);
+    }
+
+    $response = $this->actingAs($this->user)
+        ->withSession([
+            'user.business_id' => $this->business->id,
+            'business.id'      => $this->business->id,
+        ])
+        ->getJson("/settings/payment-gateways/{$this->credential->id}/quota");
+
+    $response->assertOk();
+    $payload = $response->json();
+    expect($payload['total'])->toBe(2); // só as 2 do mês corrente
+    expect($payload['counts']['boleto'] ?? 0)->toBe(1);
+    expect($payload['counts']['pix_cob'] ?? 0)->toBe(1);
+});

--- a/resources/js/Pages/Settings/PaymentGateways/_components/DrawerGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/DrawerGateway.tsx
@@ -38,6 +38,14 @@ interface WebhookEvent {
   cobranca_id: number | null;
 }
 
+// Onda 4e gap #3 (audit 2026-05-23): quota tracking MVP.
+interface QuotaPayload {
+  month: string;        // "2026-05"
+  counts: Record<string, number>;
+  total: number;
+  gateway_key: string | null;
+}
+
 interface Props {
   gateway: SettingsGateway;
   accounts: Account[];
@@ -76,6 +84,10 @@ export default function DrawerGateway({ gateway, accounts, onClose, onToggle }: 
   const [webhookEventsLoading, setWebhookEventsLoading] = useState(false);
   const [webhookEventsError, setWebhookEventsError] = useState<string | null>(null);
 
+  // Onda 4e gap #3 (audit 2026-05-23): quota tracking — lazy fetch quando tab Health ativada
+  const [quota, setQuota] = useState<QuotaPayload | null>(null);
+  const [quotaLoading, setQuotaLoading] = useState(false);
+
   useEffect(() => {
     if (tab !== 'webhook' || webhookEvents !== null || webhookEventsLoading) return;
     setWebhookEventsLoading(true);
@@ -95,6 +107,25 @@ export default function DrawerGateway({ gateway, accounts, onClose, onToggle }: 
         setWebhookEventsLoading(false);
       });
   }, [tab, gateway.id, webhookEvents, webhookEventsLoading]);
+
+  // Onda 4e gap #3: lazy fetch quota quando tab Health ativada
+  useEffect(() => {
+    if (tab !== 'health' || quota !== null || quotaLoading) return;
+    setQuotaLoading(true);
+    fetch(`/settings/payment-gateways/${gateway.id}/quota`, {
+      headers: { Accept: 'application/json' },
+      credentials: 'same-origin',
+    })
+      .then(r => r.ok ? r.json() : Promise.reject(`HTTP ${r.status}`))
+      .then((data: QuotaPayload) => {
+        setQuota(data);
+        setQuotaLoading(false);
+      })
+      .catch(() => {
+        setQuota({ month: '', counts: {}, total: 0, gateway_key: null });
+        setQuotaLoading(false);
+      });
+  }, [tab, gateway.id, quota, quotaLoading]);
 
   useEffect(() => {
     if (tab !== 'historico' || historyEntries !== null || historyLoading) return;
@@ -560,10 +591,30 @@ export default function DrawerGateway({ gateway, accounts, onClose, onToggle }: 
 
           {tab === 'health' && (
             <div className="space-y-4">
-              <div className="grid grid-cols-3 gap-3">
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
                 <KpiCard label="Último check" value={gateway.last_check ? gateway.last_check.slice(11, 16) : '—'} sub={gateway.last_check ? fmtDate(gateway.last_check.slice(0, 10)) : 'nunca testado'} icon={<RefreshCw className="h-3 w-3" />} />
                 <KpiCard label="Latência" value={gateway.latencia ? `${gateway.latencia}ms` : '—'} sub={gateway.latencia && gateway.latencia > 500 ? 'acima do SLA (<500ms)' : 'dentro do SLA'} tone={gateway.latencia && gateway.latencia > 500 ? 'rose' : 'emerald'} icon={<Zap className="h-3 w-3" />} />
                 <KpiCard label="Status" value={gateway.health} sub={gateway.warn || 'sem alertas'} tone={gateway.health === 'ok' ? 'emerald' : gateway.health === 'down' ? 'rose' : 'default'} icon={<Shield className="h-3 w-3" />} />
+                {/* Onda 4e gap #3 (audit 2026-05-23): cota mensal — limite per banco fica em follow-up */}
+                <KpiCard
+                  label="Cota mês"
+                  value={quotaLoading ? '…' : String(quota?.total ?? 0)}
+                  sub={(() => {
+                    if (quotaLoading) return 'carregando…';
+                    if (!quota || quota.total === 0) return 'sem cobranças no mês';
+                    const c = quota.counts;
+                    const parts: string[] = [];
+                    const boleto = c.boleto ?? 0;
+                    const pix = (c.pix_cob ?? 0) + (c.pix_cobv ?? 0) + (c.pix_recv ?? 0);
+                    const card = c.card ?? 0;
+                    if (boleto) parts.push(`boleto: ${boleto}`);
+                    if (pix) parts.push(`pix: ${pix}`);
+                    if (card) parts.push(`card: ${card}`);
+                    return parts.join(' · ') || '—';
+                  })()}
+                  tone="emerald"
+                  icon={<Zap className="h-3 w-3" />}
+                />
               </div>
 
               <Btn variant="outline" onClick={testar} disabled={testStatus === 'testando'}>


### PR DESCRIPTION
GET /settings/payment-gateways/{id}/quota retorna count cobrancas mês corrente per tipo (boleto/pix/card). UI: 4º KpiCard na tab Health 'Cota mês: X'. Sem migration nova (query agregada em cobrancas). Tier 0 Multi-tenant respeitado. 3 Pest GUARDs. Limites per driver ficam em follow-up. Refs: ADR 0170 + audit erros 2026-05-23.