### PR TITLE
fix(cliente/drawer): rows com cpf_cnpj_masked/ie/rg/nascimento/cargo

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -473,6 +473,22 @@ class ContactController extends Controller
         if (\Illuminate\Support\Facades\Schema::hasColumn('contacts', 'numero')) {
             $selectCols[] = 'contacts.numero';
         }
+        // Wave 2026-05-21 (canon BR restaurado pós-regressão UPOS 6.7 — ADR 0178).
+        // Sem isso, drawer IdentificacaoTab (Index Cliente) abre com CNPJ/IE/RG
+        // vazios mesmo com dado no banco — payload rows não enviava as chaves
+        // `cpf_cnpj_masked`/`ie`/`rg` que o drawer espera (Wagner 2026-05-27).
+        $hasCanonBrCols = \Illuminate\Support\Facades\Schema::hasColumn('contacts', 'cpf_cnpj');
+        if ($hasCanonBrCols) {
+            $selectCols[] = 'contacts.cpf_cnpj';
+            $selectCols[] = 'contacts.inscricao_estadual';
+            $selectCols[] = 'contacts.rg';
+        }
+        // Wave drawer 2026-05-22 — campos cadastrais drawer (nascimento + cargo).
+        $hasDrawerCols = \Illuminate\Support\Facades\Schema::hasColumn('contacts', 'cargo');
+        if ($hasDrawerCols) {
+            $selectCols[] = 'contacts.nascimento';
+            $selectCols[] = 'contacts.cargo';
+        }
         if ($hasWaveBCols) {
             $selectCols = array_merge($selectCols, [
                 'contacts.tipo',
@@ -548,7 +564,7 @@ class ContactController extends Controller
             ->get()
             ->keyBy('contact_id');
 
-        $rows = $contacts->getCollection()->map(function ($contact) use ($stats, $hasWaveBCols) {
+        $rows = $contacts->getCollection()->map(function ($contact) use ($stats, $hasWaveBCols, $hasCanonBrCols, $hasDrawerCols) {
             $row = $stats->get($contact->id);
             $totalOs = $row ? (int) $row->total_os : 0;
             $abertas = $row ? (int) $row->os_abertas : 0;
@@ -626,6 +642,18 @@ class ContactController extends Controller
             $payload['is_supplier'] = (bool) ($contact->is_supplier ?? false);
             $payload['is_employee'] = (bool) ($contact->is_employee ?? false);
             $payload['is_representative'] = (bool) ($contact->is_representative ?? false);
+
+            // Canon BR (Wave 2026-05-21 ADR 0178) — campos que IdentificacaoTab
+            // do drawer espera. Fallback `cpf_cnpj` → `tax_number` cobre legacy
+            // UPOS (cadastros pré-restauração BR). PII mascarado, NUNCA plain.
+            $cpfCnpjRaw = $hasCanonBrCols ? ($contact->cpf_cnpj ?? null) : null;
+            $payload['cpf_cnpj_masked'] = $this->maskTaxNumber($cpfCnpjRaw ?? $contact->tax_number);
+            $payload['ie'] = $hasCanonBrCols ? ($contact->inscricao_estadual ?? null) : null;
+            $payload['rg'] = $hasCanonBrCols ? ($contact->rg ?? null) : null;
+
+            // Wave drawer 2026-05-22 — campos cadastrais drawer.
+            $payload['nascimento'] = $hasDrawerCols ? ($contact->nascimento ?? null) : null;
+            $payload['cargo'] = $hasDrawerCols ? ($contact->cargo ?? null) : null;
 
             return $payload;
         })->all();

--- a/tests/Feature/Cliente/ClienteDrawerRowsCanonBrPayloadTest.php
+++ b/tests/Feature/Cliente/ClienteDrawerRowsCanonBrPayloadTest.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fix 2026-05-27 (Wagner reportou drawer Identificacao sem IE/CNPJ no Acme
+ * Comercio Ltda biz=1).
+ *
+ * IdentificacaoTab espera `contact.ie` + `contact.cpf_cnpj_masked` + `contact.rg`
+ * + `contact.nascimento` + `contact.cargo` no row. ContactController::
+ * buildClienteIndexCustomers nao enviava — drawer abria com placeholders
+ * mesmo com dado no banco.
+ *
+ * Estrategia structural file_get_contents (alinhado ClienteListagemTurbinadaTest).
+ *
+ * Refs: ADR 0178 (canon BR restaurado pos UPOS 6.7), ADR 0179 (drawer 760).
+ */
+
+// ─── GUARD 1: select cols inclui cpf_cnpj + inscricao_estadual + rg ────────
+
+test('GUARD 1 — buildClienteIndexCustomers select inclui canon BR fields graceful', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    expect($path)->toBeReadableFile();
+
+    $contents = file_get_contents($path);
+    expect($contents)
+        // hasColumn graceful pra ambiente pre-Wave 2026-05-21.
+        ->toContain("Schema::hasColumn('contacts', 'cpf_cnpj')")
+        ->toContain("'contacts.cpf_cnpj'")
+        ->toContain("'contacts.inscricao_estadual'")
+        ->toContain("'contacts.rg'")
+        // Wave drawer 2026-05-22 — nascimento + cargo.
+        ->toContain("Schema::hasColumn('contacts', 'cargo')")
+        ->toContain("'contacts.nascimento'")
+        ->toContain("'contacts.cargo'");
+});
+
+// ─── GUARD 2: payload row tem chaves drawer-friendly ──────────────────────
+
+test('GUARD 2 — buildClienteIndexCustomers payload tem cpf_cnpj_masked + ie + rg + nascimento + cargo', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        // PII: cpf_cnpj_masked sempre passa por maskTaxNumber (LGPD).
+        ->toMatch("/\\\$payload\\['cpf_cnpj_masked'\\]\\s*=\\s*\\\$this->maskTaxNumber/")
+        // Fallback canon -> legacy UPOS pra cadastros pre-Wave 2026-05-21.
+        ->toContain('cpf_cnpj ?? null')
+        ->toContain('?? $contact->tax_number')
+        // ie + rg + nascimento + cargo escapam o mask (sao livres, nao PII numerica).
+        ->toMatch("/\\\$payload\\['ie'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['rg'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['nascimento'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['cargo'\\]\\s*=/");
+});
+
+// ─── GUARD 3: contrato frontend nao quebrou — IdentificacaoTab ainda le essas chaves
+
+test('GUARD 3 — IdentificacaoTab.tsx ContactInfo declara ie + cpf_cnpj_masked', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/IdentificacaoTab.tsx';
+    expect($path)->toBeReadableFile();
+
+    $contents = file_get_contents($path);
+    expect($contents)
+        ->toContain('cpf_cnpj_masked?: string | null')
+        ->toContain('ie?: string | null')
+        ->toContain('rg?: string | null')
+        ->toContain('nascimento?: string | null')
+        ->toContain('cargo?: string | null')
+        // useState inicializa do contact prop (autosave debounce).
+        ->toContain('useState<string>(contact.ie ??')
+        ->toContain('useState<string>(contact.cpf_cnpj_masked ??');
+});
+
+// ─── GUARD 4: Index.tsx ContactRow declara as chaves (contrato shared) ─────
+
+test('GUARD 4 — Cliente/Index.tsx ClienteRow declara ie + cpf_cnpj_masked + rg + nascimento + cargo', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
+    expect($path)->toBeReadableFile();
+
+    $contents = file_get_contents($path);
+    expect($contents)
+        ->toContain('cpf_cnpj_masked?: string | null')
+        ->toContain('ie?: string | null')
+        ->toContain('rg?: string | null')
+        ->toContain('nascimento?: string | null')
+        ->toContain('cargo?: string | null');
+});


### PR DESCRIPTION
## Summary
- `ContactController::buildClienteIndexCustomers` (rows do Index Cliente) **não enviava** `cpf_cnpj_masked`/`ie`/`rg`/`nascimento`/`cargo`, mas `IdentificacaoTab.tsx` do drawer 760 espera essas chaves desde Wave drawer.
- Resultado: clicar num cliente da lista abria o drawer com placeholders mesmo com dado no banco. **Wagner reportou hoje** (2026-05-27) em Acme Comércio Ltda biz=1: CNPJ aparece na coluna DOCUMENTO da tabela (vem de `tax_number_masked`) mas some no drawer Identificação (que lia `cpf_cnpj_masked`).
- Fix aditivo + idempotente: `Schema::hasColumn` graceful pra ambiente pré-Wave 2026-05-21 (canon BR — ADR 0178) e pré-Wave drawer 2026-05-22.
- Fallback `cpf_cnpj_masked`: `cpf_cnpj` canon BR, com fallback `tax_number` legacy UPOS pra cadastros pré-restauração. PII **sempre mascarado** via `maskTaxNumber`.

## Diff
- `app/Http/Controllers/ContactController.php` — `+29 -1` (2 blocos `hasColumn` no select, 5 chaves no payload com `use` ampliado).
- `tests/Feature/Cliente/ClienteDrawerRowsCanonBrPayloadTest.php` — `+88 -0` (novo).

## Test plan
- [x] `php artisan test tests/Feature/Cliente/ClienteDrawerRowsCanonBrPayloadTest.php` → 4 passed, 32 assertions (1.58s).
- [ ] Smoke pós-merge: abrir `/cliente?type=customer` em prod, clicar num PJ com CNPJ/IE no banco e confirmar drawer Identificação populado.
- [ ] Confirmar que `/contacts/{id}/edit` (página inteira) segue OK — não tocado (já enviava `inscricao_estadual` linha 1767).

## Refs
- ADR 0178 (canon BR restaurado pós-regressão UPOS 6.7)
- ADR 0179 (drawer 760 substitui Show fullpage)
- ADR 0093 (multi-tenant Tier 0 — `business_id` scope preservado, não tocado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)