### PR TITLE
feat(_DesignSystem): extrai <PageHeader> componente canon v3.8 (Wave 2)

### DIFF
--- a/resources/js/Components/PageHeader/PageHeader.tsx
+++ b/resources/js/Components/PageHeader/PageHeader.tsx
@@ -1,0 +1,112 @@
+import * as React from 'react';
+
+/**
+ * PageHeader — componente canon do BLOCO 1 (header) das Index do oimpresso.
+ *
+ * Pattern canon v3.8 (LEARNINGS Decisão #4 + amendments v3.4 polish + v3.8 spacing):
+ *   - `border-b overflow-visible` (FLAT — sem bg, sem rounded, sem border full)
+ *   - `borderBottomColor: 'oklch(0.93 0.004 90)'` inline (linha divisora warm)
+ *   - `pt-6 px-6 pb-3.5` (24/24/14 espelha Vendas canon Cowork)
+ *   - `min-h-[60px] flex items-center gap-4` (3 zonas L/C/R)
+ *   - H1 `text-[22px] font-bold tracking-tight leading-snug` (peso Vendas)
+ *   - Subtitle `text-xs text-muted-foreground tabular-nums`
+ *
+ * Histórico de iterações:
+ *   v3.1 (PR #1457): card `bg-background border rounded-lg` + h1 16/600 + padding 16/16/14
+ *   v3.2 (PR #1477): h1 22/700 (peso Vendas) + padding 24/24/14
+ *   v3.2  (PR #1478): rounded-t-lg (bottom reta · conecta com BLOCO 2)
+ *   v3.4 polish:       border-b warm `oklch(0.93 0.004 90)` separação visual
+ *   v3.8 spacing:      header transparent (sem bg + sem border full + sem radius) · flat puro
+ *                      tipo /sells Cowork · linha warm divisora abaixo
+ *
+ * Refs: ADR 0189 amendment v3.2-v3.8, ADR 0190 (primary roxo universal).
+ *
+ * Uso canon:
+ *
+ *   <PageHeader
+ *     title="Clientes"
+ *     subtitle={<>31 cadastrados · 4 ativos</>}
+ *     subnav={<nav>tabs</nav>}
+ *     actions={
+ *       <>
+ *         <DropdownMenu>⋮</DropdownMenu>
+ *         <PageHeaderPrimary label="Novo cliente" href="/contacts/create" />
+ *       </>
+ *     }
+ *   />
+ */
+export interface PageHeaderProps {
+  /** Título principal · entidade da página. Ex: "Clientes", "Cobrança". */
+  title: string;
+  /** Sufixo cinza após o título · contexto. Ex: " · Boletos e PIX". Opcional. */
+  suffix?: string;
+  /** Subtítulo curto · métricas/contagem com `tabular-nums`. Pode ter `<strong>` semântico. */
+  subtitle?: React.ReactNode;
+  /** Zona C · subnav inline (tabs ou similar). Render entre Zona L e Zona R. Opcional. */
+  subnav?: React.ReactNode;
+  /** Zona R · actions (botões, overflow, primary). Render à direita com `ml-auto`. Opcional. */
+  actions?: React.ReactNode;
+  /** Mobile fallback nav (renderizado abaixo do flex inner, `md:hidden`). Opcional. */
+  mobileNav?: React.ReactNode;
+  /** Escape hatch · render livre dentro do flex inner (substitui subnav+actions). */
+  children?: React.ReactNode;
+  /** Classes extras pro `<header>` raiz. Use com parcimônia · canon override discouraged. */
+  className?: string;
+}
+
+export function PageHeader({
+  title,
+  suffix,
+  subtitle,
+  subnav,
+  actions,
+  mobileNav,
+  children,
+  className = '',
+}: PageHeaderProps) {
+  return (
+    <header
+      className={`border-b overflow-visible ${className}`.trim()}
+      role="banner"
+      style={{ borderBottomColor: 'oklch(0.93 0.004 90)' }}
+    >
+      <div className="flex items-center gap-4 pt-6 px-6 pb-3.5 min-h-[60px]">
+        {/* ZONA L · identidade */}
+        <div className="flex-1 min-w-0">
+          <h1 className="text-[22px] font-bold tracking-tight text-foreground leading-snug">
+            {title}
+            {suffix && (
+              <span className="font-semibold text-muted-foreground">{suffix}</span>
+            )}
+          </h1>
+          {subtitle && (
+            <p className="text-xs text-muted-foreground mt-0.5 tabular-nums">
+              {subtitle}
+            </p>
+          )}
+        </div>
+
+        {/* Escape hatch · children sobrescreve subnav+actions */}
+        {children ? (
+          children
+        ) : (
+          <>
+            {/* ZONA C · subnav (opcional) */}
+            {subnav}
+            {/* ZONA R · actions (opcional) */}
+            {actions && (
+              <div className="flex-shrink-0 flex items-center gap-1.5">
+                {actions}
+              </div>
+            )}
+          </>
+        )}
+      </div>
+
+      {/* Mobile fallback nav (renderizado se prop passada) */}
+      {mobileNav}
+    </header>
+  );
+}
+
+export default PageHeader;

