### PR TITLE
fix(cliente): hotfix re-adiciona papeis() method (PR #1503 follow-up)

### DIFF
--- a/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
+++ b/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
@@ -289,6 +289,74 @@ class ClienteAutosaveController extends Controller
     }
 
     /**
+     * Onda 4 (ADR 0188 §Plano-8) -- Drawer 760 secao "Papeis" com 4 checkboxes
+     * is_customer / is_supplier / is_employee / is_representative.
+     *
+     * Permite que 1 contato tenha N papeis simultaneos (Wagner Rocha pode ser
+     * cliente E representante = mesma row · sem duplicacao).
+     *
+     * Body: JSON com 1+ flags bool (atomic update per-checkbox · sem debounce
+     * porque toggle e discreto, nao digitacao).
+     *
+     * Invariante (ADR 0188 §Invariantes #4-5):
+     *  - Flags aditivas, NUNCA exclusivas (pode setar varios true)
+     *  - >=1 papel ativo final (anti soft-delete acidental)
+     *  - `type` enum permanece authoritative pra UPOS Sells/Compras/Folha legacy
+     *
+     * Hotfix #1503 (PR original mergeou sem este metodo devido a linter
+     * revert intermitente · re-adicionado em hotfix dedicado).
+     *
+     * @see memory/decisions/0188-contacts-multi-type-flag-aditiva.md
+     */
+    public function papeis(Request $request, int $id): JsonResponse
+    {
+        $contact = $this->locateContact($id);
+        if (! $contact instanceof Contact) {
+            return $contact;
+        }
+
+        $validator = Validator::make($request->all(), [
+            'is_customer' => ['nullable', 'boolean'],
+            'is_supplier' => ['nullable', 'boolean'],
+            'is_employee' => ['nullable', 'boolean'],
+            'is_representative' => ['nullable', 'boolean'],
+        ], $this->messages());
+
+        if ($validator->fails()) {
+            return response()->json(['errors' => $validator->errors()], 422);
+        }
+
+        $data = $validator->validated();
+
+        // Cast bool consistente (front pode mandar 0/1/true/false · normalize).
+        foreach (['is_customer', 'is_supplier', 'is_employee', 'is_representative'] as $f) {
+            if (array_key_exists($f, $data)) {
+                $data[$f] = (int) (bool) $data[$f];
+            }
+        }
+
+        // Invariante: contato precisa ter pelo menos 1 papel ativo.
+        // Calcula estado FINAL (merge entre $data parcial + $contact atual)
+        // antes de validar -- se update remover ultimo flag, bloqueia.
+        $finalFlags = [
+            'is_customer' => $data['is_customer'] ?? (int) ($contact->is_customer ?? 0),
+            'is_supplier' => $data['is_supplier'] ?? (int) ($contact->is_supplier ?? 0),
+            'is_employee' => $data['is_employee'] ?? (int) ($contact->is_employee ?? 0),
+            'is_representative' => $data['is_representative'] ?? (int) ($contact->is_representative ?? 0),
+        ];
+
+        if (array_sum($finalFlags) === 0) {
+            return response()->json([
+                'errors' => [
+                    'is_customer' => ['Contato precisa ter pelo menos 1 papel ativo (Cliente, Fornecedor, Funcionario ou Representante).'],
+                ],
+            ], 422);
+        }
+
+        return $this->updateAndRespond($contact, $data);
+    }
+
+    /**
      * Localiza o contato com escopo multi-tenant Tier 0 (ADR 0093) + checagem
      * de permission gate matricial customer/supplier.
      *


### PR DESCRIPTION
## Summary

PR #1503 (Onda 4 Drawer Papéis) mergeou mas em prod retorna **500**:

```
BadMethodCallException: Method Modules\Crm\Http\Controllers\ClienteAutosaveController::papeis does not exist
```

**Diagnose:** durante a série de commits/cherry-picks/rebases que recuperaram o worktree contaminado (PR 1503 caiu inicialmente no branch foreign feat/paymentgateway-…), o linter intentional change reverteu o método `papeis()` do controller — mantendo apenas o JSX + route + tests. Cherry-pick e rebase não re-aplicaram porque o conflito foi resolvido em favor da versão limpa.

**Fix:** re-adiciona o método `papeis()` idêntico ao design de #1503 (validate 4 flags bool + invariante ≥1 papel ativo + cast int→bool + multi-tenant via `locateContact` preservado).

## Smoke produção pré-fix

Wagner validou visualmente em https://oimpresso.com/cliente:
- ✅ Drawer abriu
- ✅ Seção "Papéis" renderou com 4 checkboxes
- ✅ Cliente já marcado (backfill da migration)
- ❌ Toggle Fornecedor → "Erro 500 ao salvar papel" + rollback funcionou

Esperado pós-merge deste hotfix:
- Toggle "Fornecedor" → 200 + "Salvo" checkmark

## Test plan

- [x] `php -l` syntax OK
- [x] `vendor/bin/pest --filter=papeis` → **2 testes pass** (rotas registradas + middleware Tier 0)
- [x] `php artisan ui:lint --strict --changed-only` → sem regressões (não toca .tsx)
- [ ] CI workflow verde
- [ ] Smoke prod pós-deploy: clicar checkbox Fornecedor → ver "Salvo"

## Constraints

- Tier 0 multi-tenant preservado (`locateContact` faz `business_id` scope)
- Append-only (Constituição v2 Art. 3): método novo, nada removido
- Backward-compat UPOS: `type` enum permanece authoritative pra Sells/Compras

## Refs

- [PR #1503 Onda 4 original](https://github.com/wagnerra23/oimpresso.com/pull/1503)
- [ADR 0188 §Plano-8](memory/decisions/0188-contacts-multi-type-flag-aditiva.md)
- [ADR 0093 multi-tenant Tier 0](memory/decisions/0093-multi-tenant-isolation-tier-0.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
