### PR TITLE
feat(financeiro,sidebar): grupo FINANÇAS = 4 entries flat (Caixa·Cobrança·Financeiro·CobRecorrente)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/DataController.php
+++ b/Modules/Financeiro/Http/Controllers/DataController.php
@@ -92,40 +92,92 @@ class DataController extends Controller
         }
 
         $background_color = config('app.env') == 'demo' ? '#ffd6a5' : '';
-        $segmento_ativo = request()->segment(1) == 'financeiro';
+        $seg2 = request()->segment(2);
 
-        // Wagner 2026-05-22 direção canon: 1 entry sidebar + 4 ghosts canon
-        // (Caixa · Cobrança · Financeiro · Relatório). Remove 12 entries
-        // duplicadas que poluíam o grupo FINANÇAS. Sub-items são absorvidos
-        // como tabs/seções DENTRO dos 4 hubs canon (acessíveis via header
-        // PageHeaderTabs ARIA + URL direta).
+        // Wagner 2026-05-26 direção canon: grupo FINANÇAS agora tem 4 entries
+        // FLAT no sidebar — substitui 1 entry "Financeiro" com 13 ghosts.
+        // Espelha PR #1541 (Fiscal flat) e PR #1547 (Governança removida).
         //
-        // Mapping canon (Wagner 2026-05-22):
-        //   Caixa     → /financeiro/caixa      (absorve Conciliação + Contas Bancárias)
-        //   Cobrança  → /financeiro/cobranca   (absorve Contas a Receber)
-        //   Financeiro → /financeiro/unificado (default — absorve Contas a Pagar + Fluxo)
-        //   Relatório → /financeiro/relatorios (absorve DRE)
+        //   sidebar FINANÇAS
+        //     ├── Caixa             /financeiro/caixa            (order 85.00)
+        //     ├── Cobrança          /financeiro/cobranca         (order 85.10) — Gateway vira GHOST aqui
+        //     ├── Financeiro (hub)  /financeiro/unificado        (order 85.20)
+        //     └── Cobrança Recorrente /recurring-billing         (order 86.00 — RecurringBilling DataController)
         //
