### PR TITLE
feat(tests): fixture contract DviInspection (7 campos cadastrais)

### DIFF
--- a/tests/Contract/Fixtures/dvi_inspection.php
+++ b/tests/Contract/Fixtures/dvi_inspection.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Fixture: contract test do CRUD DviInspection (drawer "VISTORIA DIGITAL · DVI"
+ * de Modules/OficinaAuto). Wave 3 OficinaAuto US-OFICINA-035.
+ *
+ * Origem ADR 0205 + roadmap fixtures Tier 1: complementa
+ * service_order_edit.php (cadastrais da OS) + service_order_items.php (peças
+ * & mão de obra) cobrindo o terceiro endpoint crítico do drawer da OS — o
+ * CRUD de itens DVI (vistoria digital com semáforo).
+ *
+ * O CRUD DviInspection é wedge competitivo CAPTERRA-FICHA Repair gap #3 —
+ * RepairShopr/mHelpDesk cobram US$ 49/mês addon DVI; oimpresso entrega inline.
+ * Mecânico registra item por item (motor/freios/pneus etc.) com severity
+ * ok/atencao/critico + valor recomendado pra cliente aprovar via WhatsApp+PIN
+ * (US-OFICINA-035 Wave 3b). Sem teste contract, bug silencioso possível se:
+ *   - Validator (UpdateDviRequest) deixar de aceitar `categoria` ou `severity`
+ *     enum novo (extensão futura) — silent drop
+ *   - Controller shapeItem omitir `recomendacao` ou `valor_recomendado` no
+ *     JSON response — frontend trata como null, perda silenciosa
+ *   - Cast decimal:2 em `valor_recomendado` revertido pra string sem ponto
+ *     decimal (cliente WhatsApp não enxerga "R$ 180,00" e aprova R$ 18,00)
+ *   - Enum `categoria` aceitar valor inválido por mismatch entre
+ *     OaInspectionItem::CATEGORIAS PHP e enum DB column (migration drift)
+ *
+ * Cobertura honesta (NÃO inventa endpoint que a tela não tem):
+ *   - PUT /oficina-auto/ordens-servico/{order}/dvi/{item} (update)
+ *     7 campos cadastrais cobertos:
+ *       categoria, descricao, severity, recomendacao,
+ *       valor_recomendado, sort_order, photo_url
+ *
+ * NÃO cobre (separation of concerns):
+ *   - POST /oficina-auto/ordens-servico/{order}/dvi (store) — Service::addItem
+ *     já coberto por DviInspectionItemTest unit + Service tests dedicados
+ *   - DELETE /oficina-auto/ordens-servico/{order}/dvi/{item} — sem bug silencioso
+ *     possível (204 + soft delete), já coberto
+ *   - POST .../dvi/{item}/photo — upload multipart, fixture próprio futuro
+ *     (ArquivosService::attach tem comportamento próprio: bucket + signed URLs)
+ *   - `metadata` campo array — sem schema fixo, validator aceita qualquer JSON.
+ *     Cobertura futura quando frontend padronizar shape (vida_util_pct,
+ *     km_restantes, voltagem) — iteração separada
+ *   - `client_decision` + `client_decided_at` — Wave 3b mobile aprovação,
+ *     endpoint separado quando US-OFICINA-035 Wave 3b sair
+ *   - Cross-OS guard (abort_unless service_order_id === order) — já coberto por
+ *     DviInspectionControllerTest dedicado (HTTP integration)
+ *   - Policy `update(ServiceOrder)` — ServiceOrderPolicyTest cobre Spatie
+ *     permission + sameTenant guard
+ *
+ * Aliases PT-BR vs canon EN descobertos:
+ *   - Nenhum no UpdateDviRequest (todos campos já canon PT-BR consistente:
+ *     categoria/descricao/severity/recomendacao/valor_recomendado/photo_url/
+ *     sort_order). Schema nasceu PT-BR — espelha vocabulário mecânico real
+ *     ("vistoria", "semáforo verde/amarelo/vermelho", "recomendação").
+ *
+ * IMPORTANTE — diferença vs fixture service_order_items.php:
+ *   1. Endpoint DVI update tem DOIS placeholders ({order}/{item}), não um só.
+ *      Runner default só substitui `{id}`. Solução adotada (Opção A do plano):
+ *      o test file substitui `{order}` no endpoint string ANTES de chamar
+ *      runner, deixando só `{id}` (= itemId) pra runner resolver.
+ *      Endpoint final no fixture mantém `{order}` literal — test file injeta
+ *      orderId em runtime via str_replace.
+ *   2. Método PUT (não POST) — endpoint update, item já existe (criado no
+ *      beforeEach via DB::table insert).
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): test file cria Vehicle +
+ * ServiceOrder + OaInspectionItem base ANTES de cada test (setup pattern
+ * espelhado de ServiceOrderItemsAutosaveContractTest). business_id derivado
+ * de session (NUNCA do payload — global scope OaInspectionItem garante).
+ *
+ * Setup do test (no test file, não aqui):
+ *   1. setupContext() — user autenticado + session business_id
+ *   2. DB::table('vehicles')->insert — Vehicle base
+ *   3. DB::table('service_orders')->insert — OS base apontando pro vehicle
+ *   4. DB::table('oa_inspection_items')->insert — item DVI base apontando pro OS
+ *   5. Endpoint resolve `{order}` → $this->orderId em runtime, `{id}` → $itemId
+ *
+ * @see Modules\OficinaAuto\Http\Controllers\DviInspectionController::update
+ * @see Modules\OficinaAuto\Http\Requests\UpdateDviRequest
+ * @see Modules\OficinaAuto\Entities\OaInspectionItem (CATEGORIAS, SEVERITIES_VALIDAS)
+ * @see Modules\OficinaAuto\Database\Migrations\2026_05_26_120002_create_oa_inspection_items_table.php
+ * @see tests/Contract/README.md — receita
+ * @see ADR 0205 — contract tests autosave canon
+ * @see memory/requisitos/Repair/CAPTERRA-FICHA.md gap #3 DVI (origem competitiva)
+ */
+
+use Modules\OficinaAuto\Entities\OaInspectionItem;
+
+return [
+    // ============================================================
+    // PUT /oficina-auto/ordens-servico/{order}/dvi/{id} (update)
+    // ============================================================
+    // Resposta wrapped em `item`:
+    //   { item: { id, categoria, descricao, severity, recomendacao,
+    //             valor_recomendado, metadata, photo_url, sort_order } }
+    // responseRoot 'item' = ler chave dentro do wrapper item.
+    //
+    // baseFields injeta os campos `required` (sometimes+required do
+    // UpdateDviRequest fica required quando enviado) em TODA iteração pra
+    // payload sempre passar validator. Quando o test varia `categoria` ou
+    // `severity`, baseFields fica sobrescrito pelo array_merge no
+    // AutosaveContractRunner::buildPayload.
+    'dvi_update' => [
+        // {order} resolvido pelo test file (str_replace antes do runner.run).
+        // {id} resolvido pelo runner default = OaInspectionItem id.
+        'endpoint' => '/oficina-auto/ordens-servico/{order}/dvi/{id}',
+        'method' => 'put',
+        'responseRoot' => 'item',        // resposta wrapped em { item: {...} }
+        'expectStatus' => 200,           // update retorna 200 OK
+        'payloadShape' => 'flat',
+        'baseFields' => [
+            // Campos `sometimes required` do UpdateDviRequest — quando o
+            // request inclui qualquer um destes, ele DEVE ser válido. Como
+            // PUT envia payload completo (com baseFields), garantir valores
+            // padrão válidos pra não disparar 422.
+            // OaInspectionItem::CATEGORIAS[0] = 'motor'
+            // OaInspectionItem::SEVERITIES_VALIDAS[0] = 'ok'
+            'categoria' => OaInspectionItem::CATEGORIAS[0],
+            'descricao' => 'CT-{stamp} baseline dvi',
+            'severity'  => OaInspectionItem::SEVERITIES_VALIDAS[0],
+        ],
+        'fields' => [
+            // categoria — enum Rule::in(CATEGORIAS). Bug silencioso se DB enum
+            // ficar desalinhado com const PHP. Teste com valor != baseline pra
+            // forçar mudança detectável (motor → freios).
+            ['send' => 'categoria', 'value' => 'freios', 'recv' => 'categoria'],
+
+            // descricao — string max 150. Bug silencioso clássico se Controller
+            // shapeItem deixar de incluir no JSON. Limite 150 testado com
+            // substring curta pra não estourar com `CT-{stamp}` prefix.
+            ['send' => 'descricao', 'value' => 'CT-{stamp} desc dvi', 'recv' => 'descricao'],
+
+            // severity — enum ok/atencao/critico. Crítico pro semáforo visual
+            // + soma "TOTAL RECOMENDADO · CLIENTE" (só atencao+critico entram).
+            // Bug silencioso: mismatch enum DB vs const PHP cascateia visual
+            // errado (item amarelo renderiza verde).
+            ['send' => 'severity', 'value' => 'atencao', 'recv' => 'severity'],
+
+            // recomendacao — nullable string max 255. Texto que o mecânico
+            // escreve pro cliente ("Trocar nas próximas 5.000km"). Crítico
+            // pra UX WhatsApp aprovação — cliente lê isso. Sem teste, validator
+            // pode dropar e cliente aprova sem ver recomendação.
+            ['send' => 'recomendacao', 'value' => 'CT-{stamp} trocar em 5000km', 'recv' => 'recomendacao'],
+
+            // valor_recomendado — numeric min 0, cast decimal:2 no model.
+            // Bug silencioso típico: backend retorna string "180.00", frontend
+            // espera number; ou cast decimal:2 vira int e perde centavos.
+            // Match `int` normaliza — sent 180, recv 180.00 → (int)180 == (int)180.
+            // NOTE: cast decimal:2 + (float) no shapeItem garante numeric, mas
+            // PHP json_encode pode preservar ".00". `int` evita brittleness.
+            ['send' => 'valor_recomendado', 'value' => 180, 'recv' => 'valor_recomendado', 'match' => 'int'],
+
+            // sort_order — nullable integer min 0. Controla ordem visual da
+            // lista DVI no drawer. Bug silencioso se Controller cast pra string
+            // (cast 'integer' no model resolve, mas regressão possível).
+            ['send' => 'sort_order', 'value' => 3, 'recv' => 'sort_order', 'match' => 'int'],
+
+            // photo_url — nullable string max 500. URL da foto do item (futuro
+            // S3 signed URL via Modules/Arquivos). Bug silencioso se Controller
+            // dropar campo ou truncar. Valor sintético plausível (não disparado
+            // pro Storage real — é só string field gravado).
+            ['send' => 'photo_url', 'value' => 'https://example.test/dvi/CT-{stamp}.jpg', 'recv' => 'photo_url'],
+        ],
+    ],
+];

