### PR TITLE
fix(cliente/cnpj-lookup): distinguir erro SEFAZ de cert faltando

### DIFF
--- a/Modules/Crm/Http/Controllers/ClienteLookupController.php
+++ b/Modules/Crm/Http/Controllers/ClienteLookupController.php
@@ -139,12 +139,28 @@ class ClienteLookupController extends Controller
             ], 403);
         }
 
-        $result = $this->sefazService->consultar($cnpj, $uf, $businessId);
+        $reason = null;
+        $result = $this->sefazService->consultar($cnpj, $uf, $businessId, $reason);
 
         if ($result === null) {
+            // Fix Wagner 2026-05-27 — distinguir motivo real do null pra UI mostrar
+            // mensagem certa. Antes: TODO null vinha como 'sefaz_or_cert_error' →
+            // frontend mostrava "Configure cert A1" mesmo com cert OK + erro SEFAZ.
+            // Agora SefazConsultaCadastroService popula $reason discriminado:
+            //   'no_cert'        → user precisa configurar cert (badge action /fiscal/config)
+            //   'sefaz_error'    → SEFAZ-UF retornou erro/timeout (retry, não é cert)
+            //   'uf_unsupported' → UF fora da whitelist (preencher IE manual)
+            //   'flag_off'       → feature flag desligada
+            //   'invalid_cnpj'   → CNPJ malformado (bug de envio do client)
+            $message = match ($reason) {
+                'no_cert' => 'IE indisponível — configure certificado A1 em /fiscal/config',
+                'sefaz_error' => "SEFAZ-{$uf} indisponível agora — preencha IE manualmente ou tente novamente em instantes",
+                default => 'IE indisponivel — preencha manualmente',
+            };
+
             return response()->json([
-                'message' => 'IE indisponivel — preencha manualmente',
-                'reason' => 'sefaz_or_cert_error',
+                'message' => $message,
+                'reason' => $reason ?? 'sefaz_or_cert_error',
                 'uf' => $uf,
             ], 404);
         }

--- a/Modules/NfeBrasil/Services/SefazConsultaCadastroService.php
+++ b/Modules/NfeBrasil/Services/SefazConsultaCadastroService.php
@@ -97,14 +97,23 @@ class SefazConsultaCadastroService
      * @param  string  $cnpj  CNPJ em qualquer formato (só dígitos usados)
      * @param  string  $uf    UF de 2 letras (RS, SP, etc)
      * @param  int     $businessId  Business consumidor (multi-tenant Tier 0)
-     * @return array|null  null = UF não suportada, sem cert, ou erro SEFAZ
+     * @param  string|null  &$reason  Out param populado quando retorno é null,
+     *                                 distinguindo motivo pra UI/controller:
+     *                                 'invalid_cnpj' | 'uf_unsupported' | 'flag_off'
+     *                                 | 'no_cert' | 'sefaz_error'.
+     *                                 Antes (Wagner 2026-05-27): qualquer falha caía
+     *                                 em 'sefaz_or_cert_error' genérico → UI mostrava
+     *                                 "Configure cert A1" mesmo com cert OK + erro SEFAZ.
+     * @return array|null  null = UF não suportada, sem cert, ou erro SEFAZ (ver $reason)
      */
-    public function consultar(string $cnpj, string $uf, int $businessId): ?array
+    public function consultar(string $cnpj, string $uf, int $businessId, ?string &$reason = null): ?array
     {
+        $reason = null;
         $cnpjDigits = preg_replace('/\D/', '', $cnpj) ?? '';
         $uf = strtoupper(trim($uf));
 
         if (strlen($cnpjDigits) !== 14) {
+            $reason = 'invalid_cnpj';
             return null;
         }
 
@@ -115,6 +124,7 @@ class SefazConsultaCadastroService
                 'uf' => $uf,
                 'business_id' => $businessId,
             ]);
+            $reason = 'uf_unsupported';
             return null;
         }
 
@@ -123,17 +133,25 @@ class SefazConsultaCadastroService
             Log::info('SefazConsultaCadastroService: feature flag desligada — skip', [
                 'business_id' => $businessId,
             ]);
+            $reason = 'flag_off';
             return null;
         }
 
         // Cache Redis 30d — dado público compartilhado entre businesses.
