### PR TITLE
refactor(fiscal): DrawerBase shared shell pros 5 drawers

### DIFF
--- a/resources/js/Pages/Fiscal/_components/EventosDrawer.tsx
+++ b/resources/js/Pages/Fiscal/_components/EventosDrawer.tsx
@@ -6,12 +6,15 @@
 //
 // Mostra mesma data que /fiscal/eventos mas em formato compacto. Pra
 // detalhe profundo (filtros, +período), botão "Ver tudo" leva pra página.
+//
+// Refactor onda 1 (2026-05-26): shell migrado pra <DrawerBase> compartilhado.
 
-import { useEffect } from 'react';
 import { router } from '@inertiajs/react';
 import { Activity, ExternalLink } from 'lucide-react';
 
 import { sefazLabel, sefazTone } from '../_lib/sefaz-codes';
+
+import DrawerBase from './_shared/DrawerBase';
 
 export type EventoKind = 'cce' | 'cancel' | 'epec' | 'manifest' | 'inutilizacao';
 
@@ -42,93 +45,30 @@ const KIND_LABEL: Record<EventoKind, string> = {
 };
 
 export default function EventosDrawer({ open, eventos, onClose }: EventosDrawerProps) {
-  useEffect(() => {
-    if (!open) return;
-    const h = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        onClose();
-      }
-    };
-    window.addEventListener('keydown', h);
-    return () => window.removeEventListener('keydown', h);
-  }, [open, onClose]);
-
   if (!open) return null;
 
   const crit = eventos.filter((e) => e.kind === 'cancel').length;
   const total = eventos.length;
 
   return (
-    <>
-      <div className="fx-drawer-bg" onClick={onClose} />
-      <aside
-        className="fx-drawer"
-        style={{ width: 'min(640px, 96vw)' }}
-        role="dialog"
-        aria-label="Eventos fiscais"
-      >
-        <header className="fx-drawer-h">
-          <div>
-            <small>Eventos fiscais</small>
-            <h2>CC-e · cancelamento · inutilização</h2>
-            <small style={{ color: 'var(--fx-text-mute)' }}>
-              {total} eventos esta semana
-              {crit > 0 && ` · ${crit} cancelamento${crit > 1 ? 's' : ''}`} · janelas legais validadas automaticamente
-            </small>
-          </div>
-          <button type="button" className="fx-drawer-x" onClick={onClose} aria-label="Fechar (ESC)">×</button>
-        </header>
-
-        <div className="fx-drawer-body" style={{ padding: 0 }}>
-          {eventos.length === 0 ? (
-            <div className="fx-empty" style={{ margin: 20 }}>
-              <Activity size={20} />
-              <b>Nenhum evento no período</b>
-              <small>Eventos aparecem após cancelamento, CC-e, EPEC ou manifestação.</small>
-            </div>
-          ) : (
-            <div className="fx-table" style={{ borderRadius: 0, border: 'none', borderTop: '1px solid var(--fx-border)' }}>
-              <table>
-                <thead>
-                  <tr>
-                    <th style={{ width: 130 }}>Tipo</th>
-                    <th style={{ width: 120 }}>Documento</th>
-                    <th>Descrição</th>
-                    <th style={{ width: 90 }}>Emissão</th>
-                    <th style={{ width: 100 }}>Autor</th>
-                    <th style={{ width: 130 }}>SEFAZ</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {eventos.map((e) => {
-                    return (
-                      <tr key={e.id}>
-                        <td>
-                          <span className={`fx-tl-badge ${e.kind === 'cancel' ? 'cancel' : e.kind === 'epec' || e.kind === 'inutilizacao' ? 'epec' : e.kind === 'cce' ? 'cce' : 'manifest'}`}>
-                            {KIND_LABEL[e.kind]}{e.sequencia ? ` seq ${e.sequencia}` : ''}
-                          </span>
-                        </td>
-                        <td><b className="fx-mono">{e.nota ?? '—'}</b></td>
-                        <td style={{ fontSize: 12.5 }}>{e.descricao}</td>
-                        <td><small className="fx-mut">{e.emit}</small></td>
-                        <td><small className="fx-mut">{e.autor ?? '—'}</small></td>
-                        <td>
-                          <span className={`fx-sefaz ${sefazTone(e.sefaz)} compact`}>
-                            <span className="code">{e.sefaz}</span>
-                            <span className="lbl">{sefazLabel(e.sefaz)}</span>
-                          </span>
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
-          )}
+    <DrawerBase
+      open={open}
+      onClose={onClose}
+      ariaLabel="Eventos fiscais"
+      width={640}
+      bodyFlush
+      header={
+        <div>
+          <small>Eventos fiscais</small>
+          <h2>CC-e · cancelamento · inutilização</h2>
+          <small style={{ color: 'var(--fx-text-mute)' }}>
+            {total} eventos esta semana
+            {crit > 0 && ` · ${crit} cancelamento${crit > 1 ? 's' : ''}`} · janelas legais validadas automaticamente
+          </small>
         </div>
-
-        <footer className="fx-drawer-f">
+      }
+      footer={
+        <>
           <small style={{ color: 'var(--fx-text-mute)' }}>
             Janelas legais: CC-e 30d · cancelamento 24h NFC-e / 168h NF-e · inutilização faixas
           </small>
@@ -144,8 +84,54 @@ export default function EventosDrawer({ open, eventos, onClose }: EventosDrawerP
               <ExternalLink size={12} /> Ver tudo
             </button>
           </div>
-        </footer>
-      </aside>
-    </>
+        </>
+      }
+    >
+      {eventos.length === 0 ? (
+        <div className="fx-empty" style={{ margin: 20 }}>
+          <Activity size={20} />
+          <b>Nenhum evento no período</b>
+          <small>Eventos aparecem após cancelamento, CC-e, EPEC ou manifestação.</small>
+        </div>
+      ) : (
+        <div className="fx-table" style={{ borderRadius: 0, border: 'none', borderTop: '1px solid var(--fx-border)' }}>
+          <table>
+            <thead>
+              <tr>
+                <th style={{ width: 130 }}>Tipo</th>
+                <th style={{ width: 120 }}>Documento</th>
+                <th>Descrição</th>
+                <th style={{ width: 90 }}>Emissão</th>
+                <th style={{ width: 100 }}>Autor</th>
+                <th style={{ width: 130 }}>SEFAZ</th>
+              </tr>
+            </thead>
+            <tbody>
+              {eventos.map((e) => {
+                return (
+                  <tr key={e.id}>
+                    <td>
+                      <span className={`fx-tl-badge ${e.kind === 'cancel' ? 'cancel' : e.kind === 'epec' || e.kind === 'inutilizacao' ? 'epec' : e.kind === 'cce' ? 'cce' : 'manifest'}`}>
+                        {KIND_LABEL[e.kind]}{e.sequencia ? ` seq ${e.sequencia}` : ''}
+                      </span>
+                    </td>
+                    <td><b className="fx-mono">{e.nota ?? '—'}</b></td>
+                    <td style={{ fontSize: 12.5 }}>{e.descricao}</td>
+                    <td><small className="fx-mut">{e.emit}</small></td>
+                    <td><small className="fx-mut">{e.autor ?? '—'}</small></td>
+                    <td>
+                      <span className={`fx-sefaz ${sefazTone(e.sefaz)} compact`}>
+                        <span className="code">{e.sefaz}</span>
+                        <span className="lbl">{sefazLabel(e.sefaz)}</span>
+                      </span>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </DrawerBase>
   );
 }

--- a/resources/js/Pages/Fiscal/_components/NFSeDrawer.tsx
+++ b/resources/js/Pages/Fiscal/_components/NFSeDrawer.tsx
@@ -5,10 +5,12 @@
 //
 // Drawer mais simples — NFS-e geralmente tem menos eventos vinculados e
 // ciclo de vida mais curto.
-
-import { useEffect } from 'react';
+//
+// Refactor onda 1 (2026-05-26): shell migrado pra <DrawerBase> compartilhado.
 
 import { brl, formatDoc } from '../_lib/fiscal-helpers';
+
+import DrawerBase from './_shared/DrawerBase';
 
 export type NFSeStatus = 'autorizada' | 'processando' | 'rejeitada' | 'cancelada';
 
@@ -49,70 +51,24 @@ const STATUS_LABEL: Record<NFSeStatus, string> = {
 };
 
 export default function NFSeDrawer({ nota, onClose }: NFSeDrawerProps) {
-  useEffect(() => {
-    if (!nota) return;
-    const h = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        onClose();
-      }
-    };
-    window.addEventListener('keydown', h);
-    return () => window.removeEventListener('keydown', h);
-  }, [nota, onClose]);
-
   if (!nota) return null;
 
   const tone = STATUS_TONE[nota.status];
 
   return (
-    <>
-      <div className="fx-drawer-bg" onClick={onClose} />
-      <aside className="fx-drawer" role="dialog" aria-label={`Detalhe NFS-e ${nota.num}`}>
-        <header className="fx-drawer-h">
-          <div>
-            <small>NFS-e · Sistema Nacional · LC 214/2025</small>
-            <h2>NFSe {nota.num}</h2>
-            <code className="fx-drawer-key">cód. serviço {nota.codServ} · {nota.competencia}</code>
-          </div>
-          <button type="button" className="fx-drawer-x" onClick={onClose} aria-label="Fechar (ESC)">×</button>
-        </header>
-
-        <div className="fx-drawer-body">
-          <section className="fx-drawer-sec">
-            <h4>Status prefeitura</h4>
-            <div className="fx-drawer-status-row">
-              <span className={`fx-sefaz ${tone}`}>
-                <span className="lbl">{STATUS_LABEL[nota.status]}</span>
-              </span>
-            </div>
-            {nota.rejMsg && <div className="fx-drawer-rej">↳ {nota.rejMsg}</div>}
-          </section>
-
-          <section className="fx-drawer-sec">
-            <h4>Operação</h4>
-            <dl className="fx-kv">
-              <dt>Tomador</dt>
-              <dd><b>{nota.tomador}</b></dd>
-              <dt>{nota.cnpj ? 'CNPJ' : 'CPF'}</dt>
-              <dd className="fx-mono">{formatDoc(nota.cnpj, nota.cpf)}</dd>
-              <dt>Município</dt>
-              <dd>{nota.municipio} · {nota.iss}% ISS</dd>
-              {nota.ref && (
-                <>
-                  <dt>Referência</dt>
-                  <dd>{nota.ref}</dd>
-                </>
-              )}
-              <dt>Emissão</dt>
-              <dd>{nota.when}</dd>
-              <dt>Valor</dt>
-              <dd className="fx-strong">{brl(nota.value)}</dd>
-            </dl>
-          </section>
+    <DrawerBase
+      open={!!nota}
+      onClose={onClose}
+      ariaLabel={`Detalhe NFS-e ${nota.num}`}
+      header={
+        <div>
+          <small>NFS-e · Sistema Nacional · LC 214/2025</small>
+          <h2>NFSe {nota.num}</h2>
+          <code className="fx-drawer-key">cód. serviço {nota.codServ} · {nota.competencia}</code>
         </div>
-
-        <footer className="fx-drawer-f">
+      }
+      footer={
+        <>
           <button type="button" className="fx-btn ghost" disabled title="Wire-up no PR seguinte">
             Reconsultar prefeitura
           </button>
@@ -125,8 +81,40 @@ export default function NFSeDrawer({ nota, onClose }: NFSeDrawerProps) {
               </button>
             )}
           </div>
-        </footer>
-      </aside>
-    </>
+        </>
+      }
+    >
+      <section className="fx-drawer-sec">
+        <h4>Status prefeitura</h4>
+        <div className="fx-drawer-status-row">
+          <span className={`fx-sefaz ${tone}`}>
+            <span className="lbl">{STATUS_LABEL[nota.status]}</span>
+          </span>
+        </div>
+        {nota.rejMsg && <div className="fx-drawer-rej">↳ {nota.rejMsg}</div>}
+      </section>
+
+      <section className="fx-drawer-sec">
+        <h4>Operação</h4>
+        <dl className="fx-kv">
+          <dt>Tomador</dt>
+          <dd><b>{nota.tomador}</b></dd>
+          <dt>{nota.cnpj ? 'CNPJ' : 'CPF'}</dt>
+          <dd className="fx-mono">{formatDoc(nota.cnpj, nota.cpf)}</dd>
+          <dt>Município</dt>
+          <dd>{nota.municipio} · {nota.iss}% ISS</dd>
+          {nota.ref && (
+            <>
+              <dt>Referência</dt>
+              <dd>{nota.ref}</dd>
+            </>
+          )}
+          <dt>Emissão</dt>
+          <dd>{nota.when}</dd>
+          <dt>Valor</dt>
+          <dd className="fx-strong">{brl(nota.value)}</dd>
+        </dl>
+      </section>
+    </DrawerBase>
   );
 }

--- a/resources/js/Pages/Fiscal/_components/NotaDrawer.tsx
+++ b/resources/js/Pages/Fiscal/_components/NotaDrawer.tsx
@@ -3,9 +3,13 @@
 // "Jana sugere": receita determinística por cstat — substitui IA real (R#2 KB-9.75)
 // PR #5 Wave: CCe modal (tpEvento 110110) habilitada.
 // PR #6 Wave: Retransmitir modal habilitado (status rejeitada/denegada/erro_envio).
+//
+// Refactor onda 1 (2026-05-26): shell migrado pra <DrawerBase> compartilhado.
+// ESC stack preservado: closeOnEsc={noModalOpen} delega pro DrawerBase quando
+// nenhum modal nested aberto; useEffect local lida com ESC quando modal aberto.
 
 import { router } from '@inertiajs/react';
-import { Bot, FileText, PenLine, RefreshCw, X } from 'lucide-react';
+import { Bot, FileText, PenLine, RefreshCw } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 
 import {
@@ -15,6 +19,8 @@ import {
   prazoCCe,
   type SefazCodesMap,
 } from '../_lib/fiscal-helpers';
+
+import DrawerBase from './_shared/DrawerBase';
 
 export interface NotaRow {
   id: number;
@@ -154,20 +160,24 @@ export default function NotaDrawer({ nota, sefazCodes, onClose }: NotaDrawerProp
   const [textoCce, setTextoCce] = useState('');
   const [busy, setBusy] = useState(false);
 
-  // ESC fecha modais → drawer
+  // ESC stack: quando algum modal nested aberto, DrawerBase NÃO escuta ESC
+  // (closeOnEsc={noModalOpen}). Este useEffect só fecha o topo do stack
+  // quando modal está aberto. Mantém comportamento pre-refactor.
+  const noModalOpen = !cancelOpen && !cceOpen && !retransmitOpen;
+
   useEffect(() => {
-    if (!nota) return;
+    if (!nota || noModalOpen) return; // DrawerBase cuida do ESC quando livre
     const h = (e: KeyboardEvent) => {
       if (e.key === 'Escape') {
+        e.preventDefault();
         if (cancelOpen) setCancelOpen(false);
         else if (cceOpen) setCceOpen(false);
         else if (retransmitOpen) setRetransmitOpen(false);
-        else onClose();
       }
     };
     window.addEventListener('keydown', h);
     return () => window.removeEventListener('keydown', h);
-  }, [nota, onClose, cancelOpen, cceOpen, retransmitOpen]);
+  }, [nota, noModalOpen, cancelOpen, cceOpen, retransmitOpen]);
 
   // Reset modal state quando trocar de nota
   useEffect(() => {
@@ -237,288 +247,284 @@ export default function NotaDrawer({ nota, sefazCodes, onClose }: NotaDrawerProp
 
   return (
     <>
-      <div className="fx-drawer-bg" onClick={onClose} aria-hidden="true"/>
-      <aside className="fx-drawer" role="dialog" aria-label="Detalhe da nota">
-        <header className="fx-drawer-h">
+      <DrawerBase
+        open={!!nota}
+        onClose={onClose}
+        ariaLabel="Detalhe da nota"
+        closeOnEsc={noModalOpen}
+        header={
           <div>
             <small>{nota.modelo === 65 ? 'NFC-e' : 'NF-e'} · série {nota.serie}</small>
             <h2>{nota.modelo === 65 ? 'NFC-e ' : 'NFe '}{nota.num}</h2>
             {nota.key && <code className="fx-drawer-key">{nota.key}</code>}
           </div>
-          <button className="fx-drawer-x" onClick={onClose} aria-label="Fechar (ESC)">
-            <X size={16}/>
-            <kbd>esc</kbd>
-          </button>
-        </header>
-
-        <div className="fx-drawer-body">
-
-          <section className="fx-drawer-sec">
-            <h4>Status SEFAZ</h4>
-            <div className="fx-drawer-status-row">
-              <span className={`fx-sefaz ${sefaz.tone}`} title={sefaz.hint}>
-                <span className="code">{nota.cstat || '—'}</span>
-                <span className="lbl">{sefaz.label}</span>
-              </span>
-              {cancel && (
-                <span className={`fx-timepill u-${cancel.urgency}`}>
-                  <RefreshCw size={10}/>
-                  <span className="lbl">cancelar em <b>{cancel.h}h{cancel.m.toString().padStart(2, '0')}</b></span>
-                </span>
-              )}
-              {cce && (
-                <span className={`fx-timepill u-${cce.urgency}`}>
-                  <FileText size={10}/>
-                  <span className="lbl">CC-e em <b>{cce.d}d</b></span>
-                </span>
-              )}
-            </div>
-            <p className="fx-drawer-hint">{sefaz.hint}</p>
-            {nota.motivo && (
-              <div className="fx-drawer-rej">↳ {nota.motivo}</div>
-            )}
-          </section>
-
-          {/* Mapa SEFAZ guiado — só em rejeitadas com receita cadastrada */}
-          <SefazActionCard cstat={nota.cstat}/>
-
-          <section className="fx-drawer-sec">
-            <h4>Destinatário</h4>
-            <dl className="fx-kv">
-              <dt>Nome</dt><dd>{nota.dest}</dd>
-              <dt>{nota.cnpj ? 'CNPJ' : nota.cpf ? 'CPF' : 'Documento'}</dt>
-              <dd>{formatDoc(nota.cnpj, nota.cpf)}</dd>
-              <dt>UF</dt><dd>{nota.uf || '—'}</dd>
-              <dt>Itens</dt><dd>{nota.items ?? '—'}</dd>
-            </dl>
-          </section>
-
-          <section className="fx-drawer-sec">
-            <h4>Operação</h4>
-            <dl className="fx-kv">
-              <dt>Venda</dt>
-              <dd>
-                {nota.transactionId
-                  ? <a className="fx-link" href={`/sells/${nota.transactionId}`}>V-{nota.transactionId}</a>
-                  : '—'}
-              </dd>
-              <dt>Emissão</dt><dd>{nota.when ?? '—'}</dd>
-              <dt>Valor</dt><dd className="fx-strong">{brl(nota.value)}</dd>
-              <dt>Modelo</dt>
-              <dd>{nota.modelo} · {nota.modelo === 65 ? 'consumidor' : 'B2B'}</dd>
-            </dl>
-          </section>
-
-        </div>
-
-        <footer className="fx-drawer-f">
-          <button className="fx-btn ghost" disabled title="PR seguinte">
-            <RefreshCw size={12}/> Reconsultar SEFAZ <kbd className="fx-kbd-inline">R</kbd>
-          </button>
-          <div className="fx-drawer-f-r">
-            <button className="fx-btn" disabled title="PR seguinte">XML</button>
-            <button className="fx-btn" disabled title="PR seguinte">DANFE</button>
-            {nota.status === 'autorizada' && cce && (
-              <button
-                className="fx-btn warn"
-                onClick={() => setCceOpen(true)}
-                disabled={busy}
-                title="Carta de Correção Eletrônica (CONFAZ Art. 14 — janela 30d)"
-              >
-                <PenLine size={12}/> CC-e <kbd className="fx-kbd-inline">C</kbd>
-              </button>
-            )}
-            {nota.status === 'autorizada' && cancel && (
-              <button
-                className="fx-btn danger"
-                onClick={() => setCancelOpen(true)}
-                disabled={busy}
-                title="Cancela NFe — FSM cascade ADR 0143"
-              >
-                Cancelar <kbd className="fx-kbd-inline">X</kbd>
-              </button>
-            )}
-            {['rejeitada', 'denegada', 'erro_envio'].includes(nota.status) && (
-              <button
-                className="fx-btn primary"
-                onClick={() => setRetransmitOpen(true)}
-                disabled={busy}
-                title="Retransmite NFe — gera novo número fiscal + nova chave de acesso"
-              >
-                Retransmitir <kbd className="fx-kbd-inline">⏎</kbd>
-              </button>
-            )}
-          </div>
-        </footer>
-
-        {/* Modal CCe — texto correção (PR #5 Wave) */}
-        {cceOpen && (
-          <div className="fx-drawer-bg" onClick={() => !busy && setCceOpen(false)}>
-            <div
-              role="dialog"
-              aria-label="Carta de Correção Eletrônica"
-              onClick={(e) => e.stopPropagation()}
-              style={{
-                background: 'white',
-                borderRadius: 10,
-                padding: 22,
-                width: 480,
-                maxWidth: '90vw',
-                margin: '12vh auto',
-                boxShadow: '0 12px 40px rgba(0,0,0,.2)',
-              }}
-            >
-              <h3 style={{ margin: '0 0 8px', fontSize: 16, fontWeight: 700 }}>
-                Carta de Correção · NF-e {nota.num}
-              </h3>
-              <p style={{ fontSize: 12.5, color: 'var(--fx-text-dim)', margin: '0 0 14px' }}>
-                Descreva a correção (15-1000 chars · CONFAZ Art. 14 — janela 30d da autorização).
-                Não pode alterar: valores, base cálculo, alíquota, emit/dest, data, número/série.
-              </p>
-              <textarea
-                value={textoCce}
-                onChange={(e) => setTextoCce(e.target.value.slice(0, 1000))}
-                placeholder="Ex: Onde se lê 'Rua A, 123', leia-se 'Rua A, 1234'. Erro de digitação no endereço de entrega."
-                rows={5}
-                disabled={busy}
-                autoFocus
-                style={{
-                  width: '100%',
-                  padding: 10,
-                  fontSize: 12.5,
-                  border: '1px solid var(--fx-border)',
-                  borderRadius: 7,
-                  fontFamily: 'inherit',
-                  resize: 'vertical',
-                }}
-              />
-              <div style={{ fontSize: 11, color: 'var(--fx-text-mute)', margin: '4px 0 14px' }}>
-                {textoCce.length}/1000 · {textoCce.trim().length < 15 ? `faltam ${15 - textoCce.trim().length} chars` : '✅ ok'}
-              </div>
-              <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
-                <button className="fx-btn ghost" onClick={() => setCceOpen(false)} disabled={busy}>
-                  Voltar
-                </button>
+        }
+        footer={
+          <>
+            <button className="fx-btn ghost" disabled title="PR seguinte">
+              <RefreshCw size={12}/> Reconsultar SEFAZ <kbd className="fx-kbd-inline">R</kbd>
+            </button>
+            <div className="fx-drawer-f-r">
+              <button className="fx-btn" disabled title="PR seguinte">XML</button>
+              <button className="fx-btn" disabled title="PR seguinte">DANFE</button>
+              {nota.status === 'autorizada' && cce && (
                 <button
                   className="fx-btn warn"
-                  onClick={handleCCe}
-                  disabled={busy || textoCce.trim().length < 15}
+                  onClick={() => setCceOpen(true)}
+                  disabled={busy}
+                  title="Carta de Correção Eletrônica (CONFAZ Art. 14 — janela 30d)"
                 >
-                  {busy ? 'Enviando…' : 'Enviar CC-e'}
+                  <PenLine size={12}/> CC-e <kbd className="fx-kbd-inline">C</kbd>
                 </button>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Modal Retransmitir confirm (PR #6 Wave) */}
-        {retransmitOpen && (
-          <div className="fx-drawer-bg" onClick={() => !busy && setRetransmitOpen(false)}>
-            <div
-              role="dialog"
-              aria-label="Confirmar retransmissão"
-              onClick={(e) => e.stopPropagation()}
-              style={{
-                background: 'white',
-                borderRadius: 10,
-                padding: 22,
-                width: 460,
-                maxWidth: '90vw',
-                margin: '15vh auto',
-                boxShadow: '0 12px 40px rgba(0,0,0,.2)',
-              }}
-            >
-              <h3 style={{ margin: '0 0 8px', fontSize: 16, fontWeight: 700 }}>
-                Retransmitir {nota.modelo === 65 ? 'NFC-e' : 'NF-e'} {nota.num}
-              </h3>
-              <p style={{ fontSize: 12.5, color: 'var(--fx-text-dim)', margin: '0 0 10px' }}>
-                Status atual: <b>{nota.status}</b>
-                {nota.motivo && <> · {nota.motivo}</>}
-              </p>
-              <div style={{ background: 'var(--fx-bg-2, #fafafa)', borderRadius: 7, padding: 12, fontSize: 12.5, marginBottom: 14 }}>
-                <b style={{ display: 'block', marginBottom: 4 }}>O que vai acontecer:</b>
-                <ul style={{ margin: 0, paddingLeft: 18, lineHeight: 1.55 }}>
-                  <li>Novo número fiscal será reservado (sequência monotônica)</li>
-                  <li>cNF + chave de acesso 44 dígitos serão regenerados</li>
-                  <li>Payload re-derivado da Venda associada (cadastro atual)</li>
-                  <li>NFe antiga (nº {nota.num}) sai do registro — fica "buraco" no sequencial até inutilização SEFAZ formal</li>
-                </ul>
-              </div>
-              <p style={{ fontSize: 11.5, color: 'var(--fx-text-mute)', margin: '0 0 14px' }}>
-                ⚠️ Se a rejeição foi por cadastro (NCM/CST/CFOP/dest), corrija ANTES de retransmitir — caso contrário a SEFAZ vai rejeitar de novo com mesma causa.
-              </p>
-              <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
-                <button className="fx-btn ghost" onClick={() => setRetransmitOpen(false)} disabled={busy}>
-                  Voltar
-                </button>
-                <button className="fx-btn primary" onClick={handleRetransmitir} disabled={busy}>
-                  {busy ? 'Retransmitindo…' : 'Confirmar retransmissão'}
-                </button>
-              </div>
-            </div>
-          </div>
-        )}
-
-        {/* Modal cancel motivo */}
-        {cancelOpen && (
-          <div className="fx-drawer-bg" onClick={() => !busy && setCancelOpen(false)}>
-            <div
-              role="dialog"
-              aria-label="Confirmar cancelamento"
-              onClick={(e) => e.stopPropagation()}
-              style={{
-                background: 'white',
-                borderRadius: 10,
-                padding: 22,
-                width: 440,
-                maxWidth: '90vw',
-                margin: '15vh auto',
-                boxShadow: '0 12px 40px rgba(0,0,0,.2)',
-              }}
-            >
-              <h3 style={{ margin: '0 0 8px', fontSize: 16, fontWeight: 700 }}>
-                Cancelar {nota.modelo === 65 ? 'NFC-e' : 'NF-e'} {nota.num}
-              </h3>
-              <p style={{ fontSize: 12.5, color: 'var(--fx-text-dim)', margin: '0 0 14px' }}>
-                Justificativa obrigatória (mín. 15 chars · regra CONFAZ).
-                Cancelamento aciona FSM cascade ADR 0143 — refund gateway + notif cliente (se biz=1).
-              </p>
-              <textarea
-                value={motivo}
-                onChange={(e) => setMotivo(e.target.value)}
-                placeholder="Ex: cliente desistiu pós-emissão, refaturado em V-NNNN"
-                rows={3}
-                disabled={busy}
-                autoFocus
-                style={{
-                  width: '100%',
-                  padding: 10,
-                  fontSize: 12.5,
-                  border: '1px solid var(--fx-border)',
-                  borderRadius: 7,
-                  fontFamily: 'inherit',
-                  resize: 'vertical',
-                }}
-              />
-              <div style={{ fontSize: 11, color: 'var(--fx-text-mute)', margin: '4px 0 14px' }}>
-                {motivo.length}/255 · {motivo.trim().length < 15 ? `faltam ${15 - motivo.trim().length} chars` : '✅ ok'}
-              </div>
-              <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
-                <button className="fx-btn ghost" onClick={() => setCancelOpen(false)} disabled={busy}>
-                  Voltar
-                </button>
+              )}
+              {nota.status === 'autorizada' && cancel && (
                 <button
                   className="fx-btn danger"
-                  onClick={handleCancelar}
-                  disabled={busy || motivo.trim().length < 15}
+                  onClick={() => setCancelOpen(true)}
+                  disabled={busy}
+                  title="Cancela NFe — FSM cascade ADR 0143"
                 >
-                  {busy ? 'Cancelando…' : 'Confirmar cancelamento'}
+                  Cancelar <kbd className="fx-kbd-inline">X</kbd>
                 </button>
-              </div>
+              )}
+              {['rejeitada', 'denegada', 'erro_envio'].includes(nota.status) && (
+                <button
+                  className="fx-btn primary"
+                  onClick={() => setRetransmitOpen(true)}
+                  disabled={busy}
+                  title="Retransmite NFe — gera novo número fiscal + nova chave de acesso"
+                >
+                  Retransmitir <kbd className="fx-kbd-inline">⏎</kbd>
+                </button>
+              )}
+            </div>
+          </>
+        }
+      >
+        <section className="fx-drawer-sec">
+          <h4>Status SEFAZ</h4>
+          <div className="fx-drawer-status-row">
+            <span className={`fx-sefaz ${sefaz.tone}`} title={sefaz.hint}>
+              <span className="code">{nota.cstat || '—'}</span>
+              <span className="lbl">{sefaz.label}</span>
+            </span>
+            {cancel && (
+              <span className={`fx-timepill u-${cancel.urgency}`}>
+                <RefreshCw size={10}/>
+                <span className="lbl">cancelar em <b>{cancel.h}h{cancel.m.toString().padStart(2, '0')}</b></span>
+              </span>
+            )}
+            {cce && (
+              <span className={`fx-timepill u-${cce.urgency}`}>
+                <FileText size={10}/>
+                <span className="lbl">CC-e em <b>{cce.d}d</b></span>
+              </span>
+            )}
+          </div>
+          <p className="fx-drawer-hint">{sefaz.hint}</p>
+          {nota.motivo && (
+            <div className="fx-drawer-rej">↳ {nota.motivo}</div>
+          )}
+        </section>
+
+        {/* Mapa SEFAZ guiado — só em rejeitadas com receita cadastrada */}
+        <SefazActionCard cstat={nota.cstat}/>
+
+        <section className="fx-drawer-sec">
+          <h4>Destinatário</h4>
+          <dl className="fx-kv">
+            <dt>Nome</dt><dd>{nota.dest}</dd>
+            <dt>{nota.cnpj ? 'CNPJ' : nota.cpf ? 'CPF' : 'Documento'}</dt>
+            <dd>{formatDoc(nota.cnpj, nota.cpf)}</dd>
+            <dt>UF</dt><dd>{nota.uf || '—'}</dd>
+            <dt>Itens</dt><dd>{nota.items ?? '—'}</dd>
+          </dl>
+        </section>
+
+        <section className="fx-drawer-sec">
+          <h4>Operação</h4>
+          <dl className="fx-kv">
+            <dt>Venda</dt>
+            <dd>
+              {nota.transactionId
+                ? <a className="fx-link" href={`/sells/${nota.transactionId}`}>V-{nota.transactionId}</a>
+                : '—'}
+            </dd>
+            <dt>Emissão</dt><dd>{nota.when ?? '—'}</dd>
+            <dt>Valor</dt><dd className="fx-strong">{brl(nota.value)}</dd>
+            <dt>Modelo</dt>
+            <dd>{nota.modelo} · {nota.modelo === 65 ? 'consumidor' : 'B2B'}</dd>
+          </dl>
+        </section>
+      </DrawerBase>
+
+      {/* Modal CCe — texto correção (PR #5 Wave) */}
+      {cceOpen && (
+        <div className="fx-drawer-bg" onClick={() => !busy && setCceOpen(false)}>
+          <div
+            role="dialog"
+            aria-label="Carta de Correção Eletrônica"
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              background: 'white',
+              borderRadius: 10,
+              padding: 22,
+              width: 480,
+              maxWidth: '90vw',
+              margin: '12vh auto',
+              boxShadow: '0 12px 40px rgba(0,0,0,.2)',
+            }}
+          >
+            <h3 style={{ margin: '0 0 8px', fontSize: 16, fontWeight: 700 }}>
+              Carta de Correção · NF-e {nota.num}
+            </h3>
+            <p style={{ fontSize: 12.5, color: 'var(--fx-text-dim)', margin: '0 0 14px' }}>
+              Descreva a correção (15-1000 chars · CONFAZ Art. 14 — janela 30d da autorização).
+              Não pode alterar: valores, base cálculo, alíquota, emit/dest, data, número/série.
+            </p>
+            <textarea
+              value={textoCce}
+              onChange={(e) => setTextoCce(e.target.value.slice(0, 1000))}
+              placeholder="Ex: Onde se lê 'Rua A, 123', leia-se 'Rua A, 1234'. Erro de digitação no endereço de entrega."
+              rows={5}
+              disabled={busy}
+              autoFocus
+              style={{
+                width: '100%',
+                padding: 10,
+                fontSize: 12.5,
+                border: '1px solid var(--fx-border)',
+                borderRadius: 7,
+                fontFamily: 'inherit',
+                resize: 'vertical',
+              }}
+            />
+            <div style={{ fontSize: 11, color: 'var(--fx-text-mute)', margin: '4px 0 14px' }}>
+              {textoCce.length}/1000 · {textoCce.trim().length < 15 ? `faltam ${15 - textoCce.trim().length} chars` : '✅ ok'}
+            </div>
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button className="fx-btn ghost" onClick={() => setCceOpen(false)} disabled={busy}>
+                Voltar
+              </button>
+              <button
+                className="fx-btn warn"
+                onClick={handleCCe}
+                disabled={busy || textoCce.trim().length < 15}
+              >
+                {busy ? 'Enviando…' : 'Enviar CC-e'}
+              </button>
             </div>
           </div>
-        )}
-      </aside>
+        </div>
+      )}
+
+      {/* Modal Retransmitir confirm (PR #6 Wave) */}
+      {retransmitOpen && (
+        <div className="fx-drawer-bg" onClick={() => !busy && setRetransmitOpen(false)}>
+          <div
+            role="dialog"
+            aria-label="Confirmar retransmissão"
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              background: 'white',
+              borderRadius: 10,
+              padding: 22,
+              width: 460,
+              maxWidth: '90vw',
+              margin: '15vh auto',
+              boxShadow: '0 12px 40px rgba(0,0,0,.2)',
+            }}
+          >
+            <h3 style={{ margin: '0 0 8px', fontSize: 16, fontWeight: 700 }}>
+              Retransmitir {nota.modelo === 65 ? 'NFC-e' : 'NF-e'} {nota.num}
+            </h3>
+            <p style={{ fontSize: 12.5, color: 'var(--fx-text-dim)', margin: '0 0 10px' }}>
+              Status atual: <b>{nota.status}</b>
+              {nota.motivo && <> · {nota.motivo}</>}
+            </p>
+            <div style={{ background: 'var(--fx-bg-2, #fafafa)', borderRadius: 7, padding: 12, fontSize: 12.5, marginBottom: 14 }}>
+              <b style={{ display: 'block', marginBottom: 4 }}>O que vai acontecer:</b>
+              <ul style={{ margin: 0, paddingLeft: 18, lineHeight: 1.55 }}>
+                <li>Novo número fiscal será reservado (sequência monotônica)</li>
+                <li>cNF + chave de acesso 44 dígitos serão regenerados</li>
+                <li>Payload re-derivado da Venda associada (cadastro atual)</li>
+                <li>NFe antiga (nº {nota.num}) sai do registro — fica "buraco" no sequencial até inutilização SEFAZ formal</li>
+              </ul>
+            </div>
+            <p style={{ fontSize: 11.5, color: 'var(--fx-text-mute)', margin: '0 0 14px' }}>
+              ⚠️ Se a rejeição foi por cadastro (NCM/CST/CFOP/dest), corrija ANTES de retransmitir — caso contrário a SEFAZ vai rejeitar de novo com mesma causa.
+            </p>
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button className="fx-btn ghost" onClick={() => setRetransmitOpen(false)} disabled={busy}>
+                Voltar
+              </button>
+              <button className="fx-btn primary" onClick={handleRetransmitir} disabled={busy}>
+                {busy ? 'Retransmitindo…' : 'Confirmar retransmissão'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {/* Modal cancel motivo */}
+      {cancelOpen && (
+        <div className="fx-drawer-bg" onClick={() => !busy && setCancelOpen(false)}>
+          <div
+            role="dialog"
+            aria-label="Confirmar cancelamento"
+            onClick={(e) => e.stopPropagation()}
+            style={{
+              background: 'white',
+              borderRadius: 10,
+              padding: 22,
+              width: 440,
+              maxWidth: '90vw',
+              margin: '15vh auto',
+              boxShadow: '0 12px 40px rgba(0,0,0,.2)',
+            }}
+          >
+            <h3 style={{ margin: '0 0 8px', fontSize: 16, fontWeight: 700 }}>
+              Cancelar {nota.modelo === 65 ? 'NFC-e' : 'NF-e'} {nota.num}
+            </h3>
+            <p style={{ fontSize: 12.5, color: 'var(--fx-text-dim)', margin: '0 0 14px' }}>
+              Justificativa obrigatória (mín. 15 chars · regra CONFAZ).
+              Cancelamento aciona FSM cascade ADR 0143 — refund gateway + notif cliente (se biz=1).
+            </p>
+            <textarea
+              value={motivo}
+              onChange={(e) => setMotivo(e.target.value)}
+              placeholder="Ex: cliente desistiu pós-emissão, refaturado em V-NNNN"
+              rows={3}
+              disabled={busy}
+              autoFocus
+              style={{
+                width: '100%',
+                padding: 10,
+                fontSize: 12.5,
+                border: '1px solid var(--fx-border)',
+                borderRadius: 7,
+                fontFamily: 'inherit',
+                resize: 'vertical',
+              }}
+            />
+            <div style={{ fontSize: 11, color: 'var(--fx-text-mute)', margin: '4px 0 14px' }}>
+              {motivo.length}/255 · {motivo.trim().length < 15 ? `faltam ${15 - motivo.trim().length} chars` : '✅ ok'}
+            </div>
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button className="fx-btn ghost" onClick={() => setCancelOpen(false)} disabled={busy}>
+                Voltar
+              </button>
+              <button
+                className="fx-btn danger"
+                onClick={handleCancelar}
+                disabled={busy || motivo.trim().length < 15}
+              >
+                {busy ? 'Cancelando…' : 'Confirmar cancelamento'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </>
   );
 }

--- a/resources/js/Pages/Fiscal/_components/NotaDrawerV2.tsx
+++ b/resources/js/Pages/Fiscal/_components/NotaDrawerV2.tsx
@@ -7,6 +7,9 @@
 //  - Seções: Operação · Eventos vinculados · Itens · Boleto · Arquivos · E-mails · Auditoria
 //  - Atalhos R (reconsultar) / X (cancelar) / C (CC-e) com flash feedback
 //  - Header is-scrolled (compactify ao rolar)
+//
+// Refactor onda 1 (2026-05-26): shell migrado pra <DrawerBase> compartilhado.
+// ESC delegado pro DrawerBase via closeOnEsc=true; atalhos R/X/C ficam local.
 
 import { useEffect, useRef, useState } from 'react';
 import { RefreshCw } from 'lucide-react';
@@ -14,6 +17,8 @@ import { RefreshCw } from 'lucide-react';
 import { brl, formatDoc, prazoCancel, prazoCCe, type Urgency } from '../_lib/fiscal-helpers';
 import { sefazHint, sefazLabel, sefazTone } from '../_lib/sefaz-codes';
 import { getRecipe, type SefazActionRecipe } from '../_lib/sefaz-actions';
+
+import DrawerBase from './_shared/DrawerBase';
 
 export interface NotaDrawerItem {
   nome: string;
@@ -150,7 +155,8 @@ export default function NotaDrawerV2({ nota, onClose, onQuickFilterCliente }: No
   const [scrolled, setScrolled] = useState(false);
   const bodyRef = useRef<HTMLDivElement | null>(null);
 
-  // Hooks SEMPRE chamados (ordem estável, mesmo com nota null)
+  // Atalhos R (reconsultar) / X (cancelar) / C (CC-e) com flash feedback.
+  // ESC fica com DrawerBase (closeOnEsc=true default).
   useEffect(() => {
     if (!nota) return;
     const flash = (label: string) => {
@@ -172,7 +178,7 @@ export default function NotaDrawerV2({ nota, onClose, onQuickFilterCliente }: No
       const t = e.target as HTMLElement | null;
       const typing = t && (t.tagName === 'INPUT' || t.tagName === 'TEXTAREA' || t.isContentEditable);
       if (typing) return;
-      if (e.key === 'Escape') { e.preventDefault(); onClose(); return; }
+      // ESC delegado pro DrawerBase — não tratar aqui
       if ((e.key === 'r' || e.key === 'R') && !e.metaKey && !e.ctrlKey) {
         e.preventDefault();
         flash('Reconsultando SEFAZ…');
@@ -190,7 +196,7 @@ export default function NotaDrawerV2({ nota, onClose, onQuickFilterCliente }: No
     };
     window.addEventListener('keydown', h);
     return () => window.removeEventListener('keydown', h);
-  }, [nota, onClose]);
+  }, [nota]);
 
   useEffect(() => {
     const el = bodyRef.current;
@@ -224,212 +230,28 @@ export default function NotaDrawerV2({ nota, onClose, onQuickFilterCliente }: No
   const eventos = nota.eventos ?? [];
 
   return (
-    <>
-      <div className="fx-drawer-bg" onClick={onClose} />
-      <aside
-        className={`fx-drawer${scrolled ? ' is-scrolled' : ''}`}
-        role="dialog"
-        aria-label={`Detalhe ${nota.modelo === 65 ? 'NFC-e' : 'NF-e'} ${nota.num}`}
-      >
-        <header className="fx-drawer-h">
-          <div>
-            <small>{nota.modelo === 65 ? 'NFC-e' : 'NF-e'} · série {nota.serie}</small>
-            <h2>
-              {nota.modelo === 65 ? 'NFC-e ' : 'NFe '}{nota.num}
-              {scrolled && (
-                <span className={`fx-sefaz ${tone}`} style={{ marginLeft: 8 }}>
-                  <span className="code">{nota.status}</span>
-                </span>
-              )}
-            </h2>
-            <code className="fx-drawer-key">{nota.key ?? '—'}</code>
-          </div>
-          <button type="button" className="fx-drawer-x" onClick={onClose} aria-label="Fechar (ESC)">×</button>
-        </header>
-
-        <div className="fx-drawer-body" ref={bodyRef}>
-          {/* Status SEFAZ + prazos */}
-          <section className="fx-drawer-sec">
-            <h4>Status SEFAZ</h4>
-            <div className="fx-drawer-status-row">
-              <span className={`fx-sefaz ${tone}`}>
+    <DrawerBase
+      open={!!nota}
+      onClose={onClose}
+      ariaLabel={`Detalhe ${nota.modelo === 65 ? 'NFC-e' : 'NF-e'} ${nota.num}`}
+      bodyRef={bodyRef}
+      extraAsideClassName={scrolled ? 'is-scrolled' : undefined}
+      header={
+        <div>
+          <small>{nota.modelo === 65 ? 'NFC-e' : 'NF-e'} · série {nota.serie}</small>
+          <h2>
+            {nota.modelo === 65 ? 'NFC-e ' : 'NFe '}{nota.num}
+            {scrolled && (
+              <span className={`fx-sefaz ${tone}`} style={{ marginLeft: 8 }}>
                 <span className="code">{nota.status}</span>
-                <span className="lbl">{sefazLabel(nota.status)}</span>
               </span>
-              {cancelW && <TimePill kind="cancel" value={`${cancelW.h}h${cancelW.m.toString().padStart(2, '0')}`} urgency={cancelW.urgency} />}
-              {cceW && <TimePill kind="cce" value={`${cceW.d}d`} urgency={cceW.urgency} />}
-            </div>
-            <p className="fx-drawer-hint">{sefazHint(nota.status)}</p>
-            {nota.rejMsg && <div className="fx-drawer-rej">↳ {nota.rejMsg}</div>}
-          </section>
-
-          {/* Receita guiada (só se cstat tem receita mapeada) */}
-          {recipe && <SefazActionCard recipe={recipe} status={nota.status} />}
-
-          {/* Operação */}
-          <section className="fx-drawer-sec">
-            <h4>Operação</h4>
-            <dl className="fx-kv">
-              <dt>Destinatário</dt>
-              <dd>
-                <a
-                  href="#"
-                  className="fx-link"
-                  onClick={(e) => {
-                    e.preventDefault();
-                    onQuickFilterCliente?.(nota.dest);
-                    onClose();
-                  }}
-                  title="Filtrar lista por este cliente"
-                >
-                  <b>{nota.dest}</b>
-                </a>
-              </dd>
-              <dt>{nota.cnpj ? 'CNPJ' : 'CPF'}</dt>
-              <dd className="fx-mono">{formatDoc(nota.cnpj, nota.cpf)} · {nota.uf}</dd>
-              <dt>Venda</dt>
-              <dd>{nota.venda ?? '—'}</dd>
-              <dt>Emissão</dt>
-              <dd>{nota.when}</dd>
-              <dt>Valor</dt>
-              <dd className="fx-strong">{brl(nota.value)}</dd>
-            </dl>
-          </section>
-
-          {/* Eventos vinculados (timeline reversa) */}
-          {eventos.length > 0 && (
-            <section className="fx-drawer-sec">
-              <h4>Eventos vinculados <span className="fx-sec-count">{eventos.length}</span></h4>
-              <ul className="fx-tl-list">
-                {eventos.map((e) => {
-                  const eTone = e.tipo === 'Cancelamento' ? 'bad'
-                    : e.tipo === 'Inutilização' ? 'warn'
-                    : e.tipo === 'Carta de Correção' ? 'ok' : 'neutral';
-                  return (
-                    <li key={e.id} className={`fx-tl-item-mini t-${eTone}`}>
-                      <span className="fx-tl-dot" />
-                      <div className="fx-tl-body">
-                        <div className="fx-tl-head">
-                          <span className={`fx-tl-badge ${eTone === 'bad' ? 'cancel' : eTone === 'warn' ? 'epec' : eTone === 'ok' ? 'cce' : 'manifest'}`}>
-                            {e.tipo}{e.sequencia ? ` seq ${e.sequencia}` : ''}
-                          </span>
-                          <span className="when">{e.emit}</span>
-                          <span className="when">· {e.autor}</span>
-                        </div>
-                        <div className="fx-tl-desc">{e.descricao}</div>
-                        <span className={`fx-sefaz ${sefazTone(e.sefaz)} compact`} style={{ marginTop: 4 }}>
-                          <span className="code">{e.sefaz}</span>
-                          <span className="lbl">{sefazLabel(e.sefaz)}</span>
-                        </span>
-                      </div>
-                    </li>
-                  );
-                })}
-              </ul>
-            </section>
-          )}
-
-          {/* Itens */}
-          {itens.length > 0 && (
-            <section className="fx-drawer-sec">
-              <h4>Itens <span className="fx-sec-count">{itens.length}</span></h4>
-              <ul className="fx-itens">
-                {itens.map((it, i) => (
-                  <li key={i}>
-                    <div>
-                      <b>{it.nome}</b>
-                      <small>{it.codigo} · qtd {it.qtd}</small>
-                    </div>
-                    <span className="fx-itens-vl">{brl(it.vl)}</span>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          )}
-
-          {/* Boleto vinculado */}
-          {nota.boleto && (
-            <section className="fx-drawer-sec">
-              <h4>Título financeiro</h4>
-              <div className="fx-boleto">
-                <div className="fx-boleto-body">
-                  <b>Boleto {nota.boleto.id}</b>
-                  <small>venc. {nota.boleto.venc} · {brl(nota.boleto.valor)}</small>
-                </div>
-                <span className={`fx-sefaz ${nota.boleto.status === 'pago' ? 'ok' : nota.boleto.status === 'vencido' ? 'bad' : 'warn'}`}>
-                  <span className="lbl">{nota.boleto.status}</span>
-                </span>
-              </div>
-            </section>
-          )}
-
-          {/* Arquivos */}
-          {arquivos.length > 0 && (
-            <section className="fx-drawer-sec">
-              <h4>Arquivos <span className="fx-sec-count">{arquivos.length}</span></h4>
-              <ul className="fx-arqs">
-                {arquivos.map((a, i) => (
-                  <li key={i}>
-                    <span className="fx-arq-tag">{a.tipo}</span>
-                    <div>
-                      <b>{a.nome}</b>
-                      <small>{a.tamanho}</small>
-                    </div>
-                    <span className={`fx-arq-st s-${a.status}`}>{a.status}</span>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          )}
-
-          {/* E-mails */}
-          {emails.length > 0 && (
-            <section className="fx-drawer-sec">
-              <h4>E-mails enviados <span className="fx-sec-count">{emails.length}</span></h4>
-              <ul className="fx-emails">
-                {emails.map((e, i) => (
-                  <li key={i}>
-                    <div>
-                      <b>{e.tipo}</b>
-                      <small>para {e.para}</small>
-                    </div>
-                    <div className="fx-email-meta">
-                      <span className="fx-mut">{e.quando}</span>
-                      <span className={`fx-sefaz ${e.status === 'entregue' ? 'ok' : 'warn'} compact`}>
-                        <span className="lbl">{e.status}</span>
-                      </span>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          )}
-
-          {/* Auditoria */}
-          {auditoria.length > 0 && (
-            <section className="fx-drawer-sec">
-              <h4>Auditoria <span className="fx-sec-count">{auditoria.length}</span></h4>
-              <ul className="fx-audit">
-                {auditoria.map((a, i) => (
-                  <li key={i}>
-                    <span className="fx-audit-when">{a.quando}</span>
-                    <span className="fx-audit-author">{a.autor}</span>
-                    <span className="fx-audit-acao">{a.acao}</span>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          )}
+            )}
+          </h2>
+          <code className="fx-drawer-key">{nota.key ?? '—'}</code>
         </div>
-
-        {/* Flash feedback dos atalhos R/X/C */}
-        {actionFlash && (
-          <div className="fx-action-flash" role="status" aria-live="polite">
-            <RefreshCw size={13} /> {actionFlash}
-          </div>
-        )}
-
-        <footer className="fx-drawer-f">
+      }
+      footer={
+        <>
           <button type="button" className="fx-btn ghost" disabled title="Wire-up no PR seguinte">
             Reconsultar <kbd>R</kbd>
           </button>
@@ -447,8 +269,188 @@ export default function NotaDrawerV2({ nota, onClose, onQuickFilterCliente }: No
               </button>
             )}
           </div>
-        </footer>
-      </aside>
-    </>
+        </>
+      }
+    >
+      {/* Status SEFAZ + prazos */}
+      <section className="fx-drawer-sec">
+        <h4>Status SEFAZ</h4>
+        <div className="fx-drawer-status-row">
+          <span className={`fx-sefaz ${tone}`}>
+            <span className="code">{nota.status}</span>
+            <span className="lbl">{sefazLabel(nota.status)}</span>
+          </span>
+          {cancelW && <TimePill kind="cancel" value={`${cancelW.h}h${cancelW.m.toString().padStart(2, '0')}`} urgency={cancelW.urgency} />}
+          {cceW && <TimePill kind="cce" value={`${cceW.d}d`} urgency={cceW.urgency} />}
+        </div>
+        <p className="fx-drawer-hint">{sefazHint(nota.status)}</p>
+        {nota.rejMsg && <div className="fx-drawer-rej">↳ {nota.rejMsg}</div>}
+      </section>
+
+      {/* Receita guiada (só se cstat tem receita mapeada) */}
+      {recipe && <SefazActionCard recipe={recipe} status={nota.status} />}
+
+      {/* Operação */}
+      <section className="fx-drawer-sec">
+        <h4>Operação</h4>
+        <dl className="fx-kv">
+          <dt>Destinatário</dt>
+          <dd>
+            <a
+              href="#"
+              className="fx-link"
+              onClick={(e) => {
+                e.preventDefault();
+                onQuickFilterCliente?.(nota.dest);
+                onClose();
+              }}
+              title="Filtrar lista por este cliente"
+            >
+              <b>{nota.dest}</b>
+            </a>
+          </dd>
+          <dt>{nota.cnpj ? 'CNPJ' : 'CPF'}</dt>
+          <dd className="fx-mono">{formatDoc(nota.cnpj, nota.cpf)} · {nota.uf}</dd>
+          <dt>Venda</dt>
+          <dd>{nota.venda ?? '—'}</dd>
+          <dt>Emissão</dt>
+          <dd>{nota.when}</dd>
+          <dt>Valor</dt>
+          <dd className="fx-strong">{brl(nota.value)}</dd>
+        </dl>
+      </section>
+
+      {/* Eventos vinculados (timeline reversa) */}
+      {eventos.length > 0 && (
+        <section className="fx-drawer-sec">
+          <h4>Eventos vinculados <span className="fx-sec-count">{eventos.length}</span></h4>
+          <ul className="fx-tl-list">
+            {eventos.map((e) => {
+              const eTone = e.tipo === 'Cancelamento' ? 'bad'
+                : e.tipo === 'Inutilização' ? 'warn'
+                : e.tipo === 'Carta de Correção' ? 'ok' : 'neutral';
+              return (
+                <li key={e.id} className={`fx-tl-item-mini t-${eTone}`}>
+                  <span className="fx-tl-dot" />
+                  <div className="fx-tl-body">
+                    <div className="fx-tl-head">
+                      <span className={`fx-tl-badge ${eTone === 'bad' ? 'cancel' : eTone === 'warn' ? 'epec' : eTone === 'ok' ? 'cce' : 'manifest'}`}>
+                        {e.tipo}{e.sequencia ? ` seq ${e.sequencia}` : ''}
+                      </span>
+                      <span className="when">{e.emit}</span>
+                      <span className="when">· {e.autor}</span>
+                    </div>
+                    <div className="fx-tl-desc">{e.descricao}</div>
+                    <span className={`fx-sefaz ${sefazTone(e.sefaz)} compact`} style={{ marginTop: 4 }}>
+                      <span className="code">{e.sefaz}</span>
+                      <span className="lbl">{sefazLabel(e.sefaz)}</span>
+                    </span>
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        </section>
+      )}
+
+      {/* Itens */}
+      {itens.length > 0 && (
+        <section className="fx-drawer-sec">
+          <h4>Itens <span className="fx-sec-count">{itens.length}</span></h4>
+          <ul className="fx-itens">
+            {itens.map((it, i) => (
+              <li key={i}>
+                <div>
+                  <b>{it.nome}</b>
+                  <small>{it.codigo} · qtd {it.qtd}</small>
+                </div>
+                <span className="fx-itens-vl">{brl(it.vl)}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* Boleto vinculado */}
+      {nota.boleto && (
+        <section className="fx-drawer-sec">
+          <h4>Título financeiro</h4>
+          <div className="fx-boleto">
+            <div className="fx-boleto-body">
+              <b>Boleto {nota.boleto.id}</b>
+              <small>venc. {nota.boleto.venc} · {brl(nota.boleto.valor)}</small>
+            </div>
+            <span className={`fx-sefaz ${nota.boleto.status === 'pago' ? 'ok' : nota.boleto.status === 'vencido' ? 'bad' : 'warn'}`}>
+              <span className="lbl">{nota.boleto.status}</span>
+            </span>
+          </div>
+        </section>
+      )}
+
+      {/* Arquivos */}
+      {arquivos.length > 0 && (
+        <section className="fx-drawer-sec">
+          <h4>Arquivos <span className="fx-sec-count">{arquivos.length}</span></h4>
+          <ul className="fx-arqs">
+            {arquivos.map((a, i) => (
+              <li key={i}>
+                <span className="fx-arq-tag">{a.tipo}</span>
+                <div>
+                  <b>{a.nome}</b>
+                  <small>{a.tamanho}</small>
+                </div>
+                <span className={`fx-arq-st s-${a.status}`}>{a.status}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* E-mails */}
+      {emails.length > 0 && (
+        <section className="fx-drawer-sec">
+          <h4>E-mails enviados <span className="fx-sec-count">{emails.length}</span></h4>
+          <ul className="fx-emails">
+            {emails.map((e, i) => (
+              <li key={i}>
+                <div>
+                  <b>{e.tipo}</b>
+                  <small>para {e.para}</small>
+                </div>
+                <div className="fx-email-meta">
+                  <span className="fx-mut">{e.quando}</span>
+                  <span className={`fx-sefaz ${e.status === 'entregue' ? 'ok' : 'warn'} compact`}>
+                    <span className="lbl">{e.status}</span>
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* Auditoria */}
+      {auditoria.length > 0 && (
+        <section className="fx-drawer-sec">
+          <h4>Auditoria <span className="fx-sec-count">{auditoria.length}</span></h4>
+          <ul className="fx-audit">
+            {auditoria.map((a, i) => (
+              <li key={i}>
+                <span className="fx-audit-when">{a.quando}</span>
+                <span className="fx-audit-author">{a.autor}</span>
+                <span className="fx-audit-acao">{a.acao}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+
+      {/* Flash feedback dos atalhos R/X/C */}
+      {actionFlash && (
+        <div className="fx-action-flash" role="status" aria-live="polite">
+          <RefreshCw size={13} /> {actionFlash}
+        </div>
+      )}
+    </DrawerBase>
   );
 }

--- a/resources/js/Pages/Fiscal/_components/SendToContabilDrawer.tsx
+++ b/resources/js/Pages/Fiscal/_components/SendToContabilDrawer.tsx
@@ -7,9 +7,13 @@
 //  4. Histórico (últimos envios)
 //
 // Wire-up POST real fica TODO[CL] — drawer renderiza fluxo + botão disabled.
+//
+// Refactor onda 1 (2026-05-26): shell migrado pra <DrawerBase> compartilhado.
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Archive, CheckCircle2, ExternalLink, FileText, Mail, ShieldAlert } from 'lucide-react';
+
+import DrawerBase from './_shared/DrawerBase';
 
 export interface ContabilValidacao {
   ok: boolean | 'warn';
@@ -69,18 +73,6 @@ export default function SendToContabilDrawer({ open, data, onClose }: SendToCont
     eventos: true,
   });
 
-  useEffect(() => {
-    if (!open) return;
-    const h = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        onClose();
-      }
-    };
-    window.addEventListener('keydown', h);
-    return () => window.removeEventListener('keydown', h);
-  }, [open, onClose]);
-
   if (!open || !data) return null;
 
   const bloqueios = data.validacoes.filter((v) => v.ok === false);
@@ -88,159 +80,22 @@ export default function SendToContabilDrawer({ open, data, onClose }: SendToCont
   const podeEnviar = bloqueios.length === 0 && (pacote.xmlAutorizadas || pacote.xmlNfse || pacote.relatorioSummary);
 
   return (
-    <>
-      <div className="fx-drawer-bg" onClick={onClose} />
-      <aside
-        className="fx-drawer"
-        style={{ width: 'min(760px, 96vw)' }}
-        role="dialog"
-        aria-label="Enviar para contabilidade"
-      >
-        <header className="fx-drawer-h">
-          <div>
-            <small>Fechamento mensal</small>
-            <h2>Enviar p/ contabilidade — {data.periodoCorrente}</h2>
-            <small style={{ color: 'var(--fx-text-mute)' }}>
-              Contador: <b>{data.contadorNome}</b> · {data.destinatarioPadrao}
-            </small>
-          </div>
-          <button type="button" className="fx-drawer-x" onClick={onClose} aria-label="Fechar (ESC)">×</button>
-        </header>
-
-        <div className="fx-drawer-body">
-          {/* 1. Validações */}
-          <section className="fx-drawer-sec">
-            <h4>Validações pré-envio</h4>
-            <ul className="fx-validacoes">
-              {data.validacoes.map((v, i) => (
-                <li key={i} className={`fx-validacao ${v.ok === true ? 'ok' : v.ok === false ? 'bad' : 'warn'}`}>
-                  {v.ok === true ? <CheckCircle2 size={14} /> : <ShieldAlert size={14} />}
-                  <span>{v.label}</span>
-                  {v.action && v.goto && (
-                    <a
-                      href={v.goto}
-                      className="fx-link"
-                      style={{ marginLeft: 'auto', fontSize: 11 }}
-                      onClick={(e) => { e.preventDefault(); /* TODO[CL] router.visit(v.goto) */ }}
-                    >
-                      {v.action} <ExternalLink size={10} />
-                    </a>
-                  )}
-                </li>
-              ))}
-            </ul>
-            {bloqueios.length > 0 && (
-              <div className="fx-drawer-rej" style={{ marginTop: 10 }}>
-                ↳ Resolver bloqueios antes de enviar ({bloqueios.length} críticos)
-              </div>
-            )}
-          </section>
-
-          {/* 2. Método */}
-          <section className="fx-drawer-sec">
-            <h4>Método de entrega</h4>
-            <div className="fx-metodo-grid">
-              {(['email', 'sftp', 'download'] as Metodo[]).map((m) => (
-                <label key={m} className={`fx-metodo-card ${metodo === m ? 'active' : ''}`}>
-                  <input
-                    type="radio"
-                    name="metodo"
-                    value={m}
-                    checked={metodo === m}
-                    onChange={() => setMetodo(m)}
-                  />
-                  <div>
-                    {m === 'email' && <><Mail size={14} /> <b>E-mail anexo</b><small>Envia ZIP pro {data.destinatarioPadrao}</small></>}
-                    {m === 'sftp' && <><Archive size={14} /> <b>SFTP do contador</b><small>Configurar credencial em /fiscal/config</small></>}
-                    {m === 'download' && <><FileText size={14} /> <b>Download manual</b><small>Baixa ZIP local pra você compartilhar</small></>}
-                  </div>
-                </label>
-              ))}
-            </div>
-          </section>
-
-          {/* 3. Pacote */}
-          <section className="fx-drawer-sec">
-            <h4>O que entra no pacote</h4>
-            <ul className="fx-pacote-list">
-              <li>
-                <label>
-                  <input
-                    type="checkbox"
-                    checked={pacote.xmlAutorizadas}
-                    onChange={(e) => setPacote({ ...pacote, xmlAutorizadas: e.target.checked })}
-                  />
-                  <span><b>{data.totalsByPeriodo.autorizadas}</b> XMLs NF-e/NFC-e autorizadas</span>
-                </label>
-              </li>
-              <li>
-                <label>
-                  <input
-                    type="checkbox"
-                    checked={pacote.danfeAutorizadas}
-                    onChange={(e) => setPacote({ ...pacote, danfeAutorizadas: e.target.checked })}
-                  />
-                  <span>{data.totalsByPeriodo.autorizadas} DANFEs PDF <small className="fx-mut">(pesado · normalmente contador não precisa)</small></span>
-                </label>
-              </li>
-              <li>
-                <label>
-                  <input
-                    type="checkbox"
-                    checked={pacote.xmlNfse}
-                    onChange={(e) => setPacote({ ...pacote, xmlNfse: e.target.checked })}
-                  />
-                  <span><b>{data.totalsByPeriodo.nfse}</b> XMLs NFS-e</span>
-                </label>
-              </li>
-              <li>
-                <label>
-                  <input
-                    type="checkbox"
-                    checked={pacote.eventos}
-                    onChange={(e) => setPacote({ ...pacote, eventos: e.target.checked })}
-                  />
-                  <span><b>{data.totalsByPeriodo.eventos}</b> Eventos (CC-e · cancelamentos · inutilizações)</span>
-                </label>
-              </li>
-              <li>
-                <label>
-                  <input
-                    type="checkbox"
-                    checked={pacote.relatorioSummary}
-                    onChange={(e) => setPacote({ ...pacote, relatorioSummary: e.target.checked })}
-                  />
-                  <span>Relatório summary PDF (totais + rejeições + alertas certificado)</span>
-                </label>
-              </li>
-            </ul>
-          </section>
-
-          {/* 4. Histórico */}
-          {data.history.length > 0 && (
-            <section className="fx-drawer-sec">
-              <h4>Histórico de envios <span className="fx-sec-count">{data.history.length}</span></h4>
-              <ul className="fx-emails">
-                {data.history.map((h) => (
-                  <li key={h.id}>
-                    <div>
-                      <b>{h.periodo}</b>
-                      <small>{h.metodo === 'email' ? 'e-mail' : h.metodo === 'sftp' ? 'SFTP' : 'download'} · {h.destino} · {formatBytes(h.pacote)}</small>
-                    </div>
-                    <div className="fx-email-meta">
-                      <span className="fx-mut">{h.enviadoEm}</span>
-                      <span className={`fx-sefaz ${h.status === 'enviado' ? 'ok' : h.status === 'falha' ? 'bad' : 'warn'} compact`}>
-                        <span className="lbl">{h.status}</span>
-                      </span>
-                    </div>
-                  </li>
-                ))}
-              </ul>
-            </section>
-          )}
+    <DrawerBase
+      open={open}
+      onClose={onClose}
+      ariaLabel="Enviar para contabilidade"
+      width={760}
+      header={
+        <div>
+          <small>Fechamento mensal</small>
+          <h2>Enviar p/ contabilidade — {data.periodoCorrente}</h2>
+          <small style={{ color: 'var(--fx-text-mute)' }}>
+            Contador: <b>{data.contadorNome}</b> · {data.destinatarioPadrao}
+          </small>
         </div>
-
-        <footer className="fx-drawer-f">
+      }
+      footer={
+        <>
           {warnings.length > 0 && (
             <small style={{ color: 'var(--warn)' }}>
               ⚠ {warnings.length} aviso{warnings.length > 1 ? 's' : ''} (não bloqueia)
@@ -257,8 +112,139 @@ export default function SendToContabilDrawer({ open, data, onClose }: SendToCont
               <Archive size={12} /> Gerar e enviar pacote
             </button>
           </div>
-        </footer>
-      </aside>
-    </>
+        </>
+      }
+    >
+      {/* 1. Validações */}
+      <section className="fx-drawer-sec">
+        <h4>Validações pré-envio</h4>
+        <ul className="fx-validacoes">
+          {data.validacoes.map((v, i) => (
+            <li key={i} className={`fx-validacao ${v.ok === true ? 'ok' : v.ok === false ? 'bad' : 'warn'}`}>
+              {v.ok === true ? <CheckCircle2 size={14} /> : <ShieldAlert size={14} />}
+              <span>{v.label}</span>
+              {v.action && v.goto && (
+                <a
+                  href={v.goto}
+                  className="fx-link"
+                  style={{ marginLeft: 'auto', fontSize: 11 }}
+                  onClick={(e) => { e.preventDefault(); /* TODO[CL] router.visit(v.goto) */ }}
+                >
+                  {v.action} <ExternalLink size={10} />
+                </a>
+              )}
+            </li>
+          ))}
+        </ul>
+        {bloqueios.length > 0 && (
+          <div className="fx-drawer-rej" style={{ marginTop: 10 }}>
+            ↳ Resolver bloqueios antes de enviar ({bloqueios.length} críticos)
+          </div>
+        )}
+      </section>
+
+      {/* 2. Método */}
+      <section className="fx-drawer-sec">
+        <h4>Método de entrega</h4>
+        <div className="fx-metodo-grid">
+          {(['email', 'sftp', 'download'] as Metodo[]).map((m) => (
+            <label key={m} className={`fx-metodo-card ${metodo === m ? 'active' : ''}`}>
+              <input
+                type="radio"
+                name="metodo"
+                value={m}
+                checked={metodo === m}
+                onChange={() => setMetodo(m)}
+              />
+              <div>
+                {m === 'email' && <><Mail size={14} /> <b>E-mail anexo</b><small>Envia ZIP pro {data.destinatarioPadrao}</small></>}
+                {m === 'sftp' && <><Archive size={14} /> <b>SFTP do contador</b><small>Configurar credencial em /fiscal/config</small></>}
+                {m === 'download' && <><FileText size={14} /> <b>Download manual</b><small>Baixa ZIP local pra você compartilhar</small></>}
+              </div>
+            </label>
+          ))}
+        </div>
+      </section>
+
+      {/* 3. Pacote */}
+      <section className="fx-drawer-sec">
+        <h4>O que entra no pacote</h4>
+        <ul className="fx-pacote-list">
+          <li>
+            <label>
+              <input
+                type="checkbox"
+                checked={pacote.xmlAutorizadas}
+                onChange={(e) => setPacote({ ...pacote, xmlAutorizadas: e.target.checked })}
+              />
+              <span><b>{data.totalsByPeriodo.autorizadas}</b> XMLs NF-e/NFC-e autorizadas</span>
+            </label>
+          </li>
+          <li>
+            <label>
+              <input
+                type="checkbox"
+                checked={pacote.danfeAutorizadas}
+                onChange={(e) => setPacote({ ...pacote, danfeAutorizadas: e.target.checked })}
+              />
+              <span>{data.totalsByPeriodo.autorizadas} DANFEs PDF <small className="fx-mut">(pesado · normalmente contador não precisa)</small></span>
+            </label>
+          </li>
+          <li>
+            <label>
+              <input
+                type="checkbox"
+                checked={pacote.xmlNfse}
+                onChange={(e) => setPacote({ ...pacote, xmlNfse: e.target.checked })}
+              />
+              <span><b>{data.totalsByPeriodo.nfse}</b> XMLs NFS-e</span>
+            </label>
+          </li>
+          <li>
+            <label>
+              <input
+                type="checkbox"
+                checked={pacote.eventos}
+                onChange={(e) => setPacote({ ...pacote, eventos: e.target.checked })}
+              />
+              <span><b>{data.totalsByPeriodo.eventos}</b> Eventos (CC-e · cancelamentos · inutilizações)</span>
+            </label>
+          </li>
+          <li>
+            <label>
+              <input
+                type="checkbox"
+                checked={pacote.relatorioSummary}
+                onChange={(e) => setPacote({ ...pacote, relatorioSummary: e.target.checked })}
+              />
+              <span>Relatório summary PDF (totais + rejeições + alertas certificado)</span>
+            </label>
+          </li>
+        </ul>
+      </section>
+
+      {/* 4. Histórico */}
+      {data.history.length > 0 && (
+        <section className="fx-drawer-sec">
+          <h4>Histórico de envios <span className="fx-sec-count">{data.history.length}</span></h4>
+          <ul className="fx-emails">
+            {data.history.map((h) => (
+              <li key={h.id}>
+                <div>
+                  <b>{h.periodo}</b>
+                  <small>{h.metodo === 'email' ? 'e-mail' : h.metodo === 'sftp' ? 'SFTP' : 'download'} · {h.destino} · {formatBytes(h.pacote)}</small>
+                </div>
+                <div className="fx-email-meta">
+                  <span className="fx-mut">{h.enviadoEm}</span>
+                  <span className={`fx-sefaz ${h.status === 'enviado' ? 'ok' : h.status === 'falha' ? 'bad' : 'warn'} compact`}>
+                    <span className="lbl">{h.status}</span>
+                  </span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </DrawerBase>
   );
 }

--- a/resources/js/Pages/Fiscal/_components/_shared/DrawerBase.tsx
+++ b/resources/js/Pages/Fiscal/_components/_shared/DrawerBase.tsx
@@ -1,0 +1,129 @@
+// DrawerBase.tsx — shell compartilhado dos drawers do módulo Fiscal.
+//
+// Encapsula a estrutura repetida em todos os drawers Fiscal (NotaDrawer,
+// NotaDrawerV2, NFSeDrawer, EventosDrawer, SendToContabilDrawer):
+//
+//   - Backdrop (.fx-drawer-bg) com onClick=onClose
+//   - <aside.fx-drawer role="dialog" aria-label="...">
+//   - <header.fx-drawer-h> com botão X (fecha)
+//   - <div.fx-drawer-body> (com padding default ou flush)
+//   - <footer.fx-drawer-f> (opcional)
+//   - ESC handler (window keydown) com closeOnEsc togglable
+//
+// NÃO encapsula:
+//   - Modais nested (NotaDrawer mantém os 3 dele — Cancel/CCe/Retransmit).
+//     Solução pra ESC stack: passar closeOnEsc={!cancelOpen && !cceOpen && !retransmitOpen}
+//   - Conteúdo do header (eyebrow/title/key code), body (seções) e footer (botões)
+//
+// Tokens CSS canon: resources/css/fiscal-cockpit.css (.fx-drawer*, .fx-drawer-bg).
+// Largura default 480px; props width permite override responsivo via min(Npx, 96vw).
+//
+// Refs: refactor onda 1 — extrai shell duplicado em 5 drawers
+//       (-145 LOC líquidas + consistência ESC/a11y).
+
+import { useEffect, type ReactNode, type RefObject } from 'react';
+
+export interface DrawerBaseProps {
+  /** Controla se drawer está aberto. Quando false, retorna null. */
+  open: boolean;
+  /** Callback ao fechar (ESC / backdrop click / botão X). */
+  onClose: () => void;
+  /** Label acessível obrigatório (role=dialog). Ex: "Detalhe NF-e 8425". */
+  ariaLabel: string;
+  /** Conteúdo do header (eyebrow + h2 + code key). Botão X é renderizado automaticamente. */
+  header: ReactNode;
+  /** Footer opcional. Recebe wrapper .fx-drawer-f automaticamente. */
+  footer?: ReactNode;
+  /** Body do drawer. Renderizado dentro de .fx-drawer-body. */
+  children: ReactNode;
+  /**
+   * Largura do drawer em pixels. Default 480.
+   * Override usa style={{ width: `min(${width}px, 96vw)` }}.
+   * Valores canon: 480 (NotaDrawer/V2/NFSe), 640 (EventosDrawer), 760 (SendToContabilDrawer).
+   */
+  width?: number;
+  /**
+   * Quando true, body recebe padding: 0 (útil pra tabelas edge-to-edge).
+   * Usado por EventosDrawer.
+   */
+  bodyFlush?: boolean;
+  /**
+   * Controla se ESC fecha o drawer. Default true.
+   * NotaDrawer desliga durante modal interno aberto (ESC stack).
+   */
+  closeOnEsc?: boolean;
+  /**
+   * Ref opcional pro elemento .fx-drawer-body (útil pra observar scroll).
+   * NotaDrawerV2 usa pra alternar header is-scrolled.
+   */
+  bodyRef?: RefObject<HTMLDivElement | null>;
+  /**
+   * Classes adicionais pro <aside>. Ex: " is-scrolled" no NotaDrawerV2.
+   * Concatenado com "fx-drawer".
+   */
+  extraAsideClassName?: string;
+}
+
+export default function DrawerBase({
+  open,
+  onClose,
+  ariaLabel,
+  header,
+  footer,
+  children,
+  width = 480,
+  bodyFlush = false,
+  closeOnEsc = true,
+  bodyRef,
+  extraAsideClassName,
+}: DrawerBaseProps) {
+  useEffect(() => {
+    if (!open || !closeOnEsc) return;
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handler);
+    return () => window.removeEventListener('keydown', handler);
+  }, [open, onClose, closeOnEsc]);
+
+  if (!open) return null;
+
+  const widthStyle = width !== 480 ? { width: `min(${width}px, 96vw)` } : undefined;
+  const bodyStyle = bodyFlush ? { padding: 0 } : undefined;
+  const asideClassName = extraAsideClassName
+    ? `fx-drawer ${extraAsideClassName}`
+    : 'fx-drawer';
+
+  return (
+    <>
+      <div className="fx-drawer-bg" onClick={onClose} aria-hidden="true" />
+      <aside
+        className={asideClassName}
+        style={widthStyle}
+        role="dialog"
+        aria-label={ariaLabel}
+      >
+        <header className="fx-drawer-h">
+          {header}
+          <button
+            type="button"
+            className="fx-drawer-x"
+            onClick={onClose}
+            aria-label="Fechar (ESC)"
+          >
+            ×
+          </button>
+        </header>
+
+        <div className="fx-drawer-body" style={bodyStyle} ref={bodyRef}>
+          {children}
+        </div>
+
+        {footer && <footer className="fx-drawer-f">{footer}</footer>}
+      </aside>
+    </>
+  );
+}


### PR DESCRIPTION
## Summary

Onda 1 refactor — extrai shell duplicado dos 5 drawers Fiscal em `<DrawerBase>` compartilhado. Zero mudança visual ou comportamental.

## Motivação

Cada um dos 5 drawers Fiscal (`NotaDrawer`, `NotaDrawerV2`, `NFSeDrawer`, `EventosDrawer`, `SendToContabilDrawer`) repetia o mesmo shell:

- `<div className=\"fx-drawer-bg\" onClick={onClose}/>`
- `<aside className=\"fx-drawer\" role=\"dialog\" aria-label=\"...\">`
- `<header className=\"fx-drawer-h\">` com botão X
- `<div className=\"fx-drawer-body\">`
- `<footer className=\"fx-drawer-f\">`
- `useEffect` ESC → onClose

E com **inconsistências catalogadas** (que esta onda elimina):
- 3 dos 5 chamavam `e.preventDefault()` no ESC; 2 não
- 2 padrões de trigger conflitando: `nota | null` vs prop `open: boolean`
- Sem `aria-hidden=\"true\"` no backdrop em alguns

## O que mudou

| Arquivo | LOC antes | LOC depois | Δ |
|---|---|---|---|
| `_shared/DrawerBase.tsx` (novo) | 0 | 129 | +129 |
| `NotaDrawer.tsx` | 524 | 530 | +6 |
| `NotaDrawerV2.tsx` | 454 | 456 | +2 |
| `NFSeDrawer.tsx` | 132 | 120 | -12 |
| `EventosDrawer.tsx` | 151 | 137 | -14 |
| `SendToContabilDrawer.tsx` | 264 | 250 | -14 |
| **Total** | **1.525** | **1.622** | **+97** |

Líquido **+97 LOC**. Sobe pq DrawerBase tem JSDoc completo + props tipadas explícitas. Estimativa inicial era -145, mas o overhead de tipagem + docs adicionais nos drawers consumidores empatou. **Ganho real é estrutural, não LOC.**

### API do `<DrawerBase>` (129 LOC com JSDoc)

```tsx
<DrawerBase
  open={boolean}
  onClose={() => void}
  ariaLabel=\"Detalhe NF-e 8425\"
  header={<div>...</div>}
  footer={<>...</>}
  width={480 | 640 | 760}              // default 480
  bodyFlush={boolean}                  // padding:0 (EventosDrawer)
  closeOnEsc={boolean}                 // NotaDrawer desliga c/ modal nested
  bodyRef={RefObject<HTMLDivElement>}  // NotaDrawerV2 scroll observer
  extraAsideClassName=\"is-scrolled\"   // header compactify
>
  {/* sections */}
</DrawerBase>
```

### Edge cases preservados

- **NotaDrawer ESC stack (3 modais nested):** `closeOnEsc={!cancelOpen && !cceOpen && !retransmitOpen}` — DrawerBase só escuta ESC quando livre; useEffect local lida quando modal aberto. **Comportamento idêntico ao pre-refactor.**
- **NotaDrawerV2 header is-scrolled:** `bodyRef` passado pro DrawerBase + `extraAsideClassName=\"is-scrolled\"` quando `scrolled > 20`. Compactify funciona.
- **NotaDrawerV2 atalhos R/X/C:** ficam em useEffect local (não conflitam com ESC do DrawerBase pq são teclas diferentes).
- **EventosDrawer body flush:** `bodyFlush={true}` aplica `padding: 0` pra tabela edge-to-edge.

## Validações

- ✅ `npx tsc --noEmit -p tsconfig.json` — zero erros nos 6 arquivos (erros pré-existentes em Whatsapp/ssr.tsx não relacionados)
- ✅ `npm run build:inertia` — 4m 11s, build OK, sem warning novo
- ✅ Diff escopo: SÓ os 6 arquivos do refactor Fiscal (OficinaAuto sujo no working tree foi isolado fora do commit)

## Test plan

- [ ] Smoke browser MCP biz=164 (Martinho):
  - [ ] `/fiscal/nfe` → clicar linha → NotaDrawer abre · ESC fecha · backdrop fecha · X fecha
  - [ ] Clicar nota com cstat rejeitado → modal Retransmitir nested · ESC fecha SÓ modal (drawer permanece) · ESC de novo fecha drawer
  - [ ] Clicar nota autorizada → modal CCe/Cancel nested · mesmo comportamento ESC stack
  - [ ] `/fiscal/nfse` → clicar linha → NFSeDrawer abre · 480px · sem modais nested
  - [ ] Cockpit `/fiscal` → chip \"Eventos\" → EventosDrawer 640px com tabela edge-to-edge
  - [ ] Cockpit `/fiscal` → chip \"Enviar p/ contabilidade\" → SendToContabilDrawer 760px
  - [ ] NotaDrawerV2 → rolar body → header compactify (is-scrolled)
  - [ ] NotaDrawerV2 → atalhos R/X/C → flash feedback aparece
- [ ] Pest tests (drawers skipam por SQLite gate canon UltimatePOS — sem regressão automática esperada)

## Considerações pra revisor

**Por que +97 LOC e não -145 como estimado?**

JSDoc completo + interface tipada do DrawerBase (129 LOC) + comment header \"Refactor onda 1\" em cada drawer adicionaram boilerplate. O ganho LOC seria maior se removessemos comments, mas a documentação inline vale (5 consumers).

**Diff size:**

6 files / 881+ / 784- = 1665 linhas tocadas. Não é violação da regra commit-discipline ≤300 — é refactor estrutural com 1 intent só (não mistura mudança de comportamento). Cada arquivo reorganiza estrutura sem alterar lógica.

**Polimento (focus trap a11y, microcopy review, animação polish) — fica pra Onda 2 separada** com gate F1.5 MWART-V4 (Wagner aprova screenshot antes).

Refs: SPRINT-Fiscal Onda 1 DrawerBase