### PR TITLE
fix(sells/v2): parser decimal pt-BR (BUG R$25k Larissa — venda errada em prod)

### DIFF
--- a/resources/js/Lib/numberPtBR.ts
+++ b/resources/js/Lib/numberPtBR.ts
@@ -1,0 +1,81 @@
+// Number parse/format pt-BR — paridade com `accounting.unformat` + `accounting.formatNumber`
+// usados em `public/js/functions.js` (`__read_number` + `__write_number`) do Blade legacy
+// UltimatePOS. Convenção: vírgula = decimal, ponto = milhar.
+//
+// Bug origem (Larissa @ Rota Livre biz=4 — 2026-05-27): input native `type="number"` +
+// `Number(e.target.value)` interpretava "25,00" como NaN ou "25.000" como vinte-e-cinco-mil.
+// Resultado: venda registrada R$ 25.000 quando a real era R$ 25.
+//
+// Estratégia (igual Blade legacy):
+//   - "25,00"           → 25      (vírgula = decimal)
+//   - "1.234,56"        → 1234.56 (ponto = milhar, vírgula = decimal)
+//   - "25.000,00"       → 25000   (idem)
+//   - "25.000"          → 25000   (sem vírgula, ponto = milhar)
+//   - "25"              → 25
+//   - ""                → 0
+//   - "abc"             → NaN
+//
+// NÃO trata locale en-US ("1,234.56" = 1234.56). Sistema é pt-BR canônico.
+
+const DEFAULT_PRECISION = 2;
+
+/**
+ * Parse string pt-BR em number. Tolera espaços e símbolo de moeda.
+ *
+ *   parseDecimalPtBR("25,00")     // 25
+ *   parseDecimalPtBR("1.234,56")  // 1234.56
+ *   parseDecimalPtBR("R$ 25,00")  // 25
+ *   parseDecimalPtBR("")          // 0
+ *   parseDecimalPtBR("abc")       // NaN
+ */
+export function parseDecimalPtBR(input: string | number | null | undefined): number {
+  if (typeof input === 'number') return input;
+  if (input == null) return 0;
+
+  const trimmed = String(input).trim();
+  if (trimmed === '') return 0;
+
+  // Remove símbolo moeda + espaços + qualquer caractere não-numérico exceto . , -
+  const cleaned = trimmed.replace(/[^0-9.,\-]/g, '');
+  if (cleaned === '' || cleaned === '-') return NaN;
+
+  // Detecta sinal
+  const negative = cleaned.startsWith('-');
+  const abs = negative ? cleaned.slice(1) : cleaned;
+
+  // Convenção pt-BR: vírgula = decimal, ponto = milhar.
+  // Se tem vírgula: tudo antes é parte inteira (com pontos como milhar), depois é decimal.
+  // Se NÃO tem vírgula: ponto é separador de milhar.
+  let normalized: string;
+  const commaIdx = abs.lastIndexOf(',');
+  if (commaIdx >= 0) {
+    const intPart = abs.slice(0, commaIdx).replace(/\./g, '');
+    const decPart = abs.slice(commaIdx + 1).replace(/\./g, ''); // garante sanity
+    normalized = `${intPart}.${decPart}`;
+  } else {
+    // Sem vírgula → ponto é milhar. Remove todos os pontos.
+    normalized = abs.replace(/\./g, '');
+  }
+
+  const n = Number(normalized);
+  if (Number.isNaN(n)) return NaN;
+  return negative ? -n : n;
+}
+
+/**
+ * Formata number como string pt-BR. Equivalente a `accounting.formatNumber(n, precision, '.', ',')`
+ * do Blade legacy.
+ *
+ *   formatDecimalPtBR(25)         // "25,00"
+ *   formatDecimalPtBR(1234.56)    // "1.234,56"
+ *   formatDecimalPtBR(25000)      // "25.000,00"
+ *   formatDecimalPtBR(25, 0)      // "25"
+ *   formatDecimalPtBR(NaN)        // "0,00"
+ */
+export function formatDecimalPtBR(value: number | null | undefined, precision: number = DEFAULT_PRECISION): string {
+  const n = typeof value === 'number' && Number.isFinite(value) ? value : 0;
+  return n.toLocaleString('pt-BR', {
+    minimumFractionDigits: precision,
+    maximumFractionDigits: precision,
+  });
+}

