### PR TITLE
ci(pest): remover --stop-on-failure do modules-pest.yml (relatório CI completo)

### DIFF
--- a/.github/workflows/modules-pest.yml
+++ b/.github/workflows/modules-pest.yml
@@ -101,8 +101,13 @@ jobs:
           CACHE_DRIVER: array
           SESSION_DRIVER: array
           QUEUE_CONNECTION: sync
+        # Wagner 2026-05-25: remove --stop-on-failure. Comportamento anterior
+        # escondia failures subsequentes quando 1 test falhava primeiro (ex:
+        # PR #1544 13 tests novos não rodaram pq Wave26SaturationTest forceDelete
+        # pre-existing falhou). Sem flag, CI mostra relatório completo de TODOS
+        # failures pra atacar de uma vez. Trade-off: +1-2min CI quando muitos
+        # tests quebram (raro). Vale pelo ganho de transparência.
         run: |
           vendor/bin/pest Modules/${{ matrix.module }}/Tests \
-            --stop-on-failure \
             --no-coverage \
             --colors=always


### PR DESCRIPTION
## Summary

Remove flag \`--stop-on-failure\` do workflow [modules-pest.yml](.github/workflows/modules-pest.yml). Comportamento atual escondia failures subsequentes quando 1 test falhava primeiro — bloqueio observado no [#1544](https://github.com/wagnerra23/oimpresso.com/pull/1544) onde 13 tests novos não rodaram porque \`Wave26SaturationTest forceDelete\` (pre-existing fail sendo resolvido na branch \`docs/adr-0193-nfeservice-retransmitir-sem-forcedelete\`) parou Pest primeiro.

## Diff

\`\`\`diff
 run: |
   vendor/bin/pest Modules/\${{ matrix.module }}/Tests \
-    --stop-on-failure \
     --no-coverage \
     --colors=always
\`\`\`

## Trade-offs

| | Antes (`--stop-on-failure`) | Depois (sem flag) |
|---|---|---|
| Feedback | "primeiro fail e para" | TODOS os fails do módulo |
| Tempo CI quando muitos fails | rápido | +1-2min (raro) |
| Tempo CI quando 0 ou 1 fail | igual | igual |
| Triagem PR com múltiplos issues | múltiplos pushes/runs pra ver tudo | 1 push mostra tudo |
| Beneficia | autor do 1º fail | autor de TODOS fails |

## Por que vale

- **PRs novos não ficam ofuscados** por pre-existing failures (ex: meu #1544 13 tests não rodaram)
- **Time inteiro** ganha visibilidade nos 5 módulos do workflow (Arquivos, ComunicacaoVisual, NfeBrasil, Repair, Vestuario)
- **fail-fast a nível matrix já está off** (linha 42 \`fail-fast: false\`) — impacto é só por-job
- Reversível em 1 linha se causar issue de runner

## Test plan

- [ ] Pós-merge, próximo PR que toque \`Modules/NfeBrasil/**\` mostra relatório completo (não para no primeiro fail)
- [ ] PR #1544 (rebase pós-merge) — 13 tests novos passam a aparecer no log mesmo com \`forceDelete\` ainda red

Refs: #1544 (blocker observado), #1541 (mesmo problema histórico).

🤖 Generated with [Claude Code](https://claude.com/claude-code)