### PR TITLE
fix(sells): onPickOs roteia por prefix (OS-/SO- distingue Repair vs OficinaAuto)

### DIFF
--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -1532,9 +1532,16 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
             onRowClick={(id, ri) => { setFocusIdx(ri); setOpenSaleId(id); }}
             onPaySuccess={() => setRefetchToken((t) => t + 1)}
             onPickOs={(osRef) => {
-              // Cross-módulo Onda 3: clique no link OS-NNNN da pill VdSource navega pro
-              // Repair/ProducaoOficina (Worker B Onda 5 vai abrir drawer da OS direto).
-              window.location.href = `/repair/producao-oficina?os=${encodeURIComponent(osRef)}`;
+              // Cross-módulo Onda 3 + extensão ServiceOrderObserver 2026-05-25:
+              // Roteia por prefix do os_ref pra evitar levar SO-NNNN pra Repair
+              // (que só conhece JobSheet · resultaria em kanban vazio).
+              //   OS-{id}  → Modules/Repair/JobSheet         → /repair/producao-oficina
+              //   SO-{id}  → Modules/OficinaAuto/ServiceOrder → /oficina-auto/producao-oficina
+              const isOficinaAuto = osRef.startsWith('SO-');
+              const targetPath = isOficinaAuto
+                ? '/oficina-auto/producao-oficina'
+                : '/repair/producao-oficina';
+              window.location.href = `${targetPath}?os=${encodeURIComponent(osRef)}`;
             }}
           />
         </div>


### PR DESCRIPTION
Bug revealed in review 2026-05-25 pós-merge ServiceOrderObserver (PR #1530).

`Sells/Index.tsx::onPickOs` sempre navegava pra `/repair/producao-oficina` ignorando prefix do `os_ref`. Após extensão ADR 0192 cobrir ServiceOrder, vendas com `os_ref='SO-{id}'` (OficinaAuto caçambas Martinho) caem em Repair kanban vazio.

## Fix · 8 LOC

```typescript
const isOficinaAuto = osRef.startsWith('SO-');
const targetPath = isOficinaAuto
  ? '/oficina-auto/producao-oficina'
  : '/repair/producao-oficina';
window.location.href = `${targetPath}?os=${encodeURIComponent(osRef)}`;
```

## Tabela cobertura pós-fix

| Click | Source | Roteia pra |
|---|---|---|
| `↗ #OS-3` | Modules/Repair/JobSheet | `/repair/producao-oficina?os=OS-3` |
| `↗ #SO-98` | Modules/OficinaAuto/ServiceOrder | `/oficina-auto/producao-oficina?os=SO-98` |

## Backlog (não bloqueia)

Drawer auto-open via `?os=` query param ainda não implementado nos kanbans receptores. Usuario chega no kanban correto mas precisa click manual no card pra abrir drawer. Wave futura.