### PR TITLE
feat(repair): JobSheetObserver reverse hook · OS reaberta soft-deleta Transaction (ADR 0192 follow-up)

### DIFF
--- a/Modules/Repair/Observers/JobSheetObserver.php
+++ b/Modules/Repair/Observers/JobSheetObserver.php
@@ -23,11 +23,20 @@ use Modules\Repair\Entities\RepairStatus;
  * Cria Transaction (type=sell · source='oficina' · os_ref='OS-{id}') herdando
  * business_id da OS (multi-tenant Tier 0 ADR 0093 IRREVOGÁVEL).
  *
- * Idempotência: skip se Transaction já existe pra essa OS, via 2 chaves
+ * Idempotência: skip se Transaction ATIVA já existe pra essa OS, via 2 chaves
  * (defesa-em-profundidade):
  *   (a) `repair_job_sheet_id = $jobSheet->id` (FK UPOS legacy desde 2020-08)
  *   (b) `os_ref = "OS-{$jobSheet->id}"` (string canonical UI cross-link · ADR 0192)
  * Ambas scopadas por `business_id` pra impedir cross-tenant.
+ * Filtro `whereNull('cancelled_at')` ignora cancelamentos prévios (reverse hook)
+ * pra permitir re-completion criar NOVA Transaction (ADR 0192 follow-up).
+ *
+ * Reverse hook (ADR 0192 follow-up · 2026-05-25 review trigger):
+ *   OS terminal → não-terminal (reaberta) → marca Transaction derivada como
+ *   cancelada (`cancelled_at = now()`) preservando audit trail · NÃO delete.
+ *   Caminho B' (cancelled_at TIMESTAMP NULL) escolhido sobre Caminho A
+ *   (SoftDeletes) porque `Transaction` UPOS legacy não usa trait e Caminho B
+ *   (status='cancelled') exigiria ALTER TABLE no ENUM rígido.
  *
  * OS sem nota fiscal vira venda mesmo assim (`fiscal: {}` vazio · sem badge
  * SEFAZ na UI) — fluxo informal não bloqueia auto-faturar (Wagner 2026-05-25).
@@ -53,14 +62,35 @@ class JobSheetObserver
             ->where('id', $jobSheet->status_id)
             ->first();
 
