### PR TITLE
feat(arquivos): Sprint 0.3 — Laravel disks arquivos-minio + vault-minio (ADR 0214)

### DIFF
--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -94,6 +94,56 @@ return [
             'throw' => false,
         ],
 
+        /*
+         * ADR 0214 (aceita 2026-05-28) — Arquivos backbone S3 MinIO CT 100.
+         *
+         * Disk `arquivos-minio` é o backbone canon de qualquer anexo do
+         * oimpresso após adoção `HasArquivos` trait pelos módulos
+         * (Sprint 1 WhatsApp, Sprint 2+ Sells/Financeiro/Crm/etc).
+         *
+         * Endpoint: https://minio.oimpresso.com (Traefik proxy → CT 100 :9000)
+         * Bucket: oimpresso-arquivos (criado 2026-05-28)
+         * Auth: user MinIO `oimpresso-app` policy `arquivos-rw` (limit aos 2 buckets)
+         *
+         * Tier 0 (ADR 0093): path canon `biz=<businessId>/YYYY/MM/<md5>.<ext>`.
+         * Multi-tenant via prefix path, NÃO bucket-per-business (simplifica
+         * management; ACL aplicada via signed URL TTL no Controller que serve).
+         *
+         * Path-style endpoint OBRIGATÓRIO MinIO (não virtual-hosted como AWS).
+         *
+         * Signed URL TTL default 15min via Storage::temporaryUrl() —
+         * suficiente pra render thumb em tela atendimento + previne
+         * URL leak. Mídia grande: refresh on demand.
+         */
+        'arquivos-minio' => [
+            'driver' => 's3',
+            'key' => env('MINIO_ACCESS_KEY'),
+            'secret' => env('MINIO_SECRET_KEY'),
+            'region' => env('MINIO_REGION', 'us-east-1'),
+            'bucket' => env('MINIO_BUCKET_ARQUIVOS', 'oimpresso-arquivos'),
+            'endpoint' => env('MINIO_ENDPOINT'),
+            'use_path_style_endpoint' => true,
+            'url' => env('MINIO_PUBLIC_URL'),
+            'throw' => false,
+        ],
+
+        /*
+         * Bucket dedicado pra sensitive (encrypted-at-rest via VaultEncryptionService).
+         * ADR 0123 princípio 6 — upload .env/.pfx/.rdp/.pem/XML PII vai pra cá
+         * automaticamente. Audit log obrigatório.
+         */
+        'arquivos-vault-minio' => [
+            'driver' => 's3',
+            'key' => env('MINIO_ACCESS_KEY'),
+            'secret' => env('MINIO_SECRET_KEY'),
+            'region' => env('MINIO_REGION', 'us-east-1'),
+            'bucket' => env('MINIO_BUCKET_VAULT', 'oimpresso-arquivos-vault'),
+            'endpoint' => env('MINIO_ENDPOINT'),
+            'use_path_style_endpoint' => true,
+            'url' => env('MINIO_PUBLIC_URL'),
+            'throw' => false,
+        ],
+
         'dropbox' => [
             'driver' => 'dropbox',
             'authorization_token' => env('DROPBOX_ACCESS_TOKEN'),

--- a/tests/Feature/ArquivosMinioDiskTest.php
+++ b/tests/Feature/ArquivosMinioDiskTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * R-ARQ-MINIO — anti-regressão Sprint 0.3 ADR 0214 (Arquivos backbone S3 MinIO).
+ *
+ * Garante que disks `arquivos-minio` + `arquivos-vault-minio` estão declarados
+ * em config/filesystems.php com shape S3-compat correto (path-style endpoint
+ * OBRIGATÓRIO pra MinIO).
+ *
+ * Sem este test, regressão silenciosa: alguém remove disk + Storage::disk()
+ * cai pro driver default → mídias vão pra lugar errado.
+ *
+ * NOTA: smoke E2E REAL (com MinIO live) precisa env vars setadas em prod
+ * (`MINIO_ACCESS_KEY`, `MINIO_SECRET_KEY`, `MINIO_ENDPOINT`) — esse smoke roda
+ * via cmd artisan `arquivos:health-check-minio` (criado em Sprint 1+).
+ */
+
+/**
+ * Pest test env carrega config/filesystems.php mas com env() retornando null
+ * pra vars não-setadas. Pra validar shape do disk, lemos o array RAW
+ * via require_once + verificamos KEYS presentes (não os values resolvidos).
+ */
+function getDiskConfigRaw(string $diskName): array
+{
+    $config = require __DIR__ . '/../../config/filesystems.php';
+    return $config['disks'][$diskName] ?? [];
+}
+
+it('R-ARQ-MINIO-001 — disk arquivos-minio declarado com driver s3 + path-style', function () {
+    $config = getDiskConfigRaw('arquivos-minio');
+
+    expect($config)->not->toBeEmpty();
+    expect($config['driver'])->toBe('s3');
+    expect($config['use_path_style_endpoint'])->toBeTrue();
+    expect($config)->toHaveKey('key');
+    expect($config)->toHaveKey('secret');
+    expect($config)->toHaveKey('bucket');
+    expect($config)->toHaveKey('endpoint');
+});
+
+it('R-ARQ-MINIO-002 — disk arquivos-vault-minio declarado bucket separado', function () {
+    $config = getDiskConfigRaw('arquivos-vault-minio');
+
+    expect($config)->not->toBeEmpty();
+    expect($config['driver'])->toBe('s3');
+    expect($config['use_path_style_endpoint'])->toBeTrue();
+    // Bucket sources de env vars diferentes (anti-cross-write)
+    $arquivos = getDiskConfigRaw('arquivos-minio');
+    expect($config)->toHaveKey('bucket');
+    expect($arquivos)->toHaveKey('bucket');
+});
+
+it('R-ARQ-MINIO-003 — region default us-east-1 (MinIO compat)', function () {
+    // Sem env MINIO_REGION setada, default é 'us-east-1'.
+    $config = getDiskConfigRaw('arquivos-minio');
+    // Region pode ser null ou 'us-east-1' dependendo do env teste — testamos shape
+    expect($config)->toHaveKey('region');
+});
+
+it('R-ARQ-MINIO-004 — config raw source usa env vars MINIO_* (não AWS_*)', function () {
+    // ADR 0214 separa MINIO_* (CT 100 self-hosted) de AWS_* (eventual S3 externo).
+    // Lemos o source do config pra confirmar env() apontam pras chaves canônicas.
+    $source = file_get_contents(__DIR__ . '/../../config/filesystems.php');
+    $blockArquivos = strstr($source, "'arquivos-minio' => [");
+    $blockArquivos = substr($blockArquivos, 0, strpos($blockArquivos, '],') + 2);
+
+    expect($blockArquivos)->toContain("env('MINIO_ACCESS_KEY')");
+    expect($blockArquivos)->toContain("env('MINIO_SECRET_KEY')");
+    expect($blockArquivos)->toContain("env('MINIO_BUCKET_ARQUIVOS'");
+    expect($blockArquivos)->toContain("env('MINIO_ENDPOINT')");
+    expect($blockArquivos)->not->toContain("env('AWS_ACCESS_KEY_ID')");
+});


### PR DESCRIPTION
Sprint 0.3 ADR 0214: 2 disks Laravel + 4 Pest tests anti-regressão. Awaiting DNS minio.oimpresso.com pra Sprint 0.4 (deploy + smoke E2E).

🤖 Generated with [Claude Code](https://claude.com/claude-code)