### PR TITLE
feat(repair): FASE B — VendaDerivadaCard evolution (items_list + fiscal badge) (ADR 0192 follow-up)

### DIFF
--- a/Modules/Repair/Tests/Feature/ProducaoOficinaFaseBVendaDerivadaCardTest.php
+++ b/Modules/Repair/Tests/Feature/ProducaoOficinaFaseBVendaDerivadaCardTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest — FASE B (pós Wave Z-2 backend W2 `2f6f10fc8` · 2026-05-25) · ADR 0192
+ * Integração Vendas × Oficina — VendaDerivadaCard evolution (items + fiscal).
+ *
+ * GUARD estrutural sobre `resources/js/Pages/Repair/ProducaoOficina/Index.tsx`
+ * que garante que o card evoluído renderiza breakdown + fiscal + lista
+ * expandível conforme contrato + NÃO regride pra placeholder em refactors.
+ *
+ * Implementação canônica FASE B:
+ *  - TypeScript interfaces VendaItem + VendaItemsSummary + VendaFiscal
+ *  - Breakdown grid 2-col (Peças / Serviços) + linha Subtotal/Desconto/Impostos
+ *  - Badge fiscal 4 estados: autorizada (verde + DANFE link), pendente (amber),
+ *    rejeitada (rose), null (slate "Sem nota fiscal")
+ *  - Items list collapsed por default + disclosure expand button (▸/▾)
+ *  - Cap 10 items visíveis + "+ N adicionais"
+ *  - Prefix textual "Peça" / "Serviço" (ZERO emoji em UI · skill pageheader-canon)
+ *  - Empty states tolerantes: items_list ausente/[] não renderiza breakdown nem
+ *    disclosure; fiscal null renderiza só "Sem nota fiscal" sutil
+ *  - Multi-tenant Tier 0 preservado (payload já scoped backend · frontend só lê)
+ *  - Vocabulário shared cross-vertical preservado (zero termos automotivos)
+ *
+ * Refs:
+ *  - resources/js/Pages/Repair/ProducaoOficina/Index.tsx (VendaDerivadaCard)
+ *  - resources/js/Pages/Repair/ProducaoOficina/Index.charter.md (Goals FASE B)
+ *  - Modules/Repair/Http/Controllers/ProducaoOficinaController.php (buildVendaDerivadaPayload)
+ *  - Modules/Repair/Tests/Feature/ProducaoOficinaVendaDerivadaExpandedTest.php (backend W2 GUARDs)
+ *  - memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md
+ *  - memory/requisitos/Repair/ProducaoOficina-r3-venda-derivada-expanded-visual-comparison.md
+ */
+
+uses(Tests\TestCase::class);
+
+const PRODUCAO_OFICINA_INDEX_TSX_FASE_B = 'resources/js/Pages/Repair/ProducaoOficina/Index.tsx';
+
+function faseBReadIndex(): string
+{
+    // __DIR__ resolve relativo ao próprio teste — funciona em worktree OU root.
+    // Pattern espelha W3 ProducaoOficinaOnda5CompartilharTest (mas mais robusto pra
+    // worktrees onde base_path() pode apontar pra root project compartilhado).
+    $worktreeRoot = realpath(__DIR__.'/../../../../');
+    $path = $worktreeRoot.DIRECTORY_SEPARATOR.PRODUCAO_OFICINA_INDEX_TSX_FASE_B;
+    return file_get_contents($path);
+}
+
+it('FASE B: interfaces TypeScript VendaItem + VendaItemsSummary + VendaFiscal definidas', function () {
+    $src = faseBReadIndex();
+    expect($src)
+        ->toContain('interface VendaItem {')
+        ->toContain('interface VendaItemsSummary {')
+        ->toContain('interface VendaFiscal {')
+        ->toContain("type: 'product' | 'service';")
+        ->toContain("status: 'autorizada' | 'pendente' | 'rejeitada';");
+});
+
+it('FASE B: VendaDerivada interface tem fields opcionais items_list + items_summary + fiscal (backward compat Onda 5)', function () {
+    $src = faseBReadIndex();
+    expect($src)
+        ->toContain('items_list?: VendaItem[];')
+        ->toContain('items_summary?: VendaItemsSummary;')
+        ->toContain('fiscal?: VendaFiscal | null;');
+});
+
+it('FASE B: VendaDerivadaCard usa useState para itemsExpanded (collapsed por default)', function () {
+    $src = faseBReadIndex();
+    expect($src)
+        ->toContain('const [itemsExpanded, setItemsExpanded] = useState(false);')
+        ->toContain("aria-expanded={itemsExpanded}");
+});
+
+it('FASE B: breakdown grid renderiza Peças + Serviços com count e total formatados BRL', function () {
+    $src = faseBReadIndex();
+    expect($src)
+        ->toContain('Peças')
+        ->toContain('Serviços')
+        ->toContain('summary.products_count')
+        ->toContain('summary.services_count')
+        ->toContain('fmtBRL(summary.products_total)')
+        ->toContain('fmtBRL(summary.services_total)');
+});
+
+it('FASE B: breakdown mostra linha Subtotal sempre + Desconto/Impostos condicionais (> 0)', function () {
+    $src = faseBReadIndex();
+    expect($src)
+        ->toContain('Subtotal')
+        ->toContain('fmtBRL(subtotal)')
+        ->toContain('summary.discount_total > 0')
+        ->toContain('summary.tax_total > 0')
+        ->toContain('Desconto')
+        ->toContain('Impostos');
+});
+
+it('FASE B: badge fiscal renderiza 4 estados (autorizada/pendente/rejeitada/null)', function () {
+    $src = faseBReadIndex();
+    expect($src)
+        ->toContain("fiscal === null")
+        ->toContain('Sem nota fiscal')
+        ->toContain("fiscal?.status === 'autorizada'")
+        ->toContain("fiscal?.status === 'pendente'")
+        ->toContain("fiscal?.status === 'rejeitada'")
+        ->toContain('autorizada')
+        ->toContain('pendente SEFAZ')
+        ->toContain('rejeitada');
+});
+
+it('FASE B: badge fiscal autorizada tem botão DANFE com window.open + aria-label acessível', function () {
+    $src = faseBReadIndex();
+    expect($src)
+        ->toContain('window.open(fiscal.danfe_url!')
+        ->toContain('DANFE')
+        ->toContain('aria-label={`Abrir DANFE da venda ${venda.invoice_no}`}');
+});
+
+it('FASE B: lista items usa prefix textual "Peça" / "Serviço" (ZERO emoji em UI · pageheader-canon)', function () {
+    $src = faseBReadIndex();
+    expect($src)
+        ->toContain("item.type === 'service' ? 'Serviço' : 'Peça'");
+    // Anti-regressão: não pode usar emoji 📦 ou 🛠 ou 🔧 pra type icon na lista items.
+    expect($src)
+        ->not->toContain('📦 ')
+        ->not->toContain('🛠 ')
+        ->not->toContain('🔧 ');
+});
+
+it('FASE B: items list tem cap 10 visíveis + sumário "+ N adicionais" (densidade drawer 480px)', function () {
+    $src = faseBReadIndex();
+    expect($src)
+        ->toContain('VISIBLE_ITEMS_CAP = 10')
+        ->toContain('visibleItems')
+        ->toContain('hiddenItemsCount')
+        ->toContain('adicionais');
+});
+
+it('FASE B: disclosure button mostra ▸ collapsed e ▾ expanded (símbolos canônicos · não emoji)', function () {
+    $src = faseBReadIndex();
+    expect($src)
+        ->toContain("'▾' : '▸'")
+        ->toContain('Ocultar')
+        ->toContain('Ver');
+});
+
+it('FASE B: empty states tolerantes — hasBreakdown gateia render do breakdown e disclosure', function () {
+    $src = faseBReadIndex();
+    expect($src)
+        ->toContain('const hasBreakdown = !!summary && itemsList.length > 0;')
+        ->toContain('{hasBreakdown && summary && (')
+        ->toContain('{hasBreakdown && (')
+        ->toContain('venda.items_list ?? []')
+        ->toContain('venda.fiscal ?? null');
+});
+
+it('FASE B: Onda 5 backward compat — keys core (id/invoice_no/final_total/transaction_date) intactas', function () {
+    $src = faseBReadIndex();
+    // Core fields preservados na interface VendaDerivada.
+    expect($src)
+        ->toContain('id: number;')
+        ->toContain('invoice_no: string;')
+        ->toContain('final_total: number;')
+        ->toContain('transaction_date: string | null;');
+});
+
+it('FASE B: handlers Onda 5 + W3 preservados (handleAbrir / handleImprimirRecibo / handleCompartilhar)', function () {
+    $src = faseBReadIndex();
+    // GUARD anti-regressão dos handlers Onda 5+W3 que NÃO devem ser tocados.
+    expect($src)
+        ->toContain('const handleAbrir = ()')
+        ->toContain("new CustomEvent('oimpresso:open-venda'")
+        ->toContain('const handleImprimirRecibo = ()')
+        ->toContain('/sells/${venda.id}/print')
+        ->toContain('const handleCompartilhar = async ()')
+        ->toContain('navigator.share');
+});
+
+it('FASE B: vocabulário shared cross-vertical — zero termos automotivos no card (ADR 0121 §P8)', function () {
+    $src = faseBReadIndex();
+    // Regex específico só dentro do componente VendaDerivadaCard (anti false-positive
+    // com mock data automotivo que vive em outras seções).
+    $cardStart = strpos($src, 'function VendaDerivadaCard');
+    expect($cardStart)->not->toBeFalse();
+    $cardSrc = substr($src, $cardStart);
+
+    // Vocab proibido cross-vertical dentro do card:
+    expect($cardSrc)
+        ->not->toContain('placa')
+        ->not->toContain('vehicle')
+        ->not->toContain('mecanico')
+        ->not->toContain('mecânico')
+        ->not->toContain('elevador');
+});
+
+it('FASE B: multi-tenant Tier 0 preservado — frontend NÃO dispara queries (só lê payload scoped)', function () {
+    $src = faseBReadIndex();
+    $cardStart = strpos($src, 'function VendaDerivadaCard');
+    expect($cardStart)->not->toBeFalse();
+    $cardSrc = substr($src, $cardStart);
+
+    // Anti-regressão: card não pode fazer router.get / useFetch / axios direto —
+    // payload já vem hidratado do Controller (Onda 2 + W2 expand).
+    expect($cardSrc)
+        ->not->toContain('router.get(')
+        ->not->toContain('router.post(')
+        ->not->toContain('axios.')
+        ->not->toContain('fetch(');
+});