-        if (! $newStatus || ! (bool) $newStatus->is_completed_status) {
+        $isTerminal = $newStatus && (bool) $newStatus->is_completed_status;
+
+        // Lookup do status anterior pra detectar transição terminal → não-terminal (reverse).
+        $oldStatusId = $jobSheet->getOriginal('status_id');
+        $oldStatus = $oldStatusId
+            ? RepairStatus::where('business_id', $jobSheet->business_id)
+                ->where('id', $oldStatusId)
+                ->first()
+            : null;
+        $wasTerminal = $oldStatus && (bool) $oldStatus->is_completed_status;
+
+        // REVERSE hook (ADR 0192 follow-up): OS reaberta · marca Transaction como cancelada.
+        if ($wasTerminal && ! $isTerminal) {
+            $this->reverseTransaction($jobSheet);
+
             return;
         }
 
-        // Idempotência: skip se já existe Transaction derivada.
+        // Nada a fazer se transição não termina em terminal (não-terminal → não-terminal).
+        if (! $isTerminal) {
+            return;
+        }
+
+        // Idempotência: skip se já existe Transaction derivada ATIVA (cancelled_at NULL).
         // Defesa-em-profundidade: 2 chaves (repair_job_sheet_id FK + os_ref string).
+        // Filtro whereNull('cancelled_at') permite re-completion pós-cancelamento criar NOVA.
         $osRef = $this->buildOsRef($jobSheet);
         $exists = Transaction::where('business_id', $jobSheet->business_id)
+            ->whereNull('cancelled_at')
             ->where(function ($q) use ($jobSheet, $osRef) {
                 $q->where('repair_job_sheet_id', $jobSheet->id)
                     ->orWhere('os_ref', $osRef);
@@ -117,5 +147,55 @@ class JobSheetObserver
     private function buildOsRef(JobSheet $jobSheet): string
     {
         return "OS-{$jobSheet->id}";
+    }
+
+    /**
+     * Marca Transaction derivada como cancelada quando OS é reaberta.
+     *
+     * Caminho B' (cancelled_at TIMESTAMP NULL) — preserva row + audit trail
+     * Spatie. Idempotente: já-cancelada vira no-op (whereNull filtra).
+     * Multi-tenant Tier 0: filtro `business_id` impede cross-tenant.
+     *
+     * Não-bloqueante: erro vira Log::error (pattern existente · não interrompe FSM).
+     */
+    private function reverseTransaction(JobSheet $jobSheet): void
+    {
+        $osRef = $this->buildOsRef($jobSheet);
+
+        try {
+            $tx = Transaction::where('business_id', $jobSheet->business_id)
+                ->whereNull('cancelled_at')
+                ->where(function ($q) use ($jobSheet, $osRef) {
+                    $q->where('repair_job_sheet_id', $jobSheet->id)
+                        ->orWhere('os_ref', $osRef);
+                })
+                ->first();
+
+            if (! $tx) {
+                Log::info('JobSheetObserver: reverse skip · sem Transaction ativa pra cancelar', [
+                    'os_ref' => $osRef,
+                    'job_sheet_id' => $jobSheet->id,
+                    'business_id' => $jobSheet->business_id,
+                ]);
+
+                return;
+            }
+
+            $tx->forceFill(['cancelled_at' => Carbon::now()])->save();
+
+            Log::info('JobSheetObserver: Transaction derivada cancelada (OS reaberta)', [
+                'transaction_id' => $tx->id,
+                'os_ref' => $osRef,
+                'job_sheet_id' => $jobSheet->id,
+                'business_id' => $jobSheet->business_id,
+            ]);
+        } catch (\Throwable $e) {
+            Log::error('JobSheetObserver: falha ao cancelar Transaction derivada', [
+                'os_ref' => $osRef,
+                'job_sheet_id' => $jobSheet->id,
+                'business_id' => $jobSheet->business_id,
+                'error' => $e->getMessage(),
+            ]);
+        }
     }
 }

--- a/Modules/Repair/Tests/Feature/JobSheetObserverTest.php
+++ b/Modules/Repair/Tests/Feature/JobSheetObserverTest.php
@@ -40,6 +40,9 @@ beforeEach(function () {
         || ! Schema::hasColumn('transactions', 'os_ref')) {
         $this->markTestSkipped('Migration Onda 1 não aplicada — rode migrate.');
     }
+    if (! Schema::hasColumn('transactions', 'cancelled_at')) {
+        $this->markTestSkipped('Migration reverse hook (cancelled_at) não aplicada — rode migrate.');
+    }
 });
 
 function bootstrapRepairBiz(): array
@@ -202,5 +205,154 @@ it('Multi-tenant Tier 0: Transaction derivada herda business_id da OS (ADR 0093)
 
     // cleanup
     $tx->delete();
+    $os->delete();
+});
+
+// ---------------------------------------------------------------------------
+// Reverse hook GUARDs · ADR 0192 follow-up (Caminho B' · cancelled_at TIMESTAMP NULL)
+// ---------------------------------------------------------------------------
+
+it('Reverse: OS terminal → não-terminal marca Transaction como cancelada (cancelled_at SET)', function () {
+    $ctx = bootstrapRepairBiz();
+    $os = createTestJobSheet($ctx, $ctx['open_status_id']);
+
+    // Terminal · cria Transaction.
+    $os->update(['status_id' => $ctx['done_status_id']]);
+    $tx = Transaction::where('repair_job_sheet_id', $os->id)->first();
+    expect($tx)->not->toBeNull();
+    expect($tx->cancelled_at)->toBeNull();
+
+    // Reabre OS · reverse hook marca cancelled_at.
+    $os->update(['status_id' => $ctx['open_status_id']]);
+
+    $tx->refresh();
+    expect($tx->cancelled_at)->not->toBeNull();
+
+    // cleanup
+    $tx->delete();
+    $os->delete();
+});
+
+it('Reverse + re-completion: terminal → aberto → terminal AGAIN cria NOVA Transaction (não restaura)', function () {
+    $ctx = bootstrapRepairBiz();
+    $os = createTestJobSheet($ctx, $ctx['open_status_id']);
+
+    // 1ª completion · cria Tx1.
+    $os->update(['status_id' => $ctx['done_status_id']]);
+    $tx1 = Transaction::where('repair_job_sheet_id', $os->id)->first();
+    expect($tx1)->not->toBeNull();
+    $tx1Id = $tx1->id;
+
+    // Reabre · cancela Tx1.
+    $os->update(['status_id' => $ctx['open_status_id']]);
+    $tx1->refresh();
+    expect($tx1->cancelled_at)->not->toBeNull();
+
+    // 2ª completion · cria Tx2 NOVA (não restaura Tx1).
+    $os->update(['status_id' => $ctx['done_status_id']]);
+
+    $allTx = Transaction::where('repair_job_sheet_id', $os->id)->orderBy('id')->get();
+    expect($allTx)->toHaveCount(2);
+    expect($allTx[0]->id)->toBe($tx1Id);
+    expect($allTx[0]->cancelled_at)->not->toBeNull(); // Tx1 continua cancelada
+    expect($allTx[1]->id)->not->toBe($tx1Id);
+    expect($allTx[1]->cancelled_at)->toBeNull(); // Tx2 ativa
+
+    // cleanup
+    Transaction::where('repair_job_sheet_id', $os->id)->delete();
+    $os->delete();
+});
+
+it('Edge case: aberto → terminal (cria) → aberto (cancela) → outro aberto (no-op) → terminal (cria nova)', function () {
+    $ctx = bootstrapRepairBiz();
+    $os = createTestJobSheet($ctx, $ctx['open_status_id']);
+
+    // Status aberto extra pra transição não-terminal → não-terminal.
+    $otherOpen = RepairStatus::create([
+        'business_id' => $ctx['business']->id,
+        'name' => 'TEST · Aguardando peças edge · '.uniqid(),
+        'is_completed_status' => false,
+        'sort_order' => 3,
+        'status_color' => '#fbbf24',
+    ]);
+
+    // 1) aberto → terminal · cria.
+    $os->update(['status_id' => $ctx['done_status_id']]);
+    expect(Transaction::where('repair_job_sheet_id', $os->id)->whereNull('cancelled_at')->count())->toBe(1);
+
+    // 2) terminal → aberto · cancela.
+    $os->update(['status_id' => $ctx['open_status_id']]);
+    expect(Transaction::where('repair_job_sheet_id', $os->id)->whereNull('cancelled_at')->count())->toBe(0);
+
+    // 3) aberto → outro aberto · no-op (nem cria nem cancela).
+    $os->update(['status_id' => $otherOpen->id]);
+    expect(Transaction::where('repair_job_sheet_id', $os->id)->count())->toBe(1); // só a cancelada de antes
+    expect(Transaction::where('repair_job_sheet_id', $os->id)->whereNull('cancelled_at')->count())->toBe(0);
+
+    // 4) aberto → terminal · cria nova (idempotência ignora cancelada).
+    $os->update(['status_id' => $ctx['done_status_id']]);
+    expect(Transaction::where('repair_job_sheet_id', $os->id)->whereNull('cancelled_at')->count())->toBe(1);
+    expect(Transaction::where('repair_job_sheet_id', $os->id)->count())->toBe(2); // 1 cancelada + 1 ativa
+
+    // cleanup
+    Transaction::where('repair_job_sheet_id', $os->id)->delete();
+    $os->delete();
+    $otherOpen->delete();
+});
+
+it('Multi-tenant Tier 0: reverse hook só toca Transactions do mesmo business_id (ADR 0093)', function () {
+    $ctx = bootstrapRepairBiz();
+    $os = createTestJobSheet($ctx, $ctx['open_status_id']);
+
+    // Cria Tx derivada legítima do mesmo business.
+    $os->update(['status_id' => $ctx['done_status_id']]);
+    $tx = Transaction::where('repair_job_sheet_id', $os->id)->first();
+    expect($tx)->not->toBeNull();
+
+    // Cria Transaction LOOKALIKE em business diferente com mesmo os_ref (simulando cross-tenant).
+    // Usa business_id propositalmente diferente pra garantir scope.
+    $crossBizId = $ctx['business']->id === 1 ? 2 : 1;
+    $crossLocation = DB::table('business_locations')->where('business_id', $crossBizId)->first();
+    $crossContact = DB::table('contacts')->where('business_id', $crossBizId)->first();
+    $crossUser = User::where('business_id', $crossBizId)->first();
+
+    if (! $crossLocation || ! $crossContact || ! $crossUser) {
+        // Sem 2º business completo · skip cross-tenant assertion (apenas valida que reverse não vaza).
+        $os->update(['status_id' => $ctx['open_status_id']]);
+        $tx->refresh();
+        expect($tx->cancelled_at)->not->toBeNull();
+        Transaction::where('repair_job_sheet_id', $os->id)->delete();
+        $os->delete();
+
+        return;
+    }
+
+    $crossTx = Transaction::create([
+        'business_id' => $crossBizId,
+        'location_id' => $crossLocation->id,
+        'contact_id' => $crossContact->id,
+        'type' => 'sell',
+        'status' => 'final',
+        'payment_status' => 'due',
+        'source' => 'oficina',
+        'os_ref' => "OS-{$os->id}", // mesmo os_ref · biz diferente
+        'final_total' => 999.00,
+        'total_before_tax' => 999.00,
+        'transaction_date' => Carbon::now(),
+        'created_by' => $crossUser->id,
+    ]);
+
+    // Reabre OS do business original · reverse SÓ deve cancelar Tx do business_id correto.
+    $os->update(['status_id' => $ctx['open_status_id']]);
+
+    $tx->refresh();
+    $crossTx->refresh();
+
+    expect($tx->cancelled_at)->not->toBeNull(); // Tx do mesmo biz cancelada
+    expect($crossTx->cancelled_at)->toBeNull(); // Tx de outro biz INTACTA
+
+    // cleanup
+    $crossTx->delete();
+    Transaction::where('repair_job_sheet_id', $os->id)->delete();
     $os->delete();
 });

