### PR TITLE
feat(cliente): 3º telefone + e-mail comercial + e-mail NF-e

### DIFF
--- a/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
+++ b/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
@@ -207,7 +207,12 @@ class ClienteAutosaveController extends Controller
     /**
      * PATCH /cliente/{id}/contato
      *
-     * Campos: mobile, tel2, email, site_url, canal_preferido.
+     * Campos: mobile, tel2, alternate_number, email, email_billing, email_nfe,
+     * site_url, canal_preferido.
+     *
+     * Onda 1 PR B' 2026-05-26 (Daniela @ Martinho):
+     *   - alternate_number EXPOSTO (campo UPOS legacy = 3º telefone)
+     *   - email_billing + email_nfe novos (migration 2026_05_26_140000)
      */
     public function contato(Request $request, int $id): JsonResponse
     {
@@ -219,7 +224,12 @@ class ClienteAutosaveController extends Controller
         $validator = Validator::make($request->all(), [
             'mobile' => ['nullable', 'string', 'max:25'],
             'tel2' => ['nullable', 'string', 'max:20'],
+            // Onda 1 PR B' — 3º telefone via coluna UPOS legacy `alternate_number`.
+            'alternate_number' => ['nullable', 'string', 'max:25'],
             'email' => ['nullable', 'email', 'max:255'],
+            // Onda 1 PR B' — emails diferenciados (comercial / NF-e).
+            'email_billing' => ['nullable', 'email', 'max:320'],
+            'email_nfe' => ['nullable', 'email', 'max:320'],
             // site_url aceita URL com ou sem scheme. Larissa biz=4 digita
             // "exemplo.com.br" sem https:// -- aceitamos.
             'site_url' => ['nullable', 'string', 'max:120', 'regex:/^(https?:\/\/)?[a-zA-Z0-9][a-zA-Z0-9-]{0,61}(\.[a-zA-Z0-9][a-zA-Z0-9-]{0,61})+\/?.*$/'],
@@ -512,7 +522,13 @@ class ClienteAutosaveController extends Controller
             'cargo' => $contact->cargo ?? null,
             'mobile' => $contact->mobile ?? null,
             'tel2' => $contact->tel2 ?? null,
+            // Onda 1 PR B' (Daniela) — 3º telefone via coluna UPOS legacy.
+            'alternate_number' => $contact->alternate_number ?? null,
             'email' => $contact->email ?? null,
+            // Onda 1 PR B' — emails diferenciados (comercial / NF-e). Migration
+            // 2026_05_26_140000_add_emails_extras_to_contacts.
+            'email_billing' => $contact->email_billing ?? null,
+            'email_nfe' => $contact->email_nfe ?? null,
             'site_url' => $contact->site_url ?? null,
             'canal_preferido' => $contact->canal_preferido ?? null,
             'zip_code' => $contact->zip_code ?? null,

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -1214,6 +1214,8 @@ class ContactController extends Controller
                 'prefix', 'first_name', 'middle_name', 'last_name', 'tax_number', 'pay_term_number', 'pay_term_type', 'mobile', 'landline', 'alternate_number', 'city', 'state', 'country', 'address_line_1', 'address_line_2', 'customer_group_id', 'zip_code', 'contact_id', 'custom_field1', 'custom_field2', 'custom_field3', 'custom_field4', 'custom_field5', 'custom_field6', 'custom_field7', 'custom_field8', 'custom_field9', 'custom_field10', 'email', 'shipping_address', 'position', 'dob', 'shipping_custom_field_details', 'assigned_to_users',
                 // Campos BR restaurados — migration 2026_05_21_140000 (regressão UPOS 6.7).
                 'cpf_cnpj', 'rg', 'inscricao_estadual', 'inscricao_municipal', 'indicador_ie', 'nome_fantasia', 'consumidor_final', 'contribuinte', 'regime', 'suframa',
+                // Onda 1 PR B' (Daniela @ Martinho) — emails extras (migration 2026_05_26_140000).
+                'email_billing', 'email_nfe',
             ]);
 
             $name_array = [];

--- a/database/migrations/2026_05_26_140000_add_emails_extras_to_contacts.php
+++ b/database/migrations/2026_05_26_140000_add_emails_extras_to_contacts.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Onda 1 PR B' 2026-05-26 — Pedido Daniela @ Martinho.
+ *
+ * Adiciona 2 colunas de email diferenciado em `contacts`:
+ *   - email_billing: email do contato comercial / cobrança
+ *   - email_nfe:     email pra envio de NF-e / NFS-e (área fiscal)
+ *
+ * Daniela explicou que o email principal já existe (campo `email`) mas é o
+ * pessoal — quando emite NF-e, precisa mandar pro contador (email_nfe), e o
+ * comercial vai pro vendedor (email_billing).
+ *
+ * Telefones: SEM migration — UPOS já tem `mobile`+`landline`+`alternate_number`,
+ * Wave B drawer adicionou `tel2` (PR #1422). PR B' apenas EXPÕE
+ * `alternate_number` no Edit/Drawer pra Daniela cadastrar 3º telefone.
+ *
+ * Idempotente via Schema::hasColumn — seguro de rodar 2x.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('contacts', function (Blueprint $table) {
+            if (! Schema::hasColumn('contacts', 'email_billing')) {
+                $table->string('email_billing', 320)->nullable()->after('email');
+            }
+            if (! Schema::hasColumn('contacts', 'email_nfe')) {
+                $table->string('email_nfe', 320)->nullable()->after('email_billing');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('contacts', function (Blueprint $table) {
+            if (Schema::hasColumn('contacts', 'email_nfe')) {
+                $table->dropColumn('email_nfe');
+            }
+            if (Schema::hasColumn('contacts', 'email_billing')) {
+                $table->dropColumn('email_billing');
+            }
+        });
+    }
+};

--- a/resources/js/Pages/Cliente/_drawer/ContatoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/ContatoTab.tsx
@@ -24,9 +24,14 @@ export interface ContactInfo {
   id: number;
   tel?: string | null;
   tel2?: string | null;
+  // Onda 1 PR B' (Daniela @ Martinho) — 3º telefone via coluna UPOS legacy.
+  alternate_number?: string | null;
   mobile?: string | null;
   landline?: string | null;
   email?: string | null;
+  // Onda 1 PR B' — emails diferenciados (comercial / NF-e).
+  email_billing?: string | null;
+  email_nfe?: string | null;
   site?: string | null;
   canal?: 'whatsapp' | 'email' | 'telefone' | 'presencial' | null;
 }
@@ -59,7 +64,12 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
   const initialTel = contact.tel ?? contact.mobile ?? contact.landline ?? '';
   const [tel, setTel] = useState<string>(maskTel(initialTel));
   const [tel2, setTel2] = useState<string>(maskTel(contact.tel2 ?? ''));
+  // Onda 1 PR B' — 3º telefone (alternate_number UPOS legacy).
+  const [tel3, setTel3] = useState<string>(maskTel(contact.alternate_number ?? ''));
   const [email, setEmail] = useState<string>(contact.email ?? '');
+  // Onda 1 PR B' — emails diferenciados.
+  const [emailBilling, setEmailBilling] = useState<string>(contact.email_billing ?? '');
+  const [emailNfe, setEmailNfe] = useState<string>(contact.email_nfe ?? '');
   const [site, setSite] = useState<string>(contact.site ?? '');
   const [canal, setCanal] = useState<CanalValue | ''>((contact.canal as CanalValue) ?? '');
 
@@ -74,7 +84,10 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
     const t = contact.tel ?? contact.mobile ?? contact.landline ?? '';
     setTel(maskTel(t));
     setTel2(maskTel(contact.tel2 ?? ''));
+    setTel3(maskTel(contact.alternate_number ?? ''));
     setEmail(contact.email ?? '');
+    setEmailBilling(contact.email_billing ?? '');
+    setEmailNfe(contact.email_nfe ?? '');
     setSite(contact.site ?? '');
     setCanal((contact.canal as CanalValue) ?? '');
     setErrorField(null);
@@ -88,11 +101,25 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
     return null;
   }, [email]);
 
+  // Onda 1 PR B' — validação dos 2 emails extras (mesma regra).
+  const emailBillingError = useMemo<string | null>(() => {
+    if (!emailBilling) return null;
+    return validateEmail(emailBilling) === false ? 'Formato de e-mail inválido.' : null;
+  }, [emailBilling]);
+
+  const emailNfeError = useMemo<string | null>(() => {
+    if (!emailNfe) return null;
+    return validateEmail(emailNfe) === false ? 'Formato de e-mail inválido.' : null;
+  }, [emailNfe]);
+
   // ── Autosave debounced ───────────────────────────────────────────────
   const rollbackField = useCallback((field: string, prev: unknown) => {
     if (field === 'tel') setTel((prev as string) ?? '');
     else if (field === 'tel2') setTel2((prev as string) ?? '');
+    else if (field === 'alternate_number') setTel3((prev as string) ?? '');
     else if (field === 'email') setEmail((prev as string) ?? '');
+    else if (field === 'email_billing') setEmailBilling((prev as string) ?? '');
+    else if (field === 'email_nfe') setEmailNfe((prev as string) ?? '');
     else if (field === 'site') setSite((prev as string) ?? '');
     else if (field === 'canal') setCanal((prev as CanalValue | '') ?? '');
   }, []);
@@ -163,6 +190,8 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
   const handleBlur = useCallback(
     (field: string, value: unknown) => {
       if (field === 'email' && emailError) return;
+      if (field === 'email_billing' && emailBillingError) return;
+      if (field === 'email_nfe' && emailNfeError) return;
       const prev = previousValuesRef.current[field];
       if (debounceTimersRef.current[field]) {
         clearTimeout(debounceTimersRef.current[field]);
@@ -170,7 +199,7 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
       }
       performSave(field, value, prev);
     },
-    [emailError, performSave]
+    [emailError, emailBillingError, emailNfeError, performSave]
   );
 
   const handleCanalChange = useCallback(
@@ -236,6 +265,32 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
           />
         </div>
 
+        {/* Onda 1 PR B' (Daniela @ Martinho) — 3º telefone via coluna UPOS legacy `alternate_number`. */}
+        <div className="md:col-span-2">
+          <Label htmlFor="ct-tel3" className="text-xs font-medium">
+            Telefone 3 <span className="text-muted-foreground font-normal">(opcional · recados)</span>
+          </Label>
+          <Input
+            id="ct-tel3"
+            value={tel3}
+            placeholder="(00) 0 0000-0000"
+            disabled={disabled}
+            inputMode="tel"
+            onChange={(e) => {
+              const prev = tel3;
+              const v = maskTel(e.target.value);
+              setTel3(v);
+              scheduleAutosave('alternate_number', v, prev);
+            }}
+            onBlur={(e) => handleBlur('alternate_number', e.target.value)}
+          />
+          <FieldStatus
+            saving={savingField === 'alternate_number'}
+            saved={savedField === 'alternate_number'}
+            backendError={errorField?.field === 'alternate_number' ? errorField.message : null}
+          />
+        </div>
+
         <div className="md:col-span-2">
           <Label htmlFor="ct-email" className="text-xs font-medium">
             E-mail
@@ -263,6 +318,68 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
             saving={savingField === 'email'}
             saved={savedField === 'email'}
             backendError={errorField?.field === 'email' ? errorField.message : null}
+          />
+        </div>
+
+        {/* Onda 1 PR B' (Daniela @ Martinho) — E-mails diferenciados.
+            Migration 2026_05_26_140000_add_emails_extras_to_contacts. */}
+        <div>
+          <Label htmlFor="ct-email-billing" className="text-xs font-medium">
+            E-mail comercial <span className="text-muted-foreground font-normal">(opcional · vendedor)</span>
+          </Label>
+          <Input
+            id="ct-email-billing"
+            type="email"
+            value={emailBilling}
+            placeholder="comercial@exemplo.com.br"
+            disabled={disabled}
+            aria-invalid={!!emailBillingError}
+            aria-describedby={emailBillingError ? 'ct-email-billing-error' : undefined}
+            onChange={(e) => {
+              const prev = emailBilling;
+              const v = e.target.value;
+              setEmailBilling(v);
+              scheduleAutosave('email_billing', v, prev);
+            }}
+            onBlur={(e) => handleBlur('email_billing', e.target.value)}
+            className={emailBillingError ? 'border-rose-500 focus-visible:ring-rose-400' : ''}
+          />
+          <FieldStatus
+            error={emailBillingError}
+            errorId="ct-email-billing-error"
+            saving={savingField === 'email_billing'}
+            saved={savedField === 'email_billing'}
+            backendError={errorField?.field === 'email_billing' ? errorField.message : null}
+          />
+        </div>
+
+        <div>
+          <Label htmlFor="ct-email-nfe" className="text-xs font-medium">
+            E-mail NF-e <span className="text-muted-foreground font-normal">(opcional · contador)</span>
+          </Label>
+          <Input
+            id="ct-email-nfe"
+            type="email"
+            value={emailNfe}
+            placeholder="contador@exemplo.com.br"
+            disabled={disabled}
+            aria-invalid={!!emailNfeError}
+            aria-describedby={emailNfeError ? 'ct-email-nfe-error' : undefined}
+            onChange={(e) => {
+              const prev = emailNfe;
+              const v = e.target.value;
+              setEmailNfe(v);
+              scheduleAutosave('email_nfe', v, prev);
+            }}
+            onBlur={(e) => handleBlur('email_nfe', e.target.value)}
+            className={emailNfeError ? 'border-rose-500 focus-visible:ring-rose-400' : ''}
+          />
+          <FieldStatus
+            error={emailNfeError}
+            errorId="ct-email-nfe-error"
+            saving={savingField === 'email_nfe'}
+            saved={savedField === 'email_nfe'}
+            backendError={errorField?.field === 'email_nfe' ? errorField.message : null}
           />
         </div>
 

--- a/resources/js/Pages/Cliente/_drawer/ContatoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/ContatoTab.tsx
@@ -59,6 +59,10 @@ function getCsrfToken(): string {
   );
 }
 
+// Onda 1 PR B' 2026-05-26 — Extraído pra constante única (atende UI Lint ratchet).
+// Evita 3 ocorrências literais idênticas (email/email_billing/email_nfe).
+const INVALID_INPUT_CLASS = 'border-rose-500 focus-visible:ring-rose-400';
+
 export default function ContatoTab({ contact, onSaved, disabled = false }: ContatoTabProps) {
   // Resolve tel inicial: prioriza `tel` (nova coluna Wave B), fallback pra mobile/landline UPOS legacy
   const initialTel = contact.tel ?? contact.mobile ?? contact.landline ?? '';
@@ -310,7 +314,7 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
               scheduleAutosave('email', v, prev);
             }}
             onBlur={(e) => handleBlur('email', e.target.value)}
