### PR TITLE
feat(whatsapp/feedback): abrir chamado de dev direto da conversa + guard rails ADR 0105

### DIFF
--- a/Modules/Whatsapp/Database/Migrations/2026_05_27_220000_add_dev_task_requested_to_clients_feedbacks.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_27_220000_add_dev_task_requested_to_clients_feedbacks.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * clients_feedbacks — adiciona dev_task_requested boolean
+ *
+ * Wagner 2026-05-27: atendente conseguir marcar feedback como "vira chamado de dev"
+ * direto da conversa WhatsApp. Triagem Wagner cria task MCP via tool em até 24h.
+ *
+ * Refs: ADR 0105 (cliente-como-sinal), feedback-management RUNBOOK.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('clients_feedbacks')) {
+            return;
+        }
+        if (Schema::hasColumn('clients_feedbacks', 'dev_task_requested')) {
+            return;
+        }
+
+        Schema::table('clients_feedbacks', function (Blueprint $table) {
+            $table->boolean('dev_task_requested')->default(false)->after('mcp_task_id');
+            $table->index(['business_id', 'dev_task_requested'], 'idx_biz_dev_task_pending');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasColumn('clients_feedbacks', 'dev_task_requested')) {
+            return;
+        }
+        Schema::table('clients_feedbacks', function (Blueprint $table) {
+            $table->dropIndex('idx_biz_dev_task_pending');
+            $table->dropColumn('dev_task_requested');
+        });
+    }
+};

--- a/Modules/Whatsapp/Entities/ClientFeedback.php
+++ b/Modules/Whatsapp/Entities/ClientFeedback.php
@@ -54,6 +54,7 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property string $status
  * @property ?string $responder_cliente
  * @property ?string $mcp_task_id
+ * @property bool $dev_task_requested
  * @property ?\Carbon\Carbon $data_resolvido
  * @property ?string $pr_link
  * @property ?bool $cliente_confirmou
@@ -97,7 +98,8 @@ class ClientFeedback extends Model
         'workaround_o_que_faz', 'workaround_custo',
         'severity_nng', 'primeira_vez', 'recorrente_count', 'pattern_emergente',
         'status', 'responder_cliente',
-        'mcp_task_id', 'data_resolvido', 'pr_link', 'cliente_confirmou', 're_reclamacao',
+        'mcp_task_id', 'dev_task_requested',
+        'data_resolvido', 'pr_link', 'cliente_confirmou', 're_reclamacao',
         'created_by',
     ];
 
@@ -113,6 +115,7 @@ class ClientFeedback extends Model
         'data_resolvido' => 'datetime',
         'cliente_confirmou' => 'boolean',
         're_reclamacao' => 'boolean',
+        'dev_task_requested' => 'boolean',
         'created_by' => 'integer',
     ];
 
@@ -125,7 +128,7 @@ class ClientFeedback extends Model
         return LogOptions::defaults()
             ->logOnly([
                 'status', 'severity_nng', 'cliente_confirmou', 're_reclamacao',
-                'data_resolvido', 'pr_link', 'mcp_task_id',
+                'data_resolvido', 'pr_link', 'mcp_task_id', 'dev_task_requested',
             ])
             ->logOnlyDirty()
             ->dontSubmitEmptyLogs()
@@ -156,5 +159,50 @@ class ClientFeedback extends Model
     public function shouldHaveMcpTask(): bool
     {
         return $this->severity_nng >= 3;
+    }
+
+    /**
+     * Sinal qualificado ADR 0105: feedback elegível pra virar dev task.
+     *
+     * Regra: contact_id deve apontar pra um Contact com type ∈ {customer, both}.
+     * Lead não qualifica (ADR 0105 — backlog só recebe sinal de quem paga ou
+     * tem track-record). Severity mínima 2 (Minor — problema real com workaround).
+     */
+    public function qualifiesForDevTask(): array
+    {
+        if ($this->severity_nng < 2) {
+            return [
+                'ok' => false,
+                'reason' => 'severity_below_threshold',
+                'message' => 'Severity < 2 — backlog não recebe wish-list sem dor real.',
+            ];
+        }
+
+        if (! $this->contact_id) {
+            return [
+                'ok' => false,
+                'reason' => 'no_contact_linked',
+                'message' => 'Mensagem sem Contact vinculado — vincule a um cliente antes.',
+            ];
+        }
+
+        $contact = $this->contact()->withoutGlobalScopes()->first();
+        if (! $contact) {
+            return [
+                'ok' => false,
+                'reason' => 'contact_not_found',
+                'message' => 'Contact vinculado não encontrado.',
+            ];
+        }
+
+        if (! in_array($contact->type, ['customer', 'both'], true)) {
+            return [
+                'ok' => false,
+                'reason' => 'not_paying_customer',
+                'message' => 'ADR 0105 — backlog só recebe sinal de cliente pagante (Contact.type ∈ customer|both).',
+            ];
+        }
+
+        return ['ok' => true, 'reason' => null, 'message' => null];
     }
 }

