### PR TITLE
feat(tests): fixture contract Vehicles/Edit (14 campos OficinaAuto)

### DIFF
--- a/tests/Contract/Fixtures/vehicles_edit.php
+++ b/tests/Contract/Fixtures/vehicles_edit.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fixture: contract test da tela Vehicles/Edit (Modules/OficinaAuto V0 — ADR 0137).
+ *
+ * Mesma estratégia do fixture service_order_edit.php — não usa
+ * AutosaveContractRunner::run() default pq Vehicles/Edit é PUT form submit
+ * (não PATCH per-field). Test file (VehiclesEditAutosaveContractTest) implementa
+ * loop inline customizado:
+ *   a) PUT /oficina-auto/veiculos/{id} com base_payload + 1 campo alterado
+ *   b) GET /oficina-auto/veiculos/{id}/edit com header X-Inertia: true
+ *      → lê page.props.vehicle.{recv} pra validar roundtrip
+ *
+ * Não existe endpoint JSON Accept-aware pra Vehicle (diferente de
+ * ServiceOrder que tem alias /oficina-auto/service-orders/{id} retornando JSON
+ * shape limpo). Usamos Inertia partial response pra ler props.
+ *
+ * Cobre TODOS os 14 campos do UpdateVehicleRequest:
+ *  - plate (required), secondary_plate, chassis, secondary_chassis,
+ *    contact_id, manufacture_year, model_year, renavam, vehicle_type (required),
+ *    engine, mileage_at_entry, fuel_type, color, notes
+ *
+ * NÃO cobre (separation of concerns):
+ *  - current_status FSM transition — controlado por ServiceOrder hooks
+ *    (createRental/closeRental) em Wave 5+
+ *  - current_rental_id — soft FK setada por ServiceOrder, não pelo Edit form
+ *  - capacity_m3 — só caçamba_estacionaria, schema extension separada
+ *  - legacy_id — UpdateVehicleRequest NÃO permite update (preserva trilha
+ *    Firebird importer); StoreVehicleRequest aceita. Test cobre só Update.
+ *
+ * Aliases PT-BR vs canon EN descobertos:
+ *  - Nenhum no UpdateVehicleRequest (todos campos já canon EN). Schema V0
+ *    nasceu inglês (plate, vehicle_type, mileage_at_entry, fuel_type) — sem
+ *    fase legacy PT-BR como Cliente teve. Mesma situação de ServiceOrder.
+ *
+ * Validações sintéticas seguras (NÃO PII de cliente real):
+ *  - plate: 'TST-{stamp}' (sintético, máx 10 chars — bem dentro do limit
+ *    e formato padrão BR sem confundir com placa real)
+ *  - chassis: 'CT{stamp}CHASSIS' (sintético, ~15 chars — válido sob max 30)
+ *  - renavam: '12345678901' (11 chars exatos, todos dígitos — formato DENATRAN)
+ *  - contact_id: usa $this->contactId do setupContext (existe + mesmo business)
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): test setupContext força
+ * business_id da sessão; Vehicle tem global scope automático.
+ *
+ * @see Modules\OficinaAuto\Http\Controllers\VehicleController::update
+ * @see Modules\OficinaAuto\Http\Requests\UpdateVehicleRequest
+ * @see tests/Contract/README.md — receita
+ * @see tests/Contract/Fixtures/service_order_edit.php — fixture irmã (mesmo padrão PUT form)
+ * @see ADR 0205 — contract tests autosave canon
+ */
+
+return [
+    'cadastrais' => [
+        // Endpoint PUT (não PATCH — form submit completo). Test file customiza
+        // o invoker pra não passar pelo AutosaveContractRunner::run() default.
+        'endpoint' => '/oficina-auto/veiculos/{id}',
+        'method' => 'put',
+        'fields' => [
+            // ────────────────────────────────────────────────────────────────
+            // Identificação obrigatória (required no validator)
+            // ────────────────────────────────────────────────────────────────
+
+            // plate: máx 10 chars. 'TST-{stamp}' = TST- (4) + CT (2) + 4 dígitos = 10 chars.
+            // Formato sintético — claramente teste, não confunde com placa Mercosul/antiga real.
+            ['send' => 'plate', 'value' => 'TST-{stamp}', 'recv' => 'plate'],
+
+            // vehicle_type: enum required. 'caminhao' existe em VehicleController::vehicleTypes()
+            // e cobre sub-vertical 4 mecânica pesada (Martinho).
+            ['send' => 'vehicle_type', 'value' => 'caminhao', 'recv' => 'vehicle_type'],
+
+            // ────────────────────────────────────────────────────────────────
+            // Identificação opcional (nullable)
+            // ────────────────────────────────────────────────────────────────
+
+            // secondary_plate — atende cavalo+reboque (Vargas case ADR 0137 §"20% veículos").
+            // Formato curto 'CT{stamp}-2' = CT (2) + 6 chars stamp + -2 (2) = 10 chars (max:10 cap).
+            ['send' => 'secondary_plate', 'value' => 'CT{stamp}-2', 'recv' => 'secondary_plate'],
+
+            // chassis — VIN 17 chars padrão, mas validator aceita até 30. Sintético.
+            ['send' => 'chassis', 'value' => 'CT{stamp}CHASSIS', 'recv' => 'chassis'],
+
+            // secondary_chassis — chassi do reboque/semi-reboque
+            ['send' => 'secondary_chassis', 'value' => 'CT{stamp}CHASSIS2', 'recv' => 'secondary_chassis'],
+
+            // renavam — 11 dígitos exatos (max 11 no validator, padrão DENATRAN)
+            ['send' => 'renavam', 'value' => '12345678901', 'recv' => 'renavam'],
+
+            // ────────────────────────────────────────────────────────────────
+            // Anos (integer 1900-2100)
+            // ────────────────────────────────────────────────────────────────
+
+            ['send' => 'manufacture_year', 'value' => 2024, 'recv' => 'manufacture_year', 'match' => 'int'],
+            ['send' => 'model_year', 'value' => 2025, 'recv' => 'model_year', 'match' => 'int'],
+
+            // ────────────────────────────────────────────────────────────────
+            // Características técnicas (nullable strings + int)
+            // ────────────────────────────────────────────────────────────────
+
+            ['send' => 'engine', 'value' => 'CT-{stamp} V8 Turbo', 'recv' => 'engine'],
+            ['send' => 'mileage_at_entry', 'value' => 87654, 'recv' => 'mileage_at_entry', 'match' => 'int'],
+            ['send' => 'fuel_type', 'value' => 'diesel', 'recv' => 'fuel_type'],
+            ['send' => 'color', 'value' => 'branco', 'recv' => 'color'],
+
+            // ────────────────────────────────────────────────────────────────
+            // FK + texto livre
+            // ────────────────────────────────────────────────────────────────
+
+            // contact_id — preenchido em runtime no test (depende do setupContext
+            // criar contact base no mesmo business). Marker 'CONTACT_ID' substituído
+            // pelo test loop antes do PUT.
+            ['send' => 'contact_id', 'value' => 'CONTACT_ID', 'recv' => 'contact_id', 'match' => 'int'],
+
+            // notes — texto livre, valida persistência string longa
+            ['send' => 'notes', 'value' => 'CT-{stamp} observacao veiculo teste', 'recv' => 'notes'],
+        ],
+    ],
+];

