### PR TITLE
fix(financeiro): select "Plano de Contas" da toolbar com classe canon

### DIFF
--- a/resources/css/cowork-canon-financeiro-bundle.css
+++ b/resources/css/cowork-canon-financeiro-bundle.css
@@ -8389,6 +8389,29 @@
 .fin-cowork .fin-toolbar .fin-filter-toggle:hover {
   border-color: var(--text-mute); color: var(--text);
 }
+/* Wagner 2026-05-25 — fin-filter-select casa altura/border/font com chips
+   `.fin-filter-cb` e `.fin-filter-toggle` na mesma toolbar (substitui o
+   select nativo Tailwind cru que ficava desalinhado verticalmente). */
+.fin-cowork .fin-toolbar .fin-filter-select {
+  display: inline-flex; align-items: center;
+  padding: 5px 26px 5px 10px;
+  border-radius: 5px;
+  border: 1px solid var(--border); background: var(--surface);
+  font-size: 12px; font-weight: 500; color: var(--text-dim);
+  font-family: inherit; line-height: 1.4;
+  cursor: pointer; transition: all .12s;
+  appearance: none; -webkit-appearance: none; -moz-appearance: none;
+  background-image: url("data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' width='10' height='6' viewBox='0 0 10 6'><path d='M1 1l4 4 4-4' stroke='%2378716c' stroke-width='1.5' fill='none' stroke-linecap='round' stroke-linejoin='round'/></svg>");
+  background-repeat: no-repeat;
+  background-position: right 9px center;
+}
+.fin-cowork .fin-toolbar .fin-filter-select:hover {
+  border-color: var(--text-mute); color: var(--text);
+}
+.fin-cowork .fin-toolbar .fin-filter-select:focus-visible {
+  outline: 2px solid oklch(0.55 0.15 295);
+  outline-offset: 1px;
+}
 .fin-cowork .fin-toolbar .fin-filter-toggle input {
   appearance: none; -webkit-appearance: none;
   width: 13px; height: 13px;

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -1140,7 +1140,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
             visual via `nivel` (4 espaços por nível) pra leitura tipo árvore.
             Mantém prop `filters.categoria` por back-compat (mesmo querystring). */}
         <select
-          className="h-7 px-2 rounded-md border border-stone-200 text-[12px] bg-white"
+          className="fin-filter-select"
           value={filters.categoria}
           onChange={(e) => aplicar({ categoria: e.target.value })}
           aria-label="Plano de Contas"


### PR DESCRIPTION
## Summary
- Antes: o `<select>` do plano de contas (toolbar Financeiro/Unificado) usava Tailwind cru (`h-7 px-2 rounded-md border border-stone-200 text-[12px] bg-white`), **desalinhado vertical/visualmente** dos chips `.fin-filter-cb` (lifecycle) e `.fin-filter-toggle` ("Só atrasados") na mesma linha — quebrava o ritmo da toolbar.
- Depois: nova classe canon `.fin-filter-select` com mesma signature dos chips. Chevron SVG inline no `background-image` resolve `appearance:none` sem perder a11y keyboard. Focus-visible com outline roxo 295 canon.
- Não toca `FinMultiSelectContas` (já é canon próprio via Popover+Checkbox).

## Mudanças (2 arquivos · +24/-1)
- **Index.tsx:1143** — select `className` Tailwind cru → `fin-filter-select`.
- **cowork-canon-financeiro-bundle.css:8392-8414** — nova classe canon `.fin-filter-select`:
  - padding/border/font-size/color iguais aos chips
  - `appearance:none` + chevron SVG inline (stone 500)
  - hover/focus-visible canon

## Test plan
- [ ] Após deploy, abrir `/financeiro/unificado` → toolbar de filtros
- [ ] Esperado: select "Todo o plano de contas" com mesma altura/border-radius/cor de borda dos chips à esquerda. Chevron customizado visível à direita. Ao focar via Tab, outline roxo 295 aparece.
- [ ] Não-regressão: dropdown abre normalmente, opções com indent visual `nivel` preservadas.

## Relacionado
PR irmãos:
- #1522 (aba IA com formatação canon) — mergeado
- #1526 (footer sticky-bottom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)