### PR TITLE
feat(paymentgateway): US-FIN-046 Sicoob mTLS reusa NfeCertificado (single source)

### DIFF
--- a/Modules/PaymentGateway/Database/Migrations/2026_05_27_140000_drop_mtls_columns_sicoob_reusa_nfecertificado.php
+++ b/Modules/PaymentGateway/Database/Migrations/2026_05_27_140000_drop_mtls_columns_sicoob_reusa_nfecertificado.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * US-FIN-046 — Sicoob mTLS reusa NfeCertificado (single source of truth).
+ *
+ * Drops colunas adicionadas pelo PR1 da US-FIN-044 (2026_05_27_120000_add_sicoob_api_*)
+ * que ficaram redundantes após decisão Wagner 2026-05-27 de reusar
+ * NfeCertificado em vez de upload duplicado:
+ *
+ *   - requires_mtls (bool) — sempre true pra sicoob_api (driver decide)
+ *   - mtls_pfx_path (string) — desnecessário, driver lê do NfeCertificado canon
+ *
+ * Mantém:
+ *   - sicoob_api no enum gateway_key (driver continua)
+ *   - config_json (sem mtls_pfx_password_encrypted — agora vem do NfeCertificado)
+ *
+ * Tier 0: schema-only, sem PII. SQLite no-op se dropColumn falhar
+ * (SQLite limitations). MySQL/MariaDB ALTER TABLE DROP COLUMN.
+ *
+ * Refs: US-FIN-046 Wagner 2026-05-27.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('payment_gateway_credentials')) {
+            return;
+        }
+
+        Schema::table('payment_gateway_credentials', function (Blueprint $table) {
+            if (Schema::hasColumn('payment_gateway_credentials', 'mtls_pfx_path')) {
+                $table->dropColumn('mtls_pfx_path');
+            }
+            if (Schema::hasColumn('payment_gateway_credentials', 'requires_mtls')) {
+                $table->dropColumn('requires_mtls');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('payment_gateway_credentials')) {
+            return;
+        }
+
+        Schema::table('payment_gateway_credentials', function (Blueprint $table) {
+            if (! Schema::hasColumn('payment_gateway_credentials', 'requires_mtls')) {
+                $table->boolean('requires_mtls')->default(false)->after('ambiente');
+            }
+            if (! Schema::hasColumn('payment_gateway_credentials', 'mtls_pfx_path')) {
+                $table->string('mtls_pfx_path', 255)->nullable()->after('requires_mtls');
+            }
+        });
+    }
+};

--- a/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
+++ b/Modules/PaymentGateway/Http/Controllers/Settings/PaymentGatewaysController.php
@@ -10,12 +10,12 @@ use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Http\UploadedFile;
-use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Financeiro\Models\ContaBancaria;
+use Modules\NfeBrasil\Models\NfeCertificado;
 use Modules\PaymentGateway\Models\Cobranca;
 use Modules\PaymentGateway\Models\GatewayWebhookEvent;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
@@ -60,7 +60,42 @@ class PaymentGatewaysController extends Controller
             'accounts' => Inertia::defer(fn () => $this->listarContasDestino($businessId)),
             'gateways' => Inertia::defer(fn () => $this->listarGateways($businessId)),
             'kpis' => Inertia::defer(fn () => $this->kpis($businessId)),
+            // US-FIN-046 — wizard Sicoob mostra status do cert A1 (reusa NfeCertificado)
+            'nfeCertificadoAtivo' => $this->nfeCertificadoAtivoPayload($businessId),
         ]);
+    }
+
+    /**
+     * US-FIN-046 — info do NfeCertificado ativo pro wizard SheetNovoGateway
+     * step 2 Sicoob mostrar "✅ Cert A1 cadastrado" OU "⚠️ Cadastre em /fiscal".
+     *
+     * @return array{cnpjTitular: string, validoAteBr: string, diasRestantes: int}|null
+     */
+    private function nfeCertificadoAtivoPayload(int $businessId): ?array
+    {
+        if ($businessId <= 0) {
+            return null;
+        }
+
+        $cert = NfeCertificado::query()
+            ->where('business_id', $businessId)
+            ->where('ativo', true)
+            ->orderByDesc('valido_ate')
+            ->first();
+
+        if (! $cert || ! $cert->valido_ate) {
+            return null;
+        }
+
+        $dias = (int) now()->startOfDay()->diffInDays($cert->valido_ate, false);
+
+        return [
+            'cnpjTitular'    => (string) $cert->cnpj_titular,
+            'validoAteBr'    => $cert->valido_ate->format('d/m/Y'),
+            'diasRestantes'  => $dias,
+            'vencido'        => $dias < 0,
+            'proximoVencer'  => $dias >= 0 && $dias <= 30,
+        ];
     }
 
     /**
@@ -123,9 +158,9 @@ class PaymentGatewaysController extends Controller
             'cert_file'        => 'sometimes|file|mimes:crt,pem,cer|max:32',
             'key_file'         => 'sometimes|file|mimes:key,pem|max:32',
             'cert_password'    => 'sometimes|nullable|string|max:191',
-            // Onda 4f.sicoob_api PR5 — .pfx PKCS12 + senha (Sicoob/BB/Bradesco)
-            'pfx_file'         => 'sometimes|file|mimes:pfx,p12|max:64',
-            'pfx_password'     => 'sometimes|nullable|string|max:191',
+            // US-FIN-046 (2026-05-27): pfx_file/pfx_password REMOVIDOS.
+            // Sicoob API reusa NfeCertificado canon — cliente upload UMA vez
+            // em /fiscal/configuracao/certificado.
         ]);
 
         // Tier 0: garantir conta_bancaria_id pertence ao business_id session
@@ -177,16 +212,8 @@ class PaymentGatewaysController extends Controller
             }
         }
 
-        // Onda 4f.sicoob_api PR5 — upload .pfx + senha cifrada via Crypt
-        if ($request->hasFile('pfx_file')) {
-            $pfxRelative = $this->storeSicoobPfx($request, $businessId);
-            $update = ['mtls_pfx_path' => $pfxRelative, 'requires_mtls' => true];
-            if (!empty($validated['pfx_password'])) {
-                $configJson['mtls_pfx_password_encrypted'] = Crypt::encryptString((string) $validated['pfx_password']);
-                $update['config_json'] = $configJson;
-            }
-            $cred->update($update);
-        }
+        // US-FIN-046 (2026-05-27): bloco upload .pfx removido. Sicoob API
+        // reusa NfeCertificado canon via CertificadoService::carregarParaSefaz.
 
         Log::info('[paymentgateway.credential.created]', [
             'business_id'   => $businessId,
@@ -285,32 +312,12 @@ class PaymentGatewaysController extends Controller
      * Permissions: 0600. Tier 0: business_id no path previne leak.
      * LGPD/PCI: log nunca emite conteúdo.
      *
+     * US-FIN-046 (2026-05-27): helper storeSicoobPfx() REMOVIDO. Sicoob API
+     * reusa NfeCertificado canon — cliente upload UMA vez em
+     * /fiscal/configuracao/certificado.
+     *
      * @return array<string, string>
      */
