### PR TITLE
feat(jana): move JanaCockpitV2 do /sells pra /ia/dashboard (canon)

### DIFF
--- a/Modules/Jana/Http/Controllers/DashboardController.php
+++ b/Modules/Jana/Http/Controllers/DashboardController.php
@@ -3,35 +3,43 @@
 namespace Modules\Jana\Http\Controllers;
 
 use App\Http\Controllers\Controller;
+use App\Services\Sells\SellsCockpitAggregator;
 use Illuminate\Http\Request;
 use Inertia\Inertia;
 use Modules\Jana\Entities\Meta;
 
 /**
- * Dashboard de metas ativas com sparkline + farol.
- * Renderiza Inertia Page 'Copiloto/Dashboard' (ver adr/ui/0001).
+ * Dashboard canon da Jana V2 — JanaCockpitV2 (brief diário + KPIs + análises + ações)
+ * hospedado em /ia/dashboard, com Metas como bloco secundário.
+ *
+ * Antes da Onda 2026-05-26 (jana-cockpit-move), este controller passava só `metas`
+ * e o cockpit V2 vivia como tab em /sells. Hoje JanaCockpitV2 é o conteúdo primário —
+ * a marca IA (Jana) ganha sua tela própria.
  */
 class DashboardController extends Controller
 {
-    public function index(Request $request)
+    public function index(Request $request, SellsCockpitAggregator $cockpitAggregator)
     {
-        $businessId = $request->session()->get('user.business_id');
+        $businessId = (int) $request->session()->get('user.business_id');
+        $businessName = (string) ($request->session()->get('business.name') ?? '');
 
-        // Wagner 2026-05-25: Dashboard é PRIMEIRA ABA canon da Jana + destino
-        // pós-login (`/home → /ia/dashboard`). Empty state já implementado em
-        // Dashboard.tsx (linha 296) com CTA "Pergunte algo a Jana". O redirect
-        // antigo "sem metas → chat" criava loop UX: login → /ia/dashboard →
-        // bounce pra /ia (chat). Removido — frontend renderiza empty card.
-
-        // Wagner 2026-05-25 HOTFIX pós-PR #1547: removido `Inertia::defer` no
-        // payload `metas`. Causa: Dashboard.tsx (linha 279/296/318) lê
-        // `metas.length` direto sem wrap `<Deferred>` nem fallback — defer
-        // entrega `undefined` no primeiro render e quebra com TypeError em
-        // prod. Bug pré-existia mascarado pelo redirect "sem metas → chat".
-        // Reintroduzir defer quando frontend ganhar `<Deferred data="metas"
-        // fallback={<Skeleton />}>` wrap (refactor MWART futuro).
+        // Wagner 2026-05-25 HOTFIX pós-PR #1547: `metas` SEM Inertia::defer porque
+        // Dashboard.tsx lê `metas.length` direto. coworkAggregates pode usar defer
+        // (JanaCockpitV2 é resiliente — sparkline opcional, idem em /sells).
         return Inertia::render('Jana/Dashboard', [
             'metas' => $this->buildMetasPayload($businessId),
+
+            // Jana V2 cockpit (movido de /sells — agora canon aqui).
+            'sellKpis' => $cockpitAggregator->buildSellKpis($businessId),
+            'insightsAggregates' => $cockpitAggregator->buildInsightsAggregates($businessId),
+            'coworkAggregates' => Inertia::defer(fn () => $cockpitAggregator->buildCoworkAggregates($businessId)),
+
+            // Tenant context pro header da Jana (avatar + breadcrumb v2026.05).
+            'janaContext' => [
+                'businessId'   => $businessId,
+                'businessName' => $businessName,
+                'userName'     => optional(auth()->user())->name,
+            ],
         ]);
     }
 

--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -645,24 +645,10 @@ class SellController extends Controller
 
         // Inertia render — US-SELL-008 pattern Cockpit canon (PR único).
         // DataTables AJAX legacy continua funcionando via request()->ajax() acima.
-        // KPIs counters — mesmas regras de tenant scope que getListSells (defesa em profundidade).
-        $kpiBase = \App\Transaction::where('business_id', $business_id)
-            ->where('type', 'sell')
-            ->where('status', 'final')
-            ->whereNull('sub_type');
-
-        $sellKpis = [
-            'total' => (clone $kpiBase)->count(),
-            'paid' => (clone $kpiBase)->where('payment_status', 'paid')->count(),
-            'due' => (clone $kpiBase)->where('payment_status', 'due')->count(),
-            'partial' => (clone $kpiBase)->where('payment_status', 'partial')->count(),
-            'overdue' => (clone $kpiBase)
-                ->whereIn('payment_status', ['due', 'partial'])
-                ->whereNotNull('pay_term_number')
-                ->whereNotNull('pay_term_type')
-                ->whereRaw("IF(pay_term_type='days', DATE_ADD(transaction_date, INTERVAL pay_term_number DAY) < CURDATE(), DATE_ADD(transaction_date, INTERVAL pay_term_number MONTH) < CURDATE())")
-                ->count(),
-        ];
+        // KPIs counters + coworkAggregates extraídos pra App\Services\Sells\SellsCockpitAggregator
+        // (reuso /ia/dashboard, Jana V2). Comportamento idêntico — Pest cobertura paridade.
+        $cockpitAggregator = app(\App\Services\Sells\SellsCockpitAggregator::class);
+        $sellKpis = $cockpitAggregator->buildSellKpis($business_id);
 
         // US-SELL-COWORK-COMMISSION — Coluna Comissão na grade só aparece quando
         // setting business_details.sales_cmsn_agnt ≠ 'disable' (gap PR #1043).
@@ -689,7 +675,7 @@ class SellController extends Controller
             'coworkCommissionEnabled' => $coworkCommissionEnabled,
             // US-SELL-COWORK-R5-POLISH — agregados Cowork (sparkline 30d + deltas + top vendedor).
             // Inertia::defer pra não bloquear render inicial (pages.md rule canon).
-            'coworkAggregates' => \Inertia\Inertia::defer(fn () => $this->buildCoworkAggregates($business_id)),
+            'coworkAggregates' => \Inertia\Inertia::defer(fn () => $cockpitAggregator->buildCoworkAggregates($business_id)),
         ]);
     }
 
@@ -848,128 +834,9 @@ class SellController extends Controller
         ]);
     }
 
