### PR TITLE
fix(financeiro): caixa_bridge migration usa account_type_id (FK) não account_type (enum)

### DIFF
--- a/Modules/Financeiro/Database/Migrations/2026_05_21_220000_add_caixa_bridge_to_fin_titulos_and_contas.php
+++ b/Modules/Financeiro/Database/Migrations/2026_05_21_220000_add_caixa_bridge_to_fin_titulos_and_contas.php
@@ -93,16 +93,18 @@ return new class extends Migration
             }
 
             // 3a. Cria accounts dummy (core UPOS) — pra satisfazer FK 1-1
+            // Schema real UPOS (oimpresso): coluna é `account_type_id` FK pra `account_types` (nullable),
+            // NÃO `account_type` enum como assumia versão anterior desta migration (fix 2026-05-25).
             $accountId = DB::table('accounts')->insertGetId([
-                'business_id'    => $biz->id,
-                'name'           => 'Caixa Loja',
-                'account_number' => 'CAIXA-' . $biz->id,
-                'account_type'   => null, // UPOS enum: saving_current|capital|null — caixa fica null
-                'note'           => 'Conta-mãe consolidadora de fechamentos de caixa físico (ADR 0183)',
-                'created_by'     => 1, // System / Wagner-default
-                'is_closed'      => 0,
-                'created_at'     => now(),
-                'updated_at'     => now(),
+                'business_id'     => $biz->id,
+                'name'            => 'Caixa Loja',
+                'account_number'  => 'CAIXA-' . $biz->id,
+                'account_type_id' => null, // FK opcional — caixa não bate em saving/capital tipos
+                'note'            => 'Conta-mãe consolidadora de fechamentos de caixa físico (ADR 0183)',
+                'created_by'      => 1, // System / Wagner-default
+                'is_closed'       => 0,
+                'created_at'      => now(),
+                'updated_at'      => now(),
             ]);
 
             // 3b. Cria fin_contas_bancarias linkada a essa accounts


### PR DESCRIPTION
**Unblock fix** — migration `2026_05_21_220000_add_caixa_bridge_to_fin_titulos_and_contas` (ADR 0183) falhou em prod biz=1 hoje (2026-05-25) durante deploy Wave Z-2 da Integração Vendas × Oficina.

## Erro

\`\`\`
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'account_type' in 'INSERT INTO'
at Modules/Financeiro/Database/Migrations/2026_05_21_220000_add_caixa_bridge_to_fin_titulos_and_contas.php:96
\`\`\`

## Causa raiz

Schema real UPOS oimpresso 6.7-react tem coluna **\`account_type_id\` (int FK nullable)** apontando pra tabela \`account_types\`, NÃO \`account_type\` ENUM como o doc-comment da migration assumia.

Schema confirmado em prod (\`SHOW COLUMNS FROM accounts\`):
\`\`\`
['account_type_id', 'int(11)', 'YES']  ← real
\`\`\`

Doc-comment original mencionava 'UPOS enum aceita saving_current|capital|NULL' — pegadinha de drift entre fork UPOS docs antigos e schema real oimpresso.

## Diagnóstico

- Migration **NUNCA aplicada** (zero em \`migrations\` table)
- Zero accounts 'Caixa Loja' criados (passo 3a abortou antes do INSERT)
- Passos 1+2 (ALTER fin_titulos enum + ADD tipo_conta) já tinham rodado mas commit rollback automático Laravel
- **6 migrations pendentes** em prod biz=1 + biz=4 bloqueadas em cascata (Cliente drawer Wave Z-2)

## Fix

1 chave do array: \`'account_type' => null\` → \`'account_type_id' => null\` + comment atualizado.

Idempotente: rodando de novo, passos 1 (ALTER MODIFY) + 2 (Schema::hasColumn check) + 3 (jaExiste check) skip safe.

## Plano pós-merge

1. Wagner mergeia este PR
2. SSH Hostinger: \`git pull && php artisan migrate --force\`
3. Cascata: as 6 migrations pendentes aplicam em ordem
4. \`php artisan optimize:clear && optimize\`

Refs: [ADR 0183](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0183-caixa-fisico-bridge-financeiro-canon.md)