### PR TITLE
fix(personas): Martinho (empresa) vs Jair (dono) + adicionar Kamila (admin/fiscal)

### DIFF
--- a/memory/clientes/martinho-cacambas/perfil.yml
+++ b/memory/clientes/martinho-cacambas/perfil.yml
@@ -5,7 +5,16 @@ business_id: null                       # confirmar — Wagner setup pendente
 status: piloto                          # cliente piloto Q2 2026 ramo oficina pesada
 plano: pro                              # mais features (OficinaAuto + frota)
 arr_mensal_brl: null                    # piloto Wagner
-contato_principal: daniela-martinho
+contato_principal: jair-martinho        # dono — decisor final
+contatos_operacionais:
+  - daniela-martinho                    # gerente operacional dia-a-dia
+  - kamila-martinho                     # esposa do Jair + administrativo/financeiro
+
+# Estrutura familiar/societária Martinho Caçambas:
+# - Jair (dono — decisão estratégica + dashboards)
+# - Kamila (esposa do Jair + responsável admin/financeiro/NF-e/cobrança)
+# - Daniela (gerente operacional — OSs, frota, oficina)
+# Empresa = "Martinho Caçambas" / "Martinho Transportes" (nome fantasia, NÃO pessoa).
 
 ramo: oficina-mecanica
 cnae: '4520-0'                          # serviços de manutenção e reparação de veículos automotores

--- a/memory/clientes/martinho-cacambas/personas/jair.yml
+++ b/memory/clientes/martinho-cacambas/personas/jair.yml
@@ -1,5 +1,5 @@
-slug: martinho-dono
-nome_real: Martinho
+slug: jair-martinho
+nome_real: Jair
 cliente_real: martinho-cacambas
 business_id: null
 status: ativo
@@ -61,8 +61,12 @@ pesos_override:
 
 citacoes:
   - data: "2026-05-26"
-    contexto: "infered via Daniela — Martinho pediu via Daniela"
+    contexto: "inferred via Daniela — Jair pediu via gerente Daniela"
     texto: '"quero ver os caminhões dos clientes na tela do cliente — não preciso ficar abrindo OficinaAuto separado"'
+
+# Notas
+# Casado com Kamila (administrativo/financeiro da empresa) — ver kamila.yml
+# Nome empresa: Martinho Caçambas (Jair é o dono, não tem "Martinho" como nome próprio)
 
 tags:
   - non-tech

