### PR TITLE
feat(cliente): v3.4 polish paridade /sells (col Documento + linha BLOCO 1 + border KPI warm)

### DIFF
--- a/resources/js/Components/clientes/KpiStripClickable.tsx
+++ b/resources/js/Components/clientes/KpiStripClickable.tsx
@@ -202,9 +202,14 @@ export function KpiStripClickable({
             aria-pressed={on}
             className={
               'group flex items-center gap-3 p-3 rounded-md border text-left transition-all ' +
-              (on ? 'shadow-sm' : 'bg-card border-border hover:border-muted-foreground hover:shadow-sm')
+              (on ? 'shadow-sm' : 'bg-card hover:shadow-sm')
             }
-            style={on ? { borderColor: tone.border, backgroundColor: tone.bgActive } : undefined}
+            // canon v3.4 polish (Wagner 2026-05-25): border warm `oklch(0.9 0.004 90)`
+            // (cream-deeper · familia hue 90) substitui `border-border` cool slate-200.
+            // Espelha /sells `.os-kpi` exato. Afinidade visual com fundo cream.
+            style={on
+              ? { borderColor: tone.border, backgroundColor: tone.bgActive }
+              : { borderColor: 'oklch(0.9 0.004 90)' }}
           >
             <div
               className="h-9 w-9 rounded-md flex items-center justify-center flex-shrink-0"

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -621,14 +621,16 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
          lateral) + `py-4` (16px respiro topo+rodapé) — Wagner pediu "respiro nas laterais
          e em cima". space-y-3 mantém gap entre blocos. */}
      <div className="w-full px-6 space-y-3">
-      {/* ───── BLOCO 1 · HEADER TRANSPARENTE (canon v3.4 final · 2026-05-25) ─────
+      {/* ───── BLOCO 1 · HEADER TRANSPARENTE + border-b warm (canon v3.4 polish · 2026-05-25) ─────
           Wagner pediu remover `bg-background border rounded-t-lg` pra header herdar
-          o cream `--color-page-cream` do parent — espelha `/sells` canon Cowork exato
-          (`<header class="os-head vd-head-clean">` sem bg, border, ou radius).
-          BLOCO 1 dissolve no fundo cream · KPI strip vira primeiro elemento destacado. */}
+          o cream `--color-page-cream` do parent — espelha `/sells` canon Cowork exato.
+          v3.4 polish: adicionado `border-b` warm `oklch(0.93 0.004 90)` pra criar linha
+          divisora visual entre BLOCO 1 e BLOCO 2 (espelha `.vd-toolbar` border-bottom
+          em /sells). Mesmo hue 90 da familia cream — afinidade visual com fundo. */}
       <header
-        className="overflow-visible"
+        className="border-b overflow-visible"
         role="banner"
+        style={{ borderBottomColor: 'oklch(0.93 0.004 90)' }}
       >
         {/* Wagner 2026-05-25: BLOCO 1 header padding canon Vendas (referência /sells):
             pt-6 px-6 pb-3.5 (24px topo+lateral · 14px rodapé). Bottom menor pra underline
@@ -965,7 +967,7 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
                     <Th className="w-10">&nbsp;</Th>
                     <SortableTh sortKey="name" current={sortKey} dir={sortDir} onSort={handleSort}>Cliente</SortableTh>
                     <Th className="w-14">Tipo</Th>
-                    <Th className="w-32">Documento</Th>
+                    <Th className="w-44">Documento</Th>
                     <Th className="w-28">Cidade/UF</Th>
                     <SortableTh sortKey="last_os_at" current={sortKey} dir={sortDir} onSort={handleSort} className="w-36">Frescor</SortableTh>
                     <SortableTh sortKey="valor_aberto" current={sortKey} dir={sortDir} onSort={handleSort} align="right" className="w-28">Saldo</SortableTh>
@@ -1046,7 +1048,7 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
                             <TipoPill tipo={row.tipo ?? null} />
                           </td>
                           <td className="px-4 py-2.5">
-                            <span className="text-xs text-muted-foreground tabular-nums">
+                            <span className="text-xs text-muted-foreground tabular-nums whitespace-nowrap">
                               {row.tax_number_masked ?? '—'}
                             </span>
                           </td>


### PR DESCRIPTION
## Summary

Wagner sessão 2026-05-25 polish #3 apontou 3 itens após canon v3.4:

**(D) Coluna Documento em 2 linhas**
- CNPJ "22.274.502/0001-14" (17 chars) cabia mal em `w-32` (128px) → quebrava em "22.274.502/0001-" + "14"
- Fix: `w-32` → `w-44` (176px) + `whitespace-nowrap` no `<span>`

**(E) Falta linha entre BLOCO 1 e BLOCO 2 (existe em /sells)**
- `/sells` tem `.vd-toolbar` com `border-bottom: 1px oklch(0.93 0.004 90)`
- `/cliente` header transparente não tinha linha divisora
- Fix: `border-b` warm `oklch(0.93 0.004 90)` inline no `<header>` BLOCO 1

**(F) Border dos cards KPI cor diferente do /sells**
- `/sells` `.os-kpi` border: `1px oklch(0.9 0.004 90)` **warm cream-deeper**
- `/cliente` KPI border: `1px slate-200` **cool azul**
- Border cool sobre fundo cream warm criava dissonância de hue
- Fix: `KpiStripClickable.tsx` style inline `borderColor: oklch(0.9 0.004 90)` warm
- Mantém `tone.border` quando `aria-pressed=true` (active state semântico)

## Diff

```diff
// (D) Cliente/Index.tsx
- <Th className="w-32">Documento</Th>
+ <Th className="w-44">Documento</Th>

  <td className="px-4 py-2.5">
-   <span className="text-xs text-muted-foreground tabular-nums">
+   <span className="text-xs text-muted-foreground tabular-nums whitespace-nowrap">

// (E) Cliente/Index.tsx — BLOCO 1 header
- <header className="overflow-visible" role="banner">
+ <header className="border-b overflow-visible" role="banner"
+         style={{ borderBottomColor: 'oklch(0.93 0.004 90)' }}>

// (F) KpiStripClickable.tsx — cards default
  className={
    'group flex items-center gap-3 p-3 rounded-md border text-left transition-all ' +
-   (on ? 'shadow-sm' : 'bg-card border-border hover:border-muted-foreground hover:shadow-sm')
+   (on ? 'shadow-sm' : 'bg-card hover:shadow-sm')
  }
- style={on ? { borderColor: tone.border, backgroundColor: tone.bgActive } : undefined}
+ style={on
+   ? { borderColor: tone.border, backgroundColor: tone.bgActive }
+   : { borderColor: 'oklch(0.9 0.004 90)' }}
```

Diff: 16+/9- linhas em 2 arquivos.

## Test plan

- [ ] /cliente?type=customer: CNPJ "22.274.502/0001-14" cabe em 1 linha
- [ ] Linha sutil warm visível entre header "Clientes" e KPI strip
- [ ] Border dos cards KPI tonalidade warm (afinidade com fundo cream)
- [x] Build local Vite passou (1m 51s)
- [x] UI lint sem regressões

🤖 Generated with [Claude Code](https://claude.com/claude-code)