### PR TITLE
feat(repair): expand venda_derivada payload com items_list + fiscal (ADR 0192 follow-up)

### DIFF
--- a/Modules/Repair/Http/Controllers/ProducaoOficinaController.php
+++ b/Modules/Repair/Http/Controllers/ProducaoOficinaController.php
@@ -250,15 +250,42 @@ class ProducaoOficinaController extends Controller
         // Batch lookup das Transactions derivadas (source='oficina') por job_sheet_id pra
         // exibir card "Esta OS gerou venda #V-NNNN" no drawer (frontend Onda 5).
         // 1 query única (anti-N+1) scopada por business_id (Tier 0 ADR 0093).
+        //
+        // Onda 3 (Wave Z-2 backend): eager-load sell_lines.product pra expandir
+        // payload com items_list (produto/serviço) + items_summary (counts/totals).
+        // Sem este eager-load, cada card faria N queries (anti-N+1).
         $businessId = (int) request()->session()->get('user.business_id');
         $vendaDerivadaByOs = collect();
         $osIds = $jobSheets->pluck('id')->all();
+        $nfeByTx = collect();
         if (! empty($osIds)) {
             $vendaDerivadaByOs = \App\Transaction::where('business_id', $businessId)
                 ->where('source', 'oficina')
                 ->whereIn('repair_job_sheet_id', $osIds)
+                ->with(['sell_lines' => function ($q) {
+                    $q->select([
+                        'id', 'transaction_id', 'product_id',
+                        'quantity', 'unit_price_inc_tax', 'unit_price',
+                        'item_tax', 'line_discount_amount', 'line_discount_type',
+                    ]);
+                }, 'sell_lines.product:id,name,enable_stock,type'])
                 ->get(['id', 'repair_job_sheet_id', 'invoice_no', 'final_total', 'transaction_date'])
                 ->keyBy('repair_job_sheet_id');
+
+            // Onda 3 (Wave Z-2 backend): batch lookup nfe_emissoes por transaction_id.
+            // Padrão idêntico a SellController::inertiaList (linha 1226+).
+            // Tier 0 ADR 0093: scoped por business_id (cross-tenant não vaza).
+            // Precedence: pega emissão mais recente (orderByDesc id) — autorizada
+            // sobrepõe pendente sobrepõe rejeitada quando há retentativa.
+            $txIds = $vendaDerivadaByOs->pluck('id')->all();
+            if (! empty($txIds) && class_exists(\Modules\NfeBrasil\Models\NfeEmissao::class)) {
+                $nfeByTx = \Modules\NfeBrasil\Models\NfeEmissao::where('business_id', $businessId)
+                    ->whereIn('transaction_id', $txIds)
+                    ->orderByDesc('id')
+                    ->get(['id', 'transaction_id', 'modelo', 'status', 'chave_44'])
+                    ->groupBy('transaction_id')
+                    ->map(fn ($group) => $group->first());
+            }
         }
 
         foreach ($jobSheets as $js) {
@@ -266,13 +293,98 @@ class ProducaoOficinaController extends Controller
             if ($columnId === null || ! isset($columns[$columnId])) {
                 continue;
             }
-            $columns[$columnId]['cards'][] = $this->jobSheetToCard($js, $vendaDerivadaByOs->get($js->id));
+            $tx = $vendaDerivadaByOs->get($js->id);
+            $nfe = $tx ? $nfeByTx->get($tx->id) : null;
+            $columns[$columnId]['cards'][] = $this->jobSheetToCard($js, $tx, $nfe);
         }
 
         return array_values($columns);
     }
 
