### PR TITLE
feat(tests): fixture contract Compras/Create (5 campos quick-add Fornecedor)

### DIFF
--- a/tests/Contract/Fixtures/compras_create.php
+++ b/tests/Contract/Fixtures/compras_create.php
@@ -1,0 +1,146 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fixture: contract test do fluxo Compras/Create (MWART Wave2 B5 — PurchaseCreate.tsx).
+ *
+ * Tela Compras/Create faz submit full-form `form.post('/purchases', ...)` que retorna
+ * `redirect('purchases')->with('status', $output)` — NAO JSON. Por ADR 0205 P2
+ * "tela CRUD tradicional ... opcional", cobrimos os endpoints COMPANHEIROS do
+ * fluxo onde bug silencioso e possivel:
+ *
+ *   1. POST /contacts (type=supplier)  — Quick-add Fornecedor.
+ *      Mesma rota usada por Sells/Create QuickAddCustomerSheet, mas type=supplier
+ *      ativa shape diferente: `supplier_business_name` (razao social PJ) e´ a
+ *      identidade primaria, NAO `first_name` (que e´ usado em type=customer PF).
+ *      Aliases UPOS historicos PJ supplier diferem de PF customer — bug silencioso
+ *      tipo "drawer Cliente PT-BR aliases" pode bater so´ aqui sem teste.
+ *   2. POST /purchases/check_ref_number  — Validador AJAX de duplicidade ref_no.
+ *      Endpoint critico do fluxo: tela pré-checa se ref_no + fornecedor ja existe
+ *      ANTES do submit principal. Retorna echo "true"/"false" (string raw, NAO
+ *      JSON). Hoje DESATIVADO no fixture (ver bloco final) — runner ainda nao
+ *      suporta raw_body response shape.
+ *
+ * NAO cobre:
+ *   - POST /purchases (submit principal) — redirect-flow sem JSON. Erros 422 sao
+ *     visiveis. Sem bug silencioso possivel: validator falha => redirect back
+ *     with errors. Mesmo trade-off que Sells/Create POST /pos.
+ *   - POST /purchases/update-status — pos-criacao (FSM), test proprio em
+ *     PurchaseStatusTransitionTest (caso exista) ou Modules/Inventory dedicated.
+ *     Response shape so´ tem `success`+`msg`, baixo valor pra contract.
+ *   - POST /purchases/get_purchase_entry_row — server-render Blade partial
+ *     (legacy non-Inertia), nao consumido pelo Create.tsx Inertia novo.
+ *   - POST /import-purchase-products — fluxo separado (upload XML), nao Create form.
+ *
+ * Total: 5 campos auto-verificados. Bugs evitados:
+ *   - `supplier_business_name` removido do $request->only() => fornecedor PJ
+ *     vira contact sem razao social, listagem mostra "name" vazio (regressao
+ *     classica UPOS upstream — ja aconteceu em 6.7).
+ *   - check_ref_number retornando "1"/"0" em vez de "true"/"false" => frontend
+ *     vai sempre achar que e´ duplicado, bloqueia submit sem mensagem clara.
+ *     [coberto quando runner suportar raw_body — ver bloco DESATIVADO abaixo]
+ *   - cpf_cnpj fornecedor nao persiste => emissao NFe falha em prod (PII +
+ *     legal risk LGPD/Receita).
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGAVEL): setup cria contact + transaction
+ * stub no business autenticado. Rollback automatico via DatabaseTransactions.
+ *
+ * @see app/Http/Controllers/PurchaseController.php (createInertia §425+, store §475+)
+ * @see app/Http/Controllers/PurchaseController.php (checkRefNumber §1675+)
+ * @see app/Http/Controllers/ContactController.php (store §1431+ compartilhado com Sells)
+ * @see resources/js/Pages/Purchase/Create.tsx (form.post('/purchases'))
+ * @see tests/Contract/README.md — receita
+ * @see ADR 0205 — contract tests autosave canon
+ * @see ADR 0114 — gate visual MWART (Cowork loop)
+ */
+
+return [
+    // ============================================================
+    // 1. POST /contacts (quick-add Fornecedor type=supplier)
+    // ============================================================
+    // Cada POST cria contact novo. Idempotente em termos de schema (insertGetId
+    // sem unique-constraint colidindo), gera N orfaos — OK pq DatabaseTransactions
+    // rollback ao fim do test.
+    //
+    // Diferenca chave vs Sells/Create fixture:
+    //   - type=supplier (nao customer)
+    //   - supplier_business_name PREENCHIDO (razao social PJ — identidade primaria)
+    //   - first_name fica vazio ou auxiliar (contato pessoal dentro do supplier)
+    //
+    // Validator StoreContactRequest (App\Http\Requests\Cliente\StoreContactRequest)
+    // aceita nullable em todos esses; nada e´ required. Mas controller monta `name`
+    // via implode([prefix, first, middle, last]) — se NADA preenchido, fica string
+    // vazia, pode quebrar listagem. Por isso baseFields inclui first_name fallback.
+    'quick_add_fornecedor' => [
+        'endpoint' => '/contacts',
+        'method' => 'post',
+        'responseRoot' => 'data',  // ContactController@store retorna { success, msg, data: {id, name, ...} }
+        'expectStatus' => 200,
+        // Campos sempre enviados (validator + controller flow exigem pra montar
+        // contact valido). type=supplier ativa shape PJ — supplier_business_name
+        // se torna campo primario.
+        'baseFields' => [
+            'type' => 'supplier',
+            'contact_type_radio' => 'supplier',
+            'first_name' => 'CT Contato Fornec {stamp}',  // contato pessoal opcional do supplier
+            'pay_term_number' => null,
+            'pay_term_type' => null,
+            'credit_limit' => '',
+            'opening_balance' => '0',
+        ],
+        'fields' => [
+            // CRITICO: razao social PJ. Bug silencioso aqui = supplier sem nome
+            // empresarial em listagem/relatorios. Frontend pode mostrar "name"
+            // (contato pessoal) mas relatorio fiscal/NFe usa supplier_business_name.
+            // match partial pq alguns observers podem trim/normalize espacos.
+            ['send' => 'supplier_business_name', 'value' => 'CT Fornec LTDA {stamp}', 'recv' => 'supplier_business_name', 'match' => 'partial'],
+
+            // Mobile do supplier — direto, recv = mobile.
+            ['send' => 'mobile', 'value' => '11999990{stamp}', 'recv' => 'mobile', 'match' => 'partial'],
+
+            // Email do supplier — comercial padrao.
+            ['send' => 'email', 'value' => 'fornec{stamp}@example.test', 'recv' => 'email'],
+
+            // City — comum esquecer no $request->only(), bug silencioso classico.
+            ['send' => 'city', 'value' => 'CTCidadeFornec{stamp}', 'recv' => 'city'],
+
+            // cpf_cnpj fornecedor — CNPJ PJ. Validator usa CpfCnpj mod-11 SEFAZ
+            // (App\Rules\BR\CpfCnpj), entao precisa ser sintetico VALIDO.
+            // 11.444.777/0001-61 e´ valido mod-11 (ver tests/Unit/Rules/BR/CpfCnpjTest.php).
+            // NAO usar CNPJ real (PII LGPD ADR 0127). Match partial pq observer pode strip pontuacao.
+            ['send' => 'cpf_cnpj', 'value' => '11.444.777/0001-61', 'recv' => 'cpf_cnpj', 'match' => 'partial'],
+        ],
+    ],
+
+    // ============================================================
+    // 2. [DESATIVADO] POST /purchases/check_ref_number
+    // ============================================================
+    // Endpoint critico do fluxo pre-submit: tela checa se ref_no + contact_id ja
+    // existe em outras compras desse fornecedor. Retorna echo "true" (livre)
+    // ou "false" (duplicado). NAO retorna JSON — apenas echo + exit (ver
+    // PurchaseController@checkRefNumber §1693-1699).
+    //
+    // Como o runner valida via response->json() + data_get(), echo raw "true" nao
+    // e´ JSON parseavel — data_get retorna null. Por isso NAO incluimos este tab
+    // no fixture ativo hoje.
+    //
+    // SOLUCAO PROPOSTA: extender AutosaveContractRunner com nova chave
+    // `responseShape: 'raw_body'` que muda da semantica json+path pra strpos no
+    // response->getContent(). Pequena PR ortogonal — quando estiver mergeada,
+    // descomentar bloco abaixo e o test ja cobre check_ref_number.
+    //
+    // // 'check_ref_number' => [
+    // //     'endpoint' => '/purchases/check_ref_number',
+    // //     'method' => 'post',
+    // //     'responseShape' => 'raw_body',  // FEATURE FUTURA — runner ext
+    // //     'expectStatus' => 200,
+    // //     'baseFields' => [
+    // //         'contact_id' => 0,  // overridden pelo test file pra $this->contactId
+    // //         'purchase_id' => null,
+    // //     ],
+    // //     'fields' => [
+    // //         ['send' => 'ref_no', 'value' => 'CT-REF-{stamp}', 'recv' => '__body_raw', 'match' => 'partial'],
+    // //     ],
+    // // ],
+];