--- a/memory/clientes/martinho-cacambas/personas/kamila.yml
+++ b/memory/clientes/martinho-cacambas/personas/kamila.yml
@@ -1,0 +1,93 @@
+slug: kamila-martinho
+nome_real: Kamila
+cliente_real: martinho-cacambas
+business_id: null
+status: ativo
+created_at: '2026-05-27'
+updated_at: '2026-05-27'
+ultima_entrevista: null                 # placeholder — fazer próxima visita
+
+papel: administrativo-financeiro
+idade_aproximada: 50
+formacao: ensino médio + experiência prática 20+ anos gestão escritório
+genero: feminino
+relacao_com_dono: esposa do Jair (dono)
+
+local: escritório oficina pesada Martinho Tubarão SC
+monitor: "1920x1080 desktop escritório"
+hardware: "PC desktop dedicado escritório"
+ruido: medio
+pressa: media                            # rotinas administrativas, não urgência balcão
+
+frequencia_diaria:
+  - tela: financeiro/contas-receber
+    qtd: 20                             # cobrança de cliente PJ frota
+  - tela: financeiro/contas-pagar
+    qtd: 15                             # fornecedor peças
+  - tela: nfe-brasil
+    qtd: 10                             # emissão NF-e por OS faturada
+  - tela: cliente/index
+    qtd: 8                              # busca cliente pra cobrar / emitir nota
+  - tela: financeiro/fluxo-caixa
+    qtd: 3                              # conferência diária
+  - tela: financeiro/dre
+    qtd: 1                              # fim de mês
+
+tecnico: meio                            # 20 anos experiência admin, familiar com sistemas
+modelo_mental: "preciso ter o caixa controlado e as notas saindo certas — sem erro fiscal"
+
+jtbd:
+  - quando: "cliente PJ frota está atrasado no pagamento"
+    eu_quero: "abrir cliente e ver saldo + histórico de OSs + data último pagamento + telefone Jair contato"
+    para: "ligar cobrando com autoridade e info correta"
+    motivacao_funcional: "recuperar pagamento"
+    motivacao_emocional: "se sentir profissional, não amadora"
+    motivacao_social: "preservar relação com cliente (não brigar)"
+
+  - quando: "OS aprovada e faturada — emitir NF-e"
+    eu_quero: "abrir OS finalizada e clicar 'emitir NF-e' com dados pré-preenchidos cliente + CNPJ + IE + endereço fiscal"
+    para: "NF-e validada pela SEFAZ sem erro"
+    motivacao_funcional: "compliance fiscal sem erro"
+    motivacao_emocional: "tranquilidade — nada de SPED rejeitado pelo contador"
+
+  - quando: "fim do dia, fechar caixa"
+    eu_quero: "ver fluxo do dia: o que entrou (pagamentos OS), o que saiu (peças), saldo final"
+    para: "passar resumo pro Jair (esposo/dono) à noite"
+    motivacao_funcional: "relatório diário"
+    motivacao_emocional: "se sentir no controle do administrativo"
+
+fricoes:
+  - "abrir cliente pra cobrar e não ver telefone secundário (contador, gerente compras do cliente)"
+  - "emitir NF-e e descobrir que IE do cliente está vazio — preciso voltar pra cadastro do cliente"
+  - "ver saldo total que cliente deve, mas não vejo POR QUAL OS é a dívida (precisa drill down)"
+  - "campos fiscais (CFOP, NCM, regime) sumiram do cadastro cliente quando precisei conferir antes de NF-e"
+
+sucesso:
+  - "cobrança PJ frota: abre cliente + vê saldo + histórico + contato em 1 tela (<10s)"
+  - "emitir NF-e a partir de OS aprovada: ≤5 cliques + zero erro SEFAZ"
+  - "fluxo caixa do dia em 1 visão (entrada + saída + saldo) sem múltiplos relatórios"
+  - "drill-down: clicar no saldo do cliente e ver detalhe por OS"
+
+pesos_override:
+  density: 3                            # quer ver tudo do cliente PJ de uma vez
+  information_hierarchy: 3              # saldo + última OS + telefone visíveis em prioridade
+  i18n_pt_br: 3                         # campos fiscais BR (IE, IM, CFOP, NCM, regime, CNPJ formato)
+  error_recovery: 3                     # erro fiscal NF-e é caro — tem que dar pra desfazer rápido
+  microcopy: 2                          # mensagens claras sobre erro fiscal específico
+  affordance: 2                         # botões claros pra ação fiscal (emitir, cancelar NF, CC-e)
+  brand_confidence: 1                   # default 1 — Kamila quer eficiência operacional
+
+citacoes:
+  - data: "2026-05-27"
+    contexto: "inferred pre-discovery — refinar com cliente real próxima visita Tubarão"
+    texto: '"preciso emitir nota sem erro — contador reclama quando rejeita"'
+
+tags:
+  - tecnica-meio
+  - administrativo
+  - financeiro
+  - oficina-pesada
+  - fiscal-nfe-power-user
+  - desktop-primary
+  - pme-media
+  - cobranca-pj-frota

--- a/memory/requisitos/_DesignSystem/adr/ui/0016-design-contextualizado-por-persona.md
+++ b/memory/requisitos/_DesignSystem/adr/ui/0016-design-contextualizado-por-persona.md
@@ -86,5 +86,17 @@ PR `feat/design-deep-framework-canon` 2026-05-27:
 1. ADR canon (este arquivo)
 2. `framework-15-dimensoes.md` + tabela ponderação
 3. `RUNBOOK-design-deep.md` + `RUNBOOK-cliente-discovery.md`
-4. 2 perfis empresa + 3 personas iniciais (Rota Livre/Larissa, Martinho/Daniela, Martinho/Martinho)
+4. 2 perfis empresa + 4 personas iniciais:
+   - Rota Livre/Larissa (dona-balconista vestuário)
+   - Martinho Caçambas/Jair (dono — decisor estratégico)
+   - Martinho Caçambas/Daniela (gerente operacional)
+   - Martinho Caçambas/Kamila (admin/financeiro — esposa do Jair)
 5. 2 skills (`design-deep-analysis`, `cliente-discovery`)
+
+## Errata 2026-05-27 pós-commit inicial
+
+- "Martinho" é nome da EMPRESA (Martinho Caçambas / Martinho Transportes), não pessoa.
+- **Jair** é o nome real do dono.
+- **Kamila** é esposa do Jair + administrativo/financeiro/NF-e/cobrança PJ frota.
+- Persona `martinho.yml` original (criada como "dono") foi corrigida e renomeada → `jair.yml`.
+- Persona `kamila.yml` adicionada como canon.

--- a/memory/requisitos/_DesignSystem/framework-15-dimensoes.md
+++ b/memory/requisitos/_DesignSystem/framework-15-dimensoes.md
@@ -55,30 +55,31 @@ Mesmo padrão em telas equivalentes. Filtro de Sells = filtro de Compras = filtr
 
 Peso 1× = baseline. Peso 2× = importante. Peso 3× = crítico.
 
