### PR TITLE
docs(_DesignSystem): grava padrao BLOCO 2 canon v3.3 final (KPI strip flutuante)

### DIFF
--- a/memory/requisitos/_DesignSystem/templates/PageHeader-LEARNINGS.md
+++ b/memory/requisitos/_DesignSystem/templates/PageHeader-LEARNINGS.md
@@ -482,6 +482,138 @@ no primary button, é pattern PRÉ-ADR-0190. Migrar pra `oklch(0.55 0.15 295)` h
 - Frontend: `const tabCounts = props.tab_counts ?? {all:0, customer:0, ...}` (fallback enquanto defer carrega)
 - Performance: 5 COUNT queries paralelas via defer · OK com índice `(business_id, is_X)` ou `(business_id, type)`
 
+### Decisão canon #5 — BLOCO 2 KPI strip · pattern flutuante Stripe-style (NÃO strip-conectado canon §4.6)
+
+**Contexto:**
+Wagner inspecionou Cliente/Index em prod (2026-05-25 sessão "tem dois fundos, falta folga lateral").
+Apontou 2 problemas no BLOCO 2:
+
+1. **Duplo fundo:** wrapper externo `bg-background border border-border rounded-lg overflow-hidden`
+   envolvia 5 cards que JÁ tinham `bg-card border border-border rounded-md` próprios. Resultado:
+   card-dentro-de-card branco com 2 fundos sobrepostos.
+2. **Sem respiro lateral:** cards encostavam nas bordas do wrapper externo.
+
+Iteração em 3 PRs sequenciais (#1481, #1482, #1483) fechou o pattern final.
+
+**Pattern canônico final v3.3 (gravar aqui — fonte da verdade do BLOCO 2):**
+
+```jsx
+{/* BLOCO 2 — KPI strip FLUTUANTE (canon v3.3 final · 2026-05-25) */}
+{/* NUNCA envolver em wrapper `<div bg-background border rounded-lg>` —
+    cards são autossuficientes (cada um já tem bg + border + radius próprios). */}
+<Deferred data="kpis" fallback={<KpiSkeleton />}>
+  <KpiStripClickable
+    ...counts...
+    activeKey={activeKpiKey}
+    onApply={applyKpiCard}
+  />
+</Deferred>
+```
+
+E DENTRO do `<KpiStripClickable>`:
+
+```jsx
+{/* mx-6: respiro lateral 24px de cada lado pra recuar do BLOCO 1 e BLOCO 3.
+    Espelha `px-6` (24px) do parent — KPI strip fica "duplo-aninhado".
+    NÃO usar `mt-*` interno — gap vertical vem do `space-y-3` (12px) do parent. */}
+<div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mx-6">
+  {cards.map((card) => (
+    <button
+      className="group flex items-center gap-3 p-3 rounded-md border text-left transition-all
+                 bg-card border-border hover:border-muted-foreground hover:shadow-sm"
+      ...
+    >
+      {/* ícone tile 36x36 + label uppercase 10px + value 18px + sub 10px */}
+    </button>
+  ))}
+</div>
+```
+
+**Especificação token-a-token (BLOCO 2 v3.3):**
+
+| Atributo | Classe Tailwind | Valor | Razão |
+|---|---|---|---|
+| Wrapper | NENHUM | sem moldura externa | cards autossuficientes (cada um com border próprio) |
+| Grid | `grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3` | gap 12px entre cards | responsive 2→3→5 cols |
+| **Margem lateral** | **`mx-6`** | **24px de cada lado** | recuo em relação ao BLOCO 1/3 (que usam só `px-6` parent) |
+| Margem topo | nenhuma | 0 | gap vertical = `space-y-3` (12px) do parent |
+| Card | `bg-card border border-border rounded-md p-3` | branco · border slate-200 · radius 6px · padding 12px | autossuficiente |
+| Card active | `style={{ borderColor: tone.border, backgroundColor: tone.bgActive }}` | tone oklch inline | aria-pressed=true |
+| Ícone tile | `h-9 w-9 rounded-md` + bg tone.iconBg | 36x36 com bg colorido | hierarquia visual |
+| Label | `text-[10px] font-semibold tracking-wider uppercase text-muted-foreground` | 10px uppercase | label semântico curto |
+| Value | `text-lg font-semibold text-foreground tabular-nums` | 18px tabular | métricas legíveis |
+| Sub | `text-[10px] text-muted-foreground` | 10px contexto | hint subtítulo |
+
+**Razão das 3 quebras vs canon §4.6 original:**
+
+1. **5 cards (não 4):** canon §4.6 dizia `repeat(4, 1fr)`. Wave G Cliente PTDP precisou de 5 KPIs
+   semânticos (Ativos + VIPs + Com saldo + Sem 90d + Novos). `lg:grid-cols-5` ok em 1280px Larissa.
+2. **Cards flutuantes (não strip-conectado):** canon §4.6 usava `gap: 1px` com background slate-200
+   pra criar divisores finos entre cards. Versão Wave G usa `gap-3` (12px) com cards separados
+   — pattern Stripe Dashboard (cards "elevados") em vez de strip Linear-style.
+3. **Sem moldura externa:** §4.6 implícito tinha border + radius no `.kpi-strip` (wrapper). v3.3 final
+   remove wrapper porque os 5 cards já têm bg + border + radius próprios → duplo fundo elimina.
+
+**Iterações que levaram ao pattern (histórico):**
+
+1. **PR #1481** (commit `bd0968e1a`): remove wrapper externo `<div bg-background border rounded-lg>`
+   do BLOCO 2 + move toolbar (busca + 6 filtros + chips) pra header do BLOCO 3 (`border-b border-border
+   px-4 py-3` separando da tabela · pattern Linear/Stripe). Tira `mt-4` interno do KpiStripClickable
+   pra `space-y-3` governar gap vertical canon 12px.
+2. **PR #1482** (commit `9cc7a5c1c`): adiciona `mx-3` (12px respiro lateral). Match canon `--gap-blocos`.
+3. **PR #1483** (commit `577bafeab`): aumenta pra `mx-6` (24px) — espelha `px-6` parent. Wagner aprovou
+   como pattern final.
+
+**Comparativo BLOCO 1 vs BLOCO 2 vs BLOCO 3 (canon v3.3 final):**
+
+| Bloco | Card visual | Padding inner | Margem lateral total viewport |
+|---|---|---|---|
+| **BLOCO 1 (Header)** | `bg-background border rounded-t-lg overflow-visible` | `pt-6 px-6 pb-3.5` | 24px (só `px-6` parent) |
+| **BLOCO 2 (KPI strip)** | SEM wrapper — 5 cards autossuficientes flutuantes | cards têm `p-3` | **48px** (24px parent + 24px `mx-6` KPI) |
+| **BLOCO 3 (Toolbar + Tabela)** | `bg-background border border-border rounded-lg overflow-hidden` | toolbar `px-4 py-3` + tabela `px-4 py-2.5` | 24px (só `px-6` parent) |
+
+KPI strip é o ÚNICO bloco com recuo lateral extra — cria diferenciação visual sem voltar a ter
+wrapper-card-dentro-de-card. Pattern Stripe Dashboard.
+
+**Regra dura pra próximas Index (Wave 2+):**
+> BLOCO 2 KPI strip canon v3.3 = **SEM wrapper externo** + **`mx-6`** (24px lateral) + **SEM `mt-*` interno**.
+> Toolbar (busca + filtros + chips) vai pra HEADER do BLOCO 3 (mesmo card da tabela, separada por `border-b`).
+> 5 cards flutuantes (não strip-conectado) é o pattern Wave G+ — `lg:grid-cols-5 gap-3` + `bg-card border rounded-md`.
+
+**Sintoma de detecção pra próximo agente:**
+Se encontrar Index com `<div className="bg-background border border-border rounded-lg overflow-hidden">`
+envolvendo `<KpiStripClickable>` (ou similar 4/5 cards), é pattern PRÉ-v3.3. Remover wrapper +
+adicionar `mx-6` ao grid + mover toolbar pra BLOCO 3.
+
+**Não decidido (review trigger):**
+- 5 cards é Wave G específico ou pattern canon Wave 2+? — Larissa biz=4 7d feedback decide.
+- `mx-6` é universal ou varia por viewport? — testar 1024px e 1920px (Wagner usa 1568px hoje).
+- Como adaptar quando `<3 KPIs` (ex Modules de Comercial puro)? — provavelmente cair pra 3 cards centered.
+
+### Anti-padrão #20 — Comentário JSX `{/* */}` solto entre `return (` e elemento root
+
+**O que aconteceu:**
+- No PR #1481 adicionei comentário documentando `mt-4` removido como `{/* ... */}` JSX entre
+  `return (` e `<div className="grid ...">` do KpiStripClickable
+- Vite build CI falhou: `Expected ")" but found "className"` na linha 187
+- JSX `return (...)` precisa retornar UMA expressão (1 elemento root). Comentário JSX `{/* */}`
+  SOZINHO ali NÃO é JSX válido — só vale DENTRO de outro elemento como filho
+
+**Por que isso é grave:**
+- CI Vite quebrou o PR principal — precisei push commit #2 (`c2acec4d8`) só pra fix sintaxe
+- Visual local não pega — `npm run dev` (HMR) é mais permissivo que `vite build` produção
+- Esbuild produção é mais estrito
+
+**Regra dura pra próxima:**
+> Comentários documentando código DENTRO de função React vão como `// ...` JS regular
+> ANTES do `return (...)`, NÃO como `{/* ... */}` JSX entre `return (` e o elemento root.
+> JSX `{/* */}` SÓ vale DENTRO de outro elemento JSX (como filho).
+
+**Como detectar antes:**
+- `npm run build:inertia` local antes de push (mais rápido que esperar CI 40s)
+- Lint regra: `eslint-plugin-react/no-unknown-property` ou `jsx-no-comments-near-return` (custom)
+- Code review: se vê `{/* ... */}` na linha LOGO acima de `<element>` que abre o return, suspeitar
+
 ---
 
 <!-- Próximas sessões abaixo desta linha. NUNCA editar sessões anteriores. -->

--- a/memory/requisitos/_DesignSystem/templates/PageHeader-canon-v3-1.md
+++ b/memory/requisitos/_DesignSystem/templates/PageHeader-canon-v3-1.md
@@ -383,7 +383,13 @@ escopo Cadastro (hue per grupo de ADR 0182 fica em modo de espera até decisão 
 
 **3 seções canon:** Filtros / Dados / Configuração — sempre nessa ordem, separadas por `<DropdownMenuSeparator />`.
 
-### 4.6 KPI strip card
+### 4.6 KPI strip card (pattern original strip-conectado · 4 cards)
+
+> ⚠️ **2026-05-25 v3.3 amendment:** este pattern continua válido pra Index com **exatamente 4 KPIs**
+> + canon Linear-style (cards conectados por divisores 1px). Pra Index com **5+ KPIs** OU pattern
+> Stripe-style (cards flutuantes), ver **§4.6-BIS** abaixo. Pattern Wave G Cliente/Index usa §4.6-BIS.
+>
+> Não há conflito — coexistem. Escolha baseada em (a) número de KPIs, (b) estética alvo (Linear vs Stripe).
 
 ```css
 .kpi-strip {
@@ -439,12 +445,139 @@ escopo Cadastro (hue per grupo de ADR 0182 fica em modo de espera até decisão 
 }
 ```
 
-**KPI strip rules:**
+**KPI strip rules (§4.6 original — strip-conectado):**
 - SEMPRE 4 cards (não 3, não 5) — grid `repeat(4, 1fr)`
 - Cards são CLICÁVEIS (filtro click-to-apply) — usar `<button>` semântico, não `<div>`
 - `aria-pressed="true"` quando o filtro do card está ativo
 - Cards "alert" usam bg rose pra chamar atenção (uso parcimonioso — máx 1 alert por strip)
 - Em viewport `< 768px`: cair pra grid 2×2 via media query
+
+### 4.6-BIS KPI strip Stripe-style flutuante (canon v3.3 final · 5 cards · 2026-05-25)
+
+> **Origem:** Wave G Cliente/Index PTDP Onda 2 precisou 5 KPIs semânticos. PR #1481/#1482/#1483
+> consolidaram pattern. Detalhes iterativos em [PageHeader-LEARNINGS.md](./PageHeader-LEARNINGS.md)
+> Decisão canon #5.
+>
+> **Use quando:** (a) Index precisa de 5+ KPIs OU (b) prefere estética Stripe-style (cards "elevados"
+> com gap visual) em vez de strip-conectado Linear-style do §4.6 original.
+
+**JSX canon (copiar-colar):**
+
+```jsx
+{/* BLOCO 2 — KPI strip FLUTUANTE (NÃO envolver em wrapper card · cards autossuficientes) */}
+<Deferred data="kpis" fallback={<KpiSkeleton />}>
+  <KpiStripClickable
+    {...kpiCounts}
+    activeKey={activeKpiKey}
+    onApply={applyKpiCard}
+  />
+</Deferred>
+```
+
+E DENTRO do componente que renderiza os cards:
+
+```jsx
+{/* mx-6: respiro lateral 24px de cada lado (recuo vs BLOCO 1 e BLOCO 3).
+    Espelha `px-6` (24px) do parent — KPI strip fica "duplo-aninhado".
+    NÃO usar `mt-*` — gap vertical via `space-y-3` (12px canon) do parent. */}
+<div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3 mx-6">
+  {cards.map((card) => (
+    <button
+      type="button"
+      onClick={() => onApply(active ? null : card)}
+      aria-pressed={active}
+      className="group flex items-center gap-3 p-3 rounded-md border text-left transition-all
+                 bg-card border-border hover:border-muted-foreground hover:shadow-sm"
+      style={active ? { borderColor: tone.border, backgroundColor: tone.bgActive } : undefined}
+    >
+      <div className="h-9 w-9 rounded-md flex items-center justify-center flex-shrink-0"
+           style={{ backgroundColor: tone.iconBg }}>
+        <Icon className="h-4 w-4" style={{ color: tone.iconFg }} />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-[10px] font-semibold tracking-wider uppercase text-muted-foreground truncate leading-none">
+          {card.label}
+        </p>
+        <p className="text-lg font-semibold text-foreground tabular-nums leading-tight mt-1">
+          {card.value.toLocaleString('pt-BR')}
+        </p>
+        {card.sub && (
+          <p className="text-[10px] text-muted-foreground truncate leading-none mt-0.5">
+            {card.sub}
+          </p>
+        )}
+      </div>
+    </button>
+  ))}
+</div>
+```
+
+**Especificação token-a-token (§4.6-BIS):**
+
+| Atributo | Classe / Valor | Razão |
+|---|---|---|
+| **Wrapper externo** | **NENHUM** | cards autossuficientes (cada um com border + radius próprio) — evita duplo fundo |
+| Grid | `grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3` | responsive 2→3→5 cols · gap 12px |
+| **Margem lateral** | **`mx-6` (24px)** | recuo em relação ao BLOCO 1/3 (que usam só `px-6` parent) · total 48px viewport edge |
+| Margem vertical | nenhuma | gap vertical = `space-y-3` (12px) do parent Cliente/Index.tsx |
+| Card box | `bg-card border border-border rounded-md p-3` | branco · slate-200 border · 6px radius · 12px padding |
+| Card active | inline `borderColor` + `backgroundColor` por tone | aria-pressed=true · tone oklch específico |
+| Ícone tile | `h-9 w-9 rounded-md` + inline bg `tone.iconBg` | 36x36 colorido (hierarquia visual) |
+| Label | `text-[10px] font-semibold tracking-wider uppercase text-muted-foreground` | 10px uppercase semântico |
+| Value | `text-lg font-semibold text-foreground tabular-nums` | 18px tabular-nums métricas |
+| Sub | `text-[10px] text-muted-foreground leading-none mt-0.5` | 10px hint subtítulo opcional |
+
+**3 quebras propositais vs §4.6 original:**
+
+1. **5 cards (não 4):** `lg:grid-cols-5` — Wave G+ precisou 5 KPIs semânticos
+2. **Cards flutuantes (não strip-conectado):** `gap-3` (12px) com cards separados — pattern Stripe Dashboard
+3. **Sem moldura externa:** zero wrapper externo — evita duplo fundo (cards já têm bg + border próprios)
+
+**Tons oklch por card (Wave G Cliente — exemplo aplicável):**
+
+| Tone | Border | bgActive | iconBg | iconFg | Uso semântico |
+|---|---|---|---|---|---|
+| `primary` | `oklch(0.62 0.18 250)` | `oklch(0.95 0.04 250)` | `oklch(0.92 0.05 250)` | `oklch(0.45 0.18 250)` | Ativos (azul) |
+| `amber` | `oklch(0.72 0.15 70)` | `oklch(0.96 0.05 70)` | `oklch(0.93 0.07 70)` | `oklch(0.50 0.15 70)` | VIPs (dourado) |
+| `rose` | `oklch(0.65 0.20 20)` | `oklch(0.96 0.04 20)` | `oklch(0.93 0.06 20)` | `oklch(0.50 0.20 20)` | Com saldo (alerta) |
+| `emerald` | `oklch(0.65 0.14 155)` | `oklch(0.95 0.04 155)` | `oklch(0.92 0.06 155)` | `oklch(0.45 0.14 155)` | Sem 90d (churn neutro) |
+| `violet` | `oklch(0.60 0.18 295)` | `oklch(0.96 0.04 295)` | `oklch(0.93 0.06 295)` | `oklch(0.50 0.18 295)` | Novos (novidade) |
+
+**Toolbar (busca + filtros + chips) — NÃO fica no BLOCO 2:**
+
+Canon v3.3 manda mover toolbar pra **header do BLOCO 3** (mesmo card da tabela), separada por
+`border-b border-border px-4 py-3`. Razão: BLOCO 2 = só KPI strip por canon §1. Pattern Linear/Stripe
+agrupa search+filter+chips junto da data list que eles filtram.
+
+```jsx
+{/* BLOCO 3 = toolbar + tabela num só card */}
+<div className="bg-background border border-border rounded-lg overflow-hidden">
+  {/* Toolbar header: busca + N filtros + contagem + chips */}
+  <div className="border-b border-border px-4 py-3">
+    <div className="flex items-center gap-3 flex-wrap">
+      {/* search input + FilterDropdown[] + count span */}
+    </div>
+    {/* ActiveChips removíveis (condicional) */}
+  </div>
+  {/* Tabela */}
+  <Deferred data="customers" fallback={<TableSkeleton />}>
+    <table>...</table>
+  </Deferred>
+</div>
+```
+
+**Anti-padrão AP21 (catalogado §30) — wrapper externo no BLOCO 2:**
+```jsx
+{/* ❌ NUNCA — duplo fundo (wrapper branco com cards brancos internos) */}
+<div className="bg-background border border-border rounded-lg overflow-hidden">
+  <KpiStripClickable ... />
+</div>
+
+{/* ✅ Canon v3.3 — cards flutuantes direto */}
+<Deferred data="kpis">
+  <KpiStripClickable ... />
+</Deferred>
+```
 
 ## 5. Estados completos
 
@@ -669,5 +802,7 @@ interface PageHeaderProps {
 | v1 | 2026-04-XX | PageHeader canon 3 zonas inicial | [0180](../../../decisions/0180-pageheader-canon-3-zonas.md) |
 | v2 | 2026-05-21 | Hue per grupo (cadastro=202, financas=145, etc) | [0182](../../../decisions/0182-pageheader-canon-hue-per-grupo.md) |
 | **v3.1** | **2026-05-24** | **Modern SaaS + roxo médio 295 + KPI separado + ⋮ overflow + bloco fechado + tabs abreviadas** | **[0189](../../../decisions/0189-pageheader-canon-v3-1-cadastro-roxo.md)** |
+| **v3.2** | **2026-05-25** | **BLOCO 1 final · h1 22px/700 peso Vendas + padding `pt-6 px-6 pb-3.5` + `rounded-t-lg` (bottom reta) · primary universal 295 (sem hue per grupo)** | **[0190](../../../decisions/0190-primary-button-roxo-universal-295.md)** + LEARNINGS Decisões #1 (primary universal) + #3 (h1 peso) + #4 (BLOCO 1 pattern final) |
+| **v3.3** | **2026-05-25** | **BLOCO 2 KPI strip Stripe-style flutuante · 5 cards autossuficientes · `mx-6` (24px respiro) · sem wrapper externo · toolbar move pra header BLOCO 3 · AP21 catalogado** | LEARNINGS Decisão #5 + PRs [#1481](https://github.com/wagnerra23/oimpresso.com/pull/1481), [#1482](https://github.com/wagnerra23/oimpresso.com/pull/1482), [#1483](https://github.com/wagnerra23/oimpresso.com/pull/1483) |
 
 Iterações INTRA-versão (sem ADR formal) ficam em [PageHeader-LEARNINGS.md](./PageHeader-LEARNINGS.md).


### PR DESCRIPTION
## Summary

Wagner sessão 2026-05-25 pediu salvar preferências do BLOCO 2 após trilogia [#1481](https://github.com/wagnerra23/oimpresso.com/pull/1481) + [#1482](https://github.com/wagnerra23/oimpresso.com/pull/1482) + [#1483](https://github.com/wagnerra23/oimpresso.com/pull/1483) consolidar pattern final.

## Mudanças

### `PageHeader-LEARNINGS.md` — Decisão canon #5 + Anti-padrão #20
- Documenta pattern BLOCO 2 KPI strip Stripe-style flutuante (5 cards autossuficientes)
- 3 quebras propositais vs §4.6 original: 5 cards (não 4) · flutuante (não conectado) · sem wrapper externo
- Spec token-a-token + comparativo BLOCO 1/2/3 + iteração #1481→#1482→#1483
- AP20 catalogado: comentário JSX `{/* */}` solto entre `return (` e elemento root quebra Vite build

### `PageHeader-canon-v3-1.md` — §4.6-BIS + AP21 + v3.3 no histórico
- §4.6 original (strip-conectado 4 cards) **MANTIDO** com nota de coexistência (append-only canon)
- §4.6-BIS novo (Stripe-style flutuante 5 cards · v3.3) adicionado abaixo
- JSX canon completo + tabela token-a-token + 5 tones oklch por semântica
- AP21 catalogado: wrapper externo `<div bg-background border rounded-lg>` no BLOCO 2
- §12 histórico: v3.2 (BLOCO 1 final) + v3.3 (BLOCO 2 final) adicionados

## Por que docs-only (sem mexer em código)

Trilogia #1481/#1482/#1483 já entregou o pattern em código. Esse PR é APENAS gravação canon — fonte da verdade pras próximas Index Wave 2+ seguirem sem reinventar.

Pattern coexiste: tela com **4 KPIs canon Linear-style** usa §4.6 original. Tela com **5+ KPIs canon Stripe-style** usa §4.6-BIS.

## Test plan

- [x] UI lint: `✓ Nenhum arquivo UI modificado vs origin/main` (mudança só em `memory/`)
- [x] Pest unit: N/A (docs-only)
- [ ] Próximo agente trabalhando em Index Wave 2+ (Cliente/Show, Produto/Index, etc) lê §4.6-BIS antes de codar KPI strip
- [ ] Skill `pageheader-canon` continua descobrindo via SKILL.md (não muda)

🤖 Generated with [Claude Code](https://claude.com/claude-code)