-
-    /**
-     * Onda 4f.sicoob_api PR5 — armazena .pfx em
-     * storage/app/private/sicoob/{business_id}.pfx (convenção canon usada
-     * pelo SicoobApiDriver::resolveMtlsPfxFullPath()).
-     *
-     * Retorna path RELATIVO (sicoob/{biz}.pfx) — driver prefixa storage_path.
-     * chmod 0600 best-effort em Linux (Windows ignora silenciosamente).
-     */
-    private function storeSicoobPfx(Request $request, int $businessId): string
-    {
-        /** @var UploadedFile $pfx */
-        $pfx = $request->file('pfx_file');
-        $relativePath = "sicoob/{$businessId}.pfx";
-        $pfx->storeAs('sicoob', "{$businessId}.pfx", 'local');
-
-        $absPath = Storage::disk('local')->path($relativePath);
-        if (is_file($absPath)) {
-            @chmod($absPath, 0600);
-        }
-
-        return $relativePath;
-    }
-
     private function storeCertFiles(Request $request, PaymentGatewayCredential $cred, int $businessId): array
     {
         $paths = [];

--- a/Modules/PaymentGateway/Models/PaymentGatewayCredential.php
+++ b/Modules/PaymentGateway/Models/PaymentGatewayCredential.php
@@ -54,10 +54,9 @@ class PaymentGatewayCredential extends Model
         'conta_bancaria_id',
         'health_status',
         'health_checked_at',
-        // Onda 4f.sicoob_api (US-FIN-044 PR3) — mTLS handshake real.
-        // Reusável por qualquer driver REST que exija .pfx (Bradesco/BB futuros).
-        'requires_mtls',
-        'mtls_pfx_path',
+        // US-FIN-046 (2026-05-27): colunas mtls_pfx_path + requires_mtls REMOVIDAS.
+        // Sicoob/BB/Bradesco/Inter API REST usam NfeCertificado canon (single source).
+        // Driver lê via CertificadoService::carregarParaSefaz($business_id).
     ];
 
     protected $casts = [
@@ -67,7 +66,6 @@ class PaymentGatewayCredential extends Model
         'config_json'       => 'encrypted:array',
         'ativo'             => 'boolean',
         'health_checked_at' => 'datetime',
-        'requires_mtls'     => 'boolean',
     ];
 
     /**

--- a/Modules/PaymentGateway/SCOPE.md
+++ b/Modules/PaymentGateway/SCOPE.md
@@ -21,7 +21,7 @@ contains:
   - "Services/Drivers/C6Driver — C6 Open Banking PJ OAuth2 (boleto + pix_cob + cancelar + consultar + healthCheck + processWebhook); Onda 4b. CNAB legacy fallback fica em RB"
   - "Services/Drivers/BcbPixDriver — PSP-agnóstico PIX Automático (Resolução BCB 380/2024) — pix_recv (mandato recorrente) + revogar + consultar + healthCheck + processWebhook; Onda 4d.1. base_url configurável via credential"
   - "Services/Drivers/PagarmeDriver — Pagar.me v5 REST (boleto + pix_cob + card + refund parcial + cancelar + consultar + healthCheck + processWebhook); Onda 4e. HTTP Basic Auth via secret_key, sandbox via prefixo sk_test_*"
-  - "Services/Drivers/SicoobApiDriver — Sicoob API Cobrança Bancária v3 REST OAuth2+mTLS (.pfx) (boleto + cancelar + consultar + healthCheck + processWebhook); Onda 4f.sicoob_api · US-FIN-044. Convênio + carteira (1 Simples / 3 Caucionada) + modalidade. Cache token Redis-safe por business_id"
+  - "Services/Drivers/SicoobApiDriver — Sicoob API Cobrança Bancária v3 REST OAuth2+mTLS (boleto + cancelar + consultar + healthCheck + processWebhook); Onda 4f.sicoob_api · US-FIN-044 + US-FIN-046. Convênio + carteira (1 Simples / 3 Caucionada) + modalidade. Cache token Redis-safe por business_id. mTLS REUSA NfeCertificado canon via CertificadoService::carregarParaSefaz (single source of truth — mesmo cert A1 usado pra NFe SEFAZ)"
   - "BoletoService (Onda 4d alto-nível)"
   - "RemessaCnabService (Onda 4d)"
   - "RetornoCnabService (Onda 4d)"

--- a/Modules/PaymentGateway/Services/Drivers/SicoobApiDriver.php
+++ b/Modules/PaymentGateway/Services/Drivers/SicoobApiDriver.php
@@ -5,11 +5,10 @@ declare(strict_types=1);
 namespace Modules\PaymentGateway\Services\Drivers;
 
 use Carbon\Carbon;
-use Illuminate\Contracts\Encryption\DecryptException;
 use Illuminate\Http\Client\PendingRequest;
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Crypt;
 use Illuminate\Support\Facades\Http;
+use Modules\NfeBrasil\Services\CertificadoService;
 use Modules\PaymentGateway\Contracts\PaymentDriverContract;
 use Modules\PaymentGateway\Dto\CardToken;
 use Modules\PaymentGateway\Dto\CobrancaEmitidaResult;
@@ -22,42 +21,35 @@ use Modules\PaymentGateway\Exceptions\GatewayUnavailableException;
 use Modules\PaymentGateway\Exceptions\InvalidPayerException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\HttpClientFactory;
+use RuntimeException;
 
 /**
  * Driver Sicoob — API Cobrança Bancária v3 (REST + OAuth2 + mTLS).
  *
- * US-FIN-044 — Onda 4f.sicoob_api. Sinal qualificado: biz=4 ROTA LIVRE
- * (Larissa via Kamila) pediu 2026-05-27 [ADR 0105].
+ * US-FIN-044 — Onda 4f.sicoob_api. Sinal qualificado: Martinho Caçambas
+ * (biz=164) — Kamila (Admin#164) pediu 2026-05-27 [ADR 0105]. NÃO confundir
+ * com ROTA LIVRE (biz=4 Larissa vestuário) — ROTA LIVRE não usa Sicoob.
  *
- * PR3 (este) — mTLS handshake real (.pfx + senha cifrada Laravel Crypt).
- * Webhook real-time chega no PR4.
+ * US-FIN-046 (refactor 2026-05-27) — mTLS REUSA o NfeCertificado do business
+ * em vez de upload duplicado. Sicoob API exige cert ICP-Brasil A1 do CNPJ
+ * da empresa, EXATAMENTE o mesmo cert que NfeBrasil já gerencia pra SEFAZ
+ * (encrypt-at-rest via Crypt, validação CNPJ Subject CN, audit OTel).
+ *
+ * Single source of truth: cliente upload UMA vez em /fiscal/configuracao/certificado.
+ *
+ * Acoplamento cross-module Sicoob → NfeBrasil é débito aceitável até 2º
+ * banco API entrar (Bradesco/Inter/BB). Aí extrai NfeCertificado pra
+ * módulo neutro (US-FIN-047 backlog).
  *
  * URLs (Sicoob 2026):
  *   - Token (Keycloak): https://auth.sicoob.com.br/auth/realms/cooperado/protocol/openid-connect/token
  *   - API prod:         https://api.sicoob.com.br/cobranca-bancaria/v3
  *   - API sandbox:      https://sandbox.sicoob.com.br/sicoob/sandbox/cobranca-bancaria/v3
  *
- * Particularidades vs InterDriver:
- *   - Sicoob exige header `client_id` em TODAS as chamadas (não só no token)
- *   - Token cache em Laravel Cache (Redis-safe, multi-process) — Inter usa
- *     in-memory que perde token entre requests
- *   - Scopes Sicoob são granulares: boletos_inclusao + boletos_consulta +
- *     boletos_alteracao + webhooks_inclusao + webhooks_consulta
- *   - consultar usa query string composta (numeroCliente + codigoModalidade +
- *     nossoNumero), não path /boletos/{nn}
- *
- * Em prod, mTLS configurado via $cred->mtls_pfx_path (coluna canon, path
- * relativo a storage/app/private/ OU absoluto) + senha cifrada em
- * config_json['mtls_pfx_password_encrypted']. Em test (Http::fake) bypass
- * automático pois Http::fake não bate na rede.
- *
- * Senha NUNCA logada. Crypt::encryptString → DecryptException quando chave
- * APP_KEY do Laravel muda (re-cadastrar credencial).
- *
  * Refs:
- *   - https://developers.sicoob.com.br/portal/apis (docs oficiais)
- *   - https://api.sicoob.com.br/cobranca-bancaria/v3 (base prod)
+ *   - https://developers.sicoob.com.br/portal/apis
  *   - ADR 0170-bancos-nativos-top5-drivers-separados §4f.sicoob_api
+ *   - Modules/NfeBrasil/Services/CertificadoService (canon a reusar)
  *   - memory/sessions/2026-05-27-sicoob-api-credenciais-pedido.md
  */
 class SicoobApiDriver implements PaymentDriverContract
@@ -74,6 +66,10 @@ class SicoobApiDriver implements PaymentDriverContract
      * Scopes mínimos pra cobrança REST v3. Webhook scopes chegam no PR4.
      */
     private const SCOPES = 'boletos_inclusao boletos_consulta boletos_alteracao';
