### PR TITLE
feat(cliente): BLOCO 2 KPI strip flutuante (remove duplo fundo + respiro lateral)

### DIFF
--- a/resources/js/Components/clientes/KpiStripClickable.tsx
+++ b/resources/js/Components/clientes/KpiStripClickable.tsx
@@ -182,7 +182,9 @@ export function KpiStripClickable({
   ];
 
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mt-4">
+    {/* mt-* removido (Wagner 2026-05-25): gap vertical entre blocos vem do `space-y-3`
+        do parent (Cliente/Index.tsx) — 12px canon `--gap-blocos`. */}
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
       {cards.map((card) => {
         const Icon = card.icon;
         const tone = TONE_STYLES[card.tone ?? 'primary'];

--- a/resources/js/Components/clientes/KpiStripClickable.tsx
+++ b/resources/js/Components/clientes/KpiStripClickable.tsx
@@ -181,9 +181,9 @@ export function KpiStripClickable({
     },
   ];
 
+  // mt-* removido (Wagner 2026-05-25): gap vertical entre blocos vem do `space-y-3`
+  // do parent (Cliente/Index.tsx) — 12px canon `--gap-blocos`.
   return (
-    {/* mt-* removido (Wagner 2026-05-25): gap vertical entre blocos vem do `space-y-3`
-        do parent (Cliente/Index.tsx) — 12px canon `--gap-blocos`. */}
     <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
       {cards.map((card) => {
         const Icon = card.icon;

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -794,33 +794,32 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
         </nav>
       </header>
 
-      {/* ───── BLOCO 2 · KPI STRIP SEPARADO (gap 12px do header) ───── */}
+      {/* ───── BLOCO 2 · KPI STRIP FLUTUANTE (sem moldura · 5 cards autossuficientes) ─────
+          Wagner 2026-05-25: removido wrapper externo `bg-background border rounded-lg` pra
+          eliminar "duplo fundo" (wrapper branco com 5 cards branco internos cada um já com
+          border + rounded próprios). Pattern Linear/Notion · cards flutuam direto · respiro
+          lateral vem do parent `<div w-full px-6>`. Toolbar de busca/filtros foi pra header
+          do BLOCO 3 (header do card da tabela, separada por border-b). */}
+      <Deferred data="kpis" fallback={<KpiSkeleton />}>
+        <KpiStripClickable
+          ativos={kpis?.com_os_aberta ?? 0}
+          comSaldo={kpis?.com_atraso ?? 0}
+          vips={kpiCounts.vipsCount}
+          sem90={kpiCounts.sem90Count}
+          novos={kpiCounts.novosCount}
+          activeKey={activeKpiKey}
+          onApply={applyKpiCard}
+        />
+      </Deferred>
+
+      {/* ───── BLOCO 3 · TOOLBAR + LISTA (toolbar como header do card da tabela) ───── */}
       <div className="bg-background border border-border rounded-lg overflow-hidden">
-
-          {/* PTDP Onda 2 — KPI strip clicável (5 cards-filtro). Substitui os 4 KpiCard
-              estáticos do Wave G. Counts: Ativos + ComSaldo usam `kpis` real do backend;
-              VIPs + Sem90 + Novos estimados client-side de `rows` (Onda 3 plug backend
-              dedicado quando volume de cadastros pedir). `KpiSkeleton` continua via
-              `<Deferred>` enquanto kpis carrega. */}
-          <Deferred data="kpis" fallback={<KpiSkeleton />}>
-            <KpiStripClickable
-              ativos={kpis?.com_os_aberta ?? 0}
-              comSaldo={kpis?.com_atraso ?? 0}
-              vips={kpiCounts.vipsCount}
-              sem90={kpiCounts.sem90Count}
-              novos={kpiCounts.novosCount}
-              activeKey={activeKpiKey}
-              onApply={applyKpiCard}
-            />
-          </Deferred>
-
-          {/* PT-01 Slot 3 Toolbar (Wagner 2026-05-24 sessão pós-Slot 2): busca + 6
-              filtros + contagem TODOS NA MESMA LINHA. Layout canônico Linear/Stripe:
-              busca à esquerda (flex-1 max-w-md) · filtros à direita (flex-shrink-0
-              gap-2). Wrap controlado (em 1280px Larissa cabe tudo · viewport <1100px
-              wraps graciosamente). PT-01 §62 "saved views · separador · filtros (chips)
-              · busca local" — todos juntos no Slot 3. */}
-          <div className="flex items-center gap-3 mt-6 flex-wrap" aria-label="Filtros e busca de contato">
+        {/* PT-01 Slot 3 Toolbar (Wagner 2026-05-25): movida pra header do BLOCO 3 pra
+            evitar 2º card-dentro-de-card no BLOCO 2 (sessão "tem dois fundos"). busca + 6
+            filtros + contagem todos juntos · ActiveChips removíveis logo abaixo · separado
+            da tabela por `border-b border-border`. Linear/Stripe pattern. */}
+        <div className="border-b border-border px-4 py-3">
+          <div className="flex items-center gap-3 flex-wrap" aria-label="Filtros e busca de contato">
             {/* Busca à esquerda — Slot 3 PT-01 (canônico flex-1 com max). */}
             <div className="relative flex-1 min-w-[200px] max-w-md">
               <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground pointer-events-none" />
@@ -943,10 +942,8 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
               </button>
             </div>
           )}
-      </div>
+        </div>
 
-      {/* ───── BLOCO 3 · LISTA (tabela) ───── */}
-      <div className="bg-background border border-border rounded-lg overflow-hidden">
         <Deferred data="customers" fallback={<TableSkeleton />}>
           <div className="rounded-lg border border-border bg-background overflow-hidden">
             <div className="overflow-x-auto">


### PR DESCRIPTION
## Summary

Wagner sessão 2026-05-25: "tem dois fundos, e falta folga na esquerda e direita" no BLOCO 2 (KPI strip) do Cliente/Index.

- Remove wrapper externo do BLOCO 2 (`bg-background border rounded-lg overflow-hidden`) que duplicava fundo + impedia respiro lateral — KPI strip agora flutua direto sobre `slate-50` da página (pattern Linear/Notion).
- Move toolbar (busca + 6 FilterDropdowns + contagem) e ActiveChips removíveis pra header do BLOCO 3 — mesmo card da tabela, separado por `border-b border-border px-4 py-3` (canon v3.1 §1 prevê BLOCO 2 = só KPI strip).
- Remove `mt-4` interno do `<KpiStripClickable>` — gap vertical agora vem do `space-y-3` (12px canon `--gap-blocos`) do parent.

## Antes vs Depois

| Sintoma | Antes | Depois |
|---|---|---|
| **Duplo fundo** | wrapper `bg-background border rounded-lg` + 5 cards internos cada um `bg-card border rounded-md` | só os 5 cards autossuficientes sobre `slate-50` |
| **Folga lateral** | cards encostavam na borda do wrapper externo | herda 24px do `<div w-full px-6>` do parent (mesmo respiro do BLOCO 1 + BLOCO 3) |
| **BLOCO 2 polluído** | KPI + toolbar + chips num só card | BLOCO 2 = só KPI · toolbar virou header do BLOCO 3 |

## Arquivos tocados

- [resources/js/Pages/Cliente/Index.tsx](resources/js/Pages/Cliente/Index.tsx) — remove wrapper BLOCO 2, reorganiza estrutura BLOCO 3
- [resources/js/Components/clientes/KpiStripClickable.tsx](resources/js/Components/clientes/KpiStripClickable.tsx) — remove `mt-4` interno

Diff: 29 inserções, 30 deleções (bem dentro do limite ≤300 da commit-discipline).

## Refs

- canon v3.1 §1 (3 blocos verticais separados gap 12px)
- canon v3.2 final BLOCO 1 fechado ontem (commit c0a820ef9 · PR #1478)
- [ADR 0189](memory/decisions/0189-pageheader-canon-v3-1-cadastro-roxo.md) · [template canon](memory/requisitos/_DesignSystem/templates/PageHeader-canon-v3-1.md) §4.6

## Test plan

- [ ] Larissa biz=4: abrir `/cliente?type=customer` em 1280px monitor — verificar (a) sem duplo fundo no KPI strip, (b) respiro lateral igual ao header BLOCO 1, (c) toolbar+chips agora colados na tabela (header dela)
- [ ] Filtros funcionam (Status/Tipo/UF/Tags/Sem compra há/Saldo) e ActiveChips aparecem abaixo
- [ ] KPI cards continuam clicáveis (filtro click-to-apply · `aria-pressed`)
- [ ] Mobile <768px: KPI cai pra grid 2×2 sem regressão visual
- [ ] Sem regressão em outras telas que importam `<KpiStripClickable>` (só Cliente/Index usa — verificado via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)