### PR TITLE
feat(tests): fixture contract NFe/Config (9 campos, 3 endpoints)

### DIFF
--- a/tests/Contract/Fixtures/nfe_config.php
+++ b/tests/Contract/Fixtures/nfe_config.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fixture: contract test do dominio Fiscal/Config + NfeBrasil/Configuracao
+ * (tela unificada Fiscal/Config.tsx — Wagner 2026-05-27 consolidacao).
+ *
+ * 3 endpoints autosave-style do NfeBrasil que persistem `business` e
+ * `nfe_business_configs`. Endpoints retornam RedirectResponse (302) — test
+ * file faz POST + read-back via DB column lookup (pattern ServiceOrderEdit,
+ * nao usa AutosaveContractRunner::run default).
+ *
+ * Endpoints cobertos (9 campos auto-verificados):
+ *   1. POST /nfe-brasil/configuracao/certificado/ambiente → business.ambiente (ADR 0142)
+ *   2. POST /nfe-brasil/tributacao/auto-emission/toggle   → nfe_business_configs.auto_emission_enabled (ADR 0093)
+ *   3. POST /nfe-brasil/tributacao/config-default         → nfe_business_configs.{regime, tributacao_default JSON}
+ *
+ * EXCLUIDOS POR DESIGN (outros PRs):
+ *   - POST /nfe-brasil/configuracao/certificado (upload .pfx multipart — fixture proprio)
+ *   - POST /nfe-brasil/configuracao/certificado/testar (action ping SEFAZ, nao persiste)
+ *   - POST /nfe-brasil/tributacao/templates/{slug}/aplicar (bulk mutate, tests dedicados)
+ *   - CRUD /nfe-brasil/tributacao/regras (subdominio NCM — fixture proprio)
+ *   - Import CSV (multipart + side-effects multi-row)
+ *
+ * EXCLUIDOS POR PII/SECRETS (Tier 0 — NUNCA em fixture/teste):
+ *   - Senha .pfx (Laravel encrypt + MemCofre — nao DB plain)
+ *   - CSC NFC-e + chave privada cert (Vaultwarden, nao DB)
+ *
+ * Schema fixture estendido (vs cliente_drawer.php):
+ *   - 'read_back' => 'db'|'model'   — db raw DB::table; model usa Eloquent (casts)
+ *   - 'table'     => 'business'     — tabela alvo do read-back
+ *   - 'column'    => 'ambiente'     — coluna alvo (scalar)
+ *   - 'json_path' => 'col.nested'   — quando dado vive dentro de JSON column
+ *   - 'where'     => ['id' => '{business_id}']  — chave WHERE com placeholder
+ *
+ * Pattern referencia: AutosaveContractRunner (cliente_drawer) + ServiceOrderEdit
+ * (inline custom loop pra endpoints redirect-based). ADR 0205.
+ */
+
+return [
+    // 1. POST /nfe-brasil/configuracao/certificado/ambiente
+    // Toggle SEFAZ 1=PRODUCAO / 2=HOMOLOGACAO. ADR 0142 tinyInteger 1|2.
+    // Controller faz early-return se ambiente_novo === ambiente_antes — por isso
+    // testamos OS DOIS valores sequencialmente (ambos round-trips com mudanca real).
+    'ambiente_sefaz' => [
+        'endpoint' => '/nfe-brasil/configuracao/certificado/ambiente',
+        'method' => 'post',
+        'expectStatus' => 302,
+        'read_back' => 'db',
+        'table' => 'business',
+        'where' => ['id' => '{business_id}'],
+        'fields' => [
+            ['send' => 'ambiente', 'value' => 2, 'recv' => 'ambiente', 'column' => 'ambiente', 'match' => 'int'],
+            ['send' => 'ambiente', 'value' => 1, 'recv' => 'ambiente', 'column' => 'ambiente', 'match' => 'int'],
+        ],
+    ],
+
+    // 2. POST /nfe-brasil/tributacao/auto-emission/toggle
+    // Per-business gate emissao automatica (ADR 0093 multi-tenant Tier 0).
+    // Validator inline Request::boolean. Controller early-redirect se row nao
+    // existe — test file seed baseline em beforeEach.
+    'auto_emission_toggle' => [
+        'endpoint' => '/nfe-brasil/tributacao/auto-emission/toggle',
+        'method' => 'post',
+        'expectStatus' => 302,
+        'read_back' => 'db',
+        'table' => 'nfe_business_configs',
+        'where' => ['business_id' => '{business_id}'],
+        'fields' => [
+            ['send' => 'enabled', 'value' => true,  'recv' => 'auto_emission_enabled', 'column' => 'auto_emission_enabled', 'match' => 'bool'],
+            ['send' => 'enabled', 'value' => false, 'recv' => 'auto_emission_enabled', 'column' => 'auto_emission_enabled', 'match' => 'bool'],
+        ],
+    ],
+
+    // 3. POST /nfe-brasil/tributacao/config-default
+    // Upsert Nivel 4 cascade tributario. Validator UpsertConfigDefaultRequest
+    // exige TODOS campos juntos — baseFields garante payload valido pra cada
+    // iteracao varia 1 campo. regime e coluna scalar; demais ficam dentro do
+    // JSON tributacao_default (read-back via Eloquent cast => array).
+    // NOTA: regime canon validator e 'simples' (nao 'simples_nacional' label UI).
+    'config_default' => [
+        'endpoint' => '/nfe-brasil/tributacao/config-default',
+        'method' => 'post',
+        'expectStatus' => 302,
+        'read_back' => 'model',
+        'table' => 'nfe_business_configs',
+        'where' => ['business_id' => '{business_id}'],
+        'baseFields' => [
+            'regime' => 'simples',
+            'ncm_default' => '49019900',
+            'cfop_default' => '5102',
+            'csosn' => '102',
+            'aliquota_icms' => 0.18,
+            'aliquota_pis' => 0.0165,
+            'aliquota_cofins' => 0.076,
+        ],
+        'fields' => [
+            ['send' => 'regime',         'value' => 'lucro_presumido', 'recv' => 'regime', 'column' => 'regime'],
+            ['send' => 'ncm_default',    'value' => '85423100', 'recv' => 'tributacao_default.ncm_default',  'json_path' => 'tributacao_default.ncm_default'],
+            ['send' => 'cfop_default',   'value' => '5405',     'recv' => 'tributacao_default.cfop_default', 'json_path' => 'tributacao_default.cfop_default'],
+            ['send' => 'csosn',          'value' => '500',      'recv' => 'tributacao_default.csosn',        'json_path' => 'tributacao_default.csosn'],
+            ['send' => 'aliquota_icms',  'value' => 0.12,       'recv' => 'tributacao_default.aliquota_icms', 'json_path' => 'tributacao_default.aliquota_icms', 'match' => 'float'],
+        ],
+    ],
+];

