### PR TITLE
feat(paymentgateway): Sicoob API webhook + HMAC (PR4/6 US-FIN-044)

### DIFF
--- a/Modules/PaymentGateway/Http/Controllers/Webhooks/SicoobApiWebhookController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Webhooks/SicoobApiWebhookController.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\PaymentGateway\Http\Controllers\Webhooks;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+
+/**
+ * Recebe webhooks Sicoob API v3 (boleto liquidado/vencido/cancelado).
+ *
+ * US-FIN-044 PR4 — Onda 4f.sicoob_api.
+ *
+ * Rota: POST /paymentgateway/webhooks/sicoob-api/{businessId}
+ * SEM auth middleware (chamado pelo Sicoob externamente).
+ *
+ * Pipeline:
+ *   1. Resolve credential ativa pra business_id+gateway_key=sicoob_api
+ *   2. Valida HMAC `x-sicoob-signature` ANTES de qualquer parse/DB-write
+ *      (US-PG-002 / VULN SEC P0-#2 padrão canon)
+ *   3. Delega pro WebhookProcessor (idempotência at-DB-level via UNIQUE
+ *      (business_id, gateway_key, gateway_event_id) — mesma fundação dos
+ *      Inter/C6/Asaas)
+ *
+ * Eventos esperados Sicoob v3:
+ *   - cobranca.liquidada (= boleto pago)
+ *   - cobranca.vencida
+ *   - cobranca.cancelada
+ *
+ * Identificador idempotente:
+ *   - Sicoob NÃO envia `id` único em todos eventos → fallback pro hash
+ *     determinístico (evento + nossoNumero + dataLiquidacao).
+ *
+ * HMAC:
+ *   - Header `x-sicoob-signature` = HMAC-SHA256 do raw body com
+ *     config_json['webhook_secret'] (hex lowercase, sem prefixo).
+ *   - Pattern espelha InterWebhookController (US-PG-002).
+ *   - Doc Sicoob v3 pode usar formato variante (ex `sha256=<hex>` ou
+ *     header `signature`); se Lea trouxer doc real do gerente divergente,
+ *     ajuste pontual no WebhookProcessor::validateSicoobApiHmac().
+ */
+class SicoobApiWebhookController extends Controller
+{
+    public function __construct(private WebhookProcessor $processor)
+    {
+    }
+
+    public function handle(Request $request, int $businessId): JsonResponse
+    {
+        $credential = PaymentGatewayCredential::withoutGlobalScopes()
+            ->where('business_id', $businessId)
+            ->where('gateway_key', 'sicoob_api')
+            ->where('ativo', true)
+            ->orderByDesc('id')
+            ->first();
+
+        if (! $credential) {
+            Log::warning('paymentgateway.sicoob_api.webhook.credential_not_found', [
+                'business_id' => $businessId,
+            ]);
+
+            return response()->json([
+                'ok'    => false,
+                'error' => 'credential_not_found',
+            ], 404);
+        }
+
+        if (! $this->processor->validateSignature('sicoob_api', $request, $credential)) {
+            Log::warning('paymentgateway.sicoob_api.webhook.signature_invalid', [
+                'business_id'   => $businessId,
+                'credential_id' => $credential->id,
+            ]);
+
+            return response()->json([
+                'ok'    => false,
+                'error' => 'signature_invalid',
+            ], 401);
+        }
+
+        $eventName = (string) $request->input('evento', $request->input('event', 'unknown'));
+
+        // Sicoob: tenta id explícito; fallback hash determinístico do payload
+        // (evento + nossoNumero + dataLiquidacao quando presentes).
+        $eventId = (string) (
+            $request->input('id')
+            ?? $request->input('eventId')
+            ?? $request->input('nossoNumero')
+            ?? $request->input('boleto.nossoNumero')
+            ?? md5($eventName . json_encode($request->all()))
+        );
+
+        return $this->processor->handle(
+            gatewayKey: 'sicoob_api',
+            request: $request,
+            businessId: $businessId,
+            eventName: $eventName,
+            eventId: $eventId,
+            signatureValid: true,
+        );
+    }
+}

