### PR TITLE
fix(whatsapp): batch M1+M3 — inbound media extract + outbound media whatsmeow

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/InboxController.php
@@ -1316,12 +1316,15 @@ class InboxController extends Controller
             'last_message_at' => now(),
         ])->save();
 
-        if ($channel->type !== Channel::TYPE_WHATSAPP_BAILEYS) {
+        // M3 fix 2026-05-28: aceita Baileys OU Whatsmeow (incident outbound mídia
+        // hardcoded só Baileys). SendMediaJob faz dispatch por type pro daemon.
+        if ($channel->type !== Channel::TYPE_WHATSAPP_BAILEYS
+            && $channel->type !== Channel::TYPE_WHATSAPP_WHATSMEOW) {
             $message->forceFill([
                 'status' => 'failed',
-                'failed_reason' => "Envio de mídia só implementado pra Baileys nesta fase. Tipo: {$channel->type}",
+                'failed_reason' => "Envio de mídia só implementado pra Baileys/Whatsmeow nesta fase. Tipo: {$channel->type}",
             ])->save();
-            return back()->withErrors(['send_media' => 'Envio de mídia só disponível pra canais Baileys.']);
+            return back()->withErrors(['send_media' => 'Envio de mídia só disponível pra canais Baileys/Whatsmeow.']);
         }
 
         SendMediaJob::dispatch($businessId, $message->id);

--- a/Modules/Whatsapp/Jobs/ProcessIncomingWebhookJob.php
+++ b/Modules/Whatsapp/Jobs/ProcessIncomingWebhookJob.php
@@ -234,6 +234,8 @@ class ProcessIncomingWebhookJob implements ShouldQueue
 
         // Schema 2026-05-27: messages table não tem channel_id direto;
         // canal vem via conversation_id → conversation.channel_id.
+        // M1 fix 2026-05-28: persiste media_mime/size/filename quando extractor capturou
+        // (image/video/audio/document/sticker) — antes era NULL = 45.819 msgs órfãs.
         \DB::table('messages')->insert([
             'business_id' => $this->businessId,
             'conversation_id' => $convId,
@@ -244,6 +246,9 @@ class ProcessIncomingWebhookJob implements ShouldQueue
             'body' => $msg['body'] ?? null,
             'payload' => json_encode($msg['raw'] ?? null),
             'status' => 'received',
+            'media_mime' => $msg['media_mime'] ?? null,
+            'media_size_bytes' => $msg['media_size_bytes'] ?? null,
+            'media_filename' => $msg['media_filename'] ?? null,
             'created_at' => $now,
             'updated_at' => $now,
         ]);
@@ -315,39 +320,74 @@ class ProcessIncomingWebhookJob implements ShouldQueue
         $senderJid = (string) ($info['SenderAlt'] ?? $info['Chat'] ?? '');
         $phone = '+' . preg_replace('/\D/', '', explode('@', $senderJid)[0]);
 
-        // customer_external_id — JID original do contato (Chat em 1:1; pode ser
-        // "5548...@s.whatsapp.net" ou "12345@lid"). NÃO é o phone E.164 — é o
-        // identifier estável que o UNIQUE `conv_biz_ch_ext_uniq` usa.
-        // Bug 2026-05-27: este campo NÃO era preenchido no upsert → todas as
-        // conversations whatsmeow caíam em customer_external_id='' (NOT NULL default)
-        // e a 2ª msg sempre quebrava com Duplicate entry.
+        // customer_external_id — JID original do contato (Chat em 1:1).
         $externalId = (string) ($info['Chat'] ?? $info['Sender'] ?? '');
 
-        // Body — WuzAPI/whatsmeow embute em Message.conversation (text) ou Message.imageMessage.caption (image), etc.
-        $type = strtolower((string) ($info['Type'] ?? 'text'));
+        // Mídia inbound — incident 2026-05-28 M1: ANTES NUNCA preenchia
+        // media_mime/url/size/filename → 45.819 msgs presas type='' body='[media]'
+        // sem download possível. Whatsmeow protobuf: Message.{image|video|audio|document}Message
+        // (camelCase) carrega { url, mimetype, fileLength, mediaKey, fileName, caption }.
+        $mediaInfo = null;
+        $detectedType = strtolower((string) ($info['Type'] ?? 'text'));
+        if (isset($message['imageMessage']) && is_array($message['imageMessage'])) {
+            $m = $message['imageMessage'];
+            $detectedType = 'image';
+            $mediaInfo = ['mime' => (string) ($m['mimetype'] ?? 'image/jpeg'), 'size' => (int) ($m['fileLength'] ?? 0), 'filename' => null, 'caption' => (string) ($m['caption'] ?? '')];
+        } elseif (isset($message['videoMessage']) && is_array($message['videoMessage'])) {
+            $m = $message['videoMessage'];
+            $detectedType = 'video';
+            $mediaInfo = ['mime' => (string) ($m['mimetype'] ?? 'video/mp4'), 'size' => (int) ($m['fileLength'] ?? 0), 'filename' => null, 'caption' => (string) ($m['caption'] ?? '')];
+        } elseif (isset($message['audioMessage']) && is_array($message['audioMessage'])) {
+            $m = $message['audioMessage'];
+            $detectedType = 'audio';
+            $mediaInfo = ['mime' => (string) ($m['mimetype'] ?? 'audio/ogg'), 'size' => (int) ($m['fileLength'] ?? 0), 'filename' => null, 'caption' => ''];
+        } elseif (isset($message['documentMessage']) && is_array($message['documentMessage'])) {
+            $m = $message['documentMessage'];
+            $detectedType = 'document';
+            $mediaInfo = ['mime' => (string) ($m['mimetype'] ?? 'application/octet-stream'), 'size' => (int) ($m['fileLength'] ?? 0), 'filename' => (string) ($m['fileName'] ?? 'document'), 'caption' => (string) ($m['caption'] ?? '')];
+        } elseif (isset($message['stickerMessage']) && is_array($message['stickerMessage'])) {
+            $m = $message['stickerMessage'];
+            $detectedType = 'sticker';
+            $mediaInfo = ['mime' => (string) ($m['mimetype'] ?? 'image/webp'), 'size' => (int) ($m['fileLength'] ?? 0), 'filename' => null, 'caption' => ''];
+        }
+
+        // Body (texto/caption). Mantém placeholder genérico só pra mídias sem caption.
         $body = match (true) {
             isset($message['conversation']) => (string) $message['conversation'],
             isset($message['extendedTextMessage']['text']) => (string) $message['extendedTextMessage']['text'],
-            isset($message['imageMessage']['caption']) => (string) $message['imageMessage']['caption'] ?: '[imagem]',
-            isset($message['documentMessage']['caption']) => (string) $message['documentMessage']['caption'] ?: '[documento]',
-            isset($message['audioMessage']) => '[áudio]',
-            isset($message['videoMessage']['caption']) => (string) $message['videoMessage']['caption'] ?: '[vídeo]',
-            default => '[' . $type . ']',
+            $mediaInfo !== null && $mediaInfo['caption'] !== '' => $mediaInfo['caption'],
+            $detectedType === 'image' => '[imagem]',
+            $detectedType === 'video' => '[vídeo]',
+            $detectedType === 'audio' => '[áudio]',
+            $detectedType === 'document' => '[documento]',
+            $detectedType === 'sticker' => '[sticker]',
+            default => '[' . $detectedType . ']',
         };
 
         if (($info['IsFromMe'] ?? false) === true) {
             return []; // outbound enviado por nós mesmo — ignora
         }
 
-        return [[
+        $out = [[
             'provider_message_id' => $info['ID'] ?? null,
             'external_id' => $externalId,
             'from' => $phone,
             'body' => $body,
-            'type' => $type,
+            'type' => $detectedType,
             'push_name' => $info['PushName'] ?? null,
             'raw' => $payload,
         ]];
+
+        if ($mediaInfo !== null) {
+            $out[0]['media_mime'] = $mediaInfo['mime'];
+            $out[0]['media_size_bytes'] = $mediaInfo['size'];
+            $out[0]['media_filename'] = $mediaInfo['filename'];
+            // media_url fica null — download separado pelo DownloadMediaJob whatsmeow
+            // (próximo PR M2): endpoint WuzAPI /chat/downloadimage usando mediaKey + url.
+            // Por hora UI mostra thumb placeholder com mime/size em vez de "[media]" genérico.
+        }
+
+        return $out;
     }
 
     private function extractFromMeta(array $payload): array

--- a/Modules/Whatsapp/Jobs/SendMediaJob.php
+++ b/Modules/Whatsapp/Jobs/SendMediaJob.php
@@ -93,42 +93,85 @@ class SendMediaJob implements ShouldQueue
 
         $channel = $conversation->channel;
 
-        if ($channel->type !== Channel::TYPE_WHATSAPP_BAILEYS) {
+        // M3 fix 2026-05-28: aceita Baileys OU Whatsmeow. Dispatch por type:
+        //   - Baileys (legacy):  POST /instances/{ch-uuid}/media  Bearer {API_KEY}
+        //                        body {to, media_url, mimetype, filename, caption, type}
+        //   - Whatsmeow (ADR 0204): POST /chat/send/{image|video|audio|document}
+        //                        Header Token {user_token}
+        //                        body {Phone, Image|Video|Audio|Document: <url>, Caption, FileName}
+        if ($channel->type !== Channel::TYPE_WHATSAPP_BAILEYS
+            && $channel->type !== Channel::TYPE_WHATSAPP_WHATSMEOW) {
             $message->forceFill([
                 'status' => 'failed',
-                'failed_reason' => "Envio de mídia só implementado pra Baileys nesta fase. Tipo: {$channel->type}",
+                'failed_reason' => "Envio de mídia só implementado pra Baileys/Whatsmeow nesta fase. Tipo: {$channel->type}",
             ])->save();
             return;
         }
 
-        $daemonUrl = config('whatsapp.baileys.daemon_url');
-        $apiKey = config('whatsapp.baileys.api_key');
-        $instanceId = 'ch-' . str_replace('-', '', $channel->channel_uuid);
         $toPhone = preg_replace('/^\+/', '', $conversation->customer_external_id);
-
-        // Daemon faz fetch da URL absoluta — passamos URL pública (assinada ou
-        // direto se disco público). Em prod precisaria URL externa acessível
-        // pelo CT 100 (Storage::url() na Hostinger).
         $mediaPublicUrl = Storage::disk('public')->url($message->media_url);
+        $isWhatsmeow = $channel->type === Channel::TYPE_WHATSAPP_WHATSMEOW;
+
+        if ($isWhatsmeow) {
+            $daemonUrl = rtrim((string) config('whatsapp.whatsmeow.daemon_url'), '/');
+            $userToken = $channel->config_json['whatsmeow_user_token'] ?? null;
+            if (! $userToken) {
+                $message->forceFill([
+                    'status' => 'failed',
+                    'failed_reason' => 'whatsmeow_user_token ausente em channel.config_json — reconecte via QR.',
+                ])->save();
+                return;
+            }
+            $endpoint = match ($message->type) {
+                'image' => '/chat/send/image',
+                'video' => '/chat/send/video',
+                'audio' => '/chat/send/audio',
+                'document', 'pdf' => '/chat/send/document',
+                default => null,
+            };
+            if ($endpoint === null) {
+                $message->forceFill([
+                    'status' => 'failed',
+                    'failed_reason' => "Tipo de mídia não suportado pelo whatsmeow daemon: {$message->type}",
+                ])->save();
+                return;
+            }
+            // WuzAPI accepts URL no body field específico por tipo
+            $bodyField = match ($message->type) {
+                'image' => 'Image',
+                'video' => 'Video',
+                'audio' => 'Audio',
+                default => 'Document',
+            };
+            $payload = array_filter([
+                'Phone' => $toPhone,
+                $bodyField => $mediaPublicUrl,
+                'Caption' => $message->body ?? null,
+                'FileName' => $message->media_filename ?? null,
+                'Id' => strtoupper(str_replace('-', '', (string) \Illuminate\Support\Str::uuid())),
+            ], fn ($v) => $v !== null && $v !== '');
+            $authHeaders = ['Token' => $userToken, 'Content-Type' => 'application/json'];
+        } else {
+            $daemonUrl = rtrim((string) config('whatsapp.baileys.daemon_url'), '/');
+            $apiKey = (string) config('whatsapp.baileys.api_key');
+            $instanceId = 'ch-' . str_replace('-', '', $channel->channel_uuid);
+            $endpoint = "/instances/{$instanceId}/media";
+            $payload = [
+                'to' => $toPhone,
+                'media_url' => $mediaPublicUrl,
+                'mimetype' => $message->media_mime,
+                'filename' => $message->media_filename,
+                'caption' => $message->body,
+                'type' => $message->type,
+            ];
+            $authHeaders = ['Authorization' => "Bearer {$apiKey}", 'Content-Type' => 'application/json'];
+        }
 
         try {
-            $response = Http::withToken($apiKey)
-                ->withoutVerifying() // FIXME(US-WA-058): cert LE pendente
+            $response = Http::withHeaders($authHeaders)
+                ->withoutVerifying() // FIXME(US-WA-058): cert LE pendente CT 100
                 ->timeout(30)
-                ->post("{$daemonUrl}/instances/{$instanceId}/media", [
-                    'to' => $toPhone,
-                    'media_url' => $mediaPublicUrl,
-                    // P0 #2 (2026-05-12): Zod schema do daemon espera `mimetype`,
-                    // não `mime`. Antes desta correção a chave era stripada
-                    // silenciosamente → áudios/docs outbound iam sem MIME →
-                    // WhatsApp rejeitava ou entregava como `application/octet-stream`.
-                    // Schema aceita ambas chaves por 30d (até 2026-06-12), mas
-                    // canônico aqui é `mimetype`.
-                    'mimetype' => $message->media_mime,
-                    'filename' => $message->media_filename,
-                    'caption' => $message->body, // body é caption no envio
-                    'type' => $message->type,    // image|audio|document|video
-                ]);
+                ->post("{$daemonUrl}{$endpoint}", $payload);
         } catch (\Throwable $e) {
             $message->forceFill([
                 'status' => 'failed',
@@ -136,6 +179,7 @@ class SendMediaJob implements ShouldQueue
             ])->save();
             Log::error('[send_media] daemon exception', [
                 'message_id' => $message->id,
+                'channel_type' => $channel->type,
                 'error' => $e->getMessage(),
             ]);
             throw $e; // permite retry
@@ -148,15 +192,24 @@ class SendMediaJob implements ShouldQueue
             ])->save();
             Log::warning('[send_media] daemon non-2xx', [
                 'message_id' => $message->id,
+                'channel_type' => $channel->type,
                 'status' => $response->status(),
             ]);
             return;
         }
 
-        $payload = $response->json();
+        $respJson = $response->json();
+        // Normaliza por tipo. Baileys {message_id, status} vs WuzAPI {Id, Details}.
+        $providerMsgId = $isWhatsmeow
+            ? ($respJson['Id'] ?? $respJson['Data']['Id'] ?? null)
+            : ($respJson['message_id'] ?? null);
+        $newStatus = $isWhatsmeow
+            ? (($respJson['Details'] ?? '') === 'Sent' ? 'sent' : ($respJson['Details'] ?? 'sent'))
+            : ($respJson['status'] ?? 'sent');
+
         $message->forceFill([
-            'status' => $payload['status'] ?? 'sent',
-            'provider_message_id' => $payload['message_id'] ?? null,
+            'status' => $newStatus,
+            'provider_message_id' => $providerMsgId,
         ])->save();
 
         Log::info('[send_media] dispatched', [

--- a/Modules/Whatsapp/Tests/Feature/WhatsmeowMediaInboundTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsmeowMediaInboundTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Modules\Jana\Scopes\ScopeByBusiness;
+use Modules\Whatsapp\Entities\Channel;
+use Modules\Whatsapp\Jobs\ProcessIncomingWebhookJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-WA-MEDIA-INBOUND — anti-regressão M1 fix 2026-05-28 batch midia.
+ *
+ * Sintoma reportado Wagner: 45.819 mensagens com mídia em
+ * `media_download_status='pending'` desde 2026-05-15 (cutover Baileys→whatsmeow).
+ * ZERO mídias baixadas. extractFromWhatsmeow não capturava image/video/audio/
+ * document → message.media_mime sempre NULL → Observer gate L87
+ * `if media_mime === null return` → DownloadMediaJob nunca dispatchava.
+ *
+ * Fix M1: extractFromWhatsmeow detecta {image|video|audio|document|sticker}Message
+ * no protobuf body e preenche media_mime/media_size_bytes/media_filename.
+ * media_url fica NULL — download separado (próximo PR M2 endpoint WuzAPI).
+ *
+ * Tests cobrem: image, video, audio, document, sticker; e text não tem media.
+ */
+beforeEach(function () {
+    foreach (['messages', 'conversations', 'channels', 'activity_log'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('channels', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->uuid('channel_uuid')->unique();
+        $table->string('label', 80);
+        $table->string('type', 30);
+        $table->string('status', 20)->default('setup');
+        $table->string('display_identifier', 100)->nullable();
+        $table->text('config_json')->nullable();
+        $table->boolean('handles_repair_status')->default(false);
+        $table->boolean('handles_billing')->default(false);
+        $table->boolean('handles_jana_bot')->default(true);
+        $table->boolean('handles_outbound_default')->default(false);
+        $table->boolean('bot_enabled')->default(false);
+        $table->string('channel_health', 20)->default('never_checked');
+        $table->unsignedInteger('channel_health_consecutive_failures')->default(0);
+        $table->timestamps();
+    });
+
+    Schema::create('conversations', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('channel_id');
+        $table->string('customer_external_id', 150);
+        $table->string('phone_e164', 30)->nullable();
+        $table->string('contact_name', 120)->nullable();
+        $table->string('status', 20)->default('open');
+        $table->unsignedInteger('unread_count')->default(0);
+        $table->timestamp('last_inbound_at')->nullable();
+        $table->timestamp('last_message_at')->nullable();
+        $table->string('last_message_preview', 200)->nullable();
+        $table->string('last_message_direction', 20)->nullable();
+        $table->timestamps();
+        $table->unique(['business_id', 'channel_id', 'customer_external_id'], 'conv_biz_ch_ext_uniq');
+    });
+
+    Schema::create('messages', function ($table) {
+        $table->bigIncrements('id');
+        $table->unsignedInteger('business_id');
+        $table->unsignedBigInteger('conversation_id');
+        $table->string('direction', 10);
+        $table->string('provider', 30);
+        $table->string('provider_message_id', 128)->nullable();
+        $table->string('type', 20)->default('text');
+        $table->text('body')->nullable();
+        $table->json('payload')->nullable();
+        $table->string('status', 20);
+        $table->string('media_mime', 100)->nullable();
+        $table->unsignedBigInteger('media_size_bytes')->nullable();
+        $table->string('media_filename', 255)->nullable();
+        $table->timestamps();
+        $table->unique('provider_message_id', 'msgs_provider_msg_uniq');
+    });
+
+    Schema::create('activity_log', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('log_name')->nullable();
+        $table->text('description')->nullable();
+        $table->unsignedBigInteger('subject_id')->nullable();
+        $table->string('subject_type')->nullable();
+        $table->json('properties')->nullable();
+        $table->string('event')->nullable();
+        $table->uuid('batch_uuid')->nullable();
+        $table->timestamps();
+    });
+});
+
+function createWhatsmeowChannelM1(string $uuid, string $instance): Channel
+{
+    \DB::table('channels')->insert([
+        'business_id' => 1,
+        'channel_uuid' => $uuid,
+        'label' => 'Test',
+        'type' => Channel::TYPE_WHATSAPP_WHATSMEOW,
+        'status' => 'active',
+        'config_json' => json_encode(['whatsmeow' => ['user_name' => $instance]]),
+        'created_at' => now(),
+        'updated_at' => now(),
+    ]);
+    return Channel::query()->withoutGlobalScope(ScopeByBusiness::class)->where('channel_uuid', $uuid)->firstOrFail();
+}
+
+function makeWhatsmeowMediaPayload(string $instance, string $msgKey, array $messageProto): array
+{
+    return [
+        'instanceName' => $instance,
+        'event' => [
+            'Info' => [
+                'Chat' => '554899872822@s.whatsapp.net',
+                'Sender' => '554899872822@s.whatsapp.net',
+                'SenderAlt' => '554899872822@s.whatsapp.net',
+                'IsFromMe' => false,
+                'ID' => $msgKey,
+                'Type' => 'media',
+                'PushName' => 'Cliente',
+            ],
+            'Message' => $messageProto,
+        ],
+    ];
+}
+
+it('R-WA-MEDIA-INBOUND-001 — imageMessage extrai mime/size/filename', function () {
+    $ch = createWhatsmeowChannelM1('11111111-1111-1111-1111-000000000001', 'ch-img');
+    (new ProcessIncomingWebhookJob(1, 'whatsmeow', makeWhatsmeowMediaPayload('ch-img', 'WAMID.IMG.1', [
+        'imageMessage' => ['mimetype' => 'image/jpeg', 'fileLength' => 102400, 'caption' => 'foto teste'],
+    ])))->handle();
+    $m = \DB::table('messages')->where('provider_message_id', 'WAMID.IMG.1')->first();
+    expect($m)->not->toBeNull();
+    expect($m->type)->toBe('image');
+    expect($m->media_mime)->toBe('image/jpeg');
+    expect((int) $m->media_size_bytes)->toBe(102400);
+    expect($m->body)->toBe('foto teste');
+});
+
+it('R-WA-MEDIA-INBOUND-002 — videoMessage extrai mime + caption', function () {
+    $ch = createWhatsmeowChannelM1('22222222-2222-2222-2222-000000000002', 'ch-vid');
+    (new ProcessIncomingWebhookJob(1, 'whatsmeow', makeWhatsmeowMediaPayload('ch-vid', 'WAMID.VID.1', [
+        'videoMessage' => ['mimetype' => 'video/mp4', 'fileLength' => 5242880],
+    ])))->handle();
+    $m = \DB::table('messages')->where('provider_message_id', 'WAMID.VID.1')->first();
+    expect($m->type)->toBe('video');
+    expect($m->media_mime)->toBe('video/mp4');
+    expect($m->body)->toBe('[vídeo]');
+});
+
+it('R-WA-MEDIA-INBOUND-003 — audioMessage opus ogg', function () {
+    $ch = createWhatsmeowChannelM1('33333333-3333-3333-3333-000000000003', 'ch-aud');
+    (new ProcessIncomingWebhookJob(1, 'whatsmeow', makeWhatsmeowMediaPayload('ch-aud', 'WAMID.AUD.1', [
+        'audioMessage' => ['mimetype' => 'audio/ogg; codecs=opus', 'fileLength' => 8192],
+    ])))->handle();
+    $m = \DB::table('messages')->where('provider_message_id', 'WAMID.AUD.1')->first();
+    expect($m->type)->toBe('audio');
+    expect($m->media_mime)->toContain('ogg');
+    expect($m->body)->toBe('[áudio]');
+});
+
+it('R-WA-MEDIA-INBOUND-004 — documentMessage preserva fileName', function () {
+    $ch = createWhatsmeowChannelM1('44444444-4444-4444-4444-000000000004', 'ch-doc');
+    (new ProcessIncomingWebhookJob(1, 'whatsmeow', makeWhatsmeowMediaPayload('ch-doc', 'WAMID.DOC.1', [
+        'documentMessage' => ['mimetype' => 'application/pdf', 'fileLength' => 200000, 'fileName' => 'contrato.pdf'],
+    ])))->handle();
+    $m = \DB::table('messages')->where('provider_message_id', 'WAMID.DOC.1')->first();
+    expect($m->type)->toBe('document');
+    expect($m->media_mime)->toBe('application/pdf');
+    expect($m->media_filename)->toBe('contrato.pdf');
+});
+
+it('R-WA-MEDIA-INBOUND-005 — text mantém media_mime NULL (anti-regressão M1)', function () {
+    $ch = createWhatsmeowChannelM1('55555555-5555-5555-5555-000000000005', 'ch-txt');
+    (new ProcessIncomingWebhookJob(1, 'whatsmeow', [
+        'instanceName' => 'ch-txt',
+        'event' => [
+            'Info' => ['Chat' => '554899872822@s.whatsapp.net', 'Sender' => '554899872822@s.whatsapp.net', 'IsFromMe' => false, 'ID' => 'WAMID.TXT.1', 'Type' => 'text', 'PushName' => 'Cliente'],
+            'Message' => ['conversation' => 'oi tudo bem'],
+        ],
+    ]))->handle();
+    $m = \DB::table('messages')->where('provider_message_id', 'WAMID.TXT.1')->first();
+    expect($m->type)->toBe('text');
+    expect($m->media_mime)->toBeNull();
+    expect($m->body)->toBe('oi tudo bem');
+});


### PR DESCRIPTION
## Sintoma
Wagner 2026-05-28: "imagens videos midias mensagens enviadas pelo web ja fez a pesquiza?". Auditoria DB prod biz=1: 45.819 msgs com mídia em pending desde cutover whatsmeow, todas type='' body='[media]'. Outbound mídia também rejeitado por hardcode Baileys (mesmo bug texto fechado PR #1833).

## Bugs P0 fechados (2)

**M1 — Inbound mídia whatsmeow nunca preenche metadata**

`ProcessIncomingWebhookJob::extractFromWhatsmeow` L307-345 só extraía caption, NUNCA media_mime/size/filename. `MessageObserver::maybeDispatchMediaDownload` L87 gate `if media_mime === null return` → ZERO downloads desde 2026-05-15.

Fix: detecta `{image|video|audio|document|sticker}Message` no protobuf, extrai mimetype/fileLength/fileName, mapeia type. INSERT em `messages` agora persiste media_*.

**M3 — Outbound mídia whatsmeow rejeitado**

`InboxController::sendMedia` L1319 + `SendMediaJob` L96 hardcoded `if !== BAILEYS → fail`. Daemon WuzAPI tem endpoints específicos.

Fix: aceita BAILEYS OU WHATSMEOW. Branch por type — endpoint /chat/send/{image|video|audio|document}, header Token, body {Phone, Image|Video|Audio|Document: <url>, Caption, FileName}. Normaliza response shape pra unificar persist.

## 5 Pest tests anti-regressão (5/5 verde, 17 assertions)

- imageMessage extrai mime/size/caption
- videoMessage extrai mime + fallback body
- audioMessage opus/ogg
- documentMessage preserva fileName
- text NÃO grava media_mime

## NÃO coberto (próximos PRs)

- **M2** DownloadMediaJob whatsmeow port (bytes só vão aparecer quando endpoint baixar)
- **M4** ComposerV4 paste/drop
- **M5** cap 25MB FE vs 16MB BE unificado

Detalhes em `memory/requisitos/Whatsapp/AUDITORIA-MIDIA-OUTBOUND-2026-05-28.md` (gerada pelo agent audit-research-expert nesta sessão).

## Test plan pós-merge
- [ ] SSH `git pull` + cache clear (sem npm rebuild — backend only)
- [ ] Manda imagem pelo WhatsApp → DB `type=image`, `media_mime='image/jpeg'`
- [ ] Anexa imagem no composer + envia → DB row outbound `status=sent`
- [ ] Verifica chega no celular destinatário

Refs: ADR 0202, ADR 0204, ADR 0093, incident 2026-05-28, PRs #1825 #1826 #1829 #1831 #1833

🤖 Generated with [Claude Code](https://claude.com/claude-code)