### PR TITLE
feat(r12): ativação LAZY via skill encerrar-sessao + hook UserPromptSubmit

### DIFF
--- a/.claude/hooks/force-r12-closing-signal.ps1
+++ b/.claude/hooks/force-r12-closing-signal.ps1
@@ -1,0 +1,114 @@
+# Hook UserPromptSubmit — FORÇA R12 PROTOCOLO ao detectar sinal de fechamento.
+#
+# Camada 2 de ativação R12 (defesa em depth). Camada 1 é skill `encerrar-sessao`
+# Tier B description-match. Este hook é safety-net pra caso skill não dispare
+# (ex: trigger word ambíguo, Claude já em outra skill carregada).
+#
+# Origem: Wagner 2026-05-28
+#   "mas não está funcionando porque????? se existe mas não funciona ta errado.
+#    como colocar para funcionar? qual momento tem que ser ativado?"
+#
+# Diagnóstico do gap: R12 PROTOCOLO existe desde 2026-05-17 mas é Tier A always-on
+# (eager carregado no SessionStart). Em sessão longa (200+ turnos / 8h+) conteúdo
+# sai do contexto Claude. Hook = ATIVAÇÃO LAZY garantida no momento exato.
+#
+# Como funciona:
+#   1. UserPromptSubmit recebe JSON com `prompt` do user
+#   2. Regex case-insensitive contra patterns de fechamento
+#   3. Se match → emite stdout markdown que vira <system-reminder> no contexto
+#      do próximo turn Claude — força executar R12
+#   4. Se no match → exit 0 silencioso (zero overhead em 99% dos prompts)
+#
+# Patterns disparadores (case-insensitive):
+#   - "encerrar"/"encerre"/"encerra"
+#   - "fim de sessão"/"fim da sessão"/"finalizar"
+#   - "vamos parar"/"para aqui"
+#   - "continua depois"/"continua noutra"/"outra sessão"/"próxima sessão"
+#   - "salvar tudo"/"salve as memórias"/"salve no protocolo"/"salve na memória"
+#   - "vai pra MCP"/"vai para MCP"
+#   - "tchau"/"obrigado"/"valeu"
+#   - "tá bom"/"ta bom"/"beleza"/"show"/"perfeito"
+#   - "depois eu vejo"/"fica pra depois"/"baixa prioridade"
+#
+# Anti-pattern: detectar "ok" / "fim" sozinhos = muitos false-positives
+#   (user fala "ok continua" o tempo todo). Exige forma específica de fechamento.
+#
+# Refs: PROTOCOLO-WAGNER-SEMPRE.md R12 · skill encerrar-sessao · ADR 0130
+
+$ErrorActionPreference = 'Stop'
+$payloadJson = [Console]::In.ReadToEnd()
+
+try {
+    $payload = $payloadJson | ConvertFrom-Json
+} catch {
+    exit 0
+}
+
+$prompt = $payload.prompt
+if (-not $prompt) {
+    exit 0
+}
+
+# Patterns disparadores — regex compilado uma vez
+$closingPatterns = @(
+    '\bencerrar?\b',
+    'fim\s+(de|da)\s+sess[aã]o',
+    'finalizar?\s+(a\s+)?sess[aã]o',
+    'vamos\s+parar',
+    'para\s+aqui',
+    'continua?\s+depois',
+    'continua?\s+(em\s+)?outra\s+sess[aã]o',
+    'pr[oó]xima\s+sess[aã]o',
+    'salvar?\s+tudo',
+    'salve?\s+(as\s+)?mem[oó]rias?',
+    'salve?\s+(no\s+)?protocolo',
+    'salve?\s+(na\s+)?mem[oó]ria',
+    'vai\s+pra?\s+mcp',
+    '^tchau\b',
+    '^obrigad[oa]\b',
+    '^valeu\b',
+    'depois\s+eu\s+vejo',
+    'fica\s+pra?\s+depois',
+    'baixa\s+prioridade'
+)
+
+$promptLower = $prompt.ToLowerInvariant()
+$matched = $false
+$matchedPattern = ''
+
+foreach ($pattern in $closingPatterns) {
+    if ($promptLower -match $pattern) {
+        $matched = $true
+        $matchedPattern = $matches[0]
+        break
+    }
+}
+
+if (-not $matched) {
+    exit 0
+}
+
+# Match — emite system-reminder forçando R12
+$reminder = @"
+🔔 **R12 PROTOCOLO-WAGNER-SEMPRE — sinal de fechamento detectado** (hook ``force-r12-closing-signal.ps1``)
+
+Pattern detectado: ``$matchedPattern``
+
+**EXECUTE AGORA os 5 passos do R12** (carregue conteúdo via skill ``encerrar-sessao`` OU leia ``memory/reference/PROTOCOLO-WAGNER-SEMPRE.md`` §R12):
+
+1. **MCP-first checklist**: ``cycles-active`` + ``my-work`` + ``Glob memory/handoffs/2026-MM-*.md`` + ``decisions-search``
+2. **Handoff append-only**: ``memory/handoffs/YYYY-MM-DD-HHMM-<slug>.md`` (~30-80 linhas, frontmatter completo)
+3. **Atualizar índice**: linha NO TOPO de ``memory/08-handoff.md`` ``## Últimos handoffs``
+4. **Commit + push**: handoff + índice + tudo canon do trabalho
+5. **Reportar ≤8 linhas**: tabela passos ✅/❌ + caveats + próxima ação
+
+**CITE EXPLÍCITO** no report: ``"Cumprindo R12 PROTOCOLO via skill encerrar-sessao (ativação lazy via hook UserPromptSubmit)"`` — auditoria do mecanismo.
+
+**Caso especial sessão curta (<2h, 0-1 PRs sem mudança canon)**: pular passo 1-2 OK, reportar "sessão curta — sem handoff" explícito.
+
+Pareada com [R12](../../memory/reference/PROTOCOLO-WAGNER-SEMPRE.md) · [skill encerrar-sessao](../../.claude/skills/encerrar-sessao/SKILL.md) · [ADR 0130](../../memory/decisions/0130-handoff-append-only-mcp-first.md).
+"@
+
+# stdout vira system-reminder no contexto Claude (Claude Code 2.1+)
+Write-Output $reminder
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -127,6 +127,17 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/force-r12-closing-signal.ps1"
+          }
+        ]
+      }
     ]
   }
 }