--- a/tests/Feature/Contract/DviInspectionAutosaveContractTest.php
+++ b/tests/Feature/Contract/DviInspectionAutosaveContractTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\OficinaAuto\Entities\OaInspectionItem;
+use Tests\Contract\AutosaveContractRunner;
+
+/**
+ * Contract test do CRUD DviInspection — drawer "VISTORIA DIGITAL · DVI"
+ * de Modules/OficinaAuto (Wave 3 US-OFICINA-035).
+ *
+ * Origem ADR 0205 + roadmap fixtures Tier 1: nona fixture canônica
+ * (após cliente_drawer, service_order_edit, sells_create, service_order_items,
+ * produto_edit, vehicles_edit, compras_create, nfe_config) cobrindo o terceiro
+ * endpoint crítico do drawer da OS — CRUD de itens DVI (vistoria com semáforo).
+ *
+ * Cobre PUT /oficina-auto/ordens-servico/{order}/dvi/{item} via runner default
+ * (suporta `method: put`, `responseRoot: 'item'`, `expectStatus: 200`,
+ * `baseFields`). Setup espelha ServiceOrderItemsAutosaveContractTest pattern,
+ * acrescentando criação de OaInspectionItem base ANTES de cada test:
+ *   - DB driver MySQL (sqlite skip — schema UPOS+OficinaAuto)
+ *   - Tabelas vehicles + service_orders + oa_inspection_items
+ *   - Cria Vehicle + ServiceOrder + OaInspectionItem base no beforeEach
+ *   - Multi-tenant Tier 0 (ADR 0093) via session['user.business_id']
+ *
+ * DESAFIO técnico — endpoint com 2 placeholders ({order}/{item}):
+ *   Runner default só substitui `{id}` no endpoint. Para DVI update precisamos
+ *   resolver `{order}` ANTES de chamar runner.run (Opção A do plano), deixando
+ *   `{id}` (= $this->itemId) pra runner default resolver.
+ *
+ *   Solução adotada — clone do fixture com `{order}` já substituído:
+ *     $fixture = require __DIR__ . '/../../Contract/Fixtures/dvi_inspection.php';
+ *     $fixture['dvi_update']['endpoint'] = str_replace(
+ *         '{order}',
+ *         (string) $this->orderId,
+ *         $fixture['dvi_update']['endpoint']
+ *     );
+ *     AutosaveContractRunner::run($this, $fixture, $this->itemId);
+ *
+ *   Quando runner ganhar suporte multi-placeholder, este test migra pra
+ *   passar map `['order' => $orderId, 'item' => $itemId]` direto.
+ *
+ * NÃO cobre (separation of concerns):
+ *   - POST .../dvi (store) — DviInspectionItemTest cobre Service::addItem unit
+ *   - DELETE .../dvi/{item} — sem bug silencioso possível (204 + soft delete)
+ *   - POST .../dvi/{item}/photo — multipart upload, fixture próprio futuro
+ *   - `metadata` array livre — sem shape fixo, fica pra iteração futura
+ *   - `client_decision` Wave 3b — endpoint separado mobile aprovação
+ *   - Cross-OS guard + Policy update — testes dedicados já cobrem
+ *
+ * Pra adicionar nova tela: ver tests/Contract/README.md + ADR 0205.
+ *
+ * @see Modules\OficinaAuto\Http\Controllers\DviInspectionController::update
+ * @see Modules\OficinaAuto\Http\Requests\UpdateDviRequest
+ * @see tests/Contract/Fixtures/dvi_inspection.php
+ * @see ADR 0205 (contract tests autosave canon)
+ */
+
+uses(DatabaseTransactions::class);
+
+beforeEach(function () {
+    // Pré-flight 1: DB driver — schema OficinaAuto exige MySQL (ADR 0101).
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompativel: requer schema MySQL UltimatePOS + OficinaAuto (ADR 0101)');
+    }
+    // Pré-flight 2: tabelas OficinaAuto + DVI (migration 2026_05_26_120002).
+    if (! Schema::hasTable('service_orders')
+        || ! Schema::hasTable('vehicles')
+        || ! Schema::hasTable('oa_inspection_items')
+    ) {
+        $this->markTestSkipped('Schema OficinaAuto ausente — rode `php artisan module:migrate OficinaAuto`');
+    }
+
+    // Setup multi-tenant (autentica user + session business_id) — reusa runner helper.
+    $ctx = AutosaveContractRunner::setupContext($this);
+    $this->business = $ctx['business'];
+    $this->user = $ctx['user'];
+    $this->contactId = $ctx['contactId'];
+
+    // Vehicle base — padrão validado em ServiceOrderEditAutosaveContractTest.
+    $plate = 'CTD-' . substr((string) microtime(true), -4);
+    $this->vehicleId = DB::table('vehicles')->insertGetId([
+        'business_id'  => $this->business->id,
+        'plate'        => $plate,
+        'vehicle_type' => 'automovel',
+        'created_at'   => now(),
+        'updated_at'   => now(),
+    ]);
+
+    // ServiceOrder base — campos mínimos requeridos. Items DVI atualizados via
+    // PUT contra esta OS nos asserts.
+    $this->orderId = DB::table('service_orders')->insertGetId([
+        'business_id'        => $this->business->id,
+        'vehicle_id'         => $this->vehicleId,
+        'status'             => 'aberta',
+        'mileage_at_service' => 10000,
+        'notes'              => 'CT dvi baseline',
+        'created_at'         => now(),
+        'updated_at'         => now(),
+    ]);
+
+    // OaInspectionItem base — item DVI inicial pra cada test atualizar via PUT.
+    // Valores iniciais usam constantes canônicas pra evitar mismatch enum DB/PHP.
+    $this->itemId = DB::table('oa_inspection_items')->insertGetId([
+        'business_id'      => $this->business->id,
+        'service_order_id' => $this->orderId,
+        'categoria'        => OaInspectionItem::CATEGORIAS[0],          // motor
+        'descricao'        => 'CT dvi item baseline',
+        'severity'         => OaInspectionItem::SEVERITIES_VALIDAS[0],  // ok
+        'sort_order'       => 0,
+        'created_at'       => now(),
+        'updated_at'       => now(),
+    ]);
+});
+
+it('DviInspection — PUT /dvi/{item} persiste TODOS os campos cadastrais do fixture (drawer VISTORIA DIGITAL)', function () {
+    $fixture = require __DIR__ . '/../../Contract/Fixtures/dvi_inspection.php';
+
+    // Resolve {order} ANTES do runner — runner default só substitui {id}.
+    // Estratégia validada no docblock do fixture (Opção A do plano).
+    $fixture['dvi_update']['endpoint'] = str_replace(
+        '{order}',
+        (string) $this->orderId,
+        $fixture['dvi_update']['endpoint']
+    );
+
+    // Runner aceita resourceId que substitui {id} no endpoint
+    // (/oficina-auto/ordens-servico/123/dvi/{id} → .../dvi/456).
+    $result = AutosaveContractRunner::run($this, $fixture, $this->itemId);
+
+    if ($result['passed'] !== $result['total']) {
+        $msg = "❌ Contract test FALHOU — {$result['passed']}/{$result['total']} OK.\n\n";
+        $msg .= "Bugs silenciosos detectados no CRUD DviInspection (drawer VISTORIA DIGITAL · DVI):\n";
+        foreach ($result['failures'] as $f) {
+            $msg .= sprintf(
+                "  [%s] %s %s · send=%s · value_sent=%s · recv=%s · value_received=%s · status=%d · match=%s\n",
+                $f['tab'], strtoupper($f['method']), $f['endpoint'],
+                $f['send'], var_export($f['value_sent'], true),
+                $f['recv'], var_export($f['value_received'], true),
+                $f['status'], $f['match_mode']
+            );
+        }
+        $msg .= "\nADR 0205 — todo PR que regrida contract test bloqueia merge.\n";
+        $msg .= "Fix: alinhe UpdateDviRequest rules + DviInspectionController::shapeItem JSON +\n";
+        $msg .= "      OaInspectionItem casts (categoria/severity enum, valor_recomendado decimal:2).\n";
+
+        expect($result['failures'])->toBeEmpty($msg);
+    }
+
+    expect($result['passed'])->toBe($result['total']);
+});


