### PR TITLE
fix(deps): composer update symfony/yaml v8.0.8 → v8.0.13 (4 CVEs)

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -10844,16 +10844,16 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/50f59d1f3ca46d41ac911f97a78626b6756af35b",
+                "reference": "50f59d1f3ca46d41ac911f97a78626b6756af35b",
                 "shasum": ""
             },
             "require": {
@@ -10866,7 +10866,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -10891,7 +10891,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.0"
             },
             "funding": [
                 {
@@ -10903,11 +10903,15 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-04-13T15:52:40+00:00"
         },
         {
             "name": "symfony/error-handler",
@@ -11712,7 +11716,7 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -11771,7 +11775,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -12134,7 +12138,7 @@
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.36.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
@@ -12194,7 +12198,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -12218,16 +12222,16 @@
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.36.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c"
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
                 "shasum": ""
             },
             "require": {
@@ -12274,7 +12278,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.36.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -12294,7 +12298,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-26T12:45:58+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
@@ -20146,16 +20150,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v8.0.8",
+            "version": "v8.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "54174ab48c0c0f9e21512b304be17f8150ccf8f1"
+                "reference": "a1cdf99e359d5c001782a2db67a1fc71b2a5b34e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/54174ab48c0c0f9e21512b304be17f8150ccf8f1",
-                "reference": "54174ab48c0c0f9e21512b304be17f8150ccf8f1",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/a1cdf99e359d5c001782a2db67a1fc71b2a5b34e",
+                "reference": "a1cdf99e359d5c001782a2db67a1fc71b2a5b34e",
                 "shasum": ""
             },
             "require": {
@@ -20197,7 +20201,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v8.0.8"
+                "source": "https://github.com/symfony/yaml/tree/v8.0.13"
             },
             "funding": [
                 {
@@ -20217,7 +20221,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-05-25T06:08:44+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",


### PR DESCRIPTION
## Summary

Resolve **4 CVEs ATIVAS em symfony/yaml** detectadas pelo `composer_audit` checker ([ADR 0217](memory/decisions/0217-composer-audit-checker-supply-chain-detection.md)) no smoke 2026-05-28.

Versão: `v8.0.8` → `v8.0.13` (latest patch da minor 8.0.x — zero risco de breaking change).

## CVEs resolvidas (reportadas 2026-05-20)

- [CVE-2026-45065](https://symfony.com/cve-2026-45065) — Tag URI Resolution
- [CVE-2026-45304](https://symfony.com/cve-2026-45304) — Billion Laughs (exponential memory)
- [CVE-2026-45305](https://symfony.com/cve-2026-45305) — ReDoS catastrophic backtracking
- [CVE-2026-45133](https://symfony.com/cve-2026-45133) — Stack Exhaustion via unbounded recursion

**Affected:** `>=8.0.0,<8.0.12` (oimpresso estava em v8.0.8, vulnerável)
**Fixed:** `v8.0.12+` — escolhido `v8.0.13`

## Validação

```
$ php artisan governance:audit --check=composer_audit
⚠ composer_audit — 10 findings (5197ms)   # era 13 antes
```

- **3 advisories symfony/yaml ZERADAS** (esperado: 4 — discrepância pequena: composer audit agrupa algumas advisories quando affecta múltiplas versões em ranges contínuos)
- 18/18 Pest tests verde (`Modules/Governance/Tests/Feature/`)

## CVEs pendentes (Sprint 2 — PRs isolados)

Composer audit ainda mostra 10 advisories. Não pra este PR (escopo isolado symfony/yaml):

- symfony/routing (2 advisories)
- symfony/mime (2)
- symfony/http-foundation, symfony/http-kernel, symfony/mailer (1 cada)
- symfony/polyfill-intl-idn (1)
- phpseclib/phpseclib (1)
- setasign/fpdi (1)

Cada vai ter PR próprio pra ser revisado isoladamente.

## Test plan

- [x] `composer update symfony/yaml --with-dependencies` sem breaking changes
- [x] `php artisan governance:audit --check=composer_audit` retorna 10 findings (era 13)
- [x] Pest framework tests 18/18 verde
- [x] Diff composer.lock: 1 file, 27 inserts, 23 deletes (isolado)

## Refs

- [ADR 0217](memory/decisions/0217-composer-audit-checker-supply-chain-detection.md)
- [Handoff PR #1874](memory/sessions/2026-05-28-handoff-governance-framework-PR1-merged.md) — P0 #1 desta sessão