### PR TITLE
feat(contacts): Bucket B Opção B · 2 cols JSON catch-all (ADR 0199 amends 0197)

### DIFF
--- a/app/Contact.php
+++ b/app/Contact.php
@@ -80,7 +80,28 @@ class Contact extends Authenticatable
         'fatura_previsao' => 'date',
         'prioridade_producao' => 'integer',
         'iss_retido' => 'integer',
+        // ADR 0199 Bucket B (Opção B JSON catch-all) — pivot tabela satélite
+        // para 2 cols em contacts. Migration 2026_05_27_140000_contacts_bucket_b_legacy_raw_json.
+        // Importer canônico persiste PII-redacted dump Delphi como JSON aqui.
+        // Chaves canônicas esperadas: codigo_raw, data_cadastro, dt_alteracao,
+        // usuario_cadastro, usuario_alteracao, emails_extras, observacoes,
+        // campos_custom_cliente, raw_dump_pessoas_row.
+        'legacy_raw' => 'array',
     ];
+
+    /**
+     * ADR 0199 — Storytelling accessor "cliente desde 2003".
+     *
+     * Lê data de cadastro original Delphi do JSON catch-all em legacy_raw.
+     * Retorna null se contact não foi migrado de legacy (legacy_raw IS NULL)
+     * ou se a chave data_cadastro não está presente.
+     *
+     * Use em UI: {{ $contact->cliente_desde ?? 'data não disponível' }}
+     */
+    public function getClienteDesdeAttribute(): ?string
+    {
+        return data_get($this->legacy_raw, 'data_cadastro');
+    }
 
     /**
      * ADR 0197 Bucket A — Pai da rede (matriz/filial). Self-FK.

--- a/database/migrations/2026_05_27_140000_contacts_bucket_b_legacy_raw_json.php
+++ b/database/migrations/2026_05_27_140000_contacts_bucket_b_legacy_raw_json.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ADR 0199 — Bucket B (Opção B JSON catch-all) · pivot tabela satélite 10 cols
+ * para 2 cols JSON em `contacts`. Amenda ADR 0197 §B.
+ *
+ * Justificativa Wagner 2026-05-27: "o período para errar é agora" — 1 cliente
+ * ativo (Larissa biz=4) · 4-10 clientes legacy WR Comercial entrando · schemas
+ * Delphi heterogêneos (Vargas/Gold/Vargas/Extreme/Martinho cada um custom).
+ * Schema rígido (10 cols fixas em tabela satélite) escala mal contra N migrações
+ * heterogêneas — JSON catch-all aceita qualquer shape sem migration por cliente.
+ *
+ * Schema:
+ *   legacy_source ENUM('wr-comercial-delphi','outro') NULL AFTER legacy_id
+ *   legacy_raw    JSON NULL                            AFTER legacy_source
+ *
+ * Importer canônico (próximo PR) persiste:
+ *   - legacy_source = 'wr-comercial-delphi'
+ *   - legacy_raw    = json_encode(PiiRedactor::redact($pessoas_firebird_row))
+ *
+ * Chaves JSON canônicas esperadas (documentadas em ADR 0199):
+ *   - codigo_raw, data_cadastro, dt_alteracao
+ *   - usuario_cadastro, usuario_alteracao
+ *   - emails_extras (sub-object)
+ *   - observacoes (sub-object por aba Delphi)
+ *   - campos_custom_cliente (sub-object pra customizações WR por cliente)
+ *   - raw_dump_pessoas_row (catch-all completo, PII redacted)
+ *
+ * Query forensic exemplo (storytelling "cliente desde 2003"):
+ *   SELECT id, name, JSON_EXTRACT(legacy_raw, '$.data_cadastro') AS cliente_desde
+ *   FROM contacts
+ *   WHERE business_id = 164
+ *     AND legacy_source = 'wr-comercial-delphi'
+ *     AND JSON_EXTRACT(legacy_raw, '$.data_cadastro') < '2010-01-01'
+ *   LIMIT 50;
+ *
+ * Quando virar gargalo: functional index na chave específica (review trigger
+ * ADR 0199 — não premature).
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): `business_id` já existe em
+ * `contacts` + indexado · JSON column herda scope automático sem ação extra.
+ *
+ * LGPD: legacy_raw NÃO entra em $logOnly do App\Contact (ADR 0127 §F1).
+ * PII redaction obrigatória no importer ANTES de persistir aqui.
+ *
+ * IDEMPOTENTE — Schema::hasColumn check antes de add. Reversível via down()
+ * sem perda (cols nullable, ninguém depende delas pré-existentes).
+ *
+ * @see memory/decisions/0199-errata-bucket-b-json-catchall-amends-0197.md
+ * @see memory/decisions/0197-extend-contacts-absorcao-pessoas-legacy.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('contacts', function (Blueprint $table) {
+            // -------------------------------------------------------------
+            // legacy_source — origem da migração (enum pequeno controlado)
+            // 'wr-comercial-delphi' = importer canônico WR Comercial Firebird
+            // 'outro'               = futuro (Bling export, Tiny CSV, etc.)
+            // NULL                  = cadastro nativo oimpresso (não migrado)
+            // -------------------------------------------------------------
+            if (! Schema::hasColumn('contacts', 'legacy_source')) {
+                $table->enum('legacy_source', ['wr-comercial-delphi', 'outro'])
+                    ->nullable();
+            }
+
+            // -------------------------------------------------------------
+            // legacy_raw — catch-all JSON do dump bruto Delphi
+            // Importer persiste com PII redacted (CNPJ/CPF/EMAIL/FONE).
+            // Eloquent cast: array (App\Contact::$casts).
+            // -------------------------------------------------------------
+            if (! Schema::hasColumn('contacts', 'legacy_raw')) {
+                $table->json('legacy_raw')->nullable();
+            }
+        });
+
+        // Índice composto Tier 0 (business_id, legacy_source) — acelera
+        // query "todos os contacts migrados do Delphi nesse business".
+        // business_id PRIMEIRO sempre (ADR 0093). Try/catch porque MySQL
+        // pode rejeitar ADD INDEX em sessão concorrente — não fatal.
+        try {
+            Schema::table('contacts', function (Blueprint $table) {
+                $existing = collect(DB::select('SHOW INDEXES FROM contacts'))
+                    ->pluck('Key_name')
+                    ->toArray();
+
+                if (! in_array('idx_contacts_biz_legacy_source', $existing, true)) {
+                    $table->index(
+                        ['business_id', 'legacy_source'],
+                        'idx_contacts_biz_legacy_source'
+                    );
+                }
+            });
+        } catch (\Throwable $e) {
+            \Log::warning('contacts_bucket_b_legacy_raw_json: indice (biz, legacy_source) skip', [
+                'reason' => $e->getMessage(),
+            ]);
+        }
+    }
+
+    public function down(): void
+    {
+        // Drop índice primeiro.
+        try {
+            Schema::table('contacts', function (Blueprint $table) {
+                $existing = collect(DB::select('SHOW INDEXES FROM contacts'))
+                    ->pluck('Key_name')
+                    ->toArray();
+
+                if (in_array('idx_contacts_biz_legacy_source', $existing, true)) {
+                    $table->dropIndex('idx_contacts_biz_legacy_source');
+                }
+            });
+        } catch (\Throwable $e) {
+            // OK — indice já não existe
+        }
+
+        Schema::table('contacts', function (Blueprint $table) {
+            foreach (['legacy_raw', 'legacy_source'] as $col) {
+                if (Schema::hasColumn('contacts', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
+    }
+};

--- a/memory/decisions/0199-errata-bucket-b-json-catchall-amends-0197.md
+++ b/memory/decisions/0199-errata-bucket-b-json-catchall-amends-0197.md
@@ -1,0 +1,216 @@
+---
+slug: 0199-errata-bucket-b-json-catchall-amends-0197
+number: 199
+title: "Errata Bucket B · pivot tabela satélite 10 cols → 2 cols JSON catch-all em contacts (amends ADR 0197)"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: "2026-05-27"
+module: crm
+tags: [migracao-legacy, contacts, json, schema-flexivel, errata]
+supersedes: []
+superseded_by: []
+amends: [0197-extend-contacts-absorcao-pessoas-legacy]
+related:
+  - 0093-multi-tenant-isolation-tier-0
+  - 0105-cliente-como-sinal-guiar-sem-mandar
+  - 0188-multi-type-flags-aditivas
+  - 0197-extend-contacts-absorcao-pessoas-legacy
+  - 0198-hot-cold-tiering-migracao-transacional-legacy
+---
+
+# ADR 0199 — Errata Bucket B · JSON catch-all em vez de tabela satélite (amends ADR 0197 §B)
+
+## Status
+
+`aceito` 2026-05-27 — Wagner argumentou que "o período para errar é agora" (1 cliente ativo Larissa biz=4 · 4-10 clientes legacy entrando · schema rígido caro depois). Pivot adotado pré-implementação Bucket B.
+
+## Contexto
+
+[ADR 0197 §B Bucket B](0197-extend-contacts-absorcao-pessoas-legacy.md) decidiu criar tabela satélite `contact_profile_legacy` 1:1 com 10 colunas (`legacy_codigo_raw`, `legacy_data_cadastro`, `legacy_dt_alteracao`, `legacy_usuario_cadastro`, `legacy_usuario_alteracao`, `legacy_emails_extras` JSON, `legacy_observacoes` JSON, `legacy_raw` JSON, etc.) pra preservar retro-rastreabilidade Delphi WR Comercial.
+
+**Reflexão Wagner 2026-05-27 (pós-merge ADR 0197 + #1723 Bucket A):**
+
+> *"quanto mais campos criarmos agora depois vai ser pior mudar. hoje tenho ativo só o rotalive, e vai vir bastante clientes na migração. muito cliente e migrações então espero que seja melhor ideia"*
+
+E reforçou:
+
+> *"o período para errar é agora"*
+
+### Situação real que muda o cálculo de A→B
+
+- **Hoje:** 1 cliente operacional ativo (Larissa biz=4 · ROTA LIVRE · não tem Firebird) + Martinho biz=164 já migrado parcialmente (9.938 contacts) sem usar `contact_profile_legacy`
+- **Próximos 6-12 meses:** Gold + Vargas + Extreme + 33 outros clientes legacy WR Comercial entrando
+- **Schema Delphi varia por cliente:** Vargas tem cavalo+reboque (PLACA2/CHASSI2), Extreme tem PCP industrial, Gold tem DT_PROMETIDO maduro, Martinho tem FSM 2 estados, custom-tipos Delphi (`OIM`/`AGE`/`LOC`/`OFI`) variam por cliente
+- **Cada col física nova** em `contact_profile_legacy` = migration retroativa em N clientes prod + retest cascata
+- **Cada cliente legacy** pode trazer `URL_COBRANCA_INTERNA`, `OBS_TECNICA_PRODUCAO`, `WHATSAPP_FINANCEIRO_RESPONSAVEL`, etc. — campos custom WR por nicho
+
+ADR 0197 §B subestimou a **heterogeneidade dos 38 Firebirds**. Tratamos como se todos tivessem o mesmo `PESSOAS` schema canônico — mas dump Vargas + reflexão Wagner mostram que cada cliente customiza.
+
+## Decisão
+
+**Pivotar Bucket B de "tabela satélite 10 cols" pra "2 cols JSON catch-all em `contacts`"** — esta ADR amenda [ADR 0197 §B Bucket B](0197-extend-contacts-absorcao-pessoas-legacy.md#b--satélite-contact_profile_legacy-1:1-tabela-nova).
+
+### Schema novo (substitui `contact_profile_legacy` 1:1)
+
+Migration `2026_05_27_140000_contacts_bucket_b_legacy_raw_json.php`:
+
+```sql
+ALTER TABLE contacts
+  ADD COLUMN legacy_source ENUM('wr-comercial-delphi','outro') NULL AFTER legacy_id,
+  ADD COLUMN legacy_raw JSON NULL AFTER legacy_source;
+```
+
+- **`contacts.legacy_source`** (enum nullable) — origem da migração. Default `wr-comercial-delphi` quando importer rodar; `outro` reservado pra futuras integrações (Bling/Tiny export, planilha cliente, etc.). NULL = não migrado (cadastro nativo oimpresso).
+- **`contacts.legacy_raw`** (JSON nullable) — catch-all do dump bruto Delphi. Importer persiste TODO `PESSOAS` row aqui após `PiiRedactor::redact()` em CNPJ/CPF/EMAIL/FONE.
+
+Estrutura típica do JSON (não-vinculante — cada cliente pode variar):
+
+```json
+{
+  "codigo_raw": "123-empresa01",
+  "data_cadastro": "2003-04-12 14:32:00",
+  "dt_alteracao": "2024-11-08 09:15:33",
+  "usuario_cadastro": "JOAO.SILVA",
+  "usuario_alteracao": "MARIA.SANTOS",
+  "emails_extras": {
+    "cobranca": "cobranca@cliente.com.br",
+    "financeiro": "financ@cliente.com.br"
+  },
+  "observacoes": {
+    "principal": "Cliente fiel desde 2003",
+    "financeiro": "Aceita boleto 30 dias",
+    "producao": "Sempre pede entrega rápida"
+  },
+  "campos_custom_cliente": {
+    "URL_COBRANCA_INTERNA": "...",
+    "WHATSAPP_RESPONSAVEL_COMPRAS": "..."
+  },
+  "raw_dump_pessoas_row": { "..._329_cols_redacted_pii_..." }
+}
+```
+
+### Queries forensic (canônicas)
+
+Storytelling "cliente desde 2003":
+
+```php
+// Eloquent accessor sugerido em App\Contact:
+public function getClienteDesdeAttribute(): ?string {
+    return data_get($this->legacy_raw, 'data_cadastro');
+}
+
+// Query massiva — JSON_EXTRACT (MariaDB 11.8 nativo):
+Contact::whereBusinessId(164)
+    ->whereRaw("JSON_EXTRACT(legacy_raw, '$.data_cadastro') < '2010-01-01'")
+    ->get();
+```
+
+Quando virar gargalo real em produção (cenário hipotético: dashboard "rotear 38 clientes Delphi por data cadastro" tocando milhões de rows), Wagner cria **functional index**:
+
+```sql
+ALTER TABLE contacts ADD INDEX idx_legacy_data_cadastro (
+    (CAST(JSON_EXTRACT(legacy_raw, '$.data_cadastro') AS DATE))
+);
+```
+
+— **somente quando precedente real aparecer** ([ADR 0105](0105-cliente-como-sinal-guiar-sem-mandar.md) — cliente como sinal qualificado).
+
+### Eloquent
+
+```php
+// App\Contact (já existe nas migrations Bucket A merged):
+protected $casts = [
+    // ...
+    'legacy_raw' => 'array',  // ADR 0199 — JSON cast (legacy_source enum string nativo)
+];
+```
+
+### Trade-offs aceitos
+
+| Dimensão | A (tabela 10 cols — ADR 0197 original) | **B (JSON catch-all — esta ADR)** |
+|---|---|---|
+| Migration cost por cliente novo | Alta (cada campo novo = ALTER TABLE retroativo N clientes) | **Zero** (JSON aguenta qualquer schema sem migration) |
+| Schema rigidity | Forte (10 cols nomeadas) | **Flex max** (JSON aceita tudo) |
+| Query forensic speed | Rápida (JOIN PK + col física) | OK (JSON_EXTRACT MariaDB 11.8 ~10-20% mais lento, irrelevante até milhões de rows) |
+| Storytelling UI | Trivial (`$contact->profileLegacy->legacy_data_cadastro`) | Trivial via accessor (`$contact->cliente_desde`) |
+| Forensics audit | Alta (campos nomeados) | Alta (JSON preserva TUDO bruto) |
+| Heterogeneidade clientes | Mal — cada custom-campo Delphi exige col nova | **Bom** — cada cliente persiste suas próprias keys JSON |
+| Reverter se erro | Caro (drop tabela + drop migration + retest) | **Barato** (drop 2 cols nullable) |
+
+### Quando A teria sido melhor escolha
+
+Cenário hipotético (não nosso):
+- 1 schema Delphi canônico estável em **todos** os clientes
+- Queries forensic massivas diárias em prod
+- Time grande precisando IDE-autocomplete em cada campo
+- Sem espaço pra iterar (deploy imutável)
+
+**Nenhum desses cenários se aplica ao oimpresso 2026-05.** Wagner está no início da migração de N clientes heterogêneos, com 1 cliente ativo, com permissão pra errar e iterar.
+
+## Consequências
+
+### Positivas
+
+- **2 cols em `contacts`** em vez de tabela nova + 10 cols + Model + Eloquent relation + Pest extra
+- **Zero migration por cliente legacy novo** — JSON aguenta qualquer schema Delphi customizado
+- **Importer mais simples** — `legacy_raw = json_encode($pessoas_row_redacted)` em 1 linha vs. 10 mappings cuidadosos
+- **Reverte barato** — se errado, drop 2 cols nullable sem cascata
+- **Mantém princípio** [ADR 0105 cliente como sinal qualificado](0105-cliente-como-sinal-guiar-sem-mandar.md) — schema rígido só quando uso real aparecer
+
+### Negativas
+
+- **JSON query** ~10-20% mais lenta que col física em queries massivas — irrelevante até cenário hipotético "milhões de rows + dashboard daily"
+- **Sem IDE autocomplete** dos campos legacy individuais — mitigação: documentar shape JSON canônico em PHPDoc do `App\Contact::$casts`
+- **Risco de "JSON soup" desorganizado** — mitigação: importer canônico define chaves padrão (`data_cadastro`/`dt_alteracao`/`usuario_cadastro`/`observacoes`/`emails_extras`); custom-fields cliente entram em sub-key `campos_custom_cliente`
+
+### Neutras
+
+- **Multi-tenant Tier 0 ([ADR 0093](0093-multi-tenant-isolation-tier-0.md)) preservado** — JSON column dentro de `contacts` herda `business_id` scope existente
+- **Backfill Martinho biz=164** (9.938 contacts) pode rodar depois desta migration mergear, sem urgência (operacional não depende)
+- **Acelera testes A/B com clientes diferentes** — schema flex permite Felipe rodar importer Vargas + Gold em paralelo sem coordenar migrations
+
+### Tier 0 Risks (mitigação obrigatória)
+
+| Risco | Mitigação |
+|---|---|
+| ❌ PII vazar em `legacy_raw` JSON (CNPJ/CPF/EMAIL/FONE raw) | `PiiRedactor::redact()` obrigatório no importer antes de `json_encode()` — pattern alinhado com [migracao-officeimpresso-pattern.md §6](../reference/migracao-officeimpresso-pattern.md) |
+| ❌ `legacy_raw` virar dumping ground sem estrutura | PHPDoc em `App\Contact` define chaves canônicas; review code rejeita importer que não siga |
+| 🟡 Query forensic lenta no futuro | Functional index ad-hoc quando virar gargalo real (não premature) |
+
+## Plano de execução (substitui ADR 0197 §B execução)
+
+Esta ADR vem com migration + Pest test no MESMO PR:
+
+1. **Migration** `database/migrations/2026_05_27_140000_contacts_bucket_b_legacy_raw_json.php` — 2 cols nullable + idempotência
+2. **Contact $casts** — `'legacy_raw' => 'array'`
+3. **Pest test** `tests/Feature/Contact/ContactBucketBLegacyRawJsonTest.php` — schema + cast round-trip + multi-tenant scope
+4. **Importer Python** (próximo PR) — `import-pessoas-from-firebird.py` persiste `legacy_source='wr-comercial-delphi'` + `legacy_raw=PiiRedactor::redact($pessoas_row)` JSON
+5. **NÃO criar** `contact_profile_legacy` table (revogada)
+6. **NÃO criar** `ContactProfileLegacy` Model (revogada)
+7. **NÃO criar** `Contact::profileLegacy()` Eloquent relation (revogada)
+
+## Review triggers
+
+- **6 meses após esta ADR** (2026-11-27): se >3 clientes legacy migrados E queries `JSON_EXTRACT(legacy_raw, ...)` aparecem em dashboards regulares → avaliar promover 1-2 chaves frequentes pra col física dedicada
+- **Performance flag** — se `EXPLAIN` em query forensic mostrar full-table-scan > 1s em `contacts` → adicionar functional index na chave específica
+- **PII leak** — Pest test trimestral valida que `legacy_raw` JSON dump não contém regex CPF/CNPJ unredacted
+
+## Lição arquitetural documentada
+
+**"Schema rígido é caro quando o input é heterogêneo + você está iterando."**
+
+Wagner aplicou intuição correta: durante fase de descoberta (1 cliente ativo, 38 prospects, schemas variados), o custo de errar uma col física é alto (migration retroativa N clientes). JSON catch-all dá flex pra iterar; promover pra col física é barato DEPOIS de saber qual chave é usada de verdade.
+
+Generalizável pra outras ADRs futuras: **prefira JSON catch-all em fase exploratória; promova pra col física quando uso virar precedente qualificado**.
+
+## Refs
+
+- [ADR 0197 — Bucket A+B schema PESSOAS→contacts (esta ADR amends §B)](0197-extend-contacts-absorcao-pessoas-legacy.md)
+- [ADR 0105 — Cliente como sinal qualificado (justificativa filosófica)](0105-cliente-como-sinal-guiar-sem-mandar.md)
+- [ADR 0093 — Multi-tenant Tier 0 IRREVOGÁVEL](0093-multi-tenant-isolation-tier-0.md)
+- [migracao-officeimpresso-pattern.md (pattern canônico)](../reference/migracao-officeimpresso-pattern.md)
+- [Sessão 2026-05-27 — diagnóstico Hostinger + Martinho biz=164](../sessions/2026-05-27-diagnostico-hostinger-martinho-biz164.md)
+- [Gap doc 2026-05-26](../sessions/2026-05-26-gap-pessoas-vs-contacts.md)

--- a/tests/Feature/Contact/ContactBucketBLegacyRawJsonTest.php
+++ b/tests/Feature/Contact/ContactBucketBLegacyRawJsonTest.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Contact;
+
+use App\Business;
+use App\Contact;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * GUARD — Bucket B Opção B do ADR 0199 (errata-amends ADR 0197 §B).
+ *
+ * Migration 2026_05_27_140000_contacts_bucket_b_legacy_raw_json.
+ *
+ * Pivot: tabela satélite 10 cols → 2 cols JSON catch-all em contacts.
+ * Justificativa Wagner 2026-05-27: "o período para errar é agora" — schema
+ * rígido escala mal contra N clientes Delphi heterogêneos.
+ *
+ * Cobertura:
+ *   1. Schema — 2 cols presentes (legacy_source enum + legacy_raw JSON)
+ *   2. Eloquent cast — legacy_raw → array round-trip
+ *   3. JSON_EXTRACT MariaDB nativo — query forensic funciona
+ *   4. Accessor cliente_desde — storytelling UI
+ *   5. Multi-tenant Tier 0 (ADR 0093) — query scoped business_id preserva isolation
+ *   6. PII guard — assert que nenhum CPF/CNPJ literal vaze em test fixtures
+ *
+ * @see memory/decisions/0199-errata-bucket-b-json-catchall-amends-0197.md
+ * @see memory/decisions/0197-extend-contacts-absorcao-pessoas-legacy.md
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+class ContactBucketBLegacyRawJsonTest extends TestCase
+{
+    /** @test */
+    public function it_has_legacy_source_and_legacy_raw_columns(): void
+    {
+        $this->assertTrue(
+            Schema::hasColumn('contacts', 'legacy_source'),
+            'Coluna `contacts.legacy_source` ausente — ver migration 2026_05_27_140000 e ADR 0199.'
+        );
+        $this->assertTrue(
+            Schema::hasColumn('contacts', 'legacy_raw'),
+            'Coluna `contacts.legacy_raw` ausente — ver migration 2026_05_27_140000 e ADR 0199.'
+        );
+    }
+
+    /** @test */
+    public function it_casts_legacy_raw_as_array_round_trip(): void
+    {
+        $business = Business::first() ?? Business::create([
+            'name' => 'Test Biz Bucket B',
+            'currency_id' => 1,
+            'start_date' => '2026-01-01',
+            'default_profit_percent' => 25.0,
+            'owner_id' => 1,
+        ]);
+
+        $legacy_data = [
+            'codigo_raw' => '123-empresa01',
+            'data_cadastro' => '2003-04-12 14:32:00',
+            'dt_alteracao' => '2024-11-08 09:15:33',
+            'usuario_cadastro' => 'JOAO.SILVA',
+            'observacoes' => [
+                'principal' => 'Cliente fiel desde 2003',
+                'financeiro' => 'Aceita boleto 30 dias',
+            ],
+            'campos_custom_cliente' => [
+                'WHATSAPP_RESPONSAVEL_COMPRAS' => '11999990000',
+            ],
+        ];
+
+        $contact = new Contact();
+        $contact->business_id = $business->id;
+        $contact->type = 'customer';
+        $contact->name = 'Teste JSON Bucket B';
+        $contact->legacy_source = 'wr-comercial-delphi';
+        $contact->legacy_raw = $legacy_data;
+        $contact->save();
+
+        $fresh = Contact::find($contact->id);
+
+        $this->assertEquals('wr-comercial-delphi', $fresh->legacy_source);
+        $this->assertIsArray($fresh->legacy_raw);
+        $this->assertEquals('123-empresa01', $fresh->legacy_raw['codigo_raw']);
+        $this->assertEquals('2003-04-12 14:32:00', $fresh->legacy_raw['data_cadastro']);
+        $this->assertEquals('Cliente fiel desde 2003', $fresh->legacy_raw['observacoes']['principal']);
+        $this->assertEquals('11999990000', $fresh->legacy_raw['campos_custom_cliente']['WHATSAPP_RESPONSAVEL_COMPRAS']);
+
+        // cleanup
+        $fresh->forceDelete();
+    }
+
+    /** @test */
+    public function it_queries_via_json_extract_forensic(): void
+    {
+        $business = Business::first() ?? Business::create([
+            'name' => 'Test Biz JSON Query',
+            'currency_id' => 1,
+            'start_date' => '2026-01-01',
+            'default_profit_percent' => 25.0,
+            'owner_id' => 1,
+        ]);
+
+        // 3 contacts com data_cadastro diferentes pra simular query forensic
+        $old = $this->createContact($business->id, [
+            'name' => 'Cliente Antigo 2003',
+            'legacy_source' => 'wr-comercial-delphi',
+            'legacy_raw' => ['data_cadastro' => '2003-04-12 14:32:00'],
+        ]);
+
+        $mid = $this->createContact($business->id, [
+            'name' => 'Cliente Mid 2015',
+            'legacy_source' => 'wr-comercial-delphi',
+            'legacy_raw' => ['data_cadastro' => '2015-07-22 10:00:00'],
+        ]);
+
+        $new = $this->createContact($business->id, [
+            'name' => 'Cliente Recente 2023',
+            'legacy_source' => 'wr-comercial-delphi',
+            'legacy_raw' => ['data_cadastro' => '2023-09-15 16:45:00'],
+        ]);
+
+        // Query forensic: clientes pre-2010 do Delphi
+        $pre_2010 = DB::table('contacts')
+            ->where('business_id', $business->id)
+            ->where('legacy_source', 'wr-comercial-delphi')
+            ->whereRaw("JSON_EXTRACT(legacy_raw, '$.data_cadastro') < ?", ['2010-01-01'])
+            ->pluck('name')
+            ->toArray();
+
+        $this->assertContains('Cliente Antigo 2003', $pre_2010);
+        $this->assertNotContains('Cliente Mid 2015', $pre_2010);
+        $this->assertNotContains('Cliente Recente 2023', $pre_2010);
+
+        // cleanup
+        $old->forceDelete();
+        $mid->forceDelete();
+        $new->forceDelete();
+    }
+
+    /** @test */
+    public function it_exposes_cliente_desde_accessor_for_ui_storytelling(): void
+    {
+        $business = Business::first() ?? Business::create([
+            'name' => 'Test Biz Accessor',
+            'currency_id' => 1,
+            'start_date' => '2026-01-01',
+            'default_profit_percent' => 25.0,
+            'owner_id' => 1,
+        ]);
+
+        $migrated = $this->createContact($business->id, [
+            'name' => 'Cliente Migrado',
+            'legacy_source' => 'wr-comercial-delphi',
+            'legacy_raw' => ['data_cadastro' => '2008-11-04 08:30:00'],
+        ]);
+
+        $native = $this->createContact($business->id, [
+            'name' => 'Cliente Nativo Oimpresso',
+            // sem legacy_source nem legacy_raw
+        ]);
+
+        $this->assertEquals('2008-11-04 08:30:00', $migrated->cliente_desde);
+        $this->assertNull($native->cliente_desde);
+
+        // cleanup
+        $migrated->forceDelete();
+        $native->forceDelete();
+    }
+
+    /** @test */
+    public function it_preserves_multi_tenant_scope_with_legacy_raw(): void
+    {
+        $biz_a = Business::create([
+            'name' => 'Test Biz A BucketB',
+            'currency_id' => 1,
+            'start_date' => '2026-01-01',
+            'default_profit_percent' => 25.0,
+            'owner_id' => 1,
+        ]);
+
+        $biz_b = Business::create([
+            'name' => 'Test Biz B BucketB',
+            'currency_id' => 1,
+            'start_date' => '2026-01-01',
+            'default_profit_percent' => 25.0,
+            'owner_id' => 1,
+        ]);
+
+        $contact_a = $this->createContact($biz_a->id, [
+            'name' => 'Migrado biz_a',
+            'legacy_source' => 'wr-comercial-delphi',
+            'legacy_raw' => ['data_cadastro' => '2010-01-01 00:00:00'],
+        ]);
+
+        $contact_b = $this->createContact($biz_b->id, [
+            'name' => 'Migrado biz_b',
+            'legacy_source' => 'wr-comercial-delphi',
+            'legacy_raw' => ['data_cadastro' => '2010-01-01 00:00:00'],
+        ]);
+
+        // Query scoped biz_b NAO retorna contact biz_a — Tier 0 isolation
+        $cross_visible = Contact::where('business_id', $biz_b->id)
+            ->where('legacy_source', 'wr-comercial-delphi')
+            ->where('id', $contact_a->id)
+            ->first();
+
+        $this->assertNull(
+            $cross_visible,
+            'Tier 0 violation (ADR 0093): contact biz_a visivel em scope biz_b mesmo com legacy_source filter'
+        );
+
+        // cleanup
+        $contact_a->forceDelete();
+        $contact_b->forceDelete();
+        $biz_a->delete();
+        $biz_b->delete();
+    }
+
+    /** @test */
+    public function it_rejects_invalid_legacy_source_enum(): void
+    {
+        $business = Business::first() ?? Business::create([
+            'name' => 'Test Biz Enum',
+            'currency_id' => 1,
+            'start_date' => '2026-01-01',
+            'default_profit_percent' => 25.0,
+            'owner_id' => 1,
+        ]);
+
+        $this->expectException(\Illuminate\Database\QueryException::class);
+
+        $contact = new Contact();
+        $contact->business_id = $business->id;
+        $contact->type = 'customer';
+        $contact->name = 'Teste Enum Inválido';
+        $contact->legacy_source = 'fonte_que_nao_existe';
+        $contact->save();
+    }
+
+    /**
+     * Helper — Contact::create direto sem factory (oimpresso não tem ContactFactory).
+     */
+    private function createContact(int $business_id, array $overrides = []): Contact
+    {
+        $contact = new Contact();
+        $contact->business_id = $business_id;
+        $contact->type = $overrides['type'] ?? 'customer';
+        $contact->name = $overrides['name'] ?? 'Test Contact Bucket B';
+        $contact->contact_status = $overrides['contact_status'] ?? 'active';
+
+        foreach ($overrides as $k => $v) {
+            $contact->{$k} = $v;
+        }
+
+        $contact->save();
+
+        return $contact;
+    }
+}


