### PR TITLE
feat(nfe): GAP-FISCAL-004 Onda 6 IBS/CBS scaffold — schema NT 2025.002

### DIFF
--- a/Modules/NfeBrasil/Database/Migrations/2026_05_26_000001_add_ibs_cbs_to_nfe_fiscal_rules.php
+++ b/Modules/NfeBrasil/Database/Migrations/2026_05_26_000001_add_ibs_cbs_to_nfe_fiscal_rules.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * GAP-FISCAL-004 / US-FISCAL-021 — Onda 6 IBS/CBS scaffold (Reforma Tributária NT 2025.002).
+ *
+ * Prazo regulatório (audit sênior 2026-05-25):
+ *  - 2026-04-01: validação fields IBS/CBS pela Receita Federal
+ *  - 2026-08-01: HIGHLIGHT CBS+IBS OBRIGATÓRIO NFe (CRT 3 Lucro Real/Presumido)
+ *  - 2027-01-01: CBS substitui PIS+COFINS integral; IBS começa fase transição ICMS/ISS
+ *
+ * Esta migration adiciona 5 colunas em `nfe_fiscal_rules` pra suportar
+ * cClassTrib + CST IBS + CST CBS + alíquotas IBS/CBS (NT 2025.002).
+ *
+ * Append-only ADR 0093 Garantia 8 — esquema cresce, nunca encolhe.
+ * Idempotência via Schema::hasColumn — re-rodar não duplica.
+ *
+ * NÃO ativa IBS/CBS em produção — apenas prepara schema. Quando
+ * `nfephp-org/sped-nfe` issue #1274 release versão com suporte,
+ * MotorTributarioService passa a popular essas colunas.
+ *
+ * @see memory/requisitos/Fiscal/AUDIT-SENIOR-2026-05-25.md §GAP-FISCAL-004
+ * @see https://github.com/nfephp-org/sped-nfe/issues/1274
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('nfe_fiscal_rules')) {
+            return; // tabela base ausente — migration prerequisite não rodou
+        }
+
+        Schema::table('nfe_fiscal_rules', function (Blueprint $table) {
+            // cClassTrib (Reforma Tributária NT 2025.002 grupo K)
+            // Código de classificação tributária CBS/IBS — string 6 chars
+            // catalogada CONFAZ. Exemplos: '000001' (Tributação Integral),
+            // '100001' (Isenção), '200001' (Suspensão), etc.
+            if (! Schema::hasColumn('nfe_fiscal_rules', 'c_class_trib')) {
+                $table->char('c_class_trib', 6)->nullable()->after('cst')
+                    ->comment('cClassTrib NT 2025.002 — classificação tributária IBS/CBS');
+            }
+
+            // CST IBS (Imposto sobre Bens e Serviços — estadual/municipal substitui ICMS+ISS)
+            if (! Schema::hasColumn('nfe_fiscal_rules', 'cst_ibs')) {
+                $table->char('cst_ibs', 3)->nullable()->after('c_class_trib')
+                    ->comment('CST IBS — Código Situação Tributária IBS (NT 2025.002 Anexo I)');
+            }
+
+            // CST CBS (Contribuição sobre Bens e Serviços — federal substitui PIS+COFINS)
+            if (! Schema::hasColumn('nfe_fiscal_rules', 'cst_cbs')) {
+                $table->char('cst_cbs', 3)->nullable()->after('cst_ibs')
+                    ->comment('CST CBS — Código Situação Tributária CBS (NT 2025.002 Anexo I)');
+            }
+
+            // Alíquotas em decimal (0.18 = 18%) — pattern já estabelecido pelas
+            // outras alíquotas (aliquota_icms, aliquota_pis, etc).
+            if (! Schema::hasColumn('nfe_fiscal_rules', 'aliquota_ibs')) {
+                $table->decimal('aliquota_ibs', 7, 4)->default(0)->after('aliquota_ipi')
+                    ->comment('Alíquota IBS — decimal (0.18 = 18%)');
+            }
+
+            if (! Schema::hasColumn('nfe_fiscal_rules', 'aliquota_cbs')) {
+                $table->decimal('aliquota_cbs', 7, 4)->default(0)->after('aliquota_ibs')
+                    ->comment('Alíquota CBS — decimal (0.009 = 0.9% highlight 2026)');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        // append-only (ADR 0093 Garantia 8) — não removemos colunas em down().
+        // Manter columns mesmo em rollback evita perda de dados em re-up
+        // após hotfix. Schema cresce, nunca encolhe.
+    }
+};

--- a/Modules/NfeBrasil/Models/NfeFiscalRule.php
+++ b/Modules/NfeBrasil/Models/NfeFiscalRule.php
@@ -36,6 +36,10 @@ class NfeFiscalRule extends Model
         'aliquota_icms', 'aliquota_pis', 'aliquota_cofins', 'aliquota_ipi',
         'mva', 'fcp',
         'metadata',
+        // GAP-FISCAL-004 / US-FISCAL-021 — Reforma Tributária NT 2025.002
+        // Migration 2026_05_26_000001_add_ibs_cbs_to_nfe_fiscal_rules
+        'c_class_trib', 'cst_ibs', 'cst_cbs',
+        'aliquota_ibs', 'aliquota_cbs',
     ];
 
     protected $casts = [
@@ -43,6 +47,8 @@ class NfeFiscalRule extends Model
         'aliquota_pis'    => 'float',
         'aliquota_cofins' => 'float',
         'aliquota_ipi'    => 'float',
+        'aliquota_ibs'    => 'float',
+        'aliquota_cbs'    => 'float',
         'mva'             => 'float',
         'fcp'             => 'float',
         'metadata'        => 'array',

--- a/Modules/NfeBrasil/Tests/Feature/OndaIbsCbsScaffoldTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/OndaIbsCbsScaffoldTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Models\NfeFiscalRule;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-FISCAL-021 — Onda 6 IBS/CBS scaffold (Reforma Tributária NT 2025.002).
+ *
+ * Tests focados em (1) Migration adiciona 5 colunas IBS/CBS, (2) Model
+ * NfeFiscalRule expõe novos $fillable + casts, (3) idempotência re-rodar
+ * não duplica, (4) tipos corretos (char 3/6 + decimal 7,4).
+ *
+ * Prazo regulatório (audit sênior 2026-05-25):
+ *  - 2026-08-01: HIGHLIGHT CBS+IBS obrigatório NFe (CRT 3)
+ *  - 2027-01-01: CBS substitui PIS+COFINS integral
+ *
+ * Tests rodam em SQLite source-grep + reflection — não exigem MySQL schema.
+ */
+
+it('Onda 6: Model NfeFiscalRule expõe c_class_trib em $fillable (cClassTrib NT 2025.002)', function () {
+    $model = new NfeFiscalRule;
+    $fillable = $model->getFillable();
+
+    expect(in_array('c_class_trib', $fillable, true))->toBeTrue('cClassTrib NT 2025.002');
+});
+
+it('Onda 6: Model NfeFiscalRule expõe cst_ibs + cst_cbs em $fillable', function () {
+    $model = new NfeFiscalRule;
+    $fillable = $model->getFillable();
+
+    expect(in_array('cst_ibs', $fillable, true))->toBeTrue('CST IBS estadual/municipal');
+    expect(in_array('cst_cbs', $fillable, true))->toBeTrue('CST CBS federal');
+});
+
+it('Onda 6: Model NfeFiscalRule expõe aliquota_ibs + aliquota_cbs em $fillable', function () {
+    $model = new NfeFiscalRule;
+    $fillable = $model->getFillable();
+
+    expect($fillable)->toContain('aliquota_ibs')
+        ->and($fillable)->toContain('aliquota_cbs');
+});
+
+it('Onda 6: aliquota_ibs + aliquota_cbs cast como float (decimal 7,4 padrão alíquotas)', function () {
+    $model = new NfeFiscalRule;
+    $casts = $model->getCasts();
+
+    expect($casts)->toHaveKey('aliquota_ibs')
+        ->and($casts)->toHaveKey('aliquota_cbs')
+        ->and($casts['aliquota_ibs'])->toBe('float', 'pattern decimal 7,4 → float PHP')
+        ->and($casts['aliquota_cbs'])->toBe('float');
+});
+
+it('Onda 6: Migration arquivo existe + segue convenção timestamp NfeBrasil', function () {
+    $migrationsDir = base_path('Modules/NfeBrasil/Database/Migrations');
+    $files = glob($migrationsDir . '/*_add_ibs_cbs_to_nfe_fiscal_rules.php');
+
+    expect($files)->not->toBeEmpty('migration add_ibs_cbs_to_nfe_fiscal_rules deve existir');
+});
+
+it('Onda 6: Migration up() é idempotente — usa Schema::hasColumn guard', function () {
+    $migrationsDir = base_path('Modules/NfeBrasil/Database/Migrations');
+    $files = glob($migrationsDir . '/*_add_ibs_cbs_to_nfe_fiscal_rules.php');
+    expect($files)->not->toBeEmpty();
+
+    $src = file_get_contents($files[0]);
+
+    // ADR tech/0008 idempotência — re-rodar migration NÃO deve duplicar coluna
+    expect(substr_count($src, 'Schema::hasColumn'))->toBeGreaterThanOrEqual(5,
+        'guard Schema::hasColumn pra cada uma das 5 colunas novas');
+});
+
+it('Onda 6: Migration down() preserva colunas (ADR 0093 Garantia 8 append-only)', function () {
+    $migrationsDir = base_path('Modules/NfeBrasil/Database/Migrations');
+    $files = glob($migrationsDir . '/*_add_ibs_cbs_to_nfe_fiscal_rules.php');
+    expect($files)->not->toBeEmpty();
+
+    $src = file_get_contents($files[0]);
+
+    expect(str_contains($src, 'dropColumn'))->toBeFalse('append-only — down() preserva schema');
+    expect(str_contains($src, 'append-only'))->toBeTrue('comentário explícito sobre Garantia 8');
+});
+
+it('Onda 6: Migration referencia issue sped-nfe #1274 (lib externa pending)', function () {
+    $migrationsDir = base_path('Modules/NfeBrasil/Database/Migrations');
+    $files = glob($migrationsDir . '/*_add_ibs_cbs_to_nfe_fiscal_rules.php');
+    expect($files)->not->toBeEmpty();
+
+    $src = file_get_contents($files[0]);
+
+    expect(str_contains($src, '1274'))->toBeTrue('rastrear lib sped-nfe issue #1274 release IBS/CBS');
+});
+
+it('Onda 6: 5 colunas novas cobrem cClassTrib + 2 CST + 2 alíquotas (NT 2025.002 mínimo)', function () {
+    $migrationsDir = base_path('Modules/NfeBrasil/Database/Migrations');
+    $files = glob($migrationsDir . '/*_add_ibs_cbs_to_nfe_fiscal_rules.php');
+    $src = file_get_contents($files[0]);
+
+    expect($src)->toContain('c_class_trib')
+        ->and($src)->toContain('cst_ibs')
+        ->and($src)->toContain('cst_cbs')
+        ->and($src)->toContain('aliquota_ibs')
+        ->and($src)->toContain('aliquota_cbs');
+});
+
+it('Onda 6 SCHEMA APLICADO (somente MySQL com migrate rodado): colunas existem na tabela', function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: migration roda em CI MySQL UPos (ADR 0101)');
+    }
+    if (! Schema::hasTable('nfe_fiscal_rules')) {
+        $this->markTestSkipped('Tabela nfe_fiscal_rules ausente — rodar migrate primeiro');
+    }
+
+    // Quando migrate rodou, todas 5 colunas devem existir
+    expect(Schema::hasColumn('nfe_fiscal_rules', 'c_class_trib'))->toBeTrue()
+        ->and(Schema::hasColumn('nfe_fiscal_rules', 'cst_ibs'))->toBeTrue()
+        ->and(Schema::hasColumn('nfe_fiscal_rules', 'cst_cbs'))->toBeTrue()
+        ->and(Schema::hasColumn('nfe_fiscal_rules', 'aliquota_ibs'))->toBeTrue()
+        ->and(Schema::hasColumn('nfe_fiscal_rules', 'aliquota_cbs'))->toBeTrue();
+});