--- a/database/migrations/2026_05_25_180000_add_cancelled_at_to_transactions.php
+++ b/database/migrations/2026_05_25_180000_add_cancelled_at_to_transactions.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ADR 0192 follow-up — Reverse hook JobSheetObserver (OS reaberta cancela venda derivada).
+ *
+ * Schema aditivo minimal · Caminho B' (não-destrutivo, sem mexer no ENUM `status`):
+ *
+ *   cancelled_at  TIMESTAMP  NULL  AFTER transaction_date
+ *
+ * Comportamento:
+ *  - NULL  (default) → Transaction ativa, conta em KPIs e listagens
+ *  - SET   (timestamp) → Transaction cancelada, preserva audit trail (row + Spatie activity log)
+ *
+ * Por que NÃO SoftDeletes:
+ *  - `Transaction` UPOS legacy NÃO usa trait `SoftDeletes` · adicionar exigiria
+ *    rever ~50 controllers/queries pra ignorar `deleted_at` (risco grande de bug
+ *    sutil em multi-tenant Tier 0 ADR 0093)
+ *  - `forceDelete` aniquila history (não queremos)
+ *
+ * Por que NÃO `status='cancelled'`:
+ *  - Coluna `status` é ENUM rígido `['received','pending','ordered','draft','final']`
+ *    (migration 2017_08_19_054827) · adicionar `'cancelled'` exige ALTER TABLE
+ *    schema change em produção · zero benefício vs `cancelled_at` nullable
+ *
+ * Idempotência preservada (ADR 0192):
+ *  - JobSheetObserver consulta `whereNull('cancelled_at')` no check exists()
+ *  - Re-completion (OS terminal → aberto → terminal AGAIN) cria NOVA Transaction
+ *  - History de cancelamentos prévios fica visível em queries `whereNotNull('cancelled_at')`
+ *
+ * Multi-tenant Tier 0 ADR 0093 IRREVOGÁVEL preservado:
+ *  - Coluna não-scoped (timestamp puro) · scope continua via `business_id` global
+ *  - Reverse hook do Observer filtra `where('business_id', $jobSheet->business_id)`
+ *
+ * IDEMPOTENTE — `Schema::hasColumn` check protege re-execução.
+ * down() reverte sem perda de dados (drop column).
+ *
+ * @see memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            if (! Schema::hasColumn('transactions', 'cancelled_at')) {
+                $table->timestamp('cancelled_at')
+                    ->nullable()
+                    ->after('transaction_date')
+                    ->comment('Marcador de cancelamento · NULL = ativa · timestamp = cancelada (preserva row + audit) · ADR 0192 reverse hook');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('transactions', function (Blueprint $table) {
+            if (Schema::hasColumn('transactions', 'cancelled_at')) {
+                $table->dropColumn('cancelled_at');
+            }
+        });
+    }
+};


