### PR TITLE
feat(whatsapp/feedback): sistema de relevância adaptativa (signature dedup + scoring + decay) — Fase A · ADR 0195

### DIFF
--- a/Modules/Whatsapp/Database/Migrations/2026_05_27_240000_add_signature_relevance_to_clients_feedbacks.php
+++ b/Modules/Whatsapp/Database/Migrations/2026_05_27_240000_add_signature_relevance_to_clients_feedbacks.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * clients_feedbacks — sistema de relevância adaptativa
+ *
+ * Wagner 2026-05-27: índice de feedback com checksum/signature pra dedup +
+ * ranking por relevância. Mais importantes ficam em memória (INDEX.md auto),
+ * menos importantes vão pra archive trimestral.
+ *
+ * Refs: ADR 0195-feedback-relevance-scoring-decay-adaptativo, ADR 0131 (tiering canon/local/segredo).
+ *
+ * Campos:
+ *   - signature (sha1 40c): hash de identidade pra dedup
+ *     persona + módulo + ação + literal_normalized
+ *     Mesma signature em 90d → recorrente_count++ no existente, NÃO cria novo
+ *   - relevance_score (0-100 decimal 5,2): score calculado pela formula em
+ *     FeedbackRelevanceService. Recomputado semanalmente.
+ *   - relevance_score_at: quando foi último recompute
+ *   - last_seen_at: última ocorrência (atualizado em dedup)
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('clients_feedbacks')) {
+            return;
+        }
+
+        Schema::table('clients_feedbacks', function (Blueprint $table) {
+            if (! Schema::hasColumn('clients_feedbacks', 'signature')) {
+                $table->string('signature', 40)->nullable()->after('cliente_slug');
+            }
+            if (! Schema::hasColumn('clients_feedbacks', 'relevance_score')) {
+                $table->decimal('relevance_score', 5, 2)->default(0)->after('signature');
+            }
+            if (! Schema::hasColumn('clients_feedbacks', 'relevance_score_at')) {
+                $table->timestamp('relevance_score_at')->nullable()->after('relevance_score');
+            }
+            if (! Schema::hasColumn('clients_feedbacks', 'last_seen_at')) {
+                $table->timestamp('last_seen_at')->nullable()->after('relevance_score_at');
+            }
+        });
+
+        // Indexes em call separada (alguns drivers SQLite reclamam se misturado)
+        Schema::table('clients_feedbacks', function (Blueprint $table) {
+            $table->index(['business_id', 'signature'], 'idx_biz_signature');
+            $table->index(['business_id', 'relevance_score'], 'idx_biz_relevance');
+            $table->index(['business_id', 'last_seen_at'], 'idx_biz_last_seen');
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('clients_feedbacks')) {
+            return;
+        }
+
+        Schema::table('clients_feedbacks', function (Blueprint $table) {
+            $table->dropIndex('idx_biz_signature');
+            $table->dropIndex('idx_biz_relevance');
+            $table->dropIndex('idx_biz_last_seen');
+        });
+
+        Schema::table('clients_feedbacks', function (Blueprint $table) {
+            $table->dropColumn(['signature', 'relevance_score', 'relevance_score_at', 'last_seen_at']);
+        });
+    }
+};

--- a/Modules/Whatsapp/Entities/ClientFeedback.php
+++ b/Modules/Whatsapp/Entities/ClientFeedback.php
@@ -55,6 +55,10 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property ?string $responder_cliente
  * @property ?string $mcp_task_id
  * @property bool $dev_task_requested
+ * @property ?string $signature
+ * @property float $relevance_score
+ * @property ?\Carbon\Carbon $relevance_score_at
+ * @property ?\Carbon\Carbon $last_seen_at
  * @property ?\Carbon\Carbon $data_resolvido
  * @property ?string $pr_link
  * @property ?bool $cliente_confirmou
@@ -99,6 +103,7 @@ class ClientFeedback extends Model
         'severity_nng', 'primeira_vez', 'recorrente_count', 'pattern_emergente',
         'status', 'responder_cliente',
         'mcp_task_id', 'dev_task_requested',
+        'signature', 'relevance_score', 'relevance_score_at', 'last_seen_at',
         'data_resolvido', 'pr_link', 'cliente_confirmou', 're_reclamacao',
         'created_by',
     ];
@@ -116,6 +121,9 @@ class ClientFeedback extends Model
         'cliente_confirmou' => 'boolean',
         're_reclamacao' => 'boolean',
         'dev_task_requested' => 'boolean',
+        'relevance_score' => 'decimal:2',
+        'relevance_score_at' => 'datetime',
+        'last_seen_at' => 'datetime',
         'created_by' => 'integer',
     ];
 