### PR DESCRIPTION
## Summary

Adiciona **nona fixture canon** sob ADR 0205 — contract test pra
`PUT /oficina-auto/ordens-servico/{order}/dvi/{item}` (DviInspectionController::update).

Cobre 7 campos cadastrais do UpdateDviRequest (`categoria`, `descricao`,
`severity`, `recomendacao`, `valor_recomendado`, `sort_order`, `photo_url`)
via roundtrip `send (key) → value → recv (key)`.

DVI é wedge competitivo CAPTERRA-FICHA Repair gap #3 (vs RepairShopr/mHelpDesk).
Sem teste contract, bug silencioso possível em — validator dropar `recomendacao`
(cliente WhatsApp não enxerga obs), cast `decimal:2` em `valor_recomendado`
revertido pra string sem ponto (cliente aprova R$ 18 em vez de R$ 180,00), enum
`categoria` mismatch DB vs const PHP cascateia semáforo errado, Controller
`shapeItem` omitir campo no JSON.

## Mudanças

- **`tests/Contract/Fixtures/dvi_inspection.php`** — fixture canon com docblock
  documentando coverage + diferença vs `service_order_items.php` (endpoint tem
  2 placeholders, não 1) + justificativa NÃO-cobertura (metadata array, upload
  photo, client_decision Wave 3b)
