### PR TITLE
hotfix(sells/create): AlertDialog shadcn pra rascunho (substitui confirm nativo)

### DIFF
--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -38,6 +38,16 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/Components/ui/select';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/Components/ui/alert-dialog';
 
 interface OptionMap {
   [id: number]: string;
@@ -533,7 +543,11 @@ export default function SellsCreate(props: SellsCreatePageProps) {
   }, [auth, business]);
 
   // Recover ao montar (apenas 1x). Pergunta antes — Larissa pode ter terminado em outro tab.
+  // Wagner 2026-05-27 HOTFIX: substituído window.confirm() nativo (botões cinza do browser,
+  // destoa do resto da UI) por AlertDialog shadcn estilizado. Smoke prod 2026-05-27 (Larissa
+  // achou estranho — UI inconsistente). Mantém mesma semântica: OK→recupera, Cancelar→descarta.
   const recoveredRef = useRef(false);
+  const [draftRecover, setDraftRecover] = useState<{ data: typeof data; savedAt: number; time: string } | null>(null);
   useEffect(() => {
     if (!draftKey || recoveredRef.current) return;
     recoveredRef.current = true;
@@ -549,11 +563,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
         hour: '2-digit',
         minute: '2-digit',
       });
-      if (confirm(`Recuperar rascunho de venda salvo às ${time}?`)) {
-        setData(parsed.data);
-      } else {
-        localStorage.removeItem(draftKey);
-      }
+      setDraftRecover({ data: parsed.data, savedAt: parsed.savedAt, time });
     } catch {
       // Draft corrompido — descartar silenciosamente.
       try {
@@ -564,6 +574,18 @@ export default function SellsCreate(props: SellsCreatePageProps) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [draftKey]);
+
+  const handleDraftRecover = () => {
+    if (draftRecover) setData(draftRecover.data);
+    setDraftRecover(null);
+  };
+
+  const handleDraftDiscard = () => {
+    if (draftKey) {
+      try { localStorage.removeItem(draftKey); } catch { /* ignore */ }
+    }
+    setDraftRecover(null);
+  };
 
   // Auto-save debounced 500ms quando data mudar (após mount).
   useEffect(() => {
@@ -1401,6 +1423,25 @@ export default function SellsCreate(props: SellsCreatePageProps) {
           </div>
         </div>
       </div>
+
+      {/* Wagner 2026-05-27 HOTFIX: AlertDialog shadcn substitui window.confirm() nativo
+          do browser pra auto-save de rascunho (US-SELL-007). Smoke prod 2026-05-27: UI
+          consistente com resto da app, evita "alert cinza ugly" que destoava. */}
+      <AlertDialog open={!!draftRecover} onOpenChange={(open) => { if (!open) handleDraftDiscard(); }}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Recuperar rascunho de venda?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Encontramos um rascunho salvo automaticamente às <strong>{draftRecover?.time}</strong>.
+              Você pode recuperar e continuar de onde parou ou descartar e começar do zero.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel onClick={handleDraftDiscard}>Descartar</AlertDialogCancel>
+            <AlertDialogAction onClick={handleDraftRecover}>Recuperar</AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }


### PR DESCRIPTION
## Bug visual (smoke prod Chrome MCP 2026-05-27)

Após criar venda em /sells/create, voltar pra mesma URL faz aparecer \`window.confirm()\` nativo:

\`"Recuperar rascunho de venda salvo às 10:30? [OK] [Cancelar]"\`

com botões cinza do browser. Destoa completamente da UI roxa/clean shadcn do resto da app. Wagner viu hoje e mandou screenshot.

## Fix

Substituir \`window.confirm()\` por \`AlertDialog\` do shadcn/ui (já em uso em outras 3 telas Essentials/*).

\`\`\`tsx
// Antes
if (confirm(\`Recuperar rascunho de venda salvo às \${time}?\`)) { setData(parsed.data); }
else { localStorage.removeItem(draftKey); }

// Depois
setDraftRecover({ data: parsed.data, savedAt: parsed.savedAt, time });
// + renderiza <AlertDialog open={!!draftRecover}>…<AlertDialogAction onClick={handleDraftRecover}>Recuperar</…>
\`\`\`

Mesma semântica: Recuperar → setData, Descartar/Esc/click-fora → remove localStorage.

## Test plan
- [x] Repro via Chrome MCP confirmado (screenshot do confirm nativo cinza)
- [ ] Deploy hotfix
- [ ] Smoke: criar venda, voltar pra /sells/create → modal estilizado da app (não cinza do browser)

## Follow-up (não bloqueante)

Sells/Edit.tsx:362 tem mesmo padrão \`window.confirm()\`. Fica pra PR separado.

## Refs
- Cadeia hotfixes manhã: PRs #1716/#1719/#1721/#1726/#1729/#1732
- Smoke prod 2026-05-27 ~10:30 BRT
- Audit doc: \`memory/sessions/2026-05-27-audit-sells-create-vs-blade-larissa.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)