### PR TITLE
feat(repair): Onda 5 — drawer card 'Esta OS gerou venda' (ADR 0192)

### DIFF
--- a/Modules/Repair/Tests/Feature/ProducaoOficinaTest.php
+++ b/Modules/Repair/Tests/Feature/ProducaoOficinaTest.php
@@ -186,3 +186,51 @@ it('US-REPAIR-PROD-4: move endpoint rejeita coluna inválida', function () {
 
     expect($r->status())->toBe(302);
 });
+
+/**
+ * Onda 5 (ADR 0192) — Integração Vendas × Oficina A1 KB-9.75.
+ *
+ * GUARD do contrato `venda_derivada` no payload do controller. Frontend
+ * `Index.tsx` Onda 5 espera o shape exato `{ id, invoice_no, final_total, transaction_date }`
+ * em cards quando coluna='pronto' AND existe Transaction derivada. Este test
+ * valida que controller preserva o contrato — quebrá-lo derruba drawer card.
+ *
+ * Não cria Transaction real (depende de tabela transactions com colunas Onda 1
+ * + Observer Onda 2). Apenas confirma shape do payload + scope multi-tenant.
+ */
+it('Onda 5: cards expõem field venda_derivada com shape correto OR null', function () {
+    $user = producaoOficinaBootstrap();
+    $response = $this->actingAs($user)->get('/repair/producao-oficina');
+
+    if ($response->status() === 403) {
+        test()->markTestSkipped('Module gate bloqueia.');
+    }
+
+    $page = $response->original->getProps();
+    $columns = $page['columns'] ?? [];
+
+    foreach ($columns as $col) {
+        foreach ($col['cards'] ?? [] as $card) {
+            // Field é opcional no mock fallback (sem JobSheet real); quando
+            // live data, deve ser null OR array com shape Onda 5 (ADR 0192).
+            if (! array_key_exists('venda_derivada', $card)) {
+                continue;  // mock fixture pode não ter o field
+            }
+
+            $vd = $card['venda_derivada'];
+            if ($vd === null) {
+                continue;  // OK — OS sem venda derivada
+            }
+
+            expect($vd)->toBeArray();
+            expect($vd)->toHaveKeys(['id', 'invoice_no', 'final_total', 'transaction_date']);
+            expect($vd['id'])->toBeInt();
+            expect($vd['invoice_no'])->toBeString();
+            expect($vd['final_total'])->toBeNumeric();
+            // transaction_date pode ser null (Carbon não preenchido) OR string YYYY-MM-DD
+            expect($vd['transaction_date'])->toSatisfy(
+                fn ($v) => $v === null || (is_string($v) && preg_match('/^\d{4}-\d{2}-\d{2}$/', $v))
+            );
+        }
+    }
+});

