### PR TITLE
docs(_DesignSystem): postmortem v3.1 — AP16 font herdada + AP17 overflow border

### DIFF
--- a/memory/requisitos/_DesignSystem/templates/PageHeader-LEARNINGS.md
+++ b/memory/requisitos/_DesignSystem/templates/PageHeader-LEARNINGS.md
@@ -99,4 +99,85 @@ de nomes de tabs.
 
 ---
 
+## SESSÃO 2026-05-25 — Postmortem Wave 1 piloto (Cliente/Index)
+
+### Contexto
+
+Apliquei canon v3.1 em `Pages/Cliente/Index.tsx` (PR #1457) e Wagner inspecionou em prod
+(`/contacts?type=customer`). 2 anti-padrões aparentemente "pequenos" que pareciam OK no
+protótipo mas QUEBRARAM em prod por ignorância de contexto.
+
+### Anti-padrão #16 — Font herdada de AppShellV2 (NUNCA mais confiar em herança)
+
+**O que aconteceu:**
+- Spec v3.1 §3 dizia `font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI"`
+- Meu protótipo standalone `b-v2-roxo-kpis.html` renderizou CORRETAMENTE (sem wrapper)
+- Em prod com AppShellV2, font ficou **`"IBM Plex Sans"`** porque o app define isso globalmente
+- Não forcei inline → herdou o IBM Plex global → quebrou a paridade com Cowork canon real
+
+**Por que isso é grave:**
+- Wagner escolheu família B Modern SaaS comparando 3 famílias visualmente (sessão 2026-05-24)
+- B usava system fonts → ficou diferente do que ele aprovou
+- "Quase certo" é diferente de "certo" — fidelidade ao spec é o ponto
+
+**Regra dura pra próxima:**
+> Quando spec define **font-family, color, sizing crítico** num componente isolado,
+> SEMPRE force inline OU via `className` específica. Nunca confie que vai herdar.
+> Especialmente em React+Inertia onde o wrapper (`<AppShellV2>`) pode redefinir tudo.
+
+**Como detectar antes:**
+1. Protótipo standalone roda SEM AppShellV2 → pode mascarar overrides
+2. Antes de codar, abrir uma tela QUALQUER do projeto + DevTools → ver font computed real
+3. Se font do app ≠ font do spec → spec precisa forçar OU canon precisa atualizar pra herdar
+4. Pest browser test deveria assertar `getComputedStyle(h1).fontFamily.includes('ui-sans-serif')`
+
+### Anti-padrão #17 — Overflow ⋮ com border (deve ser GHOST puro)
+
+**O que aconteceu:**
+- Usei `<Button variant="outline" size="icon">` do shadcn
+- `variant="outline"` aplica `border border-input` (slate-200 visível)
+- Em prod ficou um quadradinho com border ao lado do primary — peso visual alto demais
+- Wagner corrigiu: `⋮` deve ser **GHOST puro** (transparent, NO border)
+
+**Por que isso é grave:**
+- O `⋮` é ação de DESCOBERTA secundária — usuário só nota quando precisa
+- Border puxa atenção indevida — visualmente compete com primary que tem border colorida
+- Pattern Linear/Stripe/Notion: `⋮` é sempre invisível até hover (ghost real)
+
+**Regra dura pra próxima:**
+> Overflow `⋮` no header é SEMPRE `variant="ghost"` (transparent, sem border).
+> Outline button (com border) é pra ações secundárias EXPLÍCITAS (ex: "Cancelar" num modal).
+> Hierarquia visual no header: **primary colorido** + **secondary ghost** (sem nada entre).
+
+**Como detectar antes:**
+1. Protótipo HTML que fiz tinha `.btn.icon-only` COM border — copiei o defeito
+2. Cowork real medido (`Venda por Estagio FSM.html`) — não tinha overflow `⋮` visível pra comparar
+3. Spec v3.1 §4.4 dizia "ghost-outline" — ambíguo (ghost OU outline?) — termo confuso
+4. Pest browser test: `expect(getComputedStyle(overflow).border).toBe('1px solid transparent')`
+
+### Update aplicado ao SPEC (v3.1 stays, micro-fixes)
+
+- §3 (tokens canon): adicionar `--font-stack` explícito + nota "FORÇAR inline em React, não herdar"
+- §4.5 (overflow): mudar de "icon-only ghost-outline" para "**icon-only GHOST puro · NO border · transparent bg**"
+- §10 (decisões em aberto): adicionar "como override de font global do app (Tailwind config)"
+- §30 (anti-padrões catalogados — protótipo SPEC): adicionar AP16 (font herdada) + AP17 (overflow com border)
+
+### Outras métricas da sessão
+
+- PRs Wave 1: 1 (#1457) — mergeado mas com 6 bugs detectados em prod
+- Bugs encontrados: 6 (counter=0, KPI 5-cards legacy, header sem padding, border-duplo, toolbar separada, sufixo sumiu) + 2 desta sessão (font, overflow) = **8 bugs total**
+- Quick Sync infra falha: 1 (lock órfão Hostinger — resolveu com rerun)
+- Tempo até primeira validação visual em prod: ~10min após merge
+
+### Próxima sessão deve
+
+1. Aplicar fix dos 8 bugs num PR só (atomic) — não 8 PRs
+2. ANTES de codar, abrir DevTools em uma tela existente do projeto pra MEDIR a font real
+3. Forçar `style={{ fontFamily: ... }}` no `<header>` canon
+4. Trocar overflow pra `variant="ghost"` + `className="border-0"` se shadcn ghost ainda tem border
+5. Resolver counter das tabs via Controller (server-side counts) ou KPI strip já existente
+6. Substituir KpiStripClickable por 4-cards-strip canon v3.1 (ou adaptar)
+
+---
+
 <!-- Próximas sessões abaixo desta linha. NUNCA editar sessões anteriores. -->

--- a/memory/requisitos/_DesignSystem/templates/PageHeader-canon-v3-1.md
+++ b/memory/requisitos/_DesignSystem/templates/PageHeader-canon-v3-1.md
@@ -61,6 +61,9 @@ escopo Cadastro (hue per grupo de ADR 0182 fica em modo de espera até decisão 
 
 ## 3. Tokens canon (CSS variables `:root`)
 
+> **Regra dura — fonte:** AppShellV2 carrega `IBM Plex Sans` globalmente. Canon REJEITA herança.
+> SEMPRE forçar via `style={{ fontFamily: 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif' }}` no `<header>` do canon. Anti-padrão AP16 (LEARNINGS sessão 2026-05-25).
+
 ```css
 :root {
   /* superfícies */
@@ -90,7 +93,11 @@ escopo Cadastro (hue per grupo de ADR 0182 fica em modo de espera até decisão 
   --amber-text:  #b45309;
   --emerald-text:#047857;
   
-  /* tipografia */
+  /* tipografia — ATENÇÃO crítica:
+     AppShellV2 (Tailwind config) define IBM Plex Sans GLOBALMENTE.
+     PageHeader canon REJEITA herança — sempre FORÇAR via inline style
+     OU via classe `.page-header-canon` que reseta font-family.
+     Anti-padrão AP16 (PageHeader-LEARNINGS.md sessão 2026-05-25). */
   --font-stack:    ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif;
   --fs-h1:         16px;
   --fs-sub:        12px;
@@ -257,7 +264,49 @@ escopo Cadastro (hue per grupo de ADR 0182 fica em modo de espera até decisão 
 1. **`⋮` overflow** (icon-only ghost-outline) — abre Radix DropdownMenu com ações secundárias
 2. **Primary** roxo médio — ação principal `+ Novo {entidade}`
 
-### 4.5 Overflow menu (estrutura padrão)
+### 4.5 Overflow `⋮` button (estilo — GHOST PURO)
+
+> **Regra dura:** overflow `⋮` é GHOST puro — `bg: transparent` + `border: 0` (NÃO outline, NÃO soft).
+> Anti-padrão AP17 (LEARNINGS sessão 2026-05-25 — usar `variant="outline"` shadcn quebra).
+>
+> Em React: usar `variant="ghost"` + **forçar `className="border-0"`** se shadcn ghost ainda aplicar border.
+
+```css
+.btn.icon-only-ghost {
+  width: var(--btn-h);
+  height: var(--btn-h);
+  padding: 0;
+  background: transparent;
+  border: 0;
+  color: var(--text-dim);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--btn-radius);
+  transition: background 120ms cubic-bezier(0.4, 0, 0.2, 1), color 120ms;
+}
+.btn.icon-only-ghost:hover {
+  background: hsl(var(--accent));
+  color: var(--text-strong);
+}
+```
+
+```jsx
+{/* React equivalente */}
+<DropdownMenuTrigger asChild>
+  <button
+    type="button"
+    aria-label="Mais ações"
+    aria-haspopup="menu"
+    className="inline-flex items-center justify-center h-8 w-8 rounded-md bg-transparent border-0 text-muted-foreground hover:bg-accent hover:text-foreground transition-colors"
+  >
+    <MoreVertical className="h-4 w-4" />
+  </button>
+</DropdownMenuTrigger>
+```
+
+### 4.6 Overflow menu (estrutura interna padrão)
 
 ```jsx
 <DropdownMenu>

--- a/prototipo-ui/prototipos/pageheader-canon-v3/SPEC.md
+++ b/prototipo-ui/prototipos/pageheader-canon-v3/SPEC.md
@@ -1274,6 +1274,8 @@ Baselines em `tests/Browser/baselines/pageheader/*.png`. Diff threshold 0.1%. PR
 | AP13 | Underline sem `-mb-px` | Underline flutua 1px acima da linha base | `margin-bottom: -1px` sempre |
 | AP14 | Sem skip-link | Falha WCAG 2.4.1 | `<a href="#main-content" class="sr-only focus:not-sr-only">` |
 | AP15 | Primary sem disabled state quando offline | Usuário clica e nada acontece, frustração | `disabled={!online}` + visual feedback |
+| **AP16** | **Font herdada de AppShellV2 / Tailwind config global** | Spec dizia `ui-sans-serif`, prod ficou `IBM Plex Sans` (herdou wrapper). Protótipo standalone NÃO detectou pq não tem wrapper. Quebra paridade com Cowork canon real. | SEMPRE forçar `style={{ fontFamily: 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif' }}` no `<header>` canon. Pest browser test: assert `getComputedStyle(h1).fontFamily.includes('ui-sans-serif')` |
+| **AP17** | **Overflow `⋮` com border (shadcn `variant="outline"`)** | `variant="outline"` aplica `border border-input` slate-200 visível. ⋮ é ação de DESCOBERTA secundária, border puxa atenção indevida e compete com primary. | SEMPRE `variant="ghost"` + `className="border-0"` (caso shadcn ghost ainda aplique border). Pattern Linear/Stripe/Notion: ⋮ é invisível até hover. |
 
 ---
 


### PR DESCRIPTION
Grava memoria canon dos 2 anti-padroes detectados em prod (Wagner SESSAO 2026-05-25): font ficou IBM Plex em vez de system; overflow tem border (deveria ser ghost puro). Atualiza LEARNINGS + SPEC + bundle SPEC anti-padroes section. NAO inclui fix de codigo — proximo PR atomic.

Refs: ADR 0189, PR #1457