### PR TITLE
feat(governance): ADR 0225 — recalibra skills Tier A 8→5 (Claude 4.8-aware)

### DIFF
--- a/.claude/hooks/tier-a-banner.ps1
+++ b/.claude/hooks/tier-a-banner.ps1
@@ -1,27 +1,34 @@
-﻿# Tier A Banner - forca lembranca das skills always-on
+﻿# Tier A Banner - forca lembranca das skills Tier A (nucleo seguranca/disciplina)
 # Disparado em SessionStart pelo .claude/settings.json
-# Ver ADR 0094 (Constituicao v2) + ADR 0095 (Skills tiers)
-# G5 (2026-05-15): banner conta 8 LIVE + 1 dormente, em vez de incluir
-# tudo misturado. Wagner: "se organiza, vai entrar o time MCP"
+# Ver ADR 0094 (Constituicao v2) + ADR 0095 (Skills tiers) + ADR 0225 (recalibracao 4.8)
+# 2026-05-28 (ADR 0225): recalibrado 8->5 Tier A. Claude 4.8 (1M context, melhor
+#   instruction-following) torna always-on de skill auto-trigger redundante.
+#   6 rebaixadas pra auto-trigger (disparam por path/intencao no momento exato).
 # 2026-05-15 14h fix-encoding: ASCII puro p/ PowerShell 5.1 compat
 
 Write-Host ""
-Write-Host "=== CONSTITUICAO v2 - 8 SKILLS TIER A LIVE always-on + 1 DORMENTE ==="
+Write-Host "=== CONSTITUICAO v2 - 5 SKILLS TIER A (nucleo) + 6 AUTO-TRIGGER (ADR 0225) ==="
 Write-Host ""
-Write-Host "  LIVE (auto-trigger ativo):"
-Write-Host "  1. brief-first              - chame mcp__oimpresso__brief-fetch PRIMEIRO"
-Write-Host "  2. mcp-first                - tools MCP antes de Read/Glob/Grep filesystem"
-Write-Host "  3. multi-tenant-patterns    - business_id global scope Tier 0 IRREVOGAVEL"
-Write-Host "  4. commit-discipline        - 1 PR = 1 intent, <=300 linhas, sem PII"
-Write-Host "  5. mwart-process            - unico caminho Blade->Inertia 5 fases ADR 0104"
-Write-Host "  6. mwart-comparative V4     - gate visual F1.5+F3 + Cowork loop ADR 0114"
-Write-Host "  7. charter-first            - leia *.charter.md ANTES de editar Pages/*.tsx"
-Write-Host "  8. preflight-modulo NOVO    - ler SPEC+RUNBOOK+ADRs ANTES de Edit Modules/X G1 2026-05-15"
+Write-Host "  TIER A (seguranca/LGPD/disciplina - sempre relevantes):"
+Write-Host "  1. multi-tenant-patterns    - business_id global scope Tier 0 IRREVOGAVEL"
+Write-Host "  2. commit-discipline        - 1 PR = 1 intent, <=300 linhas, sem PII"
+Write-Host "  3. incident-done-checklist  - DoD smoke real ANTES de declarar pronto (R1)"
+Write-Host "  4. memory-first-secret-search - consultar _INDEX-SECRETS ANTES de buscar token"
+Write-Host "  5. hostinger-dns-autonomy   - nao escalar acao automatizavel pro Wagner"
 Write-Host ""
-Write-Host "  DORMENTE (ativa quando feature builder entregar):"
-Write-Host "  - ads-route                 - ativa quando S5 entregar decide ~jul/2026"
+Write-Host "  AUTO-TRIGGER (Tier B - disparam por path/intencao, ADR 0225):"
+Write-Host "  - brief-first               - brief-fetch (conveniencia inicio sessao)"
+Write-Host "  - mcp-first                 - tools MCP antes de filesystem"
+Write-Host "  - mwart-process / -comparative - dispara em Edit Pages/*.tsx"
+Write-Host "  - charter-first             - dispara ao editar tsx com .charter.md"
+Write-Host "  - preflight-modulo          - dispara em Edit Modules/<X>/ (+ hook + proibicoes)"
 Write-Host ""