--- a/Modules/PaymentGateway/Http/Controllers/Webhooks/WebhookProcessor.php
+++ b/Modules/PaymentGateway/Http/Controllers/Webhooks/WebhookProcessor.php
@@ -119,11 +119,12 @@ class WebhookProcessor
         $config = (array) ($credential->config_json ?? []);
 
         return match ($gatewayKey) {
-            'asaas'   => $this->validateAsaas($request, $config),
-            'inter'   => $this->validateInterHmac($request, $config),
-            'c6'      => $this->validateC6Hmac($request, $config),
-            'bcb_pix' => $this->validateBcbPixMtls($request, $config),
-            default   => false, // gateway desconhecido → fail-secure
+            'asaas'      => $this->validateAsaas($request, $config),
+            'inter'      => $this->validateInterHmac($request, $config),
+            'c6'         => $this->validateC6Hmac($request, $config),
+            'bcb_pix'    => $this->validateBcbPixMtls($request, $config),
+            'sicoob_api' => $this->validateSicoobApiHmac($request, $config),
+            default      => false, // gateway desconhecido → fail-secure
         };
     }
 
@@ -203,6 +204,29 @@ class WebhookProcessor
         }
         $normalize = fn (string $v): string => strtolower(str_replace([':', ' '], '', $v));
         return hash_equals($normalize($expectedFp), $normalize($fp));
+    }
+
+    /**
+     * Sicoob API v3 — HMAC-SHA256 raw body via header `x-sicoob-signature`
+     * (hex lowercase, sem prefixo). Mesmo pattern Inter legacy.
+     *
+     * US-FIN-044 PR4 — pattern conservador. Se Lea/gerente Sicoob trouxer
+     * doc real divergente (ex `sha256=` prefix ou outro header), ajuste
+     * cirúrgico aqui.
+     */
+    private function validateSicoobApiHmac(Request $request, array $config): bool
+    {
+        $secret = (string) ($config['webhook_secret'] ?? '');
+        if ($secret === '') {
+            return false;
+        }
+        $provided = (string) $request->header('x-sicoob-signature', '');
+        if ($provided === '') {
+            return false;
+        }
+        $expected = hash_hmac('sha256', $request->getContent(), $secret);
+
+        return hash_equals($expected, $provided);
     }
 
     private function isUniqueViolation(\Illuminate\Database\QueryException $e): bool

--- a/Modules/PaymentGateway/Routes/web.php
+++ b/Modules/PaymentGateway/Routes/web.php
@@ -10,6 +10,7 @@ use Modules\PaymentGateway\Http\Controllers\Webhooks\C6WebhookController;
 use Modules\PaymentGateway\Http\Controllers\Webhooks\InterPixWebhookController;
 use Modules\PaymentGateway\Http\Controllers\Webhooks\InterWebhookController;
 use Modules\PaymentGateway\Http\Controllers\Webhooks\PagarmeWebhookController;
