### PR TITLE
feat(infra): LogContextMiddleware global — Onda 1.3 (US-INFRA-016, ADR 0212 Camada 1)

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -36,6 +36,11 @@ class Kernel extends HttpKernel
             \App\Http\Middleware\EncryptCookies::class,
             \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
             \Illuminate\Session\Middleware\StartSession::class,
+            // ADR 0212 Camada 1 (2026-05-28) — injeta business_id/user_id/request_id/
+            // route_name em Log::withContext pra toda request. Camada base do
+            // "fail loud not silent" — fallbacks WARN/ERROR têm rastreabilidade
+            // automática. Posicionado APÓS StartSession (precisa session ativa).
+            \App\Http\Middleware\LogContextMiddleware::class,
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             \App\Http\Middleware\VerifyCsrfToken::class,
             \Illuminate\Routing\Middleware\SubstituteBindings::class,

--- a/app/Http/Middleware/LogContextMiddleware.php
+++ b/app/Http/Middleware/LogContextMiddleware.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Injeta contexto canônico em todos os `Log::*()` da request inteira via
+ * `Log::withContext([...])` (Laravel 12 docs canon).
+ *
+ * **Camada 1 da defensive logging** ([ADR 0212](../../../memory/decisions/0212-defensive-logging-fallback-paths.md)).
+ *
+ * Por que existir:
+ *
+ * Antes deste middleware, logs de fallback silencioso (ex: `Carbon::now()`
+ * default em `SellPosController:435` — bug R9 Larissa 2026-05-28) saíam sem
+ * `business_id` nem `user_id` nem rastreabilidade. Bug invisível: 2h47 entre
+ * Larissa abrir Sells/Create e submeter, DB gravou transaction_date errado,
+ * nenhum log apontou origem.
+ *
+ * Agora: TODO `Log::warning(...)` subsequente na request tem automaticamente:
+ *   - `business_id` (de `session('user.business_id')` — UPOS canon)
+ *   - `user_id` (de `session('user.id')`)
+ *   - `request_id` (UUID v4 gerado por request)
+ *   - `route_name` (request route name OR url)
+ *
+ * Não-objetivos:
+ *
+ * - NÃO injeta PII (email, telefone, cpf) — só identificadores.
+ * - NÃO substitui `Log::error` em exceptions reais — escopo é WARNING level
+ *   pra fallback paths + INFO/DEBUG developer-visible.
+ * - NÃO depende de Auth::user() (UPOS canon é `session()` direto pra evitar
+ *   redundância de query).
+ *
+ * Posição no pipeline:
+ *
+ * Registrado em `App\Http\Kernel::$middlewareGroups['web']` logo APÓS
+ * `StartSession` (precisa session) e ANTES de qualquer outro middleware UPOS
+ * (precisa estar ativo nos demais). Ver Kernel:36-50.
+ *
+ * Performance: `Log::withContext` é hashmap merge — microsegundos.
+ */
+class LogContextMiddleware
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $context = [
+            'request_id' => (string) Str::uuid(),
+        ];
+
+        // business_id + user_id da session UPOS canon (pode ser null em
+        // requests não-autenticados como /login, webhook receivers, etc).
+        $session = $request->session();
+        if ($session->has('user.business_id')) {
+            $context['business_id'] = (int) $session->get('user.business_id');
+        }
+        if ($session->has('user.id')) {
+            $context['user_id'] = (int) $session->get('user.id');
+        }
+
+        // route_name: prefere nome da rota (canon Laravel); fallback URL path
+        // se rota não-nomeada (legacy UPOS tem várias).
+        $route = $request->route();
+        if ($route !== null) {
+            $context['route_name'] = $route->getName() ?? $request->path();
+        } else {
+            $context['route_name'] = $request->path();
+        }
+
+        Log::withContext($context);
+
+        return $next($request);
+    }
+}

