### PR TITLE
feat(tests): fixture contract ServiceOrder/Edit (7 campos · ADR 0205)

### DIFF
--- a/tests/Contract/Fixtures/service_order_edit.php
+++ b/tests/Contract/Fixtures/service_order_edit.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fixture: contract test da tela ServiceOrder/Edit (Modules/OficinaAuto).
+ *
+ * IMPORTANTE — diferenças do fixture cliente_drawer.php:
+ *  1. ServiceOrder/Edit NÃO usa autosave PATCH per-field — usa um único
+ *     PUT /oficina-auto/ordens-servico/{id} com payload completo (form submit).
+ *  2. Por isso o test file (ServiceOrderEditAutosaveContractTest) NÃO usa
+ *     AutosaveContractRunner::run() — usa um loop inline customizado que:
+ *       a) Envia PUT com [base_payload + 1 campo alterado] por iteração
+ *       b) Verifica roundtrip via GET JSON /oficina-auto/service-orders/{id}
+ *          (endpoint Accept-aware do show() retornando JSON)
+ *  3. Mesmo princípio: contract test "envia X, lê de volta X" — pegando
+ *     bugs silenciosos validator dropping unknown keys, aliases não-mapeados,
+ *     campo no payload sem coluna destino, etc.
+ *
+ * Cobre apenas CAMPOS CADASTRAIS do UpdateServiceOrderRequest:
+ *  - notes, status, mileage_at_service, entered_at, expected_completion,
+ *    completed_at, delivered_at
+ *
+ * NÃO cobre (separation of concerns):
+ *  - FSM Pipeline transitions (current_stage_id) — ADR 0143 tem test próprio
+ *    via ServiceOrderFsmActionController + ExecuteStageActionService
+ *  - Items CRUD (peças/mão-obra) — ServiceOrderItemController tem
+ *    ServiceOrderItemHttpIntegrationTest dedicado
+ *  - DVI inspection — DviInspectionController + DviInspectionItemTest
+ *  - Vehicle assignment swap — VehicleCrudTest cobre
+ *
+ * Aliases PT-BR vs canon EN descobertos:
+ *  - Nenhum no UpdateServiceOrderRequest (todos campos já canon EN).
+ *    Schema histórico V0 nasceu inglês (vehicle_id, mileage_at_service,
+ *    entered_at, expected_completion, completed_at, delivered_at) — não
+ *    teve fase legacy PT-BR como Cliente teve (nome/doc/tel etc).
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): test setupContext força
+ * business_id da sessão; ServiceOrder + Vehicle têm global scope.
+ *
+ * @see Modules\OficinaAuto\Http\Controllers\ServiceOrderController::update
+ * @see Modules\OficinaAuto\Http\Requests\UpdateServiceOrderRequest
+ * @see tests/Contract/README.md — receita
+ * @see ADR 0205 — contract tests autosave canon
+ * @see ADR 0143 — FSM Pipeline (NÃO coberto aqui)
+ */
+
+return [
+    'cadastrais' => [
+        // Endpoint PUT (não PATCH — form submit completo). Test file customiza
+        // o invoker pra não passar pelo AutosaveContractRunner::run() default.
+        'endpoint' => '/oficina-auto/ordens-servico/{id}',
+        'method' => 'put',
+        'fields' => [
+            // Campo livre — string maior comum, valida persistência texto.
+            ['send' => 'notes', 'value' => 'CT-{stamp} obs servico', 'recv' => 'notes'],
+
+            // Status livre na V0 (FSM enum em US-OFICINA-003). Aqui valida
+            // que string aceita roundtrips. NÃO testa transição FSM — só
+            // grava o campo direto (validator não plumbing pipeline).
+            ['send' => 'status', 'value' => 'em_servico', 'recv' => 'status'],
+
+            // Integer cast — mileage_at_service na entrada do veículo.
+            ['send' => 'mileage_at_service', 'value' => 45678, 'recv' => 'mileage_at_service', 'match' => 'int'],
+
+            // datetime — entrada do veículo. Match partial pois backend retorna
+            // formato ISO completo "2026-05-27T10:00:00.000000Z" e envio
+            // "2026-05-27 10:00:00". Substring "2026-05-27" cobre o roundtrip.
+            ['send' => 'entered_at', 'value' => '2026-05-27 10:00:00', 'recv' => 'entered_at', 'match' => 'partial'],
+
+            ['send' => 'expected_completion', 'value' => '2026-05-28 18:00:00', 'recv' => 'expected_completion', 'match' => 'partial'],
+
+            // completed_at/delivered_at — só liberados no Update (não Store)
+            // conforme docblock UpdateServiceOrderRequest. Cobrir aqui valida
+            // o gate de schema sem disparar FSM (que move via ExecuteStageActionService).
+            ['send' => 'completed_at', 'value' => '2026-05-29 16:00:00', 'recv' => 'completed_at', 'match' => 'partial'],
+
+            ['send' => 'delivered_at', 'value' => '2026-05-30 09:30:00', 'recv' => 'delivered_at', 'match' => 'partial'],
+        ],
+    ],
+];

