### PR TITLE
feat(oficinaauto): US-OFICINA-035 DVI Vistoria Digital schema + API

### DIFF
--- a/Modules/OficinaAuto/Database/Migrations/2026_05_26_120002_create_oa_inspection_items_table.php
+++ b/Modules/OficinaAuto/Database/Migrations/2026_05_26_120002_create_oa_inspection_items_table.php
@@ -1,0 +1,90 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Migration `oa_inspection_items` — DVI (Vistoria Digital · Digital Vehicle Inspection).
+ *
+ * Origem Wave 3 OficinaAuto (CAPTERRA-FICHA Repair gap #3 — wedge competitivo vs
+ * RepairShopr/mHelpDesk). Permite mecânico registrar itens vistoriados na OS
+ * com semáforo (ok / atencao / critico) + valor recomendado + foto opcional.
+ * Renderização visual aprovada por screenshot Wagner 2026-05-26: card "VISTORIA
+ * DIGITAL · DVI" com badges contadores + 5 items semáforo + bloco TOTAL.
+ *
+ * Schema:
+ * - categoria: 10 grupos cobrindo manutenção típica (motor/freios/correia/bateria/
+ *   pneus/suspensao/direcao/eletrica/fluidos/outro) — extensível futuramente
+ * - severity: ok | atencao | critico (semáforo verde/amarelo/vermelho)
+ * - valor_recomendado: R$ — usado pra soma "TOTAL RECOMENDADO" agregando
+ *   apenas itens severity IN (atencao, critico)
+ * - metadata json: extensão livre (vida_util_pct, km_restantes, voltagem, etc)
+ * - photo_url: foto vista do item (futuro: storage S3)
+ * - sort_order: ordem de display na lista (mecânico controla)
+ *
+ * Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)):
+ * `business_id` indexado + FK CASCADE pra business.
+ *
+ * Idempotência: `Schema::hasTable` guard pra rerun safe (padrão hotfix #639/#640).
+ *
+ * @see memory/requisitos/OficinaAuto/SPEC.md US-OFICINA-035
+ * @see memory/requisitos/Repair/CAPTERRA-FICHA.md gap #3 DVI
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        if (Schema::hasTable('oa_inspection_items')) {
+            return; // idempotente — rerun safe
+        }
+
+        Schema::create('oa_inspection_items', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            // int(10) unsigned bate com business.id (UltimatePOS legacy FK constraint)
+            $table->unsignedInteger('business_id');
+            $table->unsignedBigInteger('service_order_id');
+
+            // enum em vez de string pra forçar conformidade no nível DB
+            $table->enum('categoria', [
+                'motor',
+                'freios',
+                'correia',
+                'bateria',
+                'pneus',
+                'suspensao',
+                'direcao',
+                'eletrica',
+                'fluidos',
+                'outro',
+            ]);
+            $table->string('descricao', 150);
+            $table->enum('severity', ['ok', 'atencao', 'critico']);
+
+            $table->string('recomendacao', 255)->nullable();
+            $table->decimal('valor_recomendado', 10, 2)->nullable();
+
+            // metadata json livre: {"vida_util_pct": 60, "km_restantes": 4500, "voltagem": 12.4}
+            $table->json('metadata')->nullable();
+            $table->string('photo_url', 500)->nullable();
+
+            $table->smallInteger('sort_order')->default(0);
+
+            $table->timestamps();
+            $table->softDeletes(); // preserva audit append-only
+
+            $table->index(['business_id', 'service_order_id'], 'idx_oai_biz_so');
+            $table->index(['business_id', 'severity'], 'idx_oai_biz_sev');
+            $table->index(['service_order_id', 'sort_order'], 'idx_oai_so_sort');
+
+            $table->foreign('business_id', 'fk_oai_business')
+                  ->references('id')->on('business')->cascadeOnDelete();
+            $table->foreign('service_order_id', 'fk_oai_service_order')
+                  ->references('id')->on('service_orders')->cascadeOnDelete();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('oa_inspection_items');
+    }
+};

--- a/Modules/OficinaAuto/Entities/OaInspectionItem.php
+++ b/Modules/OficinaAuto/Entities/OaInspectionItem.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Entities;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Spatie\Activitylog\LogOptions;
+use Spatie\Activitylog\Traits\LogsActivity;
+
+/**
+ * OaInspectionItem — item DVI (Vistoria Digital) de uma Ordem de Serviço.
+ *
+ * Wave 3 OficinaAuto (US-OFICINA-035) — wedge competitivo vs RepairShopr/mHelpDesk
+ * CAPTERRA-FICHA Repair gap #3. Mecânico registra itens vistoriados com semáforo
+ * (verde/amarelo/vermelho) + recomendação + valor pra cliente aprovar via
+ * WhatsApp (integração com US-OFICINA-014 chega em Wave 3b).
+ *
+ * Schema: oa_inspection_items (migration 2026_05_26_120002).
+ *
+ * Multi-tenant Tier 0 ([ADR 0093]): global scope obrigatório.
+ *
+ * @property int          $id
+ * @property int          $business_id
+ * @property int          $service_order_id
+ * @property string       $categoria              motor|freios|correia|bateria|pneus|suspensao|direcao|eletrica|fluidos|outro
+ * @property string       $descricao
+ * @property string       $severity               ok | atencao | critico
+ * @property string|null  $recomendacao
+ * @property string|null  $valor_recomendado      decimal:2
+ * @property array|null   $metadata               json livre (vida_util_pct, km_restantes, voltagem...)
+ * @property string|null  $photo_url
+ * @property int          $sort_order
+ *
+ * @see memory/requisitos/OficinaAuto/SPEC.md US-OFICINA-035
+ */
+class OaInspectionItem extends Model
+{
+    use LogsActivity;
+    use SoftDeletes;
+
+    protected $table = 'oa_inspection_items';
+
+    public const SEVERITY_OK = 'ok';
+    public const SEVERITY_ATENCAO = 'atencao';
+    public const SEVERITY_CRITICO = 'critico';
+
+    public const SEVERITIES_VALIDAS = [
+        self::SEVERITY_OK,
+        self::SEVERITY_ATENCAO,
+        self::SEVERITY_CRITICO,
+    ];
+
+    /** Categorias enum espelhadas da migration. Extensível futuramente via migration ALTER. */
+    public const CATEGORIAS = [
+        'motor',
+        'freios',
+        'correia',
+        'bateria',
+        'pneus',
+        'suspensao',
+        'direcao',
+        'eletrica',
+        'fluidos',
+        'outro',
+    ];
+
+    /** Severidades que entram no "TOTAL RECOMENDADO · CLIENTE" (atencao + critico). */
+    public const SEVERIDADES_RECOMENDAVEIS = [
+        self::SEVERITY_ATENCAO,
+        self::SEVERITY_CRITICO,
+    ];
+
+    protected $fillable = [
+        'business_id',
+        'service_order_id',
+        'categoria',
+        'descricao',
+        'severity',
+        'recomendacao',
+        'valor_recomendado',
+        'metadata',
+        'photo_url',
+        'sort_order',
+    ];
+
+    protected $casts = [
+        'business_id'       => 'integer',
+        'service_order_id'  => 'integer',
+        'valor_recomendado' => 'decimal:2',
+        'metadata'          => 'array',
+        'sort_order'        => 'integer',
+    ];
+
+    // ------------------------------------------------------------------
+    // Global scope multi-tenant Tier 0 ([ADR 0093])
+    // ------------------------------------------------------------------
+
+    protected static function booted(): void
+    {
+        static::addGlobalScope('business_id', function (Builder $query) {
+            $businessId = session('user.business_id') ?? session('business.id');
+            if ($businessId !== null) {
+                $query->where('oa_inspection_items.business_id', $businessId);
+            }
+        });
+
+        static::creating(function (OaInspectionItem $row) {
+            if ($row->business_id === null) {
+                $row->business_id = session('user.business_id') ?? session('business.id') ?? 0;
+            }
+        });
+    }
+
+    // ------------------------------------------------------------------
+    // Relations
+    // ------------------------------------------------------------------
+
+    public function serviceOrder(): BelongsTo
+    {
+        return $this->belongsTo(ServiceOrder::class, 'service_order_id');
+    }
+
+    // ------------------------------------------------------------------
+    // Scopes
+    // ------------------------------------------------------------------
+
+    public function scopeOks(Builder $query): Builder
+    {
+        return $query->where('severity', self::SEVERITY_OK);
+    }
+
+    public function scopeAtencoes(Builder $query): Builder
+    {
+        return $query->where('severity', self::SEVERITY_ATENCAO);
+    }
+
+    public function scopeCriticas(Builder $query): Builder
+    {
+        return $query->where('severity', self::SEVERITY_CRITICO);
+    }
+
+    /** Items recomendáveis (atencao + critico) — entram no "TOTAL RECOMENDADO". */
+    public function scopeRecomendaveis(Builder $query): Builder
+    {
+        return $query->whereIn('severity', self::SEVERIDADES_RECOMENDAVEIS);
+    }
+
+    // ------------------------------------------------------------------
+    // LGPD audit trail (D7.b — Wave 14 pattern)
+    // ------------------------------------------------------------------
+
+    public function getActivitylogOptions(): LogOptions
+    {
+        return LogOptions::defaults()
+            ->logOnly([
+                'categoria',
+                'descricao',
+                'severity',
+                'recomendacao',
+                'valor_recomendado',
+                'sort_order',
+            ])
+            ->logOnlyDirty()
+            ->dontSubmitEmptyLogs()
+            ->useLogName('oficinaauto.dvi_inspection_item');
+    }
+}

