### PR TITLE
feat(oficinaauto): US-OFICINA-027 destrava cobrança real Martinho + drawer rico manutenção

### DIFF
--- a/Modules/OficinaAuto/Database/Migrations/2026_05_26_120001_add_box_and_assigned_user_to_service_orders.php
+++ b/Modules/OficinaAuto/Database/Migrations/2026_05_26_120001_add_box_and_assigned_user_to_service_orders.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Wave 2.1 US-OFICINA-027 — Adiciona `box_label` + `assigned_user_id` em service_orders.
+ *
+ * Origem: drawer Cowork canon (`prototipo-ui/_BACKUP-NAO-USAR/.../os/cowork-app.jsx` +
+ * screenshot Wagner 2026-05-26) renderiza KV grid pro modo manutenção com:
+ *   - Box (ex "Elevador 1") → `box_label` string livre (MVP — sem tabela boxes ainda;
+ *     baixo cardinality e sem sinal qualificado pra criar entity nova ADR 0105)
+ *   - Mecânico (ex "Pedro Souza") → `assigned_user_id` FK lógica `users.id`
+ *
+ * Sem FK física (pattern Wave 5-A current_rental_id e Wave 7 current_stage_id) pra
+ * evitar cascade nightmares quando user é deletado/desativado — Service layer valida
+ * existência.
+ *
+ * Multi-tenant Tier 0 [ADR 0093]: business_id continua scope mãe; box_label é texto
+ * livre per-business (sem leak); assigned_user_id resolvido via global scope users
+ * (cada biz tem seus mecânicos).
+ *
+ * Idempotente (pattern padrão módulo Wave 7+).
+ *
+ * @see resources/js/Pages/OficinaAuto/ProducaoOficina/_components/CacambaProducaoSheet.tsx (Wave 2.2 vira ServiceOrderRichSheet polimórfico)
+ * @see memory/requisitos/OficinaAuto/SPEC.md US-OFICINA-027
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('service_orders')) {
+            return;
+        }
+
+        Schema::table('service_orders', function (Blueprint $table) {
+            if (! Schema::hasColumn('service_orders', 'box_label')) {
+                $table->string('box_label', 50)
+                    ->nullable()
+                    ->after('mileage_at_service')
+                    ->comment('Box físico onde OS está sendo executada (ex "Elevador 1"). MVP texto livre — sem tabela boxes até sinal qualificado ADR 0105.');
+            }
+
+            if (! Schema::hasColumn('service_orders', 'assigned_user_id')) {
+                $table->unsignedInteger('assigned_user_id')
+                    ->nullable()
+                    ->after('box_label')
+                    ->comment('FK lógica users.id — mecânico responsável pela OS. Sem FK física (pattern Wave 5-A).');
+
+                $table->index(['business_id', 'assigned_user_id'], 'idx_service_orders_business_assigned_user');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('service_orders')) {
+            return;
+        }
+
+        Schema::table('service_orders', function (Blueprint $table) {
+            if (Schema::hasColumn('service_orders', 'assigned_user_id')) {
+                $table->dropIndex('idx_service_orders_business_assigned_user');
+                $table->dropColumn('assigned_user_id');
+            }
+
+            if (Schema::hasColumn('service_orders', 'box_label')) {
+                $table->dropColumn('box_label');
+            }
+        });
+    }
+};

--- a/Modules/OficinaAuto/Entities/ServiceOrder.php
+++ b/Modules/OficinaAuto/Entities/ServiceOrder.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
@@ -63,6 +64,8 @@ class ServiceOrder extends Model
         'expected_return_date',
         'daily_rate',
         'mileage_at_service',
+        'box_label',           // Wave 2.1 US-OFICINA-027 — texto livre "Elevador 1"
+        'assigned_user_id',    // Wave 2.1 US-OFICINA-027 — mecânico responsável (FK lógica)
         'status',
         'entered_at',
         'expected_completion',
@@ -76,6 +79,7 @@ class ServiceOrder extends Model
         'transaction_id'        => 'integer',
         'vehicle_id'            => 'integer',
         'mileage_at_service'    => 'integer',
+        'assigned_user_id'      => 'integer',  // Wave 2.1 US-OFICINA-027
         'daily_rate'            => 'decimal:2',
         'expected_return_date'  => 'date',
         'entered_at'            => 'datetime',
@@ -135,6 +139,30 @@ class ServiceOrder extends Model
     public function contact(): BelongsTo
     {
         return $this->belongsTo(\App\Contact::class, 'contact_id');
+    }
+
+    /**
+     * Itens da OS (peças + mão-de-obra + serviços terceiros) — US-OFICINA-027.
+     *
+     * Schema `oficina_service_order_items` migrado git desde 2026-05-17 (Wave 27 G1),
+     * Model + Service + Pest entregues isolados. Esta relação completa o wire-up
+     * pra Observer `computeFinalTotal` somar OS de manutenção e pra UI consumir
+     * via Inertia payload (drawer Cowork canon seção "PEÇAS & MÃO DE OBRA").
+     */
+    public function items(): HasMany
+    {
+        return $this->hasMany(ServiceOrderItem::class, 'service_order_id');
+    }
+
+    /**
+     * Mecânico responsável pela OS (Wave 2.1 US-OFICINA-027).
+     *
+     * FK lógica pra users.id sem cascade — Service layer valida existência.
+     * Renderizado no drawer ServiceOrderRichSheet (Wave 2.2) KV grid modo manutenção.
+     */
+    public function assignedUser(): BelongsTo
+    {
+        return $this->belongsTo(\App\User::class, 'assigned_user_id');
     }
 
     // ------------------------------------------------------------------
@@ -198,6 +226,17 @@ class ServiceOrder extends Model
         }
 
         return round((float) $this->daily_rate * $this->dias_locacao, 2);
+    }
+
+    /**
+     * Total agregado de itens da OS (US-OFICINA-027) — soma `valor_total` de
+     * todos itens não-deletados. Base do `ServiceOrderObserver::computeFinalTotal`
+     * pra `order_type='manutencao'` (cálculo `peça×qty + hora×horas` que substitui
+     * o hardcode 0.0 pré-ADR 0194).
+     */
+    public function getTotalItemsAttribute(): float
+    {
+        return round((float) $this->items()->sum('valor_total'), 2);
     }
 
     // ------------------------------------------------------------------

--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
@@ -385,6 +385,10 @@ class ServiceOrderController extends Controller
             'vehicle',
             'contact:id,name,mobile',
             'transaction:id,business_id,invoice_no,final_total,transaction_date',
+            // Wave 2.3 US-OFICINA-027 — drawer ServiceOrderRichSheet seção PEÇAS & MÃO DE OBRA
+            'items',
+            // Wave 2.1 US-OFICINA-027 — drawer KV grid modo manutenção (Mecânico)
+            'assignedUser:id,first_name,last_name,surname',
         ]);
 
         // Accept-aware: drawer ServiceOrderSheet faz fetch JSON via header.
@@ -407,16 +411,47 @@ class ServiceOrderController extends Controller
                 'started_at'            => $order->entered_at,
                 'completed_at'          => $order->completed_at,
                 'notes'                 => $order->notes,
+                // Wave 2.1 US-OFICINA-027 — drawer modo manutenção (sub-vertical 4 ADR 0194)
+                'mileage_at_service'    => $order->mileage_at_service,
+                'box_label'             => $order->box_label,
+                'assigned_user'         => $order->assignedUser ? [
+                    'id'   => $order->assignedUser->id,
+                    // UltimatePOS canon: surname + first_name + last_name (mesmo pattern User::getUserFullNameAttribute)
+                    'name' => trim(
+                        ($order->assignedUser->surname ?? '') . ' ' .
+                        ($order->assignedUser->first_name ?? '') . ' ' .
+                        ($order->assignedUser->last_name ?? '')
+                    ),
+                ] : null,
                 'vehicle' => $order->vehicle ? [
-                    'id'              => $order->vehicle->id,
-                    'plate'           => $order->vehicle->plate,
-                    'vehicle_number'  => $order->vehicle->vehicle_number ?? null,
-                    'capacity_m3'     => $order->vehicle->capacity_m3 ?? null,
+                    'id'                => $order->vehicle->id,
+                    'plate'             => $order->vehicle->plate,
+                    'vehicle_number'    => $order->vehicle->vehicle_number ?? null,
+                    'vehicle_type'      => $order->vehicle->vehicle_type ?? null,
+                    'capacity_m3'       => $order->vehicle->capacity_m3 ?? null,
+                    'model_year'        => $order->vehicle->model_year ?? null,
+                    'manufacture_year'  => $order->vehicle->manufacture_year ?? null,
+                    'color'             => $order->vehicle->color ?? null,
                 ] : null,
                 'contact' => $order->contact ? [
-                    'id'   => $order->contact->id,
-                    'name' => $order->contact->name,
+                    'id'     => $order->contact->id,
+                    'name'   => $order->contact->name,
+                    'mobile' => $order->contact->mobile,
                 ] : null,
