### PR TITLE
feat(governance): NpmAuditChecker — frontend supply chain (ADR 0223)

### DIFF
--- a/.github/workflows/governance-drift.yml
+++ b/.github/workflows/governance-drift.yml
@@ -34,8 +34,14 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
-      - name: Install dependencies (no-dev)
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install PHP dependencies (no-dev)
         run: composer install --no-progress --no-interaction --prefer-dist
+      - name: Install Node dependencies (for npm_audit checker — ADR 0223)
+        run: npm ci --no-audit --no-fund || npm install --no-audit --no-fund
       - name: Run governance:audit on PR (block-level fail)
         run: |
           # PR mode: --diff-only + fail-on=block (CI gate)
@@ -67,8 +73,14 @@ jobs:
       - uses: shivammathur/setup-php@v2
         with:
           php-version: '8.4'
-      - name: Install dependencies
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+      - name: Install PHP dependencies
         run: composer install --no-progress --no-interaction --prefer-dist
+      - name: Install Node dependencies (for npm_audit checker — ADR 0223)
+        run: npm ci --no-audit --no-fund || npm install --no-audit --no-fund
       - name: Run governance:audit --all
         run: |
           # Schedule mode: --all + JSON output pra inspeção; --no-persist porque

--- a/Modules/Governance/Config/config.php
+++ b/Modules/Governance/Config/config.php
@@ -72,6 +72,7 @@ return [
      */
     'drift_checkers' => [
         \Modules\Governance\Services\Checkers\ComposerAuditChecker::class,       // ADR 0217
+        \Modules\Governance\Services\Checkers\NpmAuditChecker::class,            // ADR 0223 — frontend supply chain
         \Modules\Governance\Services\Checkers\MultiTenantScopeChecker::class,    // ADR 0218 — Tier 0 IRREVOGÁVEL
         \Modules\Governance\Services\Checkers\AdrLinksChecker::class,            // ADR 0219
         \Modules\Governance\Services\Checkers\ChartersFreshnessChecker::class,   // ADR 0220 — adapter charter:audit

--- a/Modules/Governance/Services/Checkers/NpmAuditChecker.php
+++ b/Modules/Governance/Services/Checkers/NpmAuditChecker.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Governance\Services\Checkers;
+
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Process;
+use Modules\Governance\Contracts\DriftChecker;
+use Modules\Governance\Services\DriftCheckResult;
+use Modules\Governance\Services\DriftFinding;
+
+/**
+ * NpmAuditChecker — detecta CVEs em deps Node/npm (frontend stack).
+ *
+ * ADR 0223 (filha de 0216). Complementa ComposerAuditChecker (ADR 0217)
+ * cobrindo o outro lado da stack: React, Inertia, Vite, Tailwind, TypeScript.
+ *
+ * Lições supply chain 2026:
+ * - Shai-Hulud 2.0 wave 4 mai/2026 — 640+ pacotes npm worm
+ * - axios mar/2026 — 5min exposição → 895 repos PR-pushed
+ *
+ * Mecanismo:
+ *   shell-out `npm audit --json` (cwd=base_path), timeout 120s
+ *   parse schema `auditReportVersion: 2` canonical
+ *     `vulnerabilities.<pkg>.{severity, via[], range, isDirect, fixAvailable}`
+ *
+ * Severity map npm → canonical (consistente ComposerAuditChecker):
+ *   critical → critical
+ *   high → high
+ *   moderate → medium
+ *   low → low
+ *   info → info
+ *
+ * Tags: tier_1, security, supply_chain, frontend
+ * Severity baseline: high (CVEs frontend podem permitir XSS/RCE em produção)
+ * Enforcement: warn (findings críticos viram block via --fail-on=block runtime)
+ * Cadence: daily (cron) + on_pr (CI gate)
+ */
+final class NpmAuditChecker implements DriftChecker
+{
+    public function name(): string
+    {
+        return 'npm_audit';
+    }
+
+    public function description(): string
+    {
+        return 'Detecta CVEs em deps npm/package-lock.json (frontend supply chain)';
+    }
+
+    public function tags(): array
+    {
+        return ['tier_1', 'security', 'supply_chain', 'frontend'];
+    }
+
+    public function severity(): string
+    {
+        return 'high';
+    }
+
+    public function enforcement(): string
+    {
+        return 'warn';
+    }
+
+    public function cadence(): string
+    {
+        return 'daily';
+    }
+
+    public function check(array $opts = []): DriftCheckResult
+    {
+        $start = microtime(true);
+
+        if (! file_exists(base_path('package.json')) || ! file_exists(base_path('package-lock.json'))) {
+            return DriftCheckResult::clean(
+                name: $this->name(),
+                duration_ms: 0,
+                metadata: ['skipped' => 'package.json or package-lock.json not found'],
+            );
+        }
+
+        $process = Process::path(base_path())
+            ->timeout(180)
+            ->run(['npm', 'audit', '--json']);
+
+        $durationMs = (int) ((microtime(true) - $start) * 1000);
+
+        // npm audit exit codes:
+        //   0 = no vulnerabilities
+        //   1 = vulnerabilities found
+        //   2+ = error (npm itself failed)
+        $exitCode = $process->exitCode();
+        $stdout = $process->output();
+        $stderr = $process->errorOutput();
+
+        if ($exitCode >= 2) {
+            Log::channel('single')->error('npm_audit checker — npm binary failed', [
+                'exit_code' => $exitCode,
+                'stderr' => mb_substr($stderr, 0, 500),
+            ]);
+
+            return DriftCheckResult::clean(
+                name: $this->name(),
+                duration_ms: $durationMs,
+                metadata: ['error' => 'npm binary unavailable or crashed', 'exit_code' => $exitCode],
+            );
+        }
+
+        $decoded = json_decode($stdout, true);
+        if (! is_array($decoded)) {
+            Log::channel('single')->warning('npm_audit checker — JSON inválido', [
+                'stdout_preview' => mb_substr($stdout, 0, 200),
+            ]);
+
+            return DriftCheckResult::clean($this->name(), $durationMs);
+        }
+
+        $findings = $this->extractFindings($decoded);
+
+        if (count($findings) === 0) {
+            return DriftCheckResult::clean(
+                name: $this->name(),
+                duration_ms: $durationMs,
+                metadata: [
+                    'audited_at' => now()->toIso8601String(),
+                    'audit_report_version' => $decoded['auditReportVersion'] ?? null,
+                ],
+            );
+        }
+
+        return DriftCheckResult::drifted(
+            name: $this->name(),
+            findings: $findings,
+            duration_ms: $durationMs,
+            metadata: [
+                'total_advisories' => count($findings),
+                'audited_at' => now()->toIso8601String(),
+                'highest_severity' => $this->highestSeverity($findings),
+                'severity_counts' => $this->countBySeverity($findings),
+            ],
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $decoded
+     * @return array<int, DriftFinding>
+     */
+    private function extractFindings(array $decoded): array
+    {
+        $findings = [];
+
+        $vulnerabilities = $decoded['vulnerabilities'] ?? [];
+        if (! is_array($vulnerabilities)) {
+            return [];
+        }
+
+        foreach ($vulnerabilities as $packageName => $vulnData) {
+            if (! is_array($vulnData)) {
+                continue;
+            }
+
+            $severity = $this->mapNpmSeverity($vulnData['severity'] ?? 'moderate');
+            $range = (string) ($vulnData['range'] ?? '');
+            $isDirect = (bool) ($vulnData['isDirect'] ?? false);
+            $fixAvailable = $vulnData['fixAvailable'] ?? false;
+            $effects = (array) ($vulnData['effects'] ?? []);
+
+            // Extract advisory details from via[] — pode ter strings (parent pkg) ou objects (advisory)
+            $advisories = [];
+            foreach ((array) ($vulnData['via'] ?? []) as $via) {
+                if (is_array($via) && isset($via['title'])) {
+                    $advisories[] = $via;
+                }
+            }
+
+            if (count($advisories) === 0) {
+                // Vulnerability transitive — só registramos parent + range, sem CVE direto
+                $findings[] = new DriftFinding(
+                    target: (string) $packageName,
+                    target_type: 'npm_package',
+                    severity: $severity,
+                    message: sprintf(
+                        'npm vulnerability %s em %s (range: %s, %s, fix %s). %s',
+                        $severity,
+                        $packageName,
+                        mb_strimwidth($range, 0, 60, '…'),
+                        $isDirect ? 'direct' : 'transitive',
+                        $fixAvailable ? 'available' : 'NOT available',
+                        count($effects) > 0 ? 'Affects: ' . implode(', ', array_slice($effects, 0, 3)) : '',
+                    ),
+                    evidence: [
+                        'package' => $packageName,
+                        'severity_npm' => $vulnData['severity'] ?? null,
+                        'severity_canonical' => $severity,
+                        'range' => $range,
+                        'is_direct' => $isDirect,
+                        'fix_available' => $fixAvailable,
+                        'effects' => $effects,
+                        'via_parents' => array_filter((array) ($vulnData['via'] ?? []), 'is_string'),
+                    ],
+                );
+                continue;
+            }
+
+            foreach ($advisories as $advisory) {
+                $title = $advisory['title'] ?? 'CVE sem título';
+                $url = $advisory['url'] ?? '';
+                $cwe = $advisory['cwe'] ?? [];
+
+                $findings[] = new DriftFinding(
+                    target: (string) $packageName,
+                    target_type: 'npm_package',
+                    severity: $severity,
+                    message: sprintf(
+                        'npm CVE %s em %s — %s. Range: %s. Fix %s. Ref: %s',
+                        $severity,
+                        $packageName,
+                        mb_strimwidth($title, 0, 120, '…'),
+                        mb_strimwidth($range, 0, 60, '…'),
+                        $fixAvailable ? 'available (npm audit fix)' : 'NOT available',
+                        $url,
+                    ),
+                    evidence: [
+                        'package' => $packageName,
+                        'advisory_source' => $advisory['source'] ?? null,
+                        'title' => $title,
+                        'url' => $url,
+                        'cwe' => $cwe,
+                        'severity_npm' => $advisory['severity'] ?? $vulnData['severity'] ?? null,
+                        'severity_canonical' => $severity,
+                        'range' => $range,
+                        'is_direct' => $isDirect,
+                        'fix_available' => $fixAvailable,
+                    ],
+                );
+            }
+        }
+
+        return $findings;
+    }
+
+    private function mapNpmSeverity(string $npmSeverity): string
+    {
+        return match (strtolower(trim($npmSeverity))) {
+            'critical' => 'critical',
+            'high' => 'high',
+            'moderate' => 'medium',
+            'low' => 'low',
+            'info' => 'info',
+            default => 'medium',
+        };
+    }
+
+    /**
+     * @param array<int, DriftFinding> $findings
+     */
+    private function highestSeverity(array $findings): string
+    {
+        $rank = ['critical' => 5, 'high' => 4, 'medium' => 3, 'low' => 2, 'info' => 1];
+        $max = 'info';
+        foreach ($findings as $f) {
+            if (($rank[$f->severity] ?? 0) > ($rank[$max] ?? 0)) {
+                $max = $f->severity;
+            }
+        }
+
+        return $max;
+    }
+
+    /**
+     * @param array<int, DriftFinding> $findings
+     * @return array<string, int>
+     */
+    private function countBySeverity(array $findings): array
+    {
+        $counts = ['critical' => 0, 'high' => 0, 'medium' => 0, 'low' => 0, 'info' => 0];
+        foreach ($findings as $f) {
+            $counts[$f->severity] = ($counts[$f->severity] ?? 0) + 1;
+        }
+
+        return $counts;
+    }
+}

--- a/memory/decisions/0223-npm-audit-checker-frontend-supply-chain.md
+++ b/memory/decisions/0223-npm-audit-checker-frontend-supply-chain.md
@@ -1,0 +1,127 @@
+---
+adr: 0223
+title: NpmAuditChecker — frontend supply chain CVE detection (complementa 0217)
+status: accepted
+date: 2026-05-28
+deciders: [Wagner]
+amends: []
+references:
+  - 0216-governance-drift-framework-driftchecker-plugavel.md
+  - 0217-composer-audit-checker-supply-chain-detection.md
+  - 0222-renovate-config-supply-chain-defense.md
+lifecycle: active
+---
+
+## Contexto
+
+ADR 0217 (ComposerAuditChecker) cobre lado PHP do supply chain. Falta cobertura **frontend** (Node + npm + React + Inertia + Vite + Tailwind + TypeScript).
+
+oimpresso `package.json` + `package-lock.json` existem (Inertia v3 + React 19 + Vite stack). Smoke 2026-05-28 rápido em `npm audit --json` mostrou **vulnerabilidades reais ATIVAS** (engine.io-client, protobufjs, etc.) sem ninguém saber — mesmo gap de ComposerAuditChecker descoberto há ~7h.
+
+### Lições supply chain 2026 (npm específico)
+
+- **Shai-Hulud 2.0** wave 4 mai/2026 — 640+ pacotes npm worm self-replicante
+- **axios npm** mar/2026 — 5min exposição → 895 repos Renovate/Dependabot auto-merged
+- Lock files (`package-lock.json`) NÃO impedem ataque — só registram hash atual, não verificam idoneidade
+
+Renovate config (ADR 0222) é defesa proativa mas demora 7d (cooldown). Sem `npm_audit` daily, ataques entre janelas Renovate passam invisíveis até alguém manualmente rodar `npm audit`.
+
+## Decisão
+
+Implementar `Modules\Governance\Services\Checkers\NpmAuditChecker` (`name='npm_audit'`) **simétrico** ao ComposerAuditChecker:
+
+### Mecanismo
+
+```php
+public function check(array $opts = []): DriftCheckResult
+{
+    if (!file_exists(base_path('package.json'))) return DriftCheckResult::clean(...);
+
+    $process = Process::path(base_path())
+        ->timeout(180)
+        ->run(['npm', 'audit', '--json']);
+
+    // exit 0 = clean, 1 = vulns, 2+ = error
+    // parse schema auditReportVersion: 2:
+    //   vulnerabilities.<pkg>.{severity, via[], range, isDirect, fixAvailable, effects[]}
+}
+```
+
+### Severity mapping npm → canonical
+
+| npm | canonical | Rationale |
+|---|---|---|
+| critical | critical | Tier 0-equivalent (RCE, supply chain compromise) |
+| high | high | XSS exploitable, sensitive data leak |
+| moderate | medium | normalização canon ADR 0216 (5 níveis Datadog) |
+| low | low | DoS, minor info disclosure |
+| info | info | advisory only |
+
+### via[] parsing (transitive vs direct)
+
+npm audit `via[]` pode conter:
+- **string** = nome do parent package (transitive vulnerability — vuln vem de dep do dep)
+- **object** = advisory direto com `{source, title, url, severity, cwe}` (CVE direto no package)
+
+Implementação cria 1 finding por advisory object, ou 1 finding agregado quando só houver string transitives (preservando rastro `via_parents` em evidence).
+
+### Convenções canon (consistentes ADR 0216)
+
+- Severity baseline: `high` (frontend deps podem permitir XSS/RCE em produção)
+- Enforcement: `warn` (findings critical viram block via `--fail-on=block` runtime)
+- Cadence: `daily` (cron 06:35 BRT junto com outros checkers)
+- Tags: `['tier_1', 'security', 'supply_chain', 'frontend']`
+- Persistência: `mcp_alertas_eventos` tipo `drift_npm_audit`
+- Centrifugo: channel `governance:drift`
+
+### Fail-safe quando npm ausente
+
+Se `package.json` OU `package-lock.json` faltarem → `DriftCheckResult::clean` com metadata `skipped`. Se npm binary falhar (exit code ≥ 2) → clean com error metadata + Log channel ALERT. Nunca lança exception (ADR 0216 §exit code semantic).
+
+## Não-goals
+
+- ❌ **Não roda `npm audit fix`** — apenas detecta. Humano decide upgrades (lição supply chain: auto-fix = vetor)
+- ❌ **Não cobre yarn/pnpm** — projeto usa npm canon; outros gerenciadores Sprint 3 ADR 0225 futura
+- ❌ **Não cobre pacotes globais** (`npm install -g`) — apenas deps do projeto
+- ❌ **Não emite RemediationProposal** — humano decide `npm update <pkg>`
+
+## Plano implementação
+
+✅ **Já implementado neste PR**:
+- `Modules\Governance\Services\Checkers\NpmAuditChecker` (~220 linhas)
+- Registrado em `config/governance.php > drift_checkers[]` (posição 2, logo após ComposerAuditChecker)
+- Esta ADR
+
+⏳ **GH Action update (Sprint 2 followup)**:
+- `.github/workflows/governance-drift.yml` precisa adicionar Node setup (`actions/setup-node@v4`) ANTES de chamar `governance:audit` no schedule job
+
+## Consequências
+
+✅ **Boas:**
+- 6 checkers no framework (Composer + Npm + MultiTenant + AdrLinks + Charters + RoutesZombie) cobertura supply chain end-to-end (PHP + JS)
+- Empiricamente justificado: smoke 2026-05-28 mostrou vulns reais (engine.io-client, protobufjs)
+- Renovate (ADR 0222 proativo) + Composer Audit + Npm Audit = defesa em profundidade 3 camadas supply chain
+- Brief Jana 06h ingere `npm.drift_detected` via Centrifugo `governance:drift`
+- ROI: ~3-5s shell-out `npm audit` × daily → economiza ataques supply chain passar invisíveis
+
+⚠️ **Tradeoffs:**
+- `npm audit` adiciona ~3-5s ao `governance:audit --all` daily (aceitável)
+- npm precisa estar instalado em CI runner — adicionar `actions/setup-node@v4` no workflow
+- Performance local Windows: ~2s shell-out npm (testado smoke)
+- npm audit às vezes retorna false positives quando advisory affecta versão major mas oimpresso está em compatibility patch — `range` evidence permite review human
+- Brief Jana pode ficar ruidoso se >5 npm CVEs persistirem — Wagner suprime via exception lifecycle ou roda `npm update`
+
+## Validação
+
+- ⏳ Smoke `php artisan governance:audit --check=npm_audit --json` retorna findings reais
+- ⏳ `governance:audit --all` agora tem 6 checkers
+- ⏳ Pest framework 18/18 verde (não regredir)
+- ⏳ Follow-up Sprint 2: atualizar `.github/workflows/governance-drift.yml` adicionar Node setup
+
+## Notas
+
+- ADR 0223 numeração reservada Sprint 2 — esperada handoff PR #1874
+- npm audit schema `auditReportVersion: 2` é canon npm 7+ (npm 11.4.2 oimpresso usa atual)
+- Sprint 3 futura: `YarnAuditChecker` + `PnpmAuditChecker` se algum sub-módulo migrar de gerenciador
+- Sprint 3 futura: `npm-check-updates`-style proactive (Renovate cobre isto — não duplicar)
+- Wagner pediu "continuar" sessão 2026-05-28 — esta ADR fecha defesa supply chain frontend


### PR DESCRIPTION
## Summary

**6º checker** do framework Drift (ADR 0216). Simétrico ao [ComposerAuditChecker (ADR 0217)](memory/decisions/0217-composer-audit-checker-supply-chain-detection.md) — cobre o lado **JS** da stack (React, Inertia, Vite, Tailwind, TypeScript).

Empiricamente justificado: smoke 2026-05-28 detectou **3 CVEs frontend reais** (engine.io-client, protobufjs, ws) sem ninguém saber — mesmo gap que ComposerAuditChecker.

## Mecanismo

```php
$process = Process::path(base_path())->timeout(180)->run(['npm', 'audit', '--json']);
// parse schema auditReportVersion: 2
// via[] string=transitive parent / object=advisory CVE
```

Severity map npm → canonical (consistente ADR 0216): critical→critical, high→high, **moderate→medium**, low→low, info→info

## Convenções canon

- severity baseline `high` · enforcement `warn` · cadence `daily`
- tags `tier_1, security, supply_chain, frontend`
- persist `mcp_alertas_eventos` tipo `drift_npm_audit`
- channel `governance:drift`
- **fail-safe**: skip clean se `package.json` ausente OU npm binary falha (exit ≥2)

## Wire-up GH workflow

Adiciona `actions/setup-node@v4` + `npm ci` nos 2 jobs (PR scan + scheduled) ANTES de `governance:audit` — npm precisa estar disponível no runner.

## Validação

```
$ php artisan governance:audit --no-persist
✓ composer_audit — 0 findings (2884ms)
⚠ npm_audit — 3 findings (1441ms)         ← NOVO
✓ multi_tenant_scope — 0 findings (12ms)
✓ adr_link_rot — 0 findings (3611ms)
✓ charters_freshness — 0 findings (0ms)
✓ routes_zombie — 0 findings (0ms)
Governance audit: 6 checkers · 5 clean · 1 drifted · 3 findings total
```

- ✅ 6 checkers ativos (cobertura supply chain end-to-end PHP + JS)
- ✅ Pest framework 18/18 verde
- ✅ 3 CVEs detectadas: engine.io-client, protobufjs, ws (todas medium, transitive, `fix_available: true`)

## Follow-up

3 npm CVEs medium ficam pra PR isolado (`npm audit fix` — todas transitive com fix disponível). Não bloqueante (warn enforcement).

## Refs

- [ADR 0223](memory/decisions/0223-npm-audit-checker-frontend-supply-chain.md) mãe
- [ADR 0217 ComposerAuditChecker](memory/decisions/0217-composer-audit-checker-supply-chain-detection.md) (simétrico PHP)
- [ADR 0222 Renovate](memory/decisions/0222-renovate-config-supply-chain-defense.md) (defesa proativa)
- Handoff PR #1874 — Sprint 2 item "NpmAuditChecker"