### PR TITLE
fix(sells/show): VdNextActionPanel + FsmActionPanel não montavam por guard wrong

### DIFF
--- a/resources/js/Pages/Sells/Show.tsx
+++ b/resources/js/Pages/Sells/Show.tsx
@@ -370,33 +370,34 @@ export default function SellsShow(props: SellsShowPageProps) {
           <aside className="lg:col-span-4 space-y-4">
             {/* VdNextActionPanel — KB-9.75 Cowork 2026-05-26 P0 gap #1.
                 Próxima ação contextual + gates fiscais ("emita NF antes de faturar").
-                Glossário BR corrigido: Faturar (emit NF + título) ≠ Receber (baixa título). */}
-            {headline.current_stage_key !== null && (
-              <VdNextActionPanel
+                Glossário BR corrigido: Faturar (emit NF + título) ≠ Receber (baixa título).
+                Guard removido (fix 2026-05-26): VdNextActionPanel já tem proprio early-return
+                via fetch /api/sells/{id}/fsm-actions → data.in_pipeline. Headline.current_stage_key
+                pode vir null mesmo quando backend pipeline FSM está ativo (current_stage_id
+                derivado, não eager-loaded — pre-existing inconsistência). */}
+            <VdNextActionPanel
+              saleId={headline.id}
+              paymentStatus={headline.payment_status}
+              currentStageKey={headline.current_stage_key}
+              onTransition={() => {
+                // Refresh sheet — Inertia partial reload do detail
+                router.reload({ only: ['detail', 'headline'] });
+              }}
+              onOpenEmit={(kind) => setEmitModalKind(kind)}
+            />
+
+            {/* Pipeline — todas transições disponíveis (FsmActionPanel completo).
+                Mesmo guard removido — componente decide via /api/sells/{id}/fsm-actions. */}
+            <section className="rounded-lg border border-border bg-card p-4">
+              <h2 className="font-semibold text-sm mb-3">Todas as transições</h2>
+              <FsmActionPanel
                 saleId={headline.id}
-                paymentStatus={headline.payment_status}
-                currentStageKey={headline.current_stage_key}
+                enabled={true}
                 onTransition={() => {
-                  // Refresh sheet — Inertia partial reload do detail
                   router.reload({ only: ['detail', 'headline'] });
                 }}
-                onOpenEmit={(kind) => setEmitModalKind(kind)}
               />
-            )}
-
-            {/* Pipeline — todas transições disponíveis (FsmActionPanel completo) */}
-            {headline.current_stage_key !== null && (
-              <section className="rounded-lg border border-border bg-card p-4">
-                <h2 className="font-semibold text-sm mb-3">Todas as transições</h2>
-                <FsmActionPanel
-                  saleId={headline.id}
-                  enabled={true}
-                  onTransition={() => {
-                    router.reload({ only: ['detail', 'headline'] });
-                  }}
-                />
-              </section>
-            )}
+            </section>
 
             {/* Atalhos hint */}
             <section className="rounded-lg border border-border bg-card p-4">


### PR DESCRIPTION
Bug encontrado pós-deploy PR #1645 testando em prod (https://oimpresso.com/sells/23062):

- Backend /api/sells/{id}/fsm-actions retorna `in_pipeline=true` + 5 actions
- Mas Show.tsx tinha guard `{headline.current_stage_key !== null && ...}` que escondia ambos VdNextActionPanel + FsmActionPanel
- Headline payload do Show vinha com `current_stage_key=null` mesmo quando pipeline FSM ativo

**Fix:** remover guard externo. Components já têm proprio early-return via fetch /api/sells/{id}/fsm-actions (source-of-truth correto).

1 arquivo, +23/-22 LOC. Demo Wagner 3pm crítico — sem esse fix, /sells/{id} mostra layout 2-col mas painel direito só tem 'Atalhos' (E/P/Esc), nenhum dos novos componentes KB-9.75.