### PR TITLE
fix(arquivos): suppress PHPStan MorphMany::bucket() falso-positivo (Sprint 1 fallout)

### DIFF
--- a/Modules/Arquivos/Concerns/HasArquivos.php
+++ b/Modules/Arquivos/Concerns/HasArquivos.php
@@ -35,9 +35,16 @@ trait HasArquivos
 
     /**
      * Helper: arquivos classificados num bucket específico.
+     *
+     * `bucket()` é um local scope definido em Arquivo::scopeBucket — Larastan
+     * não propaga scopes do model target via MorphMany sem `@method` annotation.
+     * Refator clean (US-ARQ-TYPE follow-up): adicionar
+     * `@method static Builder<static> bucket(string $bucket)` em Arquivo +
+     * generic `@return MorphMany<Arquivo, $this>` em arquivos() acima.
      */
     public function arquivosClassificados(string $bucket): \Illuminate\Database\Eloquent\Collection
     {
+        /** @phpstan-ignore-next-line method.notFound */
         return $this->arquivos()->bucket($bucket)->get();
     }
 }


### PR DESCRIPTION
## Summary

Sprint 1 (commit \`ac1bbc850\`, PR #1854 — US-ARQ-WA-01) introduziu \`HasArquivos::arquivosClassificados()\` que chama \`\$this->arquivos()->bucket(...)\`. \`bucket()\` é local scope válido em runtime, mas Larastan vê como \`MorphMany::bucket()\` undefined (não propaga scopes do model target via MorphMany sem annotation @method/@template).

\`phpstan-baseline.neon\` foi gerado antes do Sprint 1 → ratchet vs baseline pega esse débito agora.

**Impacto bloqueante:** TODO PR aberto pós-Sprint-1 falha PHPStan check mesmo sem tocar Arquivos. Casos detectados: PR #1856 (Pest QuickAdd).

## Fix

\`/** @phpstan-ignore-next-line method.notFound */\` no callsite + PHPDoc explicando o débito + ponteiro pro refator clean (US-ARQ-TYPE follow-up).

## Refator clean (US-ARQ-TYPE — não neste PR)

\`\`\`php
// Modules/Arquivos/Entities/Arquivo.php
/**
 * @method static \Illuminate\Database\Eloquent\Builder<static> bucket(string \$bucket)
 */
class Arquivo extends Model

// Modules/Arquivos/Concerns/HasArquivos.php
/**
 * @return \Illuminate\Database\Eloquent\Relations\MorphMany<Arquivo, \$this>
 */
public function arquivos(): MorphMany
\`\`\`

Não fiz aqui pra manter PR atômico (1 PR = 1 intent — skill commit-discipline Tier A). Refator clean = ADR ou US separada.

## Test plan

- [ ] PHPStan ratchet vs baseline volta verde
- [ ] PR #1856 (Pest QuickAdd) re-roda CI verde após este merge
- [ ] Verificar que arquivosClassificados() runtime continua funcionando (smoke whatsapp/nfe)

## Refs

- ADR 0123 (Modules/Arquivos backbone)
- Sprint 1 PR #1854 (US-ARQ-WA-01)
- PR #1856 bloqueado por isso

🤖 Generated with [Claude Code](https://claude.com/claude-code)