### PR TITLE
fix(cliente/drawer): payload rows completo (18 chaves além do canon BR)

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -497,6 +497,12 @@ class ContactController extends Controller
         if ($hasDrawerCols) {
             $selectCols[] = 'contacts.nascimento';
             $selectCols[] = 'contacts.cargo';
+            // `ie` (Wave drawer 2026-05-22) — alias Cowork de `inscricao_estadual`
+            // (Wave canon BR 2026-05-21). DUAS colunas coexistem (intencional —
+            // Wave C decide canon). ClienteAutosaveController PATCH grava SÓ em
+            // `ie`, então é a fonte de verdade pro drawer. Fallback `inscricao_estadual`
+            // cobre cadastros pre-drawer Wave (Wave 2026-05-21).
+            $selectCols[] = 'contacts.ie';
             $selectCols[] = 'contacts.tel2';
             $selectCols[] = 'contacts.site_url';
             $selectCols[] = 'contacts.canal_preferido';
@@ -679,7 +685,10 @@ class ContactController extends Controller
             // UPOS (cadastros pré-restauração BR). PII mascarado, NUNCA plain.
             $cpfCnpjRaw = $hasCanonBrCols ? ($contact->cpf_cnpj ?? null) : null;
             $payload['cpf_cnpj_masked'] = $this->maskTaxNumber($cpfCnpjRaw ?? $contact->tax_number);
-            $payload['ie'] = $hasCanonBrCols ? ($contact->inscricao_estadual ?? null) : null;
+            // IE: prioriza `contacts.ie` (Wave drawer — onde autosave grava) com
+            // fallback `inscricao_estadual` (Wave canon BR — cadastros pre-drawer).
+            $payload['ie'] = ($hasDrawerCols ? ($contact->ie ?? null) : null)
+                ?? ($hasCanonBrCols ? ($contact->inscricao_estadual ?? null) : null);
             $payload['rg'] = $hasCanonBrCols ? ($contact->rg ?? null) : null;
 
             // Wave drawer 2026-05-22 — campos cadastrais drawer.

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -453,9 +453,15 @@ class ContactController extends Controller
             'contacts.tax_number',
             'contacts.contact_id',
             'contacts.mobile',
+            'contacts.landline',
+            'contacts.alternate_number',
+            'contacts.email',
             'contacts.city',
             'contacts.state',
             'contacts.balance',
+            'contacts.credit_limit',
+            'contacts.pay_term_number',
+            'contacts.contact_status',
             'contacts.created_at',
             // Endereço completo — sem isso, router.reload({only:['rows']}) pós lookup
             // CNPJ/CEP zera campos no EnderecoTab (undefined → setState('')) e a UI
@@ -483,11 +489,36 @@ class ContactController extends Controller
             $selectCols[] = 'contacts.inscricao_estadual';
             $selectCols[] = 'contacts.rg';
         }