--- a/.claude/skills/encerrar-sessao/SKILL.md
+++ b/.claude/skills/encerrar-sessao/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: encerrar-sessao
+description: BLOQUEADOR — ATIVAR SEMPRE que user disser "encerrar sessão", "fim de sessão", "vamos parar", "continua depois", "salvar tudo", "salve as memórias", "ciclos", "outra sessão", "vai pra MCP continua depois", "tchau", "obrigado", "valeu", "fim", "fechar", "encerrar", "tá bom", "beleza", "show", "perfeito", "depois eu vejo", "fica pra depois", "baixa prioridade". TAMBÉM ativar quando agente cogitar terminar trabalho produtivo (≥3 PRs mergeados na sessão OR ≥1 ADR proposto OR ≥4h trabalho). Skill canônica que CARREGA conteúdo R12 PROTOCOLO inline NO MOMENTO do trigger (vs Tier A always-on que carrega no SessionStart e perde em sessão longa). Origem 2026-05-28 Wagner — sessão Larissa 17 PRs faltou cumprir R12 passo 3 porque conteúdo saiu do contexto após 200+ turnos. Wagner palavras textuais "mas não está funcionando porque? se existe mas não funciona ta errado. como colocar para funcionar? qual momento tem que ser ativado?". Solução: ativação lazy via description-match no momento exato vs eager always-on. Pareada com hook UserPromptSubmit `force-r12-closing-signal.ps1` (defesa em depth).
+trust_level: L2
+owner: wagner
+parent_mission: meta-skill-roi-erp-autonomo
+tier: B
+parent_adr: 0130
+---
+
+# Encerrar sessão — ativação lazy de R12 PROTOCOLO
+
+> **Wagner palavras textuais 2026-05-28:**
+> *"mas não está funcionando porque????? se existe mas não funciona ta errado. como colocar para funcionar? qual momento tem que ser ativado?"*
+>
+> Catalogou exatamente o gap: R12 do PROTOCOLO-WAGNER-SEMPRE existe desde 2026-05-17 mas é **regra passiva**. Carregada Tier A no SessionStart, sai de contexto em sessão longa (200+ turnos / 4h+). Esta skill é o **mecanismo de ativação lazy** — dispara via description-match no momento exato dos trigger words.
+
+## Por que existir (não é redundante com R12)
+
+| Mecanismo | Tipo carga | Quando dispara | Risco |
+|---|---|---|---|
+| R12 PROTOCOLO-WAGNER-SEMPRE | Eager (SessionStart) | Tier A always-on | Sai de contexto sessão longa |
+| **Skill `encerrar-sessao`** (esta) | **Lazy (description-match)** | **No momento do trigger word** | **Garantido** |
+| Hook `force-r12-closing-signal.ps1` | UserPromptSubmit | Antes do Claude responder | Defesa em depth |
+
+3 camadas = R12 dispara mesmo em sessão de 8h+ com 17 PRs.
+
+## Quando ATIVAR (description-match)
+
+Trigger words que **DEVEM** disparar a skill (description vem do header acima — keywords explícitas):
+
+### Wagner explícito (qualquer um)
+- "encerrar", "encerre", "encerra"
+- "fim", "fechar", "fecha"
+- "vamos parar", "para aqui"
+- "continua depois", "outra sessão", "próxima sessão"
+- "salvar tudo", "salve as memórias", "salve no protocolo"
+- "vai pra MCP continua depois"
+- "tchau", "obrigado", "valeu"
+- "tá bom", "beleza", "show", "perfeito"
+- "depois eu vejo", "fica pra depois", "baixa prioridade"
+
+### Auto-detect produtivo (cogitar antes de Wagner falar)
+- ≥3 PRs mergeados na sessão atual
+- ≥1 ADR `status: proposto` criado
+- ≥4h trabalho consecutivo
+- Wagner aprovou item final E não introduziu novo escopo por 2+ turnos
+
+### Bloqueio externo (encerra estado parcial)
+- GraphQL rate-limit esgotado
+- biz=4 inacessível (Wagner-account só vê biz=1)
+- SSH Hostinger down
+
+## Os 6 passos (idênticos a R12)
+
+Quando ativada, executa **OBRIGATORIAMENTE** os 5 passos de R12 + 1 reforço:
+
+### Passo 1 — MCP-first checklist (snapshot pro handoff)
+```
+mcp__oimpresso__cycles-active                   # cycle ativo + goals + drift
+mcp__oimpresso__my-work                         # tasks DOING/REVIEW/TODO
+Glob memory/handoffs/2026-MM-*.md               # handoffs irmãos
+mcp__oimpresso__decisions-search since:<data>   # ADRs aceitas
+```
+
+### Passo 2 — Handoff append-only
+Path: `memory/handoffs/YYYY-MM-DD-HHMM-<slug-kebab>.md` (~30-80 linhas máximo)
+
+Estrutura obrigatória:
+- Frontmatter: `date / hour BRT / topic / duration / authors`
+- `## Estado MCP no momento` (snapshot passo 1)
+- `## O que aconteceu` (narrativa interpretativa)
+- `## Artefatos gerados` (arquivos + linhas + canon path)
+- `## Persistência` (3 canais: git, MCP, BRIEFING quando aplicável)
+- `## Próximos passos pra retomar` (comando único)
+- `## Lições catalogadas` (especialmente violações de protocolo)
+- `## Pointers detalhados` (consultar on-demand — NÃO duplicar conteúdo)
+
+### Passo 3 — Atualizar índice `memory/08-handoff.md`
+- Linha NO TOPO da lista "Últimos handoffs"
+- Formato: `[YYYY-MM-DD HH:MM — Título curto (chave: PRs/ADRs/métricas)](handoffs/...)` + parêntese denso
+
+### Passo 4 — Commit + push (worktree filha OK)
+1 commit com handoff + índice. Webhook GitHub→MCP propaga em ~2min.
+
+### Passo 5 — Reportar fechamento ≤8 linhas
+Tabela "passos do protocolo + ✅/❌" + caveats + branch final + próxima ação.
+
+### Passo 6 — Citar explícito skill + R12 no report
+> "Cumprindo R12 PROTOCOLO via skill `encerrar-sessao` (ativação lazy)."
+
+Garante auditoria do mecanismo (Wagner pode verificar que disparou).
+
+## Sinal de violação (defesa em depth se skill falhar)
+
+Hook `force-r12-closing-signal.ps1` detecta os mesmos triggers no UserPromptSubmit e injeta `<system-reminder>` forçando execução R12. Se nem skill nem hook dispararem, Wagner cobra "esta esquecendo das regras de fechamento" — reincidência ativa hook P2 dormente bloqueador.
+
+## Heurística de duração
+
+| Sinal | Skill comportamento |
+|---|---|
+| Sessão <2h, 0-1 PRs | Pula passo 1-2 (session log) — só handoff curto |
+| Sessão 2-4h, 2-3 PRs | Executa 6 passos completos |
+| Sessão ≥4h, ≥4 PRs (épico) | Executa 6 passos + atualiza BRIEFING.md módulos tocados (skill `brief-update` Tier B auto-trigger) |
+
+## Pareada com
+
+- [R12 PROTOCOLO-WAGNER-SEMPRE](../../memory/reference/PROTOCOLO-WAGNER-SEMPRE.md) — origem da regra (texto canon)
+- [Hook `force-r12-closing-signal.ps1`](../../.claude/hooks/force-r12-closing-signal.ps1) — camada 2 (UserPromptSubmit)
+- [ADR 0130 — handoff append-only MCP-first](../../memory/decisions/0130-handoff-append-only-mcp-first.md) — base
+- [Skill `memory-sync`](../memory-sync/SKILL.md) — Tier B, push pro git canon
+- [Skill `brief-update`](../brief-update/SKILL.md) — Tier B, atualiza BRIEFING.md módulos
+- [Skill `continuar`](../continuar/SKILL.md) — counterpart (mesma sessão fecha → próxima abre)
+
+## Anti-padrões
+
+| ❌ Errado | ✅ Certo |
+|---|---|
+| User digitou "encerrar" — Claude responde sem disparar skill | Skill DEVE disparar (description-match Tier B) |
+| Cumprir R12 intuitivo sem citar | Citar explícito "Cumprindo R12 via skill" no report |
+| Handoff de 300+ linhas duplicando session log | Handoff 30-80 linhas com pointers |
+| Aceitar ADR sozinho sem Wagner confirmar | Espera "aceito" textual + sed batch |
+| Webhook sync não-confirmado | Aguarda 2min + valida via `tasks-list` |
+
+## Origem (rastreabilidade canon)
+
+- 2026-05-17: R12 criada no PROTOCOLO ([commit `stupefied-noether-89f83d`](../../memory/reference/PROTOCOLO-WAGNER-SEMPRE.md))
+- 2026-05-28 sessão Larissa: R12 não disparou em 17 PRs ~8h. Wagner cobrou. Eu cumpri 4/5 intuitivo + corrigi passo 3 após cobrança.
+- 2026-05-28 mesma sessão: Wagner perguntou "como colocar pra funcionar? qual momento tem que ser ativado?". Esta skill + hook companion respondem.
+
+ROI: cada R12 cumprido = ~10-20k tokens economizados na próxima sessão (vs re-aprender contexto). Em ~3 sessões grandes/semana = 1-3M tokens/ano.

