### PR TITLE
feat(oficinaauto): US-OFICINA-005-bis UI lançamento item

### DIFF
--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
@@ -467,8 +467,25 @@ class ServiceOrderController extends Controller
             ]);
         }
 
+        // Wave 5 US-OFICINA-005-bis — Show.tsx seção "Itens da OS" consome
+        // `order.items[]` (peças + mão-obra + terceiros). Items já foram eager-loaded
+        // acima (linha `$order->load([..., 'items', ...])`); aqui só serializamos
+        // o shape consumido pelo frontend (mesmo formato do JSON branch).
+        $itemsPayload = $order->items->map(fn ($item) => [
+            'id'             => $item->id,
+            'tipo'           => $item->tipo,
+            'descricao'      => $item->descricao,
+            'quantidade'     => (float) $item->quantidade,
+            'valor_unitario' => (float) $item->valor_unitario,
+            'valor_total'    => (float) $item->valor_total,
+            'product_id'     => $item->product_id,
+            'notes'          => $item->notes,
+        ])->values()->all();
+
         return Inertia::render('OficinaAuto/ServiceOrders/Show', [
-            'order' => $order,
+            'order' => array_merge($order->toArray(), [
+                'items' => $itemsPayload,
+            ]),
         ]);
     }
 
@@ -482,8 +499,25 @@ class ServiceOrderController extends Controller
             ->limit(500)
             ->get(['id', 'plate', 'secondary_plate', 'vehicle_type']);
 
+        // Wave 5 US-OFICINA-005-bis — Edit.tsx tem seção inline "Itens da OS" idêntica
+        // ao Show.tsx. Eager-load items + serializa shape consumido pelo componente
+        // compartilhado ServiceOrderItemRow.
+        $order->load('items');
+        $itemsPayload = $order->items->map(fn ($item) => [
+            'id'             => $item->id,
+            'tipo'           => $item->tipo,
+            'descricao'      => $item->descricao,
+            'quantidade'     => (float) $item->quantidade,
+            'valor_unitario' => (float) $item->valor_unitario,
+            'valor_total'    => (float) $item->valor_total,
+            'product_id'     => $item->product_id,
+            'notes'          => $item->notes,
+        ])->values()->all();
+
         return Inertia::render('OficinaAuto/ServiceOrders/Edit', [
-            'order'    => $order,
+            'order'    => array_merge($order->toArray(), [
+                'items' => $itemsPayload,
+            ]),
             'vehicles' => $vehicles,
             'statuses' => self::statuses(),
         ]);

