### PR TITLE
feat(paymentgateway): Onda 4f.cnab — registra 11 CnabDrivers no DRIVERS const

### DIFF
--- a/Modules/PaymentGateway/Services/PaymentGatewayService.php
+++ b/Modules/PaymentGateway/Services/PaymentGatewayService.php
@@ -17,6 +17,17 @@ use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
 use Modules\PaymentGateway\Exceptions\IdempotencyConflictException;
 use Modules\PaymentGateway\Models\Cobranca;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+use Modules\PaymentGateway\Services\Cnab\Drivers\AilosCnabDriver;
+use Modules\PaymentGateway\Services\Cnab\Drivers\BBCnabDriver;
+use Modules\PaymentGateway\Services\Cnab\Drivers\BanrisulCnabDriver;
+use Modules\PaymentGateway\Services\Cnab\Drivers\BradescoCnabDriver;
+use Modules\PaymentGateway\Services\Cnab\Drivers\BtgCnabDriver;
+use Modules\PaymentGateway\Services\Cnab\Drivers\CaixaCnabDriver;
+use Modules\PaymentGateway\Services\Cnab\Drivers\CresolCnabDriver;
+use Modules\PaymentGateway\Services\Cnab\Drivers\ItauCnabDriver;
+use Modules\PaymentGateway\Services\Cnab\Drivers\SantanderCnabDriver;
+use Modules\PaymentGateway\Services\Cnab\Drivers\SicoobCnabDriver;
+use Modules\PaymentGateway\Services\Cnab\Drivers\SicrediCnabDriver;
 use Modules\PaymentGateway\Services\Drivers\AsaasDriver;
 use Modules\PaymentGateway\Services\Drivers\BcbPixDriver;
 use Modules\PaymentGateway\Services\Drivers\C6Driver;
@@ -43,14 +54,33 @@ class PaymentGatewayService implements PaymentGatewayContract
      * Onda 4b: + c6, asaas
      * Onda 4d.1: + bcb_pix (PIX Automático regulado BCB)
      * Onda 4e: + pagarme (Pagar.me v5 — Stone group — boleto/pix_cob/card)
+     * Onda 4f.cnab: + 11 CnabDrivers (ADR 0170-bancos-nativos-top5-drivers-separados v3 Wagner 2026-05-26)
+     *               — Bradesco/Itaú/BB/Santander/Caixa/Sicoob/Ailos/Sicredi/Cresol/Banrisul/BTG
+     *               todos file-based via lib eduardokum/laravel-boleto sobre fundação CnabBoletoAdapter
+     *               PRs mergeados: #1589 #1590 #1592 #1606-#1613
      * Onda 5/6: pesapal (deprecated → remoção)
      */
     private const DRIVERS = [
+        // API REST drivers
         'inter'   => InterDriver::class,
         'c6'      => C6Driver::class,
         'asaas'   => AsaasDriver::class,
         'bcb_pix' => BcbPixDriver::class,
         'pagarme' => PagarmeDriver::class,
+
+        // CNAB drivers (file-based — boleto registrado via remessa/retorno)
+        // Onda 4f.cnab — clientes emitem boleto dia 1 sem esperar homologação Open API (14-45d)
+        'bradesco_cnab'  => BradescoCnabDriver::class,
+        'itau_cnab'      => ItauCnabDriver::class,
+        'bb_cnab'        => BBCnabDriver::class,
+        'santander_cnab' => SantanderCnabDriver::class,
+        'caixa_cnab'     => CaixaCnabDriver::class,
+        'sicoob_cnab'    => SicoobCnabDriver::class,
+        'ailos_cnab'     => AilosCnabDriver::class,
+        'sicredi_cnab'   => SicrediCnabDriver::class,
+        'cresol_cnab'    => CresolCnabDriver::class,
+        'banrisul_cnab'  => BanrisulCnabDriver::class,
+        'btg_cnab'       => BtgCnabDriver::class,
     ];
 
     /**


### PR DESCRIPTION
Consolidador após 11 PRs CnabDriver mergeados (#1589 #1590 #1592 #1606-#1613).

Adiciona 11 keys em `PaymentGatewayService::DRIVERS` const + 11 imports:
- `bradesco_cnab` / `itau_cnab` / `bb_cnab` / `santander_cnab` / `caixa_cnab`
- `sicoob_cnab` (lib Bancoob legacy name)
- `ailos_cnab` (ex-Cecred)
- `sicredi_cnab` / `cresol_cnab` / `banrisul_cnab` / `btg_cnab`

Resolve task #14 (catalogada após pattern dos 11 PRs evitarem touch no const pra prevenir merge conflict mecânico).

Refs: ADR 0170-bancos-nativos-top5-drivers-separados Onda 4f.cnab consolidação