-            className={emailError ? 'border-rose-500 focus-visible:ring-rose-400' : ''}
+            className={emailError ? INVALID_INPUT_CLASS : ''}
           />
           <FieldStatus
             error={emailError}
@@ -342,7 +346,7 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
               scheduleAutosave('email_billing', v, prev);
             }}
             onBlur={(e) => handleBlur('email_billing', e.target.value)}
-            className={emailBillingError ? 'border-rose-500 focus-visible:ring-rose-400' : ''}
+            className={emailBillingError ? INVALID_INPUT_CLASS : ''}
           />
           <FieldStatus
             error={emailBillingError}
@@ -372,7 +376,7 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
               scheduleAutosave('email_nfe', v, prev);
             }}
             onBlur={(e) => handleBlur('email_nfe', e.target.value)}
-            className={emailNfeError ? 'border-rose-500 focus-visible:ring-rose-400' : ''}
+            className={emailNfeError ? INVALID_INPUT_CLASS : ''}
           />
           <FieldStatus
             error={emailNfeError}

--- a/tests/Feature/Cliente/ClienteContatoEmailsExtrasTest.php
+++ b/tests/Feature/Cliente/ClienteContatoEmailsExtrasTest.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * GUARD — Onda 1 PR B' 2026-05-26 — Daniela @ Martinho.
+ *
+ * Cobertura:
+ *   1. Migration adiciona email_billing + email_nfe em `contacts` (idempotente)
+ *   2. PATCH /cliente/{id}/contato aceita alternate_number, email_billing, email_nfe
+ *   3. shapeContactResponse retorna os 3 campos
+ *   4. Tier 0 multi-tenant — biz=99 não atualiza contact biz=1 (404)
+ *
+ * Skip-graceful em sqlite memory.
+ */
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    if (! Schema::hasTable('contacts')) {
+        $this->markTestSkipped('Schema UltimatePOS ausente (sqlite memory) — rode com DB_CONNECTION=mysql.');
+    }
+
+    $this->business = \App\Business::first();
+    if (! $this->business) {
+        $this->markTestSkipped('Sem business em DB.');
+    }
+    $this->user = \App\User::where('business_id', $this->business->id)->first();
+    if (! $this->user) {
+        $this->markTestSkipped('Sem user no business.');
+    }
+
+    $now = now();
+    $this->contactId = DB::table('contacts')->insertGetId([
+        'business_id' => $this->business->id,
+        'created_by' => $this->user->id,
+        'type' => 'customer',
+        'name' => 'Cliente Contato Extras Test',
+        'first_name' => 'Cliente',
+        'mobile' => '11900000001',
+        'contact_status' => 'active',
+        'created_at' => $now,
+        'updated_at' => $now,
+    ]);
+
+    $this->actingAs($this->user);
+    session(['user.business_id' => $this->business->id]);
+});
+
+// ---------------------------------------------------------------------
+// 1 — Schema guard: colunas existem (migration rodou)
+// ---------------------------------------------------------------------
+
+test('migration adiciona email_billing + email_nfe em contacts', function () {
+    expect(Schema::hasColumn('contacts', 'email_billing'))->toBeTrue();
+    expect(Schema::hasColumn('contacts', 'email_nfe'))->toBeTrue();
+});
+
+// ---------------------------------------------------------------------
+// 2 — PATCH /cliente/{id}/contato persiste 3 campos novos
+// ---------------------------------------------------------------------
+
+test('PATCH alternate_number persiste 3º telefone', function () {
+    $response = $this->patchJson("/cliente/{$this->contactId}/contato", [
+        'alternate_number' => '11900000003',
+    ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('success', true)
+        ->assertJsonPath('contact.alternate_number', '11900000003');
+
+    $contact = DB::table('contacts')->where('id', $this->contactId)->first();
+    expect($contact->alternate_number)->toBe('11900000003');
+});
+
+test('PATCH email_billing persiste email comercial', function () {
+    $response = $this->patchJson("/cliente/{$this->contactId}/contato", [
+        'email_billing' => 'vendedor@martinho.com.br',
+    ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('contact.email_billing', 'vendedor@martinho.com.br');
+
+    $contact = DB::table('contacts')->where('id', $this->contactId)->first();
+    expect($contact->email_billing)->toBe('vendedor@martinho.com.br');
+});
+
+test('PATCH email_nfe persiste email do contador', function () {
+    $response = $this->patchJson("/cliente/{$this->contactId}/contato", [
+        'email_nfe' => 'contador@martinho.com.br',
+    ]);
+
+    $response->assertStatus(200)
+        ->assertJsonPath('contact.email_nfe', 'contador@martinho.com.br');
+
+    $contact = DB::table('contacts')->where('id', $this->contactId)->first();
+    expect($contact->email_nfe)->toBe('contador@martinho.com.br');
+});
+
+test('PATCH email_billing inválido retorna 422', function () {
+    $response = $this->patchJson("/cliente/{$this->contactId}/contato", [
+        'email_billing' => 'nao-eh-email',
+    ]);
+
+    $response->assertStatus(422);
+});
+
+// ---------------------------------------------------------------------
+// 3 — Tier 0 multi-tenant (ADR 0093)
+// ---------------------------------------------------------------------
+
+test('Tier 0 — user de outro business recebe 404 ao tentar PATCH contato', function () {
+    $otherBusiness = DB::table('business')->where('id', '!=', $this->business->id)->first();
+    if (! $otherBusiness) {
+        $this->markTestSkipped('Sem 2º business pra teste cross-tenant.');
+    }
+    $otherUser = \App\User::where('business_id', $otherBusiness->id)->first();
+    if (! $otherUser) {
+        $this->markTestSkipped('Sem user no business secundário.');
+    }
+
+    $this->actingAs($otherUser);
+    session(['user.business_id' => $otherBusiness->id]);
+
+    $response = $this->patchJson("/cliente/{$this->contactId}/contato", [
+        'email_billing' => 'cross-tenant@evil.com',
+    ]);
+
+    $response->assertStatus(404);
+
+    // Confirma que NÃO foi persistido.
+    $contact = DB::table('contacts')->where('id', $this->contactId)->first();
+    expect($contact->email_billing)->not->toBe('cross-tenant@evil.com');
+});


### PR DESCRIPTION
## Summary

3º telefone + 2 e-mails diferenciados no Contato do Cliente (Onda 1 PR B' — pedido Daniela @ Martinho).

Daniela explicou que o e-mail principal já existe (`email`) mas é o pessoal — quando emite NF-e precisa mandar pro contador (e-mail NF-e), e o comercial vai pro vendedor (e-mail comercial). Sobre telefones, quer cadastrar pelo menos 3 — UPOS já tem 3 colunas legacy (`mobile`, `landline`, `alternate_number`), mas o drawer só expunha 2.

## Mudanças

**Migration `2026_05_26_140000_add_emails_extras_to_contacts`**:
- Adiciona `email_billing` + `email_nfe` (string 320, nullable) em `contacts`. Idempotente via `Schema::hasColumn`.
- Sem migration pra telefone — reusa `alternate_number` (existe desde 2017).

**`Modules/Crm/Http/Controllers/ClienteAutosaveController.php`**:
- `PATCH /cliente/{id}/contato` validador estendido com `alternate_number`, `email_billing`, `email_nfe`.
- `shapeContactResponse` retorna os 3 campos no payload (cliente refresh com valores corretos).

**`app/Http/Controllers/ContactController.php`**:
- `store()` `$request->only` inclui `email_billing` + `email_nfe` pra criação via `/contacts/create` standalone.

**`resources/js/Pages/Cliente/_drawer/ContatoTab.tsx`**:
- `ContactInfo` interface estendida com 3 campos opcionais.
- 3 inputs UI novos (col-span-2 acima do email, e 2 col-span-1 lado a lado abaixo do email principal).
- Autosave debounced 800ms via `PATCH /cliente/{id}/contato` com rollback otimista no 4xx.
- Validação inline `validateEmail` pra os 2 emails extras.

## Tier 0 multi-tenant (ADR 0093)

Intacto:
- `locateContact()` já scope `business_id`.
- Test #5 cobre cross-tenant biz=99 → 404 + verifica que e-mail comercial NÃO foi persistido.

## Test plan

- [x] PHP lint OK (migration + controller + test)
- [x] TypeScript check limpo
- [x] `tests/Feature/Cliente/ClienteContatoEmailsExtrasTest.php` (6 tests, skip-graceful em sqlite, CI MySQL):
  - Migration colunas existem
  - PATCH `alternate_number` persiste 3º telefone
  - PATCH `email_billing` persiste e-mail comercial
  - PATCH `email_nfe` persiste e-mail contador
  - PATCH `email_billing` inválido → 422
  - Tier 0 — biz=99 vê 404
- [ ] **Smoke prod (Daniela @ Martinho)**: abrir drawer Cliente → tab Contato → preencher Telefone 3 + E-mail comercial + E-mail NF-e → conferir status "Salvo" → fechar drawer → reabrir → conferir valores persistiram.

## Follow-up (não-bloqueante)

- Edit standalone (`/contacts/{id}/edit`, página completa Inertia) ainda não expõe esses 3 campos no UI. ContactController já aceita no `$request->only` (PR B'), mas falta input nas seções "Contato" do `Edit.tsx`. Vai num PR pequeno separado se Daniela usar o Edit standalone (raro — fluxo principal é o drawer do Index).
- Onda 1 PR C (próximo): múltiplos endereços com labels Comercial/Entrega/Casa + selector na Sells/Create NF-e.

## Contexto

Onda 1 expansão Cliente (sessão 2026-05-26):
- ✅ **PR A** [#1693](https://github.com/wagnerra23/oimpresso.com/pull/1693) — fix Edit BR + Update Inertia
- ✅ **PR D** [#1694](https://github.com/wagnerra23/oimpresso.com/pull/1694) — aba Veículos
- ✅ **PR B'** (este) — 3º telefone + e-mails diferenciados
- 🟡 **PR C** (próximo) — múltiplos endereços + selector NF-e

🤖 Generated with [Claude Code](https://claude.com/claude-code)
