### PR TITLE
feat(ui): Button cowork variants + drawer Cliente botões críticos

### DIFF
--- a/resources/css/cowork-fields.css
+++ b/resources/css/cowork-fields.css
@@ -32,6 +32,7 @@
   --cw-text-dim:     oklch(0.50 0.01 80);
   --cw-text-mute:    oklch(0.65 0.01 80);
   --cw-accent:       oklch(0.58 0.09 220);
+  --cw-accent-2:     oklch(0.66 0.09 220);  /* accent hover (mais claro) */
   --cw-accent-soft:  oklch(0.94 0.025 220);
   --cw-error:        oklch(0.65 0.18 25);
   --cw-error-soft:   oklch(0.94 0.04 25);
@@ -211,4 +212,52 @@ select.cw-input {
   letter-spacing: .07em; text-transform: uppercase;
   color: var(--cw-text-mute);
   margin: 0 0 8px;
+}
+
+/* ── Buttons (Cowork canon — primary/ghost — Wagner 2026-05-27) ────────── */
+.cw-btn-primary {
+  appearance: none; border: 0;
+  background: var(--cw-accent); color: #fff;
+  height: 30px; padding: 0 14px;
+  border-radius: 5px;
+  display: inline-flex; align-items: center; gap: 6px;
+  font: inherit; font-size: 12.5px; font-weight: 600;
+  cursor: pointer;
+  transition: background .15s;
+  white-space: nowrap;
+}
+.cw-btn-primary:hover { background: var(--cw-accent-2); }
+.cw-btn-primary:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 3px var(--cw-accent-soft);
+}
+.cw-btn-primary:disabled {
+  background: var(--cw-border); color: var(--cw-text-mute);
+  cursor: not-allowed;
+}
+
+.cw-btn-ghost {
+  appearance: none;
+  background: var(--cw-surface);
+  border: 1px solid var(--cw-border);
+  color: var(--cw-text);
+  height: 30px; padding: 0 12px;
+  border-radius: 5px;
+  display: inline-flex; align-items: center; gap: 6px;
+  font: inherit; font-size: 12.5px; font-weight: 500;
+  cursor: pointer;
+  transition: background .12s, border-color .12s;
+  white-space: nowrap;
+}
+.cw-btn-ghost:hover {
+  background: var(--cw-bg-2);
+  border-color: var(--cw-text-mute);
+}
+.cw-btn-ghost:focus-visible {
+  outline: 0;
+  box-shadow: 0 0 0 3px var(--cw-accent-soft);
+  border-color: var(--cw-accent);
+}
+.cw-btn-ghost:disabled {
+  opacity: 0.6; cursor: not-allowed;
 }

--- a/resources/js/Components/ui/button.tsx
+++ b/resources/js/Components/ui/button.tsx
@@ -19,6 +19,10 @@ const buttonVariants = cva(
         ghost:
           "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
         link: "text-primary underline-offset-4 hover:underline",
+        // Cowork variants (ADR UI-0015) — visual fiel ao protótipo Cowork canon.
+        // Aplica classes .cw-btn-* do resources/css/cowork-fields.css.
+        "cowork-primary": "cw-btn-primary",
+        "cowork-ghost":   "cw-btn-ghost",
       },
       size: {
         default: "h-9 px-4 py-2 has-[>svg]:px-3",
@@ -29,6 +33,8 @@ const buttonVariants = cva(
         "icon-xs": "size-6 rounded-md [&_svg:not([class*='size-'])]:size-3",
         "icon-sm": "size-8",
         "icon-lg": "size-10",
+        // Cowork compact size — alinhada com .cw-input h-30px.
+        cowork: "h-[30px] gap-1.5 rounded-[5px] px-3.5 text-[12.5px] has-[>svg]:px-3",
       },
     },
     defaultVariants: {

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -1835,21 +1835,19 @@ function ClienteSheet({
             </span>
           </div>
 
-          {/* Botoes acao -- Imprimir + Copiloto. */}
+          {/* Botoes acao -- Imprimir + Copiloto. ADR UI-0015 (cowork canon). */}
           <div className="flex items-center gap-2 pt-1">
             <Button
-              variant="outline"
-              size="sm"
+              variant="cowork-ghost"
               onClick={() => {
                 // Placeholder Wave B -- window.print() abre dialogo print do navegador.
                 // Wave G implementa CSS @media print + layout dedicado.
                 if (typeof window !== 'undefined') window.print();
               }}
-              className="text-xs h-7"
             >
               Imprimir ficha
             </Button>
-            <Button asChild size="sm" className="text-xs h-7">
+            <Button asChild variant="cowork-primary">
               <a
                 href={contact ? `/ia/chat?context=cliente:${contact.id}` : '#'}
                 title="Abre o Copiloto (Jana) com contexto deste cliente"
@@ -1942,22 +1940,19 @@ function ClienteSheet({
           </div>
           <div className="flex items-center gap-2">
             <Button
-              variant="outline"
-              size="sm"
+              variant="cowork-ghost"
               onClick={() => onOpenChange(false)}
-              className="text-xs h-7"
             >
               Cancelar
             </Button>
             <Button
-              size="sm"
+              variant="cowork-primary"
               onClick={() => {
                 // Placeholder Wave B -- Wave C dispara PATCH autosave on blur.
                 // router.reload only:['contact'] refresca payload sem rerender total.
                 // TODO Wave C: substituir por toast "Salvo" + reload partial.
                 onOpenChange(false);
               }}
-              className="text-xs h-7"
             >
               Salvar
             </Button>


### PR DESCRIPTION
## Resumo

Pedido Wagner 2026-05-27 ('TODOS componentes do Cliente em cowork'). Esta onda cobre **Button** — o componente mais visível (18 usos no Cliente).

## Mudanças

**`button.tsx`** ganha 2 variants + 1 size:
- `variant='cowork-primary'` (bg accent, white text)
- `variant='cowork-ghost'` (bg surface, border)
- `size='cowork'` (h-30px, text-12.5px, alinhado com cw-input)

**`cowork-fields.css`**:
- Novo token `--cw-accent-2` pra hover do primary
- `.cw-btn-primary` + `.cw-btn-ghost` com mesma dimensão dos inputs cowork

**`Cliente/Index.tsx`** — 4 botões críticos do drawer migrados:
- 'Imprimir ficha' → cowork-ghost
- 'Falar com Copiloto →' → cowork-primary
- 'Cancelar' → cowork-ghost
- 'Salvar' → cowork-primary

## Próximas ondas (não bloqueantes)

- Outros 14 Buttons do Cliente (ActionsMenu, Show, IATab, etc)
- Switch (1 uso) — variant cowork
- DropdownMenu (2 usos) — classes cowork no MenuContent
- Sheet (1 uso) — wrapper drawer com bg cowork

## Zero risco fora do Cliente

Variants cowork-* são opt-in. Outras telas (Sells/OficinaAuto/Compras) continuam visual shadcn.

Refs: ADR UI-0015. PRs #1698-#1702.

🤖 Generated with Claude Code