### PR TITLE
feat(oficinaauto,sidebar): Oficina Auto pra COMERCIAL abaixo de Vendas + canon v3

### DIFF
--- a/Modules/OficinaAuto/Http/Controllers/DataController.php
+++ b/Modules/OficinaAuto/Http/Controllers/DataController.php
@@ -130,27 +130,26 @@ class DataController extends Controller
         Menu::modify(
             'admin-sidebar-menu',
             function ($menu) use ($segmento_ativo) {
-                // ADR 0180 Fase 4 Wave B (2026-05-21): dropdown principal declara
-                // atalho kbd + primary action + ghosts tabs no `attributes`.
+                // ADR 0180 Fase 4 Wave B (2026-05-21) + Wagner 2026-05-25:
+                // Pattern canon v3: href DIRETO (não mais `Menu::dropdown` com sub-items
+                // popover) + ghosts no PageHeader (viram tabs/atalhos secundários da página).
+                //
+                // Order 31: COMERCIAL abaixo de Vendas (order 30) — Wagner 2026-05-25
+                // pediu "Oficina Auto vai pra comercial abaixo de vendas" (operação
+                // de oficina é atividade comercial · não produção como fluxo Repair).
+                // Frontend SIDEBAR_GROUPS (Components/cockpit/Sidebar.tsx) reconhece
+                // label 'Oficina Auto' no grupo 'comercial' (PR companion).
+                //
+                // Sub-popover legacy (Veículos + Ordens de Serviço) ELIMINADO:
+                // viraram ghosts (tabs PageHeader v3) — 3 atalhos visíveis na própria
+                // página /oficina-auto/* sem precisar hover sidebar.
+                //
                 //  - `shortcut` G Y → atalho overlay (não-conflito com Repair G O)
                 //  - `primary`     → "Nova OS" via ServiceOrderController@create
-                //  - `ghosts`      → Veículos, Ordens de Serviço, Produção (Kanban
-                //    caçambas Martinho 2026-05-13)
-                $menu->dropdown(
+                //  - `ghosts`      → Veículos, Ordens de Serviço, Produção (tabs PageHeader)
+                $menu->url(
+                    url('/oficina-auto/producao-oficina'),
                     'Oficina Auto',
-                    function ($sub) {
-                        $segment2 = request()->segment(2);
-
-                        $sub->url(url('/oficina-auto/veiculos'), 'Veículos', [
-                            'icon'   => 'fa fas fa-car',
-                            'active' => $segment2 === 'veiculos',
-                        ]);
-
-                        $sub->url(url('/oficina-auto/ordens-servico'), 'Ordens de Serviço', [
-                            'icon'   => 'fa fas fa-tools',
-                            'active' => $segment2 === 'ordens-servico',
-                        ]);
-                    },
                     [
                         'icon'     => 'fa fas fa-wrench',
                         'active'   => $segmento_ativo,
@@ -166,7 +165,7 @@ class DataController extends Controller
                             ['key' => 'producao-oficina',  'label' => 'Produção',           'href' => '/oficina-auto/producao-oficina'],
                         ],
                     ]
-                )->order(56);
+                )->order(31);
             }
         );
     }

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -168,7 +168,12 @@ const SIDEBAR_GROUPS: Array<{ key: string; label: string; items: string[] }> = [
     key: 'comercial',
     label: 'COMERCIAL',
     // Wagner 2026-05-22: Crm + Vendas + Catalogue QR + Woocommerce (canal venda).
-    items: ['Crm', 'CRM', 'Vendas', 'Catalogue QR', 'Catálogo QR',
+    // Wagner 2026-05-25: Oficina Auto MOVE pra COMERCIAL abaixo de Vendas
+    // (operação de oficina = atividade comercial, não PRODUÇÃO). Sub-popover
+    // legacy (Veículos + Ordens de Serviço) virou ghosts no PageHeader v3.
+    // Companion DataController OficinaAuto.modifyAdminMenu order(31) (entre
+    // Vendas=30 e Catalogue QR=32+).
+    items: ['Crm', 'CRM', 'Vendas', 'Oficina Auto', 'Catalogue QR', 'Catálogo QR',
             'WooCommerce', 'Woocommerce'],
   },
   {


### PR DESCRIPTION
**Wagner 2026-05-25:** 'Oficina Auto deve ir para comercial abaixo de vendas, e os dois itens (sub-popover) vão para topnav'.

## Mudanças

### Backend · DataController OficinaAuto
- Troca `Menu::dropdown` (legacy popover) por `Menu::url` href direto (canon ADR 0180+)
- Sub-popover ELIMINADO: 3 ghosts já existiam no `attributes` → viram tabs PageHeader v3
- `order(56)` → **`order(31)`** (entre Vendas=30 e Catalogue QR=32+)
- `primary 'Nova OS'` + `shortcut G Y` preservados

### Frontend · SIDEBAR_GROUPS canon
- `'comercial'` items: adiciona `'Oficina Auto'` entre `'Vendas'` e `'Catalogue QR'`
- PRODUÇÃO group não mais reconhece Oficina Auto

## Resultado UI

**Antes** (sidebar):
```
PRODUÇÃO
├─ ...
├─ Oficina Auto ▾  (popover · Veículos + Ordens de Serviço)
└─ Reparar
```

**Depois** (sidebar):
```
COMERCIAL
├─ Crm
├─ Vendas
├─ Oficina Auto    ← single link, sem popover
├─ Catalogue QR
└─ Woocommerce

PRODUÇÃO
├─ ... (sem Oficina Auto)
└─ Reparar
```

**PageHeader v3 da página `/oficina-auto/*`** renderiza 3 ghosts como tabs/atalhos:
`Veículos` · `Ordens de Serviço` · `Produção` — usuário navega sem precisar abrir sidebar.

## Pattern

Linear/Notion · sub-items no topo da página (não popover lateral).

## Refs
- [ADR 0180](../blob/main/memory/decisions/0180-pageheader-canon-v3.md) — PageHeader canon v3
- ADR UI-0013 — Constituição UI v2 (sidebar light · 4 camadas)
- Skills: `sidebar-menu-arch` + `pageheader-canon`