### PR DESCRIPTION
## Summary

Implementa o review trigger #2 pendente da [ADR 0192](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md):

> "Cliente pede 'estornar' venda derivada (cancelar OS pós-entrega) → adicionar reverse hook no Observer"

JobSheetObserver agora também **reverte** Transaction derivada quando OS é reaberta (transição terminal → não-terminal), preservando audit trail.

## Matriz de transições (comportamento completo)

| Origem | Destino | Ação |
|---|---|---|
| terminal | terminal (outro) | NO-OP (continua terminal) |
| terminal | **não-terminal** | **REVERSE** (`cancelled_at = now()`) |
| não-terminal | terminal | CREATE (Onda 2, já existia) |
| não-terminal | não-terminal | NO-OP |

## Decisão de design — Caminho B' (variante)

O prompt do worker oferecia 3 caminhos. Após inspecionar `app/Transaction.php`:

- **Caminho A (SoftDeletes do prompt):** `Transaction` UPOS legacy NÃO usa `SoftDeletes` trait. Adicionar exigiria revisar ~50 controllers/queries pra ignorar `deleted_at` → risco enorme em Tier 0 multi-tenant.
- **Caminho B literal (status='cancelled'):** `status` é ENUM rígido `['received','pending','ordered','draft','final']` (migration 2017_08_19_054827). Adicionar 'cancelled' exige ALTER TABLE em produção.
- **Caminho B' (escolhido):** coluna nova nullable `cancelled_at TIMESTAMP` — additive-only, zero risco, preserva audit (row + Spatie LogsActivity existente), `down()` limpo. Cliente pode evoluir depois pra badge UI "Cancelada" sem nova migration.
- **Caminho C (skip / backlog):** descartado — review trigger explícito + custo baixo (151 LOC produção) justifica implementação preventiva.

