### PR TITLE
feat(sells/create): configure-search popover + custom fields (R10)

### DIFF
--- a/resources/js/Pages/Sells/_components/ProductSearchAutocomplete.tsx
+++ b/resources/js/Pages/Sells/_components/ProductSearchAutocomplete.tsx
@@ -27,7 +27,7 @@
 // pra usuário marcar/desmarcar product_custom_field1..4 + persistir em localStorage.
 
 import { useState, useEffect, useRef, useMemo } from 'react';
-import { Search, Loader2, X, ChevronRight, Package } from 'lucide-react';
+import { Search, Loader2, X, ChevronRight, Package, SlidersHorizontal } from 'lucide-react';
 import { Input } from '@/Components/ui/input';
 import {
   Popover,
@@ -78,6 +78,46 @@ const POST_SELECT_GRACE_MS = 500;
 // `['name', 'sku', 'lot']`. Backend (ProductUtil@filterProduct) auto-adiciona
 // `sub_sku` quando `sku` está presente (ProductController@getProducts:1522).
 const DEFAULT_SEARCH_FIELDS = ['name', 'sku', 'lot'] as const;
+
+// R10 (2026-05-28) — configure-search popover (paridade Blade
+// configure_search_modal.blade.php). Larissa @ Rota Livre quer buscar por
+// product_custom_field3 (referência interna fornecedor). Persistido localStorage
+// com prefixo canon `oimpresso.` (auto-mem GOTCHAS preference).
+const ALL_SEARCH_FIELDS = [
+  { key: 'name', label: 'Nome do produto' },
+  { key: 'sku', label: 'SKU' },
+  { key: 'lot', label: 'Lote' },
+  { key: 'product_custom_field1', label: 'Campo personalizado 1' },
+  { key: 'product_custom_field2', label: 'Campo personalizado 2' },
+  { key: 'product_custom_field3', label: 'Campo personalizado 3' },
+  { key: 'product_custom_field4', label: 'Campo personalizado 4' },
+] as const;
+const SEARCH_FIELDS_STORAGE_KEY = 'oimpresso.sells.product_search_fields';
+
+function loadSearchFields(): string[] {
+  if (typeof window === 'undefined') return [...DEFAULT_SEARCH_FIELDS];
+  try {
+    const raw = window.localStorage.getItem(SEARCH_FIELDS_STORAGE_KEY);
+    if (!raw) return [...DEFAULT_SEARCH_FIELDS];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [...DEFAULT_SEARCH_FIELDS];
+    const validKeys = new Set(ALL_SEARCH_FIELDS.map((f) => f.key));
+    const filtered = parsed.filter((k): k is string => typeof k === 'string' && validKeys.has(k as never));
+    // Failsafe — array vazio cairia em fallback backend (só nome). Mantém ao menos `name`.
+    return filtered.length > 0 ? filtered : [...DEFAULT_SEARCH_FIELDS];
+  } catch {
+    return [...DEFAULT_SEARCH_FIELDS];
+  }
+}
+
+function saveSearchFields(fields: string[]) {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(SEARCH_FIELDS_STORAGE_KEY, JSON.stringify(fields));
+  } catch {
+    // localStorage quota / private mode — silencioso
+  }
+}
 
 // Agrupamento dropdown: 1 entrada por product_id. Quando >1 variação,
 // abre Popover com lista. Quando 1 só, render direto com `-{variation}`
