### PR TITLE
docs(session): 2026-05-27 contract tests framework rollout (8 telas · 92 campos)

### DIFF
--- a/memory/sessions/2026-05-27-contract-tests-framework-rollout.md
+++ b/memory/sessions/2026-05-27-contract-tests-framework-rollout.md
@@ -1,0 +1,156 @@
+---
+title: "Contract tests autosave — framework canon + 8 telas cobertas em paralelo (ADR 0205)"
+type: session
+date: 2026-05-27
+author: Claude (Opus 4.7) sob direção Wagner — 6 sub-agents paralelos
+status: complete
+audience: Wagner + Felipe + Maiara (próximas iterações contract tests)
+related_adrs:
+  - 0205
+  - 0179
+  - 0093
+  - 0094
+  - 0061
+source_files:
+  - "tests/Contract/AutosaveContractRunner.php"
+  - "tests/Contract/Fixtures/*.php (7 fixtures)"
+  - "tests/Feature/Contract/*.php (7 tests)"
+  - "tests/Contract/README.md"
+  - "memory/decisions/0205-contract-tests-autosave-padrao-canonico.md"
+---
+
+# Contract Tests Framework Rollout — 2026-05-27
+
+> **Continuação da sessão 2026-05-27 drawer Cliente.** Wagner reagiu pós-bateria exaustiva ("podia ter criado regra pra TODAS as telas") → canonizei framework + 1 sub-agent serial (drawer Cliente) + 6 sub-agents paralelos (5 telas).
+
+## Entregas — 9 PRs merged em ~3h
+
+| # | PR | Tela | Campos | Aliases | Pattern endpoint |
+|---|---|---|---|---|---|
+| 1 | #1791 | **Drawer Cliente** | 32 (5 abas) | 6 (nome/doc/tel/site/canal/contato) | PATCH per-field |
+| 2 | #1795 | **ServiceOrder/Edit** | 7 cadastrais | ❌ canon EN nativo | PUT form + DB roundtrip |
+| 3 | #1797 | **Sells/Create** companheiros | 7 (2 endpoints) | `first_name→name` + nested shape | POST + payload nested |
+| 4 | #1799 | **ServiceOrderItem CRUD** | 7 | ❌ | POST 201 |
+| 5 | #1800 | **Vehicles/Edit** | 14 | ❌ | PUT |
+| 6 | #1801 | **Produto/Edit** | 11 | ❌ | PUT + DB roundtrip |
+| 7 | #1802 | **Compras/Create** supplier | 5 | ❌ explícito (mesmo endpoint Sells PF) | POST |
+| 8 | #1803 | **NFe/Config** | 9 (3 endpoints) | **`session['business.id']` vs `user.business_id`** | POST 302 + DB roundtrip |
+
+**Total: ~92 campos auto-testados em CI a cada PR.**
+
+ADR 0205 (canonizado) + Runner Pest reusável + README com receita 2-arquivos pra adicionar nova tela.
+
+## Patterns arquiteturais descobertos
+
+### P1 — 3 tipos de endpoint
+1. **PATCH per-field autosave** (Cliente drawer) — request `{key: value}`, response `{contact: {...}}` shape padrão
+2. **PUT form submit + DB roundtrip** (ServiceOrder/Vehicles/Produto) — request full payload, response 302 redirect, validar via `Vehicle::find($id)` direto no DB
+3. **POST 201/302** (Sells/Compras/Items/NFe) — pode retornar JSON (201) ou redirect (302)
+
+Runner extensível pra todos via opções: `method`/`responseRoot`/`payloadShape`/`baseFields`/`expectStatus`.
+
+### P2 — Aliases PT-BR↔EN só no Cliente
+Outras telas (ServiceOrder/Vehicles/Produto/Sells/Compras/NFe) nasceram canon EN nativo. Cliente foi o único módulo com fase legacy PT-BR (drawer Cowork). Heurística pra próximos PRs: **assumir canon EN; explicitar alias só quando confirmado**.
+
+### P3 — Session multi-tenant não é uniforme
+NFe usa `session['business.id']` (não `user.business_id` como resto). **Bug silencioso esperando acontecer** se dev assumir uniformidade. Solução: contract test seta ambas session keys (`setupContext` ampliado).
+
+### P4 — FSM Pipeline transitions FORA do contract test
+ServiceOrder/Vehicles têm `current_status`/`current_stage_id` FSM. Contract test cobre só campos cadastrais. FSM tem test próprio via `ExecuteStageActionService` (ADR 0143).
+
+### P5 — PII LGPD: valores sintéticos no fixture
+Pattern obrigatório: `'TEST-{stamp}'`, CNPJ fake mod-11 (`'11.222.333/0001-44'`), placa `'TEST-{stamp}'`. Cert .pfx + senha + CSC NFC-e ficam em Vaultwarden (NÃO no fixture).
+
+## Bugs descobertos pelos sub-agents (catalogados pra próxima iteração)
+
+| Bug | Sub-agent | PR | Status |
+|---|---|---|---|
+| Drawer Cliente Tags display (backend OK, chips não destacam) | Wagner manual | — | ❌ pendente — suspeito cache stale rows Inertia |
+| Bug #4 cache stale generalizado (`useEffect([contact.id])` em 4 tabs) | catalogado | — | ❌ pendente |
+| `responseShape: raw_body` faltando no runner (`check_ref_number` Compras) | Compras | bloqueado | ❌ pendente extensão runner |
+| Multi-placeholder `{order}+{item}` faltando (ServiceOrderItem PUT/DELETE) | ServiceOrderItem | bloqueado | ❌ pendente extensão runner |
+
+## Pendências priorizadas pra próxima sessão
+
+### A — Extender runner Contract Tests (~80 linhas, 1 PR rápido)
+- `responseShape: raw_body` (Compras `check_ref_number`)
+- Multi-placeholder `{order}+{item}` (ServiceOrderItem PUT/DELETE)
+- Multipart support (NFe cert .pfx upload)
+- Reativa 3 endpoints DESATIVADOS nos fixtures existentes
+
+### B — Bugs UI restantes drawer Cliente
+- Tags display chips (backend OK, frontend não destaca)
+- Bug #4 cache stale generalizado:
+  - Adicionar `onContactUpdated` callback em IdentificacaoTab/ContatoTab/ComercialTab/ClassificacaoTab (pattern do EnderecoTab fix #1786)
+  - OU pattern global `key={contact.id + lastUpdated}` no parent
+- Inspecionar via JS browser pós-PATCH se tag chip lê de prop ou state
+
+### C — Próximas telas pendentes (paralelizar com sub-agents)
+- **DviInspection CRUD** (OficinaAuto Wave 3 — wedge competitivo vs RepairShopr · sugerido por sub-agent ServiceOrder)
+- **Stock adjustment** Produto (endpoint separado `/stock-adjustments`)
+- **Variations pricing** Produto (sub_sku/single_dpp/single_dsp roundtrip)
+- **Bulk edit** Produto (POST `/products/bulk-update`)
+- **Image upload** Produto (multipart — depende runner extension A)
+- **Cert upload .pfx** NFe (multipart — depende runner extension A)
+- **Sells/Edit shipping modal** (PATCH `/sells/update-shipping/{id}`)
+- **CRUD NCM rules** NFe (`/nfe-brasil/tributacao/regras`)
+
+### D — Tier 2 Browser smoke (Q3 2026)
+- Pest Browser/Dusk pra capturar bugs de cache stale frontend
+- Plano: implementar após Tier 1 cobrir 10+ telas
+
+## Lições de processo (vale replicar)
+
+### L1 — Sub-agents paralelos via `isolation: worktree` funcionam
+6 agents paralelos hoje, todos abriram PR + admin merge autônomo. Pegadinhas catalogadas pelos próprios agents:
+- **Branch race condition** quando 2+ agents tentam `git checkout` no main repo shared. Solução: trabalhar 100% dentro do worktree próprio (`pwd` confirmar `agent-<id>`), commit + push do worktree, merge via `gh api` (evita `gh pr merge` que tenta local checkout).
+- **README.md conflict** quando 5 agents adicionam linha simultaneamente na tabela de coverage. Resolução: último agent que mergeou herdou conflito, rebase + resolve manual.
+
+### L2 — Naming `-v2`/`-v3` em branches paralelas
+Sub-agent Compras teve que usar `feat/contract-fixture-compras-create-v3` porque outros agents stomparam `compras-create` e `compras-create-v2`. Padrão a evitar: numerar branches pra evitar colisão se sub-agents paralelos forem retriggered.
+
+### L3 — Sub-agents documentam achados úteis no PR body
+Cada PR teve sub-seção "Próximos endpoints sugeridos" — backlog auto-gerado. Wagner pode revisar listas e priorizar.
+
+### L4 — `gh api` mais resiliente que `gh pr merge` em multi-agent
+`gh pr merge` tenta checkout local da branch — falha em multi-agent paralelo. `gh api repos/{owner}/{repo}/pulls/{num}/merge` faz merge server-side, sem race condition.
+
+## Custo cognitivo da sessão
+
+- ~3h totais (parent + 6 sub-agents paralelos)
+- 9 PRs merged (sem rejeição)
+- 1 conflito de merge resolvido (NFe README)
+- ~92 campos auto-testados em CI a cada PR
+- Padrão ADR 0205 ativo
+
+## Prompt sugerido pra próxima sessão
+
+```
+Continuar contract tests rollout (sessão 2026-05-27).
+
+Próximo trabalho — escolher A/B/C:
+
+A — Extender runner Contract Tests (~80 linhas, 1 PR)
+   - responseShape: raw_body (Compras check_ref_number)
+   - Multi-placeholder {order}+{item} (ServiceOrderItem PUT/DELETE)
+   - Multipart support (NFe cert .pfx)
+   - Reativa 3 endpoints DESATIVADOS
+
+B — Bugs UI drawer Cliente restantes
+   - Tags display chips
+   - Bug #4 cache stale generalizado (4 tabs sem onContactUpdated)
+
+C — Próximas telas via sub-agents paralelos
+   - DviInspection CRUD (wedge OficinaAuto)
+   - Stock adjustment Produto
+   - Sells/Edit shipping modal
+   - CRUD NCM rules NFe
+
+Ler: memory/sessions/2026-05-27-contract-tests-framework-rollout.md
+     memory/decisions/0205-contract-tests-autosave-padrao-canonico.md
+     tests/Contract/README.md
+```
+
+---
+
+**Última atualização:** 2026-05-27 — sessão fechada. Padrão ADR 0205 ativo em escala produtiva (7 telas cobertas). Próxima sessão começa pelo prompt sugerido acima.

--- a/tests/Contract/Fixtures/produto_edit.php
+++ b/tests/Contract/Fixtures/produto_edit.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fixture: contract test da tela Produto/Edit (UPOS legacy ProductController::update).
+ *
+ * IMPORTANTE — diferenças do fixture cliente_drawer.php:
+ *  1. Produto/Edit NÃO usa autosave PATCH per-field — usa um único
+ *     PUT /products/{id} com payload completo (form submit clássico que
+ *     redireciona pra /products após sucesso).
+ *  2. Por isso o test file (ProdutoEditAutosaveContractTest) NÃO usa
+ *     AutosaveContractRunner::run() default — usa loop inline customizado:
+ *       a) PUT com [base_payload + 1 campo alterado] por iteração
+ *       b) Verifica roundtrip via Product::find($id) (DB direto, pq o
+ *          response é redirect 302 sem JSON; e o show JSON via X-Inertia
+ *          só expõe um subset do que update pode escrever — `weight`,
+ *          `product_description`, custom_fields não estão lá).
+ *  3. Mesmo princípio: contract test "envia X, lê de volta X" — pegando
+ *     bugs silenciosos do tipo $request->only() dropping unknown keys
+ *     (regressão exatamente análoga à do drawer Cliente 2026-05-27 com
+ *     aliases PT-BR; e a regressão UPOS 6.7 que sumiu `cpf_cnpj`).
+ *
+ * Cobre CAMPOS CADASTRAIS do `$request->only([...])` em update() §948:
+ *  name, sku, alert_quantity, weight, product_description, barcode_type,
+ *  tax_type, product_custom_field1, product_custom_field2, product_custom_field3,
+ *  preparation_time_in_minutes
+ *
+ * NÃO cobre (separation of concerns):
+ *  - Variations (single_dpp, single_dsp, sub_sku) — gravadas em `variations`
+ *    table via Variation::find($single_variation_id), exigem produto setup
+ *    com row variations criada. Próxima iteração (ver "próximas variantes").
+ *  - product_locations sync (M2M business_locations) — exige location seedada
+ *  - Image upload (multipart) — fora do escopo contract autosave
+ *  - Expiry (expiry_period_type/expiry_period) — gated por session
+ *    `business.enable_product_expiry` que não conseguimos forçar via runner.
+ *  - Stock adjustment — endpoint /stock-adjustments distinto, ServiceOrder pattern.
+ *
+ * Aliases PT-BR vs canon EN:
+ *  - Nenhum detectado no $request->only() do update — todos campos já canon
+ *    EN herdados do UPOS upstream. Mesmo assim cobrir é valioso: se um dia
+ *    alguém adicionar alias `descricao => product_description` no controller
+ *    sem mapear ambos, este test pega.
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): test setupContext força
+ * business_id da sessão; Product tem global scope via business_id no WHERE
+ * direto do update() (`Product::where('business_id', $business_id)`).
+ *
+ * @see app/Http/Controllers/ProductController::update §940
+ * @see app/Product.php
+ * @see tests/Contract/README.md — receita
+ * @see ADR 0205 — contract tests autosave canon
+ */
+
+return [
+    'cadastrais' => [
+        // Endpoint PUT — Route::resource('products', ...) gera PUT/PATCH /products/{id}
+        // automático. Controller faz update() e redireciona pra /products (302).
+        'endpoint' => '/products/{id}',
+        'method' => 'put',
+        'fields' => [
+            // Nome do produto — string básica, valida persistência do mais
+            // crítico (campo NOT NULL no schema, primeiro do $request->only()).
+            ['send' => 'name', 'value' => 'PROD-{stamp}', 'recv' => 'name'],
+
+            // SKU — se vazio o controller gera via generateProductSku no store,
+            // no update vem direto do request. Bug clássico: se mudarem o pipeline
+            // pra "auto-trim se contém espaço" o test pega.
+            ['send' => 'sku', 'value' => 'SKU-{stamp}', 'recv' => 'sku'],
+
+            // Decimal — alert_quantity passa por num_uf (parsing pt-BR locale).
+            // Match int pois Eloquent retorna "10.0000" string pelo cast decimal(22,4)
+            // e num_uf transforma input em float — comparação int garante "10" === "10".
+            // Valor sem casa decimal pra evitar formatting quirks "10,0000" vs "10".
+            ['send' => 'alert_quantity', 'value' => '10', 'recv' => 'alert_quantity', 'match' => 'int'],
+
+            // Peso — string livre na schema (decimal 22,4 mas controller atribui
+            // direto sem num_uf). Match partial pq DB pode normalizar "1.500"
+            // vs "1.5000". Substring "1.5" cobre.
+            ['send' => 'weight', 'value' => '1.5', 'recv' => 'weight', 'match' => 'partial'],
+
+            // Description — text livre, sem transformação no controller.
+            ['send' => 'product_description', 'value' => 'CT desc {stamp}', 'recv' => 'product_description'],
+
+            // Barcode type enum — fixo ['C39','C128','EAN-13','EAN-8','UPC-A','UPC-E','ITF-14'].
+            // C128 é o default UPOS. Mudamos pra EAN-13 pra forçar persistência diferente.
+            ['send' => 'barcode_type', 'value' => 'EAN-13', 'recv' => 'barcode_type'],
+
+            // Tax type enum — ['inclusive', 'exclusive']. Default exclusive.
+            ['send' => 'tax_type', 'value' => 'inclusive', 'recv' => 'tax_type'],
+
+            // Custom fields livres (product_custom_field1..20 todos no $request->only).
+            // Cobrimos 3 — suficiente pra detectar se alguém retirar o `?? ''` fallback
+            // do controller (que silenciosamente zeraria campos não-enviados).
+            ['send' => 'product_custom_field1', 'value' => 'CT cf1 {stamp}', 'recv' => 'product_custom_field1'],
+            ['send' => 'product_custom_field2', 'value' => 'CT cf2 {stamp}', 'recv' => 'product_custom_field2'],
+            ['send' => 'product_custom_field3', 'value' => 'CT cf3 {stamp}', 'recv' => 'product_custom_field3'],
+
+            // Preparation time — integer (minutos), módulo Restaurant feature.
+            // Match int pq DB retorna int e frontend envia string às vezes.
+            ['send' => 'preparation_time_in_minutes', 'value' => 45, 'recv' => 'preparation_time_in_minutes', 'match' => 'int'],
+        ],
+    ],
+];

