### PR TITLE
hotfix(blade/sell): Status='final' default elimina 'Entradas inválidas' (Larissa)

### DIFF
--- a/resources/views/sell/create.blade.php
+++ b/resources/views/sell/create.blade.php
@@ -221,7 +221,8 @@
 					<div class="@if(!empty($commission_agent)) col-sm-3 @else col-sm-4 @endif">
 						<div class="form-group">
 							{!! Form::label('status', __('sale.status') . ':*') !!}
-							{!! Form::select('status', $statuses, null, ['class' => 'form-control select2', 'placeholder' => __('messages.please_select'), 'required']); !!}
+							{{-- Wagner 2026-05-27 HOTFIX: default 'final' (campo obrigatório). Antes vinha null → user submetia sem perceber → toast "Entradas inválidas, verifique e tente novamente !!" + label vermelha "This field is required". Pain reportada smoke prod 2026-05-27 (Larissa @ Rota Livre). Espelha comportamento Sells/Create.tsx V2 que JÁ default 'final'. --}}
+							{!! Form::select('status', $statuses, 'final', ['class' => 'form-control select2', 'placeholder' => __('messages.please_select'), 'required']); !!}
 						</div>
 					</div>
 				@endif


### PR DESCRIPTION
## Bug detectado via Chrome MCP smoke prod (2026-05-27)

Campo Status:* no Blade legacy /sells/create renderiza vazio ("Selecionar"). User clica Salvar → toast vermelho **"Entradas inválidas, verifique e tente novamente !!"** topo direita + label vermelha **"This field is required"** embaixo. Larissa não-técnica não entende qual campo é o problema.

## Fix (1 linha)

\`resources/views/sell/create.blade.php:224\`:

\`\`\`diff
- {!! Form::select('status', \$statuses, null, ['class' => 'form-control select2', ...]) !!}
+ {!! Form::select('status', \$statuses, 'final', ['class' => 'form-control select2', ...]) !!}
\`\`\`

User vê "final" pré-selecionado, pode editar pra draft/quotation/proforma quando precisar.

## Por que 'final'

- 95%+ das vendas históricas (biz=1, biz=4) são status=final
- Sells/Create.tsx V2 (Inertia) JÁ default 'final' — bug era discrepância V2 vs Blade
- Charters auditados mencionam 'final' como happy path

## Test plan
- [x] Repro via Chrome MCP (screenshot do toast vermelho)
- [ ] Deploy hotfix
- [ ] Smoke prod: abrir /sells/create + clicar Salvar imediatamente → não dá mais erro de Status

## Refs
- Smoke prod 2026-05-27 ~10:55 BRT
- Cadeia hotfixes manhã: #1716/#1719/#1721/#1726/#1729 (destravaram /ia/dashboard + /sells/create)
- Audit doc: \`memory/sessions/2026-05-27-audit-sells-create-vs-blade-larissa.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)