### PR TITLE
fix(memory-schema): backfill frontmatter ADRs+handoffs (194→114, -41%)

### DIFF
--- a/memory/decisions/0013-ecossistema-modulos-inventario.md
+++ b/memory/decisions/0013-ecossistema-modulos-inventario.md
@@ -6,7 +6,7 @@ type: adr
 status: aceito
 authority: reference
 lifecycle: arquivado
-decided_at: 2026-04-21
+decided_at: "2026-04-21"
 decided_by: [E]
 module: core
 quarter: 2026-Q2

--- a/memory/decisions/0014-essentials-pontowr2-integracao.md
+++ b/memory/decisions/0014-essentials-pontowr2-integracao.md
@@ -6,7 +6,7 @@ type: adr
 status: aceito
 authority: reference
 lifecycle: arquivado
-decided_at: 2026-04-21
+decided_at: "2026-04-21"
 decided_by: [E]
 module: pontowr2
 quarter: 2026-Q2

--- a/memory/decisions/0015-connector-api-gateway.md
+++ b/memory/decisions/0015-connector-api-gateway.md
@@ -6,7 +6,7 @@ type: adr
 status: aceito
 authority: reference
 lifecycle: arquivado
-decided_at: 2026-04-21
+decided_at: "2026-04-21"
 decided_by: [E]
 module: connector
 quarter: 2026-Q2

--- a/memory/decisions/0016-plano-otimizacao-e-roadmap.md
+++ b/memory/decisions/0016-plano-otimizacao-e-roadmap.md
@@ -6,7 +6,7 @@ type: adr
 status: aceito
 authority: reference
 lifecycle: arquivado
-decided_at: 2026-04-21
+decided_at: "2026-04-21"
 decided_by: [E]
 module: pontowr2
 quarter: 2026-Q2

--- a/memory/decisions/0062-separacao-runtime-hostinger-ct100.md
+++ b/memory/decisions/0062-separacao-runtime-hostinger-ct100.md
@@ -7,7 +7,7 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-04-30
+decided_at: "2026-04-30"
 module: infra
 quarter: 2026-Q2
 tags: [ambiente, hostinger, proxmox, octane, mcp, regras, governanca]

--- a/memory/decisions/0063-prevenir-composer-lock-drift.md
+++ b/memory/decisions/0063-prevenir-composer-lock-drift.md
@@ -7,7 +7,7 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-04-30
+decided_at: "2026-04-30"
 module: infra
 quarter: 2026-Q2
 tags: [composer, ci, drift, deploy, lock]

--- a/memory/decisions/0064-modularizacao-split-teammcp-kb-superadmin360.md
+++ b/memory/decisions/0064-modularizacao-split-teammcp-kb-superadmin360.md
@@ -1,20 +1,20 @@
 ---
 slug: 0064-modularizacao-split-teammcp-kb-superadmin360
-number: 0064
+number: 64
 title: "Modularização — split TeamMcp + KB + Superadmin 360°"
 type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-04
+decided_at: "2026-05-04"
 module: null
 quarter: 2026-Q2
 tags: [modularização, copiloto, teammcp, kb, superadmin, governance, iam]
 supersedes: []
-supersedes_partially: [0055, 0057, 0059, 0061]
+supersedes_partially: ["0055-self-host-team-plan-equivalente-anthropic", "0057-tela-team-admin-regras-governanca-tokens-mcp", "0059-governanca-memoria-estilo-anthropic-team", "0061-conhecimento-canonico-git-mcp-zero-automem"]
 superseded_by: []
-related: [0027, 0053, 0040, 0065]
+related: ["0027-gestao-memoria-roles-claros", "0053-mcp-server-governanca-como-produto", "0040-policy-publicacao-claude-supervisiona", "0065-permission-registry-contract"]
 pii: false
 review_triggers:
   - "Quando 3+ engines de governança disputarem a mesma tabela de regras → reconsiderar módulo Governance separado"

--- a/memory/decisions/0065-permission-registry-contract.md
+++ b/memory/decisions/0065-permission-registry-contract.md
@@ -1,20 +1,20 @@
 ---
 slug: 0065-permission-registry-contract
-number: 0065
+number: 65
 title: "Permission Registry — contrato declarativo de permissions per-módulo"
 type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-04
+decided_at: "2026-05-04"
 module: null
 quarter: 2026-Q2
 tags: [permission, iam, governance, modularização, superadmin, registry, auto-discovery]
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0064, 0027, 0053]
+related: ["0064-modularizacao-split-teammcp-kb-superadmin360", "0027-gestao-memoria-roles-claros", "0053-mcp-server-governanca-como-produto"]
 pii: false
 review_triggers:
   - "Quando um módulo precisar permissions com lifecycle (expira, supersede) → adicionar campos status/expires_at no contrato"

--- a/memory/decisions/0066-format-date-shift-3h-preservado-legacy-clientes.md
+++ b/memory/decisions/0066-format-date-shift-3h-preservado-legacy-clientes.md
@@ -1,20 +1,20 @@
 ---
 slug: 0066-format-date-shift-3h-preservado-legacy-clientes
-number: 0066
+number: 66
 title: "format_date com shift +3h preservado intencionalmente — quirk legacy ROTA LIVRE"
 type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-04-24
+decided_at: "2026-04-24"
 module: null
 quarter: 2026-Q2
 tags: [timezone, carbon, legacy, ux, rota-livre, format_date, dados-históricos]
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0027, 0061]
+related: ["0027-gestao-memoria-roles-claros", "0061-conhecimento-canonico-git-mcp-zero-automem"]
 pii: false
 review_triggers:
   - "Quando alguém propor 'corrigir' format_date sem migration de dados históricos → bloquear até cumprir checklist"

--- a/memory/decisions/0067-sprint8-mcp-memory-document-searchable-retrieval.md
+++ b/memory/decisions/0067-sprint8-mcp-memory-document-searchable-retrieval.md
@@ -7,12 +7,12 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 quarter: Q2-2026
-decided_at: 2026-05-04
+decided_at: "2026-05-04"
 decided_by: [W]
 module: copiloto
 supersedes: []
 superseded_by: []
-related: [0037, 0036, 0053, 0063]
+related: ["0037-roadmap-evolucao-tier-7-plus", "0036-replanejamento-meilisearch-first", "0053-mcp-server-governanca-como-produto", "0063-prevenir-composer-lock-drift"]
 tags: [retrieval, meilisearch, ragas, eval, copiloto, kb]
 ---
 

--- a/memory/decisions/0068-sprint9-retrieval-ollama-reranker-strategy.md
+++ b/memory/decisions/0068-sprint9-retrieval-ollama-reranker-strategy.md
@@ -7,12 +7,12 @@ status: rascunho
 authority: canonical
 lifecycle: ativo
 quarter: Q2-2026
-decided_at: 2026-05-04
+decided_at: "2026-05-04"
 decided_by: [W]
 module: copiloto
 supersedes: []
 superseded_by: []
-related: [0067, 0037, 0053, 0036]
+related: ["0067-sprint8-mcp-memory-document-searchable-retrieval", "0037-roadmap-evolucao-tier-7-plus", "0053-mcp-server-governanca-como-produto", "0036-replanejamento-meilisearch-first"]
 tags: [retrieval, meilisearch, ollama, reranker, ragas, eval, copiloto]
 ---
 

--- a/memory/decisions/0069-taskregistry-mcp-tools-canonico-tasks-md-deprecated.md
+++ b/memory/decisions/0069-taskregistry-mcp-tools-canonico-tasks-md-deprecated.md
@@ -7,12 +7,12 @@ status: superseded
 authority: canonical
 lifecycle: substituido
 quarter: Q2-2026
-decided_at: 2026-05-04
+decided_at: "2026-05-04"
 decided_by: [W]
 module: governance
 supersedes: []
-superseded_by: [0070]
-related: [0027, 0053, 0064, 0070]
+superseded_by: ["0070-jira-style-task-management-current-md-removed"]
+related: ["0027-gestao-memoria-roles-claros", "0053-mcp-server-governanca-como-produto", "0064-modularizacao-split-teammcp-kb-superadmin360", "0070-jira-style-task-management-current-md-removed"]
 tags: [governance, tasks, mcp, taskregistry, policy]
 ---
 

--- a/memory/decisions/0070-jira-style-task-management-current-md-removed.md
+++ b/memory/decisions/0070-jira-style-task-management-current-md-removed.md
@@ -7,12 +7,12 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 quarter: Q2-2026
-decided_at: 2026-05-04
+decided_at: "2026-05-04"
 decided_by: [W]
 module: governance
-supersedes: [0069]
+supersedes: ["0069-taskregistry-mcp-tools-canonico-tasks-md-deprecated"]
 superseded_by: []
-related: [0027, 0053, 0055, 0064, 0069]
+related: ["0027-gestao-memoria-roles-claros", "0053-mcp-server-governanca-como-produto", "0055-self-host-team-plan-equivalente-anthropic", "0064-modularizacao-split-teammcp-kb-superadmin360", "0069-taskregistry-mcp-tools-canonico-tasks-md-deprecated"]
 tags: [governance, tasks, mcp, taskregistry, jira, linear, kanban, policy]
 ---
 

--- a/memory/decisions/0071-mcp-tools-audit-2026-05-05-bugs-e-workarounds.md
+++ b/memory/decisions/0071-mcp-tools-audit-2026-05-05-bugs-e-workarounds.md
@@ -1,18 +1,18 @@
 ---
 slug: 0071-mcp-tools-audit-2026-05-05-bugs-e-workarounds
-number: 0071
+number: 71
 title: "Auditoria tools MCP 2026-05-05 — bugs descobertos + workarounds"
 type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-05
+decided_at: "2026-05-05"
 module: core
 quarter: 2026-Q2
 tags: [mcp, taskregistry, audit, bugs, schema]
 supersedes: []
-related: [0053, 0069, 0070]
+related: ["0053-mcp-server-governanca-como-produto", "0069-taskregistry-mcp-tools-canonico-tasks-md-deprecated", "0070-jira-style-task-management-current-md-removed"]
 pii: false
 review_triggers: ["bugs corrigidos por PR futura", "schema mcp_jira_projects unificado"]
 ---

--- a/memory/decisions/0072-maturacao-memoria-team-mcp-openclaw-soa-2026.md
+++ b/memory/decisions/0072-maturacao-memoria-team-mcp-openclaw-soa-2026.md
@@ -1,13 +1,13 @@
 ---
 slug: 0072-maturacao-memoria-team-mcp-openclaw-soa-2026
-number: 0072
+number: 72
 title: "Maturação memória + Team MCP — gaps identificados vs OpenClaw/Mem0/Letta/Zep/A-Mem (mai/2026)"
 type: adr
 status: proposto
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-05
+decided_at: "2026-05-05"
 module: copiloto
 quarter: 2026-Q2
 tags: [memoria, mcp, team-mcp, retrieval, governanca, roadmap]

--- a/memory/decisions/0073-team-mcp-skills-policies-entidades-governadas.md
+++ b/memory/decisions/0073-team-mcp-skills-policies-entidades-governadas.md
@@ -1,13 +1,13 @@
 ---
 slug: 0073-team-mcp-skills-policies-entidades-governadas
-number: 0073
+number: 73
 title: "Team MCP P0 — skills e policies como entidades governadas (mcp_skills + mcp_policies)"
 type: adr
 status: superseded
 authority: reference
 lifecycle: substituido
 decided_by: [W]
-decided_at: 2026-05-05
+decided_at: "2026-05-05"
 module: copiloto
 quarter: 2026-Q2
 tags: [mcp, team-mcp, skills, policies, governanca, sync, p0, superseded]

--- a/memory/decisions/0074-temporal-validity-bi-temporal-time-travel.md
+++ b/memory/decisions/0074-temporal-validity-bi-temporal-time-travel.md
@@ -1,13 +1,13 @@
 ---
 slug: 0074-temporal-validity-bi-temporal-time-travel
-number: 0074
+number: 74
 title: "P1 — Temporal validity bi-temporal: event-time vs system-time + time-travel queries"
 type: adr
 status: proposto
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-05
+decided_at: "2026-05-05"
 module: copiloto
 quarter: 2026-Q2
 tags: [memoria, temporal, bi-temporal, retrieval, p1]

--- a/memory/decisions/0075-team-mcp-skills-ui-prompt-management-style.md
+++ b/memory/decisions/0075-team-mcp-skills-ui-prompt-management-style.md
@@ -1,13 +1,13 @@
 ---
 slug: 0075-team-mcp-skills-ui-prompt-management-style
-number: 0075
+number: 75
 title: "Team MCP P0 v2 — UI gestão de skills estilo prompt-management (5 tabelas, 5 telas, approval obrigatório)"
 type: adr
 status: superseded
 authority: reference
 lifecycle: substituido
 decided_by: [W]
-decided_at: 2026-05-05
+decided_at: "2026-05-05"
 module: copiloto
 quarter: 2026-Q2
 tags: [mcp, team-mcp, skills, prompt-management, governance, approval, p0, superseded]

--- a/memory/decisions/0076-skills-db-primary-git-destino-drift-alert.md
+++ b/memory/decisions/0076-skills-db-primary-git-destino-drift-alert.md
@@ -1,13 +1,13 @@
 ---
 slug: 0076-skills-db-primary-git-destino-drift-alert
-number: 0076
+number: 76
 title: "Skills V2 — DB é primary, git é destino auditável; drift por-skill (auto/manual/pinned)"
 type: adr
 status: proposto
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-05
+decided_at: "2026-05-05"
 module: copiloto
 quarter: 2026-Q2
 tags: [mcp, skills, prompt-management, drift, governance, p0]

--- a/memory/decisions/0077-mcp-resolver-owner-via-mcp-handle.md
+++ b/memory/decisions/0077-mcp-resolver-owner-via-mcp-handle.md
@@ -1,13 +1,13 @@
 ---
 slug: 0077-mcp-resolver-owner-via-mcp-handle
-number: 0077
+number: 77
 title: "MCP resolver via users.mcp_handle (SUPERSEDED por ADR 0081 — Identity Mesh)"
 type: adr
 status: superseded
 authority: canonical
 lifecycle: substituido
 decided_by: [W]
-decided_at: 2026-05-05
+decided_at: "2026-05-05"
 module: copiloto
 quarter: 2026-Q2
 tags: [mcp, governance, identity, p1, superseded]

--- a/memory/decisions/0078-constituicao-uma-frase-skill-unidade-evolucao.md
+++ b/memory/decisions/0078-constituicao-uma-frase-skill-unidade-evolucao.md
@@ -1,13 +1,13 @@
 ---
 slug: 0078-constituicao-uma-frase-skill-unidade-evolucao
-number: 0078
+number: 78
 title: "Meta-skill ROI ERP autônomo — skill+missão como unidade operacional (parcialmente superseded por ADR 0079)"
 type: adr
 status: superseded
 authority: canonical
 lifecycle: substituido
 decided_by: [W]
-decided_at: 2026-05-05
+decided_at: "2026-05-05"
 module: ads
 quarter: 2026-Q2
 tags: [governance, skills, meta-skill, p0]

--- a/memory/decisions/0079-constituicao-oimpresso-7-camadas-governanca.md
+++ b/memory/decisions/0079-constituicao-oimpresso-7-camadas-governanca.md
@@ -1,13 +1,13 @@
 ---
 slug: 0079-constituicao-oimpresso-7-camadas-governanca
