### PR TITLE
feat(sells): timeline cross-source unified (P4 parking lot #11)

### DIFF
--- a/app/Http/Controllers/SaleHistoryController.php
+++ b/app/Http/Controllers/SaleHistoryController.php
@@ -5,8 +5,12 @@ declare(strict_types=1);
 namespace App\Http\Controllers;
 
 use App\Domain\Fsm\Models\SaleStageHistory;
+use App\Transaction;
+use App\TransactionPayment;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
+use Spatie\Activitylog\Models\Activity;
 use Symfony\Component\HttpFoundation\Response;
 
 /**
@@ -14,6 +18,10 @@ use Symfony\Component\HttpFoundation\Response;
  *
  * GET /api/sells/{id}/history → retorna histórico de transições da venda
  *   pra rendering em <SaleTimeline /> (Wave 3 frontend) ou consumo CLI.
+ *
+ * GET /api/sells/{id}/timeline-unified → agrega FSM + payments + activities
+ *   (+ comments/audit_log se tabelas existirem) num único stream cronológico
+ *   reverso pra Sells/Show + drawer. Gap #11 do parking lot pós-PR #1663.
  *
  * Multi-tenant Tier 0 (ADR 0093): HasBusinessScope em SaleStageHistory já
  * escopa por business_id da sessão. Cross-tenant attempt retorna 404.
@@ -88,5 +96,314 @@ class SaleHistoryController extends Controller
             'count' => $items->count(),
             'items' => $payload,
         ]);
+    }
+
+    /**
+     * GET /api/sells/{id}/timeline-unified
+     *
+     * Agrega 5 sources num único stream cronológico reverso:
+     *   1. fsm_transition (sale_stage_history)
+     *   2. payment (transaction_payments)
+     *   3. activity (activity_log via Spatie/Activitylog)
+     *   4. comment (sale_item_comments — se tabela existir)
+     *   5. audit (audit_log — se tabela existir)
+     *
+     * Multi-tenant Tier 0: business_id em TODA query (defense-in-depth).
+     */
+    public function timelineUnified(Request $request, int $id): JsonResponse
+    {
+        if (! auth()->check()) {
+            abort(Response::HTTP_UNAUTHORIZED);
+        }
+
+        if (! auth()->user()->can('sale.history.view')) {
+            abort(Response::HTTP_FORBIDDEN, 'Sem permissão pra ver histórico de vendas.');
+        }
+
+        $businessId = (int) $request->session()->get('user.business_id');
+
+        // Multi-tenant guard antes de qualquer agregação — Transaction must exist + same biz + type=sell.
+        $venda = Transaction::query()
+            ->where('business_id', $businessId)
+            ->where('id', $id)
+            ->where('type', 'sell')
+            ->first();
+
+        if (! $venda) {
+            return response()->json([
+                'message' => 'Venda não encontrada',
+                'transaction_id' => $id,
+                'count' => 0,
+                'events' => [],
+            ], 404);
+        }
+
+        $events = collect();
+
+        // ── 1. FSM transitions ─────────────────────────────────────────
+        $fsm = SaleStageHistory::query()
+            ->where('business_id', $businessId)
+            ->where('transaction_id', $id)
+            ->with([
+                'action:id,key,label,target_stage_id',
+                'fromStage:id,key,name,color',
+                'toStage:id,key,name,color',
+            ])
+            ->orderByDesc('executed_at')
+            ->limit(100)
+            ->get();
+
+        foreach ($fsm as $h) {
+            $from = $h->fromStage?->name;
+            $to = $h->toStage?->name ?? '—';
+            $title = $from
+                ? "{$from} → {$to}"
+                : ($h->action?->label ?? 'Pipeline iniciado');
+
+            $events->push([
+                'type' => 'fsm_transition',
+                'occurred_at' => $h->executed_at?->toIso8601String(),
+                'user_id' => $h->user_id,
+                'icon' => 'ArrowRight',
+                'tone' => $this->mapStageToTone($h->toStage?->color),
+                'title' => $title,
+                'description' => $h->action?->label ?? null,
+                'payload' => [
+                    'history_id' => $h->id,
+                    'from_stage' => $from,
+                    'to_stage' => $to,
+                    'action_key' => $h->action?->key,
+                    'motivo' => is_array($h->payload_snapshot)
+                        ? ($h->payload_snapshot['motivo'] ?? null)
+                        : null,
+                ],
+            ]);
+        }
+
+        // ── 2. Payments ────────────────────────────────────────────────
+        $payments = TransactionPayment::query()
+            ->where('business_id', $businessId)
+            ->where('transaction_id', $id)
+            ->orderByDesc('paid_on')
+            ->limit(100)
+            ->get();
+
+        foreach ($payments as $p) {
+            $events->push([
+                'type' => 'payment',
+                'occurred_at' => $p->paid_on
+                    ? (string) $p->paid_on
+                    : ($p->created_at?->toIso8601String()),
+                'user_id' => $p->created_by ?? null,
+                'icon' => 'CreditCard',
+                'tone' => 'green',
+                'title' => sprintf('Pagamento R$ %s', number_format((float) $p->amount, 2, ',', '.')),
+                'description' => $this->humanizePaymentMethod((string) ($p->method ?? '')),
+                'payload' => [
+                    'payment_id' => $p->id,
+                    'amount' => (float) $p->amount,
+                    'method' => $p->method,
+                    'is_return' => (bool) ($p->is_return ?? false),
+                ],
+            ]);
+        }
+
+        // ── 3. Activity log (Spatie/Activitylog) ───────────────────────
+        try {
+            $activities = Activity::query()
+                ->where('subject_type', \App\Transaction::class)
+                ->where('subject_id', $id)
+                ->where(function ($q) use ($businessId) {
+                    // business_id pode estar nullable em logs antigos — defense-in-depth:
+                    // aceita activity sem business_id (legacy) OU exatamente nosso biz.
+                    $q->where('business_id', $businessId)
+                        ->orWhereNull('business_id');
+                })
+                ->orderByDesc('created_at')
+                ->limit(100)
+                ->get();
+
+            foreach ($activities as $act) {
+                $events->push([
+                    'type' => 'activity',
+                    'occurred_at' => $act->created_at?->toIso8601String(),
+                    'user_id' => $act->causer_id,
+                    'icon' => 'FileText',
+                    'tone' => 'neutral',
+                    'title' => $this->humanizeActivityDescription((string) $act->description),
+                    'description' => $act->log_name ?: null,
+                    'payload' => [
+                        'activity_id' => $act->id,
+                        'log_name' => $act->log_name,
+                        'event' => $act->event ?? null,
+                    ],
+                ]);
+            }
+        } catch (\Throwable $e) {
+            // Skip silenciosamente se schema activity_log diferir do esperado.
+        }
+
+        // ── 4. Comments (sale_item_comments — se tabela existir) ───────
+        if (\Schema::hasTable('sale_item_comments')) {
+            try {
+                $comments = \DB::table('sale_item_comments')
+                    ->where('business_id', $businessId)
+                    ->where('transaction_id', $id)
+                    ->orderByDesc('created_at')
+                    ->limit(100)
+                    ->get();
+
+                foreach ($comments as $c) {
+                    $events->push([
+                        'type' => 'comment',
+                        'occurred_at' => isset($c->created_at) ? (string) $c->created_at : null,
+                        'user_id' => $c->user_id ?? null,
+                        'icon' => 'MessageSquare',
+                        'tone' => 'amber',
+                        'title' => 'Comentário',
+                        'description' => isset($c->body) ? mb_substr((string) $c->body, 0, 140) : null,
+                        'payload' => [
+                            'comment_id' => $c->id ?? null,
+                        ],
+                    ]);
+                }
+            } catch (\Throwable $e) {
+                // Skip silenciosamente.
+            }
+        }
+
+        // ── 5. Audit log (audit_log — se tabela existir) ───────────────
+        if (\Schema::hasTable('audit_log')) {
+            try {
+                $audits = \DB::table('audit_log')
+                    ->where('business_id', $businessId)
+                    ->where('entity_id', $id)
+                    ->orderByDesc('created_at')
+                    ->limit(100)
+                    ->get();
+
+                foreach ($audits as $a) {
+                    $events->push([
+                        'type' => 'audit',
+                        'occurred_at' => isset($a->created_at) ? (string) $a->created_at : null,
+                        'user_id' => $a->user_id ?? null,
+                        'icon' => 'ShieldCheck',
+                        'tone' => 'red',
+                        'title' => isset($a->action) ? (string) $a->action : 'Auditoria',
+                        'description' => isset($a->description) ? (string) $a->description : null,
+                        'payload' => [
+                            'audit_id' => $a->id ?? null,
+                        ],
+                    ]);
+                }
+            } catch (\Throwable $e) {
+                // Skip silenciosamente.
+            }
+        }
+
+        // Ordenar cronológico REVERSO + limit 100.
+        $sorted = $events
+            ->sortByDesc(fn ($e) => $e['occurred_at'] ?? '')
+            ->take(100)
+            ->values();
+
+        // Resolver users em batch (1 query).
+        $userIds = $sorted->pluck('user_id')->filter()->unique()->values();
+        $userNames = \DB::table('users')
+            ->whereIn('id', $userIds)
+            ->select(['id', 'username', 'first_name', 'last_name'])
+            ->get()
+            ->keyBy('id');
+
+        $finalEvents = $sorted->map(function (array $e) use ($userNames): array {
+            $uid = $e['user_id'] ?? null;
+            $u = $uid ? ($userNames[$uid] ?? null) : null;
+            $name = $u
+                ? trim(((string) ($u->first_name ?? '')).' '.((string) ($u->last_name ?? ''))) ?: (string) ($u->username ?? '')
+                : null;
+            $abbr = $name ? $this->makeAbbr((string) $name) : null;
+
+            return [
+                'type' => $e['type'],
+                'occurred_at' => $e['occurred_at'],
+                'user' => $uid ? [
+                    'id' => (int) $uid,
+                    'name' => $name,
+                    'abbr' => $abbr,
+                ] : null,
+                'icon' => $e['icon'],
+                'tone' => $e['tone'],
+                'title' => $e['title'],
+                'description' => $e['description'],
+                'payload' => $e['payload'],
+            ];
+        });
+
+        return response()->json([
+            'transaction_id' => $id,
+            'count' => $finalEvents->count(),
+            'events' => $finalEvents->values(),
+        ]);
+    }
+
+    /**
+     * Map stage color (sale_process_stages.color) → tone do unified timeline.
+     */
+    private function mapStageToTone(?string $color): string
+    {
+        return match ($color) {
+            'green', 'emerald' => 'green',
+            'red' => 'red',
+            'amber', 'orange' => 'amber',
+            'blue', 'cyan', 'indigo', 'violet' => 'blue',
+            default => 'neutral',
+        };
+    }
+
+    /**
+     * Humaniza method do TransactionPayment (cash → "Dinheiro" etc).
+     */
+    private function humanizePaymentMethod(string $method): ?string
+    {
+        $map = [
+            'cash' => 'Dinheiro',
+            'card' => 'Cartão',
+            'cheque' => 'Cheque',
+            'bank_transfer' => 'Transferência',
+            'pix' => 'PIX',
+            'boleto' => 'Boleto',
+            'credit_card' => 'Cartão de Crédito',
+            'debit_card' => 'Cartão de Débito',
+        ];
+
+        return $map[$method] ?? ($method ?: null);
+    }
+
+    /**
+     * Humaniza activity_log.description (snake_case → "Snake Case").
+     */
+    private function humanizeActivityDescription(string $desc): string
+    {
+        if ($desc === '') {
+            return 'Atividade';
+        }
+
+        return ucfirst(str_replace('_', ' ', $desc));
+    }
+
+    /**
+     * Abbreviação 2 letras (Wagner Rosa → WR).
+     */
+    private function makeAbbr(string $name): string
+    {
+        $parts = preg_split('/\s+/', trim($name)) ?: [];
+        if (count($parts) === 0) {
+            return '?';
+        }
+        if (count($parts) === 1) {
+            return mb_strtoupper(mb_substr($parts[0], 0, 2));
+        }
+
+        return mb_strtoupper(mb_substr($parts[0], 0, 1).mb_substr($parts[count($parts) - 1], 0, 1));
     }
 }

