### PR TITLE
feat(jana): promove Cockpit/Roadmap a ghosts + rename Governança Jana → MCP

### DIFF
--- a/Modules/Jana/Http/Controllers/DataController.php
+++ b/Modules/Jana/Http/Controllers/DataController.php
@@ -265,9 +265,19 @@ class DataController extends Controller
                             // Wagner 2026-05-23 fix: href '/ads' não existe (rota raiz ausente em
                             // Modules/ADS/Routes/web.php). Entry-point real do módulo é a tela Decisões.
                             ['key' => 'ads',       'label' => 'ADS',       'href' => '/ads/admin/decisoes'],
+                            // Wagner 2026-05-25: promovidas pra ghosts após audit Jana
+                            // (browser MCP smoke detectou 3 Pages órfãs sem link).
+                            //  - cockpit: Jana V2 Analista IA (Brief + KPIs + análises) — Pages/Jana/Cockpit.tsx
+                            //  - roadmap: Timeline Gantt das tasks MCP — Pages/Jana/Admin/Roadmap.tsx
+                            // Painel.tsx fica acessível só por URL (mock Onda A1, sobreposto ao Cockpit).
+                            ['key' => 'cockpit',  'label' => 'Cockpit',  'href' => '/ia/cockpit'],
+                            ['key' => 'roadmap',  'label' => 'Roadmap',  'href' => '/ia/admin/roadmap'],
                             // Wagner 2026-05-22 P2: zera 2 órfãs (telas Jana Admin Governança + Qualidade).
-                            ['key' => 'governanca-jana', 'label' => 'Governança Jana', 'href' => '/ia/admin/governanca'],
-                            ['key' => 'qualidade-jana',  'label' => 'Qualidade IA',    'href' => '/ia/admin/qualidade'],
+                            // Wagner 2026-05-25: rename 'Governança Jana' → 'Governança MCP' (alinha
+                            // com topnav.php que já chama de MCP — clarifica vs ghost 'governanca'
+                            // canon que aponta /governance/dashboard outro módulo).
+                            ['key' => 'governanca-mcp', 'label' => 'Governança MCP', 'href' => '/ia/admin/governanca'],
+                            ['key' => 'qualidade-jana', 'label' => 'Qualidade IA',   'href' => '/ia/admin/qualidade'],
                         ],
                     ]
                 )->order(90); // Logo após PontoWr2 (88)


### PR DESCRIPTION
## Resultado da auditoria Jana

Pós smoke browser MCP da Jana (PRs #1547/#1550/#1552/#1558 fix as 6 telas brancas), detectei 3 Pages funcionais sem ghost no PageHeader.

### Mudanças

Adiciona 2 ghosts canon ao PageHeader Jana:

| Ghost | URL | O que é |
|---|---|---|
| **Cockpit** | `/ia/cockpit` | Jana V2 Analista IA — Brief diário + 4 KPIs + 6 análises principais |
| **Roadmap** | `/ia/admin/roadmap` | Timeline Gantt das tasks MCP por cycle/owner/módulo |

*`Painel.tsx` fica acessível só por URL — mock Onda A1 sobreposto ao Cockpit; será consolidado em refactor futuro.*

Rename: `Governança Jana` → `Governança MCP` (alinha com `topnav.php` que já chama de MCP; clarifica vs ghost canon 'Governança' que aponta `/governance/dashboard` outro módulo).

### Ordem final dos ghosts Jana (13)

`Dashboard | Copiloto | Brief | Memórias | KB | Regras | Governança | Custos | ADS | Cockpit | Roadmap | Governança MCP | Qualidade IA`

Sem rebuild Vite necessário (só PHP).

Refs: PR #1547 · #1550 · #1552 · #1558 (audit batch Jana)
