### PR TITLE
fix(whatsapp): adiciona cron queue:work --queue=whatsapp (incident 2026-05-28)

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -614,6 +614,28 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // Worker da fila `whatsapp` (default do `ProcessIncomingWebhookJob`):
+        // recebe webhooks Meta/Z-API/Baileys/whatsmeow + dispara persistência.
+        // SEM ESTE CRON, msgs entrantes não persistem — incident 2026-05-28:
+        // queue worker `whatsapp` órfão fazia tela ficar vazia mesmo com daemon
+        // healthy e fix de código aplicado (PR #1825). Webhook chegava, job
+        // enfileirado, ninguém executava. Worker manual processou 54 jobs em 2s.
+        //
+        // Mesmo padrão Hostinger shared hosting cron-based: --max-time=55 +
+        // --stop-when-empty + everyMinute + runInBackground evita CPU ocioso
+        // e respeita limite de processos LSPHP. Tries=3 cobre retry transient
+        // (DB lock, OTel sidecar momentâneo).
+        $schedule->command('queue:work database --queue=whatsapp --max-time=55 --stop-when-empty --tries=3')
+            ->everyMinute()
+            ->withoutOverlapping(1)
+            ->environments(['live'])
+            ->runInBackground()
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('single')->error(
+                    'Schedule queue:work whatsapp FALHOU — msgs recebidas podem ficar órfãs em jobs table'
+                );
+            });
+
         // US-WA-082 — Cleanup nonces antigos (>24h) da tabela webhook_nonces.
         // Replay window é 5min, mas mantemos 24h por margem segurança vs time
         // skew + audit forense. Após 24h é seguro deletar (replay já seria


### PR DESCRIPTION
## Sintoma
Wagner 2026-05-28: "na tela não aparecem mensagens recebidas" biz=1 WR2 Sistemas (canais Suporte +5548 9648-6699 e Jana +5548 8878-2087).

## Causa raiz (era infra, não código)

Após PR #1825 fechar bugs de código (`status@broadcast` filter + `customer_external_id` NOT NULL), descobri smoke test:

- `ProcessIncomingWebhookJob::__construct` → `onQueue(config('whatsapp.queue', 'whatsapp'))`
- `app/Console/Kernel.php` tinha cron `queue:work --queue=whatsapp-history` everyMinute, **MAS** não `--queue=whatsapp`
- Webhooks chegavam → controller dispatch → job na queue `whatsapp` → **ninguém executava**
- 54 jobs acumulados órfãos desde 2026-05-27 (data ADR 0202 whatsmeow virou driver default)

## Evidência smoke 07:52 BRT

```
ANTES: jobs queue=whatsapp pending = 54
queue:work manual --queue=whatsapp --stop-when-empty
DEPOIS: pending = 0
       conv #414 criada (channel=12 Jana, customer_external_id="14628809617558@lid")
       4 msgs Wagner persistidas
       0 failed_jobs
```

Fix código PR #1825 ESTAVA OK — só não estava sendo exercitado.

## Fix
Cron paralelo `queue:work database --queue=whatsapp --max-time=55 --stop-when-empty --tries=3` everyMinute, espelhando o padrão já usado pra `whatsapp-history`. `runInBackground` + `withoutOverlapping(1)` respeita limite LSPHP Hostinger.

## Test plan
- [ ] Deploy SSH Hostinger (`git pull` + cache clear)
- [ ] Aguardar 1min (próximo cron tick)
- [ ] Wagner manda msg pelo celular → confere se aparece em ≤60s sem queue:work manual
- [ ] Monitor 24h: queue=whatsapp pending nunca > 60 (limite saudável)

## Limitações ainda abertas (fora do escopo deste PR)
Outras queues também órfãs no mesmo banco — não relacionadas ao sintoma reportado:
- `default`: ~20k jobs pendentes
- `customer-memory`: ~4k pendentes
- `employee-performance`: ~52 pendentes

Cada precisa avaliação separada (algumas podem ser intencional async/batch).

Refs: ADR 0062 (Hostinger ≠ CT 100), ADR 0204 (whatsmeow driver), ADR 0093 (multi-tenant Tier 0), [PR #1825](https://github.com/wagnerra23/oimpresso.com/pull/1825), incident 2026-05-28 07:52 BRT

🤖 Generated with [Claude Code](https://claude.com/claude-code)