- **`tests/Feature/Contract/DviInspectionAutosaveContractTest.php`** — test Pest
  espelhando pattern `ServiceOrderItemsAutosaveContractTest` (Vehicle +
  ServiceOrder + OaInspectionItem base no `beforeEach`) + pré-flight gates
  (SQLite skip, schema OficinaAuto skip)

## Desafio técnico — endpoint com 2 placeholders

Runner default (`AutosaveContractRunner::run`) só substitui `{id}` no endpoint.
DVI update tem `{order}/{item}`. **Solução adotada (Opção A do plano):**

```php
$fixture['dvi_update']['endpoint'] = str_replace(
    '{order}', (string) $this->orderId,
    $fixture['dvi_update']['endpoint']
);
AutosaveContractRunner::run($this, $fixture, $this->itemId);
```

Não mexi no runner (Wagner é dono). Quando runner ganhar suporte
multi-placeholder, este test migra pra passar `['order' => $orderId, 'item' => $itemId]`
direto.

## Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL)

`setupContext()` + global scope `OaInspectionItem` + criação Vehicle +
ServiceOrder + OaInspectionItem base no `beforeEach` com `business_id` da
session — espelha pattern `ServiceOrderEdit` + `ServiceOrderItems` já mergeados.

## NÃO cobre (separation of concerns)

- POST `/dvi` (store) — `DviInspectionItemTest` cobre `Service::addItem`
- DELETE `/dvi/{item}` — sem bug silencioso possível (204 + soft delete)
- POST `/dvi/{item}/photo` — multipart upload, fixture próprio futuro
- `metadata` array — sem shape fixo, iteração futura
- `client_decision` Wave 3b — endpoint separado mobile aprovação
- Cross-OS guard + Policy update — testes dedicados já cobrem

## Test plan

- [x] `php -l` syntax check OK em ambos arquivos
- [x] `vendor/bin/pest tests/Feature/Contract/DviInspectionAutosaveContractTest.php` SKIPPED localmente (SQLite + schema gate) — mesmo comportamento do test irmão `ServiceOrderItems...` já mergeado
- [ ] CI verde (espera-se SKIPPED em CI sem schema MySQL — patterns idênticos aos 8 fixtures já mergeados)
- [ ] Em ambiente com MySQL + OficinaAuto migrado: 7/7 campos PASS no roundtrip

Refs: ADR 0205 — Contract tests autosave padrão canônico

🤖 Generated with [Claude Code](https://claude.com/claude-code)