### PR TITLE
feat(financeiro): PR D quick wins — visual-comp Ondas 24/25 + keyboard nav + audit log

### DIFF
--- a/Modules/Financeiro/Http/Requests/StoreTituloRequest.php
+++ b/Modules/Financeiro/Http/Requests/StoreTituloRequest.php
@@ -3,6 +3,7 @@
 namespace Modules\Financeiro\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\Rule;
 use Modules\Financeiro\Models\Categoria;
 use Modules\Financeiro\Models\PlanoConta;
@@ -102,6 +103,17 @@ class StoreTituloRequest extends FormRequest
             : ['despesa', 'custo', 'passivo'];
 
         if (! in_array($plano->tipo, $permitidos, true)) {
+            // PR D — G12 audit log violação coerência (mesmo padrão Update).
+            Log::warning('financeiro.plano_coerencia.violada', [
+                'route'        => 'store',
+                'business_id'  => $businessId,
+                'tipo_titulo'  => $this->input('tipo'),
+                'plano_id'     => $plano->id,
+                'plano_codigo' => $plano->codigo,
+                'plano_tipo'   => $plano->tipo,
+                'user_id'      => $this->user()?->id,
+                'ip'           => $this->ip(),
+            ]);
             abort(422, "Plano de contas '{$plano->codigo} {$plano->nome}' (tipo {$plano->tipo}) é incompatível com título tipo '{$this->input('tipo')}'.");
         }
     }

--- a/Modules/Financeiro/Http/Requests/UpdateTituloRequest.php
+++ b/Modules/Financeiro/Http/Requests/UpdateTituloRequest.php
@@ -3,6 +3,7 @@
 namespace Modules\Financeiro\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Validation\Rule;
 use Modules\Financeiro\Models\Categoria;
 use Modules\Financeiro\Models\PlanoConta;
@@ -110,6 +111,19 @@ class UpdateTituloRequest extends FormRequest
             : ['despesa', 'custo', 'passivo'];
 
         if (! in_array($plano->tipo, $permitidos, true)) {
+            // PR D — G12 audit log violação coerência. Se taxa > 0.1% sinaliza
+            // bug UI (frontend filter quebrado) OU tentativa tampering.
+            Log::warning('financeiro.plano_coerencia.violada', [
+                'route'        => 'update',
+                'business_id'  => $titulo->business_id,
+                'titulo_id'    => $titulo->id,
+                'tipo_titulo'  => $titulo->tipo,
+                'plano_id'     => $plano->id,
+                'plano_codigo' => $plano->codigo,
+                'plano_tipo'   => $plano->tipo,
+                'user_id'      => $this->user()?->id,
+                'ip'           => $this->ip(),
+            ]);
             abort(422, "Plano de contas '{$plano->codigo} {$plano->nome}' (tipo {$plano->tipo}) é incompatível com título tipo '{$titulo->tipo}'.");
         }
     }

--- a/memory/requisitos/Financeiro/financeiro-unificado-visual-comparison.md
+++ b/memory/requisitos/Financeiro/financeiro-unificado-visual-comparison.md
@@ -5,6 +5,8 @@ type: visual-comparison
 module: Financeiro
 status: approved
 date: 2026-05-09
+last_updated: 2026-05-25
+last_appended_ondas: [24, 25, "PR D quick wins"]
 canon_reference: cowork-2026-05-09-protótipo "Visao Unificada" (Financeiro.html)
 canon_secundario: tasks.jsx (inbox densa com atalhos teclado)
 blade_source: n/a (greenfield — tela nova de unificação dos 4 estados)
@@ -139,3 +141,48 @@ Ver [ADR ui/0003](adr/ui/0003-amendment-0002-visao-unificada-cockpit-v2.md) pra 
 ## Backlog (do charter)
 
 US-FIN-021..028 — ver [Index.charter.md](../../../resources/js/Pages/Financeiro/Unificado/Index.charter.md) §"Backlog futuro". Cada um gated por sinal qualificado [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md).
