### PR TITLE
feat(paymentgateway): remove card PesaPal deprecated do wizard

### DIFF
--- a/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
@@ -113,7 +113,7 @@ class PaymentGatewaysController extends Controller
         }
 
         $validated = $request->validate([
-            'gateway_key'      => 'required|string|in:inter,c6,asaas,bcb_pix,pesapal,pagarme',
+            'gateway_key'      => 'required|string|in:inter,c6,asaas,bcb_pix,pagarme',
             'ambiente'         => 'required|string|in:production,sandbox',
             'nome_display'     => 'nullable|string|max:191',
             'conta_bancaria_id' => 'nullable|integer|exists:accounts,id',

--- a/resources/js/Pages/Financeiro/Cobranca/_lib/cobranca-shared.ts
+++ b/resources/js/Pages/Financeiro/Cobranca/_lib/cobranca-shared.ts
@@ -4,7 +4,7 @@
 export type CobrancaTipo = 'boleto' | 'pix_cob' | 'pix_cobv' | 'pix_recv' | 'card';
 export type CobrancaStatus = 'emitida' | 'paga' | 'vencida' | 'cancelada' | 'erro' | 'pending';
 export type OrigemType = 'sale' | 'invoice' | 'subscription_license';
-export type GatewayKey = 'inter' | 'c6' | 'asaas' | 'bcb_pix' | 'pesapal' | 'pagarme';
+export type GatewayKey = 'inter' | 'c6' | 'asaas' | 'bcb_pix' | 'pagarme';
 
 export interface Cobranca {
   id: number;
@@ -178,15 +178,6 @@ export const DRIVERS: Record<GatewayKey, DriverToken> = {
     requirements: ['Homologação BCB recebedor (Res. 380/2024)', 'mTLS ICP-Brasil', 'Mandato autorizado pagador-a-pagador'],
     recommendedFor: 'Mensalidade recorrente PIX (SaaS, plano gym) · cobrança autorizada 1× pelo cliente',
     credentialSource: { url: 'https://www.bcb.gov.br/estabilidadefinanceira/pix', label: 'BCB → PIX Automático → Homologação recebedor' },
-  },
-  pesapal: {
-    key: 'pesapal', nome: 'PesaPal', sigla: 'PP',
-    dot: 'bg-purple-500', bg: 'bg-purple-50', fg: 'text-purple-700', border: 'border-purple-200',
-    tipos: ['card'],
-    ambientes: ['production'],
-    cred: 'api_key + consumer_secret',
-    deprecated: true,
-    deprecatedReason: 'Migrar pra Asaas (cartão BR nativo + 3DS)',
   },
   pagarme: {
     key: 'pagarme', nome: 'Pagar.me', sigla: 'PG',

--- a/resources/js/Pages/Settings/PaymentGateways/_components/DrawerGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/DrawerGateway.tsx
@@ -470,19 +470,6 @@ export default function DrawerGateway({ gateway, accounts, onClose, onToggle }: 
                   </Field>
                 </>
               )}
-              {d.key === 'pesapal' && (
-                <div className="bg-amber-50 border border-amber-200 rounded p-3 text-[11.5px] text-amber-900">
-                  <div className="font-medium mb-1">Driver deprecated</div>
-                  <p className="mb-2">PesaPal foi UltimatePOS legacy pra cartão internacional. Hoje recomenda-se <strong>Asaas</strong> (BR nativo + 3DS + PIX).</p>
-                  <div className="font-medium text-[11px] mt-2 mb-1">Migrar manualmente:</div>
-                  <ol className="list-decimal list-inside space-y-0.5 text-[11px]">
-                    <li>Clique em <strong>+ Novo gateway</strong> na tela principal → escolha <strong>Asaas</strong></li>
-                    <li>Cadastre credencial Asaas (sandbox primeiro, depois production)</li>
-                    <li>Reaponte Subscriptions/cobranças ativas pra Asaas no módulo Recurring</li>
-                    <li>Desative este PesaPal aqui (toggle no header)</li>
-                  </ol>
-                </div>
-              )}
               {d.key === 'pagarme' && (
                 <>
                   <Field label="Secret Key (atualizar)">

--- a/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
@@ -369,24 +369,6 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
                   Cert ICP-Brasil ⇄ CNPJ recebedor homologado no BCB. Resolução BCB 380/2024.
                 </div>
               </>}
-              {d.key === 'pesapal' && <>
-                <Field label="Consumer Key">
-                  <input
-                    type="password"
-                    value={config.consumer_key ?? ''}
-                    onChange={e => setConfigField('consumer_key', e.target.value)}
-                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
-                  />
-                </Field>
-                <Field label="Consumer Secret">
-                  <input
-                    type="password"
-                    value={config.consumer_secret ?? ''}
-                    onChange={e => setConfigField('consumer_secret', e.target.value)}
-                    className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
-                  />
-                </Field>
-              </>}
               {d.key === 'pagarme' && <>
                 <Field label="Secret Key">
                   <input


### PR DESCRIPTION
Cleanup solicitado por Wagner. PesaPal era driver legacy UltimatePOS Subscription (cartão internacional) com card de vitrine no wizard mas sem driver real implementado em Modules/PaymentGateway/Services/Drivers/. Remove de DRIVERS map + bloco UI step 2 + bloco drawer + validator backend. 4 files / 2+/42- LOC. Defensive: warnFor() mantido pra credenciais legacy se houver. Migrations ENUM intactas (append-only ADR 0093).