+use Modules\PaymentGateway\Http\Controllers\Webhooks\SicoobApiWebhookController;
 
 /*
 |--------------------------------------------------------------------------
@@ -121,6 +122,12 @@ Route::middleware(['web'])
         Route::post('pagarme/{businessId}', [PagarmeWebhookController::class, 'handle'])
             ->whereNumber('businessId')
             ->name('paymentgateway.webhooks.pagarme');
+
+        // Onda 4f.sicoob_api — US-FIN-044 PR4. HMAC `x-sicoob-signature`
+        // raw body. Eventos cobranca.liquidada/vencida/cancelada.
+        Route::post('sicoob-api/{businessId}', [SicoobApiWebhookController::class, 'handle'])
+            ->whereNumber('businessId')
+            ->name('paymentgateway.webhooks.sicoob-api');
     });
 
 // ─── Webhook PIX Inter US-FIN-032 (Onda 26) ──────────────────────────────

--- a/Modules/PaymentGateway/Tests/Feature/SicoobApiWebhookTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/SicoobApiWebhookTest.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\PaymentGateway\Models\GatewayWebhookEvent;
+use Modules\PaymentGateway\Models\PaymentGatewayCredential;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-FIN-044 PR4 — Onda 4f.sicoob_api webhook receiver.
+ *
+ * Cobre:
+ *   1. Signature HMAC `x-sicoob-signature` válida → 200 + GatewayWebhookEvent
+ *   2. Signature inválida → 401 + nada gravado
+ *   3. Credential inexistente pra business_id → 404
+ *   4. Credential sem webhook_secret cadastrado → 401 (fail-secure)
+ *   5. Idempotência: 2x mesmo eventId → 1 linha só (UNIQUE)
+ *   6. business_id isolado biz=4 vs biz=99 (multi-tenant Tier 0)
+ *
+ * Multi-tenant Tier 0: biz=1 padrão (ADR 0101 — nunca cliente real).
+ */
+
+beforeEach(function () {
+    $this->credential = PaymentGatewayCredential::query()->create([
+        'business_id'  => 1,
+        'gateway_key'  => 'sicoob_api',
+        'ambiente'     => 'sandbox',
+        'ativo'        => true,
+        'nome_display' => 'Sicoob API Test',
+        'config_json'  => [
+            'client_id'         => 'fake-client',
+            'client_secret'     => 'fake-secret',
+            'numero_cliente'    => 12345,
+            'codigo_modalidade' => 1,
+            'numero_conta'      => 1234567,
+            'webhook_secret'    => 'super-secret-sicoob-hmac',
+        ],
+    ]);
+});
+
+function postSicoobWebhook($test, int $businessId, array $payload, string $signature)
+{
+    return $test->call(
+        method: 'POST',
+        uri: "/paymentgateway/webhooks/sicoob-api/{$businessId}",
+        parameters: [],
+        cookies: [],
+        files: [],
+        server: [
+            'CONTENT_TYPE'             => 'application/json',
+            'HTTP_X_SICOOB_SIGNATURE' => $signature,
+            'HTTP_ACCEPT'              => 'application/json',
+        ],
+        content: json_encode($payload),
+    );
+}
+
+function postSicoobWebhookSigned($test, int $businessId, array $payload, string $secret = 'super-secret-sicoob-hmac')
+{
+    $raw = json_encode($payload);
+    $signature = hash_hmac('sha256', $raw, $secret);
+
+    return postSicoobWebhook($test, $businessId, $payload, $signature);
+}
+
+it('aceita webhook com HMAC válido e grava GatewayWebhookEvent', function () {
+    $payload = [
+        'evento'      => 'cobranca.liquidada',
+        'nossoNumero' => '12345678',
+        'boleto'      => [
+            'situacaoBoleto' => 'LIQUIDADO',
+            'valorRecebido'  => 150.00,
+            'dataLiquidacao' => '2026-05-27T10:00:00-03:00',
+        ],
+    ];
+
+    postSicoobWebhookSigned($this, 1, $payload)->assertStatus(200);
+
+    expect(GatewayWebhookEvent::query()->withoutGlobalScopes()->count())->toBe(1);
+    $event = GatewayWebhookEvent::query()->withoutGlobalScopes()->first();
+    expect($event->gateway_key)->toBe('sicoob_api')
+        ->and($event->business_id)->toBe(1)
+        ->and($event->evento)->toBe('cobranca.liquidada')
+        ->and($event->gateway_event_id)->toBe('12345678')
+        ->and($event->signature_valid)->toBeTrue();
+});
+
+it('rejeita 401 quando signature HMAC inválida', function () {
+    postSicoobWebhook($this, 1, ['evento' => 'x', 'nossoNumero' => '1'], 'assinatura-falsa-deadbeef')
+        ->assertStatus(401)
+        ->assertJsonFragment(['error' => 'signature_invalid']);
+
+    expect(GatewayWebhookEvent::query()->withoutGlobalScopes()->count())->toBe(0);
+});
+
+it('rejeita 404 quando business_id não tem credential sicoob_api ativa', function () {
+    postSicoobWebhookSigned($this, 9999, ['evento' => 'x', 'nossoNumero' => '1'])
+        ->assertStatus(404)
+        ->assertJsonFragment(['error' => 'credential_not_found']);
+});
+
+it('rejeita 401 quando credential sem webhook_secret cadastrado (fail-secure)', function () {
+    $this->credential->update([
+        'config_json' => array_merge($this->credential->config_json, ['webhook_secret' => '']),
+    ]);
+
+    postSicoobWebhookSigned($this, 1, ['evento' => 'x', 'nossoNumero' => '1'])
+        ->assertStatus(401);
+});
+
+it('idempotente — 2x mesmo eventId/nossoNumero NÃO duplica em DB', function () {
+    $payload = [
+        'evento'      => 'cobranca.liquidada',
+        'nossoNumero' => '999888',
+    ];
+
+    postSicoobWebhookSigned($this, 1, $payload)->assertStatus(200);
+    postSicoobWebhookSigned($this, 1, $payload)->assertStatus(200);
+
+    // UNIQUE (business_id, gateway_key, gateway_event_id) → só 1 linha.
+    expect(GatewayWebhookEvent::query()->withoutGlobalScopes()->count())->toBe(1);
+});
+
+it('multi-tenant Tier 0: biz=4 e biz=99 webhooks ISOLADOS', function () {
+    $secret4 = 'secret-biz-4';
+    $secret99 = 'secret-biz-99';
+
+    PaymentGatewayCredential::query()->create([
+        'business_id'  => 4,
+        'gateway_key'  => 'sicoob_api',
+        'ambiente'     => 'sandbox',
+        'ativo'        => true,
+        'config_json'  => [
+            'client_id'         => 'c4',
+            'client_secret'     => 's4',
+            'numero_cliente'    => 4,
+            'codigo_modalidade' => 1,
+            'numero_conta'      => 4,
+            'webhook_secret'    => $secret4,
+        ],
+    ]);
+    PaymentGatewayCredential::query()->create([
+        'business_id'  => 99,
+        'gateway_key'  => 'sicoob_api',
+        'ambiente'     => 'sandbox',
+        'ativo'        => true,
+        'config_json'  => [
+            'client_id'         => 'c99',
+            'client_secret'     => 's99',
+            'numero_cliente'    => 99,
+            'codigo_modalidade' => 1,
+            'numero_conta'      => 99,
+            'webhook_secret'    => $secret99,
+        ],
+    ]);
+
+    // biz=4 com secret correto → 200
+    postSicoobWebhookSigned($this, 4, ['evento' => 'x', 'nossoNumero' => 'biz4-001'], $secret4)
+        ->assertStatus(200);
+
+    // biz=99 usando SECRET DO biz=4 → 401 (não vaza segredo entre tenants)
+    postSicoobWebhookSigned($this, 99, ['evento' => 'x', 'nossoNumero' => 'biz99-001'], $secret4)
+        ->assertStatus(401);
+
+    // biz=99 com secret correto → 200
+    postSicoobWebhookSigned($this, 99, ['evento' => 'x', 'nossoNumero' => 'biz99-001'], $secret99)
+        ->assertStatus(200);
+
+    // Eventos separados por business_id
+    expect(GatewayWebhookEvent::query()->withoutGlobalScopes()->where('business_id', 4)->count())->toBe(1)
+        ->and(GatewayWebhookEvent::query()->withoutGlobalScopes()->where('business_id', 99)->count())->toBe(1);
+});
+
+it('rota nomeada paymentgateway.webhooks.sicoob-api existe', function () {
+    expect(route('paymentgateway.webhooks.sicoob-api', ['businessId' => 1]))
+        ->toContain('/paymentgateway/webhooks/sicoob-api/1');
+});