--- a/tests/Feature/Middleware/LogContextMiddlewareTest.php
+++ b/tests/Feature/Middleware/LogContextMiddlewareTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest test estrutural — LogContextMiddleware (ADR 0212 Camada 1, US-INFRA-016).
+ *
+ * Cobertura:
+ *  1. Middleware existe + namespace correto
+ *  2. Registrado no Kernel `'web'` group APÓS StartSession (precisa session)
+ *  3. handle() injeta os 4 campos canônicos (business_id, user_id, request_id, route_name)
+ *  4. business_id/user_id são null-safe (request não-autenticado não crasha)
+ *  5. request_id é UUID v4 (string com 36 chars + 4 hyphens)
+ */
+
+const MIDDLEWARE_PATH = 'app/Http/Middleware/LogContextMiddleware.php';
+const KERNEL_PATH = 'app/Http/Kernel.php';
+
+function readMiddleware(): string
+{
+    return file_get_contents(base_path(MIDDLEWARE_PATH));
+}
+
+function readKernel(): string
+{
+    return file_get_contents(base_path(KERNEL_PATH));
+}
+
+it('US-INFRA-016 — LogContextMiddleware.php existe', function () {
+    expect(file_exists(base_path(MIDDLEWARE_PATH)))->toBeTrue();
+});
+
+it('US-INFRA-016 — middleware tem namespace App\\Http\\Middleware', function () {
+    $src = readMiddleware();
+    expect($src)->toContain('namespace App\\Http\\Middleware;');
+});
+
+it('US-INFRA-016 — registrado no Kernel `web` group', function () {
+    $src = readKernel();
+    expect($src)->toContain('\\App\\Http\\Middleware\\LogContextMiddleware::class');
+});
+
+it('US-INFRA-016 — registrado APÓS StartSession (precisa session ativa)', function () {
+    $src = readKernel();
+    $posStart = strpos($src, 'StartSession::class');
+    $posLog = strpos($src, 'LogContextMiddleware::class');
+    expect($posStart)->not->toBeFalse();
+    expect($posLog)->not->toBeFalse();
+    expect($posLog)->toBeGreaterThan($posStart);
+});
+
+it('US-INFRA-016 — handle() injeta request_id via Str::uuid()', function () {
+    $src = readMiddleware();
+    expect($src)->toContain("'request_id' => (string) Str::uuid()");
+});
+
+it('US-INFRA-016 — handle() injeta business_id de session UPOS canon', function () {
+    $src = readMiddleware();
+    expect($src)->toContain("'user.business_id'");
+    expect($src)->toMatch("/business_id.*session->get.*'user\\.business_id'/s");
+});
+
+it('US-INFRA-016 — handle() injeta user_id de session UPOS canon', function () {
+    $src = readMiddleware();
+    expect($src)->toContain("'user.id'");
+    expect($src)->toMatch("/user_id.*session->get.*'user\\.id'/s");
+});
+
+it('US-INFRA-016 — handle() null-safe quando session NÃO tem business_id/user_id', function () {
+    $src = readMiddleware();
+    // Padrão: `if ($session->has(...))` antes de assign
+    expect($src)->toMatch("/if\\s*\\(\\s*\\\$session->has\\(\\s*'user\\.business_id'\\s*\\)/");
+    expect($src)->toMatch("/if\\s*\\(\\s*\\\$session->has\\(\\s*'user\\.id'\\s*\\)/");
+});
+
+it('US-INFRA-016 — handle() injeta route_name (route name OR path fallback)', function () {
+    $src = readMiddleware();
+    expect($src)->toContain("'route_name'");
+    expect($src)->toContain('->getName()');
+    // Fallback pra request->path() se rota não-nomeada
+    expect($src)->toContain('->path()');
+});
+
+it('US-INFRA-016 — usa Log::withContext (não Log::* direto)', function () {
+    $src = readMiddleware();
+    expect($src)->toContain('Log::withContext($context)');
+});
+
+it('US-INFRA-016 — return $next($request) preserva chain middleware', function () {
+    $src = readMiddleware();
+    expect($src)->toContain('return $next($request);');
+});
+
+it('US-INFRA-016 — comentário cita ADR 0212 (rastreabilidade canon)', function () {
+    $src = readMiddleware();
+    expect($src)->toContain('ADR 0212');
+});


### PR DESCRIPTION
## Onda 1.3 do plano prevenção bugs MWART

**Fecha:** [US-INFRA-016](memory/requisitos/Infra/SPEC.md) (LogContextMiddleware global)

**Camada 1 do ADR 0212** (defensive logging). Habilita rastreabilidade automática em TODO `Log::*` da request via `Log::withContext`.

## Mudanças