+        // IMPORTANTE: cacheamos APENAS resultados success. Falhas (no_cert/sefaz_error)
+        // NUNCA vão pra cache porque estado pode mudar rápido (user configura cert,
+        // SEFAZ volta após manutenção) — cachear erro = bloquear retry desnecessário.
         $cacheKey = "sefaz_cadastro:{$uf}:{$cnpjDigits}";
         $cacheTtl = (int) config('fiscal.sefaz_consulta_cadastro_cache_ttl_seconds', 60 * 60 * 24 * 30);
 
-        return Cache::remember(
-            $cacheKey,
-            $cacheTtl,
-            function () use ($cnpjDigits, $uf, $businessId): ?array {
+        // Hit cache → success cached, retorna direto sem reason.
+        $cached = Cache::get($cacheKey);
+        if (is_array($cached)) {
+            return $cached;
+        }
+
+        $innerReason = null;
+        $result = (function () use ($cnpjDigits, $uf, $businessId, &$innerReason): ?array {
                 try {
                     // Carrega cert via chain (ADR 0186) — pode lançar RuntimeException se sem cert nenhum.
                     $certData = $this->certService->carregarParaSefazComFallback(
@@ -296,6 +314,7 @@ class SefazConsultaCadastroService
                         'uf' => $uf,
                         'reason' => $certErr->getMessage(),
                     ]);
+                    $innerReason = 'no_cert';
                     return null;
                 } catch (\Throwable $e) {
                     Log::warning('SefazConsultaCadastroService: erro SEFAZ ou parsing', [
@@ -304,9 +323,19 @@ class SefazConsultaCadastroService
                         'cnpj_len' => strlen($cnpjDigits),
                         'message' => $e->getMessage(),
                     ]);
+                    $innerReason = 'sefaz_error';
                     return null;
                 }
-            }
-        );
+            })();
+
+        // Cache APENAS success — falhas (no_cert/sefaz_error) ficam fora pra
+        // permitir retry imediato após user configurar cert ou SEFAZ recuperar.
+        if (is_array($result)) {
+            Cache::put($cacheKey, $result, $cacheTtl);
+        } else {
+            $reason = $innerReason;
+        }
+
+        return $result;
     }
 }

