### PR TITLE
fix(sells/cowork): carregar IBM Plex Sans via <link> (resolve prod sem fonte)

### DIFF
--- a/resources/css/sells-cowork.css
+++ b/resources/css/sells-cowork.css
@@ -11,8 +11,13 @@
  * Importado por resources/css/inertia.css. Ver:
  *  - memory/requisitos/Sells/index-r1-visual-comparison.md
  *  - memory/reference/feedback-design-literal-copy-quando-aprovado.md
+ *
+ * Fontes IBM Plex Sans/Mono são carregadas via <link rel="stylesheet"> no
+ * resources/views/layouts/inertia.blade.php — não via @import aqui. Motivo:
+ * @import de URL externa em CSS bundleado é descartado pelo Vite no build de
+ * produção, fazendo a fonte cair em system-ui em todo browser que não tem
+ * IBM Plex instalado no SO (causava prod "errada" e localhost ok).
  */
-@import url('https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap');
 .sells-cowork {
   /* Sidebar dark — espelho AppShell */
   --sb-bg:        oklch(0.21 0 0);

--- a/resources/views/layouts/inertia.blade.php
+++ b/resources/views/layouts/inertia.blade.php
@@ -21,6 +21,16 @@
 
     <title data-inertia>{{ config('app.name', 'OI Impresso') }}</title>
 
+    {{-- IBM Plex Sans/Mono — referenciada por sells-cowork.css (e demais
+         cowork bundles). Carregar via <link> aqui porque @import dentro de CSS
+         bundleado é descartado pelo Vite no build de produção, e o fallback
+         system-ui faz a tela parecer "errada" (issue: prod sem fonte
+         enquanto localhost renderiza por IBM Plex estar instalado no SO do
+         dev). --}}
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=IBM+Plex+Sans:wght@400;500;600;700&family=IBM+Plex+Mono:wght@400;500&display=swap" rel="stylesheet">
+
     {{-- Anti-flash dark mode. Rodamos ANTES do <body> pintar: se modo=auto, decide
          pela preferência do sistema; senão já veio correto do servidor.
          Sem este script, auto-mode pisca branco → escuro (vira estilo amador). --}}


### PR DESCRIPTION
## Summary

- Adiciona `<link rel=\"stylesheet\">` do Google Fonts IBM Plex Sans/Mono no [resources/views/layouts/inertia.blade.php](resources/views/layouts/inertia.blade.php) — preconnect + 400-700 (Sans) + 400-500 (Mono).
- Remove `@import url('https://fonts.googleapis.com/...')` morto da linha 15 de [resources/css/sells-cowork.css](resources/css/sells-cowork.css) (Vite descarta no build de produção, virou no-op).

## Por que

Em prod (https://oimpresso.com/sells aba Insights Jana), inspeção do bundle [/build-inertia/assets/inertia-DLn20UWL.css](https://oimpresso.com/build-inertia/assets/inertia-DLn20UWL.css) (928 KB) mostra:

- `document.fonts.size === 0` — nenhum `@font-face` declarado
- `Array.from(document.styleSheets[*].cssRules).filter(r => r.constructor.name === 'CSSFontFaceRule').length === 0`
- DOM probe: `span` com `font-family: \"IBM Plex Sans\"` mede a mesma largura que `font-family: monospace` (158 === 158) → **fonte não renderiza, fallback `ui-sans-serif` ativo**

Em localhost o problema não aparece porque o Windows do dev (Wagner) tem IBM Plex Sans instalado como fonte de sistema. Em qualquer outra máquina (Larissa @ ROTA LIVRE biz=4, Eliana, time MCP) cai no fallback e a tipografia fica fora do prototipo Cowork aprovado (KB-9.75 sells-index 9.75/10).

## Test plan

- [ ] Build local: `npm run build --workspace=build-inertia` → IBM Plex Sans renderiza em [Sells/Insights Jana](https://oimpresso.com/sells)
- [ ] Pós-deploy Hostinger: rodar no DevTools de prod:
  ```js
  Array.from(document.fonts).filter(f => f.family.includes('IBM Plex')).map(f => ({family: f.family, status: f.status}))
  ```
  Espera: lista com 4-6 `loaded` faces IBM Plex Sans + 2 IBM Plex Mono.
- [ ] DOM probe (em prod, console): widths devem diferir
  ```js
  (() => {
    const p = document.createElement('span');
    p.style.cssText = 'font-family:\"IBM Plex Sans\",monospace;font-size:48px;visibility:hidden';
    p.textContent = 'Test_M'; document.body.appendChild(p);
    const a = p.offsetWidth;
    p.style.fontFamily = 'monospace';
    const b = p.offsetWidth;
    document.body.removeChild(p);
    return {ibm:a, mono:b, ok: a !== b};
  })()
  ```
- [ ] Smoke visual: header Jana, KPIs, ações sugeridas em [Sells/Insights Jana](https://oimpresso.com/sells) com tipografia IBM Plex (não Segoe UI/Inter).

## Não-objetivos

- Não muda visual de outras telas (CSS escopado em `.sells-cowork` continua igual).
- Não troca host de fonte (continua Google Fonts via `display=swap`, latência ~10ms cacheada).
- Não inclui auto-host (`fonts/ibm-plex/*.woff2`) — pode ser onda separada se quiser eliminar Google CDN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)