### PR TITLE
style(sells/insights): ícones lucide Linear-style (tile sutil)

### DIFF
--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -282,8 +282,11 @@
   color: oklch(0.40 0.18 60);
 }
 .sells-cowork .vd-date-filter-hint-ic {
-  font-size: 16px;
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
   line-height: 1;
+  color: currentColor;
 }
 .sells-cowork .vd-date-filter-hint-tx {
   flex: 1;

--- a/resources/css/sells-cowork-insights.css
+++ b/resources/css/sells-cowork-insights.css
@@ -48,8 +48,11 @@
 }
 
 .sells-cowork .vd-tabs-mode-btn .vd-tabs-mode-ic {
-  font-size: 13px;
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
   line-height: 1;
+  color: currentColor;
 }
 
 /* ============================================================
@@ -233,8 +236,18 @@
   gap: 10px;
 }
 
+/* Card icon · Linear-style tile (subtle muted bg + monochrome icon centered).
+   Substitui emoji direto por lucide React via container squared 32x32. */
 .sells-cowork .vd-insights-card-ic {
-  font-size: 18px;
+  flex-shrink: 0;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  background: oklch(0.96 0.005 250);
+  color: oklch(0.40 0.008 250);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   line-height: 1;
 }
 
@@ -628,9 +641,18 @@
   margin-bottom: 4px;
 }
 
+/* KPI icon · Linear-style compact tile (22x22 subtle bg + monochrome icon).
+   Antes era emoji direto via font-size · agora hospeda lucide React. */
 .sells-cowork .vd-insights-kpi-ic {
-  font-size: 14px;
-  opacity: 0.85;
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  background: oklch(0.96 0.005 250);
+  color: oklch(0.45 0.008 250);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
 }
 
 .sells-cowork .vd-insights-kpi-v {
@@ -675,8 +697,13 @@
   gap: 7px;
 }
 
+/* H2 separator icon · inline neutral muted matching h2 text color. */
 .sells-cowork .vd-insights-h2-ic {
-  font-size: 14px;
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+  color: oklch(0.55 0.01 250);
+  line-height: 1;
 }
 
 /* Sparkline range labels (D-N → hoje) */


### PR DESCRIPTION
## Bug visual

PR [#1690](https://github.com/wagnerra23/oimpresso.com/pull/1690) trocou 12 emojis por lucide React em `SellsInsightsView` + `Sells/Index` (R3 lint compliance). Wagner reportou: *"acho feio esse padrão deveria ser saas moderno igual Linear"*.

Causa raiz: os 5 containers de ícone (\`vd-insights-kpi-ic\`, \`vd-insights-card-ic\`, \`vd-insights-h2-ic\`, \`vd-tabs-mode-ic\`, \`vd-date-filter-hint-ic\`) foram desenhados com \`font-size: 14-18px; opacity: 0.85\` — perfeito pra emoji-glyph colorido. Mas lucide é SVG monocromático com \`size={X}\` prop — resultado: outline solto flutuando sem ancoragem visual.

## Fix Linear-style

Wrap dos ícones em **tile sutil + cor monocromática muted** (padrão Linear Insights / Stripe Dashboard / Shopify Admin).

| Container | Antes | Depois |
|---|---|---|
| \`vd-insights-kpi-ic\` (KPI Jana header) | font-size 14 + opacity .85 | 22x22 tile · bg muted · icon centered |
| \`vd-insights-card-ic\` (4 cards análise) | font-size 18 | 32x32 tile · bg muted · icon centered |
| \`vd-insights-h2-ic\` (separadores H2) | font-size 14 | inline-flex · color matching h2 muted |
| \`vd-tabs-mode-ic\` (Dashboard/Insights toggle) | font-size 13 | inline-flex · vertical-align middle |
| \`vd-date-filter-hint-ic\` (filtro data) | font-size 16 | inline-flex · currentColor |

Cores neutras via oklch (mantém canon da paleta · zero color literal Tailwind).

## Diff

\`\`\`
resources/css/inertia.css                |  5 ++++-
resources/css/sells-cowork-insights.css  | 37 ++++++++++++++++++++++++++++-----
2 files changed, 36 insertions(+), 6 deletions(-)
\`\`\`

CSS-only · zero impacto em TypeScript / Pest / ratchet R1.

## Test plan

- [ ] CI passa (\`UI Lint · ratchet\` · \`Frontend / Vite build\`)
- [ ] Smoke /sells → tab Insights Jana → ícones em tiles cinza sutil (não mais "flutuando")
- [ ] Smoke /sells → tab Dashboard/Insights toggle → ícone alinhado vertical
- [ ] Smoke /sells → filtro data ativo → calendar icon inline

## Refs

- Constituição UI v2 · [ADR UI-0013](memory/requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md)
- PR [#1690](https://github.com/wagnerra23/oimpresso.com/pull/1690) (origem da troca emoji → lucide)
- Linear Insights · Stripe Dashboard · Shopify Admin (referência visual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)