### PR TITLE
feat(tests): fixture contract Produto/Edit (11 campos cadastrais)

### DIFF
--- a/tests/Contract/Fixtures/produto_edit.php
+++ b/tests/Contract/Fixtures/produto_edit.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fixture: contract test da tela Produto/Edit (UPOS legacy ProductController::update).
+ *
+ * IMPORTANTE — diferenças do fixture cliente_drawer.php:
+ *  1. Produto/Edit NÃO usa autosave PATCH per-field — usa um único
+ *     PUT /products/{id} com payload completo (form submit clássico que
+ *     redireciona pra /products após sucesso).
+ *  2. Por isso o test file (ProdutoEditAutosaveContractTest) NÃO usa
+ *     AutosaveContractRunner::run() default — usa loop inline customizado:
+ *       a) PUT com [base_payload + 1 campo alterado] por iteração
+ *       b) Verifica roundtrip via Product::find($id) (DB direto, pq o
+ *          response é redirect 302 sem JSON; e o show JSON via X-Inertia
+ *          só expõe um subset do que update pode escrever — `weight`,
+ *          `product_description`, custom_fields não estão lá).
+ *  3. Mesmo princípio: contract test "envia X, lê de volta X" — pegando
+ *     bugs silenciosos do tipo $request->only() dropping unknown keys
+ *     (regressão exatamente análoga à do drawer Cliente 2026-05-27 com
+ *     aliases PT-BR; e a regressão UPOS 6.7 que sumiu `cpf_cnpj`).
+ *
+ * Cobre CAMPOS CADASTRAIS do `$request->only([...])` em update() §948:
+ *  name, sku, alert_quantity, weight, product_description, barcode_type,
+ *  tax_type, product_custom_field1, product_custom_field2, product_custom_field3,
+ *  preparation_time_in_minutes
+ *
+ * NÃO cobre (separation of concerns):
+ *  - Variations (single_dpp, single_dsp, sub_sku) — gravadas em `variations`
+ *    table via Variation::find($single_variation_id), exigem produto setup
+ *    com row variations criada. Próxima iteração (ver "próximas variantes").
+ *  - product_locations sync (M2M business_locations) — exige location seedada
+ *  - Image upload (multipart) — fora do escopo contract autosave
+ *  - Expiry (expiry_period_type/expiry_period) — gated por session
+ *    `business.enable_product_expiry` que não conseguimos forçar via runner.
+ *  - Stock adjustment — endpoint /stock-adjustments distinto, ServiceOrder pattern.
+ *
+ * Aliases PT-BR vs canon EN:
+ *  - Nenhum detectado no $request->only() do update — todos campos já canon
+ *    EN herdados do UPOS upstream. Mesmo assim cobrir é valioso: se um dia
+ *    alguém adicionar alias `descricao => product_description` no controller
+ *    sem mapear ambos, este test pega.
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): test setupContext força
+ * business_id da sessão; Product tem global scope via business_id no WHERE
+ * direto do update() (`Product::where('business_id', $business_id)`).
+ *
+ * @see app/Http/Controllers/ProductController::update §940
+ * @see app/Product.php
+ * @see tests/Contract/README.md — receita
+ * @see ADR 0205 — contract tests autosave canon
+ */
+
+return [
+    'cadastrais' => [
+        // Endpoint PUT — Route::resource('products', ...) gera PUT/PATCH /products/{id}
+        // automático. Controller faz update() e redireciona pra /products (302).
+        'endpoint' => '/products/{id}',
+        'method' => 'put',
+        'fields' => [
+            // Nome do produto — string básica, valida persistência do mais
+            // crítico (campo NOT NULL no schema, primeiro do $request->only()).
+            ['send' => 'name', 'value' => 'PROD-{stamp}', 'recv' => 'name'],
+
+            // SKU — se vazio o controller gera via generateProductSku no store,
+            // no update vem direto do request. Bug clássico: se mudarem o pipeline
+            // pra "auto-trim se contém espaço" o test pega.
+            ['send' => 'sku', 'value' => 'SKU-{stamp}', 'recv' => 'sku'],
+
+            // Decimal — alert_quantity passa por num_uf (parsing pt-BR locale).
+            // Match int pois Eloquent retorna "10.0000" string pelo cast decimal(22,4)
+            // e num_uf transforma input em float — comparação int garante "10" === "10".
+            // Valor sem casa decimal pra evitar formatting quirks "10,0000" vs "10".
+            ['send' => 'alert_quantity', 'value' => '10', 'recv' => 'alert_quantity', 'match' => 'int'],
+
+            // Peso — string livre na schema (decimal 22,4 mas controller atribui
+            // direto sem num_uf). Match partial pq DB pode normalizar "1.500"
+            // vs "1.5000". Substring "1.5" cobre.
+            ['send' => 'weight', 'value' => '1.5', 'recv' => 'weight', 'match' => 'partial'],
+
+            // Description — text livre, sem transformação no controller.
+            ['send' => 'product_description', 'value' => 'CT desc {stamp}', 'recv' => 'product_description'],
+
+            // Barcode type enum — fixo ['C39','C128','EAN-13','EAN-8','UPC-A','UPC-E','ITF-14'].
+            // C128 é o default UPOS. Mudamos pra EAN-13 pra forçar persistência diferente.
+            ['send' => 'barcode_type', 'value' => 'EAN-13', 'recv' => 'barcode_type'],
+
+            // Tax type enum — ['inclusive', 'exclusive']. Default exclusive.
+            ['send' => 'tax_type', 'value' => 'inclusive', 'recv' => 'tax_type'],
+
+            // Custom fields livres (product_custom_field1..20 todos no $request->only).
+            // Cobrimos 3 — suficiente pra detectar se alguém retirar o `?? ''` fallback
+            // do controller (que silenciosamente zeraria campos não-enviados).
+            ['send' => 'product_custom_field1', 'value' => 'CT cf1 {stamp}', 'recv' => 'product_custom_field1'],
+            ['send' => 'product_custom_field2', 'value' => 'CT cf2 {stamp}', 'recv' => 'product_custom_field2'],
+            ['send' => 'product_custom_field3', 'value' => 'CT cf3 {stamp}', 'recv' => 'product_custom_field3'],
+
+            // Preparation time — integer (minutos), módulo Restaurant feature.
+            // Match int pq DB retorna int e frontend envia string às vezes.
+            ['send' => 'preparation_time_in_minutes', 'value' => 45, 'recv' => 'preparation_time_in_minutes', 'match' => 'int'],
+        ],
+    ],
+];

