### PR TITLE
feat(financeiro): TituloCreateSheet — insert manual inline (Onda 25, US-FIN-021 completa)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/UnificadoController.php
+++ b/Modules/Financeiro/Http/Controllers/UnificadoController.php
@@ -12,6 +12,7 @@ use Illuminate\Support\Str;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
+use Modules\Financeiro\Http\Requests\StoreTituloRequest;
 use Modules\Financeiro\Http\Requests\UpdateTituloRequest;
 use Modules\Financeiro\Models\Categoria;
 use Modules\Financeiro\Models\ContaBancaria;
@@ -245,6 +246,62 @@ class UnificadoController extends Controller
                 ['label' => 'Novo lançamento', 'href' => null],
             ],
         ]);
+    }
+
+    /**
+     * POST /financeiro/unificado
+     * Onda 25 (2026-05-25) US-FIN-021 — Insert manual de título via TituloCreateSheet.
+     * Substitui stub `/unificado/novo` (Non-Goal #1 do charter v6).
+     *
+     * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): business_id da session, nunca
+     * do payload (anti tampering). Numero sequencial business-isolado via
+     * `lockForUpdate` (R-FIN-002 idempotência).
+     */
+    public function store(StoreTituloRequest $request): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $userId = $request->user()->id;
+        $request->assertPlanoCoerente();
+
+        $titulo = DB::transaction(function () use ($request, $businessId, $userId) {
+            // Numero sequencial business-isolado.
+            // Padrão: receber → R-0001, R-0002… · pagar → P-0001, P-0002…
+            $prefixo = $request->input('tipo') === 'receber' ? 'R' : 'P';
+            $proximoNumero = (int) Titulo::where('business_id', $businessId)
+                ->where('numero', 'like', "{$prefixo}-%")
+                ->lockForUpdate()
+                ->selectRaw("MAX(CAST(SUBSTRING(numero, 3) AS UNSIGNED)) as max_n")
+                ->value('max_n');
+            $proximoNumero = max(1, $proximoNumero + 1);
+            $numero = sprintf('%s-%05d', $prefixo, $proximoNumero);
+
+            $valor = (float) $request->input('valor_total');
+
+            return Titulo::create([
+                'business_id'       => $businessId,
+                'numero'            => $numero,
+                'tipo'              => $request->input('tipo'),
+                'status'            => 'aberto',
+                'cliente_descricao' => $request->input('cliente_descricao'),
+                'valor_total'       => $valor,
+                'valor_aberto'      => $valor,
+                'moeda'             => 'BRL',
+                'emissao'           => now()->toDateString(),
+                'vencimento'        => $request->date('vencimento')->toDateString(),
+                'competencia_mes'   => now()->format('Y-m'),
+                'origem'            => 'manual',
+                'origem_id'         => null,
+                'categoria_id'      => $request->input('categoria_id') ?: null,
+                'plano_conta_id'    => $request->input('plano_conta_id') ?: null,
+                'observacoes'       => $request->input('observacoes'),
+                'created_by'        => $userId,
+                'updated_by'        => $userId,
+            ]);
+        });
+
+        $label = $titulo->tipo === 'receber' ? 'a receber' : 'a pagar';
+
+        return back()->with('success', "Lançamento {$titulo->numero} ({$label}) criado.");
     }
 
     /**

--- a/Modules/Financeiro/Http/Requests/StoreTituloRequest.php
+++ b/Modules/Financeiro/Http/Requests/StoreTituloRequest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Modules\Financeiro\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Modules\Financeiro\Models\Categoria;
+use Modules\Financeiro\Models\PlanoConta;
+
+/**
+ * Validação do Insert manual de título financeiro (Onda 25, 2026-05-25, US-FIN-021).
+ *
+ * Substitui o stub `/unificado/novo` (Non-Goal #1 do charter v6) por form
+ * inline drawer no próprio /financeiro/unificado.
+ *
+ * Campos obrigatórios:
+ *   - tipo: 'receber' OR 'pagar'
+ *   - valor_total: > 0
+ *   - vencimento: date >= hoje OR retroativo (skill multi-tenant-patterns —
+ *     títulos retroativos via boleto OCR ou DFe importer também valem)
+ *
+ * Campos opcionais:
+ *   - cliente_descricao (texto livre — quando ainda não há FK contacts.id)
+ *   - observacoes
+ *   - categoria_id (scope business)
+ *   - plano_conta_id (scope business + ativo + aceita_lancamento + coerência tipo)
+ *
+ * Defesa em profundidade tipo↔plano_conta.tipo via `assertPlanoCoerente()`.
+ * Mesma lógica usada em UpdateTituloRequest (DRY).
+ */
+class StoreTituloRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        // Permission gate já aplicada no Controller::__construct via
+        // can:financeiro.dashboard.view. Re-check (defesa em profundidade).
+        return $this->user()?->can('financeiro.dashboard.view') ?? false;
+    }
+
+    public function rules(): array
+    {
+        $businessId = (int) session('user.business_id');
+
+        return [
+            'tipo' => ['required', Rule::in(['receber', 'pagar'])],
+            'valor_total' => ['required', 'numeric', 'min:0.01', 'max:9999999999.99'],
+            'vencimento' => ['required', 'date'],
+            'cliente_descricao' => ['nullable', 'string', 'max:255'],
+            'observacoes' => ['nullable', 'string', 'max:2000'],
+            'categoria_id' => [
+                'nullable', 'integer',
+                Rule::exists((new Categoria)->getTable(), 'id')
+                    ->where('business_id', $businessId)
+                    ->whereNull('deleted_at'),
+            ],
+            'plano_conta_id' => [
+                'nullable', 'integer',
+                Rule::exists((new PlanoConta)->getTable(), 'id')
+                    ->where('business_id', $businessId)
+                    ->where('ativo', true)
+                    ->where('aceita_lancamento', true)
+                    ->whereNull('deleted_at'),
+            ],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'tipo.required' => 'Tipo obrigatório (receber ou pagar).',
+            'tipo.in' => 'Tipo inválido (deve ser "receber" ou "pagar").',
+            'valor_total.required' => 'Valor obrigatório.',
+            'valor_total.min' => 'Valor deve ser positivo.',
+            'vencimento.required' => 'Vencimento obrigatório.',
+            'categoria_id.exists' => 'Categoria não pertence a este negócio.',
+            'plano_conta_id.exists' => 'Plano de contas inválido (inexistente, inativo ou sintético).',
+        ];
+    }
+
+    /**
+     * Defesa em profundidade: garante que `plano_conta_id` é coerente com `tipo`.
+     * Diferente do Update (que tem $titulo já carregado), aqui usa o tipo do
+     * próprio request — chamado pelo Controller após validação básica passar.
+     */
+    public function assertPlanoCoerente(): void
+    {
+        if (! $this->filled('plano_conta_id')) {
+            return;
+        }
+
+        $businessId = (int) session('user.business_id');
+        $plano = PlanoConta::query()
+            ->where('business_id', $businessId)
+            ->find($this->input('plano_conta_id'));
+
+        if (! $plano) {
+            return; // exists rule já tratou
+        }
+
+        $permitidos = $this->input('tipo') === 'receber'
+            ? ['receita', 'ativo']
+            : ['despesa', 'custo', 'passivo'];
+
+        if (! in_array($plano->tipo, $permitidos, true)) {
+            abort(422, "Plano de contas '{$plano->codigo} {$plano->nome}' (tipo {$plano->tipo}) é incompatível com título tipo '{$this->input('tipo')}'.");
+        }
+    }
+}

