### PR TITLE
fix(fiscal/a11y): double-RAF + blur trigger (hotfix 2.1.1)

### DIFF
--- a/resources/js/Pages/Fiscal/_components/_shared/DrawerBase.tsx
+++ b/resources/js/Pages/Fiscal/_components/_shared/DrawerBase.tsx
@@ -112,16 +112,26 @@ export default function DrawerBase({
     // Salva elemento ativo antes de focar dentro do drawer
     previousFocusRef.current = document.activeElement as HTMLElement | null;
 
-    // Foca primeiro focusable do drawer (ou o próprio aside como fallback)
+    // Foca primeiro focusable do drawer (ou o próprio aside como fallback).
+    // Double-RAF é necessário pq alguns triggers (button chip do PageHeader)
+    // mantêm foco após click via React commit tardio. Single RAF é cancelado
+    // por esse commit; double-RAF espera 2 paints e garante que aplique após
+    // toda a cascata de re-render.
     const aside = asideRef.current;
     if (aside) {
       const firstFocusable = aside.querySelector<HTMLElement>(FOCUSABLE_SELECTOR);
-      // requestAnimationFrame garante que o foco aplique após render completo
-      const raf = requestAnimationFrame(() => {
-        (firstFocusable ?? aside).focus({ preventScroll: true });
+      // Tira foco do trigger imediatamente — evita race com React focus-restore
+      previousFocusRef.current?.blur?.();
+      let raf1 = 0;
+      let raf2 = 0;
+      raf1 = requestAnimationFrame(() => {
+        raf2 = requestAnimationFrame(() => {
+          (firstFocusable ?? aside).focus({ preventScroll: true });
+        });
       });
       return () => {
-        cancelAnimationFrame(raf);
+        cancelAnimationFrame(raf1);
+        cancelAnimationFrame(raf2);
         // Cleanup ao fechar: restaura foco anterior (se ainda no DOM e visível)
         const prev = previousFocusRef.current;
         if (prev && document.body.contains(prev)) {


### PR DESCRIPTION
## Hotfix da Onda 2.1 (#1625)

Smoke prod 2026-05-26 detectou que focus trap aplicava só quando trigger não era focusable (NotaDrawer linha tr). Em EventosDrawer e SendToContabilDrawer (trigger button chip do PageHeader), foco permanecia no chip.

**Causa raiz:** single RAF era cancelado por React commit tardio que restaurava foco no trigger.

**Fix:**
1. \`previousFocusRef.current?.blur()\` imediato — tira foco do trigger ANTES de qualquer concorrência
2. **Double-RAF** aninhado — espera 2 paints antes de aplicar focus

Validado via JS:
- ANTES hotfix: \`document.activeElement = button[Eventos5]\` (chip trigger), \`inside aside: false\`
- Esperado após hotfix: \`document.activeElement = button[×]\` (primeiro focusable do drawer), \`inside aside: true\`

Diff: +15 / -5 LOC no DrawerBase.tsx.

Refs: hotfix #1625

🤖 Generated with [Claude Code](https://claude.com/claude-code)