### PR TITLE
feat(transactions): Onda 1 — schema source + os_ref + commission_split (ADR 0192)

### DIFF
--- a/app/Transaction.php
+++ b/app/Transaction.php
@@ -56,6 +56,7 @@ class Transaction extends Model
         'sales_order_ids' => 'array',
         'export_custom_fields_info' => 'array',
         'purchase_requisition_ids' => 'array',
+        'commission_split' => 'array', // ADR 0192 · { mecanico_id, mecanico_pct, balcao_id, balcao_pct }
     ];
 
     /**

--- a/database/migrations/2026_05_25_140000_add_source_and_os_ref_to_transactions.php
+++ b/database/migrations/2026_05_25_140000_add_source_and_os_ref_to_transactions.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ADR 0192 — Auto-faturar OS → Venda via JobSheetObserver.
+ *
+ * Schema aditivo cross-source pra Integração Vendas × Oficina (A1 KB-9.75):
+ *
+ *   source           ENUM('balcao','oficina','online')  DEFAULT 'balcao'  AFTER type
+ *   os_ref           VARCHAR(20)                        NULL              AFTER source
+ *   commission_split JSON                               NULL              AFTER os_ref
+ *
+ *   INDEX idx_transactions_source (business_id, source, transaction_date)
+ *
+ * Default 'balcao' retroativo zero breaking change — vendas legacy aparecem
+ * automaticamente como "Balcão" na coluna Origem (frontend Onda 3).
+ *
+ * `os_ref` formato "OS-{job_sheet_id}" preenchido pelo JobSheetObserver
+ * (Onda 2) quando stage transiciona pra `entregue_completo` (FSM canonical
+ * ADR 0143). Idempotência: chave de busca composta `(business_id, os_ref)`.
+ *
+ * `commission_split` JSON shape canon:
+ *   { "mecanico_id": int, "mecanico_pct": float, "balcao_id": int|null, "balcao_pct": float }
+ * Total mecanico_pct + balcao_pct === 100. Balcão NULL quando 100% mecânico.
+ *
+ * Índice composto (business_id, source, transaction_date) explora KPI hero
+ * breakdown query do Sells/Index (Onda 4) — agrupamento por source dentro
+ * do business + filtro temporal "hoje/semana/mês".
+ *
+ * Multi-tenant Tier 0 ADR 0093 IRREVOGÁVEL preservado: business_id PRIMEIRO
+ * em todos índices · todas queries continuam scoped por business global scope.
+ *
+ * IDEMPOTENTE — Schema::hasColumn + SHOW INDEXES checks protegem re-execução.
+ * down() reverte sem perda de dados (drop columns + drop index).
+ *
+ * @see memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            if (! Schema::hasColumn('transactions', 'source')) {
+                $table->enum('source', ['balcao', 'oficina', 'online'])
+                    ->default('balcao')
+                    ->nullable()
+                    ->after('type')
+                    ->comment('Origem da venda · A1 KB-9.75 · ADR 0192');
+            }
+
+            if (! Schema::hasColumn('transactions', 'os_ref')) {
+                $table->string('os_ref', 20)
+                    ->nullable()
+                    ->after('source')
+                    ->comment('Referência cross-módulo OS-NNNN quando source=oficina · ADR 0192');
+            }
+
+            if (! Schema::hasColumn('transactions', 'commission_split')) {
+                $table->json('commission_split')
+                    ->nullable()
+                    ->after('os_ref')
+                    ->comment('Split { mecanico_id, mecanico_pct, balcao_id, balcao_pct } total=100 · ADR 0192');
+            }
+        });
+
+        // Índice composto Tier 0 multi-tenant (ADR 0093 IRREVOGÁVEL).
+        // business_id PRIMEIRO · source pra agrupamento KPI · transaction_date pra filtro temporal.
+        Schema::table('transactions', function (Blueprint $table) {
+            $existing = collect(DB::select('SHOW INDEXES FROM transactions'))
+                ->pluck('Key_name')
+                ->toArray();
+
+            if (! in_array('idx_transactions_source', $existing, true)) {
+                $table->index(
+                    ['business_id', 'source', 'transaction_date'],
+                    'idx_transactions_source'
+                );
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            $existing = collect(DB::select('SHOW INDEXES FROM transactions'))
+                ->pluck('Key_name')
+                ->toArray();
+
+            if (in_array('idx_transactions_source', $existing, true)) {
+                $table->dropIndex('idx_transactions_source');
+            }
+
+            foreach (['commission_split', 'os_ref', 'source'] as $col) {
+                if (Schema::hasColumn('transactions', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
+    }
+};

--- a/tests/Feature/Schema/TransactionsSourceOsRefSchemaTest.php
+++ b/tests/Feature/Schema/TransactionsSourceOsRefSchemaTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Transaction;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Schema GUARDs — Onda 1 do plano F3 Integração Vendas × Oficina (ADR 0192).
+ *
+ * Cobertura:
+ *  - Migration `2026_05_25_140000_add_source_and_os_ref_to_transactions` aplicada
+ *  - Coluna `source` ENUM('balcao','oficina','online') DEFAULT 'balcao'
+ *  - Coluna `os_ref` VARCHAR(20) NULL
+ *  - Coluna `commission_split` JSON NULL
+ *  - Índice composto `idx_transactions_source` (business_id, source, transaction_date)
+ *  - Model cast `commission_split` => 'array' (decode JSON automático)
+ *  - Default retroativo: vendas legacy sem source ganham 'balcao' (zero breaking change)
+ *
+ * @see memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md
+ * @see memory/sessions/2026-05-25-plano-f3-integracao-vendas-oficina.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: schema UPOS legacy requer MySQL (ADR 0101)');
+    }
+    if (! Schema::hasTable('transactions')) {
+        $this->markTestSkipped('transactions table missing — rode migrate');
+    }
+    if (! Schema::hasColumn('transactions', 'source')) {
+        $this->markTestSkipped('migration add_source_and_os_ref_to_transactions não aplicada');
+    }
+});
+
+it('migration aplicada: transactions tem source + os_ref + commission_split', function () {
+    expect(Schema::hasColumn('transactions', 'source'))->toBeTrue();
+    expect(Schema::hasColumn('transactions', 'os_ref'))->toBeTrue();
+    expect(Schema::hasColumn('transactions', 'commission_split'))->toBeTrue();
+});
+
+it('coluna source é ENUM com 3 valores canon (balcao, oficina, online) e default balcao', function () {
+    $column = collect(DB::select('SHOW COLUMNS FROM transactions LIKE ?', ['source']))->first();
+
+    expect($column)->not->toBeNull();
+    expect(strtolower((string) $column->Type))->toContain("enum('balcao','oficina','online')");
+    expect($column->Default)->toBe('balcao');
+});
+
+it('coluna os_ref é VARCHAR(20) nullable', function () {
+    $column = collect(DB::select('SHOW COLUMNS FROM transactions LIKE ?', ['os_ref']))->first();
+
+    expect($column)->not->toBeNull();
+    expect(strtolower((string) $column->Type))->toBe('varchar(20)');
+    expect($column->Null)->toBe('YES');
+});
+
+it('coluna commission_split é JSON nullable', function () {
+    $column = collect(DB::select('SHOW COLUMNS FROM transactions LIKE ?', ['commission_split']))->first();
+
+    expect($column)->not->toBeNull();
+    expect(strtolower((string) $column->Type))->toContain('json');
+    expect($column->Null)->toBe('YES');
+});
+
+it('índice composto idx_transactions_source existe com colunas business_id + source + transaction_date', function () {
+    $indexes = collect(DB::select('SHOW INDEXES FROM transactions'))
+        ->where('Key_name', 'idx_transactions_source')
+        ->sortBy('Seq_in_index')
+        ->pluck('Column_name')
+        ->values()
+        ->toArray();
+
+    expect($indexes)->toBe(['business_id', 'source', 'transaction_date']);
+});
+
+it('Transaction model casta commission_split como array (JSON decode automático)', function () {
+    $tx = new Transaction;
+    $tx->commission_split = [
+        'mecanico_id' => 42,
+        'mecanico_pct' => 70.0,
+        'balcao_id' => 17,
+        'balcao_pct' => 30.0,
+    ];
+
+    expect($tx->commission_split)->toBeArray();
+    expect($tx->commission_split['mecanico_id'])->toBe(42);
+    expect($tx->commission_split['mecanico_pct'] + $tx->commission_split['balcao_pct'])->toBe(100.0);
+});
+
+it('default retroativo: linha INSERT sem source ganha balcao (zero breaking change vendas legacy)', function () {
+    // Inspeciona DEFAULT via INFORMATION_SCHEMA pra confirmar comportamento sem
+    // depender de fixture (vendas legacy de prod terão NULL ou 'balcao' conforme MySQL).
+    $row = collect(DB::select(
+        "SELECT COLUMN_DEFAULT, IS_NULLABLE
+         FROM INFORMATION_SCHEMA.COLUMNS
+         WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = 'transactions' AND COLUMN_NAME = 'source'"
+    ))->first();
+
+    expect($row->COLUMN_DEFAULT)->toBe('balcao');
+});


### PR DESCRIPTION
**Onda 1/5 do plano F3 Integração Vendas × Oficina** ([ADR 0192](../blob/main/memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md)).

## Mudanças

**Migration aditiva idempotente** — `database/migrations/2026_05_25_140000_add_source_and_os_ref_to_transactions.php`:
- `transactions.source ENUM('balcao','oficina','online') DEFAULT 'balcao'` (retroativo zero breaking change)
- `transactions.os_ref VARCHAR(20) NULL` (formato `OS-NNNN`)
- `transactions.commission_split JSON NULL` (shape `{mecanico_id, mecanico_pct, balcao_id, balcao_pct}` total=100)
- `INDEX idx_transactions_source (business_id, source, transaction_date)` — Tier 0 multi-tenant ([ADR 0093](../blob/main/memory/decisions/0093-multi-tenant-isolation-tier-0.md))

**Model cast** — `app/Transaction.php`:
- `commission_split => 'array'` (JSON decode automático)

**Pest GUARDs** — `tests/Feature/Schema/TransactionsSourceOsRefSchemaTest.php` (7 tests):
1. Migration aplicada (3 colunas existem)
2. `source` ENUM exato com default `balcao`
3. `os_ref` VARCHAR(20) nullable
4. `commission_split` JSON nullable
5. Índice composto `(business_id, source, transaction_date)` ordem correta
6. Model casta `commission_split` como array (round-trip)
7. INFORMATION_SCHEMA confirma default retroativo `balcao`

`beforeEach` skip se SQLite (UPOS legacy MySQL only · ADR 0101).

## Multi-tenant Tier 0 preservado

- Índice composto: `business_id` PRIMEIRO em todas queries
- `os_ref` formato `OS-{job_sheet_id}` será preenchido por `JobSheetObserver` (Onda 2) com `business_id` herdado
- Idempotência futura na Onda 2: chave `(business_id, os_ref)` impede cross-tenant

## Pré-requisitos

- ✅ Onda 0 (ADR 0192) mergeada em main
- ✅ Schema additivo — não afeta vendas legacy

## Próximo

Onda 2: `Modules/Repair/Observers/JobSheetObserver.php` + `SellController::getSellsListJson` adiciona source/os_ref/label + `ProducaoOficinaController::index` adiciona venda_derivada lookup. **Depois de Onda 2 mergeada → Fase 2 paralela (Worker A Sells/Index · Worker B Repair drawer).**

LOC: +214 (~60 schema · +1 cast · +105 tests · +50 docs)