--- a/memory/reference/PROTOCOLO-WAGNER-SEMPRE.md
+++ b/memory/reference/PROTOCOLO-WAGNER-SEMPRE.md
@@ -332,6 +332,27 @@ Sinais de "Wagner está fechando" — QUALQUER um:
 
 **Skill correlata:** [`memory-sync`](../../.claude/skills/memory-sync/SKILL.md) Tier C (dispara `git push` pós-edit em `memory/`, complementa R12 mas NÃO substitui — R12 é orchestrador do checklist).
 
+### ⚠️ Mecanismos de ATIVAÇÃO no momento certo (catalogado 2026-05-28)
+
+R12 é regra **passiva**. Wagner 2026-05-28 cobrou: *"mas não está funcionando porque? se existe mas não funciona ta errado. como colocar pra funcionar? qual momento tem que ser ativado?"*. Em sessão longa (200+ turnos / 8h+), Tier A always-on sai do contexto Claude. R12 precisa de **3 camadas** de ativação:
+
+| Camada | Mecanismo | Quando dispara | Garantia |
+|---|---|---|---|
+| 1 | Skill [`wagner-protocol-enforce`](../../.claude/skills/wagner-protocol-enforce/SKILL.md) Tier A | SessionStart (eager) | Sai do contexto em sessão longa |
+| 2 | Skill [`encerrar-sessao`](../../.claude/skills/encerrar-sessao/SKILL.md) Tier B | **description-match LAZY no trigger word** | **Garantido — recarrega R12 inline** |
+| 3 | Hook [`force-r12-closing-signal.ps1`](../../.claude/hooks/force-r12-closing-signal.ps1) | **UserPromptSubmit antes do Claude responder** | **Garantido — injeta `<system-reminder>`** |
+
+Camada 2 + 3 = defesa em depth. Mesmo em sessão de 17 PRs / 8h+, ao detectar pattern de fechamento R12 dispara via skill description-match OU hook UserPromptSubmit.
+
+**Trigger words canônicos** (consultar [skill encerrar-sessao description](../../.claude/skills/encerrar-sessao/SKILL.md) pra lista completa):
+
+- Explícito: `encerrar` · `fim de sessão` · `vamos parar` · `continua depois` · `salve as memórias` · `outra sessão` · `vai pra MCP`
+- Cortesia: `tchau` · `obrigado` · `valeu` · `tá bom` · `beleza` · `show` · `perfeito`
+- Adiamento: `depois eu vejo` · `fica pra depois` · `baixa prioridade`
+- Auto-detect: ≥3 PRs mergeados · ≥1 ADR proposto · ≥4h trabalho
+
+**CITAR EXPLÍCITO no report final:** `"Cumprindo R12 PROTOCOLO via skill encerrar-sessao (ativação lazy via hook UserPromptSubmit)"`. Garante auditoria do mecanismo — Wagner verifica que disparou.
+
 ---
 
 ## Como Claude detecta violação no meio da sessão (auto-check)


