### PR TITLE
fix(financeiro): footer do drawer Unificado sticky-bottom

### DIFF
--- a/resources/css/cowork-canon-financeiro-bundle.css
+++ b/resources/css/cowork-canon-financeiro-bundle.css
@@ -7587,6 +7587,17 @@
   gap: 6px !important;
   padding: 0 14px !important;
 }
+/* Wagner 2026-05-25 — Footer sticky-bottom (irmão do body scrollable).
+   Padrão drawer canon: header fixo + body scroll + footer fixo. */
+.fin-cowork .fin-drawer-footer-sticky {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  padding: 10px 14px !important;
+  border-top: 1px solid var(--border, oklch(0.93 0.01 250));
+  background: white;
+  box-shadow: 0 -1px 0 0 oklch(0.96 0.005 250 / 0.5);
+}
 .fin-cowork .fin-foot-icon-btn {
   display: inline-flex; align-items: center; gap: 5px;
   height: 32px; padding: 0 10px;

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -1413,9 +1413,11 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                 </button>
               </nav>
 
-              {/* Aba Detalhes — info + audit + comments + actions */}
+              {/* Aba Detalhes — info + audit + comments + actions
+                  Wagner 2026-05-25: body com flex-1 + overflow-y-auto + min-h-0
+                  permite o footer (irmão, fora do scroll) ficar sticky-bottom. */}
               {drawerTab === 'detalhes' && (
-                <div className="mt-3 px-5 space-y-5 text-[13px]">
+                <div className="mt-3 px-5 pb-4 space-y-5 text-[13px] flex-1 overflow-y-auto min-h-0">
                   {/* Onda 17 (2026-05-20) — Hierarquia visual canon: UPPERCASE label colorido
                       por status + date 22px BIG + amount 34px BIG (verde se receivable, stone
                       se payable) + StatusPill + FrescorPill inline.
@@ -1595,41 +1597,44 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                     </div>
                   )}
 
-                  {/* Onda 21 (2026-05-20) — Footer canon match prototype financeiro-app.jsx:878-897.
-                      Sequência: Ver NFe (se houver) → Cobrar (receivable não-quitado) →
-                      Recebi/Paguei (primary verde grande) → Editar → Favoritar. */}
-                  <div className="fin-drawer-footer">
-                    {selected.nfe_numero && (
-                      <Button variant="outline" size="sm" className="fin-foot-icon-btn" title="Ver NFe" onClick={() => router.visit(`/fiscal/nfe?numero=${selected.nfe_numero}`)}>
-                        <span aria-hidden>👁</span>
-                        <span className="ml-1">Ver NFe</span>
-                      </Button>
-                    )}
-                    {selected.kind === 'receivable' && (selected.status !== 'recebido') && (
-                      <Button variant="outline" size="sm" className="fin-foot-icon-btn" title="Cobrar contraparte" onClick={() => router.visit(`/cobranca/recorrente/nova?titulo=${selected.id}`)}>
-                        <span aria-hidden>✉</span>
-                        <span className="ml-1">Cobrar</span>
-                      </Button>
-                    )}
-                    {(selected.status !== 'recebido' && selected.status !== 'pago') && (
-                      <Button onClick={() => onBaixar(selected.id)} className="fin-foot-mark-btn">
-                        <span aria-hidden>✓</span>
-                        <span className="ml-1">{selected.kind === 'receivable' ? 'Recebi' : 'Paguei'}</span>
-                      </Button>
-                    )}
-                    <Button variant="outline" size="sm" className="fin-edit-btn" onClick={() => setEditOpen(true)}>Editar</Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => favs.toggle(selected.id)}
-                      title="Atalho: B (com a linha selecionada)"
-                    >
-                      {favs.has(selected.id) ? '★ Favoritado' : '☆ Favoritar'}
-                    </Button>
-                  </div>
-
                   {/* US-FIN-026 (Onda 22) — painel completo Anexos (substitui botão upload-only Onda 20). */}
                   <FinAnexosPanel tituloId={selected.id} />
+                </div>
+              )}
+
+              {/* Onda 21 (2026-05-20) + Wagner 2026-05-25 — Footer sticky-bottom.
+                  Irmão do body scrollable (não filho) pra ficar fixado no rodapé
+                  do SheetContent flex-col h-full. Sequência canon:
+                  Ver NFe → Cobrar → Recebi/Paguei → Editar → Favoritar. */}
+              {drawerTab === 'detalhes' && (
+                <div className="fin-drawer-footer fin-drawer-footer-sticky">
+                  {selected.nfe_numero && (
+                    <Button variant="outline" size="sm" className="fin-foot-icon-btn" title="Ver NFe" onClick={() => router.visit(`/fiscal/nfe?numero=${selected.nfe_numero}`)}>
+                      <span aria-hidden>👁</span>
+                      <span className="ml-1">Ver NFe</span>
+                    </Button>
+                  )}
+                  {selected.kind === 'receivable' && (selected.status !== 'recebido') && (
+                    <Button variant="outline" size="sm" className="fin-foot-icon-btn" title="Cobrar contraparte" onClick={() => router.visit(`/cobranca/recorrente/nova?titulo=${selected.id}`)}>
+                      <span aria-hidden>✉</span>
+                      <span className="ml-1">Cobrar</span>
+                    </Button>
+                  )}
+                  {(selected.status !== 'recebido' && selected.status !== 'pago') && (
+                    <Button onClick={() => onBaixar(selected.id)} className="fin-foot-mark-btn">
+                      <span aria-hidden>✓</span>
+                      <span className="ml-1">{selected.kind === 'receivable' ? 'Recebi' : 'Paguei'}</span>
+                    </Button>
+                  )}
+                  <Button variant="outline" size="sm" className="fin-edit-btn" onClick={() => setEditOpen(true)}>Editar</Button>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => favs.toggle(selected.id)}
+                    title="Atalho: B (com a linha selecionada)"
+                  >
+                    {favs.has(selected.id) ? '★ Favoritado' : '☆ Favoritar'}
+                  </Button>
                 </div>
               )}
 


