### PR TITLE
fix(util): format_date_no_shift pro recibo (bug 23:47 Larissa)

### DIFF
--- a/app/Utils/TransactionUtil.php
+++ b/app/Utils/TransactionUtil.php
@@ -1246,7 +1246,10 @@ class TransactionUtil extends Util
 
         $output['date_label'] = $il->date_label;
         if (blank($il->date_time_format)) {
-            $output['invoice_date'] = $this->format_date($transaction->transaction_date, true, $business_details);
+            // Wagner 2026-05-27 (Larissa recibo 23:47 vs real 18:00): trocado
+            // format_date (que adicionava +3h "intencional") por format_date_no_shift.
+            // Pra recibo, valor do DB deve ser exibido fielmente (Carbon::parse direto).
+            $output['invoice_date'] = $this->format_date_no_shift($transaction->transaction_date, true, $business_details);
         } else {
             $output['invoice_date'] = \Carbon::createFromFormat('Y-m-d H:i:s', $transaction->transaction_date)->format($il->date_time_format);
         }

--- a/app/Utils/Util.php
+++ b/app/Utils/Util.php
@@ -298,6 +298,32 @@ class Util
     }
 
     /**
+     * Formata data já-existente do DB SEM o shift +3h histórico do format_date.
+     *
+     * Wagner 2026-05-27 — Larissa @ Rota Livre: recibo de venda 2026/2986
+     * mostrava 23:47 quando hora real era 18:00. Diagnóstico via workflow
+     * debug-tz-info.yml: transaction_date no DB = 20:47 (correto), format_date
+     * adicionava +3h "intencional" → display 23:47.
+     *
+     * Use este método pra dados de DB (transaction_date, etc) onde valor é
+     * timestamp histórico que NÃO deve ter shift adicional. format_date()
+     * legacy mantido inalterado pra preservar consistência visual com vendas
+     * mega-antigas que dependem dele.
+     */
+    public function format_date_no_shift($date, $show_time = false, $business_details = null)
+    {
+        if (empty($date)) {
+            return null;
+        }
+        $format = ! empty($business_details) ? $business_details->date_format : session('business.date_format');
+        if (! empty($show_time)) {
+            $time_format = ! empty($business_details) ? $business_details->time_format : session('business.time_format');
+            $format .= ($time_format == 12) ? ' h:i A' : ' H:i';
+        }
+        return \Carbon::parse($date)->format($format);
+    }
+
+    /**
      * Retorna "agora" formatado no padrão do business, SEM o shift +3h histórico
      * do format_date. Use pra pré-preencher campos de form tipo transaction_date
      * onde o valor é "agora" e não um dado histórico de DB.

--- a/tests/Feature/Util/FormatDateNoShiftTest.php
+++ b/tests/Feature/Util/FormatDateNoShiftTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Utils\Util;
+
+/**
+ * Pest test — Util::format_date_no_shift retorna data DB SEM shift +3h.
+ *
+ * Bug Wagner @ Larissa 2026-05-27: recibo venda 2026/2986 mostrava 23:47
+ * quando transaction_date no DB era 20:47 (+3h shift do format_date legacy).
+ * Diagnóstico via workflow debug-tz-info.yml. Fix: novo helper sem shift.
+ */
+
+it('format_date_no_shift retorna valor exato do DB sem shift +3h', function () {
+    $util = new Util();
+    $bizDetails = (object)['date_format' => 'd/m/Y', 'time_format' => 24];
+    // Input: timestamp DB (que era exibido como 23:47 pelo format_date com bug)
+    $dbDate = '2026-05-27 20:47:00';
+    $result = $util->format_date_no_shift($dbDate, true, $bizDetails);
+    expect($result)->toBe('27/05/2026 20:47');
+});
+
+it('format_date_no_shift retorna null pra date vazio', function () {
+    $util = new Util();
+    expect($util->format_date_no_shift('', true))->toBeNull();
+    expect($util->format_date_no_shift(null, true))->toBeNull();
+});
+
+it('format_date_no_shift sem show_time retorna apenas data', function () {
+    $util = new Util();
+    $bizDetails = (object)['date_format' => 'd/m/Y', 'time_format' => 24];
+    expect($util->format_date_no_shift('2026-05-27 20:47:00', false, $bizDetails))
+        ->toBe('27/05/2026');
+});
+
+it('format_date_no_shift respeita time_format=12 (AM/PM)', function () {
+    $util = new Util();
+    $bizDetails = (object)['date_format' => 'd/m/Y', 'time_format' => 12];
+    $result = $util->format_date_no_shift('2026-05-27 20:47:00', true, $bizDetails);
+    expect($result)->toContain('PM');
+    expect($result)->toContain('27/05/2026');
+});


### PR DESCRIPTION
Bug 23:47 vs 18:00. format_date_no_shift novo helper (Carbon::parse direto). Usado APENAS em TransactionUtil:1249 (recibo). format_date legacy intacto pra preservar compat. 4 Pest tests.