Decisão documentada inline no PHPDoc do Observer + commit body.

## Idempotência preservada (ADR 0192)

`Transaction::where('os_ref', $ref)->whereNull('cancelled_at')->exists()` permite ciclos:

1. aberto → terminal → cria Tx1
2. terminal → aberto → cancela Tx1 (`cancelled_at` SET)
3. aberto → terminal → cria Tx2 **NOVA** (ignora Tx1 cancelada)
4. repeat → cria Tx3, Tx4...

Cada ciclo deixa trilha completa em `transactions` + `activity_log`.

## Multi-tenant Tier 0 ([ADR 0093 IRREVOGÁVEL](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0093-multi-tenant-isolation-tier-0.md))

Reverse hook filtra `where('business_id', \$jobSheet->business_id)` antes de cancelar. Pest GUARD prova que biz=2 com mesmo `os_ref` NÃO é tocado.

## Files

| File | LOC | Tipo |
|---|---|---|
| `database/migrations/2026_05_25_180000_add_cancelled_at_to_transactions.php` | +68 | Migration aditiva (idempotente) |
| `Modules/Repair/Observers/JobSheetObserver.php` | +83/-3 | Reverse logic + PHPDoc |
| `Modules/Repair/Tests/Feature/JobSheetObserverTest.php` | +152 | 4 Pest GUARDs novos |

Total: 303 insertions, 3 deletions. Produção (Observer + migration): 151 LOC.

## Test plan

- [ ] CI passa Pest (4 GUARDs novos + 5 originais = 9 testes total · auto-skip em SQLite per ADR 0101)
- [ ] CI passa Module Grades Gate (sem regressão)
- [ ] Migration `2026_05_25_180000_add_cancelled_at_to_transactions` aplica em staging sem erro (`php artisan migrate --pretend` antes)
- [ ] Smoke staging: criar OS, transitar pra terminal (cria Tx), reabrir (cancela Tx · `cancelled_at` SET), transitar terminal novamente (cria Tx2 nova com id diferente)
- [ ] Verificar `activity_log` registra mudança em `cancelled_at` (Spatie default behavior)
- [ ] NÃO mergear sem revisão Wagner (per worker constraint)

## Refs

- ADR 0192 review trigger #2 (Cliente pede estornar venda derivada)
- Onda 2 base: `e98649989` (PR #1501)
- Onda 5 atual: `94300b057` (PR #1504)

🤖 Generated with [Claude Code](https://claude.com/claude-code)