### PR TITLE
fix(contacts): ContactController::store retorna Inertia em vez de JSON puro

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -1254,6 +1254,30 @@ class ContactController extends Controller
             ];
         }
 
+        // Inertia-aware response (bug fix 2026-05-25 -- Wagner reportou modal
+        // "All Inertia requests must receive a valid Inertia response, however
+        // a plain JSON response was received" ao salvar cliente novo via
+        // /contacts/create). Tela Inertia espera redirect com headers proprios;
+        // retornar array vira JSON puro e Inertia client lanca modal de erro.
+        //
+        // Detecta via X-Inertia header e converte pra Inertia-friendly:
+        //   sucesso -> redirect()->route('contacts.index') com flash
+        //   erro    -> back()->withInput()->withErrors([...])
+        //
+        // Legacy AJAX/cURL sem header X-Inertia mantem JSON UPOS pra
+        // back-compat com integracoes externas.
+        if ($request->header('X-Inertia')) {
+            if (! empty($output['success'])) {
+                return redirect()
+                    ->route('contacts.index')
+                    ->with('status', $output['msg'] ?? __('contact.added_success'));
+            }
+
+            return back()
+                ->withInput()
+                ->withErrors(['msg' => $output['msg'] ?? __('messages.something_went_wrong')]);
+        }
+
         return $output;
     }
 


### PR DESCRIPTION
## Bug em prod (smoke 2026-05-25)

Wagner reportou \"erro no gravar cliente\". Reproduzido:

1. Acessar \`/cliente\` (drawer 760 listagem)
2. Clicar \`+ Novo cliente\` → leva pra \`/contacts/create?type=customer\` (Blade legacy Inertia)
3. Preencher Nome → clicar \`Salvar cliente\`
4. **Modal Inertia genérica:**

\`\`\`
All Inertia requests must receive a valid Inertia response,
however a plain JSON response was received.

{\"success\":false,\"msg\":\"Algo deu errado, por favor, tente novamente mais tarde\"}
\`\`\`

## Causa raiz

\`ContactController::store\` retorna **array** em TODOS os caminhos (sucesso + catch Exception). Laravel converte automaticamente pra JSON. Frontend Inertia espera redirect/render com headers próprios; JSON puro quebra Inertia client → modal de erro.

\`\`\`php
} catch (\Exception \$e) {
    \$output = ['success' => false, 'msg' => __('messages.something_went_wrong')];
}
return \$output;  // ← Array → JSON → modal Inertia
\`\`\`

## Fix (caminho A aprovado Wagner)

Detecta header \`X-Inertia\` no request e converte response pra Inertia-friendly:

| Caso | Antes | Depois |
|---|---|---|
| Sucesso Inertia | JSON \`{success:true,...}\` | \`redirect()->route('contacts.index')->with('status', $msg)\` |
| Erro Inertia | JSON \`{success:false,msg}\` | \`back()->withInput()->withErrors(['msg' => $msg])\` |
| AJAX/cURL legacy | JSON | JSON (back-compat) |

## Test plan

- [x] Bug reproduzido localmente via Chrome MCP smoke
- [ ] Pós-deploy: criar cliente novo via \`/contacts/create\` → redirect pra \`/contacts\` (lista) com toast sucesso
- [ ] Se exception interna: \`back()\` preserva campos digitados + msg erro inline
- [ ] Legacy AJAX (sem header \`X-Inertia\`) continua recebendo JSON

## Gap arquitetural restante (próxima onda)

Tela \`/contacts/create\` é Blade legacy. [ADR 0179](memory/decisions/0179-cliente-drawer-760px-substitui-show-fullpage.md) cobriu Show, não Create. Onda futura: migrar Create pra drawer 760 modo 'novo' (\`contact.id=null\`). Esforço estimado ~6-10h IA-pair.

Este PR é **hotfix tático** pra desbloquear cadastros AGORA — Larissa biz=4 + outros businesses dependem disso.

## Família de bugs relacionados (não-regressão)

| PR | Bug | Origem |
|---|---|---|
| [#1514](https://github.com/wagnerra23/oimpresso.com/pull/1514) | \`city_code\` 4d→7d IBGE | Frontend silencioso PATCH 422 |
| **este** | \`store\` JSON→Inertia | Backend retornava JSON pra Inertia |

Ambos descobertos via smoke prod Wagner 2026-05-23/25 — padrão de **bugs-zumbi** invisíveis na UI principal mas que quebram fluxo crítico.

🤖 Generated with [Claude Code](https://claude.com/claude-code)