+
+    public function __construct(
+        private readonly CertificadoService $certificadoService,
+    ) {}
 
     public function key(): string
     {
@@ -103,8 +99,6 @@ class SicoobApiDriver implements PaymentDriverContract
 
         $data = $response->json() ?? [];
 
-        // Sicoob retorna `resultado: [{ status: 200, boleto: {...} }]` quando
-        // sucesso em batch; ou objeto direto quando 1 boleto só.
         $boleto = $data['resultado'][0]['boleto'] ?? $data['boleto'] ?? $data;
         $nossoNumero = (string) ($boleto['nossoNumero'] ?? '');
         $linhaDigitavel = (string) ($boleto['linhaDigitavel'] ?? '');
@@ -229,7 +223,6 @@ class SicoobApiDriver implements PaymentDriverContract
         $start = microtime(true);
 
         try {
-            // OAuth handshake = boa prova de saúde (token + mTLS + DNS + TLS).
             $this->getAccessToken($cred, forceRefresh: true);
             $latencyMs = (int) round((microtime(true) - $start) * 1000);
 
@@ -252,9 +245,6 @@ class SicoobApiDriver implements PaymentDriverContract
 
     public function processWebhook(array $payload, object $cred): ?object
     {
-        // PR4 implementa HMAC + dispatch real. PR2 deixa só mapping superficial
-        // pra Onda 3 (gateway_webhook_events) não quebrar se chegar payload
-        // inesperado.
         $nossoNumero = (string) ($payload['nossoNumero'] ?? $payload['boleto']['nossoNumero'] ?? '');
         if ($nossoNumero === '') {
             return null;
@@ -287,8 +277,6 @@ class SicoobApiDriver implements PaymentDriverContract
                 'Sicoob API credential precisa client_id + client_secret em config_json'
             );
         }
-        // Convênio (numero_cliente) é o código cedente Sicoob — sem ele não
-        // emite boleto. Carteira (codigo_modalidade) tem default 1 (Simples).
         if (empty($config['numero_cliente']) && empty($config['convenio'])) {
             throw new CredentialMisconfiguredException(
                 'Sicoob API credential precisa numero_cliente (convênio/código cedente)'
@@ -315,9 +303,6 @@ class SicoobApiDriver implements PaymentDriverContract
             : self::OAUTH_URL_PRODUCTION;
     }
 
-    /**
-     * Cliente HTTP com Bearer + client_id header + mTLS options.
-     */
     private function client(PaymentGatewayCredential $cred): PendingRequest
     {
         $config = $this->config($cred);
@@ -336,100 +321,61 @@ class SicoobApiDriver implements PaymentDriverContract
     }
 
     /**
-     * Monta options Guzzle pra mTLS handshake — `.pfx` (PKCS12) + senha
-     * decifrada via Laravel Crypt.
+     * mTLS options pra Guzzle — REUSA NfeCertificado do business (US-FIN-046).
      *
-     * Modelos:
-     *   - PHP_PKCS12 nativo:  ['cert' => [$pfxFullPath, $password]]
-     *   - Curl raw:           ['curl' => [CURLOPT_SSLCERT => ..., CURLOPT_SSLCERTTYPE => 'P12']]
+     * Sicoob exige cert ICP-Brasil A1 do CNPJ da empresa — mesmo cert que
+     * já vive em `nfe_certificados` encrypted-at-rest. Reusamos via
+     * `CertificadoService::carregarParaSefaz()` (canon).
      *
-     * Usamos a forma `['cert' => [path, password]]` que o Guzzle 7 aceita
-     * (passa pra curl como CURLOPT_SSLCERT + SSLCERTPASSWD automaticamente).
+     * Implementação:
+     *   1. Carrega .pfx binary + senha via CertificadoService (decrypt em memória)
+     *   2. Escreve .pfx temp em sys_get_temp_dir() pra Guzzle/curl (mTLS exige file)
+     *   3. register_shutdown_function pra unlink ao final do request
+     *   4. Retorna ['cert' => [$tempPath, $senha]] — Guzzle 7 propaga pra curl
      *
-     * Resolução:
-     *   - $cred->requires_mtls = false → retorna [] (driver pode operar sem mTLS
-     *     em sandbox de homologação Sicoob, mas em prod = mTLS obrigatório).
-     *   - $cred->mtls_pfx_path vazio com requires_mtls=true → throw.
-     *   - Path absoluto → usa direto.
-     *   - Path relativo → prefixa storage/app/private/.
+     * Segurança:
+     *   - Temp file fica em sys_get_temp_dir() com prefix `sicoob-pfx-` e
+     *     basename random via tempnam — atacante local não consegue prever path
+     *   - Conteúdo no temp é o .pfx (PKCS12 cifrado pela própria senha) — atacante
+     *     que pegue o arquivo ainda precisa da senha pra abrir
+     *   - unlink no shutdown garante cleanup mesmo em exception
      *
-     * Multi-tenant Tier 0: cada business_id tem .pfx separado em
-     * storage/app/private/sicoob/{business_id}.pfx (convenção). Path absoluto
-     * é permitido pra deployments que usam volume montado fora do storage.
+     * Em test (Http::fake) mTLS é bypass — caller NÃO precisa NfeCertificado ativo
+     * se o driver não fizer chamada real. Mas chamadas reais (emitirBoleto via
+     * Http::fake response) ainda invocam mtlsOptions → carregarParaSefaz.
      */
     private function mtlsOptions(PaymentGatewayCredential $cred): array
     {
-        if (! $cred->requires_mtls) {
-            return [];
-        }
-
-        $pfxPath = $this->resolveMtlsPfxFullPath($cred);
-        if ($pfxPath === null) {
+        try {
+            $cert = $this->certificadoService->carregarParaSefaz($cred->business_id);
+        } catch (RuntimeException $e) {
             throw new CredentialMisconfiguredException(
-                'Sicoob API credential exige mTLS (requires_mtls=true) mas mtls_pfx_path está vazio. ' .
-                "Faça upload do .pfx em /settings/payment-gateways pra business_id={$cred->business_id}."
-            );
-        }
-        if (! is_file($pfxPath)) {
-            throw new CredentialMisconfiguredException(
-                "Sicoob API .pfx não encontrado em '{$pfxPath}'. Re-upload pelo wizard."
+                'Sicoob API exige certificado A1 ICP-Brasil cadastrado em ' .
+                '/fiscal/configuracao/certificado — mesmo cert usado pra NFe SEFAZ. ' .
+                "Erro original: {$e->getMessage()}"
             );
         }
 
-        $password = $this->decryptMtlsPassword($cred);
+        $tempPath = tempnam(sys_get_temp_dir(), 'sicoob-pfx-');
+        if ($tempPath === false) {
+            throw new CredentialMisconfiguredException(
+                'Falha ao criar arquivo temporário pro .pfx Sicoob (sys_get_temp_dir não writable)'
+            );
+        }
+
+        file_put_contents($tempPath, $cert['pfx_binary']);
+        @chmod($tempPath, 0600);
+
+        // Cleanup garantido — unlink quando request termina (sucesso OU exception).
+        register_shutdown_function(static function () use ($tempPath): void {
+            if (is_file($tempPath)) {
+                @unlink($tempPath);
+            }
+        });
 
         return [
-            // Guzzle 7 aceita [path, password] e propaga pra curl como
-            // CURLOPT_SSLCERT + CURLOPT_SSLCERTPASSWD + CURLOPT_SSLCERTTYPE=P12.
-            'cert' => [$pfxPath, $password],
+            'cert' => [$tempPath, $cert['senha']],
         ];
-    }
-
-    /**
-     * Resolve path completo do .pfx — pode ser absoluto (mantém) ou relativo
-     * (prefixa com storage/app/private/). Retorna null se vazio.
-     */
-    private function resolveMtlsPfxFullPath(PaymentGatewayCredential $cred): ?string
-    {
-        $rel = trim((string) ($cred->mtls_pfx_path ?? ''));
-        if ($rel === '') {
-            return null;
-        }
-
-        // Path absoluto (Windows: C:/... ou /srv/...).
-        if (preg_match('#^([A-Za-z]:[\\\\/]|/)#', $rel) === 1) {
-            return $rel;
-        }
-
-        return storage_path('app/private/' . ltrim($rel, '/'));
-    }
-
-    /**
-     * Decifra senha do .pfx armazenada em config_json['mtls_pfx_password_encrypted'].
-     *
-     * NUNCA loga senha. DecryptException → throws CredentialMisconfigured
-     * com mensagem genérica (não vaza ciphertext nem detalhe interno).
-     */
-    private function decryptMtlsPassword(PaymentGatewayCredential $cred): string
-    {
-        $config = $this->config($cred);
-        $encrypted = (string) ($config['mtls_pfx_password_encrypted'] ?? '');
-
-        if ($encrypted === '') {
-            throw new CredentialMisconfiguredException(
-                "Sicoob mTLS configurado mas senha do .pfx ausente em config_json " .
-                '(mtls_pfx_password_encrypted). Re-cadastre senha no wizard.'
-            );
-        }
-
-        try {
-            return Crypt::decryptString($encrypted);
-        } catch (DecryptException) {
-            throw new CredentialMisconfiguredException(
-                'Senha do .pfx não decifra — APP_KEY do Laravel mudou desde o cadastro. ' .
-                'Re-cadastre senha no wizard de gateways.'
-            );
-        }
     }
 
     /**
@@ -487,8 +433,8 @@ class SicoobApiDriver implements PaymentDriverContract
             'dataEmissao'                     => Carbon::now()->toIso8601String(),
             'seuNumero'                       => substr($input->idempotencyKey, 0, 15),
             'identificacaoBoletoEmpresa'      => substr($input->idempotencyKey, 0, 25),
-            'identificacaoEmissaoBoleto'      => 2, // 2 = banco emite
-            'identificacaoDistribuicaoBoleto' => 2, // 2 = banco distribui
+            'identificacaoEmissaoBoleto'      => 2,
+            'identificacaoDistribuicaoBoleto' => 2,
             'valor'                           => $valorReais,
             'dataVencimento'                  => Carbon::instance($input->vencimento)->toIso8601String(),
             'numeroDiasLimiteRecebimento'     => $input->meta['dias_baixa'] ?? 30,
@@ -509,21 +455,11 @@ class SicoobApiDriver implements PaymentDriverContract
         ];
     }
 
-    /**
-     * Sicoob codigoBaixa (PATCH /boletos/baixa):
-     *   1 = Comandar baixa (motivo livre). Outros códigos chegam futuro.
-     */
     private function mapMotivoCancelar(string $motivo): int
     {
         return 1;
     }
 
-    /**
-     * Sicoob situacaoBoleto → status canon oimpresso.
-     *
-     * Valores Sicoob v3: EM_ABERTO, BAIXADO, LIQUIDADO, PROTESTADO,
-     * EM_PROTESTO, NEGATIVADO, EM_NEGATIVACAO, REGISTRADO.
-     */
     private function mapSituacao(string $sicoobStatus): string
     {
         return match (strtoupper($sicoobStatus)) {

--- a/Modules/PaymentGateway/Tests/Feature/SicoobApiDriverMtlsTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/SicoobApiDriverMtlsTest.php
@@ -3,10 +3,7 @@
 declare(strict_types=1);
 
 use Illuminate\Support\Facades\Cache;
-use Illuminate\Support\Facades\Crypt;
-use Illuminate\Support\Facades\File;
-use Illuminate\Support\Facades\Http;
-use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
+use Modules\NfeBrasil\Services\CertificadoService;
 use Modules\PaymentGateway\Exceptions\CredentialMisconfiguredException;
 use Modules\PaymentGateway\Models\PaymentGatewayCredential;
 use Modules\PaymentGateway\Services\Drivers\SicoobApiDriver;
@@ -14,252 +11,189 @@ use Modules\PaymentGateway\Services\Drivers\SicoobApiDriver;
 uses(Tests\TestCase::class);
 
 /**
- * Onda 4f.sicoob_api PR3 — US-FIN-044.
+ * Onda 4f.sicoob_api US-FIN-046 — mTLS reusa NfeCertificado canon.
  *
- * Testa mTLS handshake real (.pfx + senha cifrada via Laravel Crypt).
+ * Substitui SicoobApiDriverMtlsTest PR3 que testava filesystem próprio
+ * `storage/app/private/sicoob/{biz}.pfx`. Agora driver reusa
+ * `CertificadoService::carregarParaSefaz()` do NfeBrasil (single source).
  *
- * Em Http::fake() o handshake mTLS é bypass (não bate na rede), MAS as
- * options Guzzle são preenchidas pelo driver e podem ser inspecionadas
- * via reflection (ou indiretamente via comportamento esperado).
- *
- * Aqui validamos:
- *   1. requires_mtls=false → mtlsOptions vazio (compat sandbox sem cert)
- *   2. requires_mtls=true + pfx_path vazio → CredentialMisconfigured
- *   3. requires_mtls=true + .pfx inexistente → CredentialMisconfigured
- *   4. requires_mtls=true + senha ausente → CredentialMisconfigured
- *   5. requires_mtls=true + senha não decifra → CredentialMisconfigured
- *   6. Tudo OK → options 'cert' = [absolute_path, plain_password]
- *   7. Path absoluto preservado
- *   8. Path relativo prefixado com storage/app/private/
- *   9. Multi-tenant: biz=4 e biz=99 têm .pfx isolados (não compartilham)
- *  10. NUNCA loga senha (não conseguimos provar isso 100% mas o código
- *      nunca passa senha pra Log::; podemos checar que mensagens de erro
- *      não contêm o plaintext).
- *
- * Tier 0 multi-tenant: biz=1 padrão. Caso 9 usa biz=4 e biz=99 fictícios.
+ * Testes cobrem:
+ *   1. mtlsOptions chama CertificadoService com business_id correto
+ *   2. mtlsOptions retorna ['cert' => [tempPath, senha]] com binary do mock
+ *   3. mtlsOptions throws CredentialMisconfigured quando business sem cert
+ *   4. Temp file em sys_get_temp_dir() com prefix sicoob-pfx-
+ *   5. Multi-tenant Tier 0: business_id=4 e biz=99 carregam certs DIFERENTES
+ *   6. Mensagens de erro mantêm ref pra /fiscal/configuracao/certificado
  */
 
 beforeEach(function () {
     Cache::flush();
     session(['business.id' => 1]);
+});
 
-    // Diretório de teste isolado por suite — não polui storage de outros tests.
-    $this->pfxDir = storage_path('app/private/sicoob');
-    File::ensureDirectoryExists($this->pfxDir);
+function makeSicoobCredXT(int $bizId = 1, array $configExtra = []): PaymentGatewayCredential
+{
+    return PaymentGatewayCredential::query()->create([
+        'business_id'  => $bizId,
+        'gateway_key'  => 'sicoob_api',
+        'ambiente'     => 'sandbox',
+        'ativo'        => true,
+        'config_json'  => array_merge([
+            'client_id'         => 'c-' . $bizId,
+            'client_secret'     => 's-' . $bizId,
+            'numero_cliente'    => $bizId * 100,
+            'codigo_modalidade' => 1,
+            'numero_conta'      => $bizId * 1000,
+        ], $configExtra),
+    ]);
+}
 
-    $this->makeCred = function (array $extra = [], int $bizId = 1, ?string $pfxRel = null, bool $reqMtls = true): PaymentGatewayCredential {
-        return PaymentGatewayCredential::query()->create([
-            'business_id'    => $bizId,
-            'gateway_key'    => 'sicoob_api',
-            'ambiente'       => 'sandbox',
-            'ativo'          => true,
-            'requires_mtls'  => $reqMtls,
-            'mtls_pfx_path'  => $pfxRel,
-            'config_json'    => array_merge([
-                'client_id'         => 'fake-client-id',
-                'client_secret'     => 'fake-client-secret',
-                'numero_cliente'    => 12345,
-                'codigo_modalidade' => 1,
-                'numero_conta'      => 1234567,
-            ], $extra),
+function callMtls(PaymentGatewayCredential $cred): array
+{
+    $driver = app(SicoobApiDriver::class);
+    $r = new ReflectionMethod($driver, 'mtlsOptions');
+    $r->setAccessible(true);
+
+    return $r->invoke($driver, $cred);
+}
+
+it('mtlsOptions chama CertificadoService::carregarParaSefaz com business_id da credential', function () {
+    $cred = makeSicoobCredXT(bizId: 4);
+
+    $stub = Mockery::mock(CertificadoService::class);
+    $stub->shouldReceive('carregarParaSefaz')
+        ->with(4)
+        ->once()
+        ->andReturn([
+            'pfx_binary' => 'FAKE',
+            'senha'      => 's4',
+            'valido_ate' => new DateTimeImmutable('+10 days'),
+            'source'     => 'nfe_brasil',
         ]);
-    };
+    app()->instance(CertificadoService::class, $stub);
 
-    $this->writeFakePfx = function (string $relPath): string {
-        $abs = storage_path('app/private/' . ltrim($relPath, '/'));
-        File::ensureDirectoryExists(dirname($abs));
-        // Conteúdo fake — driver só checa is_file(), não valida PKCS12.
-        File::put($abs, "FAKE-PFX-BINARY-FOR-TEST");
+    callMtls($cred);
+});
 
-        return $abs;
-    };
+it('mtlsOptions retorna [cert => [tempPath, senha]] com binary do mock', function () {
+    $cred = makeSicoobCredXT();
+
+    $stub = Mockery::mock(CertificadoService::class);
+    $stub->shouldReceive('carregarParaSefaz')->andReturn([
+        'pfx_binary' => 'CONTEUDO-BINARIO-FAKE-PFX',
+        'senha'      => 'minha-senha-decifrada',
+        'valido_ate' => new DateTimeImmutable('+90 days'),
+        'source'     => 'nfe_brasil',
+    ]);
+    app()->instance(CertificadoService::class, $stub);
+
+    $opts = callMtls($cred);
+
+    expect($opts)->toHaveKey('cert');
+    expect($opts['cert'])->toBeArray()->toHaveCount(2);
+
+    [$tempPath, $senha] = $opts['cert'];
+
+    expect($tempPath)->toContain(sys_get_temp_dir())
+        ->and(basename($tempPath))->toStartWith('sicoob-pfx-');
+
+    expect(is_file($tempPath))->toBeTrue();
+    expect(file_get_contents($tempPath))->toBe('CONTEUDO-BINARIO-FAKE-PFX');
+    expect($senha)->toBe('minha-senha-decifrada');
+
+    @unlink($tempPath);
+});
+
+it('mtlsOptions throws CredentialMisconfigured quando business sem cert ativo', function () {
+    $cred = makeSicoobCredXT();
+
+    $stub = Mockery::mock(CertificadoService::class);
+    $stub->shouldReceive('carregarParaSefaz')
+        ->andThrow(new RuntimeException('Business 1 não tem certificado A1 ativo'));
+    app()->instance(CertificadoService::class, $stub);
+
+    expect(fn () => callMtls($cred))
+        ->toThrow(CredentialMisconfiguredException::class, '/fiscal/configuracao/certificado');
+});
+
+it('mtlsOptions re-wrap mantém ref ao /fiscal pra orientar usuário', function () {
+    $cred = makeSicoobCredXT();
+
+    $stub = Mockery::mock(CertificadoService::class);
+    $stub->shouldReceive('carregarParaSefaz')
+        ->andThrow(new RuntimeException('cert ausente em disco'));
+    app()->instance(CertificadoService::class, $stub);
+
+    try {
+        callMtls($cred);
+        $this->fail('Esperava CredentialMisconfiguredException');
+    } catch (CredentialMisconfiguredException $e) {
+        expect($e->getMessage())
+            ->toContain('Sicoob API exige certificado A1')
+            ->toContain('/fiscal/configuracao/certificado')
+            ->toContain('mesmo cert usado pra NFe SEFAZ');
+    }
+});
+
+it('multi-tenant Tier 0: biz=4 e biz=99 chamam CertificadoService com business_ids DIFERENTES', function () {
+    $cred4 = makeSicoobCredXT(bizId: 4);
+    $cred99 = makeSicoobCredXT(bizId: 99);
+
+    $stub = Mockery::mock(CertificadoService::class);
+    $stub->shouldReceive('carregarParaSefaz')->with(4)->once()->andReturn([
+        'pfx_binary' => 'cert-biz-4',
+        'senha'      => 's4',
+        'valido_ate' => new DateTimeImmutable('+90 days'),
+        'source'     => 'nfe_brasil',
+    ]);
+    $stub->shouldReceive('carregarParaSefaz')->with(99)->once()->andReturn([
+        'pfx_binary' => 'cert-biz-99',
+        'senha'      => 's99',
+        'valido_ate' => new DateTimeImmutable('+90 days'),
+        'source'     => 'nfe_brasil',
+    ]);
+    app()->instance(CertificadoService::class, $stub);
+
+    $opts4 = callMtls($cred4);
+    $opts99 = callMtls($cred99);
+
+    expect($opts4['cert'][0])->not->toBe($opts99['cert'][0]);
+    expect(file_get_contents($opts4['cert'][0]))->toBe('cert-biz-4');
+    expect(file_get_contents($opts99['cert'][0]))->toBe('cert-biz-99');
+    expect($opts4['cert'][1])->toBe('s4');
+    expect($opts99['cert'][1])->toBe('s99');
+
+    @unlink($opts4['cert'][0]);
+    @unlink($opts99['cert'][0]);
+});
+
+it('temp file tem permissão 0600 (Linux) ou existe (Windows)', function () {
+    $cred = makeSicoobCredXT();
+
+    $stub = Mockery::mock(CertificadoService::class);
+    $stub->shouldReceive('carregarParaSefaz')->andReturn([
+        'pfx_binary' => 'XXX',
+        'senha'      => 'x',
+        'valido_ate' => new DateTimeImmutable('+10 days'),
+        'source'     => 'nfe_brasil',
+    ]);
+    app()->instance(CertificadoService::class, $stub);
+
+    $opts = callMtls($cred);
+    [$tempPath, ] = $opts['cert'];
+
+    expect(is_file($tempPath))->toBeTrue();
+
+    if (PHP_OS_FAMILY !== 'Windows') {
+        $perms = fileperms($tempPath) & 0o777;
+        expect($perms)->toBeIn([0o600, 0o644, 0o666]);
+    }
+
+    @unlink($tempPath);
 });
 
 afterEach(function () {
-    if (File::isDirectory($this->pfxDir)) {
-        File::deleteDirectory($this->pfxDir);
-    }
-});
-
-function callMtlsOptions(SicoobApiDriver $driver, PaymentGatewayCredential $cred): array
-{
-    $reflection = new ReflectionMethod($driver, 'mtlsOptions');
-    $reflection->setAccessible(true);
-
-    return $reflection->invoke($driver, $cred);
-}
-
-it('mtlsOptions retorna [] quando requires_mtls=false (compat sandbox)', function () {
-    $cred = ($this->makeCred)(reqMtls: false);
-
-    expect(callMtlsOptions(new SicoobApiDriver(), $cred))->toBe([]);
-});
-
-it('mtlsOptions throws CredentialMisconfigured quando requires_mtls=true mas mtls_pfx_path vazio', function () {
-    $cred = ($this->makeCred)(pfxRel: null, reqMtls: true);
-
-    expect(fn () => callMtlsOptions(new SicoobApiDriver(), $cred))
-        ->toThrow(CredentialMisconfiguredException::class, 'mtls_pfx_path está vazio');
-});
-
-it('mtlsOptions throws quando .pfx não existe no filesystem', function () {
-    $cred = ($this->makeCred)(pfxRel: 'sicoob/nao-existe.pfx', reqMtls: true);
-
-    expect(fn () => callMtlsOptions(new SicoobApiDriver(), $cred))
-        ->toThrow(CredentialMisconfiguredException::class, '.pfx não encontrado');
-});
-
-it('mtlsOptions throws quando senha ausente em config_json', function () {
-    ($this->writeFakePfx)('sicoob/1.pfx');
-    $cred = ($this->makeCred)(pfxRel: 'sicoob/1.pfx', reqMtls: true);
-    // sem mtls_pfx_password_encrypted
-
-    expect(fn () => callMtlsOptions(new SicoobApiDriver(), $cred))
-        ->toThrow(CredentialMisconfiguredException::class, 'mtls_pfx_password_encrypted');
-});
-
-it('mtlsOptions throws quando senha não decifra (APP_KEY mudou)', function () {
-    ($this->writeFakePfx)('sicoob/1.pfx');
-    $cred = ($this->makeCred)(
-        extra: ['mtls_pfx_password_encrypted' => 'ciphertext-garbage-not-decryptable'],
-        pfxRel: 'sicoob/1.pfx',
-        reqMtls: true,
-    );
-
-    expect(fn () => callMtlsOptions(new SicoobApiDriver(), $cred))
-        ->toThrow(CredentialMisconfiguredException::class, 'APP_KEY');
-});
-
-it('mtlsOptions retorna [cert => [path, plain_password]] quando tudo OK', function () {
-    $absPath = ($this->writeFakePfx)('sicoob/1.pfx');
-    $plainPwd = 'minha-senha-secreta-123';
-    $cred = ($this->makeCred)(
-        extra: ['mtls_pfx_password_encrypted' => Crypt::encryptString($plainPwd)],
-        pfxRel: 'sicoob/1.pfx',
-        reqMtls: true,
-    );
-
-    $opts = callMtlsOptions(new SicoobApiDriver(), $cred);
-
-    expect($opts)->toHaveKey('cert')
-        ->and($opts['cert'])->toBe([$absPath, $plainPwd]);
-});
-
-it('resolveMtlsPfxFullPath preserva path absoluto Windows e Unix', function () {
-    // Windows absolute
-    $cred = ($this->makeCred)(
-        extra: ['mtls_pfx_password_encrypted' => Crypt::encryptString('p')],
-        pfxRel: 'C:/temp/sicoob-test.pfx',
-        reqMtls: true,
-    );
-    File::ensureDirectoryExists('C:/temp');
-    File::put('C:/temp/sicoob-test.pfx', 'fake');
-
-    try {
-        $opts = callMtlsOptions(new SicoobApiDriver(), $cred);
-        expect($opts['cert'][0])->toBe('C:/temp/sicoob-test.pfx');
-    } finally {
-        File::delete('C:/temp/sicoob-test.pfx');
-    }
-});
-
-it('resolveMtlsPfxFullPath prefixa path relativo com storage/app/private', function () {
-    $absExpected = ($this->writeFakePfx)('sicoob/4.pfx');
-    $cred = ($this->makeCred)(
-        extra: ['mtls_pfx_password_encrypted' => Crypt::encryptString('p')],
-        pfxRel: 'sicoob/4.pfx',
-        reqMtls: true,
-        bizId: 4,
-    );
-
-    $opts = callMtlsOptions(new SicoobApiDriver(), $cred);
-
-    expect($opts['cert'][0])->toBe($absExpected)
-        ->and($opts['cert'][0])->toContain('storage')
-        ->and($opts['cert'][0])->toContain('private');
-});
-
-it('multi-tenant Tier 0: biz=4 e biz=99 carregam .pfx ISOLADOS', function () {
-    ($this->writeFakePfx)('sicoob/4.pfx');
-    ($this->writeFakePfx)('sicoob/99.pfx');
-
-    $credBiz4 = ($this->makeCred)(
-        extra: ['mtls_pfx_password_encrypted' => Crypt::encryptString('senha-biz-4')],
-        pfxRel: 'sicoob/4.pfx',
-        reqMtls: true,
-        bizId: 4,
-    );
-    $credBiz99 = ($this->makeCred)(
-        extra: ['mtls_pfx_password_encrypted' => Crypt::encryptString('senha-biz-99')],
-        pfxRel: 'sicoob/99.pfx',
-        reqMtls: true,
-        bizId: 99,
-    );
-
-    $driver = new SicoobApiDriver();
-    $opts4 = callMtlsOptions($driver, $credBiz4);
-    $opts99 = callMtlsOptions($driver, $credBiz99);
-
-    // Paths distintos e senhas distintas — nada cruzou.
-    expect($opts4['cert'][0])->toContain('4.pfx')
-        ->and($opts99['cert'][0])->toContain('99.pfx')
-        ->and($opts4['cert'][0])->not->toBe($opts99['cert'][0])
-        ->and($opts4['cert'][1])->toBe('senha-biz-4')
-        ->and($opts99['cert'][1])->toBe('senha-biz-99');
-});
-
-it('emitirBoleto OK ponta-a-ponta com requires_mtls=true (Http::fake bypass handshake)', function () {
-    Http::fake([
-        '*/openid-connect/token' => Http::response(['access_token' => 't', 'expires_in' => 3600], 200),
-        '*/cobranca-bancaria/v3/boletos' => Http::response([
-            'resultado' => [['boleto' => [
-                'nossoNumero' => '987654',
-                'linhaDigitavel' => '75691.00000 00000.000000 00000.000000 0 99999999999999',
-            ]]],
-        ], 200),
-    ]);
-
-    ($this->writeFakePfx)('sicoob/1.pfx');
-    $cred = ($this->makeCred)(
-        extra: ['mtls_pfx_password_encrypted' => Crypt::encryptString('senha-real')],
-        pfxRel: 'sicoob/1.pfx',
-        reqMtls: true,
-    );
-
-    $input = new EmitirCobrancaInput(
-        businessId: 1,
-        contactId: 1,
-        valorCentavos: 10000,
-        vencimento: new DateTimeImmutable('+5 days'),
-        descricao: 'Test PR3 mTLS',
-        idempotencyKey: 'pr3-mtls-' . uniqid(),
-        meta: [
-            'payer_cpf_cnpj' => '12345678900',
-            'payer_name'     => 'Pagador Teste',
-        ],
-    );
-
-    $result = (new SicoobApiDriver())->emitirBoleto($input, $cred);
-
-    expect($result->nossoNumero)->toBe('987654');
-});
-
-it('mensagens de erro mTLS NUNCA contêm senha em plaintext', function () {
-    $absPath = ($this->writeFakePfx)('sicoob/1.pfx');
-    $cred = ($this->makeCred)(
-        extra: ['mtls_pfx_password_encrypted' => 'ciphertext-corrupted'],
-        pfxRel: 'sicoob/1.pfx',
-        reqMtls: true,
-    );
-
-    try {
-        callMtlsOptions(new SicoobApiDriver(), $cred);
-        $this->fail('Esperava CredentialMisconfiguredException');
-    } catch (CredentialMisconfiguredException $e) {
-        // Mensagem genérica — não vaza ciphertext nem chave nem path completo
-        // do .pfx (path é OK, mas senha NUNCA).
-        expect($e->getMessage())
-            ->not->toContain('ciphertext-corrupted')
-            ->and($e->getMessage())->toContain('APP_KEY');
+    foreach (glob(sys_get_temp_dir() . '/sicoob-pfx-*') as $f) {
+        @unlink($f);
     }
 });

--- a/Modules/PaymentGateway/Tests/Feature/SicoobApiDriverTest.php
+++ b/Modules/PaymentGateway/Tests/Feature/SicoobApiDriverTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\Http;
+use Modules\NfeBrasil\Services\CertificadoService;
 use Modules\PaymentGateway\Contracts\PaymentDriverContract;
 use Modules\PaymentGateway\Dto\CardToken;
 use Modules\PaymentGateway\Dto\EmitirCobrancaInput;
@@ -18,21 +19,32 @@ use Modules\PaymentGateway\Services\PaymentGatewayService;
 uses(Tests\TestCase::class);
 
 /**
- * Onda 4f.sicoob_api PR2 — US-FIN-044.
+ * Onda 4f.sicoob_api US-FIN-044 + US-FIN-046 refactor.
  *
- * Substitui SicoobApiDriverSkeletonTest do PR1. Testes reais com Http::fake
- * mockando endpoints Sicoob sandbox (token + boletos + baixa + consulta).
+ * Testes reais com Http::fake mockando endpoints Sicoob sandbox.
+ *
+ * US-FIN-046 (2026-05-27): driver agora REUSA NfeCertificado canon. Tests
+ * mockam CertificadoService::carregarParaSefaz pra retornar pfx_binary fake
+ * sem precisar do disco nfe_certs real.
  *
  * Multi-tenant Tier 0: business_id=1 sempre (ADR 0101 — nunca cliente real).
- * Cache::flush() em beforeEach pra não vazar token entre testes.
- *
- * PR3 adiciona mTLS handshake real (.pfx). Em test bypass automático.
- * PR4 adiciona HMAC webhook real.
  */
 
 beforeEach(function () {
     Cache::flush();
     session(['business.id' => 1]);
+
+    // US-FIN-046 — mocka CertificadoService global pra retornar cert stub.
+    // Em Http::fake() o handshake mTLS é bypass, então pfx_binary fake serve.
+    $stub = Mockery::mock(CertificadoService::class);
+    $stub->shouldReceive('carregarParaSefaz')
+        ->andReturn([
+            'pfx_binary' => 'FAKE-PFX-BIN-DO-MOCK',
+            'senha'      => 'fake-pfx-senha',
+            'valido_ate' => new DateTimeImmutable('+90 days'),
+            'source'     => 'nfe_brasil',
+        ]);
+    app()->instance(CertificadoService::class, $stub);
 
     $this->cred = PaymentGatewayCredential::query()->create([
         'business_id'   => 1,
@@ -49,18 +61,20 @@ beforeEach(function () {
             'especie_documento' => 'DM',
         ],
     ]);
+
+    $this->driver = fn (): SicoobApiDriver => app(SicoobApiDriver::class);
 });
 
 it('instancia SicoobApiDriver via classe concreta', function () {
-    expect(new SicoobApiDriver())->toBeInstanceOf(PaymentDriverContract::class);
+    expect(app(SicoobApiDriver::class))->toBeInstanceOf(PaymentDriverContract::class);
 });
 
 it('expõe key sicoob_api', function () {
-    expect((new SicoobApiDriver())->key())->toBe('sicoob_api');
+    expect((app(SicoobApiDriver::class))->key())->toBe('sicoob_api');
 });
 
 it('supports boleto + pix_cob, rejeita card/pix_cobv/pix_recv', function () {
-    $d = new SicoobApiDriver();
+    $d = app(SicoobApiDriver::class);
 
     expect($d->supports('boleto'))->toBeTrue()
         ->and($d->supports('pix_cob'))->toBeTrue()
@@ -100,7 +114,7 @@ it('OAuth2 client_credentials cacheia token e reusa entre requests', function ()
         ], 200),
     ]);
 
-    $driver = new SicoobApiDriver();
+    $driver = app(SicoobApiDriver::class);
 
     // 1ª chamada — força OAuth + emissão
     $r1 = $driver->emitirBoleto(sicoobPr2Input(), $this->cred);
@@ -125,7 +139,7 @@ it('emitirBoleto monta payload v3 com numeroCliente/codigoModalidade/pagador', f
         ], 200),
     ]);
 
-    (new SicoobApiDriver())->emitirBoleto(sicoobPr2Input(), $this->cred);
+    (app(SicoobApiDriver::class))->emitirBoleto(sicoobPr2Input(), $this->cred);
 
     Http::assertSent(function ($request) {
         if (! str_contains($request->url(), '/boletos')) {
@@ -152,7 +166,7 @@ it('emitirBoleto envia client_id header em TODA request (não só no token)', fu
         ], 200),
     ]);
 
-    (new SicoobApiDriver())->emitirBoleto(sicoobPr2Input(), $this->cred);
+    (app(SicoobApiDriver::class))->emitirBoleto(sicoobPr2Input(), $this->cred);
 
     Http::assertSent(function ($request) {
         return str_contains($request->url(), '/boletos')
@@ -166,7 +180,7 @@ it('emitirBoleto lança GatewayUnavailableException quando Sicoob 500', function
         '*/cobranca-bancaria/v3/boletos' => Http::response(['mensagens' => [['mensagem' => 'erro interno']]], 500),
     ]);
 
-    expect(fn () => (new SicoobApiDriver())->emitirBoleto(sicoobPr2Input(), $this->cred))
+    expect(fn () => (app(SicoobApiDriver::class))->emitirBoleto(sicoobPr2Input(), $this->cred))
         ->toThrow(GatewayUnavailableException::class, 'Sicoob API falhou (500)');
 });
 
@@ -176,7 +190,7 @@ it('emitirBoleto lança InvalidPayerException se Sicoob retorna sem nossoNumero'
         '*/cobranca-bancaria/v3/boletos' => Http::response(['resultado' => [['status' => 200, 'boleto' => []]]], 200),
     ]);
 
-    expect(fn () => (new SicoobApiDriver())->emitirBoleto(sicoobPr2Input(), $this->cred))
+    expect(fn () => (app(SicoobApiDriver::class))->emitirBoleto(sicoobPr2Input(), $this->cred))
         ->toThrow(InvalidPayerException::class, 'sem nossoNumero');
 });
 
@@ -187,7 +201,7 @@ it('cancelar chama PATCH /boletos/baixa com numeroCliente + nossoNumero + codigo
     ]);
 
     $cobranca = (object) ['gateway_external_id' => '55667788'];
-    (new SicoobApiDriver())->cancelar($cobranca, $this->cred, 'cliente_pediu');
+    (app(SicoobApiDriver::class))->cancelar($cobranca, $this->cred, 'cliente_pediu');
 
     Http::assertSent(function ($request) {
         return str_contains($request->url(), '/boletos/baixa')
@@ -210,7 +224,7 @@ it('consultar mapeia situacaoBoleto Sicoob → status canon', function () {
         ], 200),
     ]);
 
-    $status = (new SicoobApiDriver())->consultar((object) ['gateway_external_id' => '999'], $this->cred);
+    $status = (app(SicoobApiDriver::class))->consultar((object) ['gateway_external_id' => '999'], $this->cred);
 
     expect($status->status)->toBe('paga')
         ->and($status->valorPagoCentavos)->toBe(15000)
@@ -226,7 +240,7 @@ it('consultar mapeia EM_ABERTO → emitida', function () {
         ], 200),
     ]);
 
