### PR TITLE
chore(oficinaauto): cleanup _debug always-on no printInvoice (post-#1659)

### DIFF
--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
@@ -652,21 +652,18 @@ class ServiceOrderController extends Controller
                 . ' Line:' . $e->getLine() . ' Message:' . $e->getMessage()
                 . ' Trace:' . substr($e->getTraceAsString(), 0, 800));
 
-            // FIX bug 500 2026-05-26: expor exception details no JSON quando
-            // APP_DEBUG=true pra Wagner debugar smoke real prod (Hostinger).
-            // Em prod com APP_DEBUG=false fica oculto naturalmente.
-            // FIX v2 2026-05-26: forçar _debug ALWAYS porque prod tem APP_DEBUG=false.
-            // Wagner reverte depois quando bug for diagnosticado.
             $payload = [
                 'success' => 0,
                 'msg'     => 'Não foi possível gerar a impressão da OS.',
-                '_debug' => [
+            ];
+            if (config('app.debug')) {
+                $payload['_debug'] = [
                     'class'   => get_class($e),
                     'message' => $e->getMessage(),
                     'file'    => basename($e->getFile()),
                     'line'    => $e->getLine(),
-                ],
-            ];
+                ];
+            }
 
             return response()->json($payload, 500);
         }


### PR DESCRIPTION
## Summary

- Cleanup do hack `_debug` always-on no `printInvoice` (catch) do `ServiceOrderController`.
- Bug 500 OS print foi RESOLVIDO em #1659 (Blade `@endif@if` colado linha 312).
- Substitui exposicao always-on por guard `config('app.debug')` — best-practice Laravel: prod (APP_DEBUG=false) oculta exception details (seguranca), dev/staging mantem debugging.

## Contexto

PRs anteriores (#1655, #1657) injetaram `_debug` sempre presente no payload de erro pra Wagner conseguir diagnosticar bug em prod (onde `APP_DEBUG=false`). Bug foi diagnosticado e corrigido em #1659. Agora limpa o hack pra nao vazar stack trace em prod.

## Diff

Apenas `Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php` (5 insertions, 8 deletions — bloco catch do `printInvoice`).

Defensive guard multi-tenant (linhas 613-624) NAO alterada.

## Test plan

- [ ] Smoke real OS print em prod com `APP_DEBUG=false` — confirmar que payload de erro nao expoe `_debug`
- [ ] Smoke dev/staging com `APP_DEBUG=true` — confirmar que `_debug` aparece quando exception ocorre
- [ ] Verificar fluxo happy path (200 OK com HTML) continua funcionando

Refs: post-#1659

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>