### PR TITLE
fix(sells/print): iframe oculto + CSS legacy + 3 modos (recibo/romaneio/nota)

### DIFF
--- a/resources/js/Lib/printSaleReceipt.ts
+++ b/resources/js/Lib/printSaleReceipt.ts
@@ -1,19 +1,45 @@
 // Helper compartilhado pra disparar impressão de recibo de venda.
 //
-// Necessário porque /sells/{id}/print (SellPosController::printInvoice) só
-// responde a requests AJAX (return $output dentro de `if (request()->ajax())`).
-// Abrir target="_blank" devolve tela em branco. Pattern legacy equivalente:
-// public/js/app.js a.print-invoice → __print_receipt (AJAX → inject html → window.print).
+// Padrão IFRAME OCULTO + CSS legacy embutido:
+//   - /sells/{id}/print (SellPosController::printInvoice) só responde a requests AJAX.
+//   - Devolve {receipt:{html_content}} com HTML baseado em Bootstrap 3 (col-xs-12,
+//     pull-left, text-center) + classes da app legacy (.print_section, .invoice).
+//   - Usar `window.open()` puro descarrega o CSS → layout fica quebrado.
+//   - Em vez disso, criamos um <iframe> oculto na própria página Inertia carregando
+//     `/css/app.css` (tem `@media print { .print_section { display: inline !important } }`
+//     + classes Bootstrap 3 legacy + invoice CSS) e injetamos o html_content dentro
+//     da section `#receipt_section`. Depois chamamos `iframe.contentWindow.print()`.
+//   - Equivale ao legacy `public/js/app.js:1656` (a.print-invoice → __print_receipt),
+//     que injetava em `#receipt_section` do próprio `<body>` e chamava window.print().
+//
+// 3 modos do legacy (sale_pos/show.blade.php:413/416 + SellController:437-440):
+//   - 'invoice'       → GET /sells/{id}/print
+//   - 'packing_slip'  → GET /sells/{id}/print?package_slip=true
+//   - 'delivery_note' → GET /sells/{id}/print?delivery_note=true
 //
 // Uso em Pages/Sells/Show.tsx + Pages/Sells/_components/SaleSheet.tsx.
+
+export type PrintSaleMode = 'invoice' | 'packing_slip' | 'delivery_note';
 
 export interface PrintSaleReceiptOptions {
   printUrl: string;
   invoiceNo?: string | number;
+  mode?: PrintSaleMode;
 }
 
