### PR TITLE
feat(sells): a→Link no drawer 'Editar' ativa Edit.tsx Inertia em prod

### DIFF
--- a/resources/js/Pages/Sells/_components/SaleSheet.tsx
+++ b/resources/js/Pages/Sells/_components/SaleSheet.tsx
@@ -789,10 +789,10 @@ export default function SaleSheet({
                 </Link>
               </Button>
               <Button size="sm" asChild>
-                <a href={data.urls.edit}>
+                <Link href={data.urls.edit}>
                   <Edit size={14} className="mr-1.5" />
                   Editar
-                </a>
+                </Link>
               </Button>
             </div>
 


### PR DESCRIPTION
Quick-fix descoberto no smoke do PR #1651 — drawer SaleSheet 'Editar' usa `<a>` simples que cai no Blade legacy. Mudando pra `<Link>` Inertia, o backend (linha 2934) ativa branch `Sells/Edit.tsx` que JÁ EXISTE (413 LOC) mas só rendava com X-Inertia header.

1 arquivo, 1 char mudança (a → Link). Demo crítico pós comparativo PR #1651.

Padrão alinhado com 'Ver tela →' (PR #1645).