### PR TITLE
fix(whatsapp): rota midia em Routes/ uppercase (Linux case-sensitive)

### DIFF
--- a/Modules/Whatsapp/Routes/web.php
+++ b/Modules/Whatsapp/Routes/web.php
@@ -140,6 +140,14 @@ Route::group([
         ->middleware('can:whatsapp.access')
         ->name('atendimento.caixa-unificada.index');
 
+    // M7 fix 2026-05-28 — serve mídia via Controller (Hostinger LiteSpeed
+    // bloqueia /storage/* direct serve 403). Path tem 4 partes:
+    // whatsapp/<businessId>/<YYYY-MM>/<uuid>.<ext>
+    Route::get('/midia/{path}', [CaixaUnificadaController::class, 'serveMedia'])
+        ->where('path', 'whatsapp/[0-9]+/[0-9]{4}-[0-9]{2}/[a-f0-9-]+(_thumb)?\.[a-z0-9]+')
+        ->middleware('can:whatsapp.access')
+        ->name('atendimento.midia.show');
+
     Route::post('/inbox/{id}/send', [InboxController::class, 'send'])
         ->whereNumber('id')
         ->middleware('can:whatsapp.send')


### PR DESCRIPTION
Hotfix PR #1847: edit local foi em routes/ lowercase, Laravel Linux lê Routes/ uppercase. Rota declarada no path canon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)