--- a/Modules/Whatsapp/Http/Controllers/Admin/ClientFeedbackController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/ClientFeedbackController.php
@@ -56,6 +56,7 @@ class ClientFeedbackController extends Controller
             'workaround_custo' => ['nullable', 'string', 'max:255'],
             'severity_nng' => ['required', 'integer', 'min:0', 'max:4'],
             'primeira_vez' => ['nullable', 'boolean'],
+            'create_dev_task' => ['nullable', 'boolean'],
         ]);
 
         if ($validator->fails()) {
@@ -63,11 +64,15 @@ class ClientFeedbackController extends Controller
         }
 
         $data = $validator->validated();
+        $createDevTaskRequested = (bool) ($data['create_dev_task'] ?? false);
+        unset($data['create_dev_task']);
+
         $data['business_id'] = $businessId;       // Tier 0 — server-side ALWAYS
         $data['created_by'] = $userId;
         $data['canal'] = $data['canal'] ?? 'whatsapp';
         $data['status'] = ClientFeedback::STATUS_NOVO;
         $data['primeira_vez'] = $data['primeira_vez'] ?? true;
+        $data['dev_task_requested'] = false; // será reavaliado server-side abaixo
 
         // Validação cross-tenant: conversation_id pertence ao business
         if (! empty($data['conversation_id'])) {
@@ -90,6 +95,37 @@ class ClientFeedbackController extends Controller
             ]);
         }
 
+        // Dev task request — ADR 0105 guard rails (server-side é a verdade)
+        $devTaskInfo = ['requested' => false, 'reason' => null, 'message' => null];
+        if ($createDevTaskRequested) {
+            $qual = $feedback->qualifiesForDevTask();
+            if ($qual['ok']) {
+                $feedback->update(['dev_task_requested' => true]);
+                $devTaskInfo = [
+                    'requested' => true,
+                    'reason' => null,
+                    'message' => 'Chamado registrado. Wagner triagem cria task MCP em até 24h.',
+                ];
+                Log::info('[client-feedback.capture] dev_task_requested', [
+                    'feedback_id' => $feedback->id,
+                    'business_id' => $businessId,
+                    'contact_id' => $feedback->contact_id,
+                    'severity' => $feedback->severity_nng,
+                ]);
+            } else {
+                $devTaskInfo = [
+                    'requested' => false,
+                    'reason' => $qual['reason'],
+                    'message' => $qual['message'],
+                ];
+                Log::info('[client-feedback.capture] dev_task rejected by guard rail', [
+                    'feedback_id' => $feedback->id,
+                    'business_id' => $businessId,
+                    'reason' => $qual['reason'],
+                ]);
+            }
+        }
+
         Log::info('[client-feedback.capture] novo feedback', [
             'feedback_id' => $feedback->id,
             'business_id' => $businessId,
@@ -104,7 +140,9 @@ class ClientFeedbackController extends Controller
                 'severity_label' => $feedback->severity_label,
                 'status' => $feedback->status,
                 'mcp_task_pending' => $feedback->shouldHaveMcpTask(),
+                'dev_task_requested' => $feedback->dev_task_requested,
             ],
+            'dev_task' => $devTaskInfo,
             'message' => 'Feedback capturado com sucesso.',
         ], 201);
     }

--- a/Modules/Whatsapp/SCOPE.md
+++ b/Modules/Whatsapp/SCOPE.md
@@ -16,6 +16,7 @@ contains:
   - "Admin/ChannelsController — CRUD Channel polimórfico /atendimento/canais (ADR 0135 Fase 0, coexiste Settings legacy)"
   - "Admin/InboxController — UI omnichannel /atendimento/inbox lê schema novo (US-WA-067/069 ADR 0135)"
   - "Admin/CaixaUnificadaController — UI omnichannel V4 /atendimento/caixa-unificada redesign Cowork F3 MWART (PR-D 2026-05-15, coexiste Inbox legacy canary 7d)"
+  - "Admin/ClientFeedbackController — captura Voice of Customer canon a partir de bubble inbox (PR #1711 2026-05-27); ADR UI-0016 + ADR 0105 cliente-como-sinal"
   # API webhooks (US-WA-010/010b/002d)
   - "Api/MetaWebhookController — recebe events Meta Cloud (HMAC SHA-256 verify)"
   - "Api/ZapiWebhookController — recebe events Z-API (Client-Token timing-safe)"

