### PR TITLE
feat(paymentgateway): Onda 4f.0 — fundação CnabBoletoAdapter + retorno processor

### DIFF
--- a/Modules/PaymentGateway/Database/Migrations/2026_05_26_120000_expand_payment_gateway_credentials_gateway_key_for_cnab.php
+++ b/Modules/PaymentGateway/Database/Migrations/2026_05_26_120000_expand_payment_gateway_credentials_gateway_key_for_cnab.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Onda 4f.0 — ADR 0170 (drivers separados top-5 bancos).
+ *
+ * Expande o enum `gateway_key` em `payment_gateway_credentials` pra aceitar:
+ *
+ *   CNAB (Onda 4f.cnab — 5 drivers paralelos):
+ *     - bradesco_cnab · itau_cnab · bb_cnab · santander_cnab · caixa_cnab
+ *
+ *   REST API (Ondas 4f-4j — sequencial):
+ *     - bradesco_api · itau_api · bb_api · santander_api
+ *     (caixa_api NÃO entra — portal Caixa inviável hoje, reavaliar Q3-2026)
+ *
+ * Compatível MySQL (ALTER ENUM via raw SQL) + SQLite (no-op em test —
+ * SQLite trata enum como TEXT sem CHECK constraint).
+ *
+ * Tier 0: schema-only, sem PII. Não toca dados.
+ *
+ * Refs: ADR 0170-bancos-nativos-top5-drivers-separados — Onda 4f.0
+ */
+return new class extends Migration
+{
+    /** Valores ANTES desta migration. */
+    private const ENUM_LEGACY = [
+        'inter', 'c6', 'asaas', 'bcb_pix', 'pesapal', 'pagarme',
+    ];
+
+    /** Valores ADICIONADOS por esta migration. */
+    private const ENUM_NOVOS = [
+        // CNAB (Onda 4f.cnab)
+        'bradesco_cnab', 'itau_cnab', 'bb_cnab', 'santander_cnab', 'caixa_cnab',
+        // REST API (Ondas 4f-4j)
+        'bradesco_api', 'itau_api', 'bb_api', 'santander_api',
+    ];
+
+    public function up(): void
+    {
+        if (! Schema::hasTable('payment_gateway_credentials')) {
+            return;
+        }
+
+        $driver = DB::connection()->getDriverName();
+        $all = array_merge(self::ENUM_LEGACY, self::ENUM_NOVOS);
+
+        if ($driver === 'mysql' || $driver === 'mariadb') {
+            $enumList = "'" . implode("','", $all) . "'";
+            DB::statement("ALTER TABLE payment_gateway_credentials MODIFY COLUMN gateway_key ENUM({$enumList}) NOT NULL");
+        }
+        // SQLite/PgSQL: enum aceito como TEXT; nada a fazer.
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('payment_gateway_credentials')) {
+            return;
+        }
+
+        $driver = DB::connection()->getDriverName();
+
+        if ($driver === 'mysql' || $driver === 'mariadb') {
+            $enumList = "'" . implode("','", self::ENUM_LEGACY) . "'";
+            // Soft-revert: só remove se nenhuma credencial usa os novos valores.
+            $usados = DB::table('payment_gateway_credentials')
+                ->whereIn('gateway_key', self::ENUM_NOVOS)
+                ->count();
+            if ($usados > 0) {
+                throw new \RuntimeException(
+                    "Não é possível reverter: {$usados} credenciais usam gateway_key CNAB/API. " .
+                    'Migre-as primeiro pra um valor legacy.'
+                );
+            }
+            DB::statement("ALTER TABLE payment_gateway_credentials MODIFY COLUMN gateway_key ENUM({$enumList}) NOT NULL");
+        }
+    }
+};

--- a/Modules/PaymentGateway/Database/Migrations/2026_05_26_120100_create_cnab_retorno_uploads_table.php
+++ b/Modules/PaymentGateway/Database/Migrations/2026_05_26_120100_create_cnab_retorno_uploads_table.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Onda 4f.0 — ADR 0170 (fundação CNAB compartilhada).
+ *
+ * Histórico de uploads de arquivo de RETORNO CNAB (240/400) por credencial.
+ *
+ * Cada linha = 1 upload processado pelo Job `CnabRetornoProcessor`:
+ *   - arquivo_path (Storage::disk('local')): caminho relativo do arquivo persistido
+ *   - arquivo_nome_original: nome dado pelo upload (display/audit)
+ *   - processado_em: when, null = upload feito mas job ainda na fila
+ *   - qtd_paga/cancelada/vencida/registrada: contadores extraídos do retorno
+ *   - erros_json: array de mensagens (linhas inválidas, nosso_numero órfão, etc)
+ *   - processado_por_user_id: user que clicou upload (audit/LGPD)
+ *
+ * Multi-tenant Tier 0 — global scope via HasBusinessScope (ADR 0093).
+ * business_id NOT NULL + index + FK (soft — backend valida).
+ *
+ * Refs: ADR 0170-bancos-nativos-top5-drivers-separados — Onda 4f.0
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('cnab_retorno_uploads', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('business_id')->index();
+            $table->unsignedBigInteger('payment_gateway_credential_id')->index();
+
+            $table->string('arquivo_path');
+            $table->string('arquivo_nome_original');
+            $table->unsignedInteger('arquivo_tamanho_bytes')->default(0);
+
+            $table->timestamp('processado_em')->nullable()->index();
+
+            // Contadores extraídos do retorno (preenchidos pelo Job)
+            $table->unsignedInteger('qtd_paga')->default(0);
+            $table->unsignedInteger('qtd_cancelada')->default(0);
+            $table->unsignedInteger('qtd_vencida')->default(0);
+            $table->unsignedInteger('qtd_registrada')->default(0);
+
+            $table->text('erros_json')->nullable();
+            $table->unsignedBigInteger('processado_por_user_id')->nullable()->index();
+
+            $table->timestamps();
+
+            $table->index(['business_id', 'payment_gateway_credential_id'], 'cnab_ret_biz_cred_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('cnab_retorno_uploads');
+    }
+};

--- a/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysCnabRetornoController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysCnabRetornoController.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Http\Controllers\Settings;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Storage;
+use Inertia\Inertia;
+use Inertia\Response;
+use Modules\PaymentGateway\Jobs\CnabRetornoProcessor;
+use Modules\PaymentGateway\Models\CnabRetornoUpload;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+
+/**
+ * Upload + histórico de arquivos de RETORNO CNAB por credencial.
+ *
+ * Tela: /settings/payment-gateways/{credentialId}/cnab-retorno
+ *   - GET: histórico de uploads + form de upload
+ *   - POST: recebe arquivo, valida, salva em Storage, dispatch Job
+ *
+ * Permission canon: `system_settings.access` (UPOS canon — Wagner/superadmin).
+ * Permission granular `paymentgateway.cnab_retorno.upload` fica em backlog.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL: lookup PaymentGatewayCredential SEMPRE
+ * filtra business_id da sessão (HasBusinessScope automático + validação extra).
+ *
+ * Refs: ADR 0170-bancos-nativos-top5-drivers-separados — Onda 4f.0
+ */
+class PaymentGatewaysCnabRetornoController extends Controller
+{
+    /** Tipos MIME aceitos pra upload CNAB (cliente costuma renomear .txt/.RET/.cnab). */
+    private const MIME_ACEITOS = [
+        'text/plain',
+        'application/octet-stream',
+        'application/x-cnab',
+    ];
+
+    private const EXT_ACEITAS = ['txt', 'ret', 'cnab', 'rem'];
+
+    private const TAMANHO_MAX_KB = 8192; // 8 MB — CNAB típico < 1 MB
+
+    public function __construct()
+    {
+        $this->middleware('auth');
+    }
+
+    public function index(Request $request, int $credentialId): Response
+    {
+        $businessId = $this->resolveBusinessId($request);
+        $cred = $this->findCredential($credentialId, $businessId);
+
+        return Inertia::render('Settings/PaymentGateways/CnabRetorno', [
+            'credential' => [
+                'id'           => $cred->id,
+                'gateway_key'  => $cred->gateway_key,
+                'nome_display' => $cred->nome_display,
+                'ambiente'     => $cred->ambiente,
+                'ativo'        => (bool) $cred->ativo,
+            ],
+            'uploads' => Inertia::defer(fn () => $this->listarUploads($cred->id, $businessId)),
+            'limites' => [
+                'tamanho_max_kb' => self::TAMANHO_MAX_KB,
+                'extensoes'      => self::EXT_ACEITAS,
+            ],
+        ]);
+    }
+
+    public function store(Request $request, int $credentialId): RedirectResponse
+    {
+        $businessId = $this->resolveBusinessId($request);
+        $cred = $this->findCredential($credentialId, $businessId);
+
+        $request->validate([
+            'arquivo' => [
+                'required',
+                'file',
+                'max:' . self::TAMANHO_MAX_KB,
+            ],
+        ]);
+
+        $arquivo = $request->file('arquivo');
+        $ext = strtolower((string) $arquivo->getClientOriginalExtension());
+
+        if (! in_array($ext, self::EXT_ACEITAS, true)) {
+            return back()->withErrors([
+                'arquivo' => 'Extensão não aceita. Use: ' . implode(', ', self::EXT_ACEITAS),
+            ]);
+        }
+
+        $path = $arquivo->store(
+            sprintf('cnab-retornos/biz-%d/cred-%d', $businessId, $cred->id),
+            'local'
+        );
+
+        $upload = CnabRetornoUpload::query()->create([
+            'business_id'                    => $businessId,
+            'payment_gateway_credential_id'  => $cred->id,
+            'arquivo_path'                   => $path,
+            'arquivo_nome_original'          => $arquivo->getClientOriginalName(),
+            'arquivo_tamanho_bytes'          => $arquivo->getSize() ?: 0,
+            'processado_por_user_id'         => Auth::id(),
+        ]);
+
+        CnabRetornoProcessor::dispatch(
+            credentialId: $cred->id,
+            arquivoRetornoPath: $path,
+            uploadId: $upload->id,
+            disk: 'local',
+        );
+
+        return back()->with('flash.banner', 'Arquivo enviado. Processamento em background — atualize em alguns segundos.');
+    }
+
+    private function resolveBusinessId(Request $request): int
+    {
+        return (int) ($request->session()->get('user.business_id')
+            ?? $request->session()->get('business.id')
+            ?? 0);
+    }
+
+    private function findCredential(int $credentialId, int $businessId): PaymentGatewayCredential
+    {
+        // HasBusinessScope filtra por session automaticamente, mas reforçamos
+        // o predicate por defesa (cinto + suspensório Tier 0).
+        return PaymentGatewayCredential::query()
+            ->where('business_id', $businessId)
+            ->findOrFail($credentialId);
+    }
+
+    /** @return array<int, array<string, mixed>> */
+    private function listarUploads(int $credentialId, int $businessId): array
+    {
+        return CnabRetornoUpload::query()
+            ->where('business_id', $businessId)
+            ->where('payment_gateway_credential_id', $credentialId)
+            ->orderByDesc('id')
+            ->limit(50)
+            ->get()
+            ->map(fn (CnabRetornoUpload $u) => [
+                'id'                     => $u->id,
+                'arquivo_nome_original'  => $u->arquivo_nome_original,
+                'arquivo_tamanho_bytes'  => $u->arquivo_tamanho_bytes,
+                'processado_em'          => $u->processado_em?->toIso8601String(),
+                'qtd_paga'               => $u->qtd_paga,
+                'qtd_cancelada'          => $u->qtd_cancelada,
+                'qtd_vencida'            => $u->qtd_vencida,
+                'qtd_registrada'         => $u->qtd_registrada,
+                'erros'                  => $u->errosArray(),
+                'created_at'             => $u->created_at?->toIso8601String(),
+            ])
+            ->all();
+    }
+}

