### PR TITLE
feat(compras): Onda ESTABILIZAR Gaps #2 #3 #4 — hardening Tier 0 + sec

### DIFF
--- a/Modules/Compras/Http/Controllers/ComprasController.php
+++ b/Modules/Compras/Http/Controllers/ComprasController.php
@@ -6,6 +6,7 @@ use App\Utils\ModuleUtil;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
 use Inertia\Inertia;
+use Modules\Compras\Http\Requests\ListarComprasRequest;
 use Modules\Compras\Services\ComprasService;
 
 /**
@@ -33,34 +34,38 @@ class ComprasController extends Controller
 
     /**
      * Cockpit Compras — lista paginada + 4 KPIs FSM (aberto/transito/mes/fornec).
+     *
+     * Tier 0 defense-in-depth (audit sênior 2026-05-25 Gap #2):
+     *  - business_id vem de `auth()->user()->business_id` (não session — defesa
+     *    contra session spoofing). Layer 1 do pattern Laravel SaaS 2026.
+     *  - `abort_if($businessId <= 0)` guard explícito — `(int) null = 0` não
+     *    passa silencioso.
+     *  - Cross-check session === auth pra detectar drift.
+     *
+     * Validação inline substituída por `ListarComprasRequest` (Gap #4) —
+     * whitelist allow-only de filters/sort/dir/per_page anti-SQLi.
      */
-    public function index(Request $request)
+    public function index(ListarComprasRequest $request)
     {
-        if (! auth()->user()->can('compras.view')) {
-            abort(403);
+        $user = auth()->user();
+        $businessId = (int) ($user->business_id ?? 0);
+
+        abort_if($businessId <= 0, 403, 'Business inválido — usuário sem business associado');
+
+        // Cross-check defense-in-depth (layer 2)
+        $sessionBiz = (int) session('user.business_id', 0);
+        if ($sessionBiz > 0 && $sessionBiz !== $businessId) {
+            abort(403, "Business drift detectado (auth={$businessId}, session={$sessionBiz})");
         }
 
-        $businessId = (int) session('user.business_id');
-
-        $perPage = (int) $request->query('per_page', 25);
-        $perPage = in_array($perPage, [10, 25, 50, 100], true) ? $perPage : 25;
-
-        $filters = [
-            'q' => $request->query('q', ''),
-            'stage' => $request->query('stage', 'all'),
-            'sort' => $request->query('sort', 'transaction_date'),
-            'dir' => $request->query('dir', 'desc'),
-            'per_page' => $perPage,
-        ];
-
-        $compraId = (int) $request->query('compra_id', 0);
+        $filters = $request->filtros();
+        $compraId = $request->compraId();
 
         // C1 convergência (ADR compras-purchase-convergencia-c1) — botão "+ Nova
         // compra" e AcoesDropdown "Editar/Excluir" delegam /purchases/* Inertia
         // via router.visit. Permissions vêm do trilho A (Purchase MWART Wave 2
         // B5), não compras.* — alias só em V2 se Wagner mantiver módulo como
         // conceito separado.
-        $user = auth()->user();
 
         return Inertia::render('Compras/Index', [
             'filters' => $filters,
@@ -105,9 +110,14 @@ class ComprasController extends Controller
             abort(403);
         }
 
-        $businessId = (int) session('user.business_id');
+        // Tier 0 defense-in-depth (audit sênior 2026-05-25 Gap #2)
+        $businessId = (int) (auth()->user()->business_id ?? 0);
+        abort_if($businessId <= 0, 403, 'Business inválido');
+
         $detalhe = $this->comprasService->buscarDetalhe($id, $businessId);
 
+        // Defense-in-depth: 404 (não 403) — não revelar existência de compra
+        // de outro business (pattern Tier 0 audit sênior §3.1.4)
         if (! $detalhe) {
             abort(404);
         }

--- a/Modules/Compras/Http/Requests/ListarComprasRequest.php
+++ b/Modules/Compras/Http/Requests/ListarComprasRequest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Compras\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * US-COM-006 PR-0 Gap #4 (audit sênior 2026-05-25) — FormRequest pra validar
+ * filtros de listagem do cockpit Compras.
+ *
+ * Pré-refactor: validação inline solta em ComprasController::index (D8.c=0/3).
+ * Pós: FormRequest canônico + permission gate + whitelist allow-only.
+ *
+ * Whitelist (defesa anti-SQLi + anti-IDOR):
+ *  - q: string opcional, max 100 chars
+ *  - stage: enum ['all','received','ordered','pending','draft'] · default 'all'
+ *  - sort: enum ['transaction_date','ref_no','final_total','contact_name'] · default 'transaction_date'
+ *  - dir: enum ['asc','desc'] · default 'desc'
+ *  - per_page: enum [10,25,50,100] · default 25
+ *  - compra_id: integer >= 1 opcional (pra partial reload drawer)
+ *
+ * @see memory/requisitos/Compras/AUDIT-SENIOR-2026-05-25.md §Gap #4
+ */
+class ListarComprasRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return (bool) auth()->user()?->can('compras.view');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'q'         => ['nullable', 'string', 'max:100'],
+            'stage'     => ['nullable', 'string', 'in:all,received,ordered,pending,draft'],
+            'sort'      => ['nullable', 'string', 'in:transaction_date,ref_no,final_total,contact_name'],
+            'dir'       => ['nullable', 'string', 'in:asc,desc'],
+            'per_page'  => ['nullable', 'integer', 'in:10,25,50,100'],
+            'compra_id' => ['nullable', 'integer', 'min:1'],
+        ];
+    }
+
+    /**
+     * Defaults aplicados pós-validação — caller usa sem checar nullables.
+     */
+    public function filtros(): array
+    {
+        return [
+            'q'        => (string) $this->input('q', ''),
+            'stage'    => (string) $this->input('stage', 'all'),
+            'sort'     => (string) $this->input('sort', 'transaction_date'),
+            'dir'      => strtolower((string) $this->input('dir', 'desc')) === 'asc' ? 'asc' : 'desc',
+            'per_page' => (int) $this->input('per_page', 25),
+        ];
+    }
+
+    public function compraId(): int
+    {
+        return (int) $this->input('compra_id', 0);
+    }
+}

