### PR TITLE
feat(financeiro): Wave 4 — migra 10 telas pra <PageHeader> canon v3.8

### DIFF
--- a/resources/js/Pages/Financeiro/Caixa/Index.tsx
+++ b/resources/js/Pages/Financeiro/Caixa/Index.tsx
@@ -7,6 +7,7 @@ import AppShellV2 from '@/Layouts/AppShellV2';
 import { router, usePage } from '@inertiajs/react';
 import { ReactNode, useMemo } from 'react';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import { PageHeader } from '@/Components/PageHeader';
 
 interface CaixaRow {
   id: number;
@@ -86,25 +87,25 @@ function Caixa({ caixas, stats, filters, links }: Props) {
 
   return (
     <div className="fin-curadoria p-6 max-w-7xl mx-auto space-y-6">
-      <header className="os-page-h fin-page-h">
-        <div className="os-page-h-l fin-page-h-l">
-          <h1>
-            Caixa do turno <span className="fin-hero-title-sub">· Histórico e fechamentos</span>
-          </h1>
-          <p>
+      {/* Wave 4 (2026-05-25): migrado pra <PageHeader> canon v3.8 (PR #1496) */}
+      <PageHeader
+        title="Caixa do turno"
+        suffix=" · Histórico e fechamentos"
+        subtitle={
+          <>
             Visão read-only dos turnos de caixa (abertura e fechamento) feitos pela equipe via tela
             POS. Para abrir ou fechar um caixa, use os botões na header da{' '}
             <a href={links.pos_create} className="underline text-emerald-700">
               tela de venda
             </a>
             .
-          </p>
-        </div>
-        <div className="os-page-h-r fin-page-h-r">
-          {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
+          </>
+        }
+      >
+        <div className="flex-shrink-0 flex items-center gap-1.5 ml-auto">
           <FinanceiroSubNav active="caixa" hidePrimary />
         </div>
-      </header>
+      </PageHeader>
 
       {/* Banner explicativo — esta tela é WRAPPER, não substitui POS */}
       <div className="rounded-md border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-900">

--- a/resources/js/Pages/Financeiro/Categorias/Index.tsx
+++ b/resources/js/Pages/Financeiro/Categorias/Index.tsx
@@ -9,6 +9,7 @@ import { Tag, Plus, Pencil, Trash2, Power, PowerOff } from 'lucide-react';
 import { toast } from 'sonner';
 import { CategoriaSheet } from './components/CategoriaSheet';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import { PageHeader } from '@/Components/PageHeader';
 import FinanceiroPrimaryButton from '@/Pages/Financeiro/_shared/FinanceiroPrimaryButton';
 
 interface Categoria {
@@ -73,19 +74,19 @@ function Index({ categorias, planos_conta }: Props) {
           + os-btn primary. Aplicado em telas do Financeiro pra consistência
           visual depois do bundle copy canon (PR 1164). */}
       <div className="fin-curadoria vendas-aplus p-6 max-w-5xl mx-auto space-y-6">
-        <header className="os-page-h fin-page-h">
-          <div className="os-page-h-l fin-page-h-l">
-            <h1>Categorias <span className="fin-hero-title-sub">· Tags livres</span></h1>
-            <p>Complementam o plano de contas (que é fixo/contábil) — organizam lançamentos pra relatórios</p>
-          </div>
-          <div className="os-page-h-r fin-page-h-r">
-            {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
+        {/* Wave 4 (2026-05-25): migrado pra <PageHeader> canon v3.8 */}
+        <PageHeader
+          title="Categorias"
+          suffix=" · Tags livres"
+          subtitle={<>Complementam o plano de contas (que é fixo/contábil) — organizam lançamentos pra relatórios</>}
+        >
+          <div className="flex-shrink-0 flex items-center gap-1.5 ml-auto">
             <FinanceiroSubNav active="categorias" hidePrimary />
             <FinanceiroPrimaryButton onClick={() => setCreating(true)}>
               Nova categoria
             </FinanceiroPrimaryButton>
           </div>
-        </header>
+        </PageHeader>
 
         <div className="rounded-md border">
           <table className="w-full text-sm">

--- a/resources/js/Pages/Financeiro/Conciliacao/Index.tsx
+++ b/resources/js/Pages/Financeiro/Conciliacao/Index.tsx
@@ -11,6 +11,7 @@ import { useForm, router } from '@inertiajs/react';
 import { type ReactNode, type FormEvent, useState } from 'react';
 import { Upload, Check, X, Search } from 'lucide-react';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import { PageHeader } from '@/Components/PageHeader';
 
 interface Linha {
   id: number;
@@ -86,16 +87,16 @@ function FinanceiroConciliacao({ linhas, stats, contas }: Props) {
   return (
     <div className="fin-curadoria vendas-aplus">
       {/* Onda 19 — header canon */}
-      <header className="os-page-h fin-page-h">
-        <div className="os-page-h-l fin-page-h-l">
-          <h1>Conciliação <span className="fin-hero-title-sub">· OFX bancário</span></h1>
-          <p>Importe extrato OFX → parser detecta transações → fuzzy match com títulos abertos → aprovar manualmente</p>
-        </div>
-        <div className="os-page-h-r fin-page-h-r">
-          {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
+      {/* Wave 4 (2026-05-25): migrado pra <PageHeader> canon v3.8 */}
+      <PageHeader
+        title="Conciliação"
+        suffix=" · OFX bancário"
+        subtitle={<>Importe extrato OFX → parser detecta transações → fuzzy match com títulos abertos → aprovar manualmente</>}
+      >
+        <div className="flex-shrink-0 flex items-center gap-1.5 ml-auto">
           <FinanceiroSubNav active="conciliacao" hidePrimary />
         </div>
-      </header>
+      </PageHeader>
 
       {/* KPI strip canon */}
       <div className="fin-stats">

--- a/resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasBancarias/Index.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent } from '@/Components/ui/card';
 import { Settings, Plus, AlertTriangle, CheckCircle2, MinusCircle } from 'lucide-react';
 import { ConfigurarBoletoSheet } from './components/ConfigurarBoletoSheet';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import { PageHeader } from '@/Components/PageHeader';
 
 interface Account {
   id: number;
@@ -67,17 +68,18 @@ function Index({ accounts, bancos_suportados }: Props) {
     <>
       {/* Onda 12.8 (2026-05-19) — header canon paridade Unificado */}
       <div className="fin-curadoria vendas-aplus p-6 max-w-6xl mx-auto space-y-6">
-        <header className="os-page-h fin-page-h">
-          <div className="os-page-h-l fin-page-h-l">
-            <h1>Contas Bancárias <span className="fin-hero-title-sub">· Dados de emissão de boleto</span></h1>
-            <p>
+        {/* Wave 4 (2026-05-25): migrado pra <PageHeader> canon v3.8 */}
+        <PageHeader
+          title="Contas Bancárias"
+          suffix=" · Dados de emissão de boleto"
+          subtitle={
+            <>
               Banco, agência, beneficiário. Cadastro principal continua em "Contas de pagamento" do POS;
               credenciais API (Inter, Asaas, C6) ficam em <a href="/settings/payment-gateways" className="underline underline-offset-2">Gateways de Pagamento</a>.
-            </p>
-          </div>
-          <div className="os-page-h-r fin-page-h-r">
-            {/* ADR 0180 Fase 5 refine Wagner 2026-05-21 — botão "Gateways" vai pro ⋯ Mais;
-                primary "Nova conta no POS" mantém-se canto direito (canon Unificado) */}
+            </>
+          }
+        >
+          <div className="flex-shrink-0 flex items-center gap-1.5 ml-auto">
             <FinanceiroSubNav
               active="contas-bancarias"
               hidePrimary
@@ -85,15 +87,16 @@ function Index({ accounts, bancos_suportados }: Props) {
                 { key: 'gateways', label: 'Gateways', icon: <Settings size={13} />, onClick: () => { window.location.href = '/settings/payment-gateways'; }, title: 'Credenciais API gateways de pagamento' },
               ]}
             />
+            {/* TODO Wave 5: migrar pra <PageHeaderPrimary> (este inline ainda é verde 145 legacy) */}
             <a
               href="/account/account/create"
               className="os-btn primary"
-              style={{ backgroundColor: 'oklch(0.55 0.15 145)', color: 'oklch(0.99 0 0)' }}
+              style={{ backgroundColor: 'oklch(0.55 0.15 295)', borderColor: 'oklch(0.45 0.15 295)', color: 'oklch(0.99 0 0)' }}
             >
               <Plus size={13} /> Nova conta
             </a>
           </div>
-        </header>
+        </PageHeader>
 
         <div className="rounded-md border">
           <table className="w-full text-sm">

--- a/resources/js/Pages/Financeiro/ContasPagar/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasPagar/Index.tsx
@@ -13,6 +13,7 @@ import { Textarea } from '@/Components/ui/textarea';
 import { CreditCard, AlertTriangle, CheckCircle2, Circle, Hourglass } from 'lucide-react';
 import { toast } from 'sonner';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import { PageHeader } from '@/Components/PageHeader';
 import FinanceiroPrimaryButton from '@/Pages/Financeiro/_shared/FinanceiroPrimaryButton';
 
 interface Titulo {
@@ -164,18 +165,19 @@ function Index({ titulos, contas_bancarias, filtros }: Props) {
     <>
       {/* Onda 12.8 (2026-05-19) — header canon paridade Unificado */}
       <div className="fin-curadoria vendas-aplus p-6 max-w-6xl mx-auto space-y-6">
-        <header className="os-page-h fin-page-h">
-          <div className="os-page-h-l fin-page-h-l">
-            <h1>Contas a Pagar <span className="fin-hero-title-sub">· Títulos</span></h1>
-            <p>Compras, despesas, contratos</p>
-          </div>
-          <div className="os-page-h-r fin-page-h-r">
+        {/* Wave 4 (2026-05-25): migrado pra <PageHeader> canon v3.8 */}
+        <PageHeader
+          title="Contas a Pagar"
+          suffix=" · Títulos"
+          subtitle={<>Compras, despesas, contratos</>}
+        >
+          <div className="flex-shrink-0 flex items-center gap-1.5 ml-auto">
             <FinanceiroSubNav active="contas-pagar" hidePrimary />
             <FinanceiroPrimaryButton onClick={() => router.visit('/financeiro/unificado/novo?kind=payable')}>
               Novo pagamento
             </FinanceiroPrimaryButton>
           </div>
-        </header>
+        </PageHeader>
 
         <div className="flex flex-wrap gap-2">
           <span className="text-xs text-muted-foreground self-center mr-2">Filtros:</span>

--- a/resources/js/Pages/Financeiro/ContasReceber/Index.tsx
+++ b/resources/js/Pages/Financeiro/ContasReceber/Index.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent } from '@/Components/ui/card';
 import { Receipt, AlertTriangle, CheckCircle2, Circle, Hourglass } from 'lucide-react';
 import { toast } from 'sonner';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import { PageHeader } from '@/Components/PageHeader';
 import FinanceiroPrimaryButton from '@/Pages/Financeiro/_shared/FinanceiroPrimaryButton';
 
 interface BoletoInfo {
@@ -90,18 +91,19 @@ function Index({ titulos, filtros }: Props) {
     <>
       {/* Onda 12.8 (2026-05-19) — header canon paridade Unificado */}
       <div className="fin-curadoria vendas-aplus p-6 max-w-6xl mx-auto space-y-6">
-        <header className="os-page-h fin-page-h">
-          <div className="os-page-h-l fin-page-h-l">
-            <h1>Contas a Receber <span className="fin-hero-title-sub">· Títulos</span></h1>
-            <p>Gerados de vendas (auto) ou cadastrados manualmente</p>
-          </div>
-          <div className="os-page-h-r fin-page-h-r">
+        {/* Wave 4 (2026-05-25): migrado pra <PageHeader> canon v3.8 (PR #1496) */}
+        <PageHeader
+          title="Contas a Receber"
+          suffix=" · Títulos"
+          subtitle={<>Gerados de vendas (auto) ou cadastrados manualmente</>}
+        >
+          <div className="flex-shrink-0 flex items-center gap-1.5 ml-auto">
             <FinanceiroSubNav active="contas-receber" hidePrimary />
             <FinanceiroPrimaryButton onClick={() => router.visit('/financeiro/unificado/novo?kind=receivable')}>
               Novo recebimento
             </FinanceiroPrimaryButton>
           </div>
-        </header>
+        </PageHeader>
 
         {/* Filtros simples */}
         <div className="flex flex-wrap gap-2">

--- a/resources/js/Pages/Financeiro/Dre/Index.tsx
+++ b/resources/js/Pages/Financeiro/Dre/Index.tsx
@@ -28,6 +28,7 @@ import {
 import { BalancoView, type BalancoData } from './_components/BalancoView';
 import { BalanceteView, type BalanceteData } from './_components/BalanceteView';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import { PageHeader } from '@/Components/PageHeader';
 import FinanceiroPrimaryButton from '@/Pages/Financeiro/_shared/FinanceiroPrimaryButton';
 
 // ---------- Tipos das linhas (espelha DRE_LINES canon TelaDRE) ----------
@@ -183,27 +184,21 @@ function FinanceiroDre({
       {/* Topnav contextual módulo — copy-paste inline do bloco `os-page-h` de
           Unificado/Index.tsx:956-1043, adaptando handlers DRE-specific.
           Extração `<FinModuleTopnav>` shared = backlog US-FIN-TOPNAV-COMPONENT (Q8a). */}
-      <header className="os-page-h fin-page-h">
-        <div className="os-page-h-l fin-page-h-l">
-          <h1>
-            Financeiro{' '}
-            <span className="fin-hero-title-sub">
-              ·{' '}
-              {abaAtiva === 'balanco'
-                ? 'Balanço Patrimonial'
-                : abaAtiva === 'balancete'
-                  ? 'Balancete de Verificação'
-                  : 'DRE / Relatórios'}
-            </span>
-          </h1>
-          <p>
-            {meta.periodo_label} · {meta.business_name} · caixa unificado
-          </p>
-        </div>
-        <div className="os-page-h-r fin-page-h-r">
-          {/* ADR 0180 Fase 5 refine Wagner 2026-05-21 — botões action features → ⋯ Mais;
-              "Conciliar" + "Plano de contas" REMOVIDOS (duplicados com ghosts);
-              primary "Novo lançamento" fica no canto direito (canon Unificado) */}
+      {/* Wave 4 (2026-05-25): migrado pra <PageHeader> canon v3.8 */}
+      <PageHeader
+        title="Financeiro"
+        suffix={
+          ' · ' +
+          (abaAtiva === 'balanco'
+            ? 'Balanço Patrimonial'
+            : abaAtiva === 'balancete'
+              ? 'Balancete de Verificação'
+              : 'DRE / Relatórios')
+        }
+        subtitle={<>{meta.periodo_label} · {meta.business_name} · caixa unificado</>}
+      >
+        <div className="flex-shrink-0 flex items-center gap-1.5 ml-auto">
+          {/* ADR 0180 Fase 5 refine — botões features → ⋯ Mais; primary `Novo lançamento` separado */}
           <FinanceiroSubNav
             active="dre"
             hidePrimary
@@ -219,7 +214,7 @@ function FinanceiroDre({
             Novo lançamento
           </FinanceiroPrimaryButton>
         </div>
-      </header>
+      </PageHeader>
 
       <TabSwitcher aba={abaAtiva} />
 

--- a/resources/js/Pages/Financeiro/Fluxo/Index.tsx
+++ b/resources/js/Pages/Financeiro/Fluxo/Index.tsx
@@ -17,6 +17,7 @@ import { Card } from '@/Components/ui/card';
 import { router } from '@inertiajs/react';
 import { useMemo, type ReactNode } from 'react';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import { PageHeader } from '@/Components/PageHeader';
 
 interface Dia {
   data: string;
@@ -511,22 +512,22 @@ function FinanceiroFluxo(props: Props) {
   return (
     <div className="fin-curadoria vendas-aplus">
       {/* Onda 12.8 (2026-05-19) — header canon paridade Unificado */}
-      <header className="os-page-h fin-page-h">
-        <div className="os-page-h-l fin-page-h-l">
-          <h1>
-            Fluxo de caixa <span className="fin-hero-title-sub">· {headerSub}</span>
-          </h1>
-          <p>
+      {/* Wave 4 (2026-05-25): migrado pra <PageHeader> canon v3.8 */}
+      <PageHeader
+        title="Fluxo de caixa"
+        suffix={' · ' + headerSub}
+        subtitle={
+          <>
             {tab === 'realizado'
               ? 'Entradas e saídas confirmadas, agrupadas por mês'
               : 'Saldo, entradas e saídas dia-a-dia'}
-          </p>
-        </div>
-        <div className="os-page-h-r fin-page-h-r">
-          {/* ADR 0180 Fase 5 propagação — ghost tabs Financeiro + primary `+ Novo título` */}
+          </>
+        }
+      >
+        <div className="flex-shrink-0 flex items-center gap-1.5 ml-auto">
           <FinanceiroSubNav active="fluxo" hidePrimary />
         </div>
-      </header>
+      </PageHeader>
 
       <TabSwitcher tab={tab} />
 

--- a/resources/js/Pages/Financeiro/PlanoContas/Index.tsx
+++ b/resources/js/Pages/Financeiro/PlanoContas/Index.tsx
@@ -12,6 +12,7 @@ import { type ReactNode, useMemo, useState } from 'react';
 import { Lock, FileText, Search } from 'lucide-react';
 import { router } from '@inertiajs/react';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import { PageHeader } from '@/Components/PageHeader';
 import FinanceiroPrimaryButton from '@/Pages/Financeiro/_shared/FinanceiroPrimaryButton';
 
 interface PlanoConta {
@@ -68,18 +69,19 @@ function FinanceiroPlanoContas({ planos, stats }: Props) {
   return (
     <div className="fin-curadoria vendas-aplus">
       {/* Onda 18 — header canon paridade Unificado */}
-      <header className="os-page-h fin-page-h">
-        <div className="os-page-h-l fin-page-h-l">
-          <h1>Plano de Contas <span className="fin-hero-title-sub">· Estrutura contábil BR</span></h1>
-          <p>{stats.total} contas hierárquicas (Receita Federal/DCASP) — Eliana classifica lançamentos pelo plano</p>
-        </div>
-        <div className="os-page-h-r fin-page-h-r">
+      {/* Wave 4 (2026-05-25): migrado pra <PageHeader> canon v3.8 */}
+      <PageHeader
+        title="Plano de Contas"
+        suffix=" · Estrutura contábil BR"
+        subtitle={<>{stats.total} contas hierárquicas (Receita Federal/DCASP) — Eliana classifica lançamentos pelo plano</>}
+      >
+        <div className="flex-shrink-0 flex items-center gap-1.5 ml-auto">
           <FinanceiroSubNav active="plano-contas" hidePrimary />
           <FinanceiroPrimaryButton onClick={() => router.visit('/financeiro/plano-contas/create')}>
             Nova conta
           </FinanceiroPrimaryButton>
         </div>
-      </header>
+      </PageHeader>
 
       {/* KPI strip canon */}
       <div className="fin-stats">

--- a/resources/js/Pages/Financeiro/Relatorios/Index.tsx
+++ b/resources/js/Pages/Financeiro/Relatorios/Index.tsx
@@ -17,6 +17,7 @@ import { Badge } from '@/Components/ui/badge';
 import { Download } from 'lucide-react';
 // Onda 14 — PageHeader removido (canon os-page-h direto)
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
+import { PageHeader } from '@/Components/PageHeader';
 
 type TabId = 'fluxo' | 'resumo';
 
@@ -90,14 +91,13 @@ function FinanceiroRelatorios({ filters, fluxo, resumo }: Props) {
   return (
     <div className="fin-curadoria vendas-aplus">
       {/* Onda 14 (2026-05-19) — header canon paridade Unificado */}
-      <header className="os-page-h fin-page-h">
-        <div className="os-page-h-l fin-page-h-l">
-          <h1>Relatórios <span className="fin-hero-title-sub">· Financeiro</span></h1>
-          <p>DRE gerencial, fluxo de caixa projetado vs realizado e resumo do período</p>
-        </div>
-        <div className="os-page-h-r fin-page-h-r">
-          {/* ADR 0180 Fase 5 refine Wagner 2026-05-21 — "Exportar CSV" move pra ⋯ Mais;
-              tela não tem primary "Novo X" (Relatorios é só leitura) */}
+      {/* Wave 4 (2026-05-25): migrado pra <PageHeader> canon v3.8 */}
+      <PageHeader
+        title="Relatórios"
+        suffix=" · Financeiro"
+        subtitle={<>DRE gerencial, fluxo de caixa projetado vs realizado e resumo do período</>}
+      >
+        <div className="flex-shrink-0 flex items-center gap-1.5 ml-auto">
           <FinanceiroSubNav
             active="relatorios"
             hidePrimary
@@ -106,7 +106,7 @@ function FinanceiroRelatorios({ filters, fluxo, resumo }: Props) {
             ]}
           />
         </div>
-      </header>
+      </PageHeader>
 
       {/* Filtros de período */}
       <Card className="mt-6 mb-4">


### PR DESCRIPTION
Wave 4 — replica canon v3.8 do Cliente em 10 telas Financeiro.

**Migrado:** Caixa · Categorias · Conciliação · ContasBancarias · ContasPagar · ContasReceber · DRE · Fluxo · PlanoContas · Relatorios

**Não migrado (Wave 5):** Unificado/Index (mais complexo).

DRY: 21 linhas JSX duplicado por tela → 8 linhas com <PageHeader> componente. Manutenção 1 lugar.

Refs: ADR 0189 v3.8, ADR 0190, PRs #1494/#1496