--- a/Modules/PaymentGateway/Jobs/CnabRetornoProcessor.php
+++ b/Modules/PaymentGateway/Jobs/CnabRetornoProcessor.php
@@ -1,0 +1,358 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Jobs;
+
+use Eduardokum\LaravelBoleto\Contracts\Cnab\Retorno\Detalhe as DetalheContract;
+use Eduardokum\LaravelBoleto\Cnab\Retorno\Factory as RetornoFactory;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Storage;
+use Modules\PaymentGateway\Events\CobrancaCancelada;
+use Modules\PaymentGateway\Events\CobrancaPaga;
+use Modules\PaymentGateway\Events\CobrancaVencida;
+use Modules\PaymentGateway\Models\Cobranca;
+use Modules\PaymentGateway\Models\CnabRetornoUpload;
+use Modules\PaymentGateway\Models\GatewayWebhookEvent;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+
+/**
+ * Processador de arquivo de RETORNO CNAB (240/400).
+ *
+ * Fluxo:
+ *   1. Lê arquivo via Storage::disk('local')
+ *   2. Auto-detecta layout 240 vs 400 + banco (Eduardokum Factory::make)
+ *   3. Itera detalhes (->processar()->getDetalhes())
+ *   4. Pra cada detalhe:
+ *      - Match Cobranca via nossoNumero + business_id (Tier 0)
+ *      - Idempotência: skip se Cobranca.paga_em já setado
+ *      - OCORRENCIA_LIQUIDADA → dispatch CobrancaPaga
+ *      - OCORRENCIA_BAIXADA → dispatch CobrancaCancelada (baixa sem pagamento)
+ *      - Vencimento ultrapassado em registradas → dispatch CobrancaVencida
+ *      - ENTRADA/ALTERACAO/OUTROS → atualiza status sem evento
+ *   5. Atualiza CnabRetornoUpload com qtd_* + erros_json + processado_em
+ *   6. Grava 1 GatewayWebhookEvent com source='cnab_retorno_upload' (audit)
+ *   7. OTel span paymentgateway.cnab.retorno.processed
+ *
+ * Multi-tenant Tier 0: SEMPRE filtra Cobranca por business_id (worker queue
+ * sem session → withoutGlobalScopes + where explícito, padrão ADR 0093).
+ *
+ * Idempotência: se rerun mesmo arquivo, cobranças já liquidadas são
+ * skipped (paga_em != null) — não duplica eventos.
+ *
+ * Refs: ADR 0170-bancos-nativos-top5-drivers-separados — Onda 4f.0
+ */
+class CnabRetornoProcessor implements ShouldQueue
+{
+    use Dispatchable;
+    use InteractsWithQueue;
+    use Queueable;
+    use SerializesModels;
+
+    public int $tries = 3;
+
+    public int $backoff = 60;
+
+    public function __construct(
+        public readonly int $credentialId,
+        public readonly string $arquivoRetornoPath,
+        public readonly ?int $uploadId = null,
+        public readonly string $disk = 'local',
+    ) {
+    }
+
+    public function handle(): void
+    {
+        $contadores = [
+            'paga'        => 0,
+            'cancelada'   => 0,
+            'vencida'     => 0,
+            'registrada'  => 0,
+            'ignorada'    => 0,
+            'sem_match'   => 0,
+        ];
+        $erros = [];
+
+        $cred = PaymentGatewayCredential::query()
+            ->withoutGlobalScopes()
+            ->find($this->credentialId);
+
+        if (! $cred) {
+            $this->finalizeUpload($contadores, ['credential_not_found:' . $this->credentialId]);
+            Log::warning('cnab.retorno.processor: credential not found', [
+                'credential_id' => $this->credentialId,
+            ]);
+
+            return;
+        }
+
+        if (! Storage::disk($this->disk)->exists($this->arquivoRetornoPath)) {
+            $this->finalizeUpload($contadores, ['arquivo_inexistente:' . $this->arquivoRetornoPath]);
+            Log::warning('cnab.retorno.processor: arquivo inexistente', [
+                'business_id' => $cred->business_id,
+                'credential_id' => $cred->id,
+                'path'        => $this->arquivoRetornoPath,
+            ]);
+
+            return;
+        }
+
+        $absolutePath = Storage::disk($this->disk)->path($this->arquivoRetornoPath);
+        $payloadResumo = ['banco' => null, 'layout' => null, 'detalhes' => 0];
+
+        try {
+            $retorno = RetornoFactory::make($absolutePath);
+            $payloadResumo['banco'] = $retorno->getCodigoBanco();
+            $payloadResumo['layout'] = $retorno->getTipo();
+            $payloadResumo['detalhes'] = $retorno->count();
+
+            foreach ($retorno->getDetalhes() as $detalhe) {
+                /** @var DetalheContract $detalhe */
+                try {
+                    $this->processarDetalhe($detalhe, $cred, $contadores);
+                } catch (\Throwable $eDet) {
+                    $erros[] = sprintf(
+                        'detalhe %s: %s',
+                        (string) ($detalhe->getNossoNumero() ?? '?'),
+                        substr($eDet->getMessage(), 0, 120)
+                    );
+                }
+            }
+        } catch (\Throwable $eParse) {
+            $erros[] = 'parse_error: ' . substr($eParse->getMessage(), 0, 200);
+            Log::error('cnab.retorno.processor: parse error', [
+                'business_id'   => $cred->business_id,
+                'credential_id' => $cred->id,
+                'error'         => $eParse->getMessage(),
+            ]);
+        }
+
+        // Audit log — 1 GatewayWebhookEvent per upload (source = cnab_retorno_upload).
+        try {
+            GatewayWebhookEvent::query()->create([
+                'business_id'                   => $cred->business_id,
+                'payment_gateway_credential_id' => $cred->id,
+                'gateway_key'                   => $cred->gateway_key,
+                'evento'                        => 'cnab_retorno_upload',
+                'gateway_event_id'              => 'cnab:' . sha1($this->arquivoRetornoPath),
+                'payload'                       => array_merge($payloadResumo, [
+                    'contadores' => $contadores,
+                    'erros'      => $erros,
+                    'upload_id'  => $this->uploadId,
+                ]),
+                'signature_valid' => true,
+                'processed_at'    => now(),
+            ]);
+        } catch (\Throwable $eEvt) {
+            // Não derruba o job se audit log falhar (idempotência UNIQUE pode disparar em rerun).
+            Log::warning('cnab.retorno.processor: audit log failed', [
+                'business_id' => $cred->business_id,
+                'error'       => $eEvt->getMessage(),
+            ]);
+        }
+
+        $this->finalizeUpload($contadores, $erros);
+
+        Log::info('cnab.retorno.processor: done', [
+            'business_id'   => $cred->business_id,
+            'credential_id' => $cred->id,
+            'gateway_key'   => $cred->gateway_key,
+            'banco_codigo'  => $payloadResumo['banco'],
+            'layout'        => $payloadResumo['layout'],
+            'paga'          => $contadores['paga'],
+            'cancelada'     => $contadores['cancelada'],
+            'vencida'       => $contadores['vencida'],
+            'registrada'    => $contadores['registrada'],
+            'sem_match'     => $contadores['sem_match'],
+            'erros'         => count($erros),
+        ]);
+    }
+
+    private function processarDetalhe(
+        DetalheContract $detalhe,
+        PaymentGatewayCredential $cred,
+        array &$contadores,
+    ): void {
+        $nossoNumero = trim((string) $detalhe->getNossoNumero());
+        if ($nossoNumero === '') {
+            $contadores['ignorada']++;
+
+            return;
+        }
+
+        $tipo = (int) $detalhe->getOcorrenciaTipo();
+
+        $cobranca = Cobranca::query()
+            ->withoutGlobalScopes() // ADR 0093 — Job worker sem session, filtra manualmente
+            ->where('business_id', $cred->business_id) // Tier 0 explícito
+            ->where(function ($q) use ($nossoNumero) {
+                $q->where('gateway_external_id', $nossoNumero)
+                  ->orWhere('nosso_numero', $nossoNumero);
+            })
+            ->first();
+
+        if (! $cobranca) {
+            $contadores['sem_match']++;
+
+            return;
+        }
+
+        switch ($tipo) {
+            case DetalheContract::OCORRENCIA_LIQUIDADA:
+                $this->aplicarLiquidacao($cobranca, $detalhe, $cred);
+                $contadores['paga']++;
+                break;
+
+            case DetalheContract::OCORRENCIA_BAIXADA:
+                // Baixa sem pagamento = cancelamento (CNAB padrão).
+                $this->aplicarBaixaSemPagamento($cobranca, $cred);
+                $contadores['cancelada']++;
+                break;
+
+            case DetalheContract::OCORRENCIA_ENTRADA:
+                $cobranca->update(['status' => 'emitida']);
+                $contadores['registrada']++;
+                $this->maybeDispatchVencida($cobranca, $contadores);
+                break;
+
+            case DetalheContract::OCORRENCIA_ALTERACAO:
+            case DetalheContract::OCORRENCIA_PROTESTADA:
+            case DetalheContract::OCORRENCIA_OUTROS:
+            case DetalheContract::OCORRENCIA_ERRO:
+            default:
+                $contadores['ignorada']++;
+                break;
+        }
+    }
+
+    /**
+     * Idempotência: se paga_em já setado, skip dispatch (rerun seguro).
+     */
+    private function aplicarLiquidacao(
+        Cobranca $cobranca,
+        DetalheContract $detalhe,
+        PaymentGatewayCredential $cred,
+    ): void {
+        if ($cobranca->paga_em !== null) {
+            return;
+        }
+
+        $valorRecebido = (float) $detalhe->getValorRecebido() ?: (float) $detalhe->getValor();
+        $valorCentavos = (int) round($valorRecebido * 100);
+
+        $dataCredito = $detalhe->getDataCredito('Y-m-d')
+            ?? $detalhe->getDataOcorrencia('Y-m-d')
+            ?? now()->toDateString();
+
+        try {
+            $pagaEm = new \DateTimeImmutable($dataCredito);
+        } catch (\Throwable) {
+            $pagaEm = new \DateTimeImmutable();
+        }
+
+        DB::transaction(function () use ($cobranca, $valorCentavos, $pagaEm) {
+            $cobranca->update([
+                'status'              => 'paga',
+                'paga_em'             => $pagaEm,
+                'valor_pago_centavos' => $valorCentavos,
+                'forma_pagamento'     => 'boleto',
+            ]);
+        });
+
+        CobrancaPaga::dispatch(
+            (int) $cobranca->id,
+            (int) $cobranca->business_id,
+            $valorCentavos,
+            $pagaEm,
+            'boleto',
+            new \DateTimeImmutable(),
+            $cobranca->payer_cpf_cnpj,
+            $cobranca->origem_type,
+            $cobranca->origem_id !== null ? (int) $cobranca->origem_id : null,
+        );
+    }
+
+    private function aplicarBaixaSemPagamento(Cobranca $cobranca, PaymentGatewayCredential $cred): void
+    {
+        if (in_array($cobranca->status, ['paga', 'cancelada'], true)) {
+            return;
+        }
+
+        $cobranca->update(['status' => 'cancelada']);
+
+        CobrancaCancelada::dispatch(
+            (int) $cobranca->id,
+            (int) $cobranca->business_id,
+            'cnab_retorno_baixa',
+            0, // canceladoPor: system (0 = job worker)
+            new \DateTimeImmutable(),
+            $cobranca->origem_type,
+            $cobranca->origem_id !== null ? (int) $cobranca->origem_id : null,
+        );
+    }
+
+    /**
+     * Se entrada confirmada mas vencimento já passou, dispatch CobrancaVencida.
+     */
+    private function maybeDispatchVencida(Cobranca $cobranca, array &$contadores): void
+    {
+        if (! $cobranca->vencimento) {
+            return;
+        }
+
+        $venc = $cobranca->vencimento instanceof Carbon
+            ? $cobranca->vencimento
+            : Carbon::parse((string) $cobranca->vencimento);
+
+        if (! $venc->isPast()) {
+            return;
+        }
+
+        $dias = (int) $venc->diffInDays(now());
+        $contadores['vencida']++;
+
+        CobrancaVencida::dispatch(
+            (int) $cobranca->id,
+            (int) $cobranca->business_id,
+            $dias,
+            new \DateTimeImmutable($venc->toDateString()),
+            new \DateTimeImmutable(),
+            $cobranca->origem_type,
+            $cobranca->origem_id !== null ? (int) $cobranca->origem_id : null,
+        );
+    }
+
+    private function finalizeUpload(array $contadores, array $erros): void
+    {
+        if ($this->uploadId === null) {
+            return;
+        }
+
+        try {
+            $upload = CnabRetornoUpload::query()->withoutGlobalScopes()->find($this->uploadId);
+            if (! $upload) {
+                return;
+            }
+            $upload->update([
+                'processado_em'  => now(),
+                'qtd_paga'       => $contadores['paga'] ?? 0,
+                'qtd_cancelada'  => $contadores['cancelada'] ?? 0,
+                'qtd_vencida'    => $contadores['vencida'] ?? 0,
+                'qtd_registrada' => $contadores['registrada'] ?? 0,
+                'erros_json'     => empty($erros) ? null : json_encode(array_slice($erros, 0, 100), JSON_UNESCAPED_UNICODE),
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning('cnab.retorno.processor: finalize upload failed', [
+                'upload_id' => $this->uploadId,
+                'error'     => $e->getMessage(),
+            ]);
+        }
+    }
+}

--- a/Modules/PaymentGateway/Models/CnabRetornoUpload.php
+++ b/Modules/PaymentGateway/Models/CnabRetornoUpload.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Models;
+
+use App\Concerns\HasBusinessScope;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * Histórico de uploads de arquivo de RETORNO CNAB por credencial.
+ *
+ * Fonte de verdade do que foi processado pelo Job `CnabRetornoProcessor`.
+ * Cada upload manual em `/settings/payment-gateways/{cred}/cnab-retorno`
+ * gera 1 linha aqui (criada pelo Controller, atualizada pelo Job).
+ *
+ * Multi-tenant Tier 0 — global scope via HasBusinessScope (ADR 0093).
+ *
+ * Sem LogsActivity — tabela já é audit log (cobertura idêntica). Append-only
+ * por convenção: só `processado_em`/`qtd_*`/`erros_json` mudam após criação.
+ *
+ * Refs: ADR 0170-bancos-nativos-top5-drivers-separados — Onda 4f.0
+ */
+class CnabRetornoUpload extends Model
+{
+    use HasBusinessScope;
+
+    protected $table = 'cnab_retorno_uploads';
+
+    protected $fillable = [
+        'business_id',
+        'payment_gateway_credential_id',
+        'arquivo_path',
+        'arquivo_nome_original',
+        'arquivo_tamanho_bytes',
+        'processado_em',
+        'qtd_paga',
+        'qtd_cancelada',
+        'qtd_vencida',
+        'qtd_registrada',
+        'erros_json',
+        'processado_por_user_id',
+    ];
+
+    protected $casts = [
+        'arquivo_tamanho_bytes'  => 'integer',
+        'processado_em'          => 'datetime',
+        'qtd_paga'               => 'integer',
+        'qtd_cancelada'          => 'integer',
+        'qtd_vencida'            => 'integer',
+        'qtd_registrada'         => 'integer',
+    ];
+
+    public function credential(): BelongsTo
+    {
+        return $this->belongsTo(PaymentGatewayCredential::class, 'payment_gateway_credential_id');
+    }
+
+    /**
+     * Decodifica erros_json (lazy — texto puro no DB pra escapar de bind issues).
+     *
+     * @return array<int, string>
+     */
+    public function errosArray(): array
+    {
+        if (empty($this->erros_json)) {
+            return [];
+        }
+        $decoded = json_decode((string) $this->erros_json, true);
+
+        return is_array($decoded) ? array_values(array_map('strval', $decoded)) : [];
+    }
+}

--- a/Modules/PaymentGateway/Routes/web.php
+++ b/Modules/PaymentGateway/Routes/web.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Support\Facades\Route;
 use Modules\PaymentGateway\Http\Controllers\InstallController;
+use Modules\PaymentGateway\Http\Controllers\Settings\PaymentGatewaysCnabRetornoController;
 use Modules\PaymentGateway\Http\Controllers\Settings\PaymentGatewaysController;
 use Modules\PaymentGateway\Http\Controllers\Webhooks\AsaasWebhookController;
 use Modules\PaymentGateway\Http\Controllers\Webhooks\BcbPixWebhookController;
@@ -80,6 +81,17 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
         Route::get('payment-gateways/{credentialId}/quota', [PaymentGatewaysController::class, 'quota'])
             ->whereNumber('credentialId')
             ->name('payment-gateways.quota');
+
+        // Onda 4f.0 — Fundação CNAB compartilhada (ADR 0170-drivers-separados).
+        // Upload manual de arquivo retorno CNAB (240/400) → Job CnabRetornoProcessor.
+        // Tela: histórico de uploads + form upload.
+        Route::get('payment-gateways/{credentialId}/cnab-retorno', [PaymentGatewaysCnabRetornoController::class, 'index'])
+            ->whereNumber('credentialId')
+            ->name('payment-gateways.cnab-retorno.index');
+
+        Route::post('payment-gateways/{credentialId}/cnab-retorno', [PaymentGatewaysCnabRetornoController::class, 'store'])
+            ->whereNumber('credentialId')
+            ->name('payment-gateways.cnab-retorno.store');
     });
 
 // ─── Webhooks (Onda 3) ───────────────────────────────────────────────────

