### PR TITLE
feat(jana): propagar JanaAreaHeader sticky nas 6 telas faltantes

### DIFF
--- a/resources/js/Pages/Jana/Admin/Custos/Index.tsx
+++ b/resources/js/Pages/Jana/Admin/Custos/Index.tsx
@@ -14,7 +14,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/Com
 import { Button } from '@/Components/ui/button';
 import { Input } from '@/Components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
-import PageHeader from '@/Components/shared/PageHeader';
+import { JanaAreaHeader } from '@/Pages/Jana/components/JanaAreaHeader';
+import { Coins } from 'lucide-react';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
 
@@ -208,19 +209,26 @@ function CustosIaIndex(props: Props) {
 
   return (
     <>
-      <PageHeader
-        icon="coins"
-        title="Custos de IA"
-        description={`Visão de consumo do Copiloto — ${periodo.label}`}
-        action={
-          <div className="text-xs text-muted-foreground text-right">
-            <div>
-              Modelo base: <span className="font-mono">{pricing.modelo_default}</span>
-            </div>
-            <div>Câmbio: R$ {pricing.cambio_brl_usd.toFixed(2)} / US$</div>
+      <JanaAreaHeader active="custos" />
+
+      {/* Title local da tela — preservado pós-migração JanaAreaHeader (Wagner 2026-05-25) */}
+      <div className="px-6 pt-6 flex items-start justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <Coins className="size-6 text-primary" />
+          <div>
+            <h1 className="text-xl font-semibold">Custos de IA</h1>
+            <p className="text-sm text-muted-foreground">
+              Visão de consumo do Copiloto — {periodo.label}
+            </p>
           </div>
-        }
-      />
+        </div>
+        <div className="text-xs text-muted-foreground text-right shrink-0">
+          <div>
+            Modelo base: <span className="font-mono">{pricing.modelo_default}</span>
+          </div>
+          <div>Câmbio: R$ {pricing.cambio_brl_usd.toFixed(2)} / US$</div>
+        </div>
+      </div>
 
       <KpiGrid cols={4} className="mt-6">
         <KpiCard

--- a/resources/js/Pages/Jana/Admin/Governanca/Index.tsx
+++ b/resources/js/Pages/Jana/Admin/Governanca/Index.tsx
@@ -14,7 +14,8 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/Com
 import { Button } from '@/Components/ui/button';
 import { Input } from '@/Components/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
-import PageHeader from '@/Components/shared/PageHeader';
+import { JanaAreaHeader } from '@/Pages/Jana/components/JanaAreaHeader';
+import { ShieldCheck } from 'lucide-react';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
 import StatusBadge from '@/Components/shared/StatusBadge';
@@ -217,17 +218,24 @@ function GovernancaIndex(props: Props) {
 
   return (
     <>
-      <PageHeader
-        icon="shield-check"
-        title="Governança MCP"
-        description={`Consumo cross-team do MCP server — ${periodo.label}`}
-        action={
-          <div className="text-xs text-muted-foreground text-right">
-            <div>Endpoint: <span className="font-mono">mcp.oimpresso.com</span></div>
-            <div>Audit: <span className="font-mono">mcp_audit_log</span> (append-only)</div>
+      <JanaAreaHeader active="governanca-mcp" />
+
+      {/* Title local da tela — preservado pós-migração JanaAreaHeader (Wagner 2026-05-25) */}
+      <div className="px-6 pt-6 flex items-start justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <ShieldCheck className="size-6 text-primary" />
+          <div>
+            <h1 className="text-xl font-semibold">Governança MCP</h1>
+            <p className="text-sm text-muted-foreground">
+              Consumo cross-team do MCP server — {periodo.label}
+            </p>
           </div>
-        }
-      />
+        </div>
+        <div className="text-xs text-muted-foreground text-right shrink-0">
+          <div>Endpoint: <span className="font-mono">mcp.oimpresso.com</span></div>
+          <div>Audit: <span className="font-mono">mcp_audit_log</span> (append-only)</div>
+        </div>
+      </div>
 
       {/* Sub-navegação por seção — variante underline */}
       <SubNav

--- a/resources/js/Pages/Jana/Admin/Qualidade/Index.tsx
+++ b/resources/js/Pages/Jana/Admin/Qualidade/Index.tsx
@@ -17,7 +17,8 @@ import { Badge } from '@/Components/ui/badge';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
 import { Label } from '@/Components/ui/label';
 import { ScrollArea } from '@/Components/ui/scroll-area';
-import PageHeader from '@/Components/shared/PageHeader';
+import { JanaAreaHeader } from '@/Pages/Jana/components/JanaAreaHeader';
+import { TrendingUp } from 'lucide-react';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
 
@@ -153,11 +154,18 @@ function QualidadeIndex(props: Props) {
 
   return (
     <>
-      <PageHeader
-        icon="trending-up"
-        title="Qualidade IA"
-        description={`Trend ${filtros.dias}d das 8 métricas obrigatórias + 3 RAGAS. Gates ADR 0049/0050. Eval contra gabarito ${gabarito_total} perguntas.`}
-      />
+      <JanaAreaHeader active="qualidade-jana" />
+
+      {/* Title local da tela — preservado pós-migração JanaAreaHeader (Wagner 2026-05-25) */}
+      <div className="px-6 pt-6 flex items-center gap-3">
+        <TrendingUp className="size-6 text-primary" />
+        <div>
+          <h1 className="text-xl font-semibold">Qualidade IA</h1>
+          <p className="text-sm text-muted-foreground">
+            Trend {filtros.dias}d das 8 métricas obrigatórias + 3 RAGAS. Gates ADR 0049/0050. Eval contra gabarito {gabarito_total} perguntas.
+          </p>
+        </div>
+      </div>
 
       <Card className="mt-4">
         <CardContent className="py-3 flex flex-wrap items-end gap-3">

--- a/resources/js/Pages/Jana/Admin/Roadmap.tsx
+++ b/resources/js/Pages/Jana/Admin/Roadmap.tsx
@@ -14,7 +14,8 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { router } from '@inertiajs/react';
 import { useMemo, useState, useCallback } from 'react';
-import PageHeader from '@/Components/shared/PageHeader';
+import { JanaAreaHeader } from '@/Pages/Jana/components/JanaAreaHeader';
+import { GitBranch } from 'lucide-react';
 import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
 import {
   Select,
@@ -379,28 +380,33 @@ function RoadmapIndex(props: Props) {
 
   return (
     <>
-      <PageHeader
-        icon="git-branch"
-        title="Roadmap"
-        description={
-          cycleAtual
-            ? `${cycleAtual.key} — ${cycleAtual.goal ?? 'sem goal definido'}`
-            : 'Visão cronológica de cycles e tasks (MCP)'
-        }
-        action={
-          <div className="text-xs text-muted-foreground text-right">
-            <div>
-              {tasks.length} task{tasks.length === 1 ? '' : 's'} no filtro atual
-            </div>
-            {active_cycle_id && (
-              <div className="text-[10px]">
-                Cycle ativo:{' '}
-                {cycles.find((c) => c.id === active_cycle_id)?.key ?? '—'}
-              </div>
-            )}
+      <JanaAreaHeader active="roadmap" />
+
+      {/* Title local da tela — preservado pós-migração JanaAreaHeader (Wagner 2026-05-25) */}
+      <div className="px-6 pt-6 flex items-start justify-between gap-4">
+        <div className="flex items-center gap-3">
+          <GitBranch className="size-6 text-primary" />
+          <div>
+            <h1 className="text-xl font-semibold">Roadmap</h1>
+            <p className="text-sm text-muted-foreground">
+              {cycleAtual
+                ? `${cycleAtual.key} — ${cycleAtual.goal ?? 'sem goal definido'}`
+                : 'Visão cronológica de cycles e tasks (MCP)'}
+            </p>
           </div>
-        }
-      />
+        </div>
+        <div className="text-xs text-muted-foreground text-right shrink-0">
+          <div>
+            {tasks.length} task{tasks.length === 1 ? '' : 's'} no filtro atual
+          </div>
+          {active_cycle_id && (
+            <div className="text-[10px]">
+              Cycle ativo:{' '}
+              {cycles.find((c) => c.id === active_cycle_id)?.key ?? '—'}
+            </div>
+          )}
+        </div>
+      </div>
 
       {/* Filtros */}
       <Card className="mt-6 mb-4">

--- a/resources/js/Pages/Jana/Cockpit.tsx
+++ b/resources/js/Pages/Jana/Cockpit.tsx
@@ -20,6 +20,7 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { BusinessOpt } from '@/Components/cockpit/shared';
+import { JanaAreaHeader } from './components/JanaAreaHeader';
 
 // ─── Tipos ─────────────────────────────────────────────────────────────
 
@@ -954,6 +955,7 @@ export default function Cockpit({
       }}
     >
       <Head title="Jana · Cockpit" />
+      <JanaAreaHeader active="cockpit" />
       <div className="px-6 py-5 max-w-[1280px] mx-auto">
         <JanaHeader data={jana} businessNome={businessNome} />
 

--- a/resources/js/Pages/Jana/Painel.tsx
+++ b/resources/js/Pages/Jana/Painel.tsx
@@ -10,6 +10,7 @@
 import React from 'react'
 import { Head } from '@inertiajs/react'
 import AppShellV2 from '@/Layouts/AppShellV2'
+import { JanaAreaHeader } from './components/JanaAreaHeader'
 
 interface BriefData {
   greeting: string
@@ -74,6 +75,7 @@ export default function Painel({ business, painel }: Props) {
   return (
     <AppShellV2 title="Jana · Painel">
       <Head title="Jana · Painel" />
+      <JanaAreaHeader active="painel" />
 
       <div className="jc-page" data-screen-label="Jana — Dashboard">
         <header className="jc-header">

--- a/resources/js/Pages/Jana/components/JanaAreaHeader.tsx
+++ b/resources/js/Pages/Jana/components/JanaAreaHeader.tsx
@@ -30,24 +30,33 @@ export type JanaAreaTab =
   | 'chat'      // = copiloto
   | 'dashboard'
   | 'memoria'   // = memorias
-  | 'cockpit'   // = copiloto (consolidado)
+  | 'cockpit'   // ghost canon próprio (DataController Wagner 2026-05-25)
   | 'custos'
   | 'metas'
   | 'brief'
   | 'kb'
   | 'regras'
   | 'copiloto'
-  | 'memorias';
+  | 'memorias'
+  // Wagner 2026-05-25 (propagação JanaAreaHeader pra 6 telas faltantes):
+  | 'painel'
+  | 'roadmap'
+  | 'governanca-mcp'
+  | 'qualidade-jana';
 
-// Map retrocompat — telas antigas passam 'chat'/'memoria'/etc; convertemos pro
-// ghost key canon do DataController Jana.
+// Map retrocompat — telas antigas passam 'chat'/'memoria'; convertemos pro
+// ghost key canon do DataController Jana. NOTA: 'cockpit' tem ghost próprio
+// desde Wagner 2026-05-25 (DataController linha 268), não cai mais em 'copiloto'.
 function mapActiveToGhostKey(active: JanaAreaTab): string {
   switch (active) {
     case 'chat':
-    case 'cockpit':
       return 'copiloto';
     case 'memoria':
       return 'memorias';
+    case 'painel':
+      // Painel.tsx é mock Onda A1 (sobreposto ao Cockpit). Não tem ghost próprio
+      // — usa 'copiloto' como destaque ativo (Wagner avalia se promove a ghost).
+      return 'copiloto';
     default:
       return active;
   }


### PR DESCRIPTION
## Summary

Aplica o pattern canon do header da Jana (`JanaAreaHeader` sticky com dot azul `oklch(0.62 0.13 220)` + `JanaSubNav` ARIA + primary `Conversar`) nas **6 telas Jana** que ainda usavam header customizado ou `PageHeader` shared genérico. Consistência UX entre todos os ghosts do hub IA.

Wagner aprovou caminho **"Propagar JanaAreaHeader (sticky)"** via `AskUserQuestion` em sessão 2026-05-25 (alternativas: migrar tudo pro `os-page-h` canon ou híbrido).

## Telas afetadas (6)

| Tela | Mudança |
|---|---|
| `Pages/Jana/Cockpit.tsx` | `<JanaAreaHeader active="cockpit">` antes do `<JanaHeader>` local |
| `Pages/Jana/Painel.tsx` | `<JanaAreaHeader active="painel">` antes do `<header.jc-header>` |
| `Pages/Jana/Admin/Roadmap.tsx` | substitui `<PageHeader>` por `<JanaAreaHeader active="roadmap">` + title local com `<GitBranch>` + contador tasks/cycle preservado |
| `Pages/Jana/Admin/Governanca/Index.tsx` | `<JanaAreaHeader active="governanca-mcp">` + title local `<ShieldCheck>` + endpoint/audit preservados |
| `Pages/Jana/Admin/Qualidade/Index.tsx` | `<JanaAreaHeader active="qualidade-jana">` + title local `<TrendingUp>` |
| `Pages/Jana/Admin/Custos/Index.tsx` | `<JanaAreaHeader active="custos">` + title local `<Coins>` + modelo/câmbio preservados |

## Bugfix colateral em `JanaAreaHeader.tsx`

- **Map fix**: `cockpit → cockpit` (não mais `cockpit → copiloto`). Ghost `cockpit` canon existe no `DataController` desde Wagner 2026-05-25 (linha 268).
- **Novos keys** no type `JanaAreaTab`: `painel`, `roadmap`, `governanca-mcp`, `qualidade-jana`.

## Não-mudanças

- `DataController.php` permanece canon ✅ (group `ia`, shortcut `G I`, primary `Conversar com Jana`, 13 ghosts).
- 5 telas que já usavam `JanaAreaHeader` (Dashboard, Chat, Memoria, Brief, Regras) — não tocadas.

## Validação

- ✅ `npm run typecheck` — 0 erros nas telas Jana (só warning pré-existente `baseUrl` no `tsconfig.json`)
- ✅ `npm run build:inertia` — bundle gerado (Cockpit/Roadmap/etc), 2m29s, sem erros

## Test plan

- [ ] Após deploy: abrir `/ia/cockpit` — header sticky com SubNav ativo em `cockpit`
- [ ] Abrir `/ia/painel` — header sticky + ghost `copiloto` ativo (`painel` mapeia pra `copiloto` no SubNav)
- [ ] Abrir `/ia/admin/roadmap` — header + title local com contador tasks/cycle preservado
- [ ] Abrir `/ia/admin/governanca` — header + title local com endpoint MCP preservado
- [ ] Abrir `/ia/admin/qualidade` — header + title local com gates ADR 0049/0050
- [ ] Abrir `/ia/admin/custos` — header + title local com modelo/câmbio

Refs: skill `pageheader-canon` · [ADR 0180](memory/decisions/0180-sidebar-v3-5-grupos-ghosts-header.md) · [ADR 0182](memory/decisions/0182-pageheadertabs-canon-pattern-telas.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)