+
+---
+
+## Anexo: Ondas 24 + 25 (2026-05-25) — Plano de Contas + Insert manual
+
+> **Status:** approved 2026-05-25 via Chrome MCP smoke prod biz=MARTINHO (PRs #1533 + #1538 mergeados).
+> **Reabertura retroativa do gate F1.5 mwart-comparative V4** (G2 da auditoria 2026-05-25).
+
+### Ondas 24/25 — diff visual vs canon
+
+| Dimensão | Canon Cowork original | Implementação Onda 24+25 | Decisão |
+|---|---|---|---|
+| **Campo plano de contas no Edit** | Ausente (canon protótipo não previa) | `PlanoContaCombobox` searchable hierárquico DCASP filtrado por `kind` do título | **Adição funcional** — canon visual aceito porque DRE depende de plano classificado na origem |
+| **Insert manual inline** | Canon previa botão "+" no header → tela separada `/novo` | `TituloCreateSheet` drawer inline reusando padrão `TituloEditSheet` | **Cumpre intent do canon** (sem navegação) — DropdownMenu existente "+ Novo título" virou wire pro Sheet |
+| **Combobox hues semânticos por tipo DCASP** | n/a (canon não tinha plano de contas) | 6 tipos (receita, ativo, despesa, custo, passivo, patrimonio) via `style` inline oklch tokens | Fora dos tokens shadcn (ui:lint R1 escape). Hues coerentes com paleta financeira (receita=verde 145, despesa=rose 25, custo=amber 60, passivo=rose 25, ativo=verde 145, patrimonio=azul 240) |
+| **Filtragem do combobox por `kind`** | n/a | `receivable` → receita+ativo (11 opções biz=MARTINHO) · `payable` → despesa+custo+passivo (17 opções) | Reduz cognitive load — Eliana não vê opções inválidas |
+| **Numero sequencial R-/P-** | Canon previa `numero` opcional | `R-NNNNN` (receber) / `P-NNNNN` (pagar) com `lockForUpdate` business-isolado | R-FIN-002 idempotência forte |
+| **2 botões vs Dropdown** | Decisão pendente | Opção A do design: Wagner aprovou 2 escolhas explícitas ANTES do form. Reusou `DropdownMenu` existente em vez de criar 2 botões novos no header | Menos poluição visual + mantém mental model Eliana |
+
+### Validação Chrome MCP smoke prod (2026-05-25 biz=MARTINHO)
+
+| Fluxo | Resultado |
+|---|---|
+| Dropdown "+ Novo título" 3 itens | ✅ |
+| Novo recebimento → Sheet "Nova conta a receber" | ✅ Title + 6 labels + combobox `cr-plano` |
+| Combobox receber filtragem | ✅ 11 opções tipos `ativo + receita` |
+| Novo pagamento → Sheet "Nova conta a pagar" | ✅ placeholder "Despesa, custo ou passivo" |
+| Combobox pagar filtragem | ✅ 17 opções tipos `passivo + custo + despesa` |
+| Edit título #68042 (pagar) | ✅ combobox `ed-plano` filtrado correto, label "Plano de contas" entre Categoria/Vencimento |
+| Console errors | 0 |
+
+### PR D — Combobox keyboard navigation (G7 auditoria)
+
+WAI-ARIA Combobox pattern adicionado pós-smoke:
+- `↑` / `↓` navega lista
+- `Enter` seleciona ativo
+- `Esc` fecha
+- `Home` / `End` primeiro/último
+- `aria-activedescendant` linka input ↔ option pra screen reader
+- Mouse hover atualiza activeIdx (consistência visual)
+- `scrollIntoView({block:'nearest'})` mantém ativo visível em listas longas
+
+### PR D — G12 audit log violação coerência
+
+`UpdateTituloRequest::assertPlanoCoerente()` + `StoreTituloRequest::assertPlanoCoerente()` agora emitem `Log::warning('financeiro.plano_coerencia.violada', ...)` antes do abort(422) com payload completo (route, business_id, titulo_id, tipo_titulo, plano_id, plano_codigo, plano_tipo, user_id, ip). Permite alerta em dashboard se taxa > 0.1% (signal de bug UI ou tentativa tampering).

--- a/resources/js/Pages/Financeiro/Unificado/_components/PlanoContaCombobox.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/_components/PlanoContaCombobox.tsx
@@ -8,10 +8,17 @@
 // Busca client-side por código OU nome (case insensitive). Hierarquia visual
 // indentada por nivel (folhas tipicamente nivel=4).
 //
+// PR D (2026-05-25) — WAI-ARIA Combobox keyboard nav (auditoria G7):
+//   - ↑ / ↓ navega lista
+//   - Enter seleciona ativo
+//   - Esc fecha
+//   - Home / End primeiro/último
+//   - aria-activedescendant pra screen reader
+//
 // Reusável entre Edit e Create. Backend defesa em profundidade via
 // `UpdateTituloRequest::assertPlanoCoerente()`.
 
-import { useMemo, useRef, useState, useEffect } from 'react';
+import { useMemo, useRef, useState, useEffect, type KeyboardEvent } from 'react';
 import { Search, X } from 'lucide-react';
 
 export interface PlanoConta {
@@ -49,7 +56,11 @@ const TIPO_STYLE: Record<PlanoConta['tipo'], React.CSSProperties> = {
 export function PlanoContaCombobox({ planos, value, onChange, kind, id, placeholder, disabled }: Props) {
   const [open, setOpen] = useState(false);
   const [busca, setBusca] = useState('');
+  const [activeIdx, setActiveIdx] = useState(0);
   const containerRef = useRef<HTMLDivElement>(null);
+  const listboxRef = useRef<HTMLUListElement>(null);
+  const baseId = id ?? 'plano-combobox';
+  const listboxId = `${baseId}-listbox`;
 
   const tiposPermitidos = kind === 'receivable' ? TIPOS_RECEBER : TIPOS_PAGAR;
 
@@ -67,6 +78,22 @@ export function PlanoContaCombobox({ planos, value, onChange, kind, id, placehol
     );
   }, [planos, tiposPermitidos, busca]);
 
+  // Reset índice ativo quando filtro muda OU abre.
+  useEffect(() => {
+    if (open) {
+      const idxAtual = lista.findIndex((p) => p.id === value);
+      setActiveIdx(idxAtual >= 0 ? idxAtual : 0);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, busca]);
+
+  // Garante que item ativo fique visível durante navegação por teclado.
+  useEffect(() => {
+    if (! open || ! listboxRef.current) return;
+    const activeEl = listboxRef.current.querySelector<HTMLLIElement>(`#${baseId}-opt-${activeIdx}`);
+    activeEl?.scrollIntoView({ block: 'nearest' });
+  }, [activeIdx, open, baseId]);
+
   // Fecha ao clicar fora.
   useEffect(() => {
     if (! open) return;
@@ -80,16 +107,48 @@ export function PlanoContaCombobox({ planos, value, onChange, kind, id, placehol
     return () => document.removeEventListener('mousedown', handler);
   }, [open]);
 
+  const close = () => {
+    setOpen(false);
+    setBusca('');
+  };
+
+  const handleKey = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIdx((i) => Math.min(i + 1, Math.max(0, lista.length - 1)));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIdx((i) => Math.max(0, i - 1));
+    } else if (e.key === 'Home') {
+      e.preventDefault();
+      setActiveIdx(0);
+    } else if (e.key === 'End') {
+      e.preventDefault();
+      setActiveIdx(Math.max(0, lista.length - 1));
+    } else if (e.key === 'Enter') {
+      e.preventDefault();
+      const ativo = lista[activeIdx];
+      if (ativo) {
+        onChange(ativo.id);
+        close();
+      }
+    } else if (e.key === 'Escape') {
+      e.preventDefault();
+      close();
+    }
+  };
+
   return (
     <div className="relative" ref={containerRef}>
       <button
         type="button"
-        id={id}
+        id={baseId}
         disabled={disabled}
         onClick={() => setOpen((o) => !o)}
         className="w-full h-9 rounded-md border border-input bg-background px-3 text-left text-[13px] flex items-center justify-between gap-2 hover:border-ring disabled:bg-muted disabled:cursor-not-allowed"
         aria-haspopup="listbox"
         aria-expanded={open}
+        aria-controls={open ? listboxId : undefined}
       >
         {selecionado ? (
           <span className="flex items-center gap-2 truncate">
@@ -135,31 +194,44 @@ export function PlanoContaCombobox({ planos, value, onChange, kind, id, placehol
             <input
               autoFocus
               type="text"
-              placeholder={`Buscar ${kind === 'receivable' ? 'receita/ativo' : 'despesa/custo/passivo'} por código ou nome…`}
+              role="combobox"
+              aria-controls={listboxId}
+              aria-expanded={true}
+              aria-activedescendant={lista[activeIdx] ? `${baseId}-opt-${activeIdx}` : undefined}
+              placeholder={`Buscar ${kind === 'receivable' ? 'receita/ativo' : 'despesa/custo/passivo'} (↑↓ navega · Enter seleciona)`}
               value={busca}
               onChange={(e) => setBusca(e.target.value)}
+              onKeyDown={handleKey}
               className="flex-1 text-[13px] outline-none bg-transparent"
             />
           </div>
-          <ul role="listbox" className="overflow-y-auto flex-1">
+          <ul
+            id={listboxId}
+            ref={listboxRef}
+            role="listbox"
+            aria-label="Planos de contas disponíveis"
+            className="overflow-y-auto flex-1"
+          >
             {lista.length === 0 && (
               <li className="px-3 py-4 text-center text-[12px] text-muted-foreground">
                 Nenhum plano encontrado.
               </li>
             )}
-            {lista.map((p) => {
+            {lista.map((p, idx) => {
               const isSelected = p.id === value;
+              const isActive = idx === activeIdx;
               return (
                 <li
                   key={p.id}
+                  id={`${baseId}-opt-${idx}`}
                   role="option"
                   aria-selected={isSelected}
                   onClick={() => {
                     onChange(p.id);
-                    setOpen(false);
-                    setBusca('');
+                    close();
                   }}
-                  className={`flex items-center gap-2 px-3 py-1.5 text-[13px] cursor-pointer hover:bg-accent ${isSelected ? 'bg-accent' : ''}`}
+                  onMouseEnter={() => setActiveIdx(idx)}
+                  className={`flex items-center gap-2 px-3 py-1.5 text-[13px] cursor-pointer ${isActive ? 'bg-accent' : ''} ${isSelected && ! isActive ? 'bg-accent/50' : ''}`}
                   style={{ paddingLeft: 12 + (p.nivel - 1) * 12 }}
                 >
                   <span className="font-mono text-foreground text-[12px] tabular-nums shrink-0">{p.codigo}</span>


### PR DESCRIPTION
> Follow-up das Ondas 24+25 (PRs #1533 + #1538). Resolve 3 itens da [auditoria 2026-05-25](memory/sessions/2026-05-25-auditoria-financeiro-pos-ondas-24-25.md): **G2 visual-comparison** + **G7 keyboard nav** + **G12 audit log**.

## Summary

- **G2**: `financeiro-unificado-visual-comparison.md` ganha anexo Ondas 24+25 (gate F1.5 mwart-comparative V4 reaberto retroativamente) — 6 dimensões diff vs canon + validação Chrome MCP smoke biz=MARTINHO documentada.
- **G7**: `PlanoContaCombobox` ganha WAI-ARIA Combobox keyboard nav completo (↑↓ Enter Esc Home/End + `aria-activedescendant` + mouse hover sync + scrollIntoView).
- **G12**: `Update/StoreTituloRequest::assertPlanoCoerente()` emitem `Log::warning('financeiro.plano_coerencia.violada', ...)` antes do abort(422) — payload com route/business_id/titulo_id/tipo/plano/user/ip permite alerta se taxa > 0.1%.

## UX Eliana (power user)

Antes: combobox plano só clicável com mouse. Eliana power-user perdia velocidade.

Depois: abre combobox, digita 2-3 letras pra filtrar, ↑↓ navega visivelmente, Enter seleciona, Esc fecha. `aria-activedescendant` anuncia ao screen reader qual opção está focada.

## Test plan

- [x] `npm run typecheck` passa
- [x] UI Lint sem regressão (style inline oklch escapa R1)
- [ ] CI verde — não há novo Pest test (mudança de comportamento UI testado via smoke real)
- [ ] Smoke prod biz=MARTINHO pós-deploy: tab pro combobox, ↑↓ navega, Enter seleciona, Esc fecha (Chrome MCP)
- [ ] Log warning visível em `storage/logs/laravel.log` se forçar tampering (curl POST com plano_conta_id de tipo errado)

## Refs

- US-FIN-027 parcial
- ADR 0093 Multi-tenant Tier 0
- WAI-ARIA Combobox pattern (https://www.w3.org/WAI/ARIA/apg/patterns/combobox/)
- Auditoria 2026-05-25: G2 + G7 + G12

🤖 Generated with [Claude Code](https://claude.com/claude-code)