--- a/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx
@@ -481,7 +481,7 @@ export default function IdentificacaoTab({
 
       // ── Campos derivados SEFAZ (#1431 Técnica C) — gatilhos NFe + UX warnings
       const certSrc = (sefazData?.cert_source as string) || '';
-      let sefazSource: 'none' | 'primary' | 'institutional' | 'unsupported' | 'no_cert' = 'none';
+      let sefazSource: 'none' | 'primary' | 'institutional' | 'unsupported' | 'no_cert' | 'sefaz_error' = 'none';
       const alertasSefaz = (sefazData?.alertas as Array<{ code: string; severity: string; msg: string }>) ?? [];
 
       if (sefazData) {
@@ -502,8 +502,14 @@ export default function IdentificacaoTab({
         }
       } else if (sefazReason === 'uf_unsupported') {
         sefazSource = 'unsupported';
-      } else if (sefazReason === 'no_cert' || sefazReason === 'sefaz_or_cert_error') {
+      } else if (sefazReason === 'no_cert') {
         sefazSource = 'no_cert';
+      } else if (sefazReason === 'sefaz_error' || sefazReason === 'sefaz_or_cert_error') {
+        // Fix Wagner 2026-05-27: distingue erro SEFAZ (timeout/SOAP/parsing) de
+        // cert faltando. Antes ambos caíam em 'no_cert' → badge "Configure cert A1"
+        // mesmo com cert OK (gerou frustração: "já configurei!").
+        // 'sefaz_or_cert_error' legacy mantido pra compat com backend pré-fix.
+        sefazSource = 'sefaz_error';
       }
 
       // Fix 2026-05-25 — sincronizar contact state no parent direto (sem depender
@@ -552,6 +558,8 @@ export default function IdentificacaoTab({
         mensagemBadge = `${fontesMsg} preenchidos. SEFAZ-${ufFinal} não disponível — preencha IE manual.`;
       } else if (sefazSource === 'no_cert') {
         mensagemBadge = `${fontesMsg} preenchidos. Configure cert A1 em /fiscal/config pra IE automática.`;
+      } else if (sefazSource === 'sefaz_error') {
+        mensagemBadge = `${fontesMsg} preenchidos. SEFAZ-${ufFinal} indisponível agora — tente de novo em alguns minutos pra IE automática.`;
       }
 
       // Append alerta SEFAZ severity high/medium (evitar rejeição NFe antes da emissão).

--- a/tests/Feature/Cliente/SefazConsultaCadastroChainTest.php
+++ b/tests/Feature/Cliente/SefazConsultaCadastroChainTest.php
@@ -159,6 +159,37 @@ test('SefazConsultaCadastroService retorna null pra CNPJ menor que 14 digitos', 
     expect($result)->toBeNull();
 });
 
+// Fix Wagner 2026-05-27 — out param $reason distingue causa do null
+// (antes: qualquer falha caía em 'sefaz_or_cert_error' → UI mostrava "Configure
+// cert A1" mesmo com cert OK e erro SEFAZ).
+test('SefazConsultaCadastroService popula $reason=invalid_cnpj quando CNPJ malformado', function () {
+    $svc = app(\Modules\NfeBrasil\Services\SefazConsultaCadastroService::class);
+    $reason = null;
+    $result = $svc->consultar('123', 'RS', $this->business->id, $reason);
+
+    expect($result)->toBeNull();
+    expect($reason)->toBe('invalid_cnpj');
+});
+
+test('SefazConsultaCadastroService popula $reason=uf_unsupported quando UF fora da whitelist', function () {
+    $svc = app(\Modules\NfeBrasil\Services\SefazConsultaCadastroService::class);
+    $reason = null;
+    $result = $svc->consultar('11222333000181', 'GO', $this->business->id, $reason);
+
+    expect($result)->toBeNull();
+    expect($reason)->toBe('uf_unsupported');
+});
+
+test('SefazConsultaCadastroService popula $reason=flag_off quando feature flag desligada', function () {
+    Config::set('fiscal.sefaz_consulta_cadastro_enabled', false);
+    $svc = app(\Modules\NfeBrasil\Services\SefazConsultaCadastroService::class);
+    $reason = null;
+    $result = $svc->consultar('11222333000181', 'RS', $this->business->id, $reason);
+
+    expect($result)->toBeNull();
+    expect($reason)->toBe('flag_off');
+});
+
 // ---------------------------------------------------------------------
 // Técnica C (ADR 0186 §Evolução) — derivação indIeDest + warnings + persist
 // ---------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Bug Wagner 2026-05-27:** consulta CNPJ no drawer cliente mostrava "Configure cert A1 em /fiscal/config" mesmo com cert configurado e funcionando.
- **Causa:** `SefazConsultaCadastroService::consultar()` retornava `null` igualmente pra cert vazio E pra erro SEFAZ (timeout/SOAP/parsing). Frontend mostrava mensagem de cert pra QUALQUER falha SEFAZ.
- **Fix:** out param `&$reason` discriminado (`no_cert` | `sefaz_error` | `uf_unsupported` | `flag_off` | `invalid_cnpj`). Cache de success preservado (30d). Falhas NUNCA cacheadas. Frontend mostra mensagem certa por categoria de erro.

## Test plan

- [x] PHP lint OK em `SefazConsultaCadastroService.php` e `ClienteLookupController.php`
- [x] Pest novo: `$reason=invalid_cnpj` / `uf_unsupported` / `flag_off` (3 tests)
- [x] Tests existentes preservam compat (param `&$reason` é opcional)
- [ ] Validar prod pós-deploy: clicar Buscar CNPJ em cliente, ver badge mostra mensagem correta
- [ ] Validar prod: forçar erro SEFAZ (CNPJ válido + UF momento indisponível) → mensagem "SEFAZ-{UF} indisponível" em vez de "Configure cert A1"

## Files changed

```
Modules/NfeBrasil/Services/SefazConsultaCadastroService.php   +45 (out param $reason discriminado + cache só success)
Modules/Crm/Http/Controllers/ClienteLookupController.php      +22 (lê $reason e devolve mensagem contextual)
resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx       +12 (branch sefaz_error separado de no_cert)
tests/Feature/Cliente/SefazConsultaCadastroChainTest.php      +31 (3 tests novos pros reasons)
```

## Pegadinhas resolvidas

- Cache 30d era aplicado a TODO retorno do `Cache::remember` — inclusive `null`. Trocado pra `Cache::get`/`Cache::put` manual cacheando só array success.
- Closure `(function () use (..., &$innerReason))()` IIFE preserva `$this` automaticamente (PHP 7.4+).
- Frontend mantém compat backward com `reason: 'sefaz_or_cert_error'` legacy enquanto deploy não chega em prod.

Refs: SPRINT-5 PASSO 1 (Larissa biz=4 piloto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