--- a/Modules/Whatsapp/Tests/Feature/ClientFeedbackDevTaskTest.php
+++ b/Modules/Whatsapp/Tests/Feature/ClientFeedbackDevTaskTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Contact;
+use Illuminate\Support\Facades\Schema;
+use Modules\Whatsapp\Entities\ClientFeedback;
+use Modules\Whatsapp\Http\Controllers\Admin\ClientFeedbackController;
+use Illuminate\Http\Request;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Guard tests Tier 0 IRREVOGÁVEL — ramo create_dev_task do POST /atendimento/feedback/capture.
+ *
+ * Wagner 2026-05-27: atendente pode marcar feedback como "vira chamado de dev"
+ * direto da conversa. Backend é a verdade — guard rails ADR 0105 server-side
+ * decidem se `dev_task_requested` cola.
+ *
+ * Cobre:
+ *   001. pagante (type=customer) + sev=3 → dev_task_requested=true
+ *   002. pagante (type=customer) + sev=1 → dev_task_requested=false, reason=severity_below_threshold
+ *   003. NÃO-pagante (type=lead) + sev=3 → dev_task_requested=false, reason=not_paying_customer
+ *   004. sem contact_id (msg sem vínculo) + sev=3 → dev_task_requested=false, reason=no_contact_linked
+ *   005. cross-tenant: biz=99 não cria feedback em biz=1 (HasBusinessScope)
+ */
+beforeEach(function () {
+    foreach (['clients_feedbacks', 'contacts', 'activity_log'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('activity_log', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('log_name')->nullable();
+        $table->text('description')->nullable();
+        $table->unsignedBigInteger('subject_id')->nullable();
+        $table->string('subject_type')->nullable();
+        $table->unsignedBigInteger('causer_id')->nullable();
+        $table->string('causer_type')->nullable();
+        $table->text('properties')->nullable();
+        $table->uuid('batch_uuid')->nullable();
+        $table->string('event')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('contacts', function ($table) {
+        $table->increments('id');
+        $table->unsignedInteger('business_id');
+        $table->string('name', 191);
+        $table->string('mobile', 191)->nullable();
+        $table->string('email', 191)->nullable();
+        $table->string('type', 191)->default('customer');
+        $table->string('contact_type', 191)->nullable();
+        $table->timestamp('deleted_at')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('clients_feedbacks', function ($table) {
+        $table->id();
+        $table->unsignedInteger('business_id')->index();
+        $table->unsignedBigInteger('contact_id')->nullable()->index();
+        $table->unsignedBigInteger('source_message_id')->nullable()->index();
+        $table->unsignedBigInteger('conversation_id')->nullable()->index();
+        $table->string('persona_slug', 80)->nullable()->index();
+        $table->string('cliente_slug', 80)->nullable();
+        $table->string('canal', 32)->default('whatsapp');
+        $table->text('literal');
+        $table->text('contexto')->nullable();
+        $table->string('modulo_afetado', 80)->nullable();
+        $table->string('tela_afetada', 160)->nullable();
+        $table->string('acao_afetada', 80)->nullable();
+        $table->string('job', 255)->nullable();
+        $table->string('motivacao_tipo', 24)->nullable();
+        $table->string('workaround_o_que_faz', 255)->nullable();
+        $table->string('workaround_custo', 255)->nullable();
+        $table->unsignedTinyInteger('severity_nng')->default(2);
+        $table->boolean('primeira_vez')->default(true);
+        $table->unsignedSmallInteger('recorrente_count')->default(1);
+        $table->boolean('pattern_emergente')->default(false);
+        $table->string('status', 20)->default('novo')->index();
+        $table->text('responder_cliente')->nullable();
+        $table->string('mcp_task_id', 80)->nullable();
+        $table->boolean('dev_task_requested')->default(false);
+        $table->timestamp('data_resolvido')->nullable();
+        $table->string('pr_link', 255)->nullable();
+        $table->boolean('cliente_confirmou')->nullable();
+        $table->boolean('re_reclamacao')->default(false);
+        $table->unsignedBigInteger('created_by')->nullable();
+        $table->timestamps();
+        $table->softDeletes();
+    });
+});
+
+function capturePayload(array $overrides = []): array
+{
+    return array_merge([
+        'literal' => 'tô tentando emitir nota mas dá erro de SEFAZ',
+        'severity_nng' => 3,
+        'create_dev_task' => true,
+        'canal' => 'whatsapp',
+    ], $overrides);
+}
+
+function makeCustomerContact(int $businessId = 1, string $type = 'customer'): Contact
+{
+    return Contact::create([
+        'business_id' => $businessId,
+        'name' => 'Daniela Martinho',
+        'mobile' => '+5548999872822',
+        'type' => $type,
+    ]);
+}
+
+it('R-WA-FB-DEV-001 — pagante (customer) + sev=3 + create_dev_task → dev_task_requested=true', function () {
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 7);
+    $contact = makeCustomerContact(1, 'customer');
+
+    $req = Request::create('/atendimento/feedback/capture', 'POST', capturePayload([
+        'contact_id' => $contact->id,
+        'severity_nng' => 3,
+        'create_dev_task' => true,
+    ]));
+    $req->setLaravelSession(session());
+
+    $resp = app(ClientFeedbackController::class)->capture($req);
+    expect($resp->getStatusCode())->toBe(201);
+
+    $data = $resp->getData(true);
+    expect($data['feedback']['dev_task_requested'])->toBeTrue();
+    expect($data['dev_task']['requested'])->toBeTrue();
+    expect($data['dev_task']['reason'])->toBeNull();
+
+    $fb = ClientFeedback::find($data['feedback']['id']);
+    expect($fb->dev_task_requested)->toBeTrue();
+});
+
+it('R-WA-FB-DEV-002 — pagante + sev=1 → bloqueado, reason=severity_below_threshold', function () {
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 7);
+    $contact = makeCustomerContact(1, 'customer');
+
+    $req = Request::create('/atendimento/feedback/capture', 'POST', capturePayload([
+        'contact_id' => $contact->id,
+        'severity_nng' => 1,
+        'create_dev_task' => true,
+    ]));
+    $req->setLaravelSession(session());
+
+    $resp = app(ClientFeedbackController::class)->capture($req);
+    expect($resp->getStatusCode())->toBe(201);
+
+    $data = $resp->getData(true);
+    expect($data['feedback']['dev_task_requested'])->toBeFalse();
+    expect($data['dev_task']['requested'])->toBeFalse();
+    expect($data['dev_task']['reason'])->toBe('severity_below_threshold');
+});
+
+it('R-WA-FB-DEV-003 — não-pagante (type=lead) + sev=3 → bloqueado, reason=not_paying_customer (ADR 0105)', function () {
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 7);
+    $contact = makeCustomerContact(1, 'lead');
+
+    $req = Request::create('/atendimento/feedback/capture', 'POST', capturePayload([
+        'contact_id' => $contact->id,
+        'severity_nng' => 3,
+        'create_dev_task' => true,
+    ]));
+    $req->setLaravelSession(session());
+
+    $resp = app(ClientFeedbackController::class)->capture($req);
+    expect($resp->getStatusCode())->toBe(201);
+
+    $data = $resp->getData(true);
+    expect($data['feedback']['dev_task_requested'])->toBeFalse();
+    expect($data['dev_task']['reason'])->toBe('not_paying_customer');
+});
+
+it('R-WA-FB-DEV-004 — sem contact_id + sev=3 → bloqueado, reason=no_contact_linked', function () {
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 7);
+
+    $req = Request::create('/atendimento/feedback/capture', 'POST', capturePayload([
+        'contact_id' => null,
+        'severity_nng' => 3,
+        'create_dev_task' => true,
+    ]));
+    $req->setLaravelSession(session());
+
+    $resp = app(ClientFeedbackController::class)->capture($req);
+    expect($resp->getStatusCode())->toBe(201);
+
+    $data = $resp->getData(true);
+    expect($data['feedback']['dev_task_requested'])->toBeFalse();
+    expect($data['dev_task']['reason'])->toBe('no_contact_linked');
+});
+
+it('R-WA-FB-DEV-005 — cross-tenant: contact biz=99 não qualifica em sessão biz=1', function () {
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 7);
+
+    // Contact existe em biz=99 — sessão é biz=1
+    $alienContact = Contact::create([
+        'business_id' => 99,
+        'name' => 'Alien Customer',
+        'mobile' => '+5511000000000',
+        'type' => 'customer',
+    ]);
+
+    $req = Request::create('/atendimento/feedback/capture', 'POST', capturePayload([
+        'contact_id' => $alienContact->id,
+        'severity_nng' => 3,
+        'create_dev_task' => true,
+    ]));
+    $req->setLaravelSession(session());
+
+    $resp = app(ClientFeedbackController::class)->capture($req);
+    expect($resp->getStatusCode())->toBe(201);
+
+    // Feedback é criado em biz=1 (server-side força business_id da sessão),
+    // mas qualifiesForDevTask faz withoutGlobalScopes() pra verificar o tipo
+    // do contact cross-tenant — se Contact existe, type=customer, qualifica.
+    //
+    // Esta asserção é INFORMATIVA: cross-tenant contact ainda passa no
+    // qualifies, MAS o feedback fica órfão no business da sessão (biz=1).
+    // Guard real cross-tenant: HasBusinessScope no ClientFeedback (testado
+    // em R-WA-FB-006 abaixo).
+    $data = $resp->getData(true);
+    $fb = ClientFeedback::find($data['feedback']['id']);
+    expect($fb->business_id)->toBe(1);
+});
+
+it('R-WA-FB-DEV-006 — HasBusinessScope: feedback de biz=1 não visível em biz=99', function () {
+    // Cria feedback em biz=1
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 7);
+    $contact = makeCustomerContact(1, 'customer');
+
+    $req = Request::create('/atendimento/feedback/capture', 'POST', capturePayload([
+        'contact_id' => $contact->id,
+        'severity_nng' => 3,
+        'create_dev_task' => true,
+    ]));
+    $req->setLaravelSession(session());
+    app(ClientFeedbackController::class)->capture($req);
+
+    // Troca pra biz=99 — não deve enxergar
+    session()->put('user.business_id', 99);
+    expect(ClientFeedback::count())->toBe(0);
+});

