### PR TITLE
fix(cliente/drawer): lookup CEP atualiza rows cache via onContactUpdated

### DIFF
--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -2010,7 +2010,11 @@ function ClienteSheet({
                 <ContatoTab contact={contact} />
               </div>
               <div hidden={activeTab !== 'endereco'}>
-                <EnderecoTab key={enderecoVersion} contact={contact} />
+                <EnderecoTab
+                  key={enderecoVersion}
+                  contact={contact}
+                  onContactUpdated={onContactUpdated}
+                />
               </div>
               <div hidden={activeTab !== 'comercial'}>
                 <ComercialTab contact={contact} />

--- a/resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx
@@ -61,6 +61,16 @@ export interface ContactInfo {
 export interface EnderecoTabProps {
   contact: ContactInfo;
   onSaved?: (field: string, value: unknown) => void;
+  /**
+   * Wagner 2026-05-27 — chamado apos lookup CEP persistir campos novos no
+   * banco. Pai (ClienteSheet) atualiza `draftContact` ou row no parent state
+   * DIRETAMENTE pra evitar cache stale Inertia (rows.find retornaria snapshot
+   * pre-lookup). Padrao alinhado ao `IdentificacaoTab.onContactUpdated`.
+   *
+   * Sintoma sem este callback: user clica Buscar CEP → 5 PATCHes 200 OK →
+   * fecha drawer → reabre → campos voltam aos VELHOS (rows nao atualizou).
+   */
+  onContactUpdated?: (patched: Record<string, unknown>) => void;
   disabled?: boolean;
 }
 
@@ -81,7 +91,7 @@ function getCsrfToken(): string {
   );
 }
 
-export default function EnderecoTab({ contact, onSaved, disabled = false }: EnderecoTabProps) {
+export default function EnderecoTab({ contact, onSaved, onContactUpdated, disabled = false }: EnderecoTabProps) {
   // Inicialização — preferir canon UPOS, fallback PT-BR legado pra graceful com
   // a listagem (Index.tsx ainda emite cidade/uf PT-BR no payload da tabela).
   const [zipCode, setZipCode] = useState<string>(maskCEP(contact.zip_code ?? contact.cep ?? ''));
@@ -246,27 +256,42 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
       const novaCidade = (json?.cidade as string) ?? '';
       const novaUf = (json?.uf as string) ?? '';
 
+      // Wagner 2026-05-27 — acumula campos preenchidos pra emitir 1 callback batch
+      // ao final ao parent (ClienteSheet) atualizar draftContact/rows direto
+      // sem depender de router.reload (que nao pega Inertia::defer cache).
+      const contactPatch: Record<string, unknown> = {};
+
       if (novoLogr) {
         setAddressLine1(novoLogr);
         performSave('address_line_1', novoLogr, addressLine1);
+        contactPatch.address_line_1 = novoLogr;
       }
       // Complemento ViaCEP (ex "lado impar 612 a 1510" SP) — SOBRESCREVE
       // (política feedback-lookup-cnpj-sobrescreve-dados: dado oficial público).
       if (novoComplemento) {
         setAddressLine2(novoComplemento);
         performSave('address_line_2', novoComplemento, addressLine2);
+        contactPatch.address_line_2 = novoComplemento;
       }
       if (novoBairro) {
         setNeighborhood(novoBairro);
         performSave('neighborhood', novoBairro, neighborhood);
+        contactPatch.neighborhood = novoBairro;
       }
       if (novaCidade) {
         setCity(novaCidade);
         performSave('city', novaCidade, city);
+        contactPatch.city = novaCidade;
       }
       if (novaUf) {
         setStateUf(novaUf);
         performSave('state', novaUf, stateUf);
+        contactPatch.state = novaUf;
+      }
+      // Notifica parent pra atualizar draftContact/row -- evita cache stale
+      // Inertia ao fechar+reabrir drawer pos lookup (bug Wagner 2026-05-27).
+      if (Object.keys(contactPatch).length > 0) {
+        onContactUpdated?.(contactPatch);
       }
       setCepLookup('ok');
       setCepLookupMsg('Endereço preenchido pelo ViaCEP.');
@@ -280,7 +305,7 @@ export default function EnderecoTab({ contact, onSaved, disabled = false }: Ende
       // eslint-disable-next-line no-console
       console.error('[EnderecoTab] cep lookup failed', err);
     }
-  }, [zipCode, addressLine1, neighborhood, city, stateUf, performSave]);
+  }, [zipCode, addressLine1, addressLine2, neighborhood, city, stateUf, performSave, onContactUpdated]);
 
   const handleUfChange = useCallback(
     (v: string) => {

--- a/tests/Feature/Cliente/ClienteDrawerCepLookupRowsRefreshTest.php
+++ b/tests/Feature/Cliente/ClienteDrawerCepLookupRowsRefreshTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Wagner 2026-05-27 -- bug Endereco lookup CEP NAO ATUALIZAVA drawer ao reabrir.
+ *
+ * Sintoma: user clica Buscar CEP → 5 PATCHes 200 OK → fecha drawer → reabre
+ * mesmo cliente → campos voltam aos VELHOS (logradouro, complemento, bairro,
+ * cidade ainda dados pre-lookup).
+ *
+ * Raiz: EnderecoTab nao tinha `onContactUpdated` callback (IdentificacaoTab
+ * tinha). Backend persistia OK (resposta PATCH com dados novos) mas
+ * `rows.find()` Inertia cache mantinha snapshot velho.
+ *
+ * Fix: EnderecoTab aceita prop `onContactUpdated` + acumula campos do lookup
+ * em batch + chama callback ao final → parent atualiza draftContact direto.
+ *
+ * GUARDs estruturais (file_get_contents, sem DB).
+ */
+
+// ─── GUARD 1: EnderecoTab declara onContactUpdated ────────────────────────
+
+test('GUARD 1 — EnderecoTab interface declara onContactUpdated callback', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain('onContactUpdated?: (patched: Record<string, unknown>) => void')
+        // Destructured no componente principal.
+        ->toContain('export default function EnderecoTab({ contact, onSaved, onContactUpdated');
+});
+
+// ─── GUARD 2: handleCepLookup acumula contactPatch + chama callback ──────
+
+test('GUARD 2 — handleCepLookup acumula contactPatch batch e chama onContactUpdated ao final', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        // Cada campo persistido tambem entra no batch contactPatch.
+        ->toContain('contactPatch.address_line_1 = novoLogr')
+        ->toContain('contactPatch.address_line_2 = novoComplemento')
+        ->toContain('contactPatch.neighborhood = novoBairro')
+        ->toContain('contactPatch.city = novaCidade')
+        ->toContain('contactPatch.state = novaUf')
+        // Callback chamado ao final (so se houver patch).
+        ->toContain('onContactUpdated?.(contactPatch)');
+});
+
+// ─── GUARD 3: Index.tsx repassa onContactUpdated pro EnderecoTab ─────────
+
+test('GUARD 3 — Cliente/Index.tsx repassa onContactUpdated pro EnderecoTab', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toMatch("/<EnderecoTab\\s+key=\\{enderecoVersion\\}\\s+contact=\\{contact\\}\\s+onContactUpdated=\\{onContactUpdated\\}/");
+});


### PR DESCRIPTION
Wagner 2026-05-27 reportou: "se consultar só o CEP e salvar não salva nada".

Backend persistia OK (validado via PATCH monkey-patch — 4 PATCHes 200 com response `addressBack: 'Rua Sete de Setembro - D'`). Bug era no carregamento — `rows.find()` no Inertia::defer cache retornava snapshot pré-lookup.

EnderecoTab agora aceita `onContactUpdated` callback (igual IdentificacaoTab desde #1419). Acumula campos do lookup em batch + chama 1 callback ao final → parent atualiza `draftContact` direto.

3 GUARDs Pest. Refs: ADR 0179, session 2026-05-27