### PR TITLE
feat(clarity): Microsoft Clarity integration gated por consent + multi-tenant tag

### DIFF
--- a/app/Http/Middleware/HandleInertiaRequests.php
+++ b/app/Http/Middleware/HandleInertiaRequests.php
@@ -156,7 +156,70 @@ class HandleInertiaRequests extends Middleware
             // Lido em ConsentBanner.tsx pra decidir se mostra a barra. Cookie
             // é HttpOnly (JS não enxerga) — share é o canal pro frontend.
             'consent' => $this->consentShare($request),
+            // ADR 0191 — Microsoft Clarity config (null quando snippet NÃO deve
+            // carregar: env off, sem project_id, anon, superadmin/oimpresso,
+            // ou sem consent analytics). Frontend não lê — snippet vem do Blade
+            // partial pra carregar cedo (evita race com hydration React).
+            'clarity' => $this->clarityShare($request),
         ]);
+    }
+
+    /**
+     * Microsoft Clarity config pro Inertia share (ADR 0191).
+     *
+     * Retorna `null` (snippet NÃO renderiza) quando QUALQUER guard falha:
+     *   - `services.clarity.enabled` = false (default — Wagner ativa manual)
+     *   - `services.clarity.project_id` ausente
+     *   - usuário não autenticado
+     *   - user_type ∈ ['superadmin', 'user_oimpresso'] (Wagner não polui dataset)
+     *   - consent analytics não aceito (LGPD opt-in obrigatório)
+     *
+     * Multi-tenant Tier 0 (ADR 0093): `business_id` vem de `auth.user.business_id`
+     * server-side, NUNCA de query string ou input cliente.
+     */
+    protected function clarityShare(Request $request): ?array
+    {
+        if (! config('services.clarity.enabled')) {
+            return null;
+        }
+        $projectId = config('services.clarity.project_id');
+        if (! $projectId) {
+            return null;
+        }
+        $user = $request->user();
+        if (! $user) {
+            return null;
+        }
+        if (in_array($user->user_type, ['superadmin', 'user_oimpresso'], true)) {
+            return null;
+        }
+        if (! $this->consentAnalyticsAccepted($request)) {
+            return null;
+        }
+
+        return [
+            'project_id'    => (string) $projectId,
+            'business_id'   => (string) $user->business_id,
+            'user_type'     => (string) $user->user_type,
+            'mask_strategy' => (string) config('services.clarity.mask_strategy', 'mask-all'),
+        ];
+    }
+
+    /**
+     * Verifica se o usuário aceitou cookies de analytics via banner LGPD.
+     * Reusa o cookie já parseado pelo `consentShare()`.
+     */
+    protected function consentAnalyticsAccepted(Request $request): bool
+    {
+        $raw = $request->cookie((string) config('services.consent.cookie_name', 'oimpresso_consent_v1'));
+        if (! $raw) {
+            return false;
+        }
+        $decoded = json_decode((string) $raw, true);
+        if (! is_array($decoded)) {
+            return false;
+        }
+        return (bool) ($decoded['analytics'] ?? false);
     }
 
     /**

--- a/config/services.php
+++ b/config/services.php
@@ -126,4 +126,28 @@ return [
         'categories'      => ['necessary', 'analytics', 'marketing'],
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Microsoft Clarity (session replay + heatmaps) — ADR 0191 LGPD-compliant
+    |--------------------------------------------------------------------------
+    |
+    | Setup: criar projeto em https://clarity.microsoft.com → anotar PROJECT_ID
+    | Ativação: CLARITY_ENABLED=true + CLARITY_PROJECT_ID=xxx em .env produção
+    | Default OFF — sem ativação manual Wagner, snippet NÃO carrega em lugar
+    | nenhum (zero risco de tracking sem opt-in).
+    |
+    | Multi-tenant: 1 projeto Clarity global + custom tag `business_id` no JS
+    | (filtragem nativa no dashboard). NUNCA criar 1 projeto por business.
+    |
+    | mask_strategy:
+    |   - 'mask-all' (default LGPD-safe) → mascarariza TODO texto/input;
+    |     unmask seletivo via `data-clarity-unmask="True"` em elementos seguros.
+    |   - 'mask-none' → captura tudo (NÃO usar em prod com PII de cliente).
+    */
+    'clarity' => [
+        'enabled'       => (bool) env('CLARITY_ENABLED', false),
+        'project_id'    => env('CLARITY_PROJECT_ID'),
+        'mask_strategy' => env('CLARITY_MASK_STRATEGY', 'mask-all'),
+    ],
+
 ];