--- a/Modules/OficinaAuto/Entities/ServiceOrder.php
+++ b/Modules/OficinaAuto/Entities/ServiceOrder.php
@@ -6,6 +6,7 @@ use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
@@ -135,6 +136,38 @@ class ServiceOrder extends Model
     public function contact(): BelongsTo
     {
         return $this->belongsTo(\App\Contact::class, 'contact_id');
+    }
+
+    /**
+     * Itens DVI (Vistoria Digital) — Wave 3 US-OFICINA-035.
+     *
+     * Global scope multi-tenant em OaInspectionItem garante isolamento Tier 0.
+     * Eager-load em show JSON quando UI Wave 3b consumir.
+     */
+    public function dviInspectionItems(): HasMany
+    {
+        return $this->hasMany(OaInspectionItem::class, 'service_order_id');
+    }
+
+    /**
+     * Breakdown DVI agregado pra UI card (8 ok · 2 atenção · 1 crítico + R$ total).
+     *
+     * Accessor evita re-execução de queries quando frontend lê duas vezes.
+     * NÃO eager pra evitar N+1 — usar explicitamente $order->dvi_breakdown depois
+     * de $order->load('dviInspectionItems') OU chamar DviInspectionService::breakdownPorSeverity.
+     *
+     * @return array{ok:int, atencao:int, critico:int, total_recomendado:float}
+     */
+    public function getDviBreakdownAttribute(): array
+    {
+        $items = $this->dviInspectionItems;
+
+        return [
+            'ok'                => $items->where('severity', 'ok')->count(),
+            'atencao'           => $items->where('severity', 'atencao')->count(),
+            'critico'           => $items->where('severity', 'critico')->count(),
+            'total_recomendado' => (float) $items->whereIn('severity', ['atencao', 'critico'])->sum('valor_recomendado'),
+        ];
     }
 
     // ------------------------------------------------------------------

--- a/Modules/OficinaAuto/Entities/ServiceOrder.php
+++ b/Modules/OficinaAuto/Entities/ServiceOrder.php
@@ -141,6 +141,7 @@ class ServiceOrder extends Model
         return $this->belongsTo(\App\Contact::class, 'contact_id');
     }
 
+    /**
      * Itens da OS (peças + mão-de-obra + serviços terceiros) — US-OFICINA-027.
      *
      * Schema `oficina_service_order_items` migrado git desde 2026-05-17 (Wave 27 G1),

--- a/Modules/OficinaAuto/Http/Controllers/DviInspectionController.php
+++ b/Modules/OficinaAuto/Http/Controllers/DviInspectionController.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Http\Controllers;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Modules\OficinaAuto\Entities\OaInspectionItem;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Http\Requests\StoreDviRequest;
+use Modules\OficinaAuto\Http\Requests\UpdateDviRequest;
+use Modules\OficinaAuto\Services\DviInspectionService;
+
+/**
+ * DviInspectionController — CRUD HTTP de itens DVI (Vistoria Digital).
+ *
+ * Wave 3 OficinaAuto US-OFICINA-035. JSON-only — UI vai consumir via fetch
+ * direto do drawer ServiceOrderRichSheet (Wave 3b futura, depende PR #1624).
+ *
+ * Endpoints (Routes/web.php):
+ *   POST   /oficina-auto/ordens-servico/{order}/dvi          → store (201)
+ *   PUT    /oficina-auto/ordens-servico/{order}/dvi/{item}   → update (200)
+ *   DELETE /oficina-auto/ordens-servico/{order}/dvi/{item}   → destroy (204)
+ *
+ * Defesa em profundidade:
+ *  1. Policy `update(ServiceOrder)` — Spatie permission + sameTenant guard ADR 0093
+ *  2. abort_unless cross-OS — item DEVE pertencer à OS da rota (proteção contra
+ *     /orders/1/dvi/{item_da_OS_2} mesmo dentro do mesmo business)
+ *
+ * @see memory/requisitos/OficinaAuto/SPEC.md US-OFICINA-035
+ */
+class DviInspectionController extends Controller
+{
+    public function __construct(private DviInspectionService $service)
+    {
+    }
+
+    /**
+     * Cria novo item DVI numa OS. 201 + payload do item criado.
+     */
+    public function store(StoreDviRequest $request, ServiceOrder $order): JsonResponse
+    {
+        // Policy: só quem pode editar a OS pode adicionar itens DVI (sameTenant guard).
+        $this->authorize('update', $order);
+
+        $item = $this->service->addItem(
+            (int) $order->business_id,
+            (int) $order->id,
+            $request->validated()
+        );
+
+        return response()->json([
+            'item' => $this->shapeItem($item),
+        ], 201);
+    }
+
+    /**
+     * Atualiza item DVI existente. 200 + payload atualizado.
+     */
+    public function update(UpdateDviRequest $request, ServiceOrder $order, OaInspectionItem $item): JsonResponse
+    {
+        $this->authorize('update', $order);
+
+        // Cross-OS guard: item PRECISA pertencer à OS da rota
+        abort_unless((int) $item->service_order_id === (int) $order->id, 404);
+
+        $item->fill($request->validated())->save();
+
+        return response()->json([
+            'item' => $this->shapeItem($item->fresh()),
+        ]);
+    }
+
+    /**
+     * Remove item DVI (soft delete). 204 sem body.
+     */
+    public function destroy(ServiceOrder $order, OaInspectionItem $item): JsonResponse
+    {
+        $this->authorize('update', $order);
+
+        abort_unless((int) $item->service_order_id === (int) $order->id, 404);
+
+        $item->delete();
+
+        return response()->json(null, 204);
+    }
+
+    /**
+     * Shape canônico de OaInspectionItem pra JSON API (espelha drawer V0).
+     *
+     * @return array{id:int, categoria:string, descricao:string, severity:string, recomendacao:string|null, valor_recomendado:float|null, metadata:array|null, photo_url:string|null, sort_order:int}
+     */
+    private function shapeItem(OaInspectionItem $item): array
+    {
+        return [
+            'id'                => (int) $item->id,
+            'categoria'         => (string) $item->categoria,
+            'descricao'         => (string) $item->descricao,
+            'severity'          => (string) $item->severity,
+            'recomendacao'      => $item->recomendacao,
+            'valor_recomendado' => $item->valor_recomendado !== null ? (float) $item->valor_recomendado : null,
+            'metadata'          => $item->metadata,
+            'photo_url'         => $item->photo_url,
+            'sort_order'        => (int) $item->sort_order,
+        ];
+    }
+}

