### PR TITLE
feat(cliente): adiciona Grupos de clientes no overflow menu

### DIFF
--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -28,6 +28,7 @@ import {
   Edit,
   Eye,
   Keyboard,
+  Layers,
   List,
   Loader2,
   MoreVertical,
@@ -48,6 +49,7 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/Components/ui/dropdown-menu';
 import {
@@ -622,7 +624,7 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
                       <MoreVertical className="h-4 w-4" />
                     </Button>
                   </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-44">
+                  <DropdownMenuContent align="end" className="w-52">
                     {props.permissions.import && (
                       <DropdownMenuItem asChild>
                         <a href="/contacts/import">
@@ -639,6 +641,21 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
                         </a>
                       </DropdownMenuItem>
                     )}
+                    {/* Wagner 2026-05-24 pediu "cadastro tipo de contato nos ..."
+                        UPOS legacy admin: customer_groups (Cliente VIP, Atacado,
+                        Varejo, Premium etc) — rota /customer-group (CustomerGroup
+                        Controller). Atualmente biz=4 ROTA LIVRE tem 0 cadastros,
+                        link facilita o primeiro cadastro. Separator visual entre
+                        ações de dados (importar/exportar) e cadastro auxiliar. */}
+                    {(props.permissions.import || props.permissions.view) && (
+                      <DropdownMenuSeparator />
+                    )}
+                    <DropdownMenuItem asChild>
+                      <a href="/customer-group" title="Cadastrar grupos/tipos de cliente (VIP, atacado, varejo, etc)">
+                        <Layers className="mr-2 h-4 w-4" />
+                        Grupos de clientes
+                      </a>
+                    </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>
               )}


### PR DESCRIPTION
## Summary

Wagner 2026-05-24 (validação visual `/cliente` prod pós-merge #1451): "coloca o cadastro tipo de contato nos ..." (overflow menu 3 pontinhos).

UPOS legacy tem rota `/customer-group` (CustomerGroupController) que gerencia **grupos de clientes** (VIP, Atacado, Varejo, Premium etc) — categorização auxiliar pra segmentação. biz=4 ROTA LIVRE tem 0 cadastros ainda → link facilita primeiro cadastro pra Larissa.

### Overflow menu antes vs depois

```
ANTES                    DEPOIS
┌──────────────┐         ┌──────────────────┐
│ ↑ Importar   │         │ ↑ Importar       │
│ ↓ Exportar   │         │ ↓ Exportar CSV   │
└──────────────┘         ├──────────────────┤
                         │ ◫ Grupos de      │
                         │   clientes       │
                         └──────────────────┘
```

Separator visual entre ações de dados (import/export) e cadastro auxiliar.

## Test plan

- [x] `php artisan ui:lint --strict --changed-only` → **Ok · sem regressões**
- [x] Pre-commit hook validou local antes do commit
- [ ] CI ui-lint workflow verde
- [ ] CI pr-ui-judge (pode falhar por bug UTF-8 PrUiJudgeAgent — informational)
- [ ] Validação visual Wagner em `/cliente` → click `⋮` → ver item "Grupos de clientes"

## Constraints

- PT-01 Slot 1 §60 (DNA Header) preserved
- Rota `/customer-group` UPOS legacy intocada (sem mudança backend)
- Tier 0 multi-tenant preservado (controller já scoped por business_id)

## Refs

- [ADR UI-0013 · Constituição UI v2](memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md)
- [PT-01 · Lista canônica](memory/requisitos/_DesignSystem/padroes-tela/PT-01-Lista.md) §60 DNA Header
- [ADR 0188 · Contatos multi-type](memory/decisions/0188-contacts-multi-type-flag-aditiva.md) (contexto multi-papel)
- Wagner 2026-05-24 pedido literal: "coloca o cadastro tipo de contato nos ..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)