--- a/tests/Contract/README.md
+++ b/tests/Contract/README.md
@@ -128,8 +128,8 @@ Skips gracefully se ambiente sem schema (`Schema::hasTable('contacts')` false) �
 |---|---|---|
 | Cliente drawer | ✅ implementado | 5 abas (identificacao/contato/endereco/comercial/classificacao) |
 | Sells/Create | ✅ parcial | quick-add cliente (POST /contacts), commission-split (PATCH /sells/{id}/commission-split). NÃO cobre POST /pos (full-form). |
-| OficinaAuto/ServiceOrder | 🟡 alto | edit, status_change |
-| Compras/Create | 🟡 médio | draft, item edit |
+| OficinaAuto/ServiceOrder | ✅ implementado | PUT /oficina-auto/ordens-servico/{id} (7 campos cadastrais) |
+| Compras/Create | ✅ parcial | quick-add Fornecedor (POST /contacts type=supplier, 5 campos). NÃO cobre POST /purchases (redirect-flow). check_ref_number reservado pra runner raw_body. |
 | Vehicles/Edit | ⚪ baixo | edit |
 | Produto/Edit | ⚪ baixo | edit, variations |
 | NFe/Config | ⚪ baixo | certificate upload, ambiente toggle |

--- a/tests/Feature/Contract/ComprasCreateAutosaveContractTest.php
+++ b/tests/Feature/Contract/ComprasCreateAutosaveContractTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\Contract\AutosaveContractRunner;
+
+/**
+ * Contract test do fluxo Compras/Create (MWART Wave2 B5 — PurchaseCreate.tsx).
+ *
+ * Wagner 2026-05-27 — quarto fixture sob padrao ADR 0205 (apos drawer Cliente,
+ * Sells/Create, ServiceOrder/Edit). Compras/Create faz submit full-form
+ * `form.post('/purchases', ...)` que retorna redirect — sem JSON. Por isso
+ * cobrimos os endpoints COMPANHEIROS do fluxo (quick-add Fornecedor + check
+ * ref_no) onde bug silencioso e´ possivel.
+ *
+ * Cobertura honesta (NAO inventa endpoints que a tela nao tem):
+ *   1. POST /contacts (type=supplier)  — Quick-add Fornecedor (5 campos)
+ *      Mesma rota de Sells, mas type=supplier ativa shape PJ diferente
+ *      (supplier_business_name como primaria, NAO first_name).
+ *   2. POST /purchases/check_ref_number  — DESATIVADO temporario (runner nao
+ *      suporta raw body response). Ver fixture pra justificativa + reativacao.
+ *
+ * Total: 5 campos auto-verificados. Bugs evitados (ver fixture):
+ *   - supplier_business_name removido do $request->only() => regressao UPOS 6.7
+ *   - cpf_cnpj fornecedor nao persiste => emissao NFe falha em prod
+ *   - city silencioso => relatorios fiscais sem cidade
+ *
+ * NAO cobre POST /purchases (submit principal) — full-form redirect-flow, erros
+ * 422 visiveis, sem bug silencioso possivel. Mesma justificativa que
+ * SellsCreateAutosaveContractTest pra POST /pos.
+ *
+ * Setup: usa `setupSellsContext` em vez de `setupContext` porque alguns endpoints
+ * futuros do fluxo Compras (update-status quando coberto) precisam de transaction
+ * stub no biz. Hoje so quick-add nao precisa, mas mantemos paridade pra extensao.
+ * Custo: cria 1 sell stub extra que e´ rollback-ado — trivial.
+ *
+ * @see tests/Contract/Fixtures/compras_create.php
+ * @see app/Http/Controllers/PurchaseController.php (createInertia §425+, store §475+)
+ * @see resources/js/Pages/Purchase/Create.tsx
+ * @see ADR 0205 — contract tests autosave canon
+ * @see ADR 0093 — multi-tenant Tier 0 IRREVOGAVEL
+ */
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    // Pré-flight 1: DB driver — schema UPOS Transaction + contact requer MySQL real.
+    // Skip graceful em sqlite memory (CI smoke) — runner do AutosaveContractRunner ja
+    // faz seu proprio skip, mas reforcamos aqui pra mensagem de erro mais clara.
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS (ADR 0093 Tier 0 + ADR 0101)');
+    }
+
+    // Pré-flight 2: tabelas. setupSellsContext ja faz skip via Schema::hasTable,
+    // mas explicitamos contacts.cpf_cnpj (coluna BR Slice 1 — migration 2026_05_21_140000).
+    if (! Schema::hasColumn('contacts', 'cpf_cnpj')) {
+        $this->markTestSkipped('Coluna contacts.cpf_cnpj ausente — rode `php artisan migrate` (Slice 1 BR).');
+    }
+    if (! Schema::hasColumn('contacts', 'supplier_business_name')) {
+        $this->markTestSkipped('Coluna contacts.supplier_business_name ausente — schema UPOS upstream.');
+    }
+
+    // Setup multi-tenant Tier 0 (ADR 0093): autentica user + session + cria contact
+    // base + sell stub (status=draft). Sell stub nao e´ usado por este fixture hoje,
+    // mas mantem paridade com Sells/Create pattern pra futura extensao
+    // (PATCH /purchases/{id}/something quando algum endpoint autosave for adicionado).
+    $ctx = AutosaveContractRunner::setupSellsContext($this);
+    $this->business = $ctx['business'];
+    $this->user = $ctx['user'];
+    $this->contactId = $ctx['contactId'];
+    $this->transactionId = $ctx['transactionId'];
+});
+
+it('Compras/Create — endpoint companheiro quick-add Fornecedor (POST /contacts type=supplier) persiste campos do fixture', function () {
+    $fixture = require __DIR__ . '/../../Contract/Fixtures/compras_create.php';
+
+    // POST /contacts nao usa {id} placeholder — runner so substitui se presente,
+    // entao passar transactionId como resourceId nao quebra (e fica disponivel pra
+    // futuros endpoints que tenham {id}).
+    $result = AutosaveContractRunner::run($this, $fixture, $this->transactionId);
+
+    if ($result['passed'] !== $result['total']) {
+        $msg = "❌ Contract test FALHOU — {$result['passed']}/{$result['total']} OK.\n\n";
+        $msg .= "Bugs silenciosos detectados no fluxo Compras/Create:\n";
+        foreach ($result['failures'] as $f) {
+            $msg .= sprintf(
+                "  [%s] %s %s · send=%s · value_sent=%s · recv=%s · value_received=%s · status=%d · match=%s\n",
+                $f['tab'], strtoupper($f['method']), $f['endpoint'],
+                $f['send'], var_export($f['value_sent'], true),
+                $f['recv'], var_export($f['value_received'], true),
+                $f['status'], $f['match_mode']
+            );
+        }
+        $msg .= "\nADR 0205 — todo PR que regrida contract test bloqueia merge.\n";
+        $msg .= "Fix: alinhe validator backend (\$request->only() + StoreContactRequest rules)\n";
+        $msg .= "       + response shape (data.X path) + alias se necessario.\n";
+        $msg .= "Atencao: Compras quick-add usa type=supplier — shape difere de Sells quick-add\n";
+        $msg .= "       (supplier_business_name primario vs first_name primario).\n";
+
+        expect($result['failures'])->toBeEmpty($msg);
+    }
+
+    expect($result['passed'])->toBe($result['total']);
+});