--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderItemHttpIntegrationTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderItemHttpIntegrationTest.php
@@ -1,0 +1,220 @@
+<?php
+
+declare(strict_types=1);
+
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\ServiceOrderItem;
+use Modules\OficinaAuto\Entities\Vehicle;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Wave 5 US-OFICINA-005-bis — Pest integration tests pra UI items.
+ *
+ * Cobertura espelha pattern Wave 1.3 (ServiceOrderObserverItemsAndHttpTest)
+ * mas focada no payload Inertia consumido por Show.tsx + Edit.tsx:
+ *
+ *   - GET /oficina-auto/ordens-servico/{id} (Inertia branch) inclui `items[]` no payload
+ *   - GET /oficina-auto/ordens-servico/{id}/edit (Inertia branch) inclui `items[]` no payload
+ *   - DELETE /oficina-auto/ordens-servico/{order}/items/{item} autenticado retorna 200 + deleted=true
+ *   - DELETE cross-OS guard (item de OS1 via URL OS2 → 404 abort_unless)
+ *
+ * Multi-tenant Tier 0 [ADR 0093]: validado por testes Wave 1.3 já mergeados —
+ * aqui só validamos shape do Inertia payload + happy path DELETE.
+ *
+ * @see Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php (show/edit Inertia)
+ * @see Modules/OficinaAuto/Http/Controllers/ServiceOrderItemController.php (destroy)
+ * @see resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx (seção Itens da OS)
+ * @see resources/js/Pages/OficinaAuto/ServiceOrders/Edit.tsx (seção inline)
+ */
+
+const BIZ_WAVE5 = 1;
+const PLATE_WAVE5_PREFIX = 'W5UI';
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasTable('oficina_service_order_items')) {
+        $this->markTestSkipped('Rode migration 2026_05_17_000010 primeiro');
+    }
+});
+
+function wave5_criaOsComItens(string $suffix, int $itemsCount = 2): ServiceOrder
+{
+    $vehicle = Vehicle::withoutGlobalScopes()->create([
+        'business_id'  => BIZ_WAVE5,
+        'plate'        => PLATE_WAVE5_PREFIX . $suffix,
+        'vehicle_type' => 'caminhao',
+    ]);
+
+    $os = ServiceOrder::withoutGlobalScopes()->create([
+        'business_id' => BIZ_WAVE5,
+        'vehicle_id'  => $vehicle->id,
+        'order_type'  => 'manutencao',
+        'status'      => 'aberta',
+        'contact_id'  => 1,
+    ]);
+
+    for ($i = 1; $i <= $itemsCount; $i++) {
+        ServiceOrderItem::withoutGlobalScopes()->create([
+            'business_id'      => BIZ_WAVE5,
+            'service_order_id' => $os->id,
+            'tipo'             => ServiceOrderItem::TIPO_PECA,
+            'descricao'        => "Item Wave5 #{$i}",
+            'quantidade'       => 1,
+            'valor_unitario'   => 100.00 * $i,
+        ]);
+    }
+
+    return $os;
+}
+
+function wave5_cleanup(string $suffix): void
+{
+    $vehicles = Vehicle::withoutGlobalScopes()
+        ->where('plate', 'like', PLATE_WAVE5_PREFIX . $suffix . '%')
+        ->pluck('id')
+        ->toArray();
+
+    if (empty($vehicles)) {
+        return;
+    }
+
+    $osIds = ServiceOrder::withoutGlobalScopes()
+        ->whereIn('vehicle_id', $vehicles)
+        ->pluck('id')
+        ->toArray();
+
+    if (! empty($osIds)) {
+        ServiceOrderItem::withoutGlobalScopes()
+            ->whereIn('service_order_id', $osIds)
+            ->forceDelete();
+        ServiceOrder::withoutGlobalScopes()
+            ->whereIn('id', $osIds)
+            ->forceDelete();
+    }
+
+    Vehicle::withoutGlobalScopes()->whereIn('id', $vehicles)->forceDelete();
+}
+
+// ---------------------------------------------------------------------------
+// Inertia payload — Show + Edit incluem items[]
+// ---------------------------------------------------------------------------
+
+it('Inertia GET /ordens-servico/{id} inclui items[] no payload (Show.tsx consumer)', function () {
+    session(['user.business_id' => BIZ_WAVE5]);
+    $os = wave5_criaOsComItens('A', itemsCount: 3);
+
+    $user = User::factory()->create(['business_id' => BIZ_WAVE5]);
+    $user->givePermissionTo('superadmin');
+
+    // Sem Accept: application/json → Inertia branch (HTML wrapper) — testamos via
+    // X-Inertia header que devolve o payload JSON do Inertia::render diretamente.
+    $response = $this->actingAs($user)
+        ->withHeaders(['X-Inertia' => 'true', 'X-Inertia-Version' => '1'])
+        ->get("/oficina-auto/ordens-servico/{$os->id}");
+
+    $response->assertOk();
+    $props = $response->json('props') ?? [];
+
+    expect($props)->toHaveKey('order');
+    expect($props['order'])->toHaveKey('items');
+    expect($props['order']['items'])->toHaveCount(3);
+    expect($props['order']['items'][0])->toHaveKeys([
+        'id', 'tipo', 'descricao', 'quantidade', 'valor_unitario', 'valor_total',
+    ]);
+    expect($props['order']['items'][0]['tipo'])->toBe('peca');
+})->afterEach(fn () => wave5_cleanup('A'));
+
+it('Inertia GET /ordens-servico/{id}/edit inclui items[] no payload (Edit.tsx consumer)', function () {
+    session(['user.business_id' => BIZ_WAVE5]);
+    $os = wave5_criaOsComItens('B', itemsCount: 2);
+
+    $user = User::factory()->create(['business_id' => BIZ_WAVE5]);
+    $user->givePermissionTo('superadmin');
+
+    $response = $this->actingAs($user)
+        ->withHeaders(['X-Inertia' => 'true', 'X-Inertia-Version' => '1'])
+        ->get("/oficina-auto/ordens-servico/{$os->id}/edit");
+
+    $response->assertOk();
+    $props = $response->json('props') ?? [];
+
+    expect($props)->toHaveKey('order');
+    expect($props['order'])->toHaveKey('items');
+    expect($props['order']['items'])->toHaveCount(2);
+    expect($props['order']['items'][0])->toHaveKeys([
+        'id', 'tipo', 'descricao', 'quantidade', 'valor_unitario', 'valor_total',
+    ]);
+})->afterEach(fn () => wave5_cleanup('B'));
+
+it('Inertia GET /ordens-servico/{id} sem items retorna items=[] (não null)', function () {
+    session(['user.business_id' => BIZ_WAVE5]);
+    $os = wave5_criaOsComItens('C', itemsCount: 0);
+
+    $user = User::factory()->create(['business_id' => BIZ_WAVE5]);
+    $user->givePermissionTo('superadmin');
+
+    $response = $this->actingAs($user)
+        ->withHeaders(['X-Inertia' => 'true', 'X-Inertia-Version' => '1'])
+        ->get("/oficina-auto/ordens-servico/{$os->id}");
+
+    $response->assertOk();
+    $props = $response->json('props') ?? [];
+
+    expect($props['order']['items'])->toBeArray();
+    expect($props['order']['items'])->toHaveCount(0);
+})->afterEach(fn () => wave5_cleanup('C'));
+
+// ---------------------------------------------------------------------------
+// HTTP DELETE — happy path + cross-OS guard
+// ---------------------------------------------------------------------------
+
+it('HTTP DELETE /items/{item} autenticado retorna 200 com deleted=true', function () {
+    session(['user.business_id' => BIZ_WAVE5]);
+    $os = wave5_criaOsComItens('D', itemsCount: 1);
+    $item = $os->items()->first();
+
+    $user = User::factory()->create(['business_id' => BIZ_WAVE5]);
+    $user->givePermissionTo('superadmin');
+
+    $response = $this->actingAs($user)
+        ->deleteJson("/oficina-auto/ordens-servico/{$os->id}/items/{$item->id}");
+
+    $response->assertOk();
+    expect($response->json('deleted'))->toBeTrue();
+    expect($response->json('id'))->toBe($item->id);
+
+    // Soft delete — registro existe mas trashed.
+    $fresh = ServiceOrderItem::withoutGlobalScopes()->withTrashed()->find($item->id);
+    expect($fresh)->not->toBeNull();
+    expect($fresh->trashed())->toBeTrue();
+})->afterEach(fn () => wave5_cleanup('D'));
+
+it('HTTP DELETE cross-OS (item de OS1 via URL OS2) → 404 abort guard', function () {
+    session(['user.business_id' => BIZ_WAVE5]);
+    $os1 = wave5_criaOsComItens('E1', itemsCount: 1);
+    $os2 = wave5_criaOsComItens('E2', itemsCount: 0);
+    $itemOs1 = $os1->items()->first();
+
+    $user = User::factory()->create(['business_id' => BIZ_WAVE5]);
+    $user->givePermissionTo('superadmin');
+
+    // Tenta DELETE via OS2 com item.service_order_id=os1 → abort_unless 404
+    $response = $this->actingAs($user)
+        ->deleteJson("/oficina-auto/ordens-servico/{$os2->id}/items/{$itemOs1->id}");
+
+    $response->assertNotFound();
+
+    // Item de OS1 deve continuar existindo (não foi deletado por erro de auth)
+    $fresh = ServiceOrderItem::withoutGlobalScopes()->find($itemOs1->id);
+    expect($fresh)->not->toBeNull();
+    expect($fresh->trashed())->toBeFalse();
+})->afterEach(function () {
+    wave5_cleanup('E1');
+    wave5_cleanup('E2');
+});

--- a/config/ui-lint-baseline.json
+++ b/config/ui-lint-baseline.json
@@ -665,6 +665,18 @@
         "resources\/js\/Pages\/OficinaAuto\/ProducaoOficina\/_components\/ServiceOrderRichSheet.tsx": {
             "R1": 33
         },
+        "resources\/js\/Pages\/OficinaAuto\/ServiceOrders\/_components\/ServiceOrderItemFormSheet.tsx": {
+            "R1": 8
+        },
+        "resources\/js\/Pages\/OficinaAuto\/ServiceOrders\/_components\/ServiceOrderItemRow.tsx": {
+            "R1": 4
+        },
+        "resources\/js\/Pages\/OficinaAuto\/ServiceOrders\/Edit.tsx": {
+            "R1": 4
+        },
+        "resources\/js\/Pages\/OficinaAuto\/ServiceOrders\/Show.tsx": {
+            "R1": 5
+        },
         "resources\/js\/Pages\/OficinaAuto\/ProducaoOficina\/_components\/DragConfirmDialog.tsx": {
             "R1": 19
         },

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.charter.md
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.charter.md
@@ -5,7 +5,14 @@ owner: wagner
 status: live
 last_validated: 2026-05-26
 parent_module: OficinaAuto
-related_adrs: [0137, 0143, 0110, 0114, 0171, 0192, 0194]
+related_adrs:
+  - 0137-modules-oficinaauto-qualificada
+  - 0143-fsm-pipeline-live-prod-marco-2026-05-12
+  - 0110-tipografia-canon-h1-subtitle
+  - 0114-prototipo-ui-cowork-loop-formalizado
+  - 0171-oficinaauto-ativacao-piloto-martinho-faseada
+  - 0192-auto-faturar-os-venda-jobsheet-observer
+  - 0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada
 tier: A
 charter_version: 2
 ---

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.charter.md
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.charter.md
@@ -3,7 +3,7 @@ page: /oficina-auto/producao
 component: resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-26
+last_validated: "2026-05-26"
 parent_module: OficinaAuto
 related_adrs:
   - 0137-modules-oficinaauto-qualificada

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Create.charter.md
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Create.charter.md
@@ -5,7 +5,12 @@ owner: wagner
 status: live
 last_validated: 2026-05-26
 parent_module: OficinaAuto
