### PR TITLE
fix(oficinaauto): expose printInvoice exception details when APP_DEBUG (smoke real bug 500)

### DIFF
--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
@@ -649,12 +649,26 @@ class ServiceOrderController extends Controller
             ]);
         } catch (\Throwable $e) {
             \Log::emergency('OficinaAuto printInvoice: File:' . $e->getFile()
-                . ' Line:' . $e->getLine() . ' Message:' . $e->getMessage());
+                . ' Line:' . $e->getLine() . ' Message:' . $e->getMessage()
+                . ' Trace:' . substr($e->getTraceAsString(), 0, 800));
 
-            return response()->json([
+            // FIX bug 500 2026-05-26: expor exception details no JSON quando
+            // APP_DEBUG=true pra Wagner debugar smoke real prod (Hostinger).
+            // Em prod com APP_DEBUG=false fica oculto naturalmente.
+            $payload = [
                 'success' => 0,
                 'msg'     => 'Não foi possível gerar a impressão da OS.',
-            ], 500);
+            ];
+            if (config('app.debug')) {
+                $payload['_debug'] = [
+                    'class'   => get_class($e),
+                    'message' => $e->getMessage(),
+                    'file'    => basename($e->getFile()),
+                    'line'    => $e->getLine(),
+                ];
+            }
+
+            return response()->json($payload, 500);
         }
     }
 


### PR DESCRIPTION
Wagner detectou no smoke real biz=1 que TODAS as OS retornam HTTP 500 ao clicar 'Imprimir OS' (post PR #1650 Gap 3). Controller mascarava exception em mensagem genérica.

Fix: quando APP_DEBUG=true, JSON resposta inclui _debug{class,message,file,line}. Prod com APP_DEBUG=false segue oculto.

Pos-merge: re-rodar fetch e ler _debug.message pra ver causa real do exception.

🤖 Generated with [Claude Code](https://claude.com/claude-code)