### PR TITLE
fix(ci): pr-ui-judge Telescope + pre-commit hook Windows PHP detection

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -15,14 +15,26 @@
 
 set -e
 
-# Procura PHP executável (prioriza Herd no Windows)
+# Procura PHP executável (prioriza Herd no Windows).
+# Nota: usar -f (existe) ao invés de -x (executable) — arquivos .bat no
+# Windows Git Bash não têm bit POSIX executable mesmo rodando via cmd.exe.
 PHP_BIN=""
 if command -v php >/dev/null 2>&1; then
     PHP_BIN="php"
-elif [ -x "/c/Users/$USER/.config/herd/bin/php.bat" ]; then
-    PHP_BIN="/c/Users/$USER/.config/herd/bin/php.bat"
-elif [ -x "$HOME/.config/herd/bin/php.bat" ]; then
+elif [ -f "$HOME/.config/herd/bin/php.bat" ]; then
     PHP_BIN="$HOME/.config/herd/bin/php.bat"
+elif [ -n "$USERNAME" ] && [ -f "/c/Users/$USERNAME/.config/herd/bin/php.bat" ]; then
+    PHP_BIN="/c/Users/$USERNAME/.config/herd/bin/php.bat"
+elif [ -n "$USER" ] && [ -f "/c/Users/$USER/.config/herd/bin/php.bat" ]; then
+    PHP_BIN="/c/Users/$USER/.config/herd/bin/php.bat"
+else
+    # Última tentativa: enumerar /c/Users/*/.config/herd/bin/php.bat
+    for CANDIDATE in /c/Users/*/.config/herd/bin/php.bat; do
+        if [ -f "$CANDIDATE" ]; then
+            PHP_BIN="$CANDIDATE"
+            break
+        fi
+    done
 fi
 
 if [ -z "$PHP_BIN" ]; then

--- a/.github/workflows/pr-ui-judge.yml
+++ b/.github/workflows/pr-ui-judge.yml
@@ -80,6 +80,7 @@ jobs:
       - name: Setup .env mínimo
         env:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
         run: |
           mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views storage/logs bootstrap/cache
           cat > .env <<EOF
@@ -94,7 +95,11 @@ jobs:
           QUEUE_CONNECTION=sync
           SESSION_DRIVER=array
           MAIL_MAILER=array
+          TELESCOPE_ENABLED=false
+          VIEW_COMPILED_PATH=storage/framework/views
+          BCRYPT_ROUNDS=4
           ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY}
+          OPENAI_API_KEY=${OPENAI_API_KEY}
           EOF
           php artisan key:generate
 


### PR DESCRIPTION
Dois bugs descobertos no smoke #1445:

1. `.github/workflows/pr-ui-judge.yml`: faltava `TELESCOPE_ENABLED=false` (mesmo fix de #1444)
2. `.githooks/pre-commit`: `[ -x ... ]` falhava em `.bat` no Windows · trocado pra `[ -f ... ]` + fallback robusto

Refs: PR #1445 smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)