-Write-Host "  ADRs canon: 0094 Constituicao v2 mae | 0095 Skills tiers | 0104 MWART | 0114 Cowork"
+Write-Host "  PROTOCOLO WAGNER: doc memory/reference/PROTOCOLO-WAGNER-SEMPRE.md (on-demand)"
+Write-Host "    R1 smoke real + R10 aprovacao humana = Tier 0 duro (memory/proibicoes.md)"
+Write-Host ""
+Write-Host "  DORMENTE: ads-route (ativa quando S5 entregar decide ~jul/2026)"
+Write-Host ""
+Write-Host "  ADRs canon: 0094 Constituicao v2 | 0095 Skills tiers | 0225 recalibracao 4.8 | 0104 MWART"
 Write-Host "  Health: php artisan jana:health-check 5 checks SQL diarios"
 Write-Host ""
 Write-Host "=== INVIOLAVEL (Tier 0 sem ADR mae nova) ==="

--- a/.claude/skills/brief-first/SKILL.md
+++ b/.claude/skills/brief-first/SKILL.md
@@ -9,7 +9,7 @@ description: |
   tasks-active, decisions-search). Custo trivial (cache 5min), economia ~27k
   tokens por sessão.
 trust_level: 1
-tier: A
+tier: B
 parent_mission: mission.constituicao-v2
 charter_adr: 0091-daily-brief
 auto_trigger: session_start

--- a/.claude/skills/charter-first/SKILL.md
+++ b/.claude/skills/charter-first/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: charter-first
 description: BLOQUEADOR — ANTES de editar qualquer .tsx que tenha .charter.md ao lado (ex Index.tsx + Index.charter.md), chame tool MCP `charter-fetch <page-id>` pra carregar contrato vivo da página (Mission/Goals/Non-Goals/UX targets/Anti-hooks). Tier A always-on — princípio duro #3 Constituição V2 (Charter > Spec). 26 charters em prod, tool MCP deployed em 2026-05-13.
-tier: A
-always_on: true
+tier: B
+always_on: false
 tier_enforce: hook-pre-tool-use-edit
 parent_adr: 0095
 related_adrs: [0094, 0101]

--- a/.claude/skills/mcp-first/SKILL.md
+++ b/.claude/skills/mcp-first/SKILL.md
@@ -5,7 +5,7 @@ trust_level: L2
 owner: wagner
 parent_mission: meta-skill-roi-erp-autonomo
 charter_adr: 0080
-tier: A
+tier: B
 parent_adr: 0095
 ---
 

--- a/.claude/skills/mwart-comparative/SKILL.md
+++ b/.claude/skills/mwart-comparative/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mwart-comparative
 description: Use SEMPRE antes de codar Page Inertia em migração MWART (Blade→React) no oimpresso. Skill Tier A always-on V4 que ORQUESTRA o Claude Design plugin Anthropic (design:design-critique + design:design-handoff + design:design-system + design:ux-copy + design:accessibility-review + design:research-synthesis) **e** o loop Cowork ↔ Claude Code formalizado em `prototipo-ui/` (ADR 0114). Gera artefato OBRIGATÓRIO `memory/requisitos/<Mod>/<tela>-visual-comparison.md` com 15 dimensões + framework Anthropic completo + sincroniza com `prototipo-ui/SYNC_LOG.md`. Skill PARA após gerar draft e aguarda Wagner aprovar SCREENSHOT (não tabela) ~10min síncrono ANTES de qualquer Edit/Write em `resources/js/Pages/<Mod>/<Tela>.tsx`. Restaura o loop "design supervisionado" da era Repair S2.5 com qualidade estado-da-arte. Ativa quando user pede "migrar tela X pra MWART", "comparativo visual", "/mwart-comparative <tela>", OU em qualquer Edit/Write em Page Inertia que não tenha visual-comparison.md ao lado.
-tier: A
+tier: B
 status: active
 version: 4.0
 authority: canonical