-        // Wave drawer 2026-05-22 — campos cadastrais drawer (nascimento + cargo).
+        // Wave drawer 2026-05-22 — campos cadastrais drawer (nascimento + cargo +
+        // tel2 + site_url + canal_preferido + tabela_preco_padrao + pgto_padrao +
+        // obs_comercial). Sem isso, ContatoTab/ComercialTab/IdentificacaoTab abrem
+        // com placeholders. Wagner 2026-05-27 reportou "drawer não traz dados".
         $hasDrawerCols = \Illuminate\Support\Facades\Schema::hasColumn('contacts', 'cargo');
         if ($hasDrawerCols) {
             $selectCols[] = 'contacts.nascimento';
             $selectCols[] = 'contacts.cargo';
+            $selectCols[] = 'contacts.tel2';
+            $selectCols[] = 'contacts.site_url';
+            $selectCols[] = 'contacts.canal_preferido';
+            $selectCols[] = 'contacts.tabela_preco_padrao';
+            $selectCols[] = 'contacts.pgto_padrao';
+            $selectCols[] = 'contacts.obs_comercial';
+        }
+        // Wave emails extras 2026-05-26 (Onda 1 PR B' Daniela) — emails
+        // diferenciados (comercial / NF-e). ContatoTab espera.
+        $hasEmailsExtras = \Illuminate\Support\Facades\Schema::hasColumn('contacts', 'email_billing');
+        if ($hasEmailsExtras) {
+            $selectCols[] = 'contacts.email_billing';
+            $selectCols[] = 'contacts.email_nfe';
+        }
+        // Wave SEFAZ 2026-05-23 — campos derivados ConsultaCadastro (badge alertas
+        // IdentificacaoTab). Graceful pra ambiente pré-Wave.
+        $hasSefazCols = \Illuminate\Support\Facades\Schema::hasColumn('contacts', 'sefaz_cad_sit');
+        if ($hasSefazCols) {
+            $selectCols[] = 'contacts.ind_ie_dest';
+            $selectCols[] = 'contacts.sefaz_cad_sit';
+            $selectCols[] = 'contacts.sefaz_cad_ind_cred_nfe';
+            $selectCols[] = 'contacts.sefaz_cad_consultado_em';
         }
         if ($hasWaveBCols) {
             $selectCols = array_merge($selectCols, [
@@ -564,7 +595,7 @@ class ContactController extends Controller
             ->get()
             ->keyBy('contact_id');
 
-        $rows = $contacts->getCollection()->map(function ($contact) use ($stats, $hasWaveBCols, $hasCanonBrCols, $hasDrawerCols) {
+        $rows = $contacts->getCollection()->map(function ($contact) use ($stats, $hasWaveBCols, $hasCanonBrCols, $hasDrawerCols, $hasEmailsExtras, $hasSefazCols) {
             $row = $stats->get($contact->id);
             $totalOs = $row ? (int) $row->total_os : 0;
             $abertas = $row ? (int) $row->os_abertas : 0;
@@ -654,6 +685,51 @@ class ContactController extends Controller
             // Wave drawer 2026-05-22 — campos cadastrais drawer.
             $payload['nascimento'] = $hasDrawerCols ? ($contact->nascimento ?? null) : null;
             $payload['cargo'] = $hasDrawerCols ? ($contact->cargo ?? null) : null;
+
+            // ── ContatoTab: telefones + emails + site + canal ────────────────
+            // UPOS canon (sempre presentes).
+            $payload['landline'] = $contact->landline ?? null;
+            $payload['alternate_number'] = $contact->alternate_number ?? null;
+            $payload['email'] = $contact->email ?? null;
+            // Wave drawer + Wave emails extras. Aliases PT-BR (`site`/`canal`)
+            // pra ContatoTab que declara essas chaves diretamente; canon EN
+            // (`site_url`/`canal_preferido`) preservados pra compat shapeContactResponse.
+            $payload['tel2'] = $hasDrawerCols ? ($contact->tel2 ?? null) : null;
+            $payload['site_url'] = $hasDrawerCols ? ($contact->site_url ?? null) : null;
+            $payload['site'] = $payload['site_url'];
+            $payload['canal_preferido'] = $hasDrawerCols ? ($contact->canal_preferido ?? null) : null;
+            $payload['canal'] = $payload['canal_preferido'];
+            $payload['email_billing'] = $hasEmailsExtras ? ($contact->email_billing ?? null) : null;
+            $payload['email_nfe'] = $hasEmailsExtras ? ($contact->email_nfe ?? null) : null;
+
+            // ── ComercialTab: limite, prazo, tabela, pgto, obs ───────────────
+            // UPOS canon + Wave drawer enums. Aliases PT-BR pro tab que declara
+            // `limite_credito`/`prazo_padrao_dias` em vez de `credit_limit`/`pay_term_number`.
+            $payload['credit_limit'] = $contact->credit_limit !== null ? (float) $contact->credit_limit : null;
+            $payload['limite_credito'] = $payload['credit_limit'];
+            $payload['pay_term_number'] = $contact->pay_term_number !== null ? (int) $contact->pay_term_number : null;
+            $payload['prazo_padrao_dias'] = $payload['pay_term_number'];
+            $payload['tabela_preco_padrao'] = $hasDrawerCols ? ($contact->tabela_preco_padrao ?? null) : null;
+            $payload['pgto_padrao'] = $hasDrawerCols ? ($contact->pgto_padrao ?? null) : null;
+            $payload['obs_comercial'] = $hasDrawerCols ? ($contact->obs_comercial ?? null) : null;
+
+            // ── ClassificacaoTab: contact_status enum UPOS ───────────────────
+            // NOTA: `status` (linha ~559) é DERIVADO do payment_status das OS
+            // (late/active/idle pra FrescorPill) — NÃO renomear pra evitar
+            // regressão visual. `contact_status` (ativo/inativo/bloqueado) é
+            // separado e o tab pode escolher entre os 2 ao migrar.
+            $payload['contact_status'] = $contact->contact_status ?? null;
+
+            // ── IdentificacaoTab: SEFAZ ConsultaCadastro (Wave 2026-05-23) ───
+            // Badge alertas NFe (rejeicao 478/487/770) — IdentificacaoTab lê via
+            // shapeContactResponse pos lookup; ler no payload inicial mantem
+            // consistencia (drawer abre com warning sem precisar re-lookup).
+            $payload['ind_ie_dest'] = $hasSefazCols && $contact->ind_ie_dest !== null
+                ? (int) $contact->ind_ie_dest : null;
+            $payload['sefaz_cad_sit'] = $hasSefazCols ? ($contact->sefaz_cad_sit ?? null) : null;
+            $payload['sefaz_cad_ind_cred_nfe'] = $hasSefazCols && $contact->sefaz_cad_ind_cred_nfe !== null
+                ? (int) $contact->sefaz_cad_ind_cred_nfe : null;
+            $payload['sefaz_cad_consultado_em'] = $hasSefazCols ? ($contact->sefaz_cad_consultado_em ?? null) : null;
 
             return $payload;
         })->all();

--- a/tests/Feature/Cliente/ClienteDrawerRowsCanonBrPayloadTest.php
+++ b/tests/Feature/Cliente/ClienteDrawerRowsCanonBrPayloadTest.php
@@ -86,3 +86,83 @@ test('GUARD 4 — Cliente/Index.tsx ClienteRow declara ie + cpf_cnpj_masked + rg
         ->toContain('nascimento?: string | null')
         ->toContain('cargo?: string | null');
 });
+
+// ─── GUARD 5: ContatoTab — telefones + emails + site + canal ──────────────
+
+test('GUARD 5 — payload tem landline + tel2 + alternate_number + email + email_billing + email_nfe + site + canal', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("'contacts.landline'")
+        ->toContain("'contacts.alternate_number'")
+        ->toContain("'contacts.email'")
+        ->toContain("'contacts.tel2'")
+        ->toContain("'contacts.site_url'")
+        ->toContain("'contacts.canal_preferido'")
+        ->toContain("Schema::hasColumn('contacts', 'email_billing')")
+        ->toContain("'contacts.email_billing'")
+        ->toContain("'contacts.email_nfe'")
+        ->toMatch("/\\\$payload\\['landline'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['tel2'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['alternate_number'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['email'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['email_billing'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['email_nfe'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['site_url'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['site'\\]\\s*=\\s*\\\$payload\\['site_url'\\]/")
+        ->toMatch("/\\\$payload\\['canal_preferido'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['canal'\\]\\s*=\\s*\\\$payload\\['canal_preferido'\\]/");
+});
+
+// ─── GUARD 6: ComercialTab — limite, prazo, tabela, pgto, obs ──────────────
+
+test('GUARD 6 — payload tem credit_limit + pay_term_number + tabela_preco_padrao + pgto_padrao + obs_comercial + aliases PT-BR', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("'contacts.credit_limit'")
+        ->toContain("'contacts.pay_term_number'")
+        ->toContain("'contacts.tabela_preco_padrao'")
+        ->toContain("'contacts.pgto_padrao'")
+        ->toContain("'contacts.obs_comercial'")
+        ->toMatch("/\\\$payload\\['credit_limit'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['limite_credito'\\]\\s*=\\s*\\\$payload\\['credit_limit'\\]/")
+        ->toMatch("/\\\$payload\\['pay_term_number'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['prazo_padrao_dias'\\]\\s*=\\s*\\\$payload\\['pay_term_number'\\]/")
+        ->toMatch("/\\\$payload\\['tabela_preco_padrao'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['pgto_padrao'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['obs_comercial'\\]\\s*=/");
+});
+
+// ─── GUARD 7: ClassificacaoTab + SEFAZ derivados ───────────────────────────
+
+test('GUARD 7 — payload tem contact_status + SEFAZ derivados (ind_ie_dest, sefaz_cad_*)', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("'contacts.contact_status'")
+        ->toMatch("/\\\$payload\\['contact_status'\\]\\s*=/")
+        ->toContain("Schema::hasColumn('contacts', 'sefaz_cad_sit')")
+        ->toContain("'contacts.ind_ie_dest'")
+        ->toContain("'contacts.sefaz_cad_sit'")
+        ->toContain("'contacts.sefaz_cad_ind_cred_nfe'")
+        ->toContain("'contacts.sefaz_cad_consultado_em'")
+        ->toMatch("/\\\$payload\\['ind_ie_dest'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['sefaz_cad_sit'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['sefaz_cad_ind_cred_nfe'\\]\\s*=/")
+        ->toMatch("/\\\$payload\\['sefaz_cad_consultado_em'\\]\\s*=/");
+});
+
+// ─── GUARD 8: `status` (derivado OS) NÃO foi renomeado — sem regressão ─────
+
+test('GUARD 8 — payload[status] ainda eh late|active|idle derivado OS (FrescorPill)', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("\$status = \$atrasadas > 0 ? 'late' : (\$abertas > 0 ? 'active' : 'idle')")
+        ->toMatch("/'status'\\s*=>\\s*\\\$status/");
+});

