### PR TITLE
feat(jana,sidebar): Dashboard primeira aba + login → /ia/dashboard + remove Governança do sidebar

### DIFF
--- a/Modules/Governance/Http/Controllers/DataController.php
+++ b/Modules/Governance/Http/Controllers/DataController.php
@@ -52,6 +52,15 @@ class DataController extends Controller
 
     public function modifyAdminMenu()
     {
+        // Wagner 2026-05-25: entry sidebar de Governança REMOVIDA — módulo
+        // continua acessível por URL direta (/governance/dashboard, /policies,
+        // /audit, /drift, /module-grades) mas não aparece no sidebar. Roteamento
+        // canon agora é via Jana: login pós-redirect → /ia/dashboard (primeira
+        // aba). Permissions/package/rotas preservadas — só desligamos o
+        // Menu::modify pra parar de renderizar entry no AppShellV2.
+        return;
+
+        // ↓ DEAD CODE preservado pra histórico (até ADR formalizar a remoção).
         if (!auth()->check()) return;
 
         $module_util = new ModuleUtil();

--- a/Modules/Jana/Http/Controllers/DashboardController.php
+++ b/Modules/Jana/Http/Controllers/DashboardController.php
@@ -17,20 +17,11 @@ class DashboardController extends Controller
     {
         $businessId = $request->session()->get('user.business_id');
 
-        // Pré-check rápido (count) pra decidir redirect antes de hidratar payload.
-        // Anti-pattern evitado: get() completo só pra ver isEmpty() — desperdiça
-        // a query pesada com eager loads quando user não tem meta ativa.
-        $temMetas = Meta::where('ativo', true)
-            ->where(function ($q) use ($businessId) {
-                $q->where('business_id', $businessId)
-                  ->orWhereNull('business_id');
-            })
-            ->exists();
-
-        if (! $temMetas) {
-            return redirect()->route('jana.chat.index')
-                ->with('status', 'Nenhuma meta ativa. Converse com o Copiloto pra criar a primeira.');
-        }
+        // Wagner 2026-05-25: Dashboard é PRIMEIRA ABA canon da Jana + destino
+        // pós-login (`/home → /ia/dashboard`). Empty state já implementado em
+        // Dashboard.tsx (linha 296) com CTA "Pergunte algo a Jana". O redirect
+        // antigo "sem metas → chat" criava loop UX: login → /ia/dashboard →
+        // bounce pra /ia (chat). Removido — frontend renderiza empty card.
 
         // D6.a (Wave 14 governance v3) — Inertia::defer no payload `metas`.
         // Eager loads (periodoAtual + ultimaApuracao + apuracoes×12) podem

--- a/Modules/Jana/Http/Controllers/DataController.php
+++ b/Modules/Jana/Http/Controllers/DataController.php
@@ -250,6 +250,12 @@ class DataController extends Controller
                             ['key' => 'memorias',  'label' => 'Memórias',  'href' => '/ia/memorias'],
                             ['key' => 'kb',        'label' => 'KB',        'href' => '/ia/kb'],
                             ['key' => 'regras',    'label' => 'Regras',    'href' => '/ia/regras'],
+                            // Wagner 2026-05-25: Governança canon (Modules/Governance · policies/audit/
+                            // drift/module-grades) entra como ghost da Jana — "governança é da IA".
+                            // Entry sidebar foi desligada no mesmo dia (Modules/Governance/DataController
+                            // modifyAdminMenu early-return). Sub-views Dashboard/Policies/Audit/Drift/
+                            // Module Grades navegáveis pelo PageHeader da própria Governança.
+                            ['key' => 'governanca', 'label' => 'Governança', 'href' => '/governance/dashboard'],
                             // Wagner 2026-05-23: ghost 'metas' removido — MetasController@index ainda
                             // retorna Blade view ('copiloto::metas.index'), o que faz Inertia Link no
                             // PageHeaderTabs silenciar (click no-op). Reintroduzir quando MetasController

--- a/Modules/Jana/Http/Controllers/DataController.php
+++ b/Modules/Jana/Http/Controllers/DataController.php
@@ -238,14 +238,18 @@ class DataController extends Controller
                         // Wagner 2026-05-22: hrefs /jana → /ia (vertical-slice IA piloto
                         // sidebar v3 — URL canon casa com label "IA" do topo).
                         'ghosts'   => [
-                            // 5 destinos canon do guia
+                            // Wagner 2026-05-25: Dashboard PROMOVIDO pra primeira aba canon
+                            // da Jana — destino pós-login (`/home → /ia/dashboard`). Charter
+                            // Pages/Jana/Dashboard.charter.md já cobre empty state. Substitui
+                            // Copiloto (chat) como entry-point default da Jana — chat continua
+                            // acessível em 2ª aba e via FAB. Tentativas anteriores travaram em
+                            // DashboardController@index redirect "sem metas → chat" (removido).
+                            ['key' => 'dashboard', 'label' => 'Dashboard', 'href' => '/ia/dashboard'],
                             ['key' => 'copiloto',  'label' => 'Copiloto',  'href' => '/ia'],
                             ['key' => 'brief',     'label' => 'Brief',     'href' => '/ia/brief'],
                             ['key' => 'memorias',  'label' => 'Memórias',  'href' => '/ia/memorias'],
                             ['key' => 'kb',        'label' => 'KB',        'href' => '/ia/kb'],
                             ['key' => 'regras',    'label' => 'Regras',    'href' => '/ia/regras'],
-                            // Operacional interno (descoberta admin)
-                            ['key' => 'dashboard', 'label' => 'Dashboard', 'href' => '/ia/dashboard'],
                             // Wagner 2026-05-23: ghost 'metas' removido — MetasController@index ainda
                             // retorna Blade view ('copiloto::metas.index'), o que faz Inertia Link no
                             // PageHeaderTabs silenciar (click no-op). Reintroduzir quando MetasController

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -224,7 +224,9 @@ const SIDEBAR_GROUPS: Array<{ key: string; label: string; items: string[] }> = [
     label: 'SISTEMA',
     // Wagner 2026-05-22: Auditoria/Modelos de notificação/Relatórios/Dashboard
     // adicionados (eram módulos soltos em MAIS).
-    items: ['Governança', 'Plataforma', 'Auditoria',
+    // Wagner 2026-05-25: 'Governança' REMOVIDO — entry sidebar desligada no
+    // Modules/Governance/DataController.modifyAdminMenu (acesso via URL direta).
+    items: ['Plataforma', 'Auditoria',
             'Modelos de notificação', 'Modelo de notificação',
             'Relatórios', 'Dashboard',
             // Wagner 2026-05-22: Planilha vai pra SISTEMA.

--- a/routes/web.php
+++ b/routes/web.php
@@ -159,14 +159,15 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     // (TaskProvider interface + TaskRegistry agregando providers de cada módulo).
     Route::get('/tarefas', fn () => inertia('Tarefas/Index'))->name('tarefas.index');
 
-    // Wagner 2026-05-22: /home redireciona pra /ia (entry-point canon do
-    // oimpresso é o hub IA/Jana — sidebar v3 ADR 0180). Dashboard legacy
+    // Wagner 2026-05-22: /home redireciona pra hub IA/Jana — sidebar v3 ADR 0180.
+    // Wagner 2026-05-25: alvo passou de /ia (chat) pra /ia/dashboard (Dashboard
+    // Jana = primeira aba canon, com farol das metas + KPIs do business). Chat
+    // continua entry-point IA conversacional via aba 2 e FAB. Dashboard legacy
     // UltimatePOS (HomeController@index com cards Total Vendas/Líquido/A
-    // Receber) ainda acessível via /dashboard-legacy se precisar de tela
-    // específica futuramente. Name `home` preservado pra compat com
-    // `route('home')` chamado em ~30 lugares (post-login redirect, breadcrumbs,
-    // links externos UltimatePOS core).
-    Route::get('/home', fn () => redirect('/ia', 302))->name('home');
+    // Receber) ainda acessível via /dashboard-legacy se precisar. Name `home`
+    // preservado pra compat com `route('home')` chamado em ~30 lugares
+    // (post-login redirect, breadcrumbs, links externos UltimatePOS core).
+    Route::get('/home', fn () => redirect('/ia/dashboard', 302))->name('home');
     Route::get('/dashboard-legacy', [HomeController::class, 'index'])->name('home.legacy');
     Route::get('/home/get-totals', [HomeController::class, 'getTotals']);
     Route::get('/home/product-stock-alert', [HomeController::class, 'getProductStockAlert']);


### PR DESCRIPTION
## Summary

Wagner 2026-05-25 — pedido único de 3 etapas ("Dashboard dentro da Jana na primeira aba, apague do sidebar, o login deve encaminhar para isso. Essa é difícil, já tentei algumas vezes"):

- **Dashboard da Jana** virou **primeira aba** (PageHeaderTabs: `Dashboard | Copiloto | Brief | …`)
- **Pós-login** (`/home`) redireciona pra `/ia/dashboard` (era `/ia`/chat)
- **Governança** sai do sidebar mas ENTRA como ghost da Jana (Wagner: "a governança é da IA")

### Pegadinha resolvida

Tentativas anteriores travaram em `DashboardController@index` — ele tinha um `redirect()->route('jana.chat.index')` quando o user não tinha metas ativas. Isso criava loop UX: login → `/ia/dashboard` → sem metas → bounce pra `/ia` (chat). Solução: remover o redirect — frontend já implementa empty state em `resources/js/Pages/Jana/Dashboard.tsx:296` com CTA "Pergunte a Jana".

## Mudanças (2 commits, 6 arquivos)

| Arquivo | O quê |
|---|---|
| `Modules/Jana/Http/Controllers/DataController.php` | Reorder ghosts — `dashboard` na pos 0 + adiciona `governanca` (`/governance/dashboard`) após `regras`. |
| `Modules/Jana/Http/Controllers/DashboardController.php` | Remove `if (! \$temMetas) return redirect(chat)`. |
| `routes/web.php` | `/home → /ia/dashboard` (era `/home → /ia`). |
| `Modules/Governance/Http/Controllers/DataController.php` | `modifyAdminMenu` early-return — sem entry sidebar. |
| `resources/js/Components/cockpit/Sidebar.tsx` | Remove `'Governança'` do `items[]` do grupo `sistema`. |

## Infra Contract

### 1. Happy path — comando + output esperado LITERAL

\`\`\`bash
$ curl -sv https://app.oimpresso.com/home 2>&1 | grep '^< HTTP\|^< Location'
< HTTP/1.1 302 Found
< Location: /ia/dashboard
\`\`\`

(Não-autenticado é redirecionado pra `/login` pelo middleware `auth` antes da closure rodar — testar autenticado com cookie de sessão Wagner biz=1.)

### 2. Regression adjacent — rotas que NÃO devem mudar

\`\`\`bash
$ curl -sv https://app.oimpresso.com/ia 2>&1 | grep '^< HTTP'
< HTTP/1.1 200 OK         # ChatController@index continua respondendo

$ curl -sv https://app.oimpresso.com/ia/dashboard 2>&1 | grep '^< HTTP'
< HTTP/1.1 200 OK         # DashboardController@index sem redirect pra chat (user sem metas vê empty state)

$ curl -sv https://app.oimpresso.com/governance/dashboard 2>&1 | grep '^< HTTP'
< HTTP/1.1 200 OK         # rotas /governance/* preservadas — só sidebar entry removida

$ curl -sv https://app.oimpresso.com/login 2>&1 | grep '^< HTTP'
< HTTP/1.1 200 OK         # tela de login intacta (middleware `guest` ainda envia logged-in pra /home)
\`\`\`

### 3. Environment delta — onde Pest local NÃO prova prod

- [x] Pest local NÃO foi rodado (mudança é routing trivial + DataController declarativo) — smoke prod obrigatório
- [x] `Request::create()` em Pest reproduz o redirect chain `/home → /ia/dashboard`? **Não testado** — manual via browser MCP cobre
- [x] OPcache em prod pode cachear o `DataController` antigo (sidebar entry Governança) — exigir `php artisan optimize:clear` + `opcache_reset` pós-deploy
- [x] LSCache (LiteSpeed) pode servir HTML stale do sidebar pra usuários já logados — `php artisan view:clear` pós-deploy

Declarado: **"Pest local + smoke Herd NÃO provam prod. Validação em prod via curl -sv + login real obrigatória pós-deploy."**

### 4. Smoke prod pós-deploy (preencher após merge + git pull Hostinger)

\`\`\`bash
# Output real colado aqui pós-deploy:
$ curl -sv https://app.oimpresso.com/home 2>&1 | grep '^< HTTP\|^< Location'
# (preencher após merge)
\`\`\`

| Caso | Esperado | Observado | OK |
|---|---|---|---|
| `/home` redirect | `302 → /ia/dashboard` | (preencher) | ⏳ |
| `/ia/dashboard` (sem metas) | `200` (empty state, sem bounce) | (preencher) | ⏳ |
| `/governance/dashboard` direto | `200` | (preencher) | ⏳ |
| Sidebar SEM entry "Governança" (HTML) | `grep -c 'Governança' < 5` | (preencher) | ⏳ |

## Test plan

- [ ] Login com user biz=1 (Wagner) — confirma redirect pra `/ia/dashboard`
- [ ] Login com user biz=4 (Larissa) — idem
- [ ] PageHeader Jana abre na aba `Dashboard` (não em `Copiloto`)
- [ ] Sidebar não mostra mais entry `Governança` (SISTEMA grupo)
- [ ] `/governance/dashboard` ainda abre direto via URL (acesso preservado)
- [ ] User sem metas vê empty state na Dashboard (não bounce pra chat)
- [ ] Chat continua acessível via aba `Copiloto` + FAB
- [ ] Ghost `Governança` aparece na PageHeaderTabs da Jana

## Refs

- ADR 0180 (sidebar v3 — primary universal roxo 295)
- ADR 0094 (Constituição v2 — Charter > Spec)
- ADR 0107 (visual-comparison gate F3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)