### PR TITLE
fix(nfebrasil): sidebar 'Fiscal' aponta /fiscal (cockpit real) em vez de /nfebrasil (stub 500)

### DIFF
--- a/Modules/NfeBrasil/Http/Controllers/DataController.php
+++ b/Modules/NfeBrasil/Http/Controllers/DataController.php
@@ -147,14 +147,19 @@ class DataController extends Controller
         // Sub-items (Emitir/SPED/Settings/Certificado/Tributação) ficam
         // acessíveis via URL direta ou tabs internas das telas (TODO Fase 4).
         $background_color = config('app.env') == 'demo' ? '#a8d8ea' : '';
-        $segmento_ativo = request()->segment(1) == 'nfebrasil'
-            || request()->segment(1) == 'nfe-brasil';
+        // Wagner 2026-05-25: entry "Fiscal" aponta /fiscal (cockpit unificado
+        // Modules/Fiscal — implementado, funcional, 7 abas) em vez de
+        // /nfebrasil (controller chama view('create') que não existe → 500).
+        // Highlight inclui /fiscal + rotas legacy /nfebrasil ainda usadas pelos
+        // ghosts (Notas fiscais, Tributação, Certificado etc — discussão UX
+        // separada pra eventual repointed pros equivalentes /fiscal/*).
+        $segmento_ativo = in_array(request()->segment(1), ['fiscal', 'nfebrasil', 'nfe-brasil'], true);
 
         Menu::modify(
             'admin-sidebar-menu',
             function ($menu) use ($background_color, $segmento_ativo) {
                 $menu->url(
-                    url('/nfebrasil'),
+                    url('/fiscal'),
                     'Fiscal',
                     [
                         'icon'     => 'fa fas fa-file-invoice-dollar',


### PR DESCRIPTION
## Summary

- Sidebar entry "Fiscal" do grupo FISCAL agora aponta `/fiscal` (cockpit unificado funcional) em vez de `/nfebrasil` (controller chamava `view('create')` inexistente => 500)
- `segmento_ativo` inclui `'fiscal'` pra item ficar highlighted quando user navega no cockpit

## Contexto

`Modules/Fiscal` cockpit unificado já estava implementado (7 abas: Cockpit · NF-e·NFC-e · NFS-e · Manifesto DF-e · Eventos · Certif. & Cfg. · SPED & Livros) mas a entry do sidebar registrada por [`Modules/NfeBrasil/Http/Controllers/DataController.php:157`](https://github.com/wagnerra23/oimpresso.com/blob/main/Modules/NfeBrasil/Http/Controllers/DataController.php#L157) apontava pra `/nfebrasil`.

Comentário do próprio [`Modules/Fiscal/Http/Controllers/DataController.php:94-96`](https://github.com/wagnerra23/oimpresso.com/blob/main/Modules/Fiscal/Http/Controllers/DataController.php#L94) já previa:

> "Retomar quando PR #2 Wave consolidada entregar cockpit real /fiscal — então renomear/promover entry pra principal"

Este PR fecha esse loose end mínimo.

## Validação visual

Validado em prod biz=164 MARTINHO CAÇAMBAS LTDA (após habilitar nfebrasil_module via subscription patch):
- ✅ Cockpit `/fiscal` renderiza completo: header "Cockpit fiscal", badge "SEFAZ-SP operacional", 6 KPIs (Emitidas mês, Autorizadas, Rejeitadas, Faturado fiscal, DF-e p/ Manifestar, Certificado A1), 6 cards de seções
- ❌ Pré-fix: `/nfebrasil` → "Hello World - Module: NfeBrasil" (stub scaffold)
- ❌ Pré-fix: `/nfebrasil/create` (primary "Emitir NF-e") → 500 `InvalidArgumentException: View [create] not found`

## Fora deste PR (discussão UX separada)

Mantidos apontando pra rotas legacy `/nfebrasil/*` e `/nfe-brasil/*`:
- `primary` "Emitir NF-e" `href=/nfebrasil/create` (ainda 500 — repointar pra `/fiscal#emitir` ou similar quando UX decidir)
- 7 ghosts: Notas fiscais, Manifestação, Certificado Digital, Tributação, SPED, Configurações, NFSe (algumas legacy funcionais — certificado A1, tributação, manifestação; outras stub)

## Test plan

- [ ] Após merge + deploy, clicar em "Fiscal" no sidebar (qualquer business com nfebrasil_module=1) abre `/fiscal` cockpit
- [ ] Item fica highlighted enquanto user navega `/fiscal/*`, `/nfebrasil/*` ou `/nfe-brasil/*` (mantém compatibilidade legacy)
- [ ] Smoke: `/fiscal` carrega 7 abas + KPIs sem erro

Refs: ADR 0180 (consolidação 1 entry + ghosts), bug regressivo do PR Wave consolidação 2026-05-22.

🤖 Generated with [Claude Code](https://claude.com/claude-code)