### PR TITLE
feat(contacts): adopta canon sync bidirecional Wagner 2024-11 (ADR 0200)

### DIFF
--- a/app/Contact.php
+++ b/app/Contact.php
@@ -81,12 +81,17 @@ class Contact extends Authenticatable
         'prioridade_producao' => 'integer',
         'iss_retido' => 'integer',
         // ADR 0199 Bucket B (Opção B JSON catch-all) — pivot tabela satélite
-        // para 2 cols em contacts. Migration 2026_05_27_140000_contacts_bucket_b_legacy_raw_json.
+        // para col JSON em contacts. Migration 2026_05_27_140000_contacts_bucket_b_legacy_raw_json.
         // Importer canônico persiste PII-redacted dump Delphi como JSON aqui.
         // Chaves canônicas esperadas: codigo_raw, data_cadastro, dt_alteracao,
         // usuario_cadastro, usuario_alteracao, emails_extras, observacoes,
         // campos_custom_cliente, raw_dump_pessoas_row.
         'legacy_raw' => 'array',
+        // ADR 0200 — canon sync bidirecional Delphi ↔ oimpresso (Wagner 2024-11).
+        // Pareada com 11 outras tabelas (brands/products/users/etc).
+        // BaseApiController::syncData usa officeimpresso_dt_alteracao em conflict
+        // detection (linha 67-73). Migration 2026_05_27_160000_contacts_consolidate_officeimpresso_sync_canon.
+        'officeimpresso_dt_alteracao' => 'datetime',
     ];
 
     /**

--- a/database/migrations/2026_05_27_160000_contacts_consolidate_officeimpresso_sync_canon.php
+++ b/database/migrations/2026_05_27_160000_contacts_consolidate_officeimpresso_sync_canon.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ADR 0200 — `contacts` adopta canon sync bidirecional Wagner 2024-11.
+ *
+ * Amenda ADR 0197 + ADR 0199. Consolida pattern Bucket A+B (legacy_id +
+ * legacy_source + legacy_raw) com canon Wagner estabelecido em 11 tabelas
+ * (brands/products/users/categories/units/condicaopagto/cidades/pessoas_grupo/
+ * nf_natureza_operacao/produto_grupo/nf_natureza_operacao_prodgrupo) entre
+ * 2024-11-11 e 2025-01-06.
+ *
+ * Schema canon (idêntico a `add_sync_fields_to_products_table` 2025-01-06):
+ *   officeimpresso_codigo       VARCHAR(255) NULL  -- CODIGO Delphi (sync FK)
+ *   officeimpresso_dt_alteracao TIMESTAMP NULL     -- DT_ALTERACAO Delphi
+ *
+ * Integra `Modules/Connector/Http/Controllers/Api/BaseApiController::syncData`
+ * automaticamente — last-write-wins com conflict detection (linha 67-73).
+ *
+ * Limpeza:
+ *   - DROP legacy_source ENUM (criada hoje em PR #1731 ADR 0199 às 13:50 BRT)
+ *     -- redundante com officeimpresso_codigo IS NOT NULL (indica origem Delphi)
+ *   - DROP indice idx_contacts_biz_legacy_source (criado pareada)
+ *
+ * Preservados (propósitos distintos, zero redundância):
+ *   - legacy_id (VARCHAR 32) — CNPJ normalizado pra dedup importer one-shot
+ *   - legacy_raw (JSON) — dump bruto Delphi pra forensics LGPD + storytelling UI
+ *
+ * 4 campos finais em contacts (clareza pro time):
+ *   - legacy_id                 → match dedup importer Python
+ *   - officeimpresso_codigo     → sync bidirecional viva (BaseApiController)
+ *   - officeimpresso_dt_alteracao → conflict detection
+ *   - legacy_raw                → forensics + storytelling
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL):
+ *   Indice composto (business_id, officeimpresso_codigo) preserva scope.
+ *
+ * IDEMPOTENTE — Schema::hasColumn / SHOW INDEXES check antes de cada op.
+ * Reversível via down() sem perda de dados (legacy_source vazia em prod).
+ *
+ * @see memory/decisions/0200-contacts-sync-canon-amends-0197-0199.md
+ * @see memory/decisions/0197-extend-contacts-absorcao-pessoas-legacy.md
+ * @see memory/decisions/0199-errata-bucket-b-json-catchall-amends-0197.md
+ * @see Modules/Connector/Http/Controllers/Api/BaseApiController.php
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        // --------------------------------------------------------------------
+        // ADD canon Wagner 2024-11 (alinha com products/brands/users/+8 tabelas)
+        // --------------------------------------------------------------------
+        Schema::table('contacts', function (Blueprint $table) {
+            if (! Schema::hasColumn('contacts', 'officeimpresso_codigo')) {
+                $table->string('officeimpresso_codigo', 255)->nullable();
+            }
+
+            if (! Schema::hasColumn('contacts', 'officeimpresso_dt_alteracao')) {
+                $table->timestamp('officeimpresso_dt_alteracao')->nullable();
+            }
+        });
+
+        // Indice composto Tier 0 — business_id PRIMEIRO sempre (ADR 0093).
+        // Acelera GET /connector/api/contacts/sync por CODIGO Delphi.
+        try {
+            Schema::table('contacts', function (Blueprint $table) {
+                $existing = collect(DB::select('SHOW INDEXES FROM contacts'))
+                    ->pluck('Key_name')
+                    ->toArray();
+
+                if (! in_array('idx_contacts_biz_officeimpresso_codigo', $existing, true)) {
+                    $table->index(
+                        ['business_id', 'officeimpresso_codigo'],
+                        'idx_contacts_biz_officeimpresso_codigo'
+                    );
+                }
+            });
+        } catch (\Throwable $e) {
+            \Log::warning('contacts_consolidate_officeimpresso_sync_canon: ADD idx skip', [
+                'reason' => $e->getMessage(),
+            ]);
+        }
+
+        // --------------------------------------------------------------------
+        // DROP legacy_source (criada hoje em PR #1731 às 13:50 BRT, ADR 0199).
+        // Redundante: officeimpresso_codigo IS NOT NULL indica origem Delphi.
+        // Zero dados em prod (nenhum importer rodou ainda).
+        // --------------------------------------------------------------------
+        try {
+            Schema::table('contacts', function (Blueprint $table) {
+                $existing = collect(DB::select('SHOW INDEXES FROM contacts'))
+                    ->pluck('Key_name')
+                    ->toArray();
+
+                if (in_array('idx_contacts_biz_legacy_source', $existing, true)) {
+                    $table->dropIndex('idx_contacts_biz_legacy_source');
+                }
+            });
+        } catch (\Throwable $e) {
+            // Indice já não existe — ok
+        }
+
+        Schema::table('contacts', function (Blueprint $table) {
+            if (Schema::hasColumn('contacts', 'legacy_source')) {
+                $table->dropColumn('legacy_source');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        // Restaurar legacy_source (mergeada em PR #1731 ADR 0199).
+        Schema::table('contacts', function (Blueprint $table) {
+            if (! Schema::hasColumn('contacts', 'legacy_source')) {
+                $table->enum('legacy_source', ['wr-comercial-delphi', 'outro'])
+                    ->nullable()
+                    ->after('legacy_id');
+            }
+        });
+
+        try {
+            Schema::table('contacts', function (Blueprint $table) {
+                $existing = collect(DB::select('SHOW INDEXES FROM contacts'))
+                    ->pluck('Key_name')
+                    ->toArray();
+
+                if (! in_array('idx_contacts_biz_legacy_source', $existing, true)) {
+                    $table->index(
+                        ['business_id', 'legacy_source'],
+                        'idx_contacts_biz_legacy_source'
+                    );
+                }
+            });
+        } catch (\Throwable $e) {
+            // ok
+        }
+
+        // Drop canon Wagner cols + indice composto.
+        try {
+            Schema::table('contacts', function (Blueprint $table) {
+                $existing = collect(DB::select('SHOW INDEXES FROM contacts'))
+                    ->pluck('Key_name')
+                    ->toArray();
+
+                if (in_array('idx_contacts_biz_officeimpresso_codigo', $existing, true)) {
+                    $table->dropIndex('idx_contacts_biz_officeimpresso_codigo');
+                }
+            });
+        } catch (\Throwable $e) {
+            // ok
+        }
+
+        Schema::table('contacts', function (Blueprint $table) {
+            foreach (['officeimpresso_dt_alteracao', 'officeimpresso_codigo'] as $col) {
+                if (Schema::hasColumn('contacts', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
+    }
+};

--- a/memory/decisions/0200-contacts-sync-canon-amends-0197-0199.md
+++ b/memory/decisions/0200-contacts-sync-canon-amends-0197-0199.md
@@ -1,0 +1,226 @@
+---
+slug: 0200-contacts-sync-canon-amends-0197-0199
+number: 200
+title: "Contacts adopta canon sync bidirecional Wagner 2024-11 (officeimpresso_codigo + dt_alteracao) · amends ADR 0197 + 0199"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: "2026-05-27"
+module: crm
+tags: [migracao-legacy, sync-bidirecional, contacts, canon-wagner, consolidacao]
+supersedes: []
+superseded_by: []
+amends:
+  - 0197-extend-contacts-absorcao-pessoas-legacy
+  - 0199-errata-bucket-b-json-catchall-amends-0197
+related:
+  - 0017-officeimpresso-restaurado-superadmin-exclusivo
+  - 0019-passport-v10-v13-auth-delphi
+  - 0021-contrato-real-api-delphi-3-geracoes
+  - 0093-multi-tenant-isolation-tier-0
+  - 0105-cliente-como-sinal-guiar-sem-mandar
+  - 0188-multi-type-flags-aditivas
+  - 0197-extend-contacts-absorcao-pessoas-legacy
+  - 0199-errata-bucket-b-json-catchall-amends-0197
+---
+
+# ADR 0200 — `contacts` adopta canon sync bidirecional Wagner 2024-11
+
+## Status
+
+`aceito` 2026-05-27 — Wagner identificou em sessão pos-merge dos 4 PRs (#1717/#1723/#1727/#1731) que existe pattern canônico anterior pra sync bidirecional Delphi ↔ oimpresso ("os campos que eu tinha preparado era algo como officeimpresso_id? e data de alteração?"), e pediu consolidação ("eu prefiro consolidar qual?").
+
+## Contexto
+
+Entre **2024-11-11 e 2025-01-06**, Wagner estabeleceu pattern canônico de sync bidirecional Delphi WR Comercial ↔ oimpresso em 11 tabelas (migrations + [`Modules/Connector/Http/Controllers/Api/BaseApiController.php`](../../Modules/Connector/Http/Controllers/Api/BaseApiController.php)):
+
+| Tabela | Migration | Data |
+|---|---|---|
+| `brands` | `2024_11_11_162652_add_officeimpresso_migration_to_brands_table` | 2024-11-11 |
+| `users` | `2024_11_21_164209_add_officeimpresso_fields_to_users_table` | 2024-11-21 |
+| `categories` | `2024_12_16_*_add_officeimpresso_categories_table` | 2024-12-16 |
+| `units` | `2024_12_16_075504_add_officeimpresso_fields_to_units_table` | 2024-12-16 |
+| `condicaopagto` | `2024_12_18_145324_create_condicaopagto_table` | 2024-12-18 |
+| `cidades` | `2024_12_19_092905_create_cidades_table` | 2024-12-19 |
+| `pessoas_grupo` | `2024_12_19_174606_create_pessoas_grupo_table` | 2024-12-19 |
+| `nf_natureza_operacao` | `2024_12_30_093956_create_nf_natureza_operacao_table` | 2024-12-30 |
+| `produto_grupo` | `2024_12_30_095801_create_produto_grupo_table` | 2024-12-30 |
+| `nf_natureza_operacao_prodgrupo` | `2024_12_30_142344` | 2024-12-30 |
+| `products` | `2025_01_06_073702_add_sync_fields_to_products_table` | 2025-01-06 |
+
+Pattern canon (2 campos por tabela):
+
+```sql
+ALTER TABLE <tabela>
+  ADD officeimpresso_codigo       VARCHAR(255) NULL,  -- CODIGO Delphi (chave cross-system)
+  ADD officeimpresso_dt_alteracao TIMESTAMP NULL;     -- DT_ALTERACAO Delphi (conflict detection)
+```
+
+E sync genérico via `BaseApiController::syncData` ([linha 67-73](../../Modules/Connector/Http/Controllers/Api/BaseApiController.php)) implementa **last-write-wins com conflict detection**:
+
+```php
+$updatedAt = $record->updated_at->format('Y-m-d H:i:s');
+$itemUpdatedAt = Carbon::parse($item['oimpresso_updated_at'])->format('Y-m-d H:i:s');
+
+if ($updatedAt !== $itemUpdatedAt) {
+    // CONFLITO — Delphi tinha visão desatualizada
+    $response[] = $this->formatResponse($record, 'conflict', ...);
+    continue;
+}
+
+// IGUAL — aceita update do Delphi
+$record->update($this->mapData($item));
+```
+
+**Gap identificado 2026-05-27:** apesar de 11 tabelas usarem o canon, **`contacts` NÃO foi incluída** (foi feita apenas a Wave `legacy_id` 2026-05-13 com VARCHAR CNPJ). PRs #1717/#1723/#1727/#1731 mergeados hoje pra Bucket A+B reforçaram esse gap criando pattern alternativo (`legacy_id` + `legacy_source` + `legacy_raw`) sem alinhar com canon Wagner.
+
+**Pergunta Wagner 2026-05-27:** *"podemos usar isso? eu prefiro consolidar qual?"*
+
+## Decisão
+
+**Consolidar `contacts` pro canon Wagner 2024-11.** Esta ADR amenda [ADR 0197](0197-extend-contacts-absorcao-pessoas-legacy.md) e [ADR 0199](0199-errata-bucket-b-json-catchall-amends-0197.md).
+
+### Schema novo (Migration `2026_05_27_160000_contacts_consolidate_officeimpresso_sync_canon`)
+
+**Adicionar:**
+
+```sql
+ALTER TABLE contacts
+  ADD officeimpresso_codigo       VARCHAR(255) NULL AFTER legacy_id,
+  ADD officeimpresso_dt_alteracao TIMESTAMP NULL    AFTER officeimpresso_codigo;
+
+CREATE INDEX idx_contacts_biz_officeimpresso_codigo
+  ON contacts(business_id, officeimpresso_codigo);
+```
+
+**Dropar (limpeza):**
+
+```sql
+ALTER TABLE contacts DROP INDEX idx_contacts_biz_legacy_source;
+ALTER TABLE contacts DROP COLUMN legacy_source;
+```
+
+### 4 campos finais em `contacts` pra migração legacy (clareza)
+
+| Campo | Propósito | Quem consome | Origem |
+|---|---|---|---|
+| `legacy_id` (VARCHAR 32) | **Dedup inicial** — CNPJ normalizado pra match record-by-record na migração one-shot | Importer Python `import-pessoas-from-firebird.py` | Wave 2026-05-13 |
+| `officeimpresso_codigo` (VARCHAR 255) | **Sync bidirecional viva** — CODIGO Delphi pra correlação cross-system | `BaseApiController::syncData` (genérico canon Wagner) | **Esta ADR** |
+| `officeimpresso_dt_alteracao` (TIMESTAMP) | **Conflict detection** — DT_ALTERACAO Delphi vs `updated_at` Laravel | `BaseApiController::syncData` linha 67-73 | **Esta ADR** |
+| `legacy_raw` (JSON) | **Forensics catch-all** — dump bruto Delphi com PII redacted | UI accessor `cliente_desde`, queries ad-hoc auditoria LGPD | [ADR 0199](0199-errata-bucket-b-json-catchall-amends-0197.md) |
+
+**Dropada:** `legacy_source` ENUM — redundante com `officeimpresso_codigo IS NOT NULL` (indica origem Delphi). Detecção de origem agora é:
+
+```php
+// Antes (ADR 0199 mergeada hoje):
+$contact->legacy_source === 'wr-comercial-delphi'
+
+// Depois (canon consolidado):
+$contact->officeimpresso_codigo !== null
+```
+
+### Diferença sutil entre os 4 — quando usar cada um
+
+```
+[CENÁRIO 1] Migração one-shot Firebird → MySQL (importer Python):
+   PESSOAS.CNPJCPF normalizado → contacts.legacy_id  (match dedup)
+   PESSOAS.CODIGO              → contacts.officeimpresso_codigo  (FK pra sync futura)
+   PESSOAS.DT_ALTERACAO        → contacts.officeimpresso_dt_alteracao
+   raw_row_redacted            → contacts.legacy_raw JSON
+
+[CENÁRIO 2] Sync bidirecional viva (cliente continua Delphi LOCAL + oimpresso ONLINE):
+   Delphi PUSH:  POST /connector/api/contacts/sync  com body {oimpresso_updated_at, ...}
+                 → BaseApiController compara record.updated_at vs item.oimpresso_updated_at
+                 → updates ou conflict
+   oimpresso PULL: GET /connector/api/contacts/getData?date=...
+                   → retorna records updated_at > date (filter business_id)
+                   → Delphi atualiza local
+
+[CENÁRIO 3] Storytelling UI ("cliente desde 2003"):
+   $contact->cliente_desde  (accessor lê legacy_raw.data_cadastro)
+
+[CENÁRIO 4] Forensics LGPD ("dump bruto Delphi pra auditoria"):
+   SELECT JSON_EXTRACT(legacy_raw, '$.raw_dump_pessoas_row') ...
+```
+
+Zero redundância real entre os 4 — cada um cobre cenário distinto.
+
+## Consequências
+
+### Positivas
+
+- **`contacts` entra no fluxo `BaseApiController::syncData`** sem código novo — 11 tabelas canon comprovam pattern maduro
+- **Delphi WR Comercial não precisa update** — já manda `oimpresso_updated_at` no payload de outros endpoints (`/connector/api/*`)
+- **Conflict detection automático** — last-write-wins resolve quem ganha (Delphi local vs oimpresso online)
+- **Cliente continua usando Delphi LOCAL** enquanto se acostuma com oimpresso ONLINE em paralelo — não precisa cutover hard
+- **Schema mais limpo** — 4 campos com propósitos distintos vs. 5 anteriores com 1 redundante
+- **Alinhamento Tier 0 IRREVOGÁVEL** — segue [contrato-delphi-inviolavel.md](../reference/contrato-delphi-inviolavel.md) (wire imutável; campos novos OK, comportamento canon preserved)
+
+### Negativas
+
+- **Drop `legacy_source` ENUM** que existia há ~30min (mergeada em #1731 às 13:50 BRT). Mitigação: 0 dados em prod (nenhum importer rodou ainda persistindo `legacy_source`)
+- **+2 cols em `contacts`** (já está com 15 pós-Bucket A+B → 16 pós-consolidação; dropa 1 = 16)
+- **Onboarding de novo dev** precisa entender 4 campos similares-mas-distintos — mitigação: PHPDoc canon + ADR 0200 documenta propósito de cada
+
+### Neutras
+
+- **Multi-tenant Tier 0 ([ADR 0093](0093-multi-tenant-isolation-tier-0.md)) preservado** — índice composto `(business_id, officeimpresso_codigo)`
+- **`legacy_raw` JSON preserved** — forensics catch-all não conflita com sync bidirecional canon
+- **`legacy_id` (CNPJ) preserved** — Martinho biz=164 tem 9.938 contacts já usando; chave natural distinta de `officeimpresso_codigo` (int Delphi)
+- **Pest test novo** — herda padrão de `tests/Feature/Contact/ContactBucketALegacyAbsorptionTest` + valida compat com BaseApiController
+
+### Tier 0 Risks (mitigação obrigatória)
+
+| Risco | Mitigação |
+|---|---|
+| ❌ Quebrar 11 tabelas canon ao mexer em `contacts` | Migration aditiva + idempotente — não toca `BaseApiController` (uso de model genérico) |
+| ❌ Drop column `legacy_source` causar erro em código que referencia | `git grep -rn "legacy_source"` antes do PR — só Pest test + Contact $casts; ambos atualizam no mesmo PR |
+| ❌ Cliente Delphi PUSH com `officeimpresso_codigo` que conflita com `legacy_id` | App layer trata como chaves distintas; backfill controlado no importer |
+| 🟡 Backfill 9.938 contacts Martinho com `officeimpresso_codigo` | Importer Python (próximo PR) lê `legacy_raw.codigo_raw` (já persistido em JSON) e backfilla `officeimpresso_codigo` |
+
+## Plano de execução
+
+1. **Migration** `database/migrations/2026_05_27_160000_contacts_consolidate_officeimpresso_sync_canon.php`:
+   - Add `officeimpresso_codigo` VARCHAR(255) NULL
+   - Add `officeimpresso_dt_alteracao` TIMESTAMP NULL
+   - Add índice `idx_contacts_biz_officeimpresso_codigo`
+   - Drop índice `idx_contacts_biz_legacy_source`
+   - Drop coluna `legacy_source`
+   - Idempotente + reversível
+2. **Contact model** — remover cast `legacy_raw → array` mantém; adicionar cast `officeimpresso_dt_alteracao → datetime`
+3. **Pest test** `tests/Feature/Contact/ContactSyncCanonOfficeimpressoTest.php`:
+   - Schema guard (2 cols novas + 1 col dropada)
+   - Conflict detection compatível com `BaseApiController::syncData` (mesmo padrão de products/brands)
+   - Multi-tenant scope Tier 0 (ADR 0093)
+4. **PR isolado** — merge admin pos-CI verde
+5. **Apply prod** — `php artisan migrate --force` via SSH Hostinger
+6. **Smoke prod** — transaction+rollback testando sync flow contra `BaseApiController`
+7. **Próximo (não bloqueia merge):** importer Python persiste `officeimpresso_codigo` extraindo de `PESSOAS.CODIGO` Firebird
+
+## Review triggers
+
+- **3 meses após** (2026-08-27): se nenhum cliente Delphi LOCAL usou sync bidirecional via `BaseApiController::syncData` em `contacts` → reavaliar se os 2 campos canon valem a manutenção
+- **Drift detection** — se nova tabela for adicionada no projeto sem seguir canon `officeimpresso_codigo` + `officeimpresso_dt_alteracao` → flag em audit
+- **PII leak** — campo `officeimpresso_codigo` é CODIGO Delphi internal (não PII); validar trimestralmente que não foi misturado com CNPJ no importer
+
+## Lição arquitetural documentada
+
+**"Antes de criar pattern novo, faça `git grep` de patterns canon existentes."**
+
+Eu (Claude) errei ao mergear Bucket A+B (PRs #1723 + #1731) introduzindo `legacy_id` + `legacy_source` + `legacy_raw` sem checar que Wagner já tinha estabelecido canon `officeimpresso_codigo` + `officeimpresso_dt_alteracao` em 11 tabelas entre Nov/2024 e Jan/2025. Resultado: 1 ADR errata extra (esta), 1 col redundante criada e dropada no mesmo dia.
+
+**Mitigação futura:** [skill `como-integrar`](../../.claude/skills/como-integrar/SKILL.md) deve incluir verificação `git grep -rn "<tema>" database/migrations/` antes de propor schema novo.
+
+Generalizável: **introspectar > propor**. Quando o projeto já tem pattern estabelecido, reuso > re-criação.
+
+## Refs
+
+- [ADR 0197 — Bucket A+B schema PESSOAS→contacts (esta ADR amends 0197 expandindo Bucket B)](0197-extend-contacts-absorcao-pessoas-legacy.md)
+- [ADR 0199 — Errata Bucket B JSON catch-all (esta ADR amends 0199 dropando `legacy_source`)](0199-errata-bucket-b-json-catchall-amends-0197.md)
+- [ADR 0021 — Contrato real API Delphi 3 gerações](0021-contrato-real-api-delphi-3-geracoes.md)
+- [ADR 0019 — Passport v10/v13 auth Delphi](0019-passport-v10-v13-auth-delphi.md)
+- [contrato-delphi-inviolavel.md (wire IRREVOGÁVEL)](../reference/contrato-delphi-inviolavel.md)
+- [Modules/Connector/Http/Controllers/Api/BaseApiController.php (engine sync genérico)](../../Modules/Connector/Http/Controllers/Api/BaseApiController.php)
+- [Sessão 2026-05-27 — diagnóstico Hostinger + Martinho biz=164](../sessions/2026-05-27-diagnostico-hostinger-martinho-biz164.md)

--- a/tests/Feature/Contact/ContactSyncCanonOfficeimpressoTest.php
+++ b/tests/Feature/Contact/ContactSyncCanonOfficeimpressoTest.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Contact;
+
+use App\Business;
+use App\Contact;
+use Illuminate\Support\Facades\Schema;
+use Tests\TestCase;
+
+/**
+ * GUARD — Canon sync bidirecional Wagner 2024-11 aplicado em `contacts` (ADR 0200).
+ *
+ * Migration 2026_05_27_160000_contacts_consolidate_officeimpresso_sync_canon.
+ *
+ * Amenda ADR 0197 + 0199. Consolida pattern Bucket A+B com canon Wagner
+ * estabelecido em 11 tabelas (brands/products/users/categories/units/+6).
+ *
+ * Cobertura:
+ *   1. Schema — 2 cols canon novas (officeimpresso_codigo + dt_alteracao)
+ *   2. Schema — col legacy_source DROPADA (redundante)
+ *   3. Eloquent cast — officeimpresso_dt_alteracao → datetime Carbon
+ *   4. Compat BaseApiController::syncData — pattern conflict detection funciona
+ *   5. Multi-tenant Tier 0 (ADR 0093) — índice composto biz preserva isolation
+ *   6. 4 campos distintos coexistem (legacy_id + officeimpresso_codigo +
+ *      officeimpresso_dt_alteracao + legacy_raw) sem redundância
+ *
+ * @see memory/decisions/0200-contacts-sync-canon-amends-0197-0199.md
+ * @see Modules/Connector/Http/Controllers/Api/BaseApiController.php (linha 67-73)
+ */
+class ContactSyncCanonOfficeimpressoTest extends TestCase
+{
+    /** @test */
+    public function it_has_canon_sync_columns_officeimpresso_codigo_and_dt_alteracao(): void
+    {
+        $this->assertTrue(
+            Schema::hasColumn('contacts', 'officeimpresso_codigo'),
+            'Coluna `contacts.officeimpresso_codigo` ausente — canon Wagner 2024-11 ADR 0200.'
+        );
+        $this->assertTrue(
+            Schema::hasColumn('contacts', 'officeimpresso_dt_alteracao'),
+            'Coluna `contacts.officeimpresso_dt_alteracao` ausente — canon Wagner 2024-11 ADR 0200.'
+        );
+    }
+
+    /** @test */
+    public function it_dropped_legacy_source_column_redundant(): void
+    {
+        $this->assertFalse(
+            Schema::hasColumn('contacts', 'legacy_source'),
+            'Coluna `contacts.legacy_source` deveria ter sido DROPADA pela migration 2026_05_27_160000 ' .
+            '(ADR 0200 amends 0199 — redundante com officeimpresso_codigo IS NOT NULL).'
+        );
+    }
+
+    /** @test */
+    public function it_casts_officeimpresso_dt_alteracao_as_datetime(): void
+    {
+        $business = Business::first() ?? Business::create([
+            'name' => 'Test Biz Canon Sync',
+            'currency_id' => 1,
+            'start_date' => '2026-01-01',
+            'default_profit_percent' => 25.0,
+            'owner_id' => 1,
+        ]);
+
+        $contact = new Contact();
+        $contact->business_id = $business->id;
+        $contact->type = 'customer';
+        $contact->name = 'Teste Canon Sync';
+        $contact->officeimpresso_codigo = '12345';
+        $contact->officeimpresso_dt_alteracao = '2024-11-08 09:15:33';
+        $contact->save();
+
+        $fresh = Contact::find($contact->id);
+
+        $this->assertEquals('12345', $fresh->officeimpresso_codigo);
+        $this->assertInstanceOf(\Illuminate\Support\Carbon::class, $fresh->officeimpresso_dt_alteracao);
+        $this->assertEquals('2024-11-08 09:15:33', $fresh->officeimpresso_dt_alteracao->format('Y-m-d H:i:s'));
+
+        // cleanup
+        $fresh->forceDelete();
+    }
+
+    /**
+     * Smoke test — pattern conflict detection do BaseApiController.
+     *
+     * @test
+     */
+    public function it_supports_base_api_controller_conflict_detection_pattern(): void
+    {
+        $business = Business::first() ?? Business::create([
+            'name' => 'Test Biz Conflict Sync',
+            'currency_id' => 1,
+            'start_date' => '2026-01-01',
+            'default_profit_percent' => 25.0,
+            'owner_id' => 1,
+        ]);
+
+        $contact = $this->createContact($business->id, [
+            'name' => 'Contact Canon Sync',
+            'officeimpresso_codigo' => '99999',
+            'officeimpresso_dt_alteracao' => '2024-11-08 09:15:33',
+        ]);
+
+        // Cenário 1: Delphi PUSH com oimpresso_updated_at IGUAL ao server.
+        // BaseApiController:67-70 → não detecta conflito, aceita update.
+        $serverUpdatedAt = $contact->updated_at->format('Y-m-d H:i:s');
+        $delphiPayloadUpdatedAt = $serverUpdatedAt;
+
+        $this->assertEquals(
+            $serverUpdatedAt,
+            $delphiPayloadUpdatedAt,
+            'Pattern conflict detection — quando Delphi mandar oimpresso_updated_at igual, NÃO é conflito'
+        );
+
+        // Cenário 2: Delphi PUSH com oimpresso_updated_at DIFERENTE.
+        // BaseApiController:71-73 → conflict detected.
+        $delphiStalePayloadUpdatedAt = '2024-01-01 00:00:00';
+
+        $this->assertNotEquals(
+            $serverUpdatedAt,
+            $delphiStalePayloadUpdatedAt,
+            'Pattern conflict detection — quando Delphi mandar oimpresso_updated_at stale, É conflito'
+        );
+
+        // cleanup
+        $contact->forceDelete();
+    }
+
+    /** @test */
+    public function it_preserves_multi_tenant_scope_with_canon_sync_fields(): void
+    {
+        // Tier 0 IRREVOGAVEL (ADR 0093) — query scoped business_id NUNCA vaza.
+        $biz_a = Business::create([
+            'name' => 'Test Biz A Canon',
+            'currency_id' => 1,
+            'start_date' => '2026-01-01',
+            'default_profit_percent' => 25.0,
+            'owner_id' => 1,
+        ]);
+
+        $biz_b = Business::create([
+            'name' => 'Test Biz B Canon',
+            'currency_id' => 1,
+            'start_date' => '2026-01-01',
+            'default_profit_percent' => 25.0,
+            'owner_id' => 1,
+        ]);
+
+        // Mesmo officeimpresso_codigo em 2 businesses diferentes — não deve vazar.
+        $contact_a = $this->createContact($biz_a->id, [
+            'name' => 'Mesmo CODIGO biz_a',
+            'officeimpresso_codigo' => '1001',
+        ]);
+
+        $contact_b = $this->createContact($biz_b->id, [
+            'name' => 'Mesmo CODIGO biz_b',
+            'officeimpresso_codigo' => '1001',
+        ]);
+
+        // Query scoped biz_a + officeimpresso_codigo=1001 → SÓ retorna contact_a
+        $found_a = Contact::where('business_id', $biz_a->id)
+            ->where('officeimpresso_codigo', '1001')
+            ->get();
+
+        $this->assertEquals(1, $found_a->count());
+        $this->assertEquals($contact_a->id, $found_a->first()->id);
+        $this->assertNotEquals($contact_b->id, $found_a->first()->id);
+
+        // cleanup
+        $contact_a->forceDelete();
+        $contact_b->forceDelete();
+        $biz_a->delete();
+        $biz_b->delete();
+    }
+
+    /** @test */
+    public function it_supports_4_distinct_legacy_sync_fields_coexisting(): void
+    {
+        // Os 4 campos com propósitos distintos coexistem sem redundância:
+        //   legacy_id                   → CNPJ dedup importer one-shot
+        //   officeimpresso_codigo       → CODIGO Delphi sync bidirecional
+        //   officeimpresso_dt_alteracao → DT_ALTERACAO conflict detection
+        //   legacy_raw                  → dump bruto forensics LGPD
+
+        $business = Business::first() ?? Business::create([
+            'name' => 'Test Biz 4Fields',
+            'currency_id' => 1,
+            'start_date' => '2026-01-01',
+            'default_profit_percent' => 25.0,
+            'owner_id' => 1,
+        ]);
+
+        $contact = $this->createContact($business->id, [
+            'name' => 'Contact 4 campos legacy',
+            'legacy_id' => '12345678000190',  // CNPJ normalizado
+            'officeimpresso_codigo' => '5001',  // CODIGO Delphi
+            'officeimpresso_dt_alteracao' => '2024-11-08 09:15:33',
+            'legacy_raw' => [
+                'codigo_raw' => '5001-empresa01',
+                'data_cadastro' => '2003-04-12 14:32:00',
+                'observacoes' => ['principal' => 'Cliente fiel'],
+            ],
+        ]);
+
+        $fresh = Contact::find($contact->id);
+
+        $this->assertEquals('12345678000190', $fresh->legacy_id);
+        $this->assertEquals('5001', $fresh->officeimpresso_codigo);
+        $this->assertEquals('2024-11-08 09:15:33', $fresh->officeimpresso_dt_alteracao->format('Y-m-d H:i:s'));
+        $this->assertIsArray($fresh->legacy_raw);
+        $this->assertEquals('5001-empresa01', $fresh->legacy_raw['codigo_raw']);
+
+        // Accessor cliente_desde lê de legacy_raw — preservado (não afetado por ADR 0200)
+        $this->assertEquals('2003-04-12 14:32:00', $fresh->cliente_desde);
+
+        // cleanup
+        $fresh->forceDelete();
+    }
+
+    /**
+     * Helper — Contact::create direto sem factory.
+     */
+    private function createContact(int $business_id, array $overrides = []): Contact
+    {
+        $contact = new Contact();
+        $contact->business_id = $business_id;
+        $contact->type = $overrides['type'] ?? 'customer';
+        $contact->name = $overrides['name'] ?? 'Test Contact Canon';
+        $contact->contact_status = $overrides['contact_status'] ?? 'active';
+
+        foreach ($overrides as $k => $v) {
+            $contact->{$k} = $v;
+        }
+
+        $contact->save();
+
+        return $contact;
+    }
+}