-    /**
-     * US-SELL-COWORK-R5-POLISH — agregados pra cards Cowork da Sells/Index.
-     *
-     * Retorna:
-     *  - sparkline: array 30 days revenue (final_total) — multi-tenant Tier 0 scoped via business_id
-     *  - deltaRevenueVsYesterday: pct (round int) — null se ontem == 0
-     *  - deltaTicketVsLastWeek: pct (round int) — null se semana passada == 0
-     *  - topSeller: { name, total } — commission_agent do mês corrente OU null
-     *
-     * Multi-tenant Tier 0 IRREVOGÁVEL: todo where() abaixo recebe ->where('business_id', $business_id)
-     * explícito além do global scope (defesa em profundidade, ADR 0093).
-     */
-    protected function buildCoworkAggregates(int $business_id): array
-    {
-        $today = now()->startOfDay();
-        $yesterday = (clone $today)->subDay();
-        $start30 = (clone $today)->subDays(29);
-        $monthStart = (clone $today)->startOfMonth();
-        $lastWeekStart = (clone $today)->subDays(13);
-        $lastWeekEnd = (clone $today)->subDays(7);
-        $thisWeekStart = (clone $today)->subDays(6);
-
-        // Sparkline — 30d revenue per day. GROUP BY DATE().
-        $sparkRowsQ = \App\Transaction::where('business_id', $business_id)
-            ->where('type', 'sell')
-            ->where('status', 'final')
-            ->whereNull('sub_type')
-            ->whereBetween('transaction_date', [$start30, (clone $today)->endOfDay()])
-            ->selectRaw('DATE(transaction_date) as d, SUM(final_total) as total')
-            ->groupBy('d')
-            ->orderBy('d');
-
-        $sparkByDate = $sparkRowsQ->get()->keyBy('d')->map(fn ($r) => (float) $r->total);
-
-        $sparkline = [];
-        for ($i = 29; $i >= 0; $i--) {
-            $date = (clone $today)->subDays($i)->format('Y-m-d');
-            $sparkline[] = (float) ($sparkByDate[$date] ?? 0.0);
-        }
-
-        // Delta revenue hoje vs ontem (round int %).
-        $revToday = \App\Transaction::where('business_id', $business_id)
-            ->where('type', 'sell')
-            ->where('status', 'final')
-            ->whereNull('sub_type')
-            ->whereDate('transaction_date', $today)
-            ->sum('final_total');
-        $revYesterday = \App\Transaction::where('business_id', $business_id)
-            ->where('type', 'sell')
-            ->where('status', 'final')
-            ->whereNull('sub_type')
-            ->whereDate('transaction_date', $yesterday)
-            ->sum('final_total');
-
-        $deltaRevenueVsYesterday = $revYesterday > 0
-            ? (int) round((($revToday - $revYesterday) / $revYesterday) * 100)
-            : null;
-
-        // Delta ticket médio esta semana vs semana passada (round int %).
-        $thisWeekRows = \App\Transaction::where('business_id', $business_id)
-            ->where('type', 'sell')
-            ->where('status', 'final')
-            ->whereNull('sub_type')
-            ->whereBetween('transaction_date', [$thisWeekStart, (clone $today)->endOfDay()])
-            ->selectRaw('COUNT(*) as c, SUM(final_total) as s')
-            ->first();
-        $lastWeekRows = \App\Transaction::where('business_id', $business_id)
-            ->where('type', 'sell')
-            ->where('status', 'final')
-            ->whereNull('sub_type')
-            ->whereBetween('transaction_date', [$lastWeekStart, $lastWeekEnd])
-            ->selectRaw('COUNT(*) as c, SUM(final_total) as s')
-            ->first();
-
-        $thisWeekTicket = ($thisWeekRows && $thisWeekRows->c > 0) ? $thisWeekRows->s / $thisWeekRows->c : 0.0;
-        $lastWeekTicket = ($lastWeekRows && $lastWeekRows->c > 0) ? $lastWeekRows->s / $lastWeekRows->c : 0.0;
-
-        $deltaTicketVsLastWeek = $lastWeekTicket > 0
-            ? (int) round((($thisWeekTicket - $lastWeekTicket) / $lastWeekTicket) * 100)
-            : null;
-
-        // Top vendedor do mês (commission_agent).
-        $topSellerRow = \App\Transaction::where('transactions.business_id', $business_id)
-            ->where('transactions.type', 'sell')
-            ->where('transactions.status', 'final')
-            ->whereNull('transactions.sub_type')
-            ->whereBetween('transactions.transaction_date', [$monthStart, (clone $today)->endOfDay()])
-            ->whereNotNull('transactions.commission_agent')
-            ->join('users', 'users.id', '=', 'transactions.commission_agent')
-            ->selectRaw("CONCAT(COALESCE(users.first_name, ''), ' ', COALESCE(users.last_name, '')) as name, SUM(transactions.final_total) as total")
-            ->groupBy('transactions.commission_agent', 'users.first_name', 'users.last_name')
-            ->orderByDesc('total')
-            ->limit(1)
-            ->first();
-
-        $topSeller = $topSellerRow && trim((string) $topSellerRow->name) !== ''
-            ? ['name' => trim((string) $topSellerRow->name), 'total' => (float) $topSellerRow->total]
-            : null;
-
-        // PR #1666 — PIX hoje (5º KPI Cowork canon). Soma transaction_payments
-        // method='custom_pay_1' (PIX UPOS) onde transação é venda final do dia.
-        // Multi-tenant Tier 0: business_id em transaction_payments + Transaction.
-        $pixHojeTotal = (float) \DB::table('transaction_payments')
-            ->join('transactions', 'transactions.id', '=', 'transaction_payments.transaction_id')
-            ->where('transactions.business_id', $business_id)
-            ->where('transactions.type', 'sell')
-            ->where('transactions.status', 'final')
-            ->whereNull('transactions.sub_type')
-            ->whereDate('transactions.transaction_date', $today)
-            ->where('transaction_payments.method', 'custom_pay_1')
-            ->sum('transaction_payments.amount');
-
-        return [
-            'sparkline' => $sparkline,
-            'deltaRevenueVsYesterday' => $deltaRevenueVsYesterday,
-            'deltaTicketVsLastWeek' => $deltaTicketVsLastWeek,
-            'topSeller' => $topSeller,
-            // PR #1666 — 5º KPI PIX hoje (paridade prototipo Cowork)
-            'pixHojeTotal' => $pixHojeTotal,
-            'faturadoHojeTotal' => (float) $revToday,
-        ];
-    }
+    // buildCoworkAggregates() extraído para App\Services\Sells\SellsCockpitAggregator
+    // (reuso em Modules\Jana\Http\Controllers\DashboardController — /ia/dashboard
+    // Jana V2). Lógica preservada verbatim — Pest cobertura paridade.
 
     /**
      * Show the form for creating a new resource.

--- a/app/Services/Sells/SellsCockpitAggregator.php
+++ b/app/Services/Sells/SellsCockpitAggregator.php
@@ -1,0 +1,315 @@
+<?php
+
+namespace App\Services\Sells;
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * SellsCockpitAggregator — fonte única dos números do cockpit "Analista IA" (Jana V2).
+ *
+ * Consumido por:
+ *  - App\Http\Controllers\SellController@index  (Sells/Index — payload sellKpis + coworkAggregates)
+ *  - Modules\Jana\Http\Controllers\DashboardController@index  (/ia/dashboard — payload completo do cockpit)
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093): todo where() recebe ->where('business_id', $businessId)
+ * explícito além do global scope (defesa em profundidade).
+ *
+ * Origem: extração do app/Http/Controllers/SellController (linhas 649-665 sellKpis + 863-972
+ * buildCoworkAggregates). Sem mudança de comportamento — Pest tests devem continuar passando.
+ */
+class SellsCockpitAggregator
+{
+    /**
+     * KPIs counters da grade Sells (Total / Paga / Pendente / Parcial / Estourada).
+     *
+     * Origem: extraído verbatim de SellController@index linhas 649-665.
+     */
+    public function buildSellKpis(int $businessId): array
+    {
+        $kpiBase = \App\Transaction::where('business_id', $businessId)
+            ->where('type', 'sell')
+            ->where('status', 'final')
+            ->whereNull('sub_type');
+
+        return [
+            'total' => (clone $kpiBase)->count(),
+            'paid' => (clone $kpiBase)->where('payment_status', 'paid')->count(),
+            'due' => (clone $kpiBase)->where('payment_status', 'due')->count(),
+            'partial' => (clone $kpiBase)->where('payment_status', 'partial')->count(),
+            'overdue' => (clone $kpiBase)
+                ->whereIn('payment_status', ['due', 'partial'])
+                ->whereNotNull('pay_term_number')
+                ->whereNotNull('pay_term_type')
+                ->whereRaw("IF(pay_term_type='days', DATE_ADD(transaction_date, INTERVAL pay_term_number DAY) < CURDATE(), DATE_ADD(transaction_date, INTERVAL pay_term_number MONTH) < CURDATE())")
+                ->count(),
+        ];
+    }
+
+    /**
+     * Agregados Cowork (sparkline 30d + deltas hoje vs ontem / semana vs anterior + topSeller mês + PIX hoje).
+     *
+     * Origem: extraído verbatim de SellController@buildCoworkAggregates linhas 863-972.
+     */
+    public function buildCoworkAggregates(int $businessId): array
+    {
+        $today = now()->startOfDay();
+        $yesterday = (clone $today)->subDay();
+        $start30 = (clone $today)->subDays(29);
+        $monthStart = (clone $today)->startOfMonth();
+        $lastWeekStart = (clone $today)->subDays(13);
+        $lastWeekEnd = (clone $today)->subDays(7);
+        $thisWeekStart = (clone $today)->subDays(6);
+
+        // Sparkline — 30d revenue per day.
+        $sparkRowsQ = \App\Transaction::where('business_id', $businessId)
+            ->where('type', 'sell')
+            ->where('status', 'final')
+            ->whereNull('sub_type')
+            ->whereBetween('transaction_date', [$start30, (clone $today)->endOfDay()])
+            ->selectRaw('DATE(transaction_date) as d, SUM(final_total) as total')
+            ->groupBy('d')
+            ->orderBy('d');
+
+        $sparkByDate = $sparkRowsQ->get()->keyBy('d')->map(fn ($r) => (float) $r->total);
+
+        $sparkline = [];
+        for ($i = 29; $i >= 0; $i--) {
+            $date = (clone $today)->subDays($i)->format('Y-m-d');
+            $sparkline[] = (float) ($sparkByDate[$date] ?? 0.0);
+        }
+
+        // Delta revenue hoje vs ontem.
+        $revToday = \App\Transaction::where('business_id', $businessId)
+            ->where('type', 'sell')
+            ->where('status', 'final')
+            ->whereNull('sub_type')
+            ->whereDate('transaction_date', $today)
+            ->sum('final_total');
+        $revYesterday = \App\Transaction::where('business_id', $businessId)
+            ->where('type', 'sell')
+            ->where('status', 'final')
+            ->whereNull('sub_type')
+            ->whereDate('transaction_date', $yesterday)
+            ->sum('final_total');
+
+        $deltaRevenueVsYesterday = $revYesterday > 0
+            ? (int) round((($revToday - $revYesterday) / $revYesterday) * 100)
+            : null;
+
+        // Delta ticket médio esta semana vs semana passada.
+        $thisWeekRows = \App\Transaction::where('business_id', $businessId)
+            ->where('type', 'sell')
+            ->where('status', 'final')
+            ->whereNull('sub_type')
+            ->whereBetween('transaction_date', [$thisWeekStart, (clone $today)->endOfDay()])
+            ->selectRaw('COUNT(*) as c, SUM(final_total) as s')
+            ->first();
+        $lastWeekRows = \App\Transaction::where('business_id', $businessId)
+            ->where('type', 'sell')
+            ->where('status', 'final')
+            ->whereNull('sub_type')
+            ->whereBetween('transaction_date', [$lastWeekStart, $lastWeekEnd])
+            ->selectRaw('COUNT(*) as c, SUM(final_total) as s')
+            ->first();
+
+        $thisWeekTicket = ($thisWeekRows && $thisWeekRows->c > 0) ? $thisWeekRows->s / $thisWeekRows->c : 0.0;
+        $lastWeekTicket = ($lastWeekRows && $lastWeekRows->c > 0) ? $lastWeekRows->s / $lastWeekRows->c : 0.0;
+
+        $deltaTicketVsLastWeek = $lastWeekTicket > 0
+            ? (int) round((($thisWeekTicket - $lastWeekTicket) / $lastWeekTicket) * 100)
+            : null;
+
+        // Top vendedor do mês (commission_agent).
+        $topSellerRow = \App\Transaction::where('transactions.business_id', $businessId)
+            ->where('transactions.type', 'sell')
+            ->where('transactions.status', 'final')
+            ->whereNull('transactions.sub_type')
+            ->whereBetween('transactions.transaction_date', [$monthStart, (clone $today)->endOfDay()])
+            ->whereNotNull('transactions.commission_agent')
+            ->join('users', 'users.id', '=', 'transactions.commission_agent')
+            ->selectRaw("CONCAT(COALESCE(users.first_name, ''), ' ', COALESCE(users.last_name, '')) as name, SUM(transactions.final_total) as total")
+            ->groupBy('transactions.commission_agent', 'users.first_name', 'users.last_name')
+            ->orderByDesc('total')
+            ->limit(1)
+            ->first();
+
+        $topSeller = $topSellerRow && trim((string) $topSellerRow->name) !== ''
+            ? ['name' => trim((string) $topSellerRow->name), 'total' => (float) $topSellerRow->total]
+            : null;
+
+        // PIX hoje — soma transaction_payments method='custom_pay_1' (canon UPOS).
+        $pixHojeTotal = (float) DB::table('transaction_payments')
+            ->join('transactions', 'transactions.id', '=', 'transaction_payments.transaction_id')
+            ->where('transactions.business_id', $businessId)
+            ->where('transactions.type', 'sell')
+            ->where('transactions.status', 'final')
+            ->whereNull('transactions.sub_type')
+            ->whereDate('transactions.transaction_date', $today)
+            ->where('transaction_payments.method', 'custom_pay_1')
+            ->sum('transaction_payments.amount');
+
+        return [
+            'sparkline' => $sparkline,
+            'deltaRevenueVsYesterday' => $deltaRevenueVsYesterday,
+            'deltaTicketVsLastWeek' => $deltaTicketVsLastWeek,
+            'topSeller' => $topSeller,
+            'pixHojeTotal' => $pixHojeTotal,
+            'faturadoHojeTotal' => (float) $revToday,
+        ];
+    }
+
+    /**
+     * Pré-agregações que o JanaCockpitV2 antes computava no frontend a partir de `rows`.
+     *
+     * Pré-computar server-side elimina dependência do componente ser embutido em uma tela
+     * que já tenha os rows filtrados carregados (necessário pra `/ia/dashboard` standalone).
+     *
+     * Retorna:
+     *   - overdueCount: int — vendas atrasadas (paid != true && days_to_due < 0)
+     *   - overdueValue: float — soma final_total das overdue
+     *   - ageingBuckets: ['0-30d','30-90d','90-365d','>365d'] => float (overdue por idade)
+     *   - methodsAgg: array<{method, total}> (top 5 por payment_method_label) — método da última payment
+     *   - topClientes: array<{name, total}> (top 5 customer_name pra base atual)
+     *   - topDevedor: {name, total}|null — maior venda overdue do tenant
+     *   - ticketMedio: float — média final_total das vendas final
+     *   - totalAReceber: float — sum final_total onde payment_status != 'paid'
+     */
+    public function buildInsightsAggregates(int $businessId): array
+    {
+        $today = now()->startOfDay();
+
+        // Base — vendas final do tenant. Multi-tenant Tier 0.
+        $base = \App\Transaction::where('business_id', $businessId)
+            ->where('type', 'sell')
+            ->where('status', 'final')
+            ->whereNull('sub_type');
+
+        // Computa due_date e days_to_due via subquery — apenas vendas com pay_term completo.
+        // sla_kind='overdue' espelha lógica do SellController@getListSells (linha 1425):
+        //   paid → paid; sem pay_term → fresh; days < 0 → overdue; <=7 → warning; >7 → fresh.
+        //
+        // Overdue = não-paga + tem pay_term + due_date < hoje.
+        $overdueSelect = "
+            transactions.id,
+            transactions.final_total,
+            transactions.transaction_date,
+            transactions.payment_status,
+            transactions.pay_term_number,
+            transactions.pay_term_type,
+            CASE
+                WHEN pay_term_type='days' THEN DATE_ADD(transaction_date, INTERVAL pay_term_number DAY)
+                WHEN pay_term_type='months' THEN DATE_ADD(transaction_date, INTERVAL pay_term_number MONTH)
+                ELSE NULL
+            END as due_date_calc,
+            CASE
+                WHEN pay_term_type='days' THEN DATEDIFF(DATE_ADD(transaction_date, INTERVAL pay_term_number DAY), CURDATE())
+                WHEN pay_term_type='months' THEN DATEDIFF(DATE_ADD(transaction_date, INTERVAL pay_term_number MONTH), CURDATE())
+                ELSE NULL
+            END as days_to_due_calc,
+            COALESCE(contacts.supplier_business_name, contacts.name) as customer_label
+        ";
+
+        $overdueRows = (clone $base)
+            ->whereIn('payment_status', ['due', 'partial'])
+            ->whereNotNull('pay_term_number')
+            ->whereNotNull('pay_term_type')
+            ->whereRaw("IF(pay_term_type='days', DATE_ADD(transaction_date, INTERVAL pay_term_number DAY) < CURDATE(), DATE_ADD(transaction_date, INTERVAL pay_term_number MONTH) < CURDATE())")
+            ->leftJoin('contacts', 'contacts.id', '=', 'transactions.contact_id')
+            ->selectRaw($overdueSelect)
+            ->get();
+
+        $overdueCount = $overdueRows->count();
+        $overdueValue = (float) $overdueRows->sum('final_total');
+
+        // Ageing buckets — agrupa por abs(days_to_due) (já negativo nas overdue).
+        $ageingBuckets = ['0-30d' => 0.0, '30-90d' => 0.0, '90-365d' => 0.0, '>365d' => 0.0];
+        foreach ($overdueRows as $row) {
+            $days = abs((int) ($row->days_to_due_calc ?? 0));
+            $v = (float) $row->final_total;
+            if ($days <= 30) {
+                $ageingBuckets['0-30d'] += $v;
+            } elseif ($days <= 90) {
+                $ageingBuckets['30-90d'] += $v;
+            } elseif ($days <= 365) {
+                $ageingBuckets['90-365d'] += $v;
+            } else {
+                $ageingBuckets['>365d'] += $v;
+            }
+        }
+
+        // Top devedor — maior venda overdue do tenant.
+        $topDevedor = null;
+        $topRow = $overdueRows->sortByDesc(fn ($r) => (float) $r->final_total)->first();
+        if ($topRow) {
+            $name = trim((string) ($topRow->customer_label ?? '')) ?: 'Cliente padrão';
+            $topDevedor = ['name' => $name, 'total' => (float) $topRow->final_total];
+        }
+
+        // Métodos de pagamento — top 5 por SUM(amount) usando o método da ÚLTIMA payment
+        // de cada venda final (espelha lógica do SellController.getListSells linha 1462).
+        // Mapeia chaves curtas pra labels PT-BR.
+        $methodsRaw = DB::table('transaction_payments as tp')
+            ->join('transactions', 'transactions.id', '=', 'tp.transaction_id')
+            ->where('transactions.business_id', $businessId)
+            ->where('transactions.type', 'sell')
+            ->where('transactions.status', 'final')
+            ->whereNull('transactions.sub_type')
+            ->selectRaw('tp.method as method, SUM(tp.amount) as total')
+            ->groupBy('tp.method')
+            ->orderByDesc('total')
+            ->limit(5)
+            ->get();
+
+        $methodLabel = fn (string $m): string => match ($m) {
+            'cash'         => 'Dinheiro',
+            'card'         => 'Cartão',
+            'bank_transfer'=> 'Transferência',
+            'cheque'       => 'Cheque',
+            'other'        => 'Outro',
+            'custom_pay_1' => 'PIX',
+            'custom_pay_2' => 'Boleto',
+            'custom_pay_3' => 'Crediário',
+            ''             => 'Outros',
+            default        => ucfirst($m),
+        };
+
+        $methodsAgg = $methodsRaw->map(fn ($r) => [
+            'method' => $methodLabel((string) ($r->method ?? '')),
+            'total'  => (float) $r->total,
+        ])->values()->all();
+
+        // Top 5 clientes — sum final_total agrupado por contact.
+        $topClientesRaw = (clone $base)
+            ->leftJoin('contacts', 'contacts.id', '=', 'transactions.contact_id')
+            ->selectRaw("COALESCE(NULLIF(TRIM(COALESCE(contacts.supplier_business_name, contacts.name)), ''), 'Cliente padrão') as name, SUM(transactions.final_total) as total")
+            ->groupBy('name')
+            ->orderByDesc('total')
+            ->limit(5)
+            ->get();
+
+        $topClientes = $topClientesRaw->map(fn ($r) => [
+            'name'  => (string) $r->name,
+            'total' => (float) $r->total,
+        ])->values()->all();
+
+        // Ticket médio + total a receber.
+        $aggregates = (clone $base)
+            ->selectRaw('COUNT(*) as c, SUM(final_total) as s, SUM(CASE WHEN payment_status != \'paid\' THEN final_total ELSE 0 END) as a_receber')
+            ->first();
+
+        $ticketMedio = ($aggregates && $aggregates->c > 0) ? (float) ($aggregates->s / $aggregates->c) : 0.0;
+        $totalAReceber = $aggregates ? (float) $aggregates->a_receber : 0.0;
+
+        return [
+            'overdueCount'   => $overdueCount,
+            'overdueValue'   => $overdueValue,
+            'ageingBuckets'  => $ageingBuckets,
+            'methodsAgg'     => $methodsAgg,
+            'topClientes'    => $topClientes,
+            'topDevedor'     => $topDevedor,
+            'ticketMedio'    => $ticketMedio,
+            'totalAReceber'  => $totalAReceber,
+        ];
+    }
+}

