### PR TITLE
fix(sells/create): auto-aplicar price_group/pay_term/shipping ao trocar cliente (R8)

### DIFF
--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -28,7 +28,9 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/Components/ui/card';
 import ProductSearchAutocomplete, {
   type ProductSearchResult,
 } from './_components/ProductSearchAutocomplete';
-import CustomerSearchAutocomplete from './_components/CustomerSearchAutocomplete';
+import CustomerSearchAutocomplete, {
+  type CustomerSearchResult,
+} from './_components/CustomerSearchAutocomplete';
 import PaymentRow, { type Payment } from './_components/PaymentRow';
 import NumericInputPtBR from './_components/NumericInputPtBR';
 import { dropdownEntries } from './_components/dropdownEntries';
@@ -414,6 +416,49 @@ export default function SellsCreate(props: SellsCreatePageProps) {
       return { ...line, unit_price: found.unit_price };
     });
     setData('products', updated);
+  };
+
+  // R8 (2026-05-28) — Bug 2 hotfix Larissa "preço diferenciado" ainda aberto.
+  // Quando troca cliente, auto-aplica:
+  //   - selling_price_group_id (recalcula unit_price do carrinho via handlePriceGroupChange)
+  //   - pay_term_number/pay_term_type (cliente VIP "30 dias" não estava puxando)
+  //   - shipping_address (endereço de entrega pré-fill)
+  //
+  // Backend ContactController@getCustomers já devolve TODOS estes campos (linhas
+  // 2150-2176). Antes deste fix, o handler descartava — só salvava contact_id.
+  // Paridade Blade `customer_id.on('change')` em public/js/pos.js.
+  //
+  // shipping_address vive em data.shipping.address (nested) — setData usa dot path.
+  const handleCustomerSelect = (c: CustomerSearchResult) => {
+    setData('contact_id', c.id);
+    if (c.pay_term_number !== null && c.pay_term_number !== undefined && c.pay_term_number !== '') {
+      setData('pay_term_number', String(c.pay_term_number));
+    }
+    if (c.pay_term_type === 'days' || c.pay_term_type === 'months') {
+      setData('pay_term_type', c.pay_term_type);
+    }
+    // Shipping address — `data.shipping.address` é nested. Usa spread pra preservar
+    // outros campos (details, cost, status, deliver_to) que user pode ter editado.
+    if (c.shipping_address && c.shipping_address !== '') {
+      setData('shipping', { ...data.shipping, address: c.shipping_address });
+    }
+    // Grupo de preço — `handlePriceGroupChange` já existe (R3) e recalcula linhas.
+    // null/undefined → não muda (preserva default já aplicado).
+    if (c.selling_price_group_id !== null && c.selling_price_group_id !== undefined) {
+      void handlePriceGroupChange(c.selling_price_group_id);
+    }
+  };
+
+  // R8 — reset ao limpar cliente. Volta pros defaults (walk-in + props default).
+  const handleCustomerClear = () => {
+    setData('contact_id', props.walkInCustomer.id);
+    setData('pay_term_number', '');
+    setData('pay_term_type', 'days');
+    // shipping fica como user editou — não auto-limpa (pode ser endereço manual)
+    // price_group volta ao default do business
+    if (props.defaultPriceGroupId !== data.price_group_id) {
+      void handlePriceGroupChange(props.defaultPriceGroupId);
+    }
   };
 
   const handleProductChange = (
@@ -913,8 +958,8 @@ export default function SellsCreate(props: SellsCreatePageProps) {
             <Label htmlFor="contact_id">Cliente</Label>
             <CustomerSearchAutocomplete
               defaultName={props.walkInCustomer.name}
-              onSelect={(c) => setData('contact_id', c.id)}
-              onClear={() => setData('contact_id', props.walkInCustomer.id)}
+              onSelect={handleCustomerSelect}
+              onClear={handleCustomerClear}
               forcedValue={forcedCustomer}
             />
             <p className="text-xs text-muted-foreground">

--- a/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
+++ b/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
@@ -23,6 +23,18 @@ export interface CustomerSearchResult {
   city?: string | null;
   /** Saldo devedor cliente (R$). >0 = devedor — exibe badge vermelho. */
   balance?: number | string | null;
+  // R8 (2026-05-28) — campos pra auto-aplicar prazo + grupo de preço ao trocar cliente.
+  // Backend ContactController@getCustomers (linhas 2150-2176) já devolve todos.
+  // Bug 2 hotfix Larissa 2026-05-13 era: "preço diferenciado" — cliente VIP com
+  // grupo de preço cobrava balcão. Fix: ao onSelect, parent reaplica.
+  /** Grupo de preço (cg.selling_price_group_id via customer_group join). */
+  selling_price_group_id?: number | null;
+  /** Prazo de pagamento (qtd unidades) — pré-fill no campo "pay_term_number". */
+  pay_term_number?: number | string | null;
+  /** Tipo prazo — 'days' | 'months'. */
+  pay_term_type?: 'days' | 'months' | string | null;
+  /** Endereço entrega — pré-fill no campo shipping. */
+  shipping_address?: string | null;
 }
 
 /**

--- a/tests/Feature/Sells/CustomerAutoApplyOnSelectTest.php
+++ b/tests/Feature/Sells/CustomerAutoApplyOnSelectTest.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest test estrutural — Sells/Create.tsx auto-aplicar campos do cliente
+ * ao trocar (R8 2026-05-28).
+ *
+ * Bug 2 do hotfix Larissa 2026-05-13 — Dor 2 do audit 2026-05-27:
+ *   "Cliente trocado mas preço/prazo NÃO recalcula (preço diferenciado)"
+ *
+ *   Antes do fix: onSelect só chamava `setData('contact_id', c.id)`.
+ *   Cliente VIP com selling_price_group_id=ATACADO continuava cobrando preço
+ *   balcão. Prazo "30 dias" do cliente B2B não pré-preenchia. Endereço de
+ *   entrega não vinha. Backend ContactController@getCustomers (linhas 2150-2176)
+ *   já devolvia TODOS os campos — frontend descartava.
+ *
+ * Solução R8 (Create.tsx + CustomerSearchAutocomplete.tsx):
+ *   1. Expandir tipo `CustomerSearchResult` com 4 campos novos
+ *   2. Novo handler `handleCustomerSelect` que aplica:
+ *      - contact_id (preserva)
+ *      - pay_term_number/pay_term_type
+ *      - shipping.address (via spread pra preservar outros campos shipping)
+ *      - selling_price_group_id (delega pro `handlePriceGroupChange` R3 existente
+ *        que recalcula unit_price das linhas via refetch /products/list)
+ *   3. `handleCustomerClear` reseta pros defaults (walk-in + price_group default)
+ *
+ * Paridade Blade `customer_id.on('change')` em public/js/pos.js.
+ */
+
+const PAGE_PATH_R8 = 'resources/js/Pages/Sells/Create.tsx';
+const COMP_PATH_R8 = 'resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx';
+
+function readPageR8(): string
+{
+    return file_get_contents(base_path(PAGE_PATH_R8));
+}
+
+function readCompR8(): string
+{
+    return file_get_contents(base_path(COMP_PATH_R8));
+}
+
+// === Tipo expandido no componente ===
+
+it('R8 — tipo CustomerSearchResult exporta selling_price_group_id', function () {
+    $src = readCompR8();
+    expect($src)->toContain('selling_price_group_id');
+    expect($src)->toMatch('/selling_price_group_id\?:\s*number\s*\|\s*null/');
+});
+
+it('R8 — tipo CustomerSearchResult exporta pay_term_number + pay_term_type', function () {
+    $src = readCompR8();
+    expect($src)->toContain('pay_term_number?');
+    expect($src)->toContain('pay_term_type?');
+});
+
+it('R8 — tipo CustomerSearchResult exporta shipping_address', function () {
+    $src = readCompR8();
+    expect($src)->toContain('shipping_address?');
+});
+
+// === Handler no Create.tsx ===
+
+it('R8 — Create.tsx importa CustomerSearchResult type', function () {
+    $src = readPageR8();
+    expect($src)->toContain('type CustomerSearchResult');
+});
+
+it('R8 — Create.tsx tem handleCustomerSelect handler', function () {
+    $src = readPageR8();
+    expect($src)->toContain('handleCustomerSelect');
+    expect($src)->toMatch('/const\s+handleCustomerSelect\s*=\s*\(c:\s*CustomerSearchResult\)/');
+});
+
+it('R8 — handleCustomerSelect chama setData contact_id', function () {
+    $src = readPageR8();
+    $start = strpos($src, 'const handleCustomerSelect');
+    expect($start)->not->toBeFalse();
+    $body = substr($src, $start, 1500);
+    expect($body)->toContain("setData('contact_id', c.id)");
+});
+
+it('R8 — handleCustomerSelect aplica pay_term_number quando presente', function () {
+    $src = readPageR8();
+    $start = strpos($src, 'const handleCustomerSelect');
+    $body = substr($src, $start, 1500);
+    expect($body)->toContain("setData('pay_term_number'");
+    expect($body)->toContain('c.pay_term_number');
+});
+
+it('R8 — handleCustomerSelect aplica pay_term_type só se válido (days|months)', function () {
+    $src = readPageR8();
+    $start = strpos($src, 'const handleCustomerSelect');
+    $body = substr($src, $start, 1500);
+    expect($body)->toMatch("/c\\.pay_term_type\\s*===\\s*'days'/");
+    expect($body)->toContain("c.pay_term_type === 'months'");
+});
+
+it('R8 — handleCustomerSelect aplica shipping.address via spread (preserva outros campos)', function () {
+    $src = readPageR8();
+    $start = strpos($src, 'const handleCustomerSelect');
+    $body = substr($src, $start, 1500);
+    expect($body)->toContain("setData('shipping', { ...data.shipping, address:");
+});
+
+it('R8 — handleCustomerSelect chama handlePriceGroupChange quando cliente tem grupo', function () {
+    $src = readPageR8();
+    $start = strpos($src, 'const handleCustomerSelect');
+    $body = substr($src, $start, 1500);
+    expect($body)->toContain('c.selling_price_group_id');
+    expect($body)->toMatch('/handlePriceGroupChange\(c\.selling_price_group_id\)/');
+});
+
+// === Handler clear ===
+
+it('R8 — Create.tsx tem handleCustomerClear handler', function () {
+    $src = readPageR8();
+    expect($src)->toContain('handleCustomerClear');
+});
+
+it('R8 — handleCustomerClear reseta pay_term pros defaults', function () {
+    $src = readPageR8();
+    $start = strpos($src, 'const handleCustomerClear');
+    expect($start)->not->toBeFalse();
+    $body = substr($src, $start, 800);
+    expect($body)->toContain("setData('pay_term_number', '')");
+    expect($body)->toContain("setData('pay_term_type', 'days')");
+});
+
+it('R8 — handleCustomerClear volta pra walkInCustomer.id', function () {
+    $src = readPageR8();
+    $start = strpos($src, 'const handleCustomerClear');
+    $body = substr($src, $start, 800);
+    expect($body)->toContain("setData('contact_id', props.walkInCustomer.id)");
+});
+
+// === Wiring no JSX ===
+
+it('R8 — CustomerSearchAutocomplete usa handleCustomerSelect (não inline)', function () {
+    $src = readPageR8();
+    expect($src)->toContain('onSelect={handleCustomerSelect}');
+    expect($src)->toContain('onClear={handleCustomerClear}');
+});
+
+it('R8 — onSelect NÃO usa mais inline (c) => setData(contact_id, c.id) padrão', function () {
+    $src = readPageR8();
+    // Negar a versão antiga inline
+    expect($src)->not->toMatch('/onSelect=\{\(c\)\s*=>\s*setData\([\'"]contact_id[\'"],\s*c\.id\)\}/');
+});


### PR DESCRIPTION
## Bug

Bug 2 do hotfix Larissa 2026-05-13 ("preço diferenciado") + Dor 2 do audit 2026-05-27 ainda em aberto:

- Cliente VIP com `selling_price_group_id=ATACADO` → cobrava preço balcão
- Cliente B2B com prazo "30 dias" → não pré-preenchia
- Endereço de entrega do cliente → não vinha

Backend [ContactController@getCustomers:2150-2176](app/Http/Controllers/ContactController.php#L2150) **JÁ DEVOLVIA** todos os campos. Frontend descartava — só salvava `contact_id`.

## Solução R8

**[CustomerSearchAutocomplete.tsx](resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx)** — expande tipo `CustomerSearchResult`:
- `selling_price_group_id?: number | null`
- `pay_term_number?: number | string | null`
- `pay_term_type?: 'days' | 'months' | string | null`
- `shipping_address?: string | null`

**[Create.tsx](resources/js/Pages/Sells/Create.tsx)** — 2 novos handlers:

- `handleCustomerSelect(c)`:
  - `setData('contact_id', c.id)` ✓
  - `setData('pay_term_number', ...)` se cliente tem
  - `setData('pay_term_type', ...)` só se valor válido (`'days'|'months'`)
  - `setData('shipping', { ...data.shipping, address: c.shipping_address })` via spread (preserva outros campos shipping que user pode ter editado)
  - **Delega `selling_price_group_id` pro `handlePriceGroupChange` existente (R3)** — que JÁ refazia recalc de `unit_price` das linhas via refetch `/products/list?price_group=Y` 

- `handleCustomerClear()`:
  - Volta `contact_id` pro walk-in
  - Reseta `pay_term_number=''` + `pay_term_type='days'`
  - Volta `price_group_id` pro default do business (e recalcula)
  - Mantém shipping que user editou (não auto-limpa)

Paridade Blade `customer_id.on('change')` em `public/js/pos.js`.

## Validação

- **15 Pest estruturais** novos ([CustomerAutoApplyOnSelectTest.php](tests/Feature/Sells/CustomerAutoApplyOnSelectTest.php)) — **25 assertions, todos verde local.**
- Smoke prod via Chrome MCP pendente pós-deploy.

## Critérios de aceite (smoke pós-deploy)

- [ ] Trocar cliente VIP com grupo ATACADO → linhas do carrinho recalculam pro preço atacado
- [ ] Cliente com `pay_term_number=30, pay_term_type=days` → campos pré-preenchem
- [ ] Cliente com `shipping_address` → vem no campo de entrega
- [ ] Limpar cliente → tudo volta pro walk-in/defaults

## Refs

- Sequência: R7 (scanner race [#1824](https://github.com/wagnerra23/oimpresso.com/pull/1824)) → R8 (este)
- `memory/sessions/2026-05-27-audit-sells-create-vs-blade-larissa.md` Dor 2
- `memory/sessions/2026-05-27-sells-v2-larissa-13-bugs-batch.md`
- ADR 0093 (multi-tenant — sem changes em scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)