### PR TITLE
feat(repair): Onda 5 follow-up — botão Compartilhar via Web Share API + clipboard fallback

### DIFF
--- a/Modules/Repair/Tests/Feature/ProducaoOficinaOnda5CompartilharTest.php
+++ b/Modules/Repair/Tests/Feature/ProducaoOficinaOnda5CompartilharTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest — Onda 5 follow-up (Worker 3 · 2026-05-25) · ADR 0192
+ * Integração Vendas × Oficina — botão "Compartilhar" no drawer card.
+ *
+ * GUARD estrutural sobre `resources/js/Pages/Repair/ProducaoOficina/Index.tsx`
+ * que garante que o handler `handleCompartilhar` permanece funcional e NÃO
+ * regride pra placeholder no-op em refactors futuros.
+ *
+ * Implementação canônica:
+ *  - Web Share API nativa (`navigator.share`) com `canShare` guard (Safari iOS quirk)
+ *  - Fallback `navigator.clipboard.writeText()` + toast Sonner (pattern projeto)
+ *  - `AbortError` tratado silenciosamente (user cancelou share-sheet)
+ *  - Botão NÃO tem `title="Em breve"` (placeholder removido)
+ *  - Botão tem `aria-label="Compartilhar venda V-NNNN"` (acessibilidade)
+ *
+ * Refs:
+ *  - resources/js/Pages/Repair/ProducaoOficina/Index.tsx (VendaDerivadaCard)
+ *  - resources/js/Pages/Repair/ProducaoOficina/Index.charter.md (Goals)
+ *  - memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md
+ *  - memory/requisitos/Repair/ProducaoOficina-r2-drawer-card-venda-derivada-visual-comparison.md
+ */
+
+uses(Tests\TestCase::class);
+
+const PRODUCAO_OFICINA_INDEX_TSX = 'resources/js/Pages/Repair/ProducaoOficina/Index.tsx';
+
+function ondaCincoCompartilharReadIndex(): string
+{
+    return file_get_contents(base_path(PRODUCAO_OFICINA_INDEX_TSX));
+}
+
+it('Onda 5 share: Index.tsx importa toast do sonner (pattern projeto)', function () {
+    $src = ondaCincoCompartilharReadIndex();
+    expect($src)->toContain("import { toast } from 'sonner';");
+});
+
+it('Onda 5 share: handleCompartilhar é async + usa Web Share API nativa', function () {
+    $src = ondaCincoCompartilharReadIndex();
+    expect($src)
+        ->toContain('const handleCompartilhar = async () =>')
+        ->toContain('navigator.share')
+        ->toContain('navigator.canShare');
+});
+
+it('Onda 5 share: payload share inclui invoice_no + total BRL + url /sells/{id}', function () {
+    $src = ondaCincoCompartilharReadIndex();
+    expect($src)
+        ->toContain('`${window.location.origin}/sells/${venda.id}`')
+        ->toContain('`Venda #${venda.invoice_no}')
+        ->toContain("style: 'currency'")
+        ->toContain("currency: 'BRL'");
+});
+
+it('Onda 5 share: AbortError (user cancelou share-sheet) NÃO loga erro nem mostra toast', function () {
+    $src = ondaCincoCompartilharReadIndex();
+    expect($src)
+        ->toContain("name === 'AbortError'")
+        ->toContain("'AbortError') return");
+});
+
+it('Onda 5 share: fallback usa navigator.clipboard.writeText + toast.success', function () {
+    $src = ondaCincoCompartilharReadIndex();
+    expect($src)
+        ->toContain('navigator.clipboard.writeText')
+        ->toContain("toast.success('Link da venda copiado')");
+});
+
+it('Onda 5 share: fallback erro clipboard mostra toast.error gracioso', function () {
+    $src = ondaCincoCompartilharReadIndex();
+    expect($src)->toContain("toast.error('Não foi possível copiar o link')");
+});
+
+it('Onda 5 share: botão Compartilhar tem onClick={handleCompartilhar} (não no-op)', function () {
+    $src = ondaCincoCompartilharReadIndex();
+    expect($src)->toContain('onClick={handleCompartilhar}');
+});
+
+it('Onda 5 share: botão Compartilhar perdeu title="Em breve" placeholder', function () {
+    $src = ondaCincoCompartilharReadIndex();
+    expect($src)->not->toContain('title="Em breve · backlog wave futura"');
+});
+
+it('Onda 5 share: botão Compartilhar tem aria-label acessibilidade', function () {
+    $src = ondaCincoCompartilharReadIndex();
+    expect($src)->toContain('aria-label={`Compartilhar venda ${venda.invoice_no}`}');
+});

