### PR TITLE
fix(cliente/ui): dark mode bleed + SelectTrigger variant cowork

### DIFF
--- a/resources/css/cowork-fields.css
+++ b/resources/css/cowork-fields.css
@@ -37,20 +37,15 @@
   --cw-error-soft:   oklch(0.94 0.04 25);
 }
 
-/* Dark mode auto via media query OU .dark wrapper Inertia */
-@media (prefers-color-scheme: dark) {
-  :root {
-    --cw-bg:           oklch(0.16 0.003 240);
-    --cw-bg-2:         oklch(0.19 0.006 240);
-    --cw-surface:      oklch(0.26 0.008 240);
-    --cw-border:       oklch(0.32 0.005 240);
-    --cw-border-2:     oklch(0.28 0.005 240);
-    --cw-text:         oklch(0.92 0.005 90);
-    --cw-text-dim:     oklch(0.72 0.005 90);
-    --cw-text-mute:    oklch(0.55 0.005 90);
-    --cw-accent-soft:  oklch(0.32 0.05 220);
-  }
-}
+/* Dark mode — APENAS via classe .dark (canon do Inertia/shadcn no oimpresso).
+ *
+ * NÃO usar @media (prefers-color-scheme: dark): o resto do app (sidebar,
+ * tabela, header) só respeita a classe .dark no <html>. Se usássemos
+ * media query, OS em dark mode → SÓ os campos cowork ficariam escuros
+ * enquanto resto do app continua light. Bug catalogado 2026-05-27 pós-PR
+ * #1699: Wagner em Windows dark mode viu drawer com campos pretos sobre
+ * fundo light (mismatch).
+ */
 .dark {
   --cw-bg:           oklch(0.16 0.003 240);
   --cw-bg-2:         oklch(0.19 0.006 240);

--- a/resources/js/Components/ui/select.tsx
+++ b/resources/js/Components/ui/select.tsx
@@ -25,11 +25,39 @@ function SelectValue({
 function SelectTrigger({
   className,
   size = "default",
+  variant = "default",
   children,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
   size?: "sm" | "default"
+  /**
+   * Visual variant — `cowork` aplica classes `.cw-input` (port fiel do
+   * protótipo Cowork) em vez do shadcn default. Adicionado 2026-05-27
+   * pra emparelhar com <Input variant="cowork"> no drawer Cliente.
+   * Ver resources/css/cowork-fields.css.
+   */
+  variant?: "default" | "cowork"
 }) {
+  if (variant === "cowork") {
+    return (
+      <SelectPrimitive.Trigger
+        data-slot="select-trigger"
+        data-size={size}
+        className={cn(
+          "cw-input flex items-center justify-between gap-2",
+          "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 [&_svg:not([class*='text-'])]:text-muted-foreground",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <SelectPrimitive.Icon asChild>
+          <ChevronDownIcon className="size-4 opacity-50" />
+        </SelectPrimitive.Icon>
+      </SelectPrimitive.Trigger>
+    )
+  }
+
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"

--- a/resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx
@@ -424,7 +424,7 @@ export default function ClassificacaoTab({ contact, onSaved, disabled = false }:
             Status
           </Label>
           <Select value={status} onValueChange={handleStatusChange} disabled={disabled}>
-            <SelectTrigger id="cl-status" className="w-full">
+            <SelectTrigger id="cl-status" variant="cowork" className="w-full">
               <SelectValue placeholder="Selecionar status" />
             </SelectTrigger>
             <SelectContent>

--- a/resources/js/Pages/Cliente/_drawer/ComercialTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/ComercialTab.tsx
@@ -269,7 +269,7 @@ export default function ComercialTab({ contact, onSaved, disabled = false }: Com
             onValueChange={(v) => handleSelectChange('tabela_preco_padrao', v)}
             disabled={disabled}
           >
-            <SelectTrigger id="cm-tabela" className="w-full">
+            <SelectTrigger id="cm-tabela" variant="cowork" className="w-full">
               <SelectValue placeholder="Selecionar tabela" />
             </SelectTrigger>
             <SelectContent>
@@ -296,7 +296,7 @@ export default function ComercialTab({ contact, onSaved, disabled = false }: Com
             onValueChange={(v) => handleSelectChange('pgto_padrao', v)}
             disabled={disabled}
           >
-            <SelectTrigger id="cm-pgto" className="w-full">
+            <SelectTrigger id="cm-pgto" variant="cowork" className="w-full">
               <SelectValue placeholder="Selecionar forma de pagamento" />
             </SelectTrigger>
             <SelectContent>

--- a/resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx
@@ -333,7 +333,7 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
                   handleCepLookup();
                 }
               }}
-              className={cepError ? 'border-rose-500 focus-visible:ring-rose-400' : ''}
+              /* aria-invalid já dispara `.cw-input[aria-invalid="true"]` no CSS (border error) — não precisa className condicional duplicado */
             />
             <Button
               type="button"
@@ -507,7 +507,7 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
             UF
           </Label>
           <Select value={stateUf} onValueChange={handleUfChange} disabled={disabled}>
-            <SelectTrigger id="ed-uf" className="w-full">
+            <SelectTrigger id="ed-uf" variant="cowork" className="w-full">
               <SelectValue placeholder="UF" />
             </SelectTrigger>
             <SelectContent>


### PR DESCRIPTION
## 3 bugs corrigidos

### Bug 1 (crítico) — Dark mode bleed

`@media (prefers-color-scheme: dark)` que adicionei no #1699 ativou tokens dark **dos campos** quando OS está em dark mode. Mas o resto do app (sidebar, header, tabela) só respeita `.dark` class do Inertia. Resultado: campos pretos sobre fundo light (mismatch).

**Fix**: remover `@media` block. Manter apenas `.dark { ... }` selector (canon Inertia/shadcn).

### Bug 2 — SelectTrigger sem variant cowork

4 `<SelectTrigger>` do drawer (`cl-status`, `cm-tabela`, `cm-pgto`, `ed-uf`) usavam shadcn default — PR #1698 esqueceu deles, focou só em `<Input>`.

**Fix**: adicionar prop `variant?: 'default' | 'cowork'` em `SelectTrigger` ([Components/ui/select.tsx](resources/js/Components/ui/select.tsx)). Quando `variant=cowork`, aplica `.cw-input`. Caret ChevronDown mantida. Aplicar nos 4 triggers.

### Bug 3 — className condicional duplicado

EnderecoTab tinha `className={cepError ? 'border-rose-500 focus-visible:ring-rose-400' : ''}` no input CEP. Mas `.cw-input` já trata via `[aria-invalid='true']` selector. Removido.

## Smoke prod

- [ ] Refresh drawer Cliente → campos brancos (não pretos) mesmo com OS em dark mode
- [ ] Tab Endereço → UF dropdown com visual cowork
- [ ] Tab Comercial → Tabela Preço + Forma Pagamento dropdowns cowork
- [ ] Tab Classificação → Status dropdown cowork

Refs: PR #1698, #1699

🤖 Generated with [Claude Code](https://claude.com/claude-code)