--- a/Modules/OficinaAuto/Http/Requests/StoreDviRequest.php
+++ b/Modules/OficinaAuto/Http/Requests/StoreDviRequest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Modules\OficinaAuto\Entities\OaInspectionItem;
+
+/**
+ * D8 Security — FormRequest pra criação de item DVI.
+ *
+ * Wave 3 OficinaAuto US-OFICINA-035. authorize() casa com Policy update(OS) —
+ * só quem pode editar a OS pode adicionar itens DVI nela.
+ *
+ * Multi-tenant Tier 0 ([ADR 0093]): business_id derivado da sessão pelo Model creating()
+ * hook — request nunca pode injetar (proteção mass-assignment cross-tenant).
+ *
+ * @see Modules\OficinaAuto\Http\Controllers\DviInspectionController::store
+ * @see memory/requisitos/OficinaAuto/SPEC.md US-OFICINA-035
+ */
+class StoreDviRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+
+        if ($user === null) {
+            return false;
+        }
+
+        return $user->can('superadmin') || $user->can('oficinaauto.service_order.update');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'categoria'         => ['required', 'string', Rule::in(OaInspectionItem::CATEGORIAS)],
+            'descricao'         => ['required', 'string', 'max:150'],
+            'severity'          => ['required', 'string', Rule::in(OaInspectionItem::SEVERITIES_VALIDAS)],
+            'recomendacao'      => ['nullable', 'string', 'max:255'],
+            'valor_recomendado' => ['nullable', 'numeric', 'min:0'],
+            'metadata'          => ['nullable', 'array'],
+            'photo_url'         => ['nullable', 'string', 'max:500'],
+            'sort_order'        => ['nullable', 'integer', 'min:0'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'categoria.in'  => 'Categoria inválida. Permitidas: ' . implode(', ', OaInspectionItem::CATEGORIAS) . '.',
+            'severity.in'   => 'Severidade inválida. Permitidas: ok, atencao, critico.',
+            'descricao.required' => 'Descrição obrigatória.',
+        ];
+    }
+}

--- a/Modules/OficinaAuto/Http/Requests/UpdateDviRequest.php
+++ b/Modules/OficinaAuto/Http/Requests/UpdateDviRequest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Modules\OficinaAuto\Entities\OaInspectionItem;
+
+/**
+ * D8 Security — FormRequest pra update de item DVI.
+ *
+ * Wave 3 OficinaAuto US-OFICINA-035. Diff de StoreDviRequest: usa `sometimes` —
+ * permite PATCH parcial (UI atualiza só severity sem reenviar tudo).
+ *
+ * @see Modules\OficinaAuto\Http\Controllers\DviInspectionController::update
+ */
+class UpdateDviRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        $user = $this->user();
+
+        if ($user === null) {
+            return false;
+        }
+
+        return $user->can('superadmin') || $user->can('oficinaauto.service_order.update');
+    }
+
+    public function rules(): array
+    {
+        return [
+            'categoria'         => ['sometimes', 'required', 'string', Rule::in(OaInspectionItem::CATEGORIAS)],
+            'descricao'         => ['sometimes', 'required', 'string', 'max:150'],
+            'severity'          => ['sometimes', 'required', 'string', Rule::in(OaInspectionItem::SEVERITIES_VALIDAS)],
+            'recomendacao'      => ['nullable', 'string', 'max:255'],
+            'valor_recomendado' => ['nullable', 'numeric', 'min:0'],
+            'metadata'          => ['nullable', 'array'],
+            'photo_url'         => ['nullable', 'string', 'max:500'],
+            'sort_order'        => ['nullable', 'integer', 'min:0'],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'categoria.in' => 'Categoria inválida. Permitidas: ' . implode(', ', OaInspectionItem::CATEGORIAS) . '.',
+            'severity.in'  => 'Severidade inválida. Permitidas: ok, atencao, critico.',
+        ];
+    }
+}

--- a/Modules/OficinaAuto/Routes/web.php
+++ b/Modules/OficinaAuto/Routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Http\Controllers\ServiceOrderFsmActionController;
 use Illuminate\Support\Facades\Route;
+use Modules\OficinaAuto\Http\Controllers\DviInspectionController;
 use Modules\OficinaAuto\Http\Controllers\InstallController;
 use Modules\OficinaAuto\Http\Controllers\ProducaoOficinaController;
 use Modules\OficinaAuto\Http\Controllers\Public\AprovacaoOsController;
@@ -108,6 +109,26 @@ Route::middleware(['web', 'SetSessionData', 'auth', 'language', 'timezone', 'Adm
         Route::get('service-orders/{order}/history',
             [ServiceOrderFsmActionController::class, 'history'])
             ->name('oficinaauto.service_orders.history');
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Wave 3 — DVI (Vistoria Digital) US-OFICINA-035.
+        // CAPTERRA-FICHA Repair gap #3 — wedge competitivo vs RepairShopr/mHelpDesk.
+        // UI consumirá via fetch JSON em Wave 3b (depende drawer ServiceOrderRichSheet PR #1624).
+        // ─────────────────────────────────────────────────────────────────────
+        Route::post('ordens-servico/{order}/dvi',
+            [DviInspectionController::class, 'store'])
+            ->middleware('throttle:60,1')
+            ->name('oficinaauto.orders.dvi.store');
+
+        Route::put('ordens-servico/{order}/dvi/{item}',
+            [DviInspectionController::class, 'update'])
+            ->middleware('throttle:60,1')
+            ->name('oficinaauto.orders.dvi.update');
+
+        Route::delete('ordens-servico/{order}/dvi/{item}',
+            [DviInspectionController::class, 'destroy'])
+            ->middleware('throttle:60,1')
+            ->name('oficinaauto.orders.dvi.destroy');
     });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/Modules/OficinaAuto/SCOPE.md
