### PR TITLE
feat(sells/v2): Dor 1 — incrementar qty em vez de duplicar linha (Larissa)

### DIFF
--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -48,6 +48,7 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from '@/Components/ui/alert-dialog';
+import { toast } from 'sonner';
 
 interface OptionMap {
   [id: number]: string;
@@ -277,12 +278,55 @@ export default function SellsCreate(props: SellsCreatePageProps) {
     }
   };
 
+  // Dor 1 Larissa (2026-05-13 rollback V2): adicionar 2x o mesmo produto (mesmo
+  // product_id + variation_id) criava 2 linhas distintas. Comportamento esperado
+  // pelo Blade legacy POS era incrementar qty da linha existente.
+  //
+  // MVP atual (PR r4-group-variations-v2):
+  //   - Mesmo product_id + mesma variation_id  → incrementa qty (+1) na linha existente
+  //   - Mesmo product_id + variation_id diferente → toast info + adiciona como linha nova
+  //     (refactor com popover de variações fica pra PR separado se Wagner pedir)
+  //   - product_id novo → push linha nova (comportamento original)
   const handleAddProduct = (p: ProductSearchResult) => {
+    const incomingVariationId = p.variation_id ?? null;
+    const existing = data.products.find(
+      (row) => row.product_id === p.product_id,
+    );
+
+    // Caso 1a — mesmo product_id E mesma variation_id: incrementa qty da linha
+    // existente. Fix Dor 1 Larissa (rollback V2 2026-05-13): MARTELO-P + MARTELO-P
+    // criava 2 linhas distintas — agora vira 1 linha com qty 2.
+    if (existing && existing.variation_id === incomingVariationId) {
+      const newQty = Number(existing.quantity) + 1;
+      setData(
+        'products',
+        data.products.map((row) =>
+          row.product_id === p.product_id && row.variation_id === incomingVariationId
+            ? { ...row, quantity: newQty }
+            : row,
+        ),
+      );
+      toast.success(`${p.name} — quantidade ${newQty}`, { duration: 1500 });
+      return;
+    }
+
+    // Caso 1b — mesmo product_id mas variation_id diferente (ex: MARTELO-P já está,
+    // user agora adicionou MARTELO-M). Variações podem ter preço/estoque distinto,
+    // então agrupar como sub-row demanda refactor de UI maior (popover de variações).
+    // Por enquanto: adiciona linha separada + toast info pra deixar comportamento
+    // explícito (evita confusão tipo Dor 1 onde user acha que tá duplicando).
+    if (existing && existing.variation_id !== incomingVariationId) {
+      toast.info(`Variação diferente de ${p.name} — adicionada como linha separada`, {
+        duration: 2500,
+      });
+    }
+
+    // Caso 2 (product_id novo) ou 1b (variação diferente): adiciona linha nova.
     setData('products', [
       ...data.products,
       {
         product_id: p.product_id,
-        variation_id: p.variation_id ?? null,
+        variation_id: incomingVariationId,
         name: p.name,
         sku: p.sku,
         quantity: 1,


### PR DESCRIPTION
## Summary

Fix da **Dor #1** catalogada na auditoria do rollback V2 (2026-05-13) — gatilho original que fez a Larissa rejeitar a V2 Inertia.

**Antes:** adicionar MARTELO-P + MARTELO-P (mesmo `product_id`+`variation_id`) criava 2 linhas distintas no carrinho.
**Depois:** vira 1 linha com `quantity = 2` + toast curto confirmando.

## Mudanças

Apenas `handleAddProduct` em `resources/js/Pages/Sells/Create.tsx` (+45 linhas, -1 linha):

| Caso | Comportamento |
|---|---|
| `product_id` + `variation_id` iguais aos de uma linha existente | **Incrementa `quantity` +1** + `toast.success` |
| `product_id` igual mas `variation_id` diferente (ex: MARTELO-P depois MARTELO-M) | Adiciona como **linha separada** + `toast.info` explicando |
| `product_id` novo | Push linha nova (comportamento original, sem regressão) |

## Decisão simples vs. refactor

Escolhi **MVP simples** (incrementar qty) em vez do refactor maior (popover de variações por linha agrupada por `product_id`):

- ✅ Resolve o caso **mais comum** (Larissa adiciona o mesmo produto/variação 2x clicando rápido) que foi a real Dor #1.
- ✅ Diff de 1 função (`handleAddProduct`) — alto rendimento, baixíssimo risco de regressão na rota crítica `/pos`.
- ✅ Não conflita com agents R2/R6 que mexem em `CustomerSearchAutocomplete.tsx`.
- ❌ Não cobre o caso "user quer ver MARTELO-P/M/G agrupados visualmente" — toast `info` deixa claro que abriu linha separada, evitando que ele ache que está com bug.

Refactor com popover de variações por linha pode ser PR separado se Wagner pedir após smoke prod.

## Restrições Tier 0 respeitadas

- Não toca `__number_uf` (restrição explícita)
- Não toca `CustomerSearchAutocomplete.tsx` (agents R2/R6 paralelos)
- Toast via `sonner` (canon do módulo Sells)
- 1 PR = 1 intent

## Test plan

- [ ] Larissa: abrir `/sells/create` (V2 Inertia), buscar MARTELO-P, clicar resultado 2x → ver 1 linha com qty 2 + toast "MARTELO-P — quantidade 2"
- [ ] Larissa: adicionar MARTELO-P, depois MARTELO-M → ver 2 linhas distintas + toast "Variação diferente de MARTELO — adicionada como linha separada"
- [ ] Smoke: salvar venda com qty incrementada e verificar que backend (`SellPosController@store`) aceita o payload sem 422
- [ ] Smoke: confirmar que produtos diferentes (`product_id` distintos) continuam adicionando linhas normalmente

## Notas técnicas

- TypeScript: 0 erros NOVOS no arquivo (4 erros pré-existentes em main: TS2322 useForm spread + TS2345 OptionMap em outras funções — não tocados).
- ESLint/tsc não rodaram suite full por escopo do PR (1 função touched).
- Custo runtime adicional: O(n) em `data.products.find()` — n ≤ ~50 produtos por venda típica, negligível.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Refs: Dor 1 auditoria V2 rollback 2026-05-13, ADR 0104 MWART F3