### PR TITLE
fix(skill/pre-adr-introspect): aspas em related_adrs + paths 3 níveis up

### DIFF
--- a/.claude/skills/commit-discipline/SKILL.md
+++ b/.claude/skills/commit-discipline/SKILL.md
@@ -115,6 +115,16 @@ gh pr create ...
 - **Migration grande** (criação tabela com índices) — single intent, OK ser >300
 - **Refactor PR-9 oficialmente declarado** (ex: rename copiloto_* → jana_*) — ADR justificando
 
+## Pré-req adicional pra PR que cria ADR canon (`memory/decisions/NNNN-*.md`)
+
+Quando o PR adiciona arquivo novo em `memory/decisions/NNNN-*.md`, antes do commit:
+
+1. Skill [pre-adr-introspect](../pre-adr-introspect/SKILL.md) deve ter rodado (verifica `git grep` de patterns canon + diagnóstico prod se ADR depende de estado DB)
+2. Commit body OU §Contexto da ADR cita pelo menos 1 pattern canon investigado (mesmo que conclua "não existe — criar novo")
+3. Se ADR `amends` ou `supersedes` outras → `related_adrs` no frontmatter lista TODAS as relacionadas
+
+**Origem:** sessão 2026-05-27 — 3 ADRs erratas mesmo dia (#1731, #1735, #1744) por não introspectar antes. Documentado em ADR 0200 §Lição arquitetural.
+
 ## Métricas (skill telemetria)
 
 - `mcp_skill_telemetry`: total commits onde commit-discipline disparou
@@ -125,4 +135,6 @@ gh pr create ...
 
 - [ADR 0094](../../../memory/decisions/0094-constituicao-v2-7-camadas-8-principios.md) — Constituição v2 (princípio #5 SoC)
 - [ADR 0095](../../../memory/decisions/0095-skills-tiers-convencao-interna.md) — Skills Tiers
+- [ADR 0200](../../../memory/decisions/0200-contacts-sync-canon-amends-0197-0199.md) — §Lição arquitetural (origem do pré-req pre-adr-introspect)
+- [pre-adr-introspect skill](../pre-adr-introspect/SKILL.md) — Tier B pareada
 - [Anthropic 2026 Agentic Coding Trends](https://resources.anthropic.com/hubfs/2026%20Agentic%20Coding%20Trends%20Report.pdf) — diff size best-practice

--- a/.claude/skills/pre-adr-introspect/SKILL.md
+++ b/.claude/skills/pre-adr-introspect/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: pre-adr-introspect
+description: ATIVAR ANTES de qualquer Write em `memory/decisions/NNNN-*.md` (ADR nova) OU antes de propor schema novo (`database/migrations/*.php` que adiciona col em tabela existente) OU antes de propor pattern arquitetural (endpoint, middleware, service genérico). Força introspecção do projeto pra detectar patterns canon já estabelecidos (git grep ADRs/migrations/Controllers + diagnóstico prod se ADR depende de estado DB). Previne 80% dos erros de retrabalho mesmo-dia documentados em sessão 2026-05-27 (3 ADRs erratas + 1 RUNBOOK histórico + 2 CI fails Append-only canon). Lição arquitetural ADR 0200 §Lição operacionalizada.
+tier: B
+trigger: description-matching
+parent_adr: 0095
+related_adrs: [0028, 0093, 0094, 0095, 0105, 0120, 0200]
+---
+
+# pre-adr-introspect — Tier B auto-trigger
+
+> **Quando ativar:** ANTES de qualquer Write em `memory/decisions/NNNN-*.md` (ADR nova) OU antes de propor schema novo em tabela já-existente OU antes de propor pattern arquitetural (Controller API, middleware, Service genérico) que pode duplicar infra canon.
+
+## Origem (custo capturado — sessão 2026-05-27)
+
+Em **2026-05-27** entre 13:23 e 14:59 BRT, 7 PRs criados/mergeados pela mesma sessão. **3 foram retrabalho de erros próprios**:
+
+| Erro | Custo real | Causa raiz |
+|---|---|---|
+| Inventei `legacy_source` ENUM + tabela satélite `contact_profile_legacy` em ADR 0197 sem `git grep` dos patterns canon Wagner 2024-11 (11 tabelas já usavam `officeimpresso_codigo` + `officeimpresso_dt_alteracao`) | 2 ADRs erratas mesmo dia ([#1731](https://github.com/wagnerra23/oimpresso.com/pull/1731) + [#1735](https://github.com/wagnerra23/oimpresso.com/pull/1735)) | Não introspectei `git grep officeimpresso_dt_alteracao database/migrations/` antes |
+| Escrevi RUNBOOK Martinho Fase 3+4 ([#1717](https://github.com/wagnerra23/oimpresso.com/pull/1717)) assumindo fases pendentes — realidade: já estavam em prod com 43.974 vendas + 83.045 títulos há semanas | RUNBOOK virou `historical` no mesmo dia ([#1727](https://github.com/wagnerra23/oimpresso.com/pull/1727) retrospectiva §7) | Não rodei diagnóstico Hostinger ANTES de escrever plano |
+| Tentei resolver colisão `number: 195` ([#1714](https://github.com/wagnerra23/oimpresso.com/pull/1714) vs [#1736](https://github.com/wagnerra23/oimpresso.com/pull/1736)) via rename/append em ADR — bloqueado por gate Append-only canon. Existiam 3 precedentes (0101/0102/0119) tratados via `_INDEX-LIFECYCLE.md` | 2 CI fails + 1 PR extra ([#1741](https://github.com/wagnerra23/oimpresso.com/pull/1741) fail · [#1744](https://github.com/wagnerra23/oimpresso.com/pull/1744)) | Não busquei precedente de colisão numérica em `memory/decisions/_INDEX-LIFECYCLE.md` |
+
+**Padrão único:** propus solução nova ANTES de verificar o que o projeto já tinha resolvido. **Mesma lição** documentada em [ADR 0200 §Lição arquitetural](../../memory/decisions/0200-contacts-sync-canon-amends-0197-0199.md) — e cometi 2 vezes depois disso.
+
+Esta skill operacionaliza o "antes de criar pattern novo, faça `git grep`".
+
+## Checklist obrigatório (rodar ANTES de Write em `memory/decisions/`)
+
+### 1. Pattern canon similar já existe?
+
+```bash
+# Busca ADRs canon que abordam tema próximo
+git grep -rn "<palavra-chave-do-tema>" memory/decisions/ memory/reference/ 2>&1 | head -20
+
+# Ex (caso ADR 0197 falhou):
+git grep -rn "sync.*delphi\|officeimpresso_dt_alteracao\|BaseApiController" memory/decisions/
+# → teria revelado canon Wagner 2024-11 antes de inventar legacy_source
+```
+
+### 2. Schema/endpoint canon já estabelecido?
+
+```bash
+# Busca migrations recentes que adicionaram cols com tema similar
+git grep -rn "<field-novo>" database/migrations/ Modules/*/Database/Migrations/ 2>&1 | head -20
+
+# Busca endpoints canon que servem propósito similar
+git grep -rn "<endpoint-novo>\|<method-novo>" Modules/*/Http/Controllers/Api/ app/Http/Controllers/Api/ 2>&1 | head -10
+
+# Ex (caso ADR 0197 falhou):
+git grep -rn "officeimpresso_codigo\|officeimpresso_dt_alteracao" database/migrations/
+# → teria mostrado 11 migrations 2024-11→2025-01 com mesmo pattern
+```
+
+### 3. Precedente de colisão / conflict resolution?
+
+```bash
+# Verifica colisões registradas + convenções de resolução
+grep -n "numbering_collisions\|colis" memory/decisions/_INDEX-LIFECYCLE.md
+ls memory/decisions/NNNN-*.md  # número candidato livre? colisão same-day?
+
+# Ex (caso PR #1741 falhou):
+# → teria mostrado 3 precedentes 0101a/b, 0102a/b, 0119a/b
+#   resolvidos via Bloco apended no INDEX, NÃO via rename
+```
+
+### 4. Diagnóstico prod ANTES (se ADR depende de estado DB)
+
+```bash
+# Se ADR define plano executável (RUNBOOK / Fase X de migração / cleanup retroativo):
+ssh -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@oimpresso.com \
+  'cd /home/u906587222/domains/oimpresso.com/public_html && php artisan tinker --execute="
+    echo DB::table(\"<tabela-relevante>\")->where(\"business_id\", <biz>)->count();
+  "'
+
+# Ex (caso RUNBOOK Martinho falhou):
+# php artisan tinker → DB::table('transactions')->where('business_id', 164)->count()
+# → teria mostrado 43.974 vendas (não 0) antes de escrever "Fase 3 pendente"
+```
+
+### 5. Documentos de contrato / pattern canônico do tema?
+
+```bash
+# Lista docs de referência canônicos
+ls memory/reference/contrato-*.md memory/reference/migracao-*.md memory/reference/<tema>-*.md 2>&1
+ls memory/requisitos/_DesignSystem/ 2>&1 | grep -i "<tema>"
+
+# Ex: existe migracao-officeimpresso-pattern.md? contrato-delphi-inviolavel.md?
+# Leitura prévia evita reinventar wire/pattern já contratado
+```
+
+## Output esperado
+
+Após rodar os 5 itens, gerar bullet list curta:
+
+```
+## pre-adr-introspect — relatório (gerar antes do Write)
+
+- Tema: <descrição curta da ADR proposta>
+- Número candidato: NNNN (verificado livre: ✅ / colisão same-day: ⚠️)
+- Patterns canon similares encontrados:
+  - [ADR 0NNN — slug](path) — relação: <reuso / pareado / supersede?>
+  - <schema/endpoint canon> em <path>
+- Diagnóstico prod (se aplicável):
+  - Tabela X biz=Y tem N rows · esperado pelo plano: M (drift: ±%)
+- Decisão pós-introspecção:
+  - [ ] REUSAR pattern canon X (preferido)
+  - [ ] EXTEND pattern canon X com Y campos novos
+  - [ ] CRIAR pattern novo (justificar: por que NÃO reusar?)
+```
+
+Esse relatório vai no corpo da ADR (seção "Contexto" ou "Análise prévia") ou pelo menos no commit body.
+
+## Quando NÃO ativar
+
+- ADR de **errata pequena** (typo, ref quebrada) que reusa pattern existente — overhead desnecessário
+- ADR de **documentação de incidente** post-mortem retroativo (não propõe schema novo)
+- ADR de **deprecação** de módulo (não cria nada — só remove)
+- Edit em **session log** ou **handoff** (não é ADR canon)
+
+## Integração com outras skills
+
+| Skill | Relação |
+|---|---|
+| [memory-schema-preflight](../memory-schema-preflight/SKILL.md) | Roda DEPOIS da introspecção — valida frontmatter da ADR já com decisões alinhadas |
+| [como-integrar](../como-integrar/SKILL.md) | Pareado — `como-integrar` introspecta antes de feature; `pre-adr-introspect` antes de ADR |
+| [commit-discipline](../commit-discipline/SKILL.md) | Pré-req antes de commit de PR que cria ADR canon |
+| [mcp-first](../mcp-first/SKILL.md) | Tools MCP `decisions-search` cobrem parte do item 1 (canon search) |
+
+## Workflow recomendado
+
+```
+1. User pede ADR nova                      → ATIVE esta skill
+2. Rode os 5 itens do checklist            → gere relatório
+3. APRESENTE relatório pro Wagner          → "achei pattern X canon · proponho REUSAR / EXTEND / CRIAR"
+4. Wagner aprova direção                   → SÓ ENTÃO Write memory/decisions/NNNN-*.md
+5. memory-schema-preflight valida          → commit
+6. commit-discipline valida (1 PR = 1 intent · ≤300 linhas)  → push
+```
+
+## Métricas de sucesso
+
+Esta skill é eficaz se nas próximas sessões multi-PR:
+
+- Zero ADRs erratas same-day (vs 3 hoje 2026-05-27)
+- Zero RUNBOOK virando `historical` no mesmo dia que foi escrito
+- Zero CI fail por "Append-only canon" tentando mexer em ADR canon
+- ≥80% das ADRs novas referenciam pattern canon existente no §Contexto
+
+Revisar em 30 dias (2026-06-27) — se métricas batem, virar Tier A always-on.
+
+## Refs
+
+- [ADR 0200 — Contacts adopta canon sync Wagner](../../memory/decisions/0200-contacts-sync-canon-amends-0197-0199.md) (§Lição arquitetural que esta skill operacionaliza)
+- [ADR 0095 — Skills tiers convenção interna](../../memory/decisions/0095-skills-tiers-convencao-interna.md)
+- [_INDEX-LIFECYCLE.md](../../memory/decisions/_INDEX-LIFECYCLE.md) (única forma de "mover" ADR sem violar append-only)
+- [memory-schema-preflight skill](../memory-schema-preflight/SKILL.md) (pareada)
+- [como-integrar skill](../como-integrar/SKILL.md) (pareada — features vs ADRs)
+- [contrato-delphi-inviolavel.md](../../memory/reference/contrato-delphi-inviolavel.md) (exemplo de doc canônico que ADR deve respeitar)
+- [migracao-officeimpresso-pattern.md](../../memory/reference/migracao-officeimpresso-pattern.md) (exemplo de pattern canônico que ADR deve reusar)

--- a/.claude/skills/pre-adr-introspect/SKILL.md
+++ b/.claude/skills/pre-adr-introspect/SKILL.md
@@ -4,7 +4,7 @@ description: ATIVAR ANTES de qualquer Write em `memory/decisions/NNNN-*.md` (ADR
 tier: B
 trigger: description-matching
 parent_adr: 0095
-related_adrs: [0028, 0093, 0094, 0095, 0105, 0120, 0200]
+related_adrs: ["0028", "0093", "0094", "0095", "0105", "0120", "0200"]
 ---
 
 # pre-adr-introspect — Tier B auto-trigger
@@ -21,7 +21,7 @@ Em **2026-05-27** entre 13:23 e 14:59 BRT, 7 PRs criados/mergeados pela mesma se
 | Escrevi RUNBOOK Martinho Fase 3+4 ([#1717](https://github.com/wagnerra23/oimpresso.com/pull/1717)) assumindo fases pendentes — realidade: já estavam em prod com 43.974 vendas + 83.045 títulos há semanas | RUNBOOK virou `historical` no mesmo dia ([#1727](https://github.com/wagnerra23/oimpresso.com/pull/1727) retrospectiva §7) | Não rodei diagnóstico Hostinger ANTES de escrever plano |
 | Tentei resolver colisão `number: 195` ([#1714](https://github.com/wagnerra23/oimpresso.com/pull/1714) vs [#1736](https://github.com/wagnerra23/oimpresso.com/pull/1736)) via rename/append em ADR — bloqueado por gate Append-only canon. Existiam 3 precedentes (0101/0102/0119) tratados via `_INDEX-LIFECYCLE.md` | 2 CI fails + 1 PR extra ([#1741](https://github.com/wagnerra23/oimpresso.com/pull/1741) fail · [#1744](https://github.com/wagnerra23/oimpresso.com/pull/1744)) | Não busquei precedente de colisão numérica em `memory/decisions/_INDEX-LIFECYCLE.md` |
 
-**Padrão único:** propus solução nova ANTES de verificar o que o projeto já tinha resolvido. **Mesma lição** documentada em [ADR 0200 §Lição arquitetural](../../memory/decisions/0200-contacts-sync-canon-amends-0197-0199.md) — e cometi 2 vezes depois disso.
+**Padrão único:** propus solução nova ANTES de verificar o que o projeto já tinha resolvido. **Mesma lição** documentada em [ADR 0200 §Lição arquitetural](../../../memory/decisions/0200-contacts-sync-canon-amends-0197-0199.md) — e cometi 2 vezes depois disso.
 
 Esta skill operacionaliza o "antes de criar pattern novo, faça `git grep`".
 
@@ -123,7 +123,7 @@ Esse relatório vai no corpo da ADR (seção "Contexto" ou "Análise prévia") o
 | Skill | Relação |
 |---|---|
 | [memory-schema-preflight](../memory-schema-preflight/SKILL.md) | Roda DEPOIS da introspecção — valida frontmatter da ADR já com decisões alinhadas |
-| [como-integrar](../como-integrar/SKILL.md) | Pareado — `como-integrar` introspecta antes de feature; `pre-adr-introspect` antes de ADR |
+| `como-integrar` (agente, não skill — `Agent(subagent_type: "como-integrar")`) | Pareado — `como-integrar` introspecta antes de feature; `pre-adr-introspect` antes de ADR |
 | [commit-discipline](../commit-discipline/SKILL.md) | Pré-req antes de commit de PR que cria ADR canon |
 | [mcp-first](../mcp-first/SKILL.md) | Tools MCP `decisions-search` cobrem parte do item 1 (canon search) |
 
@@ -151,10 +151,10 @@ Revisar em 30 dias (2026-06-27) — se métricas batem, virar Tier A always-on.
 
 ## Refs
 
-- [ADR 0200 — Contacts adopta canon sync Wagner](../../memory/decisions/0200-contacts-sync-canon-amends-0197-0199.md) (§Lição arquitetural que esta skill operacionaliza)
-- [ADR 0095 — Skills tiers convenção interna](../../memory/decisions/0095-skills-tiers-convencao-interna.md)
-- [_INDEX-LIFECYCLE.md](../../memory/decisions/_INDEX-LIFECYCLE.md) (única forma de "mover" ADR sem violar append-only)
+- [ADR 0200 — Contacts adopta canon sync Wagner](../../../memory/decisions/0200-contacts-sync-canon-amends-0197-0199.md) (§Lição arquitetural que esta skill operacionaliza)
+- [ADR 0095 — Skills tiers convenção interna](../../../memory/decisions/0095-skills-tiers-convencao-interna.md)
+- [_INDEX-LIFECYCLE.md](../../../memory/decisions/_INDEX-LIFECYCLE.md) (única forma de "mover" ADR sem violar append-only)
 - [memory-schema-preflight skill](../memory-schema-preflight/SKILL.md) (pareada)
-- [como-integrar skill](../como-integrar/SKILL.md) (pareada — features vs ADRs)
-- [contrato-delphi-inviolavel.md](../../memory/reference/contrato-delphi-inviolavel.md) (exemplo de doc canônico que ADR deve respeitar)
-- [migracao-officeimpresso-pattern.md](../../memory/reference/migracao-officeimpresso-pattern.md) (exemplo de pattern canônico que ADR deve reusar)
+- `como-integrar` agente (`Agent(subagent_type: "como-integrar")`) — pareado (features vs ADRs)
+- [contrato-delphi-inviolavel.md](../../../memory/reference/contrato-delphi-inviolavel.md) (exemplo de doc canônico que ADR deve respeitar)
+- [migracao-officeimpresso-pattern.md](../../../memory/reference/migracao-officeimpresso-pattern.md) (exemplo de pattern canônico que ADR deve reusar)


### PR DESCRIPTION
## Summary

Wagner perguntou pós-merge [#1747](https://github.com/wagnerra23/oimpresso.com/pull/1747): *"fez testes pra garantir que não vai regredir?"*. Rodei 4 validações e achei 2 bugs reais + 1 ref errada. Esta PR corrige.

## Testes que rodei (após #1747 mergear)

| Test | Resultado | Detalhe |
|---|---|---|
| 1. YAML frontmatter parse | ❌ **FAIL** | `related_adrs: [0105, 0120, 0200]` parseado como `[69, 80, 128]` (interpretação octal sem quotes) |
| 2. Links internos resolvem | ❌ **FAIL** | 8 links com `../../memory/` precisam `../../../memory/` (3 níveis up) |
| 3. Trigger collision | ✅ PASS | Overlap com `memory-schema-preflight` é intencional (complementares ordenadas) |
| 4. Simulação retroativa caso ADR 0197 | ✅ PASS | Skill retornaria 11+ migrations canon `officeimpresso_codigo` ANTES de propor `legacy_source` |

## 3 fixes nesta PR

### Bug 1 — YAML octal interpretation

```diff
- related_adrs: [0028, 0093, 0094, 0095, 0105, 0120, 0200]
+ related_adrs: ["0028", "0093", "0094", "0095", "0105", "0120", "0200"]
```

YAML sem aspas interpreta `0105` como **octal** (= decimal 69). Aspas força string preservando zeros à esquerda.

### Bug 2 — Path relativo errado

Skill está em `.claude/skills/pre-adr-introspect/SKILL.md`. Pra chegar em `memory/` precisa de 3 níveis up:

```
.claude/skills/pre-adr-introspect/  →  .claude/skills/  →  .claude/  →  root  →  memory/
                                    ../              ../          ../       
```

Sed corrigiu 8 ocorrências de `../../memory/` → `../../../memory/`. Pattern confirmado em sibling skills (`memory-schema-preflight`, `commit-discipline`).

### Bug 3 — `como-integrar` é AGENTE, não skill

Refs erradas a `[como-integrar skill](../como-integrar/SKILL.md)`. Trocado por nota textual:

```
`como-integrar` agente (`Agent(subagent_type: "como-integrar")`) — pareado
```

## Validação pós-fix

```
YAML OK: related_adrs[0] type = str           ✅
Links: 10 checked · 0 broken                  ✅
```

## Test plan

- [ ] CI memory-schema-gate verde
- [ ] Próxima ADR nova testa skill em campo (revisão 30d em 2026-06-27)

## Refs

PR [#1747](https://github.com/wagnerra23/oimpresso.com/pull/1747) (skill original criada hoje) · `memory-schema-preflight` (pattern de links confirmado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)