### PR TITLE
feat(compras): C1 convergência — cockpit /compras delega CRUD pra /purchases/* Inertia

### DIFF
--- a/Modules/Compras/Http/Controllers/ComprasController.php
+++ b/Modules/Compras/Http/Controllers/ComprasController.php
@@ -55,10 +55,23 @@ class ComprasController extends Controller
 
         $compraId = (int) $request->query('compra_id', 0);
 
+        // C1 convergência (ADR compras-purchase-convergencia-c1) — botão "+ Nova
+        // compra" e AcoesDropdown "Editar/Excluir" delegam /purchases/* Inertia
+        // via router.visit. Permissions vêm do trilho A (Purchase MWART Wave 2
+        // B5), não compras.* — alias só em V2 se Wagner mantiver módulo como
+        // conceito separado.
+        $user = auth()->user();
+
         return Inertia::render('Compras/Index', [
             'filters' => $filters,
 
             'selected_id' => $compraId ?: null,
+
+            'permissions' => [
+                'create' => $user->can('purchase.create'),
+                'update' => $user->can('purchase.update'),
+                'delete' => $user->can('purchase.delete'),
+            ],
 
             'kpis' => Inertia::defer(
                 fn () => $this->comprasService->calcularKpis($businessId)

--- a/Modules/Compras/Http/Controllers/DataController.php
+++ b/Modules/Compras/Http/Controllers/DataController.php
@@ -97,11 +97,13 @@ class DataController extends Controller
             // ADR 0180 Fase 4 Wave B (2026-05-21): entry principal declara
             // atalho kbd + primary action + ghosts tabs.
             //  - `shortcut` G S → atalho overlay (Suprimentos/Estoque)
-            //  - `primary`     → "Nova compra" (rota /compras/create chega na Wave 3
-            //    do scaffold — declarado pra contrato sidebar v3, frontend pode
-            //    exibir 404/coming-soon enquanto não migra)
+            //  - `primary`     → "Nova compra" delega trilho A Purchase MWART
+            //    Wave 2 B5 via /purchases/create Inertia (ADR
+            //    compras-purchase-convergencia-c1 · 2026-05-25). Frontend usa
+            //    router.visit pra injetar header X-Inertia e disparar dual-path
+            //    no PurchaseController:400 → Purchase/Create.tsx React.
             //  - `ghosts`      → Lista (index Wave 1); demais sub-views (importar XML,
-            //    NF entrada, etc) entram nas Waves 3-6 do SPEC.
+            //    NF entrada, etc) entram nas Waves 6+ do SPEC.
             $menu->url(
                 action([\Modules\Compras\Http\Controllers\ComprasController::class, 'index']),
                 'Compras',
@@ -111,7 +113,7 @@ class DataController extends Controller
                     'shortcut' => 'G S',
                     'primary'  => [
                         'label'    => 'Nova compra',
-                        'href'     => '/compras/create',
+                        'href'     => '/purchases/create',
                         'shortcut' => 'N',
                     ],
                     'ghosts'   => [

--- a/Modules/Compras/Tests/Feature/ComprasIndexTest.php
+++ b/Modules/Compras/Tests/Feature/ComprasIndexTest.php
@@ -25,9 +25,15 @@ class ComprasIndexTest extends TestCase
         parent::setUp();
 
         // Suffix #1 (biz_id=1) — convenção UltimatePOS spatie/laravel-permission.
-        $perm = Permission::firstOrCreate(['name' => 'compras.view', 'guard_name' => 'web']);
+        $permView = Permission::firstOrCreate(['name' => 'compras.view', 'guard_name' => 'web']);
+        // C1 convergência (ADR compras-purchase-convergencia-c1) — botão "+ Nova
+        // compra" + AcoesDropdown Editar/Excluir gateiam por purchase.* (trilho
+        // A MWART), não compras.*. Admin#1 recebe todas pras smoke tests.
+        $permPurchaseCreate = Permission::firstOrCreate(['name' => 'purchase.create', 'guard_name' => 'web']);
+        $permPurchaseUpdate = Permission::firstOrCreate(['name' => 'purchase.update', 'guard_name' => 'web']);
+        $permPurchaseDelete = Permission::firstOrCreate(['name' => 'purchase.delete', 'guard_name' => 'web']);
         $role = Role::firstOrCreate(['name' => 'admin#1', 'guard_name' => 'web']);
-        $role->givePermissionTo($perm);
+        $role->givePermissionTo([$permView, $permPurchaseCreate, $permPurchaseUpdate, $permPurchaseDelete]);
 
         $this->admin = User::factory()->create(['business_id' => 1]);
         $this->admin->assignRole($role);
@@ -62,5 +68,62 @@ class ComprasIndexTest extends TestCase
             ->get('/compras');
 
         $response->assertStatus(403);
+    }
+
+    /**
+     * C1 convergência — prop `permissions.create` vem de `purchase.create` (trilho A
+     * MWART), não `compras.create`. Frontend usa o gate pra mostrar/ocultar botão
+     * "+ Nova compra" que delega `/purchases/create` via `router.visit`.
+     *
+     * ADR `compras-purchase-convergencia-c1` review trigger #4 ativa SE gap reportado:
+     * user com `compras.view` mas SEM `purchase.create` vê cockpit sem o botão.
+     */
+    public function test_c1_prop_permissions_create_resolve_via_purchase_create(): void
+    {
+        $response = $this->actingAs($this->admin)
+            ->withSession(['user' => ['business_id' => 1, 'id' => $this->admin->id]])
+            ->withHeaders(['X-Inertia' => 'true', 'X-Inertia-Version' => '1'])
+            ->get('/compras');
+
+        $response->assertStatus(200);
+
+        // Payload Inertia JSON: 'permissions' deve estar presente com create=true
+        // (admin#1 tem purchase.create no setUp).
+        $payload = $response->json();
+        $this->assertArrayHasKey('props', $payload);
+        $this->assertArrayHasKey('permissions', $payload['props']);
+        $this->assertTrue(
+            $payload['props']['permissions']['create'],
+            'admin#1 com purchase.create deve ver permissions.create=true'
+        );
+        $this->assertTrue($payload['props']['permissions']['update']);
+        $this->assertTrue($payload['props']['permissions']['delete']);
+    }
+
+    /**
+     * C1 convergência — user com `compras.view` SEM `purchase.create` vê cockpit
+     * mas prop `permissions.create=false` (botão "+ Nova compra" oculto no frontend).
+     */
+    public function test_c1_user_sem_purchase_create_recebe_permissions_create_false(): void
+    {
+        $permView = Permission::firstOrCreate(['name' => 'compras.view', 'guard_name' => 'web']);
+        $roleViewer = Role::firstOrCreate(['name' => 'viewer-only#1', 'guard_name' => 'web']);
+        $roleViewer->givePermissionTo($permView);
+
+        $viewer = User::factory()->create(['business_id' => 1]);
+        $viewer->assignRole($roleViewer);
+
+        $response = $this->actingAs($viewer)
+            ->withSession(['user' => ['business_id' => 1, 'id' => $viewer->id]])
+            ->withHeaders(['X-Inertia' => 'true', 'X-Inertia-Version' => '1'])
+            ->get('/compras');
+
+        $response->assertStatus(200);
+
+        $payload = $response->json();
+        $this->assertFalse(
+            $payload['props']['permissions']['create'],
+            'viewer sem purchase.create deve ver permissions.create=false (esconde botão)'
+        );
     }
 }

