### PR TITLE
hotfix(ci/deploy): desabilitar route:cache (routes-v7.php some em prod)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -129,6 +129,16 @@ jobs:
         run: /tmp/ssh_exec.sh "cd /home/u906587222/domains/oimpresso.com/public_html && php artisan ${{ inputs.extra_artisan }} 2>&1 | tail -30"
 
       - name: Clear caches + re-cache
+        # Wagner 2026-05-27 HOTFIX: removido `php artisan route:cache` — em prod o arquivo
+        # `bootstrap/cache/routes-v7.php` é gerado OK no deploy, smoke /login retorna 200,
+        # mas LOGO DEPOIS o arquivo SUMME (algum cron/job/shared-hosting cleanup destrói),
+        # quebrando TODA request autenticada subsequente com:
+        #   "Failed opening required '.../bootstrap/cache/routes-v7.php'
+        #    at RouteServiceProvider.php:150"
+        # Sintoma: Larissa @ Rota Livre travada em /ia/dashboard 500 (deploy 26512430704
+        # logo após hotfix #1716 que resolveu ClientFeedback bootstrap).
+        # Trade-off: routes resolvidas em runtime (latência ~10-30ms a mais por request),
+        # mas prod estável. Investigação root cause em PR separado (ver tail laravel.log).
         run: |
           /tmp/ssh_exec.sh "
             cd /home/u906587222/domains/oimpresso.com/public_html &&
@@ -136,8 +146,7 @@ jobs:
             php artisan route:clear &&
             php artisan view:clear &&
             php artisan cache:clear &&
-            php artisan config:cache &&
-            php artisan route:cache
+            php artisan config:cache
           "
 
       - name: Package discover


### PR DESCRIPTION
## Sintoma

Larissa @ Rota Livre (biz=4) bloqueada em /ia/dashboard com HTTP 500 confirmado via Chrome MCP. Hotfix #1716 resolveu o anterior (ClientFeedback bootstrap) mas surgiu novo erro:

\`\`\`
[2026-05-27 10:01:11] live.ERROR: Failed opening required '...bootstrap/cache/routes-v7.php'
  at RouteServiceProvider.php:150
\`\`\`

## Sequência observada (deploy 26512430704)

| t | evento |
|---|---|
| 12:59:58 UTC | route:cache → "Routes cached successfully" ✅ |
| 13:00:05 UTC | chmod -R 775 bootstrap/cache |
| 13:00:07 UTC | php artisan up |
| 13:00:10 UTC | smoke /login → HTTP 200 (file OK) |
| 13:00:12-13:01:06 UTC | schedulers ADS rodam (auto_task_generator, planner, brain_b) |
| 13:01:11 UTC | /ia/dashboard → 500 (routes-v7.php SUMME) |

## Root cause em aberto

Hipóteses:
- Hostinger shared hosting tem auto-cleanup de cache dirs
- Algum job ADS chama route:clear/optimize:clear indiretamente
- Permissão filesystem inconsistente SSH user ↔ PHP-FPM user

## Fix conservador

Remove \`php artisan route:cache\` do pipeline. Laravel resolve rotas em runtime — latência +10-30ms por request, mas prod estável.

Mantidos:
- \`route:clear\` (estado limpo pós-deploy)
- \`config:cache\` (sem evidência de problema com config-v7.php)

## Test plan

- [x] PR aberto pós-investigação (deploy 26512430704 tail log)
- [ ] Deploy do hotfix
- [ ] Wagner valida /ia/dashboard 200 estável
- [ ] Larissa @ Rota Livre consegue acessar

## Próximo PR (não bloqueante)

Investigar quem destrói \`bootstrap/cache/routes-v7.php\` via SSH Hostinger + lsof/fanotify. Possível mover cache pra diretório alternativo fora de bootstrap/cache/.

## Refs
- Incident: deploy run [26512430704](https://github.com/wagnerra23/oimpresso.com/actions/runs/26512430704)
- PR anterior: [#1716](https://github.com/wagnerra23/oimpresso.com/pull/1716) (ClientFeedback bootstrap)
- [ADR 0062](memory/decisions/0062-separacao-runtime-hostinger-ct100.md) Hostinger ≠ CT 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)