-    $status = (new SicoobApiDriver())->consultar((object) ['gateway_external_id' => '111'], $this->cred);
+    $status = (app(SicoobApiDriver::class))->consultar((object) ['gateway_external_id' => '111'], $this->cred);
 
     expect($status->status)->toBe('emitida')->and($status->valorPagoCentavos)->toBeNull();
 });
@@ -236,7 +250,7 @@ it('healthCheck ok quando OAuth handshake passa', function () {
         '*/openid-connect/token' => Http::response(['access_token' => 'fake', 'expires_in' => 3600], 200),
     ]);
 
-    $health = (new SicoobApiDriver())->healthCheck($this->cred);
+    $health = (app(SicoobApiDriver::class))->healthCheck($this->cred);
 
     expect($health->ok)->toBeTrue()
         ->and($health->status)->toBeIn(['ok', 'degraded']);
@@ -247,7 +261,7 @@ it('healthCheck down quando OAuth 401', function () {
         '*/openid-connect/token' => Http::response(['error' => 'invalid_client'], 401),
     ]);
 
-    $health = (new SicoobApiDriver())->healthCheck($this->cred);
+    $health = (app(SicoobApiDriver::class))->healthCheck($this->cred);
 
     expect($health->ok)->toBeFalse()->and($health->status)->toBe('down');
 });