-number: 0079
+number: 79
 title: "Constituição do Oimpresso ERP — 10 artigos supremos sobre 7 camadas de governança"
 type: adr
 status: superseded
 authority: canonical
 lifecycle: substituido
 decided_by: [W]
-decided_at: 2026-05-05
+decided_at: "2026-05-05"
 superseded_at: 2026-05-06
 superseded_by_adr: '0094'
 module: governance

--- a/memory/decisions/0080-trust-tiers-operacional-audit-findings.md
+++ b/memory/decisions/0080-trust-tiers-operacional-audit-findings.md
@@ -1,13 +1,13 @@
 ---
 slug: 0080-trust-tiers-operacional-audit-findings
-number: 0080
+number: 80
 title: "Trust Tiers operacional + Architecture & Scope + audit findings v1.1.0"
 type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-05
+decided_at: "2026-05-05"
 module: governance
 quarter: 2026-Q2
 tags: [governance, trust-tiers, architecture, audit, p0]

--- a/memory/decisions/0081-identity-mesh-mcp-actors.md
+++ b/memory/decisions/0081-identity-mesh-mcp-actors.md
@@ -1,13 +1,13 @@
 ---
 slug: 0081-identity-mesh-mcp-actors
-number: 0081
+number: 81
 title: "Identity Mesh — schema mcp_actors + manifest pattern + seed inicial 6 actors"
 type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-05
+decided_at: "2026-05-05"
 module: governance
 quarter: 2026-Q2
 tags: [governance, identity, identity-mesh, mcp-actors, p0]

--- a/memory/decisions/0084-triggers-mysql-imutabilidade-mcp-audit-log.md
+++ b/memory/decisions/0084-triggers-mysql-imutabilidade-mcp-audit-log.md
@@ -1,13 +1,13 @@
 ---
 slug: 0084-triggers-mysql-imutabilidade-mcp-audit-log
-number: 0084
+number: 84
 title: "Triggers MySQL append-only em mcp_audit_log + correção audit P0.1"
 type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-05
+decided_at: "2026-05-05"
 module: governance
 quarter: 2026-Q2
 tags: [governance, audit, immutability, mysql-trigger, p0]

--- a/memory/decisions/0085-fase-3-4-scope-md-completo-actor-resolver-pii-redactor.md
+++ b/memory/decisions/0085-fase-3-4-scope-md-completo-actor-resolver-pii-redactor.md
@@ -1,13 +1,13 @@
 ---
 slug: 0085-fase-3-4-scope-md-completo-actor-resolver-pii-redactor
-number: 0085
+number: 85
 title: "Fase 3.4 SCOPE.md completo + ActorResolver + PII Redactor + roadmap pendências"
 type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-05
+decided_at: "2026-05-05"
 module: governance
 quarter: 2026-Q2
 tags: [governance, scope-md, identity-mesh, lgpd, p1]

--- a/memory/decisions/0086-fase-5-mvp-governance-actiongate-warn.md
+++ b/memory/decisions/0086-fase-5-mvp-governance-actiongate-warn.md
@@ -1,13 +1,13 @@
 ---
 slug: 0086-fase-5-mvp-governance-actiongate-warn
-number: 0086
+number: 86
 title: "Fase 5 MVP — Modules/Governance scaffold + ActionGate (warn-only) + Sidebar GOVERNANÇA"
 type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-05
+decided_at: "2026-05-05"
 module: governance
 quarter: 2026-Q2
 tags: [governance, actiongate, fase-5, mvp]

--- a/memory/decisions/0087-drift-resolution-sem-mover-url.md
+++ b/memory/decisions/0087-drift-resolution-sem-mover-url.md
@@ -1,13 +1,13 @@
 ---
 slug: 0087-drift-resolution-sem-mover-url
-number: 0087
+number: 87
 title: "Drift resolution sem mover URL — pattern de migration safe"
 type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-06
+decided_at: "2026-05-06"
 module: null
 quarter: 2026-Q2
 tags: [governance, refactor, drift-resolution, module-charter, migration-pattern]

--- a/memory/decisions/0088-module-rename-php-only.md
+++ b/memory/decisions/0088-module-rename-php-only.md
@@ -1,6 +1,6 @@
 ---
 slug: 0088-module-rename-php-only
-number: 0088
+number: 88
 title: "Module rename PHP-only — fachada legacy mantida durante transição"
 type: adr
 status: aceito
@@ -9,7 +9,7 @@ superseded_by_section:
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-06
+decided_at: "2026-05-06"
 module: null
 quarter: 2026-Q2
 tags: [governance, refactor, rename, module-charter, migration-pattern, php-only]

--- a/memory/decisions/0089-capterra-driven-module-evolution.md
+++ b/memory/decisions/0089-capterra-driven-module-evolution.md
@@ -6,7 +6,7 @@ type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
-decided_at: 2026-05-06
+decided_at: "2026-05-06"
 decided_by: [W]
 module: governance
 quarter: 2026-Q2

--- a/memory/decisions/0090-nfe-replace-gradual-app-services.md
+++ b/memory/decisions/0090-nfe-replace-gradual-app-services.md
@@ -6,7 +6,7 @@ type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
-decided_at: 2026-05-06
+decided_at: "2026-05-06"
 decided_by: [W]
 module: core
 quarter: 2026-Q2

--- a/memory/decisions/0091-daily-brief.md
+++ b/memory/decisions/0091-daily-brief.md
@@ -7,12 +7,12 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 quarter: Q2-2026
-decided_at: 2026-05-06
+decided_at: "2026-05-06"
 decided_by: [W]
 module: governance
 supersedes: []
 superseded_by: []
-related: [0035, 0040, 0048, 0053, 0061, 0070]
+related: ["0035-stack-ai-canonica-wagner-2026-04-26", "0040-policy-publicacao-claude-supervisiona", "0048-framework-agentes-laravel-ai-vizra-rejeitada", "0053-mcp-server-governanca-como-produto", "0061-conhecimento-canonico-git-mcp-zero-automem", "0070-jira-style-task-management-current-md-removed"]
 tags: [governance, mcp, daily-brief, context-engineering, constituicao-v2, l7]
 ---
 

--- a/memory/decisions/0092-tabela-rename-copiloto-para-jana.md
+++ b/memory/decisions/0092-tabela-rename-copiloto-para-jana.md
@@ -6,12 +6,12 @@ type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
-decided_at: 2026-05-06
+decided_at: "2026-05-06"
 decided_by: [W]
 module: copiloto
 quarter: 2026-Q2
 supersedes: ["0088#db"]
-related: ["0084", "0087", "0088"]
+related: ["0084-triggers-mysql-imutabilidade-mcp-audit-log", "0087-drift-resolution-sem-mover-url", "0088-module-rename-php-only"]
 authors: [wagner, claude]
 ---
 

--- a/memory/decisions/0093-multi-tenant-isolation-tier-0.md
+++ b/memory/decisions/0093-multi-tenant-isolation-tier-0.md
@@ -7,21 +7,21 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 quarter: Q2-2026
-decided_at: 2026-05-06
+decided_at: "2026-05-06"
 decided_by: [W]
 module: governance
 tier: CANON
 trust_level: tier-0-irrevogavel
 last_reviewed: 2026-05-06
 review_due: 2027-05-06
-related_adrs: [0006, 0053, 0057, 0059, 0066, 0070, 0072, 0073, 0074, 0076, 0078, 0084, 0089]
+related_adrs: ["0006-multi-tenancy-logica", "0053-mcp-server-governanca-como-produto", "0057-tela-team-admin-regras-governanca-tokens-mcp", "0059-governanca-memoria-estilo-anthropic-team", "0066-format-date-shift-3h-preservado-legacy-clientes", "0070-jira-style-task-management-current-md-removed", "0072-maturacao-memoria-team-mcp-openclaw-soa-2026", "0073-team-mcp-skills-policies-entidades-governadas", "0074-temporal-validity-bi-temporal-time-travel", "0076-skills-db-primary-git-destino-drift-alert", "0078-constituicao-uma-frase-skill-unidade-evolucao", "0084-triggers-mysql-imutabilidade-mcp-audit-log", "0089-capterra-driven-module-evolution"]
 parent_charter: mission.constituicao-v2  # criada em S3
 supersedes: []
 referenced_by: []
 authors: [wagner, sonnet]
 draft_origin: ROTEIRO-MESTRE.md §12 (rascunho 2026-05-06)
-accepted_at: 2026-05-06
-accepted_by: wagner
+accepted_at: "2026-05-06"
+decided_by: [W]
 ---
 
 # ADR 0093 — Multi-tenant isolation by default (Tier 0, IRREVOGÁVEL)

--- a/memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md
+++ b/memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md
@@ -7,18 +7,18 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 quarter: Q2-2026
-decided_at: 2026-05-06
+decided_at: "2026-05-06"
 decided_by: [W]
 module: governance
 tier: CANON
 trust_level: tier-0-irrevogavel
-related_adrs: [0035, 0040, 0053, 0061, 0062, 0070, 0079, 0091, 0093, 0095]
+related_adrs: ["0035-stack-ai-canonica-wagner-2026-04-26", "0040-policy-publicacao-claude-supervisiona", "0053-mcp-server-governanca-como-produto", "0061-conhecimento-canonico-git-mcp-zero-automem", "0062-separacao-runtime-hostinger-ct100", "0070-jira-style-task-management-current-md-removed", "0079-constituicao-oimpresso-7-camadas-governanca", "0091-daily-brief", "0093-multi-tenant-isolation-tier-0", "0095-skills-tiers-convencao-interna"]
 parent_charter: mission.constituicao-v2
-supersedes: [0078, 0079]
+supersedes: ["0078-constituicao-uma-frase-skill-unidade-evolucao", "0079-constituicao-oimpresso-7-camadas-governanca"]
 referenced_by: []
 authors: [wagner, sonnet]
-accepted_at: 2026-05-06
-accepted_by: wagner
+accepted_at: "2026-05-06"
+decided_by: [W]
 ---
 
 # ADR 0094 — Constituição v2 Oimpresso (mãe das 7 camadas)

--- a/memory/decisions/0095-skills-tiers-convencao-interna.md
+++ b/memory/decisions/0095-skills-tiers-convencao-interna.md
@@ -7,18 +7,18 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 quarter: Q2-2026
-decided_at: 2026-05-06
+decided_at: "2026-05-06"
 decided_by: [W]
 module: governance
 tier: CANON
-related_adrs: [0094, 0091, 0093]
+related_adrs: ["0094-constituicao-v2-7-camadas-8-principios", "0091-daily-brief", "0093-multi-tenant-isolation-tier-0"]
 parent_charter: mission.constituicao-v2
 parent_adr: 0094
 supersedes: []
 referenced_by: []
 authors: [wagner, sonnet]
-accepted_at: 2026-05-06
-accepted_by: wagner
+accepted_at: "2026-05-06"
+decided_by: [W]
 ---
 
 # ADR 0095 — Skills Tier A/B/C (convenção interna)

--- a/memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md
+++ b/memory/decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md
@@ -7,14 +7,14 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-07
-accepted_at: 2026-05-07
-accepted_by: wagner
+decided_at: "2026-05-07"
+accepted_at: "2026-05-07"
+decided_by: [W]
 module: whatsapp
 quarter: 2026-Q2
 tier: CANON
 tags: [whatsapp, integracao, meta, zapi, baileys, multi-tenant, modulo-novo, evolution-proibido, custom-driver-sprint-3]
-related_adrs: [0011, 0024, 0035, 0048, 0058, 0062, 0093, 0094]
+related_adrs: ["0011-alinhamento-padrao-jana", "0024-instalacao-1-clique-modulos", "0035-stack-ai-canonica-wagner-2026-04-26", "0048-framework-agentes-laravel-ai-vizra-rejeitada", "0058-reverb-substituido-por-centrifugo-frankenphp", "0062-separacao-runtime-hostinger-ct100", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios"]
 parent_charter: null
 parent_adr: 0094
 supersedes: []

--- a/memory/decisions/0097-brief-model-gpt4o-mini-supersede-parcial-0091.md
+++ b/memory/decisions/0097-brief-model-gpt4o-mini-supersede-parcial-0091.md
@@ -7,18 +7,18 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 quarter: Q2-2026
-decided_at: 2026-05-07
+decided_at: "2026-05-07"
 decided_by: [W]
 module: governance
 tier: CANON
-related_adrs: [0091, 0036, 0094]
+related_adrs: ["0091-daily-brief", "0036-replanejamento-meilisearch-first", "0094-constituicao-v2-7-camadas-8-principios"]
 parent_charter: mission.constituicao-v2
 parent_adr: 0091
 supersedes: []
 referenced_by: []
 authors: [wagner, opus]
-accepted_at: 2026-05-07
-accepted_by: wagner
+accepted_at: "2026-05-07"
+decided_by: [W]
 ---
 
 # ADR 0097 — BRIEF generator usa gpt-4o-mini (supersede parcial ADR 0091)

--- a/memory/decisions/0098-build-inertia-hostinger-pos-pull.md
+++ b/memory/decisions/0098-build-inertia-hostinger-pos-pull.md
@@ -1,20 +1,20 @@
 ---
 slug: 0098-build-inertia-hostinger-pos-pull
-number: 0098
+number: 98
 title: "build:inertia roda na Hostinger pós git-pull (substitui GH Actions runner)"
 type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-07
+decided_at: "2026-05-07"
 module: infra
 quarter: 2026-Q2
 tags: [ci, deploy, hostinger, inertia, vite]
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0062]
+related: ["0062-separacao-runtime-hostinger-ct100"]
 pii: false
 review_triggers:
   - Hostinger remover Node ou nvm

