### PR TITLE
fix(jana,sidebar): Custos tela branca + sidebar IA aponta Dashboard

### DIFF
--- a/Modules/Jana/Http/Controllers/Admin/CustosController.php
+++ b/Modules/Jana/Http/Controllers/Admin/CustosController.php
@@ -43,9 +43,20 @@ class CustosController extends Controller
             $request->get('ate'),
         );
 
-        // D6.a Wave 17: painel é DB-bound + foreach pesado → deferred.
-        // Build helper closure pra evitar chamar service 4× (1 por prop).
-        $painelDeferred = Inertia::defer(fn () => $service->painel($businessId, $range['inicio'], $range['fim']));
+        // Wagner 2026-05-25 HOTFIX: removido `Inertia::defer` em kpis/
+        // por_usuario/serie_diaria. Causa: Custos/Index.tsx (linha 186)
+        // destruct `{kpis, por_usuario, serie_diaria}` direto e linha 192
+        // chama `serie_diaria.reduce(...)` sem wrap `<Deferred>` nem
+        // fallback. Defer entrega undefined no primeiro render → TypeError
+        // crasha (tela branca em prod). Mesmo bug do Dashboard.tsx (fix
+        // anterior PR #1550). Reintroduzir defer quando frontend ganhar
+        // `<Deferred data="kpis,por_usuario,serie_diaria" fallback={...}>`
+        // wrap (refactor MWART futuro).
+        //
+        // Painel é DB-bound + foreach pesado, mas 1 chamada eager é melhor
+        // que tela branca. Chamada única (não 4×) — destructure em vars
+        // locais antes do render.
+        $painel = $service->painel($businessId, $range['inicio'], $range['fim']);
 
         return Inertia::render('Jana/Admin/Custos/Index', [
             'periodo'      => $range,  // eager — range resolvido sem DB
@@ -58,10 +69,9 @@ class CustosController extends Controller
                 'modelo_default' => config('copiloto.ai.pricing_default_model'),
                 'cambio_brl_usd' => (float) config('copiloto.ai.cambio_brl_usd'),
             ],
-            // D6.a Wave 17 — payloads pesados defer'd. Front wrap em <Deferred data="kpis,por_usuario,serie_diaria" fallback={skeleton}>.
-            'kpis'         => Inertia::defer(fn () => $service->painel($businessId, $range['inicio'], $range['fim'])['kpis']),
-            'por_usuario'  => Inertia::defer(fn () => $service->painel($businessId, $range['inicio'], $range['fim'])['por_usuario']),
-            'serie_diaria' => Inertia::defer(fn () => $service->painel($businessId, $range['inicio'], $range['fim'])['serie_diaria']),
+            'kpis'         => $painel['kpis'],
+            'por_usuario'  => $painel['por_usuario'],
+            'serie_diaria' => $painel['serie_diaria'],
         ]);
     }
 }

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -516,7 +516,10 @@ function SidebarShortcuts({
   return (
     <div className="sb-shortcuts">
       {showIa && (
-        <a href="/ia" className="sb-shortcut">
+        // Wagner 2026-05-25: sidebar IA aponta /ia/dashboard (Dashboard =
+        // primeira aba canon da Jana + destino pós-login). Chat acessível
+        // via aba "Copiloto" do PageHeader + FAB.
+        <a href="/ia/dashboard" className="sb-shortcut">
           <Bot size={13} />
           <span className="label">IA</span>
           {!!chatCount && <span className="badge">{chatCount}</span>}
@@ -743,8 +746,9 @@ function SidebarMenuRail({
   return (
     <div className="sb-menu-rail">
       {showIa && (
+        // Wagner 2026-05-25: rail collapsed IA aponta /ia/dashboard (espelha sb-shortcut acima).
         <a
-          href="/ia"
+          href="/ia/dashboard"
           className="sb-rail-btn"
           data-tip="IA"
           onClick={() => setFlyout(null)}


### PR DESCRIPTION
## Bugs achados via smoke prod browser MCP

Pós-merge PR #1547/#1550, Wagner navegou os ghosts do PageHeader Jana e detectou 2 problemas:

### 🔴 /ia/admin/custos = tela branca

Console:
\`\`\`
TypeError: Cannot read properties of undefined (reading 'reduce')
  at Index-D4w2VelI.js:1:7728
\`\`\`

**Mesmo bug do Dashboard.tsx** (fix PR #1550): `CustosController@index` usa 4× `Inertia::defer`, `Custos/Index.tsx:186` destruct direto e linha 192 chama `serie_diaria.reduce(...)` sem `<Deferred>` wrap. Defer entrega undefined → crash.

Hotfix: chamar service uma vez, passar payloads direto. Sem rebuild Vite.

### 🟡 Sidebar entry "IA" abria Chat, não Dashboard

Wagner: "no menu da Jana abra o dashboard". Sidebar tinha `href=\"/ia\"` hardcoded em 2 lugares (`Sidebar.tsx:519` + `:747`). Trocado pra `/ia/dashboard`.

⚠️ **EXIGE rebuild Vite em prod** (mudança em .tsx). Confirmar `npm run build` no deploy Hostinger.

## Mudanças

| Arquivo | O quê |
|---|---|
| `Modules/Jana/Http/Controllers/Admin/CustosController.php` | Remove 4× `Inertia::defer`, chama service uma vez. |
| `resources/js/Components/cockpit/Sidebar.tsx` | href IA: `/ia` → `/ia/dashboard` (linhas 519 + 747). |

## Infra Contract

### 1. Happy path

\`\`\`bash
$ curl -sv https://oimpresso.com/ia/admin/custos -b session=... 2>&1 | grep '^< HTTP'
< HTTP/1.1 200 OK
\`\`\`

Console esperado: **zero** `TypeError`.

### 2. Regression adjacent

\`\`\`bash
$ curl -sv https://oimpresso.com/ia/dashboard 2>&1 | grep '^< HTTP'
< HTTP/1.1 200 OK   # ainda renderiza (fix PR #1550)
$ curl -sv https://oimpresso.com/ia 2>&1 | grep '^< HTTP'
< HTTP/1.1 200 OK   # chat intacto
\`\`\`

### 3. Environment delta

- [x] CustosController: só PHP — sem rebuild Vite, sem npm install
- [x] **Sidebar.tsx: EXIGE `npm run build` em prod** (mudança em .tsx compilado)
- [x] OPcache reset pós-deploy (`php artisan optimize:clear`)
- [x] LSCache não cacheia /ia/admin/* (auth-only)

### 4. Smoke prod pós-deploy

| Caso | Esperado | Observado | OK |
|---|---|---|---|
| `/ia/admin/custos` renderiza | painel KPIs visível | (preencher) | ⏳ |
| Console JS limpo | sem `TypeError reduce` | (preencher) | ⏳ |
| Click "IA" sidebar | redireciona pra `/ia/dashboard` | (preencher) | ⏳ |

Refs: PR #1547 · PR #1550 · ADR 0094 (Princípio 8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)