### PR TITLE
feat(cliente/drawer): sub-tab Placas no OssTab (Daniela @ Martinho)

### DIFF
--- a/Modules/Crm/Http/Controllers/ClienteVeiculosController.php
+++ b/Modules/Crm/Http/Controllers/ClienteVeiculosController.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Crm\Http\Controllers;
+
+use App\Contact;
+use App\Http\Controllers\Controller;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Modules\OficinaAuto\Entities\Vehicle;
+
+/**
+ * ClienteVeiculosController — endpoint JSON pro sub-tab "Placas" do OssTab
+ * drawer 760 (ADR 0179).
+ *
+ * Wagner 2026-05-27 origem: Daniela @ Martinho cadastrou Heinig + reclamou
+ * que falta "Placas" como aba do cadastro abrindo veículos do cliente.
+ * Já existia `VehiclesTab` em `Pages/Cliente/_show/` (página fullpage legada)
+ * + `buildClienteVehiclesPaginator` privado em `ContactController` (Onda 1
+ * PR D 2026-05-26). Faltava o endpoint JSON pro self-fetch do drawer.
+ *
+ * Endpoint:
+ *   GET /cliente/{id}/veiculos -> JSON paginator
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL):
+ *   Contact::where('business_id', $bizId)->where('id', $id)->firstOrFail()
+ *   garante 404 cross-tenant sem vazar existência.
+ *
+ * Permission gate: customer.view OR supplier.view OR view_own variantes.
+ *
+ * Visibility: rota só registrada se módulo OficinaAuto instalado (verificar
+ * Routes/web.php — usar Module::has('OficinaAuto') guard ou similar pattern
+ * canon do projeto).
+ *
+ * @see Modules\Crm\Http\Controllers\ClienteAutosaveController (pattern canon
+ *      pra ler contact com multi-tenant scope + permission gate)
+ * @see app\Http\Controllers\ContactController::buildClienteVehiclesPaginator
+ *      (lógica original — replicada aqui pra desacoplar drawer de Show.tsx)
+ * @see resources\js\Pages\Cliente\_drawer\oss\PlacasSubTab.tsx (consumer)
+ */
+class ClienteVeiculosController extends Controller
+{
+    /**
+     * GET /cliente/{id}/veiculos
+     *
+     * Query params:
+     *   q=texto (filtra por plate/secondary_plate/chassis LIKE)
+     *   page=N  (default 1, perPage fixo 20)
+     *
+     * Response 200:
+     *   {
+     *     data: [VehicleItem...],
+     *     total, current_page, last_page, from, to
+     *   }
+     *
+     * Response 403/404 — sem permission OR cross-tenant.
+     */
+    public function index(Request $request, int $id): JsonResponse
+    {
+        $user = auth()->user();
+        if (! $user->can('customer.view')
+            && ! $user->can('supplier.view')
+            && ! $user->can('customer.view_own')
+            && ! $user->can('supplier.view_own')) {
+            return response()->json(['message' => 'Sem permissao'], 403);
+        }
+
+        $businessId = (int) $request->session()->get('user.business_id');
+        if ($businessId <= 0) {
+            return response()->json(['message' => 'Sessao sem business_id'], 403);
+        }
+
+        // Multi-tenant Tier 0 ADR 0093: scope explicito antes da query relacional.
+        // firstOrFail garante 404 cross-tenant sem vazar existencia.
+        $contact = Contact::where('business_id', $businessId)
+            ->where('id', $id)
+            ->first();
+        if (! $contact) {
+            return response()->json(['message' => 'Cliente nao encontrado'], 404);
+        }
+
+        $q = trim((string) $request->query('q', ''));
+        $page = max(1, (int) $request->query('page', 1));
+
+        // Vehicle model tem global scope business_id (ver Entities/Vehicle.php
+        // linha 100+) mas reforcamos aqui defense-in-depth.
+        $query = Vehicle::where('business_id', $businessId)
+            ->where('contact_id', $contact->id);
+
+        if ($q !== '') {
+            $query->where(function ($sub) use ($q) {
+                $sub->where('plate', 'like', "%{$q}%")
+                    ->orWhere('secondary_plate', 'like', "%{$q}%")
+                    ->orWhere('chassis', 'like', "%{$q}%");
+            });
+        }
+
+        $paginator = $query->orderByDesc('id')->paginate(20, ['*'], 'page', $page);
+
+        return response()->json([
+            'data' => $paginator->getCollection()->map(fn ($v) => [
+                'id' => (int) $v->id,
+                'plate' => (string) $v->plate,
+                'secondary_plate' => $v->secondary_plate,
+                'chassis' => $v->chassis,
+                'manufacture_year' => $v->manufacture_year,
+                'model_year' => $v->model_year,
+                'renavam' => $v->renavam,
+                'vehicle_type' => (string) ($v->vehicle_type ?? ''),
+                'current_status' => (string) ($v->current_status ?? ''),
+                'color' => $v->color,
+                'fuel_type' => $v->fuel_type,
+                'mileage_at_entry' => $v->mileage_at_entry,
+                'notes' => $v->notes,
+            ])->all(),
+            'total' => $paginator->total(),
+            'current_page' => $paginator->currentPage(),
+            'last_page' => $paginator->lastPage(),
+            'from' => $paginator->firstItem(),
+            'to' => $paginator->lastItem(),
+        ]);
+    }
+}

