### PR TITLE
feat(design-system): integração persona auto-load + JTBD Forces + Nielsen 10

### DIFF
--- a/.claude/skills/personas-resolve/SKILL.md
+++ b/.claude/skills/personas-resolve/SKILL.md
@@ -1,0 +1,123 @@
+---
+name: personas-resolve
+description: BLOQUEADOR Tier A — ATIVAR ANTES de qualquer Edit/Write/MultiEdit em arquivos de `resources/js/Pages/**/*.tsx` ou criação de tela nova. Resolve a(s) persona(s) alvo da tela em 3 níveis de fallback (1) charter da tela `<Tela>.charter.md` campo `personas_alvo`; (2) mapping módulo em `memory/requisitos/_DesignSystem/personas-por-modulo.yml`; (3) pergunta interativa ao Wagner. Carrega persona YAML completa de `memory/clientes/<cliente>/personas/<slug>.yml` no contexto antes de codar. Sem persona resolvida = NÃO procede com edit visual. Reforça ADR UI-0016 (design contextualizado por persona). NUNCA usar persona hipotética sem cliente real (ADR 0105).
+---
+
+# personas-resolve — Auto-load persona alvo da tela (Tier A bloqueador)
+
+Quando ativar (auto-trigger description matches):
+- Edit/Write/MultiEdit em `resources/js/Pages/**/*.tsx`
+- Criação de tela nova (file não existe ainda)
+- Wagner pede "cria tela X" / "edita tela Y" / "refator visual tela Z"
+
+NÃO ativar pra:
+- Edit em `_components/`, `_form/`, `_show/` (componente isolado — herda persona da tela pai)
+- Edit em `Components/ui/*` (shadcn — universal, sem persona)
+- Edit em scripts / migrations / controllers / models (não-visual)
+
+## Workflow de resolução (3 níveis)
+
+### Nível 1 — Charter declara persona
+
+Procurar `<Tela>.charter.md` ao lado do `.tsx` editado. Se existir campo:
+
+```yaml
+---
+personas_alvo:
+  - daniela-martinho                    # primary (peso maior)
+  - jair-martinho                       # secondary
+job_principal: "registrar entrada OS em ≤45s"
+fricoes_conhecidas:
+  - daniela: "4 tabs até fotos do veículo"
+---
+```
+
+Use as personas declaradas em ordem. Carregar YAML de cada via `memory/clientes/<cliente-real>/personas/<slug>.yml`.
+
+### Nível 2 — Mapping módulo (fallback se charter sem campo)
+
+Ler `memory/requisitos/_DesignSystem/personas-por-modulo.yml`. Cada módulo tem:
+
+```yaml
+sells:
+  primary: larissa-rota-livre
+  secondary: [daniela-martinho]
+```
+
+Pegar `primary` do módulo da tela (ex: `Pages/Sells/Create.tsx` → módulo `sells` → Larissa).
+
+### Nível 3 — Pergunta interativa (fallback se nada acima resolveu)
+
+Mostrar pergunta ao Wagner:
+
+```
+Vou editar/criar resources/js/Pages/<Mod>/<Tela>.tsx mas não encontrei persona declarada.
+
+Persona alvo principal?
+  1) Larissa (Rota Livre — dona-balconista vestuário)
+  2) Daniela (Martinho — gerente operacional oficina)
+  3) Jair (Martinho — dono, dashboards)
+  4) Kamila (Martinho — admin/fiscal, NF-e + cobrança)
+  5) Outra (especifique)
+  6) Universal (sem persona específica — raro)
+```
+
+Após resposta, **SALVAR no charter** (cria se não existe). Próxima vez não pergunta de novo.
+
+## Anúncio antes de codar
+
+Após resolver, **anunciar pra Wagner**:
+
+```
+🎯 Vou codar pra:
+  PRIMARY: <persona> (<papel> — <cliente real>)
+  SECONDARY: [<persona2>, ...]
+
+Top 3 dimensões priorizadas (framework 15D):
+  - <dim> (peso N)
+  - <dim> (peso N)
+  - <dim> (peso N)
+
+Top JOB: <job_principal>
+Fricções conhecidas: <fricoes_conhecidas>
+
+Confirma persona? (s = procedo / outra = trocar / -- = sem persona, faz genérico)
+```
+
+Se Wagner confirma com `s` → procede. Se trocar → re-load. Se `--` → procede como genérico (excepcional, perde a vantagem contextual).
+
+## Princípios duros
+
+- **Bloqueador Tier A** — sem persona declarada/resolvida não procede em Pages/
+- **Anúncio obrigatório** — Wagner precisa ver persona-alvo ANTES do diff, não depois
+- **Charter wins** — declaração explícita no charter sempre prevalece sobre mapping módulo
+- **Salvar no charter pós-pergunta** — append-only, não pergunta de novo
+- **ADR 0105** — só persona com cliente real paga + reportou
+- **ADR UI-0016** — design contextualizado é canon, não improviso
+
+## Integração com outras skills
+
+- **`charter-first`** (Tier A já existe) — esta skill EXTENDE com resolução de persona
+- **`charter-write`** — se nível 3 disparou pergunta, append persona resolvida ao charter
+- **`design-deep-analysis`** (Tier B) — depois de Wagner confirmar persona, pode rodar análise profunda
+- **`mwart-process`** (Tier A) — durante MWART F3 (frontend), usar persona como input
+- **`cliente-discovery`** — se persona não existe ainda, sugerir rodar discovery primeiro
+
+## Anti-patterns
+
+❌ Codar tela sem ter declarado/resolvido persona = improviso disfarçado
+❌ Pular anúncio "vou codar pra X" → Wagner não sabe contexto da decisão
+❌ Inventar persona hipotética sem cliente real (= ficção, ADR 0105 viola)
+❌ Ignorar fricoes_conhecidas do charter (= refator regenera fricção velha)
+❌ Usar peso default sem checar `pesos_override` do YAML persona
+
+## Output esperado
+
+Sempre que skill ativa, contexto do turno tem:
+
+- 1+ personas YAML completas carregadas
+- JTBD principal da tela
+- Top 5 fricções persona (combinadas de charter + persona.fricoes)
+- Pesos 15D ponderados (override do YAML > default módulo > default papel)
+
+Daí Claude codifica decisões justificadas. Cada commit pode citar "essa escolha foi pra resolver fricção X da Daniela".

