### PR TITLE
feat(ui): cowork compact density (SaaS Linear/Vercel/Stripe feel)

### DIFF
--- a/resources/css/cowork-fields.css
+++ b/resources/css/cowork-fields.css
@@ -60,27 +60,29 @@
 
 /* ── Field wrapper (label + input + error) ─────────────────────────────── */
 .cw-field {
-  display: flex; flex-direction: column; gap: 5px; min-width: 0;
+  display: flex; flex-direction: column; gap: 4px; min-width: 0;
 }
 .cw-field label,
 .cw-label {
-  font-size: 11.5px; font-weight: 500; color: var(--cw-text-dim);
-  display: flex; align-items: center; gap: 6px;
+  font-size: 11px; font-weight: 500; color: var(--cw-text-dim);
+  display: flex; align-items: center; gap: 5px;
 }
 .cw-opt {
-  font-size: 10.5px; color: var(--cw-text-mute); font-weight: 400;
+  font-size: 10px; color: var(--cw-text-mute); font-weight: 400;
 }
 
 /* ── Input ─────────────────────────────────────────────────────────────── */
+/* SaaS compact density (Wagner 2026-05-27) — feel Linear / Vercel / Stripe.
+ * Era 36px h × 13px font × 10px pad. Agora 30px × 12.5px × 8px. */
 .cw-input {
   appearance: none;
-  width: 100%; height: 36px;
+  width: 100%; height: 30px;
   border: 1px solid var(--cw-border);
   background: var(--cw-surface);
   color: var(--cw-text);
-  border-radius: 6px;
-  padding: 0 10px;
-  font: inherit; font-size: 13px;
+  border-radius: 5px;
+  padding: 0 8px;
+  font: inherit; font-size: 12.5px;
   outline: none;
   transition: border-color .12s, box-shadow .12s;
 }
@@ -100,8 +102,8 @@
 
 /* Textarea variant (auto-height) */
 .cw-input.cw-textarea {
-  height: auto; padding: 8px 10px; line-height: 1.5;
-  min-height: 70px; resize: vertical;
+  height: auto; padding: 6px 8px; line-height: 1.45;
+  min-height: 56px; resize: vertical;
 }
 
 /* Native select dropdown — adiciona caret manual */