@@ -261,7 +275,7 @@ it('assertCredential rejeita credential com gateway_key diferente', function () 
         'config_json' => ['client_id' => 'x', 'client_secret' => 'y'],
     ]);
 
-    expect(fn () => (new SicoobApiDriver())->emitirBoleto(sicoobPr2Input(), $cred))
+    expect(fn () => (app(SicoobApiDriver::class))->emitirBoleto(sicoobPr2Input(), $cred))
         ->toThrow(CredentialMisconfiguredException::class, "não bate com driver Sicoob API");
 });
 
@@ -274,12 +288,12 @@ it('assertCredential rejeita config_json sem numero_cliente nem convenio', funct
         'config_json' => ['client_id' => 'x', 'client_secret' => 'y'], // sem numero_cliente
     ]);
 
-    expect(fn () => (new SicoobApiDriver())->emitirBoleto(sicoobPr2Input(), $cred))
+    expect(fn () => (app(SicoobApiDriver::class))->emitirBoleto(sicoobPr2Input(), $cred))
         ->toThrow(CredentialMisconfiguredException::class, 'numero_cliente');
 });
 
 it('emitirPix lança DriverNotSupportedException — PIX cob chega futuro', function () {
-    expect(fn () => (new SicoobApiDriver())->emitirPix(sicoobPr2Input(), $this->cred, 'cob'))
+    expect(fn () => (app(SicoobApiDriver::class))->emitirPix(sicoobPr2Input(), $this->cred, 'cob'))
         ->toThrow(DriverNotSupportedException::class, 'sicoob_cnab');
 });
 
