### PR TITLE
feat(cliente): BLOCO 1 header padding px-4 pt-4 (topo+lateral)

### DIFF
--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -622,7 +622,10 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
         className="bg-background border border-border rounded-lg overflow-visible"
         role="banner"
       >
-        <div className="flex items-center gap-4 px-6 py-3.5 min-h-[60px]">
+        {/* Wagner 2026-05-25: BLOCO 1 header padding pt-4 px-4 (16px topo+lateral) — antes
+            era px-6 py-3.5. Mantém bottom levemente menor pra underline da tab ativa
+            casar com border-bottom do card (pattern -mb-px). */}
+        <div className="flex items-center gap-4 pt-4 px-4 pb-3.5 min-h-[60px]">
           {/* ZONA L · identidade */}
           <div className="flex-1 min-w-0">
             <h1 className="text-base font-semibold tracking-tight text-foreground leading-snug">


### PR DESCRIPTION
Wagner: px-4 no topo, esquerda e direita do BLOCO 1.

**Antes:** px-6 py-3.5 (24px lat · 14px topo+rodape)
**Depois:** pt-4 px-4 pb-3.5 (16px topo+lat · 14px rodape mantido pra underline canon)