### PR TITLE
hotfix(sells): aceitar ponto como decimal em pt-BR (bug 100x — Larissa)

### DIFF
--- a/public/js/functions.js
+++ b/public/js/functions.js
@@ -165,6 +165,28 @@ function __number_uf(input, use_page_currency = false) {
         var decimal = __currency_decimal_separator;
     }
 
+    // Wagner 2026-05-27 HOTFIX: aceita PONTO como decimal alternativo em locale pt-BR
+    // (decimal=','). Smoke prod via Chrome MCP detectou que digitar "10.50" em campo
+    // Preço/Quantidade/Desconto gerava subtotal 100x maior (accounting.unformat trata
+    // ponto como milhar quando decimal=','). Risco financeiro: Larissa @ Rota Livre
+    // poderia cobrar 100x do cliente sem aviso visual.
+    //
+    // Heurística conservadora: se input tem SÓ ponto (sem vírgula) E o ponto tem
+    // 1-2 dígitos depois, é decimal — converte pra vírgula. "10.50" → "10,50".
+    // "1.000" (3 dígitos depois) NÃO converte — preserva semântica de milhar.
+    if (typeof input === 'string' && decimal === ',') {
+        var hasComma = input.indexOf(',') !== -1;
+        var lastDot  = input.lastIndexOf('.');
+        if (!hasComma && lastDot !== -1) {
+            var afterDot = input.length - lastDot - 1;
+            // Só converte se for o ÚNICO ponto (evita ambiguidade tipo "1.000.50")
+            var dotCount = (input.match(/\./g) || []).length;
+            if (dotCount === 1 && afterDot >= 1 && afterDot <= 2) {
+                input = input.substring(0, lastDot) + ',' + input.substring(lastDot + 1);
+            }
+        }
+    }
+
     return accounting.unformat(input, decimal);
 }
 


### PR DESCRIPTION
## 🚨 Bug FINANCEIRO grave detectado smoke prod 2026-05-27

Em /sells/create, digitar preço com **ponto** (\`10.50\`) em vez de vírgula (\`10,50\`):

| Input | Esperado | **Observado** |
|---|---|---|
| Qty 2 · Preço **10.50** | R$ 21,00 | **R$ 2.100,00** ❌ |
| Qty 2 · Preço **10,50** | R$ 21,00 | R$ 21,00 ✅ |

**Risco Larissa @ Rota Livre**: hábito de digitar com ponto (copia do Excel, teclado numérico, apps antigos) → vende **100x mais caro** sem warning visual.

## Repro

\`\`\`js
\$('input.pos_unit_price').val('10.50').trigger('change')
// subtotal_linha mostrado: R\$ 2.100,00  (esperado: R\$ 21,00)
\`\`\`

## Root cause

\`public/js/functions.js:161 __number_uf()\` chama \`accounting.unformat(input, ',')\` em locale pt-BR. accounting.js trata ponto como milhar quando decimal=\`,\`. \"10.50\" → 1050.

## Fix (heurística conservadora)

Pré-processa input antes do unformat. Se input:
- está em pt-BR (decimal=\`,\`) **E**
- tem SÓ um ponto (sem vírgula) **E**
- ponto tem 1-2 dígitos depois

→ converte ponto pra vírgula. \"10.50\" → \"10,50\". 

Preserva semântica de milhar:
- \"1.000\" (3 dígitos depois) → fica como está (1000)
- \"1.000,50\" (tem vírgula) → fica como está (1000.50)

## Impacto

\`__number_uf\` é chamado em ~50+ lugares (pos.js, product.js, financeiro etc). **Fix global** elimina o bug em TODOS os campos de uma vez:
- Preço unitário, Quantidade, Desconto (linha)
- Valor pagamento, Troco
- Frete, Imposto pedido, Despesa adicional

## Test plan
- [x] Repro via Chrome MCP smoke prod
- [ ] Deploy
- [ ] Manual: \"10.50\" em Preço → R$ 21 ✅ | \"10,50\" → R$ 21 ✅ | \"1.000\" Qty → 1000 ✅

## Refs
- Cadeia hotfixes Larissa hoje: #1716/#1719/#1721/#1726/#1729/#1732/#1733
- Audit: \`memory/sessions/2026-05-27-audit-sells-create-vs-blade-larissa.md\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)