### PR TITLE
feat(cliente): respiro lateral 12px no BLOCO 2 KPI strip (mx-3 canon)

### DIFF
--- a/resources/js/Components/clientes/KpiStripClickable.tsx
+++ b/resources/js/Components/clientes/KpiStripClickable.tsx
@@ -183,8 +183,11 @@ export function KpiStripClickable({
 
   // mt-* removido (Wagner 2026-05-25): gap vertical entre blocos vem do `space-y-3`
   // do parent (Cliente/Index.tsx) — 12px canon `--gap-blocos`.
+  // mx-3 (Wagner 2026-05-25 #2): respiro lateral 12px de cada lado pra recuar o KPI
+  // strip do header/tabela. Match com gap vertical canon `--gap-blocos`. Cria simetria
+  // visual e diferencia o KPI strip dos outros blocos sem voltar a ter wrapper-card.
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mx-3">
       {cards.map((card) => {
         const Icon = card.icon;
         const tone = TONE_STYLES[card.tone ?? 'primary'];


### PR DESCRIPTION
## Summary

Continuação direta do PR #1481 — Wagner pediu respiro nas laterais do BLOCO 2 KPI pra diferenciar visualmente do header e tabela sem voltar a ter wrapper-card-dentro-de-card.

Adiciona `mx-3` (12px de margem horizontal cada lado) ao grid do `<KpiStripClickable>`. Total lateral: **24px parent (`px-6`) + 12px KPI = 36px da viewport edge**. KPI strip recuado 12px em relação ao Header BLOCO 1 e Tabela BLOCO 3 (que herdam apenas o `px-6` do parent).

## Por que 12px

Match com gap vertical canon `--gap-blocos` (12px = `space-y-3`). Cria simetria visual entre eixo X (`mx-3`) e Y (`space-y-3`) sem desalinhar muito da grid principal. Sutil mas perceptível em 1280px (monitor Larissa biz=4 ROTA LIVRE).

## Test plan

- [ ] /cliente?type=customer em 1280px: KPI strip recuado 12px lateral em relação ao header/tabela
- [ ] Mobile <768px: respiro mantido (12px de cada lado)
- [ ] Sem regressão funcional (cards continuam clicáveis · `aria-pressed` funcionando)

Diff: 4+/1- linhas. ✅ commit-discipline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)