+                // Wave 2.3 US-OFICINA-027 — items lançados na OS (peça + mão-obra + terceiro)
+                // alimentam seção "PEÇAS & MÃO DE OBRA" do drawer ServiceOrderRichSheet.
+                // Observer ::computeFinalTotal soma valor_total destes pra Transaction.final_total.
+                'items' => $order->items->map(fn ($item) => [
+                    'id'             => $item->id,
+                    'tipo'           => $item->tipo,
+                    'descricao'      => $item->descricao,
+                    'quantidade'     => (float) $item->quantidade,
+                    'valor_unitario' => (float) $item->valor_unitario,
+                    'valor_total'    => (float) $item->valor_total,
+                    'product_id'     => $item->product_id,
+                    'notes'          => $item->notes,
+                ])->values()->all(),
+                'items_total' => (float) $order->total_items,
                 // ADR 0192 · V0 core shape (Onda 5). FASE B (items_list / items_summary /
                 // fiscal NF-e) fica pra wave futura — exige join sell_lines + NfeBrasil
                 // que já existe no equivalente Modules/Repair/ProducaoOficinaController

--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderItemController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderItemController.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use InvalidArgumentException;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\ServiceOrderItem;
+use Modules\OficinaAuto\Http\Requests\StoreServiceOrderItemRequest;
+use Modules\OficinaAuto\Http\Requests\UpdateServiceOrderItemRequest;
+use Modules\OficinaAuto\Services\ServiceOrderItemService;
+
+/**
+ * Wave 1.3 US-OFICINA-027 — HTTP layer pra `oficina_service_order_items`.
+ *
+ * Domain (Model + Service + 10 Pest) entregue em Wave 27 G1 (2026-05-17) + Wave 28 polish.
+ * Esta Controller só wirea HTTP CRUD pra UI consumir — drawer Cowork seção "PEÇAS &
+ * MÃO DE OBRA" (Wave 2) chama estes endpoints.
+ *
+ * Multi-tenant Tier 0 [ADR 0093]: business_id derivado de `auth()->user()` (NUNCA
+ * request). Service `addItem` faz double-check cross-tenant (OS pertence ao biz)
+ * via `withoutGlobalScopes()->where('business_id', ...)`.
+ *
+ * Rotas registradas em `Modules/OficinaAuto/Routes/web.php`:
+ *   POST   /oficina-auto/ordens-servico/{order}/items         → store
+ *   PUT    /oficina-auto/ordens-servico/{order}/items/{item}  → update
+ *   DELETE /oficina-auto/ordens-servico/{order}/items/{item}  → destroy
+ *
+ * Throttle 60/1 nas mutações (padrão módulo, ServiceOrderController).
+ *
+ * @see Modules\OficinaAuto\Services\ServiceOrderItemService
+ * @see memory/requisitos/OficinaAuto/SPEC.md US-OFICINA-027
+ */
+class ServiceOrderItemController extends Controller
+{
+    public function __construct(private readonly ServiceOrderItemService $service) {}
+
+    /**
+     * Cria item na OS (peça / mão-de-obra / serviço terceiro).
+     *
+     * Multi-tenant: Service::addItem rejeita cross-tenant via `InvalidArgumentException`
+     * "OS não pertence ao business" — convertido em HTTP 422 aqui.
+     */
+    public function store(StoreServiceOrderItemRequest $request, ServiceOrder $order): JsonResponse
+    {
+        // Policy sameTenant — defesa em profundidade (Service ainda rechecará).
+        $this->authorize('update', $order);
+
+        $businessId = (int) ($request->user()->business_id ?? 0);
+
+        try {
+            $item = $this->service->addItem($businessId, $order->id, $request->validated());
+        } catch (InvalidArgumentException $e) {
+            return response()->json(['message' => $e->getMessage()], 422);
+        }
+
+        return response()->json([
+            'id'             => $item->id,
+            'tipo'           => $item->tipo,
+            'descricao'      => $item->descricao,
+            'quantidade'     => (float) $item->quantidade,
+            'valor_unitario' => (float) $item->valor_unitario,
+            'valor_total'    => (float) $item->valor_total,
+            'product_id'     => $item->product_id,
+            'notes'          => $item->notes,
+            'created_at'     => $item->created_at?->toIso8601String(),
+        ], 201);
+    }
+
+    /**
+     * Atualiza item existente. Policy via parent OS — operador da OS edita os items dela.
+     * Auto-recalc `valor_total` acontece no Model `updating` hook (ServiceOrderItem.php).
+     */
+    public function update(
+        UpdateServiceOrderItemRequest $request,
+        ServiceOrder $order,
+        ServiceOrderItem $item,
+    ): JsonResponse {
+        $this->authorize('update', $order);
+
+        // Tier 0 hardening: garante que o item pertence à OS da URL (não só ao biz).
+        // Sem isso, biz=164 poderia editar item da OS #1 passando como /ordens-servico/2/items/1.
+        abort_unless($item->service_order_id === $order->id, 404);
+
+        $item->fill($request->validated())->save();
+
+        return response()->json([
+            'id'             => $item->id,
+            'tipo'           => $item->tipo,
+            'descricao'      => $item->descricao,
+            'quantidade'     => (float) $item->quantidade,
+            'valor_unitario' => (float) $item->valor_unitario,
+            'valor_total'    => (float) $item->valor_total,
+            'product_id'     => $item->product_id,
+            'notes'          => $item->notes,
+            'updated_at'     => $item->updated_at?->toIso8601String(),
+        ]);
+    }
+
+    /**
+     * Remove item (soft delete — preserva audit append-only LGPD D7.b).
+     */
+    public function destroy(Request $request, ServiceOrder $order, ServiceOrderItem $item): JsonResponse
+    {
+        $this->authorize('update', $order);
+
+        abort_unless($item->service_order_id === $order->id, 404);
+
+        $item->delete();
+
+        return response()->json(['deleted' => true, 'id' => $item->id]);
+    }
+}

--- a/Modules/OficinaAuto/Http/Requests/StoreServiceOrderItemRequest.php
+++ b/Modules/OficinaAuto/Http/Requests/StoreServiceOrderItemRequest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Modules\OficinaAuto\Entities\ServiceOrderItem;
+
+/**
+ * Wave 1.3 US-OFICINA-027 — FormRequest pra criar item de OS (peça / mão-de-obra / terceiro).
+ *
+ * Multi-tenant Tier 0 [ADR 0093]: business_id NUNCA vem do request — Controller passa
+ * `auth()->user()->business_id` explicitamente pro Service. Request só valida shape +
+ * permission. Service ainda faz dupla-checagem cross-tenant (OS pertence ao biz).
+ *
+ * @see Modules\OficinaAuto\Http\Controllers\ServiceOrderItemController::store
+ * @see Modules\OficinaAuto\Services\ServiceOrderItemService::addItem
+ * @see memory/requisitos/OficinaAuto/SPEC.md US-OFICINA-027
+ */
+class StoreServiceOrderItemRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+
+        if ($user === null) {
+            return false;
+        }
+
+        // Reusa permission oficinaauto.service_order.update — quem edita OS pode lançar items.
+        return $user->can('superadmin') || $user->can('oficinaauto.service_order.update');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'tipo'           => ['required', 'string', 'in:' . implode(',', ServiceOrderItem::TIPOS_VALIDOS)],
+            'descricao'      => ['required', 'string', 'max:255'],
+            'quantidade'     => ['nullable', 'numeric', 'min:0.001', 'max:9999999.999'],
+            'valor_unitario' => ['nullable', 'numeric', 'min:0', 'max:9999999.99'],
+            'valor_total'    => ['nullable', 'numeric', 'min:0', 'max:9999999.99'],
+            'product_id'     => ['nullable', 'integer'],
+            'notes'          => ['nullable', 'string', 'max:1000'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'tipo.required'      => 'Selecione o tipo (peça, mão-de-obra ou serviço terceiro).',
+            'tipo.in'            => 'Tipo inválido. Permitidos: peca, mao_obra, servico_terceiro.',
+            'descricao.required' => 'Informe a descrição do item.',
+            'quantidade.min'     => 'Quantidade deve ser maior que zero.',
+        ];
+    }
+}