@@ -159,6 +167,36 @@ class ClientFeedback extends Model
     public function shouldHaveMcpTask(): bool
     {
         return $this->severity_nng >= 3;
+    }
+
+    /**
+     * Scope HOT: relevance_score >= 70 (camada in-context, INDEX.md).
+     */
+    public function scopeHot($query)
+    {
+        return $query->where('relevance_score', '>=', 70);
+    }
+
+    /**
+     * Scope WARM: 30 <= relevance_score < 70.
+     */
+    public function scopeWarm($query)
+    {
+        return $query->whereBetween('relevance_score', [30, 69.99]);
+    }
+
+    /**
+     * Scope COLD: relevance_score < 30 OU resolved/closed >= 90d.
+     */
+    public function scopeCold($query)
+    {
+        return $query->where(function ($q) {
+            $q->where('relevance_score', '<', 30)
+              ->orWhere(function ($qq) {
+                  $qq->whereIn('status', [self::STATUS_CLOSED, self::STATUS_RESOLVED])
+                     ->where('updated_at', '<', now()->subDays(90));
+              });
+        });
     }
 
     /**

--- a/Modules/Whatsapp/Http/Controllers/Admin/ClientFeedbackController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/ClientFeedbackController.php
@@ -11,6 +11,7 @@ use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Validator;
 use Modules\Whatsapp\Entities\ClientFeedback;
 use Modules\Whatsapp\Entities\Conversation;
+use Modules\Whatsapp\Services\FeedbackRelevanceService;
 
 /**
  * ClientFeedbackController — captura + listagem + status update de feedback canon.
@@ -82,7 +83,34 @@ class ClientFeedbackController extends Controller
             }
         }
 
-        $feedback = ClientFeedback::create($data);
+        // Dedup por signature (últimos 90d): mesma persona + módulo + ação + literal
+        // normalizada → bump recorrente_count em vez de criar duplicata.
+        $relevance = app(FeedbackRelevanceService::class);
+        $tempFb = new ClientFeedback($data);
+        $tempFb->business_id = $businessId;
+        $signature = $relevance->computeSignature($tempFb);
+        $existing = $relevance->findDuplicateWithin90d($signature, $businessId);
+
+        $isDedup = false;
+        if ($existing) {
+            $existing->recorrente_count = ($existing->recorrente_count ?? 1) + 1;
+            $existing->pattern_emergente = $existing->recorrente_count >= 3;
+            $existing->severity_nng = max($existing->severity_nng, (int) $data['severity_nng']);
+            $existing->last_seen_at = now();
+            $existing->save();   // Observer rescore automaticamente
+            $feedback = $existing;
+            $isDedup = true;
+
+            Log::info('[client-feedback.capture] dedup hit', [
+                'feedback_id' => $feedback->id,
+                'business_id' => $businessId,
+                'signature' => $signature,
+                'recorrente_count' => $feedback->recorrente_count,
+                'pattern_emergente' => $feedback->pattern_emergente,
+            ]);
+        } else {
+            $feedback = ClientFeedback::create($data);
+        }
 
         // Severity ≥ 3 → MCP task (via Observer/event ou inline).
         // MVP: log apenas. Job assíncrono em PR follow-up.
@@ -141,9 +169,19 @@ class ClientFeedbackController extends Controller
                 'status' => $feedback->status,
                 'mcp_task_pending' => $feedback->shouldHaveMcpTask(),
                 'dev_task_requested' => $feedback->dev_task_requested,
+                'signature' => $feedback->signature,
+                'recorrente_count' => $feedback->recorrente_count,
+                'pattern_emergente' => $feedback->pattern_emergente,
+                'relevance_score' => (float) $feedback->relevance_score,
             ],
             'dev_task' => $devTaskInfo,
-            'message' => 'Feedback capturado com sucesso.',
+            'dedup' => [
+                'matched_existing' => $isDedup,
+                'recorrente_count' => $feedback->recorrente_count,
+            ],
+            'message' => $isDedup
+                ? "Mesma reclamação já registrada — agora com {$feedback->recorrente_count} ocorrência(s)."
+                : 'Feedback capturado com sucesso.',
         ], 201);
     }
 

--- a/Modules/Whatsapp/Observers/ClientFeedbackObserver.php
+++ b/Modules/Whatsapp/Observers/ClientFeedbackObserver.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Observers;
+
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Entities\ClientFeedback;
+use Modules\Whatsapp\Services\FeedbackRelevanceService;
+
+/**
+ * ClientFeedbackObserver — auto-compute signature + relevance_score em todo write.
+ *
+ * Hook creating: signature + last_seen_at + score inicial.
+ * Hook updating: rescore se severity ou recorrente_count mudou.
+ *
+ * NÃO faz dedup aqui — dedup vive em ClientFeedbackController::capture()
+ * antes do create(), pra retornar feedback existente (idempotência cliente HTTP).
+ */
+class ClientFeedbackObserver
+{
+    public function __construct(protected FeedbackRelevanceService $relevance)
+    {
+    }
+
+    public function creating(ClientFeedback $fb): void
+    {
+        // Signature determinística
+        if (! $fb->signature) {
+            $fb->signature = $this->relevance->computeSignature($fb);
+        }
+
+        // last_seen_at = agora se não setado
+        if (! $fb->last_seen_at) {
+            $fb->last_seen_at = now();
+        }
+
+        // Score inicial — pode ser refinado depois pelo job de reindex
+        if ($fb->relevance_score === null || $fb->relevance_score == 0.0) {
+            $fb->relevance_score = $this->relevance->computeScore($fb);
+            $fb->relevance_score_at = now();
+        }
+    }
+
+    public function updating(ClientFeedback $fb): void
+    {
+        // Se severity OU recorrente_count mudou, recompute score
+        $dirty = $fb->getDirty();
+        $needsRescore = isset($dirty['severity_nng']) || isset($dirty['recorrente_count']) || isset($dirty['last_seen_at']);
+
+        if ($needsRescore) {
+            $fb->relevance_score = $this->relevance->computeScore($fb);
+            $fb->relevance_score_at = now();
+
+            Log::debug('[feedback.observer] rescore on update', [
+                'feedback_id' => $fb->id,
+                'business_id' => $fb->business_id,
+                'score' => $fb->relevance_score,
+                'reason' => array_keys($dirty),
+            ]);
+        }
+    }
+}

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -136,6 +136,10 @@ class WhatsappServiceProvider extends ServiceProvider
         // do post-mortem 2026-05-13).
         \Modules\Whatsapp\Entities\Channel::observe(\Modules\Whatsapp\Observers\ChannelObserver::class);
 
+        // Observer ClientFeedback — auto-compute signature/relevance_score em creating/updating.
+        // Ref: ADR 0195 + FeedbackRelevanceService.
+        \Modules\Whatsapp\Entities\ClientFeedback::observe(\Modules\Whatsapp\Observers\ClientFeedbackObserver::class);
+
         // Observer LidPhoneMap — wave-protocol-stack PR2 (sessão 2026-05-15).
         // Quando LID resolve pra phone (NULL→valor em phone_e164), dispara
         // BackfillLidConversationsJob que re-linka conversations órfãs

