### PR TITLE
fix(linter): aceita module=_DesignSystem como legacy (destrava ADR frontmatter CI)

### DIFF
--- a/tests/Feature/Memory/AdrFrontmatterLinterTest.php
+++ b/tests/Feature/Memory/AdrFrontmatterLinterTest.php
@@ -58,6 +58,7 @@ const MODULE_VALIDOS    = [
     'Sells', 'Autopecas', 'Comissao', 'Pcp', 'Governance', 'ADS',
     'Infra', 'jana', 'sells', 'design-system', 'Sells',
     'NfeBrasil',    // ADR 0186 mergeada com case canônico do path Modules/NfeBrasil/ — append-only impede fix
+    '_DesignSystem', // ADRs 0189/0190 mergeadas com prefixo underscore (era convenção early-design-system) — append-only impede fix; convenção futura: design-system (lowercase)
 ];
 
 const CAMPOS_OBRIGATORIOS = [


### PR DESCRIPTION
## Resumo

ADR frontmatter linter (`tests/Feature/Memory/AdrFrontmatterLinterTest.php`) rejeitava `module: _DesignSystem` (vocabulário inválido), quebrando CI de **TODO PR aberto** que tocasse o banco de ADRs.

**Conflito de governança:**
- ADR frontmatter lint exige correção pra `design-system` (canon)
- Append-only canon ([Constituição Art. 3](../blob/main/memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md) + [ADR 0095](../blob/main/memory/decisions/0095-skills-tiers-convencao-interna.md)) **PROÍBE edição** de ADRs aceitas

## Resolução

Adicionar `_DesignSystem` à lista `MODULE_VALIDOS` como legacy variant — consistente com outros já aceitos (`NfeBrasil`, `Sells`, `jana`, `ADS`, `design-system`).

ADRs 0189/0190 ficam **intactas** (append-only respeitado). Convenção futura permanece `design-system` (lowercase, hyphen) — só nesses 2 ADRs específicos é aceito o variante PascalCase + underscore.

## Mudança

```diff
 // Legacy/Wave variants (case-sensitive em ADRs aceitas pre-migração — append-only Tier 0)
 'Sells', 'Autopecas', 'Comissao', 'Pcp', 'Governance', 'ADS',
 'Infra', 'jana', 'sells', 'design-system', 'Sells',
 'NfeBrasil',    // ADR 0186 mergeada com case canônico do path Modules/NfeBrasil/ — append-only impede fix
+'_DesignSystem', // ADRs 0189/0190 mergeadas com prefixo underscore (era convenção early-design-system) — append-only impede fix; convenção futura: design-system (lowercase)
```

## Destrava

- [#1469](https://github.com/wagnerra23/oimpresso.com/pull/1469) — `docs(adr): 0191 Microsoft Clarity`
- [#1473](https://github.com/wagnerra23/oimpresso.com/pull/1473) — `feat(consent): banner LGPD`

## Test plan

- [x] `php artisan test --filter=AdrFrontmatterLinterTest` passa local (7 tests, 20 assertions)
- [ ] CI ADR frontmatter lint passa
- [ ] PRs #1469 e #1473 re-rodam CI e destravam

🤖 Generated with [Claude Code](https://claude.com/claude-code)