### PR TITLE
feat(commands): business:set-pos-setting aceita 'all' (ativar MSP em todos)

### DIFF
--- a/app/Console/Commands/SetPosSettingCommand.php
+++ b/app/Console/Commands/SetPosSettingCommand.php
@@ -26,15 +26,15 @@ use Illuminate\Console\Command;
 class SetPosSettingCommand extends Command
 {
     protected $signature = 'business:set-pos-setting
-                            {business_id : ID do business (Tier 0 ADR 0093)}
+                            {business_id : ID do business OU "all" pra todos (Tier 0 ADR 0093)}
                             {key : Chave do pos_settings (ex: enable_msp)}
                             {value : Valor (1/0 boolean ou string)}';
 
-    protected $description = 'Atualiza chave em business.pos_settings JSON pra 1 business.';
+    protected $description = 'Atualiza chave em business.pos_settings JSON pra 1 business ou TODOS (all).';
 
     public function handle(): int
     {
-        $businessId = (int) $this->argument('business_id');
+        $businessIdArg = (string) $this->argument('business_id');
         $key = (string) $this->argument('key');
         $value = $this->argument('value');
 
@@ -43,12 +43,35 @@ class SetPosSettingCommand extends Command
             $value = (int) $value;
         }
 
+        // Wagner 2026-05-27: aceitar "all" pra iterar TODOS os businesses
+        // (ativar enable_msp pra biz=1, biz=4 e quaisquer futuros sem
+        // rodar comando N vezes).
+        if (strtolower($businessIdArg) === 'all') {
+            $businesses = Business::all();
+            if ($businesses->isEmpty()) {
+                $this->warn('Nenhum business encontrado.');
+                return self::SUCCESS;
+            }
+            foreach ($businesses as $b) {
+                $this->applyToBusiness($b, $key, $value);
+            }
+            $this->info("✓ Aplicado em {$businesses->count()} businesses.");
+            return self::SUCCESS;
+        }
+
+        $businessId = (int) $businessIdArg;
         $business = Business::find($businessId);
         if (!$business) {
             $this->error("business_id={$businessId} não encontrado");
             return self::FAILURE;
         }
 
+        $this->applyToBusiness($business, $key, $value);
+        return self::SUCCESS;
+    }
+
+    protected function applyToBusiness(Business $business, string $key, $value): void
+    {
         $settings = $business->pos_settings ? json_decode($business->pos_settings, true) : [];
         if (!is_array($settings)) {
             $settings = [];
@@ -59,9 +82,6 @@ class SetPosSettingCommand extends Command
         $business->pos_settings = json_encode($settings);
         $business->save();
 
-        $this->info("✓ business_id={$businessId} pos_settings['{$key}']: " . json_encode($before) . ' → ' . json_encode($value));
-        $this->line('Settings completos: ' . json_encode($settings));
-
-        return self::SUCCESS;
+        $this->info("✓ business_id={$business->id} ({$business->name}) pos_settings['{$key}']: " . json_encode($before) . ' → ' . json_encode($value));
     }
 }


### PR DESCRIPTION
## Por que

Wagner pediu \"não precisa disso ative para todos pronto\" — quer \`enable_msp\` ativado pra TODOS os businesses, não só biz=4.

Estender comando do PR #1748 pra aceitar \`all\` como business_id:

\`\`\`bash
php artisan business:set-pos-setting all enable_msp 1
\`\`\`

## Multi-tenant Tier 0 preservado

ADR 0093: business_id ainda é arg obrigatório. \`all\` é opt-in explícito, não default. Logging mostra business_id + name em cada linha pra audit.

## Próximo passo (após merge)

Dispatch deploy.yml:
\`\`\`
extra_artisan=\"business:set-pos-setting all enable_msp 1\"
\`\`\`

## Refs
- PR #1748 (versão inicial single-business)
- Cadeia hotfixes Larissa #1716/.../#1746

🤖 Generated with [Claude Code](https://claude.com/claude-code)