-| Dimensão | Larissa (balconista) | Daniela (operacional) | Martinho (dono) | Contador (futuro) |
+| Dimensão | Larissa (balconista) | Daniela (operacional) | Jair (dono Martinho) | Kamila (admin/fiscal) |
 |---|---|---|---|---|
 | 1. Density | 2 | 3 | 1 | 3 |
-| 2. Discoverability | 3 | 2 | 2 | 1 |
-| 3. Speed-to-task | 3 | 2 | 1 | 1 |
-| 4. Error recovery | 3 | 2 | 1 | 2 |
-| 5. Cognitive load | 3 | 2 | 1 | 1 |
+| 2. Discoverability | 3 | 2 | 2 | 2 |
+| 3. Speed-to-task | 3 | 2 | 1 | 2 |
+| 4. Error recovery | 3 | 2 | 1 | 3 |
+| 5. Cognitive load | 3 | 2 | 1 | 2 |
 | 6. Aesthetic-usability | 2 | 1 | 3 | 1 |
-| 7. Affordance | 3 | 2 | 1 | 1 |
-| 8. Brand confidence | 1 | 1 | 3 | 2 |
+| 7. Affordance | 3 | 2 | 1 | 2 |
+| 8. Brand confidence | 1 | 1 | 3 | 1 |
 | 9. Mobile fit | 2 | 1 | 2 | 1 |
 | 10. A11y WCAG | 2 | 2 | 1 | 2 |
 | 11. i18n PT-BR | 3 | 3 | 2 | 3 |
 | 12. Performance perceived | 2 | 2 | 1 | 1 |
 | 13. Information hierarchy | 1 | 3 | 3 | 3 |
-| 14. Microcopy | 3 | 2 | 1 | 1 |
-| 15. Internal consistency | 1 | 2 | 2 | 1 |
-| **Total ponderado max** | **34** | **30** | **25** | **24** |
+| 14. Microcopy | 3 | 2 | 1 | 2 |
+| 15. Internal consistency | 1 | 2 | 2 | 2 |
+| **Total ponderado max** | **34** | **30** | **25** | **29** |
 
 ### Como ler a tabela
 
-- **Larissa** (não-técnica, balcão): peso 3 em Speed/Cognitive/Affordance/Microcopy/Discoverability — ela odeia "achar onde clicar"
-- **Daniela** (operacional oficina): peso 3 em Density/Information hierarchy/i18n — quer ver tudo de uma vez, frota + saldo + última OS
-- **Martinho** (dono): peso 3 em Brand confidence/Information hierarchy — paga pra "parecer empresa séria"
+- **Larissa** (não-técnica, balcão Rota Livre): peso 3 em Speed/Cognitive/Affordance/Microcopy/Discoverability — ela odeia "achar onde clicar"
+- **Daniela** (gerente operacional Martinho): peso 3 em Density/Information hierarchy/i18n — quer ver tudo de uma vez, frota + saldo + última OS
+- **Jair** (dono Martinho Caçambas): peso 3 em Brand confidence/Information hierarchy/Aesthetic-usability — paga pra "parecer empresa séria"
+- **Kamila** (admin/financeiro Martinho — esposa do Jair): peso 3 em Density/Error recovery/i18n PT-BR/Information hierarchy — emite NF-e, cobra cliente, fluxo caixa — erro fiscal é caro
 
 ### Cálculo do score
 


### PR DESCRIPTION
## Errata factual

Wagner 2026-05-27 corrigiu: **Martinho é nome da EMPRESA** (Martinho Caçambas / Martinho Transportes), não pessoa. O dono é o **Jair**. E **Kamila** é esposa do Jair + administrativo/financeiro.

Erro original no #1707: criei `martinho.yml` como persona dono. Princípio violado: ADR 0105 (cliente-como-sinal) — persona deve ser pessoa real factual, não inferida de nome fantasia.

## Correções

- `martinho.yml` RENAMED → `jair.yml` (slug `jair-martinho`, nome_real Jair)
- `kamila.yml` CRIADO — papel administrativo/financeiro (Wagner confirmou via question)
- `perfil.yml` atualizado: contato_principal=jair, operacionais=[daniela, kamila]
- `framework-15-dimensoes.md` tabela ponderação atualizada com Jair + Kamila (Kamila tem pesos altos em Density/Error recovery/i18n PT-BR/Information hierarchy — fiscal NF-e + cobrança)
- ADR UI-0016 ganha errata explicando correção

## Estrutura final Martinho Caçambas

- **Jair** — dono (decisor estratégico + dashboards à noite)
- **Kamila** — esposa do Jair + administrativo/financeiro/NF-e/cobrança PJ frota
- **Daniela** — gerente operacional (OSs, frota, oficina dia-a-dia)

Refs: ADR UI-0016. PR #1707 (original).

🤖 Generated with Claude Code