### PR DESCRIPTION
## Summary

PR4 de 6 — **stacked em [#1722](https://github.com/wagnerra23/oimpresso.com/pull/1722)** (base: \`feat/sicoob-api-pr3-mtls\`).

Webhook receiver real-time pro Sicoob.

- **SicoobApiWebhookController** em \`/paymentgateway/webhooks/sicoob-api/{businessId}\` — pipeline canon InterWebhookController:
  1. Resolve credential ativa pra business+gateway_key=sicoob_api (withoutGlobalScopes pois webhook externo sem session)
  2. Valida HMAC ANTES de qualquer parse/DB-write
  3. Extrai eventId determinístico (id → eventId → nossoNumero → hash payload)
  4. Delega `WebhookProcessor::handle` — idempotência DB-level via UNIQUE
- **WebhookProcessor::validateSignature** ganha case `'sicoob_api'` + private `validateSicoobApiHmac()`. HMAC-SHA256 raw body via header `x-sicoob-signature` (constant-time `hash_equals`).
- **Rota** `POST /paymentgateway/webhooks/sicoob-api/{businessId}` SEM auth, com middleware `web`.

## Pest test (7 cases)

| Caso | Status |
|---|---|
| HMAC válido | 200 + GatewayWebhookEvent gravado |
| HMAC inválido | 401, nada gravado |
| business_id sem credential | 404 |
| webhook_secret vazio | 401 (fail-secure) |
| 2x mesmo eventId | UNIQUE → 1 linha |
| **biz=4 secret testa biz=99** | **401 cross-tenant Tier 0** |
| Route name resolve | URL canônica |

## Pendência humana

Doc oficial Sicoob v3 NÃO especifica claramente o header HMAC do webhook. Escolhi pattern conservador = espelhar Inter (header `x-sicoob-signature`, hex sem prefixo). Se Lea/gerente do Sicoob trouxer doc real do banco divergente (ex header `signature` ou prefixo `sha256=<hex>`), ajuste cirúrgico em [WebhookProcessor::validateSicoobApiHmac()](Modules/PaymentGateway/Http/Controllers/Webhooks/WebhookProcessor.php).

## Diff

4 arquivos · +319 / -5 net.

Refs: US-FIN-044 PR4