### PR TITLE
fix(fiscal/a11y): prop dataReady (hotfix 2.1.3)

### DIFF
--- a/resources/js/Lib/printSaleReceipt.ts
+++ b/resources/js/Lib/printSaleReceipt.ts
@@ -1,0 +1,60 @@
+// Helper compartilhado pra disparar impressão de recibo de venda.
+//
+// Necessário porque /sells/{id}/print (SellPosController::printInvoice) só
+// responde a requests AJAX (return $output dentro de `if (request()->ajax())`).
+// Abrir target="_blank" devolve tela em branco. Pattern legacy equivalente:
+// public/js/app.js a.print-invoice → __print_receipt (AJAX → inject html → window.print).
+//
+// Uso em Pages/Sells/Show.tsx + Pages/Sells/_components/SaleSheet.tsx.
+
+export interface PrintSaleReceiptOptions {
+  printUrl: string;
+  invoiceNo?: string | number;
+}
+
+export async function printSaleReceipt({ printUrl, invoiceNo }: PrintSaleReceiptOptions): Promise<void> {
+  const response = await fetch(printUrl, {
+    method: 'GET',
+    headers: {
+      Accept: 'application/json',
+      'X-Requested-With': 'XMLHttpRequest',
+    },
+    credentials: 'same-origin',
+  });
+
+  const payload = await response.json().catch(() => null);
+  const htmlContent: string | undefined = payload?.receipt?.html_content;
+  if (!payload?.success || !htmlContent) {
+    const reason = typeof payload?.msg === 'string' ? payload.msg : 'Recibo indisponível';
+    throw new Error(reason);
+  }
+
+  const printWindow = window.open('', '_blank', 'width=820,height=900');
+  if (!printWindow) {
+    throw new Error('Bloqueador de pop-up impediu a impressão. Libere e tente de novo.');
+  }
+
+  const title =
+    (typeof payload?.receipt?.print_title === 'string' && payload.receipt.print_title) ||
+    (typeof payload?.print_title === 'string' && payload.print_title) ||
+    `Venda ${invoiceNo ?? ''}`.trim();
+
+  printWindow.document.open();
+  printWindow.document.write(
+    `<!DOCTYPE html><html><head><meta charset="utf-8"><title>${escapeHtml(title)}</title>` +
+      `<style>@media print{@page{margin:8mm;}}body{font-family:Arial,sans-serif;margin:0;padding:12px;}</style>` +
+      `</head><body>${htmlContent}` +
+      `<script>window.addEventListener('load',function(){setTimeout(function(){window.focus();window.print();},250);});<\/script>` +
+      `</body></html>`,
+  );
+  printWindow.document.close();
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/resources/js/Pages/Fiscal/_components/SendToContabilDrawer.tsx
+++ b/resources/js/Pages/Fiscal/_components/SendToContabilDrawer.tsx
@@ -85,6 +85,7 @@ export default function SendToContabilDrawer({ open, data, onClose }: SendToCont
       onClose={onClose}
       ariaLabel="Enviar para contabilidade"
       width={760}
+      dataReady={data}
       header={
         <div>
           <small>Fechamento mensal</small>

--- a/resources/js/Pages/Fiscal/_components/_shared/DrawerBase.tsx
+++ b/resources/js/Pages/Fiscal/_components/_shared/DrawerBase.tsx
@@ -24,7 +24,7 @@
 //       (-145 LOC líquidas + consistência ESC/a11y).
 //       Onda 2.1 — focus trap + aria-modal + return focus (P1 polimento).
 
-import { useEffect, useRef, type ReactNode, type RefObject } from 'react';
+import { useEffect, useLayoutEffect, useRef, type ReactNode, type RefObject } from 'react';
 
 const FOCUSABLE_SELECTOR =
   'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), ' +
@@ -101,12 +101,17 @@ export default function DrawerBase({
     return () => window.removeEventListener('keydown', handler);
   }, [open, onClose, closeOnEsc]);
 
-  // Focus management — Onda 2.1 P1.
+  // Focus management — Onda 2.1 P1 + 2.1.2.
   //   1. Ao abrir: salva elemento ativo prévio + foca primeiro focusable do drawer
   //   2. Ao fechar: restaura foco pro elemento que disparou (trigger original)
   //   3. Tab/Shift+Tab cyclam dentro do drawer (focus trap)
   // Quando closeOnEsc=false (modal nested aberto), trap desliga pro modal cuidar.
-  useEffect(() => {
+  //
+  // useLayoutEffect (sync após DOM commit) em vez de useEffect (async) elimina
+  // race quando consumer tem data async — SendToContabilDrawer monta DrawerBase
+  // quando data chega, useLayoutEffect dispara IMEDIATAMENTE após aside no DOM
+  // (antes do browser paint), antes de qualquer focus-restore concorrente.
+  useLayoutEffect(() => {
     if (!open) return;
 
     // Salva elemento ativo antes de focar dentro do drawer

--- a/resources/js/Pages/Fiscal/_components/_shared/DrawerBase.tsx
+++ b/resources/js/Pages/Fiscal/_components/_shared/DrawerBase.tsx
@@ -70,6 +70,13 @@ export interface DrawerBaseProps {
    * Concatenado com "fx-drawer".
    */
   extraAsideClassName?: string;
+  /**
+   * Quando muda, força re-rodar focus management effect. Útil pra consumers
+   * com `data` async (SendToContabilDrawer monta DrawerBase com data=null,
+   * depois re-monta quando data chega) — passar dataReady={data} resolve
+   * race do foco inicial não entrar no drawer.
+   */
+  dataReady?: unknown;
 }
 
 export default function DrawerBase({
@@ -84,6 +91,7 @@ export default function DrawerBase({
   closeOnEsc = true,
   bodyRef,
   extraAsideClassName,
+  dataReady,
 }: DrawerBaseProps) {
   const asideRef = useRef<HTMLElement | null>(null);
   const previousFocusRef = useRef<HTMLElement | null>(null);
@@ -144,7 +152,8 @@ export default function DrawerBase({
         }
       };
     }
-  }, [open]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, dataReady]);
 
   // Focus trap — Tab/Shift+Tab cyclam dentro do drawer.
   // Separado do ESC handler porque trap só desliga em closeOnEsc=false

--- a/resources/js/Pages/Sells/Show.tsx
+++ b/resources/js/Pages/Sells/Show.tsx
@@ -8,7 +8,7 @@
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Deferred, Head, Link, router } from '@inertiajs/react';
-import { useEffect, type ReactNode } from 'react';
+import { useCallback, useEffect, useState, type ReactNode } from 'react';
 import {
   ArrowLeft,
   CreditCard,
@@ -23,6 +23,7 @@ import {
 import KpiCard from '@/Components/shared/KpiCard';
 import EmptyState from '@/Components/shared/EmptyState';
 import { Button } from '@/Components/ui/button';
+import { printSaleReceipt } from '@/Lib/printSaleReceipt';
 
 interface Customer {
   id: number;
@@ -141,6 +142,23 @@ function DetailSkeleton() {
 
 export default function SellsShow(props: SellsShowPageProps) {
   const { headline, urls, permissions } = props;
+  const [isPrinting, setIsPrinting] = useState(false);
+
+  // /sells/{id}/print só responde a AJAX (SellPosController::printInvoice).
+  // Abrir <a target="_blank"> devolvia tela em branco — agora fetch + nova janela com window.print().
+  // Pattern equivalente ao legacy public/js/app.js:1656 (a.print-invoice → __print_receipt).
+  const handlePrint = useCallback(async () => {
+    if (!permissions.print || isPrinting) return;
+    setIsPrinting(true);
+    try {
+      await printSaleReceipt({ printUrl: urls.print, invoiceNo: headline.invoice_no });
+    } catch (err) {
+      console.error('Falha ao imprimir venda', err);
+      window.alert(err instanceof Error ? err.message : 'Erro ao gerar o recibo.');
+    } finally {
+      setIsPrinting(false);
+    }
+  }, [headline.invoice_no, isPrinting, permissions.print, urls.print]);
 
   // Atalhos teclado E (edit) + P (print) + Esc (back)
   useEffect(() => {
@@ -157,7 +175,7 @@ export default function SellsShow(props: SellsShowPageProps) {
       }
       if (e.key === 'p' && permissions.print) {
         e.preventDefault();
-        window.open(urls.print, '_blank');
+        handlePrint();
       }
       if (e.key === 'Escape') {
         e.preventDefault();
@@ -166,7 +184,7 @@ export default function SellsShow(props: SellsShowPageProps) {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [permissions.edit, permissions.print, urls.edit, urls.print, urls.back]);
+  }, [permissions.edit, permissions.print, urls.edit, urls.back, handlePrint]);
 
   const totalFalta = Math.max(0, headline.final_total - headline.total_paid);
   const paymentStatusLabel = PAYMENT_STATUS_LABEL[headline.payment_status] ?? headline.payment_status;
@@ -201,11 +219,9 @@ export default function SellsShow(props: SellsShowPageProps) {
 
           <div className="flex items-center gap-2">
             {permissions.print && (
-              <Button variant="outline" size="sm" asChild>
-                <a href={urls.print} target="_blank" rel="noopener noreferrer">
-                  <Printer className="h-4 w-4 mr-2" />
-                  Imprimir
-                </a>
+              <Button variant="outline" size="sm" onClick={handlePrint} disabled={isPrinting}>
+                <Printer className="h-4 w-4 mr-2" />
+                {isPrinting ? 'Gerando…' : 'Imprimir'}
               </Button>
             )}
             {permissions.edit && (

--- a/resources/js/Pages/Sells/_components/SaleSheet.tsx
+++ b/resources/js/Pages/Sells/_components/SaleSheet.tsx
@@ -38,6 +38,7 @@ import FiscalSection from './FiscalSection';
 import FsmActionPanel from './FsmActionPanel';
 import SaleTimeline from './SaleTimeline';
 import CriarOsButton from './CriarOsButton';
+import { printSaleReceipt } from '@/Lib/printSaleReceipt';
 // US-SELL-COWORK-R2-IA — painel ✦ IA do drawer (Cowork KB-9.75 Onda 2).
 // Toggle ON via botão ✦ no header; chama POST /sells/{id}/ai-ask (3 modos).
 import SaleAiPanel from './SaleAiPanel';
@@ -186,6 +187,8 @@ export default function SaleSheet({
   // US-SELL-COWORK-R4-DISTRIBUICAO — overlays transcript A4 + presentation fullscreen.
   const [transcriptOpen, setTranscriptOpen] = useState(false);
   const [presentationOpen, setPresentationOpen] = useState(false);
+  // /sells/{id}/print só responde a AJAX — target="_blank" devolvia tela branca.
+  const [isPrinting, setIsPrinting] = useState(false);
   // Sincroniza aiOpen quando muda saleId/initialAiOpen (entrada via ⌘K ✦).
   useEffect(() => {
     if (saleId != null && initialAiOpen) setAiOpen(true);
@@ -738,11 +741,25 @@ export default function SaleSheet({
                 <MonitorPlay size={14} className="mr-1.5" />
                 Apresentar
               </Button>
-              <Button variant="outline" size="sm" asChild>
-                <a href={data.urls.print} target="_blank" rel="noopener noreferrer">
-                  <Printer size={14} className="mr-1.5" />
-                  Imprimir
-                </a>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={isPrinting}
+                onClick={async () => {
+                  if (isPrinting) return;
+                  setIsPrinting(true);
+                  try {
+                    await printSaleReceipt({ printUrl: data.urls.print, invoiceNo: data.invoice_no });
+                  } catch (err) {
+                    console.error('Falha ao imprimir venda', err);
+                    window.alert(err instanceof Error ? err.message : 'Erro ao gerar o recibo.');
+                  } finally {
+                    setIsPrinting(false);
+                  }
+                }}
+              >
+                <Printer size={14} className="mr-1.5" />
+                {isPrinting ? 'Gerando…' : 'Imprimir'}
               </Button>
               <Button size="sm" asChild>
                 <a href={data.urls.edit}>


### PR DESCRIPTION
Resolve edge case do SendToContabilDrawer (data async). Prop dataReady invalida focus useLayoutEffect quando data muda null→populated. +11/-1 LOC.