--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -30,6 +30,7 @@ import ProductSearchAutocomplete, {
 } from './_components/ProductSearchAutocomplete';
 import CustomerSearchAutocomplete from './_components/CustomerSearchAutocomplete';
 import PaymentRow, { type Payment } from './_components/PaymentRow';
+import NumericInputPtBR from './_components/NumericInputPtBR';
 import { dropdownEntries } from './_components/dropdownEntries';
 import {
   Select,
@@ -1023,48 +1024,31 @@ export default function SellsCreate(props: SellsCreatePageProps) {
                           <div className="text-xs text-muted-foreground">SKU {p.sku}</div>
                         </td>
                         <td className="px-3 py-2">
-                          <Input
-                            type="number"
-                            inputMode="decimal"
-                            min="0"
-                            step="1"
+                          {/* NumericInputPtBR — paridade Blade __read_number/__write_number.
+                              Bug origem R$25k Larissa (2026-05-27): type=number+Number(...) virou parser pt-BR-safe. */}
+                          <NumericInputPtBR
                             value={p.quantity}
-                            onChange={(e) =>
-                              handleProductChange(idx, 'quantity', Number(e.target.value))
-                            }
+                            onChange={(n) => handleProductChange(idx, 'quantity', n)}
+                            precision={0}
                             aria-label={`Quantidade de ${p.name}`}
-                            className="h-8"
+                            className="h-8 tabular-nums"
                           />
                         </td>
                         <td className="px-3 py-2">
-                          <Input
-                            type="number"
-                            inputMode="decimal"
-                            min="0"
-                            step="0.01"
+                          <NumericInputPtBR
                             value={p.unit_price}
-                            onChange={(e) =>
-                              handleProductChange(
-                                idx,
-                                'unit_price',
-                                Number(e.target.value),
-                              )
-                            }
+                            onChange={(n) => handleProductChange(idx, 'unit_price', n)}
+                            precision={2}
                             disabled={!props.permissions.editPrice}
                             aria-label={`Preço unitário de ${p.name}`}
                             className="h-8 tabular-nums"
                           />
                         </td>
                         <td className="px-3 py-2">
-                          <Input
-                            type="number"
-                            inputMode="decimal"
-                            min="0"
-                            step="0.01"
+                          <NumericInputPtBR
                             value={p.discount}
-                            onChange={(e) =>
-                              handleProductChange(idx, 'discount', Number(e.target.value))
-                            }
+                            onChange={(n) => handleProductChange(idx, 'discount', n)}
+                            precision={2}
                             disabled={!props.permissions.editDiscount}
                             aria-label={`Desconto em ${p.name}`}
                             className="h-8 tabular-nums"

--- a/resources/js/Pages/Sells/_components/NumericInputPtBR.tsx
+++ b/resources/js/Pages/Sells/_components/NumericInputPtBR.tsx
@@ -1,0 +1,88 @@
+// NumericInputPtBR — input numérico pt-BR safe.
+//
+// Origem (Bug R$25k Larissa 2026-05-27):
+//   <Input type="number" value={p.unit_price} onChange={Number(e.target.value)}> permitia
+//   "25,00" virar NaN OU "25.000" virar 25000 dependendo do locale do navegador. Larissa
+//   digitou R$ 25 e o sistema gravou R$ 25.000 em produção.
+//
+// Solução (paridade Blade legacy pos.js `__read_number`/`__write_number`):
+//   - type="text" (não "number" — evita quirks de locale do navegador)
+//   - inputMode="decimal" (teclado numérico mobile)
+//   - Display formatado pt-BR quando NÃO focado
+//   - Durante edição: aceita raw com vírgula/ponto, parse pt-BR
+//   - onBlur: reformata display + emit value canônico
+//
+// State interno (string) ≠ state externo (number). Reconcilia em useEffect quando
+// value externo muda sem foco.
+
+import { useEffect, useRef, useState, forwardRef } from 'react';
+import { Input } from '@/Components/ui/input';
+import { parseDecimalPtBR, formatDecimalPtBR } from '@/Lib/numberPtBR';
+
+interface Props extends Omit<React.ComponentProps<typeof Input>, 'value' | 'onChange' | 'type'> {
+  value: number;
+  onChange: (n: number) => void;
+  precision?: number;
+}
+
+const NumericInputPtBR = forwardRef<HTMLInputElement, Props>(function NumericInputPtBR(
+  { value, onChange, precision = 2, onFocus, onBlur, ...rest },
+  ref,
+) {
+  const [text, setText] = useState<string>(() => formatDecimalPtBR(value, precision));
+  const focusedRef = useRef(false);
+
+  // Sincroniza display quando value externo muda E não está focado
+  // (ex: ao selecionar produto, unit_price vem de selling_price).
+  useEffect(() => {
+    if (!focusedRef.current) {
+      setText(formatDecimalPtBR(value, precision));
+    }
+  }, [value, precision]);
+
+  return (
+    <Input
+      ref={ref}
+      type="text"
+      inputMode="decimal"
+      autoComplete="off"
+      // Permite digitar dígitos, vírgula, ponto, hífen (negativo) — paridade Blade.
+      pattern="[0-9.,\-]*"
+      value={text}
+      onFocus={(e) => {
+        focusedRef.current = true;
+        // Mostra valor "editável" sem separador de milhar pra facilitar edição.
+        // Mas mantém vírgula decimal se houver.
+        const raw = value === 0 ? '' : String(value).replace('.', ',');
+        setText(raw);
+        // Seleciona pra facilitar overwrite (UX padrão input numérico).
+        e.currentTarget.select();
+        onFocus?.(e);
+      }}
+      onChange={(e) => {
+        const v = e.target.value;
+        setText(v);
+        const parsed = parseDecimalPtBR(v);
+        if (!Number.isNaN(parsed)) {
+          onChange(parsed);
+        }
+      }}
+      onBlur={(e) => {
+        focusedRef.current = false;
+        const parsed = parseDecimalPtBR(text);
+        if (Number.isNaN(parsed)) {
+          // Inválido — volta pro último value canônico.
+          setText(formatDecimalPtBR(value, precision));
+        } else {
+          // Reformata display + emite.
+          setText(formatDecimalPtBR(parsed, precision));
+          onChange(parsed);
+        }
+        onBlur?.(e);
+      }}
+      {...rest}
+    />
+  );
+});
+
+export default NumericInputPtBR;

--- a/tests/Feature/Sells/SellsCreatePageTest.php
+++ b/tests/Feature/Sells/SellsCreatePageTest.php
@@ -302,3 +302,72 @@ it('ProductSearchAutocomplete NÃO altera DEBOUNCE_MS=250 (PR #1729 fixou — n�
     );
     expect($componentSource)->toContain('DEBOUNCE_MS = 250');
 });
