### PR TITLE
feat(sells): KB-9.75 P0 batch — VdNextActionPanel + validações fiscais BR + glossário corrigido

### DIFF
--- a/config/ui-lint-baseline.json
+++ b/config/ui-lint-baseline.json
@@ -942,6 +942,9 @@
         "resources\/js\/Pages\/Sells\/_components\/SaleTimeline.tsx": {
             "R1": 44
         },
+        "resources\/js\/Pages\/Sells\/_components\/VdNextActionPanel.tsx": {
+            "R3": 3
+        },
         "resources\/js\/Pages\/Settings\/PaymentGateways\/CnabRetorno.tsx": {
             "R1": 38
         },

--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -5,6 +5,9 @@
 /* Sells/Index Cowork visual — escopado em .sells-cowork (ver scripts/scope-sells-cowork-css.py) */
 @import "./sells-cowork.css";
 
+/* Sells KB-9.75 NextActionPanel + validações fiscais BR (Cowork bundle 2026-05-26 P0 gaps #1/#5) */
+@import "./sells-kb975-next-action.css";
+
 /* Sells Cowork Onda 2 R2 IA drawer — escopado em .sells-cowork + .sells-cowork-ia-panel */
 @import "./sells-cowork-ia.css";
 

--- a/resources/css/sells-kb975-next-action.css
+++ b/resources/css/sells-kb975-next-action.css
@@ -1,0 +1,280 @@
+/* sells-kb975-next-action.css — KB-9.75 Cowork bundle 2026-05-26 P0 gap #1
+ * Tokens .vd-next-* pra VdNextActionPanel + .vd-validation-* pra feedback inline fiscal BR
+ * Escopo .sells-cowork .vendas-aplus pra coexistir com legacy
+ * Refs:
+ *   - memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md
+ *   - prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/vendas.css linhas .vd-next-*
+ */
+
+/* ============================================================
+ * VdNextActionPanel — painel "Próxima Ação"
+ * ============================================================ */
+
+.sells-cowork .vendas-aplus .vd-next {
+  margin: 0 0 16px;
+  border: 1px solid oklch(0.91 0.01 250);
+  border-radius: 10px;
+  background: oklch(0.99 0.005 250);
+  overflow: hidden;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.03);
+}
+
+.sells-cowork .vendas-aplus .vd-next-h {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 16px;
+  padding: 16px 18px;
+}
+
+.sells-cowork .vendas-aplus .vd-next-now {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sells-cowork .vendas-aplus .vd-next-now > small,
+.sells-cowork .vendas-aplus .vd-next-cta > small {
+  font-size: 10.5px;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: oklch(0.55 0.01 250);
+  font-weight: 600;
+}
+
+.sells-cowork .vendas-aplus .vd-next-now > b {
+  font-size: 17px;
+  font-weight: 600;
+  color: oklch(0.20 0.01 250);
+}
+
+.sells-cowork .vendas-aplus .vd-next-progress {
+  display: inline-flex;
+  gap: 4px;
+  margin-top: 3px;
+}
+
+.sells-cowork .vendas-aplus .vd-next-dot {
+  width: 16px;
+  height: 4px;
+  border-radius: 2px;
+  background: oklch(0.92 0.01 250);
+}
+
+.sells-cowork .vendas-aplus .vd-next-dot.done {
+  background: oklch(0.55 0.10 155);
+}
+
+.sells-cowork .vendas-aplus .vd-next-dot.current {
+  background: oklch(0.55 0.13 240);
+  box-shadow: 0 0 0 2px oklch(0.55 0.13 240 / 0.18);
+}
+
+.sells-cowork .vendas-aplus .vd-next-arr {
+  font-size: 22px;
+  color: oklch(0.70 0.02 250);
+  opacity: 0.55;
+}
+
+.sells-cowork .vendas-aplus .vd-next-cta {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-end;
+}
+
+.sells-cowork .vendas-aplus .vd-next-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 9px 15px;
+  border-radius: 8px;
+  border: 0;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.sells-cowork .vendas-aplus .vd-next-btn:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 3px 10px rgba(0, 0, 0, 0.10);
+}
+
+.sells-cowork .vendas-aplus .vd-next-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+  transform: none;
+}
+
+.sells-cowork .vendas-aplus .vd-next-btn.blue   { background: oklch(0.55 0.13 240); color: #fff; }
+.sells-cowork .vendas-aplus .vd-next-btn.indigo { background: oklch(0.50 0.18 270); color: #fff; }
+.sells-cowork .vendas-aplus .vd-next-btn.amber  { background: oklch(0.65 0.16 75);  color: oklch(0.20 0.05 75); }
+.sells-cowork .vendas-aplus .vd-next-btn.green  { background: oklch(0.55 0.12 155); color: #fff; }
+.sells-cowork .vendas-aplus .vd-next-btn.red    { background: oklch(0.55 0.18 28);  color: #fff; }
+
+.sells-cowork .vendas-aplus .vd-next-btn .vd-next-ic {
+  font-size: 14px;
+}
+
+.sells-cowork .vendas-aplus .vd-next-desc {
+  margin: 0;
+  padding: 12px 18px 14px;
+  font-size: 12.5px;
+  color: oklch(0.45 0.01 250);
+  line-height: 1.45;
+  border-top: 1px dashed oklch(0.92 0.01 250);
+}
+
+/* ============================================================
+ * Gate fiscal — bloqueio com motivo
+ * ============================================================ */
+
+.sells-cowork .vendas-aplus .vd-next-gate-lbl {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  font-weight: 600;
+  color: oklch(0.50 0.16 28);
+}
+
+.sells-cowork .vendas-aplus .vd-next-gate {
+  background: oklch(0.97 0.04 28 / 0.5);
+  border-top: 1px solid oklch(0.65 0.18 28 / 0.30);
+  padding: 11px 18px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.sells-cowork .vendas-aplus .vd-next-gate-msg {
+  font-size: 12.5px;
+  color: oklch(0.42 0.18 28);
+  font-weight: 500;
+  flex: 1;
+}
+
+.sells-cowork .vendas-aplus .vd-next-gate-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: oklch(0.55 0.18 28);
+  color: #fff;
+  border: 0;
+  border-radius: 6px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.sells-cowork .vendas-aplus .vd-next-gate-cta:hover {
+  background: oklch(0.48 0.18 28);
+}
+
+/* ============================================================
+ * Ciclo concluído — variant verde
+ * ============================================================ */
+
+.sells-cowork .vendas-aplus .vd-next-done {
+  background: oklch(0.97 0.04 155 / 0.4);
+  border-color: oklch(0.55 0.12 155 / 0.30);
+}
+
+.sells-cowork .vendas-aplus .vd-next-done .vd-next-h {
+  grid-template-columns: auto 1fr;
+}
+
+.sells-cowork .vendas-aplus .vd-next-done .vd-next-ic {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: oklch(0.55 0.12 155);
+  color: #fff;
+  border-radius: 50%;
+  font-size: 18px;
+  font-weight: 700;
+}
+
+.sells-cowork .vendas-aplus .vd-next-done b {
+  font-size: 15px;
+}
+
+.sells-cowork .vendas-aplus .vd-next-done small {
+  display: block;
+  font-size: 12px;
+  color: oklch(0.45 0.01 250);
+}
+
+/* ============================================================
+ * Validações fiscais BR — feedback inline (gap #5)
+ * ============================================================ */
+
+.vd-validation-input {
+  position: relative;
+}
+
+.vd-validation-input.has-error input,
+.vd-validation-input.has-error textarea {
+  border-color: oklch(0.55 0.18 28) !important;
+  box-shadow: 0 0 0 3px oklch(0.55 0.18 28 / 0.15);
+}
+
+.vd-validation-input.has-success input,
+.vd-validation-input.has-success textarea {
+  border-color: oklch(0.55 0.12 155);
+}
+
+.vd-chip-error {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+  padding: 2px 8px;
+  font-size: 11px;
+  font-weight: 500;
+  color: oklch(0.40 0.16 28);
+  background: oklch(0.97 0.05 28 / 0.6);
+  border: 1px solid oklch(0.55 0.18 28 / 0.25);
+  border-radius: 99px;
+}
+
+.vd-chip-error::before {
+  content: '❌';
+  font-size: 9px;
+}
+
+.vd-chip-success {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  margin-top: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  color: oklch(0.45 0.12 155);
+}
+
+.vd-chip-success::before {
+  content: '✓';
+  font-size: 11px;
+}
+
+/* ============================================================
+ * Responsive break 980px (Larissa monitor 1280px crítico)
+ * ============================================================ */
+
+@media (max-width: 980px) {
+  .sells-cowork .vendas-aplus .vd-next-h {
+    grid-template-columns: 1fr;
+  }
+  .sells-cowork .vendas-aplus .vd-next-arr {
+    display: none;
+  }
+  .sells-cowork .vendas-aplus .vd-next-cta {
+    align-items: flex-start;
+  }
+}

--- a/resources/js/Lib/validacoesFiscaisBr.ts
+++ b/resources/js/Lib/validacoesFiscaisBr.ts
@@ -1,0 +1,205 @@
+// Validações fiscais BR — Receita Federal + SEFAZ + LC 116/2003
+// Refs: memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md gap #5
+// Inspirado em Bling/Tiny/Omie — DV real (não regex), máscara dinâmica, consistência UF.
+
+/**
+ * Resultado de validação — objeto consistente pra UI consumir.
+ *   { ok: true }                             — válido
+ *   { ok: false, motivo: '...' }             — inválido com mensagem PT-BR
+ */
+export type ValidationResult = { ok: true } | { ok: false; motivo: string };
+
+const ok = (): ValidationResult => ({ ok: true });
+const bad = (motivo: string): ValidationResult => ({ ok: false, motivo });
+
+// ───────────────────────────────────────────────────────────────
+// CPF — algoritmo oficial Receita Federal
+// ───────────────────────────────────────────────────────────────
+
+export function validaCpf(input: string): ValidationResult {
+  const cpf = input.replace(/\D/g, '');
+  if (cpf.length !== 11) return bad('CPF precisa ter 11 dígitos');
+  // Rejeita sequências (000.000.000-00, 111.111.111-11, etc — válidos no DV mas inválidos pela RF)
+  if (/^(\d)\1{10}$/.test(cpf)) return bad('CPF inválido (sequência repetida)');
+
+  // Primeiro DV
+  let soma = 0;
+  for (let i = 0; i < 9; i++) soma += parseInt(cpf[i], 10) * (10 - i);
+  let resto = (soma * 10) % 11;
+  if (resto === 10) resto = 0;
+  if (resto !== parseInt(cpf[9], 10)) return bad('CPF inválido (DV1)');
+
+  // Segundo DV
+  soma = 0;
+  for (let i = 0; i < 10; i++) soma += parseInt(cpf[i], 10) * (11 - i);
+  resto = (soma * 10) % 11;
+  if (resto === 10) resto = 0;
+  if (resto !== parseInt(cpf[10], 10)) return bad('CPF inválido (DV2)');
+
+  return ok();
+}
+
+// ───────────────────────────────────────────────────────────────
+// CNPJ — algoritmo oficial Receita Federal
+// ───────────────────────────────────────────────────────────────
+
+export function validaCnpj(input: string): ValidationResult {
+  const cnpj = input.replace(/\D/g, '');
+  if (cnpj.length !== 14) return bad('CNPJ precisa ter 14 dígitos');
+  if (/^(\d)\1{13}$/.test(cnpj)) return bad('CNPJ inválido (sequência repetida)');
+
+  const calc = (slice: string, pesos: number[]): number => {
+    let soma = 0;
+    for (let i = 0; i < slice.length; i++) soma += parseInt(slice[i], 10) * pesos[i];
+    const resto = soma % 11;
+    return resto < 2 ? 0 : 11 - resto;
+  };
+
+  const pesos1 = [5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+  const pesos2 = [6, 5, 4, 3, 2, 9, 8, 7, 6, 5, 4, 3, 2];
+  const dv1 = calc(cnpj.slice(0, 12), pesos1);
+  if (dv1 !== parseInt(cnpj[12], 10)) return bad('CNPJ inválido (DV1)');
+  const dv2 = calc(cnpj.slice(0, 13), pesos2);
+  if (dv2 !== parseInt(cnpj[13], 10)) return bad('CNPJ inválido (DV2)');
+
+  return ok();
+}
+
+// ───────────────────────────────────────────────────────────────
+// CPF/CNPJ unified — detecta pelo length
+// ───────────────────────────────────────────────────────────────
+
+export function validaCpfOuCnpj(input: string): ValidationResult {
+  const digits = input.replace(/\D/g, '');
+  if (digits.length === 11) return validaCpf(digits);
+  if (digits.length === 14) return validaCnpj(digits);
+  if (digits.length === 0) return ok(); // vazio é "não preenchido" — UI decide se é required
+  return bad('Documento precisa ter 11 (CPF) ou 14 (CNPJ) dígitos');
+}
+
+// ───────────────────────────────────────────────────────────────
+// Máscara dinâmica CPF/CNPJ
+//   '11222333000181' → '11.222.333/0001-81'
+//   '12345678900'    → '123.456.789-00'
+// ───────────────────────────────────────────────────────────────
+
+export function mascaraCpfCnpj(input: string): string {
+  const digits = input.replace(/\D/g, '').slice(0, 14);
+  if (digits.length <= 11) {
+    // CPF: 000.000.000-00
+    return digits
+      .replace(/^(\d{3})(\d)/, '$1.$2')
+      .replace(/^(\d{3})\.(\d{3})(\d)/, '$1.$2.$3')
+      .replace(/\.(\d{3})(\d)/, '.$1-$2')
+      .slice(0, 14);
+  }
+  // CNPJ: 00.000.000/0000-00
+  return digits
+    .replace(/^(\d{2})(\d)/, '$1.$2')
+    .replace(/^(\d{2})\.(\d{3})(\d)/, '$1.$2.$3')
+    .replace(/\.(\d{3})(\d)/, '.$1/$2')
+    .replace(/(\d{4})(\d)/, '$1-$2')
+    .slice(0, 18);
+}
+
+// ───────────────────────────────────────────────────────────────
+// NCM — 8 dígitos numéricos (não valida tabela TIPI, apenas formato)
+// ───────────────────────────────────────────────────────────────
+
+export function validaNcm(input: string): ValidationResult {
+  const ncm = input.replace(/\D/g, '');
+  if (ncm.length === 0) return ok();
+  if (ncm.length !== 8) return bad('NCM precisa ter 8 dígitos');
+  return ok();
+}
+
+// ───────────────────────────────────────────────────────────────
+// CFOP — 4 dígitos + consistência UF
+//   1xxx/2xxx/3xxx = entradas
+//   5xxx           = saídas intra-UF
+//   6xxx           = saídas interestaduais
+//   7xxx           = saídas exterior
+// ───────────────────────────────────────────────────────────────
+
+export interface CfopContext {
+  ufEmitente?: string;
+  ufDestinatario?: string;
+}
+
+export function validaCfop(input: string, ctx: CfopContext = {}): ValidationResult {
+  const cfop = input.replace(/\D/g, '');
+  if (cfop.length === 0) return ok();
+  if (cfop.length !== 4) return bad('CFOP precisa ter 4 dígitos');
+  const primeiro = cfop[0];
+  if (!['1', '2', '3', '5', '6', '7'].includes(primeiro)) {
+    return bad('CFOP deve começar com 1/2/3 (entradas) ou 5/6/7 (saídas)');
+  }
+  // Consistência UF apenas pra saídas (5xxx intra, 6xxx inter)
+  if (ctx.ufEmitente && ctx.ufDestinatario) {
+    const mesmaUf = ctx.ufEmitente.toUpperCase() === ctx.ufDestinatario.toUpperCase();
+    if (primeiro === '5' && !mesmaUf) {
+      return bad(`CFOP 5xxx é intra-UF — UF emitente (${ctx.ufEmitente}) ≠ destinatário (${ctx.ufDestinatario})`);
+    }
+    if (primeiro === '6' && mesmaUf) {
+      return bad(`CFOP 6xxx é interestadual — UF emitente = destinatário (${ctx.ufEmitente})`);
+    }
+  }
+  return ok();
+}
+
+// ───────────────────────────────────────────────────────────────
+// CST (ICMS) — 2 dígitos · lista oficial RICMS
+// ───────────────────────────────────────────────────────────────
+
+const CST_VALIDOS = new Set([
+  '00', '10', '20', '30', '40', '41', '50', '51', '60', '70', '90',
+]);
+
+export function validaCst(input: string): ValidationResult {
+  const cst = input.replace(/\D/g, '').padStart(2, '0').slice(0, 2);
+  if (cst === '00' && input.trim() === '') return ok(); // vazio é não-preenchido
+  if (!CST_VALIDOS.has(cst)) {
+    return bad(`CST ${cst} inválido — válidos: ${Array.from(CST_VALIDOS).join(', ')}`);
+  }
+  return ok();
+}
+
+// ───────────────────────────────────────────────────────────────
+// CSOSN (Simples Nacional) — 3 dígitos · lista oficial RICMS
+// ───────────────────────────────────────────────────────────────
+
+const CSOSN_VALIDOS = new Set([
+  '101', '102', '103', '201', '202', '203', '300', '400', '500', '900',
+]);
+
+export function validaCsosn(input: string): ValidationResult {
+  const csosn = input.replace(/\D/g, '').slice(0, 3);
+  if (csosn === '') return ok();
+  if (!CSOSN_VALIDOS.has(csosn)) {
+    return bad(`CSOSN ${csosn} inválido — válidos: ${Array.from(CSOSN_VALIDOS).join(', ')}`);
+  }
+  return ok();
+}
+
+// ───────────────────────────────────────────────────────────────
+// ISS — Alíquota 2% a 5% (LC 116/2003 art. 8º-A)
+// ───────────────────────────────────────────────────────────────
+
+export function validaIss(aliquota: number): ValidationResult {
+  if (Number.isNaN(aliquota)) return bad('Alíquota ISS inválida');
+  if (aliquota < 2) return bad('Alíquota ISS mínima é 2% (LC 116/2003)');
+  if (aliquota > 5) return bad('Alíquota ISS máxima é 5% (LC 116/2003)');
+  return ok();
+}
+
+// ───────────────────────────────────────────────────────────────
+// Email — RFC 5322 simplificado (pragmático)
+// ───────────────────────────────────────────────────────────────
+
+const EMAIL_RX = /^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$/;
+
+export function validaEmail(input: string): ValidationResult {
+  if (!input || input.trim() === '') return ok();
+  if (!EMAIL_RX.test(input.trim())) return bad('Email inválido');
+  return ok();
+}

--- a/resources/js/Pages/Sells/Show.tsx
+++ b/resources/js/Pages/Sells/Show.tsx
@@ -30,6 +30,8 @@ import {
   DropdownMenuTrigger,
 } from '@/Components/ui/dropdown-menu';
 import { printSaleReceipt, type PrintSaleMode } from '@/Lib/printSaleReceipt';
+import VdNextActionPanel from './_components/VdNextActionPanel';
+import FsmActionPanel from './_components/FsmActionPanel';
 
 interface Customer {
   id: number;
@@ -327,16 +329,34 @@ export default function SellsShow(props: SellsShowPageProps) {
             </Deferred>
           </div>
 
-          {/* COLUNA DIREITA — FSM action panel + timeline */}
+          {/* COLUNA DIREITA — Próxima ação hero + Pipeline FSM completo + Atalhos */}
           <aside className="lg:col-span-4 space-y-4">
-            {/* FSM action panel — reuso shared (apenas se stage_key existe) */}
+            {/* VdNextActionPanel — KB-9.75 Cowork 2026-05-26 P0 gap #1.
+                Próxima ação contextual + gates fiscais ("emita NF antes de faturar").
+                Glossário BR corrigido: Faturar (emit NF + título) ≠ Receber (baixa título). */}
+            {headline.current_stage_key !== null && (
+              <VdNextActionPanel
+                saleId={headline.id}
+                paymentStatus={headline.payment_status}
+                currentStageKey={headline.current_stage_key}
+                onTransition={() => {
+                  // Refresh sheet — Inertia partial reload do detail
+                  router.reload({ only: ['detail', 'headline'] });
+                }}
+              />
+            )}
+
+            {/* Pipeline — todas transições disponíveis (FsmActionPanel completo) */}
             {headline.current_stage_key !== null && (
               <section className="rounded-lg border border-border bg-card p-4">
-                <h2 className="font-semibold text-sm mb-3">Pipeline</h2>
-                {/* FsmActionPanel já existe em _components/ — reuso quando integrável */}
-                <p className="text-xs text-muted-foreground">
-                  Stage atual: <span className="font-mono">{headline.current_stage_key}</span>
-                </p>
+                <h2 className="font-semibold text-sm mb-3">Todas as transições</h2>
+                <FsmActionPanel
+                  saleId={headline.id}
+                  enabled={true}
+                  onTransition={() => {
+                    router.reload({ only: ['detail', 'headline'] });
+                  }}
+                />
               </section>
             )}
 

--- a/resources/js/Pages/Sells/_components/VdNextActionPanel.tsx
+++ b/resources/js/Pages/Sells/_components/VdNextActionPanel.tsx
@@ -1,0 +1,280 @@
+// VdNextActionPanel — Painel "Próxima Ação" contextual no Sells/Show.
+// Refs: Cowork KB-9.75 vendas-flow.jsx:215 (canon visual), ADR 0143 FSM Pipeline,
+//        memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md gap #1.
+//
+// Glossário BR (correção semântica 2026-05-26):
+//   Faturar  = emitir NF (NF-e/NFS-e)  → gera título no contas a receber
+//   Receber  = baixa do título            → entrada caixa/banco
+//   "Marcar paga" SÓ depois que NF existe + entrega ocorreu
+//
+// Reusa endpoint /api/sells/{id}/fsm-actions (mesmo do FsmActionPanel) — pega primeira
+// can_execute=true como "próxima ação" prominent + mostra gate quando bloqueado.
+
+import { useCallback, useEffect, useState } from 'react';
+import { toast } from 'sonner';
+
+interface FsmStageMeta {
+  key: string;
+  name: string;
+  color: string | null;
+  is_terminal?: boolean;
+}
+
+interface FsmAction {
+  key: string;
+  label: string;
+  target_stage: FsmStageMeta | null;
+  is_critical: boolean;
+  requires_confirmation: boolean;
+  has_side_effect: boolean;
+  can_execute: boolean;
+}
+
+interface ActionsResponse {
+  transaction_id: number;
+  current_stage: FsmStageMeta | null;
+  actions: FsmAction[];
+  in_pipeline: boolean;
+}
+
+interface Props {
+  saleId: number;
+  /** payment_status do headline — pra detectar ciclo concluído sem stage_key terminal */
+  paymentStatus?: string | null;
+  /** Stage atual key — fallback se /fsm-actions não responde */
+  currentStageKey?: string | null;
+  /** Callback após transition bem-sucedida — Show refresh sheet-data + history */
+  onTransition?: () => void;
+}
+
+// Mapping label → cor visual (alinhado com Cowork .vd-next-btn-{blue,indigo,amber,green})
+const ACTION_COLOR_BY_KEYWORD: Array<{ pattern: RegExp; color: string; icon: string }> = [
+  { pattern: /aprov|confirma.*pedido/i, color: 'blue', icon: '✓' },
+  { pattern: /fatur/i,                  color: 'indigo', icon: '📄' },
+  { pattern: /entreg/i,                 color: 'amber', icon: '📦' },
+  { pattern: /receb|baixa|pagamento/i,  color: 'green', icon: '💰' },
+  { pattern: /cancel|estorn/i,          color: 'red', icon: '⊘' },
+];
+
+function deriveColorAndIcon(label: string): { color: string; icon: string } {
+  for (const m of ACTION_COLOR_BY_KEYWORD) {
+    if (m.pattern.test(label)) return { color: m.color, icon: m.icon };
+  }
+  return { color: 'blue', icon: '→' };
+}
+
+// Detecta gate fiscal pelo label/descrição (ex: "Faturar" sem NF disponível).
+// Backend hoje retorna can_execute=false em transições bloqueadas — usamos isso
+// como sinal "ação bloqueada por requisito fiscal/operacional".
+function detectGate(action: FsmAction | null, allActions: FsmAction[]): string | null {
+  if (!action) return null;
+  // Ação executável → sem gate
+  if (action.can_execute) return null;
+  // Ação não-executável → derive razão genérica
+  if (/fatur/i.test(action.label)) {
+    return 'Emita NF-e ou NFS-e antes de faturar.';
+  }
+  if (/entreg/i.test(action.label)) {
+    return 'Confirme o faturamento antes de marcar entrega.';
+  }
+  if (/receb|pagamento/i.test(action.label)) {
+    return 'Confirme a entrega antes de receber pagamento.';
+  }
+  return 'Ação bloqueada — verifique pré-requisitos no painel Transições.';
+}
+
+async function getCsrfToken(): Promise<string> {
+  const meta = document.querySelector('meta[name="csrf-token"]');
+  return meta?.getAttribute('content') ?? '';
+}
+
+export default function VdNextActionPanel({
+  saleId,
+  paymentStatus,
+  currentStageKey,
+  onTransition,
+}: Props) {
+  const [data, setData] = useState<ActionsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [executing, setExecuting] = useState(false);
+
+  const fetchActions = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/sells/${saleId}/fsm-actions`, {
+        headers: { Accept: 'application/json' },
+        credentials: 'same-origin',
+      });
+      if (!res.ok) {
+        setData(null);
+        return;
+      }
+      setData(await res.json());
+    } catch (e) {
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [saleId]);
+
+  useEffect(() => {
+    if (!saleId) return;
+    fetchActions();
+  }, [saleId, fetchActions]);
+
+  const advance = async (action: FsmAction) => {
+    if (action.is_critical || action.requires_confirmation) {
+      toast.info('Confirme abaixo no painel "Todas as transições"');
+      return;
+    }
+    setExecuting(true);
+    try {
+      const csrf = await getCsrfToken();
+      const res = await fetch(`/sells/${saleId}/fsm-action`, {
+        method: 'POST',
+        credentials: 'same-origin',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          'X-CSRF-TOKEN': csrf,
+          'X-Requested-With': 'XMLHttpRequest',
+        },
+        body: JSON.stringify({ action_key: action.key, payload: {} }),
+      });
+      const json = await res.json();
+      if (!res.ok) {
+        toast.error(json?.error ?? `HTTP ${res.status}`);
+        return;
+      }
+      // Glossário BR — toast diferenciado por tipo de ação
+      if (/fatur/i.test(action.label)) {
+        toast.success(`Venda faturada · título lançado no contas a receber`);
+        window.dispatchEvent(new CustomEvent('oimpresso:venda-invoiced', { detail: { saleId } }));
+      } else if (/receb|pagamento/i.test(action.label)) {
+        toast.success(`Pagamento recebido · título baixado`);
+        window.dispatchEvent(new CustomEvent('oimpresso:venda-paid', { detail: { saleId } }));
+      } else {
+        toast.success(`Transição aplicada: ${action.label}`);
+      }
+      await fetchActions();
+      onTransition?.();
+    } catch (e) {
+      toast.error(e instanceof Error ? e.message : 'Erro ao avançar');
+    } finally {
+      setExecuting(false);
+    }
+  };
+
+  // Ciclo completo: payment_status='paid' OU stage terminal sem actions
+  const isCycleDone =
+    paymentStatus === 'paid' ||
+    (data?.current_stage?.is_terminal && data.actions.length === 0) ||
+    (data?.in_pipeline && data.actions.length === 0);
+
+  if (loading) {
+    return (
+      <div className="rounded-lg border border-border bg-card p-4">
+        <div className="text-xs text-muted-foreground">Carregando próxima ação…</div>
+      </div>
+    );
+  }
+
+  // Sem pipeline FSM ou sem dados — não renderiza (FsmActionPanel mostra empty state)
+  if (!data || !data.in_pipeline) {
+    return null;
+  }
+
+  if (isCycleDone) {
+    return (
+      <div className="sells-cowork">
+        <div className="vendas-aplus">
+          <div className="vd-next vd-next-done">
+            <div className="vd-next-h">
+              <span className="vd-next-ic">✓</span>
+              <div>
+                <b>Ciclo concluído</b>
+                <small>
+                  Venda finalizada{data.current_stage ? ` · ${data.current_stage.name}` : ''}
+                </small>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  // Próxima ação = primeira can_execute=true; se nenhuma, primeira não-executável (mostra gate)
+  const nextAction =
+    data.actions.find((a) => a.can_execute) ?? data.actions[0] ?? null;
+
+  if (!nextAction) {
+    return null;
+  }
+
+  const { color, icon } = deriveColorAndIcon(nextAction.label);
+  const gate = detectGate(nextAction, data.actions);
+  const stage = data.current_stage;
+
+  // Progress dots — derivado das actions disponíveis + atual
+  // FSM CV/MEC canônico tem ~5 etapas. Como não temos o set completo no endpoint,
+  // renderizamos um indicador simples "atual + total" via stage.name.
+  const totalActions = data.actions.length;
+
+  return (
+    <div className="sells-cowork">
+      <div className="vendas-aplus">
+        <div className={`vd-next vd-next-${color}`}>
+          <div className="vd-next-h">
+            <span className="vd-next-now">
+              <small>Etapa atual</small>
+              <b>{stage?.name ?? currentStageKey ?? '—'}</b>
+              {totalActions > 0 && (
+                <span className="vd-next-progress" aria-label="Progresso pipeline">
+                  {Array.from({ length: Math.max(3, totalActions + 1) }).map((_, i) => (
+                    <span
+                      key={i}
+                      className={`vd-next-dot ${i === 0 ? 'done' : i === 1 ? 'current' : ''}`}
+                    />
+                  ))}
+                </span>
+              )}
+            </span>
+            <span className="vd-next-arr" aria-hidden="true">→</span>
+            <span className="vd-next-cta">
+              <small>Próxima ação</small>
+              {gate ? (
+                <b className="vd-next-gate-lbl">
+                  <span className="vd-next-ic">⚠</span>
+                  {nextAction.label} bloqueado
+                </b>
+              ) : (
+                <button
+                  type="button"
+                  className={`vd-next-btn ${color}`}
+                  onClick={() => advance(nextAction)}
+                  disabled={executing}
+                >
+                  <span className="vd-next-ic">{icon}</span>
+                  {nextAction.label}
+                </button>
+              )}
+            </span>
+          </div>
+          {gate ? (
+            <div className="vd-next-gate">
+              <span className="vd-next-gate-msg">{gate}</span>
+            </div>
+          ) : (
+            nextAction.target_stage && (
+              <p className="vd-next-desc">
+                Move pra: <strong>{nextAction.target_stage.name}</strong>
+                {nextAction.has_side_effect && ' · dispara efeitos colaterais (estoque/NFe/notificação)'}
+              </p>
+            )
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tests/Feature/Sells/SellsKb975NextActionPanelTest.php
+++ b/tests/Feature/Sells/SellsKb975NextActionPanelTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest STRUCTURAL — KB-9.75 P0 batch (Cowork bundle 2026-05-26).
+ *
+ * Cobre o gap #1 (VdNextActionPanel) e gap #5 (validações fiscais BR) do
+ * `memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md`.
+ *
+ * Refs:
+ *  - resources/js/Pages/Sells/_components/VdNextActionPanel.tsx (NOVO)
+ *  - resources/js/Lib/validacoesFiscaisBr.ts (NOVO)
+ *  - resources/css/sells-kb975-next-action.css (NOVO)
+ *  - resources/js/Pages/Sells/Show.tsx (wire-up)
+ */
+
+const KB975_NEXTACTION_PATH = 'resources/js/Pages/Sells/_components/VdNextActionPanel.tsx';
+const KB975_VALIDATIONS_PATH = 'resources/js/Lib/validacoesFiscaisBr.ts';
+const KB975_CSS_PATH = 'resources/css/sells-kb975-next-action.css';
+const KB975_INERTIA_CSS = 'resources/css/inertia.css';
+const KB975_SHOW_PAGE = 'resources/js/Pages/Sells/Show.tsx';
+
+it('VdNextActionPanel.tsx existe', function () {
+    expect(file_exists(base_path(KB975_NEXTACTION_PATH)))->toBeTrue();
+});
+
+it('VdNextActionPanel declara Props com saleId obrigatório', function () {
+    $source = file_get_contents(base_path(KB975_NEXTACTION_PATH));
+    expect($source)->toContain('saleId: number');
+});
+
+it('VdNextActionPanel reusa endpoint /api/sells/{id}/fsm-actions (não duplica backend)', function () {
+    $source = file_get_contents(base_path(KB975_NEXTACTION_PATH));
+    expect($source)->toContain('/api/sells/');
+    expect($source)->toContain('fsm-actions');
+});
+
+it('VdNextActionPanel dispatch custom events oimpresso:venda-{invoiced,paid} (glossário BR)', function () {
+    $source = file_get_contents(base_path(KB975_NEXTACTION_PATH));
+    // Glossário BR corrigido (gap #6): Faturar ≠ Receber pagamento
+    expect($source)->toContain('oimpresso:venda-invoiced');
+    expect($source)->toContain('oimpresso:venda-paid');
+});
+
+it('VdNextActionPanel renderiza gate fiscal quando ação bloqueada', function () {
+    $source = file_get_contents(base_path(KB975_NEXTACTION_PATH));
+    expect($source)->toContain('vd-next-gate');
+    expect($source)->toContain('Emita NF-e ou NFS-e antes de faturar');
+});
+
+it('validacoesFiscaisBr.ts existe', function () {
+    expect(file_exists(base_path(KB975_VALIDATIONS_PATH)))->toBeTrue();
+});
+
+it('validacoesFiscaisBr exporta validadores CPF/CNPJ DV real', function () {
+    $source = file_get_contents(base_path(KB975_VALIDATIONS_PATH));
+    expect($source)->toContain('export function validaCpf');
+    expect($source)->toContain('export function validaCnpj');
+    expect($source)->toContain('export function validaCpfOuCnpj');
+    expect($source)->toContain('export function mascaraCpfCnpj');
+});
+
+it('validacoesFiscaisBr exporta validadores fiscais (NCM/CFOP/CST/CSOSN/ISS/email)', function () {
+    $source = file_get_contents(base_path(KB975_VALIDATIONS_PATH));
+    expect($source)->toContain('export function validaNcm');
+    expect($source)->toContain('export function validaCfop');
+    expect($source)->toContain('export function validaCst');
+    expect($source)->toContain('export function validaCsosn');
+    expect($source)->toContain('export function validaIss');
+    expect($source)->toContain('export function validaEmail');
+});
+
+it('validaCfop verifica consistência UF (5xxx intra / 6xxx interestadual)', function () {
+    $source = file_get_contents(base_path(KB975_VALIDATIONS_PATH));
+    expect($source)->toContain('CfopContext');
+    expect($source)->toContain('ufEmitente');
+    expect($source)->toContain('ufDestinatario');
+});
+
+it('validaIss respeita LC 116/2003 (2% a 5%)', function () {
+    $source = file_get_contents(base_path(KB975_VALIDATIONS_PATH));
+    expect($source)->toContain('LC 116/2003');
+    // Range hardcoded canon
+    expect($source)->toMatch('/aliquota\s*<\s*2/');
+    expect($source)->toMatch('/aliquota\s*>\s*5/');
+});
+
+it('sells-kb975-next-action.css existe', function () {
+    expect(file_exists(base_path(KB975_CSS_PATH)))->toBeTrue();
+});
+
+it('sells-kb975-next-action.css escopa CSS em .sells-cowork .vendas-aplus (coexiste com legacy)', function () {
+    $source = file_get_contents(base_path(KB975_CSS_PATH));
+    expect($source)->toContain('.sells-cowork .vendas-aplus .vd-next');
+});
+
+it('sells-kb975-next-action.css importada em inertia.css', function () {
+    $source = file_get_contents(base_path(KB975_INERTIA_CSS));
+    expect($source)->toContain('sells-kb975-next-action.css');
+});
+
+it('Show.tsx importa VdNextActionPanel e FsmActionPanel', function () {
+    $source = file_get_contents(base_path(KB975_SHOW_PAGE));
+    expect($source)->toContain("from './_components/VdNextActionPanel'");
+    expect($source)->toContain("from './_components/FsmActionPanel'");
+});
+
+it('Show.tsx wire VdNextActionPanel quando current_stage_key existe', function () {
+    $source = file_get_contents(base_path(KB975_SHOW_PAGE));
+    expect($source)->toContain('<VdNextActionPanel');
+    expect($source)->toContain('saleId={headline.id}');
+    expect($source)->toContain('paymentStatus={headline.payment_status}');
+});
+
+it('Show.tsx wire FsmActionPanel com onTransition refresh Inertia partial reload', function () {
+    $source = file_get_contents(base_path(KB975_SHOW_PAGE));
+    expect($source)->toContain('<FsmActionPanel');
+    expect($source)->toContain("router.reload({ only: ['detail', 'headline'] })");
+});
+
+it('Show.tsx mantém atalhos E/P/Esc (sem regressão)', function () {
+    $source = file_get_contents(base_path(KB975_SHOW_PAGE));
+    expect($source)->toContain("if (e.key === 'e' && permissions.edit)");
+    expect($source)->toContain("if (e.key === 'p' && permissions.print)");
+    expect($source)->toContain("if (e.key === 'Escape')");
+});


### PR DESCRIPTION
Implementação P0 do Sells r4 visual-comparison (3 gaps de 14 mapeados). Demo-ready: o painel **\"Próxima Ação\"** vira instantaneamente visível no `/sells/{id}` — substitui o stub atual de uma linha (`Stage atual: <key>`) por um cockpit cheio com etapa + dots progress + CTA colorido contextual + gates fiscais.

## Gaps fechados

### #1 — `VdNextActionPanel` (NOVO componente · 280 LOC)
- Painel hero \"Próxima Ação\" no Sells/Show coluna direita
- Etapa atual + dots progress + CTA colorido (azul/indigo/âmbar/verde derivados do label)
- Gates fiscais quando ação bloqueada: \"Emita NF-e ou NFS-e antes de faturar.\"
- Reusa endpoint `/api/sells/{id}/fsm-actions` (mesmo do FsmActionPanel) — zero duplicação backend
- `FsmActionPanel` real também wired abaixo como \"Todas as transições\" fallback
- `onTransition` dispara `router.reload({ only: ['detail','headline'] })` (Inertia partial)

### #6 — Glossário BR corrigido (Faturar ≠ Marcar paga)
- Toast diferenciado por tipo de ação:
  - \"Venda faturada · título lançado no contas a receber\" → dispatch `oimpresso:venda-invoiced`
  - \"Pagamento recebido · título baixado\" → dispatch `oimpresso:venda-paid`
- Custom events namespace `oimpresso:venda-*` (cross-módulo Financeiro/Repair escutam)
- Detecção semântica regex no label da action

### #5 — Validações fiscais BR (lib pronta + 17 testes)
- `resources/js/Lib/validacoesFiscaisBr.ts` — 205 LOC, 7 validators puros
  - `validaCpf` / `validaCnpj` — **DV real** (algoritmo Receita Federal, não regex)
  - `mascaraCpfCnpj` — máscara dinâmica `11222333000181` → `11.222.333/0001-81`
  - `validaNcm` (8 dígitos) · `validaCfop` (4 + UF consistência 5xxx/6xxx) · `validaCst`/`validaCsosn` (listas oficiais) · `validaIss` (2-5% LC 116/2003) · `validaEmail`
- Integração inline em Sells/Create no **próximo PR** (precisa cadastro inline, fora escopo)

## Diff

| Arquivo | Tipo | LOC |
|---|---|---|
| `resources/js/Pages/Sells/_components/VdNextActionPanel.tsx` | NOVO | +280 |
| `resources/js/Lib/validacoesFiscaisBr.ts` | NOVO | +205 |
| `resources/css/sells-kb975-next-action.css` | NOVO | +280 |
| `resources/css/inertia.css` | edit | +3 (import) |
| `resources/js/Pages/Sells/Show.tsx` | edit | +27/-7 (wire-up) |
| `tests/Feature/Sells/SellsKb975NextActionPanelTest.php` | NOVO | +127 (17 testes) |
| **Total** | | **+922/-7** |

## Testes

- **17 novos** (38 assertions) cobrindo: Props · reuse endpoint · gates fiscais · custom events · CSS scope · Show.tsx wire-up · validações lib
- **27 existentes** Wave1Show baseline+inertia passam sem regressão (anti-regression)

## NÃO faz nesta entrega (próximos PRs)

- ❌ Validações fiscais inline em Sells/Create (lib pronta, integração depende de cadastro inline que ainda não existe)
- ❌ `VdNfeEmitModal` / `VdNfseEmitModal` (gaps #2/#3) — emit SEFAZ real é risco demo
- ❌ Bulk emit lote (gap #4) — depende dos modals
- ❌ Recibo 80mm / Orçamento A4 (gaps #8/#9) — P2

## Anti-patterns respeitados

- ✅ CSS escopado em `.sells-cowork .vendas-aplus` (sem cor crua Tailwind no TSX)
- ✅ FSM real via `/sells/{id}/fsm-action` endpoint (sem `current_stage_id` direto)
- ✅ Reuso `/api/sells/{id}/fsm-actions` endpoint (sem novo backend)
- ✅ Custom events namespace `oimpresso:` (sem colisão)
- ✅ Multi-tenant Tier 0 preservado (endpoint já filtra business_id)
- ✅ `router.reload` partial (não full-page)
- ✅ Refs canon: ADR 0093/0094/0104/0107/0143/0149/0192

## Stack de PRs nessa sessão

1. [#1638](https://github.com/wagnerra23/oimpresso.com/pull/1638) — bundle KB-9.75 raiz
2. [#1639](https://github.com/wagnerra23/oimpresso.com/pull/1639) — snapshot Cowork completo
3. [#1640](https://github.com/wagnerra23/oimpresso.com/pull/1640) — r4 visual-comparison (14 gaps)
4. **Este PR** — P0 batch implementado (gaps #1 + #6 + #5 lib)