### PR TITLE
feat(sells): JanaCockpit V2 — fecha 5 gaps r5 (header + KPIs + H2 + Ações + brief)

### DIFF
--- a/resources/css/sells-cowork-insights.css
+++ b/resources/css/sells-cowork-insights.css
@@ -411,3 +411,406 @@
   font-style: italic;
   text-align: center;
 }
+
+/* ============================================================
+ * V2 · Onda gaps r5 (PR #1685) — header dedicado + KPIs Jana + H2 + Ações
+ * Refs:
+ *   - prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/chat-jana.css
+ *   - memory/requisitos/Sells/Sells-r5-cowork-vs-prod-2026-05-26.md
+ * ============================================================ */
+
+/* ── GAP 3 — JanaHeader dedicado (avatar grande + tenant breadcrumb) ── */
+.sells-cowork .vd-insights-jh {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-bottom: 14px;
+}
+
+.sells-cowork .vd-insights-jh-l {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+  min-width: 0;
+}
+
+.sells-cowork .vd-insights-jh-av {
+  width: 44px;
+  height: 44px;
+  border-radius: 10px;
+  display: grid;
+  place-items: center;
+  background: linear-gradient(135deg, oklch(0.62 0.18 285), oklch(0.48 0.20 280));
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.sells-cowork .vd-insights-jh-id h2 {
+  margin: 0;
+  font-size: 19px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: oklch(0.18 0.01 250);
+}
+
+.sells-cowork .vd-insights-jh-id h2 .dot {
+  color: oklch(0.55 0.01 250);
+  margin: 0 2px;
+}
+
+.sells-cowork .vd-insights-jh-id p {
+  margin: 2px 0 0;
+  font-size: 11.5px;
+  color: oklch(0.55 0.01 250);
+  font-family: ui-monospace, SFMono-Regular, monospace;
+  letter-spacing: 0.02em;
+}
+
+.sells-cowork .vd-insights-jh-tenant {
+  font-weight: 600;
+  color: oklch(0.30 0.01 250);
+}
+
+.sells-cowork .vd-insights-jh-sep {
+  margin: 0 6px;
+  opacity: 0.4;
+}
+
+.sells-cowork .vd-insights-jh-r {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-shrink: 0;
+}
+
+.sells-cowork .vd-insights-jh-updated {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  color: oklch(0.40 0.01 250);
+  margin-right: 6px;
+}
+
+.sells-cowork .vd-insights-jh-updated .d {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: oklch(0.55 0.16 145);
+}
+
+.sells-cowork .vd-insights-jh-btn {
+  appearance: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid oklch(0.90 0.005 250);
+  background: #fff;
+  color: oklch(0.20 0.01 250);
+  font: inherit;
+  font-size: 12px;
+  padding: 6px 12px;
+  border-radius: 7px;
+  transition: background 120ms ease, border-color 120ms ease;
+}
+
+.sells-cowork .vd-insights-jh-btn.ghost {
+  background: transparent;
+}
+
+.sells-cowork .vd-insights-jh-btn:hover {
+  background: oklch(0.97 0.005 250);
+  border-color: oklch(0.85 0.005 250);
+}
+
+.sells-cowork .vd-insights-jh-btn.dark {
+  background: oklch(0.18 0.01 250);
+  color: #fff;
+  border-color: oklch(0.18 0.01 250);
+}
+
+.sells-cowork .vd-insights-jh-btn.dark:hover {
+  background: oklch(0.12 0.01 250);
+  border-color: oklch(0.12 0.01 250);
+}
+
+/* ── GAP 4 — Brief header refinements (📅 + IA pill + Ouvir áudio) ── */
+.sells-cowork .vd-insights-brief-h-l {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: oklch(0.40 0.01 250);
+}
+
+.sells-cowork .vd-insights-brief-h-l b {
+  color: oklch(0.18 0.01 250);
+  font-weight: 600;
+}
+
+.sells-cowork .vd-insights-brief-h-l .sep {
+  margin: 0 4px;
+  opacity: 0.5;
+}
+
+.sells-cowork .vd-insights-pill.ia {
+  background: oklch(0.94 0.05 285);
+  color: oklch(0.48 0.20 280);
+}
+
+.sells-cowork .vd-insights-audio {
+  appearance: none;
+  border: 0;
+  background: transparent;
+  margin-left: auto;
+  font: inherit;
+  font-size: 12px;
+  color: oklch(0.40 0.01 250);
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 6px;
+  border-radius: 4px;
+  transition: color 120ms ease;
+}
+
+.sells-cowork .vd-insights-audio:hover {
+  color: oklch(0.48 0.20 280);
+  background: oklch(0.96 0.02 280 / 0.3);
+}
+
+.sells-cowork .vd-insights-brief-greet strong {
+  font-size: 14px;
+}
+
+/* ── GAP 1 — KPIs row dedicado Jana (4 cards próprios) ── */
+.sells-cowork .vd-insights-kpis {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 18px;
+}
+
+@media (max-width: 980px) {
+  .sells-cowork .vd-insights-kpis {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+.sells-cowork .vd-insights-kpi {
+  background: #fff;
+  border: 1px solid oklch(0.92 0.005 250);
+  border-radius: 10px;
+  padding: 12px 14px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.sells-cowork .vd-insights-kpi.emph {
+  border-color: oklch(0.85 0.08 28);
+  background: oklch(0.99 0.015 28);
+}
+
+.sells-cowork .vd-insights-kpi-h {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: oklch(0.55 0.01 250);
+  margin-bottom: 4px;
+}
+
+.sells-cowork .vd-insights-kpi-ic {
+  font-size: 14px;
+  opacity: 0.85;
+}
+
+.sells-cowork .vd-insights-kpi-v {
+  font-size: 22px;
+  font-weight: 700;
+  letter-spacing: -0.02em;
+  color: oklch(0.18 0.01 250);
+  font-variant-numeric: tabular-nums;
+}
+
+.sells-cowork .vd-insights-kpi-v.red {
+  color: oklch(0.50 0.18 25);
+}
+
+.sells-cowork .vd-insights-kpi-d {
+  font-size: 11px;
+  color: oklch(0.55 0.01 250);
+}
+
+.sells-cowork .vd-insights-kpi-d.down {
+  color: oklch(0.50 0.18 25);
+}
+
+.sells-cowork .vd-insights-kpi-d.up {
+  color: oklch(0.50 0.14 145);
+}
+
+.sells-cowork .vd-insights-kpi-d.info {
+  color: oklch(0.48 0.13 240);
+}
+
+/* ── GAP 5 — H2 separadores hierárquicos ── */
+.sells-cowork .vd-insights-h2 {
+  margin: 6px 0 10px;
+  font-size: 11px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: oklch(0.55 0.01 250);
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.sells-cowork .vd-insights-h2-ic {
+  font-size: 14px;
+}
+
+/* Sparkline range labels (D-N → hoje) */
+.sells-cowork .vd-insights-spark-range {
+  display: flex;
+  justify-content: space-between;
+  font-size: 10px;
+  color: oklch(0.55 0.01 250);
+  font-variant-numeric: tabular-nums;
+  margin-top: 2px;
+}
+
+/* ── GAP 2 — Lista de ações sugeridas (AcaoRow) ── */
+.sells-cowork .vd-insights-acoes {
+  background: #fff;
+  border: 1px solid oklch(0.92 0.005 250);
+  border-radius: 12px;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  margin-bottom: 18px;
+}
+
+.sells-cowork .vd-insights-acao {
+  display: grid;
+  grid-template-columns: 40px 1fr auto;
+  gap: 14px;
+  align-items: center;
+  padding: 12px 16px;
+  border-bottom: 1px solid oklch(0.96 0.005 250);
+  transition: background 120ms ease;
+}
+
+.sells-cowork .vd-insights-acao:last-child {
+  border-bottom: 0;
+}
+
+.sells-cowork .vd-insights-acao.tone-rose {
+  background: linear-gradient(90deg, oklch(0.98 0.025 28) 0%, #fff 80%);
+}
+
+.sells-cowork .vd-insights-acao.tone-violet {
+  background: linear-gradient(90deg, oklch(0.97 0.03 285) 0%, #fff 80%);
+}
+
+.sells-cowork .vd-insights-acao.tone-peach {
+  background: linear-gradient(90deg, oklch(0.98 0.04 70) 0%, #fff 80%);
+}
+
+.sells-cowork .vd-insights-acao.tone-grey {
+  background: linear-gradient(90deg, oklch(0.97 0.005 250) 0%, #fff 80%);
+}
+
+.sells-cowork .vd-insights-acao-ic {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  display: grid;
+  place-items: center;
+  background: #fff;
+  border: 1px solid oklch(0.92 0.005 250);
+  font-size: 16px;
+  color: oklch(0.30 0.01 250);
+}
+
+.sells-cowork .vd-insights-acao-text b {
+  display: block;
+  font-size: 13px;
+  font-weight: 600;
+  color: oklch(0.18 0.01 250);
+  line-height: 1.3;
+}
+
+.sells-cowork .vd-insights-acao-text small {
+  display: block;
+  font-size: 11.5px;
+  color: oklch(0.55 0.01 250);
+  margin-top: 2px;
+}
+
+/* CTAs (botões coloridos) */
+.sells-cowork .vd-insights-cta {
+  appearance: none;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font: inherit;
+  font-size: 12px;
+  font-weight: 600;
+  padding: 7px 16px;
+  border-radius: 7px;
+  border: 0;
+  color: #fff;
+  white-space: nowrap;
+  transition: background 120ms ease;
+}
+
+.sells-cowork .vd-insights-cta.danger {
+  background: oklch(0.55 0.18 25);
+}
+
+.sells-cowork .vd-insights-cta.danger:hover {
+  background: oklch(0.48 0.18 25);
+}
+
+.sells-cowork .vd-insights-cta.violet {
+  background: oklch(0.55 0.18 285);
+}
+
+.sells-cowork .vd-insights-cta.violet:hover {
+  background: oklch(0.48 0.20 280);
+}
+
+.sells-cowork .vd-insights-cta.orange {
+  background: oklch(0.60 0.16 60);
+}
+
+.sells-cowork .vd-insights-cta.orange:hover {
+  background: oklch(0.52 0.16 60);
+}
+
+.sells-cowork .vd-insights-cta.dark {
+  background: oklch(0.18 0.01 250);
+}
+
+.sells-cowork .vd-insights-cta.dark:hover {
+  background: oklch(0.10 0.01 250);
+}
+
+.sells-cowork .vd-insights-cta.primary {
+  background: oklch(0.50 0.14 145);
+}
+
+.sells-cowork .vd-insights-cta.primary:hover {
+  background: oklch(0.42 0.14 145);
+}

--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -425,9 +425,14 @@ const SAVED_VIEWS: SavedView[] = [
 // MAIN — SellsIndex
 // ──────────────────────────────────────────────────────────────
 export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
-  // Auth user pra view Insights Jana (greeting "Bom dia, <nome>!").
-  const sharedPage = usePage<{ auth?: { user?: { name?: string } } }>();
+  // Auth user + business pra view Insights Jana (greeting + header dedicado com tenant breadcrumb).
+  const sharedPage = usePage<{
+    auth?: { user?: { name?: string; business_id?: number } };
+    business?: { id?: number; name?: string };
+  }>();
   const authUserName = sharedPage.props.auth?.user?.name;
+  const businessName = sharedPage.props.business?.name;
+  const businessIdShared = sharedPage.props.business?.id ?? sharedPage.props.auth?.user?.business_id;
   // Tier 0 multi-tenant: storage scoped per business_id (ver useBizStorage acima).
   const ls = useBizStorage();
 
@@ -1124,6 +1129,8 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
               payment_method_label: r.payment_method_label ?? null,
             }))}
             userName={authUserName}
+            businessName={businessName}
+            businessId={businessIdShared}
           />
         ) : (
         <>

--- a/resources/js/Pages/Sells/_components/SellsInsightsView.tsx
+++ b/resources/js/Pages/Sells/_components/SellsInsightsView.tsx
@@ -1,14 +1,32 @@
-// SellsInsightsView — view "Insights Jana" da tab bar Sells (PR #1682 · P5 parking lot).
+// SellsInsightsView — Cockpit "Analista IA" da tab Sells (V2 · Onda gaps r5).
 // Refs:
 //   - prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/chat-jana.jsx (canon visual)
-//   - memory/requisitos/Sells/Sells-r4-cowork-kb975-2026-05-26-visual-comparison.md gap #13
+//   - prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/chat-jana.css (tokens .jc-*)
+//   - memory/requisitos/Sells/Sells-r5-cowork-vs-prod-2026-05-26.md (5 gaps catalogados)
 //
-// Mode "Analista IA" da rota Sells — mostra brief diário + 4 análises usando dados
-// agregados que já existem no payload (sellKpis + coworkAggregates + rows atuais).
-// MVP enxuto. Próxima onda plugará agentes Brain B Jana real (ADR 0035).
+// V2 fecha 5 gaps vs V1 (PR #1684):
+//  GAP 1 — KPIs row dedicado Jana (4 cards independentes do dashboard)
+//  GAP 2 — Lista "AÇÕES QUE [USER] SUGERE" estruturadas (AcaoRow)
+//  GAP 3 — JanaHeader avatar grande + tenant breadcrumb + updatedAt + Configurar/Exportar
+//  GAP 4 — Brief header refinements (📅 + IA pill + "Ouvir áudio" btn placeholder)
+//  GAP 5 — H2 separadores hierárquicos ("ANÁLISES PRINCIPAIS" + "AÇÕES QUE JANA SUGERE")
+//
+// Mode "Analista IA" da rota Sells — mostra brief diário + KPIs Jana + 4 análises + ações
+// sugeridas, usando dados agregados que já existem no payload (sellKpis + coworkAggregates
+// + rows atuais). MVP enxuto. Próxima onda plugará agentes Brain B Jana real (ADR 0035).
 
-import type { ReactNode } from 'react';
-import { AlertCircle, TrendingUp, TrendingDown, MessageSquare, Sparkles } from 'lucide-react';
+import { useMemo, type ReactNode } from 'react';
+import {
+  AlertCircle,
+  TrendingUp,
+  TrendingDown,
+  MessageSquare,
+  Sparkles,
+  Calendar,
+  Volume2,
+  Settings,
+  Download,
+} from 'lucide-react';
 
 export interface InsightsViewProps {
   sellKpis: {
@@ -36,6 +54,9 @@ export interface InsightsViewProps {
     payment_method_label: string | null;
   }>;
   userName?: string;
+  /** Tenant context pro header breadcrumb. */
+  businessName?: string;
+  businessId?: number;
 }
 
 const fmtBRL = (n: number) =>
@@ -51,27 +72,33 @@ const greeting = (): string => {
   return 'Boa noite';
 };
 
+const formatTimeShort = (): string =>
+  new Date().toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
+
 export default function SellsInsightsView({
   sellKpis,
   coworkAggregates,
   rows,
   userName,
+  businessName,
+  businessId,
 }: InsightsViewProps): ReactNode {
-  // Brief calculations
+  // ── Brief calculations ───────────────────────────────────────────────────
   const faturadoHoje = coworkAggregates?.faturadoHojeTotal ?? 0;
   const pixHoje = coworkAggregates?.pixHojeTotal ?? 0;
   const deltaRev = coworkAggregates?.deltaRevenueVsYesterday ?? null;
   const deltaTicket = coworkAggregates?.deltaTicketVsLastWeek ?? null;
-  // sellKpis.total = nº total vendas; sellKpis.due = pendentes (não pagas).
-  // Usados no brief topo pra contextualizar volume.
   const totalVendas = sellKpis?.total ?? rows.length;
   const totalPendentes = sellKpis?.due ?? rows.filter((r) => r.payment_status !== 'paid').length;
   const overdueCount = rows.filter((r) => r.sla_kind === 'overdue').length;
   const overdueValue = rows
     .filter((r) => r.sla_kind === 'overdue')
     .reduce((acc, r) => acc + (Number(r.final_total) || 0), 0);
+  const totalAReceber = rows
+    .filter((r) => r.payment_status !== 'paid')
+    .reduce((acc, r) => acc + (Number(r.final_total) || 0), 0);
 
-  // Inadimplência buckets (paridade prototipo Cowork chat-jana.jsx)
+  // ── Inadimplência buckets ────────────────────────────────────────────────
   const ageingBuckets = (() => {
     const buckets = { '0-30d': 0, '30-90d': 0, '90-365d': 0, '>365d': 0 };
     rows
@@ -88,7 +115,7 @@ export default function SellsInsightsView({
   })();
   const ageingTotal = Object.values(ageingBuckets).reduce((a, b) => a + b, 0);
 
-  // Métodos pagamento
+  // ── Métodos pagamento ────────────────────────────────────────────────────
   const methodsAgg = (() => {
     const m: Record<string, number> = {};
     rows.forEach((r) => {
@@ -101,7 +128,7 @@ export default function SellsInsightsView({
   })();
   const methodsTotal = methodsAgg.reduce((a, [, v]) => a + v, 0);
 
-  // Top clientes
+  // ── Top clientes ─────────────────────────────────────────────────────────
   const topClientes = (() => {
     const m: Record<string, number> = {};
     rows.forEach((r) => {
@@ -114,33 +141,226 @@ export default function SellsInsightsView({
   })();
   const topClientesTotal = topClientes.reduce((a, [, v]) => a + v, 0);
 
-  // Sparkline 30d
+  // ── Sparkline 30d ────────────────────────────────────────────────────────
   const sparkline = coworkAggregates?.sparkline ?? [];
   const sparkMax = Math.max(...sparkline, 1);
+  const sparkSum = sparkline.reduce((a, b) => a + b, 0);
+
+  // ── Ticket médio ─────────────────────────────────────────────────────────
+  const ticketMedio = rows.length > 0
+    ? rows.reduce((acc, r) => acc + (Number(r.final_total) || 0), 0) / rows.length
+    : 0;
+
+  const firstName = userName?.split(' ')[0] || 'você';
+  const firstNameUpper = firstName.toUpperCase();
+
+  // ── GAP 2 — Ações sugeridas (estruturadas) ───────────────────────────────
+  // Gera ações de acordo com sinais detectados no payload. Cada ação tem
+  // ícone + título + descrição + tone (rose/violet/peach/grey) + CTA.
+  type AcaoTone = 'rose' | 'violet' | 'peach' | 'grey';
+  type CtaTone = 'danger' | 'violet' | 'orange' | 'dark' | 'primary';
+  interface Acao {
+    id: string;
+    icon: ReactNode;
+    title: string;
+    sub: string;
+    tone: AcaoTone;
+    cta: { label: string; tone: CtaTone };
+  }
+
+  const acoes = useMemo((): Acao[] => {
+    const list: Acao[] = [];
+    // Sinal 1 — vendas vencidas → régua WhatsApp HITL
+    if (overdueCount > 0) {
+      const topDevedor = rows
+        .filter((r) => r.sla_kind === 'overdue')
+        .sort((a, b) => (Number(b.final_total) || 0) - (Number(a.final_total) || 0))[0];
+      list.push({
+        id: 'regua-whatsapp',
+        icon: <MessageSquare size={16} />,
+        title: `Régua WhatsApp · ${overdueCount} venda${overdueCount === 1 ? '' : 's'} vencida${overdueCount === 1 ? '' : 's'}`,
+        sub: `Potencial recuperação: ${fmtShort(overdueValue)} · ${topDevedor ? `top devedor: ${topDevedor.customer_name || 'Cliente padrão'}` : ''}`.replace(/ · $/, ''),
+        tone: 'rose',
+        cta: { label: 'Disparar', tone: 'danger' },
+      });
+    }
+    // Sinal 2 — top devedor > R$1k (mesmo se não overdue ainda)
+    if (overdueCount > 0 && overdueValue > 1000) {
+      const topDevedor = rows
+        .filter((r) => r.sla_kind === 'overdue')
+        .sort((a, b) => (Number(b.final_total) || 0) - (Number(a.final_total) || 0))[0];
+      if (topDevedor?.customer_name) {
+        list.push({
+          id: 'negociar-top',
+          icon: <Sparkles size={16} />,
+          title: `Negociar com ${topDevedor.customer_name}`,
+          sub: `Valor ${fmtShort(Number(topDevedor.final_total) || 0)} · contato direto vale mais que régua automática`,
+          tone: 'violet',
+          cta: { label: 'Preparar', tone: 'violet' },
+        });
+      }
+    }
+    // Sinal 3 — queda ticket médio
+    if (deltaTicket !== null && deltaTicket <= -5) {
+      list.push({
+        id: 'investigar-ticket',
+        icon: <TrendingDown size={16} />,
+        title: 'Investigar queda ticket médio',
+        sub: `${deltaTicket}% vs semana passada · pode ser mix de produto mudando`,
+        tone: 'peach',
+        cta: { label: 'Investigar', tone: 'orange' },
+      });
+    }
+    // Sinal 4 — PIX adoção alta (positivo — manter)
+    if (faturadoHoje > 0 && pixHoje > 0 && pixHoje / faturadoHoje > 0.5) {
+      const pct = Math.round((pixHoje / faturadoHoje) * 100);
+      list.push({
+        id: 'pix-adocao',
+        icon: <TrendingUp size={16} />,
+        title: `PIX adoção em ${pct}% — manter`,
+        sub: `${fmtShort(pixHoje)} de ${fmtShort(faturadoHoje)} hoje · custo zero vs maquininha`,
+        tone: 'grey',
+        cta: { label: 'Detalhe', tone: 'dark' },
+      });
+    }
+    // Sinal 5 — pendentes alto sem overdue (alerta antes do estouro)
+    if (overdueCount === 0 && totalPendentes > 10) {
+      list.push({
+        id: 'preventivo-pendentes',
+        icon: <Calendar size={16} />,
+        title: `${totalPendentes} pendentes sem estourar ainda`,
+        sub: 'Janela ideal pra lembrete amigável antes da régua agressiva',
+        tone: 'grey',
+        cta: { label: 'Lembrar', tone: 'primary' },
+      });
+    }
+    return list;
+  }, [overdueCount, overdueValue, deltaTicket, faturadoHoje, pixHoje, totalPendentes, rows]);
+
+  // ── GAP 1 — KPIs row Jana (4 cards próprios) ─────────────────────────────
+  interface JanaKpi {
+    label: string;
+    icon: string;
+    value: string;
+    delta?: string;
+    deltaCls?: 'down' | 'up' | 'info' | '';
+    sub?: string;
+    emphasize?: boolean;
+  }
+
+  const janaKpis: JanaKpi[] = [
+    {
+      label: 'Faturamento mês',
+      icon: '💰',
+      value: fmtShort(sparkSum || faturadoHoje),
+      delta: deltaRev !== null ? `${deltaRev >= 0 ? '↑ +' : '↓ '}${deltaRev}% vs ontem` : undefined,
+      deltaCls: deltaRev !== null ? (deltaRev >= 0 ? 'up' : 'down') : '',
+    },
+    {
+      label: 'Inadimplência total',
+      icon: '🚨',
+      value: fmtShort(overdueValue),
+      sub: overdueCount > 0
+        ? `${overdueCount} venda${overdueCount === 1 ? '' : 's'} vencida${overdueCount === 1 ? '' : 's'}`
+        : 'tudo em dia',
+      emphasize: overdueValue > 0,
+      deltaCls: overdueValue > 0 ? 'down' : '',
+    },
+    {
+      label: 'Ticket médio',
+      icon: '📈',
+      value: fmtShort(ticketMedio),
+      delta: deltaTicket !== null
+        ? `${deltaTicket >= 0 ? '↑ +' : '↓ '}${deltaTicket}% 7d`
+        : undefined,
+      deltaCls: deltaTicket !== null ? (deltaTicket >= 0 ? 'up' : 'down') : '',
+    },
+    {
+      label: 'PIX hoje',
+      icon: '⚡',
+      value: fmtShort(pixHoje),
+      sub: faturadoHoje > 0
+        ? `${Math.round((pixHoje / faturadoHoje) * 100)}% do faturado`
+        : '— sem faturamento hoje',
+      deltaCls: 'info',
+    },
+  ];
 
   return (
     <div className="vd-insights">
-      {/* Brief diário · Jana */}
+      {/* GAP 3 — JanaHeader dedicado ──────────────────────────────────────── */}
+      <header className="vd-insights-jh">
+        <div className="vd-insights-jh-l">
+          <div className="vd-insights-jh-av">
+            <Sparkles size={22} />
+          </div>
+          <div className="vd-insights-jh-id">
+            <h2>
+              Jana <span className="dot">·</span> Analista IA
+            </h2>
+            <p>
+              <span className="vd-insights-jh-tenant">
+                {(businessName || 'OIMPRESSO').toUpperCase()}
+              </span>
+              {businessId != null && (
+                <>
+                  <span className="vd-insights-jh-sep">·</span>biz={businessId}
+                </>
+              )}
+              <span className="vd-insights-jh-sep">·</span>v2026.05
+            </p>
+          </div>
+        </div>
+        <div className="vd-insights-jh-r">
+          <span className="vd-insights-jh-updated">
+            <span className="d" />
+            Atualizado {formatTimeShort()}
+          </span>
+          <button
+            type="button"
+            className="vd-insights-jh-btn ghost"
+            title="Configurar Brain B Jana (em breve)"
+          >
+            <Settings size={12} /> Configurar
+          </button>
+          <button
+            type="button"
+            className="vd-insights-jh-btn dark"
+            title="Exportar relatório (em breve)"
+          >
+            <Download size={12} /> Exportar
+          </button>
+        </div>
+      </header>
+
+      {/* Brief diário · Jana (GAP 4 — header refinements) ──────────────────── */}
       <section className="vd-insights-brief">
         <header className="vd-insights-brief-h">
-          <div className="vd-insights-brief-av">
-            <Sparkles size={18} />
-          </div>
-          <div className="vd-insights-brief-meta">
-            <b>Jana · Analista IA</b>
-            <small>
-              {greeting()}{userName ? `, ${userName.split(' ')[0]}` : ''} ·{' '}
-              {new Date().toLocaleDateString('pt-BR', {
-                day: '2-digit',
-                month: 'long',
-                year: 'numeric',
-              })}
-            </small>
-          </div>
+          <span className="vd-insights-brief-h-l">
+            <Calendar size={14} />
+            <b>Brief diário</b>
+            <span className="sep">·</span>
+            {new Date().toLocaleDateString('pt-BR', {
+              day: '2-digit',
+              month: 'long',
+              year: 'numeric',
+            })}
+          </span>
+          <span className="vd-insights-pill ia">IA</span>
+          <button
+            type="button"
+            className="vd-insights-audio"
+            title="Ouvir áudio do brief (em breve — TTS V2)"
+          >
+            <Volume2 size={11} /> Ouvir áudio
+          </button>
         </header>
 
         <div className="vd-insights-brief-body">
-          <p>
+          <p className="vd-insights-brief-greet">
+            <strong>
+              {greeting()}{userName ? `, ${firstName}` : ''}.
+            </strong>{' '}
             <strong>{totalVendas}</strong> vendas no período
             {totalPendentes > 0 && (
               <>
@@ -223,7 +443,34 @@ export default function SellsInsightsView({
         </div>
       </section>
 
-      {/* 4 análises grid 2x2 */}
+      {/* GAP 1 — KPIs row dedicado Jana (4 cards próprios) ──────────────────── */}
+      <div className="vd-insights-kpis">
+        {janaKpis.map((k) => (
+          <div
+            key={k.label}
+            className={`vd-insights-kpi${k.emphasize ? ' emph' : ''}`}
+          >
+            <div className="vd-insights-kpi-h">
+              <span>{k.label.toUpperCase()}</span>
+              <span className="vd-insights-kpi-ic">{k.icon}</span>
+            </div>
+            <b className={`vd-insights-kpi-v ${k.deltaCls === 'down' ? 'red' : ''}`}>
+              {k.value}
+            </b>
+            {k.delta && (
+              <small className={`vd-insights-kpi-d ${k.deltaCls || ''}`}>{k.delta}</small>
+            )}
+            {k.sub && <small className="vd-insights-kpi-d">{k.sub}</small>}
+          </div>
+        ))}
+      </div>
+
+      {/* GAP 5 — H2 separador "ANÁLISES PRINCIPAIS" ─────────────────────────── */}
+      <h2 className="vd-insights-h2">
+        <span className="vd-insights-h2-ic">📊</span> ANÁLISES PRINCIPAIS
+      </h2>
+
+      {/* 4 análises grid 2x2 (já existia) ──────────────────────────────────── */}
       <div className="vd-insights-grid">
         {/* Análise 1: Inadimplência buckets */}
         <section className="vd-insights-card">
@@ -276,24 +523,28 @@ export default function SellsInsightsView({
             )}
           </header>
           <div className="vd-insights-card-big">
-            <span className="vd-pos">
-              {fmtShort(sparkline.reduce((a, b) => a + b, 0))}
-            </span>
+            <span className="vd-pos">{fmtShort(sparkSum)}</span>
           </div>
           <div className="vd-insights-spark">
             {sparkline.length === 0 ? (
               <div className="vd-insights-empty">Carregando sparkline…</div>
             ) : (
-              <svg viewBox={`0 0 ${sparkline.length * 4} 40`} preserveAspectRatio="none">
-                <polyline
-                  fill="none"
-                  stroke="currentColor"
-                  strokeWidth="1.5"
-                  points={sparkline
-                    .map((v, i) => `${i * 4},${40 - (v / sparkMax) * 38 - 1}`)
-                    .join(' ')}
-                />
-              </svg>
+              <>
+                <svg viewBox={`0 0 ${sparkline.length * 4} 40`} preserveAspectRatio="none">
+                  <polyline
+                    fill="none"
+                    stroke="currentColor"
+                    strokeWidth="1.5"
+                    points={sparkline
+                      .map((v, i) => `${i * 4},${40 - (v / sparkMax) * 38 - 1}`)
+                      .join(' ')}
+                  />
+                </svg>
+                <div className="vd-insights-spark-range">
+                  <span>D-{sparkline.length}</span>
+                  <span>hoje</span>
+                </div>
+              </>
             )}
           </div>
         </section>
@@ -373,10 +624,42 @@ export default function SellsInsightsView({
         </section>
       </div>
 
+      {/* GAP 5 — H2 separador "AÇÕES QUE [USER] SUGERE" ────────────────────── */}
+      {acoes.length > 0 && (
+        <>
+          <h2 className="vd-insights-h2">
+            <span className="vd-insights-h2-ic">💡</span> AÇÕES QUE {firstNameUpper} SUGERE
+          </h2>
+
+          {/* GAP 2 — Lista de ações estruturadas (AcaoRow) ─────────────────── */}
+          <div className="vd-insights-acoes">
+            {acoes.map((a) => (
+              <div key={a.id} className={`vd-insights-acao tone-${a.tone}`}>
+                <span className="vd-insights-acao-ic">{a.icon}</span>
+                <div className="vd-insights-acao-text">
+                  <b>{a.title}</b>
+                  <small>{a.sub}</small>
+                </div>
+                <button
+                  type="button"
+                  className={`vd-insights-cta ${a.cta.tone}`}
+                  title={`${a.cta.label} (HITL — em breve V2)`}
+                >
+                  {a.cta.label}
+                </button>
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
       <p className="vd-insights-foot">
         💡 Insights baseados em vendas filtradas atual + agregados 30d.
-        Próximas ondas: ações HITL (régua WhatsApp · investigar anomalias) + agentes Brain B Jana real.
+        Próximas ondas: ações HITL real (régua WhatsApp · investigar anomalias) + agentes Brain B Jana real.
       </p>
+
+      {/* Anti-flicker placeholder de totalAReceber pra reuso futuro do hook. */}
+      <span hidden data-total-a-receber={totalAReceber} />
     </div>
   );
 }

--- a/tests/Feature/Sells/SellsTabsViewModeTest.php
+++ b/tests/Feature/Sells/SellsTabsViewModeTest.php
@@ -103,12 +103,107 @@ it('SellsInsightsView renderiza brief diário Jana + 4 análises grid', function
     expect($src)
         ->toContain('vd-insights-brief')
         ->toContain('vd-insights-grid')
-        ->toContain('Jana · Analista IA')
+        // V2 onda gaps r5: nome Jana agora dentro de h2 com span.dot (não literal "Jana · Analista IA")
+        ->toContain('vd-insights-jh-id')
+        ->toContain('Analista IA')
         // 4 análises
         ->toContain('Inadimplência')
         ->toContain('Faturamento')
         ->toContain('Top 5 clientes')
         ->toContain('Métodos de pagamento');
+});
+
+// ── V2 onda gaps r5 — header Jana + KPIs + H2 + Ações ────────────────────────
+
+it('SellsInsightsView V2 — GAP 3 JanaHeader dedicado com avatar + tenant breadcrumb', function () {
+    $src = tabsReadInsightsView();
+    expect($src)
+        ->toContain('vd-insights-jh')
+        ->toContain('vd-insights-jh-av')
+        ->toContain('vd-insights-jh-tenant')
+        ->toContain('vd-insights-jh-updated')
+        ->toContain('Configurar')
+        ->toContain('Exportar');
+});
+
+it('SellsInsightsView V2 — GAP 4 Brief header com 📅 + IA pill + Ouvir áudio', function () {
+    $src = tabsReadInsightsView();
+    expect($src)
+        ->toContain('vd-insights-brief-h-l')
+        ->toContain('Brief diário')
+        ->toContain('vd-insights-pill ia')
+        ->toContain('vd-insights-audio')
+        ->toContain('Ouvir áudio');
+});
+
+it('SellsInsightsView V2 — GAP 1 KPIs row dedicado Jana (4 cards próprios)', function () {
+    $src = tabsReadInsightsView();
+    expect($src)
+        ->toContain('vd-insights-kpis')
+        ->toContain('vd-insights-kpi-h')
+        ->toContain('vd-insights-kpi-v')
+        ->toContain('Faturamento mês')
+        ->toContain('Inadimplência total')
+        ->toContain('Ticket médio')
+        ->toContain('PIX hoje');
+});
+
+it('SellsInsightsView V2 — GAP 5 H2 separadores hierárquicos', function () {
+    $src = tabsReadInsightsView();
+    expect($src)
+        ->toContain('vd-insights-h2')
+        ->toContain('ANÁLISES PRINCIPAIS')
+        ->toContain('SUGERE');
+});
+
+it('SellsInsightsView V2 — GAP 2 Lista AÇÕES sugeridas estruturadas (AcaoRow)', function () {
+    $src = tabsReadInsightsView();
+    expect($src)
+        ->toContain('vd-insights-acoes')
+        ->toContain('vd-insights-acao')
+        ->toContain('vd-insights-acao-ic')
+        ->toContain('vd-insights-acao-text')
+        ->toContain('vd-insights-cta')
+        // 5 sinais geradores de ação
+        ->toContain('regua-whatsapp')
+        ->toContain('negociar-top')
+        ->toContain('investigar-ticket')
+        ->toContain('pix-adocao')
+        ->toContain('preventivo-pendentes');
+});
+
+it('SellsInsightsView V2 — sparkline range labels D-N e hoje', function () {
+    $src = tabsReadInsightsView();
+    expect($src)->toContain('vd-insights-spark-range');
+});
+
+it('Index.tsx passa businessName + businessId pro SellsInsightsView', function () {
+    $src = tabsReadIndexTsx();
+    expect($src)
+        ->toContain('businessName={businessName}')
+        ->toContain('businessId={businessIdShared}')
+        ->toContain('sharedPage.props.business?.name');
+});
+
+it('sells-cowork-insights.css define tokens V2 (JanaHeader + KPIs + H2 + Ações)', function () {
+    $src = tabsReadInsightsCss();
+    expect($src)
+        // GAP 3 JanaHeader
+        ->toContain('.sells-cowork .vd-insights-jh')
+        ->toContain('.sells-cowork .vd-insights-jh-av')
+        ->toContain('.sells-cowork .vd-insights-jh-btn')
+        // GAP 4 Brief header
+        ->toContain('.sells-cowork .vd-insights-pill.ia')
+        ->toContain('.sells-cowork .vd-insights-audio')
+        // GAP 1 KPIs row
+        ->toContain('.sells-cowork .vd-insights-kpis')
+        ->toContain('.sells-cowork .vd-insights-kpi-v')
+        // GAP 5 H2 separadores
+        ->toContain('.sells-cowork .vd-insights-h2')
+        // GAP 2 Ações
+        ->toContain('.sells-cowork .vd-insights-acoes')
+        ->toContain('.sells-cowork .vd-insights-acao.tone-rose')
+        ->toContain('.sells-cowork .vd-insights-cta.danger');
 });
 
 it('SellsInsightsView trata empty states sem crash', function () {


### PR DESCRIPTION
## Summary

Onda V2 do mode Insights Jana após visual comparison r5 (PR #1685). Fecha **5 gaps estruturais** entre nossa V1 (PR #1684) e prototipo Cowork `chat-jana.jsx` 2026-05-26.

**Tudo num único PR (~836 linhas)** porque os 5 gaps formam uma única identidade visual coerente — fragmentar geraria 5 versões intermediárias visualmente quebradas.

## Gaps fechados

| # | Gap | Antes V1 | Agora V2 |
|---|---|---|---|
| 1 | KPIs row Jana | ❌ ausente | 4 cards próprios (Faturamento mês · Inadimplência · Ticket médio · PIX hoje) com delta/sub/emphasize |
| 2 | Lista AÇÕES SUGERIDAS | só chips no brief | bloco com AcaoRow (icon + título + desc + tone) — 5 sinais geram ações automáticas |
| 3 | JanaHeader dedicado | só avatar pequeno | avatar 44px gradient violeta + h2 + tenant breadcrumb + Configurar/Exportar |
| 4 | Brief header | só greeting | 📅 Calendar + "Brief diário · DATA" + pill IA + Ouvir áudio btn |
| 5 | H2 separadores | sem hierarquia | "ANÁLISES PRINCIPAIS" + "AÇÕES QUE {USER} SUGERE" |

## Multi-tenant Tier 0 (ADR 0093)

- `businessId`/`businessName` lidos via `usePage` props.business (HandleInertiaRequests shared) — zero query nova
- localStorage Tier 0 preservado (`oimpresso.sells.b{biz}.u{user}.view_mode`)
- Componente SellsInsightsView puro — lê só props já isoladas

## Tests

**18 Pest tests passando (87 assertions)** — `tests/Feature/Sells/SellsTabsViewModeTest.php`
- 9 novos cobrindo V2 (GAP 1-5 + sparkline range + Index passing props + CSS tokens V2)
- 9 preexistentes (V1 tab bar + estado + persistência + import)
- Build inertia OK (`app-B43kmjOd.js` + assets atualizados)

## Test plan

- [x] `npx tsc --noEmit` — sem erros novos
- [x] `vendor/bin/pest tests/Feature/Sells/SellsTabsViewModeTest.php` — 18/18 pass
- [x] `npm run build:inertia` — OK
- [ ] Smoke prod pós-merge:
  - Clicar Insights Jana → ver header novo + brief com 📅 + IA pill + KPIs row + H2 ANÁLISES + grid 2x2 + H2 AÇÕES + lista AcaoRow + footer
  - Verify ações geradas conforme sinais (régua WhatsApp aparece se overdue > 0)
  - Tenant breadcrumb mostra "WR2 SISTEMAS · biz=1 · v2026.05" (biz=1 Wagner) ou "ROTA LIVRE · biz=4 · v2026.05" (Larissa)

## Próxima onda

Ações HITL real plugando Brain B Jana (ADR 0035) com mutations endpoint `POST /api/jana/actions/{id}` — V3 future.

Refs:
- `prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/chat-jana.jsx` (canon visual)
- `prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/chat-jana.css` (.jc-* tokens)
- `memory/requisitos/Sells/Sells-r5-cowork-vs-prod-2026-05-26.md` (gaps catalogados)
- PR #1684 (V1) · PR #1685 (r5 doc)
- ADR 0093 Tier 0 · ADR 0104 MWART · ADR 0035 stack IA Jana

🤖 Generated with [Claude Code](https://claude.com/claude-code)