### PR DESCRIPTION
## Summary

Quarto fixture sob padrao ADR 0205 (apos drawer Cliente, Sells/Create, ServiceOrder/Edit). Cobre endpoint companheiro POST /contacts (type=supplier) — Quick-add Fornecedor do fluxo Compras/Create.

Tela `resources/js/Pages/Purchase/Create.tsx` faz submit full-form `form.post('/purchases')` que retorna redirect (não JSON). Por ADR 0205 P2 ("tela CRUD tradicional ... opcional"), cobrimos endpoints companheiros onde bug silencioso é possível — mesmo trade-off que `SellsCreateAutosaveContractTest` faz pra POST /pos.

## Cobertura (5 campos)

POST /contacts type=supplier:
- `supplier_business_name` — razão social PJ (identidade primária — diferente de Sells que usa `first_name`)
- `mobile`, `email`, `city` — comum esquecer em `$request->only()`
- `cpf_cnpj` — CNPJ sintético válido mod-11 (`11.444.777/0001-61` per `tests/Unit/Rules/BR/CpfCnpjTest.php`), zero PII LGPD ADR 0127

## Bugs evitados

- `supplier_business_name` removido do `$request->only()` => fornecedor PJ sem razão social (regressão clássica UPOS 6.7).
- `cpf_cnpj` fornecedor não persiste => emissão NFe falha em prod.
- Aliases shape PJ supplier diferem de PF customer — `SellsCreateAutosaveContractTest` cobre customer; este fixture fecha o gap supplier.