--- a/Modules/OficinaAuto/Http/Requests/UpdateServiceOrderItemRequest.php
+++ b/Modules/OficinaAuto/Http/Requests/UpdateServiceOrderItemRequest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Modules\OficinaAuto\Entities\ServiceOrderItem;
+
+/**
+ * Wave 1.3 US-OFICINA-027 — FormRequest pra atualizar item existente.
+ *
+ * Mais permissivo que Store: todos campos opcionais (PATCH-like). Multi-tenant
+ * Tier 0 garantido por Policy `update` no Controller + global scope do Model.
+ *
+ * @see Modules\OficinaAuto\Http\Controllers\ServiceOrderItemController::update
+ */
+class UpdateServiceOrderItemRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+
+        if ($user === null) {
+            return false;
+        }
+
+        return $user->can('superadmin') || $user->can('oficinaauto.service_order.update');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'tipo'           => ['sometimes', 'required', 'string', 'in:' . implode(',', ServiceOrderItem::TIPOS_VALIDOS)],
+            'descricao'      => ['sometimes', 'required', 'string', 'max:255'],
+            'quantidade'     => ['sometimes', 'numeric', 'min:0.001', 'max:9999999.999'],
+            'valor_unitario' => ['sometimes', 'numeric', 'min:0', 'max:9999999.99'],
+            'valor_total'    => ['sometimes', 'numeric', 'min:0', 'max:9999999.99'],
+            'product_id'     => ['nullable', 'integer'],
+            'notes'          => ['nullable', 'string', 'max:1000'],
+        ];
+    }
+}

--- a/Modules/OficinaAuto/Observers/ServiceOrderObserver.php
+++ b/Modules/OficinaAuto/Observers/ServiceOrderObserver.php
@@ -30,8 +30,10 @@ use Modules\OficinaAuto\Entities\ServiceOrder;
  *
  * Cálculo `final_total`:
  *   - locação (order_type='locacao'): `daily_rate × dias_locacao` (accessor `valor_receber`)
- *   - manutenção (order_type='manutencao'): zero por default — Wagner edita manual depois
- *     (gap: V1 traz orçamento integrado · v0 mantém manual)
+ *   - manutenção (order_type='manutencao'): `sum(items.valor_total)` agregando peças +
+ *     mão-de-obra + serviços terceiros via `ServiceOrder::items()` hasMany (US-OFICINA-027
+ *     2026-05-26 · ADR 0194 §"Critério validação"). Backward compat: OS sem items lançados
+ *     ainda gera Transaction com final_total=0 (Wagner edita manual — comportamento legacy).
  *
  * Distinção `os_ref` vs Repair JobSheet:
  *   - JobSheet (Repair shared): `os_ref="OS-{id}"`
@@ -148,8 +150,25 @@ class ServiceOrderObserver
             return (float) ($so->valor_receber ?? 0);
         }
 
-        // order_type='manutencao' (default oficina automotiva): V0 sem orçamento auto.
-        // Wagner edita Transaction depois. V1 (ADR futuro) traz orçamento integrado.
-        return 0.0;
+        // order_type='manutencao' (Martinho sub-vertical 4 mecânica pesada CNAE 4520 — ADR 0194):
+        // soma valor_total de todos itens (peça + mão-de-obra + serviço terceiro) via
+        // hasMany ServiceOrder::items() — schema oficina_service_order_items entregue em
+        // Wave 27 G1 (migration 2026_05_17_000010). Accessor `total_items` retorna float
+        // já arredondado decimal:2.
+        //
+        // OS sem items lançados retorna 0.0 — backward compat com comportamento legacy
+        // (Wagner edita Transaction manual depois). Pós-UI Wave 2, mecânico lança peças
+        // pela tela e o cálculo fecha automático.
+        $total = $so->total_items;
+
+        if ($total > 0) {
+            Log::info('ServiceOrderObserver: final_total recalculado via items()', [
+                'service_order_id' => $so->id,
+                'business_id' => $so->business_id,
+                'items_total' => $total,
+            ]);
+        }
+
+        return $total;
     }
 }

--- a/Modules/OficinaAuto/Routes/web.php
+++ b/Modules/OficinaAuto/Routes/web.php
@@ -6,6 +6,7 @@ use Modules\OficinaAuto\Http\Controllers\InstallController;
 use Modules\OficinaAuto\Http\Controllers\ProducaoOficinaController;
 use Modules\OficinaAuto\Http\Controllers\Public\AprovacaoOsController;
 use Modules\OficinaAuto\Http\Controllers\ServiceOrderController;
