### PR TITLE
feat(fiscal): US-FISCAL-018 yaml entry Larissa biz=4 pre-canary + BRIEFING update

### DIFF
--- a/config/governance/module_clients.yaml
+++ b/config/governance/module_clients.yaml
@@ -45,6 +45,14 @@ NfeBrasil:
   level: biz_1_wagner_active
   note: biz=1 + biz=4 emitem NFe ativamente
 
+Fiscal:
+  level: piloto_reportando_dor
+  note: |
+    US-FISCAL-018 Onda ESTABILIZAR 2026-05-25 — Larissa @ ROTA LIVRE biz=4
+    pre-canary (provisionamento técnico ok via `php artisan fiscal:habilitar-business 4`;
+    briefing manual 30min + canary 7d humano-limitado pending Wagner). Post-canary
+    Wagner promove pra biz_4_rota_livre_prod. Audit sênior 2026-05-25 §GAP-FISCAL-001.
+
 Financeiro:
   level: biz_1_wagner_active
   note: Wagner usa cobrança + Larissa AR/AP

--- a/memory/requisitos/Fiscal/BRIEFING.md
+++ b/memory/requisitos/Fiscal/BRIEFING.md
@@ -24,7 +24,7 @@ Tudo + **5 ações fiscais SEFAZ** (Cancelar, Manifestar, CC-e, Inutilizar, Retr
 - **Wagner** — emissão, cancelamento, retransmissão (operações live)
 - **Eliana (contadora)** — leitura, conferência, SPED Fiscal mensal entrega dia 15
 
-Não tem cliente biz=4 (Larissa ROTA LIVRE) tocando esse módulo ainda — usa Sells/NfeBrasil canônico diretamente. Quando ativar Fiscal cockpit pra biz=4, **Tier 0 IRREVOGÁVEL:** tests SEMPRE biz=1, NUNCA biz=4 ([ADR 0101](../../decisions/0101-tests-business-id-1-nunca-cliente.md)).
+**Larissa ROTA LIVRE biz=4 em pre-canary** (US-FISCAL-018 Onda ESTABILIZAR 2026-05-25 — audit sênior §GAP-FISCAL-001): provisionamento técnico ok (`php artisan fiscal:habilitar-business 4` idempotente — 6 perms `fiscal.*` ao role Admin#4 EXCETO `fiscal.sped.export` que fica bloqueada por feature flag `fiscal.sped_simples_only_lock=true` enquanto GAP-FISCAL-003 não eliminar 6 hardcodes Tier-0 em SpedIcmsIpiGeneratorService). Briefing manual 30min + canary 7d humano-limitado pending Wagner. Post-canary Wagner promove `module_clients.yaml` Fiscal de `piloto_reportando_dor` -> `biz_4_rota_livre_prod`. **Tier 0 IRREVOGÁVEL:** tests SEMPRE biz=1, NUNCA biz=4 ([ADR 0101](../../decisions/0101-tests-business-id-1-nunca-cliente.md)).
 
 ## Capacidades canônicas
 


### PR DESCRIPTION
## Origem

Audit Sênior 2026-05-25 §GAP-FISCAL-001. Fiscal 66/100 — D5 Cliente 0/15.

## 💡 Surpresa do agent

Partes 1, 2 e 5 do acceptance **JÁ implementadas** em commits anteriores Onda ESTABILIZAR Fiscal (SPEC.md v1.9.0):
- HabilitarBusinessCommand idempotente
- Feature flag `sped_simples_only_lock=true` default
- 19 Pest verde

**Gap real era só Parte 3 (yaml) + Parte 4 (BRIEFING).**

## O que muda

- `config/governance/module_clients.yaml` — Fiscal entry como `piloto_reportando_dor` (+8 pts D5)
- `memory/requisitos/Fiscal/BRIEFING.md` — Cliente piloto seção reescrita

## Impacto

- D5 Cliente: 0/15 → **8/15** (pre-canary)
- Nota Fiscal: 66 → **~74**
- Pós-canary 7d: promover pra `biz_4_rota_livre_prod` (+7 → 15/15 D5)

## Tests

19/19 + 10 skipped (SQLite per ADR 0101) — 40 assertions, 9.34s.

## ⚠️ Pendente Wagner (humano-limitado)

1. `php artisan fiscal:habilitar-business 4` em prod via SSH CT 100
2. Briefing manual Larissa 30min
3. Canary 7d biz=4 observação ativa
4. Smoke browser MCP `/fiscal/*` logado como Larissa
5. Post-canary promover yaml pra `biz_4_rota_livre_prod`
6. SPEC.md US-FISCAL-018 marcar 3 checkboxes restantes `[x]`

## Refs

- [memory/requisitos/Fiscal/AUDIT-SENIOR-2026-05-25.md](memory/requisitos/Fiscal/AUDIT-SENIOR-2026-05-25.md) §GAP-FISCAL-001
- ADR 0105 — Cliente sinal qualificado
- ADR 0101 — tests nunca usam business cliente real

🤖 Generated with [Claude Code](https://claude.com/claude-code)