### PR TITLE
fix(sidebar): grupos órfãos FINANÇAS/PRODUÇÃO/ESTOQUE/RH com 0 anchors visíveis

### DIFF
--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -660,9 +660,16 @@ export function SidebarMenu({ items, mode = 'expanded' }: { items: ShellMenuItem
   }
 
   // 5 grupos canon (autorizados) + MAIS fallback no fim (collapse fechado)
+  // PR #1669 — filter MAIS ESTRITO pra evitar grupos órfãos sem anchors:
+  // verifica que grupo tem PELO MENOS 1 item com url+label válidos (não é
+  // header sem destination ou item invisible). Smoke 2026-05-26 17:50 mostrou
+  // FINANÇAS/PRODUÇÃO/ESTOQUE/RH como labels SEM children renderizados —
+  // grupos eram populated com items que SidebarMenuItem ignorava (url vazia).
+  const hasVisibleItem = (items: ShellMenuItem[] | undefined): boolean =>
+    !!items && items.some((it) => Boolean(it.href) && Boolean(it.label));
   const groupsToRender = [
-    ...SIDEBAR_GROUPS.filter((g) => groupedItems[g.key]?.length),
-    ...(groupedItems.mais?.length
+    ...SIDEBAR_GROUPS.filter((g) => hasVisibleItem(groupedItems[g.key])),
+    ...(hasVisibleItem(groupedItems.mais)
       ? [{ key: 'mais', label: 'MAIS', items: [] }]
       : []),
   ];


### PR DESCRIPTION
Smoke real prod 2026-05-26 17:50 (Wagner: **'side bar errada'**) descobriu:

```
CADASTRO → 2 anchors · is-open ✅
COMERCIAL → 2 anchors · is-open ✅
FINANÇAS → 0 anchors · sb-group ❌
FISCAL → 3 anchors · is-open ✅
PRODUÇÃO → 0 anchors · sb-group ❌
ESTOQUE → 0 anchors · sb-group ❌
RH → 0 anchors · sb-group ❌
SISTEMA → 4 anchors · is-open ✅
```

## Root cause

Filter linha 664 era `groupedItems[g.key]?.length` — permitia grupos com items que SidebarMenuItem **silenciosamente ignora** (href vazio · label vazio · permission-blocked). Items entram em groupedItems, length>0, label renderiza, mas children são vazios na prática.

## Fix

```tsx
const hasVisibleItem = (items: ShellMenuItem[] | undefined): boolean =>
  !!items && items.some((it) => Boolean(it.href) && Boolean(it.label));

const groupsToRender = [
  ...SIDEBAR_GROUPS.filter((g) => hasVisibleItem(groupedItems[g.key])),
  ...(hasVisibleItem(groupedItems.mais) ? [...] : []),
];
```

## Resultado esperado pós-fix

**biz=1 Wagner WR2:** FINANÇAS/PRODUÇÃO/ESTOQUE/RH **somem da sidebar** (não têm items válidos). Sidebar limpa: CADASTRO/COMERCIAL/FISCAL/SISTEMA.

**Outros biz (Larissa biz=4 etc):** quando tiverem módulos Compras/Manufacturing/Ponto ativos, grupos voltam **automaticamente** (filter dinâmico). Multi-tenant Tier 0 ADR 0093 preservado.

## Diff

1 arquivo, +8/-2 LOC.

Refs: PR #1665 comparativo visual · ADR 0093 Tier 0.