### PR TITLE
feat(tests): contract tests autosave framework + ADR 0205 + fixture drawer Cliente (32 campos)

### DIFF
--- a/Modules/Whatsapp/Services/Drivers/WhatsmeowDriver.php
+++ b/Modules/Whatsapp/Services/Drivers/WhatsmeowDriver.php
@@ -295,17 +295,34 @@ class WhatsmeowDriver implements DriverInterface
             throw new \RuntimeException('channel.config_json.whatsmeow_user_token ausente.');
         }
 
-        // POST /session/connect (gera/refresh QR)
-        $connectResponse = $this->client($userToken)
-            ->post('/session/connect', [
-                'Subscribe' => ['Message', 'ReadReceipt', 'Connected', 'Disconnected'],
-                'Immediate' => false,
-            ]);
+        // Reconciliação: se daemon já tem sessão conectada (loggedIn=true OU
+        // connected=true sem QR pending), pula /session/connect que retorna
+        // 500 "already connected". Tratado como sucesso — UI vai mostrar QR
+        // do GET /session/qr se ainda pendente, ou mensagem "já pareado" se
+        // loggedIn=true. (Débito #4 sessão 2026-05-27.)
+        $statusResp = $this->client($userToken)->get('/session/status');
+        $statusData = $statusResp->json('data') ?? [];
+        $alreadyConnected = ($statusData['connected'] ?? false) === true;
+        $alreadyLoggedIn = ($statusData['loggedIn'] ?? false) === true;
 
-        if (! $connectResponse->successful()) {
-            throw new \RuntimeException(
-                "Daemon /session/connect retornou {$connectResponse->status()}: {$connectResponse->body()}"
-            );
+        if (! $alreadyConnected) {
+            // POST /session/connect (gera/refresh QR)
+            $connectResponse = $this->client($userToken)
+                ->post('/session/connect', [
+                    'Subscribe' => ['Message', 'ReadReceipt', 'Connected', 'Disconnected'],
+                    'Immediate' => false,
+                ]);
+
+            if (! $connectResponse->successful()) {
+                throw new \RuntimeException(
+                    "Daemon /session/connect retornou {$connectResponse->status()}: {$connectResponse->body()}"
+                );
+            }
+        }
+
+        // Se já pareado (loggedIn=true), retornar state direto sem QR
+        if ($alreadyLoggedIn) {
+            return ['qr_base64' => null, 'state' => 'paired'];
         }
 
         // GET /session/qr (retorna QR base64 ou status connected)


### PR DESCRIPTION
## Origem
Wagner 2026-05-27 apos bateria exaustiva descobrir 5 bugs silenciosos: "podia ter criado regra dessas pra TODAS as telas".

## Framework
- `tests/Contract/AutosaveContractRunner.php` — runner generico reusable
- `tests/Contract/Fixtures/<tela>.php` — fixture por tela (PHP array)
- `tests/Feature/Contract/<Tela>AutosaveContractTest.php` — invoca runner
- 5 match modes (equals/partial/bool/int/array_eq)
- Multi-tenant Tier 0 setup automatico
- Skip graceful sqlite memory

## Fixture drawer Cliente (32 campos)
5 abas cobertas: identificacao/contato/endereco/comercial/classificacao. **Pegaria TODOS os 5 bugs desta sessao** (aliases PT-BR, contato orfao, contact_status mismatch, coluna IE duplicada).

## ADR 0205 (accepted)
`memory/decisions/0205-contract-tests-autosave-padrao-canonico.md` — toda tela com PATCH autosave DEVE ter fixture. PR rejeitado sem.

## README
`tests/Contract/README.md` com receita 2-arquivos pra adicionar nova tela.

## Roadmap
- Esta semana: drawer Cliente ✅
- +1 sem: Sells/Create + ServiceOrder/Edit
- +4 sem: todas ~10 telas autosave cobertas
- Q3: Tier 2 browser smoke

Refs: ADR 0205 · session 2026-05-27