### PR TITLE
feat(paymentgateway): UI catalog — 11 CnabDrivers em cobranca-shared

### DIFF
--- a/resources/js/Pages/Financeiro/Cobranca/_lib/cobranca-shared.ts
+++ b/resources/js/Pages/Financeiro/Cobranca/_lib/cobranca-shared.ts
@@ -4,7 +4,12 @@
 export type CobrancaTipo = 'boleto' | 'pix_cob' | 'pix_cobv' | 'pix_recv' | 'card';
 export type CobrancaStatus = 'emitida' | 'paga' | 'vencida' | 'cancelada' | 'erro' | 'pending';
 export type OrigemType = 'sale' | 'invoice' | 'subscription_license';
-export type GatewayKey = 'inter' | 'c6' | 'asaas' | 'bcb_pix' | 'pagarme';
+export type GatewayKey =
+  // API REST drivers
+  | 'inter' | 'c6' | 'asaas' | 'bcb_pix' | 'pagarme'
+  // CNAB drivers (Onda 4f.cnab — ADR 0170-bancos-nativos-top5-drivers-separados v3 Wagner 2026-05-26)
+  | 'bradesco_cnab' | 'itau_cnab' | 'bb_cnab' | 'santander_cnab' | 'caixa_cnab'
+  | 'sicoob_cnab' | 'ailos_cnab' | 'sicredi_cnab' | 'cresol_cnab' | 'banrisul_cnab' | 'btg_cnab';
 
 export interface Cobranca {
   id: number;
@@ -194,6 +199,175 @@ export const DRIVERS: Record<GatewayKey, DriverToken> = {
     requirements: ['KYC PJ Stone (1-3d homologação)', 'sk_test_* sandbox após approval', 'Webhook dashboard separado'],
     recommendedFor: 'Marketplace + parcelamento longo · grupo Stone · split de pagamentos',
     credentialSource: { url: 'https://dashboard.pagar.me', label: 'Pagar.me Dashboard → Configurações → Chaves' },
+  },
+
+  // ─── CNAB DRIVERS (Onda 4f.cnab — file-based, boleto registrado via arquivo remessa) ───
+  // ADR 0170-bancos-nativos-top5-drivers-separados (v3 Wagner 2026-05-26 · 11 bancos)
+  // Cliente emite dia 1 sem esperar homologação Open API (14-45d). Coexistem com REST.
+
+  bradesco_cnab: {
+    key: 'bradesco_cnab', nome: 'Bradesco', sigla: 'BR',
+    dot: 'bg-red-600', bg: 'bg-red-50', fg: 'text-red-700', border: 'border-red-200',
+    tipos: ['boleto'],
+    ambientes: ['production'],
+    cred: 'agência + conta + carteira (02/04/09/21/26) + cedente CNPJ · CNAB 240',
+    pricing: {
+      boleto: 'Tarifa boleto Bradesco (R$ 2,50-3,50/boleto típico PJ)',
+      settlement: 'D+1 após pagamento',
+    },
+    requirements: ['Conta PJ Bradesco ativa', 'Convênio cobrança liberado pelo gerente PJ', 'Carteira definida (recomendado 09)', 'Sem PIX/cartão (só boleto)'],
+    recommendedFor: 'PJ que já tem Bradesco como banco principal · emissão imediata sem esperar API Open Banking (14d homologação)',
+    credentialSource: { url: 'https://banco.bradesco/internet-banking-pessoa-juridica', label: 'Bradesco Net Empresa → Convênio Cobrança' },
+  },
+
+  itau_cnab: {
+    key: 'itau_cnab', nome: 'Itaú', sigla: 'IT',
+    dot: 'bg-orange-600', bg: 'bg-orange-50', fg: 'text-orange-700', border: 'border-orange-300',
+    tipos: ['boleto'],
+    ambientes: ['production'],
+    cred: 'agência + conta + DV + carteira (109/110/112/115/188) + cedente CNPJ · CNAB 240',
+    pricing: {
+      boleto: 'Tarifa boleto Itaú (R$ 2,50-3,80/boleto típico PJ)',
+      settlement: 'D+1 após pagamento',
+    },
+    requirements: ['Conta PJ Itaú Empresas ativa', 'Convênio cobrança liberado pelo gerente PJ', 'Carteira 109 (cobrança simples com registro) padrão', 'CNAB 240 (Manual Itaú v10.2 descontinuou 400)'],
+    recommendedFor: 'PJ Itaú Empresas · emissão imediata sem esperar Open API (2-3 semanas homologação)',
+    credentialSource: { url: 'https://www.itau.com.br/empresas/', label: 'Itaú Empresas → Cobrança Bancária → Convênio' },
+  },
+
+  bb_cnab: {
+    key: 'bb_cnab', nome: 'Banco do Brasil', sigla: 'BB',
+    dot: 'bg-yellow-500', bg: 'bg-yellow-50', fg: 'text-yellow-800', border: 'border-yellow-300',
+    tipos: ['boleto'],
+    ambientes: ['production'],
+    cred: 'agência + conta + convênio CIP + carteira (17 padrão) + cedente CNPJ · CNAB 240',
+    pricing: {
+      boleto: 'Tarifa BB cobrança (R$ 2,00-3,50/boleto típico PJ)',
+      settlement: 'D+1 após pagamento',
+    },
+    requirements: ['Conta PJ BB ativa', 'Convênio CIP off-API liberado presencialmente pelo gerente PJ', 'numeroConvenio obrigatório (sem ele boleto não registra)', 'Carteira 17 (Cobrança Simples Eletrônica) padrão PJ'],
+    recommendedFor: 'PJ Banco do Brasil · cobertura nacional · sandbox aberto pra dev mas convênio presencial',
+    credentialSource: { url: 'https://www.bb.com.br/empresas', label: 'BB → PJ → Cobrança → Convênio CIP' },
+  },
+
+  santander_cnab: {
+    key: 'santander_cnab', nome: 'Santander', sigla: 'SA',
+    dot: 'bg-red-700', bg: 'bg-red-50', fg: 'text-red-800', border: 'border-red-300',
+    tipos: ['boleto'],
+    ambientes: ['production'],
+    cred: 'agência + conta + código_cliente + carteira (101 padrão) + cedente CNPJ · CNAB 240',
+    pricing: {
+      boleto: 'Tarifa Santander cobrança (R$ 2,80-4,00/boleto típico PJ)',
+      settlement: 'D+1 após pagamento',
+    },
+    requirements: ['Conta PJ Santander Empresas ativa', 'Código cliente SIGCB obtido com gerente PJ', 'Homologação 3-5 semanas (mais burocrático que outros)', 'Carteira 101 (Cobrança Simples com Registro) padrão'],
+    recommendedFor: 'PJ Santander · alternativa CNAB enquanto cliente não compra cert A1 ICP-Brasil pra API REST (R$ 200-400/ano)',
+    credentialSource: { url: 'https://www.santander.com.br/pj', label: 'Santander Empresas → Cobrança → Código Cliente SIGCB' },
+  },
+
+  caixa_cnab: {
+    key: 'caixa_cnab', nome: 'Caixa', sigla: 'CX',
+    dot: 'bg-blue-700', bg: 'bg-blue-50', fg: 'text-blue-800', border: 'border-blue-300',
+    tipos: ['boleto'],
+    ambientes: ['production'],
+    cred: 'agência + código_cliente SIGCB + carteira (RG) + cedente CNPJ · CNAB 240',
+    pricing: {
+      boleto: 'Tarifa Caixa SIGCB (R$ 2,00-3,50/boleto típico PJ)',
+      settlement: 'D+1 após pagamento',
+    },
+    requirements: ['Conta PJ Caixa ativa', 'Convênio SIGCB presencial via gerente PJ (30-90 dias)', 'Sem opção API REST viável em 2026 (portal devs.caixa.gov.br fora)', 'Carteira RG (Cobrança Registrada) única ativa'],
+    recommendedFor: 'PJ Caixa · ÚNICA opção viável Caixa hoje (API REST não funciona pra PME)',
+    credentialSource: { url: 'https://www.caixa.gov.br/empresa', label: 'Caixa Empresa → Cobrança SIGCB → Convênio' },
+  },
+
+  sicoob_cnab: {
+    key: 'sicoob_cnab', nome: 'Sicoob', sigla: 'SO',
+    dot: 'bg-emerald-700', bg: 'bg-emerald-50', fg: 'text-emerald-800', border: 'border-emerald-300',
+    tipos: ['boleto'],
+    ambientes: ['production'],
+    cred: 'agência + conta + convênio + carteira (1/3) + modalidade + cedente CNPJ · CNAB 240',
+    pricing: {
+      boleto: 'Tarifa cooperativa Sicoob (R$ 1,50-3,00/boleto · varia por singular)',
+      settlement: 'D+1 após pagamento',
+    },
+    requirements: ['Conta PJ cooperativa Sicoob (singular)', 'Convênio cobrança liberado pela cooperativa', 'Carteira 1 (cobrança simples) padrão', 'Modalidade definida (auto-explicativa singular)'],
+    recommendedFor: 'PJ associada Sicoob (sistema cooperativista nacional · 5.000+ agências) · tarifa cooperativa vantajosa',
+    credentialSource: { url: 'https://www.sicoob.com.br/web/empresarial/cobranca', label: 'Sicoob Empresarial → Cobrança → Convênio' },
+  },
+
+  ailos_cnab: {
+    key: 'ailos_cnab', nome: 'Ailos (ex-Cecred)', sigla: 'AI',
+    dot: 'bg-teal-600', bg: 'bg-teal-50', fg: 'text-teal-700', border: 'border-teal-200',
+    tipos: ['boleto'],
+    ambientes: ['production'],
+    cred: 'agência+DV + conta+DV + carteira (1) + convênio + cedente CNPJ · CNAB 240',
+    pricing: {
+      boleto: 'Tarifa cooperativa Ailos (R$ 1,50-2,50/boleto típico)',
+      settlement: 'D+1 após pagamento',
+    },
+    requirements: ['Conta PJ cooperativa Ailos (centrais SC/PR/RS)', 'Convênio liberado pela cooperativa', 'Cecred rebatizado Ailos em 2018'],
+    recommendedFor: 'PJ associada Ailos (cooperativa Sul · forte SC/PR) · ex-clientes Cecred',
+    credentialSource: { url: 'https://www.ailos.coop.br', label: 'Ailos → Internet Banking PJ → Cobrança' },
+  },
+
+  sicredi_cnab: {
+    key: 'sicredi_cnab', nome: 'Sicredi', sigla: 'SR',
+    dot: 'bg-lime-700', bg: 'bg-lime-50', fg: 'text-lime-800', border: 'border-lime-300',
+    tipos: ['boleto'],
+    ambientes: ['production'],
+    cred: 'cooperativa + posto + conta + carteira (A) + byte_id_arquivo + cedente CNPJ · CNAB 240',
+    pricing: {
+      boleto: 'Tarifa cooperativa Sicredi (R$ 1,50-3,00/boleto · varia por singular)',
+      settlement: 'D+1 após pagamento',
+    },
+    requirements: ['Conta PJ cooperativa Sicredi (2º maior sistema cooperativista BR)', 'Convênio cobrança liberado pela cooperativa', 'Carteira A (cobrança simples) padrão', 'byte_id_arquivo controlado por singular'],
+    recommendedFor: 'PJ associada Sicredi · forte Centro-Sul · 2º maior cooperativista BR após Sicoob',
+    credentialSource: { url: 'https://www.sicredi.com.br/empresas/', label: 'Sicredi Empresas → Cobrança → Convênio' },
+  },
+
+  cresol_cnab: {
+    key: 'cresol_cnab', nome: 'Cresol', sigla: 'CR',
+    dot: 'bg-green-700', bg: 'bg-green-50', fg: 'text-green-800', border: 'border-green-300',
+    tipos: ['boleto'],
+    ambientes: ['production'],
+    cred: 'cooperativa + posto + conta + carteira + cedente CNPJ · CNAB 240',
+    pricing: {
+      boleto: 'Tarifa cooperativa Cresol (R$ 1,50-2,50/boleto típico)',
+      settlement: 'D+1 após pagamento',
+    },
+    requirements: ['Conta PJ cooperativa Cresol (Centro-Sul rural)', 'Convênio liberado pela cooperativa', 'Estrutura similar Sicredi (cooperativa+posto)'],
+    recommendedFor: 'PJ associada Cresol · cooperativa rural Centro-Sul · agronegócio familiar',
+    credentialSource: { url: 'https://www.cresol.com.br', label: 'Cresol → Internet Banking PJ → Cobrança' },
+  },
+
+  banrisul_cnab: {
+    key: 'banrisul_cnab', nome: 'Banrisul', sigla: 'BA',
+    dot: 'bg-sky-700', bg: 'bg-sky-50', fg: 'text-sky-800', border: 'border-sky-300',
+    tipos: ['boleto'],
+    ambientes: ['production'],
+    cred: 'agência + conta + carteira (1) + código_cliente + cedente CNPJ · CNAB 240',
+    pricing: {
+      boleto: 'Tarifa Banrisul cobrança (R$ 2,00-3,50/boleto típico PJ)',
+      settlement: 'D+1 após pagamento',
+    },
+    requirements: ['Conta PJ Banrisul (RS/SC)', 'Código cliente 7+2DV obtido com gerente PJ via carta-circular', 'Carteira 1 (cobrança simples) padrão pra gráficas/confecções', 'Layout 240 (Banrisul descontinuou 400 em 12/2020)'],
+    recommendedFor: 'PJ regional Sul (Banrisul presença forte SC/RS) · gráficas e confecções segmento vestuário',
+    credentialSource: { url: 'https://www.banrisul.com.br/bob/pj', label: 'Banrisul Internet Banking PJ → Cobrança' },
+  },
+
+  btg_cnab: {
+    key: 'btg_cnab', nome: 'BTG Pactual', sigla: 'BT',
+    dot: 'bg-slate-800', bg: 'bg-slate-100', fg: 'text-slate-800', border: 'border-slate-300',
+    tipos: ['boleto'],
+    ambientes: ['production'],
+    cred: 'agência + conta + carteira (1=Simples PJ) + código_cliente 12 dígitos + cedente CNPJ · CNAB 240',
+    pricing: {
+      boleto: 'Tarifa BTG Pactual cobrança PJ (negociável)',
+      settlement: 'D+1 após pagamento',
+    },
+    requirements: ['Conta PJ BTG Pactual Empresas', 'Código cliente 12 dígitos obrigatório (agenciaCodigoBeneficiario)', 'CNPJ conta = CNPJ beneficiário', 'Carteira 1 (Cobrança Simples PJ) padrão'],
+    recommendedFor: 'PJ BTG Pactual · banco de investimento com cobrança PJ moderna · clientes high-end',
+    credentialSource: { url: 'https://www.btgpactualbusiness.com', label: 'BTG Pactual Business → Cobrança PJ' },
   },
 };
 


### PR DESCRIPTION
Estende DRIVERS + GatewayKey TypeScript pra expor os 11 CnabDrivers backend (PR #1616 consolidador) no wizard /settings/payment-gateways. Cada driver tem cor própria, pricing, requirements, credentialSource. Refs: ADR 0170-bancos-nativos-top5-drivers-separados Onda 4f.cnab UI.