-export async function printSaleReceipt({ printUrl, invoiceNo }: PrintSaleReceiptOptions): Promise<void> {
-  const response = await fetch(printUrl, {
+const MODE_QUERY: Record<PrintSaleMode, string> = {
+  invoice: '',
+  packing_slip: '?package_slip=true',
+  delivery_note: '?delivery_note=true',
+};
+
+export async function printSaleReceipt({
+  printUrl,
+  invoiceNo,
+  mode = 'invoice',
+}: PrintSaleReceiptOptions): Promise<void> {
+  const url = printUrl + MODE_QUERY[mode];
+  const response = await fetch(url, {
     method: 'GET',
     headers: {
       Accept: 'application/json',
@@ -29,25 +55,80 @@ export async function printSaleReceipt({ printUrl, invoiceNo }: PrintSaleReceipt
     throw new Error(reason);
   }
 
-  const printWindow = window.open('', '_blank', 'width=820,height=900');
-  if (!printWindow) {
-    throw new Error('Bloqueador de pop-up impediu a impressão. Libere e tente de novo.');
-  }
-
   const title =
     (typeof payload?.receipt?.print_title === 'string' && payload.receipt.print_title) ||
     (typeof payload?.print_title === 'string' && payload.print_title) ||
     `Venda ${invoiceNo ?? ''}`.trim();
 
-  printWindow.document.open();
-  printWindow.document.write(
-    `<!DOCTYPE html><html><head><meta charset="utf-8"><title>${escapeHtml(title)}</title>` +
-      `<style>@media print{@page{margin:8mm;}}body{font-family:Arial,sans-serif;margin:0;padding:12px;}</style>` +
-      `</head><body>${htmlContent}` +
-      `<script>window.addEventListener('load',function(){setTimeout(function(){window.focus();window.print();},250);});<\/script>` +
-      `</body></html>`,
-  );
-  printWindow.document.close();
+  await renderInHiddenIframe({ htmlContent, title });
+}
+
+interface RenderArgs {
+  htmlContent: string;
+  title: string;
+}
+
+function renderInHiddenIframe({ htmlContent, title }: RenderArgs): Promise<void> {
+  return new Promise((resolve) => {
+    // Remove iframe anterior se houver (segurança contra duplo-click).
+    const previous = document.getElementById('sale-receipt-print-iframe');
+    if (previous) previous.remove();
+
+    const iframe = document.createElement('iframe');
+    iframe.id = 'sale-receipt-print-iframe';
+    iframe.setAttribute('aria-hidden', 'true');
+    iframe.style.position = 'fixed';
+    iframe.style.right = '0';
+    iframe.style.bottom = '0';
+    iframe.style.width = '0';
+    iframe.style.height = '0';
+    iframe.style.border = '0';
+    iframe.style.visibility = 'hidden';
+
+    // Stylesheets do legacy que dão Bootstrap 3 + .print_section + .invoice CSS.
+    // (`/css/app.css` linha 703-719: .print_section{display:none} + @media print { display:inline !important }).
+    // Também carrega init.css (resets) e tailwind/app.css (utilitários tw-* usados em alguns templates).
+    const stylesheets = ['/css/app.css', '/css/init.css', '/css/tailwind/app.css']
+      .map((href) => `<link rel="stylesheet" href="${href}">`)
+      .join('');
+
+    const srcdoc = `<!DOCTYPE html><html><head><meta charset="utf-8"><title>${escapeHtml(title)}</title>${stylesheets}
+<style>
+  /* Mostra a section também na tela do iframe (legacy só mostra em @media print) */
+  body { margin: 0; padding: 12px; background: white; }
+  .print_section { display: block !important; }
+  .no-print { display: none !important; }
+  @page { margin: 8mm; }
+</style>
+</head><body>
+<section class="invoice print_section" id="receipt_section">${htmlContent}</section>
+<script>
+(function(){
+  function go(){
+    try {
+      if (typeof window.parent !== 'undefined' && typeof window.parent.__currency_convert_recursively === 'function') {
+        try { window.parent.__currency_convert_recursively(document.getElementById('receipt_section')); } catch(e){}
+      }
+      setTimeout(function(){ window.focus(); window.print(); }, 200);
+    } catch(e) { console.error('print error', e); }
+  }
+  if (document.readyState === 'complete') { go(); } else { window.addEventListener('load', go); }
+})();
+<\/script>
+</body></html>`;
+
+    iframe.srcdoc = srcdoc;
+    iframe.addEventListener('load', () => {
+      // Resolve cedo — o print() é disparado pelo script dentro do iframe.
+      // Limpa iframe ~30s depois (suficiente pro user fechar a janela nativa de impressão).
+      setTimeout(() => {
+        try { iframe.remove(); } catch {}
+      }, 30000);
+      resolve();
+    }, { once: true });
+
+    document.body.appendChild(iframe);
+  });
 }
 
 function escapeHtml(value: string): string {

--- a/resources/js/Pages/Sells/Show.tsx
+++ b/resources/js/Pages/Sells/Show.tsx
@@ -23,7 +23,13 @@ import {
 import KpiCard from '@/Components/shared/KpiCard';
 import EmptyState from '@/Components/shared/EmptyState';
 import { Button } from '@/Components/ui/button';
-import { printSaleReceipt } from '@/Lib/printSaleReceipt';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/Components/ui/dropdown-menu';
+import { printSaleReceipt, type PrintSaleMode } from '@/Lib/printSaleReceipt';
 
 interface Customer {
   id: number;
@@ -145,20 +151,24 @@ export default function SellsShow(props: SellsShowPageProps) {
   const [isPrinting, setIsPrinting] = useState(false);
 
   // /sells/{id}/print só responde a AJAX (SellPosController::printInvoice).
-  // Abrir <a target="_blank"> devolvia tela em branco — agora fetch + nova janela com window.print().
-  // Pattern equivalente ao legacy public/js/app.js:1656 (a.print-invoice → __print_receipt).
-  const handlePrint = useCallback(async () => {
-    if (!permissions.print || isPrinting) return;
-    setIsPrinting(true);
-    try {
-      await printSaleReceipt({ printUrl: urls.print, invoiceNo: headline.invoice_no });
-    } catch (err) {
-      console.error('Falha ao imprimir venda', err);
-      window.alert(err instanceof Error ? err.message : 'Erro ao gerar o recibo.');
-    } finally {
-      setIsPrinting(false);
-    }
-  }, [headline.invoice_no, isPrinting, permissions.print, urls.print]);
+  // Render via iframe oculto + CSS legacy (Bootstrap 3 + .print_section) — pattern equivale
+  // ao legacy public/js/app.js:1656 (a.print-invoice → __print_receipt). 3 modos do legacy
+  // sale_pos/show.blade.php:413/416 (invoice / packing_slip / delivery_note).
+  const handlePrint = useCallback(
+    async (mode: PrintSaleMode = 'invoice') => {
+      if (!permissions.print || isPrinting) return;
+      setIsPrinting(true);
+      try {
+        await printSaleReceipt({ printUrl: urls.print, invoiceNo: headline.invoice_no, mode });
+      } catch (err) {
+        console.error('Falha ao imprimir venda', err);
+        window.alert(err instanceof Error ? err.message : 'Erro ao gerar o recibo.');
+      } finally {
+        setIsPrinting(false);
+      }
+    },
+    [headline.invoice_no, isPrinting, permissions.print, urls.print],
+  );
 
   // Atalhos teclado E (edit) + P (print) + Esc (back)
   useEffect(() => {
@@ -175,7 +185,7 @@ export default function SellsShow(props: SellsShowPageProps) {
       }
       if (e.key === 'p' && permissions.print) {
         e.preventDefault();
-        handlePrint();
+        handlePrint('invoice');
       }
       if (e.key === 'Escape') {
         e.preventDefault();
@@ -219,10 +229,25 @@ export default function SellsShow(props: SellsShowPageProps) {
 
           <div className="flex items-center gap-2">
             {permissions.print && (
-              <Button variant="outline" size="sm" onClick={handlePrint} disabled={isPrinting}>
-                <Printer className="h-4 w-4 mr-2" />
-                {isPrinting ? 'Gerando…' : 'Imprimir'}
-              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" size="sm" disabled={isPrinting}>
+                    <Printer className="h-4 w-4 mr-2" />
+                    {isPrinting ? 'Gerando…' : 'Imprimir'}
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  <DropdownMenuItem onSelect={() => handlePrint('invoice')}>
+                    Recibo / fatura (P)
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => handlePrint('packing_slip')}>
+                    Romaneio / packing slip
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => handlePrint('delivery_note')}>
+                    Nota de entrega
+                  </DropdownMenuItem>
+                </DropdownMenuContent>
+              </DropdownMenu>
             )}
             {permissions.edit && (
               <Button variant="default" size="sm" asChild>

--- a/resources/js/Pages/Sells/_components/SaleSheet.tsx
+++ b/resources/js/Pages/Sells/_components/SaleSheet.tsx
@@ -34,11 +34,17 @@ import {
   SheetDescription,
 } from '@/Components/ui/sheet';
 import { Button } from '@/Components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/Components/ui/dropdown-menu';
 import FiscalSection from './FiscalSection';
 import FsmActionPanel from './FsmActionPanel';
 import SaleTimeline from './SaleTimeline';
 import CriarOsButton from './CriarOsButton';
-import { printSaleReceipt } from '@/Lib/printSaleReceipt';
+import { printSaleReceipt, type PrintSaleMode } from '@/Lib/printSaleReceipt';
 // US-SELL-COWORK-R2-IA — painel ✦ IA do drawer (Cowork KB-9.75 Onda 2).
 // Toggle ON via botão ✦ no header; chama POST /sells/{id}/ai-ask (3 modos).
 import SaleAiPanel from './SaleAiPanel';
@@ -741,26 +747,41 @@ export default function SaleSheet({
                 <MonitorPlay size={14} className="mr-1.5" />
                 Apresentar
               </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={isPrinting}
-                onClick={async () => {
-                  if (isPrinting) return;
-                  setIsPrinting(true);
-                  try {
-                    await printSaleReceipt({ printUrl: data.urls.print, invoiceNo: data.invoice_no });
-                  } catch (err) {
-                    console.error('Falha ao imprimir venda', err);
-                    window.alert(err instanceof Error ? err.message : 'Erro ao gerar o recibo.');
-                  } finally {
-                    setIsPrinting(false);
-                  }
-                }}
-              >
-                <Printer size={14} className="mr-1.5" />
-                {isPrinting ? 'Gerando…' : 'Imprimir'}
-              </Button>
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button variant="outline" size="sm" disabled={isPrinting}>
+                    <Printer size={14} className="mr-1.5" />
+                    {isPrinting ? 'Gerando…' : 'Imprimir'}
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  {(['invoice', 'packing_slip', 'delivery_note'] as PrintSaleMode[]).map((mode) => (
+                    <DropdownMenuItem
+                      key={mode}
+                      onSelect={async () => {
+                        if (isPrinting) return;
+                        setIsPrinting(true);
+                        try {
+                          await printSaleReceipt({
+                            printUrl: data.urls.print,
+                            invoiceNo: data.invoice_no,
+                            mode,
+                          });
+                        } catch (err) {
+                          console.error('Falha ao imprimir venda', err);
+                          window.alert(err instanceof Error ? err.message : 'Erro ao gerar o recibo.');
+                        } finally {
+                          setIsPrinting(false);
+                        }
+                      }}
+                    >
+                      {mode === 'invoice' && 'Recibo / fatura'}
+                      {mode === 'packing_slip' && 'Romaneio / packing slip'}
+                      {mode === 'delivery_note' && 'Nota de entrega'}
+                    </DropdownMenuItem>
+                  ))}
+                </DropdownMenuContent>
+              </DropdownMenu>
               <Button size="sm" asChild>
                 <a href={data.urls.edit}>
                   <Edit size={14} className="mr-1.5" />


### PR DESCRIPTION
## Summary

Refator do helper `printSaleReceipt` — substitui `window.open()` por **iframe oculto** na própria página Inertia carregando `/css/app.css` + `/css/init.css` + `/css/tailwind/app.css`. Esses CSS dão **Bootstrap 3 + `.print_section` + `.invoice`** necessários pros 6 layouts legacy (`classic`/`slim`/`slim2`/`elegant`/`elegant_modified`/`detailed`/`columnize-taxes`) renderizarem como no Blade antigo.

E restaura os **3 modos do legacy** ([sale_pos/show.blade.php:413/416](resources/views/sale_pos/show.blade.php#L413)):
- **Recibo / fatura** → `/sells/{id}/print`
- **Romaneio / packing slip** → `?package_slip=true`
- **Nota de entrega** → `?delivery_note=true`

UI agora é **DropdownMenu** em [Show.tsx](resources/js/Pages/Sells/Show.tsx) + drawer [SaleSheet.tsx](resources/js/Pages/Sells/_components/SaleSheet.tsx).

## Por que (gap descoberto pelo Wagner pós-deploy v1)

Feedback Wagner 2026-05-26: *\"impressão era mais bonita e com mais opções\"*. PR #1628 (v1) tinha 4 regressões vs Blade legacy:

1. ❌ `window.open()` abria popup **sem Bootstrap 3** → `col-xs-12`, `pull-left`, `text-center` quebravam
2. ❌ Faltava dropdown com `packing_slip` + `delivery_note` (legacy tinha)
3. ❌ `__currency_convert_recursively` não rodava
4. ⚠️ Popup-blocker bloqueava em alguns contextos

## Como funciona agora

1. Fetch AJAX devolve `{receipt:{html_content}}` (backend não muda)
2. Cria `<iframe id=\"sale-receipt-print-iframe\">` oculto (`position:fixed; w:0; h:0`)
3. `srcdoc` carrega os 3 stylesheets legacy + injeta `<section class=\"invoice print_section\" id=\"receipt_section\">{html_content}</section>` (mesma estrutura do [layouts/app.blade.php:108](resources/views/layouts/app.blade.php#L108))
4. Script dentro do iframe tenta chamar `window.parent.__currency_convert_recursively` (compat legacy) → depois `window.print()` do contexto do iframe
5. Iframe self-remove após 30s

Sem popup-blocker (iframe não dispara security check). Backend `SellPosController::printInvoice` já trata `$is_package_slip`/`$is_delivery_note` ([linhas 1950/1951](app/Http/Controllers/SellPosController.php#L1950)) — só faltava o frontend chamar.

## Test plan

- [ ] Build:inertia limpo (rodado local antes do push)
- [ ] Após merge + deploy: clicar **Imprimir** → dropdown abre com 3 opções
- [ ] **Recibo / fatura** → iframe renderiza com Bootstrap 3 (colunas, centralização) idêntico à Blade legacy
- [ ] **Romaneio** → backend retorna `packing_slip.blade.php` (234 linhas)
- [ ] **Nota de entrega** → backend retorna `delivery_note.blade.php` (279 linhas)
- [ ] Atalho `P` em /sells/{id} (Show) dispara modo `invoice`
- [ ] Valores monetários formatados (BRL R$) via `__currency_convert_recursively` se disponível no window

🤖 Generated with [Claude Code](https://claude.com/claude-code)