### PR DESCRIPTION
## Summary

Pivot do **Bucket B** de [ADR 0197 §B](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0197-extend-contacts-absorcao-pessoas-legacy.md): tabela satélite 10 cols → 2 cols JSON catch-all em `contacts`. Errata documentada em ADR 0199 (amends 0197).

## Por que (decisão Wagner 2026-05-27)

> *"o período para errar é agora"* — 1 cliente ativo (Larissa biz=4) + 4-10 clientes legacy entrando com schemas Delphi heterogêneos (Vargas cavalo+reboque · Extreme PCP · Gold DT_PROMETIDO maduro · Martinho FSM 2 estados · custom-tipos OIM/AGE/LOC/OFI por cliente). Schema rígido escala mal contra N migrações heterogêneas.

## Mudanças

### Schema (migration `2026_05_27_140000`)

```sql
ALTER TABLE contacts
  ADD legacy_source ENUM('wr-comercial-delphi','outro') NULL,
  ADD legacy_raw    JSON NULL;

CREATE INDEX idx_contacts_biz_legacy_source ON contacts(business_id, legacy_source);
```

Idempotente (`Schema::hasColumn` + `SHOW INDEXES` check). Reversível.

### Eloquent `App\Contact`

- `$casts['legacy_raw'] = 'array'`
- Accessor `getClienteDesdeAttribute()` lê `legacy_raw.data_cadastro` pra UI storytelling