### PR DESCRIPTION
## Summary
- Antes: `<div class=\"fin-drawer-footer\">` renderizava **no meio** do scroll da aba Detalhes (entre Aprovação e FinAnexosPanel). Botão **Editar** e demais ações (Ver NFe, Cobrar, Recebi/Paguei, Favoritar) ficavam invisíveis sem rolar até o meio do conteúdo.
- Depois: footer extraído pra fora do bloco da aba (irmão direto do SheetContent, dentro do mesmo flex-col h-full). Body da aba ganha `flex-1 overflow-y-auto min-h-0` pra scrollar isolado; footer fica naturalmente colado no rodapé.

## Mudanças (2 arquivos · +51/-35)
- **Index.tsx** — body da aba Detalhes vira flex-1 scrollable; bloco do footer movido pra fora (irmão), renderizado condicionalmente só quando `drawerTab === 'detalhes'` (IA e Editar não têm footer).
- **cowork-canon-financeiro-bundle.css** — nova classe `.fin-drawer-footer-sticky`: `flex-shrink:0` + `border-top` + `background:white` + `box-shadow` sutil pra demarcar separação visual do body scroll. Mesmo gap/padding canon do `.fin-drawer-footer`.

## Padrão canon
Drawer Linear/Notion: **header fixo + body scroll + footer fixo**. Esta PR fecha a parte do footer. Header sticky-top já vem do Sheet/Radix padrão.

## Test plan
- [ ] Após deploy, abrir `/financeiro/unificado` → clicar em linha → aba Detalhes
- [ ] Esperado: footer (Ver NFe / Cobrar / Recebi / Editar / Favoritar) fixo no rodapé do drawer, com border-top visual; conteúdo da aba scrolla SEM mover o footer
- [ ] Não-regressão: troca pra aba IA ou Editar → footer some (correto, só Detalhes tem)
- [ ] Não-regressão: drawer no mobile (width <460px) — footer continua colado no fundo

## Relacionado
PR irmão #1522 (aba IA com formatação canon) — mergeado em main hoje.

🤖 Generated with [Claude Code](https://claude.com/claude-code)