### PR TITLE
feat(fiscal): Onda 2 — drawers Eventos/Contabilidade + tabs Dfe/Config + SeriesTab

### DIFF
--- a/Modules/Fiscal/Http/Controllers/CockpitController.php
+++ b/Modules/Fiscal/Http/Controllers/CockpitController.php
@@ -65,7 +65,81 @@ class CockpitController extends Controller
             'notasMock'      => $this->mockNotasUnificadas(),
             'savedViewCounts' => $this->mockSavedViewCounts(),
             'sefazStatus'    => $this->mockSefazStatus(),
+            // Onda 2 — drawers do header (Eventos + Enviar p/ contabilidade)
+            'eventosMock'    => $this->mockEventos(),
+            'contabilData'   => $this->mockContabilData(),
         ]);
+    }
+
+    /**
+     * Mock eventos fiscais (CC-e, cancelamento, inutilização, EPEC,
+     * manifestação) pra alimentar EventosDrawer do header. Onda 2.
+     * TODO[CL]: substituir por query real em nfe_eventos (NfeBrasil).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function mockEventos(): array
+    {
+        $now = now();
+
+        return [
+            ['id' => 'evt-1', 'tipo' => 'Carta de Correção', 'kind' => 'cce', 'nota' => 'NFe 8424',
+             'sequencia' => 1, 'descricao' => 'Corrigir info adicional natureza operação',
+             'emit' => $now->copy()->subHours(3)->format('d/m H:i'), 'autor' => 'Eliana', 'sefaz' => 100],
+            ['id' => 'evt-2', 'tipo' => 'Cancelamento', 'kind' => 'cancel', 'nota' => 'NFe 8420',
+             'descricao' => 'Cliente desistiu da compra antes de envelopamento',
+             'emit' => $now->copy()->subHours(8)->format('d/m H:i'), 'autor' => 'Eliana', 'sefaz' => 101],
+            ['id' => 'evt-3', 'tipo' => 'Inutilização', 'kind' => 'inutilizacao', 'nota' => 'Faixa 8418-8419',
+             'descricao' => 'Inutilização de faixa numérica saltada (erro digitação)',
+             'emit' => $now->copy()->subDay()->format('d/m H:i'), 'autor' => 'Wagner', 'sefaz' => 102],
+            ['id' => 'evt-4', 'tipo' => 'Manifestação destinatário', 'kind' => 'manifest', 'nota' => 'NFe entrada 982',
+             'descricao' => 'Confirmação operação fornecedor TechSupply Ltda',
+             'emit' => $now->copy()->subDays(2)->format('d/m H:i'), 'autor' => 'Wagner', 'sefaz' => 135],
+            ['id' => 'evt-5', 'tipo' => 'Cancelamento', 'kind' => 'cancel', 'nota' => 'NFCe 9005',
+             'descricao' => 'Cliente devolveu mercadoria mesma data',
+             'emit' => $now->copy()->subDays(3)->format('d/m H:i'), 'autor' => 'Larissa', 'sefaz' => 101],
+        ];
+    }
+
+    /**
+     * Mock dados pro SendToContabilDrawer. Onda 2.
+     * TODO[CL]: substituir por ContabilSendService real (validações reais
+     * + agrega XMLs + dispara job de envio email/SFTP).
+     *
+     * @return array<string, mixed>
+     */
+    protected function mockContabilData(): array
+    {
+        $now = now();
+
+        return [
+            'periodoCorrente'    => $now->locale('pt_BR')->isoFormat('MMMM/YYYY'),
+            'contadorNome'       => 'A configurar em /fiscal/config',
+            'destinatarioPadrao' => 'contador@example.com.br',
+            'validacoes' => [
+                ['ok' => true,   'label' => '184 NF-e autorizadas no período'],
+                ['ok' => 'warn', 'label' => '3 NF-e rejeitadas — não entram no pacote', 'action' => 'Ver rejeitadas', 'goto' => '/fiscal/nfe?status=rejeitadas'],
+                ['ok' => true,   'label' => '5 DF-e manifestadas (4 confirmadas + 1 desconhecida)'],
+                ['ok' => 'warn', 'label' => 'Certificado A1 vence em 47d — renovar antes do próximo fechamento', 'action' => 'Renovar', 'goto' => '/fiscal/config'],
+                ['ok' => true,   'label' => 'SPED EFD ICMS/IPI pronto pra gerar (último: abr/2026)'],
+            ],
+            'totalsByPeriodo' => [
+                'autorizadas' => 184,
+                'nfse'        => 12,
+                'eventos'     => 5,
+            ],
+            'history' => [
+                ['id' => 'hist-1', 'periodo' => 'abril/2026', 'enviadoEm' => '03/05 09:23',
+                 'metodo' => 'email', 'destino' => 'contador@example.com.br',
+                 'pacote' => 4_320_000, 'status' => 'enviado'],
+                ['id' => 'hist-2', 'periodo' => 'março/2026', 'enviadoEm' => '02/04 10:15',
+                 'metodo' => 'email', 'destino' => 'contador@example.com.br',
+                 'pacote' => 3_980_000, 'status' => 'enviado'],
+                ['id' => 'hist-3', 'periodo' => 'fevereiro/2026', 'enviadoEm' => '04/03 11:48',
+                 'metodo' => 'download', 'destino' => 'eliana@local',
+                 'pacote' => 2_140_000, 'status' => 'enviado'],
+            ],
+        ];
     }
 
     /**

--- a/Modules/Fiscal/Http/Controllers/ConfigController.php
+++ b/Modules/Fiscal/Http/Controllers/ConfigController.php
@@ -78,7 +78,31 @@ class ConfigController extends Controller
             ] : null,
             // Painel fiscal — espelha CertificadoController::status() do NfeBrasil
             'painel' => $painel,
+            // Onda 2 I — séries fiscais (tab "Séries" do ModuleTopNav).
+            // TODO[CL]: substituir por query real (business.numero_serie_nfe +
+            // possíveis tabelas de séries auxiliares).
+            'seriesMock' => $this->mockSeriesFiscais(
+                $painel['serieNfe'] ?? '1',
+                (int) ($painel['proximoNumero'] ?? 1),
+            ),
         ]);
+    }
+
+    /**
+     * Mock séries fiscais. Onda 2 I — tab Séries do Config.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function mockSeriesFiscais(string $serieNfePrincipal, int $proximoNfe): array
+    {
+        return [
+            ['modelo' => 55, 'serie' => $serieNfePrincipal, 'proximo' => $proximoNfe,
+             'filial' => 'Matriz', 'ativo' => true, 'obs' => null],
+            ['modelo' => 65, 'serie' => '9', 'proximo' => 9013,
+             'filial' => 'Matriz · balcão', 'ativo' => true, 'obs' => null],
+            ['modelo' => 55, 'serie' => '2', 'proximo' => 1,
+             'filial' => 'Filial 02 (futuro)', 'ativo' => false, 'obs' => 'Reservada — sem operação ainda'],
+        ];
     }
 
     /**

--- a/Modules/Fiscal/Http/Controllers/DfeController.php
+++ b/Modules/Fiscal/Http/Controllers/DfeController.php
@@ -34,7 +34,50 @@ class DfeController extends Controller
             'filters' => $filters,
             'counts'  => $this->computeCounts(),
             'rows'    => Inertia::defer(fn () => $this->buildRowsPayload($filters)),
+            // Onda 2 G — tab Histórico de manifestações já processadas.
+            // TODO[CL]: substituir por query real de NfeDfeRecebido WHERE
+            // status_manifestacao IN ('confirmada','desconhecida','nao_realizada')
+            // ordenado por manifestado_em DESC.
+            'historicoMock' => $this->mockHistorico(),
         ]);
+    }
+
+    /**
+     * Mock pra tab Histórico do DF-e (Onda 2). PII-safe.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected function mockHistorico(): array
+    {
+        $now = now();
+
+        return [
+            ['id' => 901, 'chave' => '[REDACTED-CHAVE-NFE-44]',
+             'nomeEmitente' => 'TechSupply Ltda', 'cnpjEmitente' => '[REDACTED-CNPJ]',
+             'when' => $now->copy()->subDays(2)->format('d/m H:i'),
+             'ack' => 'confirmada', 'actor' => 'Wagner',
+             'obs' => 'Material recebido OK · NFe 12345', 'valor' => 8420.00],
+            ['id' => 902, 'chave' => '[REDACTED-CHAVE-NFE-44]',
+             'nomeEmitente' => 'Gráfica Parceira ME', 'cnpjEmitente' => '[REDACTED-CNPJ]',
+             'when' => $now->copy()->subDays(4)->format('d/m H:i'),
+             'ack' => 'confirmada', 'actor' => 'Eliana',
+             'obs' => 'Insumos pra produção', 'valor' => 3240.00],
+            ['id' => 903, 'chave' => '[REDACTED-CHAVE-NFE-44]',
+             'nomeEmitente' => 'Logística Express', 'cnpjEmitente' => '[REDACTED-CNPJ]',
+             'when' => $now->copy()->subDays(7)->format('d/m H:i'),
+             'ack' => 'ciencia', 'actor' => 'Auto (job diário)',
+             'obs' => null, 'valor' => 142.00],
+            ['id' => 904, 'chave' => '[REDACTED-CHAVE-NFE-44]',
+             'nomeEmitente' => 'Empresa Desconhecida XYZ', 'cnpjEmitente' => '[REDACTED-CNPJ]',
+             'when' => $now->copy()->subDays(10)->format('d/m H:i'),
+             'ack' => 'desconhecida', 'actor' => 'Wagner',
+             'obs' => 'Operação não foi solicitada por nós — fornecedor errou destinatário', 'valor' => 18900.00],
+            ['id' => 905, 'chave' => '[REDACTED-CHAVE-NFE-44]',
+             'nomeEmitente' => 'Material Especial', 'cnpjEmitente' => '[REDACTED-CNPJ]',
+             'when' => $now->copy()->subDays(14)->format('d/m H:i'),
+             'ack' => 'nao_realizada', 'actor' => 'Eliana',
+             'obs' => 'Pedido cancelado em comum acordo · mercadoria nunca chegou', 'valor' => 5200.00],
+        ];
     }
 
     protected function computeCounts(): array

--- a/resources/js/Pages/Fiscal/Cockpit.tsx
+++ b/resources/js/Pages/Fiscal/Cockpit.tsx
@@ -18,9 +18,11 @@ import {
 } from 'lucide-react';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
+import EventosDrawer, { type EventoFiscal } from './_components/EventosDrawer';
 import FxShell from './_components/FxShell';
 import NFSeDrawer, { type NFSeDrawerData } from './_components/NFSeDrawer';
 import NotaDrawerV2, { type NotaDrawerData } from './_components/NotaDrawerV2';
+import SendToContabilDrawer, { type SendToContabilData } from './_components/SendToContabilDrawer';
 import { brl, truncKey } from './_lib/fiscal-helpers';
 
 import '../../../css/fiscal-cockpit.css';
@@ -122,6 +124,9 @@ interface CockpitProps {
   notasMock: NotaRow[];
   savedViewCounts: SavedViewCounts;
   sefazStatus: SefazStatus;
+  // Onda 2 — drawers do header (Eventos + Enviar p/ contabilidade)
+  eventosMock?: EventoFiscal[];
+  contabilData?: SendToContabilData | null;
 }
 
 type ViewId = 'todas' | 'resolver' | 'janela24' | 'processando' | 'nfse' | 'nfce' | 'custom';
@@ -215,6 +220,7 @@ function mapToNFSeDrawerData(n: NotaRow): NFSeDrawerData {
 
 export default function Cockpit({
   kpis, alerts, notasMock, savedViewCounts, sefazStatus,
+  eventosMock = [], contabilData = null,
 }: CockpitProps) {
   const goto = (path: string) => router.visit(path);
 
@@ -236,6 +242,10 @@ export default function Cockpit({
   const openedNfse = openedNota && openedNota.kind === 'nfse'
     ? mapToNFSeDrawerData(openedNota)
     : null;
+
+  // Onda 2 — drawers do header chip (Eventos + Enviar p/ contabilidade)
+  const [eventosOpen, setEventosOpen] = useState(false);
+  const [contabilOpen, setContabilOpen] = useState(false);
 
   const applyView = (vid: Exclude<ViewId, 'custom'>) => {
     const v = SAVED_VIEWS.find((x) => x.id === vid);
@@ -319,10 +329,17 @@ export default function Cockpit({
         ]}
         actions={
           <>
-            <button type="button" className="fx-chip-action" onClick={() => goto('/fiscal/eventos')}>
+            <button type="button" className="fx-chip-action" onClick={() => setEventosOpen(true)}>
               <RefreshCw size={12} /> Eventos
+              {eventosMock.length > 0 && <span style={{ marginLeft: 4, fontSize: 10, fontWeight: 700, color: 'var(--fx-text-mute)' }}>{eventosMock.length}</span>}
             </button>
-            <button type="button" className="fx-chip-action" disabled title="Drawer 'Enviar p/ contabilidade' — TODO[CL]">
+            <button
+              type="button"
+              className="fx-chip-action"
+              onClick={() => setContabilOpen(true)}
+              disabled={!contabilData}
+              title={contabilData ? 'Abrir fluxo de envio mensal' : 'Backend stub — TODO[CL]'}
+            >
               <Archive size={12} /> Enviar p/ contabilidade
             </button>
             <div ref={emitirRef} className="fx-popmenu-wrap">
@@ -604,6 +621,20 @@ export default function Cockpit({
       <NFSeDrawer
         nota={openedNfse}
         onClose={() => setOpenedId(null)}
+      />
+
+      {/* Drawer Eventos (chip 'Eventos' do header — Onda 2 D) */}
+      <EventosDrawer
+        open={eventosOpen}
+        eventos={eventosMock}
+        onClose={() => setEventosOpen(false)}
+      />
+
+      {/* Drawer Enviar p/ contabilidade (chip do header — Onda 2 D) */}
+      <SendToContabilDrawer
+        open={contabilOpen}
+        data={contabilData}
+        onClose={() => setContabilOpen(false)}
       />
     </AppShellV2>
   );