--- a/memory/decisions/proposals/compras-purchase-convergencia-c1.md
+++ b/memory/decisions/proposals/compras-purchase-convergencia-c1.md
@@ -1,0 +1,169 @@
+---
+slug: compras-purchase-convergencia-c1
+title: "Compras × Purchase convergência C1 — cockpit /compras delega CRUD pra /purchases/* Inertia"
+type: adr
+status: proposed
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+proposed_at: "2026-05-25"
+proposed_via: "Wagner aprovou em sessão `frosty-greider-83ab2f` 2026-05-25 via AskUserQuestion 3-opções pós-comparativo Compras × Sells — opção C1 (cockpit reusa Pages/Purchase/*) escolhida sobre C2 (reescrever Create no estilo Cowork) e C3 (coexistir)"
+module: Compras
+quarter: 2026-Q2
+tags: [compras, purchase, mwart, convergence, cockpit, multi-tenant, tier-0, append-only, charter-amendment]
+supersedes: []
+supersedes_partially: [compras-modulo-greenfield-hibrido]
+amends: []
+superseded_by: []
+related:
+  - "0093-multi-tenant-isolation-tier-0"
+  - "0094-constituicao-v2-7-camadas-8-principios"
+  - "0104-processo-mwart-canonico-unico-caminho"
+  - "0107-emendation-0104-visual-comparison-gate-f3"
+  - "0114-prototipo-ui-cowork-loop-formalizado"
+  - "0141-skill-migracao-blade-react"
+  - "0149-pattern-reuse-mwart-create-edit"
+charter_impact:
+  - "Pages/Compras/Index.charter.md v1 → v2 (Non-Goals + Anti-hooks reescritos: 'NÃO permite criar inline' vira 'NÃO replica form Create — delega /purchases/create via router.visit')"
+spec_impact:
+  - "memory/requisitos/Compras/SPEC.md §3 — Caminho C1 substitui Caminho B Wave 8 prometida"
+  - "US-COM-002 (criar compra manual) — delega a Purchase MWART Wave 2 B5"
+  - "US-COM-004 (deprecar /purchases) — INVERTE direção: /purchases canônico, /compras é cockpit complementar"
+pii: false
+review_triggers:
+  - "Wagner decidir criar Pages/Compras/Create.tsx mesmo assim (vertical-específico vestuário Larissa) → revisar C1 vs C2"
+  - "Time MCP (Felipe/Maiara) reportar 'qual link uso /compras ou /purchases' >3 vezes em 7d → criar topnav Modules/Compras/Resources/menus/topnav.php apontando /purchases/create"
+  - "GradeMatrixInput Wave 4.5 ROTA LIVRE Larissa biz=4 exigir entry-point cockpit /compras → criar Pages/Compras/Create.tsx APENAS pra vertical vestuário (não default)"
+  - "Permission gap user com compras.view mas SEM purchase.create reportado >2 vezes → criar alias PermissionsSeeder compras.create ↔ purchase.create"
+---
+
+# ADR · Compras × Purchase convergência C1
+
+## Contexto
+
+Wagner pediu comparativo Compras × Sells na sessão `frosty-greider-83ab2f` 2026-05-25 após Ondas 3+4+5+6 do ADR 0192 (Integração Vendas × Oficina) terem subido a nota Vendas de 9,0 → 9,3.
+
+Comparativo descobriu que existem **2 trilhos paralelos de Compras** vivos hoje:
+
+| Trilho | Rota | Onde | LOC | Status |
+|---|---|---|---:|---|
+| **A — Purchase (UltimatePOS core)** | `/purchases` `/purchases/create` `/purchases/{id}/edit` `/purchases/{id}` | `Pages/Purchase/*` + `app/Http/Controllers/PurchaseController.php` | 1.729 (Index+Create+Edit+Show) | **F3 implementado · aguarda smoke Wagner** (piloto skill `migracao-blade-react` v0.1.0 · ADR 0141) |
+| **B — Compras (Modules greenfield)** | `/compras` | `Pages/Compras/Index.tsx` + `Modules/Compras/Http/Controllers/ComprasController.php` | 828 (Index só · drawer 2 tabs) | scaffold Wave 1+2+3+4 F1 · SPEC `proposed` |
+
+A SPEC Compras §3 + US-COM-002 + US-COM-004 (referenciando proposta [`compras-modulo-greenfield-hibrido`](compras-modulo-greenfield-hibrido.md) ainda `proposed`) prometia:
+
+- Wave 8: criar `Pages/Compras/Create.tsx` form completo Cowork
+- US-COM-004: `/purchases` Blade legacy deprecada via 301 → `/compras` quando flag ON
+
+**Erro de premissa descoberto agora:** SPEC trata `/purchases` como Blade legacy. Mas o trilho A **JÁ É React/Inertia** desde a Wave 2 B5 do piloto `migracao-blade-react` (ADR 0141). `/purchases/create`, `/purchases/{id}/edit`, `/purchases/{id}` retornam Inertia React via dual-response (`X-Inertia` header ou `?v=2` query — `PurchaseController:400, 928`). `Purchase/Create.tsx` (520 LOC) e `Purchase/Edit.tsx` (502 LOC) têm charters Tier A ★ com ADRs canon 0104/0093/0114/0149 já validados.
+
+Manter os 2 trilhos e seguir SPEC original cria:
+
+1. **3 telas pra mesma operação** — `/purchases/create` (Purchase MWART), `/compras/create` (Compras Wave 8 futuro), Blade legacy ainda viva pra rollback
+2. **1.729 LOC duplicados** + 4 testes Pest Wave2 duplicados + charters Tier A duplicados
+3. **Confusão pra Felipe/Maiara** ("qual link uso?") — sidebar com 2 entry-points pra mesma intent
+4. **Débito de manutenção** — bug em Purchase/Create exige fix em 2 lugares depois
+
+**3 caminhos avaliados** (Wagner via AskUserQuestion):
+
+| Caminho | Trade-off |
+|---|---|
+| **C1 · Cockpit Compras vira shell e reusa `/purchases/*`** | Reusa 1.729 LOC já em smoke. Mata duplicação. ~30 LOC efetivas. Charter Tier A intacto. Perde verbatim Cowork no Create. |
+| **C2 · Wave 8 reescreve Create no estilo Cowork (`Pages/Compras/Create.tsx`)** e deprecia Purchase/Create | Visual Cowork end-to-end. 520 LOC charter Tier A vira débito morto. Quebra ADR 0149 pattern reuse. |
+| **C3 · Coexistir** (status quo) | Confusão sidebar. PR Wave 8 cria duplicação confirmada. |
+
+## Decisão
+
+**Caminho C1 — cockpit `/compras` delega CRUD pra `/purchases/*` Inertia.**
+
+### Contrato
+
+1. **`/compras` permanece como cockpit de listagem + KPIs + drawer denso Cowork** — preserva valor visual da Wave 1-4 (CSS bundle `cowork-compras-bundle.css` aplicado Tier 0)
+2. **Botão "+ Nova compra"** (`Pages/Compras/Index.tsx:240-242`) deixa de ser `disabled` → `onClick={() => router.visit('/purchases/create')}`. `router.visit` injeta `X-Inertia` header automaticamente, dispara dual-path em `PurchaseController:400`, retorna `Purchase/Create.tsx` Inertia React. **NÃO** cai no Blade
+3. **AcoesDropdown "Editar / Atualizar status / Notif. pendente"** (linhas 115, 152, 162) — trocar `navigateBlade(url) → window.location.href` (cai no Blade legacy sem header X-Inertia) por `router.visit(url)` (Inertia → Purchase/Edit.tsx React)
+4. **Sidebar primary action** (`DataController:114`) — `'href' => '/compras/create'` (404 hoje) vira `'href' => '/purchases/create'`
+5. **Permission gate** — botão "+ Nova compra" lê `props.permissions.create` que vem de `auth()->user()->can('purchase.create')` (não `compras.create` — alias V2 se Wagner mantiver módulo como conceito separado)
+6. **Drawer cockpit `/compras` 5 tabs in-page mantido** — Cowork denso é diferencial UX da listagem. Adicionar link secundário "Ver tela cheia" no rodapé do drawer apontando `/purchases/{id}?v=2` é opção V2
+7. **Botão "↓ Importar XML"** — segue `disabled` aguardando Wave 6 (bridge `ImportarDfeComoCompraService` US-COM-003 GAP NOVO) — **fora do escopo C1**
+
+### Multi-tenant Tier 0 ([ADR 0093](../0093-multi-tenant-isolation-tier-0.md))
+
+**Boa surpresa do audit:** brief Wagner suspeitou de divergência (`auth()->user()->business_id` em Purchase vs `session('user.business_id')` em Compras). **Não há divergência.** `PurchaseController` linhas 66, 354, 482, 634, 834, 1057, 1186, 1284, 1342, 1432 → **todas** usam `request()->session()->get('user.business_id')`. Igual ao `ComprasController:43`.
+
+C1 não toca scope — só roteamento. Tier 0 fica intacto.
+
+### Charter impact
+
+- `Pages/Compras/Index.charter.md` v1 → v2:
+  - Frontmatter `charter_version: 1` → `2`, `last_validated: 2026-05-25`
+  - Non-Goal "NÃO permite criar compra inline — botão '+ Nova compra' disabled. Form completo Wave 8 (`/compras/create`)" → "NÃO replica form Create — delega `/purchases/create` Inertia via `router.visit` (C1 · ADR `compras-purchase-convergencia-c1`)"
+  - Non-Goal "NÃO toca `/purchases` legacy — deprecação só na Wave 8 via 301 + feature flag" → "Cockpit reusa `/purchases/*` Inertia (Trilho A piloto MWART Wave 2 B5). `/compras` e `/purchases/*` coexistem como cockpit + CRUD"
+  - Anti-hook "Aparecer botão 'criar compra inline' sem Wave 8 — drift" → "Aparecer botão 'criar compra inline' que NÃO seja `router.visit('/purchases/create')` — drift"
+- `Pages/Purchase/Create.charter.md` e `Pages/Purchase/Edit.charter.md` **intocados** (Tier A ★ piloto MWART)
+
+### SPEC impact
+
+- `memory/requisitos/Compras/SPEC.md` §3 amendment 2026-05-25 — Caminho C1 substitui Caminho B Wave 8 prometida
+- US-COM-002 (criar compra manual) — vira "delegada a Purchase MWART Wave 2 B5 via router.visit; nasce wrapper `ComprasService::criar()` SE/QUANDO sinal real exigir vertical-específico vestuário"
+- US-COM-004 (deprecar `/purchases`) — INVERTE direção: `/purchases` canon, `/compras` cockpit complementar; R-COM-302 anula
+- Status SPEC `proposed` → `accepted` via esta ADR (substitui dependência da proposta `compras-modulo-greenfield-hibrido` ainda não promovida)
+
+### Permissions
+
+- Botão "+ Nova compra" usa `purchase.create` (não `compras.create`)
+- AcoesDropdown "Editar" usa `purchase.update`
+- AcoesDropdown "Excluir" mantém `purchase.delete` (já no Purchase/Index.tsx)
+- Cockpit `/compras` continua gateado por `compras.view` (catálogo permissions Modules/Compras intacto)
+- **Sem alias** `compras.create ↔ purchase.create` agora — review trigger ativa se gap reportado
+
+### Tests
+
+- `Modules/Compras/Tests/Feature/ComprasIndexTest.php` — adicionar teste 4 "user com `purchase.create` vê prop `permissions.create=true`" e teste 5 "Inertia component `Purchase/Create` é retornado quando user clica botão (smoke `withHeaders(X-Inertia)->get('/purchases/create')`)"
+- `tests/Feature/Purchase/Wave2CreateInertiaTest.php` — **intocado** (smoke convergência cross-modulo opcional fora do escopo C1 MVP)
+
+## Status
+
+**proposed** — aguarda Wagner aprovar via merge do PR `feat/compras-purchase-convergencia-c1`. Implementação ~30 LOC efetivas + amendments charter v2 + SPEC + esta ADR.
+
+## Consequências
+
+### Positivas
+
+- **Mata duplicação preventiva** — Wave 8 prometia criar `Pages/Compras/Create.tsx` (520 LOC + charter Tier A + testes). C1 cancela essa wave.
+- **Reuso integral Wave 2 B5 MWART** — 1.729 LOC + 4 testes Pest + charters Tier A já validados (F3 implementado aguardando smoke Wagner).
+- **Sidebar primary action conserta link quebrado** — `/compras/create` hoje retorna 404; C1 aponta `/purchases/create` que existe.
+- **Princípio "Charter > Spec" da Constituição v2** preservado — charter Purchase/Create Tier A ★ continua sendo fonte da verdade.
+- **Princípio "Loop fechado por métrica"** — se review trigger ativar (Larissa exigir vertical-específico vestuário, ou gap de permission reportado), criar Pages/Compras/Create.tsx aí.
+- **ADR 0149 (pattern reuse)** — C1 é exemplo canônico: cockpit greenfield reusa trilho MWART em vez de duplicar.
+
+### Negativas
+
+- **Charter Compras/Index v1 Non-Goals + Anti-hooks ficam violados** entre merge desta ADR e amendment charter — mitigação: ambos vão no mesmo PR atômico (decisão Wagner opção C "tudo num PR só").
+- **Visual `/purchases/create` ainda é Tailwind shadcn (não Cowork bundle)** — divergência estética entre cockpit `/compras` (Cowork denso) e form `/purchases/create` (shadcn utility). Aceitável até Larissa ou outro cliente reportar dor; review trigger #1 ativa.
+- **SPEC US-COM-002 e US-COM-004 ficam vazios** — manutenção exige amendment ou ADR explicit superseded.
+- **Permission split `compras.view` × `purchase.create`** — user com 1 sem o outro vê UI inconsistente. Aceitável V1; review trigger #4 ativa.
+- **`/compras/create` rota fica 404 definitivamente** — se algum link interno hardcoded apontar pra lá (busca grep cobre), redirect 301 → `/purchases/create` opcional V2.
+- **Proposta `compras-modulo-greenfield-hibrido`** fica **parcialmente superseded** — apenas a parte que prometia Wave 8 com `/compras/create` é anulada. Backend híbrido (transactions polimórfica + TransactionUtil + Observer Financeiro) **continua canon**.
+
+### Pendências (não bloqueiam aceite)
+
+- ADR amendment `compras-modulo-greenfield-hibrido` ou nota explícita marking Wave 8 da proposta como cancelled
+- Topnav `Modules/Compras/Resources/menus/topnav.php` adicionando `/purchases/create` (Cowork visual sidebar) — V2 polimento
+- Pest test smoke convergência cross-modulo `tests/Feature/Purchase/Wave2CreateInertiaTest.php` (user vem de `/compras`) — V2
+- Link "Ver tela cheia" no rodapé do drawer cockpit `/compras` apontando `/purchases/{id}?v=2` — V2
+
+## Refs
+
+- [Comparativo Compras × Sells](../../sessions/2026-05-25-como-integrar-c1-compras-converge-purchase.md) — audit introspectivo via skill `como-integrar`
+- [Proposta `compras-modulo-greenfield-hibrido`](compras-modulo-greenfield-hibrido.md) — supersedes_partially (Wave 8 cancelled)
+- [`memory/requisitos/Compras/SPEC.md`](../../requisitos/Compras/SPEC.md) — amendment §3 + US-COM-002 + US-COM-004 neste PR
+- [`Pages/Compras/Index.charter.md`](../../../resources/js/Pages/Compras/Index.charter.md) — v1 → v2 amendment neste PR
+- [`Pages/Purchase/Create.charter.md`](../../../resources/js/Pages/Purchase/Create.charter.md) — Tier A ★ intocado
+- [`Pages/Purchase/Edit.charter.md`](../../../resources/js/Pages/Purchase/Edit.charter.md) — Tier A intocado
+- `PurchaseController:400, 928` — dual-response `X-Inertia` header ou `?v=2` query
+- [ADR 0141 skill `migracao-blade-react`](../0141-skill-migracao-blade-react.md) — piloto Wave 2 B5
+- [ADR 0149 pattern reuse MWART](../0149-pattern-reuse-mwart-create-edit.md) — Edit reusa ~80% UI do Create
+- [ADR 0093 multi-tenant Tier 0](../0093-multi-tenant-isolation-tier-0.md) — preservado intocado
+- [ADR 0104 MWART canônico](../0104-processo-mwart-canonico-unico-caminho.md) — Purchase trilho A é caso canon
+- [ADR 0107 visual gate F1.5](../0107-emendation-0104-visual-comparison-gate-f3.md) — Purchase/Create gate já passou; C1 não exige novo gate (entry-point externo só)
+- [ADR 0114 prototipo-ui Cowork loop](../0114-prototipo-ui-cowork-loop-formalizado.md) — `/compras` cockpit é caso canon Cowork

