### PR TITLE
feat(sells): Inertia Link 'Ver tela →' no drawer SaleSheet → /sells/{id}

### DIFF
--- a/resources/js/Pages/Sells/_components/SaleSheet.tsx
+++ b/resources/js/Pages/Sells/_components/SaleSheet.tsx
@@ -3,6 +3,7 @@
 //        Pages/ProjectMgmt/Board/DetailSheet.tsx (pattern fonte interno).
 
 import { useCallback, useEffect, useState } from 'react';
+import { Link } from '@inertiajs/react';
 import {
   AlertTriangle,
   CheckCircle2,
@@ -782,6 +783,11 @@ export default function SaleSheet({
                   ))}
                 </DropdownMenuContent>
               </DropdownMenu>
+              <Button size="sm" variant="outline" asChild title="Abrir página completa (Show.tsx)">
+                <Link href={`/sells/${data.id}`}>
+                  Ver tela →
+                </Link>
+              </Button>
               <Button size="sm" asChild>
                 <a href={data.urls.edit}>
                   <Edit size={14} className="mr-1.5" />


### PR DESCRIPTION
Habilita SPA navigation do drawer pra Show.tsx full page. **Bloqueia demo 3pm sem esse link** — drawer hoje só permite Editar via `<a href>` que cai no Blade legacy.

## O que faz

Adiciona 1 botão "Ver tela →" (variant=outline) ao lado do "Editar" no footer do drawer SaleSheet, usando `<Link>` do Inertia. Click dispara SPA navigation pra `/sells/{id}` que ativa Show.tsx Inertia (com X-Inertia header automático).

Show.tsx tem todas features do KB-9.75 P0+P1+P2+P3 mergeadas:
- VdNextActionPanel (PR #1641)
- VdNfeEmitModal + VdNfseEmitModal + Saved view Aguardando (PR #1644)
- SaleReciboPrint80mm + SaleOrcamentoA4 (PR #1642)
- SellsCheatSheet '?' (PR #1643)

Sem esse Link, Wagner navega via URL direta `/sells/{id}` que **cai no Blade legacy** (sale_pos.show.blade.php) porque controller exige X-Inertia header (linha 2507).

## Diff

1 arquivo, +6 linhas:
- `resources/js/Pages/Sells/_components/SaleSheet.tsx` — import `Link` Inertia + botão "Ver tela →"

## Anti-patterns respeitados

- ✅ `<Link>` Inertia (não `<a>` legacy) — dispara X-Inertia automático
- ✅ Botão `variant="outline"` (não competir com primary "Editar")
- ✅ Sem mexer outras rotas
- ✅ Sem deletar legacy