--- a/.claude/skills/mwart-process/SKILL.md
+++ b/.claude/skills/mwart-process/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: mwart-process
 description: Use SEMPRE que o trabalho envolva migrar tela Blade legacy → Inertia/React no oimpresso (MWART). Carrega o processo canônico ÚNICO definido em ADR 0104 — 5 fases obrigatórias e sequenciais (PLAN → BACKEND BASELINE → FRONTEND INCREMENTAL → QA → CUTOVER). Não há caminho alternativo. Ativa quando o pedido é "migrar tela X pra MWART", "criar tela em Pages/<Mod>/<Tela>.tsx", "migrar Blade pra React", ou quando Edit/Write em qualquer `resources/js/Pages/<Mod>/<Tela>.tsx` ou em controller chamando `Inertia::render`.
-tier: A
+tier: B
 status: active
 version: 1.2
 authority: canonical

--- a/.claude/skills/preflight-modulo/SKILL.md
+++ b/.claude/skills/preflight-modulo/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: preflight-modulo
-description: BLOQUEADOR — ATIVAR ANTES de qualquer Edit/Write/MultiEdit em Modules/<X>/. PRÉ-FLIGHT obrigatório: ler memory/requisitos/<X>/SPEC.md + RUNBOOK*.md + CAPTERRA*.md + charter da página + decisions-search ADRs relacionadas + skill como-integrar se feature parcial. Regra Primária Tier 0 IRREVOGÁVEL (memory/proibicoes.md). Workflow 3 fases obrigatório (PRE-FLIGHT/DURING/POST). Tier A always-on — pareada com hook .claude/hooks/modulo-preflight-warning.ps1. Wagner regra 2026-05-15: "vai mexer no módulo ler briefing e se mexer salva o progresso. mexe não registra altera sem ler as regras do módulo fica sempre errando." Time MCP (Felipe/Maiara/Eliana/Luiz) entra em breve — sem essa skill ativa, fica zona.
+description: BLOQUEADOR — ATIVAR ANTES de qualquer Edit/Write/MultiEdit em Modules/<X>/. PRÉ-FLIGHT obrigatório: ler memory/requisitos/<X>/SPEC.md + RUNBOOK*.md + CAPTERRA*.md + charter da página + decisions-search ADRs relacionadas + skill como-integrar se feature parcial. Regra Primária Tier 0 IRREVOGÁVEL (memory/proibicoes.md). Workflow 3 fases obrigatório (PRE-FLIGHT/DURING/POST). Auto-trigger por path Modules/ (ADR 0225 — dispara no momento exato vs banner always-on) — pareada com hook .claude/hooks/modulo-preflight-warning.ps1. Wagner regra 2026-05-15: "vai mexer no módulo ler briefing e se mexer salva o progresso. mexe não registra altera sem ler as regras do módulo fica sempre errando." Time MCP (Felipe/Maiara/Eliana/Luiz) entra em breve — sem essa skill ativa, fica zona.
+tier: B
 ---
 
 # preflight-modulo — Workflow Tier 0 obrigatório ao tocar Module/

--- a/.claude/skills/wagner-protocol-enforce/SKILL.md
+++ b/.claude/skills/wagner-protocol-enforce/SKILL.md
@@ -10,10 +10,17 @@ description: |
   humana antes commit/push/merge) — sem Wagner precisar repedir. Origem: sessão
   2026-05-17 Wagner "não é justo eu sempre ficar pedindo a mesma coisa".
 trust_level: 1
-tier: A
+tier: B
 parent_mission: mission.constituicao-v2
 charter_adr: 0094-constituicao-v2-7-camadas-8-principios
-auto_trigger: session_start
+auto_trigger: on_demand
+recalibrado_por: 0225-hooks-skills-tier-recalibracao-claude-4.8
+recalibracao_nota: |
+  ADR 0225 (2026-05-28) — rebaixado A->B. O binding REAL das regras R1-R11 ja
+  vive em memory/proibicoes.md "REGRA ZERO" (Tier 0 IRREVOGAVEL), que e @import
+  no CLAUDE.md => SEMPRE em contexto, independente desta skill. Logo always-on
+  desta skill era redundante. R1 (smoke real) + R10 (aprovacao humana) continuam
+  Tier 0 duro via proibicoes. Esta skill vira referencia on-demand do doc completo.
 applies_to:
   - any session in oimpresso project
   - both human-driven and agent-driven sessions

