### PR TITLE
fix(repair): Carbon::parse defensivo em venda_derivada (transaction_date string)

### DIFF
--- a/Modules/Repair/Http/Controllers/ProducaoOficinaController.php
+++ b/Modules/Repair/Http/Controllers/ProducaoOficinaController.php
@@ -365,7 +365,9 @@ class ProducaoOficinaController extends Controller
             'id' => $tx->id,
             'invoice_no' => $tx->invoice_no,
             'final_total' => (float) $tx->final_total,
-            'transaction_date' => $tx->transaction_date?->toDateString(),
+            // Defensive cast: select específico (linha 272) NÃO dispara model casts auto-Carbon
+            // → $tx->transaction_date vem como string. Carbon::parse handle both cases.
+            'transaction_date' => $tx->transaction_date ? \Carbon\Carbon::parse($tx->transaction_date)->toDateString() : null,
             'items_list' => $itemsList,
             'items_summary' => [
                 'products_count' => $productsCount,


### PR DESCRIPTION
**Bug discovered live em demo prod biz=164 MARTINHO 2026-05-25 16:45.**

`ProducaoOficinaController:368` chamava `toDateString()` em string (não Carbon instance) → **500 Server Error** em `/repair/producao-oficina` quando há OS com `venda_derivada` existente.

## Causa raiz

Query select específico na linha 272 (`->get(['id', 'repair_job_sheet_id', 'invoice_no', 'final_total', 'transaction_date'])`) **não dispara model casts auto pra Carbon** — Eloquent só aplica cast quando coluna está implícita no select all.

## Fix · 3 LOC

```php
'transaction_date' => $tx->transaction_date ? \Carbon\Carbon::parse($tx->transaction_date)->toDateString() : null,
```

Defensive: handle both string e Carbon instance.

## Impacto

- ❌ Pré-fix: `/repair/producao-oficina` retornava 500 quando há ao menos 1 venda_derivada no biz
- ✅ `/sells` lista vendas Oficina **NÃO afetado** (campo source vai como string puro)
- ✅ Bug surgiu APENAS após primeira OS terminal-transition (Observer disparar)
- Demo prod MARTINHO biz=164 confirmou + cleanup imediato

Refs: PR #1510 W2 (commit `2f6f10fc8` · Onda 3 backend expand venda_derivada) · ADR 0192