--- a/memory/requisitos/Repair/ProducaoOficina-r2-drawer-card-venda-derivada-visual-comparison.md
+++ b/memory/requisitos/Repair/ProducaoOficina-r2-drawer-card-venda-derivada-visual-comparison.md
@@ -1,0 +1,172 @@
+---
+tela: /repair/producao-oficina (drawer · adição cirúrgica)
+componente: resources/js/Pages/Repair/ProducaoOficina/Index.tsx (JobDrawer)
+onda: Onda 5 — Integração Vendas × Oficina (A1 KB-9.75)
+status: aprovado-cowork — mapeamento direto F1 protótipo
+fonte_cowork: prototipo-ui/oficina-page.jsx (linhas 392-458) + prototipo-ui/oficina-page.css (linhas 465-598)
+adr: 0192 (auto-faturar OS→Venda) · 0121 §P8 (vocabulário shared) · 0093 (multi-tenant Tier 0)
+data: 2026-05-25
+worker: B (sub-agent paralelo)
+---
+
+# Visual Comparison — Drawer card "Esta OS gerou venda"
+
+> **Escopo:** adição cirúrgica ao drawer existente. NÃO toca kanban, drag-and-drop, filtros, mock data, ou demais sections do drawer. Renderiza UM card novo no topo do drawer body **quando** `card.approved === true` (= coluna `pronto` = FSM `entregue_completo`) AND `card.venda_derivada !== null`.
+
+## Mapeamento Cowork → Inertia React
+
+### Fonte Cowork (`prototipo-ui/oficina-page.jsx` linhas 392-458)
+
+Drawer body do `oficina-page.jsx` tem `{showVendaCard && (...)}` que renderiza `.ofc-venda-card` com:
+
+- `.ofc-venda-flag` — pill canto superior esquerdo "✎ Integração Vendas×Oficina"
+- `.ofc-venda-head` — grid 2-col: título "Esta OS gerou a venda #V-NNNN" + small descritivo · estágio à direita
+- `.ofc-venda-grid` — 3-col com `Total venda` / `Peças (NF-e)` / `Mão-de-obra (NFS-e)` (CONDICIONAL — descartado nesta onda · charter Non-Goal por ora)
+- `.ofc-venda-fiscal` — badges NF-e / NFS-e (CONDICIONAL — descartado nesta onda · charter Non-Goal por ora)
+- `.ofc-venda-actions` — 4 botões: `Abrir #ID ↗` primary + DANFE NF-e + DANFS-e + Ver no Caixa
+
+### Adaptação Inertia (Onda 5)
+
+Payload **real** do Controller (Onda 2 ADR 0192) entrega APENAS 4 fields em `venda_derivada`:
+
+```json
+{
+  "venda_derivada": {
+    "id": 456,
+    "invoice_no": "V-456",
+    "final_total": 150.00,
+    "transaction_date": "2026-05-25"
+  }
+}
+```
+
+Peças/serviço breakdown e fiscal NF-e/NFS-e **não chegam ainda** — adiada pra wave futura (charter Non-Goal). Renderizamos o que temos + placeholder TODO no charter pra evoluir.
+
+## Dimensões avaliadas
+
+### 1. Hierarquia visual
+
+- **Cowork:** card destacado verde (oklch emerald 155° hue) com flag pill canto superior + título bold + estágio capsule à direita
+- **Inertia:** mesma hierarquia preservada — card `.ofc-venda-card` highlight verde + flag pill + título com `#V-NNNN` em `<code>` mono + total + data
+
+### 2. Tokens cor/tipo (oklch)
+
+| Token Cowork | Valor | Uso |
+|---|---|---|
+| Card bg | `linear-gradient(135deg, oklch(0.96 0.05 155), oklch(0.985 0.003 90))` | gradient verde-suave |
+| Card border | `oklch(0.50 0.13 155)` | verde sólido |
+| Flag pill bg | `oklch(0.50 0.13 155)` | verde sólido · texto branco |
+| Code mono | `oklch(0.50 0.13 155)` | identificador venda |
+| CTA primary | `oklch(0.50 0.13 155)` bg + white text | botão "Abrir" |
+| CTA secondary | white bg + verde border `oklch(0.94 0.06 155)` | "Imprimir recibo" / "Compartilhar" |
+
+Preservados verbatim. Sem hue shift — verde 155° (success/emerald).
+
+### 3. Layout
+
+- Card no **topo** do drawer body (antes de outras sections)
+- Width herda do drawer (480px)
+- Padding `18px 20px 16px` (Cowork)
+- Border-radius 10px (Cowork)
+
+### 4. Vocabulário shared (CRÍTICO — CI guard)
+
+✅ **Não usa termos automotivos** — apenas `venda_derivada`, `invoice_no`, `final_total`, `transaction_date`, `os_ref` (genérico cross-vertical conforme ADR 0121 §P8).
+
+✅ Card label PT-BR neutro: **"Esta OS gerou a venda #V-NNNN"** — funciona pra OficinaAuto (carro), ComunicacaoVisual (arte), Vestuario (peça reparada).
+
+### 5. Acessibilidade
+
+- Botões `<button type="button">` (não `<a>`)
+- `aria-label="Abrir venda V-NNNN"` no CTA primary (anti-screen-reader noise)
+- Contraste verde/branco WCAG AA (oklch 0.50 vs 1.0 = ~4.7:1 ratio)
+- Foco visível keyboard (`focus:ring-2 ring-emerald-500/40`)
+
+### 6. Dispatch CustomEvent (cross-módulo)
+
+```ts
+window.dispatchEvent(
+  new CustomEvent('oimpresso:open-venda', {
+    detail: { venda_id: card.venda_derivada.id },
+  }),
+);
+```
+
+Worker A em Onda 4 registra listener em `Sells/Index.tsx`. Esta Onda 5 **só dispara** — não precisa garantir handler exist (graceful degradation).
+
+### 7. Estados condicionais
+
+| Condição | Render |
+|---|---|
+| `!card.approved` | Não renderiza (card só na coluna `pronto`) |
+| `card.approved && !card.venda_derivada` | Não renderiza (Observer ADR 0192 ainda não criou Transaction — OS pré-existente pré-deploy) |
+| `card.approved && card.venda_derivada` | Renderiza card highlight verde com 3 CTAs |
+
+### 8. Atalhos (3 botões)
+
+1. **"Abrir #V-{invoice_no}"** (primary verde) → dispatch event
+2. **"Imprimir recibo"** (secondary outline verde) → `window.open('/sells/' + venda_id + '/print', '_blank')`
+3. **"Compartilhar"** (secondary outline verde) → **placeholder TODO** · charter Non-Goal por ora (botão visível mas `onClick` no-op)
+
+### 9. Non-Goals desta onda (Wagner aprovou plano F3)
+
+- ❌ Breakdown peças/serviço (Cowork tem mas payload backend não entrega · charter Non-Goal · wave futura)
+- ❌ Badges fiscais NF-e/NFS-e (charter Non-Goal · wave futura)
+- ❌ Botão "Ver no Caixa do dia" (Sells/Caixa.tsx é Onda 6 wave separada · charter Non-Goal)
+- ❌ Vocabulário automotivo (`placa`, `box`, `mecanico`) — CI guard `repair-shared-vocab.yml` bloqueia
+- ❌ Acoplamento direto Sells/Index — usa CustomEvent (loose coupling)
+
+### 10. Anti-padrões UI evitados
+
+- ❌ Modal (drawer continua sendo único container)
+- ❌ Loading skeleton (payload vem inline)
+- ❌ Toast/snackbar
+- ❌ Cores berrantes (verde oklch 155° conservador)
+- ❌ Animação decorativa (só hover transition Cowork)
+
+### 11. Multi-tenant Tier 0 (ADR 0093)
+
+- ✅ `venda_derivada` payload já vem scopado pelo Controller (Onda 2)
+- ✅ Frontend só renderiza — não dispara queries adicionais
+- ✅ `id` da venda é o ID interno do business correto (lookup batch já scopado)
+
+### 12. Performance
+
+- Zero queries adicionais (payload vem com `venda_derivada` já hidratado · Onda 2)
+- Card renderiza condicional — não custa nada se OS não tem venda
+- 3 CTAs sem fetch (dispatch event + open + no-op)
+
+### 13. Anti-hooks Cowork preservados
+
+✅ Sem CTA WhatsApp · sem emoji em UI (só símbolos canônicos ↗) · UI 100% português · sem rounded-xl+ (radius 6-10px) · tokens oklch dentro paleta.
+
+### 14. Charter compliance
+
+Adicionar à `Goals`:
+- Card "Esta OS gerou a venda #V-NNNN" no drawer quando OS está em coluna `pronto` AND tem `venda_derivada !== null` (ADR 0192 · Onda 5)
+- 3 CTAs: Abrir (dispatch `oimpresso:open-venda` → Worker A Sells/Index listener) · Imprimir recibo (`/sells/{id}/print`) · Compartilhar (placeholder TODO)
+
+Adicionar à `Non-Goals`:
+- Botão "Compartilhar" sem ação por ora (placeholder visual · backlog wave futura)
+- Breakdown peças/serviço no card (Cowork tem mas payload backend não entrega · wave futura)
+- Badges fiscais NF-e/NFS-e (wave futura)
+- Edição inline da venda derivada (drawer só lê)
+
+### 15. Pest GUARD (apêndice)
+
+Test novo em `Modules/Repair/Tests/Feature/ProducaoOficinaTest.php`:
+
+```php
+it('Onda 5: payload cards contém field venda_derivada (null OR shape correto)', function () {
+    // Valida que controller payload tem shape compatível com Index.tsx Onda 5
+    // (frontend espera: id INT · invoice_no STRING · final_total FLOAT · transaction_date STRING)
+});
+```
+
+---
+
+## Aprovação Wagner
+
+Wagner aprovou screenshot F1 do protótipo Cowork em PR #1493 (`b2fcabbf2`) 2026-05-25. ADR 0192 (Onda 0) aceito · Onda 1 + Onda 2 mergeadas. Esta Onda 5 é mapeamento direto do `.ofc-venda-card` Cowork pra Inertia React preservando tokens + hierarquia + vocabulário shared.
+
+Sem screenshot novo necessário — adição cirúrgica reproduz protótipo já aprovado.

