### PR TITLE
fix(nfebrasil): repointar primary + 3 ghosts /nfebrasil/* (stub 500) pro cockpit /fiscal/*

### DIFF
--- a/Modules/NfeBrasil/Http/Controllers/DataController.php
+++ b/Modules/NfeBrasil/Http/Controllers/DataController.php
@@ -163,19 +163,24 @@ class DataController extends Controller
                         // Wagner 2026-05-22: FISCAL virou grupo próprio (era ghost de FINANÇAS).
                         'group'    => 'fiscal',
                         'shortcut' => 'G X',
+                        // Wagner 2026-05-25 repoint: rotas /nfebrasil/{create,sped,settings}
+                        // sao stub do scaffold nWidart (View not found => 500). Repointado
+                        // pros cockpits funcionais /fiscal/*. Ghosts c/ rota legacy 200
+                        // (manifestacao, certificado, tributacao, /nfse) mantem destino
+                        // legacy pq sao telas especializadas funcionais.
                         'primary'  => [
                             'label'    => 'Emitir NF-e',
-                            'href'     => '/nfebrasil/create',
+                            'href'     => '/fiscal/nfe',
                             'shortcut' => 'N',
                         ],
                         'ghosts'   => [
-                            ['key' => 'notas',         'label' => 'Notas fiscais',     'href' => '/nfebrasil'],
+                            ['key' => 'notas',         'label' => 'Notas fiscais',     'href' => '/fiscal/nfe'],
                             ['key' => 'manifestacao',  'label' => 'Manifestação',      'href' => '/nfe-brasil/manifestacao'],
                             ['key' => 'certificado',   'label' => 'Certificado Digital','href' => '/nfe-brasil/configuracao/certificado'],
                             // Wagner 2026-05-22 P1: +4 ghosts pra zerar órfãs Fiscal.
                             ['key' => 'tributacao',    'label' => 'Tributação',        'href' => '/nfe-brasil/tributacao'],
-                            ['key' => 'sped',          'label' => 'SPED',              'href' => '/nfebrasil/sped'],
-                            ['key' => 'settings',      'label' => 'Configurações',     'href' => '/nfebrasil/settings'],
+                            ['key' => 'sped',          'label' => 'SPED',              'href' => '/fiscal/sped'],
+                            ['key' => 'settings',      'label' => 'Configurações',     'href' => '/fiscal/config'],
                             ['key' => 'nfse',          'label' => 'NFSe',              'href' => '/nfse'],
                         ],
                     ]


### PR DESCRIPTION
## Summary

Continuação de #1535. Smoke test em prod biz=164 revelou que 3 rotas legacy registradas pelo menu Fiscal são stub scaffold nWidart (`view('create')` não existe → 500). Repointadas pros cockpits funcionais `Modules/Fiscal`.

## Smoke test prévio (prod biz=164)

| Item | Rota atual | HTTP | Decisão |
|---|---|---|---|
| primary "Emitir NF-e" | `/nfebrasil/create` | **500** | → `/fiscal/nfe` |
| ghost Notas fiscais | `/nfebrasil` | stub | → `/fiscal/nfe` |
| ghost SPED | `/nfebrasil/sped` | **500** | → `/fiscal/sped` |
| ghost Configurações | `/nfebrasil/settings` | **500** | → `/fiscal/config` |
| ghost Manifestação | `/nfe-brasil/manifestacao` | 200 ✅ | mantida (tela US-NFE-XXX especializada) |
| ghost Certificado Digital | `/nfe-brasil/configuracao/certificado` | 200 ✅ | mantida (US-NFE-041) |
| ghost Tributação | `/nfe-brasil/tributacao` | 200 ✅ | mantida (US-NFE-010, CRUD regras NCM) |
| ghost NFSe | `/nfse` | 200 ✅ | mantida (Modules/NFSe) |

**Regra aplicada:** só repointa se a rota atual está quebrada. Telas legacy funcionais permanecem (são especializadas, podem ter feature paridade > cockpit).

## Achado lateral (NÃO incluso)

`/fiscal/nfse` também retorna 500 em prod — `NfseCockpitController` tem bug próprio. Como o ghost "NFSe" já aponta pra `/nfse` legacy (200), não bloqueia este PR. Issue separada quando alguém olhar.

## Test plan

- [ ] Após merge + deploy, clicar no botão primary "+ Emitir NF-e" no item Fiscal abre `/fiscal/nfe` (cockpit NF-e/NFC-e) — não mais 500
- [ ] Ghosts "Notas fiscais" / "SPED" / "Configurações" abrem cockpit
- [ ] Ghosts "Manifestação" / "Certificado Digital" / "Tributação" / "NFSe" continuam abrindo telas legacy funcionais
- [ ] Item Fiscal continua highlighted enquanto user navega `/fiscal/*`, `/nfebrasil/*` ou `/nfe-brasil/*`

Refs: ADR 0180 (consolidação 1 entry + ghosts), complementa #1535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)