### PR TITLE
docs(canon): SPEC US-FIN-044/045/046 + lições 7/8 NfeCertificado

### DIFF
--- a/memory/requisitos/Financeiro/SPEC.md
+++ b/memory/requisitos/Financeiro/SPEC.md
@@ -1459,3 +1459,120 @@ Quando Maiara entregar `review`, Daily Brief avisa Wagner automatic. NAO criar t
 - ADR 0093 multi-tenant Tier 0 (business_id obrigatorio)
 - ADR 0118 segregacao dominios externos (bridge table `accounts_legacy_map`)
 - ADR 0120 PII redaction em audit JSON (legacy_metadata redacted)
+
+---
+
+### US-FIN-044 · SicoobApiDriver nativo (OAuth2 + mTLS + webhook real-time)
+
+> owner: wagner · priority: p1 · estimate: 24h · status: in_progress · type: story
+> blocked_by: cliente (Kamila/Martinho biz=164 buscando credenciais sandbox Sicoob Developer Portal)
+
+## Contexto
+
+Sicoob é Top 5 mercado BR cooperativista. Antes desta US, oimpresso só tinha `SicoobCnabDriver` (CNAB 240 arquivo via `eduardokum/laravel-boleto`). Cliente real (Kamila — Admin#164 do Martinho Caçambas, biz=164, locação caçambas Tubarão/SC, competidor HiSoft) pediu API REST por OAuth2 + webhook real-time pra evitar import manual de arquivo retorno.
+
+**Atenção:** Kamila é do Martinho Caçambas (biz=164), NÃO da ROTA LIVRE (biz=4 Larissa vestuário Gravatal/SC). Confundi os 2 clientes na sessão 2026-05-27 — consolidação canon em PR [#1734](https://github.com/wagnerra23/oimpresso.com/pull/1734).
+
+## Acceptance criteria
+
+Backend em prod (6 PRs mergeados via PR [#1730](https://github.com/wagnerra23/oimpresso.com/pull/1730) cherry-pick consolidation):
+
+- [x] `Modules/PaymentGateway/Services/Drivers/SicoobApiDriver.php` implementando `PaymentDriverContract`
+- [x] OAuth2 client_credentials flow (cache Laravel TTL 3500s, key por business_id + ambiente + hash client_id)
+- [x] mTLS handshake — **reusa NfeCertificado canon** (US-FIN-046 fix, ver abaixo)
+- [x] Endpoints: POST `/cobranca-bancaria/v3/boletos`, GET `/boletos` (consultar), PATCH `/boletos/baixa` (cancelar), webhook receiver
+- [x] `Modules/PaymentGateway/Http/Controllers/Webhooks/SicoobApiWebhookController.php` validando HMAC `x-sicoob-signature` + idempotência
+- [x] Registro `PaymentGatewayService::DRIVERS['sicoob_api']`
+- [x] Wizard step Sicoob no `SheetNovoGateway.tsx` — client_id + secret + convênio + carteira + conta + webhook_secret + indicador cert A1 do Fiscal
+- [x] Deep-link "Onde gerar credencial" → `https://developers.sicoob.com.br`
+- [x] Pest contract test + cross-tenant ampliado
+- [x] [RUNBOOK-sicoob-api.md](../PaymentGateway/RUNBOOK-sicoob-api.md) (11 seções)
+- [x] Charter `Settings/PaymentGateways/Index.charter.md` atualizado
+- [ ] Smoke E2E real com credenciais sandbox da Kamila (BLOQUEADO — pré-req humano)
+
+## Pré-requisito humano
+
+Checklist completo em [memory/sessions/2026-05-27-sicoob-api-credenciais-pedido.md](../../sessions/2026-05-27-sicoob-api-credenciais-pedido.md). Kamila pede pro gerente Sicoob libera Developer Portal + client_id/secret + convênio + webhook scopes.
+
+**NÃO precisa upload .pfx do Sicoob** — cert A1 ICP-Brasil já cadastrado em Fiscal pra NFe SEFAZ serve (verdade canon: Sicoob exige A1 ICP-Brasil do CNPJ, mesmo que NfeBrasil gerencia). Fix arquitetural em US-FIN-046.
+
+## Multi-tenant Tier 0
+
+- Cache OAuth token key por `business_id` — nunca compartilhado entre tenants
+- Webhook valida HMAC com `webhook_secret` da credential do `business_id` da rota
+- mTLS reusa `NfeCertificado` filtrado por `business_id` (single source, encrypted-at-rest via Crypt)
+
+## Refs
+
+- 7 PRs: [#1718](https://github.com/wagnerra23/oimpresso.com/pull/1718) skeleton · [#1720](https://github.com/wagnerra23/oimpresso.com/pull/1720) OAuth+emissão · [#1722](https://github.com/wagnerra23/oimpresso.com/pull/1722) mTLS · [#1724](https://github.com/wagnerra23/oimpresso.com/pull/1724) webhook · [#1725](https://github.com/wagnerra23/oimpresso.com/pull/1725) UI · [#1728](https://github.com/wagnerra23/oimpresso.com/pull/1728) docs · [#1730](https://github.com/wagnerra23/oimpresso.com/pull/1730) cherry-pick stack
+- US-FIN-046 fix arquitetural mTLS
+- ADR 0105 cliente como sinal qualificado
+- ADR 0170 §4f.sicoob_api bancos nativos top-5
+
+---
+
+### US-FIN-045 · Wizard bank-first 2-step (banco → modo conexão)
+
+> owner: — · priority: p1 · estimate: 8h · status: todo · type: story
+> blocked_by: —
+
+## Contexto
+
+Wagner identificou 2026-05-27 (durante sessão US-FIN-044): wizard `SheetNovoGateway` step 1 lista 16+ drivers misturando bancos com modos de conexão (`sicoob_api` ao lado de `sicoob_cnab`, `inter` ao lado de `bradesco_cnab`...). Usuário pensa "quero Sicoob", não "quero `sicoob_api`".
+
+## Acceptance criteria
+
+- [ ] Wizard refatorado pra 4 steps:
+  - **Step 1 — Banco**: 1 card por instituição (Sicoob, Inter, Bradesco, BB, Itaú, Santander, Caixa, BTG, Sicredi, Ailos, Cresol, Banrisul, C6 + grupo PSPs: Asaas, Pagar.me + grupo Regulador: BCB PIX)
+  - **Step 2 — Modo conexão**: opções disponíveis pro banco (API REST / CNAB 240 / API PIX / outros) com trade-offs
+  - **Step 3 — Credenciais**: form dinâmico baseado em (banco, modo)
+  - **Step 4 — Vínculo**: conta destino + ambiente + ativo
+
+- [ ] `gateway-shared.ts` ganha estrutura `BANKS` (top-level) + `MODES` (segundo nível) com mapping `(bank, mode) → GatewayKey`
+
+- [ ] PSPs/Reguladores em grupo separado (Asaas, Pagar.me, BCB)
+
+- [ ] Pest navega wizard 4 steps com casos Sicoob+API / Sicoob+CNAB / Inter+API
+
+## Multi-tenant Tier 0
+
+Sem mudança backend — apenas UI reorganizada. Backend continua recebendo `gateway_key` canon.
+
+## Refs
+
+- US-FIN-044 origem do feedback
+- Não-blocker pra Sicoob funcionar — refactor reduz fricção quando 2º API driver (Bradesco/BB/Itaú) entrar
+
+---
+
+### US-FIN-046 · Sicoob mTLS reusa NfeCertificado (single source of truth)
+
+> owner: wagner · priority: p0 · estimate: 4h · status: review · type: story
+> blocked_by: —
+
+## Contexto
+
+Bug arquitetural US-FIN-044 (Wagner apontou 2026-05-27): `.pfx` Sicoob ficava em 2 lugares — `storage/app/nfe-brasil/{biz}/cert/{uuid}.pfx.enc` (encrypted canon NfeCertificado) + minha cópia `storage/app/private/sicoob/{biz}.pfx` (PLAIN, inseguro). Cliente teria que upload o MESMO cert A1 ICP-Brasil duas vezes.
+
+**Verdade canon (pesquisa Wagner 2026-05-27 — TecnoSpeed/Soften/ACBr):** Sicoob API Cobrança v3 EXIGE cert ICP-Brasil A1 do CNPJ da empresa — EXATAMENTE o mesmo que NfeBrasil já gerencia pra SEFAZ.
+
+## Acceptance criteria
+
+- [x] `SicoobApiDriver::mtlsOptions()` chama `CertificadoService::carregarParaSefaz($cred->business_id)` canon NfeBrasil
+- [x] Temp file `sys_get_temp_dir()/sicoob-pfx-*` com chmod 0600 + cleanup via `register_shutdown_function`
+- [x] `CredentialMisconfigured` clara com link `/fiscal/configuracao/certificado` se business sem cert
+- [x] Migration revert PR1: drop colunas `requires_mtls` + `mtls_pfx_path`
+- [x] Wizard step 2 Sicoob: remove upload .pfx; adiciona indicador colorido (verde/âmbar/rose) cert A1 ativo OU warning + deep-link Fiscal
+- [x] RUNBOOK + SCOPE.md atualizados
+- [x] Pest reescrito: mock `CertificadoService` via `app->instance()`
+- [ ] PR [#1737](https://github.com/wagnerra23/oimpresso.com/pull/1737) merged + deployed
+
+## Débito anotado
+
+Acoplamento cross-module `Modules/PaymentGateway → Modules/NfeBrasil` é débito aceitável até 2º banco API entrar (Bradesco/Inter/BB). Aí extrai `NfeCertificado` pra módulo neutro com campo `proposito` — vira **US-FIN-047** backlog.
+
+## Refs
+
+- US-FIN-044 origem do bug
+- Modules/NfeBrasil/Services/CertificadoService.php canon a reusar
+- Sicoob docs: TecnoSpeed/SoftenSistemas/ACBr confirmam ICP-Brasil A1 (busca Wagner 2026-05-27)

--- a/memory/requisitos/Financeiro/SPEC.md
+++ b/memory/requisitos/Financeiro/SPEC.md
@@ -4,13 +4,16 @@ title: "Especificação funcional — Financeiro"
 type: spec
 module: Financeiro
 status: ativo
-related_adrs: [0154, 0155, 0156]
+related_adrs:
+  - 0154-rubrica-module-grade-v2
+  - 0155-rubrica-module-grade-v3
+  - 0156-rubrica-module-grade-v3-detail
 na_justified_v3:
   D1.c: "Job `CriarTituloDeVendaJob` é `@deprecated` órfão (Onda 2, 2026-04-25) e nunca foi dispatched em produção; sincronização canônica de títulos a partir de transactions ocorre via `TituloAutoService::sincronizarDeTransacao` chamado diretamente pelo `TransactionObserver`. O constructor do Job recebe apenas `$transactionId` e extrai `business_id` da Eloquent (pattern legítimo de Job-por-ID), portanto a checagem `$businessId` no constructor não se aplica ao módulo."
 pii: false
 updated_at: 2026-05-16
-last_updated: 2026-05-19
-version: 1.1
+last_updated: '2026-05-27'
+version: '1.2'
 owner: wagner
 ---
 

--- a/memory/sessions/2026-05-27-us-fin-044-sicoob-api-completion.md
+++ b/memory/sessions/2026-05-27-us-fin-044-sicoob-api-completion.md
@@ -142,7 +142,54 @@ Martinho Caçambas (biz=164, locação/manutenção caçambas, região Tubarão/
 ## Próximos passos
 
 1. **Wagner manda checklist pra Kamila** ([memory/sessions/2026-05-27-sicoob-api-credenciais-pedido.md](2026-05-27-sicoob-api-credenciais-pedido.md))
-2. **Lea/Kamila junta credenciais sandbox Sicoob** (~2-7 dias úteis, depende cooperativa)
-3. **Wagner cadastra biz=4 no wizard sandbox** + smoke E2E real
-4. **Wagner aprova migração biz=4 sicoob_cnab → sicoob_api** (manter ambos 30d)
-5. **Aplicar US-FIN-045 bank-first** quando 2º API driver (Bradesco/BB/Itaú) entrar pra justificar refactor amplo do wizard.
+2. **Kamila junta credenciais sandbox Sicoob** (~2-7 dias úteis, depende cooperativa) — atenção: **não precisa baixar .pfx do Sicoob** (US-FIN-046 reusa cert A1 ICP-Brasil já cadastrado em Fiscal)
+3. **Wagner cadastra biz=164 no wizard sandbox** + smoke E2E real
+4. **Wagner aprova migração biz=164 sicoob_cnab → sicoob_api** (manter ambos 30d)
+5. **Aplicar US-FIN-045 bank-first** quando 2º API driver (Bradesco/BB/Itaú) entrar pra justificar refactor amplo do wizard
+6. **Aplicar US-FIN-047 extrair NfeCertificado** pra módulo neutro quando 2º banco API exigir (Bradesco/Inter/BB todos exigem ICP-Brasil A1)
+
+---
+
+## Adendo 2026-05-27 — Lição US-FIN-046 (bug arquitetural .pfx duplicado)
+
+### O bug que Wagner pegou na revisão
+
+Quando entreguei US-FIN-044, fiz o driver Sicoob armazenar `.pfx` em `storage/app/private/sicoob/{biz}.pfx` (plain) — INDEPENDENTE de qualquer cert que o cliente já tivesse cadastrado no Fiscal pra NFe SEFAZ. Wagner perguntou "Certificado .pfx (PKCS12) vai ficar em dois lugares?" — sim, eu tinha criado duplicação:
+
+| Local | Encrypt-at-rest | Origem |
+|---|---|---|
+| `storage/app/nfe-brasil/{biz}/cert/{uuid}.pfx.enc` | ✅ `Crypt::encrypt(binary)` | NfeCertificado canon (NFe SEFAZ) |
+| `storage/app/private/sicoob/{biz}.pfx` | ❌ plain | minha cópia US-FIN-044 PR5 |
+
+### Verdade canon que faltava
+
+Sicoob API Cobrança v3 EXIGE cert **ICP-Brasil A1 do CNPJ da empresa** — EXATAMENTE o mesmo certificado que NfeBrasil/SEFAZ já usa. Confirmado em TecnoSpeed + SoftenSistemas + ACBr Projeto (pesquisa 2026-05-27). O mesmo vale pra futuros Bradesco API, Inter API mTLS, BB API, Itaú API — todos ICP-Brasil A1.
+
+**Padrão arquitetural recomendado:** drivers de banco PJ no Brasil que exigem mTLS devem **reusar `NfeCertificado` canon** (não criar storage próprio). Cliente upload UMA vez em `/fiscal/configuracao/certificado`. Multi-uso (NFe + Sicoob + Bradesco + ...) automático.
+
+### Fix (US-FIN-046)
+
+`SicoobApiDriver::mtlsOptions()` agora chama `CertificadoService::carregarParaSefaz($cred->business_id)` (canon NfeBrasil), escreve `.pfx` binary em temp file (`sys_get_temp_dir()/sicoob-pfx-*` com chmod 0600), cleanup via `register_shutdown_function`. Retorna `['cert' => [tempPath, plain_password]]` pra Guzzle.
+
+Wizard step 2 Sicoob: removeu upload `.pfx` + senha; adicionou indicador colorido (verde/âmbar/rose) do cert A1 ativo OU warning se ausente com deep-link `/fiscal/configuracao/certificado`. UX clara: cert A1 vive UMA VEZ no Fiscal, todos os drivers consomem.
+
+Migration revert: drop colunas `payment_gateway_credentials.requires_mtls` + `mtls_pfx_path` que ficaram órfãs.
+
+### Lição #7 (registrar canon)
+
+**Antes de criar storage/encrypt/upload novo, GREP por pattern existente** em arquivos canon (`Modules/NfeBrasil/Models/NfeCertificado`, `Modules/NfeBrasil/Services/CertificadoService`, etc). Especialmente pra coisas que parecem "óbvias de criar do zero" (.pfx, cert digital, encrypt-at-rest) — provavelmente alguém já fez canonicamente. Confundir com decisão de implementação inicial gera 2 sistemas e cliente upload duplicado.
+
+### Débito futuro anotado — US-FIN-047
+
+Acoplamento cross-module `Modules/PaymentGateway → Modules/NfeBrasil/Models/NfeCertificado` é débito aceitável até 2º banco API entrar (Bradesco/Inter/BB). Aí extrair pra módulo neutro:
+
+- `app/Models/CertificadoDigital` (ou `Modules/Infra/Certificados/Models/CertificadoDigital`)
+- Campo novo `proposito`: `nfe_sefaz` / `sicoob_mtls` / `bradesco_mtls` / `inter_mtls` / `bb_mtls`
+- Validação CNPJ Subject CN configurável por propósito (NFe exige bater, Sicoob exige bater, BB pode aceitar wildcard)
+- Migrar consumers (NfeBrasil + PaymentGateway) pra novo model
+
+Hoje semanticamente confuso pra time MCP — "por que `Modules/PaymentGateway/Services/Drivers/SicoobApiDriver` importa de `Modules/NfeBrasil/Services/CertificadoService`?". Comentário no driver explica, mas ideal é refactor.
+
+### Lição #8 (revisão por Wagner)
+
+Quando entregar feature técnica que toca infra compartilhada (storage, encrypt, modelo único da empresa, certificados, integrações OAuth), **explicar arquitetura ANTES de implementar** + pesquisar fato canon (ex: "Sicoob aceita ICP-Brasil A1 da empresa?"). Custou um refactor (US-FIN-046) e PR adicional pra corrigir. Padrão pra próximas integrações bancárias.


### PR DESCRIPTION
## Resumo

Wagner perguntou na revisão final 2026-05-27: \"vai revisar os outros e colocar na memória?\". Lacunas e lições novas que ainda não estavam no git canon:

## Lacuna 1 — SPEC.md sem US-FIN-044/045/046

MCP `tasks-create` grava US no DB MCP mas **não commita SPEC.md** — só avisa pra fazer manual. Esqueci as 3 US desta sessão. Append agora:

- **US-FIN-044** · SicoobApiDriver completo (status `in_progress`, blocked_by cliente buscando credenciais sandbox)
- **US-FIN-045** · Wizard bank-first 2-step (status `todo`, P1)
- **US-FIN-046** · mTLS reusa NfeCertificado (status `review`, P0, [PR #1737](https://github.com/wagnerra23/oimpresso.com/pull/1737))

## Lacuna 2 — lições NfeCertificado / Sicoob ICP-Brasil

Adendo em [memory/sessions/2026-05-27-us-fin-044-sicoob-api-completion.md](memory/sessions/2026-05-27-us-fin-044-sicoob-api-completion.md):

**Verdade canon agora documentada:**
- Sicoob API Cobrança v3 exige cert ICP-Brasil A1 do CNPJ da empresa — **mesmo cert que NfeBrasil/SEFAZ usa** (TecnoSpeed/Soften/ACBr)
- Padrão pra futuros API drivers PJ BR (Bradesco/Inter/BB/Itaú/Santander) — todos exigem ICP-Brasil A1: **reusar `NfeCertificado` canon**, NÃO criar storage próprio
- Débito **US-FIN-047** anotado: extrair `NfeCertificado` pra módulo neutro (`app/Models/CertificadoDigital` com campo `proposito`) quando 2º banco API entrar

**Lições novas (#7 + #8):**
- **#7:** GREP pattern canon ANTES de criar storage/encrypt/upload novo. Caso real custou refactor US-FIN-046.
- **#8:** Integrações que tocam infra compartilhada (storage/encrypt/cert) → EXPLICAR arquitetura + pesquisar fato canon ANTES de implementar.

## Diff

2 arquivos · +168 / -4 net (SPEC append + adendo session log).

Refs: US-FIN-046 [PR #1737](https://github.com/wagnerra23/oimpresso.com/pull/1737) · sessão 2026-05-27 Wagner consolidação canon