### PR TITLE
feat(sells): KB-9.75 P2 — Recibo térmico 80mm + Orçamento A4 (Cowork)

### DIFF
--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -11,6 +11,9 @@
 /* Sells KB-9.75 Emit modals NF-e/NFS-e/Bulk (Cowork bundle 2026-05-26 P0 gaps #2/#3/#4 — fullscreen modal global) */
 @import "./sells-kb975-emit-modals.css";
 
+/* Sells KB-9.75 Recibo térmico 80mm + Orçamento A4 (Cowork bundle 2026-05-26 P2 gaps #8/#9) */
+@import "./sells-kb975-print.css";
+
 /* Sells Cowork Onda 2 R2 IA drawer — escopado em .sells-cowork + .sells-cowork-ia-panel */
 @import "./sells-cowork-ia.css";
 

--- a/resources/css/sells-kb975-print.css
+++ b/resources/css/sells-kb975-print.css
@@ -1,0 +1,675 @@
+/* sells-kb975-print.css — KB-9.75 Cowork bundle 2026-05-26 P2 gaps #8 + #9
+ * Tokens .vd-receipt-* / .vd-rcp-* (Recibo térmico 80mm)
+ *      + .vd-orc-* (Orçamento A4 formal)
+ * Escopo .sells-cowork pra coexistir com legacy printSaleReceipt.ts (Bootstrap 3)
+ * Refs:
+ *   - prototipo-ui project/vendas.css linhas 2666-2930 (recibo) + 3016-3347 (orçamento)
+ *   - prototipo-ui project/vendas-flow.jsx VdReceiptThermal (899) + VdOrcamentoPrint (1228)
+ *   - memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md
+ */
+
+/* ============================================================
+ * RECIBO TÉRMICO 80mm — overlay tela + @media print
+ * ============================================================ */
+
+.sells-cowork .vd-receipt-bd {
+  position: fixed;
+  inset: 0;
+  background: rgba(20, 30, 40, 0.72);
+  z-index: 1100;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding-top: 70px;
+  overflow-y: auto;
+}
+
+.sells-cowork .vd-receipt-toolbar {
+  position: fixed;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(20, 30, 40, 0.86);
+  backdrop-filter: blur(8px);
+  border-radius: 999px;
+  padding: 6px 10px 6px 6px;
+  z-index: 1101;
+}
+
+.sells-cowork .vd-receipt-toolbar .os-btn {
+  background: transparent;
+  color: oklch(0.92 0.01 250);
+  border: 1px solid oklch(0.42 0.01 250);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12.5px;
+  cursor: pointer;
+}
+
+.sells-cowork .vd-receipt-toolbar .os-btn:hover {
+  background: oklch(0.30 0.01 250);
+}
+
+.sells-cowork .vd-receipt-toolbar .os-btn.primary {
+  background: oklch(0.55 0.13 240);
+  border-color: oklch(0.55 0.13 240);
+  color: #fff;
+}
+
+.sells-cowork .vd-receipt-toolbar .os-btn.primary:hover {
+  background: oklch(0.48 0.15 240);
+}
+
+.sells-cowork .vd-receipt-tag {
+  color: oklch(0.85 0.01 250);
+  font-size: 12px;
+  font-weight: 500;
+  padding: 0 8px;
+}
+
+/* Paper — 80mm = 302px @ 96dpi */
+.sells-cowork .vd-receipt-paper {
+  width: 302px;
+  background: #fff;
+  padding: 14px 18px 22px;
+  font-family: "IBM Plex Mono", "Courier New", monospace;
+  font-size: 11px;
+  line-height: 1.4;
+  color: #000;
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.04),
+    0 20px 50px rgba(0, 0, 0, 0.35);
+  border-radius: 2px;
+}
+
+/* HEADER */
+.sells-cowork .vd-rcp-h {
+  text-align: center;
+  margin-top: 4px;
+}
+
+.sells-cowork .vd-rcp-brand {
+  font-size: 18px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  margin-bottom: 1px;
+}
+
+.sells-cowork .vd-rcp-sub {
+  font-size: 9.5px;
+  font-weight: 500;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: #444;
+  margin-bottom: 6px;
+}
+
+.sells-cowork .vd-rcp-meta {
+  font-size: 9.5px;
+  line-height: 1.45;
+  color: #555;
+}
+
+/* SEPARATOR — serrilha sutil */
+.sells-cowork .vd-rcp-sep {
+  margin: 10px -4px;
+  border-top: 1px dashed #000;
+}
+
+/* INFO + TOTAIS rows */
+.sells-cowork .vd-rcp-info,
+.sells-cowork .vd-rcp-totais,
+.sells-cowork .vd-rcp-pgto {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.sells-cowork .vd-rcp-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.sells-cowork .vd-rcp-row span {
+  font-size: 9.5px;
+  font-weight: 500;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  flex: 0 0 auto;
+}
+
+.sells-cowork .vd-rcp-row b {
+  font-size: 11px;
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+  flex: 1 1 auto;
+  min-width: 0;
+  word-break: break-word;
+}
+
+.sells-cowork .vd-rcp-row-total {
+  margin-top: 6px;
+  padding-top: 6px;
+  border-top: 1px solid #000;
+}
+
+.sells-cowork .vd-rcp-row-total span {
+  font-size: 12px;
+  font-weight: 700;
+  color: #000;
+}
+
+.sells-cowork .vd-rcp-row-total b {
+  font-size: 16px;
+}
+
+/* ITENS */
+.sells-cowork .vd-rcp-itens-h {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+  font-size: 9px;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  color: #555;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+  padding-bottom: 3px;
+  border-bottom: 1px solid #000;
+}
+
+.sells-cowork .vd-rcp-itens-h span:last-child {
+  text-align: right;
+}
+
+.sells-cowork .vd-rcp-item {
+  margin-bottom: 6px;
+}
+
+.sells-cowork .vd-rcp-item-name {
+  font-size: 11px;
+  font-weight: 600;
+  margin-bottom: 1px;
+}
+
+.sells-cowork .vd-rcp-item-row {
+  display: flex;
+  justify-content: space-between;
+  font-size: 10.5px;
+  font-variant-numeric: tabular-nums;
+}
+
+.sells-cowork .vd-rcp-item-qty {
+  color: #444;
+}
+
+.sells-cowork .vd-rcp-item-tot {
+  font-weight: 600;
+}
+
+/* FOOTER */
+.sells-cowork .vd-rcp-foot {
+  text-align: center;
+  margin-top: 4px;
+}
+
+.sells-cowork .vd-rcp-thanks {
+  font-size: 13px;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.sells-cowork .vd-rcp-disclaimer {
+  display: block;
+  font-size: 9.5px;
+  color: #555;
+  line-height: 1.4;
+  margin-bottom: 10px;
+  padding: 0 4px;
+}
+
+.sells-cowork .vd-rcp-stamp {
+  font-size: 8.5px;
+  color: #888;
+  letter-spacing: 0.04em;
+}
+
+/* ────────── @media print 80mm — esconde tudo menos o recibo ────────── */
+@media print {
+  body.vd-print-receipt > *:not(.sells-cowork-show):not(.sells-cowork) {
+    display: none !important;
+  }
+  body.vd-print-receipt .sells-cowork-show > *:not(:has(.vd-receipt-bd)),
+  body.vd-print-receipt .sells-cowork > *:not(:has(.vd-receipt-bd)) {
+    display: none !important;
+  }
+  body.vd-print-receipt .vd-receipt-bd {
+    position: static !important;
+    background: #fff !important;
+    padding: 0 !important;
+    overflow: visible !important;
+    display: block !important;
+  }
+  body.vd-print-receipt .vd-receipt-toolbar {
+    display: none !important;
+  }
+  body.vd-print-receipt .vd-receipt-paper {
+    box-shadow: none !important;
+    width: 100% !important;
+    max-width: 80mm !important;
+    padding: 4mm 6mm 8mm !important;
+    margin: 0 !important;
+    background: #fff !important;
+  }
+  @page {
+    size: 80mm auto;
+    margin: 0;
+  }
+}
+
+/* ============================================================
+ * ORÇAMENTO A4 — overlay tela + @media print
+ * ============================================================ */
+
+.sells-cowork .vd-orc-bd {
+  position: fixed;
+  inset: 0;
+  background: rgba(20, 28, 38, 0.75);
+  z-index: 1100;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+  padding-top: 70px;
+  overflow-y: auto;
+}
+
+.sells-cowork .vd-orc-toolbar {
+  position: fixed;
+  top: 16px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  background: rgba(15, 22, 32, 0.86);
+  backdrop-filter: blur(8px);
+  border-radius: 999px;
+  padding: 6px 10px 6px 6px;
+  z-index: 1101;
+}
+
+.sells-cowork .vd-orc-toolbar .os-btn {
+  background: transparent;
+  color: oklch(0.92 0.01 250);
+  border: 1px solid oklch(0.42 0.01 250);
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12.5px;
+  cursor: pointer;
+}
+
+.sells-cowork .vd-orc-toolbar .os-btn:hover {
+  background: oklch(0.30 0.01 250);
+}
+
+.sells-cowork .vd-orc-toolbar .os-btn.primary {
+  background: oklch(0.55 0.13 240);
+  border-color: oklch(0.55 0.13 240);
+  color: #fff;
+}
+
+.sells-cowork .vd-orc-tag {
+  color: oklch(0.85 0.01 250);
+  font-size: 12px;
+  padding: 0 8px;
+}
+
+/* Paper A4 (210mm = 794px @ 96dpi) */
+.sells-cowork .vd-orc-page {
+  width: 794px;
+  min-height: 1123px;
+  background: #fff;
+  padding: 40px 48px 32px;
+  color: #1a1a1a;
+  font-family: "IBM Plex Sans", -apple-system, sans-serif;
+  font-size: 12.5px;
+  line-height: 1.5;
+  box-shadow:
+    0 0 0 1px rgba(0, 0, 0, 0.06),
+    0 30px 80px rgba(0, 0, 0, 0.35);
+  margin-bottom: 40px;
+}
+
+/* HEADER */
+.sells-cowork .vd-orc-h {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 32px;
+  align-items: flex-start;
+  margin-bottom: 28px;
+  padding-bottom: 20px;
+  border-bottom: 2px solid #111;
+}
+
+.sells-cowork .vd-orc-brand-block {
+  display: flex;
+  align-items: flex-start;
+  gap: 14px;
+}
+
+.sells-cowork .vd-orc-logo {
+  width: 54px;
+  height: 54px;
+  background: oklch(0.45 0.10 155);
+  color: #fff;
+  font-size: 22px;
+  font-weight: 700;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  letter-spacing: -0.02em;
+  flex-shrink: 0;
+}
+
+.sells-cowork .vd-orc-brand {
+  font-size: 20px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  margin-bottom: 1px;
+}
+
+.sells-cowork .vd-orc-brand-sub {
+  font-size: 11.5px;
+  font-weight: 500;
+  color: #555;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin-bottom: 8px;
+}
+
+.sells-cowork .vd-orc-brand-meta {
+  font-size: 10.5px;
+  color: #444;
+  line-height: 1.55;
+}
+
+.sells-cowork .vd-orc-num-block {
+  text-align: right;
+  min-width: 220px;
+}
+
+.sells-cowork .vd-orc-num-label {
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  color: #555;
+  margin-bottom: 2px;
+}
+
+.sells-cowork .vd-orc-num {
+  font-size: 28px;
+  font-weight: 700;
+  font-family: "IBM Plex Mono", monospace;
+  color: oklch(0.40 0.10 155);
+  margin-bottom: 10px;
+  letter-spacing: -0.01em;
+}
+
+.sells-cowork .vd-orc-num-meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 2px 10px;
+  font-size: 11px;
+  margin: 0;
+}
+
+.sells-cowork .vd-orc-num-meta dt {
+  font-weight: 500;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-size: 9.5px;
+  align-self: center;
+}
+
+.sells-cowork .vd-orc-num-meta dd {
+  margin: 0;
+  font-weight: 600;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+
+.sells-cowork .vd-orc-validade {
+  color: oklch(0.50 0.16 28) !important;
+}
+
+/* Seções h3 padrão */
+.sells-cowork .vd-orc-page h3 {
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.10em;
+  text-transform: uppercase;
+  color: #555;
+  margin: 24px 0 10px;
+  padding-bottom: 5px;
+  border-bottom: 1px solid #ddd;
+}
+
+/* DESTINATÁRIO */
+.sells-cowork .vd-orc-dest-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px 24px;
+}
+
+.sells-cowork .vd-orc-dest-grid > div {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sells-cowork .vd-orc-dest-lbl {
+  font-size: 9.5px;
+  font-weight: 500;
+  color: #666;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.sells-cowork .vd-orc-dest-grid b {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+/* ITENS table */
+.sells-cowork .vd-orc-tbl {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11.5px;
+}
+
+.sells-cowork .vd-orc-tbl thead th {
+  background: oklch(0.97 0.01 250);
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  color: #444;
+  padding: 8px 10px;
+  text-align: left;
+  border-bottom: 1.5px solid #222;
+}
+
+.sells-cowork .vd-orc-tbl tbody td {
+  padding: 10px;
+  border-bottom: 1px solid #eee;
+  vertical-align: top;
+}
+
+.sells-cowork .vd-orc-tbl-n {
+  font-family: "IBM Plex Mono", monospace;
+  color: #888;
+  font-weight: 600;
+  font-size: 11px;
+}
+
+.sells-cowork .vd-orc-tbl tbody b {
+  font-weight: 600;
+  font-size: 12px;
+  display: block;
+}
+
+.sells-cowork .vd-orc-tbl-sku {
+  display: block;
+  font-size: 10px;
+  color: #777;
+  margin-top: 2px;
+  letter-spacing: 0.02em;
+}
+
+.sells-cowork .vd-orc-tbl-tot {
+  font-weight: 700;
+  font-variant-numeric: tabular-nums;
+}
+
+.sells-cowork .vd-orc-tbl tfoot td {
+  padding: 7px 10px;
+  font-variant-numeric: tabular-nums;
+}
+
+.sells-cowork .vd-orc-tbl-foot-lbl {
+  text-align: right;
+  font-weight: 500;
+  font-size: 11px;
+  color: #555;
+}
+
+.sells-cowork .vd-orc-tbl-total-row td {
+  background: oklch(0.96 0.04 155 / 0.4);
+  border-top: 2px solid oklch(0.40 0.10 155);
+  font-weight: 700;
+  font-size: 14px;
+  padding-top: 11px;
+  padding-bottom: 11px;
+}
+
+.sells-cowork .vd-orc-tbl-total-row .vd-orc-tbl-foot-lbl {
+  color: #000;
+  font-size: 12px;
+  letter-spacing: 0.04em;
+}
+
+/* CONDIÇÕES */
+.sells-cowork .vd-orc-cond ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.sells-cowork .vd-orc-cond li {
+  padding: 4px 0 4px 18px;
+  position: relative;
+  font-size: 11.5px;
+  line-height: 1.55;
+}
+
+.sells-cowork .vd-orc-cond li::before {
+  content: "▸";
+  position: absolute;
+  left: 0;
+  color: oklch(0.45 0.10 155);
+  font-weight: 600;
+}
+
+.sells-cowork .vd-orc-cond li b {
+  font-weight: 600;
+}
+
+/* ASSINATURAS */
+.sells-cowork .vd-orc-sign {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 40px;
+  margin-top: 48px;
+  padding-top: 40px;
+}
+
+.sells-cowork .vd-orc-sign-col {
+  text-align: center;
+}
+
+.sells-cowork .vd-orc-sign-line {
+  border-top: 1px solid #444;
+  margin-bottom: 8px;
+}
+
+.sells-cowork .vd-orc-sign-lbl {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  font-size: 11px;
+}
+
+.sells-cowork .vd-orc-sign-lbl b {
+  font-weight: 600;
+  font-size: 12px;
+}
+
+.sells-cowork .vd-orc-sign-lbl small {
+  font-size: 10.5px;
+  color: #666;
+}
+
+/* FOOTER */
+.sells-cowork .vd-orc-ft {
+  margin-top: 32px;
+  padding-top: 14px;
+  border-top: 1px solid #eee;
+  display: flex;
+  justify-content: space-between;
+  font-size: 9.5px;
+  color: #777;
+  letter-spacing: 0.04em;
+}
+
+/* @media print A4 — esconde tudo exceto o orçamento */
+@media print {
+  body.vd-print-orc > *:not(.sells-cowork-show):not(.sells-cowork) {
+    display: none !important;
+  }
+  body.vd-print-orc .sells-cowork-show > *:not(:has(.vd-orc-bd)),
+  body.vd-print-orc .sells-cowork > *:not(:has(.vd-orc-bd)) {
+    display: none !important;
+  }
+  body.vd-print-orc .vd-orc-bd {
+    position: static !important;
+    background: #fff !important;
+    padding: 0 !important;
+    overflow: visible !important;
+    display: block !important;
+  }
+  body.vd-print-orc .vd-orc-toolbar {
+    display: none !important;
+  }
+  body.vd-print-orc .vd-orc-page {
+    box-shadow: none !important;
+    width: 100% !important;
+    min-height: auto !important;
+    padding: 12mm 14mm !important;
+    margin: 0 !important;
+  }
+  @page {
+    size: A4;
+    margin: 0;
+  }
+}

--- a/resources/js/Pages/Sells/Show.tsx
+++ b/resources/js/Pages/Sells/Show.tsx
@@ -34,8 +34,11 @@ import VdNextActionPanel from './_components/VdNextActionPanel';
 import FsmActionPanel from './_components/FsmActionPanel';
 import VdNfeEmitModal, { type NfeEmitVenda } from './_components/VdNfeEmitModal';
 import VdNfseEmitModal, { type NfseEmitVenda } from './_components/VdNfseEmitModal';
-import VdNextActionPanel from './_components/VdNextActionPanel';
-import FsmActionPanel from './_components/FsmActionPanel';
+import SaleReciboPrint80mm from './_components/SaleReciboPrint80mm';
+import SaleOrcamentoA4 from './_components/SaleOrcamentoA4';
+
+// Modos de impressão KB-9.75 Cowork bundle 2026-05-26 P2 gaps #8 + #9
+type CoworkPrintMode = 'recibo-80mm' | 'orcamento-a4' | null;
 
 interface Customer {
   id: number;
@@ -157,6 +160,8 @@ export default function SellsShow(props: SellsShowPageProps) {
   const [isPrinting, setIsPrinting] = useState(false);
   // KB-9.75 P0 gaps #2/#3 — emit modals abertos via VdNextActionPanel gate.
   const [emitModalKind, setEmitModalKind] = useState<'nfe' | 'nfse' | null>(null);
+  // KB-9.75 P2 gaps #8/#9 — printMode controla render dos overlays Cowork (Recibo 80mm + Orçamento A4)
+  const [printMode, setPrintMode] = useState<CoworkPrintMode>(null);
 
   // /sells/{id}/print só responde a AJAX (SellPosController::printInvoice).
   // Render via iframe oculto + CSS legacy (Bootstrap 3 + .print_section) — pattern equivale
@@ -177,6 +182,14 @@ export default function SellsShow(props: SellsShowPageProps) {
     },
     [headline.invoice_no, isPrinting, permissions.print, urls.print],
   );
+
+  // KB-9.75 Cowork P2 gaps #8/#9 — abrir overlay print-only (não usa rota /sells/{id}/print legacy)
+  const handleCoworkPrint = useCallback((mode: Exclude<CoworkPrintMode, null>) => {
+    if (!permissions.print) return;
+    setPrintMode(mode);
+  }, [permissions.print]);
+
+  const handleCoworkPrintClose = useCallback(() => setPrintMode(null), []);
 
   // Atalhos teclado E (edit) + P (print) + Esc (back)
   useEffect(() => {
@@ -253,6 +266,12 @@ export default function SellsShow(props: SellsShowPageProps) {
                   </DropdownMenuItem>
                   <DropdownMenuItem onSelect={() => handlePrint('delivery_note')}>
                     Nota de entrega
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => handleCoworkPrint('recibo-80mm')}>
+                    Recibo térmico (80mm)
+                  </DropdownMenuItem>
+                  <DropdownMenuItem onSelect={() => handleCoworkPrint('orcamento-a4')}>
+                    Orçamento A4
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
@@ -443,6 +462,28 @@ export default function SellsShow(props: SellsShowPageProps) {
         onClose={() => setEmitModalKind(null)}
         onSuccess={() => router.reload({ only: ['detail', 'headline'] })}
       />
+
+      {/* KB-9.75 Cowork P2 gaps #8/#9 — overlays print-only.
+          Wrapper `sells-cowork` aplica os tokens CSS canon (`.sells-cowork .vd-receipt-paper`).
+          Renderizam só quando user seleciona no dropdown "Imprimir" E detail deferred já chegou. */}
+      {printMode === 'recibo-80mm' && props.detail && (
+        <div className="sells-cowork">
+          <SaleReciboPrint80mm
+            headline={headline}
+            detail={{ lines: props.detail.lines, payments: props.detail.payments }}
+            onClose={handleCoworkPrintClose}
+          />
+        </div>
+      )}
+      {printMode === 'orcamento-a4' && props.detail && (
+        <div className="sells-cowork">
+          <SaleOrcamentoA4
+            headline={headline}
+            detail={{ lines: props.detail.lines }}
+            onClose={handleCoworkPrintClose}
+          />
+        </div>
+      )}
     </>
   );
 }

--- a/resources/js/Pages/Sells/_components/SaleOrcamentoA4.tsx
+++ b/resources/js/Pages/Sells/_components/SaleOrcamentoA4.tsx
@@ -1,0 +1,328 @@
+// SaleOrcamentoA4 — Proposta comercial A4 imprimível.
+// Refs: Cowork KB-9.75 bundle 2026-05-26 P2 gap #9 (orçamento A4 formal).
+//        prototipo-ui project/vendas-flow.jsx:1228 VdOrcamentoPrint (canon visual)
+//        prototipo-ui project/vendas.css:3016-3347 (.vd-orc-* + @page A4)
+//        memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md
+//
+// Diferente do recibo térmico (80mm) e da NF-e fiscal — é a proposta comercial enviada ao
+// cliente ANTES da venda virar pedido. Layout A4 (210mm × 297mm), validade 7 dias padrão.
+// Número Q-XXXX deriva do invoice_no da venda.
+//
+// Componente print-only: visível só durante window.print() — wrapper recebe className
+// `sells-cowork` no Show.tsx, e este componente só renderiza quando `printMode === 'orcamento-a4'`.
+// CSS escopa `.sells-cowork .vd-orc-page` + `@media print { body.vd-print-orc … }`.
+//
+// Fallbacks de empresa/destinatário são hardcoded — Wagner personaliza depois via settings.
+// Multi-tenant Tier 0 herda do Show.tsx.
+
+import { useEffect } from 'react';
+
+interface SaleLine {
+  id: number;
+  product_name: string;
+  product_sku: string;
+  quantity: number;
+  unit_price: number;
+  discount: number;
+  subtotal: number;
+  tax_amount: number;
+  unit: string;
+}
+
+interface Customer {
+  id: number;
+  name: string;
+  mobile: string | null;
+  email: string | null;
+}
+
+interface Headline {
+  id: number;
+  invoice_no: string;
+  transaction_date: string;
+  final_total: number;
+  total_paid: number;
+  customer: Customer | null;
+  location: { id: number; name: string } | null;
+}
+
+interface Detail {
+  lines: SaleLine[];
+}
+
+interface CompanyInfo {
+  name: string;
+  tagline: string;
+  cnpj: string;
+  ie: string;
+  address: string;
+  phone: string;
+  email: string;
+  website: string;
+}
+
+interface Props {
+  headline: Headline;
+  detail: Detail;
+  /** Callback acionado quando o usuário clica em Fechar ou pressiona Esc */
+  onClose: () => void;
+  /** Override opcional de dados da empresa */
+  company?: Partial<CompanyInfo>;
+  /** Validade em dias da proposta (default 7) */
+  validadeDias?: number;
+}
+
+const DEFAULT_COMPANY: CompanyInfo = {
+  name: 'OIMPRESSO',
+  tagline: 'Comunicação Visual',
+  cnpj: 'CNPJ 12.345.678/0001-90',
+  ie: 'IE 123.456.789.012',
+  address: 'Rua Exemplo 100, São Paulo/SP · 01310-100',
+  phone: '(11) 4002-8922',
+  email: 'contato@oimpresso.com.br',
+  website: 'oimpresso.com.br',
+};
+
+function fmtBRL(n: number): string {
+  return (n || 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+function fmtDt(d: Date): string {
+  return d.toLocaleDateString('pt-BR');
+}
+
+export default function SaleOrcamentoA4({
+  headline,
+  detail,
+  onClose,
+  company,
+  validadeDias = 7,
+}: Props) {
+  const empresa: CompanyInfo = { ...DEFAULT_COMPANY, ...(company ?? {}) };
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    document.body.classList.add('vd-print-orc');
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.body.classList.remove('vd-print-orc');
+    };
+  }, [onClose]);
+
+  const lines = detail.lines ?? [];
+  const subtotal = lines.reduce((s, l) => s + l.quantity * l.unit_price, 0);
+  const desconto = lines.reduce((s, l) => s + (l.discount || 0), 0);
+  const total = headline.final_total ?? subtotal - desconto;
+
+  const today = new Date();
+  const validade = new Date(today.getTime() + validadeDias * 86400000);
+
+  // V-XXXX → Q-XXXX; sem prefixo V- usa invoice_no direto
+  const orcNum = headline.invoice_no.startsWith('V-')
+    ? headline.invoice_no.replace(/^V-/, 'Q-')
+    : `Q-${headline.invoice_no}`;
+
+  const clientName = headline.customer?.name ?? 'Consumidor Final';
+  const clientPhone = headline.customer?.mobile ?? '—';
+  const clientEmail = headline.customer?.email ?? '—';
+
+  // Brand initials (2 letras) do nome da empresa pra logo
+  const brandInitials = empresa.name.slice(0, 2);
+
+  return (
+    <div className="vd-orc-bd" onClick={onClose}>
+      <div className="vd-orc-toolbar">
+        <button type="button" className="os-btn ghost" onClick={onClose}>
+          ← Fechar
+        </button>
+        <span className="vd-orc-tag">
+          Orçamento {orcNum} · {clientName}
+        </span>
+        <button type="button" className="os-btn primary" onClick={() => window.print()}>
+          ⎙ Imprimir / Salvar PDF
+        </button>
+      </div>
+
+      <div className="vd-orc-page" onClick={(e) => e.stopPropagation()}>
+        {/* HEADER */}
+        <header className="vd-orc-h">
+          <div className="vd-orc-brand-block">
+            <div className="vd-orc-logo">{brandInitials}</div>
+            <div>
+              <div className="vd-orc-brand">{empresa.name}</div>
+              <div className="vd-orc-brand-sub">{empresa.tagline}</div>
+              <div className="vd-orc-brand-meta">
+                {empresa.cnpj} · {empresa.ie}
+                <br />
+                {empresa.address}
+                <br />
+                {empresa.phone} · {empresa.email}
+              </div>
+            </div>
+          </div>
+          <div className="vd-orc-num-block">
+            <div className="vd-orc-num-label">ORÇAMENTO</div>
+            <div className="vd-orc-num">{orcNum}</div>
+            <dl className="vd-orc-num-meta">
+              <dt>Data emissão</dt>
+              <dd>{fmtDt(today)}</dd>
+              <dt>Válido até</dt>
+              <dd className="vd-orc-validade">{fmtDt(validade)}</dd>
+              {headline.location && (
+                <>
+                  <dt>Loja</dt>
+                  <dd>{headline.location.name}</dd>
+                </>
+              )}
+            </dl>
+          </div>
+        </header>
+
+        {/* DESTINATÁRIO */}
+        <section className="vd-orc-dest">
+          <h3>PROPOSTA PARA</h3>
+          <div className="vd-orc-dest-grid">
+            <div>
+              <span className="vd-orc-dest-lbl">Razão social</span>
+              <b>{clientName}</b>
+            </div>
+            <div>
+              <span className="vd-orc-dest-lbl">Telefone</span>
+              <b>{clientPhone}</b>
+            </div>
+            <div>
+              <span className="vd-orc-dest-lbl">E-mail</span>
+              <b>{clientEmail}</b>
+            </div>
+            <div>
+              <span className="vd-orc-dest-lbl">Venda ref.</span>
+              <b>#{headline.invoice_no}</b>
+            </div>
+          </div>
+        </section>
+
+        {/* ITENS */}
+        <section className="vd-orc-itens">
+          <h3>ITENS DA PROPOSTA</h3>
+          <table className="vd-orc-tbl">
+            <thead>
+              <tr>
+                <th style={{ width: 32 }}>#</th>
+                <th>Descrição</th>
+                <th style={{ width: 60, textAlign: 'right' }}>Qtd</th>
+                <th style={{ width: 90, textAlign: 'right' }}>Vl. unit.</th>
+                <th style={{ width: 110, textAlign: 'right' }}>Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {lines.map((l, i) => (
+                <tr key={l.id}>
+                  <td className="vd-orc-tbl-n">{String(i + 1).padStart(2, '0')}</td>
+                  <td>
+                    <b>{l.product_name}</b>
+                    {l.product_sku && (
+                      <small className="vd-orc-tbl-sku">SKU {l.product_sku}</small>
+                    )}
+                  </td>
+                  <td style={{ textAlign: 'right' }}>
+                    {l.quantity} {l.unit}
+                  </td>
+                  <td style={{ textAlign: 'right' }}>{fmtBRL(l.unit_price)}</td>
+                  <td style={{ textAlign: 'right' }} className="vd-orc-tbl-tot">
+                    {fmtBRL(l.quantity * l.unit_price)}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+            <tfoot>
+              <tr>
+                <td colSpan={4} className="vd-orc-tbl-foot-lbl">
+                  Subtotal
+                </td>
+                <td style={{ textAlign: 'right' }}>{fmtBRL(subtotal)}</td>
+              </tr>
+              {desconto > 0 && (
+                <tr>
+                  <td colSpan={4} className="vd-orc-tbl-foot-lbl">
+                    Desconto comercial
+                  </td>
+                  <td style={{ textAlign: 'right' }}>-{fmtBRL(desconto)}</td>
+                </tr>
+              )}
+              <tr className="vd-orc-tbl-total-row">
+                <td colSpan={4} className="vd-orc-tbl-foot-lbl">
+                  TOTAL
+                </td>
+                <td style={{ textAlign: 'right' }}>{fmtBRL(total)}</td>
+              </tr>
+            </tfoot>
+          </table>
+        </section>
+
+        {/* CONDIÇÕES */}
+        <section className="vd-orc-cond">
+          <h3>CONDIÇÕES COMERCIAIS</h3>
+          <ul>
+            <li>
+              <b>Prazo de entrega:</b> 5 dias úteis após confirmação do pedido e aprovação
+              da arte.
+            </li>
+            <li>
+              <b>Forma de pagamento:</b> a combinar (PIX, cartão, boleto ou transferência).
+            </li>
+            <li>
+              <b>Validade desta proposta:</b> {validadeDias} dias corridos a contar da data de
+              emissão.
+            </li>
+            <li>
+              <b>Arte e revisão:</b> 1 (uma) revisão inclusa. Revisões adicionais R$ 80,00
+              cada.
+            </li>
+            <li>
+              <b>Tributação:</b> valores já incluem impostos. Emissão de NF-e/NFS-e conforme
+              natureza do item.
+            </li>
+            <li>
+              <b>Cancelamento:</b> em caso de cancelamento após início da produção, será
+              cobrado proporcional ao executado.
+            </li>
+          </ul>
+        </section>
+
+        {/* ASSINATURAS */}
+        <section className="vd-orc-sign">
+          <div className="vd-orc-sign-col">
+            <div className="vd-orc-sign-line" />
+            <div className="vd-orc-sign-lbl">
+              <b>Aprovação do cliente</b>
+              <small>{clientName}</small>
+              <small>Data: ____ / ____ / ________</small>
+            </div>
+          </div>
+          <div className="vd-orc-sign-col">
+            <div className="vd-orc-sign-line" />
+            <div className="vd-orc-sign-lbl">
+              <b>{empresa.name} {empresa.tagline}</b>
+              <small>Vendedor</small>
+              <small>Data: {fmtDt(today)}</small>
+            </div>
+          </div>
+        </section>
+
+        {/* FOOTER */}
+        <footer className="vd-orc-ft">
+          <span>
+            Orçamento {orcNum} · Emitido em {fmtDt(today)} · Página 1 de 1
+          </span>
+          <span>{empresa.website}</span>
+        </footer>
+      </div>
+    </div>
+  );
+}

--- a/resources/js/Pages/Sells/_components/SaleReciboPrint80mm.tsx
+++ b/resources/js/Pages/Sells/_components/SaleReciboPrint80mm.tsx
@@ -1,0 +1,274 @@
+// SaleReciboPrint80mm — Recibo térmico 80mm imprimível.
+// Refs: Cowork KB-9.75 bundle 2026-05-26 P2 gap #8 (recibo térmico).
+//        prototipo-ui project/vendas-flow.jsx:899 VdReceiptThermal (canon visual)
+//        prototipo-ui project/vendas.css:2666-2930 (.vd-receipt-* + .vd-rcp-* + @page 80mm)
+//        memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md
+//
+// Componente print-only: visível só durante window.print() — wrapper recebe className
+// `sells-cowork` no Show.tsx, e este componente só renderiza quando `printMode === 'recibo-80mm'`.
+// CSS escopa `.sells-cowork .vd-receipt-paper` + `@media print { body.vd-print-receipt … }`
+// pra esconder o resto da app (sidebar, header, painéis FSM) durante a impressão.
+//
+// Fallbacks de empresa (CNPJ/endereço/telefone) são hardcoded — Wagner personaliza depois
+// via settings (não-bloqueante pra demo). Multi-tenant Tier 0 herda do Show.tsx.
+
+import { useEffect } from 'react';
+
+interface SaleLine {
+  id: number;
+  product_name: string;
+  product_sku: string;
+  quantity: number;
+  unit_price: number;
+  discount: number;
+  subtotal: number;
+  tax_amount: number;
+  unit: string;
+}
+
+interface SalePayment {
+  id: number;
+  amount: number;
+  method: string;
+  paid_on: string | null;
+  note: string | null;
+}
+
+interface Customer {
+  id: number;
+  name: string;
+  mobile: string | null;
+  email: string | null;
+}
+
+interface Headline {
+  id: number;
+  invoice_no: string;
+  transaction_date: string;
+  final_total: number;
+  total_paid: number;
+  payment_status: 'paid' | 'due' | 'partial' | string;
+  customer: Customer | null;
+  location: { id: number; name: string } | null;
+}
+
+interface Detail {
+  lines: SaleLine[];
+  payments: SalePayment[];
+}
+
+interface CompanyInfo {
+  name: string;
+  tagline: string;
+  cnpj: string;
+  address: string;
+  phone: string;
+}
+
+interface Props {
+  headline: Headline;
+  detail: Detail;
+  /** Callback acionado quando o usuário clica em Fechar ou pressiona Esc */
+  onClose: () => void;
+  /** Override opcional de dados da empresa — default vem dos fallbacks hardcoded */
+  company?: Partial<CompanyInfo>;
+}
+
+const DEFAULT_COMPANY: CompanyInfo = {
+  name: 'OIMPRESSO',
+  tagline: 'Comunicação Visual',
+  cnpj: 'CNPJ 12.345.678/0001-90',
+  address: 'Rua Exemplo 100 · São Paulo/SP',
+  phone: '(11) 4002-8922',
+};
+
+const PAYMENT_METHOD_LABEL: Record<string, string> = {
+  cash: 'Dinheiro',
+  card: 'Cartão',
+  bank_transfer: 'Transferência',
+  custom_pay_1: 'PIX',
+  custom_pay_2: 'Boleto',
+};
+
+function fmtBRL(n: number): string {
+  return (n || 0).toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+function fmtCompact(n: number): string {
+  return (n || 0).toLocaleString('pt-BR', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function fmtDateBR(input: string): string {
+  if (!input) return '—';
+  const d = new Date(input);
+  if (Number.isNaN(d.getTime())) return input;
+  const dd = String(d.getDate()).padStart(2, '0');
+  const mm = String(d.getMonth() + 1).padStart(2, '0');
+  const yy = d.getFullYear();
+  const hh = String(d.getHours()).padStart(2, '0');
+  const mi = String(d.getMinutes()).padStart(2, '0');
+  return `${dd}/${mm}/${yy} ${hh}:${mi}`;
+}
+
+export default function SaleReciboPrint80mm({ headline, detail, onClose, company }: Props) {
+  const empresa: CompanyInfo = { ...DEFAULT_COMPANY, ...(company ?? {}) };
+
+  // Escape fecha + adiciona classe no body pra @media print esconder o resto
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    document.body.classList.add('vd-print-receipt');
+    return () => {
+      window.removeEventListener('keydown', onKey);
+      document.body.classList.remove('vd-print-receipt');
+    };
+  }, [onClose]);
+
+  const lines = detail.lines ?? [];
+  const subtotal = lines.reduce((s, l) => s + l.quantity * l.unit_price, 0);
+  const desconto = lines.reduce((s, l) => s + (l.discount || 0), 0);
+  const total = headline.final_total ?? subtotal - desconto;
+
+  // primeiro payment como "forma" exibida (caso múltiplos → usa rótulo do primeiro)
+  const primaryPayment = detail.payments?.[0];
+  const formaPagamento = primaryPayment
+    ? PAYMENT_METHOD_LABEL[primaryPayment.method] ?? primaryPayment.method
+    : '—';
+
+  return (
+    <div className="vd-receipt-bd" onClick={onClose}>
+      <div className="vd-receipt-toolbar">
+        <button type="button" className="os-btn ghost" onClick={onClose}>
+          ← Fechar
+        </button>
+        <span className="vd-receipt-tag">Recibo térmico · #{headline.invoice_no}</span>
+        <button type="button" className="os-btn primary" onClick={() => window.print()}>
+          ⎙ Imprimir
+        </button>
+      </div>
+
+      <div className="vd-receipt-paper" onClick={(e) => e.stopPropagation()}>
+        {/* HEADER */}
+        <div className="vd-rcp-h">
+          <div className="vd-rcp-brand">{empresa.name}</div>
+          <div className="vd-rcp-sub">{empresa.tagline}</div>
+          <div className="vd-rcp-meta">
+            {empresa.cnpj}
+            <br />
+            {empresa.address}
+            <br />
+            {empresa.phone}
+          </div>
+        </div>
+
+        <div className="vd-rcp-sep" />
+
+        {/* INFO VENDA */}
+        <div className="vd-rcp-info">
+          <div className="vd-rcp-row">
+            <span>VENDA</span>
+            <b>#{headline.invoice_no}</b>
+          </div>
+          <div className="vd-rcp-row">
+            <span>DATA</span>
+            <b>{fmtDateBR(headline.transaction_date)}</b>
+          </div>
+          {headline.location && (
+            <div className="vd-rcp-row">
+              <span>LOJA</span>
+              <b>{headline.location.name}</b>
+            </div>
+          )}
+          {headline.customer && (
+            <div className="vd-rcp-row">
+              <span>CLIENTE</span>
+              <b>{headline.customer.name}</b>
+            </div>
+          )}
+        </div>
+
+        <div className="vd-rcp-sep" />
+
+        {/* ITENS */}
+        <div className="vd-rcp-itens">
+          <div className="vd-rcp-itens-h">
+            <span>ITEM</span>
+            <span>VL.UNIT</span>
+            <span>TOTAL</span>
+          </div>
+          {lines.map((l) => (
+            <div key={l.id} className="vd-rcp-item">
+              <div className="vd-rcp-item-name">{l.product_name}</div>
+              <div className="vd-rcp-item-row">
+                <span className="vd-rcp-item-qty">
+                  {l.quantity}× {fmtCompact(l.unit_price)}
+                </span>
+                <span className="vd-rcp-item-tot">{fmtCompact(l.quantity * l.unit_price)}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <div className="vd-rcp-sep" />
+
+        {/* TOTAIS */}
+        <div className="vd-rcp-totais">
+          <div className="vd-rcp-row">
+            <span>SUBTOTAL</span>
+            <b>{fmtBRL(subtotal)}</b>
+          </div>
+          {desconto > 0 && (
+            <div className="vd-rcp-row">
+              <span>DESCONTO</span>
+              <b>-{fmtBRL(desconto)}</b>
+            </div>
+          )}
+          <div className="vd-rcp-row vd-rcp-row-total">
+            <span>TOTAL</span>
+            <b>{fmtBRL(total)}</b>
+          </div>
+        </div>
+
+        <div className="vd-rcp-sep" />
+
+        {/* PAGAMENTO */}
+        <div className="vd-rcp-pgto">
+          <div className="vd-rcp-row">
+            <span>PAGAMENTO</span>
+            <b>{formaPagamento}</b>
+          </div>
+          {detail.payments && detail.payments.length > 1 && (
+            <div className="vd-rcp-row">
+              <span>LANÇAMENTOS</span>
+              <b>{detail.payments.length}</b>
+            </div>
+          )}
+          <div className="vd-rcp-row">
+            <span>PAGO</span>
+            <b>{fmtBRL(headline.total_paid)}</b>
+          </div>
+        </div>
+
+        <div className="vd-rcp-sep" />
+
+        {/* FOOTER */}
+        <div className="vd-rcp-foot">
+          <div className="vd-rcp-thanks">Obrigado pela preferência!</div>
+          <small className="vd-rcp-disclaimer">
+            Este documento NÃO é um documento fiscal.
+          </small>
+          <div className="vd-rcp-stamp">
+            Impresso em{' '}
+            {new Date().toLocaleDateString('pt-BR')}{' '}
+            {new Date().toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/tests/Feature/Sells/SellsKb975PrintTest.php
+++ b/tests/Feature/Sells/SellsKb975PrintTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest STRUCTURAL — KB-9.75 P2 batch (Cowork bundle 2026-05-26).
+ *
+ * Cobre os gaps #8 (Recibo térmico 80mm) e #9 (Orçamento A4) do
+ * `memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md`.
+ *
+ * Refs:
+ *  - resources/js/Pages/Sells/_components/SaleReciboPrint80mm.tsx (NOVO)
+ *  - resources/js/Pages/Sells/_components/SaleOrcamentoA4.tsx (NOVO)
+ *  - resources/css/sells-kb975-print.css (NOVO — 80mm + A4 @page)
+ *  - resources/js/Pages/Sells/Show.tsx (wire-up — dropdown + state printMode)
+ */
+
+const KB975_PRINT_RECIBO_PATH = 'resources/js/Pages/Sells/_components/SaleReciboPrint80mm.tsx';
+const KB975_PRINT_ORCAMENTO_PATH = 'resources/js/Pages/Sells/_components/SaleOrcamentoA4.tsx';
+const KB975_PRINT_CSS_PATH = 'resources/css/sells-kb975-print.css';
+const KB975_PRINT_INERTIA_CSS = 'resources/css/inertia.css';
+const KB975_PRINT_SHOW_PAGE = 'resources/js/Pages/Sells/Show.tsx';
+
+it('SaleReciboPrint80mm.tsx existe', function () {
+    expect(file_exists(base_path(KB975_PRINT_RECIBO_PATH)))->toBeTrue();
+});
+
+it('SaleReciboPrint80mm declara interface Props TS strict com headline + detail + onClose', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_RECIBO_PATH));
+    expect($source)->toContain('interface Props');
+    expect($source)->toContain('headline: Headline');
+    expect($source)->toContain('detail: Detail');
+    expect($source)->toContain('onClose: () => void');
+});
+
+it('SaleReciboPrint80mm dispara window.print() no botão Imprimir', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_RECIBO_PATH));
+    expect($source)->toContain('window.print()');
+});
+
+it('SaleReciboPrint80mm adiciona body.vd-print-receipt pra @media print esconder app', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_RECIBO_PATH));
+    expect($source)->toContain("classList.add('vd-print-receipt')");
+    expect($source)->toContain("classList.remove('vd-print-receipt')");
+});
+
+it('SaleReciboPrint80mm renderiza estrutura canon vd-receipt-paper + vd-rcp-*', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_RECIBO_PATH));
+    expect($source)->toContain('vd-receipt-paper');
+    expect($source)->toContain('vd-rcp-brand');
+    expect($source)->toContain('vd-rcp-itens');
+    expect($source)->toContain('vd-rcp-row-total');
+    expect($source)->toContain('vd-rcp-thanks');
+});
+
+it('SaleReciboPrint80mm tem fallback hardcoded de empresa (CNPJ + endereço + telefone)', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_RECIBO_PATH));
+    expect($source)->toContain('DEFAULT_COMPANY');
+    expect($source)->toContain('CNPJ');
+});
+
+it('SaleOrcamentoA4.tsx existe', function () {
+    expect(file_exists(base_path(KB975_PRINT_ORCAMENTO_PATH)))->toBeTrue();
+});
+
+it('SaleOrcamentoA4 declara interface Props TS strict + validadeDias default 7', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_ORCAMENTO_PATH));
+    expect($source)->toContain('interface Props');
+    expect($source)->toContain('validadeDias?: number');
+    expect($source)->toContain('validadeDias = 7');
+});
+
+it('SaleOrcamentoA4 deriva número Q-XXXX do invoice_no da venda', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_ORCAMENTO_PATH));
+    expect($source)->toContain('orcNum');
+    expect($source)->toContain("'Q-'");
+});
+
+it('SaleOrcamentoA4 adiciona body.vd-print-orc pra @media print esconder app', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_ORCAMENTO_PATH));
+    expect($source)->toContain("classList.add('vd-print-orc')");
+    expect($source)->toContain("classList.remove('vd-print-orc')");
+});
+
+it('SaleOrcamentoA4 renderiza estrutura canon vd-orc-page + tabela + assinaturas + footer', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_ORCAMENTO_PATH));
+    expect($source)->toContain('vd-orc-page');
+    expect($source)->toContain('vd-orc-brand');
+    expect($source)->toContain('vd-orc-tbl');
+    expect($source)->toContain('vd-orc-sign');
+    expect($source)->toContain('vd-orc-ft');
+});
+
+it('SaleOrcamentoA4 tem condições comerciais default (prazo + arte + cancelamento)', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_ORCAMENTO_PATH));
+    expect($source)->toContain('vd-orc-cond');
+    expect($source)->toContain('Prazo de entrega');
+    expect($source)->toContain('Cancelamento');
+});
+
+it('sells-kb975-print.css existe', function () {
+    expect(file_exists(base_path(KB975_PRINT_CSS_PATH)))->toBeTrue();
+});
+
+it('sells-kb975-print.css escopa em .sells-cowork (coexiste com legacy printSaleReceipt.ts)', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_CSS_PATH));
+    expect($source)->toContain('.sells-cowork .vd-receipt-paper');
+    expect($source)->toContain('.sells-cowork .vd-orc-page');
+});
+
+it('sells-kb975-print.css declara @page 80mm pra recibo térmico', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_CSS_PATH));
+    expect($source)->toContain('size: 80mm auto');
+});
+
+it('sells-kb975-print.css declara @page A4 pra orçamento', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_CSS_PATH));
+    expect($source)->toContain('size: A4');
+});
+
+it('sells-kb975-print.css esconde resto da app via body.vd-print-receipt/orc', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_CSS_PATH));
+    expect($source)->toContain('body.vd-print-receipt');
+    expect($source)->toContain('body.vd-print-orc');
+});
+
+it('sells-kb975-print.css importada em inertia.css', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_INERTIA_CSS));
+    expect($source)->toContain('sells-kb975-print.css');
+});
+
+it('Show.tsx importa SaleReciboPrint80mm + SaleOrcamentoA4', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_SHOW_PAGE));
+    expect($source)->toContain("from './_components/SaleReciboPrint80mm'");
+    expect($source)->toContain("from './_components/SaleOrcamentoA4'");
+});
+
+it('Show.tsx declara state printMode com type CoworkPrintMode', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_SHOW_PAGE));
+    expect($source)->toContain('CoworkPrintMode');
+    expect($source)->toContain('useState<CoworkPrintMode>(null)');
+});
+
+it('Show.tsx tem dropdown items "Recibo térmico (80mm)" e "Orçamento A4"', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_SHOW_PAGE));
+    expect($source)->toContain('Recibo térmico (80mm)');
+    expect($source)->toContain('Orçamento A4');
+    expect($source)->toContain("handleCoworkPrint('recibo-80mm')");
+    expect($source)->toContain("handleCoworkPrint('orcamento-a4')");
+});
+
+it('Show.tsx conditional render dos overlays (não bloqueia legacy printSaleReceipt)', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_SHOW_PAGE));
+    // Modal só renderiza quando user pediu E detail deferred já chegou
+    expect($source)->toContain("printMode === 'recibo-80mm' && props.detail");
+    expect($source)->toContain("printMode === 'orcamento-a4' && props.detail");
+    // Legacy NÃO removido — convive
+    expect($source)->toContain('printSaleReceipt');
+});
+
+it('Show.tsx mantém atalhos E/P/Esc + dropdown legacy invoice/packing/delivery (sem regressão)', function () {
+    $source = file_get_contents(base_path(KB975_PRINT_SHOW_PAGE));
+    expect($source)->toContain("if (e.key === 'p' && permissions.print)");
+    expect($source)->toContain("handlePrint('invoice')");
+    expect($source)->toContain("handlePrint('packing_slip')");
+    expect($source)->toContain("handlePrint('delivery_note')");
+});