### PR DESCRIPTION
## Resumo

Audit sênior 2026-05-25 §GAP-FISCAL-004 — **Reforma Tributária NT 2025.002**.

**Prazo regulatório:**
- 2026-04-01: validação fields IBS/CBS Receita Federal
- **2026-08-01: HIGHLIGHT CBS+IBS OBRIGATÓRIO NFe** (CRT 3 Lucro Real/Presumido)
- 2027-01-01: CBS substitui PIS+COFINS integral; IBS começa transição ICMS/ISS

Esta wave **PREPARA schema** (não ativa em prod) pra estar pronto quando lib `nfephp-org/sped-nfe` issue #1274 release versão com suporte.

## Mudanças

### Schema additive — `nfe_fiscal_rules` (append-only ADR 0093 Garantia 8)

Migration `2026_05_26_000001_add_ibs_cbs_to_nfe_fiscal_rules` adiciona **5 colunas**:

| Coluna | Tipo | Descrição |
|---|---|---|
| `c_class_trib` | `char(6)` | cClassTrib NT 2025.002 grupo K |
| `cst_ibs` | `char(3)` | CST IBS estadual/municipal |
| `cst_cbs` | `char(3)` | CST CBS federal |
| `aliquota_ibs` | `decimal(7,4)` | Alíquota IBS decimal (0.18 = 18%) |
| `aliquota_cbs` | `decimal(7,4)` | Alíquota CBS decimal (0.009 = 0.9% highlight 2026) |

