### PR TITLE
fix(whatsapp): CustomerMemoryBlock crash com JID LID — tela branca click conv

### DIFF
--- a/resources/js/Pages/Whatsapp/_components/CustomerMemoryBlock.tsx
+++ b/resources/js/Pages/Whatsapp/_components/CustomerMemoryBlock.tsx
@@ -114,7 +114,17 @@ export default function CustomerMemoryBlock({ customerExternalId }: Props) {
 
   useEffect(() => {
     if (!customerExternalId) return;
-    const ext = customerExternalId.replace(/^\+/, '');
+    // Tira leading "+" + sufixo "@lid"/"@s.whatsapp.net"/"@..." (JIDs Baileys/whatsmeow).
+    // Endpoint customer-profile só aceita E.164 puro 8-20 dígitos — JIDs LID que
+    // ainda não foram resolvidos pra phone real não tem profile e devem pular o fetch
+    // (caso contrário backend retorna 422 invalid_external_id e este componente quebra).
+    const ext = customerExternalId.replace(/^\+/, '').replace(/@.*$/, '');
+    if (!/^\d{8,20}$/.test(ext)) {
+      // LID/JID não-numérico → não buscar profile (não temos cadastro pelo LID raw).
+      // Sidebar oculta o bloco até LidPhoneResolver mapear pra phone real.
+      setData(null);
+      return;
+    }
     setLoading(true);
     setError(null);
 
@@ -146,7 +156,12 @@ export default function CustomerMemoryBlock({ customerExternalId }: Props) {
     );
   }
 
-  if (!data || data.state === 'not_found') {
+  // Defense-in-depth — `state: 'ok'` deve sempre vir junto de `memory`, mas se
+  // backend retornar shape inesperado (422 invalid_external_id, network error,
+  // memory rebuild não-completado), `data.memory` pode ser undefined.
+  // Sem este guard, linha 172 `const m = data.memory!` + acesso `m.display_name`
+  // crashava o React inteiro (incident 2026-05-28 Wagner click conv LID).
+  if (!data || data.state === 'not_found' || !data.memory) {
     return null;
   }
 


### PR DESCRIPTION
## Sintoma reportado
Wagner 2026-05-28 09:00 BRT: \"erro no selecionar o cliente tela branca testou tudo?\"

Após PR #1825 (broadcast filter) + PR #1826 (queue worker cron), as mensagens passaram a aparecer na lista esquerda, **mas clicar a conversation deixa a tela INTEIRA branca** — não só a direita.

## Causa raiz (capturada via JS error handler em prod)

```
Uncaught TypeError: Cannot read properties of undefined (reading 'display_name')
  at CustomerMemoryBlock-B76hJ4zY.js:1:3268
```

Sequência (incident 2026-05-28 09:00):
1. Conv channel=12 Jana criada com `customer_external_id=\"14628809617558@lid\"` (JID LID Baileys/whatsmeow, normal antes do LidPhoneResolver mapear pra phone E.164).
2. `ContextSidebarV4` renderiza `<CustomerMemoryBlock customerExternalId=\"14628809617558@lid\">`.
3. `CustomerMemoryBlock.useEffect` faz GET `/atendimento/customer/14628809617558@lid/profile`.
4. `CustomerProfileController:56` valida `preg_match('/^\d{8,20}$/', \$extId)` — **rejeita `@lid`**. Retorna 422 `{error: 'invalid_external_id'}`.
5. Frontend: `data = {error: 'invalid_external_id'}` — sem `state`, sem `memory`.
6. Render final: `const m = data.memory!` (non-null assertion!) → `m.display_name` → **TypeError**.
7. Sem error boundary próximo → React unmount tudo → `<div id=\"app\">` vazia.

## Fix (frontend-only — backend retorna 422 corretamente)

[CustomerMemoryBlock.tsx](resources/js/Pages/Whatsapp/_components/CustomerMemoryBlock.tsx):

1. **Skip fetch quando external_id é JID** (`@lid`/`@s.whatsapp.net`/etc) — limpa sufixo `@.*$` antes da validação E.164. Sidebar oculta o bloco até LidPhoneResolver mapear pra phone real.
2. **Defense-in-depth** — adiciona `!data.memory` ao null check do render. Cobre qualquer shape inesperado futuro (422, 500, network error).

## Como testei (live em prod)

Chrome MCP + JS error handler capturou TypeError exato com stack trace. Antes do fix: tela branca total reproduzida. Após fix (em branch): rebuild necessário (`npm run build:inertia`).

## Test plan pós-merge
- [ ] SSH Hostinger → `git pull` + `npm run build:inertia` + cache clear
- [ ] Wagner clica conv \"Wagner Rocha\" em `/atendimento/caixa-unificada` → tela direita mostra messages
- [ ] CustomerMemoryBlock fica oculto (esperado — LID não tem profile) sem crashar

## Próximo passo (fora deste PR)
Adicionar **React ErrorBoundary** em `Index.tsx` em volta de `<ContextSidebarV4>` pra que crashes futuros do sidebar não derrubem a tela inteira. Anti-regressão de classe.

Refs: ADR 0204 (whatsmeow driver), ADR 0146 (LID Resolver), incident 2026-05-28 09:00, [PR #1825](https://github.com/wagnerra23/oimpresso.com/pull/1825), [PR #1826](https://github.com/wagnerra23/oimpresso.com/pull/1826)

🤖 Generated with [Claude Code](https://claude.com/claude-code)