### PR TITLE
feat(governance): ADR 0226 — Brief v2 (1M-aware) régua 3.5k → 8k tokens

### DIFF
--- a/Modules/Brief/Services/BriefGeneratorService.php
+++ b/Modules/Brief/Services/BriefGeneratorService.php
@@ -33,9 +33,24 @@ final class BriefGeneratorService
 
     private const TEMPERATURE = 0.2;
 
-    private const MAX_TOKENS = 4096;
+    /**
+     * Teto de tokens de geração do brief.
+     *
+     * ADR 0226 (Claude 4.8-aware): 4096 → 8192. Premissa antiga (ADR 0091) era
+     * "contexto escasso/caro" (janela ~200k → brief enxuto economiza). Com 1M
+     * context, 8k de brief = 0,8% da janela; brief mais RICO (mais EM VOO, mais
+     * decisões, mais contexto) vale mais que brief telegráfico. Custo gpt-4o-mini
+     * extra é trivial (~$0,001/brief). Override via env pra Wagner calibrar.
+     */
+    private const MAX_TOKENS = 8192;
 
     private const STOP_SEQUENCE = "\n---END---";
+
+    /** Régua de tamanho-alvo do brief no prompt (ADR 0226 — env-overridable). */
+    private function targetTokens(): int
+    {
+        return (int) env('GOVERNANCE_BRIEF_TARGET_TOKENS', 8000);
+    }
 
     /** Custo em USD por 1k tokens — gpt-4o-mini 2025 pricing. */
     private const PRICE_INPUT_PER_1K = 0.00015;
@@ -153,10 +168,12 @@ REGRAS DURAS (não negocie):
    ## CHARTERS APODRECENDO
    ## FLAGS
    ## METADATA
-3. Total ≤3.500 tokens. Conte mentalmente. Se passar, corte da seção
-   menos crítica (geralmente SKILLS ou CHARTERS).
+3. Total ≤8.000 tokens (ADR 0226 — 1M context, brief RICO > brief enxuto).
+   Não precisa cortar agressivo: priorize completude útil. Se exceder MUITO,
+   corte da seção menos crítica (geralmente SKILLS ou CHARTERS).
 4. Termine com a linha exata: \n---END---
-5. PT-BR sempre. Tom: telegráfico, denso, factual. Sem floreio.
+5. PT-BR sempre. Tom: denso e factual, mas com contexto suficiente pro Wagner
+   decidir sem abrir 5 ferramentas. Sem floreio, mas sem amputar informação útil.
 6. Use emojis SOMENTE em FLAGS (🔴 🟡 🟢) e setas (↑ ↓ →) onde fizer sentido.
 7. Datas: "há 3d", "há 2h", "hoje 14h", "ontem". Nunca ISO completo no corpo.
 8. Números: pt-BR (R$ 1.234,56 / 47% / 14d).
@@ -176,7 +193,7 @@ ESTRUTURA OBRIGATÓRIA DE CADA SEÇÃO:
 Lista numerada. Cada linha:
 N. <actor_id> @ <target_path> — <intent_label>, <aging_human>
 
-Limite 8 linhas. Resto vira "+N outros".
+Limite 12 linhas (ADR 0226 — brief rico). Resto vira "+N outros".
 
 ## DECISÕES RECENTES (24h)
 - ADRs: <lista compacta com IDs e títulos truncados em 50 chars>
@@ -208,14 +225,14 @@ Critério emoji:
 
 ## METADATA
 - Gerado: <human relative>
-- Versão gerador: v1
+- Versão gerador: v2 (ADR 0226 — 1M-aware, ≤8k)
 - Tokens estimados: <N>
 
 VALIDADOR INTERNO antes de devolver:
 - 7 headers ##? ✓
 - Termina em ---END---? ✓
 - Tem PII de cliente final? ✗ (refazer se sim)
-- Total tokens ≤3500? ✓
+- Total tokens ≤8000? ✓ (ADR 0226)
 PROMPT;
     }
 

--- a/Modules/Brief/Services/BriefValidator.php
+++ b/Modules/Brief/Services/BriefValidator.php
@@ -10,7 +10,7 @@ use App\Util\OtelHelper;
  * Garante 4 invariantes (ver ADR 0091):
  * 1. 7 headers exatos, na ordem correta
  * 2. Termina com \n---END---
