### PR TITLE
feat(cmd): sells:final-total-audit — DRY-RUN auditor pra final_total corrompido (fallout #1867)

### DIFF
--- a/app/Console/Commands/SellsFinalTotalAuditCommand.php
+++ b/app/Console/Commands/SellsFinalTotalAuditCommand.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Transaction;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Auditoria de `transactions.final_total` corrompido por bug histórico do
+ * parser pt-BR `num_uf` (corrigido no PR #1867 — `app/Utils/Util.php@num_uf`).
+ *
+ * O bug devolvia `num_uf("80.00") = 8000` (ponto interpretado como milhar).
+ * Resultado: vendas criadas/editadas com valor en-US no input gravavam
+ * `final_total` 10x/100x/1000x maior que o esperado.
+ *
+ * Casos canon detectados em prod biz=4 (Larissa @ Rota Livre):
+ *   - Invoice 17642 (id 69293) — total_before_tax=2788 → final_total=2.500.836 (ratio 931x)
+ *   - Invoice 17639 (id 69287) — total_before_tax=79,90 → final_total=0 (discount 100%)
+ *
+ * Modo DRY-RUN por padrão — APENAS lista candidatos com diagnóstico. Não
+ * modifica nada. Para aplicar correção é `--apply` + confirmação explícita
+ * + nunca em transação com NFe emitida (chave preenchida).
+ *
+ * Refs:
+ *   - PR #1867 (fix root cause num_uf)
+ *   - Wagner sessão 2026-05-28 "blusa R$ 80 vira R$ 800+"
+ *   - ADR 0093 (multi-tenant Tier 0 — scope obrigatório por --business)
+ */
+class SellsFinalTotalAuditCommand extends Command
+{
+    /**
+     * Sintaxe:
+     *   php artisan sells:final-total-audit --business=4
+     *   php artisan sells:final-total-audit --business=4 --since=2026-05-01
+     *   php artisan sells:final-total-audit --business=4 --ratio=5
+     *   php artisan sells:final-total-audit --business=4 --apply --transaction=69293
+     */
+    protected $signature = 'sells:final-total-audit
+        {--business= : ID do business (OBRIGATÓRIO — Tier 0 ADR 0093 scope)}
+        {--since= : Data ISO (YYYY-MM-DD) a partir de quando auditar (default: últimos 30d)}
+        {--ratio=5 : Razão final_total / esperado considerada suspeita (default 5x)}
+        {--apply : Aplica correção (default DRY-RUN). Exige --transaction.}
+        {--transaction= : ID da transaction única a corrigir (apply requer este)}';
+
+    protected $description = 'Audita transactions.final_total corrompidas por bug num_uf histórico (DRY-RUN por padrão).';
+
+    public function handle(): int
+    {
+        $business = (int) $this->option('business');
+        if ($business <= 0) {
+            $this->error('--business obrigatório (ADR 0093 Tier 0 multi-tenant scope).');
+
+            return self::FAILURE;
+        }
+
+        $since = $this->option('since') ?: now()->subDays(30)->format('Y-m-d');
+        $ratio = (float) ($this->option('ratio') ?: 5);
+
+        if (! $this->option('apply')) {
+            return $this->runDryRun($business, $since, $ratio);
+        }
+
+        $tid = (int) $this->option('transaction');
+        if ($tid <= 0) {
+            $this->error('--apply exige --transaction=ID específico (correção per-row, nunca em massa).');
+
+            return self::FAILURE;
+        }
+
+        return $this->runApply($business, $tid);
+    }
+
+    private function runDryRun(int $business, string $since, float $ratio): int
+    {
+        $this->info("DRY-RUN — business={$business}, since={$since}, ratio_threshold={$ratio}x");
+        $this->line('');
+
+        // Heurística: final_total deveria ser ≈ (total_before_tax - discount) + tax + shipping.
+        // Quando `discount_type=fixed`, esperado = total_before_tax - discount.
+        // Quando `discount_type=percentage`, esperado = total_before_tax * (1 - discount/100).
+        // tax e shipping são separados e geralmente 0 em biz=4.
+        $rows = DB::select(
+            <<<'SQL'
+                SELECT
+                    t.id,
+                    t.invoice_no,
+                    t.contact_id,
+                    t.created_by,
+                    u.username AS created_by_username,
+                    t.total_before_tax,
+                    t.discount_amount,
+                    t.discount_type,
+                    t.tax_amount,
+                    t.shipping_charges,
+                    t.final_total,
+                    t.payment_status,
+                    t.chave AS nfe_chave,
+                    t.status,
+                    t.created_at,
+                    CASE
+                        WHEN t.discount_type = 'percentage' THEN
+                            ROUND(t.total_before_tax * (1 - t.discount_amount / 100), 2)
+                        ELSE
+                            ROUND(t.total_before_tax - t.discount_amount, 2)
+                    END AS final_total_esperado
+                FROM transactions t
+                LEFT JOIN users u ON u.id = t.created_by
+                WHERE t.business_id = ?
+                  AND t.type = 'sell'
+                  AND t.created_at >= ?
+                  AND t.total_before_tax > 0
+                  AND t.final_total > 0
+                ORDER BY t.id DESC
+            SQL,
+            [$business, $since]
+        );
+
+        $suspeitas = [];
+        foreach ($rows as $r) {
+            $esperado = (float) $r->final_total_esperado;
+            $real = (float) $r->final_total;
+            if ($esperado <= 0) {
+                continue;
+            }
+            $razao = $real / $esperado;
+            if ($razao >= $ratio || $razao <= (1.0 / $ratio)) {
+                $suspeitas[] = ['row' => $r, 'esperado' => $esperado, 'razao' => $razao];
+            }
+        }
+
+        if (empty($suspeitas)) {
+            $this->info('Nenhuma transaction suspeita detectada.');
+
+            return self::SUCCESS;
+        }
+
+        $this->warn(sprintf('Detectadas %d transactions suspeitas:', count($suspeitas)));
+        $this->line('');
+
+        $tableRows = [];
+        foreach ($suspeitas as $s) {
+            $r = $s['row'];
+            $tableRows[] = [
+                'id'         => $r->id,
+                'invoice'    => $r->invoice_no,
+                'created_by' => $r->created_by_username,
+                'before_tax' => number_format((float) $r->total_before_tax, 2, ',', '.'),
+                'disc'       => $r->discount_amount.' '.($r->discount_type === 'percentage' ? '%' : 'R$'),
+                'esperado'   => number_format($s['esperado'], 2, ',', '.'),
+                'real'       => number_format((float) $r->final_total, 2, ',', '.'),
+                'ratio'      => sprintf('%.1fx', $s['razao']),
+                'nfe'        => $r->nfe_chave ? '⚠️ EMITIDA' : 'não',
+                'pgto'       => $r->payment_status,
+            ];
+        }
+
+        $this->table(
+            ['id', 'invoice', 'created_by', 'before_tax', 'disc', 'esperado', 'real', 'ratio', 'nfe', 'pgto'],
+            $tableRows
+        );
+
+        $this->line('');
+        $this->warn('Pra aplicar correção numa transaction específica:');
+        $this->line('  php artisan sells:final-total-audit --business='.$business.' --apply --transaction=ID');
+        $this->line('');
+        $this->warn('REGRAS DE SEGURANÇA:');
+        $this->line('  • NUNCA aplicar em transaction com NFe emitida (chave preenchida).');
+        $this->line('  • SEMPRE confirmar com Larissa/operador antes de corrigir transaction com pagamento != 0.');
+        $this->line('  • Validar visualmente o valor "esperado" contra o documento físico/cliente.');
+
+        return self::SUCCESS;
+    }
+
+    private function runApply(int $business, int $tid): int
+    {
+        /** @var Transaction|null $t */
+        $t = Transaction::where('business_id', $business)->where('id', $tid)->first();
+        if (! $t) {
+            $this->error("Transaction {$tid} não pertence a business {$business} (Tier 0 scope).");
+
+            return self::FAILURE;
+        }
+
+        if (! empty($t->chave)) {
+            $this->error("Transaction {$tid} tem NFe EMITIDA (chave={$t->chave}). Correção bloqueada — anular via SEFAZ antes.");
+
+            return self::FAILURE;
+        }
+
+        $totalBeforeTax = (float) $t->total_before_tax;
+        $disc = (float) $t->discount_amount;
+        $esperado = $t->discount_type === 'percentage'
+            ? round($totalBeforeTax * (1 - $disc / 100), 2)
+            : round($totalBeforeTax - $disc, 2);
+
+        $real = (float) $t->final_total;
+
+        $this->info("Transaction #{$tid} (invoice {$t->invoice_no}):");
+        $this->line('  total_before_tax: '.number_format($totalBeforeTax, 2, ',', '.'));
+        $this->line('  discount:         '.$disc.' '.($t->discount_type === 'percentage' ? '%' : 'R$'));
+        $this->line('  final_total esperado: '.number_format($esperado, 2, ',', '.'));
+        $this->line('  final_total atual:    '.number_format($real, 2, ',', '.'));
+        $this->line('  payment_status:   '.$t->payment_status);
+        $this->line('');
+
+        if (! $this->confirm("Confirma UPDATE final_total = {$esperado} (era {$real})?", false)) {
+            $this->info('Cancelado pelo operador.');
+
+            return self::SUCCESS;
+        }
+
+        DB::transaction(function () use ($t, $esperado, $real, $business): void {
+            // Audit append-only (paridade com pattern UPOS activity_log).
+            DB::table('activity_log')->insert([
+                'log_name' => 'sells-final-total-audit',
+                'description' => 'final_total corrigido via sells:final-total-audit (bug histórico num_uf PR #1867)',
+                'subject_type' => 'App\\Transaction',
+                'subject_id' => $t->id,
+                'causer_type' => null,
+                'causer_id' => null,
+                'properties' => json_encode([
+                    'business_id' => $business,
+                    'attributes' => ['final_total' => $esperado],
+                    'old' => ['final_total' => $real],
+                ]),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            DB::table('transactions')->where('id', $t->id)->update([
+                'final_total' => $esperado,
+                'updated_at' => now(),
+            ]);
+        });
+
+        $this->info("✅ Transaction {$tid} corrigida. final_total {$real} → {$esperado}.");
+        $this->warn('Lembre de revisar payment_status / fin_titulos / commission manualmente se aplicável.');
+
+        return self::SUCCESS;
+    }
+}


### PR DESCRIPTION
## Summary

Fallout do PR #1867 (fix root cause `num_uf`): restam **vendas históricas com `final_total` corrompido no banco**. Casos canon biz=4 Larissa:

- **Invoice 17642** (id 69293) — esperado R$ 2.685, gravado **R$ 2.500.836** (ratio 931x)
- **Invoice 17639** (id 69287) — esperado R$ 0 (discount 100%), OK na verdade

## Por que Artisan command (não migração / SQL direto)

- `final_total` afeta `payment_status`, `transaction_payments`, `commission`, `fin_titulos`, `tax_amount` derivados, NFe potencial. **Correção em massa é perigosa.**
- Cada transaction precisa validação humana (Larissa confirma valor real do cliente).
- Comando expõe DRY-RUN por default + apply per-row com confirmação interativa.

## Sintaxe

```bash
# Listar candidatos biz=4 últimos 30d (DRY-RUN — sem alterar BD):
php artisan sells:final-total-audit --business=4

# Listar últimos 90d com threshold de razão custom:
php artisan sells:final-total-audit --business=4 --since=2026-02-01 --ratio=3

# Aplicar correção numa transaction específica (com confirmação interativa):
php artisan sells:final-total-audit --business=4 --apply --transaction=69293
```

## Salvaguardas

- ✅ `--business` obrigatório (Tier 0 ADR 0093 multi-tenant scope)
- ✅ `--apply` exige `--transaction` (NUNCA correção em massa)
- ✅ Bloqueia se NFe emitida (chave preenchida) — anulação SEFAZ é manual
- ✅ Confirmação interativa (`$this->confirm`) antes do UPDATE
- ✅ Registra audit em `activity_log` (subject_type=`App\Transaction`, old/new)
- ✅ NÃO toca `payment_status` / `fin_titulos` / `commission` — operador valida e ajusta manualmente

## Heurística de detecção

```sql
final_total_esperado =
  CASE discount_type
    WHEN 'percentage' THEN total_before_tax * (1 - discount_amount / 100)
    ELSE total_before_tax - discount_amount
  END

Suspeita se: |final_total / final_total_esperado| >= ratio_threshold (default 5x)
```

## Test plan

- [x] PHP lint OK
- [ ] DRY-RUN biz=4 em prod via SSH: ver se detecta 17642
- [ ] Wagner valida casos detectados com Larissa
- [ ] Apply test em UMA transaction (provavelmente 17642 ou 17639)

## Próximos passos pós-merge

1. Wagner roda `--business=4` em prod
2. Confirma com Larissa quais transactions corrompidas tem valor real conhecido
3. Aplica `--apply --transaction=...` per-row
4. Revê manualmente `payment_status` + `transaction_payments` + comissões

## Refs

- PR #1867 (root cause num_uf fix)
- ADR 0093 (multi-tenant Tier 0)
- Wagner sessão 2026-05-28

🤖 Generated with [Claude Code](https://claude.com/claude-code)