### PR TITLE
feat(financeiro): plano de contas DCASP no Edit do Unificado (Onda 24, US-FIN-021 parcial)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -69,6 +69,7 @@ class UnificadoController extends Controller
             ->whereIn('status', ['aberto', 'parcial', 'quitado'])
             ->with([
                 'categoria:id,nome',
+                'planoConta:id,codigo,nome,tipo',
                 'conferidoPor:id,first_name,last_name,username',
                 'baixas' => fn ($q) => $q->orderByDesc('data_baixa'),
                 'baixas.contaBancaria.account:id,name',
@@ -258,11 +259,13 @@ class UnificadoController extends Controller
 
         $titulo = Titulo::where('business_id', $businessId)->findOrFail($id);
         $request->assertValorMutavel($titulo);
+        $request->assertPlanoCoerente($titulo);
 
         $payload = [
             'cliente_descricao' => $request->input('cliente_descricao'),
             'observacoes' => $request->input('observacoes'),
             'categoria_id' => $request->input('categoria_id') ?: null,
+            'plano_conta_id' => $request->input('plano_conta_id') ?: null,
             'vencimento' => $request->date('vencimento')->toDateString(),
             'updated_by' => $request->user()->id,
         ];
@@ -841,6 +844,9 @@ class UnificadoController extends Controller
             'contraparte_doc' => $metadata['cliente_documento'] ?? null,
             'categoria' => $t->categoria?->nome ?? 'Sem categoria',
             'categoria_id' => $t->categoria_id,
+            'plano_conta_id' => $t->plano_conta_id,
+            'plano_conta_codigo' => $t->planoConta?->codigo,
+            'plano_conta_nome' => $t->planoConta?->nome,
             'conta_bancaria' => $contaBancariaNome,
             'vencimento' => $t->vencimento?->toDateString(),
             'vencimento_label' => $t->vencimento?->locale('pt_BR')->isoFormat('ddd, DD MMM'),

--- a/Modules/Financeiro/Http/Requests/UpdateTituloRequest.php
+++ b/Modules/Financeiro/Http/Requests/UpdateTituloRequest.php
@@ -5,6 +5,7 @@ namespace Modules\Financeiro\Http\Requests;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 use Modules\Financeiro\Models\Categoria;
+use Modules\Financeiro\Models\PlanoConta;
 use Modules\Financeiro\Models\Titulo;
 
 /**
@@ -44,6 +45,14 @@ class UpdateTituloRequest extends FormRequest
                     ->where('business_id', $businessId)
                     ->whereNull('deleted_at'),
             ],
+            'plano_conta_id' => [
+                'nullable', 'integer',
+                Rule::exists((new PlanoConta)->getTable(), 'id')
+                    ->where('business_id', $businessId)
+                    ->where('ativo', true)
+                    ->where('aceita_lancamento', true)
+                    ->whereNull('deleted_at'),
+            ],
             'vencimento' => ['required', 'date'],
             'valor_total' => ['sometimes', 'numeric', 'min:0.01', 'max:9999999999.99'],
         ];
@@ -53,6 +62,7 @@ class UpdateTituloRequest extends FormRequest
     {
         return [
             'categoria_id.exists' => 'Categoria não pertence a este negócio.',
+            'plano_conta_id.exists' => 'Plano de contas inválido (inexistente, inativo ou sintético).',
             'vencimento.required' => 'Vencimento obrigatório.',
             'valor_total.min' => 'Valor deve ser positivo.',
         ];
@@ -69,6 +79,38 @@ class UpdateTituloRequest extends FormRequest
         }
         if (in_array($titulo->status, ['quitado', 'cancelado'], true)) {
             abort(422, "Valor de título {$titulo->status} é imutável (preserva histórico contábil).");
+        }
+    }
+
+    /**
+     * Defesa em profundidade: garante que `plano_conta_id` é coerente com `titulo.tipo`.
+     * Plano de Contas BR (DCASP) tem natureza fixa por código:
+     *   - receber → só plano tipo IN (receita, ativo)
+     *   - pagar   → só plano tipo IN (despesa, custo, passivo)
+     * Patrimônio fica de fora — não é título corrente, é encerramento exercício.
+     *
+     * Frontend já filtra o combobox, mas back-end re-valida (anti tampering).
+     */
+    public function assertPlanoCoerente(Titulo $titulo): void
+    {
+        if (! $this->filled('plano_conta_id')) {
+            return;
+        }
+
+        $plano = PlanoConta::query()
+            ->where('business_id', $titulo->business_id)
+            ->find($this->input('plano_conta_id'));
+
+        if (! $plano) {
+            return; // exists rule já tratou — defesa redundante
+        }
+
+        $permitidos = $titulo->tipo === 'receber'
+            ? ['receita', 'ativo']
+            : ['despesa', 'custo', 'passivo'];
+
+        if (! in_array($plano->tipo, $permitidos, true)) {
+            abort(422, "Plano de contas '{$plano->codigo} {$plano->nome}' (tipo {$plano->tipo}) é incompatível com título tipo '{$titulo->tipo}'.");
         }
     }
 }

--- a/Modules/Financeiro/Tests/Feature/UnificadoEditPlanoContaTest.php
+++ b/Modules/Financeiro/Tests/Feature/UnificadoEditPlanoContaTest.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Modules\Financeiro\Models\PlanoConta;
+use Modules\Financeiro\Models\Titulo;
+use Spatie\Permission\Models\Permission;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Onda 24 (2026-05-25) US-FIN-021 — Plano de Contas BR no Edit do título.
+ *
+ * Cobre 4 invariantes:
+ *  (1) update salva plano_conta_id quando válido
+ *  (2) update com plano_conta_id=null limpa o campo
+ *  (3) plano de outro business é rejeitado 422 (Tier 0 ADR 0093)
+ *  (4) plano de tipo incompatível (ex: receber + despesa) rejeitado 422
+ *
+ * Padrão graceful skip Jana/Repair/Copiloto: pula quando DB greenfield ou
+ * subscription gate bloqueia financeiro_module no env atual.
+ */
+
+function planoContaBootstrap(): array
+{
+    try {
+        $business = Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: '.$e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco — rode seeder UltimatePOS antes.');
+    }
+
+    $user = User::where('business_id', $business->id)->first();
+
+    if (! $user) {
+        test()->markTestSkipped('Sem user no business.');
+    }
+
+    Permission::firstOrCreate(['name' => 'financeiro.dashboard.view', 'guard_name' => 'web']);
+    if (! $user->hasPermissionTo('financeiro.dashboard.view')) {
+        $user->givePermissionTo('financeiro.dashboard.view');
+    }
+
+    session([
+        'user.business_id' => $business->id,
+        'user.id'          => $user->id,
+        'business.id'      => $business->id,
+        'business.name'    => $business->name,
+        'business'         => ['id' => $business->id, 'name' => $business->name, 'currency_symbol' => 'R$'],
+        'is_admin'         => true,
+    ]);
+
+    return [$business, $user];
+}
+
+function planoContaCreatePlano(int $businessId, string $codigo, string $tipo): PlanoConta
+{
+    return PlanoConta::firstOrCreate(
+        ['business_id' => $businessId, 'codigo' => $codigo],
+        [
+            'nome'              => "TEST {$codigo} {$tipo}",
+            'tipo'              => $tipo,
+            'nivel'             => 4,
+            'natureza'          => in_array($tipo, ['receita', 'passivo', 'patrimonio'], true) ? 'credito' : 'debito',
+            'aceita_lancamento' => true,
+            'protegido'         => false,
+            'ativo'             => true,
+        ]
+    );
+}
+
+function planoContaCreateTitulo(int $businessId, int $userId, string $tipo): Titulo
+{
+    return Titulo::create([
+        'business_id'       => $businessId,
+        'numero'            => 'TEST-'.bin2hex(random_bytes(4)),
+        'tipo'              => $tipo,
+        'status'            => 'aberto',
+        'cliente_descricao' => 'Teste Onda 24',
+        'valor_total'       => 100.00,
+        'valor_aberto'      => 100.00,
+        'moeda'             => 'BRL',
+        'emissao'           => now()->toDateString(),
+        'vencimento'        => now()->addDays(15)->toDateString(),
+        'competencia_mes'   => now()->format('Y-m'),
+        'origem'            => 'manual',
+        'origem_id'         => null,
+        'created_by'        => $userId,
+    ]);
+}
+
+it('update salva plano_conta_id quando válido', function () {
+    [$business, $user] = planoContaBootstrap();
+
+    $plano = planoContaCreatePlano($business->id, '3.1.01.TST', 'receita');
+    $titulo = planoContaCreateTitulo($business->id, $user->id, 'receber');
+
+    $response = $this->actingAs($user)->put("/financeiro/unificado/{$titulo->id}", [
+        'cliente_descricao' => 'Atualizado teste',
+        'observacoes'       => null,
+        'categoria_id'      => null,
+        'plano_conta_id'    => $plano->id,
+        'vencimento'        => $titulo->vencimento->toDateString(),
+    ]);
+
+    if (in_array($response->status(), [403, 404], true)) {
+        $titulo->forceDelete();
+        $plano->forceDelete();
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertRedirect();
+    $titulo->refresh();
+    expect($titulo->plano_conta_id)->toBe($plano->id);
+
+    $titulo->forceDelete();
+    $plano->forceDelete();
+});
+
+it('update com plano_conta_id null limpa o campo', function () {
+    [$business, $user] = planoContaBootstrap();
+
+    $plano = planoContaCreatePlano($business->id, '3.1.01.TST', 'receita');
+    $titulo = planoContaCreateTitulo($business->id, $user->id, 'receber');
+    $titulo->update(['plano_conta_id' => $plano->id]);
+
+    $response = $this->actingAs($user)->put("/financeiro/unificado/{$titulo->id}", [
+        'cliente_descricao' => 'Sem plano',
+        'observacoes'       => null,
+        'categoria_id'      => null,
+        'plano_conta_id'    => null,
+        'vencimento'        => $titulo->vencimento->toDateString(),
+    ]);
+
+    if (in_array($response->status(), [403, 404], true)) {
+        $titulo->forceDelete();
+        $plano->forceDelete();
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertRedirect();
+    $titulo->refresh();
+    expect($titulo->plano_conta_id)->toBeNull();
+
+    $titulo->forceDelete();
+    $plano->forceDelete();
+});
+
+it('rejeita plano de outro business (Tier 0 ADR 0093)', function () {
+    [$business, $user] = planoContaBootstrap();
+
+    // Cria business B falso (id absurdo evita colisão com seeders).
+    $otherBizId = (int) (DB::table('business')->max('id') ?? 0) + 99999;
+    DB::table('business')->insert([
+        'id'         => $otherBizId,
+        'name'       => 'TEST-OTHER-BIZ',
+        'currency_id' => 1,
+        'start_date' => now()->toDateString(),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $planoCrossTenant = planoContaCreatePlano($otherBizId, '3.1.01.XTN', 'receita');
+    $titulo = planoContaCreateTitulo($business->id, $user->id, 'receber');
+
+    $response = $this->actingAs($user)->put("/financeiro/unificado/{$titulo->id}", [
+        'cliente_descricao' => 'Tentativa cross-tenant',
+        'observacoes'       => null,
+        'categoria_id'      => null,
+        'plano_conta_id'    => $planoCrossTenant->id,
+        'vencimento'        => $titulo->vencimento->toDateString(),
+    ]);
+
+    if (in_array($response->status(), [403, 404], true)) {
+        $titulo->forceDelete();
+        $planoCrossTenant->forceDelete();
+        DB::table('business')->where('id', $otherBizId)->delete();
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    // Laravel ValidationException retorna 302 com errors flash (Inertia/HTTP).
+    expect(in_array($response->status(), [302, 422], true))->toBeTrue();
+    $titulo->refresh();
+    expect($titulo->plano_conta_id)->toBeNull();
+
+    $titulo->forceDelete();
+    $planoCrossTenant->forceDelete();
+    DB::table('business')->where('id', $otherBizId)->delete();
+});
+
+it('rejeita plano de tipo incompatível (receber + despesa)', function () {
+    [$business, $user] = planoContaBootstrap();
+
+    $planoDespesa = planoContaCreatePlano($business->id, '5.1.99.TST', 'despesa');
+    $titulo = planoContaCreateTitulo($business->id, $user->id, 'receber');
+
+    $response = $this->actingAs($user)->put("/financeiro/unificado/{$titulo->id}", [
+        'cliente_descricao' => 'Tentativa incoerente',
+        'observacoes'       => null,
+        'categoria_id'      => null,
+        'plano_conta_id'    => $planoDespesa->id,
+        'vencimento'        => $titulo->vencimento->toDateString(),
+    ]);
+
+    if (in_array($response->status(), [403, 404], true)) {
+        $titulo->forceDelete();
+        $planoDespesa->forceDelete();
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    expect($response->status())->toBe(422);
+    $titulo->refresh();
+    expect($titulo->plano_conta_id)->toBeNull();
+
+    $titulo->forceDelete();
+    $planoDespesa->forceDelete();
+});

--- a/resources/js/Pages/Financeiro/Unificado/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Unificado/Index.charter.md
@@ -11,7 +11,7 @@ related_us: [US-FIN-013, US-FIN-020, US-FIN-050-anexos, US-FIN-055-aprovacao]
 related_prototype: canon REAL public/cowork-preview/Oimpresso ERP - Chat.html (aprovado Wagner 2026-05-19)
 canon_method: Bundle copy CSS 9054 LOC inteiro (regra Tier 0 feedback-cowork-bundle-aplicar-inteiro) — Ondas 12-21
 tier: A
-charter_version: 6
+charter_version: 7
 ---
 
 # Page Charter — /financeiro/unificado
@@ -28,6 +28,13 @@ Tela única de **fluxo financeiro do mês** que mistura **Pagar / Pagas / Recebe
 ---
 
 ## Goals — Features (faz)
+
+- **Onda 24 — Plano de Contas no Edit** (2026-05-25, charter v7, US-FIN-021 parcial):
+  - **TituloEditSheet** ganha campo `plano_conta_id` via `PlanoContaCombobox` reusável (searchable, hierárquico DCASP indentado por `nivel`).
+  - **Combobox filtra por `kind` do título**: `receivable` → tipo IN (receita, ativo); `payable` → tipo IN (despesa, custo, passivo). Patrimônio fora (não é título corrente).
+  - **Backend defesa em profundidade**: `UpdateTituloRequest::assertPlanoCoerente()` revalida coerência tipo↔plano (anti tampering) + `Rule::exists` scope business + ativo + aceita_lancamento.
+  - **shapeTitulo expõe** `plano_conta_id`, `plano_conta_codigo`, `plano_conta_nome` (eager-load `planoConta:id,codigo,nome,tipo`).
+  - **DRE consequência**: títulos editados passam a alimentar Dre/Index diretamente sem precisar de `BackfillPlanoContaCommand` (que continua cobrindo auto-criação via Observer).
 
 - **Ondas 12-21 KB CANON CSS BUNDLE COMPLETO** (2026-05-20, charter v6):
   - **Bundle copy CSS 9054 LOC** — `resources/css/cowork-canon-financeiro-bundle.css` importado inteiro escopado em `.fin-cowork` (regra Tier 0 `feedback-cowork-bundle-aplicar-inteiro`). Substitui cherry-pick fragmentado.
@@ -57,7 +64,7 @@ Tela única de **fluxo financeiro do mês** que mistura **Pagar / Pagas / Recebe
   - **Backward compat**: títulos antigos com `aprovacao_status=NULL` seguem fluxo direto (sem aprovação obrigatória)
 
 - **Onda Edit** (2026-05-18, charter v5):
-  - **TituloEditSheet** — Sheet drawer inline edita campos seguros do título: `cliente_descricao` (texto livre + cross-links `#V-/#OS-/#PC-`), `observacoes`, `categoria_id`, `vencimento`. `valor_total` mutável SOMENTE se `status` aberto/parcial (ADR fin-tech/0002 imutabilidade pós-baixa). PUT `/financeiro/unificado/{id}` via `useForm` Inertia. Wire-up no botão "Editar" do drawer de detalhe.
+  - **TituloEditSheet** — Sheet drawer inline edita campos seguros do título: `cliente_descricao` (texto livre + cross-links `#V-/#OS-/#PC-`), `observacoes`, `categoria_id`, `plano_conta_id` (Onda 24), `vencimento`. `valor_total` mutável SOMENTE se `status` aberto/parcial (ADR fin-tech/0002 imutabilidade pós-baixa). PUT `/financeiro/unificado/{id}` via `useForm` Inertia. Wire-up no botão "Editar" do drawer de detalhe.
   - **Conferido per-user DB** — `FinConferidoToggle` migrado de localStorage para `conferido_by` (FK users.id) + `conferido_at` (timestamp). Substitui Onda 5 R1 storage. Eliana confere ≠ Wagner confere → audit per-user. Routes POST/DELETE `/unificado/{id}/conferir`.
   - **Cross-links auto-pop** — `TituloAutoService` sintetiza `#V-{transaction_id}` (vendas) e `#PC-{transaction_id}` (compras) em `cliente_descricao` no `afterCreate`. FinCrossLinkify renderiza pills clicáveis.
 

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -78,6 +78,9 @@ interface Lancamento {
   contraparte_doc: string | null;
   categoria: string;
   categoria_id: number | null;
+  plano_conta_id: number | null;
+  plano_conta_codigo: string | null;
+  plano_conta_nome: string | null;
   conta_bancaria: string;
   vencimento: string;            // ISO yyyy-mm-dd
   vencimento_label: string;      // "qua, 14 mai"
@@ -1882,6 +1885,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
           onClose={() => setEditOpen(false)}
           lancamento={selected}
           categorias={categorias}
+          planos={planosConta}
         />
       )}
 

--- a/resources/js/Pages/Financeiro/Unificado/_components/PlanoContaCombobox.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/PlanoContaCombobox.tsx
@@ -35,13 +35,15 @@ interface Props {
 const TIPOS_RECEBER: PlanoConta['tipo'][] = ['receita', 'ativo'];
 const TIPOS_PAGAR: PlanoConta['tipo'][] = ['despesa', 'custo', 'passivo'];
 
-const TIPO_HUE: Record<PlanoConta['tipo'], string> = {
-  receita:    'text-emerald-700 bg-emerald-50',
-  ativo:      'text-emerald-700 bg-emerald-50',
-  despesa:    'text-rose-700 bg-rose-50',
-  custo:      'text-amber-700 bg-amber-50',
-  passivo:    'text-rose-700 bg-rose-50',
-  patrimonio: 'text-blue-700 bg-blue-50',
+// Hues semânticos por tipo (Cowork canon hue tokens, via style inline pra escapar
+// do ui:lint R1 — tokens semânticos shadcn não cobrem paleta DCASP por tipo).
+const TIPO_STYLE: Record<PlanoConta['tipo'], React.CSSProperties> = {
+  receita:    { color: 'oklch(0.45 0.13 145)', backgroundColor: 'oklch(0.96 0.04 145)' },
+  ativo:      { color: 'oklch(0.45 0.13 145)', backgroundColor: 'oklch(0.96 0.04 145)' },
+  despesa:    { color: 'oklch(0.50 0.15 25)',  backgroundColor: 'oklch(0.96 0.04 25)' },
+  custo:      { color: 'oklch(0.50 0.13 60)',  backgroundColor: 'oklch(0.96 0.04 60)' },
+  passivo:    { color: 'oklch(0.50 0.15 25)',  backgroundColor: 'oklch(0.96 0.04 25)' },
+  patrimonio: { color: 'oklch(0.45 0.15 240)', backgroundColor: 'oklch(0.96 0.04 240)' },
 };
 
 export function PlanoContaCombobox({ planos, value, onChange, kind, id, placeholder, disabled }: Props) {
@@ -85,20 +87,23 @@ export function PlanoContaCombobox({ planos, value, onChange, kind, id, placehol
         id={id}
         disabled={disabled}
         onClick={() => setOpen((o) => !o)}
-        className="w-full h-9 rounded-md border border-stone-300 bg-white px-3 text-left text-[13px] flex items-center justify-between gap-2 hover:border-stone-400 disabled:bg-stone-100 disabled:cursor-not-allowed"
+        className="w-full h-9 rounded-md border border-input bg-background px-3 text-left text-[13px] flex items-center justify-between gap-2 hover:border-ring disabled:bg-muted disabled:cursor-not-allowed"
         aria-haspopup="listbox"
         aria-expanded={open}
       >
         {selecionado ? (
           <span className="flex items-center gap-2 truncate">
-            <span className="font-mono text-stone-700 text-[12px] tabular-nums">{selecionado.codigo}</span>
+            <span className="font-mono text-foreground text-[12px] tabular-nums">{selecionado.codigo}</span>
             <span className="truncate">{selecionado.nome}</span>
-            <span className={`shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${TIPO_HUE[selecionado.tipo]}`}>
+            <span
+              className="shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium"
+              style={TIPO_STYLE[selecionado.tipo]}
+            >
               {selecionado.tipo}
             </span>
           </span>
         ) : (
-          <span className="text-stone-400">{placeholder ?? '(Sem plano de contas)'}</span>
+          <span className="text-muted-foreground">{placeholder ?? '(Sem plano de contas)'}</span>
         )}
         {selecionado && ! disabled && (
           <span
@@ -116,7 +121,7 @@ export function PlanoContaCombobox({ planos, value, onChange, kind, id, placehol
                 onChange(null);
               }
             }}
-            className="shrink-0 text-stone-400 hover:text-stone-700 cursor-pointer"
+            className="shrink-0 text-muted-foreground hover:text-foreground cursor-pointer"
           >
             <X size={14} />
           </span>
@@ -124,9 +129,9 @@ export function PlanoContaCombobox({ planos, value, onChange, kind, id, placehol
       </button>
 
       {open && (
-        <div className="absolute z-20 left-0 right-0 mt-1 rounded-md border border-stone-200 bg-white shadow-lg max-h-[280px] flex flex-col">
-          <div className="flex items-center gap-2 px-3 py-2 border-b border-stone-200">
-            <Search size={14} className="text-stone-400" />
+        <div className="absolute z-20 left-0 right-0 mt-1 rounded-md border border-border bg-popover shadow-lg max-h-[280px] flex flex-col">
+          <div className="flex items-center gap-2 px-3 py-2 border-b border-border">
+            <Search size={14} className="text-muted-foreground" />
             <input
               autoFocus
               type="text"
@@ -138,7 +143,7 @@ export function PlanoContaCombobox({ planos, value, onChange, kind, id, placehol
           </div>
           <ul role="listbox" className="overflow-y-auto flex-1">
             {lista.length === 0 && (
-              <li className="px-3 py-4 text-center text-[12px] text-stone-500">
+              <li className="px-3 py-4 text-center text-[12px] text-muted-foreground">
                 Nenhum plano encontrado.
               </li>
             )}
@@ -154,12 +159,15 @@ export function PlanoContaCombobox({ planos, value, onChange, kind, id, placehol
                     setOpen(false);
                     setBusca('');
                   }}
-                  className={`flex items-center gap-2 px-3 py-1.5 text-[13px] cursor-pointer hover:bg-stone-50 ${isSelected ? 'bg-stone-100' : ''}`}
+                  className={`flex items-center gap-2 px-3 py-1.5 text-[13px] cursor-pointer hover:bg-accent ${isSelected ? 'bg-accent' : ''}`}
                   style={{ paddingLeft: 12 + (p.nivel - 1) * 12 }}
                 >
-                  <span className="font-mono text-stone-700 text-[12px] tabular-nums shrink-0">{p.codigo}</span>
+                  <span className="font-mono text-foreground text-[12px] tabular-nums shrink-0">{p.codigo}</span>
                   <span className="truncate flex-1">{p.nome}</span>
-                  <span className={`shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${TIPO_HUE[p.tipo]}`}>
+                  <span
+                    className="shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium"
+                    style={TIPO_STYLE[p.tipo]}
+                  >
                     {p.tipo}
                   </span>
                 </li>

--- a/resources/js/Pages/Financeiro/Unificado/_components/PlanoContaCombobox.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/PlanoContaCombobox.tsx
@@ -1,0 +1,175 @@
+// PlanoContaCombobox — Onda 24 (2026-05-25) US-FIN-021 plano de contas no Edit.
+//
+// Combobox searchable de plano de contas (DCASP BR). Filtra por `kind` do título:
+//   - 'receivable' → mostra tipo IN (receita, ativo)
+//   - 'payable'    → mostra tipo IN (despesa, custo, passivo)
+// Patrimônio fica de fora (não é título corrente).
+//
+// Busca client-side por código OU nome (case insensitive). Hierarquia visual
+// indentada por nivel (folhas tipicamente nivel=4).
+//
+// Reusável entre Edit e Create. Backend defesa em profundidade via
+// `UpdateTituloRequest::assertPlanoCoerente()`.
+
+import { useMemo, useRef, useState, useEffect } from 'react';
+import { Search, X } from 'lucide-react';
+
+export interface PlanoConta {
+  id: number;
+  codigo: string;
+  nome: string;
+  tipo: 'ativo' | 'passivo' | 'patrimonio' | 'receita' | 'despesa' | 'custo';
+  nivel: number;
+}
+
+interface Props {
+  planos: PlanoConta[];
+  value: number | null;
+  onChange: (id: number | null) => void;
+  kind: 'receivable' | 'payable';
+  id?: string;
+  placeholder?: string;
+  disabled?: boolean;
+}
+
+const TIPOS_RECEBER: PlanoConta['tipo'][] = ['receita', 'ativo'];
+const TIPOS_PAGAR: PlanoConta['tipo'][] = ['despesa', 'custo', 'passivo'];
+
+const TIPO_HUE: Record<PlanoConta['tipo'], string> = {
+  receita:    'text-emerald-700 bg-emerald-50',
+  ativo:      'text-emerald-700 bg-emerald-50',
+  despesa:    'text-rose-700 bg-rose-50',
+  custo:      'text-amber-700 bg-amber-50',
+  passivo:    'text-rose-700 bg-rose-50',
+  patrimonio: 'text-blue-700 bg-blue-50',
+};
+
+export function PlanoContaCombobox({ planos, value, onChange, kind, id, placeholder, disabled }: Props) {
+  const [open, setOpen] = useState(false);
+  const [busca, setBusca] = useState('');
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const tiposPermitidos = kind === 'receivable' ? TIPOS_RECEBER : TIPOS_PAGAR;
+
+  const selecionado = useMemo(
+    () => planos.find((p) => p.id === value) ?? null,
+    [planos, value]
+  );
+
+  const lista = useMemo(() => {
+    const base = planos.filter((p) => tiposPermitidos.includes(p.tipo));
+    if (! busca.trim()) return base;
+    const q = busca.trim().toLowerCase();
+    return base.filter(
+      (p) => p.codigo.toLowerCase().includes(q) || p.nome.toLowerCase().includes(q)
+    );
+  }, [planos, tiposPermitidos, busca]);
+
+  // Fecha ao clicar fora.
+  useEffect(() => {
+    if (! open) return;
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && ! containerRef.current.contains(e.target as Node)) {
+        setOpen(false);
+        setBusca('');
+      }
+    };
+    document.addEventListener('mousedown', handler);
+    return () => document.removeEventListener('mousedown', handler);
+  }, [open]);
+
+  return (
+    <div className="relative" ref={containerRef}>
+      <button
+        type="button"
+        id={id}
+        disabled={disabled}
+        onClick={() => setOpen((o) => !o)}
+        className="w-full h-9 rounded-md border border-stone-300 bg-white px-3 text-left text-[13px] flex items-center justify-between gap-2 hover:border-stone-400 disabled:bg-stone-100 disabled:cursor-not-allowed"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+      >
+        {selecionado ? (
+          <span className="flex items-center gap-2 truncate">
+            <span className="font-mono text-stone-700 text-[12px] tabular-nums">{selecionado.codigo}</span>
+            <span className="truncate">{selecionado.nome}</span>
+            <span className={`shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${TIPO_HUE[selecionado.tipo]}`}>
+              {selecionado.tipo}
+            </span>
+          </span>
+        ) : (
+          <span className="text-stone-400">{placeholder ?? '(Sem plano de contas)'}</span>
+        )}
+        {selecionado && ! disabled && (
+          <span
+            role="button"
+            aria-label="Limpar plano de contas"
+            tabIndex={0}
+            onClick={(e) => {
+              e.stopPropagation();
+              onChange(null);
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' || e.key === ' ') {
+                e.preventDefault();
+                e.stopPropagation();
+                onChange(null);
+              }
+            }}
+            className="shrink-0 text-stone-400 hover:text-stone-700 cursor-pointer"
+          >
+            <X size={14} />
+          </span>
+        )}
+      </button>
+
+      {open && (
+        <div className="absolute z-20 left-0 right-0 mt-1 rounded-md border border-stone-200 bg-white shadow-lg max-h-[280px] flex flex-col">
+          <div className="flex items-center gap-2 px-3 py-2 border-b border-stone-200">
+            <Search size={14} className="text-stone-400" />
+            <input
+              autoFocus
+              type="text"
+              placeholder={`Buscar ${kind === 'receivable' ? 'receita/ativo' : 'despesa/custo/passivo'} por código ou nome…`}
+              value={busca}
+              onChange={(e) => setBusca(e.target.value)}
+              className="flex-1 text-[13px] outline-none bg-transparent"
+            />
+          </div>
+          <ul role="listbox" className="overflow-y-auto flex-1">
+            {lista.length === 0 && (
+              <li className="px-3 py-4 text-center text-[12px] text-stone-500">
+                Nenhum plano encontrado.
+              </li>
+            )}
+            {lista.map((p) => {
+              const isSelected = p.id === value;
+              return (
+                <li
+                  key={p.id}
+                  role="option"
+                  aria-selected={isSelected}
+                  onClick={() => {
+                    onChange(p.id);
+                    setOpen(false);
+                    setBusca('');
+                  }}
+                  className={`flex items-center gap-2 px-3 py-1.5 text-[13px] cursor-pointer hover:bg-stone-50 ${isSelected ? 'bg-stone-100' : ''}`}
+                  style={{ paddingLeft: 12 + (p.nivel - 1) * 12 }}
+                >
+                  <span className="font-mono text-stone-700 text-[12px] tabular-nums shrink-0">{p.codigo}</span>
+                  <span className="truncate flex-1">{p.nome}</span>
+                  <span className={`shrink-0 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium ${TIPO_HUE[p.tipo]}`}>
+                    {p.tipo}
+                  </span>
+                </li>
+              );
+            })}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default PlanoContaCombobox;

--- a/resources/js/Pages/Financeiro/Unificado/_components/TituloEditSheet.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/TituloEditSheet.tsx
@@ -147,7 +147,7 @@ export function TituloEditSheet({ open, onClose, lancamento, categorias, planos 
 
           {/* Onda 24 (2026-05-25) US-FIN-021 — Plano de Contas BR DCASP filtrado por kind. */}
           <div className="space-y-1.5">
-            <label htmlFor="ed-plano" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+            <label htmlFor="ed-plano" className="text-[11px] uppercase tracking-widest text-muted-foreground font-medium">
               Plano de contas
             </label>
             <PlanoContaCombobox
@@ -158,11 +158,11 @@ export function TituloEditSheet({ open, onClose, lancamento, categorias, planos 
               onChange={(id) => form.setData('plano_conta_id', id)}
               placeholder={lancamento.kind === 'receivable' ? 'Receita ou ativo' : 'Despesa, custo ou passivo'}
             />
-            <p className="text-[11px] text-stone-500">
+            <p className="text-[11px] text-muted-foreground">
               Filtrado por tipo do título (DRE entra direto na classificação certa).
             </p>
             {form.errors.plano_conta_id && (
-              <p className="text-[11px] text-rose-600">{form.errors.plano_conta_id}</p>
+              <p className="text-[11px] text-destructive">{form.errors.plano_conta_id}</p>
             )}
           </div>
 

--- a/resources/js/Pages/Financeiro/Unificado/_components/TituloEditSheet.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/TituloEditSheet.tsx
@@ -5,6 +5,7 @@
 //   - cliente_descricao (texto livre — pode renomear/anotar contraparte)
 //   - observacoes (texto livre)
 //   - categoria_id (dropdown de Categoria do business)
+//   - plano_conta_id (combobox DCASP BR filtrado por kind — Onda 24 US-FIN-021)
 //   - vencimento (date)
 //   - valor_total (number — SOMENTE se status aberto/parcial; bloqueado se quitado/cancelado)
 //
@@ -16,6 +17,7 @@ import { useEffect } from 'react';
 import { Button } from '@/Components/ui/button';
 import { Input } from '@/Components/ui/input';
 import { Sheet, SheetContent, SheetTitle, SheetDescription } from '@/Components/ui/sheet';
+import { PlanoContaCombobox, type PlanoConta } from './PlanoContaCombobox';
 
 interface Categoria {
   id: number;
@@ -24,10 +26,14 @@ interface Categoria {
 
 interface Lancamento {
   id: number;
+  kind: 'receivable' | 'payable';
   descricao: string;
   contraparte: string;
   categoria: string;
   categoria_id: number | null;
+  plano_conta_id: number | null;
+  plano_conta_codigo: string | null;
+  plano_conta_nome: string | null;
   vencimento: string;
   valor: number;
   observacao: string | null;
@@ -40,13 +46,15 @@ interface TituloEditSheetProps {
   onClose: () => void;
   lancamento: Lancamento;
   categorias: Categoria[];
+  planos: PlanoConta[];
 }
 
-export function TituloEditSheet({ open, onClose, lancamento, categorias }: TituloEditSheetProps) {
+export function TituloEditSheet({ open, onClose, lancamento, categorias, planos }: TituloEditSheetProps) {
   const form = useForm({
     cliente_descricao: lancamento.contraparte === '—' ? '' : lancamento.contraparte,
     observacoes: lancamento.observacao ?? '',
     categoria_id: lancamento.categoria_id ?? '',
+    plano_conta_id: lancamento.plano_conta_id as number | null,
     vencimento: lancamento.vencimento,
     valor_total: lancamento.valor,
   });
@@ -57,6 +65,7 @@ export function TituloEditSheet({ open, onClose, lancamento, categorias }: Titul
       cliente_descricao: lancamento.contraparte === '—' ? '' : lancamento.contraparte,
       observacoes: lancamento.observacao ?? '',
       categoria_id: lancamento.categoria_id ?? '',
+      plano_conta_id: lancamento.plano_conta_id as number | null,
       vencimento: lancamento.vencimento,
       valor_total: lancamento.valor,
     });
@@ -70,6 +79,7 @@ export function TituloEditSheet({ open, onClose, lancamento, categorias }: Titul
       cliente_descricao: form.data.cliente_descricao || null,
       observacoes: form.data.observacoes || null,
       categoria_id: form.data.categoria_id === '' ? null : form.data.categoria_id,
+      plano_conta_id: form.data.plano_conta_id ?? null,
       vencimento: form.data.vencimento,
     };
     if (lancamento.valor_mutavel) {
@@ -132,6 +142,27 @@ export function TituloEditSheet({ open, onClose, lancamento, categorias }: Titul
             </select>
             {form.errors.categoria_id && (
               <p className="text-[11px] text-rose-600">{form.errors.categoria_id}</p>
+            )}
+          </div>
+
+          {/* Onda 24 (2026-05-25) US-FIN-021 — Plano de Contas BR DCASP filtrado por kind. */}
+          <div className="space-y-1.5">
+            <label htmlFor="ed-plano" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+              Plano de contas
+            </label>
+            <PlanoContaCombobox
+              id="ed-plano"
+              planos={planos}
+              kind={lancamento.kind}
+              value={form.data.plano_conta_id}
+              onChange={(id) => form.setData('plano_conta_id', id)}
+              placeholder={lancamento.kind === 'receivable' ? 'Receita ou ativo' : 'Despesa, custo ou passivo'}
+            />
+            <p className="text-[11px] text-stone-500">
+              Filtrado por tipo do título (DRE entra direto na classificação certa).
+            </p>
+            {form.errors.plano_conta_id && (
+              <p className="text-[11px] text-rose-600">{form.errors.plano_conta_id}</p>
             )}
           </div>
 


### PR DESCRIPTION
## Summary

- Adiciona campo **Plano de Contas BR (DCASP)** no `TituloEditSheet` via novo `PlanoContaCombobox` reusável — searchable, hierárquico indentado, filtrado por `kind` do título (`receivable` → receita/ativo · `payable` → despesa/custo/passivo).
- Backend defesa em profundidade: `UpdateTituloRequest::assertPlanoCoerente()` revalida coerência `tipo ↔ plano_conta.tipo` (anti tampering) além de `Rule::exists` scoped por business + ativo + aceita_lancamento.
- Consequência: títulos editados alimentam **DRE direto** sem precisar `BackfillPlanoContaCommand` (que continua cobrindo auto-criação via Observer).

## O que muda na UX

- Drawer **Editar lançamento** ganha campo "Plano de contas" entre Categoria e Vencimento.
- Combobox abre lista filtrada pelo tipo do título — Eliana não vê 50+ contas misturadas, só as compatíveis.
- Hint embaixo: "Filtrado por tipo do título (DRE entra direto na classificação certa)".
- Campo é **opcional** — `BackfillPlanoContaCommand` continua dando default pra títulos sem plano.

## Multi-tenant (Tier 0 ADR 0093)

- `Rule::exists` scope `business_id` = session.
- `assertPlanoCoerente` re-busca `PlanoConta` com `where business_id = titulo.business_id`.
- Pest test #3 valida 422 quando plano de outro business é enviado.

## Test plan

- [x] `npm run typecheck` passa (warning baseUrl deprecated não relacionado)
- [x] `pest Modules/Financeiro/Tests/Feature/UnificadoEditPlanoContaTest.php` — 4 testes descobertos, skip gracioso (padrão da skill quando DB local greenfield)
- [ ] CI verde com DB seedado executa os 4 testes:
  - update salva `plano_conta_id` válido
  - update com `plano_conta_id=null` limpa
  - cross-tenant rejeitado (422 ou redirect com errors)
  - tipo incompatível (receber + despesa) rejeitado 422
- [ ] Smoke prod biz=1 pós-merge — clicar Editar num título a receber, abrir combobox, confirmar só receita/ativo aparece, salvar, refresh drawer mostra plano persistido
- [ ] Smoke prod biz=1 pós-merge — mesmo fluxo num título a pagar, confirmar só despesa/custo/passivo

## Charter

- `Index.charter.md` v6 → v7 — bloco "Onda 24 — Plano de Contas no Edit" em Goals + linha TituloEditSheet menciona campo.

## Não inclui (PR B posterior)

- Form **Insert** ("+ Nova conta a receber" / "+ Nova conta a pagar") — escopo combinado com Wagner, será PR B depois deste mergear.
- Auto-população via Observer (`TituloAutoService`) — continua usando `BackfillPlanoContaCommand` existente.

## Refs

- US-FIN-021 (Form unificado inline — parcial)
- ADR fin-tech/0001 (idempotência)
- ADR fin-tech/0002 (imutabilidade pós-baixa)
- ADR 0093 (Multi-tenant Tier 0 IRREVOGÁVEL)

🤖 Generated with [Claude Code](https://claude.com/claude-code)