### PR TITLE
fix(sells): botão Imprimir devolvia tela em branco em Show + drawer SaleSheet

### DIFF
--- a/resources/js/Lib/printSaleReceipt.ts
+++ b/resources/js/Lib/printSaleReceipt.ts
@@ -1,0 +1,60 @@
+// Helper compartilhado pra disparar impressão de recibo de venda.
+//
+// Necessário porque /sells/{id}/print (SellPosController::printInvoice) só
+// responde a requests AJAX (return $output dentro de `if (request()->ajax())`).
+// Abrir target="_blank" devolve tela em branco. Pattern legacy equivalente:
+// public/js/app.js a.print-invoice → __print_receipt (AJAX → inject html → window.print).
+//
+// Uso em Pages/Sells/Show.tsx + Pages/Sells/_components/SaleSheet.tsx.
+
+export interface PrintSaleReceiptOptions {
+  printUrl: string;
+  invoiceNo?: string | number;
+}
+
+export async function printSaleReceipt({ printUrl, invoiceNo }: PrintSaleReceiptOptions): Promise<void> {
+  const response = await fetch(printUrl, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+    credentials: 'same-origin',
+  });
+
+  const payload = await response.json().catch(() => null);
+  const htmlContent: string | undefined = payload?.receipt?.html_content;
+  if (!payload?.success || !htmlContent) {
+    const reason = typeof payload?.msg === 'string' ? payload.msg : 'Recibo indisponível';
+    throw new Error(reason);
+  }
+
+  const printWindow = window.open('', '_blank', 'width=820,height=900');
+  if (!printWindow) {
+    throw new Error('Bloqueador de pop-up impediu a impressão. Libere e tente de novo.');
+  }
+
+  const title =
+    (typeof payload?.receipt?.print_title === 'string' && payload.receipt.print_title) ||
+    (typeof payload?.print_title === 'string' && payload.print_title) ||
+    `Venda ${invoiceNo ?? ''}`.trim();
+
+  printWindow.document.open();
+  printWindow.document.write(
+    `<!DOCTYPE html><html><head><meta charset="utf-8"><title>${escapeHtml(title)}</title>` +
+      `<style>@media print{@page{margin:8mm;}}body{font-family:Arial,sans-serif;margin:0;padding:12px;}</style>` +
+      `</head><body>${htmlContent}` +
+      `<script>window.addEventListener('load',function(){setTimeout(function(){window.focus();window.print();},250);});<\/script>` +
+      `</body></html>`,
+  );
+  printWindow.document.close();
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/resources/js/Pages/Sells/Show.tsx
+++ b/resources/js/Pages/Sells/Show.tsx
@@ -8,7 +8,7 @@
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Deferred, Head, Link, router } from '@inertiajs/react';
-import { useEffect, type ReactNode } from 'react';
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import {
   ArrowLeft,
   CreditCard,
@@ -23,6 +23,7 @@ import {
 import KpiCard from '@/Components/shared/KpiCard';
 import EmptyState from '@/Components/shared/EmptyState';
 import { Button } from '@/Components/ui/button';
+import { printSaleReceipt } from '@/Lib/printSaleReceipt';
 
 interface Customer {
   id: number;
@@ -141,6 +142,23 @@ function DetailSkeleton() {
 
 export default function SellsShow(props: SellsShowPageProps) {
   const { headline, urls, permissions } = props;
+  const [isPrinting, setIsPrinting] = useState(false);
+
+  // /sells/{id}/print só responde a AJAX (SellPosController::printInvoice).
+  // Abrir <a target="_blank"> devolvia tela em branco — agora fetch + nova janela com window.print().
+  // Pattern equivalente ao legacy public/js/app.js:1656 (a.print-invoice → __print_receipt).
+  const handlePrint = useCallback(async () => {
+    if (!permissions.print || isPrinting) return;
+    setIsPrinting(true);
+    try {
+      await printSaleReceipt({ printUrl: urls.print, invoiceNo: headline.invoice_no });
+    } catch (err) {
+      console.error('Falha ao imprimir venda', err);
+      window.alert(err instanceof Error ? err.message : 'Erro ao gerar o recibo.');
+    } finally {
+      setIsPrinting(false);
+    }
+  }, [headline.invoice_no, isPrinting, permissions.print, urls.print]);
 
   // Atalhos teclado E (edit) + P (print) + Esc (back)
   useEffect(() => {
@@ -157,7 +175,7 @@ export default function SellsShow(props: SellsShowPageProps) {
       }
       if (e.key === 'p' && permissions.print) {
         e.preventDefault();
-        window.open(urls.print, '_blank');
+        handlePrint();
       }
       if (e.key === 'Escape') {
         e.preventDefault();
@@ -166,7 +184,7 @@ export default function SellsShow(props: SellsShowPageProps) {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [permissions.edit, permissions.print, urls.edit, urls.print, urls.back]);
+  }, [permissions.edit, permissions.print, urls.edit, urls.back, handlePrint]);
 
   const totalFalta = Math.max(0, headline.final_total - headline.total_paid);
   const paymentStatusLabel = PAYMENT_STATUS_LABEL[headline.payment_status] ?? headline.payment_status;
@@ -201,11 +219,9 @@ export default function SellsShow(props: SellsShowPageProps) {
 
           <div className="flex items-center gap-2">
             {permissions.print && (
-              <Button variant="outline" size="sm" asChild>
-                <a href={urls.print} target="_blank" rel="noopener noreferrer">
-                  <Printer className="h-4 w-4 mr-2" />
-                  Imprimir
-                </a>
+              <Button variant="outline" size="sm" onClick={handlePrint} disabled={isPrinting}>
+                <Printer className="h-4 w-4 mr-2" />
+                {isPrinting ? 'Gerando…' : 'Imprimir'}
               </Button>
             )}
             {permissions.edit && (

--- a/resources/js/Pages/Sells/_components/SaleSheet.tsx
+++ b/resources/js/Pages/Sells/_components/SaleSheet.tsx
@@ -38,6 +38,7 @@ import FiscalSection from './FiscalSection';
 import FsmActionPanel from './FsmActionPanel';
 import SaleTimeline from './SaleTimeline';
 import CriarOsButton from './CriarOsButton';
+import { printSaleReceipt } from '@/Lib/printSaleReceipt';
 // US-SELL-COWORK-R2-IA — painel ✦ IA do drawer (Cowork KB-9.75 Onda 2).
 // Toggle ON via botão ✦ no header; chama POST /sells/{id}/ai-ask (3 modos).
 import SaleAiPanel from './SaleAiPanel';
@@ -186,6 +187,8 @@ export default function SaleSheet({
   // US-SELL-COWORK-R4-DISTRIBUICAO — overlays transcript A4 + presentation fullscreen.
   const [transcriptOpen, setTranscriptOpen] = useState(false);
   const [presentationOpen, setPresentationOpen] = useState(false);
+  // /sells/{id}/print só responde a AJAX — target="_blank" devolvia tela branca.
+  const [isPrinting, setIsPrinting] = useState(false);
   // Sincroniza aiOpen quando muda saleId/initialAiOpen (entrada via ⌘K ✦).
   useEffect(() => {
     if (saleId != null && initialAiOpen) setAiOpen(true);
@@ -738,11 +741,25 @@ export default function SaleSheet({
                 <MonitorPlay size={14} className="mr-1.5" />
                 Apresentar
               </Button>
-              <Button variant="outline" size="sm" asChild>
-                <a href={data.urls.print} target="_blank" rel="noopener noreferrer">
-                  <Printer size={14} className="mr-1.5" />
-                  Imprimir
-                </a>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={isPrinting}
+                onClick={async () => {
+                  if (isPrinting) return;
+                  setIsPrinting(true);
+                  try {
+                    await printSaleReceipt({ printUrl: data.urls.print, invoiceNo: data.invoice_no });
+                  } catch (err) {
+                    console.error('Falha ao imprimir venda', err);
+                    window.alert(err instanceof Error ? err.message : 'Erro ao gerar o recibo.');
+                  } finally {
+                    setIsPrinting(false);
+                  }
+                }}
+              >
+                <Printer size={14} className="mr-1.5" />
+                {isPrinting ? 'Gerando…' : 'Imprimir'}
               </Button>
               <Button size="sm" asChild>
                 <a href={data.urls.edit}>


### PR DESCRIPTION
## Summary

- Endpoint `/sells/{id}/print` ([SellPosController::printInvoice](app/Http/Controllers/SellPosController.php#L1926)) só responde a requests AJAX. O botão Imprimir em [Show.tsx](resources/js/Pages/Sells/Show.tsx) e no drawer [SaleSheet.tsx](resources/js/Pages/Sells/_components/SaleSheet.tsx) usava `<a href={urls.print} target=\"_blank\">` (navegação HTML) — controller caía fora do `if (request()->ajax())` e devolvia tela em branco.
- Frontend agora faz `fetch` AJAX, recebe `receipt.html_content`, abre nova janela com o HTML e dispara `window.print()` via script inline. Pattern equivalente ao legacy [public/js/app.js:1656](public/js/app.js#L1656) (`a.print-invoice → __print_receipt`).
- Helper extraído pra `resources/js/Lib/printSaleReceipt.ts` evita drift entre a página completa Show e o drawer dentro do Index.

## Bug reproduzido em prod (pré-fix)

Clicar Imprimir em [Vendas → Show / Drawer SaleSheet] abria nova aba em `https://oimpresso.com/sells/{id}/print` totalmente branca (screenshot anexado na conversa).

## Fora de escopo (não consertar nesta PR)

Reportado junto: data do recibo aparece **+3h à frente**. **Não corrigido** porque é o bug intencional documentado em [memory/sessions/2026-04-24-revert-format-date-timezone.md](memory/sessions/2026-04-24-revert-format-date-timezone.md):
- Fix anterior (`10634ad2`) foi revertido (`e5c8c90d`) porque ROTA LIVRE reclamou que vendas "voltaram 3h pra trás".
- Comentário em [Util.php:301-308](app/Utils/Util.php#L301) explicita que o shift é intencional até plano de migração formal.
- Exige: levantamento por cliente + migration condicional + comunicação prévia + reaplicar `Carbon::parse` + ADR formal.

## Test plan

- [ ] Build Inertia (`npm run build:inertia`) sem erros novos
- [ ] Após merge + deploy: clicar **Imprimir** numa venda finalizada via drawer no `/sells` → nova janela abre com recibo
- [ ] Mesmo caminho via `/sells/{id}` (Show full page) + atalho `P`
- [ ] Sem pop-up bloqueado: receipt renderiza e `window.print()` dispara
- [ ] Com pop-up bloqueado: aparece alert "Bloqueador de pop-up impediu a impressão"

🤖 Generated with [Claude Code](https://claude.com/claude-code)