### PR TITLE
fix(vestuario): EAN13 check-digit correto no test 10-etiquetas-grid

### DIFF
--- a/Modules/Vestuario/Tests/Feature/UsVest020EtiquetaTagControllerTest.php
+++ b/Modules/Vestuario/Tests/Feature/UsVest020EtiquetaTagControllerTest.php
@@ -232,15 +232,32 @@ it('blade vestuario::etiquetas.pdf compila e renderiza HTML válido', function (
 });
 
 it('blade pdf renderiza 10 etiquetas em grid (acceptance criteria)', function () {
+    // EAN13 = 12 dígitos base + 1 check digit (mod-10 GS1).
+    // Antes: '789100000001' + ($i % 10) — só o sufixo i=4 acertava o check digit
+    // por coincidência; outras 9 iterações disparavam Milon\Barcode\WrongCheckDigitException
+    // quando vendor/milon/barcode renderizava o SVG na view (CI Pest Vestuario red
+    // detectado a partir do PR #1856 — job só roda em PRs, débito ficou invisível
+    // nos merges main).
+    $ean13Check = static function (string $base12): string {
+        $sum = 0;
+        for ($k = 0; $k < 12; $k++) {
+            $d = (int) $base12[$k];
+            $sum += ($k % 2 === 0) ? $d : ($d * 3);
+        }
+
+        return $base12 . (string) ((10 - ($sum % 10)) % 10);
+    };
+
     $etiquetas = [];
     for ($i = 1; $i <= 10; $i++) {
+        $base12 = '789100000' . sprintf('%03d', $i); // 9 + 3 = 12 dígitos
         $etiquetas[] = [
             'nome'        => "Produto {$i}",
             'tamanho'     => 'M',
             'cor'         => 'Preto',
             'preco'       => 29.90 + $i,
             'sku'         => sprintf('SKU-%03d', $i),
-            'ean13'       => '789100000001' . (string) ($i % 10),
+            'ean13'       => $ean13Check($base12),
             'qr_enabled'  => false,
             'colecao'     => '',
         ];
@@ -251,9 +268,15 @@ it('blade pdf renderiza 10 etiquetas em grid (acceptance criteria)', function ()
         'business_id' => 1,
     ])->render();
 
-    // 10 etiquetas devem aparecer
+    // 10 etiquetas devem aparecer.
+    // NOTA: Pest `toContain(...$needles)` aceita N needles como variadic, NÃO
+    // mensagem custom (sintaxe difere de PHPUnit assertStringContainsString).
+    // Antes: `expect($html)->toContain("Produto {$i}", "etiqueta #{$i} ausente...")` —
+    // o 2º arg virava needle adicional ("etiqueta #1 ausente no PDF render") que
+    // o HTML obviamente não continha → fail SEMPRE. Mascarado porque o EAN13
+    // disparava WrongCheckDigitException ANTES da assertion. Fix: 1 needle por chamada.
     for ($i = 1; $i <= 10; $i++) {
-        expect($html)->toContain("Produto {$i}", "etiqueta #{$i} ausente no PDF render");
+        expect($html)->toContain("Produto {$i}");
     }
 
     expect($html)->toContain('10 etiquetas');


### PR DESCRIPTION
## Summary

Dois bugs sequenciais em `UsVest020EtiquetaTagControllerTest::it('blade pdf renderiza 10 etiquetas em grid')`:

### Bug 1 — EAN13 check-digit ausente

Test gerava `'789100000001' + ($i % 10)` — sufixo aleatório no lugar do check digit mod-10 GS1. 9/10 iterações disparavam `Milon\Barcode\WrongCheckDigitException` ao renderizar SVG na view.

**Fix:** closure `$ean13Check(string $base12)` calcula GS1 mod-10 inline. Algoritmo conferido contra `'7891000000014'` no test acima (linha 229).

### Bug 2 — `expect()->toContain($a, $b)` com message incorreto

Sintaxe original confundia PHPUnit (`assertStringContainsString(needle, haystack, message)`) com Pest (`toContain(...$needles)` variadic). O 2º argumento `"etiqueta #{$i} ausente no PDF render"` virava needle adicional que o HTML óbvio não continha → fail SEMPRE.

Mascarado porque Bug 1 abortava a execução ANTES da assertion. Corrigir só Bug 1 expôs Bug 2 no CI do PR #1856.

**Fix:** 1 needle por chamada (mensagem default Pest é suficiente).

## Por que ficou invisível em main

Job CI **Pest Vestuario só roda em PRs** (matrix por módulo), não nos merges direto. Wagner mergeou PRs anteriores aceitando essa luz vermelha (ex #1855 mergeado com PHPStan red).

## Test plan

- [x] PHP lint OK ambos commits
- [ ] CI Pest Vestuario volta verde com os 2 fixes
- [x] EAN13 conferido contra linha 229 (`7891000000014` → check 4 ✓)

## Refs

- PR #1856 expôs débito
- SPEC US-VEST-020 acceptance criteria PDF etiquetas

🤖 Generated with [Claude Code](https://claude.com/claude-code)