### PR TITLE
docs(design-system): Constituição UI v2 — 4 camadas + ADRs UI-0013/0014 + PT-01 + PRE-MERGE-UI

### DIFF
--- a/.claude/skills/mwart-process/SKILL.md
+++ b/.claude/skills/mwart-process/SKILL.md
@@ -3,7 +3,7 @@ name: mwart-process
 description: Use SEMPRE que o trabalho envolva migrar tela Blade legacy → Inertia/React no oimpresso (MWART). Carrega o processo canônico ÚNICO definido em ADR 0104 — 5 fases obrigatórias e sequenciais (PLAN → BACKEND BASELINE → FRONTEND INCREMENTAL → QA → CUTOVER). Não há caminho alternativo. Ativa quando o pedido é "migrar tela X pra MWART", "criar tela em Pages/<Mod>/<Tela>.tsx", "migrar Blade pra React", ou quando Edit/Write em qualquer `resources/js/Pages/<Mod>/<Tela>.tsx` ou em controller chamando `Inertia::render`.
 tier: A
 status: active
-version: 1.1
+version: 1.2
 authority: canonical
 ---
 
@@ -29,8 +29,13 @@ RUNBOOK + SPEC → BASELINE      → INCREMENTAL     → HARDENING        → + 
 
 1. Verifica F1 completa: `memory/requisitos/<Mod>/RUNBOOK-<tela-kebab>.md` existe?
 2. Verifica F2 completa: SPEC.md tem epic + US `<MOD>-002` (backend baseline) com status `done`?
+3. **Identifica camada-3 (Padrão de Tela)** aplicável — ver [Constituição UI v2 / ADR UI-0013](../../memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md):
+   - Tela-lista → ler [PT-01-Lista.md](../../memory/requisitos/_DesignSystem/padroes-tela/PT-01-Lista.md) **antes** de codar (6 slots canônicos)
+   - Tela form/drawer → PT-02 (não documentado ainda — drawer 760px em [ADR 0185](../../memory/decisions/0185-drawer-760-canon-entidades-cadastrais.md))
+   - Tela detalhe/dashboard/config → abrir ADR ou justificar desvio
+4. **Antes do PR:** rodar checklist [PRE-MERGE-UI](../../memory/requisitos/_DesignSystem/PRE-MERGE-UI.md) camada 4 (anti-padrões AP1-AP8)
 
-**Se NÃO:** recusa o Edit/Write. Recomenda voltar pra fase faltante. Mensagem PT-BR explicando.
+**Se NÃO (1) OU (2):** recusa o Edit/Write. Recomenda voltar pra fase faltante. Mensagem PT-BR explicando.
 
 ## Skills associadas por fase
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,9 +20,10 @@
 1. `brief-fetch` → estado consolidado (~3k tokens) — Tier A always-on via hook `SessionStart`
 2. `my-work` → minhas tasks ativas
 3. (S4+) `charter-fetch <page-id>` antes de editar `.tsx` que tenha `.charter.md` ao lado
-4. Trabalhar (ler código, edit, test)
-5. (S5+) `decide(domain, intent, payload)` se mudança custosa
-6. Commit conventional + `Refs: SPRINT-N PASSO M` (skill `commit-discipline` Tier A)
+4. **Antes de tocar UI** (Pages/Components/css): ler [Constituição UI v2 · ADR UI-0013](memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md) + [PT aplicável](memory/requisitos/_DesignSystem/padroes-tela/) + rodar [PRE-MERGE-UI](memory/requisitos/_DesignSystem/PRE-MERGE-UI.md)
+5. Trabalhar (ler código, edit, test)
+6. (S5+) `decide(domain, intent, payload)` se mudança custosa
+7. Commit conventional + `Refs: SPRINT-N PASSO M` (skill `commit-discipline` Tier A)
 
 @memory/how-trabalhar.md
 
@@ -51,6 +52,14 @@ Princípios duros:
 1. Context as a product · 2. Tiered cost · 3. Charter > Spec · 4. Loop fechado por métrica · 5. SoC brutal · 6. **Multi-tenant Tier 0 IRREVOGÁVEL** · 7. Transparência · 8. Confiabilidade com fallback
 
 Lista completa de ADRs canon via tool MCP `decisions-search` (default: só ativas — convenção lifecycle [ADR 0095](memory/decisions/0095-skills-tiers-convencao-interna.md)).
+
+## Constituição UI v2 (4 camadas · UI-0013)
+
+Documento mãe UI: **[ADR UI-0013](memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md)** (accepted 2026-05-24).
+
+Hierarquia: **Fundações** (tokens cor/tipo/espaço · imutável via ADR) → **Shell** (AppShellV2 + PageHeader · 1× pro app) → **Padrão de Tela** ([PT-01 Lista](memory/requisitos/_DesignSystem/padroes-tela/PT-01-Lista.md) · 5-7 templates) → **Módulo** (varia). Camada superior **herda** das inferiores e **nunca contradiz**.
+
+Regra-mestre: pedido vago = agente **pergunta** antes de implementar (skill `wagner-request-refiner` + agente `wagner-understand` operacionalizam). Sidebar permanece light ([UI-0009](memory/requisitos/_DesignSystem/adr/ui/0009-cockpit-sidebar-light-padrao.md) + [UI-0014](memory/requisitos/_DesignSystem/adr/ui/0014-sidebar-light-mantida-v2-parcial.md) — Wagner-explícito).
 
 ## Proibições (Tier 0 — sem ADR mãe nova é proibido)
 @memory/proibicoes.md
@@ -92,4 +101,6 @@ Se algum falhar → investigar `storage/logs/laravel.log` ALERT entries.
 - Reportar bug: https://github.com/anthropics/claude-code/issues
 
 ---
-**Última atualização:** 2026-05-06 — Constituição v2 ([ADR 0094](memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md)) aceita. CLAUDE.md reescrito de 289 → ~85 linhas (Anthropic 2026 best-practice).
+**Última atualização:** 2026-05-24 — Constituição UI v2 ([ADR UI-0013](memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md) + [UI-0014](memory/requisitos/_DesignSystem/adr/ui/0014-sidebar-light-mantida-v2-parcial.md)) aceita. Adicionado passo 4 protocolo UI + seção Hierarquia UI.
+
+**2026-05-06** — Constituição v2 ([ADR 0094](memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md)) aceita. CLAUDE.md reescrito de 289 → ~85 linhas (Anthropic 2026 best-practice).

--- a/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
+++ b/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
@@ -8,7 +8,7 @@ authority: canonical
 lifecycle: ativo
 decided_by: [W]
 decided_at: 2026-05-23
-module: NfeBrasil
+module: nfebrasil
 quarter: 2026-Q2
 tags: [multi-tenant, fiscal, cert-a1, sefaz, lookup-cnpj, tier-zero, irrevogavel, no-regression]
 supersedes: []

--- a/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
+++ b/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
@@ -8,7 +8,7 @@ authority: canonical
 lifecycle: ativo
 decided_by: [W]
 decided_at: 2026-05-23
-module: nfebrasil
+module: NfeBrasil
 quarter: 2026-Q2
 tags: [multi-tenant, fiscal, cert-a1, sefaz, lookup-cnpj, tier-zero, irrevogavel, no-regression]
 supersedes: []

--- a/memory/decisions/0187-constituicao-ui-v2-ponteiro-canon.md
+++ b/memory/decisions/0187-constituicao-ui-v2-ponteiro-canon.md
@@ -1,0 +1,163 @@
+---
+slug: 0187-constituicao-ui-v2-ponteiro-canon
+number: 187
+title: "Constituição UI v2 — ponteiro canon (hierarquia 4 camadas + regra-mestre + PT-01 + PRE-MERGE-UI)"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: "2026-05-24"
+accepted_at: "2026-05-24"
+accepted_via: "Wagner aprovou explícito em sessão `frosty-greider-83ab2f` 2026-05-24 — comando exato: 'eu aporvo' (UI-0013) + 'eu realmente gosto como esta hoje. não gostaria de mudar' (sidebar opção A → UI-0014)"
+module: _DesignSystem
+quarter: 2026-Q2
+tags: [constituicao-ui, design-system, governança, hierarquia-camadas, ui-0013, ui-0014, mcp-discoverable, ponteiro-adr, multi-agent]
+supersedes: []
+supersedes_partially: []
+amends: []
+superseded_by: []
+related:
+  - "0093-multi-tenant-isolation-tier-0"
+  - "0094-constituicao-v2-7-camadas-8-principios"
+  - "0104-processo-mwart-canonico-unico-caminho"
+  - "0107-emendation-0104-visual-comparison-gate-f3"
+  - "0114-prototipo-ui-cowork-loop-formalizado"
+  - "0149-mwart-screen-pattern-reuse-cowork"
+  - "0179-cliente-drawer-760px-substitui-show-fullpage"
+  - "0185-drawer-760-canon-entidades-cadastrais"
+charter_impact:
+  - "CLAUDE.md raiz (Constituição UI v2 ganha seção Hierarquia UI + passo 4 protocolo)"
+  - "Skill mwart-process v1.1 → v1.2 (Regra de ouro cita PT-01 + PRE-MERGE-UI)"
+links_externos:
+  ui_0013: "memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md"
+  ui_0014: "memory/requisitos/_DesignSystem/adr/ui/0014-sidebar-light-mantida-v2-parcial.md"
+  pt_01: "memory/requisitos/_DesignSystem/padroes-tela/PT-01-Lista.md"
+  pre_merge_ui: "memory/requisitos/_DesignSystem/PRE-MERGE-UI.md"
+  proposal_sidebar: "memory/decisions/proposals/2026-05-24-sidebar-dark-vs-light.md"
+  ds_changelog: "memory/requisitos/_DesignSystem/CHANGELOG.md"
+---
+
+# ADR 0187 — Constituição UI v2 (ponteiro canon)
+
+## Contexto
+
+ADRs do design system vivem em `memory/requisitos/_DesignSystem/adr/ui/` (12 ADRs UI hoje, UI-0001 a UI-0014). A tool MCP `decisions-search` indexa `memory/decisions/*.md` raiz. ADRs UI ficavam **invisíveis** ao `decisions-search` mesmo sendo canônicas.
+
+Esta ADR existe **só pra dar visibilidade MCP** à Constituição UI v2 — sem ela, o time MCP (Felipe, Maiara, Eliana, Luiz) e qualquer agente novo não descobriria UI-0013/0014 via `decisions-search "constituição"` ou `decisions-search "ui"`.
+
+A Constituição UI v2 foi aprovada por Wagner em 2026-05-24 (sessão `frosty-greider-83ab2f`) após análise de handoff externo Claude Design v2:
+- **ADR UI-0013** (aceita) — hierarquia 4 camadas Fundações→Shell→PT→Módulo + regra-mestre "pedido vago, pergunta antes" + vocabulário canônico
+- **ADR UI-0014** (aceita) — confirmação opção A: sidebar permanece light (UI-0009 vence v2 ADR 0041 externa)
+- **PT-01 Lista** — primeiro Padrão de Tela formalizado (12 telas-lista já aplicam)
+- **PRE-MERGE-UI checklist** — anti-regressão por camada (AP1-AP8)
+
+## Decisão
+
+Adotar **Constituição UI v2** como mental model canônico do design system oimpresso, com este ADR servindo de **ponteiro indexável pelo MCP**.
+
+### Hierarquia adotada (referência rápida)
+
+```
+┌─────────────────────────────────────────────────────┐
+│  4 · MÓDULO          Modules/<X> · Pages/<X>        │  ← varia
+├─────────────────────────────────────────────────────┤
+│  3 · PADRÃO DE TELA  PT-01 Lista · (PT-02..05 TBD)  │  ← templates fixos
+├─────────────────────────────────────────────────────┤
+│  2 · SHELL           AppShellV2 · PageHeader        │  ← 1× pro app
+├─────────────────────────────────────────────────────┤
+│  1 · FUNDAÇÕES       tokens cor · tipo · espaço     │  ← imutável via ADR
+└─────────────────────────────────────────────────────┘
+```
+
+**Princípio:** camada superior **herda** das inferiores e **nunca contradiz**. Conflito? Camada inferior vence (Fundações > Shell > PT > Módulo).
+
+### Regra-mestre · pedido vago
+
+Antes de tocar UI, agente verifica se pedido aponta:
+- ✅ Camada (1-Fundações / 2-Shell / 3-PT / 4-Módulo)
+- ✅ Artefato canônico aplicar
+- ✅ Mudança específica
+
+Se vago → **pergunta** antes de implementar (operacionalizado por skill `wagner-request-refiner` + agente `wagner-understand`).
+
+### Sidebar permanece light
+
+Conflito v2 (sidebar dark sempre) vs UI-0009 (sidebar light padrão) **resolvido por Wagner explícito 2026-05-24**: opção A — manter UI-0009. Formalizado em [UI-0014](memory/requisitos/_DesignSystem/adr/ui/0014-sidebar-light-mantida-v2-parcial.md).
+
+## Docs operacionais (onde o time MCP busca)
+
+| Doc | Path | Quando ler |
+|---|---|---|
+| **ADR-mãe UI-0013** | `memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md` | Antes de tocar qualquer arquivo UI |
+| **ADR UI-0014 sidebar** | `memory/requisitos/_DesignSystem/adr/ui/0014-sidebar-light-mantida-v2-parcial.md` | Se for mexer em sidebar dark/light |
+| **PT-01 Lista** | `memory/requisitos/_DesignSystem/padroes-tela/PT-01-Lista.md` | Antes de criar/editar tela-lista (Index.tsx) |
+| **PRE-MERGE-UI** | `memory/requisitos/_DesignSystem/PRE-MERGE-UI.md` | Antes de abrir PR que toca UI |
+| **README DS** | `memory/requisitos/_DesignSystem/README.md` | Visão geral + mapa 4 camadas |
+| **Proposal sidebar** | `memory/decisions/proposals/2026-05-24-sidebar-dark-vs-light.md` | Histórico desempate |
+
+## Enforcement — automatizado vs disciplina
+
+Esta ADR não pretende ser CI lint. Enforça via combinação:
+
+### Automatizado (CI / hooks / skills always-on)
+
+- **CLAUDE.md raiz** (`@imports` no SessionStart) — passo 4 do protocolo aponta esta ADR
+- **Skill `mwart-process` Tier A v1.2** — Regra de ouro cita PT-01 + PRE-MERGE-UI
+- **Skill `preflight-modulo`** (hook bloqueador) — Edit em `Modules/<X>/` exige leitura prévia
+- **Skill `multi-tenant-patterns` Tier A** — `business_id` scope (ADR 0093)
+- **Module Grades Gate CI** — bloqueia PR se nota módulo baixar
+
+### Disciplina humana / agente (não automatizado ainda)
+
+- Aplicar PRE-MERGE-UI mentalmente antes do PR
+- Reconhecer pedido vago e perguntar (regra-mestre)
+- Não adicionar 6ª origin badge sem ADR
+- Não tocar tokens Fundações em arquivo de módulo
+
+### Próximos passos pra subir automação (lista priorizada)
+
+| # | Mecanismo | Esforço | Quando |
+|---|---|---|---|
+| 1 | Skill `constituicao-ui-aware` Tier A description-match em Edit/Write em Pages/ | 30min | quando >2 agentes errarem na ordem |
+| 2 | CI lint `php artisan ui:lint` — grep cor crua, ícone fora lucide, emoji em UI | 2h | quando primeira regressão real aparecer |
+| 3 | Hook pre-commit local em Pages/ | 1h | opcional |
+| 4 | Webhook GitHub → Slack/MCP-notif quando UI canônica muda | 4h | quando time MCP estiver maior |
+
+## Consequências
+
+### Positivas
+
+- **`decisions-search` MCP** agora retorna esta ADR pra queries "constituição", "ui", "camadas", "design system" — time MCP descobre
+- **`brief-fetch`** lista esta ADR em "decisões 24h" no dia da aprovação
+- **Hierarquia explícita** acaba com pergunta recorrente "qual cor aplicar / qual padrão de tela / onde mexe"
+- **Append-only mantido** — UI-0001..UI-0012 + UI-0013 + UI-0014 coexistem
+- **Lacunas declaradas** (PT-02..PT-05, 11 hues v2, voice&tone) — agente sabe o que NÃO inventar
+
+### Negativas
+
+- ADR ponteiro duplica informação que já vive em UI-0013/0014 — risco de divergência se um for atualizado e outro não. Mitigação: linkam-se mutuamente, atualização sempre toca os 2 em mesmo PR.
+- Convenção "ADRs UI em `_DesignSystem/adr/ui/` + ponteiro em `decisions/`" não está documentada em nenhum lugar — depende de Wagner+Claude lembrarem. Mitigação: linha em CLAUDE.md futura, ou ADR sobre "convenção indexação MCP".
+
+### Neutras / a observar
+
+- Time MCP descobrir esta ADR depende de chamarem `brief-fetch` ou `decisions-search` numa sessão — não tem notificação push hoje
+- Próxima Claude Design vai propor sidebar dark de novo provavelmente — UI-0014 é a resposta canônica indexada
+- Se `decisions-search` MCP for atualizado pra indexar `_DesignSystem/adr/ui/` direto, esta ADR vira redundante mas continua válida
+
+## Pegadinhas conhecidas
+
+- **Não atualizar UI-0013 sem atualizar esta ADR também** (ou vice-versa). Append-only — mudança vira nova ADR `supersedes: [0187]`.
+- **PT-02 Form/Drawer** ainda não existe — quando criar, esta ADR ganha referência via amendment ou link em "Docs operacionais".
+- **Constituição v2 backend (ADR 0094)** é coisa diferente da Constituição UI v2 (UI-0013). Nomes parecidos, escopos disjuntos. Esta ADR é só sobre UI v2.
+
+## Referências
+
+- ADR UI-0013: [`memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md`](../requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md)
+- ADR UI-0014: [`memory/requisitos/_DesignSystem/adr/ui/0014-sidebar-light-mantida-v2-parcial.md`](../requisitos/_DesignSystem/adr/ui/0014-sidebar-light-mantida-v2-parcial.md)
+- PT-01 Lista: [`memory/requisitos/_DesignSystem/padroes-tela/PT-01-Lista.md`](../requisitos/_DesignSystem/padroes-tela/PT-01-Lista.md)
+- PRE-MERGE-UI: [`memory/requisitos/_DesignSystem/PRE-MERGE-UI.md`](../requisitos/_DesignSystem/PRE-MERGE-UI.md)
+- README DS: [`memory/requisitos/_DesignSystem/README.md`](../requisitos/_DesignSystem/README.md)
+- Proposal sidebar (decided): [`memory/decisions/proposals/2026-05-24-sidebar-dark-vs-light.md`](./proposals/2026-05-24-sidebar-dark-vs-light.md)
+- Handoff externo Claude Design v2: 2026-05-24 (sessão chat8 projeto Cowork "Constituição UI v2")
+- Sessão de aprovação: worktree `frosty-greider-83ab2f` 2026-05-24

