### PR TITLE
fix(comvis): hub stub /comunicacao-visual — substitui dropdown 4 sub-itens 404

### DIFF
--- a/Modules/ComunicacaoVisual/Http/Controllers/DataController.php
+++ b/Modules/ComunicacaoVisual/Http/Controllers/DataController.php
@@ -78,8 +78,19 @@ class DataController extends Controller
     }
 
     /**
-     * Injeta item "Comunicação Visual" na sidebar do AdminLTE.
-     * Sub-itens: Orçamentos, Ordens de Serviço, Materiais, Apontamentos.
+     * Injeta item "Comunicação Visual" na sidebar.
+     *
+     * 2026-05-26 (Wagner reportou módulo quebrado): substituído dropdown
+     * 4-sub-items (Orçamentos/OS/Materiais/Apontamentos) que apontava pra
+     * URLs /comunicacao-visual/admin/* INEXISTENTES — Sprint 2 nunca
+     * entregou as 4 telas Inertia. Cliques no sidebar davam 404.
+     *
+     * Estado novo: entry single top-level apontando pra /comunicacao-visual
+     * (rota nova em Routes/web.php → Inertia::render('ComunicacaoVisual/Index')
+     * stub que lista as 4 áreas como "em construção"). Quando Sprint 2 entregar
+     * as telas, ghosts podem voltar via attribute 'ghosts' canon ADR 0180.
+     *
+     * APIs /comunicacao-visual/api/* continuam ativas (Sprint 1 entrega).
      */
     public function modifyAdminMenu(): void
     {
@@ -113,34 +124,15 @@ class DataController extends Controller
         Menu::modify(
             'admin-sidebar-menu',
             function ($menu) use ($segmento_ativo) {
-                $menu->dropdown(
+                $menu->url(
+                    url('/comunicacao-visual'),
                     'Comunicação Visual',
-                    function ($sub) {
-                        $segment3 = request()->segment(3);
-
-                        $sub->url(url('/comunicacao-visual/admin/orcamentos'), 'Orçamentos', [
-                            'icon'   => 'fa fas fa-file-invoice',
-                            'active' => $segment3 === 'orcamentos',
-                        ]);
-
-                        $sub->url(url('/comunicacao-visual/admin/os'), 'Ordens de Serviço', [
-                            'icon'   => 'fa fas fa-tasks',
-                            'active' => $segment3 === 'os',
-                        ]);
-
-                        $sub->url(url('/comunicacao-visual/admin/materiais'), 'Materiais', [
-                            'icon'   => 'fa fas fa-layer-group',
-                            'active' => $segment3 === 'materiais',
-                        ]);
-
-                        $sub->url(url('/comunicacao-visual/admin/apontamentos'), 'Apontamentos', [
-                            'icon'   => 'fa fas fa-clock',
-                            'active' => $segment3 === 'apontamentos',
-                        ]);
-                    },
                     [
                         'icon'   => 'fa fas fa-print',
                         'active' => $segmento_ativo,
+                        // group: legacy default → LEGACY_GROUP_MAP frontend
+                        // mapeia pra 'producao' (vertical gráfica = produção).
+                        'group'  => 'producao',
                     ]
                 )->order(55);
             }

--- a/Modules/ComunicacaoVisual/Routes/web.php
+++ b/Modules/ComunicacaoVisual/Routes/web.php
@@ -1,8 +1,32 @@
 <?php
 
+use Inertia\Inertia;
 use Modules\ComunicacaoVisual\Http\Controllers\ApontamentoController;
 use Modules\ComunicacaoVisual\Http\Controllers\InstallController;
 use Modules\ComunicacaoVisual\Http\Controllers\OrcamentoController;
+
+// Hub stub Sprint 2 (Wagner 2026-05-26): rota raiz renderiza Index.tsx
+// existente como hub "em construção" listando 4 áreas (Orçamentos/OS/
+// Materiais/Apontamentos). Substitui o dropdown legacy do DataController
+// que apontava pra URLs /comunicacao-visual/admin/* não existentes (404).
+// Sprint 2 entrega telas Inertia próprias — até lá, hub stub +
+// acesso direto via APIs /comunicacao-visual/api/*.
+Route::middleware(['web', 'auth', 'SetSessionData', 'language', 'timezone', 'AdminSidebarMenu', 'CheckUserLogin'])
+    ->prefix('comunicacao-visual')
+    ->group(function () {
+        Route::get('/', function () {
+            // Permission gate canon — qualquer perm de visualização CV libera o hub.
+            if (! auth()->user()->can('superadmin')
+                && ! auth()->user()->can('comvis.orcamento.view')
+                && ! auth()->user()->can('comvis.os.view')) {
+                abort(403, 'Sem permissão Comunicação Visual (comvis.orcamento.view ou comvis.os.view).');
+            }
+
+            return Inertia::render('ComunicacaoVisual/Index', [
+                'bizName' => session('business.name', 'oimpresso'),
+            ]);
+        })->name('comunicacao-visual.index');
+    });
 
 // Rotas Install 1-click (ADR 0024 / BaseModuleInstallController).
 // Sem essas rotas o action() helper em Install/ModulesController vira '#'

--- a/resources/js/Pages/ComunicacaoVisual/Index.tsx
+++ b/resources/js/Pages/ComunicacaoVisual/Index.tsx
@@ -1,12 +1,15 @@
 /**
- * Pages/ComunicacaoVisual/Index — landing do vertical gráfica rápida BR.
+ * Pages/ComunicacaoVisual/Index — hub stub do vertical gráfica rápida BR.
  *
- * STATUS: stub Sprint 2 — UI Inertia ainda em construção (BRIEFING.md §3).
+ * STATUS: hub stub Sprint 2 — UI Inertia ainda em construção.
  *  - Sprint 1 entregou: API JSON (OrcamentoController + ApontamentoController)
  *  - Sprint 2 TODO: pages Inertia próprias (orçamento, PCP Kanban, apontamento)
  *
- * Wave 25 — placeholder com charter ao lado (.charter.md) pra MWART F1.5 gate
- * visual quando UI for ativada (ROTA LIVRE ainda usa endpoint legado).
+ * 2026-05-26 (Wagner reportou módulo quebrado): substituí stub puro por hub
+ * lista 4 áreas como cards "em breve". Antes o sidebar dropdown apontava pra
+ * URLs /comunicacao-visual/admin/* INEXISTENTES — todos cliques davam 404.
+ * Agora o sidebar tem 1 entry top-level apontando pra esta Page que mostra
+ * o estado real do módulo.
  *
  * @see Modules/ComunicacaoVisual/README.md §3 "Como o cliente usa"
  * @see resources/js/Pages/ComunicacaoVisual/Index.charter.md
@@ -14,23 +17,102 @@
  */
 import React from 'react';
 import { Head } from '@inertiajs/react';
+import { FileText, ClipboardList, Layers, Timer, ExternalLink } from 'lucide-react';
 
 interface Props {
     bizName?: string;
 }
 
+const AREAS_EM_BREVE = [
+    {
+        key: 'orcamentos',
+        label: 'Orçamentos',
+        descricao: 'Cálculo por m² (banner, adesivo, lona) — frente de loja Larissa.',
+        icon: FileText,
+        api_hint: 'POST /comunicacao-visual/api/calcular',
+        sprint: 'Sprint 1 ✅ API · Sprint 2 ⏳ UI',
+    },
+    {
+        key: 'os',
+        label: 'Ordens de Serviço',
+        descricao: 'PCP Kanban (Aguardando · Em produção · Pronto) por OS.',
+        icon: ClipboardList,
+        api_hint: 'GET /comunicacao-visual/api/orcamentos/{id}',
+        sprint: 'Sprint 2 ⏳ UI Kanban',
+    },
+    {
+        key: 'materiais',
+        label: 'Materiais',
+        descricao: 'Cadastro de matéria-prima (m² · tributação · custo).',
+        icon: Layers,
+        api_hint: '(roadmap Sprint 3)',
+        sprint: 'Sprint 3 ⏳ CRUD',
+    },
+    {
+        key: 'apontamentos',
+        label: 'Apontamentos',
+        descricao: 'Spool de produção — iniciar/finalizar etapa por operador.',
+        icon: Timer,
+        api_hint: 'POST /comunicacao-visual/api/apontamentos/iniciar',
+        sprint: 'Sprint 1 ✅ API · Sprint 2 ⏳ UI',
+    },
+];
+
 export default function Index({ bizName = 'oimpresso' }: Props) {
     return (
         <>
-            <Head title="Comunicação Visual — ComVis" />
-            <div className="p-6 space-y-4">
-                <h1 className="text-2xl font-semibold">Comunicação Visual</h1>
-                <p className="text-sm text-zinc-600">
-                    Vertical gráfica rápida ({bizName}) — orçamento por m² · PCP gráfico · apontamento.
-                </p>
-                <p className="text-xs text-amber-700">
-                    UI em construção (Sprint 2). Use endpoints API legados em /comunicacao-visual/api/*.
-                </p>
+            <Head title="Comunicação Visual — Hub" />
+            <div className="p-6 max-w-5xl">
+                <header className="mb-6">
+                    <h1 className="text-2xl font-semibold text-zinc-900">Comunicação Visual</h1>
+                    <p className="mt-1 text-sm text-zinc-600">
+                        Vertical gráfica rápida ({bizName}) — orçamento por m² · PCP gráfico · apontamento.
+                    </p>
+                </header>
+
+                <div className="rounded-lg border border-amber-200 bg-amber-50 p-4 mb-6">
+                    <p className="text-sm text-amber-900">
+                        <strong>UI Inertia em construção (Sprint 2).</strong> APIs JSON da Sprint 1 já estão
+                        ativas em <code className="rounded bg-amber-100 px-1.5 py-0.5 text-xs">/comunicacao-visual/api/*</code>
+                        {' '}— integráveis externamente. Telas próprias (Kanban, CRUD materiais, drawer de OS)
+                        chegam quando cliente piloto CV ativar.
+                    </p>
+                </div>
+
+                <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
+                    {AREAS_EM_BREVE.map((area) => {
+                        const Icon = area.icon;
+                        return (
+                            <div
+                                key={area.key}
+                                className="rounded-lg border border-zinc-200 bg-white p-4 hover:border-zinc-300 transition-colors"
+                            >
+                                <div className="flex items-start gap-3">
+                                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-zinc-100">
+                                        <Icon size={18} className="text-zinc-700" />
+                                    </div>
+                                    <div className="flex-1 min-w-0">
+                                        <h2 className="text-sm font-medium text-zinc-900">{area.label}</h2>
+                                        <p className="mt-0.5 text-xs text-zinc-600">{area.descricao}</p>
+                                        <div className="mt-2 flex items-center gap-2 text-[11px] text-zinc-500">
+                                            <span className="inline-flex items-center gap-1 rounded bg-zinc-50 px-1.5 py-0.5 font-mono">
+                                                <ExternalLink size={10} />
+                                                {area.api_hint}
+                                            </span>
+                                        </div>
+                                        <p className="mt-1.5 text-[11px] text-zinc-500">{area.sprint}</p>
+                                    </div>
+                                </div>
+                            </div>
+                        );
+                    })}
+                </div>
+
+                <footer className="mt-6 border-t border-zinc-100 pt-4 text-xs text-zinc-500">
+                    Quando o cliente piloto CV ativar, este hub vira home com KPIs
+                    (m² produzidos hoje, OS abertas, tempo médio etapa). Por enquanto,
+                    use APIs JSON ou contate Wagner.
+                </footer>
             </div>
         </>
     );


### PR DESCRIPTION
## Resumo

Wagner reportou 2026-05-26: _\"módulo de comunicação visual esta todo quebrado\"_.

**Diagnóstico:** sidebar tinha dropdown com 4 sub-itens apontando pra URLs `/comunicacao-visual/admin/{orcamentos,os,materiais,apontamentos}` que **NUNCA existiram** em `Routes/web.php`. Sprint 1 entregou só APIs JSON. Sprint 2 (UI Inertia das 4 telas) nunca foi entregue — dívida técnica pré-existente. Clicar em qualquer sub-item = 404.

## Antes → Depois

```
PRODUÇÃO antes                           PRODUÇÃO depois
  └─ Comunicação Visual (dropdown)         └─ Comunicação Visual     /comunicacao-visual
      ├─ Orçamentos   ← 404                    (1 entry top-level, hub stub Inertia)
      ├─ OS           ← 404
      ├─ Materiais    ← 404
      └─ Apontamentos ← 404
```

## Arquivos tocados (3)

- **\`Modules/ComunicacaoVisual/Routes/web.php\`** — rota GET \`/comunicacao-visual\` com closure renderizando \`Inertia::render('ComunicacaoVisual/Index')\`. Permission gate inline (superadmin OR \`comvis.orcamento.view\` OR \`comvis.os.view\`). Middleware canon (web/auth/SetSessionData/language/timezone/AdminSidebarMenu/CheckUserLogin).
- **\`Modules/ComunicacaoVisual/Http/Controllers/DataController.php\`** — \`modifyAdminMenu\` substituiu \`\$menu->dropdown(4 sub-items)\` por \`\$menu->url\` single top-level. \`'group' => 'producao'\` explícito.
- **\`resources/js/Pages/ComunicacaoVisual/Index.tsx\`** — stub puro virou hub real: header + banner \"UI Sprint 2 em construção\" + grid 4 cards (Orçamentos/OS/Materiais/Apontamentos) listando descrição + endpoint API + sprint status. Mostra dívida técnica visível ao usuário em vez de esconder.

## Por que hub stub (não 4 telas reais)

Wagner pediu opção B (\"Hub stub: 1 rota /comunicacao-visual que renderiza Index.tsx existente\") sobre as 4 alternativas. Sprint 2 (4 telas Inertia próprias) tem escopo de dias/semanas e não tem cliente piloto CV ativo no momento. Hub stub:
- ✅ Elimina os 404 imediatos
- ✅ Mostra estado real do módulo (dívida visível, não escondida)
- ✅ APIs JSON Sprint 1 continuam ativas + descobríveis (cards mostram endpoint)
- ✅ Quando cliente piloto CV ativar, ghosts ADR 0180 podem voltar facilmente

## Compatibilidade

- ✅ APIs \`/comunicacao-visual/api/*\` INALTERADAS (Sprint 1 — calcular m², orçamentos store/show, apontamentos CRUD)
- ✅ Permissions \`comvis.*\` INALTERADAS (controlam APIs + hub render)
- ✅ Rotas Install 1-click INALTERADAS (ADR 0024)
- ✅ Sidebar.tsx whitelist 'Comunicação Visual' em \`SIDEBAR_GROUPS.producao\` INALTERADA

## Test plan

- [x] \`php -l Routes/web.php\` — sem erros sintáticos
- [x] \`php -l DataController.php\` — sem erros sintáticos
- [x] Grep zero referências às URLs `/admin/*` em Modules/resources/app/tests (só docblock)
- [ ] Smoke biz=4 Larissa: sidebar PRODUÇÃO mostra \"Comunicação Visual\" como 1 entry, clicar → \`/comunicacao-visual\` renderiza hub stub com 4 cards
- [ ] Smoke biz=1 superadmin: idem
- [ ] Permission gate: user sem \`comvis.*\` permissions → 403 ao acessar \`/comunicacao-visual\`

## Refs

- Wagner direção 2026-05-26 (chat sessão sidebar)
- Sprint 1 (PR #676) entregou scaffold + APIs JSON
- Sprint 2 ainda pendente — sem cliente piloto CV ativo
- BRIEFING.md §3 do módulo ComVis

<!-- evidence-override: Mudança é APENAS adicionar rota GET /comunicacao-visual no Routes/web.php (closure → Inertia::render) + simplificar dropdown do DataController. Não mexe em routing existente, redirects, .htaccess, ou middleware request handling. Rotas /api/* + /install/* inalteradas. APIs externamente consumíveis continuam funcionais. -->

🤖 Generated with [Claude Code](https://claude.com/claude-code)