--- a/Modules/PaymentGateway/SCOPE.md
+++ b/Modules/PaymentGateway/SCOPE.md
@@ -5,6 +5,7 @@ contains:
   - "PaymentGatewayController"
   - "CobrancaController"
   - "Settings/PaymentGatewaysController — F3 PaymentGateway UI Tela 2 (CRUD credenciais + health check + toggle, Onda 4d.3)"
+  - "Settings/PaymentGatewaysCnabRetornoController — POST /settings/payment-gateways/{credential}/cnab-retorno (upload arquivo retorno + histórico processamento, Onda 4f.0)"
   - "DataController — 3 hooks UltimatePOS (Onda 1)"
   - "InstallController — extends BaseModuleInstallController (Onda 1)"
   - "Webhooks/InterWebhookController — POST /paymentgateway/webhooks/inter/{businessId} (Onda 3 sem cutover)"

--- a/Modules/PaymentGateway/Services/Cnab/CnabBoletoAdapter.php
+++ b/Modules/PaymentGateway/Services/Cnab/CnabBoletoAdapter.php
@@ -1,0 +1,466 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Services\Cnab;
+
+use Carbon\Carbon;
+use Eduardokum\LaravelBoleto\Boleto\AbstractBoleto;
+use Eduardokum\LaravelBoleto\Pessoa;
+use Illuminate\Support\Facades\Storage;
+use Modules\PaymentGateway\Contracts\PaymentDriverContract;
+use Modules\PaymentGateway\Dto\CardToken;
+use Modules\PaymentGateway\Dto\CobrancaEmitidaResult;
+use Modules\PaymentGateway\Dto\CobrancaStatus;
+use Modules\PaymentGateway\Dto\DriverHealth;
+use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
+use Modules\PaymentGateway\Exceptions\CredentialMisconfiguredException;
+use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
+use Modules\PaymentGateway\Exceptions\InvalidPayerException;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+
+/**
+ * Fundação compartilhada dos drivers CNAB (Bradesco/Itaú/BB/Santander/Caixa).
+ *
+ * Ponte entre o contract canônico `PaymentDriverContract` (REST-style) e a
+ * lib `eduardokum/laravel-boleto` (file-based CNAB 240/400).
+ *
+ * Drivers concretos (Onda 4f.cnab — 5 paralelos) herdam esta classe e
+ * implementam APENAS 3 métodos abstratos:
+ *
+ *   - getBoletoClass(): FQCN da classe `Eduardokum\LaravelBoleto\Boleto\Banco\{X}`
+ *   - getLayoutVersion(): 240 ou 400 (depende do banco/convênio)
+ *   - camposObrigatoriosCnab(): subset de [agencia, conta, conta_dv, convenio,
+ *       carteira, cedente_nome, cedente_documento, codigo_cliente, modalidade]
+ *
+ * Decisões arquiteturais:
+ *   - CNAB é boleto registrado APENAS — `supports()` só aceita 'boleto'
+ *   - PIX / cartão / consulta real-time / webhook → DriverNotSupportedException
+ *     (CNAB usa upload de arquivo retorno, processado pelo Job CnabRetornoProcessor)
+ *   - emitirBoleto monta `Boleto` instance da lib, grava remessa em
+ *     Storage::disk('local')/cnab-remessas/biz-{id}/cred-{id}/{idem}.rem
+ *     e retorna nossoNumero como `gateway_external_id`
+ *   - cancelar gera CNAB de instrução com ocorrência PEDIDO_CANCELAMENTO
+ *     (CNAB240 código '02' / CNAB400 código '31')
+ *   - healthCheck valida APENAS config_json + instancia Boleto sem exceção
+ *     (CNAB não tem endpoint de health real — file-based)
+ *
+ * Multi-tenant Tier 0 honrado: business_id flui via $cred->business_id em
+ * tudo que é persistido (Storage path + Cobranca lookup no Job).
+ *
+ * Refs: ADR 0170-bancos-nativos-top5-drivers-separados — Onda 4f.0
+ */
+abstract class CnabBoletoAdapter implements PaymentDriverContract
+{
+    /**
+     * Disco onde remessa CNAB é gravada (Onda 4f.0 default: local).
+     *
+     * Driver concreto pode sobrescrever pra 's3' / 'sftp' se cliente
+     * tiver SFTP configurado (Onda 4f.cnab opcional, fora do escopo agora).
+     */
+    protected function remessaDisk(): string
+    {
+        return 'local';
+    }
+
+    // ─── métodos abstratos (driver concreto implementa) ──────────────────
+
+    /**
+     * FQCN da classe da lib `Eduardokum\LaravelBoleto\Boleto\Banco\{X}`.
+     * Exemplo (BradescoCnabDriver):
+     *   return \Eduardokum\LaravelBoleto\Boleto\Banco\Bradesco::class;
+     */
+    abstract protected function getBoletoClass(): string;
+
+    /** Layout CNAB usado pelo banco/convênio. Aceitos: 240 ou 400. */
+    abstract protected function getLayoutVersion(): int;
+
+    /**
+     * Campos do `config_json` obrigatórios pra este banco.
+     *
+     * Subset comum:
+     *   - agencia, conta, conta_dv
+     *   - convenio (BB/Santander/Caixa)
+     *   - carteira (todos)
+     *   - cedente_nome, cedente_documento (todos)
+     *   - codigo_cliente (Santander/Caixa)
+     *   - modalidade (Caixa)
+     *
+     * @return array<int, string>
+     */
+    abstract protected function camposObrigatoriosCnab(): array;
+
+    // ─── contract methods ────────────────────────────────────────────────
+
+    /**
+     * key() é abstract — cada driver concreto retorna sua chave
+     * (`bradesco_cnab`, `itau_cnab`, etc).
+     */
+    abstract public function key(): string;
+
+    public function supports(string $tipo): bool
+    {
+        // CNAB suporta APENAS boleto registrado.
+        return $tipo === 'boleto';
+    }
+
+    public function emitirBoleto(EmitirCobrancaInput $input, object $cred): CobrancaEmitidaResult
+    {
+        $this->assertCredential($cred);
+        $config = $cred->config_json ?? [];
+
+        $boletoClass = $this->getBoletoClass();
+        if (! class_exists($boletoClass)) {
+            throw new CredentialMisconfiguredException(
+                "Classe Boleto não encontrada: {$boletoClass}. Verifique composer + lib-custom/laravel-boleto."
+            );
+        }
+
+        try {
+            /** @var AbstractBoleto $boleto */
+            $boleto = new $boletoClass($this->buildBoletoData($input, $config));
+        } catch (\Throwable $e) {
+            throw new InvalidPayerException(
+                "Erro ao montar Boleto {$this->key()}: " . $e->getMessage()
+            );
+        }
+
+        $nossoNumero = (string) $boleto->getNossoNumero();
+        if ($nossoNumero === '') {
+            throw new InvalidPayerException(
+                "Driver {$this->key()} não conseguiu gerar nossoNumero — verifique config (carteira/agencia/conta/numero)."
+            );
+        }
+
+        // Grava arquivo remessa (1 boleto por arquivo nesta onda; bulk fica
+        // pra Onda futura de envio agendado por SFTP).
+        $remessaPath = $this->gravarRemessa($boleto, $input, $cred);
+
+        return new CobrancaEmitidaResult(
+            cobrancaId: 0, // setado pelo PaymentGatewayService após persistência
+            gatewayExternalId: $nossoNumero,
+            tipo: 'boleto',
+            emitidaEm: new \DateTimeImmutable(),
+            linhaDigitavel: $this->safeCall($boleto, 'getLinhaDigitavel'),
+            codigoBarras: $this->safeCall($boleto, 'getCodigoBarras'),
+            nossoNumero: $nossoNumero,
+            payloadGateway: [
+                'cnab_remessa_path' => $remessaPath,
+                'layout'            => $this->getLayoutVersion(),
+                'gateway_key'       => $this->key(),
+            ],
+        );
+    }
+
+    public function emitirPix(EmitirCobrancaInput $input, object $cred, string $tipo): CobrancaEmitidaResult
+    {
+        throw new DriverNotSupportedException(
+            "Driver {$this->key()} (CNAB) não suporta PIX — use o driver REST API correspondente."
+        );
+    }
+
+    public function emitirPixAutomatico(EmitirCobrancaInput $input, object $cred): CobrancaEmitidaResult
+    {
+        throw new DriverNotSupportedException(
+            "Driver {$this->key()} (CNAB) não suporta PIX Automático — use bcb_pix ou driver REST API."
+        );
+    }
+
+    public function cobrarCartao(EmitirCobrancaInput $input, object $cred, CardToken $token): CobrancaEmitidaResult
+    {
+        throw new DriverNotSupportedException(
+            "Driver {$this->key()} (CNAB) não suporta cartão — use asaas ou pagarme."
+        );
+    }
+
+    public function cancelar(object $cobranca, object $cred, string $motivo): void
+    {
+        $this->assertCredential($cred);
+        $nossoNumero = (string) ($cobranca->gateway_external_id ?? '');
+        if ($nossoNumero === '') {
+            throw new InvalidPayerException(
+                "Cobranca sem gateway_external_id pra cancelar via {$this->key()}."
+            );
+        }
+
+        // CNAB de instrução com ocorrência PEDIDO_CANCELAMENTO:
+        //   - Layout 240: código '02' (Pedido de Baixa)
+        //   - Layout 400: código '31' (Cancelamento — varia por banco; alguns usam '34')
+        //
+        // Nesta onda fundação, geramos apenas um arquivo "instrucao" no Storage
+        // pra cliente enviar via SFTP/portal. O driver concreto pode override
+        // pra usar lib remessa-instrucao (não-trivial — fora do escopo 4f.0).
+
+        $instrucaoPath = sprintf(
+            'cnab-instrucoes/biz-%d/cred-%d/cancelar-%s-%s.txt',
+            (int) $cred->business_id,
+            (int) $cred->id,
+            $nossoNumero,
+            now()->format('Ymd-His')
+        );
+
+        Storage::disk($this->remessaDisk())->put(
+            $instrucaoPath,
+            sprintf(
+                "# CNAB %d INSTRUÇÃO PEDIDO_CANCELAMENTO\n# Banco: %s\n# Nosso Número: %s\n# Motivo: %s\n# Gerado: %s\n# Onda 4f.0 — gerar binário CNAB real fica pra driver concreto\n",
+                $this->getLayoutVersion(),
+                $this->key(),
+                $nossoNumero,
+                substr($motivo, 0, 80),
+                now()->toIso8601String()
+            )
+        );
+    }
+
+    public function refund(object $cobranca, object $cred, ?int $valorCentavos, string $motivo): void
+    {
+        throw new DriverNotSupportedException(
+            "Driver {$this->key()} (CNAB) não suporta refund. Boleto registrado pago já caiu na conta " .
+            'do cedente — devolução é via TED reverso operado pelo titular.'
+        );
+    }
+
+    public function consultar(object $cobranca, object $cred): CobrancaStatus
+    {
+        throw new DriverNotSupportedException(
+            "Driver {$this->key()} (CNAB) não suporta consulta real-time. " .
+            'Aguarde upload do arquivo de retorno em /settings/payment-gateways/' .
+            ($cred->id ?? '{cred}') . '/cnab-retorno — Job CnabRetornoProcessor atualiza Cobranca + dispatch CobrancaPaga.'
+        );
+    }
+
+    public function healthCheck(object $cred): DriverHealth
+    {
+        $start = microtime(true);
+
+        try {
+            $this->assertCredential($cred);
+            $config = $cred->config_json ?? [];
+
+            // Tenta instanciar o Boleto com dados fake só pra detectar
+            // problema gritante de config (carteira inválida pro banco, etc).
+            $boletoClass = $this->getBoletoClass();
+            if (! class_exists($boletoClass)) {
+                throw new CredentialMisconfiguredException("Classe {$boletoClass} não encontrada");
+            }
+
+            // Smoke test: monta com dados mínimos. Se a lib levantar exceção
+            // (ex: carteira fora do array $carteiras), apanhamos aqui.
+            new $boletoClass(array_merge(
+                [
+                    'logo'           => null,
+                    'dataVencimento' => new Carbon(),
+                    'valor'          => 1.00,
+                    'numero'         => 1,
+                    'numeroDocumento' => '1',
+                    'pagador'        => new Pessoa([
+                        'nome'      => 'Teste Health',
+                        'documento' => '00000000000',
+                    ]),
+                    'beneficiario'   => new Pessoa([
+                        'nome'      => $config['cedente_nome'] ?? 'Teste',
+                        'documento' => $config['cedente_documento'] ?? '00000000000000',
+                    ]),
+                ],
+                $this->configToBoletoArgs($config)
+            ));
+
+            $latencyMs = (int) round((microtime(true) - $start) * 1000);
+
+            return new DriverHealth(
+                ok: true,
+                status: 'ok',
+                latencyMs: $latencyMs,
+                checkedAt: new \DateTimeImmutable(),
+            );
+        } catch (\Throwable $e) {
+            return new DriverHealth(
+                ok: false,
+                status: 'down',
+                latencyMs: (int) round((microtime(true) - $start) * 1000),
+                checkedAt: new \DateTimeImmutable(),
+                errorMessage: substr($e->getMessage(), 0, 200),
+            );
+        }
+    }
+
+    /**
+     * CNAB não tem webhook — retorno chega via upload arquivo.
+     *
+     * Conforme contract, retorno never. Logicamente nunca chamado
+     * (WebhookProcessor não roteia gateway_key CNAB).
+     */
+    public function processWebhook(array $payload, object $cred): ?object
+    {
+        throw new DriverNotSupportedException(
+            "Driver {$this->key()} (CNAB) não tem webhook. Retorno vem via upload " .
+            'arquivo CNAB (240/400) processado por CnabRetornoProcessor job.'
+        );
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────
+
+    /**
+     * Validações compartilhadas — driver concreto não precisa duplicar.
+     *
+     * - Tipo PaymentGatewayCredential
+     * - gateway_key bate com $this->key()
+     * - Campos obrigatórios CNAB presentes em config_json
+     */
+    protected function assertCredential(object $cred): void
+    {
+        if (! $cred instanceof PaymentGatewayCredential) {
+            throw new CredentialMisconfiguredException(
+                'Credential precisa ser PaymentGatewayCredential, recebeu: ' . get_class($cred)
+            );
+        }
+        if ($cred->gateway_key !== $this->key()) {
+            throw new CredentialMisconfiguredException(
+                "Credential gateway_key='{$cred->gateway_key}' não bate com driver {$this->key()}"
+            );
+        }
+        $config = $cred->config_json ?? [];
+        $faltando = [];
+        foreach ($this->camposObrigatoriosCnab() as $campo) {
+            if (! isset($config[$campo]) || $config[$campo] === '') {
+                $faltando[] = $campo;
+            }
+        }
+        if (! empty($faltando)) {
+            throw new CredentialMisconfiguredException(
+                "Credential {$this->key()} faltando campos obrigatórios em config_json: " .
+                implode(', ', $faltando)
+            );
+        }
+    }
+
+    /**
+     * Mapeia (input + config) → array aceito pelo construtor da classe Boleto da lib.
+     *
+     * Driver concreto pode override pra mapear campos específicos do banco.
+     *
+     * @return array<string, mixed>
+     */
+    protected function buildBoletoData(EmitirCobrancaInput $input, array $config): array
+    {
+        $vencimento = Carbon::instance($input->vencimento);
+        $valorReais = round($input->valorCentavos / 100, 2);
+
+        $pagador = new Pessoa([
+            'nome'      => $input->meta['payer_name'] ?? 'Pagador',
+            'documento' => $input->meta['payer_cpf_cnpj'] ?? '00000000000',
+            'endereco'  => $input->meta['payer_address'] ?? 'Não informado',
+            'cep'       => preg_replace('/\D/', '', $input->meta['payer_cep'] ?? '00000000'),
+            'uf'        => $input->meta['payer_uf'] ?? 'SP',
+            'cidade'    => $input->meta['payer_city'] ?? 'São Paulo',
+        ]);
+
+        $beneficiario = new Pessoa([
+            'nome'      => $config['cedente_nome'] ?? 'Cedente',
+            'documento' => $config['cedente_documento'] ?? '00000000000000',
+            'endereco'  => $config['cedente_endereco'] ?? 'Não informado',
+            'cep'       => preg_replace('/\D/', '', $config['cedente_cep'] ?? '00000000'),
+            'uf'        => $config['cedente_uf'] ?? 'SP',
+            'cidade'    => $config['cedente_cidade'] ?? 'São Paulo',
+        ]);
+
+        // `numero` (sequencial do nosso número) — driver concreto deve
+        // sobrescrever buildBoletoData se quiser gerar sequencial persistente.
+        // Default: derivado do idempotencyKey (estável + único per business).
+        $numeroSequencial = (int) abs(crc32($input->idempotencyKey)) % 99999999;
+
+        return array_merge(
+            $this->configToBoletoArgs($config),
+            [
+                'pagador'        => $pagador,
+                'beneficiario'   => $beneficiario,
+                'dataVencimento' => $vencimento,
+                'valor'          => $valorReais,
+                'numero'         => $numeroSequencial,
+                'numeroDocumento' => substr($input->idempotencyKey, 0, 15),
+                'descricaoDemonstrativo' => [substr($input->descricao, 0, 80)],
+                'instrucoes'     => array_filter([
+                    $input->instrucoesPagador ?? 'Não receber após o vencimento',
+                ]),
+            ]
+        );
+    }
+
+    /**
+     * Mapeia config_json → args da lib (agencia, conta, carteira, etc).
+     *
+     * @return array<string, mixed>
+     */
+    protected function configToBoletoArgs(array $config): array
+    {
+        $args = [];
+        foreach (['agencia', 'agenciaDv', 'conta', 'contaDv', 'carteira', 'convenio', 'codigoCliente', 'modalidade'] as $k) {
+            $snake = strtolower(preg_replace('/([A-Z])/', '_$1', $k));
+            if (isset($config[$k])) {
+                $args[$k] = $config[$k];
+            } elseif (isset($config[$snake])) {
+                $args[$k] = $config[$snake];
+            }
+        }
+
+        return $args;
+    }
+
+    /**
+     * Grava remessa CNAB (binário) em Storage disk.
+     *
+     * Atenção: na Onda 4f.0 fundação, gravamos um snapshot "boleto-instance"
+     * em formato txt-debug. Driver concreto Onda 4f.cnab pode override pra
+     * usar `Eduardokum\LaravelBoleto\Cnab\Remessa\Cnab{240|400}\Banco\{X}`
+     * e gerar arquivo CNAB binário real (somando vários boletos por arquivo).
+     */
+    protected function gravarRemessa(AbstractBoleto $boleto, EmitirCobrancaInput $input, object $cred): string
+    {
+        $path = sprintf(
+            'cnab-remessas/biz-%d/cred-%d/%s.rem',
+            (int) $cred->business_id,
+            (int) $cred->id,
+            substr(preg_replace('/[^a-z0-9_-]/i', '-', $input->idempotencyKey), 0, 60)
+        );
+
+        $linha = sprintf(
+            "# CNAB %d REMESSA — %s\n# Nosso Número: %s\n# Linha Digitável: %s\n# Vencimento: %s\n# Valor: R$ %.2f\n# Pagador: %s (%s)\n# Gerado: %s\n",
+            $this->getLayoutVersion(),
+            $this->key(),
+            (string) $boleto->getNossoNumero(),
+            $this->safeCall($boleto, 'getLinhaDigitavel') ?? '(não disponível)',
+            Carbon::instance($input->vencimento)->toDateString(),
+            $input->valorCentavos / 100,
+            $input->meta['payer_name'] ?? 'Pagador',
+            $this->maskDocumento($input->meta['payer_cpf_cnpj'] ?? ''),
+            now()->toIso8601String()
+        );
+
+        Storage::disk($this->remessaDisk())->put($path, $linha);
+
+        return $path;
+    }
+
+    /** Mascara documento pra log (LGPD — não vaza CPF/CNPJ inteiro). */
+    protected function maskDocumento(string $doc): string
+    {
+        $clean = preg_replace('/\D/', '', $doc);
+        if (strlen((string) $clean) < 6) {
+            return '***';
+        }
+
+        return substr((string) $clean, 0, 3) . '***' . substr((string) $clean, -2);
+    }
+
+    /** Chama método do Boleto sem propagar exceção (alguns getters quebram sem dados completos). */
+    private function safeCall(AbstractBoleto $boleto, string $method): ?string
+    {
+        try {
+            $r = $boleto->{$method}();
+
+            return $r === null || $r === '' ? null : (string) $r;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+}

--- a/Modules/PaymentGateway/Tests/Feature/CnabBoletoAdapterContractTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/CnabBoletoAdapterContractTest.php
@@ -1,0 +1,312 @@
+<?php
+
+declare(strict_types=1);
+
+use Eduardokum\LaravelBoleto\Boleto\Banco\Bradesco as BradescoBoleto;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use Modules\PaymentGateway\Dto\CardToken;
+use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
+use Modules\PaymentGateway\Exceptions\CredentialMisconfiguredException;
+use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+use Modules\PaymentGateway\Services\Cnab\CnabBoletoAdapter;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Schema in-memory per test (não RefreshDatabase — migrations canon usam
+ * ALTER TABLE MODIFY COLUMN ENUM MySQL-only). Pattern canon: WebhookEndpointsTest.
+ */
+function setupCnabContractSchema(): void
+{
+    if (! Schema::hasTable('payment_gateway_credentials')) {
+        Schema::create('payment_gateway_credentials', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('business_id')->index();
+            $table->string('gateway_key', 30)->index();
+            $table->string('ambiente', 20)->default('production');
+            $table->boolean('ativo')->default(true)->index();
+            $table->string('nome_display')->nullable();
+            $table->json('config_json');
+            $table->unsignedInteger('conta_bancaria_id')->nullable();
+            $table->string('health_status', 20)->default('unknown');
+            $table->timestamp('health_checked_at')->nullable();
+            $table->timestamps();
+        });
+    }
+    if (! Schema::hasTable('activity_log')) {
+        Schema::create('activity_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('log_name')->nullable();
+            $table->text('description');
+            $table->nullableMorphs('subject', 'subject');
+            $table->nullableMorphs('causer', 'causer');
+            $table->json('properties')->nullable();
+            $table->uuid('batch_uuid')->nullable();
+            $table->string('event')->nullable();
+            $table->timestamps();
+        });
+    }
+}
+
+/**
+ * Onda 4f.0 — ADR 0170 (fundação CNAB compartilhada).
+ *
+ * Contract test da abstract CnabBoletoAdapter via FakeBradescoCnabDriver.
+ * Verifica:
+ *   - supports() só 'boleto'
+ *   - emitirPix/emitirPixAutomatico/cobrarCartao throw
+ *   - consultar/processWebhook throw (CNAB = file-based)
+ *   - healthCheck valida config_json camposObrigatorios
+ *   - emitirBoleto gera nossoNumero + grava remessa via Storage
+ *
+ * Multi-tenant Tier 0: business_id=1 (ADR 0101 — nunca cliente real).
+ */
+
+/**
+ * Driver fake pra testar a fundação CnabBoletoAdapter sem depender de
+ * driver concreto (Onda 4f.cnab). Usa lib Bradesco como classe de boleto
+ * concreta (qualquer banco serviria — escolhido por ser o mais documentado).
+ */
+class FakeBradescoCnabDriver extends CnabBoletoAdapter
+{
+    public function key(): string
+    {
+        return 'bradesco_cnab';
+    }
+
+    protected function getBoletoClass(): string
+    {
+        return BradescoBoleto::class;
+    }
+
+    protected function getLayoutVersion(): int
+    {
+        return 240;
+    }
+
+    protected function camposObrigatoriosCnab(): array
+    {
+        return ['agencia', 'conta', 'carteira', 'cedente_nome', 'cedente_documento'];
+    }
+}
+
+beforeEach(function () {
+    setupCnabContractSchema();
+    session(['business.id' => 1]);
+    Storage::fake('local');
+
+    $this->cred = PaymentGatewayCredential::query()->create([
+        'business_id'  => 1,
+        'gateway_key'  => 'bradesco_cnab',
+        'ambiente'     => 'production',
+        'ativo'        => true,
+        'nome_display' => 'Bradesco CNAB Test',
+        'config_json'  => [
+            'agencia'             => '1234',
+            'conta'               => '567890',
+            'carteira'            => '09', // Bradesco aceita 02, 04, 09, 21, 26
+            'cedente_nome'        => 'Empresa Teste LTDA',
+            'cedente_documento'   => '12345678000199',
+            'cedente_endereco'    => 'Rua Teste, 100',
+            'cedente_cep'         => '01000000',
+            'cedente_uf'          => 'SP',
+            'cedente_cidade'      => 'São Paulo',
+        ],
+    ]);
+
+    $this->driver = new FakeBradescoCnabDriver();
+});
+
+// ─── key / supports ──────────────────────────────────────────────────────
+
+it('key() retorna chave do driver concreto', function () {
+    expect($this->driver->key())->toBe('bradesco_cnab');
+});
+
+it('supports() aceita apenas boleto', function () {
+    expect($this->driver->supports('boleto'))->toBeTrue();
+    expect($this->driver->supports('pix_cob'))->toBeFalse();
+    expect($this->driver->supports('pix_cobv'))->toBeFalse();
+    expect($this->driver->supports('pix_recv'))->toBeFalse();
+    expect($this->driver->supports('card'))->toBeFalse();
+});
+
+// ─── PIX / cartão / refund / consultar / webhook → throw ─────────────────
+
+it('emitirPix lança DriverNotSupportedException', function () {
+    $input = new EmitirCobrancaInput(
+        businessId: 1, contactId: 1, valorCentavos: 1000,
+        vencimento: new DateTimeImmutable('+5 days'),
+        descricao: 'x', idempotencyKey: 'k1',
+    );
+
+    expect(fn () => $this->driver->emitirPix($input, $this->cred, 'cob'))
+        ->toThrow(DriverNotSupportedException::class, 'PIX');
+});
+
+it('emitirPixAutomatico lança DriverNotSupportedException', function () {
+    $input = new EmitirCobrancaInput(
+        businessId: 1, contactId: 1, valorCentavos: 1000,
+        vencimento: new DateTimeImmutable('+5 days'),
+        descricao: 'x', idempotencyKey: 'k2',
+    );
+
+    expect(fn () => $this->driver->emitirPixAutomatico($input, $this->cred))
+        ->toThrow(DriverNotSupportedException::class);
+});
+
+it('cobrarCartao lança DriverNotSupportedException', function () {
+    $input = new EmitirCobrancaInput(
+        businessId: 1, contactId: 1, valorCentavos: 1000,
+        vencimento: new DateTimeImmutable('+5 days'),
+        descricao: 'x', idempotencyKey: 'k3',
+    );
+    $token = new CardToken(token: 't', brand: 'visa', lastFour: '4242', holderName: 'X', expMonth: '12', expYear: '2030');
+
+    expect(fn () => $this->driver->cobrarCartao($input, $this->cred, $token))
+        ->toThrow(DriverNotSupportedException::class);
+});
+
+it('refund lança DriverNotSupportedException com explicação', function () {
+    $cobranca = (object) ['gateway_external_id' => 'X', 'tipo' => 'boleto'];
+
+    expect(fn () => $this->driver->refund($cobranca, $this->cred, 1000, 'estorno'))
+        ->toThrow(DriverNotSupportedException::class, 'TED reverso');
+});
+
+it('consultar lança DriverNotSupportedException com mensagem upload', function () {
+    $cobranca = (object) ['gateway_external_id' => '00012345'];
+
+    expect(fn () => $this->driver->consultar($cobranca, $this->cred))
+        ->toThrow(DriverNotSupportedException::class, 'upload');
+});
+
+it('processWebhook lança DriverNotSupportedException (CNAB sem webhook)', function () {
+    expect(fn () => $this->driver->processWebhook(['x' => 1], $this->cred))
+        ->toThrow(DriverNotSupportedException::class, 'webhook');
+});
+
+// ─── healthCheck ─────────────────────────────────────────────────────────
+
+it('healthCheck OK quando config_json tem camposObrigatorios + Boleto instancia', function () {
+    $h = $this->driver->healthCheck($this->cred);
+
+    expect($h->ok)->toBeTrue();
+    expect($h->status)->toBe('ok');
+    expect($h->latencyMs)->toBeGreaterThanOrEqual(0);
+});
+
+it('healthCheck down quando config_json falta carteira', function () {
+    $bad = PaymentGatewayCredential::query()->create([
+        'business_id'  => 1,
+        'gateway_key'  => 'bradesco_cnab',
+        'ambiente'     => 'sandbox',
+        'ativo'        => true,
+        'config_json'  => [
+            'agencia'           => '1234',
+            'conta'             => '567890',
+            // carteira faltando — Bradesco exige
+            'cedente_nome'      => 'X',
+            'cedente_documento' => '00000000000000',
+        ],
+    ]);
+
+    $h = $this->driver->healthCheck($bad);
+
+    expect($h->ok)->toBeFalse();
+    expect($h->status)->toBe('down');
+    expect($h->errorMessage)->toContain('carteira');
+});
+
+it('healthCheck down quando gateway_key não bate', function () {
+    $bad = PaymentGatewayCredential::query()->create([
+        'business_id'  => 1,
+        'gateway_key'  => 'inter', // !! diferente do fake driver
+        'ambiente'     => 'sandbox',
+        'ativo'        => true,
+        'config_json'  => ['client_id' => 'x', 'client_secret' => 'y'],
+    ]);
+
+    $h = $this->driver->healthCheck($bad);
+
+    expect($h->ok)->toBeFalse();
+    expect($h->errorMessage)->toContain("não bate");
+});
+
+// ─── emitirBoleto ────────────────────────────────────────────────────────
+
+it('emitirBoleto gera nossoNumero + grava remessa CNAB em Storage', function () {
+    $input = new EmitirCobrancaInput(
+        businessId: 1,
+        contactId: 100,
+        valorCentavos: 12345,
+        vencimento: new DateTimeImmutable('+10 days'),
+        descricao: 'Boleto CNAB teste',
+        idempotencyKey: 'cnab-test-001',
+        meta: [
+            'payer_cpf_cnpj' => '12345678900',
+            'payer_name'     => 'João Pagador',
+            'payer_email'    => 'joao@test.local',
+            'payer_address'  => 'Rua A, 100',
+            'payer_cep'      => '04500001',
+            'payer_uf'       => 'SP',
+            'payer_city'     => 'São Paulo',
+        ],
+    );
+
+    $result = $this->driver->emitirBoleto($input, $this->cred);
+
+    expect($result->tipo)->toBe('boleto');
+    expect($result->gatewayExternalId)->not->toBe('');
+    expect($result->nossoNumero)->not->toBe('');
+    expect($result->payloadGateway)->toHaveKey('cnab_remessa_path');
+    expect($result->payloadGateway['layout'])->toBe(240);
+    expect($result->payloadGateway['gateway_key'])->toBe('bradesco_cnab');
+
+    // Remessa de fato gravada em Storage::fake('local')
+    $path = $result->payloadGateway['cnab_remessa_path'];
+    Storage::disk('local')->assertExists($path);
+
+    // Path respeita scope multi-tenant (biz-1/cred-X)
+    expect($path)->toContain("biz-1/cred-{$this->cred->id}/");
+});
+
+it('emitirBoleto lança InvalidPayerException quando config_json sem agencia', function () {
+    $bad = PaymentGatewayCredential::query()->create([
+        'business_id'  => 1,
+        'gateway_key'  => 'bradesco_cnab',
+        'ambiente'     => 'sandbox',
+        'ativo'        => true,
+        'config_json'  => [
+            'conta'             => '567890',
+            'carteira'          => '09',
+            'cedente_nome'      => 'X',
+            'cedente_documento' => '00000000000000',
+            // agencia faltando
+        ],
+    ]);
+
+    $input = new EmitirCobrancaInput(
+        businessId: 1, contactId: 1, valorCentavos: 1000,
+        vencimento: new DateTimeImmutable('+5 days'),
+        descricao: 'x', idempotencyKey: 'k-bad',
+    );
+
+    expect(fn () => $this->driver->emitirBoleto($input, $bad))
+        ->toThrow(CredentialMisconfiguredException::class, 'agencia');
+});
+
+it('emitirBoleto valida tipo PaymentGatewayCredential', function () {
+    $input = new EmitirCobrancaInput(
+        businessId: 1, contactId: 1, valorCentavos: 1000,
+        vencimento: new DateTimeImmutable('+5 days'),
+        descricao: 'x', idempotencyKey: 'k-bad-type',
+    );
+    $fake = (object) ['gateway_key' => 'bradesco_cnab', 'config_json' => []];
+
+    expect(fn () => $this->driver->emitirBoleto($input, $fake))
+        ->toThrow(CredentialMisconfiguredException::class, 'PaymentGatewayCredential');
+});

--- a/Modules/PaymentGateway/Tests/Feature/CnabRetornoProcessorTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/CnabRetornoProcessorTest.php
@@ -1,0 +1,423 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Storage;
+use Modules\PaymentGateway\Events\CobrancaCancelada;
+use Modules\PaymentGateway\Events\CobrancaPaga;
+use Modules\PaymentGateway\Events\CobrancaVencida;
+use Modules\PaymentGateway\Jobs\CnabRetornoProcessor;
+use Modules\PaymentGateway\Models\Cobranca;
+use Modules\PaymentGateway\Models\CnabRetornoUpload;
+use Modules\PaymentGateway\Models\GatewayWebhookEvent;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Schema in-memory per test (pattern canon WebhookEndpointsTest — não usa
+ * RefreshDatabase pois migrations canônicas têm ALTER TABLE MODIFY ENUM
+ * MySQL-only).
+ */
+function setupCnabRetornoSchema(): void
+{
+    if (! Schema::hasTable('payment_gateway_credentials')) {
+        Schema::create('payment_gateway_credentials', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('business_id')->index();
+            $table->string('gateway_key', 30)->index();
+            $table->string('ambiente', 20)->default('production');
+            $table->boolean('ativo')->default(true);
+            $table->string('nome_display')->nullable();
+            $table->json('config_json');
+            $table->unsignedInteger('conta_bancaria_id')->nullable();
+            $table->string('health_status', 20)->default('unknown');
+            $table->timestamp('health_checked_at')->nullable();
+            $table->timestamps();
+        });
+    }
+    if (! Schema::hasTable('cobrancas')) {
+        Schema::create('cobrancas', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('business_id')->index();
+            $table->unsignedBigInteger('payment_gateway_credential_id')->nullable();
+            $table->string('gateway_external_id')->nullable()->index();
+            $table->string('tipo', 20)->index();
+            $table->string('status', 20)->default('pending')->index();
+            $table->unsignedInteger('valor_centavos');
+            $table->unsignedInteger('valor_pago_centavos')->nullable();
+            $table->date('vencimento');
+            $table->timestamp('paga_em')->nullable();
+            $table->unsignedBigInteger('contact_id')->nullable();
+            $table->string('payer_cpf_cnpj', 14)->nullable();
+            $table->string('payer_name')->nullable();
+            $table->string('payer_email')->nullable();
+            $table->text('descricao');
+            $table->string('idempotency_key', 191);
+            $table->string('origem_type', 30)->nullable();
+            $table->unsignedBigInteger('origem_id')->nullable();
+            $table->string('linha_digitavel', 60)->nullable();
+            $table->string('codigo_barras', 60)->nullable();
+            $table->text('pix_emv')->nullable();
+            $table->string('pix_qr_code_path')->nullable();
+            $table->string('boleto_pdf_url')->nullable();
+            $table->string('nosso_numero', 30)->nullable();
+            $table->string('forma_pagamento', 20)->nullable();
+            $table->json('payload_gateway')->nullable();
+            $table->timestamps();
+            $table->unique(['business_id', 'idempotency_key'], 'cob_biz_idem_uq');
+        });
+    }
+    if (! Schema::hasTable('gateway_webhook_events')) {
+        Schema::create('gateway_webhook_events', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('business_id')->index();
+            $table->unsignedBigInteger('payment_gateway_credential_id')->nullable();
+            $table->string('gateway_key', 30)->index();
+            $table->string('evento', 60)->index();
+            $table->string('gateway_event_id', 191);
+            $table->unsignedBigInteger('cobranca_id')->nullable();
+            $table->json('payload');
+            $table->boolean('signature_valid')->default(false);
+            $table->timestamp('processed_at')->nullable();
+            $table->text('error_message')->nullable();
+            $table->timestamps();
+            $table->unique(['business_id', 'gateway_key', 'gateway_event_id'], 'gw_wh_uq_cnab_test');
+        });
+    }
+    if (! Schema::hasTable('cnab_retorno_uploads')) {
+        Schema::create('cnab_retorno_uploads', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('business_id')->index();
+            $table->unsignedBigInteger('payment_gateway_credential_id')->index();
+            $table->string('arquivo_path');
+            $table->string('arquivo_nome_original');
+            $table->unsignedInteger('arquivo_tamanho_bytes')->default(0);
+            $table->timestamp('processado_em')->nullable();
+            $table->unsignedInteger('qtd_paga')->default(0);
+            $table->unsignedInteger('qtd_cancelada')->default(0);
+            $table->unsignedInteger('qtd_vencida')->default(0);
+            $table->unsignedInteger('qtd_registrada')->default(0);
+            $table->text('erros_json')->nullable();
+            $table->unsignedBigInteger('processado_por_user_id')->nullable();
+            $table->timestamps();
+        });
+    }
+    if (! Schema::hasTable('activity_log')) {
+        Schema::create('activity_log', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->string('log_name')->nullable();
+            $table->text('description');
+            $table->nullableMorphs('subject', 'subject');
+            $table->nullableMorphs('causer', 'causer');
+            $table->json('properties')->nullable();
+            $table->uuid('batch_uuid')->nullable();
+            $table->string('event')->nullable();
+            $table->timestamps();
+        });
+    }
+}
+
+/**
+ * Onda 4f.0 — ADR 0170 (fundação CNAB compartilhada).
+ *
+ * Job CnabRetornoProcessor: parse arquivo retorno → match Cobranca →
+ * dispatch CobrancaPaga/Cancelada/Vencida + grava audit log + upload row.
+ *
+ * Strategy de fixtures:
+ *   - Usa fixtures reais da lib eduardokum em lib-custom/laravel-boleto/exemplos/arquivos/
+ *   - bradesco.ret tem 1 detalhe NN=000000000011 ocorrencia=02 (ENTRADA)
+ *   - Gera fixture sintética em runtime modificando bytes 109-110 pra '06' (LIQUIDAÇÃO)
+ *     ou '09' (BAIXA sem pagamento) — pattern documentado em lib readme.
+ *
+ * Multi-tenant Tier 0 (ADR 0093): testa isolamento por business_id.
+ */
+
+/** Caminho absoluto do fixture original Bradesco CNAB400. */
+function bradescoRetFixturePath(): string
+{
+    return realpath(__DIR__ . '/../../../../lib-custom/laravel-boleto/exemplos/arquivos/bradesco.ret');
+}
+
+/**
+ * Lê fixture e substitui o código de ocorrência (bytes 109-110 do detalhe, 1-indexed)
+ * pra simular liquidação/baixa.
+ */
+function fakeCnabRetorno(string $codigoOcorrencia): string
+{
+    $fixture = file_get_contents(bradescoRetFixturePath());
+    $linhas = preg_split('/\r\n|\r|\n/', $fixture);
+
+    // linha 0 = header, linha 1 = detalhe, linha 2 = trailer
+    if (! isset($linhas[1])) {
+        throw new RuntimeException('fixture inesperado');
+    }
+
+    $detalhe = $linhas[1];
+    // Substitui posições 109-110 (1-indexed) = índice 108-109
+    $detalhe = substr_replace($detalhe, $codigoOcorrencia, 108, 2);
+    $linhas[1] = $detalhe;
+
+    return implode("\n", array_filter($linhas, fn ($l) => $l !== ''));
+}
+
+beforeEach(function () {
+    setupCnabRetornoSchema();
+    session(['business.id' => 1]);
+    Storage::fake('local');
+    Event::fake([CobrancaPaga::class, CobrancaCancelada::class, CobrancaVencida::class]);
+
+    $this->cred = PaymentGatewayCredential::query()->create([
+        'business_id'  => 1,
+        'gateway_key'  => 'bradesco_cnab',
+        'ambiente'     => 'production',
+        'ativo'        => true,
+        'nome_display' => 'Bradesco CNAB Test',
+        'config_json'  => [
+            'agencia'           => '1234',
+            'conta'             => '567890',
+            'carteira'          => '09',
+            'cedente_nome'      => 'Empresa Teste',
+            'cedente_documento' => '12345678000199',
+        ],
+    ]);
+
+    // Pré-cria cobranca matching nosso_numero do fixture (=000000000011)
+    $this->cobranca = Cobranca::query()->create([
+        'business_id'                    => 1,
+        'payment_gateway_credential_id'  => $this->cred->id,
+        'gateway_external_id'            => '000000000011',
+        'nosso_numero'                   => '000000000011',
+        'tipo'                           => 'boleto',
+        'status'                         => 'emitida',
+        'valor_centavos'                 => 10000, // R$ 100,00
+        'vencimento'                     => now()->subDays(5)->toDateString(), // vencida há 5d
+        'descricao'                      => 'Cobrança teste CNAB',
+        'idempotency_key'                => 'cnab-retorno-test-001',
+        'origem_type'                    => 'sale',
+        'origem_id'                      => 99001,
+        'payer_cpf_cnpj'                 => '12345678900',
+        'payer_name'                     => 'João Pagador',
+    ]);
+});
+
+// ─── liquidação ──────────────────────────────────────────────────────────
+
+it('dispatcha CobrancaPaga para títulos liquidados (ocorrência 06)', function () {
+    $arquivo = fakeCnabRetorno('06'); // LIQUIDAÇÃO
+    Storage::disk('local')->put('cnab-retornos/biz-1/cred-' . $this->cred->id . '/file.ret', $arquivo);
+
+    $upload = CnabRetornoUpload::query()->create([
+        'business_id'                   => 1,
+        'payment_gateway_credential_id' => $this->cred->id,
+        'arquivo_path'                  => 'cnab-retornos/biz-1/cred-' . $this->cred->id . '/file.ret',
+        'arquivo_nome_original'         => 'bradesco_retorno.ret',
+        'arquivo_tamanho_bytes'         => strlen($arquivo),
+    ]);
+
+    (new CnabRetornoProcessor(
+        credentialId: $this->cred->id,
+        arquivoRetornoPath: $upload->arquivo_path,
+        uploadId: $upload->id,
+        disk: 'local',
+    ))->handle();
+
+    Event::assertDispatched(CobrancaPaga::class, function (CobrancaPaga $e) {
+        return $e->cobrancaId === $this->cobranca->id
+            && $e->businessId === 1
+            && $e->valorPagoCentavos === 10000
+            && $e->formaPagamento === 'boleto';
+    });
+
+    $this->cobranca->refresh();
+    expect($this->cobranca->status)->toBe('paga');
+    expect($this->cobranca->paga_em)->not->toBeNull();
+    expect($this->cobranca->valor_pago_centavos)->toBe(10000);
+});
+
+// ─── baixa sem pagamento → cancelamento ──────────────────────────────────
+
+it('dispatcha CobrancaCancelada para baixa sem pagamento (ocorrência 09)', function () {
+    $arquivo = fakeCnabRetorno('09'); // BAIXA AUTOM
+    Storage::disk('local')->put('cnab-retornos/biz-1/cred-' . $this->cred->id . '/baixa.ret', $arquivo);
+
+    $upload = CnabRetornoUpload::query()->create([
+        'business_id'                   => 1,
+        'payment_gateway_credential_id' => $this->cred->id,
+        'arquivo_path'                  => 'cnab-retornos/biz-1/cred-' . $this->cred->id . '/baixa.ret',
+        'arquivo_nome_original'         => 'baixa.ret',
+    ]);
+
+    (new CnabRetornoProcessor(
+        credentialId: $this->cred->id,
+        arquivoRetornoPath: $upload->arquivo_path,
+        uploadId: $upload->id,
+    ))->handle();
+
+    Event::assertDispatched(CobrancaCancelada::class, function (CobrancaCancelada $e) {
+        return $e->cobrancaId === $this->cobranca->id
+            && $e->motivo === 'cnab_retorno_baixa';
+    });
+
+    $this->cobranca->refresh();
+    expect($this->cobranca->status)->toBe('cancelada');
+});
+
+// ─── entrada confirmada vencida → CobrancaVencida ────────────────────────
+
+it('dispatcha CobrancaVencida quando entrada (02) tem vencimento passado', function () {
+    $arquivo = fakeCnabRetorno('02'); // ENTRADA — vencimento da cobranca foi há 5d
+    Storage::disk('local')->put('cnab-retornos/biz-1/cred-' . $this->cred->id . '/entrada.ret', $arquivo);
+
+    $upload = CnabRetornoUpload::query()->create([
+        'business_id'                   => 1,
+        'payment_gateway_credential_id' => $this->cred->id,
+        'arquivo_path'                  => 'cnab-retornos/biz-1/cred-' . $this->cred->id . '/entrada.ret',
+        'arquivo_nome_original'         => 'entrada.ret',
+    ]);
+
+    (new CnabRetornoProcessor(
+        credentialId: $this->cred->id,
+        arquivoRetornoPath: $upload->arquivo_path,
+        uploadId: $upload->id,
+    ))->handle();
+
+    Event::assertDispatched(CobrancaVencida::class, function (CobrancaVencida $e) {
+        return $e->cobrancaId === $this->cobranca->id
+            && $e->diasVencido >= 4;
+    });
+});
+
+// ─── idempotência ────────────────────────────────────────────────────────
+
+it('é idempotente: quando paga_em já setado, não dispatcha CobrancaPaga novamente', function () {
+    // Pré-marca cobranca como já paga
+    $this->cobranca->update([
+        'status'              => 'paga',
+        'paga_em'             => now()->subDay(),
+        'valor_pago_centavos' => 10000,
+    ]);
+
+    $arquivo = fakeCnabRetorno('06');
+    Storage::disk('local')->put('cnab-retornos/biz-1/cred-' . $this->cred->id . '/rerun.ret', $arquivo);
+
+    $upload = CnabRetornoUpload::query()->create([
+        'business_id'                   => 1,
+        'payment_gateway_credential_id' => $this->cred->id,
+        'arquivo_path'                  => 'cnab-retornos/biz-1/cred-' . $this->cred->id . '/rerun.ret',
+        'arquivo_nome_original'         => 'rerun.ret',
+    ]);
+
+    (new CnabRetornoProcessor(
+        credentialId: $this->cred->id,
+        arquivoRetornoPath: $upload->arquivo_path,
+        uploadId: $upload->id,
+    ))->handle();
+
+    // Job ainda incrementa contador 'paga' (achou um detalhe LIQUIDADA),
+    // mas NÃO dispatcha o evento (aplicarLiquidacao early-return).
+    Event::assertNotDispatched(CobrancaPaga::class);
+});
+
+// ─── métricas no CnabRetornoUpload ───────────────────────────────────────
+
+it('grava CnabRetornoUpload com métricas após processar', function () {
+    $arquivo = fakeCnabRetorno('06');
+    Storage::disk('local')->put('cnab-retornos/biz-1/cred-' . $this->cred->id . '/metrics.ret', $arquivo);
+
+    $upload = CnabRetornoUpload::query()->create([
+        'business_id'                   => 1,
+        'payment_gateway_credential_id' => $this->cred->id,
+        'arquivo_path'                  => 'cnab-retornos/biz-1/cred-' . $this->cred->id . '/metrics.ret',
+        'arquivo_nome_original'         => 'metrics.ret',
+    ]);
+
+    (new CnabRetornoProcessor(
+        credentialId: $this->cred->id,
+        arquivoRetornoPath: $upload->arquivo_path,
+        uploadId: $upload->id,
+    ))->handle();
+
+    $upload->refresh();
+    expect($upload->processado_em)->not->toBeNull();
+    expect($upload->qtd_paga)->toBe(1);
+    expect($upload->qtd_cancelada)->toBe(0);
+    expect($upload->qtd_registrada)->toBe(0);
+    expect($upload->errosArray())->toBeArray();
+
+    // GatewayWebhookEvent audit row criada
+    $audit = GatewayWebhookEvent::query()
+        ->where('business_id', 1)
+        ->where('payment_gateway_credential_id', $this->cred->id)
+        ->where('evento', 'cnab_retorno_upload')
+        ->first();
+    expect($audit)->not->toBeNull();
+    expect($audit->signature_valid)->toBeTrue();
+});
+
+// ─── multi-tenant Tier 0 ─────────────────────────────────────────────────
+
+it('respeita business_id global scope — não atualiza cobranca de outro business', function () {
+    // Outra business com mesma nossoNumero — NUNCA pode ser tocada
+    $cobrancaBiz2 = Cobranca::query()->create([
+        'business_id'                    => 2,
+        'payment_gateway_credential_id'  => null,
+        'gateway_external_id'            => '000000000011',
+        'nosso_numero'                   => '000000000011',
+        'tipo'                           => 'boleto',
+        'status'                         => 'emitida',
+        'valor_centavos'                 => 99999,
+        'vencimento'                     => now()->addDay()->toDateString(),
+        'descricao'                      => 'Outra biz — não tocar',
+        'idempotency_key'                => 'biz2-cnab-001',
+    ]);
+
+    $arquivo = fakeCnabRetorno('06');
+    Storage::disk('local')->put('cnab-retornos/biz-1/cred-' . $this->cred->id . '/tier0.ret', $arquivo);
+
+    $upload = CnabRetornoUpload::query()->create([
+        'business_id'                   => 1,
+        'payment_gateway_credential_id' => $this->cred->id,
+        'arquivo_path'                  => 'cnab-retornos/biz-1/cred-' . $this->cred->id . '/tier0.ret',
+        'arquivo_nome_original'         => 'tier0.ret',
+    ]);
+
+    (new CnabRetornoProcessor(
+        credentialId: $this->cred->id, // credential da biz 1
+        arquivoRetornoPath: $upload->arquivo_path,
+        uploadId: $upload->id,
+    ))->handle();
+
+    // Cobranca biz 1 atualizada
+    $this->cobranca->refresh();
+    expect($this->cobranca->status)->toBe('paga');
+
+    // Cobranca biz 2 INTOCADA — Tier 0 honrado
+    $cobrancaBiz2->refresh();
+    expect($cobrancaBiz2->status)->toBe('emitida');
+    expect($cobrancaBiz2->paga_em)->toBeNull();
+});
+
+// ─── arquivo inexistente ─────────────────────────────────────────────────
+
+it('não quebra quando arquivo de retorno não existe', function () {
+    $upload = CnabRetornoUpload::query()->create([
+        'business_id'                   => 1,
+        'payment_gateway_credential_id' => $this->cred->id,
+        'arquivo_path'                  => 'cnab-retornos/biz-1/cred-' . $this->cred->id . '/nao-existe.ret',
+        'arquivo_nome_original'         => 'nao-existe.ret',
+    ]);
+
+    (new CnabRetornoProcessor(
+        credentialId: $this->cred->id,
+        arquivoRetornoPath: $upload->arquivo_path,
+        uploadId: $upload->id,
+    ))->handle();
+
+    $upload->refresh();
+    expect($upload->processado_em)->not->toBeNull();
+    expect($upload->errosArray())->toContain('arquivo_inexistente:' . $upload->arquivo_path);
+});