--- a/memory/decisions/0187-constituicao-ui-v2-ponteiro-canon.md
+++ b/memory/decisions/0187-constituicao-ui-v2-ponteiro-canon.md
@@ -10,7 +10,7 @@ decided_by: [W]
 decided_at: "2026-05-24"
 accepted_at: "2026-05-24"
 accepted_via: "Wagner aprovou explícito em sessão `frosty-greider-83ab2f` 2026-05-24 — comando exato: 'eu aporvo' (UI-0013) + 'eu realmente gosto como esta hoje. não gostaria de mudar' (sidebar opção A → UI-0014)"
-module: _DesignSystem
+module: design-system
 quarter: 2026-Q2
 tags: [constituicao-ui, design-system, governança, hierarquia-camadas, ui-0013, ui-0014, mcp-discoverable, ponteiro-adr, multi-agent]
 supersedes: []

--- a/memory/decisions/proposals/2026-05-24-sidebar-dark-vs-light.md
+++ b/memory/decisions/proposals/2026-05-24-sidebar-dark-vs-light.md
@@ -1,0 +1,114 @@
+---
+proposal_id: sidebar-dark-vs-light
+status: decided
+decision: A
+created: 2026-05-24
+decided_at: 2026-05-24
+proposed_by: claude-code
+decided_by: wagner
+parent_adr: UI-0013 (Constituição UI v2)
+related_adrs: [UI-0008, UI-0009, UI-0014]
+resulting_adr: UI-0014
+type: conflito-camada-2-shell
+---
+
+# Proposta · Sidebar dark vs light — desempate explícito
+
+> **Status:** ✅ **DECIDED 2026-05-24 — opção A** (sidebar permanece light).
+> Comando exato do Wagner: *"eu realmente gosto como esta hoje. não gostaria de mudar"*.
+> Formalizada em **[ADR UI-0014](../../requisitos/_DesignSystem/adr/ui/0014-sidebar-light-mantida-v2-parcial.md)**.
+> Este doc fica como referência histórica do desempate.
+
+## Contexto
+
+A **Constituição UI v2** (handoff Claude Design 2026-05-24, sessão chat8) propõe **sidebar sempre dark, em qualquer tema** ([ADR 0041 v2](../../../.claude/worktrees/frosty-greider-83ab2f/_v2-tmp/project/06-decisoes/0041-sidebar-sempre-dark.md) — externa) — citando Stripe Dashboard, Vercel, Linear como benchmark. Argumento:
+
+1. **Diferenciação visual** — sidebar light vira parecido com filtros/toolbar, perde papel de "chrome de navegação"
+2. **Consistência de referência** — usuário sempre tem âncora visual à esquerda, mesmo trocando de tema
+3. **Cor de origem dos grupos** — hues `oklch(0.62 0.13 H)` precisam de fundo escuro pra contrastar; em fundo claro ficam diluídos
+
+O oimpresso JÁ TEM decisão oposta vigente: [**ADR UI-0009 Cockpit Sidebar Light padrão**](../../requisitos/_DesignSystem/adr/ui/0009-cockpit-sidebar-light-padrao.md), aceita 2026-05-04, **superseding parcial** o trecho "sidebar dark" da [UI-0008](../../requisitos/_DesignSystem/adr/ui/0008-cockpit-layout-mae-do-erp.md). Sidebar light foi escolha **explícita do Wagner** quando viu a versão dark inicial — comando registrado: "manter sidebar" (light).
+
+## Conflito
+
+| Aspecto | v2 (proposta) | oimpresso (vigente) |
+|---|---|---|
+| Cor sidebar base | dark fixo `oklch(0.21 0 0)` | light `data-theme` do usuário |
+| Tokens | `--sb-*` literais fora do `[data-theme="dark"]` | `--sb-*` herda `data-theme` |
+| Benchmark | Stripe, Vercel, Linear | Wagner-preference 2026-05-04 |
+| Cor grupos (Operação/Fiscal/etc) | `oklch(0.62 0.13 H)` brilha em dark | precisa hue/L ajustado em light |
+| Reversibilidade | trivial (toggle tokens) | trivial (toggle tokens) |
+| Impacto | shell único — afeta todas as telas | shell único — afeta todas as telas |
+
+## Por que isto não pode regredir silenciosamente
+
+Se um agente futuro (Claude DS, Claude Code, sucessor) ler a Constituição UI v2 e aplicar "dark sempre" sem ler UI-0009, **regressão automática** — Wagner perde a escolha que fez 2026-05-04. Esta proposta congela o estado e força desempate explícito.
+
+## Opções
+
+### Opção A · Manter UI-0009 (sidebar light)
+
+- ✅ Honra escolha explícita do Wagner 2026-05-04
+- ✅ Zero refactor — sidebar já vive light em produção há 20 dias
+- ✅ Cliente Larissa (biz=4 ROTA LIVRE) já habituou
+- ❌ Diverge de benchmark Stripe/Vercel/Linear
+- ❌ Hues dos grupos precisam ajuste se v2 incorporar paleta de 11 hues
+
+### Opção B · Adotar v2 (sidebar dark sempre)
+
+- ✅ Casa com benchmark global Stripe/Vercel/Linear
+- ✅ Diferenciação visual mais forte (sidebar = "chrome", main = "conteúdo")
+- ✅ Cor de grupos (`oklch(0.62 0.13 H)`) brilha mais
+- ❌ Reverte decisão Wagner 2026-05-04 — precisa ADR explícita `supersedes: [UI-0009]`
+- ❌ Larissa precisa reaprender visual (mitigação: avisar antes de deploy + fallback toggle no Aparência)
+- ❌ Refactor `cockpit.css` move `--sb-*` pra fora do `[data-theme="dark"]`
+
+### Opção C · Híbrido (toggle no Aparência)
+
+- ✅ Wagner não escolhe — usuário escolhe
+- ✅ Comporta ambas escolas
+- ❌ Token custodial: dobra superfície de teste (cada tela renderiza nos 2 modos)
+- ❌ Larissa não toca no toggle — fica no default da casa = volta ao problema "qual o default?"
+- ❌ Anti-padrão "ESM" (Excessive Setting Multiplication) — Anthropic skill `update-config` recomenda evitar setting que poucos usuários tocam
+
+### Opção D · Pendente (mantém UI-0009, posterga decisão)
+
+- ✅ Status quo · zero risco
+- ❌ Decisão volta a aparecer toda vez que um novo handoff Claude Design propor mudança
+- ❌ Constituição UI v2 fica "incompleta" no oimpresso até decidir
+
+## Recomendação técnica
+
+**Opção A** se prioridade é estabilidade + honrar histórico Wagner.
+**Opção B** se prioridade é adotar v2 integralmente + alinhar com Stripe.
+**Opção C** é tentação de "ter os dois" — geralmente vira dívida (`update-config` skill anti-padrão).
+**Opção D** evita decisão — pode acumular se outras propostas v2 dependerem desta.
+
+Eu recomendo **A ou B explícito, não C nem D**. Wagner decide qual com base em preferência atual.
+
+## Se A for escolhida
+
+1. ADR UI-0014 formaliza: "Constituição UI v2 adotada exceto sidebar dark — Wagner mantém UI-0009 light"
+2. v2 ADR 0041 entra como `historical` no oimpresso (referência, não vigente)
+3. PT-01-Lista.md atualiza tabela de tokens pra refletir light
+4. CHANGELOG apenda `DECISION · A · sidebar permanece light · Wagner`
+
+## Se B for escolhida
+
+1. ADR UI-0014 supersedes UI-0009 explicitamente
+2. `cockpit.css` move `--sb-*` pra fora de `[data-theme="dark"]`
+3. Smoke test em biz=4 ROTA LIVRE antes de deploy prod (Larissa)
+4. Bump v2.0.0 do DS (mudança Fundação/Shell breaking)
+5. ADR menciona "se feedback de fadiga visual em dark mode, considerar L: 0.16 ao invés de 0.21" (mitigação preventiva da v2)
+
+## Próximo passo
+
+Wagner abre PR de aprovação dessa proposta marcando **A** ou **B** no comentário. Claude Code cria ADR UI-0014 correspondente, atualiza CHANGELOG, e (se B) inicia refactor em PR separado.
+
+## Refs
+
+- [ADR UI-0008](../../requisitos/_DesignSystem/adr/ui/0008-cockpit-layout-mae-do-erp.md) — Cockpit layout-mãe (sidebar dark original)
+- [ADR UI-0009](../../requisitos/_DesignSystem/adr/ui/0009-cockpit-sidebar-light-padrao.md) — sidebar light padrão (vigente)
+- [ADR UI-0013](../../requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md) — Constituição UI v2 (aditiva)
+- ADR 0041 v2 (externa) — sidebar sempre dark
+- [ADR 0185](../0185-drawer-760-canon-entidades-cadastrais.md) — drawer 760 canônico (similar pattern de desempate)

