### PR TITLE
feat(fiscal/microcopy): remove jargão dev tooltips (Onda 2.3)

### DIFF
--- a/resources/js/Pages/Fiscal/_components/NFSeDrawer.tsx
+++ b/resources/js/Pages/Fiscal/_components/NFSeDrawer.tsx
@@ -69,14 +69,14 @@ export default function NFSeDrawer({ nota, onClose }: NFSeDrawerProps) {
       }
       footer={
         <>
-          <button type="button" className="fx-btn ghost" disabled title="Wire-up no PR seguinte">
+          <button type="button" className="fx-btn ghost" disabled title="Em breve">
             Reconsultar prefeitura
           </button>
           <div className="fx-drawer-f-r">
             <button type="button" className="fx-btn ghost" disabled title="Download XML">XML</button>
             <button type="button" className="fx-btn ghost" disabled title="Download DANFSe">DANFSe</button>
             {nota.status === 'autorizada' && (
-              <button type="button" className="fx-btn danger" disabled title="Wire-up no PR seguinte">
+              <button type="button" className="fx-btn danger" disabled title="Em breve">
                 Cancelar
               </button>
             )}

--- a/resources/js/Pages/Fiscal/_components/NotaDrawerV2.tsx
+++ b/resources/js/Pages/Fiscal/_components/NotaDrawerV2.tsx
@@ -121,12 +121,12 @@ function SefazActionCard({ recipe, status }: { recipe: SefazActionRecipe; status
       {(recipe.primary || recipe.secondary) && (
         <div className="fx-action-btns">
           {recipe.primary && (
-            <button type="button" className={`fx-btn ${recipe.primary.kind}`} disabled title="Wire-up no PR seguinte">
+            <button type="button" className={`fx-btn ${recipe.primary.kind}`} disabled title="Em breve">
               {recipe.primary.label} <kbd>⏎</kbd>
             </button>
           )}
           {recipe.secondary && (
-            <button type="button" className="fx-btn ghost" disabled title="Wire-up no PR seguinte">
+            <button type="button" className="fx-btn ghost" disabled title="Em breve">
               {recipe.secondary.label}
             </button>
           )}
@@ -252,19 +252,19 @@ export default function NotaDrawerV2({ nota, onClose, onQuickFilterCliente }: No
       }
       footer={
         <>
-          <button type="button" className="fx-btn ghost" disabled title="Wire-up no PR seguinte">
+          <button type="button" className="fx-btn ghost" disabled title="Em breve">
             Reconsultar <kbd>R</kbd>
           </button>
           <div className="fx-drawer-f-r">
             <button type="button" className="fx-btn ghost" disabled title="Download XML">XML</button>
             <button type="button" className="fx-btn ghost" disabled title="Download DANFE">DANFE</button>
             {nota.status === 100 && cancelW && (
-              <button type="button" className="fx-btn danger" disabled title="Wire-up no PR seguinte">
+              <button type="button" className="fx-btn danger" disabled title="Em breve">
                 Cancelar <kbd>X</kbd>
               </button>
             )}
             {rejected && (
-              <button type="button" className="fx-btn primary" disabled title="Wire-up no PR seguinte">
+              <button type="button" className="fx-btn primary" disabled title="Em breve">
                 Retransmitir <kbd>⏎</kbd>
               </button>
             )}

--- a/resources/js/Pages/Fiscal/_components/SendToContabilDrawer.tsx
+++ b/resources/js/Pages/Fiscal/_components/SendToContabilDrawer.tsx
@@ -108,7 +108,7 @@ export default function SendToContabilDrawer({ open, data, onClose }: SendToCont
               type="button"
               className="fx-btn primary"
               disabled={!podeEnviar}
-              title={!podeEnviar ? 'Resolver bloqueios + selecionar pelo menos 1 item do pacote' : 'TODO[CL]: wire-up real no PR seguinte'}
+              title={!podeEnviar ? 'Resolver bloqueios + selecionar pelo menos 1 item do pacote' : 'Em breve · envio automático em preparação'}
             >
               <Archive size={12} /> Gerar e enviar pacote
             </button>
@@ -159,8 +159,8 @@ export default function SendToContabilDrawer({ open, data, onClose }: SendToCont
               />
               <div>
                 {m === 'email' && <><Mail size={14} /> <b>E-mail anexo</b><small>Envia ZIP pro {data.destinatarioPadrao}</small></>}
-                {m === 'sftp' && <><Archive size={14} /> <b>SFTP do contador</b><small>Configurar credencial em /fiscal/config</small></>}
-                {m === 'download' && <><FileText size={14} /> <b>Download manual</b><small>Baixa ZIP local pra você compartilhar</small></>}
+                {m === 'sftp' && <><Archive size={14} /> <b>SFTP do contador</b><small>Configure a credencial em Fiscal → Configurações</small></>}
+                {m === 'download' && <><FileText size={14} /> <b>Download manual</b><small>Baixa o ZIP pra você enviar manualmente</small></>}
               </div>
             </label>
           ))}

--- a/resources/js/Pages/Fiscal/_components/WriteOffAuditoriaCard.tsx
+++ b/resources/js/Pages/Fiscal/_components/WriteOffAuditoriaCard.tsx
@@ -53,7 +53,7 @@ export default function WriteOffAuditoriaCard({ summary, onReview }: WriteOffAud
           className="fx-btn ghost"
           onClick={onReview}
           disabled={!onReview}
-          title={onReview ? 'Abrir drawer pra revisar candidatos' : 'Wire-up no PR seguinte'}
+          title={onReview ? 'Abrir lista pra revisar candidatos' : 'Em breve'}
         >
           <TrendingDown size={12} /> Revisar
         </button>


### PR DESCRIPTION
Polimento microcopy persona Eliana contadora. Substitui jargão dev ('Wire-up', 'PR seguinte', 'TODO[CL]', 'drawer') por linguagem que contadora entende ('Em breve', 'lista', 'Fiscal → Configurações').

11 strings substituídas, 4 arquivos, +11/-11 LOC (text-only).

MANTIDO: jargão fiscal/contábil que Eliana usa (CC-e, CFOP, NCM, CONFAZ, etc).

Refs: Onda 2.3 polimento drawers.