--- a/tests/Feature/Contract/VehiclesEditAutosaveContractTest.php
+++ b/tests/Feature/Contract/VehiclesEditAutosaveContractTest.php
@@ -1,0 +1,187 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\Contract\AutosaveContractRunner;
+
+/**
+ * Contract test da tela Vehicles/Edit (Modules/OficinaAuto V0 — ADR 0137).
+ *
+ * Ver fixture `tests/Contract/Fixtures/vehicles_edit.php` pro detalhe dos
+ * 14 campos cobertos + justificativa de por que NÃO usa
+ * AutosaveContractRunner::run() default (Vehicles/Edit é PUT form submit,
+ * não PATCH per-field autosave — mesmo padrão de ServiceOrder/Edit).
+ *
+ * Pattern segue ServiceOrderEditAutosaveContractTest mas com 1 adaptação:
+ *   - GET roundtrip lê via Inertia partial response (X-Inertia: true)
+ *     da rota /oficina-auto/veiculos/{id}/edit, extraindo page.props.vehicle.{field}.
+ *     ServiceOrder usa endpoint JSON Accept-aware (/service-orders/{id}),
+ *     mas Vehicle não tem alias JSON — Inertia é o canal disponível.
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL) preservado via setupContext +
+ * session['user.business_id'] + global scope Vehicle/Contact.
+ *
+ * Vertical OficinaAuto pode estar disabled em algum biz — skip graceful
+ * via Schema::hasTable check (mesmo padrão fixture irmã).
+ *
+ * @see Modules\OficinaAuto\Http\Controllers\VehicleController::update
+ * @see Modules\OficinaAuto\Http\Requests\UpdateVehicleRequest
+ * @see tests/Contract/Fixtures/vehicles_edit.php
+ * @see tests/Feature/Contract/ServiceOrderEditAutosaveContractTest.php (test irmão)
+ * @see ADR 0205 (contract tests autosave canon)
+ */
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    // Pré-flight 1: DB driver — schema OficinaAuto exige MySQL.
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS + OficinaAuto (ADR 0101)');
+    }
+    // Pré-flight 2: tabela OficinaAuto. Quando módulo ainda não instalou neste env.
+    if (! Schema::hasTable('vehicles')) {
+        $this->markTestSkipped('Schema OficinaAuto ausente — rode `php artisan module:migrate OficinaAuto`');
+    }
+
+    // Setup multi-tenant (autentica user + session business_id) — reusa runner helper.
+    // Cria também contact base que usamos como contact_id válido (mesmo business).
+    $ctx = AutosaveContractRunner::setupContext($this);
+    $this->business = $ctx['business'];
+    $this->user = $ctx['user'];
+    $this->contactId = $ctx['contactId'];
+
+    // Cria Vehicle base com campos mínimos requeridos pelo validator (plate + vehicle_type).
+    // Inserção direta no DB pra evitar fillable/observer side-effects no setup.
+    // business_id explícito pra honrar global scope (session já populada acima).
+    $plate = 'CTS-' . substr((string) microtime(true), -4);
+    $this->vehicleId = DB::table('vehicles')->insertGetId([
+        'business_id'  => $this->business->id,
+        'plate'        => $plate,
+        'vehicle_type' => 'automovel',
+        'created_at'   => now(),
+        'updated_at'   => now(),
+    ]);
+});
+
+it('Vehicles/Edit — PUT endpoint persiste TODOS os 14 campos do fixture (roundtrip via Inertia GET)', function () {
+    $fixture = require __DIR__ . '/../../Contract/Fixtures/vehicles_edit.php';
+    $stamp = 'CT' . substr((string) microtime(true), -4);
+    $passed = 0;
+    $total = 0;
+    $failures = [];
+
+    foreach ($fixture as $tabName => $tabSpec) {
+        $endpoint = str_replace('{id}', (string) $this->vehicleId, $tabSpec['endpoint']);
+        $method = $tabSpec['method'] ?? 'patch';
+
+        foreach ($tabSpec['fields'] as $field) {
+            $total++;
+            $sendKey = $field['send'];
+            $recvKey = $field['recv'];
+            $match = $field['match'] ?? 'equals';
+
+            // Substitui {stamp} pra valor único por iteração (evita falso-positivo
+            // de cache HTTP retornar estado anterior).
+            $sent = is_string($field['value'])
+                ? str_replace('{stamp}', $stamp, $field['value'])
+                : $field['value'];
+
+            // Substitui marker CONTACT_ID pelo contactId real do setupContext
+            // (contact_id precisa ser FK válida em contacts mesmo business).
+            if ($sent === 'CONTACT_ID') {
+                $sent = $this->contactId;
+            }
+
+            // PUT precisa de payload completo (plate + vehicle_type required).
+            // Mergeamos base + 1 campo alterado pra cada iteração — outros campos
+            // ficam com valor neutro pra não interferir.
+            $base = [
+                'plate'        => 'BASE-' . substr((string) microtime(true), -3),
+                'vehicle_type' => 'automovel',
+            ];
+            $payload = array_merge($base, [$sendKey => $sent]);
+
+            // 1) PUT — envia payload. Controller redireciona pro show (302) — sucesso.
+            $putResponse = $this->put($endpoint, $payload);
+            $putStatus = $putResponse->status();
+
+            // PUT retorna 302 (redirect pra show) em caso sucesso ou 422 em validation fail.
+            $putOk = in_array($putStatus, [200, 302], true);
+
+            // 2) GET Inertia — lê page.props.vehicle.{recv} de volta via Edit route.
+            // X-Inertia header faz o middleware retornar JSON envelope (não HTML wrapper).
+            $getResponse = $this->withHeaders(['X-Inertia' => 'true', 'X-Inertia-Version' => '1'])
+                ->get('/oficina-auto/veiculos/' . $this->vehicleId . '/edit');
+            $getStatus = $getResponse->status();
+
+            $page = $getResponse->headers->get('X-Inertia')
+                ? json_decode($getResponse->getContent(), true)
+                : null;
+            $received = data_get($page, 'props.vehicle.' . $recvKey);
+
+            $valueOk = matchesVehicleValue($sent, $received, $match);
+
+            if (! $putOk || $getStatus !== 200 || ! $valueOk) {
+                $failures[] = [
+                    'tab' => $tabName,
+                    'endpoint' => $endpoint,
+                    'method' => $method,
+                    'send' => $sendKey,
+                    'value_sent' => is_string($sent) ? substr($sent, 0, 60) : $sent,
+                    'recv' => $recvKey,
+                    'value_received' => is_string($received) ? substr((string) $received, 0, 60) : $received,
+                    'put_status' => $putStatus,
+                    'get_status' => $getStatus,
+                    'match_mode' => $match,
+                ];
+            } else {
+                $passed++;
+            }
+        }
+    }
+
+    // Falha legível pra dev (lista cada bug catalogado) — espelha
+    // ServiceOrderEditAutosaveContractTest pattern.
+    if ($passed !== $total) {
+        $msg = "❌ Contract test FALHOU — {$passed}/{$total} OK.\n\n";
+        $msg .= "Bugs silenciosos detectados (PUT 302 + GET 200, mas valor não bate):\n";
+        foreach ($failures as $f) {
+            $msg .= sprintf(
+                "  [%s] %s %s · send=%s · value_sent=%s · recv=%s · value_received=%s · put=%d get=%d · match=%s\n",
+                $f['tab'], strtoupper($f['method']), $f['endpoint'], $f['send'], var_export($f['value_sent'], true),
+                $f['recv'], var_export($f['value_received'], true), $f['put_status'], $f['get_status'], $f['match_mode']
+            );
+        }
+        $msg .= "\nADR 0205 — todo PR que regrida contract test bloqueia merge.\n";
+        $msg .= "Fix: alinhe validator UpdateVehicleRequest + props vehicle no Edit + frontend Edit.tsx.\n";
+
+        expect($failures)->toBeEmpty($msg);
+    }
+
+    expect($passed)->toBe($total);
+});
+
+/**
+ * Helper inline pra match modes — mesma semântica de
+ * AutosaveContractRunner::matches() (private) e ServiceOrderEditAutosaveContractTest.
+ * Duplicado aqui pra evitar coupling cross-file até runner ganhar suporte a
+ * PUT + Inertia roundtrip configurable.
+ *
+ * Nome `matchesVehicleValue` (não `matchesValue`) pra evitar function collision
+ * com o helper de ServiceOrderEditAutosaveContractTest quando Pest carrega ambos
+ * tests no mesmo run.
+ */
+function matchesVehicleValue(mixed $sent, mixed $received, string $match): bool
+{
+    return match ($match) {
+        'partial' => $received !== null && is_string($received)
+            && str_contains((string) $received, is_string($sent) ? $sent : (string) $sent),
+        'bool' => (bool) $received === (bool) $sent,
+        'int' => (int) $received === (int) $sent,
+        'array_eq' => json_encode($received) === json_encode($sent),
+        default => $received === $sent || (string) $received === (string) $sent,
+    };
+}


