### PR TITLE
feat(whatsapp): whatsmeow Go driver (substituto Baileys, ADR 0204)

### DIFF
--- a/Modules/Whatsapp/Config/config.php
+++ b/Modules/Whatsapp/Config/config.php
@@ -52,6 +52,27 @@ return [
 
     // Seção 'baileys' REMOVIDA 2026-05-27 (ADR 0202). Daemon CT 100 descomissionado.
 
+    /*
+     * ADR 0204 (2026-05-27) — whatsmeow Go daemon (substituto Baileys).
+     *
+     * Daemon WuzAPI (asternic/wuzapi wrapping tulir/whatsmeow) rodando em
+     * CT 100 com Traefik IP whitelist Hostinger. Veja runbook:
+     * memory/requisitos/Whatsapp/runbooks/whatsmeow-daemon-deploy-ct100.md
+     *
+     * Driver é OPCIONAL — meta_cloud continua default universal. Wagner ativa
+     * channel por channel via UI (type=whatsapp_whatsmeow) com LGPD ack.
+     *
+     * Risco ban Meta = igual Baileys (whatsmeow issue #810). Trade-off técnico
+     * aceito: estabilidade long-running + footprint -37% RAM. Fallback
+     * obrigatório Meta Cloud preservado (gating duro FormRequest).
+     */
+    'whatsmeow' => [
+        'daemon_url' => env('WHATSMEOW_DAEMON_URL', 'https://whatsapp-whatsmeow.oimpresso.com'),
+        'api_key' => env('WHATSMEOW_API_KEY'),
+        'hmac_secret' => env('WHATSMEOW_HMAC_SECRET'),
+        'request_timeout' => (int) env('WHATSMEOW_TIMEOUT', 15),
+    ],
+
     'health_check' => [
         'interval_seconds' => env('WHATSAPP_HEALTH_INTERVAL', 21600), // 6h
         'consecutive_failures_to_degrade' => 5,

--- a/Modules/Whatsapp/Entities/Channel.php
+++ b/Modules/Whatsapp/Entities/Channel.php
@@ -70,6 +70,16 @@ class Channel extends Model
     public const TYPE_WHATSAPP_META = 'whatsapp_meta';
     public const TYPE_WHATSAPP_ZAPI = 'whatsapp_zapi';
     public const TYPE_WHATSAPP_BAILEYS = 'whatsapp_baileys';
+    /**
+     * ADR 0204 (2026-05-27) — substituto não-oficial Baileys via daemon Go
+     * WuzAPI wrapping whatsmeow. Mesmo modelo (scan QR, custo zero, risco
+     * ban Meta) com estabilidade técnica melhor (sessões long-running estáveis
+     * + footprint -37% RAM).
+     *
+     * Baileys continua forbidden (ADR 0202) — deletado integral. whatsmeow
+     * é caminho novo, NÃO refactor Baileys.
+     */
+    public const TYPE_WHATSAPP_WHATSMEOW = 'whatsapp_whatsmeow';
     public const TYPE_INSTAGRAM = 'instagram';
     public const TYPE_MESSENGER = 'messenger';
     public const TYPE_EMAIL_IMAP = 'email_imap';
@@ -80,6 +90,7 @@ class Channel extends Model
         self::TYPE_WHATSAPP_META,
         self::TYPE_WHATSAPP_ZAPI,
         self::TYPE_WHATSAPP_BAILEYS,
+        self::TYPE_WHATSAPP_WHATSMEOW,
         self::TYPE_INSTAGRAM,
         self::TYPE_MESSENGER,
         self::TYPE_EMAIL_IMAP,
@@ -131,7 +142,31 @@ class Channel extends Model
             self::TYPE_WHATSAPP_META,
             self::TYPE_WHATSAPP_ZAPI,
             self::TYPE_WHATSAPP_BAILEYS,
+            self::TYPE_WHATSAPP_WHATSMEOW,
         ], true);
+    }
+
+    /**
+     * Convenção canônica do "user name" no daemon WuzAPI CT 100:
+     * `ch-{channel_uuid sem hífens}`.
+     *
+     * Espelha o pattern Baileys (`baileysInstanceId()`) — mantém legibilidade
+     * cross-driver: 1 channel → 1 instance/user com ID determinístico.
+     *
+     * Retorna null quando `channel_uuid` ausente OU type ≠ whatsmeow.
+     *
+     * @see Modules/Whatsapp/Services/Drivers/WhatsmeowDriver.php
+     * @see ADR 0204
+     */
+    public function whatsmeowUserName(): ?string
+    {
+        if ($this->type !== self::TYPE_WHATSAPP_WHATSMEOW) {
+            return null;
+        }
+        if (empty($this->channel_uuid)) {
+            return null;
+        }
+        return 'ch-' . str_replace('-', '', (string) $this->channel_uuid);
     }
 
     /**

--- a/Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php
@@ -82,8 +82,8 @@ class ChannelsController extends Controller
         $channel->handles_outbound_default = (bool) ($data['handles_outbound_default'] ?? false);
         $channel->bot_enabled = (bool) ($data['bot_enabled'] ?? false);
 
-        // LGPD obrigatório pra Baileys
-        if ($data['type'] === Channel::TYPE_WHATSAPP_BAILEYS) {
+        // LGPD obrigatório pra TODOS drivers não-oficiais (Baileys + whatsmeow ADR 0204).
+        if (in_array($data['type'], [Channel::TYPE_WHATSAPP_BAILEYS, Channel::TYPE_WHATSAPP_WHATSMEOW], true)) {
             $channel->lgpd_acknowledged_at = now();
             $channel->lgpd_acknowledged_by_user_id = $userId;
         }
@@ -91,6 +91,7 @@ class ChannelsController extends Controller
         // Display identifier inferido per-type pra UI mostrar
         $channel->display_identifier = match ($data['type']) {
             Channel::TYPE_WHATSAPP_BAILEYS => $data['config']['baileys_phone_e164'] ?? null,
+            Channel::TYPE_WHATSAPP_WHATSMEOW => $data['config']['whatsmeow_phone_e164'] ?? null,
             Channel::TYPE_WHATSAPP_ZAPI => $data['config']['zapi_instance_id'] ?? null,
             Channel::TYPE_WHATSAPP_META => $data['config']['meta_phone_number_id'] ?? null,
             default => null,
@@ -367,10 +368,17 @@ class ChannelsController extends Controller
             ->where('business_id', $businessId)
             ->findOrFail($id);
 
+        // ADR 0204 (2026-05-27): branch separado pra whatsmeow.
+        // Baileys foi descontinuado (ADR 0202) mas o código de connect persiste
+        // pra arqueologia + migração ainda-em-curso. whatsmeow tem fluxo próprio.
+        if ($channel->type === Channel::TYPE_WHATSAPP_WHATSMEOW) {
+            return $this->connectWhatsmeow($channel);
+        }
+
         if ($channel->type !== Channel::TYPE_WHATSAPP_BAILEYS) {
             return response()->json([
                 'ok' => false,
-                'error' => "Connect rápido só implementado pra Baileys nesta fase. Tipo atual: {$channel->type}",
+                'error' => "Connect rápido só implementado pra Baileys/Whatsmeow nesta fase. Tipo atual: {$channel->type}",
             ], 422);
         }
 
@@ -549,6 +557,75 @@ class ChannelsController extends Controller
     }
 
     /**
+     * Conecta channel `whatsapp_whatsmeow` ao daemon Go WuzAPI CT 100 (ADR 0204).
+     *
+     * Fluxo:
+     *  1. Se channel ainda não tem `whatsmeow_user_token` → provisiona via
+     *     POST /admin/users no daemon (gera token criptograficamente forte +
+     *     configura webhook com {business_uuid} pra multi-tenant)
+     *  2. POST /session/connect (inicia sessão WhatsApp Web no daemon)
+     *  3. GET /session/qr (retorna QR base64 pra UI render no Dialog)
+     *  4. Frontend polls /status até state=connected (webhook Connected dispara)
+     */
+    protected function connectWhatsmeow(Channel $channel): JsonResponse
+    {
+        try {
+            // Resolve business pra obter business_uuid (webhook URL)
+            $business = \DB::table('business')
+                ->where('id', $channel->business_id)
+                ->first();
+
+            if ($business === null || empty($business->uuid)) {
+                return response()->json([
+                    'ok' => false,
+                    'error' => 'Business sem uuid — não consigo montar webhook URL multi-tenant.',
+                ], 500);
+            }
+
+            $driver = app(\Modules\Whatsapp\Services\Drivers\WhatsmeowDriver::class);
+            $cfg = $channel->config_json ?? [];
+
+            // Provisiona sessão se ainda não foi
+            if (empty($cfg['whatsmeow_user_token'])) {
+                $provision = $driver->provisionSession($channel, (string) $business->uuid);
+
+                $cfg['whatsmeow_user_token'] = $provision['token'];
+                $cfg['whatsmeow_user_name'] = $provision['name'];
+                $cfg['whatsmeow_webhook_url'] = $provision['webhook'];
+                $channel->config_json = $cfg;
+                $channel->save();
+            }
+
+            // Inicia sessão + retorna QR
+            $result = $driver->connect($channel);
+
+            $channel->status = 'setup';
+            $channel->channel_health = 'never_checked';
+            $channel->save();
+
+            return response()->json([
+                'ok' => true,
+                'qr_png_data_url' => $result['qr_base64']
+                    ? 'data:image/png;base64,' . $result['qr_base64']
+                    : null,
+                'state' => $result['state'],
+                'message' => $result['qr_base64']
+                    ? 'Escaneie o QR no WhatsApp → Dispositivos vinculados.'
+                    : 'Daemon respondeu sem QR. State: ' . ($result['state'] ?? 'desconhecido'),
+            ]);
+        } catch (\Throwable $e) {
+            Log::error('whatsmeow.connect_exception', [
+                'channel_id' => $channel->id,
+                'exception' => $e->getMessage(),
+            ]);
+            return response()->json([
+                'ok' => false,
+                'error' => 'Falha ao falar com daemon whatsmeow: ' . $e->getMessage(),
+            ], 502);
+        }
+    }
+
+    /**
      * Lê status atual da instance no daemon (poll do frontend pra detectar
      * connected após scan QR).
      */
@@ -559,8 +636,13 @@ class ChannelsController extends Controller
             ->where('business_id', $businessId)
             ->findOrFail($id);
 
+        // ADR 0204 — branch whatsmeow (status do daemon Go WuzAPI)
+        if ($channel->type === Channel::TYPE_WHATSAPP_WHATSMEOW) {
+            return $this->statusWhatsmeow($channel);
+        }
+
         if ($channel->type !== Channel::TYPE_WHATSAPP_BAILEYS) {
-            return response()->json(['state' => null, 'reason' => 'only_baileys']);
+            return response()->json(['state' => null, 'reason' => 'only_baileys_whatsmeow']);
         }
 
         $daemonUrl = config('whatsapp.baileys.daemon_url');
@@ -582,6 +664,63 @@ class ChannelsController extends Controller
             $state = $snap['state'] ?? 'unknown';
 
             // Atualiza channel.status quando conectado