--- a/tests/Contract/README.md
+++ b/tests/Contract/README.md
@@ -128,11 +128,11 @@ Skips gracefully se ambiente sem schema (`Schema::hasTable('contacts')` false) �
 |---|---|---|
 | Cliente drawer | ✅ implementado | 5 abas (identificacao/contato/endereco/comercial/classificacao) |
 | Sells/Create | ✅ parcial | quick-add cliente (POST /contacts), commission-split (PATCH /sells/{id}/commission-split). NÃO cobre POST /pos (full-form). |
-| OficinaAuto/ServiceOrder | 🟡 alto | edit, status_change |
+| OficinaAuto/ServiceOrder | ✅ implementado | PUT edit (status + datas + notes + odometer) — roundtrip via GET JSON |
+| NFe/Config | ✅ parcial | ambiente SEFAZ (POST), auto-emission toggle (POST), config-default upsert (POST). NÃO cobre upload .pfx (multipart, fixture próprio) nem testar SEFAZ (action, não autosave). |
 | Compras/Create | 🟡 médio | draft, item edit |
 | Vehicles/Edit | ⚪ baixo | edit |
 | Produto/Edit | ⚪ baixo | edit, variations |
-| NFe/Config | ⚪ baixo | certificate upload, ambiente toggle |
 
 ## Tier 2 (futuro)
 