--- a/memory/requisitos/Repair/ProducaoOficina-r3-venda-derivada-expanded-visual-comparison.md
+++ b/memory/requisitos/Repair/ProducaoOficina-r3-venda-derivada-expanded-visual-comparison.md
@@ -1,0 +1,215 @@
+---
+tela: /repair/producao-oficina (drawer · VendaDerivadaCard evolution)
+componente: resources/js/Pages/Repair/ProducaoOficina/Index.tsx (VendaDerivadaCard)
+fase: FASE B — pós Wave Z-2 backend W2 (`2f6f10fc8`)
+status: aprovado-cowork — mapeamento direto F1 protótipo expandido
+fonte_cowork: prototipo-ui/oficina-page.jsx (linhas 392-458) + prototipo-ui/oficina-page.css (linhas 526-598)
+adr: 0192 (auto-faturar OS→Venda) · 0121 §P8 (vocabulário shared) · 0093 (multi-tenant Tier 0)
+data: 2026-05-25
+worker: B (sub-agent FASE B paralelo · pós Wave Z-2 merged)
+backend_dep: PR #1510 (`2f6f10fc8`) — buildVendaDerivadaPayload expand items_list + items_summary + fiscal
+---
+
+# Visual Comparison — VendaDerivadaCard evolution (items_list + fiscal badge)
+
+> **Escopo:** evolução cirúrgica do card existente. Adiciona breakdown peças/serviço + badge fiscal NF-e + lista items expandível. NÃO toca kanban, drag-and-drop, filtros, mock data, drawer sections legacy, handlers Onda 5/W3 (Abrir/Imprimir recibo/Compartilhar). Empty states tolerantes preservam backward compat com payload Onda 5 (apenas core fields).
+
+## Mapeamento Cowork → Inertia React (delta vs r2)
+
+### Antes (r2 · Onda 5 entregue 2026-05-25)
+
+Card mostrava só:
+- Header "Esta OS gerou a venda #V-NNNN" + flag pill
+- Grid 2-col (Total + Data)
+- 3 CTAs (Abrir / Imprimir recibo / Compartilhar W3)
+
+### Agora (r3 · FASE B)
+
+Card adiciona entre grid Total/Data e CTAs:
+
+1. **Breakdown peças/serviço** — grid 2-col responsive (empilha em mobile) com `Peças · N itens · R$ X` + `Serviços · N itens · R$ Y` + linha `Subtotal · R$ Z` + (condicional) `Desconto · -R$ W` + (condicional) `Impostos · +R$ V`
+2. **Badge fiscal NF-e** — 4 estados condicionais (autorizada verde + DANFE link · pendente amber · rejeitada rose · null slate "Sem nota fiscal")
+3. **Lista items expandível** — disclosure `▸ Ver N itens da venda` (collapsed default) → `▾ Ocultar` expanded, com cap 10 items + "+ N adicionais"
+
+## Dimensões avaliadas (15 dimensões)
+
+### 1. Hierarquia visual
+
+- **Cowork F1 mantida:** card destacado verde (oklch emerald 155° hue) com flag pill canto superior + título bold
+- **Nova hierarquia interna:** Total/Data → Breakdown → Fiscal badge → Items list (collapsed) → 3 CTAs. Densidade cresce progressivamente.
+
+### 2. Densidade informativa ⭐ (foco solicitado)
+
+- **Antes:** ~80px altura útil do card (header + grid 2-col + 3 botões)
+- **Depois:** ~160-240px collapsed / ~340-440px expanded (até 10 items)
+- **Justificativa cap 10:** drawer body é 480px wide × ~600-800px viewport. Lista ilimitada quebraria scroll/UX. Sumário "+ N adicionais" sinaliza overflow sem custar densidade. Drilldown completo continua em `/sells/{id}` (CTA "Abrir #V-NNNN").
+- **Empty states tolerantes** evitam vazamento de densidade desnecessária quando payload backend vem mínimo (sem items_list ou sem fiscal).
+
+### 3. Hierarquia visual interna ⭐ (foco solicitado)
+
+Pattern Linear/Notion: scan vertical top-down:
+
+```
+┌─ flag pill (9px mono uppercase)
+├─ TÍTULO bold + invoice code mono (14px)
+├─ subtítulo emerald-800/80 (11px) — origem
+├─ Grid 2-col Total/Data (sm 14px)
+├─ ─── Breakdown ─── (bg white/65 contained)
+│  ├─ Peças (count + total) · Serviços (count + total)  ←  grid 2-col
+│  └─ border-t emerald-100
+│     ├─ Subtotal               R$ X     ←  sempre
+│     ├─ Desconto              -R$ Y     ←  if > 0 (rose)
+│     └─ Impostos              +R$ Z     ←  if > 0 (slate)
+├─ Fiscal badge — pill 11px (autorizada/pendente/rejeitada/null)
+├─ ▸/▾ Ver N itens (collapsed default)
+│  └─ ul items (11.5px texto · prefix "Peça"/"Serviço")
+└─ 3 CTAs (primary verde + 2 secondary outline)
+```
+
+Cada bloco tem subtítulo uppercase 9.5px tracking-wider · valor mono semibold pra leitura financeira rápida.
+
+### 4. Tokens cor/tipo (oklch preservados Cowork verbatim)
+
+| Token Cowork | Valor | Uso novo (FASE B) |
+|---|---|---|
+| `.ofc-fb-ok` | `color: oklch(0.50 0.13 155); border: oklch(0.94 0.06 155)` | badge `autorizada` verde |
+| `.ofc-fb-wait` | `color: oklch(0.55 0.13 60); border: oklch(0.94 0.06 60)` | badge `pendente` amber |
+| `.ofc-fb-bad` | `color: oklch(0.55 0.18 25); border: oklch(0.94 0.07 25)` | badge `rejeitada` rose |
+| `.ofc-fb-na` | `color: var(--text-mute)` | badge `null` slate |
+| `.ofc-vc` bg | `rgba(255,255,255,0.65)` | cards Peças/Serviços + items ul |
+| `.ofc-vc` border-top | `oklch(emerald-100)` | divider subtotal/desconto/impostos |
+
+Tailwind classes mapeadas: `border-emerald-200 text-emerald-700` (autorizada) · `border-amber-200 text-amber-700` (pendente) · `border-rose-200 text-rose-700` (rejeitada) · `border-slate-200 text-slate-500` (null).
+
+### 5. Empty states tolerantes ⭐ (foco solicitado)
+
+Backward compat com payload Onda 5 (apenas core fields) garantida via:
+
+```ts
+const itemsList = venda.items_list ?? [];
+const summary = venda.items_summary;
+const hasBreakdown = !!summary && itemsList.length > 0;
+const fiscal = venda.fiscal ?? null;
+```
+
+| Cenário payload | Render |
+|---|---|
+| Onda 5 puro (sem `items_list`, sem `fiscal`) | header + Total/Data + badge "Sem nota fiscal" + 3 CTAs |
+| W2 expand: `items_list=[]`, `fiscal=null` | mesmo do Onda 5 (graceful) |
+| W2 expand: `items_list=[3]`, `fiscal=null` | + breakdown + disclosure + badge "Sem nota fiscal" |
+| W2 expand: `items_list=[5]`, `fiscal.status='autorizada'` | + breakdown + disclosure + badge verde + DANFE link |
+| W2 expand: `items_list=[12]`, `fiscal.status='pendente'` | + breakdown + disclosure (10 visíveis + "+2 adicionais") + badge amber |
+
+Anti-regressão: Pest GUARD `FASE B: empty states tolerantes — hasBreakdown gateia render` valida que ambos os blocos breakdown e disclosure ficam fora do DOM quando `hasBreakdown=false`.
+
+### 6. Vocabulário shared (CRÍTICO — CI guard `repair-shared-vocab.yml`)
+
+✅ **Não usa termos automotivos** — `Peças` e `Serviços` são genéricos cross-vertical (Comunicação Visual: peça = lona/banner · serviço = instalação; Vestuário: peça = roupa reparada · serviço = ajuste).
+
+✅ Pest GUARD `FASE B: vocabulário shared cross-vertical` extrai apenas o JSX dentro de `function VendaDerivadaCard` e proíbe `placa|vehicle|mecanico|elevador` (anti false-positive vs mock data automotivo).
+
+### 7. Acessibilidade (WCAG AA)
+
+- Disclosure button: `aria-expanded={itemsExpanded}` + `aria-controls={\`venda-items-${venda.id}\`}` (relacionamento semântico ARIA)
+- DANFE button: `aria-label={\`Abrir DANFE da venda ${venda.invoice_no}\`}`
+- Símbolos `▸/▾` marcados `aria-hidden="true"` (texto "Ver/Ocultar N itens" carrega significado)
+- Contraste rose-700/white = ~5.2:1 · amber-700/white = ~4.8:1 · emerald-700/white = ~5.4:1 · todos AA
+- Foco visível keyboard preservado (`focus:ring-2 ring-emerald-500/40` nos botões)
+
+### 8. Disclosure pattern (collapsed por default — UX intencional)
+
+**Por que collapsed:** drawer 480px wide é stack denso. OS pode ter 1-15 items. Lista sempre expanded explodiria scroll. Padrão Notion/Linear: detalhes ricos atrás de toggle.
+
+**Por que ▸/▾ (não +/-):** símbolos canônicos Unicode triangle (`U+25B8` collapsed / `U+25BE` expanded) são WCAG-friendly e funcionam em qualquer font. ZERO emoji (ADR pageheader-canon).
+
+### 9. Vocabulário "Peça" vs "Serviço" (prefix textual)
+
+Cowork F1 protótipo usa emoji `📦 produto / 🛠 serviço`. **Substituído** por prefix textual `Peça · {name}` / `Serviço · {name}` per skill `pageheader-canon` (ZERO emoji em UI). Pest GUARD anti-regressão valida ausência dos 3 emojis comuns (📦 🛠 🔧).
+
+### 10. Multi-tenant Tier 0 (ADR 0093)
+
+- ✅ `items_list` + `items_summary` + `fiscal` vêm scoped pelo Controller (W2 backend · `Transaction::where('business_id', $businessId)` + `NfeEmissao::where('business_id', ...)`)
+- ✅ Frontend só renderiza — Pest GUARD valida ausência de `router.get/post`, `axios`, `fetch` dentro do componente
+- ✅ DANFE link aponta pra `/danfe/{id}` server-side (gated por business_id no NfeBrasil module)
+
+### 11. Performance
+
+- Zero queries adicionais (W2 backend já entregou anti-N+1 com eager-load + batch lookup)
+- `useState(false)` único pro itemsExpanded — re-render barato
+- `useMemo` desnecessário (cap 10 + slice O(1))
+- Cards collapsed: ~0 custo render dos items
+- Cards expanded: max 10 `<li>` simples sem componente filho
+
+### 12. Anti-padrões UI evitados
+
+- ❌ Modal (drawer continua sendo único container)
+- ❌ Loading skeleton (payload inline)
+- ❌ Toast/snackbar pra disclosure (operação client-side)
+- ❌ Animação decorativa (só transition em hover/focus dos botões)
+- ❌ Emoji em UI (prefix textual + símbolos Unicode triangle)
+- ❌ Drilldown per-item dentro do card (CTA "Abrir #V-NNNN" cobre)
+- ❌ Edição inline (drawer só lê)
+
+### 13. Anti-hooks Cowork preservados
+
+✅ Sem CTA WhatsApp · sem emoji em UI (só símbolos canônicos ↗ ▸ ▾) · UI 100% português · sem rounded-xl+ (radius 4-10px) · tokens oklch dentro paleta · vocabulário shared cross-vertical.
+
+### 14. Charter compliance
+
+Adicionado à `Goals`:
+- Card mostra breakdown Peças vs Serviços + linha Subtotal/Desconto/Impostos
+- Badge fiscal NF-e 4 estados (autorizada/pendente/rejeitada/null)
+- Lista items expandível (collapsed default · cap 10 + "+ N adicionais")
+- Prefix textual "Peça"/"Serviço" (ZERO emoji)
+- Empty states tolerantes (backward compat Onda 5)
+
+Mantido em `Non-Goals`:
+- NFS-e badge (NfeBrasil não emite NFS-e ainda)
+- Edição inline da venda derivada
+- Items list ilimitada (cap 10 + sumário)
+- Drilldown per-item
+- Botão "Ver no Caixa do dia" (Onda 6 separada)
+
+### 15. Pest GUARDs (file-content pattern W3)
+
+Arquivo `Modules/Repair/Tests/Feature/ProducaoOficinaFaseBVendaDerivadaCardTest.php` com 14 GUARDs:
+
+1. Interfaces TS (VendaItem/VendaItemsSummary/VendaFiscal) definidas
+2. VendaDerivada com fields opcionais (backward compat)
+3. useState(false) pro itemsExpanded (collapsed default) + aria-expanded
+4. Breakdown renderiza count + total formatados BRL pra ambos types
+5. Subtotal sempre + Desconto/Impostos condicionais
+6. Badge fiscal 4 estados completos
+7. Autorizada tem DANFE button com window.open + aria-label
+8. Prefix textual "Peça"/"Serviço" (ZERO emoji 📦 🛠 🔧)
+9. Cap 10 visíveis + "+ N adicionais"
+10. Disclosure usa símbolos canônicos ▸/▾
+11. Empty states gateados por `hasBreakdown`
+12. Backward compat — keys core preservadas
+13. Handlers Onda 5+W3 preservados (Abrir/Imprimir/Compartilhar)
+14. Vocabulário shared (zero termos automotivos no card)
+15. Multi-tenant Tier 0 (frontend NÃO dispara queries)
+
+---
+
+## Decisões UI tomadas (FASE B)
+
+| Decisão | Alternativa rejeitada | Justificativa |
+|---|---|---|
+| Items list **collapsed** por default | Sempre expanded | Densidade drawer 480px · evita scroll explosivo · pattern Notion/Linear |
+| Cap **10 items** + "+ N adicionais" | Lista ilimitada com scroll interno | UX simples sem scroll-in-scroll · drilldown completo via CTA "Abrir #V-NNNN" |
+| Prefix textual "Peça"/"Serviço" | Emoji 📦 🛠 (Cowork F1) | skill `pageheader-canon` ZERO emoji em UI |
+| Símbolos Unicode ▸/▾ | Chevron SVG ou +/- | Unicode canônico funciona em qualquer font · WCAG-friendly · zero deps |
+| Badge "Sem nota fiscal" sutil slate | Não renderizar badge quando `fiscal=null` | Sinaliza intencionalidade (OS informal sem nota) vs ausência de feature |
+| DANFE como link separado | Inline no badge "autorizada" | Click-target maior (44×44 mínimo) · aria-label dedicado · pattern accessibility |
+| Subtotal **sempre** + Desconto/Impostos condicionais | Mostrar todos com R$ 0,00 | Reduz noise visual · clareza financeira |
+| Grid 2-col responsive (`sm:grid-cols-2 → grid-cols-1`) | 2-col fixo | Drawer pode shrinkar em viewport mobile · mobile-first |
+| Border-t emerald-100 antes do Subtotal | Sem divider | Hierarquia visual: "agregados" vs "componentes" |
+
+---
+
+## Aprovação Wagner
+
+Wagner aprovou screenshot F1 do protótipo Cowork em PR #1493 (`b2fcabbf2`) 2026-05-25 — esta FASE B é mapeamento direto da seção `.ofc-venda-grid` + `.ofc-venda-fiscal` + items list Cowork pra Inertia React preservando tokens + hierarquia + vocabulário shared, agora com payload backend W2 (`2f6f10fc8`) entregando o expansão real.
+
+Sem screenshot novo necessário — evolução cirúrgica reproduz protótipo já aprovado, adaptando empty states tolerantes pra backward compat Onda 5 e respeitando ZERO emoji em UI (skill pageheader-canon).

