### PR TITLE
fix(jana): JanaAreaHeader em Memoria + esconder /ia/alertas STUB do menu

### DIFF
--- a/Modules/Jana/Http/Controllers/DataController.php
+++ b/Modules/Jana/Http/Controllers/DataController.php
@@ -183,15 +183,10 @@ class DataController extends Controller
                             );
                         }
 
-                        // Alertas
-                        $sub->url(
-                            route('jana.alertas.index'),
-                            __('copiloto::copiloto.menu.alertas'),
-                            [
-                                'icon'   => 'fa fas fa-bell',
-                                'active' => request()->segment(2) == 'alertas',
-                            ]
-                        );
+                        // Alertas — REMOVIDO do dropdown legacy (Wagner 2026-05-25).
+                        // Tela /ia/alertas é STUB ("spec-ready ver US-COPI-060") sem
+                        // implementação real. Reativar quando US-COPI-060 entregar.
+                        // Rota e Controller mantidos pra não quebrar bookmarks externos.
 
                         // Custos de IA (admin do business — US-COPI-070)
                         if (auth()->user()->can('superadmin') || auth()->user()->can('jana.admin.custos.view')) {

--- a/Modules/Jana/Resources/menus/topnav.php
+++ b/Modules/Jana/Resources/menus/topnav.php
@@ -21,7 +21,9 @@ return [
         ['label' => 'copiloto::copiloto.menu.conversar',  'href' => '/ia',                  'icon' => 'MessageSquare',   'can' => 'jana.chat'],
         ['label' => 'copiloto::copiloto.menu.dashboard',  'href' => '/ia/dashboard',        'icon' => 'LayoutDashboard', 'can' => 'jana.access'],
         ['label' => 'copiloto::copiloto.menu.metas',      'href' => '/ia/metas',            'icon' => 'Target',          'can' => 'jana.metas.manage'],
-        ['label' => 'copiloto::copiloto.menu.alertas',    'href' => '/ia/alertas',          'icon' => 'Bell',            'can' => 'jana.access'],
+        // Wagner 2026-05-25: /ia/alertas REMOVIDO do topnav legacy — tela é STUB
+        // ("spec-ready ver US-COPI-060"). Reativar quando US-COPI-060 entregar.
+        // ['label' => 'copiloto::copiloto.menu.alertas',    'href' => '/ia/alertas',          'icon' => 'Bell',            'can' => 'jana.access'],
         ['label' => 'Governança MCP',                     'href' => '/ia/admin/governanca', 'icon' => 'ShieldCheck',     'can' => 'jana.mcp.usage.all'],
         // KB foi splitado pro módulo Modules/KB em 2026-05-03 (Etapa 2 modularização).
         // Link cross-module aqui pra continuidade visual.

--- a/resources/js/Pages/Jana/Memoria.tsx
+++ b/resources/js/Pages/Jana/Memoria.tsx
@@ -15,6 +15,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card'
 import { Badge } from '@/Components/ui/badge'
 import { Brain, Trash2, Pencil, Save, X } from 'lucide-react'
 import FabJana from './components/FabJana'
+import { JanaAreaHeader } from '@/Pages/Jana/components/JanaAreaHeader'
 
 interface MemoriaFato {
   id: number
@@ -143,6 +144,11 @@ function Memoria({ memorias }: Props) {
 
   return (
     <>
+      {/* Wagner 2026-05-25: JanaAreaHeader adicionado pós-audit browser MCP —
+          /ia/memoria estava sem header da área Jana (vs Brief/Dashboard/etc).
+          Consistência UX entre todos os ghosts. */}
+      <JanaAreaHeader active="memoria" />
+
       <div className="max-w-4xl mx-auto p-6 space-y-6">
         <div className="flex items-center gap-3">
           <Brain className="size-7 text-primary" />


### PR DESCRIPTION
## Cleanup final pós-audit Jana

Continuação da onda de audit Jana (PRs #1547 #1550 #1552 #1558 #1560).

### 1. JanaAreaHeader em /ia/memoria

`Pages/Jana/Memoria.tsx` estava sem o componente `<JanaAreaHeader />` no topo — quebrava consistência UX entre os ghosts (Dashboard/Brief/Regras todos têm; Memoria não tinha). Adicionado com `active="memoria"`.

### 2. /ia/alertas escondido do menu

Tela é STUB ("spec-ready ver US-COPI-060") sem implementação. Removida do dropdown DataController + topnav.php pra não enganar usuário. Rota + Controller preservados (bookmarks externos não quebram).

## Mudanças

| Arquivo | O quê |
|---|---|
| `resources/js/Pages/Jana/Memoria.tsx` | +import `JanaAreaHeader` +render `<JanaAreaHeader active="memoria" />` |
| `Modules/Jana/Http/Controllers/DataController.php` | Comenta entry 'Alertas' do dropdown legacy |
| `Modules/Jana/Resources/menus/topnav.php` | Comenta entry alertas |

## Infra Contract

### 1. Happy path

```bash
$ curl -sv https://oimpresso.com/ia/memoria -b session=... | grep '^< HTTP'
< HTTP/1.1 200 OK
```

Visual: header JANA · Dashboard · Copiloto · Brief · Memórias (ativa) · KB · ... aparece no topo.

### 2. Regression adjacent

```bash
$ curl -sv https://oimpresso.com/ia/alertas -b session=... | grep '^< HTTP'
< HTTP/1.1 200 OK   # rota preservada — só sumiu do menu
$ curl -sv https://oimpresso.com/ia/dashboard | grep '^< HTTP'
< HTTP/1.1 200 OK   # PageHeader Jana intacto
```

### 3. Environment delta

- [x] **Exige `npm run build` pra propagar Memoria.tsx** (mudança em .tsx)
- [x] PHP: DataController + topnav.php propagam via `php artisan optimize:clear`

Refs: PR #1547 · #1550 · #1552 · #1558 · #1560 (audit batch Jana)
