### PR TITLE
hotfix(header): remover <script> com PHP cru (quebrava /sells/create JS)

### DIFF
--- a/resources/views/layouts/partials/header.blade.php
+++ b/resources/views/layouts/partials/header.blade.php
@@ -270,29 +270,12 @@
     </div>
 </div>
 
-<script>
-    //get color plate
-    if (!function_exists("get_custom_theme_color_list")) {
-
-        function get_custom_theme_color_list() {
-            //scan the css files for theme color and show a list
-            try {
-                $dir = getcwd() . '/assets/css/color/';
-                $files = scandir($dir);
-                if ($files && is_array($files)) {
-
-                    echo "<span class='color-tag clickable mr15 change-theme' data-color='F2F2F2' style='background:#F2F2F2'> </span>"; //default color
-
-                    foreach ($files as $file) {
-                        if ($file != "." && $file != ".." && $file != "index.html" && $file != ".DS_Store") {
-                            $color_code = str_replace(".css", "", $file);
-                            echo "<span class='color-tag clickable mr15 change-theme' style='background:#$color_code' data-color='$color_code'> </span>";
-                        }
-                    }
-                }
-            } catch (\Exception $exc) {
-            }
-        }
-    }
-</script>
+{{-- Wagner 2026-05-27 HOTFIX: removido bloco <script> com código PHP cru (legacy UltimatePOS).
+     `if (!function_exists("get_custom_theme_color_list"))` + scandir() vazavam PHP pra dentro
+     de tag <script> HTML — browser interpretava como JS e quebrava com
+     "SyntaxError: Unexpected string" na linha 1554 do HTML rendered, paralisando
+     interatividade da /sells/create (consultar produto / consultar cliente,
+     dores reportadas pela Larissa @ Rota Livre).
+     Função get_custom_theme_color_list() é código morto — `grep` confirma que
+     não é chamada em nenhum lugar do projeto (theme picker legacy desabilitado). --}}
 


### PR DESCRIPTION
## Sintoma

Larissa @ Rota Livre disse "tela de venda horrível, blade estava funcionando". Após 3 hotfixes destravarem /ia/dashboard (PRs #1716/#1719/#1721), descoberto que **/sells/create renderiza HTTP 200 mas tem SyntaxError JS** paralisando interatividade.

\`\`\`
Uncaught SyntaxError: Unexpected string
at https://oimpresso.com/sells/create:1554:34
\`\`\`

## Root cause

\`resources/views/layouts/partials/header.blade.php:273-297\` tem **código PHP DENTRO de tag \`<script>\`** sem \`@php\` / \`<?php\`:

\`\`\`html
<script>
    //get color plate
    if (!function_exists("get_custom_theme_color_list")) {
        function get_custom_theme_color_list() {
            \$dir = getcwd() . '/assets/css/color/';
            \$files = scandir(\$dir);
            ...
\`\`\`

Browser recebe \`function_exists(...)\` + \`\$dir = getcwd()\` como JavaScript → quebra → handler do \`$(document).ready\` jQuery nem executa → toda interatividade morre:
- Search produto autocomplete
- Search cliente autocomplete
- Adicionar ao carrinho
- Recalcular total/desconto

## Por que só agora

Erro provavelmente sempre existiu, mas 500 anterior em /ia/dashboard bloqueava acesso autenticado. Larissa só chegou em /sells/create depois que dashboard voltou.

## Fix

\`grep get_custom_theme_color_list()\` retorna SÓ a declaração — função nunca é invocada (theme color picker legacy UltimatePOS desativado). **Remoção do bloco inteiro** (linhas 273-297).

## Test plan
- [x] Repro via Chrome MCP (script 2/10 inline, 1037 chars, SyntaxError)
- [x] Grep confirma função é código morto
- [ ] Deploy hotfix
- [ ] Validar /sells/create via Chrome MCP: console SEM SyntaxError
- [ ] Larissa @ Rota Livre testa consultar produto + cliente

## Refs
- Repro: SyntaxError em \`/sells/create:1554:34\`
- Cadeia hotfix manhã: PR #1716 (boot ServiceProvider), #1719 (route:cache), #1721 (SQL ambiguous)
- Audit doc: \`memory/sessions/2026-05-27-audit-sells-create-vs-blade-larissa.md\` (dores 1+2: search produto/cliente)

🤖 Generated with [Claude Code](https://claude.com/claude-code)