### PR TITLE
feat(sells): tab bar Dashboard | Insights Jana (KB-9.75 P5 parking lot)

### DIFF
--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -5,6 +5,9 @@
 /* Sells/Index Cowork visual — escopado em .sells-cowork (ver scripts/scope-sells-cowork-css.py) */
 @import "./sells-cowork.css";
 
+/* Sells Insights Jana view — KB-9.75 P5 parking lot tabs Dashboard|Insights (PR #1682) */
+@import "./sells-cowork-insights.css";
+
 /* Sells KB-9.75 NextActionPanel + validações fiscais BR (Cowork bundle 2026-05-26 P0 gaps #1/#5) */
 @import "./sells-kb975-next-action.css";
 

--- a/resources/css/sells-cowork-insights.css
+++ b/resources/css/sells-cowork-insights.css
@@ -1,0 +1,413 @@
+/* sells-cowork-insights.css — KB-9.75 P5 parking lot (PR #1682)
+ * Tokens .vd-insights-* pra view "Insights Jana" da tab bar Sells
+ * Escopado em .sells-cowork pra coexistir com legacy
+ * Refs:
+ *   - resources/js/Pages/Sells/_components/SellsInsightsView.tsx
+ *   - prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/chat-jana.css
+ */
+
+/* ============================================================
+ * Tabs bar topo Sells (Dashboard | Insights Jana)
+ * ============================================================ */
+
+.sells-cowork .vd-tabs-mode {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px;
+  background: oklch(0.96 0.005 250);
+  border-radius: 999px;
+  margin-top: 8px;
+}
+
+.sells-cowork .vd-tabs-mode-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  font-size: 12.5px;
+  font-weight: 500;
+  color: oklch(0.45 0.01 250);
+  background: transparent;
+  border: 0;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 120ms ease, color 120ms ease;
+}
+
+.sells-cowork .vd-tabs-mode-btn:hover {
+  background: oklch(0.93 0.005 250);
+  color: oklch(0.25 0.01 250);
+}
+
+.sells-cowork .vd-tabs-mode-btn.active {
+  background: oklch(1 0 0);
+  color: oklch(0.20 0.01 250);
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
+  font-weight: 600;
+}
+
+.sells-cowork .vd-tabs-mode-btn .vd-tabs-mode-ic {
+  font-size: 13px;
+  line-height: 1;
+}
+
+/* ============================================================
+ * Insights view container
+ * ============================================================ */
+
+.sells-cowork .vd-insights {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 16px 0;
+}
+
+/* ============================================================
+ * Brief diário (Jana)
+ * ============================================================ */
+
+.sells-cowork .vd-insights-brief {
+  background: linear-gradient(135deg, oklch(0.98 0.015 270), oklch(0.99 0.005 250));
+  border: 1px solid oklch(0.90 0.02 270);
+  border-radius: 12px;
+  padding: 20px 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
+.sells-cowork .vd-insights-brief-h {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.sells-cowork .vd-insights-brief-av {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  background: oklch(0.55 0.18 270);
+  color: #fff;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.sells-cowork .vd-insights-brief-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.sells-cowork .vd-insights-brief-meta b {
+  font-size: 14.5px;
+  font-weight: 600;
+  color: oklch(0.20 0.01 250);
+}
+
+.sells-cowork .vd-insights-brief-meta small {
+  font-size: 11.5px;
+  color: oklch(0.50 0.01 250);
+}
+
+.sells-cowork .vd-insights-brief-body {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sells-cowork .vd-insights-brief-body p {
+  margin: 0;
+  font-size: 14px;
+  line-height: 1.55;
+  color: oklch(0.25 0.01 250);
+}
+
+.sells-cowork .vd-insights-brief-body p strong {
+  font-weight: 600;
+  color: oklch(0.15 0.01 250);
+}
+
+.sells-cowork .vd-insights-anomaly {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 10px 12px;
+  background: oklch(0.97 0.04 28 / 0.4);
+  border-left: 3px solid oklch(0.55 0.18 28);
+  border-radius: 6px;
+  font-size: 13px;
+}
+
+.sells-cowork .vd-insights-anomaly-ic {
+  display: inline-flex;
+  color: oklch(0.55 0.18 28);
+  margin-top: 1px;
+  flex-shrink: 0;
+}
+
+.sells-cowork .vd-pos {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  color: oklch(0.50 0.14 145);
+  font-weight: 500;
+}
+
+.sells-cowork .vd-neg {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  color: oklch(0.50 0.18 25);
+  font-weight: 500;
+}
+
+/* Action chips */
+.sells-cowork .vd-insights-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 8px;
+}
+
+.sells-cowork .vd-insights-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 6px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  background: oklch(0.95 0.005 250);
+  color: oklch(0.30 0.01 250);
+  border: 1px solid oklch(0.90 0.005 250);
+  border-radius: 999px;
+  cursor: pointer;
+  transition: background 120ms ease;
+}
+
+.sells-cowork .vd-insights-chip:hover {
+  background: oklch(0.92 0.005 250);
+}
+
+.sells-cowork .vd-insights-chip.primary {
+  background: oklch(0.55 0.18 270);
+  color: #fff;
+  border-color: oklch(0.55 0.18 270);
+}
+
+.sells-cowork .vd-insights-chip.primary:hover {
+  background: oklch(0.48 0.18 270);
+}
+
+/* ============================================================
+ * Grid 2x2 análises
+ * ============================================================ */
+
+.sells-cowork .vd-insights-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 14px;
+}
+
+@media (max-width: 980px) {
+  .sells-cowork .vd-insights-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.sells-cowork .vd-insights-card {
+  background: oklch(1 0 0);
+  border: 1px solid oklch(0.92 0.005 250);
+  border-radius: 12px;
+  padding: 16px 18px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.sells-cowork .vd-insights-card-h {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.sells-cowork .vd-insights-card-ic {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.sells-cowork .vd-insights-card-h > div {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  flex: 1;
+}
+
+.sells-cowork .vd-insights-card-h b {
+  font-size: 13.5px;
+  font-weight: 600;
+  color: oklch(0.20 0.01 250);
+}
+
+.sells-cowork .vd-insights-card-h small {
+  font-size: 11px;
+  color: oklch(0.55 0.01 250);
+}
+
+.sells-cowork .vd-insights-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  font-size: 10.5px;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  border-radius: 999px;
+}
+
+.sells-cowork .vd-insights-pill.ok {
+  background: oklch(0.94 0.05 145);
+  color: oklch(0.40 0.14 145);
+}
+
+.sells-cowork .vd-insights-pill.warn {
+  background: oklch(0.94 0.05 75);
+  color: oklch(0.42 0.15 75);
+}
+
+.sells-cowork .vd-insights-pill.crit {
+  background: oklch(0.94 0.05 28);
+  color: oklch(0.42 0.18 28);
+}
+
+.sells-cowork .vd-insights-card-big {
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: oklch(0.20 0.01 250);
+  font-variant-numeric: tabular-nums;
+}
+
+/* Buckets de inadimplência */
+.sells-cowork .vd-insights-buckets {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.sells-cowork .vd-insights-bucket {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.sells-cowork .vd-insights-bucket-lbl {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 12px;
+}
+
+.sells-cowork .vd-insights-bucket-lbl span {
+  color: oklch(0.50 0.01 250);
+}
+
+.sells-cowork .vd-insights-bucket-lbl b {
+  font-weight: 600;
+  color: oklch(0.30 0.01 250);
+  font-variant-numeric: tabular-nums;
+}
+
+.sells-cowork .vd-insights-bucket-bar {
+  height: 6px;
+  background: oklch(0.96 0.005 250);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.sells-cowork .vd-insights-bucket-fill {
+  height: 100%;
+  background: linear-gradient(90deg, oklch(0.65 0.18 60), oklch(0.55 0.18 28));
+  border-radius: 3px;
+  transition: width 200ms ease;
+}
+
+/* Sparkline */
+.sells-cowork .vd-insights-spark {
+  height: 60px;
+  color: oklch(0.50 0.14 145);
+}
+
+.sells-cowork .vd-insights-spark svg {
+  width: 100%;
+  height: 100%;
+}
+
+/* Bars genéricas (top clientes, métodos) */
+.sells-cowork .vd-insights-bars {
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+}
+
+.sells-cowork .vd-insights-bar-row {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.sells-cowork .vd-insights-bar-lbl {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  font-size: 12px;
+}
+
+.sells-cowork .vd-insights-bar-lbl span {
+  color: oklch(0.35 0.01 250);
+  max-width: 70%;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sells-cowork .vd-insights-bar-lbl b {
+  font-weight: 600;
+  color: oklch(0.25 0.01 250);
+  font-variant-numeric: tabular-nums;
+}
+
+.sells-cowork .vd-insights-bar {
+  height: 6px;
+  background: oklch(0.96 0.005 250);
+  border-radius: 3px;
+  overflow: hidden;
+}
+
+.sells-cowork .vd-insights-bar-fill {
+  height: 100%;
+  background: oklch(0.55 0.13 240);
+  border-radius: 3px;
+  transition: width 200ms ease;
+}
+
+.sells-cowork .vd-insights-bar-fill.green {
+  background: oklch(0.55 0.12 155);
+}
+
+.sells-cowork .vd-insights-empty {
+  padding: 16px;
+  text-align: center;
+  font-size: 12.5px;
+  color: oklch(0.55 0.01 250);
+  font-style: italic;
+}
+
+.sells-cowork .vd-insights-foot {
+  margin: 4px 0 0;
+  font-size: 11.5px;
+  color: oklch(0.55 0.01 250);
+  font-style: italic;
+  text-align: center;
+}

--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -48,6 +48,7 @@ import SellsTabelaUnificada, {
   type SaleRow as UnifiedSaleRow,
 } from './_components/SellsTabelaUnificada';
 import SellsCheatSheet, { SELLS_INDEX_SHORTCUTS } from './_components/SellsCheatSheet';
+import SellsInsightsView from './_components/SellsInsightsView';
 
 // ──────────────────────────────────────────────────────────────
 // TIPOS
@@ -424,6 +425,9 @@ const SAVED_VIEWS: SavedView[] = [
 // MAIN — SellsIndex
 // ──────────────────────────────────────────────────────────────
 export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
+  // Auth user pra view Insights Jana (greeting "Bom dia, <nome>!").
+  const sharedPage = usePage<{ auth?: { user?: { name?: string } } }>();
+  const authUserName = sharedPage.props.auth?.user?.name;
   // Tier 0 multi-tenant: storage scoped per business_id (ver useBizStorage acima).
   const ls = useBizStorage();
 
@@ -470,6 +474,16 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
   useEffect(() => ls.set('visao_origem', visaoOrigem), [visaoOrigem]);
   // Branch tree expand/collapse state (não persiste — UX volátil).
   const [origemExpanded, setOrigemExpanded] = useState<boolean>(false);
+
+  // KB-9.75 P5 parking lot — tab bar topo Sells [Dashboard | Insights Jana].
+  // Mode "Analista IA" alterna view sem mudar rota — preserva filtros/state Index.
+  // Persistência Tier 0 multi-tenant: `oimpresso.sells.b{biz}.u{user}.view_mode`.
+  type ViewMode = 'dashboard' | 'insights';
+  const [viewMode, setViewMode] = useState<ViewMode>(() => {
+    const v = ls.get('view_mode', 'dashboard');
+    return (['dashboard', 'insights'] as const).includes(v as ViewMode) ? (v as ViewMode) : 'dashboard';
+  });
+  useEffect(() => ls.set('view_mode', viewMode), [viewMode]);
 
   // Data fetch state.
   const [rows, setRows] = useState<SaleRow[]>([]);
@@ -1059,6 +1073,29 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
                 'Pedidos · faturamento · NF-e/NFS-e'
               )}
             </p>
+            {/* KB-9.75 P5 — Tab bar Dashboard | Insights Jana.
+                Alterna view sem mudar rota; preserva filtros/state Index.
+                Persistência Tier 0 via `ls.view_mode`. */}
+            <div className="vd-tabs-mode" role="tablist" aria-label="Modo de visualização">
+              <button
+                type="button"
+                className={`vd-tabs-mode-btn ${viewMode === 'dashboard' ? 'active' : ''}`}
+                onClick={() => setViewMode('dashboard')}
+                role="tab"
+                aria-selected={viewMode === 'dashboard'}
+              >
+                <span className="vd-tabs-mode-ic">📊</span> Dashboard
+              </button>
+              <button
+                type="button"
+                className={`vd-tabs-mode-btn ${viewMode === 'insights' ? 'active' : ''}`}
+                onClick={() => setViewMode('insights')}
+                role="tab"
+                aria-selected={viewMode === 'insights'}
+              >
+                <span className="vd-tabs-mode-ic">✦</span> Insights Jana
+              </button>
+            </div>
           </div>
 
           <div className="os-head-r">
@@ -1071,6 +1108,25 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
           </div>
         </header>
 
+        {/* KB-9.75 P5 — Conditional render por viewMode.
+            Dashboard = toolbar + KPIs + table + pagination + bulk (legacy).
+            Insights Jana = SellsInsightsView com brief + 4 análises. */}
+        {viewMode === 'insights' ? (
+          <SellsInsightsView
+            sellKpis={props.sellKpis}
+            coworkAggregates={props.coworkAggregates}
+            rows={filtered.map((r) => ({
+              final_total: Number(r.final_total) || 0,
+              payment_status: r.payment_status ?? '',
+              sla_kind: r.sla_kind ?? '',
+              days_to_due: r.days_to_due ?? null,
+              customer_name: r.customer_name ?? null,
+              payment_method_label: r.payment_method_label ?? null,
+            }))}
+            userName={authUserName}
+          />
+        ) : (
+        <>
         {/* TOOLBAR linha 2: Foco group + Visões btn / Imprimir + Visões ▾ */}
         <div className="vd-toolbar">
           <div className="vd-toolbar-l">
@@ -1634,6 +1690,8 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
               ✕
             </button>
           </div>
+        )}
+        </>
         )}
 
         {/* CHEAT-SHEET (?) */}

--- a/resources/js/Pages/Sells/_components/SellsInsightsView.tsx
+++ b/resources/js/Pages/Sells/_components/SellsInsightsView.tsx
@@ -1,0 +1,382 @@
+// SellsInsightsView — view "Insights Jana" da tab bar Sells (PR #1682 · P5 parking lot).
+// Refs:
+//   - prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/chat-jana.jsx (canon visual)
+//   - memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md gap #13
+//
+// Mode "Analista IA" da rota Sells — mostra brief diário + 4 análises usando dados
+// agregados que já existem no payload (sellKpis + coworkAggregates + rows atuais).
+// MVP enxuto. Próxima onda plugará agentes Brain B Jana real (ADR 0035).
+
+import type { ReactNode } from 'react';
+import { AlertCircle, TrendingUp, TrendingDown, MessageSquare, Sparkles } from 'lucide-react';
+
+export interface InsightsViewProps {
+  sellKpis: {
+    total: number;
+    paid: number;
+    due: number;
+    partial: number;
+    overdue: number;
+  };
+  coworkAggregates?: {
+    sparkline?: number[];
+    deltaRevenueVsYesterday?: number | null;
+    deltaTicketVsLastWeek?: number | null;
+    topSeller?: { name: string; total: number } | null;
+    pixHojeTotal?: number;
+    faturadoHojeTotal?: number;
+  };
+  /** Vendas atuais (já filtradas no Index pelo saved view + status pill). */
+  rows: Array<{
+    final_total: number;
+    payment_status: string;
+    sla_kind: string;
+    days_to_due: number | null;
+    customer_name: string | null;
+    payment_method_label: string | null;
+  }>;
+  userName?: string;
+}
+
+const fmtBRL = (n: number) =>
+  n.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+
+const fmtShort = (n: number) =>
+  n >= 1000 ? 'R$ ' + (n / 1000).toFixed(1).replace('.', ',') + 'k' : fmtBRL(n);
+
+const greeting = (): string => {
+  const h = new Date().getHours();
+  if (h < 12) return 'Bom dia';
+  if (h < 18) return 'Boa tarde';
+  return 'Boa noite';
+};
+
+export default function SellsInsightsView({
+  sellKpis,
+  coworkAggregates,
+  rows,
+  userName,
+}: InsightsViewProps): ReactNode {
+  // Brief calculations
+  const faturadoHoje = coworkAggregates?.faturadoHojeTotal ?? 0;
+  const pixHoje = coworkAggregates?.pixHojeTotal ?? 0;
+  const deltaRev = coworkAggregates?.deltaRevenueVsYesterday ?? null;
+  const deltaTicket = coworkAggregates?.deltaTicketVsLastWeek ?? null;
+  // sellKpis.total = nº total vendas; sellKpis.due = pendentes (não pagas).
+  // Usados no brief topo pra contextualizar volume.
+  const totalVendas = sellKpis?.total ?? rows.length;
+  const totalPendentes = sellKpis?.due ?? rows.filter((r) => r.payment_status !== 'paid').length;
+  const overdueCount = rows.filter((r) => r.sla_kind === 'overdue').length;
+  const overdueValue = rows
+    .filter((r) => r.sla_kind === 'overdue')
+    .reduce((acc, r) => acc + (Number(r.final_total) || 0), 0);
+
+  // Inadimplência buckets (paridade prototipo Cowork chat-jana.jsx)
+  const ageingBuckets = (() => {
+    const buckets = { '0-30d': 0, '30-90d': 0, '90-365d': 0, '>365d': 0 };
+    rows
+      .filter((r) => r.sla_kind === 'overdue' && r.days_to_due !== null)
+      .forEach((r) => {
+        const days = Math.abs(r.days_to_due as number);
+        const v = Number(r.final_total) || 0;
+        if (days <= 30) buckets['0-30d'] += v;
+        else if (days <= 90) buckets['30-90d'] += v;
+        else if (days <= 365) buckets['90-365d'] += v;
+        else buckets['>365d'] += v;
+      });
+    return buckets;
+  })();
+  const ageingTotal = Object.values(ageingBuckets).reduce((a, b) => a + b, 0);
+
+  // Métodos pagamento
+  const methodsAgg = (() => {
+    const m: Record<string, number> = {};
+    rows.forEach((r) => {
+      const k = r.payment_method_label || 'Outros';
+      m[k] = (m[k] ?? 0) + (Number(r.final_total) || 0);
+    });
+    return Object.entries(m)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5);
+  })();
+  const methodsTotal = methodsAgg.reduce((a, [, v]) => a + v, 0);
+
+  // Top clientes
+  const topClientes = (() => {
+    const m: Record<string, number> = {};
+    rows.forEach((r) => {
+      const k = r.customer_name || 'Cliente padrão';
+      m[k] = (m[k] ?? 0) + (Number(r.final_total) || 0);
+    });
+    return Object.entries(m)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 5);
+  })();
+  const topClientesTotal = topClientes.reduce((a, [, v]) => a + v, 0);
+
+  // Sparkline 30d
+  const sparkline = coworkAggregates?.sparkline ?? [];
+  const sparkMax = Math.max(...sparkline, 1);
+
+  return (
+    <div className="vd-insights">
+      {/* Brief diário · Jana */}
+      <section className="vd-insights-brief">
+        <header className="vd-insights-brief-h">
+          <div className="vd-insights-brief-av">
+            <Sparkles size={18} />
+          </div>
+          <div className="vd-insights-brief-meta">
+            <b>Jana · Analista IA</b>
+            <small>
+              {greeting()}{userName ? `, ${userName.split(' ')[0]}` : ''} ·{' '}
+              {new Date().toLocaleDateString('pt-BR', {
+                day: '2-digit',
+                month: 'long',
+                year: 'numeric',
+              })}
+            </small>
+          </div>
+        </header>
+
+        <div className="vd-insights-brief-body">
+          <p>
+            <strong>{totalVendas}</strong> vendas no período
+            {totalPendentes > 0 && (
+              <>
+                {' · '}
+                <strong>{totalPendentes}</strong> pendentes
+              </>
+            )}
+            . Hoje somou <strong>{fmtShort(faturadoHoje)}</strong>
+            {deltaRev !== null && (
+              <>
+                {' '}
+                <span className={deltaRev >= 0 ? 'vd-pos' : 'vd-neg'}>
+                  {deltaRev >= 0 ? <TrendingUp size={11} /> : <TrendingDown size={11} />}
+                  {deltaRev >= 0 ? '+' : ''}
+                  {deltaRev}% vs ontem
+                </span>
+              </>
+            )}
+            {pixHoje > 0 && faturadoHoje > 0 && (
+              <>
+                {' · PIX'} <strong>{fmtShort(pixHoje)}</strong>{' '}
+                <small>
+                  ({Math.round((pixHoje / faturadoHoje) * 100)}% imediato)
+                </small>
+              </>
+            )}
+            .
+          </p>
+
+          {overdueCount > 0 && (
+            <p className="vd-insights-anomaly">
+              <span className="vd-insights-anomaly-ic">
+                <AlertCircle size={13} />
+              </span>
+              <strong className="vd-neg">{fmtShort(overdueValue)}</strong> em{' '}
+              <strong>{overdueCount} vendas vencidas</strong>. Top devedor:{' '}
+              {(() => {
+                const top = rows
+                  .filter((r) => r.sla_kind === 'overdue')
+                  .sort((a, b) => (b.final_total || 0) - (a.final_total || 0))[0];
+                return top ? (
+                  <>
+                    <strong>{top.customer_name || 'Cliente padrão'}</strong> ({fmtShort(top.final_total)})
+                  </>
+                ) : (
+                  '—'
+                );
+              })()}
+              .
+            </p>
+          )}
+
+          {deltaTicket !== null && Math.abs(deltaTicket) >= 5 && (
+            <p className="vd-insights-anomaly">
+              <span className="vd-insights-anomaly-ic">
+                <AlertCircle size={13} />
+              </span>
+              Ticket médio{' '}
+              <strong className={deltaTicket >= 0 ? 'vd-pos' : 'vd-neg'}>
+                {deltaTicket >= 0 ? '+' : ''}
+                {deltaTicket}%
+              </strong>{' '}
+              vs semana passada — investigar mix de produto.
+            </p>
+          )}
+
+          <div className="vd-insights-chips">
+            {overdueCount > 0 && (
+              <button type="button" className="vd-insights-chip primary">
+                <MessageSquare size={11} /> Disparar régua WhatsApp pros {overdueCount} atrasados
+              </button>
+            )}
+            <button type="button" className="vd-insights-chip">
+              📋 Ver top devedores
+            </button>
+            <button type="button" className="vd-insights-chip">
+              🔍 Investigar queda ticket médio
+            </button>
+          </div>
+        </div>
+      </section>
+
+      {/* 4 análises grid 2x2 */}
+      <div className="vd-insights-grid">
+        {/* Análise 1: Inadimplência buckets */}
+        <section className="vd-insights-card">
+          <header className="vd-insights-card-h">
+            <span className="vd-insights-card-ic">🚨</span>
+            <div>
+              <b>Inadimplência</b>
+              <small>{overdueCount} vendas vencidas</small>
+            </div>
+            <span className={`vd-insights-pill ${overdueCount > 0 ? 'crit' : 'ok'}`}>
+              {overdueCount > 0 ? 'CRÍTICO' : 'OK'}
+            </span>
+          </header>
+          <div className="vd-insights-card-big">
+            <span className="vd-neg">{fmtShort(ageingTotal)}</span>
+          </div>
+          <div className="vd-insights-buckets">
+            {Object.entries(ageingBuckets).map(([label, v]) => (
+              <div key={label} className="vd-insights-bucket">
+                <div className="vd-insights-bucket-lbl">
+                  <span>{label}</span>
+                  <b>{fmtShort(v)}</b>
+                </div>
+                <div className="vd-insights-bucket-bar">
+                  <div
+                    className="vd-insights-bucket-fill"
+                    style={{
+                      width: ageingTotal > 0 ? `${(v / ageingTotal) * 100}%` : '0%',
+                    }}
+                  />
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+
+        {/* Análise 2: Faturamento sparkline 30d */}
+        <section className="vd-insights-card">
+          <header className="vd-insights-card-h">
+            <span className="vd-insights-card-ic">📈</span>
+            <div>
+              <b>Faturamento</b>
+              <small>30 dias</small>
+            </div>
+            {deltaRev !== null && (
+              <span className={`vd-insights-pill ${deltaRev >= 0 ? 'ok' : 'warn'}`}>
+                {deltaRev >= 0 ? '+' : ''}
+                {deltaRev}% vs ontem
+              </span>
+            )}
+          </header>
+          <div className="vd-insights-card-big">
+            <span className="vd-pos">
+              {fmtShort(sparkline.reduce((a, b) => a + b, 0))}
+            </span>
+          </div>
+          <div className="vd-insights-spark">
+            {sparkline.length === 0 ? (
+              <div className="vd-insights-empty">Carregando sparkline…</div>
+            ) : (
+              <svg viewBox={`0 0 ${sparkline.length * 4} 40`} preserveAspectRatio="none">
+                <polyline
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.5"
+                  points={sparkline
+                    .map((v, i) => `${i * 4},${40 - (v / sparkMax) * 38 - 1}`)
+                    .join(' ')}
+                />
+              </svg>
+            )}
+          </div>
+        </section>
+
+        {/* Análise 3: Top clientes Pareto */}
+        <section className="vd-insights-card">
+          <header className="vd-insights-card-h">
+            <span className="vd-insights-card-ic">🎯</span>
+            <div>
+              <b>Top 5 clientes</b>
+              <small>concentração</small>
+            </div>
+          </header>
+          <div className="vd-insights-card-big">
+            <span>{topClientes.length}</span>
+          </div>
+          <div className="vd-insights-bars">
+            {topClientes.length === 0 ? (
+              <div className="vd-insights-empty">Sem dados de clientes</div>
+            ) : (
+              topClientes.map(([name, value]) => (
+                <div key={name} className="vd-insights-bar-row">
+                  <div className="vd-insights-bar-lbl">
+                    <span title={name}>{name.slice(0, 28)}</span>
+                    <b>{fmtShort(value)}</b>
+                  </div>
+                  <div className="vd-insights-bar">
+                    <div
+                      className="vd-insights-bar-fill"
+                      style={{
+                        width: topClientesTotal > 0 ? `${(value / topClientesTotal) * 100}%` : '0%',
+                      }}
+                    />
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </section>
+
+        {/* Análise 4: Métodos de pagamento */}
+        <section className="vd-insights-card">
+          <header className="vd-insights-card-h">
+            <span className="vd-insights-card-ic">💳</span>
+            <div>
+              <b>Métodos de pagamento</b>
+              <small>top {methodsAgg.length}</small>
+            </div>
+          </header>
+          <div className="vd-insights-card-big">
+            <span>{fmtShort(methodsTotal)}</span>
+          </div>
+          <div className="vd-insights-bars">
+            {methodsAgg.length === 0 ? (
+              <div className="vd-insights-empty">Sem pagamentos registrados</div>
+            ) : (
+              methodsAgg.map(([method, value]) => (
+                <div key={method} className="vd-insights-bar-row">
+                  <div className="vd-insights-bar-lbl">
+                    <span>{method}</span>
+                    <b>
+                      {methodsTotal > 0 ? Math.round((value / methodsTotal) * 100) : 0}%
+                    </b>
+                  </div>
+                  <div className="vd-insights-bar">
+                    <div
+                      className="vd-insights-bar-fill green"
+                      style={{
+                        width: methodsTotal > 0 ? `${(value / methodsTotal) * 100}%` : '0%',
+                      }}
+                    />
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </section>
+      </div>
+
+      <p className="vd-insights-foot">
+        💡 Insights baseados em vendas filtradas atual + agregados 30d.
+        Próximas ondas: ações HITL (régua WhatsApp · investigar anomalias) + agentes Brain B Jana real.
+      </p>
+    </div>
+  );
+}

--- a/tests/Feature/Sells/SellsTabsViewModeTest.php
+++ b/tests/Feature/Sells/SellsTabsViewModeTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest — KB-9.75 P5 parking lot · Tab bar Sells [Dashboard | Insights Jana].
+ *
+ * Cobertura estrutural (segue pattern SellsCommissionColumnTest, sem boot DB):
+ *   - Index.tsx tem estado viewMode persistido em ls Tier 0
+ *   - Tab bar markup presente (.vd-tabs-mode + 2 botões)
+ *   - Conditional render: viewMode='insights' renderiza <SellsInsightsView/>
+ *   - Componente SellsInsightsView.tsx existe + brief diário Jana + 4 análises
+ *   - CSS sells-cowork-insights.css importado no inertia.css
+ *
+ * Refs:
+ *   - resources/js/Pages/Sells/Index.tsx
+ *   - resources/js/Pages/Sells/_components/SellsInsightsView.tsx
+ *   - resources/css/sells-cowork-insights.css
+ *   - resources/css/inertia.css
+ *   - memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md gap #13
+ */
+
+const TABS_INDEX_TSX_PATH = 'resources/js/Pages/Sells/Index.tsx';
+const TABS_INSIGHTS_VIEW_PATH = 'resources/js/Pages/Sells/_components/SellsInsightsView.tsx';
+const TABS_INSIGHTS_CSS_PATH = 'resources/css/sells-cowork-insights.css';
+const TABS_INERTIA_CSS_PATH = 'resources/css/inertia.css';
+
+function tabsReadIndexTsx(): string
+{
+    return file_get_contents(base_path(TABS_INDEX_TSX_PATH));
+}
+
+function tabsReadInsightsView(): string
+{
+    return file_get_contents(base_path(TABS_INSIGHTS_VIEW_PATH));
+}
+
+function tabsReadInsightsCss(): string
+{
+    return file_get_contents(base_path(TABS_INSIGHTS_CSS_PATH));
+}
+
+function tabsReadInertiaCss(): string
+{
+    return file_get_contents(base_path(TABS_INERTIA_CSS_PATH));
+}
+
+// ─── Index.tsx: estado viewMode ─────────────────────────────────────────────
+
+it('Index.tsx declara estado viewMode com persistência ls Tier 0', function () {
+    $src = tabsReadIndexTsx();
+    expect($src)
+        ->toContain("type ViewMode = 'dashboard' | 'insights'")
+        ->toContain("useState<ViewMode>")
+        ->toContain("ls.get('view_mode', 'dashboard')")
+        ->toContain("ls.set('view_mode', viewMode)");
+});
+
+// ─── Index.tsx: tab bar markup ──────────────────────────────────────────────
+
+it('Index.tsx renderiza tab bar com 2 botões Dashboard/Insights Jana', function () {
+    $src = tabsReadIndexTsx();
+    expect($src)
+        ->toContain('className="vd-tabs-mode"')
+        ->toContain("setViewMode('dashboard')")
+        ->toContain("setViewMode('insights')")
+        ->toContain('Dashboard')
+        ->toContain('Insights Jana');
+});
+
+it('Index.tsx tab buttons têm semântica role=tab + aria-selected', function () {
+    $src = tabsReadIndexTsx();
+    expect($src)
+        ->toContain('role="tab"')
+        ->toContain("aria-selected={viewMode === 'dashboard'}")
+        ->toContain("aria-selected={viewMode === 'insights'}");
+});
+
+// ─── Index.tsx: conditional render ──────────────────────────────────────────
+
+it('Index.tsx faz conditional render do SellsInsightsView quando viewMode=insights', function () {
+    $src = tabsReadIndexTsx();
+    expect($src)
+        ->toContain("viewMode === 'insights' ? (")
+        ->toContain('<SellsInsightsView')
+        ->toContain("import SellsInsightsView from './_components/SellsInsightsView'");
+});
+
+// ─── SellsInsightsView component ────────────────────────────────────────────
+
+it('SellsInsightsView.tsx existe com props canônicas', function () {
+    $src = tabsReadInsightsView();
+    expect($src)
+        ->toContain('export interface InsightsViewProps')
+        ->toContain('sellKpis:')
+        ->toContain('coworkAggregates?:')
+        ->toContain('rows:')
+        ->toContain('export default function SellsInsightsView');
+});
+
+it('SellsInsightsView renderiza brief diário Jana + 4 análises grid', function () {
+    $src = tabsReadInsightsView();
+    expect($src)
+        ->toContain('vd-insights-brief')
+        ->toContain('vd-insights-grid')
+        ->toContain('Jana · Analista IA')
+        // 4 análises
+        ->toContain('Inadimplência')
+        ->toContain('Faturamento')
+        ->toContain('Top 5 clientes')
+        ->toContain('Métodos de pagamento');
+});
+
+it('SellsInsightsView trata empty states sem crash', function () {
+    $src = tabsReadInsightsView();
+    expect($src)
+        // Sparkline carregando
+        ->toContain('Carregando sparkline')
+        // Sem dados de clientes
+        ->toContain('Sem dados de clientes')
+        // Sem pagamentos
+        ->toContain('Sem pagamentos registrados');
+});
+
+// ─── CSS tokens ─────────────────────────────────────────────────────────────
+
+it('sells-cowork-insights.css define tokens .vd-tabs-mode-* + .vd-insights-*', function () {
+    $src = tabsReadInsightsCss();
+    expect($src)
+        ->toContain('.sells-cowork .vd-tabs-mode')
+        ->toContain('.sells-cowork .vd-tabs-mode-btn')
+        ->toContain('.sells-cowork .vd-tabs-mode-btn.active')
+        ->toContain('.sells-cowork .vd-insights')
+        ->toContain('.sells-cowork .vd-insights-brief')
+        ->toContain('.sells-cowork .vd-insights-grid')
+        ->toContain('.sells-cowork .vd-insights-card')
+        ->toContain('.sells-cowork .vd-insights-bucket');
+});
+
+it('inertia.css importa sells-cowork-insights.css', function () {
+    $src = tabsReadInertiaCss();
+    expect($src)->toContain('sells-cowork-insights.css');
+});
+
+it('sells-cowork-insights.css escopado em .sells-cowork (não vaza fora)', function () {
+    $src = tabsReadInsightsCss();
+    // Cada regra .vd-* prefixada por .sells-cowork
+    expect(preg_match_all('/^\.vd-/m', $src))->toBe(0);
+});


### PR DESCRIPTION
## Summary

- Tab bar pill no header Sells/Index [Dashboard | Insights Jana] — alterna view sem mudar rota
- Novo componente SellsInsightsView: brief diário Jana + 4 análises grid 2x2 (Inadimplência buckets · Faturamento sparkline · Top 5 clientes · Métodos pagamento)
- Persistência ls Tier 0 (`oimpresso.sells.b{biz}.u{user}.view_mode`)
- CSS escopado `.sells-cowork` (zero vazamento)

## Context

Última pendência do KB-9.75 parking lot — Sells r4 visual comparison (2026-05-26) gap #13. Prototipo Cowork chat-jana 2026-05-26 introduziu mode "Analista IA" dashboard-style com insights agregados acionáveis em vez de lista tática.

Reusa agregados que já vêm no payload (`sellKpis` + `coworkAggregates` + `rows` filtradas) — zero novo backend.

Larissa @ ROTA LIVRE biz=4 reportou 2026-05-21 querer "visão de gestor" do faturamento (ADR 0105 sinal qualificado).

## Test plan

- [x] 10 Pest tests structural (passam local — `tests/Feature/Sells/SellsTabsViewModeTest.php`)
- [x] `npm run build:inertia` OK (build sem erro)
- [x] TS errors em Index.tsx são pre-existing (DollarSign/FileText/QuickPaymentPopover unused — não introduzidos por este PR)
- [ ] Smoke prod pós-merge: clicar "Insights Jana" → renderiza brief + 4 cards; clicar "Dashboard" → volta legacy; reload mantém escolha
- [ ] Verificar com biz=1 (WR2) e biz=4 (ROTA LIVRE) sem cross-talk de ls

## Multi-tenant Tier 0 (ADR 0093)

- ls.view_mode escopado por `b{biz}.u{user}` via useBizStorage (preexistente)
- componente lê só props já isoladas; nenhum fetch novo

## Próxima onda

Action chips HITL (régua WhatsApp + investigar anomalia) ainda são placeholder visual — V2 plugará Brain B Jana real (ADR 0035) com mutations endpoint.

Refs: KB-9.75 parking lot P5 · `memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md` gap #13 · `prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/chat-jana.jsx` · ADR 0104 MWART · ADR 0093 Multi-tenant Tier 0 · ADR 0035 stack IA Jana

🤖 Generated with [Claude Code](https://claude.com/claude-code)