--- a/memory/decisions/0225-skills-tier-a-recalibracao-claude-4.8.md
+++ b/memory/decisions/0225-skills-tier-a-recalibracao-claude-4.8.md
@@ -1,0 +1,104 @@
+---
+adr: 0225
+title: Recalibração skills Tier A pós-Claude 4.8 — 8 always-on → 5 núcleo + 7 auto-trigger
+status: accepted
+date: 2026-05-28
+deciders: [Wagner]
+amends: []
+supersedes_partially: [0095, 0168]
+references:
+  - 0061-conhecimento-canonico-git-mcp-zero-automem.md
+  - 0093-multi-tenant-isolation-tier-0.md
+  - 0094-constituicao-v2-7-camadas-8-principios.md
+  - 0095-skills-tiers-convencao-interna.md
+  - 0168-protocolo-wagner-sempre-tier-A-irrevogavel.md
+  - 0224-hooks-block-vs-advisory-claude-4.8-aware.md
+lifecycle: active
+---
+
+## Contexto
+
+Segunda ADR da reavaliação Claude 4.8 ([sessions/2026-05-28-reavaliacao-projeto-claude-4.8.md](../sessions/2026-05-28-reavaliacao-projeto-claude-4.8.md)), sequência depois de [ADR 0224](0224-hooks-block-vs-advisory-claude-4.8-aware.md) (hooks).
+
+O banner SessionStart (`tier-a-banner.ps1`) declarava **8 skills Tier A always-on** + 1 dormente. Cada uma carrega ~90-260 linhas no início de TODA sessão de TODO dev (time MCP Felipe/Maiara/Eliana/Luiz incluso) = ~1.300 linhas de overhead fixo.
+
+Premissa que motivou always-on (maio/2026): **modelo esquece regra entre turnos** (instruction-following imperfeito, janela ~200k). Com Claude 4.8 (1M context, instruction-following muito melhor), o always-on de skill vira redundante — o modelo ativa a skill certa quando o trabalho toca o path/intenção relevante (description matching), no momento exato em vez de carregar tudo no boot.
+
+Critério: **Tier A = sempre relevante (segurança/LGPD/disciplina) OU instituída por Wagner em reação a falha concreta.** Tudo que dispara por path/intenção específica → auto-trigger (Tier B).
+
+## Decisão
+
+### MANTER Tier A (5 skills — núcleo)
+
+| Skill | Razão (NÃO é muleta de modelo) |
+|---|---|
+| `multi-tenant-patterns` | Segurança Tier 0 IRREVOGÁVEL ([ADR 0093](0093-multi-tenant-isolation-tier-0.md)) — sempre relevante |
+| `commit-discipline` | Núcleo PII/LGPD + disciplina de PR — toda sessão commita |
+| `incident-done-checklist` | DoD smoke real (R1) — disciplina de qualidade que nenhum modelo dispensa |
+| `memory-first-secret-search` | Wagner instituiu 2026-05-28 ("arrume essa memória pra não acontecer mais") — segurança |
+| `hostinger-dns-autonomy` | Wagner instituiu 2026-05-28 ("não me pergunte, foi incapaz") — anti-helpdesk |
+
+### REBAIXAR pra auto-trigger / Tier B (7 skills)
+
+| Skill | Premissa antiga | Por que auto-trigger basta no 4.8 |
+|---|---|---|
+| `brief-first` | "contexto escasso/caro" (200k) | 1M context: 30k onboarding = 3% janela. Vira conveniência início sessão, não bloqueador |
+| `mcp-first` | "tokens exploração caros" | Exploração filesystem barata + agentic loop 4.8 eficiente |
+| `mwart-process` | "modelo repete 6 gotchas" | Description já dispara em Edit `Pages/*.tsx` — momento exato |
+| `mwart-comparative` | processo visual | Description já dispara em Edit Page Inertia |
+| `charter-first` | "não cabe spec inteira" (200k) | Já semi-dormente; dispara ao editar tsx com `.charter.md`. Hook `charter-validate` (advisory) fica |
+| `preflight-modulo` | "esquece de ler regras módulo" | Description "ANTES de Edit Modules/<X>/" dispara no momento exato (mira melhor que banner). Hook `modulo-preflight-warning` + Regra Primária proibicoes.md ficam |
+| `wagner-protocol-enforce` | "esquece protocolo Wagner" | **Binding REAL já está em `proibicoes.md` REGRA ZERO** (Tier 0 IRREVOGÁVEL), que é `@import` no CLAUDE.md ⇒ SEMPRE em contexto. Always-on da skill era duplicação |
+
+### Achado-chave: PROTOCOLO WAGNER já é Tier 0 duro sem a skill
+
+`memory/proibicoes.md` linha 3+ tem **"REGRA ZERO — PROTOCOLO WAGNER SEMPRE (Tier 0 IRREVOGÁVEL)"** com a tabela completa R1-R11. E `proibicoes.md` é `@import` no `CLAUDE.md` ("## Proibições @memory/proibicoes.md") → carregado em **toda sessão automaticamente**, independente de qualquer skill. Portanto:
+
+- **R1 (smoke real)** + **R10 (aprovação humana)** + R2-R11 continuam **Tier 0 duro** — zero risco de afrouxar
+- A skill `wagner-protocol-enforce` always-on era redundante com a REGRA ZERO sempre-carregada
+- Rebaixá-la pra on-demand NÃO afrouxa nada — só remove duplicação
+
+## Não-goals
+
+- ❌ **Não remove nenhuma skill** — só muda `tier: A → B` (metadata + banner)
+- ❌ **Não afrouxa R1/R10 nem nenhuma regra Wagner** — ficam Tier 0 em proibicoes.md (sempre @import)
+- ❌ **Não toca as 3 skills Wagner-instituídas que ficam Tier A** (memory-first-secret, hostinger-dns, + incident-done)
+- ❌ **Não remove hooks pareados** (charter-validate, modulo-preflight-warning continuam advisory)
+- ❌ **Não mexe em multi-tenant nem LGPD**
+
+## Implementação (este PR)
+
+- `tier: A → tier: B` em 6 frontmatters: brief-first, mcp-first, mwart-process, mwart-comparative, charter-first, wagner-protocol-enforce (+ `preflight-modulo` ganha `tier: B` explícito)
+- `charter-first`: `always_on: true → false`; `wagner-protocol-enforce`: `auto_trigger: session_start → on_demand` + nota recalibração
+- `tier-a-banner.ps1` reescrito: 5 Tier A núcleo + 6 auto-trigger listadas + nota PROTOCOLO WAGNER on-demand (R1/R10 Tier 0 via proibicoes)
+- Esta ADR (`supersedes_partially: [0095, 0168]` — append-only, não reescreve as mães)
+
+## Consequências
+
+✅ **Boas:**
+- ~1.300 → ~620 linhas de overhead SessionStart (5 skills núcleo vs 8+); resto carrega só quando relevante
+- Mira melhor: skill ativa no momento exato do trabalho (Edit Pages/, Edit Modules/) vs sempre no boot
+- Time MCP entra com SessionStart mais leve e focado
+- Zero afrouxamento Tier 0: proibicoes.md REGRA ZERO (sempre @import) + 9 hooks deny (ADR 0224) + 5 skills núcleo
+- Banner honesto: reflete o que realmente sempre-importa vs o que dispara por contexto
+
+⚠️ **Tradeoffs:**
+- Skill auto-trigger depende do description matching disparar — se a description for fraca, pode não ativar. Mitigação: as 6 rebaixadas têm descriptions fortes ("ANTES de Edit Pages/*.tsx", "ANTES de Edit Modules/") que disparam por path
+- `brief-first` não força mais brief no boot — Wagner pode chamar manualmente OU a description ainda sugere. Se Wagner sentir falta, reverter brief-first pra Tier A é 1 linha
+- Mudança de convenção que time MCP precisa entender — banner novo documenta
+- `supersedes_partially` em 0095/0168 — append-only respeitado, mas exige ler 0225 junto com as mães
+
+## Validação
+
+- ✅ 7 frontmatters editados (`tier: B`)
+- ✅ `tier-a-banner.ps1` reflete 5 núcleo + 6 auto-trigger
+- ✅ proibicoes.md REGRA ZERO confirmada (R1-R11 Tier 0, sempre @import via CLAUDE.md)
+- ✅ Hooks pareados (charter-validate, modulo-preflight) permanecem advisory
+- ⏳ Teste real: próxima sessão SessionStart mostra banner novo; skills auto-trigger ativam ao tocar path relevante
+
+## Notas
+
+- Sequência reavaliação 4.8: 0224 (hooks) → **0225 (skills)** → 0226 (brief v2) → 0227 (MWART single-layer) → 0228 (subagent nativo)
+- Wagner aprovou triagem caso-a-caso 2026-05-28 ("sim faça vamos testar") após ver tabela das 12 skills
+- Reverter qualquer rebaixamento = 1 linha (`tier: B → A` + banner) — totalmente reversível
+- ADR 0226 (brief v2) é independente, pode ir em paralelo na próxima sessão


