### PR TITLE
fix(cliente/drawer): aliases PT-BR → canon EN validators (bug crítico Daniela)

### DIFF
--- a/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
+++ b/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
@@ -173,7 +173,19 @@ class ClienteAutosaveController extends Controller
             return $contact; // ja e JsonResponse 404/403
         }
 
-        $validator = Validator::make($request->all(), [
+        // Fix Daniela 2026-05-27 (cliente Heinig nao salvou razao social + CNPJ):
+        // Frontend IdentificacaoTab.tsx envia chaves PT-BR (`nome`, `doc`, `contato`).
+        // Backend validator espera canon EN (`name`, `tax_number`, `contato` ja
+        // canon). Normaliza aliases ANTES de validar -- silent no-op vira save real.
+        $input = $request->all();
+        if (array_key_exists('nome', $input) && ! array_key_exists('name', $input)) {
+            $input['name'] = $input['nome'];
+        }
+        if (array_key_exists('doc', $input) && ! array_key_exists('tax_number', $input)) {
+            $input['tax_number'] = $input['doc'];
+        }
+
+        $validator = Validator::make($input, [
             'tipo' => ['nullable', 'string', 'in:PF,PJ'],
             'name' => ['nullable', 'string', 'max:255'],
             'fantasia' => ['nullable', 'string', 'max:255'],
@@ -182,6 +194,9 @@ class ClienteAutosaveController extends Controller
             'rg' => ['nullable', 'string', 'max:20'],
             'nascimento' => ['nullable', 'date', 'before:today'],
             'cargo' => ['nullable', 'string', 'max:80'],
+            // Daniela 2026-05-27 -- nome do responsavel principal (PJ). Coluna
+            // criada nesta sessao via migration 2026_05_27_180000.
+            'contato' => ['nullable', 'string', 'max:100'],
             // ADR 0186 Técnica C — campos derivados da SEFAZ ConsultaCadastro.
             'ind_ie_dest' => ['nullable', 'integer', 'in:1,2,9'],
             'sefaz_cad_sit' => ['nullable', 'string', 'in:habilitado,nao_habilitado,suspenso,cancelado,paralisado,baixado'],
@@ -221,7 +236,22 @@ class ClienteAutosaveController extends Controller
             return $contact;
         }
 
-        $validator = Validator::make($request->all(), [
+        // Fix Daniela 2026-05-27 (telefone principal nao salvou em cadastro Heinig):
+        // Frontend ContatoTab.tsx envia chaves PT-BR (`tel`, `site`, `canal`).
+        // Backend validator espera canon EN (`mobile`, `site_url`, `canal_preferido`).
+        // Normaliza aliases ANTES de validar.
+        $input = $request->all();
+        if (array_key_exists('tel', $input) && ! array_key_exists('mobile', $input)) {
+            $input['mobile'] = $input['tel'];
+        }
+        if (array_key_exists('site', $input) && ! array_key_exists('site_url', $input)) {
+            $input['site_url'] = $input['site'];
+        }
+        if (array_key_exists('canal', $input) && ! array_key_exists('canal_preferido', $input)) {
+            $input['canal_preferido'] = $input['canal'];
+        }
+
+        $validator = Validator::make($input, [
             'mobile' => ['nullable', 'string', 'max:25'],
             'tel2' => ['nullable', 'string', 'max:20'],
             // Onda 1 PR B' — 3º telefone via coluna UPOS legacy `alternate_number`.
@@ -524,6 +554,9 @@ class ClienteAutosaveController extends Controller
             'rg' => $contact->rg ?? null,
             'nascimento' => $contact->nascimento ?? null,
             'cargo' => $contact->cargo ?? null,
+            // Daniela 2026-05-27 — Nome do responsavel principal. Coluna
+            // criada via migration 2026_05_27_180000_add_contato_to_contacts.
+            'contato' => $contact->contato ?? null,
             'mobile' => $contact->mobile ?? null,
             'tel2' => $contact->tel2 ?? null,
             // Onda 1 PR B' (Daniela) — 3º telefone via coluna UPOS legacy.

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -532,6 +532,12 @@ class ContactController extends Controller
         if ($hasBucketACols) {
             $selectCols[] = 'contacts.bloqueado';
         }
+        // Daniela 2026-05-27 — `contato` (nome do responsavel principal PJ).
+        // Migration 2026_05_27_180000_add_contato_to_contacts.
+        $hasContatoCol = \Illuminate\Support\Facades\Schema::hasColumn('contacts', 'contato');
+        if ($hasContatoCol) {
+            $selectCols[] = 'contacts.contato';
+        }
         if ($hasWaveBCols) {
             $selectCols = array_merge($selectCols, [
                 'contacts.tipo',
@@ -607,7 +613,7 @@ class ContactController extends Controller
             ->get()
             ->keyBy('contact_id');
 
-        $rows = $contacts->getCollection()->map(function ($contact) use ($stats, $hasWaveBCols, $hasCanonBrCols, $hasDrawerCols, $hasEmailsExtras, $hasSefazCols, $hasBucketACols) {
+        $rows = $contacts->getCollection()->map(function ($contact) use ($stats, $hasWaveBCols, $hasCanonBrCols, $hasDrawerCols, $hasEmailsExtras, $hasSefazCols, $hasBucketACols, $hasContatoCol) {
             $row = $stats->get($contact->id);
             $totalOs = $row ? (int) $row->total_os : 0;
             $abertas = $row ? (int) $row->os_abertas : 0;
@@ -748,6 +754,9 @@ class ContactController extends Controller
 
             // ── Bucket A: bloqueado (ADR 0195) ───────────────────────────────
             $payload['bloqueado'] = $hasBucketACols ? (bool) ($contact->bloqueado ?? false) : false;
+
+            // ── Daniela 2026-05-27: contato (nome do responsavel principal PJ)
+            $payload['contato'] = $hasContatoCol ? ($contact->contato ?? null) : null;
 
             return $payload;
         })->all();

--- a/database/migrations/2026_05_27_180000_add_contato_to_contacts.php
+++ b/database/migrations/2026_05_27_180000_add_contato_to_contacts.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Fix Daniela 2026-05-27 — drawer Cliente input "Contato principal" era
+ * silencioso (validator aceitava `contato` mas nao havia coluna destino;
+ * Eloquent::update jogava fora).
+ *
+ * Daniela @ Martinho (Onda 1 PR B') cadastrou Heinig Pre-Moldados e nao
+ * conseguiu salvar nome do responsavel. Frontend ja envia ha tempos.
+ *
+ * Schema:
+ *   contacts.contato VARCHAR(100) NULL
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGAVEL): preservado -- `business_id`
+ * scope herdado da tabela contacts (nao precisa novo indice).
+ *
+ * Idempotente: hasColumn check pra ambiente onde migration ja rodou.
+ *
+ * Refs: ADR 0179 (drawer 760) · session 2026-05-27 (auditoria drawer + Daniela).
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasColumn('contacts', 'contato')) {
+            Schema::table('contacts', function (Blueprint $table) {
+                $table->string('contato', 100)
+                    ->nullable()
+                    ->after('cargo')
+                    ->comment('Nome do responsavel principal (PJ) — drawer IdentificacaoTab. Daniela 2026-05-27.');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (Schema::hasColumn('contacts', 'contato')) {
+            Schema::table('contacts', function (Blueprint $table) {
+                $table->dropColumn('contato');
+            });
+        }
+    }
+};

--- a/tests/Feature/Cliente/ClienteAutosaveAliasesPtBrTest.php
+++ b/tests/Feature/Cliente/ClienteAutosaveAliasesPtBrTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fix Daniela 2026-05-27 — drawer Cliente nao salvava Razao Social/CNPJ/Tel
+ * principal porque frontend envia chaves PT-BR (`nome`, `doc`, `tel`, `site`,
+ * `canal`) mas backend validator so aceita canon EN (`name`, `tax_number`,
+ * `mobile`, `site_url`, `canal_preferido`).
+ *
+ * Validator filtra com `validated()` -> chaves desconhecidas viram silent no-op.
+ * `Eloquent::update([])` retorna sem persistir. Badge "Salvo" verde aparece
+ * (status 200) mas dado nunca chega no banco.
+ *
+ * Fix: normalizar aliases ANTES do validator (input map).
+ * Plus: campo `contato` (Nome do responsavel principal) ganhou coluna nova
+ * via migration 2026_05_27_180000_add_contato_to_contacts.
+ *
+ * GUARDs estruturais (file_get_contents, sem DB).
+ */
+
+// ─── GUARD 1: identificacao normaliza nome/doc + aceita contato ───────────
+
+test('GUARD 1 — identificacao() normaliza nome->name + doc->tax_number + aceita contato', function () {
+    $path = __DIR__ . '/../../../Modules/Crm/Http/Controllers/ClienteAutosaveController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        // Normalizacao input antes do validator.
+        ->toContain("array_key_exists('nome', \$input)")
+        ->toContain("\$input['name'] = \$input['nome']")
+        ->toContain("array_key_exists('doc', \$input)")
+        ->toContain("\$input['tax_number'] = \$input['doc']")
+        // Validator aceita `contato` novo.
+        ->toContain("'contato' => ['nullable', 'string', 'max:100']");
+});
+
+// ─── GUARD 2: contato() normaliza tel/site/canal ──────────────────────────
+
+test('GUARD 2 — contato() normaliza tel->mobile + site->site_url + canal->canal_preferido', function () {
+    $path = __DIR__ . '/../../../Modules/Crm/Http/Controllers/ClienteAutosaveController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("array_key_exists('tel', \$input)")
+        ->toContain("\$input['mobile'] = \$input['tel']")
+        ->toContain("array_key_exists('site', \$input)")
+        ->toContain("\$input['site_url'] = \$input['site']")
+        ->toContain("array_key_exists('canal', \$input)")
+        ->toContain("\$input['canal_preferido'] = \$input['canal']");
+});
+
+// ─── GUARD 3: shapeContactResponse retorna contato ────────────────────────
+
+test('GUARD 3 — shapeContactResponse retorna contato (anti-regressao)', function () {
+    $path = __DIR__ . '/../../../Modules/Crm/Http/Controllers/ClienteAutosaveController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("'contato' => \$contact->contato ?? null");
+});
+
+// ─── GUARD 4: Migration cria coluna contato ───────────────────────────────
+
+test('GUARD 4 — Migration 2026_05_27_180000 cria coluna contato VARCHAR(100) nullable', function () {
+    $path = __DIR__ . '/../../../database/migrations/2026_05_27_180000_add_contato_to_contacts.php';
+    expect($path)->toBeReadableFile();
+
+    $contents = file_get_contents($path);
+    expect($contents)
+        ->toContain("Schema::hasColumn('contacts', 'contato')")
+        ->toContain("string('contato', 100)")
+        ->toContain('->nullable()')
+        ->toContain("->after('cargo')");
+});
+
+// ─── GUARD 5: buildClienteIndexCustomers select + payload com contato ─────
+
+test('GUARD 5 — ContactController select + payload contato graceful', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("Schema::hasColumn('contacts', 'contato')")
+        ->toContain("'contacts.contato'")
+        ->toMatch("/\\\$payload\\['contato'\\]\\s*=/");
+});


### PR DESCRIPTION
## Summary
Daniela @ Martinho cadastrou Heinig Pre-Moldados em prod hoje e reportou: **Razão Social + CNPJ + Telefone principal NÃO SALVARAM** (badge "Salvo" mostrava verde mas nada persistia).

## Causa raiz
Frontend drawer envia chaves PT-BR (`nome`, `doc`, `tel`, `site`, `canal`) mas validators backend só aceitam canon EN (`name`, `tax_number`, `mobile`, `site_url`, `canal_preferido`). `validated()` filtra chaves desconhecidas → `Eloquent::update([])` silent no-op.

## Fix backend (back-compat — sem mexer frontend)
- `identificacao()` normaliza `nome`→`name`, `doc`→`tax_number`
- `contato()` normaliza `tel`→`mobile`, `site`→`site_url`, `canal`→`canal_preferido`
- Validator `identificacao` aceita `contato` (nova coluna)
- `shapeContactResponse` + `buildClienteIndexCustomers` retornam `contato`

## Migration
`2026_05_27_180000_add_contato_to_contacts.php` cria `contacts.contato VARCHAR(100) NULL after cargo`. Idempotente `hasColumn` guard.

## Test plan
- [x] Pest 5 GUARDs (21 assertions)
- [ ] Smoke pós-deploy: refazer cadastro Heinig em prod, conferir Razão/CNPJ/Tel/Contato responsável persistem

## Features pedidas Daniela (separar pra outro PR)
- Anexos (precisa `contact_attachments` table + storage)
- Endereço de entrega (UPOS já tem `shipping_*` 5 cols — falta UI nova tab drawer)
- Placas (Oficina vertical — não pertence ao drawer cliente; verificar)

Refs: ADR 0179 · session 2026-05-27

🤖 Generated with [Claude Code](https://claude.com/claude-code)