### PR TITLE
feat(ui): Onda 2 Cliente — Switch cowork + dark mode tokens + Buttons

### DIFF
--- a/resources/css/cowork-fields.css
+++ b/resources/css/cowork-fields.css
@@ -56,7 +56,11 @@
   --cw-text:         oklch(0.92 0.005 90);
   --cw-text-dim:     oklch(0.72 0.005 90);
   --cw-text-mute:    oklch(0.55 0.005 90);
+  --cw-accent:       oklch(0.64 0.10 220);  /* mais legível em fundo escuro */
+  --cw-accent-2:     oklch(0.72 0.10 220);
   --cw-accent-soft:  oklch(0.32 0.05 220);
+  --cw-error:        oklch(0.70 0.18 25);
+  --cw-error-soft:   oklch(0.30 0.08 25);
 }
 
 /* ── Field wrapper (label + input + error) ─────────────────────────────── */
@@ -260,4 +264,39 @@ select.cw-input {
 }
 .cw-btn-ghost:disabled {
   opacity: 0.6; cursor: not-allowed;
+}
+
+/* ── Switch Radix (ADR UI-0015 — Onda 2 Cliente 2026-05-27) ────────────── */
+/* Pareada com Switch.tsx variant="cowork". Usa Radix data-state attributes. */
+.cw-switch {
+  appearance: none;
+  width: 28px; height: 16px;
+  background: var(--cw-border);
+  border-radius: 999px;
+  position: relative;
+  flex-shrink: 0;
+  cursor: pointer;
+  outline: none;
+  border: 0;
+  transition: background .15s;
+}
+.cw-switch[data-state="checked"] { background: var(--cw-accent); }
+.cw-switch:focus-visible {
+  box-shadow: 0 0 0 3px var(--cw-accent-soft);
+}
+.cw-switch:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.cw-switch-thumb {
+  pointer-events: none;
+  display: block;
+  width: 12px; height: 12px;
+  background: #fff;
+  border-radius: 50%;
+  box-shadow: 0 1px 2px rgba(0,0,0,.2);
+  position: absolute;
+  top: 2px; left: 2px;
+  transition: transform .15s;
+}
+.cw-switch[data-state="checked"] .cw-switch-thumb {
+  transform: translateX(12px);
 }

--- a/resources/js/Components/ui/switch.tsx
+++ b/resources/js/Components/ui/switch.tsx
@@ -3,13 +3,37 @@ import { Switch as SwitchPrimitive } from "radix-ui"
 
 import { cn } from "@/Lib/utils"
 
+type SwitchVariant = "shadcn" | "cowork"
+
 function Switch({
   className,
   size = "default",
+  variant = "shadcn",
   ...props
 }: React.ComponentProps<typeof SwitchPrimitive.Root> & {
   size?: "sm" | "default"
+  /**
+   * Visual variant.
+   *
+   * **Default `shadcn`** (mantido pra não quebrar telas legacy).
+   *
+   * **Opt-in `cowork` (ADR UI-0015)**: aplica `.cw-switch` / `.cw-switch-thumb`
+   * — track 28×16, thumb 12px, accent quando on. Visual fiel ao protótipo Cowork.
+   */
+  variant?: SwitchVariant
 }) {
+  if (variant === "cowork") {
+    return (
+      <SwitchPrimitive.Root
+        data-slot="switch"
+        className={cn("cw-switch", className)}
+        {...props}
+      >
+        <SwitchPrimitive.Thumb data-slot="switch-thumb" className="cw-switch-thumb" />
+      </SwitchPrimitive.Root>
+    )
+  }
+
   return (
     <SwitchPrimitive.Root
       data-slot="switch"
@@ -31,3 +55,4 @@ function Switch({
 }
 
 export { Switch }
+export type { SwitchVariant }

--- a/resources/js/Pages/Cliente/Create.tsx
+++ b/resources/js/Pages/Cliente/Create.tsx
@@ -318,10 +318,10 @@ export default function ClienteCreate(props: ClienteCreatePageProps) {
           )}
 
           <div className="flex items-center justify-end gap-2 pt-4 border-t border-border">
-            <Button type="button" variant="outline" asChild>
+            <Button type="button" variant="cowork-ghost" asChild>
               <a href="/contacts/customer">Cancelar</a>
             </Button>
-            <Button type="submit" disabled={processing}>
+            <Button type="submit" variant="cowork-primary" disabled={processing}>
               <Save className="mr-1.5 h-4 w-4" />
               {processing ? 'Salvando…' : 'Salvar cliente'}
             </Button>

--- a/resources/js/Pages/Cliente/Edit.tsx
+++ b/resources/js/Pages/Cliente/Edit.tsx
@@ -276,10 +276,10 @@ export default function ClienteEdit(props: ClienteEditPageProps) {
           )}
 
           <div className="flex items-center justify-end gap-2 pt-4 border-t border-border">
-            <Button type="button" variant="outline" asChild>
+            <Button type="button" variant="cowork-ghost" asChild>
               <a href={`/contacts/${c.id}`}>Cancelar</a>
             </Button>
-            <Button type="submit" disabled={processing}>
+            <Button type="submit" variant="cowork-primary" disabled={processing}>
               <Save className="mr-1.5 h-4 w-4" />
               {processing ? 'Salvando…' : 'Salvar alterações'}
             </Button>

--- a/resources/js/Pages/Cliente/Import.tsx
+++ b/resources/js/Pages/Cliente/Import.tsx
@@ -177,10 +177,10 @@ export default function ClienteImport(props: ClienteImportPageProps) {
           )}
 
           <div className="flex items-center justify-end gap-2 mt-6 pt-4 border-t border-border">