--- a/Modules/Compras/Routes/web.php
+++ b/Modules/Compras/Routes/web.php
@@ -28,7 +28,11 @@ Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'Adm
     });
 
 // Rotas operacionais.
-Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin'])
+// Throttle 60/min anti-DOS (audit sênior 2026-05-25 Gap #3) — pattern Laravel
+// docs + Modules/Fiscal/Routes precedente. Cobre user spam F5 + filter rage
+// + screen-scraping. Threshold conservador (Larissa biz=4 raramente bate 60
+// requests/min num cockpit; bot spamming bate fácil).
+Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin', 'throttle:60,1'])
     ->prefix('compras')
     ->name('compras.')
     ->group(function () {

--- a/Modules/Compras/Tests/Feature/GapsHardeningTest.php
+++ b/Modules/Compras/Tests/Feature/GapsHardeningTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Compras\Http\Controllers\ComprasController;
+use Modules\Compras\Http\Requests\ListarComprasRequest;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Audit sênior 2026-05-25 — Onda ESTABILIZAR Compras (Gaps #2 #3 #4 #6).
+ *
+ * Tests source-grep + contract — rodam em SQLite sem dependência de
+ * schema MySQL UPos. Smoke completo (HTTP 429 throttle real) fica em
+ * CI MySQL pós-merge.
+ */
+
+it('Gap #2: ComprasController index usa user->business_id do auth (não session direto)', function () {
+    $src = file_get_contents(
+        (new ReflectionClass(ComprasController::class))->getFileName(),
+    );
+
+    // index() deve ler business_id do auth user — defesa layer 1 (Laracopilot 2026)
+    expect(str_contains($src, '$user->business_id') || str_contains($src, 'auth()->user()->business_id'))
+        ->toBeTrue('source deve referenciar user->business_id ou auth()->user()->business_id');
+    expect(str_contains($src, 'abort_if($businessId <= 0'))->toBeTrue('guard contra business_id zerado');
+});
+
+it('Gap #2: index faz cross-check session vs auth (defense layer 2)', function () {
+    $src = file_get_contents(
+        (new ReflectionClass(ComprasController::class))->getFileName(),
+    );
+
+    // Cross-check session('user.business_id') vs auth — detecta drift
+    expect(str_contains($src, 'Business drift detectado'))->toBeTrue('msg explicativa quando session ≠ auth');
+    expect(str_contains($src, "session('user.business_id', 0)"))->toBeTrue('lê session com default 0 pra comparar');
+});
+
+it('Gap #2: show() também aplica guard business_id (não só index)', function () {
+    $src = file_get_contents(
+        (new ReflectionClass(ComprasController::class))->getFileName(),
+    );
+
+    // Conta ocorrências do guard — deve aparecer em index E show
+    expect(substr_count($src, 'abort_if($businessId <= 0'))->toBeGreaterThanOrEqual(2);
+});
+
+it('Gap #3: route /compras tem middleware throttle 60/1', function () {
+    $src = file_get_contents(base_path('Modules/Compras/Routes/web.php'));
+    expect($src)->toContain("'throttle:60,1'");
+});
+
+it('Gap #4: ListarComprasRequest existe + é FormRequest', function () {
+    expect(class_exists(ListarComprasRequest::class))->toBeTrue();
+
+    $ref = new ReflectionClass(ListarComprasRequest::class);
+    expect($ref->isSubclassOf(\Illuminate\Foundation\Http\FormRequest::class))->toBeTrue();
+});
+
+it('Gap #4: ListarComprasRequest.authorize() exige permission compras.view', function () {
+    $request = new ListarComprasRequest;
+
+    // Sem usuário autenticado deve negar
+    expect($request->authorize())->toBeFalse();
+});
+
+it('Gap #4: ListarComprasRequest validation rules cobrem 6 filtros canônicos', function () {
+    $request = new ListarComprasRequest;
+    $rules = $request->rules();
+
+    expect($rules)->toHaveKey('q')
+        ->and($rules)->toHaveKey('stage')
+        ->and($rules)->toHaveKey('sort')
+        ->and($rules)->toHaveKey('dir')
+        ->and($rules)->toHaveKey('per_page')
+        ->and($rules)->toHaveKey('compra_id');
+});
+
+it('Gap #4: stage whitelist anti-SQLi/IDOR (5 valores enum)', function () {
+    $request = new ListarComprasRequest;
+    $rules = $request->rules();
+
+    // stage rule deve conter 'in:all,received,ordered,pending,draft'
+    $stageRules = is_array($rules['stage']) ? implode(',', $rules['stage']) : $rules['stage'];
+    expect($stageRules)->toContain('in:all,received,ordered,pending,draft');
+});
+
+it('Gap #4: sort whitelist anti-SQLi (4 columns enum)', function () {
+    $request = new ListarComprasRequest;
+    $rules = $request->rules();
+
+    $sortRules = is_array($rules['sort']) ? implode(',', $rules['sort']) : $rules['sort'];
+    expect($sortRules)->toContain('in:transaction_date,ref_no,final_total,contact_name');
+});
+
+it('Gap #4: per_page whitelist (anti-DOS via per_page=999999)', function () {
+    $request = new ListarComprasRequest;
+    $rules = $request->rules();
+
+    $perPageRules = is_array($rules['per_page']) ? implode(',', $rules['per_page']) : $rules['per_page'];
+    expect($perPageRules)->toContain('in:10,25,50,100');
+});
+
+it('Gap #4: filtros() helper aplica defaults canônicos', function () {
+    // Validator manual (não dá pra resolver request via DI sem session)
+    $request = new ListarComprasRequest;
+    $request->replace([]);
+
+    $filtros = $request->filtros();
+    expect($filtros)->toHaveKey('q')
+        ->and($filtros)->toHaveKey('stage')
+        ->and($filtros)->toHaveKey('sort')
+        ->and($filtros)->toHaveKey('dir')
+        ->and($filtros)->toHaveKey('per_page')
+        ->and($filtros['stage'])->toBe('all')
+        ->and($filtros['sort'])->toBe('transaction_date')
+        ->and($filtros['dir'])->toBe('desc')
+        ->and($filtros['per_page'])->toBe(25);
+});
+
+it('Gap #4: filtros() normaliza dir inválido → desc', function () {
+    $request = new ListarComprasRequest;
+    $request->replace(['dir' => 'sideways']);
+
+    $filtros = $request->filtros();
+    expect($filtros['dir'])->toBe('desc', 'dir inválido cai pra default desc');
+});
+
+it('Gap #4: filtros() aceita asc explícito', function () {
+    $request = new ListarComprasRequest;
+    $request->replace(['dir' => 'asc']);
+
+    $filtros = $request->filtros();
+    expect($filtros['dir'])->toBe('asc');
+});
+
+it('Gap #4: compraId() retorna 0 quando ausente (não null) — int safe', function () {
+    $request = new ListarComprasRequest;
+    $request->replace([]);
+
+    expect($request->compraId())->toBe(0);
+});
+
+it('Gap #2: ComprasController não usa mais "(int) session(\'user.business_id\')" em index', function () {
+    $src = file_get_contents(
+        (new ReflectionClass(ComprasController::class))->getFileName(),
+    );
+
+    // Especificamente em index() — show() pode ainda referenciar pra cross-check
+    // mas o source-of-truth é auth()
+    $indexBlock = substr($src, strpos($src, 'public function index'), 2000);
+    expect($indexBlock)->not->toContain("(int) session('user.business_id')",
+        'pré-refactor business_id vinha de session — agora vem de auth()');
+});


### PR DESCRIPTION
## Resumo

Audit sênior 2026-05-25 Compras (nota **38/100** — único bucket Crítico do projeto). Esta PR fecha **3 dos 6 gaps P0** da Onda ESTABILIZAR (sem feature nova — só hardening + sec).

- **Gap #1** (Pest cross-tenant biz=1 vs biz=99) está em [PR #1569](https://github.com/wagnerra23/oimpresso.com/pull/1569) paralelo
- **Gap #5** (validar JOIN TransactionUtil) + **Gap #6** (eager-load) ficam pra PR follow-up — exigem auditoria do TransactionUtil legacy

## Gap #2 — defense-in-depth `business_id` (Laracopilot 2026)

3 camadas no `ComprasController`:
1. **Source-of-truth:** `auth()->user()->business_id` (não session — anti spoofing)
2. **Guard explícito:** `abort_if(\$businessId <= 0, 403)` (anti silent fail quando `(int) null == 0`)
3. **Cross-check:** compara session vs auth — detecta drift retorna 403 com msg `"Business drift detectado (auth=X, session=Y)"`

Mesmo guard aplicado em `show()`.

## Gap #3 — throttle anti-DOS

Route group `/compras` adiciona middleware `throttle:60,1` (60 requests/min por IP+user). Pattern já validado em `Modules/Fiscal`.

## Gap #4 — FormRequest whitelist anti-SQLi/IDOR

Novo `Modules/Compras/Http/Requests/ListarComprasRequest.php` substitui validação inline. 6 filtros com regras strict:

- `q`: string max 100
- `stage`: enum 5 valores (`all|received|ordered|pending|draft`)
- `sort`: enum 4 columns (`transaction_date|ref_no|final_total|contact_name`)
- `dir`: enum (`asc|desc`)
- `per_page`: enum (`10|25|50|100`) — **anti-DOS** `per_page=999999`
- `compra_id`: integer >= 1

`authorize()` exige permission `compras.view` (gate antes validation).
`filtros()` helper aplica defaults + normaliza `dir` inválido pra `desc`.

## Tests (Pest)

**15 tests novos** — todos verde local (rodam em SQLite, source-grep + contract):

\`\`\`
Tests:    15 passed (32 assertions)
Duration: 5.01s
\`\`\`

Cobre:
- Gap #2: `user->business_id` source · `abort_if` guard · cross-check session/auth · `show()` guard
- Gap #3: route middleware `throttle:60,1`
- Gap #4: FormRequest existe + extends Illuminate · `authorize()` exige permission · 6 rules canônicas · whitelists `stage`/`sort`/`per_page` anti-SQLi · `filtros()` defaults · `compraId()` int-safe
- Refactor: index não usa mais `(int) session('user.business_id')` direto

## Projeção rubrica V3

| | Pré | Pós este PR | Pós este + #1569 |
|---|---:|---:|---:|
| D1.b cross-tenant Pest | 0/15 | 0/15 | **15/15** |
| D2.b padrão canônico | 0/8 | 0/8 | 8/8 |
| D8.a throttle | 0/3 | **3/3** | 3/3 |
| D8.c FormRequest | 0/3 | **3/3** | 3/3 |
| **Total Compras** | **38** | **~44** | **~67** |

Caminho audit Onda ESTABILIZAR alvo ~53/100 (atinge com merge dos 2 PRs).

## Sequência de merge sugerida

1. PR #1569 (Gap #1 Pest cross-tenant) → merge primeiro
2. Este PR (Gaps #2 #3 #4) → rebase em main e merge

Sem conflito real (PRs tocam arquivos diferentes — meu mexe em Controller/Routes/Requests/Tests, #1569 só adiciona MultiTenantTest.php).

## Test plan

- [x] Pest local 15/15 verde
- [x] Lint PHP todos arquivos
- [ ] CI \`gh pr checks\` verde
- [ ] Wagner aprova merge

Refs: audit-senior-compras-2026-05-25 §Gaps #2 #3 #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)