### PR TITLE
hotfix(sells): CustomerSearchAutocomplete concatena 'Cliente padrão' (smoke prod)

### DIFF
--- a/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
+++ b/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
@@ -163,8 +163,31 @@ export default function CustomerSearchAutocomplete({
           ref={inputRef}
           type="text"
           value={query.length > 0 ? query : selectedLabel}
-          onChange={(e) => setQuery(e.target.value)}
-          onFocus={() => results.length > 0 && setOpen(true)}
+          onChange={(e) => {
+            // Wagner 2026-05-27 HOTFIX: quando o value mostra `selectedLabel`
+            // ("Cliente padrão" antes da primeira busca), o user digitava
+            // e o texto era CONCATENADO ao label visual (e.target.value
+            // virava "Cliente padrãowagner"), disparando fetch quebrado
+            // `q=Cliente+padr%C3%A3owagner`. Smoke prod Wagner 2026-05-27
+            // 10:25 BRT via Chrome MCP detectou o bug.
+            // Fix: ao digitar com selectedLabel ainda no campo, extrair APENAS
+            // o suffix adicionado pelo usuário.
+            const raw = e.target.value;
+            if (query.length === 0 && raw.startsWith(selectedLabel) && raw.length > selectedLabel.length) {
+              setQuery(raw.slice(selectedLabel.length));
+            } else {
+              setQuery(raw);
+            }
+          }}
+          onFocus={(e) => {
+            // Wagner 2026-05-27 HOTFIX: seleciona conteúdo no focus pra
+            // primeira digitação substituir o `selectedLabel` (defesa
+            // em profundidade pro caso de o user digitar do meio).
+            if (query.length === 0) {
+              e.currentTarget.select();
+            }
+            if (results.length > 0) setOpen(true);
+          }}
           onKeyDown={handleKeyDown}
           placeholder={placeholder}
           disabled={disabled}


### PR DESCRIPTION
## Bug detectado via Chrome MCP smoke prod (2026-05-27 10:25 BRT)

Após cadeia de 4 hotfixes manhã destravar /ia/dashboard, Wagner testou /sells/create via Chrome MCP. **Adicionar produto + pagamento + Salvar venda funciona** (criou #OS00130 R$ 150 Paga). **Único bug**: buscar cliente quebra na primeira digitação.

## Repro

\`\`\`
GET /contacts/customers?q=Cliente+padr%C3%A3owagner  → 200 OK [] (quebrado)
GET /contacts/customers?q=wagner                     → 200 OK [...] (correto)
\`\`\`

## Root cause

\`\`\`tsx
value={query.length > 0 ? query : selectedLabel}
onChange={(e) => setQuery(e.target.value)}
\`\`\`

Quando query="" e selectedLabel="Cliente padrão", DOM input mostra "Cliente padrão". User clica + digita "wagner" → e.target.value = "Cliente padrãowagner" (concat). setQuery armazena valor estragado. useEffect dispara fetch com query inválido.

## Impacto na Larissa

Larissa (não-técnica) acha que não tem cliente cadastrado → não consegue trocar cliente padrão por um real. Dor #2 da auditoria realizada esta manhã (\`memory/sessions/2026-05-27-audit-sells-create-vs-blade-larissa.md\`).

## Fix conservador

- **onChange**: se query="" + raw começa com selectedLabel, extrai apenas o suffix digitado.
- **onFocus**: e.currentTarget.select() — defesa em profundidade.

Não muda UX visual (selectedLabel continua aparecendo como cliente atual). Apenas faz o input se comportar corretamente quando user começa a digitar.

## Próximo PR (não bloqueante)

Refactor UX: separar "cliente selecionado" da "string de busca" — usar Badge/Chip (pattern Linear/Notion) em vez de tentar mostrar dentro do mesmo input.

## Test plan
- [x] Repro via Chrome MCP confirmado
- [ ] Deploy hotfix
- [ ] Validar via Chrome MCP: digitar "wagner" → fetch \`q=wagner\` (sem concat)
- [ ] Validar dropdown mostra clientes reais

🤖 Generated with [Claude Code](https://claude.com/claude-code)