--- a/Modules/Financeiro/Routes/web.php
+++ b/Modules/Financeiro/Routes/web.php
@@ -73,6 +73,11 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
         Route::put('/unificado/{id}', [UnificadoController::class, 'update'])
             ->whereNumber('id')
             ->name('unificado.update');
+        // Onda 25 (2026-05-25) US-FIN-021 — Insert manual via TituloCreateSheet
+        // (substitui stub /unificado/novo). Multi-tenant Tier 0 + idempotência
+        // via lockForUpdate no numero sequencial business-isolado.
+        Route::post('/unificado', [UnificadoController::class, 'store'])
+            ->name('unificado.store');
         Route::post('/unificado/{id}/conferir', [UnificadoController::class, 'conferir'])
             ->whereNumber('id')
             ->name('unificado.conferir');

--- a/Modules/Financeiro/Tests/Feature/UnificadoStoreTest.php
+++ b/Modules/Financeiro/Tests/Feature/UnificadoStoreTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Modules\Financeiro\Models\PlanoConta;
+use Modules\Financeiro\Models\Titulo;
+use Spatie\Permission\Models\Permission;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Onda 25 (2026-05-25) US-FIN-021 — Insert manual de título via TituloCreateSheet.
+ *
+ * Cobre 6 invariantes:
+ *  (1) POST /unificado tipo=receber cria Titulo aberto com numero R-NNNNN
+ *  (2) POST /unificado tipo=pagar cria Titulo aberto com numero P-NNNNN
+ *  (3) tipo ausente → 422
+ *  (4) valor_total ausente → 422
+ *  (5) plano de outro business → rejeitado (Tier 0 ADR 0093)
+ *  (6) plano incompatível com tipo (receber + despesa) → 422
+ *
+ * Padrão graceful skip Jana/Repair/Copiloto.
+ */
+
+function storeBootstrap(): array
+{
+    try {
+        $business = Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: '.$e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco — rode seeder UltimatePOS antes.');
+    }
+
+    $user = User::where('business_id', $business->id)->first();
+
+    if (! $user) {
+        test()->markTestSkipped('Sem user no business.');
+    }
+
+    Permission::firstOrCreate(['name' => 'financeiro.dashboard.view', 'guard_name' => 'web']);
+    if (! $user->hasPermissionTo('financeiro.dashboard.view')) {
+        $user->givePermissionTo('financeiro.dashboard.view');
+    }
+
+    session([
+        'user.business_id' => $business->id,
+        'user.id'          => $user->id,
+        'business.id'      => $business->id,
+        'business.name'    => $business->name,
+        'business'         => ['id' => $business->id, 'name' => $business->name, 'currency_symbol' => 'R$'],
+        'is_admin'         => true,
+    ]);
+
+    return [$business, $user];
+}
+
+function storeCreatePlano(int $businessId, string $codigo, string $tipo): PlanoConta
+{
+    return PlanoConta::firstOrCreate(
+        ['business_id' => $businessId, 'codigo' => $codigo],
+        [
+            'nome'              => "TEST {$codigo} {$tipo}",
+            'tipo'              => $tipo,
+            'nivel'             => 4,
+            'natureza'          => in_array($tipo, ['receita', 'passivo', 'patrimonio'], true) ? 'credito' : 'debito',
+            'aceita_lancamento' => true,
+            'protegido'         => false,
+            'ativo'             => true,
+        ]
+    );
+}
+
+it('store tipo=receber cria Titulo aberto', function () {
+    [$business, $user] = storeBootstrap();
+
+    $response = $this->actingAs($user)->post('/financeiro/unificado', [
+        'tipo'              => 'receber',
+        'valor_total'       => 250.50,
+        'vencimento'        => now()->addDays(15)->toDateString(),
+        'cliente_descricao' => 'Cliente teste recebimento',
+        'categoria_id'      => null,
+        'plano_conta_id'    => null,
+        'observacoes'       => null,
+    ]);
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertRedirect();
+
+    $created = Titulo::where('business_id', $business->id)
+        ->where('cliente_descricao', 'Cliente teste recebimento')
+        ->latest('id')
+        ->first();
+
+    expect($created)->not->toBeNull();
+    expect($created->tipo)->toBe('receber');
+    expect($created->status)->toBe('aberto');
+    expect((float) $created->valor_total)->toBe(250.50);
+    expect((float) $created->valor_aberto)->toBe(250.50);
+    expect($created->numero)->toStartWith('R-');
+    expect($created->origem)->toBe('manual');
+    expect($created->created_by)->toBe($user->id);
+
+    $created->forceDelete();
+});
+
+it('store tipo=pagar cria Titulo aberto', function () {
+    [$business, $user] = storeBootstrap();
+
+    $response = $this->actingAs($user)->post('/financeiro/unificado', [
+        'tipo'              => 'pagar',
+        'valor_total'       => 100.00,
+        'vencimento'        => now()->addDays(7)->toDateString(),
+        'cliente_descricao' => 'Fornecedor teste pagamento',
+        'categoria_id'      => null,
+        'plano_conta_id'    => null,
+        'observacoes'       => null,
+    ]);
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    $response->assertRedirect();
+
+    $created = Titulo::where('business_id', $business->id)
+        ->where('cliente_descricao', 'Fornecedor teste pagamento')
+        ->latest('id')
+        ->first();
+
+    expect($created)->not->toBeNull();
+    expect($created->tipo)->toBe('pagar');
+    expect($created->numero)->toStartWith('P-');
+
+    $created->forceDelete();
+});
+
+it('rejeita store sem tipo (422)', function () {
+    [$business, $user] = storeBootstrap();
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/unificado')
+        ->post('/financeiro/unificado', [
+            'valor_total' => 50,
+            'vencimento'  => now()->addDays(5)->toDateString(),
+        ]);
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    expect(in_array($response->status(), [302, 422], true))->toBeTrue();
+    $response->assertSessionHasErrors('tipo');
+});
+
+it('rejeita store sem valor_total (422)', function () {
+    [$business, $user] = storeBootstrap();
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/unificado')
+        ->post('/financeiro/unificado', [
+            'tipo'       => 'receber',
+            'vencimento' => now()->addDays(5)->toDateString(),
+        ]);
+
+    if (in_array($response->status(), [403, 404], true)) {
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    expect(in_array($response->status(), [302, 422], true))->toBeTrue();
+    $response->assertSessionHasErrors('valor_total');
+});
+
+it('rejeita plano de outro business no store (Tier 0 ADR 0093)', function () {
+    [$business, $user] = storeBootstrap();
+
+    $otherBizId = (int) (DB::table('business')->max('id') ?? 0) + 99999;
+    DB::table('business')->insert([
+        'id'         => $otherBizId,
+        'name'       => 'TEST-OTHER-BIZ-STORE',
+        'currency_id' => 1,
+        'start_date' => now()->toDateString(),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    $planoCrossTenant = storeCreatePlano($otherBizId, '3.1.01.XST', 'receita');
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/unificado')
+        ->post('/financeiro/unificado', [
+            'tipo'              => 'receber',
+            'valor_total'       => 50,
+            'vencimento'        => now()->addDays(5)->toDateString(),
+            'cliente_descricao' => 'Tentativa cross-tenant store',
+            'plano_conta_id'    => $planoCrossTenant->id,
+        ]);
+
+    if (in_array($response->status(), [403, 404], true)) {
+        $planoCrossTenant->forceDelete();
+        DB::table('business')->where('id', $otherBizId)->delete();
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    expect(in_array($response->status(), [302, 422], true))->toBeTrue();
+    $response->assertSessionHasErrors('plano_conta_id');
+
+    // Não criou Titulo.
+    $exists = Titulo::where('business_id', $business->id)
+        ->where('cliente_descricao', 'Tentativa cross-tenant store')
+        ->exists();
+    expect($exists)->toBeFalse();
+
+    $planoCrossTenant->forceDelete();
+    DB::table('business')->where('id', $otherBizId)->delete();
+});
+
+it('rejeita plano de tipo incompatível no store (receber + despesa)', function () {
+    [$business, $user] = storeBootstrap();
+
+    $planoDespesa = storeCreatePlano($business->id, '5.1.99.STT', 'despesa');
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/unificado')
+        ->post('/financeiro/unificado', [
+            'tipo'              => 'receber',
+            'valor_total'       => 50,
+            'vencimento'        => now()->addDays(5)->toDateString(),
+            'cliente_descricao' => 'Tentativa incoerente store',
+            'plano_conta_id'    => $planoDespesa->id,
+        ]);
+
+    if (in_array($response->status(), [403, 404], true)) {
+        $planoDespesa->forceDelete();
+        test()->markTestSkipped('Module gate bloqueia neste env.');
+    }
+
+    expect($response->status())->toBe(422);
+
+    $exists = Titulo::where('business_id', $business->id)
+        ->where('cliente_descricao', 'Tentativa incoerente store')
+        ->exists();
+    expect($exists)->toBeFalse();
+
+    $planoDespesa->forceDelete();
+});

--- a/resources/js/Pages/Financeiro/Unificado/Index.charter.md
+++ b/resources/js/Pages/Financeiro/Unificado/Index.charter.md
@@ -11,7 +11,7 @@ related_us: [US-FIN-013, US-FIN-020, US-FIN-050-anexos, US-FIN-055-aprovacao]
 related_prototype: canon REAL public/cowork-preview/Oimpresso ERP - Chat.html (aprovado Wagner 2026-05-19)
 canon_method: Bundle copy CSS 9054 LOC inteiro (regra Tier 0 feedback-cowork-bundle-aplicar-inteiro) — Ondas 12-21
 tier: A
-charter_version: 7
+charter_version: 8
 ---
 
 # Page Charter — /financeiro/unificado
@@ -28,6 +28,14 @@ Tela única de **fluxo financeiro do mês** que mistura **Pagar / Pagas / Recebe
 ---
 
 ## Goals — Features (faz)
+
+- **Onda 25 — Insert manual inline** (2026-05-25, charter v8, US-FIN-021 completa):
+  - **TituloCreateSheet** reusa `PlanoContaCombobox` da Onda 24. Drawer abre via DropdownMenu existente "+ Novo título" → "Novo recebimento" (verde 145) ou "Novo pagamento" (rose 25), com `tipo` pré-fixado e não editável (Opção A do design: usuário escolhe tipo ANTES do form).
+  - **POST `/financeiro/unificado`** → `UnificadoController::store(StoreTituloRequest)`. Numero sequencial business-isolado (`R-NNNNN` ou `P-NNNNN`) gerado com `lockForUpdate` (R-FIN-002 idempotência).
+  - **Substitui stub `/unificado/novo`** — remove Non-Goal #1 do charter v6 ("Form unificado de novo lançamento inline").
+  - **Defesa em profundidade**: `StoreTituloRequest::assertPlanoCoerente()` revalida tipo↔plano_conta.tipo no backend (anti tampering — mesmo padrão da Onda 24).
+  - **Multi-tenant Tier 0** (ADR 0093): `business_id` da session, nunca do payload. Pest cross-tenant rejeita 422.
+  - **origem='manual'**, `valor_aberto=valor_total`, `status='aberto'`, `created_by=user.id`, `competencia_mes=Y-m`.
 
 - **Onda 24 — Plano de Contas no Edit** (2026-05-25, charter v7, US-FIN-021 parcial):
   - **TituloEditSheet** ganha campo `plano_conta_id` via `PlanoContaCombobox` reusável (searchable, hierárquico DCASP indentado por `nivel`).
@@ -101,7 +109,7 @@ Tela única de **fluxo financeiro do mês** que mistura **Pagar / Pagas / Recebe
 
 > Anti-alucinação. Cada item vira Pest GUARD test (Non-Goal violado = CI quebra).
 
-- ❌ Form unificado de novo lançamento inline — F1 é stub picker (Receber/Pagar) em `/unificado/novo`. Roadmap entrega form modal/sheet futuramente
+- ❌ ~~Form unificado de novo lançamento inline~~ — **RESOLVIDO Onda 25** (TituloCreateSheet via DropdownMenu "+ Novo título")
 - ❌ Cancelamento/estorno — vai por rotas dedicadas (`status='cancelado'` via append-only, não delete)
 - ❌ Edição de `tipo`, `origem`, `origem_id`, `status`, `emissao` — imutáveis (anti-corrupção contábil; alterar requer cancelar+criar novo). Onda Edit edita só campos seguros + valor pré-baixa.
 - ❌ Pagination explícita (default `limit(200)` no controller) — paginar quando 1000+ títulos virar dor
@@ -168,7 +176,7 @@ Tela única de **fluxo financeiro do mês** que mistura **Pagar / Pagas / Recebe
 
 ## Backlog futuro (US explícitas)
 
-- **US-FIN-021** — Form unificado inline (modal/sheet) — substitui stub `/unificado/novo`
+- ~~**US-FIN-021** — Form unificado inline (modal/sheet) — substitui stub `/unificado/novo`~~ **DONE Onda 25 (2026-05-25)**
 - **US-FIN-022** — Aging buckets <30/30-60/60-90/90+ + filtro
 - **US-FIN-023** — Comparação `+X% vs mês anterior` por KPI (delta_pct)
 - **US-FIN-024** — Combobox cliente/contraparte com autocomplete

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -59,6 +59,7 @@ import { FinMonthResumeDialog } from './_components/FinMonthResume';
 import { FinEditPanel } from './_components/FinEditPanel';
 // Onda Edit 2026-05-18 — Sheet inline pra editar título financeiro.
 import { TituloEditSheet } from './_components/TituloEditSheet';
+import { TituloCreateSheet } from './_components/TituloCreateSheet';
 // US-FIN-026 (Onda 22) — painel completo de anexos no drawer (GET + upload + download + delete).
 import { FinAnexosPanel } from './_components/FinAnexosPanel';
 // US-FIN-029 (Onda 23) — Sheet OCR boleto (OpenAI Vision API extrai linha digitavel + valor + vencimento).
@@ -846,6 +847,9 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
   useEffect(() => { setDrawerTab('detalhes'); }, [selectedId]);
   // Onda Edit 2026-05-18 — Edit Sheet state (separate from detail drawer).
   const [editOpen, setEditOpen] = useState(false);
+  // Onda 25 (2026-05-25) US-FIN-021 — Insert manual via TituloCreateSheet.
+  // `createTipo` controla qual variante abre (receber=verde · pagar=rose).
+  const [createTipo, setCreateTipo] = useState<'receber' | 'pagar' | null>(null);
   // US-FIN-029 (Onda 23) — Sheet OCR boleto.
   const [ocrSheetOpen, setOcrSheetOpen] = useState(false);
 
@@ -1009,10 +1013,10 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
               </button>
             </DropdownMenuTrigger>
             <DropdownMenuContent align="end" className="min-w-48">
-              <DropdownMenuItem onClick={() => router.visit('/financeiro/unificado/novo?kind=receivable')}>
+              <DropdownMenuItem onClick={() => setCreateTipo('receber')}>
                 <TrendingUp size={13} className="mr-2 text-emerald-600" /> Novo recebimento
               </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => router.visit('/financeiro/unificado/novo?kind=payable')}>
+              <DropdownMenuItem onClick={() => setCreateTipo('pagar')}>
                 <TrendingDown size={13} className="mr-2 text-rose-600" /> Novo pagamento
               </DropdownMenuItem>
               <DropdownMenuSeparator />
@@ -1884,6 +1888,17 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
           open={editOpen}
           onClose={() => setEditOpen(false)}
           lancamento={selected}
+          categorias={categorias}
+          planos={planosConta}
+        />
+      )}
+
+      {/* Onda 25 (2026-05-25) US-FIN-021 — Sheet Insert manual (substitui stub /unificado/novo) */}
+      {createTipo && (
+        <TituloCreateSheet
+          open={createTipo !== null}
+          onClose={() => setCreateTipo(null)}
+          tipo={createTipo}
           categorias={categorias}
           planos={planosConta}
         />

--- a/resources/js/Pages/Financeiro/Unificado/_components/TituloCreateSheet.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/TituloCreateSheet.tsx
@@ -1,0 +1,231 @@
+// TituloCreateSheet — Onda 25 (2026-05-25) US-FIN-021 Insert manual de título.
+//
+// Sheet drawer inline pra criar novo título a receber OU a pagar. Tipo
+// pré-fixado pela origem do click no DropdownMenu "+ Novo título" do header
+// (Novo recebimento → tipo='receber' · Novo pagamento → tipo='pagar').
+//
+// Plano de Contas combobox filtra DCASP por tipo do título — Eliana não vê
+// 50+ contas misturadas, só receita/ativo (receber) ou despesa/custo/passivo
+// (pagar). Backend defesa em profundidade via assertPlanoCoerente.
+//
+// Substitui o stub /unificado/novo (Non-Goal #1 do charter v6).
+
+import { useForm } from '@inertiajs/react';
+import { useEffect } from 'react';
+import { TrendingUp, TrendingDown } from 'lucide-react';
+import { Button } from '@/Components/ui/button';
+import { Input } from '@/Components/ui/input';
+import { Sheet, SheetContent, SheetTitle, SheetDescription } from '@/Components/ui/sheet';
+import { PlanoContaCombobox, type PlanoConta } from './PlanoContaCombobox';
+
+interface Categoria {
+  id: number;
+  nome: string;
+}
+
+interface TituloCreateSheetProps {
+  open: boolean;
+  onClose: () => void;
+  tipo: 'receber' | 'pagar';
+  categorias: Categoria[];
+  planos: PlanoConta[];
+}
+
+const hojeIso = () => new Date().toISOString().slice(0, 10);
+
+export function TituloCreateSheet({ open, onClose, tipo, categorias, planos }: TituloCreateSheetProps) {
+  const kind = tipo === 'receber' ? 'receivable' : 'payable';
+  const accentHue = tipo === 'receber' ? 145 : 25; // verde / rose
+
+  const form = useForm({
+    tipo,
+    cliente_descricao: '',
+    observacoes: '',
+    categoria_id: '' as number | '',
+    plano_conta_id: null as number | null,
+    vencimento: hojeIso(),
+    valor_total: 0,
+  });
+
+  // Reset quando trocar tipo (usuário fechou drawer e abriu outro).
+  useEffect(() => {
+    form.setData({
+      tipo,
+      cliente_descricao: '',
+      observacoes: '',
+      categoria_id: '' as number | '',
+      plano_conta_id: null as number | null,
+      vencimento: hojeIso(),
+      valor_total: 0,
+    });
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [tipo, open]);
+
+  const submit = (e: React.FormEvent) => {
+    e.preventDefault();
+    const data: Record<string, unknown> = {
+      tipo: form.data.tipo,
+      cliente_descricao: form.data.cliente_descricao || null,
+      observacoes: form.data.observacoes || null,
+      categoria_id: form.data.categoria_id === '' ? null : form.data.categoria_id,
+      plano_conta_id: form.data.plano_conta_id ?? null,
+      vencimento: form.data.vencimento,
+      valor_total: form.data.valor_total,
+    };
+    form.post('/financeiro/unificado', {
+      ...({ data } as any),
+      preserveScroll: true,
+      onSuccess: () => onClose(),
+    });
+  };
+
+  const titulo = tipo === 'receber' ? 'Nova conta a receber' : 'Nova conta a pagar';
+  const Icon = tipo === 'receber' ? TrendingUp : TrendingDown;
+
+  return (
+    <Sheet open={open} onOpenChange={(o) => !o && onClose()}>
+      <SheetContent side="right" className="w-[460px] sm:max-w-[460px] flex flex-col p-0">
+        <header className="os-drawer-head">
+          <div className="os-drawer-head-l">
+            <SheetTitle asChild>
+              <h2 className="m-0 flex items-center gap-2">
+                <Icon size={16} style={{ color: `oklch(0.55 0.15 ${accentHue})` }} />
+                {titulo}
+              </h2>
+            </SheetTitle>
+            <SheetDescription asChild>
+              <p>Lançamento manual · numero gerado automaticamente</p>
+            </SheetDescription>
+          </div>
+        </header>
+
+        <form onSubmit={submit} className="os-drawer-body p-5 space-y-4 text-[13px] flex-1 overflow-y-auto">
+          <div className="space-y-1.5">
+            <label htmlFor="cr-desc" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+              Descrição / contraparte
+            </label>
+            <Input
+              id="cr-desc"
+              value={form.data.cliente_descricao}
+              onChange={(e) => form.setData('cliente_descricao', e.target.value)}
+              placeholder={tipo === 'receber' ? 'Ex: Cliente João Silva · sublocação' : 'Ex: Fornecedor papelaria XYZ'}
+              maxLength={255}
+              autoFocus
+            />
+            {form.errors.cliente_descricao && (
+              <p className="text-[11px] text-rose-600">{form.errors.cliente_descricao}</p>
+            )}
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div className="space-y-1.5">
+              <label htmlFor="cr-valor" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+                Valor (R$)
+              </label>
+              <Input
+                id="cr-valor"
+                type="number"
+                step="0.01"
+                min="0.01"
+                value={form.data.valor_total || ''}
+                onChange={(e) => form.setData('valor_total', parseFloat(e.target.value) || 0)}
+                placeholder="0,00"
+              />
+              {form.errors.valor_total && (
+                <p className="text-[11px] text-rose-600">{form.errors.valor_total}</p>
+              )}
+            </div>
+
+            <div className="space-y-1.5">
+              <label htmlFor="cr-venc" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+                Vencimento
+              </label>
+              <Input
+                id="cr-venc"
+                type="date"
+                value={form.data.vencimento}
+                onChange={(e) => form.setData('vencimento', e.target.value)}
+              />
+              {form.errors.vencimento && (
+                <p className="text-[11px] text-rose-600">{form.errors.vencimento}</p>
+              )}
+            </div>
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="cr-cat" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+              Categoria
+            </label>
+            <select
+              id="cr-cat"
+              value={form.data.categoria_id as string | number}
+              onChange={(e) => form.setData('categoria_id', e.target.value as unknown as number | '')}
+              className="w-full h-9 rounded-md border border-stone-300 bg-white px-3 text-[13px]"
+            >
+              <option value="">(Sem categoria)</option>
+              {categorias.map((c) => (
+                <option key={c.id} value={c.id}>{c.nome}</option>
+              ))}
+            </select>
+            {form.errors.categoria_id && (
+              <p className="text-[11px] text-rose-600">{form.errors.categoria_id}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="cr-plano" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+              Plano de contas
+            </label>
+            <PlanoContaCombobox
+              id="cr-plano"
+              planos={planos}
+              kind={kind}
+              value={form.data.plano_conta_id}
+              onChange={(id) => form.setData('plano_conta_id', id)}
+              placeholder={tipo === 'receber' ? 'Receita ou ativo' : 'Despesa, custo ou passivo'}
+            />
+            <p className="text-[11px] text-stone-500">
+              Opcional. Se vazio, BackfillPlanoContaCommand atribui &quot;(a classificar)&quot; depois.
+            </p>
+            {form.errors.plano_conta_id && (
+              <p className="text-[11px] text-rose-600">{form.errors.plano_conta_id}</p>
+            )}
+          </div>
+
+          <div className="space-y-1.5">
+            <label htmlFor="cr-obs" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+              Observações
+            </label>
+            <textarea
+              id="cr-obs"
+              value={form.data.observacoes}
+              onChange={(e) => form.setData('observacoes', e.target.value)}
+              maxLength={2000}
+              rows={3}
+              className="w-full rounded-md border border-stone-300 bg-white px-3 py-2 text-[13px] resize-none"
+              placeholder="Notas internas (opcional)…"
+            />
+            {form.errors.observacoes && (
+              <p className="text-[11px] text-rose-600">{form.errors.observacoes}</p>
+            )}
+          </div>
+
+          <div className="flex gap-2 pt-3 border-t border-stone-200 mt-auto">
+            <Button
+              type="submit"
+              disabled={form.processing}
+              style={{ backgroundColor: `oklch(0.55 0.15 ${accentHue})`, color: 'oklch(0.99 0 0)' }}
+            >
+              {form.processing ? 'Salvando…' : `Criar ${tipo === 'receber' ? 'recebimento' : 'pagamento'}`}
+            </Button>
+            <Button type="button" variant="outline" onClick={onClose} disabled={form.processing}>
+              Cancelar
+            </Button>
+          </div>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+export default TituloCreateSheet;

--- a/resources/js/Pages/Financeiro/Unificado/_components/TituloCreateSheet.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/TituloCreateSheet.tsx
@@ -101,7 +101,7 @@ export function TituloCreateSheet({ open, onClose, tipo, categorias, planos }: T
 
         <form onSubmit={submit} className="os-drawer-body p-5 space-y-4 text-[13px] flex-1 overflow-y-auto">
           <div className="space-y-1.5">
-            <label htmlFor="cr-desc" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+            <label htmlFor="cr-desc" className="text-[11px] uppercase tracking-widest text-muted-foreground font-medium">
               Descrição / contraparte
             </label>
             <Input
@@ -113,13 +113,13 @@ export function TituloCreateSheet({ open, onClose, tipo, categorias, planos }: T
               autoFocus
             />
             {form.errors.cliente_descricao && (
-              <p className="text-[11px] text-rose-600">{form.errors.cliente_descricao}</p>
+              <p className="text-[11px] text-destructive">{form.errors.cliente_descricao}</p>
             )}
           </div>
 
           <div className="grid grid-cols-2 gap-3">
             <div className="space-y-1.5">
-              <label htmlFor="cr-valor" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+              <label htmlFor="cr-valor" className="text-[11px] uppercase tracking-widest text-muted-foreground font-medium">
                 Valor (R$)
               </label>
               <Input
@@ -132,12 +132,12 @@ export function TituloCreateSheet({ open, onClose, tipo, categorias, planos }: T
                 placeholder="0,00"
               />
               {form.errors.valor_total && (
-                <p className="text-[11px] text-rose-600">{form.errors.valor_total}</p>
+                <p className="text-[11px] text-destructive">{form.errors.valor_total}</p>
               )}
             </div>
 
             <div className="space-y-1.5">
-              <label htmlFor="cr-venc" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+              <label htmlFor="cr-venc" className="text-[11px] uppercase tracking-widest text-muted-foreground font-medium">
                 Vencimento
               </label>
               <Input
@@ -147,20 +147,20 @@ export function TituloCreateSheet({ open, onClose, tipo, categorias, planos }: T
                 onChange={(e) => form.setData('vencimento', e.target.value)}
               />
               {form.errors.vencimento && (
-                <p className="text-[11px] text-rose-600">{form.errors.vencimento}</p>
+                <p className="text-[11px] text-destructive">{form.errors.vencimento}</p>
               )}
             </div>
           </div>
 
           <div className="space-y-1.5">
-            <label htmlFor="cr-cat" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+            <label htmlFor="cr-cat" className="text-[11px] uppercase tracking-widest text-muted-foreground font-medium">
               Categoria
             </label>
             <select
               id="cr-cat"
               value={form.data.categoria_id as string | number}
               onChange={(e) => form.setData('categoria_id', e.target.value as unknown as number | '')}
-              className="w-full h-9 rounded-md border border-stone-300 bg-white px-3 text-[13px]"
+              className="w-full h-9 rounded-md border border-input bg-background px-3 text-[13px]"
             >
               <option value="">(Sem categoria)</option>
               {categorias.map((c) => (
@@ -168,12 +168,12 @@ export function TituloCreateSheet({ open, onClose, tipo, categorias, planos }: T
               ))}
             </select>
             {form.errors.categoria_id && (
-              <p className="text-[11px] text-rose-600">{form.errors.categoria_id}</p>
+              <p className="text-[11px] text-destructive">{form.errors.categoria_id}</p>
             )}
           </div>
 
           <div className="space-y-1.5">
-            <label htmlFor="cr-plano" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+            <label htmlFor="cr-plano" className="text-[11px] uppercase tracking-widest text-muted-foreground font-medium">
               Plano de contas
             </label>
             <PlanoContaCombobox
@@ -184,16 +184,16 @@ export function TituloCreateSheet({ open, onClose, tipo, categorias, planos }: T
               onChange={(id) => form.setData('plano_conta_id', id)}
               placeholder={tipo === 'receber' ? 'Receita ou ativo' : 'Despesa, custo ou passivo'}
             />
-            <p className="text-[11px] text-stone-500">
+            <p className="text-[11px] text-muted-foreground">
               Opcional. Se vazio, BackfillPlanoContaCommand atribui &quot;(a classificar)&quot; depois.
             </p>
             {form.errors.plano_conta_id && (
-              <p className="text-[11px] text-rose-600">{form.errors.plano_conta_id}</p>
+              <p className="text-[11px] text-destructive">{form.errors.plano_conta_id}</p>
             )}
           </div>
 
           <div className="space-y-1.5">
-            <label htmlFor="cr-obs" className="text-[11px] uppercase tracking-widest text-stone-500 font-medium">
+            <label htmlFor="cr-obs" className="text-[11px] uppercase tracking-widest text-muted-foreground font-medium">
               Observações
             </label>
             <textarea
@@ -202,15 +202,15 @@ export function TituloCreateSheet({ open, onClose, tipo, categorias, planos }: T
               onChange={(e) => form.setData('observacoes', e.target.value)}
               maxLength={2000}
               rows={3}
-              className="w-full rounded-md border border-stone-300 bg-white px-3 py-2 text-[13px] resize-none"
+              className="w-full rounded-md border border-input bg-background px-3 py-2 text-[13px] resize-none"
               placeholder="Notas internas (opcional)…"
             />
             {form.errors.observacoes && (
-              <p className="text-[11px] text-rose-600">{form.errors.observacoes}</p>
+              <p className="text-[11px] text-destructive">{form.errors.observacoes}</p>
             )}
           </div>
 
-          <div className="flex gap-2 pt-3 border-t border-stone-200 mt-auto">
+          <div className="flex gap-2 pt-3 border-t border-border mt-auto">
             <Button
               type="submit"
               disabled={form.processing}


### PR DESCRIPTION
> Sucessor de #1536 (fechado auto quando PR base #1533 mergeou).

## Summary

- Substitui stub `/unificado/novo` por **drawer inline** `TituloCreateSheet`. DropdownMenu existente "+ Novo título" no header passa a abrir o Sheet em vez de `router.visit` — preserva mental model, mata stub, cumpre Opção A (usuário escolhe tipo ANTES do form).
- Sheet reusa `PlanoContaCombobox` (Onda 24 / #1533 mergeado) — filtra DCASP por kind do título.
- Backend: `UnificadoController::store(StoreTituloRequest)` + rota `POST /unificado`. Numero sequencial business-isolado (`R-NNNNN` / `P-NNNNN`) com `lockForUpdate` (R-FIN-002 idempotência).

## UX (Opção A)

- "+ Novo título" no header → DropdownMenu:
  - **Novo recebimento** (verde 145) → Sheet `tipo='receber'`, combobox filtra receita/ativo
  - **Novo pagamento** (rose 25) → Sheet `tipo='pagar'`, combobox filtra despesa/custo/passivo
  - Importar boleto OCR (intacto)

## Multi-tenant Tier 0 (ADR 0093)

- `business_id` da session, nunca payload
- `StoreTituloRequest::assertPlanoCoerente()` revalida tipo↔plano (anti tampering)
- Pest cross-tenant rejeita 422

## Test plan

- [x] TypeScript `npm run typecheck` passa
- [x] Pest 6 testes descobertos, skip gracioso local
- [x] UI Lint sem regressão (tokens semânticos shadcn aplicados)
- [ ] CI verde com DB seedado
- [ ] Smoke prod biz=1 — "+ Novo título" → Novo recebimento → salvar → confirmar R-NNNNN na lista

## Refs

- US-FIN-021 — Form unificado inline · **DONE com este PR**
- ADR fin-tech/0001 idempotência via lockForUpdate
- ADR 0093 Multi-tenant Tier 0 IRREVOGÁVEL

🤖 Generated with [Claude Code](https://claude.com/claude-code)