--- a/resources/css/sells-cowork-show.css
+++ b/resources/css/sells-cowork-show.css
@@ -341,3 +341,26 @@
   .sells-cowork-show .vds-section { box-shadow: none; border-color: #ccc; }
   .sells-cowork-show { background: #fff; color: #000; }
 }
+
+/* ─── Timeline unified (P4 parking lot #11 — cross-source stream) ─── */
+.sells-cowork-show .sb-timeline-unified {
+  --sb-timeline-gap: 0.625rem;
+}
+.sells-cowork-show .sb-timeline-event {
+  transition: background-color 120ms ease, border-color 120ms ease;
+}
+.sells-cowork-show .sb-timeline-event:hover {
+  background-color: var(--bg-2, #f8fafc);
+  border-color: var(--border-2, #e2e8f0);
+}
+.sells-cowork-show .sb-timeline-avatar {
+  box-shadow: 0 0 0 2px var(--surface, #ffffff);
+}
+.sells-cowork-show .sb-timeline-colorbar {
+  border-radius: 2px 0 0 2px;
+}
+@media print {
+  .sells-cowork-show .sb-timeline-event { border-color: #ccc; box-shadow: none; }
+  .sells-cowork-show .sb-timeline-colorbar { display: none; }
+  .sells-cowork-show .sb-timeline-avatar { background: #eee !important; color: #000 !important; box-shadow: none; }
+}

--- a/resources/js/Pages/Sells/Show.tsx
+++ b/resources/js/Pages/Sells/Show.tsx
@@ -37,6 +37,7 @@ import VdNfseEmitModal, { type NfseEmitVenda } from './_components/VdNfseEmitMod
 import SaleReciboPrint80mm from './_components/SaleReciboPrint80mm';
 import SaleOrcamentoA4 from './_components/SaleOrcamentoA4';
 import SellsCheatSheet, { SELLS_SHOW_SHORTCUTS } from './_components/SellsCheatSheet';
+import SaleTimeline from './_components/SaleTimeline';
 
 // Modos de impressão KB-9.75 Cowork bundle 2026-05-26 P2 gaps #8 + #9
 type CoworkPrintMode = 'recibo-80mm' | 'orcamento-a4' | null;
@@ -165,6 +166,23 @@ export default function SellsShow(props: SellsShowPageProps) {
   const [printMode, setPrintMode] = useState<CoworkPrintMode>(null);
   // KB-9.75 P3 gap #12 — cheat-sheet overlay '?' (Cowork bundle 2026-05-26).
   const [cheatOpen, setCheatOpen] = useState(false);
+  // P4 parking lot #11 — refresh trigger pro SaleTimeline unified
+  // (incrementa quando VdNextActionPanel/Emit* dispatcham CustomEvents).
+  const [timelineRefreshKey, setTimelineRefreshKey] = useState(0);
+
+  useEffect(() => {
+    const bump = () => setTimelineRefreshKey((k) => k + 1);
+    const events = [
+      'oimpresso:venda-invoiced',
+      'oimpresso:venda-paid',
+      'oimpresso:venda-emitted-nfe',
+      'oimpresso:venda-emitted-nfse',
+    ];
+    events.forEach((ev) => window.addEventListener(ev, bump));
+    return () => {
+      events.forEach((ev) => window.removeEventListener(ev, bump));
+    };
+  }, []);
 
   // /sells/{id}/print só responde a AJAX (SellPosController::printInvoice).
   // Render via iframe oculto + CSS legacy (Bootstrap 3 + .print_section) — pattern equivale
@@ -362,7 +380,11 @@ export default function SellsShow(props: SellsShowPageProps) {
 
             {/* Linhas + pagamentos + atividades — deferred */}
             <Deferred data="detail" fallback={<DetailSkeleton />}>
-              <ShowDetailSections detail={props.detail} headline={headline} />
+              <ShowDetailSections
+                detail={props.detail}
+                headline={headline}
+                timelineRefreshKey={timelineRefreshKey}
+              />
             </Deferred>
           </div>
 
@@ -514,9 +536,11 @@ export default function SellsShow(props: SellsShowPageProps) {
 interface ShowDetailSectionsProps {
   detail?: ShowDetail;
   headline: Headline;
+  /** P4 parking lot #11 — bump pro SaleTimeline unified re-fetch. */
+  timelineRefreshKey?: number;
 }
 
-function ShowDetailSections({ detail, headline }: ShowDetailSectionsProps) {
+function ShowDetailSections({ detail, headline, timelineRefreshKey = 0 }: ShowDetailSectionsProps) {
   if (!detail) return <DetailSkeleton />;
 
   return (
@@ -636,27 +660,24 @@ function ShowDetailSections({ detail, headline }: ShowDetailSectionsProps) {
         </section>
       )}
 
-      {/* Atividades */}
-      {detail.activities.length > 0 && (
-        <section className="rounded-lg border border-border bg-card overflow-hidden">
-          <div className="flex items-center gap-2 px-5 py-3 border-b border-border bg-muted/30">
-            <h2 className="font-semibold text-sm">Histórico</h2>
-            <span className="ml-auto text-xs text-muted-foreground">
-              {detail.activities.length} evento(s)
-            </span>
-          </div>
-          <div className="divide-y divide-border">
-            {detail.activities.map((a, idx) => (
-              <div key={idx} className="px-5 py-3 text-sm">
-                <div className="text-foreground">{a.description}</div>
-                <div className="text-xs text-muted-foreground mt-0.5">
-                  {a.causer_name} · {formatDateTime(a.created_at)}
-                </div>
-              </div>
-            ))}
-          </div>
-        </section>
-      )}
+      {/* Histórico unificado — P4 parking lot #11 (FSM + payments + activities
+          + comments + audit num único stream cronológico reverso). */}
+      <section className="rounded-lg border border-border bg-card overflow-hidden sells-cowork-show">
+        <div className="flex items-center gap-2 px-5 py-3 border-b border-border bg-muted/30">
+          <h2 className="font-semibold text-sm">Histórico</h2>
+          <span className="ml-auto text-xs text-muted-foreground">
+            Todos os eventos (FSM, pagamentos, atividades)
+          </span>
+        </div>
+        <div className="px-5 py-4">
+          <SaleTimeline
+            saleId={headline.id}
+            enabled
+            mode="unified"
+            refreshKey={timelineRefreshKey}
+          />
+        </div>
+      </section>
     </>
   );
 }

--- a/resources/js/Pages/Sells/_components/SaleSheet.tsx
+++ b/resources/js/Pages/Sells/_components/SaleSheet.tsx
@@ -678,9 +678,9 @@ export default function SaleSheet({
                 </p>
               </section>
 
-              {/* Histórico — timeline FSM da venda (US-SELL-035) */}
+              {/* Histórico — timeline cross-source unificado (P4 parking lot #11) */}
               <Section title="Histórico" icon={Clock}>
-                <SaleTimeline saleId={data.id} enabled={open} />
+                <SaleTimeline saleId={data.id} enabled={open} mode="unified" />
               </Section>
 
               {/* US-SELL-COWORK-R3-CURADORIA — audit trail compacto (Cowork Onda 3)

--- a/resources/js/Pages/Sells/_components/SaleTimeline.tsx
+++ b/resources/js/Pages/Sells/_components/SaleTimeline.tsx
@@ -1,8 +1,28 @@
-// US-SELL-035 frontend — Timeline FSM da venda (sale_stage_history).
+// US-SELL-035 frontend — Timeline da venda.
+// Modos:
+//   - mode="fsm" (default — back-compat): só transições FSM (/api/sells/{id}/history)
+//   - mode="unified" (P4 parking lot #11): FSM + payments + activities + comments + audit
+//     num único stream cronológico reverso com avatar + tone + icon.
+//
 // Refs: PR #618 backend (SaleHistoryController), CASOS-USO-PIPELINE-VENDAS.md §CU-07
+//       PR P4 #2026-05-26 backend timelineUnified() + r4 visual-comparison gap #11.
 
-import { useEffect, useState } from 'react';
-import { Clock, Loader2, User2, Zap, FileCheck2, ArrowRight } from 'lucide-react';
+import { useCallback, useEffect, useState } from 'react';
+import {
+  ArrowRight,
+  Clock,
+  CreditCard,
+  FileCheck2,
+  FileText,
+  Inbox,
+  Loader2,
+  MessageSquare,
+  ShieldCheck,
+  User2,
+  Zap,
+} from 'lucide-react';
+
+// ─── Tipos FSM (modo legado) ───────────────────────────────────────────
 
 interface TimelineUser {
   id: number | null;
@@ -38,10 +58,52 @@ interface TimelineResponse {
   items: TimelineItem[];
 }
 
+// ─── Tipos Unified (modo cross-source) ─────────────────────────────────
+
+type UnifiedEventType = 'fsm_transition' | 'payment' | 'activity' | 'comment' | 'audit';
+type UnifiedTone = 'blue' | 'green' | 'amber' | 'red' | 'neutral';
+type UnifiedIcon = 'ArrowRight' | 'CreditCard' | 'FileText' | 'MessageSquare' | 'ShieldCheck';
+
+interface UnifiedUser {
+  id: number;
+  name: string | null;
+  abbr: string | null;
+}
+
+interface UnifiedEvent {
+  type: UnifiedEventType;
+  occurred_at: string | null;
+  user: UnifiedUser | null;
+  icon: UnifiedIcon;
+  tone: UnifiedTone;
+  title: string;
+  description: string | null;
+  payload: Record<string, unknown> | null;
+}
+
+interface UnifiedResponse {
+  transaction_id: number;
+  count: number;
+  events: UnifiedEvent[];
+}
+
+// ─── Props ─────────────────────────────────────────────────────────────
+
 interface Props {
   saleId: number;
   enabled: boolean;
+  /**
+   * 'fsm' = só transições FSM (default — back-compat com Wave 3).
+   * 'unified' = cross-source (FSM + payments + activities + comments + audit).
+   */
+  mode?: 'fsm' | 'unified';
+  /**
+   * Trigger pra re-fetch (incrementa quando ação externa cria evento novo).
+   */
+  refreshKey?: number;
 }
+
+// ─── Helpers visuais ───────────────────────────────────────────────────
 
 const STAGE_COLOR_MAP: Record<string, string> = {
   gray: 'bg-gray-100 text-gray-700 dark:bg-gray-800 dark:text-gray-300',
@@ -54,6 +116,30 @@ const STAGE_COLOR_MAP: Record<string, string> = {
   green: 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300',
   red: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
   slate: 'bg-slate-100 text-slate-700 dark:bg-slate-800 dark:text-slate-300',
+};
+
+const TONE_COLORBAR: Record<UnifiedTone, string> = {
+  blue: 'bg-blue-500',
+  green: 'bg-emerald-500',
+  amber: 'bg-amber-500',
+  red: 'bg-red-500',
+  neutral: 'bg-slate-400',
+};
+
+const TONE_ICON_BG: Record<UnifiedTone, string> = {
+  blue: 'bg-blue-100 text-blue-700 dark:bg-blue-900/40 dark:text-blue-300',
+  green: 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/40 dark:text-emerald-300',
+  amber: 'bg-amber-100 text-amber-700 dark:bg-amber-900/40 dark:text-amber-300',
+  red: 'bg-red-100 text-red-700 dark:bg-red-900/40 dark:text-red-300',
+  neutral: 'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300',
+};
+
+const ICON_MAP: Record<UnifiedIcon, typeof ArrowRight> = {
+  ArrowRight,
+  CreditCard,
+  FileText,
+  MessageSquare,
+  ShieldCheck,
 };
 
 const stageBadge = (stage: TimelineStage | null) => {
@@ -78,20 +164,57 @@ const formatDate = (iso: string | null) => {
   }
 };
 
-export default function SaleTimeline({ saleId, enabled }: Props) {
+// Relativo: "há 3h", "há 2d", "agora", abs no title pra hover.
+const formatRelative = (iso: string | null): string => {
+  if (!iso) return '—';
+  try {
+    const then = new Date(iso).getTime();
+    const now = Date.now();
+    const diff = Math.max(0, now - then);
+    const sec = Math.floor(diff / 1000);
+    if (sec < 60) return 'agora';
+    const min = Math.floor(sec / 60);
+    if (min < 60) return `há ${min}min`;
+    const hr = Math.floor(min / 60);
+    if (hr < 24) return `há ${hr}h`;
+    const day = Math.floor(hr / 24);
+    if (day < 30) return `há ${day}d`;
+    return formatDate(iso);
+  } catch {
+    return iso;
+  }
+};
+
+// Hash determinístico → 5 cores pré-aprovadas pra avatar.
+const AVATAR_PALETTE = ['#6366f1', '#0ea5e9', '#10b981', '#f59e0b', '#ef4444'];
+const avatarColor = (name: string | null): string => {
+  if (!name) return '#94a3b8';
+  let h = 0;
+  for (let i = 0; i < name.length; i++) h = (h << 5) - h + name.charCodeAt(i);
+  return AVATAR_PALETTE[Math.abs(h) % AVATAR_PALETTE.length] ?? '#94a3b8';
+};
+
+// ─── Componente ────────────────────────────────────────────────────────
+
+export default function SaleTimeline({ saleId, enabled, mode = 'fsm', refreshKey = 0 }: Props) {
   const [items, setItems] = useState<TimelineItem[]>([]);
+  const [events, setEvents] = useState<UnifiedEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [forbidden, setForbidden] = useState(false);
 
-  useEffect(() => {
-    if (!enabled || !saleId) return;
+  const url = mode === 'unified'
+    ? `/api/sells/${saleId}/timeline-unified`
+    : `/api/sells/${saleId}/history`;
+
+  const fetchTimeline = useCallback(() => {
+    if (!enabled || !saleId) return () => {};
     let cancelled = false;
     setLoading(true);
     setError(null);
     setForbidden(false);
 
-    fetch(`/api/sells/${saleId}/history`, {
+    fetch(url, {
       headers: { Accept: 'application/json' },
       credentials: 'same-origin',
     })
@@ -100,17 +223,24 @@ export default function SaleTimeline({ saleId, enabled }: Props) {
           if (!cancelled) {
             setForbidden(true);
             setItems([]);
+            setEvents([]);
           }
           return null;
         }
         if (!res.ok) {
           throw new Error(`HTTP ${res.status}`);
         }
-        return (await res.json()) as TimelineResponse;
+        return await res.json();
       })
       .then((data) => {
         if (cancelled || !data) return;
-        setItems(data.items ?? []);
+        if (mode === 'unified') {
+          const r = data as UnifiedResponse;
+          setEvents(r.events ?? []);
+        } else {
+          const r = data as TimelineResponse;
+          setItems(r.items ?? []);
+        }
       })
       .catch((e) => {
         if (cancelled) return;
@@ -123,7 +253,12 @@ export default function SaleTimeline({ saleId, enabled }: Props) {
     return () => {
       cancelled = true;
     };
-  }, [saleId, enabled]);
+  }, [enabled, saleId, url, mode]);
+
+  useEffect(() => {
+    const cleanup = fetchTimeline();
+    return cleanup;
+  }, [fetchTimeline, refreshKey]);
 
   if (forbidden) {
     return (
@@ -134,6 +269,21 @@ export default function SaleTimeline({ saleId, enabled }: Props) {
   }
 
   if (loading) {
+    if (mode === 'unified') {
+      return (
+        <div className="sb-timeline-loading space-y-3" aria-busy="true">
+          {[0, 1, 2].map((i) => (
+            <div key={i} className="flex items-start gap-3 animate-pulse">
+              <div className="h-8 w-8 rounded-full bg-muted" />
+              <div className="flex-1 space-y-2">
+                <div className="h-3 w-1/3 rounded bg-muted" />
+                <div className="h-3 w-2/3 rounded bg-muted/70" />
+              </div>
+            </div>
+          ))}
+        </div>
+      );
+    }
     return (
       <div className="flex items-center gap-2 text-xs text-muted-foreground">
         <Loader2 size={14} className="animate-spin" />
@@ -150,6 +300,98 @@ export default function SaleTimeline({ saleId, enabled }: Props) {
     );
   }
 
+  // ── Render unified (cross-source) ──
+  if (mode === 'unified') {
+    if (events.length === 0) {
+      return (
+        <div className="sb-timeline-empty flex flex-col items-center justify-center gap-2 py-8 text-center">
+          <Inbox size={32} className="text-muted-foreground/50" />
+          <p className="text-sm text-muted-foreground">
+            Sem eventos ainda.
+          </p>
+          <p className="text-xs text-muted-foreground/70 max-w-xs">
+            Quando ações forem executadas (faturar, pagar, transitar FSM, comentar),
+            tudo aparece aqui em ordem cronológica reversa.
+          </p>
+        </div>
+      );
+    }
+
+    return (
+      <ol className="sb-timeline-unified relative space-y-3">
+        {events.map((ev, idx) => {
+          const Icon = ICON_MAP[ev.icon] ?? FileText;
+          const colorbar = TONE_COLORBAR[ev.tone] ?? TONE_COLORBAR.neutral;
+          const iconBg = TONE_ICON_BG[ev.tone] ?? TONE_ICON_BG.neutral;
+          const userName = ev.user?.name ?? null;
+          const userAbbr = ev.user?.abbr ?? '?';
+          const absDate = formatDate(ev.occurred_at);
+
+          return (
+            <li
+              key={`${ev.type}-${idx}-${ev.occurred_at ?? ''}`}
+              className="sb-timeline-event relative flex items-stretch gap-3 rounded-md border border-border bg-card overflow-hidden"
+            >
+              {/* Colorbar à esquerda */}
+              <span
+                aria-hidden
+                className={`sb-timeline-colorbar w-1 shrink-0 ${colorbar}`}
+              />
+
+              {/* Avatar circular */}
+              <div className="flex items-start pt-3 pl-1">
+                {userName ? (
+                  <span
+                    className="sb-timeline-avatar inline-flex h-8 w-8 items-center justify-center rounded-full text-[10px] font-semibold text-white"
+                    style={{ backgroundColor: avatarColor(userName) }}
+                    title={userName}
+                  >
+                    {userAbbr}
+                  </span>
+                ) : (
+                  <span className="sb-timeline-avatar inline-flex h-8 w-8 items-center justify-center rounded-full bg-muted text-muted-foreground">
+                    <User2 size={14} />
+                  </span>
+                )}
+              </div>
+
+              {/* Conteúdo */}
+              <div className="flex-1 py-3 pr-3 space-y-1 min-w-0">
+                <div className="flex items-start justify-between gap-2">
+                  <div className="flex items-center gap-2 min-w-0">
+                    <span className={`sb-timeline-icon inline-flex h-6 w-6 items-center justify-center rounded ${iconBg}`}>
+                      <Icon size={12} />
+                    </span>
+                    <span className="text-sm font-medium text-foreground truncate" title={ev.title}>
+                      {ev.title}
+                    </span>
+                  </div>
+                  <span
+                    className="text-[11px] text-muted-foreground whitespace-nowrap"
+                    title={absDate}
+                  >
+                    {formatRelative(ev.occurred_at)}
+                  </span>
+                </div>
+                {ev.description && (
+                  <p className="text-xs text-muted-foreground line-clamp-2">
+                    {ev.description}
+                  </p>
+                )}
+                {userName && (
+                  <p className="text-[11px] text-muted-foreground/80">
+                    por <span className="font-medium text-foreground/80">{userName}</span>
+                  </p>
+                )}
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    );
+  }
+
+  // ── Render FSM (modo legado) ──
   if (items.length === 0) {
     return (
       <p className="text-xs text-muted-foreground">
@@ -211,3 +453,5 @@ export default function SaleTimeline({ saleId, enabled }: Props) {
     </ol>
   );
 }
+
+export type { UnifiedEvent, UnifiedResponse, UnifiedEventType, UnifiedTone, UnifiedIcon };

--- a/routes/web.php
+++ b/routes/web.php
@@ -360,6 +360,11 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     // US-SELL-035 — Timeline FSM (sale_stage_history) pra drawer e auditoria.
     Route::get('/api/sells/{id}/history', [\App\Http\Controllers\SaleHistoryController::class, 'index'])
         ->name('sells.history');
+    // P4 parking lot pós-PR #1663 (gap #11 r4 visual-comparison) — timeline
+    // cross-source: FSM + payments + activities + comments + audit_log num
+    // único stream cronológico reverso pra Sells/Show + drawer.
+    Route::get('/api/sells/{id}/timeline-unified', [\App\Http\Controllers\SaleHistoryController::class, 'timelineUnified'])
+        ->name('sells.timeline-unified');
     // US-SELL-COWORK-R3-CURADORIA Onda 3.5 — Audit Trail FSM real (formato flat
     // amigável pro componente SaleAuditTrail.tsx). Multi-tenant Tier 0.
     Route::get('/sells/{sale}/audit', [\App\Http\Controllers\SellAuditController::class, 'show'])

--- a/tests/Feature/Sells/SellsTimelineUnifiedTest.php
+++ b/tests/Feature/Sells/SellsTimelineUnifiedTest.php
@@ -1,0 +1,284 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest — P4 parking lot #11 (pós-PR #1663) — Timeline cross-source unified.
+ *
+ * Cobertura estrutural (file_get_contents + ReflectionClass) — garante que:
+ *  - SaleHistoryController::timelineUnified existe + assinatura correta
+ *  - Multi-tenant Tier 0 (ADR 0093): business_id em TODA query
+ *  - Permission gate sale.history.view
+ *  - Agrega 5 sources (fsm/payment/activity/comment/audit)
+ *  - Ordem cronológica reversa + limit 100
+ *  - Rota /api/sells/{id}/timeline-unified registrada com FQCN
+ *  - SaleTimeline.tsx aceita prop mode='fsm' | 'unified' + refreshKey
+ *  - Show.tsx wire-up: SaleTimeline mode unified + event listeners
+ *  - SaleSheet.tsx atualizado pra mode unified
+ *
+ * Refs:
+ *  - app/Http/Controllers/SaleHistoryController.php (método timelineUnified)
+ *  - routes/web.php (linha sells.timeline-unified)
+ *  - resources/js/Pages/Sells/_components/SaleTimeline.tsx
+ *  - resources/js/Pages/Sells/Show.tsx
+ *  - resources/js/Pages/Sells/_components/SaleSheet.tsx
+ *  - memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md (gap #11)
+ */
+
+const P4_CTRL_PATH = 'app/Http/Controllers/SaleHistoryController.php';
+const P4_ROUTES_PATH = 'routes/web.php';
+const P4_TIMELINE_TSX_PATH = 'resources/js/Pages/Sells/_components/SaleTimeline.tsx';
+const P4_SHOW_TSX_PATH = 'resources/js/Pages/Sells/Show.tsx';
+const P4_SHEET_TSX_PATH = 'resources/js/Pages/Sells/_components/SaleSheet.tsx';
+const P4_CSS_PATH = 'resources/css/sells-cowork-show.css';
+
+function p4Read(string $rel): string
+{
+    return file_get_contents(base_path($rel));
+}
+
+// ─── Controller: método existe + assinatura ────────────────────────────
+
+it('SaleHistoryController::timelineUnified existe + retorna JsonResponse', function () {
+    expect(method_exists(\App\Http\Controllers\SaleHistoryController::class, 'timelineUnified'))->toBeTrue();
+    $ref = new ReflectionMethod(\App\Http\Controllers\SaleHistoryController::class, 'timelineUnified');
+    $params = $ref->getParameters();
+    expect($params)->toHaveCount(2);
+    expect($params[0]->getName())->toBe('request');
+    expect($params[1]->getName())->toBe('id');
+    expect($params[1]->getType()?->getName())->toBe('int');
+    expect($ref->getReturnType()?->getName())->toBe(\Illuminate\Http\JsonResponse::class);
+});
+
+// ─── Multi-tenant Tier 0 (ADR 0093) ────────────────────────────────────
+
+it('timelineUnified aplica multi-tenant Tier 0 (business_id scope explícito)', function () {
+    $source = p4Read(P4_CTRL_PATH);
+    expect($source)
+        ->toContain("session()->get('user.business_id')")
+        ->toContain("Transaction::query()")
+        ->toContain("where('business_id', \$businessId)")
+        ->toContain("where('type', 'sell')");
+});
+
+it('timelineUnified retorna 404 se venda não existe ou cross-tenant', function () {
+    $source = p4Read(P4_CTRL_PATH);
+    expect($source)
+        ->toContain("'Venda não encontrada'")
+        ->toContain('], 404);');
+});
+
+it('timelineUnified retorna 401 se não autenticado e 403 sem permission', function () {
+    $source = p4Read(P4_CTRL_PATH);
+    expect($source)
+        ->toContain('auth()->check()')
+        ->toContain('Response::HTTP_UNAUTHORIZED')
+        ->toContain("can('sale.history.view')")
+        ->toContain('Response::HTTP_FORBIDDEN');
+});
+
+// ─── Agrega 5 sources ──────────────────────────────────────────────────
+
+it('timelineUnified agrega FSM transitions (SaleStageHistory)', function () {
+    $source = p4Read(P4_CTRL_PATH);
+    expect($source)
+        ->toContain('SaleStageHistory::query()')
+        ->toContain("'type' => 'fsm_transition'");
+});
+
+it('timelineUnified agrega payments (TransactionPayment)', function () {
+    $source = p4Read(P4_CTRL_PATH);
+    expect($source)
+        ->toContain('TransactionPayment::query()')
+        ->toContain("'type' => 'payment'");
+});
+
+it('timelineUnified agrega activities (Spatie/Activitylog)', function () {
+    $source = p4Read(P4_CTRL_PATH);
+    expect($source)
+        ->toContain('Activity::query()')
+        ->toContain("'type' => 'activity'");
+});
+
+it('timelineUnified detecta sale_item_comments via Schema::hasTable (skip silencioso)', function () {
+    $source = p4Read(P4_CTRL_PATH);
+    expect($source)
+        ->toContain("Schema::hasTable('sale_item_comments')")
+        ->toContain("'type' => 'comment'");
+});
+
+it('timelineUnified detecta audit_log via Schema::hasTable (skip silencioso)', function () {
+    $source = p4Read(P4_CTRL_PATH);
+    expect($source)
+        ->toContain("Schema::hasTable('audit_log')")
+        ->toContain("'type' => 'audit'");
+});
+
+// ─── Ordem cronológica reversa + limit 100 ─────────────────────────────
+
+it('timelineUnified ordena cronológico reverso e limita a 100', function () {
+    $source = p4Read(P4_CTRL_PATH);
+    expect($source)
+        ->toContain('sortByDesc')
+        ->toContain('->take(100)');
+});
+
+it('timelineUnified resolve user names em batch (1 query) anti N+1', function () {
+    $source = p4Read(P4_CTRL_PATH);
+    expect($source)
+        ->toContain("DB::table('users')")
+        ->toContain('whereIn(\'id\', $userIds)')
+        ->toContain('keyBy(\'id\')');
+});
+
+// ─── Payload format ────────────────────────────────────────────────────
+
+it('timelineUnified retorna shape { transaction_id, count, events[] }', function () {
+    $source = p4Read(P4_CTRL_PATH);
+    expect($source)
+        ->toContain("'transaction_id' => \$id")
+        ->toContain("'count' => \$finalEvents->count()")
+        ->toContain("'events' => \$finalEvents->values()");
+});
+
+it('timelineUnified event tem campos canônicos (type, occurred_at, user, icon, tone, title)', function () {
+    $source = p4Read(P4_CTRL_PATH);
+    expect($source)
+        ->toContain("'type' => \$e['type']")
+        ->toContain("'occurred_at' => \$e['occurred_at']")
+        ->toContain("'icon' => \$e['icon']")
+        ->toContain("'tone' => \$e['tone']")
+        ->toContain("'title' => \$e['title']");
+});
+
+// ─── Rota registrada com FQCN (ADR rule routes.md) ─────────────────────
+
+it('Rota /api/sells/{id}/timeline-unified registrada com FQCN', function () {
+    $source = p4Read(P4_ROUTES_PATH);
+    expect($source)
+        ->toContain("Route::get('/api/sells/{id}/timeline-unified'")
+        ->toContain('\App\Http\Controllers\SaleHistoryController::class')
+        ->toContain("'timelineUnified'")
+        ->toContain("->name('sells.timeline-unified')");
+});
+
+it('Rota sells.timeline-unified aparece em route:list', function () {
+    $routes = collect(\Illuminate\Support\Facades\Route::getRoutes()->getRoutes())
+        ->map(fn ($r) => $r->getName())
+        ->filter()
+        ->values()
+        ->toArray();
+    expect($routes)->toContain('sells.timeline-unified');
+});
+
+// ─── Frontend SaleTimeline.tsx ─────────────────────────────────────────
+
+it('SaleTimeline.tsx aceita prop opcional mode (fsm | unified) com default fsm', function () {
+    $source = p4Read(P4_TIMELINE_TSX_PATH);
+    expect($source)
+        ->toContain("mode?: 'fsm' | 'unified'")
+        ->toContain("mode = 'fsm'");
+});
+
+it('SaleTimeline.tsx aceita prop opcional refreshKey pra re-fetch externo', function () {
+    $source = p4Read(P4_TIMELINE_TSX_PATH);
+    expect($source)
+        ->toContain('refreshKey?: number')
+        ->toContain('refreshKey = 0');
+});
+
+it('SaleTimeline.tsx escolhe endpoint dinâmico por mode', function () {
+    $source = p4Read(P4_TIMELINE_TSX_PATH);
+    $dollar = '$';
+    expect($source)
+        ->toContain("`/api/sells/{$dollar}{saleId}/timeline-unified`")
+        ->toContain("`/api/sells/{$dollar}{saleId}/history`");
+});
+
+it('SaleTimeline.tsx tem tipos UnifiedEvent + UnifiedResponse + UnifiedEventType', function () {
+    $source = p4Read(P4_TIMELINE_TSX_PATH);
+    expect($source)
+        ->toContain('interface UnifiedEvent')
+        ->toContain('interface UnifiedResponse')
+        ->toContain('export type { UnifiedEvent, UnifiedResponse');
+});
+
+it('SaleTimeline.tsx render unified com avatar + icon + colorbar + tone', function () {
+    $source = p4Read(P4_TIMELINE_TSX_PATH);
+    expect($source)
+        ->toContain('sb-timeline-unified')
+        ->toContain('sb-timeline-avatar')
+        ->toContain('sb-timeline-colorbar')
+        ->toContain('sb-timeline-icon');
+});
+
+it('SaleTimeline.tsx tem empty state ilustrado com Inbox icon', function () {
+    $source = p4Read(P4_TIMELINE_TSX_PATH);
+    expect($source)
+        ->toContain('sb-timeline-empty')
+        ->toContain('Sem eventos ainda');
+});
+
+it('SaleTimeline.tsx tem loading skeleton 3 rows pulse pro mode unified', function () {
+    $source = p4Read(P4_TIMELINE_TSX_PATH);
+    expect($source)
+        ->toContain('sb-timeline-loading')
+        ->toContain('animate-pulse');
+});
+
+it('SaleTimeline.tsx tem formatRelative com pt-BR (agora/min/h/d)', function () {
+    $source = p4Read(P4_TIMELINE_TSX_PATH);
+    $d = '$';
+    expect($source)
+        ->toContain('formatRelative')
+        ->toContain("'agora'")
+        ->toContain("há {$d}{min}min")
+        ->toContain("há {$d}{hr}h")
+        ->toContain("há {$d}{day}d");
+});
+
+it('SaleTimeline.tsx fallback FSM-mode preservado (back-compat)', function () {
+    $source = p4Read(P4_TIMELINE_TSX_PATH);
+    expect($source)
+        ->toContain('Nenhuma transição registrada ainda')
+        ->toContain('via <strong className="text-foreground">{item.action.label}</strong>');
+});
+
+// ─── Wire-up Show.tsx ──────────────────────────────────────────────────
+
+it('Show.tsx importa SaleTimeline + usa mode="unified" + refreshKey', function () {
+    $source = p4Read(P4_SHOW_TSX_PATH);
+    expect($source)
+        ->toContain("import SaleTimeline from './_components/SaleTimeline'")
+        ->toContain('mode="unified"')
+        ->toContain('refreshKey={timelineRefreshKey}');
+});
+
+it('Show.tsx listener pra eventos venda-invoiced/paid/emitted-{nfe,nfse}', function () {
+    $source = p4Read(P4_SHOW_TSX_PATH);
+    expect($source)
+        ->toContain("'oimpresso:venda-invoiced'")
+        ->toContain("'oimpresso:venda-paid'")
+        ->toContain("'oimpresso:venda-emitted-nfe'")
+        ->toContain("'oimpresso:venda-emitted-nfse'")
+        ->toContain('setTimelineRefreshKey');
+});
+
+// ─── Wire-up SaleSheet.tsx ─────────────────────────────────────────────
+
+it('SaleSheet.tsx atualiza SaleTimeline pra mode unified', function () {
+    $source = p4Read(P4_SHEET_TSX_PATH);
+    expect($source)
+        ->toContain('<SaleTimeline saleId={data.id} enabled={open} mode="unified" />');
+});
+
+// ─── CSS tokens ────────────────────────────────────────────────────────
+
+it('sells-cowork-show.css tem tokens .sb-timeline-* scopados', function () {
+    $source = p4Read(P4_CSS_PATH);
+    expect($source)
+        ->toContain('.sells-cowork-show .sb-timeline-unified')
+        ->toContain('.sells-cowork-show .sb-timeline-event')
+        ->toContain('.sells-cowork-show .sb-timeline-avatar')
+        ->toContain('.sells-cowork-show .sb-timeline-colorbar');
+});


### PR DESCRIPTION
## Summary

Gap #11 do [r4 visual-comparison](memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md) — `SaleTimeline.tsx` hoje só mostra FSM transitions. Protótipo Cowork agrega FSM + payments + activities num único stream cronológico reverso. Este PR pluga o componente cross-source preservando back-compat.

- **Backend (`SaleHistoryController::timelineUnified`):** endpoint novo `GET /api/sells/{id}/timeline-unified` agregando 5 sources (`sale_stage_history` + `transaction_payments` + `activity_log` + `sale_item_comments` opcional + `audit_log` opcional). Multi-tenant Tier 0 (ADR 0093) com `business_id` em toda query + permission gate `sale.history.view` + sort cronológico reverso + limit 100 + resolve users em batch anti-N+1.
- **Frontend (`SaleTimeline.tsx` refator):** prop opcional `mode='fsm' | 'unified'` (default `'fsm'` — back-compat) + prop `refreshKey` pra re-fetch externo. Render unified com avatar circular (cor por hash do nome) + icon Lucide por tipo + colorbar tone à esquerda + time relativo pt-BR ("há 3h"/"há 2d") + empty state ilustrado + loading skeleton pulse.
- **Wire-up:** `Show.tsx` substitui seção "Atividades" por `SaleTimeline mode="unified"` + listener pros eventos `oimpresso:venda-{invoiced,paid,emitted-nfe,emitted-nfse}` que bumpam `refreshKey`. `SaleSheet.tsx` (drawer Index) passa `mode="unified"`.
- **CSS:** tokens `.sells-cowork-show .sb-timeline-*` scopados + print-mode override.

## Infra Contract

### 1. Happy path — endpoint novo (rota GET read-only, auth required)

A rota nova é `GET /api/sells/{id}/timeline-unified`. Behind auth — sem sessão retorna 401, sem permission retorna 403, com id de outra biz retorna 404.

```bash
$ curl -sv https://oimpresso.com/api/sells/25149/timeline-unified 2>&1 | grep '^< HTTP\|^< Location'
< HTTP/1.1 302
< Location: https://oimpresso.com/login
```

(302 → /login esperado sem cookies — middleware `auth` redireciona. Pós-login com permission `sale.history.view`, 200 + JSON `{transaction_id, count, events[]}`.)

### 2. Regression adjacent — rotas Sells irmãs que NÃO devem mudar

```bash
$ curl -sv https://oimpresso.com/api/sells/25149/history 2>&1 | grep '^< HTTP\|^< Location'
< HTTP/1.1 302
< Location: https://oimpresso.com/login

$ curl -sv https://oimpresso.com/api/sells/25149/fsm-actions 2>&1 | grep '^< HTTP\|^< Location'
< HTTP/1.1 302
< Location: https://oimpresso.com/login

$ curl -sv https://oimpresso.com/sells/25149/audit 2>&1 | grep '^< HTTP\|^< Location'
< HTTP/1.1 302
< Location: https://oimpresso.com/login
```

Todas as rotas Sells API irmãs continuam retornando 302 → /login sem cookies (sem regressão no auth middleware).

### 3. Environment delta — onde Pest local NÃO prova prod

- Pest local cobre estrutura (controller + rota + componente) — **NÃO** prova que LiteSpeed em prod serve o endpoint. Validação prod via `curl -sv` pós-deploy obrigatória.
- Endpoint usa eager-load Eloquent + `Schema::hasTable` — comportamento idêntico em qualquer engine SQL (validado contra MariaDB local).
- LSCache não afeta endpoint API (JSON sem header `Cache-Control public`).
- Sem mudança em middleware/.htaccess/Kernel — risk superfície zero pra cascata #1024/#1026/#1028.

Declarar: **"Pest local + smoke Herd NÃO provam prod. Validação em prod via `curl -sv` obrigatória pós-deploy."**

### 4. Smoke prod pós-deploy (preencher após merge + git pull Hostinger)

```bash
# Output real colado aqui, com timestamp:
$ curl -sv https://oimpresso.com/api/sells/25149/timeline-unified 2>&1 | grep '^< HTTP\|^< Location'
# (preencher pós-deploy)
```

| Caso | Esperado | Observado | OK |
|---|---|---|---|
| Happy path sem auth | `302 → /login` | (pós-deploy) | (preencher) |
| Adjacent `/history` | `302 → /login` | (pós-deploy) | (preencher) |
| Adjacent `/fsm-actions` | `302 → /login` | (pós-deploy) | (preencher) |

## Test plan

- [x] **TS strict typecheck:** `npx tsc --noEmit` zero erros novos nos arquivos modificados (SaleTimeline.tsx · Show.tsx · SaleSheet.tsx)
- [x] **Pest:** `tests/Feature/Sells/SellsTimelineUnifiedTest.php` — **28 passed / 81 assertions** (estrutural: assinatura + multi-tenant + 5 sources + ordem + limit + shape + rota FQCN + componente props + CSS tokens)
- [ ] **Smoke MCP browser (Wagner):** abrir `/sells/{id}` (Sells/Show) — confirmar seção "Histórico" carrega timeline unified com avatares + tone colorbar; abrir SaleSheet via Index — drawer mostra timeline unified; executar action FSM via `VdNextActionPanel` → confirmar timeline re-fetcha
- [ ] **Multi-tenant guard:** confirmar que tentar acessar `/api/sells/{id}/timeline-unified` com id de outra biz retorna 404

## Compat & rollback

- Modo `fsm` legado (`/api/sells/{id}/history`) **preservado integral** — qualquer consumer externo continua funcional.
- Endpoint `timeline-unified` é additive — não substitui `/history`.
- Tabelas `sale_item_comments` e `audit_log` são detectadas via `Schema::hasTable` (skip silencioso se ausentes hoje).
- Rollback: revert do commit deixa Show.tsx voltando à seção "Atividades" original (`detail.activities`).

## Diff

- 7 files · +929 / -35
- 28 testes estruturais (file_get_contents + ReflectionClass — padrão `SellsAuditTrailRealTest`)

Refs: P4 parking lot pós-PR #1663 · KB-9.75 Cowork bundle 2026-05-26

🤖 Generated with [Claude Code](https://claude.com/claude-code)