### PR TITLE
fix(crm): lookup CNPJ usa codigo_municipio_ibge (7d) em vez de codigo_municipio (4d Receita)

### DIFF
--- a/Modules/Crm/Services/BrLookupService.php
+++ b/Modules/Crm/Services/BrLookupService.php
@@ -184,11 +184,14 @@ class BrLookupService
                     $cepRaw = (string) ($response->json('cep') ?? '');
                     $zipCode = preg_replace('/\D/', '', $cepRaw) ?? '';
 
-                    // city_code IBGE: BrasilAPI retorna `codigo_municipio`
-                    // como inteiro 7 digitos (ex 3550308 = SP). Defensivo:
-                    // normaliza pra string so com digitos. Wagner 2026-05-22:
-                    // obrigatorio em NFe/NFSe (campos enderEmit/cMun, enderDest/cMun).
-                    $cityCodeRaw = $response->json('codigo_municipio');
+                    // city_code IBGE: BrasilAPI retorna `codigo_municipio_ibge` como
+                    // inteiro 7 digitos (ex 3550308 = Sao Paulo). NAO confundir com
+                    // `codigo_municipio` (4 digitos -- codigo interno Receita Federal,
+                    // p.ex. 7107 pra SP). Backend valida exatamente 7 digitos por causa
+                    // do XML NFe (enderEmit/cMun, enderDest/cMun). Bug fix 2026-05-23
+                    // descoberto via smoke prod -- PATCH /endereco retornava 422 silencioso
+                    // pois city_code chegava como '7107' em vez de '3550308'.
+                    $cityCodeRaw = $response->json('codigo_municipio_ibge');
                     $cityCode = '';
                     if (is_numeric($cityCodeRaw) || is_string($cityCodeRaw)) {
                         $cityCode = preg_replace('/\D/', '', (string) $cityCodeRaw) ?? '';


### PR DESCRIPTION
## Bug em prod (smoke 2026-05-23)

Drawer 760 Cliente — testando lookup CNPJ Magalu/Ambev em prod (pós-merge #1419):
- Razão social, fantasia preenchem ✅
- **Tab Endereço fica VAZIA** ❌ — bug silencioso (badge UI diz \"Receita preenchidos\")

## Causa raiz

PR #1419 (commit \`a03e7efd7\`) mapeou campo errado da BrasilAPI:

\`\`\`
BrasilAPI v1 CNPJ retorna 2 campos:
  codigo_municipio       = 7107      (4d — código interno Receita Federal)
  codigo_municipio_ibge  = 3550308   (7d — IBGE oficial, usado em NFe XML)
\`\`\`

\`BrLookupService::lookupCnpj\` linha 191 lia o errado → PATCH /endereco devolvia 422 silencioso (\"Codigo IBGE deve ter 7 digitos.\") → frontend log warning + cross-tab fill abortado.

## Confirmação via console no oimpresso.com

\`\`\`json
PATCH /cliente/30462/endereco {
  \"zip_code\": \"04530001\",
  \"address_line_1\": \"DR RENATO PAES DE BARROS, 1017\",
  \"city\": \"SAO PAULO\",
  \"state\": \"SP\",
  \"city_code\": \"7107\"   ← 4 dígitos (errado)
}
→ 422 { \"errors\": { \"city_code\": [\"Codigo IBGE deve ter 7 digitos.\"] } }
\`\`\`

## Fix

1 linha em \`Modules/Crm/Services/BrLookupService.php:191\`:
\`\`\`diff
- \$cityCodeRaw = \$response->json('codigo_municipio');
+ \$cityCodeRaw = \$response->json('codigo_municipio_ibge');
\`\`\`

Comment expandido documentando os 2 campos pra ninguém regredir.

## Test plan

- [x] **Smoke prod manual via Chrome DevTools** (Wagner sessão WR2 Sistemas): PATCH /endereco com \`city_code: '3550308'\` retorna 200 OK
- [ ] **Pós-merge**: refazer lookup CNPJ Magalu/Ambev no drawer Acme → tab Endereço deve preencher tudo
- [x] Pest coverage de \`city_code\` validator 7d já existe (PR #1419)
- [ ] CI passa automaticamente (sem mudança de schema, sem migration nova)

## Refs

- PR #1419 (origem do bug)
- Migration \`2026_05_22_180000_add_city_code_to_contacts_table\`
- ClienteAutosaveController::endereco validator regra \`'city_code' => 'max:7'\` + after closure \"7 digitos\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)