### PR DESCRIPTION
## Wagner cobrou hoje

> *"mas não está funcionando porque?????? se existe mas não funciona ta errado. como colocar para funcionar? qual momento tem que ser ativado?"*

R12 PROTOCOLO existe desde 2026-05-17 mas é **regra passiva**. Em sessão longa (200+ turnos / 8h+) sai do contexto. Falhou hoje na sessão Larissa de 17 PRs — cumpri 4/5 passos intuitivos.

## Solução — 3 camadas defesa em depth

| Camada | Tipo | Garantia |
|---|---|---|
| 1 | Skill `wagner-protocol-enforce` Tier A (existente) | eager SessionStart |
| 2 | Skill `encerrar-sessao` Tier B (**NOVA**) | description-match LAZY no momento exato |
| 3 | Hook `force-r12-closing-signal.ps1` (**NOVO**) | UserPromptSubmit injeta system-reminder antes do Claude responder |

## Trigger words (regex case-insensitive)

`encerrar` · `fim de sessão` · `continua depois` · `salve as memórias` · `outra sessão` · `vai pra MCP` · `tchau` · `obrigado` · `valeu` · `depois eu vejo` · `baixa prioridade` · etc

## Mudanças

- [`.claude/skills/encerrar-sessao/SKILL.md`](.claude/skills/encerrar-sessao/SKILL.md) — Tier B, ~150 LOC
- [`.claude/hooks/force-r12-closing-signal.ps1`](.claude/hooks/force-r12-closing-signal.ps1) — UserPromptSubmit hook, ~90 LOC
- [`.claude/settings.json`](.claude/settings.json) — entry `UserPromptSubmit` (event novo no projeto, primeiro hook nesse evento)
- [`memory/reference/PROTOCOLO-WAGNER-SEMPRE.md`](memory/reference/PROTOCOLO-WAGNER-SEMPRE.md) — R12 ganha seção 'Mecanismos de Ativação' citando 3 camadas

## Validação próxima sessão

Wagner digita "encerrar" → skill disp + hook injeta system-reminder forçando R12 → Claude cita explícito "Cumprindo R12 via skill encerrar-sessao" no report → auditoria visível.

🤖 Generated with [Claude Code](https://claude.com/claude-code)