### PR TITLE
chore(adrs): aceitar ADRs 0208-0213 (status: proposto → aceito)

### DIFF
--- a/memory/decisions/0208-larastan-baseline-ratchet.md
+++ b/memory/decisions/0208-larastan-baseline-ratchet.md
@@ -3,7 +3,7 @@ slug: 0208-larastan-baseline-ratchet
 number: 208
 title: "Larastan PHPStan baseline ratchet — enforcement passivo de anti-padrões PHP"
 type: adr
-status: proposto
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]

--- a/memory/decisions/0209-eslint-9-flat-config.md
+++ b/memory/decisions/0209-eslint-9-flat-config.md
@@ -3,7 +3,7 @@ slug: 0209-eslint-9-flat-config
 number: 209
 title: "ESLint 9 flat-config + react-hooks + jsx-a11y baseline ratchet — enforcement passivo JS/TS"
 type: adr
-status: proposto
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]

--- a/memory/decisions/0210-type-safety-end-to-end-wayfinder.md
+++ b/memory/decisions/0210-type-safety-end-to-end-wayfinder.md
@@ -3,7 +3,7 @@ slug: 0210-type-safety-end-to-end-wayfinder
 number: 210
 title: "Type safety end-to-end via Wayfinder — eliminar R8/AP-12 (type drift backend↔frontend) na raiz"
 type: adr
-status: proposto
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]

--- a/memory/decisions/0211-tanstack-query-data-fetching-padrao.md
+++ b/memory/decisions/0211-tanstack-query-data-fetching-padrao.md
@@ -3,7 +3,7 @@ slug: 0211-tanstack-query-data-fetching-padrao
 number: 211
 title: "TanStack Query como padrão de data-fetching em componentes — eliminar R7 (race condition) na raiz"
 type: adr
-status: proposto
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]

--- a/memory/decisions/0212-defensive-logging-fallback-paths.md
+++ b/memory/decisions/0212-defensive-logging-fallback-paths.md
@@ -3,7 +3,7 @@ slug: 0212-defensive-logging-fallback-paths
 number: 212
 title: "Defensive logging em fallback paths — eliminar R9-class (silent fallback) via Log::warning canon + PHPStan rule"
 type: adr
-status: proposto
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]

--- a/memory/decisions/0213-audit-creates-tasks-loop-fechado.md
+++ b/memory/decisions/0213-audit-creates-tasks-loop-fechado.md
@@ -3,7 +3,7 @@ slug: 0213-audit-creates-tasks-loop-fechado
 number: 213
 title: "Audit docs com gaps criam MCP tasks automaticamente — loop fechado audit → backlog → ação"
 type: adr
-status: proposto
+status: aceito
 authority: canonical
 lifecycle: ativo
 decided_by: [W]


### PR DESCRIPTION
Wagner aprovou explicitamente 2026-05-28 ("aceito sim"). 6 ADRs viram canonical aceitos.

5 já implementados (Ondas 1+2). 1 (0213) ainda backlog Onda 5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)