--- a/memory/requisitos/_DesignSystem/framework-15-dimensoes.md
+++ b/memory/requisitos/_DesignSystem/framework-15-dimensoes.md
@@ -102,3 +102,75 @@ Tela com score > 80 = ótimo.
 7. Wagner decide → aplica → smoke prod
 
 Detalhes operacionais no [RUNBOOK-design-deep.md](RUNBOOK-design-deep.md).
+
+---
+
+## Frameworks complementares canon (adicionados 2026-05-27)
+
+O **15D** cobre análise tática de tela. Pra cobrir outros ângulos do design o canon do oimpresso agora incorpora 2 frameworks consolidados:
+
+### A. JTBD Forces (Bob Moesta — Re-Wired Group)
+
+Modelo de **DECISÃO de adoção/abandono** do usuário. Quatro forças competem:
+
+| Força | Definição | Pergunta canon |
+|---|---|---|
+| **Push (do velho)** | Frustração com sistema atual | "O que dói no que ele usa hoje?" |
+| **Pull (do novo)** | Atração pelo oimpresso | "O que o oimpresso resolve que ele queria?" |
+| **Anxiety (do novo)** | Medo de trocar (vai dar certo?) | "O que ele tem MEDO se trocar?" |
+| **Habit (do velho)** | Apego ao familiar | "O que ele vai sentir falta do velho?" |
+
+**Trocar acontece quando**: `Push + Pull > Anxiety + Habit`.
+
+Aplicação no oimpresso: análise de **conversão piloto→pago** (Larissa, Daniela) e **prevenção de churn** (oimpresso vs Bling/Tiny/Omie). Quando designar tela que afeta decisão de continuar usando, escorar via JTBD Forces — NÃO 15D.
+
+Exemplo concreto Sells/Create:
+- **Push velho**: Excel + caderno fiado, perde controle saldo cliente
+- **Pull novo**: vê saldo no balcão em 1 clique
+- **Anxiety**: "se quebrar o sistema, perco vendas"
+- **Habit**: "Excel eu sei onde tudo está"
+
+Decisão design Sells/Create deve **MAXIMIZAR Pull (saldo evidente, NF-e auto)** + **REDUZIR Anxiety (recovery rápido, offline mode)** + **REDUZIR Habit (atalhos espelham caderno mental)**.
+
+### B. Nielsen Heuristics 10 (NN/g 1994)
+
+Checklist universal de sanity. **Pre-merge UI review** — Claude valida tela contra os 10 antes de aprovar PR:
+
+| # | Heurística | Pergunta |
+|---|---|---|
+| H1 | Visibility of system status | Usuário sabe o que está acontecendo agora? (loading, saved, etc) |
+| H2 | Match between system and real world | Termos = linguagem do usuário (PT-BR PME, não tech) |
+| H3 | User control and freedom | Saída de emergência sempre disponível (Cancelar, Voltar) |
+| H4 | Consistency and standards | Mesmo padrão em telas equivalentes |
+| H5 | Error prevention | Validação antes do erro (mascara CNPJ, confirma antes deletar) |
+| H6 | Recognition over recall | Mostra opções (dropdown) > exige lembrar (input livre) |
+| H7 | Flexibility and efficiency | Atalhos pra power user, sem complicar pra novato |
+| H8 | Aesthetic and minimalist design | Cada elemento na tela compete por atenção — corte o desnecessário |
+| H9 | Help users recognize, diagnose, recover from errors | Mensagem de erro explica + sugere ação corretiva |
+| H10 | Help and documentation | Onde necessário, ajuda contextual em ≤1 clique |
+
+Aplicação no oimpresso: skill `design-deep-analysis` roda Nielsen 10 como **quick sanity check** ANTES de pontuar 15D detalhado. Se reprovar em ≥3 heurísticas, sinaliza "tela tem problema fundamental, refator profundo".
+
+### Como combinar
+
+```
+┌─ Pergunta tipo "tela X tá ruim" ─────────────────────────────────────┐
+│                                                                       │
+│  1. Quick check Nielsen 10 (5 min) — algum vermelho?                  │
+│     SIM → refator profundo (15D + 3 alternativas)                     │
+│     NÃO → continua                                                    │
+│                                                                       │
+│  2. 15D score ponderado por persona — score < 60? refator             │
+│                                                                       │
+│  3. Se tela é "porta de entrada" (Sells/Create, Cliente landing):     │
+│     rodar JTBD Forces — Push/Pull/Anxiety/Habit balanceado?           │
+│                                                                       │
+└───────────────────────────────────────────────────────────────────────┘
+```
+
+### Refs
+
+- Bob Moesta — "Demand-Side Sales" + "Forces of Progress" framework
+- Clayton Christensen — "Competing Against Luck" (livro)
+- Jakob Nielsen — "10 Usability Heuristics" (NN/g, 1994)
+- Whitney Quesenbery — "5Es of Usability" (cabíveis em futuras expansões)