--- a/Modules/Whatsapp/Services/FeedbackRelevanceService.php
+++ b/Modules/Whatsapp/Services/FeedbackRelevanceService.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services;
+
+use App\Contact;
+use Carbon\Carbon;
+use Modules\Whatsapp\Entities\ClientFeedback;
+
+/**
+ * FeedbackRelevanceService — checksum/signature + ranking adaptativo.
+ *
+ * Wagner 2026-05-27: índice de feedback com dedup + decay temporal.
+ * Mantém só os relevantes em memória ativa (INDEX.md top 20), arquiva resto.
+ *
+ * Refs: ADR 0195-feedback-relevance-scoring-decay-adaptativo, ADR 0105 (cliente-como-sinal),
+ * ADR 0131 (tiering memória canon/local/segredo).
+ *
+ * 4 camadas de relevância:
+ *   HOT     score >= 70   → INDEX.md auto-loaded
+ *   WARM    30..69        → DB only, sob demanda
+ *   COLD    < 30 OU closed >= 90d → archive trimestral
+ *   FROZEN  resolved >= 365d → LGPD retention
+ *
+ * Score formula (0-100):
+ *   40 * severity/4                            severidade NN/g (dor real)
+ * + 25 * log10(recorrente+1)/log10(5)           plateau em 5 ocorrências
+ * + 15 * (cliente_pagante ? 1.0 : 0.2)          ADR 0105 sinal qualificado
+ * + 10 * persona_priority                      primary=1 / secondary=0.6 / outras=0.3
+ * + 10 * exp(-days_since_last_seen/60)         decay meia-vida 60d
+ *
+ * Signature (sha1 40c):
+ *   sha1(business_id|persona_slug|modulo|acao|literal_normalized)
+ *
+ *   literal_normalized = lowercase + strip punctuation + 5 primeiras palavras
+ *   significativas (>= 3 chars, não-stopword).
+ *
+ * Personas primary mapping vem de memory/requisitos/_DesignSystem/personas-por-modulo.yml
+ * — hardcoded aqui pra evitar I/O em hot path. Atualizar quando expandir personas.
+ */
+class FeedbackRelevanceService
+{
+    /**
+     * Personas primary por módulo (ADR UI-0016 design contextualizado).
+     */
+    public const PRIMARY_PERSONAS = [
+        'sells' => ['larissa-rota-livre'],
+        'oficinaauto' => ['daniela-martinho'],
+        'financeiro' => ['kamila-martinho'],
+        'cliente' => ['larissa-rota-livre', 'daniela-martinho'],
+        'fiscal' => ['kamila-martinho'],
+        'nfe-brasil' => ['kamila-martinho'],
+        'nfse' => ['kamila-martinho'],
+        'whatsapp' => ['larissa-rota-livre', 'daniela-martinho'],
+    ];
+
+    public const SECONDARY_PERSONAS = [
+        'sells' => ['daniela-martinho'],
+        'oficinaauto' => ['jair-martinho'],
+        'financeiro' => ['jair-martinho'],
+        'whatsapp' => ['kamila-martinho'],
+    ];
+
+    public const STOPWORDS_PT = [
+        'a', 'o', 'e', 'de', 'do', 'da', 'das', 'dos', 'em', 'no', 'na', 'que',
+        'um', 'uma', 'pra', 'para', 'por', 'com', 'se', 'ou', 'ao', 'tem',
+        'tá', 'ta', 'to', 'tô', 'sou', 'eu', 'me', 'meu', 'minha',
+        'é', 'foi', 'ser', 'mas', 'só', 'já', 'aqui', 'isso', 'esse',
+        'esta', 'este', 'eles', 'elas', 'voce', 'você', 'nao', 'não',
+        'sim', 'tudo', 'aí', 'lá', 'todo', 'toda',
+    ];
+
+    /**
+     * Computa signature determinística do feedback pra dedup.
+     */
+    public function computeSignature(ClientFeedback $fb): string
+    {
+        $persona = $fb->persona_slug ?? 'desconhecido';
+        $modulo = $fb->modulo_afetado ?? 'global';
+        $acao = $fb->acao_afetada ?? 'sem-acao';
+        $literalNorm = $this->normalizeLiteral($fb->literal);
+
+        return sha1(implode('|', [$fb->business_id, $persona, $modulo, $acao, $literalNorm]));
+    }
+
+    /**
+     * Normaliza literal pra 5 primeiras palavras significativas.
+     *
+     * "tô tentando emitir nota mas dá erro de SEFAZ! socorro"
+     * → "tentando emitir nota dá erro"
+     */
+    public function normalizeLiteral(string $literal): string
+    {
+        $lower = mb_strtolower($literal);
+        $stripped = preg_replace('/[^\p{L}\p{N}\s]/u', ' ', $lower);
+        $words = preg_split('/\s+/', trim($stripped ?? ''), -1, PREG_SPLIT_NO_EMPTY);
+        $significant = [];
+
+        foreach ($words as $w) {
+            if (mb_strlen($w) < 3) {
+                continue;
+            }
+            if (in_array($w, self::STOPWORDS_PT, true)) {
+                continue;
+            }
+            $significant[] = $w;
+            if (count($significant) >= 5) {
+                break;
+            }
+        }
+
+        return implode(' ', $significant);
+    }
+
+    /**
+     * Procura feedback com mesma signature nos últimos 90d.
+     * Retorna null se não há match (criar novo).
+     */
+    public function findDuplicateWithin90d(string $signature, int $businessId): ?ClientFeedback
+    {
+        return ClientFeedback::query()
+            ->where('business_id', $businessId)
+            ->where('signature', $signature)
+            ->where('created_at', '>=', now()->subDays(90))
+            ->orderByDesc('created_at')
+            ->first();
+    }
+
+    /**
+     * Computa relevance_score (0-100) do feedback baseado na fórmula canônica.
+     */
+    public function computeScore(ClientFeedback $fb): float
+    {
+        // Severidade (0..1)
+        $sev = max(0, min(4, $fb->severity_nng)) / 4.0;
+        $scoreSev = 40 * $sev;
+
+        // Recorrência log-plateau em 5 ocorrências (0..1)
+        $rec = max(1, (int) ($fb->recorrente_count ?? 1));
+        $scoreRec = 25 * (log10($rec + 1) / log10(5 + 1));
+        $scoreRec = min(25, $scoreRec);
+
+        // Cliente pagante (1.0) vs lead/null (0.2)
+        $isPaying = $this->isPayingCustomer($fb);
+        $scorePag = 15 * ($isPaying ? 1.0 : 0.2);
+
+        // Persona prioridade
+        $personaPrio = $this->personaPriority($fb);
+        $scorePersona = 10 * $personaPrio;
+
+        // Decay temporal exp(-days/60)
+        $lastSeen = $fb->last_seen_at ?? $fb->created_at ?? now();
+        $days = max(0, Carbon::parse($lastSeen)->diffInDays(now()));
+        $scoreRecency = 10 * exp(-$days / 60.0);
+
+        return round($scoreSev + $scoreRec + $scorePag + $scorePersona + $scoreRecency, 2);
+    }
+
+    /**
+     * É cliente pagante (Contact.type ∈ customer|both)?
+     */
+    protected function isPayingCustomer(ClientFeedback $fb): bool
+    {
+        if (! $fb->contact_id) {
+            return false;
+        }
+        // withoutGlobalScopes pra resilir scope quando rescore via cli sem session
+        $contact = Contact::withoutGlobalScopes()->find($fb->contact_id);
+        if (! $contact) {
+            return false;
+        }
+        return in_array($contact->type, ['customer', 'both'], true);
+    }
+
+    /**
+     * Prioridade da persona (1=primary, 0.6=secondary, 0.3=outras).
+     */
+    protected function personaPriority(ClientFeedback $fb): float
+    {
+        $modulo = $fb->modulo_afetado;
+        $persona = $fb->persona_slug;
+
+        if (! $modulo || ! $persona) {
+            return 0.3;
+        }
+        if (in_array($persona, self::PRIMARY_PERSONAS[$modulo] ?? [], true)) {
+            return 1.0;
+        }
+        if (in_array($persona, self::SECONDARY_PERSONAS[$modulo] ?? [], true)) {
+            return 0.6;
+        }
+        return 0.3;
+    }
+
+    /**
+     * Classifica feedback em HOT/WARM/COLD/FROZEN baseado em score + status + age.
+     */
+    public function classify(ClientFeedback $fb): string
+    {
+        $score = (float) ($fb->relevance_score ?? $this->computeScore($fb));
+
+        // FROZEN: resolved >= 365d (LGPD retention)
+        if ($fb->status === ClientFeedback::STATUS_RESOLVED && $fb->data_resolvido) {
+            if (Carbon::parse($fb->data_resolvido)->lt(now()->subDays(365))) {
+                return 'FROZEN';
+            }
+        }
+
+        // COLD: score < 30 OR closed >= 90d
+        $isClosedOld = in_array($fb->status, [ClientFeedback::STATUS_CLOSED, ClientFeedback::STATUS_RESOLVED], true)
+            && $fb->updated_at
+            && Carbon::parse($fb->updated_at)->lt(now()->subDays(90));
+
+        if ($score < 30 || $isClosedOld) {
+            return 'COLD';
+        }
+
+        // HOT: score >= 70
+        if ($score >= 70) {
+            return 'HOT';
+        }
+
+        // WARM
+        return 'WARM';
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/FeedbackRelevanceTest.php
+++ b/Modules/Whatsapp/Tests/Feature/FeedbackRelevanceTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Contact;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Schema;
+use Modules\Whatsapp\Entities\ClientFeedback;
+use Modules\Whatsapp\Http\Controllers\Admin\ClientFeedbackController;
+use Modules\Whatsapp\Services\FeedbackRelevanceService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Guard tests ADR 0195 — feedback relevance scoring + signature dedup + decay.
+ *
+ * Cobre:
+ *   001. signature determinística (mesma input → mesmo hash)
+ *   002. normalizeLiteral filtra stopwords + < 3 chars
+ *   003. computeScore segue fórmula: sev=4 + recor=5 + pagante + primary → ~95
+ *   004. dedup: 2ª captura mesma signature em 90d → recorrente_count++, NÃO cria
+ *   005. pattern_emergente true quando recorrente >= 3
+ *   006. classify HOT/WARM/COLD por score boundary
+ *   007. Observer creating computa signature automaticamente
+ *   008. cross-tenant: signature inclui business_id (mesma frase em biz=1 e biz=2 → hashes diferentes)
+ */
+beforeEach(function () {
+    foreach (['clients_feedbacks', 'contacts', 'activity_log'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('activity_log', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('log_name')->nullable();
+        $table->text('description')->nullable();
+        $table->unsignedBigInteger('subject_id')->nullable();
+        $table->string('subject_type')->nullable();
+        $table->unsignedBigInteger('causer_id')->nullable();
+        $table->string('causer_type')->nullable();
+        $table->text('properties')->nullable();
+        $table->uuid('batch_uuid')->nullable();
+        $table->string('event')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('contacts', function ($table) {
+        $table->increments('id');
+        $table->unsignedInteger('business_id');
+        $table->string('name', 191);
+        $table->string('mobile', 191)->nullable();
+        $table->string('email', 191)->nullable();
+        $table->string('type', 191)->default('customer');
+        $table->string('contact_type', 191)->nullable();
+        $table->timestamp('deleted_at')->nullable();
+        $table->timestamps();
+    });
+
+    Schema::create('clients_feedbacks', function ($table) {
+        $table->id();
+        $table->unsignedInteger('business_id')->index();
+        $table->unsignedBigInteger('contact_id')->nullable()->index();
+        $table->unsignedBigInteger('source_message_id')->nullable()->index();
+        $table->unsignedBigInteger('conversation_id')->nullable()->index();
+        $table->string('persona_slug', 80)->nullable()->index();
+        $table->string('cliente_slug', 80)->nullable();
+        $table->string('signature', 40)->nullable();
+        $table->decimal('relevance_score', 5, 2)->default(0);
+        $table->timestamp('relevance_score_at')->nullable();
+        $table->timestamp('last_seen_at')->nullable();
+        $table->string('canal', 32)->default('whatsapp');
+        $table->text('literal');
+        $table->text('contexto')->nullable();
+        $table->string('modulo_afetado', 80)->nullable();
+        $table->string('tela_afetada', 160)->nullable();
+        $table->string('acao_afetada', 80)->nullable();
+        $table->string('job', 255)->nullable();
+        $table->string('motivacao_tipo', 24)->nullable();
+        $table->string('workaround_o_que_faz', 255)->nullable();
+        $table->string('workaround_custo', 255)->nullable();
+        $table->unsignedTinyInteger('severity_nng')->default(2);
+        $table->boolean('primeira_vez')->default(true);
+        $table->unsignedSmallInteger('recorrente_count')->default(1);
+        $table->boolean('pattern_emergente')->default(false);
+        $table->string('status', 20)->default('novo')->index();
+        $table->text('responder_cliente')->nullable();
+        $table->string('mcp_task_id', 80)->nullable();
+        $table->boolean('dev_task_requested')->default(false);
+        $table->timestamp('data_resolvido')->nullable();
+        $table->string('pr_link', 255)->nullable();
+        $table->boolean('cliente_confirmou')->nullable();
+        $table->boolean('re_reclamacao')->default(false);
+        $table->unsignedBigInteger('created_by')->nullable();
+        $table->timestamps();
+        $table->softDeletes();
+    });
+});
+
+it('R-WA-FR-001 — signature é determinística (mesma input → mesmo hash)', function () {
+    $svc = app(FeedbackRelevanceService::class);
+
+    $fb1 = new ClientFeedback([
+        'business_id' => 1,
+        'persona_slug' => 'kamila-martinho',
+        'modulo_afetado' => 'fiscal',
+        'acao_afetada' => 'emitir-nfe',
+        'literal' => 'tô tentando emitir nota mas dá erro SEFAZ',
+    ]);
+
+    $fb2 = new ClientFeedback([
+        'business_id' => 1,
+        'persona_slug' => 'kamila-martinho',
+        'modulo_afetado' => 'fiscal',
+        'acao_afetada' => 'emitir-nfe',
+        'literal' => 'tô tentando emitir nota mas dá erro SEFAZ',
+    ]);
+
+    expect($svc->computeSignature($fb1))->toBe($svc->computeSignature($fb2));
+    expect(strlen($svc->computeSignature($fb1)))->toBe(40); // sha1
+});
+
+it('R-WA-FR-002 — normalizeLiteral filtra stopwords + < 3 chars + lower', function () {
+    $svc = app(FeedbackRelevanceService::class);
+
+    $norm = $svc->normalizeLiteral('Eu TÔ tentando emitir Nota Fiscal mas DÁ erro! socorro');
+
+    // "tô" stopword; "dá" 2 chars filter; "mas" stopword.
+    // Significativas: tentando, emitir, nota, fiscal, erro
+    expect($norm)->toBe('tentando emitir nota fiscal erro');
+});
+
+it('R-WA-FR-003 — computeScore: sev=4 + recor=5 + pagante + primary → ~95', function () {
+    $svc = app(FeedbackRelevanceService::class);
+
+    $contact = Contact::create([
+        'business_id' => 1, 'name' => 'Kamila', 'mobile' => '+5548999999999', 'type' => 'customer',
+    ]);
+
+    $fb = new ClientFeedback([
+        'business_id' => 1,
+        'contact_id' => $contact->id,
+        'persona_slug' => 'kamila-martinho',
+        'modulo_afetado' => 'financeiro', // kamila-martinho é primary em financeiro
+        'severity_nng' => 4,
+        'recorrente_count' => 5,
+        'last_seen_at' => now(),
+        'literal' => 'erro financeiro',
+    ]);
+
+    $score = $svc->computeScore($fb);
+    // Esperado: 40*1 + 25*log10(6)/log10(6)=25 + 15*1 + 10*1 + 10*1 = 100
+    expect($score)->toBeGreaterThan(95);
+    expect($score)->toBeLessThanOrEqual(100);
+});
+
+it('R-WA-FR-004 — dedup: 2ª captura mesma signature em 90d → recorrente_count++, NÃO cria duplicata', function () {
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 7);
+
+    $contact = Contact::create([
+        'business_id' => 1, 'name' => 'Kamila', 'mobile' => '+5548888888888', 'type' => 'customer',
+    ]);
+
+    $payload = [
+        'literal' => 'erro emissão NF-e SEFAZ timeout',
+        'severity_nng' => 3,
+        'contact_id' => $contact->id,
+        'persona_slug' => 'kamila-martinho',
+        'modulo_afetado' => 'fiscal',
+        'acao_afetada' => 'emitir-nfe',
+    ];
+
+    // 1ª captura
+    $req1 = Request::create('/atendimento/feedback/capture', 'POST', $payload);
+    $req1->setLaravelSession(session());
+    $resp1 = app(ClientFeedbackController::class)->capture($req1);
+    $data1 = $resp1->getData(true);
+
+    // 2ª captura idêntica
+    $req2 = Request::create('/atendimento/feedback/capture', 'POST', $payload);
+    $req2->setLaravelSession(session());
+    $resp2 = app(ClientFeedbackController::class)->capture($req2);
+    $data2 = $resp2->getData(true);
+
+    // Mesmo feedback ID
+    expect($data2['feedback']['id'])->toBe($data1['feedback']['id']);
+    expect($data2['dedup']['matched_existing'])->toBeTrue();
+    expect($data2['dedup']['recorrente_count'])->toBe(2);
+    expect(ClientFeedback::count())->toBe(1);  // só 1 registro
+});
+
+it('R-WA-FR-005 — pattern_emergente vira true quando recorrente >= 3', function () {
+    session()->put('user.business_id', 1);
+    session()->put('user.id', 7);
+
+    $contact = Contact::create([
+        'business_id' => 1, 'name' => 'Kamila', 'mobile' => '+5548777777777', 'type' => 'customer',
+    ]);
+
+    $payload = [
+        'literal' => 'travou no fechamento mensal',
+        'severity_nng' => 3,
+        'contact_id' => $contact->id,
+        'persona_slug' => 'kamila-martinho',
+        'modulo_afetado' => 'financeiro',
+        'acao_afetada' => 'fechar-mes',
+    ];
+
+    foreach (range(1, 3) as $i) {
+        $req = Request::create('/atendimento/feedback/capture', 'POST', $payload);
+        $req->setLaravelSession(session());
+        app(ClientFeedbackController::class)->capture($req);
+    }
+
+    $fb = ClientFeedback::first();
+    expect($fb->recorrente_count)->toBe(3);
+    expect($fb->pattern_emergente)->toBeTrue();
+});
+
+it('R-WA-FR-006 — classify HOT/WARM/COLD baseado em score boundary', function () {
+    $svc = app(FeedbackRelevanceService::class);
+
+    $contact = Contact::create([
+        'business_id' => 1, 'name' => 'C', 'mobile' => '+1', 'type' => 'customer',
+    ]);
+
+    // HOT: score >= 70 (sev=4 + pagante + primary)
+    $fb_hot = ClientFeedback::create([
+        'business_id' => 1, 'contact_id' => $contact->id,
+        'literal' => 'crítico bloqueia',
+        'severity_nng' => 4, 'recorrente_count' => 3,
+        'persona_slug' => 'kamila-martinho', 'modulo_afetado' => 'financeiro',
+        'status' => 'novo',
+    ]);
+    expect($svc->classify($fb_hot))->toBe('HOT');
+
+    // COLD: score baixo (lead + sev=1 + sem persona)
+    $fb_cold = ClientFeedback::create([
+        'business_id' => 1, 'contact_id' => null,
+        'literal' => 'cosmético sem dor',
+        'severity_nng' => 1, 'recorrente_count' => 1,
+        'status' => 'novo',
+    ]);
+    expect($svc->classify($fb_cold))->toBe('COLD');
+});
+
+it('R-WA-FR-007 — Observer creating computa signature + score automaticamente', function () {
+    $contact = Contact::create([
+        'business_id' => 1, 'name' => 'C', 'mobile' => '+1', 'type' => 'customer',
+    ]);
+
+    $fb = ClientFeedback::create([
+        'business_id' => 1, 'contact_id' => $contact->id,
+        'literal' => 'auto-compute signature funciona',
+        'severity_nng' => 3,
+        'persona_slug' => 'larissa-rota-livre', 'modulo_afetado' => 'sells',
+    ]);
+
+    expect($fb->signature)->not->toBeNull();
+    expect(strlen($fb->signature))->toBe(40);
+    expect((float) $fb->relevance_score)->toBeGreaterThan(0);
+    expect($fb->relevance_score_at)->not->toBeNull();
+    expect($fb->last_seen_at)->not->toBeNull();
+});
+
+it('R-WA-FR-008 — signature inclui business_id (mesma frase em biz=1 e biz=2 → hashes diferentes)', function () {
+    $svc = app(FeedbackRelevanceService::class);
+
+    $fb1 = new ClientFeedback([
+        'business_id' => 1, 'persona_slug' => 'p', 'modulo_afetado' => 'm',
+        'acao_afetada' => 'a', 'literal' => 'mesma reclamação literal',
+    ]);
+    $fb2 = new ClientFeedback([
+        'business_id' => 2, 'persona_slug' => 'p', 'modulo_afetado' => 'm',
+        'acao_afetada' => 'a', 'literal' => 'mesma reclamação literal',
+    ]);
+
+    expect($svc->computeSignature($fb1))->not->toBe($svc->computeSignature($fb2));
+});

--- a/memory/decisions/0195-feedback-relevance-scoring-decay-adaptativo.md
+++ b/memory/decisions/0195-feedback-relevance-scoring-decay-adaptativo.md
@@ -1,12 +1,26 @@
 ---
-adr: 0195
-title: Feedback indexing — relevance scoring + decay adaptativo + signature dedup
-status: accepted
-date: 2026-05-27
-deciders: [Wagner Rocha]
-tags: [feedback, voice-of-customer, memoria, lgpd, tier-0]
+slug: 0195-feedback-relevance-scoring-decay-adaptativo
+number: 195
+title: "Feedback indexing — relevance scoring + decay adaptativo + signature dedup"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: "2026-05-27"
+accepted_at: "2026-05-27"
+accepted_via: "Wagner aprovou via AskUserQuestion 3-decisões 2026-05-27 sessão `frosty-greider-83ab2f` — decay 60d, archive OR (score<30 OR closed>=90d), sequencial Fase A→B"
+module: whatsapp
+quarter: 2026-Q2
+tags: [feedback, voice-of-customer, memoria, lgpd, tier-0, scoring, dedup, decay, append-only]
 supersedes: []
-related: [0093, 0105, 0131, 0140]
+supersedes_partially: []
+amends: []
+superseded_by: []
+related:
+  - 0093-multi-tenant-isolation-tier-0
+  - 0105-cliente-como-sinal-guiar-sem-mandar
+  - 0131-tiering-memoria-canonico-local-segredo
 authors:
   - W
   - C
@@ -166,8 +180,6 @@ ALTER TABLE clients_feedbacks ADD:
   qualificado (peso 15 do score)
 - [ADR 0131](0131-tiering-memoria-canonico-local-segredo.md) — tiering memória
   canonico/local/segredo (mesma filosofia HOT/WARM/COLD)
-- [ADR 0140](0140-feedback-management-canon-voice-of-customer.md) — feedback
-  management canon Voice of Customer
 - PR #1711 — captura Voice of Customer in-app inbox
 - PR #1713 — abrir chamado dev direto da conversa + guard rails ADR 0105
 - Voice of Customer (Six Sigma + NN/g) — fundamento metodológico

--- a/memory/decisions/0195-feedback-relevance-scoring-decay-adaptativo.md
+++ b/memory/decisions/0195-feedback-relevance-scoring-decay-adaptativo.md
@@ -1,0 +1,175 @@
+---
+adr: 0195
+title: Feedback indexing — relevance scoring + decay adaptativo + signature dedup
+status: accepted
+date: 2026-05-27
+deciders: [Wagner Rocha]
+tags: [feedback, voice-of-customer, memoria, lgpd, tier-0]
+supersedes: []
+related: [0093, 0105, 0131, 0140]
+authors:
+  - W
+  - C
+---
+
+# 0195 — Feedback indexing: relevance scoring + decay adaptativo + signature dedup
+
+## Contexto
+
+Wagner 2026-05-27, após PR #1711/#1712/#1713 entregar captura Voice of Customer in-app
+no WhatsApp inbox: "crie índice de feedback, como checksum pra ficar na memória
+apenas as mais importantes e ir retirando da memória com o tempo como nas outras
+memorias, otimize, acho que tu sabe fazer melhor que eu".
+
+Sem otimização, `clients_feedbacks` cresce linearmente. Mesma reclamação (ex: "erro
+emissão NF-e SEFAZ timeout") repetida por 5 clientes ao longo de 60d vira 5 registros
+distintos no INDEX agregado — sinal real fica diluído. Pior: feedbacks
+resolvidos há 6 meses continuam carregados em todo `feedback-search` consumindo
+contexto Claude sem agregar valor.
+
+## Decisão
+
+Implementar **sistema de relevância adaptativa** com 3 mecanismos:
+
+### 1. Signature (checksum) pra dedup
+
+```
+signature = sha1(business_id | persona_slug | modulo | acao | literal_normalized)
+
+literal_normalized:
+  lowercase + strip punctuation
+  → split em palavras
+  → filtrar palavras < 3 chars + stopwords PT-BR
+  → 5 primeiras palavras significativas
+  → join " "
+```
+
+Quando captura novo feedback com mesma signature nos últimos 90d:
+- `recorrente_count++` no existente
+- `severity = MAX(antigo, novo)`
+- `pattern_emergente = true` se recorrente_count ≥ 3
+- `last_seen_at = now()`
+- **NÃO cria registro novo** — atualiza existente (idempotência HTTP)
+
+### 2. Relevance score (0-100)
+
+```
+score = 40 * severity/4                              # peso 1 — dor real
+      + 25 * log10(recorrente+1) / log10(5+1)         # peso 2 — recorrência (plateau em 5)
+      + 15 * (cliente_pagante ? 1.0 : 0.2)            # peso 3 — ADR 0105 sinal qualificado
+      + 10 * persona_priority                         # primary=1 / secondary=0.6 / outras=0.3
+      + 10 * exp(-days_since_last_seen / 60)          # decay meia-vida 60d
+```
+
+Recomputado pelo Observer `creating/updating` + job semanal `feedback:reindex`.
+
+### 3. 4 camadas (tiering ADR 0131)
+
+| Camada | Critério | Onde | Carregamento Claude |
+|--------|----------|------|---------------------|
+| **HOT** | score ≥ 70 | DB + `memory/feedback/INDEX.md` (top 20) | Sempre (~2k tokens) |
+| **WARM** | 30 ≤ score < 70 | DB only | Sob demanda via tool |
+| **COLD** | score < 30 OU closed/resolved ≥ 90d | DB + `memory/feedback/archive/YYYY-QN.md` (digest agregado) | Apenas com query explícita |
+| **FROZEN** | resolved ≥ 365d | DB soft-deleted | LGPD retention apenas |
+
+### Decay window: 60 dias meia-vida
+
+Wagner aprovou explicitamente 2026-05-27 default (vs 30d agressivo / 90d
+conservador). 60d sinaliza recente mas não esquece patterns trimestrais
+(fechamento mensal NFe, sazonal vestuário).
+
+### Archive condition: OR (não AND)
+
+`score < 30` OU `closed ≥ 90d` arquiva. Wagner aprovou explicitamente 2026-05-27
+(vs AND mais conservador). Mantém INDEX enxuto; closed antigo sai do hot mesmo
+se score residual alto.
+
+## Schema (migration 2026_05_27_240000)
+
+```sql
+ALTER TABLE clients_feedbacks ADD:
+  signature CHAR(40) NULL                  AFTER cliente_slug
+  relevance_score DECIMAL(5,2) DEFAULT 0   AFTER signature
+  relevance_score_at TIMESTAMP NULL        AFTER relevance_score
+  last_seen_at TIMESTAMP NULL              AFTER relevance_score_at
+
+  INDEX idx_biz_signature (business_id, signature)
+  INDEX idx_biz_relevance (business_id, relevance_score)
+  INDEX idx_biz_last_seen (business_id, last_seen_at)
+```
+
+## Componentes (Fase A — esta ADR)
+
+1. **Migration** `2026_05_27_240000_add_signature_relevance_to_clients_feedbacks`
+2. **Service** `Modules/Whatsapp/Services/FeedbackRelevanceService` —
+   `computeSignature()` + `computeScore()` + `findDuplicateWithin90d()` + `classify()`
+3. **Observer** `Modules/Whatsapp/Observers/ClientFeedbackObserver` —
+   `creating` (sig + score inicial), `updating` (rescore se severity/recorrente mudou)
+4. **Controller** `ClientFeedbackController::capture()` — dedup branch usando service
+5. **Model** scopes `hot()` / `warm()` / `cold()` + fillable + casts atualizados
+
+## Componentes (Fase B — próxima ADR ou seguimento)
+
+1. **Command** `php artisan feedback:reindex {--business=}` — rescore todos +
+   gera `memory/feedback/INDEX.md` (top 20 HOT) + `memory/feedback/archive/YYYY-QN.md`
+2. **Schedule** semanal domingo 03:00 BRT (Kernel.php)
+3. **Pest tests E2E** scoring + decay + archive
+
+## Consequências
+
+### Positivas
+
+- **Sinal qualificado**: cliente reclama 5× mesmo problema → 1 feedback com
+  `recorrente_count=5, pattern_emergente=true, score≈85`. Antes: 5 linhas no INDEX.
+- **Contexto Claude leve**: INDEX.md auto-loaded só carrega top 20 HOT
+  (~2k tokens) em vez de N feedbacks históricos.
+- **ADR 0105 reforçado**: score weighting `cliente_pagante` peso 15 favorece sinal
+  de quem paga. Lead vira ruído de fundo.
+- **Pattern detection automático**: `pattern_emergente=true` quando recorrente
+  ≥ 3 → triagem prioriza.
+- **LGPD retention**: FROZEN tier formaliza soft-delete após 365d.
+
+### Negativas
+
+- **Dedup window de 90d é arbitrário**: cliente que reclama mesma coisa após
+  6 meses cria registro novo. Mitigação: `pattern_emergente` em FeedbackRelevanceService
+  pode olhar histórico além de 90d se for caso edge.
+- **Score recomputado semanal**: pode ter drift de até 7d entre escala real
+  e cached. Mitigação: Observer já rescore on-update (severity/recorrente_count).
+- **Stopwords PT-BR hardcoded**: vocabulário regional ("tô", "trampar") pode
+  variar — lista atual cobre 80% casos comuns. Mitigação: extender via
+  config quando aparecer.
+- **personas-por-modulo hardcoded em Service**: evita I/O em hot path, custa
+  duplicação vs `memory/requisitos/_DesignSystem/personas-por-modulo.yml`.
+  Mitigação: documentado pra atualizar manualmente quando expandir.
+
+### Neutras
+
+- Schema cresce 4 colunas + 3 índices em `clients_feedbacks`. Custo storage
+  desprezível (< 100 bytes/row). Custo write desprezível (Observer em-process).
+- Backfill dos registros existentes (já criados sem signature) precisa rodar
+  `feedback:reindex --backfill` 1× — comando entrega na Fase B.
+
+## Métrica de saúde
+
+`feedback_index_dedup_rate_7d` = `dedup_hits / total_captures` na janela 7d.
+
+- Target esperado: 5-15% (1 em cada 7-20 capturas é repetição)
+- Alert se > 40% (atendentes capturando o mesmo problema sem triagem) OU
+  < 1% (dedup quebrado, signature instável)
+
+## Referências
+
+- [ADR 0093](0093-multi-tenant-isolation-tier-0.md) — multi-tenant Tier 0
+  (HasBusinessScope no ClientFeedback)
+- [ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md) — cliente como sinal
+  qualificado (peso 15 do score)
+- [ADR 0131](0131-tiering-memoria-canonico-local-segredo.md) — tiering memória
+  canonico/local/segredo (mesma filosofia HOT/WARM/COLD)
+- [ADR 0140](0140-feedback-management-canon-voice-of-customer.md) — feedback
+  management canon Voice of Customer
+- PR #1711 — captura Voice of Customer in-app inbox
+- PR #1713 — abrir chamado dev direto da conversa + guard rails ADR 0105
+- Voice of Customer (Six Sigma + NN/g) — fundamento metodológico
+- NN/g 1995 — severity 0-4 scale (Nielsen Heuristics)
+- Mom Test (Rob Fitzpatrick) — JTBD reverse capture

--- a/tests/Feature/Memory/AdrFrontmatterLinterTest.php
+++ b/tests/Feature/Memory/AdrFrontmatterLinterTest.php
@@ -59,6 +59,7 @@ const MODULE_VALIDOS    = [
     'Infra', 'jana', 'sells', 'design-system', 'Sells',
     'NfeBrasil',    // ADR 0186 mergeada com case canônico do path Modules/NfeBrasil/ — append-only impede fix
     '_DesignSystem', // ADRs 0189/0190 mergeadas com prefixo underscore (era convenção early-design-system) — append-only impede fix; convenção futura: design-system (lowercase)
+    'OficinaAuto',  // ADR 0194 mergeada com case canônico do path Modules/OficinaAuto/ — append-only impede fix; convenção futura: oficinaauto (lowercase)
 ];
 
 const CAMPOS_OBRIGATORIOS = [

--- a/tests/Feature/Memory/AdrFrontmatterLinterTest.php
+++ b/tests/Feature/Memory/AdrFrontmatterLinterTest.php
@@ -101,6 +101,7 @@ const ADRS_LEGACY_SKIP = [
     // lifecycle/decided_at). Append-only Tier 0 — não editar. Backlog migração junto
     // com 0122-0128 + 0172-0173 em Wave 30+.
     '0170-onda5-simplificada',
+    '0170-bancos-nativos-top5-drivers-separados',
 ];
 
 /**


### PR DESCRIPTION
## Summary

Wagner pediu (2026-05-27): "crie índice de feedback, como checksum para ficar na memória apenas as mais importantes e ir retirando da memória com o tempo como nas outras memorias, otimize, acho que tu sabe fazer melhor que eu".

**Fase A** do [ADR 0195](memory/decisions/0195-feedback-relevance-scoring-decay-adaptativo.md). Implementa **signature dedup + relevance scoring 0-100 + classify HOT/WARM/COLD/FROZEN** no servidor. Fase B (PR follow-up) entrega command artisan + INDEX.md auto-gerado + schedule semanal.

## Como funciona

### 1. Signature (checksum) pra dedup

```
signature = sha1(business_id | persona | módulo | ação | literal_normalized)
literal_normalized = lowercase + strip punct + filtra stopwords PT-BR + 5 palavras significativas
```

Mesma signature em 90d → `recorrente_count++` em vez de criar duplicata. `pattern_emergente=true` quando recorrente ≥ 3.

### 2. Relevance score (0-100)

```
40 * severity/4                       # dor real (NN/g)
+ 25 * log10(recorrente+1)/log10(6)    # recorrência (plateau 5)
+ 15 * (cliente_pagante ? 1 : 0.2)     # ADR 0105 sinal qualificado
+ 10 * persona_priority                # primary=1 / secondary=0.6 / outras=0.3
+ 10 * exp(-days_since_seen/60)        # decay meia-vida 60d
```

### 3. 4 camadas (tiering ADR 0131)

| Camada | Critério | Carrega em sessão Claude? |
|--------|----------|---------------------------|
| **HOT** | score ≥ 70 | Sempre (INDEX.md auto) |
| **WARM** | 30 ≤ score < 70 | Sob demanda |
| **COLD** | score < 30 OR closed ≥ 90d | Apenas query explícita |
| **FROZEN** | resolved ≥ 365d | LGPD retention apenas |

## Componentes Fase A

- **Migration** `2026_05_27_240000`: +4 colunas (signature, relevance_score, relevance_score_at, last_seen_at) + 3 índices compostos
- **`FeedbackRelevanceService`** — computeSignature + normalizeLiteral + computeScore + findDuplicateWithin90d + classify
- **`ClientFeedbackObserver`** — creating (auto-sig + score), updating (rescore se severity/recor mudou)
- **Controller capture()** — dedup branch (1ª nova / 2ª-N bumps existente)
- **Model** — scopes `hot()`/`warm()`/`cold()` + fillable + casts

## Test plan (CI Pest)

| # | Cenário | Validação |
|---|---------|-----------|
| 001 | signature determinística | mesma input → mesmo hash, len=40 |
| 002 | normalizeLiteral | filtra stopwords + < 3 chars + lower |
| 003 | computeScore fórmula | sev=4 + recor=5 + pagante + primary → ~95-100 |
| 004 | dedup happy path | 2ª captura mesma sig em 90d → recorrente++ NÃO duplica |
| 005 | pattern_emergente | true quando recorrente ≥ 3 |
| 006 | classify boundaries | HOT/WARM/COLD por score |
| 007 | Observer creating | auto-sig + score inicial |
| 008 | cross-tenant signature | biz=1 ≠ biz=2 hash (mesma frase) |

## Fase B (próximo PR follow-up)

- Command `php artisan feedback:reindex {--business=}` — rescore todos + gera `memory/feedback/INDEX.md` (top 20 HOT) + `memory/feedback/archive/YYYY-QN.md` (digest COLD)
- Schedule semanal domingo 03:00 BRT
- Pest tests E2E reindex + archive

## Refs

- [ADR 0195](memory/decisions/0195-feedback-relevance-scoring-decay-adaptativo.md) — esta arquitetura
- [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md) — multi-tenant Tier 0 (signature inclui business_id)
- [ADR 0105](memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — cliente como sinal qualificado (peso 15)
- [ADR 0131](memory/decisions/0131-tiering-memoria-canonico-local-segredo.md) — tiering memória canon/local/segredo (mesma filosofia HOT/WARM/COLD)

Refs: SPRINT-5 PASSO M (Voice of Customer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
