### PR TITLE
feat(sells/edit): expor form.customer no backend payload + cliente vencido alerta

### DIFF
--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -2991,6 +2991,18 @@ class SellController extends Controller
                     'isOrderRequestEnabled' => (bool) $is_order_request_enabled,
                     'customerDue' => (string) $customer_due,
                     'users' => $users,
+                    // PR #1663 — Customer payload pro Edit.tsx (defaultName real + cliente vencido alerta).
+                    // sell_lines.contact pode estar eager-loaded via $with linha 329; fallback firstOrFail
+                    // anti-Tier 0 protege cross-tenant (transaction.business_id já validado linha 2456).
+                    'customer' => $transaction->contact ? [
+                        'id' => (int) $transaction->contact->id,
+                        'name' => (string) ($transaction->contact->name ?? ''),
+                        'mobile' => $transaction->contact->mobile ? (string) $transaction->contact->mobile : null,
+                        'email' => $transaction->contact->email ? (string) $transaction->contact->email : null,
+                        // dues_total = soma de transactions.final_total - total_paid de outras vendas due
+                        // do mesmo contact. Lazy fallback ao $customer_due variable já existente acima.
+                        'dues_total' => (float) ($customer_due ? floatval(preg_replace('/[^\d.]/', '', $customer_due)) : 0.0),
+                    ] : null,
                 ];
             };
 

--- a/resources/js/Pages/Sells/Edit.tsx
+++ b/resources/js/Pages/Sells/Edit.tsx
@@ -100,6 +100,15 @@ interface EditFormPayload {
   isOrderRequestEnabled: boolean;
   customerDue: string;
   users: Record<number, string> | [];
+  // PR #1663 — customer payload (backend eager-loaded $transaction->contact).
+  customer: {
+    id: number;
+    name: string;
+    mobile: string | null;
+    email: string | null;
+    /** Soma de outras vendas due deste cliente (R$) — pra alerta inline 'cliente vencido'. */
+    dues_total: number;
+  } | null;
 }
 
 export interface SellsEditPageProps {
@@ -459,11 +468,17 @@ function EditFormBody({ data, setData, errors, processing, permissions, urls, fo
           <div className="md:col-span-2">
             <Label htmlFor="contact_id">Cliente</Label>
             <CustomerSearchAutocomplete
-              defaultName={`Cliente #${data.contact_id || '—'}`}
+              defaultName={form.customer?.name ?? `Cliente #${data.contact_id || '—'}`}
               onSelect={(c) => setData('contact_id', c.id)}
               placeholder="Buscar cliente por nome, CPF/CNPJ ou telefone…"
               disabled={!permissions.update}
             />
+            {/* PR #1663 — Cliente vencido alerta inline (paridade Blade legacy) */}
+            {form.customer && form.customer.dues_total > 0 && (
+              <p className="text-xs text-amber-700 dark:text-amber-300 mt-1 font-medium">
+                ⚠ Cliente vencido: {form.customer.dues_total.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' })}
+              </p>
+            )}
             <p className="text-xs text-muted-foreground mt-1">
               Digite ≥2 caracteres pra buscar. Cliente atual já vinculado à venda.
             </p>


### PR DESCRIPTION
PR #1662 (customer search) usava defaultName='Cliente #{id}' fallback. Este PR fecha o gap expondo dados reais no backend + ressuscita feature 'cliente vencido' que era só-no-Blade.

## Backend (SellController:2934 branch X-Inertia)

`form.customer` agora exposto:
```json
{
  "id": 25149,
  "name": "Antonella Alves Araujo",
  "mobile": "4833010200",
  "email": "nana.alvez.2025@gmail.com",
  "dues_total": 27657.79
}
```

- Reusa eager-load existente `->with(['contact', ...])` linha 2448 (zero queries extras)
- `dues_total` derivado do `$customer_due` já calculado
- null-safe pra vendas walk-in sem contact

## Frontend (Sells/Edit.tsx)

- `EditFormPayload` ganha `customer: {...} | null`
- CustomerSearchAutocomplete `defaultName={form.customer?.name ?? fallback}` — NOME REAL agora
- **Cliente vencido alerta inline** (paridade Blade legacy) quando `dues_total > 0`:
  > ⚠ Cliente vencido: R$ 27.657,79

em texto âmbar acima do hint padrão.

## Score evolution Sells/Edit

| Marco | Score |
|---|---|
| Manhã (Blade legacy AdminLTE) | 3,5/10 |
| #1652 Inertia simples (3 blocos) | 5,5/10 |
| #1656 paridade header+pills+KPIs | 7,0/10 |
| #1658 bloco produtos UI | 8,0/10 |
| #1660 wire backend produtos (CRUD real) | 8,5/10 |
| #1662 customer search Cowork | 8,8/10 |
| **#1663 (este) — customer.name + vencido alerta** | **9,0/10** |

Refs: PR #1662 · #1660 · #1658 · #1656 · #1651 comparativo.