--- a/tests/Feature/Contract/ServiceOrderEditAutosaveContractTest.php
+++ b/tests/Feature/Contract/ServiceOrderEditAutosaveContractTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\Contract\AutosaveContractRunner;
+
+/**
+ * Contract test da tela ServiceOrder/Edit (Modules/OficinaAuto V0 — ADR 0137).
+ *
+ * Ver fixture `tests/Contract/Fixtures/service_order_edit.php` pro detalhe
+ * dos campos cobertos + justificativa de por que NÃO usa AutosaveContractRunner::run()
+ * default (ServiceOrder/Edit usa PUT form submit, não PATCH per-field autosave).
+ *
+ * Pattern do test segue ClienteDrawerAutosaveContractTest mas com 3 adaptações:
+ *   1. Cria Vehicle base (via Vehicle::withoutGlobalScopes per pattern ServiceOrderCrudTest)
+ *      + ServiceOrder base apontando pro vehicle ANTES de cada test
+ *   2. Loop custom inline (não chama runner.run): PUT com base_payload + 1 campo,
+ *      depois GET JSON pra ler resposta e validar roundtrip
+ *   3. Permite skip graceful em ambiente sqlite memory OU sem schema OficinaAuto
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL) preservado via setupContext +
+ * session['user.business_id'] + global scope Vehicle/ServiceOrder.
+ *
+ * FSM Pipeline (ADR 0143) NÃO coberto aqui — `current_stage_id` tem test próprio
+ * em ServiceOrderStagePipelineTest + ExecuteStageActionService. Aqui cobrimos
+ * apenas o pipeline do form Edit V0 (status livre + datas + notes).
+ *
+ * @see Modules\OficinaAuto\Http\Controllers\ServiceOrderController::update
+ * @see tests/Contract/Fixtures/service_order_edit.php
+ * @see ADR 0205 (contract tests autosave canon)
+ */
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    // Pré-flight 1: DB driver — schema OficinaAuto exige MySQL.
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS + OficinaAuto (ADR 0101)');
+    }
+    // Pré-flight 2: tabelas OficinaAuto. Quando módulo ainda não instalou neste env.
+    if (! Schema::hasTable('service_orders') || ! Schema::hasTable('vehicles')) {
+        $this->markTestSkipped('Schema OficinaAuto ausente — rode `php artisan module:migrate OficinaAuto`');
+    }
+    // Pré-flight 3: vertical OficinaAuto enabled no biz alvo. (Setup ctx vai pegar biz=1.)
+    // Não usamos isModuleInstalled aqui pra evitar dep circular nos tests CI fresh.
+
+    // Setup multi-tenant (autentica user + session business_id) — reusa runner helper.
+    $ctx = AutosaveContractRunner::setupContext($this);
+    $this->business = $ctx['business'];
+    $this->user = $ctx['user'];
+    $this->contactId = $ctx['contactId'];
+
+    // Cria Vehicle base usando padrão validado em ServiceOrderCrudTest (withoutGlobalScopes
+    // pq estamos em context "superadmin de teste" — Vehicle Model exige business_id no creating
+    // hook senão herda da session, que já está populada acima).
+    $plate = 'CT-' . substr((string) microtime(true), -4);
+    $this->vehicleId = DB::table('vehicles')->insertGetId([
+        'business_id'  => $this->business->id,
+        'plate'        => $plate,
+        'vehicle_type' => 'automovel',
+        'created_at'   => now(),
+        'updated_at'   => now(),
+    ]);
+
+    // Cria ServiceOrder base — campos mínimos requeridos pela validator (vehicle_id + status).
+    // contact_id opcional aqui (não exigido em V0). Cliente derivado via vehicle no Producao.
+    $this->orderId = DB::table('service_orders')->insertGetId([
+        'business_id'        => $this->business->id,
+        'vehicle_id'         => $this->vehicleId,
+        'status'             => 'aberta',
+        'mileage_at_service' => 10000,
+        'notes'              => 'CT setup baseline',
+        'created_at'         => now(),
+        'updated_at'         => now(),
+    ]);
+});
+
+it('ServiceOrder/Edit — PUT endpoint persiste TODOS os campos cadastrais do fixture (roundtrip via GET JSON)', function () {
+    $fixture = require __DIR__ . '/../../Contract/Fixtures/service_order_edit.php';
+    $stamp = 'CT' . substr((string) microtime(true), -4);
+    $passed = 0;
+    $total = 0;
+    $failures = [];
+
+    foreach ($fixture as $tabName => $tabSpec) {
+        $endpoint = str_replace('{id}', (string) $this->orderId, $tabSpec['endpoint']);
+        $method = $tabSpec['method'] ?? 'patch';
+
+        foreach ($tabSpec['fields'] as $field) {
+            $total++;
+            $sendKey = $field['send'];
+            $recvKey = $field['recv'];
+            $match = $field['match'] ?? 'equals';
+
+            // Substitui {stamp} pra valor único por iteração (evita falso-positivo
+            // de cache HTTP retornar estado anterior).
+            $sent = is_string($field['value'])
+                ? str_replace('{stamp}', $stamp, $field['value'])
+                : $field['value'];
+
+            // PUT precisa de payload completo (vehicle_id + status são required).
+            // Mergeamos base + 1 campo alterado pra cada iteração — outros campos
+            // ficam com valor neutro pra não interferir.
+            $base = [
+                'vehicle_id' => (string) $this->vehicleId,
+                'status'     => 'aberta',
+            ];
+            $payload = array_merge($base, [$sendKey => $sent]);
+
+            // 1) PUT — envia payload. Controller redireciona pro show (302) — sucesso.
+            $putResponse = $this->put($endpoint, $payload);
+            $putStatus = $putResponse->status();
+
+            // PUT retorna 302 (redirect pra show) em caso sucesso ou 422 em validation fail.
+            $putOk = in_array($putStatus, [200, 302], true);
+
+            // 2) GET JSON show — lê valor de volta via endpoint Accept-aware.
+            // Endpoint alias /oficina-auto/service-orders/{id} (Wave 7+) retorna JSON shape
+            // limpo definido em ServiceOrderController::show §397+.
+            $getResponse = $this->getJson('/oficina-auto/service-orders/' . $this->orderId);
+            $getStatus = $getResponse->status();
+            $received = data_get($getResponse->json(), $recvKey);
+
+            $valueOk = matchesValue($sent, $received, $match);
+
+            if (! $putOk || $getStatus !== 200 || ! $valueOk) {
+                $failures[] = [
+                    'tab' => $tabName,
+                    'endpoint' => $endpoint,
+                    'method' => $method,
+                    'send' => $sendKey,
+                    'value_sent' => is_string($sent) ? substr($sent, 0, 60) : $sent,
+                    'recv' => $recvKey,
+                    'value_received' => is_string($received) ? substr((string) $received, 0, 60) : $received,
+                    'put_status' => $putStatus,
+                    'get_status' => $getStatus,
+                    'match_mode' => $match,
+                ];
+            } else {
+                $passed++;
+            }
+        }
+    }
+
+    // Falha legível pra dev (lista cada bug catalogado) — espelha
+    // ClienteDrawerAutosaveContractTest pattern.
+    if ($passed !== $total) {
+        $msg = "❌ Contract test FALHOU — {$passed}/{$total} OK.\n\n";
+        $msg .= "Bugs silenciosos detectados (PUT 302 + GET 200, mas valor não bate):\n";
+        foreach ($failures as $f) {
+            $msg .= sprintf(
+                "  [%s] %s %s · send=%s · value_sent=%s · recv=%s · value_received=%s · put=%d get=%d · match=%s\n",
+                $f['tab'], strtoupper($f['method']), $f['endpoint'], $f['send'], var_export($f['value_sent'], true),
+                $f['recv'], var_export($f['value_received'], true), $f['put_status'], $f['get_status'], $f['match_mode']
+            );
+        }
+        $msg .= "\nADR 0205 — todo PR que regrida contract test bloqueia merge.\n";
+        $msg .= "Fix: alinhe validator UpdateServiceOrderRequest + payload show JSON + frontend Edit.tsx.\n";
+
+        expect($failures)->toBeEmpty($msg);
+    }
+
+    expect($passed)->toBe($total);
+});
+
+/**
+ * Helper inline pra match modes — mesma semântica de
+ * AutosaveContractRunner::matches() (private). Duplicado aqui pq runner default
+ * não cobre PUT (somente patchJson). Quando runner ganhar suporte a method
+ * configurable, este test migra pra invocar runner direto.
+ */
+function matchesValue(mixed $sent, mixed $received, string $match): bool
+{
+    return match ($match) {
+        'partial' => $received !== null && is_string($received)
+            && str_contains((string) $received, is_string($sent) ? $sent : (string) $sent),
+        'bool' => (bool) $received === (bool) $sent,
+        'int' => (int) $received === (int) $sent,
+        'array_eq' => json_encode($received) === json_encode($sent),
+        default => $received === $sent || (string) $received === (string) $sent,
+    };
+}