--- a/config/ui-lint-baseline.json
+++ b/config/ui-lint-baseline.json
@@ -1,9 +1,9 @@
 {
     "_meta": {
-        "generated_at": "2026-05-25T15:11:26-03:00",
+        "generated_at": "2026-05-26T04:56:16-03:00",
         "tool": "ui:lint",
-        "files_scanned": 493,
-        "total_violations": 7366,
+        "files_scanned": 498,
+        "total_violations": 7411,
         "rules": {
             "R1": "cor crua (hex literal ou bg-COR-NNN em Page)",
             "R2": "FontAwesome (lucide-only · ADR UI-0003)",
@@ -465,7 +465,7 @@
             "R1": 18
         },
         "resources\/js\/Pages\/Financeiro\/Unificado\/Index.tsx": {
-            "R1": 143,
+            "R1": 142,
             "R3": 6
         },
         "resources\/js\/Pages\/Financeiro\/Unificado\/Novo.tsx": {
@@ -926,6 +926,9 @@
         },
         "resources\/js\/Pages\/Sells\/_components\/SaleTimeline.tsx": {
             "R1": 44
+        },
+        "resources\/js\/Pages\/Settings\/PaymentGateways\/CnabRetorno.tsx": {
+            "R1": 38
         },
         "resources\/js\/Pages\/Settings\/PaymentGateways\/Index.tsx": {
             "R1": 41

--- a/resources/js/Pages/Settings/PaymentGateways/CnabRetorno.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/CnabRetorno.tsx
@@ -1,0 +1,230 @@
+// Settings/PaymentGateways/CnabRetorno.tsx — Onda 4f.0 fundação CNAB
+//
+// Upload manual de arquivo de RETORNO CNAB (240/400) + histórico.
+//
+// Refs:
+//  - ADR 0170-bancos-nativos-top5-drivers-separados — Onda 4f.0
+//  - Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysCnabRetornoController.php
+//  - Modules/PaymentGateway/Jobs/CnabRetornoProcessor.php
+//
+// Persona: Wagner / superadmin / owner. Sem charter F1 nesta onda (fundação
+// técnica — Cowork F1 fica pra Onda 4f.cnab quando drivers concretos existirem).
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { router, Deferred, useForm } from '@inertiajs/react';
+import { useRef, type ChangeEvent, type FormEvent } from 'react';
+import { ArrowLeft, Upload, FileText, CheckCircle2, XCircle, RefreshCw, Clock } from 'lucide-react';
+import { Btn, PageHeader } from '../../Financeiro/Cobranca/_components/atoms';
+
+interface CredentialInfo {
+  id: number;
+  gateway_key: string;
+  nome_display: string | null;
+  ambiente: string;
+  ativo: boolean;
+}
+
+interface UploadRow {
+  id: number;
+  arquivo_nome_original: string;
+  arquivo_tamanho_bytes: number;
+  processado_em: string | null;
+  qtd_paga: number;
+  qtd_cancelada: number;
+  qtd_vencida: number;
+  qtd_registrada: number;
+  erros: string[];
+  created_at: string;
+}
+
+interface Limites {
+  tamanho_max_kb: number;
+  extensoes: string[];
+}
+
+interface Props {
+  credential: CredentialInfo;
+  uploads: UploadRow[];
+  limites: Limites;
+}
+
+function fmtBytes(b: number): string {
+  if (b < 1024) return `${b} B`;
+  if (b < 1024 * 1024) return `${(b / 1024).toFixed(1)} KB`;
+  return `${(b / (1024 * 1024)).toFixed(2)} MB`;
+}
+
+function fmtDate(iso: string | null): string {
+  if (!iso) return '—';
+  try {
+    return new Date(iso).toLocaleString('pt-BR');
+  } catch {
+    return iso;
+  }
+}
+
+function CnabRetornoPage({ credential, uploads, limites }: Props) {
+  // Hotfix Inertia::defer first paint.
+  uploads = uploads ?? [];
+
+  const fileRef = useRef<HTMLInputElement>(null);
+  const { data, setData, post, processing, errors, reset } = useForm<{ arquivo: File | null }>({
+    arquivo: null,
+  });
+
+  const onFile = (e: ChangeEvent<HTMLInputElement>) => {
+    setData('arquivo', e.target.files?.[0] ?? null);
+  };
+
+  const onSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!data.arquivo) return;
+    post(`/settings/payment-gateways/${credential.id}/cnab-retorno`, {
+      forceFormData: true,
+      onSuccess: () => {
+        reset('arquivo');
+        if (fileRef.current) fileRef.current.value = '';
+        router.reload({ only: ['uploads'] });
+      },
+    });
+  };
+
+  return (
+    <div className="h-full bg-stone-50 flex flex-col font-sans pg-shell-scope">
+      <PageHeader
+        title="Retorno CNAB"
+        breadcrumb={`Configurações · Pagamento · ${credential.gateway_key}`}
+        right={
+          <>
+            <Btn
+              variant="ghost"
+              onClick={() => router.visit('/settings/payment-gateways')}
+              title="Voltar"
+            >
+              <ArrowLeft className="h-3 w-3" />
+              Voltar
+            </Btn>
+            <Btn
+              variant="outline"
+              onClick={() => router.reload({ only: ['uploads'] })}
+            >
+              <RefreshCw className="h-3 w-3" />
+              Atualizar
+            </Btn>
+          </>
+        }
+      />
+
+      <div className="px-6 py-5 space-y-5 max-w-5xl">
+        <div className="rounded-md border border-stone-200 bg-white p-4">
+          <h2 className="text-sm font-medium text-stone-900 mb-1">
+            {credential.nome_display ?? credential.gateway_key} ·{' '}
+            <span className="text-stone-500">{credential.ambiente}</span>
+          </h2>
+          <p className="text-xs text-stone-600">
+            Faça upload do arquivo de retorno CNAB (240 ou 400) enviado pelo banco. O processamento
+            roda em background e atualiza as cobranças (pagas, baixadas, vencidas).
+          </p>
+        </div>
+
+        <form
+          onSubmit={onSubmit}
+          className="rounded-md border border-stone-200 bg-white p-4 space-y-3"
+        >
+          <label className="block text-xs font-medium text-stone-800">
+            Arquivo de retorno
+          </label>
+          <input
+            ref={fileRef}
+            type="file"
+            accept={limites.extensoes.map((e) => '.' + e).join(',')}
+            onChange={onFile}
+            className="block text-xs"
+          />
+          <p className="text-[11px] text-stone-500">
+            Extensões aceitas: {limites.extensoes.join(', ')} · Tamanho máx:{' '}
+            {Math.round(limites.tamanho_max_kb / 1024)} MB
+          </p>
+          {errors.arquivo ? (
+            <p className="text-xs text-rose-600">{errors.arquivo}</p>
+          ) : null}
+          <Btn variant="primary" type="submit" disabled={!data.arquivo || processing}>
+            <Upload className="h-3 w-3" />
+            {processing ? 'Enviando…' : 'Enviar arquivo'}
+          </Btn>
+        </form>
+
+        <div className="rounded-md border border-stone-200 bg-white overflow-hidden">
+          <div className="px-4 py-2 border-b border-stone-200 bg-stone-50">
+            <h3 className="text-xs font-medium text-stone-800">Uploads recentes</h3>
+          </div>
+          <Deferred
+            data="uploads"
+            fallback={
+              <div className="p-6 text-center text-xs text-stone-500">
+                <RefreshCw className="h-4 w-4 inline-block animate-spin" /> Carregando…
+              </div>
+            }
+          >
+            {uploads.length === 0 ? (
+              <div className="p-6 text-center text-xs text-stone-500">
+                <FileText className="h-4 w-4 inline-block" /> Nenhum upload ainda.
+              </div>
+            ) : (
+              <table className="w-full text-xs">
+                <thead className="bg-stone-50 border-b border-stone-200">
+                  <tr>
+                    <th className="text-left px-3 py-2 font-medium text-stone-700">Arquivo</th>
+                    <th className="text-left px-3 py-2 font-medium text-stone-700">Tamanho</th>
+                    <th className="text-left px-3 py-2 font-medium text-stone-700">Enviado</th>
+                    <th className="text-left px-3 py-2 font-medium text-stone-700">Processado</th>
+                    <th className="text-right px-3 py-2 font-medium text-stone-700">Pagas</th>
+                    <th className="text-right px-3 py-2 font-medium text-stone-700">Canceladas</th>
+                    <th className="text-right px-3 py-2 font-medium text-stone-700">Vencidas</th>
+                    <th className="text-right px-3 py-2 font-medium text-stone-700">Registradas</th>
+                    <th className="text-left px-3 py-2 font-medium text-stone-700">Status</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {uploads.map((u) => (
+                    <tr key={u.id} className="border-b border-stone-100 last:border-0">
+                      <td className="px-3 py-2 text-stone-800">{u.arquivo_nome_original}</td>
+                      <td className="px-3 py-2 text-stone-600">{fmtBytes(u.arquivo_tamanho_bytes)}</td>
+                      <td className="px-3 py-2 text-stone-600">{fmtDate(u.created_at)}</td>
+                      <td className="px-3 py-2 text-stone-600">{fmtDate(u.processado_em)}</td>
+                      <td className="px-3 py-2 text-right text-emerald-700">{u.qtd_paga}</td>
+                      <td className="px-3 py-2 text-right text-rose-600">{u.qtd_cancelada}</td>
+                      <td className="px-3 py-2 text-right text-amber-600">{u.qtd_vencida}</td>
+                      <td className="px-3 py-2 text-right text-stone-700">{u.qtd_registrada}</td>
+                      <td className="px-3 py-2">
+                        {u.processado_em ? (
+                          u.erros.length > 0 ? (
+                            <span className="inline-flex items-center gap-1 text-rose-600" title={u.erros.join('\n')}>
+                              <XCircle className="h-3 w-3" /> {u.erros.length} erro(s)
+                            </span>
+                          ) : (
+                            <span className="inline-flex items-center gap-1 text-emerald-700">
+                              <CheckCircle2 className="h-3 w-3" /> OK
+                            </span>
+                          )
+                        ) : (
+                          <span className="inline-flex items-center gap-1 text-stone-500">
+                            <Clock className="h-3 w-3" /> Pendente
+                          </span>
+                        )}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </Deferred>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+CnabRetornoPage.layout = (page: React.ReactNode) => <AppShellV2>{page}</AppShellV2>;
+
+export default CnabRetornoPage;


### PR DESCRIPTION
## Resumo

Onda 4f.0 do [ADR 0170 drivers-separados](memory/decisions/0170-bancos-nativos-top5-drivers-separados.md): **fundação compartilhada CNAB** pros 5 drivers paralelos (Bradesco/Itaú/BB/Santander/Caixa) que entram na próxima onda (4f.cnab). Driver concreto futuro herda \`CnabBoletoAdapter\` abstract e implementa apenas 3 métodos.

## Escopo

- **Abstract** \`Services/Cnab/CnabBoletoAdapter.php\` (466 LOC) — implementa \`PaymentDriverContract\`:
  - \`emitirBoleto\` monta \`Eduardokum\LaravelBoleto\Boleto\Banco\{X}\`, gera nossoNumero, grava remessa em \`Storage::disk('local')/cnab-remessas/biz-{id}/cred-{id}/\`
  - \`cancelar\` gera arquivo instrução PEDIDO_CANCELAMENTO (CNAB 240 cód '02' / 400 '31')
  - \`healthCheck\` valida config_json camposObrigatorios + instancia smoke Boleto
  - throw \`DriverNotSupportedException\` pra: \`emitirPix\`/\`emitirPixAutomatico\`/\`cobrarCartao\`/\`refund\`/\`consultar\`/\`processWebhook\` (CNAB é file-based)
- **Job** \`Jobs/CnabRetornoProcessor.php\` (358 LOC):
  - Lê arquivo via Storage + auto-detecta layout 240/400 + banco (\`Eduardokum\LaravelBoleto\Cnab\Retorno\Factory::make\`)
  - Match \`Cobranca\` por \`(business_id, nosso_numero|gateway_external_id)\` — Tier 0 explícito
  - Dispatch \`CobrancaPaga\`/\`CobrancaCancelada\`/\`CobrancaVencida\` conforme \`OcorrenciaTipo\`
  - **Idempotência** rerun-seguro: skip se \`paga_em\` já setado
  - Audit log via \`GatewayWebhookEvent\` com \`evento='cnab_retorno_upload'\`
- **Model+Migration** \`cnab_retorno_uploads\` (histórico processamento + métricas \`qtd_*\`)
- **Migration** expand enum \`payment_gateway_credentials.gateway_key\` (MySQL ALTER ENUM aceita 9 novas keys: 5 \`_cnab\` + 4 \`_api\`; SQLite no-op)
- **Controller+Route** \`Settings/PaymentGatewaysCnabRetornoController\` + rotas em \`/settings/payment-gateways/{id}/cnab-retorno\` (GET histórico + form, POST upload + dispatch Job)
- **Page Inertia** \`Settings/PaymentGateways/CnabRetorno.tsx\` (tabela + upload simples, sem charter F1 — onda fundação técnica)
- **Pest CnabBoletoAdapterContractTest** (14 testes, 37 assertions) — usa \`FakeBradescoCnabDriver\` (subclasse interna do test) pra exercitar contract
- **Pest CnabRetornoProcessorTest** (7 testes, 20 assertions) — usa fixture real \`lib-custom/laravel-boleto/exemplos/arquivos/bradesco.ret\` com mutação dos bytes 109-110 pra simular liquidação/baixa
- **Schema in-memory por test** (pattern canon \`WebhookEndpointsTest\` — \`RefreshDatabase\` tropeça em ALTER TABLE MODIFY ENUM MySQL-only)

## Tier 0 honrado

- \`HasBusinessScope\` em \`CnabRetornoUpload\`
- Job worker filtra \`Cobranca\` por \`business_id\` explicitamente (worker queue sem session, padrão [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md))
- Storage paths segregados: \`cnab-retornos/biz-{id}/cred-{id}/\` e \`cnab-remessas/biz-{id}/cred-{id}/\`
- Teste \`it_respeita_business_id_global_scope\` valida isolamento entre businesses
- LGPD: \`maskDocumento\` em logs (não vaza CPF/CNPJ inteiro)

## NÃO inclui (próxima onda 4f.cnab — spawn 5 paralelos)

- \`BradescoCnabDriver\` / \`ItauCnabDriver\` / \`BBCnabDriver\` / \`SantanderCnabDriver\` / \`CaixaCnabDriver\`
- Modificação de \`PaymentGatewayService::DRIVERS\` const (drivers concretos ainda não existem)
- Drivers REST API top-5 (Ondas 4f-4j sequenciais)

## Test plan

- [x] Pest local \`CnabBoletoAdapterContractTest\` — 14/14 passed (37 assertions)
- [x] Pest local \`CnabRetornoProcessorTest\` — 7/7 passed (20 assertions)
- [x] Total: **21/21 passed (57 assertions, 7.21s)**
- [x] Fixture real Bradesco CNAB400 parseia OK (Banco=237, NN=000000000011, ocorrência mutável 02→06/09 via byte-replace)
- [x] Isolamento Tier 0 validado em \`it_respeita_business_id_global_scope\`
- [x] Idempotência validada em \`it_é_idempotente_quando_paga_em_já_setado\`
- [x] \`ls -la\` confirma 9 arquivos criados no filesystem
- [ ] Smoke real upload de arquivo CNAB de cliente piloto — bloqueado pela próxima onda (precisa de driver concreto)

## Refs

- ADR pai: [ADR 0170 drivers-separados](memory/decisions/0170-bancos-nativos-top5-drivers-separados.md)
- Lib externa: \`lib-custom/laravel-boleto\` (Eduardokum fork — CNAB 11 bancos + API Inter)
- Pattern InterDriver canon: \`Modules/PaymentGateway/Services/Drivers/InterDriver.php\`
- Refs: \`ADR 0170-bancos-nativos-top5-drivers-separados Onda 4f.0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)