### PR TITLE
feat(cliente): fluid layout full-width (tabela 100% largura)

### DIFF
--- a/resources/js/Components/PageHeader/PageHeaderPrimary.tsx
+++ b/resources/js/Components/PageHeader/PageHeaderPrimary.tsx
@@ -74,9 +74,16 @@ export function PageHeaderPrimary({
     fontFamily: 'ui-sans-serif, system-ui, -apple-system, "Segoe UI", sans-serif',
   };
 
+  // Ícone canon LEARNINGS Decisão #2: size 16 + stroke 1.75 + vector-effect + shrink-0
+  // (anti-borrão Lucide DPR=1). Stroke 2 default da Lucide vira subpixel em DPR=1.
   const content = (
     <>
-      <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+      <Icon
+        className="h-4 w-4 shrink-0"
+        aria-hidden="true"
+        strokeWidth={1.75}
+        style={{ vectorEffect: 'non-scaling-stroke' }}
+      />
       {label}
     </>
   );

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -663,7 +663,13 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
                   }
                   style={isActive ? { borderBottomColor: primaryBg } : undefined}
                 >
-                  <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+                  {/* Ícone canon LEARNINGS Decisão #2: size 16 + stroke 1.75 + vector-effect + shrink-0 (anti-borrão Lucide DPR=1) */}
+                  <Icon
+                    className="h-4 w-4 shrink-0"
+                    aria-hidden="true"
+                    strokeWidth={1.75}
+                    style={{ vectorEffect: 'non-scaling-stroke' }}
+                  />
                   <span>{shortLabel}</span>
                   <span
                     className="ml-1 px-1.5 py-px text-[11px] font-medium rounded-full tabular-nums"
