### PR TITLE
feat(infra): Onda 5 audit-to-backlog loop fechado — ADR 0213 (R10 raiz)

### DIFF
--- a/.claude/hooks/audit-creates-tasks.mjs
+++ b/.claude/hooks/audit-creates-tasks.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// Hook PostToolUse(Write) — detecta tasks órfãs em audit doc + propõe tasks-create MCP.
+//
+// **Cross-platform** (Node.js — Windows/macOS/Linux). Lição R12 2026-05-28
+// aplicada: NUNCA .ps1 (Windows-only). Funciona pra todo dev do time MCP.
+//
+// **Mecanismo 2 do ADR 0213** (audit-to-backlog loop fechado).
+//
+// Origem: R10 sessão Larissa 2026-05-28 — audit catalogou 11 gaps, 6 viraram
+// órfãos no doc (fora do MCP backlog). 24h depois diagnóstico leu snapshot
+// estático e listou 2 gaps JÁ fechados. Hook fecha o loop.
+//
+// Como funciona:
+//   1. PostToolUse(Write) recebe JSON via stdin com tool_input.file_path + tool_input.content
+//   2. Se path matcha `memory/sessions/*-audit-*.md` OU `memory/requisitos/*/AUDIT-*.md`
+//   3. Parse linhas `- [ ] TASK[<owner>](P\d): <desc>` SEM `<!-- TASK_CREATED -->` ao lado
+//   4. Se achou N tasks órfãs → emite system-reminder pro Claude propor tasks-create batch
+//   5. Sem match → exit 0 silencioso (zero overhead em 99% dos Writes)
+//
+// NÃO cria task automaticamente — só LEMBRA Claude de propor (Wagner confirma 1×).
+// Respeita ADR 0105: gap dormente usa `<!-- TASK_IGNORED: razão -->` e não dispara.
+//
+// Refs: ADR 0213 Mecanismo 2 · skill audit-to-backlog · template _TEMPLATE-audit.md
+
+import { stdin } from 'node:process';
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString('utf8');
+}
+
+/** Path matcha um audit doc? */
+function isAuditPath(filePath) {
+  if (!filePath) return false;
+  const p = filePath.replace(/\\/g, '/');
+  // memory/sessions/*-audit-*.md  OU  memory/requisitos/<X>/AUDIT-*.md
+  return (
+    /memory\/sessions\/\d{4}-\d{2}-\d{2}-audit-.+\.md$/i.test(p) ||
+    /memory\/requisitos\/[^/]+\/AUDIT-.+\.md$/i.test(p)
+  );
+}
+
+(async () => {
+  try {
+    const raw = await readStdin();
+    if (!raw) process.exit(0);
+
+    let payload;
+    try {
+      payload = JSON.parse(raw);
+    } catch {
+      process.exit(0);
+    }
+
+    // PostToolUse payload: tool_name + tool_input
+    const toolName = payload.tool_name;
+    if (toolName !== 'Write' && toolName !== 'Edit') process.exit(0);
+
+    const filePath = payload.tool_input?.file_path;
+    if (!isAuditPath(filePath)) process.exit(0);
+
+    // Conteúdo escrito: Write usa .content, Edit usa .new_string
+    const content = payload.tool_input?.content ?? payload.tool_input?.new_string ?? '';
+    if (!content) process.exit(0);
+
+    // Parse linhas TASK[owner](Px): desc
+    // Captura tasks SEM TASK_CREATED na mesma linha OU linha seguinte
+    const lines = content.split('\n');
+    const taskPattern = /^\s*-\s*\[ \]\s*TASK\[([a-z]+)\]\((P[0-3])\):\s*(.+)$/i;
+    const orphanTasks = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const m = lines[i].match(taskPattern);
+      if (!m) continue;
+
+      // Já tem TASK_CREATED nesta linha ou nas próximas 4 (bullets Onde/Esforço/Impact)?
+      const window = lines.slice(i, Math.min(i + 5, lines.length)).join('\n');
+      if (window.includes('TASK_CREATED') || window.includes('TASK_IGNORED')) {
+        continue; // já linkada OR ignorada conscientemente
+      }
+
+      orphanTasks.push({
+        owner: m[1],
+        priority: m[2],
+        desc: m[3].trim().slice(0, 100),
+      });
+    }
+
+    if (orphanTasks.length === 0) process.exit(0);
+
+    // Emite system-reminder
+    const taskList = orphanTasks
+      .map((t, i) => `  ${i + 1}. [${t.owner}](${t.priority}) ${t.desc}`)
+      .join('\n');
+
+    const reminder = `📋 **ADR 0213 — Audit-to-backlog: ${orphanTasks.length} task(s) órfã(s) detectada(s)** (hook \`audit-creates-tasks.mjs\`)
+
+Path: \`${filePath.replace(/\\/g, '/')}\`
+
+Tasks no audit SEM \`<!-- TASK_CREATED -->\` correspondente:
+
+${taskList}
+
+**AÇÃO (ADR 0213 Mecanismo 2):**
+1. Propor ao Wagner criar estas ${orphanTasks.length} task(s) via \`tasks-create\` MCP em batch (NÃO criar sem confirmação 1×)
+2. Após Wagner confirmar + criar: escrever \`<!-- TASK_CREATED: US-MOD-NNN -->\` ao lado de cada item no audit doc
+3. Gap dormente consciente (ADR 0105 cliente-como-sinal): marcar \`<!-- TASK_IGNORED: razão -->\` em vez de criar
+
+Skill \`audit-to-backlog\` carrega o fluxo completo. NÃO deixar gap órfão — foi o R10 raiz da sessão Larissa.`;
+
+    process.stdout.write(reminder);
+    process.exit(0);
+  } catch {
+    process.exit(0);
+  }
+})();

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -115,6 +115,15 @@
             "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/post-merge-ui-smoke-required.ps1"
           }
         ]