## NÃO cobre (justificado)

- **POST /purchases** (submit principal) — redirect-flow sem JSON, erros 422 visíveis, sem bug silencioso possível.
- **POST /purchases/check_ref_number** — runner ainda não suporta `raw_body` response shape (endpoint retorna `echo "true"/"false"` raw, não JSON). Bloco DESATIVADO no fixture documenta contrato esperado pra futura reativação quando `AutosaveContractRunner` ganhar `responseShape: raw_body`.
- **POST /purchases/update-status** — pos-criação, baixo valor pra contract (response só tem `success`+`msg`).

## Pegadinhas multi-tenant Tier 0 (ADR 0093)

- `setupSellsContext` autentica user + popula `session['user.business_id']` + cria contact base + sell stub (status=draft, rollback automático via `DatabaseTransactions`).
- Paridade com Sells/Create test pattern — sell stub não usado hoje, mas facilita extensão futura (PATCH /purchases/{id}/something).

## Test plan

- [x] PHP lint clean (`php -l`)
- [x] Fixture loads como array (`require` retorna 1 entry com 5 campos)
- [x] Skip graceful em sqlite memory (sem schema MySQL UltimatePOS)
- [ ] CI Pest (mysql runner) executa 5 assertions sucesso
- [ ] Falha controlada se `$request->only()` regredir e dropar `supplier_business_name`

## Refs

- ADR 0205 — contract tests autosave canon
- ADR 0093 — multi-tenant Tier 0 IRREVOGÁVEL
- ADR 0127 — LGPD redact (CNPJ sintético, sem PII real)
- ADR 0114 — gate visual MWART (Cowork loop)
- `tests/Contract/README.md` — receita atualizada (linha 132 marca Compras/Create ✅ parcial)

## Próximos endpoints sugeridos

1. Extender `AutosaveContractRunner` com `responseShape: raw_body` (PR ortogonal ~30 linhas) → reativar `check_ref_number` neste mesmo fixture.
2. Cobrir PATCH /sells/update-shipping/{id} no fixture sells_create (legacy shipping update, hoje vazio).
3. Vehicles/Edit (parallel agent já em flight).
4. Produto/Edit (parallel agent já em flight).
5. NFe/Config (parallel agent já em flight).

🤖 Generated with [Claude Code](https://claude.com/claude-code)