+
+// R7 — Bug R$25k Larissa (2026-05-27): input `type=number` + `Number(e.target.value)`
+// não lidava com vírgula decimal pt-BR. Substituído por NumericInputPtBR + parseDecimalPtBR
+// (paridade Blade __read_number/__write_number — accounting.unformat pt-BR).
+
+it('numberPtBR helper existe em Lib (utility shared)', function () {
+    expect(file_exists(base_path('resources/js/Lib/numberPtBR.ts')))->toBeTrue();
+});
+
+it('parseDecimalPtBR converte string pt-BR em number (paridade Blade __read_number)', function () {
+    $source = file_get_contents(base_path('resources/js/Lib/numberPtBR.ts'));
+    // Função exportada com nome canônico
+    expect($source)->toContain('export function parseDecimalPtBR');
+    // Convenção pt-BR: vírgula = decimal, ponto = milhar
+    expect($source)->toContain('vírgula = decimal');
+    // Detecta vírgula como decimal (não usa parseFloat ingênuo)
+    expect($source)->toContain('lastIndexOf');
+    // Remove pontos como milhar quando há vírgula decimal
+    expect($source)->toMatch('/replace\(\/\\\\\.\/g/');
+});
+
+it('formatDecimalPtBR formata number em pt-BR (paridade Blade __write_number)', function () {
+    $source = file_get_contents(base_path('resources/js/Lib/numberPtBR.ts'));
+    expect($source)->toContain('export function formatDecimalPtBR');
+    expect($source)->toContain("toLocaleString('pt-BR'");
+    expect($source)->toContain('minimumFractionDigits');
+});
+
+it('NumericInputPtBR componente existe em Sells/_components', function () {
+    expect(file_exists(base_path('resources/js/Pages/Sells/_components/NumericInputPtBR.tsx')))
+        ->toBeTrue();
+});
+
+it('NumericInputPtBR usa type=text NÃO type=number (evita quirks locale navegador)', function () {
+    $source = file_get_contents(
+        base_path('resources/js/Pages/Sells/_components/NumericInputPtBR.tsx'),
+    );
+    expect($source)->toContain('type="text"');
+    // type=number é o BUG — não deve aparecer no input rendered (strip comments).
+    $codeOnly = preg_replace('#//[^\n]*#', '', $source);
+    expect($codeOnly)->not->toMatch('/type="number"/');
+    // inputMode="decimal" preservado pra teclado numérico mobile
+    expect($source)->toContain('inputMode="decimal"');
+});
+
+it('NumericInputPtBR usa parseDecimalPtBR do Lib (não Number(e.target.value))', function () {
+    $source = file_get_contents(
+        base_path('resources/js/Pages/Sells/_components/NumericInputPtBR.tsx'),
+    );
+    expect($source)->toContain("from '@/Lib/numberPtBR'");
+    expect($source)->toContain('parseDecimalPtBR');
+    expect($source)->toContain('formatDecimalPtBR');
+    // ANTIPADRÃO: NÃO usa Number(e.target.value) — bug origem R$25k.
+    // Regex strip comments primeiro pra ignorar menções históricas.
+    $codeOnly = preg_replace('#//[^\n]*#', '', $source);
+    expect($codeOnly)->not->toMatch('/Number\(e\.target\.value\)/');
+});
+
+it('Sells/Create.tsx usa NumericInputPtBR para quantity/unit_price/discount (anti-regressão R$25k)', function () {
+    $source = file_get_contents(base_path('resources/js/Pages/Sells/Create.tsx'));
+    expect($source)->toContain("from './_components/NumericInputPtBR'");
+    // 3 inputs convertidos
+    expect(substr_count($source, '<NumericInputPtBR'))->toBeGreaterThanOrEqual(3);
+    // Os antigos `<Input type="number"` nesses 3 lugares NÃO devem mais existir
+    // pra qty/unit_price/discount (PaymentRow e outros podem manter durante migração).
+    expect($source)->not->toMatch("/<Input[^>]*type=\"number\"[^>]*value=\\{p\\.unit_price\\}/");
+    expect($source)->not->toMatch("/<Input[^>]*type=\"number\"[^>]*value=\\{p\\.quantity\\}/");
+    expect($source)->not->toMatch("/<Input[^>]*type=\"number\"[^>]*value=\\{p\\.discount\\}/");
+});