### PR DESCRIPTION
## Summary

Segunda ADR da [reavaliação Claude 4.8](memory/sessions/2026-05-28-reavaliacao-projeto-claude-4.8.md) (após [0224 hooks](memory/decisions/0224-hooks-block-vs-advisory-claude-4.8-aware.md)). Premissa "modelo esquece regra entre turnos" (maio/2026) encolheu com 4.8 (1M context + instruction-following). Always-on de skill → redundante; auto-trigger por path ativa no momento exato.

## MANTER Tier A (5 núcleo)

| Skill | Razão |
|---|---|
| multi-tenant-patterns | Segurança Tier 0 IRREVOGÁVEL |
| commit-discipline | Núcleo PII/LGPD |
| incident-done-checklist | DoD smoke real (R1) |
| memory-first-secret-search | **Wagner instituiu** 2026-05-28 |
| hostinger-dns-autonomy | **Wagner instituiu** 2026-05-28 |

## REBAIXAR auto-trigger (7)

brief-first · mcp-first · mwart-process · mwart-comparative · charter-first · preflight-modulo · wagner-protocol-enforce

Todas têm description forte que dispara por path/intenção (ex: "ANTES de Edit Pages/*.tsx", "ANTES de Edit Modules/").

## 🔑 Achado-chave: PROTOCOLO WAGNER já é Tier 0 duro SEM a skill

