### PR TITLE
chore(scope): declara ClienteVeiculosController em Crm/SCOPE.md

### DIFF
--- a/Modules/Crm/SCOPE.md
+++ b/Modules/Crm/SCOPE.md
@@ -8,6 +8,7 @@ contains:
   - "ClienteAutosaveController"    # Drawer 760 autosave draft (Wave A-G refinada #1382)
   - "ClienteIaController"          # Wave E IA cards (#1344 merged 2026-05-21)
   - "ClienteLookupController"      # Drawer 760 endpoint lookup CEP/CNPJ (Wave A-G refinada #1382)
+  - "ClienteVeiculosController"    # Drawer 760 sub-tab Placas (Daniela @ Martinho #1776 2026-05-27)
   - "ContactBookingController"
   - "ContactLoginController"
   - "CrmDashboardController"


### PR DESCRIPTION
Follow-up do #1776 -- scope-guard CI gate detectou drift. ClienteVeiculosController novo nao foi declarado em Modules/Crm/SCOPE.md.contains[].