--- a/memory/requisitos/_DesignSystem/AUTOMATION-ROADMAP.md
+++ b/memory/requisitos/_DesignSystem/AUTOMATION-ROADMAP.md
@@ -1,0 +1,274 @@
+---
+doc: AUTOMATION-ROADMAP
+camada: meta-protocolo
+status: planejado
+created: 2026-05-24
+parent_adr: UI-0013
+related_adrs: [UI-0013, UI-0014, 0187]
+target: subir enforcement de 30% → 90% automatizado
+estimate_total: 17-25h em 4 ondas
+quando_executar: "sob demanda · ondas independentes · cada onda vira PR"
+---
+
+# AUTOMATION-ROADMAP · Constituição UI v2
+
+> **Status:** planejado · nenhuma onda executada.
+> **Objetivo:** subir enforcement da [Constituição UI v2](adr/ui/0013-constituicao-ui-v2-camadas.md) de **~30% automatizado** (CI Module Grades + skills Tier A + CLAUDE.md SessionStart) pra **~90% automatizado** (CI lint + visual regression + LLM-judge). 10-20% restante é palpite estético — sempre humano.
+
+## Por que existe
+
+Wagner aprovou Constituição UI v2 em 2026-05-24 (PR #1438). Pergunta dele: *"isso vai pra minha rede MCP? minha equipe vai saber como operar. ou ainda depende de humano para não errar?"*. Resposta honesta: **70% disciplina humana**. Este roadmap é o caminho pra subir.
+
+Não é compromisso de execução. É **plano executável** — cada onda pode ser pegada em sessão dedicada, isolada, vira PR próprio.
+
+---
+
+## Estado atual (~30% automatizado)
+
+### ✅ O que JÁ enforça automaticamente
+
+| Mecanismo | Camada coberta | Como |
+|---|---|---|
+| **CLAUDE.md raiz** carrega no SessionStart | meta | Todo Claude novo lê passo 4 protocolo UI + seção Hierarquia UI v2 |
+| **Skill `mwart-process` Tier A v1.2** | 3-PT | Description-match em "migrar tela / Edit em Pages/" — cita PT-01 + PRE-MERGE-UI |
+| **Skill `multi-tenant-patterns` Tier A** | 4-Módulo | Força `business_id` global scope (ADR 0093) |
+| **Skill `commit-discipline` Tier A** | meta | 1 PR = 1 intent · ≤300 linhas · conventional commits |
+| **Skill `preflight-modulo`** (hook bloqueador) | 4-Módulo | Edit em `Modules/<X>/` exige leitura prévia SPEC/RUNBOOK |
+| **Module Grades Gate CI** | 4-Módulo | Bloqueia PR se nota módulo baixar vs baseline |
+| **Pest tests** | 4-Módulo | Quebram se mudança breaking detectada |
+| **ADR 0187 indexação MCP** | meta | `decisions-search "constituição"` retorna · `brief-fetch` lista decisão 24h |
+
+### ❌ O que NÃO enforça (depende de disciplina)
+
+- "Sidebar light, não dark" → só docs ([UI-0009](adr/ui/0009-cockpit-sidebar-light-padrao.md) + [UI-0014](adr/ui/0014-sidebar-light-mantida-v2-parcial.md))
+- "PT-01 tem 6 slots fixos" → só doc, não tem AST validando
+- "Não introduzir 6ª origin badge" → só doc
+- "Pedido vago, pergunte" → depende de agente seguir regra-mestre
+- "Hierarquia camadas — Módulo não toca Fundação" → só doc
+- "Cor hardcoded em Pages" → não tem grep CI ativo
+
+---
+
+## 🌊 Onda 1 — Fundação automação (~1h30) · sobe 30→50%
+
+### Item 1.1 · Skill `constituicao-ui-aware` Tier A
+
+**O que faz:** description-match em "Edit/Write em `resources/js/Pages/`", "criar tela nova", "tocar Components/shared/UI/". Carrega no contexto **antes do agente codar**:
+- UI-0013 chave (2 parágrafos: hierarquia 4 camadas + regra-mestre pedido vago)
+- PT aplicável conforme tipo de tela (Index = PT-01)
+- 8 anti-padrões PRE-MERGE-UI (AP1-AP8) em lista curta
+
+**Resultado:** próxima sessão Maiara/Felipe/qualquer Claude tocando Pages/ **não consegue mais esquecer** de aplicar a Constituição. Não substitui leitura completa — é gancho de atenção.
+
+**Esforço:** 30min · arquivo único `.claude/skills/constituicao-ui-aware/SKILL.md`
+
+**Onde:** branch `feat/skill-constituicao-ui-aware` · PR isolado
+
+### Item 1.2 · Artisan command `php artisan ui:lint` (esqueleto + 3 regras críticas)
+
+**O que faz:** scan de `resources/js/Pages/` + `resources/js/Components/shared/` aplicando regras:
+
+```php
+// app/Console/Commands/UiLint.php (NOVO)
+- Regra R1 (cor crua):
+  rg "(#[0-9a-fA-F]{3,8}|bg-(blue|red|green|amber|violet|orange)-\d{3})" Pages/
+  → falha se >0 hits (exceto #fff/#000 em comments)
+- Regra R2 (FontAwesome):
+  rg "from ['\"]@fortawesome" Pages/
+  → falha se >0 hits (lucide-only · UI-0003)
+- Regra R3 (emoji em UI):
+  rg "[😀-🙏🌀-🗿✨🇧🇷]" Pages/ Components/shared/
+  → falha se >0 hits (lucide icon, não emoji)
+```
+
+**Output:** lista de violações com path + linha + regra · exit code 1 se hit > 0
+
+**Esforço:** 1h · arquivo único PHP + integração `composer test`
+
+**Onde:** branch `feat/artisan-ui-lint` · PR isolado
+
+---
+
+## 🌊 Onda 2 — CI + pre-commit + PT-XX (~2-3h) · sobe 50→75%
+
+### Item 2.1 · GitHub Actions workflow `ui-lint.yml`
+
+**O que faz:** roda `php artisan ui:lint --strict` em PRs que tocam Pages/ ou Components/shared/. Falha CI se hit > 0. Comenta inline no PR com link pra cada violação.
+
+**Esforço:** 30min · `.github/workflows/ui-lint.yml` + reuso composer setup existente
+
+### Item 2.2 · Hook `.git/hooks/pre-commit`
+
+**O que faz:** roda `ui:lint` só em arquivos staged via `git diff --staged --name-only`. Pega regressão antes de chegar CI. Alerta amarelo (warning) por padrão · vermelho (block) se Wagner ativar via env.
+
+**Esforço:** 1h · script bash + `.husky/` ou direct `.git/hooks/` + doc em CLAUDE.md
+
+### Item 2.3 · Regras PT-01 lint
+
+**O que faz:** `php artisan ui:lint --pt=01` checa todo `Pages/<X>/Index.tsx`:
+- ✓ Importa `PageHeader` ou `<PageHeader>` em JSX (Slot 1)
+- ✓ Importa `DataTable` ou `<DataTable>` em JSX (Slot 5) — ou `<table>` se justificado
+- ⚠ Warning se não tem ModuleTopNav + BulkActionBar (Slots 2/4 opcionais)
+- ✗ Erro se tem `<h1>` hardcoded sem `<PageHeader>` (violação Slot 1)
+
+**Output:** "PT-01 violação: Pages/X/Index.tsx · Slot 1 (PageHeader) missing"
+
+**Esforço:** 1h · extensão do `ui:lint` command
+
+### Item 2.4 · Regra "não introduzir 6ª origin badge"
+
+**O que faz:** `php artisan ui:lint --origins` checa `resources/css/cockpit.css` + `inertia.css`:
+
+```bash
+# Token canon = exatamente 5 origins
+EXPECTED="OS|CRM|FIN|PNT|MFG"
+ACTUAL=$(rg -o "\-\-origin-(\w+)-bg" cockpit.css | sort -u)
+# Hit nova origin = falha
+```
+
+**Esforço:** 30min · regra trivial
+
+**Onde Ondas 2.x:** branch única `feat/ui-lint-ci-and-rules` · PR consolidado
+
+---
+
+## 🌊 Onda 3 — Descoberta MCP + visual regression (~4-6h) · sobe 75→85%
+
+### Item 3.1 · Webhook GitHub → MCP-notif
+
+**O que faz:** quando PR mergeia tocando `memory/requisitos/_DesignSystem/`, `Pages/` ou `Components/shared/`, dispara notificação para o time MCP (Felipe/Maiara/Eliana/Luiz) via tool MCP `team-notify` ou Slack canal #design-system.
+
+**Mensagem:**
+```
+🎨 UI canônica atualizada · PR #NNNN
+Tocou: <arquivos>
+ADR aplicável: <UI-XXXX>
+Próxima brief-fetch reflete · ou acesse: <link PR>
+```
+
+**Esforço:** 4h · `.github/workflows/notify-mcp.yml` + endpoint MCP-notif (precisa existir ou criar) + template mensagem
+
+**Dependência externa:** endpoint MCP `team-notify` precisa existir no mcp-server. Hoje provavelmente **não existe** — precisa scope MCP-server primeiro.
+
+### Item 3.2 · Visual regression (Playwright trace OU Percy/Chromatic free tier)
+
+**O que faz:** snapshot pixel-diff de telas críticas em PR. Rejeita drift visual silencioso. Implementação:
+- Playwright trace built-in (gratuito, runs em CI) — screenshots de 5-10 telas-âncora pré e pós-merge
+- OU Percy/Chromatic free tier (até 5k snapshots/mês free) — mais maduro, integração GitHub nativa
+
+**Telas-âncora:** Sells/Index, Cliente/Index, Financeiro, Fiscal (4 telas-lista representativas) + Cliente drawer aberto (PT-02 quando existir)
+
+**Esforço:** 6-8h · CI infrastructure + baseline screenshots + auto-update workflow
+
+**Dependência:** Playwright já instalado? Verificar `package.json`. Se não, scope = adicionar dep + setup primeiro.
+
+**Onde Ondas 3.x:** branches separadas — `feat/webhook-mcp-notif` e `feat/visual-regression-playwright`
+
+---
+
+## 🌊 Onda 4 — LLM-as-judge (~1-2 dias) · sobe 85→90%
+
+### Item 4.1 · Agente CI `pr-ui-judge`
+
+**O que faz:** GitHub Action dispara em PR que toca UI. Carrega no contexto LLM (Brain B Sonnet):
+- Constituição UI v2 completa (UI-0013 + UI-0014 + PT-01-Lista.md ~30k tokens)
+- Diff do PR
+- 9 dimensões de scoring (slot adherence, hierarquia respeitada, anti-padrões grep-invisíveis, copy PT-BR, acessibilidade básica)
+
+**Output:** comentário inline no PR:
+```
+[PR-UI-JUDGE · score 87/100]
+
+✅ PT-01 6 slots respeitados
+✅ Token canon aplicado (sem cor crua)
+⚠ Slot 4 (BulkBar) ausente — opcional, mas Sells aplica
+✗ Drawer aberto sem `<Sheet>` shadcn — usa <div> custom (PRE-MERGE-UI AP2)
+
+Sugestões: ...
+```
+
+**Esforço:** 1-2 dias · agent implementation (Laravel command + LLM client existente `App\Services\Copiloto\ClaudeClient`) + workflow CI + tuning prompt
+
+**Custo:** Brain B Sonnet ~$0.03/PR (média 10k tokens input + 1k output) · ~$3/mês a 100 PRs/mês
+
+### Item 4.2 · Skill `pr-ui-judge-manual` (Wagner-invoke)
+
+**O que faz:** Wagner em qualquer sessão pode rodar `/pr-ui-judge <PR#>` pra forçar judge LLM sem esperar CI.
+
+**Esforço:** 2h · skill description + integração API GitHub + reuso pr-ui-judge
+
+**Onde:** branch `feat/llm-as-judge-pr-ui` · PR isolado · provavelmente sub-PRs (CI + skill)
+
+---
+
+## O que NÃO automatiza (10-20% sempre humano)
+
+| Categoria | Por quê fica humano |
+|---|---|
+| "Tipo Stripe / deixa bonito" | Palpite estético — regra-mestre força pergunta mas não substitui Wagner |
+| Desempate entre 2 ADRs em conflito | Caso sidebar dark vs light · Wagner explícito |
+| Quando criar PT-XX novo (PT-02, PT-03...) | Depende ≥2 módulos pedirem · sinal humano |
+| Aposentar padrão / ADR | Decisão estratégica · Wagner aprova |
+| Voice & tone (copy criativa) | Carioca-startup direto · gosto humano |
+| Larissa-fit (cliente real) | Smoke test biz=4 ROTA LIVRE · Wagner valida |
+
+---
+
+## Critério de start por onda
+
+Quando começar cada onda? Sinal claro, não cronograma:
+
+| Onda | Critério "vale start" |
+|---|---|
+| **1** | **Sempre.** Custo baixo · valor alto · faz sozinha. Roda em qualquer sessão de 1h30 |
+| **2** | Quando primeira regressão real aparecer (Maiara/Felipe/qualquer Claude introduzir cor crua em PR) · OU 1 sprint depois de Onda 1 estabilizar |
+| **3** | Quando time MCP tiver ≥3 ativos (hoje Wagner trabalha sozinho com Claude — notif pra "ninguém" não vale) · OU visual drift detectado manualmente em 2+ módulos |
+| **4** | Quando custo Brain B já estiver mapeado em `copiloto.admin.custos` (existe?) · OU Onda 2 não pegar 5+ tipos de regressão semântica em 30 dias |
+
+---
+
+## Ordem recomendada de execução
+
+```
+hoje ──→ Onda 1 (skill + ui:lint esqueleto)        1h30
+         ↓
+sprint+1 → Onda 2 (CI + hook + PT-01 + origins)    2-3h
+         ↓
+quando ≥2 sinais ──→ Onda 3.1 (webhook MCP)        4h
+         ↓
+quando módulos UI maduros ──→ Onda 3.2 (visual)    6-8h
+         ↓
+último (alto investimento) ──→ Onda 4 (LLM judge)  1-2d
+```
+
+## Custos cumulativos
+
+| Pós-onda | Esforço total | % Automatizado | Custo running mensal |
+|---|---|---|---|
+| Onda 1 | 1h30 | 50% | $0 (skill + lint local) |
+| + Onda 2 | 4h | 75% | $0 (CI já existe) |
+| + Onda 3 | 10h | 85% | $0 (Playwright trace) ou ~$0 (Percy free tier) |
+| + Onda 4 | 1-2d | 90% | ~$3/mês (LLM judge 100 PRs) |
+
+---
+
+## Quando esta ADR vira obsoleta
+
+Quando 90% automatizado virar realidade — este doc move pra `historical/` com nota *"superseded by automation real"*. ADRs operacionais individuais (skill, ui:lint command, CI workflow) ficam vivas.
+
+---
+
+## Refs
+
+- **ADR-mãe Constituição UI v2:** [`adr/ui/0013-constituicao-ui-v2-camadas.md`](adr/ui/0013-constituicao-ui-v2-camadas.md)
+- **Ponteiro MCP:** [`memory/decisions/0187-constituicao-ui-v2-ponteiro-canon.md`](../../decisions/0187-constituicao-ui-v2-ponteiro-canon.md)
+- **PR onde foi proposto:** [#1438](https://github.com/wagnerra23/oimpresso.com/pull/1438)
+- **Sessão de origem:** worktree `frosty-greider-83ab2f` · 2026-05-24
+- **PRE-MERGE-UI checklist atual:** [`PRE-MERGE-UI.md`](PRE-MERGE-UI.md)
+- **PT-01 (lint target Onda 2):** [`padroes-tela/PT-01-Lista.md`](padroes-tela/PT-01-Lista.md)
+- **Skills correlatas existentes:** `mwart-process` v1.2 · `preflight-modulo` · `commit-discipline` · `multi-tenant-patterns`
+
+---
+
+**Última revisão:** 2026-05-24 · proposta inicial · zero ondas executadas.
+**Próxima revisão:** quando Wagner executar Onda 1 (atualizar com timestamps reais + resultados).

--- a/memory/requisitos/_DesignSystem/CHANGELOG.md
+++ b/memory/requisitos/_DesignSystem/CHANGELOG.md
@@ -1,5 +1,62 @@
 # Changelog · Design System
 
+## [0.6.1] - 2026-05-24 · Wagner aprova v2 + desempate sidebar (opção A · light mantido)
+
+### Changed
+
+- **ADR UI-0013** status `proposed` → `accepted`. Wagner aprovou explícito ("eu aporvo") em 2026-05-24. Constituição UI v2 oficialmente adotada (hierarquia 4 camadas + regra-mestre + vocabulário + PT-01 + PRE-MERGE-UI).
+- **proposal [sidebar-dark-vs-light](../../decisions/proposals/2026-05-24-sidebar-dark-vs-light.md)** status `discussion` → `decided`. Opção **A** escolhida (manter UI-0009 light). Comando Wagner: *"eu realmente gosto como esta hoje. não gostaria de mudar"*.
+
+### Added
+
+- **ADR UI-0014** [sidebar-light-mantida-v2-parcial](adr/ui/0014-sidebar-light-mantida-v2-parcial.md): formaliza desempate. Constituição UI v2 adotada **integralmente exceto trecho "sidebar dark sempre"**. UI-0009 (sidebar light padrão) confirmada vigente. v2 ADR 0041 externa entra como referência rejeitada. Zero refactor de código — `cockpit.css` intacto.
+
+### Não regrediu
+
+- Nenhum token `--sb-*` movido — UI-0009 segue vigente.
+- Nenhuma página Inertia tocada.
+- UI-0008 (Cockpit layout-mãe) e UI-0009 (sidebar light) **permanecem aceitas** — UI-0014 confirma, não substitui.
+
+### Não fez (intencional)
+
+- Migração 5 origin badges → 11 hues semânticos v2 — sem ADR específica (próxima decisão Wagner se quiser)
+- PT-02..PT-05 — abrem ADR cada um quando ≥2 módulos pedirem
+- Update `CLAUDE.md` raiz citando UI-0013 Tier A — pendente, Wagner pode pedir
+- Voice & tone formalizado · animação tokens — sem dor que justifique ainda
+
+## [0.6.0] - 2026-05-24 · Constituição UI v2 incorporada
+
+### Added
+
+- **ADR UI-0013**: Constituição UI v2 — hierarquia de 4 camadas (Fundações → Shell → Padrão de Tela → Módulo) com princípio "camada superior herda e nunca contradiz". Regra-mestre "não-gastar-tokens-com-pedido-vago" + vocabulário canônico de pedido. Status: `proposed` (aguarda Wagner). Origem: handoff Claude Design 2026-05-24 (sessão chat8 projeto Cowork "Constituição UI v2").
+- **`padroes-tela/PT-01-Lista.md`** (NOVA PASTA `padroes-tela/` + primeiro doc canônico): template de 6 slots (PageHeader, ModuleTopNav, Toolbar, BulkBar, Table, Drawer) com DNA por slot, regras de ouro, estados obrigatórios, atalhos canônicos, snippet pronto. Documenta paridade de 12 telas-lista que JÁ implementam o padrão (Sells/Cliente/Compras/Purchase/Repair/etc) — não introduz mudança visual.
+- **`PRE-MERGE-UI.md`**: checklist obrigatório por camada (1-Fundações/2-Shell/3-PT/4-Módulo/5-Protocolo/6-ADR) antes de PR que toca UI. Anti-padrões AP1-AP8 (cor hardcoded, componente reinventado, localStorage sem prefixo, ícone fora lucide, gradient decorativo, emoji UI, bg-fill status badge, copy não-PT-BR). Sinais de regressão "alerte Wagner, não corrija silenciosamente".
+- **`memory/decisions/proposals/2026-05-24-sidebar-dark-vs-light.md`** (proposal, não ADR ainda): conflito formal entre v2 ADR 0041 (dark sempre) vs UI-0009 vigente (light padrão). 4 opções (A manter light · B adotar dark · C híbrido toggle · D postergar) com recomendação A ou B explícito. Wagner desempata.
+
+### Changed
+
+- **`README.md`** (DS root) — adicionada seção "Hierarquia de 4 camadas" + ponteiros pra UI-0013, PT-01, PRE-MERGE-UI. Índice expandido. Mantém estrutura anterior.
+
+### Não regrediu
+
+- Nenhuma ADR UI-0001..UI-0012 alterada — UI-0013 é **aditiva**.
+- Nenhum token CSS canon (`cockpit.css`, `inertia.css`) tocado nesta entrega.
+- Nenhuma Page Inertia ou Component shared modificado.
+- Sidebar UI-0009 (light) permanece vigente até Wagner decidir proposal.
+
+### Não fez (lacunas explícitas)
+
+- PT-02 Form/Drawer · PT-03 Detalhe · PT-04 Dashboard · PT-05 Config — abrir ADR quando ≥2 módulos pedirem
+- Migração 5 origin badges → 11 hues semânticos da v2 — sem ADR específica
+- Voice & tone formalizado · iconografia stroke sizes · animação tokens — sem dor que justifique
+
+### Skills correlatas (não tocadas, só citadas)
+
+- `mwart-process` (Tier A) — segue válida, ganha referência futura à PT-01
+- `charter-first` (Tier A · dormente S4) — segue válida
+- `wagner-request-refiner` + agente `wagner-understand` — operacionalizam regra-mestre da UI-0013
+- `commit-discipline` (Tier A) — aplicada nesta entrega (1 PR = 1 intent, ≤300 linhas, conventional commits)
+
 ## [0.5.0] - 2026-05-05 (tarde)
 
 ### Added

--- a/memory/requisitos/_DesignSystem/CHANGELOG.md
+++ b/memory/requisitos/_DesignSystem/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog · Design System
 
+## [0.6.2] - 2026-05-24 · AUTOMATION-ROADMAP planejado (4 ondas · 30→90%)
+
+### Added
+
+- **[AUTOMATION-ROADMAP.md](AUTOMATION-ROADMAP.md)**: plano executável de 4 ondas pra subir enforcement da Constituição UI v2 de **~30% automatizado** (hoje) pra **~90%** (alvo).
+  - **Onda 1** (1h30 · sobe 30→50%): skill `constituicao-ui-aware` Tier A + artisan `php artisan ui:lint` esqueleto com 3 regras (cor crua, FontAwesome, emoji UI)
+  - **Onda 2** (2-3h · sobe 50→75%): GitHub Actions `ui-lint.yml` + hook pre-commit + regras PT-01 + "não introduzir 6ª origin"
+  - **Onda 3** (4-6h · sobe 75→85%): webhook GitHub → MCP-notif + visual regression (Playwright/Percy)
+  - **Onda 4** (1-2d · sobe 85→90%): agente CI `pr-ui-judge` (LLM Brain B Sonnet ~$3/mês a 100 PRs)
+- Critério de start explícito por onda (não cronograma — sinal real, e.g. "primeira regressão de cor crua aparece")
+- 10-20% sempre humano declarado (palpite estético · desempate ADR · voice&tone · Larissa-fit)
+
+### Status
+
+- Plano: **planejado · zero ondas executadas**
+- Quando: sob demanda · ondas independentes · cada uma vira PR isolado
+- Wagner decide ordem · pode pular ondas se sinal não justificar (Onda 3 depende time MCP >3 ativos)
+
+### Não regrediu
+
+- Nenhum código de produção tocado nesta entrega
+- ADRs UI-0013 + UI-0014 + ADR 0187 + PT-01 + PRE-MERGE-UI permanecem vigentes
+
 ## [0.6.1] - 2026-05-24 · Wagner aprova v2 + desempate sidebar (opção A · light mantido)
 
 ### Changed

--- a/memory/requisitos/_DesignSystem/PRE-MERGE-UI.md
+++ b/memory/requisitos/_DesignSystem/PRE-MERGE-UI.md
@@ -1,0 +1,145 @@
+---
+doc: PRE-MERGE-UI
+camada: meta
+status: ativo
+created: 2026-05-24
+parent_adr: UI-0013
+---
+
+# PRE-MERGE UI · checklist por camada antes de PR
+
+> **Quando aplicar:** todo PR que toca `resources/js/Pages/`, `resources/js/Components/`, `resources/css/`, `tailwind.config.*`, ou `memory/requisitos/_DesignSystem/`.
+> **Tempo:** ~3 min de revisão mental.
+> **Se algum item falhar:** comunique Wagner antes de mergear, **não corrija silenciosamente**.
+
+Checklist deriva da **hierarquia de 4 camadas** ([ADR UI-0013](adr/ui/0013-constituicao-ui-v2-camadas.md)). Cada camada tem regras específicas — só roda a seção da camada que você tocou.
+
+---
+
+## Camada 1 · Fundações (`resources/css/inertia.css`, `cockpit.css`, tailwind config)
+
+**Critério-gatilho:** tocou cor/fonte/espaço/sombra/radius em CSS canon.
+
+- [ ] Existe **ADR UI aprovada por Wagner** pra essa mudança? Se não, **PARE** — abre ADR `06-decisoes/proposals/` antes de codar.
+- [ ] Token novo segue **fórmula canônica**:
+  - Cor: `oklch(L C H)` ([ADR 0043 v2](../../../.claude/worktrees/frosty-greider-83ab2f/_v2-tmp/project/06-decisoes/0043-oklch-espaco-cor.md) — quando incorporada como UI-0014)
+  - Espaço: múltiplo de 4 (`4px`, `8px`, `12px`, `16px`, `20px`, `24px`, `32px`)
+  - Tipografia: IBM Plex Sans/Mono ([UI-0001](adr/ui/0001-tailwind-4-como-fundacao-css.md))
+- [ ] Não introduzi cor crua (`#hex`, `rgb()`, `hsl()` literal) fora de `#fff` e `#000`
+- [ ] Token é **semântico**, não estético (ex: `--accent`, não `--azul-1`)
+- [ ] Bumped versão do DS no `CHANGELOG.md` (Fundação muda = mínimo v0.X → v0.Y; breaking = v0 → v1)
+- [ ] Não regrediu nenhuma ADR já aceita (UI-0001 a UI-0013) sem `supersedes:` explícito
+
+## Camada 2 · Shell (`AppShellV2.tsx`, `PageHeader.tsx`, `ModuleTopNav.tsx`, `Sidebar.tsx`)
+
+**Critério-gatilho:** mudança no chrome universal do app (não por tela).
+
+- [ ] Mudança **não muda por tela** — é universal a todo módulo
+- [ ] ADR existente (UI-0008, UI-0011, UI-0009) **lida antes** de modificar
+- [ ] Se quebra contrato (ex: tira slot, adiciona slot, muda comportamento default), **abriu ADR nova**
+- [ ] Sidebar não virou light se ADR-0009 ainda vigente (ou virou e proposal `sidebar-dark-vs-light` foi aceita)
+- [ ] `localStorage` segue prefixo `oimpresso.cockpit.*` ([UI-0011](adr/ui/0011-sidebar-single-pane-cascata-user-menu.md))
+- [ ] Charter `.charter.md` atualizado se mudou contrato visual
+- [ ] CHANGELOG apendado
+
+## Camada 3 · Padrão de Tela (`memory/requisitos/_DesignSystem/padroes-tela/PT-XX-*.md`)
+
+**Critério-gatilho:** criou ou alterou doc canônico de PT-01..PT-XX.
+
+- [ ] Doc segue formato canônico (`PT-01-Lista.md` como template — anatomia + DNA + regras + snippet + casos limite + refs)
+- [ ] Lista "Aplicado em" reflete **estado real** dos módulos (rodar `grep` ou inventário se incerto)
+- [ ] Mudança breaking? Lista módulos a refatorar + abre ADR
+- [ ] Adicionou variante? Documentou em seção "Variantes" sem mudar anatomia base
+- [ ] Frontmatter `versao:` bumpado (v1.0 → v1.1 minor; v1 → v2 breaking)
+- [ ] CHANGELOG apendado com linha `ADD PT-XX vN.M`
+
+## Camada 4 · Módulo (`Modules/<X>/`, `resources/js/Pages/<X>/*.tsx`)
+
+**Critério-gatilho:** tocou Page Inertia ou Component específico de módulo.
+
+### Anti-padrões (KB-9.75)
+
+- [ ] **AP1** Sem cor hardcoded · `rg -E "(#[0-9a-fA-F]{3,8}|oklch\(0\.\d+ \d+\.\d+ \d+)" resources/js/Pages/<X>/` retorna 0 ocorrências (excetuando comments e `#fff`/`#000`)
+- [ ] **AP2** Componentes vêm do shared · sem reinventar `<Table>`, `<Drawer>`, `<PageHeader>`, `<DataTable>`, `<BulkActionBar>`, `<EmptyState>`, `<StatusBadge>`
+- [ ] **AP3** `localStorage` sempre prefixado `oimpresso.<modulo>.*` ([ADR 0093 multi-tenant Tier 0](../../decisions/0093-multi-tenant-isolation-tier-0.md))
+- [ ] **AP4** Sem ícone fora do `lucide-react` ([UI-0003](adr/ui/0003-lucide-react-como-unica-iconografia.md))
+- [ ] **AP5** Sem gradient decorativo 135deg (bluish-purple) — anti-trope DS
+- [ ] **AP6** Sem emoji em UI de produto (só ícone SVG do lucide)
+- [ ] **AP7** Sem `bg-fill` em status badges — usa dot + texto colorido (Stripe-style)
+- [ ] **AP8** PT-BR em todo label, copy, erro, mensagem
+
+### Estrutural
+
+- [ ] Charter `.charter.md` ao lado do `.tsx` existe e está `status: live` (skill `charter-first` Tier A)
+- [ ] Inertia::defer aplicado em props pesadas (skill `inertia-defer-default`)
+- [ ] Multi-tenant Tier 0 — query usa `business_id` global scope ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md))
+- [ ] PT-01 (ou PT-XX aplicável) segue 6 slots — documentado em `04-modulos/<x>/OWNERS.md` (futuro) ou na charter
+
+### Métricas
+
+- [ ] Score Module Grade v4 **não baixou** vs `governance/module-grades-baseline.json` — se baixou, **NÃO** sobrescreve baseline, alerta Wagner
+- [ ] Pest tests cobrem mudança visual crítica
+- [ ] Smoke test em https://oimpresso.com (biz=4 ROTA LIVRE Larissa) se mudança visível ao cliente
+
+## Camada 5 · Protocolo (KB-9.75, governance, rubric)
+
+**Critério-gatilho:** alterou rubric, AUDIT_PROTOCOL, governance, ADR template.
+
+- [ ] Mudança no rubric tem ADR? (rubric é régua — mudar régua exige justificativa)
+- [ ] Versão da rubric incrementada se mudou peso/feature/anti-padrão
+- [ ] CHANGELOG apendado
+
+## Camada 6 · Decisões (`memory/requisitos/_DesignSystem/adr/ui/NNNN-*.md`)
+
+**Critério-gatilho:** criou ADR UI nova ou alterou existente.
+
+- [ ] Template seguido (formato Nygard — Status/Data/Categoria/Refs + Contexto/Decisão/Consequências)
+- [ ] Numeração sequencial (próximo número livre — `ls adr/ui/ | tail`)
+- [ ] Status correto: `proposed` (aguardando Wagner) | `accepted` | `superseded` | `deprecated` | `historical`
+- [ ] Append-only — se substituindo ADR anterior, marca `supersedes: [N]` e a antiga ganha `superseded_by: [M]`, **nunca apaga**
+- [ ] CHANGELOG apendado com linha `ADR UI-NNNN <título>`
+
+---
+
+## Universal · sempre verificar
+
+- [ ] **Commit-discipline** ([skill](../../../.claude/skills/commit-discipline/SKILL.md)) — 1 PR = 1 intent · ≤300 linhas · conventional commits · sem PII em código/log/commit msg
+- [ ] CHANGELOG tem linha(s) do trabalho desta sessão
+- [ ] Nenhum arquivo deletado sem ADR (deleção = mudança estrutural)
+- [ ] Nenhuma renomeação de path sem `MOVE` no CHANGELOG
+- [ ] Se mudou UI visível em produção, screenshot anexado ao PR (smoke evidence — [skill `smoke-prod-evidence`](../../../.claude/skills/smoke-prod-evidence/))
+
+---
+
+## Sinais de regressão · alertar Wagner (não corrige silenciosamente)
+
+- Score KB-9.75 / Module Grade v4 de um módulo baixou
+- Token sendo usado fora da camada permitida (ex: `--sb-bg` em arquivo de módulo)
+- Hardcoded color/font/spacing em arquivo de módulo
+- Componente novo reinventando algo do shared
+- ADR sendo contradita silenciosamente
+- Charter `.charter.md` ficou desatualizado vs `.tsx` (drift)
+
+**Pare. Reporte. Não corrija silenciosamente.**
+
+---
+
+## Por que esse checklist existe
+
+Sem ele, qualquer agente (Claude DS, Claude Code, agente externo) pode regredir o sistema sem perceber. Wagner é único humano + único aprovador — **disciplina é código**.
+
+Inspirado em:
+- Constituição UI v2 (handoff Claude Design 2026-05-24)
+- KB-9.75 rubric (5 categorias + 8 anti-padrões)
+- Loop Design↔Code [PROTOCOL.md](../../../prototipo-ui/PROTOCOL.md) 7 fases
+
+## Refs
+
+- **ADR-mãe**: [UI-0013 Constituição UI v2](adr/ui/0013-constituicao-ui-v2-camadas.md)
+- **Template ADR**: [`adr/ui/`](adr/ui/) (próximo número: 0014)
+- **PT-01 canon**: [`padroes-tela/PT-01-Lista.md`](padroes-tela/PT-01-Lista.md)
+- **Skills correlatas**: `commit-discipline` · `mwart-quality` · `multi-tenant-patterns` · `inertia-defer-default` · `charter-first` · `module-completeness-audit`
+
+---
+
+**Última revisão:** 2026-05-24