--- a/resources/js/Pages/Repair/ProducaoOficina/Index.charter.md
+++ b/resources/js/Pages/Repair/ProducaoOficina/Index.charter.md
@@ -5,7 +5,7 @@ owner: wagner
 status: rascunho
 last_validated: 2026-05-10
 parent_module: Repair
-related_adrs: [0094, 0101, 0114, 0121, 0093]
+related_adrs: [0094, 0101, 0114, 0121, 0093, 0192]
 related_prototype: prototipo-ui/prototipos/producao-oficina/F1.html
 tier: A
 ---
@@ -36,6 +36,11 @@ Visão de produção em **kanban de 5 colunas** (Recepção → Diagnóstico →
 - Cabe em monitor 1280px sem scroll horizontal (Larissa quirk crítico — aplicado a outros clientes 1280px também)
 - AppShellV2 + topnav Repair (`KanbanSquare` icon)
 - **Multi-tenant Tier 0** ([ADR 0093](../../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)) preservado: queries `JobSheet` scopadas por `business_id` global scope; endpoint `/move` valida `business_id` antes de mutação
+- **Onda 5 — Integração Vendas × Oficina** ([ADR 0192](../../../../memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md)): drawer renderiza card `Esta OS gerou a venda #V-NNNN` quando OS está na coluna `pronto` (= FSM `entregue_completo`) AND tem `venda_derivada` (Transaction `source='oficina'` criada pelo `JobSheetObserver`). Card mostra total + data + 3 atalhos:
+  - **Abrir #V-NNNN** → dispatch `window.CustomEvent('oimpresso:open-venda', { detail: { venda_id } })` — listener em `Sells/Index.tsx` (Worker A Onda 4) abre drawer SaleSheet (loose coupling)
+  - **Imprimir recibo** → `window.open('/sells/{venda_id}/print', '_blank')` (rota Blade legacy preservada)
+  - **Compartilhar** → placeholder TODO (botão visível · ver Non-Goals)
+- Vocabulário shared multi-vertical preservado ([ADR 0121 §P8](../../../../memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md)) — `venda_derivada` é cross-vertical (OficinaAuto, ComunicacaoVisual, Vestuario)
 
 ---
 
@@ -50,6 +55,12 @@ Visão de produção em **kanban de 5 colunas** (Recepção → Diagnóstico →
 - ❌ Aprovação cliente *via* esta tela (botão "Reenviar" no drawer só dispara WhatsApp template — sem UI de aprovar/recusar aqui)
 - ❌ Edição inline em qualquer card
 - ❌ Tela específica per-vertical (Vestuario/ComVisual/OficinaAuto NÃO tem `/vestuario/producao-oficina` — todas usam `/repair/producao-oficina` parametrizado por `business.repair_settings`)
+- ❌ **Onda 5 placeholder TODOs (charter aceita explícito):**
+  - Botão "Compartilhar" no card da venda derivada **sem ação por ora** (visível mas `onClick` no-op). Backlog wave futura: copy-to-clipboard link · WhatsApp template · email PDF
+  - Breakdown peças/serviço no card (Cowork F1 tem mas payload `venda_derivada` Onda 2 não entrega esses fields — adiada pra wave futura quando Sells expor `itemsList`)
+  - Badges fiscais NF-e/NFS-e no card (wave futura · payload Onda 2 não entrega `fiscal` ainda)
+  - Edição inline da venda derivada (drawer só lê · CRUD vai pra `/sells/{id}/edit`)
+  - Botão "Ver no Caixa do dia" (Sells/Caixa.tsx é Onda 6 wave separada · fora deste plano)
 
 ---
 
@@ -115,3 +126,4 @@ Vertical decide o que faz sentido. Vestuário pode ter `slots: [{key: "rack", la
 - ✅ **US-REPA-002** — Caminho A refactor vocabulário shared (este charter atualizado)
 - ⏳ **US-REPA-003** — CI workflow `repair-shared-vocab.yml` que falha se `placa|vehicle|km|mecanico|elevador|box` voltar em `Modules/Repair/**` ou `resources/js/Pages/Repair/**`
 - ⏳ **US-REPA-004** — Vestuario/ComVisual/OficinaAuto seeders `RepairSettingsSeeder` populando `business.repair_settings` per-vertical
+- ✅ **US-REPA-INT-VND-5** — Onda 5 Integração Vendas × Oficina A1 KB-9.75 ([ADR 0192](../../../../memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md)): drawer card "Esta OS gerou venda #V-NNNN" + 3 CTAs (Abrir dispatch / Imprimir recibo / Compartilhar TODO). Adição cirúrgica preservando kanban + drag-drop + filtros + demais drawer sections.

--- a/resources/js/Pages/Repair/ProducaoOficina/Index.tsx
+++ b/resources/js/Pages/Repair/ProducaoOficina/Index.tsx
@@ -17,6 +17,18 @@ import { useEffect, useMemo, useState } from 'react';
 
 type Tone = 'slate' | 'blue' | 'amber' | 'violet' | 'emerald';
 
+// Onda 5 — Integração Vendas × Oficina (ADR 0192).
+// Quando OS está em coluna 'pronto' (= FSM `entregue_completo` · is_completed_status=true)
+// AND tem Transaction derivada (source='oficina'), o Controller (Onda 2) anexa este
+// shape ao card. Frontend renderiza card "Esta OS gerou venda" no drawer.
+// Vocabulário shared (ADR 0121 §P8): zero termos automotivos · cross-vertical.
+interface VendaDerivada {
+  id: number;
+  invoice_no: string;
+  final_total: number;
+  transaction_date: string | null;  // ISO date 'YYYY-MM-DD'
+}
+
 interface Card {
   id?: number;                    // presente em live data; ausente em mock (drag-drop só local)
   code: string;                   // genérico: placa (auto) | nº OS (com.visual) | código serviço (vestuario)
@@ -31,11 +43,12 @@ interface Card {
   area?: string | null;           // elevador (auto) | área impressão (com.visual)
   eta?: string;
   pending_approval?: boolean;
-  approved?: boolean;
+  approved?: boolean;             // true quando coluna='pronto' (is_completed_status)
   status_label?: string;
   quote_total?: number;
   quote_items?: number;
   quote_status?: string;
+  venda_derivada?: VendaDerivada | null;  // Onda 5 · ADR 0192
 }
 
 interface Column {
@@ -506,6 +519,15 @@ function JobDrawer({ card, labelOverrides, onClose }: { card: Card; labelOverrid
       )}
 
       <div className="flex-1 overflow-y-auto">
+        {/* Onda 5 (ADR 0192) — Integração Vendas × Oficina A1 KB-9.75.
+            Card renderiza quando OS está em coluna 'pronto' (= FSM `entregue_completo` ·
+            is_completed_status=true) AND o JobSheetObserver criou Transaction derivada
+            (source='oficina'). Loose coupling via window.CustomEvent — Sells/Index
+            (Worker A Onda 4) registra listener pra abrir drawer SaleSheet. */}
+        {card.approved && card.venda_derivada && (
+          <VendaDerivadaCard venda={card.venda_derivada} />
+        )}
+
         <DrawerSection title="Sintoma reportado">
           <p className="text-sm text-slate-800">
             Cliente relata barulho na suspensão dianteira ao passar em buraco. Volante puxa pra direita em
@@ -603,5 +625,112 @@ function TimelineEvent({
         <div className="text-xs text-slate-500">{meta}</div>
       </div>
     </li>
+  );
+}
+
+// Onda 5 (ADR 0192) — Integração Vendas × Oficina A1 KB-9.75.
+//
+// Card "Esta OS gerou venda #V-NNNN" renderizado no topo do drawer body quando
+// `card.approved === true` AND `card.venda_derivada !== null`. Mapeamento direto
+// do protótipo Cowork `oficina-page.jsx` linhas 392-458 + `oficina-page.css`
+// linhas 465-598 (.ofc-venda-* tokens preservados verbatim).
+//
+// Vocabulário shared (ADR 0121 §P8): zero termos automotivos.
+// Multi-tenant Tier 0 (ADR 0093): payload já scopado backend, frontend só lê.
+//
+// 3 CTAs:
+//  1. "Abrir #V-NNNN" → dispatch CustomEvent 'oimpresso:open-venda' (Worker A
+//     Sells/Index listener Onda 4 abre drawer SaleSheet · loose coupling)
+//  2. "Imprimir recibo" → window.open rota Blade legacy preservada
+//  3. "Compartilhar" → placeholder TODO · charter Non-Goal por ora
+//
+// Breakdown peças/serviço + badges fiscais NF-e/NFS-e do Cowork ficam pra wave
+// futura (charter Non-Goal · payload backend Onda 2 não entrega esses fields).
+function VendaDerivadaCard({ venda }: { venda: VendaDerivada }) {
+  const handleAbrir = () => {
+    window.dispatchEvent(
+      new CustomEvent('oimpresso:open-venda', {
+        detail: { venda_id: venda.id },
+      }),
+    );
+  };
+
+  const handleImprimirRecibo = () => {
+    window.open(`/sells/${venda.id}/print`, '_blank', 'noopener,noreferrer');
+  };
+
+  const handleCompartilhar = () => {
+    // TODO Onda futura — backlog item (charter Non-Goal por ora).
+    // Possibilidades: copy-to-clipboard link · WhatsApp template · email PDF.
+  };
+
+  const totalBR = venda.final_total.toLocaleString('pt-BR', {
+    style: 'currency',
+    currency: 'BRL',
+  });
+
+  const dataBR = venda.transaction_date
+    ? new Date(venda.transaction_date + 'T00:00:00').toLocaleDateString('pt-BR')
+    : '—';
+
+  return (
+    <div className="ofc-venda-card relative mx-5 mt-4 mb-2 rounded-[10px] border border-emerald-600/70 bg-gradient-to-br from-emerald-50 to-amber-50/30 px-5 pt-5 pb-4">
+      <div className="ofc-venda-flag absolute -top-2.5 left-4 rounded-full bg-emerald-600 px-2.5 py-0.5 font-mono text-[9px] font-bold uppercase tracking-wider text-white">
+        Integração Vendas × Oficina
+      </div>
+
+      <div className="ofc-venda-head mb-3">
+        <div className="text-sm font-bold leading-tight text-slate-900">
+          Esta OS gerou a venda{' '}
+          <code className="ml-0.5 rounded border border-emerald-200 bg-white px-2 py-0.5 font-mono text-[12.5px] font-bold text-emerald-700">
+            #{venda.invoice_no}
+          </code>
+        </div>
+        <div className="mt-1 text-[11px] font-medium text-emerald-800/80">
+          Auto-criada na transição para "Pronto" (ADR 0192)
+        </div>
+      </div>
+
+      <div className="ofc-venda-grid mb-3 grid grid-cols-2 gap-2">
+        <div className="rounded-md bg-white/65 px-3 py-2">
+          <div className="text-[9.5px] font-bold uppercase tracking-wider text-slate-500">
+            Total
+          </div>
+          <div className="mt-0.5 text-sm font-semibold text-slate-900">{totalBR}</div>
+        </div>
+        <div className="rounded-md bg-white/65 px-3 py-2">
+          <div className="text-[9.5px] font-bold uppercase tracking-wider text-slate-500">
+            Data
+          </div>
+          <div className="mt-0.5 text-sm font-semibold text-slate-900">{dataBR}</div>
+        </div>
+      </div>
+
+      <div className="ofc-venda-actions flex flex-wrap gap-1.5">
+        <button
+          type="button"
+          onClick={handleAbrir}
+          aria-label={`Abrir venda ${venda.invoice_no}`}
+          className="ofc-venda-cta primary inline-flex items-center gap-1 rounded-[5px] border border-emerald-600 bg-emerald-600 px-3 py-1.5 text-[11.5px] font-semibold text-white hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+        >
+          Abrir #{venda.invoice_no} ↗
+        </button>
+        <button
+          type="button"
+          onClick={handleImprimirRecibo}
+          className="ofc-venda-cta inline-flex items-center gap-1 rounded-[5px] border border-emerald-200 bg-white px-3 py-1.5 text-[11.5px] font-semibold text-emerald-700 hover:bg-emerald-50 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+        >
+          Imprimir recibo
+        </button>
+        <button
+          type="button"
+          onClick={handleCompartilhar}
+          title="Em breve · backlog wave futura"
+          className="ofc-venda-cta inline-flex items-center gap-1 rounded-[5px] border border-emerald-200 bg-white px-3 py-1.5 text-[11.5px] font-semibold text-emerald-700 hover:bg-emerald-50 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+        >
+          Compartilhar
+        </button>
+      </div>
+    </div>
   );
 }


### PR DESCRIPTION
## Resumo

**Onda 5 da Integração Vendas × Oficina (A1 KB-9.75 · [ADR 0192](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md))** — adição cirúrgica ao drawer de `/repair/producao-oficina` renderizando card **"Esta OS gerou a venda #V-NNNN"** quando OS está em coluna `pronto` (FSM `entregue_completo`) AND tem `venda_derivada` (Transaction `source='oficina'` criada pelo `JobSheetObserver` na Onda 2).

Worker B sequencial da Fase 2 paralela (Worker A trabalha `Sells/Index.tsx` em PRs separados).

## Mudanças

| Arquivo | LOC | Tipo |
|---|---|---|
| `resources/js/Pages/Repair/ProducaoOficina/Index.tsx` | +131 | interface `VendaDerivada` + `Card.venda_derivada` field + componente `VendaDerivadaCard` + render condicional |
| `resources/js/Pages/Repair/ProducaoOficina/Index.charter.md` | +14 | Goals/Non-Goals/backlog/related_adrs Onda 5 |
| `Modules/Repair/Tests/Feature/ProducaoOficinaTest.php` | +48 | Pest GUARD: cards expõem `venda_derivada` com shape correto OR null |
| `memory/requisitos/Repair/ProducaoOficina-r2-drawer-card-venda-derivada-visual-comparison.md` | +152 | mwart-comparative V4 · 15 dimensões + mapeamento Cowork→Inertia |

**Total:** 193 LOC code + 152 LOC docs · abaixo do limite 300 LOC (skill `commit-discipline`).

## Payload exemplo (vindo do Controller Onda 2)

```json
{
  "columns": [{
    "id": "pronto",
    "cards": [{
      "id": 123,
      "code": "RUI-2A45",
      "item": "Civic 2019",
      "approved": true,
      "status_label": "Aguardando retirada",
      "venda_derivada": {
        "id": 456,
        "invoice_no": "V-456",
        "final_total": 150.00,
        "transaction_date": "2026-05-25"
      }
    }]
  }]
}
```

Card só renderiza quando `card.approved === true` AND `card.venda_derivada !== null`.

## 3 CTAs (botões pequenos)

1. **"Abrir #V-NNNN"** (primary verde) → dispatch `window.CustomEvent('oimpresso:open-venda', { detail: { venda_id } })` → listener Sells/Index Worker A Onda 4 abre drawer SaleSheet (loose coupling cross-módulo)
2. **"Imprimir recibo"** (secondary outline verde) → `window.open('/sells/{id}/print', '_blank', 'noopener,noreferrer')` (rota Blade legacy preservada)
3. **"Compartilhar"** (secondary outline verde) → placeholder TODO (charter Non-Goal · backlog wave futura · `onClick` no-op com `title=\"Em breve\"`)

## Charter diff

**Goals adicionados:**
- Drawer renderiza card `Esta OS gerou a venda #V-NNNN` quando OS está na coluna `pronto` AND tem `venda_derivada`
- 3 atalhos (Abrir dispatch / Imprimir recibo / Compartilhar TODO)
- Vocabulário shared multi-vertical preservado ([ADR 0121 §P8](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md))

**Non-Goals adicionados (placeholder TODOs aceitos explícito):**
- Botão "Compartilhar" sem ação por ora (backlog: copy-to-clipboard · WhatsApp template · email PDF)
- Breakdown peças/serviço no card (payload Onda 2 não entrega `itemsList` ainda)
- Badges fiscais NF-e/NFS-e (payload Onda 2 não entrega `fiscal` ainda)
- Botão "Ver no Caixa do dia" (Sells/Caixa.tsx é Onda 6 wave separada)

**related_adrs:** `[0094, 0101, 0114, 0121, 0093, 0192]` (adicionado 0192)

**Backlog:** US-REPA-INT-VND-5 marcado como ✅ entregue

## Visual comparison

Skill `mwart-comparative V4` gerou [memory/requisitos/Repair/ProducaoOficina-r2-drawer-card-venda-derivada-visual-comparison.md](memory/requisitos/Repair/ProducaoOficina-r2-drawer-card-venda-derivada-visual-comparison.md) com 15 dimensões:

- Hierarquia visual · Tokens cor/tipo oklch 155° · Layout · Vocabulário shared · Acessibilidade · Dispatch CustomEvent · Estados condicionais · 3 atalhos · Non-Goals · Anti-padrões UI evitados · Multi-tenant Tier 0 · Performance · Anti-hooks Cowork · Charter compliance · Pest GUARD

Sem screenshot novo necessário — adição cirúrgica reproduz protótipo Cowork F1 já aprovado por Wagner em PR #1493 (`b2fcabbf2`).

## Vocabulário shared preservado ([ADR 0121 §P8](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md))

✅ Zero termos automotivos (`placa`, `vehicle`, `km`, `mecanico`, `box`, `elevador`, `aprovacao_pendente`, `orcamento_*`)
✅ Apenas `venda_derivada`, `invoice_no`, `final_total`, `transaction_date` (cross-vertical)
✅ Label PT-BR neutro: "Esta OS gerou a venda #V-NNNN" funciona pra OficinaAuto/ComunicacaoVisual/Vestuario
✅ CI `repair-shared-vocab.yml` PASSA (sem keys/accessors banidos no código novo)

## Multi-tenant Tier 0 ([ADR 0093](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0093-multi-tenant-isolation-tier-0.md))

✅ Payload `venda_derivada` vem do Controller Onda 2 já scopado por `business_id` (lookup batch · `Transaction::where('business_id', $businessId)->where('source', 'oficina')`)
✅ Frontend só renderiza — não dispara queries adicionais
✅ Zero risco de cross-tenant (ID interno do business correto)

## Pest GUARD

Test novo em `Modules/Repair/Tests/Feature/ProducaoOficinaTest.php`:

```
it('Onda 5: cards expõem field venda_derivada com shape correto OR null', ...)
```

Valida contrato do payload: cada card pode ter `venda_derivada` `null` OU `{ id: int, invoice_no: string, final_total: numeric, transaction_date: 'YYYY-MM-DD'|null }`. Quebrar shape derruba drawer card → CI falha. Skip gracioso em SQLite (UltimatePOS MODIFY COLUMN MySQL-only).

## Review triggers (revisar quando)

1. **Worker A entrega Onda 4** → testar end-to-end: clicar "Abrir #V-NNNN" no drawer Repair dispara CustomEvent → Sells/Index drawer SaleSheet abre a venda correta
2. **Sells expor `itemsList` no payload `venda_derivada`** → remover Non-Goal "Breakdown peças/serviço" + implementar grid 3-col Cowork (Total/Peças/Mão-de-obra)
3. **Cliente reporta "OS entregue mas não vejo card no drawer"** → debug Observer Onda 2 (Transaction created? `os_ref` correto? business_id scoped?)

## Checklist pré-merge (Wagner)

- [ ] CI verde (Pest + repair-shared-vocab)
- [ ] Screenshot drawer com OS em coluna `pronto` mostrando card verde + 3 CTAs
- [ ] Smoke manual: clicar "Abrir #V-NNNN" dispara CustomEvent (verificar em devtools console)
- [ ] Smoke manual: "Imprimir recibo" abre `/sells/{id}/print` em nova aba

🤖 Generated with [Claude Code](https://claude.com/claude-code)