--- a/tests/Feature/Cliente/ClienteDrawerRowsCanonBrPayloadTest.php
+++ b/tests/Feature/Cliente/ClienteDrawerRowsCanonBrPayloadTest.php
@@ -29,10 +29,13 @@ test('GUARD 1 — buildClienteIndexCustomers select inclui canon BR fields grace
         ->toContain("'contacts.cpf_cnpj'")
         ->toContain("'contacts.inscricao_estadual'")
         ->toContain("'contacts.rg'")
-        // Wave drawer 2026-05-22 — nascimento + cargo.
+        // Wave drawer 2026-05-22 — nascimento + cargo + ie (alias Cowork).
         ->toContain("Schema::hasColumn('contacts', 'cargo')")
         ->toContain("'contacts.nascimento'")
-        ->toContain("'contacts.cargo'");
+        ->toContain("'contacts.cargo'")
+        // `ie` (Wave drawer) e a fonte de verdade — autosave grava la, NAO em
+        // `inscricao_estadual` (Wave canon BR — kept como fallback legacy).
+        ->toContain("'contacts.ie'");
 });
 
 // ─── GUARD 2: payload row tem chaves drawer-friendly ──────────────────────
@@ -47,6 +50,10 @@ test('GUARD 2 — buildClienteIndexCustomers payload tem cpf_cnpj_masked + ie + 
         // Fallback canon -> legacy UPOS pra cadastros pre-Wave 2026-05-21.
         ->toContain('cpf_cnpj ?? null')
         ->toContain('?? $contact->tax_number')
+        // ie prioriza coluna Wave drawer (`contacts.ie`) com fallback canon BR
+        // (`inscricao_estadual`) pra cadastros pre-drawer. Autosave grava em `ie`.
+        ->toContain('$contact->ie ?? null')
+        ->toContain('$contact->inscricao_estadual ?? null')
         // ie + rg + nascimento + cargo escapam o mask (sao livres, nao PII numerica).
         ->toMatch("/\\\$payload\\['ie'\\]\\s*=/")
         ->toMatch("/\\\$payload\\['rg'\\]\\s*=/")


### PR DESCRIPTION
## Summary
Continuação de #1763. Após validação em prod (Wagner 2026-05-27 — Mercado União biz=1), drawer continuou trazendo só Razão social/Tipo. Auditoria via `ClienteAutosaveController::shapeContactResponse` (que é a fonte canônica que o backend retorna depois de PATCH) revelou que `buildClienteIndexCustomers` mandava só metade das chaves esperadas pelos 5 tabs do drawer.

## Faltavam (18 chaves)
- **ContatoTab:** `landline`, `tel2`, `alternate_number`, `email`, `email_billing`, `email_nfe`, `site` (alias `site_url`), `canal` (alias `canal_preferido`)
- **ComercialTab:** `credit_limit`, `pay_term_number`, `tabela_preco_padrao`, `pgto_padrao`, `obs_comercial` + aliases PT-BR `limite_credito`/`prazo_padrao_dias`
- **ClassificacaoTab:** `contact_status` (separado do `status` derivado OS pra FrescorPill, que segue `late|active|idle`)
- **IdentificacaoTab:** `ind_ie_dest`, `sefaz_cad_sit`, `sefaz_cad_ind_cred_nfe`, `sefaz_cad_consultado_em` (badge SEFAZ ConsultaCadastro)

## Implementação
- Aditiva + idempotente: `Schema::hasColumn` graceful pra Wave drawer 2026-05-22, Wave emails 2026-05-26, Wave SEFAZ 2026-05-23.
- UPOS canon sempre presente (`landline`, `email`, `alternate_number`, `credit_limit`, `pay_term_number`, `contact_status`).
- Aliases PT-BR onde drawer interface declara chave diferente do shape canônico — sem custo, frontend pega a que tiver.
- `status` NÃO renomeado (anti-regressão FrescorPill) — `GUARD 8` ancora o ternary literal.

## Diff
- `app/Http/Controllers/ContactController.php` — `+78 -2`
- `tests/Feature/Cliente/ClienteDrawerRowsCanonBrPayloadTest.php` — `+80 -0`

## Test plan
- [x] `php artisan test tests/Feature/Cliente/ClienteDrawerRowsCanonBrPayloadTest.php` → 8 passed, 76 assertions (21.76s, 1.6s estrutural).
- [ ] Smoke pós-deploy: abrir `/cliente?type=customer` em prod, clicar num PJ com dados completos (telefone + email + endereço), conferir todos os 5 tabs populados.
- [ ] Confirmar que coluna lista (FrescorPill saldo OS) não regrediu — `status` derivado preservado.

## Refs
- ADR 0178 (canon BR restaurado pós UPOS 6.7)
- ADR 0179 (drawer 760)
- ADR 0186 (SEFAZ Técnica C — paralelo BrasilAPI + ConsultaCadastro)
- ADR 0093 (multi-tenant Tier 0 — scope preservado, não tocado)

🤖 Generated with [Claude Code](https://claude.com/claude-code)