--- a/memory/requisitos/Compras/SPEC.md
+++ b/memory/requisitos/Compras/SPEC.md
@@ -4,18 +4,36 @@ title: "Especificação funcional — Compras"
 type: spec
 module: Compras
 status: proposed
-related_adrs: [0093, 0094, 0101, 0104, 0105, 0106, 0107, 0114, 0143]
+related_adrs: [0093, 0094, 0101, 0104, 0105, 0106, 0107, 0114, 0141, 0143, 0149]
+related_proposals:
+  - "compras-modulo-greenfield-hibrido"
+  - "compras-purchase-convergencia-c1"
 pii: false
-updated_at: 2026-05-21
-last_updated: 2026-05-21
-version: 0.1
+updated_at: 2026-05-25
+last_updated: 2026-05-25
+version: 0.2
 owner: wagner
 ---
 
 # Especificação funcional — Compras
 
 > Convenção do ID: `US-COM-NNN` user stories, `R-COM-NNN` regras Gherkin.
-> Status `proposed` até ADR `compras-modulo-greenfield-hibrido` ser promovida a `accepted`.
+> Status `proposed` até ADRs `compras-modulo-greenfield-hibrido` + `compras-purchase-convergencia-c1` serem promovidas a `accepted`.
+
+## 0. Amendments
+
+### v0.2 — 2026-05-25 — Convergência C1
+
+ADR proposta [`compras-purchase-convergencia-c1`](../../decisions/proposals/compras-purchase-convergencia-c1.md) **inverte a direção** que esta SPEC v0.1 prometia em duas frentes:
+
+- **US-COM-002 (criar compra manual)** → **CANCELADA**. Cockpit `/compras` botão "+ Nova compra" delega `/purchases/create` Inertia (Trilho A piloto MWART Wave 2 B5 · ADR 0141). Não nasce `Pages/Compras/Create.tsx`. Wrapper `ComprasService::criar()` só nasce SE review trigger ADR C1 ativar (vertical-específico vestuário Larissa).
+- **US-COM-004 (deprecar `/purchases`)** → **INVERTIDA**. `/purchases` permanece canônico (Inertia React desde Wave 2 B5). `/compras` é cockpit complementar de listagem + KPIs + drawer denso Cowork. Coexistem. R-COM-302 (redirect 301) **anulada**.
+- **US-COM-005 (GradeMatrixInput Wave 4.5)** — entra em `Pages/Purchase/Create.tsx` (C1) OU nasce `Pages/Compras/Create.tsx` vertical-específico SE Larissa validar canary Bloco 4.5 (review trigger #3 ADR C1).
+- **US-COM-001** + **US-COM-003 (importar XML DF-e)** — **mantidas** intactas. GAP NOVO bridge `ImportarDfeComoCompraService` segue na Wave 6.
+
+Motivação: comparativo Compras × Sells 2026-05-25 (sessão `frosty-greider-83ab2f`) descobriu que `/purchases/{create,edit,show}` JÁ eram Inertia React (1.729 LOC + 4 charters Tier A) desde a Wave 2 B5 do piloto `migracao-blade-react`. Manter Wave 8 cria 3 telas pra mesma operação + 1.729 LOC duplicados. Detalhes em [`memory/sessions/2026-05-25-como-integrar-c1-compras-converge-purchase.md`](../../sessions/2026-05-25-como-integrar-c1-compras-converge-purchase.md).
+
+
 
 ## 1. Glossário rápido
 
@@ -60,16 +78,20 @@ Como user com permission `compras.view`, quero acessar `/compras` e ver cockpit 
 
 ### US-COM-002 — Criar compra manual
 
-**Status:** pending (Wave 3+)
-**Persona:** user com permission `compras.create`
+**Status:** ~~pending Wave 3+~~ → **cancelled-c1** (2026-05-25 · ADR `compras-purchase-convergencia-c1`)
+**Persona:** user com permission `purchase.create` (C1 — não `compras.create`)
 
-Como user com permission `compras.create`, quero criar uma compra manual com fornecedor, linhas (produto + qty + custo) e plano de pagamento, sem precisar abrir o Blade legacy `/purchases/create`.
+> **C1:** Cockpit `/compras` delega botão "+ Nova compra" pra `/purchases/create` Inertia (Trilho A piloto MWART Wave 2 B5). `Pages/Purchase/Create.tsx` (520 LOC + charter Tier A ★) cobre 100% do form. Não nasce `Pages/Compras/Create.tsx` agora.
+
+Como user com permission `purchase.create`, quero clicar "+ Nova compra" no cockpit `/compras` e navegar via Inertia (sem reload) pra `/purchases/create` que já é React, sem precisar reabrir o cockpit nem trocar de aba/tab.
 
 **Regras:**
 
-- R-COM-101 — Wrapper sobre `PurchaseController::store` extraído pra `ComprasService::criar()`
-- R-COM-102 — Disparar event `PurchaseCreatedOrModified` (listeners existentes não quebram)
-- R-COM-103 — Observer Financeiro (`TransactionObserver`) já cria `fin_titulos` type=pagar automaticamente
+- R-COM-101 ~~Wrapper sobre `PurchaseController::store` extraído pra `ComprasService::criar()`~~ → **anulada**. `PurchaseController::store` permanece canon
+- R-COM-102 — `router.visit('/purchases/create')` injeta header `X-Inertia` automaticamente; dispara dual-path em `PurchaseController:400` → `Purchase/Create.tsx`. NÃO usar `<a href>` ou `window.location.href` (cai no Blade legacy)
+- R-COM-103 — Observer Financeiro (`TransactionObserver`) já cria `fin_titulos` type=pagar automaticamente — comportamento preservado pois `/purchases/store` continua sendo o handler
+
+**Review trigger pra reabrir US-COM-002:** Larissa @ ROTA LIVRE biz=4 ou outro cliente piloto reportar dor real de vertical-específico vestuário que `Purchase/Create.tsx` não atende. Aí nasce `Pages/Compras/Create.tsx` apenas pro vertical (não default).
 
 ### US-COM-003 — Importar XML DF-e como compra (GAP NOVO)
 
@@ -89,16 +111,20 @@ Como user com permission `compras.import_xml`, quero abrir modal "Importar XML" 
 
 ### US-COM-004 — Deprecar `/purchases` legacy
 
-**Status:** pending (Wave 8)
+**Status:** ~~pending Wave 8~~ → **inverted-c1** (2026-05-25 · ADR `compras-purchase-convergencia-c1`)
 **Persona:** infra — não user-facing direto
 
-Como Wagner, quero `/purchases` redirecionar 301 → `/compras` (padrão Financeiro #1283) e esconder Expense/Account dropdowns legacy quando `compras_module_enabled`, mantendo o Blade desativado mas presente pra rollback.
+> **C1 inverte premissa:** `/purchases/*` não é Blade legacy — desde Wave 2 B5 do piloto `migracao-blade-react` (ADR 0141) é Inertia React via dual-path `X-Inertia` header ou `?v=2`. `/compras` é cockpit complementar, não substituto.
+
+Como Wagner, quero `/purchases/*` (Inertia React MWART Wave 2 B5) e `/compras` (cockpit Cowork denso) coexistirem como entry-points complementares: `/compras` lista + KPIs + drawer; `/purchases/create|edit|show` CRUD pesado reusado via `router.visit`.
 
 **Regras:**
 
-- R-COM-301 — Feature flag per-business `compras_module_enabled` (NÃO hardcode `if (biz=4)`)
-- R-COM-302 — `/purchases` → 301 `/compras` quando flag ON
-- R-COM-303 — Menu legacy "Purchases" desaparece quando flag ON
+- R-COM-301 — Feature flag per-business `compras_module_enabled` ainda controla **visibilidade do entry "Compras"** no sidebar (não bloqueia `/purchases`)
+- R-COM-302 ~~`/purchases` → 301 `/compras` quando flag ON~~ → **anulada**. Sem redirect
+- R-COM-303 ~~Menu legacy "Purchases" desaparece quando flag ON~~ → **anulada**. Topnav `core_topnavs.php` key 'Purchase' (label "Compras") mantido + sidebar entry "Compras" (`/compras`) coexistem
+
+**Review trigger pra reabrir US-COM-004:** Time MCP (Felipe/Maiara) reportar "qual link uso `/compras` ou `/purchases`?" >3 vezes em 7d → criar `Modules/Compras/Resources/menus/topnav.php` apontando `/purchases/create` (Cowork visual sidebar) pra unificar entry-points sem deprecar `/purchases`.
 
 ### US-COM-005 — Entrada matricial tam×cor (GradeMatrixInput)
 
@@ -142,7 +168,9 @@ Como Larissa criando compra de modelo `type='variable'` no `/compras/create`, qu
 - [memory/requisitos/Compras/DISCOVERY-LARISSA-COMPRAS.md](DISCOVERY-LARISSA-COMPRAS.md) — discovery cliente
 - [memory/requisitos/Compras/AUDITORIA-COMPRAS-2026-05-21.md](AUDITORIA-COMPRAS-2026-05-21.md)
 - [memory/requisitos/Compras/CAPTERRA-DESIGN-FICHA.md](CAPTERRA-DESIGN-FICHA.md)
-- [memory/decisions/proposals/compras-modulo-greenfield-hibrido.md](../../decisions/proposals/compras-modulo-greenfield-hibrido.md) — ADR proposta
+- [memory/decisions/proposals/compras-modulo-greenfield-hibrido.md](../../decisions/proposals/compras-modulo-greenfield-hibrido.md) — ADR proposta (Wave 8 parcial superseded por C1)
+- [memory/decisions/proposals/compras-purchase-convergencia-c1.md](../../decisions/proposals/compras-purchase-convergencia-c1.md) — **ADR C1 vigente** (2026-05-25)
+- [memory/sessions/2026-05-25-como-integrar-c1-compras-converge-purchase.md](../../sessions/2026-05-25-como-integrar-c1-compras-converge-purchase.md) — plug-points C1
 - [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md) Multi-tenant Tier 0 IRREVOGÁVEL
 - [ADR 0104](../../decisions/0104-processo-mwart-canonico-unico-caminho.md) Processo MWART canônico
 - [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) Cliente como sinal

--- a/memory/sessions/2026-05-25-como-integrar-c1-compras-converge-purchase.md
+++ b/memory/sessions/2026-05-25-como-integrar-c1-compras-converge-purchase.md
@@ -1,0 +1,244 @@
+---
+slug: como-integrar-c1-compras-converge-purchase
+title: "Convergência C1 — botão + drawer de /compras delegam pra /purchases/{create,edit,show}"
+type: como-integrar
+date: 2026-05-25
+status: introspectivo (não executado)
+related_adrs: [0093, 0094, 0104, 0107, 0114, 0141, 0149]
+related_specs: [memory/requisitos/Compras/SPEC.md]
+related_us: [US-COM-001, US-COM-002, US-COM-004]
+pii: false
+owner: wagner
+---
+
+# Convergência C1 — /compras (cockpit) reusa /purchases ({create,edit})
+
+> Decisão Wagner 2026-05-25: parar de prometer Wave 8 com `Pages/Compras/Create.tsx`. Trilho A (Purchase MWART piloto Wave2 B5) já tem `/purchases/create|edit|show` Inertia React funcional. Cockpit Compras vira shell de listagem + KPIs + drawer e **delega** CRUD pro trilho A.
+
+Auditoria 100% INTROSPECTIVA — só leu código + memory. Sem web. Sem commit. Sem MCP task.
+
+---
+
+## Fase 1 — INVENTÁRIO (o que já existe?)
+
+### Tabela de descoberta
+
+| O que procurei | Onde achei | Status |
+|---|---|---|
+| Purchase/Create.tsx Inertia React | `resources/js/Pages/Purchase/Create.tsx` (520 LOC, charter Tier A F3 ★) | **completo** — aguarda smoke Wagner |
+| Purchase/Edit.tsx Inertia React | `resources/js/Pages/Purchase/Edit.tsx` (502 LOC, charter Tier A) | **completo** — `canBeEdited` + bloqueio devolução |
+| Purchase/Show.tsx Inertia React | `resources/js/Pages/Purchase/Show.tsx` (379 LOC, sem charter) | **completo** |
+| Dual-response Blade/Inertia | `PurchaseController:73, 400, 928, 697` (`?v=2` ou header `X-Inertia`) | ativo — pegadinha crítica (§Fase 2) |
+| Cockpit Compras Index | `resources/js/Pages/Compras/Index.tsx` (828 LOC) | Wave 1-4 scaffold |
+| ComprasController backend | `Modules/Compras/Http/Controllers/ComprasController.php` (128 LOC) | só `index()` + `show()` JSON (Wave 5) |
+| Rota `/compras/create` registrada | `Modules/Compras/Routes/web.php` | **AUSENTE** — 404 hoje |
+| Botão "+ Nova compra" disabled | `Pages/Compras/Index.tsx:240-242` | promete Wave 8 — alvo C1 |
+| Botão "↓ Importar XML" disabled | `Pages/Compras/Index.tsx:237-239` | promete Wave 6 — **NÃO** entra em C1 |
+| Sidebar entry "Compras" → `/compras` | `Modules/Compras/Http/Controllers/DataController.php:106` | ativo via `\Menu::modify('admin-sidebar-menu')` |
+| Sidebar `primary.href = /compras/create` | `DataController.php:114` | **link quebrado hoje (404)** — alvo C1 |
+| Sidebar duplicação Purchase × Compras | `app/Http/Middleware/AdminSidebarMenu.php:260-271` | **JÁ resolvido** 2026-05-22 P3 (entry duplicada comentada por Wagner) |
+| Topnav módulo Compras | `config/core_topnavs.php:59-94` | registrado em key `'Purchase'` com label "Compras", sub-itens `/purchases/*` |
+| Permissions `compras.*` declaradas | `Modules/Compras/Http/Controllers/DataController.php:46-72` | catálogo `compras.{view,create,edit,delete,import_xml}` — **não há alias** com `purchase.*` |
+| AcoesDropdown navegando edit/show | `Pages/Compras/components/AcoesDropdown.tsx:115, 108, 146, 155, 162` | **PARCIAL** — `navigateBlade('/purchases/{id}/edit')` via `window.location.href` (não Inertia → cai no Blade sem `?v=2`) |
+| ADR proposta convergência | `memory/decisions/proposals/compras-modulo-greenfield-hibrido.md` | **AUSENTE** (SPEC referencia mas não está no repo) |
+| Sessão prévia "como-integrar-compras" | `memory/sessions/2026-05-21-como-integrar-compras.md` | **AUSENTE** (SPEC referencia mas glob não encontra) |
+| SPEC Compras §3 US-COM-004 | `memory/requisitos/Compras/SPEC.md:90-101` | **INVERTE** com C1 ("`/purchases` → 301 → `/compras`") |
+| Tests Wave2 Inertia Purchase | `tests/Feature/Purchase/Wave2{Create,Edit}{Baseline,Inertia}Test.php` (4 files) | funcionais — dual-path testado |
+| Test Compras Index | `Modules/Compras/Tests/Feature/ComprasIndexTest.php` (3 testes) | verde |
+
+### Veredito Fase 1
+
+**Estende — não cria do zero.** A peça nova de C1 é ~30 linhas:
+1. trocar 2 botões em `Pages/Compras/Index.tsx:237-242`
+2. trocar fluxo do AcoesDropdown linha 115/146/155/162 (que hoje usa `window.location.href` sem `?v=2`)
+3. corrigir `DataController:114` (`/compras/create` → `/purchases/create`)
+
+NÃO precisa criar `Pages/Compras/Create.tsx`. NÃO precisa criar `Pages/Compras/Edit.tsx`. NÃO precisa controller novo no `Modules/Compras/`. Reuso integral 1.401 LOC + 4 testes Pest já em smoke.
+
+Economia: ~6-8h IA-pair (Wave 8 inteira) + manutenção 1.401 LOC paralelas + charter Tier A duplicado.
+
+---
+
+## Fase 2 — PEGADINHAS APLICÁVEIS
+
+Filtradas pela natureza do C1 (trocar entry-point + AcoesDropdown). Lista enxuta, só relevantes.
+
+### P1 — Dual-response Blade↔Inertia exige `?v=2` ou header `X-Inertia` (CRÍTICA)
+
+**Fonte:** `PurchaseController:73, 400, 697, 928` + ADR 0104 MWART + ADR 0149.
+
+`/purchases/create`, `/purchases/{id}/edit`, `/purchases/{id}` retornam Inertia React **só se** o request tiver header `X-Inertia: true` OU query string `?v=2`. Sem isso → Blade legacy (`view('purchase.create')`).
+
+`<a href="/purchases/create">` simples cai no Blade legacy.
+`router.visit('/purchases/create')` injeta `X-Inertia` automaticamente → React.
+`window.location.href = '/purchases/{id}/edit'` (AcoesDropdown atual) **cai no Blade**.
+
+**Implicação C1:**
+- Botões `+ Nova compra` e edit no AcoesDropdown precisam usar `router.visit(...)` (Inertia) ou `?v=2` na URL. Nada de `<a href>` puro nem `window.location.href` sem fallback.
+
+### P2 — Tier 0 multi-tenant `business_id` (ADR 0093 IRREVOGÁVEL)
+
+**Boa surpresa:** brief Wagner suspeitou de divergência (`auth()->user()->business_id` em Purchase vs `session('user.business_id')` em Compras). **Não há divergência.**
+
+`PurchaseController` linhas 66, 354, 482, 634, 834, 1057, 1186, 1284, 1342, 1432 → **todas** usam `request()->session()->get('user.business_id')`. Igual ao ComprasController:43.
+
+C1 não toca scope — só roteamento. Tier 0 fica intacto.
+
+### P3 — Charter Tier A Purchase/Create.tsx ★ — não invalidar
+
+**Fonte:** `resources/js/Pages/Purchase/Create.charter.md` status "F3 implementado (aguarda smoke Wagner)" + ADRs 0104/0093/0114/0149.
+
+C1 não muda Purchase/Create.tsx (só seu entry-point externo). Charter Tier A do trilho A **permanece intocado** — Wagner ainda valida smoke F1.5 visual gate (ADR 0107).
+
+Implicação: **NÃO precisa novo visual gate F1.5 pra C1**. Visual já validado é da `/purchases/create` que continua igual; só o caller mudou.
+
+### P4 — Charter `Pages/Compras/Index.charter.md` § Non-Goals + Anti-hooks colidem com C1
+
+**Fonte:** `resources/js/Pages/Compras/Index.charter.md:52-54, 77`.
+
+Charter v1 declara:
+- ❌ Non-Goal: "NÃO permite criar compra inline — botão '+ Nova compra' disabled. Form completo Wave 8 (`/compras/create`)"
+- ❌ Non-Goal: "NÃO toca `/purchases` legacy — deprecação só na Wave 8 via 301 + feature flag"
+- ⚠️ Anti-hook: "Aparecer botão 'criar compra inline' sem Wave 8 — drift"
+
+C1 quebra **explicitamente** esses 2 Non-Goals + o Anti-hook. **Precisa amendment do charter v1 → v2** (`charter_version: 2`, last_validated 2026-05-25). Sugestão de redação no §Fase 3.
+
+### P5 — SPEC §3 US-COM-004 INVERTE direção da deprecação
+
+**Fonte:** `memory/requisitos/Compras/SPEC.md:90-101` US-COM-004 "Deprecar `/purchases` legacy".
+
+R-COM-302 hoje: `/purchases` → 301 → `/compras` quando flag ON.
+C1 inverte: **`/purchases`** continua canônico (Inertia React Wave2 B5) e `/compras` só é cockpit de listagem.
+
+US-COM-002 (criar compra manual) R-COM-101 ("Wrapper sobre PurchaseController::store extraído pra ComprasService::criar()") também fica vazio — C1 mantém `PurchaseController::store` como canon.
+
+**Implicação:** SPEC §3 + US-COM-002 + US-COM-004 precisam amendment ou superseded.
+
+### P6 — Permissions `compras.*` × `purchase.*` (gap, não bug)
+
+**Fonte:** `DataController.php:48-72` declara 5 permissions `compras.{view,create,edit,delete,import_xml}`. `ComprasController:39, 91` usa `compras.view`. `PurchaseController:63, 350, 477` usa `purchase.{view,create,update,delete}`.
+
+User com `purchase.create` mas SEM `compras.view` → vê `/purchases/create` mas é bloqueado em `/compras` (403). Inversamente, user com `compras.view` SEM `purchase.create` → vê cockpit `/compras`, clica "+ Nova compra", **leva 403** em `/purchases/create`.
+
+C1 implica:
+- Cockpit `/compras` esconde botão "+ Nova compra" se `!auth()->user()->can('purchase.create')` (não `compras.create`)
+- Inversa: Edit também checa `purchase.update`
+- **Alternativa V2:** PermissionsSeeder cria alias `compras.create` ↔ `purchase.create` (preserva nomenclatura módulo nova mas reusa permission existente). Não bloqueador V1.
+
+### P7 — F3 LICOES anti-padrão M-AP-1 ("ler 2 arquivos do repo antes de TSX/PHP")
+
+**Fonte:** `prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md` §M-AP-1.
+
+C1 é F6 Soft (sem novo Cowork → React), MAS edita 3 arquivos sensíveis (Index.tsx, AcoesDropdown.tsx, DataController.php). **Ler antes**:
+- `PurchaseController::create()` para confirmar `?v=2` exigido
+- `Pages/Compras/Index.tsx` linhas 1-100 + 237-242 (estilo Cowork bundle CSS)
+- AcoesDropdown.tsx inteiro (já navega Blade — só trocar Blade → Inertia)
+
+### P8 — Topnav `core_topnavs.php` chave `'Purchase'` com label "Compras"
+
+**Fonte:** `config/core_topnavs.php:59-94`.
+
+Chave PHP é `'Purchase'` (não `'Compras'`), mas label visível é "Compras". `useAutoModuleNav()` ativa esse topnav pra URLs root `/purchases`. **Em `/compras` o topnav é renderizado por `Modules/Compras/Resources/menus/topnav.php` se existir** — hoje ausente (Glob retornou 0).
+
+C1 pode opcionalmente:
+- (a) NÃO adicionar topnav em Modules/Compras → `/compras` fica sem topnav próprio (estado atual)
+- (b) Criar `Modules/Compras/Resources/menus/topnav.php` listando `/compras` (lista) + `/purchases/create` (nova compra) + `/purchase-return` (devoluções) + `/purchase-order` (pedidos). Convergência visual total.
+
+Pendente Wagner — opção (b) é mais coerente com C1 mas adiciona ~30 LOC PHP. **Sugestão: deixar pra wave de polimento depois.**
+
+---
+
+## Fase 3 — PONTO DE PLUGUE (onde tocar)
+
+### Mapa concreto
+
+| Peça | Arquivo:linha | Ação |
+|---|---|---|
+| Botão "+ Nova compra" | `resources/js/Pages/Compras/Index.tsx:240-242` | Trocar `disabled` por `onClick={() => router.visit('/purchases/create')}` + check perm `purchase.create` via prop `permissions` (a adicionar no Controller) |
+| Botão "↓ Importar XML" | `resources/js/Pages/Compras/Index.tsx:237-239` | **NÃO TOCAR em C1** — segue disabled aguardando Wave 6 (bridge DFe→Compra) |
+| AcoesDropdown "Editar" | `resources/js/Pages/Compras/components/AcoesDropdown.tsx:115` | Substituir `navigateBlade('/purchases/{compraId}/edit')` por `router.visit('/purchases/${compraId}/edit')` (assina header X-Inertia, abre React) |
+| AcoesDropdown "Ver" (linha) | `Index.tsx + AcoesDropdown.tsx:100-103` | **DECIDIR Wagner:** continua abrindo Drawer in-page (estado atual)? OU passa a navegar `/purchases/{id}` Show React? Sugestão: **manter Drawer in-page** (5 tabs Cowork denso é diferencial) e adicionar **link secundário "Ver tela cheia"** nos pés do drawer apontando `/purchases/{id}?v=2` |
+| AcoesDropdown "Impressão" | `AcoesDropdown.tsx:108` | Manter `window.open('/purchases/print/{id}')` — print é Blade legacy ainda (não migrado) |
+| AcoesDropdown "Reembolso" | `AcoesDropdown.tsx:146` | Manter `navigateBlade('/purchase-return/add/{id}')` — devolução é Blade legacy |
+| AcoesDropdown "Atualizar status" | `AcoesDropdown.tsx:152-156` | Mudar pra `router.visit('/purchases/{id}/edit#status')` (Inertia → cai no Edit.tsx React) |
+| AcoesDropdown "Notif. pendente" | `AcoesDropdown.tsx:162` | Mesmo: `router.visit('/purchases/{id}/edit#notify-pending')` |
+| Sidebar primary action quebrado | `Modules/Compras/Http/Controllers/DataController.php:114` | Trocar `'href' => '/compras/create'` por `'href' => '/purchases/create'`. Update comentário linhas 100-102 (remover menção "Wave 3"). |
+| Permission gate botão "+ Nova compra" | `ComprasController::index()` Inertia::render `Compras/Index` | Adicionar prop `permissions: ['create' => auth()->user()->can('purchase.create'), 'edit' => auth()->user()->can('purchase.update'), 'delete' => auth()->user()->can('purchase.delete')]` |
+| Charter `Pages/Compras/Index.charter.md` | linhas 52-54 (Non-Goals) + 77 (Anti-hooks) + frontmatter `charter_version: 1` → 2 | Reescrever Non-Goal "NÃO permite criar inline" → "NÃO replica form Create — delega `/purchases/create` Inertia (C1)". Anti-hook "botão criar inline drift" → "botão criar inline que NÃO seja delegação `router.visit('/purchases/create')`" |
+| SPEC `memory/requisitos/Compras/SPEC.md` | §3 + US-COM-002 R-COM-101 + US-COM-004 R-COM-302 + Wave 8 referência | Amendment date 2026-05-25 — Caminho C1 substitui Caminho B Wave 8 prometida. US-COM-002 vira "delegada a US-PUR-Wave2" (ou similar). US-COM-004 INVERTE direção: `/compras` cockpit não substitui `/purchases`, ambos coexistem. |
+| ADR nova (opcional) | `memory/decisions/proposals/compras-purchase-convergencia-c1.md` | **Recomendado** — slug sugerido `compras-purchase-convergencia-c1-cockpit-delega-crud-purchase` (supersedes da proposta `compras-modulo-greenfield-hibrido` que sequer existe — apenas referencia). |
+| Test Pest Compras navega `/purchases/create` | `Modules/Compras/Tests/Feature/ComprasIndexTest.php` | Adicionar test 4: "clique '+ Nova compra' navega via Inertia pra `/purchases/create` e retorna 200 React" — usa `actingAs` + `withHeaders(['X-Inertia' => 'true'])->get('/purchases/create')` assertComponent Purchase/Create |
+| Test Pest Purchase smoke convergência | `tests/Feature/Purchase/Wave2CreateInertiaTest.php` (a estender) | Adicionar test smoke "user navega de `/compras` → `/purchases/create` mantém sessão multi-tenant + permission ok" |
+
+### Plugues que NÃO existem (⚠️ atenção)
+
+- ⚠️ **`Modules/Compras/Resources/menus/topnav.php`** — não existe. C1 V1 pode passar sem (mantém topnav `Purchase` do `core_topnavs.php`). V2 pode criar.
+- ⚠️ **ADR proposta `compras-modulo-greenfield-hibrido`** referenciada na SPEC NÃO existe no repo. Status SPEC ainda `proposed` espera essa ADR — C1 pode promover a SPEC direto pra `accepted` via ADR `compras-purchase-convergencia-c1` substituindo a hipótese hibrida.
+- ⚠️ **Session prévia `2026-05-21-como-integrar-compras.md`** referenciada na SPEC NÃO existe (Glob 0 resultados). Não-bloqueador, só hygiene de links quebrados.
+
+---
+
+## Fase 4 — CHECKLIST PRÉ-CÓDIGO
+
+```markdown
+## Pré-código checklist — C1 Compras converge Purchase
+
+### Antes de Edit/Write
+- [ ] Ler RUNBOOK existente:
+  - `memory/requisitos/Compras/RUNBOOK-compras-index.md` (existe)
+  - `memory/requisitos/Inventory/RUNBOOK-purchase-create.md` (referenciado em Purchase/Create.charter.md — confirmar)
+- [ ] Confirmar feature flag necessária? **NÃO** — sem rollout gradual. C1 reuso direto, rollback é git revert único PR.
+- [ ] Schema migration necessária? **NÃO** — só roteamento + UI.
+- [ ] ADR nova necessária? **SIM** — recomendado `compras-purchase-convergencia-c1` slug supersedes da hipótese hibrida proposed nunca aceita.
+
+### Pegadinhas a respeitar (filtradas C1)
+- [ ] P1 — `router.visit(...)` Inertia em vez de `<a href>` ou `window.location.href` (caso contrário cai no Blade legacy de `/purchases/*`)
+- [ ] P3 — NÃO tocar Purchase/Create.tsx nem charter Tier A. Só caller mudou.
+- [ ] P4 — Amendment `Pages/Compras/Index.charter.md` v1 → v2 (Non-Goals + Anti-hooks atualizados)
+- [ ] P5 — Amendment SPEC §3 + US-COM-002 + US-COM-004 OR superseded por ADR nova
+- [ ] P6 — Permission gate botão usa `purchase.create` (não `compras.create`) até alias V2
+- [ ] P7 — Ler 3 arquivos antes de Edit: PurchaseController:60-80, Index.tsx:230-250, AcoesDropdown.tsx inteiro
+
+### Pontos de plugue (em ordem)
+- [ ] Backend `ComprasController.php` — adicionar prop `permissions` (`purchase.create/update/delete` do auth user)
+- [ ] Frontend `Pages/Compras/Index.tsx:240-242` — botão "+ Nova compra" → `onClick={() => router.visit('/purchases/create')}` + gate `props.permissions.create`
+- [ ] Frontend `Pages/Compras/components/AcoesDropdown.tsx:115, 152, 162` — Blade → Inertia (`navigateBlade` → `router.visit`)
+- [ ] Sidebar `DataController.php:114` — `/compras/create` → `/purchases/create`
+- [ ] Charter `Pages/Compras/Index.charter.md` — version 2, Non-Goals + Anti-hooks reescritos
+- [ ] SPEC `memory/requisitos/Compras/SPEC.md` — amendment §3 + US-COM-002 + US-COM-004 OU superseded por ADR
+- [ ] ADR `memory/decisions/proposals/compras-purchase-convergencia-c1.md` (criar — opcional mas recomendado)
+- [ ] Test: `Modules/Compras/Tests/Feature/ComprasIndexTest.php` — adicionar test smoke navega `/purchases/create` via Inertia retorna React
+- [ ] Test: `tests/Feature/Purchase/Wave2CreateInertiaTest.php` — adicionar smoke convergência multi-tenant cross-modulo
+
+### Smoke pós-deploy
+- [ ] biz=1 (Pest) — clique "+ Nova compra" em `/compras` abre Purchase/Create.tsx (assertComponent)
+- [ ] biz=1 (Pest) — clique "Editar" no AcoesDropdown abre Purchase/Edit.tsx (assertComponent)
+- [ ] biz=4 (ROTA LIVRE prod, canary opcional Larissa) — fluxo end-to-end clique cockpit → criar compra real Larissa vestuário
+- [ ] Chrome MCP `read_console_messages` — 0 erros JS após navegação Inertia cross-page
+
+### Estimativa total (IA-pair, ADR 0106)
+- Edits código: ~30min IA-pair (3 arquivos pequenos)
+- Amendment charter + SPEC + ADR: ~45min
+- Tests novos (2): ~30min
+- Smoke biz=1: ~5min CI + ~15min review
+- Smoke biz=4 Larissa: depende agenda dela (não estimável aqui)
+- **Total IA-pair editável:** ~2h. Margem 2x ADR 0106: **4h**. Smoke real (Larissa): relógio mundo.
+```
+
+---
+
+## Sinais / drifts a monitorar pós-merge
+
+- ⚠️ Se aparecer `Pages/Compras/Create.tsx` ou `Pages/Compras/Edit.tsx` → **DRIFT** — quebra C1
+- ⚠️ Se `DataController:114` voltar a apontar `/compras/create` → drift (link quebrado)
+- ⚠️ Se PR contém migration nova de tabela `compras_*` ou `purchases_*` → fora do escopo C1
+- ⚠️ Se charter Compras/Index Anti-hooks NÃO for atualizado → próximas waves vão re-introduzir botão disabled
+
+---
+
+## PENDENTE — perguntar Wagner
+
+1. **ADR proposta `compras-modulo-greenfield-hibrido`** que SPEC referencia não existe no repo. Foi descartada ou está fora do worktree? Se descartada, C1 ADR vira nascimento, não supersedes.
+2. **Drawer cockpit /compras** — após C1, manter Drawer 5 tabs in-page OU substituir por `router.visit('/purchases/{id}')` pra Show React? Recomendação: manter Drawer (Cowork denso é diferencial UX da listagem) e adicionar link "Ver tela cheia" no rodapé do drawer.
+3. **Topnav `Modules/Compras/Resources/menus/topnav.php`** — criar agora ou empurrar pra wave de polimento? Hoje topnav global `core_topnavs.php` key `'Purchase'` cobre.
+4. **Permission alias `compras.* ↔ purchase.*`** — criar PermissionsSeeder alias agora ou usar `purchase.*` direto nos gates? Sugestão: V1 usa `purchase.*` (zero migration), V2 cria alias se Wagner mantiver módulo Compras como conceito separado.

--- a/resources/js/Pages/Compras/Index.charter.md
+++ b/resources/js/Pages/Compras/Index.charter.md
@@ -3,20 +3,25 @@ page: /compras
 component: resources/js/Pages/Compras/Index.tsx
 owner: wagner
 status: scaffold
-last_validated: 2026-05-21
+last_validated: 2026-05-25
 parent_module: Compras
 parent_spec: memory/requisitos/Compras/SPEC.md
-related_adrs: [0093, 0094, 0101, 0104, 0107, 0114]
+related_adrs: [0093, 0094, 0101, 0104, 0107, 0114, 0141, 0149]
 related_us: [US-COM-001]
 related_prototype: public/cowork-preview/erp-shell-v2/compras-page.jsx
 tier: A
-charter_version: 1
+charter_version: 2
+related_proposals:
+  - "compras-purchase-convergencia-c1"
 ---
 
-# Page Charter — /compras (cockpit)
+# Page Charter — /compras (cockpit · v2 C1 convergência)
 
-> **Status:** Wave 1+2+3+4 scaffold (2026-05-21). F1 pin literal do protótipo Cowork canônico (`compras-page.jsx`).
-> Persona: todo user com permission `compras.view`. Larissa @ ROTA LIVRE biz=4 (1280px, vestuário, não-técnica) é a piloto de Wave 4.5+ (GradeMatrixInput).
+> **Status v2 (2026-05-25):** mantém Wave 1+2+3+4 visual scaffold mas pivota Non-Goals + Anti-hooks via convergência C1 — cockpit `/compras` delega CRUD pra trilho A `Pages/Purchase/*` Inertia (Wave 2 B5 piloto MWART · ADR 0141). Botão "+ Nova compra" deixa de prometer Wave 8 com `/compras/create` e passa a `router.visit('/purchases/create')`. Ver ADR proposta [`compras-purchase-convergencia-c1`](../../../memory/decisions/proposals/compras-purchase-convergencia-c1.md).
+>
+> **Status v1 original (2026-05-21):** F1 pin literal do protótipo Cowork canônico (`compras-page.jsx`).
+>
+> Persona: todo user com permission `compras.view` + `purchase.create/update` pros botões (C1 — sem alias `compras.create`). Larissa @ ROTA LIVRE biz=4 (1280px, vestuário, não-técnica) é a piloto de Wave 4.5+ (GradeMatrixInput).
 
 ---
 
@@ -49,9 +54,9 @@ Servir como **cockpit operacional de Compras** entregando 4 KPIs (a pagar / em t
 
 - ❌ **NÃO renderiza DrawerView 5 tabs** (Resumo/Itens/Documentos/Pagamentos/Histórico) — backend `show()` ainda não existe. Wave 6+ habilitam
 - ❌ **NÃO importa XML DF-e** — botão disabled. Bridge `ImportarDfeComoCompraService` vem na Wave 6
-- ❌ **NÃO permite criar compra inline** — botão "+ Nova compra" disabled. Form completo Wave 8 (`/compras/create`)
-- ❌ **NÃO renderiza GradeMatrixInput** — entrada matricial tam×cor vive em `/compras/create` (Wave 4.5+)
-- ❌ **NÃO toca `/purchases` legacy** — deprecação só na Wave 8 via 301 + feature flag
+- ❌ **NÃO replica form Create no estilo Cowork** — botão "+ Nova compra" delega `/purchases/create` Inertia via `router.visit` (C1 · ADR `compras-purchase-convergencia-c1`). Criar `Pages/Compras/Create.tsx` só se review trigger ativar (vertical-específico vestuário Larissa)
+- ❌ **NÃO renderiza GradeMatrixInput inline** — entrada matricial tam×cor entra em `Pages/Purchase/Create.tsx` ou no futuro `Pages/Compras/Create.tsx` vertical-específico (Wave 4.5+)
+- ❌ **NÃO substitui `/purchases` legacy via 301** — C1 inverte direção: `/purchases` é canônico Inertia React (Wave 2 B5 piloto MWART), `/compras` é cockpit complementar. Coexistem
 - ❌ **NÃO usa session storage** pra filtros — query string (`?stage=...&q=...`) anti-hook charter
 - ❌ **NÃO mock data** — se backend retornar `null/[]`, UI mostra empty state real (não inventa números)
 
@@ -72,9 +77,11 @@ Servir como **cockpit operacional de Compras** entregando 4 KPIs (a pagar / em t
 > Quando esta tela "ganhar" funcionalidade, suspeite — fica fácil escorregar pra F6 Hard sem ADR.
 
 - ⚠️ Aparecer **modal "Importar XML" funcional** sem ADR Wave 6 promovida — drift, exige ImportarDfeComoCompraService completo
-- ⚠️ Aparecer **GradeMatrixInput inline** no cockpit — drift, esse componente vive em `/compras/create` (US-COM-005 Wave 4.5)
+- ⚠️ Aparecer **GradeMatrixInput inline** no cockpit — drift, esse componente vive em `Pages/Purchase/Create.tsx` (C1) ou futuro `/compras/create` vertical-específico (US-COM-005 Wave 4.5)
 - ⚠️ Aparecer **dependência nova** (AG Grid, Handsontable, etc) — drift custo bundle, viola arte 2026-05-21 (TanStack v8 headless é o caminho)
-- ⚠️ Aparecer **botão "criar compra inline"** sem Wave 8 — drift
+- ⚠️ Aparecer **botão "criar compra inline" que NÃO seja `router.visit('/purchases/create')`** — drift C1, exige novo ADR pra reverter convergência
+- ⚠️ Aparecer **`Pages/Compras/Create.tsx` ou `Pages/Compras/Edit.tsx`** — drift C1 (review trigger #1 da ADR ativa antes)
+- ⚠️ Aparecer **`<a href="/purchases/*">` ou `window.location.href='/purchases/*'`** em qualquer componente Compras — cai no Blade legacy sem header `X-Inertia`. Usar `router.visit(...)` Inertia
 - ⚠️ Aparecer **session storage** para filtros — preferir query string (`?stage=...`)
 - ⚠️ Aparecer **mock data** (`rand()`, fixtures hardcoded) em controller ou Page — banido por LICOES_F3_FINANCEIRO_REJEITADO M-AP-2
 
@@ -99,11 +106,12 @@ Wave 7 adicionará:
 
 ## Backlog (não no escopo Waves 1-5)
 
-- **US-COM-002 Wave 8** — Nova compra inline (`/compras/create` Inertia)
-- **US-COM-003 Wave 6** — Importar XML DF-e (modal + bridge `ImportarDfeComoCompraService`)
-- **US-COM-005 Wave 4.5** — GradeMatrixInput.tsx em `/compras/create` produtos variable
-- **US-COM-004 Wave 8** — Deprecar `/purchases` legacy (301 + feature flag)
-- **Drawer 5 tabs** — Resumo/Itens/Documentos/Pagamentos/Histórico (Wave 6+ quando `show()` existir)
+- ~~**US-COM-002 Wave 8** — Nova compra inline (`/compras/create` Inertia)~~ — **cancelada via C1** (delega `/purchases/create`)
+- ~~**US-COM-004 Wave 8** — Deprecar `/purchases` legacy (301 + feature flag)~~ — **invertida via C1** (`/purchases` canon, `/compras` cockpit complementar)
+- **US-COM-003 Wave 6** — Importar XML DF-e (modal + bridge `ImportarDfeComoCompraService`) — **mantida** (GAP NOVO único)
+- **US-COM-005 Wave 4.5** — GradeMatrixInput.tsx vestuário Larissa biz=4 — vai pra `Pages/Purchase/Create.tsx` (C1) ou futuro `Pages/Compras/Create.tsx` SE review trigger ADR C1 ativar
+- **Drawer 5 tabs** — Resumo/Itens/Documentos/Pagamentos/Histórico (Wave 6+ quando `show()` existir) — **mantido** (diferencial UX cockpit)
+- **Link "Ver tela cheia" no drawer** apontando `/purchases/{id}?v=2` — V2 polimento C1
 - **Server-side filter persistido** — hoje filter é client-side (sobre rows defer); migrar pra query string Wave 7
 
 ---
@@ -116,7 +124,10 @@ Wave 7 adicionará:
 - [ADR 0093](../../../memory/decisions/0093-multi-tenant-isolation-tier-0.md) — Multi-tenant Tier 0 IRREVOGÁVEL
 - [ADR 0094](../../../memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md) — Constituição v2
 - [ADR 0104](../../../memory/decisions/0104-processo-mwart-canonico-unico-caminho.md) — Processo MWART canônico
-- [ADR proposta compras-modulo-greenfield-hibrido](../../../memory/decisions/proposals/compras-modulo-greenfield-hibrido.md)
+- [ADR proposta compras-modulo-greenfield-hibrido](../../../memory/decisions/proposals/compras-modulo-greenfield-hibrido.md) — supersedes_partially por C1 (Wave 8 cancelled)
+- [ADR proposta compras-purchase-convergencia-c1](../../../memory/decisions/proposals/compras-purchase-convergencia-c1.md) — **C1 vigente nesta charter v2**
+- [ADR 0141 skill migracao-blade-react](../../../memory/decisions/0141-skill-migracao-blade-react.md) — piloto Wave 2 B5 do trilho A Purchase
+- [Pages/Purchase/Create.charter.md](../Purchase/Create.charter.md) — Tier A ★ intocado por C1
 - Pattern Soft wrapper precedente: PR [#1288 Caixa](https://github.com/wagnerra23/oimpresso.com/pull/1288) + PR [#1297 Home](https://github.com/wagnerra23/oimpresso.com/pull/1297)
 - Protótipo canon: `public/cowork-preview/erp-shell-v2/compras-page.{jsx,css}`
 - `Modules/Compras/Http/Controllers/ComprasController.php` — Controller Wave 3

--- a/resources/js/Pages/Compras/Index.tsx
+++ b/resources/js/Pages/Compras/Index.tsx
@@ -51,6 +51,19 @@ interface Summary {
   reembolso: number;
 }
 
+/**
+ * Permissions C1 — ADR compras-purchase-convergencia-c1 (2026-05-25).
+ *
+ * Backend `ComprasController::index()` resolve via `purchase.create/update/delete`
+ * (não `compras.*` — alias V2 se Wagner mantiver módulo separado). User com
+ * `compras.view` mas SEM `purchase.create` vê cockpit sem botão "+ Nova compra".
+ */
+interface PermissionsC1 {
+  create: boolean;
+  update: boolean;
+  delete: boolean;
+}
+
 interface Props {
   filters: {
     q: string;
@@ -60,6 +73,7 @@ interface Props {
     per_page: number;
   };
   selected_id: number | null;
+  permissions: PermissionsC1;
   kpis: Kpis | null;
   rows: RowsPayload | null;
   summary: Summary | null;
@@ -108,7 +122,7 @@ function dueAmount(row: Row): number {
   return Math.max(0, Number(row.final_total ?? 0) - Number(row.amount_paid ?? 0));
 }
 
-function ComprasIndex({ filters, selected_id, kpis, rows, summary, compra_detalhe }: Props) {
+function ComprasIndex({ filters, selected_id, permissions, kpis, rows, summary, compra_detalhe }: Props) {
   const [localFilter, setLocalFilter] = useState<string>(filters.stage || 'all');
   const [drawerInitialTab, setDrawerInitialTab] = useState<'resumo' | 'pagamentos'>('resumo');
   const [colVisibility, setColVisibility] = useColumnVisibility('compras-cols-v1', DEFAULT_COL_VISIBILITY);
@@ -237,9 +251,16 @@ function ComprasIndex({ filters, selected_id, kpis, rows, summary, compra_detalh
           <button className="btn" disabled title="Disponível na Wave 6 (importar XML DF-e)">
             ↓ Importar XML
           </button>
-          <button className="btn primary" disabled title="Disponível na Wave 8 (form de criação)">
-            + Nova compra
-          </button>
+          {permissions.create && (
+            <button
+              className="btn primary"
+              type="button"
+              title="Nova compra (delega /purchases/create · ADR compras-purchase-convergencia-c1)"
+              onClick={() => router.visit('/purchases/create')}
+            >
+              + Nova compra
+            </button>
+          )}
         </header>
 
         {/* TABS */}

--- a/resources/js/Pages/Compras/components/AcoesDropdown.tsx
+++ b/resources/js/Pages/Compras/components/AcoesDropdown.tsx
@@ -1,10 +1,12 @@
 // AcoesDropdown.tsx — paridade Blade /purchases dropdown "Ações" (9 opções).
-// US-COM-001 — Wave 5b.
+// US-COM-001 — Wave 5b + C1 convergência (ADR compras-purchase-convergencia-c1).
 //
-// Bridge mode: ações que JÁ EXISTEM no Inertia (Ver / Ver pagamentos / Excluir)
-// rodam nativo; ações que ainda dependem do Blade legacy (Editar, Imprimir,
-// Rótulos, Reembolso, Atualizar status, Notif. pendente) abrem rota Blade
-// preservando UX legacy enquanto migração progride.
+// Bridge mode evoluído (2026-05-25):
+//   - Editar / Atualizar status / Notif. pendente → router.visit Inertia
+//     (dispara X-Inertia header em PurchaseController:928 → Purchase/Edit.tsx
+//     React, NÃO Blade legacy)
+//   - Ver / Ver pagamentos / Excluir → nativo Inertia desde Wave 5b
+//   - Impressão / Rótulos / Reembolso → seguem Blade legacy (não migrados)
 
 import { router } from '@inertiajs/react';
 import { useEffect, useRef, useState } from 'react';
@@ -112,7 +114,12 @@ export default function AcoesDropdown({
       label: 'Editar',
       icon: '✎',
       hidden: !visibility.canEdit,
-      onClick: () => navigateBlade(`/purchases/${compraId}/edit`),
+      // C1 convergência — router.visit injeta X-Inertia automaticamente,
+      // dispara dual-path em PurchaseController:928 → Purchase/Edit.tsx React.
+      onClick: () => {
+        router.visit(`/purchases/${compraId}/edit`);
+        setOpen(false);
+      },
     },
     {
       id: 'excluir',
@@ -150,16 +157,22 @@ export default function AcoesDropdown({
       label: 'Atualizar status',
       icon: '↻',
       onClick: () => {
-        // Wave 8 substitui por modal Inertia. Bridge: abre tela de edição
-        // que já tem o select de status no form Blade.
-        navigateBlade(`/purchases/${compraId}/edit#status`);
+        // C1 convergência — Inertia Purchase/Edit.tsx React (hash #status
+        // serve como anchor pro scroll inicial). Wave 8 prometia modal
+        // separado, cancelada via ADR compras-purchase-convergencia-c1.
+        router.visit(`/purchases/${compraId}/edit#status`);
+        setOpen(false);
       },
     },
     {
       id: 'notify',
       label: 'Elementos pendentes de notificação',
       icon: '✉',
-      onClick: () => navigateBlade(`/purchases/${compraId}/edit#notify-pending`),
+      // C1 convergência — Inertia Purchase/Edit.tsx React.
+      onClick: () => {
+        router.visit(`/purchases/${compraId}/edit#notify-pending`);
+        setOpen(false);
+      },
     },
   ];
 


### PR DESCRIPTION
## Summary

Cockpit `/compras` deixa de prometer Wave 8 com `Pages/Compras/Create.tsx` separado e passa a delegar CRUD pro trilho A `Pages/Purchase/*` (Wave 2 B5 piloto MWART [ADR 0141](memory/decisions/0141-skill-migracao-blade-react.md), charters Tier A F3 já em smoke).

- **~30 LOC efetivas** de código — botão "+ Nova compra" + AcoesDropdown + sidebar primary action + 1 prop `permissions` no Controller
- **Reusa 1.729 LOC** já validadas (Purchase/{Index,Create,Edit,Show}.tsx + charters Tier A ★) — mata duplicação preventiva
- **Inverte SPEC US-COM-002 (cancelled-c1) + US-COM-004 (inverted-c1)** — `/purchases` permanece canônico, `/compras` é cockpit complementar (coexistem)

Decisão Wagner em [sessão `frosty-greider-83ab2f` 2026-05-25](memory/sessions/2026-05-25-como-integrar-c1-compras-converge-purchase.md) via AskUserQuestion 3-opções (C1 escolhida sobre C2 reescrever Create no estilo Cowork e C3 coexistir sem convergência).

## Como C1 funciona

```ts
// Pages/Compras/Index.tsx — antes
<button className="btn primary" disabled title="Wave 8...">+ Nova compra</button>

// Pages/Compras/Index.tsx — depois
{permissions.create && (
  <button onClick={() => router.visit('/purchases/create')}>+ Nova compra</button>
)}
```

`router.visit` injeta header `X-Inertia` → `PurchaseController:400` dispara dual-path → `Purchase/Create.tsx` React (não Blade legacy).

Mesmo padrão em [AcoesDropdown.tsx:115, 152, 162](resources/js/Pages/Compras/components/AcoesDropdown.tsx) — `navigateBlade` (`window.location.href`) vira `router.visit` Inertia pra Editar / Atualizar status / Notif. pendente.

## Mudanças

### Código (~30 LOC efetivas)
- [Modules/Compras/Http/Controllers/ComprasController.php](Modules/Compras/Http/Controllers/ComprasController.php) — prop `permissions` resolve via `purchase.create/update/delete` (não `compras.*` — alias V2 se Wagner mantiver módulo separado)
- [resources/js/Pages/Compras/Index.tsx](resources/js/Pages/Compras/Index.tsx) — interface `PermissionsC1` + gate botão "+ Nova compra"
- [resources/js/Pages/Compras/components/AcoesDropdown.tsx](resources/js/Pages/Compras/components/AcoesDropdown.tsx) — 3 ações Blade → Inertia (Editar/Atualizar status/Notif pendente). Impressão/Rótulos/Reembolso seguem Blade legacy (não migrados)
- [Modules/Compras/Http/Controllers/DataController.php:114](Modules/Compras/Http/Controllers/DataController.php) — sidebar primary `/compras/create` (404 hoje) vira `/purchases/create`

### Governança
- [memory/decisions/proposals/compras-purchase-convergencia-c1.md](memory/decisions/proposals/compras-purchase-convergencia-c1.md) — ADR proposta. `supersedes_partially: [compras-modulo-greenfield-hibrido]` (Wave 8 cancelled). 4 review triggers
- [resources/js/Pages/Compras/Index.charter.md](resources/js/Pages/Compras/Index.charter.md) — v1 → v2. Non-Goals + Anti-hooks reescritos. Anti-hook novo bloqueia `<a href>` ou `window.location.href` pra `/purchases/*` (cai no Blade sem `X-Inertia`)
- [memory/requisitos/Compras/SPEC.md](memory/requisitos/Compras/SPEC.md) — v0.1 → v0.2. Amendment §0. US-COM-002 cancelled-c1 + US-COM-004 inverted-c1. R-COM-302 anulada
- [memory/sessions/2026-05-25-como-integrar-c1-compras-converge-purchase.md](memory/sessions/2026-05-25-como-integrar-c1-compras-converge-purchase.md) — audit introspectivo via skill `como-integrar` (plug-points + pegadinhas P1-P8 + checklist atômico)

### Tests Pest
- [Modules/Compras/Tests/Feature/ComprasIndexTest.php](Modules/Compras/Tests/Feature/ComprasIndexTest.php) — 2 testes novos:
  - `test_c1_prop_permissions_create_resolve_via_purchase_create` (admin#1 com `purchase.create` vê `permissions.create=true`)
  - `test_c1_user_sem_purchase_create_recebe_permissions_create_false` (viewer-only sem `purchase.create` vê `false` → botão oculto)

## Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md))

**Boa surpresa do audit:** suspeita inicial de divergência (`auth()->user()->business_id` em Purchase vs `session('user.business_id')` em Compras) era erro. Não há divergência. `PurchaseController` 10 sites + `ComprasController:43` → todos `session('user.business_id')`. C1 não toca scope — só roteamento. Tier 0 preservado.

## Não toca

- `Pages/Purchase/{Create,Edit,Show}.tsx` — Tier A ★ intocado (charter F3 aguarda smoke Wagner separadamente)
- `PurchaseController` dual-response — comportamento inalterado
- Botão "↓ Importar XML" — segue `disabled` aguardando Wave 6 US-COM-003 (GAP NOVO bridge `ImportarDfeComoCompraService`)
- Permission alias `compras.* ↔ purchase.*` — review trigger #4 ativa se gap reportado

## Test plan

- [ ] CI Pest verde (3 testes existentes + 2 novos C1)
- [ ] `gh pr checks` verde
- [ ] biz=1 smoke manual: clique "+ Nova compra" em `/compras` abre `Purchase/Create.tsx` React (Chrome MCP `read_console_messages` 0 erros JS)
- [ ] biz=1 smoke manual: AcoesDropdown "Editar" abre `Purchase/Edit.tsx` (não Blade)
- [ ] biz=4 (ROTA LIVRE, opcional Larissa canary) — fluxo cockpit → criar compra real vestuário

## Refs

- ADR proposta [`compras-purchase-convergencia-c1`](memory/decisions/proposals/compras-purchase-convergencia-c1.md) (este PR)
- Session [`frosty-greider-83ab2f` 2026-05-25](memory/sessions/2026-05-25-como-integrar-c1-compras-converge-purchase.md) — comparativo Compras × Sells + decisão Wagner
- [ADR 0141 piloto skill migracao-blade-react](memory/decisions/0141-skill-migracao-blade-react.md) · [ADR 0149 pattern reuse MWART](memory/decisions/0149-pattern-reuse-mwart-create-edit.md)
- [ADR 0093 Tier 0](memory/decisions/0093-multi-tenant-isolation-tier-0.md) · [ADR 0104 MWART canônico](memory/decisions/0104-processo-mwart-canonico-unico-caminho.md) · [ADR 0114 Cowork loop](memory/decisions/0114-prototipo-ui-cowork-loop-formalizado.md)
- Proposta [`compras-modulo-greenfield-hibrido`](memory/decisions/proposals/compras-modulo-greenfield-hibrido.md) — `supersedes_partially` (Wave 8 cancelled, backend híbrido `transactions` polimórfica + Observer Financeiro permanece canon)

🤖 Generated with [Claude Code](https://claude.com/claude-code)