### PR TITLE
feat(paymentgateway): Sicoob API driver skeleton + migration requires_mtls (PR1/6 US-FIN-044)

### DIFF
--- a/Modules/PaymentGateway/Database/Migrations/2026_05_27_120000_add_sicoob_api_to_payment_gateway_credentials.php
+++ b/Modules/PaymentGateway/Database/Migrations/2026_05_27_120000_add_sicoob_api_to_payment_gateway_credentials.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Onda 4f.sicoob_api — US-FIN-044.
+ *
+ * Adiciona suporte ao driver REST API do Sicoob no enum gateway_key,
+ * mais 2 colunas necessárias pra credenciais que exigem certificado
+ * mTLS (Sicoob/BB/Bradesco usam .pfx + senha — mantemos coluna agnóstica
+ * pra ser reusada por API drivers futuros).
+ *
+ *   - sicoob_api (REST v3 com OAuth2 + mTLS)
+ *   - requires_mtls (boolean) — flag declarativa do driver
+ *   - mtls_pfx_path (string) — path por tenant em storage/app/private
+ *
+ * O .pfx em si NÃO entra no DB — fica em
+ * storage/app/private/sicoob/{business_id}.pfx; aqui só o ponteiro.
+ * Senha do .pfx vive em config_json (cifrada via Crypt::encryptString),
+ * NUNCA em log/audit.
+ *
+ * Tier 0: schema-only. Não toca dados. SQLite no-op (TEXT sem CHECK).
+ *
+ * Refs: US-FIN-044 — Wagner aprovou 2026-05-27 (sessão "kamila quer
+ *       cadastrar o cobrança pelo sicoob"). ADR 0170 §4f.sicoob_api.
+ */
+return new class extends Migration
+{
+    /**
+     * Enum legacy ANTES desta migration (pós-Onda 4f.cnab).
+     *
+     * @var array<int, string>
+     */
+    private const ENUM_LEGACY = [
+        'inter', 'c6', 'asaas', 'bcb_pix', 'pesapal', 'pagarme',
+        'bradesco_cnab', 'itau_cnab', 'bb_cnab', 'santander_cnab', 'caixa_cnab',
+        'sicoob_cnab', 'ailos_cnab', 'sicredi_cnab', 'cresol_cnab', 'banrisul_cnab', 'btg_cnab',
+        'bradesco_api', 'itau_api', 'bb_api', 'santander_api',
+    ];
+
+    private const ENUM_NOVOS = ['sicoob_api'];
+
+    public function up(): void
+    {
+        if (! Schema::hasTable('payment_gateway_credentials')) {
+            return;
+        }
+
+        $driver = DB::connection()->getDriverName();
+        $all = array_merge(self::ENUM_LEGACY, self::ENUM_NOVOS);
+
+        if ($driver === 'mysql' || $driver === 'mariadb') {
+            $enumList = "'" . implode("','", $all) . "'";
+            DB::statement("ALTER TABLE payment_gateway_credentials MODIFY COLUMN gateway_key ENUM({$enumList}) NOT NULL");
+        }
+
+        Schema::table('payment_gateway_credentials', function (Blueprint $table) {
+            if (! Schema::hasColumn('payment_gateway_credentials', 'requires_mtls')) {
+                $table->boolean('requires_mtls')->default(false)->after('ambiente');
+            }
+            if (! Schema::hasColumn('payment_gateway_credentials', 'mtls_pfx_path')) {
+                $table->string('mtls_pfx_path', 255)->nullable()->after('requires_mtls');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('payment_gateway_credentials')) {
+            return;
+        }
+
+        Schema::table('payment_gateway_credentials', function (Blueprint $table) {
+            if (Schema::hasColumn('payment_gateway_credentials', 'mtls_pfx_path')) {
+                $table->dropColumn('mtls_pfx_path');
+            }
+            if (Schema::hasColumn('payment_gateway_credentials', 'requires_mtls')) {
+                $table->dropColumn('requires_mtls');
+            }
+        });
+
+        $driver = DB::connection()->getDriverName();
+
+        if ($driver === 'mysql' || $driver === 'mariadb') {
+            $usados = DB::table('payment_gateway_credentials')
+                ->whereIn('gateway_key', self::ENUM_NOVOS)
+                ->count();
+
+            if ($usados > 0) {
+                throw new \RuntimeException(
+                    "Não é possível reverter: {$usados} credenciais usam sicoob_api. " .
+                    'Migre-as antes pra outro gateway_key.'
+                );
+            }
+
+            $enumList = "'" . implode("','", self::ENUM_LEGACY) . "'";
+            DB::statement("ALTER TABLE payment_gateway_credentials MODIFY COLUMN gateway_key ENUM({$enumList}) NOT NULL");
+        }
+    }
+};

--- a/Modules/PaymentGateway/Services/Drivers/SicoobApiDriver.php
+++ b/Modules/PaymentGateway/Services/Drivers/SicoobApiDriver.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Services\Drivers;
+
+use Modules\PaymentGateway\Contracts\PaymentDriverContract;
+use Modules\PaymentGateway\Dto\CardToken;
+use Modules\PaymentGateway\Dto\CobrancaEmitidaResult;
+use Modules\PaymentGateway\Dto\CobrancaStatus;
+use Modules\PaymentGateway\Dto\DriverHealth;
+use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
+use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
+
+/**
+ * Driver Sicoob — API Cobrança v3 (REST + OAuth2 client_credentials + mTLS).
+ *
+ * US-FIN-044 — Onda 4f.sicoob_api. Sinal qualificado: biz=4 ROTA LIVRE
+ * (Larissa via Kamila) pediu 2026-05-27 [ADR 0105 — cliente como sinal].
+ *
+ * PR1 (este arquivo) — APENAS skeleton:
+ *   ✓ key, supports
+ *   ✗ todos demais métodos lançam DriverNotSupportedException("PR{N}")
+ *
+ * Próximas fatias do mesmo módulo:
+ *   PR2: OAuth2 client_credentials + emitirBoleto (POST /cobranca/v3/boletos)
+ *   PR3: mTLS handshake real (.pfx + senha cifrada via Crypt)
+ *   PR4: processWebhook + HMAC + idempotência
+ *   PR5: Wizard UI step Sicoob (SheetNovoGateway.tsx)
+ *   PR6: RUNBOOK + Charter + Pest cross-tenant biz=4 vs biz=99
+ *
+ * Diferença frente ao SicoobCnabDriver:
+ *   - CnabDriver = arquivo remessa/retorno (assíncrono, sem webhook)
+ *   - ApiDriver  = REST tempo real (sync) + webhook baixa real-time
+ *
+ * Os 2 coexistem — cliente escolhe qual ativar no wizard
+ * `/settings/payment-gateways`. Mesma cooperativa singular Sicoob pode
+ * ter os dois cadastrados (um por business_id separado).
+ *
+ * Refs:
+ *   - https://developers.sicoob.com.br/#!/apis (docs oficiais)
+ *   - ADR 0170-bancos-nativos-top5-drivers-separados §4f.sicoob_api
+ *   - memory/sessions/2026-05-27-sicoob-api-credenciais-pedido.md (checklist Kamila)
+ */
+class SicoobApiDriver implements PaymentDriverContract
+{
+    /**
+     * Endpoint REST oficial Sicoob (cooperativa singular agnóstica —
+     * roteamento por client_id no token).
+     */
+    private const API_BASE_PRODUCTION = 'https://api.sicoob.com.br';
+
+    private const API_BASE_SANDBOX = 'https://sandbox.sicoob.com.br';
+
+    public function key(): string
+    {
+        return 'sicoob_api';
+    }
+
+    /**
+     * Sicoob API v3 hoje suporta boleto + pix_cob.
+     * pix_cobv (com vencimento) chega futuramente — ver Sicoob roadmap.
+     */
+    public function supports(string $tipo): bool
+    {
+        return in_array($tipo, ['boleto', 'pix_cob'], true);
+    }
+
+    public function emitirBoleto(EmitirCobrancaInput $input, object $cred): CobrancaEmitidaResult
+    {
+        throw new DriverNotSupportedException('SicoobApiDriver::emitirBoleto chega no PR2 (US-FIN-044).');
+    }
+
+    public function emitirPix(EmitirCobrancaInput $input, object $cred, string $tipo): CobrancaEmitidaResult
+    {
+        throw new DriverNotSupportedException('SicoobApiDriver::emitirPix chega no PR2+ (US-FIN-044). Use sicoob_cnab por enquanto.');
+    }
+
+    public function emitirPixAutomatico(EmitirCobrancaInput $input, object $cred): CobrancaEmitidaResult
+    {
+        throw new DriverNotSupportedException('Sicoob PIX Automático não suportado nesta API. Use bcb_pix driver (regulado BCB).');
+    }
+
+    public function cobrarCartao(EmitirCobrancaInput $input, object $cred, CardToken $token): CobrancaEmitidaResult
+    {
+        throw new DriverNotSupportedException('Sicoob não emite cartão via API Cobrança. Use Asaas/Pagar.me.');
+    }
+
+    public function cancelar(object $cobranca, object $cred, string $motivo): void
+    {
+        throw new DriverNotSupportedException('SicoobApiDriver::cancelar chega no PR2 (US-FIN-044).');
+    }
+
+    public function refund(object $cobranca, object $cred, ?int $valorCentavos, string $motivo): void
+    {
+        throw new DriverNotSupportedException('Sicoob refund de boleto não suportado via API. TED reverso operado manualmente.');
+    }
+
+    public function consultar(object $cobranca, object $cred): CobrancaStatus
+    {
+        throw new DriverNotSupportedException('SicoobApiDriver::consultar chega no PR2 (US-FIN-044).');
+    }
+
+    public function healthCheck(object $cred): DriverHealth
+    {
+        throw new DriverNotSupportedException('SicoobApiDriver::healthCheck chega no PR2 (US-FIN-044).');
+    }
+
+    public function processWebhook(array $payload, object $cred): ?object
+    {
+        throw new DriverNotSupportedException('SicoobApiDriver::processWebhook chega no PR4 (US-FIN-044).');
+    }
+}

--- a/Modules/PaymentGateway/Services/PaymentGatewayService.php
+++ b/Modules/PaymentGateway/Services/PaymentGatewayService.php
@@ -33,6 +33,7 @@ use Modules\PaymentGateway\Services\Drivers\BcbPixDriver;
 use Modules\PaymentGateway\Services\Drivers\C6Driver;
 use Modules\PaymentGateway\Services\Drivers\InterDriver;
 use Modules\PaymentGateway\Services\Drivers\PagarmeDriver;
+use Modules\PaymentGateway\Services\Drivers\SicoobApiDriver;
 
 /**
  * Implementação do PaymentGatewayContract — coordena drivers + persistência.
@@ -58,15 +59,19 @@ class PaymentGatewayService implements PaymentGatewayContract
      *               — Bradesco/Itaú/BB/Santander/Caixa/Sicoob/Ailos/Sicredi/Cresol/Banrisul/BTG
      *               todos file-based via lib eduardokum/laravel-boleto sobre fundação CnabBoletoAdapter
      *               PRs mergeados: #1589 #1590 #1592 #1606-#1613
+     * Onda 4f.sicoob_api: + sicoob_api (US-FIN-044 — Wagner aprovou 2026-05-27 a pedido
+     *               de Kamila/Larissa biz=4 ROTA LIVRE; REST v3 OAuth2+mTLS+webhook real-time)
+     *               PR1 skeleton, PR2 OAuth2+emissão, PR3 mTLS, PR4 webhook, PR5 UI, PR6 docs.
      * Onda 5/6: pesapal (deprecated → remoção)
      */
     private const DRIVERS = [
         // API REST drivers
-        'inter'   => InterDriver::class,
-        'c6'      => C6Driver::class,
-        'asaas'   => AsaasDriver::class,
-        'bcb_pix' => BcbPixDriver::class,
-        'pagarme' => PagarmeDriver::class,
+        'inter'      => InterDriver::class,
+        'c6'         => C6Driver::class,
+        'asaas'      => AsaasDriver::class,
+        'bcb_pix'    => BcbPixDriver::class,
+        'pagarme'    => PagarmeDriver::class,
+        'sicoob_api' => SicoobApiDriver::class,
 
         // CNAB drivers (file-based — boleto registrado via remessa/retorno)
         // Onda 4f.cnab — clientes emitem boleto dia 1 sem esperar homologação Open API (14-45d)

--- a/Modules/PaymentGateway/Tests/Feature/SicoobApiDriverSkeletonTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/SicoobApiDriverSkeletonTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\PaymentGateway\Contracts\PaymentDriverContract;
+use Modules\PaymentGateway\Dto\CardToken;
+use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
+use Modules\PaymentGateway\Exceptions\DriverNotSupportedException;
+use Modules\PaymentGateway\Services\Drivers\SicoobApiDriver;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Onda 4f.sicoob_api PR1 — US-FIN-044.
+ *
+ * Testa skeleton: instanciação, key, supports, throws DriverNotSupported
+ * em todos métodos de operação (que chegam em PR2-PR4).
+ *
+ * Pest contract test REAL (com mock HTTP) chega no PR2 quando emitirBoleto
+ * estiver implementado. Aqui só validamos contrato superficial.
+ */
+it('instancia SicoobApiDriver via classe concreta', function () {
+    $driver = new SicoobApiDriver();
+
+    expect($driver)->toBeInstanceOf(PaymentDriverContract::class);
+});
+
+it('expõe key "sicoob_api"', function () {
+    expect((new SicoobApiDriver())->key())->toBe('sicoob_api');
+});
+
+it('supports boleto + pix_cob mas não card/pix_cobv', function () {
+    $driver = new SicoobApiDriver();
+
+    expect($driver->supports('boleto'))->toBeTrue()
+        ->and($driver->supports('pix_cob'))->toBeTrue()
+        ->and($driver->supports('card'))->toBeFalse()
+        ->and($driver->supports('pix_cobv'))->toBeFalse()
+        ->and($driver->supports('pix_recv'))->toBeFalse();
+});
+
+function sicoobPr1Input(): EmitirCobrancaInput
+{
+    return new EmitirCobrancaInput(
+        businessId: 4,
+        contactId: 1,
+        valorCentavos: 10000,
+        vencimento: new DateTimeImmutable('+5 days'),
+        descricao: 'Test PR1',
+        idempotencyKey: 'sk-pr1-' . uniqid(),
+    );
+}
+
+it('emitirBoleto lança DriverNotSupportedException com aviso PR2', function () {
+    expect(fn () => (new SicoobApiDriver())->emitirBoleto(sicoobPr1Input(), (object) []))
+        ->toThrow(DriverNotSupportedException::class, 'PR2');
+});
+
+it('emitirPix lança DriverNotSupportedException', function () {
+    expect(fn () => (new SicoobApiDriver())->emitirPix(sicoobPr1Input(), (object) [], 'cob'))
+        ->toThrow(DriverNotSupportedException::class);
+});
+
+it('cobrarCartao rejeita explicitamente — Sicoob não emite cartão', function () {
+    $token = new CardToken(
+        token: 'tok_test',
+        brand: 'visa',
+        lastFour: '4242',
+        holderName: 'Test',
+        expMonth: '12',
+        expYear: '2030',
+    );
+
+    expect(fn () => (new SicoobApiDriver())->cobrarCartao(sicoobPr1Input(), (object) [], $token))
+        ->toThrow(DriverNotSupportedException::class, 'não emite cartão');
+});
+
+it('refund de boleto rejeitado — TED reverso manual', function () {
+    expect(fn () => (new SicoobApiDriver())->refund((object) ['tipo' => 'boleto'], (object) [], null, 'erro'))
+        ->toThrow(DriverNotSupportedException::class, 'TED reverso');
+});
+
+it('emitirPixAutomatico aponta pra bcb_pix driver dedicado', function () {
+    expect(fn () => (new SicoobApiDriver())->emitirPixAutomatico(sicoobPr1Input(), (object) []))
+        ->toThrow(DriverNotSupportedException::class, 'bcb_pix');
+});
+
+it('métodos PR2/PR4 (cancelar, consultar, healthCheck, processWebhook) marcam PR esperado', function () {
+    $driver = new SicoobApiDriver();
+    $stub = (object) ['gateway_external_id' => 'NN-123'];
+
+    expect(fn () => $driver->cancelar($stub, (object) [], 'cliente_pediu'))
+        ->toThrow(DriverNotSupportedException::class, 'PR2');
+
+    expect(fn () => $driver->consultar($stub, (object) []))
+        ->toThrow(DriverNotSupportedException::class, 'PR2');
+
+    expect(fn () => $driver->healthCheck((object) []))
+        ->toThrow(DriverNotSupportedException::class, 'PR2');
+
+    expect(fn () => $driver->processWebhook(['evento' => 'cobranca.liquidada'], (object) []))
+        ->toThrow(DriverNotSupportedException::class, 'PR4');
+});
+
+it('registry PaymentGatewayService mapeia sicoob_api → SicoobApiDriver::class', function () {
+    $reflection = new ReflectionClass(\Modules\PaymentGateway\Services\PaymentGatewayService::class);
+    $drivers = $reflection->getConstant('DRIVERS');
+
+    expect($drivers)->toHaveKey('sicoob_api')
+        ->and($drivers['sicoob_api'])->toBe(SicoobApiDriver::class);
+});


### PR DESCRIPTION
## Summary

PR1 de 6 da **US-FIN-044** (Sicoob REST API · OAuth2 + mTLS + webhook real-time).

Adiciona infra mínima pra os próximos PRs operarem em paralelo:
- Migration: expande enum `gateway_key` com `sicoob_api` + colunas reusáveis `requires_mtls` (bool) + `mtls_pfx_path` (string nullable). SQLite no-op, MySQL ALTER MODIFY ENUM.
- `SicoobApiDriver.php` (113 linhas) — skeleton implementando `PaymentDriverContract`. `key()`='sicoob_api', `supports(boleto|pix_cob)`. Demais métodos lançam `DriverNotSupportedException` apontando PR onde chegam.
- `PaymentGatewayService::DRIVERS` registra `'sicoob_api' → SicoobApiDriver::class`.
- Pest skeleton test (10 cases): instanciação, key, supports, exceptions esperadas, registry mapping via Reflection.

## Roadmap

| PR | Escopo |
|---|---|
| **PR1** *(este)* | Migration + skeleton + registry + Pest base |
| PR2 | OAuth2 client_credentials + `emitirBoleto` (POST /cobranca/v3/boletos) |
| PR3 | mTLS handshake real (.pfx + senha cifrada via Laravel Crypt) |
| PR4 | `SicoobWebhookController` + HMAC + idempotência |
| PR5 | Wizard UI step Sicoob (`SheetNovoGateway.tsx`) |
| PR6 | RUNBOOK + Charter + Pest cross-tenant biz=4 vs biz=99 |

## Sinal qualificado (ADR 0105)

Kamila/Larissa biz=4 ROTA LIVRE pediu API Sicoob 2026-05-27 (Wagner aprovou na sessão). Sicoob é banco operacional dela. Não-hipótese.

`SicoobCnabDriver` (CNAB 240 arquivo) continua existindo e funcional — esta US adiciona caminho API alternativo, não substitui.

## Pré-requisito humano

Checklist `memory/sessions/2026-05-27-sicoob-api-credenciais-pedido.md` (já mergeado em paralelo) lista o que Kamila pede pro gerente Sicoob antes de PR2 ativar com credenciais reais (sandbox client_id/secret + `.pfx` + convênio + faixa nosso número).

## Multi-tenant Tier 0

- `.pfx` ficará em `storage/app/private/sicoob/{business_id}.pfx` (path por tenant) — PR3
- Senha do .pfx cifrada via `Crypt::encryptString`, NUNCA em log — PR3
- OAuth2 token cache key por `{business_id}:{client_id_hash}` — PR2

## Test plan

- [x] `php -l` passou nos 4 arquivos
- [x] Pest test sintaxe OK (rodará no CI — vendor não populado neste worktree)
- [ ] CI verde
- [ ] Code review humano

Refs: US-FIN-044 PR1 · [ADR 0170 §4f.sicoob_api](memory/decisions/0170-bancos-nativos-top5-drivers-separados.md) · [memory/requisitos/Financeiro/SPEC.md#US-FIN-044](memory/requisitos/Financeiro/SPEC.md)