### PR TITLE
feat(cliente): respiro lateral 24px no BLOCO 2 KPI (mx-3 → mx-6)

### DIFF
--- a/resources/js/Components/clientes/KpiStripClickable.tsx
+++ b/resources/js/Components/clientes/KpiStripClickable.tsx
@@ -183,11 +183,12 @@ export function KpiStripClickable({
 
   // mt-* removido (Wagner 2026-05-25): gap vertical entre blocos vem do `space-y-3`
   // do parent (Cliente/Index.tsx) — 12px canon `--gap-blocos`.
-  // mx-3 (Wagner 2026-05-25 #2): respiro lateral 12px de cada lado pra recuar o KPI
-  // strip do header/tabela. Match com gap vertical canon `--gap-blocos`. Cria simetria
-  // visual e diferencia o KPI strip dos outros blocos sem voltar a ter wrapper-card.
+  // mx-6 (Wagner 2026-05-25 #3): respiro lateral 24px de cada lado pra recuar o KPI
+  // strip do header/tabela. Espelha o `px-6` (24px) do parent — KPI strip fica
+  // visualmente "duplo-aninhado" em relação ao Header BLOCO 1 e Tabela BLOCO 3.
+  // Total lateral: 24px parent + 24px KPI = 48px viewport edge.
   return (
-    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mx-3">
+    <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mx-6">
       {cards.map((card) => {
         const Icon = card.icon;
         const tone = TONE_STYLES[card.tone ?? 'primary'];


### PR DESCRIPTION
## Summary

Wagner sessão 2026-05-25 #3: aumentar respiro lateral do KPI strip de 12px (`mx-3`) pra 24px (`mx-6`). Espelha o `px-6` (24px) do parent — KPI strip fica visualmente "duplo-aninhado" em relação ao Header BLOCO 1 e Tabela BLOCO 3.

**Total lateral:** 24px parent + 24px KPI = 48px viewport edge.

Continuação direta de #1481 + #1482.

🤖 Generated with [Claude Code](https://claude.com/claude-code)