### PR TITLE
fix(financeiro): aba IA do drawer Unificado — ativa CSS canon

### DIFF
--- a/resources/css/fin-ia.css
+++ b/resources/css/fin-ia.css
@@ -44,6 +44,10 @@
   background: oklch(0.96 0.04 240);
   color: oklch(0.45 0.10 240);
 }
+.fin-cowork .fin-curadoria .fin-anomaly-ok {
+  background: oklch(0.97 0.03 145);
+  color: oklch(0.45 0.13 145);
+}
 .fin-cowork .fin-curadoria .fin-anomaly-ic {
   display: grid;
   place-items: center;

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -1323,7 +1323,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
             DENTRO do drawer (CSS vars + grid layouts + spacing). Root cause descoberto
             via JS check: drawerInsideFinCowork=false, audit-row display=list-item
             (deveria ser grid). */}
-        <SheetContent side="right" className="fin-cowork fin-drawer-wide w-[560px] sm:max-w-[560px]">
+        <SheetContent side="right" className="fin-cowork fin-curadoria fin-drawer-wide w-[560px] sm:max-w-[560px]">
           {selected && (
             <>
               {/* Onda 17 (2026-05-20) — Header canon match prototype financeiro-app.jsx:739-754.
@@ -1633,29 +1633,39 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                 </div>
               )}
 
-              {/* Aba IA — insights computacionais (Anomaly + Party History) */}
+              {/* Aba IA — insights computacionais (Anomaly + Party History)
+                  Wagner 2026-05-25: section headers `<h3>` ativam CSS canon
+                  `.fin-cowork .fin-ai-panel h3 { uppercase purple 295 }` que estava
+                  no-op por falta de markup. Wrapper `fin-curadoria` no
+                  SheetContent ativa background/border de .fin-anomaly/.fin-party-history. */}
               {drawerTab === 'ia' && (
-                <div className="mt-3 px-5 space-y-4 text-[13px] fin-ai-panel">
-                  <FinAnomalyDetector
-                    row={{
-                      id: selected.id,
-                      contraparte: selected.contraparte,
-                      categoria: selected.categoria,
-                      valor: selected.valor,
-                      vencimento: selected.vencimento,
-                      liquidacao: selected.liquidacao,
-                      status: selected.status,
-                      kind: selected.kind,
-                    }}
-                    all={lancamentos}
-                  />
+                <div className="mt-3 px-5 text-[13px] fin-ai-panel">
+                  <section>
+                    <h3>Anomalia de valor</h3>
+                    <FinAnomalyDetector
+                      row={{
+                        id: selected.id,
+                        contraparte: selected.contraparte,
+                        categoria: selected.categoria,
+                        valor: selected.valor,
+                        vencimento: selected.vencimento,
+                        liquidacao: selected.liquidacao,
+                        status: selected.status,
+                        kind: selected.kind,
+                      }}
+                      all={lancamentos}
+                    />
+                  </section>
 
-                  <FinPartyHistory
-                    currentRow={{ id: selected.id, contraparte: selected.contraparte }}
-                    all={lancamentos}
-                  />
+                  <section>
+                    <h3>Histórico com a contraparte</h3>
+                    <FinPartyHistory
+                      currentRow={{ id: selected.id, contraparte: selected.contraparte }}
+                      all={lancamentos}
+                    />
+                  </section>
 
-                  <p className="text-[11.5px] text-stone-500 italic pt-2 border-t border-stone-100">
+                  <p className="text-[11.5px] text-stone-500 italic pt-3 mt-3 border-t border-stone-100">
                     Insights computacionais · pure compute · Fase 2 plugará JanaService LLM
                   </p>
                 </div>

--- a/resources/js/Pages/Financeiro/Unificado/_components/FinAnomalyDetector.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/FinAnomalyDetector.tsx
@@ -72,7 +72,18 @@ interface FinAnomalyDetectorProps {
 export function FinAnomalyDetector({ row, all }: FinAnomalyDetectorProps) {
   const anomaly = useMemo(() => finAnomalyDetect(row, all), [row.id, row.valor, all]);
 
-  if (!anomaly) return null;
+  // Estado vazio canon — aba IA precisa de feedback explícito, não silêncio.
+  if (!anomaly) {
+    return (
+      <div className="fin-anomaly fin-anomaly-ok" data-kind="ok">
+        <span className="fin-anomaly-ic">✓</span>
+        <div className="fin-anomaly-body">
+          <b>Sem desvio detectado</b>
+          <small>Valor dentro do padrão histórico da contraparte.</small>
+        </div>
+      </div>
+    );
+  }
 
   const icon = anomaly.kind === 'high' ? '⚠' : '◇';
 


### PR DESCRIPTION
## Summary
- Aba IA do drawer Financeiro/Unificado renderizava flat (sem cards/headers canon) — CSS prefixado `.fin-cowork .fin-curadoria` ficava no-op porque Sheet (Portal Radix) renderiza fora do wrapper raiz.
- `FinAnomalyDetector` retornava `null` quando não havia anomalia (maioria dos casos) → aba parecia vazia sem feedback.
- Sem `<h3>` sections, regra canon `.fin-ai-panel h3 { uppercase purple 295 }` (cowork-canon-financeiro-bundle.css:7951) não tinha onde aplicar.

## Mudanças (3 arquivos · +47/-22)
- **Index.tsx:1326** — `SheetContent` ganha `fin-curadoria` na className → ativa background/border/radius dos cards `.fin-anomaly` e `.fin-party-history` dentro do drawer.
- **Index.tsx:1636-1672** — Aba IA reescrita com 2 `<section><h3>` ("Anomalia de valor" / "Histórico com a contraparte") → ativa header canon uppercase roxo 295.
- **FinAnomalyDetector.tsx:75-87** — `return null` → card canon `✓ Sem desvio detectado` (variante nova `.fin-anomaly-ok`). Aba IA tem feedback explícito em todos os casos.
- **fin-ia.css:46-49** — Nova variante `.fin-anomaly-ok` (verde 145 oklch) consistente com a paleta semântica das outras severities.

## Test plan
- [ ] Após deploy, abrir `/financeiro/unificado` → clicar em qualquer linha → aba "✦ IA"
- [ ] Esperado: 2 headers UPPERCASE roxo ("ANOMALIA DE VALOR" / "HISTÓRICO COM A CONTRAPARTE"), cards com background/border canon, e card verde "✓ Sem desvio detectado" quando o lançamento está dentro da média
- [ ] Validar com lançamento que dispare anomalia real (>25% desvio vs média da contraparte) — card deve aparecer laranja/azul conforme severity
- [ ] Não-regressão aba Detalhes e Editar (mesmo SheetContent agora tem `fin-curadoria`, mas só ativa regras de `.fin-anomaly` e `.fin-party-history` que só vivem na aba IA)

## Escopo NÃO incluído (desmarcados pelo Wagner nesta rodada)
- Footer sticky-bottom (botão Editar no meio da aba Detalhes)
- Padronizar selects da toolbar (`Todas as contas` / `Todo o plano de contas` com estilos divergentes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)