--- a/memory/requisitos/_DesignSystem/personas-por-modulo.yml
+++ b/memory/requisitos/_DesignSystem/personas-por-modulo.yml
@@ -1,0 +1,114 @@
+# ── Mapping módulo → persona dominante (fallback nível 2 da skill personas-resolve) ──
+#
+# Refs: ADR UI-0016 (design contextualizado), .claude/skills/personas-resolve/SKILL.md
+#
+# Usado quando charter da tela NÃO declara `personas_alvo` explicitamente.
+# Quando declara, charter wins (mais específico).
+#
+# Princípio: `primary` é a persona QUE PASSA MAIS TEMPO usando o módulo no dia-a-dia.
+# `secondary` são personas que tocam ocasionalmente.
+#
+# Cada slug aponta pra um arquivo em memory/clientes/<cliente>/personas/<slug>.yml
+
+# ── Módulos Inertia/React (resources/js/Pages/<Mod>/) ──────────────────────
+
+sells:
+  primary: larissa-rota-livre           # POS balcão 50×/dia
+  secondary:
+    - daniela-martinho                  # venda peça avulsa eventual
+    - kamila-martinho                   # consulta venda pra emitir NF-e
+
+cliente:                                # módulo Cliente (Contacts) — uso UNIVERSAL
+  primary: depends_on_ramo              # ramo do cliente final determina
+  secondary:
+    - larissa-rota-livre                # cliente PF balcão
+    - daniela-martinho                  # cliente PJ frota
+    - kamila-martinho                   # consultar saldo + dados fiscais
+
+oficinaauto:
+  primary: daniela-martinho             # gerente operacional — OSs ativas 30×/dia
+  secondary:
+    - jair-martinho                     # dono — vê dashboard
+    - kamila-martinho                   # admin — faturamento pós-OS
+
+financeiro:
+  primary: kamila-martinho              # admin/fiscal 50+ acessos/dia
+  secondary:
+    - jair-martinho                     # dono — fluxo + DRE final mês
+    - larissa-rota-livre                # contas a receber básico (balcão)
+
+nfe-brasil:
+  primary: kamila-martinho              # power user fiscal NF-e
+  secondary:
+    - daniela-martinho                  # emite ao finalizar OS
+
+nfse:
+  primary: kamila-martinho
+  secondary: []
+
+repair:                                 # módulo Repair legacy (mecânica simples)
+  primary: daniela-martinho             # similar OficinaAuto mas menor escopo
+  secondary: []
+
+ponto:                                  # módulo Ponto (folha + espelho)
+  primary: kamila-martinho              # admin RH
+  secondary:
+    - jair-martinho                     # dono aprovação espelho
+
+compras:
+  primary: kamila-martinho              # compra peça/produto
+  secondary:
+    - daniela-martinho                  # solicita peça pra OS
+
+produto:                                # cadastro de produto
+  primary: larissa-rota-livre           # cadastra peça vestuário
+  secondary:
+    - kamila-martinho                   # cadastra peça automotiva
+
+whatsapp:                               # módulo WhatsApp (atendimento + outbound)
+  primary: larissa-rota-livre           # atende cliente balcão via WA
+  secondary:
+    - daniela-martinho                  # aprovação orçamento via WA cliente frota
+
+atendimento:                            # módulo Atendimento (ticket)
+  primary: depends_on_business          # varia
+  secondary: []
+
+essentials:                             # cadastros gerais (categorias, etc)
+  primary: kamila-martinho              # admin que configura
+  secondary: []
+
+jana:                                   # módulo Copiloto/IA
+  primary: depends_on_business
+  secondary: [larissa-rota-livre, daniela-martinho, kamila-martinho, jair-martinho]
+
+# ── Áreas especiais ──────────────────────────────────────────────────────
+
+admin/feature-flags:                    # painel super-admin
+  primary: wagner                       # só Wagner mesmo
+  secondary: []
+
+superadmin:                             # tools dev
+  primary: wagner
+  secondary: []
+
+ads:                                    # painel ADS (dual brain audit)
+  primary: wagner
+  secondary: []
+
+# ── Notas ────────────────────────────────────────────────────────────────
+#
+# `depends_on_ramo` / `depends_on_business`:
+#   Resolução dinâmica — Claude detecta o `business_id` da sessão e infere
+#   persona pelo ramo do cliente real (Rota Livre vestuário → Larissa primary;
+#   Martinho oficina → Daniela primary).
+#
+# `wagner`:
+#   Telas admin/dev. Não precisa de persona contextualizada — Wagner é
+#   power user que entende o domínio. Pode pular skill personas-resolve.
+#
+# Personas extras a adicionar quando aparecer cliente real:
+#   - contador (escritório terceirizado) — perfil específico fiscal/SPED
+#   - vendedor externo (rep comercial visita cliente)
+#   - mecanico (chão de oficina — tablet ruidoso)
+#   - cliente final (visualizar status OS via link público)