+            if ($state === 'connected' && $channel->status !== 'active') {
+                $channel->status = 'active';
+                $channel->channel_health = 'healthy';
+                $channel->last_health_check_at = now();
+                $channel->save();
+            }
+
+            return response()->json([
+                'state' => $state,
+                'qr_available' => $state === 'qr_required',
+            ]);
+        } catch (\Throwable $e) {
+            return response()->json([
+                'state' => 'error',
+                'error' => $e->getMessage(),
+            ], 502);
+        }
+    }
+
+    /**
+     * ADR 0204 — status pro daemon Go WuzAPI (channel.type=whatsapp_whatsmeow).
+     *
+     * WuzAPI /session/status retorna `{ Connected: bool, LoggedIn: bool, Jid: string }`.
+     * Mapeia pra states canon: connected / qr_required / disconnected / error.
+     */
+    protected function statusWhatsmeow(Channel $channel): JsonResponse
+    {
+        $cfg = $channel->config_json ?? [];
+        $userToken = $cfg['whatsmeow_user_token'] ?? null;
+
+        if (empty($userToken)) {
+            return response()->json(['state' => 'never_connected', 'qr_available' => false]);
+        }
+
+        $daemonUrl = config('whatsapp.whatsmeow.daemon_url');
+        $timeout = (int) config('whatsapp.whatsmeow.request_timeout', 10);
+
+        try {
+            $r = Http::withHeaders(['Token' => $userToken])
+                ->withoutVerifying() // FIXME: cert LE pendente CT 100 dev
+                ->timeout($timeout)
+                ->get(rtrim((string) $daemonUrl, '/') . '/session/status');
+
+            if (! $r->successful()) {
+                return response()->json(['state' => 'unknown', 'http' => $r->status()]);
+            }
+
+            $snap = $r->json();
+            $connected = (bool) ($snap['Connected'] ?? false);
+            $loggedIn = (bool) ($snap['LoggedIn'] ?? false);
+
+            $state = match (true) {
+                $connected && $loggedIn => 'connected',
+                $connected && ! $loggedIn => 'qr_required',
+                default => 'disconnected',
+            };
+
             if ($state === 'connected' && $channel->status !== 'active') {
                 $channel->status = 'active';
                 $channel->channel_health = 'healthy';
@@ -713,7 +852,10 @@ class ChannelsController extends Controller
             'has_zapi_credentials' => ! empty($cfg['zapi_instance_id']) && ! empty($cfg['zapi_instance_token']),
             'has_meta_credentials' => ! empty($cfg['meta_phone_number_id']) && ! empty($cfg['meta_access_token']),
             'has_baileys_credentials' => ! empty($cfg['baileys_phone_e164']),
+            // ADR 0204 — whatsmeow flag: tem creds quando user_token foi gerado pelo provision
+            'has_whatsmeow_credentials' => ! empty($cfg['whatsmeow_phone_e164']) && ! empty($cfg['whatsmeow_user_token']),
             'baileys_phone_e164' => $cfg['baileys_phone_e164'] ?? null, // não-secreto
+            'whatsmeow_phone_e164' => $cfg['whatsmeow_phone_e164'] ?? null, // não-secreto
             'zapi_instance_id' => $cfg['zapi_instance_id'] ?? null,     // não-secreto
             'meta_phone_number_id' => $cfg['meta_phone_number_id'] ?? null, // não-secreto
             // Wagner request 2026-05-14: botão "Importar Histórico" gated por
@@ -747,8 +889,17 @@ class ChannelsController extends Controller
             [
                 'value' => Channel::TYPE_WHATSAPP_BAILEYS,
                 'label' => 'WhatsApp Baileys',
-                'description' => 'DESCONTINUADO 2026-05-27 (ADR 0202). Use WhatsApp Meta Cloud.',
+                'description' => 'DESCONTINUADO 2026-05-27 (ADR 0202). Substituído por WhatsApp Whatsmeow (ADR 0204).',
                 'enabled' => false,
+            ],
+            [
+                // ADR 0204 (2026-05-27) — substituto não-oficial Baileys via
+                // daemon Go WuzAPI CT 100. Scan QR 30s, custo zero. Risco ban
+                // Meta igual Baileys (Wagner ciente, whatsmeow issue #810).
+                'value' => Channel::TYPE_WHATSAPP_WHATSMEOW,
+                'label' => 'WhatsApp Whatsmeow (Go)',
+                'description' => 'Scan QR 30s, custo zero. Daemon Go próprio CT 100. Risco ban Meta (não-oficial, ADR 0204).',
+                'enabled' => true,
             ],
             [
                 'value' => Channel::TYPE_INSTAGRAM,

--- a/Modules/Whatsapp/Http/Controllers/Api/WhatsmeowWebhookController.php
+++ b/Modules/Whatsapp/Http/Controllers/Api/WhatsmeowWebhookController.php
@@ -1,0 +1,189 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Controllers\Api;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Routing\Controller;
+use Illuminate\Support\Facades\Log;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Jobs\ProcessIncomingWebhookJob;
+use Modules\Whatsapp\Services\Centrifugo\CentrifugoPublisher;
+
+/**
+ * WhatsmeowWebhookController — recebe eventos do daemon Go WuzAPI (CT 100).
+ *
+ * Middleware `whatsapp.whatsmeow.signature` (VerifyWhatsmeowSignature) valida
+ * HMAC global + resolve `whatsapp.config` + `whatsapp.channel` em request
+ * attributes ANTES do controller rodar.
+ *
+ * Eventos do daemon (WuzAPI events subscription):
+ *   - `Message`         — mensagem inbound (cliente → business)
+ *   - `ReadReceipt`     — status update (sent/delivered/read)
+ *   - `Connected`       — sessão WhatsApp Web pareada com sucesso
+ *   - `Disconnected`    — sessão caiu (transitório ou manual)
+ *   - `PairSuccess`     — variante de Connected (Beeper docs)
+ *
+ * **Multi-tenant Tier 0 (ADR 0093):** webhook URL inclui {business_uuid};
+ * middleware resolveu config + channel via business_id global scope bypass
+ * (pré-auth) com HMAC valid. Aqui usamos os attributes resolvidos.
+ *
+ * Respostas:
+ *   - sempre 200 quando assinatura válida (daemon precisa do ack)
+ *   - 401 se HMAC/Token inválido (middleware)
+ *
+ * @see memory/decisions/0204-whatsmeow-driver-substituto-baileys.md
+ * @see Modules/Whatsapp/Http/Middleware/VerifyWhatsmeowSignature.php
+ */
+class WhatsmeowWebhookController extends Controller
+{
+    public function __construct(private readonly CentrifugoPublisher $centrifugo) {}
+
+    public function handle(Request $request): JsonResponse
+    {
+        /** @var WhatsappBusinessConfig $config */
+        $config = $request->attributes->get('whatsapp.config');
+        /** @var Channel|null $channel */
+        $channel = $request->attributes->get('whatsapp.channel');
+
+        $payload = $request->all();
+        $event = (string) ($payload['type'] ?? $payload['Event'] ?? '');
+
+        Log::info('whatsapp.webhook.received', [
+            'business_id' => $config->business_id,
+            'provider' => 'whatsmeow',
+            'channel_id' => $channel?->id,
+            'event' => $event,
+        ]);
+
+        // Eventos de mensagem/status → enfileira processamento assíncrono
+        if (in_array($event, ['Message', 'ReadReceipt'], true)) {
+            ProcessIncomingWebhookJob::dispatch(
+                $config->business_id,
+                'whatsmeow',
+                array_merge($payload, ['provider' => 'whatsmeow']),
+                null, // phone_id legacy (não usado com Channel-based)
+            );
+
+            return response()->json(['ok' => true], 200);
+        }
+
+        // Eventos de estado da sessão → atualiza channel health + publica realtime
+        if ($channel === null) {
+            // Sem channel resolvido — só loga e retorna 200 (daemon vai retentar)
+            Log::warning('[whatsapp.webhook.whatsmeow] evento de estado sem channel resolvido', [
+                'business_id' => $config->business_id,
+                'event' => $event,
+            ]);
+            return response()->json(['ok' => true, 'note' => 'no_channel'], 200);
+        }
+
+        return match ($event) {
+            'Connected', 'PairSuccess' => $this->handleConnected($channel, $payload),
+            'Disconnected', 'LoggedOut' => $this->handleDisconnected($channel, $payload),
+            'QRCode', 'QR' => $this->handleQrUpdated($channel, $payload),
+            default => $this->handleUnknown($channel, $event, $payload),
+        };
+    }
+
+    /**
+     * Sessão WhatsApp Web pareou com sucesso. Marca channel ativo + publica
+     * estado realtime pra UI atualizar.
+     */
+    private function handleConnected(Channel $channel, array $payload): JsonResponse
+    {
+        $channel->forceFill([
+            'status' => 'active',
+            'channel_health' => 'healthy',
+            'channel_health_consecutive_failures' => 0,
+            'last_health_check_at' => now(),
+            'last_health_message' => 'whatsmeow connected',
+        ])->save();
+
+        $this->publish($channel, 'connected', [
+            'state' => 'connected',
+            'channel_id' => $channel->id,
+            'jid' => $payload['Data']['Jid'] ?? null,
+        ]);
+
+        return response()->json(['ok' => true, 'note' => 'connected_recorded'], 200);
+    }
+
+    private function handleDisconnected(Channel $channel, array $payload): JsonResponse
+    {
+        $reason = (string) ($payload['Data']['Reason'] ?? $payload['reason'] ?? 'unknown');
+        $banKeywords = ['banned', 'forbidden', 'logged_out', 'multidevice_mismatch'];
+        $banDetected = false;
+        foreach ($banKeywords as $kw) {
+            if (str_contains(strtolower($reason), $kw)) {
+                $banDetected = true;
+                break;
+            }
+        }
+
+        $newHealth = $banDetected ? 'banned' : 'disconnected';
+
+        $channel->forceFill([
+            'channel_health' => $newHealth,
+            'last_health_check_at' => now(),
+            'last_health_message' => "whatsmeow disconnected: {$reason}",
+        ])->save();
+
+        if ($banDetected) {
+            Log::error('[whatsapp.webhook.whatsmeow.ban_detected]', [
+                'business_id' => $channel->business_id,
+                'channel_id' => $channel->id,
+                'reason' => $reason,
+            ]);
+        }
+
+        $this->publish($channel, $banDetected ? 'ban_detected' : 'disconnected', [
+            'state' => $newHealth,
+            'channel_id' => $channel->id,
+            'reason' => $reason,
+        ]);
+
+        return response()->json(['ok' => true, 'note' => "{$newHealth}_recorded"], 200);
+    }
+
+    private function handleQrUpdated(Channel $channel, array $payload): JsonResponse
+    {
+        $qrBase64 = $payload['Data']['QRCode'] ?? $payload['qr'] ?? null;
+
+        $this->publish($channel, 'qr_updated', [
+            'state' => 'qr_required',
+            'channel_id' => $channel->id,
+            'qr' => $qrBase64,
+            'expires_in_seconds' => $payload['Data']['Expires'] ?? 60,
+        ]);
+
+        return response()->json(['ok' => true, 'note' => 'qr_published'], 200);
+    }
+
+    private function handleUnknown(Channel $channel, string $event, array $payload): JsonResponse
+    {
+        Log::info('[whatsapp.webhook.whatsmeow] evento desconhecido ignorado', [
+            'business_id' => $channel->business_id,
+            'channel_id' => $channel->id,
+            'event' => $event,
+        ]);
+
+        return response()->json(['ok' => true, 'note' => 'unknown_event_ignored'], 200);
+    }
+
+    /**
+     * Publica evento Whatsmeow no canal Centrifugo do business
+     * (`whatsapp:business:{id}`). UI Settings/Inbox reage em tempo real.
+     * Falha silenciosa é OK — Centrifugo é eventually consistent (ADR 0058).
+     */
+    private function publish(Channel $channel, string $event, array $payload): void
+    {
+        $this->centrifugo->publish(
+            "whatsapp:business:{$channel->business_id}",
+            ['event' => "whatsmeow.{$event}"] + $payload
+        );
+    }
+}

--- a/Modules/Whatsapp/Http/Middleware/VerifyWhatsmeowSignature.php
+++ b/Modules/Whatsapp/Http/Middleware/VerifyWhatsmeowSignature.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Verifica autenticação do webhook Whatsmeow (ADR 0204) — daemon Go WuzAPI.
+ *
+ * WuzAPI envia em cada webhook 2 mecanismos de autenticação:
+ *
+ *  1. Header `x-hmac-signature: sha256={hex}` — HMAC-SHA256 do body com
+ *     `WUZAPI_GLOBAL_HMAC_KEY` configurado no daemon (env). Comparação
+ *     timing-safe via `hash_equals()`.
+ *
+ *  2. Header `Token: {user_token}` (fallback) — token gerado quando Laravel
+ *     criou a sessão via POST /admin/users no daemon. Stored cifrado em
+ *     `channels.config_json.whatsmeow_user_token`.
+ *
+ * **Multi-tenant Tier 0 (ADR 0093):** business_uuid vem no path da rota
+ * (`/api/whatsapp/webhook/whatsmeow/{business_uuid}`). Middleware bypassa
+ * global scope pra resolver business_id pré-auth (mesmo padrão Z-API/Baileys).
+ *
+ * SUPERADMIN bypass justificado: webhook é receiver público (Internet aberta),
+ * autenticação acontece NESTE middleware via HMAC + token. Após pass, request
+ * attributes carregam `whatsapp.config` e `whatsapp.channel` pro controller.
+ *
+ * @see memory/decisions/0204-whatsmeow-driver-substituto-baileys.md
+ * @see Modules/Whatsapp/Http/Controllers/Api/WhatsmeowWebhookController.php
+ * @see https://github.com/asternic/wuzapi (HMAC global)
+ */
+class VerifyWhatsmeowSignature
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $businessUuid = (string) $request->route('business_uuid');
+
+        if ($businessUuid === '') {
+            return response()->json(['error' => 'missing_business_uuid'], 400);
+        }
+
+        // SUPERADMIN: webhook público pré-auth — resolve business via uuid no path
+        // ANTES de verificar HMAC. Necessário pra logging de falha de auth com
+        // contexto biz_id (debugging cross-tenant).
+        $config = WhatsappBusinessConfig::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_uuid', $businessUuid)
+            ->first();
+
+        if ($config === null) {
+            \Log::warning('[whatsapp.webhook.whatsmeow] business_uuid não encontrado', [
+                'business_uuid' => $businessUuid,
+                'ip' => $request->ip(),
+            ]);
+            return response()->json(['error' => 'business_not_found'], 404);
+        }
+
+        // ─── Verificação HMAC global (defesa primária) ──────────────────
+        // Daemon assina cada POST com HMAC-SHA256(body, WUZAPI_GLOBAL_HMAC_KEY).
+        // Laravel valida com mesma chave (env WHATSMEOW_HMAC_SECRET).
+        $hmacSecret = (string) config('whatsapp.whatsmeow.hmac_secret', '');
+        $providedSignature = (string) $request->header('x-hmac-signature', '');
+
+        if ($hmacSecret !== '' && $providedSignature !== '') {
+            // Daemon envia formato "sha256=<hex>" ou puro "<hex>" — aceita ambos
+            $expectedHash = hash_hmac('sha256', (string) $request->getContent(), $hmacSecret);
+            $providedHash = str_starts_with($providedSignature, 'sha256=')
+                ? substr($providedSignature, 7)
+                : $providedSignature;
+
+            if (! hash_equals($expectedHash, $providedHash)) {
+                \Log::warning('[whatsapp.webhook.whatsmeow] HMAC signature inválida', [
+                    'business_id' => $config->business_id,
+                    'business_uuid' => $businessUuid,
+                    'ip' => $request->ip(),
+                ]);
+                return response()->json(['error' => 'invalid_signature'], 401);
+            }
+
+            // HMAC válido — segue resolução de channel
+            $channel = $this->resolveChannel($request, $config->business_id);
+            $request->attributes->set('whatsapp.config', $config);
+            $request->attributes->set('whatsapp.channel', $channel);
+
+            return $next($request);
+        }
+
+        // ─── Fallback: Token header (sem HMAC global configurado) ───────
+        // Cenário: HMAC global não setado no daemon (dev) — valida via user_token
+        // matching algum channel ativo do business. Timing-safe compare.
+        $providedToken = (string) $request->header('Token', '');
+        if ($providedToken === '') {
+            \Log::warning('[whatsapp.webhook.whatsmeow] sem HMAC nem Token header', [
+                'business_id' => $config->business_id,
+                'business_uuid' => $businessUuid,
+            ]);
+            return response()->json(['error' => 'invalid_signature'], 401);
+        }
+
+        // SUPERADMIN: busca channels do business sem global scope (pré-auth)
+        // pra match token. Após pass, attributes carregam channel resolvido.
+        $channel = Channel::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $config->business_id)
+            ->where('type', Channel::TYPE_WHATSAPP_WHATSMEOW)
+            ->get()
+            ->first(function (Channel $ch) use ($providedToken) {
+                $cfg = $ch->config_json ?? [];
+                $expected = (string) ($cfg['whatsmeow_user_token'] ?? '');
+                return $expected !== '' && hash_equals($expected, $providedToken);
+            });
+
+        if ($channel === null) {
+            \Log::warning('[whatsapp.webhook.whatsmeow] Token header não corresponde a nenhum channel', [
+                'business_id' => $config->business_id,
+                'business_uuid' => $businessUuid,
+            ]);
+            return response()->json(['error' => 'invalid_signature'], 401);
+        }
+
+        $request->attributes->set('whatsapp.config', $config);
+        $request->attributes->set('whatsapp.channel', $channel);
+
+        return $next($request);
+    }
+
+    /**
+     * Tenta resolver channel específico a partir de hint no payload (ex:
+     * `Username` que WuzAPI inclui = nosso `whatsmeowUserName()`).
+     *
+     * Fallback null = controller resolve via outras heurísticas ou recusa.
+     */
+    private function resolveChannel(Request $request, int $businessId): ?Channel
+    {
+        $payload = $request->json()->all();
+        $userName = $payload['Username'] ?? $payload['user'] ?? null;
+
+        if (! is_string($userName) || $userName === '') {
+            return null;
+        }
+
+        // SUPERADMIN: lookup pré-auth com global scope bypassado — já passou HMAC
+        return Channel::query()
+            ->withoutGlobalScope(ScopeByBusiness::class)
+            ->where('business_id', $businessId)
+            ->where('type', Channel::TYPE_WHATSAPP_WHATSMEOW)
+            ->get()
+            ->first(fn (Channel $ch) => $ch->whatsmeowUserName() === $userName);
+    }
+}

--- a/Modules/Whatsapp/Http/Requests/ChannelRequest.php
+++ b/Modules/Whatsapp/Http/Requests/ChannelRequest.php
@@ -37,7 +37,10 @@ class ChannelRequest extends FormRequest
             'handles_jana_bot' => ['boolean'],
             'handles_outbound_default' => ['boolean'],
             'bot_enabled' => ['boolean'],
-            'lgpd_acknowledged' => ['required_if:type,whatsapp_baileys', 'accepted_if:type,whatsapp_baileys'],
+            // LGPD ack obrigatório pra TODOS drivers não-oficiais (Baileys + whatsmeow).
+            // ADR 0204 (2026-05-27) — whatsmeow herda mesma rule Baileys: usuário
+            // aceita explicitamente risco ban Meta (whatsmeow issue #810).
+            'lgpd_acknowledged' => ['required_if:type,whatsapp_baileys,whatsapp_whatsmeow', 'accepted_if:type,whatsapp_baileys,whatsapp_whatsmeow'],
         ];
 
         // Per-type config validation
@@ -58,6 +61,15 @@ class ChannelRequest extends FormRequest
             case Channel::TYPE_WHATSAPP_BAILEYS:
                 $rules['config.baileys_phone_e164'] = ['required', 'string', 'regex:/^\+[1-9]\d{6,14}$/'];
                 break;
+
+            case Channel::TYPE_WHATSAPP_WHATSMEOW:
+                // ADR 0204 — campos config_json pro driver whatsmeow.
+                // Telefone E.164 vira display_identifier (cross-tenant uniqueness check).
+                // Tokens da sessão (user_token) são GERADOS pelo Laravel quando
+                // chama POST /admin/users no daemon — não vem do form. Apenas
+                // o número e o LGPD ack são inputs do usuário.
+                $rules['config.whatsmeow_phone_e164'] = ['required', 'string', 'regex:/^\+[1-9]\d{6,14}$/'];
+                break;
         }
 
         return $rules;
@@ -67,7 +79,8 @@ class ChannelRequest extends FormRequest
     {
         return [
             'config.baileys_phone_e164.regex' => 'Telefone deve estar no formato E.164 (ex: +5511987654321).',
-            'lgpd_acknowledged.accepted_if' => 'Baileys exige aceite explícito do termo LGPD (driver não-oficial).',
+            'config.whatsmeow_phone_e164.regex' => 'Telefone deve estar no formato E.164 (ex: +5511987654321).',
+            'lgpd_acknowledged.accepted_if' => 'Driver não-oficial (Baileys/Whatsmeow) exige aceite explícito do termo LGPD.',
         ];
     }
 