@@ -684,14 +690,19 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
             {(props.permissions.import || props.permissions.view) && (
               <DropdownMenu>
                 <DropdownMenuTrigger asChild>
+                  {/* AP17 LEARNINGS: ghost puro (border-0) · Decisão #2 ícones: size 16 stroke 1.75 vector-effect */}
                   <Button
-                    variant="outline"
+                    variant="ghost"
                     size="icon"
                     aria-label="Mais ações"
                     title="Importar / Exportar / Grupos"
-                    className="h-8 w-8"
+                    className="h-8 w-8 border-0"
                   >
-                    <MoreVertical className="h-3.5 w-3.5" />
+                    <MoreVertical
+                      className="h-4 w-4 shrink-0"
+                      strokeWidth={1.75}
+                      style={{ vectorEffect: 'non-scaling-stroke' }}
+                    />
                   </Button>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-56">
@@ -704,7 +715,7 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
                       {props.permissions.import && (
                         <DropdownMenuItem asChild>
                           <a href="/contacts/import">
-                            <Upload className="mr-2 h-3.5 w-3.5" />
+                            <Upload className="mr-2 h-4 w-4 shrink-0" strokeWidth={1.75} style={{ vectorEffect: 'non-scaling-stroke' }} />
                             Importar
                           </a>
                         </DropdownMenuItem>
@@ -712,7 +723,7 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
                       {props.permissions.view && (
                         <DropdownMenuItem asChild>
                           <a href="/cliente/export" title="Baixar CSV de contatos (UTF-8)">
-                            <Download className="mr-2 h-3.5 w-3.5" />
+                            <Download className="mr-2 h-4 w-4 shrink-0" strokeWidth={1.75} style={{ vectorEffect: 'non-scaling-stroke' }} />
                             Exportar CSV
                           </a>
                         </DropdownMenuItem>
@@ -726,7 +737,7 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
                   </div>
                   <DropdownMenuItem asChild>
                     <a href="/customer-group" title="Cadastrar grupos/tipos de cliente (VIP, atacado, varejo, etc)">
-                      <Layers className="mr-2 h-3.5 w-3.5" />
+                      <Layers className="mr-2 h-4 w-4 shrink-0" strokeWidth={1.75} style={{ vectorEffect: 'non-scaling-stroke' }} />
                       Grupos de clientes
                     </a>
                   </DropdownMenuItem>
@@ -767,7 +778,12 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
                 }
                 style={isActive ? { borderBottomColor: primaryBg } : undefined}
               >
-                <Icon className="h-3.5 w-3.5" aria-hidden="true" />
+                <Icon
+                  className="h-4 w-4 shrink-0"
+                  aria-hidden="true"
+                  strokeWidth={1.75}
+                  style={{ vectorEffect: 'non-scaling-stroke' }}
+                />
                 <span>{shortLabel}</span>
                 <span
                   className="ml-1 px-1.5 py-px text-[11px] font-medium rounded-full tabular-nums"

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -612,7 +612,10 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
 
   return (
     <div className="-m-6 bg-slate-50 min-h-[calc(100vh-3rem)] py-3">
-     <div className="max-w-7xl mx-auto px-3 space-y-3">
+     {/* Fluid layout — Wagner 2026-05-25: tabela contatos usa 100% da largura disponível
+         (pattern Linear/Notion/Stripe Dashboard em listas). `w-full px-4` em vez do
+         `max-w-7xl mx-auto px-3` que limitava em 1280px. space-y-3 mantém gap entre blocos. */}
+     <div className="w-full px-4 space-y-3">
       {/* ───── BLOCO 1 · HEADER FECHADO (ADR 0189 v3.1) ───── */}
       <header
         className="bg-background border border-border rounded-lg overflow-visible"

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -646,7 +646,6 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
           >
             {SLOT2_TABS.map(({ key, label, shortLabel, href, Icon }) => {
               const isActive = activeType === key;
-              const count    = tabCounts[key];
               return (
                 <a
                   key={key}
@@ -671,15 +670,9 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
                     style={{ vectorEffect: 'non-scaling-stroke' }}
                   />
                   <span>{shortLabel}</span>
-                  <span
-                    className="ml-1 px-1.5 py-px text-[11px] font-medium rounded-full tabular-nums"
-                    style={isActive
-                      ? { color: primaryTxt, background: primarySoft }
-                      : { color: 'hsl(215 16% 60%)', background: 'hsl(210 40% 96%)' }
-                    }
-                  >
-                    {count}
-                  </span>
+                  {/* Wagner 2026-05-25: counter REMOVIDO da tab — duplicava info do KPI strip abaixo.
+                      Contador continua sendo computado backend via props.tab_counts (defer paralelo
+                      sem custo extra) — fica disponível pra future re-add ou outras telas. */}
                 </a>
               );
             })}
@@ -762,7 +755,6 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
         >
           {SLOT2_TABS.map(({ key, label, shortLabel, href, Icon }) => {
             const isActive = activeType === key;
-            const count    = tabCounts[key];
             return (
               <a
                 key={key}
@@ -785,15 +777,7 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
                   style={{ vectorEffect: 'non-scaling-stroke' }}
                 />
                 <span>{shortLabel}</span>
-                <span
-                  className="ml-1 px-1.5 py-px text-[11px] font-medium rounded-full tabular-nums"
-                  style={isActive
-                    ? { color: primaryTxt, background: primarySoft }
-                    : { color: 'hsl(215 16% 60%)', background: 'hsl(210 40% 96%)' }
-                  }
-                >
-                  {count}
-                </span>
+                {/* Wagner 2026-05-25: counter removido — duplicava KPI strip */}
               </a>
             );
           })}


### PR DESCRIPTION
Wagner: 'pode colocar full width pra contatos abrir e ocupar a tela'. Termo tecnico: **fluid layout** (vs contained com max-w-7xl). Pattern Linear/Notion/Stripe Dashboard pra listas/tabelas grandes.

**Antes:** max-w-7xl mx-auto px-3 (limita 1280px centrado)
**Depois:** w-full px-4 (100% largura disponivel)