--- a/resources/js/Pages/Cliente/Index.charter.md
+++ b/resources/js/Pages/Cliente/Index.charter.md
@@ -4,11 +4,30 @@ component: resources/js/Pages/Cliente/Index.tsx
 owner: wagner
 status: live
 last_validated: 2026-05-24
-charter_version: 6
+charter_version: 7
 parent_module: Cliente / Crm
 related_adrs: [0093, 0094, 0104, 0107, 0110, 0114, 0149, 0179, 0187]
 supersedes: [Pages/Cliente/Show.charter.md v2]
 tier: A
+
+# ── ADR UI-0016 design contextualizado por persona ──────────────────────
+# Skill personas-resolve (Tier A) carrega persona(s) automaticamente em edit.
+personas_alvo:
+  - depends_on_ramo                     # universal — varia por cliente final
+  - daniela-martinho                    # secondary — frota Martinho pediu Veículos
+  - kamila-martinho                     # secondary — admin/fiscal busca cliente
+  - larissa-rota-livre                  # secondary — POS lookup cliente recorrente
+job_principal: "buscar cliente recorrente em ≤3s; abrir drawer com info contextual em ≤1 clique"
+fricoes_conhecidas:
+  daniela: "veículos do cliente escondidos em sub-tab OSs (Fix #1694)"
+  kamila: "saldo cliente sem drill-down por OS"
+  larissa: "cliente fiado: precisa ir em Financeiro pra ver saldo"
+metrica_sucesso:
+  - "buscar cliente por nome parcial em ≤3 chars + ≤500ms"
+  - "abrir drawer + ver KPIs primários (saldo, última OS, contato) em ≤1s"
+  - "Daniela vê frota do cliente sem trocar de tab"
+# ── /ADR UI-0016 ────────────────────────────────────────────────────────
+
 mwart_pattern_reuse:
   blueprint_cowork: "prototipo-ui/prototipos/clientes/ (HTML + 13 .jsx)"
   blueprint_screenshot_approval: "Wagner 2026-05-21 aprovou opção A (drawer 760px)"


