### PR TITLE
feat(compras): Onda ESTABILIZAR Gaps #5 #6 #11 — guards invariantes + OTel spans

### DIFF
--- a/Modules/Compras/Services/ComprasService.php
+++ b/Modules/Compras/Services/ComprasService.php
@@ -3,6 +3,7 @@
 namespace Modules\Compras\Services;
 
 use App\Transaction;
+use App\Util\OtelHelper;
 use App\Utils\TransactionUtil;
 use Carbon\Carbon;
 use Spatie\Activitylog\Models\Activity;
@@ -46,6 +47,23 @@ class ComprasService
      * @return \Illuminate\Database\Eloquent\Builder|\Illuminate\Database\Query\Builder
      */
     public function listarCompras(int $businessId, array $filters = [])
+    {
+        // Audit sênior 2026-05-25 Gap #11 — OTel span custom (D9.a +1).
+        // spanBiz wrap captura latência + tenant_id automaticamente quando OTel
+        // habilitado; zero-cost path quando desabilitado (OtelHelper::span line 64).
+        return OtelHelper::spanBiz('compras.listarCompras', function () use ($businessId, $filters) {
+            return $this->listarComprasInterno($businessId, $filters);
+        }, [
+            'module' => 'Compras',
+            'q_len' => strlen((string) ($filters['q'] ?? '')),
+            'stage' => (string) ($filters['stage'] ?? 'all'),
+        ]);
+    }
+
+    /**
+     * @internal Wrapped pelo span OTel em listarCompras.
+     */
+    private function listarComprasInterno(int $businessId, array $filters)
     {
         $query = $this->transactionUtil->getListPurchases($businessId);
 
@@ -129,6 +147,17 @@ class ComprasService
      */
     public function calcularKpis(int $businessId): array
     {
+        // Audit sênior 2026-05-25 Gap #11 — OTel span KPIs (D9.a +1)
+        return OtelHelper::spanBiz('compras.calcularKpis', function () use ($businessId): array {
+            return $this->calcularKpisInterno($businessId);
+        }, ['module' => 'Compras']);
+    }
+
+    /**
+     * @internal Wrapped pelo span OTel em calcularKpis.
+     */
+    private function calcularKpisInterno(int $businessId): array
+    {
         $base = Transaction::where('business_id', $businessId)
             ->where('type', 'purchase');
 
@@ -167,6 +196,20 @@ class ComprasService
      * Retorna null se não achar (caller responde 404).
      */
     public function buscarDetalhe(int $id, int $businessId): ?array
+    {
+        // Audit sênior 2026-05-25 Gap #11 — OTel span detalhe (D9.a +1)
+        return OtelHelper::spanBiz('compras.buscarDetalhe', function () use ($id, $businessId): ?array {
+            return $this->buscarDetalheInterno($id, $businessId);
+        }, [
+            'module' => 'Compras',
+            'compra_id' => $id,
+        ]);
+    }
+
+    /**
+     * @internal Wrapped pelo span OTel em buscarDetalhe.
+     */
+    private function buscarDetalheInterno(int $id, int $businessId): ?array
     {
         $compra = Transaction::where('business_id', $businessId)
             ->where('id', $id)

--- a/Modules/Compras/Tests/Feature/GapsP1HardeningTest.php
+++ b/Modules/Compras/Tests/Feature/GapsP1HardeningTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Utils\TransactionUtil;
+use Modules\Compras\Services\ComprasService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Audit sênior 2026-05-25 — Onda ESTABILIZAR Compras PR-0 (Gaps #5 #6 #11).
+ *
+ * Gap #5: regression guard pro hotfix R1 (TransactionUtil::getListPurchases
+ *         JOIN com contacts.business_id) — já aplicado em hotfix/us-com-009.
+ * Gap #6: documentação de N/A (getListPurchases SELECT flat — sem N+1).
+ * Gap #11: OTel span custom em 3 métodos do ComprasService (D9.a +1pt).
+ */
+
+function gapP1_transactionUtilMethodBlock(): string
+{
+    $src = file_get_contents(
+        (new ReflectionMethod(TransactionUtil::class, 'getListPurchases'))->getFileName(),
+    );
+    $start = strpos($src, 'function getListPurchases');
+    return substr($src, $start, 3000);
+}
+
+function gapP1_comprasServiceSrc(): string
+{
+    return file_get_contents(
+        (new ReflectionClass(ComprasService::class))->getFileName(),
+    );
+}
+
+it('Gap #5 INVARIANTE: getListPurchases JOIN contacts scoped por business_id', function () {
+    $block = gapP1_transactionUtilMethodBlock();
+
+    expect(str_contains($block, "leftJoin('contacts'"))->toBeTrue('JOIN contacts presente');
+    expect(str_contains($block, "'contacts.business_id'"))->toBeTrue('scope contacts.business_id presente');
+    expect(str_contains($block, "'BS.business_id'"))->toBeTrue('business_locations scoped');
+});
+
+it('Gap #5 INVARIANTE: WHERE transactions.business_id (defense layer 2)', function () {
+    $block = gapP1_transactionUtilMethodBlock();
+
+    expect(str_contains($block, "'transactions.business_id'"))->toBeTrue(
+        'defense-in-depth: WHERE transactions.business_id é layer 2',
+    );
+});
+
+it('Gap #6 N/A: getListPurchases SELECT flat columns (justifica ausência de with())', function () {
+    $block = gapP1_transactionUtilMethodBlock();
+
+    expect(str_contains($block, "'contacts.name'"))->toBeTrue('contact.name vem flat — sem N+1');
+    expect(str_contains($block, "'contacts.supplier_business_name'"))->toBeTrue('supplier_business_name flat');
+    expect(str_contains($block, "'BS.name as location_name'"))->toBeTrue('location.name vem flat aliased');
+});
+
+it('Gap #11: ComprasService import OtelHelper', function () {
+    $src = gapP1_comprasServiceSrc();
+    expect(str_contains($src, 'use App\Util\OtelHelper;'))->toBeTrue('import canon');
+});
+
+it('Gap #11: listarCompras envolve com spanBiz compras.listarCompras', function () {
+    $src = gapP1_comprasServiceSrc();
+    expect(str_contains($src, "spanBiz('compras.listarCompras'"))->toBeTrue();
+});
+
+it('Gap #11: calcularKpis envolve com spanBiz compras.calcularKpis', function () {
+    $src = gapP1_comprasServiceSrc();
+    expect(str_contains($src, "spanBiz('compras.calcularKpis'"))->toBeTrue();
+});
+
+it('Gap #11: buscarDetalhe envolve com spanBiz compras.buscarDetalhe', function () {
+    $src = gapP1_comprasServiceSrc();
+    expect(str_contains($src, "spanBiz('compras.buscarDetalhe'"))->toBeTrue();
+});
+
+it('Gap #11: spans canon usam prefix compras.* (no module leak)', function () {
+    $src = gapP1_comprasServiceSrc();
+
+    preg_match_all("/spanBiz\\('([^']+)'/", $src, $matches);
+    expect($matches[1])->not->toBeEmpty('spans devem ser declarados');
+
+    foreach ($matches[1] as $span) {
+        expect(str_starts_with($span, 'compras.'))->toBeTrue("span '{$span}' deve ter prefix compras.");
+    }
+});
+
+it('Gap #11: métodos *Interno são private (callback wrap pattern)', function () {
+    $ref = new ReflectionClass(ComprasService::class);
+
+    expect($ref->hasMethod('listarComprasInterno'))->toBeTrue('callback wrap')
+        ->and($ref->hasMethod('calcularKpisInterno'))->toBeTrue()
+        ->and($ref->hasMethod('buscarDetalheInterno'))->toBeTrue()
+        ->and($ref->getMethod('listarComprasInterno')->isPrivate())->toBeTrue('@internal')
+        ->and($ref->getMethod('calcularKpisInterno')->isPrivate())->toBeTrue()
+        ->and($ref->getMethod('buscarDetalheInterno')->isPrivate())->toBeTrue();
+});
+
+it('Gap #11: pelo menos 3 spans canon — target D9.a +1pt', function () {
+    $src = gapP1_comprasServiceSrc();
+    $count = preg_match_all("/spanBiz\\(/", $src);
+
+    expect($count)->toBeGreaterThanOrEqual(3,
+        'pelo menos 3 spans canon — listarCompras + calcularKpis + buscarDetalhe (audit Gap #11)');
+});


### PR DESCRIPTION
## Resumo

Audit sênior 2026-05-25 Compras (38/100 — bucket Crítico). PR follow-up do [#1581](https://github.com/wagnerra23/oimpresso.com/pull/1581) fechando mais 3 gaps da Onda ESTABILIZAR.

## Gap #5 — N/A (já coberto + regression guard adicionado)

Audit alertou \"validar TransactionUtil::getListPurchases JOIN scope\".

**Investigação confirmou:** `app/Utils/TransactionUtil.php:4895-4904` JÁ TEM hotfix `'contacts.business_id' => \$business_id` (commit anterior hotfix/us-com-009 R1 leak getlistpurchases — Wave 26).

Adicionados 2 tests de **regression guard** pro hotfix permanecer válido:
- INVARIANTE 1: JOIN contacts scoped por business_id presente
- INVARIANTE 2: WHERE `transactions.business_id` (defense layer 2)

Garante que próximo refactor de TransactionUtil **não regrida** — Pest trava merge se hotfix sumir.

## Gap #6 — N/A (sem N+1 — `getListPurchases` SELECT flat)

Audit alertou \"eager-load `with([...])` anti-N+1\".

**Investigação confirmou:** `getListPurchases` já faz SELECT flat de `contacts.name`, `contacts.supplier_business_name`, `BS.name as location_name`. Frontend lê `row.name` direto sem disparar query relacional. **Não há N+1.**

Test documental adicionado.

## Gap #11 — OTel spans custom (D9.a +2pts)

`ComprasService` ganha 3 spans canon via `OtelHelper::spanBiz` callback wrap:
- `compras.listarCompras`
- `compras.calcularKpis`
- `compras.buscarDetalhe`

Pattern validado em `Fiscal/SpedIcmsIpiGeneratorService`. Métodos internos renomeados `*Interno` (private). Public mantém signature — back-compat 100%.

Quando ext opentelemetry carregada (`config/otel.php`), captura latência + `tenant_id` automaticamente. Quando ausente, `OtelHelper::span` zero-cost path.

## Tests (Pest)

**10 tests novos** — verde local (SQLite source-grep + contract):

\`\`\`
Tests:    10 passed (23 assertions)
Duration: 3.34s
\`\`\`

- Gap #5 INVARIANTE: JOIN contacts scoped + `transactions.business_id` WHERE
- Gap #6 N/A: SELECT flat columns documentado
- Gap #11: import `OtelHelper` + 3 spans canon + prefix `compras.*` + métodos `*Interno` private + count spans >= 3

## Projeção rubrica V3

| | Pré (main) | Pós este PR | Pós + #1569 (Pest cross-tenant) |
|---|---:|---:|---:|
| D8.a throttle | 3/3 (PR #1581) | 3/3 | 3/3 |
| D8.c FormRequest | 3/3 (PR #1581) | 3/3 | 3/3 |
| D9.a OTel spans | 0/4 | **2/4** | 2/4 |
| D1.b Pest cross-tenant | 0/15 | 0/15 | **15/15** |
| **Total Compras** | ~44 | **~46** | **~69** |

Aproxima audit target 70/100.

## Não-mudanças intencionais

- `TransactionUtil` sem alteração — hotfix R1 já aplicado anterior
- `ComprasService` public signature mantida — só wrap span
- `ComprasIndexTest` 5 fails pré-existentes (SQLite sem schema `permissions` — passam em CI MySQL UPos)

## Test plan

- [x] Pest local 10/10 verde
- [x] Lint PHP
- [ ] CI \`gh pr checks\` verde
- [ ] Merge

Refs: audit-senior-compras-2026-05-25 §Gaps #5 #6 #11 · PR #1581 (Gaps #2 #3 #4) · PR #1569 (Gap #1 cross-tenant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)