### PR TITLE
fix(cliente/drawer): Classificação Status display (canon EN vs alias PT-BR)

### DIFF
--- a/resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx
@@ -30,7 +30,10 @@ export interface ContactInfo {
   id: number;
   segmento?: string | null;
   tags?: string[] | null;
-  status?: 'ativo' | 'inativo' | 'bloqueado' | string | null;
+  /** Frontend legacy PT-BR. Pode chegar como `status` (alias) ou `contact_status`
+   *  (canon EN UPOS — backend persiste assim via PATCH /classificacao). */
+  status?: 'ativo' | 'inativo' | 'bloqueado' | 'active' | 'inactive' | 'blocked' | string | null;
+  contact_status?: 'active' | 'inactive' | 'blocked' | string | null;
   vip?: boolean | null;
   // ADR 0188 Onda 4 — flags multi-papel (Wagner 2026-05-25 UX refactor:
   // movido de IdentificacaoTab pra cá · papel é classificação semântica).
@@ -79,11 +82,26 @@ const TAG_OPTIONS = [
   'reincidente',
 ];
 
-const STATUS_OPTIONS: Array<{ value: 'ativo' | 'inativo' | 'bloqueado'; label: string; color: string }> = [
-  { value: 'ativo', label: 'Ativo', color: 'text-emerald-700' },
-  { value: 'inativo', label: 'Inativo', color: 'text-stone-700' },
-  { value: 'bloqueado', label: 'Bloqueado', color: 'text-rose-700' },
+// Wagner 2026-05-27 — backend canon UPOS persiste valores EN (`active`/
+// `inactive`/`blocked`) via PATCH /classificacao + ContactController. Frontend
+// legado nasceu PT-BR (`ativo`/`inativo`/`bloqueado`). Normaliza EN canon
+// (sem migration retroativa de dados).
+const STATUS_OPTIONS: Array<{ value: 'active' | 'inactive' | 'blocked'; label: string; color: string }> = [
+  { value: 'active', label: 'Ativo', color: 'text-emerald-700' },
+  { value: 'inactive', label: 'Inativo', color: 'text-stone-700' },
+  { value: 'blocked', label: 'Bloqueado', color: 'text-rose-700' },
 ];
+
+// Mapeamento alias PT-BR -> EN canon UPOS (cadastros pre-canon).
+function normalizeStatus(s: string | null | undefined): 'active' | 'inactive' | 'blocked' | '' {
+  if (!s) return '';
+  const map: Record<string, 'active' | 'inactive' | 'blocked'> = {
+    ativo: 'active', active: 'active',
+    inativo: 'inactive', inactive: 'inactive',
+    bloqueado: 'blocked', blocked: 'blocked',
+  };
+  return map[s.toLowerCase()] ?? '';
+}
 
 function getCsrfToken(): string {
   return (
@@ -94,7 +112,12 @@ function getCsrfToken(): string {
 export default function ClassificacaoTab({ contact, onSaved, disabled = false }: ClassificacaoTabProps) {
   const [segmento, setSegmento] = useState<string>(contact.segmento ?? '');
   const [tags, setTags] = useState<string[]>(Array.isArray(contact.tags) ? contact.tags : []);
-  const [status, setStatus] = useState<string>(contact.status ?? 'ativo');
+  // Wagner 2026-05-27 — backend persiste canon EN em `contact_status`. Lê de
+  // `contact_status` (canon) com fallback `status` (alias legado). Normaliza
+  // PT-BR -> EN. Default 'active'.
+  const [status, setStatus] = useState<string>(
+    normalizeStatus(contact.contact_status ?? contact.status) || 'active'
+  );
   const [vip, setVip] = useState<boolean>(!!contact.vip);
   // ADR 0188 Onda 4 — 4 flags multi-papel (Wagner 2026-05-25 UX refactor).
   const [isCustomer, setIsCustomer] = useState<boolean>(Boolean(contact.is_customer));
@@ -113,7 +136,7 @@ export default function ClassificacaoTab({ contact, onSaved, disabled = false }:
   useEffect(() => {
     setSegmento(contact.segmento ?? '');
     setTags(Array.isArray(contact.tags) ? contact.tags : []);
-    setStatus(contact.status ?? 'ativo');
+    setStatus(normalizeStatus(contact.contact_status ?? contact.status) || 'active');
     setVip(!!contact.vip);
     setIsCustomer(Boolean(contact.is_customer));
     setIsSupplier(Boolean(contact.is_supplier));
@@ -127,7 +150,7 @@ export default function ClassificacaoTab({ contact, onSaved, disabled = false }:
   const rollbackField = useCallback((field: string, prev: unknown) => {
     if (field === 'segmento') setSegmento((prev as string) ?? '');
     else if (field === 'tags') setTags(Array.isArray(prev) ? (prev as string[]) : []);
-    else if (field === 'status') setStatus((prev as string) ?? 'ativo');
+    else if (field === 'status' || field === 'contact_status') setStatus((prev as string) ?? 'active');
     else if (field === 'vip') setVip(!!prev);
     else if (field === 'bloqueado') setBloqueado(!!prev);
   }, []);
@@ -204,7 +227,9 @@ export default function ClassificacaoTab({ contact, onSaved, disabled = false }:
       if (prev === v) return;
       setStatus(v);
       previousValuesRef.current['status'] = prev;
-      performSave('status', v, prev);
+      // Wagner 2026-05-27 — envia chave canon backend (contact_status). Validator
+      // backend nao aceita 'status' -- silent no-op caso bug 'status'.
+      performSave('contact_status', v, prev);
     },
     [status, performSave]
   );

--- a/tests/Feature/Cliente/ClienteDrawerClassificacaoStatusFixTest.php
+++ b/tests/Feature/Cliente/ClienteDrawerClassificacaoStatusFixTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Wagner 2026-05-27 -- bug Classificacao Status select VAZIO mesmo apos
+ * PATCH bem-sucedido.
+ *
+ * Bateria exaustiva descobriu: backend retornava `contact_status:"active"`
+ * mas drawer mostrava dropdown vazio. Mismatch dupla:
+ *   1. Chave: ClassificacaoTab lia `contact.status` (alias legacy PT-BR),
+ *      backend ContactController payload rows envia `contact_status` (canon EN UPOS)
+ *   2. Valor enum: STATUS_OPTIONS tinha PT-BR `'ativo'/'inativo'/'bloqueado'`,
+ *      backend persistiu EN `'active'/'inactive'/'blocked'`
+ *
+ * Plus: handleStatusChange enviava `performSave('status', ...)`. Validator
+ * backend so aceita `contact_status` -> silent no-op (mesmo bug aliases PT-BR
+ * que afetou Daniela #1773).
+ *
+ * Fix:
+ *   - useState init: `normalizeStatus(contact.contact_status ?? contact.status) || 'active'`
+ *   - useEffect resync: idem
+ *   - STATUS_OPTIONS canon EN (active/inactive/blocked)
+ *   - normalizeStatus map alias PT-BR -> EN (cadastros pre-canon)
+ *   - handleStatusChange: performSave('contact_status', v, prev) -- canon backend
+ *
+ * GUARDs estruturais file_get_contents.
+ */
+
+// ─── GUARD 1: ContactInfo aceita contact_status canon EN ─────────────────
+
+test('GUARD 1 — ContactInfo declara contact_status (canon EN) + status (alias legado)', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        // Tipo aceita ambos EN + PT-BR (alias).
+        ->toContain("status?: 'ativo' | 'inativo' | 'bloqueado' | 'active' | 'inactive' | 'blocked'")
+        ->toContain("contact_status?: 'active' | 'inactive' | 'blocked'");
+});
+
+// ─── GUARD 2: STATUS_OPTIONS usa canon EN ────────────────────────────────
+
+test('GUARD 2 — STATUS_OPTIONS usa canon EN (active/inactive/blocked)', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("value: 'active', label: 'Ativo'")
+        ->toContain("value: 'inactive', label: 'Inativo'")
+        ->toContain("value: 'blocked', label: 'Bloqueado'");
+});
+
+// ─── GUARD 3: normalizeStatus mapeia PT-BR alias -> EN canon ─────────────
+
+test('GUARD 3 — normalizeStatus function mapeia alias PT-BR -> EN canon', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain('function normalizeStatus')
+        ->toContain('ativo: \'active\'')
+        ->toContain('inativo: \'inactive\'')
+        ->toContain('bloqueado: \'blocked\'');
+});
+
+// ─── GUARD 4: useState init + useEffect resync usam normalizeStatus ──────
+
+test('GUARD 4 — useState/useEffect leem contact_status (com fallback status) normalizado', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain('normalizeStatus(contact.contact_status ?? contact.status) || \'active\'');
+});
+
+// ─── GUARD 5: handleStatusChange envia chave canon contact_status ────────
+
+test('GUARD 5 — handleStatusChange envia chave canon backend (contact_status, nao status)', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/ClassificacaoTab.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("performSave('contact_status', v, prev)")
+        ->not->toContain("performSave('status', v, prev)");
+});


### PR DESCRIPTION
Bateria exaustiva descobriu: backend grava `contact_status:'active'` mas dropdown Status vazio. Mismatch chave + valor enum + handleStatusChange enviava chave errada (silent no-op padrão Daniela #1773).

Fix: normalizeStatus PT-BR→EN + ContactInfo aceita ambos + STATUS_OPTIONS canon EN + performSave('contact_status').

5 GUARDs Pest (12 assertions). Refs session 2026-05-27