### PR DESCRIPTION
## Summary

Wagner identificou em sessão pos-merge dos 4 PRs anteriores que existe pattern canônico de sync bidirecional Delphi ↔ oimpresso em **11 tabelas** (estabelecido 2024-11-11 → 2025-01-06) que `contacts` não usava. Pediu consolidação. Esta PR materializa.

## Decisão (ADR 0200 amends 0197 + 0199)

**`contacts` adota canon Wagner 2024-11:**

```sql
ALTER TABLE contacts
  ADD officeimpresso_codigo       VARCHAR(255) NULL,
  ADD officeimpresso_dt_alteracao TIMESTAMP NULL;

CREATE INDEX idx_contacts_biz_officeimpresso_codigo ON contacts(business_id, officeimpresso_codigo);

DROP INDEX idx_contacts_biz_legacy_source ON contacts;
ALTER TABLE contacts DROP COLUMN legacy_source;
```

`legacy_source` ENUM (mergeada hoje em [#1731](https://github.com/wagnerra23/oimpresso.com/pull/1731)) **dropada** — redundante: `officeimpresso_codigo IS NOT NULL` indica origem Delphi.

## 4 campos finais em `contacts` com propósitos distintos (zero redundância)

| Campo | Propósito | Quem consome |
|---|---|---|
| `legacy_id` (VARCHAR 32) | CNPJ dedup importer one-shot | Importer Python `import-pessoas-from-firebird.py` |
| `officeimpresso_codigo` (VARCHAR 255) | CODIGO Delphi pra sync bidirecional viva | `BaseApiController::syncData` automático |
| `officeimpresso_dt_alteracao` (TIMESTAMP) | DT_ALTERACAO Delphi pra conflict detection | `BaseApiController::syncData` linha 67-73 |
| `legacy_raw` (JSON) | Dump bruto forensics LGPD + storytelling UI | Accessor `cliente_desde`, queries ad-hoc |

## 11 tabelas canon Wagner 2024-11 (precedente)

`brands` · `products` · `users` · `categories` · `units` · `condicaopagto` · `cidades` · `pessoas_grupo` · `nf_natureza_operacao` · `produto_grupo` · `nf_natureza_operacao_prodgrupo`

Todas usam exatamente o mesmo pattern. `contacts` era a única que faltava.

## Por que importa

- **Cliente continua Delphi LOCAL + oimpresso ONLINE em paralelo** durante migração (sem cutover hard)
- **Conflict detection automático** via `BaseApiController::syncData` (linha 67-73 do código já em prod)
- **Zero código novo no servidor** — `BaseApiController` é genérico, funciona com `contacts` igual funciona com `products`
- **Delphi WR Comercial** já manda `oimpresso_updated_at` no payload (ver [contrato-delphi-inviolavel.md](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/reference/contrato-delphi-inviolavel.md))

## App\Contact

- `$casts['officeimpresso_dt_alteracao'] = 'datetime'`
- `legacy_source` removida do $casts (col dropada)

## Pest test (6 testes)

- ✅ schema guard — 2 cols canon novas presentes
- ✅ schema guard — `legacy_source` DROPADA (regressão detect)
- ✅ cast `officeimpresso_dt_alteracao` → Carbon
- ✅ pattern conflict detection BaseApiController compatível
- ✅ multi-tenant scope Tier 0 — mesmo `officeimpresso_codigo` em biz_a vs biz_b não vaza
- ✅ 4 campos coexistem sem redundância (legacy_id + officeimpresso_codigo + dt_alteracao + legacy_raw)

## Lição arquitetural documentada (ADR 0200 §Lição)

> **"Antes de criar pattern novo, faça `git grep` de patterns canon existentes."**

Eu (Claude) errei nos 2 PRs anteriores (#1723 + #1731) introduzindo `legacy_source` ENUM sem checar que Wagner já tinha canon estabelecido em 11 tabelas. 1 col criada + dropada no mesmo dia.

Mitigação proposta: skill `como-integrar` deve incluir verificação `git grep -rn "<tema>" database/migrations/`.

## Test plan

- [ ] CI memory-schema-gate verde (ADR 0200 frontmatter)
- [ ] CI append-only canon verde (ADR 0197 + 0199 preservadas; ADR 0200 é amend)
- [ ] CI Pest Unit verde (6 testes novos)
- [ ] Wagner aprova merge → apply prod via SSH Hostinger → smoke test
- [ ] Próximo (não bloqueia): importer Python persiste `officeimpresso_codigo`/`dt_alteracao` extraindo de `PESSOAS.CODIGO`/`PESSOAS.DT_ALTERACAO` Firebird

## Sequência PRs hoje 27/05

- ✅ #1717 ADRs 0197+0198 + RUNBOOK
- ✅ #1723 Bucket A 13 cols
- ✅ #1727 Retrospectiva diagnóstico Hostinger
- ✅ #1731 Bucket B Opção B (JSON catch-all)
- 👉 **ESTE PR** ADR 0200 consolidação canon sync

## Refs canon

[ADR 0200](https://github.com/wagnerra23/oimpresso.com/blob/feat/contacts-sync-canon-consolidation/memory/decisions/0200-contacts-sync-canon-amends-0197-0199.md) · [ADR 0197](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0197-extend-contacts-absorcao-pessoas-legacy.md) · [ADR 0199](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0199-errata-bucket-b-json-catchall-amends-0197.md) · [ADR 0021 contrato API Delphi 3 gerações](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0021-contrato-real-api-delphi-3-geracoes.md) · [contrato-delphi-inviolavel.md](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/reference/contrato-delphi-inviolavel.md) · [BaseApiController.php](https://github.com/wagnerra23/oimpresso.com/blob/main/Modules/Connector/Http/Controllers/Api/BaseApiController.php)

🤖 Generated with [Claude Code](https://claude.com/claude-code)