### PR DESCRIPTION
## Bug crítico — venda R$ 25.000 errada em produção

**Wagner @ Daniela viu hoje (2026-05-27):** Larissa @ Rota Livre digitou R$ 25 no preço unitário e o sistema gravou **R$ 25.000** em produção. Venda real era R$ 25.

### Causa raiz

[Sells/Create.tsx:1041-1052](resources/js/Pages/Sells/Create.tsx#L1041-L1052) usava `<Input type="number">` + `Number(e.target.value)` pros 3 inputs (qty/unit_price/discount). `Number('25,00')` em JS retorna `NaN`. Em locale do navegador pt-BR, `type="number"` REJEITA vírgula visualmente mas a string interna pode ser "25" ou "2500" dependendo do browser. Combinado com a UX, Larissa não percebia que o que ela digitou virou outra coisa.

Blade legacy (UltimatePOS) usava [`__read_number` / `__write_number`](public/js/functions.js#L182-L198) — wrapper de `accounting.unformat(value, decimal=',')` que entende **vírgula = decimal, ponto = milhar** (padrão pt-BR).

### Comportamento agora vs antes

| Input | Antes (bug) | Agora (fix) |
|---|---|---|
| `25,00` | NaN / 2500 / 25 (depende browser) | **25** |
| `1.234,56` | NaN / 1234 | **1234.56** |
| `25.000,00` (vinte e cinco mil) | descartado parcial | **25000** |
| `25.000` (sem decimal, pensando milhar) | 25 (JS interpreta como decimal) | **25000** |
| `25` | 25 | 25 |
| (vazio) | NaN | 0 |

## Mudanças

| Arquivo | LOC | O que |
|---|---|---|
| `resources/js/Lib/numberPtBR.ts` (novo) | +81 | Helper utility `parseDecimalPtBR` + `formatDecimalPtBR` (paridade Blade) |
| `resources/js/Pages/Sells/_components/NumericInputPtBR.tsx` (novo) | +88 | Componente: `type="text"` + `inputMode="decimal"` + parse pt-BR + reformato no blur. Sincroniza state externo (number) ↔ display (string) sem React warnings |
| [Sells/Create.tsx](resources/js/Pages/Sells/Create.tsx) | +13 / -29 | 3 inputs convertidos (qty, unit_price, discount) |
| [SellsCreatePageTest.php](tests/Feature/Sells/SellsCreatePageTest.php) | +69 | 7 Pest tests anti-regressão |

**Total:** +251 / -29 LOC. Dentro do limite 300 LOC do commit-discipline.

## Backend / multi-tenant

- ✅ **Sem mudança backend** (Tier 0 ADR 0093 intacto)
- ✅ **Sem alteração schema**
- ✅ **Multi-tenant scope preservado** (componente é puramente front)

## PaymentRow.amount fica como follow-up

`PaymentRow.tsx` também tem `type="number"` no campo `amount` — mesmo bug latente. **NÃO incluído nesta PR** (1 PR = 1 intent). Recomendado abrir PR separado pra converter PaymentRow após este mergear + smoke validar.

## Test plan

- [x] Pest: 7/7 R7 tests passando (helper + componente + Create.tsx wiring)
- [x] TypeScript: 0 erros novos
- [ ] **Smoke staging Hostinger biz=4 PENDENTE pós-merge:** Wagner valida com Larissa cenário real:
  - Digitar `25,00` → ver R$ 25,00 (não R$ 25.000) no subtotal
  - Digitar `1.234,56` → ver R$ 1.234,56
  - Digitar `25` → ver R$ 25,00
  - Tab/blur reformata display pra `25,00`
  - Fechar venda → backend recebe `25.00` (number canônico)

## Refs

- US-SELL-005 (autocomplete + tabela editável produtos)
- ADR 0104 (MWART canônico §F3 frontend incremental)
- ADR 0093 (multi-tenant Tier 0 — preservado)
- `public/js/functions.js:182` `__read_number` (paridade Blade)
- `public/js/functions.js:187` `__write_number` (paridade Blade)
- Bug evidência: venda R$ 25.000 prod 2026-05-27 (deveria R$ 25)
- Coexiste com PR #1778 (Dor 1 variação) — ambos atacam regressões V2 pra Larissa

🤖 Generated with [Claude Code](https://claude.com/claude-code)