### PR DESCRIPTION
## Summary

Adiciona fixture contract test pra tela **Vehicles/Edit** (Modules/OficinaAuto V0 — ADR 0137) cobrindo TODOS os 14 campos do `UpdateVehicleRequest` via PUT roundtrip.

- **Fixture**: `tests/Contract/Fixtures/vehicles_edit.php` — 14 campos (plate, vehicle_type, secondary_plate, chassis, secondary_chassis, renavam, manufacture_year, model_year, engine, mileage_at_entry, fuel_type, color, contact_id, notes)
- **Test file**: `tests/Feature/Contract/VehiclesEditAutosaveContractTest.php` — segue padrão de `ServiceOrderEditAutosaveContractTest` (PUT form submit, não PATCH autosave)
- **Diferença vs ServiceOrder/Edit**: GET roundtrip via Inertia partial response (`X-Inertia: true`) lendo `page.props.vehicle.{recv}` — Vehicle não tem endpoint JSON Accept-aware como ServiceOrder (alias `/service-orders/{id}`)

## Cobertura

| Categoria | Campos |
|---|---|
| Required | plate, vehicle_type |
| Identificação | secondary_plate, chassis, secondary_chassis, renavam |
| Anos (int) | manufacture_year, model_year |
| Técnicas | engine, mileage_at_entry, fuel_type, color |
| FK + texto | contact_id, notes |

