### PR TITLE
feat(cliente): BLOCO 1 header transparente (canon v3.4 espelha /sells)

### DIFF
--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -621,9 +621,13 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
          lateral) + `py-4` (16px respiro topo+rodapé) — Wagner pediu "respiro nas laterais
          e em cima". space-y-3 mantém gap entre blocos. */}
      <div className="w-full px-6 space-y-3">
-      {/* ───── BLOCO 1 · HEADER FECHADO (ADR 0189 v3.1) ───── */}
+      {/* ───── BLOCO 1 · HEADER TRANSPARENTE (canon v3.4 final · 2026-05-25) ─────
+          Wagner pediu remover `bg-background border rounded-t-lg` pra header herdar
+          o cream `--color-page-cream` do parent — espelha `/sells` canon Cowork exato
+          (`<header class="os-head vd-head-clean">` sem bg, border, ou radius).
+          BLOCO 1 dissolve no fundo cream · KPI strip vira primeiro elemento destacado. */}
       <header
-        className="bg-background border border-border rounded-t-lg overflow-visible"
+        className="overflow-visible"
         role="banner"
       >
         {/* Wagner 2026-05-25: BLOCO 1 header padding canon Vendas (referência /sells):
@@ -762,9 +766,10 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
           </div>
         </div>
 
-        {/* Mobile fallback: tabs em 2ª linha quando <md (no md+ ficam inline acima) */}
+        {/* Mobile fallback: tabs em 2ª linha quando <md (no md+ ficam inline acima).
+            canon v3.4: removido `border-t border-border` — consistência com header transparente. */}
         <nav
-          className="md:hidden flex items-center gap-0 border-t border-border overflow-x-auto px-4"
+          className="md:hidden flex items-center gap-0 overflow-x-auto px-4"
           aria-label="Tipo de contato (mobile)"
         >
           {SLOT2_TABS.map(({ key, label, shortLabel, href, Icon }) => {


### PR DESCRIPTION
## Summary

Wagner sessão 2026-05-25 (continuação canon v3.4): "acho que deve remover o fundo do grupo 1, para ficar com o --bg."

Header BLOCO 1 tinha `bg-background border border-border rounded-t-lg` (branco com border) que competia visualmente com o fundo cream warm (`bg-page-cream` PR #1485). Removido tudo — header agora herda o cream do parent, igual `/sells` canon Cowork exato.

## Mudança

```diff
- <header className="bg-background border border-border rounded-t-lg overflow-visible">
+ <header className="overflow-visible">

  {/* Mobile fallback */}
- <nav className="md:hidden flex items-center gap-0 border-t border-border overflow-x-auto px-4">
+ <nav className="md:hidden flex items-center gap-0 overflow-x-auto px-4">
```

## Resultado visual

- BLOCO 1 **"dissolve" no fundo cream** — só título "Clientes" + subtitle + subnav + actions visíveis
- KPI strip BLOCO 2 vira o **primeiro elemento "destacado"** da página (cards brancos sobre cream)
- BLOCO 3 (toolbar + tabela) continua card branco com border
- Pattern Vendas canon Cowork puro (`<header class="os-head vd-head-clean">` bg `rgba(0,0,0,0)`)

## Sequência canon completa fechada com esse PR

| Versão | PR | Mudança |
|---|---|---|
| v3.1 | #1457 | Modern SaaS + roxo 295 + 3 blocos |
| v3.2 | #1475/#1477/#1478 | BLOCO 1 final (pt-6 px-6 pb-3.5 · h1 22/700 · rounded-t-lg) |
| v3.3 | #1481/#1482/#1483 | BLOCO 2 final (Stripe flutuante 5 cards · mx-6 24px) |
| v3.4 fundo | #1485 | `bg-page-cream` (cream warm hue 90) |
| **v3.4 BLOCO 1** | **este PR** | **Header transparente — espelha /sells exato** |

🤖 Generated with [Claude Code](https://claude.com/claude-code)