--- a/resources/js/Pages/Jana/Dashboard.tsx
+++ b/resources/js/Pages/Jana/Dashboard.tsx
@@ -16,6 +16,7 @@ import { Badge } from '@/Components/ui/badge'
 import { MessageSquare, TrendingUp, TrendingDown, Minus, ExternalLink, Sparkles, Brain, Clock, Zap } from 'lucide-react'
 import FabJana from './components/FabJana'
 import { JanaAreaHeader } from './components/JanaAreaHeader'
+import JanaCockpitV2, { type JanaCockpitV2Props } from './components/JanaCockpitV2'
 
 interface Apuracao {
   data_ref: string
@@ -42,6 +43,15 @@ interface Meta {
 
 interface Props {
   metas: Meta[]
+  /** Jana V2 cockpit payload (movido de /sells Onda 2026-05-26). */
+  sellKpis: JanaCockpitV2Props['sellKpis']
+  insightsAggregates: JanaCockpitV2Props['insightsAggregates']
+  coworkAggregates?: JanaCockpitV2Props['coworkAggregates']
+  janaContext: {
+    businessId: number | null
+    businessName: string
+    userName: string | null
+  }
 }
 
 function calcularFarol(
@@ -252,7 +262,7 @@ function ProximaAcaoCard() {
   )
 }
 
-export default function Dashboard({ metas }: Props) {
+export default function Dashboard({ metas, sellKpis, insightsAggregates, coworkAggregates, janaContext }: Props) {
   return (
     <>
       {/* JanaAreaHeader — header sticky com tabs Dashboard | Chat (Wagner
@@ -260,6 +270,22 @@ export default function Dashboard({ metas }: Props) {
           memory/requisitos/Jana/Chat-header-tabs-visual-comparison.md */}
       <JanaAreaHeader active="dashboard" />
 
+      {/* JanaCockpitV2 — conteúdo primário (movido de /sells Onda 2026-05-26).
+          Wrapper .sells-cowork porque os tokens .vd-insights-* estão escopados
+          nesse seletor em resources/css/sells-cowork-insights.css. */}
+      <div className="sells-cowork px-6 pt-6">
+        <JanaCockpitV2
+          sellKpis={sellKpis}
+          insightsAggregates={insightsAggregates}
+          coworkAggregates={coworkAggregates}
+          userName={janaContext.userName ?? undefined}
+          businessName={janaContext.businessName || undefined}
+          businessId={janaContext.businessId ?? undefined}
+        />
+      </div>
+
+      {/* Bloco secundário — Dashboard de Metas (continua acessível, mas não é
+          mais a face primária da /ia/dashboard). */}
       <div className="space-y-6 p-6">
         <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
           <div className="space-y-2">
@@ -269,12 +295,12 @@ export default function Dashboard({ metas }: Props) {
                 aria-label="Versão Jana V2"
               >
                 <Sparkles className="mr-1 h-3 w-3" aria-hidden="true" />
-                JANA V2
+                METAS
               </Badge>
-              <span className="text-xs text-muted-foreground">Copiloto operacional</span>
+              <span className="text-xs text-muted-foreground">Acompanhamento contínuo</span>
             </div>
             <div>
-              <h1 className="text-2xl font-semibold tracking-tight">Dashboard de Metas</h1>
+              <h2 className="text-xl font-semibold tracking-tight">Metas ativas</h2>
               <p className="text-sm text-muted-foreground">
                 {metas.length} {metas.length === 1 ? 'meta ativa' : 'metas ativas'} — visão consolidada do business
               </p>
@@ -282,7 +308,7 @@ export default function Dashboard({ metas }: Props) {
           </div>
 
           <Link href="/ia">
-            <Button className="gap-2">
+            <Button variant="outline" className="gap-2">
               <MessageSquare className="h-4 w-4" />
               Conversar com a Jana
             </Button>
@@ -295,12 +321,12 @@ export default function Dashboard({ metas }: Props) {
 
         {metas.length === 0 ? (
           <Card className="border-dashed">
-            <CardContent className="flex flex-col items-center justify-center gap-4 py-16 text-center">
+            <CardContent className="flex flex-col items-center justify-center gap-4 py-12 text-center">
               <div className="rounded-full bg-violet-500/10 p-4">
                 <Sparkles className="h-10 w-10 text-violet-500" aria-hidden="true" />
               </div>
               <div className="space-y-1">
-                <p className="text-base font-medium">Nada por aqui ainda</p>
+                <p className="text-base font-medium">Nenhuma meta cadastrada ainda</p>
                 <p className="max-w-sm text-sm text-muted-foreground">
                   Pergunte algo à Jana — ela aprende o que importa pro seu business e cria metas com base no que conversamos.
                 </p>

--- a/resources/js/Pages/Jana/components/JanaCockpitV2.tsx
+++ b/resources/js/Pages/Jana/components/JanaCockpitV2.tsx
@@ -1,19 +1,27 @@
-// SellsInsightsView — Cockpit "Analista IA" da tab Sells (V2 · Onda gaps r5).
+// JanaCockpitV2 — Cockpit "Analista IA" canon da Jana V2, hospedado em /ia/dashboard.
 // Refs:
 //   - prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/chat-jana.jsx (canon visual)
 //   - prototipo-ui/cowork-2026-05-26-comunicacao-visual/project/chat-jana.css (tokens .jc-*)
 //   - memory/requisitos/Sells/Sells-r5-cowork-vs-prod-2026-05-26.md (5 gaps catalogados)
 //
-// V2 fecha 5 gaps vs V1 (PR #1684):
-//  GAP 1 — KPIs row dedicado Jana (4 cards independentes do dashboard)
+// História:
+//   1. PR #1684 — V1 como tab em /sells
+//   2. PR #1686 — V2 fecha 5 gaps r5 (header + KPIs + H2 + Ações + brief)
+//   3. Onda atual — movido pra /ia/dashboard (Jana é marca IA; Sells volta single-view)
+//     Antes: resources/js/Pages/Sells/_components/SellsInsightsView.tsx
+//     Agora: resources/js/Pages/Jana/components/JanaCockpitV2.tsx
+//
+// Mudança técnica da Onda atual: contrato de props refatorado de `rows`-driven
+// (computava ageingBuckets/methodsAgg/topClientes/topDevedor no frontend) pra
+// `insightsAggregates` pré-computed server-side via App\Services\Sells\
+// SellsCockpitAggregator. Componente standalone — não depende de filtros Sells.
+//
+// V2 features:
+//  GAP 1 — KPIs row dedicado Jana (4 cards próprios)
 //  GAP 2 — Lista "AÇÕES QUE [USER] SUGERE" estruturadas (AcaoRow)
 //  GAP 3 — JanaHeader avatar grande + tenant breadcrumb + updatedAt + Configurar/Exportar
 //  GAP 4 — Brief header refinements (📅 + IA pill + "Ouvir áudio" btn placeholder)
 //  GAP 5 — H2 separadores hierárquicos ("ANÁLISES PRINCIPAIS" + "AÇÕES QUE JANA SUGERE")
-//
-// Mode "Analista IA" da rota Sells — mostra brief diário + KPIs Jana + 4 análises + ações
-// sugeridas, usando dados agregados que já existem no payload (sellKpis + coworkAggregates
-// + rows atuais). MVP enxuto. Próxima onda plugará agentes Brain B Jana real (ADR 0035).
 
 import { useMemo, type ReactNode } from 'react';
 import {
@@ -37,7 +45,7 @@ import {
   Zap,
 } from 'lucide-react';
 
-export interface InsightsViewProps {
+export interface JanaCockpitV2Props {
   sellKpis: {
     total: number;
     paid: number;
@@ -53,15 +61,20 @@ export interface InsightsViewProps {
     pixHojeTotal?: number;
     faturadoHojeTotal?: number;
   };
-  /** Vendas atuais (já filtradas no Index pelo saved view + status pill). */
-  rows: Array<{
-    final_total: number;
-    payment_status: string;
-    sla_kind: string;
-    days_to_due: number | null;
-    customer_name: string | null;
-    payment_method_label: string | null;
-  }>;
+  /**
+   * Pré-agregações server-side (SellsCockpitAggregator.buildInsightsAggregates).
+   * Substituem o `rows`-driven que existia em SellsInsightsView V1/V2.
+   */
+  insightsAggregates: {
+    overdueCount: number;
+    overdueValue: number;
+    ageingBuckets: { '0-30d': number; '30-90d': number; '90-365d': number; '>365d': number };
+    methodsAgg: Array<{ method: string; total: number }>;
+    topClientes: Array<{ name: string; total: number }>;
+    topDevedor: { name: string; total: number } | null;
+    ticketMedio: number;
+    totalAReceber: number;
+  };
   userName?: string;
   /** Tenant context pro header breadcrumb. */
   businessName?: string;
@@ -84,81 +97,39 @@ const greeting = (): string => {
 const formatTimeShort = (): string =>
   new Date().toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' });
 
-export default function SellsInsightsView({
+export default function JanaCockpitV2({
   sellKpis,
   coworkAggregates,
-  rows,
+  insightsAggregates,
   userName,
   businessName,
   businessId,
-}: InsightsViewProps): ReactNode {
+}: JanaCockpitV2Props): ReactNode {
   // ── Brief calculations ───────────────────────────────────────────────────
   const faturadoHoje = coworkAggregates?.faturadoHojeTotal ?? 0;
   const pixHoje = coworkAggregates?.pixHojeTotal ?? 0;
   const deltaRev = coworkAggregates?.deltaRevenueVsYesterday ?? null;
   const deltaTicket = coworkAggregates?.deltaTicketVsLastWeek ?? null;
-  const totalVendas = sellKpis?.total ?? rows.length;
-  const totalPendentes = sellKpis?.due ?? rows.filter((r) => r.payment_status !== 'paid').length;
-  const overdueCount = rows.filter((r) => r.sla_kind === 'overdue').length;
-  const overdueValue = rows
-    .filter((r) => r.sla_kind === 'overdue')
-    .reduce((acc, r) => acc + (Number(r.final_total) || 0), 0);
-  const totalAReceber = rows
-    .filter((r) => r.payment_status !== 'paid')
-    .reduce((acc, r) => acc + (Number(r.final_total) || 0), 0);
+  const totalVendas = sellKpis?.total ?? 0;
+  const totalPendentes = sellKpis?.due ?? 0;
 
-  // ── Inadimplência buckets ────────────────────────────────────────────────
-  const ageingBuckets = (() => {
-    const buckets = { '0-30d': 0, '30-90d': 0, '90-365d': 0, '>365d': 0 };
-    rows
-      .filter((r) => r.sla_kind === 'overdue' && r.days_to_due !== null)
-      .forEach((r) => {
-        const days = Math.abs(r.days_to_due as number);
-        const v = Number(r.final_total) || 0;
-        if (days <= 30) buckets['0-30d'] += v;
-        else if (days <= 90) buckets['30-90d'] += v;
-        else if (days <= 365) buckets['90-365d'] += v;
-        else buckets['>365d'] += v;
-      });
-    return buckets;
-  })();
+  // Pré-agregados server-side (SellsCockpitAggregator.buildInsightsAggregates).
+  const overdueCount = insightsAggregates.overdueCount;
+  const overdueValue = insightsAggregates.overdueValue;
+  const totalAReceber = insightsAggregates.totalAReceber;
+  const ageingBuckets = insightsAggregates.ageingBuckets;
   const ageingTotal = Object.values(ageingBuckets).reduce((a, b) => a + b, 0);
-
-  // ── Métodos pagamento ────────────────────────────────────────────────────
-  const methodsAgg = (() => {
-    const m: Record<string, number> = {};
-    rows.forEach((r) => {
-      const k = r.payment_method_label || 'Outros';
-      m[k] = (m[k] ?? 0) + (Number(r.final_total) || 0);
-    });
-    return Object.entries(m)
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 5);
-  })();
-  const methodsTotal = methodsAgg.reduce((a, [, v]) => a + v, 0);
-
-  // ── Top clientes ─────────────────────────────────────────────────────────
-  const topClientes = (() => {
-    const m: Record<string, number> = {};
-    rows.forEach((r) => {
-      const k = r.customer_name || 'Cliente padrão';
-      m[k] = (m[k] ?? 0) + (Number(r.final_total) || 0);
-    });
-    return Object.entries(m)
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 5);
-  })();
-  const topClientesTotal = topClientes.reduce((a, [, v]) => a + v, 0);
+  const methodsAggList = insightsAggregates.methodsAgg;
+  const methodsTotal = methodsAggList.reduce((a, m) => a + m.total, 0);
+  const topClientesList = insightsAggregates.topClientes;
+  const topClientesTotal = topClientesList.reduce((a, c) => a + c.total, 0);
+  const ticketMedio = insightsAggregates.ticketMedio;
+  const topDevedor = insightsAggregates.topDevedor;
 
   // ── Sparkline 30d ────────────────────────────────────────────────────────
   const sparkline = coworkAggregates?.sparkline ?? [];
   const sparkMax = Math.max(...sparkline, 1);
   const sparkSum = sparkline.reduce((a, b) => a + b, 0);
-
-  // ── Ticket médio ─────────────────────────────────────────────────────────
-  const ticketMedio = rows.length > 0
-    ? rows.reduce((acc, r) => acc + (Number(r.final_total) || 0), 0) / rows.length
-    : 0;
 
   const firstName = userName?.split(' ')[0] || 'você';
   const firstNameUpper = firstName.toUpperCase();
@@ -181,33 +152,25 @@ export default function SellsInsightsView({
     const list: Acao[] = [];
     // Sinal 1 — vendas vencidas → régua WhatsApp HITL
     if (overdueCount > 0) {
-      const topDevedor = rows
-        .filter((r) => r.sla_kind === 'overdue')
-        .sort((a, b) => (Number(b.final_total) || 0) - (Number(a.final_total) || 0))[0];
       list.push({
         id: 'regua-whatsapp',
         icon: <MessageSquare size={16} />,
         title: `Régua WhatsApp · ${overdueCount} venda${overdueCount === 1 ? '' : 's'} vencida${overdueCount === 1 ? '' : 's'}`,
-        sub: `Potencial recuperação: ${fmtShort(overdueValue)} · ${topDevedor ? `top devedor: ${topDevedor.customer_name || 'Cliente padrão'}` : ''}`.replace(/ · $/, ''),
+        sub: `Potencial recuperação: ${fmtShort(overdueValue)} · ${topDevedor ? `top devedor: ${topDevedor.name}` : ''}`.replace(/ · $/, ''),
         tone: 'rose',
         cta: { label: 'Disparar', tone: 'danger' },
       });
     }
     // Sinal 2 — top devedor > R$1k (mesmo se não overdue ainda)
-    if (overdueCount > 0 && overdueValue > 1000) {
-      const topDevedor = rows
-        .filter((r) => r.sla_kind === 'overdue')
-        .sort((a, b) => (Number(b.final_total) || 0) - (Number(a.final_total) || 0))[0];
-      if (topDevedor?.customer_name) {
-        list.push({
-          id: 'negociar-top',
-          icon: <Sparkles size={16} />,
-          title: `Negociar com ${topDevedor.customer_name}`,
-          sub: `Valor ${fmtShort(Number(topDevedor.final_total) || 0)} · contato direto vale mais que régua automática`,
-          tone: 'violet',
-          cta: { label: 'Preparar', tone: 'violet' },
-        });
-      }
+    if (overdueCount > 0 && overdueValue > 1000 && topDevedor) {
+      list.push({
+        id: 'negociar-top',
+        icon: <Sparkles size={16} />,
+        title: `Negociar com ${topDevedor.name}`,
+        sub: `Valor ${fmtShort(topDevedor.total)} · contato direto vale mais que régua automática`,
+        tone: 'violet',
+        cta: { label: 'Preparar', tone: 'violet' },
+      });
     }
     // Sinal 3 — queda ticket médio
     if (deltaTicket !== null && deltaTicket <= -5) {
@@ -244,7 +207,7 @@ export default function SellsInsightsView({
       });
     }
     return list;
-  }, [overdueCount, overdueValue, deltaTicket, faturadoHoje, pixHoje, totalPendentes, rows]);
+  }, [overdueCount, overdueValue, deltaTicket, faturadoHoje, pixHoje, totalPendentes, topDevedor]);
 
   // ── GAP 1 — KPIs row Jana (4 cards próprios) ─────────────────────────────
   interface JanaKpi {
@@ -406,18 +369,13 @@ export default function SellsInsightsView({
               </span>
               <strong className="vd-neg">{fmtShort(overdueValue)}</strong> em{' '}
               <strong>{overdueCount} vendas vencidas</strong>. Top devedor:{' '}
-              {(() => {
-                const top = rows
-                  .filter((r) => r.sla_kind === 'overdue')
-                  .sort((a, b) => (b.final_total || 0) - (a.final_total || 0))[0];
-                return top ? (
-                  <>
-                    <strong>{top.customer_name || 'Cliente padrão'}</strong> ({fmtShort(top.final_total)})
-                  </>
-                ) : (
-                  '—'
-                );
-              })()}
+              {topDevedor ? (
+                <>
+                  <strong>{topDevedor.name}</strong> ({fmtShort(topDevedor.total)})
+                </>
+              ) : (
+                '—'
+              )}
               .
             </p>
           )}
@@ -568,23 +526,23 @@ export default function SellsInsightsView({
             </div>
           </header>
           <div className="vd-insights-card-big">
-            <span>{topClientes.length}</span>
+            <span>{topClientesList.length}</span>
           </div>
           <div className="vd-insights-bars">
-            {topClientes.length === 0 ? (
+            {topClientesList.length === 0 ? (
               <div className="vd-insights-empty">Sem dados de clientes</div>
             ) : (
-              topClientes.map(([name, value]) => (
-                <div key={name} className="vd-insights-bar-row">
+              topClientesList.map((c) => (
+                <div key={c.name} className="vd-insights-bar-row">
                   <div className="vd-insights-bar-lbl">
-                    <span title={name}>{name.slice(0, 28)}</span>
-                    <b>{fmtShort(value)}</b>
+                    <span title={c.name}>{c.name.slice(0, 28)}</span>
+                    <b>{fmtShort(c.total)}</b>
                   </div>
                   <div className="vd-insights-bar">
                     <div
                       className="vd-insights-bar-fill"
                       style={{
-                        width: topClientesTotal > 0 ? `${(value / topClientesTotal) * 100}%` : '0%',
+                        width: topClientesTotal > 0 ? `${(c.total / topClientesTotal) * 100}%` : '0%',
                       }}
                     />
                   </div>
@@ -600,29 +558,29 @@ export default function SellsInsightsView({
             <span className="vd-insights-card-ic"><CreditCard size={16} /></span>
             <div>
               <b>Métodos de pagamento</b>
-              <small>top {methodsAgg.length}</small>
+              <small>top {methodsAggList.length}</small>
             </div>
           </header>
           <div className="vd-insights-card-big">
             <span>{fmtShort(methodsTotal)}</span>
           </div>
           <div className="vd-insights-bars">
-            {methodsAgg.length === 0 ? (
+            {methodsAggList.length === 0 ? (
               <div className="vd-insights-empty">Sem pagamentos registrados</div>
             ) : (
-              methodsAgg.map(([method, value]) => (
-                <div key={method} className="vd-insights-bar-row">
+              methodsAggList.map((m) => (
+                <div key={m.method} className="vd-insights-bar-row">
                   <div className="vd-insights-bar-lbl">
-                    <span>{method}</span>
+                    <span>{m.method}</span>
                     <b>
-                      {methodsTotal > 0 ? Math.round((value / methodsTotal) * 100) : 0}%
+                      {methodsTotal > 0 ? Math.round((m.total / methodsTotal) * 100) : 0}%
                     </b>
                   </div>
                   <div className="vd-insights-bar">
                     <div
                       className="vd-insights-bar-fill green"
                       style={{
-                        width: methodsTotal > 0 ? `${(value / methodsTotal) * 100}%` : '0%',
+                        width: methodsTotal > 0 ? `${(m.total / methodsTotal) * 100}%` : '0%',
                       }}
                     />
                   </div>

--- a/resources/js/Pages/Sells/Index.tsx
+++ b/resources/js/Pages/Sells/Index.tsx
@@ -50,7 +50,9 @@ import SellsTabelaUnificada, {
   type SaleRow as UnifiedSaleRow,
 } from './_components/SellsTabelaUnificada';
 import SellsCheatSheet, { SELLS_INDEX_SHORTCUTS } from './_components/SellsCheatSheet';
-import SellsInsightsView from './_components/SellsInsightsView';
+// Insights Jana movido pra /ia/dashboard (Jana V2 canon). Antes era tab embutida aqui via
+// `viewMode === 'insights'` + SellsInsightsView. Ver Modules/Jana/Http/Controllers/DashboardController
+// + resources/js/Pages/Jana/components/JanaCockpitV2.tsx.
 
 // ──────────────────────────────────────────────────────────────
 // TIPOS
@@ -427,14 +429,8 @@ const SAVED_VIEWS: SavedView[] = [
 // MAIN — SellsIndex
 // ──────────────────────────────────────────────────────────────
 export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
-  // Auth user + business pra view Insights Jana (greeting + header dedicado com tenant breadcrumb).
-  const sharedPage = usePage<{
-    auth?: { user?: { name?: string; business_id?: number } };
-    business?: { id?: number; name?: string };
-  }>();
-  const authUserName = sharedPage.props.auth?.user?.name;
-  const businessName = sharedPage.props.business?.name;
-  const businessIdShared = sharedPage.props.business?.id ?? sharedPage.props.auth?.user?.business_id;
+  // (authUserName + businessName + businessIdShared removidos junto com o render
+  // Insights Jana — usavam-se só pra header tenant. Veja /ia/dashboard via Jana V2.)
   // Tier 0 multi-tenant: storage scoped per business_id (ver useBizStorage acima).
   const ls = useBizStorage();
 
@@ -482,15 +478,9 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
   // Branch tree expand/collapse state (não persiste — UX volátil).
   const [origemExpanded, setOrigemExpanded] = useState<boolean>(false);
 
-  // KB-9.75 P5 parking lot — tab bar topo Sells [Dashboard | Insights Jana].
-  // Mode "Analista IA" alterna view sem mudar rota — preserva filtros/state Index.
-  // Persistência Tier 0 multi-tenant: `oimpresso.sells.b{biz}.u{user}.view_mode`.
-  type ViewMode = 'dashboard' | 'insights';
-  const [viewMode, setViewMode] = useState<ViewMode>(() => {
-    const v = ls.get('view_mode', 'dashboard');
-    return (['dashboard', 'insights'] as const).includes(v as ViewMode) ? (v as ViewMode) : 'dashboard';
-  });
-  useEffect(() => ls.set('view_mode', viewMode), [viewMode]);
+  // Tab bar [Dashboard | Insights Jana] removida — Insights migrado pra /ia/dashboard
+  // (Jana V2 canon). viewMode state + localStorage `view_mode` removidos. Sells/Index
+  // volta a ser single-view (Dashboard) sem mode-switching.
 
   // Data fetch state.
   const [rows, setRows] = useState<SaleRow[]>([]);
@@ -1080,29 +1070,8 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
                 'Pedidos · faturamento · NF-e/NFS-e'
               )}
             </p>
-            {/* KB-9.75 P5 — Tab bar Dashboard | Insights Jana.
-                Alterna view sem mudar rota; preserva filtros/state Index.
-                Persistência Tier 0 via `ls.view_mode`. */}
-            <div className="vd-tabs-mode" role="tablist" aria-label="Modo de visualização">
-              <button
-                type="button"
-                className={`vd-tabs-mode-btn ${viewMode === 'dashboard' ? 'active' : ''}`}
-                onClick={() => setViewMode('dashboard')}
-                role="tab"
-                aria-selected={viewMode === 'dashboard'}
-              >
-                <span className="vd-tabs-mode-ic"><BarChart3 size={12} /></span> Dashboard
-              </button>
-              <button
-                type="button"
-                className={`vd-tabs-mode-btn ${viewMode === 'insights' ? 'active' : ''}`}
-                onClick={() => setViewMode('insights')}
-                role="tab"
-                aria-selected={viewMode === 'insights'}
-              >
-                <span className="vd-tabs-mode-ic">✦</span> Insights Jana
-              </button>
-            </div>
+            {/* Tab bar Dashboard | Insights Jana removida — Insights V2 migrado pra
+                /ia/dashboard (canon Jana). */}
           </div>
 
           <div className="os-head-r">
@@ -1115,27 +1084,7 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
           </div>
         </header>
 
-        {/* KB-9.75 P5 — Conditional render por viewMode.
-            Dashboard = toolbar + KPIs + table + pagination + bulk (legacy).
-            Insights Jana = SellsInsightsView com brief + 4 análises. */}
-        {viewMode === 'insights' ? (
-          <SellsInsightsView
-            sellKpis={props.sellKpis}
-            coworkAggregates={props.coworkAggregates}
-            rows={filtered.map((r) => ({
-              final_total: Number(r.final_total) || 0,
-              payment_status: r.payment_status ?? '',
-              sla_kind: r.sla_kind ?? '',
-              days_to_due: r.days_to_due ?? null,
-              customer_name: r.customer_name ?? null,
-              payment_method_label: r.payment_method_label ?? null,
-            }))}
-            userName={authUserName}
-            businessName={businessName}
-            businessId={businessIdShared}
-          />
-        ) : (
-        <>
+        {/* Render do Dashboard (Insights Jana migrado pra /ia/dashboard). */}
         {/* TOOLBAR linha 2: Foco group + Visões btn / Imprimir + Visões ▾ */}
         <div className="vd-toolbar">
           <div className="vd-toolbar-l">
@@ -1699,8 +1648,6 @@ export default function SellsIndex(props: SellsIndexPageProps): ReactNode {
               ✕
             </button>
           </div>
-        )}
-        </>
         )}
 
         {/* CHEAT-SHEET (?) */}


### PR DESCRIPTION
## Summary

- Cockpit \"Analista IA\" (brief diário + KPIs + 4 análises + ações) sai da tab `Insights Jana` em /sells e vira o conteúdo primário de **/ia/dashboard**. Jana é a marca IA — lugar dela é a tela IA.
- /sells volta a abrir direto em modo Dashboard único, sem tab bar.
- Extrai `App\Services\Sells\SellsCockpitAggregator` (~315 LOC) com 3 métodos: `buildSellKpis`, `buildCoworkAggregates`, `buildInsightsAggregates`. Multi-tenant Tier 0 IRREVOGÁVEL ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)) — business_id explícito em todo where().

## Mudanças

| Arquivo | Antes | Depois |
|---|---|---|
| [app/Services/Sells/SellsCockpitAggregator.php](app/Services/Sells/SellsCockpitAggregator.php) | (não existia) | Service novo — 3 métodos públicos pra ambos controllers |
| [app/Http/Controllers/SellController.php](app/Http/Controllers/SellController.php) | sellKpis inline + buildCoworkAggregates(private) embutido | `app(SellsCockpitAggregator::class)` chama buildSellKpis + buildCoworkAggregates(defer). ~125 LOC migradas |
| [Modules/Jana/Http/Controllers/DashboardController.php](Modules/Jana/Http/Controllers/DashboardController.php) | passa só metas | Injeta SellsCockpitAggregator + passa sellKpis + insightsAggregates + coworkAggregates(defer) + janaContext |
| [resources/js/Pages/Sells/_components/SellsInsightsView.tsx](resources/js/Pages/Sells/_components/SellsInsightsView.tsx) → [resources/js/Pages/Jana/components/JanaCockpitV2.tsx](resources/js/Pages/Jana/components/JanaCockpitV2.tsx) | rows-driven (filtered.map…) | insightsAggregates pré-computado server-side — standalone |
| [resources/js/Pages/Jana/Dashboard.tsx](resources/js/Pages/Jana/Dashboard.tsx) | só Metas | JanaCockpitV2 primário (wrapper .sells-cowork) + Metas subordinado h2 |
| [resources/js/Pages/Sells/Index.tsx](resources/js/Pages/Sells/Index.tsx) | tab bar [Dashboard\|Insights Jana] + viewMode state + render condicional | -75 LOC; single-view Dashboard. authUserName/businessName/businessIdShared cleanup |

## Test plan

- [ ] `vendor/bin/pest --filter \"Sell|Jana.*Dashboard\"` — aggregator extraído com lógica idêntica.
- [ ] Smoke prod **/sells**: sem tab bar; KPIs Caixa/Faturamento/Comissão funcionam; tabela paginada idem.
- [ ] Smoke prod **/ia/dashboard** (biz=1):
  - JanaHeader avatar gradient violeta + tenant breadcrumb \`WR2 SISTEMAS · biz=1 · v2026.05\`
  - Brief diário com greeting + \"X vendas no período · Y pendentes\"
  - Anomaly bar inadimplência (se overdue > 0): \"R\$ N em M vendas vencidas. Top devedor: …\"
  - 4 KPIs Jana (Faturamento mês / Inadimplência total / Ticket médio / PIX hoje)
  - H2 \"📊 ANÁLISES PRINCIPAIS\" + grid 2x2 (Inadimplência ageing 0-30/30-90/90-365/>365 + Faturamento sparkline 30d + Top 5 clientes + Métodos pagamento)
  - H2 \"💡 AÇÕES QUE [USER] SUGERE\" + AcaoRows (rose/violet/peach/grey tones)
  - \"Metas ativas\" abaixo do cockpit, empty state quando 0 metas
- [ ] Multi-tenant Tier 0 — biz=1 vs biz=4 isolados (sellKpis e insightsAggregates).

## Não-objetivos

- Não cria CSS escopado novo `.jana-cockpit` (reusa `.sells-cowork` via wrapper). Onda futura.
- Não muda rotas (/sells e /ia/dashboard preservadas).
- Não toca getListSells AJAX endpoint — DataTable do /sells continua igual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)