- [`app/Http/Middleware/LogContextMiddleware.php`](app/Http/Middleware/LogContextMiddleware.php) — novo, 70 LOC
- [`app/Http/Kernel.php`](app/Http/Kernel.php) — registrado em `'web'` group APÓS `StartSession` (precisa session) e ANTES dos demais middlewares UPOS
- [`tests/Feature/Middleware/LogContextMiddlewareTest.php`](tests/Feature/Middleware/LogContextMiddlewareTest.php) — 12 Pest estruturais

## 4 campos canônicos injetados

| Campo | Origem | Null-safe? |
|---|---|---|
| `business_id` | `session('user.business_id')` UPOS canon | ✓ só se `session->has` |
| `user_id` | `session('user.id')` | ✓ só se `session->has` |
| `request_id` | `Str::uuid()` v4 | sempre injeta |
| `route_name` | `route->getName()` OR `request->path()` | sempre injeta |

## Por que

Bug R9 Larissa 2026-05-28: `SellPosController:435` fallback cego `Carbon::now()` em transaction_date. 2h47 entre Larissa abrir tela e submeter, DB gravou hora errada. **Nenhum log apontou origem.** Diagnose levou ~1h via `debug-tz-info.yml` workflow custom.

Agora qualquer `Log::warning(...)` em fallback tem rastreabilidade automática — drill-down 1-click em `storage/logs/laravel.log`.

## Defesa em profundidade

- **null-safe**: requests não-autenticados (/login, webhooks) não crasham
- **Performance**: `Log::withContext` é hashmap merge — microsegundos
- **NÃO injeta PII** (email/telefone/cpf) — só identificadores

## Próximas Camadas ADR 0212

- **Camada 2** (doc AP-18 no LICOES_F3): pattern `Log::warning` antes de fallback
- **Camada 3** (PHPStan rule): `NoSilentFallbackRule` custom (US-INFRA-020)
- **Camada 4** (health-check): `controllers_with_silent_fallback` periódico
- **Camada 5** (trait `HasContextualException`): retro-compat exceptions futuras

## Refs

- [ADR 0212 — Defensive logging fallback paths](memory/decisions/0212-defensive-logging-fallback-paths.md)
- [PR #1830 R9](https://github.com/wagnerra23/oimpresso.com/pull/1830) — bug original
- [Dossier estado-da-arte 2026 F3-A](memory/sessions/2026-05-28-arte-prevencao-bugs-mwart-larissa.md)
- Sequência: [PR #1850 Larastan](https://github.com/wagnerra23/oimpresso.com/pull/1850) → este (Onda 1.3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Infra Contract

### 1. Happy path — comando + output esperado LITERAL

Middleware é dev-side defensive logging (não muda rotas/redirect). Validação é em
laravel.log após próximo request autenticado:

```bash
$ tail -1 storage/logs/laravel.log | jq -r '.context | {business_id, user_id, request_id, route_name}'
{
  "business_id": <int>,
  "user_id": <int>,
  "request_id": "<uuid-v4>",
  "route_name": "<rota>"
}
```

### 2. Regression adjacent — rotas que NÃO devem mudar

```bash
$ curl -skI https://oimpresso.com/login 2>&1 | grep '^HTTP\|^Location'
HTTP/1.1 200 OK

$ curl -skI https://oimpresso.com/ 2>&1 | grep '^HTTP\|^Location'
HTTP/1.1 302
Location: https://oimpresso.com/home
```

(Esperado: zero mudança em redirect/status — middleware só injeta context em log,
não toca pipeline de resposta.)

### 3. Environment delta — onde Pest local NÃO prova prod

- [x] Pest local valida estrutura (12 testes file_get_contents + string match)
- [ ] Pest local NÃO prova: `Log::withContext` resolve session em request real
  (precisa session UPOS canon ativa — não simulado em Pest unit)
- [ ] **Validação prod obrigatória pós-deploy**: rodar smoke `/login` → autenticar →
  rota qualquer → `tail storage/logs/laravel.log | grep request_id` confirma 4
  campos presentes

### 4. Rollback plan

Reverter PR via revert (1 commit). Middleware é puro-aditivo: remover do Kernel
pipeline + deletar arquivo. Zero impacto em runtime se removido.

### 5. Evidência ratchet

`Log::withContext` é hashmap merge no PHP — overhead trivial (microsegundos).
Não invalida cache nem persiste em DB.