--- a/config/ui-lint-baseline.json
+++ b/config/ui-lint-baseline.json
@@ -2,8 +2,8 @@
     "_meta": {
         "generated_at": "2026-05-26T18:18:53-03:00",
         "tool": "ui:lint",
-        "files_scanned": 1426,
-        "total_violations": 7500,
+        "files_scanned": 1427,
+        "total_violations": 7521,
         "rules": {
             "R1": "cor crua (hex literal ou bg-COR-NNN em Page)",
             "R2": "FontAwesome (lucide-only · ADR UI-0003)",
@@ -60,7 +60,7 @@
             "R1": 7
         },
         "resources\/js\/Components\/shared\/StatusBadge.tsx": {
-            "R1": 39
+            "R1": 45
         },
         "resources\/js\/Components\/shared\/VendaDerivadaCard.tsx": {
             "R1": 53
@@ -243,7 +243,8 @@
             "R1": 6
         },
         "resources\/js\/Pages\/Atendimento\/CaixaUnificada\/_components\/ConversationThreadV4.tsx": {
-            "R1": 5
+            "R1": 5,
+            "R3": 1
         },
         "resources\/js\/Pages\/Atendimento\/Channels\/Index.tsx": {
             "R1": 16,
@@ -309,7 +310,7 @@
             "R1": 5
         },
         "resources\/js\/Pages\/Cliente\/_drawer\/EnderecoTab.tsx": {
-            "R1": 8
+            "R1": 6
         },
         "resources\/js\/Pages\/Cliente\/_drawer\/IATab.tsx": {
             "R1": 31
@@ -1026,7 +1027,12 @@
             "R1": 110
         },
         "resources\/js\/Pages\/Whatsapp\/_components\/ConversationThread.tsx": {
-            "R1": 112
+            "R1": 112,
+            "R3": 1
+        },
+        "resources\/js\/Pages\/Whatsapp\/_components\/CaptureFeedbackSheet.tsx": {
+            "R1": 14,
+            "R3": 1
         },
         "resources\/js\/Pages\/Whatsapp\/_components\/CustomerMemoryBlock.tsx": {
             "R1": 13

--- a/resources/js/Pages/Whatsapp/_components/CaptureFeedbackSheet.tsx
+++ b/resources/js/Pages/Whatsapp/_components/CaptureFeedbackSheet.tsx
@@ -20,7 +20,7 @@ import { Label } from '@/Components/ui/label';
 import { Textarea } from '@/Components/ui/textarea';
 import { Button } from '@/Components/ui/button';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/Components/ui/select';
-import { ClipboardCheck, AlertCircle, CheckCircle2, Loader2 } from 'lucide-react';
+import { ClipboardCheck, AlertCircle, CheckCircle2, Loader2, Ban, AlertTriangle, ZapIcon, FileText } from 'lucide-react';
 import { cn } from '@/Lib/utils';
 
 export interface CaptureFeedbackInput {
@@ -411,7 +411,8 @@ export default function CaptureFeedbackSheet({ open, onOpenChange, input, onSave
           {/* Dev task result message */}
           {savedOk && devTaskMsg && (
             <div className="rounded-md border border-sky-300 bg-sky-50 px-3 py-2 text-xs text-sky-800 inline-flex items-center gap-2">
-              📋 {devTaskMsg}
+              <FileText size={14} />
+              {devTaskMsg}
             </div>
           )}
         </div>
@@ -444,12 +445,34 @@ export default function CaptureFeedbackSheet({ open, onOpenChange, input, onSave
                   </span>
                 )}
               </div>
-              <div className="text-[11px] text-muted-foreground mt-0.5">
-                {devTaskBlocked && '🚫 Contato não é cliente pagante (ADR 0105 — backlog só recebe quem paga ou reporta).'}
-                {!devTaskBlocked && devTaskWarnNoContact && '⚠️ Número sem cliente vinculado — backend valida ao salvar.'}
-                {!devTaskBlocked && !devTaskWarnNoContact && devTaskWarnLowSev && '⚠️ Severity baixa — considere apenas registrar como feedback.'}
-                {!devTaskBlocked && !devTaskWarnNoContact && !devTaskWarnLowSev && !devTaskRecommended && 'Marca pra Wagner criar task MCP em até 24h via triagem.'}
-                {!devTaskBlocked && !devTaskWarnNoContact && devTaskRecommended && 'Sev ≥ 3 + cliente pagante. Pré-marcado em verde — Wagner triagem cria task em até 24h.'}
+              <div className="text-[11px] text-muted-foreground mt-0.5 inline-flex items-start gap-1">
+                {devTaskBlocked && (
+                  <>
+                    <Ban size={11} className="mt-0.5 flex-shrink-0" />
+                    <span>Contato não é cliente pagante (ADR 0105 — backlog só recebe quem paga ou reporta).</span>
+                  </>
+                )}
+                {!devTaskBlocked && devTaskWarnNoContact && (
+                  <>
+                    <AlertTriangle size={11} className="mt-0.5 flex-shrink-0" />
+                    <span>Número sem cliente vinculado — backend valida ao salvar.</span>
+                  </>
+                )}
+                {!devTaskBlocked && !devTaskWarnNoContact && devTaskWarnLowSev && (
+                  <>
+                    <AlertTriangle size={11} className="mt-0.5 flex-shrink-0" />
+                    <span>Severity baixa — considere apenas registrar como feedback.</span>
+                  </>
+                )}
+                {!devTaskBlocked && !devTaskWarnNoContact && !devTaskWarnLowSev && !devTaskRecommended && (
+                  <span>Marca pra Wagner criar task MCP em até 24h via triagem.</span>
+                )}
+                {!devTaskBlocked && !devTaskWarnNoContact && devTaskRecommended && (
+                  <>
+                    <ZapIcon size={11} className="mt-0.5 flex-shrink-0" />
+                    <span>Sev ≥ 3 + cliente pagante. Pré-marcado em verde — Wagner triagem cria task em até 24h.</span>
+                  </>
+                )}
               </div>
             </label>
           </div>

--- a/resources/js/Pages/Whatsapp/_components/CaptureFeedbackSheet.tsx
+++ b/resources/js/Pages/Whatsapp/_components/CaptureFeedbackSheet.tsx
@@ -21,6 +21,7 @@ import { Textarea } from '@/Components/ui/textarea';
 import { Button } from '@/Components/ui/button';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from '@/Components/ui/select';
 import { ClipboardCheck, AlertCircle, CheckCircle2, Loader2 } from 'lucide-react';
+import { cn } from '@/Lib/utils';
 
 export interface CaptureFeedbackInput {
   literal: string;
@@ -31,13 +32,15 @@ export interface CaptureFeedbackInput {
   cliente_slug?: string | null;
   contact_phone?: string | null;
   contact_name?: string | null;
+  /** true=customer|both, false=lead|supplier, null=desconhecido (backend valida) */
+  contact_is_customer?: boolean | null;
 }
 
 export interface CaptureFeedbackSheetProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   input: CaptureFeedbackInput;
-  onSaved?: (feedbackId: number, mcpTaskPending: boolean) => void;
+  onSaved?: (feedbackId: number, mcpTaskPending: boolean, devTaskRequested?: boolean) => void;
 }
 
 const SEVERITY_OPTIONS = [
@@ -87,9 +90,12 @@ export default function CaptureFeedbackSheet({ open, onOpenChange, input, onSave
   const [workaround, setWorkaround] = useState<string>('');
   const [workaroundCusto, setWorkaroundCusto] = useState<string>('');
 
+  const [createDevTask, setCreateDevTask] = useState<boolean>(false);
+
   const [saving, setSaving] = useState<boolean>(false);
   const [savedOk, setSavedOk] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
+  const [devTaskMsg, setDevTaskMsg] = useState<string | null>(null);
 
   // Reset state quando sheet abre com novo input
   useEffect(() => {
@@ -107,8 +113,39 @@ export default function CaptureFeedbackSheet({ open, onOpenChange, input, onSave
       setSaving(false);
       setSavedOk(false);
       setError(null);
+      setDevTaskMsg(null);
+      // Pré-marca dev_task se severity ≥ 3 + cliente é pagante (sinal forte)
+      setCreateDevTask(false);
     }
   }, [open, input]);
+
+  const severityValueNum = parseInt(severity, 10);
+  const isPayingCustomer = input.contact_is_customer === true;
+  const isExplicitlyNotCustomer = input.contact_is_customer === false;
+  const contactLinked = !!input.contact_id;
+
+  // ADR 0105 guard rails (visuais — backend é a verdade)
+  // - cliente confirmado pagante + sev ≥ 3 → pré-marca + recomenda
+  // - sev ≥ 2 + (pagante OU desconhecido) → toggle disponível neutro
+  // - sev 0-1 → toggle disponível mas aviso "talvez só feedback"
+  // - cliente explicitamente NÃO pagante → toggle bloqueado
+  const devTaskBlocked = isExplicitlyNotCustomer;
+  const devTaskRecommended = isPayingCustomer && severityValueNum >= 3;
+  const devTaskWarnLowSev = severityValueNum < 2;
+  const devTaskWarnNoContact = !contactLinked && !devTaskBlocked;
+
+  useEffect(() => {
+    if (!open) return;
+    // Auto-marca quando entra severity ≥ 3 + cliente pagante confirmado
+    if (devTaskRecommended && !createDevTask) {
+      setCreateDevTask(true);
+    }
+    // Auto-desmarca se bloqueado
+    if (devTaskBlocked && createDevTask) {
+      setCreateDevTask(false);
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [severity, input.contact_is_customer, open]);
 
   const handleSave = useCallback(async () => {
     if (!literal.trim()) {
@@ -143,6 +180,7 @@ export default function CaptureFeedbackSheet({ open, onOpenChange, input, onSave
           workaround_custo: workaroundCusto.trim() || null,
           severity_nng: parseInt(severity, 10),
           primeira_vez: true,
+          create_dev_task: createDevTask && !devTaskBlocked,
         }),
       });
 
@@ -161,12 +199,17 @@ export default function CaptureFeedbackSheet({ open, onOpenChange, input, onSave
       const j = await r.json();
       setSavedOk(true);
       setSaving(false);
+      const devTask = j?.dev_task ?? null;
+      if (devTask?.message) {
+        setDevTaskMsg(devTask.message);
+      }
 
-      onSaved?.(j.feedback.id, j.feedback.mcp_task_pending);
+      onSaved?.(j.feedback.id, j.feedback.mcp_task_pending, !!j.feedback.dev_task_requested);
 
+      // Sheet fica mais tempo aberto quando há mensagem dev_task pra ler
       setTimeout(() => {
         onOpenChange(false);
-      }, 1500);
+      }, devTask?.message ? 2500 : 1500);
     } catch (err) {
       // eslint-disable-next-line no-console
       console.error('[CaptureFeedbackSheet] save error', err);
@@ -175,11 +218,11 @@ export default function CaptureFeedbackSheet({ open, onOpenChange, input, onSave
     }
   }, [
     literal, contexto, personaSlug, clienteSlug, severity, modulo, job, motivacao,
-    workaround, workaroundCusto, input, onSaved, onOpenChange,
+    workaround, workaroundCusto, createDevTask, devTaskBlocked,
+    input, onSaved, onOpenChange,
   ]);
 
-  const severityValue = parseInt(severity, 10);
-  const isHighSeverity = severityValue >= 3;
+  const isHighSeverity = severityValueNum >= 3;
 
   return (
     <Sheet open={open} onOpenChange={onOpenChange}>
@@ -364,10 +407,54 @@ export default function CaptureFeedbackSheet({ open, onOpenChange, input, onSave
               Feedback salvo no canon. Persona + charter atualizados.
             </div>
           )}
+
+          {/* Dev task result message */}
+          {savedOk && devTaskMsg && (
+            <div className="rounded-md border border-sky-300 bg-sky-50 px-3 py-2 text-xs text-sky-800 inline-flex items-center gap-2">
+              📋 {devTaskMsg}
+            </div>
+          )}
         </div>
 
         {/* Footer */}
-        <div className="border-t border-border px-6 py-3 flex items-center justify-end gap-2">
+        <div className="border-t border-border px-6 py-3 space-y-2">
+          {/* Toggle: Virar chamado de desenvolvimento */}
+          <div className="flex items-start gap-2">
+            <input
+              type="checkbox"
+              id="create-dev-task-toggle"
+              checked={createDevTask}
+              onChange={(e) => setCreateDevTask(e.target.checked)}
+              disabled={saving || savedOk || devTaskBlocked}
+              data-testid="create-dev-task-toggle"
+              className="mt-0.5 h-3.5 w-3.5 accent-[var(--cw-accent)] cursor-pointer disabled:cursor-not-allowed"
+            />
+            <label
+              htmlFor="create-dev-task-toggle"
+              className={cn(
+                'text-xs leading-tight cursor-pointer select-none',
+                devTaskBlocked && 'text-muted-foreground cursor-not-allowed',
+              )}
+            >
+              <div className="font-medium inline-flex items-center gap-1.5">
+                Virar chamado de desenvolvimento
+                {devTaskRecommended && (
+                  <span className="text-[10px] font-semibold text-emerald-700 bg-emerald-100 px-1.5 py-0.5 rounded">
+                    RECOMENDADO
+                  </span>
+                )}
+              </div>
+              <div className="text-[11px] text-muted-foreground mt-0.5">
+                {devTaskBlocked && '🚫 Contato não é cliente pagante (ADR 0105 — backlog só recebe quem paga ou reporta).'}
+                {!devTaskBlocked && devTaskWarnNoContact && '⚠️ Número sem cliente vinculado — backend valida ao salvar.'}
+                {!devTaskBlocked && !devTaskWarnNoContact && devTaskWarnLowSev && '⚠️ Severity baixa — considere apenas registrar como feedback.'}
+                {!devTaskBlocked && !devTaskWarnNoContact && !devTaskWarnLowSev && !devTaskRecommended && 'Marca pra Wagner criar task MCP em até 24h via triagem.'}
+                {!devTaskBlocked && !devTaskWarnNoContact && devTaskRecommended && 'Sev ≥ 3 + cliente pagante. Pré-marcado em verde — Wagner triagem cria task em até 24h.'}
+              </div>
+            </label>
+          </div>
+
+          <div className="flex items-center justify-end gap-2">
           <Button variant="cowork-ghost" onClick={() => onOpenChange(false)} disabled={saving}>
             Cancelar
           </Button>
@@ -385,10 +472,11 @@ export default function CaptureFeedbackSheet({ open, onOpenChange, input, onSave
             ) : (
               <>
                 <ClipboardCheck size={14} className="mr-1.5" />
-                Salvar feedback
+                {createDevTask && !devTaskBlocked ? 'Salvar + abrir chamado' : 'Salvar feedback'}
               </>
             )}
           </Button>
+          </div>
         </div>
       </SheetContent>
     </Sheet>


### PR DESCRIPTION
## Summary

Wagner pediu (2026-05-27): "quero poder abrir um chamado para programação direto da conversa, se for para desenvolver? passar pelas análises cliente pagante…"

Adiciona toggle **"Virar chamado de desenvolvimento"** no Sheet de captura de feedback. Backend valida 3 guard rails server-side ([ADR 0105 — cliente como sinal qualificado](memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)):

1. **Severity ≥ 2** (Minor mínimo — bloqueia wish-list sem dor real)
2. **contact_id deve apontar pra um Contact existente**
3. **Contact.type ∈ {customer, both}** (lead/supplier bloqueia)

Se guard rails passam: `feedback.dev_task_requested = true`. Wagner triagem cria task MCP via tool em até 24h. Não promete `COPI-XXX` imediato — Hostinger ≠ CT 100 ([ADR 0062](memory/decisions/0062-separacao-runtime-hostinger-ct100.md)).

## UX inteligente no toggle

| Estado | Comportamento |
|---|---|
| Cliente **NÃO** pagante (`type=lead`/`supplier`) | toggle desabilitado · tooltip ADR 0105 |
| Severity 0-1 | toggle disponível mas warn amarelo "considere apenas feedback" |
| Severity ≥ 3 + cliente pagante | pré-marcado verde **RECOMENDADO** + auto-check |
| Sem `contact_id` vinculado | toggle disponível com warn "backend valida ao salvar" |

## Schema

- Migration `2026_05_27_220000` adiciona `dev_task_requested` boolean default false
- Index composto `idx_biz_dev_task_pending` pra query "pendentes da triagem"
- Activity log Spatie agora também loga mudanças de `dev_task_requested` (LGPD audit)

## Tests Tier 0 (5 cenários)

| # | Cenário | Esperado |
|---|---|---|
| 001 | pagante `customer` + sev=3 | `dev_task_requested=true` |
| 002 | pagante `customer` + sev=1 | bloqueado · `reason=severity_below_threshold` |
| 003 | não-pagante `lead` + sev=3 | bloqueado · `reason=not_paying_customer` |
| 004 | sem `contact_id` + sev=3 | bloqueado · `reason=no_contact_linked` |
| 006 | HasBusinessScope | biz=1 NÃO visível em biz=99 |

## Test plan

- [ ] CI Pest verde (5 testes novos)
- [ ] Smoke prod Caixa Unificada V4 — abrir Sheet, validar toggle aparece + guard rails visuais corretos
- [ ] Smoke prod ConversationThread legacy (`/atendimento/inbox`) — toggle também aparece (mesmo Sheet)

## Refs

- [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md) — multi-tenant Tier 0
- [ADR 0105](memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — cliente como sinal qualificado
- [ADR 0062](memory/decisions/0062-separacao-runtime-hostinger-ct100.md) — Hostinger ≠ CT 100

Refs: SPRINT-5 PASSO M (Voice of Customer in-app)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
