### PR TITLE
fix(cliente): search server-side em vez de filtro client-side

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -430,10 +430,32 @@ class ContactController extends Controller
         // ADR 0188 — filtra por papel (`is_X`) se a coluna existir, fallback `type` enum.
         $contactsQuery = Contact::where('contacts.business_id', $business_id);
         $contactsQuery = $this->applyContactTypeFilter($contactsQuery, $type);
+
+        // Fix 2026-05-26 — search server-side. Antes o frontend filtrava `rows`
+        // em memória sobre a página paginada (default 50) — busca por nome só
+        // encontrava clientes da página atual. Agora `q` bate no banco via LIKE
+        // em colunas indexáveis (name/tax_number/mobile/fantasia). Multi-tenant
+        // Tier 0 OK — scope `business_id` já aplicado acima ([ADR 0093]).
+        $q = trim((string) request()->input('q', ''));
+        if ($q !== '') {
+            $like = '%'.str_replace(['%', '_'], ['\%', '\_'], $q).'%';
+            $hasFantasia = $hasWaveBCols; // fantasia veio na Wave B junto com tipo.
+            $contactsQuery->where(function ($w) use ($like, $hasFantasia) {
+                $w->where('contacts.name', 'like', $like)
+                    ->orWhere('contacts.tax_number', 'like', $like)
+                    ->orWhere('contacts.mobile', 'like', $like)
+                    ->orWhere('contacts.contact_id', 'like', $like);
+                if ($hasFantasia) {
+                    $w->orWhere('contacts.fantasia', 'like', $like);
+                }
+            });
+        }
+
         $contacts = $contactsQuery
             ->select($selectCols)
             ->orderBy('contacts.name', 'asc')
-            ->paginate($perPage);
+            ->paginate($perPage)
+            ->withQueryString();
 
         $contactIds = $contacts->pluck('id')->all();
 

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -356,6 +356,26 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
     return () => clearTimeout(t);
   }, [searchInput]);
 
+  // Fix 2026-05-26 — search server-side via router.reload. Antes filtrava
+  // `rows` em memória (página paginada do backend) → busca só achava entre
+  // os 25-50 da página atual. Agora `q` vai pro Controller, bate LIKE em
+  // name/tax_number/mobile/contact_id/fantasia (ADR 0093 multi-tenant scope
+  // já no Builder). Debounce 300ms já existente acima evita request por
+  // keystroke. Skip primeiro render (mount) pra não disparar reload vazio.
+  const isSearchMounted = useRef(false);
+  useEffect(() => {
+    if (!isSearchMounted.current) {
+      isSearchMounted.current = true;
+      return;
+    }
+    router.reload({
+      only: ['customers'],
+      data: { q: search || undefined, page: 1 },
+      preserveScroll: true,
+      preserveState: true,
+    });
+  }, [search]);
+
   const [page, setPage] = useState(1);
   const [perPage, setPerPage] = useState(25);
   const [sortKey, setSortKey] = useState<SortKey>('name');
@@ -513,14 +533,11 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
   const filteredRows = useMemo(() => {
     let r = rows;
     if (statusFilter) r = r.filter((x) => x.status === statusFilter);
-    if (search) {
-      const q = search.toLowerCase();
-      r = r.filter((x) =>
-        x.name.toLowerCase().includes(q) ||
-        (x.tax_number_masked ?? '').toLowerCase().includes(q) ||
-        (x.mobile ?? '').includes(q),
-      );
-    }
+    // Fix 2026-05-26 — busca por nome/tax_number/mobile MIGROU pro backend
+    // (useEffect [search] acima dispara router.reload com `q`). Aqui rows
+    // já vem filtrado server-side; filtro client-side seria duplicado e
+    // amputaria resultados que casam o `q` SQL mas não o regex JS (acentos,
+    // case). Filtros locais abaixo continuam (tipo/UF/tags/stale/saldo).
     // Wave G — filtros novos. Cada um é AND independente (espelha protótipo Cowork).
     if (tipoFilter) r = r.filter((x) => x.tipo === tipoFilter);
     if (ufFilter) r = r.filter((x) => (x.uf ?? x.state ?? '') === ufFilter);
@@ -567,7 +584,7 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
       });
     }
     return r;
-  }, [rows, statusFilter, search, tipoFilter, ufFilter, tagsFilter, staleFilter, saldoFilter, recentMonthFilter]);
+  }, [rows, statusFilter, tipoFilter, ufFilter, tagsFilter, staleFilter, saldoFilter, recentMonthFilter]);
 
   // PTDP Onda 2 — counts pros 5 KPI cards. Ativos + ComSaldo usam `kpis`
   // reais do backend; VIPs + Sem90 + Novos vêm estimados das `rows` da página


### PR DESCRIPTION
## Bug

O input de busca da listagem `/cliente` filtrava `rows = props.customers.data` em memória. Como rows vem paginado (default 50/page), digitar `João` só encontrava clientes da página atual — clientes na página 5 sumiam.

Reportado por Wagner 2026-05-26: *"arruma a consulta de clientes acho que esta consultando apenas nos dados que estao na tela a pesquisa tem que ser pelo banco"*.

## Fix

**Backend** — `ContactController::buildClienteIndexCustomers`:
- Lê `request()->input('q')`, aplica `where` LIKE em `name`, `tax_number`, `mobile`, `contact_id`, `fantasia` (fantasia gated por `hasWaveBCols`) antes do `paginate`.
- `withQueryString()` no paginator pra preservar `q` nos links de página.
- Escape de wildcards `%` `_` no termo.
- Multi-tenant Tier 0 OK — scope `business_id` aplicado no Builder antes ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)).

**Frontend** — `Cliente/Index.tsx`:
- `useEffect [search]` (debounce 300ms já existia) dispara `router.reload({ only: ['customers'], data: { q, page: 1 }, preserveScroll, preserveState })`. Skip 1º render via `useRef` pra não disparar reload vazio no mount.
- Removido o `r.filter(name/tax/mobile)` do `filteredRows` (duplicaria + amputaria, ex: regex JS não casa "joao" com "João" mas LIKE SQL com `utf8mb4_general_ci` sim).
- `search` removido das deps do `useMemo` de `filteredRows`.

**Out of scope** — filtros combobox (status/tipo/UF/tags/stale/saldo) continuam client-side. Migração completa = onda separada (afeta KPI Strip, tab_counts, paginação).

## Test plan

- [ ] Abrir `/cliente?type=customer` com >100 clientes no biz
- [ ] Digitar nome de cliente que está na página 3+ → aparece (antes não aparecia)
- [ ] Digitar parte do CPF/CNPJ → encontra
- [ ] Digitar parte do mobile → encontra
- [ ] Limpar busca (X) → volta listagem completa
- [ ] Filtros combobox (Tipo/UF/Tags) ainda funcionam combinados com search
- [ ] Multi-tenant — biz=1 não vê clientes biz=4 ao buscar nome comum

## Diff stat

`2 files changed, 49 insertions(+), 10 deletions(-)` — bem abaixo do limite ≤300 linhas (skill `commit-discipline`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)