### PR TITLE
fix(whatsapp/whatsmeow): remove prefix Bearer (WuzAPI 401)

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/ChannelsController.php
@@ -422,7 +422,7 @@ class ChannelsController extends Controller
             // Estados que NÃO precisam (fresh start já vai conectar):
             //  - 404 not_found (instância nunca existiu)
             //  - connecting / qr_required / connected (já está OK ou em fluxo)
-            $statusResponse = Http::withToken($apiKey)
+            $statusResponse = Http::withHeaders(["Authorization" => $apiKey])
                 ->withoutVerifying()
                 ->timeout($timeout)
                 ->get("{$daemonUrl}/instances/{$instanceId}/status");
@@ -442,7 +442,7 @@ class ChannelsController extends Controller
                     'ban_reason' => $statusResponse->json('ban_reason'),
                 ]);
 
-                $purgeResponse = Http::withToken($apiKey)
+                $purgeResponse = Http::withHeaders(["Authorization" => $apiKey])
                     ->withoutVerifying()
                     ->timeout($timeout)
                     ->delete("{$daemonUrl}/instances/{$instanceId}");
@@ -461,7 +461,7 @@ class ChannelsController extends Controller
             // FIXME(US-WA-058): withoutVerifying temp — cert Let's Encrypt no CT 100
             // ainda não emitido (DNS propagou após Traefik tentar ACME). Remover
             // após restart container disparar nova emissão.
-            $connectResponse = Http::withToken($apiKey)
+            $connectResponse = Http::withHeaders(["Authorization" => $apiKey])
                 ->withoutVerifying()
                 ->timeout($timeout)
                 ->post("{$daemonUrl}/instances/{$instanceId}/connect", [
@@ -500,7 +500,7 @@ class ChannelsController extends Controller
             $state = null;
             for ($i = 0; $i < 15; $i++) {
                 usleep(800_000); // 800ms
-                $statusResponse = Http::withToken($apiKey)
+                $statusResponse = Http::withHeaders(["Authorization" => $apiKey])
                     ->withoutVerifying() // FIXME(US-WA-058): cert LE pendente
                     ->timeout($timeout)
                     ->get("{$daemonUrl}/instances/{$instanceId}/status");
@@ -520,7 +520,7 @@ class ChannelsController extends Controller
 
             // Fallback pairing code se QR não veio (raro)
             if (! $qrPngDataUrl && $state !== 'connected') {
-                $pcResponse = Http::withToken($apiKey)
+                $pcResponse = Http::withHeaders(["Authorization" => $apiKey])
                     ->withoutVerifying()
                     ->timeout($timeout)
                     ->post("{$daemonUrl}/instances/{$instanceId}/pairing-code", [
@@ -651,7 +651,7 @@ class ChannelsController extends Controller
         $instanceId = 'ch-' . str_replace('-', '', $channel->channel_uuid);
 
         try {
-            $r = Http::withToken($apiKey)
+            $r = Http::withHeaders(["Authorization" => $apiKey])
                 ->withoutVerifying() // FIXME(US-WA-058): cert LE pendente
                 ->timeout($timeout)
                 ->get("{$daemonUrl}/instances/{$instanceId}/status");

--- a/Modules/Whatsapp/Services/Drivers/WhatsmeowDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/WhatsmeowDriver.php
@@ -255,7 +255,7 @@ class WhatsmeowDriver implements DriverInterface
         $webhookUrl = rtrim((string) config('app.url'), '/')
             . "/api/whatsapp/webhook/whatsmeow/{$businessUuid}";
 
-        $response = Http::withHeaders(['Authorization' => "Bearer {$adminToken}"])
+        $response = Http::withHeaders(['Authorization' => $adminToken])
             ->withoutVerifying() // Daemon CT 100 self-signed dev; cert LE pendente
             ->timeout($timeout)
             ->baseUrl($daemonUrl)


### PR DESCRIPTION
Fix urgente — Wagner bloqueado tentando parear Suporte: `Daemon /admin/users retornou 401`. Root cause: `Http::withToken` Laravel adiciona prefix `Bearer ` mas WuzAPI exige token puro. 7 ocorrências fixed. Refs: ADR-0204 fix-auth-bearer-prefix