--- a/resources/js/Pages/Repair/ProducaoOficina/Index.charter.md
+++ b/resources/js/Pages/Repair/ProducaoOficina/Index.charter.md
@@ -40,6 +40,7 @@ Visão de produção em **kanban de 5 colunas** (Recepção → Diagnóstico →
   - **Abrir #V-NNNN** → dispatch `window.CustomEvent('oimpresso:open-venda', { detail: { venda_id } })` — listener em `Sells/Index.tsx` (Worker A Onda 4) abre drawer SaleSheet (loose coupling)
   - **Imprimir recibo** → `window.open('/sells/{venda_id}/print', '_blank')` (rota Blade legacy preservada)
   - **Compartilhar** → Web Share API nativa (mobile/PWA share-sheet) com fallback `navigator.clipboard.writeText()` + toast Sonner (desktop). Payload `Venda #V-NNNN · R$ XX,XX · DD/MM/YYYY` + URL `/sells/{id}`. `AbortError` (user cancelou) tratado silenciosamente. (Onda 5 follow-up Worker 3 · 2026-05-25)
+- **FASE B — VendaDerivadaCard evolution** (Wave Z-2 backend W2 `2f6f10fc8` · 2026-05-25): card mostra **breakdown** Peças vs Serviços (grid 2-col responsive · empilha em mobile) + linha Subtotal + Desconto (se > 0 · rose) + Impostos (se > 0 · slate); **badge fiscal** NF-e com 4 estados (`autorizada` verde + link DANFE clicável `window.open(/danfe/{id}, '_blank')` · `pendente` amber · `rejeitada` rose · `null` slate sutil "Sem nota fiscal" pra OS informal); **lista items expandível** disclosure pattern (collapsed por default · `▸ Ver N itens da venda` → `▾ Ocultar` · max 10 visíveis · "+ N adicionais" sumário). Prefix textual "Peça" / "Serviço" (skill `pageheader-canon` · ZERO emoji em UI). Empty states tolerantes preservam Onda 5 backward compat: `items_list` ausente/`[]` não renderiza breakdown nem disclosure; `fiscal: null` renderiza só badge "Sem nota fiscal".
 - Vocabulário shared multi-vertical preservado ([ADR 0121 §P8](../../../../memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md)) — `venda_derivada` é cross-vertical (OficinaAuto, ComunicacaoVisual, Vestuario)
 
 ---
@@ -55,12 +56,14 @@ Visão de produção em **kanban de 5 colunas** (Recepção → Diagnóstico →
 - ❌ Aprovação cliente *via* esta tela (botão "Reenviar" no drawer só dispara WhatsApp template — sem UI de aprovar/recusar aqui)
 - ❌ Edição inline em qualquer card
 - ❌ Tela específica per-vertical (Vestuario/ComVisual/OficinaAuto NÃO tem `/vestuario/producao-oficina` — todas usam `/repair/producao-oficina` parametrizado por `business.repair_settings`)
-- ❌ **Onda 5 placeholder TODOs (charter aceita explícito):**
+- ❌ **Onda 5 / FASE B placeholder TODOs (charter aceita explícito):**
   - ~~Botão "Compartilhar" no card da venda derivada **sem ação por ora**~~ → **entregue Onda 5 follow-up Worker 3 (2026-05-25)** via Web Share API nativa + clipboard fallback + toast Sonner
-  - Breakdown peças/serviço no card (Cowork F1 tem mas payload `venda_derivada` Onda 2 não entrega esses fields — adiada pra wave futura quando Sells expor `itemsList`)
-  - Badges fiscais NF-e/NFS-e no card (wave futura · payload Onda 2 não entrega `fiscal` ainda)
+  - ~~Breakdown peças/serviço no card~~ → **entregue FASE B (2026-05-25)** após Wave Z-2 backend W2 (`2f6f10fc8`) expandir payload com `items_list` + `items_summary` (eager-load `sell_lines.product` anti-N+1)
+  - ~~Badges fiscais NF-e/NFS-e no card~~ → **entregue FASE B (2026-05-25)** apenas para NF-e (modelo 55/65). NFS-e segue Non-Goal — feature `NfeBrasil` não emite NFS-e ainda; quando emitir, expandir badge.
   - Edição inline da venda derivada (drawer só lê · CRUD vai pra `/sells/{id}/edit`)
   - Botão "Ver no Caixa do dia" (Sells/Caixa.tsx é Onda 6 wave separada · fora deste plano)
+  - Items list ilimitada — capamos em 10 visíveis + sumário "+ N adicionais" pra não estourar densidade do drawer (480px)
+  - Drilldown per-item (clicar num item → abrir detalhe) — fora do escopo; drawer Sells/SaleSheet já cobre
 
 ---
 
@@ -127,3 +130,4 @@ Vertical decide o que faz sentido. Vestuário pode ter `slots: [{key: "rack", la
 - ⏳ **US-REPA-003** — CI workflow `repair-shared-vocab.yml` que falha se `placa|vehicle|km|mecanico|elevador|box` voltar em `Modules/Repair/**` ou `resources/js/Pages/Repair/**`
 - ⏳ **US-REPA-004** — Vestuario/ComVisual/OficinaAuto seeders `RepairSettingsSeeder` populando `business.repair_settings` per-vertical
 - ✅ **US-REPA-INT-VND-5** — Onda 5 Integração Vendas × Oficina A1 KB-9.75 ([ADR 0192](../../../../memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md)): drawer card "Esta OS gerou venda #V-NNNN" + 3 CTAs (Abrir dispatch / Imprimir recibo / Compartilhar TODO). Adição cirúrgica preservando kanban + drag-drop + filtros + demais drawer sections.
+- ✅ **US-REPA-INT-VND-B** — FASE B VendaDerivadaCard evolution (Wave Z-2 backend `2f6f10fc8`): breakdown peças/serviço + badge fiscal NF-e (autorizada/pendente/rejeitada/null) + lista items expandível com cap 10 + "+ N adicionais". Empty states tolerantes (items vazio + fiscal null). Tokens `.ofc-venda-grid` / `.ofc-vc` / `.ofc-fb-*` Cowork preservados verbatim. Pest GUARDs file-content pattern: `ProducaoOficinaFaseBVendaDerivadaCardTest.php`.

--- a/resources/js/Pages/Repair/ProducaoOficina/Index.tsx
+++ b/resources/js/Pages/Repair/ProducaoOficina/Index.tsx
@@ -23,11 +23,46 @@ type Tone = 'slate' | 'blue' | 'amber' | 'violet' | 'emerald';
 // AND tem Transaction derivada (source='oficina'), o Controller (Onda 2) anexa este
 // shape ao card. Frontend renderiza card "Esta OS gerou venda" no drawer.
 // Vocabulário shared (ADR 0121 §P8): zero termos automotivos · cross-vertical.
+//
+// FASE B (2026-05-25 · Wave Z-2 backend W2 mergeado em main `2f6f10fc8`):
+// Payload expandido com items_list (breakdown produto/serviço), items_summary
+// (counts/totals/tax/discount) e fiscal (NF-e status/modelo/chave/DANFE).
+// Backward compat: keys core (id/invoice_no/final_total/transaction_date) preservadas.
+// Empty states tolerantes: items_list=[] OR fiscal=null não quebram render.
+interface VendaItem {
+  type: 'product' | 'service';
+  name: string;
+  qty: number;
+  unit_price: number;
+  subtotal: number;
+}
+
+interface VendaItemsSummary {
+  products_count: number;
+  products_total: number;
+  services_count: number;
+  services_total: number;
+  tax_total: number;
+  discount_total: number;
+}
+
+interface VendaFiscal {
+  status: 'autorizada' | 'pendente' | 'rejeitada';
+  modelo: string | null;       // '55' | '65' | 'NFSe' (Cowork pode trazer '65' como int — cast string)
+  chave: string | null;        // 44 dígitos SEFAZ
+  danfe_url: string | null;    // '/danfe/{id}'
+}
+
 interface VendaDerivada {
+  // Core (Onda 5 — sempre presente).
   id: number;
   invoice_no: string;
   final_total: number;
   transaction_date: string | null;  // ISO date 'YYYY-MM-DD'
+  // Fase B — expandido (Wave Z-2 W2). Opcionais pra backward compat.
+  items_list?: VendaItem[];
+  items_summary?: VendaItemsSummary;
+  fiscal?: VendaFiscal | null;
 }
 
 interface Card {
@@ -646,9 +681,20 @@ function TimelineEvent({
 //  3. "Compartilhar" → Web Share API nativa (mobile/PWA) + fallback
 //     navigator.clipboard.writeText() + toast Sonner (desktop · pattern Repair/JobSheet)
 //
-// Breakdown peças/serviço + badges fiscais NF-e/NFS-e do Cowork ficam pra wave
-// futura (charter Non-Goal · payload backend Onda 2 não entrega esses fields).
+// FASE B (2026-05-25 · pós Wave Z-2 backend W2 `2f6f10fc8`):
+// Card evoluído pra exibir breakdown peças/serviço + badge fiscal NF-e + lista
+// items_list collapsable. Tokens `.ofc-venda-grid` + `.ofc-vc` + `.ofc-fb-*`
+// mapeados verbatim do protótipo Cowork. Empty states tolerantes:
+//   - items_list ausente/[] → não renderiza breakdown nem lista expandível
+//   - fiscal null → renderiza badge "Sem nota fiscal" sutil (slate · OS informal)
+//   - fiscal.status 'autorizada' → verde + link DANFE clicável
+//   - fiscal.status 'pendente'   → amber "NF-e pendente SEFAZ"
+//   - fiscal.status 'rejeitada'  → rose "NF-e rejeitada"
+// Items list collapsed por default; user clica ▾ pra expandir. Max 10 visíveis
+// + "+N mais" sumário se exceder. Prefixo textual "Peça" / "Serviço" em vez de
+// emoji (skill pageheader-canon · ZERO emoji em UI).
 function VendaDerivadaCard({ venda }: { venda: VendaDerivada }) {
+  const [itemsExpanded, setItemsExpanded] = useState(false);
   const handleAbrir = () => {
     window.dispatchEvent(
       new CustomEvent('oimpresso:open-venda', {
@@ -700,14 +746,28 @@ function VendaDerivadaCard({ venda }: { venda: VendaDerivada }) {
     }
   };
 
-  const totalBR = venda.final_total.toLocaleString('pt-BR', {
-    style: 'currency',
-    currency: 'BRL',
-  });
+  const fmtBRL = (n: number) =>
+    n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+  const totalBR = fmtBRL(venda.final_total);
 
   const dataBR = venda.transaction_date
     ? new Date(venda.transaction_date + 'T00:00:00').toLocaleDateString('pt-BR')
     : '—';
+
+  // FASE B — empty states tolerantes (Wave Z-2 W2 backward compat).
+  const itemsList = venda.items_list ?? [];
+  const summary = venda.items_summary;
+  const hasBreakdown = !!summary && itemsList.length > 0;
+  const subtotal = summary
+    ? Number((summary.products_total + summary.services_total).toFixed(2))
+    : 0;
+  const fiscal = venda.fiscal ?? null;
+
+  // Max 10 items visíveis na lista expandida — resto vira "+N mais".
+  const VISIBLE_ITEMS_CAP = 10;
+  const visibleItems = itemsList.slice(0, VISIBLE_ITEMS_CAP);
+  const hiddenItemsCount = Math.max(0, itemsList.length - VISIBLE_ITEMS_CAP);
 
   return (
     <div className="ofc-venda-card relative mx-5 mt-4 mb-2 rounded-[10px] border border-emerald-600/70 bg-gradient-to-br from-emerald-50 to-amber-50/30 px-5 pt-5 pb-4">
@@ -741,6 +801,142 @@ function VendaDerivadaCard({ venda }: { venda: VendaDerivada }) {
           <div className="mt-0.5 text-sm font-semibold text-slate-900">{dataBR}</div>
         </div>
       </div>
+
+      {/* FASE B — Breakdown peças vs serviço (renderiza só se W2 backend entregou).
+          Grid 2-col responsive (empilha sm:grid-cols-2 → grid-cols-1 abaixo) +
+          linha subtotal · desconto · impostos quando aplicáveis. */}
+      {hasBreakdown && summary && (
+        <div className="ofc-venda-breakdown mb-3 rounded-md bg-white/65 px-3 py-2.5">
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <div>
+              <div className="text-[9.5px] font-bold uppercase tracking-wider text-slate-500">
+                Peças
+              </div>
+              <div className="mt-0.5 text-[12.5px] font-semibold text-slate-900">
+                {summary.products_count} {summary.products_count === 1 ? 'item' : 'itens'} ·{' '}
+                {fmtBRL(summary.products_total)}
+              </div>
+            </div>
+            <div>
+              <div className="text-[9.5px] font-bold uppercase tracking-wider text-slate-500">
+                Serviços
+              </div>
+              <div className="mt-0.5 text-[12.5px] font-semibold text-slate-900">
+                {summary.services_count} {summary.services_count === 1 ? 'item' : 'itens'} ·{' '}
+                {fmtBRL(summary.services_total)}
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-2 space-y-0.5 border-t border-emerald-100 pt-2 text-[11px] text-slate-700">
+            <div className="flex items-center justify-between">
+              <span>Subtotal</span>
+              <span className="font-mono font-semibold text-slate-900">{fmtBRL(subtotal)}</span>
+            </div>
+            {summary.discount_total > 0 && (
+              <div className="flex items-center justify-between text-rose-700">
+                <span>Desconto</span>
+                <span className="font-mono font-semibold">-{fmtBRL(summary.discount_total)}</span>
+              </div>
+            )}
+            {summary.tax_total > 0 && (
+              <div className="flex items-center justify-between text-slate-700">
+                <span>Impostos</span>
+                <span className="font-mono font-semibold">+{fmtBRL(summary.tax_total)}</span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+
+      {/* FASE B — Badge fiscal (NF-e). 4 estados: autorizada (verde + DANFE link) ·
+          pendente (amber) · rejeitada (rose) · null (slate sutil "Sem nota fiscal").
+          Vocabulário shared: usa "NF-e" genérico (cross-vertical · OficinaAuto / ComVisual / Vestuario). */}
+      <div className="ofc-venda-fiscal mb-3 flex flex-wrap gap-1.5">
+        {fiscal === null && (
+          <span className="ofc-fb ofc-fb-na inline-flex items-center gap-1 rounded border border-slate-200 bg-white px-2 py-0.5 text-[11px] font-semibold text-slate-500">
+            Sem nota fiscal
+          </span>
+        )}
+        {fiscal?.status === 'autorizada' && (
+          <>
+            <span className="ofc-fb ofc-fb-ok inline-flex items-center gap-1 rounded border border-emerald-200 bg-white px-2 py-0.5 text-[11px] font-semibold text-emerald-700">
+              NF-e{fiscal.modelo ? ` ${fiscal.modelo}` : ''} autorizada
+            </span>
+            {fiscal.danfe_url && (
+              <button
+                type="button"
+                onClick={() => window.open(fiscal.danfe_url!, '_blank', 'noopener,noreferrer')}
+                aria-label={`Abrir DANFE da venda ${venda.invoice_no}`}
+                className="inline-flex items-center gap-1 rounded border border-emerald-200 bg-white px-2 py-0.5 text-[11px] font-semibold text-emerald-700 hover:bg-emerald-50 focus:outline-none focus:ring-2 focus:ring-emerald-500/40"
+              >
+                DANFE ↗
+              </button>
+            )}
+          </>
+        )}
+        {fiscal?.status === 'pendente' && (
+          <span className="ofc-fb ofc-fb-wait inline-flex items-center gap-1 rounded border border-amber-200 bg-white px-2 py-0.5 text-[11px] font-semibold text-amber-700">
+            NF-e{fiscal.modelo ? ` ${fiscal.modelo}` : ''} pendente SEFAZ
+          </span>
+        )}
+        {fiscal?.status === 'rejeitada' && (
+          <span className="ofc-fb ofc-fb-bad inline-flex items-center gap-1 rounded border border-rose-200 bg-white px-2 py-0.5 text-[11px] font-semibold text-rose-700">
+            NF-e{fiscal.modelo ? ` ${fiscal.modelo}` : ''} rejeitada
+          </span>
+        )}
+      </div>
+
+      {/* FASE B — Lista items expandível (collapsed por default · disclosure pattern).
+          Prefix textual "Peça" / "Serviço" (skill pageheader-canon: ZERO emoji em UI). */}
+      {hasBreakdown && (
+        <div className="ofc-venda-items-toggle mb-3">
+          <button
+            type="button"
+            onClick={() => setItemsExpanded((v) => !v)}
+            aria-expanded={itemsExpanded}
+            aria-controls={`venda-items-${venda.id}`}
+            className="inline-flex items-center gap-1 text-[11px] font-semibold text-emerald-800 hover:text-emerald-900 focus:outline-none"
+          >
+            <span aria-hidden="true">{itemsExpanded ? '▾' : '▸'}</span>
+            {itemsExpanded ? 'Ocultar' : 'Ver'} {itemsList.length}{' '}
+            {itemsList.length === 1 ? 'item da venda' : 'itens da venda'}
+          </button>
+          {itemsExpanded && (
+            <ul
+              id={`venda-items-${venda.id}`}
+              className="ofc-venda-items mt-2 space-y-1 rounded-md bg-white/65 px-3 py-2 text-[11.5px] text-slate-800"
+            >
+              {visibleItems.map((item, idx) => (
+                <li
+                  key={`${item.type}-${item.name}-${idx}`}
+                  className="flex items-baseline justify-between gap-2"
+                >
+                  <span className="truncate">
+                    <span className="font-semibold text-slate-600">
+                      {item.type === 'service' ? 'Serviço' : 'Peça'}
+                    </span>
+                    <span className="text-slate-400"> · </span>
+                    <span>{item.name}</span>
+                    <span className="text-slate-400">
+                      {' · '}
+                      {item.qty.toLocaleString('pt-BR')}× {fmtBRL(item.unit_price)}
+                    </span>
+                  </span>
+                  <span className="font-mono font-semibold text-slate-900">
+                    {fmtBRL(item.subtotal)}
+                  </span>
+                </li>
+              ))}
+              {hiddenItemsCount > 0 && (
+                <li className="pt-1 text-[11px] italic text-slate-500">
+                  + {hiddenItemsCount} {hiddenItemsCount === 1 ? 'item' : 'itens'} adicionais
+                </li>
+              )}
+            </ul>
+          )}
+        </div>
+      )}
 
       <div className="ofc-venda-actions flex flex-wrap gap-1.5">
         <button


### PR DESCRIPTION
## Resumo

Evolui o card "Esta OS gerou a venda #V-NNNN" no drawer de `Repair/ProducaoOficina/Index.tsx` consumindo o payload expandido entregue pela **Wave Z-2 backend W2** (`2f6f10fc8` — PR #1510).

Antes (Onda 5, `94300b057`): card mostrava Total + Data + 3 CTAs (Abrir/Imprimir/Compartilhar).
Agora (FASE B): card mostra Total + Data + **breakdown peças/serviço + linha subtotal/desconto/impostos + badge fiscal NF-e (4 estados) + lista items expandível** + 3 CTAs Onda 5/W3 preservados.

## Mudanças

### `resources/js/Pages/Repair/ProducaoOficina/Index.tsx` (+199 / -9)
- Novas interfaces TypeScript: `VendaItem` · `VendaItemsSummary` · `VendaFiscal`
- `VendaDerivada.items_list` / `items_summary` / `fiscal` opcionais (backward compat Onda 5)
- `VendaDerivadaCard`:
  - `useState(false)` pro `itemsExpanded` (collapsed default)
  - Bloco breakdown 2-col responsive (`sm:grid-cols-2` → `grid-cols-1`)
  - Linha Subtotal sempre · Desconto (rose, condicional `> 0`) · Impostos (slate, condicional `> 0`)
  - Badge fiscal 4 estados — `autorizada` (verde + DANFE link `window.open('/danfe/{id}', '_blank')`) · `pendente` (amber) · `rejeitada` (rose) · `null` (slate "Sem nota fiscal" sutil)
  - Lista disclosure `▸/▾ Ver N itens` (collapsed default · cap 10 visíveis + sumário `"+ N adicionais"`)
  - Prefix textual `Peça · {name}` / `Serviço · {name}` — **ZERO emoji em UI** (skill `pageheader-canon`)
  - `aria-expanded` + `aria-controls` no disclosure + `aria-label` no DANFE
- **Empty states tolerantes** — `const hasBreakdown = !!summary && itemsList.length > 0;` gateia os blocos breakdown e disclosure; `fiscal === null` renderiza apenas badge "Sem nota fiscal"
- Handlers Onda 5+W3 **INTACTOS** (`handleAbrir` dispatch CustomEvent · `handleImprimirRecibo` window.open · `handleCompartilhar` Web Share API + clipboard fallback + toast Sonner)

### `resources/js/Pages/Repair/ProducaoOficina/Index.charter.md` (+9 / -1)
- Move breakdown peças/serviço + badge fiscal NF-e de **Non-Goals (placeholder TODO Onda 5)** pra **Goals** como `US-REPA-INT-VND-B`
- Mantém `Non-Goals`: NFS-e (NfeBrasil não emite ainda) · edição inline · lista items ilimitada · drilldown per-item · botão "Caixa do dia"

### `Modules/Repair/Tests/Feature/ProducaoOficinaFaseBVendaDerivadaCardTest.php` (+207, novo)
**15 Pest GUARDs file-content pattern** (espelha `ProducaoOficinaOnda5CompartilharTest`):
1. Interfaces TS definidas (`VendaItem` / `VendaItemsSummary` / `VendaFiscal`)
2. `VendaDerivada` fields opcionais (backward compat)
3. `useState(false)` pro `itemsExpanded` collapsed default + `aria-expanded`
4. Breakdown renderiza Peças + Serviços formatados BRL
5. Subtotal sempre + Desconto/Impostos condicionais (`> 0`)
6. Badge fiscal 4 estados completos
7. `autorizada` tem botão DANFE com `window.open` + aria-label
8. Prefix textual "Peça"/"Serviço" (anti-regressão: proíbe emoji 📦 🛠 🔧)
9. Cap 10 visíveis + sumário "adicionais"
10. Disclosure usa símbolos canônicos ▸/▾
11. Empty states gateados por `hasBreakdown`
12. Backward compat — keys core preservadas
13. Handlers Onda 5+W3 preservados (anti-regressão)
14. Vocabulário shared (zero termos automotivos NO CARD)
15. Multi-tenant Tier 0 — frontend NÃO dispara queries (sem `router/axios/fetch`)

**Resultado local:** `Tests: 15 passed (70 assertions) · Duration: 7.63s`

### `memory/requisitos/Repair/ProducaoOficina-r3-venda-derivada-expanded-visual-comparison.md` (+215, novo)
Visual-comparison r3 com 15 dimensões cobrindo:
- **Densidade informativa** (collapsed ~160-240px / expanded ~340-440px · justificativa cap 10)
- **Hierarquia visual interna** (scan vertical top-down pattern Linear/Notion)
- **Empty states tolerantes** (tabela 5 cenários payload × render)
- Tokens oklch Cowork preservados verbatim · vocabulário shared · acessibilidade WCAG AA · multi-tenant Tier 0 · performance · charter compliance · Pest GUARDs

## Decisões de UI tomadas

| Decisão | Justificativa |
|---|---|
| Items list **collapsed** por default | Densidade drawer 480px · pattern Notion/Linear |
| Cap **10 items** + "+ N adicionais" | UX simples sem scroll-in-scroll · drilldown via "Abrir #V-NNNN" |
| Prefix textual "Peça"/"Serviço" | Skill `pageheader-canon` ZERO emoji em UI |
| Símbolos Unicode ▸/▾ | Funciona em qualquer font · WCAG-friendly · zero deps |
| Badge "Sem nota fiscal" sutil slate | Sinaliza OS informal vs ausência de feature |
| DANFE como botão separado | Click-target 44×44 · aria-label dedicado |
| Subtotal sempre + Desconto/Impostos condicionais | Reduz noise visual |

## Backward compat / empty states tolerantes

| Payload | Render |
|---|---|
| Onda 5 puro (sem `items_list`, sem `fiscal`) | header + Total/Data + badge "Sem nota fiscal" + CTAs |
| W2: `items_list=[]`, `fiscal=null` | mesmo do Onda 5 (graceful) |
| W2: `items_list=[3]`, `fiscal=null` | + breakdown + disclosure + badge "Sem nota fiscal" |
| W2: `items_list=[5]`, `fiscal.status='autorizada'` | + breakdown + disclosure + badge verde + DANFE link |
| W2: `items_list=[12]`, `fiscal.status='pendente'` | + breakdown + disclosure (10 vis + "+2 adicionais") + badge amber |

## Vocabulário shared preservado

Pest GUARD `FASE B: vocabulário shared cross-vertical` extrai apenas o JSX dentro de `function VendaDerivadaCard` e proíbe `placa|vehicle|mecanico|elevador`. Card funciona pra OficinaAuto (carro), ComunicacaoVisual (arte/lona), Vestuario (roupa reparada). CI guard `repair-shared-vocab.yml` segue verde.

## Refs

- ADR [0192](memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md) — Auto-faturar OS→Venda
- ADR [0121 §P8](memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md) — Vocabulário shared
- ADR [0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md) — Multi-tenant Tier 0
- PR #1510 (`2f6f10fc8`) — Wave Z-2 backend W2 (buildVendaDerivadaPayload expand)
- Worker B Onda 5 (`94300b057`) — VendaDerivadaCard inicial
- Worker 3 W3 (`129dab230`) — Compartilhar Web Share

## Test plan

- [ ] CI verde (Pest 15 GUARDs + TypeScript build + lint + repair-shared-vocab.yml)
- [ ] Smoke manual: abrir drawer de OS na coluna "Pronto" com Transaction derivada — verificar breakdown + badge fiscal + disclosure
- [ ] Smoke empty state: OS sem NF emitida → badge "Sem nota fiscal" sutil; OS sem items → sem breakdown
- [ ] Smoke responsive: viewport mobile → grid breakdown empilha 1-col

🤖 Generated with [Claude Code](https://claude.com/claude-code)