### PR TITLE
fix(sidebar): grupos colapsados pareciam vazios — defaultOpen=true + lsKey v2

### DIFF
--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -577,7 +577,9 @@ function SidebarGroup({
   // Inline accordion (não popover lateral) — Wagner 2026-05-05.
   // Persistência por grupo em LS pra não recarregar entre navegações.
   // Múltiplos grupos podem estar abertos simultaneamente.
-  const lsKey = `oimpresso.cockpit.group.${groupKey}.expanded`;
+  // PR #1674 — bump pra v2 invalida preferências antigas (smoke Wagner descobriu
+  // grupos parecendo vazios porque ls.collapsed=true persistia mesmo com items).
+  const lsKey = `oimpresso.cockpit.group.v2.${groupKey}.expanded`;
   const [expanded, setExpanded] = useState<boolean>(() => {
     if (typeof window === 'undefined') return defaultOpen;
     const v = localStorage.getItem(lsKey);
@@ -710,7 +712,12 @@ export function SidebarMenu({ items, mode = 'expanded' }: { items: ShellMenuItem
           key={g.key}
           groupKey={g.key}
           label={g.label}
-          defaultOpen={['cadastro', 'comercial', 'financas', 'fiscal', 'producao', 'estoque'].includes(g.key)}
+          // PR #1674 — defaultOpen=true UNIVERSAL pra paridade prototipo Cowork.
+          // Smoke real Wagner 2026-05-26 18h: grupos pareciam vazios porque user
+          // tinha localStorage antigo persistido como collapsed. lsKey bump pra v2
+          // (SidebarGroup) invalida prefs antigas + todos grupos abrem por default.
+          // Items COM permissão renderizam dentro do body expandido.
+          defaultOpen={true}
         >
           {(groupedItems[g.key] ?? []).map((item, idx) => (
             <SidebarMenuItem key={`${item.label}-${idx}`} item={item} />


### PR DESCRIPTION
Smoke real Wagner 2026-05-26 17:50 ('side bar errada'). PR #1672 não bastou — root cause é diferente.

## Diagnóstico

Click manual no header FINANÇAS revelou:
- **ANTES click:** 0 anchors (parecia vazio · Wagner achou bug)
- **DEPOIS click:** **4 anchors** (Caixa · Cobrança · Financeiro · Cobrança Recorrente — items existiam!)

Grupos tinham items SIM mas COLAPSADOS por:

1. `defaultOpen` array excluía `pessoas` (RH) e `sistema` do auto-open canon
2. localStorage `oimpresso.cockpit.group.{key}.expanded=0` persistia state antigo

## Fix duas camadas

1. `defaultOpen={true}` UNIVERSAL — paridade prototipo Cowork (todos grupos auto-abertos)
2. lsKey bump pra v2: `oimpresso.cockpit.group.v2.{key}.expanded` — invalida prefs antigas

User pode colapsar manualmente depois; novo state persiste em v2 keys.

## Diff

1 arquivo, 2 mudanças:
- `SidebarGroup.lsKey` ← bump v2
- `groupsToRender.map` `defaultOpen` ← `true` universal

Refs: PR #1672 (filter hasVisibleItem complementar) · PR #1665 comparativo · ADR 0093.