### PR TITLE
feat(cliente): + Novo cliente abre drawer 760 modo 'novo' (substitui /contacts/create Blade)

### DIFF
--- a/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
+++ b/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
@@ -88,6 +88,79 @@ class ClienteAutosaveController extends Controller
     private const CONTACT_STATUSES = ['active', 'inactive', 'blocked'];
 
     /**
+     * POST /cliente/draft
+     *
+     * Cria um Contact placeholder vazio multi-tenant + retorna o `id` pro
+     * frontend abrir o drawer 760 em modo 'novo cliente'. Pattern Linear/Notion:
+     * usuário NÃO preenche form antes de salvar — drawer abre direto com row
+     * pré-criada, autosave on blur preenche conforme ele digita.
+     *
+     * Substitui o fluxo legacy Blade /contacts/create que tem 2 problemas:
+     *   1. Render de erros Inertia em Blade legacy falha (bug fix #1517 sintoma)
+     *   2. UX descontinua entre criar (form full-page) e editar (drawer 760)
+     *
+     * Body: opcional. Aceita `type` ('customer'|'supplier'|'both') pra
+     * pré-classificar; default 'customer'.
+     *
+     * Response: 201 + {id, success:true}
+     *
+     * Multi-tenant Tier 0 (ADR 0093): business_id forçado session('user.business_id').
+     * Permission: customer.create OR supplier.create OR ambos (depende do type).
+     * Created_by: session('user.id').
+     *
+     * NÃO chama event `ContactCreatedOrModified` aqui — disparado quando autosave
+     * preenche os primeiros campos significativos (name não vazio).
+     *
+     * @see Modules\Crm\Http\Controllers\ClienteAutosaveController::identificacao
+     * @see resources/js/Pages/Cliente/Index.tsx — botão 'Novo cliente' chama esta rota
+     */
+    public function draft(Request $request): JsonResponse
+    {
+        $type = (string) $request->input('type', 'customer');
+        if (! in_array($type, ['customer', 'supplier', 'both'], true)) {
+            $type = 'customer';
+        }
+
+        // Permission gate matricial — coerente com locateContact().
+        $user = auth()->user();
+        $canCustomer = $user->can('customer.create');
+        $canSupplier = $user->can('supplier.create');
+
+        $allowed = match ($type) {
+            'supplier' => $canSupplier,
+            'customer' => $canCustomer,
+            'both' => ($canCustomer && $canSupplier),
+            default => false,
+        };
+
+        if (! $allowed) {
+            return response()->json(['message' => 'Sem permissao pra criar contato deste tipo'], 403);
+        }
+
+        $businessId = (int) $request->session()->get('user.business_id');
+        if ($businessId <= 0) {
+            return response()->json(['message' => 'Sessao sem business_id'], 403);
+        }
+
+        $userId = (int) $request->session()->get('user.id');
+
+        // Cria placeholder vazio — `name` vazio sinaliza modo 'novo' pro frontend.
+        // contact_status='active' pra aparecer na listagem default + index.
+        $contact = Contact::create([
+            'business_id' => $businessId,
+            'created_by' => $userId,
+            'type' => $type,
+            'name' => '',
+            'contact_status' => 'active',
+        ]);
+
+        return response()->json([
+            'success' => true,
+            'id' => (int) $contact->id,
+        ], 201);
+    }
+
+    /**
      * PATCH /cliente/{id}/identificacao
      *
      * Campos permitidos: tipo, name, fantasia, tax_number, ie, rg, nascimento, cargo.

--- a/Modules/Crm/Routes/web.php
+++ b/Modules/Crm/Routes/web.php
@@ -102,6 +102,13 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     ->prefix('cliente')
     ->name('cliente.')
     ->group(function () {
+        // POST /cliente/draft -- cria placeholder vazio + retorna id pro drawer
+        // 760 abrir em modo "novo cliente" (substitui /contacts/create Blade legacy).
+        // Throttle 30/min anti-abuso (Larissa biz=4 max ~30 cadastros/dia).
+        Route::post('draft', [\Modules\Crm\Http\Controllers\ClienteAutosaveController::class, 'draft'])
+            ->middleware('throttle:30,1')
+            ->name('draft.create');
+
         // 5 endpoints autosave (Q2 inline -- debounce 800ms client-side).
         Route::patch('{id}/identificacao', [\Modules\Crm\Http\Controllers\ClienteAutosaveController::class, 'identificacao'])
             ->whereNumber('id')

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -362,6 +362,48 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
   const [sortDir, setSortDir] = useState<SortDir>('asc');
   const [openContactId, setOpenContactId] = useState<number | null>(null);
 
+  // ADR 0179 evolução 2026-05-25 — "Novo cliente" via drawer 760 modo 'novo'.
+  // POST /cliente/draft cria placeholder vazio + retorna id, drawer abre sobre ele,
+  // autosave on blur preenche conforme user digita. Substitui /contacts/create Blade
+  // (que tinha bugs Inertia handler + validation errors invisíveis na Blade).
+  const [creatingDraft, setCreatingDraft] = useState(false);
+
+  const createNewContactDraft = useCallback(async () => {
+    if (creatingDraft) return;
+    setCreatingDraft(true);
+    try {
+      const csrf = (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement | null)?.content ?? '';
+      const draftType = activeType === 'fornecedor' ? 'supplier' : 'customer';
+      const r = await fetch('/cliente/draft', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'X-CSRF-TOKEN': csrf,
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        body: JSON.stringify({ type: draftType }),
+      });
+      if (!r.ok) {
+        // eslint-disable-next-line no-console
+        console.error('[ClienteIndex] POST /cliente/draft falhou', r.status);
+        alert('Não foi possível criar novo cliente. Tente de novo ou contate suporte.');
+        return;
+      }
+      const json = await r.json();
+      const newId = Number(json?.id ?? 0);
+      if (newId > 0) {
+        setOpenContactId(newId);
+      }
+    } catch (err) {
+      // eslint-disable-next-line no-console
+      console.error('[ClienteIndex] POST /cliente/draft network', err);
+      alert('Falha de rede ao criar cliente. Verifique sua conexão e tente de novo.');
+    } finally {
+      setCreatingDraft(false);
+    }
+  }, [activeType, creatingDraft]);
+
   // Wave G — 5 filtros adicionais (Status legacy já tratado em statusFilter).
   // Tipo PF/PJ · UF (27) · Tags (multi) · Sem compra há (5 ranges) · Saldo (devedor/zerado).
   const [tipoFilter, setTipoFilter] = useState<string>('');
@@ -769,7 +811,8 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
             {props.permissions.create && activeType !== 'all' && (
               <PageHeaderPrimary
                 label={`Novo ${ROLE_TITLE[activeType].singular}`}
-                href={`/contacts/create?type=${activeType}`}
+                onClick={createNewContactDraft}
+                disabled={creatingDraft}
               />
             )}
           </div>
@@ -1178,6 +1221,7 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
             setSearch('');
             setFocusedIndex(null);
           }}
+          onCreateDraft={createNewContactDraft}
         />
       )}
       {cheatOpen && <CheatSheet onClose={() => setCheatOpen(false)} />}
@@ -1966,11 +2010,13 @@ function CommandPalette({
   onClose,
   onSelectContact,
   onClearFilters,
+  onCreateDraft,
 }: {
   rows: ClienteRow[];
   onClose: () => void;
   onSelectContact: (id: number) => void;
   onClearFilters: () => void;
+  onCreateDraft: () => void;
 }) {
   const [query, setQuery] = useState('');
   const [selectedIdx, setSelectedIdx] = useState(0);
@@ -1989,7 +2035,7 @@ function CommandPalette({
   }, [rows, query]);
 
   const actions: PaletteAction[] = [
-    { id: 'novo', label: 'Novo cliente', icon: Plus, href: '/contacts/create?type=customer' },
+    { id: 'novo', label: 'Novo cliente', icon: Plus, action: () => { onClose(); onCreateDraft(); } },
     { id: 'importar', label: 'Importar clientes', icon: Upload, href: '/contacts/import' },
     { id: 'clear', label: 'Limpar filtros desta página', icon: X, action: onClearFilters },
   ];


### PR DESCRIPTION
## Summary

Fecha gap arquitetural [ADR 0179](memory/decisions/0179-cliente-drawer-760px-substitui-show-fullpage.md) — drawer 760 cobre Show + Edit há tempo, mas **Create** ainda dependia da tela Blade legacy \`/contacts/create\`. Wagner reportou erro \"gravar cliente\" e aprovou migração canônica.

## Bug que isso resolve definitivamente

| PR | O que resolveu | Gap residual |
|---|---|---|
| [#1517](https://github.com/wagnerra23/oimpresso.com/pull/1517) | Modal Inertia genérica \"JSON response\" | Errors Inertia não visíveis na Blade legacy |
| **este** | **Migra Create pra drawer 760** | — fecha gap |

## UX (padrão Linear/Notion)

Antes: \"+ Novo cliente\" → \`/contacts/create\` (Blade full-page) → preencher TUDO → Salvar → bug Inertia.

Agora: \"+ Novo cliente\" → \`POST /cliente/draft\` cria placeholder vazio → drawer 760 abre sobre id → user preenche tab Identificação digitando + autosave on blur → fecha drawer quando quiser (já salvou).

Sem form full-page, sem botão \"Salvar\" final, sem submit explícito.

## Backend

\`POST /cliente/draft\`:
- Permission gate matricial (\`customer.create\` OR \`supplier.create\` conforme \`type\`)
- Multi-tenant Tier 0: \`business_id\` forçado \`session('user.business_id')\`
- Cria Contact com: \`business_id\`, \`type='customer'\` (default), \`name=''\`, \`contact_status='active'\`
- Retorna 201 + \`{id, success:true}\`
- Throttle 30/min (Larissa biz=4 max ~30 cadastros/dia)

## Frontend

- State \`creatingDraft\` (loading) + callback \`createNewContactDraft\`
- \`PageHeaderPrimary\` \"Novo cliente\" usa \`onClick\` em vez de \`href\`
- \`CommandPalette\` action \"Novo cliente\" usa nova prop \`onCreateDraft\`
- Após POST /draft sucesso: \`setOpenContactId(newId)\` → drawer 760 abre normalmente

## Test plan

- [ ] Smoke pós-deploy: clicar \"+ Novo cliente\" → drawer abre vazio → digitar CNPJ no tab Identificação → Buscar CNPJ → dados preenchem → fechar → reabrir na lista (último item) → tudo persistido
- [ ] Cliente PJ: lookup CNPJ + endereço cross-tab funcionam normalmente
- [ ] Cliente PF: toggle PF → state mantém
- [ ] CmdK (Ctrl+K) → \"Novo cliente\" → mesmo fluxo
- [ ] Throttle 30/min: stress test 35 cliques rápidos → últimos retornam 429 graceful
- [ ] Multi-tenant: testar cross-business → 403 (business_id session enforcement)

## Não cobrado neste PR (gap residual, próxima onda)

- **Modo \"novo\" indicator visual** no drawer (header \"Novo cliente\" em vez do nome). Hoje header mostra nome vazio temporariamente até user digitar. Não bloqueia UX, mas polish.
- **Esconder tabs incompatíveis em modo novo** (IA, OSs). Hoje tabs aparecem normalmente — clicar mostra empty state.
- **Cron limpar drafts órfãos** (cliente criou draft mas nunca preencheu name). Hoje placeholder \`name=''\` fica na listagem como entry vazia até ser limpo manual.
- **Deprecar \`/contacts/create\` Blade legacy** + redirect → \`/cliente\`. Back-compat preservada por enquanto.

Tasks MCP P1 podem cobrir os 4 itens conforme aparecerem casos reais.

## Refs

- ADR 0179 (drawer 760 — agora também cobre Create)
- ADR 0093 (multi-tenant Tier 0)
- ADR 0186 IRREVOGÁVEL (SEFAZ Técnica C — drawer + CNPJ lookup canônico)
- PR #1517 (sintoma anterior — modal Inertia)
- Feedback Wagner 2026-05-25: \"erro no gravar cliente\"

🤖 Generated with [Claude Code](https://claude.com/claude-code)