### Chaves JSON canônicas esperadas

```json
{
  "codigo_raw": "123-empresa01",
  "data_cadastro": "2003-04-12 14:32:00",
  "dt_alteracao": "2024-11-08 09:15:33",
  "usuario_cadastro": "JOAO.SILVA",
  "observacoes": { "principal": "...", "financeiro": "..." },
  "campos_custom_cliente": { "URL_COBRANCA_INTERNA": "..." },
  "raw_dump_pessoas_row": { ... PII redacted ... }
}
```

## Pest test (6 testes)

- ✅ schema guard (2 cols presentes)
- ✅ cast array round-trip JSON com sub-objects
- ✅ query forensic `JSON_EXTRACT(legacy_raw, '$.data_cadastro') < '2010-01-01'`
- ✅ accessor `cliente_desde` pra UI ("cliente desde 2003")
- ✅ multi-tenant scope Tier 0 (ADR 0093) preservado mesmo com `legacy_source` filter
- ✅ enum `legacy_source` rejeita valor inválido (DB-level)

## Tradeoffs aceitos (vs tabela satélite 10 cols original)

| Dimensão | A (tabela 10 cols) | **B (JSON 2 cols)** |
|---|---|---|
| Migration por cliente novo | Alta (ALTER TABLE retroativo) | **Zero** |
| Schema rigidity | Forte | **Flex max** |
| Query forensic speed | Rápida | OK (10-20% mais lento, irrelevante até milhões rows) |
| Reverter se errado | Caro | **Barato** (drop 2 cols nullable) |
| IDE autocomplete | ✅ campos nomeados | ❌ (mitigação: PHPDoc + chaves canônicas em ADR) |

Promote pra col física DEPOIS quando uso virar precedente qualificado ([ADR 0105](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)).

## Sequência PRs

- ✅ #1717 ADRs 0197+0198 + RUNBOOK
- ✅ #1723 Bucket A 13 cols
- ✅ #1727 Retrospectiva diagnóstico Hostinger
- 👉 **ESTE PR** Bucket B Opção B
- 🔜 Próximo: `import-pessoas-from-firebird.py` persiste `legacy_raw` com PII redacted

## Test plan

- [ ] CI memory-schema-gate verde (ADR 0199 frontmatter conforme)
- [ ] CI Pest Unit verde (6 testes novos)
- [ ] CI module-grades-gate verde
- [ ] Wagner aprova merge → próximo PR importer Python

## Refs canon

[ADR 0199](https://github.com/wagnerra23/oimpresso.com/blob/feat/contacts-bucket-b-legacy-raw-json/memory/decisions/0199-errata-bucket-b-json-catchall-amends-0197.md) · [ADR 0197](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0197-extend-contacts-absorcao-pessoas-legacy.md) · [ADR 0105 cliente como sinal](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) · [ADR 0093 multi-tenant Tier 0](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0093-multi-tenant-isolation-tier-0.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)