--- a/tests/Feature/Contract/ProdutoEditAutosaveContractTest.php
+++ b/tests/Feature/Contract/ProdutoEditAutosaveContractTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\Contract\AutosaveContractRunner;
+
+/**
+ * Contract test da tela Produto/Edit (UPOS legacy ProductController::update).
+ *
+ * Pattern espelha ServiceOrderEditAutosaveContractTest — PUT form submit
+ * (redirect 302, não JSON) + roundtrip via DB direto (pq Product::show via
+ * X-Inertia expõe apenas subset dos campos que update aceita; ler do DB
+ * é a fonte de verdade pra "o que persistiu de verdade").
+ *
+ * Ver fixture `tests/Contract/Fixtures/produto_edit.php` pra detalhe dos
+ * campos cobertos + justificativa do que NÃO está aqui (variations,
+ * locations, expiry, image upload).
+ *
+ * Setup (3 fases):
+ *   1. setupContext: pega Business + User reais, autentica, popula session
+ *   2. Cria Unit no business (foreign key required em products.unit_id)
+ *   3. Cria Product base + ProductVariation dummy + Variation dummy (o
+ *      controller update() em produto type=single faz Variation::find($single_variation_id)
+ *      e dá save() — se o ID não existir, NPE. Mesmo enviando só campos
+ *      cadastrais, o controller SEMPRE atravessa o branch single).
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL):
+ *   - Product Eloquent ::where('business_id', $bid) hardcoded no controller §952
+ *   - Session user.business_id populada via setupContext
+ *   - Unit/Variation/ProductVariation criados no mesmo business
+ *
+ * Skip graceful: sqlite memory OU schema UPOS ausente. Permission
+ * `product.update` precisa estar atribuída ao user — tentamos via
+ * Permission::firstOrCreate + assignRole se Spatie estiver disponível.
+ *
+ * @see app/Http/Controllers/ProductController::update §940
+ * @see tests/Contract/Fixtures/produto_edit.php
+ * @see ADR 0205 — contract tests autosave canon
+ * @see ADR 0093 — multi-tenant Tier 0 IRREVOGÁVEL
+ */
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    // Pré-flight 1: DB driver — schema UPOS exige MySQL.
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS (products+variations+units)');
+    }
+    // Pré-flight 2: tabelas UPOS.
+    foreach (['products', 'variations', 'product_variations', 'units'] as $tbl) {
+        if (! Schema::hasTable($tbl)) {
+            $this->markTestSkipped("Schema UPOS ausente: tabela {$tbl} não existe");
+        }
+    }
+
+    // Setup multi-tenant (autentica user + session business_id) — reusa runner helper.
+    $ctx = AutosaveContractRunner::setupContext($this);
+    $this->business = $ctx['business'];
+    $this->user = $ctx['user'];
+
+    // Garante que user tem permission product.update — sem isso, controller aborta 403.
+    // Tentamos via Spatie Permission se disponível; fallback silencioso (test pode
+    // ainda passar se user for super-admin via outro mecanismo).
+    try {
+        if (class_exists(\Spatie\Permission\Models\Permission::class)) {
+            $perm = \Spatie\Permission\Models\Permission::firstOrCreate(
+                ['name' => 'product.update', 'guard_name' => 'web']
+            );
+            $this->user->givePermissionTo($perm);
+        }
+    } catch (\Throwable $e) {
+        // Best-effort — se Spatie não carregar ou role/permission models não disponíveis,
+        // pula sem quebrar (test pode skip-ar com 403 mensagem clara).
+    }
+
+    // Cria Unit no business — products.unit_id é foreign key NOT NULL.
+    $this->unitId = DB::table('units')->insertGetId([
+        'business_id' => $this->business->id,
+        'actual_name' => 'CT Unit ' . substr((string) microtime(true), -4),
+        'short_name' => 'CTU',
+        'allow_decimal' => 1,
+        'created_by' => $this->user->id,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    // Cria Product base (type=single, tax_type=exclusive, barcode_type=C128).
+    // Schema NOT NULL: name, business_id, type, unit_id, tax_type, sku, barcode_type, created_by.
+    $this->productId = DB::table('products')->insertGetId([
+        'business_id' => $this->business->id,
+        'name' => 'CT Setup Product ' . substr((string) microtime(true), -4),
+        'type' => 'single',
+        'unit_id' => $this->unitId,
+        'tax_type' => 'exclusive',
+        'sku' => 'CT-SETUP-' . substr((string) microtime(true), -4),
+        'barcode_type' => 'C128',
+        'enable_stock' => 0,
+        'alert_quantity' => 0,
+        'created_by' => $this->user->id,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    // Cria ProductVariation dummy (1×1 com product) — controller update() lê
+    // ->product_variations no with() e a Variation dummy aponta pra ela.
+    $this->productVariationId = DB::table('product_variations')->insertGetId([
+        'product_id' => $this->productId,
+        'name' => 'DUMMY',
+        'is_dummy' => 1,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    // Cria Variation dummy — controller §1073 faz Variation::find($single_variation_id)
+    // e ->save(). Se ID inexistente -> erro de catch silencia (output success=0).
+    $this->variationId = DB::table('variations')->insertGetId([
+        'name' => 'DUMMY',
+        'product_id' => $this->productId,
+        'product_variation_id' => $this->productVariationId,
+        'sub_sku' => 'CT-SETUP-VAR-' . substr((string) microtime(true), -4),
+        'default_purchase_price' => 0,
+        'dpp_inc_tax' => 0,
+        'profit_percent' => 0,
+        'default_sell_price' => 0,
+        'sell_price_inc_tax' => 0,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+});
+
+it('Produto/Edit — PUT /products/{id} persiste TODOS os campos cadastrais do fixture (roundtrip via DB)', function () {
+    $fixture = require __DIR__ . '/../../Contract/Fixtures/produto_edit.php';
+    $stamp = 'CT' . substr((string) microtime(true), -4);
+    $passed = 0;
+    $total = 0;
+    $failures = [];
+
+    foreach ($fixture as $tabName => $tabSpec) {
+        $endpoint = str_replace('{id}', (string) $this->productId, $tabSpec['endpoint']);
+
+        foreach ($tabSpec['fields'] as $field) {
+            $total++;
+            $sendKey = $field['send'];
+            $recvKey = $field['recv'];
+            $match = $field['match'] ?? 'equals';
+
+            // {stamp} substitution — único por iteração pra evitar
+            // falso-positivo de cache HTTP/Eloquent retornar estado anterior.
+            $sent = is_string($field['value'])
+                ? str_replace('{stamp}', $stamp, $field['value'])
+                : $field['value'];
+
+            // PUT precisa de payload completo (name + unit_id required). Mergeamos
+            // base + 1 campo alterado por iteração — outros ficam neutros e
+            // não interferem na verificação per-campo.
+            //
+            // single_variation_id + single_dpp/dsp são required pelo branch
+            // single (controller §1071). Valores zero são aceitos pelo num_uf
+            // e não rompem o Variation::find($single_variation_id)->save().
+            $base = [
+                'name' => 'CT base name',
+                'unit_id' => $this->unitId,
+                'tax_type' => 'exclusive',
+                'barcode_type' => 'C128',
+                'sku' => 'CT-BASE-' . $stamp,
+                'enable_stock' => 0,
+                'product_description' => 'CT base desc',
+                'single_variation_id' => $this->variationId,
+                'single_dpp' => '0',
+                'single_dpp_inc_tax' => '0',
+                'single_dsp' => '0',
+                'single_dsp_inc_tax' => '0',
+                'profit_percent' => '0',
+            ];
+            $payload = array_merge($base, [$sendKey => $sent]);
+
+            // 1) PUT — controller redireciona pro /products (302) em sucesso
+            // ou 422 em validation fail. Catch interno transforma exceções em
+            // output success=0 mas ainda retorna 302 — daí precisarmos do
+            // DB roundtrip pra detectar persistência real.
+            $putResponse = $this->put($endpoint, $payload);
+            $putStatus = $putResponse->status();
+            $putOk = in_array($putStatus, [200, 302], true);
+
+            // 2) DB lookup — fonte de verdade. Bypassamos cache Eloquent
+            // usando query builder direto. Se controller silenciosamente
+            // dropou a chave (regressão UPOS 6.7 do cpf_cnpj), o valor não bate.
+            $received = DB::table('products')
+                ->where('id', $this->productId)
+                ->value($recvKey);
+
+            $valueOk = matchesProdutoValue($sent, $received, $match);
+
+            if (! $putOk || ! $valueOk) {
+                $failures[] = [
+                    'tab' => $tabName,
+                    'endpoint' => $endpoint,
+                    'method' => 'put',
+                    'send' => $sendKey,
+                    'value_sent' => is_string($sent) ? substr($sent, 0, 60) : $sent,
+                    'recv' => $recvKey,
+                    'value_received' => is_string($received) ? substr((string) $received, 0, 60) : $received,
+                    'put_status' => $putStatus,
+                    'match_mode' => $match,
+                ];
+            } else {
+                $passed++;
+            }
+        }
+    }
+
+    // Falha legível pra dev — espelha ClienteDrawerAutosaveContractTest pattern.
+    if ($passed !== $total) {
+        $msg = "❌ Contract test FALHOU — {$passed}/{$total} OK.\n\n";
+        $msg .= "Bugs silenciosos detectados em Produto/Edit (PUT 302 mas valor não persistiu):\n";
+        foreach ($failures as $f) {
+            $msg .= sprintf(
+                "  [%s] %s %s · send=%s · value_sent=%s · recv=%s · value_received=%s · put=%d · match=%s\n",
+                $f['tab'], strtoupper($f['method']), $f['endpoint'], $f['send'], var_export($f['value_sent'], true),
+                $f['recv'], var_export($f['value_received'], true), $f['put_status'], $f['match_mode']
+            );
+        }
+        $msg .= "\nADR 0205 — todo PR que regrida contract test bloqueia merge.\n";
+        $msg .= "Fix comum: alinhar \$request->only() em ProductController::update §948 + colunas products schema.\n";
+
+        expect($failures)->toBeEmpty($msg);
+    }
+
+    expect($passed)->toBe($total);
+});
+
+/**
+ * Helper inline pra match modes — mesma semântica de
+ * AutosaveContractRunner::matches() (private). Duplicado aqui pq runner default
+ * só suporta patchJson e leitura via response->json(); nós precisamos DB direto.
+ * Pattern espelha matchesValue() em ServiceOrderEditAutosaveContractTest.
+ */
+function matchesProdutoValue(mixed $sent, mixed $received, string $match): bool
+{
+    return match ($match) {
+        'partial' => $received !== null && is_string($received)
+            && str_contains((string) $received, is_string($sent) ? $sent : (string) $sent),
+        'bool' => (bool) $received === (bool) $sent,
+        'int' => (int) $received === (int) $sent,
+        'array_eq' => json_encode($received) === json_encode($sent),
+        default => $received === $sent || (string) $received === (string) $sent,
+    };
+}


### PR DESCRIPTION
## Summary

Adiciona contract test pra **Produto/Edit** (UPOS legacy `ProductController::update`) sob padrão **ADR 0205** (contract tests autosave canon).

- **Fixture** `tests/Contract/Fixtures/produto_edit.php` — 11 campos cadastrais cobertos: `name`, `sku`, `alert_quantity`, `weight`, `product_description`, `barcode_type`, `tax_type`, `product_custom_field1..3`, `preparation_time_in_minutes`.
- **Test file** `tests/Feature/Contract/ProdutoEditAutosaveContractTest.php` — segue pattern `ServiceOrderEditAutosaveContractTest` (PUT form submit + DB roundtrip, pq controller redireciona 302 sem JSON e o Inertia show só expõe subset).
- **Multi-tenant Tier 0** (ADR 0093 IRREVOGÁVEL): setupContext + Unit/ProductVariation/Variation criados no mesmo `business_id`.

## Por que importa

Mesma classe de bug do drawer Cliente 2026-05-27 (regressão UPOS 6.7 que sumiu `cpf_cnpj`): controller tem 30+ campos no `$request->only(...)`, fácil adicionar/remover errado, frontend recebe redirect 302 verde mas dado não persiste.

## NÃO cobre (separation of concerns)

- Variations (`single_dpp`, `single_dsp`, `sub_sku`) — exige roundtrip `variations` table
- `product_locations` sync (M2M business_locations)
- Image upload (multipart, fora escopo contract autosave)
- Expiry gate (session `business.enable_product_expiry`)
- Stock adjustment (endpoint distinto `/stock-adjustments`)

## Aliases PT-BR vs canon EN

Nenhum detectado no `$request->only()` do update — todos campos já canon EN herdados do UPOS upstream. Cobrir mesmo assim pega regressão futura tipo adicionar alias `descricao => product_description` sem mapear ambos.

## Test plan

- [x] Local Pest: `php vendor/bin/pest tests/Feature/Contract/ProdutoEditAutosaveContractTest.php` → 1 skipped graceful OK (sqlite memory). Sintaxe validada.
- [x] Bateria completa contract tests: `php vendor/bin/pest tests/Feature/Contract/` → 6 skipped graceful, sem colisão de função (`matchesProdutoValue` distinto de `matchesValue` do ServiceOrderEdit).
- [ ] CI MySQL: aguardando workflow rodar nesta PR pra validar execução real contra schema UPOS.

## Próximas variantes (futuras iterações separadas)

- Variations pricing roundtrip (single_dpp/dsp em `variations` table)
- Stock adjustment endpoint `/stock-adjustments` PATCH per linha
- Bulk edit (`/products/bulk-update`)

## Refs

- ADR 0205 — contract tests autosave canon
- ADR 0093 — multi-tenant Tier 0 IRREVOGÁVEL
- Pattern source: `ServiceOrderEditAutosaveContractTest` (PR #1795)

🤖 Generated with [Claude Code](https://claude.com/claude-code)