-    private function jobSheetToCard(JobSheet $js, ?\App\Transaction $vendaDerivada = null): array
+    /**
+     * Onda 3 (Wave Z-2 backend) — expand `venda_derivada` com breakdown
+     * items_list / items_summary / fiscal pro drawer Cowork-styled.
+     *
+     * Backward compat: se sell_lines vazio retorna items_list=[] + summary zerado
+     * (não quebra Worker B Onda 5 que checa só presença de venda_derivada).
+     */
+    private function buildVendaDerivadaPayload(\App\Transaction $tx, $nfe = null): array
+    {
+        $itemsList = [];
+        $productsCount = 0;
+        $productsTotal = 0.0;
+        $servicesCount = 0;
+        $servicesTotal = 0.0;
+        $taxTotal = 0.0;
+        $discountTotal = 0.0;
+
+        foreach ($tx->sell_lines ?? [] as $line) {
+            // Convenção UltimatePOS — enable_stock=1 → produto físico, 0 → serviço.
+            // Ver app/Utils/ProductUtil.php:361/406 (uso histórico canonical).
+            $product = $line->product;
+            $isService = $product ? ((int) $product->enable_stock === 0) : false;
+            $type = $isService ? 'service' : 'product';
+
+            $qty = (float) ($line->quantity ?? 0);
+            $unitPrice = (float) ($line->unit_price_inc_tax ?? $line->unit_price ?? 0);
+            $subtotal = round($qty * $unitPrice, 2);
+
+            // Discount per-line (line_discount_amount * qty se fixed; % se percentage).
+            $lineDiscount = 0.0;
+            if (! empty($line->line_discount_amount) && ! empty($line->line_discount_type)) {
+                if ($line->line_discount_type === 'fixed') {
+                    $lineDiscount = (float) $line->line_discount_amount * $qty;
+                } elseif ($line->line_discount_type === 'percentage') {
+                    $lineDiscount = ($subtotal * (float) $line->line_discount_amount) / 100;
+                }
+            }
+
+            // Tax per-line (item_tax é por 1 unidade — multiplica por qty).
+            $lineTax = (float) ($line->item_tax ?? 0) * $qty;
+
+            $itemsList[] = [
+                'type' => $type,
+                'name' => $product?->name ?? '—',
+                'qty' => $qty,
+                'unit_price' => $unitPrice,
+                'subtotal' => $subtotal,
+            ];
+
+            if ($isService) {
+                $servicesCount++;
+                $servicesTotal += $subtotal;
+            } else {
+                $productsCount++;
+                $productsTotal += $subtotal;
+            }
+            $taxTotal += $lineTax;
+            $discountTotal += $lineDiscount;
+        }
+
+        return [
+            'id' => $tx->id,
+            'invoice_no' => $tx->invoice_no,
+            'final_total' => (float) $tx->final_total,
+            'transaction_date' => $tx->transaction_date?->toDateString(),
+            'items_list' => $itemsList,
+            'items_summary' => [
+                'products_count' => $productsCount,
+                'products_total' => round($productsTotal, 2),
+                'services_count' => $servicesCount,
+                'services_total' => round($servicesTotal, 2),
+                'tax_total' => round($taxTotal, 2),
+                'discount_total' => round($discountTotal, 2),
+            ],
+            'fiscal' => $nfe ? [
+                'status' => $nfe->status,
+                'modelo' => $nfe->modelo !== null ? (string) $nfe->modelo : null,
+                'chave' => $nfe->chave_44,
+                'danfe_url' => '/danfe/'.$nfe->id,
+            ] : null,
+        ];
+    }
+
+    private function jobSheetToCard(JobSheet $js, ?\App\Transaction $vendaDerivada = null, $nfe = null): array
     {
         $tech = $js->technician;
         $brand = $js->Brand;
@@ -312,12 +424,11 @@ class ProducaoOficinaController extends Controller
             // ADR 0192 — Integração Vendas × Oficina (A1 KB-9.75).
             // Card "Esta OS gerou venda #V-NNNN" renderizado no drawer Onda 5
             // quando coluna='pronto' AND venda_derivada !== null.
-            'venda_derivada' => $vendaDerivada ? [
-                'id' => $vendaDerivada->id,
-                'invoice_no' => $vendaDerivada->invoice_no,
-                'final_total' => (float) $vendaDerivada->final_total,
-                'transaction_date' => $vendaDerivada->transaction_date?->toDateString(),
-            ] : null,
+            //
+            // Onda 3 (Wave Z-2 backend) expand: items_list / items_summary / fiscal
+            // pra breakdown Cowork. Backward compat: keys core (id/invoice_no/
+            // final_total/transaction_date) preservadas — Worker B Onda 5 segue OK.
+            'venda_derivada' => $vendaDerivada ? $this->buildVendaDerivadaPayload($vendaDerivada, $nfe) : null,
         ];
     }
 

