### PR TITLE
fix(jana): hotfix Dashboard.tsx crash com Inertia::defer undefined

### DIFF
--- a/Modules/Jana/Http/Controllers/DashboardController.php
+++ b/Modules/Jana/Http/Controllers/DashboardController.php
@@ -23,13 +23,15 @@ class DashboardController extends Controller
         // antigo "sem metas → chat" criava loop UX: login → /ia/dashboard →
         // bounce pra /ia (chat). Removido — frontend renderiza empty card.
 
-        // D6.a (Wave 14 governance v3) — Inertia::defer no payload `metas`.
-        // Eager loads (periodoAtual + ultimaApuracao + apuracoes×12) podem
-        // ficar custosos com N metas. Closure só executa em segundo round
-        // partial-reload, mantendo TTFB inicial baixo e exibindo skeleton.
-        // Multi-tenant scope preservado dentro do closure (business_id capturado).
+        // Wagner 2026-05-25 HOTFIX pós-PR #1547: removido `Inertia::defer` no
+        // payload `metas`. Causa: Dashboard.tsx (linha 279/296/318) lê
+        // `metas.length` direto sem wrap `<Deferred>` nem fallback — defer
+        // entrega `undefined` no primeiro render e quebra com TypeError em
+        // prod. Bug pré-existia mascarado pelo redirect "sem metas → chat".
+        // Reintroduzir defer quando frontend ganhar `<Deferred data="metas"
+        // fallback={<Skeleton />}>` wrap (refactor MWART futuro).
         return Inertia::render('Jana/Dashboard', [
-            'metas' => Inertia::defer(fn () => $this->buildMetasPayload($businessId)),
+            'metas' => $this->buildMetasPayload($businessId),
         ]);
     }
 


### PR DESCRIPTION
## Hotfix urgente — pós PR #1547

Smoke prod via browser MCP (Wagner navegando logo após merge do PR #1547) capturou:

\`\`\`
TypeError: Cannot read properties of undefined (reading 'length')
  at E (https://oimpresso.com/build-inertia/assets/Dashboard-DBi2AdB8.js:1:8078)
\`\`\`

**Tela em branco** em \`/ia/dashboard\` (nova primeira aba canon da Jana + destino pós-login).

### Causa

`DashboardController@index` usa `Inertia::defer(fn() => buildMetasPayload)`, mas `Dashboard.tsx` lê `metas.length` direto:

- linha 279: `{metas.length} metas ativas`
- linha 296: `{metas.length === 0 ? <EmptyState /> : ...}`
- linha 318: `{metas.map(...)}`

Sem wrap `<Deferred data="metas" fallback={<Skeleton />}>` e sem default `metas = []` na destruct. Defer entrega `undefined` no primeiro render → TypeError crash.

**Bug pré-existia mascarado** pelo redirect "sem metas → chat" (removido no PR #1547) — todo user sem metas era bounced antes do render. Agora todo user cai aqui (entry-point pós-login) → 100% das renders crasham.

### Solução

Remove `Inertia::defer` — passa `metas` direto. Perde otimização TTFB, mas:

- ✅ Sem rebuild Vite necessário (só PHP — propaga via `git pull` + `optimize:clear` em Hostinger)
- ✅ Resolve 100% dos casos imediatamente
- ✅ Reintroduzir defer quando frontend ganhar `<Deferred>` wrap (MWART futuro)

## Infra Contract

### 1. Happy path

\`\`\`bash
$ curl -sv https://oimpresso.com/ia/dashboard -b "session=<cookie>" 2>&1 | grep '^< HTTP'
< HTTP/1.1 200 OK
\`\`\`

Browser console esperado: **zero** \`TypeError: Cannot read properties of undefined\`.

### 2. Regression adjacent

\`\`\`bash
$ curl -sv https://oimpresso.com/ia 2>&1 | grep '^< HTTP'
< HTTP/1.1 200 OK        # ChatController intacto

$ curl -sv https://oimpresso.com/home 2>&1 | grep '^< HTTP\|^< Location'
< HTTP/1.1 302 Found
< Location: /ia/dashboard # redirect canon intacto
\`\`\`

### 3. Environment delta

- [x] Mudança só em PHP — sem rebuild Vite, sem npm install
- [x] OPcache em prod precisa reset pós-deploy (\`opcache_reset\` ou \`php artisan optimize:clear\`)
- [x] LSCache não cacheia /ia/dashboard (auth-only, sem cache directive)

### 4. Smoke prod pós-deploy

\`\`\`bash
# Console JS DEVE ficar limpo:
# (preencher após deploy + browser MCP)
\`\`\`

| Caso | Esperado | Observado | OK |
|---|---|---|---|
| `/ia/dashboard` renderiza (sem metas) | empty state visível | (preencher) | ⏳ |
| Console JS limpo | sem `TypeError` | (preencher) | ⏳ |
| `metas.length === 0` ramo | empty card "Nada por aqui ainda" | (preencher) | ⏳ |

Refs: PR #1547 (mergeado 22:38 UTC) · ADR 0094 (Princípio 8 — Confiabilidade com fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)