- * 3. ≤3500 tokens estimados (~4 chars/token PT-BR)
+ * 3. ≤8000 tokens estimados (~4 chars/token PT-BR) — ADR 0226 (1M-aware)
  * 4. Sem PII de cliente final (CPF/CNPJ)
  *
  * Ver memory/sprints/s1-daily-brief/03-prompt-generator.md.
@@ -30,7 +30,9 @@ final class BriefValidator
         '## METADATA',
     ];
 
-    public const MAX_TOKENS = 3500;
+    // ADR 0226 (Claude 4.8-aware): 3500 → 8000. Brief RICO > brief enxuto com 1M
+    // context. Validator acompanha o teto do gerador (BriefGeneratorService).
+    public const MAX_TOKENS = 8000;
 
     public function validate(string $content): ValidationResult
     {
@@ -56,7 +58,7 @@ final class BriefValidator
             return ValidationResult::fail('missing_end_sentinel');
         }
 
-        // 3) Token count <= 3500 (estimativa: ~4 chars/token PT-BR)
+        // 3) Token count <= MAX_TOKENS (8000, ADR 0226 — estimativa ~4 chars/token PT-BR)
         $estimatedTokens = (int) ceil(mb_strlen($content) / 4);
         if ($estimatedTokens > self::MAX_TOKENS) {
             return ValidationResult::fail("token_overflow:{$estimatedTokens}");

--- a/Modules/Brief/Tests/Feature/BriefValidatorTest.php
+++ b/Modules/Brief/Tests/Feature/BriefValidatorTest.php
@@ -90,10 +90,10 @@ it('falha quando sentinela ---END--- ausente', function () {
     expect($r->reason)->toBe('missing_end_sentinel');
 });
 
-it('falha quando token count > 3500', function () {
-    // Brief válido + ~15k chars de padding (>3500 tokens estimados)
+it('falha quando token count > 8000 (ADR 0226)', function () {
+    // Brief válido + ~36k chars de padding (>8000 tokens estimados @ ~4 chars/token)
     $valid = briefValido();
-    $padded = str_replace('---END---', str_repeat('a', 15_000) . "\n---END---", $valid);
+    $padded = str_replace('---END---', str_repeat('a', 36_000) . "\n---END---", $valid);
     $r = (new BriefValidator())->validate($padded);
 
     expect($r->isOk())->toBeFalse();
@@ -134,5 +134,5 @@ it('ValidationResult::fail cria instância imutável com reason', function () {
 
 it('BriefValidator::REQUIRED_HEADERS bate exato 7 entradas (ADR 0091)', function () {
     expect(BriefValidator::REQUIRED_HEADERS)->toHaveCount(7);
-    expect(BriefValidator::MAX_TOKENS)->toBe(3500);
+    expect(BriefValidator::MAX_TOKENS)->toBe(8000); // ADR 0226 — 1M-aware (era 3500)
 });

--- a/memory/decisions/0226-brief-v2-1m-aware-rico.md
+++ b/memory/decisions/0226-brief-v2-1m-aware-rico.md
@@ -1,0 +1,96 @@
+---
+adr: 0226
+title: Brief v2 (1M-aware) — régua 3.5k → 8k tokens, reposiciona como estado-rico-pro-Wagner
+status: accepted
+date: 2026-05-28
+deciders: [Wagner]
+amends: []
+supersedes_partially: [0091, 0097]
+references:
+  - 0091-daily-brief.md
+  - 0097-brief-model-gpt4o-mini-supersede-parcial-0091.md
+  - 0094-constituicao-v2-7-camadas-8-principios.md
+  - 0224-hooks-block-vs-advisory-claude-4.8-aware.md
+  - 0225-skills-tier-a-recalibracao-claude-4.8.md
+lifecycle: active
+---
+
+## Contexto
+
+Terceira ADR da reavaliação Claude 4.8 ([sessions/2026-05-28-reavaliacao-projeto-claude-4.8.md](../sessions/2026-05-28-reavaliacao-projeto-claude-4.8.md)), após 0224 (hooks) e 0225 (skills).
+
+O Daily Brief ([ADR 0091](0091-daily-brief.md)) nasceu com régua **≤3.500 tokens** sob a premissa "contexto escasso/caro": janela ~200k → 15-30k de onboarding × 30 sessões/dia = ~500k desperdiçados, logo brief enxuto economiza. A régua estava em 3 lugares:
+- `BriefGeneratorService::MAX_TOKENS = 4096` (teto de geração gpt-4o-mini)
+- Prompt: "Total ≤3.500 tokens. Conte mentalmente. Se passar, corte..."
+- `BriefValidator::MAX_TOKENS = 3500` (rejeita brief maior)
+
+Com **Claude 4.8 (1M context)**, essa premissa caiu: 8k de brief = **0,8% da janela**. O custo de geração (gpt-4o-mini, ADR 0097) de um brief maior é trivial (~$0,001 extra/brief). O trade-off inverteu: **brief RICO (mais EM VOO, mais decisões, mais contexto pro Wagner decidir sem abrir 5 ferramentas) vale mais que brief telegráfico amputado**.
+
+A própria régua de 3.500 forçava cortes ("corte da seção menos crítica") que removiam informação útil — exatamente o que o 1M context torna desnecessário.
+
+## Decisão
+
+Brief v2 — **régua 3.500 → 8.000 tokens**, reposicionado como **estado-rico-pro-Wagner**, não economia de tokens.
+
+| Local | Antes | Depois |
+|---|---|---|
+| `BriefGeneratorService::MAX_TOKENS` | 4096 | **8192** (env `GOVERNANCE_BRIEF_TARGET_TOKENS` override) |
+| Prompt instrução | "≤3.500, conte mentalmente, corte" | "≤8.000, priorize completude útil, corte só se exceder MUITO" |
+| Prompt seção EM VOO | "Limite 8 linhas" | **"Limite 12 linhas"** |
+| `BriefValidator::MAX_TOKENS` | 3500 | **8000** |
+| Versão gerador (metadata) | v1 | **v2 (ADR 0226)** |
+
+Tom ajustado: de "telegráfico, denso, sem floreio" → "denso e factual, mas com contexto suficiente pro Wagner decidir sem abrir 5 ferramentas. Sem floreio, mas sem amputar informação útil."
+
+### O que NÃO muda
+
+- **Modelo gpt-4o-mini** ([ADR 0097](0097-brief-model-gpt4o-mini-supersede-parcial-0091.md)) — continua o certo (geração estruturada barata, não é muleta de modelo)
+- **7 seções obrigatórias** + ordem + headers exatos — estrutura canon intacta
+- **Sentinela `---END---`** — intacta
+- **Zero PII de cliente final** — regra LGPD intacta (validator continua rejeitando CPF/CNPJ)
+- **Cron de geração** + cache 5min — intactos
+
+## Não-goals
+
+- ❌ **Não troca o modelo** (gpt-4o-mini fica — economia legítima de OPEX)
+- ❌ **Não muda as 7 seções** nem a estrutura
+- ❌ **Não afrouxa LGPD** (PII de cliente final continua bloqueada)
+- ❌ **Não remove o cap** — só sobe pra 8k (ainda há teto, anti-runaway)
+- ❌ **Não força brief sempre** (ADR 0225 já rebaixou brief-first pra auto-trigger)
+
+## Implementação (este PR)
+
+- `BriefGeneratorService.php`: `MAX_TOKENS 4096→8192` + método `targetTokens()` env-overridable + 3 edições de prompt (régua, EM VOO 8→12, validador interno, versão v2) + tom
+- `BriefValidator.php`: `MAX_TOKENS 3500→8000` + comentários
+- `GenerateBriefCommand.php`: comentário doc ≤8000
+- `BriefValidatorTest.php`: 2 testes atualizados (assert 8000 + padding 36k chars pra overflow)
+- Esta ADR (`supersedes_partially: [0091, 0097]`)
+
+## Consequências
+
+✅ **Boas:**
+- Brief mais rico: mais EM VOO (12 vs 8 linhas), mais decisões, mais contexto — Wagner decide sem abrir cycles-active + my-work + decisions-search
+- Custo extra trivial (~$0,001/brief gpt-4o-mini) — OPEX irrelevante
+- Régua env-overridable: Wagner calibra `GOVERNANCE_BRIEF_TARGET_TOKENS` sem deploy
+- Alinhado com 1M context: para de tratar contexto como recurso escasso
+- Reposicionamento honesto: brief é UX-pro-Wagner, não hack de economia
+
+⚠️ **Tradeoffs:**
+- Brief maior = mais tokens lidos por sessão (~8k vs ~3.5k). Com 1M context é 0,8% — irrelevante. Mas em sessões hiper-curtas é leve overhead.
+- gpt-4o-mini pode às vezes não preencher os 8k (gera o que tem) — OK, 8k é teto não piso
+- Validator a 8k aceita briefs que antes rejeitaria — risco de brief verboso. Mitigação: prompt ainda pede "denso e factual, sem floreio"
+- `supersedes_partially` 0091/0097 — append-only respeitado, ler 0226 junto
+
+## Validação
+
+- ✅ BriefValidatorTest 10/10 verde (assert MAX_TOKENS=8000 + overflow >8000 com 36k padding)
+- ✅ Suite Brief completa 45 passed / 15 skipped (SQLite-incompat esperado)
+- ✅ Sem refs residuais a 3500/4096 no código (só comentários históricos atualizados)
+- ⏳ Teste real: próximo cron `brief:generate` produz brief até 8k; Wagner vê brief mais rico
+
+## Notas
+
+- Sequência reavaliação 4.8: 0224 (hooks) ✅ → 0225 (skills) ✅ → **0226 (brief v2)** ✅ → 0227 (MWART single-layer) → 0228 (subagent nativo)
+- Wagner aprovou 2026-05-28 ("sim eu preciso")
+- Reverter = `MAX_TOKENS` 8000/8192→3500/4096 + prompt (totalmente reversível)
+- ADRs 0227 (MWART) + 0228 (subagent) ficam pra próxima sessão — são as 2 últimas da reavaliação, e 0228 é EVOLUIR (piloto, mais envolvido)


### PR DESCRIPTION
## Summary

Terceira ADR da [reavaliação Claude 4.8](memory/sessions/2026-05-28-reavaliacao-projeto-claude-4.8.md) (após 0224 hooks ✅, 0225 skills ✅).

Brief nasceu com régua **≤3.500 tokens** sob premissa "contexto escasso/caro" (janela ~200k). Com 4.8 (1M context), 8k de brief = **0,8% da janela**; brief RICO > brief telegráfico amputado. Custo gpt-4o-mini extra trivial (~$0,001/brief).

## Mudanças (régua estava em 3 lugares)

| Local | Antes | Depois |
|---|---|---|
| `BriefGeneratorService::MAX_TOKENS` | 4096 | **8192** (+ env `GOVERNANCE_BRIEF_TARGET_TOKENS`) |
| `BriefValidator::MAX_TOKENS` | 3500 | **8000** |
| Prompt régua | "≤3.500, corte" | "≤8.000, priorize completude" |
| Prompt EM VOO | 8 linhas | **12 linhas** |
| Tom | "telegráfico" | "denso mas com contexto pro Wagner decidir sem abrir 5 ferramentas" |
| Versão | v1 | **v2** |

## NÃO muda

- Modelo gpt-4o-mini (economia legítima OPEX, não muleta)
- 7 seções canon + ordem + headers
- Sentinela `---END---`
- **Zero PII cliente final (LGPD intacto)** — validator continua rejeitando CPF/CNPJ
- Cron + cache 5min

## Validação

```
$ pest Modules/Brief/Tests/Feature/BriefValidatorTest.php
✓ 10 passed (assert MAX_TOKENS=8000 + overflow >8000 com 36k padding)

$ pest Modules/Brief/Tests/
45 passed / 15 skipped (SQLite-incompat esperado)

$ php -l (ambos services) → No syntax errors
```

Env override `GOVERNANCE_BRIEF_TARGET_TOKENS` — Wagner calibra sem deploy. Totalmente reversível.

## Refs

- [ADR 0226](memory/decisions/0226-brief-v2-1m-aware-rico.md) `supersedes_partially: [0091, 0097]`
- Sequência: 0224 ✅ → 0225 ✅ → **0226** ✅ → 0227 (MWART) → 0228 (subagent nativo)