### PR DESCRIPTION
## Summary

Implementa **gaps P2 #8 + #9** do bundle Cowork KB-9.75 — referência protótipo `prototipo-ui/cowork-2026-05-26-comunicacao-visual` (VdReceiptThermal linha 899 + VdOrcamentoPrint linha 1228).

- **#8 Recibo térmico 80mm** — overlay print-only monospace, layout térmico canon, totais + pagamento + agradecimento
- **#9 Orçamento A4** — proposta comercial formal Q-XXXX, validade 7d, tabela itens, condições comerciais default, assinaturas, footer

### Arquivos

| Tipo | Path | LOC |
|---|---|---|
| Componente | `resources/js/Pages/Sells/_components/SaleReciboPrint80mm.tsx` | +257 |
| Componente | `resources/js/Pages/Sells/_components/SaleOrcamentoA4.tsx` | +315 |
| CSS escopado | `resources/css/sells-kb975-print.css` (80 seletores `.sells-cowork`) | +566 |
| CSS import | `resources/css/inertia.css` | +3 |
| Wire-up | `resources/js/Pages/Sells/Show.tsx` | +43 |
| Test Pest | `tests/Feature/Sells/SellsKb975PrintTest.php` (23 testes / 54 assertions) | +135 |

### Regras

- **TS strict** — `interface Props` explícita em ambos os componentes
- **CSS escopado em `.sells-cowork`** — coexiste com legacy `printSaleReceipt.ts` (modes invoice/packing_slip/delivery_note intactos)
- **`@page` canon** — `size: 80mm auto; margin: 0` (recibo) e `size: A4; margin: 0` (orçamento)
- **Multi-tenant Tier 0** — herda do Show.tsx, sem nova superfície DB
- **NÃO toca** controllers PHP, `printSaleReceipt.ts`, ou rota legacy `/sells/{id}/print`

### Fallbacks razoáveis

Empresa/CNPJ/endereço/telefone hardcoded em `DEFAULT_COMPANY` — Wagner personaliza depois via settings sem bloquear demo 3pm.

## Test plan

- [x] `php vendor/bin/pest tests/Feature/Sells/SellsKb975PrintTest.php` → **23 passed (54 assertions)**
- [ ] Smoke manual `/sells/{id}` → dropdown "Imprimir" → "Recibo térmico (80mm)" → preview correto + `window.print()` mostra só recibo
- [ ] Smoke manual `/sells/{id}` → dropdown "Imprimir" → "Orçamento A4" → preview correto + `window.print()` mostra só proposta
- [ ] Regressão legacy: dropdown ainda tem `invoice / packing_slip / delivery_note` funcionando via iframe legacy
- [ ] Atalho `P` continua disparando legacy invoice (sem regressão)

## Refs

- `memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md` (gaps P2 #8/#9)
- PR #1638 (bundle KB-9.75 mergeado em `prototipo-ui/`)
- PR #1641 (P0 batch — VdNextActionPanel sibling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)