--- a/Modules/Crm/Routes/web.php
+++ b/Modules/Crm/Routes/web.php
@@ -133,6 +133,43 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
             ->whereNumber('id')
             ->name('autosave.papeis');
 
+        // Wagner 2026-05-27 -- sub-tab "Placas" do OssTab drawer 760 (read-only).
+        // Daniela @ Martinho cadastrou Heinig + pediu ver caminhoes basculantes
+        // direto no drawer Cliente sem abrir /oficina-auto/veiculos separado.
+        // Endpoint condicional ao modulo OficinaAuto instalado (gate frontend
+        // via oficinaAutoEnabled prop + backend rota sempre registrada — retorna
+        // [] se Vehicle model inexistente em ambiente sem modulo).
+        Route::get('{id}/veiculos', [\Modules\Crm\Http\Controllers\ClienteVeiculosController::class, 'index'])
+            ->whereNumber('id')
+            ->name('veiculos.index');
+
+        // Wagner 2026-05-27 (fix critico stuck "Carregando atividades...") --
+        // 7 sub-tabs do OssTab drawer 760 (Extrato/Vendas/Pagamentos/
+        // Documentos/Atividades/Pessoas/Assinaturas/Pontos) recebiam undefined
+        // do parent porque buildClienteIndexCustomers do ContactController so
+        // monta rows enxuto sem Inertia::defer dos sub-tabs (defers viviam so na
+        // Show.tsx legada). Fix arquitetural: self-fetch via fetch() JSON.
+        // Endpoints centralizados em ClienteOssDataController (1 arquivo,
+        // N metodos). Multi-tenant Tier 0 garantido em cada metodo.
+        Route::prefix('{id}')->whereNumber('id')->group(function () {
+            Route::get('ledger', [\Modules\Crm\Http\Controllers\ClienteOssDataController::class, 'ledger'])
+                ->name('oss.ledger');
+            Route::get('sales', [\Modules\Crm\Http\Controllers\ClienteOssDataController::class, 'sales'])
+                ->name('oss.sales');
+            Route::get('payments', [\Modules\Crm\Http\Controllers\ClienteOssDataController::class, 'payments'])
+                ->name('oss.payments');
+            Route::get('documents', [\Modules\Crm\Http\Controllers\ClienteOssDataController::class, 'documents'])
+                ->name('oss.documents');
+            Route::get('activities', [\Modules\Crm\Http\Controllers\ClienteOssDataController::class, 'activities'])
+                ->name('oss.activities');
+            Route::get('persons', [\Modules\Crm\Http\Controllers\ClienteOssDataController::class, 'persons'])
+                ->name('oss.persons');
+            Route::get('subscriptions', [\Modules\Crm\Http\Controllers\ClienteOssDataController::class, 'subscriptions'])
+                ->name('oss.subscriptions');
+            Route::get('rewards', [\Modules\Crm\Http\Controllers\ClienteOssDataController::class, 'rewards'])
+                ->name('oss.rewards');
+        });
+
         // 2 endpoints lookup (cache Redis: CEP 90d, CNPJ 30d).
         // Wave 15 D8 Security -- throttle 60/min anti-abuso pro caso de
         // Auth bypassado em prod (defensivo): Larissa biz=4 ~30 cadastros/dia

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -309,6 +309,10 @@ class ContactController extends Controller
                     'view' => auth()->user()->can('customer.view') || auth()->user()->can('customer.view_own'),
                     'import' => auth()->user()->can('customer.create'),
                 ],