+use Modules\OficinaAuto\Http\Controllers\ServiceOrderItemController;
 use Modules\OficinaAuto\Http\Controllers\VehicleController;
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -69,6 +70,27 @@ Route::middleware(['web', 'SetSessionData', 'auth', 'language', 'timezone', 'Adm
         Route::delete('ordens-servico/{order}',     [ServiceOrderController::class, 'destroy'])
             ->middleware('throttle:30,1')
             ->name('oficinaauto.orders.destroy');
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Wave 1.3 US-OFICINA-027 — Items de OS (peça / mão-de-obra / terceiro).
+        // Schema oficina_service_order_items em Wave 27 G1 (migration 2026-05-17).
+        // Drawer Cowork seção "PEÇAS & MÃO DE OBRA" (Wave 2) consome estes endpoints.
+        // Throttle 60/1 nas mutações (padrão módulo).
+        // ─────────────────────────────────────────────────────────────────────
+        Route::post('ordens-servico/{order}/items',
+            [ServiceOrderItemController::class, 'store'])
+            ->middleware('throttle:60,1')
+            ->name('oficinaauto.orders.items.store');
+
+        Route::put('ordens-servico/{order}/items/{item}',
+            [ServiceOrderItemController::class, 'update'])
+            ->middleware('throttle:60,1')
+            ->name('oficinaauto.orders.items.update');
+
+        Route::delete('ordens-servico/{order}/items/{item}',
+            [ServiceOrderItemController::class, 'destroy'])
+            ->middleware('throttle:60,1')
+            ->name('oficinaauto.orders.items.destroy');
 
         // ─────────────────────────────────────────────────────────────────────
         // Hotfix Wave 7+ — drawer ServiceOrderSheet.fetchData chama URL inglês

--- a/Modules/OficinaAuto/SCOPE.md
+++ b/Modules/OficinaAuto/SCOPE.md
@@ -7,6 +7,7 @@ contains:
   - "ProducaoOficinaController"
   - "Public/AprovacaoOsController — endpoint público SEM auth pra cliente aprovar/rejeitar OS via link WhatsApp + PIN (US-OFICINA-006). Token HMAC carrega business_id assinado. Throttle:30,1 + lockout 5 tentativas PIN."
   - "ServiceOrderController"
+  - "ServiceOrderItemController — CRUD HTTP de items lançados na OS (peça/mão-obra/serviço terceiro). Wave 1.3 US-OFICINA-027 — alimenta drawer ServiceOrderRichSheet seção PEÇAS & MÃO DE OBRA + Observer ::computeFinalTotal."
   - "VehicleController"
   - "ServiceOrderFsmActionController (app/Http/Controllers — shared FSM canon, espelha SaleFsmActionController)"
 not_contains:

--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderObserverItemsAndHttpTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderObserverItemsAndHttpTest.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Transaction;
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\ServiceOrderItem;
+use Modules\OficinaAuto\Entities\Vehicle;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Wave 1.2 + 1.3 US-OFICINA-027 — Pest integration tests.
+ *
+ * Cobertura:
+ *   - Observer `computeFinalTotal` manutenção: OS com 3 items (peça + mão-obra + terceiro)
+ *     → Transaction derivada `final_total` = sum(valor_total) (substitui hardcode 0.0)
+ *   - Observer backward compat: OS manutenção SEM items → Transaction.final_total = 0
+ *   - Controller HTTP `POST /oficina-auto/ordens-servico/{order}/items` autenticado retorna 201
+ *   - Multi-tenant Tier 0 [ADR 0093]: user biz=1 tentando criar item em OS biz=99 → 422
+ *     (Service::addItem rejeita "OS não pertence ao business")
+ *   - PUT/DELETE: abort_unless item.service_order_id === order.id (404 se cross-OS)
+ *
+ * Cobertura Model + Service entregue em Wave 27 G1 (`ServiceOrderItemTest.php`)
+ * + Wave 28 polish (`Wave28OficinaAutoPolishTest.php`). Este arquivo testa o wire-up
+ * Observer (Wave 1.2) + HTTP (Wave 1.3).
+ *
+ * @see Modules/OficinaAuto/Observers/ServiceOrderObserver.php
+ * @see Modules/OficinaAuto/Http/Controllers/ServiceOrderItemController.php
+ * @see memory/requisitos/OficinaAuto/SPEC.md US-OFICINA-027
+ */
+
+const BIZ_US027_A = 1;
+const BIZ_US027_B = 99;
+const PLATE_US027_PREFIX = 'US027';
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasTable('oficina_service_order_items')) {
+        $this->markTestSkipped('Rode migration 2026_05_17_000010 primeiro');
+    }
+    if (! Schema::hasTable('transactions')) {
+        $this->markTestSkipped('Schema UltimatePOS transactions missing');
+    }
+});
+
+function us027_criaOs(string $suffix, int $biz = BIZ_US027_A, string $orderType = 'manutencao'): ServiceOrder
+{
+    $vehicle = Vehicle::withoutGlobalScopes()->create([
+        'business_id'  => $biz,
+        'plate'        => PLATE_US027_PREFIX . $suffix,
+        'vehicle_type' => 'caminhao',
+    ]);
+
+    return ServiceOrder::withoutGlobalScopes()->create([
+        'business_id' => $biz,
+        'vehicle_id'  => $vehicle->id,
+        'order_type'  => $orderType,
+        'status'      => 'aberta',
+        'contact_id'  => 1, // Observer exige contact_id resolvível
+    ]);
+}
+
+function us027_cleanup(string $suffix): void
+{
+    $vehicles = Vehicle::withoutGlobalScopes()
+        ->where('plate', 'like', PLATE_US027_PREFIX . $suffix . '%')
+        ->pluck('id')
+        ->toArray();
+
+    if (empty($vehicles)) {
+        return;
+    }
+
+    $osIds = ServiceOrder::withoutGlobalScopes()
+        ->whereIn('vehicle_id', $vehicles)
+        ->pluck('id')
+        ->toArray();
+
+    if (! empty($osIds)) {
+        ServiceOrderItem::withoutGlobalScopes()->whereIn('service_order_id', $osIds)->forceDelete();
+        Transaction::whereIn('os_ref', array_map(fn ($id) => "SO-{$id}", $osIds))->delete();
+        ServiceOrder::withoutGlobalScopes()->whereIn('id', $osIds)->forceDelete();
+    }
+
+    Vehicle::withoutGlobalScopes()->whereIn('id', $vehicles)->forceDelete();
+}
+
+// ---------------------------------------------------------------------------
+// Wave 1.2 — Observer recalc final_total via items() (manutenção)
+// ---------------------------------------------------------------------------
+
+it('Observer: OS manutenção com 3 items lançados → Transaction.final_total = soma valor_total', function () {
+    session(['user.business_id' => BIZ_US027_A]);
+    $os = us027_criaOs('A');
+
+    // 3 items: peça R$ 4.800 + mão-obra 3h × R$ 120 = R$ 360 + serviço terceiro R$ 850 = R$ 6.010
+    ServiceOrderItem::withoutGlobalScopes()->create([
+        'business_id'      => BIZ_US027_A,
+        'service_order_id' => $os->id,
+        'tipo'             => ServiceOrderItem::TIPO_PECA,
+        'descricao'        => 'Cilindro hidráulico 6.5T',
+        'quantidade'       => 1,
+        'valor_unitario'   => 4800.00,
+    ]);
+    ServiceOrderItem::withoutGlobalScopes()->create([
+        'business_id'      => BIZ_US027_A,
+        'service_order_id' => $os->id,
+        'tipo'             => ServiceOrderItem::TIPO_MAO_OBRA,
+        'descricao'        => 'Troca cilindro + sangria',
+        'quantidade'       => 3,
+        'valor_unitario'   => 120.00,
+    ]);
+    ServiceOrderItem::withoutGlobalScopes()->create([
+        'business_id'      => BIZ_US027_A,
+        'service_order_id' => $os->id,
+        'tipo'             => ServiceOrderItem::TIPO_SERVICO_TERCEIRO,
+        'descricao'        => 'Recondicionamento bomba',
+        'quantidade'       => 1,
+        'valor_unitario'   => 850.00,
+    ]);
+
+    // Dispara Observer via transição status → 'concluida'
+    $os->status = 'concluida';
+    $os->save();
+
+    $tx = Transaction::where('os_ref', "SO-{$os->id}")->first();
+    expect($tx)->not->toBeNull();
+    expect((float) $tx->final_total)->toBe(6010.00);
+    expect($tx->source)->toBe('oficina');
+    expect($tx->business_id)->toBe(BIZ_US027_A);
+})->afterEach(fn () => us027_cleanup('A'));
+
+it('Observer: OS manutenção SEM items lançados → Transaction.final_total = 0 (backward compat)', function () {
+    session(['user.business_id' => BIZ_US027_A]);
+    $os = us027_criaOs('B');
+
+    $os->status = 'concluida';
+    $os->save();
+
+    $tx = Transaction::where('os_ref', "SO-{$os->id}")->first();
+    expect($tx)->not->toBeNull();
+    expect((float) $tx->final_total)->toBe(0.0);
+})->afterEach(fn () => us027_cleanup('B'));
+
+// ---------------------------------------------------------------------------
+// Wave 1.3 — Controller HTTP CRUD items
+// ---------------------------------------------------------------------------
+
+it('HTTP POST /items autenticado biz=1 → 201 com item criado', function () {
+    session(['user.business_id' => BIZ_US027_A]);
+    $os = us027_criaOs('C');
+
+    $user = User::factory()->create(['business_id' => BIZ_US027_A]);
+    $user->givePermissionTo('superadmin');
+
+    $response = $this->actingAs($user)
+        ->postJson("/oficina-auto/ordens-servico/{$os->id}/items", [
+            'tipo'           => 'peca',
+            'descricao'      => 'Filtro óleo motor',
+            'quantidade'     => 1,
+            'valor_unitario' => 35.00,
+        ]);
+
+    $response->assertCreated();
+    expect($response->json('tipo'))->toBe('peca');
+    expect($response->json('valor_total'))->toBe(35.00);
+
+    $count = ServiceOrderItem::withoutGlobalScopes()
+        ->where('service_order_id', $os->id)
+        ->count();
+    expect($count)->toBe(1);
+})->afterEach(fn () => us027_cleanup('C'));
+
+it('HTTP POST /items cross-tenant biz=1 tentando OS biz=99 → 422 (Service rejeita)', function () {
+    session(['user.business_id' => BIZ_US027_A]);
+    $osBizOutro = us027_criaOs('D', BIZ_US027_B);
+
+    $user = User::factory()->create(['business_id' => BIZ_US027_A]);
+    $user->givePermissionTo('superadmin');
+
+    $response = $this->actingAs($user)
+        ->postJson("/oficina-auto/ordens-servico/{$osBizOutro->id}/items", [
+            'tipo'           => 'peca',
+            'descricao'      => 'Cross-tenant attack',
+            'quantidade'     => 1,
+            'valor_unitario' => 10,
+        ]);
+
+    // Service::addItem lança InvalidArgumentException convertido em 422 no Controller
+    // (Policy authorize('update', $order) também pode rejeitar — qualquer 4xx é guard ok).
+    expect($response->status())->toBeIn([403, 404, 422]);
+
+    $count = ServiceOrderItem::withoutGlobalScopes()
+        ->where('service_order_id', $osBizOutro->id)
+        ->count();
+    expect($count)->toBe(0);
+})->afterEach(function () {
+    us027_cleanup('D');
+});
+
+it('HTTP PUT /items/{item} cross-OS (item de OS diferente da URL) → 404 abort guard', function () {
+    session(['user.business_id' => BIZ_US027_A]);
+    $os1 = us027_criaOs('E1');
+    $os2 = us027_criaOs('E2');
+
+    $item = ServiceOrderItem::withoutGlobalScopes()->create([
+        'business_id'      => BIZ_US027_A,
+        'service_order_id' => $os1->id,
+        'tipo'             => 'peca',
+        'descricao'        => 'Item de OS1',
+        'quantidade'       => 1,
+        'valor_unitario'   => 100,
+    ]);
+
+    $user = User::factory()->create(['business_id' => BIZ_US027_A]);
+    $user->givePermissionTo('superadmin');
+
+    // Tenta editar item via OS2 (URL não bate com item.service_order_id)
+    $response = $this->actingAs($user)
+        ->putJson("/oficina-auto/ordens-servico/{$os2->id}/items/{$item->id}", [
+            'descricao' => 'Tentativa cross-OS',
+        ]);
+
+    $response->assertNotFound();
+    expect($item->fresh()->descricao)->toBe('Item de OS1');
+})->afterEach(function () {
+    us027_cleanup('E1');
+    us027_cleanup('E2');
+});