--- a/resources/js/Pages/Fiscal/Config.tsx
+++ b/resources/js/Pages/Fiscal/Config.tsx
@@ -11,13 +11,25 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, useForm, usePage } from '@inertiajs/react';
 import type { PageProps } from '@inertiajs/core';
-import { CheckCircle2, KeyRound, Loader2, PlugZap, Shield, Upload, XCircle } from 'lucide-react';
+import { Archive, CheckCircle2, FileText, KeyRound, Loader2, PlugZap, Settings, Shield, Upload, XCircle } from 'lucide-react';
 import { type FormEvent, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
 import FxShell from './_components/FxShell';
+import ModuleTopNav from './_components/ModuleTopNav';
 
 import '../../../css/fiscal-cockpit.css';
+
+type ConfigTab = 'cert' | 'series' | 'ambiente' | 'sped';
+
+export interface SerieFiscal {
+  modelo: 55 | 65;
+  serie: string;
+  proximo: number;
+  filial: string;
+  ativo: boolean;
+  obs?: string | null;
+}
 
 interface Certificado {
   uuid: string;
@@ -56,6 +68,8 @@ interface ConfigProps {
   certificado: Certificado | null;
   config: Config | null;
   painel: Painel;
+  // Onda 2 I — séries fiscais (modelo 55 NF-e + 65 NFC-e)
+  seriesMock?: SerieFiscal[];
 }
 
 interface FlashProps extends PageProps {
@@ -87,7 +101,9 @@ function formatCnpj(raw: string | null): string {
   return `${digits.slice(0, 2)}.${digits.slice(2, 5)}.${digits.slice(5, 8)}/${digits.slice(8, 12)}-${digits.slice(12)}`;
 }
 
-export default function Config({ certificado, config, painel }: ConfigProps) {
+export default function Config({ certificado, config, painel, seriesMock = [] }: ConfigProps) {
+  const [tab, setTab] = useState<ConfigTab>('cert');
+
   const { props: pageProps } = usePage<FlashProps>();
   const flashSuccess = pageProps.flash?.success;
 
@@ -241,6 +257,19 @@ export default function Config({ certificado, config, painel }: ConfigProps) {
           </div>
         )}
 
+        {/* Onda 2 H — ModuleTopNav 4 tabs */}
+        <ModuleTopNav
+          items={[
+            { id: 'cert',     label: 'Certificado A1', icon: <Shield size={12} />,    count: certificado ? undefined : 0, tone: certificado ? null : 'bad' },
+            { id: 'series',   label: 'Séries',         icon: <FileText size={12} />,  count: seriesMock.filter((s) => s.ativo).length },
+            { id: 'ambiente', label: 'Ambiente',       icon: <Settings size={12} /> },
+            { id: 'sped',     label: 'SPED & Livros',  icon: <Archive size={12} /> },
+          ]}
+          value={tab}
+          onChange={(id) => setTab(id as ConfigTab)}
+        />
+
+        {tab === 'cert' && (<>
         {/* Cert + Help (2-col grid — port fiscal-page.jsx §12 CertificadoTab) */}
         <div className="fx-cert-grid">
           <section className="fx-cert-card">
@@ -306,7 +335,10 @@ export default function Config({ certificado, config, painel }: ConfigProps) {
             </ul>
           </section>
         </div>
+        </>)}
 
+        {tab === 'ambiente' && (
+        <>
         {/* Ambiente SEFAZ — radio + submit */}
         <section className="fx-cert-card" style={{ marginBottom: 14 }}>
           <h3>Ambiente SEFAZ</h3>
@@ -356,7 +388,10 @@ export default function Config({ certificado, config, painel }: ConfigProps) {
             )}
           </form>
         </section>
+        </>
+        )}
 
+        {tab === 'cert' && (<>
         {/* Upload .pfx — Inertia useForm → POST /nfe-brasil/configuracao/certificado */}
         <section className="fx-cert-card" style={{ marginBottom: 14 }}>
           <h3>
@@ -457,6 +492,81 @@ export default function Config({ certificado, config, painel }: ConfigProps) {
             <a href="/nfe-brasil/tributacao" className="fx-link">/nfe-brasil/tributacao</a>.
           </small>
         </section>
+        </>)}
+
+        {tab === 'series' && (
+          seriesMock.length === 0 ? (
+            <div className="fx-empty">
+              <FileText size={20} />
+              <b>Nenhuma série fiscal cadastrada</b>
+              <small>Séries NFe (modelo 55) e NFCe (modelo 65) são configuradas em NfeBrasil/business.numero_serie_nfe.</small>
+              <a href="/nfe-brasil/configuracao/series" className="fx-btn ghost" style={{ marginTop: 12 }}>Configurar em NfeBrasil</a>
+            </div>
+          ) : (
+            <section className="fx-cert-card">
+              <h3>Séries fiscais</h3>
+              <p className="lead">
+                Numeração ativa por modelo + filial. Read-only no Fiscal Cockpit —
+                edição em <a href="/nfe-brasil/configuracao/series" className="fx-link">NfeBrasil/Series</a>.
+              </p>
+              <div className="fx-table" style={{ marginTop: 12 }}>
+                <table>
+                  <thead>
+                    <tr>
+                      <th style={{ width: 140 }}>Modelo</th>
+                      <th style={{ width: 100 }}>Série</th>
+                      <th style={{ width: 130, textAlign: 'right' }}>Próximo nº</th>
+                      <th>Filial</th>
+                      <th style={{ width: 140 }}>Estado</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {seriesMock.map((s, i) => (
+                      <tr key={`${s.modelo}-${s.serie}-${i}`}>
+                        <td><b>{s.modelo}</b> <small className="fx-mut">({s.modelo === 65 ? 'NFC-e' : 'NF-e'})</small></td>
+                        <td className="fx-mono">série {s.serie}</td>
+                        <td className="fx-mono fx-strong" style={{ textAlign: 'right' }}>{s.proximo.toLocaleString('pt-BR')}</td>
+                        <td><small>{s.filial}</small></td>
+                        <td>
+                          <span className={`fx-sefaz ${s.ativo ? 'ok' : 'warn'}`}>
+                            <span className="lbl">{s.ativo ? 'ativa' : 'inativa'}</span>
+                          </span>
+                          {s.obs && <small style={{ display: 'block', color: 'var(--fx-text-mute)', marginTop: 3 }}>{s.obs}</small>}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </section>
+          )
+        )}
+
+        {tab === 'sped' && (
+          <section className="fx-cert-card">
+            <h3>SPED &amp; Livros fiscais</h3>
+            <p className="lead">
+              EFD ICMS/IPI · PIS/COFINS · ECF · Conciliação SEFAZ.
+              Gerador completo vive em <a href="/fiscal/sped" className="fx-link">/fiscal/sped</a>.
+            </p>
+            <div className="fx-callout" role="region" style={{ marginTop: 12 }}>
+              <Archive size={16} />
+              <div>
+                <b>Próxima entrega: maio/2026 — prazo 15/06</b>
+                <small>
+                  Última: 03/2026 protocolada 14/04 (SPED EFD ICMS/IPI).
+                  <br />
+                  ECF anual: prazo julho.
+                </small>
+              </div>
+            </div>
+            <div style={{ marginTop: 14 }}>
+              <a href="/fiscal/sped" className="fx-btn primary">
+                <Archive size={12} /> Abrir gerador SPED
+              </a>
+            </div>
+          </section>
+        )}
       </FxShell>
     </AppShellV2>
   );

--- a/resources/js/Pages/Fiscal/Dfe.tsx
+++ b/resources/js/Pages/Fiscal/Dfe.tsx
@@ -6,13 +6,28 @@
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Deferred, Head, router } from '@inertiajs/react';
-import { Check, CheckCircle2, Eye, FileSearch, Info, ShieldAlert, XCircle } from 'lucide-react';
+import { Check, CheckCircle2, Eye, FileSearch, Info, Inbox, ShieldAlert, XCircle } from 'lucide-react';
 import { useState } from 'react';
 
 import FxShell from './_components/FxShell';
+import ModuleTopNav from './_components/ModuleTopNav';
 import { brl, formatDoc, truncKey } from './_lib/fiscal-helpers';
 
 import '../../../css/fiscal-cockpit.css';
+
+type DfeTab = 'pendente' | 'historico';
+
+interface HistoricoEntry {
+  id: number;
+  chave: string;
+  nomeEmitente: string;
+  cnpjEmitente: string | null;
+  when: string;
+  ack: 'confirmada' | 'ciencia' | 'desconhecida' | 'nao_realizada';
+  actor: string;
+  obs: string | null;
+  valor: number;
+}
 
 type StatusManifestacao = 'pendente' | 'ciencia' | 'confirmada' | 'desconhecida' | 'nao_realizada';
 
@@ -49,6 +64,8 @@ interface DfeProps {
   filters: Filters;
   counts: Counts;
   rows?: { data: DfeRow[]; meta: { total: number; current_page: number; last_page: number } };
+  // Onda 2 — histórico de manifestações já processadas (mock no controller)
+  historicoMock?: HistoricoEntry[];
 }
 
 const STATUS_META: Record<StatusManifestacao, { label: string; tone: 'ok' | 'warn' | 'bad' }> = {
@@ -61,8 +78,9 @@ const STATUS_META: Record<StatusManifestacao, { label: string; tone: 'ok' | 'war
 
 type ManifestAction = 'cienciar' | 'confirmar' | 'desconhecer' | 'nao_realizada';
 
-export default function Dfe({ filters: initialFilters, counts, rows }: DfeProps) {
+export default function Dfe({ filters: initialFilters, counts, rows, historicoMock = [] }: DfeProps) {
   const [filters, setFilters] = useState<Filters>(initialFilters);
+  const [tab, setTab] = useState<DfeTab>('pendente');
   const dataRows = rows?.data ?? [];
   const [busyId, setBusyId] = useState<number | null>(null);
   const [modal, setModal] = useState<{ id: number; acao: 'desconhecer' | 'nao_realizada' } | null>(null);
@@ -121,6 +139,17 @@ export default function Dfe({ filters: initialFilters, counts, rows }: DfeProps)
           </button>
         }
       >
+        {/* ModuleTopNav — Onda 2 G — tabs Pendentes / Histórico */}
+        <ModuleTopNav
+          items={[
+            { id: 'pendente',  label: 'Aguardando ciência', icon: <Inbox size={12} />,          count: counts.pendentes, tone: counts.pendentes > 0 ? 'warn' : null },
+            { id: 'historico', label: 'Histórico',          icon: <CheckCircle2 size={12} />, count: historicoMock.length },
+          ]}
+          value={tab}
+          onChange={(id) => setTab(id as DfeTab)}
+        />
+
+        {tab === 'pendente' && (<>
         {/* Callout informativo (port do fiscal-page.jsx §10 FiscalDFePage) */}
         <div className="fx-callout" role="region" aria-label="O que é manifestação">
           <Info size={16} />
@@ -255,6 +284,58 @@ export default function Dfe({ filters: initialFilters, counts, rows }: DfeProps)
             </div>
           )}
         </Deferred>
+        </>)}
+
+        {tab === 'historico' && (
+          historicoMock.length === 0 ? (
+            <div className="fx-empty">
+              <CheckCircle2 size={20} />
+              <b>Sem histórico ainda</b>
+              <small>Manifestações confirmadas/desconhecidas/não-realizadas aparecem aqui após processamento SEFAZ.</small>
+            </div>
+          ) : (
+            <div className="fx-table">
+              <table>
+                <thead>
+                  <tr>
+                    <th>Emitente</th>
+                    <th style={{ width: 100 }}>Quando</th>
+                    <th style={{ width: 150 }}>Manifestação</th>
+                    <th style={{ width: 110 }}>Por</th>
+                    <th>Observação</th>
+                    <th style={{ width: 110, textAlign: 'right' }}>Valor</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {historicoMock.map((h) => {
+                    const tone = h.ack === 'confirmada' ? 'ok' : h.ack === 'ciencia' ? 'warn' : 'bad';
+                    const label = h.ack === 'confirmada' ? '✓ Confirmada'
+                      : h.ack === 'ciencia' ? '~ Ciência'
+                      : h.ack === 'desconhecida' ? '✗ Desconhecida'
+                      : '— Não realizada';
+                    return (
+                      <tr key={h.id}>
+                        <td>
+                          <b>{h.nomeEmitente}</b>
+                          <small style={{ display: 'block', color: 'var(--fx-text-mute)' }}>{formatDoc(h.cnpjEmitente, null)}</small>
+                        </td>
+                        <td><small className="fx-mono">{h.when}</small></td>
+                        <td>
+                          <span className={`fx-sefaz ${tone}`}>
+                            <span className="lbl">{label}</span>
+                          </span>
+                        </td>
+                        <td><small>{h.actor}</small></td>
+                        <td><small style={{ color: 'var(--fx-text-dim)' }}>{h.obs ?? '—'}</small></td>
+                        <td className="fx-mono fx-strong" style={{ textAlign: 'right' }}>{brl(h.valor)}</td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )
+        )}
       </FxShell>
 
       {/* Modal motivo (desconhecer / nao_realizada) */}

--- a/resources/js/Pages/Fiscal/_components/EventosDrawer.tsx
+++ b/resources/js/Pages/Fiscal/_components/EventosDrawer.tsx
@@ -1,0 +1,151 @@
+// EventosDrawer.tsx — Slide-in 640px com tabela de eventos fiscais.
+//
+// Port do fiscal-page.jsx §EventosDrawer (Onda 2 D). Invocado pelo chip
+// "Eventos" do header do Cockpit, em vez de navegar pra /fiscal/eventos.
+// Mais ágil — Eliana fica no Cockpit, abre/fecha sem perder contexto.
+//
+// Mostra mesma data que /fiscal/eventos mas em formato compacto. Pra
+// detalhe profundo (filtros, +período), botão "Ver tudo" leva pra página.
+
+import { useEffect } from 'react';
+import { router } from '@inertiajs/react';
+import { Activity, ExternalLink } from 'lucide-react';
+
+import { sefazLabel, sefazTone } from '../_lib/sefaz-codes';
+
+export type EventoKind = 'cce' | 'cancel' | 'epec' | 'manifest' | 'inutilizacao';
+
+export interface EventoFiscal {
+  id: number | string;
+  tipo: string; // 'Cancelamento' | 'Carta de Correção' | ...
+  kind: EventoKind;
+  nota?: string; // ex "NFe 8425"
+  sequencia?: number;
+  descricao: string;
+  emit: string;
+  autor?: string;
+  sefaz: number;
+}
+
+interface EventosDrawerProps {
+  open: boolean;
+  eventos: EventoFiscal[];
+  onClose: () => void;
+}
+
+const KIND_LABEL: Record<EventoKind, string> = {
+  cce: 'CC-e',
+  cancel: 'Cancelamento',
+  epec: 'EPEC',
+  manifest: 'Manifestação',
+  inutilizacao: 'Inutilização',
+};
+
+export default function EventosDrawer({ open, eventos, onClose }: EventosDrawerProps) {
+  useEffect(() => {
+    if (!open) return;
+    const h = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const crit = eventos.filter((e) => e.kind === 'cancel').length;
+  const total = eventos.length;
+
+  return (
+    <>
+      <div className="fx-drawer-bg" onClick={onClose} />
+      <aside
+        className="fx-drawer"
+        style={{ width: 'min(640px, 96vw)' }}
+        role="dialog"
+        aria-label="Eventos fiscais"
+      >
+        <header className="fx-drawer-h">
+          <div>
+            <small>Eventos fiscais</small>
+            <h2>CC-e · cancelamento · inutilização</h2>
+            <small style={{ color: 'var(--fx-text-mute)' }}>
+              {total} eventos esta semana
+              {crit > 0 && ` · ${crit} cancelamento${crit > 1 ? 's' : ''}`} · janelas legais validadas automaticamente
+            </small>
+          </div>
+          <button type="button" className="fx-drawer-x" onClick={onClose} aria-label="Fechar (ESC)">×</button>
+        </header>
+
+        <div className="fx-drawer-body" style={{ padding: 0 }}>
+          {eventos.length === 0 ? (
+            <div className="fx-empty" style={{ margin: 20 }}>
+              <Activity size={20} />
+              <b>Nenhum evento no período</b>
+              <small>Eventos aparecem após cancelamento, CC-e, EPEC ou manifestação.</small>
+            </div>
+          ) : (
+            <div className="fx-table" style={{ borderRadius: 0, border: 'none', borderTop: '1px solid var(--fx-border)' }}>
+              <table>
+                <thead>
+                  <tr>
+                    <th style={{ width: 130 }}>Tipo</th>
+                    <th style={{ width: 120 }}>Documento</th>
+                    <th>Descrição</th>
+                    <th style={{ width: 90 }}>Emissão</th>
+                    <th style={{ width: 100 }}>Autor</th>
+                    <th style={{ width: 130 }}>SEFAZ</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {eventos.map((e) => {
+                    return (
+                      <tr key={e.id}>
+                        <td>
+                          <span className={`fx-tl-badge ${e.kind === 'cancel' ? 'cancel' : e.kind === 'epec' || e.kind === 'inutilizacao' ? 'epec' : e.kind === 'cce' ? 'cce' : 'manifest'}`}>
+                            {KIND_LABEL[e.kind]}{e.sequencia ? ` seq ${e.sequencia}` : ''}
+                          </span>
+                        </td>
+                        <td><b className="fx-mono">{e.nota ?? '—'}</b></td>
+                        <td style={{ fontSize: 12.5 }}>{e.descricao}</td>
+                        <td><small className="fx-mut">{e.emit}</small></td>
+                        <td><small className="fx-mut">{e.autor ?? '—'}</small></td>
+                        <td>
+                          <span className={`fx-sefaz ${sefazTone(e.sefaz)} compact`}>
+                            <span className="code">{e.sefaz}</span>
+                            <span className="lbl">{sefazLabel(e.sefaz)}</span>
+                          </span>
+                        </td>
+                      </tr>
+                    );
+                  })}
+                </tbody>
+              </table>
+            </div>
+          )}
+        </div>
+
+        <footer className="fx-drawer-f">
+          <small style={{ color: 'var(--fx-text-mute)' }}>
+            Janelas legais: CC-e 30d · cancelamento 24h NFC-e / 168h NF-e · inutilização faixas
+          </small>
+          <div className="fx-drawer-f-r">
+            <button
+              type="button"
+              className="fx-btn ghost"
+              onClick={() => {
+                onClose();
+                router.visit('/fiscal/eventos');
+              }}
+            >
+              <ExternalLink size={12} /> Ver tudo
+            </button>
+          </div>
+        </footer>
+      </aside>
+    </>
+  );
+}

--- a/resources/js/Pages/Fiscal/_components/ModuleTopNav.tsx
+++ b/resources/js/Pages/Fiscal/_components/ModuleTopNav.tsx
@@ -1,0 +1,44 @@
+// ModuleTopNav.tsx — Sub-tabs internas (Pendentes/Histórico em DF-e,
+// Cert/Séries/Ambiente/SPED em Config). Onda 2 G+H.
+//
+// Port do fiscal-page.jsx §ModuleTopNav. Usa CSS .fx-subtabs já existente
+// (canon shared, não cria novo token).
+
+import type { ReactNode } from 'react';
+
+export interface ModuleTopNavItem {
+  id: string;
+  label: string;
+  icon?: ReactNode;
+  count?: number;
+  tone?: 'ok' | 'warn' | 'bad' | null;
+}
+
+interface ModuleTopNavProps {
+  items: ModuleTopNavItem[];
+  value: string;
+  onChange: (id: string) => void;
+}
+
+export default function ModuleTopNav({ items, value, onChange }: ModuleTopNavProps) {
+  return (
+    <nav className="fx-subtabs" role="tablist" aria-label="Sub-páginas">
+      {items.map((it) => (
+        <button
+          key={it.id}
+          type="button"
+          role="tab"
+          aria-selected={value === it.id}
+          className={`fx-subtab${value === it.id ? ' active' : ''}`}
+          onClick={() => onChange(it.id)}
+        >
+          {it.icon}
+          <span>{it.label}</span>
+          {typeof it.count === 'number' && it.count > 0 && (
+            <span className={`n${it.tone ? ` t-${it.tone}` : ''}`}>{it.count}</span>
+          )}
+        </button>
+      ))}
+    </nav>
+  );
+}

--- a/resources/js/Pages/Fiscal/_components/SendToContabilDrawer.tsx
+++ b/resources/js/Pages/Fiscal/_components/SendToContabilDrawer.tsx
@@ -1,0 +1,264 @@
+// SendToContabilDrawer.tsx — Slide-in 760px com fluxo guiado "Enviar p/ contabilidade".
+//
+// Port do fiscal-page.jsx §SendToContabilDrawer (Onda 2 D). Multi-seção:
+//  1. Validações (rejeições pendentes? cert vencendo? DF-e pendente?)
+//  2. Período + método (email anexo / SFTP / download manual)
+//  3. Pacote (selecionar: XML autorizadas + DANFE + NFS-e + relatório summary)
+//  4. Histórico (últimos envios)
+//
+// Wire-up POST real fica TODO[CL] — drawer renderiza fluxo + botão disabled.
+
+import { useEffect, useState } from 'react';
+import { Archive, CheckCircle2, ExternalLink, FileText, Mail, ShieldAlert } from 'lucide-react';
+
+export interface ContabilValidacao {
+  ok: boolean | 'warn';
+  label: string;
+  action?: string;
+  goto?: string;
+}
+
+export interface ContabilHistoryEntry {
+  id: string | number;
+  periodo: string; // ex "abril/2026"
+  enviadoEm: string; // ex "03/05 09:23"
+  metodo: 'email' | 'sftp' | 'download';
+  destino: string; // ex "contador@example.br" ou "sftp://..."
+  pacote: number; // bytes
+  status: 'enviado' | 'falha' | 'pendente';
+}
+
+export interface SendToContabilData {
+  periodoCorrente: string; // ex "maio/2026"
+  validacoes: ContabilValidacao[];
+  destinatarioPadrao: string;
+  contadorNome: string;
+  history: ContabilHistoryEntry[];
+  totalsByPeriodo: { autorizadas: number; nfse: number; eventos: number };
+}
+
+interface SendToContabilDrawerProps {
+  open: boolean;
+  data: SendToContabilData | null;
+  onClose: () => void;
+}
+
+type Metodo = 'email' | 'sftp' | 'download';
+
+interface PacoteSelecao {
+  xmlAutorizadas: boolean;
+  danfeAutorizadas: boolean;
+  xmlNfse: boolean;
+  relatorioSummary: boolean;
+  eventos: boolean;
+}
+
+function formatBytes(b: number): string {
+  if (b < 1024) return `${b} B`;
+  if (b < 1024 * 1024) return `${(b / 1024).toFixed(1)} KB`;
+  return `${(b / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+export default function SendToContabilDrawer({ open, data, onClose }: SendToContabilDrawerProps) {
+  const [metodo, setMetodo] = useState<Metodo>('email');
+  const [pacote, setPacote] = useState<PacoteSelecao>({
+    xmlAutorizadas: true,
+    danfeAutorizadas: false,
+    xmlNfse: true,
+    relatorioSummary: true,
+    eventos: true,
+  });
+
+  useEffect(() => {
+    if (!open) return;
+    const h = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', h);
+    return () => window.removeEventListener('keydown', h);
+  }, [open, onClose]);
+
+  if (!open || !data) return null;
+
+  const bloqueios = data.validacoes.filter((v) => v.ok === false);
+  const warnings = data.validacoes.filter((v) => v.ok === 'warn');
+  const podeEnviar = bloqueios.length === 0 && (pacote.xmlAutorizadas || pacote.xmlNfse || pacote.relatorioSummary);
+
+  return (
+    <>
+      <div className="fx-drawer-bg" onClick={onClose} />
+      <aside
+        className="fx-drawer"
+        style={{ width: 'min(760px, 96vw)' }}
+        role="dialog"
+        aria-label="Enviar para contabilidade"
+      >
+        <header className="fx-drawer-h">
+          <div>
+            <small>Fechamento mensal</small>
+            <h2>Enviar p/ contabilidade — {data.periodoCorrente}</h2>
+            <small style={{ color: 'var(--fx-text-mute)' }}>
+              Contador: <b>{data.contadorNome}</b> · {data.destinatarioPadrao}
+            </small>
+          </div>
+          <button type="button" className="fx-drawer-x" onClick={onClose} aria-label="Fechar (ESC)">×</button>
+        </header>
+
+        <div className="fx-drawer-body">
+          {/* 1. Validações */}
+          <section className="fx-drawer-sec">
+            <h4>Validações pré-envio</h4>
+            <ul className="fx-validacoes">
+              {data.validacoes.map((v, i) => (
+                <li key={i} className={`fx-validacao ${v.ok === true ? 'ok' : v.ok === false ? 'bad' : 'warn'}`}>
+                  {v.ok === true ? <CheckCircle2 size={14} /> : <ShieldAlert size={14} />}
+                  <span>{v.label}</span>
+                  {v.action && v.goto && (
+                    <a
+                      href={v.goto}
+                      className="fx-link"
+                      style={{ marginLeft: 'auto', fontSize: 11 }}
+                      onClick={(e) => { e.preventDefault(); /* TODO[CL] router.visit(v.goto) */ }}
+                    >
+                      {v.action} <ExternalLink size={10} />
+                    </a>
+                  )}
+                </li>
+              ))}
+            </ul>
+            {bloqueios.length > 0 && (
+              <div className="fx-drawer-rej" style={{ marginTop: 10 }}>
+                ↳ Resolver bloqueios antes de enviar ({bloqueios.length} críticos)
+              </div>
+            )}
+          </section>
+
+          {/* 2. Método */}
+          <section className="fx-drawer-sec">
+            <h4>Método de entrega</h4>
+            <div className="fx-metodo-grid">
+              {(['email', 'sftp', 'download'] as Metodo[]).map((m) => (
+                <label key={m} className={`fx-metodo-card ${metodo === m ? 'active' : ''}`}>
+                  <input
+                    type="radio"
+                    name="metodo"
+                    value={m}
+                    checked={metodo === m}
+                    onChange={() => setMetodo(m)}
+                  />
+                  <div>
+                    {m === 'email' && <><Mail size={14} /> <b>E-mail anexo</b><small>Envia ZIP pro {data.destinatarioPadrao}</small></>}
+                    {m === 'sftp' && <><Archive size={14} /> <b>SFTP do contador</b><small>Configurar credencial em /fiscal/config</small></>}
+                    {m === 'download' && <><FileText size={14} /> <b>Download manual</b><small>Baixa ZIP local pra você compartilhar</small></>}
+                  </div>
+                </label>
+              ))}
+            </div>
+          </section>
+
+          {/* 3. Pacote */}
+          <section className="fx-drawer-sec">
+            <h4>O que entra no pacote</h4>
+            <ul className="fx-pacote-list">
+              <li>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={pacote.xmlAutorizadas}
+                    onChange={(e) => setPacote({ ...pacote, xmlAutorizadas: e.target.checked })}
+                  />
+                  <span><b>{data.totalsByPeriodo.autorizadas}</b> XMLs NF-e/NFC-e autorizadas</span>
+                </label>
+              </li>
+              <li>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={pacote.danfeAutorizadas}
+                    onChange={(e) => setPacote({ ...pacote, danfeAutorizadas: e.target.checked })}
+                  />
+                  <span>{data.totalsByPeriodo.autorizadas} DANFEs PDF <small className="fx-mut">(pesado · normalmente contador não precisa)</small></span>
+                </label>
+              </li>
+              <li>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={pacote.xmlNfse}
+                    onChange={(e) => setPacote({ ...pacote, xmlNfse: e.target.checked })}
+                  />
+                  <span><b>{data.totalsByPeriodo.nfse}</b> XMLs NFS-e</span>
+                </label>
+              </li>
+              <li>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={pacote.eventos}
+                    onChange={(e) => setPacote({ ...pacote, eventos: e.target.checked })}
+                  />
+                  <span><b>{data.totalsByPeriodo.eventos}</b> Eventos (CC-e · cancelamentos · inutilizações)</span>
+                </label>
+              </li>
+              <li>
+                <label>
+                  <input
+                    type="checkbox"
+                    checked={pacote.relatorioSummary}
+                    onChange={(e) => setPacote({ ...pacote, relatorioSummary: e.target.checked })}
+                  />
+                  <span>Relatório summary PDF (totais + rejeições + alertas certificado)</span>
+                </label>
+              </li>
+            </ul>
+          </section>
+
+          {/* 4. Histórico */}
+          {data.history.length > 0 && (
+            <section className="fx-drawer-sec">
+              <h4>Histórico de envios <span className="fx-sec-count">{data.history.length}</span></h4>
+              <ul className="fx-emails">
+                {data.history.map((h) => (
+                  <li key={h.id}>
+                    <div>
+                      <b>{h.periodo}</b>
+                      <small>{h.metodo === 'email' ? 'e-mail' : h.metodo === 'sftp' ? 'SFTP' : 'download'} · {h.destino} · {formatBytes(h.pacote)}</small>
+                    </div>
+                    <div className="fx-email-meta">
+                      <span className="fx-mut">{h.enviadoEm}</span>
+                      <span className={`fx-sefaz ${h.status === 'enviado' ? 'ok' : h.status === 'falha' ? 'bad' : 'warn'} compact`}>
+                        <span className="lbl">{h.status}</span>
+                      </span>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </div>
+
+        <footer className="fx-drawer-f">
+          {warnings.length > 0 && (
+            <small style={{ color: 'var(--warn)' }}>
+              ⚠ {warnings.length} aviso{warnings.length > 1 ? 's' : ''} (não bloqueia)
+            </small>
+          )}
+          <div className="fx-drawer-f-r">
+            <button type="button" className="fx-btn ghost" onClick={onClose}>Cancelar</button>
+            <button
+              type="button"
+              className="fx-btn primary"
+              disabled={!podeEnviar}
+              title={!podeEnviar ? 'Resolver bloqueios + selecionar pelo menos 1 item do pacote' : 'TODO[CL]: wire-up real no PR seguinte'}
+            >
+              <Archive size={12} /> Gerar e enviar pacote
+            </button>
+          </div>
+        </footer>
+      </aside>
+    </>
+  );
+}


### PR DESCRIPTION
Continuação do inventário Cowork (PR #1614 Onda 1 = NotaDrawer + receita SEFAZ). **Onda 2 fecha 4 dos 12 gaps** (D, G, H, I).

## 🆕 Componentes novos (3)

| Arquivo | Linhas | Função |
|---|---:|---|
| `EventosDrawer.tsx` | +151 | Slide-in 640px — tabela CC-e/cancel/inut/EPEC/manifest |
| `SendToContabilDrawer.tsx` | +264 | Slide-in 760px — fluxo guiado 4 seções |
| `ModuleTopNav.tsx` | +44 | Shared sub-tabs (`.fx-subtabs` canon) |

## 🔧 Refactor

- **Cockpit.tsx** — chips header agora abrem drawers (era navegação / disabled)
- **Dfe.tsx** — 2 tabs: Pendentes (atual) + **Histórico** (NOVO)
- **Config.tsx** — 4 tabs: Cert + **Séries** (NOVO) + Ambiente + **SPED** (NOVO)

## 🔧 Backend mocks (TODO[CL] queries reais)
- `mockEventos()` · `mockContabilData()` · `mockSeriesFiscais()` · `mockHistorico()`

## Validação local
- TS zero erros em \`Pages/Fiscal/*\`
- PHP -l × 3 controllers OK
- PII scan ✅ em 9 arquivos
- **Zero IA** — mantém princípio Wagner

## Inventário (8/12 fechados)
✅ A·B·E·D·G·H·I·K  ⏳ C·F·J·L (Onda 3)

Refs: PRs #1599 + #1605 + #1614, ADR 0093/0094/0114