### PR TITLE
fix(oficinaauto): v2 printInvoice _debug forcar sempre (post-#1655)

### DIFF
--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
@@ -655,18 +655,18 @@ class ServiceOrderController extends Controller
             // FIX bug 500 2026-05-26: expor exception details no JSON quando
             // APP_DEBUG=true pra Wagner debugar smoke real prod (Hostinger).
             // Em prod com APP_DEBUG=false fica oculto naturalmente.
+            // FIX v2 2026-05-26: forçar _debug ALWAYS porque prod tem APP_DEBUG=false.
+            // Wagner reverte depois quando bug for diagnosticado.
             $payload = [
                 'success' => 0,
                 'msg'     => 'Não foi possível gerar a impressão da OS.',
-            ];
-            if (config('app.debug')) {
-                $payload['_debug'] = [
+                '_debug' => [
                     'class'   => get_class($e),
                     'message' => $e->getMessage(),
                     'file'    => basename($e->getFile()),
                     'line'    => $e->getLine(),
-                ];
-            }
+                ],
+            ];
 
             return response()->json($payload, 500);
         }


### PR DESCRIPTION
Follow-up #1655: APP_DEBUG=false em prod oculta _debug. v2 forca sempre pra Wagner conseguir ler exception via fetch JS no smoke real. Reverter quando bug diagnosticado.

🤖 Generated with [Claude Code](https://claude.com/claude-code)