--- a/resources/js/Pages/Repair/ProducaoOficina/Index.charter.md
+++ b/resources/js/Pages/Repair/ProducaoOficina/Index.charter.md
@@ -39,7 +39,7 @@ Visão de produção em **kanban de 5 colunas** (Recepção → Diagnóstico →
 - **Onda 5 — Integração Vendas × Oficina** ([ADR 0192](../../../../memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md)): drawer renderiza card `Esta OS gerou a venda #V-NNNN` quando OS está na coluna `pronto` (= FSM `entregue_completo`) AND tem `venda_derivada` (Transaction `source='oficina'` criada pelo `JobSheetObserver`). Card mostra total + data + 3 atalhos:
   - **Abrir #V-NNNN** → dispatch `window.CustomEvent('oimpresso:open-venda', { detail: { venda_id } })` — listener em `Sells/Index.tsx` (Worker A Onda 4) abre drawer SaleSheet (loose coupling)
   - **Imprimir recibo** → `window.open('/sells/{venda_id}/print', '_blank')` (rota Blade legacy preservada)
-  - **Compartilhar** → placeholder TODO (botão visível · ver Non-Goals)
+  - **Compartilhar** → Web Share API nativa (mobile/PWA share-sheet) com fallback `navigator.clipboard.writeText()` + toast Sonner (desktop). Payload `Venda #V-NNNN · R$ XX,XX · DD/MM/YYYY` + URL `/sells/{id}`. `AbortError` (user cancelou) tratado silenciosamente. (Onda 5 follow-up Worker 3 · 2026-05-25)
 - Vocabulário shared multi-vertical preservado ([ADR 0121 §P8](../../../../memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md)) — `venda_derivada` é cross-vertical (OficinaAuto, ComunicacaoVisual, Vestuario)
 
 ---
@@ -56,7 +56,7 @@ Visão de produção em **kanban de 5 colunas** (Recepção → Diagnóstico →
 - ❌ Edição inline em qualquer card
 - ❌ Tela específica per-vertical (Vestuario/ComVisual/OficinaAuto NÃO tem `/vestuario/producao-oficina` — todas usam `/repair/producao-oficina` parametrizado por `business.repair_settings`)
 - ❌ **Onda 5 placeholder TODOs (charter aceita explícito):**
-  - Botão "Compartilhar" no card da venda derivada **sem ação por ora** (visível mas `onClick` no-op). Backlog wave futura: copy-to-clipboard link · WhatsApp template · email PDF
+  - ~~Botão "Compartilhar" no card da venda derivada **sem ação por ora**~~ → **entregue Onda 5 follow-up Worker 3 (2026-05-25)** via Web Share API nativa + clipboard fallback + toast Sonner
   - Breakdown peças/serviço no card (Cowork F1 tem mas payload `venda_derivada` Onda 2 não entrega esses fields — adiada pra wave futura quando Sells expor `itemsList`)
   - Badges fiscais NF-e/NFS-e no card (wave futura · payload Onda 2 não entrega `fiscal` ainda)
   - Edição inline da venda derivada (drawer só lê · CRUD vai pra `/sells/{id}/edit`)

--- a/resources/js/Pages/Repair/ProducaoOficina/Index.tsx
+++ b/resources/js/Pages/Repair/ProducaoOficina/Index.tsx
@@ -14,6 +14,7 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { router } from '@inertiajs/react';
 import { useEffect, useMemo, useState } from 'react';
+import { toast } from 'sonner';
 
 type Tone = 'slate' | 'blue' | 'amber' | 'violet' | 'emerald';
 
@@ -642,7 +643,8 @@ function TimelineEvent({
 //  1. "Abrir #V-NNNN" → dispatch CustomEvent 'oimpresso:open-venda' (Worker A
 //     Sells/Index listener Onda 4 abre drawer SaleSheet · loose coupling)
 //  2. "Imprimir recibo" → window.open rota Blade legacy preservada
-//  3. "Compartilhar" → placeholder TODO · charter Non-Goal por ora
+//  3. "Compartilhar" → Web Share API nativa (mobile/PWA) + fallback
+//     navigator.clipboard.writeText() + toast Sonner (desktop · pattern Repair/JobSheet)
 //
 // Breakdown peças/serviço + badges fiscais NF-e/NFS-e do Cowork ficam pra wave
 // futura (charter Non-Goal · payload backend Onda 2 não entrega esses fields).
@@ -659,9 +661,43 @@ function VendaDerivadaCard({ venda }: { venda: VendaDerivada }) {
     window.open(`/sells/${venda.id}/print`, '_blank', 'noopener,noreferrer');
   };
 
-  const handleCompartilhar = () => {
-    // TODO Onda futura — backlog item (charter Non-Goal por ora).
-    // Possibilidades: copy-to-clipboard link · WhatsApp template · email PDF.
+  // Onda 5 follow-up (Worker 3 · 2026-05-25) — share real.
+  // Decisão Wagner: Web Share API nativa (mobile/PWA share-sheet) + fallback
+  // navigator.clipboard.writeText() + toast Sonner (pattern já em uso no projeto,
+  // ver Modules/Repair Pages/Repair/JobSheet/Show.tsx). Sem dependência nova.
+  // - AbortError (user cancelou share-sheet) NÃO loga erro (UX silencioso).
+  // - canShare check protege Safari iOS quirks (sem text-only sem url).
+  const handleCompartilhar = async () => {
+    const url = `${window.location.origin}/sells/${venda.id}`;
+    const text = `Venda #${venda.invoice_no} · ${venda.final_total.toLocaleString('pt-BR', {
+      style: 'currency',
+      currency: 'BRL',
+    })}${venda.transaction_date ? ` · ${new Date(venda.transaction_date + 'T00:00:00').toLocaleDateString('pt-BR')}` : ''}`;
+    const shareData = { title: `Venda #${venda.invoice_no}`, text, url };
+
+    if (typeof navigator !== 'undefined' && typeof navigator.share === 'function') {
+      const canShare = typeof navigator.canShare === 'function' ? navigator.canShare(shareData) : true;
+      if (canShare) {
+        try {
+          await navigator.share(shareData);
+          return;
+        } catch (err) {
+          // AbortError = user dismissed share-sheet · não logar nem mostrar toast erro.
+          if ((err as DOMException)?.name === 'AbortError') return;
+          // Outros erros → cair pro fallback clipboard.
+          console.error('Web Share falhou, caindo pro clipboard:', err);
+        }
+      }
+    }
+
+    // Fallback clipboard + toast Sonner (pattern projeto).
+    try {
+      await navigator.clipboard.writeText(`${text}\n${url}`);
+      toast.success('Link da venda copiado');
+    } catch (err) {
+      console.error('Clipboard falhou:', err);
+      toast.error('Não foi possível copiar o link');
+    }
   };
 
   const totalBR = venda.final_total.toLocaleString('pt-BR', {
@@ -725,7 +761,7 @@ function VendaDerivadaCard({ venda }: { venda: VendaDerivada }) {
         <button
           type="button"
           onClick={handleCompartilhar}
-          title="Em breve · backlog wave futura"
+          aria-label={`Compartilhar venda ${venda.invoice_no}`}
           className="ofc-venda-cta inline-flex items-center gap-1 rounded-[5px] border border-emerald-200 bg-white px-3 py-1.5 text-[11.5px] font-semibold text-emerald-700 hover:bg-emerald-50 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
         >
           Compartilhar


### PR DESCRIPTION
## Summary

- Implementa atalho **Compartilhar** real no drawer card `Esta OS gerou venda` (Pages/Repair/ProducaoOficina/Index.tsx · VendaDerivadaCard) — antes placeholder no-op com `title="Em breve"`
- **Web Share API nativa** + fallback **`navigator.clipboard.writeText()` + toast Sonner** (pattern existente · sem dependência nova)
- `AbortError` (user cancelou share-sheet) tratado silenciosamente · UX correta · não loga erro nem mostra toast
- Charter atualizado: `Compartilhar` migra de Non-Goals (TODO) pra Goals (entrega real)
- Pest GUARD 9 tests cobrindo handler async + AbortError silencioso + onClick não regride + aria-label persistente

## Comportamento

1. `navigator.share` + `canShare` guard (proteção Safari iOS quirks)
2. Fallback `navigator.clipboard.writeText` + `toast.success('Link da venda copiado')`
3. Erro clipboard → `toast.error('Não foi possível copiar o link')`
4. Payload: `Venda #V-NNNN · R$ XX,XX · DD/MM/YYYY` + URL `${origin}/sells/{id}`

## Stats

- 3 arquivos · +133 / −7 LOC · 1 PR = 1 intent (commit-discipline OK)
- 9/9 Pest passando localmente (`php artisan test Modules/Repair/Tests/Feature/ProducaoOficinaOnda5CompartilharTest.php`)

## Constraints respeitadas

- ✅ NÃO criar dependência nova — `sonner` já é dependência (ver Pages/Jana/Chat.tsx, Pages/Repair/JobSheet/Show.tsx)
- ✅ NÃO bloquear render sem Web Share — `typeof navigator.share === 'function'` guard
- ✅ `AbortError` silencioso (sem log, sem toast)
- ✅ Multi-tenant Tier 0 (ADR 0093) — URL `${origin}/sells/{id}` scoped por sessão · zero queries adicionais
- ✅ Pest GUARD com `Tests\TestCase::class` (`Modules/Repair/Tests/Feature/` requer `uses()` explícito · ver ProducaoOficinaTest.php)
- ✅ Commit-discipline: ≤300 LOC

## Test plan

- [x] Pest GUARD `ProducaoOficinaOnda5CompartilharTest` passa local (9/9)
- [ ] Smoke desktop: clicar Compartilhar → verificar toast "Link da venda copiado" + clipboard contém `Venda #V-... · R$ ... · DD/MM/YYYY\n${origin}/sells/{id}`
- [ ] Smoke mobile/PWA: clicar Compartilhar → share-sheet OS nativa abre
- [ ] Smoke mobile: cancelar share-sheet → sem toast erro, sem console.error
- [ ] AppShellV2 navigate /repair/producao-oficina → abrir card OS pronto com venda derivada → drawer card render verde · 3 CTAs visíveis

## Refs

- [ADR 0192](memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md) — Integração Vendas × Oficina (Onda 5 follow-up)
- Worker A: `tests/Feature/Sells/SellsIndexOnda4IntegracaoOficinaTest.php` (pattern file-content assertion)
- Visual comparison: [Worker B doc](memory/requisitos/Repair/ProducaoOficina-r2-drawer-card-venda-derivada-visual-comparison.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)