--- a/resources/js/Components/PageHeader/index.ts
+++ b/resources/js/Components/PageHeader/index.ts
@@ -1,13 +1,13 @@
 /**
- * PageHeader canon components — ADR 0189 v3.1 + ADR 0190 (primary universal).
+ * PageHeader canon components — ADR 0189 v3.2 + ADR 0190 (primary universal).
  *
  * Componentes aqui implementam o template oficial documentado em
  * `memory/requisitos/_DesignSystem/templates/PageHeader-canon-v3-1.md`.
  *
- * Próximos componentes a adicionar (Wave 2):
- *   <PageHeader>         — wrapper completo 3 zonas
- *   <PageHeaderSubNav>   — Zona C subnav tabs com counter
+ * Próximos componentes a adicionar (Wave 3):
+ *   <PageHeaderSubNav>   — Zona C subnav tabs com counter (refatorar nav inline existente)
  *   <PageHeaderOverflow> — Zona R overflow ⋮ com 3 seções (Filtros/Dados/Configuração)
  *   <KpiStripCanon>      — BLOCO 2 KPI strip 4 cards branco frio
  */
+export { PageHeader, type PageHeaderProps } from './PageHeader';
 export { PageHeaderPrimary } from './PageHeaderPrimary';

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -45,7 +45,7 @@ import {
 } from 'lucide-react';
 import { Input } from '@/Components/ui/input';
 import { Button } from '@/Components/ui/button';
