### PR TITLE
fix(nfe): retransmitir usa UPDATE preservation (CONFAZ Art. 14) em vez de forceDelete

### DIFF
--- a/Modules/NfeBrasil/Services/NfeService.php
+++ b/Modules/NfeBrasil/Services/NfeService.php
@@ -849,14 +849,17 @@ class NfeService
      * oficialmente). Retransmitir = pegar próximo número novo + re-enviar pra
      * SEFAZ com payload re-derivado da Transaction associada.
      *
-     * Estratégia:
+     * Estratégia (CONFAZ SINIEF 07/2005 Art. 14 preservation IRREVOGÁVEL —
+     * Wave 27/28 saturation D6/D2 enforce ZERO hard-delete em NfeEmissao):
      *  1. Valida emissao status in [rejeitada, denegada, erro_envio]
      *  2. Cross-tenant guard
      *  3. Verifica transaction_id != null (emissões manuais sem TX exigem
      *     scope dedicado — fora deste PR)
-     *  4. `forceDelete()` na NfeEmissao antiga (libera UNIQUE constraint
-     *     business_id+transaction_id). Audit preservado via Spatie LogsActivity
-     *     (Wave 18 D7 — log captura status/cstat/motivo/numero/chave_44).
+     *  4. **UPDATE** na NfeEmissao antiga (NUNCA hard-delete — documento fiscal
+     *     imutável): `status='inutilizada'` + `transaction_id=null` (libera UNIQUE
+     *     biz+tx pra a nova emissão) + `metadata.original_transaction_id` (audit
+     *     trail) + `metadata.retransmitido_em`. Spatie LogsActivity (Wave 18 D7)
+     *     captura o `updated` event automaticamente.
      *  5. Chama `emitirParaTransaction($tx, $modelo)` que cria NfeEmissao NOVA
      *     com próximo número (proximoNumeroLocked withTrashed = sequencial
      *     fiscal monotônico, sem reuso).
@@ -948,12 +951,25 @@ class NfeService
             'transaction_id' => $tx->id,
         ]);
 
-        // ── 5. forceDelete antigo (libera UNIQUE biz+tx; audit via Spatie) ──
-        // Spatie LogsActivity (Wave 18 D7) já registrou 'updated' nas mudanças
-        // status anteriores. O 'deleted' event aqui não loga payload completo
-        // (logOnly em getActivitylogOptions captura apenas chave_44/numero/etc).
-        // Pra audit fiscal trail: activity_log + NfeEvento (eventos SEFAZ associados).
-        $emissao->forceDelete();
+        // ── 5. UPDATE antigo (preserva audit CONFAZ Art. 14 — NUNCA hard-delete) ──
+        // Wave 27/28 saturation D6/D2 IRREVOGÁVEL: remoção física de NfeEmissao
+        // viola CONFAZ SINIEF 07/2005 Art. 14 (documento fiscal imutável). Em
+        // vez disso: status='inutilizada' + transaction_id=null libera a UNIQUE
+        // biz+tx (MySQL trata NULL como distinto em UNIQUE), preservando o row
+        // na tabela com audit completo. Spatie LogsActivity captura o 'updated'
+        // automaticamente; metadata.original_transaction_id mantém referência
+        // pra recuperação caso preciso futuramente.
+        $emissao->update([
+            'status' => 'inutilizada',
+            'transaction_id' => null,
+            'metadata' => array_merge((array) ($emissao->metadata ?? []), [
+                'original_transaction_id' => $tx->id,
+                'retransmitido_em' => now()->toIso8601String(),
+                'retransmitido_por_business' => $businessId,
+                'status_antes_retransmissao' => $statusOriginal,
+                'cstat_antes_retransmissao' => $cstatOriginal,
+            ]),
+        ]);
 
         // ── 6. Re-emite via fluxo canon emitirParaTransaction ──────────────
         // Cria NfeEmissao NOVA com próximo número (proximoNumeroLocked


### PR DESCRIPTION
## Resumo

Fix Wave 26/27/28 NfeBrasil saturation tests + drift entre SPEC US-FISCAL-014 e implementação.

## Problema

PR #1573 expôs (no CI) que `Modules\NfeBrasil\Tests\Feature\Wave{26,27,28}*Test` falhavam com:

> Expecting '<?phpdeclare(strict_types…}}' not to contain 'forceDelete'.

`NfeService::retransmitirInterno()` linha 956 chamava `\$emissao->forceDelete()` apesar do SPEC US-FISCAL-014 declarar explicitamente:

> [x] NUNCA usa \`->forceDelete()\` — documento fiscal imutável CONFAZ Art. 14

Implementação original **violava o intent declarado**: SPEC marcava acceptance como done mas código fazia hard-delete. CONFAZ SINIEF 07/2005 Art. 14 exige **preservação** do documento fiscal mesmo após inutilização/retransmissão.

## Fix conforme SPEC

Substitui hard-delete por UPDATE preservation:

\`\`\`php
\$emissao->update([
    'status' => 'inutilizada',
    'transaction_id' => null,  // libera UNIQUE biz+tx (NULL distinto em MySQL)
    'metadata' => array_merge((array) (\$emissao->metadata ?? []), [
        'original_transaction_id' => \$tx->id,
        'retransmitido_em' => now()->toIso8601String(),
        'retransmitido_por_business' => \$businessId,
        'status_antes_retransmissao' => \$statusOriginal,
        'cstat_antes_retransmissao' => \$cstatOriginal,
    ]),
]);
\`\`\`

### Audit preservado

- **Spatie LogsActivity** (Wave 18 D7) captura o `updated` event automaticamente em `activity_log`
- `metadata.original_transaction_id` mantém referência pra recuperação caso preciso
- Row da emissão antiga permanece na tabela com audit completo (vs hard-delete que apagaria)
- `emitirParaTransaction()` cria NfeEmissao **nova** com próximo número (`proximoNumeroLocked withTrashed` = sequencial monotônico sem reuso) — fluxo canon intacto

### Por que NULL libera UNIQUE

MySQL trata `NULL` como **distinto** em índices UNIQUE — múltiplos rows com `transaction_id = NULL` coexistem. A UNIQUE constraint `(business_id, transaction_id)` permite múltiplas inutilizadas + uma ativa por transação.

## Tests

**Locais NfeBrasil Wave26/27/28:** 39 passed · 1 skipped · **0 failed** (antes 3 failed).

\`\`\`
Tests:    1 skipped, 39 passed (87 assertions)
Duration: 14.37s
\`\`\`

Outros fails na suite NfeBrasil (CertificadoServiceTest, 8 TypeError) são pré-existentes em main por SQLite vs schema MySQL UPos missing — NÃO relacionados a este fix.

## Test plan

- [x] Pest local Wave26/27/28 verde
- [x] Pest local NfeBrasil suite total — 8 fails pré-existentes (CertificadoServiceTest TypeError, mesma falha em main)
- [ ] CI \`gh pr checks\` verde no contexto deste PR
- [ ] Wagner aprova merge

## Não-mudanças intencionais

- `CertificadoServiceTest` fails NÃO tocados — escopo separado (schema test fixtures)
- Fluxo `emitirParaTransaction` permanece — só substituí a destruição da row antiga
- Spatie LogsActivity não precisa configuração nova — captura `updated` automaticamente

Refs: PR #1573 (Onda ESTABILIZAR Fiscal) · CONFAZ SINIEF 07/2005 Art. 14 · SPEC US-FISCAL-014

🤖 Generated with [Claude Code](https://claude.com/claude-code)