+      },
+      {
+        "matcher": "Write|Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node .claude/hooks/audit-creates-tasks.mjs"
+          }
+        ]
       }
     ],
     "Stop": [

--- a/.claude/skills/audit-to-backlog/SKILL.md
+++ b/.claude/skills/audit-to-backlog/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: audit-to-backlog
+mission: "Fechar o loop audit → MCP backlog → ação. Gap catalogado em audit NUNCA vira órfão invisível pra próxima sessão."
+description: ATIVAR quando user pedir "transformar audit em tasks", "levar audit X pro backlog", "criar tasks do audit", "/audit-to-backlog <doc>", OU quando agente escreve/lê audit doc em `memory/sessions/*-audit-*.md` ou `memory/requisitos/*/AUDIT-*.md` com itens `❌`/`🟡`/`TASK[owner](Px)` sem `TASK_CREATED` correspondente. Generaliza `comparativo-do-modulo` (que só cobre audits Capterra de módulo) pra QUALQUER audit interno — Sells/Create vs Blade, audit de processo, postmortem, bug investigation. Lê audit → cruza com MCP backlog (tasks-list) pra detectar duplicatas → propõe batch tasks-create com parent_audit metadata → Wagner confirma 1× → cria tasks + escreve cross-link no audit. NÃO cria tasks sem confirmação humana (publication-policy). Pareada com hook audit-creates-tasks.mjs (Mecanismo 2).
+type: process-skill
+status: active
+version: 1.0.0
+trust_level: L2
+owner: wagner
+created_at: 2026-05-28
+parent_adr: 0213
+parent_mission: meta-skill-roi-erp-autonomo
+tier: B
+---
+
+# Audit-to-backlog — loop fechado audit → MCP task
+
+> **Mecanismo 3 do [ADR 0213](../../memory/decisions/0213-audit-creates-tasks-loop-fechado.md).** Generaliza [`comparativo-do-modulo`](../comparativo-do-modulo/SKILL.md) (audits Capterra) pra QUALQUER audit interno.
+
+## Por que existe (R10 raiz)
+
+Sessão Larissa 2026-05-28: audit `2026-05-27-audit-sells-create-vs-blade-larissa.md` catalogou 11 gaps `❌`. R5/R6 atacou 5, **6 ficaram órfãos no doc** (fora do MCP backlog). 24h depois, diagnóstico Wagner-style "quais erros podem acontecer?" consultou o **snapshot estático** do audit e listou 2 gaps **já fechados** em commits do mesmo dia.
+
+**Causa raiz:** audit doc é estático, MCP backlog é vivo. Sem ponte, gaps viram órfãos invisíveis. Esta skill é a ponte.
+
+## Quando ATIVAR (3 modos)
+
+| Modo | Gatilho | Output |
+|---|---|---|
+| **A. Explícito** | "transformar audit em tasks", "/audit-to-backlog <doc>", "levar audit pro backlog" | Executa fluxo completo |
+| **B. Hook-triggered** | Hook `audit-creates-tasks.mjs` detectou tasks órfãs no Write → injetou system-reminder | Propõe batch ao Wagner |
+| **C. Auto-detect** | Agente lê audit doc com `❌`/`🟡`/`TASK[...]` sem `TASK_CREATED` | Sugere rodar a skill |
+
+## Fluxo (6 passos)
+
+### 1. Ler audit doc completo
+`Read memory/sessions/<doc>-audit-*.md` (ou path informado).
+
+### 2. Extrair itens acionáveis
+Prioriza convenção parseável `TASK[owner](Px): desc`. Se audit usa só `❌`/`🟡` (formato antigo), extrair manualmente:
+- `❌ AUSENTE` → candidato P1/P2
+- `🟡 PARCIAL` → candidato P2/P3
+- `✅ APROVADO` → ignorar (já feito)
+
+### 3. Cruzar com MCP backlog (detectar duplicatas)
+```
+mcp__oimpresso__tasks-list module:<X> status:todo
+mcp__oimpresso__tasks-list module:<X> status:doing
+```
+Pra cada item do audit, checar se já existe task similar (título/descrição match). **Crítico** — evita o erro inverso (criar task duplicada de algo já no backlog OU já fechado).
+
+### 4. Cruzar com PRs recentes (detectar já-fechados)
+```
+gh pr list --state merged --search "<keyword>" --limit 20
+```
+Item do audit que já foi fechado em PR mergeado → marcar `<!-- TASK_DONE: #PR -->` em vez de criar task. **Isto previne exatamente o R10** (listar gap já resolvido).
+
+### 5. Propor batch `tasks-create` ao Wagner (confirmação 1×)
+Apresentar tabela:
+| # | Gap | Módulo | Prio | Esforço | Status detectado |
+|---|---|---|---|---|---|
+| 1 | ... | Sells | P1 | S | NOVO (criar) |
+| 2 | ... | Sells | P2 | M | DUPLICATA US-SELL-099 (skip) |
+| 3 | ... | Sells | P3 | L | JÁ-FECHADO PR #1832 (marcar DONE) |
+
+Wagner confirma **1× batch** (não 1-a-1). Pra cada NOVO confirmado:
+```
+mcp__oimpresso__tasks-create module:<X> title:"..." priority:pN estimate_h:N
+```
+Com metadata `parent_audit:<slug-do-audit>` pra drill-down reverso.
+
+### 6. Escrever cross-link no audit doc
+Após criar, editar o audit:
+- Item criado → `<!-- TASK_CREATED: US-MOD-NNN -->` ao lado
+- Item duplicado → `<!-- TASK_CREATED: US-MOD-NNN (pré-existente) -->`
+- Item já-fechado → `<!-- TASK_DONE: #PR -->`
+- Gap dormente consciente (ADR 0105) → `<!-- TASK_IGNORED: razão -->`
+
+Audit doc vira sincronizado com MCP backlog. Hook `audit-creates-tasks.mjs` não dispara mais (todos linkados).
+
+## Anti-padrões
+
+| ❌ Errado | ✅ Certo |
+|---|---|
+| Criar task de cada `❌` sem cruzar backlog | Passo 3+4 detecta duplicata/já-fechado primeiro |
+| Criar tasks sem Wagner confirmar | Batch + confirmação 1× (publication-policy) |
+| Deixar audit doc sem cross-link após criar | Passo 6 obrigatório — senão hook redispara |
+| Forçar task em gap dormente | `TASK_IGNORED: razão` (respeitando ADR 0105 cliente-como-sinal) |
+
+## Pareada com
+
+- [ADR 0213](../../memory/decisions/0213-audit-creates-tasks-loop-fechado.md) — loop fechado (5 mecanismos)
+- [Hook `audit-creates-tasks.mjs`](../../.claude/hooks/audit-creates-tasks.mjs) — Mecanismo 2 (PostToolUse Write)
+- [Template `_TEMPLATE-audit.md`](../../memory/sessions/_TEMPLATE-audit.md) — Mecanismo 1 (convenção)
+- [`comparativo-do-modulo`](../comparativo-do-modulo/SKILL.md) — irmã (audits Capterra de módulo)
+- [ADR 0070](../../memory/decisions/0070-jira-style-task-management.md) — Jira-style task management
+- [ADR 0105](../../memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — cliente-como-sinal (justifica TASK_IGNORED)
+
+## Origem
+
+R10 sessão Larissa 2026-05-28. Wagner não pediu explicitamente esta skill, mas o dossier estado-da-arte 6 frentes (Frente 4 audit-to-backlog) + ADR 0213 catalogaram o gap. Esta skill + hook + template + (futuro) workflow CI + health-check = 5 mecanismos do loop fechado.
+
+ROI: cada audit que vira backlog sincronizado evita "diagnose outdated" na próxima sessão (~10k tokens desperdiçados re-analisando gaps já fechados). Mais: time futuro (Felipe/Maiara/Eliana/Luiz) vê backlog vivo, não doc estático.

--- a/memory/sessions/_TEMPLATE-audit.md
+++ b/memory/sessions/_TEMPLATE-audit.md
@@ -1,0 +1,89 @@
+<!--
+  TEMPLATE AUDIT — base canônica pra audits internos (ADR 0213).
+  Copie pra `memory/sessions/{{YYYY-MM-DD}}-audit-{{slug-kebab}}.md`
+  (filename DEVE conter `audit` pra hook `audit-creates-tasks.mjs` disparar).
+
+  Diferença vs _TEMPLATE.md (session log normal):
+    - Audit usa convenção parseável `TASK[owner](Px): desc` em vez de `❌` solto
+    - Hook PostToolUse detecta as linhas TASK[...] e propõe `tasks-create` MCP em batch
+    - Items que viram task ganham `<!-- TASK_CREATED: US-MOD-NNN -->` ao lado
+
+  Por que: R10 da sessão Larissa 2026-05-28 — audit catalogou 11 gaps,
+  6 ficaram órfãos no doc (fora do MCP backlog). 24h depois o diagnóstico
+  consultou snapshot estático e listou 2 gaps JÁ fechados. Convenção +
+  hook fecham o loop audit → backlog → ação.
+
+  Override: `<!-- schema-allowlist: <razão> -->`.
+-->
+---
+date: {{YYYY-MM-DD}}
+hour: "{{HH:MM BRT}}"
+duration: "{{2.5h}}"
+topic: "Auditoria {{tema}} — {{escopo}}"
+authors: [W, C]
+outcomes:
+  - "{{N gaps catalogados}}"
+prs: []
+us:  []
+related_adrs: ["0213-audit-creates-tasks-loop-fechado"]
+audit: true   # marca como audit (vs session log normal)
+---
+
+# Auditoria {{YYYY-MM-DD}} — {{título curto}}
+
+## TL;DR
+
+{{1-3 frases: o que foi auditado, quantos gaps, prioridade dominante}}
+
+## Escopo
+
+{{O que foi auditado e o que ficou de fora}}
+
+## Inventário (3 buckets)
+
+### ✅ APROVADO (paridade OK)
+- {{item já implementado}}
+
+### 🟡 PARCIAL (existe mas incompleto)
+- {{item parcial}}
+
+### ❌ AUSENTE (gap real)
+- {{gap não implementado}}
+
+---
+
+## Tasks acionáveis (convenção ADR 0213 — parseável pelo hook)
+
+> Cada gap que vira task usa o pattern abaixo. Hook `audit-creates-tasks.mjs`
+> detecta no Write e propõe `tasks-create` MCP em batch (Wagner confirma 1×).
+> Após criar, hook escreve `<!-- TASK_CREATED: US-MOD-NNN -->` ao lado.
+
+- [ ] TASK[claude](P1): {{Descrição curta do gap acionável}}
+  - Onde: {{path/arquivo.tsx:linha}}
+  - Esforço: {{S | M | L}}
+  - Impact: {{quem sofre + como}}
+
+- [ ] TASK[wagner](P0): {{Gap que precisa decisão Wagner}}
+  - Onde: {{path}}
+  - Esforço: {{S/M/L}}
+  - Impact: {{...}}
+
+<!--
+  Gaps que NÃO viram task (decisão consciente) devem usar:
+  <!-- TASK_IGNORED: razão (ex: dormente até sinal qualificado ADR 0105) -->
+  pra não disparar warning no workflow audit-orphan-check.yml.
+-->
+
+## Recomendação de ataque
+
+{{Ordem priorizada — qual task primeiro e por quê}}
+
+## Refs
+
+- ADR 0213 — Audit docs criam MCP tasks (loop fechado)
+- {{outras refs}}
+
+---
+
+**Arquivo:** `memory/sessions/{{YYYY-MM-DD}}-audit-{{slug}}.md`
+**Status:** audit-only (nenhum código alterado durante a auditoria)


### PR DESCRIPTION
## Onda 5 — fecha R10 raiz (último ADR não-implementado)

Implementa **ADR 0213** (audit docs criam MCP tasks). Gap catalogado em audit NUNCA mais vira órfão invisível.

### Origem (R10 sessão Larissa)

Audit `2026-05-27-audit-sells-create-vs-blade-larissa.md` catalogou 11 gaps `❌`. 6 ficaram órfãos no doc. 24h depois meu diagnóstico leu o snapshot estático e listou **2 gaps já fechados** em PRs do mesmo dia. Esta onda fecha o loop audit → backlog → ação.

### 3 mecanismos core (de 5 do ADR 0213)

| Mec | Arquivo | Função |
|---|---|---|
| 1 | `memory/sessions/_TEMPLATE-audit.md` | Convenção parseável `TASK[owner](Px): desc` + cross-link |
| 2 | `.claude/hooks/audit-creates-tasks.mjs` | PostToolUse(Write/Edit) detecta tasks órfãs → system-reminder |
| 3 | `.claude/skills/audit-to-backlog/SKILL.md` | Tier B — fluxo 6 passos (lê audit → cruza backlog → cruza PRs → batch → confirma → cross-link) |

Mecanismos 4 (CI workflow) + 5 (health-check) ficam follow-up (safety-nets — US-INFRA-029/030).

### Cross-platform (lição R12 aplicada)

Hook é **`.mjs` Node** (Windows/macOS/Linux) — **NÃO `.ps1`**. Funciona em todo computador do time MCP. Wagner 2026-05-28: *"tem que funcionar no MCP em todos os computadores"*.

### Validação local (4 cenários hook) — todos PASS

1. audit com task órfã → dispara system-reminder
2. task com TASK_CREATED → silencioso
3. path não-audit → silencioso
4. gap TASK_IGNORED consciente → silencioso (respeita ADR 0105)

### Anti-R10 embutido

Skill passo 4 cruza com PRs mergeados (`gh pr list --search`) → item já-fechado vira `TASK_DONE: #PR` em vez de task duplicada. **Previne exatamente o erro que cometi** (listar gap já resolvido).

## Refs

- [ADR 0213](memory/decisions/0213-audit-creates-tasks-loop-fechado.md) — último dos 6 ADRs prevenção, agora implementado
- [ADR 0105](memory/decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) — TASK_IGNORED dormente
- ADR 0089 comparativo-do-modulo — skill irmã (template)

## Infra Contract

### 1. Happy path
Hook dev-side. Próximo audit doc com `TASK[claude](P1): ...` órfã → hook injeta system-reminder propondo `tasks-create` batch.

### 2. Regression adjacent
Hook só dispara em paths `*-audit-*.md` / `AUDIT-*.md`. Session logs normais + outros Writes = silencioso (test 3 confirma).

### 3. Environment delta
- [x] Validação local Node: 4 cenários PASS
- [ ] CI: hook é client-side Claude Code, não roda em CI — N/A
- [ ] Real: próximo audit doc real dispara

### 4. Rollback
Reverter PR. Remove hook entry settings.json + deleta 3 arquivos. Zero impacto runtime.

### 5. Evidência
Hook testado 4 cenários. Skill + template são docs passivos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