+++ b/Modules/OficinaAuto/SCOPE.md
@@ -7,6 +7,7 @@ contains:
   - "ProducaoOficinaController"
   - "Public/AprovacaoOsController — endpoint público SEM auth pra cliente aprovar/rejeitar OS via link WhatsApp + PIN (US-OFICINA-006). Token HMAC carrega business_id assinado. Throttle:30,1 + lockout 5 tentativas PIN."
   - "ServiceOrderController"
+  - "DviInspectionController — CRUD HTTP de items DVI (Vistoria Digital · semáforo ok/atenção/crítico). Wave 3 US-OFICINA-035 — wedge competitivo vs RepairShopr/mHelpDesk."
   - "VehicleController"
   - "ServiceOrderFsmActionController (app/Http/Controllers — shared FSM canon, espelha SaleFsmActionController)"
 not_contains:

--- a/Modules/OficinaAuto/Services/DviInspectionService.php
+++ b/Modules/OficinaAuto/Services/DviInspectionService.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Services;
+
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use InvalidArgumentException;
+use Modules\OficinaAuto\Entities\OaInspectionItem;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+
+/**
+ * DviInspectionService — operações de domínio sobre itens DVI (Vistoria Digital).
+ *
+ * Wave 3 OficinaAuto (US-OFICINA-035). Espelha pattern ServiceOrderItemService:
+ * Service NÃO confia em session (defesa em profundidade) — business_id é parâmetro
+ * obrigatório explícito, conforme princípio multi-tenant Tier 0 ([ADR 0093]).
+ *
+ * Responsabilidades:
+ * - addItem: cria item validando business_id + categoria + severity + OS cross-tenant
+ * - breakdownPorSeverity: agrega contadores + total recomendado pra UI card DVI
+ * - totalRecomendado: soma valor_recomendado WHERE severity IN (atencao, critico)
+ * - listarOrdenado: lista ordenada (critico → atencao → ok, depois sort_order)
+ *
+ * @see memory/requisitos/OficinaAuto/SPEC.md US-OFICINA-035
+ */
+class DviInspectionService
+{
+    /**
+     * Adiciona item DVI a uma OS.
+     *
+     * @param  int  $businessId  obrigatório (defesa em profundidade — Service NÃO confia em session)
+     * @param  int  $serviceOrderId  ServiceOrder.id
+     * @param  array{categoria:string, descricao:string, severity:string, recomendacao?:string|null, valor_recomendado?:float|string|null, metadata?:array|null, photo_url?:string|null, sort_order?:int}  $data
+     *
+     * @throws InvalidArgumentException  se categoria/severity inválida OU OS não pertence ao biz
+     */
+    public function addItem(int $businessId, int $serviceOrderId, array $data): OaInspectionItem
+    {
+        if ($businessId <= 0) {
+            throw new InvalidArgumentException('business_id obrigatório (Tier 0 ADR 0093)');
+        }
+
+        $categoria = $data['categoria'] ?? null;
+        if (! in_array($categoria, OaInspectionItem::CATEGORIAS, true)) {
+            throw new InvalidArgumentException(
+                "categoria inválida: '{$categoria}'. Permitidas: " . implode(', ', OaInspectionItem::CATEGORIAS)
+            );
+        }
+
+        $severity = $data['severity'] ?? null;
+        if (! in_array($severity, OaInspectionItem::SEVERITIES_VALIDAS, true)) {
+            throw new InvalidArgumentException(
+                "severity inválida: '{$severity}'. Permitidas: " . implode(', ', OaInspectionItem::SEVERITIES_VALIDAS)
+            );
+        }
+
+        $descricao = trim((string) ($data['descricao'] ?? ''));
+        if ($descricao === '') {
+            throw new InvalidArgumentException('descricao obrigatória');
+        }
+
+        // Valida OS pertence ao business (defesa contra cross-tenant)
+        $osPertenceAoBiz = ServiceOrder::withoutGlobalScopes() // SUPERADMIN: check cross-tenant
+            ->where('id', $serviceOrderId)
+            ->where('business_id', $businessId)
+            ->exists();
+
+        if (! $osPertenceAoBiz) {
+            throw new InvalidArgumentException(
+                "ServiceOrder #{$serviceOrderId} não existe OU não pertence ao business {$businessId}"
+            );
+        }
+
+        return OaInspectionItem::withoutGlobalScopes()->create([
+            'business_id'        => $businessId,
+            'service_order_id'   => $serviceOrderId,
+            'categoria'          => $categoria,
+            'descricao'          => $descricao,
+            'severity'           => $severity,
+            'recomendacao'       => $data['recomendacao'] ?? null,
+            'valor_recomendado'  => isset($data['valor_recomendado']) ? (float) $data['valor_recomendado'] : null,
+            'metadata'           => $data['metadata'] ?? null,
+            'photo_url'          => $data['photo_url'] ?? null,
+            'sort_order'         => (int) ($data['sort_order'] ?? 0),
+        ]);
+    }
+
+    /**
+     * Breakdown agregado pra UI card DVI ("8 ok · 2 atenção · 1 crítico" + total).
+     *
+     * @return array{ok:int, atencao:int, critico:int, total_recomendado:float}
+     */
+    public function breakdownPorSeverity(int $serviceOrderId): array
+    {
+        $rows = OaInspectionItem::withoutGlobalScopes() // SUPERADMIN: agregado controlado por OS
+            ->where('service_order_id', $serviceOrderId)
+            ->whereNull('deleted_at')
+            ->select('severity', DB::raw('COUNT(*) AS total'), DB::raw('SUM(valor_recomendado) AS soma'))
+            ->groupBy('severity')
+            ->get()
+            ->keyBy('severity');
+
+        $ok = (int) ($rows[OaInspectionItem::SEVERITY_OK]->total ?? 0);
+        $atencao = (int) ($rows[OaInspectionItem::SEVERITY_ATENCAO]->total ?? 0);
+        $critico = (int) ($rows[OaInspectionItem::SEVERITY_CRITICO]->total ?? 0);
+
+        $totalRecomendado = round(
+            (float) ($rows[OaInspectionItem::SEVERITY_ATENCAO]->soma ?? 0)
+            + (float) ($rows[OaInspectionItem::SEVERITY_CRITICO]->soma ?? 0),
+            2
+        );
+
+        return [
+            'ok'                => $ok,
+            'atencao'           => $atencao,
+            'critico'           => $critico,
+            'total_recomendado' => $totalRecomendado,
+        ];
+    }
+
+    /**
+     * Soma valor_recomendado de itens severity IN (atencao, critico).
+     * Cross-business safe (filtro explícito por OS, OS já carrega business_id).
+     */
+    public function totalRecomendado(int $serviceOrderId): float
+    {
+        $total = OaInspectionItem::withoutGlobalScopes()
+            ->where('service_order_id', $serviceOrderId)
+            ->whereIn('severity', OaInspectionItem::SEVERIDADES_RECOMENDAVEIS)
+            ->whereNull('deleted_at')
+            ->sum('valor_recomendado');
+
+        return round((float) $total, 2);
+    }
+
+    /**
+     * Lista itens ordenados — critico → atencao → ok, depois sort_order ASC.
+     *
+     * Pra UI card DVI mostrar criticos no topo (lê primeiro o que importa).
+     */
+    public function listarOrdenado(int $serviceOrderId): Collection
+    {
+        return OaInspectionItem::withoutGlobalScopes()
+            ->where('service_order_id', $serviceOrderId)
+            ->whereNull('deleted_at')
+            // MySQL ORDER BY FIELD: ordem custom (critico=1, atencao=2, ok=3)
+            ->orderByRaw("FIELD(severity, 'critico', 'atencao', 'ok')")
+            ->orderBy('sort_order')
+            ->orderBy('id')
+            ->get();
+    }
+}