--- a/memory/decisions/0099-project-legacy-discovery-pre-deletion.md
+++ b/memory/decisions/0099-project-legacy-discovery-pre-deletion.md
@@ -7,14 +7,14 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-07
+decided_at: "2026-05-07"
 module: governance
 quarter: 2026-Q2
 tags: [mwart, legacy, project, discovery, pre-deletion, queue-for-delete]
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0011, 0070, 0079, 0080, 0086, 0087, 0088, 0089, 0093, 0094]
+related: ["0011-alinhamento-padrao-jana", "0070-jira-style-task-management-current-md-removed", "0079-constituicao-oimpresso-7-camadas-governanca", "0080-trust-tiers-operacional-audit-findings", "0086-fase-5-mvp-governance-actiongate-warn", "0087-drift-resolution-sem-mover-url", "0088-module-rename-php-only", "0089-capterra-driven-module-evolution", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios"]
 pii: false
 review_triggers: ["Quando Fase 3.8 começar — usar este discovery pra decidir o que extrair antes de git rm", "Se ProjectMgmt absorver alguma capacidade do legacy (ex: TimeLogs, Invoice from work)"]
 ---

--- a/memory/decisions/0100-projectmgmt-ui-redesign.md
+++ b/memory/decisions/0100-projectmgmt-ui-redesign.md
@@ -7,14 +7,14 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-07
+decided_at: "2026-05-07"
 module: governance
 quarter: 2026-Q2
 tags: [projectmgmt, ui, redesign, capterra-driven, jira-like, linear-style]
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0058, 0070, 0079, 0080, 0086, 0089, 0093, 0094, 0099]
+related: ["0058-reverb-substituido-por-centrifugo-frankenphp", "0070-jira-style-task-management-current-md-removed", "0079-constituicao-oimpresso-7-camadas-governanca", "0080-trust-tiers-operacional-audit-findings", "0086-fase-5-mvp-governance-actiongate-warn", "0089-capterra-driven-module-evolution", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0099-project-legacy-discovery-pre-deletion"]
 pii: false
 review_triggers: ["Após Fase 1 mergeada (drag-drop + Cmd+K) reavaliar Fase 2 com base em uso real do time", "Se time não adotar Cmd+K em 14d, reconsiderar prioridade Fase 1"]
 ---

--- a/memory/decisions/0101-sistema-charter-capterra-governanca-escopo.md
+++ b/memory/decisions/0101-sistema-charter-capterra-governanca-escopo.md
@@ -7,13 +7,13 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 quarter: 2026-Q2
-decided_at: 2026-05-07
+decided_at: "2026-05-07"
 decided_by: [W]
-accepted_at: 2026-05-07
-accepted_by: wagner
+accepted_at: "2026-05-07"
+decided_by: [W]
 module: governance
 tier: CANON
-related_adrs: [0089, 0094, 0095]
+related_adrs: ["0089-capterra-driven-module-evolution", "0094-constituicao-v2-7-camadas-8-principios", "0095-skills-tiers-convencao-interna"]
 parent_charter: mission.charter-system
 authors: [wagner, opus]
 ---

--- a/memory/decisions/0101-tests-business-id-1-nunca-cliente.md
+++ b/memory/decisions/0101-tests-business-id-1-nunca-cliente.md
@@ -7,14 +7,14 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-07
+decided_at: "2026-05-07"
 module: governance
 quarter: 2026-Q2
 tags: [multi-tenant, tests, governance, security, lgpd, biz-isolation]
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0070, 0093, 0094]
+related: ["0070-jira-style-task-management-current-md-removed", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios"]
 pii: false
 review_triggers: ["Se aparecer 3+ falsos-positivos do BusinessIdGuardTest em PRs legítimos, revisar regex patterns", "Se chegar dev novo sem onboarding, validar que skill `multi-tenant-patterns` cobre regra"]
 ---

--- a/memory/decisions/0102-nfce-status-polling-vs-broadcast.md
+++ b/memory/decisions/0102-nfce-status-polling-vs-broadcast.md
@@ -7,14 +7,14 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-07
+decided_at: "2026-05-07"
 module: nfebrasil
 quarter: 2026-Q2
 tags: [nfe, ui, polling, broadcast, centrifugo, runtime-split, hostinger, ct100]
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0058, 0062, 0093]
+related: ["0058-reverb-substituido-por-centrifugo-frankenphp", "0062-separacao-runtime-hostinger-ct100", "0093-multi-tenant-isolation-tier-0"]
 pii: false
 review_triggers: ["Quando Centrifugo HTTP bridge Hostinger→CT 100 for desbloqueado, reavaliar substituir polling por broadcast (sem mudar componentes consumidores)", "Se polling 2s × 30 max não cobrir p99 SEFAZ em prod, ajustar maxPolls antes de migrar pra broadcast"]
 ---

--- a/memory/decisions/0102-s6-charter-capterra-postmortem-s7-backlog.md
+++ b/memory/decisions/0102-s6-charter-capterra-postmortem-s7-backlog.md
@@ -7,13 +7,13 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 quarter: 2026-Q2
-decided_at: 2026-05-08
+decided_at: "2026-05-08"
 decided_by: [W]
-accepted_at: 2026-05-08
-accepted_by: wagner
+accepted_at: "2026-05-08"
+decided_by: [W]
 module: governance
 tier: CANON
-related_adrs: [0089, 0094, 0095, 0101]
+related_adrs: ["0089-capterra-driven-module-evolution", "0094-constituicao-v2-7-camadas-8-principios", "0095-skills-tiers-convencao-interna", "0101-sistema-charter-capterra-governanca-escopo"]
 parent_charter: mission.charter-system
 authors: [wagner, opus]
 ---

--- a/memory/decisions/0103-eventos-fiscais-separados-por-modelo.md
+++ b/memory/decisions/0103-eventos-fiscais-separados-por-modelo.md
@@ -7,14 +7,14 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-07
+decided_at: "2026-05-07"
 module: nfebrasil
 quarter: 2026-Q2
 tags: [nfe, events, listeners, broadcasting, modelo-55, modelo-65, sped-nfe]
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0093]
+related: ["0093-multi-tenant-isolation-tier-0"]
 pii: false
 review_triggers: ["Quando CT-e (modelo 67) for adicionado, decidir se cria CTeAutorizada ou se generaliza pra DocumentoFiscalAutorizado", "Se webhook outbound externos surgirem, validar que filter por event class é mais simples que filter por payload"]
 ---

--- a/memory/decisions/0111-emenda-0096-bypass-meta-fallback-per-business.md
+++ b/memory/decisions/0111-emenda-0096-bypass-meta-fallback-per-business.md
@@ -7,14 +7,14 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-08
-accepted_at: 2026-05-08
-accepted_by: wagner
+decided_at: "2026-05-08"
+accepted_at: "2026-05-08"
+decided_by: [W]
 module: whatsapp
 quarter: 2026-Q2
 tier: CANON
 tags: [whatsapp, zapi, gating-tier-0, bypass-piloto, smoke, biz-1]
-related_adrs: [0094, 0096, 0093]
+related_adrs: ["0094-constituicao-v2-7-camadas-8-principios", "0096-modulo-whatsapp-meta-cloud-api-direto", "0093-multi-tenant-isolation-tier-0"]
 parent_charter: null
 parent_adr: 0096
 supersedes: []

--- a/memory/decisions/0113-integracao-delphi-laravel-ads-3-caminhos.md
+++ b/memory/decisions/0113-integracao-delphi-laravel-ads-3-caminhos.md
@@ -1,20 +1,20 @@
 ---
 slug: 0113-integracao-delphi-laravel-ads-3-caminhos
-number: 0113
+number: 113
 title: "Integração Delphi WR Comercial ↔ Laravel oimpresso ↔ ADs em 3 caminhos aditivos"
 type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-09
+decided_at: "2026-05-09"
 module: null
 quarter: 2026-Q2
 tags: [integracao, delphi, ads, connector, multi-system]
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0021, 0015, 0096-arq-0001-ads]
+related: ["0021-officeimpresso-contrato-api-delphi", "0015-connector-api-gateway", "0096-arq-0001-ads"]
 pii: false
 review_triggers:
   - cliente Delphi for recompilado e redistribuído

--- a/memory/decisions/0117-multiplos-numeros-whatsapp-por-business.md
+++ b/memory/decisions/0117-multiplos-numeros-whatsapp-por-business.md
@@ -10,18 +10,18 @@ renumbered_reason: "Conflito de numeração — PR #308 (ADRs 0115-Gold + 0116-G
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-09
-accepted_at: 2026-05-09
-accepted_by: wagner
+decided_at: "2026-05-09"
+accepted_at: "2026-05-09"
+decided_by: [W]
 module: whatsapp
 quarter: 2026-Q2
 tier: CANON
 tags: [whatsapp, multi-numeros, driver-per-phone, multi-tenant, schema-change, sprint-4]
-related_adrs: [0093, 0094, 0096, 0105, 0111]
+related_adrs: ["0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0096-modulo-whatsapp-meta-cloud-api-direto", "0105-cliente-como-sinal-guiar-sem-mandar", "0111-emenda-0096-bypass-meta-fallback-per-business"]
 parent_charter: resources/js/Pages/Whatsapp/Settings.charter.md
 parent_adr: 0096
 supersedes: []
-supersedes_partially: [0096]
+supersedes_partially: ["0096-modulo-whatsapp-meta-cloud-api-direto"]
 superseded_by: []
 authors: [wagner, opus-4.7]
 pii: false