-        // TODO Fase 4 user menu cascade (Wagner aprovou 2026-05-22):
-        //   Plano de Contas + Categorias + Contador vão pra cascade
-        //   "Configurações do business" no user menu (rodapé). Por ora,
-        //   acessíveis via URL direta /financeiro/plano-contas, /categorias,
-        //   /configuracoes/contador (rotas continuam existindo).
+        // Gateway de Pagamento NÃO é mais entry própria do sidebar (PaymentGateway
+        // DataController deixou de chamar Menu::modify). Vive como ghost da
+        // Cobrança — fica acessível via PageHeader em /financeiro/cobranca.
+        //
+        // Sub-items legacy (DRE/Fluxo/Conciliação/Contas a Pagar/Plano de Contas/
+        // Categorias/Dashboard/Extrato/Contador/Relatórios) continuam acessíveis
+        // como ghosts do hub "Financeiro" (terceira entry).
         Menu::modify(
             'admin-sidebar-menu',
-            function ($menu) use ($background_color, $segmento_ativo) {
-                // Entry única — hub Financeiro com 4 ghosts canon no header.
-                //
-                // ADR 0180 + Wagner 2026-05-22 direção: reduz 13→4 ghosts.
-                // PageHeaderTabs renderiza inline (Caixa/Cobrança/Financeiro/
-                // Relatório), todos visíveis sem overflow.
+            function ($menu) use ($background_color, $seg2) {
+                // ENTRY 1 — Caixa (operação Larissa diária: abrir/fechar caixa).
+                $menu->url(
+                    url('/financeiro/caixa'),
+                    'Caixa',
+                    [
+                        'icon'     => 'fa fas fa-cash-register',
+                        'style'    => 'background-color:' . $background_color,
+                        'active'   => $seg2 === 'caixa',
+                        'group'    => 'financas',
+                        'shortcut' => 'G C',
+                        'primary'  => [
+                            'label'    => 'Abrir caixa',
+                            'href'     => '/financeiro/caixa',
+                            'shortcut' => 'N',
+                        ],
+                        'ghosts'   => [
+                            ['key' => 'caixa',            'label' => 'Caixa',            'href' => '/financeiro/caixa'],
+                            ['key' => 'conciliacao',      'label' => 'Conciliação',      'href' => '/financeiro/conciliacao'],
+                            ['key' => 'contas-bancarias', 'label' => 'Contas Bancárias', 'href' => '/financeiro/contas-bancarias'],
+                            ['key' => 'extrato',          'label' => 'Extrato',          'href' => '/financeiro/extrato'],
+                        ],
+                    ]
+                )->order(85.00);
+
+                // ENTRY 2 — Cobrança (emitir boleto/pix/cartão). Gateway de
+                // Pagamento é GHOST aqui (PR #1577+ Wagner 2026-05-26).
+                $cobrancaAtiva = in_array($seg2, ['cobranca', 'contas-receber', 'boletos'])
+                    || (request()->segment(1) === 'settings' && $seg2 === 'payment-gateways');
+                $menu->url(
+                    url('/financeiro/cobranca'),
+                    'Cobrança',
+                    [
+                        'icon'     => 'fa fas fa-file-invoice-dollar',
+                        'style'    => 'background-color:' . $background_color,
+                        'active'   => $cobrancaAtiva,
+                        'group'    => 'financas',
+                        'shortcut' => 'G B',
+                        'primary'  => [
+                            'label'    => 'Nova cobrança',
+                            'href'     => '/financeiro/cobranca',
+                            'shortcut' => 'N',
+                        ],
+                        'ghosts'   => [
+                            ['key' => 'cobranca',        'label' => 'Cobrança',         'href' => '/financeiro/cobranca'],
+                            ['key' => 'contas-receber',  'label' => 'Contas a Receber', 'href' => '/financeiro/contas-receber'],
+                            ['key' => 'gateway',         'label' => 'Gateway',          'href' => '/settings/payment-gateways'],
+                        ],
+                    ]
+                )->order(85.10);
+
+                // ENTRY 3 — Financeiro (hub geral). Mantém label do lang module_label
+                // pra compat com modules superadmin + traduções i18n. Ghosts =
+                // restante das telas legacy (Fluxo/DRE/Pagar/Categorias/etc).
+                $financeiroAtiva = in_array($seg2, [
+                    'unificado','lancamentos','contas-pagar','fluxo','dre','plano-contas',
+                    'categorias','dashboard','configuracoes','relatorios',
+                ]);
                 $menu->url(
                     url('/financeiro/unificado'),
                     __('financeiro::financeiro.module_label'),
                     [
                         'icon'     => 'fa fas fa-coins',
                         'style'    => 'background-color:' . $background_color,
-                        'active'   => $segmento_ativo,
+                        'active'   => $financeiroAtiva,
                         'group'    => 'financas',
                         'shortcut' => 'G F',
                         'primary'  => [
@@ -134,26 +186,18 @@ class DataController extends Controller
                             'shortcut' => 'N',
                         ],
                         'ghosts'   => [
-                            // 4 ghosts canon (Wagner 2026-05-22) — visíveis inline.
-                            ['key' => 'caixa',      'label' => 'Caixa',      'href' => '/financeiro/caixa'],
-                            ['key' => 'cobranca',   'label' => 'Cobrança',   'href' => '/financeiro/cobranca'],
-                            ['key' => 'financeiro', 'label' => 'Financeiro', 'href' => '/financeiro/unificado'],
-                            ['key' => 'relatorio',  'label' => 'Relatório',  'href' => '/financeiro/relatorios'],
-                            // Wagner 2026-05-22 P1: +11 ghosts pra zerar órfãs (vão pro overflow ⋯ Mais).
-                            ['key' => 'contas-receber',   'label' => 'Contas a Receber', 'href' => '/financeiro/contas-receber'],
-                            ['key' => 'contas-pagar',     'label' => 'Contas a Pagar',   'href' => '/financeiro/contas-pagar'],
-                            ['key' => 'fluxo',            'label' => 'Fluxo de Caixa',   'href' => '/financeiro/fluxo'],
-                            ['key' => 'conciliacao',      'label' => 'Conciliação',      'href' => '/financeiro/conciliacao'],
-                            ['key' => 'dre',              'label' => 'DRE',              'href' => '/financeiro/dre'],
-                            ['key' => 'contas-bancarias', 'label' => 'Contas Bancárias', 'href' => '/financeiro/contas-bancarias'],
-                            ['key' => 'plano-contas',     'label' => 'Plano de Contas',  'href' => '/financeiro/plano-contas'],
-                            ['key' => 'categorias',       'label' => 'Categorias',       'href' => '/financeiro/categorias'],
-                            ['key' => 'dashboard',        'label' => 'Dashboard',        'href' => '/financeiro/dashboard'],
-                            ['key' => 'extrato',          'label' => 'Extrato',          'href' => '/financeiro/extrato'],
-                            ['key' => 'contador',         'label' => 'Contador',         'href' => '/financeiro/configuracoes/contador'],
+                            ['key' => 'unificado',     'label' => 'Lançamentos',    'href' => '/financeiro/unificado'],
+                            ['key' => 'contas-pagar',  'label' => 'Contas a Pagar', 'href' => '/financeiro/contas-pagar'],
+                            ['key' => 'fluxo',         'label' => 'Fluxo de Caixa', 'href' => '/financeiro/fluxo'],
+                            ['key' => 'dre',           'label' => 'DRE',            'href' => '/financeiro/dre'],
+                            ['key' => 'relatorios',    'label' => 'Relatórios',     'href' => '/financeiro/relatorios'],
+                            ['key' => 'dashboard',     'label' => 'Dashboard',      'href' => '/financeiro/dashboard'],
+                            ['key' => 'plano-contas',  'label' => 'Plano de Contas','href' => '/financeiro/plano-contas'],
+                            ['key' => 'categorias',    'label' => 'Categorias',     'href' => '/financeiro/categorias'],
+                            ['key' => 'contador',      'label' => 'Contador',       'href' => '/financeiro/configuracoes/contador'],
                         ],
                     ]
-                )->order(85.00);
+                )->order(85.20);
             }
         );
     }

