### PR TITLE
fix(cmd): sells:final-total-audit detecta discount > 100% (heurística A teto)

### DIFF
--- a/app/Console/Commands/SellsFinalTotalAuditCommand.php
+++ b/app/Console/Commands/SellsFinalTotalAuditCommand.php
@@ -122,6 +122,19 @@ class SellsFinalTotalAuditCommand extends Command
         foreach ($rows as $r) {
             $esperado = (float) $r->final_total_esperado;
             $real = (float) $r->final_total;
+            $beforeTax = (float) $r->total_before_tax;
+
+            // Heurística A: final_total >> total_before_tax + tax + shipping (impossível
+            // matematicamente — desconto não pode AUMENTAR o total). Pega 17642 (931x).
+            $extras = (float) $r->tax_amount + (float) $r->shipping_charges;
+            $tetoRazoavel = $beforeTax + $extras;
+            if ($tetoRazoavel > 0 && $real > $tetoRazoavel * 1.5) {
+                $suspeitas[] = ['row' => $r, 'esperado' => $esperado > 0 ? $esperado : $tetoRazoavel, 'razao' => $real / max($tetoRazoavel, 0.01)];
+
+                continue;
+            }
+
+            // Heurística B: razão final vs esperado fora do threshold (caso clássico).
             if ($esperado <= 0) {
                 continue;
             }


### PR DESCRIPTION
Patch fast-follow do PR #1870. DRY-RUN inicial biz=4 últimos 60d retornou 'Nenhuma transaction suspeita' porque heurística original pulava casos com discount_amount > 100% (esperado vira negativo, skip).

Caso real: 17642 — discount=103 percentage sobre R$ 2.788 → esperado=-83 → skip silencioso.

Fix: heurística A adicionada — final_total NUNCA pode ser maior que total_before_tax + tax + shipping (desconto só REDUZ). Pega 17642 (real 2.500.836, teto 2.788, razão 897x).

Heurística B (razão vs esperado) preservada pros discounts válidos <100%.

Refs: #1870