### PR DESCRIPTION
## Summary

Implementa contract test fixture pra ServiceOrder/Edit (Modules/OficinaAuto · ADR 0137), seguindo o padrão canonizado pela ADR 0205 (PR #1791 mergeado).

Cobre 7 campos cadastrais via PUT /oficina-auto/ordens-servico/{id}:

| Campo | Tipo | Match |
|---|---|---|
| notes | string | equals |
| status | enum livre V0 | equals |
| mileage_at_service | integer | int |
| entered_at | datetime | partial |
| expected_completion | datetime | partial |
| completed_at | datetime | partial |
| delivered_at | datetime | partial |

## Diferenças vs cliente_drawer.php

| Aspecto | cliente_drawer | service_order_edit |
|---|---|---|
| HTTP method | PATCH per-field autosave | PUT form submit completo |
| Verificação | response do PATCH (`contact.X`) | GET JSON show (Accept-aware Wave 7+) |
| Runner | `AutosaveContractRunner::run()` | Loop inline custom (TODO migrar quando runner suportar method configurable) |

Justificativa: ServiceOrder/Edit não tem PATCH per-field autosave — usa form submit. O runner default é PATCH+`contact.X`-only. Loop inline replica match modes (equals/partial/int/bool/array_eq).

## NÃO coberto (separation of concerns)

- **FSM Pipeline** (current_stage_id) — ADR 0143, test próprio `ServiceOrderStagePipelineTest`
- **Items CRUD** (peças/mão-obra/terceiros) — `ServiceOrderItemHttpIntegrationTest`
- **DVI inspection** — `DviInspectionItemTest`
- **Vehicle assignment swap** — `VehicleCrudTest`

## Aliases PT-BR vs canon EN

**Nenhum descoberto.** Schema OficinaAuto nasceu canon EN (vehicle_id, mileage_at_service, entered_at, expected_completion, completed_at, delivered_at) — não teve fase legacy PT-BR como Cliente teve (nome→name, doc→tax_number, tel→mobile, site→site_url, canal→canal_preferido).

## Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL)

Preservado via:
- `AutosaveContractRunner::setupContext($this)` autentica user + popula `session['user.business_id']`
- Vehicle + ServiceOrder têm global scope `business_id` (Model::booted)
- Setup cria Vehicle+ServiceOrder no biz da sessão (sem cross-tenant)

## Test plan

- [x] PHP lint OK (`php -l` ambos arquivos)
- [x] Local skip gracefully em sqlite memory (`Tests: 1 skipped (0 assertions)`)
- [ ] CI MySQL runner (workflow PHP/Pest Feature) — valida roundtrip real
- [ ] Sibling agent (Sells/Create) PR sem conflito de merge (arquivos diferentes)

## Referências

- ADR 0205 — Contract tests autosave canon
- ADR 0137 — Modules/OficinaAuto qualificada
- ADR 0143 — FSM Pipeline (NÃO coberto aqui)
- ADR 0093 — Multi-tenant Tier 0
- PR #1791 — ADR 0205 mergeado origem

🤖 Generated with [Claude Code](https://claude.com/claude-code)