### PR TITLE
feat(ui): padrão Cowork como visual default dos campos (ADR UI-0015)

### DIFF
--- a/memory/requisitos/_DesignSystem/adr/ui/0015-padrao-cowork-default-forms.md
+++ b/memory/requisitos/_DesignSystem/adr/ui/0015-padrao-cowork-default-forms.md
@@ -1,0 +1,115 @@
+# ADR UI-0015 (_DesignSystem) · Padrão Cowork como visual default dos campos de formulário
+
+- **Status**: accepted
+- **Data**: 2026-05-27
+- **Decisores**: Wagner, Claude
+- **Categoria**: ui
+- **Supersedes**: nenhuma (consolida pattern já introduzido em UI-0013)
+- **Related**: UI-0001 (Tailwind 4), UI-0002 (shadcn copy-paste), UI-0004 (Dark mode via .dark class), UI-0010/UI-0012 (Cowork canon visual), UI-0013 (Constituição UI v2)
+
+## Contexto
+
+Até 2026-05-26 o oimpresso usava o `<Input>` / `<SelectTrigger>` / `<Textarea>` / `<Label>` shadcn canônico em ~120 telas Inertia. Visual padrão shadcn: `bg-transparent`, `text-sm`, ring opaco, label preto principal.
+
+O protótipo Cowork (`prototipo-ui/prototipos/clientes/clientes.css`) — referência visual do design system desde UI-0010 — tinha pattern distinto que o time preferia: bg sólido `--surface`, text 13px, label dim cinza, ring suave `--accent-soft`, radio pill com `--accent-soft`. Wagner reportou pós-PR #1695 (telefones/emails Cliente):
+
+> "as tonalidades fazem diferença. incrivel pouca coisa faz mesmo muito diferença. quero o padrão"
+
+Sequência PRs #1698 → #1699 → #1700 introduziu `variant="cowork"` **opt-in** nos 5 tabs do drawer Cliente, com `cowork-fields.css` definindo classes `.cw-input`, `.cw-label`, `.cw-radio`, `.cw-toggle`, etc usando tokens namespaced `--cw-*` em `:root` (pra resolver fora de wrapper `.cockpit`).
+
+Após validar visual em prod (drawer Cliente Identificação/Contato/Endereço/Comercial/Classificação), Wagner pediu padronização do site inteiro:
+
+> "vai ter que documentar tudo inclusive o dark mode, ache tudo sobre isso estais fazendo o padrão do site inteiro"
+
+## Decisão
+
+**Inverter o default dos 4 componentes shadcn principais de formulário:**
+
+1. `<Input>` (resources/js/Components/ui/input.tsx)
+2. `<SelectTrigger>` (resources/js/Components/ui/select.tsx)
+3. `<Textarea>` (resources/js/Components/ui/textarea.tsx)
+4. `<Label>` (resources/js/Components/ui/label.tsx)
+
+**Default novo:** `variant="cowork"` — aplica classes `.cw-*` do `cowork-fields.css`.
+**Opt-in legacy:** `variant="shadcn"` — visual shadcn antigo (use APENAS em containers escuros onde bg branco quebra hierarquia, raro).
+
+**Cobertura instantânea**: ~120 telas mudam visual no merge.
+
+### Tokens (resources/css/cowork-fields.css)
+
+Definidos em `:root` (light) + `.dark` (override dark mode), namespaced `--cw-*` pra evitar colisão com tokens `.cockpit { ... }` legacy:
+
+```css
+:root {
+  --cw-surface:      #ffffff;
+  --cw-bg:           oklch(0.985 0.003 90);
+  --cw-bg-2:         oklch(0.965 0.004 90);
+  --cw-border:       oklch(0.90 0.004 90);
+  --cw-text:         oklch(0.22 0.01 80);
+  --cw-text-dim:     oklch(0.50 0.01 80);
+  --cw-text-mute:    oklch(0.65 0.01 80);
+  --cw-accent:       oklch(0.58 0.09 220);
+  --cw-accent-soft:  oklch(0.94 0.025 220);
+  --cw-error:        oklch(0.65 0.18 25);
+  --cw-error-soft:   oklch(0.94 0.04 25);
+}
+```
+
+Valores `oklch()` IDÊNTICOS ao Cowork canon (`prototipo-ui/prototipos/clientes/cockpit.css`).
+
+### Dark mode
+
+Aplicado apenas via class `.dark` no `<html>` — canon definido em **UI-0004** (accepted 2026-04-22).
+
+**ANTI-PATTERN documentado:** `@media (prefers-color-scheme: dark)` em CSS de componentes individuais. Bug catalogado pós-PR #1699 em 2026-05-27: Wagner em Windows OS dark mode viu drawer Cliente com campos pretos sobre fundo light enquanto resto do app continuava light. Causa: `@media` ativa baseado em OS, ignorando preferência manual gerenciada por [useTheme.ts](../../../../../resources/js/Hooks/useTheme.ts). Fix em #1700 removeu o `@media` — manteve apenas `.dark { ... }` selector.
+
+Regra: **componente NÃO deve ter `@media (prefers-color-scheme: dark)` no CSS** — confiar na class `.dark` aplicada no root.
+
+## Consequências
+
+**Positivas:**
+
+- Visual consistente em 120+ telas (Sells, OficinaAuto, Compras, Financeiro, Ponto, etc).
+- Daniela/Larissa não percebem mismatch entre módulos.
+- Fonte única de truth (`cowork-fields.css`) — ajustar tokens uma vez, propaga.
+- Reversibilidade: `variant="shadcn"` opt-in mantém visual antigo onde necessário.
+- Tokens namespaced `--cw-*` não colidem com `.cockpit { ... }` legacy nem com Tailwind utilities.
+
+**Negativas:**
+
+- Telas que tinham visual shadcn de propósito (modais escuros, drawers coloridos) vão ficar visualmente quebradas até receber `variant="shadcn"` explícito.
+- Mudança massiva instantânea — risco de visual regression em telas raramente acessadas que não foram testadas.
+
+**Mitigação:**
+
+- Smoke prod nos 5 módulos top (Sells/Cliente/Financeiro/Essentials/Ponto).
+- Rollback simples: re-inverter o `if (variant === ...)` nos 4 componentes.
+
+## Alternativas consideradas
+
+### A) Manter `variant="cowork"` opt-in, propagar tela a tela (~10 PRs por módulo)
+
+Rejeitado — leva 3-5 dias de PRs sequenciais, deixa app com 2 visuais coexistindo, e Wagner explicitamente pediu padrão do site inteiro.
+
+### B) `variant="shadcn-legacy"` mais explícito
+
+Rejeitado — só "shadcn" é suficiente; "legacy" no nome cria atrito quando alguém legitimamente precisa do visual antigo.
+
+### C) Manter ambos como variants iguais (sem default)
+
+Rejeitado — TypeScript não permite default obrigatório opcional ao mesmo tempo. Definir default é compatível com retro-compatibilidade (telas existentes não precisam mudar nada).
+
+## Implementação
+
+PR `feat/cowork-default-global` 2026-05-27:
+
+1. `input.tsx`, `select.tsx`, `textarea.tsx`, `label.tsx` — inverter `variant` default
+2. `cowork-fields.css` — manter (tokens já namespaced `--cw-*` desde #1699)
+3. Remover `variant="cowork"` redundantes nos 5 tabs do drawer Cliente (agora default — code smell de redundância)
+4. Smoke prod via `mcp__Claude_in_Chrome__*` em 3-5 telas top (Sells/Create, OficinaAuto/Edit, Financeiro)
+
+PRs anteriores históricos:
+
+- **#1698** [feat(cliente/ui): campos do drawer fiéis ao Cowork](https://github.com/wagnerra23/oimpresso.com/pull/1698) — introduziu `variant="cowork"` opt-in
+- **#1699** [fix(cliente/ui): tokens em :root](https://github.com/wagnerra23/oimpresso.com/pull/1699) — fix scope `.cockpit`
+- **#1700** [fix(cliente/ui): remove dark media query + SelectTrigger variant](https://github.com/wagnerra23/oimpresso.com/pull/1700) — fix dark mode bleed

--- a/resources/js/Components/ui/input.tsx
+++ b/resources/js/Components/ui/input.tsx
@@ -2,31 +2,39 @@ import * as React from "react"
 
 import { cn } from "@/Lib/utils"
 
-type InputVariant = "default" | "cowork"
+type InputVariant = "cowork" | "shadcn"
 
 interface InputProps extends React.ComponentProps<"input"> {
   /**
    * Visual variant.
    *
-   * - `default` (shadcn canon): bg-transparent, text-sm, ring shadcn.
-   *   Mantido pra todas as telas que já usavam `<Input>` sem prop.
+   * **Default desde 2026-05-27 (ADR UI-0015):** `cowork` — bg sólido `--cw-surface`,
+   * text 13px, label dim, ring accent-soft. Aplica classes `.cw-input` definidas
+   * em resources/css/cowork-fields.css.
    *
-   * - `cowork`: replica fiel do protótipo Cowork canon (`.cl-input` em
-   *   prototipo-ui/prototipos/clientes/clientes.css). Usa classes `.cw-input`
-   *   definidas em resources/css/cowork-fields.css com bg `--surface`, text
-   *   13px, ring `--accent-soft`. Adotado pelo drawer Cliente após pedido
-   *   Wagner 2026-05-26 "copie do cowork seja fiel".
+   * **Opt-in legacy:** `shadcn` — visual canônico shadcn (bg-transparent,
+   * text-sm, ring-ring/50). Use APENAS quando precisar em containers escuros
+   * onde bg branco quebra hierarquia (raro).
+   *
+   * Histórico: até PR #1698, default era shadcn e cowork era opt-in. PRs #1698→#1700
+   * provaram fidelidade ao protótipo Cowork no drawer Cliente. Wagner 2026-05-27
+   * pediu padronização do site inteiro → invertemos o default.
    */
   variant?: InputVariant
 }
 
-function Input({ className, type, variant = "default", ...props }: InputProps) {
-  if (variant === "cowork") {
+function Input({ className, type, variant = "cowork", ...props }: InputProps) {
+  if (variant === "shadcn") {
     return (
       <input
         type={type}
         data-slot="input"
-        className={cn("cw-input", className)}
+        className={cn(
+          "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
+          "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
+          "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+          className
+        )}
         {...props}
       />
     )
@@ -36,12 +44,7 @@ function Input({ className, type, variant = "default", ...props }: InputProps) {
     <input
       type={type}
       data-slot="input"
-      className={cn(
-        "h-9 w-full min-w-0 rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-xs transition-[color,box-shadow] outline-none selection:bg-primary selection:text-primary-foreground file:inline-flex file:h-7 file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50 md:text-sm dark:bg-input/30",
-        "focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50",
-        "aria-invalid:border-destructive aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
-        className
-      )}
+      className={cn("cw-input", className)}
       {...props}
     />
   )

--- a/resources/js/Components/ui/label.tsx
+++ b/resources/js/Components/ui/label.tsx
@@ -5,20 +5,44 @@ import { Label as LabelPrimitive } from "radix-ui"
 
 import { cn } from "@/Lib/utils"
 
-function Label({
-  className,
-  ...props
-}: React.ComponentProps<typeof LabelPrimitive.Root>) {
+type LabelVariant = "cowork" | "shadcn"
+
+interface LabelProps extends React.ComponentProps<typeof LabelPrimitive.Root> {
+  /**
+   * Visual variant.
+   *
+   * **Default desde 2026-05-27 (ADR UI-0015):** `cowork` aplica classe `.cw-label`
+   * (font 11.5px, weight 500, color `--cw-text-dim` — hierarquia visual clara
+   * label vs valor).
+   *
+   * **Opt-in legacy:** `shadcn` — text-sm font-medium text-foreground (preto
+   * principal).
+   */
+  variant?: LabelVariant
+}
+
+function Label({ className, variant = "cowork", ...props }: LabelProps) {
+  if (variant === "shadcn") {
+    return (
+      <LabelPrimitive.Root
+        data-slot="label"
+        className={cn(
+          "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+
   return (
     <LabelPrimitive.Root
       data-slot="label"
-      className={cn(
-        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
-        className
-      )}
+      className={cn("cw-label", className)}
       {...props}
     />
   )
 }
 
 export { Label }
+export type { LabelVariant, LabelProps }

--- a/resources/js/Components/ui/select.tsx
+++ b/resources/js/Components/ui/select.tsx
@@ -25,20 +25,23 @@ function SelectValue({
 function SelectTrigger({
   className,
   size = "default",
-  variant = "default",
+  variant = "cowork",
   children,
   ...props
 }: React.ComponentProps<typeof SelectPrimitive.Trigger> & {
   size?: "sm" | "default"
   /**
-   * Visual variant — `cowork` aplica classes `.cw-input` (port fiel do
-   * protótipo Cowork) em vez do shadcn default. Adicionado 2026-05-27
-   * pra emparelhar com <Input variant="cowork"> no drawer Cliente.
-   * Ver resources/css/cowork-fields.css.
+   * Visual variant.
+   *
+   * **Default desde 2026-05-27 (ADR UI-0015):** `cowork` aplica classes
+   * `.cw-input` (port fiel do protótipo Cowork) — bg sólido, ring accent-soft.
+   *
+   * **Opt-in legacy:** `shadcn` — visual canônico shadcn antigo. Use APENAS
+   * quando precisar em containers escuros onde bg branco quebra hierarquia.
    */
-  variant?: "default" | "cowork"
+  variant?: "cowork" | "shadcn"
 }) {
-  if (variant === "cowork") {
+  if (variant !== "shadcn") {
     return (
       <SelectPrimitive.Trigger
         data-slot="select-trigger"
@@ -58,6 +61,7 @@ function SelectTrigger({
     )
   }
 
+  // variant === "shadcn" — visual canônico opt-in legacy
   return (
     <SelectPrimitive.Trigger
       data-slot="select-trigger"

--- a/resources/js/Components/ui/textarea.tsx
+++ b/resources/js/Components/ui/textarea.tsx
@@ -2,17 +2,43 @@ import * as React from "react"
 
 import { cn } from "@/Lib/utils"
 
-function Textarea({ className, ...props }: React.ComponentProps<"textarea">) {
+type TextareaVariant = "cowork" | "shadcn"
+
+interface TextareaProps extends React.ComponentProps<"textarea"> {
+  /**
+   * Visual variant.
+   *
+   * **Default desde 2026-05-27 (ADR UI-0015):** `cowork` aplica classes
+   * `.cw-input.cw-textarea` (port fiel do protótipo Cowork) — bg sólido,
+   * text 13px, ring accent-soft.
+   *
+   * **Opt-in legacy:** `shadcn` — visual canônico shadcn antigo.
+   */
+  variant?: TextareaVariant
+}
+
+function Textarea({ className, variant = "cowork", ...props }: TextareaProps) {
+  if (variant === "shadcn") {
+    return (
+      <textarea
+        data-slot="textarea"
+        className={cn(
+          "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
+          className
+        )}
+        {...props}
+      />
+    )
+  }
+
   return (
     <textarea
       data-slot="textarea"
-      className={cn(
-        "flex field-sizing-content min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-xs transition-[color,box-shadow] outline-none placeholder:text-muted-foreground focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-destructive/20 md:text-sm dark:bg-input/30 dark:aria-invalid:ring-destructive/40",
-        className
-      )}
+      className={cn("cw-input cw-textarea", className)}
       {...props}
     />
   )
 }
 
 export { Textarea }
+export type { TextareaVariant, TextareaProps }


### PR DESCRIPTION
## Resumo

Inverte o default dos 4 componentes shadcn principais de formulário para usar visual Cowork. Atende pedido Wagner 2026-05-27 'estais fazendo o padrão do site inteiro'.

**~120 telas Inertia** mudam visual no merge.

## Mudanças

| Componente | Antes (default) | Depois (default) | Opt-in legacy |
|---|---|---|---|
| `<Input>` | shadcn | **cowork** | `variant='shadcn'` |
| `<SelectTrigger>` | shadcn | **cowork** | `variant='shadcn'` |
| `<Textarea>` | shadcn | **cowork** | `variant='shadcn'` |
| `<Label>` | shadcn (text-sm preto) | **cowork** (text-xs dim) | `variant='shadcn'` |

## ADR canon

[memory/requisitos/_DesignSystem/adr/ui/0015-padrao-cowork-default-forms.md](memory/requisitos/_DesignSystem/adr/ui/0015-padrao-cowork-default-forms.md) — documenta:

1. Decisão de inverter default + opt-in legacy (4 componentes)
2. Tokens namespaced `--cw-*` em `:root` + `.dark` (não colidem com .cockpit)
3. **Dark mode anti-pattern documentado**: @media (prefers-color-scheme: dark) em componentes quebra preferência manual gerenciada por useTheme.ts. Bug catalogado pós-#1699. Fix em #1700 removeu o @media. Regra: confiar na class .dark do root.
4. Alternativas consideradas + tradeoffs
5. Refs: ADR UI-0004 (.dark class), UI-0010/UI-0012 (Cowork canon), UI-0013 (Constituição UI v2)

## Cobertura por módulo (top 10)

- Sells (13 telas) · Cliente (13, já cowork) · Financeiro (11) · Essentials (10)
- Ponto (9) · OficinaAuto (9) · Repair (6) · Whatsapp (5) · Produto (5) · NfeBrasil (5)
- Outros: 1-4 telas cada

## Reversibilidade

- Visual: re-inverter `if (variant === ...)` nos 4 componentes
- Tokens: namespaced `--cw-*` não colidem com nada — manter

## Test plan

- [x] PHP/TS lint OK
- [ ] **Smoke prod**: Sells/Create + OficinaAuto/Edit OS + Compras/Create + Financeiro + Ponto
- [ ] Dark mode: trocar tema no menu user → confirmar campos seguem (não mais bleed de OS)
- [ ] Telas legacy (Sales POS Blade, Repair Blade): não-afetadas (não usam Inertia <Input>)

## Refs

PR #1698 #1699 #1700 (drawer Cliente piloto)

🤖 Generated with Claude Code