### PR TITLE
fix(atendimento/channels): Baileys descontinuado na UI (ADR 0202)

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php
@@ -735,20 +735,20 @@ class ChannelsController extends Controller
             [
                 'value' => Channel::TYPE_WHATSAPP_META,
                 'label' => 'WhatsApp Meta Cloud',
-                'description' => 'Oficial Meta. Aprovação 1-3 dias. Free 1k conv/mês.',
+                'description' => 'Oficial Meta. Embedded Signup v4 — 5-15 min via OAuth Facebook. Free 1k conv/mês. Zero risco ban.',
                 'enabled' => true,
             ],
             [
                 'value' => Channel::TYPE_WHATSAPP_ZAPI,
                 'label' => 'WhatsApp Z-API',
-                'description' => 'SaaS BR. 5 min scan QR. Risco ban Meta.',
+                'description' => 'SaaS BR opcional (legacy). 5 min scan QR. Risco ban Meta. Use só se já tem conta Z-API ativa.',
                 'enabled' => true,
             ],
             [
                 'value' => Channel::TYPE_WHATSAPP_BAILEYS,
                 'label' => 'WhatsApp Baileys',
-                'description' => 'Daemon Node próprio CT 100. Custo zero. Risco ban Meta.',
-                'enabled' => true,
+                'description' => 'DESCONTINUADO 2026-05-27 (ADR 0202). Use WhatsApp Meta Cloud.',
+                'enabled' => false,
             ],
             [
                 'value' => Channel::TYPE_INSTAGRAM,

--- a/resources/js/Pages/Atendimento/Channels/Index.tsx
+++ b/resources/js/Pages/Atendimento/Channels/Index.tsx
@@ -83,14 +83,14 @@ export default function ChannelsIndex({ channels, availableTypes }: Props) {
   const [qrError, setQrError] = useState<string | null>(null);
   const [qrLoading, setQrLoading] = useState(false);
 
-  // Form state
-  const [type, setType] = useState<string>('whatsapp_baileys');
+  // Form state — default Meta Cloud (ADR 0202 — Baileys descontinuado)
+  const [type, setType] = useState<string>('whatsapp_meta');
   const [label, setLabel] = useState('');
   const [config, setConfig] = useState<Record<string, string>>({});
   const [lgpdOk, setLgpdOk] = useState(false);
 
   function resetForm() {
-    setType('whatsapp_baileys');
+    setType('whatsapp_meta');
     setLabel('');
     setConfig({});
     setLgpdOk(false);


### PR DESCRIPTION
## Summary

Modal "Adicionar canal" em /atendimento/canais ainda mostrava **WhatsApp Baileys como opção ativa** mesmo após ADR 0202 marcar como `forbidden_driver`. Wagner reportou via screenshot 2026-05-27.

## Mudanças (2 arquivos · +7/-7 LOC)

**Backend** — `ChannelsController::availableTypesForUi()`:
- Baileys agora `enabled => false` + description "DESCONTINUADO 2026-05-27 (ADR 0202). Use WhatsApp Meta Cloud."
- Meta Cloud description atualizada: "Embedded Signup v4 — 5-15 min via OAuth Facebook" (era "1-3 dias")
- Z-API description: "opcional (legacy). Use só se já tem conta ativa."

**Frontend** — `Pages/Atendimento/Channels/Index.tsx`:
- Default `useState<string>('whatsapp_meta')` (era `whatsapp_baileys`)
- `resetForm()` aponta pro Meta também

## Contexto

Após Wagner aceitar ADR 0202 + spawn das Fases 0/1/2 + DELETE dos 2 channels Baileys órfãos (Jana ID 8 + Suporte ID 10, 45770 mensagens preservadas), Wagner notou via screenshot que o modal ainda permitia criar canais Baileys novos. Bug de UI desalinhado com `forbidden_drivers` config.

## Test plan

- [ ] CI verde
- [ ] Wagner abre `/atendimento/canais` → "Adicionar canal" → vê Baileys greyed out + texto "DESCONTINUADO 2026-05-27"
- [ ] Default selecionado é Meta Cloud (não mais Baileys)

Refs: ADR-0202 cleanup-ui-baileys
🤖 Generated with Claude Code (executando autônomo — Wagner "siga não pergunte" 2026-05-27)