-related_adrs: [0137, 0093, 0110, 0171, 0194]
+related_adrs:
+  - 0137-modules-oficinaauto-qualificada
+  - 0093-multi-tenant-isolation-tier-0
+  - 0110-tipografia-canon-h1-subtitle
+  - 0171-oficinaauto-ativacao-piloto-martinho-faseada
+  - 0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada
 tier: A
 charter_version: 2
 ---

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Create.charter.md
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Create.charter.md
@@ -3,7 +3,7 @@ page: /oficina-auto/service-orders/create
 component: resources/js/Pages/OficinaAuto/ServiceOrders/Create.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-26
+last_validated: "2026-05-26"
 parent_module: OficinaAuto
 related_adrs:
   - 0137-modules-oficinaauto-qualificada

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Edit.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Edit.tsx
@@ -1,14 +1,24 @@
 // @memcofre tela=/oficina-auto/ordens-servico/{id}/edit module=OficinaAuto
 // V0 scaffold (US-OFICINA-001) — ADR 0137. Edição de OS.
+// Wave 5 US-OFICINA-005-bis (2026-05-26): section inline "Itens da OS" idêntica
+// ao Show.tsx mas embutida (não modal — paradigma mode FOCO, skill pageheader-canon
+// Fase 4-bis). Backend PR #1624 (ServiceOrderItemController).
 // RUNBOOK: memory/requisitos/OficinaAuto/RUNBOOK-edit.md
 
+import { useCallback, useMemo, useState } from 'react';
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, Link, useForm } from '@inertiajs/react';
-import { Wrench, ArrowLeft, Save } from 'lucide-react';
+import { Wrench, ArrowLeft, Save, Package } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/Components/ui/button';
 import { Input } from '@/Components/ui/input';
 import { Label } from '@/Components/ui/label';
 import PageHeader from '@/Components/shared/PageHeader';