--- a/memory/decisions/0118-segregacao-dominios-externos-clientes-legacy.md
+++ b/memory/decisions/0118-segregacao-dominios-externos-clientes-legacy.md
@@ -7,14 +7,14 @@ status: proposto
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-09
+decided_at: "2026-05-09"
 module: null
 quarter: 2026-Q2
 tags: [knowledge-management, ddd, bounded-context, anticorruption-layer, legacy-migration, multi-tenant]
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0061, 0070, 0093, 0094, 0113]
+related: ["0061-conhecimento-canonico-git-mcp-zero-automem", "0070-jira-style-task-management-current-md-removed", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0113-integracao-delphi-laravel-ads-3-caminhos"]
 pii: false
 review_triggers:
   - "terceira integração externa surgir (atualmente: Delphi WR Comercial; previstas: Bling/Tiny/Asaas APIs)"

--- a/memory/decisions/0119-migration-factory-capacidade-institucional.md
+++ b/memory/decisions/0119-migration-factory-capacidade-institucional.md
@@ -7,14 +7,14 @@ status: proposto
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-09
+decided_at: "2026-05-09"
 module: null
 quarter: 2026-Q2
 tags: [migration-factory, legacy-migration, business-strategy, brownfield-ai, ddd, multi-tenant]
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0061, 0070, 0093, 0094, 0106, 0113, 0118]
+related: ["0061-conhecimento-canonico-git-mcp-zero-automem", "0070-jira-style-task-management-current-md-removed", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0106-recalibracao-velocidade-fator-10x-ia-pair", "0113-integracao-delphi-laravel-ads-3-caminhos", "0118-segregacao-dominios-externos-clientes-legacy"]
 pii: false
 review_triggers:
   - "terceira fonte de migração entrar em produção (atual: WR Comercial; previstas: Bling, Tiny, Sankhya, concorrentes nicho gráfico)"

--- a/memory/decisions/0120-reverse-supersession-metadata-housekeeping.md
+++ b/memory/decisions/0120-reverse-supersession-metadata-housekeeping.md
@@ -1,16 +1,16 @@
 ---
 slug: 0120-reverse-supersession-metadata-housekeeping
-number: 0120
+number: 120
 title: "Supersession metadata housekeeping — fix 0079 + documenta drift de direção forward"
 type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-09
+decided_at: "2026-05-09"
 quarter: 2026-Q2
 tags: [governance, adr, metadata, housekeeping, audit-constituicao]
-related_adrs: [0028, 0094, 0095]
+related_adrs: ["0028-adrs-numeracao-monotonica", "0094-constituicao-v2-7-camadas-8-principios", "0095-skills-tiers-convencao-interna"]
 amends: []
 supersedes: []
 parent_adr: 0094

--- a/memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md
+++ b/memory/decisions/0121-oimpresso-modular-especializado-por-vertical.md
@@ -7,7 +7,7 @@ status: aceita
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-10
+decided_at: "2026-05-10"
 module: null
 quarter: 2026-Q2
 tags: [arquitetura, posicionamento, modular, multi-vertical, produto, business-strategy]
@@ -15,7 +15,7 @@ supersedes: []
 supersedes_partially: []
 amends: [0011]
 superseded_by: []
-related: [0011, 0024, 0093, 0094, 0105, 0106, 0119]
+related: ["0011-alinhamento-padrao-jana", "0024-instalacao-1-clique-modulos", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0105-cliente-como-sinal-guiar-sem-mandar", "0106-recalibracao-velocidade-fator-10x-ia-pair", "0119-migration-factory-capacidade-institucional"]
 pii: false
 review_triggers:
   - "terceiro módulo vertical em produção com 3+ clientes pagando (atual: 0; previsto: ComunicacaoVisual, Vestuario, OficinaAuto)"

--- a/memory/decisions/0122-admin-center-ct100.md
+++ b/memory/decisions/0122-admin-center-ct100.md
@@ -1,8 +1,8 @@
 ---
-adr: 0122
+number: 122
 title: Admin Center — Centro de Operações @ CT 100 (Tailscale-only, Wagner-only, agrega)
-status: proposed
-date: 2026-05-09
+status: proposto
+date: "2026-05-09"
 deciders: [Wagner]
 supersedes: []
 references:

--- a/memory/decisions/0123-modules-arquivos-backbone.md
+++ b/memory/decisions/0123-modules-arquivos-backbone.md
@@ -1,8 +1,8 @@
 ---
-adr: 0123
+number: 123
 title: Modules/Arquivos — backbone DMS (todo arquivo anexado entra aqui)
-status: proposed
-date: 2026-05-09
+status: proposto
+date: "2026-05-09"
 deciders: [Wagner]
 supersedes: []
 references:

--- a/memory/decisions/0124-curador-conhecimento-pipeline.md
+++ b/memory/decisions/0124-curador-conhecimento-pipeline.md
@@ -1,8 +1,8 @@
 ---
-adr: 0124
+number: 124
 title: Curador — pipeline canônico de ingestão de conhecimento (computador → empresa → MCP)
-status: proposed
-date: 2026-05-09
+status: proposto
+date: "2026-05-09"
 deciders: [Wagner]
 supersedes: []
 references:

--- a/memory/decisions/0125-modules-autopecas-feature-wish.md
+++ b/memory/decisions/0125-modules-autopecas-feature-wish.md
@@ -3,11 +3,11 @@ slug: 0125-modules-autopecas-feature-wish
 number: 125
 title: "Modules/Autopecas como feature-wish — Vargas é sinal qualificado"
 type: adr
-status: proposed
+status: proposto
 authority: canonical
 lifecycle: feature_wish
 decided_by: [W]
-decided_at: 2026-05-10
+decided_at: "2026-05-10"
 module: Autopecas
 quarter: 2026-Q4
 tags: [arquitetura, modular, multi-vertical, autopecas, vargas, feature-wish, sinal-qualificado]
@@ -15,7 +15,7 @@ supersedes: []
 supersedes_partially: []
 amends: []
 superseded_by: []
-related: [0121, 0105, 0103, 0119, 0011, 0094, 0093, 0106]
+related: ["0121-oimpresso-modular-especializado-por-vertical", "0105-cliente-como-sinal-guiar-sem-mandar", "0103-eventos-fiscais-separados-por-modelo", "0119-migration-factory-capacidade-institucional", "0011-alinhamento-padrao-jana", "0094-constituicao-v2-7-camadas-8-principios", "0093-multi-tenant-isolation-tier-0", "0106-recalibracao-velocidade-fator-10x-ia-pair"]
 pii: false
 review_triggers:
   - "Vargas assinar contrato Enterprise pioneer (R$ 1.499/m grandfathered) → mover pra ADR de ativação `em_construcao`"

--- a/memory/decisions/0126-mcp-jira-projects-modulos-verticais.md
+++ b/memory/decisions/0126-mcp-jira-projects-modulos-verticais.md
@@ -2,12 +2,12 @@
 id: 0125
 slug: mcp-jira-projects-modulos-verticais
 title: Habilitar ComunicacaoVisual + Vestuario + OficinaAuto como projects canônicos no MCP
-status: proposed
-date: 2026-05-10
+status: proposto
+date: "2026-05-10"
 deciders: [wagner]
 supersedes: []
 superseded_by: []
-related: [0070, 0094, 0105, 0121]
+related: ["0070-jira-style-task-management-current-md-removed", "0094-constituicao-v2-7-camadas-8-principios", "0105-cliente-como-sinal-guiar-sem-mandar", "0121-oimpresso-modular-especializado-por-vertical"]
 lifecycle: canon
 ---
 

--- a/memory/decisions/0127-modules-auditoria-undo-activity-log.md
+++ b/memory/decisions/0127-modules-auditoria-undo-activity-log.md
@@ -1,8 +1,8 @@
 ---
-adr: 0127
+number: 127
 title: Modules/Auditoria — UI rica + undo sobre activity_log existente
-status: accepted
-date: 2026-05-10
+status: aceito
+date: "2026-05-10"
 deciders: [Wagner]
 supersedes: []
 references:

--- a/memory/decisions/0129-state-machine-canonica-fsm-rbac.md
+++ b/memory/decisions/0129-state-machine-canonica-fsm-rbac.md
@@ -3,18 +3,18 @@ slug: 0129-state-machine-canonica-fsm-rbac
 number: 129
 title: "State Machine canônica — FSM tabular custom + Spatie Permission por transição"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: canon
 decided_by: [W]
-decided_at: 2026-05-10
+decided_at: "2026-05-10"
 module: Sells
 tags: [arquitetura, fsm, state-machine, rbac, side-effects, multi-tenant, sells, repair, projectmgmt, nfe-brasil, fiscal-br]
 supersedes: []
 supersedes_partially: []
 amends: []
 superseded_by: []
-related: [0093, 0094, 0011, 0070, 0095, 0121]
+related: ["0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0011-alinhamento-padrao-jana", "0070-jira-style-task-management-current-md-removed", "0095-skills-tiers-convencao-interna", "0121-oimpresso-modular-especializado-por-vertical"]
 pii: false
 review_triggers:
   - "Spatie/laravel-model-states ou symfony/workflow ganharem multi-tenant nativo + parametrização runtime via UI → reavaliar adoção"

--- a/memory/decisions/0130-handoff-append-only-mcp-first.md
+++ b/memory/decisions/0130-handoff-append-only-mcp-first.md
@@ -3,18 +3,18 @@ slug: 0130-handoff-append-only-mcp-first
 number: 130
 title: "Handoff append-only + MCP-first antes de escrever — fim do overwrite cego de 08-handoff.md"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: canon
 decided_by: [W]
-decided_at: 2026-05-10
+decided_at: "2026-05-10"
 module: Governance
 tags: [governanca, handoff, memoria, mcp, append-only, sessoes-paralelas]
 supersedes: []
 supersedes_partially: []
 amends: [0070]
 superseded_by: []
-related: [0027, 0040, 0061, 0070, 0091, 0094, 0114, 0119]
+related: ["0027-gestao-memoria-roles-claros", "0040-policy-publicacao-claude-supervisiona", "0061-conhecimento-canonico-git-mcp-zero-automem", "0070-jira-style-task-management-current-md-removed", "0091-daily-brief", "0094-constituicao-v2-7-camadas-8-principios", "0114-prototipo-ui-cowork-loop-formalizado", "0119-migration-factory-capacidade-institucional"]
 pii: false
 review_triggers:
   - "Mais de 1 incidente de perda de narrativa entre sessões em 30d após implementação → endurecer regra com hook bloqueador (item P2 deste ADR)"

--- a/memory/decisions/0131-tiering-memoria-canonico-local-segredo.md
+++ b/memory/decisions/0131-tiering-memoria-canonico-local-segredo.md
@@ -3,18 +3,18 @@ slug: 0131-tiering-memoria-canonico-local-segredo
 number: 131
 title: "Tiering de memória — canônico (git/MCP) / máquina-local / segredo (Vaultwarden)"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: canon
 decided_by: [W]
-decided_at: 2026-05-10
+decided_at: "2026-05-10"
 module: Governance
 tags: [governanca, memoria, vaultwarden, auto-mem, seguranca, multi-dev, lgpd]
 supersedes: []
 supersedes_partially: []
 amends: [0061]
 superseded_by: []
-related: [0040, 0061, 0094, 0119, 0130]
+related: ["0040-policy-publicacao-claude-supervisiona", "0061-conhecimento-canonico-git-mcp-zero-automem", "0094-constituicao-v2-7-camadas-8-principios", "0119-migration-factory-capacidade-institucional", "0130-handoff-append-only-mcp-first"]
 pii: false
 review_triggers:
   - "≥1 incidente de segredo vazado em git em 90d → endurecer hook + adicionar gitleaks pre-push obrigatório"

--- a/memory/decisions/0132-langfuse-self-host-ct100.md
+++ b/memory/decisions/0132-langfuse-self-host-ct100.md
@@ -3,18 +3,18 @@ slug: 0132-langfuse-self-host-ct100
 number: 132
 title: "Langfuse self-host CT 100 — observabilidade GenAI canônica oimpresso"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: canon
 decided_by: [W]
-decided_at: 2026-05-10
+decided_at: "2026-05-10"
 module: Infra
 tags: [infra, observabilidade, otel, langfuse, ct100, proxmox, jana, custo-genai]
 supersedes: []
 supersedes_partially: []
 amends: []
 superseded_by: []
-related: [0035, 0051, 0053, 0058, 0062, 0067, 0094]
+related: ["0035-stack-ai-canonica-wagner-2026-04-26", "0051-schema-proprio-adapter-otel-genai", "0053-mcp-server-governanca-como-produto", "0058-reverb-substituido-por-centrifugo-frankenphp", "0062-separacao-runtime-hostinger-ct100", "0067-sprint8-mcp-memory-document-searchable-retrieval", "0094-constituicao-v2-7-camadas-8-principios"]
 pii: false
 review_triggers:
   - "Langfuse OSS v4 sair com breaking change → reavaliar self-host vs Cloud paid"

--- a/memory/decisions/0133-system-health-audit-canonico.md
+++ b/memory/decisions/0133-system-health-audit-canonico.md
@@ -3,18 +3,18 @@ slug: 0133-system-health-audit-canonico
 number: 133
 title: "System health audit canônico — 5 dimensões automáticas (Tool MCP + cron daily)"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: canon
 decided_by: [W]
-decided_at: 2026-05-10
+decided_at: "2026-05-10"
 module: Governance
 tags: [governanca, observabilidade, auditoria, mcp, automacao, tiered-cost, constituicao-v2]
 supersedes: []
 supersedes_partially: []
 amends: []
 superseded_by: []
-related: [0091, 0094, 0119, 0130, 0131, 0132]
+related: ["0091-daily-brief", "0094-constituicao-v2-7-camadas-8-principios", "0119-migration-factory-capacidade-institucional", "0130-handoff-append-only-mcp-first", "0131-tiering-memoria-canonico-local-segredo", "0132-langfuse-self-host-ct100"]
 pii: false
 review_triggers:
   - "Wagner pedir audit reavaliação 2x sem mudança no output → expandir checks (signal weak)"

--- a/memory/decisions/0134-tasks-create-respeita-spec-placeholders.md
+++ b/memory/decisions/0134-tasks-create-respeita-spec-placeholders.md
@@ -7,14 +7,14 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-11
+decided_at: "2026-05-11"
 module: copiloto
 tags: [governance, mcp, tasks, spec, drift, prevention]
 supersedes: []
 supersedes_partially: []
 amends: []
 superseded_by: []
-related: [0053, 0070, 0093, 0094]
+related: ["0053-mcp-server-governanca-como-produto", "0070-jira-style-task-management-current-md-removed", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios"]
 pii: false
 review_triggers:
   - "Detectado ≥1 drift duro em jana:health-check spec_id_drift por ≥3 dias consecutivos → reavaliar política (auto-renumerar? bloquear push?)"

--- a/memory/decisions/0135-omnichannel-inbox-arquitetura.md
+++ b/memory/decisions/0135-omnichannel-inbox-arquitetura.md
@@ -7,14 +7,14 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-11
+decided_at: "2026-05-11"
 module: whatsapp
 tags: [omnichannel, inbox, channel, driver-pattern, atendimento, whatsapp, instagram, messenger, email, mercadolivre]
 supersedes: []
 supersedes_partially: []
 amends: [0096, 0117]
 superseded_by: []
-related: [0093, 0094, 0096, 0105, 0117]
+related: ["0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0096-modulo-whatsapp-meta-cloud-api-direto", "0105-cliente-como-sinal-guiar-sem-mandar", "0117-multiplos-numeros-whatsapp-por-business"]
 pii: false
 review_triggers:
   - "≥1 cliente pagante reportar necessidade de Mercado Livre ou Email inbox → ativar Fase 2/3"

--- a/memory/decisions/0136-sells-grade-avancada-modo-toggle.md
+++ b/memory/decisions/0136-sells-grade-avancada-modo-toggle.md
@@ -7,14 +7,14 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-11
+decided_at: "2026-05-11"
 module: sells
 tags: [migration, ux, legacy, officeimpresso, comunicacao-visual, grid, power-user, ADR-0105-cliente-sinal, ADR-0121-modular-vertical]
 supersedes: []
 supersedes_partially: []
 amends: []
 superseded_by: []
-related: [0094, 0104, 0105, 0107, 0121]
+related: ["0094-constituicao-v2-7-camadas-8-principios", "0104-processo-mwart-canonico-unico-caminho", "0105-cliente-como-sinal-guiar-sem-mandar", "0107-emendation-0104-visual-comparison-gate-f3", "0121-oimpresso-modular-especializado-por-vertical"]
 pii: false
 review_triggers:
   - "≥3 clientes OfficeImpresso migrados reclamarem da Lista padrão → acelerar US Grade Avançada"

--- a/memory/decisions/0137-modules-oficinaauto-qualificada.md
+++ b/memory/decisions/0137-modules-oficinaauto-qualificada.md
@@ -7,7 +7,7 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-11
+decided_at: "2026-05-11"
 module: null
 quarter: 2026-Q2
 tags: [arquitetura, modular, vertical, oficina-auto, modules-oficina, qualified-signal, ADR-0105, ADR-0121]
@@ -15,7 +15,7 @@ supersedes: []
 supersedes_partially: []
 amends: [0121]
 superseded_by: []
-related: [0105, 0121, 0136]
+related: ["0105-cliente-como-sinal-guiar-sem-mandar", "0121-oimpresso-modular-especializado-por-vertical", "0136-sells-grade-avancada-modo-toggle"]
 pii: false
 review_triggers:
   - "Modules/OficinaAuto ter <2 clientes pagantes após 12m de scaffold (candidato lifecycle: historical)"

--- a/memory/decisions/0140-jana-pro-produto-comercial-saas.md
+++ b/memory/decisions/0140-jana-pro-produto-comercial-saas.md
@@ -7,14 +7,14 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-11
+decided_at: "2026-05-11"
 module: copiloto
 tags: [produto-comercial, saas, ia, vizra, jana, atendimento, pricing, go-to-market, monetizacao]
 supersedes: []
 supersedes_partially: []
 amends: [0022]
 superseded_by: []
-related: [0035, 0048, 0053, 0093, 0094, 0096, 0105, 0135]
+related: ["0035-stack-ai-canonica-wagner-2026-04-26", "0048-framework-agentes-laravel-ai-vizra-rejeitada", "0053-mcp-server-governanca-como-produto", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0096-modulo-whatsapp-meta-cloud-api-direto", "0105-cliente-como-sinal-guiar-sem-mandar", "0135-omnichannel-inbox-arquitetura"]
 pii: false
 review_triggers:
   - "<5 clientes pagantes em 90d pós-GA → reavaliar pricing/posicionamento"

--- a/memory/decisions/0141-skill-migracao-blade-react.md
+++ b/memory/decisions/0141-skill-migracao-blade-react.md
@@ -7,14 +7,14 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-11
+decided_at: "2026-05-11"
 module: infra
 tags: [skill, mwart, blade, react, inertia, migracao, cowork, escala-massiva]
 supersedes: []
 supersedes_partially: []
 amends: []
 superseded_by: []
-related: [0093, 0094, 0095, 0104, 0106, 0107, 0109, 0114]
+related: ["0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0095-skills-tiers-convencao-interna", "0104-processo-mwart-canonico-unico-caminho", "0106-recalibracao-velocidade-fator-10x-ia-pair", "0107-emendation-0104-visual-comparison-gate-f3", "0109-claude-design-plugin-integrado-processo-mwart", "0114-prototipo-ui-cowork-loop-formalizado"]
 pii: false
 review_triggers:
   - "Pós-piloto Crm/Compras (16 views) — paridade real <95% medida em smoke biz=4 → reabrir STEP 1 snapshot"

--- a/memory/decisions/0142-notas-internas-sinal-treino-jana.md
+++ b/memory/decisions/0142-notas-internas-sinal-treino-jana.md
@@ -7,14 +7,14 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-12
+decided_at: "2026-05-12"
 module: whatsapp
 tags: [whatsapp, jana, memoria, slash-commands, atendimento, training-signal, ux-chatwoot]
 supersedes: []
 supersedes_partially: []
 amends: [0135]
 superseded_by: []
-related: [0035, 0048, 0052, 0093, 0135]
+related: ["0035-stack-ai-canonica-wagner-2026-04-26", "0048-framework-agentes-laravel-ai-vizra-rejeitada", "0052-contextonegocio-expor-multiplos-angulos", "0093-multi-tenant-isolation-tier-0", "0135-omnichannel-inbox-arquitetura"]
 pii: false
 review_triggers:
   - "Volume de correções `/corrigir` > 50/mês/business → ativar export JSONL automático pra fine-tune"

--- a/memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md
+++ b/memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md
@@ -3,18 +3,18 @@ slug: 0143-fsm-pipeline-live-prod-marco-2026-05-12
 number: 143
 title: "FSM Pipeline Canônico LIVE em prod biz=1 — marco 2026-05-12 (40+ PRs em ~10h)"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: canon
 decided_by: [W]
-decided_at: 2026-05-12
+decided_at: "2026-05-12"
 module: Sells
 tags: [marco, fsm, pipeline-canon, live-prod, sells, repair, nfse, refund, lgpd, paralelizacao-agents, audit-trail, multi-tenant]
 supersedes: []
 supersedes_partially: []
 amends: [0129]
 superseded_by: []
-related: [0129, 0093, 0094, 0104, 0107, 0136, 0117, 0093, 0094, 0106]
+related: ["0129-state-machine-canonica-fsm-rbac", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0104-processo-mwart-canonico-unico-caminho", "0107-emendation-0104-visual-comparison-gate-f3", "0136-sells-grade-avancada-modo-toggle", "0117-multiplos-numeros-whatsapp-por-business", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0106-recalibracao-velocidade-fator-10x-ia-pair"]
 pii: false
 review_triggers:
   - "Próximo cliente além de WR2/ROTA LIVRE ativar o pipeline FSM completo — revisar mapping status legacy → stage"

--- a/memory/decisions/0144-tasks-db-canonico-spec-template.md
+++ b/memory/decisions/0144-tasks-db-canonico-spec-template.md
@@ -3,17 +3,17 @@ slug: 0144-tasks-db-canonico-spec-template
 number: 144
 title: "TaskRegistry — DB é canon de estado vivo, SPEC.md é template descritivo"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: ativo
 quarter: Q2-2026
-decided_at: 2026-05-13
-accepted_at: 2026-05-13
+decided_at: "2026-05-13"
+accepted_at: "2026-05-13"
 decided_by: [wagner]
 module: governance
-supersedes_partially: [0070]
+supersedes_partially: ["0070-jira-style-task-management-current-md-removed"]
 superseded_by: []
-related: [0053, 0070, 0093]
+related: ["0053-mcp-server-governanca-como-produto", "0070-jira-style-task-management-current-md-removed", "0093-multi-tenant-isolation-tier-0"]
 tags: [governance, tasks, mcp, taskregistry, sync, webhook]
 ---
 

--- a/memory/decisions/0145-ia-administradora-pivot-ads-fsm-piloto-cobradora.md
+++ b/memory/decisions/0145-ia-administradora-pivot-ads-fsm-piloto-cobradora.md
@@ -3,18 +3,18 @@ slug: 0145-ia-administradora-pivot-ads-fsm-piloto-cobradora
 number: 145
 title: "IA Administradora do oimpresso — pivot ADS↔FSM + piloto Cobradora ROTA LIVRE"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: canon
 decided_by: [W]
-decided_at: 2026-05-15
+decided_at: "2026-05-15"
 module: ADS
 tags: [visao, ia-administradora, ads, fsm, cobradora, lgpd-art-20, anpd-nt-12-2025, multi-tenant, hitl, audit-card, rota-livre, piloto, cycle-07]
 supersedes: []
 supersedes_partially: []
 amends: [0094]
 superseded_by: []
-related: [0035, 0048, 0053, 0061, 0093, 0094, 0101, 0104, 0106, 0129, 0131, 0140, 0143]
+related: ["0035-stack-ai-canonica-wagner-2026-04-26", "0048-framework-agentes-laravel-ai-vizra-rejeitada", "0053-mcp-server-governanca-como-produto", "0061-conhecimento-canonico-git-mcp-zero-automem", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0101-sistema-charter-capterra-governanca-escopo", "0104-processo-mwart-canonico-unico-caminho", "0106-recalibracao-velocidade-fator-10x-ia-pair", "0129-state-machine-canonica-fsm-rbac", "0131-tiering-memoria-canonico-local-segredo", "0140-jana-pro-produto-comercial-saas", "0143-fsm-pipeline-live-prod-marco-2026-05-12"]
 pii: false
 review_triggers:
   - "Piloto Cobradora rodou 30d em biz=4 — revisar KPIs e decidir GA pra outros biz"

--- a/memory/decisions/0146-contact-lid-canonico-pk-refactor.md
+++ b/memory/decisions/0146-contact-lid-canonico-pk-refactor.md
@@ -7,7 +7,7 @@ status: proposto
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-15
+decided_at: "2026-05-15"
 module: whatsapp
 quarter: 2026-Q2
 tags: [whatsapp, identity, lid, refactor, feature-wish]

--- a/memory/decisions/0147-cascade-review-defesa-drift-time-mcp.md
+++ b/memory/decisions/0147-cascade-review-defesa-drift-time-mcp.md
@@ -7,7 +7,7 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-15
+decided_at: "2026-05-15"
 quarter: 2026-Q2
 module: governance
 tags: [governance, drift, enforcement, team-mcp, cascade-review, constitution-art-7-8-9-10]

--- a/memory/decisions/0148-cascade-review-onda-6-memoria-senior-98.md
+++ b/memory/decisions/0148-cascade-review-onda-6-memoria-senior-98.md
@@ -7,7 +7,7 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-15
+decided_at: "2026-05-15"
 quarter: 2026-Q2
 module: jana
 tags: [governance, memoria, retrieval, anthropic, contextual-retrieval, cascade-review, constitution-art-7-9, onda-6]

--- a/memory/decisions/0149-mwart-screen-pattern-reuse-cowork.md
+++ b/memory/decisions/0149-mwart-screen-pattern-reuse-cowork.md
@@ -7,12 +7,12 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-15
+decided_at: "2026-05-15"
 quarter: 2026-Q2
 module: design-system
 tags: [mwart, cowork, design-system, pattern-reuse, governance, wave-massiva]
 supersedes: []
-related: [0104, 0114, 0107, 0109]
+related: ["0104-processo-mwart-canonico-unico-caminho", "0114-prototipo-ui-cowork-loop-formalizado", "0107-emendation-0104-visual-comparison-gate-f3", "0109-claude-design-plugin-integrado-processo-mwart"]
 amended-by: []
 ---
 

--- a/memory/decisions/0150-kb-unificado-grafo-conhecimento-modulo-ia-central.md
+++ b/memory/decisions/0150-kb-unificado-grafo-conhecimento-modulo-ia-central.md
@@ -1,15 +1,15 @@
 ---
 slug: 0150-kb-unificado-grafo-conhecimento-modulo-ia-central
-number: 0150
+number: 150
 title: "KB Unificado como Grafo de Conhecimento — módulo IA central do oimpresso"
 type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-16
+decided_at: "2026-05-16"
 proposed_at: 2026-05-15
-accepted_at: 2026-05-16
+accepted_at: "2026-05-16"
 implemented_in_pr: 934
 implemented_via:
   - branch: claude/practical-engelbart-8d8eb0 (10 commits, 132 files, +25465 LOC, 7 agents paralelos)

--- a/memory/decisions/0151-modules-comissao-feature-wish.md
+++ b/memory/decisions/0151-modules-comissao-feature-wish.md
@@ -3,11 +3,11 @@ slug: 0151-modules-comissao-feature-wish
 number: 151
 title: "Modules/Comissao como feature-wish — aguarda cliente que reporta dor real"
 type: adr
-status: proposed
+status: proposto
 authority: canonical
 lifecycle: feature_wish
 decided_by: [W]
-decided_at: 2026-05-15
+decided_at: "2026-05-15"
 module: Comissao
 quarter: 2026-Q4
 tags: [arquitetura, modular, cross-vertical, comissao, feature-wish, sinal-qualificado, adr-0105]
@@ -15,7 +15,7 @@ supersedes: []
 supersedes_partially: []
 amends: []
 superseded_by: []
-related: [0105, 0121, 0093, 0094, 0125, 0143, 0106]
+related: ["0105-cliente-como-sinal-guiar-sem-mandar", "0121-oimpresso-modular-especializado-por-vertical", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0125-modules-autopecas-feature-wish", "0143-fsm-pipeline-live-prod-marco-2026-05-12", "0106-recalibracao-velocidade-fator-10x-ia-pair"]
 pii: false
 review_triggers:
   - "Larissa (ROTA LIVRE biz=4) reportar que planilha paralela de comissão Eliana[E] está custando >1h/mês OU pedir explicitamente automação"

--- a/memory/decisions/0152-modules-pcp-feature-wish.md
+++ b/memory/decisions/0152-modules-pcp-feature-wish.md
@@ -3,11 +3,11 @@ slug: 0152-modules-pcp-feature-wish
 number: 152
 title: "Modules/Pcp como feature-wish — aguarda Vargas ou ComVis 1º piloto"
 type: adr
-status: proposed
+status: proposto
 authority: canonical
 lifecycle: feature_wish
 decided_by: [W]
-decided_at: 2026-05-15
+decided_at: "2026-05-15"
 module: Pcp
 quarter: 2026-Q4
 tags: [arquitetura, modular, cross-vertical, pcp, apontamento, feature-wish, sinal-qualificado, adr-0105]
@@ -15,7 +15,7 @@ supersedes: []
 supersedes_partially: []
 amends: []
 superseded_by: []
-related: [0105, 0121, 0093, 0094, 0125, 0143, 0104, 0106, 0137]
+related: ["0105-cliente-como-sinal-guiar-sem-mandar", "0121-oimpresso-modular-especializado-por-vertical", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0125-modules-autopecas-feature-wish", "0143-fsm-pipeline-live-prod-marco-2026-05-12", "0104-processo-mwart-canonico-unico-caminho", "0106-recalibracao-velocidade-fator-10x-ia-pair", "0137-modules-oficinaauto-qualificada"]
 pii: false
 review_triggers:
   - "Vargas (ADR 0125) assinar + demandar apontamento multi-mecânico (recapagem 2-3 mecânicos por OS — gateway US-PCP-007 + US-PCP-014)"

--- a/memory/decisions/0153-module-grade-rubrica-v1.md
+++ b/memory/decisions/0153-module-grade-rubrica-v1.md
@@ -1,20 +1,20 @@
 ---
 slug: 0153-module-grade-rubrica-v1
-number: 0153
+number: 153
 title: "Rubrica oficial `module-grade-v1` — nota 0-100 ponderada pra cada Module"
 type: adr
 status: proposto
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-16
+decided_at: "2026-05-16"
 module: Governance
 quarter: 2026-Q2
 tags: [governance, qualidade, audit, dashboard, dim-5-pesos-100]
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0093, 0094, 0101, 0105, 0143]
+related: ["0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0101-sistema-charter-capterra-governanca-escopo", "0105-cliente-como-sinal-guiar-sem-mandar", "0143-fsm-pipeline-live-prod-marco-2026-05-12"]
 pii: false
 review_triggers:
   - Quando pesos das 5 dimensões precisarem ajuste (ex: receita por módulo vira mensurável)

--- a/memory/decisions/0154-module-grade-v2-na-justificado.md
+++ b/memory/decisions/0154-module-grade-v2-na-justificado.md
@@ -1,22 +1,22 @@
 ---
 slug: 0154-module-grade-v2-na-justificado
-number: 0154
+number: 154
 title: "Rubrica `module-grade-v2` — regra N/A justificado pra dimensões inaplicáveis por design"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-16
-accepted_at: 2026-05-16
+decided_at: "2026-05-16"
+accepted_at: "2026-05-16"
 review_at: 2026-05-23
 module: Governance
 quarter: 2026-Q2
 tags: [governance, qualidade, audit, dashboard, rubrica, na-justificado, dim-5-pesos-100]
 supersedes: []
-supersedes_partially: [0153]
+supersedes_partially: ["0153-module-grade-rubrica-v1"]
 superseded_by: []
-related: [0093, 0094, 0101, 0105, 0143, 0153]
+related: ["0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0101-sistema-charter-capterra-governanca-escopo", "0105-cliente-como-sinal-guiar-sem-mandar", "0143-fsm-pipeline-live-prod-marco-2026-05-12", "0153-module-grade-rubrica-v1"]
 pii: false
 review_triggers:
   - Quando média projeto bater 75+ (rubrica v2 saturou — precisa v3)

--- a/memory/decisions/0155-module-grade-v3-sub-dimensoes-gate-ci.md
+++ b/memory/decisions/0155-module-grade-v3-sub-dimensoes-gate-ci.md
@@ -1,22 +1,22 @@
 ---
 slug: 0155-module-grade-v3-sub-dimensoes-gate-ci
-number: 0155
+number: 155
 title: "module-grade-v3 — 4 sub-dimensões novas (Performance/LGPD/Security/Observability) + reweight + gate CI anti-regressão"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-16
-accepted_at: 2026-05-16
+decided_at: "2026-05-16"
+accepted_at: "2026-05-16"
 review_at: 2026-05-23
 module: Governance
 quarter: 2026-Q2
 tags: [governance, qualidade, audit, dashboard, dim-9-pesos-100-normalizado, gate-ci, anti-regressao, performance, lgpd, security, observability]
 supersedes: []
-supersedes_partially: [0153, 0154]
+supersedes_partially: ["0153-module-grade-rubrica-v1", "0154-module-grade-v2-na-justificado"]
 superseded_by: []
-related: [0093, 0094, 0101, 0105, 0143, 0153, 0154]
+related: ["0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0101-sistema-charter-capterra-governanca-escopo", "0105-cliente-como-sinal-guiar-sem-mandar", "0143-fsm-pipeline-live-prod-marco-2026-05-12", "0153-module-grade-rubrica-v1", "0154-module-grade-v2-na-justificado"]
 pii: false
 review_triggers:
   - Quando média projeto bater 90+ (sinal v3 saturou — precisa v4 com financial/ROI dims)

--- a/memory/decisions/0156-module-grade-v3-errata-otel-helper-na-justified.md
+++ b/memory/decisions/0156-module-grade-v3-errata-otel-helper-na-justified.md
@@ -1,22 +1,22 @@
 ---
 slug: 0156-module-grade-v3-errata-otel-helper-na-justified
-number: 0156
+number: 156
 title: "module-grade-v3 errata — D9.a regex inclui OtelHelper canônico + ratifica na_justified D6-D9 backward-compat"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-16
-accepted_at: 2026-05-16
+decided_at: "2026-05-16"
+accepted_at: "2026-05-16"
 review_at: 2026-05-23
 module: Governance
 quarter: 2026-Q2
 tags: [governance, errata, observability, na-justified, backward-compat]
 supersedes: []
-supersedes_partially: [0155]
+supersedes_partially: ["0155-module-grade-v3-sub-dimensoes-gate-ci"]
 superseded_by: []
-related: [0155, 0154, 0153, 0094]
+related: ["0155-module-grade-v3-sub-dimensoes-gate-ci", "0154-module-grade-v2-na-justificado", "0153-module-grade-rubrica-v1", "0094-constituicao-v2-7-camadas-8-principios"]
 pii: false
 review_triggers:
   - Quando OTel SDK consolidar e D6.b virar hard check (também trigger 0155)

--- a/memory/decisions/0157-module-grade-v3-d2-detection-hardening.md
+++ b/memory/decisions/0157-module-grade-v3-d2-detection-hardening.md
@@ -1,22 +1,22 @@
 ---
 slug: 0157-module-grade-v3-d2-detection-hardening
-number: 0157
+number: 157
 title: "module-grade-v3 — endurecimento D2 detection (parser XML + verificação subpastas Pest)"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-16
-accepted_at: 2026-05-16
+decided_at: "2026-05-16"
+accepted_at: "2026-05-16"
 review_at: 2026-05-23
 module: Governance
 quarter: 2026-Q2
 tags: [governance, rubrica, d2-pest-coverage, hardening, anti-gaming]
 supersedes: []
-supersedes_partially: [0155]
+supersedes_partially: ["0155-module-grade-v3-sub-dimensoes-gate-ci"]
 superseded_by: []
-related: [0155, 0156, 0154, 0153, 0094, 0070, 0093, 0101]
+related: ["0155-module-grade-v3-sub-dimensoes-gate-ci", "0156-module-grade-v3-errata-otel-helper-na-justified", "0154-module-grade-v2-na-justificado", "0153-module-grade-rubrica-v1", "0094-constituicao-v2-7-camadas-8-principios", "0070-jira-style-task-management-current-md-removed", "0093-multi-tenant-isolation-tier-0", "0101-sistema-charter-capterra-governanca-escopo"]
 pii: false
 review_triggers:
   - Se >5 módulos baixarem nota >5 pts após adoção (sinal que baseline estava ENTUPIDO de inflação)

--- a/memory/decisions/0158-module-grade-v3-d1-heuristica-hardening.md
+++ b/memory/decisions/0158-module-grade-v3-d1-heuristica-hardening.md
@@ -1,22 +1,22 @@
 ---
 slug: 0158-module-grade-v3-d1-heuristica-hardening
-number: 0158
+number: 158
 title: "module-grade-v3 — endurecimento heurística D1 (recursive + scope singular + Job $entityId pattern)"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-16
-accepted_at: 2026-05-16
+decided_at: "2026-05-16"
+accepted_at: "2026-05-16"
 review_at: 2026-05-23
 module: Governance
 quarter: 2026-Q2
 tags: [governance, rubrica, d1-multitenancy, hardening, falso-positivo, falso-negativo]
 supersedes: []
-supersedes_partially: [0155]
+supersedes_partially: ["0155-module-grade-v3-sub-dimensoes-gate-ci"]
 superseded_by: []
-related: [0155, 0156, 0157, 0154, 0153, 0094, 0093]
+related: ["0155-module-grade-v3-sub-dimensoes-gate-ci", "0156-module-grade-v3-errata-otel-helper-na-justified", "0157-module-grade-v3-d2-detection-hardening", "0154-module-grade-v2-na-justificado", "0153-module-grade-rubrica-v1", "0094-constituicao-v2-7-camadas-8-principios", "0093-multi-tenant-isolation-tier-0"]
 pii: false
 review_triggers:
   - Quando >3 módulos beneficiados/penalizados pelo recursive caírem na ressalva

--- a/memory/decisions/0159-module-grade-v3-errata-meta-97-realismo.md
+++ b/memory/decisions/0159-module-grade-v3-errata-meta-97-realismo.md
@@ -1,22 +1,22 @@
 ---
 slug: 0159-module-grade-v3-errata-meta-97-realismo
-number: 0159
+number: 159
 title: "module-grade-v3 errata — realismo meta 97.75 (D5 cross-cutting / D9.b ready / D4.b N/A / D3.b CHANGELOG)"
 type: adr
-status: proposed
+status: proposto
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-16
+decided_at: "2026-05-16"
 proposed_at: 2026-05-16
 review_at: 2026-05-23
 module: Governance
 quarter: 2026-Q2
 tags: [governance, errata, rubrica, meta-97, realismo, cross-cutting]
 supersedes: []
-supersedes_partially: [0155, 0156]
+supersedes_partially: ["0155-module-grade-v3-sub-dimensoes-gate-ci", "0156-module-grade-v3-errata-otel-helper-na-justified"]
 superseded_by: []
-related: [0155, 0156, 0157, 0158, 0153, 0154, 0094, 0105]
+related: ["0155-module-grade-v3-sub-dimensoes-gate-ci", "0156-module-grade-v3-errata-otel-helper-na-justified", "0157-module-grade-v3-d2-detection-hardening", "0158-module-grade-v3-d1-heuristica-hardening", "0153-module-grade-rubrica-v1", "0154-module-grade-v2-na-justificado", "0094-constituicao-v2-7-camadas-8-principios", "0105-cliente-como-sinal-guiar-sem-mandar"]
 pii: false
 review_triggers:
   - Quando média global da rubrica ultrapassar 97.75 (meta Wagner) e tendência continuar subindo → considerar reapertar D5

--- a/memory/decisions/0160-governance-v4-scoped-scorecards-buckets.md
+++ b/memory/decisions/0160-governance-v4-scoped-scorecards-buckets.md
@@ -1,22 +1,22 @@
 ---
 slug: 0160-governance-v4-scoped-scorecards-buckets
-number: 0160
+number: 160
 title: "module-grade-v4 — Scoped Scorecards (Lens per Module Kind) com 4 buckets + meta por bucket"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-16
-accepted_at: 2026-05-16
+decided_at: "2026-05-16"
+accepted_at: "2026-05-16"
 review_at: 2026-08-16
 module: Governance
 quarter: 2026-Q2
 tags: [governance, v4, scoped-scorecards, lenses, buckets, meta-por-bucket, anti-gaming, score-as-code]
 supersedes: []
-supersedes_partially: [0155, 0159]
+supersedes_partially: ["0155-module-grade-v3-sub-dimensoes-gate-ci", "0159-module-grade-v3-errata-meta-97-realismo"]
 superseded_by: []
-related: [0155, 0156, 0157, 0158, 0159, 0093, 0094, 0105]
+related: ["0155-module-grade-v3-sub-dimensoes-gate-ci", "0156-module-grade-v3-errata-otel-helper-na-justified", "0157-module-grade-v3-d2-detection-hardening", "0158-module-grade-v3-d1-heuristica-hardening", "0159-module-grade-v3-errata-meta-97-realismo", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0105-cliente-como-sinal-guiar-sem-mandar"]
 pii: false
 review_triggers:
   - Quando 3+ módulos abusarem mudança de bucket sem label aprovação (gaming)

--- a/memory/decisions/0161-governance-v4-aposentar-hacks-0159-redundantes.md
+++ b/memory/decisions/0161-governance-v4-aposentar-hacks-0159-redundantes.md
@@ -1,22 +1,22 @@
 ---
 slug: 0161-governance-v4-aposentar-hacks-0159-redundantes
-number: 0161
+number: 161
 title: "Governance v4 — aposentar 3 dos 4 hacks ADR 0159 redundantes com Scoped Scorecards"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-16
+decided_at: "2026-05-16"
 proposed_at: 2026-05-16
 review_at: 2026-08-16
 module: Governance
 quarter: 2026-Q2
 tags: [governance, deprecation, rubrica, v4, scoped-scorecards, hacks]
 supersedes: []
-supersedes_partially: [0159]
+supersedes_partially: ["0159-module-grade-v3-errata-meta-97-realismo"]
 superseded_by: []
-related: [0159, 0160, 0155, 0156, 0157, 0158, 0153, 0154, 0094]
+related: ["0159-module-grade-v3-errata-meta-97-realismo", "0160-governance-v4-scoped-scorecards-buckets", "0155-module-grade-v3-sub-dimensoes-gate-ci", "0156-module-grade-v3-errata-otel-helper-na-justified", "0157-module-grade-v3-d2-detection-hardening", "0158-module-grade-v3-d1-heuristica-hardening", "0153-module-grade-rubrica-v1", "0154-module-grade-v2-na-justificado", "0094-constituicao-v2-7-camadas-8-principios"]
 pii: false
 review_triggers:
   - Quando `governance.v4_enabled=true` virar default em prod (Hostinger biz=1 + biz=4) → remover branches v3 hack do Service (dead code cleanup)

--- a/memory/decisions/0162-otel-collector-prod-observability.md
+++ b/memory/decisions/0162-otel-collector-prod-observability.md
@@ -1,14 +1,14 @@
 ---
 slug: 0162-otel-collector-prod-observability
-number: 0162
+number: 162
 title: "OpenTelemetry Collector ativo em prod (CT 100) — destrava D6.b + D9.b governance v4"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-17
-accepted_at: 2026-05-17
+decided_at: "2026-05-17"
+accepted_at: "2026-05-17"
 review_at: 2026-08-17
 module: Infra
 quarter: 2026-Q2
@@ -16,7 +16,7 @@ tags: [observability, opentelemetry, otel-collector, tempo, grafana, governance,
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0058, 0062, 0094, 0155, 0156, 0160, 0161]
+related: ["0058-reverb-substituido-por-centrifugo-frankenphp", "0062-separacao-runtime-hostinger-ct100", "0094-constituicao-v2-7-camadas-8-principios", "0155-module-grade-v3-sub-dimensoes-gate-ci", "0156-module-grade-v3-errata-otel-helper-na-justified", "0160-governance-v4-scoped-scorecards-buckets", "0161-governance-v4-aposentar-hacks-0159-redundantes"]
 pii: false
 review_triggers:
   - Se >1% overhead p99 detectado em prod (3 dias consecutivos) — reduzir sampling pra 1%

--- a/memory/decisions/0163-governance-v4-metas-alcancadas-ondas-19-28.md
+++ b/memory/decisions/0163-governance-v4-metas-alcancadas-ondas-19-28.md
@@ -1,14 +1,14 @@
 ---
 slug: 0163-governance-v4-metas-alcancadas-ondas-19-28
-number: 0163
+number: 163
 title: "Governance v4 — metas por bucket alcançadas (Ondas 19-28) · 4/4 buckets acima da meta"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-17
-accepted_at: 2026-05-17
+decided_at: "2026-05-17"
+accepted_at: "2026-05-17"
 review_at: 2026-08-17
 module: Governance
 quarter: 2026-Q2
@@ -16,7 +16,7 @@ tags: [governance, v4, scoped-scorecards, metas, ondas-19-28, milestone, dual-mo
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0155, 0156, 0157, 0158, 0159, 0160, 0161, 0162, 0094, 0105]
+related: ["0155-module-grade-v3-sub-dimensoes-gate-ci", "0156-module-grade-v3-errata-otel-helper-na-justified", "0157-module-grade-v3-d2-detection-hardening", "0158-module-grade-v3-d1-heuristica-hardening", "0159-module-grade-v3-errata-meta-97-realismo", "0160-governance-v4-scoped-scorecards-buckets", "0161-governance-v4-aposentar-hacks-0159-redundantes", "0162-otel-collector-prod-observability", "0094-constituicao-v2-7-camadas-8-principios", "0105-cliente-como-sinal-guiar-sem-mandar"]
 pii: false
 review_triggers:
   - Quando dual-mode v3/v4 completar 30 dias estável em prod (aposentar v3 código + UI)

--- a/memory/decisions/0164-screen-review-pdca-tela-smoke-pos-merge.md
+++ b/memory/decisions/0164-screen-review-pdca-tela-smoke-pos-merge.md
@@ -1,14 +1,14 @@
 ---
 slug: 0164-screen-review-pdca-tela-smoke-pos-merge
-number: 0164
+number: 164
 title: "Screen Review PDCA — fase C (Check) automática pós-merge via skill tela-smoke-pos-merge"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-17
-accepted_at: 2026-05-17
+decided_at: "2026-05-17"
+accepted_at: "2026-05-17"
 review_at: 2026-08-17
 module: Governance
 quarter: 2026-Q2
@@ -16,7 +16,7 @@ tags: [governance, pdca, mwart, screen-review, browser-mcp, visual-validation, s
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0104, 0107, 0114, 0109, 0094, 0163]
+related: ["0104-processo-mwart-canonico-unico-caminho", "0107-emendation-0104-visual-comparison-gate-f3", "0114-prototipo-ui-cowork-loop-formalizado", "0109-claude-design-plugin-integrado-processo-mwart", "0094-constituicao-v2-7-camadas-8-principios", "0163-governance-v4-metas-alcancadas-ondas-19-28"]
 pii: false
 review_triggers:
   - Quando 3+ telas falham smoke 2x consecutivo → revisar charter UX targets (sinal que metas estão calibradas erradas)

--- a/memory/decisions/0165-design-system-breakpoints-mobile-first-responsive.md
+++ b/memory/decisions/0165-design-system-breakpoints-mobile-first-responsive.md
@@ -1,13 +1,13 @@
 ---
 slug: 0165-design-system-breakpoints-mobile-first-responsive
-number: 0165
+number: 165
 title: "Design System — breakpoints canon + regra mobile-first em todas as Pages Inertia"
 type: adr
-status: proposed
+status: proposto
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-17
+decided_at: "2026-05-17"
 accepted_at: null
 review_at: 2026-11-17
 module: Governance
@@ -16,7 +16,7 @@ tags: [design-system, responsive, mobile-first, breakpoints, tailwind, charter, 
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0104, 0107, 0110, 0114, 0094, 0093, 0066]
+related: ["0104-processo-mwart-canonico-unico-caminho", "0107-emendation-0104-visual-comparison-gate-f3", "0110-cockpit-pattern-v2-canon-list-detail", "0114-prototipo-ui-cowork-loop-formalizado", "0094-constituicao-v2-7-camadas-8-principios", "0093-multi-tenant-isolation-tier-0", "0066-format-date-shift-3h-preservado-legacy-clientes"]
 pii: false
 review_triggers:
   - Quando ≥5 telas falharem viewport smoke 2x consecutivo → revisar breakpoints canon (sinal que escolha está mal calibrada vs parque real)

--- a/memory/decisions/0166-errata-0162-otel-require-dev-hostinger.md
+++ b/memory/decisions/0166-errata-0162-otel-require-dev-hostinger.md
@@ -1,14 +1,14 @@
 ---
 slug: 0166-errata-0162-otel-require-dev-hostinger
-number: 0166
+number: 166
 title: "Errata ADR 0162 — OTel SDK em require-dev (Hostinger shared sem ext-opentelemetry)"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-17
-accepted_at: 2026-05-17
+decided_at: "2026-05-17"
+accepted_at: "2026-05-17"
 review_at: 2026-11-17
 module: Governance
 quarter: 2026-Q2
@@ -16,7 +16,7 @@ tags: [errata, opentelemetry, composer, hostinger, deploy, runtime-separation, c
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0062, 0094, 0143, 0156, 0162]
+related: ["0062-separacao-runtime-hostinger-ct100", "0094-constituicao-v2-7-camadas-8-principios", "0143-fsm-pipeline-live-prod-marco-2026-05-12", "0156-module-grade-v3-errata-otel-helper-na-justified", "0162-otel-collector-prod-observability"]
 pii: false
 review_triggers:
   - Se Hostinger migrar de shared hosting pra VPS dedicada com PECL próprio (ext-opentelemetry passa a estar disponível) — reavaliar move dev→require (cenário ADR 0062 review_triggers)

--- a/memory/decisions/0167-errata-0130-indice-handoff-historico-longo.md
+++ b/memory/decisions/0167-errata-0130-indice-handoff-historico-longo.md
@@ -1,14 +1,14 @@
 ---
 slug: 0167-errata-0130-indice-handoff-historico-longo
-number: 0167
+number: 167
 title: "Errata ADR 0130 — Índice de handoff mantém histórico longo (não trunca 5)"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-17
-accepted_at: 2026-05-17
+decided_at: "2026-05-17"
+accepted_at: "2026-05-17"
 review_at: 2026-11-17
 module: Governance
 quarter: 2026-Q2
@@ -17,7 +17,7 @@ supersedes: []
 supersedes_partially: []
 superseded_by: []
 amends: [0130]
-related: [0061, 0070, 0094, 0119, 0130, 0131]
+related: ["0061-conhecimento-canonico-git-mcp-zero-automem", "0070-jira-style-task-management-current-md-removed", "0094-constituicao-v2-7-camadas-8-principios", "0119-migration-factory-capacidade-institucional", "0130-handoff-append-only-mcp-first", "0131-tiering-memoria-canonico-local-segredo"]
 pii: false
 review_triggers:
   - "Diretório `memory/handoffs/` ultrapassar 200 arquivos (vs gate antigo 100 em ADR 0130) — avaliar arquivamento `memory/handoffs/_archive/YYYY/`"

--- a/memory/decisions/0168-protocolo-wagner-sempre-tier-A-irrevogavel.md
+++ b/memory/decisions/0168-protocolo-wagner-sempre-tier-A-irrevogavel.md
@@ -1,20 +1,20 @@
 ---
 slug: 0168-protocolo-wagner-sempre-tier-A-irrevogavel
-number: 0168
+number: 168
 title: "PROTOCOLO WAGNER SEMPRE — 10 regras canon Tier A always-on (Constituição v2 emenda)"
 type: adr
 status: proposto
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-17
+decided_at: "2026-05-17"
 module: null
 quarter: 2026-Q2
 tags: [governance, constituicao, skills-tier-A, wagner-protocol, automation]
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0094, 0095, 0061, 0093, 0101, 0104, 0106, 0114, 0143, 0167]
+related: ["0094-constituicao-v2-7-camadas-8-principios", "0095-skills-tiers-convencao-interna", "0061-conhecimento-canonico-git-mcp-zero-automem", "0093-multi-tenant-isolation-tier-0", "0101-sistema-charter-capterra-governanca-escopo", "0104-processo-mwart-canonico-unico-caminho", "0106-recalibracao-velocidade-fator-10x-ia-pair", "0114-prototipo-ui-cowork-loop-formalizado", "0143-fsm-pipeline-live-prod-marco-2026-05-12", "0167-errata-0130-indice-handoff-historico-longo"]
 pii: false
 review_triggers:
   - "Wagner pergunta 'o que eu sempre solicito?' em 2+ sessões diferentes"

--- a/memory/decisions/0169-errata-0168-runbook-onda-cowork-canon.md
+++ b/memory/decisions/0169-errata-0168-runbook-onda-cowork-canon.md
@@ -1,20 +1,20 @@
 ---
 slug: 0169-errata-0168-runbook-onda-cowork-canon
-number: 0169
+number: 169
 title: "Errata ADR 0168 — RUNBOOK-onda-cowork.md como artefato 4º da triade governance"
 type: adr
 status: proposto
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-17
+decided_at: "2026-05-17"
 module: null
 quarter: 2026-Q2
 tags: [governance, errata, ondas-cowork, design-system, playbook]
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0094, 0104, 0107, 0114, 0141, 0143, 0168]
+related: ["0094-constituicao-v2-7-camadas-8-principios", "0104-processo-mwart-canonico-unico-caminho", "0107-emendation-0104-visual-comparison-gate-f3", "0114-prototipo-ui-cowork-loop-formalizado", "0141-agents-tool-use-pattern-claude-code", "0143-fsm-pipeline-live-prod-marco-2026-05-12", "0168-protocolo-wagner-sempre-tier-A-irrevogavel"]
 pii: false
 review_triggers:
   - "Time MCP (Felipe/Maiara/Eliana/Luiz) reporta dúvida sobre como aplicar Ondas"

--- a/memory/decisions/0170-onda5-simplificada.md
+++ b/memory/decisions/0170-onda5-simplificada.md
@@ -3,8 +3,8 @@ adr: 0170-onda5-simplificada
 title: "PaymentGateway Onda 5 SIMPLIFICADA — Dogfooding SaaS via 6º gateway adicional"
 status: aceito
 decided_by: [W]
-date: 2026-05-19
-related: [0017, 0093, 0094, 0105, 0170]
+date: "2026-05-19"
+related: ["0017-officeimpresso-restaurado-superadmin-exclusivo", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0105-cliente-como-sinal-guiar-sem-mandar", "0170-onda5-simplificada"]
 supersedes: []
 amends: [0170]
 tipo: amendment

--- a/memory/decisions/0171-oficinaauto-ativacao-piloto-martinho-faseada.md
+++ b/memory/decisions/0171-oficinaauto-ativacao-piloto-martinho-faseada.md
@@ -7,7 +7,7 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-20
+decided_at: "2026-05-20"
 module: null
 quarter: 2026-Q2
 tags: [oficina-auto, piloto, ativacao, martinho-cacambas, cliente-sinal, add-on-faturavel, migracao-faseada]
@@ -15,7 +15,7 @@ supersedes: []
 supersedes_partially: []
 amends: [0137]
 superseded_by: []
-related: [0105, 0137, 0143, 0094, 0121, 0106, 0119]
+related: ["0105-cliente-como-sinal-guiar-sem-mandar", "0137-modules-oficinaauto-qualificada", "0143-fsm-pipeline-live-prod-marco-2026-05-12", "0094-constituicao-v2-7-camadas-8-principios", "0121-oimpresso-modular-especializado-por-vertical", "0106-recalibracao-velocidade-fator-10x-ia-pair", "0119-migration-factory-capacidade-institucional"]
 pii: false
 review_triggers:
   - "Martinho Caçambas churn antes de 90d pós-ativação (sinal de modelo faseado mal calibrado)"

--- a/memory/decisions/0172-deprecar-modulo-accounting-fundir-financeiro.md
+++ b/memory/decisions/0172-deprecar-modulo-accounting-fundir-financeiro.md
@@ -1,10 +1,10 @@
 ---
-adr: 0172
+number: 172
 title: "Deprecar Modules/Accounting e consolidar contabilidade operacional no Modules/Financeiro"
-status: accepted
-date: 2026-05-20
-accepted_at: 2026-05-20
-accepted_by: wagner
+status: aceito
+date: "2026-05-20"
+accepted_at: "2026-05-20"
+decided_by: [W]
 authors: [wagner]
 supersedes:
   - memory/requisitos/Financeiro/adr/arq/0005-financeiro-vs-accounting-paralelo.md

--- a/memory/decisions/0173-errata-arq-0005-tabelas-accounting-sem-prefixo.md
+++ b/memory/decisions/0173-errata-arq-0005-tabelas-accounting-sem-prefixo.md
@@ -1,10 +1,10 @@
 ---
-adr: 0173
+number: 173
 title: "Errata ARQ-0005 — tabelas Accounting usam nomes nus (não prefixo `accounting_*`)"
-status: accepted
-date: 2026-05-20
-accepted_at: 2026-05-20
-accepted_by: wagner
+status: aceito
+date: "2026-05-20"
+accepted_at: "2026-05-20"
+decided_by: [W]
 authors: [wagner]
 errata_de:
   - memory/requisitos/Financeiro/adr/arq/0005-financeiro-vs-accounting-paralelo.md

--- a/memory/decisions/0174-errata-deprecation-plan-accounting-ondas-3-4-skip.md
+++ b/memory/decisions/0174-errata-deprecation-plan-accounting-ondas-3-4-skip.md
@@ -3,11 +3,11 @@ slug: 0174-errata-deprecation-plan-accounting-ondas-3-4-skip
 number: 174
 title: "Errata DEPRECATION-PLAN Accounting — Ondas 3+4 SKIP (audit prod 0 rows)"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-20
+decided_at: "2026-05-20"
 module: financeiro
 quarter: 2026-Q2
 tags: [deprecation, accounting, financeiro, errata, audit-prod]

--- a/memory/decisions/0175-fix-observer-conta-bancaria-opcional.md
+++ b/memory/decisions/0175-fix-observer-conta-bancaria-opcional.md
@@ -3,11 +3,11 @@ slug: 0175-fix-observer-conta-bancaria-opcional
 number: 175
 title: "Fix arquitetural — Observer Financeiro permite baixa sem fin_contas_bancarias (remove guard no-op)"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-20
+decided_at: "2026-05-20"
 module: financeiro
 quarter: 2026-Q2
 tags: [financeiro, observer, fix-arquitetural, debito-tecnico, multi-tenant]

--- a/memory/decisions/0178-sells-unified-tabs-visao-supersede-0136.md
+++ b/memory/decisions/0178-sells-unified-tabs-visao-supersede-0136.md
@@ -7,15 +7,15 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-21
+decided_at: "2026-05-21"
 module: sells
 quarter: 2026-Q2
 tags: [ux, unification, tabs, persona, refactor, ADR-0105-cliente-sinal, ADR-0136-superseded, multi-tenant-tier-0]
-supersedes: [0136]
+supersedes: ["0136-sells-grade-avancada-modo-toggle"]
 supersedes_partially: []
 amends: []
 superseded_by: []
-related: [0093, 0094, 0104, 0105, 0107, 0136]
+related: ["0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0104-processo-mwart-canonico-unico-caminho", "0105-cliente-como-sinal-guiar-sem-mandar", "0107-emendation-0104-visual-comparison-gate-f3", "0136-sells-grade-avancada-modo-toggle"]
 pii: false
 review_triggers:
   - "Larissa @ ROTA LIVRE biz=4 reclamar que tab default 'Operacional' perdeu coluna que ela usava → ajustar visibleColumns Operacional"

--- a/memory/decisions/0179-cliente-drawer-760px-substitui-show-fullpage.md
+++ b/memory/decisions/0179-cliente-drawer-760px-substitui-show-fullpage.md
@@ -3,7 +3,7 @@ slug: 0179-cliente-drawer-760px-substitui-show-fullpage
 number: 179
 title: "Cliente — drawer lateral 760px substitui Show.tsx full-page (paradigma cadastral 8 tabs)"
 type: adr
-status: accepted
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
@@ -15,7 +15,7 @@ module: crm
 tags: [paradigma, cliente, drawer, mwart, cowork-blueprint, tier-A, multi-tenant]
 supersedes: []
 superseded_by: []
-related: [0093, 0094, 0104, 0107, 0110, 0114, 0149, 0167, 0177]
+related: ["0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0104-processo-mwart-canonico-unico-caminho", "0107-emendation-0104-visual-comparison-gate-f3", "0110-cockpit-pattern-v2-canon-list-detail", "0114-prototipo-ui-cowork-loop-formalizado", "0149-mwart-screen-pattern-reuse-cowork", "0167-errata-0130-indice-handoff-historico-longo", "0177-mwart-excecao-cliente-show-wave-paralela"]
 charter_impact:
   - "Pages/Cliente/Show.charter.md v2 → status: superseded"
   - "Pages/Cliente/Index.charter.md draft → published v3 com drawer_pattern: 760px-lateral + 8 tabs"

--- a/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
+++ b/memory/decisions/0186-chain-certificado-sefaz-consulta-cadastro.md
@@ -7,7 +7,7 @@ status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-23
+decided_at: "2026-05-23"
 module: NfeBrasil
 quarter: 2026-Q2
 tags: [multi-tenant, fiscal, cert-a1, sefaz, lookup-cnpj, tier-zero, irrevogavel, no-regression]

--- a/memory/decisions/0189-pageheader-canon-v3-1-cadastro-roxo.md
+++ b/memory/decisions/0189-pageheader-canon-v3-1-cadastro-roxo.md
@@ -1,21 +1,21 @@
 ---
 slug: 0189-pageheader-canon-v3-1-cadastro-roxo
-number: 0189
+number: 189
 title: "PageHeader canon v3.1 — bloco fechado + KPI strip separado + ⋮ overflow + roxo médio cadastro"
 type: adr
 status: proposto
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-24
+decided_at: "2026-05-24"
 module: _DesignSystem
 quarter: 2026-Q2
 tags: [design-system, page-header, ui-canon, modern-saas, kpi-strip, overflow-menu]
 supersedes: []
-supersedes_partially: [0180, 0182]
+supersedes_partially: ["0180-drift-numero-adr-0178-conflito-paralelo", "0182-pageheadertabs-canon-pattern-telas"]
 superseded_by: []
 amended_by: [0190]
-related: [0094, 0104, 0114, 0180, 0182, 0185, 0187, 0190]
+related: ["0094-constituicao-v2-7-camadas-8-principios", "0104-processo-mwart-canonico-unico-caminho", "0114-prototipo-ui-cowork-loop-formalizado", "0180-drift-numero-adr-0178-conflito-paralelo", "0182-pageheadertabs-canon-pattern-telas", "0185-drawer-760-canon-entidades-cadastrais", "0187-constituicao-ui-v2-ponteiro-canon", "0190-primary-button-roxo-universal-295"]
 pii: false
 review_triggers:
   - Larissa biz=4 testar a v3.1 em prod e dar feedback negativo

--- a/memory/decisions/0191-microsoft-clarity-session-replay-lgpd.md
+++ b/memory/decisions/0191-microsoft-clarity-session-replay-lgpd.md
@@ -1,14 +1,14 @@
 ---
 slug: 0191-microsoft-clarity-session-replay-lgpd
-number: 0191
+number: 191
 title: "Microsoft Clarity como ferramenta canon de session replay + heatmap LGPD-compliant — 1 projeto global + custom tag business_id"
 type: adr
 status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]
-decided_at: 2026-05-25
-accepted_at: 2026-05-25
+decided_at: "2026-05-25"
+accepted_at: "2026-05-25"
 accepted_via: "Wagner aprovou em sessão `frosty-greider-83ab2f` 2026-05-25 — comando exato: 'Aceito — marca aceito + commit + começa PR 1 (banner)'. Decisão precedida por 4 escolhas explícitas via AskUserQuestion: (1) multi-tenant = 1 projeto + custom tag business_id, (2) consent banner = PR separado prerequisito, (3) mask PII = mask all default + unmask seguro, (4) carregar Clarity = só após autenticar."
 module: null
 quarter: 2026-Q2
@@ -16,7 +16,7 @@ tags: [observability, ux-analytics, lgpd, session-replay, heatmap, microsoft-cla
 supersedes: []
 supersedes_partially: []
 superseded_by: []
-related: [0061, 0062, 0093, 0094]
+related: ["0061-conhecimento-canonico-git-mcp-zero-automem", "0062-separacao-runtime-hostinger-ct100", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios"]
 pii: true
 review_triggers:
   - Larissa biz=4 reportar invasão de privacidade após ver session replay

--- a/memory/handoffs/2026-05-11-1730-sells-grade-oficinaauto-paralelizacao.md
+++ b/memory/handoffs/2026-05-11-1730-sells-grade-oficinaauto-paralelizacao.md
@@ -1,6 +1,6 @@
 ---
 title: Handoff 2026-05-11 — Sells Grade Avançada + Modules/OficinaAuto qualificada + 5 agents paralelos
-date: 2026-05-11
+date: "2026-05-11"
 cycle: CYCLE-05 (D1 — primeiro dia)
 sessao_owner: Wagner [W] + Claude (IA-pair)
 duracao: ~6h wallclock (com paralelização agents)

--- a/memory/handoffs/2026-05-14-1130-saga-maratona-fluxo-jana-routes-boletos.md
+++ b/memory/handoffs/2026-05-14-1130-saga-maratona-fluxo-jana-routes-boletos.md
@@ -1,6 +1,6 @@
 ---
 title: "Sessão maratona 2026-05-14 — F3 Fluxo + Jana amendment V2 + fix routes + F3 Boletos"
-date: 2026-05-14
+date: "2026-05-14"
 slug: 2026-05-14-1130-saga-maratona-fluxo-jana-routes-boletos
 type: handoff
 session_start: 2026-05-14 06:21 (extração Oimpresso-handoff.zip Claude Design)

--- a/memory/handoffs/2026-05-16-1640-governance-v3-completion-3prs-abertos.md
+++ b/memory/handoffs/2026-05-16-1640-governance-v3-completion-3prs-abertos.md
@@ -2,11 +2,11 @@
 slug: 2026-05-16-1640-governance-v3-completion-3prs-abertos
 title: "Governance module-grade v3 completion — Wave 2-3-4-5 · 3 PRs abertos"
 type: handoff
-date: 2026-05-16
+date: "2026-05-16"
 time: "16:40"
 participants: [W, claude]
 related_prs: [973, 974, 975, 976]
-related_adrs: [0155, 0156, 0154, 0153, 0094]
+related_adrs: ["0155-module-grade-v3-sub-dimensoes-gate-ci", "0156-module-grade-v3-errata-otel-helper-na-justified", "0154-module-grade-v2-na-justificado", "0153-module-grade-rubrica-v1", "0094-constituicao-v2-7-camadas-8-principios"]
 pii: false
 ---
 

--- a/memory/handoffs/2026-05-16-2100-governance-v3-mega-sessao-13-waves-65pp.md
+++ b/memory/handoffs/2026-05-16-2100-governance-v3-mega-sessao-13-waves-65pp.md
@@ -2,11 +2,11 @@
 slug: 2026-05-16-2100-governance-v3-mega-sessao-13-waves-65pp
 title: "Governance v3 mega-sessão completa — 13 Waves · ~85 agents · 12 PRs · média 49→65.9pp"
 type: handoff
-date: 2026-05-16
+date: "2026-05-16"
 time: "21:00"
 participants: [W, claude]
 related_prs: [973, 974, 975, 976, 977, 978, 979, 980, 981, 982]
-related_adrs: [0155, 0156, 0157, 0158, 0093, 0094, 0130]
+related_adrs: ["0155-module-grade-v3-sub-dimensoes-gate-ci", "0156-module-grade-v3-errata-otel-helper-na-justified", "0157-module-grade-v3-d2-detection-hardening", "0158-module-grade-v3-d1-heuristica-hardening", "0093-multi-tenant-isolation-tier-0", "0094-constituicao-v2-7-camadas-8-principios", "0130-handoff-append-only-mcp-first"]
 pii: false
 ---
 

--- a/memory/handoffs/2026-05-17-0700-governance-v4-final-ondas-19-28.md
+++ b/memory/handoffs/2026-05-17-0700-governance-v4-final-ondas-19-28.md
@@ -2,11 +2,11 @@
 slug: 2026-05-17-0700-governance-v4-final-ondas-19-28
 title: "Governance v4 final · 10 Ondas W19-W28 · 25 PRs · ~100 agents · média 78+ · 4/4 buckets meta atingida"
 type: handoff
-date: 2026-05-17
+date: "2026-05-17"
 time: "07:00"
 participants: [W, claude]
 related_prs: [973, 974, 975, 976, 977, 978, 979, 980, 981, 982, 983, 984, 985, 986, 987, 988, 989, 990, 991, 992, 993, 994, 995, 996, 997, 998, 999]
-related_adrs: [0155, 0156, 0157, 0158, 0159, 0160, 0161, 0162, 0163, 0094, 0105, 0130]
+related_adrs: ["0155-module-grade-v3-sub-dimensoes-gate-ci", "0156-module-grade-v3-errata-otel-helper-na-justified", "0157-module-grade-v3-d2-detection-hardening", "0158-module-grade-v3-d1-heuristica-hardening", "0159-module-grade-v3-errata-meta-97-realismo", "0160-governance-v4-scoped-scorecards-buckets", "0161-governance-v4-aposentar-hacks-0159-redundantes", "0162-otel-collector-prod-observability", "0163-governance-v4-metas-alcancadas-ondas-19-28", "0094-constituicao-v2-7-camadas-8-principios", "0105-cliente-como-sinal-guiar-sem-mandar", "0130-handoff-append-only-mcp-first"]
 pii: false
 ---
 

--- a/memory/handoffs/2026-05-19-1805-f3-paymentgateway-ui-completa-prod.md
+++ b/memory/handoffs/2026-05-19-1805-f3-paymentgateway-ui-completa-prod.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-19
+date: "2026-05-19"
 time: '18:05'
 slug: f3-paymentgateway-ui-completa-prod
 authors: [W, CL]

--- a/memory/handoffs/2026-05-20-1944-fin-bridge-larissa-accounting-deprec-complete.md
+++ b/memory/handoffs/2026-05-20-1944-fin-bridge-larissa-accounting-deprec-complete.md
@@ -1,7 +1,7 @@
 ---
 slug: 2026-05-20-1944-fin-bridge-larissa-accounting-deprec-complete
 title: "Handoff sessão tarde — Accounting deprec Ondas 0-5 + Larissa biz=4 bridge recovery R$ 12k→R$ 418k + canon"
-date: 2026-05-20
+date: "2026-05-20"
 hour_utc: 19:44
 owner: claude
 session_id: frosty-greider-83ab2f

--- a/memory/handoffs/2026-05-20-2000-fiscal-waves-5-9-mergeadas-score-102.md
+++ b/memory/handoffs/2026-05-20-2000-fiscal-waves-5-9-mergeadas-score-102.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-20
+date: "2026-05-20"
 time: "20:00"
 slug: fiscal-waves-5-9-mergeadas-score-102
 authors: [wagner, claude]

--- a/scripts/memory-schemas/backfill-frontmatter.py
+++ b/scripts/memory-schemas/backfill-frontmatter.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+"""
+Backfill conservador de frontmatter YAML em memory/decisions/*.md +
+memory/handoffs/*.md pra ratificar com schemas canon.
+
+Fixes aplicados (apenas LINHA-A-LINHA, sem re-serializar YAML):
+  1. `date: YYYY-MM-DD` → `date: "YYYY-MM-DD"` (aspas — schema quer string)
+  2. `decided_at: YYYY-MM-DD` → `decided_at: "YYYY-MM-DD"`
+  3. `accepted_at: YYYY-MM-DD` → idem
+  4. `number: 0NNN` → `number: NNN` (integer sem leading zero)
+  5. `related: [0061, ...]` → `related: ["0061-...", ...]` via mapping decisions/
+  6. `supersedes: [0061, ...]` → idem
+  7. `superseded_by: [0061, ...]` → idem
+  8. `related_adrs: [0061, ...]` → idem (handoffs)
+
+NÃO TOCA:
+  - Conteúdo markdown abaixo de `---`
+  - Strings que já estão aspeadas
+  - Campos required faltantes (decisão manual case-a-case)
+  - tldr > 500 chars (truncar é destrutivo — deixa pro humano)
+
+Modo `--check` apenas reporta o que mudaria sem aplicar.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+DECISIONS = ROOT / "memory" / "decisions"
+HANDOFFS = ROOT / "memory" / "handoffs"
+
+# Mapping NNNN → "NNNN-slug" via listing real de decisions/
+SLUG_MAP: dict[str, str] = {}
+for p in DECISIONS.glob("*.md"):
+    name = p.stem  # ex: "0191-microsoft-clarity-session-replay-lgpd"
+    m = re.match(r"^(\d{4})-(.+)$", name)
+    if m:
+        num = m.group(1)
+        # Se já houver mapping (caso 0170 tenha 2 ADRs), pegar o primeiro encontrado
+        SLUG_MAP.setdefault(num, name)
+
+
+def expand_related_items(line: str) -> str:
+    """
+    Converte arrays inline tipo `related: [0061, 0062]` → `related: ["0061-slug", "0062-slug"]`.
+    Preserva comentários e indentação.
+    """
+    m = re.match(r"^(\s*)(related|supersedes|superseded_by|related_adrs|relacionada_a|errata_de|supersedes_partially)(\s*:\s*)\[([^\]]+)\](.*)$", line)
+    if not m:
+        return line
+
+    indent, key, sep, inner, tail = m.groups()
+    items = [x.strip() for x in inner.split(",") if x.strip()]
+    if not items:
+        return line
+
+    new_items: list[str] = []
+    changed = False
+    for it in items:
+        # Remove aspas existentes pra normalizar
+        clean = it.strip().strip('"').strip("'")
+        # Caso 1: já está no formato "NNNN-slug" (com ou sem aspas)
+        if re.match(r"^\d{4}-[a-z0-9-]+$", clean):
+            new_items.append(f'"{clean}"')
+        # Caso 2: só NNNN (integer ou string curta)
+        elif re.match(r"^\d{1,4}$", clean):
+            num = clean.zfill(4)
+            slug = SLUG_MAP.get(num)
+            if slug:
+                new_items.append(f'"{slug}"')
+                changed = True
+            else:
+                # Sem mapping — usa placeholder explícito
+                new_items.append(f'"{num}-unknown"')
+                changed = True
+        else:
+            # Outros padrões (path absoluto, slug livre) — mantém aspeado
+            new_items.append(f'"{clean}"')
+            if not (it.startswith('"') or it.startswith("'")):
+                changed = True
+
+    if not changed and inner.count('"') >= len(items):
+        return line  # nada mudou + tudo já aspeado
+
+    # Preserva line ending da linha original (CRLF/LF/nenhum)
+    if line.endswith("\r\n"):
+        eol = "\r\n"
+    elif line.endswith("\n"):
+        eol = "\n"
+    else:
+        eol = ""
+    tail_clean = tail.rstrip("\r\n")
+    return f"{indent}{key}{sep}[{', '.join(new_items)}]{tail_clean}{eol}"
+
+
+# Canonização status legacy → ADR enum válido
+STATUS_MAP = {
+    "accepted": "aceito",
+    "Accepted": "aceito",
+    "ACCEPTED": "aceito",
+    "proposed": "proposto",
+    "Proposed": "proposto",
+    "PROPOSED": "proposto",
+    "draft": "rascunho",
+    "Draft": "rascunho",
+    "DRAFT": "rascunho",
+    "deprecated": "deprecated",
+    "Deprecated": "deprecated",
+    "superseded": "superseded",
+    "Superseded": "superseded",
+}
+
+# Canonização decided_by string → array [W/F/M/L/E]
+USER_MAP = {
+    "wagner": "W",
+    "Wagner": "W",
+    "felipe": "F",
+    "Felipe": "F",
+    "maiara": "M",
+    "Maiara": "M",
+    "luiz": "L",
+    "Luiz": "L",
+    "eliana": "E",
+    "Eliana": "E",
+}
+
+
+def fix_line(line: str) -> tuple[str, bool]:
+    """Retorna (linha_corrigida, mudou). Preserva line ending original (CRLF/LF)."""
+    original = line
+
+    # Detecta line ending pra reaplicar fielmente
+    if line.endswith("\r\n"):
+        eol = "\r\n"
+        body = line[:-2]
+    elif line.endswith("\n"):
+        eol = "\n"
+        body = line[:-1]
+    else:
+        eol = ""
+        body = line
+
+    # 1-3. Quote ISO date em campos date/decided_at/accepted_at (sem aspas)
+    m = re.match(r'^(\s*)(date|decided_at|accepted_at)(\s*:\s*)(\d{4}-\d{2}-\d{2})(\s*)$', body)
+    if m:
+        indent, key, sep, dt, _ = m.groups()
+        body = f'{indent}{key}{sep}"{dt}"'
+
+    # 4. number: 0NNN → number: NNN
+    m = re.match(r'^(\s*)number(\s*:\s*)0+(\d{1,4})(\s*)$', body)
+    if m:
+        indent, sep, n, _ = m.groups()
+        body = f'{indent}number{sep}{int(n)}'
+
+    # 4b. status: legacy → enum válido pra ADR
+    m = re.match(r'^(\s*)status(\s*:\s*)(["\']?)([A-Za-z]+)(["\']?)(\s*)$', body)
+    if m:
+        indent, sep, q1, val, q2, _ = m.groups()
+        if val in STATUS_MAP and val != STATUS_MAP[val]:
+            body = f'{indent}status{sep}{STATUS_MAP[val]}'
+
+    # 4c. decided_by: wagner (string singleton) → [W]
+    m = re.match(r'^(\s*)decided_by(\s*:\s*)(["\']?)([A-Za-z]+)(["\']?)(\s*)$', body)
+    if m:
+        indent, sep, q1, val, q2, _ = m.groups()
+        if val in USER_MAP:
+            body = f'{indent}decided_by{sep}[{USER_MAP[val]}]'
+
+    # 4d. accepted_by: wagner → decided_by: [W] alias (preserva ambos por compat)
+    m = re.match(r'^(\s*)accepted_by(\s*:\s*)(["\']?)([A-Za-z]+)(["\']?)(\s*)$', body)
+    if m:
+        indent, sep, q1, val, q2, _ = m.groups()
+        if val in USER_MAP:
+            # Substitui accepted_by por decided_by canon (mais correto)
+            body = f'{indent}decided_by{sep}[{USER_MAP[val]}]'
+
+    # 4e. authors: [wagner, claude] → ignora; ADR não usa esse campo
+    # (campo authors é legacy livre, schema additionalProperties: true aceita)
+
+    # 4f. adr: 0NNN (legacy field não padronizado) → number: NNN
+    m = re.match(r'^(\s*)adr(\s*:\s*)0*(\d{1,4})(\s*)$', body)
+    if m:
+        indent, sep, n, _ = m.groups()
+        body = f'{indent}number{sep}{int(n)}'
+
+    # 5-8. Expand related/supersedes/superseded_by/related_adrs com NNNN puro
+    expanded = expand_related_items(body + eol)
+    # expand_related_items pode adicionar \n se entrada não tem; normaliza pro eol original
+    if expanded.endswith("\n") and not expanded.endswith("\r\n") and eol == "\r\n":
+        expanded = expanded[:-1] + eol
+    elif expanded.endswith("\n") and eol == "":
+        expanded = expanded[:-1]
+
+    return expanded, expanded != original
+
+
+def process_file(path: Path, dry_run: bool) -> int:
+    """Retorna número de linhas alteradas no frontmatter."""
+    text = path.read_text(encoding="utf-8")
+    lines = text.splitlines(keepends=True)
+
+    if not lines or not lines[0].startswith("---"):
+        return 0
+
+    # Localiza fim do frontmatter
+    end_idx = None
+    for i, l in enumerate(lines[1:], start=1):
+        if l.strip() == "---":
+            end_idx = i
+            break
+    if end_idx is None:
+        return 0
+
+    changed = 0
+    new_fm = []
+    for l in lines[:end_idx + 1]:
+        new_l, did_change = fix_line(l)
+        if did_change:
+            changed += 1
+        new_fm.append(new_l)
+
+    if changed == 0:
+        return 0
+
+    new_content = "".join(new_fm) + "".join(lines[end_idx + 1:])
+    if not dry_run:
+        path.write_text(new_content, encoding="utf-8", newline="")
+
+    return changed
+
+
+def main() -> int:
+    dry_run = "--check" in sys.argv
+
+    total_files = 0
+    total_lines = 0
+
+    for folder in [DECISIONS, HANDOFFS]:
+        if not folder.exists():
+            continue
+        for p in sorted(folder.glob("*.md")):
+            if p.stem.startswith("_") or p.stem == "README":
+                continue
+            n = process_file(p, dry_run)
+            if n > 0:
+                total_files += 1
+                total_lines += n
+                print(f"  [{'DRY' if dry_run else 'FIX'}] {p.relative_to(ROOT)} ({n} lines)")
+
+    print()
+    print(f"{'[DRY-RUN] would fix' if dry_run else 'Fixed'}: {total_files} arquivos, {total_lines} linhas")
+    print(f"SLUG_MAP cached: {len(SLUG_MAP)} ADRs")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Resolve warnings de schema gate apontados no review do PR #1563 (memory-schema-gate). Script Python idempotente em `scripts/memory-schemas/backfill-frontmatter.py` aplica fixes conservadores line-a-line.

## Score

| Schema | Antes | Depois | Δ |
|---|---:|---:|---:|
| ADR (memory/decisions) | 179 | 101 | -78 (-44%) |
| Handoff (memory/handoffs) | 15 | 13 | -2 (-13%) |
| **Total** | **194** | **114** | **-80 (-41%)** |

## Fixes aplicados (line-a-line, preserva CRLF/LF + markdown)

1. `date/decided_at/accepted_at`: ISO sem aspas → com aspas (YAML não interpreta como Date)
2. `number: 0NNN` → `number: NNN` (integer schema)
3. `related/supersedes/superseded_by/related_adrs`: `[0061, 0062]` → `["0061-slug", "0062-slug"]` via mapping real de 185 ADRs
4. `status: accepted` → `aceito` (enum schema PT-BR)
5. `decided_by: wagner` (string) → `[W]` (array com user code)
6. `accepted_by` legacy → `decided_by` canon
7. `adr: 0NNN` legacy → `number` canon

## NÃO toca

- Conteúdo markdown abaixo de `---`
- Strings já aspeadas
- Campos required totalmente faltantes (decisão manual case-a-case)
- `tldr > 500 chars` (truncar é destrutivo — humano decide)

## Pendências (114 restantes — manual)

- ADRs antigas sem fields required (slug, number, type, etc)
- `decided_at` integer (timestamp epoch 1779580800 — parser quirky)
- related items apontando pra ADRs novas (192+) sem mapping
- Handoff tldr > 500 chars

## Como rodar

```bash
python scripts/memory-schemas/backfill-frontmatter.py --check   # dry-run
python scripts/memory-schemas/backfill-frontmatter.py            # aplica
```

Idempotente — segura pra rodar repetidas vezes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)