### PR TITLE
fix(ci): secrets-governance composer install ignora ext-opentelemetry

### DIFF
--- a/.github/workflows/secrets-governance.yml
+++ b/.github/workflows/secrets-governance.yml
@@ -24,7 +24,11 @@ jobs:
         with:
           php-version: '8.4'
       - name: Install dependencies (no-dev)
-        run: composer install --no-progress --no-interaction --prefer-dist
+        # --ignore-platform-req=ext-opentelemetry: ubuntu-latest runner não tem
+        # PECL opentelemetry pré-built. Paridade com `composer dump-autoload
+        # --no-scripts` em prod Hostinger shared host (ADR de deploy webhook
+        # autoload regen — incident 2026-05-28 10:11→13:22).
+        run: composer install --no-progress --no-interaction --prefer-dist --ignore-platform-req=ext-opentelemetry
       - name: Run secrets:scan --fail-on-drift
         run: php artisan secrets:scan --fail-on-drift
 
@@ -40,7 +44,9 @@ jobs:
         with:
           php-version: '8.4'
       - name: Install dependencies
-        run: composer install --no-progress --no-interaction --prefer-dist
+        # Mesma justificativa do job `scan`: ext-opentelemetry não disponível
+        # em ubuntu-latest sem build PECL.
+        run: composer install --no-progress --no-interaction --prefer-dist --ignore-platform-req=ext-opentelemetry
       - name: Run secrets:audit --auto-pr
         run: |
           # Configure git pra auto-PR (Camada 3)


### PR DESCRIPTION
## Summary

PR #1864 (Sprint S-0215-1) adicionou `.github/workflows/secrets-governance.yml`. O step `composer install --no-progress --no-interaction --prefer-dist` aborta em ubuntu-latest porque **`ext-opentelemetry` não está pré-built** no `shivammathur/setup-php@v2` default (extensão PECL, build complexo).

Resultado: **TODO PR pós-merge do #1864 falha "Camada 1 — Auto-discovery (secrets:scan)"** mesmo sem tocar `memory/**`, `config/**`, `Modules/**` ou `.env.example`.

Caso real: PR #1856 (Pest QuickAdd Sells) bloqueado por arrasto.

## Fix

`--ignore-platform-req=ext-opentelemetry` em ambos jobs (`scan` e `audit`).

## Paridade prod

Mesma causa raiz do incident prod 2026-05-28 10:11→13:22 BRT (deploy webhook quebrado por `composer dump-autoload` sem `--no-scripts` → opentelemetry `_register.php` fatal). Solução já documentada em ADR proposta no PR #1857 (que vou renumerar de 0215 pra 0216 — número 0215 já ocupado pelo Sprint S-0215-1 mergeado em paralelo).

## Test plan

- [x] YAML válido (visual diff)
- [ ] Próximo PR roda CI Camada 1 verde

## Refs

- PR #1864 (Sprint S-0215-1 introduziu o workflow)
- PR #1856 bloqueado
- PR #1857 (ADR a renumerar 0215 → 0216, mesma causa raiz)

🤖 Generated with [Claude Code](https://claude.com/claude-code)