### PR TITLE
feat(cliente): Onda 4 Drawer 760 seção Papéis · 4 checkboxes is_X

### DIFF
--- a/Modules/Crm/Routes/web.php
+++ b/Modules/Crm/Routes/web.php
@@ -119,6 +119,13 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
             ->whereNumber('id')
             ->name('autosave.classificacao');
 
+        // ADR 0188 Onda 4 -- multi-type papeis (4 flags is_X · Drawer secao "Papeis").
+        // Contato pode ter N papeis simultaneos sem duplicar cadastro (insight Delphi
+        // WR Comercial). Backend invariante: >=1 papel ativo (anti soft-delete acidental).
+        Route::patch('{id}/papeis', [\Modules\Crm\Http\Controllers\ClienteAutosaveController::class, 'papeis'])
+            ->whereNumber('id')
+            ->name('autosave.papeis');
+
         // 2 endpoints lookup (cache Redis: CEP 90d, CNPJ 30d).
         // Wave 15 D8 Security -- throttle 60/min anti-abuso pro caso de
         // Auth bypassado em prod (defensivo): Larissa biz=4 ~30 cadastros/dia

--- a/Modules/Crm/Tests/Feature/SmokeRoutesTest.php
+++ b/Modules/Crm/Tests/Feature/SmokeRoutesTest.php
@@ -88,3 +88,28 @@ it('cenario 9: rotas install/uninstall estão registradas (Wagner aprova superad
     expect(collect($routes))->toContain('crm/install');
     expect(collect($routes))->toContain('crm/install/uninstall');
 });
+
+it('cenario 10: rota PATCH cliente/{id}/papeis registrada (ADR 0188 Onda 4)', function () {
+    // ADR 0188 §Plano-8 — Drawer 760 secao "Papeis" com 4 checkboxes is_X.
+    // Endpoint separado pra isolar invariante ">=1 papel ativo" no backend.
+    expect(\Route::has('cliente.autosave.papeis'))->toBeTrue(
+        'Rota cliente.autosave.papeis deveria existir per Routes/web.php (PATCH /cliente/{id}/papeis)'
+    );
+
+    $route = \Route::getRoutes()->getByName('cliente.autosave.papeis');
+    expect($route)->not->toBeNull();
+    expect($route->methods())->toContain('PATCH');
+    expect($route->uri())->toBe('cliente/{id}/papeis');
+});
+
+it('cenario 11: rota papeis mantem stack canonico multi-tenant (Tier 0)', function () {
+    // ADR 0093 IRREVOGAVEL — todas rotas autenticadas precisam de
+    // SetSessionData + auth + CheckUserLogin pra business_id scope correto.
+    $route = \Route::getRoutes()->getByName('cliente.autosave.papeis');
+    expect($route)->not->toBeNull();
+
+    $middlewares = $route->gatherMiddleware();
+    expect($middlewares)->toContain('auth');
+    expect($middlewares)->toContain('SetSessionData');
+    expect($middlewares)->toContain('CheckUserLogin');
+});

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -414,6 +414,19 @@ class ContactController extends Controller
             ]);
         }
 
+        // ADR 0188 Onda 4 — incluir flags multi-papel se a migration rodou.
+        // Graceful degradation: hasColumn check evita erro SQL em ambiente
+        // pre-migration. Front recebe null/false → Drawer trata como unchecked.
+        $hasOnda4Cols = \Illuminate\Support\Facades\Schema::hasColumn('contacts', 'is_customer');
+        if ($hasOnda4Cols) {
+            $selectCols = array_merge($selectCols, [
+                'contacts.is_customer',
+                'contacts.is_supplier',
+                'contacts.is_employee',
+                'contacts.is_representative',
+            ]);
+        }
+
         // ADR 0188 — filtra por papel (`is_X`) se a coluna existir, fallback `type` enum.
         $contactsQuery = Contact::where('contacts.business_id', $business_id);
         $contactsQuery = $this->applyContactTypeFilter($contactsQuery, $type);
@@ -503,6 +516,13 @@ class ContactController extends Controller
                 $payload['segmento'] = null;
                 $payload['vip'] = false;
             }