- **Idempotência:** `Schema::hasColumn` guard em cada coluna (ADR tech/0008)
- **Append-only:** `down()` preserva schema (ADR 0093 Garantia 8 — sem `dropColumn`)

### Model `NfeFiscalRule`

5 novos `$fillable` + 2 `$casts` float (aliquota_ibs/cbs pattern decimal 7,4 → float PHP). Pareados com outras alíquotas por consistência.

## Tests (Pest)

**9 tests verde** + 1 skip MySQL:

\`\`\`
Tests:    1 skipped, 9 passed (23 assertions)
Duration: 3.62s
\`\`\`

Cobre:
- `$fillable` expõe as 5 colunas
- `$casts` aliquota_ibs/cbs como float
- Migration arquivo existe + convenção timestamp
- Migration up() idempotente (5× `Schema::hasColumn`)
- Migration down() preserva schema (sem `dropColumn` — append-only literal)
- Migration referencia issue sped-nfe #1274
- 5 colunas cobrem mínimo NT 2025.002

## NÃO ativa IBS/CBS em produção

- `MotorTributarioService` ignora novas colunas até lib externa release
- Feature flag `fiscal.sped_simples_only_lock` permanece `true` em prod
- Quando lib release: MotorTributarioService passa a popular essas colunas

## Projeção

- Pré: D2 NfeBrasil cobertura IBS/CBS = 0/8 · Reforma exposure crítica
- Pós: D2 IBS/CBS = 2/8 (schema scaffold + tests não-regressão) · pronto pra release lib

**Compliance:** scaffold cumpre prep regulatório ago/2026 com margem.

## Test plan

- [x] Pest local 9/9 verde
- [x] Lint PHP
- [ ] CI \`gh pr checks\` verde
- [ ] Merge

Refs: audit-senior-fiscal-2026-05-25 §GAP-FISCAL-004 · [NT 2025.002](https://www.sefaz.am.gov.br/noticias/31893) · [sped-nfe issue #1274](https://github.com/nfephp-org/sped-nfe/issues/1274) · ADR 0093 Garantia 8

🤖 Generated with [Claude Code](https://claude.com/claude-code)