--- a/tests/Feature/Contract/NfeConfigAutosaveContractTest.php
+++ b/tests/Feature/Contract/NfeConfigAutosaveContractTest.php
@@ -1,0 +1,183 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\NfeBrasil\Models\NfeBusinessConfig;
+use Tests\Contract\AutosaveContractRunner;
+
+/**
+ * Contract test do dominio NFe/Config (Fiscal/Config.tsx unificado + endpoints
+ * NfeBrasil/Configuracao + NfeBrasil/Tributacao). Wagner 2026-05-27 — extensao
+ * do ADR 0205 (contract tests autosave canon) pra dominio fiscal.
+ *
+ * Endpoints aqui retornam RedirectResponse — test usa custom loop inline (como
+ * ServiceOrderEditAutosaveContractTest) em vez de AutosaveContractRunner::run.
+ * Read-back via DB column lookup (source of truth direto).
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGAVEL):
+ *   - setupContext autentica user + popula user.business_id
+ *   - +session['business.id'] (validator NfeBrasil le dessa chave)
+ *   - +permission superadmin (FormRequests autorizam por can('nfe.tributacao.manage'))
+ *
+ * EXCLUIDOS: upload .pfx (multipart, fixture proprio), testar SEFAZ (action),
+ * senhas/CSC/cert (Vaultwarden — NUNCA DB).
+ *
+ * @see Modules\NfeBrasil\Http\Controllers\CertificadoController::updateAmbiente
+ * @see Modules\NfeBrasil\Http\Controllers\TributacaoController::toggleAutoEmission
+ * @see Modules\NfeBrasil\Http\Controllers\ConfigDefaultController::upsert
+ * @see ADR 0205 (contract tests autosave canon) · ADR 0142 (ambiente 1/2)
+ */
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompativel: requer schema MySQL UltimatePOS (ADR 0101) + tabelas NfeBrasil');
+    }
+    if (! Schema::hasTable('nfe_business_configs')) {
+        $this->markTestSkipped('Schema NfeBrasil ausente — rode `php artisan module:migrate NfeBrasil`');
+    }
+    if (! Schema::hasColumn('business', 'ambiente')) {
+        $this->markTestSkipped('Coluna business.ambiente ausente — ADR 0142 migration nao rodou');
+    }
+    if (! Schema::hasColumn('nfe_business_configs', 'auto_emission_enabled')) {
+        $this->markTestSkipped('Coluna auto_emission_enabled ausente — migration 2026_05_08 nao rodou');
+    }
+
+    $ctx = AutosaveContractRunner::setupContext($this);
+    $this->business = $ctx['business'];
+    $this->user = $ctx['user'];
+
+    // Validator NfeBrasil le `business.id` da session (setupContext popula apenas user.business_id).
+    session(['business.id' => $this->business->id]);
+
+    // FormRequests exigem `nfe.tributacao.manage` (validator authorize).
+    // superadmin e wildcard — skip gracioso se role nao existir no env.
+    try {
+        $this->user->givePermissionTo('superadmin');
+    } catch (\Throwable $e) {
+        $this->markTestSkipped('Permission `superadmin` indisponivel — rode seeder de roles antes');
+    }
+
+    // Seed baseline nfe_business_configs — toggleAutoEmission + upsert dependem da row.
+    DB::table('nfe_business_configs')->updateOrInsert(
+        ['business_id' => $this->business->id],
+        [
+            'regime' => 'simples',
+            'tributacao_default' => json_encode([
+                'ncm_default' => '00000000', 'cfop_default' => '5102', 'cfop' => '5102',
+                'csosn' => '102', 'aliquota_icms' => 0.0, 'aliquota_pis' => 0.0, 'aliquota_cofins' => 0.0,
+            ]),
+            'auto_emission_enabled' => false,
+            'updated_at' => now(), 'created_at' => now(),
+        ]
+    );
+});
+
+it('NFe/Config — 3 endpoints autosave persistem TODOS os campos do fixture (round-trip DB read-back)', function () {
+    $fixture = require __DIR__ . '/../../Contract/Fixtures/nfe_config.php';
+
+    $passed = 0;
+    $total = 0;
+    $failures = [];
+
+    foreach ($fixture as $tabName => $tabSpec) {
+        $endpoint = $tabSpec['endpoint'];
+        $method = strtolower($tabSpec['method'] ?? 'post');
+        $expectStatus = $tabSpec['expectStatus'] ?? 302;
+        $readBack = $tabSpec['read_back'] ?? 'db';
+        $table = $tabSpec['table'];
+        $baseFields = $tabSpec['baseFields'] ?? [];
+
+        $where = [];
+        foreach (($tabSpec['where'] ?? []) as $col => $val) {
+            $where[$col] = is_string($val)
+                ? str_replace('{business_id}', (string) $this->business->id, $val)
+                : $val;
+        }
+
+        foreach ($tabSpec['fields'] as $field) {
+            $total++;
+            $sendKey = $field['send'];
+            $recvKey = $field['recv'];
+            $match = $field['match'] ?? 'equals';
+            $sent = $field['value'];
+
+            $payload = array_merge($baseFields, [$sendKey => $sent]);
+
+            $response = match ($method) {
+                'put' => $this->put($endpoint, $payload),
+                'patch' => $this->patch($endpoint, $payload),
+                default => $this->post($endpoint, $payload),
+            };
+            $status = $response->status();
+            $statusOk = $status === $expectStatus || ($expectStatus === 302 && in_array($status, [200, 302], true));
+
+            // Read-back source of truth direto.
+            $received = null;
+            if ($readBack === 'model' && $table === 'nfe_business_configs') {
+                // Eloquent → tributacao_default cast como array.
+                $model = NfeBusinessConfig::where($where)->first();
+                $received = $model ? data_get($model->toArray(), $recvKey) : null;
+            } elseif (! empty($field['json_path'])) {
+                $row = (array) DB::table($table)->where($where)->first();
+                $jsonCol = explode('.', $field['json_path'])[0];
+                $rawJson = $row[$jsonCol] ?? null;
+                $decoded = is_string($rawJson) ? json_decode($rawJson, true) : $rawJson;
+                $nested = substr($field['json_path'], strlen($jsonCol) + 1);
+                $received = $nested === '' ? $decoded : data_get($decoded, $nested);
+            } elseif (! empty($field['column'])) {
+                $received = DB::table($table)->where($where)->value($field['column']);
+            }
+
+            $valueOk = matchesNfeConfigValue($sent, $received, $match);
+
+            if (! $statusOk || ! $valueOk) {
+                $failures[] = [
+                    'tab' => $tabName, 'endpoint' => $endpoint, 'method' => $method,
+                    'send' => $sendKey, 'value_sent' => is_scalar($sent) ? (string) $sent : json_encode($sent),
+                    'recv' => $recvKey, 'value_received' => is_scalar($received) ? (string) $received : json_encode($received),
+                    'status' => $status, 'match_mode' => $match,
+                ];
+            } else {
+                $passed++;
+            }
+        }
+    }
+
+    if ($passed !== $total) {
+        $msg = "Contract test FALHOU — {$passed}/{$total} OK.\n\nBugs silenciosos detectados (POST aceito mas valor nao bate em DB read-back):\n";
+        foreach ($failures as $f) {
+            $msg .= sprintf(
+                "  [%s] %s %s — send=%s value_sent=%s recv=%s value_received=%s status=%d match=%s\n",
+                $f['tab'], strtoupper($f['method']), $f['endpoint'], $f['send'], var_export($f['value_sent'], true),
+                $f['recv'], var_export($f['value_received'], true), $f['status'], $f['match_mode']
+            );
+        }
+        $msg .= "\nADR 0205 — todo PR que regrida contract test bloqueia merge.\n";
+        expect($failures)->toBeEmpty($msg);
+    }
+
+    expect($passed)->toBe($total);
+});
+
+/**
+ * Match modes — estende AutosaveContractRunner::matches com modo 'float'
+ * (tolerancia 1e-6 pra comparar floats DB roundtrip string vs PHP float).
+ */
+function matchesNfeConfigValue(mixed $sent, mixed $received, string $match): bool
+{
+    return match ($match) {
+        'partial' => $received !== null && is_string($received)
+            && str_contains((string) $received, is_string($sent) ? $sent : (string) $sent),
+        'bool' => (bool) $received === (bool) $sent,
+        'int' => (int) $received === (int) $sent,
+        'float' => is_numeric($received) && is_numeric($sent)
+            && abs((float) $received - (float) $sent) < 1e-6,
+        'array_eq' => json_encode($received) === json_encode($sent),
+        default => $received === $sent || (string) $received === (string) $sent,
+    };
+}