--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderRichSheetPayloadTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderRichSheetPayloadTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\ServiceOrderItem;
+use Modules\OficinaAuto\Entities\Vehicle;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Wave 2.5 US-OFICINA-027 — Pest payload JSON endpoint drawer ServiceOrderRichSheet.
+ *
+ * Garante que `GET /oficina-auto/service-orders/{id}` (Accept: application/json) retorna:
+ *   - items[]   → list de ServiceOrderItem populando seção "PEÇAS & MÃO DE OBRA"
+ *   - items_total → soma valor_total (espelha accessor total_items + alimenta Observer)
+ *   - assigned_user.name → concat surname+first_name+last_name (UltimatePOS canon)
+ *   - box_label, mileage_at_service → campos modo manutenção sub-vertical 4 ADR 0194
+ *   - vehicle.model_year / manufacture_year / color → drawer header polimórfico
+ *
+ * Smoke browser MCP biz=164 Martinho fica pra fase pós-merge (Wagner rolará manual
+ * via Chrome MCP screenshot — gap conhecido catalogado RUNBOOK smoke-prod-evidence).
+ *
+ * Multi-tenant Tier 0 [ADR 0093]: global scope filtra; este test atua biz=1 explícito.
+ *
+ * @see resources/js/Pages/OficinaAuto/ProducaoOficina/_components/ServiceOrderRichSheet.tsx
+ * @see Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php::show
+ */
+
+const BIZ_RICH = 1;
+const PLATE_RICH_PREFIX = 'RICH';
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasTable('oficina_service_order_items')) {
+        $this->markTestSkipped('Rode migration 2026_05_17_000010 primeiro');
+    }
+    if (! Schema::hasColumn('service_orders', 'box_label')) {
+        $this->markTestSkipped('Rode migration 2026_05_26_120001 primeiro (box_label + assigned_user_id)');
+    }
+});
+
+function rich_criaOs(string $suffix, int $biz = BIZ_RICH): ServiceOrder
+{
+    $vehicle = Vehicle::withoutGlobalScopes()->create([
+        'business_id'    => $biz,
+        'plate'          => PLATE_RICH_PREFIX . $suffix,
+        'vehicle_type'   => 'caminhao',
+        'model_year'     => 2022,
+        'color'          => 'branco',
+    ]);
+
+    return ServiceOrder::withoutGlobalScopes()->create([
+        'business_id'        => $biz,
+        'vehicle_id'         => $vehicle->id,
+        'order_type'         => 'manutencao',
+        'status'             => 'aberta',
+        'contact_id'         => 1,
+        'mileage_at_service' => 42500,
+        'box_label'          => 'Elevador 1',
+    ]);
+}
+
+function rich_cleanup(string $suffix): void
+{
+    $vehicles = Vehicle::withoutGlobalScopes()
+        ->where('plate', 'like', PLATE_RICH_PREFIX . $suffix . '%')
+        ->pluck('id')
+        ->toArray();
+
+    if (empty($vehicles)) {
+        return;
+    }
+
+    $osIds = ServiceOrder::withoutGlobalScopes()
+        ->whereIn('vehicle_id', $vehicles)
+        ->pluck('id')
+        ->toArray();
+
+    if (! empty($osIds)) {
+        ServiceOrderItem::withoutGlobalScopes()->whereIn('service_order_id', $osIds)->forceDelete();
+        ServiceOrder::withoutGlobalScopes()->whereIn('id', $osIds)->forceDelete();
+    }
+
+    Vehicle::withoutGlobalScopes()->whereIn('id', $vehicles)->forceDelete();
+}
+
+// ---------------------------------------------------------------------------
+// Wave 2.3 + 2.1 — JSON payload com items + assigned_user + box_label
+// ---------------------------------------------------------------------------
+
+it('GET /service-orders/{id} JSON retorna items[] + items_total + campos manutenção', function () {
+    session(['user.business_id' => BIZ_RICH]);
+    $os = rich_criaOs('A');
+
+    // Lança 3 items: peça R$ 4800 + 3h mão-obra × R$ 120 + serviço terceiro R$ 850
+    ServiceOrderItem::withoutGlobalScopes()->create([
+        'business_id'      => BIZ_RICH,
+        'service_order_id' => $os->id,
+        'tipo'             => 'peca',
+        'descricao'        => 'Cilindro hidráulico 6.5T',
+        'quantidade'       => 1,
+        'valor_unitario'   => 4800,
+    ]);
+    ServiceOrderItem::withoutGlobalScopes()->create([
+        'business_id'      => BIZ_RICH,
+        'service_order_id' => $os->id,
+        'tipo'             => 'mao_obra',
+        'descricao'        => 'Troca cilindro + sangria',
+        'quantidade'       => 3,
+        'valor_unitario'   => 120,
+    ]);
+    ServiceOrderItem::withoutGlobalScopes()->create([
+        'business_id'      => BIZ_RICH,
+        'service_order_id' => $os->id,
+        'tipo'             => 'servico_terceiro',
+        'descricao'        => 'Recondicionamento bomba',
+        'quantidade'       => 1,
+        'valor_unitario'   => 850,
+    ]);
+
+    $user = User::factory()->create(['business_id' => BIZ_RICH]);
+    $user->givePermissionTo('superadmin');
+
+    $response = $this->actingAs($user)
+        ->getJson("/oficina-auto/service-orders/{$os->id}");
+
+    $response->assertOk();
+
+    // items[] populated
+    $items = $response->json('items');
+    expect($items)->toBeArray()->toHaveCount(3);
+
+    $items_total = (float) $response->json('items_total');
+    expect($items_total)->toBe(6010.0);
+
+    // Campos modo manutenção
+    expect($response->json('order_type'))->toBe('manutencao');
+    expect($response->json('box_label'))->toBe('Elevador 1');
+    expect($response->json('mileage_at_service'))->toBe(42500);
+
+    // Vehicle expandido com campos novos
+    expect($response->json('vehicle.model_year'))->toBe(2022);
+    expect($response->json('vehicle.color'))->toBe('branco');
+    expect($response->json('vehicle.vehicle_type'))->toBe('caminhao');
+})->afterEach(fn () => rich_cleanup('A'));
+
+it('GET /service-orders/{id} OS sem items → items=[] + items_total=0 (backward compat)', function () {
+    session(['user.business_id' => BIZ_RICH]);
+    $os = rich_criaOs('B');
+
+    $user = User::factory()->create(['business_id' => BIZ_RICH]);
+    $user->givePermissionTo('superadmin');
+
+    $response = $this->actingAs($user)
+        ->getJson("/oficina-auto/service-orders/{$os->id}");
+
+    $response->assertOk();
+    expect($response->json('items'))->toBeArray()->toHaveCount(0);
+    expect((float) $response->json('items_total'))->toBe(0.0);
+})->afterEach(fn () => rich_cleanup('B'));
+
+it('GET /service-orders/{id} com assigned_user populado → name concatenado UltimatePOS canon', function () {
+    session(['user.business_id' => BIZ_RICH]);
+
+    $mecanico = User::factory()->create([
+        'business_id' => BIZ_RICH,
+        'first_name'  => 'Pedro',
+        'surname'     => '',
+        'last_name'   => 'Souza',
+    ]);
+
+    $os = rich_criaOs('C');
+    $os->assigned_user_id = $mecanico->id;
+    $os->save();
+
+    $user = User::factory()->create(['business_id' => BIZ_RICH]);
+    $user->givePermissionTo('superadmin');
+
+    $response = $this->actingAs($user)
+        ->getJson("/oficina-auto/service-orders/{$os->id}");
+
+    $response->assertOk();
+    expect($response->json('assigned_user.id'))->toBe($mecanico->id);
+    // Concat trimmed: "Pedro Souza" (sem surname)
+    expect($response->json('assigned_user.name'))->toBe('Pedro Souza');
+})->afterEach(fn () => rich_cleanup('C'));

