### PR TITLE
fix(whatsapp): expose media_url no msgToUiArray + render thumb/player (M6)

### DIFF
--- a/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
+++ b/Modules/Whatsapp/Http/Controllers/Admin/CaixaUnificadaController.php
@@ -595,6 +595,16 @@ class CaixaUnificadaController extends Controller
             'sender_user_name' => $senderName,
             'is_internal_note' => (bool) $m->is_internal_note,
             'created_at' => $m->created_at?->toIso8601String() ?? now()->toIso8601String(),
+            // M6 fix 2026-05-28: expor media fields pro frontend renderizar
+            // thumb/player. Antes UI mostrava body literal "[imagem]"/"[áudio]"
+            // mesmo com media_url preenchido no DB (audit smoke pós M2 download).
+            'media_url' => $m->media_url ? \Storage::disk('public')->url($m->media_url) : null,
+            'media_thumbnail_url' => $m->media_thumbnail_url ? \Storage::disk('public')->url($m->media_thumbnail_url) : null,
+            'media_mime' => $m->media_mime,
+            'media_size_bytes' => $m->media_size_bytes ? (int) $m->media_size_bytes : null,
+            'media_filename' => $m->media_filename,
+            'media_transcription' => $m->media_transcription,
+            'media_download_status' => $m->media_download_status,
         ];
     }
 

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/ConversationThreadV4.tsx
@@ -292,7 +292,51 @@ export default function ConversationThreadV4({
                         {m.sender_user_name}
                       </small>
                     )}
-                    <span>{m.body ?? <em className="text-muted-foreground">[mídia]</em>}</span>
+                    {/* M6 fix 2026-05-28 — renderiza thumb/player quando media_url presente.
+                        Antes UI mostrava body literal "[imagem]"/"[áudio]" pq backend
+                        msgToUiArray não enviava media_url + frontend não checava. */}
+                    {m.media_url && m.type === 'image' && (
+                      <img
+                        src={m.media_thumbnail_url || m.media_url}
+                        alt={m.media_filename || 'imagem'}
+                        onClick={() => window.open(m.media_url!, '_blank')}
+                        className="rounded-md max-w-full max-h-64 cursor-pointer object-cover mb-1"
+                        loading="lazy"
+                      />
+                    )}
+                    {m.media_url && m.type === 'video' && (
+                      <video
+                        src={m.media_url}
+                        controls
+                        preload="metadata"
+                        className="rounded-md max-w-full max-h-64 mb-1"
+                      />
+                    )}
+                    {m.media_url && m.type === 'audio' && (
+                      <audio src={m.media_url} controls preload="metadata" className="max-w-full mb-1" />
+                    )}
+                    {m.media_url && (m.type === 'document' || m.type === 'pdf') && (
+                      <a
+                        href={m.media_url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex items-center gap-2 px-2 py-1 rounded border bg-card hover:bg-muted/50 text-xs mb-1"
+                      >
+                        📄 {m.media_filename || 'documento'}
+                        {m.media_size_bytes && (
+                          <span className="text-muted-foreground text-[10px]">
+                            ({(m.media_size_bytes / 1024).toFixed(0)} KB)
+                          </span>
+                        )}
+                      </a>
+                    )}
+                    {/* Body texto (caption ou só texto) */}
+                    {(m.body && m.body !== '[imagem]' && m.body !== '[vídeo]' && m.body !== '[áudio]' && m.body !== '[documento]') && (
+                      <span>{m.body}</span>
+                    )}
+                    {!m.media_url && !m.body && (
+                      <em className="text-muted-foreground">[mídia]</em>
+                    )}
                     <small className="text-[9.5px] opacity-60 mt-1 font-mono inline-flex items-center gap-1 self-end">
                       {new Date(m.created_at).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' })}
                       {m.direction === 'outbound' && (

--- a/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
+++ b/resources/js/Pages/Atendimento/CaixaUnificada/_components/helpers.ts
@@ -134,6 +134,15 @@ export interface CaixaUnifMessage {
   sender_user_name: string | null;
   is_internal_note: boolean;
   created_at: string;
+  // M6 fix 2026-05-28: media fields expostos pro componente renderizar
+  // thumb/player. msgToUiArray no backend agora retorna.
+  media_url?: string | null;
+  media_thumbnail_url?: string | null;
+  media_mime?: string | null;
+  media_size_bytes?: number | null;
+  media_filename?: string | null;
+  media_transcription?: string | null;
+  media_download_status?: 'pending' | 'downloading' | 'success' | 'failed_permanent' | null;
 }
 
 export interface Paginated<T> {


### PR DESCRIPTION
Smoke pós-download: 11 mídias success no DB mas tela mostra '[imagem]' text. msgToUiArray não retornava media_url + ConversationThreadV4 sem branch type. Fix backend + FE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)