@@ -133,6 +173,19 @@ export default function ProductSearchAutocomplete({
   // R7 anti-race — timestamp da última seleção. Bloqueia fetches em flight do
   // useEffect debounce de reabrirem o dropdown logo após handleSelectVariation.
   const lastSelectedAtRef = useRef(0);
+  // R10 configure-search — fields persistidos em localStorage.
+  const [searchFields, setSearchFields] = useState<string[]>(() => loadSearchFields());
+  const [configureOpen, setConfigureOpen] = useState(false);
+
+  const toggleSearchField = (key: string) => {
+    setSearchFields((prev) => {
+      const next = prev.includes(key) ? prev.filter((k) => k !== key) : [...prev, key];
+      // Failsafe — não permite array vazio (sem isso busca cai em fallback backend).
+      const safe = next.length > 0 ? next : ['name'];
+      saveSearchFields(safe);
+      return safe;
+    });
+  };
 
   const groups = useMemo(() => groupResults(results).slice(0, 10), [results]);
 
@@ -143,7 +196,8 @@ export default function ProductSearchAutocomplete({
     if (!locationId || term.length < MIN_QUERY_LENGTH) return [];
     const params = new URLSearchParams({ term });
     params.set('location_id', String(locationId));
-    DEFAULT_SEARCH_FIELDS.forEach((f) => params.append('search_fields[]', f));
+    // R10 — searchFields configurável via popover, persistido em localStorage
+    searchFields.forEach((f) => params.append('search_fields[]', f));
     try {
       const res = await fetch(`/products/list?${params.toString()}`, {
         headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
@@ -177,8 +231,9 @@ export default function ProductSearchAutocomplete({
         const params = new URLSearchParams({ term: query });
         if (locationId) params.set('location_id', String(locationId));
 
-        // Dor 3 R5 — search_fields[] array (paridade Blade default).
-        DEFAULT_SEARCH_FIELDS.forEach((field) => {
+        // R10 — search_fields[] configurável via popover (paridade Blade
+        // configure_search_modal.blade.php), persistido em localStorage.
+        searchFields.forEach((field) => {
           params.append('search_fields[]', field);
         });
 
@@ -220,7 +275,9 @@ export default function ProductSearchAutocomplete({
       clearTimeout(handle);
       controller.abort();
     };
-  }, [query, locationId]);
+    // R10 — `searchFields` na dep array: ao alternar campos no popover,
+    // re-dispara busca com novos filtros pra UX feedback imediato.
+  }, [query, locationId, searchFields]);
 
   // Click fora fecha dropdown
   useEffect(() => {
@@ -351,25 +408,74 @@ export default function ProductSearchAutocomplete({
           // padding hardcoded `0 8px` no .cw-input que sobrepõe utilities Tailwind
           // — ícone Search fica em cima do texto. ADR UI-0015 default cowork 2026-05-27.
           variant="shadcn"
-          className="pl-9 pr-9"
+          className="pl-9 pr-16"
           aria-label="Buscar produto"
           aria-expanded={open}
           aria-haspopup="listbox"
           autoComplete="off"
         />
         {loading && (
-          <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
+          <Loader2 className="absolute right-10 top-1/2 -translate-y-1/2 h-4 w-4 animate-spin text-muted-foreground" />
         )}
         {!loading && query.length > 0 && (
           <button
             type="button"
             onClick={handleClear}
             aria-label="Limpar busca"
-            className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground hover:text-foreground"
+            className="absolute right-10 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground hover:text-foreground"
           >
             <X className="h-4 w-4" />
           </button>
         )}
+        {/* R10 (2026-05-28) — configure-search popover. Paridade Blade
+            configure_search_modal.blade.php. Sempre visível (não depende de
+            query) — Larissa pode pré-configurar antes de digitar. */}
+        <Popover open={configureOpen} onOpenChange={setConfigureOpen}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              aria-label="Configurar campos de busca"
+              className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground hover:text-foreground focus:outline-none"
+              data-testid="configure-search-trigger"
+            >
+              <SlidersHorizontal className="h-4 w-4" />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent
+            side="bottom"
+            align="end"
+            sideOffset={8}
+            className="w-72 p-0"
+          >
+            <div className="border-b border-border px-3 py-2">
+              <p className="text-xs font-medium text-foreground">
+                Buscar produto por:
+              </p>
+              <p className="text-[10px] text-muted-foreground mt-0.5">
+                Persistido neste navegador
+              </p>
+            </div>
+            <ul className="py-1" role="group" aria-label="Campos de busca">
+              {ALL_SEARCH_FIELDS.map((field) => {
+                const checked = searchFields.includes(field.key);
+                return (
+                  <li key={field.key}>
+                    <label className="flex w-full cursor-pointer items-center gap-2 px-3 py-1.5 text-sm hover:bg-accent hover:text-accent-foreground">
+                      <input
+                        type="checkbox"
+                        checked={checked}
+                        onChange={() => toggleSearchField(field.key)}
+                        className="h-4 w-4 cursor-pointer accent-primary"
+                        data-testid={`search-field-${field.key}`}
+                      />
+                      <span className="select-none">{field.label}</span>
+                    </label>
+                  </li>
+                );
+              })}
+            </ul>
+          </PopoverContent>
+        </Popover>
       </div>
 
       {!locationId && (

--- a/tests/Feature/Sells/ProductSearchConfigurableFieldsTest.php
+++ b/tests/Feature/Sells/ProductSearchConfigurableFieldsTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest test estrutural — Sells/Create configure-search popover (R10 2026-05-28).
+ *
+ * Dor 3 do audit 2026-05-27 (parte ainda aberta — outra parte foi feita no R5):
+ *   "Sem busca por código de barras / lote / custom fields (regressão
+ *    configure-search modal Blade)"
+ *
+ *   Larissa @ Rota Livre não conseguia ativar busca por product_custom_field3
+ *   (referência interna fornecedor). V2 mandava só `name+sku+lot` hardcoded.
+ *   Paridade Blade: configure_search_modal.blade.php tinha 7 checkboxes
+ *   (name, sku, lot, custom_field1-4) persistido em localStorage do user.
+ *
+ * Solução R10 (3 camadas):
+ *   1. Constantes — ALL_SEARCH_FIELDS (7 entries) + SEARCH_FIELDS_STORAGE_KEY
+ *      com prefixo canon `oimpresso.` (preference_persistent_layouts).
+ *   2. State — useState<string[]>(() => loadSearchFields()) + toggle helper
+ *      + saveSearchFields(safeArray) com failsafe (nunca vazio).
+ *   3. UI — Popover trigger ícone SlidersHorizontal sempre visível ao lado
+ *      do botão X, com 7 checkboxes que persistem no toggle.
+ *   4. Integração — useEffect debounce + fetchProductsNow agora usam o state
+ *      `searchFields` ao invés do hardcoded DEFAULT_SEARCH_FIELDS. Dep array
+ *      do useEffect inclui searchFields pra re-busca imediata ao alternar.
+ */
+
+const COMP_PATH_R10 = 'resources/js/Pages/Sells/_components/ProductSearchAutocomplete.tsx';
+
+function readCompR10(): string
+{
+    return file_get_contents(base_path(COMP_PATH_R10));
+}
+
+it('R10 — ALL_SEARCH_FIELDS define 7 fields (name + sku + lot + 4 custom_field)', function () {
+    $src = readCompR10();
+    expect($src)->toContain('ALL_SEARCH_FIELDS');
+    foreach (['name', 'sku', 'lot', 'product_custom_field1', 'product_custom_field2', 'product_custom_field3', 'product_custom_field4'] as $key) {
+        expect($src)->toContain("'$key'");
+    }
+});
+
+it('R10 — SEARCH_FIELDS_STORAGE_KEY usa prefixo canon oimpresso.', function () {
+    $src = readCompR10();
+    expect($src)->toContain('SEARCH_FIELDS_STORAGE_KEY');
+    expect($src)->toMatch("/SEARCH_FIELDS_STORAGE_KEY\s*=\s*'oimpresso\\./");
+});
+
+it('R10 — loadSearchFields tem failsafe contra localStorage corrompido (JSON.parse)', function () {
+    $src = readCompR10();
+    expect($src)->toContain('function loadSearchFields()');
+    // Try/catch + filtros pra string + validKeys + failsafe vazio
+    expect($src)->toContain('JSON.parse');
+    expect($src)->toContain('Array.isArray(parsed)');
+    expect($src)->toContain('validKeys.has');
+});
+
+it('R10 — loadSearchFields retorna defaults se localStorage vazio/inválido', function () {
+    $src = readCompR10();
+    $start = strpos($src, 'function loadSearchFields');
+    $body = substr($src, $start, 700);
+    // Deve cair em DEFAULT_SEARCH_FIELDS em ≥2 paths (no raw, no parse fail, no validKeys fail)
+    expect(substr_count($body, 'DEFAULT_SEARCH_FIELDS'))->toBeGreaterThanOrEqual(2);
+});
+
+it('R10 — saveSearchFields envolto em try/catch (quota / private mode)', function () {
+    $src = readCompR10();
+    expect($src)->toContain('function saveSearchFields');
+    $start = strpos($src, 'function saveSearchFields');
+    $body = substr($src, $start, 400);
+    expect($body)->toMatch('/try\s*\{/');
+    expect($body)->toMatch('/catch\s*\{/');
+    expect($body)->toContain('localStorage.setItem');
+});
+
+it('R10 — toggleSearchField tem failsafe (nunca permite array vazio)', function () {
+    $src = readCompR10();
+    $start = strpos($src, 'const toggleSearchField');
+    expect($start)->not->toBeFalse();
+    $body = substr($src, $start, 600);
+    // Failsafe: next.length > 0 ? next : ['name']
+    expect($body)->toMatch("/next\\.length\\s*>\\s*0\\s*\\?\\s*next\\s*:\\s*\\['name'\\]/");
+    expect($body)->toContain('saveSearchFields(safe)');
+});
+
+it('R10 — useEffect debounce inclui searchFields no dep array (re-fetch on toggle)', function () {
+    $src = readCompR10();
+    expect($src)->toMatch('/\}, \[query, locationId, searchFields\]\)/');
+});
+
+it('R10 — fetchProductsNow usa searchFields state (não DEFAULT_SEARCH_FIELDS hardcoded)', function () {
+    $src = readCompR10();
+    $start = strpos($src, 'const fetchProductsNow');
+    expect($start)->not->toBeFalse();
+    $body = substr($src, $start, 600);
+    expect($body)->toContain('searchFields.forEach');
+});
+
+it('R10 — JSX renderiza Popover com 7 checkboxes mapeados de ALL_SEARCH_FIELDS', function () {
+    $src = readCompR10();
+    expect($src)->toContain('configure-search-trigger');
+    expect($src)->toContain('ALL_SEARCH_FIELDS.map');
+    expect($src)->toContain('search-field-');
+    expect($src)->toContain('toggleSearchField');
+});
+
+it('R10 — trigger usa ícone SlidersHorizontal acessível (aria-label)', function () {
+    $src = readCompR10();
+    expect($src)->toContain('SlidersHorizontal');
+    expect($src)->toContain('aria-label="Configurar campos de busca"');
+});
+
+it('R10 — input padding ajustado pr-16 pra acomodar trigger configure + X', function () {
+    $src = readCompR10();
+    expect($src)->toContain('pl-9 pr-16');
+});
+
+it('R10 — loading spinner e X reposicionados pra right-10 (libera right-3 pro configure)', function () {
+    $src = readCompR10();
+    // Loading spinner Loader2 right-10
+    expect($src)->toMatch('/Loader2[^}]*right-10/');
+});


### PR DESCRIPTION
## Bug

Dor 3 parte aberta do audit 2026-05-27 — Larissa @ Rota Livre quer buscar produto por `product_custom_field3` (referência interna do fornecedor). V2 mandava só `name+sku+lot` hardcoded (R5 já tinha posto search_fields[] no fetch mas sem UI pra configurar). Paridade Blade: [configure_search_modal.blade.php](resources/views/sale_pos/configure_search_modal.blade.php) tinha 7 checkboxes persistidos em localStorage.

## Implementação

**Constantes**:
- `ALL_SEARCH_FIELDS` — 7 entries (`name`, `sku`, `lot`, `product_custom_field1-4`)
- `SEARCH_FIELDS_STORAGE_KEY = 'oimpresso.sells.product_search_fields'` (prefixo canon)

**Persistência defensiva**:
- `loadSearchFields()` — try/catch + `Array.isArray(parsed)` + filtro `validKeys.has(k)` + failsafe (sempre ≥1 field)
- `saveSearchFields()` — try/catch (quota/private mode)
- `toggleSearchField()` — failsafe `next.length > 0 ? next : ['name']` (vazio cairia em fallback backend = só name)

**UI**:
- Trigger `SlidersHorizontal` 4x4 sempre visível em `right-3`. Loading spinner e X reposicionados pra `right-10`. Input padding `pl-9 pr-16`.
- Popover side=bottom align=end com 7 checkboxes mapeados de `ALL_SEARCH_FIELDS`. Persiste no `onChange` do checkbox.

**Integração search**:
- `useEffect` debounce deps: `[query, locationId, searchFields]` — re-busca imediata ao alternar pra UX feedback
- `fetchProductsNow` (scanner path) também usa state `searchFields` (não `DEFAULT_SEARCH_FIELDS` hardcoded)

## Validação

- **12 Pest estruturais** novos ([ProductSearchConfigurableFieldsTest.php](tests/Feature/Sells/ProductSearchConfigurableFieldsTest.php)) — **34 assertions, todos verde local.**

## Critérios de aceite (smoke pós-deploy)

- [ ] Clicar no ícone configurar → popover abre com 7 checkboxes (3 marcados default)
- [ ] Marcar `product_custom_field3` → busca volta resultados que matchem esse campo
- [ ] Recarregar página → seleção persiste (localStorage)
- [ ] Tentar desmarcar tudo → sistema mantém ao menos `name` (failsafe)
- [ ] Scanner com novo campo ativo → fetch sync usa o mesmo array

## Refs

- Sequência: R7 ([#1824](https://github.com/wagnerra23/oimpresso.com/pull/1824)) → R8 ([#1828](https://github.com/wagnerra23/oimpresso.com/pull/1828)) → R9 ([#1830](https://github.com/wagnerra23/oimpresso.com/pull/1830)) → R10 (este)
- `memory/sessions/2026-05-27-audit-sells-create-vs-blade-larissa.md` Dor 3
- ADR 0093 (multi-tenant — sem changes em scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)