--- a/Modules/PaymentGateway/Http/Controllers/DataController.php
+++ b/Modules/PaymentGateway/Http/Controllers/DataController.php
@@ -2,9 +2,7 @@
 
 namespace Modules\PaymentGateway\Http\Controllers;
 
-use App\Utils\ModuleUtil;
 use Illuminate\Routing\Controller;
-use Menu;
 
 /**
  * DataController do módulo PaymentGateway.
@@ -58,68 +56,32 @@ class DataController extends Controller
     }
 
     /**
-     * Camada visual sidebar — Onda 5 (2026-05-19): popular.
+     * Camada visual sidebar — Wagner 2026-05-26: NO-OP.
      *
-     * Adiciona entrada "Gateways de Pagamento" apontando pra
-     * /settings/payment-gateways (Page Inertia Onda 4d F3, PR #1135).
+     * Gateway de Pagamento NÃO é mais entry própria do sidebar. Vive como
+     * GHOST da entry "Cobrança" (definido em Modules/Financeiro/Http/Controllers/
+     * DataController.modifyAdminMenu, ghost key='gateway' → /settings/payment-gateways).
      *
-     * Pattern segue Financeiro DataController.modifyAdminMenu — guard
-     * via isModuleInstalled + permission `paymentgateway.access`.
-     * 'group' => 'fin' agrupa visualmente com Financeiro na sidebar
-     * (Sidebar.tsx SIDEBAR_GROUPS canon ADR sidebar-menu-arch).
+     * Justificativa Wagner 2026-05-26:
+     *  - Grupo FINANÇAS = 4 entries flat canon (Caixa · Cobrança · Financeiro ·
+     *    Cobrança Recorrente). Gateway é CONFIGURAÇÃO de cobrança, não fluxo
+     *    operacional diário — não merece entry top-level.
+     *  - Larissa (biz=4 cliente piloto) acessa via PageHeader da Cobrança
+     *    quando configura Asaas/Inter/BCB pix.
+     *  - Reduz ruído visual no sidebar (FINANÇAS tinha 3 entries antes do PR;
+     *    agora tem 4 entries semanticamente paralelas).
+     *
+     * Rotas /settings/payment-gateways CONTINUAM ativas — apenas a injeção
+     * sidebar foi desligada. Acesso via URL direta, ghost na Cobrança, ou
+     * Cmd+K palette.
+     *
+     * Histórico do método (Onda 5 PR #1135 → 2026-05-26):
+     *   PR #1135 — Onda 5: criada entrada "Gateways de Pagamento" order 85.4
+     *   2026-05-22 — fix label hardcoded i18n bug
+     *   2026-05-26 — DESLIGADA (Wagner direção: vira ghost da Cobrança)
      */
     public function modifyAdminMenu(): void
     {
-        $module_util = new ModuleUtil();
-
-        if (auth()->user() && auth()->user()->can('superadmin')) {
-            $is_enabled = $module_util->isModuleInstalled('PaymentGateway');
-        } else {
-            $business_id = session('user.business_id');
-            $is_enabled = $business_id
-                ? (bool) $module_util->hasThePermissionInSubscription(
-                    $business_id,
-                    'paymentgateway_module',
-                    'superadmin_package'
-                )
-                : false;
-        }
-
-        if (! $is_enabled) {
-            return;
-        }
-
-        if (! auth()->user()->can('superadmin') && ! auth()->user()->can('paymentgateway.access')) {
-            return;
-        }
-
-        $segmento_settings = request()->segment(1) === 'settings'
-            && request()->segment(2) === 'payment-gateways';
-
-        // Wagner 2026-05-22 fix: label hardcoded literal pra resolver bug i18n
-        // que mostrava 'paymentgateway:paymentga...' no sidebar. Lang file existe
-        // mas namespace `paymentgateway::` não carregava (OPcache Hostinger ou
-        // module discovery). Hardcode é exceção pragmática à regra "frontend
-        // não hardcode label" — DataController PHP pode hardcode quando lang
-        // resolve quebra em prod. group: 'financas' canon v3.
-        Menu::modify('admin-sidebar-menu', function ($menu) use ($segmento_settings) {
-            $menu->url(
-                url('/settings/payment-gateways'),
-                'Gateway de Pagamento',
-                [
-                    'icon'    => 'fa fas fa-key',
-                    'active'  => $segmento_settings,
-                    'group'   => 'financas',
-                    'primary' => [
-                        'label'    => 'Conectar gateway',
-                        'href'     => '/settings/payment-gateways',
-                        'shortcut' => 'N',
-                    ],
-                    'ghosts'  => [
-                        ['key' => 'payment-gateways', 'label' => 'Gateway de Pagamento', 'href' => '/settings/payment-gateways'],
-                    ],
-                ]
-            )->order(85.4);
-        });
+        // No-op intencional. Ver docblock acima.
     }
 }

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -9,9 +9,9 @@
 import { useEffect, useRef, useState } from 'react';
 import { usePage } from '@inertiajs/react';
 import {
-  ArrowRightLeft, BarChart3, Bell, BookOpen, Bot, Box, Calculator, Calendar,
+  ArrowRightLeft, Banknote, BarChart3, Bell, BookOpen, Bot, Box, Calculator, Calendar,
   Check, ChevronDown, ChevronRight, ChevronUp, ClipboardList, Clock, CreditCard,
-  Factory, FileSearch, FileSpreadsheet, FileText, FolderKanban, Hash, Home, Inbox, Keyboard, LogOut,
+  Factory, FileSearch, FileSpreadsheet, FileText, FolderKanban, HandCoins, Hash, Home, Inbox, Keyboard, LogOut,
   MessageCircle, Monitor, Moon, Package, PackageCheck, Palette, Plug, Receipt,
   RefreshCw, Rocket, Search, Settings, Sheet, ShieldAlert, ShieldCheck, ShoppingCart, Sun,
   TrendingUp, UserCog, Users, Utensils, User, Vault, Wallet, Wrench,
@@ -68,9 +68,12 @@ const MENU_ICON_MAP: Record<string, LucideIcon> = {
   'contas de pagamento': Wallet,
   accounting: Calculator, contabilidade: Calculator,
   financeiro: Wallet,
-  // Wagner 2026-05-18: 3 entradas novas top-level KB-9.75 Financeiro.
-  // "Boletos" renomeado pra "Gateway de Pagamento" — ícone CreditCard
-  // (mais inclusivo: Inter boleto + PIX + Asaas futuro).
+  // Wagner 2026-05-26: grupo FINANÇAS = 4 entries flat (Caixa · Cobrança ·
+  // Financeiro · Cobrança Recorrente). Gateway de Pagamento virou ghost da
+  // Cobrança — removido como entry, mantém ícone aqui pra ghost render.
+  caixa: Banknote,
+  'cobrança': HandCoins,
+  cobranca: HandCoins,
   'fluxo de caixa': TrendingUp,
   'dre / relatórios': FileSpreadsheet,
   'gateway de pagamento': CreditCard,
@@ -184,7 +187,14 @@ const SIDEBAR_GROUPS: Array<{ key: string; label: string; items: string[] }> = [
     key: 'financas',
     label: 'FINANÇAS',
     // Wagner 2026-05-22: Fiscal SAI de FINANÇAS → vira grupo próprio FISCAL abaixo.
-    items: ['Financeiro'],
+    // Wagner 2026-05-26: 4 entries FLAT canon (Caixa · Cobrança · Financeiro ·
+    // Cobrança Recorrente). Gateway de Pagamento removido como entry (virou
+    // ghost da Cobrança em Modules/Financeiro/Http/Controllers/DataController).
+    // Espelha PR #1541 (Fiscal flat) — substitui 1 entry "Financeiro" + 13 ghosts
+    // por 3 entries semanticamente paralelas no DataController do Financeiro,
+    // mais "Cobrança Recorrente" que vem do RecurringBilling DataController.
+    // Alias 'Financeiro' mantido pra label resolvido do __('financeiro::module_label').
+    items: ['Caixa', 'Cobrança', 'Financeiro', 'Cobrança Recorrente'],
   },
   {
     key: 'fiscal',

--- a/tests/Feature/Sidebar/Biz4RotaLivreSidebarTest.php
+++ b/tests/Feature/Sidebar/Biz4RotaLivreSidebarTest.php
@@ -72,36 +72,53 @@ describe('Anti-regressão hardcode biz=N — IRREVOGÁVEL Wagner 2026-05-18', fu
     });
 });
 