+
+            // ADR 0188 Onda 4 — flags multi-papel pro Drawer 760 seção "Papéis".
+            // Bool no payload (front cast direto · MySQL int 0/1 → React bool).
+            $payload['is_customer'] = (bool) ($contact->is_customer ?? false);
+            $payload['is_supplier'] = (bool) ($contact->is_supplier ?? false);
+            $payload['is_employee'] = (bool) ($contact->is_employee ?? false);
+            $payload['is_representative'] = (bool) ($contact->is_representative ?? false);
 
             return $payload;
         })->all();

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -142,6 +142,11 @@ interface ClienteRow {
   avatar_hash_seed?: string | null;     // string p/ HSL determinístico — default = name
   saldo_devedor?: number | null;        // valor_aberto - balance (positivo = cliente nos deve)
   last_purchase_at?: string | null;     // ISO; FrescorPill calcula 4 estados client-side
+  // ADR 0188 Onda 4 — flags multi-papel (Drawer seção "Papéis").
+  is_customer?: boolean | null;
+  is_supplier?: boolean | null;
+  is_employee?: boolean | null;
+  is_representative?: boolean | null;
 }
 
 interface ListMeta {

--- a/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx
@@ -34,6 +34,13 @@ export interface ContactInfo {
   nascimento?: string | null;
   contato?: string | null;
   cargo?: string | null;
+  // ADR 0188 Onda 4 — flags multi-papel. Backend retorna bool (cast no
+  // shapeContactResponse · MySQL int 0/1 → React bool). Default false se
+  // ausente (contato pre-Onda 4 que não tem flags ainda em prod).
+  is_customer?: boolean | null;
+  is_supplier?: boolean | null;
+  is_employee?: boolean | null;
+  is_representative?: boolean | null;
   // Endereço completo — política Wagner 2026-05-22 (#1419 mergeado):
   // lookup CNPJ SOBRESCREVE dados cadastrais oficiais (Receita é fonte da
   // verdade). ContactInfo aceita PT-BR e canon UPOS pra compat dual na leitura.
@@ -95,6 +102,11 @@ export default function IdentificacaoTab({
   const [nascimento, setNascimento] = useState<string>(contact.nascimento ?? '');
   const [contatoNome, setContatoNome] = useState<string>(contact.contato ?? '');
   const [cargo, setCargo] = useState<string>(contact.cargo ?? '');
+  // ADR 0188 Onda 4 — flags multi-papel. Default false se ausente (contato pre-migration).
+  const [isCustomer, setIsCustomer] = useState<boolean>(Boolean(contact.is_customer));
+  const [isSupplier, setIsSupplier] = useState<boolean>(Boolean(contact.is_supplier));
+  const [isEmployee, setIsEmployee] = useState<boolean>(Boolean(contact.is_employee));
+  const [isRepresentative, setIsRepresentative] = useState<boolean>(Boolean(contact.is_representative));
 
   const [savingField, setSavingField] = useState<string | null>(null);
   const [savedField, setSavedField] = useState<string | null>(null);
@@ -116,6 +128,10 @@ export default function IdentificacaoTab({
     setNascimento(contact.nascimento ?? '');
     setContatoNome(contact.contato ?? '');
     setCargo(contact.cargo ?? '');
+    setIsCustomer(Boolean(contact.is_customer));
+    setIsSupplier(Boolean(contact.is_supplier));
+    setIsEmployee(Boolean(contact.is_employee));
+    setIsRepresentative(Boolean(contact.is_representative));
     setErrorField(null);
     setSavedField(null);
     setCnpjLookup('idle');
@@ -253,6 +269,87 @@ export default function IdentificacaoTab({
       performSave('tipo', newTipo, previous);
     },
     [tipo, performSave]
+  );
+
+  // ADR 0188 Onda 4 — toggle papel (4 checkboxes is_X). Endpoint /papeis separado
+  // (não /identificacao) pra isolar invariante "≥1 papel ativo" no backend.
+  //
+  // Optimistic UI: troca state imediato + PATCH em paralelo. Rollback no 4xx/5xx.
+  // Sem debounce (checkbox toggle é discreto, não digitação).
+  const handlePapelToggle = useCallback(
+    async (
+      flag: 'is_customer' | 'is_supplier' | 'is_employee' | 'is_representative',
+      newValue: boolean,
+    ) => {
+      if (disabled) return;
+
+      // Optimistic UI — troca state local imediato.
+      const setters = {
+        is_customer: setIsCustomer,
+        is_supplier: setIsSupplier,
+        is_employee: setIsEmployee,
+        is_representative: setIsRepresentative,
+      };
+      const previousValues = {
+        is_customer: isCustomer,
+        is_supplier: isSupplier,
+        is_employee: isEmployee,
+        is_representative: isRepresentative,
+      };
+      setters[flag](newValue);
+
+      setSavingField(flag);
+      setErrorField(null);
+
+      try {
+        const r = await fetch(`/cliente/${contact.id}/papeis`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            'X-CSRF-TOKEN': getCsrfToken(),
+            'X-Requested-With': 'XMLHttpRequest',
+          },
+          body: JSON.stringify({ [flag]: newValue }),
+        });
+
+        if (!r.ok) {
+          // Rollback optimistic UI
+          setters[flag](previousValues[flag]);
+          let msg = `Erro ${r.status} ao salvar papel.`;
+          if (r.status === 422) {
+            const j = await r.json().catch(() => ({}));
+            msg = j?.errors?.[flag]?.[0] ?? j?.errors?.is_customer?.[0] ?? msg;
+          } else if (r.status === 403) {
+            msg = 'Sem permissão pra editar papéis.';
+          }
+          setErrorField({ field: flag, message: msg });
+          // eslint-disable-next-line no-console
+          console.error(`[IdentificacaoTab] papeis ${flag} falhou`, { status: r.status, msg });
+          return;
+        }
+
+        setSavedField(flag);
+        setTimeout(() => setSavedField((current) => (current === flag ? null : current)), 1800);
+        onSaved?.(flag, newValue);
+      } catch (err) {
+        setters[flag](previousValues[flag]);
+        setErrorField({ field: flag, message: 'Falha de rede. Tente de novo.' });
+        // eslint-disable-next-line no-console
+        console.error(`[IdentificacaoTab] papeis ${flag} network error`, err);
+      } finally {
+        setSavingField((current) => (current === flag ? null : current));
+      }
+    },
+    [
+      contact.id,
+      disabled,
+      isCustomer,
+      isSupplier,
+      isEmployee,
+      isRepresentative,
+      onSaved,
+    ],
   );
 
   // ── Lookup CNPJ — Técnica C ADR 0186: BrasilAPI + SEFAZ em PARALELO ──
@@ -570,6 +667,52 @@ export default function IdentificacaoTab({
           <Building2 size={12} aria-hidden /> Pessoa jurídica
         </button>
       </div>
+
+      {/* ADR 0188 Onda 4 — Seção Papéis (multi-type flags).
+          Permite que 1 contato tenha N papéis simultâneos (Wagner Rocha cliente+
+          representante = mesma row · sem duplicar cadastro como acontecia no UPOS
+          single-type). Insight Delphi WR Comercial — flag bool por papel.
+          Backend invariante: ≥1 papel ativo (não permite desmarcar todos). */}
+      <fieldset className="rounded-md border border-input bg-muted/20 p-3">
+        <legend className="px-1.5 text-xs font-medium text-muted-foreground">
+          Papéis <span className="font-normal">(marque todos que se aplicam)</span>
+        </legend>
+        <div className="grid grid-cols-2 gap-2 mt-1">
+          {([
+            { flag: 'is_customer' as const,       value: isCustomer,       label: 'Cliente',       Icon: User },
+            { flag: 'is_supplier' as const,       value: isSupplier,       label: 'Fornecedor',    Icon: Building2 },
+            { flag: 'is_employee' as const,       value: isEmployee,       label: 'Funcionário',   Icon: User },
+            { flag: 'is_representative' as const, value: isRepresentative, label: 'Representante', Icon: User },
+          ]).map(({ flag, value, label, Icon }) => (
+            <label
+              key={flag}
+              className={
+                'inline-flex items-center gap-2 px-2 py-1.5 text-sm rounded-md cursor-pointer transition-colors ' +
+                'hover:bg-background focus-within:ring-2 focus-within:ring-primary/40 ' +
+                (value ? 'text-foreground font-medium' : 'text-muted-foreground')
+              }
+            >
+              <input
+                type="checkbox"
+                checked={value}
+                disabled={disabled}
+                onChange={(e) => handlePapelToggle(flag, e.target.checked)}
+                aria-label={label}
+                className="h-4 w-4 rounded border-input accent-primary cursor-pointer disabled:opacity-50"
+              />
+              <Icon size={14} aria-hidden className={value ? 'text-primary' : ''} />
+              {label}
+              {savingField === flag && <Loader2 size={11} className="animate-spin ml-auto" aria-hidden />}
+              {savedField === flag && <CheckCircle2 size={11} className="ml-auto text-primary" aria-hidden />}
+            </label>
+          ))}
+        </div>
+        {errorField?.field?.startsWith('is_') && (
+          <p className="mt-2 inline-flex items-center gap-1 text-xs text-destructive" role="alert">
+            <AlertCircle size={11} aria-hidden /> {errorField.message}
+          </p>
+        )}
+      </fieldset>
 
       {/* Linha 1: Nome/Razão social */}
       <div className="grid gap-4 md:grid-cols-2">


### PR DESCRIPTION
## Summary

Wagner 2026-05-24 autorizou Onda 4 (ADR 0188 §Plano-8). Onda 3 já entregou schema + Slot 2 + overflow menu. **Esta Onda 4 fecha o ciclo multi-papel** permitindo que 1 contato tenha N papéis simultâneos via Drawer 760.

### Insight Delphi WR Comercial (Wagner 2026-05-24)

> "no Delphi tenho cadastro de tipo de contato, mesmo contato pode ser classificado como cliente, fornecedor, funcionário — evita ter o mesmo cadastro em tabelas separadas"

UPOS legacy single-type duplica cadastros (Wagner Rocha cliente+representante = 2 rows). Onda 4 implementa o padrão Delphi: **1 row · N papéis ativos simultâneos**.

### Antes vs Depois (Drawer 760 — Tab Identificação)

```
ANTES                              DEPOIS
┌─ Tab Identificação ──┐           ┌─ Tab Identificação ──────────┐
│ [PF] [PJ]            │           │ [PF] [PJ]                    │
│ Nome: __________     │           │ ┌─ Papéis ─────────────────┐ │
│ ...                  │           │ │ ☑ Cliente   ☐ Fornecedor│ │
│                      │           │ │ ☐ Func.     ☐ Repres.   │ │
└──────────────────────┘           │ └─────────────────────────┘ │
                                   │ Nome: __________            │
                                   │ ...                         │
                                   └──────────────────────────────┘
```

## Test plan

- [x] `php artisan ui:lint --strict --changed-only` → **Ok · sem regressões**
- [x] `vendor/bin/pest Modules/Crm/Tests/Feature/SmokeRoutesTest.php` → **11 testes pass** (24 assertions)
- [x] Pre-commit hook validou local
- [ ] CI ui-lint workflow verde
- [ ] CI pr-ui-judge LLM ≥ 70
- [ ] Smoke prod: clicar `⋮` linha → drawer abrir → tab Identificação → ver "Papéis" → marcar/desmarcar → ver "Salvo"
- [ ] Smoke prod: tentar desmarcar todos 4 → ver erro "Contato precisa ter pelo menos 1 papel ativo"

## Constraints

- **Tier 0 multi-tenant** (ADR 0093 IRREVOGÁVEL) — endpoint usa `session('user.business_id')`, índices compostos `(business_id, is_X)` preservados
- **Append-only** — ADR 0188 §Plano-8 escopo respeitado
- **Backward-compat UPOS** — `type` enum permanece, flags são aditivas
- **Optimistic UI** — toggle imediato + rollback em 4xx/5xx
- **Invariante backend** — ≥1 papel ativo (anti soft-delete acidental)

## Backend changes

### `ClienteAutosaveController::papeis()` novo método

- Body parcial `{ is_customer: bool, is_supplier: bool, ... }`
- Validação 4 flags nullable boolean
- Cast int→bool consistente
- Invariante: `array_sum(merge(payload, contact_atual)) >= 1` (422 se 0)
- Response `{ success: true, contact: { ..., is_X bool } }`

### `ContactController::index` payload

`selectCols` agora inclui 4 flags via `hasColumn` check (graceful degradation pré-migration). Payload retorna bool pro Drawer ler direto do array `rows`.

### Routes (Modules/Crm)

```php
Route::patch('{id}/papeis', [..., 'papeis'])
  ->whereNumber('id')
  ->name('autosave.papeis');
```

## Frontend changes

- `IdentificacaoTab.tsx`: 4 state booleans + `handlePapelToggle` async optimistic + JSX fieldset
- `Index.tsx`: `ClienteRow` type adiciona 4 flags opcionais
- Tokens semânticos canon (`text-foreground` / `text-muted-foreground` / `text-primary` / `text-destructive` · zero AP1)

## Refs

- [ADR 0188 · Contatos multi-type · §Plano-8 Onda 4](memory/decisions/0188-contacts-multi-type-flag-aditiva.md)
- [ADR 0179 · Cliente Drawer 760px](memory/decisions/0179-cliente-drawer-760px-substitui-show-fullpage.md)
- [ADR 0093 · Multi-tenant Tier 0](memory/decisions/0093-multi-tenant-isolation-tier-0.md)
- [ADR UI-0013 · Constituição UI v2](memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md)
- Wagner 2026-05-24 "pode fazer resolve" + AskUserQuestion (escolheu Onda 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