### PR DESCRIPTION
## Summary

Estende ADR 0205 (contract tests autosave canon) pro dominio Fiscal/Config unificado + endpoints NfeBrasil/Configuracao + NfeBrasil/Tributacao. **9 campos auto-verificados** em 3 endpoints, read-back via DB column lookup direto (endpoints retornam RedirectResponse — pattern espelha ServiceOrderEditAutosaveContractTest).

## Endpoints cobertos

| # | Endpoint | Persiste em | Campos |
|---|---|---|---|
| 1 | `POST /nfe-brasil/configuracao/certificado/ambiente` | `business.ambiente` (toggle 1=PROD / 2=HOMOLOG, ADR 0142) | 2 (ambos valores) |
| 2 | `POST /nfe-brasil/tributacao/auto-emission/toggle` | `nfe_business_configs.auto_emission_enabled` (ADR 0093 per-business gate) | 2 (true/false) |
| 3 | `POST /nfe-brasil/tributacao/config-default` | `nfe_business_configs.regime` + `tributacao_default` JSON (ncm_default, cfop_default, csosn, aliquota_icms) | 5 |

## Endpoints EXCLUIDOS POR DESIGN (outros PRs)

- `POST /nfe-brasil/configuracao/certificado` (upload .pfx multipart — fixture proprio com complexidade X509)
- `POST /nfe-brasil/configuracao/certificado/testar` (action ping SEFAZ, nao persiste estado)
- `POST /nfe-brasil/tributacao/templates/{slug}/aplicar` (bulk mutate, tests dedicados)
- CRUD `/nfe-brasil/tributacao/regras` (subdominio NCM rules — fixture proprio)
- Import CSV (multipart + side-effects multi-row)