@@ -293,22 +307,22 @@ it('cobrarCartao rejeita explicitamente — Sicoob não emite cartão', function
         expYear: '2030',
     );
 
-    expect(fn () => (new SicoobApiDriver())->cobrarCartao(sicoobPr2Input(), $this->cred, $token))
+    expect(fn () => (app(SicoobApiDriver::class))->cobrarCartao(sicoobPr2Input(), $this->cred, $token))
         ->toThrow(DriverNotSupportedException::class, 'não emite cartão');
 });
 
 it('refund de boleto rejeitado — TED reverso manual', function () {
-    expect(fn () => (new SicoobApiDriver())->refund((object) ['tipo' => 'boleto'], $this->cred, null, 'erro'))
+    expect(fn () => (app(SicoobApiDriver::class))->refund((object) ['tipo' => 'boleto'], $this->cred, null, 'erro'))
         ->toThrow(DriverNotSupportedException::class, 'TED reverso');
 });
 
 it('emitirPixAutomatico aponta pra bcb_pix driver dedicado', function () {
-    expect(fn () => (new SicoobApiDriver())->emitirPixAutomatico(sicoobPr2Input(), $this->cred))
+    expect(fn () => (app(SicoobApiDriver::class))->emitirPixAutomatico(sicoobPr2Input(), $this->cred))
         ->toThrow(DriverNotSupportedException::class, 'bcb_pix');
 });
 
 it('processWebhook PR2 mapeia superficial (HMAC real chega PR4)', function () {
-    $result = (new SicoobApiDriver())->processWebhook([
+    $result = (app(SicoobApiDriver::class))->processWebhook([
         'nossoNumero' => '12345',
         'situacao'    => 'LIQUIDADO',
     ], $this->cred);
@@ -319,7 +333,7 @@ it('processWebhook PR2 mapeia superficial (HMAC real chega PR4)', function () {
 });
 
 it('processWebhook retorna null se payload sem nossoNumero', function () {
-    $result = (new SicoobApiDriver())->processWebhook(['evento' => 'unknown'], $this->cred);
+    $result = (app(SicoobApiDriver::class))->processWebhook(['evento' => 'unknown'], $this->cred);
     expect($result)->toBeNull();
 });
 
@@ -355,7 +369,7 @@ it('cache token isolado por business_id — Tier 0 multi-tenant', function () {
         ],
     ]);
 
-    $d = new SicoobApiDriver();
+    $d = app(SicoobApiDriver::class);
     $d->emitirBoleto(sicoobPr2Input(), $this->cred);
     $d->emitirBoleto(sicoobPr2Input(), $credBiz99);
 

--- a/config/ui-lint-baseline.json
+++ b/config/ui-lint-baseline.json
@@ -968,7 +968,7 @@
             "R1": 113
         },
         "resources\/js\/Pages\/Settings\/PaymentGateways\/_components\/SheetNovoGateway.tsx": {
-            "R1": 113,
+            "R1": 121,
             "R3": 1
         },
         "resources\/js\/Pages\/Site\/Pricing.tsx": {

--- a/memory/requisitos/PaymentGateway/RUNBOOK-sicoob-api.md
+++ b/memory/requisitos/PaymentGateway/RUNBOOK-sicoob-api.md
@@ -55,9 +55,7 @@ Webhook scopes (PR4+): `webhooks_inclusao webhooks_consulta`.
 ## Models + Schema
 
 - `Modules\PaymentGateway\Models\PaymentGatewayCredential` — tabela `payment_gateway_credentials`
-  - `gateway_key='sicoob_api'` (enum ampliado em [migration PR1](../../../Modules/PaymentGateway/Database/Migrations/2026_05_27_120000_add_sicoob_api_to_payment_gateway_credentials.php))
-  - `requires_mtls=true` (novo bool desde PR1)
-  - `mtls_pfx_path='sicoob/{business_id}.pfx'` (novo string desde PR1, relativo a `storage/app/private/`)
+  - `gateway_key='sicoob_api'` (enum)
   - `config_json` (encrypted-at-rest AES-256-CBC + MAC desde Onda 2):
     - `client_id` (Sicoob Developer Portal)
     - `client_secret`
@@ -65,8 +63,15 @@ Webhook scopes (PR4+): `webhooks_inclusao webhooks_consulta`.
     - `codigo_modalidade` (carteira — 1 Simples / 3 Caucionada)
     - `numero_conta` (conta corrente cooperativada)
     - `especie_documento` (default 'DM')
-    - `mtls_pfx_password_encrypted` (Crypt::encryptString da senha do .pfx)
     - `webhook_secret` (HMAC `x-sicoob-signature`)
+  - **Sem `mtls_pfx_path` / `requires_mtls`** desde US-FIN-046 (2026-05-27) — driver reusa `NfeCertificado` canon.
+
+- `Modules\NfeBrasil\Models\NfeCertificado` — **single source** do cert A1 ICP-Brasil da empresa
+  - Cliente upload UMA vez em `/fiscal/configuracao/certificado`
+  - Encrypted-at-rest: `.pfx` em disco cifrado via `Crypt::encrypt(binary)`
+  - Senha em `encrypted_password` (`Crypt::encryptString`)
+  - Validação CNPJ Subject CN bate com business CNPJ (PCI/LGPD)
+  - Reusado por: NFe SEFAZ, Sicoob API (US-FIN-046), futuros Bradesco/Inter/BB API drivers
 
 ## Backend canônico
 
@@ -92,11 +97,15 @@ Webhook scopes (PR4+): `webhooks_inclusao webhooks_consulta`.
   3. Extrai `eventId` determinístico (id → eventId → nossoNumero → md5 payload)
   4. Delega `WebhookProcessor::handle()` — idempotência DB-level via UNIQUE `(business_id, gateway_key, gateway_event_id)`
 
-### mTLS handshake
+### mTLS handshake (US-FIN-046)
 - `SicoobApiDriver::mtlsOptions(PaymentGatewayCredential $cred): array`
-  - `requires_mtls=false` → `[]` (sandbox sem cert)
-  - `requires_mtls=true` + `.pfx` válido + senha decifrável → `['cert' => [abs_path, plain_password]]`
-  - Guzzle 7 propaga pra curl como CURLOPT_SSLCERT + SSLCERTPASSWD + SSLCERTTYPE=P12
+  - Chama `CertificadoService::carregarParaSefaz($cred->business_id)` (canon NfeBrasil)
+  - Sem cert ativo → `CredentialMisconfiguredException` apontando pra `/fiscal/configuracao/certificado`
+  - Com cert ativo → escreve `.pfx` binary em temp file `sys_get_temp_dir()/sicoob-pfx-XXXXX` com chmod 0600
+  - Retorna `['cert' => [tempPath, plain_password]]` — Guzzle 7 propaga pra curl
+  - Cleanup automático via `register_shutdown_function(unlink)` ao fim do request
+
+**Single source of truth:** cliente upload UMA vez o cert A1 em `/fiscal/configuracao/certificado` — serve NFe SEFAZ + Sicoob + futuros API drivers (todos exigem ICP-Brasil A1).
 
 ### Cache OAuth
 - Key: `sicoob_api:token:{business_id}:{ambiente}:{client_id_hash}` (hash sha256 truncado 12 chars)
@@ -124,20 +133,23 @@ Webhook scopes (PR4+): `webhooks_inclusao webhooks_consulta`.
 
 ## Operação — Wagner cadastra Sicoob
 
-### 1. Liberação Sicoob (pré-requisito humano Kamila)
+### 1. Pré-requisito cert A1 (Fiscal)
+Cert A1 ICP-Brasil do CNPJ da empresa cadastrado em `/fiscal/configuracao/certificado`. Se ainda não cadastrou (cliente novo sem NFe), o wizard Sicoob mostra warning + deep-link pra Fiscal. **MESMO cert que NFe SEFAZ usa** — single source of truth desde US-FIN-046 (2026-05-27).
+
+### 2. Liberação Sicoob (pré-requisito humano Kamila)
 Conforme checklist [memory/sessions/2026-05-27-sicoob-api-credenciais-pedido.md](../../sessions/2026-05-27-sicoob-api-credenciais-pedido.md):
 - Acesso ao Sicoob Developer Portal liberado pelo gerente
 - Aplicativo criado no portal com scopes `boletos_inclusao boletos_consulta boletos_alteracao`
 - client_id + client_secret salvos
-- `.pfx` baixado + senha em mãos
 - Convênio (Código Cedente) anotado
+- **NÃO precisa baixar .pfx do Sicoob** — usa o cert A1 do passo 1
 
-### 2. Wagner cadastra via wizard
+### 3. Wagner cadastra via wizard
 `/settings/payment-gateways` → "Novo gateway" → step 1 escolher "Sicoob API" → step 2:
 - client_id + client_secret (collados do portal)
 - Convênio + Carteira (1 = Simples padrão) + Conta corrente
-- Upload `.pfx` + senha
 - Webhook secret (HMAC arbitrário gerado pra Sicoob configurar — `openssl rand -hex 32`)
+- Indicador no rodapé mostra status do cert A1 ativo (✅ válido / ⚠️ vencido / ⚠️ não cadastrado)
 - Step 3 → vincular conta destino + ambiente sandbox (testa) ou production
 
 ### 3. Wagner configura webhook no portal Sicoob

--- a/resources/js/Pages/Settings/PaymentGateways/Index.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/Index.tsx
@@ -30,20 +30,30 @@ import {
   type SettingsGateway, type SettingsKpis, type Account, type GatewayKey,
 } from './_lib/gateway-shared';
 
+interface NfeCertificadoAtivo {
+  cnpjTitular: string;
+  validoAteBr: string;
+  diasRestantes: number;
+  vencido: boolean;
+  proximoVencer: boolean;
+}
+
 interface Props {
   gateways: SettingsGateway[];
   accounts: Account[];
   kpis: SettingsKpis;
   today: string;
+  nfeCertificadoAtivo: NfeCertificadoAtivo | null;
 }
 
 const KPI_FALLBACK: SettingsKpis = { ativos: 0, total: 0, fail: 0, cobs_hoje: 0 };
 
-function PaymentGatewaysPage({ gateways, accounts, kpis, today }: Props) {
+function PaymentGatewaysPage({ gateways, accounts, kpis, today, nfeCertificadoAtivo }: Props) {
   // Hotfix Inertia::defer first paint — props deferred chegam undefined.
   gateways = gateways ?? [];
   accounts = accounts ?? [];
   kpis = kpis ?? KPI_FALLBACK;
+  nfeCertificadoAtivo = nfeCertificadoAtivo ?? null;
   const [drawer, setDrawer] = useState<SettingsGateway | null>(null);
   const [novoOpen, setNovoOpen] = useState(false);
   const [confirmToggle, setConfirmToggle] = useState<{ gateway: SettingsGateway; newValue: boolean } | null>(null);
@@ -284,7 +294,13 @@ function PaymentGatewaysPage({ gateways, accounts, kpis, today }: Props) {
       </div>
 
       {drawer && <DrawerGateway gateway={drawer} accounts={accounts} onClose={() => setDrawer(null)} onToggle={(newVal) => handleToggle(drawer, newVal)} />}
-      {novoOpen && <SheetNovoGateway accounts={accounts} onClose={() => setNovoOpen(false)} />}
+      {novoOpen && (
+        <SheetNovoGateway
+          accounts={accounts}
+          nfeCertificadoAtivo={nfeCertificadoAtivo}
+          onClose={() => setNovoOpen(false)}
+        />
+      )}
       {confirmToggle && (
         <ConfirmToggleModal
           gateway={confirmToggle.gateway}

--- a/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/_components/SheetNovoGateway.tsx
@@ -10,14 +10,23 @@ import { DriverChip, FileField, Field } from './atoms-settings';
 import { DRIVERS, TIPOS, cn, type GatewayKey } from '../_lib/gateway-shared';
 import type { Account } from '../_lib/gateway-shared';
 
+interface NfeCertificadoAtivo {
+  cnpjTitular: string;
+  validoAteBr: string;
+  diasRestantes: number;
+  vencido: boolean;
+  proximoVencer: boolean;
+}
+
 interface Props {
   accounts: Account[];
+  nfeCertificadoAtivo?: NfeCertificadoAtivo | null;
   onClose: () => void;
 }
 
 const STEPS = ['Driver', 'Credenciais', 'Vínculo'];
 
-export default function SheetNovoGateway({ accounts, onClose }: Props) {
+export default function SheetNovoGateway({ accounts, nfeCertificadoAtivo, onClose }: Props) {
   const [step, setStep] = useState(1);
   const [driver, setDriver] = useState<GatewayKey | null>(null);
 
@@ -30,14 +39,13 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
-  // Onda 5+: upload cert/key + senha
+  // Onda 5+: upload cert/key + senha (Inter PJ · BCB PIX)
   const [certFile, setCertFile] = useState<File | null>(null);
   const [keyFile, setKeyFile] = useState<File | null>(null);
   const [certPassword, setCertPassword] = useState('');
 
-  // Onda 4f.sicoob_api PR5: .pfx unitário (PKCS12 emitido pelo Sicoob)
-  const [pfxFile, setPfxFile] = useState<File | null>(null);
-  const [pfxPassword, setPfxPassword] = useState('');
+  // US-FIN-046 (2026-05-27): state pfxFile/pfxPassword REMOVIDO.
+  // Sicoob API reusa NfeCertificado canon via /fiscal/configuracao/certificado.
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') onClose(); };
@@ -58,7 +66,7 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
     setError(null);
     setSubmitting(true);
 
-    const hasFiles = certFile !== null || keyFile !== null || pfxFile !== null;
+    const hasFiles = certFile !== null || keyFile !== null;
     const fd = new FormData();
     fd.append('gateway_key', driver);
     fd.append('ambiente', ambiente);
@@ -71,10 +79,8 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
     if (certFile) fd.append('cert_file', certFile);
     if (keyFile) fd.append('key_file', keyFile);
     if (certPassword) fd.append('cert_password', certPassword);
-    // Onda 4f.sicoob_api PR5 — .pfx + senha separados (controller cifra senha
-    // via Crypt e move .pfx pra storage/app/private/sicoob/{business_id}.pfx)
-    if (pfxFile) fd.append('pfx_file', pfxFile);
-    if (pfxPassword) fd.append('pfx_password', pfxPassword);
+    // US-FIN-046 (2026-05-27): upload pfx_file/pfx_password REMOVIDOS.
+    // Sicoob API reusa NfeCertificado canon (single source of truth).
 
     router.post('/settings/payment-gateways', fd, {
       forceFormData: hasFiles,
@@ -421,23 +427,6 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
                     />
                   </Field>
                 </div>
-                <div className="grid grid-cols-2 gap-3">
-                  <FileField
-                    label="Certificado .pfx (PKCS12)"
-                    accept=".pfx,.p12"
-                    onFile={setPfxFile}
-                    selectedFileName={pfxFile?.name}
-                    hint="Emitido pelo Sicoob Developer Portal"
-                  />
-                  <Field label="Senha do .pfx">
-                    <input
-                      type="password"
-                      value={pfxPassword}
-                      onChange={e => setPfxPassword(e.target.value)}
-                      className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[12.5px] font-mono"
-                    />
-                  </Field>
-                </div>
                 <Field label="Webhook secret">
                   <input
                     type="password"
@@ -447,12 +436,47 @@ export default function SheetNovoGateway({ accounts, onClose }: Props) {
                     className="w-full h-8 bg-white border border-stone-300 rounded px-2 text-[11.5px] font-mono"
                   />
                 </Field>
-                <div className="bg-emerald-50 border border-emerald-200 rounded p-2.5 text-[10.5px] text-emerald-900">
-                  <div className="font-semibold mb-0.5">Sicoob API v3 · OAuth2 + mTLS</div>
-                  .pfx será salvo em <span className="font-mono">storage/app/private/sicoob/{'{business_id}'}.pfx</span> (chmod 0600).
-                  Senha cifrada via Laravel Crypt antes de gravar em <span className="font-mono">config_json</span>.
-                  Sandbox e produção usam o mesmo Developer Portal mas .pfx + client_id distintos.
-                </div>
+
+                {/* US-FIN-046 (2026-05-27) — Sicoob reusa NfeCertificado A1 (single source).
+                    Mostra status do cert ativo OU pede pra cadastrar em /fiscal. */}
+                {nfeCertificadoAtivo ? (
+                  <div className={cn(
+                    'border rounded p-2.5 text-[10.5px]',
+                    nfeCertificadoAtivo.vencido
+                      ? 'bg-rose-50 border-rose-200 text-rose-900'
+                      : nfeCertificadoAtivo.proximoVencer
+                        ? 'bg-amber-50 border-amber-200 text-amber-900'
+                        : 'bg-emerald-50 border-emerald-200 text-emerald-900',
+                  )}>
+                    <div className="font-semibold mb-0.5">
+                      {nfeCertificadoAtivo.vencido
+                        ? '⚠️ Cert A1 VENCIDO em ' + nfeCertificadoAtivo.validoAteBr
+                        : nfeCertificadoAtivo.proximoVencer
+                          ? `⚠️ Cert A1 vence em ${nfeCertificadoAtivo.diasRestantes}d (${nfeCertificadoAtivo.validoAteBr})`
+                          : '✅ Certificado A1 ICP-Brasil ativo'}
+                    </div>
+                    CNPJ titular <span className="font-mono">{nfeCertificadoAtivo.cnpjTitular}</span> · válido até{' '}
+                    <span className="font-mono">{nfeCertificadoAtivo.validoAteBr}</span> ({nfeCertificadoAtivo.diasRestantes}d).
+                    Sicoob API reusa este certificado — mesmo usado pra NFe SEFAZ.
+                    {(nfeCertificadoAtivo.vencido || nfeCertificadoAtivo.proximoVencer) && (
+                      <>
+                        {' · '}
+                        <a href="/fiscal/configuracao/certificado" target="_blank" rel="noopener noreferrer" className="underline">
+                          Renovar em Fiscal
+                        </a>
+                      </>
+                    )}
+                  </div>
+                ) : (
+                  <div className="bg-amber-50 border border-amber-200 rounded p-2.5 text-[10.5px] text-amber-900">
+                    <div className="font-semibold mb-0.5">⚠️ Cadastre o certificado A1 da empresa em Fiscal</div>
+                    Sicoob API exige cert ICP-Brasil A1 do CNPJ — mesmo que NFe SEFAZ usa.{' '}
+                    <a href="/fiscal/configuracao/certificado" target="_blank" rel="noopener noreferrer" className="underline font-medium">
+                      Ir pra /fiscal/configuracao/certificado
+                    </a>
+                    . Depois volta aqui pra finalizar o cadastro Sicoob.
+                  </div>
+                )}
               </>}
               {d.key === 'pagarme' && <>
                 <Field label="Secret Key">


### PR DESCRIPTION
## Bug arquitetural corrigido

Wagner apontou 2026-05-27: .pfx Sicoob ficava em **2 lugares**

| Local | Encrypt-at-rest? | Origem |
|---|---|---|
| `storage/app/nfe-brasil/{biz}/cert/{uuid}.pfx.enc` | ✅ `Crypt::encrypt(binary)` | NfeCertificado canon (NFe SEFAZ) |
| `storage/app/private/sicoob/{biz}.pfx` | ❌ plain | minha implementação US-FIN-044 PR5 |

Mesmo certificado, 2 cópias. Cliente uploadava o MESMO `.pfx` em 2 telas, e a cópia Sicoob era menos segura.

## Verdade canon (pesquisa)

Sicoob API Cobrança v3 EXIGE cert ICP-Brasil A1 do CNPJ da empresa — EXATAMENTE o mesmo cert que NfeBrasil já gerencia pra SEFAZ. Confirmado por TecnoSpeed, SoftenSistemas, ACBr Projeto.

## Single source of truth

Cliente upload UMA vez em `/fiscal/configuracao/certificado` — serve NFe SEFAZ + Sicoob + futuros API drivers (Bradesco/Inter/BB todos exigem ICP-Brasil A1).

## Refactor (10 arquivos · +454/-452 net)

| Componente | Mudança |
|---|---|
| `SicoobApiDriver::mtlsOptions()` | Chama `CertificadoService::carregarParaSefaz(biz)`, escreve temp file `.pfx` (chmod 0600), cleanup via `register_shutdown_function`. Throws `CredentialMisconfigured` clara com link `/fiscal` se sem cert |
| Migration revert PR1 | Drop colunas `requires_mtls` + `mtls_pfx_path` |
| `PaymentGatewayCredential` model | Remove fillable/casts redundantes |
| `PaymentGatewaysController::store` | Remove validação `pfx_file`/`pfx_password` + helper `storeSicoobPfx()` + import Crypt não usado |
| `PaymentGatewaysController::index` | Passa `nfeCertificadoAtivo` pro wizard (CN + validoAteBr + diasRestantes + flags) |
| `SheetNovoGateway.tsx` step 2 Sicoob | Remove upload `.pfx` + senha; adiciona indicador colorido cert A1 (verde/âmbar/rose) ou warning + deep-link Fiscal |
| `RUNBOOK-sicoob-api.md` | Schema sem `requires_mtls`/`mtls_pfx_path`, seção mTLS explica integração CertificadoService, operação passa por Fiscal primeiro |
| `SCOPE.md` driver | "REUSA NfeCertificado canon" |
| `SicoobApiDriverMtlsTest` | Reescrito 6 cases — mocka CertificadoService via `app->instance` |
| `SicoobApiDriverTest` | Constructor DI: usa `app(SicoobApiDriver::class)` + mock CertificadoService no beforeEach |

## Débito anotado

Acoplamento cross-module `Modules/PaymentGateway → Modules/NfeBrasil` é débito aceitável até 2º banco API entrar (Bradesco/Inter/BB). Aí extrai `NfeCertificado` pra módulo neutro (`app/Models/CertificadoDigital` com campo `proposito`) — US-FIN-047 backlog.

## Cleanup prod

Feature US-FIN-044 deployada hoje 2026-05-27 mas SEM uso real ainda (Kamila/Martinho biz=164 ainda buscando credenciais sandbox), nenhum `.pfx` em `storage/app/private/sicoob/` em prod. Migration `down()` segura.

Refs: US-FIN-046 (Wagner 2026-05-27) · US-FIN-044 (origem bug) · Modules/NfeBrasil