### PR TITLE
fix(cliente/drawer): trocar de aba nao apaga mais dados nao-salvos

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -457,7 +457,22 @@ class ContactController extends Controller
             'contacts.state',
             'contacts.balance',
             'contacts.created_at',
+            // Endereço completo — sem isso, router.reload({only:['rows']}) pós lookup
+            // CNPJ/CEP zera campos no EnderecoTab (undefined → setState('')) e a UI
+            // some apesar do DB ter os dados. Wagner 2026-05-27.
+            'contacts.zip_code',
+            'contacts.address_line_1',
+            'contacts.address_line_2',
         ];
+        // `neighborhood` e `numero` (BR canon) — migrations aditivas recentes
+        // (2026_05_22_120000 e 2026_05_22_180000). hasColumn graceful pra
+        // ambientes pré-migration.
+        if (\Illuminate\Support\Facades\Schema::hasColumn('contacts', 'neighborhood')) {
+            $selectCols[] = 'contacts.neighborhood';
+        }
+        if (\Illuminate\Support\Facades\Schema::hasColumn('contacts', 'numero')) {
+            $selectCols[] = 'contacts.numero';
+        }
         if ($hasWaveBCols) {
             $selectCols = array_merge($selectCols, [
                 'contacts.tipo',
@@ -574,6 +589,18 @@ class ContactController extends Controller
                 'last_purchase_at' => $lastPurchaseAt,
                 // Z-2.1: subtitle drawer "Pessoa jurídica · cadastrado há Xd".
                 'created_at' => optional($contact->created_at)->toIso8601String(),
+                // Endereço canon EN — sem esses campos no payload, EnderecoTab
+                // useEffect reseta state local pra '' quando router.reload({only:['rows']})
+                // dispara pós lookup CNPJ/CEP (`contact.zip_code ?? ''` com undefined → '').
+                // city/state já presentes acima como cidade/uf alias PT-BR — mas
+                // EnderecoTab prefere canon EN. Wagner 2026-05-27.
+                'zip_code' => $contact->zip_code,
+                'address_line_1' => $contact->address_line_1,
+                'address_line_2' => $contact->address_line_2,
+                'neighborhood' => $contact->neighborhood ?? null,
+                'numero' => $contact->numero ?? null,
+                'city' => $contact->city,
+                'state' => $contact->state,
             ];
 
             // Wave G — campos opcionais quando migration Wave B rodou.

--- a/app/Http/Middleware/AdminSidebarMenu.php
+++ b/app/Http/Middleware/AdminSidebarMenu.php
@@ -28,6 +28,14 @@ class AdminSidebarMenu
 
         Menu::create('admin-sidebar-menu', function ($menu) {
             $enabled_modules = !empty(session('business.enabled_modules')) ? session('business.enabled_modules') : [];
+            // Defensive: session pode armazenar enabled_modules como string JSON
+            // se o cast `array` do Business model não foi aplicado (ex: session
+            // hidratada via DB::table sem cast, ou Eloquent serializado perdeu cast
+            // entre requests). json_decode garante array sempre que entrar em in_array.
+            if (is_string($enabled_modules)) {
+                $decoded = json_decode($enabled_modules, true);
+                $enabled_modules = is_array($decoded) ? $decoded : [];
+            }
 
             $common_settings = !empty(session('business.common_settings')) ? session('business.common_settings') : [];
             $pos_settings = !empty(session('business.pos_settings')) ? json_decode(session('business.pos_settings'), true) : [];

--- a/memory/decisions/0195-tabs-autosave-mount-sempre-hidden.md
+++ b/memory/decisions/0195-tabs-autosave-mount-sempre-hidden.md
@@ -1,0 +1,151 @@
+---
+slug: 0195-tabs-autosave-mount-sempre-hidden
+number: 195
+title: "Tabs com autosave/state user-editável ficam mount-sempre (hidden via CSS) — render-condicional só pra tabs read-only"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: "2026-05-27"
+module: core
+quarter: 2026-Q2
+tags: [drawer-760, tabs, autosave, react-state, ux, debounce, persona-larissa, ADR-0179-cliente-drawer, ADR-0185-drawer-canon]
+supersedes: []
+supersedes_partially: []
+superseded_by: []
+related:
+  - "0179-cliente-drawer-760px-substitui-show-fullpage"
+  - "0185-drawer-760-canon-entidades-cadastrais"
+  - "0094-constituicao-v2-7-camadas-8-principios"
+pii: false
+review_triggers:
+  - "Custo de render inicial (5 tabs mount simultâneos) virar gargalo perceptível em monitor médio → considerar lazy-on-first-visit + keep-mounted"
+  - "Algum tab cadastral disparar fetch pesado no mount (BrasilAPI/SEFAZ/IA) → mover fetch pra on-visible em vez de on-mount"
+  - "Tab read-only ganhar state user-editável → promover pra mount-sempre"
+---
+
+# ADR 0195 — Tabs com autosave/state user-editável ficam mount-sempre (hidden via CSS)
+
+## Contexto
+
+[ADR 0179](0179-cliente-drawer-760px-substitui-show-fullpage.md) + [ADR 0185](0185-drawer-760-canon-entidades-cadastrais.md) estabelecem o **Drawer 760** como pattern canônico pra entidades cadastrais (Cliente piloto, escalando pra Fornecedor/Produto/Veículo/Ordem de Serviço/Plano/Equipamento). Cada drawer tem múltiplas tabs (Cliente: 8 — Identificação · Contato · Endereço · Comercial · Classificação · OSs · IA · Auditoria), com **autosave on blur** (debounce 800ms) nas tabs cadastrais.
+
+Implementação inicial em `Pages/Cliente/Index.tsx` (ClienteSheet) usava **render-condicional**:
+
+```tsx
+{activeTab === 'endereco' && <EnderecoTab contact={contact} />}
+```
+
+Wagner 2026-05-27 reportou bug em prod (biz=4 Larissa @ ROTA LIVRE): **"fui testar e ainda perde informações quando troca de aba"**. Reprodução:
+1. User digita CEP/número/email num campo
+2. Troca de aba antes do debounce 800ms disparar
+3. Componente da aba antiga **desmonta** (render-condicional false) → state local perdido + cleanup `useEffect` faz `clearTimeout` em todos os debounces pendentes
+4. User volta pra aba → componente remonta → `useState` inicial pega `contact.*` antigo do payload → valor digitado **sumiu silenciosamente sem nunca ter chegado ao servidor**
+
+Mesmo após [fix payload completo no `rows`](../../app/Http/Controllers/ContactController.php) (commit 2026-05-27 desta sessão), o problema persistia porque o mount/unmount do componente é o que perde o state, não o payload.
+
+Alternativas avaliadas:
+
+| Opção | Trade-off |
+|---|---|
+| **A**: Render-condicional + flush síncrono no cleanup | Refactor por tab — tem que rastrear `currentValue` de cada field em `useRef` pra disparar `performSave` no unmount. Race condition fetch-async vs unmount. |
+| **B**: State elevado pro pai (ClienteSheet via Context/useReducer) | Refactor pesado em 5 tabs + 30+ campos. Quebra encapsulamento. |
+| **C**: `useImperativeHandle` + `tabRef.current.flush()` chamado pelo pai antes de mudar aba | Funciona mas adiciona acoplamento pai↔filho. |
+| **D**: Manter tabs mounted sempre, esconder via `hidden` quando inativas | 1 mudança no pai. State preservado naturalmente. Blur natural do input dispara autosave síncrono ao trocar aba (input perde foco antes do `setActiveTab` re-render). |
+
+## Decisão
+
+**Tabs com autosave ou state user-editável: SEMPRE montadas, escondidas via `hidden={activeTab !== 'X'}`.**
+
+**Tabs read-only (consulta, sem state editável): render-condicional OK** (desmontar economiza memória sem custo de UX).
+
+Implementação padrão (referência canônica: [Pages/Cliente/Index.tsx:1903-1942](../../resources/js/Pages/Cliente/Index.tsx)):
+
+```tsx
+{contact && (
+  <>
+    {/* Tabs cadastrais com autosave — MOUNTED SEMPRE */}
+    <div hidden={activeTab !== 'identificacao'}>
+      <IdentificacaoTab contact={contact} ... />
+    </div>
+    <div hidden={activeTab !== 'contato'}>
+      <ContatoTab contact={contact} />
+    </div>
+    <div hidden={activeTab !== 'endereco'}>
+      <EnderecoTab contact={contact} />
+    </div>
+    {/* ... outras tabs cadastrais ... */}
+
+    {/* Tabs read-only — render-condicional OK */}
+    {activeTab === 'oss' && <OssTab contact={...} />}
+    {activeTab === 'ia' && <IATab contact={...} />}
+    {activeTab === 'auditoria' && <AuditoriaTab contact={...} />}
+  </>
+)}
+```
+
+### Matriz de classificação
+
+| Tipo de tab | Padrão | Por quê |
+|---|---|---|
+| Form com autosave (debounce on change + blur) | **mount-sempre** | State local + debounce timers morrem no unmount |
+| Form sem autosave (botão Salvar explícito) | **mount-sempre** | Form dirty perdido no unmount = re-trabalho do user |
+| Lista/leitura com filtros locais (search, sort) | **mount-sempre** | Filtros aplicados perdidos no unmount |
+| Lista/leitura pura (sem state user) | **render-condicional OK** | Re-fetch do servidor é fonte da verdade |
+| Tab pesada (gráficos AI, timeline ledger) | **render-condicional OK** | Custo de render alto, sem state a preservar |
+
+## Justificativa
+
+- **UX**: Padrão Notion/Linear/Figma — trocar de aba **nunca** descarta trabalho do usuário. Persona Larissa @ biz=4 (não-técnica, 1280×1024) não tem como suspeitar que trocar de aba apaga rascunho.
+- **Simplicidade**: 1 linha de mudança (`{x && <Y/>}` → `<div hidden>...`) cobre o caso 95% sem refactor de cada tab.
+- **Blur natural funciona**: input ativo perde foco quando user clica na nova aba — `handleBlur` dispara `clearTimeout(debounce)` + `performSave` síncrono ANTES do `setActiveTab` re-render. Autosave on blur já estava implementado em cada tab; só faltava o componente não desmontar.
+- **Custo render aceitável pros 5 tabs cadastrais**: forms são leves (sem queries pesadas no mount). IA/OSs/Auditoria continuam lazy.
+
+## Consequências
+
+**Positivas:**
+- State local + debounces pendentes preservados ao trocar aba — zero perda silenciosa
+- Blur natural cobre 100% dos casos sem refactor por tab
+- Pattern aplicável a outras telas com drawer multi-tab (Fornecedor/Produto/Veículo/OS/Plano/Equipamento conforme ADR 0185)
+
+**Negativas / Trade-offs:**
+- Mount inicial do drawer renderiza N tabs simultâneas (custo 1× ao abrir). Mitigação: tabs cadastrais são forms leves; revisitar se a abertura virar perceptivelmente lenta.
+- Bundle inicial do drawer carrega código de todas as tabs cadastrais mesmo se user só visitar 1. Aceitável — não vale code-splitting pra esse volume.
+- Se um tab cadastral disparar fetch no mount (ex: BrasilAPI autocomplete on-mount), agora dispara mesmo se a aba nunca for visitada. Mitigar movendo fetch pra on-visible (`useEffect` com `activeTab === 'X'` gate) ou on-blur do campo gatilho.
+
+**Riscos mitigados:**
+- Usuária Larissa perdendo cadastro silenciosamente (regressão de confiança no produto)
+- Tickets de suporte tipo "salvei e sumiu" sem reprodução fácil pra time
+
+## Quando aplicar
+
+Em **qualquer tela** do oimpresso que tenha:
+1. Componente container com múltiplas tabs/seções (Drawer 760, Sheet, Modal multi-step)
+2. Alguma tab/seção com input user-editável que persiste via autosave (debounce) OU botão Salvar explícito
+3. Render-condicional desmontando ao trocar de tab/seção
+
+**Telas atuais elegíveis** (a auditar conforme ADR 0185 escala):
+- `Pages/Cliente/Index.tsx` — **piloto** (aplicado 2026-05-27)
+- `Pages/Fornecedores/*` (quando entrar em drawer 760)
+- `Pages/Produto/*` (idem)
+- `Pages/OficinaAuto/Vehicles/*`
+- `Pages/OficinaAuto/ServiceOrders/*`
+- `Pages/RecurringBilling/Planos/*`
+- `Pages/Repair/DeviceModels/*`
+- `Pages/Sells/Create.tsx` — pills de seção fazem `scrollIntoView` (não desmontam), não aplica
+- Qualquer Sheet/Drawer multi-tab futuro
+
+## Não aplicar quando
+
+- Tab é **read-only puro** (consulta sem state editável) — render-condicional economiza memória
+- Tab dispara query pesada no mount (gráficos, timeline ledger longo, AI brief) — render-condicional + skeleton de loading é melhor
+- Tela é **wizard sequencial** (step 1 → 2 → 3 linear, sem volta) — neste caso re-mount é semanticamente correto
+
+## Referências
+
+- [ADR 0179](0179-cliente-drawer-760px-substitui-show-fullpage.md) — Drawer 760 substitui Show.tsx full-page (Cliente piloto)
+- [ADR 0185](0185-drawer-760-canon-entidades-cadastrais.md) — Drawer 760 escala pra entidades cadastrais do projeto
+- [ADR 0094](0094-constituicao-v2-7-camadas-8-principios.md) — Princípio "Loop fechado por métrica" + "Confiabilidade com fallback"
+- Implementação canônica: [Pages/Cliente/Index.tsx:1903-1942](../../resources/js/Pages/Cliente/Index.tsx)
+- Sessão de origem: `frosty-greider-83ab2f` 2026-05-27 — bugs CNPJ-apaga-endereço + CEP-fecha-tela + troca-de-aba-perde-dados

--- a/public/index.php
+++ b/public/index.php
@@ -4,6 +4,12 @@
 // Só afeta este projeto. Erros reais (E_ERROR/E_WARNING/E_PARSE) continuam aparecendo.
 error_reporting(E_ALL & ~E_DEPRECATED & ~E_USER_DEPRECATED & ~E_NOTICE);
 
+// display_errors=0 sempre — Ignition captura erros fatais (Throwable). Warnings
+// vendor não-fatais (ex: opentelemetry-auto-laravel sem ext-opentelemetry no Herd
+// local) iam pra display_errors e corromper JSON responses Inertia. Logs continuam
+// indo pra storage/logs/laravel.log via Laravel error handler.
+ini_set('display_errors', '0');
+
 use Illuminate\Contracts\Http\Kernel;
 use Illuminate\Http\Request;
 

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -1749,6 +1749,13 @@ function ClienteSheet({
   // Placeholder no payload ClienteRow nao tem `tipo` ainda (Migration Wave B
   // adiciona; ContactController nao pro frontend ainda nesta wave).
   const [tipo, setTipo] = useState<'PF' | 'PJ'>('PJ');
+  // Fix Wagner 2026-05-27 — version counter pra forçar remount do EnderecoTab
+  // SÓ quando CNPJ lookup explicitamente persistir endereço (sobrescrita autorizada
+  // pelo user). Tabs cadastrais agora usam useEffect deps `[contact.id]` apenas
+  // (preserva state local quando user troca de aba). Sem isso, pós CNPJ lookup
+  // o EnderecoTab continuaria mostrando state local antigo. Incrementar key
+  // descarta state local e re-monta com novo `contact.zip_code/address_line_1/...`.
+  const [enderecoVersion, setEnderecoVersion] = useState(0);
 
   // Reset tab ao abrir contact diferente. Drawer abre default em "Identificação".
   useEffect(() => {
@@ -1792,6 +1799,12 @@ function ClienteSheet({
         // scroll horizontal). Pest Wave B asserta `w-[760px]` no HTML.
         // cw-sheet (ADR UI-0015): bg --cw-bg sutil — destaca seções brancas dentro
         className="cw-sheet w-[760px] sm:max-w-[760px] p-0 flex flex-col"
+        // Fix Wagner 2026-05-27 — ESC dentro do drawer (ex: dispensar erro
+        // "CEP não encontrado" após Buscar CEP, ou limpar focus de um input)
+        // fechava o Sheet inteiro perdendo todo o trabalho não-salvo. Drawer
+        // tem botão X visível (top-right) + click no overlay pra fechar — ESC
+        // é foot-gun. Padrão Notion/Linear: ESC NUNCA fecha drawer de edição.
+        onEscapeKeyDown={(e) => e.preventDefault()}
       >
         {/* ─── Header rico ─────────────────────────────────────────────── */}
         <SheetHeader className="cw-sheet-header px-6 py-4 space-y-3">
@@ -1895,28 +1908,39 @@ function ClienteSheet({
         >
           {contact && (
             <>
-              {/* Tabs cadastrais 1-5 — Wave C-FE plugadas com autosave on blur. */}
-              {activeTab === 'identificacao' && (
+              {/* Tabs cadastrais 1-5 — Wagner 2026-05-27: MOUNTED SEMPRE (hidden via
+                  CSS quando inativo) pra preservar state local + debounces pendentes
+                  quando user troca de aba antes do autosave 800ms disparar. Padrão
+                  Notion/Linear. Render-condicional anterior desmontava o componente,
+                  matando state + cleanup clearTimeout matando debounces → user digita
+                  CEP/número/etc e troca pra aba "Contato" em <800ms → valor sumia.
+                  Tabs read-only (oss/ia/auditoria) seguem condicionais — desmontar
+                  é OK pra elas (consultas pesadas, sem state user-editável). */}
+              <div hidden={activeTab !== 'identificacao'}>
                 <IdentificacaoTab
                   contact={contact}
-                  onCnpjEnderecoPersisted={() =>
-                    router.reload({ only: ['rows'], preserveScroll: true, preserveState: true })
-                  }
+                  onCnpjEnderecoPersisted={() => {
+                    router.reload({ only: ['rows'], preserveScroll: true, preserveState: true });
+                    // Força remount do EnderecoTab pra sincronizar com novos campos
+                    // da BrasilAPI (CEP/logradouro/bairro/cidade/UF). Sobrescrita
+                    // autorizada (user clicou "Buscar CNPJ").
+                    setEnderecoVersion((v) => v + 1);
+                  }}
                   onContactUpdated={onContactUpdated}
                 />
-              )}
-              {activeTab === 'contato' && (
+              </div>
+              <div hidden={activeTab !== 'contato'}>
                 <ContatoTab contact={contact} />
-              )}
-              {activeTab === 'endereco' && (
-                <EnderecoTab contact={contact} />
-              )}
-              {activeTab === 'comercial' && (
+              </div>
+              <div hidden={activeTab !== 'endereco'}>
+                <EnderecoTab key={enderecoVersion} contact={contact} />
+              </div>
+              <div hidden={activeTab !== 'comercial'}>
                 <ComercialTab contact={contact} />
-              )}
-              {activeTab === 'classificacao' && (
+              </div>
+              <div hidden={activeTab !== 'classificacao'}>
                 <ClassificacaoTab contact={contact} />
-              )}
+              </div>
               {activeTab === 'oss' && (
                 <OssTab contact={{ id: contact.id, name: contact.name }} />
               )}

--- a/resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx
@@ -102,42 +102,30 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
   const previousValuesRef = useRef<Record<string, unknown>>({});
 
   useEffect(() => {
-    setZipCode(maskCEP(contact.zip_code ?? contact.cep ?? ''));
-    setAddressLine1(contact.address_line_1 ?? contact.endereco ?? '');
-    setNumero(contact.numero ?? '');
-    setAddressLine2(contact.address_line_2 ?? contact.complemento ?? '');
-    setNeighborhood(contact.neighborhood ?? contact.bairro ?? '');
-    setCity(contact.city ?? contact.cidade ?? '');
-    setStateUf(contact.state ?? contact.uf ?? '');
+    // Fix Wagner 2026-05-27 — deps reduzidas pra `[contact.id]` APENAS
+    // (alinha com ContatoTab/IdentificacaoTab/ComercialTab). Antes deps expandidas
+    // `[contact.zip_code, contact.address_line_1, ...]` disparavam re-sync toda vez
+    // que o parent recebia update do `contact` (router.reload, onContactUpdated)
+    // → sobrescrevia state local que o user tinha digitado em outra aba e voltado
+    // ("trocou as outras abas apaga tudo"). Agora useEffect só roda na mount
+    // inicial (drawer abre) ou se drawer abrir cliente diferente.
+    //
+    // Trade-off: pós CNPJ lookup, o EnderecoTab NÃO auto-atualiza state local
+    // (user precisa ver via key remount controlado pelo pai via `key={enderecoVersion}`
+    // em ClienteSheet — disparado por onCnpjEnderecoPersisted).
+    setZipCode(maskCEP((contact.zip_code ?? contact.cep ?? '') as string));
+    setAddressLine1((contact.address_line_1 ?? contact.endereco ?? '') as string);
+    setNumero((contact.numero ?? '') as string);
+    setAddressLine2((contact.address_line_2 ?? contact.complemento ?? '') as string);
+    setNeighborhood((contact.neighborhood ?? contact.bairro ?? '') as string);
+    setCity((contact.city ?? contact.cidade ?? '') as string);
+    setStateUf((contact.state ?? contact.uf ?? '') as string);
     setErrorField(null);
     setSavedField(null);
     setCepLookup('idle');
     setCepLookupMsg(null);
-    // Deps expandidas (PR #1419 + #1422) — ressincroniza quando parent
-    // (ClienteSheet) faz router.reload({ only: ['rows'] }) após lookup CNPJ
-    // ter persistido endereço em /cliente/{id}/endereco. Inclui canon EN
-    // (zip_code, address_line_1, address_line_2, numero, neighborhood) + aliases
-    // PT-BR legados (cep, endereco, complemento, bairro, cidade, uf) pra graceful
-    // com listagem que ainda emite PT-BR.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [
-    contact.id,
-    // Canon EN (preferidos).
-    contact.zip_code,
-    contact.address_line_1,
-    contact.address_line_2,
-    contact.numero,
-    contact.neighborhood,
-    contact.city,
-    contact.state,
-    // Aliases PT-BR (legado listagem).
-    contact.cep,
-    contact.endereco,
-    contact.complemento,
-    contact.bairro,
-    contact.cidade,
-    contact.uf,
-  ]);
+  }, [contact.id]);
 
   const cepError = useMemo<string | null>(() => {
     const v = validateCEP(zipCode);


### PR DESCRIPTION
## Summary

- **Bug:** trocar de aba no drawer Cliente apagava dados não-salvos (state local + debounces pendentes morriam no unmount). Pior cenário: usuária digita CEP/número/email, troca pra Identificação, valor some sem persistir.
- **Fix:** tabs cadastrais (Identificação/Contato/Endereço/Comercial/Classificação) ficam mount-sempre via `<div hidden={activeTab !== 'X'}>`. EnderecoTab `useEffect` deps reduzidas pra `[contact.id]` apenas (alinhado com outros tabs). Pós CNPJ lookup, `enderecoVersion` counter força remount autorizado pra mostrar dados da Receita.
- **Bônus:** `onEscapeKeyDown` preventDefault no `<SheetContent>` (ESC não fecha mais drawer com edição não-salva). ContactController inclui campos de endereço completos no payload `rows`. AdminSidebarMenu defensive contra `enabled_modules` string. `display_errors=0` no `public/index.php` evita warnings PHP corromperem JSON Inertia local.
- **ADR 0195** (proposto) documenta o pattern "mount-sempre via hidden" pra reusar nas demais entidades cadastrais (Fornecedor/Produto/Veículo/OS/Plano/Equipamento — ADR 0185).

## Test plan

- [x] Validado via Chrome MCP no Herd local biz=1
- [x] Cliente Antonella Alves Araujo, aba Endereço → digitei `TESTE123` no Número → troquei pra Contato → voltei → `TESTE123` preservado
- [x] CEP `88702-230` → ViaCEP autopreencheu Rua dos Ferroviários / Oficinas / Tubarão / SC → Número `TESTE123` **PERSISTIU**
- [x] Percorri Identificação → Comercial → Classificação → voltei pra Endereço → tudo intacto
- [x] PHP lint OK em `ContactController.php` e `AdminSidebarMenu.php`
- [x] `npm run build:inertia` OK (4m 38s, sem erro)
- [ ] Verificar canary biz=1 prod pós-merge
- [ ] Liberar pra biz=4 (Larissa @ ROTA LIVRE) após canary OK

## Files changed

```
app/Http/Controllers/ContactController.php         +27 (selectCols + payload endereço completo)
app/Http/Middleware/AdminSidebarMenu.php            +8 (defensive enabled_modules string→array)
public/index.php                                    +6 (display_errors=0 anti-warning corrupção JSON)
resources/js/Pages/Cliente/Index.tsx               +54 (mount-sempre tabs + enderecoVersion + ESC bloqueado)
resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx -50 (deps reduzidas [contact.id])
memory/decisions/0195-tabs-autosave-mount-sempre-hidden.md +151 (ADR proposto)
```

Refs: SPRINT-5 PASSO 1 (Larissa biz=4 piloto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