--- a/Modules/OficinaAuto/Tests/Feature/DviInspectionItemTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/DviInspectionItemTest.php
@@ -1,0 +1,283 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\OficinaAuto\Entities\OaInspectionItem;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+use Modules\OficinaAuto\Services\DviInspectionService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Wave 3 — Smoke DVI (Vistoria Digital) US-OFICINA-035.
+ *
+ * Tests biz=1 conforme ADR 0101 (biz=99 só usado pra isolamento cross-tenant).
+ * Espelha padrão ServiceOrderItemTest (Wave 27 G1).
+ *
+ * @see Modules/OficinaAuto/Entities/OaInspectionItem.php
+ * @see Modules/OficinaAuto/Services/DviInspectionService.php
+ * @see Modules/OficinaAuto/Http/Controllers/DviInspectionController.php
+ */
+
+const BIZ_DVI = 1;
+const BIZ_DVI_OUTRO = 99;
+const PLATE_DVI_PREFIX = 'WDVI';
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasTable('oa_inspection_items')) {
+        $this->markTestSkipped('Rode migration 2026_05_26_120002_create_oa_inspection_items_table primeiro');
+    }
+});
+
+function dvi_criaOs(string $suffix, int $biz = BIZ_DVI): ServiceOrder
+{
+    $vehicle = Vehicle::withoutGlobalScopes()->create([
+        'business_id'  => $biz,
+        'plate'        => PLATE_DVI_PREFIX . $suffix,
+        'vehicle_type' => 'automovel',
+    ]);
+
+    return ServiceOrder::withoutGlobalScopes()->create([
+        'business_id' => $biz,
+        'vehicle_id'  => $vehicle->id,
+        'status'      => 'aberta',
+    ]);
+}
+
+function dvi_cleanup(string $suffix): void
+{
+    $vehicles = Vehicle::withoutGlobalScopes()
+        ->where('plate', PLATE_DVI_PREFIX . $suffix)
+        ->pluck('id')
+        ->toArray();
+
+    if (! empty($vehicles)) {
+        $osIds = ServiceOrder::withoutGlobalScopes()
+            ->whereIn('vehicle_id', $vehicles)
+            ->pluck('id')
+            ->toArray();
+
+        if (! empty($osIds)) {
+            OaInspectionItem::withoutGlobalScopes()->whereIn('service_order_id', $osIds)->forceDelete();
+            ServiceOrder::withoutGlobalScopes()->whereIn('id', $osIds)->forceDelete();
+        }
+
+        Vehicle::withoutGlobalScopes()->whereIn('id', $vehicles)->forceDelete();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entity tests — CRUD + global scope
+// ---------------------------------------------------------------------------
+
+it('cria OaInspectionItem com auto-set business_id via creating hook', function () {
+    session(['user.business_id' => BIZ_DVI]);
+    $os = dvi_criaOs('A');
+
+    $item = OaInspectionItem::withoutGlobalScopes()->create([
+        'business_id'      => BIZ_DVI,
+        'service_order_id' => $os->id,
+        'categoria'        => 'motor',
+        'descricao'        => 'Motor · óleo + filtro',
+        'severity'         => OaInspectionItem::SEVERITY_OK,
+        'metadata'         => ['km_restantes' => 4500],
+    ]);
+
+    expect($item->id)->toBeGreaterThan(0);
+    expect($item->business_id)->toBe(BIZ_DVI);
+    expect($item->severity)->toBe('ok');
+    expect($item->metadata)->toBe(['km_restantes' => 4500]);
+})->afterEach(fn () => dvi_cleanup('A'));
+
+it('escopa por business_id global scope (biz=99 não enxerga itens biz=1)', function () {
+    session(['user.business_id' => BIZ_DVI]);
+    $os = dvi_criaOs('B', BIZ_DVI);
+    OaInspectionItem::withoutGlobalScopes()->create([
+        'business_id'      => BIZ_DVI,
+        'service_order_id' => $os->id,
+        'categoria'        => 'freios',
+        'descricao'        => 'Pastilhas dianteiras 3mm',
+        'severity'         => OaInspectionItem::SEVERITY_ATENCAO,
+        'valor_recomendado' => 145.00,
+    ]);
+
+    // Switch session pra biz=99 — global scope deve esconder
+    session(['user.business_id' => BIZ_DVI_OUTRO]);
+    $visiveis = OaInspectionItem::where('service_order_id', $os->id)->get();
+    expect($visiveis)->toHaveCount(0);
+
+    // SUPERADMIN bypass mostra
+    $todos = OaInspectionItem::withoutGlobalScopes()->where('service_order_id', $os->id)->get();
+    expect($todos)->toHaveCount(1);
+})->afterEach(fn () => dvi_cleanup('B'));
+
+// ---------------------------------------------------------------------------
+// Service tests
+// ---------------------------------------------------------------------------
+
+it('Service::addItem cria item válido e respeita severity', function () {
+    session(['user.business_id' => BIZ_DVI]);
+    $os = dvi_criaOs('C');
+    $service = new DviInspectionService();
+
+    $item = $service->addItem(BIZ_DVI, $os->id, [
+        'categoria'         => 'correia',
+        'descricao'         => 'Correia dentada · trincada',
+        'severity'          => OaInspectionItem::SEVERITY_CRITICO,
+        'recomendacao'      => 'recomenda troca imediata',
+        'valor_recomendado' => 480.00,
+        'metadata'          => ['mao_obra_horas' => 2],
+    ]);
+
+    expect($item->id)->toBeGreaterThan(0);
+    expect($item->severity)->toBe('critico');
+    expect((float) $item->valor_recomendado)->toBe(480.00);
+})->afterEach(fn () => dvi_cleanup('C'));
+
+it('Service::addItem rejeita categoria inválida', function () {
+    session(['user.business_id' => BIZ_DVI]);
+    $os = dvi_criaOs('D');
+    $service = new DviInspectionService();
+
+    expect(fn () => $service->addItem(BIZ_DVI, $os->id, [
+        'categoria' => 'inexistente',
+        'descricao' => 'X',
+        'severity'  => OaInspectionItem::SEVERITY_OK,
+    ]))->toThrow(InvalidArgumentException::class, "categoria inválida");
+})->afterEach(fn () => dvi_cleanup('D'));
+
+it('Service::addItem rejeita severity inválida', function () {
+    session(['user.business_id' => BIZ_DVI]);
+    $os = dvi_criaOs('E');
+    $service = new DviInspectionService();
+
+    expect(fn () => $service->addItem(BIZ_DVI, $os->id, [
+        'categoria' => 'motor',
+        'descricao' => 'X',
+        'severity'  => 'amarelo', // inválido
+    ]))->toThrow(InvalidArgumentException::class, "severity inválida");
+})->afterEach(fn () => dvi_cleanup('E'));
+
+it('Service::addItem rejeita OS de outro business (cross-tenant defense)', function () {
+    session(['user.business_id' => BIZ_DVI]);
+    $osBiz99 = dvi_criaOs('F', BIZ_DVI_OUTRO);
+    $service = new DviInspectionService();
+
+    expect(fn () => $service->addItem(BIZ_DVI, $osBiz99->id, [
+        'categoria' => 'motor',
+        'descricao' => 'X',
+        'severity'  => OaInspectionItem::SEVERITY_OK,
+    ]))->toThrow(InvalidArgumentException::class, 'não pertence ao business');
+})->afterEach(fn () => dvi_cleanup('F'));
+
+it('Service::breakdownPorSeverity retorna agregados corretos (5 items mistos)', function () {
+    session(['user.business_id' => BIZ_DVI]);
+    $os = dvi_criaOs('G');
+    $service = new DviInspectionService();
+
+    // 2 OK
+    $service->addItem(BIZ_DVI, $os->id, ['categoria' => 'motor', 'descricao' => 'M1', 'severity' => 'ok']);
+    $service->addItem(BIZ_DVI, $os->id, ['categoria' => 'bateria', 'descricao' => 'B1', 'severity' => 'ok']);
+    // 2 atencao com valor
+    $service->addItem(BIZ_DVI, $os->id, ['categoria' => 'freios', 'descricao' => 'F1', 'severity' => 'atencao', 'valor_recomendado' => 145.00]);
+    $service->addItem(BIZ_DVI, $os->id, ['categoria' => 'pneus', 'descricao' => 'P1', 'severity' => 'atencao', 'valor_recomendado' => 1200.00]);
+    // 1 critico com valor
+    $service->addItem(BIZ_DVI, $os->id, ['categoria' => 'correia', 'descricao' => 'C1', 'severity' => 'critico', 'valor_recomendado' => 480.00]);
+
+    $bd = $service->breakdownPorSeverity($os->id);
+    expect($bd['ok'])->toBe(2);
+    expect($bd['atencao'])->toBe(2);
+    expect($bd['critico'])->toBe(1);
+    expect($bd['total_recomendado'])->toBe(1825.00); // 145 + 1200 + 480
+})->afterEach(fn () => dvi_cleanup('G'));
+
+it('Service::totalRecomendado soma apenas atencao + critico (ignora ok)', function () {
+    session(['user.business_id' => BIZ_DVI]);
+    $os = dvi_criaOs('H');
+    $service = new DviInspectionService();
+
+    $service->addItem(BIZ_DVI, $os->id, ['categoria' => 'motor', 'descricao' => 'M', 'severity' => 'ok', 'valor_recomendado' => 999.99]); // não conta
+    $service->addItem(BIZ_DVI, $os->id, ['categoria' => 'freios', 'descricao' => 'F', 'severity' => 'atencao', 'valor_recomendado' => 100.00]);
+    $service->addItem(BIZ_DVI, $os->id, ['categoria' => 'correia', 'descricao' => 'C', 'severity' => 'critico', 'valor_recomendado' => 250.50]);
+
+    expect($service->totalRecomendado($os->id))->toBe(350.50);
+})->afterEach(fn () => dvi_cleanup('H'));
+
+it('Service::listarOrdenado coloca críticos no topo', function () {
+    session(['user.business_id' => BIZ_DVI]);
+    $os = dvi_criaOs('I');
+    $service = new DviInspectionService();
+
+    $service->addItem(BIZ_DVI, $os->id, ['categoria' => 'motor', 'descricao' => 'OK1', 'severity' => 'ok']);
+    $service->addItem(BIZ_DVI, $os->id, ['categoria' => 'correia', 'descricao' => 'CRIT', 'severity' => 'critico']);
+    $service->addItem(BIZ_DVI, $os->id, ['categoria' => 'freios', 'descricao' => 'ATE', 'severity' => 'atencao']);
+
+    $rows = $service->listarOrdenado($os->id);
+    expect($rows->pluck('severity')->all())->toBe(['critico', 'atencao', 'ok']);
+})->afterEach(fn () => dvi_cleanup('I'));
+
+// ---------------------------------------------------------------------------
+// HTTP Controller tests — store + cross-OS guard
+// ---------------------------------------------------------------------------
+
+it('HTTP POST cria item DVI 201 com payload correto (autenticado superadmin)', function () {
+    session(['user.business_id' => BIZ_DVI]);
+    $user = \App\User::withoutGlobalScopes()->where('business_id', BIZ_DVI)->first();
+    if ($user === null) {
+        $this->markTestSkipped('Sem user disponível em biz=1 pra testar HTTP');
+    }
+
+    $os = dvi_criaOs('J');
+    $resp = $this->actingAs($user)->postJson(
+        "/oficina-auto/ordens-servico/{$os->id}/dvi",
+        [
+            'categoria'         => 'freios',
+            'descricao'         => 'Pastilhas dianteiras 3mm',
+            'severity'          => 'atencao',
+            'recomendacao'      => 'trocar em 5.000 km',
+            'valor_recomendado' => 145.00,
+            'metadata'          => ['vida_util_pct' => 60],
+        ]
+    );
+
+    $resp->assertStatus(201);
+    $resp->assertJsonPath('item.severity', 'atencao');
+    $resp->assertJsonPath('item.categoria', 'freios');
+    $resp->assertJsonPath('item.valor_recomendado', 145.00);
+})->afterEach(fn () => dvi_cleanup('J'));
+
+it('HTTP PUT cross-OS guard: item de OS diferente retorna 404', function () {
+    session(['user.business_id' => BIZ_DVI]);
+    $user = \App\User::withoutGlobalScopes()->where('business_id', BIZ_DVI)->first();
+    if ($user === null) {
+        $this->markTestSkipped('Sem user disponível em biz=1');
+    }
+
+    // Cria 2 OS biz=1, item pertence ao OS-K1, tenta atualizar via rota OS-K2
+    $os1 = dvi_criaOs('K1');
+    $os2 = dvi_criaOs('K2');
+
+    $item = OaInspectionItem::withoutGlobalScopes()->create([
+        'business_id'      => BIZ_DVI,
+        'service_order_id' => $os1->id,
+        'categoria'        => 'motor',
+        'descricao'        => 'X',
+        'severity'         => 'ok',
+    ]);
+
+    $resp = $this->actingAs($user)->putJson(
+        "/oficina-auto/ordens-servico/{$os2->id}/dvi/{$item->id}",
+        ['severity' => 'critico']
+    );
+
+    $resp->assertStatus(404);
+})->afterEach(function () {
+    dvi_cleanup('K1');
+    dvi_cleanup('K2');
+});

--- a/memory/requisitos/OficinaAuto/SPEC.md
+++ b/memory/requisitos/OficinaAuto/SPEC.md
@@ -1,6 +1,8 @@
 ---
 module: OficinaAuto
-status: em-construcao
+version: 0.1.0
+last_updated: 2026-05-26
+status: ativo
 lifecycle: ativo
 piloto: Vargas + Martinho (sinal qualificado em ADR 0137 — 2 de 4 candidatos OfficeImpresso saudáveis são oficina/recapagem)
 piloto_previsao: V0 scaffold 2026-05-11 (PR US-OFICINA-001); V1 importer Martinho Sprint 2+
@@ -9,12 +11,16 @@ cnaes_cobertos: ["4520-0/01", "2212-9/00", "4581-4/00"]
 related_adrs: [0137, 0121, 0094, 0093, 0105, 0106, 0035, 0011, 0089, 0119, 0129]
 related_proposals: [proposals/gap-repair-vs-oficina-auto.md]
 last_review: 2026-05-26
-owner: [W]
+owners: [W]
 ---
 
 # Especificação funcional — Modules/OficinaAuto
 
 > ⚠️ **STATUS ATUALIZADO 2026-05-11** — [ADR 0137](../../decisions/0137-modules-oficinaauto-qualificada.md) (`amends` 0121) qualifica `Modules/OficinaAuto` como **em construção** baseado em sinal qualificado (Vargas + Martinho — 50% sample OfficeImpresso saudável). Seções §1-§13 abaixo são do SPEC antecipatório original (2026-05-10) — preservadas como contexto estratégico (concorrentes, posicionamento, pricing). A tabela de US **ativas** é a §V0 logo abaixo. Esquema técnico canônico está em ADR 0137 §"Escopo arquitetural V0".
+
+## US ativas
+
+Ver §V0 logo abaixo — convenção `US-OFICINA-NNN` ([ADR 0134](../../decisions/0134-tasks-create-respeita-spec-placeholders.md)).
 
 ## V0 — Scaffold ativo (US-OFICINA-NNN)
 

--- a/memory/requisitos/OficinaAuto/SPEC.md
+++ b/memory/requisitos/OficinaAuto/SPEC.md
@@ -6,8 +6,8 @@ status: ativo
 lifecycle: ativo
 piloto: Vargas + Martinho (sinal qualificado em ADR 0137 — 2 de 4 candidatos OfficeImpresso saudáveis são oficina/recapagem)
 piloto_previsao: V0 scaffold 2026-05-11 (PR US-OFICINA-001); V1 importer Martinho Sprint 2+
-cnae_principal: "4520-0/01" (serviços de manutenção e reparação mecânica de veículos automotores)
-cnaes_cobertos: ["4520-0/01", "2212-9/00", "4581-4/00"]
+cnae_principal: '4520-0/01 (serviços de manutenção e reparação mecânica de veículos automotores)'
+cnaes_cobertos: ['4520-0/01', '2212-9/00', '4581-4/00']
 related_adrs: [0137, 0121, 0094, 0093, 0105, 0106, 0035, 0011, 0089, 0119, 0129]
 related_proposals: [proposals/gap-repair-vs-oficina-auto.md]
 last_review: 2026-05-26

--- a/memory/requisitos/OficinaAuto/SPEC.md
+++ b/memory/requisitos/OficinaAuto/SPEC.md
@@ -8,7 +8,7 @@ cnae_principal: "4520-0/01" (serviços de manutenção e reparação mecânica d
 cnaes_cobertos: ["4520-0/01", "2212-9/00", "4581-4/00"]
 related_adrs: [0137, 0121, 0094, 0093, 0105, 0106, 0035, 0011, 0089, 0119, 0129]
 related_proposals: [proposals/gap-repair-vs-oficina-auto.md]
-last_review: 2026-05-11
+last_review: 2026-05-26
 owner: [W]
 ---
 
@@ -1247,6 +1247,29 @@ Quando os pré-requisitos forem satisfeitos, **abrir ADR canon** "OficinaAuto-at
 - Sindirepa-SP TAM R$ 128bi/2022 — https://rafamarrafon.com.br/oicinas-mecanicas-faturam-128-bilhoes-em-2022/
 - CINAU 121k oficinas BR — https://oficinabrasil.com.br/noticia/mercado-cinau/dimensoes-do-mercado-de-reposicao-quem-somos-onde-estamos-e-quanto-representamos
 
+### US-OFICINA-035 · DVI (Vistoria Digital · Digital Vehicle Inspection) schema + API — **P1**
+
+> owner: — · priority: p1 · estimate: 4h (IA-pair fator 10x ADR 0106) · status: in-progress (backend done) · type: story · origin: Wave 3 OficinaAuto · 2026-05-26
+> blocked_by: —
+> blocks: Wave 3b (UI integration drawer ServiceOrderRichSheet — depende PR #1624) · WhatsApp "Enviar p/ cliente" (depende US-OFICINA-014 PR #1627)
+
+Wedge competitivo vs RepairShopr/mHelpDesk catalogado em [CAPTERRA-FICHA Repair gap #3](../Repair/CAPTERRA-FICHA.md). Mecânico registra itens vistoriados na OS com semáforo verde/amarelo/vermelho (ok/atencao/critico) + recomendação + valor + foto opcional. Card UI proposto (screenshot Wagner 2026-05-26): "VISTORIA DIGITAL · DVI" com badges contadores ("8 ok · 2 atenção · 1 crítico"), lista de 5 items com semáforo + valor, e bloco "TOTAL RECOMENDADO · CLIENTE" agregando atencao+critico.
+
+**DoD (entregue Wave 3):**
+- [x] Migration `oa_inspection_items` (10 categorias enum + 3 severity enum + metadata json + photo_url + sort_order + multi-tenant business_id Tier 0 ADR 0093)
+- [x] Model `OaInspectionItem` com global scope business_id + LogsActivity D7.b + SoftDeletes + scopes (oks/atencoes/criticas/recomendaveis) + constantes CATEGORIAS + SEVERITIES_VALIDAS
+- [x] Service `DviInspectionService` com 4 métodos (addItem cross-tenant defense, breakdownPorSeverity, totalRecomendado, listarOrdenado)
+- [x] Controller `DviInspectionController` HTTP JSON (store 201 / update / destroy) com Policy `update(ServiceOrder)` + cross-OS guard (item.service_order_id === order.id)
+- [x] FormRequests `StoreDviRequest` + `UpdateDviRequest` (Rule::in CATEGORIAS + SEVERITIES_VALIDAS, descricao max:150, recomendacao max:255, valor_recomendado numeric min:0)
+- [x] 3 rotas Routes/web.php (POST/PUT/DELETE em `/ordens-servico/{order}/dvi[/{item}]`) com throttle:60,1
+- [x] ServiceOrder.dviInspectionItems() HasMany + getDviBreakdownAttribute() accessor
+- [x] Pest 10 specs (CRUD + global scope cross-tenant + Service validações + cross-OS HTTP 404)
+
+**Pendente Wave 3b:**
+- [ ] UI Pages/OficinaAuto integração no drawer ServiceOrderRichSheet (depende PR #1624 mergear)
+- [ ] Botão "Enviar p/ cliente" via WhatsApp (depende US-OFICINA-014 / PR #1627 — link público + PIN)
+- [ ] Upload de foto S3 (V0 só aceita photo_url string — UI vai precisar de file picker)
+
 ### US-OFICINA-026 · Outreach Martinho Caçambas + cutover discovery — fechar contrato pioneer
 
 > owner: wagner · priority: p0 · estimate: 8h · status: todo · type: story
@@ -1264,4 +1287,4 @@ Fechar 1º cliente pagante Modules/OficinaAuto (goal #1 CYCLE-06 — sinal quali
 
 ---
 
-**Última atualização:** 2026-05-15 — US-OFICINA-026 adicionada (goal #1 CYCLE-06 Martinho prod). 2026-05-10 — SPEC criada **antecipatória** sem cliente piloto. Status `feature-wish` lifecycle `aguarda-sinal-qualificado`. Não codar até gatilho §9 satisfeito. Revisar trimestralmente — se 12 meses sem sinal, considerar arquivar como `historical` (ADR 0095 lifecycle).
+**Última atualização:** 2026-05-26 — US-OFICINA-035 DVI Vistoria Digital backend (schema + Model + Service + HTTP API + Pest) — wedge CAPTERRA Repair gap #3. UI Wave 3b. 2026-05-15 — US-OFICINA-026 adicionada (goal #1 CYCLE-06 Martinho prod). 2026-05-10 — SPEC criada **antecipatória** sem cliente piloto. Status `feature-wish` lifecycle `aguarda-sinal-qualificado`. Não codar até gatilho §9 satisfeito. Revisar trimestralmente — se 12 meses sem sinal, considerar arquivar como `historical` (ADR 0095 lifecycle).

--- a/memory/requisitos/OficinaAuto/SPEC.md
+++ b/memory/requisitos/OficinaAuto/SPEC.md
@@ -1,16 +1,21 @@
 ---
 module: OficinaAuto
 version: 0.1.0
-last_updated: 2026-05-26
+last_updated: "2026-05-26"
 status: ativo
 lifecycle: ativo
 piloto: Vargas + Martinho (sinal qualificado em ADR 0137 — 2 de 4 candidatos OfficeImpresso saudáveis são oficina/recapagem)
 piloto_previsao: V0 scaffold 2026-05-11 (PR US-OFICINA-001); V1 importer Martinho Sprint 2+
 cnae_principal: '4520-0/01 (serviços de manutenção e reparação mecânica de veículos automotores)'
 cnaes_cobertos: ['4520-0/01', '2212-9/00', '4581-4/00']
-related_adrs: [0137, 0121, 0094, 0093, 0105, 0106, 0035, 0011, 0089, 0119, 0129]
+related_adrs:
+  - 0093-multi-tenant-isolation-tier-0
+  - 0094-constituicao-v2-7-camadas-8-principios
+  - 0137-modules-oficinaauto-qualificada
+  - 0143-fsm-pipeline-live-prod-marco-2026-05-12
+  - 0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada
 related_proposals: [proposals/gap-repair-vs-oficina-auto.md]
-last_review: 2026-05-26
+last_review: "2026-05-26"
 owners: [W]
 ---
 


### PR DESCRIPTION
## Resumo

Wave 3 OficinaAuto — wedge competitivo vs RepairShopr/mHelpDesk catalogado em `memory/requisitos/Repair/CAPTERRA-FICHA.md` gap #3 (DVI · Digital Vehicle Inspection). Backend completo: schema + Model + Service + Controller HTTP JSON + 10 Pest specs.

Visual de referência aprovado por screenshot Wagner 2026-05-26: card "VISTORIA DIGITAL · DVI" com badges contadores ("8 ok · 2 atenção · 1 crítico"), 5 items com semáforo verde/amarelo/vermelho + valor recomendado, e bloco "TOTAL RECOMENDADO · CLIENTE" agregando severidades atencao+critico.

## Schema

Migration `oa_inspection_items` (2026_05_26_120002):
- 10 categorias enum (motor/freios/correia/bateria/pneus/suspensao/direcao/eletrica/fluidos/outro)
- 3 severity enum (ok / atencao / critico)
- valor_recomendado decimal(10,2) nullable
- metadata json livre (vida_util_pct / km_restantes / voltagem...)
- photo_url string(500) nullable (V0 só string; upload S3 fica Wave 3b)
- sort_order smallInt (mecânico controla ordem display)
- 3 indices (biz+os / biz+severity / os+sort) + 2 FK CASCADE (business, service_orders)
- Idempotente Schema::hasTable guard

## Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093)

- Model com global scope business_id (auto-resolve session) + creating hook auto-set
- Service `addItem(int \$businessId, int \$serviceOrderId, array \$data)` — Service NÃO confia em session, business_id é parâmetro obrigatório (defesa em profundidade)
- Service valida OS pertence ao business via `ServiceOrder::withoutGlobalScopes()->where('id', \$osId)->where('business_id', \$businessId)->exists()` antes de criar item
- Controller cross-OS guard: `abort_unless(\$item->service_order_id === \$order->id, 404)` previne /orders/1/dvi/{item_da_OS_2} no MESMO business
- Pest cobertura: biz=99 não enxerga itens biz=1 + Service rejeita OS cross-tenant + HTTP 404 cross-OS

## LGPD (D7.b)

Spatie ActivityLog com `logOnlyDirty` em `categoria/descricao/severity/recomendacao/valor_recomendado/sort_order`. Log name `oficinaauto.dvi_inspection_item`. Soft delete preserva audit trail append-only.

## Pest coverage (10 specs)

\`\`\`
Modules/OficinaAuto/Tests/Feature/DviInspectionItemTest.php
\`\`\`

Entity:
- cria com auto-set business_id via creating hook
- escopa por business_id global scope (cross-tenant biz=99 não enxerga biz=1)

Service:
- addItem cria + respeita severity
- addItem rejeita categoria inválida
- addItem rejeita severity inválida
- addItem rejeita OS de outro business (cross-tenant)
- breakdownPorSeverity retorna agregados corretos (5 items mistos)
- totalRecomendado soma apenas atencao+critico (ignora ok)
- listarOrdenado coloca críticos no topo (FIELD severity)

HTTP:
- POST cria 201 com payload correto (superadmin)
- PUT cross-OS guard retorna 404

Pattern espelha `ServiceOrderItemTest.php` (Wave 27 G1) — mesma estrutura `beforeEach` markTestSkipped SQLite + helpers + afterEach cleanup `forceDelete`.

## NÃO inclui (Wave 3b futura)

- UI Pages/OficinaAuto integração drawer `ServiceOrderRichSheet` (depende PR #1624 mergear)
- Botão "Enviar p/ cliente" via WhatsApp (depende US-OFICINA-014 / PR #1627 — link público + PIN)
- Upload de foto S3 (V0 só aceita photo_url string — UI vai precisar file picker)

## Endpoints

\`\`\`
POST   /oficina-auto/ordens-servico/{order}/dvi          → store 201
PUT    /oficina-auto/ordens-servico/{order}/dvi/{item}   → update 200
DELETE /oficina-auto/ordens-servico/{order}/dvi/{item}   → destroy 204
\`\`\`

Todos com `throttle:60,1` middleware + Policy `update(ServiceOrder)` + cross-OS guard.

## Test plan

- [ ] Rodar migration: `php artisan migrate --path=Modules/OficinaAuto/Database/Migrations`
- [ ] Pest local: `php artisan test Modules/OficinaAuto/Tests/Feature/DviInspectionItemTest.php`
- [ ] Smoke manual: POST item DVI numa OS biz=1, verificar 201 + breakdown agregado correto
- [ ] Smoke cross-tenant: login biz=99, tentar listar DVI de OS biz=1 → deve vir vazio
- [ ] Smoke cross-OS: PUT item-da-OS-A via rota /orders/B/dvi/{item_id} → deve retornar 404
- [ ] Verificar LogsActivity registrou criação no Spatie audit (log_name = oficinaauto.dvi_inspection_item)

## Refs

- SPEC: `memory/requisitos/OficinaAuto/SPEC.md` US-OFICINA-035 (status in-progress backend done)
- ADRs: 0093 (Tier 0 IRREVOGÁVEL) · 0137 (OficinaAuto qualificada) · 0194 (sub-vertical 4 mecânica pesada)
- CAPTERRA: `memory/requisitos/Repair/CAPTERRA-FICHA.md` gap #3 DVI
- Refs SPRINT-22 PASSO 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)