**Aliases PT-BR vs canon EN**: nenhum — schema V0 nasceu inglês (mesmo que ServiceOrder, sem fase legacy PT-BR como Cliente teve).

**NÃO coberto** (separation of concerns):
- `current_status` / `current_rental_id` — controlados por ServiceOrder hooks (Wave 5+)
- `capacity_m3` — só caçamba_estacionaria, schema extension separada
- `legacy_id` — UpdateVehicleRequest não permite update (trilha Firebird importer)

## Segurança Tier 0

- ✅ Multi-tenant ADR 0093 — `setupContext` força business_id na session, Vehicle global scope automático
- ✅ Placas/chassi sintéticos (`TST-{stamp}`, `CT{stamp}CHASSIS`) — sem PII de cliente real
- ✅ `contact_id` usa contact criado pelo setupContext no mesmo business (FK válida + Tier 0 preservado)
- ✅ Skip graceful em ambiente sqlite OU sem schema OficinaAuto (mesmo gate de fixture irmã)

## Test plan

- [x] PHP lint OK (`php -l`) em fixture + test file
- [x] Test executa skip-graceful em dev local (DB sem `contacts.tipo` Wave B — mesmo comportamento de `ServiceOrderEditAutosaveContractTest`)
- [ ] CI MySQL com schema completo executa as 14 asserções de roundtrip (validar via Actions após merge)
- [ ] Próximas fixtures sugeridas — `DviInspection`, `Compras/Create`, `Produto/Edit`

## Refs

- ADR 0205 — Contract tests autosave canon
- ADR 0093 — Multi-tenant Tier 0
- ADR 0137 — OficinaAuto vertical V0
- Fixture irmã: `tests/Contract/Fixtures/service_order_edit.php` (PR #1795)

🤖 Generated with [Claude Code](https://claude.com/claude-code)