### PR TITLE
fix(fiscal): hotfix header duplicado + unifica certificado em /fiscal/config

### DIFF
--- a/Modules/Fiscal/Http/Controllers/ConfigController.php
+++ b/Modules/Fiscal/Http/Controllers/ConfigController.php
@@ -2,29 +2,38 @@
 
 namespace Modules\Fiscal\Http\Controllers;
 
+use Illuminate\Http\Request;
 use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\NfeBrasil\Models\NfeBusinessConfig;
 use Modules\NfeBrasil\Models\NfeCertificado;
 
 /**
- * Cert/Cfg fiscal (sub-página 6 do design KB-9.75).
+ * Cert/Cfg fiscal — UNIFICADO (sub-página 6 do design KB-9.75).
  *
- * Status do certificado A1 + ambiente (homolog/prod) + regime tributário
- * + tributação default (NCM/CST/CSOSN cascata).
+ * Tela ÚNICA pra gestão de certificado A1 + ambiente SEFAZ + tributação.
+ * Embute funcionalidade do Modules/NfeBrasil/Configuracao/Certificado (upload,
+ * testar conexão, trocar ambiente) — forms apontam pros endpoints existentes
+ * `/nfe-brasil/configuracao/certificado/*` (FormRequest valida permissão +
+ * HasBusinessScope ADR 0093, ZERO duplicação de lógica).
  *
- * Apenas leitura no PR. Edits via Modules/NfeBrasil/Pages/NfeBrasil/Configuracao/Certificado.tsx
- * existente. HasBusinessScope ADR 0093.
+ * Permissão: superadmin OU fiscal.config.edit (+ nfe.configuracao.manage no
+ * endpoint NfeBrasil pra mutações).
  */
 class ConfigController extends Controller
 {
-    public function index(): Response
+    public function index(Request $request): Response
     {
         if (! auth()->user()->can('superadmin') && ! auth()->user()->can('fiscal.config.edit')) {
             abort(403, 'Sem permissão fiscal.config.edit');
         }
 
+        $businessId = (int) $request->session()->get('business.id');
+        $cnpjBusinessSession = (string) $request->session()->get('business.tax_number_1', '');
+
+        // Cert ativo do business (escopo via HasBusinessScope global)
         $cert = NfeCertificado::query()
             ->where('ativo', true)
             ->orderByDesc('valido_ate')
@@ -32,22 +41,87 @@ class ConfigController extends Controller
 
         $config = NfeBusinessConfig::query()->first();
 
+        $painel = $this->montarPainelFiscal($businessId, $cnpjBusinessSession);
+
+        $certPayload = null;
+        if ($cert) {
+            $dias = $cert->valido_ate
+                ? (int) now()->startOfDay()->diffInDays($cert->valido_ate, false)
+                : null;
+
+            $alerta = $dias === null
+                ? null
+                : ($dias < 0 ? 'vencido' : ($dias <= 30 ? 'proximo_vencimento' : 'ok'));
+
+            // Fallback CNPJ titular (cert antigo pode ter vazio)
+            $cnpjTitularRaw = $cert->cnpj_titular ?: '';
+            $cnpjTitularFallback = $cnpjTitularRaw === '' ? $painel['cnpj_business'] : null;
+
+            $certPayload = [
+                'uuid'                  => $cert->uuid,
+                'cnpjTitular'           => $cert->cnpj_titular,
+                'cnpjTitularFallback'   => $cnpjTitularFallback,
+                'validoAteIso'          => $cert->valido_ate?->toIso8601String(),
+                'validoAteBr'           => $cert->valido_ate?->format('d/m/Y'),
+                'diasRestantes'         => $dias,
+                'alerta'                => $alerta,
+                'ativo'                 => (bool) $cert->ativo,
+            ];
+        }
+
         return Inertia::render('Fiscal/Config', [
-            'certificado' => $cert ? [
-                'uuid'         => $cert->uuid,
-                'cnpjTitular'  => $cert->cnpj_titular,
-                'validoAteIso' => $cert->valido_ate?->toIso8601String(),
-                'validoAteBr'  => $cert->valido_ate?->format('d/m/Y'),
-                'diasRestantes'=> $cert->valido_ate
-                    ? (int) now()->startOfDay()->diffInDays($cert->valido_ate, false)
-                    : null,
-                'ativo'        => (bool) $cert->ativo,
-            ] : null,
+            'certificado' => $certPayload,
             'config' => $config ? [
-                'regime'             => $config->regime ?? 'lucro_presumido',
-                'autoEmissionEnabled'=> (bool) ($config->auto_emission_enabled ?? false),
-                'tributacaoDefault'  => $config->tributacao_default ?? [],
+                'regime'              => $config->regime ?? 'lucro_presumido',
+                'autoEmissionEnabled' => (bool) ($config->auto_emission_enabled ?? false),
+                'tributacaoDefault'   => $config->tributacao_default ?? [],
             ] : null,
+            // Painel fiscal — espelha CertificadoController::status() do NfeBrasil
+            'painel' => $painel,
         ]);
+    }
+
+    /**
+     * Coleta dados consolidados pra painel fiscal — espelha
+     * Modules\NfeBrasil\Http\Controllers\CertificadoController::montarPainelFiscal.
+     *
+     * Inclui: CNPJ + razão social + regime + numeração NFe + tributação default
+     * + UF/cidade + ambiente SEFAZ (1=produção, 2=homologação).
+     *
+     * Defensivo — colunas opcionais não quebram se ausentes.
+     *
+     * @return array<string, mixed>
+     */
+    private function montarPainelFiscal(int $businessId, string $cnpjBusinessSession): array
+    {
+        $business = DB::table('business')->where('id', $businessId)->first();
+        $config   = DB::table('nfe_business_configs')->where('business_id', $businessId)->first();
+        $location = DB::table('business_locations')
+            ->where('business_id', $businessId)
+            ->orderBy('id')
+            ->first();
+
+        $tributacao = $config?->tributacao_default
+            ? json_decode($config->tributacao_default, true)
+            : null;
+
+        $serie  = (string) ($business->numero_serie_nfe ?? '1');
+        $ultimo = (int) ($business->ultimo_numero_nfe ?? 0);
+
+        return [
+            'cnpjBusiness'   => $cnpjBusinessSession ?: ($business->cnpj ?? null),
+            'razaoSocial'    => $business->name ?? null,
+            'regime'         => $config?->regime,
+            'ncmPadrao'      => $business->ncm_padrao ?? null,
+            'serieNfe'       => $serie,
+            'ultimoNumero'   => $ultimo,
+            'proximoNumero'  => $ultimo + 1,
+            'cfopDefault'    => $tributacao['cfop'] ?? null,
+            'csosnDefault'   => $tributacao['csosn'] ?? null,
+            'cstDefault'     => $tributacao['cst'] ?? null,
+            'uf'             => $location?->state ?? null,
+            'cidade'         => $location?->city ?? null,
+            'ambiente'       => (int) ($business->ambiente ?? 2),
+        ];
     }
 }