--- a/config/ui-lint-baseline.json
+++ b/config/ui-lint-baseline.json
@@ -151,7 +151,7 @@
             "R1": 5
         },
         "resources\/js\/Pages\/Admin\/_components\/WidgetCurador.tsx": {
-            "R1": 29
+            "R1": 33
         },
         "resources\/js\/Pages\/Admin\/_components\/WidgetCycles.tsx": {
             "R1": 11
@@ -662,8 +662,8 @@
         "resources\/js\/Pages\/OficinaAuto\/ProducaoOficina\/_components\/CacambaKanbanColumn.tsx": {
             "R1": 17
         },
-        "resources\/js\/Pages\/OficinaAuto\/ProducaoOficina\/_components\/CacambaProducaoSheet.tsx": {
-            "R1": 29
+        "resources\/js\/Pages\/OficinaAuto\/ProducaoOficina\/_components\/ServiceOrderRichSheet.tsx": {
+            "R1": 33
         },
         "resources\/js\/Pages\/OficinaAuto\/ProducaoOficina\/_components\/DragConfirmDialog.tsx": {
             "R1": 19
@@ -967,7 +967,7 @@
             "R1": 33
         },
         "resources\/js\/Pages\/StockTransfer\/Index.tsx": {
-            "R1": 29,
+            "R1": 33,
             "R4": 1
         },
         "resources\/js\/Pages\/superadmin\/Usuario360\/Show.tsx": {

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx
@@ -3,15 +3,15 @@
 // Espelha 1:1 protótipo Cowork rico:
 //   prototipo-ui/prototipos/producao-oficina/visual-source.html (1213 linhas — fonte canônica visual)
 // Adaptado pra caçambas (5 colunas: Disponível/Locada/Aguardando recolhimento/
-// Em manutenção/Pronta entrega) com 6 KPIs ricos + drawer próprio CacambaProducaoSheet.
+// Em manutenção/Pronta entrega) com 6 KPIs ricos + drawer próprio ServiceOrderRichSheet polimórfico.
 //
 // Refs:
 //   - ADR 0137 (OficinaAuto qualificada)
 //   - ADR 0143 (FSM Pipeline LIVE prod biz=1)
 //   - ADR 0110 (Cockpit V2 — AppShellV2 obrigatório)
 //   - PR #717 lição: useMemo/useCallback nos handlers descendentes (re-render loop)
-//   - ServiceOrderSheet existing (PR #729) — NÃO usado aqui (drawer próprio CacambaProducaoSheet
-//     embute ServiceOrderFsmActionPanel)
+//   - ServiceOrderSheet existing (PR #729) — NÃO usado aqui (drawer próprio ServiceOrderRichSheet
+//     embute ServiceOrderFsmActionPanel) — renomeado de CacambaProducaoSheet Wave 2.2 US-OFICINA-027
 // Visual comparison: memory/requisitos/OficinaAuto/producao-oficina-cacamba-visual-comparison.md (V2)
 
 import AppShellV2 from '@/Layouts/AppShellV2';
@@ -29,7 +29,7 @@ import { Input } from '@/Components/ui/input';
 import { Button } from '@/Components/ui/button';
 import CacambaKanbanColumn from './_components/CacambaKanbanColumn';
 import type { CacambaCardData, CacambaStatus } from './_components/CacambaCard';
-import CacambaProducaoSheet from './_components/CacambaProducaoSheet';
+import ServiceOrderRichSheet from './_components/ServiceOrderRichSheet';
 import KanbanDndProvider from './_components/KanbanDndProvider';
 import DragConfirmDialog, {
   type PendingTransition,
@@ -607,8 +607,9 @@ export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
         </main>
       </div>
 
-      {/* Drawer rico Caçamba — específico desta tela (embute FsmActionPanel reusado) */}
-      <CacambaProducaoSheet
+      {/* Drawer rico polimórfico (locação CNAE 4581 + manutenção CNAE 4520) — Wave 2.2 US-OFICINA-027
+          embute FsmActionPanel reusado · seção PEÇAS & MÃO DE OBRA consome data.items[] */}
+      <ServiceOrderRichSheet
         serviceOrderId={openOsId}
         open={openOsId !== null}
         onOpenChange={handleSheetOpenChange}

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/ServiceOrderRichSheet.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/ServiceOrderRichSheet.tsx
@@ -1,17 +1,28 @@
-// Drawer rico Caçamba — específico Produção · Oficina (NÃO confundir com ServiceOrderSheet
-// genérico em PR #729 — usado por listagem ServiceOrders/Vehicles).
+// ServiceOrderRichSheet — drawer rico polimórfico Produção · Oficina (origem
+// CacambaProducaoSheet pré-ADR 0194 — renomeado 2026-05-26 Wave 2.2 US-OFICINA-027).
 //
-// Espelha 1:1 protótipo Cowork canon `prototipo-ui/prototipos/producao-oficina/visual-source.html`
-// drawer rico (5 sections):
-//   1. Header com placa Mercosul size=md + KV grid (Cliente, Capacidade, Endereço, Atendente, Valor)
-//   2. OBSERVAÇÃO (rental.notes — italic se vazio)
-//   3. FOTOS & LAUDO — grid 3 placeholders aspect-square + botão "+ Adicionar foto" (V2 upload real)
-//   4. PIPELINE FSM — embed ServiceOrderFsmActionPanel (PR #729 existing — REUSO, não recria)
-//   5. LINHA DO TEMPO — placeholder skeleton (V2: fetch sale_stage_history)
+// Espelha 1:1 protótipo Cowork canon — locação caçamba CNAE 4581 hipotético
+// (`prototipo-ui/prototipos/producao-oficina/visual-source.html`) E protótipo OS
+// mecânica CNAE 4520 Martinho (screenshot Wagner 2026-05-26 · sub-vertical 4 ADR 0194).
 //
-// Footer: ações "Editar OS" / "Imprimir" / "Avançar etapa →" (CTA — embebido pelo FsmActionPanel).
+// 6 sections polimórficas (branching por `data.order_type`):
+//   1. Header KV grid:
+//        - locação: Cliente / Capacidade / Endereço / Diárias / Valor
+//        - manutenção: KM / Box / Mecânico / Valor (items_total) — ADR 0194 mecânica pesada
+//   2. OBSERVAÇÃO (notes — italic se vazio)
+//   3. PEÇAS & MÃO DE OBRA — NOVA Wave 2.3 (data.items[] consumindo `oficina_service_order_items`
+//      via US-OFICINA-027 backend). Renderiza linha-a-linha com ícones tipo + qty + valor unit
+//      + valor total. Footer da section: TOTAL OS.
+//   4. FOTOS & LAUDO — grid 3 placeholders aspect-square + "Adicionar foto" (disabled V2)
+//   5. PIPELINE FSM — embed ServiceOrderFsmActionPanel (REUSO PR #729, não recria)
+//   6. LINHA DO TEMPO — placeholder skeleton derivada (V2: fetch sale_stage_history real)
+//
+// Footer Wave 2.4: "Conversa cliente" (WhatsApp Linker) / "Imprimir OS" / "Avançar etapa" embedded.
 //
 // CRÍTICO React 19 — useMemo/useCallback nos handlers descendentes (lição PR #717).
+//
+// Consumidores: ProducaoOficina/Index.tsx — drawer abre ao clicar card kanban.
+// Multi-tenant Tier 0 [ADR 0093]: payload vem do endpoint show() que respeita global scope.
 
 import { useCallback, useEffect, useState } from 'react';
 import {
@@ -38,8 +49,27 @@ import {
 import { Button } from '@/Components/ui/button';
 import MercosulPlate from './MercosulPlate';
 import ServiceOrderFsmActionPanel from '../../ServiceOrders/_components/ServiceOrderFsmActionPanel';
+import { MessageCircle, Printer, Wrench, Package, UserCog } from 'lucide-react';
 
 type OrderType = 'locacao' | 'manutencao' | null;
+
+type ItemTipo = 'peca' | 'mao_obra' | 'servico_terceiro';
+
+interface ServiceOrderItemRel {
+  id: number;
+  tipo: ItemTipo;
+  descricao: string;
+  quantidade: number | string;
+  valor_unitario: number | string;
+  valor_total: number | string;
+  product_id: number | null;
+  notes: string | null;
+}
+
+interface AssignedUserRel {
+  id: number;
+  name: string;
+}
 
 interface ContactRel {
   id: number;
@@ -54,6 +84,9 @@ interface VehicleRel {
   vehicle_number?: string | null;
   vehicle_type?: string | null;
   capacity_m3?: number | string | null;
+  model_year?: number | null;
+  manufacture_year?: number | null;
+  color?: string | null;
 }
 
 interface ServiceOrderDetail {
@@ -74,6 +107,13 @@ interface ServiceOrderDetail {
   notes: string | null;
   vehicle: VehicleRel | null;
   contact: ContactRel | null;
+  // Wave 2.1 US-OFICINA-027 — campos modo manutenção (sub-vertical 4 ADR 0194)
+  box_label?: string | null;
+  assigned_user?: AssignedUserRel | null;
+  mileage_at_service?: number | null;
+  // Wave 2.3 US-OFICINA-027 — items lançados (peças + mão-de-obra + terceiros)
+  items?: ServiceOrderItemRel[];
+  items_total?: number | string;
   urls?: {
     edit?: string | null;
     show?: string | null;
@@ -116,7 +156,30 @@ const formatDateOnly = (iso: string | null | undefined) => {
   return `${d}/${m}/${y}`;
 };
 
-export default function CacambaProducaoSheet({
+const capitalize = (s: string | null | undefined) => {
+  if (!s) return '';
+  return s.charAt(0).toUpperCase() + s.slice(1).toLowerCase();
+};
+
+const ITEM_TIPO_LABEL: Record<ItemTipo, string> = {
+  peca: 'Peça',
+  mao_obra: 'Mão de obra',
+  servico_terceiro: 'Serviço terceiro',
+};
+
+const ITEM_TIPO_ICON: Record<ItemTipo, typeof Wrench> = {
+  peca: Package,
+  mao_obra: Wrench,
+  servico_terceiro: UserCog,
+};
+
+const toFloat = (value: number | string | null | undefined): number => {
+  if (value === null || value === undefined || value === '') return 0;
+  const n = typeof value === 'string' ? parseFloat(value) : value;
+  return Number.isNaN(n) ? 0 : n;
+};
+
+export default function ServiceOrderRichSheet({
   serviceOrderId,
   open,
   onOpenChange,
@@ -201,12 +264,27 @@ export default function CacambaProducaoSheet({
                 )}
               </div>
               <SheetTitle className="text-lg font-semibold tracking-tight text-foreground">
-                Caçamba {data.vehicle?.vehicle_number ?? data.vehicle?.plate ?? '—'}
-                {data.vehicle?.capacity_m3 ? (
-                  <span className="text-sm font-normal text-muted-foreground ml-1.5">
-                    · {data.vehicle.capacity_m3}m³
-                  </span>
-                ) : null}
+                {data.order_type === 'manutencao' ? (
+                  <>
+                    {data.vehicle?.vehicle_type ? capitalize(data.vehicle.vehicle_type) : 'Veículo'}
+                    {' '}
+                    {data.vehicle?.plate ?? '—'}
+                    {data.vehicle?.model_year ? (
+                      <span className="text-sm font-normal text-muted-foreground ml-1.5">
+                        · {data.vehicle.model_year}
+                      </span>
+                    ) : null}
+                  </>
+                ) : (
+                  <>
+                    Caçamba {data.vehicle?.vehicle_number ?? data.vehicle?.plate ?? '—'}
+                    {data.vehicle?.capacity_m3 ? (
+                      <span className="text-sm font-normal text-muted-foreground ml-1.5">
+                        · {data.vehicle.capacity_m3}m³
+                      </span>
+                    ) : null}
+                  </>
+                )}
               </SheetTitle>
               <SheetDescription className="text-sm text-muted-foreground">
                 {data.contact ? data.contact.name : 'Cliente não informado'}
@@ -216,49 +294,82 @@ export default function CacambaProducaoSheet({
             {/* Conteúdo scroll — 5 sections empilhadas */}
             <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
 
-              {/* ─── SEÇÃO 1: Veículo + KV grid (espelha .ofc-veh-card) ─── */}
+              {/* ─── SEÇÃO 1: Veículo + KV grid polimórfico (Wave 2.2 US-OFICINA-027) ───
+                  - manutenção (Martinho sub-vertical 4 CNAE 4520): KM / Box / Mecânico / Valor (items_total)
+                  - locação    (sub-vertical 3 hipotético CNAE 4581): Cliente / Capacidade / Endereço / Diárias / Valor */}
               {data.vehicle && (
                 <div className="rounded-lg border border-slate-200 bg-slate-50 p-3 grid grid-cols-[auto_1fr] gap-3">
                   <MercosulPlate plate={data.vehicle.plate} size="md" />
                   <dl className="grid grid-cols-[auto_1fr] gap-x-2.5 gap-y-1 text-[11.5px] self-end">
-                    {data.contact && (
+                    {data.order_type === 'manutencao' ? (
                       <>
-                        <dt className="text-muted-foreground">Cliente</dt>
-                        <dd className="text-foreground font-medium truncate">
-                          {data.contact.name}
+                        {data.mileage_at_service != null && (
+                          <>
+                            <dt className="text-muted-foreground">KM</dt>
+                            <dd className="text-foreground font-medium tabular-nums">
+                              {data.mileage_at_service.toLocaleString('pt-BR')}
+                            </dd>
+                          </>
+                        )}
+                        {data.box_label && (
+                          <>
+                            <dt className="text-muted-foreground">Box</dt>
+                            <dd className="text-foreground">{data.box_label}</dd>
+                          </>
+                        )}
+                        {data.assigned_user && (
+                          <>
+                            <dt className="text-muted-foreground">Mecânico</dt>
+                            <dd className="text-foreground">{data.assigned_user.name}</dd>
+                          </>
+                        )}
+                        <dt className="text-muted-foreground">Valor</dt>
+                        <dd className="tabular-nums font-semibold text-emerald-700">
+                          {formatBRL(data.items_total ?? 0)}
                         </dd>
                       </>
-                    )}
-                    {data.vehicle.capacity_m3 && (
+                    ) : (
                       <>
-                        <dt className="text-muted-foreground">Capacidade</dt>
+                        {data.contact && (
+                          <>
+                            <dt className="text-muted-foreground">Cliente</dt>
+                            <dd className="text-foreground font-medium truncate">
+                              {data.contact.name}
+                            </dd>
+                          </>
+                        )}
+                        {data.vehicle.capacity_m3 && (
+                          <>
+                            <dt className="text-muted-foreground">Capacidade</dt>
+                            <dd className="text-foreground tabular-nums">
+                              {data.vehicle.capacity_m3}m³
+                            </dd>
+                          </>
+                        )}
+                        {data.delivery_address && (
+                          <>
+                            <dt className="text-muted-foreground">Endereço</dt>
+                            <dd className="text-foreground truncate" title={data.delivery_address}>
+                              {data.delivery_address}
+                            </dd>
+                          </>
+                        )}
+                        <dt className="text-muted-foreground">Diárias</dt>
                         <dd className="text-foreground tabular-nums">
-                          {data.vehicle.capacity_m3}m³
+                          {data.dias_locacao ?? 0}d ×{' '}
+                          <span className="text-muted-foreground">{formatBRL(data.daily_rate)}</span>
+                        </dd>
+                        <dt className="text-muted-foreground">Valor</dt>
+                        <dd
+                          className={
+                            'tabular-nums font-semibold ' +
+                            (data.is_overdue ? 'text-rose-700' : 'text-emerald-700')
+                          }
+                        >
+                          {formatBRL(data.valor_receber)}
                         </dd>
                       </>
                     )}
-                    {data.delivery_address && (
-                      <>
-                        <dt className="text-muted-foreground">Endereço</dt>
-                        <dd className="text-foreground truncate" title={data.delivery_address}>
-                          {data.delivery_address}
-                        </dd>
-                      </>
-                    )}
-                    <dt className="text-muted-foreground">Diárias</dt>
-                    <dd className="text-foreground tabular-nums">
-                      {data.dias_locacao ?? 0}d ×{' '}
-                      <span className="text-muted-foreground">{formatBRL(data.daily_rate)}</span>
-                    </dd>
-                    <dt className="text-muted-foreground">Valor</dt>
-                    <dd
-                      className={
-                        'tabular-nums font-semibold ' +
-                        (data.is_overdue ? 'text-rose-700' : 'text-emerald-700')
-                      }
-                    >
-                      {formatBRL(data.valor_receber)}
-                    </dd>
                   </dl>
                 </div>
               )}
@@ -342,6 +453,61 @@ export default function CacambaProducaoSheet({
                 )}
               </Section>
 
+              {/* ─── SEÇÃO PEÇAS & MÃO DE OBRA (Wave 2.3 US-OFICINA-027) ───
+                  Consome `data.items[]` populado pelo endpoint ServiceOrderController::show()
+                  via relação ServiceOrder::items() (Wave 1.1). Lista peças + mão-de-obra +
+                  serviços terceiros lançados na OS com qty × valor_unitario = valor_total.
+                  Footer: TOTAL OS soma (espelha data.items_total backend) — alimentação direta
+                  do ServiceOrderObserver::computeFinalTotal (Wave 1.2). */}
+              <Section title="Peças & Mão de obra" icon={Package}>
+                {data.items && data.items.length > 0 ? (
+                  <>
+                    <ul className="divide-y divide-slate-100 border border-slate-200 rounded-md overflow-hidden bg-white">
+                      {data.items.map((item) => {
+                        const Icon = ITEM_TIPO_ICON[item.tipo];
+                        const qtd = toFloat(item.quantidade);
+                        const vu = toFloat(item.valor_unitario);
+                        const total = toFloat(item.valor_total);
+                        return (
+                          <li
+                            key={item.id}
+                            className="px-3 py-2 grid grid-cols-[auto_1fr_auto] gap-2 items-center text-[11.5px]"
+                          >
+                            <Icon size={14} className="text-muted-foreground shrink-0" aria-hidden />
+                            <div className="min-w-0">
+                              <div className="text-foreground font-medium truncate">
+                                {item.descricao}
+                              </div>
+                              <div className="text-muted-foreground text-[10.5px]">
+                                {ITEM_TIPO_LABEL[item.tipo]} · {qtd.toLocaleString('pt-BR', { maximumFractionDigits: 3 })}
+                                {' × '}
+                                {formatBRL(vu)}
+                              </div>
+                            </div>
+                            <div className="text-foreground tabular-nums font-medium">
+                              {formatBRL(total)}
+                            </div>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                    <div className="mt-2 flex items-center justify-between px-1">
+                      <span className="text-[10.5px] uppercase tracking-wider text-muted-foreground">
+                        Total OS
+                      </span>
+                      <span className="text-sm tabular-nums font-semibold text-emerald-700">
+                        {formatBRL(data.items_total ?? 0)}
+                      </span>
+                    </div>
+                  </>
+                ) : (
+                  <p className="text-sm italic text-muted-foreground">
+                    — nenhum item lançado ainda
+                    {data.order_type === 'manutencao' ? ' (cobrança não fechará automática)' : ''}
+                  </p>
+                )}
+              </Section>
+
               {/* ─── SEÇÃO 3: FOTOS & LAUDO (placeholders V2) ─── */}
               <Section title="Fotos & Laudo" icon={Camera}>
                 <div className="grid grid-cols-3 gap-1.5">
@@ -381,11 +547,33 @@ export default function CacambaProducaoSheet({
               </Section>
             </div>
 
-            {/* Footer ações sticky */}
+            {/* Footer ações sticky (Wave 2.4 US-OFICINA-027) ───
+                3 botões espelhando protótipo Cowork canon (screenshot Wagner 2026-05-26):
+                - "Conversa cliente" → wa.me direct link (LGPD: sem mensagem pré-formatada com PII)
+                - "Imprimir OS" → window.print() (CSS print stylesheet em V2 polish wave)
+                - "Editar OS" → fallback href edit (Avançar etapa fica no Pipeline FSM section, não duplica) */}
             <div className="border-t border-border px-6 py-3 bg-background flex items-center justify-end gap-2">
-              <Button size="sm" variant="ghost" disabled title="Imprimir OS — V2">
-                <FileText size={14} className="mr-1.5" />
-                Imprimir
+              {data.contact?.mobile && (
+                <Button size="sm" variant="ghost" asChild>
+                  <a
+                    href={`https://wa.me/${data.contact.mobile.replace(/\D/g, '')}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title="Abrir conversa WhatsApp com cliente"
+                  >
+                    <MessageCircle size={14} className="mr-1.5" />
+                    Conversa cliente
+                  </a>
+                </Button>
+              )}
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => window.print()}
+                title="Imprimir / Salvar PDF (Ctrl+P)"
+              >
+                <Printer size={14} className="mr-1.5" />
+                Imprimir OS
               </Button>
               {data.urls?.edit && (
                 <Button size="sm" asChild>


### PR DESCRIPTION
## Resumo executivo (3 bullets)

- **Destrava cobrança automática Martinho biz=164 CNAE 4520 mecânica pesada** ([ADR 0194](memory/decisions/0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada.md)) — `ServiceOrderObserver::computeFinalTotal` agora soma `oficina_service_order_items` em vez de hardcoded 0.0. Wagner para de editar Transaction manual cada OS.
- **Drawer rico polimórfico** espelha protótipo Cowork aprovado (screenshot Wagner 2026-05-26) — `CacambaProducaoSheet.tsx` → `ServiceOrderRichSheet.tsx` (git mv preserva blame) com seção nova "PEÇAS & MÃO DE OBRA" + footer Conversa cliente / Imprimir OS / Editar OS + KV grid polimórfico (manutenção KM/Box/Mecânico/Valor · locação preservada).
- **Wire-up apenas** — Wave 27 G1 + Wave 28 polish (Model `ServiceOrderItem` + Service `ServiceOrderItemService` + 10 Pest) já estavam em main. Este PR adiciona apenas a relação hasMany na entity pai, recalc Observer, HTTP layer (Controller + 2 FormRequest + 3 rotas), payload JSON, e drawer adaptação. ~1.091/-68 LOC, 12 arquivos.

## Wave 1 — Backend cobrança automática

| # | Entrega | LOC | Path |
|---|---|---:|---|
| 1.1 | `ServiceOrder::items()` hasMany + accessor `total_items` | ~15 | [Entities/ServiceOrder.php](Modules/OficinaAuto/Entities/ServiceOrder.php) |
| 1.2 | Observer recalc `final_total` manutenção via `items()->sum('valor_total')` | ~15 | [Observers/ServiceOrderObserver.php](Modules/OficinaAuto/Observers/ServiceOrderObserver.php) |
| 1.3 | `ServiceOrderItemController` CRUD + 2 FormRequest + 3 rotas throttle 60/1 | ~225 | [Http/Controllers/ServiceOrderItemController.php](Modules/OficinaAuto/Http/Controllers/ServiceOrderItemController.php) |
| 1.4 | 5 Pest specs Observer + HTTP + cross-tenant + cross-OS | ~235 | [Tests/Feature/ServiceOrderObserverItemsAndHttpTest.php](Modules/OficinaAuto/Tests/Feature/ServiceOrderObserverItemsAndHttpTest.php) |

## Wave 2 — Drawer rico polimórfico

| # | Entrega | LOC |
|---|---|---:|
| 2.1 | Migration aditiva `box_label` + `assigned_user_id` nullable (sem FK física pattern Wave 5-A) + Entity fillable/cast/`assignedUser()` belongsTo | ~75 |
| 2.2 | `git mv` CacambaProducaoSheet → ServiceOrderRichSheet (rename preserva blame) + SheetTitle polimórfico + função rename | ~50 |
| 2.3 | Seção "PEÇAS & MÃO DE OBRA" no drawer consumindo `data.items[]` + `ServiceOrderController::show()` JSON expandido (items + items_total + assigned_user + box_label + vehicle.model_year/color) | ~140 |
| 2.4 | Footer 3 botões: Conversa cliente (wa.me direct link) + Imprimir OS (window.print) + Editar OS (avançar etapa fica via FsmActionPanel section, não duplica) | ~40 |
| 2.5 | 3 Pest payload specs: items populated + items_total + sem items backward compat + assigned_user UPOS-canon concat | ~192 |

## Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)) — IRREVOGÁVEL preservado

- `business_id` derivado de `auth()->user()` (NUNCA request) no Controller
- Service `addItem` faz double-check cross-tenant (`OS não pertence ao business`) → 422
- Policy `update($order)` + global scope Model + `abort_unless($item->service_order_id === $order->id, 404)` (defesa cross-OS)
- 2 Pest specs explícitas multi-tenant guard (biz=1 user em OS biz=99 → 4xx; item de OS1 via URL OS2 → 404)

## ADRs preservados/referenciados

- [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md) — Multi-tenant Tier 0 IRREVOGÁVEL (preservado em todos novos endpoints)
- [ADR 0192](memory/decisions/0192-auto-faturar-os-venda-jobsheet-observer.md) — Auto-faturar OS→Venda Observer (recalc final_total agora cobre manutenção §"Critério validação")
- [ADR 0194](memory/decisions/0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada.md) — Domínio Martinho sub-vertical 4 CNAE 4520 mecânica pesada (vocabulário aplicado em comments)

## NÃO inclui (waves futuras catalogadas)

- **DVI Vistoria Digital** (screenshot Wagner: 8 ok / 2 atenção / 1 crítico) — feature nova ~24h IA-pair, schema `oa_inspection_items` + workflow approval + WhatsApp send. Wave 3 separada.
- **US-OFICINA-014 WhatsApp PIN aprovação** — 7h P0 já planejada ([ADR 0171](memory/decisions/0171-oficinaauto-ativacao-piloto-martinho-faseada.md)).
- **UI lançamento item via Edit.tsx** — drawer só MOSTRA items; lançamento via tinker/API até wave seguinte (UI mecânico campo lançando peça).
- **Tabela `boxes` estruturada** — MVP texto livre `box_label` (sem sinal qualificado ADR 0105).

## Test plan (manual pós-merge)

- [ ] Migration `2026_05_26_120001_add_box_and_assigned_user_to_service_orders` aplicada em prod biz=164
- [ ] Tinker biz=164 — criar OS manutenção, lançar 3 items (peça R$ 4800 + 3h mão-obra R$ 360 + serviço R$ 850), transicionar status='concluida', verificar `Transaction.final_total = 6010.00`
- [ ] Smoke browser MCP `/oficina-auto/producao-oficina` — abrir drawer de OS Martinho real, verificar KV grid manutenção (KM/Box/Mecânico/Valor) + seção PEÇAS & MO renderiza
- [ ] Pest local: `php artisan test --filter=ServiceOrderObserverItemsAndHttpTest && php artisan test --filter=ServiceOrderRichSheetPayloadTest`
- [ ] Confirmar que Pest Wave 27/28 continuam verdes (sem regressão)

🤖 Generated with [Claude Code](https://claude.com/claude-code)