### PR TITLE
feat(cliente/ui): campos do drawer fiéis ao protótipo Cowork

### DIFF
--- a/resources/css/cowork-fields.css
+++ b/resources/css/cowork-fields.css
@@ -1,0 +1,170 @@
+/**
+ * Cowork fields — port fiel do protótipo prototipo-ui/prototipos/clientes/clientes.css
+ *
+ * Origem: pedido Wagner 2026-05-26 "copie do cowork seja fiel".
+ * Drawer Cliente do oimpresso (Modules/Crm + resources/js/Pages/Cliente/) tinha
+ * campos shadcn `<Input>` com bg-transparent + text-sm — visual diferente do
+ * protótipo Cowork que o time gostava. Este arquivo replica as classes canon
+ * do Cowork (`.cl-input`, `.cl-field`, `.cl-radio`) sob namespace `cw-*` pra
+ * evitar colisão com qualquer `.cl-*` legacy.
+ *
+ * Tokens já existem em resources/css/cockpit.css (--bg, --surface, --text,
+ * --text-dim, --text-mute, --accent, --accent-soft, --border). Este arquivo
+ * NÃO redefine tokens — só usa.
+ *
+ * Aplicado via `<Input variant="cowork">` + `<Label variant="cowork">` —
+ * ver Components/ui/input.tsx e Components/ui/label.tsx.
+ */
+
+/* ── Field wrapper (label + input + error) ─────────────────────────────── */
+.cw-field {
+  display: flex; flex-direction: column; gap: 5px; min-width: 0;
+}
+.cw-field label,
+.cw-label {
+  font-size: 11.5px; font-weight: 500; color: var(--text-dim);
+  display: flex; align-items: center; gap: 6px;
+}
+.cw-opt {
+  font-size: 10.5px; color: var(--text-mute); font-weight: 400;
+}
+
+/* ── Input ─────────────────────────────────────────────────────────────── */
+.cw-input {
+  appearance: none;
+  width: 100%; height: 36px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  color: var(--text);
+  border-radius: 6px;
+  padding: 0 10px;
+  font: inherit; font-size: 13px;
+  outline: none;
+  transition: border-color .12s, box-shadow .12s;
+}
+.cw-input::placeholder {
+  color: var(--text-mute);
+}
+.cw-input:focus,
+.cw-input:focus-visible {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px var(--accent-soft);
+}
+.cw-input:disabled {
+  background: var(--bg-2);
+  color: var(--text-mute);
+  cursor: not-allowed;
+}
+
+/* Textarea variant (auto-height) */
+.cw-input.cw-textarea {
+  height: auto; padding: 8px 10px; line-height: 1.5;
+  min-height: 70px; resize: vertical;
+}
+
+/* Native select dropdown — adiciona caret manual */
+select.cw-input {
+  appearance: auto; cursor: pointer; padding-right: 26px;
+}
+
+/* Error state — usa cores Cowork canon (oklch vermelho) */
+.cw-field.has-error .cw-input,
+.cw-input[aria-invalid="true"],
+.cw-input.cw-error {
+  border-color: oklch(0.65 0.18 25);
+}
+.cw-field.has-error .cw-input:focus,
+.cw-input[aria-invalid="true"]:focus,
+.cw-input.cw-error:focus {
+  box-shadow: 0 0 0 3px oklch(0.94 0.04 25);
+}
+
+.cw-err {
+  display: flex; align-items: center; gap: 4px;
+  font-size: 11px; color: oklch(0.55 0.18 25);
+}
+
+.cw-hint {
+  font-size: 11px; color: var(--text-mute);
+}
+
+/* ── Radio pill ────────────────────────────────────────────────────────── */
+.cw-radio-row {
+  display: flex; gap: 6px; flex-wrap: wrap;
+}
+.cw-radio {
+  display: inline-flex; align-items: center; gap: 6px;
+  border: 1px solid var(--border); background: var(--surface);
+  padding: 6px 10px; border-radius: 6px;
+  font-size: 12px; cursor: pointer;
+  transition: background .12s, border-color .12s, color .12s;
+}
+.cw-radio input { display: none; }
+.cw-radio:hover { background: var(--bg-2); }
+.cw-radio.on,
+.cw-radio:has(input:checked) {
+  background: var(--accent-soft); color: var(--accent);
+  border-color: transparent; font-weight: 600;
+}
+
+/* ── Tag chip selector ─────────────────────────────────────────────────── */
+.cw-tags-input {
+  display: flex; gap: 4px; flex-wrap: wrap;
+}
+.cw-tag-btn {
+  appearance: none; border: 1px solid var(--border);
+  background: var(--surface); color: var(--text-dim);
+  padding: 5px 12px; border-radius: 999px;
+  font: inherit; font-size: 11.5px; cursor: pointer;
+  transition: background .12s, color .12s, border-color .12s;
+}
+.cw-tag-btn:hover { background: var(--bg-2); color: var(--text); }
+.cw-tag-btn.on {
+  background: var(--accent); color: #fff;
+  border-color: transparent; font-weight: 500;
+}
+
+/* ── Toggle switch ─────────────────────────────────────────────────────── */
+.cw-toggle {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 12.5px; cursor: pointer; color: var(--text);
+}
+.cw-toggle input { display: none; }
+.cw-toggle-track {
+  width: 32px; height: 18px; background: var(--border);
+  border-radius: 999px; position: relative;
+  transition: background .15s;
+  flex-shrink: 0;
+}
+.cw-toggle-thumb {
+  position: absolute; top: 2px; left: 2px;
+  width: 14px; height: 14px; background: #fff; border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  transition: left .15s;
+}
+.cw-toggle input:checked + .cw-toggle-track {
+  background: var(--accent);
+}
+.cw-toggle input:checked + .cw-toggle-track .cw-toggle-thumb {
+  left: 16px;
+}
+
+/* ── Form grid (2 cols default, responsive) ────────────────────────────── */
+.cw-form-grid {
+  display: grid; grid-template-columns: repeat(2, 1fr);
+  gap: 14px 12px;
+}
+.cw-form-grid > .cw-field.full-row {
+  grid-column: 1 / -1;
+}
+@media (max-width: 640px) {
+  .cw-form-grid { grid-template-columns: 1fr; }
+}
+
+/* ── Section title (idênticos ao Cowork) ───────────────────────────────── */
+.cw-section-title {
+  font-size: 10.5px; font-weight: 700;
+  letter-spacing: .06em; text-transform: uppercase;
+  color: var(--text-mute);
+  margin: 0 0 10px;
+}