@@ -123,22 +125,22 @@ select.cw-input {
 
 .cw-err {
   display: flex; align-items: center; gap: 4px;
-  font-size: 11px; color: oklch(0.55 0.18 25);
+  font-size: 10.5px; color: oklch(0.55 0.18 25);
 }
 
 .cw-hint {
-  font-size: 11px; color: var(--cw-text-mute);
+  font-size: 10.5px; color: var(--cw-text-mute);
 }
 
 /* ── Radio pill ────────────────────────────────────────────────────────── */
 .cw-radio-row {
-  display: flex; gap: 6px; flex-wrap: wrap;
+  display: flex; gap: 5px; flex-wrap: wrap;
 }
 .cw-radio {
-  display: inline-flex; align-items: center; gap: 6px;
+  display: inline-flex; align-items: center; gap: 5px;
   border: 1px solid var(--cw-border); background: var(--cw-surface);
-  padding: 6px 10px; border-radius: 6px;
-  font-size: 12px; cursor: pointer;
+  padding: 4px 9px; border-radius: 5px;
+  font-size: 11.5px; cursor: pointer;
   transition: background .12s, border-color .12s, color .12s;
 }
 .cw-radio input { display: none; }
@@ -156,8 +158,8 @@ select.cw-input {
 .cw-tag-btn {
   appearance: none; border: 1px solid var(--cw-border);
   background: var(--cw-surface); color: var(--cw-text-dim);
-  padding: 5px 12px; border-radius: 999px;
-  font: inherit; font-size: 11.5px; cursor: pointer;
+  padding: 3px 10px; border-radius: 999px;
+  font: inherit; font-size: 11px; cursor: pointer;
   transition: background .12s, color .12s, border-color .12s;
 }
 .cw-tag-btn:hover { background: var(--cw-bg-2); color: var(--cw-text); }
@@ -168,19 +170,19 @@ select.cw-input {
 
 /* ── Toggle switch ─────────────────────────────────────────────────────── */
 .cw-toggle {
-  display: inline-flex; align-items: center; gap: 8px;
-  font-size: 12.5px; cursor: pointer; color: var(--cw-text);
+  display: inline-flex; align-items: center; gap: 7px;
+  font-size: 12px; cursor: pointer; color: var(--cw-text);
 }
 .cw-toggle input { display: none; }
 .cw-toggle-track {
-  width: 32px; height: 18px; background: var(--cw-border);
+  width: 28px; height: 16px; background: var(--cw-border);
   border-radius: 999px; position: relative;
   transition: background .15s;
   flex-shrink: 0;
 }
 .cw-toggle-thumb {
   position: absolute; top: 2px; left: 2px;
-  width: 14px; height: 14px; background: #fff; border-radius: 50%;
+  width: 12px; height: 12px; background: #fff; border-radius: 50%;
   box-shadow: 0 1px 2px rgba(0,0,0,.2);
   transition: left .15s;
 }
@@ -188,13 +190,13 @@ select.cw-input {
   background: var(--cw-accent);
 }
 .cw-toggle input:checked + .cw-toggle-track .cw-toggle-thumb {
-  left: 16px;
+  left: 14px;
 }
 
 /* ── Form grid (2 cols default, responsive) ────────────────────────────── */
 .cw-form-grid {
   display: grid; grid-template-columns: repeat(2, 1fr);
-  gap: 14px 12px;
+  gap: 10px 10px;
 }
 .cw-form-grid > .cw-field.full-row {
   grid-column: 1 / -1;
@@ -205,8 +207,8 @@ select.cw-input {
 
 /* ── Section title (idênticos ao Cowork) ───────────────────────────────── */
 .cw-section-title {
-  font-size: 10.5px; font-weight: 700;
-  letter-spacing: .06em; text-transform: uppercase;
+  font-size: 10px; font-weight: 700;
+  letter-spacing: .07em; text-transform: uppercase;
   color: var(--cw-text-mute);
-  margin: 0 0 10px;
+  margin: 0 0 8px;
 }


### PR DESCRIPTION
## Resumo

Wagner 2026-05-27 pós #1701: 'ficou melhor, só prefiro modo compact é um saas'.

Ajusta dimensões do CSS cowork-fields.css pra densidade SaaS canon (Linear / Vercel / Stripe / Notion). Apenas o CSS muda — zero mudança em componentes ou telas.

## Comparativo dimensões vs líderes SaaS

| | Antes (#1701) | **Agora (compact)** | Linear | Vercel | Stripe | DaisyUI compact |
|---|---|---|---|---|---|---|
| Input height | 36px | **30px** | 28px | 32px | 32px | 32px (input-sm) |
| Font size | 13px | **12.5px** | 13px | 14px | 14px | 14px |
| Padding | 10px | **8px** | 8px | 12px | 12px | 8px |

Fica meio-termo entre Linear (mais agressivo) e Vercel/Stripe (mais aerado).

## Mudanças (1 arquivo só)

`resources/css/cowork-fields.css`:
- Input: h 36→30, font 13→12.5, padding 10→8, border-radius 6→5
- Label: font 11.5→11, gap 6→5, opt 10.5→10
- Radio pill: padding 6/10→4/9, font 12→11.5
- Tag chip: padding 5/12→3/10, font 11.5→11
- Toggle: track 32x18→28x16, thumb 14→12
- Section title: 10.5→10, letter-spacing .06→.07em
- Form grid gap: 14/12→10/10
- Field gap label-input: 5→4

## Test plan

- [ ] **Smoke prod**: drawer Cliente + Sells/Create + OficinaAuto/Edit + Financeiro → conferir feel mais compact, denso, profissional
- [ ] Acessibilidade: clique nos campos ainda funciona bem (30px ≈ 28px Linear, aceitável WCAG 2.5.5 com largura suficiente)

## Reversibilidade

Rollback: re-inverter valores no CSS file. 1 arquivo, ~29 linhas mudadas.

Refs: ADR UI-0015 · PR #1701 (cowork default global)

🤖 Generated with Claude Code