### PR TITLE
fix(cliente): Papéis → Classificação · chips · remove toggle PF/PJ duplicado

### DIFF
--- a/config/ui-lint-baseline.json
+++ b/config/ui-lint-baseline.json
@@ -1,9 +1,9 @@
 {
     "_meta": {
-        "generated_at": "2026-05-25T14:48:04-03:00",
+        "generated_at": "2026-05-25T15:11:26-03:00",
         "tool": "ui:lint",
-        "files_scanned": 490,
-        "total_violations": 7304,
+        "files_scanned": 491,
+        "total_violations": 7328,
         "rules": {
             "R1": "cor crua (hex literal ou bg-COR-NNN em Page)",
             "R2": "FontAwesome (lucide-only · ADR UI-0003)",
@@ -866,7 +866,7 @@
             "R1": 30
         },
         "resources\/js\/Pages\/Repair\/ProducaoOficina\/Index.tsx": {
-            "R1": 92,
+            "R1": 116,
             "R3": 1
         },
         "resources\/js\/Pages\/Repair\/Show.tsx": {

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -1668,32 +1668,12 @@ function ClienteSheet({
             />
 
             <div className="flex-1 min-w-0">
-              {/* Toggle PF/PJ -- radio group simples. Wave C planta PATCH on blur. */}
-              <div
-                className="inline-flex items-center gap-1 rounded-md bg-muted/60 p-0.5 text-xs"
-                role="radiogroup"
-                aria-label="Tipo de pessoa"
-              >
-                {(['PF', 'PJ'] as const).map((t) => (
-                  <button
-                    key={t}
-                    type="button"
-                    role="radio"
-                    aria-checked={tipo === t}
-                    onClick={() => setTipo(t)}
-                    className={
-                      'rounded px-2 py-0.5 transition-colors ' +
-                      (tipo === t
-                        ? 'bg-background text-foreground shadow-sm'
-                        : 'text-muted-foreground hover:text-foreground')
-                    }
-                  >
-                    {t === 'PF' ? 'Pessoa física' : 'Pessoa jurídica'}
-                  </button>
-                ))}
-              </div>
-
-              <SheetTitle className="text-lg font-semibold leading-tight mt-1.5">
+              {/* Wagner 2026-05-25 UX feedback: toggle PF/PJ duplicado removido.
+                  Toggle fantasma aqui no header só mudava state local (não persistia
+                  PATCH) · gerava confusão "qual está valendo?". Toggle REAL fica em
+                  IdentificacaoTab (`handleTipoChange` → PATCH /cliente/{id}/identificacao
+                  com autosave on blur). Aqui mantemos só o subtitle informativo. */}
+              <SheetTitle className="text-lg font-semibold leading-tight">
                 {contact?.name ?? 'Cliente'}
               </SheetTitle>
 

--- a/resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx
@@ -32,7 +32,22 @@ export interface ContactInfo {
   tags?: string[] | null;
   status?: 'ativo' | 'inativo' | 'bloqueado' | string | null;
   vip?: boolean | null;
+  // ADR 0188 Onda 4 — flags multi-papel (Wagner 2026-05-25 UX refactor:
+  // movido de IdentificacaoTab pra cá · papel é classificação semântica).
+  is_customer?: boolean | null;
+  is_supplier?: boolean | null;
+  is_employee?: boolean | null;
+  is_representative?: boolean | null;
 }
+
+/** 4 papéis canônicos ADR 0188. Ordem visual estável (Cliente primeiro · papel
+ *  mais comum em PME ROTA LIVRE biz=4). */
+const PAPEL_OPTIONS: Array<{ flag: 'is_customer' | 'is_supplier' | 'is_employee' | 'is_representative'; label: string }> = [
+  { flag: 'is_customer',       label: 'Cliente' },
+  { flag: 'is_supplier',       label: 'Fornecedor' },
+  { flag: 'is_employee',       label: 'Funcionário' },
+  { flag: 'is_representative', label: 'Representante' },
+];
 
 export interface ClassificacaoTabProps {
   contact: ContactInfo;
@@ -78,6 +93,11 @@ export default function ClassificacaoTab({ contact, onSaved, disabled = false }:
   const [tags, setTags] = useState<string[]>(Array.isArray(contact.tags) ? contact.tags : []);
   const [status, setStatus] = useState<string>(contact.status ?? 'ativo');
   const [vip, setVip] = useState<boolean>(!!contact.vip);
+  // ADR 0188 Onda 4 — 4 flags multi-papel (Wagner 2026-05-25 UX refactor).
+  const [isCustomer, setIsCustomer] = useState<boolean>(Boolean(contact.is_customer));
+  const [isSupplier, setIsSupplier] = useState<boolean>(Boolean(contact.is_supplier));
+  const [isEmployee, setIsEmployee] = useState<boolean>(Boolean(contact.is_employee));
+  const [isRepresentative, setIsRepresentative] = useState<boolean>(Boolean(contact.is_representative));
 
   const [savingField, setSavingField] = useState<string | null>(null);
   const [savedField, setSavedField] = useState<string | null>(null);
@@ -90,6 +110,10 @@ export default function ClassificacaoTab({ contact, onSaved, disabled = false }:
     setTags(Array.isArray(contact.tags) ? contact.tags : []);
     setStatus(contact.status ?? 'ativo');
     setVip(!!contact.vip);
+    setIsCustomer(Boolean(contact.is_customer));
+    setIsSupplier(Boolean(contact.is_supplier));
+    setIsEmployee(Boolean(contact.is_employee));
+    setIsRepresentative(Boolean(contact.is_representative));
     setErrorField(null);
     setSavedField(null);
   }, [contact.id]);
@@ -189,9 +213,128 @@ export default function ClassificacaoTab({ contact, onSaved, disabled = false }:
     [vip, performSave]
   );
 
+  // ADR 0188 Onda 4 — toggle papel via endpoint /papeis separado (não
+  // /classificacao) pra isolar invariante ">=1 papel ativo" no backend.
+  // Optimistic UI: troca state imediato + PATCH paralelo. Rollback no 4xx/5xx.
+  const handlePapelToggle = useCallback(
+    async (
+      flag: 'is_customer' | 'is_supplier' | 'is_employee' | 'is_representative',
+    ) => {
+      if (disabled) return;
+
+      const setters = {
+        is_customer: setIsCustomer,
+        is_supplier: setIsSupplier,
+        is_employee: setIsEmployee,
+        is_representative: setIsRepresentative,
+      };
+      const currentValues = {
+        is_customer: isCustomer,
+        is_supplier: isSupplier,
+        is_employee: isEmployee,
+        is_representative: isRepresentative,
+      };
+      const newValue = !currentValues[flag];
+
+      setters[flag](newValue);
+      setSavingField(flag);
+      setErrorField(null);
+
+      try {
+        const r = await fetch(`/cliente/${contact.id}/papeis`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            'X-CSRF-TOKEN': getCsrfToken(),
+            'X-Requested-With': 'XMLHttpRequest',
+          },
+          body: JSON.stringify({ [flag]: newValue }),
+        });
+
+        if (!r.ok) {
+          setters[flag](currentValues[flag]);
+          let msg = `Erro ${r.status} ao salvar papel.`;
+          if (r.status === 422) {
+            const j = await r.json().catch(() => ({}));
+            msg = j?.errors?.[flag]?.[0] ?? j?.errors?.is_customer?.[0] ?? msg;
+          } else if (r.status === 403) {
+            msg = 'Sem permissão pra editar papéis.';
+          }
+          setErrorField({ field: flag, message: msg });
+          // eslint-disable-next-line no-console
+          console.error(`[ClassificacaoTab] papeis ${flag} falhou`, { status: r.status });
+          return;
+        }
+
+        setSavedField(flag);
+        setTimeout(() => setSavedField((c) => (c === flag ? null : c)), 1800);
+        onSaved?.(flag, newValue);
+      } catch (err) {
+        setters[flag](currentValues[flag]);
+        setErrorField({ field: flag, message: 'Falha de rede. Tente de novo.' });
+        // eslint-disable-next-line no-console
+        console.error(`[ClassificacaoTab] papeis ${flag} network`, err);
+      } finally {
+        setSavingField((c) => (c === flag ? null : c));
+      }
+    },
+    [contact.id, disabled, isCustomer, isSupplier, isEmployee, isRepresentative, onSaved],
+  );
+
+  // Helper pra map flag → state local (usado no JSX dos chips).
+  const papelValue = (flag: typeof PAPEL_OPTIONS[number]['flag']): boolean => {
+    if (flag === 'is_customer') return isCustomer;
+    if (flag === 'is_supplier') return isSupplier;
+    if (flag === 'is_employee') return isEmployee;
+    return isRepresentative;
+  };
+
   return (
     <div className="space-y-5">
       <div className="grid gap-4 md:grid-cols-2">
+        {/* ADR 0188 Onda 4 — Papéis (4 chips toggleáveis · Wagner 2026-05-25
+            UX feedback: chips estilo TagChip canon · padrão Stripe/Linear).
+            Permite N papéis simultâneos no mesmo cadastro (insight Delphi).
+            Backend invariante: ≥1 papel ativo (anti soft-delete acidental). */}
+        <div className="md:col-span-2">
+          <Label className="text-xs font-medium">
+            Papéis <span className="text-muted-foreground font-normal">(clique pra alternar)</span>
+          </Label>
+          <div
+            className="mt-1 flex flex-wrap gap-1.5"
+            role="group"
+            aria-label="Papéis do contato"
+          >
+            {PAPEL_OPTIONS.map(({ flag, label }) => {
+              const checked = papelValue(flag);
+              return (
+                <button
+                  key={flag}
+                  type="button"
+                  onClick={() => handlePapelToggle(flag)}
+                  disabled={disabled || savingField === flag}
+                  aria-pressed={checked}
+                  className={`rounded-full border px-2.5 py-1 text-xs transition-colors ${
+                    checked
+                      ? 'border-primary bg-primary/10 text-foreground'
+                      : 'border-input bg-background text-muted-foreground hover:border-muted-foreground/40 hover:text-foreground'
+                  } ${disabled ? 'pointer-events-none opacity-50' : ''}`}
+                >
+                  {label}
+                </button>
+              );
+            })}
+          </div>
+          <FieldStatus
+            saving={['is_customer', 'is_supplier', 'is_employee', 'is_representative'].includes(savingField ?? '')}
+            saved={['is_customer', 'is_supplier', 'is_employee', 'is_representative'].includes(savedField ?? '')}
+            backendError={
+              errorField?.field?.startsWith('is_') ? errorField.message : null
+            }
+          />
+        </div>
+
         {/* Segmento — radio 6 valores */}
         <div className="md:col-span-2">
           <Label className="text-xs font-medium">Segmento</Label>

--- a/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx
@@ -102,11 +102,10 @@ export default function IdentificacaoTab({
   const [nascimento, setNascimento] = useState<string>(contact.nascimento ?? '');
   const [contatoNome, setContatoNome] = useState<string>(contact.contato ?? '');
   const [cargo, setCargo] = useState<string>(contact.cargo ?? '');
-  // ADR 0188 Onda 4 — flags multi-papel. Default false se ausente (contato pre-migration).
-  const [isCustomer, setIsCustomer] = useState<boolean>(Boolean(contact.is_customer));
-  const [isSupplier, setIsSupplier] = useState<boolean>(Boolean(contact.is_supplier));
-  const [isEmployee, setIsEmployee] = useState<boolean>(Boolean(contact.is_employee));
-  const [isRepresentative, setIsRepresentative] = useState<boolean>(Boolean(contact.is_representative));
+  // ADR 0188 Onda 4 — flags multi-papel migradas pra ClassificacaoTab (UX
+  // refactor Wagner 2026-05-25 · papel é classificação, não identidade).
+  // Mantemos tipo definido em ContactInfo só pra retrocompat de quem ainda
+  // lê do prop, mas state local foi removido daqui.
 
   const [savingField, setSavingField] = useState<string | null>(null);
   const [savedField, setSavedField] = useState<string | null>(null);
@@ -128,10 +127,6 @@ export default function IdentificacaoTab({
     setNascimento(contact.nascimento ?? '');
     setContatoNome(contact.contato ?? '');
     setCargo(contact.cargo ?? '');
-    setIsCustomer(Boolean(contact.is_customer));
-    setIsSupplier(Boolean(contact.is_supplier));
-    setIsEmployee(Boolean(contact.is_employee));
-    setIsRepresentative(Boolean(contact.is_representative));
     setErrorField(null);
     setSavedField(null);
     setCnpjLookup('idle');
@@ -271,86 +266,8 @@ export default function IdentificacaoTab({
     [tipo, performSave]
   );
 
-  // ADR 0188 Onda 4 — toggle papel (4 checkboxes is_X). Endpoint /papeis separado
-  // (não /identificacao) pra isolar invariante "≥1 papel ativo" no backend.
-  //
-  // Optimistic UI: troca state imediato + PATCH em paralelo. Rollback no 4xx/5xx.
-  // Sem debounce (checkbox toggle é discreto, não digitação).
-  const handlePapelToggle = useCallback(
-    async (
-      flag: 'is_customer' | 'is_supplier' | 'is_employee' | 'is_representative',
-      newValue: boolean,
-    ) => {
-      if (disabled) return;
-
-      // Optimistic UI — troca state local imediato.
-      const setters = {
-        is_customer: setIsCustomer,
-        is_supplier: setIsSupplier,
-        is_employee: setIsEmployee,
-        is_representative: setIsRepresentative,
-      };
-      const previousValues = {
-        is_customer: isCustomer,
-        is_supplier: isSupplier,
-        is_employee: isEmployee,
-        is_representative: isRepresentative,
-      };
-      setters[flag](newValue);
-
-      setSavingField(flag);
-      setErrorField(null);
-
-      try {
-        const r = await fetch(`/cliente/${contact.id}/papeis`, {
-          method: 'PATCH',
-          headers: {
-            'Content-Type': 'application/json',
-            Accept: 'application/json',
-            'X-CSRF-TOKEN': getCsrfToken(),
-            'X-Requested-With': 'XMLHttpRequest',
-          },
-          body: JSON.stringify({ [flag]: newValue }),
-        });
-
-        if (!r.ok) {
-          // Rollback optimistic UI
-          setters[flag](previousValues[flag]);
-          let msg = `Erro ${r.status} ao salvar papel.`;
-          if (r.status === 422) {
-            const j = await r.json().catch(() => ({}));
-            msg = j?.errors?.[flag]?.[0] ?? j?.errors?.is_customer?.[0] ?? msg;
-          } else if (r.status === 403) {
-            msg = 'Sem permissão pra editar papéis.';
-          }
-          setErrorField({ field: flag, message: msg });
-          // eslint-disable-next-line no-console
-          console.error(`[IdentificacaoTab] papeis ${flag} falhou`, { status: r.status, msg });
-          return;
-        }
-
-        setSavedField(flag);
-        setTimeout(() => setSavedField((current) => (current === flag ? null : current)), 1800);
-        onSaved?.(flag, newValue);
-      } catch (err) {
-        setters[flag](previousValues[flag]);
-        setErrorField({ field: flag, message: 'Falha de rede. Tente de novo.' });
-        // eslint-disable-next-line no-console
-        console.error(`[IdentificacaoTab] papeis ${flag} network error`, err);
-      } finally {
-        setSavingField((current) => (current === flag ? null : current));
-      }
-    },
-    [
-      contact.id,
-      disabled,
-      isCustomer,
-      isSupplier,
-      isEmployee,
-      isRepresentative,
-      onSaved,
-    ],
-  );
+  // ADR 0188 Onda 4 — handler `handlePapelToggle` migrado pra ClassificacaoTab
+  // (UX refactor Wagner 2026-05-25 · papel é classificação, não identidade).
 
   // ── Lookup CNPJ — Técnica C ADR 0186: BrasilAPI + SEFAZ em PARALELO ──
   //
@@ -668,51 +585,11 @@ export default function IdentificacaoTab({
         </button>
       </div>
 
-      {/* ADR 0188 Onda 4 — Seção Papéis (multi-type flags).
-          Permite que 1 contato tenha N papéis simultâneos (Wagner Rocha cliente+
-          representante = mesma row · sem duplicar cadastro como acontecia no UPOS
-          single-type). Insight Delphi WR Comercial — flag bool por papel.
-          Backend invariante: ≥1 papel ativo (não permite desmarcar todos). */}
-      <fieldset className="rounded-md border border-input bg-muted/20 p-3">
-        <legend className="px-1.5 text-xs font-medium text-muted-foreground">
-          Papéis <span className="font-normal">(marque todos que se aplicam)</span>
-        </legend>
-        <div className="grid grid-cols-2 gap-2 mt-1">
-          {([
-            { flag: 'is_customer' as const,       value: isCustomer,       label: 'Cliente',       Icon: User },
-            { flag: 'is_supplier' as const,       value: isSupplier,       label: 'Fornecedor',    Icon: Building2 },
-            { flag: 'is_employee' as const,       value: isEmployee,       label: 'Funcionário',   Icon: User },
-            { flag: 'is_representative' as const, value: isRepresentative, label: 'Representante', Icon: User },
-          ]).map(({ flag, value, label, Icon }) => (
-            <label
-              key={flag}
-              className={
-                'inline-flex items-center gap-2 px-2 py-1.5 text-sm rounded-md cursor-pointer transition-colors ' +
-                'hover:bg-background focus-within:ring-2 focus-within:ring-primary/40 ' +
-                (value ? 'text-foreground font-medium' : 'text-muted-foreground')
-              }
-            >
-              <input
-                type="checkbox"
-                checked={value}
-                disabled={disabled}
-                onChange={(e) => handlePapelToggle(flag, e.target.checked)}
-                aria-label={label}
-                className="h-4 w-4 rounded border-input accent-primary cursor-pointer disabled:opacity-50"
-              />
-              <Icon size={14} aria-hidden className={value ? 'text-primary' : ''} />
-              {label}
-              {savingField === flag && <Loader2 size={11} className="animate-spin ml-auto" aria-hidden />}
-              {savedField === flag && <CheckCircle2 size={11} className="ml-auto text-primary" aria-hidden />}
-            </label>
-          ))}
-        </div>
-        {errorField?.field?.startsWith('is_') && (
-          <p className="mt-2 inline-flex items-center gap-1 text-xs text-destructive" role="alert">
-            <AlertCircle size={11} aria-hidden /> {errorField.message}
-          </p>
-        )}
-      </fieldset>
+      {/* Wagner 2026-05-25 UX feedback: secao "Papeis" movida pra
+          ClassificacaoTab (semantica correta — papel e categorizacao, nao
+          identidade). Identificacao agora foca em PF/PJ + nome + CPF/CNPJ
+          (quem o contato e), e Classificacao trata todos os papeis cadastrais
+          (como o sistema categoriza esse contato). */}
 
       {/* Linha 1: Nome/Razão social */}
       <div className="grid gap-4 md:grid-cols-2">


### PR DESCRIPTION
## Summary

Wagner 2026-05-25 (pós validação visual Onda 4 em prod) deu 3 observações UX:

1. **"Papéis é classificação? deveria ficar lá, correto?"** → ✅ sim — papel é categorização semântica (tab Classificação), não identidade (tab Identificação)
2. **"deveria passar uma pílula pra melhorar o design"** → ✅ chips toggleáveis (estilo TagChip canon) em vez de checkboxes brutos
3. **"tipo de pessoa existe 2 vezes — qual está valendo?"** → toggle no **header do drawer era FANTASMA** (só state local, sem PATCH). Toggle real fica no IdentificacaoTab com autosave

## Mudanças

### A) Header do drawer (`Index.tsx`)
Remove toggle PF/PJ fantasma que não persistia. Mantém só o subtitle informativo:
```
Antonella Alves Araujo
Pessoa jurídica · cadastrado há 11m
```

### B) `IdentificacaoTab.tsx`
Remove seção Papéis (fieldset + checkboxes + 4 state booleans + handler). Tab volta a focar em **"quem o contato é"** (PF/PJ + nome + CPF/CNPJ + IE/RG).

### C) `ClassificacaoTab.tsx`
Adiciona seção **"Papéis"** no topo da tab com **4 chips toggleáveis** estilo `TagChip` canon:

```
┌─ Papéis (clique pra alternar) ──────────────────────┐
│ [Cliente]  Fornecedor  Funcionário  Representante  │ ← chips
└─────────────────────────────────────────────────────┘
   ativo: border-primary bg-primary/10
   inativo: border-input bg-background hover
```

Endpoint backend `PATCH /cliente/{id}/papeis` **não mudou** — só quem chama do frontend.

## Antes vs Depois (Drawer)

```
ANTES                                  DEPOIS
┌─ Header drawer ───────────┐         ┌─ Header drawer ───────────┐
│ [PF | PJ]  (FANTASMA ❌)  │         │ Antonella Alves Araujo    │
│ Antonella Alves Araujo    │         │ Pessoa jurídica · cad. X  │
│ Pessoa jurídica · cad. X  │         └───────────────────────────┘
└───────────────────────────┘
                                       ┌─ Tab Identificação ───────┐
┌─ Tab Identificação ───────┐         │ [PF | PJ]  ← único, REAL │
│ [PF | PJ]                 │         │ Nome: ...                 │
│ ┌─ Papéis ❌ wrong tab──┐ │         │ ...                       │
│ │ ☑ Cliente  ☐ Forn.   │ │         └───────────────────────────┘
│ └────────────────────── │ │         ┌─ Tab Classificação ───────┐
│ Nome: ...               │ │         │ ┌─ Papéis ✅ chips ───────┐ │
└─────────────────────────┘ │         │ │ [Cliente] Forn. Func.  │ │
                            │         │ └────────────────────────┘ │
┌─ Tab Classificação ───────┐         │ Segmento: ...             │
│ Segmento: ...             │         │ Tags: ...                 │
│ Tags: ...                 │         │ Status: ...               │
└───────────────────────────┘         └───────────────────────────┘
```

## Test plan

- [x] `php artisan ui:lint --strict --changed-only` → **Ok · sem regressões**
- [x] Pre-commit hook validou local
- [ ] CI ui-lint workflow verde
- [ ] CI pr-ui-judge LLM ≥ 70
- [ ] Smoke prod:
  - Abrir drawer → ver subtitle "Pessoa jurídica · cadastrado X" (sem toggle duplicado)
  - Tab Identificação → ver SÓ um toggle PF/PJ (real, com autosave)
  - Tab Classificação → ver chips "Papéis" no topo
  - Clicar chip Fornecedor → toggle anima + persiste 200

## Constraints

- **Backend intacto** — endpoint `/papeis` já existe (hotfix #1505) · só muda chamador
- **Append-only** — código antigo removido pertenceu ao mesmo escopo Onda 4 (refinamento, não reversão)
- **Tier 0 multi-tenant preservado** — `locateContact` no controller continua filtrando `business_id`
- **Tokens semânticos canon** — `border-primary`, `bg-primary/10`, `text-foreground`, `text-muted-foreground` · zero AP1

## Refs

- [ADR 0188 · Contatos multi-type · Onda 4](memory/decisions/0188-contacts-multi-type-flag-aditiva.md)
- [ADR UI-0013 · Constituição UI v2](memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md)
- ClassificacaoTab `TAG_OPTIONS` (pattern de design referência)
- Wagner 2026-05-25 feedback literal: "Papéis é classificação?... pílula melhorar design... tipo de pessoa 2 vezes qual vale?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
