### PR TITLE
fix(cliente): drawer modo novo - router.reload({only:[customers]}) antes de abrir

### DIFF
--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -455,7 +455,29 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
       const json = await r.json();
       const newId = Number(json?.id ?? 0);
       if (newId > 0) {
-        setOpenContactId(newId);
+        // Hotfix 2026-05-25 — bug reportado Wagner "endereço não traz, drawer tab
+        // vazia". Causa: ClienteSheet faz `rows.find(r => r.id === contactId)` mas
+        // o draft recém-criado NÃO está em rows (snapshot listagem). Resultado:
+        // contact = null → IdentificacaoTab.contact = undefined → tab vazia.
+        //
+        // Fix: router.reload({only:['customers']}) PRIMEIRO pra puxar a row nova
+        // do backend, AÍ setOpenContactId quando rows estão atualizados. Inertia
+        // garante sequência via callback onSuccess.
+        router.reload({
+          only: ['customers'],
+          preserveScroll: true,
+          preserveState: true,
+          onSuccess: () => {
+            setOpenContactId(newId);
+          },
+          onError: () => {
+            // Mesmo se reload falhar, abre drawer — autosave on blur ainda persiste,
+            // só que header mostra "Cliente" placeholder até user digitar nome.
+            // eslint-disable-next-line no-console
+            console.warn('[ClienteIndex] router.reload pós-draft falhou — abrindo drawer com fallback');
+            setOpenContactId(newId);
+          },
+        });
       }
     } catch (err) {
       // eslint-disable-next-line no-console


### PR DESCRIPTION
## Bug Wagner reportou (smoke prod)

"não está trazendo o endereço, está salvando?" — drawer abre vazio.

## Causa raiz (1 linha)

ClienteSheet faz `rows.find(r => r.id === contactId)`. Draft recém-criado NÃO está em rows (snapshot Inertia inicial) → contact=null → tab vazia.

## Fix

`router.reload({only:['customers'], onSuccess: () => setOpenContactId(newId)})` antes de abrir drawer.

## Auto-crítica

PR #1519 foi mergeado sem teste E2E real. Reportei sucesso baseado em smoke superficial (só vi drawer abrir, sem digitar nada). Lição: testar de verdade antes de declarar 'funcionando'.

🤖 Generated with [Claude Code](https://claude.com/claude-code)