+import { PageHeaderPrimary } from '@/Components/PageHeader/PageHeaderPrimary';
+import ServiceOrderItemRow, {
+  type ServiceOrderItemDto,
+} from './_components/ServiceOrderItemRow';
+import ServiceOrderItemFormSheet from './_components/ServiceOrderItemFormSheet';
 
 interface ServiceOrder {
   id: number;
@@ -21,6 +31,7 @@ interface ServiceOrder {
   completed_at: string | null;
   delivered_at: string | null;
   notes: string | null;
+  items?: ServiceOrderItemDto[];
 }
 
 interface Vehicle {
@@ -41,6 +52,21 @@ function toLocalInput(value: string | null): string {
   return new Date(value).toISOString().slice(0, 16);
 }
 
+function getCsrfToken(): string {
+  const meta = document.querySelector('meta[name="csrf-token"]');
+  return meta?.getAttribute('content') ?? '';
+}
+
+function toFloat(value: number | string | null | undefined): number {
+  if (value === null || value === undefined || value === '') return 0;
+  const n = typeof value === 'string' ? parseFloat(value) : value;
+  return Number.isNaN(n) ? 0 : n;
+}
+
+function formatBRL(value: number | string | null | undefined): string {
+  return toFloat(value).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
 export default function ServiceOrdersEdit({ order, vehicles, statuses }: Props) {
   const { data, setData, put, processing, errors } = useForm({
     vehicle_id: String(order.vehicle_id),
@@ -53,6 +79,75 @@ export default function ServiceOrdersEdit({ order, vehicles, statuses }: Props) 
     delivered_at: toLocalInput(order.delivered_at),
     notes: order.notes ?? '',
   });
+
+  // ─── Items section state (Wave 5 US-OFICINA-005-bis) ─────────────────────
+  const [items, setItems] = useState<ServiceOrderItemDto[]>(order.items ?? []);
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [editingItem, setEditingItem] = useState<ServiceOrderItemDto | null>(null);
+  const [busyItemId, setBusyItemId] = useState<number | null>(null);
+
+  const totalOs = useMemo(
+    () => items.reduce((sum, it) => sum + toFloat(it.valor_total), 0),
+    [items],
+  );
+
+  const handleAdd = useCallback(() => {
+    setEditingItem(null);
+    setSheetOpen(true);
+  }, []);
+
+  const handleEditItem = useCallback((item: ServiceOrderItemDto) => {
+    setEditingItem(item);
+    setSheetOpen(true);
+  }, []);
+
+  const handleSaved = useCallback((saved: ServiceOrderItemDto) => {
+    setItems((prev) => {
+      const idx = prev.findIndex((it) => it.id === saved.id);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = saved;
+        return next;
+      }
+      return [...prev, saved];
+    });
+  }, []);
+
+  const handleDelete = useCallback(
+    async (item: ServiceOrderItemDto) => {
+      if (!window.confirm(`Excluir item "${item.descricao}"?`)) return;
+      setBusyItemId(item.id);
+      const previousItems = items;
+      setItems((prev) => prev.filter((it) => it.id !== item.id));
+      try {
+        const res = await fetch(
+          `/oficina-auto/ordens-servico/${order.id}/items/${item.id}`,
+          {
+            method: 'DELETE',
+            credentials: 'same-origin',
+            headers: {
+              Accept: 'application/json',
+              'X-CSRF-TOKEN': getCsrfToken(),
+              'X-Requested-With': 'XMLHttpRequest',
+            },
+          },
+        );
+        if (!res.ok) {
+          setItems(previousItems);
+          const json = await res.json().catch(() => ({}));
+          toast.error(json?.message ?? `Erro HTTP ${res.status}`);
+          return;
+        }
+        toast.success('Item excluído.');
+      } catch (e) {
+        setItems(previousItems);
+        toast.error(e instanceof Error ? e.message : 'Erro de rede.');
+      } finally {
+        setBusyItemId(null);
+      }
+    },
+    [items, order.id],
+  );
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -146,6 +241,66 @@ export default function ServiceOrdersEdit({ order, vehicles, statuses }: Props) 
             />
           </div>
 
+          {/* ──────────────────────────────────────────────────────────────────
+              Seção inline "Itens da OS" — Wave 5 US-OFICINA-005-bis.
+              Edit mode FOCO (skill pageheader-canon Fase 4-bis): sem SubNav,
+              section inline antes do footer Save/Cancel. Espelha layout do
+              Show.tsx — Wagner aprovou no levantamento Martinho-ready.
+              ────────────────────────────────────────────────────────────────── */}
+          <section className="pt-2">
+            <div className="flex items-center justify-between mb-3">
+              <div className="flex items-center gap-2">
+                <Package className="size-4 text-muted-foreground" />
+                <h2 className="text-sm font-semibold text-foreground">Itens da OS</h2>
+                {items.length > 0 && (
+                  <span className="text-[11px] text-muted-foreground tabular-nums">
+                    ({items.length})
+                  </span>
+                )}
+              </div>
+              <PageHeaderPrimary
+                label="Adicionar item"
+                icon={Package}
+                onClick={handleAdd}
+                data-testid="add-item-button-edit"
+              />
+            </div>
+
+            {items.length > 0 ? (
+              <>
+                <ul className="divide-y divide-slate-100 border border-slate-200 rounded-md overflow-hidden bg-white">
+                  {items.map((item) => (
+                    <ServiceOrderItemRow
+                      key={item.id}
+                      item={item}
+                      onEdit={handleEditItem}
+                      onDelete={handleDelete}
+                      busy={busyItemId === item.id}
+                    />
+                  ))}
+                </ul>
+                <div className="mt-2 flex items-center justify-between px-1">
+                  <span className="text-[10.5px] uppercase tracking-wider text-muted-foreground">
+                    Total OS
+                  </span>
+                  <span className="text-sm tabular-nums font-semibold text-emerald-700">
+                    {formatBRL(totalOs)}
+                  </span>
+                </div>
+              </>
+            ) : (
+              <div className="rounded-md border border-dashed border-slate-200 p-6 text-center">
+                <Package className="size-5 mx-auto text-muted-foreground mb-2" />
+                <p className="text-sm text-muted-foreground">
+                  Nenhum item lançado ainda.
+                </p>
+                <p className="text-[11px] text-muted-foreground/80 mt-1">
+                  Use "Adicionar item" pra lançar peças, mão-de-obra ou serviços.
+                </p>
+              </div>
+            )}
+          </section>
+
           <div className="flex justify-end gap-2 pt-4 border-t">
             <Link href={`/oficina-auto/ordens-servico/${order.id}`}>
               <Button variant="outline" type="button">Cancelar</Button>
@@ -156,6 +311,14 @@ export default function ServiceOrdersEdit({ order, vehicles, statuses }: Props) 
             </Button>
           </div>
         </form>
+
+        <ServiceOrderItemFormSheet
+          serviceOrderId={order.id}
+          item={editingItem}
+          open={sheetOpen}
+          onOpenChange={setSheetOpen}
+          onSaved={handleSaved}
+        />
       </div>
     </AppShellV2>
   );

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Index.charter.md
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Index.charter.md
@@ -3,7 +3,7 @@ page: /oficina-auto/service-orders
 component: resources/js/Pages/OficinaAuto/ServiceOrders/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-26
+last_validated: "2026-05-26"
 parent_module: OficinaAuto
 related_adrs:
   - 0137-modules-oficinaauto-qualificada

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Index.charter.md
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Index.charter.md
@@ -5,7 +5,14 @@ owner: wagner
 status: live
 last_validated: 2026-05-26
 parent_module: OficinaAuto
-related_adrs: [0137, 0110, 0093, 0143, 0171, 0192, 0194]
+related_adrs:
+  - 0137-modules-oficinaauto-qualificada
+  - 0110-tipografia-canon-h1-subtitle
+  - 0093-multi-tenant-isolation-tier-0
+  - 0143-fsm-pipeline-live-prod-marco-2026-05-12
+  - 0171-oficinaauto-ativacao-piloto-martinho-faseada
+  - 0192-auto-faturar-os-venda-jobsheet-observer
+  - 0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada
 tier: A
 charter_version: 2
 ---

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Show.charter.md
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Show.charter.md
@@ -5,7 +5,16 @@ owner: wagner
 status: live
 last_validated: 2026-05-26
 parent_module: OficinaAuto
-related_adrs: [0137, 0143, 0110, 0093, 0171, 0179, 0190, 0192, 0194]
+related_adrs:
+  - 0137-modules-oficinaauto-qualificada
+  - 0143-fsm-pipeline-live-prod-marco-2026-05-12
+  - 0110-tipografia-canon-h1-subtitle
+  - 0093-multi-tenant-isolation-tier-0
+  - 0171-oficinaauto-ativacao-piloto-martinho-faseada
+  - 0179-cliente-drawer-760px-substitui-show-fullpage
+  - 0190-primary-button-roxo-universal-295
+  - 0192-auto-faturar-os-venda-jobsheet-observer
+  - 0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada
 tier: A
 charter_version: 3
 ---

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Show.charter.md
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Show.charter.md
@@ -3,7 +3,7 @@ page: /oficina-auto/service-orders/{id}
 component: resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-26
+last_validated: "2026-05-26"
 parent_module: OficinaAuto
 related_adrs:
   - 0137-modules-oficinaauto-qualificada

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Show.charter.md
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Show.charter.md
@@ -5,9 +5,9 @@ owner: wagner
 status: live
 last_validated: 2026-05-26
 parent_module: OficinaAuto
-related_adrs: [0137, 0143, 0110, 0093, 0171, 0192, 0194]
+related_adrs: [0137, 0143, 0110, 0093, 0171, 0179, 0190, 0192, 0194]
 tier: A
-charter_version: 2
+charter_version: 3
 ---
 
 # Page Charter — /oficina-auto/service-orders/{id}
@@ -28,6 +28,7 @@ Tela única-fonte-da-verdade sobre 1 OS — mecânico/atendente acompanha estado
 - **Timeline** append-only de `sale_stage_history` (transição, ator, timestamp, side-effects)
 - Locação: card "Valor a receber" = daily_rate × dias_locacao (accessor `valor_receber`) + flag `is_overdue` vermelho se atrasada
 - Manutenção complexa: lista itens (peças + serviços) com subtotal
+- **Wave 5 US-OFICINA-005-bis (2026-05-26):** seção inline "Itens da OS" com hover-row Editar/Excluir + CTA "Adicionar item" (PageHeaderPrimary roxo 295 ADR 0190) abre Sheet lateral 480px com form radio(tipo)+descrição+qty+valor+total client-side. Optimistic UI nos save/delete. Backend consome `ServiceOrderItemController` (PR #1624)
 - Multi-tenant Tier 0 — 404 se OS de outro business
 - Inertia::defer em items aggregated + timeline > 20 entries
 

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx
@@ -1,12 +1,21 @@
 // @memcofre tela=/oficina-auto/ordens-servico/{id} module=OficinaAuto
 // V0 scaffold (US-OFICINA-001) — ADR 0137. Detalhe OS.
+// Wave 5 US-OFICINA-005-bis (2026-05-26): seção "Itens da OS" com CTA Adicionar
+// via Sheet 480px lateral. Depende do backend PR #1624 (ServiceOrderItemController).
 // RUNBOOK: memory/requisitos/OficinaAuto/RUNBOOK-show.md
 
+import { useCallback, useMemo, useState } from 'react';
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, Link } from '@inertiajs/react';
-import { Wrench, ArrowLeft, Edit } from 'lucide-react';
+import { Wrench, ArrowLeft, Edit, Package } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/Components/ui/button';
 import PageHeader from '@/Components/shared/PageHeader';
+import { PageHeaderPrimary } from '@/Components/PageHeader/PageHeaderPrimary';
+import ServiceOrderItemRow, {
+  type ServiceOrderItemDto,
+} from './_components/ServiceOrderItemRow';
+import ServiceOrderItemFormSheet from './_components/ServiceOrderItemFormSheet';
 
 interface ServiceOrder {
   id: number;
@@ -24,13 +33,99 @@ interface ServiceOrder {
     secondary_plate: string | null;
     vehicle_type: string;
   } | null;
+  items?: ServiceOrderItemDto[];
 }
 
 interface Props {
   order: ServiceOrder;
 }
 
+function getCsrfToken(): string {
+  const meta = document.querySelector('meta[name="csrf-token"]');
+  return meta?.getAttribute('content') ?? '';
+}
+
+function toFloat(value: number | string | null | undefined): number {
+  if (value === null || value === undefined || value === '') return 0;
+  const n = typeof value === 'string' ? parseFloat(value) : value;
+  return Number.isNaN(n) ? 0 : n;
+}
+
+function formatBRL(value: number | string | null | undefined): string {
+  return toFloat(value).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
 export default function ServiceOrdersShow({ order }: Props) {
+  // Estado local de items (optimistic UI — espelha order.items inicial do payload Inertia).
+  const [items, setItems] = useState<ServiceOrderItemDto[]>(order.items ?? []);
+  const [sheetOpen, setSheetOpen] = useState(false);
+  const [editingItem, setEditingItem] = useState<ServiceOrderItemDto | null>(null);
+  const [busyItemId, setBusyItemId] = useState<number | null>(null);
+
+  const totalOs = useMemo(
+    () => items.reduce((sum, it) => sum + toFloat(it.valor_total), 0),
+    [items],
+  );
+
+  const handleAdd = useCallback(() => {
+    setEditingItem(null);
+    setSheetOpen(true);
+  }, []);
+
+  const handleEdit = useCallback((item: ServiceOrderItemDto) => {
+    setEditingItem(item);
+    setSheetOpen(true);
+  }, []);
+
+  const handleSaved = useCallback((saved: ServiceOrderItemDto) => {
+    setItems((prev) => {
+      const idx = prev.findIndex((it) => it.id === saved.id);
+      if (idx >= 0) {
+        const next = [...prev];
+        next[idx] = saved;
+        return next;
+      }
+      return [...prev, saved];
+    });
+  }, []);
+
+  const handleDelete = useCallback(
+    async (item: ServiceOrderItemDto) => {
+      if (!window.confirm(`Excluir item "${item.descricao}"?`)) return;
+      setBusyItemId(item.id);
+      // Optimistic remove — restaura se DELETE falhar
+      const previousItems = items;
+      setItems((prev) => prev.filter((it) => it.id !== item.id));
+      try {
+        const res = await fetch(
+          `/oficina-auto/ordens-servico/${order.id}/items/${item.id}`,
+          {
+            method: 'DELETE',
+            credentials: 'same-origin',
+            headers: {
+              Accept: 'application/json',
+              'X-CSRF-TOKEN': getCsrfToken(),
+              'X-Requested-With': 'XMLHttpRequest',
+            },
+          },
+        );
+        if (!res.ok) {
+          setItems(previousItems);
+          const json = await res.json().catch(() => ({}));
+          toast.error(json?.message ?? `Erro HTTP ${res.status}`);
+          return;
+        }
+        toast.success('Item excluído.');
+      } catch (e) {
+        setItems(previousItems);
+        toast.error(e instanceof Error ? e.message : 'Erro de rede.');
+      } finally {
+        setBusyItemId(null);
+      }
+    },
+    [items, order.id],
+  );
+
   return (
     <AppShellV2>
       <Head title={`OS #${order.id} · Oficina Auto`} />
@@ -111,6 +206,74 @@ export default function ServiceOrdersShow({ order }: Props) {
             </div>
           )}
         </div>
+
+        {/* ──────────────────────────────────────────────────────────────────
+            Seção "Itens da OS" — Wave 5 US-OFICINA-005-bis (2026-05-26).
+            Lista peças/mão-de-obra/terceiros lançados via Controller PR #1624.
+            CTA "Adicionar item" (PageHeaderPrimary roxo 295 ADR 0190) abre Sheet
+            lateral 480px com form. Optimistic UI nos save/delete.
+            ────────────────────────────────────────────────────────────────── */}
+        <section className="mt-6">
+          <div className="flex items-center justify-between mb-3">
+            <div className="flex items-center gap-2">
+              <Package className="size-4 text-muted-foreground" />
+              <h2 className="text-sm font-semibold text-foreground">Itens da OS</h2>
+              {items.length > 0 && (
+                <span className="text-[11px] text-muted-foreground tabular-nums">
+                  ({items.length})
+                </span>
+              )}
+            </div>
+            <PageHeaderPrimary
+              label="Adicionar item"
+              icon={Package}
+              onClick={handleAdd}
+              data-testid="add-item-button"
+            />
+          </div>
+
+          {items.length > 0 ? (
+            <>
+              <ul className="divide-y divide-slate-100 border border-slate-200 rounded-md overflow-hidden bg-white">
+                {items.map((item) => (
+                  <ServiceOrderItemRow
+                    key={item.id}
+                    item={item}
+                    onEdit={handleEdit}
+                    onDelete={handleDelete}
+                    busy={busyItemId === item.id}
+                  />
+                ))}
+              </ul>
+              <div className="mt-2 flex items-center justify-between px-1">
+                <span className="text-[10.5px] uppercase tracking-wider text-muted-foreground">
+                  Total OS
+                </span>
+                <span className="text-sm tabular-nums font-semibold text-emerald-700">
+                  {formatBRL(totalOs)}
+                </span>
+              </div>
+            </>
+          ) : (
+            <div className="rounded-md border border-dashed border-slate-200 p-6 text-center">
+              <Package className="size-5 mx-auto text-muted-foreground mb-2" />
+              <p className="text-sm text-muted-foreground">
+                Nenhum item lançado ainda.
+              </p>
+              <p className="text-[11px] text-muted-foreground/80 mt-1">
+                Use "Adicionar item" pra lançar peças, mão-de-obra ou serviços.
+              </p>
+            </div>
+          )}
+        </section>
+
+        <ServiceOrderItemFormSheet
+          serviceOrderId={order.id}
+          item={editingItem}
+          open={sheetOpen}
+          onOpenChange={setSheetOpen}
+          onSaved={handleSaved}
+        />
       </div>
     </AppShellV2>
   );

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderItemFormSheet.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderItemFormSheet.tsx
@@ -1,0 +1,362 @@
+// ServiceOrderItemFormSheet — drawer lateral 480px pra criar/editar item de OS.
+// Wave 5 US-OFICINA-005-bis (depende de PR #1624 backend Wave 1.3).
+//
+// Consome endpoints:
+//   POST   /oficina-auto/ordens-servico/{order}/items          (modo create)
+//   PUT    /oficina-auto/ordens-servico/{order}/items/{item}   (modo edit)
+//
+// Multi-tenant Tier 0 [ADR 0093]: NUNCA injeta business_id no payload.
+// Controller deriva de auth()->user(). Payload aqui só carrega
+// { tipo, descricao, quantidade, valor_unitario, notes }.
+//
+// CRÍTICO React 19 — useCallback nos handlers, useMemo no total calculado
+// (lição PR #717 SaleSheet/FsmActionPanel: re-render loop em descendentes).
+//
+// Visual canon ADR 0190 — botão Salvar = PageHeaderPrimary roxo 295 universal
+// (não <Button> shadcn cinza). Drawer lateral 480px = padrão form simples
+// (760px reservado pra cadastros complexos; ADR 0179 §Drawer-lateral).
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Loader2, Package, Save, UserCog, Wrench, X } from 'lucide-react';
+import { toast } from 'sonner';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from '@/Components/ui/sheet';
+import { Button } from '@/Components/ui/button';
+import { Input } from '@/Components/ui/input';
+import { Label } from '@/Components/ui/label';
+import { PageHeaderPrimary } from '@/Components/PageHeader/PageHeaderPrimary';
+import type { ItemTipo, ServiceOrderItemDto } from './ServiceOrderItemRow';
+
+interface Props {
+  serviceOrderId: number;
+  item?: ServiceOrderItemDto | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSaved: (item: ServiceOrderItemDto) => void;
+}
+
+const TIPO_OPTIONS: Array<{ value: ItemTipo; label: string; icon: typeof Wrench; hint: string }> = [
+  { value: 'peca', label: 'Peça', icon: Package, hint: 'Material físico (cilindro, filtro)' },
+  { value: 'mao_obra', label: 'Mão de obra', icon: Wrench, hint: 'Hora trabalhada pelo mecânico' },
+  { value: 'servico_terceiro', label: 'Serviço terceiro', icon: UserCog, hint: 'Subcontratado externo' },
+];
+
+function getCsrfToken(): string {
+  const meta = document.querySelector('meta[name="csrf-token"]');
+  return meta?.getAttribute('content') ?? '';
+}
+
+function toFloat(value: string): number {
+  if (!value) return 0;
+  // Aceita "1,5" (BR) ou "1.5" — normaliza pra ponto
+  const normalized = value.replace(/\./g, '').replace(',', '.');
+  const n = parseFloat(normalized);
+  return Number.isNaN(n) ? 0 : n;
+}
+
+function formatBRL(num: number): string {
+  return num.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+export default function ServiceOrderItemFormSheet({
+  serviceOrderId,
+  item,
+  open,
+  onOpenChange,
+  onSaved,
+}: Props) {
+  const isEdit = !!item;
+
+  const [tipo, setTipo] = useState<ItemTipo>('peca');
+  const [descricao, setDescricao] = useState('');
+  const [quantidade, setQuantidade] = useState('1');
+  const [valorUnitario, setValorUnitario] = useState('');
+  const [notes, setNotes] = useState('');
+  const [saving, setSaving] = useState(false);
+  const [fieldErrors, setFieldErrors] = useState<Record<string, string[]>>({});
+
+  // Reset state ao abrir/trocar item (modo create vs edit).
+  useEffect(() => {
+    if (!open) return;
+    if (item) {
+      setTipo(item.tipo);
+      setDescricao(item.descricao);
+      setQuantidade(String(item.quantidade));
+      setValorUnitario(String(item.valor_unitario));
+      setNotes(item.notes ?? '');
+    } else {
+      setTipo('peca');
+      setDescricao('');
+      setQuantidade('1');
+      setValorUnitario('');
+      setNotes('');
+    }
+    setFieldErrors({});
+  }, [open, item]);
+
+  const totalCalculado = useMemo(() => {
+    return toFloat(quantidade) * toFloat(valorUnitario);
+  }, [quantidade, valorUnitario]);
+
+  const handleSubmit = useCallback(
+    async (e: React.FormEvent) => {
+      e.preventDefault();
+      setSaving(true);
+      setFieldErrors({});
+
+      // Multi-tenant Tier 0 [ADR 0093]: NUNCA enviar business_id (Controller deriva).
+      const payload = {
+        tipo,
+        descricao: descricao.trim(),
+        quantidade: toFloat(quantidade),
+        valor_unitario: toFloat(valorUnitario),
+        notes: notes.trim() || null,
+      };
+
+      const url = isEdit
+        ? `/oficina-auto/ordens-servico/${serviceOrderId}/items/${item!.id}`
+        : `/oficina-auto/ordens-servico/${serviceOrderId}/items`;
+      const method = isEdit ? 'PUT' : 'POST';
+
+      try {
+        const res = await fetch(url, {
+          method,
+          credentials: 'same-origin',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+            'X-CSRF-TOKEN': getCsrfToken(),
+            'X-Requested-With': 'XMLHttpRequest',
+          },
+          body: JSON.stringify(payload),
+        });
+
+        if (res.status === 422) {
+          const json = await res.json();
+          if (json?.errors) {
+            setFieldErrors(json.errors);
+            toast.error('Verifique os campos destacados.');
+          } else {
+            toast.error(json?.message ?? 'Validação falhou.');
+          }
+          return;
+        }
+        if (!res.ok) {
+          const json = await res.json().catch(() => ({}));
+          toast.error(json?.message ?? `Erro HTTP ${res.status}`);
+          return;
+        }
+
+        const json = (await res.json()) as ServiceOrderItemDto;
+        toast.success(isEdit ? 'Item atualizado.' : 'Item adicionado.');
+        onSaved(json);
+        onOpenChange(false);
+      } catch (err) {
+        toast.error(err instanceof Error ? err.message : 'Erro de rede.');
+      } finally {
+        setSaving(false);
+      }
+    },
+    [tipo, descricao, quantidade, valorUnitario, notes, isEdit, item, serviceOrderId, onSaved, onOpenChange],
+  );
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent
+        side="right"
+        className="!w-full sm:!max-w-[480px] flex flex-col p-0 overflow-hidden"
+      >
+        <SheetHeader className="px-6 pt-6 pb-4 border-b border-border">
+          <SheetTitle className="text-lg font-semibold">
+            {isEdit ? 'Editar item' : 'Adicionar item'}
+          </SheetTitle>
+          <SheetDescription className="text-sm text-muted-foreground">
+            {isEdit
+              ? 'Atualiza descrição, quantidade ou valor do item lançado.'
+              : 'Lance peça, mão-de-obra ou serviço terceiro nesta OS.'}
+          </SheetDescription>
+        </SheetHeader>
+
+        <form
+          onSubmit={handleSubmit}
+          className="flex-1 flex flex-col overflow-hidden"
+          id="service-order-item-form"
+        >
+          <div className="flex-1 overflow-y-auto px-6 py-5 space-y-5">
+            {/* Tipo — radio 3 opções */}
+            <div>
+              <Label className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground mb-2 block">
+                Tipo *
+              </Label>
+              <div className="grid grid-cols-1 gap-1.5">
+                {TIPO_OPTIONS.map((opt) => {
+                  const Icon = opt.icon;
+                  const selected = tipo === opt.value;
+                  return (
+                    <button
+                      key={opt.value}
+                      type="button"
+                      onClick={() => setTipo(opt.value)}
+                      className={
+                        'flex items-center gap-3 rounded-md border px-3 py-2 text-left transition-all ' +
+                        (selected
+                          ? 'border-foreground bg-foreground/5'
+                          : 'border-slate-200 hover:border-slate-300 hover:bg-slate-50')
+                      }
+                      aria-pressed={selected}
+                    >
+                      <Icon size={16} className={selected ? 'text-foreground' : 'text-muted-foreground'} />
+                      <div className="min-w-0 flex-1">
+                        <div className="text-sm font-medium text-foreground">{opt.label}</div>
+                        <div className="text-[11px] text-muted-foreground">{opt.hint}</div>
+                      </div>
+                      <span
+                        className={
+                          'h-3.5 w-3.5 rounded-full border-2 shrink-0 ' +
+                          (selected ? 'border-foreground bg-foreground' : 'border-slate-300')
+                        }
+                        aria-hidden
+                      />
+                    </button>
+                  );
+                })}
+              </div>
+              {fieldErrors.tipo && (
+                <p className="text-xs text-destructive mt-1">{fieldErrors.tipo[0]}</p>
+              )}
+            </div>
+
+            {/* Descrição */}
+            <div>
+              <Label htmlFor="item-descricao" className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                Descrição *
+              </Label>
+              <Input
+                id="item-descricao"
+                type="text"
+                maxLength={150}
+                value={descricao}
+                onChange={(e) => setDescricao(e.target.value)}
+                placeholder="Ex: Cilindro hidráulico 6.5T"
+                required
+                autoFocus={!isEdit}
+                className="mt-1"
+              />
+              {fieldErrors.descricao && (
+                <p className="text-xs text-destructive mt-1">{fieldErrors.descricao[0]}</p>
+              )}
+            </div>
+
+            {/* Quantidade + Valor unitário */}
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <Label htmlFor="item-quantidade" className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                  Quantidade *
+                </Label>
+                <Input
+                  id="item-quantidade"
+                  type="number"
+                  step="0.001"
+                  min="0.001"
+                  value={quantidade}
+                  onChange={(e) => setQuantidade(e.target.value)}
+                  required
+                  className="mt-1 tabular-nums"
+                />
+                {fieldErrors.quantidade && (
+                  <p className="text-xs text-destructive mt-1">{fieldErrors.quantidade[0]}</p>
+                )}
+              </div>
+              <div>
+                <Label htmlFor="item-valor-unitario" className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                  Valor unit. (R$) *
+                </Label>
+                <Input
+                  id="item-valor-unitario"
+                  type="number"
+                  step="0.01"
+                  min="0"
+                  value={valorUnitario}
+                  onChange={(e) => setValorUnitario(e.target.value)}
+                  placeholder="0,00"
+                  required
+                  className="mt-1 tabular-nums"
+                />
+                {fieldErrors.valor_unitario && (
+                  <p className="text-xs text-destructive mt-1">{fieldErrors.valor_unitario[0]}</p>
+                )}
+              </div>
+            </div>
+
+            {/* Total calc client-side (readonly visual) */}
+            <div className="rounded-md border border-emerald-200 bg-emerald-50/60 px-3 py-2 flex items-center justify-between">
+              <span className="text-[10.5px] font-semibold uppercase tracking-wider text-emerald-800">
+                Total
+              </span>
+              <span className="text-base tabular-nums font-semibold text-emerald-800">
+                {formatBRL(totalCalculado)}
+              </span>
+            </div>
+
+            {/* Notes opcional */}
+            <div>
+              <Label htmlFor="item-notes" className="text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">
+                Observação (opcional)
+              </Label>
+              <textarea
+                id="item-notes"
+                rows={3}
+                maxLength={1000}
+                value={notes}
+                onChange={(e) => setNotes(e.target.value)}
+                placeholder="Detalhes adicionais sobre o item…"
+                className="mt-1 w-full rounded-md border bg-background px-3 py-2 text-sm"
+              />
+              {fieldErrors.notes && (
+                <p className="text-xs text-destructive mt-1">{fieldErrors.notes[0]}</p>
+              )}
+            </div>
+          </div>
+
+          {/* Footer sticky com ações */}
+          <div className="border-t border-border px-6 py-3 bg-background flex items-center justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => onOpenChange(false)}
+              disabled={saving}
+            >
+              <X className="size-4 mr-1" />
+              Cancelar
+            </Button>
+            {saving ? (
+              <Button type="button" size="sm" disabled>
+                <Loader2 className="size-4 mr-1 animate-spin" />
+                Salvando…
+              </Button>
+            ) : (
+              <PageHeaderPrimary
+                label={isEdit ? 'Salvar' : 'Adicionar'}
+                icon={Save}
+                onClick={() => {
+                  // PageHeaderPrimary renderiza <button type="button"> — disparamos submit
+                  // do form ancestral via id estável. Garante validação HTML5 dos required.
+                  const formEl = document.getElementById(
+                    'service-order-item-form',
+                  ) as HTMLFormElement | null;
+                  if (formEl) formEl.requestSubmit();
+                }}
+              />
+            )}
+          </div>
+        </form>
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderItemRow.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderItemRow.tsx
@@ -1,0 +1,104 @@
+// ServiceOrderItemRow — card per-item lançado na OS (Wave 5 US-OFICINA-005-bis).
+//
+// Espelha visual da seção "PEÇAS & MÃO DE OBRA" do drawer ServiceOrderRichSheet.tsx
+// (PR #1624 Wave 2.3) mas com hover actions Editar/Excluir pra UI de gestão
+// inline em Show.tsx + Edit.tsx (não read-only mais).
+//
+// Multi-tenant Tier 0 [ADR 0093]: callbacks `onEdit`/`onDelete` apenas notificam
+// pai — quem chama Controller (que tem global scope + Policy update). NUNCA
+// envia business_id no payload.
+//
+// CRÍTICO React 19 — handlers descendentes do pai precisam ser useCallback estável.
+
+import { Package, Pencil, Trash2, UserCog, Wrench } from 'lucide-react';
+
+export type ItemTipo = 'peca' | 'mao_obra' | 'servico_terceiro';
+
+export interface ServiceOrderItemDto {
+  id: number;
+  tipo: ItemTipo;
+  descricao: string;
+  quantidade: number | string;
+  valor_unitario: number | string;
+  valor_total: number | string;
+  product_id: number | null;
+  notes: string | null;
+}
+
+interface Props {
+  item: ServiceOrderItemDto;
+  onEdit: (item: ServiceOrderItemDto) => void;
+  onDelete: (item: ServiceOrderItemDto) => void;
+  /** Desabilita actions (durante save/delete em flight). */
+  busy?: boolean;
+}
+
+const TIPO_LABEL: Record<ItemTipo, string> = {
+  peca: 'Peça',
+  mao_obra: 'Mão de obra',
+  servico_terceiro: 'Serviço terceiro',
+};
+
+const TIPO_ICON: Record<ItemTipo, typeof Wrench> = {
+  peca: Package,
+  mao_obra: Wrench,
+  servico_terceiro: UserCog,
+};
+
+function toFloat(value: number | string | null | undefined): number {
+  if (value === null || value === undefined || value === '') return 0;
+  const n = typeof value === 'string' ? parseFloat(value) : value;
+  return Number.isNaN(n) ? 0 : n;
+}
+
+function formatBRL(value: number | string | null | undefined): string {
+  const num = toFloat(value);
+  return num.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+export default function ServiceOrderItemRow({ item, onEdit, onDelete, busy = false }: Props) {
+  const Icon = TIPO_ICON[item.tipo];
+  const qtd = toFloat(item.quantidade);
+  const vu = toFloat(item.valor_unitario);
+  const total = toFloat(item.valor_total);
+
+  return (
+    <li className="group px-3 py-2 grid grid-cols-[auto_1fr_auto_auto] gap-2 items-center text-[11.5px] hover:bg-slate-50/80 transition-colors">
+      <Icon size={14} className="text-muted-foreground shrink-0" aria-hidden />
+      <div className="min-w-0">
+        <div className="text-foreground font-medium truncate">{item.descricao}</div>
+        <div className="text-muted-foreground text-[10.5px]">
+          {TIPO_LABEL[item.tipo]} ·{' '}
+          {qtd.toLocaleString('pt-BR', { maximumFractionDigits: 3 })} × {formatBRL(vu)}
+        </div>
+      </div>
+      <div className="text-foreground tabular-nums font-medium whitespace-nowrap">
+        {formatBRL(total)}
+      </div>
+      {/* Hover actions — visíveis sempre em mobile (group-hover requer hover capable device).
+          Acessibilidade: focus visible via :focus-visible nativo, opacity-100 ao focus. */}
+      <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 focus-within:opacity-100 transition-opacity">
+        <button
+          type="button"
+          onClick={() => onEdit(item)}
+          disabled={busy}
+          className="inline-flex items-center justify-center h-6 w-6 rounded hover:bg-slate-200 text-muted-foreground hover:text-foreground disabled:opacity-40 disabled:cursor-not-allowed"
+          title="Editar item"
+          aria-label="Editar item"
+        >
+          <Pencil size={11} />
+        </button>
+        <button
+          type="button"
+          onClick={() => onDelete(item)}
+          disabled={busy}
+          className="inline-flex items-center justify-center h-6 w-6 rounded hover:bg-rose-100 text-muted-foreground hover:text-rose-700 disabled:opacity-40 disabled:cursor-not-allowed"
+          title="Excluir item"
+          aria-label="Excluir item"
+        >
+          <Trash2 size={11} />
+        </button>
+      </div>
+    </li>
+  );
+}

--- a/resources/js/Pages/OficinaAuto/Vehicles/Index.charter.md
+++ b/resources/js/Pages/OficinaAuto/Vehicles/Index.charter.md
@@ -5,7 +5,12 @@ owner: wagner
 status: live
 last_validated: 2026-05-26
 parent_module: OficinaAuto
-related_adrs: [0137, 0093, 0110, 0171, 0194]
+related_adrs:
+  - 0137-modules-oficinaauto-qualificada
+  - 0093-multi-tenant-isolation-tier-0
+  - 0110-tipografia-canon-h1-subtitle
+  - 0171-oficinaauto-ativacao-piloto-martinho-faseada
+  - 0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada
 tier: A
 charter_version: 2
 ---

--- a/resources/js/Pages/OficinaAuto/Vehicles/Index.charter.md
+++ b/resources/js/Pages/OficinaAuto/Vehicles/Index.charter.md
@@ -3,7 +3,7 @@ page: /oficina-auto/vehicles
 component: resources/js/Pages/OficinaAuto/Vehicles/Index.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-26
+last_validated: "2026-05-26"
 parent_module: OficinaAuto
 related_adrs:
   - 0137-modules-oficinaauto-qualificada


### PR DESCRIPTION
## Resumo

Wave 5 — **UI de lançamento de item da OS** (peça / mão-de-obra / serviço terceiro). Antes desta entrega, cliente acessava Show.tsx via drawer (PR #1624) e via items somente leitura — sem CTA pra adicionar. Esta PR fecha o loop com Sheet lateral 480px + section embutida no Show + Edit.

Wagner aprovou o fluxo no levantamento Martinho-ready (2026-05-26).

## Dependências

⚠️ **Depends on #1624** — backend `ServiceOrderItemController` + rotas `oficinaauto.orders.items.*` + Model `ServiceOrderItem` + migration `oficina_service_order_items`. **NÃO mergear esta PR antes do #1624.** Quando #1624 mergear pra `main`, o base muda automaticamente.

## Entregas

| Arquivo | Tipo | LOC | Comentário |
|---|---|---|---|
| `resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderItemRow.tsx` | new | ~95 | Card per-item · hover actions Editar/Excluir |
| `resources/js/Pages/OficinaAuto/ServiceOrders/_components/ServiceOrderItemFormSheet.tsx` | new | ~290 | Drawer 480px · radio tipo + form + total client-side |
| `resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx` | edit | +148 | Seção "Itens da OS" + CTA primary roxo 295 |
| `resources/js/Pages/OficinaAuto/ServiceOrders/Edit.tsx` | edit | +148 | Section inline idêntica (mode FOCO sem SubNav) |
| `Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php` | edit | +33 | show()/edit() eager-load items + serializam payload Inertia |
| `Modules/OficinaAuto/Tests/Feature/ServiceOrderItemHttpIntegrationTest.php` | new | ~210 | 5 testes — Inertia payload shape + DELETE happy + cross-OS guard |
| `resources/js/Pages/OficinaAuto/ServiceOrders/Show.charter.md` | edit | +2 | charter_version 3 + ADR refs Wave 5 |

**Diff total:** 7 files · +1053 / -6 LOC

## Padrões canon respeitados

- ✅ **ADR 0093 (Multi-tenant Tier 0):** payload do form NUNCA inclui `business_id` — Controller deriva de `auth()->user()` (testado em Wave 1.3 PR #1624 + esta PR cobre cross-OS guard DELETE)
- ✅ **ADR 0179 (drawer-lateral):** `<Sheet side="right" w-[480px]>` pra form simples (760px reservado pra cadastros complexos)
- ✅ **ADR 0190 (primary universal):** `<PageHeaderPrimary>` roxo 295 `oklch(0.55 0.15 295)` — NÃO `<Button>` shadcn cinza
- ✅ **ADR 0182 / skill pageheader-canon:** labels ≤2 palavras ("Adicionar item", "Salvar", "Editar", "Excluir")
- ✅ **React 19 (lição PR #717):** `useMemo` em `totalCalculado` + `useCallback` em todos handlers descendentes
- ✅ **Show.tsx = mode NAV** preserva PageHeader existente · **Edit.tsx = mode FOCO** sem SubNav adicional

## UX flow

1. Show.tsx → seção "Itens da OS" com lista (ou empty state) + CTA "Adicionar item" roxo
2. Click → Sheet 480px abre com radio (Peça/Mão de obra/Serviço terceiro) + form + total live
3. Salva → POST `/oficina-auto/ordens-servico/{id}/items` → item aparece **otimistic** (sem reload)
4. Hover row mostra Editar/Excluir → ações inline
5. DELETE com `window.confirm` + optimistic remove + rollback se 4xx

## Tests

```
Modules/OficinaAuto/Tests/Feature/ServiceOrderItemHttpIntegrationTest.php
  ✓ Inertia GET show inclui items[] no payload
  ✓ Inertia GET edit inclui items[] no payload
  ✓ Inertia GET show sem items retorna [] (não null)
  ✓ HTTP DELETE happy path → 200 + soft delete
  ✓ HTTP DELETE cross-OS → 404 abort guard
```

Pattern espelha `ServiceOrderObserverItemsAndHttpTest` (Wave 1.3 PR #1624).
SQLite-skipped (precisa schema MySQL UltimatePOS · ADR 0101).

## Não-escopo (preservado)

- ❌ NÃO toca `ServiceOrderRichSheet.tsx` (drawer Cowork PR #1624 — seção PEÇAS read-only continua só pra leitura no kanban Producao)
- ❌ NÃO toca `ServiceOrderItemController` (backend já existe em PR #1624)
- ❌ NÃO toca Vehicles/ProducaoOficina/outros módulos
- ❌ NÃO altera `PageHeader` shared (erros TS pré-existentes em `subtitle`/`icon`/`actions` mantidos · fora escopo)

## Test plan

- [ ] Mergear #1624 primeiro · esta PR rebase trivial em `main` após
- [ ] Smoke biz=1 admin → /oficina-auto/ordens-servico/{id} → click "Adicionar item" → salva → vê item na lista
- [ ] Hover row → click Editar → Sheet abre populado → muda valor → salva → row atualiza
- [ ] Hover row → click Excluir → confirm → row some otimistic → toast success
- [ ] Repetir fluxo em Edit.tsx (seção inline) — sem reload entre form OS + items
- [ ] Pest run `php artisan test Modules/OficinaAuto/Tests/Feature/ServiceOrderItemHttpIntegrationTest.php` (em MySQL · CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)