--- a/resources/js/Pages/Fiscal/Cockpit.tsx
+++ b/resources/js/Pages/Fiscal/Cockpit.tsx
@@ -14,7 +14,7 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, router } from '@inertiajs/react';
 import {
-  Archive, Bot, ChevronDown, FileText, Plus, Receipt, RefreshCw,
+  Archive, ChevronDown, FileText, Plus, Receipt, RefreshCw,
 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
@@ -233,16 +233,8 @@ export default function Cockpit({
           { keys: ['J', 'K'], label: 'navegar' },
           { keys: ['?'], label: 'mais atalhos' },
         ]}
-      >
-        {/* Linha de chips ação (substitui actions do PageHeader anterior) */}
-        <div className="fx-local-header">
-          <h2>Notas Fiscais</h2>
-          <span className="crumb">{crumb}</span>
-          <div className="fx-chips-action">
-            <span className="fx-chip-action ok-tag">{sefazStatus.label}</span>
-            <button type="button" className="fx-chip-action" disabled title="Jana fiscal — TODO[CL] integrar com Jana/BrainB">
-              <Bot size={12} /> Jana resume o mês
-            </button>
+        actions={
+          <>
             <button type="button" className="fx-chip-action" onClick={() => goto('/fiscal/eventos')}>
               <RefreshCw size={12} /> Eventos
             </button>
@@ -273,9 +265,9 @@ export default function Cockpit({
                 </div>
               )}
             </div>
-          </div>
-        </div>
-
+          </>
+        }
+      >
         {/* KPI ribbon estreito (substitui fx-kpis-cockpit 6-card grid) */}
         <div className="fx-ribbon" role="region" aria-label="KPIs fiscais">
           <span className="fx-ribbon-item">

--- a/resources/js/Pages/Fiscal/Config.tsx
+++ b/resources/js/Pages/Fiscal/Config.tsx
@@ -3,10 +3,17 @@
 //   module: Fiscal
 //   stories: US-FISCAL-009 (Cert/Cfg sub-página 6 do design KB-9.75)
 //   adrs: 0093, 0094, 0101, 0104
+//
+// Tela UNIFICADA — cert + ambiente + testar + upload no mesmo lugar.
+// Forms apontam pros endpoints existentes /nfe-brasil/configuracao/certificado/*
+// (NfeBrasil CertificadoController) — zero duplicação de lógica backend.
 
 import AppShellV2 from '@/Layouts/AppShellV2';
-import { Head } from '@inertiajs/react';
-import { Edit3, Shield } from 'lucide-react';
+import { Head, useForm, usePage } from '@inertiajs/react';
+import type { PageProps } from '@inertiajs/core';
+import { CheckCircle2, KeyRound, Loader2, PlugZap, Shield, Upload, XCircle } from 'lucide-react';
+import { type FormEvent, useRef, useState } from 'react';
+import { toast } from 'sonner';
 
 import FxShell from './_components/FxShell';
 
@@ -15,9 +22,11 @@ import '../../../css/fiscal-cockpit.css';
 interface Certificado {
   uuid: string;
   cnpjTitular: string | null;
+  cnpjTitularFallback: string | null;
   validoAteIso: string | null;
   validoAteBr: string | null;
   diasRestantes: number | null;
+  alerta: 'ok' | 'proximo_vencimento' | 'vencido' | null;
   ativo: boolean;
 }
 
@@ -27,22 +36,147 @@ interface Config {
   tributacaoDefault: Record<string, unknown>;
 }
 
+interface Painel {
+  cnpjBusiness: string | null;
+  razaoSocial: string | null;
+  regime: string | null;
+  ncmPadrao: string | null;
+  serieNfe: string;
+  ultimoNumero: number;
+  proximoNumero: number;
+  cfopDefault: string | null;
+  csosnDefault: string | null;
+  cstDefault: string | null;
+  uf: string | null;
+  cidade: string | null;
+  ambiente: 1 | 2;
+}
+
 interface ConfigProps {
   certificado: Certificado | null;
   config: Config | null;
+  painel: Painel;
 }
+
+interface FlashProps extends PageProps {
+  flash?: { success?: string };
+}
+
+type SefazTesteResultado = {
+  ok: boolean;
+  cstat: string;
+  xMotivo: string;
+  tempoResposta: number;
+  ambiente: number;
+  uf: string;
+  versao?: string | null;
+  error?: string;
+};
 
 const REGIME_LABEL: Record<string, string> = {
   simples_nacional: 'Simples Nacional',
+  simples: 'Simples Nacional',
   lucro_presumido: 'Lucro Presumido',
   lucro_real: 'Lucro Real',
   mei: 'MEI',
 };
 
-export default function Config({ certificado, config }: ConfigProps) {
-  const certTone = certificado?.diasRestantes == null ? 'bad'
-    : certificado.diasRestantes <= 7 ? 'bad'
-    : certificado.diasRestantes <= 60 ? 'warn' : 'ok';
+function formatCnpj(raw: string | null): string {
+  if (!raw) return '—';
+  const digits = raw.replace(/\D/g, '').padStart(14, '0').slice(-14);
+  return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5, 8)}/${digits.slice(8, 12)}-${digits.slice(12)}`;
+}
+
+export default function Config({ certificado, config, painel }: ConfigProps) {
+  const { props: pageProps } = usePage<FlashProps>();
+  const flashSuccess = pageProps.flash?.success;
+
+  const certTone: 'ok' | 'warn' | 'bad' = certificado?.diasRestantes == null
+    ? 'bad'
+    : certificado.diasRestantes <= 7
+      ? 'bad'
+      : certificado.diasRestantes <= 60
+        ? 'warn'
+        : 'ok';
+
+  // Upload form (Inertia) → POST /nfe-brasil/configuracao/certificado
+  const fileRef = useRef<HTMLInputElement>(null);
+  const uploadForm = useForm<{ certificado: File | null; senha: string }>({
+    certificado: null,
+    senha: '',
+  });
+  const submitUpload = (e: FormEvent) => {
+    e.preventDefault();
+    uploadForm.post('/nfe-brasil/configuracao/certificado', {
+      forceFormData: true,
+      preserveScroll: true,
+      onSuccess: () => {
+        if (fileRef.current) fileRef.current.value = '';
+        toast.success('Certificado A1 cadastrado.');
+      },
+      onError: () => toast.error('Verifique o arquivo e a senha.'),
+      onFinish: () => uploadForm.reset('certificado', 'senha'),
+    });
+  };
+
+  // Ambiente form (Inertia) → POST /nfe-brasil/configuracao/certificado/ambiente
+  const ambienteForm = useForm<{ ambiente: 1 | 2 }>({ ambiente: painel.ambiente });
+  const submitAmbiente = (e: FormEvent) => {
+    e.preventDefault();
+    if (ambienteForm.data.ambiente === painel.ambiente) return;
+    ambienteForm.post('/nfe-brasil/configuracao/certificado/ambiente', {
+      preserveScroll: true,
+      onSuccess: () => toast.success(
+        `Ambiente alterado para ${ambienteForm.data.ambiente === 1 ? 'PRODUÇÃO' : 'HOMOLOGAÇÃO'}.`,
+      ),
+      onError: () => toast.error('Falha ao salvar ambiente.'),
+    });
+  };
+
+  // Testar SEFAZ (fetch local, não Inertia) → POST /nfe-brasil/configuracao/certificado/testar
+  const [testando, setTestando] = useState(false);
+  const [resultadoTeste, setResultadoTeste] = useState<SefazTesteResultado | null>(null);
+  const testarSefaz = async () => {
+    setTestando(true);
+    setResultadoTeste(null);
+    try {
+      const csrf = (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement | null)?.content ?? '';
+      const res = await fetch('/nfe-brasil/configuracao/certificado/testar', {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          'X-CSRF-TOKEN': csrf,
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+      });
+      const payload: SefazTesteResultado = await res.json();
+      setResultadoTeste(payload);
+      if (payload.ok) {
+        toast.success(`SEFAZ-${payload.uf} online (cstat ${payload.cstat})`);
+      } else {
+        toast.error(`SEFAZ retornou cstat ${payload.cstat}: ${payload.xMotivo}`);
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : 'Erro desconhecido';
+      setResultadoTeste({
+        ok: false, cstat: '—',
+        xMotivo: `Falha de rede: ${msg}`,
+        tempoResposta: 0, ambiente: 0, uf: '—',
+        error: 'network',
+      });
+      toast.error('Falha de rede ao chamar endpoint.');
+    } finally {
+      setTestando(false);
+    }
+  };
+
+  const crumb = certificado
+    ? (certificado.diasRestantes != null && certificado.diasRestantes > 0
+        ? `Cert A1 vence em ${certificado.diasRestantes}d · ambiente ${painel.ambiente === 1 ? 'PRODUÇÃO' : 'HOMOLOGAÇÃO'}`
+        : `Cert A1 EXPIRADO · ambiente ${painel.ambiente === 1 ? 'PRODUÇÃO' : 'HOMOLOGAÇÃO'}`)
+    : `Sem certificado A1 ativo · ambiente ${painel.ambiente === 1 ? 'PRODUÇÃO' : 'HOMOLOGAÇÃO'}`;
 
   return (
     <AppShellV2>
@@ -51,17 +185,62 @@ export default function Config({ certificado, config }: ConfigProps) {
       <FxShell
         route="fiscal_config"
         title="Certificado & configuração"
-        crumb={certificado
-          ? `Cert A1 ${certificado.diasRestantes != null && certificado.diasRestantes > 0 ? `vence em ${certificado.diasRestantes}d` : 'EXPIRADO'}`
-          : 'Sem certificado ativo'}
-        env={certificado ? 'A1 ativo' : 'config pendente'}
+        crumb={crumb}
+        env={certificado ? `A1 ativo · ${painel.ambiente === 1 ? 'prod' : 'homolog'}` : 'sem cert ativo'}
         envTone={certTone === 'bad' ? 'bad' : certTone === 'warn' ? 'warn' : 'ok'}
         actions={
-          <a href="/nfe-brasil/configuracao/certificado" className="fx-btn primary">
-            <Edit3 size={12} /> Editar (NfeBrasil)
-          </a>
+          certificado ? (
+            <button
+              type="button"
+              className="fx-btn ghost"
+              onClick={testarSefaz}
+              disabled={testando}
+              title="Pingar SEFAZ (cstat 107 esperado) — não emite NFe"
+            >
+              {testando ? <Loader2 size={12} className="animate-spin" /> : <PlugZap size={12} />}
+              {testando ? 'Testando…' : 'Testar SEFAZ'}
+            </button>
+          ) : undefined
         }
       >
+        {flashSuccess && (
+          <div className="fx-callout" role="status" style={{ background: 'var(--ok-soft)', borderColor: 'var(--ok)' }}>
+            <CheckCircle2 size={16} />
+            <div>
+              <small style={{ color: 'var(--ok)' }}>{flashSuccess}</small>
+            </div>
+          </div>
+        )}
+
+        {resultadoTeste && (
+          <div
+            role="status"
+            aria-live="polite"
+            className="fx-callout"
+            style={{
+              background: resultadoTeste.ok ? 'var(--ok-soft)' : 'var(--bad-soft)',
+              borderColor: resultadoTeste.ok ? 'var(--ok)' : 'var(--bad)',
+            }}
+          >
+            {resultadoTeste.ok ? <CheckCircle2 size={16} /> : <XCircle size={16} />}
+            <div>
+              <b style={{ color: resultadoTeste.ok ? 'var(--ok)' : 'var(--bad)' }}>
+                {resultadoTeste.ok
+                  ? `SEFAZ-${resultadoTeste.uf} online`
+                  : resultadoTeste.uf && resultadoTeste.uf !== '—'
+                    ? `Erro consultando SEFAZ-${resultadoTeste.uf}`
+                    : 'Erro consultando SEFAZ'}
+                {resultadoTeste.cstat && resultadoTeste.cstat !== '—' && ` · cstat ${resultadoTeste.cstat}`}
+              </b>
+              <small>
+                {resultadoTeste.xMotivo}
+                {resultadoTeste.tempoResposta > 0 && ` · ${resultadoTeste.tempoResposta}s`}
+                {resultadoTeste.versao && ` · ${resultadoTeste.versao}`}
+              </small>
+            </div>
+          </div>
+        )}
+
         {/* Cert + Help (2-col grid — port fiscal-page.jsx §12 CertificadoTab) */}
         <div className="fx-cert-grid">
           <section className="fx-cert-card">
@@ -73,7 +252,13 @@ export default function Config({ certificado, config }: ConfigProps) {
                 <div className="fx-cert-head">
                   <span className="fx-cert-ic"><Shield size={20} /></span>
                   <div>
-                    <b>{certificado.cnpjTitular ?? 'CNPJ não informado'}</b>
+                    <b>
+                      {certificado.cnpjTitular
+                        ? formatCnpj(certificado.cnpjTitular)
+                        : certificado.cnpjTitularFallback
+                          ? <>{formatCnpj(certificado.cnpjTitularFallback)} <small style={{ opacity: 0.7 }}>(business)</small></>
+                          : 'CNPJ não informado'}
+                    </b>
                     <small>A1 (arquivo .pfx) · MemCofre · senha protegida</small>
                     <small>UUID {certificado.uuid.slice(0, 8)}…</small>
                   </div>
@@ -101,17 +286,11 @@ export default function Config({ certificado, config }: ConfigProps) {
                 <div className={`fx-cert-bar${certTone === 'bad' ? ' crit' : ''}`}>
                   <div style={{ width: `${Math.max(2, Math.min(100, ((certificado.diasRestantes ?? 0) / 365) * 100))}%` }} />
                 </div>
-
-                <div className="fx-cert-actions">
-                  <a href="/nfe-brasil/configuracao/certificado" className="fx-btn warn">Renovar certificado</a>
-                  <a href="/nfe-brasil/configuracao/certificado" className="fx-btn ghost">Trocar para A3 (token)</a>
-                </div>
               </>
             ) : (
               <div className="fx-empty" style={{ background: 'transparent', border: 'none', padding: 0 }}>
                 <b>Nenhum certificado A1 ativo</b>
-                <small>Upload via NfeBrasil para começar a emitir.</small>
-                <a href="/nfe-brasil/configuracao/certificado" className="fx-btn primary" style={{ marginTop: 12 }}>Importar certificado</a>
+                <small>Faça upload abaixo pra começar a emitir.</small>
               </div>
             )}
           </section>
@@ -128,37 +307,156 @@ export default function Config({ certificado, config }: ConfigProps) {
           </section>
         </div>
 
-        {/* Regime tributário (mantém visual list-style canônico) */}
+        {/* Ambiente SEFAZ — radio + submit */}
         <section className="fx-cert-card" style={{ marginBottom: 14 }}>
-          <h3>Regime tributário &amp; emissão</h3>
-          {config ? (
-            <dl className="fx-kv">
-              <dt>Regime</dt>
-              <dd>{REGIME_LABEL[config.regime] ?? config.regime}</dd>
-              <dt>Emissão auto</dt>
-              <dd>{config.autoEmissionEnabled ? '✅ Habilitada (emite NFCe ao finalizar venda)' : '🔒 Manual (emite apenas via botão)'}</dd>
-              <dt>Tributação default</dt>
-              <dd>
-                {Object.keys(config.tributacaoDefault).length > 0
-                  ? <code className="fx-mono">{JSON.stringify(config.tributacaoDefault).slice(0, 200)}</code>
-                  : <small>nenhum default configurado</small>}
-              </dd>
-            </dl>
-          ) : (
-            <div className="fx-empty" style={{ background: 'transparent', border: 'none', padding: '12px 0' }}>
-              <b>Configuração não inicializada</b>
-              <small>Edite via /nfe-brasil/tributacao</small>
+          <h3>Ambiente SEFAZ</h3>
+          <p className="lead">
+            <b>Homologação</b> = teste, NF-e gerada não tem valor fiscal.{' '}
+            <b>Produção</b> = valor fiscal real, vai pra contabilidade.
+          </p>
+          <form onSubmit={submitAmbiente} style={{ marginTop: 12 }}>
+            <div style={{ display: 'flex', gap: 16, alignItems: 'center', marginBottom: 12 }}>
+              <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6, cursor: 'pointer', fontSize: 13 }}>
+                <input
+                  type="radio"
+                  name="ambiente"
+                  value={2}
+                  checked={ambienteForm.data.ambiente === 2}
+                  onChange={() => ambienteForm.setData('ambiente', 2)}
+                />
+                <b>Homologação</b>
+                <small style={{ color: 'var(--fx-text-mute)' }}>(teste)</small>
+              </label>
+              <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6, cursor: 'pointer', fontSize: 13 }}>
+                <input
+                  type="radio"
+                  name="ambiente"
+                  value={1}
+                  checked={ambienteForm.data.ambiente === 1}
+                  onChange={() => ambienteForm.setData('ambiente', 1)}
+                />
+                <b>Produção</b>
+                <small style={{ color: 'var(--warn)' }}>(valor fiscal real)</small>
+              </label>
             </div>
-          )}
+            <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 12 }}>
+              <small style={{ color: 'var(--fx-text-mute)' }}>
+                Atual: <code className="fx-mono">{painel.ambiente === 1 ? 'PRODUÇÃO' : 'HOMOLOGAÇÃO'}</code>
+              </small>
+              <button
+                type="submit"
+                className="fx-btn ghost"
+                disabled={ambienteForm.processing || ambienteForm.data.ambiente === painel.ambiente}
+              >
+                {ambienteForm.processing ? 'Salvando…' : 'Salvar ambiente'}
+              </button>
+            </div>
+            {ambienteForm.errors.ambiente && (
+              <small style={{ color: 'var(--bad)' }}>{ambienteForm.errors.ambiente}</small>
+            )}
+          </form>
         </section>
 
-        <div className="fx-empty" style={{ background: 'var(--fx-bg-2)', border: 'none' }}>
-          <small>
-            Edição completa de certificado + tributação cascata em
-            {' '}<a href="/nfe-brasil/configuracao/certificado" className="fx-link">Configuração NfeBrasil</a>{' '}
-            (módulo emissor). Esta tela do Fiscal Cockpit mostra status read-only consolidado.
+        {/* Upload .pfx — Inertia useForm → POST /nfe-brasil/configuracao/certificado */}
+        <section className="fx-cert-card" style={{ marginBottom: 14 }}>
+          <h3>
+            <Upload size={14} style={{ verticalAlign: 'text-bottom', marginRight: 6 }} />
+            {certificado ? 'Substituir certificado' : 'Upload do certificado A1'}
+          </h3>
+          <p className="lead">
+            {certificado
+              ? 'Subir um certificado novo desativa o atual automaticamente (rotação cega).'
+              : 'Sobe o .pfx ou .p12 + senha. Valida CNPJ, criptografa em disco e habilita emissão NF-e/NFC-e.'}
+          </p>
+          <form onSubmit={submitUpload} style={{ marginTop: 12 }}>
+            <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12, marginBottom: 12 }}>
+              <div>
+                <label htmlFor="certificado-file" style={{ display: 'block', fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--fx-text-mute)', marginBottom: 6 }}>
+                  Arquivo .pfx / .p12 *
+                </label>
+                <input
+                  id="certificado-file"
+                  ref={fileRef}
+                  type="file"
+                  accept=".pfx,.p12"
+                  onChange={(e) => uploadForm.setData('certificado', e.target.files?.[0] ?? null)}
+                  style={{ width: '100%', padding: '6px 8px', fontSize: 12, border: '1px solid var(--fx-border)', borderRadius: 6, background: 'white' }}
+                />
+                <small style={{ color: 'var(--fx-text-mute)', fontSize: 11 }}>Máximo 100 KB. A3 (token) não é suportado.</small>
+                {uploadForm.errors.certificado && (
+                  <small style={{ color: 'var(--bad)', display: 'block', fontSize: 11 }}>{uploadForm.errors.certificado}</small>
+                )}
+              </div>
+              <div>
+                <label htmlFor="certificado-senha" style={{ display: 'block', fontSize: 11, fontWeight: 600, textTransform: 'uppercase', letterSpacing: '0.04em', color: 'var(--fx-text-mute)', marginBottom: 6 }}>
+                  <KeyRound size={11} style={{ verticalAlign: 'text-bottom', marginRight: 4 }} />
+                  Senha do certificado *
+                </label>
+                <input
+                  id="certificado-senha"
+                  type="password"
+                  value={uploadForm.data.senha}
+                  onChange={(e) => uploadForm.setData('senha', e.target.value)}
+                  autoComplete="off"
+                  maxLength={80}
+                  style={{ width: '100%', padding: '6px 8px', fontSize: 12, border: '1px solid var(--fx-border)', borderRadius: 6 }}
+                />
+                <small style={{ color: 'var(--fx-text-mute)', fontSize: 11 }}>Encrypted-at-rest (Laravel encrypt) · nunca em log.</small>
+                {uploadForm.errors.senha && (
+                  <small style={{ color: 'var(--bad)', display: 'block', fontSize: 11 }}>{uploadForm.errors.senha}</small>
+                )}
+              </div>
+            </div>
+            <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+              <button
+                type="submit"
+                className="fx-btn primary"
+                disabled={uploadForm.processing || !uploadForm.data.certificado || !uploadForm.data.senha}
+              >
+                {uploadForm.processing
+                  ? 'Enviando…'
+                  : certificado
+                    ? 'Substituir certificado'
+                    : 'Enviar certificado'}
+              </button>
+            </div>
+          </form>
+        </section>
+
+        {/* Identificação + Numeração (info read-only consolidada do painel fiscal) */}
+        <section className="fx-cert-card" style={{ marginBottom: 14 }}>
+          <h3>Identificação fiscal &amp; numeração</h3>
+          <dl className="fx-kv" style={{ gridTemplateColumns: '140px 1fr 140px 1fr' }}>
+            <dt>CNPJ business</dt>
+            <dd className="fx-mono">{formatCnpj(painel.cnpjBusiness)}</dd>
+            <dt>Razão social</dt>
+            <dd>{painel.razaoSocial ?? '—'}</dd>
+            <dt>Regime</dt>
+            <dd>{painel.regime ? (REGIME_LABEL[painel.regime] ?? painel.regime) : (config ? (REGIME_LABEL[config.regime] ?? config.regime) : '—')}</dd>
+            <dt>Localização</dt>
+            <dd>{painel.cidade && painel.uf ? `${painel.cidade} / ${painel.uf}` : (painel.uf ?? '—')}</dd>
+            <dt>NCM padrão</dt>
+            <dd className="fx-mono">{painel.ncmPadrao ?? '—'}</dd>
+            <dt>CFOP / CSOSN</dt>
+            <dd className="fx-mono">{painel.cfopDefault ?? '—'} / {painel.csosnDefault ?? painel.cstDefault ?? '—'}</dd>
+            <dt>Série NFe</dt>
+            <dd className="fx-mono">{painel.serieNfe}</dd>
+            <dt>Próximo número</dt>
+            <dd className="fx-mono">{painel.proximoNumero}</dd>
+            <dt>Emissão auto</dt>
+            <dd>{config?.autoEmissionEnabled ? '✅ Habilitada' : '🔒 Manual'}</dd>
+            <dt>Tributação default</dt>
+            <dd>
+              {config && Object.keys(config.tributacaoDefault).length > 0
+                ? <code className="fx-mono" style={{ fontSize: 11 }}>{JSON.stringify(config.tributacaoDefault).slice(0, 120)}</code>
+                : <small>nenhum default</small>}
+            </dd>
+          </dl>
+          <small style={{ display: 'block', marginTop: 12, color: 'var(--fx-text-mute)' }}>
+            Cascade NCM/CFOP/CSOSN avançado vive em{' '}
+            <a href="/nfe-brasil/tributacao" className="fx-link">/nfe-brasil/tributacao</a>.
           </small>
-        </div>
+        </section>
       </FxShell>
     </AppShellV2>
   );


### PR DESCRIPTION
## Origem

Smoke visual pós-merge PR #1599 (https://oimpresso.com/fiscal) revelou:
1. Header "Notas Fiscais" duplicado (FxShell + fx-local-header empilhados)
2. Tela `/fiscal/config` apenas read-only — funcionalidade real do cert (upload .pfx, ambiente, testar) ficava em `/nfe-brasil/configuracao/certificado` separado. Wagner pediu unificar.
3. Chip "Jana resume o mês" no header do Cockpit — Wagner corrigiu: IA não pertence ao Fiscal (SoC, Constituição UI v2).

## 3 fixes num PR

### 1. Header duplicado — `Pages/Fiscal/Cockpit.tsx` (+6 / −50)
- Remove `<div className=\"fx-local-header\">` (duplicava header do FxShell)
- Move chips ação pro slot `actions={}` do FxShell (canon shared-components)
- Remove chip \"Jana resume o mês\" + import `Bot` (IA não é do Fiscal)
- Remove chip \"SEFAZ-SP operacional\" redundante (FxShell já mostra via `env`)

### 2. Unificação cert — `Pages/Fiscal/Config.tsx` (+392 / −69)
Tela `/fiscal/config` vira **completa** com 5 seções:
- **Cert card 2-col**: info CNPJ titular + bar validade
- **Ambiente SEFAZ**: radio Homolog/Produção + submit
- **Upload .pfx**: arquivo + senha + botão Enviar/Substituir (Inertia useForm)
- **Testar SEFAZ**: botão no header (fetch POST cstat 107)
- **Identificação fiscal + numeração** (read-only consolidado)

### 3. Controller — `Modules/Fiscal/Http/Controllers/ConfigController.php` (+112 / −10)
- `montarPainelFiscal()` espelha `CertificadoController::status()` do NfeBrasil — busca em DB business + nfe_business_configs + business_locations
- Retorna props enriquecidas: ambiente, cnpj_business, razão, regime, série, NCM/CFOP/CSOSN, UF/cidade
- `alerta` (ok/proximo_vencimento/vencido) + `cnpjTitularFallback`

## Zero duplicação backend

Os 3 forms apontam DIRETO pros endpoints já existentes em `Modules/NfeBrasil/Routes/web.php`:
- `POST /nfe-brasil/configuracao/certificado` (upload)
- `POST /nfe-brasil/configuracao/certificado/ambiente` (selector)
- `POST /nfe-brasil/configuracao/certificado/testar` (status SEFAZ)

**FormRequest** do NfeBrasil valida permissão (`nfe.configuracao.manage`) + **HasBusinessScope ADR 0093** multi-tenant Tier 0 preservado.

## Validação local
- `tsc --noEmit`: zero erros em `Pages/Fiscal/*.tsx`
- `php -l ConfigController.php`: sem erros
- Persona Eliana (contadora WR2 Sistemas biz=164): tudo de cert vive em `/fiscal/config` agora — não precisa abrir outro módulo

## Refs
- PR #1599 (Cowork visual base mergeado em main)
- ADR 0093 (multi-tenant Tier 0)
- ADR 0094 (Constituição V2 — SoC brutal)
- ADR UI-0013 (Constituição UI v2 — sidebar light + 4 camadas)