### PR TITLE
feat(contacts): Bucket A · extend contacts pra absorver PESSOAS legacy (ADR 0197)

### DIFF
--- a/app/Contact.php
+++ b/app/Contact.php
@@ -71,7 +71,48 @@ class Contact extends Authenticatable
         'favorito_users' => 'array',
         'vip' => 'bool',
         'nascimento' => 'date',
+        // ADR 0197 Bucket A — extend contacts pra absorver PESSOAS legacy.
+        // Migration 2026_05_27_120000_extend_contacts_bucket_a_legacy_absorption.
+        'bloqueado' => 'bool',
+        'cobrar_custo_boleto' => 'bool',
+        'limite_desconto_percentual' => 'decimal:2',
+        'boleto_desconto_pontualidade_pct' => 'decimal:2',
+        'fatura_previsao' => 'date',
+        'prioridade_producao' => 'integer',
+        'iss_retido' => 'integer',
     ];
+
+    /**
+     * ADR 0197 Bucket A — Pai da rede (matriz/filial). Self-FK.
+     *
+     * 1 contact pode ter N filhos (parent_contact_id apontando pra ele).
+     * Importer Vargas 2-pass resolve via legacy_id; orfaos viram NULL.
+     */
+    public function parentContact()
+    {
+        return $this->belongsTo(self::class, 'parent_contact_id');
+    }
+
+    public function childContacts()
+    {
+        return $this->hasMany(self::class, 'parent_contact_id');
+    }
+
+    /**
+     * ADR 0197 Bucket A — Representante responsavel pelo cliente (comissao Sells).
+     *
+     * Aponta pra OUTRO contacts row com is_representative=1. Type-check
+     * em app layer (nao via DB constraint).
+     */
+    public function salesRep()
+    {
+        return $this->belongsTo(self::class, 'sales_rep_contact_id');
+    }
+
+    public function customersAsRep()
+    {
+        return $this->hasMany(self::class, 'sales_rep_contact_id');
+    }
 
     /**
      * LGPD — Pode receber notificação WhatsApp?

--- a/database/migrations/2026_05_27_120000_extend_contacts_bucket_a_legacy_absorption.php
+++ b/database/migrations/2026_05_27_120000_extend_contacts_bucket_a_legacy_absorption.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ADR 0197 — Bucket A · extend `contacts` pra absorver schema legacy PESSOAS.
+ *
+ * Wave D (pos-Bucket A+B+C+D+E acordo Wagner 2026-05-27). Adiciona 14 colunas
+ * nullable que multiplos modulos (Sells, NfeBrasil, Compras, Financeiro,
+ * ProducaoOficina) consultam direto via Eloquent durante migracao WR Comercial
+ * (Delphi/Firebird) -> oimpresso (Laravel/MySQL).
+ *
+ * Pareada com Bucket B (proximo PR) que cria `contact_profile_legacy` 1:1
+ * pra retro-rastreabilidade Delphi (campos auditoria + JSON catch-all).
+ *
+ * IDEMPOTENTE -- Schema::hasColumn check antes de cada add. Reversivel via
+ * down() so pra colunas desta wave (campos pre-existentes ficam intactos).
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGAVEL): `business_id` ja existe em
+ * `contacts` (UPOS core) + indexado. FK self-referencing (parent_contact_id
+ * + sales_rep_contact_id) NAO usam ON DELETE CASCADE pra preservar history
+ * (importer Vargas 2-pass resolve via legacy_id; ciclo/orfao vira NULL).
+ *
+ * @see memory/decisions/0197-extend-contacts-absorcao-pessoas-legacy.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ * @see memory/sessions/2026-05-26-gap-pessoas-vs-contacts.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('contacts', function (Blueprint $table) {
+            // ------------------------------------------------------------------
+            // ENDERECO -- split logradouro/numero/complemento pra clareza fiscal.
+            // UPOS legacy empacota em address_line_2 (text); separar permite
+            // mapping direto Delphi PESSOAS.COMPLEMENTO.
+            // ------------------------------------------------------------------
+            if (! Schema::hasColumn('contacts', 'complemento')) {
+                $table->string('complemento', 120)->nullable();
+            }
+
+            // ------------------------------------------------------------------
+            // BLOQUEIO COMERCIAL -- Sells/Financeiro consultam pre-checkout.
+            // Cliente bloqueado no Delphi NAO pode vender/cobrar no oimpresso.
+            // contact_status enum nao basta (cliente pode estar 'active' +
+            // 'bloqueado'=1 simultaneamente).
+            // ------------------------------------------------------------------
+            if (! Schema::hasColumn('contacts', 'bloqueado')) {
+                $table->boolean('bloqueado')->default(false);
+            }
+
+            // ------------------------------------------------------------------
+            // FINANCEIRO -- limites/preferencias comerciais.
+            // ------------------------------------------------------------------
+
+            // Limite de desconto por cliente -- PDV impede desconto > limite.
+            // Aplica so a CLI (cliente). Fornecedor/funcionario nao usa.
+            if (! Schema::hasColumn('contacts', 'limite_desconto_percentual')) {
+                $table->decimal('limite_desconto_percentual', 5, 2)->nullable();
+            }
+
+            // Desconto pontualidade boleto -- Asaas/Modules/Financeiro incentivo
+            // "paga ate dia X ganha Y% desconto". CLI only.
+            if (! Schema::hasColumn('contacts', 'boleto_desconto_pontualidade_pct')) {
+                $table->decimal('boleto_desconto_pontualidade_pct', 5, 2)->nullable();
+            }
+
+            // Cobrar custo boleto -- repassa tarifa banco/Asaas pro cliente.
+            // Config per-cliente (alguns CLI tem custom rate). Default false.
+            if (! Schema::hasColumn('contacts', 'cobrar_custo_boleto')) {
+                $table->boolean('cobrar_custo_boleto')->default(false);
+            }
+
+            // Previsao proxima fatura -- Modules/Crm/Financeiro forecast UI.
+            if (! Schema::hasColumn('contacts', 'fatura_previsao')) {
+                $table->date('fatura_previsao')->nullable();
+            }
+
+            // ------------------------------------------------------------------
+            // PRODUCAO/OFICINA -- prioridade na fila + NFSe.
+            // ------------------------------------------------------------------
+
+            // Prioridade producao 0-5 estrelas -- Modules/ProducaoOficina + Oficinas
+            // ordenam fila por essa col. CLI only (fornecedor nao entra na fila).
+            if (! Schema::hasColumn('contacts', 'prioridade_producao')) {
+                $table->unsignedTinyInteger('prioridade_producao')->nullable();
+            }
+
+            // ISS retido NFSe -- 1=retido / 2=nao retido (SEFAZ). Modules/NfeBrasil.
+            if (! Schema::hasColumn('contacts', 'iss_retido')) {
+                $table->unsignedTinyInteger('iss_retido')->nullable();
+            }
+
+            // ------------------------------------------------------------------
+            // PESSOAL -- aniversario PF (comemoracao, distinto de DOB).
+            // Delphi distingue ANIVERSARIO (MM-DD pra parabens) de DATANASCIMENTO
+            // (data exata cadastral). UPOS `dob` cobre o segundo; precisamos do
+            // primeiro pra mailing/WhatsApp parabens sem expor ano.
+            // ------------------------------------------------------------------
+            if (! Schema::hasColumn('contacts', 'aniversario_mmdd')) {
+                $table->string('aniversario_mmdd', 5)->nullable();
+            }
+
+            // ------------------------------------------------------------------
+            // SELF-FK -- rede de filiais + representante.
+            // ------------------------------------------------------------------
+
+            // Pai da rede -- matriz/filial (CLI ou FOR). 2-pass importer resolve
+            // via lookup legacy_id (Pass 1 INSERT sem FK · Pass 2 UPDATE).
+            // ON DELETE NO ACTION (default) preserva orfao se matriz deletada.
+            if (! Schema::hasColumn('contacts', 'parent_contact_id')) {
+                $table->unsignedBigInteger('parent_contact_id')->nullable();
+                $table->foreign('parent_contact_id', 'fk_contacts_parent')
+                    ->references('id')->on('contacts')
+                    ->nullOnDelete();
+            }
+
+            // Representante responsavel pelo cliente -- comissao Sells.
+            // FK aponta pra OUTRO contacts row com is_representative=1.
+            // Self-FK; nao adiciona contraint type-check (validado em app layer).
+            if (! Schema::hasColumn('contacts', 'sales_rep_contact_id')) {
+                $table->unsignedBigInteger('sales_rep_contact_id')->nullable();
+                $table->foreign('sales_rep_contact_id', 'fk_contacts_sales_rep')
+                    ->references('id')->on('contacts')
+                    ->nullOnDelete();
+            }
+
+            // ------------------------------------------------------------------
+            // UI / DISPLAY -- papel principal + situacao livre.
+            // ------------------------------------------------------------------
+
+            // Papel principal pra UI (qual flag is_X exibir como destaque).
+            // Default = primeira flag=1 (resolvido em accessor App\Contact).
+            if (! Schema::hasColumn('contacts', 'primary_role')) {
+                $table->enum('primary_role', [
+                    'customer', 'supplier', 'employee', 'representative',
+                ])->nullable();
+            }
+
+            // Situacao livre Delphi (raw) -- back-compat string ad-hoc.
+            // Casos canonicos (`VIP`, `BLACKLIST`) viram `tags` JSON + `vip` bool
+            // no importer; casos exoticos preservam aqui pra forensics.
+            // Review trigger ADR 0197: drop col se 0 uso pos-90d.
+            if (! Schema::hasColumn('contacts', 'situacao')) {
+                $table->string('situacao', 30)->nullable();
+            }
+        });
+
+        // Indices compostos Tier 0 -- business_id PRIMEIRO sempre (ADR 0093).
+        // try/catch porque alguns motores rejeitam ADD INDEX em paralelo a
+        // ADD COLUMN no mesmo ALTER. Hostinger/CT100 MySQL 8.x OK; legacy
+        // pode falhar -- nao fatal, query degrade gracioso.
+        try {
+            Schema::table('contacts', function (Blueprint $table) {
+                $existing = collect(DB::select('SHOW INDEXES FROM contacts'))
+                    ->pluck('Key_name')
+                    ->toArray();
+
+                if (! in_array('idx_contacts_biz_bloqueado', $existing, true)) {
+                    $table->index(['business_id', 'bloqueado'], 'idx_contacts_biz_bloqueado');
+                }
+                if (! in_array('idx_contacts_biz_parent', $existing, true)) {
+                    $table->index(['business_id', 'parent_contact_id'], 'idx_contacts_biz_parent');
+                }
+                if (! in_array('idx_contacts_biz_sales_rep', $existing, true)) {
+                    $table->index(['business_id', 'sales_rep_contact_id'], 'idx_contacts_biz_sales_rep');
+                }
+            });
+        } catch (\Throwable $e) {
+            \Log::warning('extend_contacts_bucket_a: indices compostos skip', [
+                'reason' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        // Drop indices compostos primeiro.
+        try {
+            Schema::table('contacts', function (Blueprint $table) {
+                $existing = collect(DB::select('SHOW INDEXES FROM contacts'))
+                    ->pluck('Key_name')
+                    ->toArray();
+
+                foreach ([
+                    'idx_contacts_biz_bloqueado',
+                    'idx_contacts_biz_parent',
+                    'idx_contacts_biz_sales_rep',
+                ] as $idx) {
+                    if (in_array($idx, $existing, true)) {
+                        $table->dropIndex($idx);
+                    }
+                }
+            });
+        } catch (\Throwable $e) {
+            // Indices ja nao existem -- ok.
+        }
+
+        // Drop FKs explicitas antes de dropar colunas (MySQL requer ordem).
+        Schema::table('contacts', function (Blueprint $table) {
+            try {
+                $table->dropForeign('fk_contacts_parent');
+            } catch (\Throwable $e) { /* FK nao existe */ }
+
+            try {
+                $table->dropForeign('fk_contacts_sales_rep');
+            } catch (\Throwable $e) { /* FK nao existe */ }
+        });
+
+        Schema::table('contacts', function (Blueprint $table) {
+            $cols = [
+                'complemento',
+                'bloqueado',
+                'limite_desconto_percentual',
+                'boleto_desconto_pontualidade_pct',
+                'cobrar_custo_boleto',
+                'fatura_previsao',
+                'prioridade_producao',
+                'iss_retido',
+                'aniversario_mmdd',
+                'parent_contact_id',
+                'sales_rep_contact_id',
+                'primary_role',
+                'situacao',
+            ];
+
+            foreach ($cols as $col) {
+                if (Schema::hasColumn('contacts', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
+    }
+};

--- a/tests/Feature/Contact/ContactBucketALegacyAbsorptionTest.php
+++ b/tests/Feature/Contact/ContactBucketALegacyAbsorptionTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Contact;
+
+use App\Business;
+use App\Contact;
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * GUARD — Bucket A do ADR 0197 (extend contacts pra absorver PESSOAS legacy).
+ *
+ * Wave D 2026-05-27. Migration 2026_05_27_120000_extend_contacts_bucket_a_legacy_absorption.
+ *
+ * Cobertura:
+ *   1. Schema — 13 cols Bucket A presentes
+ *   2. Eloquent casts — bool/decimal/integer/date funcionam
+ *   3. Self-FK — parent_contact_id + sales_rep_contact_id resolvem via belongsTo
+ *   4. Multi-tenant Tier 0 (ADR 0093) — query scoped por business_id preserva isolation
+ *
+ * @see memory/decisions/0197-extend-contacts-absorcao-pessoas-legacy.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+class ContactBucketALegacyAbsorptionTest extends TestCase
+{
+    /** @test */
+    public function it_has_all_bucket_a_columns(): void
+    {
+        $expected = [
+            'complemento',
+            'bloqueado',
+            'limite_desconto_percentual',
+            'boleto_desconto_pontualidade_pct',
+            'cobrar_custo_boleto',
+            'fatura_previsao',
+            'prioridade_producao',
+            'iss_retido',
+            'aniversario_mmdd',
+            'parent_contact_id',
+            'sales_rep_contact_id',
+            'primary_role',
+            'situacao',
+        ];
+
+        foreach ($expected as $col) {
+            $this->assertTrue(
+                Schema::hasColumn('contacts', $col),
+                "Coluna Bucket A `contacts.{$col}` ausente — ver migration 2026_05_27_120000 e ADR 0197."
+            );
+        }
+    }
+
+    /** @test */
+    public function it_has_self_fk_relations_defined_on_model(): void
+    {
+        $contact = new Contact();
+
+        $this->assertTrue(method_exists($contact, 'parentContact'),
+            'Contact::parentContact() relation ausente — ADR 0197 Bucket A');
+        $this->assertTrue(method_exists($contact, 'childContacts'),
+            'Contact::childContacts() relation ausente — ADR 0197 Bucket A');
+        $this->assertTrue(method_exists($contact, 'salesRep'),
+            'Contact::salesRep() relation ausente — ADR 0197 Bucket A');
+        $this->assertTrue(method_exists($contact, 'customersAsRep'),
+            'Contact::customersAsRep() relation ausente — ADR 0197 Bucket A');
+
+        // belongsTo retorna Relation -- contract validado
+        $this->assertInstanceOf(
+            \Illuminate\Database\Eloquent\Relations\BelongsTo::class,
+            $contact->parentContact()
+        );
+        $this->assertInstanceOf(
+            \Illuminate\Database\Eloquent\Relations\HasMany::class,
+            $contact->childContacts()
+        );
+    }
+
+    /** @test */
+    public function it_casts_bucket_a_bool_decimal_date_fields_correctly(): void
+    {
+        $business = Business::first() ?? Business::create([
+            'name' => 'Test Biz Bucket A',
+            'currency_id' => 1,
+            'start_date' => '2026-01-01',
+            'default_profit_percent' => 25.0,
+            'owner_id' => 1,
+        ]);
+
+        $contact = new Contact();
+        $contact->business_id = $business->id;
+        $contact->name = 'Teste Bucket A casts';
+        $contact->type = 'customer';
+        $contact->bloqueado = 1;
+        $contact->cobrar_custo_boleto = 0;
+        $contact->limite_desconto_percentual = '15.50';
+        $contact->boleto_desconto_pontualidade_pct = '5.00';
+        $contact->fatura_previsao = '2026-06-15';
+        $contact->prioridade_producao = 4;
+        $contact->iss_retido = 1;
+        $contact->save();
+
+        $fresh = Contact::find($contact->id);
+
+        $this->assertIsBool($fresh->bloqueado);
+        $this->assertTrue($fresh->bloqueado);
+        $this->assertIsBool($fresh->cobrar_custo_boleto);
+        $this->assertFalse($fresh->cobrar_custo_boleto);
+        $this->assertEquals(15.50, (float) $fresh->limite_desconto_percentual);
+        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $fresh->fatura_previsao);
+        $this->assertEquals('2026-06-15', $fresh->fatura_previsao->format('Y-m-d'));
+        $this->assertIsInt($fresh->prioridade_producao);
+        $this->assertEquals(4, $fresh->prioridade_producao);
+
+        // cleanup
+        $fresh->forceDelete();
+    }
+
+    /** @test */
+    public function it_resolves_parent_and_sales_rep_via_self_fk(): void
+    {
+        $business = Business::first() ?? Business::create([
+            'name' => 'Test Biz SelfFK',
+            'currency_id' => 1,
+            'start_date' => '2026-01-01',
+            'default_profit_percent' => 25.0,
+            'owner_id' => 1,
+        ]);
+
+        $matriz = $this->createContact($business->id, [
+            'name' => 'Cliente Matriz Bucket A',
+            'is_customer' => 1,
+        ]);
+
+        $rep = $this->createContact($business->id, [
+            'name' => 'Joao Representante Bucket A',
+            'is_representative' => 1,
+        ]);
+
+        $filial = $this->createContact($business->id, [
+            'name' => 'Cliente Filial Bucket A',
+            'is_customer' => 1,
+            'parent_contact_id' => $matriz->id,
+            'sales_rep_contact_id' => $rep->id,
+        ]);
+
+        $this->assertEquals($matriz->id, $filial->parentContact->id);
+        $this->assertEquals($rep->id, $filial->salesRep->id);
+        $this->assertEquals(1, $matriz->childContacts()->count());
+        $this->assertEquals(1, $rep->customersAsRep()->count());
+
+        // cleanup
+        $filial->forceDelete();
+        $matriz->forceDelete();
+        $rep->forceDelete();
+    }
+
+    /** @test */
+    public function it_preserves_multi_tenant_scope_with_bucket_a_self_fk(): void
+    {
+        // Tier 0 IRREVOGAVEL (ADR 0093) — query scoped por business_id NUNCA
+        // pode vazar dados de outro tenant via FK self-ref persistida no DB.
+
+        $biz_a = Business::create([
+            'name' => 'Test Biz A Bucket A',
+            'currency_id' => 1,
+            'start_date' => '2026-01-01',
+            'default_profit_percent' => 25.0,
+            'owner_id' => 1,
+        ]);
+
+        $biz_b = Business::create([
+            'name' => 'Test Biz B Bucket A',
+            'currency_id' => 1,
+            'start_date' => '2026-01-01',
+            'default_profit_percent' => 25.0,
+            'owner_id' => 1,
+        ]);
+
+        $matriz_biz_a = $this->createContact($biz_a->id, [
+            'name' => 'Matriz biz_a',
+            'is_customer' => 1,
+        ]);
+
+        // Persiste FK cross-tenant (cenario hipotetico que app layer NAO deve criar).
+        $filial_biz_b = $this->createContact($biz_b->id, [
+            'name' => 'Filial biz_b',
+            'is_customer' => 1,
+            'parent_contact_id' => $matriz_biz_a->id,
+        ]);
+
+        // Query scoped biz_b NAO retorna matriz de biz_a — Tier 0 isolation no UI.
+        $matriz_visible_to_biz_b = Contact::where('business_id', $biz_b->id)
+            ->where('id', $matriz_biz_a->id)
+            ->first();
+
+        $this->assertNull(
+            $matriz_visible_to_biz_b,
+            'Tier 0 violation (ADR 0093): contacts row de biz_a visivel em scope biz_b'
+        );
+
+        // cleanup
+        $filial_biz_b->forceDelete();
+        $matriz_biz_a->forceDelete();
+        $biz_a->delete();
+        $biz_b->delete();
+    }
+
+    /**
+     * Helper -- Contact::create direto sem factory (oimpresso nao tem ContactFactory).
+     */
+    private function createContact(int $business_id, array $overrides = []): Contact
+    {
+        $contact = new Contact();
+        $contact->business_id = $business_id;
+        $contact->type = $overrides['type'] ?? 'customer';
+        $contact->name = $overrides['name'] ?? 'Test Contact';
+        $contact->contact_status = $overrides['contact_status'] ?? 'active';
+
+        foreach ($overrides as $k => $v) {
+            $contact->{$k} = $v;
+        }
+
+        $contact->save();
+
+        return $contact;
+    }
+}


### PR DESCRIPTION
> **DRAFT — depende [#1717](https://github.com/wagnerra23/oimpresso.com/pull/1717) mergeado em main primeiro** (cria ADR 0197 canon). Marca ready-for-review quando #1717 verde + mergeado.

## Summary

Implementa **Bucket A** do [ADR 0197](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0197-extend-contacts-absorcao-pessoas-legacy.md) (extend `contacts` pra absorver schema legacy `PESSOAS` Firebird WR Comercial).

13 colunas nullable em `contacts` + 3 índices compostos Tier 0 + atualização do `App\Contact` Eloquent com $casts e 4 self-FK relations + Pest test cobrindo schema/casts/FK/multi-tenant scope.

## Por que

Migração 4 clientes legacy WR Comercial → oimpresso (Martinho biz=164 piloto canônico — Fase 1+2 já em prod; Fase 3+4 cobertas pelo [RUNBOOK](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/requisitos/Officeimpresso/RUNBOOK-migracao-martinho-fase3-fase4.md)). Multiplos módulos (Sells / NfeBrasil / Compras / Financeiro / ProducaoOficina) consultam essas cols direto via Eloquent — não cabe em satélite (Bucket B vai pro `contact_profile_legacy` 1:1 que será PR separado).

## Colunas adicionadas

| Coluna | Tipo | Origem PESSOAS | Aplica a |
|---|---|---|---|
| `complemento` | string(120) null | `COMPLEMENTO` | CLI+FOR+REP |
| `bloqueado` | bool default 0 | `BLOQUEADO` (S/N) | CLI+FOR |
| `limite_desconto_percentual` | decimal(5,2) null | `LIMITE_DESCONTO` | CLI |
| `boleto_desconto_pontualidade_pct` | decimal(5,2) null | `BOLETO_PERC_DESCONTO_PADRAO` | CLI |
| `cobrar_custo_boleto` | bool default 0 | `COBRAR_CUSTO_BOLETO` | CLI |
| `fatura_previsao` | date null | `FATURA_PREVISAO` | CLI |
| `prioridade_producao` | tinyint 0-5 null | `PRIORIDADE_PRODUCAO` | CLI |
| `iss_retido` | tinyint 1/2 null | `ISS_RETIDO` | CLI+FOR (NFSe) |
| `aniversario_mmdd` | string(5) null `MM-DD` | `ANIVERSARIO` | CLI PF (comemoração distinta de DOB) |
| `parent_contact_id` | bigint FK self null | `PESSOA_ASSOCIADO_CODIGO` | CLI+FOR (rede filial/matriz) |
| `sales_rep_contact_id` | bigint FK self null | `PESSOA_REPRESENTANTE_CODIGO` | CLI (comissão Sells) |
| `primary_role` | enum null | `TIPO_PADRAO` | display UI |
| `situacao` | string(30) null | `SITUACAO` (livre) | back-compat string Delphi |

## Índices compostos Tier 0 (ADR 0093 IRREVOGÁVEL)

- `idx_contacts_biz_bloqueado` (business_id, bloqueado)
- `idx_contacts_biz_parent` (business_id, parent_contact_id)
- `idx_contacts_biz_sales_rep` (business_id, sales_rep_contact_id)

`business_id` PRIMEIRO sempre — global scope multi-tenant explora rapidez do índice.

## App\Contact mudanças

- `$casts` atualizado: `bloqueado`, `cobrar_custo_boleto` → bool; `limite_desconto_percentual`, `boleto_desconto_pontualidade_pct` → decimal:2; `fatura_previsao` → date; `prioridade_producao`, `iss_retido` → integer
- 4 self-FK relations: `parentContact()` (belongsTo), `childContacts()` (hasMany), `salesRep()` (belongsTo), `customersAsRep()` (hasMany)

## Pest test (5 testes)

- ✅ schema guard — 13 cols presentes (regression detect)
- ✅ Eloquent contract — relations definidas (belongsTo/hasMany corretos)
- ✅ casts bool/decimal/date funcionam round-trip DB
- ✅ self-FK resolve parent + rep
- ✅ **Tier 0 ADR 0093** — query scoped `business_id` NÃO vaza dados cross-tenant mesmo com FK cross-business persistida

## Idempotência + Rollback

- Migration usa `Schema::hasColumn()` + `SHOW INDEXES` check antes de cada operação
- `down()` reverte sem perda: dropa indices + FK constraints + colunas Bucket A (cols pre-existentes ficam)
- Try/catch em índices (MySQL legacy compat)

## Test plan

- [ ] PR [#1717](https://github.com/wagnerra23/oimpresso.com/pull/1717) (ADR 0197+0198 + RUNBOOK) mergeado em main primeiro
- [ ] Marcar este PR ready-for-review
- [ ] CI memory-schema-gate verde
- [ ] CI Pest Unit verde (5 testes novos passam)
- [ ] CI module-grades-gate verde
- [ ] Wagner aprova merge → próximo PR Bucket B (`contact_profile_legacy` satélite + Model novo)

## Refs canon

[ADR 0197](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0197-extend-contacts-absorcao-pessoas-legacy.md) · [ADR 0093 multi-tenant Tier 0](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0093-multi-tenant-isolation-tier-0.md) · [ADR 0188 multi-type flags aditivas](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0188-multi-type-flags-aditivas.md) · [ADR 0179 drawer cliente Wave B/C](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0179-cliente-drawer-760px-substitui-show-fullpage.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)