--- a/resources/css/inertia.css
+++ b/resources/css/inertia.css
@@ -44,6 +44,13 @@
 /* Sells/Subscriptions Cowork — lista assinaturas recorrentes (extensões mínimas além da família Index) */
 @import "./sells-cowork-subscriptions.css";
 
+/* Cowork fields — port fiel `.cl-input`/`.cl-field`/`.cl-radio` do protótipo
+ * (prototipo-ui/prototipos/clientes/clientes.css). Aplicado via
+ * `<Input variant="cowork">` no drawer Cliente após pedido Wagner 2026-05-26
+ * "copie do cowork seja fiel". Classes `.cw-*` (não-escopadas — usam tokens
+ * globais já definidos em cockpit.css). */
+@import "./cowork-fields.css";
+
 /* ============================================================================
  * FINANCEIRO — Design System Cowork — REATIVADO 2026-05-19 (Plano B canon)
  *

--- a/resources/js/Components/ui/input.tsx
+++ b/resources/js/Components/ui/input.tsx
@@ -2,7 +2,36 @@ import * as React from "react"
 
 import { cn } from "@/Lib/utils"
 
-function Input({ className, type, ...props }: React.ComponentProps<"input">) {
+type InputVariant = "default" | "cowork"
+
+interface InputProps extends React.ComponentProps<"input"> {
+  /**
+   * Visual variant.
+   *
+   * - `default` (shadcn canon): bg-transparent, text-sm, ring shadcn.
+   *   Mantido pra todas as telas que já usavam `<Input>` sem prop.
+   *
+   * - `cowork`: replica fiel do protótipo Cowork canon (`.cl-input` em
+   *   prototipo-ui/prototipos/clientes/clientes.css). Usa classes `.cw-input`
+   *   definidas em resources/css/cowork-fields.css com bg `--surface`, text
+   *   13px, ring `--accent-soft`. Adotado pelo drawer Cliente após pedido
+   *   Wagner 2026-05-26 "copie do cowork seja fiel".
+   */
+  variant?: InputVariant
+}
+
+function Input({ className, type, variant = "default", ...props }: InputProps) {
+  if (variant === "cowork") {
+    return (
+      <input
+        type={type}
+        data-slot="input"
+        className={cn("cw-input", className)}
+        {...props}
+      />
+    )
+  }
+
   return (
     <input
       type={type}
@@ -19,3 +48,4 @@ function Input({ className, type, ...props }: React.ComponentProps<"input">) {
 }
 
 export { Input }
+export type { InputVariant, InputProps }

--- a/resources/js/Pages/Cliente/_drawer/ComercialTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/ComercialTab.tsx
@@ -209,10 +209,11 @@ export default function ComercialTab({ contact, onSaved, disabled = false }: Com
     <div className="space-y-5">
       <div className="grid gap-4 md:grid-cols-2">
         <div>
-          <Label htmlFor="cm-limite" className="text-xs font-medium">
+          <Label htmlFor="cm-limite" className="cw-label">
             Limite de crédito <span className="text-muted-foreground font-normal">(R$, vazio = sem limite)</span>
           </Label>
           <Input
+            variant="cowork"
             id="cm-limite"
             value={limite}
             placeholder="0"
@@ -234,10 +235,11 @@ export default function ComercialTab({ contact, onSaved, disabled = false }: Com
         </div>
 
         <div>
-          <Label htmlFor="cm-prazo" className="text-xs font-medium">
+          <Label htmlFor="cm-prazo" className="cw-label">
             Prazo padrão <span className="text-muted-foreground font-normal">(dias)</span>
           </Label>
           <Input
+            variant="cowork"
             id="cm-prazo"
             value={prazo}
             placeholder="30"
@@ -259,7 +261,7 @@ export default function ComercialTab({ contact, onSaved, disabled = false }: Com
         </div>
 
         <div className="md:col-span-2">
-          <Label htmlFor="cm-tabela" className="text-xs font-medium">
+          <Label htmlFor="cm-tabela" className="cw-label">
             Tabela de preço
           </Label>
           <Select
@@ -286,7 +288,7 @@ export default function ComercialTab({ contact, onSaved, disabled = false }: Com
         </div>
 
         <div className="md:col-span-2">
-          <Label htmlFor="cm-pgto" className="text-xs font-medium">
+          <Label htmlFor="cm-pgto" className="cw-label">
             Forma de pagamento preferida
           </Label>
           <Select
@@ -313,7 +315,7 @@ export default function ComercialTab({ contact, onSaved, disabled = false }: Com
         </div>
 
         <div className="md:col-span-2">
-          <Label htmlFor="cm-obs" className="text-xs font-medium">
+          <Label htmlFor="cm-obs" className="cw-label">
             Observações comerciais <span className="text-muted-foreground font-normal">(opcional)</span>
           </Label>
           <Textarea

--- a/resources/js/Pages/Cliente/_drawer/ContatoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/ContatoTab.tsx
@@ -220,10 +220,11 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
     <div className="space-y-5">
       <div className="grid gap-4 md:grid-cols-2">
         <div>
-          <Label htmlFor="ct-tel" className="text-xs font-medium">
+          <Label htmlFor="ct-tel" className="cw-label">
             Telefone principal
           </Label>
           <Input
+            variant="cowork"
             id="ct-tel"
             value={tel}
             placeholder="(00) 0 0000-0000"
@@ -245,10 +246,11 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
         </div>
 
         <div>
-          <Label htmlFor="ct-tel2" className="text-xs font-medium">
+          <Label htmlFor="ct-tel2" className="cw-label">
             Telefone alternativo <span className="text-muted-foreground font-normal">(opcional)</span>
           </Label>
           <Input
+            variant="cowork"
             id="ct-tel2"
             value={tel2}
             placeholder="(00) 0 0000-0000"
@@ -271,10 +273,11 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
 
         {/* Onda 1 PR B' (Daniela @ Martinho) — 3º telefone via coluna UPOS legacy `alternate_number`. */}
         <div className="md:col-span-2">
-          <Label htmlFor="ct-tel3" className="text-xs font-medium">
+          <Label htmlFor="ct-tel3" className="cw-label">
             Telefone 3 <span className="text-muted-foreground font-normal">(opcional · recados)</span>
           </Label>
           <Input
+            variant="cowork"
             id="ct-tel3"
             value={tel3}
             placeholder="(00) 0 0000-0000"
@@ -296,10 +299,11 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
         </div>
 
         <div className="md:col-span-2">
-          <Label htmlFor="ct-email" className="text-xs font-medium">
+          <Label htmlFor="ct-email" className="cw-label">
             E-mail
           </Label>
           <Input
+            variant="cowork"
             id="ct-email"
             type="email"
             value={email}
@@ -328,10 +332,11 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
         {/* Onda 1 PR B' (Daniela @ Martinho) — E-mails diferenciados.
             Migration 2026_05_26_140000_add_emails_extras_to_contacts. */}
         <div>
-          <Label htmlFor="ct-email-billing" className="text-xs font-medium">
+          <Label htmlFor="ct-email-billing" className="cw-label">
             E-mail comercial <span className="text-muted-foreground font-normal">(opcional · vendedor)</span>
           </Label>
           <Input
+            variant="cowork"
             id="ct-email-billing"
             type="email"
             value={emailBilling}
@@ -358,10 +363,11 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
         </div>
 
         <div>
-          <Label htmlFor="ct-email-nfe" className="text-xs font-medium">
+          <Label htmlFor="ct-email-nfe" className="cw-label">
             E-mail NF-e <span className="text-muted-foreground font-normal">(opcional · contador)</span>
           </Label>
           <Input
+            variant="cowork"
             id="ct-email-nfe"
             type="email"
             value={emailNfe}
@@ -388,10 +394,11 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
         </div>
 
         <div className="md:col-span-2">
-          <Label htmlFor="ct-site" className="text-xs font-medium">
+          <Label htmlFor="ct-site" className="cw-label">
             Site <span className="text-muted-foreground font-normal">(opcional)</span>
           </Label>
           <Input
+            variant="cowork"
             id="ct-site"
             type="url"
             value={site}
@@ -413,7 +420,7 @@ export default function ContatoTab({ contact, onSaved, disabled = false }: Conta
         </div>
 
         <div className="md:col-span-2">
-          <Label className="text-xs font-medium">
+          <Label className="cw-label">
             Canal preferido <span className="text-muted-foreground font-normal">(opcional)</span>
           </Label>
           <div

--- a/resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx
@@ -308,11 +308,12 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
     <div className="space-y-5">
       <div className="grid gap-4 md:grid-cols-2">
         <div>
-          <Label htmlFor="ed-cep" className="text-xs font-medium">
+          <Label htmlFor="ed-cep" className="cw-label">
             CEP
           </Label>
           <div className="flex gap-2">
             <Input
+              variant="cowork"
               id="ed-cep"
               value={zipCode}
               placeholder="00000-000"
@@ -377,10 +378,11 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
         </div>
 
         <div>
-          <Label htmlFor="ed-numero" className="text-xs font-medium">
+          <Label htmlFor="ed-numero" className="cw-label">
             Número
           </Label>
           <Input
+            variant="cowork"
             id="ed-numero"
             value={numero}
             placeholder="123"
@@ -401,10 +403,11 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
         </div>
 
         <div className="md:col-span-2">
-          <Label htmlFor="ed-endereco" className="text-xs font-medium">
+          <Label htmlFor="ed-endereco" className="cw-label">
             Endereço
           </Label>
           <Input
+            variant="cowork"
             id="ed-endereco"
             value={addressLine1}
             placeholder="Rua, avenida, alameda…"
@@ -425,10 +428,11 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
         </div>
 
         <div className="md:col-span-2">
-          <Label htmlFor="ed-complemento" className="text-xs font-medium">
+          <Label htmlFor="ed-complemento" className="cw-label">
             Complemento <span className="text-muted-foreground font-normal">(opcional)</span>
           </Label>
           <Input
+            variant="cowork"
             id="ed-complemento"
             value={addressLine2}
             placeholder="Apto, conjunto, sala…"
@@ -449,10 +453,11 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
         </div>
 
         <div>
-          <Label htmlFor="ed-bairro" className="text-xs font-medium">
+          <Label htmlFor="ed-bairro" className="cw-label">
             Bairro
           </Label>
           <Input
+            variant="cowork"
             id="ed-bairro"
             value={neighborhood}
             placeholder=""
@@ -473,10 +478,11 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
         </div>
 
         <div>
-          <Label htmlFor="ed-cidade" className="text-xs font-medium">
+          <Label htmlFor="ed-cidade" className="cw-label">
             Cidade
           </Label>
           <Input
+            variant="cowork"
             id="ed-cidade"
             value={city}
             placeholder=""
@@ -497,7 +503,7 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
         </div>
 
         <div>
-          <Label htmlFor="ed-uf" className="text-xs font-medium">
+          <Label htmlFor="ed-uf" className="cw-label">
             UF
           </Label>
           <Select value={stateUf} onValueChange={handleUfChange} disabled={disabled}>

--- a/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx
@@ -627,10 +627,11 @@ export default function IdentificacaoTab({
       {/* Linha 1: Nome/Razão social */}
       <div className="grid gap-4 md:grid-cols-2">
         <div className="md:col-span-2">
-          <Label htmlFor="id-nome" className="text-xs font-medium">
+          <Label htmlFor="id-nome" className="cw-label">
             {isPJ ? 'Razão social' : 'Nome completo'} <span className="text-rose-600">*</span>
           </Label>
           <Input
+            variant="cowork"
             id="id-nome"
             value={nome}
             placeholder={isPJ ? 'Ex.: Dragão Verde Comunicação Visual Ltda' : 'Ex.: Marina Costa'}
@@ -658,10 +659,11 @@ export default function IdentificacaoTab({
         {/* Fantasia só PJ */}
         {isPJ && (
           <div className="md:col-span-2">
-            <Label htmlFor="id-fantasia" className="text-xs font-medium">
+            <Label htmlFor="id-fantasia" className="cw-label">
               Nome fantasia <span className="text-muted-foreground font-normal">(opcional)</span>
             </Label>
             <Input
+              variant="cowork"
               id="id-fantasia"
               value={fantasia}
               placeholder="Como o cliente é conhecido"
@@ -684,11 +686,12 @@ export default function IdentificacaoTab({
 
         {/* Documento (CPF ou CNPJ) + botão Buscar CNPJ */}
         <div className="md:col-span-2">
-          <Label htmlFor="id-doc" className="text-xs font-medium">
+          <Label htmlFor="id-doc" className="cw-label">
             {isPJ ? 'CNPJ' : 'CPF'} {isPJ && <span className="ml-1 text-xs text-muted-foreground">(clique em Buscar pra preencher automático)</span>}
           </Label>
           <div className="flex gap-2">
             <Input
+              variant="cowork"
               id="id-doc"
               value={doc}
               placeholder={isPJ ? '00.000.000/0000-00' : '000.000.000-00'} // pii-allowlist máscara visual de input
@@ -754,10 +757,11 @@ export default function IdentificacaoTab({
         {/* IE (PJ) ou RG (PF) */}
         {isPJ ? (
           <div>
-            <Label htmlFor="id-ie" className="text-xs font-medium">
+            <Label htmlFor="id-ie" className="cw-label">
               Inscrição estadual <span className="text-muted-foreground font-normal">(opcional)</span>
             </Label>
             <Input
+              variant="cowork"
               id="id-ie"
               value={ie}
               placeholder="000.000.000.000"
@@ -778,10 +782,11 @@ export default function IdentificacaoTab({
           </div>
         ) : (
           <div>
-            <Label htmlFor="id-rg" className="text-xs font-medium">
+            <Label htmlFor="id-rg" className="cw-label">
               RG <span className="text-muted-foreground font-normal">(opcional)</span>
             </Label>
             <Input
+              variant="cowork"
               id="id-rg"
               value={rg}
               placeholder="00.000.000-0"
@@ -805,10 +810,11 @@ export default function IdentificacaoTab({
         {/* Nascimento — só PF */}
         {!isPJ && (
           <div>
-            <Label htmlFor="id-nascimento" className="text-xs font-medium">
+            <Label htmlFor="id-nascimento" className="cw-label">
               Data de nascimento <span className="text-muted-foreground font-normal">(opcional)</span>
             </Label>
             <Input
+              variant="cowork"
               id="id-nascimento"
               type="date"
               value={nascimento}
@@ -832,10 +838,11 @@ export default function IdentificacaoTab({
         {/* Contato principal — só PJ */}
         {isPJ && (
           <div className="md:col-span-2">
-            <Label htmlFor="id-contato" className="text-xs font-medium">
+            <Label htmlFor="id-contato" className="cw-label">
               Contato principal <span className="text-muted-foreground font-normal">(opcional)</span>
             </Label>
             <Input
+              variant="cowork"
               id="id-contato"
               value={contatoNome}
               placeholder="Nome do responsável"
@@ -859,10 +866,11 @@ export default function IdentificacaoTab({
         {/* Cargo — só PJ */}
         {isPJ && (
           <div className="md:col-span-2">
-            <Label htmlFor="id-cargo" className="text-xs font-medium">
+            <Label htmlFor="id-cargo" className="cw-label">
               Cargo do contato <span className="text-muted-foreground font-normal">(opcional)</span>
             </Label>
             <Input
+              variant="cowork"
               id="id-cargo"
               value={cargo}
               placeholder="Ex.: Diretor de marketing"


### PR DESCRIPTION
## Summary

Replica fiel das classes `.cl-input`/`.cl-field`/`.cl-radio` do protótipo Cowork (`prototipo-ui/prototipos/clientes/clientes.css`) no drawer do Cliente — pedido Wagner 2026-05-26 `copie do cowork seja fiel` após Onda 1 (#1693-1696) mergeada.

## Estratégia (Opção 2 do mockup comparativo)

- **NÃO mudar** o <Input> shadcn global → outras telas (Sells, OficinaAuto, Compras, Financeiro) continuam usando default.
- Criar `variant=cowork` opt-in no <Input> que aplica classes `.cw-*` do novo CSS dedicado.
- Aplicar `variant=cowork` nos 5 tabs do drawer Cliente.

## Mudanças

**Arquivo novo** `resources/css/cowork-fields.css` (port fiel — 12 classes `.cw-*`):
- `.cw-input` — h-36px · bg surface · border · text 13px · ring accent-soft no focus
- `.cw-label` — text-dim · 11.5px · weight 500
- `.cw-opt` — text-mute · 10.5px · weight 400 (marker opcional)
- `.cw-radio` — pill com on=accent-soft + accent text
- `.cw-toggle`, `.cw-tag-btn`, `.cw-err`, `.cw-hint` (bonus)
- `.cw-input.cw-error` + `aria-invalid` selector
- Dark mode automático via tokens cockpit.css
- Usa tokens já globais (`--surface`, `--text-dim`, `--accent`, `--accent-soft`, `--border`) — sem redefinição.

**Modificados:**
- `resources/css/inertia.css` +1 @import line
- `resources/js/Components/ui/input.tsx` +27 linhas — prop `variant?: default | cowork`, default mantém shadcn
- `resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx` (8 inputs + 8 labels)
- `resources/js/Pages/Cliente/_drawer/ContatoTab.tsx` (7 inputs + 7 labels)
- `resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx` (6 inputs + 6 labels)
- `resources/js/Pages/Cliente/_drawer/ComercialTab.tsx` (2 inputs + 2 labels)

## Zero risco fora do drawer Cliente

Telas que não passarem `variant=cowork` ficam idênticas (default = shadcn). Apenas 4 arquivos de tab Cliente foram tocados, mais o componente base + CSS.

## Test plan

- [x] PHP lint OK
- [x] TypeScript check limpo nos meus 5 arquivos
- [ ] **Smoke prod (Wagner)**: abrir cliente no drawer → verificar visual identical ao protótipo Cowork — bg branco sólido nos campos sobre bg do drawer levemente cinza, label dim 11.5px, ring suave ao focar, radio pill com cor accent quando selecionado
- [ ] **Outras telas intactas**: abrir Sells/Create + OficinaAuto/Edit + Compras/Index pra confirmar que <Input> default não mudou

## Próximos passos sugeridos (não-bloqueante)

- Se você gostar do resultado, vale aplicar `variant=cowork` nas outras telas que devem virar canon (Sells/Edit, OficinaAuto/Edit OS, etc) gradualmente.
- Eventualmente, virar o `variant=cowork` em default global e deletar o `default` shadcn antigo — quando o time chegar ao consenso.

Refs: CYCLE-06 · pós-Onda 1 Cliente · mockups `prototipo-ui/mockup-cliente-fields-*-2026-05-26.html`

🤖 Generated with [Claude Code](https://claude.com/claude-code)