### PR TITLE
feat(oficinaauto): Gap 1 backend uploadPhoto via HasArquivos (mecanica pesada)

### DIFF
--- a/Modules/OficinaAuto/Entities/OaInspectionItem.php
+++ b/Modules/OficinaAuto/Entities/OaInspectionItem.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Modules\Arquivos\Concerns\HasArquivos;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
@@ -39,6 +40,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  */
 class OaInspectionItem extends Model
 {
+    use HasArquivos; // Gap 1 (2026-05-26) — upload foto inline DVI item via Modules/Arquivos backbone (ADR 0123). Best-practice 2026 (AutoVitals/Tekmetric): foto por item DVI, não anexo solto.
     use LogsActivity;
     use SoftDeletes;
 

--- a/Modules/OficinaAuto/Entities/ServiceOrder.php
+++ b/Modules/OficinaAuto/Entities/ServiceOrder.php
@@ -8,6 +8,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Modules\Arquivos\Concerns\HasArquivos;
 use Spatie\Activitylog\LogOptions;
 use Spatie\Activitylog\Traits\LogsActivity;
 
@@ -50,6 +51,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  */
 class ServiceOrder extends Model
 {
+    use HasArquivos; // Gap 1 (2026-05-26) — anexo OS-level laudo geral / foto chassi via Modules/Arquivos backbone (ADR 0123). Complementa foto inline por item DVI (OaInspectionItem).
     use LogsActivity; // D7.b LGPD audit trail (Wave 14)
     use SoftDeletes;
 

--- a/Modules/OficinaAuto/Http/Controllers/DviInspectionController.php
+++ b/Modules/OficinaAuto/Http/Controllers/DviInspectionController.php
@@ -6,10 +6,13 @@ namespace Modules\OficinaAuto\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
+use Modules\Arquivos\Entities\Arquivo;
+use Modules\Arquivos\Services\ArquivosService;
 use Modules\OficinaAuto\Entities\OaInspectionItem;
 use Modules\OficinaAuto\Entities\ServiceOrder;
 use Modules\OficinaAuto\Http\Requests\StoreDviRequest;
 use Modules\OficinaAuto\Http\Requests\UpdateDviRequest;
+use Modules\OficinaAuto\Http\Requests\UploadDviPhotoRequest;
 use Modules\OficinaAuto\Services\DviInspectionService;
 
 /**
@@ -32,8 +35,10 @@ use Modules\OficinaAuto\Services\DviInspectionService;
  */
 class DviInspectionController extends Controller
 {
-    public function __construct(private DviInspectionService $service)
-    {
+    public function __construct(
+        private DviInspectionService $service,
+        private ArquivosService $arquivos,
+    ) {
     }
 
     /**
@@ -84,6 +89,89 @@ class DviInspectionController extends Controller
         $item->delete();
 
         return response()->json(null, 204);
+    }
+
+    /**
+     * Gap 1 (2026-05-26) — upload foto pra item DVI via Modules/Arquivos backbone.
+     *
+     * Pattern AutoVitals/Tekmetric 2026: foto inline em CADA item DVI (não anexo
+     * solto da OS). Caminhão basculante Martinho biz=164 — motorista leva foto
+     * antes/depois pra ressarcir transportadora 3a (sub-vertical 4 ADR 0194).
+     *
+     * Multi-tenant Tier 0 ([ADR 0093]):
+     *  1. Policy `update(ServiceOrder)` — Spatie + sameTenant guard
+     *  2. abort_unless cross-OS — item DEVE pertencer à OS da rota
+     *  3. ArquivosService::attach lê business_id da sessão e propaga global scope
+     *
+     * 201 Created + `{arquivo: {id, original_name, mime_type, size_bytes,
+     * display_url}}` pra UI atualizar grid sem refetch da OS inteira.
+     */
+    public function uploadPhoto(UploadDviPhotoRequest $request, ServiceOrder $order, OaInspectionItem $item): JsonResponse
+    {
+        $this->authorize('update', $order);
+
+        // Cross-OS guard: item PRECISA pertencer à OS da rota (defesa em profundidade
+        // mesmo dentro do mesmo business — espelha pattern update/destroy acima).
+        abort_unless((int) $item->service_order_id === (int) $order->id, 404);
+
+        $arquivo = $this->arquivos->attach(
+            $item,
+            $request->file('photo'),
+            ['context' => 'oficina-auto-dvi-photo'],
+        );
+
+        return response()->json([
+            'arquivo' => $this->shapeArquivo($arquivo),
+        ], 201);
+    }
+
+    /**
+     * Gap 1 (2026-05-26) — soft-delete foto de item DVI.
+     *
+     * Defesa em profundidade:
+     *  1. Policy `update(ServiceOrder)`
+     *  2. Cross-OS guard — item pertence à OS da rota
+     *  3. Cross-item guard — arquivo `arquivable` PRECISA ser este item (não outro)
+     *  4. Global scope Arquivo (business_id) já garante cross-tenant
+     *
+     * ArquivosService::softDelete grava audit-log + emite OTel span.
+     */
+    public function deletePhoto(ServiceOrder $order, OaInspectionItem $item, Arquivo $arquivo): JsonResponse
+    {
+        $this->authorize('update', $order);
+
+        abort_unless((int) $item->service_order_id === (int) $order->id, 404);
+
+        // Cross-item guard: arquivo morphTo PRECISA ser este OaInspectionItem.
+        abort_unless(
+            $arquivo->arquivable_type === OaInspectionItem::class
+            && (int) $arquivo->arquivable_id === (int) $item->id,
+            404
+        );
+
+        $this->arquivos->softDelete($arquivo);
+
+        return response()->json(null, 204);
+    }
+
+    /**
+     * Shape canônico de Arquivo pra JSON API (espelha frontend DviPhotoGrid).
+     *
+     * NÃO expõe storage_path/MD5/business_id (defesa em profundidade — display_url
+     * é signed quando bucket=sensitive, asset() direto caso contrário).
+     *
+     * @return array{id:int, original_name:string, mime_type:string, size_bytes:int, display_url:string, created_at:string|null}
+     */
+    private function shapeArquivo(Arquivo $arquivo): array
+    {
+        return [
+            'id'             => (int) $arquivo->id,
+            'original_name'  => (string) ($arquivo->original_name ?? ''),
+            'mime_type'      => (string) $arquivo->mime_type,
+            'size_bytes'     => (int) $arquivo->size_bytes,
+            'display_url'    => (string) $arquivo->display_url,
+            'created_at'     => $arquivo->created_at?->toIso8601String(),
+        ];
     }
 
     /**

--- a/Modules/OficinaAuto/Http/Requests/UploadDviPhotoRequest.php
+++ b/Modules/OficinaAuto/Http/Requests/UploadDviPhotoRequest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\OficinaAuto\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+/**
+ * D8 Security — FormRequest pra upload de foto/laudo num item DVI.
+ *
+ * Gap 1 (2026-05-26) — substitui placeholder V2 FOTOS no drawer ServiceOrderRichSheet
+ * por upload real via `Modules/Arquivos` trait HasArquivos polimórfica (ADR 0123).
+ *
+ * Best-practice 2026 (AutoVitals/Tekmetric): foto inline em CADA item DVI, não
+ * anexo solto da OS. Motorista caminhão basculante leva foto antes/depois pra
+ * ressarcir transportadora 3a / seguradora (sub-vertical 4 mecânica pesada ADR 0194).
+ *
+ * Multi-tenant Tier 0 ([ADR 0093]): business_id auto-fill via ArquivosService::attach
+ * (lê session('user.business_id') / session('business.id')). Request nunca injeta.
+ *
+ * Validação:
+ * - `photo`: required file, image MIME jpeg/png/webp/heic/heif, max 10MB (HEIC iPhone ~3-4MB)
+ *
+ * @see Modules\OficinaAuto\Http\Controllers\DviInspectionController::uploadPhoto
+ * @see Modules\Arquivos\Services\ArquivosService::attach
+ * @see memory/sessions/2026-05-26-plano-gap-1-upload-foto-laudo-drawer.md
+ */
+class UploadDviPhotoRequest extends FormRequest
+{
+    /**
+     * Autorização — mesma policy da edição da OS (Spatie + sameTenant guard).
+     */
+    public function authorize(): bool
+    {
+        $user = $this->user();
+
+        if ($user === null) {
+            return false;
+        }
+
+        return $user->can('superadmin') || $user->can('oficinaauto.service_order.update');
+    }
+
+    /**
+     * Validação MIME whitelist + tamanho máximo.
+     *
+     * - max:10240 KB = 10 MB. HEIC iPhone padrão fica em 3-4MB; foto câmera traseira
+     *   Android 12MP em JPEG fica ~3-5MB. Margem generosa.
+     * - MIME whitelist explícito evita SVG (XSS via embedded JS) e file extension spoofing.
+     * - `dimensions` opcional NÃO incluído — DVI foto pode vir de câmera baixa qualidade
+     *   ou recorte. Validar dimensões mata UX em caso real (rebocador na chuva).
+     */
+    public function rules(): array
+    {
+        return [
+            'photo' => [
+                'required',
+                'file',
+                'mimes:jpeg,jpg,png,webp,heic,heif',
+                'mimetypes:image/jpeg,image/png,image/webp,image/heic,image/heif',
+                'max:10240', // 10 MB em kilobytes
+            ],
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'photo.required'   => 'Arquivo de foto obrigatório.',
+            'photo.file'       => 'Upload inválido — não é um arquivo.',
+            'photo.mimes'      => 'Formato inválido. Use JPEG, PNG, WebP, HEIC ou HEIF.',
+            'photo.mimetypes'  => 'Tipo MIME inválido. Apenas imagens (jpeg/png/webp/heic/heif).',
+            'photo.max'        => 'Foto excede 10 MB. Reduza a qualidade antes de subir.',
+        ];
+    }
+}

--- a/Modules/OficinaAuto/Routes/web.php
+++ b/Modules/OficinaAuto/Routes/web.php
@@ -163,6 +163,23 @@ Route::middleware(['web', 'SetSessionData', 'auth', 'language', 'timezone', 'Adm
             [DviInspectionController::class, 'destroy'])
             ->middleware('throttle:60,1')
             ->name('oficinaauto.orders.dvi.destroy');
+
+        // ─────────────────────────────────────────────────────────────────────
+        // Gap 1 (2026-05-26) — Upload foto/laudo item DVI via Modules/Arquivos.
+        // Substitui placeholder V2 FOTOS no drawer ServiceOrderRichSheet.
+        // Multi-tenant Tier 0 (ADR 0093) via ArquivosService::attach (session-derived
+        // business_id). Throttle 30/1 (upload mais pesado que CRUD JSON normal).
+        // Sub-vertical 4 mecânica pesada Martinho biz=164 (ADR 0194).
+        // ─────────────────────────────────────────────────────────────────────
+        Route::post('ordens-servico/{order}/dvi/{item}/photo',
+            [DviInspectionController::class, 'uploadPhoto'])
+            ->middleware('throttle:30,1')
+            ->name('oficinaauto.orders.dvi.photo.upload');
+
+        Route::delete('ordens-servico/{order}/dvi/{item}/photo/{arquivo}',
+            [DviInspectionController::class, 'deletePhoto'])
+            ->middleware('throttle:30,1')
+            ->name('oficinaauto.orders.dvi.photo.delete');
     });
 
 // ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
Onda H — Gap 1 do plano consolidado 6 gaps OficinaAuto. Etapas 1-2 (backend) prontas. Frontend DviPhotoGrid + Pest tests + retention config ficam pra follow-up PR.

## Commits
- `ac351186b` Etapa 1 — trait HasArquivos em OaInspectionItem + ServiceOrder
- `3d7b909c1` Etapa 2 — Controller uploadPhoto + UploadDviPhotoRequest + 2 routes

## Refs
- ADR 0093 Multi-tenant Tier 0
- ADR 0123 Modules/Arquivos backbone canon
- ADR 0194 sub-vertical 4 mecânica pesada
- Plano: memory/sessions/2026-05-26-plano-gap-1-upload-foto-laudo-drawer.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)