### PR TITLE
fix(whatsapp): WuzAPI download data URL strip — smoke 3 revelou

### DIFF
--- a/Modules/Whatsapp/Jobs/DownloadMediaJob.php
+++ b/Modules/Whatsapp/Jobs/DownloadMediaJob.php
@@ -443,16 +443,28 @@ class DownloadMediaJob implements ShouldQueue
 
         if (str_contains($contentType, 'application/json')) {
             $json = $response->json();
-            $base64 = $json['data']['Data'] ?? $json['Data'] ?? null;
-            if (! $base64) {
+            $dataField = $json['data']['Data'] ?? $json['Data'] ?? null;
+            if (! $dataField) {
                 throw new HttpFetchException(
                     'WuzAPI download response sem Data field: ' . mb_substr($rawBody, 0, 200),
                     retryable: false,
                 );
             }
-            $decoded = base64_decode($base64, true);
+            // WuzAPI Data field é DATA URL: "data:image/jpeg;base64,<base64>"
+            // (validado via spec.yml + smoke 2026-05-28 msg #46403).
+            // base64_decode direto sem strip → fails. Strip prefixo primeiro.
+            if (str_starts_with($dataField, 'data:')) {
+                $commaPos = strpos($dataField, ',');
+                if ($commaPos !== false) {
+                    $dataField = substr($dataField, $commaPos + 1);
+                }
+            }
+            $decoded = base64_decode($dataField, true);
             if ($decoded === false) {
-                throw new HttpFetchException('Base64 inválido no response WuzAPI', retryable: false);
+                throw new HttpFetchException(
+                    'Base64 inválido no response WuzAPI (após strip data: prefix)',
+                    retryable: false,
+                );
             }
             return $decoded;
         }


### PR DESCRIPTION
Smoke real msg #46403: HTTP 200 mas 'Base64 inválido'. Spec.yml WuzAPI mostra Data field é DATA URL completa. Strip prefix antes decode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)