### PR TITLE
fix(sells): commission_split URL gated por OficinaAuto (Larissa vestuario nao ve Mecanico)

### DIFF
--- a/app/Http/Controllers/SellController.php
+++ b/app/Http/Controllers/SellController.php
@@ -2909,13 +2909,21 @@ class SellController extends Controller
                     'editDiscount' => (bool) $edit_discount,
                     'update' => true,
                 ],
-                'urls' => [
+                'urls' => array_filter([
                     'submit' => '/sells/' . $id,
                     'cancel' => '/sells/' . $id,
                     'back' => '/sells',
                     // ADR 0192 Onda 2 follow-up — endpoint dedicado pra salvar commission_split.
-                    'commission_split' => '/sells/' . $id . '/commission-split',
-                ],
+                    // Wagner 2026-05-27: Larissa @ Rota Livre (vestuário, biz=4) reportou ver
+                    // "Mecânico" no Edit da venda. Causa: commission_split é feature OficinaAuto
+                    // (sub-vertical 4 Martinho mecânica pesada, ADR 0194) com labels hardcoded
+                    // "Mecânico"/"Balconista" no CommissionSplitEditor. Filtro canon: só popular
+                    // a URL quando OficinaAuto está instalado pro business. Sem OficinaAuto →
+                    // Edit.tsx:719 condicional `urls.commission_split` é falsy → editor nem renderiza.
+                    'commission_split' => $this->moduleUtil->isModuleInstalled('OficinaAuto')
+                        ? '/sells/' . $id . '/commission-split'
+                        : null,
+                ]),
             ]);
         }
 

--- a/tests/Feature/Sells/CommissionSplitUrlGatedByOficinaAutoTest.php
+++ b/tests/Feature/Sells/CommissionSplitUrlGatedByOficinaAutoTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest test estrutural — Bug Wagner @ Larissa 2026-05-27:
+ * Larissa @ Rota Livre (vestuário, biz=4) vê "Mecânico" no Edit da venda.
+ * Causa: SellController populava urls.commission_split pra TODA venda sem
+ * filtrar OficinaAuto instalado. CommissionSplitEditor.tsx tem "Mecânico"/
+ * "Balconista" hardcoded (ADR 0192 feature OficinaAuto Martinho).
+ *
+ * Fix canon: usar moduleUtil->isModuleInstalled('OficinaAuto') como gate.
+ * Sem OficinaAuto → URL não populada → Edit.tsx:719 condicional falsy →
+ * editor nem renderiza.
+ */
+
+it('SellController gateia urls.commission_split por isModuleInstalled OficinaAuto', function () {
+    $source = file_get_contents(base_path('app/Http/Controllers/SellController.php'));
+
+    // Gate canon presente
+    expect($source)->toContain("isModuleInstalled('OficinaAuto')");
+
+    // Especificamente associado ao commission_split URL (não a outro check qualquer)
+    // Pattern: `'commission_split' => $this->moduleUtil->isModuleInstalled('OficinaAuto')`
+    expect($source)->toMatch(
+        "/'commission_split'\s*=>\s*\\\$this->moduleUtil->isModuleInstalled\\('OficinaAuto'\\)/"
+    );
+
+    // Garante que NÃO sobrou commission_split URL sem gate (regressão)
+    // Pattern bugado antigo: `'commission_split' => '/sells/' . $id . '/commission-split'` direto sem ternary
+    expect($source)->not->toMatch(
+        "/'commission_split'\s*=>\s*'\\/sells\\/'\s*\\.\s*\\\$id/"
+    );
+});
+
+it('SellController usa array_filter no urls pra remover commission_split null (vestuário)', function () {
+    $source = file_get_contents(base_path('app/Http/Controllers/SellController.php'));
+
+    // array_filter sem callback remove null/false/empty — Larissa biz sem OficinaAuto:
+    // commission_split = null → array_filter remove → frontend não recebe a key.
+    expect($source)->toContain("'urls' => array_filter([");
+});


### PR DESCRIPTION
Wagner 2026-05-27: Larissa @ Rota Livre (vestuario, biz=4) viu 'Mecanico' no Edit da venda. CommissionSplitEditor e feature OficinaAuto (ADR 0192/0194 Martinho mecanica). Fix: gateie URL por `isModuleInstalled('OficinaAuto')` + `array_filter` no urls. Padrao canon (igual ContactController:315). 2 Pest tests anti-regressao. ~10 LOC.