--- a/Modules/Repair/Tests/Feature/ProducaoOficinaVendaDerivadaExpandedTest.php
+++ b/Modules/Repair/Tests/Feature/ProducaoOficinaVendaDerivadaExpandedTest.php
@@ -1,0 +1,302 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\Product;
+use App\Transaction;
+use App\TransactionSellLine;
+use App\User;
+use App\Variation;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Repair\Entities\JobSheet;
+use Modules\Repair\Entities\RepairStatus;
+use Spatie\Permission\Models\Permission;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Onda 3 (Wave Z-2 backend) — GUARD do payload expandido `venda_derivada`.
+ *
+ * Frontend Cowork drawer card precisa de breakdown peças/serviço/fiscal além
+ * do shape Onda 5 (id/invoice_no/final_total/transaction_date). Este test
+ * GUARDa o contrato expandido:
+ *   - items_list (array de {type, name, qty, unit_price, subtotal})
+ *   - items_summary (counts/totals por type + tax_total + discount_total)
+ *   - fiscal (status/modelo/chave/danfe_url OR null)
+ *
+ * Tier 0 ADR 0093: nfe lookup scoped por business_id (cross-tenant não vaza).
+ * Anti-N+1: eager-load de sell_lines.product + batch nfe_emissoes.
+ *
+ * Comportamento defensivo (skips):
+ * - SQLite Pest CI sem tabelas core → skip.
+ * - Schema UltimatePOS usa MODIFY COLUMN MySQL-only → fixtures pulados em SQLite.
+ */
+
+beforeEach(function () {
+    if (! Schema::hasTable('users')
+        || ! Schema::hasTable('business')
+        || ! Schema::hasTable('permissions')) {
+        $this->markTestSkipped('Tabelas users/business/permissions ausentes — rode migrate primeiro.');
+    }
+});
+
+function vendaDerivadaBootstrap(): User
+{
+    try {
+        $business = Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: '.$e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco — rode seeder UltimatePOS antes.');
+    }
+
+    $user = User::where('business_id', $business->id)->first();
+
+    if (! $user) {
+        test()->markTestSkipped('Sem user no business.');
+    }
+
+    Permission::firstOrCreate(['name' => 'repair.view', 'guard_name' => 'web']);
+    if (! $user->hasPermissionTo('repair.view')) {
+        $user->givePermissionTo('repair.view');
+    }
+
+    session([
+        'user.business_id'         => $business->id,
+        'user.id'                  => $user->id,
+        'business.id'              => $business->id,
+        'business.name'            => $business->name,
+        'business.currency_symbol' => 'R$',
+        'business'                 => [
+            'id'              => $business->id,
+            'name'            => $business->name,
+            'currency_symbol' => 'R$',
+        ],
+        'is_admin'                 => true,
+    ]);
+
+    return $user;
+}
+
+it('payload shape inclui items_list, items_summary e fiscal quando venda_derivada !== null', function () {
+    $user = vendaDerivadaBootstrap();
+    $response = $this->actingAs($user)->get('/repair/producao-oficina');
+
+    if ($response->status() === 403) {
+        test()->markTestSkipped('Module gate bloqueia.');
+    }
+
+    $page = $response->original->getProps();
+    $columns = $page['columns'] ?? [];
+
+    $checkedAtLeastOne = false;
+
+    foreach ($columns as $col) {
+        foreach ($col['cards'] ?? [] as $card) {
+            if (! array_key_exists('venda_derivada', $card)) {
+                continue; // mock fixture pode não ter o field
+            }
+
+            $vd = $card['venda_derivada'];
+            if ($vd === null) {
+                continue; // OS sem venda derivada
+            }
+
+            $checkedAtLeastOne = true;
+
+            // Backward compat (Onda 5 shape preservado).
+            expect($vd)->toHaveKeys(['id', 'invoice_no', 'final_total', 'transaction_date']);
+
+            // Onda 3 expansion.
+            expect($vd)->toHaveKeys(['items_list', 'items_summary', 'fiscal']);
+            expect($vd['items_list'])->toBeArray();
+            expect($vd['items_summary'])->toBeArray();
+            expect($vd['items_summary'])->toHaveKeys([
+                'products_count', 'products_total',
+                'services_count', 'services_total',
+                'tax_total', 'discount_total',
+            ]);
+
+            // fiscal pode ser null (sem NF emitida) OR array com shape.
+            if ($vd['fiscal'] !== null) {
+                expect($vd['fiscal'])->toHaveKeys(['status', 'modelo', 'chave', 'danfe_url']);
+            }
+        }
+    }
+
+    if (! $checkedAtLeastOne) {
+        test()->markTestSkipped('Sem venda_derivada não-null no payload — fixture/seed precisa ter Transaction source=oficina vinculada.');
+    }
+});
+
+it('items_list separa produtos (enable_stock=1) de serviços (enable_stock=0) por type', function () {
+    $user = vendaDerivadaBootstrap();
+    $response = $this->actingAs($user)->get('/repair/producao-oficina');
+
+    if ($response->status() === 403) {
+        test()->markTestSkipped('Module gate bloqueia.');
+    }
+
+    $page = $response->original->getProps();
+    $columns = $page['columns'] ?? [];
+
+    foreach ($columns as $col) {
+        foreach ($col['cards'] ?? [] as $card) {
+            if (! array_key_exists('venda_derivada', $card)) {
+                continue;
+            }
+            $vd = $card['venda_derivada'];
+            if ($vd === null) {
+                continue;
+            }
+
+            foreach ($vd['items_list'] as $item) {
+                expect($item)->toHaveKeys(['type', 'name', 'qty', 'unit_price', 'subtotal']);
+                // Type deve ser 'product' OR 'service' — convenção UltimatePOS.
+                expect($item['type'])->toBeIn(['product', 'service']);
+                expect($item['qty'])->toBeNumeric();
+                expect($item['unit_price'])->toBeNumeric();
+                expect($item['subtotal'])->toBeNumeric();
+            }
+
+            // Summary deve bater com items_list (counts coerentes).
+            $productsCountActual = count(array_filter($vd['items_list'], fn ($i) => $i['type'] === 'product'));
+            $servicesCountActual = count(array_filter($vd['items_list'], fn ($i) => $i['type'] === 'service'));
+            expect($vd['items_summary']['products_count'])->toBe($productsCountActual);
+            expect($vd['items_summary']['services_count'])->toBe($servicesCountActual);
+        }
+    }
+});
+
+it('fiscal.status reflete último nfe_emissoes (autorizada > pendente > rejeitada precedence)', function () {
+    // Unit test do precedence helper — não depende de Transaction real.
+    // Simula 3 emissões pra mesma TX e verifica que orderByDesc(id) pega a mais recente.
+    if (! Schema::hasTable('nfe_emissoes')) {
+        test()->markTestSkipped('Tabela nfe_emissoes ausente — feature NfeBrasil não migrada.');
+    }
+    if (! class_exists(\Modules\NfeBrasil\Models\NfeEmissao::class)) {
+        test()->markTestSkipped('Classe NfeEmissao indisponível.');
+    }
+
+    $business = Business::first();
+    if (! $business) {
+        test()->markTestSkipped('Sem business.');
+    }
+
+    // Cleanup possível leftover (test idempotente).
+    $txStub = 9999990;
+    DB::table('nfe_emissoes')->where('transaction_id', $txStub)
+        ->where('business_id', $business->id)->delete();
+
+    try {
+        // Tenta inserir 3 emissões — se schema reject (FK, NULL not allowed), skip.
+        $modelo = '55';
+        DB::table('nfe_emissoes')->insert([
+            ['business_id' => $business->id, 'transaction_id' => $txStub, 'modelo' => $modelo, 'serie' => 1, 'numero' => 1, 'status' => 'rejeitada', 'cstat' => '999', 'created_at' => now(), 'updated_at' => now()],
+            ['business_id' => $business->id, 'transaction_id' => $txStub, 'modelo' => $modelo, 'serie' => 1, 'numero' => 2, 'status' => 'pendente', 'cstat' => '103', 'created_at' => now(), 'updated_at' => now()],
+            ['business_id' => $business->id, 'transaction_id' => $txStub, 'modelo' => $modelo, 'serie' => 1, 'numero' => 3, 'status' => 'autorizada', 'cstat' => '100', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Não foi possível inserir nfe_emissoes stub: '.$e->getMessage());
+    }
+
+    try {
+        // Replica a query do controller — pega mais recente (orderByDesc id).
+        $latest = \Modules\NfeBrasil\Models\NfeEmissao::where('business_id', $business->id)
+            ->whereIn('transaction_id', [$txStub])
+            ->orderByDesc('id')
+            ->get(['id', 'transaction_id', 'modelo', 'status', 'chave_44'])
+            ->groupBy('transaction_id')
+            ->map(fn ($g) => $g->first())
+            ->get($txStub);
+
+        expect($latest)->not()->toBeNull();
+        // Última inserida (id maior) é a 'autorizada' — precedence garantido pela ordem temporal.
+        expect($latest->status)->toBe('autorizada');
+    } finally {
+        DB::table('nfe_emissoes')->where('transaction_id', $txStub)
+            ->where('business_id', $business->id)->delete();
+    }
+});
+
+it('Tier 0 ADR 0093: nfe lookup scoped por business_id — cross-tenant não vaza', function () {
+    if (! Schema::hasTable('nfe_emissoes')) {
+        test()->markTestSkipped('Tabela nfe_emissoes ausente.');
+    }
+    if (! class_exists(\Modules\NfeBrasil\Models\NfeEmissao::class)) {
+        test()->markTestSkipped('Classe NfeEmissao indisponível.');
+    }
+
+    $business = Business::first();
+    if (! $business) {
+        test()->markTestSkipped('Sem business.');
+    }
+
+    // Cria business "outro tenant" sintético (id alto pra não colidir).
+    $otherBusinessId = $business->id + 999999;
+    $txStub = 9999991;
+
+    DB::table('nfe_emissoes')->where('transaction_id', $txStub)->delete();
+
+    try {
+        DB::table('nfe_emissoes')->insert([
+            // Emissão pertence ao OUTRO tenant.
+            ['business_id' => $otherBusinessId, 'transaction_id' => $txStub, 'modelo' => '55', 'serie' => 1, 'numero' => 1, 'status' => 'autorizada', 'cstat' => '100', 'created_at' => now(), 'updated_at' => now()],
+        ]);
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Não foi possível inserir stub cross-tenant: '.$e->getMessage());
+    }
+
+    try {
+        // Query scoped pro tenant ATIVO — não deve enxergar emissão do outro.
+        $leaked = \Modules\NfeBrasil\Models\NfeEmissao::where('business_id', $business->id)
+            ->whereIn('transaction_id', [$txStub])
+            ->get();
+
+        expect($leaked)->toHaveCount(0);
+    } finally {
+        DB::table('nfe_emissoes')->where('transaction_id', $txStub)->delete();
+    }
+});
+
+it('backward compat: payload sem sell_lines retorna items_list=[] e summary zerado', function () {
+    // Validação direta do helper buildVendaDerivadaPayload via reflexão —
+    // garante que Worker B Onda 5 continua funcionando mesmo com tx sem itens.
+    $business = Business::first();
+    if (! $business) {
+        test()->markTestSkipped('Sem business.');
+    }
+
+    $controller = new \Modules\Repair\Http\Controllers\ProducaoOficinaController();
+    $ref = new \ReflectionClass($controller);
+    $method = $ref->getMethod('buildVendaDerivadaPayload');
+    $method->setAccessible(true);
+
+    // Stub Transaction-like com sell_lines vazio.
+    $txStub = new \App\Transaction();
+    $txStub->id = 12345;
+    $txStub->invoice_no = 'V-TEST';
+    $txStub->final_total = 100.00;
+    $txStub->setRelation('sell_lines', collect());
+
+    $payload = $method->invoke($controller, $txStub, null);
+
+    expect($payload['items_list'])->toBe([]);
+    expect($payload['items_summary'])->toBe([
+        'products_count' => 0,
+        'products_total' => 0.0,
+        'services_count' => 0,
+        'services_total' => 0.0,
+        'tax_total' => 0.0,
+        'discount_total' => 0.0,
+    ]);
+    expect($payload['fiscal'])->toBeNull();
+    // Backward compat — keys Onda 5 preservadas.
+    expect($payload['id'])->toBe(12345);
+    expect($payload['invoice_no'])->toBe('V-TEST');
+    expect($payload['final_total'])->toBe(100.0);
+});


### PR DESCRIPTION
## Summary

Onda 3 da **Wave Z-2 (Worker 2 backend)** da Integração Vendas × Oficina (ADR 0192). Expande o payload `venda_derivada` em `ProducaoOficinaController::buildColumns` com breakdown de **itens (produto/serviço)** + **summary agregado** + **status fiscal** pro drawer card Cowork.

Backend Onda 2 (`94300b057`) retornava 4 keys (`id` / `invoice_no` / `final_total` / `transaction_date`). Frontend Worker B Onda 5 consome esse shape. Prototype Cowork pede MAIS detalhe — peças, serviços, fiscal — então este PR **expande** o payload preservando 100% backward compat com o consumer atual.

- **Eager-load anti-N+1:** `Transaction::with(['sell_lines.product'])` + batch lookup `nfe_emissoes` por `transaction_id` (padrão de `SellController::inertiaList` linha 1226+). Tier 0 ADR 0093 — todas queries scopadas por `business_id`.
- **Novo helper privado `buildVendaDerivadaPayload(Transaction $tx, ?NfeEmissao $nfe)`:** monta `items_list[]`, `items_summary{}`, `fiscal{}`. Convenção UltimatePOS: `enable_stock=1` → product, `enable_stock=0` → service.
- **Backward compat:** `sell_lines` vazio → `items_list:[]`, `items_summary` zerado, `fiscal:null`. Worker B Onda 5 segue funcionando sem mudança no frontend.

## Shape do payload expandido

```json
{
  "venda_derivada": {
    "id": 1234,
    "invoice_no": "V-5678",
    "final_total": 150.00,
    "transaction_date": "2026-05-25",
    "items_list": [
      {"type": "product", "name": "Filtro óleo", "qty": 1, "unit_price": 35.00, "subtotal": 35.00},
      {"type": "service", "name": "Troca de óleo", "qty": 1, "unit_price": 80.00, "subtotal": 80.00}
    ],
    "items_summary": {
      "products_count": 1, "products_total": 35.00,
      "services_count": 1, "services_total": 80.00,
      "tax_total": 0.00, "discount_total": 0.00
    },
    "fiscal": {
      "status": "autorizada", "modelo": "55",
      "chave": "<chave-44>", "danfe_url": "/danfe/123"
    }
  }
}
```

## Query count (anti-N+1)

| Cenário | Antes (Onda 2) | Depois (Onda 3) |
|---|---|---|
| Index sem OS | 1 query (jobsheets) | 1 query (jobsheets) |
| Index com N OS sem venda | +1 query (transactions empty) | +1 query (transactions empty), 0 nfe lookup |
| Index com N OS com M vendas | +1 query (transactions) | +1 (transactions com sell_lines.product eager) +1 (nfe_emissoes batch) = **+2 queries fixas** |

Sem expansão N+1: cada Transaction carrega `sell_lines` em UMA query (`whereIn` Eloquent eager), cada `sell_lines.product` em UMA query. Nfe lookup é UMA query batch. Total fixo independente de N OS ou M vendas.

## Test plan

Pest GUARDs novos (`Modules/Repair/Tests/Feature/ProducaoOficinaVendaDerivadaExpandedTest.php`):

- [x] payload shape inclui `items_list` / `items_summary` / `fiscal` quando `venda_derivada !== null` (preserva keys Onda 5)
- [x] `items_list` separa produtos (`type=product`) de serviços (`type=service`) — convenção `enable_stock` UltimatePOS
- [x] `fiscal.status` reflete último `nfe_emissoes` via `orderByDesc(id)` (autorizada > pendente > rejeitada por ordem de inserção)
- [x] **Tier 0 ADR 0093:** nfe lookup scoped por `business_id` — cross-tenant não vaza (test injeta emissão em outro tenant e confirma que query retorna 0)
- [x] backward compat: payload sem `sell_lines` retorna `items_list:[]` + summary zerado + `fiscal:null` (Worker B Onda 5 segue OK)

Todos skipam graciosamente em CI SQLite (sem `users/business/permissions`).

## Constraints (todas verificadas)

- [x] Multi-tenant Tier 0 — todas queries adicionais com `where('business_id', $businessId)`
- [x] Anti-N+1 — eager-load `with(...)` + batch `whereIn(...)`, sem loop de queries
- [x] Backward compat — Worker B Onda 5 (#1504) segue funcionando
- [x] Pest skip gracioso em SQLite
- [x] Branch separada, NÃO mergear (aguarda review)

## Refs

- Backend Onda 2: `94300b057` (ProducaoOficinaController.buildColumns inicial)
- Frontend Worker B Onda 5: PR #1504 (drawer card consumer)
- ADR 0192 — Auto-faturar OS via Observer
- ADR 0093 — Multi-tenant Tier 0 IRREVOGÁVEL

🤖 Generated with [Claude Code](https://claude.com/claude-code)