-            <Button type="button" variant="outline" asChild>
+            <Button type="button" variant="cowork-ghost" asChild>
               <a href="/contacts/customer">Cancelar</a>
             </Button>
-            <Button type="submit" disabled={!data.contacts_csv || processing}>
+            <Button type="submit" variant="cowork-primary" disabled={!data.contacts_csv || processing}>
               <Upload className="mr-1.5 h-4 w-4" />
               {processing ? 'Importando…' : 'Importar'}
             </Button>

--- a/resources/js/Pages/Cliente/Show.tsx
+++ b/resources/js/Pages/Cliente/Show.tsx
@@ -171,7 +171,7 @@ export default function ClienteShow(props: ClienteShowPageProps) {
             </div>
             <div className="flex items-center gap-2">
               {permissions.update && (
-                <Button asChild>
+                <Button asChild variant="cowork-primary">
                   <a href={`/contacts/${contact.id}/edit`}>
                     <Edit className="mr-1.5 h-4 w-4" />
                     Editar

--- a/resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx
@@ -461,6 +461,7 @@ export default function ClassificacaoTab({ contact, onSaved, disabled = false }:
           </Label>
           <div className="mt-1 flex items-center gap-3 rounded-md border border-input bg-background px-3 py-2">
             <Switch
+              variant="cowork"
               id="cl-vip"
               checked={vip}
               disabled={disabled}


### PR DESCRIPTION
## Resumo

Wagner 2026-05-27 pós #1703: completar cowork em todos componentes do Cliente + modo dark.

## Mudanças

**Dark mode completo** (cowork-fields.css):
- Tokens `--cw-accent`, `--cw-accent-2`, `--cw-error`, `--cw-error-soft` adicionados em `.dark` (faltavam)
- Estratégia mantida: classe `.dark` no <html> (ADR UI-0004 canon)
- Anti-pattern documentado: NUNCA `@media (prefers-color-scheme: dark)`  - quebra preferência manual

**Switch.tsx** ganha `variant='cowork'`:
- Track 28×16, thumb 12px, accent quando checked
- Classe `.cw-switch` Radix-aware via `[data-state='checked']`
- Default mantido `shadcn` (não quebra telas legacy)

**6 Buttons migrados** pra cowork-primary / cowork-ghost:
- Show.tsx (Editar)
- Edit.tsx (Cancelar + Salvar alterações)
- Create.tsx (Cancelar + Salvar cliente)
- Import.tsx (Cancelar + Importar)

**1 Switch migrado**: `ClassificacaoTab` (VIP toggle)

## Cobertura módulo Cliente

| Componente | Antes | Agora |
|---|---|---|
| Input/Select/Textarea/Label | ✅ #1701 | ✅ |
| Button (drawer header/footer) | ✅ #1703 | ✅ |
| Button (Show/Edit/Create/Import) | shadcn | ✅ **ESTE PR** |
| Switch | shadcn | ✅ **ESTE PR** |
| DropdownMenu | shadcn | ⏳ próxima onda |
| Sheet (drawer wrapper) | shadcn | ⏳ próxima onda |

## Test plan

- [ ] Smoke drawer Cliente em light → switch VIP, botões drawer cowork
- [ ] Trocar pra **dark mode** no menu user (canto inferior) → confirmar:
  - Campos input continuam com bg cinza escuro consistente
  - Buttons primary com accent legível (azul mais claro)
  - Switch funciona em dark
  - Resto do app (sidebar, tabela) também dark
- [ ] Edit/Create/Import standalone com cowork-primary/ghost
- [ ] Show.tsx botão Editar cowork-primary

Refs: ADR UI-0004 (.dark), UI-0015 (cowork). PRs #1701/#1702/#1703.

🤖 Generated with Claude Code