`memory/proibicoes.md` tem **"REGRA ZERO — PROTOCOLO WAGNER SEMPRE (Tier 0 IRREVOGÁVEL)"** com R1-R11 completos. E proibicoes.md é `@import` no CLAUDE.md → **sempre em contexto**.

Logo rebaixar `wagner-protocol-enforce` **NÃO afrouxa nada** — R1 (smoke real) + R10 (aprovação humana) continuam Tier 0 via proibicoes. A skill always-on era pura duplicação.

## Zero afrouxamento Tier 0

proibicoes REGRA ZERO (sempre @import) + 9 hooks `deny` (ADR 0224) + 5 skills núcleo. Hooks pareados (charter-validate, modulo-preflight) continuam advisory.

## Mudanças

- `tier: A → B` em 7 frontmatters
- charter-first `always_on: false`; wagner-protocol `auto_trigger: on_demand` + nota
- `tier-a-banner.ps1` reescrito (5 núcleo + 6 auto-trigger + nota PROTOCOLO)
- Overhead SessionStart: **~1.300 → ~620 linhas**

## Validação

- ✅ banner PARSE OK + output correto (5 núcleo listadas)
- ✅ proibicoes REGRA ZERO confirmada (R1-R11 Tier 0)
- ✅ Totalmente reversível (`tier: B → A` = 1 linha)
- ⏳ Teste real: próxima sessão SessionStart mostra banner novo

## Refs

- [ADR 0225](memory/decisions/0225-skills-tier-a-recalibracao-claude-4.8.md) `supersedes_partially: [0095, 0168]`
- Sequência: 0224 ✅ → **0225** → 0226 (brief v2) → 0227 (MWART) → 0228 (subagent nativo)