### PR TITLE
feat(sells/v2): Bug E — recalcular preço ao trocar grupo (ATACADO)

### DIFF
--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -292,6 +292,90 @@ export default function SellsCreate(props: SellsCreatePageProps) {
     ]);
   };
 
+  // Bug R3 (E) — recalcular preço retroativo ao trocar Grupo de preço.
+  //
+  // Cenário Larissa: adiciona "Blusa P" (R$ 150 padrão), depois muda Grupo → ATACADO.
+  // Antes do fix: linha continuava R$ 150 (preço congelado no add).
+  // Depois do fix: refetch /products/list?term=<name>&location_id=X&price_group=Y
+  //                pra cada linha, atualiza unit_price com variation_group_price
+  //                (legacy pattern public/js/pos.js linhas 265-266).
+  //
+  // Failsafe: se refetch falha ou variation_id não aparece no resultado, MANTÉM
+  // preço atual (sem warning visual — só console.warn). Não quebra fluxo.
+  //
+  // 1 request HTTP por linha — OK pra primeiro fix (Larissa raramente tem >5 itens).
+  // Batch/debounce fica pra otimização futura se necessário.
+  //
+  // R3 escopo SÓ no handler de price_group_id. Não toca __number_uf, handleAddProduct,
+  // ou submit (PR R4 outro agent vai trabalhar handler add).
+  const handlePriceGroupChange = async (newGroupId: number | null) => {
+    setData('price_group_id', newGroupId);
+
+    // Sem linhas adicionadas → nada a refetchar
+    if (data.products.length === 0) return;
+
+    // Sem location → endpoint /products/list não filtra direito (skip refetch)
+    if (!data.location_id) {
+      console.warn('[Sells/Create] price group changed sem location_id, skip recalc');
+      return;
+    }
+
+    // Refetch concorrente pra cada linha. Promise.all com Settled pra não quebrar
+    // tudo se 1 falhar.
+    const requests = data.products.map(async (line) => {
+      if (!line.variation_id) return null; // linha sem variation → skip
+      const params = new URLSearchParams({ term: line.name });
+      params.set('location_id', String(data.location_id));
+      if (newGroupId) params.set('price_group', String(newGroupId));
+
+      try {
+        const res = await fetch(`/products/list?${params.toString()}`, {
+          headers: {
+            Accept: 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+          },
+          credentials: 'same-origin',
+        });
+        if (!res.ok) return null;
+        const arr = (await res.json()) as Array<{
+          variation_id: number;
+          selling_price?: number;
+          variation_group_price?: number;
+        }>;
+        const match = Array.isArray(arr)
+          ? arr.find((r) => r.variation_id === line.variation_id)
+          : undefined;
+        if (!match) return null;
+        // Pattern legacy public/js/pos.js: variation_group_price tem prioridade
+        const newPrice =
+          match.variation_group_price !== undefined &&
+          match.variation_group_price !== null
+            ? Number(match.variation_group_price)
+            : Number(match.selling_price ?? line.unit_price);
+        return { variation_id: line.variation_id, unit_price: newPrice };
+      } catch (err) {
+        console.warn(
+          '[Sells/Create] refetch preço falhou pra linha',
+          line.variation_id,
+          err,
+        );
+        return null;
+      }
+    });
+
+    const results = await Promise.all(requests);
+
+    // Aplica atualizações em batch (1 setData só, evita N re-renders)
+    const updated = data.products.map((line) => {
+      const found = results.find(
+        (r) => r && r.variation_id === line.variation_id,
+      );
+      if (!found) return line; // failsafe: mantém preço atual
+      return { ...line, unit_price: found.unit_price };
+    });
+    setData('products', updated);
+  };
+
   const handleProductChange = (
     idx: number,
     field: 'quantity' | 'unit_price' | 'discount',
@@ -1298,7 +1382,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
                 <Label htmlFor="price_group_id">Grupo de preço</Label>
                 <Select
                   value={data.price_group_id ? String(data.price_group_id) : ''}
-                  onValueChange={(v) => setData('price_group_id', v ? Number(v) : null)}
+                  onValueChange={(v) => handlePriceGroupChange(v ? Number(v) : null)}
                 >
                   <SelectTrigger id="price_group_id">
                     <SelectValue placeholder="Padrão" />


### PR DESCRIPTION
## Bug catalogado (E)

**Cenário Larissa @ Rota Livre:**
1. Cria venda em /sells/create (V2 React)
2. Busca "Blusa P" e adiciona — linha vem R$ 150 (preço grupo padrão)
3. Abre "Mais opções" → troca **Grupo de preço** pra ATACADO
4. **Bug:** linha CONTINUA R$ 150 (deveria ir pra preço atacado, ex: R$ 120)

Preço congelava no momento do add — não refetchava quando grupo mudava.

## Fix

Frontend agora chama `/products/list?term=<name>&location_id=X&price_group=Y` pra cada linha quando user troca Grupo de preço, e atualiza `unit_price` com `variation_group_price` (prioridade legacy) ou `selling_price` (fallback).

Backend **já aceitava** o param `price_group` ([ProductController@getProducts linhas 1515-1518](https://github.com/wagnerra23/oimpresso.com/blob/main/app/Http/Controllers/ProductController.php#L1515-L1518) + [ProductUtil@filterProduct linhas 1626-1633/1728-1730](https://github.com/wagnerra23/oimpresso.com/blob/main/app/Utils/ProductUtil.php#L1626-L1733)). Só faltava o frontend chamar. **Zero alteração backend.**

Pattern legacy [`public/js/pos.js` linhas 265-266](https://github.com/wagnerra23/oimpresso.com/blob/main/public/js/pos.js#L265-L266) já fazia isso no POS antigo (jQuery). Migrado pra React.

## Comportamento

| Estado | Antes | Depois |
|---|---|---|
| Adiciona Blusa R$150 + muda grupo p/ ATACADO | R$ 150 (errado) | R$ 120 (correto) |
| Sem location_id setado | — | skip recalc + `console.warn` |
| Refetch falha (HTTP error) | — | mantém preço atual + `console.warn` |
| variation_id não bate no array | — | mantém preço atual |
| Linha sem variation_id | — | skip (não envia request) |
| Múltiplas linhas | — | Promise.all concorrente |

## Trade-offs / escopo

- **1 request HTTP por linha** — OK pra primeiro fix (Larissa raramente tem >5 itens). Batch/debounce fica pra otimização futura se telemetria mostrar latência ruim.
- **Failsafe sem alert visual** — `console.warn` só. Não queremos toast nessa interação (usuária está mudando grupo, não precisa ser interrompida).
- **Escopo estritamente o handler do select Grupo de preço.** `handleAddProduct` intocado (PR R4 vai mexer separadamente). `__number_uf`, submit, transform, totais — intocados.

## Test plan

- [ ] Adicionar Blusa P (R$ 150 padrão) → mudar grupo pra ATACADO → preço da linha vai pra R$ 120 (ou valor configurado em variation_group_prices)
- [ ] Adicionar 3 produtos diferentes → mudar grupo → todas as 3 linhas atualizam
- [ ] Adicionar produto → mudar grupo pra um sem `variation_group_prices` configurado → preço cai pra `selling_price` (sell_price_inc_tax padrão)
- [ ] Mudar grupo SEM produtos adicionados → nada acontece (early return)
- [ ] Mudar grupo SEM location_id setado → console.warn, sem crash
- [ ] DevTools Network: 1 request por linha, parâmetros corretos (`term`, `location_id`, `price_group`)
- [ ] Recalcular não dispara salvamento — só atualiza state local
- [ ] Multi-tenant: business_id é resolvido via session no backend, então OK

## Refs

- Bug E (audit Sells/Create V2)
- [ADR 0093](https://github.com/wagnerra23/oimpresso.com/blob/main/memory/decisions/0093-multi-tenant-isolation-tier-0.md) (multi-tenant — endpoint respeita business_id via session, sem leak entre tenants)
- Pattern legacy [`public/js/pos.js` linhas 265-266](https://github.com/wagnerra23/oimpresso.com/blob/main/public/js/pos.js#L265-L266) (variation_group_price prioridade)
- US-SELL-005 (bloco produtos onde linha vive)

**NÃO MERGE** — Wagner aprovará manualmente após teste prod com Larissa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)