### PR TITLE
feat(canon-v3.4): fundo Cliente/Index cream warm hue 90 (token bg-page-cream)

### DIFF
--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -89,6 +89,13 @@
   --color-background: hsl(0 0% 100%);
   --color-foreground: hsl(222.2 84% 4.9%);
 
+  /* canon v3.4 (Wagner 2026-05-25): fundo cream warm hue 90 pra Index canon v3.x.
+     Espelha `.cockpit` em /sells (Cowork canon · oklch(0.985 0.003 90)).
+     Substitui `bg-slate-50` cool hue 248. Cria afinidade visual com cards brancos
+     (mesma família temperatura) sem competir com filtros coloridos.
+     Gera utility `bg-page-cream` automaticamente via Tailwind v4. */
+  --color-page-cream: oklch(0.985 0.003 90);
+
   --color-primary: hsl(221.2 83.2% 53.3%);
   --color-primary-foreground: hsl(210 40% 98%);
   --color-secondary: hsl(210 40% 96.1%);
@@ -120,6 +127,9 @@
   --color-ring: hsl(212.7 26.8% 83.9%);
   --color-background: hsl(222.2 84% 4.9%);
   --color-foreground: hsl(210 40% 98%);
+
+  /* canon v3.4 dark mode: cream warm não inverte coerente — usa slate-950 neutro */
+  --color-page-cream: hsl(222.2 84% 4.9%);
 
   --color-primary: hsl(217.2 91.2% 59.8%);
   --color-primary-foreground: hsl(222.2 47.4% 11.2%);

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -611,7 +611,11 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
   };
 
   return (
-    <div className="-m-6 bg-slate-50 min-h-[calc(100vh-3rem)] py-4">
+    /* canon v3.4 (Wagner 2026-05-25): bg-page-cream substitui bg-slate-50 — fundo cream
+       warm hue 90 espelha `.cockpit` /sells canon Cowork. Cria afinidade visual com cards
+       brancos (mesma família temperatura) sem competir com filtros coloridos.
+       Token `--color-page-cream` definido em resources/css/inertia.css @theme block. */
+    <div className="-m-6 bg-page-cream min-h-[calc(100vh-3rem)] py-4">
      {/* Fluid layout — Wagner 2026-05-25: tabela contatos usa 100% da largura disponível
          (pattern Linear/Notion/Stripe Dashboard em listas). `w-full px-6` (24px respiro
          lateral) + `py-4` (16px respiro topo+rodapé) — Wagner pediu "respiro nas laterais


### PR DESCRIPTION
## Summary

Wagner sessão 2026-05-25 pediu fundo cream igual `/sells` (Cowork canon) em vez de slate-50 cool atual.

**Inspeção medida via browser MCP `getComputedStyle`:**
- `/sells .cockpit` bg = `oklch(0.985 0.003 90)` **cream warm hue 90**
- `/cliente -m-6 bg-slate-50` = `oklch(0.984 0.003 247.858)` **slate cool hue 248**

Mesma luminosidade 98.5%, mesma chroma 0.003 — **só muda o hue**. Cream tem afinidade visual com cards brancos (mesma família temperatura) sem competir com filtros coloridos.

## Mudanças

**`resources/css/inertia.css`** — novo token canon `--color-page-cream`:
- `@theme` light: `oklch(0.985 0.003 90)` (cream warm)
- `.dark`: `hsl(222.2 84% 4.9%)` (slate-950 — cream warm não inverte coerente)
- Tailwind v4 gera utility `.bg-page-cream { background-color: var(--color-page-cream) }` automaticamente

**`resources/js/Pages/Cliente/Index.tsx`** — 1 classe trocada:
```diff
- <div className="-m-6 bg-slate-50 min-h-[calc(100vh-3rem)] py-4">
+ <div className="-m-6 bg-page-cream min-h-[calc(100vh-3rem)] py-4">
```

## Escopo

- **Piloto Cliente/Index** (única tela canon v3.x em prod hoje)
- **Token canon global disponível** pra Wave 2+ — outras Index migram trocando `bg-slate-50` → `bg-page-cream` quando aderirem canon v3.x
- **Cards (BLOCO 1, 2, 3) continuam todos brancos** — só o "papel" da página muda de slate cool pra cream warm
- BLOCO 3 wrapper continua branco (Wagner aprovou — mantém hierarquia `cream fundo > branco cards`)

## Test plan

- [ ] Larissa biz=4 1280px: fundo cream visível, cards brancos destacam, filtros não "competem" visualmente
- [ ] Dark mode: `bg-page-cream` herda slate-950 (fallback) — sem branco-flash
- [ ] Sem regressão em ProducaoOficina/Index (outra tela com `-m-6 bg-slate-50` que NÃO mudou)
- [x] Build local Vite passou (1m 49s)
- [x] Utility `.bg-page-cream` gerada no CSS bundle (verificado via grep)

## Sequência canon

| Versão | PR | Mudança |
|---|---|---|
| v3.1 | #1457 piloto | Modern SaaS + roxo 295 + 3 blocos |
| v3.2 | #1475+1477+1478 | BLOCO 1 final (pt-6 px-6 pb-3.5 · h1 22/700 · rounded-t-lg) |
| v3.3 | #1481+1482+1483 | BLOCO 2 final (Stripe flutuante 5 cards · mx-6 24px) |
| **v3.4** | **este PR** | **Fundo cream `bg-page-cream` espelha /sells canon Cowork** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)