### PR TITLE
polish(cliente): canon v3.9 · espaçamento KPI/busca + lista cola na linha

### DIFF
--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -627,7 +627,7 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
          e em cima".
          canon v3.8 (Wagner 2026-05-25): space-y-3 (12px) → space-y-4 (16px) — gaps maiores
          entre blocos (Header→KPI→Toolbar→Tabela) pra cada um respirar melhor. */}
-     <div className="w-full px-6 space-y-4">
+     <div className="w-full px-6 space-y-2">
       {/* ───── BLOCO 1 · HEADER TRANSPARENTE + border-b warm (canon v3.4 polish · 2026-05-25) ─────
           Wagner pediu remover `bg-background border rounded-t-lg` pra header herdar
           o cream `--color-page-cream` do parent — espelha `/sells` canon Cowork exato.
@@ -973,8 +973,11 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
           {/* canon v3.6 (Wagner 2026-05-25): tabela FLAT — `rounded-lg` removido pra
               parar com aparencia de card. Lista usa borders retas igual /sells.
               canon v3.7 (Wagner 2026-05-25): `mt-1` (4px) gap entre toolbar e tabela
-              pra evitar borders coladas. */}
-          <div className="mt-1 border border-border bg-background overflow-hidden">
+              pra evitar borders coladas.
+              canon v3.9 (Wagner 2026-05-25 polish #5): `mt-0` — lista COLADA na
+              linha separadora da toolbar (Wagner: "remova o espaço entre lista
+              e a linha, cole nela"). 0px gap · borders compartilham · cleaner. */}
+          <div className="border border-border bg-background overflow-hidden">
             <div className="overflow-x-auto">
               {/* Wave G — Tabela turbinada (paridade Cowork blueprint score 9,4/10).
                   Colunas: Avatar HSL · Cliente+sub · Tipo · Documento · Cidade/UF ·


### PR DESCRIPTION
## Summary

Wagner 2026-05-25 feedback pós validação visual `/cliente`:

1. **"qual o espaço entre o buscar e kpi? quero a metade"** → `space-y-4` (16px) → `space-y-2` (8px)
2. **"remova o espaço entre lista e a linha, cole nela"** → `mt-1` (4px) → `mt-0` (colado)

### Visual estimate

```
ANTES                  DEPOIS
─ Header               ─ Header
↕ 16px                 ↕ 8px (metade)
─ KPI strip            ─ KPI strip
↕ 16px                 ↕ 8px (metade)
─ Toolbar              ─ Toolbar
↕ 4px                  ↕ 0px (colado)
═ Tabela               ═ Tabela
```

## Outras observações da sessão (separadas)

- **"Auditoria não pode exportar"** → botão "Exportar log" + rota `GET /cliente/{id}/auditoria/export` **já existem** (linha 152-161 AuditoriaTab.tsx + Route::get linha 219 Modules/Crm/Routes/web.php). Vamos smoke-testar em prod pós-merge.
- **"PF/PJ duplicado"** → smoke automatizado confirmou que prod tem apenas **1** `[role="radiogroup"][aria-label="Tipo de pessoa"]` no drawer (eperado: 1). Wagner via cache stale do navegador — **Ctrl+Shift+R** resolve.

## Test plan

- [x] `php artisan ui:lint --strict --changed-only` → **Ok · sem regressões**
- [ ] CI ui-lint workflow verde
- [ ] CI pr-ui-judge LLM
- [ ] Smoke prod: ver lista colada na linha + busca↔KPI com 8px

## Refs

- ADR UI-0013 Constituição UI v2 (tokens tailwind)
- PR #1507 (canon v3.8 — este PR é polish #5 sequencial)
- Wagner 2026-05-25 feedback literal

🤖 Generated with [Claude Code](https://claude.com/claude-code)