--- a/memory/requisitos/_DesignSystem/README.md
+++ b/memory/requisitos/_DesignSystem/README.md
@@ -6,28 +6,133 @@ migration_target: N/A
 migration_priority: alta
 risk: baixo
 areas: [ui, tokens, componentes, acessibilidade]
-last_generated: 2026-04-22
-version: 0.1
+last_generated: 2026-05-24
+version: 0.6
+parent_adr: UI-0013
 ---
 
 # Design System (cross-cutting)
 
 Decisões de UI que atravessam todos os módulos — tokens Tailwind 4, componentes shadcn/ui, iconografia lucide, dark mode, acessibilidade e convenções visuais.
 
-## Propósito
-
-Hoje cada módulo decide seu CSS isoladamente. Isso gera drift: `border-border` em um lugar, `border` em outro; `text-muted-foreground` vs `text-gray-500`; bolhas de chat vs cards genéricos. Este módulo virtual consolida as decisões visuais num só lugar, com ADRs rastreáveis.
-
 **NÃO é um módulo Laravel** — não tem controller, rota nem migration. É pasta de documentação cross-cutting.
 
-## Índice
+---
 
+## Hierarquia de 4 camadas (ADR UI-0013 · Constituição UI v2)
+
+> **Princípio único:** uma camada superior **herda** das inferiores e **nunca contradiz**. Módulo não cria token, padrão não muda shell, shell não toca fundações sem ADR.
+
+```
+┌─────────────────────────────────────────────────────┐
+│  4 · MÓDULO          Crm · Fiscal · Financeiro...   │  ← varia
+├─────────────────────────────────────────────────────┤
+│  3 · PADRÃO DE TELA  PT-01 Lista · PT-02 Form...    │  ← 5-7 templates fixos
+├─────────────────────────────────────────────────────┤
+│  2 · SHELL           AppShellV2 · PageHeader...     │  ← 1× pro app inteiro
+├─────────────────────────────────────────────────────┤
+│  1 · FUNDAÇÕES       Tokens (cor · tipo · espaço)   │  ← imutável (ADR)
+└─────────────────────────────────────────────────────┘
+```
+
+| Camada | Quem pode mudar | Não pode mudar |
+|---|---|---|
+| **4 · Módulo** | colunas, regras, dados, copy de negócio | nada da camada 1-3 |
+| **3 · Padrão de Tela** | slots internos, estados, variantes documentadas | tokens, shell |
+| **2 · Shell** | item ativo no sidebar, breadcrumb no header | tokens |
+| **1 · Fundações** | adicionar token via **ADR explícita** | nada sem ADR |
+
+**Hierarquia de override (conflito):** Fundações > Shell > PT > Módulo (a de baixo vence).
+
+---
+
+## Onde está cada coisa
+
+### Camada 1 · Fundações (tokens canônicos)
+
+- **Tokens reais** → [`resources/css/inertia.css`](../../../resources/css/inertia.css) (light/dark, slate+blue) + [`cockpit.css`](../../../resources/css/cockpit.css) (oklch hues sidebar)
+- **Tailwind v4 setup** → [UI-0001](adr/ui/0001-tailwind-4-como-fundacao-css.md)
+- **shadcn/ui** → [UI-0002](adr/ui/0002-shadcn-ui-copy-paste-em-vez-de-npm.md)
+- **lucide-react** (icones únicos) → [UI-0003](adr/ui/0003-lucide-react-como-unica-iconografia.md)
+- **Dark mode user-toggle** → [UI-0004](adr/ui/0004-dark-mode-por-usuario-via-classe-html.md)
+
+### Camada 2 · Shell (chrome universal)
+
+- **AppShellV2** → [`resources/js/Layouts/AppShellV2.tsx`](../../../resources/js/Layouts/AppShellV2.tsx)
+- **PageHeader canon** → [`Components/shared/PageHeader.tsx`](../../../resources/js/Components/shared/PageHeader.tsx) + [ADR 0182](../../decisions/) + skill [`pageheader-canon`](../../../.claude/skills/pageheader-canon/SKILL.md)
+- **Cockpit layout-mãe** → [UI-0008](adr/ui/0008-cockpit-layout-mae-do-erp.md)
+- **Sidebar light padrão** → [UI-0009](adr/ui/0009-cockpit-sidebar-light-padrao.md) (Wagner-explícito 2026-05-04) · **proposal de desempate v2 dark** → [proposals/2026-05-24-sidebar-dark-vs-light.md](../../decisions/proposals/2026-05-24-sidebar-dark-vs-light.md)
+- **Sidebar single-pane + user menu cascata** → [UI-0011](adr/ui/0011-sidebar-single-pane-cascata-user-menu.md)
+- **Skill correlata** → [`sidebar-menu-arch`](../../../.claude/skills/sidebar-menu-arch/SKILL.md)
+
+### Camada 3 · Padrão de Tela (templates)
+
+- **PT-01 Lista** → [`padroes-tela/PT-01-Lista.md`](padroes-tela/PT-01-Lista.md) — 6 slots, 12+ telas aplicam
+- **PT-02 Form/Drawer** → ainda não documentado · candidato pra próximo (drawer 760px já implementado em [ADR 0179](../../decisions/0179-cliente-drawer-760px-substitui-show-fullpage.md), [ADR 0185](../../decisions/0185-drawer-760-canon-entidades-cadastrais.md))
+- **PT-03 Detalhe** → não documentado
+- **PT-04 Dashboard** → não documentado
+- **PT-05 Configuração** → não documentado
+- **Pattern operacional original** (vira PT-01) → [UI-0006](adr/ui/0006-padrao-tela-operacional.md)
+
+### Camada 4 · Módulo (instâncias)
+
+- Cada módulo vive em `Modules/<X>/` + `resources/js/Pages/<X>/`
+- Charter `.charter.md` ao lado de cada `.tsx` (skill `charter-first` Tier A)
+- Listagem das 12 telas-lista que seguem PT-01 → ver [`PT-01-Lista.md` seção "Aplicado em"](padroes-tela/PT-01-Lista.md#aplicado-em-estado-real)
+
+### Camada 5 · Protocolo (avaliação e governança)
+
+- **KB-9.75** método de avaliação → [`memory/requisitos/_DesignSystem/audits/`](audits/) + skill [`module-completeness-audit`](../../../.claude/skills/module-completeness-audit/SKILL.md)
+- **Module Grade v4** (CI gate) → `governance/module-grades-baseline.json` + skill [`module-grades-gate`](../../../.claude/skills/module-grades-gate/SKILL.md)
+- **PRE-MERGE-UI checklist** → [`PRE-MERGE-UI.md`](PRE-MERGE-UI.md) ← anti-regressão por camada
+- **Loop Design↔Code formal** → [`prototipo-ui/PROTOCOL.md`](../../../prototipo-ui/PROTOCOL.md) (7 fases)
+
+### Camada 6 · Decisões (ADRs)
+
+- **ADRs UI** → [`adr/ui/`](adr/ui/) (UI-0001 a UI-0013 hoje)
+- **ADRs raiz cross-cutting** → [`memory/decisions/`](../../decisions/)
+- **Propostas em discussão** → [`memory/decisions/proposals/`](../../decisions/proposals/)
+
+---
+
+## Como ler / como pedir (vocabulário canônico)
+
+| Pedido vago ❌ | Pedido determinístico ✅ |
+|---|---|
+| "faz uma tela de cobranças" | "aplica **PT-01 Lista** no módulo Recorrente, colunas X/Y/Z" |
+| "muda a cor pra ficar igual fiscal" | "usa **token Fundações** `--origin-FIN-bg`" |
+| "o sidebar tá diferente" | "**replicar Shell-Sidebar** (AppShellV2) sem modificar" |
+| "deixa bonito" | "**aplica KB-9.75** e me mostra o score + top 3 gaps" |
+
+Agente segue a regra-mestre da [UI-0013](adr/ui/0013-constituicao-ui-v2-camadas.md): **se pedido não aponta camada+artefato+mudança, pergunta antes de implementar.**
+
+---
+
+## Ordem de leitura pra novo agente (humano ou IA)
+
+1. **[adr/ui/0013-constituicao-ui-v2-camadas.md](adr/ui/0013-constituicao-ui-v2-camadas.md)** — ADR-mãe (10 min)
+2. **[padroes-tela/PT-01-Lista.md](padroes-tela/PT-01-Lista.md)** — template canônico (10 min)
+3. **[PRE-MERGE-UI.md](PRE-MERGE-UI.md)** — checklist antes de mergear (3 min)
+4. **[ARCHITECTURE.md](ARCHITECTURE.md)** — stack visual (5 min)
+5. **[SPEC.md](SPEC.md)** — regras R-DS-001..R-DS-016 (10 min)
+6. **[CHANGELOG.md](CHANGELOG.md)** — últimas 3 entradas (5 min)
+7. **[adr/ui/](adr/ui/)** UI-0001..UI-0012 — se precisar de contexto histórico
+
+---
+
+## Índice de docs nesta pasta
+
+- **[adr/ui/0013-constituicao-ui-v2-camadas.md](adr/ui/0013-constituicao-ui-v2-camadas.md)** ← ADR-mãe (Constituição v2)
+- **[padroes-tela/PT-01-Lista.md](padroes-tela/PT-01-Lista.md)** ← camada 3 primeiro template
+- **[PRE-MERGE-UI.md](PRE-MERGE-UI.md)** ← checklist anti-regressão
 - **[ARCHITECTURE.md](ARCHITECTURE.md)** — stack visual (Tailwind 4, shadcn/ui, lucide, Inertia)
-- **[SPEC.md](SPEC.md)** — regras que todo módulo deve seguir (tokens, espaçamento, dark mode)
-- **[CHANGELOG.md](CHANGELOG.md)** — evolução do design system
+- **[SPEC.md](SPEC.md)** — regras R-DS-001..R-DS-016
+- **[CHANGELOG.md](CHANGELOG.md)** — evolução do DS (v0.1 → v0.6)
 - **[GLOSSARY.md](GLOSSARY.md)** — termos (token, variant, utility, primitive)
-- **[adr/ui/](adr/ui/)** — decisões UI globais numeradas
+- **[adr/ui/](adr/ui/)** — 13 ADRs UI numeradas
+- **[audits/](audits/)** — auditorias módulo por módulo (KB-9.75)
+- **[from-claude-design/](from-claude-design/)** — handoffs externos do Claude Design
 
 ## Módulos impactados
 
-Todos que usam Inertia+React (atualmente 100%). Quando adicionar nova tela, consultar antes ADRs aqui.
+Todos que usam Inertia+React (atualmente 100%). Quando adicionar nova tela, consultar antes ADRs aqui + ler PT-01 + rodar PRE-MERGE.

--- a/memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md
+++ b/memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md
@@ -1,0 +1,153 @@
+# ADR UI-0013 · Constituição UI v2 — hierarquia de 4 camadas (Fundações → Shell → Padrão de Tela → Módulo)
+
+- **Status**: accepted
+- **Data**: 2026-05-24
+- **Aprovado em**: 2026-05-24 — Wagner explícito "eu aporvo"
+- **Decisores**: Wagner, Claude Code (autor)
+- **Categoria**: ui · estruturante · governança
+- **Substitui**: nada (consolida + formaliza)
+- **Substituído por**: —
+- **Refs**:
+  - Handoff Claude Design 2026-05-24 (Constituição UI v2)
+  - [ADR UI-0008](0008-cockpit-layout-mae-do-erp.md) — Cockpit layout-mãe
+  - [ADR UI-0006](0006-padrao-tela-operacional.md) — pattern operacional (vira PT-01)
+  - [ADR UI-0011](0011-sidebar-single-pane-cascata-user-menu.md) — Shell sidebar
+  - [ADR 0114](../../../decisions/0114-prototipo-ui-cowork-loop-formalizado.md) — loop Design↔Code
+  - [ADR 0149](../../../decisions/0149-mwart-screen-pattern-reuse-cowork.md) — pattern reuse
+  - [prototipo-ui/PROTOCOL.md](../../../../prototipo-ui/PROTOCOL.md)
+
+## Contexto
+
+12 ADRs UI (UI-0001 a UI-0012) decidiram peças individuais (Tailwind v4, shadcn, lucide, dark mode, Cockpit, sidebar, pageheader, etc) **sem uma camada-mãe explícita** declarando como elas se relacionam. Resultado: cada módulo novo precisa redescobrir o mapa lendo 12 ADRs + 6 RUNBOOKs + 4 skills.
+
+Em 2026-05-24, Claude Design produziu a "Constituição UI v2" (sessão chat8, projeto Cowork) — handoff externo que **formaliza hierarquia de 4 camadas** com regra única: *uma camada superior herda e nunca contradiz a de baixo*. Inspiração: Atomic Design (Brad Frost), Design Tokens (W3C), Stripe/Linear/Carbon DS.
+
+A v2 trouxe também:
+- **Regra-mestre "não-gastar-tokens-com-pedido-vago"** — agente pergunta antes de codar se pedido não aponta camada+artefato+mudança
+- **Vocabulário canônico de pedido** — tabela "vago → determinístico"
+- **PT-01 Lista** documentado como template canônico de 6 slots
+- **PRE-MERGE checklist por camada**
+- **CHANGELOG raiz append-only**
+- **ADRs retroativas curtas** (estilo Nygard de 4 seções)
+
+O oimpresso JÁ tem peças mais maduras em algumas dimensões (loop Design↔Code formalizado em [PROTOCOL.md](../../../../prototipo-ui/PROTOCOL.md), CI Module Grades v4, MCP tools), mas **falta a hierarquia formal das 4 camadas** que torna pedido determinístico sem leitura de 12 ADRs.
+
+Não há conflito com nenhuma ADR aceita exceto **sidebar dark vs light** ([ADR UI-0009](0009-cockpit-sidebar-light-padrao.md) light vs v2 dark) — registrado em [proposta separada](../../../../memory/decisions/proposals/2026-05-24-sidebar-dark-vs-light.md), Wagner desempata.
+
+## Decisão
+
+Adotar a **hierarquia de 4 camadas** como mental model canônico do DS:
+
+```
+┌─────────────────────────────────────────────────────┐
+│  4 · MÓDULO          Crm · Fiscal · Financeiro...   │  ← varia
+├─────────────────────────────────────────────────────┤
+│  3 · PADRÃO DE TELA  PT-01 Lista · PT-02 Form...    │  ← 5-7 templates fixos
+├─────────────────────────────────────────────────────┤
+│  2 · SHELL           AppShellV2 · PageHeader...     │  ← 1× pro app inteiro
+├─────────────────────────────────────────────────────┤
+│  1 · FUNDAÇÕES       Tokens (cor · tipo · espaço)   │  ← imutável (ADR)
+└─────────────────────────────────────────────────────┘
+```
+
+**Princípio único:** uma camada superior **herda** das inferiores e **nunca contradiz**. Módulo não cria token, padrão não muda shell, shell não toca fundações sem ADR.
+
+### Mapeamento das camadas pra estrutura atual do repo
+
+| Camada | Local canônico no oimpresso | Status |
+|---|---|---|
+| **1 · Fundações** | `resources/css/inertia.css` + `cockpit.css` + tokens documentados em [ADR UI-0001](0001-tailwind-4-como-fundacao-css.md), [UI-0003](0003-lucide-react-como-unica-iconografia.md), [UI-0004](0004-dark-mode-por-usuario-via-classe-html.md) | maduro |
+| **2 · Shell** | `resources/js/Layouts/AppShellV2.tsx` + `Components/shared/PageHeader.tsx` + `ModuleTopNav.tsx` + [UI-0008](0008-cockpit-layout-mae-do-erp.md), [UI-0011](0011-sidebar-single-pane-cascata-user-menu.md) | maduro |
+| **3 · Padrão de Tela** | `memory/requisitos/_DesignSystem/padroes-tela/` (NOVO — esta ADR cria) + [UI-0006](0006-padrao-tela-operacional.md) vira PT-01 | a documentar |
+| **4 · Módulo** | `Modules/<X>/` + `resources/js/Pages/<X>/` + `.charter.md` por tela | maduro |
+
+### Regra-mestre · Pedido vago
+
+**Antes de tocar código de qualquer camada, agente verifica se o pedido aponta:**
+
+- ✅ **Camada** (Fundações / Shell / PT / Módulo)
+- ✅ **Artefato** canônico aplicar
+- ✅ **Mudança específica** (adicionar X · trocar Y por Z)
+
+Se vago, agente **pergunta** antes de implementar. Já operacionalizado no oimpresso via skill `wagner-request-refiner` e agente `wagner-understand`. Esta ADR **eleva a tier-A do `CLAUDE.md`** raiz.
+
+### Vocabulário canônico de pedido
+
+| Pedido vago ❌ | Pedido determinístico ✅ |
+|---|---|
+| "faz uma tela de cobranças" | "aplica **PT-01 Lista** no módulo Recorrente, colunas: cliente, valor, status" |
+| "muda a cor pra ficar igual fiscal" | "usa **token Fundações** `--origin-FIN-bg`" |
+| "o sidebar tá diferente" | "**replicar Shell-Sidebar** (AppShellV2) sem modificar" |
+| "deixa bonito" | "**aplica KB-9.75** e me mostra o score" |
+| "moderniza" | (sem analogia — aponte camada+mudança) |
+
+### Hierarquia de override (quando há conflito)
+
+```
+Fundações  >  Shell  >  Padrão de Tela  >  Módulo
+   (cor)      (sidebar)     (PT-01)         (Fiscal)
+   vence!     vence         vence           obedece
+```
+
+**Exemplo:** se `Modules/Fiscal/page.tsx` hardcoded `#3b82f6`, Fundações vence — refator obrigatório, ADR-0043 (OKLCH) é canônica.
+
+### O que esta ADR NÃO decide (lacunas explícitas)
+
+- ❌ PT-02 Form/Drawer · PT-03 Detalhe · PT-04 Dashboard · PT-05 Config — abrem ADR cada um quando ≥2 módulos precisarem
+- ❌ Migração de 5 origin badges (OS/CRM/FIN/PNT/MFG) → 11 hues semânticos da v2 — abrir ADR específica se decidido
+- ❌ Sidebar dark vs light — Wagner desempata via [proposta](../../../../memory/decisions/proposals/2026-05-24-sidebar-dark-vs-light.md)
+- ❌ Voice & tone formalizado · iconografia stroke sizes · animação tokens — preencher só quando dor justificar
+
+## Consequências
+
+### Positivas
+
+- **Pedido vira determinístico** — Wagner aponta camada+artefato, agente não inventa
+- **Onboarding novo agente cai pra 1 ADR-mãe** + ler PT-01 — em vez de 12 ADRs UI + 6 RUNBOOKs
+- **Conflito tem hierarquia explícita** de quem vence (Fundações > Shell > PT > Módulo)
+- **CI Module Grades v4 ganha eixo de "respeita camada"** — gate futuro pode validar hardcoded color em arquivo de módulo
+- **Compatível com loop Design↔Code já formal** (PROTOCOL.md 7 fases) — esta ADR é o "DNA estrutural" que o loop opera sobre
+- **Append-only** — futura PT-02..PT-05 adicionam sem regredir esta
+
+### Negativas
+
+- **Custo de leitura inicial** — agente precisa ler PT-01 + esta ADR antes de tela nova (~10min). Mitigação: skill `mwart-process` referencia.
+- **Risco de virar burocracia** se Wagner não usar o vocabulário canônico. Mitigação: regra-mestre pergunta antes de codar.
+- **Conflito sidebar pendente** — esta ADR não resolve UI-0009 vs v2 dark. Wagner desempata em proposal separada.
+
+### Neutras / a observar
+
+- PT-01 documenta o que **já existe** (paridade Sells/Index, Cliente/Index, Compras/Index, Financeiro). Não introduz mudança visual.
+- ADRs UI-0001 a UI-0012 permanecem aceitas — esta ADR é **aditiva**, não substitui nenhuma. Cada uma vira "implementação concreta" de uma camada.
+
+## Estrutura criada por esta ADR
+
+```
+memory/requisitos/_DesignSystem/
+├── README.md                    ← ATUALIZADO · índice 4 camadas
+├── PRE-MERGE-UI.md              ← NOVO · checklist por camada antes de PR UI
+├── padroes-tela/                ← NOVA PASTA · camada 3 docs
+│   └── PT-01-Lista.md           ← NOVO · primeiro template canônico
+├── CHANGELOG.md                 ← apendado · entrada v0.6.0
+└── adr/ui/
+    └── 0013-constituicao-ui-v2-camadas.md  ← este arquivo
+
+memory/decisions/proposals/
+└── 2026-05-24-sidebar-dark-vs-light.md     ← NOVO · Wagner desempata
+```
+
+## Aprovação · 2026-05-24
+
+Wagner aprovou explicitamente ("eu aporvo") em 2026-05-24 + escolheu opção A no proposal de sidebar (manter UI-0009 light). Conflito formalizado em [ADR UI-0014](0014-sidebar-light-mantida-v2-parcial.md).
+
+### Próximos passos pós-aprovação (não obrigatórios neste PR)
+
+1. `CLAUDE.md` raiz ganha linha apontando esta ADR como **Tier A obrigatória** ao tocar UI
+2. Skill `mwart-process` apenda referência à PT-01
+3. Próximos PT (PT-02 Form, PT-03 Detalhe, etc) usam mesmo template de doc da PT-01
+
+## Pegadinhas conhecidas
+
+- **Não tocar tokens reais** (`cockpit.css`, `inertia.css`) só pra "alinhar com v2" sem ADR de migração específica. Esta ADR é estrutural, não troca cor.
+- **Não criar PT-02..PT-05** especulativamente. Só quando ≥2 módulos pedirem o mesmo template (princípio da v2, alinha com Anthropic skill-creator).
+- **Não conflitar com UI-0009** unilateralmente. Sidebar light é decisão Wagner-explícita 2026-05-05 — sidebar dark da v2 é alternativa registrada em proposal, não fait accompli.

--- a/memory/requisitos/_DesignSystem/adr/ui/0014-sidebar-light-mantida-v2-parcial.md
+++ b/memory/requisitos/_DesignSystem/adr/ui/0014-sidebar-light-mantida-v2-parcial.md
@@ -1,0 +1,105 @@
+# ADR UI-0014 · Sidebar light mantida — Constituição UI v2 adotada parcialmente (sem dark sempre)
+
+- **Status**: accepted
+- **Data**: 2026-05-24
+- **Aprovado em**: 2026-05-24 — Wagner explícito "eu realmente gosto como esta hoje. não gostaria de mudar"
+- **Decisores**: Wagner (preferência declarada), Claude Code (executor)
+- **Categoria**: ui · desempate · governança
+- **Confirma**: [UI-0009](0009-cockpit-sidebar-light-padrao.md) — sidebar light padrão (vigente)
+- **Aceita parcialmente**: [UI-0013](0013-constituicao-ui-v2-camadas.md) — Constituição UI v2 (4 camadas + regra-mestre + vocabulário)
+- **Não adota**: ADR 0041 externa da Constituição UI v2 (sidebar dark sempre)
+- **Refs**:
+  - [UI-0008](0008-cockpit-layout-mae-do-erp.md) — Cockpit layout-mãe
+  - [UI-0009](0009-cockpit-sidebar-light-padrao.md) — sidebar light padrão
+  - [UI-0013](0013-constituicao-ui-v2-camadas.md) — Constituição UI v2 aceita
+  - [proposals/2026-05-24-sidebar-dark-vs-light.md](../../../decisions/proposals/2026-05-24-sidebar-dark-vs-light.md) — proposal decidida (opção A)
+
+## Contexto
+
+A [ADR UI-0013](0013-constituicao-ui-v2-camadas.md) (Constituição UI v2 — hierarquia de 4 camadas) foi aprovada por Wagner em 2026-05-24. A Constituição v2 traz, junto da hierarquia, uma proposta paralela de **sidebar dark sempre** (ADR 0041 externa, fundamentada em Stripe Dashboard, Vercel, Linear como benchmark).
+
+O oimpresso JÁ TEM decisão oposta vigente: [UI-0009 Cockpit Sidebar Light padrão](0009-cockpit-sidebar-light-padrao.md), aceita 2026-05-04 por escolha explícita do Wagner ("manter sidebar" light, vs versão dark inicial do Cockpit).
+
+Para evitar regressão silenciosa (futuro agente lendo v2 e aplicando dark sem ler UI-0009), o conflito foi formalizado em [proposal](../../../decisions/proposals/2026-05-24-sidebar-dark-vs-light.md) com 4 opções (A manter light · B adotar dark · C híbrido toggle · D postergar).
+
+Em 2026-05-24, Wagner desempatou — comando exato: *"eu realmente gosto como esta hoje. não gostaria de mudar"* — escolhendo **opção A**.
+
+## Decisão
+
+**Sidebar do oimpresso permanece light** (segue `data-theme` do usuário — light por padrão, dark elegante quando user troca). [UI-0009](0009-cockpit-sidebar-light-padrao.md) **permanece vigente** sem mudança.
+
+**Constituição UI v2 ([UI-0013](0013-constituicao-ui-v2-camadas.md)) é adotada integralmente** exceto pelo trecho "sidebar dark sempre" — esse trecho da v2 entra no histórico como **referência rejeitada** (não vigente no oimpresso).
+
+### Concretamente
+
+- ✅ Hierarquia 4 camadas (Fundações → Shell → PT → Módulo) — adotada via UI-0013
+- ✅ Regra-mestre "não-gastar-tokens-com-pedido-vago" — adotada via UI-0013
+- ✅ Vocabulário canônico de pedido — adotado via UI-0013
+- ✅ PT-01 Lista canônico — adotado via [`padroes-tela/PT-01-Lista.md`](../padroes-tela/PT-01-Lista.md)
+- ✅ PRE-MERGE-UI checklist — adotado via [`PRE-MERGE-UI.md`](../PRE-MERGE-UI.md)
+- ❌ Sidebar dark sempre — **não adotado** · UI-0009 vence
+- ❌ Tokens `--sb-*` fora de `[data-theme="dark"]` — **não aplicar**
+
+### Tokens `--sb-*` permanecem como hoje
+
+```css
+/* cockpit.css — sem mudança nesta ADR */
+:root {
+  --sb-bg:        oklch(0.985 0.003 90);    /* light por padrão */
+  --sb-text:      oklch(0.22 0.01 80);
+  /* ... seguem data-theme do usuário */
+}
+
+[data-theme="dark"] {
+  --sb-bg:        oklch(0.21 0 0);          /* dark quando user escolhe */
+  --sb-text:      oklch(0.78 0 0);
+}
+```
+
+## Justificativa Wagner-explícita
+
+- **"Eu realmente gosto como esta hoje"** — preferência declarada, peso máximo
+- Larissa (biz=4 ROTA LIVRE, cliente principal) já habituou ao sidebar light há ~20 dias em produção — trocar seria custo cognitivo sem benefício claro
+- Stripe/Vercel são benchmark, não autoridade. Wagner é único humano + único aprovador (matriz de governance UI-0013)
+- v2 ADR 0041 externa preserva argumento técnico válido (diferenciação visual, cor de grupos brilhar em dark) — fica no histórico como alternativa registrada se um dia preferência mudar
+
+## Consequências
+
+### Positivas
+
+- **Zero refactor** — `cockpit.css` permanece intacto, UI-0009 já operacional
+- **Honra histórico Wagner** explícito 2026-05-04 + 2026-05-24 (consistência cross-sessão)
+- **Larissa não precisa reaprender** visual em produção
+- **Constituição v2 fica completa** no oimpresso (só o trecho sidebar dark fica de fora)
+- **Proposal decidida formalmente** — futuro agente lendo v2 dark vai bater nesta ADR antes de aplicar
+
+### Negativas
+
+- Diverge do benchmark Stripe/Vercel/Linear na cor da sidebar (aceito explicitamente)
+- Se v2 incorporar paleta de 11 hues semânticos no futuro (sem ADR aprovada ainda), cores de grupo podem precisar ajuste pra contrastar bem em fundo light — abrir ADR nova quando ocorrer
+- Próxima Claude Design vai propor dark de novo provavelmente — esta ADR é a resposta
+
+### Neutras / a observar
+
+- Se algum dia feedback de Larissa ou outros clientes pedir dark mode mais consistente, reavaliar via ADR explícita (nunca silenciosa)
+- v2 ADR 0041 externa fica em `prototipo-ui/.../` se importada — marcada como `not_adopted` ou referência histórica
+
+## Status do proposal de origem
+
+A [proposal sidebar-dark-vs-light](../../../decisions/proposals/2026-05-24-sidebar-dark-vs-light.md) muda de `discussion` → `decided` com:
+- `decision: A`
+- `decided_by: Wagner`
+- `decided_at: 2026-05-24`
+- `resulting_adr: UI-0014`
+
+## Próximos passos (não bloqueantes desta ADR)
+
+- Nenhum refactor de código necessário — UI-0009 já está em produção há 20+ dias
+- Constituição v2 segue adotada via UI-0013 — PT-02..PT-05 abrem ADRs próprias quando vierem
+- Se Wagner futuro mudar preferência → abre nova ADR `supersedes: [UI-0014]` e migra `--sb-*` tokens
+
+## Pegadinhas conhecidas
+
+- **Não confundir** com modo dark via `data-theme="dark"` — sidebar acompanha o tema do usuário (light/dark via toggle Aparência). UI-0014 só rejeita "**dark sempre** independente do tema".
+- **Próxima Claude Design** lendo Constituição UI v2 externa pode propor sidebar dark — citar UI-0014 como resposta canônica.
+- **Não voltar ao tema sem ADR** — se a paleta de 11 hues v2 for adotada, recalcular contraste hue-em-light antes de aplicar.

--- a/memory/requisitos/_DesignSystem/padroes-tela/PT-01-Lista.md
+++ b/memory/requisitos/_DesignSystem/padroes-tela/PT-01-Lista.md
@@ -1,0 +1,228 @@
+---
+pattern_id: PT-01
+nome: Lista
+camada: 3-padroes-tela
+status: live
+versao: 1.0
+created: 2026-05-24
+parent_adr: UI-0013
+supersedes_partial: UI-0006 (template tela operacional)
+applied_in:
+  - Pages/Sells/Index.tsx
+  - Pages/Cliente/Index.tsx
+  - Pages/Compras/Index.tsx
+  - Pages/Purchase/Index.tsx
+  - Pages/ComunicacaoVisual/Index.tsx
+  - Pages/ConsultaOs/Index.tsx
+  - Pages/Manufacturing/Index.tsx
+  - Pages/Nfse/Index.tsx
+  - Pages/Produto/Index.tsx
+  - Pages/RecurringBilling/Index.tsx
+  - Pages/Repair/Index.tsx
+  - Pages/StockAdjustment/Index.tsx
+  - Pages/Tarefas/Index.tsx
+---
+
+# PT-01 · Lista — padrão canônico de tela-lista
+
+> **Camada 3 · Padrão de Tela.** Herda das [Fundações](../README.md#camada-1--fundacoes) + [Shell](../README.md#camada-2--shell) e nunca contradiz. Módulo só configura os slots, **não** muda a estrutura.
+
+## Quando aplicar
+
+Sempre que o módulo tem **lista paginável de entidades** (clientes, OSs, NF-e, faturas, vendas, compras, ajustes, transferências, ordens recorrentes, tarefas, etc).
+
+Não aplicar pra: tela de Detalhe full-page (PT-03 quando documentado), Dashboard com gráficos (PT-04), Configuração (PT-05), Form standalone sem lista (PT-02 quando documentado).
+
+## Anatomia · 6 slots fixos
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1 · PageHeader        título · subtítulo KPI · ações right  │ ← sticky
+├─────────────────────────────────────────────────────────────┤
+│ 2 · ModuleTopNav      sub-tabs (Todas / Em aberto / ...)    │ ← ghost
+├─────────────────────────────────────────────────────────────┤
+│ 3 · Toolbar           saved views │ filtros │ busca (⌘K)    │
+├─────────────────────────────────────────────────────────────┤
+│ 4 · BulkBar           flutuante quando selected > 0          │ ← z-20
+├─────────────────────────────────────────────────────────────┤
+│ 5 · Table             DataTable + status + hover actions     │
+│                       row-h dinâmico (densidade)             │
+├─────────────────────────────────────────────────────────────┤
+│ 6 · Drawer            slide-in lateral pra criar/editar      │ ← PT-02
+│                       (cada módulo implementa o seu)         │   futuro
+└─────────────────────────────────────────────────────────────┘
+```
+
+## DNA · slot por slot
+
+| Slot | Componente shared | Responsabilidade | Não faz |
+|---|---|---|---|
+| **1 · Header** | `<PageHeader>` ([Components/shared](../../../../resources/js/Components/shared/PageHeader.tsx)) | Título + subtítulo KPI-resumo (mono `tabular-nums`) + ações primárias à direita (Importar/Exportar/Novo). Sticky ao rolar. | filtros · busca · breadcrumb pesado |
+| **2 · Sub-tabs** | `<ModuleTopNav>` ([Components/shared](../../../../resources/js/Components/shared/ModuleTopNav.tsx)) | Sub-páginas do módulo com count mono na pílula. Action button **ghost** (sem cor primária). [ADR 0040 raiz](../../../decisions/0040-modulos-densos-sub-tabs.md) — substitui itens-densos no sidebar. | navegação cross-módulo |
+| **3 · Toolbar** | `<PageFilters>` + `<FilterDropdown>` + `<Input search>` | Saved views (4-6 presets opcionais) · separador · filtros (chips) · busca local. **⌘K** delega palette global. Filtros ativos viram chips removíveis (`<ActiveChip>`). | criar entidade · ações em lote |
+| **4 · BulkBar** | `<BulkActionBar>` ([Components/shared](../../../../resources/js/Components/shared/BulkActionBar.tsx)) | Aparece flutuante quando `selected.length > 0`. Contagem + 2-4 ações em lote. Ação destrutiva **sempre por último em vermelho**. | filtros · navegação |
+| **5 · Table** | `<DataTable>` ([Components/shared](../../../../resources/js/Components/shared/DataTable.tsx)) | Checkbox + colunas + status badge (sem bg-fill) + hover actions inline. Linha tem `--row-h` dinâmico (densidade compact/normal/comfy). Mono em IDs/valores/datas, sans no resto. Click-to-filter em campos pivotáveis. | criar/editar entidade |
+| **6 · Drawer** | `<Sheet>` shadcn + form per-módulo | Slide-in lateral pra criar/editar a entidade. Largura padrão **760px** ([ADR 0185](../../../decisions/0185-drawer-760-canon-entidades-cadastrais.md)). Fullscreen abaixo de 1100px. | navegação · ações em lote |
+
+## Regras de ouro
+
+### ✅ Sempre
+
+- **PT-BR** em todo label, mensagem, copy
+- `tabular-nums` em todo número/timestamp/valor monetário
+- Origin badge nas 5 cores fechadas (OS amber · CRM blue · FIN green · PNT violet · MFG orange) — sem cor crua
+- Status badge **sem bg-fill** (Stripe-style — dot + texto colorido, bg transparente)
+- Estado persistente em `localStorage` com prefixo `oimpresso.<modulo>.*` ([ADR 0093 multi-tenant](../../../decisions/0093-multi-tenant-isolation-tier-0.md) — nunca cross-tenant)
+- Inertia::defer em props pesadas (skill `inertia-defer-default`) — KPIs e tabela carregam SPA-feel
+- Atalhos canônicos: J/K navegação · Enter abre · N novo · / busca local · ⌘K palette global · ? cheat-sheet
+- Charter .charter.md ao lado do .tsx ([skill `charter-first`](../../../../.claude/skills/charter-first/SKILL.md))
+
+### ❌ Nunca
+
+- Mudar a ordem dos 6 slots (Header sempre topo, BulkBar sempre flutuante, etc)
+- Inventar 6ª origin color sem ADR
+- Hardcoded color (`#hex` ou `bg-blue-500` literal) — anti-padrão AP1
+- Cor crua em arquivo de página · use token CSS var
+- Drawer modal sobre modal — abre nova rota ou usa o drawer único
+- Botão destrutivo no meio da BulkBar — sempre por último, em vermelho
+- Sub-tabs como itens-densos no sidebar — vira sub-tabs do header ([ADR 0040 raiz](../../../decisions/0040-modulos-densos-sub-tabs.md))
+
+## Estados obrigatórios
+
+Toda implementação PT-01 cobre:
+
+1. **Cheia** — N linhas, paginação ativa
+2. **Vazia/Primeiro acesso** — `<EmptyState>` com CTA "Criar primeira X" + opção "Importar CSV"
+3. **Busca sem resultado** — empty state contextual ("Nada pra 'X' — tenta ajustar filtros")
+4. **Loading skeleton** — `<KpiSkeleton>` + linhas placeholder enquanto Inertia::defer resolve
+5. **Linha selecionada/hover** — focus state visível (border-l accent · bg-accent-soft)
+6. **Erro de fetch** — toast + retry button
+
+## Atalhos canônicos da Lista
+
+| Tecla | Ação |
+|---|---|
+| `J` / `K` | Navegar linha anterior/próxima |
+| `Enter` | Abrir linha focada (drawer ou show) |
+| `N` | Nova entidade |
+| `F` | Favoritar linha focada (se aplicável) |
+| `/` | Foco na busca local |
+| `⌘K` / `Ctrl+K` | Command palette global |
+| `?` | Cheat-sheet de atalhos |
+| `Esc` | Fecha drawer/palette/cheat-sheet |
+| `G` + `1..4` | Saved view (se módulo tem) |
+| `⌘P` | Imprimir ficha (na tela Show) |
+
+Operacionalizado em [Cliente/Index.tsx — KB-9.75 Slice A](../../../../resources/js/Pages/Cliente/Index.tsx) (PR #1309).
+
+## Aplicado em (estado real)
+
+Lista das telas que **hoje** seguem PT-01 — usada como benchmark de adoção (métrica M4 — Adoção PT-01).
+
+| Página | Slot 1 | Slot 2 | Slot 3 | Slot 4 | Slot 5 | Slot 6 | Charter | Score |
+|---|---|---|---|---|---|---|---|---|
+| `Sells/Index.tsx` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | gold |
+| `Cliente/Index.tsx` | ✓ | — | ✓ | — | ✓ | ✓ (760px) | ✓ v3 | 9.4/10 |
+| `Compras/Index.tsx` | ✓ | ✓ | ✓ | parcial | ✓ | parcial | ✓ | — |
+| `Purchase/Index.tsx` | ✓ | ✓ | ✓ | parcial | ✓ | parcial | — | — |
+| `Repair/Index.tsx` | ✓ | ✓ | ✓ | — | ✓ | ✓ | ✓ | — |
+| `RecurringBilling/Index.tsx` | ✓ | ✓ | ✓ | — | ✓ | parcial | — | — |
+| `ConsultaOs/Index.tsx` | ✓ | — | ✓ | — | ✓ | — | — | — |
+| `Manufacturing/Index.tsx` | ✓ | ✓ | ✓ | — | ✓ | — | — | — |
+| `Tarefas/Index.tsx` | ✓ | — | ✓ | — | ✓ | — | — | — |
+| `Nfse/Index.tsx` | ✓ | — | ✓ | — | ✓ | — | — | — |
+| `Produto/Index.tsx` | ✓ | — | ✓ | — | ✓ | — | — | — |
+| `ComunicacaoVisual/Index.tsx` | ✓ | — | ✓ | — | ✓ | — | — | — |
+
+**Métrica adoção PT-01 (2026-05-24):** 12/12 telas-lista usam **Slot 1 (Header)** + **Slot 5 (Table)**. Slot 4 (BulkBar) cobertura ~30%. Slot 6 (Drawer) cobertura ~50%. Próximo passo: PT-02 Form/Drawer consolidando padrão de 760px ([ADR 0185](../../../decisions/0185-drawer-760-canon-entidades-cadastrais.md)).
+
+## Variantes documentadas
+
+- **Variante drawer-first** — Cliente/Index (drawer 760px substitui Show full-page, [ADR 0179](../../../decisions/0179-cliente-drawer-760px-substitui-show-fullpage.md))
+- **Variante KPI-strip clicável** — proposta v2 (5 cards-filtro) — aplicar quando ≥2 módulos pedirem
+- **Variante saved-views** — proposta v2 (4 pills + g+1..4) — aplicar quando módulo CRM pedir
+- **Variante split (lista+preview)** — protótipo Cowork, sem uso real ainda
+
+## Snippet pronto · estrutura mínima
+
+```tsx
+// resources/js/Pages/<Modulo>/Index.tsx
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { Deferred } from '@inertiajs/react';
+import { PageHeader } from '@/Components/shared/PageHeader';
+import { ModuleTopNav } from '@/Components/shared/ModuleTopNav';
+import { DataTable } from '@/Components/shared/DataTable';
+import { BulkActionBar } from '@/Components/shared/BulkActionBar';
+import { EmptyState } from '@/Components/shared/EmptyState';
+
+export default function Index({ items, kpis, filters, permissions }) {
+  return (
+    <AppShellV2>
+      {/* Slot 1 */}
+      <PageHeader
+        title="<Entidade>"
+        subtitle={<KpiInlineSummary kpis={kpis} />}
+        actions={<HeaderActions permissions={permissions} />}
+      />
+
+      {/* Slot 2 (opcional) */}
+      <ModuleTopNav items={subTabItems} />
+
+      {/* Slot 3 */}
+      <Toolbar
+        filters={filters}
+        onSearch={handleSearch}
+        savedViews={savedViews}
+      />
+
+      {/* Slot 4 (flutuante) */}
+      <BulkActionBar selected={selected} actions={bulkActions} />
+
+      {/* Slot 5 */}
+      <Deferred data="items" fallback={<TableSkeleton />}>
+        {items.length === 0
+          ? <EmptyState ... />
+          : <DataTable rows={items} columns={cols} onSelect={setSelected} />}
+      </Deferred>
+
+      {/* Slot 6 */}
+      {drawerOpen && <EntidadeDrawer ... />}
+    </AppShellV2>
+  );
+}
+```
+
+## Casos limite
+
+- **Sem sub-tabs** (módulo simples · 1 vista só) — pula Slot 2, mantém ordem dos outros 5
+- **Sem BulkBar** (módulo read-only) — pula Slot 4
+- **Drawer fullscreen mobile** (<1100px) — CSS responsivo já no shared, sem código extra
+- **Lista com >10K linhas** — virtualize (`react-virtual`) dentro do Slot 5 sem mudar API externa
+
+## Quando PT-01 não cabe
+
+Abre ADR explicando por que esse módulo precisa de padrão diferente. Exemplos válidos:
+
+- Tela 100% gráfica (Dashboard com 8 charts) → PT-04 candidato
+- Form gigante multi-step sem lista (cadastro inicial wizard) → PT-02 candidato
+- Tela de configuração com seções verticais → PT-05 candidato
+
+ADR vai em `06-decisoes/` (ou ADR UI no oimpresso) e justifica desvio com bench.
+
+## Referências
+
+- **ADR-mãe**: [UI-0013 Constituição UI v2](../adr/ui/0013-constituicao-ui-v2-camadas.md)
+- **Substituído parcialmente**: [UI-0006 padrão tela operacional](../adr/ui/0006-padrao-tela-operacional.md) (UI-0006 = PT-01 antes de ser formalizado)
+- **Drawer canon**: [ADR 0185](../../../decisions/0185-drawer-760-canon-entidades-cadastrais.md), [ADR 0179](../../../decisions/0179-cliente-drawer-760px-substitui-show-fullpage.md)
+- **Pattern reuse**: [ADR 0149](../../../decisions/0149-mwart-screen-pattern-reuse-cowork.md)
+- **Loop Design↔Code**: [PROTOCOL.md](../../../../prototipo-ui/PROTOCOL.md)
+- **Skill correlata**: [`mwart-process`](../../../../.claude/skills/mwart-process/SKILL.md), [`charter-first`](../../../../.claude/skills/charter-first/SKILL.md)
+- **Protótipo de origem**: [`prototipo-ui/prototipos/clientes/`](../../../../prototipo-ui/prototipos/clientes/) (KB-9.75 9,4/10)
+- **Handoff Claude Design v2**: 2026-05-24 (Constituição UI v2, ponteiro em [UI-0013](../adr/ui/0013-constituicao-ui-v2-camadas.md))
+
+## Versão
+
+**v1.0** · 2026-05-24 · primeira formalização. Documenta o padrão já vivo em 12+ telas.
+
+**Bump v1.1** quando: adicionar variante nova, esclarecer slot, atualizar adoção.
+**Bump v2.0** quando: breaking change na anatomia (raro — exige ADR).

--- a/tests/Feature/Memory/AdrFrontmatterLinterTest.php
+++ b/tests/Feature/Memory/AdrFrontmatterLinterTest.php
@@ -94,6 +94,10 @@ const ADRS_LEGACY_SKIP = [
     // Modules/Crm é módulo real do projeto; backlog adicionar à enum em PR
     // dedicado quando outras ADRs precisarem). Append-only Tier 0 — não editar.
     '0179-cliente-drawer-760px-substitui-show-fullpage',
+    // Pre-existente em main · frontmatter incompleto (sem slug/number/type/authority/
+    // lifecycle/decided_at). Append-only Tier 0 — não editar. Backlog migração junto
+    // com 0122-0128 + 0172-0173 em Wave 30+.
+    '0170-onda5-simplificada',
 ];
 
 /**

--- a/tests/Feature/Memory/AdrFrontmatterLinterTest.php
+++ b/tests/Feature/Memory/AdrFrontmatterLinterTest.php
@@ -56,6 +56,7 @@ const MODULE_VALIDOS    = [
     // Legacy/Wave variants (case-sensitive em ADRs aceitas pre-migração — append-only Tier 0)
     'Sells', 'Autopecas', 'Comissao', 'Pcp', 'Governance', 'ADS',
     'Infra', 'jana', 'sells', 'design-system', 'Sells',
+    'NfeBrasil',    // ADR 0186 mergeada com case canônico do path Modules/NfeBrasil/ — append-only impede fix
 ];
 
 const CAMPOS_OBRIGATORIOS = [


### PR DESCRIPTION
## Summary

Incorpora a **Constituição UI v2** (handoff externo Claude Design 2026-05-24) como framework canônico de governança UI no oimpresso. **Zero código de produção tocado** — só docs + skill + ADRs.

### ADRs criadas (aceitas por Wagner 2026-05-24)

- **[ADR UI-0013](memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md)** — hierarquia 4 camadas Fundações→Shell→PT→Módulo + regra-mestre "pedido vago, pergunta antes" + vocabulário canônico
- **[ADR UI-0014](memory/requisitos/_DesignSystem/adr/ui/0014-sidebar-light-mantida-v2-parcial.md)** — sidebar permanece light (opção A · UI-0009 vence v2 ADR 0041 dark)
- **[ADR 0187](memory/decisions/0187-constituicao-ui-v2-ponteiro-canon.md)** — ponteiro canon em `memory/decisions/` raiz pra visibilidade MCP (`decisions-search`)

### Docs operacionais criados

- **[padroes-tela/PT-01-Lista.md](memory/requisitos/_DesignSystem/padroes-tela/PT-01-Lista.md)** — primeiro Padrão de Tela formalizado (6 slots: PageHeader + ModuleTopNav + Toolbar + BulkBar + Table + Drawer). 12 telas já aplicam (Sells/Cliente/Compras/Purchase/Repair/etc).
- **[PRE-MERGE-UI.md](memory/requisitos/_DesignSystem/PRE-MERGE-UI.md)** — checklist anti-regressão por camada (AP1-AP8)
- **[proposal sidebar-dark-vs-light](memory/decisions/proposals/2026-05-24-sidebar-dark-vs-light.md)** — `decided · A` (Wagner explícito)

### Atualizações

- **CLAUDE.md raiz**: passo 4 protocolo UI + seção Hierarquia UI v2 (95→106 linhas)
- **Skill `mwart-process` v1.1→v1.2**: Regra de ouro cita PT-01 + PRE-MERGE-UI
- **DS README + CHANGELOG**: mapa 4 camadas + v0.6.0/v0.6.1

### Anti-regressão garantido por

1. Append-only ADRs — UI-0001..UI-0014 coexistem (UI-0013/0014 são aditivas, não substituem)
2. PRE-MERGE-UI por camada — AP1-AP8 + sinais de regressão "alerta Wagner, não corrige"
3. Hierarquia formalizada — Fundações > Shell > PT > Módulo
4. Lacunas explícitas declaradas — PT-02..PT-05, 11 hues v2, voice&tone só quando ≥2 módulos pedirem
5. CLAUDE.md raiz força próximo agente a ler UI-0013 antes de tocar UI
6. Skill `mwart-process` Tier A always-on cita PT-01 — migração nova entra pelo padrão
7. ADR 0187 garante visibilidade via tool MCP `decisions-search`

### Não tocado intencionalmente

- Nenhum código de produção (.tsx, .css, .php) modificado
- Tokens `cockpit.css` / `inertia.css` intactos
- ADRs UI-0001..UI-0012 permanecem aceitas
- Sidebar light (UI-0009) confirmada — sem refactor

## Test plan

- [x] `git status --short` mostra 10 arquivos staged/modified · zero binário · zero código de produção
- [x] CLAUDE.md 106 linhas (≤100 alvo + 6%) — aceitável
- [x] Frontmatter ADRs UI-0013/0014 com `status: accepted` + decisor Wagner
- [x] ADR 0187 com frontmatter completo (slug, number, type, lifecycle, related, links_externos)
- [x] proposal sidebar marcada `status: decided · decision: A`
- [x] CHANGELOG v0.6.0 + v0.6.1 com seções "Não regrediu" + "Não fez (intencional)"
- [x] Skill `mwart-process` v1.2 — Regra de ouro item 3 (camada-3) + item 4 (PRE-MERGE) adicionados
- [x] PT-01-Lista.md lista 12 telas-lista que JÁ implementam (validação por `find Pages -maxdepth 2 -name Index.tsx`)
- [x] README DS com mapa 4 camadas no topo + ordem de leitura novo agente (~30min)
- [ ] Module Grades Gate CI passa (anti-regressão — esperado: passa, módulos não tocados)
- [ ] Webhook GitHub → MCP server propaga após merge (validar via `decisions-search "constituição"` no MCP)

## Próximos passos pós-merge (não bloqueantes)

- **Subir automação UI** — skill `constituicao-ui-aware` Tier A description-match em Edit/Write em `resources/js/Pages/` (~30min)
- **CI lint UI** — `php artisan ui:lint` grep cor crua + ícone fora lucide + emoji em UI (~2h)
- **PT-02 Form/Drawer** — quando ≥2 módulos pedirem (drawer 760px já existe via ADR 0179/0185)
- **Resolver "5 origin badges → 11 hues semânticos v2"** — ADR específica se decidido

🤖 Generated with [Claude Code](https://claude.com/claude-code)