### PR TITLE
fix(financeiro): border coerente no PrimaryButton (hue do grupo, sem magenta)

### DIFF
--- a/resources/js/Pages/Financeiro/_shared/FinanceiroPrimaryButton.tsx
+++ b/resources/js/Pages/Financeiro/_shared/FinanceiroPrimaryButton.tsx
@@ -47,6 +47,7 @@ export default function FinanceiroPrimaryButton({
       className={`os-btn primary ${className}`.trim()}
       style={{
         backgroundColor: `oklch(0.55 0.15 ${hue})`,
+        borderColor: `oklch(0.45 0.15 ${hue})`,
         color: 'oklch(0.99 0 0)',
         ...style,
       }}


### PR DESCRIPTION
## Summary

- Fix anti-padrão **borda magenta hue 330** no `.os-btn.primary` do header Financeiro
- Causa raiz: `.cockpit` (UltimatePOS root) define `--accent: oklch(0.58 0.12 330)` que vazava pra `border-color` via `.fin-cowork .os-btn.primary`
- `FinanceiroPrimaryButton` já sobrescrevia `backgroundColor` (verde 145) mas não tocava `borderColor` — agora override completo

## What changed

`resources/js/Pages/Financeiro/_shared/FinanceiroPrimaryButton.tsx` (+1 linha):

```diff
       style={{
         backgroundColor: `oklch(0.55 0.15 ${hue})`,
+        borderColor: `oklch(0.45 0.15 ${hue})`,
         color: 'oklch(0.99 0 0)',
         ...style,
       }}
```

Mantém a **linha delimitadora 1px** (Wagner gostou visualmente — "header tem uma linha delineando o botão ghost? ficou bem legal") mas troca a cor pra coerente com o grupo (verde escuro 10% abaixo do bg).

## Onde vê

- https://oimpresso.com/financeiro/cobranca — botão `+ Nova cobrança`
- Todas as 12 telas Financeiro que usam `FinanceiroPrimaryButton`

## Não-objetivos (testar antes de regrar)

- ❌ NÃO tokeniza canon — Wagner quer testar com Larissa (biz=4 RotaLivre) antes de virar regra global
- ❌ NÃO toca outros grupos (Ponto/Jana têm componentes próprios com mesmo bug — endereçar em PR separado se este pegar OK)
- ❌ NÃO endurece `pageheader-canon` check C6 (continua warning)

## Próximos passos (depois do teste cliente)

Se aprovado:
1. Override `--accent` em `.fin-cowork` (e equivalente nos outros grupos) — tokeniza
2. Endurecer skill `pageheader-canon` check C6 (warning → erro)
3. Replicar fix em `PontoPrimaryButton`, `JanaPrimaryButton`

## Test plan

- [x] `ui:lint` passou
- [ ] Reload `/financeiro/cobranca` em prod pós-deploy
- [ ] Confirmar `getComputedStyle` borderColor = `oklch(0.45 0.15 145)` (verde escuro)
- [ ] Validar visual em outras telas Financeiro (Conciliação, Caixa, Dashboard, Contas a Receber)

Refs: ADR 0182 (PageHeader hue per grupo), pageheader-canon skill C6

🤖 Generated with [Claude Code](https://claude.com/claude-code)