-describe('Que sobrevive do trabalho biz=4 anterior — sem hardcode', function () {
-    it('Financeiro DataController publica 4 entradas top-level (não dropdown)', function () {
+describe('Sidebar FINANÇAS canon — 4 entries flat (Wagner 2026-05-26)', function () {
+    it('Financeiro DataController publica 3 entries top-level (Caixa · Cobrança · Financeiro)', function () {
         $src = file_get_contents(ROOT . '/Modules/Financeiro/Http/Controllers/DataController.php');
-        // 4 URLs separados em vez de 1 dropdown
-        expect($src)->toContain('/financeiro/unificado');
-        expect($src)->toContain('/financeiro/fluxo');
-        expect($src)->toContain('/financeiro/relatorios');
-        expect($src)->toContain('/financeiro/boletos');
-        // Orders fracionários 85.0/85.1/85.2/85.3
-        expect($src)->toContain('->order(85)');
-        expect($src)->toContain('->order(85.1)');
-        expect($src)->toContain('->order(85.2)');
-        expect($src)->toContain('->order(85.3)');
+        // 3 URLs primary distintos (4ª entrada Cobrança Recorrente vem do RecurringBilling)
+        expect($src)->toContain("url('/financeiro/caixa')");
+        expect($src)->toContain("url('/financeiro/cobranca')");
+        expect($src)->toContain("url('/financeiro/unificado')");
+        // Orders fracionários 85.00 / 85.10 / 85.20 (3 entries Financeiro)
+        expect($src)->toContain('->order(85.00)');
+        expect($src)->toContain('->order(85.10)');
+        expect($src)->toContain('->order(85.20)');
+        // Labels canon
+        expect($src)->toContain("'Caixa'");
+        expect($src)->toContain("'Cobrança'");
+        // Gateway é GHOST da Cobrança — não entry separada
+        expect($src)->toContain("'key' => 'gateway'");
+        expect($src)->toContain("/settings/payment-gateways");
     });
 
-    it('Lang pt/financeiro tem 3 chaves (cashflow / dre / boletos=Gateway)', function () {
-        $src = file_get_contents(ROOT . '/Modules/Financeiro/Resources/lang/pt/financeiro.php');
-        expect($src)->toContain("'cashflow_label' => 'Fluxo de Caixa'");
-        expect($src)->toContain("'dre_label' => 'DRE / Relatórios'");
-        expect($src)->toContain("'boletos_label' => 'Gateway de Pagamento'");
+    it('Cobrança Recorrente continua entry própria (RecurringBilling DataController)', function () {
+        $src = file_get_contents(ROOT . '/Modules/RecurringBilling/Http/Controllers/DataController.php');
+        expect($src)->toContain("'Cobrança Recorrente'");
+        expect($src)->toContain("'group'   => 'financas'");
+        expect($src)->toContain('->order(86)');
     });
 
-    it('Sidebar.tsx SIDEBAR_GROUPS tem 3 labels novas no grupo fin', function () {
+    it('PaymentGateway DataController NÃO injeta sidebar (Gateway virou ghost)', function () {
+        $src = file_get_contents(ROOT . '/Modules/PaymentGateway/Http/Controllers/DataController.php');
+        // Método modifyAdminMenu existe MAS é no-op (vazio + docblock)
+        expect($src)->toContain('public function modifyAdminMenu(): void');
+        expect($src)->not->toContain("Menu::modify");
+        expect($src)->not->toContain("'Gateway de Pagamento'");
+    });
+
+    it('Sidebar.tsx SIDEBAR_GROUPS.financas tem 4 labels canon flat', function () {
         $src = file_get_contents(ROOT . '/resources/js/Components/cockpit/Sidebar.tsx');
-        expect($src)->toContain("'Fluxo de Caixa'");
-        expect($src)->toContain("'DRE / Relatórios'");
-        expect($src)->toContain("'Gateway de Pagamento'");
-        // MENU_ICON_MAP entries
-        expect($src)->toContain("'fluxo de caixa': TrendingUp");
+        // Whitelist canon (substitui ['Financeiro'] de antes)
+        expect($src)->toContain("items: ['Caixa', 'Cobrança', 'Financeiro', 'Cobrança Recorrente'],");
+        // MENU_ICON_MAP entries novos
+        expect($src)->toContain("caixa: Banknote,");
+        expect($src)->toContain("'cobrança': HandCoins");
+        // Ícones legacy preservados pra ghost render
         expect($src)->toContain("'gateway de pagamento': CreditCard");
+        expect($src)->toContain("'cobrança recorrente': RefreshCw");
+        // Imports lucide novos
+        expect($src)->toContain("Banknote,");
+        expect($src)->toContain("HandCoins,");
     });
 });
 


### PR DESCRIPTION
## Resumo

Reorganiza grupo **FINANÇAS** no sidebar de **1 entry "Financeiro" + 13 ghosts** para **4 entries semanticamente paralelas**. Espelha PR #1541 (Fiscal flat) e PR #1547 (Governança removida).

Direção Wagner 2026-05-26: _"Na parte Grupo financeira deve ter → Caixa, Cobrança, Financeiro, Cobrança Recorrente. Gateway deve ir para ghost"_.

## Antes → Depois

| Antes (origin/main) | Depois |
|---|---|
| Financeiro `/financeiro/unificado` order 85.00 (+13 ghosts) | **Caixa** `/financeiro/caixa` order 85.00 |
| **Gateway de Pagamento** `/settings/payment-gateways` order 85.4 | **Cobrança** `/financeiro/cobranca` order 85.10 *(Gateway agora é ghost daqui)* |
| Cobrança Recorrente `/recurring-billing` order 86 | **Financeiro (hub)** `/financeiro/unificado` order 85.20 *(ghosts legacy: Fluxo/DRE/Pagar/etc)* |
|   | Cobrança Recorrente `/recurring-billing` order 86 *(inalterado)* |

## Arquivos tocados (4)

- **\`Modules/Financeiro/Http/Controllers/DataController.php\`** — 1 \`Menu::modify\` agora cria **3 entries flat** com primary + ghosts próprios cada. Caixa absorve Conciliação/ContasBancárias/Extrato como ghosts. Cobrança absorve ContasReceber + **Gateway** como ghosts. Hub Financeiro mantém ghosts legacy (Fluxo/DRE/Pagar/Categorias/PlanoContas/Dashboard/Relatórios/Contador).
- **\`Modules/PaymentGateway/Http/Controllers/DataController.php\`** — \`modifyAdminMenu\` vira **NO-OP**. Removido \`Menu::modify\`. Rotas \`/settings/payment-gateways\` continuam ativas (acesso via PageHeader da Cobrança ou URL direta).
- **\`resources/js/Components/cockpit/Sidebar.tsx\`** — whitelist \`SIDEBAR_GROUPS.financas.items\` → \`['Caixa', 'Cobrança', 'Financeiro', 'Cobrança Recorrente']\`. \`MENU_ICON_MAP\` ganha \`caixa: Banknote\` + \`cobrança: HandCoins\`. Imports lucide-react: \`Banknote\` + \`HandCoins\`.
- **\`tests/Feature/Sidebar/Biz4RotaLivreSidebarTest.php\`** — describe \"Sidebar FINANÇAS canon — 4 entries flat\" atualizado pro estado novo. Tests anti-hardcode biz=4 inalterados (passam 4/4 igual antes).

## Por que Gateway virou ghost (não entry)

- Gateway é **configuração** de cobrança (credenciais Asaas/Inter/BCB pix), não fluxo operacional diário da Larissa (biz=4 cliente piloto).
- Acesso via PageHeader da Cobrança quando precisa conectar/desconectar gateway — coerente com FIN-005 (gateways são *usados* pela Cobrança).
- Reduz ruído visual: FINANÇAS tinha 3 entries de peso desigual; agora 4 entries conceitualmente paralelas (operações cotidianas).

## Compatibilidade

- ✅ Rotas \`/settings/payment-gateways\` inalteradas (acesso via URL direta + ghost da Cobrança).
- ✅ Permission \`paymentgateway.access\` continua válida (controla Page render).
- ✅ Lang \`pt/financeiro.boletos_label => 'Gateway de Pagamento'\` mantida pra back-compat menu legacy.
- ✅ \`Modules/RecurringBilling/DataController\` inalterado — Cobrança Recorrente continua entry própria order 86.

## Test plan

- [x] \`php -l Modules/Financeiro/Http/Controllers/DataController.php\` — sem erros sintáticos
- [x] \`php -l Modules/PaymentGateway/Http/Controllers/DataController.php\` — sem erros sintáticos
- [x] \`vendor/bin/pest tests/Feature/Sidebar/Biz4RotaLivreSidebarTest.php\` — **7/8 passa** (1 fail pre-existente em test sobre memory/reference markdown, não causa deste PR — ver PR #1080)
- [x] \`lucide-react\` v0.* tem \`Banknote\` + \`HandCoins\` (verificado em \`node_modules/lucide-react/dist/lucide-react.d.ts\`)
- [ ] Smoke biz=4 (Larissa): abrir sidebar → grupo FINANÇAS mostra 4 entries flat na ordem Caixa·Cobrança·Financeiro·CobRecorrente, clicar Cobrança → PageHeader mostra ghost "Gateway" apontando pra /settings/payment-gateways
- [ ] Smoke biz=1 (superadmin admin oimpresso): mesma estrutura
- [ ] Permission gate: user com \`financeiro.access\` mas sem \`paymentgateway.access\` deve ver Cobrança no sidebar mas ghost Gateway leva pra Page que retorna 403 (gate Spatie permission no PaymentGatewaysController, fora do escopo deste PR)

## Refs

- Wagner direção 2026-05-26 (chat sessão sidebar)
- Espelha PR #1541 (Fiscal flat) e PR #1547 (Governança removida do sidebar)
- ADR 0180 (Sidebar v3 — href direto + ghosts no PageHeader)

🤖 Generated with [Claude Code](https://claude.com/claude-code)