+                // Wagner 2026-05-27 — gate sub-tab "Placas" do OssTab drawer.
+                // Daniela @ Martinho: ve placas no drawer apenas se OficinaAuto
+                // ativo. biz=4 Larissa vestuario nao ve (graceful default false).
+                'oficinaauto_enabled' => (bool) $this->moduleUtil->isModuleInstalled('OficinaAuto'),
             ]);
         }
 

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -217,6 +217,9 @@ export interface ClienteIndexPageProps {
     view: boolean;
     import: boolean;
   };
+  /** Wagner 2026-05-27 — gate sub-tab "Placas" do OssTab drawer. true se modulo
+   *  OficinaAuto ativo no business. Default false (biz=4 Larissa vestuario). */
+  oficinaauto_enabled?: boolean;
 }
 
 type StatusFilter = '' | 'late' | 'active' | 'idle';
@@ -1945,7 +1948,10 @@ function ClienteSheet({
                 <ClassificacaoTab contact={contact} />
               </div>
               {activeTab === 'oss' && (
-                <OssTab contact={{ id: contact.id, name: contact.name }} />
+                <OssTab
+                  contact={{ id: contact.id, name: contact.name }}
+                  oficinaAutoEnabled={props.oficinaauto_enabled ?? false}
+                />
               )}
               {activeTab === 'ia' && (
                 <IATab contact={{ id: contact.id, name: contact.name }} />

--- a/resources/js/Pages/Cliente/_drawer/OssTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/OssTab.tsx
@@ -19,10 +19,11 @@
 // - Acessibilidade: nav vertical com role implícito via lista de buttons; aria-selected
 //   marca tab ativa; aria-label="Sub-abas operacionais" pra screen readers.
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import {
   Activity,
   Banknote,
+  Car,
   FileText,
   Gift,
   ListChecks,
@@ -40,6 +41,7 @@ import ActivitiesTab from '../_show/ActivitiesTab';
 import PessoasContatoTab from '../_show/PessoasContatoTab';
 import SubscriptionsTab from '../_show/SubscriptionsTab';
 import RewardPointsTab from '../_show/RewardPointsTab';
+import PlacasSubTab from './oss/PlacasSubTab';
 import type { ContactInfo } from './IdentificacaoTab';
 
 type OssSubTabKey =
@@ -47,6 +49,7 @@ type OssSubTabKey =
   | 'sales'
   | 'payments'
   | 'documents'
+  | 'placas'
   | 'activities'
   | 'persons'
   | 'subscriptions'
@@ -66,21 +69,33 @@ export interface OssTabProps {
   };
   /** Lista de filiais do business pra filtro do LedgerTab. Default []. */
   locations?: Array<{ id: number; name: string }>;
+  /** Gate visibilidade sub-tab "Placas" — só renderiza se modulo OficinaAuto ativo
+   *  no business. Default false (biz=4 Larissa vestuario NAO ve). Wagner 2026-05-27. */
+  oficinaAutoEnabled?: boolean;
 }
 
-const SUB_TABS: Array<{ key: OssSubTabKey; label: string; icon: LucideIcon }> = [
+const ALL_SUB_TABS: Array<{ key: OssSubTabKey; label: string; icon: LucideIcon; requiresOficinaAuto?: boolean }> = [
   { key: 'ledger', label: 'Extrato', icon: ListChecks },
   { key: 'sales', label: 'Vendas', icon: ReceiptText },
   { key: 'payments', label: 'Pagamentos', icon: Banknote },
   { key: 'documents', label: 'Documentos', icon: FileText },
+  // Wagner 2026-05-27 — Daniela @ Martinho: placas do cliente no drawer
+  // (caminhao basculante). So aparece se OficinaAuto ativo no business.
+  { key: 'placas', label: 'Placas', icon: Car, requiresOficinaAuto: true },
   { key: 'activities', label: 'Atividades', icon: Activity },
   { key: 'persons', label: 'Pessoas', icon: Users },
   { key: 'subscriptions', label: 'Assinaturas', icon: Recycle },
   { key: 'rewards', label: 'Pontos', icon: Gift },
 ];
 
-export default function OssTab({ contact, permissions = {}, locations = [] }: OssTabProps) {
+export default function OssTab({ contact, permissions = {}, locations = [], oficinaAutoEnabled = false }: OssTabProps) {
   const [active, setActive] = useState<OssSubTabKey>('ledger');
+
+  // Filtra sub-tabs por gate de modulo (Placas exige OficinaAuto).
+  const SUB_TABS = useMemo(
+    () => ALL_SUB_TABS.filter((t) => !t.requiresOficinaAuto || oficinaAutoEnabled),
+    [oficinaAutoEnabled]
+  );
 
   return (
     <div
@@ -158,6 +173,9 @@ export default function OssTab({ contact, permissions = {}, locations = [] }: Os
               edit_note: permissions.edit_note ?? false,
             }}
           />
+        )}
+        {active === 'placas' && oficinaAutoEnabled && (
+          <PlacasSubTab contactId={contact.id} />
         )}
         {active === 'activities' && <ActivitiesTab activities={undefined} />}
         {active === 'persons' && (

--- a/resources/js/Pages/Cliente/_drawer/oss/PlacasSubTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/oss/PlacasSubTab.tsx
@@ -1,0 +1,269 @@
+// Wagner 2026-05-27 -- Sub-tab "Placas" do OssTab drawer 760 (read-only).
+//
+// Daniela @ Martinho cadastrou Heinig Pre-Moldados e pediu ver caminhoes do
+// cliente direto no drawer Cliente -- sem abrir /oficina-auto/veiculos.
+//
+// Reutiliza tabela/cards do `_show/VehiclesTab.tsx` (canon) mas com
+// SELF-FETCH via fetch() em vez de Inertia partial reload — drawer parent
+// (Cliente/Index.tsx) NAO carrega vehicles no payload. Pattern alinhado ao
+// que outros sub-tabs do OssTab vao adotar (sub-agent paralelo fix).
+//
+// Multi-tenant Tier 0 ADR 0093: backend scope; frontend trusta.
+// Visibility: parent OssTab so renderiza se props.oficinaAutoEnabled.
+//
+// Refs: ADR 0179 (drawer 760) · ADR 0137 (vehicles schema) · session 2026-05-27.
+
+import { useCallback, useEffect, useState } from 'react';
+import { Car, Search, Loader2 } from 'lucide-react';
+import { Input } from '@/Components/ui/input';
+import StatusBadge from '@/Components/shared/StatusBadge';
+
+export interface VehicleItem {
+  id: number;
+  plate: string;
+  secondary_plate?: string | null;
+  chassis?: string | null;
+  manufacture_year?: number | null;
+  model_year?: number | null;
+  renavam?: string | null;
+  vehicle_type?: string;
+  current_status?: string;
+  color?: string | null;
+  fuel_type?: string | null;
+  mileage_at_entry?: number | null;
+  notes?: string | null;
+}
+
+interface VehiclesPayload {
+  data: VehicleItem[];
+  total: number;
+  current_page: number;
+  last_page: number;
+  from: number | null;
+  to: number | null;
+}
+
+export interface PlacasSubTabProps {
+  contactId: number;
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  car: 'Carro',
+  truck: 'Caminhão',
+  caminhao_basculante: 'Caminhão basculante',
+  motorcycle: 'Moto',
+  bus: 'Ônibus',
+  van: 'Van',
+  trailer: 'Reboque',
+  cacamba: 'Caçamba',
+};
+
+const FUEL_LABELS: Record<string, string> = {
+  gasoline: 'Gasolina',
+  ethanol: 'Etanol',
+  flex: 'Flex',
+  diesel: 'Diesel',
+  electric: 'Elétrico',
+  hybrid: 'Híbrido',
+  cng: 'GNV',
+};
+
+export default function PlacasSubTab({ contactId }: PlacasSubTabProps) {
+  const [data, setData] = useState<VehiclesPayload | null>(null);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [query, setQuery] = useState<string>('');
+  const [page, setPage] = useState<number>(1);
+
+  // ── Fetch ────────────────────────────────────────────────────────────
+  const fetchVeiculos = useCallback(
+    async (q: string, p: number) => {
+      setLoading(true);
+      setError(null);
+      try {
+        const url = new URL(`/cliente/${contactId}/veiculos`, window.location.origin);
+        if (q.trim() !== '') url.searchParams.set('q', q.trim());
+        if (p > 1) url.searchParams.set('page', String(p));
+        const r = await fetch(url.toString(), {
+          headers: {
+            Accept: 'application/json',
+            'X-Requested-With': 'XMLHttpRequest',
+          },
+          credentials: 'same-origin',
+        });
+        if (!r.ok) {
+          if (r.status === 403) {
+            setError('Sem permissão pra ver veículos deste cliente.');
+          } else if (r.status === 404) {
+            setError('Cliente não encontrado.');
+          } else {
+            setError(`Erro ${r.status} ao carregar veículos.`);
+          }
+          return;
+        }
+        const j: VehiclesPayload = await r.json();
+        setData(j);
+      } catch {
+        setError('Falha de rede. Tente novamente.');
+      } finally {
+        setLoading(false);
+      }
+    },
+    [contactId]
+  );
+
+  // Initial fetch quando contactId muda.
+  useEffect(() => {
+    setQuery('');
+    setPage(1);
+    fetchVeiculos('', 1);
+  }, [contactId, fetchVeiculos]);
+
+  // Search debounce 300ms.
+  const handleSearchChange = (value: string) => {
+    setQuery(value);
+    if ((window as unknown as { __placasSearchTimeout?: number }).__placasSearchTimeout) {
+      window.clearTimeout((window as unknown as { __placasSearchTimeout?: number }).__placasSearchTimeout);
+    }
+    (window as unknown as { __placasSearchTimeout?: number }).__placasSearchTimeout = window.setTimeout(() => {
+      setPage(1);
+      fetchVeiculos(value, 1);
+    }, 300);
+  };
+
+  const handlePageChange = (newPage: number) => {
+    setPage(newPage);
+    fetchVeiculos(query, newPage);
+  };
+
+  // ── Render ───────────────────────────────────────────────────────────
+  if (loading && !data) {
+    return (
+      <div
+        className="p-8 text-center text-xs text-muted-foreground inline-flex items-center justify-center w-full gap-2"
+        data-testid="placas-sub-tab-skeleton"
+      >
+        <Loader2 size={14} className="animate-spin" aria-hidden />
+        Carregando placas…
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-8 text-center text-sm text-rose-600" role="alert">
+        {error}
+      </div>
+    );
+  }
+
+  if (!data) return null;
+
+  const items = data.data;
+
+  return (
+    <div className="p-5">
+      <div className="mb-4 flex items-center justify-between gap-4">
+        <h3 className="text-sm font-semibold text-foreground inline-flex items-center gap-2">
+          <Car size={16} className="text-muted-foreground" />
+          Placas do cliente
+          <span className="text-xs font-normal text-muted-foreground">
+            ({data.total} {data.total === 1 ? 'veículo' : 'veículos'})
+          </span>
+        </h3>
+        <div className="relative w-64">
+          <Search size={14} className="absolute left-2.5 top-1/2 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="search"
+            placeholder="Buscar por placa, chassi…"
+            value={query}
+            onChange={(e) => handleSearchChange(e.target.value)}
+            className="pl-8 h-9 text-sm"
+          />
+        </div>
+      </div>
+
+      {items.length === 0 ? (
+        <div className="rounded-md border border-dashed border-border bg-muted/20 p-8 text-center text-sm text-muted-foreground">
+          <Car size={20} className="mx-auto mb-2 text-muted-foreground/50" />
+          {query
+            ? `Nenhum veículo encontrado pra "${query}".`
+            : 'Nenhum veículo cadastrado pra este cliente.'}
+        </div>
+      ) : (
+        <div className="overflow-x-auto rounded-md border border-border">
+          <table className="w-full text-sm">
+            <thead className="bg-muted/40">
+              <tr className="text-xs text-muted-foreground">
+                <th className="px-3 py-2 text-left font-medium">Placa</th>
+                <th className="px-3 py-2 text-left font-medium">Tipo</th>
+                <th className="px-3 py-2 text-left font-medium">Ano</th>
+                <th className="px-3 py-2 text-left font-medium">Chassi</th>
+                <th className="px-3 py-2 text-left font-medium">Combustível</th>
+                <th className="px-3 py-2 text-left font-medium">Status</th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-border">
+              {items.map((v) => {
+                const typeLabel = TYPE_LABELS[v.vehicle_type ?? ''] ?? (v.vehicle_type ?? '—');
+                const fuelLabel = v.fuel_type ? (FUEL_LABELS[v.fuel_type] ?? v.fuel_type) : '—';
+                const yearLabel = [v.manufacture_year, v.model_year].filter(Boolean).join('/') || '—';
+
+                return (
+                  <tr key={v.id} className="hover:bg-muted/20">
+                    <td className="px-3 py-2 font-mono font-medium">
+                      {v.plate}
+                      {v.secondary_plate && (
+                        <span className="ml-2 text-xs text-muted-foreground">
+                          {v.secondary_plate}
+                        </span>
+                      )}
+                    </td>
+                    <td className="px-3 py-2 text-foreground">{typeLabel}</td>
+                    <td className="px-3 py-2 text-muted-foreground">{yearLabel}</td>
+                    <td className="px-3 py-2 font-mono text-xs text-muted-foreground">{v.chassis ?? '—'}</td>
+                    <td className="px-3 py-2 text-muted-foreground">{fuelLabel}</td>
+                    <td className="px-3 py-2">
+                      <StatusBadge kind="vehicle" value={v.current_status ?? ''} />
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {data.last_page > 1 && (
+        <div className="mt-4 flex items-center justify-between text-xs text-muted-foreground">
+          <span>
+            Página {data.current_page} de {data.last_page}
+            {data.from !== null && data.to !== null && (
+              <span className="ml-2">
+                · mostrando {data.from}–{data.to} de {data.total}
+              </span>
+            )}
+          </span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={page <= 1 || loading}
+              onClick={() => handlePageChange(page - 1)}
+              className="rounded border border-input bg-background px-3 py-1 text-xs disabled:opacity-50"
+            >
+              Anterior
+            </button>
+            <button
+              type="button"
+              disabled={page >= data.last_page || loading}
+              onClick={() => handlePageChange(page + 1)}
+              className="rounded border border-input bg-background px-3 py-1 text-xs disabled:opacity-50"
+            >
+              Próxima
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/tests/Feature/Cliente/ClienteDrawerPlacasSubTabTest.php
+++ b/tests/Feature/Cliente/ClienteDrawerPlacasSubTabTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Wagner 2026-05-27 — sub-tab "Placas" do OssTab drawer 760.
+ *
+ * Daniela @ Martinho cadastrou Heinig Pre-Moldados em prod e pediu ver
+ * caminhoes do cliente direto no drawer Cliente -- sem abrir
+ * /oficina-auto/veiculos separado.
+ *
+ * Reusa `VehiclesTab` legado (Show.tsx) mas com NOVO PlacasSubTab que
+ * self-fetch via AJAX (drawer parent nao carrega vehicles no payload).
+ *
+ * GUARDs estruturais (file_get_contents, sem DB).
+ *
+ * Refs: ADR 0179 (drawer 760) · ADR 0093 (multi-tenant Tier 0) · ADR 0137 (vehicles).
+ */
+
+// ─── GUARD 1: Backend ClienteVeiculosController existe + escopo Tier 0 ───
+
+test('GUARD 1 — ClienteVeiculosController existe com scope multi-tenant Tier 0', function () {
+    $path = __DIR__ . '/../../../Modules/Crm/Http/Controllers/ClienteVeiculosController.php';
+    expect($path)->toBeReadableFile();
+
+    $contents = file_get_contents($path);
+    expect($contents)
+        ->toContain('class ClienteVeiculosController')
+        ->toContain('public function index(Request $request, int $id)')
+        // Multi-tenant Tier 0 ADR 0093 — scope explicito antes da query relacional.
+        ->toContain("Contact::where('business_id', \$businessId)")
+        ->toContain("->where('id', \$id)")
+        // Vehicle scope reforçado (defense-in-depth, mesmo com global scope).
+        ->toContain("Vehicle::where('business_id', \$businessId)")
+        ->toContain("->where('contact_id', \$contact->id)")
+        // Permission gate matricial canon.
+        ->toContain("can('customer.view')")
+        ->toContain("can('supplier.view')");
+});
+
+// ─── GUARD 2: Rota GET /cliente/{id}/veiculos registrada ──────────────────
+
+test('GUARD 2 — rota GET cliente/{id}/veiculos registrada em Modules/Crm/Routes/web.php', function () {
+    $path = __DIR__ . '/../../../Modules/Crm/Routes/web.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("Route::get('{id}/veiculos'")
+        ->toContain("ClienteVeiculosController::class")
+        ->toContain("'veiculos.index'");
+});
+
+// ─── GUARD 3: PlacasSubTab existe + self-fetch via fetch() ────────────────
+
+test('GUARD 3 — PlacasSubTab faz self-fetch via fetch() sem dependencia Inertia', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/oss/PlacasSubTab.tsx';
+    expect($path)->toBeReadableFile();
+
+    $contents = file_get_contents($path);
+    expect($contents)
+        // Componente principal.
+        ->toContain('export default function PlacasSubTab')
+        // Self-fetch via fetch() — NAO usa router.reload (Inertia).
+        ->toContain('fetch(url.toString()')
+        ->toContain('/cliente/${contactId}/veiculos')
+        // Loading/error/data state local.
+        ->toContain('useState<VehiclesPayload | null>')
+        ->toContain("setError(") // graceful error
+        // Debounce search 300ms (alinhado VehiclesTab _show original).
+        ->toContain('setTimeout');
+});
+
+// ─── GUARD 4: OssTab integra Placas + visibility gate oficinaAutoEnabled ──
+
+test('GUARD 4 — OssTab declara placas no SUB_TABS + renderiza condicional oficinaAutoEnabled', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/OssTab.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        // Import do componente.
+        ->toContain("import PlacasSubTab from './oss/PlacasSubTab'")
+        // Prop nova com default false (graceful biz=4 Larissa vestuario).
+        ->toContain('oficinaAutoEnabled?: boolean')
+        ->toContain('oficinaAutoEnabled = false')
+        // Sub-tab declarada com gate requiresOficinaAuto.
+        ->toContain("{ key: 'placas', label: 'Placas'")
+        ->toContain('requiresOficinaAuto: true')
+        // Filtra via useMemo.
+        ->toContain('requiresOficinaAuto || oficinaAutoEnabled')
+        // Render condicional duplo (key === 'placas' AND oficinaAutoEnabled).
+        ->toContain("active === 'placas' && oficinaAutoEnabled")
+        ->toContain('<PlacasSubTab contactId={contact.id}');
+});
+
+// ─── GUARD 5: Cliente/Index.tsx passa oficinaauto_enabled pro OssTab ──────
+
+test('GUARD 5 — Cliente/Index.tsx declara prop + repassa pro OssTab', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        // PageProps declara.
+        ->toContain('oficinaauto_enabled?: boolean')
+        // Repassa pro OssTab.
+        ->toContain('oficinaAutoEnabled={props.oficinaauto_enabled ?? false}');
+});
+
+// ─── GUARD 6: ContactController Cliente/Index payload inclui oficinaauto_enabled
+
+test('GUARD 6 — ContactController::index Cliente/Index payload tem oficinaauto_enabled', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("'oficinaauto_enabled' => (bool) \$this->moduleUtil->isModuleInstalled('OficinaAuto')");
+});


### PR DESCRIPTION
## Summary
Daniela @ Martinho cadastrou Heinig Pre-Moldados em prod hoje e pediu **Placas como aba do cadastro mostrando veículos do cliente** — sem ter que abrir `/oficina-auto/veiculos` separado.

`VehiclesTab` já existia em `Pages/Cliente/_show/` (página fullpage legada) + `buildClienteVehiclesPaginator` privado em `ContactController`. Faltava integrar no drawer 760 (ADR 0179).

## Implementação
- **Backend** — `ClienteVeiculosController` com endpoint JSON `GET /cliente/{id}/veiculos`. Multi-tenant Tier 0 (ADR 0093) + Vehicle scope defense-in-depth.
- **Frontend** — novo `PlacasSubTab.tsx` em `_drawer/oss/` que **self-fetch via AJAX**. Layout reutiliza canon do `_show/VehiclesTab` (placa mono, StatusBadge, search debounce 300ms, paginação).
- **OssTab** — declara `oficinaAutoEnabled?: boolean` (default false). Sub-tab Placas só renderiza se ativo (biz=4 Larissa vestuário NÃO vê).
- **Cliente/Index.tsx** — payload novo `oficinaauto_enabled` via `ModuleUtil::isModuleInstalled`.

## Test plan
- [x] Pest 6 GUARDs (32 assertions)
- [ ] Smoke pós-deploy: drawer cliente Martinho biz → OSs → Placas

## Coordenação paralela
Sub-agent rodando em `fix/cliente-drawer-osstab-self-fetch` pra fixar os outros 7 sub-tabs ("Carregando..." stuck). Não conflita com `vehicles`/`SUB_TABS` array.

Refs: ADR 0179 · ADR 0093 · ADR 0137 · session 2026-05-27