### PR TITLE
feat(sidebar,fiscal): remove entry "Fiscal" duplicada — 3 entries flat (Notas·Manifestação·Certificado)

### DIFF
--- a/Modules/Fiscal/Http/Controllers/DataController.php
+++ b/Modules/Fiscal/Http/Controllers/DataController.php
@@ -92,34 +92,30 @@ class DataController extends Controller
         // sob o cockpit. NfeBrasil vira motor headless (Services + rotas
         // backend ainda existem pra superadmin troubleshooting).
         //
-        // Ordering: Cockpit 93 (raiz) · Notas 95 · Manifestação 96 · Certificado 97.
+        // 2026-05-26 — Wagner direção: REMOVIDA entry "Fiscal" (cockpit dashboard
+        // order 93) do sidebar — duplicava visualmente com "Notas Fiscais" logo
+        // abaixo. Rota /fiscal CONTINUA ativa (FiscalCockpitController.index) —
+        // acesso via URL direta ou Cmd+K palette. Sidebar fica com 3 entries
+        // flat: Notas Fiscais · Manifestação · Certificado.
+        //
+        // Ordering: Notas 95 · Manifestação 96 · Certificado 97.
         // Mantém afinidade visual antes do Financeiro (order 85).
         Menu::modify('admin-sidebar-menu', function ($menu) use ($background_color, $is_fiscal) {
-            // Entry 1 — Cockpit Fiscal (dashboard agregado: KPIs + alertas + sparklines)
-            $menu->url(
-                url('/fiscal'),
-                'Fiscal',
-                [
-                    'icon'   => 'fa fas fa-balance-scale',
-                    'style'  => 'background-color:' . $background_color,
-                    'active' => $is_fiscal && request()->segment(2) === null,
-                    'group'  => 'fiscal',
-                ]
-            )->order(93);
-
-            // Entry 2 — Notas Fiscais (cockpit NF-e/NFC-e — sub-página 2)
+            // Entry 1 — Notas Fiscais (cockpit NF-e/NFC-e — sub-página 2)
+            // Active também quando segment(2) é null pra cobrir /fiscal raiz
+            // (URL direta cai aqui visualmente até o user clicar).
             $menu->url(
                 url('/fiscal/nfe'),
                 'Notas Fiscais',
                 [
                     'icon'   => 'fa fas fa-receipt',
                     'style'  => 'background-color:' . $background_color,
-                    'active' => $is_fiscal && request()->segment(2) === 'nfe',
+                    'active' => $is_fiscal && in_array(request()->segment(2), [null, 'nfe'], true),
                     'group'  => 'fiscal',
                 ]
             )->order(95);
 
-            // Entry 3 — Manifestação DF-e (Fiscal/Dfe.tsx — sub-página 4)
+            // Entry 2 — Manifestação DF-e (Fiscal/Dfe.tsx — sub-página 4)
             // Pré-2026-05-25 apontava pra /nfe-brasil/manifestacao (legacy NfeBrasil).
             // Consolidado pra /fiscal/dfe canon (com 4 botões via ManifestacaoService).
             $menu->url(
@@ -133,7 +129,7 @@ class DataController extends Controller
                 ]
             )->order(96);
 
-            // Entry 4 — Certificado A1 (Fiscal/Config.tsx — sub-página 6)
+            // Entry 3 — Certificado A1 (Fiscal/Config.tsx — sub-página 6)
             // Pré-2026-05-25 apontava pra /nfe-brasil/configuracao/certificado.
             // Consolidado pra /fiscal/config canon (read-only + link Editar → NfeBrasil
             // pra upload cert — fluxo permanece em NfeBrasil canon).

--- a/Modules/Fiscal/Tests/Feature/SidebarConsolidacaoTest.php
+++ b/Modules/Fiscal/Tests/Feature/SidebarConsolidacaoTest.php
@@ -11,11 +11,15 @@ uses(Tests\TestCase::class);
  * Onda ESTABILIZAR 2026-05-25 — Wagner apontou "fiscal manifestação certificado
  * tem telas competindo". Consolidação:
  *
- *   - Modules/Fiscal/DataController.modifyAdminMenu — publica 4 entries
- *     (Cockpit · Notas · Manifestação · Certificado) todas em /fiscal/*
+ *   - Modules/Fiscal/DataController.modifyAdminMenu — publica 3 entries
+ *     (Notas · Manifestação · Certificado) todas em /fiscal/*
  *
  *   - Modules/NfeBrasil/DataController.modifyAdminMenu — NÃO publica entries
  *     fiscais (eram 3: Notas/Manifestação/Certificado). Vira motor headless.
+ *
+ * Atualizado 2026-05-26 (Wagner): entry "Fiscal" (cockpit dashboard order 93)
+ * REMOVIDA — duplicava visualmente com "Notas Fiscais" logo abaixo. Rota
+ * /fiscal continua ativa (FiscalCockpitController) — acesso URL direta.
  *
  * Tests via análise source (NÃO via boot completo do Menu facade — requer
  * AdminSidebarMenu middleware + ModuleUtil + auth user, complexo demais pra
@@ -23,13 +27,15 @@ uses(Tests\TestCase::class);
  * desde que o intent permaneça.
  */
 
-it('Fiscal/DataController publica entry url(/fiscal) — cockpit raiz', function () {
+it('Fiscal/DataController NÃO publica entry url(/fiscal) raiz (removida 2026-05-26 — duplicava com Notas)', function () {
     $src = file_get_contents(
         (new ReflectionClass(FiscalDataController::class))->getFileName(),
     );
 
-    expect($src)->toContain("url('/fiscal')")
-        ->and($src)->toContain("'Fiscal'");
+    // Pattern busca chamada efetiva $menu->url(url('/fiscal'), 'Fiscal', ...).
+    // Comentário/docblock contendo url('/fiscal') é OK — o regex exige preceder
+    // por `$menu->url(\s*` e seguir por `,` (não barra).
+    expect($src)->not->toMatch('/\$menu->url\(\s*url\([\'"]\/fiscal[\'"]\)\s*,/');
 });
 
 it('Fiscal/DataController publica entry url(/fiscal/nfe) — Notas Fiscais', function () {

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -204,9 +204,13 @@ const SIDEBAR_GROUPS: Array<{ key: string; label: string; items: string[] }> = [
     // Wagner 2026-05-25: 3 entries flat — Notas Fiscais, Manifestação, Certificado.
     // (Substitui 1 entry "Fiscal" + ghosts PageHeader). Labels legacy mantidos
     // pra compat com módulos não-migrados ainda apontando labels antigos.
+    // Wagner 2026-05-26: label 'Fiscal' REMOVIDO da whitelist — entry "Fiscal"
+    // (cockpit dashboard order 93) foi desligada em Modules/Fiscal/Http/
+    // Controllers/DataController pra eliminar duplicação visual com "Notas
+    // Fiscais" logo abaixo. Rota /fiscal continua ativa via URL direta.
     items: ['Notas Fiscais', 'Manifestação', 'Certificado',
             'Notas fiscais', 'NFSe', 'NF-e Brasil', 'NF-e', 'NFC-e',
-            'Certificado Digital', 'Fiscal'],
+            'Certificado Digital'],
   },
   {
     key: 'producao',


### PR DESCRIPTION
## Resumo

Direção Wagner 2026-05-26: _\"Fiscal <- esse pode ser removido esta duplicado com o debaixo Notas Fiscais\"_.

Entry \"Fiscal\" (cockpit dashboard order 93) **removida** do sidebar — duplicava visualmente com \"Notas Fiscais\" logo abaixo. Grupo FISCAL fica com 3 entries flat semanticamente claras.

## Antes → Depois

| FISCAL antes (4 entries) | FISCAL depois (3 entries) |
|---|---|
| **Fiscal** (cockpit dashboard) → \`/fiscal\` order 93 | _removida_ |
| Notas Fiscais → \`/fiscal/nfe\` order 95 | Notas Fiscais → \`/fiscal/nfe\` order 95 |
| Manifestação → \`/fiscal/dfe\` order 96 | Manifestação → \`/fiscal/dfe\` order 96 |
| Certificado → \`/fiscal/config\` order 97 | Certificado → \`/fiscal/config\` order 97 |

## Arquivos tocados (3)

- **\`Modules/Fiscal/Http/Controllers/DataController.php\`** — removida Entry 1 (\`\$menu->url(url('/fiscal'), 'Fiscal', ...)->order(93)\`). Entry \"Notas Fiscais\" passa a ter \`active\` cobrindo também \`segment(2)===null\` (pinta Notas como ativa quando user acessa \`/fiscal\` raiz via URL direta).
- **\`Modules/Fiscal/Tests/Feature/SidebarConsolidacaoTest.php\`** — invertido test 1 de \"publica entry url(/fiscal)\" para \"NÃO publica\" (regex). Outros 3 tests Pest (Notas/Manifestação/Certificado entries) + NfeBrasil headless inalterados.
- **\`resources/js/Components/cockpit/Sidebar.tsx\`** — label \`'Fiscal'\` removido do whitelist \`SIDEBAR_GROUPS.fiscal.items[]\` (alias legacy). Outros 9 aliases legacy mantidos.

## Compatibilidade

- ✅ Rota \`/fiscal\` CONTINUA ativa (\`FiscalCockpitController.index\` não foi tocado). Acesso via URL direta, Cmd+K palette, ou link interno.
- ✅ Permission \`fiscal.access\` inalterada (gate canon do módulo).
- ✅ Tests Pest restantes do \`SidebarConsolidacaoTest\` inalterados.

## Test plan

- [x] \`php -l Modules/Fiscal/Http/Controllers/DataController.php\` — sem erros sintáticos
- [x] Regex pattern do test invertido: \`\$menu->url(\s*url(['\"]\/fiscal['\"])\s*,\` — cobre as 4 entries \`/fiscal/nfe\`, \`/fiscal/dfe\`, \`/fiscal/config\` mas exclui apenas \`/fiscal\` raiz (assertiva ainda passa porque essas têm \`/`\` antes da vírgula)
- [ ] Smoke biz=4 Larissa: sidebar grupo FISCAL mostra 3 entries (Notas Fiscais · Manifestação · Certificado), URL direta \`/fiscal\` continua renderizando cockpit
- [ ] Smoke biz=1 superadmin: idem

## Refs

- Wagner direção 2026-05-26
- PR #1573 (Onda ESTABILIZAR Fiscal — origem das 4 entries)
- PR #1588 + PR #1591 (paralelos mergeados hoje — mesma onda de cleanup sidebar)

<!-- evidence-override: Mudança puramente visual no sidebar — remoção de uma entry do \$menu->url no DataController do módulo Fiscal. Não toca routing, middleware request handling, .htaccess, ou redirects. Rota /fiscal continua ativa. Render visual apenas. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)