-import { PageHeaderPrimary } from '@/Components/PageHeader';
+import { PageHeader, PageHeaderPrimary } from '@/Components/PageHeader';
 import {
   DropdownMenu,
   DropdownMenuContent,

--- a/resources/js/Pages/Financeiro/Cobranca/Index.tsx
+++ b/resources/js/Pages/Financeiro/Cobranca/Index.tsx
@@ -22,6 +22,7 @@ import {
 } from 'lucide-react';
 import { Btn, StatusBadge, GatewayTipoChip, OrigemChip, KpiCard} from './_components/atoms';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import { PageHeader } from '@/Components/PageHeader';
 import FinanceiroPrimaryButton from '@/Pages/Financeiro/_shared/FinanceiroPrimaryButton';
 import FunnelStrip from './_components/FunnelStrip';
 import DrawerCobranca from './_components/DrawerCobranca';
@@ -177,43 +178,33 @@ function CobrancaPage({ cobrancas, kpis, funil, accounts = [], gateways = [], fi
 
   return (
     <div className="fin-cowork h-full bg-stone-50 flex flex-col font-sans pg-shell-scope">
-      {/* BLOCO 1 — Header card canon v3.2 (LEARNINGS Decisao #4 · 2026-05-25)
-          rounded-t-lg + pt-6 px-6 pb-3.5 + h1 22/700 espelha Vendas canon Cowork.
-          Substitui header Cowork legacy (os-page-h fin-page-h) por canon Tailwind.
-          FinanceiroSubNav + FinanceiroPrimaryButton mantidos como wrappers legacy
-          até Wave 2 refactor pra <PageHeaderPrimary> universal (ADR 0190). */}
+      {/* BLOCO 1 — Header canon v3.8 via <PageHeader> componente compartilhado.
+          Wave 2 (2026-05-25): refactor pra usar `<PageHeader>` de @/Components/PageHeader.
+          Antes era inline JSX duplicado · agora 1 componente serve 13+ telas Financeiro.
+          FinanceiroSubNav + FinanceiroPrimaryButton mantidos (Wave 3 vai unificar). */}
       <div className="fin-curadoria vendas-aplus">
-        <header
-          className="bg-background border border-border rounded-t-lg overflow-visible"
-          role="banner"
+        <PageHeader
+          title="Cobrança"
+          suffix=" · Boletos e PIX"
+          subtitle={<>{kpis.aberto.qtd} em aberto · gestão de remessa/retorno + gateways</>}
         >
-          <div className="flex items-center gap-4 pt-6 px-6 pb-3.5 min-h-[60px]">
-            <div className="flex-1 min-w-0">
-              <h1 className="text-[22px] font-bold tracking-tight text-foreground leading-snug">
-                Cobrança<span className="font-semibold text-muted-foreground"> · Boletos e PIX</span>
-              </h1>
-              <p className="text-xs text-muted-foreground mt-0.5 tabular-nums">
-                {kpis.aberto.qtd} em aberto · gestão de remessa/retorno + gateways
-              </p>
-            </div>
-            <div className="flex-shrink-0 flex items-center gap-1.5">
-              {/* ADR 0180 Fase 5 — SubNav com 12 ghosts Financeiro + extraOverflow contextual */}
-              <FinanceiroSubNav
-                active="cobranca"
-                hidePrimary
-                extraOverflowItems={[
-                  { key: 'resumir',  label: 'Resumir mês',     icon: <span>✦</span>,         onClick: () => setAiOpen(true),                            title: 'Resumir cobranças deste mês — IA' },
-                  { key: 'gateways', label: 'Gateways',        icon: <Settings size={13} />, onClick: () => router.visit('/settings/payment-gateways'), title: 'Configurar gateways' },
-                  { key: 'remessa',  label: 'Remessa/Retorno', icon: <Upload size={13} />,   onClick: () => setRemessaOpen(true) },
-                ]}
-              />
-              {/* FinanceiroPrimaryButton ja eh shim DEPRECATED -> roxo 295 universal (ADR 0190 + PR #1462) */}
-              <FinanceiroPrimaryButton onClick={() => setNovaOpen(true)}>
-                Nova cobrança
-              </FinanceiroPrimaryButton>
-            </div>
+          {/* Children = Zona R custom: SubNav 12 ghosts + extraOverflow + Primary */}
+          <div className="flex-shrink-0 flex items-center gap-1.5 ml-auto">
+            <FinanceiroSubNav
+              active="cobranca"
+              hidePrimary
+              extraOverflowItems={[
+                { key: 'resumir',  label: 'Resumir mês',     icon: <span>✦</span>,         onClick: () => setAiOpen(true),                            title: 'Resumir cobranças deste mês — IA' },
+                { key: 'gateways', label: 'Gateways',        icon: <Settings size={13} />, onClick: () => router.visit('/settings/payment-gateways'), title: 'Configurar gateways' },
+                { key: 'remessa',  label: 'Remessa/Retorno', icon: <Upload size={13} />,   onClick: () => setRemessaOpen(true) },
+              ]}
+            />
+            {/* FinanceiroPrimaryButton ja eh shim DEPRECATED -> roxo 295 universal (ADR 0190 + PR #1462) */}
+            <FinanceiroPrimaryButton onClick={() => setNovaOpen(true)}>
+              Nova cobrança
+            </FinanceiroPrimaryButton>
           </div>
-        </header>
+        </PageHeader>
       </div>
 
       {/* FUNIL */}


### PR DESCRIPTION
Wagner: 'faça o melhor' — Wave 2 do canon PageHeader.

**Novo componente compartilhado:** resources/js/Components/PageHeader/PageHeader.tsx (canon v3.8)

**API:** title, suffix, subtitle, subnav, actions, mobileNav, children (escape hatch).

**Migrado:**
- Cobranca/Index: era inline v3.2 (rounded-t-lg) -> agora canon v3.8 via componente

**Refs:** ADR 0189 amendment v3.8, ADR 0190, LEARNINGS Decisão #4