### PR TITLE
fix(whatsapp): align Centrifugo channel + event type com frontend (latência 60s → <1s)

### DIFF
--- a/Modules/Whatsapp/Jobs/ProcessIncomingWebhookJob.php
+++ b/Modules/Whatsapp/Jobs/ProcessIncomingWebhookJob.php
@@ -249,12 +249,20 @@ class ProcessIncomingWebhookJob implements ShouldQueue
         ]);
 
         // Realtime Centrifugo — publica evento "message.received" no canal
-        // do business pra UI Inbox/ConversationThread atualizar sem refresh.
+        // omnichannel do business pra UI Caixa Unificada V4 atualizar sem refresh.
+        //
+        // 🚨 INCIDENT 2026-05-28: canal e nome do evento ESTAVAM em MISMATCH com
+        // o frontend (`Pages/Atendimento/CaixaUnificada/Index.tsx`):
+        //   - Publish ERA "whatsapp:business:{id}"      → Frontend subscribe "omnichannel:business:{id}"
+        //   - Evento ERA "whatsmeow.message.received"   → Frontend `ctx.data.type === 'message.received'`
+        // Resultado: msgs persistiam OK no DB mas WebSocket NUNCA entregava → tela
+        // só atualizava via polling 5s (que pausa em tab inativa) → latência percebida ~60s.
+        // Fix: publicar no canal omnichannel canon (ADR 0135) com chave `type` esperada.
         try {
             app(\Modules\Whatsapp\Services\Centrifugo\CentrifugoPublisher::class)->publish(
-                "whatsapp:business:{$this->businessId}",
+                "omnichannel:business:{$this->businessId}",
                 [
-                    'event' => 'whatsmeow.message.received',
+                    'type' => 'message.received',
                     'channel_id' => $channel->id,
                     'conversation_id' => $convId,
                     'phone_e164' => $phoneE164,
@@ -262,8 +270,18 @@ class ProcessIncomingWebhookJob implements ShouldQueue
                     'body_preview' => mb_substr((string) ($msg['body'] ?? ''), 0, 200),
                 ]
             );
+            Log::info('whatsapp.centrifugo.publish.success', [
+                'business_id' => $this->businessId,
+                'channel_centrifugo' => "omnichannel:business:{$this->businessId}",
+                'conversation_id' => $convId,
+                'event_type' => 'message.received',
+            ]);
         } catch (\Throwable $e) {
-            Log::warning('whatsmeow.centrifugo.publish_failed', ['error' => $e->getMessage()]);
+            Log::warning('whatsmeow.centrifugo.publish_failed', [
+                'error' => $e->getMessage(),
+                'business_id' => $this->businessId,
+                'conversation_id' => $convId,
+            ]);
         }
 
         if ($conversation !== null) {


### PR DESCRIPTION
## Sintoma
Wagner 2026-05-28: \"que demora para ser notificada na tela absurdo isso centrifugo funcionando?\"

Latência percebida ~60s entre msg whatsmeow chegar e aparecer na tela. Deveria ser <1s via WebSocket Centrifugo.

## Causa raiz (dual mismatch backend ↔ frontend)

| | Backend publica | Frontend espera |
|---|---|---|
| **Canal Centrifugo** | \`whatsapp:business:{biz_id}\` | \`omnichannel:business:{biz_id}\` |
| **Chave evento** | \`event: 'whatsmeow.message.received'\` | \`ctx.data.type === 'message.received'\` |

Resultado: msgs persistiam OK no DB, Centrifugo publish acontecia (daemon healthy curl 401 ok), MAS browser NUNCA recebia o evento WS porque (a) subscribe em canal diferente, (b) chave do payload errada, (c) valor com prefixo \`whatsmeow.\` falha o string match.

Única fonte realtime restante era polling fallback 5s (\`useEffect setInterval router.reload\`), que **pausa quando** \`document.visibilityState !== 'visible'\` (tab inativa) → latência ~60s até cron \`queue:work --queue=whatsapp\` everyMinute do PR #1826 processar.

## Fix mínimo (1 arquivo)

[ProcessIncomingWebhookJob.php:251-274](Modules/Whatsapp/Jobs/ProcessIncomingWebhookJob.php:251):
- Canal: \`whatsapp:business:{id}\` → \`omnichannel:business:{id}\` (ADR 0135 canon)
- Payload key \`event\` → \`type\` com valor \`message.received\` (sem prefixo \`whatsmeow.\`)
- Adiciona \`Log::info 'whatsapp.centrifugo.publish.success'\` (antes só logava warning em falha — invisível em sucesso)

## Como descobri

1. SSH log grep \`centrifugo\` ult 30min: **VAZIO** — nenhum warning de publish_failed nem info de publish.success (não existia)
2. \`curl https://realtime.oimpresso.com/api\` → 401 (daemon healthy, só falta auth — esperado)
3. \`grep publish( ProcessIncomingWebhookJob\` → \`whatsapp:business:\$id\` (linha 255)
4. \`grep centrifugoChannel CaixaUnificadaController\` → \`omnichannel:business:\$id\` (linha 122)
5. Smoking gun confirmada: 2 mismatches independentes na mesma camada

## Test plan pós-merge
- [ ] SSH Hostinger \`git pull\` + cache clear (NÃO precisa npm build — backend only)
- [ ] Smoke Chrome MCP: tab aberta em \`/atendimento/caixa-unificada?thread=414\` → mando msg WhatsApp → mede tempo até DOM atualizar
- [ ] Esperado: <2s (rede + WS handshake + render React) em vez de 60s

## Limitações ainda abertas
- WhatsmeowWebhookController:272 também publica em \`whatsapp:business:{id}\` pra eventos \`paired/disconnected/ban_detected/qr_updated\` — esses sim seguem canal correto pra Settings/Channels page, fora do escopo deste PR.
- Auditoria realtime em background spawn pra catalogar erros restantes + propor Pest E2E.

Refs: ADR 0058 (Centrifugo runtime), ADR 0135 (omnichannel arquitetura), ADR 0204 (whatsmeow driver), incident 2026-05-28 09:30 BRT, [PR #1825](https://github.com/wagnerra23/oimpresso.com/pull/1825), [PR #1826](https://github.com/wagnerra23/oimpresso.com/pull/1826), [PR #1829](https://github.com/wagnerra23/oimpresso.com/pull/1829)

🤖 Generated with [Claude Code](https://claude.com/claude-code)