### PR TITLE
feat(sells): KB-9.75 P3 #12 cheat-sheet reusável + P1 #10 toast hub canon

### DIFF
--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -14,6 +14,9 @@
 /* Sells KB-9.75 Recibo térmico 80mm + Orçamento A4 (Cowork bundle 2026-05-26 P2 gaps #8/#9) */
 @import "./sells-kb975-print.css";
 
+/* Sells KB-9.75 Cheat-sheet overlay '?' (Cowork bundle 2026-05-26 gap P3 #12 — fullscreen global, fora .sells-cowork) */
+@import "./sells-kb975-cheatsheet.css";
+
 /* Sells Cowork Onda 2 R2 IA drawer — escopado em .sells-cowork + .sells-cowork-ia-panel */
 @import "./sells-cowork-ia.css";
 

--- a/resources/css/sells-kb975-cheatsheet.css
+++ b/resources/css/sells-kb975-cheatsheet.css
@@ -1,0 +1,242 @@
+/**
+ * sells-kb975-cheatsheet.css — Cheat-sheet overlay (gap P3 #12 KB-9.75).
+ *
+ * Refs:
+ *  - prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/.../styles.css (linha 6222+)
+ *  - resources/js/Pages/Sells/_components/SellsCheatSheet.tsx
+ *  - memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md
+ *
+ * NOTA DE ESCOPO: este overlay é fullscreen global — disparado em qualquer
+ * sub-rota de Vendas (Index, Show, Caixa, Drafts, Quotations, Edit). Por isso
+ * NÃO está escopado em `.sells-cowork` como os outros bundles Cowork — fica
+ * top-level pra renderizar acima de qualquer wrapper. Z-index 1000 acima do
+ * AppShellV2 mas abaixo de modais críticos (toast sonner é 9999).
+ *
+ * Tokens usados: --surface, --border, --border-2, --text, --text-mute,
+ * --text-dim, --bg-2, --vd-green, --font-mono. Todos definidos em
+ * sells-cowork.css :root e em themes.css — o overlay renderiza com tokens
+ * herdados do <html>/<body> mesmo fora do .sells-cowork.
+ *
+ * Fallbacks defensivos: caso tokens não estejam carregados (raríssimo —
+ * pulando o bundle Cowork inteiro), os fallbacks após `var(...)` mantém
+ * visual aceitável.
+ */
+
+/* ── Backdrop fullscreen ── */
+.vd-cheat-bd {
+  position: fixed;
+  inset: 0;
+  z-index: 1000;
+  background: oklch(0 0 0 / 0.5);
+  display: grid;
+  place-items: center;
+  padding: 24px;
+  animation: vdCheatFadeIn 0.15s ease-out;
+  backdrop-filter: blur(2px);
+}
+
+@keyframes vdCheatFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+/* ── Container (max 760px, centrado, scroll interno) ── */
+.vd-cheat {
+  background: var(--surface, #ffffff);
+  color: var(--text, #1f2937);
+  border-radius: 12px;
+  box-shadow: 0 24px 60px rgba(0, 0, 0, 0.18);
+  width: 100%;
+  max-width: 760px;
+  max-height: 86vh;
+  overflow: auto;
+  display: flex;
+  flex-direction: column;
+  animation: vdCheatSlideUp 0.18s ease-out;
+}
+
+@keyframes vdCheatSlideUp {
+  from { transform: translateY(12px); opacity: 0; }
+  to { transform: none; opacity: 1; }
+}
+
+/* ── Header: ícone | título+subtítulo | botão X ── */
+.vd-cheat-h {
+  padding: 22px 26px 18px;
+  border-bottom: 1px solid var(--border, #e5e7eb);
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  grid-template-areas:
+    "ic title x"
+    "ic sub x";
+  gap: 2px 14px;
+  align-items: center;
+}
+
+.vd-cheat-ic {
+  grid-area: ic;
+  display: grid;
+  place-items: center;
+  width: 38px;
+  height: 38px;
+  background: var(--vd-green, #16a34a);
+  color: white;
+  border-radius: 8px;
+  font-size: 19px;
+  align-self: center;
+}
+
+.vd-cheat-h h2 {
+  grid-area: title;
+  margin: 0;
+  font-size: 17px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--text, #1f2937);
+}
+
+.vd-cheat-h p {
+  grid-area: sub;
+  margin: 0;
+  font-size: 12.5px;
+  color: var(--text-mute, #6b7280);
+}
+
+.vd-cheat-x {
+  grid-area: x;
+  background: transparent;
+  border: 1px solid var(--border, #e5e7eb);
+  padding: 4px 10px;
+  border-radius: 5px;
+  cursor: pointer;
+  color: var(--text-mute, #6b7280);
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.vd-cheat-x:hover {
+  background: var(--bg-2, #f9fafb);
+  color: var(--text, #1f2937);
+}
+
+.vd-cheat-x kbd {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10px;
+  border: none;
+  padding: 0;
+  background: transparent;
+}
+
+/* ── Grid de seções (default 2 colunas; 3 em telas grandes; 1 em mobile) ── */
+.vd-cheat-grid {
+  padding: 22px 26px;
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 22px 32px;
+}
+
+@media (min-width: 1280px) {
+  .vd-cheat-grid {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
+
+@media (max-width: 900px) {
+  .vd-cheat-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.vd-cheat-sec h4 {
+  margin: 0 0 10px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--vd-green, #16a34a);
+}
+
+/* ── Linhas de atalho: keys | label ── */
+.vd-cs-row {
+  display: grid;
+  grid-template-columns: 130px 1fr;
+  gap: 12px;
+  padding: 5px 0;
+  align-items: center;
+  font-size: 12px;
+  color: var(--text-dim, #4b5563);
+}
+
+.vd-cs-row + .vd-cs-row {
+  border-top: 1px solid var(--border-2, #f3f4f6);
+}
+
+.vd-cs-keys {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.vd-cs-keys-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.vd-cs-keys kbd {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10.5px;
+  font-weight: 600;
+  background: var(--surface, #ffffff);
+  color: var(--text, #1f2937);
+  border: 1px solid var(--border, #e5e7eb);
+  border-bottom-width: 2px;
+  border-radius: 4px;
+  padding: 2px 7px;
+  min-width: 24px;
+  text-align: center;
+}
+
+.vd-cs-plus {
+  font-size: 10px;
+  color: var(--text-mute, #6b7280);
+}
+
+.vd-cs-lbl b {
+  color: var(--text, #1f2937);
+  font-weight: 600;
+}
+
+.vd-cs-lbl code {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 10.5px;
+  background: var(--bg-2, #f9fafb);
+  padding: 1px 4px;
+  border-radius: 3px;
+  color: var(--vd-green, #16a34a);
+}
+
+/* ── Footer ── */
+.vd-cheat-ft {
+  padding: 14px 26px;
+  border-top: 1px solid var(--border, #e5e7eb);
+  background: var(--bg-2, #f9fafb);
+  font-size: 11px;
+  color: var(--text-mute, #6b7280);
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+/* ── Dark mode (futuro — themes.css define .dark) ── */
+.dark .vd-cheat {
+  background: var(--surface, #1f2937);
+  color: var(--text, #f9fafb);
+}
+
+.dark .vd-cheat-bd {
+  background: oklch(0 0 0 / 0.7);
+}

--- a/resources/js/Lib/oimpressoToast.ts
+++ b/resources/js/Lib/oimpressoToast.ts
@@ -1,0 +1,136 @@
+// resources/js/Lib/oimpressoToast.ts — toast hub canônico (gap P1 #10 KB-9.75).
+// Refs:
+//  - memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md
+//  - resources/js/Pages/Sells/_components/VdNextActionPanel.tsx (dispatch oimpresso:venda-*)
+//  - resources/js/Pages/Sells/_components/FsmActionPanel.tsx (sonner direto, mantém)
+//
+// Hub canon que centraliza dois canais:
+//  (a) sonner toast UI (visível pro usuário — top-right);
+//  (b) CustomEvent `oimpresso:toast` no window (escutável por outros widgets/SaleSheet/
+//      Inertia partial reloaders pra trigger refresh sem polling).
+//
+// Adicionalmente dispatch eventos namespaced pelo domínio (oimpresso:venda-invoiced,
+// venda-paid, venda-emitted-nfe, venda-emitted-nfse) — mesmo padrão usado em
+// VdNextActionPanel pra desacoplar componente publisher do componente subscriber.
+//
+// NÃO substitui sonner direto — código existente em FsmActionPanel/CobrancaDrawer/
+// CriarOsButton continua usando `import { toast } from 'sonner'`. Este hub é
+// wrapper OPCIONAL que dá:
+//  - dispatch evento namespaced (Inertia partial reload sem polling);
+//  - log estruturado pra clarity/telemetria futura;
+//  - vocabulário BR canônico (Faturar ≠ Receber pagamento).
+//
+// Multi-tenant Tier 0 ADR 0093: nenhum business_id explícito aqui — sale_id já é
+// per-tenant (model SaleSell tem global scope BusinessIdScope).
+
+import { toast } from 'sonner';
+
+export type OimpressoToastTone = 'success' | 'error' | 'info' | 'warning';
+
+export interface OimpressoToastDetail {
+  tone: OimpressoToastTone;
+  msg: string;
+  saleId?: number | string | null;
+  /** Opcional — metadados extras pra subscribers (ex: orderable_id, invoice_no). */
+  meta?: Record<string, unknown>;
+}
+
+const HUB_EVENT = 'oimpresso:toast' as const;
+
+function dispatchHub(detail: OimpressoToastDetail): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.dispatchEvent(new CustomEvent(HUB_EVENT, { detail }));
+  } catch {
+    // SSR / non-DOM env — silent no-op.
+  }
+}
+
+function dispatchNamed(name: string, detail: Record<string, unknown>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.dispatchEvent(new CustomEvent(name, { detail }));
+  } catch {
+    // silent no-op.
+  }
+}
+
+/**
+ * Notifica que a venda foi FATURADA (emissão fiscal autorizada — NF-e ou NFS-e).
+ * Vocabulário BR canon ADR-pendente: "faturar" = emitir documento fiscal,
+ * NÃO confundir com "receber pagamento" (vide `paid`).
+ */
+function invoiced(saleId: number | string, msg: string, meta?: Record<string, unknown>): void {
+  toast.success(msg);
+  dispatchHub({ tone: 'success', msg, saleId, meta });
+  dispatchNamed('oimpresso:venda-invoiced', { saleId, msg, ...(meta ?? {}) });
+}
+
+/**
+ * Notifica que a venda foi PAGA (recebimento financeiro registrado).
+ * Distinto de `invoiced` — venda pode estar paga sem NF-e e vice-versa.
+ */
+function paid(saleId: number | string, msg: string, meta?: Record<string, unknown>): void {
+  toast.success(msg);
+  dispatchHub({ tone: 'success', msg, saleId, meta });
+  dispatchNamed('oimpresso:venda-paid', { saleId, msg, ...(meta ?? {}) });
+}
+
+/**
+ * Notifica emissão de documento fiscal específico (NF-e mercadoria ou NFS-e serviço).
+ * Use kind='nfe' pra NF-e (modelo 55) e kind='nfse' pra NFS-e (serviço municipal).
+ */
+function emitted(
+  saleId: number | string,
+  kind: 'nfe' | 'nfse',
+  msg: string,
+  meta?: Record<string, unknown>,
+): void {
+  toast.success(msg);
+  dispatchHub({ tone: 'success', msg, saleId, meta: { kind, ...(meta ?? {}) } });
+  const eventName = kind === 'nfe' ? 'oimpresso:venda-emitted-nfe' : 'oimpresso:venda-emitted-nfse';
+  dispatchNamed(eventName, { saleId, msg, kind, ...(meta ?? {}) });
+}
+
+/** Notifica erro genérico. saleId opcional (alguns erros são globais). */
+function error(msg: string, saleId?: number | string, meta?: Record<string, unknown>): void {
+  toast.error(msg);
+  dispatchHub({ tone: 'error', msg, saleId: saleId ?? null, meta });
+}
+
+/** Notifica informação neutra (não success / não error). */
+function info(msg: string, saleId?: number | string, meta?: Record<string, unknown>): void {
+  toast.info(msg);
+  dispatchHub({ tone: 'info', msg, saleId: saleId ?? null, meta });
+}
+
+/** Notifica aviso (warning) — entre info e error. */
+function warning(msg: string, saleId?: number | string, meta?: Record<string, unknown>): void {
+  toast.warning(msg);
+  dispatchHub({ tone: 'warning', msg, saleId: saleId ?? null, meta });
+}
+
+export const oimpressoToast = {
+  invoiced,
+  paid,
+  emitted,
+  error,
+  info,
+  warning,
+} as const;
+
+export type OimpressoToastApi = typeof oimpressoToast;
+
+// Re-export do nome do evento canon pra subscribers usarem como string literal type-safe.
+export const OIMPRESSO_TOAST_EVENT = HUB_EVENT;
+
+// Tipagem auxiliar pra subscribers usarem `window.addEventListener` com tipo certo.
+declare global {
+  interface WindowEventMap {
+    'oimpresso:toast': CustomEvent<OimpressoToastDetail>;
+    'oimpresso:venda-invoiced': CustomEvent<{ saleId: number | string; msg: string }>;
+    'oimpresso:venda-paid': CustomEvent<{ saleId: number | string; msg: string }>;
+    'oimpresso:venda-emitted-nfe': CustomEvent<{ saleId: number | string; msg: string; kind: 'nfe' }>;
+    'oimpresso:venda-emitted-nfse': CustomEvent<{ saleId: number | string; msg: string; kind: 'nfse' }>;
+  }
+}

--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -28,7 +28,6 @@ import {
   Printer,
   Search,
   SlidersHorizontal,
-  X,
 } from 'lucide-react';
 import SaleSheet from './_components/SaleSheet';
 import QuickPaymentPopover from './_components/QuickPaymentPopover';
@@ -46,6 +45,7 @@ import SellsTabelaUnificada, {
   type ColumnId,
   type SaleRow as UnifiedSaleRow,
 } from './_components/SellsTabelaUnificada';
+import SellsCheatSheet, { SELLS_INDEX_SHORTCUTS } from './_components/SellsCheatSheet';
 
 // ──────────────────────────────────────────────────────────────
 // TIPOS
@@ -386,61 +386,10 @@ function Sparkline({
 }
 
 // ──────────────────────────────────────────────────────────────
-// Cheat sheet overlay (?)
+// Cheat sheet overlay (?) — extraído pra _components/SellsCheatSheet.tsx
+// (gap P3 #12 KB-9.75 Cowork bundle 2026-05-26). Lista canônica de atalhos
+// em SELLS_INDEX_SHORTCUTS no mesmo módulo.
 // ──────────────────────────────────────────────────────────────
-function SellsCheatSheet({ onClose }: { onClose: () => void }): ReactNode {
-  return (
-    <div className="vd-cheat-bd" onClick={onClose}>
-      <div className="vd-cheat" onClick={(e) => e.stopPropagation()} role="dialog" aria-label="Atalhos">
-        <header className="vd-cheat-h">
-          <span className="vd-cheat-ic">⌨</span>
-          <h2>Atalhos · Lista de vendas</h2>
-          <button className="vd-cheat-x" onClick={onClose} aria-label="Fechar">
-            <X size={14} />
-          </button>
-        </header>
-        <div className="vd-cheat-body">
-          <section className="vd-cheat-grp">
-            <h3>Navegar</h3>
-            <ul>
-              <li><kbd>J</kbd> <kbd>K</kbd> linha anterior/próxima</li>
-              <li><kbd>Enter</kbd> abrir detalhes</li>
-              <li><kbd>Esc</kbd> fechar drawer / palette</li>
-            </ul>
-          </section>
-          <section className="vd-cheat-grp">
-            <h3>Ações</h3>
-            <ul>
-              <li><kbd>N</kbd> nova venda</li>
-              <li><kbd>B</kbd> favoritar linha em foco ★</li>
-              <li><kbd>R</kbd> imprimir recibo</li>
-              <li><kbd>F</kbd> faturar (emitir NF)</li>
-              <li><kbd>X</kbd> marcar pra ação em lote</li>
-              <li><kbd>E</kbd> editar venda</li>
-            </ul>
-          </section>
-          <section className="vd-cheat-grp">
-            <h3>⌘K palette</h3>
-            <ul>
-              <li><kbd>⌘K</kbd> abrir busca rápida</li>
-              <li><kbd>/</kbd> ações</li>
-              <li><kbd>#</kbd> ID da venda</li>
-              <li><kbd>@</kbd> vendedor</li>
-              <li><kbd>$</kbd> valor mínimo</li>
-            </ul>
-          </section>
-          <section className="vd-cheat-grp">
-            <h3>Sair</h3>
-            <ul>
-              <li><kbd>?</kbd> abre/fecha este painel</li>
-              <li><kbd>Esc</kbd> fechar</li>
-            </ul>
-          </section>
-        </div>
-      </div>
-    </div>
-  );
-}
 
 // ──────────────────────────────────────────────────────────────
 // Saved views — Hoje / Pendentes / Atrasadas / Rejeitadas / Faturadas / Favoritas
@@ -1607,7 +1556,13 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
         )}
 
         {/* CHEAT-SHEET (?) */}
-        {cheatOpen && <SellsCheatSheet onClose={() => setCheatOpen(false)} />}
+        <SellsCheatSheet
+          open={cheatOpen}
+          onClose={() => setCheatOpen(false)}
+          shortcuts={SELLS_INDEX_SHORTCUTS}
+          title="Atalhos · Lista de vendas"
+          footerLeft="Atalhos persistem em toda sub-rota de Vendas (Lista · Caixa · Devoluções · Comissões · Relatórios)."
+        />
 
         {/* ⌘K palette — versão simplificada (backend search + recent + actions) */}
         {palOpen && (

--- a/resources/js/Pages/Sells/Show.tsx
+++ b/resources/js/Pages/Sells/Show.tsx
@@ -36,6 +36,7 @@ import VdNfeEmitModal, { type NfeEmitVenda } from './_components/VdNfeEmitModal'
 import VdNfseEmitModal, { type NfseEmitVenda } from './_components/VdNfseEmitModal';
 import SaleReciboPrint80mm from './_components/SaleReciboPrint80mm';
 import SaleOrcamentoA4 from './_components/SaleOrcamentoA4';
+import SellsCheatSheet, { SELLS_SHOW_SHORTCUTS } from './_components/SellsCheatSheet';
 
 // Modos de impressão KB-9.75 Cowork bundle 2026-05-26 P2 gaps #8 + #9
 type CoworkPrintMode = 'recibo-80mm' | 'orcamento-a4' | null;
@@ -162,6 +163,8 @@ export default function SellsShow(props: SellsShowPageProps) {
   const [emitModalKind, setEmitModalKind] = useState<'nfe' | 'nfse' | null>(null);
   // KB-9.75 P2 gaps #8/#9 — printMode controla render dos overlays Cowork (Recibo 80mm + Orçamento A4)
   const [printMode, setPrintMode] = useState<CoworkPrintMode>(null);
+  // KB-9.75 P3 gap #12 — cheat-sheet overlay '?' (Cowork bundle 2026-05-26).
+  const [cheatOpen, setCheatOpen] = useState(false);
 
   // /sells/{id}/print só responde a AJAX (SellPosController::printInvoice).
   // Render via iframe oculto + CSS legacy (Bootstrap 3 + .print_section) — pattern equivale
@@ -191,13 +194,22 @@ export default function SellsShow(props: SellsShowPageProps) {
 
   const handleCoworkPrintClose = useCallback(() => setPrintMode(null), []);
 
-  // Atalhos teclado E (edit) + P (print) + Esc (back)
+  // Atalhos teclado E (edit) + P (print) + ? (cheat-sheet KB-9.75 gap #12) + Esc (back/close).
+  // Quando cheatOpen, todos os outros atalhos ficam suprimidos — o próprio
+  // SellsCheatSheet possui seu listener pra Esc/? (fecha o overlay).
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
       if (
         e.target instanceof HTMLInputElement ||
         e.target instanceof HTMLTextAreaElement
       ) {
+        return;
+      }
+      // Suprime atalhos enquanto cheat-sheet aberta — o overlay tem listener próprio.
+      if (cheatOpen) return;
+      if (e.key === '?') {
+        e.preventDefault();
+        setCheatOpen(true);
         return;
       }
       if (e.key === 'e' && permissions.edit) {
@@ -215,7 +227,7 @@ export default function SellsShow(props: SellsShowPageProps) {
     };
     window.addEventListener('keydown', handler);
     return () => window.removeEventListener('keydown', handler);
-  }, [permissions.edit, permissions.print, urls.edit, urls.back, handlePrint]);
+  }, [cheatOpen, permissions.edit, permissions.print, urls.edit, urls.back, handlePrint]);
 
   const totalFalta = Math.max(0, headline.final_total - headline.total_paid);
   const paymentStatusLabel = PAYMENT_STATUS_LABEL[headline.payment_status] ?? headline.payment_status;
@@ -397,6 +409,16 @@ export default function SellsShow(props: SellsShowPageProps) {
             </section>
           </aside>
         </div>
+
+        {/* KB-9.75 P3 gap #12 — cheat-sheet overlay '?' (Cowork bundle 2026-05-26).
+            Lista canon SELLS_SHOW_SHORTCUTS exporta os atalhos da tela Detalhe. */}
+        <SellsCheatSheet
+          open={cheatOpen}
+          onClose={() => setCheatOpen(false)}
+          shortcuts={SELLS_SHOW_SHORTCUTS}
+          title="Atalhos · Detalhe da venda"
+          footerLeft="Vendas opera sem mouse — atalhos persistem em Lista, Caixa, Detalhe e Edição."
+        />
       </div>
 
       {/* KB-9.75 P0 gaps #2/#3 — emit modals abertos pelo gate fiscal do VdNextActionPanel.

--- a/resources/js/Pages/Sells/_components/SellsCheatSheet.tsx
+++ b/resources/js/Pages/Sells/_components/SellsCheatSheet.tsx
@@ -1,0 +1,187 @@
+// Sells/_components/SellsCheatSheet — cheat-sheet overlay reusável (gap P3 #12 KB-9.75).
+// Refs:
+//  - prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/vendas-shortcuts.jsx (canon)
+//  - memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md
+//  - resources/css/sells-kb975-cheatsheet.css (CSS escopado fora .sells-cowork)
+//
+// Estado controlado externamente via `open` + `onClose` — facilita compartilhar
+// entre Sells/Index.tsx, Sells/Show.tsx, Sells/Caixa, etc. Cada Page declara
+// seu próprio array de shortcuts (lista canônica J/K/Enter/N/E/?/Esc/Cmd+K
+// no Index; subset operacional em Show).
+//
+// Ativação canônica: a Page que renderiza este componente deve adicionar
+// `useEffect` com `keydown` listener pra setar `open=true` quando `e.key === '?'`.
+// O componente em si trata `Esc` e `?` pra fechar (idempotente, listener próprio).
+
+import { useEffect, type ReactNode } from 'react';
+import { X } from 'lucide-react';
+
+export interface SellsShortcut {
+  /** Sequência de keys (uma ou várias, ex: ["⌘", "K"]). Cada item vira <kbd>. */
+  kbd: string | string[];
+  /** Label descritivo. Pode conter <b>/<code>/JSX já que aceita ReactNode. */
+  label: ReactNode;
+  /** Agrupador opcional ("Navegar", "Ações", "⌘K palette", "Sair"). Default "Geral". */
+  area?: string;
+}
+
+export interface SellsCheatSheetProps {
+  /** Visibilidade controlada pelo pai. */
+  open: boolean;
+  /** Callback fechar — chamado em click no backdrop, no botão X, ou ao pressionar Esc/?. */
+  onClose: () => void;
+  /** Lista de atalhos a renderizar. Agrupa por `area`. */
+  shortcuts: SellsShortcut[];
+  /** Título do cabeçalho. Default "Atalhos do balcão". */
+  title?: string;
+  /** Subtítulo abaixo do título. Default texto Cowork canon. */
+  subtitle?: string;
+  /** Rodapé esquerdo (contexto). */
+  footerLeft?: ReactNode;
+  /** Rodapé direito (versão). Default "KB-9.75 · maio/2026". */
+  footerRight?: ReactNode;
+}
+
+const DEFAULT_TITLE = 'Atalhos do balcão';
+const DEFAULT_SUBTITLE = 'Vendas opera sem mouse. Pressione qualquer combinação abaixo.';
+const DEFAULT_FOOTER_RIGHT = 'KB-9.75 · maio/2026';
+const DEFAULT_AREA = 'Geral';
+
+function normalizeKbd(kbd: string | string[]): string[] {
+  return Array.isArray(kbd) ? kbd : [kbd];
+}
+
+function groupByArea(shortcuts: SellsShortcut[]): Map<string, SellsShortcut[]> {
+  const groups = new Map<string, SellsShortcut[]>();
+  for (const sc of shortcuts) {
+    const key = sc.area ?? DEFAULT_AREA;
+    const arr = groups.get(key) ?? [];
+    arr.push(sc);
+    groups.set(key, arr);
+  }
+  return groups;
+}
+
+export default function SellsCheatSheet({
+  open,
+  onClose,
+  shortcuts,
+  title = DEFAULT_TITLE,
+  subtitle = DEFAULT_SUBTITLE,
+  footerLeft,
+  footerRight = DEFAULT_FOOTER_RIGHT,
+}: SellsCheatSheetProps): ReactNode {
+  // Listener próprio pra Esc/? — idempotente: fecha mesmo se a Page também
+  // capturar (a Page geralmente abre via '?' e o cheat-sheet fecha via '?').
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent): void => {
+      if (e.key === 'Escape' || e.key === '?') {
+        e.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const groups = groupByArea(shortcuts);
+
+  return (
+    <div
+      className="vd-cheat-bd"
+      onClick={onClose}
+      role="presentation"
+      data-testid="sells-cheatsheet-backdrop"
+    >
+      <div
+        className="vd-cheat"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-label={title}
+        aria-modal="true"
+      >
+        <header className="vd-cheat-h">
+          <span className="vd-cheat-ic" aria-hidden="true">⌨</span>
+          <h2>{title}</h2>
+          <p>{subtitle}</p>
+          <button
+            type="button"
+            className="vd-cheat-x"
+            onClick={onClose}
+            aria-label="Fechar cheat-sheet"
+          >
+            <kbd>esc</kbd>
+            <X size={12} aria-hidden="true" />
+          </button>
+        </header>
+
+        <div className="vd-cheat-grid">
+          {Array.from(groups.entries()).map(([area, items]) => (
+            <section key={area} className="vd-cheat-sec">
+              <h4>{area}</h4>
+              {items.map((sc, idx) => {
+                const keys = normalizeKbd(sc.kbd);
+                return (
+                  <div key={idx} className="vd-cs-row">
+                    <div className="vd-cs-keys">
+                      {keys.map((k, i) => (
+                        <span key={i} className="vd-cs-keys-item">
+                          {i > 0 && <span className="vd-cs-plus" aria-hidden="true">+</span>}
+                          <kbd>{k}</kbd>
+                        </span>
+                      ))}
+                    </div>
+                    <div className="vd-cs-lbl">{sc.label}</div>
+                  </div>
+                );
+              })}
+            </section>
+          ))}
+        </div>
+
+        <footer className="vd-cheat-ft">
+          <span>{footerLeft ?? 'Atalhos persistem em toda sub-rota de Vendas.'}</span>
+          <span>{footerRight}</span>
+        </footer>
+      </div>
+    </div>
+  );
+}
+
+// Lista canônica de atalhos pra Sells/Index (Lista de vendas).
+// Reusável também por Sells/Caixa, Sells/Drafts, Sells/Quotations.
+export const SELLS_INDEX_SHORTCUTS: SellsShortcut[] = [
+  { area: 'Navegar', kbd: 'J', label: <span>próxima venda <b>↓</b></span> },
+  { area: 'Navegar', kbd: 'K', label: <span>anterior venda <b>↑</b></span> },
+  { area: 'Navegar', kbd: 'Enter', label: 'abrir drawer da venda focada' },
+  { area: 'Navegar', kbd: '/', label: 'focar campo de busca' },
+  { area: 'Navegar', kbd: ['⌘', 'K'], label: 'command palette (busca global + ações)' },
+
+  { area: 'Ações na venda focada', kbd: 'N', label: 'nova venda' },
+  { area: 'Ações na venda focada', kbd: 'E', label: 'editar venda (drawer Create)' },
+  { area: 'Ações na venda focada', kbd: 'R', label: 'imprimir recibo (térmica/A4)' },
+  { area: 'Ações na venda focada', kbd: 'F', label: 'faturar NF-e / NFS-e' },
+  { area: 'Ações na venda focada', kbd: 'B', label: 'favoritar linha (pessoal)' },
+  { area: 'Ações na venda focada', kbd: 'X', label: 'selecionar pra ação em lote' },
+
+  { area: '⌘K prefixos', kbd: '/', label: <span>filtra <b>ações</b> · ex: <code>/faturar lote</code></span> },
+  { area: '⌘K prefixos', kbd: '#', label: <span>busca por <b>ID</b> · ex: <code>#7825</code></span> },
+  { area: '⌘K prefixos', kbd: '@', label: <span>filtra por <b>vendedor</b> · ex: <code>@bruna</code></span> },
+  { area: '⌘K prefixos', kbd: '$', label: <span>valor <b>mínimo</b> · ex: <code>$2000</code></span> },
+
+  { area: 'Sair / ajuda', kbd: 'Esc', label: 'fechar palette · drawer · cheat-sheet' },
+  { area: 'Sair / ajuda', kbd: '?', label: 'abrir/fechar este cheat-sheet' },
+];
+
+// Lista canônica de atalhos pra Sells/Show (Detalhe de venda).
+export const SELLS_SHOW_SHORTCUTS: SellsShortcut[] = [
+  { area: 'Navegar', kbd: 'Esc', label: 'voltar pra lista' },
+
+  { area: 'Ações', kbd: 'E', label: 'editar venda' },
+  { area: 'Ações', kbd: 'P', label: 'imprimir comprovante' },
+
+  { area: 'Sair / ajuda', kbd: '?', label: 'abrir/fechar este cheat-sheet' },
+];

--- a/tests/Feature/Sells/SellsKb975CheatToastTest.php
+++ b/tests/Feature/Sells/SellsKb975CheatToastTest.php
@@ -1,0 +1,233 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest STRUCTURAL — KB-9.75 P3 #12 (cheat-sheet) + P1 #10 (toast hub).
+ *
+ * Cobre gaps P3 #12 (cheat-sheet overlay '?') e P1 #10 (oimpressoToast hub
+ * canônico) do `memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md`.
+ *
+ * Refs:
+ *  - resources/js/Pages/Sells/_components/SellsCheatSheet.tsx (NOVO)
+ *  - resources/js/Lib/oimpressoToast.ts (NOVO)
+ *  - resources/css/sells-kb975-cheatsheet.css (NOVO)
+ *  - resources/js/Pages/Sells/Index.tsx (wire-up)
+ *  - resources/js/Pages/Sells/Show.tsx (wire-up)
+ */
+
+const KB975_CHEAT_PATH = 'resources/js/Pages/Sells/_components/SellsCheatSheet.tsx';
+const KB975_TOAST_PATH = 'resources/js/Lib/oimpressoToast.ts';
+const KB975_CHEAT_CSS = 'resources/css/sells-kb975-cheatsheet.css';
+const KB975_INERTIA_CSS = 'resources/css/inertia.css';
+const KB975_INDEX_PAGE = 'resources/js/Pages/Sells/Index.tsx';
+const KB975_SHOW_PAGE = 'resources/js/Pages/Sells/Show.tsx';
+
+// ──────────────────────────────────────────────────────────────
+// SellsCheatSheet.tsx (gap P3 #12)
+// ──────────────────────────────────────────────────────────────
+
+it('SellsCheatSheet.tsx existe em _components', function () {
+    expect(file_exists(base_path(KB975_CHEAT_PATH)))->toBeTrue();
+});
+
+it('SellsCheatSheet declara Props com open + onClose + shortcuts controlados externamente', function () {
+    $source = file_get_contents(base_path(KB975_CHEAT_PATH));
+    expect($source)->toContain('open: boolean');
+    expect($source)->toContain('onClose: () => void');
+    expect($source)->toContain('shortcuts: SellsShortcut[]');
+});
+
+it('SellsCheatSheet exporta interface SellsShortcut com kbd + label + area', function () {
+    $source = file_get_contents(base_path(KB975_CHEAT_PATH));
+    expect($source)->toContain('export interface SellsShortcut');
+    expect($source)->toContain('kbd: string | string[]');
+    expect($source)->toContain('label: ReactNode');
+    expect($source)->toContain('area?: string');
+});
+
+it('SellsCheatSheet trata Esc e ? via listener próprio (idempotente com Page handler)', function () {
+    $source = file_get_contents(base_path(KB975_CHEAT_PATH));
+    expect($source)->toContain("e.key === 'Escape'");
+    expect($source)->toContain("e.key === '?'");
+    expect($source)->toContain("window.addEventListener('keydown'");
+    expect($source)->toContain("window.removeEventListener('keydown'");
+});
+
+it('SellsCheatSheet renderiza overlay backdrop + dialog ARIA modal', function () {
+    $source = file_get_contents(base_path(KB975_CHEAT_PATH));
+    expect($source)->toContain('vd-cheat-bd');
+    expect($source)->toContain('vd-cheat');
+    expect($source)->toContain('role="dialog"');
+    expect($source)->toContain('aria-modal="true"');
+});
+
+it('SellsCheatSheet exporta listas canon SELLS_INDEX_SHORTCUTS e SELLS_SHOW_SHORTCUTS', function () {
+    $source = file_get_contents(base_path(KB975_CHEAT_PATH));
+    expect($source)->toContain('export const SELLS_INDEX_SHORTCUTS');
+    expect($source)->toContain('export const SELLS_SHOW_SHORTCUTS');
+});
+
+it('SELLS_INDEX_SHORTCUTS cobre atalhos canon J/K/Enter/N/E/?/Esc/Cmd+K', function () {
+    $source = file_get_contents(base_path(KB975_CHEAT_PATH));
+    // Lista mínima Cowork KB-9.75 — Wagner aprovou no prompt
+    expect($source)->toContain("kbd: 'J'");
+    expect($source)->toContain("kbd: 'K'");
+    expect($source)->toContain("kbd: 'Enter'");
+    expect($source)->toContain("kbd: 'N'");
+    expect($source)->toContain("kbd: 'E'");
+    expect($source)->toContain("kbd: '?'");
+    expect($source)->toContain("kbd: 'Esc'");
+    expect($source)->toContain("kbd: ['⌘', 'K']");
+});
+
+// ──────────────────────────────────────────────────────────────
+// oimpressoToast.ts (gap P1 #10)
+// ──────────────────────────────────────────────────────────────
+
+it('oimpressoToast.ts existe em resources/js/Lib', function () {
+    expect(file_exists(base_path(KB975_TOAST_PATH)))->toBeTrue();
+});
+
+it('oimpressoToast exporta API canon invoiced/paid/emitted/error/info/warning', function () {
+    $source = file_get_contents(base_path(KB975_TOAST_PATH));
+    expect($source)->toContain('export const oimpressoToast');
+    expect($source)->toContain('invoiced,');
+    expect($source)->toContain('paid,');
+    expect($source)->toContain('emitted,');
+    expect($source)->toContain('error,');
+    expect($source)->toContain('info,');
+    expect($source)->toContain('warning,');
+});
+
+it('oimpressoToast dispatch CustomEvent oimpresso:toast no window com detail tone/msg/saleId', function () {
+    $source = file_get_contents(base_path(KB975_TOAST_PATH));
+    expect($source)->toContain("'oimpresso:toast'");
+    expect($source)->toContain('new CustomEvent(HUB_EVENT');
+    expect($source)->toContain('tone:');
+    expect($source)->toContain('msg,');
+    expect($source)->toContain('saleId');
+});
+
+it('oimpressoToast dispatch eventos namespaced venda-invoiced/paid/emitted-nfe/nfse', function () {
+    $source = file_get_contents(base_path(KB975_TOAST_PATH));
+    // Glossário BR canon — Faturar ≠ Receber pagamento (gap #6 vocabulário)
+    expect($source)->toContain('oimpresso:venda-invoiced');
+    expect($source)->toContain('oimpresso:venda-paid');
+    expect($source)->toContain('oimpresso:venda-emitted-nfe');
+    expect($source)->toContain('oimpresso:venda-emitted-nfse');
+});
+
+it('oimpressoToast usa sonner toast (não substitui — wrapper opcional canon)', function () {
+    $source = file_get_contents(base_path(KB975_TOAST_PATH));
+    expect($source)->toContain("import { toast } from 'sonner'");
+    expect($source)->toContain('toast.success(');
+    expect($source)->toContain('toast.error(');
+    expect($source)->toContain('toast.info(');
+});
+
+it('oimpressoToast emitted aceita kind nfe ou nfse e roteia o evento correto', function () {
+    $source = file_get_contents(base_path(KB975_TOAST_PATH));
+    expect($source)->toContain("kind: 'nfe' | 'nfse'");
+    expect($source)->toContain("kind === 'nfe'");
+});
+
+it('oimpressoToast trata ambiente sem window (SSR-safe, no-op silent)', function () {
+    $source = file_get_contents(base_path(KB975_TOAST_PATH));
+    expect($source)->toContain("typeof window === 'undefined'");
+});
+
+// ──────────────────────────────────────────────────────────────
+// CSS bundle
+// ──────────────────────────────────────────────────────────────
+
+it('sells-kb975-cheatsheet.css existe', function () {
+    expect(file_exists(base_path(KB975_CHEAT_CSS)))->toBeTrue();
+});
+
+it('sells-kb975-cheatsheet.css NÃO está escopado em .sells-cowork (overlay fullscreen global)', function () {
+    $source = file_get_contents(base_path(KB975_CHEAT_CSS));
+    // O overlay precisa renderizar acima de qualquer wrapper — Index, Show, Caixa, etc.
+    // Por isso .vd-cheat-bd e .vd-cheat ficam top-level, NÃO prefixados.
+    expect($source)->toContain('.vd-cheat-bd {');
+    expect($source)->toContain('.vd-cheat {');
+    expect($source)->not->toContain('.sells-cowork .vd-cheat-bd');
+});
+
+it('sells-kb975-cheatsheet.css define grid 2 colunas default + responsive 3 cols / 1 col mobile', function () {
+    $source = file_get_contents(base_path(KB975_CHEAT_CSS));
+    expect($source)->toContain('grid-template-columns: 1fr 1fr');
+    expect($source)->toContain('grid-template-columns: repeat(3, 1fr)');
+    expect($source)->toContain('@media (max-width: 900px)');
+});
+
+it('sells-kb975-cheatsheet.css importada em inertia.css', function () {
+    $source = file_get_contents(base_path(KB975_INERTIA_CSS));
+    expect($source)->toContain('sells-kb975-cheatsheet.css');
+});
+
+// ──────────────────────────────────────────────────────────────
+// Sells/Index.tsx wire-up
+// ──────────────────────────────────────────────────────────────
+
+it('Sells/Index.tsx importa SellsCheatSheet + SELLS_INDEX_SHORTCUTS', function () {
+    $source = file_get_contents(base_path(KB975_INDEX_PAGE));
+    expect($source)->toContain("import SellsCheatSheet, { SELLS_INDEX_SHORTCUTS } from './_components/SellsCheatSheet'");
+});
+
+it('Sells/Index.tsx renderiza SellsCheatSheet controlado por cheatOpen', function () {
+    $source = file_get_contents(base_path(KB975_INDEX_PAGE));
+    expect($source)->toContain('<SellsCheatSheet');
+    expect($source)->toContain('open={cheatOpen}');
+    expect($source)->toContain('onClose={() => setCheatOpen(false)}');
+    expect($source)->toContain('shortcuts={SELLS_INDEX_SHORTCUTS}');
+});
+
+it('Sells/Index.tsx mantém handler que abre cheatOpen via ? (sem regressão)', function () {
+    $source = file_get_contents(base_path(KB975_INDEX_PAGE));
+    expect($source)->toContain("e.key === '?'");
+    expect($source)->toContain('setCheatOpen(true)');
+});
+
+it('Sells/Index.tsx NÃO contém mais a função inline SellsCheatSheet (extraída pra _components)', function () {
+    $source = file_get_contents(base_path(KB975_INDEX_PAGE));
+    // A definição inline foi extraída — não pode haver `function SellsCheatSheet(`
+    // local no arquivo. O import + JSX continuam.
+    expect($source)->not->toMatch('/function\s+SellsCheatSheet\s*\(/');
+});
+
+// ──────────────────────────────────────────────────────────────
+// Sells/Show.tsx wire-up
+// ──────────────────────────────────────────────────────────────
+
+it('Sells/Show.tsx importa SellsCheatSheet + SELLS_SHOW_SHORTCUTS', function () {
+    $source = file_get_contents(base_path(KB975_SHOW_PAGE));
+    expect($source)->toContain("import SellsCheatSheet, { SELLS_SHOW_SHORTCUTS } from './_components/SellsCheatSheet'");
+});
+
+it('Sells/Show.tsx declara state cheatOpen e renderiza overlay', function () {
+    $source = file_get_contents(base_path(KB975_SHOW_PAGE));
+    expect($source)->toContain('const [cheatOpen, setCheatOpen]');
+    expect($source)->toContain('<SellsCheatSheet');
+    expect($source)->toContain('shortcuts={SELLS_SHOW_SHORTCUTS}');
+});
+
+it('Sells/Show.tsx adiciona ? ao handler keydown (abre cheat-sheet)', function () {
+    $source = file_get_contents(base_path(KB975_SHOW_PAGE));
+    expect($source)->toContain("e.key === '?'");
+    expect($source)->toContain('setCheatOpen(true)');
+});
+
+it('Sells/Show.tsx suprime E/P/Esc-back enquanto cheatOpen (precedência correta)', function () {
+    $source = file_get_contents(base_path(KB975_SHOW_PAGE));
+    // Suprimir outros atalhos quando overlay aberta evita Esc → router.visit(back)
+    // disparar quando o usuário queria só fechar o overlay.
+    expect($source)->toContain('if (cheatOpen) return');
+});
+
+it('Sells/Show.tsx mantém atalhos E/P/Esc-back (sem regressão dos handlers existentes)', function () {
+    $source = file_get_contents(base_path(KB975_SHOW_PAGE));
+    expect($source)->toContain("e.key === 'e'");
+    expect($source)->toContain("e.key === 'p'");
+    expect($source)->toContain("e.key === 'Escape'");
+});


### PR DESCRIPTION
## Summary

Refino #1 Cowork bundle 2026-05-26 (demo Wagner 3pm) — extrai cheat-sheet inline de `Sells/Index.tsx` pra componente reusável + cria hub canônico `oimpressoToast` substituindo `alert()`/`console.log` scattered nos handlers fiscais.

### GAP P3 #12 — SellsCheatSheet reusável

- `resources/js/Pages/Sells/_components/SellsCheatSheet.tsx` (187 LOC) — componente controlado via props `open`/`onClose`/`shortcuts`/`title`/`footerLeft`. Listas canon `SELLS_INDEX_SHORTCUTS` (lista de vendas — J/K/Enter/N/E/?/Esc/⌘K + ⌘K prefixes /#@$) e `SELLS_SHOW_SHORTCUTS` (detalhe — E/P/?/Esc) exportadas no mesmo módulo. Listener próprio idempotente pra `Esc`/`?` fechar overlay.
- `resources/css/sells-kb975-cheatsheet.css` (242 LOC) — overlay fullscreen escopado **fora** `.sells-cowork` pra renderizar acima de qualquer wrapper (z-index 1000, abaixo do sonner 9999). Grid responsivo 3 cols ≥1280px / 2 cols default / 1 col ≤900px. Backdrop blur + animações fade/slide. Cowork canon do `prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/.../styles.css` linha 6222+.
- **Wire-up Sells/Index.tsx** — remove função inline `SellsCheatSheet` (extraída) + remove import `X` lucide-react órfão. Substitui `{cheatOpen && <SellsCheatSheet ... />}` por nova prop signature.
- **Wire-up Sells/Show.tsx** — adiciona state `cheatOpen` + handler `?` no `useEffect` keydown + suprime `E`/`P`/`Esc-back` enquanto `cheatOpen` (precedência correta — overlay tem listener próprio que fecha em `Esc`).

### GAP P1 #10 — oimpressoToast hub canon

- `resources/js/Lib/oimpressoToast.ts` (136 LOC) — API canon:
  - `invoiced(saleId, msg)` — venda faturada (NF-e/NFS-e autorizada — *Faturar* ≠ *Receber pgto*)
  - `paid(saleId, msg)` — venda paga (recebimento financeiro)
  - `emitted(saleId, kind, msg)` — emissão fiscal específica (`kind: 'nfe' | 'nfse'`)
  - `error/info/warning(msg, saleId?, meta?)` — neutros
- Cada chamada dispatch (a) `sonner` toast UI top-right + (b) `CustomEvent('oimpresso:toast', {detail:{tone,msg,saleId,meta}})` no window + (c) evento namespaced por domínio (`oimpresso:venda-invoiced` / `venda-paid` / `venda-emitted-nfe` / `venda-emitted-nfse`).
- **NÃO substitui** uso atual de `sonner` direto em `FsmActionPanel`/`CobrancaDrawer`/`CriarOsButton` — wrapper opcional canon. Mesmo padrão de dispatch que `VdNextActionPanel` (PR #1638 KB-9.75 P0).
- SSR-safe (`typeof window === 'undefined'` guard).
- Tipagem global `declare global { interface WindowEventMap }` pros subscribers usarem `addEventListener('oimpresso:venda-invoiced', ...)` com type-safety.

### Tier 0 multi-tenant
Nenhum `business_id` explícito — `sale_id` é per-tenant via global scope `BusinessIdScope` em `SaleSell` model. Sem riscos cross-business ([ADR 0093](../../memory/decisions/0093-multi-tenant-isolation-tier-0.md)).

## Test plan

- [x] **Pest structural** `tests/Feature/Sells/SellsKb975CheatToastTest.php` — 27 testes (76 assertions) cobrindo:
  - SellsCheatSheet.tsx existe + Props open/onClose/shortcuts + SellsShortcut interface + Esc/? listener idempotente + ARIA modal + listas canon exportadas + atalhos J/K/Enter/N/E/?/Esc/⌘K presentes
  - oimpressoToast.ts existe + API invoiced/paid/emitted/error/info/warning + dispatch `oimpresso:toast` com tone/msg/saleId + eventos namespaced venda-* + sonner integration + kind nfe/nfse + SSR-safe
  - CSS NÃO escopado em `.sells-cowork` + grid 2/3/1 cols responsive + importado em `inertia.css`
  - Wire-up Index.tsx: import + render JSX + handler `?` mantido + função inline removida
  - Wire-up Show.tsx: import + state cheatOpen + handler `?` + suppressão `if (cheatOpen) return` + handlers E/P/Esc-back mantidos
- [x] **TypeScript** `npx tsc --noEmit` — zero novos erros (8 pré-existentes em `Sells/Index.tsx` e `Show.tsx` herdados de `origin/main`, +1 fix do `X` import órfão)
- [x] **Vite build** `npm run build:inertia` — 3m31s, builds limpos
- [ ] Smoke browser MCP `/sells` e `/sells/{id}` pra confirmar `?` abre overlay + `Esc`/`?` fecha + outros atalhos suprimidos enquanto overlay aberta (pendente Wagner — demo 3pm)

## Refs

- `memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md`
- `prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/vendas-shortcuts.jsx` (canon visual)
- ADR 0104 (MWART) · 0107 (visual gate) · 0114 (Cowork loop) · 0093 (multi-tenant Tier 0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)