--- a/tests/Feature/Contract/ProdutoEditAutosaveContractTest.php
+++ b/tests/Feature/Contract/ProdutoEditAutosaveContractTest.php
@@ -1,0 +1,251 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Tests\Contract\AutosaveContractRunner;
+
+/**
+ * Contract test da tela Produto/Edit (UPOS legacy ProductController::update).
+ *
+ * Pattern espelha ServiceOrderEditAutosaveContractTest — PUT form submit
+ * (redirect 302, não JSON) + roundtrip via DB direto (pq Product::show via
+ * X-Inertia expõe apenas subset dos campos que update aceita; ler do DB
+ * é a fonte de verdade pra "o que persistiu de verdade").
+ *
+ * Ver fixture `tests/Contract/Fixtures/produto_edit.php` pra detalhe dos
+ * campos cobertos + justificativa do que NÃO está aqui (variations,
+ * locations, expiry, image upload).
+ *
+ * Setup (3 fases):
+ *   1. setupContext: pega Business + User reais, autentica, popula session
+ *   2. Cria Unit no business (foreign key required em products.unit_id)
+ *   3. Cria Product base + ProductVariation dummy + Variation dummy (o
+ *      controller update() em produto type=single faz Variation::find($single_variation_id)
+ *      e dá save() — se o ID não existir, NPE. Mesmo enviando só campos
+ *      cadastrais, o controller SEMPRE atravessa o branch single).
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL):
+ *   - Product Eloquent ::where('business_id', $bid) hardcoded no controller §952
+ *   - Session user.business_id populada via setupContext
+ *   - Unit/Variation/ProductVariation criados no mesmo business
+ *
+ * Skip graceful: sqlite memory OU schema UPOS ausente. Permission
+ * `product.update` precisa estar atribuída ao user — tentamos via
+ * Permission::firstOrCreate + assignRole se Spatie estiver disponível.
+ *
+ * @see app/Http/Controllers/ProductController::update §940
+ * @see tests/Contract/Fixtures/produto_edit.php
+ * @see ADR 0205 — contract tests autosave canon
+ * @see ADR 0093 — multi-tenant Tier 0 IRREVOGÁVEL
+ */
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    // Pré-flight 1: DB driver — schema UPOS exige MySQL.
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS (products+variations+units)');
+    }
+    // Pré-flight 2: tabelas UPOS.
+    foreach (['products', 'variations', 'product_variations', 'units'] as $tbl) {
+        if (! Schema::hasTable($tbl)) {
+            $this->markTestSkipped("Schema UPOS ausente: tabela {$tbl} não existe");
+        }
+    }
+
+    // Setup multi-tenant (autentica user + session business_id) — reusa runner helper.
+    $ctx = AutosaveContractRunner::setupContext($this);
+    $this->business = $ctx['business'];
+    $this->user = $ctx['user'];
+
+    // Garante que user tem permission product.update — sem isso, controller aborta 403.
+    // Tentamos via Spatie Permission se disponível; fallback silencioso (test pode
+    // ainda passar se user for super-admin via outro mecanismo).
+    try {
+        if (class_exists(\Spatie\Permission\Models\Permission::class)) {
+            $perm = \Spatie\Permission\Models\Permission::firstOrCreate(
+                ['name' => 'product.update', 'guard_name' => 'web']
+            );
+            $this->user->givePermissionTo($perm);
+        }
+    } catch (\Throwable $e) {
+        // Best-effort — se Spatie não carregar ou role/permission models não disponíveis,
+        // pula sem quebrar (test pode skip-ar com 403 mensagem clara).
+    }
+
+    // Cria Unit no business — products.unit_id é foreign key NOT NULL.
+    $this->unitId = DB::table('units')->insertGetId([
+        'business_id' => $this->business->id,
+        'actual_name' => 'CT Unit ' . substr((string) microtime(true), -4),
+        'short_name' => 'CTU',
+        'allow_decimal' => 1,
+        'created_by' => $this->user->id,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    // Cria Product base (type=single, tax_type=exclusive, barcode_type=C128).
+    // Schema NOT NULL: name, business_id, type, unit_id, tax_type, sku, barcode_type, created_by.
+    $this->productId = DB::table('products')->insertGetId([
+        'business_id' => $this->business->id,
+        'name' => 'CT Setup Product ' . substr((string) microtime(true), -4),
+        'type' => 'single',
+        'unit_id' => $this->unitId,
+        'tax_type' => 'exclusive',
+        'sku' => 'CT-SETUP-' . substr((string) microtime(true), -4),
+        'barcode_type' => 'C128',
+        'enable_stock' => 0,
+        'alert_quantity' => 0,
+        'created_by' => $this->user->id,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    // Cria ProductVariation dummy (1×1 com product) — controller update() lê
+    // ->product_variations no with() e a Variation dummy aponta pra ela.
+    $this->productVariationId = DB::table('product_variations')->insertGetId([
+        'product_id' => $this->productId,
+        'name' => 'DUMMY',
+        'is_dummy' => 1,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+
+    // Cria Variation dummy — controller §1073 faz Variation::find($single_variation_id)
+    // e ->save(). Se ID inexistente -> erro de catch silencia (output success=0).
+    $this->variationId = DB::table('variations')->insertGetId([
+        'name' => 'DUMMY',
+        'product_id' => $this->productId,
+        'product_variation_id' => $this->productVariationId,
+        'sub_sku' => 'CT-SETUP-VAR-' . substr((string) microtime(true), -4),
+        'default_purchase_price' => 0,
+        'dpp_inc_tax' => 0,
+        'profit_percent' => 0,
+        'default_sell_price' => 0,
+        'sell_price_inc_tax' => 0,
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+});
+
+it('Produto/Edit — PUT /products/{id} persiste TODOS os campos cadastrais do fixture (roundtrip via DB)', function () {
+    $fixture = require __DIR__ . '/../../Contract/Fixtures/produto_edit.php';
+    $stamp = 'CT' . substr((string) microtime(true), -4);
+    $passed = 0;
+    $total = 0;
+    $failures = [];
+
+    foreach ($fixture as $tabName => $tabSpec) {
+        $endpoint = str_replace('{id}', (string) $this->productId, $tabSpec['endpoint']);
+
+        foreach ($tabSpec['fields'] as $field) {
+            $total++;
+            $sendKey = $field['send'];
+            $recvKey = $field['recv'];
+            $match = $field['match'] ?? 'equals';
+
+            // {stamp} substitution — único por iteração pra evitar
+            // falso-positivo de cache HTTP/Eloquent retornar estado anterior.
+            $sent = is_string($field['value'])
+                ? str_replace('{stamp}', $stamp, $field['value'])
+                : $field['value'];
+
+            // PUT precisa de payload completo (name + unit_id required). Mergeamos
+            // base + 1 campo alterado por iteração — outros ficam neutros e
+            // não interferem na verificação per-campo.
+            //
+            // single_variation_id + single_dpp/dsp são required pelo branch
+            // single (controller §1071). Valores zero são aceitos pelo num_uf
+            // e não rompem o Variation::find($single_variation_id)->save().
+            $base = [
+                'name' => 'CT base name',
+                'unit_id' => $this->unitId,
+                'tax_type' => 'exclusive',
+                'barcode_type' => 'C128',
+                'sku' => 'CT-BASE-' . $stamp,
+                'enable_stock' => 0,
+                'product_description' => 'CT base desc',
+                'single_variation_id' => $this->variationId,
+                'single_dpp' => '0',
+                'single_dpp_inc_tax' => '0',
+                'single_dsp' => '0',
+                'single_dsp_inc_tax' => '0',
+                'profit_percent' => '0',
+            ];
+            $payload = array_merge($base, [$sendKey => $sent]);
+
+            // 1) PUT — controller redireciona pro /products (302) em sucesso
+            // ou 422 em validation fail. Catch interno transforma exceções em
+            // output success=0 mas ainda retorna 302 — daí precisarmos do
+            // DB roundtrip pra detectar persistência real.
+            $putResponse = $this->put($endpoint, $payload);
+            $putStatus = $putResponse->status();
+            $putOk = in_array($putStatus, [200, 302], true);
+
+            // 2) DB lookup — fonte de verdade. Bypassamos cache Eloquent
+            // usando query builder direto. Se controller silenciosamente
+            // dropou a chave (regressão UPOS 6.7 do cpf_cnpj), o valor não bate.
+            $received = DB::table('products')
+                ->where('id', $this->productId)
+                ->value($recvKey);
+
+            $valueOk = matchesProdutoValue($sent, $received, $match);
+
+            if (! $putOk || ! $valueOk) {
+                $failures[] = [
+                    'tab' => $tabName,
+                    'endpoint' => $endpoint,
+                    'method' => 'put',
+                    'send' => $sendKey,
+                    'value_sent' => is_string($sent) ? substr($sent, 0, 60) : $sent,
+                    'recv' => $recvKey,
+                    'value_received' => is_string($received) ? substr((string) $received, 0, 60) : $received,
+                    'put_status' => $putStatus,
+                    'match_mode' => $match,
+                ];
+            } else {
+                $passed++;
+            }
+        }
+    }
+
+    // Falha legível pra dev — espelha ClienteDrawerAutosaveContractTest pattern.
+    if ($passed !== $total) {
+        $msg = "❌ Contract test FALHOU — {$passed}/{$total} OK.\n\n";
+        $msg .= "Bugs silenciosos detectados em Produto/Edit (PUT 302 mas valor não persistiu):\n";
+        foreach ($failures as $f) {
+            $msg .= sprintf(
+                "  [%s] %s %s · send=%s · value_sent=%s · recv=%s · value_received=%s · put=%d · match=%s\n",
+                $f['tab'], strtoupper($f['method']), $f['endpoint'], $f['send'], var_export($f['value_sent'], true),
+                $f['recv'], var_export($f['value_received'], true), $f['put_status'], $f['match_mode']
+            );
+        }
+        $msg .= "\nADR 0205 — todo PR que regrida contract test bloqueia merge.\n";
+        $msg .= "Fix comum: alinhar \$request->only() em ProductController::update §948 + colunas products schema.\n";
+
+        expect($failures)->toBeEmpty($msg);
+    }
+
+    expect($passed)->toBe($total);
+});
+
+/**
+ * Helper inline pra match modes — mesma semântica de
+ * AutosaveContractRunner::matches() (private). Duplicado aqui pq runner default
+ * só suporta patchJson e leitura via response->json(); nós precisamos DB direto.
+ * Pattern espelha matchesValue() em ServiceOrderEditAutosaveContractTest.
+ */
+function matchesProdutoValue(mixed $sent, mixed $received, string $match): bool
+{
+    return match ($match) {
+        'partial' => $received !== null && is_string($received)
+            && str_contains((string) $received, is_string($sent) ? $sent : (string) $sent),
+        'bool' => (bool) $received === (bool) $sent,
+        'int' => (int) $received === (int) $sent,
+        'array_eq' => json_encode($received) === json_encode($sent),
+        default => $received === $sent || (string) $received === (string) $sent,
+    };
+}


### PR DESCRIPTION
Session log canon pra próxima sessão. 9 PRs · ~92 campos auto-testados · 8 telas cobertas · 4 patterns + 4 lições processo.

Prompt sugerido pra continuar incluído no log.

Refs: PRs #1791/#1795/#1797/#1799/#1800/#1801/#1802/#1803 · ADR 0205