### PR DESCRIPTION
## Resumo

Wagner 2026-05-27 'sim' — integração completa do framework design contextualizado com fluxo de criação real.

Fecha o ciclo entre ADR UI-0016 canônica e workflow editorial — daqui pra frente toda edição em `Pages/` carrega persona automaticamente.

## O que entrega

### Skill `personas-resolve` Tier A (bloqueador)

Auto-trigger em `Edit/Write/MultiEdit` de `resources/js/Pages/**/*.tsx`. Resolve persona em 3 níveis:

1. **Charter da tela** (`personas_alvo:` frontmatter) — wins
2. **Mapping módulo** (`personas-por-modulo.yml`) — fallback
3. **Pergunta interativa** + salva no charter pra próxima vez

Anuncia ANTES de codar:
```n🎯 Vou codar pra:
  PRIMARY: Daniela (gerente operacional Martinho)
  SECONDARY: Jair

Top 3 dimensões (15D ponderado):
  - Density (peso 3)
  - Information hierarchy (peso 3)
  - i18n PT-BR (peso 3)

Top JOB: registrar entrada OS em ≤45s

Confirma? (s/n/trocar)
```n
### Mapping `personas-por-modulo.yml`

14 módulos mapeados:
- sells → Larissa (POS 50×/dia)
- oficinaauto → Daniela (gerente operacional)
- financeiro/nfe-brasil → Kamila (admin/fiscal)
- cliente → depends_on_ramo (universal)
- jana/atendimento → depends_on_business
- admin/superadmin/ads → wagner

### Charter Cliente/Index atualizado (template canônico)

Novos campos frontmatter:
- `personas_alvo: [...]`
- `job_principal: '...'`
- `fricoes_conhecidas: {persona: descrição, ...}`
- `metrica_sucesso: [...]`

### 2 frameworks complementares anexados ao 15D canon

**JTBD Forces** (Bob Moesta): Push + Pull + Anxiety + Habit. Modelo de DECISÃO adoção/abandono — usar pra conversão piloto→pago + prevenção churn vs Bling/Tiny.

**Nielsen Heuristics 10** (NN/g 1994): checklist universal sanity. Quick check pre-merge UI review.

Workflow combinado:
1. Nielsen 10 quick → algum vermelho? refator profundo
2. 15D score ponderado → < 60? refator
3. JTBD Forces se é tela porta de entrada → Push+Pull > Anxiety+Habit?

## Princípio

Design contextualizado vira **AUTOMÁTICO**. Wagner não precisa mais lembrar de mencionar persona — skill carrega + anuncia + procede.

## Refs

ADR UI-0016 · ADR 0105 · PRs #1707 #1708.

🤖 Generated with Claude Code