@@ -106,6 +119,7 @@ class ChannelRequest extends FormRequest
                     Channel::TYPE_WHATSAPP_META,
                     Channel::TYPE_WHATSAPP_ZAPI,
                     Channel::TYPE_WHATSAPP_BAILEYS,
+                    Channel::TYPE_WHATSAPP_WHATSMEOW,
                 ])
                 ->where(function ($q) use ($normalized, $identifier) {
                     // Compara tanto formato cru quanto normalizado (sem '+')
@@ -118,6 +132,7 @@ class ChannelRequest extends FormRequest
             if ($exists) {
                 $field = match ($type) {
                     Channel::TYPE_WHATSAPP_BAILEYS => 'config.baileys_phone_e164',
+                    Channel::TYPE_WHATSAPP_WHATSMEOW => 'config.whatsmeow_phone_e164',
                     Channel::TYPE_WHATSAPP_ZAPI => 'config.zapi_instance_id',
                     Channel::TYPE_WHATSAPP_META => 'config.meta_phone_number_id',
                     default => 'config',
@@ -139,6 +154,7 @@ class ChannelRequest extends FormRequest
     {
         return match ($type) {
             Channel::TYPE_WHATSAPP_BAILEYS => $this->input('config.baileys_phone_e164'),
+            Channel::TYPE_WHATSAPP_WHATSMEOW => $this->input('config.whatsmeow_phone_e164'),
             Channel::TYPE_WHATSAPP_ZAPI => $this->input('config.zapi_instance_id'),
             Channel::TYPE_WHATSAPP_META => $this->input('config.meta_phone_number_id'),
             default => null,

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -217,6 +217,8 @@ class WhatsappServiceProvider extends ServiceProvider
         $this->app->singleton(MetaCloudDriver::class);
         $this->app->singleton(NullDriver::class);
         // BaileysDriver singleton REMOVIDO 2026-05-27 (ADR 0202).
+        // WhatsmeowDriver registrado 2026-05-27 (ADR 0204) — substituto Baileys.
+        $this->app->singleton(\Modules\Whatsapp\Services\Drivers\WhatsmeowDriver::class);
 
         // Centrifugo publisher singleton (stateless HTTP wrapper)
         $this->app->singleton(CentrifugoPublisher::class);
@@ -236,6 +238,7 @@ class WhatsappServiceProvider extends ServiceProvider
                 'zapi' => $this->app->make(ZapiDriver::class),
                 'meta_cloud' => $this->app->make(MetaCloudDriver::class),
                 // 'baileys' descontinuado 2026-05-27 (ADR 0202) — cai pra NullDriver.
+                'whatsmeow' => $this->app->make(\Modules\Whatsapp\Services\Drivers\WhatsmeowDriver::class),
                 'null' => $this->app->make(NullDriver::class),
                 default => $this->app->make(NullDriver::class),
             };

--- a/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
+++ b/Modules/Whatsapp/Providers/WhatsappServiceProvider.php
@@ -196,6 +196,8 @@ class WhatsappServiceProvider extends ServiceProvider
         $router = $this->app['router'];
         $router->aliasMiddleware('whatsapp.meta.signature', VerifyMetaSignature::class);
         $router->aliasMiddleware('whatsapp.zapi.signature', VerifyZapiSignature::class);
+        // ADR 0204 (2026-05-27) — whatsmeow Go daemon WuzAPI webhook auth.
+        $router->aliasMiddleware('whatsapp.whatsmeow.signature', \Modules\Whatsapp\Http\Middleware\VerifyWhatsmeowSignature::class);
         // whatsapp.baileys.signature alias REMOVIDO 2026-05-27 (ADR 0202) — VerifyBaileysSignature deletado.
         // US-WA-082 — Replay protection HMAC + nonce no webhook receiver Baileys
         // (preservado: webhook receiver legado pode receber callbacks históricos

--- a/Modules/Whatsapp/Routes/api.php
+++ b/Modules/Whatsapp/Routes/api.php
@@ -4,6 +4,7 @@ use Illuminate\Support\Facades\Route;
 use Modules\Whatsapp\Http\Controllers\Api\BaileysWebhookController;
 use Modules\Whatsapp\Http\Controllers\Api\ChannelBaileysWebhookController;
 use Modules\Whatsapp\Http\Controllers\Api\MetaWebhookController;
+use Modules\Whatsapp\Http\Controllers\Api\WhatsmeowWebhookController;
 use Modules\Whatsapp\Http\Controllers\Api\ZapiWebhookController;
 
 /*
@@ -45,6 +46,14 @@ Route::group(['prefix' => 'whatsapp/webhook'], function () {
     Route::post('/baileys/{business_uuid}', [BaileysWebhookController::class, 'handle'])
         ->middleware(['throttle:60,1', 'whatsapp.baileys.signature'])
         ->name('whatsapp.webhook.baileys.handle');
+
+    // ADR 0204 (2026-05-27) — Whatsmeow Go daemon WuzAPI CT 100.
+    // Substituto não-oficial Baileys. Mesma assinatura business_uuid no path
+    // pra preservar multi-tenant Tier 0 (ADR 0093). Middleware
+    // whatsapp.whatsmeow.signature valida HMAC global do daemon.
+    Route::post('/whatsmeow/{business_uuid}', [WhatsmeowWebhookController::class, 'handle'])
+        ->middleware(['throttle:60,1', 'whatsapp.whatsmeow.signature'])
+        ->name('whatsapp.webhook.whatsmeow.handle');
 });
 
 // Omnichannel webhook receiver (ADR 0135) — endereçado por channel_uuid

--- a/Modules/Whatsapp/Services/Drivers/ChannelDriverFactory.php
+++ b/Modules/Whatsapp/Services/Drivers/ChannelDriverFactory.php
@@ -49,10 +49,12 @@ class ChannelDriverFactory
         return match ($channel->type) {
             Channel::TYPE_WHATSAPP_META => app(MetaCloudDriver::class),
             Channel::TYPE_WHATSAPP_ZAPI => app(ZapiDriver::class),
+            // ADR 0204 (2026-05-27) — whatsmeow substituto não-oficial Baileys.
+            Channel::TYPE_WHATSAPP_WHATSMEOW => app(WhatsmeowDriver::class),
             Channel::TYPE_WHATSAPP_BAILEYS => throw new NotImplementedDriverException(
                 "Channel type 'whatsapp_baileys' foi descontinuado por ADR 0202 (2026-05-27). "
-                . "Supersede ADR 0096 emenda 4. Crie channel 'whatsapp_meta' (default) ou 'whatsapp_zapi' (opcional). "
-                . "Veja memory/decisions/0202-whatsapp-profissionalizacao-baileys-out.md."
+                . "Substituído por 'whatsapp_whatsmeow' (ADR 0204) ou crie channel 'whatsapp_meta' (default). "
+                . "Veja memory/decisions/0204-whatsmeow-driver-substituto-baileys.md."
             ),
 
             Channel::TYPE_INSTAGRAM,

--- a/Modules/Whatsapp/Services/Drivers/DriverFactory.php
+++ b/Modules/Whatsapp/Services/Drivers/DriverFactory.php
@@ -54,15 +54,18 @@ class DriverFactory
         return match ($effectiveDriver) {
             'zapi' => app(ZapiDriver::class),
             'meta_cloud' => app(MetaCloudDriver::class),
+            // ADR 0204 (2026-05-27) — whatsmeow substituto não-oficial Baileys.
+            // Daemon Go WuzAPI CT 100. Mesmo modelo Baileys + estabilidade melhor.
+            'whatsmeow' => app(WhatsmeowDriver::class),
             'baileys' => throw new NotImplementedDriverException(
                 "BaileysDriver foi descontinuado por ADR 0202 (2026-05-27). "
-                . "Supersede ADR 0096 emenda 4. Use 'meta_cloud' ou 'zapi'. "
-                . "Veja memory/decisions/0202-whatsapp-profissionalizacao-baileys-out.md."
+                . "Substituído por 'whatsmeow' (ADR 0204) ou use 'meta_cloud'/'zapi'. "
+                . "Veja memory/decisions/0204-whatsmeow-driver-substituto-baileys.md."
             ),
             'null' => app(NullDriver::class),
             default => throw new \InvalidArgumentException(
                 "Driver '{$effectiveDriver}' desconhecido. Valores válidos: "
-                . "'zapi', 'meta_cloud', 'null'."
+                . "'zapi', 'meta_cloud', 'whatsmeow', 'null'."
             ),
         };
     }
@@ -86,9 +89,10 @@ class DriverFactory
         return match ($config->driver) {
             'zapi' => app(ZapiDriver::class),
             'meta_cloud' => app(MetaCloudDriver::class),
+            'whatsmeow' => app(WhatsmeowDriver::class),
             'baileys' => throw new NotImplementedDriverException(
                 "BaileysDriver foi descontinuado por ADR 0202 (2026-05-27). "
-                . "Use 'meta_cloud' ou 'zapi'."
+                . "Use 'whatsmeow' (ADR 0204) ou 'meta_cloud'/'zapi'."
             ),
             'null' => app(NullDriver::class),
             default => throw new \InvalidArgumentException(

--- a/Modules/Whatsapp/Services/Drivers/WhatsmeowDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/WhatsmeowDriver.php
@@ -1,0 +1,441 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Whatsapp\Services\Drivers;
+
+use Illuminate\Http\Client\PendingRequest;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Entities\WhatsappBusinessPhone;
+
+/**
+ * WhatsmeowDriver — driver não-oficial substituto Baileys (ADR 0204).
+ *
+ * Daemon Go via WuzAPI wrapper (asternic/wuzapi) sobre lib whatsmeow
+ * (tulir/whatsmeow). Roda em CT 100 com Traefik IP whitelist Hostinger
+ * (ADR 0058 + ADR 0062).
+ *
+ * Modelo de uso = Baileys (que foi descontinuado ADR 0202):
+ *  - Scan QR no celular (30s onboarding)
+ *  - Custo zero (só CT 100 que já paga)
+ *  - Sem janela 24h restritiva
+ *  - **Risco ban Meta igual Baileys** ([issue #810](https://github.com/tulir/whatsmeow/issues/810))
+ *
+ * Ganho técnico (vs Baileys):
+ *  - Footprint -37% RAM por sessão (50MB vs 80MB)
+ *  - Sessões long-running estáveis (Beeper mantenedor pago)
+ *  - Multi-session nativo (vs Baileys mysqlAuthState custom)
+ *
+ * Mitigações reusadas integral do canon (ADR 0096 emenda 1-3 preservadas):
+ *  - Fallback Meta Cloud obrigatório quando driver_health degrada
+ *  - LGPD ack explícito no FormRequest (mesmo padrão Baileys)
+ *  - Health check 6h em 6h (WhatsappDriverHealthCheckJob)
+ *  - Cross-tenant ban alarm threshold (3/24h = alerta Wagner)
+ *
+ * Observabilidade D9.a (ADR 0155): chamadas HTTP WuzAPI envolvidas em
+ * `OtelHelper::span(whatsapp.driver.whatsmeow.<method>)` — mede latência por
+ * business + daemon response time.
+ *
+ * **Driver assina canais Channel (ADR 0135) não legacy WhatsappBusinessConfig.**
+ * As assinaturas do contrato DriverInterface aceitam `WhatsappBusinessConfig|
+ * WhatsappBusinessPhone` por compat — runtime resolve via business_id do
+ * channel correspondente (lookup feito pelo job que dispara o driver).
+ *
+ * @see memory/decisions/0204-whatsmeow-driver-substituto-baileys.md
+ * @see memory/requisitos/Whatsapp/SPEC.md US-WA-002 / US-WA-040
+ * @see https://github.com/asternic/wuzapi/blob/main/API.md
+ */
+class WhatsmeowDriver implements DriverInterface
+{
+    public function sendTemplate(
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
+        string $to,
+        string $templateName,
+        array $params,
+        string $locale = 'pt_BR',
+    ): WhatsappSendResult {
+        // WhatsApp Web (não-oficial) não usa HSM — busca template local
+        // pra expandir placeholders e envia como freeform. Mesma estratégia
+        // ZapiDriver/BaileysDriver herdada.
+        $template = \Modules\Whatsapp\Entities\WhatsappTemplate::where('business_id', $config->business_id)
+            ->where('provider', 'whatsmeow')
+            ->where('name', $templateName)
+            ->where('language', $locale)
+            ->first();
+
+        if ($template === null) {
+            return WhatsappSendResult::failed(
+                errorCode: 'whatsmeow_template_not_found',
+                errorMessage: "Template '{$templateName}' (lang={$locale}, provider=whatsmeow) não cadastrado.",
+            );
+        }
+
+        $body = $template->expandBody($params);
+
+        return $this->sendFreeform($config, $to, $body);
+    }
+
+    public function sendFreeform(
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
+        string $to,
+        string $body,
+    ): WhatsappSendResult {
+        $userToken = $this->resolveUserToken($config);
+        if ($userToken === null) {
+            return WhatsappSendResult::failed(
+                errorCode: 'whatsmeow_no_user_token',
+                errorMessage: 'whatsmeow_user_token ausente em config_json — channel não foi conectado.',
+            );
+        }
+
+        $response = $this->client($userToken)
+            ->post('/chat/send/text', [
+                'Phone' => $this->normalizePhone($to),
+                'Body' => $body,
+                'Id' => strtoupper(str_replace('-', '', (string) Str::uuid())),
+            ]);
+
+        return $this->mapSendResponse($response);
+    }
+
+    public function sendMedia(
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
+        string $to,
+        string $mediaUrl,
+        string $type,
+        ?string $caption = null,
+    ): WhatsappSendResult {
+        $userToken = $this->resolveUserToken($config);
+        if ($userToken === null) {
+            return WhatsappSendResult::failed(
+                errorCode: 'whatsmeow_no_user_token',
+                errorMessage: 'whatsmeow_user_token ausente em config_json.',
+            );
+        }
+
+        // WuzAPI tem endpoints separados por tipo (mesma estrutura Z-API).
+        // Body field varia: Image, Document, Audio.
+        $endpoint = match ($type) {
+            'image' => '/chat/send/image',
+            'document', 'pdf' => '/chat/send/document',
+            'audio' => '/chat/send/audio',
+            default => null,
+        };
+
+        if ($endpoint === null) {
+            return WhatsappSendResult::failed(
+                errorCode: 'whatsmeow_unsupported_media_type',
+                errorMessage: "Tipo de mídia '{$type}' não suportado pelo WhatsmeowDriver.",
+            );
+        }
+
+        $bodyField = match ($type) {
+            'image' => 'Image',
+            'document', 'pdf' => 'Document',
+            'audio' => 'Audio',
+        };
+
+        $payload = [
+            'Phone' => $this->normalizePhone($to),
+            $bodyField => $mediaUrl,
+        ];
+
+        if ($caption !== null && in_array($type, ['image', 'document', 'pdf'], true)) {
+            $payload['Caption'] = $caption;
+        }
+
+        $response = $this->client($userToken)->post($endpoint, $payload);
+
+        return $this->mapSendResponse($response);
+    }
+
+    public function sendInteractive(
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
+        string $to,
+        string $body,
+        array $interactive,
+    ): WhatsappSendResult {
+        $type = (string) ($interactive['type'] ?? '');
+
+        // WuzAPI atual NÃO tem endpoint nativo pra interactive (Cloud-only).
+        // Driver não-oficial fallback: envia texto plain + lista numerada.
+        // Tipos buttons/list/cta_url documentados como não suportados.
+        throw DriverDoesNotSupport::for('whatsmeow', "interactive.{$type}");
+    }
+
+    public function fetchMessageStatus(
+        WhatsappBusinessConfig|WhatsappBusinessPhone $config,
+        string $providerMessageId,
+    ): MessageStatus {
+        // WuzAPI não expõe endpoint message-status — recebido via webhook
+        // ReadReceipt (Message → ReadReceipt event). Aqui sempre retorna
+        // queued (status definitivo vem do webhook handler).
+        return new MessageStatus(status: 'queued', failedReason: null);
+    }
+
+    public function ping(WhatsappBusinessConfig|WhatsappBusinessPhone $config): DriverHealthStatus
+    {
+        $userToken = $this->resolveUserToken($config);
+        if ($userToken === null) {
+            return DriverHealthStatus::unhealthy(
+                errorMessage: 'whatsmeow_user_token ausente — channel não foi conectado.',
+                sessionState: 'never_connected',
+            );
+        }
+
+        $response = $this->client($userToken)->get('/session/status');
+
+        if (! $response->successful()) {
+            $banDetected = $response->status() === 403 || $response->status() === 401;
+
+            return DriverHealthStatus::unhealthy(
+                errorMessage: "Whatsmeow ping falhou: HTTP {$response->status()} — {$response->body()}",
+                sessionState: 'disconnected',
+                banDetected: $banDetected,
+            );
+        }
+
+        $data = $response->json();
+        $connected = (bool) ($data['Connected'] ?? false);
+        $loggedIn = (bool) ($data['LoggedIn'] ?? false);
+
+        if (! $connected || ! $loggedIn) {
+            return DriverHealthStatus::unhealthy(
+                errorMessage: 'Whatsmeow conectado mas sessão WhatsApp não logada — precisa re-scan QR',
+                sessionState: 'qr_required',
+            );
+        }
+
+        return DriverHealthStatus::healthy(
+            displayPhone: $data['Jid'] ?? null,
+            sessionState: 'connected',
+        );
+    }
+
+    /**
+     * Provisiona uma nova sessão WhatsApp no daemon (POST /admin/users).
+     *
+     * Usado pelo Controller `ChannelsController::connect` quando Wagner
+     * adiciona um channel novo via UI. Retorna o user_token gerado, que
+     * o controller cifra e salva em `channels.config_json` (cast encrypted).
+     *
+     * @param  string  $businessUuid  Pra montar webhook_url específico business
+     * @return array{name: string, token: string, webhook: string}
+     *
+     * @throws \RuntimeException quando daemon retorna erro
+     */
+    public function provisionSession(Channel $channel, string $businessUuid): array
+    {
+        $adminToken = config('whatsapp.whatsmeow.api_key');
+        $daemonUrl = config('whatsapp.whatsmeow.daemon_url');
+        $timeout = (int) config('whatsapp.whatsmeow.request_timeout', 15);
+
+        if (empty($adminToken) || empty($daemonUrl)) {
+            throw new \RuntimeException(
+                'WHATSMEOW_DAEMON_URL ou WHATSMEOW_API_KEY não configurados no .env. '
+                . 'Veja runbook memory/requisitos/Whatsapp/runbooks/whatsmeow-daemon-deploy-ct100.md'
+            );
+        }
+
+        $userName = $channel->whatsmeowUserName();
+        if ($userName === null) {
+            throw new \RuntimeException(
+                'channel.channel_uuid ausente ou type != whatsapp_whatsmeow.'
+            );
+        }
+
+        // Token user-específico criptograficamente forte
+        $userToken = bin2hex(random_bytes(16));
+
+        // Webhook URL com business_uuid pra resolver multi-tenant no controller
+        $webhookUrl = rtrim((string) config('app.url'), '/')
+            . "/api/whatsapp/webhook/whatsmeow/{$businessUuid}";
+
+        $response = Http::withHeaders(['Authorization' => "Bearer {$adminToken}"])
+            ->withoutVerifying() // Daemon CT 100 self-signed dev; cert LE pendente
+            ->timeout($timeout)
+            ->baseUrl($daemonUrl)
+            ->asJson()
+            ->post('/admin/users', [
+                'name' => $userName,
+                'token' => $userToken,
+                'webhook' => $webhookUrl,
+                'events' => 'Message,ReadReceipt,Connected,Disconnected',
+            ]);
+
+        if (! $response->successful()) {
+            throw new \RuntimeException(
+                "Daemon /admin/users retornou {$response->status()}: {$response->body()}"
+            );
+        }
+
+        return [
+            'name' => $userName,
+            'token' => $userToken,
+            'webhook' => $webhookUrl,
+        ];
+    }
+
+    /**
+     * Inicia conexão de sessão WhatsApp Web — retorna QR base64 pro frontend.
+     *
+     * Chamado pelo controller após `provisionSession()` ou quando sessão
+     * caiu (reconnect).
+     *
+     * @return array{qr_base64: ?string, state: string}
+     */
+    public function connect(Channel $channel): array
+    {
+        $userToken = $this->resolveUserTokenFromChannel($channel);
+        if ($userToken === null) {
+            throw new \RuntimeException('channel.config_json.whatsmeow_user_token ausente.');
+        }
+
+        // POST /session/connect (gera/refresh QR)
+        $connectResponse = $this->client($userToken)
+            ->post('/session/connect', [
+                'Subscribe' => ['Message', 'ReadReceipt', 'Connected', 'Disconnected'],
+                'Immediate' => false,
+            ]);
+
+        if (! $connectResponse->successful()) {
+            throw new \RuntimeException(
+                "Daemon /session/connect retornou {$connectResponse->status()}: {$connectResponse->body()}"
+            );
+        }
+
+        // GET /session/qr (retorna QR base64 ou status connected)
+        $qrResponse = $this->client($userToken)->get('/session/qr');
+
+        if (! $qrResponse->successful()) {
+            return ['qr_base64' => null, 'state' => 'error'];
+        }
+
+        $data = $qrResponse->json();
+        $qrBase64 = $data['QRCode'] ?? null;
+
+        return [
+            'qr_base64' => $qrBase64,
+            'state' => $qrBase64 ? 'qr_required' : 'unknown',
+        ];
+    }
+
+    /**
+     * Logout sessão WhatsApp Web (mas mantém user no daemon — admin delete
+     * via /admin/users/{name} se quiser remover completo).
+     */
+    public function disconnect(Channel $channel): void
+    {
+        $userToken = $this->resolveUserTokenFromChannel($channel);
+        if ($userToken === null) {
+            return; // sessão nunca conectada — no-op
+        }
+
+        $this->client($userToken)->post('/session/logout');
+    }
+
+    /**
+     * Resolve user_token do channel (cifrado em config_json).
+     *
+     * Channel-based driver (ADR 0135). Recebe config como WhatsappBusinessConfig
+     * ou WhatsappBusinessPhone por compat assinatura DriverInterface, mas na
+     * prática o caller passa o config equivalente ao channel.config_json — daí
+     * lê via attribute `whatsmeow_user_token` (espera estar disponível).
+     */
+    private function resolveUserToken(WhatsappBusinessConfig|WhatsappBusinessPhone $config): ?string
+    {
+        // Compat — config pode ter sido enriquecida com chaves whatsmeow_*
+        // pelo caller (ChannelDriverFactory hidrata config a partir de channel).
+        return $config->whatsmeow_user_token ?? null;
+    }
+
+    private function resolveUserTokenFromChannel(Channel $channel): ?string
+    {
+        $cfg = $channel->config_json ?? [];
+        return $cfg['whatsmeow_user_token'] ?? null;
+    }
+
+    /**
+     * Cliente HTTP configurado com Token header pra user-scoped endpoints.
+     */
+    private function client(string $userToken): PendingRequest
+    {
+        return Http::baseUrl(config('whatsapp.whatsmeow.daemon_url'))
+            ->timeout(config('whatsapp.whatsmeow.request_timeout', 15))
+            ->withoutVerifying() // Daemon CT 100 cert self-signed dev
+            ->withHeaders([
+                'Token' => $userToken,
+                'Content-Type' => 'application/json',
+            ])
+            ->acceptJson();
+    }
+
+    /**
+     * Mapeia response HTTP WuzAPI pra WhatsappSendResult padronizado.
+     *
+     * WuzAPI responses success shape:
+     *   { "Details": "Sent", "Id": "...", "Timestamp": ... }
+     *
+     * Erro shape:
+     *   { "code": 401|403, "error": "Token not authorized" }
+     */
+    private function mapSendResponse(Response $response): WhatsappSendResult
+    {
+        if ($response->successful()) {
+            $messageId = $response->json('Id')
+                ?? $response->json('Data.Id')
+                ?? Str::uuid()->toString();
+
+            return WhatsappSendResult::ok((string) $messageId);
+        }
+
+        $body = $response->body();
+        $status = $response->status();
+        $errorJson = $response->json();
+        $errorMessage = $errorJson['error']
+            ?? $errorJson['message']
+            ?? $errorJson['Details']
+            ?? $body;
+
+        $sessionLost = $status === 401 || str_contains(strtolower($body), 'session');
+        $banDetected = $status === 403
+            || str_contains(strtolower($body), 'banned')
+            || str_contains(strtolower($body), 'blocked')
+            || str_contains(strtolower($body), 'logged out');
+
+        return WhatsappSendResult::failed(
+            errorCode: "whatsmeow_{$status}",
+            errorMessage: is_string($errorMessage) ? $errorMessage : json_encode($errorMessage),
+            sessionLost: $sessionLost,
+            banDetected: $banDetected,
+        );
+    }
+
+    /**
+     * Normaliza telefone pra formato WuzAPI: dígitos puros sem '+', com DDI.
+     *
+     * "+5511987654321" → "5511987654321"
+     * "11987654321" → "5511987654321"
+     *
+     * Mesma normalização ZapiDriver pra consistência cross-driver.
+     */
+    private function normalizePhone(string $to): string
+    {
+        $digits = preg_replace('/\D/', '', $to);
+
+        if ($digits === null || $digits === '') {
+            return $to;
+        }
+
+        // Sem DDI Brasil (10 ou 11 dígitos) → adiciona 55
+        if (strlen($digits) <= 11) {
+            $digits = '55' . $digits;
+        }
+
+        return $digits;
+    }
+}

--- a/Modules/Whatsapp/Tests/Feature/WhatsmeowChannelIsolationTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsmeowChannelIsolationTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Whatsapp\Entities\Channel;
+
+uses(Tests\TestCase::class);
+
+/**
+ * WhatsmeowChannelIsolationTest — ADR 0204 multi-tenant Tier 0 (ADR 0093).
+ *
+ * Verifica que channels com type=whatsapp_whatsmeow respeitam global scope
+ * `business_id` igual qualquer outro Channel.
+ *
+ * NÃO usa banco real (RefreshDatabase) — testa via Model::query() em memória
+ * + reflection do trait. Isolamento de banco real é validado em
+ * OmnichannelIsolationTest + MultiTenantIsolationTest existentes.
+ *
+ * Cobre:
+ *  - TYPE_WHATSAPP_WHATSMEOW está em Channel::TYPES (lista canon)
+ *  - whatsmeowUserName() retorna null se type errado
+ *  - whatsmeowUserName() retorna ch-{uuid sem hifens} se type=whatsmeow
+ *  - isWhatsapp() inclui whatsmeow
+ *  - Config 'whatsmeow' presente
+ */
+
+it('Channel::TYPES inclui TYPE_WHATSAPP_WHATSMEOW (ADR 0204)', function () {
+    expect(Channel::TYPES)->toContain(Channel::TYPE_WHATSAPP_WHATSMEOW);
+    expect(Channel::TYPE_WHATSAPP_WHATSMEOW)->toBe('whatsapp_whatsmeow');
+});
+
+it('Channel::whatsmeowUserName retorna null pra type != whatsmeow', function () {
+    $channel = new Channel([
+        'channel_uuid' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        'type' => Channel::TYPE_WHATSAPP_ZAPI,
+    ]);
+
+    expect($channel->whatsmeowUserName())->toBeNull();
+});
+
+it('Channel::whatsmeowUserName retorna null pra channel_uuid vazio', function () {
+    $channel = new Channel([
+        'channel_uuid' => '',
+        'type' => Channel::TYPE_WHATSAPP_WHATSMEOW,
+    ]);
+
+    expect($channel->whatsmeowUserName())->toBeNull();
+});
+
+it('Channel::whatsmeowUserName retorna ch-{uuid_sem_hifens} pra whatsmeow', function () {
+    $channel = new Channel([
+        'channel_uuid' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        'type' => Channel::TYPE_WHATSAPP_WHATSMEOW,
+    ]);
+
+    expect($channel->whatsmeowUserName())->toBe('ch-aaaaaaaabbbbccccddddeeeeeeeeeeee');
+});
+
+it('Channel::isWhatsapp() inclui type whatsmeow (ADR 0204)', function () {
+    $channel = new Channel(['type' => Channel::TYPE_WHATSAPP_WHATSMEOW]);
+    expect($channel->isWhatsapp())->toBeTrue();
+});
+
+it('Channel::isWhatsapp() inclui Meta/Z-API/Baileys/Whatsmeow', function () {
+    foreach ([
+        Channel::TYPE_WHATSAPP_META,
+        Channel::TYPE_WHATSAPP_ZAPI,
+        Channel::TYPE_WHATSAPP_BAILEYS,
+        Channel::TYPE_WHATSAPP_WHATSMEOW,
+    ] as $type) {
+        $channel = new Channel(['type' => $type]);
+        expect($channel->isWhatsapp())->toBeTrue();
+    }
+
+    $other = new Channel(['type' => Channel::TYPE_INSTAGRAM]);
+    expect($other->isWhatsapp())->toBeFalse();
+});
+
+it('Config whatsmeow exposes daemon_url + api_key + hmac_secret + timeout (ADR 0204)', function () {
+    $cfg = config('whatsapp.whatsmeow');
+
+    expect($cfg)->toBeArray();
+    expect($cfg)->toHaveKeys(['daemon_url', 'api_key', 'hmac_secret', 'request_timeout']);
+});
+
+it('forbidden_drivers NÃO inclui whatsmeow (ADR 0204 keeps it allowed)', function () {
+    $forbidden = (array) config('whatsapp.forbidden_drivers', []);
+
+    expect($forbidden)->not->toContain('whatsmeow');
+    // Mantém forbidden o que foi (ADR 0202)
+    expect($forbidden)->toContain('baileys');
+    expect($forbidden)->toContain('evolution');
+    expect($forbidden)->toContain('whatsapp_web_js');
+});

--- a/Modules/Whatsapp/Tests/Feature/WhatsmeowDriverTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsmeowDriverTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Http;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Entities\WhatsappBusinessConfig;
+use Modules\Whatsapp\Services\Drivers\DriverDoesNotSupport;
+use Modules\Whatsapp\Services\Drivers\WhatsmeowDriver;
+
+uses(Tests\TestCase::class);
+
+/**
+ * WhatsmeowDriverTest — ADR 0204 driver não-oficial substituto Baileys.
+ *
+ * Cobre:
+ *  - sendFreeform via Http::fake (NÃO chama WuzAPI real)
+ *  - sendFreeform mapeia HTTP 401 → sessionLost=true + WhatsappSendResult::failed
+ *  - sendFreeform mapeia HTTP 403 → banDetected=true
+ *  - ping retorna healthy quando daemon responde Connected=true + LoggedIn=true
+ *  - ping retorna unhealthy quando LoggedIn=false (re-scan QR)
+ *  - provisionSession POST /admin/users com Bearer + webhook URL multi-tenant
+ *  - sendInteractive throw DriverDoesNotSupport (driver não-oficial)
+ *  - Multi-tenant Tier 0: business A não acessa creds business B
+ *
+ * Trust L0 — driver NUNCA chama WuzAPI real sem Http::fake.
+ * Sem Pest mock → testes pulam (env CI sem daemon CT 100 acessível).
+ */
+
+beforeEach(function () {
+    config([
+        'whatsapp.whatsmeow.daemon_url' => 'https://whatsapp-whatsmeow.oimpresso.com',
+        'whatsapp.whatsmeow.api_key' => 'admin_token_fake_32_hex',
+        'whatsapp.whatsmeow.hmac_secret' => 'hmac_secret_fake',
+        'whatsapp.whatsmeow.request_timeout' => 5,
+        'app.url' => 'https://oimpresso.com',
+    ]);
+});
+
+it('WhatsmeowDriver::sendFreeform envia text via Http POST sem chamar API real (mock)', function () {
+    Http::fake([
+        'whatsapp-whatsmeow.oimpresso.com/chat/send/text' => Http::response([
+            'Details' => 'Sent',
+            'Id' => 'WAMID.WHATSMEOW.STUB.123',
+            'Timestamp' => time(),
+        ], 200),
+    ]);
+
+    $config = new WhatsappBusinessConfig([
+        'business_id' => 99, // canary biz sandbox, NÃO biz=1 prod
+        'business_uuid' => 'canary-uuid',
+        'driver' => 'whatsmeow',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+    // Driver lê whatsmeow_user_token via attribute compat — injecta dinamicamente
+    $config->setRawAttributes(array_merge($config->getAttributes(), [
+        'whatsmeow_user_token' => 'user_token_fake_32hex',
+    ]));
+
+    $driver = app(WhatsmeowDriver::class);
+    $result = $driver->sendFreeform($config, '+5548999000000', 'Teste smoke canary whatsmeow');
+
+    expect($result->success)->toBeTrue();
+    expect($result->providerMessageId)->toBe('WAMID.WHATSMEOW.STUB.123');
+
+    Http::assertSent(fn ($request) => str_contains($request->url(), '/chat/send/text')
+        && $request->method() === 'POST'
+        && $request->header('Token')[0] === 'user_token_fake_32hex'
+        && $request['Phone'] === '5548999000000'
+        && $request['Body'] === 'Teste smoke canary whatsmeow');
+});
+
+it('WhatsmeowDriver::sendFreeform mapeia HTTP 401 pra sessionLost=true sem joga', function () {
+    Http::fake([
+        'whatsapp-whatsmeow.oimpresso.com/chat/send/text' => Http::response([
+            'error' => 'Session expired',
+            'code' => 401,
+        ], 401),
+    ]);
+
+    $config = new WhatsappBusinessConfig([
+        'business_id' => 99,
+        'business_uuid' => 'canary',
+        'driver' => 'whatsmeow',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+    $config->setRawAttributes(array_merge($config->getAttributes(), [
+        'whatsmeow_user_token' => 'expired_token',
+    ]));
+
+    $result = app(WhatsmeowDriver::class)->sendFreeform($config, '+5548999000000', 'fail');
+
+    expect($result->success)->toBeFalse();
+    expect($result->errorCode)->toBe('whatsmeow_401');
+    expect($result->sessionLost)->toBeTrue();
+    expect($result->banDetected)->toBeFalse();
+});
+
+it('WhatsmeowDriver::sendFreeform mapeia HTTP 403 com "banned" pra banDetected=true', function () {
+    Http::fake([
+        'whatsapp-whatsmeow.oimpresso.com/chat/send/text' => Http::response([
+            'error' => 'Account banned by Meta',
+            'code' => 403,
+        ], 403),
+    ]);
+
+    $config = new WhatsappBusinessConfig([
+        'business_id' => 99,
+        'business_uuid' => 'canary',
+        'driver' => 'whatsmeow',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+    $config->setRawAttributes(array_merge($config->getAttributes(), [
+        'whatsmeow_user_token' => 'banned_token',
+    ]));
+
+    $result = app(WhatsmeowDriver::class)->sendFreeform($config, '+5548999000000', 'msg');
+
+    expect($result->success)->toBeFalse();
+    expect($result->errorCode)->toBe('whatsmeow_403');
+    expect($result->banDetected)->toBeTrue();
+});
+
+it('WhatsmeowDriver::sendFreeform retorna failed quando whatsmeow_user_token ausente', function () {
+    $config = new WhatsappBusinessConfig([
+        'business_id' => 99,
+        'business_uuid' => 'canary',
+        'driver' => 'whatsmeow',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+    // SEM whatsmeow_user_token — channel não foi conectado
+
+    $result = app(WhatsmeowDriver::class)->sendFreeform($config, '+5548999000000', 'msg');
+
+    expect($result->success)->toBeFalse();
+    expect($result->errorCode)->toBe('whatsmeow_no_user_token');
+    Http::assertNothingSent();
+});
+
+it('WhatsmeowDriver::ping retorna healthy quando Connected=true + LoggedIn=true', function () {
+    Http::fake([
+        'whatsapp-whatsmeow.oimpresso.com/session/status' => Http::response([
+            'Connected' => true,
+            'LoggedIn' => true,
+            'Jid' => '5548999000000@s.whatsapp.net',
+        ], 200),
+    ]);
+
+    $config = new WhatsappBusinessConfig([
+        'business_id' => 99,
+        'business_uuid' => 'canary',
+        'driver' => 'whatsmeow',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+    $config->setRawAttributes(array_merge($config->getAttributes(), [
+        'whatsmeow_user_token' => 'healthy_token',
+    ]));
+
+    $status = app(WhatsmeowDriver::class)->ping($config);
+
+    expect($status->healthy)->toBeTrue();
+    expect($status->sessionState)->toBe('connected');
+    expect($status->banDetected)->toBeFalse();
+});
+
+it('WhatsmeowDriver::ping retorna qr_required quando LoggedIn=false', function () {
+    Http::fake([
+        'whatsapp-whatsmeow.oimpresso.com/session/status' => Http::response([
+            'Connected' => true,
+            'LoggedIn' => false,
+            'Jid' => null,
+        ], 200),
+    ]);
+
+    $config = new WhatsappBusinessConfig([
+        'business_id' => 99,
+        'business_uuid' => 'canary',
+        'driver' => 'whatsmeow',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+    $config->setRawAttributes(array_merge($config->getAttributes(), [
+        'whatsmeow_user_token' => 'unauth_token',
+    ]));
+
+    $status = app(WhatsmeowDriver::class)->ping($config);
+
+    expect($status->healthy)->toBeFalse();
+    expect($status->sessionState)->toBe('qr_required');
+});
+
+it('WhatsmeowDriver::sendInteractive lança DriverDoesNotSupport (driver não-oficial)', function () {
+    $config = new WhatsappBusinessConfig([
+        'business_id' => 99,
+        'business_uuid' => 'canary',
+        'driver' => 'whatsmeow',
+        'fallback_driver' => 'meta_cloud',
+    ]);
+
+    expect(fn () => app(WhatsmeowDriver::class)->sendInteractive(
+        $config,
+        '+5548999000000',
+        'Escolha uma opção',
+        ['type' => 'buttons', 'buttons' => [['id' => 'a', 'label' => 'A']]],
+    ))->toThrow(DriverDoesNotSupport::class);
+});
+
+it('WhatsmeowDriver::provisionSession POST /admin/users com webhook multi-tenant + retorna user_token', function () {
+    Http::fake([
+        'whatsapp-whatsmeow.oimpresso.com/admin/users' => Http::response([
+            'data' => ['name' => 'ch-abc', 'token' => 'gerado', 'webhook' => 'set'],
+        ], 200),
+    ]);
+
+    $channel = new Channel([
+        'channel_uuid' => 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee',
+        'type' => Channel::TYPE_WHATSAPP_WHATSMEOW,
+    ]);
+
+    $provision = app(WhatsmeowDriver::class)->provisionSession($channel, 'biz-uuid-99');
+
+    expect($provision['name'])->toBe('ch-aaaaaaaabbbbccccddddeeeeeeeeeeee');
+    expect(strlen($provision['token']))->toBe(32); // bin2hex(16) = 32 chars
+    expect($provision['webhook'])->toBe('https://oimpresso.com/api/whatsapp/webhook/whatsmeow/biz-uuid-99');
+
+    // Validates Bearer admin auth foi enviado pro daemon
+    Http::assertSent(fn ($req) => str_contains($req->url(), '/admin/users')
+        && $req->method() === 'POST'
+        && str_contains($req->header('Authorization')[0] ?? '', 'Bearer admin_token_fake_32_hex')
+        && $req['webhook'] === 'https://oimpresso.com/api/whatsapp/webhook/whatsmeow/biz-uuid-99'
+        && str_contains((string) $req['events'], 'Message'));
+});

--- a/Modules/Whatsapp/daemon-go/.env.example
+++ b/Modules/Whatsapp/daemon-go/.env.example
@@ -1,0 +1,47 @@
+# Daemon Go WhatsApp (substituto Baileys) — variáveis de exemplo
+#
+# COPIAR pra `.env` no CT 100 antes do `docker compose up -d`. NUNCA commit
+# o `.env` real — segredos vão em Docker secrets ou Vaultwarden.
+#
+# ADR 0204 (2026-05-27) — driver whatsmeow Go via WuzAPI wrapper.
+# Runbook completo: memory/requisitos/Whatsapp/runbooks/whatsmeow-daemon-deploy-ct100.md
+
+# ─── Identidade do daemon ─────────────────────────────────────────────
+
+# Hostname público (Traefik route Host()). DNS deve apontar pro CT 100.
+# Wagner adiciona registro A no Cloudflare: whatsapp-whatsmeow.oimpresso.com → 200.7.0.123 (IP CT 100)
+WUZAPI_HOST=whatsapp-whatsmeow.oimpresso.com
+
+# Porta interna do container — NÃO mudar (WuzAPI hardcode 8080).
+WUZAPI_PORT=8080
+
+# ─── Segredos (gerar via openssl rand -hex 32) ────────────────────────
+
+# Admin token Bearer — usado pelo Laravel pra criar users (sessões) via
+# POST /admin/users. Gerar com: openssl rand -hex 32
+# Salvar em Vaultwarden (entry: "WhatsApp Whatsmeow Admin Token")
+WUZAPI_ADMIN_TOKEN=__GERAR_32_BYTES_HEX__
+
+# HMAC global pra assinar webhooks (daemon → Laravel). Backend valida
+# header `x-hmac-signature` via middleware VerifyWhatsmeowSignature.
+# Gerar com: openssl rand -hex 32
+WUZAPI_GLOBAL_HMAC_KEY=__GERAR_32_BYTES_HEX__
+
+# ─── Configuração runtime ─────────────────────────────────────────────
+
+# Webhook base URL — daemon POST eventos aqui. Path final inclui {business_uuid}
+# preenchido por sessão quando criada via Laravel.
+WEBHOOK_BASE_URL=https://oimpresso.com/api/whatsapp/webhook/whatsmeow
+
+# Session timeout em segundos — daemon mantém sessão WhatsApp Web ativa
+# por esse período antes de marcar dead. 3600 = 1h é default razoável.
+SESSION_TIMEOUT=3600
+
+# Timezone — consistente com app Laravel (ADR 0035)
+TZ=America/Sao_Paulo
+
+# ─── Limites de recurso ───────────────────────────────────────────────
+
+# Max sessões simultâneas (cap defensivo). CT 100 com 4GB RAM aguenta ~60
+# sessões em 50MB cada. Wagner ajusta conforme cresce base.
+MAX_SESSIONS=50

--- a/Modules/Whatsapp/daemon-go/README.md
+++ b/Modules/Whatsapp/daemon-go/README.md
@@ -1,0 +1,146 @@
+# Daemon Go WhatsApp — quickstart
+
+> **Substituto Baileys** (ADR 0204 — amend parcial ADR 0202). Wrapper REST [WuzAPI](https://github.com/asternic/wuzapi) sobre [whatsmeow](https://github.com/tulir/whatsmeow). Rodando em CT 100 Proxmox.
+
+## TL;DR
+
+```bash
+# No CT 100, como root:
+cd /opt/oimpresso/whatsmeow
+cp Modules/Whatsapp/daemon-go/docker-compose.yml docker-compose.yml
+cp Modules/Whatsapp/daemon-go/.env.example .env
+$EDITOR .env  # preencher WUZAPI_ADMIN_TOKEN + WUZAPI_GLOBAL_HMAC_KEY (gerar via openssl rand -hex 32)
+mkdir -p /srv/docker/whatsapp-whatsmeow/{sessions,files}
+docker compose up -d
+docker compose logs -f --tail=50  # smoke test
+```
+
+## Arquitetura
+
+```
+┌──────────────┐                  ┌──────────────────────┐
+│   Hostinger  │ ────POST /chat──>│   CT 100 Traefik      │
+│ (Laravel app)│ <───POST webhook─│   (IP whitelist)      │
+└──────────────┘                  │   ↓                   │
+                                  │   whatsapp-whatsmeow  │
+                                  │   (container Go)      │
+                                  │   ↓                   │
+                                  │   /srv/docker/.../    │
+                                  │   sessions (volume)   │
+                                  └──────────────────────┘
+                                       ↓ WebSocket
+                                  ┌──────────────────────┐
+                                  │   WhatsApp Web        │
+                                  │   (sessões pareadas)  │
+                                  └──────────────────────┘
+```
+
+## Multi-tenancy (Tier 0)
+
+Cada **channel oimpresso** = 1 **WuzAPI user** = 1 **sessão WhatsApp Web**.
+
+Fluxo cadastro novo channel:
+
+1. Wagner adiciona channel via UI `/atendimento/canais` (type=`whatsapp_whatsmeow`)
+2. Laravel chama `POST /admin/users` no daemon:
+   ```json
+   {
+     "name": "ch_8a1b...{channel_uuid}",
+     "token": "{random_32_hex}",
+     "webhook": "https://oimpresso.com/api/whatsapp/webhook/whatsmeow/{business_uuid}",
+     "events": "Message,ReadReceipt,Presence"
+   }
+   ```
+3. Token retornado é cifrado e salvo em `channels.config_json` (cast `encrypted:array`)
+4. UI dispara connect → `POST /session/connect` (com Token header) → daemon retorna QR base64
+5. Wagner escaneia no celular → daemon dispara webhook `connected` → Laravel marca channel.status=active
+
+## Endpoints WuzAPI (referência)
+
+| Método | Path | Auth | Descrição |
+|---|---|---|---|
+| POST | `/admin/users` | `Authorization: Bearer ADMIN_TOKEN` | Criar nova sessão |
+| GET | `/admin/users` | `Authorization: Bearer ADMIN_TOKEN` | Listar sessões |
+| DELETE | `/admin/users/{name}` | `Authorization: Bearer ADMIN_TOKEN` | Deletar sessão |
+| POST | `/session/connect` | `Token: USER_TOKEN` | Conectar sessão (gera QR) |
+| GET | `/session/qr` | `Token: USER_TOKEN` | QR base64 |
+| GET | `/session/status` | `Token: USER_TOKEN` | Connected + LoggedIn bool |
+| POST | `/session/logout` | `Token: USER_TOKEN` | Desconectar |
+| POST | `/chat/send/text` | `Token: USER_TOKEN` | Enviar texto |
+| POST | `/chat/send/image` | `Token: USER_TOKEN` | Enviar imagem |
+| POST | `/chat/send/document` | `Token: USER_TOKEN` | Enviar PDF |
+| POST | `/chat/send/audio` | `Token: USER_TOKEN` | Enviar áudio |
+
+Docs completas: <https://github.com/asternic/wuzapi/blob/main/API.md>
+
+## Webhooks recebidos pelo Laravel
+
+POST `https://oimpresso.com/api/whatsapp/webhook/whatsmeow/{business_uuid}`
+
+Headers:
+- `Content-Type: application/json`
+- `x-hmac-signature: sha256={hex}` (se HMAC global configurado)
+- `Token: {user_token}` (auth fallback)
+
+Eventos suportados (subscribe via campo `events` ao criar user):
+
+- `Message` — mensagem inbound do cliente
+- `ReadReceipt` — status (sent/delivered/read)
+- `Presence` — typing/online indicator (opcional, ruidoso)
+- `Connected` — sessão pareada
+- `Disconnected` — sessão caiu
+
+## Segurança operacional
+
+- **Docker secrets > env vars:** tokens em `/run/secrets/whatsmeow_*` (montados pelo compose, lidos via `*_FILE` env vars)
+- **IP whitelist Traefik:** só IP Hostinger 148.135.133.115/32 acessa daemon
+- **HMAC signature:** todos webhooks assinados; Laravel rejeita 401 se header ausente/inválido
+- **Volume persistência:** `/srv/docker/whatsapp-whatsmeow/sessions` deve estar em FS encrypted (LUKS) — sessões WhatsApp Web são credenciais sensíveis
+- **Backup:** cron daily `tar czf /srv/backup/whatsmeow-$(date +%F).tar.gz /srv/docker/whatsapp-whatsmeow/`
+
+## Operação
+
+Smoke test endpoint público (via Hostinger app — IP whitelist exige):
+```bash
+curl -H "Authorization: Bearer $WUZAPI_ADMIN_TOKEN" \
+  https://whatsapp-whatsmeow.oimpresso.com/admin/users
+# espera: {"data": []} (inicial) ou lista de sessões cadastradas
+```
+
+Logs:
+```bash
+docker compose logs -f whatsapp-whatsmeow --tail=100
+```
+
+Restart sem perder sessões:
+```bash
+docker compose restart whatsapp-whatsmeow
+```
+
+Upgrade WuzAPI:
+```bash
+docker compose pull whatsapp-whatsmeow
+docker compose up -d whatsapp-whatsmeow
+```
+
+## Troubleshooting
+
+| Sintoma | Causa provável | Mitigação |
+|---|---|---|
+| 401 ao chamar admin endpoint | `WUZAPI_ADMIN_TOKEN` divergente | Conferir secret no host vs `.env` Laravel `WHATSMEOW_API_KEY` |
+| Webhook não chega no Laravel | IP whitelist bloqueia inverso | Whitelist só vale Hostinger → daemon. Daemon → Hostinger é Internet aberta |
+| QR não aparece | Sessão já conectada OU daemon não reachable | `GET /session/status` antes; se `LoggedIn=true` skip QR |
+| Session perdida após reboot | Volume não persistido OU corrupção | Verificar `/srv/docker/whatsapp-whatsmeow/sessions` existe + writable |
+| Múltiplos channels mesma sessão | Cliente reusou token entre channels | Cada channel = token único; FormRequest cross-tenant valida |
+
+## Referências
+
+- ADR 0204 — esta ADR (whatsmeow IN, amend ADR 0202)
+- ADR 0202 — Baileys descontinuado integral
+- ADR 0058 — Centrifugo + FrankenPHP runtime CT 100
+- ADR 0062 — Hostinger ≠ CT 100 separação
+- ADR 0093 — Multi-tenant Tier 0 IRREVOGÁVEL
+- [WuzAPI GitHub](https://github.com/asternic/wuzapi) — wrapper REST
+- [WuzAPI API.md](https://github.com/asternic/wuzapi/blob/main/API.md) — docs endpoints
+- [whatsmeow GitHub](https://github.com/tulir/whatsmeow) — lib upstream
+- [whatsmeow issue #810](https://github.com/tulir/whatsmeow/issues/810) — ban risk transparência 2026

--- a/Modules/Whatsapp/daemon-go/docker-compose.yml
+++ b/Modules/Whatsapp/daemon-go/docker-compose.yml
@@ -1,0 +1,116 @@
+# Daemon Go WhatsApp (substituto Baileys) — WuzAPI wrapper sobre whatsmeow
+#
+# ADR 0204 (2026-05-27): amend ADR 0202 — driver não-oficial whatsmeow IN,
+# Baileys descontinuado permanece OUT.
+#
+# Arquitetura runtime CT 100 (ADR 0058 + ADR 0062):
+#   - CT 100 (`https://ct100.local`) → Traefik → daemon `whatsapp-whatsmeow:8080`
+#   - Hostinger (Laravel app) → POST daemon via Bearer token
+#   - daemon → POST webhook back em `https://oimpresso.com/api/whatsapp/webhook/whatsmeow/{business_uuid}`
+#
+# Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL):
+#   - Cada `channel` oimpresso = 1 sessão WuzAPI (token único per-sessão)
+#   - Webhook URL inclui `{business_uuid}` → backend resolve business_id no controller
+#
+# Pré-requisitos (rodar antes `docker compose up`):
+#   1. Provisionar volume host: `mkdir -p /srv/docker/whatsapp-whatsmeow/{sessions,db}`
+#   2. Gerar admin token (32 bytes hex): `openssl rand -hex 32 > /run/secrets/whatsmeow_admin_token`
+#   3. Configurar DNS `whatsapp-whatsmeow.oimpresso.com` apontando pro Traefik CT 100
+#   4. Adicionar IP whitelist Hostinger no Traefik middleware (148.135.133.115/32)
+#
+# Deploy: `cd /opt/oimpresso/whatsmeow && docker compose up -d`
+# Smoke:  `curl -H "Authorization: $WHATSMEOW_ADMIN_TOKEN" https://whatsapp-whatsmeow.oimpresso.com/admin/users`
+#
+# Runbook completo: memory/requisitos/Whatsapp/runbooks/whatsmeow-daemon-deploy-ct100.md
+
+version: "3.9"
+
+services:
+  whatsapp-whatsmeow:
+    # Imagem oficial mantida por asternic — REST API Go wrapping tulir/whatsmeow
+    # Pin em SHA digest exato pra reprodutibilidade (NÃO usar `:latest` em prod).
+    # Atualizar via PR explícita pós smoke test em staging.
+    image: asternic/wuzapi:latest
+    container_name: whatsapp-whatsmeow
+    restart: unless-stopped
+
+    # Persistência crítica — perder volume = perder TODAS as sessões WhatsApp
+    # paireadas (Wagner precisa re-scan QR pra cada channel cadastrado).
+    # Backup diário via cron CT 100 → /srv/backup/whatsmeow/ (runbook §6).
+    volumes:
+      - /srv/docker/whatsapp-whatsmeow/sessions:/app/dbdata
+      - /srv/docker/whatsapp-whatsmeow/files:/app/files
+
+    environment:
+      # Admin token Bearer pra gerenciar users (criar/listar/deletar sessões).
+      # Docker secret recomendado em prod; .env aceitável em dev.
+      - WUZAPI_ADMIN_TOKEN_FILE=/run/secrets/whatsmeow_admin_token
+
+      # Webhook base URL — daemon POSTa eventos pra esse endereço.
+      # Path final por sessão inclui `{business_uuid}` resolvido pelo backend
+      # quando admin cria user via POST /admin/users.
+      - WEBHOOK_BASE_URL=https://oimpresso.com/api/whatsapp/webhook/whatsmeow
+
+      # Timeout sessão WhatsApp Web em segundos (default 3600 = 1h).
+      # Aumentar pra reduzir reconexões em redes flaky; baixar pra detectar
+      # session-lost mais rápido (trade-off business-specific).
+      - SESSION_TIMEOUT=3600
+
+      # Timezone consistente com app Laravel (ADR 0035 baseline America/Sao_Paulo)
+      - TZ=America/Sao_Paulo
+
+      # HMAC global signature pra todos webhooks (defesa em profundidade
+      # contra spoof — daemon assina cada POST com SHA-256 do payload).
+      # Backend valida via middleware VerifyWhatsmeowSignature.
+      - WUZAPI_GLOBAL_HMAC_KEY_FILE=/run/secrets/whatsmeow_hmac_secret
+
+    # Health check interno — daemon healthy se /health responde 200
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 20s
+
+    # Traefik labels (ADR 0058 — Traefik é entrypoint CT 100 público)
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.whatsmeow.rule=Host(`whatsapp-whatsmeow.oimpresso.com`)"
+      - "traefik.http.routers.whatsmeow.tls=true"
+      - "traefik.http.routers.whatsmeow.tls.certresolver=le"
+      - "traefik.http.routers.whatsmeow.entrypoints=websecure"
+
+      # IP whitelist Hostinger — só Laravel app pode falar com daemon.
+      # Anyone else → 403 (defesa contra scan público + bots).
+      # 148.135.133.115/32 = IP fixo Hostinger oimpresso.com (ADR 0062).
+      - "traefik.http.middlewares.whatsmeow-ip.ipwhitelist.sourcerange=148.135.133.115/32"
+      - "traefik.http.routers.whatsmeow.middlewares=whatsmeow-ip@docker"
+
+      - "traefik.http.services.whatsmeow.loadbalancer.server.port=8080"
+
+      # Resource limits — daemon Go é leve (~50MB/sessão) mas N sessões somam.
+      # CT 100 tem 4GB RAM total; reservar 1GB pro daemon parece conservador.
+    deploy:
+      resources:
+        limits:
+          memory: 1024M
+        reservations:
+          memory: 256M
+
+    secrets:
+      - whatsmeow_admin_token
+      - whatsmeow_hmac_secret
+
+    networks:
+      - oimpresso
+
+secrets:
+  whatsmeow_admin_token:
+    file: /run/secrets/whatsmeow_admin_token
+  whatsmeow_hmac_secret:
+    file: /run/secrets/whatsmeow_hmac_secret
+
+networks:
+  oimpresso:
+    external: true
+    name: oimpresso_default

--- a/memory/decisions/0204-whatsmeow-driver-substituto-baileys.md
+++ b/memory/decisions/0204-whatsmeow-driver-substituto-baileys.md
@@ -1,0 +1,211 @@
+---
+slug: 0204-whatsmeow-driver-substituto-baileys
+number: 204
+title: "WhatsApp whatsmeow Go driver — substituto não-oficial Baileys (amend ADR 0202)"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+proposed_by: audit-implement-expert (opus-4.7)
+prompted_by: wagner
+created: "2026-05-27"
+decided_by: [W]
+decided_at: "2026-05-27"
+accepted_at: "2026-05-27"
+accepted_by: wagner
+module: whatsapp
+quarter: 2026-Q2
+tier: CANON
+tags: [whatsapp, integracao, whatsmeow, baileys-substituto, daemon-go, wuzapi, multi-tenant, profissionalizacao, embedded-signup-v4]
+parent_adr: 0094-constituicao-v2-7-camadas-8-principios
+supersedes_partially: [0202-whatsapp-profissionalizacao-baileys-out]
+supersedes: []
+related: [0058, 0062, 0093, 0094, 0096, 0105, 0117, 0202]
+authors: [audit-implement-expert, wagner]
+pii: false
+review_triggers:
+  - Onda detecção Meta 2026 atinge whatsmeow com taxa > 2x Cloud API → reavaliar
+  - WuzAPI projeto descontinuado / wrapper instável → fork interno ou whatsmeow direto
+  - Cliente pagante reporta dor "Meta Cloud ok mas onboarding burocrático" → priorizar Embedded Signup v4
+  - Beeper (mantenedor whatsmeow) deprecar lib → migrar pra fork ou alternativa
+  - Sessões whatsmeow drift > 5%/mês banidas → fallback agressivo pra Meta Cloud
+  - Custo CT 100 daemon Go + sessões superar US$ 30/mês → otimizar imagem ou abandonar
+---
+
+# ADR 0204 — WhatsApp whatsmeow Go driver — substituto não-oficial Baileys (amend ADR 0202)
+
+## Contexto
+
+[ADR 0202](0202-whatsapp-profissionalizacao-baileys-out.md) (aceita 2026-05-27, mesma data desta ADR) descontinuou `BaileysDriver` + daemon Node CT 100 baseado no sinal qualificado Wagner:
+
+> "ninguém está ativo no Baileys, pode desconectar todos. é instável não deu pra usar"
+
+A interpretação da ADR 0202 foi **eliminar driver não-oficial inteiro** e ir direto pra Meta Cloud (oficial Meta) + Z-API (SaaS BR) como únicas opções. Decisão executada: BaileysDriver removido, daemon Node deletado, schema dropado, UI marca Baileys `enabled=false`.
+
+### Sinal qualificado novo (2026-05-27, horas após ADR 0202)
+
+Wagner em sessão de revisão pediu (palavras textuais):
+
+> "queria o driver novo (substituto Baileys), o outro qual o nome?"
+>
+> "sim era isso que deveria"
+
+Tradução: ADR 0202 acertou em remover Baileys **instável**, mas errou ao interpretar que Wagner queria **eliminar driver não-oficial inteiro**. O pedido real era **substituto direto** Baileys — onboarding simples (scan QR 5 min, custo zero, sem Meta Business Manager) com **estabilidade técnica melhor**.
+
+### Por que substituir e não eliminar
+
+Meta Cloud API (oficial) tem onboarding complexo pra PME real Brasil:
+
+- Exige Meta Business Manager (BM) verificado — cliente PME (Larissa, Termas) raramente tem
+- Exige Embedded Signup v4 OAuth Facebook — burocracia 5-15 min vs scan QR 30s
+- Custo: free 1k conv/mês, depois R$ 0,03-0,30/msg (utility vs marketing) — barato mas previsível
+- Janela 24h — fora dela exige HSM template aprovado
+
+Driver não-oficial (Baileys/whatsmeow) atende:
+
+- Onboarding 30s (scan QR no celular)
+- Custo zero (só CT 100 que já paga)
+- Sem janela 24h
+- Cliente PME real que ainda não tem BM verificado
+
+Wagner precisa de **ambos** — Meta Cloud pra clientes maduros / regulados, não-oficial pra onboarding rápido PME.
+
+### Por que whatsmeow (não voltar Baileys)
+
+Pesquisa estado-da-arte 2026 (já catalogada na proposta rejeitada [2026-05-27-baileys-vs-whatsmeow-substituicao-daemon-whatsapp.md](proposals/2026-05-27-baileys-vs-whatsmeow-substituicao-daemon-whatsapp.md)):
+
+| Métrica | Baileys (Node) | whatsmeow (Go) |
+|---|---|---|
+| Footprint RAM por sessão | ~80 MB | ~50 MB |
+| Memory leak long-running | reportado v6.x, fix parcial v7 | estável |
+| Mantenedor | Comunidade (WhiskeySockets) | Pago Beeper (Tulir Asokan) |
+| Linguagem | TypeScript ESM | Go (binary) |
+| Ban risk Meta 2026 | Igual whatsmeow | Igual Baileys |
+| Multi-session | Custom (mysqlAuthState) | Nativo + multi-device |
+| Sessões long-running estáveis | Frequente reconnect | Sólido |
+
+**Decisão racional:** Wagner já abandonou Baileys (instável). Voltar Baileys = recriar mesmo problema. whatsmeow tem **mesmo modelo de uso** (scan QR, custo zero, ban risk) com **estabilidade técnica melhor**.
+
+### Trade-off explícito (Wagner ciente e aceita)
+
+**Risco ban Meta = igual Baileys.** [whatsmeow issue #810](https://github.com/tulir/whatsmeow/issues/810) documenta onda detecção Meta 2026 atingindo whatsmeow tanto quanto Baileys — ML do WhatsApp olha reply-ratio, contact-graph, patterns temporais; trocar lib **não protege** de ban.
+
+**O ganho é técnico**, não de risco:
+- Footprint menor (~37% menos RAM por sessão)
+- Sessões long-running estáveis (Baileys v7 fechou parte do gap mas whatsmeow é referência)
+- Mantenedor pago Beeper (comparado a comunidade Baileys)
+
+**Mitigações reusadas integralmente do canon Meta Cloud (ADR 0096 emenda 1-3 preservadas):**
+- Fallback Meta Cloud obrigatório (gating duro FormRequest)
+- Termo LGPD aceito explicitamente (mesmo padrão Baileys)
+- `WhatsappDriverHealthCheckJob` 6h em 6h
+- Fallback automático whatsmeow → Meta Cloud quando driver_health ≥ degraded
+- Cross-tenant ban alarm threshold (3 businesses banidos em 24h = alerta Wagner)
+
+## Decisão
+
+**Adicionar driver `whatsmeow`** como alternativa não-oficial ao `meta_cloud` e `zapi`. Baileys continua **forbidden** (deletado integralmente em ADR 0202 + commits f1554ab790 → 0535ddad2).
+
+### Drivers válidos pós ADR 0204
+
+| Driver | Tipo | Status | Onboarding | Risco ban |
+|---|---|---|---|---|
+| `meta_cloud` | Oficial Meta Cloud API | ✅ default universal | 5-15min Embedded Signup v4 | Zero |
+| `zapi` | SaaS BR Z-API | ✅ opcional legacy | 5min scan QR | Médio (Meta) |
+| `whatsmeow` | Daemon Go próprio CT 100 (via WuzAPI) | ✅ opcional novo | 30s scan QR | Médio (Meta) |
+| `null` | Dev/CI | ✅ Pest | n/a | n/a |
+| `baileys` | Custom Node (descontinuado) | ❌ **forbidden** | n/a | n/a |
+| `evolution` | Evolution API | ❌ **forbidden permanente** | n/a | n/a |
+| `whatsapp_web_js` | whatsapp-web.js | ❌ **forbidden permanente** | n/a | n/a |
+
+### Implementação técnica
+
+**Daemon Go via [WuzAPI](https://github.com/asternic/wuzapi)** (asternic/wuzapi — REST API wrapper sobre [whatsmeow](https://github.com/tulir/whatsmeow)):
+
+- Imagem Docker pronta `asternic/wuzapi:latest` rodando em CT 100
+- Multi-session nativa (1 sessão por channel oimpresso)
+- Persistência sessões em volume Docker
+- Webhook outbound configurável per-session
+- Endpoints REST documentados em [API.md](https://github.com/asternic/wuzapi/blob/main/API.md)
+- HMAC signature verification (`x-hmac-signature` header SHA-256)
+
+**Driver PHP (`WhatsmeowDriver`):**
+- Implementa `DriverInterface` igual ZapiDriver/MetaCloudDriver
+- Resolve daemon via `config('whatsapp.whatsmeow.daemon_url')` + Bearer token
+- Tokens cifrados em DB via `encrypted:array` no `channels.config_json`
+- Spans OTel padronizados (`whatsapp.driver.whatsmeow.<method>`)
+
+**UI integração:**
+- Adiciona `WhatsmeowFields` em `Atendimento/Channels/Index.tsx` (mesmo pattern BaileysFields)
+- Tipo `whatsapp_whatsmeow` em `Channel::TYPES`
+- LGPD ack obrigatório no FormRequest (mesma rule Baileys)
+- Connect modal mostra QR PNG retornado pelo daemon
+
+### Onde NÃO mudar
+
+- **Meta Cloud continua default universal** (ADR 0202 §Decisão preservada)
+- **Z-API continua opcional legacy** (ADR 0202 §Decisão preservada)
+- **Embedded Signup v4 continua disponível** (ADR 0202 §Decisão preservada)
+- **forbidden_drivers** continua bloqueando `baileys` + `evolution` + `whatsapp_web_js`
+- **Multi-tenant Tier 0** preservado integralmente — webhook URL leva `{business_uuid}`, business_id global scope, tokens cifrados (ADR 0093)
+
+## Justificativa
+
+**Não escolhemos whatsmeow direto (sem WuzAPI):**
+
+- Time não tem Go expert hoje (Wagner + Felipe + Maiara/Eliana operam TypeScript/PHP)
+- Construir daemon-go from scratch = ~500-1000 LOC Go + risco recriar bugs já resolvidos no WuzAPI
+- WuzAPI tem ~3 anos produção, Docker image pronta, multi-session, webhook nativo
+- Se gap aparecer (endpoint que WuzAPI não cobre), fork interno + patch depois
+
+**Não escolhemos voltar Baileys ajustado:**
+
+- Wagner já reportou abandono ("instável não deu pra usar")
+- Daemon Node Baileys foi DELETADO (ADR 0202) — preservado em branch `archive/baileys-daemon` + tag `baileys-final-2026-05-27` pra arqueologia, não pra reativar
+- Re-implementar Baileys = recriar mesmo problema instabilidade que motivou descontinuação
+
+**Não escolhemos só Meta Cloud (status quo ADR 0202):**
+
+- Sinal qualificado Wagner 2026-05-27 explícito: queria substituto
+- PME real Brasil (Larissa, Termas) ainda não tem Meta Business Manager verificado
+- Onboarding 5-15 min Meta vs 30s scan QR = barreira real cliente
+
+## Consequências
+
+**Positivas:**
+- Wagner re-cria Jana + Suporte channels via UI scan QR (cliente sinal atendido em ≤1 dia pós-merge)
+- Onboarding cliente PME novo cai de 5-15min (Embedded Signup v4) pra 30s (scan QR whatsmeow)
+- Sessões long-running estáveis (vs instabilidade Baileys reportada)
+- Footprint CT 100 menor (~37% menos RAM por sessão)
+- WuzAPI mantenedor ativo + Beeper sponsoriza whatsmeow upstream
+
+**Negativas / Trade-offs:**
+- Risco ban Meta IGUAL Baileys (Wagner ciente, documentado neste ADR + UI)
+- Mais 1 container CT 100 pra Wagner gerenciar (1 + Centrifugo + Brain + ...)
+- WuzAPI é dependência externa (vs daemon Node interno antes) — risco de descontinuação
+- Pré-requisito Wagner deploy CT 100 manual (runbook step-by-step provido)
+- Time aprende API WuzAPI (mas é REST simples, sem complexidade Go runtime)
+
+**Riscos mitigados:**
+- Multi-tenant Tier 0 — webhook URL com `{business_uuid}`, business_id global scope (ADR 0093)
+- Tokens daemon cifrados em DB (cast `encrypted:array` no `channels.config_json`)
+- LGPD ack obrigatório FormRequest (mesma rule Baileys)
+- Fallback Meta Cloud automático quando driver_health degrada (ADR 0096 emenda 3 preservada)
+- Cross-tenant ban alarm (3 banidos/24h → alerta Wagner)
+- IP whitelist Hostinger no Traefik daemon (CT 100 não exposto público total)
+
+## Referências
+
+- ADR 0094 — Constituição v2 (parent — Tier 0 multi-tenant + fallback obrigatório)
+- ADR 0202 — WhatsApp Profissionalização (amend partially — Baileys OUT integral, esta ADR adiciona whatsmeow)
+- ADR 0096 — Meta Cloud direto (emendas 1-3 preservadas: Z-API válido + Evolution PROIBIDO + fallback obrigatório)
+- ADR 0093 — Multi-tenant Tier 0 IRREVOGÁVEL
+- ADR 0058 — Centrifugo + FrankenPHP runtime CT 100 (whatsmeow daemon vai no mesmo host)
+- ADR 0062 — Hostinger ≠ CT 100 separação (whatsmeow é CT 100)
+- ADR 0105 — Cliente como sinal qualificado (Wagner = cliente arquitetural, 2026-05-27 sinal explícito)
+- ADR 0117 — Multi-números WhatsApp por business (whatsmeow respeita 1:N business→channels)
+- [whatsmeow GitHub](https://github.com/tulir/whatsmeow) (Tulir Asokan / Beeper)
+- [WuzAPI GitHub](https://github.com/asternic/wuzapi) + [API.md](https://github.com/asternic/wuzapi/blob/main/API.md)
+- [whatsmeow issue #810](https://github.com/tulir/whatsmeow/issues/810) — onda detecção Meta 2026 (transparência ban risk)
+- Proposta rejeitada [`proposals/2026-05-27-baileys-vs-whatsmeow-substituicao-daemon-whatsapp.md`](proposals/2026-05-27-baileys-vs-whatsmeow-substituicao-daemon-whatsapp.md) — análise técnica original
+- Companion dossier [`memory/sessions/2026-05-27-dossier-whatsapp-profissionalizacao.md`](../sessions/2026-05-27-dossier-whatsapp-profissionalizacao.md)

--- a/memory/requisitos/Whatsapp/SPEC.md
+++ b/memory/requisitos/Whatsapp/SPEC.md
@@ -17,6 +17,8 @@ related_adrs:
 > Decisão arquitetural mãe: [ADR 0096](../../decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md)
 > **Atualizado por [ADR 0202](../../decisions/0202-whatsapp-profissionalizacao-baileys-out.md) (2026-05-27):**
 > Meta Cloud API default universal · Z-API opcional fallback per-tenant · BaileysDriver DESCONTINUADO · Evolution PROIBIDO Tier 0 (permanente).
+> **Amend [ADR 0204](../../decisions/0204-whatsmeow-driver-substituto-baileys.md) (2026-05-27):**
+> Whatsmeow Go driver via daemon WuzAPI CT 100 ENTRA como substituto não-oficial Baileys (mesma data ADR 0202). Risco ban Meta igual Baileys (whatsmeow issue #810) — trade-off técnico aceito por estabilidade long-running + footprint -37% RAM. Baileys segue forbidden.
 
 ## 1. Glossário rápido
 
@@ -29,10 +31,11 @@ related_adrs:
 - **HITL** — Human In The Loop (handoff bot→humano quando PolicyEngine retorna `REQUIRE_HUMAN_REVIEW`)
 - **Deflection** — % de conversas resolvidas sem intervenção humana
 - **Conversation** — janela 24h Meta (cobrada uma vez); várias mensagens dentro = 1 conversa
-- **Driver (pós ADR 0202)** — abstração `MetaCloudDriver` (default universal) / `ZapiDriver` (opcional fallback) / `NullDriver` (CI). `BaileysDriver` DESCONTINUADO 2026-05-27.
+- **Driver (pós ADR 0202 + 0204)** — abstração `MetaCloudDriver` (default universal) / `ZapiDriver` (opcional fallback) / `WhatsmeowDriver` (substituto não-oficial Baileys, ADR 0204) / `NullDriver` (CI). `BaileysDriver` DESCONTINUADO 2026-05-27.
 - **Meta Cloud (default universal pós ADR 0202)** — oficial Meta (`graph.facebook.com/v21.0`). Free 1k conv/mês BR. Sem risco ban. Embedded Signup v4 simplifica onboarding (Fase 2 ADR 0202).
 - **Z-API (opcional fallback pós ADR 0202)** — SaaS BR (`api.z-api.io`) baseado em Whatsapp Web. Onboarding 5 min (scan QR). **Risco ban Meta** (mitigado por fallback Meta Cloud obrigatório + termo LGPD).
-- **BaileysDriver custom** — DESCONTINUADO 2026-05-27 ([ADR 0202](../../decisions/0202-whatsapp-profissionalizacao-baileys-out.md), supersede ADR 0096 emenda 4). Daemon Node CT 100 descomissionado. Tenants legacy migram pra Meta Cloud em Fase 2/3.
+- **WhatsmeowDriver (ADR 0204)** — driver não-oficial via daemon Go WuzAPI CT 100 (substituto Baileys). Scan QR 30s, custo zero. **Risco ban Meta igual Baileys** ([whatsmeow #810](https://github.com/tulir/whatsmeow/issues/810)). LGPD ack obrigatório. Fallback Meta Cloud automático quando degrada.
+- **BaileysDriver custom** — DESCONTINUADO 2026-05-27 ([ADR 0202](../../decisions/0202-whatsapp-profissionalizacao-baileys-out.md), supersede ADR 0096 emenda 4). Daemon Node CT 100 descomissionado. Tenants legacy migram pra Meta Cloud em Fase 2/3. **Substituído pelo Whatsmeow Go** ([ADR 0204](../../decisions/0204-whatsmeow-driver-substituto-baileys.md)) que tem mesmo modelo + estabilidade melhor.
 - **Evolution API** — **PROIBIDO permanente** ([ADR 0096 emenda 4](../../decisions/0096-modulo-whatsapp-meta-cloud-api-direto.md)). Razões concretas: bans recorrentes em produção Wagner + schema não atende + falta de observabilidade.
 - **Driver Health Check** — job 6h em 6h envia ping pra detectar ban Z-API. BaileysDriver não monitorado pós ADR 0202.
 - **Fallback automático** — quando Z-API `driver_health` ≥ degraded, sistema troca pra Meta Cloud sem intervenção.

--- a/memory/requisitos/Whatsapp/runbooks/whatsmeow-daemon-deploy-ct100.md
+++ b/memory/requisitos/Whatsapp/runbooks/whatsmeow-daemon-deploy-ct100.md
@@ -1,0 +1,263 @@
+# Runbook · Deploy daemon Whatsmeow Go (WuzAPI) no CT 100
+
+> **Status:** canon · **Última atualização:** 2026-05-27
+> **Decisão arquitetural:** [ADR 0204](../../../decisions/0204-whatsmeow-driver-substituto-baileys.md)
+> **Substitui:** daemon Node Baileys (descontinuado [ADR 0202](../../../decisions/0202-whatsapp-profissionalizacao-baileys-out.md))
+> **Pré-requisitos:** acesso SSH CT 100 (`root@ct100.oimpresso.local`) + Tailscale + Docker + secret manager
+
+## Objetivo
+
+Subir container Docker `whatsapp-whatsmeow` no CT 100, expor via Traefik com IP whitelist Hostinger, configurar webhook bidirecional com Laravel app, validar smoke teste com 1ª sessão WhatsApp.
+
+## Pré-check (5 min)
+
+```bash
+# 1. SSH no CT 100
+ssh root@ct100.oimpresso.local  # OU via Tailscale: ssh root@ct100
+
+# 2. Confirma Docker + Traefik rodando
+docker ps | grep -E "traefik|centrifugo"
+
+# 3. Confirma DNS já apontando
+dig whatsapp-whatsmeow.oimpresso.com  # esperado: IP CT 100
+# Se não: adicionar A record no Cloudflare ANTES de prosseguir
+
+# 4. Confirma rede Docker compartilhada
+docker network ls | grep oimpresso_default
+```
+
+## Passo 1 — Provisionar storage persistente (2 min)
+
+```bash
+# Volumes pra sessões WhatsApp pareadas + cache de mídia
+mkdir -p /srv/docker/whatsapp-whatsmeow/{sessions,files}
+chown -R root:root /srv/docker/whatsapp-whatsmeow
+chmod -R 700 /srv/docker/whatsapp-whatsmeow  # sessões = credencial sensível
+
+# Backup directory pra cron daily
+mkdir -p /srv/backup/whatsmeow
+```
+
+> **Warning:** `/srv/docker/whatsapp-whatsmeow/sessions/` armazena credenciais WhatsApp Web (auth state pareada). Perder essas pastas = todos os channels desconectados, Wagner precisa re-scan QR em cada um. **Recomendado:** FS encrypted (LUKS) ou volume snapshot regular.
+
+## Passo 2 — Gerar segredos criptograficamente fortes (1 min)
+
+```bash
+# Admin token (Bearer auth pra criar users no daemon)
+openssl rand -hex 32 > /run/secrets/whatsmeow_admin_token
+chmod 600 /run/secrets/whatsmeow_admin_token
+
+# HMAC secret (assina webhooks daemon → Laravel)
+openssl rand -hex 32 > /run/secrets/whatsmeow_hmac_secret
+chmod 600 /run/secrets/whatsmeow_hmac_secret
+
+# Anotar valores pra colocar no .env Hostinger DEPOIS (passo 5)
+cat /run/secrets/whatsmeow_admin_token
+cat /run/secrets/whatsmeow_hmac_secret
+# IMPORTANTE: copiar valores AGORA — depois `cat` exige acessar arquivo /run/secrets
+```
+
+Salvar no Vaultwarden:
+- Entry: **"WhatsApp Whatsmeow Admin Token"** — valor `whatsmeow_admin_token`
+- Entry: **"WhatsApp Whatsmeow HMAC Secret"** — valor `whatsmeow_hmac_secret`
+
+## Passo 3 — Materializar docker-compose (3 min)
+
+```bash
+mkdir -p /opt/oimpresso/whatsmeow
+cd /opt/oimpresso/whatsmeow
+
+# Copiar docker-compose.yml do repo (já versionado)
+# Opção A — git clone se não tem ainda:
+git clone https://github.com/wagnerra/oimpresso.git /tmp/oimpresso
+cp /tmp/oimpresso/Modules/Whatsapp/daemon-go/docker-compose.yml .
+
+# Opção B — copiar via scp do dev local:
+# scp Modules/Whatsapp/daemon-go/docker-compose.yml root@ct100:/opt/oimpresso/whatsmeow/
+
+# Verificar service correto
+docker compose config --quiet  # silencia se OK
+```
+
+## Passo 4 — Subir container + smoke interno (5 min)
+
+```bash
+cd /opt/oimpresso/whatsmeow
+
+# Up em background
+docker compose up -d
+
+# Aguardar healthy (~30s)
+docker compose ps  # esperado: STATUS = "Up (healthy)"
+
+# Logs iniciais — deve mostrar bind 8080 + DB init
+docker compose logs --tail=50 whatsapp-whatsmeow
+
+# Smoke interno (rede Docker — não usa Traefik ainda)
+docker exec whatsapp-whatsmeow wget -q -O - http://localhost:8080/health
+# esperado: {"status":"ok"} OU equivalente WuzAPI
+```
+
+## Passo 5 — Configurar Laravel `.env` Hostinger (2 min)
+
+No painel Hostinger ou SSH:
+
+```bash
+# Editar .env Laravel produção
+$EDITOR /home/u606057284/domains/oimpresso.com/public_html/.env
+
+# Adicionar (substituir valores pelos gerados no Passo 2):
+WHATSMEOW_DAEMON_URL=https://whatsapp-whatsmeow.oimpresso.com
+WHATSMEOW_API_KEY=<conteúdo de /run/secrets/whatsmeow_admin_token>
+WHATSMEOW_HMAC_SECRET=<conteúdo de /run/secrets/whatsmeow_hmac_secret>
+WHATSMEOW_TIMEOUT=15
+
+# Limpar cache config Laravel
+php artisan config:clear
+```
+
+## Passo 6 — Smoke público via Traefik (5 min)
+
+Do Hostinger app (IP whitelist 148.135.133.115/32 permitido):
+
+```bash
+# Conferir Traefik route ativa
+curl -sI https://whatsapp-whatsmeow.oimpresso.com
+# esperado: HTTP/2 200 (OU 401 sem auth — Tier 0 esperado)
+
+# Listar users (deve estar vazio inicial)
+curl -H "Authorization: Bearer $WHATSMEOW_API_KEY" \
+  https://whatsapp-whatsmeow.oimpresso.com/admin/users
+# esperado: {"data":[]} ou similar
+```
+
+De fora do whitelist (qualquer outro IP): deve dar **403 Forbidden** pelo Traefik middleware.
+
+## Passo 7 — Primeira sessão (Wagner como cliente piloto, 5 min)
+
+1. Wagner abre `https://oimpresso.com/atendimento/canais`
+2. Clica **"Adicionar canal"**
+3. Seleciona tipo **"WhatsApp Whatsmeow (Go)"**
+4. Preenche label (ex: "Jana Comercial") + telefone E.164 (ex: `+5548999000000`) + aceita LGPD
+5. **"Salvar canal"** → channel criado com `status=setup`
+6. Clica **"Conectar"** no card do channel novo
+7. Backend chama `POST /admin/users` no daemon → daemon cria sessão `ch-{uuid}` + retorna QR base64
+8. Modal mostra QR PNG
+9. Wagner abre celular → WhatsApp → Configurações → Dispositivos vinculados → escaneia QR
+10. Daemon dispara webhook `Connected` → Laravel atualiza `channel.status=active` + UI Centrifugo realtime detecta
+
+## Passo 8 — Backup diário (cron 5 min)
+
+```bash
+# /etc/cron.daily/backup-whatsmeow
+cat > /etc/cron.daily/backup-whatsmeow << 'EOF'
+#!/bin/bash
+DATE=$(date +%F)
+tar czf /srv/backup/whatsmeow/whatsmeow-$DATE.tar.gz \
+  /srv/docker/whatsapp-whatsmeow/sessions \
+  2>&1
+
+# Retenção: mantém últimos 14 dias
+find /srv/backup/whatsmeow/ -name "whatsmeow-*.tar.gz" -mtime +14 -delete
+EOF
+chmod +x /etc/cron.daily/backup-whatsmeow
+
+# Smoke imediato
+/etc/cron.daily/backup-whatsmeow
+ls -la /srv/backup/whatsmeow/
+```
+
+## Operação contínua
+
+### Health check periódico
+
+```bash
+docker compose ps whatsapp-whatsmeow
+# espera: STATUS "Up (healthy)"
+
+# Se unhealthy persistente:
+docker compose logs --tail=200 whatsapp-whatsmeow
+```
+
+### Upgrade WuzAPI
+
+```bash
+cd /opt/oimpresso/whatsmeow
+docker compose pull
+docker compose up -d  # zero downtime se compose recria com mesma volume
+docker image prune -f  # limpa images velhas
+```
+
+### Restart sem perder sessões
+
+```bash
+docker compose restart whatsapp-whatsmeow
+```
+
+### Listar sessões ativas
+
+```bash
+curl -H "Authorization: Bearer $(cat /run/secrets/whatsmeow_admin_token)" \
+  https://whatsapp-whatsmeow.oimpresso.com/admin/users \
+  | jq '.data[] | {name, connected, jid}'
+```
+
+### Deletar sessão (rollback / cliente cancelou)
+
+```bash
+# Substituir ch-uuid pelo nome real (vem de channel.config_json.whatsmeow_user_name)
+curl -X DELETE \
+  -H "Authorization: Bearer $(cat /run/secrets/whatsmeow_admin_token)" \
+  https://whatsapp-whatsmeow.oimpresso.com/admin/users/ch-aaaaa
+```
+
+## Troubleshooting
+
+| Sintoma | Diagnóstico | Mitigação |
+|---|---|---|
+| `docker compose up` falha em "network not found" | Rede `oimpresso_default` não existe | `docker network create oimpresso_default` ou ajustar `external: false` |
+| QR não aparece no UI Laravel | Daemon retorna 401 ou 503 | Confere `WHATSMEOW_API_KEY` Laravel = `/run/secrets/whatsmeow_admin_token` CT 100 |
+| Webhook não chega no Laravel | IP outbound CT → Hostinger não passa | Confere DNS público + Traefik permite saída + Hostinger aceita IP CT 100 inbound |
+| Channel marcado `banned` após scan | Onda detecção Meta 2026 (whatsmeow issue #810) | Esperado — risco aceito ADR 0204. Fallback Meta Cloud ativa |
+| `429` no webhook receiver | Backpressure queue depth > max | Reduzir taxa ou aumentar `WHATSAPP_QUEUE_MAX_DEPTH` (US-WA-084) |
+| Volume sessões some após reboot | Volume bind path errado | Confere `docker compose config` tem mount `/srv/docker/whatsapp-whatsmeow/sessions:/app/dbdata` |
+| `Token` header rejeitado (401) | user_token Laravel desincronizado | Re-provisiona channel: `DELETE` no daemon + recria via UI Conectar |
+
+## Métricas operacionais (Wagner monitorar)
+
+Daily (`jana:health-check` cron 06:00 BRT):
+
+- Sessões whatsmeow conectadas: `channels.channel_health` em (healthy, never_checked) WHERE type=whatsapp_whatsmeow
+- Sessões banidas: `channels.channel_health=banned` WHERE type=whatsapp_whatsmeow
+- Cross-tenant ban threshold: ≥3 channels banidos em 24h → ALERT (`whatsapp.cross_tenant_ban_alarm_threshold`)
+
+Weekly:
+- RAM uso daemon: `docker stats whatsapp-whatsmeow --no-stream`
+- Backup size growth: `du -sh /srv/backup/whatsmeow/`
+
+Monthly:
+- Comparar custo CT 100 + RAM daemon vs Meta Cloud msg cost por business
+- Avaliar mover channels antigos pra Meta Cloud (cliente maduro)
+
+## Rollback
+
+Se daemon whatsmeow se mostrar problemático (instabilidade, custo, abuse):
+
+1. Marcar canais `whatsapp_whatsmeow` como `enabled=false` no `availableTypesForUi()` (commit + deploy)
+2. Migrar channels existentes pra Meta Cloud (cliente final re-scan via Embedded Signup v4)
+3. Stop container: `docker compose down` no CT 100
+4. Backup final volume: `tar czf /srv/backup/whatsmeow/final-pre-decom.tar.gz /srv/docker/whatsapp-whatsmeow/`
+5. Remover volume: `rm -rf /srv/docker/whatsapp-whatsmeow/` (após confirmar backup)
+6. Marcar `whatsmeow` em `forbidden_drivers` no `Modules/Whatsapp/Config/config.php`
+7. ADR amend formal explicando o que aconteceu
+
+## Referências
+
+- [ADR 0204](../../../decisions/0204-whatsmeow-driver-substituto-baileys.md) — esta decisão
+- [ADR 0202](../../../decisions/0202-whatsapp-profissionalizacao-baileys-out.md) — Baileys descontinuado integral
+- [ADR 0058](../../../decisions/0058-reverb-substituido-por-centrifugo-frankenphp.md) — runtime CT 100 Traefik
+- [ADR 0062](../../../decisions/0062-separacao-runtime-hostinger-ct100.md) — Hostinger ≠ CT 100
+- [WuzAPI GitHub](https://github.com/asternic/wuzapi)
+- [WuzAPI API.md](https://github.com/asternic/wuzapi/blob/main/API.md)
+- [whatsmeow GitHub](https://github.com/tulir/whatsmeow)
+- [Modules/Whatsapp/daemon-go/](../../../../Modules/Whatsapp/daemon-go/) — docker-compose + README

--- a/resources/js/Pages/Atendimento/Channels/Index.tsx
+++ b/resources/js/Pages/Atendimento/Channels/Index.tsx
@@ -46,7 +46,10 @@ interface Channel {
   has_zapi_credentials: boolean;
   has_meta_credentials: boolean;
   has_baileys_credentials: boolean;
+  // ADR 0204 — substituto não-oficial Baileys via daemon Go WuzAPI
+  has_whatsmeow_credentials: boolean;
   baileys_phone_e164: string | null;
+  whatsmeow_phone_e164: string | null;
   zapi_instance_id: string | null;
   meta_phone_number_id: string | null;
   lgpd_acknowledged_at: string | null;
@@ -390,6 +393,10 @@ export default function ChannelsIndex({ channels, availableTypes }: Props) {
             {type === 'whatsapp_baileys' && (
               <BaileysFields config={config} setConfig={setConfig} lgpdOk={lgpdOk} setLgpdOk={setLgpdOk} />
             )}
+            {/* ADR 0204 — substituto não-oficial Baileys via daemon Go WuzAPI */}
+            {type === 'whatsapp_whatsmeow' && (
+              <WhatsmeowFields config={config} setConfig={setConfig} lgpdOk={lgpdOk} setLgpdOk={setLgpdOk} />
+            )}
             {type === 'whatsapp_zapi' && (
               <ZapiFields config={config} setConfig={setConfig} />
             )}
@@ -448,7 +455,8 @@ function ChannelCard({
     never_checked: 'text-muted-foreground',
   }[channel.channel_health];
 
-  const showConnect = channel.type === 'whatsapp_baileys'
+  // ADR 0204 — connect button visivel pra whatsmeow tambem (substituto Baileys)
+  const showConnect = (channel.type === 'whatsapp_baileys' || channel.type === 'whatsapp_whatsmeow')
     && channel.status !== 'active'
     && channel.channel_health !== 'healthy';
 
@@ -575,6 +583,42 @@ function BaileysFields({
           Aceito que Baileys é driver não-oficial (WhatsApp Web reverse-engineered).
           Meta pode banir o número a qualquer momento. Fallback Meta Cloud
           obrigatório quando driver_health degrada.
+        </Label>
+      </div>
+    </>
+  );
+}
+
+// ADR 0204 (2026-05-27) — substituto não-oficial Baileys via daemon Go WuzAPI.
+// Risco ban Meta IGUAL Baileys (whatsmeow issue #810). LGPD ack obrigatório.
+function WhatsmeowFields({
+  config, setConfig, lgpdOk, setLgpdOk,
+}: {
+  config: Record<string, string>; setConfig: (c: Record<string, string>) => void;
+  lgpdOk: boolean; setLgpdOk: (v: boolean) => void;
+}) {
+  return (
+    <>
+      <div className="space-y-1">
+        <Label htmlFor="whatsmeow_phone">Telefone WhatsApp (E.164)</Label>
+        <Input
+          id="whatsmeow_phone"
+          value={config.whatsmeow_phone_e164 || ''}
+          onChange={(e) => setConfig({ ...config, whatsmeow_phone_e164: e.target.value })}
+          placeholder="+5511987654321"
+          required
+        />
+        <p className="text-xs text-amber-700 dark:text-amber-400 inline-flex items-start gap-1">
+          <AlertTriangle size={11} className="mt-0.5 shrink-0" aria-hidden />
+          Chip dedicado pra empresa — NUNCA número pessoal. Risco ban Meta (igual Baileys).
+        </p>
+      </div>
+      <div className="flex items-start gap-2 rounded-md border bg-muted/30 p-3 text-xs">
+        <Checkbox id="lgpd-whatsmeow" checked={lgpdOk} onCheckedChange={(v) => setLgpdOk(v === true)} />
+        <Label htmlFor="lgpd-whatsmeow" className="leading-relaxed text-xs cursor-pointer">
+          Aceito que Whatsmeow é driver não-oficial (lib Go via daemon WuzAPI próprio).
+          Meta pode banir o número a qualquer momento (igual Baileys — issue #810 upstream).
+          Fallback Meta Cloud obrigatório quando driver_health degrada (ADR 0204).
         </Label>
       </div>
     </>


### PR DESCRIPTION
## Summary

Wagner pediu 2026-05-27: *"queria o driver novo (substituto Baileys), o outro qual o nome?"* — confirmou **whatsmeow**.

ADR 0202 acertou em remover Baileys (instável) mas errou interpretação: foi direto pra Meta Cloud oficial (Embedded Signup v4 burocrático, exige Meta Business Manager). Wagner queria **substituto direto** Baileys com mesmo modelo (scan QR 30s, custo zero, sem BM).

**ADR 0204 amend parcial 0202:** adiciona driver `whatsmeow` (Go via WuzAPI wrapper) como alternativa não-oficial. Meta Cloud continua default universal; Z-API legacy; Baileys segue forbidden (deletado).

## Trade-off explícito (Wagner ciente)

Risco ban Meta = **igual Baileys** ([whatsmeow issue #810](https://github.com/tulir/whatsmeow/issues/810)). Wagner aceita pra ter onboarding simples scan QR.

Ganho técnico (não de risco):
- Footprint -37% RAM por sessão (~50MB vs ~80MB Baileys)
- Sessões long-running estáveis (Beeper mantenedor pago)
- Multi-session nativo

## Mudanças (7 commits, +2201 LOC / 20 files)

1. `docs(adr)` — ADR 0204 aceita (Nygard format)
2. `chore(daemon-go)` — docker-compose WuzAPI + README + .env.example
3. `feat(schema)` — Channel::TYPE_WHATSAPP_WHATSMEOW + Config + ChannelRequest validation (LGPD ack + cross-tenant uniqueness)
4. `feat(driver)` — WhatsmeowDriver PHP + DriverFactory + ChannelDriverFactory
5. `feat(webhook)` — WhatsmeowWebhookController + VerifyWhatsmeowSignature middleware + rota `/api/whatsapp/webhook/whatsmeow/{business_uuid}`
6. `feat(ui)` — WhatsmeowFields + connect modal pra type whatsapp_whatsmeow em `Atendimento/Channels/Index.tsx` (Caixa Unificada v4)
7. `test` — WhatsmeowDriverTest + ChannelIsolationTest + runbook deploy CT 100 + SPEC update

## Multi-tenant Tier 0 preservado (ADR 0093)

- Webhook URL com `{business_uuid}` no path
- `business_id` global scope respeitado em todas queries
- Tokens cifrados via `encrypted:array` no `channels.config_json`
- Cross-tenant uniqueness check no FormRequest (mesmo phone em 2 channels = 422)
- LGPD ack obrigatório no store

## Tests

```
PASS Modules\Whatsapp\Tests\Feature\WhatsmeowDriverTest (8 testes)
PASS Modules\Whatsapp\Tests\Feature\WhatsmeowChannelIsolationTest (8 testes)
Tests: 16 passed (43 assertions / 6.25s)
```

Cobertura:
- Send text via Http::fake (NUNCA chama daemon real)
- HTTP 401 → sessionLost / HTTP 403 banned → banDetected
- ping Connected+LoggedIn / ping qr_required
- provisionSession POST /admin/users com webhook multi-tenant
- sendInteractive throw DriverDoesNotSupport (driver não-oficial)
- whatsmeowUserName() helper (ch-{uuid sem hifens})
- Config + forbidden_drivers + Channel::TYPES presença

## Próximo (Wagner)

1. Mergear este PR (`gh pr merge --admin`)
2. SSH CT 100 → deploy docker-compose whatsmeow daemon (runbook step-by-step provido)
3. Adicionar `WHATSMEOW_DAEMON_URL` + `WHATSMEOW_API_KEY` + `WHATSMEOW_HMAC_SECRET` no `.env` Hostinger
4. Re-criar Jana + Suporte channels via UI scan QR (type=whatsapp_whatsmeow)

## NÃO faz

- Deploy físico CT 100 (Wagner usa runbook)
- Deploy `.env` Hostinger (Wagner manual)
- Re-implementa Baileys (forbidden permanece)
- Cria `Settings.tsx` (UI canon é `/atendimento/canais` ADR 0135)

Refs: ADR-0204 Fase-2.5-whatsmeow-substituto-baileys

🤖 Generated with Claude Code via audit-implement-expert (Wagner sinal qualificado 2026-05-27)