### PR TITLE
fix(memory): session log date como string quoted (schema gate)

### DIFF
--- a/memory/sessions/2026-05-26-sidebar-canon-cleanup-comvis-fix.md
+++ b/memory/sessions/2026-05-26-sidebar-canon-cleanup-comvis-fix.md
@@ -1,5 +1,5 @@
 ---
-date: 2026-05-26
+date: "2026-05-26"
 hour: "05:00 BRT"
 duration: "3.5h"
 topic: "Sidebar canon cleanup — 4 ondas Wagner: FINANÇAS flat, Vendas absorve Catalogue+Woo como ghosts, Fiscal remove cockpit duplicado, ComVis hub stub"


### PR DESCRIPTION
Schema gate fix: `date: 2026-05-26` (sem aspas) era parseado como Date object pelo js-yaml. Schema exige string. Aspas adicionadas. Validador ajv retorna VALID.

Skill `memory-schema-preflight` catalogou esse trap — não apliquei na primeira passada (PR #1596).

🤖 Generated with [Claude Code](https://claude.com/claude-code)