--- a/resources/js/Components/PageHeader/PageHeaderPrimary.tsx
+++ b/resources/js/Components/PageHeader/PageHeaderPrimary.tsx
@@ -89,6 +89,8 @@ export function PageHeaderPrimary({
   );
 
   // Render como <a> quando tem href e não desabilitado
+  // ADR 0191 — data-clarity-unmask: label é verbo de ação ("Novo cliente",
+  // "Pagar") — não-PII; desmascarar pra rage-click heatmap fazer sentido.
   if (href && !disabled) {
     return (
       <a
@@ -98,6 +100,7 @@ export function PageHeaderPrimary({
         title={title}
         aria-label={ariaLabel}
         data-testid={dataTestId}
+        data-clarity-unmask="True"
       >
         {content}
       </a>
@@ -115,6 +118,7 @@ export function PageHeaderPrimary({
       title={title}
       aria-label={ariaLabel}
       data-testid={dataTestId}
+      data-clarity-unmask="True"
     >
       {content}
     </button>

--- a/resources/js/Layouts/AppShellV2.tsx
+++ b/resources/js/Layouts/AppShellV2.tsx
@@ -479,7 +479,11 @@ export default function AppShellV2({
         {/* MAIN COLUMN */}
         <div className="main" data-topbar={hideTopbar ? 'hidden' : 'on'}>
           {!hideTopbar && (
-          <header className="topbar">
+          /* ADR 0191 — data-clarity-unmask: breadcrumb + topnav são contexto
+             de navegação não-PII; desmascarar pra heatmap fazer sentido
+             visual no dashboard Clarity. Forms/listagens com dados de
+             cliente seguem mascarados pelo mask-all default. */
+          <header className="topbar" data-clarity-unmask="True">
             <div className="bc">
               {crumb.map((part, i) => (
                 <span key={i} style={{ display: 'inline-flex', alignItems: 'center', gap: 8 }}>

--- a/resources/js/Lib/clarity.ts
+++ b/resources/js/Lib/clarity.ts
@@ -1,0 +1,48 @@
+// @memcofre
+//   util: clarity
+//   adrs: ADR 0191 (Microsoft Clarity session replay LGPD-compliant)
+//   nota: helpers opcionais pra interagir com window.clarity em runtime.
+//         O snippet em si vem do Blade (resources/views/layouts/partials/clarity.blade.php)
+//         pra carregar cedo e evitar race com hydration React.
+
+import { hasConsent } from './consent';
+
+declare global {
+  interface Window {
+    clarity?: (...args: unknown[]) => void;
+  }
+}
+
+/**
+ * INTENCIONAL no-op. NÃO chamar clarity('identify', user_id) — ADR 0191
+ * §pegadinha 2: passar user_id pra Microsoft + cruzando com IP permite
+ * re-identificação. Mantemos sessões pseudoanônimas e filtramos via custom
+ * tags (business_id, user_type) já setadas no Blade snippet.
+ */
+export function clarityIdentify(_userId: string): void {
+  if (typeof console !== 'undefined') {
+    // eslint-disable-next-line no-console
+    console.warn('clarityIdentify is intentionally a no-op. See ADR 0191.');
+  }
+}
+
+/**
+ * Custom event pro Clarity dashboard. Útil pra marcar momentos relevantes
+ * (ex.: "venda_concluida", "erro_pagamento"). Respeita opt-in analytics.
+ */
+export function clarityEvent(name: string, data?: Record<string, unknown>): void {
+  if (typeof window === 'undefined' || !window.clarity) return;
+  if (!hasConsent('analytics')) return;
+  window.clarity('event', name, data);
+}
+
+/**
+ * Força upgrade da sessão atual pra session replay prioritário no Clarity
+ * (sessão será sampled-up mesmo que aleatoriamente caísse fora). Útil pra
+ * capturar fluxos críticos (erro fatal, abandono carrinho).
+ */
+export function clarityUpgradeSession(reason: string): void {
+  if (typeof window === 'undefined' || !window.clarity) return;
+  if (!hasConsent('analytics')) return;
+  window.clarity('upgrade', reason);
+}

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -136,6 +136,10 @@
         {{-- ADR 0191 — consent banner LGPD pra Blade legacy --}}
         @include('layouts.partials.consent-banner')
 
+        {{-- ADR 0191 — Microsoft Clarity session replay (Blade legacy).
+             Guard server-side decide se renderiza. --}}
+        @include('layouts.partials.clarity')
+
         <div class="modal fade view_modal" tabindex="-1" role="dialog" aria-labelledby="gridSystemModalLabel"></div>
 
         @if (!empty($__additional_views) && is_array($__additional_views))

--- a/resources/views/layouts/inertia.blade.php
+++ b/resources/views/layouts/inertia.blade.php
@@ -54,5 +54,9 @@
 </head>
 <body class="bg-background text-foreground antialiased">
     @inertia
+
+    {{-- Microsoft Clarity session replay (ADR 0191) — guard server-side decide
+         se renderiza. NÃO mover pro <head> (snippet oficial Microsoft é async). --}}
+    @include('layouts.partials.clarity')
 </body>
 </html>

--- a/resources/views/layouts/partials/clarity.blade.php
+++ b/resources/views/layouts/partials/clarity.blade.php
@@ -1,0 +1,49 @@
+{{--
+    Microsoft Clarity — session replay + heatmaps (ADR 0191).
+
+    Guards (TODOS devem passar pro snippet carregar):
+      1. CLARITY_ENABLED=true em .env (default false — Wagner ativa manual)
+      2. CLARITY_PROJECT_ID setado em .env
+      3. usuário autenticado
+      4. user_type NÃO é superadmin nem user_oimpresso (Wagner não polui dataset)
+      5. cookie consent LGPD presente com analytics=true (opt-in obrigatório)
+
+    Multi-tenant Tier 0 (ADR 0093): business_id vem de auth()->user()->business_id
+    server-side via Blade. Custom tag no JS pro dashboard filtrar por cliente.
+
+    NÃO chamar clarity('identify', user_id) — ADR 0191 §pegadinha 2 (re-identificação
+    cruzando user_id + IP). Manter sessões pseudoanônimas, filtrar via custom tags.
+
+    Carregar nos layouts root (inertia.blade.php + app.blade.php) via @include.
+    NÃO incluir em layouts públicos (auth2, home) — guard sempre retornaria false
+    anyway, mas economiza bytes.
+--}}
+@php
+    $clarityEnabled = config('services.clarity.enabled')
+        && config('services.clarity.project_id')
+        && auth()->check()
+        && ! in_array(auth()->user()->user_type ?? null, ['superadmin', 'user_oimpresso'], true);
+
+    if ($clarityEnabled) {
+        $consentRaw = request()->cookie(config('services.consent.cookie_name', 'oimpresso_consent_v1'));
+        $consentDecoded = $consentRaw ? json_decode((string) $consentRaw, true) : null;
+        $clarityEnabled = is_array($consentDecoded) && ! empty($consentDecoded['analytics']);
+    }
+@endphp
+
+@if ($clarityEnabled)
+<script type="text/javascript">
+    (function(c,l,a,r,i,t,y){
+        c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+        t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+        y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+    })(window, document, "clarity", "script", @json(config('services.clarity.project_id')));
+
+    @if (config('services.clarity.mask_strategy') === 'mask-all')
+    clarity("set", "mask_strategy", "all");
+    @endif
+
+    clarity("set", "business_id", @json((string) auth()->user()->business_id));
+    clarity("set", "user_type", @json((string) auth()->user()->user_type));
+</script>
+@endif

--- a/tests/Feature/Clarity/ClarityShareTest.php
+++ b/tests/Feature/Clarity/ClarityShareTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * ADR 0191 — clarityShare() do HandleInertiaRequests retorna config Clarity
+ * APENAS quando 5 guards passam (env on, project_id setado, user autenticado,
+ * user_type não-interno, consent analytics aceito).
+ *
+ * Reflection-based: chama o protected method direto sem hidratar DB completo,
+ * mesmo pattern usado em ConsentControllerTest.
+ */
+
+use App\Http\Middleware\HandleInertiaRequests;
+use Illuminate\Http\Request;
+
+/**
+ * Helper — chama HandleInertiaRequests::clarityShare() via reflection.
+ *
+ * @param  array{user?: object|null, cookie?: string|null}  $opts
+ */
+function callClarityShare(array $opts = []): ?array
+{
+    $cookieName = (string) config('services.consent.cookie_name', 'oimpresso_consent_v1');
+    $cookies = isset($opts['cookie']) ? [$cookieName => $opts['cookie']] : [];
+
+    $request = Request::create('/', 'GET', [], $cookies);
+    if (array_key_exists('user', $opts) && $opts['user'] !== null) {
+        $request->setUserResolver(fn () => $opts['user']);
+    }
+
+    $middleware = new HandleInertiaRequests();
+    $method = (new ReflectionClass($middleware))->getMethod('clarityShare');
+    $method->setAccessible(true);
+
+    return $method->invoke($middleware, $request);
+}
+
+function fakeUser(string $userType = 'user', int $businessId = 4): object
+{
+    return new class($userType, $businessId) {
+        public function __construct(public string $user_type, public int $business_id) {}
+    };
+}
+
+function consentCookieAnalytics(bool $analytics): string
+{
+    return (string) json_encode(['analytics' => $analytics, 'marketing' => false, 'ts' => now()->toIso8601String()]);
+}
+
+beforeEach(function () {
+    config()->set('services.clarity.enabled', true);
+    config()->set('services.clarity.project_id', 'abc1234567');
+    config()->set('services.clarity.mask_strategy', 'mask-all');
+});
+
+test('clarityShare retorna null quando CLARITY_ENABLED=false', function () {
+    config()->set('services.clarity.enabled', false);
+    $result = callClarityShare(['user' => fakeUser(), 'cookie' => consentCookieAnalytics(true)]);
+    expect($result)->toBeNull();
+});
+
+test('clarityShare retorna null quando CLARITY_PROJECT_ID está vazio', function () {
+    config()->set('services.clarity.project_id', null);
+    $result = callClarityShare(['user' => fakeUser(), 'cookie' => consentCookieAnalytics(true)]);
+    expect($result)->toBeNull();
+});
+
+test('clarityShare retorna null quando user não está autenticado', function () {
+    $result = callClarityShare(['user' => null, 'cookie' => consentCookieAnalytics(true)]);
+    expect($result)->toBeNull();
+});
+
+test('clarityShare retorna null quando user_type é superadmin', function () {
+    $result = callClarityShare([
+        'user' => fakeUser('superadmin'),
+        'cookie' => consentCookieAnalytics(true),
+    ]);
+    expect($result)->toBeNull();
+});
+
+test('clarityShare retorna null quando user_type é user_oimpresso', function () {
+    $result = callClarityShare([
+        'user' => fakeUser('user_oimpresso'),
+        'cookie' => consentCookieAnalytics(true),
+    ]);
+    expect($result)->toBeNull();
+});
+
+test('clarityShare retorna null quando consent analytics não foi aceito', function () {
+    $result = callClarityShare([
+        'user' => fakeUser(),
+        'cookie' => consentCookieAnalytics(false),
+    ]);
+    expect($result)->toBeNull();
+});
+
+test('clarityShare retorna null quando cookie consent ausente', function () {
+    $result = callClarityShare(['user' => fakeUser(), 'cookie' => null]);
+    expect($result)->toBeNull();
+});
+
+test('clarityShare retorna config completa quando todos guards passam', function () {
+    $result = callClarityShare([
+        'user' => fakeUser('user', 4),
+        'cookie' => consentCookieAnalytics(true),
+    ]);
+
+    expect($result)->toBeArray()
+        ->and($result['project_id'])->toBe('abc1234567')
+        ->and($result['business_id'])->toBe('4')
+        ->and($result['user_type'])->toBe('user')
+        ->and($result['mask_strategy'])->toBe('mask-all');
+});


### PR DESCRIPTION
## Summary

PR 2/2 do plano [ADR 0191](memory/decisions/0191-microsoft-clarity-session-replay-lgpd.md) — Microsoft Clarity (session replay + heatmaps) integrado de forma **LGPD-compliant** e **Tier 0 multi-tenant safe**. Consome o consent banner do PR 1 (#1473).

- **Default OFF** (`CLARITY_ENABLED=false`) — Wagner ativa manual em prod após criar projeto em https://clarity.microsoft.com e setar `CLARITY_PROJECT_ID` no `.env` Hostinger.
- 5 guards server-side (env on · project_id setado · auth · não-superadmin · consent analytics aceito) — qualquer um falhar, snippet NÃO renderiza.
- 1 projeto Clarity global + custom tag `business_id`/`user_type` no JS (filtragem nativa no dashboard, sem 200 projetos).
- Mask-all default + `data-clarity-unmask` seletivo em breadcrumb/topnav (AppShellV2) e label do `PageHeaderPrimary` (verbos não-PII).

## Arquivos tocados

| Arquivo | Mudança |
|---|---|
| `config/services.php` | Novo bloco `clarity` com docs inline (env keys + ativação manual) |
| `app/Http/Middleware/HandleInertiaRequests.php` | Share `clarity` (null when guards fail) + métodos `clarityShare()`/`consentAnalyticsAccepted()` |
| `resources/views/layouts/partials/clarity.blade.php` | Novo — snippet oficial Microsoft + custom tags + mesmos guards server-side |
| `resources/views/layouts/inertia.blade.php` | `@include('layouts.partials.clarity')` antes do `</body>` |
| `resources/views/layouts/app.blade.php` | `@include('layouts.partials.clarity')` antes do `</body>` |
| `resources/js/Lib/clarity.ts` | Novo — helpers `clarityEvent`/`clarityUpgradeSession` (respeitam consent); `clarityIdentify` intencional no-op |
| `resources/js/Layouts/AppShellV2.tsx` | `data-clarity-unmask` no `<header className="topbar">` |
| `resources/js/Components/PageHeader/PageHeaderPrimary.tsx` | `data-clarity-unmask` no `<a>`/`<button>` (label é verbo) |
| `tests/Feature/Clarity/ClarityShareTest.php` | Novo — 8 casos Pest (1 happy + 7 guards) via reflection |

## Tier 0 + LGPD checks

- [x] `CLARITY_ENABLED=false` default — sem ativação manual, snippet não carrega em lugar nenhum
- [x] `business_id` de `auth.user.business_id` server-side (ADR 0093)
- [x] Mask-all default (ADR 0191 §3)
- [x] Superadmin/user_oimpresso filtrados (ADR 0191 §5)
- [x] Só após auth + após consent analytics aceito (ADR 0191 §4)
- [x] `clarity('identify', user_id)` NÃO chamado (ADR 0191 §pegadinha 2 — re-identificação)
- [x] NÃO carrega em layouts públicos (`auth2`, `home`)
- [x] `CLARITY_PROJECT_ID` real NÃO commitado (test usa fake `'abc1234567'`)

## Test plan

- [x] `php vendor/bin/pest tests/Feature/Clarity/ClarityShareTest.php` — 8 passed, 12 assertions
- [x] `npm run build:inertia` — build OK (warnings preexistentes de chunk size, sem erros)
- [ ] Smoke prod pós-deploy (Wagner): após setar `CLARITY_ENABLED=true` + `CLARITY_PROJECT_ID=xxx` em `.env` Hostinger, abrir `/sells/create` como user não-admin com consent aceito → DevTools Network mostra `https://www.clarity.ms/tag/xxx` carregando → após 30s dashboard Clarity mostra sessão com tag `business_id=4`
- [ ] Smoke superadmin Wagner: abrir mesma tela → script NÃO carrega (verificar DevTools)

## Infra Contract

PR toca `app/Http/Middleware/HandleInertiaRequests.php`. Validação prod abaixo.

### 1. Happy path — pós ativação manual Wagner

Comando que valida o snippet em prod APÓS Wagner setar `CLARITY_ENABLED=true` + `CLARITY_PROJECT_ID=xxxxxxxxxx` no `.env` Hostinger.

```bash
# Esperado: HTML retornado contém o snippet Clarity (project_id renderizado).
# Pré-condição: cookie consent com analytics=true presente; user não-superadmin.
$ curl -sv -b 'oimpresso_consent_v1={"analytics":true,"marketing":false,"ts":"2026-05-25T00:00:00Z"}' \
    -b 'laravel_session=<sessao-user-comum>' \
    https://oimpresso.com/sells 2>&1 | grep -o 'clarity.ms/tag/[a-z0-9]*'
# Esperado: clarity.ms/tag/xxxxxxxxxx (10 chars do PROJECT_ID)
```

### 2. Regression adjacent — snippet NÃO carrega quando guard falha

```bash
# Sem cookie consent: snippet NÃO deve aparecer
$ curl -sv -b 'laravel_session=<sessao-user-comum>' \
    https://oimpresso.com/sells 2>&1 | grep -c 'clarity.ms/tag'
# Esperado: 0

# Superadmin (Wagner): snippet NÃO deve aparecer mesmo com consent
$ curl -sv -b 'oimpresso_consent_v1={"analytics":true,"marketing":false}' \
    -b 'laravel_session=<sessao-wagner-superadmin>' \
    https://oimpresso.com/sells 2>&1 | grep -c 'clarity.ms/tag'
# Esperado: 0

# Anon (login page): snippet NÃO deve aparecer
$ curl -sv https://oimpresso.com/login 2>&1 | grep -c 'clarity.ms/tag'
# Esperado: 0
```

### 3. Environment delta — onde Pest local NÃO prova prod

- [x] Pest local cobre `clarityShare()` (lógica pura) — mas NÃO cobre renderização Blade real em prod
- [ ] LSCache (LiteSpeed) pode servir HTML stale por usuário? Validar com `curl -sv` literal pós-deploy
- [ ] Verificar `Cache-Control: private` no response do Inertia (snippet renderiza com dados do user logado — nunca cacheável globalmente)
- [ ] `CLARITY_ENABLED=false` default em config — confirmar via `php artisan tinker; config('services.clarity.enabled')` em prod retorna `false` antes de qualquer ativação manual

**"Pest local NÃO prova prod. Validação prod via curl + DevTools obrigatória após Wagner ativar."**

### 4. Smoke prod pós-deploy

A preencher por Wagner após setar `CLARITY_ENABLED=true` + `CLARITY_PROJECT_ID` em `.env` Hostinger.

## Refs

- ADR 0191 — Microsoft Clarity session replay LGPD-compliant
- ADR 0093 — Multi-tenant Tier 0 (business_id server-side)
- PR 1: #1473 — consent banner LGPD
- Dossier: `memory/sessions/2026-05-25-como-integrar-microsoft-clarity.md`

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>