## EXCLUIDOS POR PII/SECRETS (Tier 0 — NUNCA em fixture)

- Senha .pfx do certificado A1 (Laravel encrypt + MemCofre, nao DB plain)
- CSC NFC-e + chave privada cert (Vaultwarden, nao DB)

## Multi-tenant Tier 0 (ADR 0093 IRREVOGAVEL) preservado

- `setupContext` autentica user + popula `user.business_id`
- **+session['business.id']** (validator NfeBrasil le dessa chave especifica, diferente da convencao Cliente)
- **+permission `superadmin`** (FormRequests autorizam por `can('nfe.tributacao.manage')`)
- Seed baseline `nfe_business_configs` row no `beforeEach` (toggleAutoEmission early-redirect se row nao existir)
- `DatabaseTransactions` cobre rollback automatico

## Schema fixture estendido

Nova convencao documentada vs `cliente_drawer.php`:
- `'read_back' => 'db' | 'model'` — `db` usa `DB::table` raw; `model` usa Eloquent (casts JSON → array)
- `'table'` + `'where'` (placeholder `{business_id}`) + `'column'` | `'json_path'`
- Novo match mode `'float'` (tolerancia 1e-6 — DB pode retornar string, PHP float)

## Test plan

- [x] PHP `-l` syntax check OK (fixture + test file)
- [x] `php artisan test tests/Feature/Contract/NfeConfigAutosaveContractTest.php` skipa gracioso em SQLite CI (1 skipped, 0 assertions, sem erro)
- [x] Skip gracioso em ambiente sem migration NfeBrasil (`nfe_business_configs`) / sem ADR 0142 (`business.ambiente`) / sem migration 2026_05_08 (`auto_emission_enabled`)
- [x] Skip gracioso se role `superadmin` indisponivel
- [x] Tamanho commit ≤300 linhas (291 insertions, conventional commit)
- [ ] Validacao end-to-end MySQL (gate Wagner local) — corrida pos-merge

## Refs

- ADR 0205 — Contract tests autosave padrao canonico
- ADR 0142 — NFe ambiente prod/homolog tinyInteger 1/2
- ADR 0093 — Multi-tenant Tier 0 (preservado nos contract tests)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>