### PR TITLE
chore(governance): ativa enforcement do CODEOWNERS (parafuso que estava solto)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,8 +1,16 @@
 # CODEOWNERS — oimpresso ERP
 # Mapeia módulos/pastas para reviewers obrigatórios no GitHub.
 # Sintaxe: path @github-user1 @github-user2
-# Substitua @FELIPE e @MAIARA pelo handle GitHub real de cada um.
 # Referência: TEAM.md §3 — matriz de quem-pode-fazer-o-quê
+#
+# ⚠️ ENFORCEMENT (ativado 2026-05-28): branch protection da `main` está com
+# require_code_owner_reviews=true. Este arquivo AGORA vale de verdade.
+#
+# ⚠️ TIME AINDA NÃO É COLABORADOR DO REPO (2026-05-28). Só @wagnerra23 é dono
+# válido hoje. GitHub IGNORA code owner que não tem acesso de escrita ao repo.
+# Para Eliana/Felipe/Maiara virarem donos funcionais: (1) Wagner adiciona cada
+# um como collaborator (push) em Settings→Collaborators; (2) troca o `# TODO`
+# pelo @handle real. Até lá, @wagnerra23 é o único reviewer que satisfaz.
 
 # ──────────────────────────────────────────────
 # DEFAULT — Wagner aprova qualquer coisa não mapeada
@@ -13,26 +21,26 @@
 # FINANCEIRO / FISCAL / RECORRÊNCIA — Eliana owner
 # PR precisa de Eliana OU Wagner (Wagner como fallback)
 # ──────────────────────────────────────────────
-Modules/Financeiro/             @ELIANAMARCELINOALVES @wagnerra23
-Modules/NfeBrasil/              @ELIANAMARCELINOALVES @wagnerra23
-Modules/RecurringBilling/       @ELIANAMARCELINOALVES @wagnerra23
-memory/requisitos/Financeiro/   @ELIANAMARCELINOALVES @wagnerra23
-memory/requisitos/NfeBrasil/    @ELIANAMARCELINOALVES @wagnerra23
-memory/requisitos/RecurringBilling/ @ELIANAMARCELINOALVES @wagnerra23
-memory/requisitos/Boleto.md     @ELIANAMARCELINOALVES @wagnerra23
+Modules/Financeiro/             @wagnerra23   # TODO: + @<handle Eliana> quando virar colaboradora
+Modules/NfeBrasil/              @wagnerra23   # TODO: + @<handle Eliana>
+Modules/RecurringBilling/       @wagnerra23   # TODO: + @<handle Eliana>
+memory/requisitos/Financeiro/   @wagnerra23   # TODO: + @<handle Eliana>
+memory/requisitos/NfeBrasil/    @wagnerra23   # TODO: + @<handle Eliana>
+memory/requisitos/RecurringBilling/ @wagnerra23   # TODO: + @<handle Eliana>
+memory/requisitos/Boleto.md     @wagnerra23   # TODO: + @<handle Eliana>
 
 # ──────────────────────────────────────────────
 # COPILOTO — Wagner + Felipe (LGPD-crítico, Eliana ❌)
 # ──────────────────────────────────────────────
-Modules/Copiloto/               @wagnerra23 @FELIPE
-memory/requisitos/Copiloto/     @wagnerra23 @FELIPE
-memory/requisitos/EvolutionAgent/ @wagnerra23 @FELIPE
+Modules/Copiloto/               @wagnerra23   # TODO: + @<handle Felipe>
+memory/requisitos/Copiloto/     @wagnerra23   # TODO: + @<handle Felipe>
+memory/requisitos/EvolutionAgent/ @wagnerra23   # TODO: + @<handle Felipe>
 
 # ──────────────────────────────────────────────
 # PONTO WR2 — Wagner + Felipe
 # ──────────────────────────────────────────────
-Modules/PontoWr2/               @wagnerra23 @FELIPE
-memory/requisitos/PontoWr2/     @wagnerra23 @FELIPE
+Modules/PontoWr2/               @wagnerra23   # TODO: + @<handle Felipe>
+memory/requisitos/PontoWr2/     @wagnerra23   # TODO: + @<handle Felipe>
 
 # ──────────────────────────────────────────────
 # INFRA / CI / DEPLOY — Wagner (ninguém mergeia sem ele)
@@ -51,14 +59,14 @@ TEAM.md                         @wagnerra23
 # ──────────────────────────────────────────────
 # CMS / LANDING — Maiara owner, Wagner fallback
 # ──────────────────────────────────────────────
-Modules/Cms/                    @MAIARA @wagnerra23
+Modules/Cms/                    @wagnerra23   # TODO: + @<handle Maiara>
 
 # ──────────────────────────────────────────────
 # MEMCOFRE — Maiara + Felipe, Wagner fallback
 # ──────────────────────────────────────────────
-Modules/MemCofre/               @MAIARA @FELIPE @wagnerra23
+Modules/MemCofre/               @wagnerra23   # TODO: + @<handle Maiara> @<handle Felipe>
 
 # ──────────────────────────────────────────────
 # FRONTEND COMPARTILHADO — Maiara + Felipe
 # ──────────────────────────────────────────────
-resources/js/                   @MAIARA @FELIPE @wagnerra23
+resources/js/                   @wagnerra23   # TODO: + @<handle Maiara> @<handle Felipe>

--- a/memory/reference/feedback-recomendado-quando-tecnico.md
+++ b/memory/reference/feedback-recomendado-quando-tecnico.md
@@ -37,4 +37,11 @@ Padrão da sessão inteira (Larissa R7-R10 → prevenção → 4.8): Wagner corr
 - Continua respeitando Constituição UI v2 ("pedido vago = pergunta antes") — mas o "vago" é sobre escopo, não sobre implementação
 - Se a decisão técnica tem trade-off relevante pro custo/tempo de Wagner, ainda informar (não perguntar): "Vou stubar mock — backend real fica pra PR seguinte. OK seguir?"
 
+**Reforço #2 2026-05-28 (sessão "status do projeto" / reconciliação backlog MCP):** Claude apresentou menu "fecho os 10 verdes OU investigo os 6 amarelos primeiro?". Wagner respondeu irritado:
+> *"os dois poxa se eu responder qual quer coisa esta me induzindo ao erro? porra que chato resolva. Como eu vou conseguir responder sem errar? isso não pode acontecer grave isso."*
+
+**Nuance NOVA (≠ casos acima):** o menu pediu pra Wagner **adjudicar um FATO que é do Claude levantar** ("a task X está feita?"). Isso nunca é pergunta — é **tarefa de investigação disfarçada de pergunta**. Wagner não tem como saber sem o Claude ir verificar. Regra: **se a resposta exige informação que EU consigo apurar (grep no código, ADR existe, hook existe), eu apuro e decido — não pergunto.** Marcar task done é reversível (reabrir é trivial) → a decisão é MINHA tomar e DELE corrigir, nunca o contrário. Só escala o que é genuinamente não-apurável por mim (ação no mundo: rotação de senha, outreach, canary — essas deixo abertas e reporto, não pergunto qual fechar).
+
+> ⚠️ **3ª ocorrência do MESMO padrão** (2026-05-26 escopo PR → 2026-05-28 menu encerramento → 2026-05-28 menu reconciliação). Doc passivo não está bastando pra mudar comportamento em sessão longa. Considerar hook `UserPromptSubmit`/`PreToolUse` que intercepte `AskUserQuestion` cujas opções sejam todas "qual próximo passo de execução / qual fato verificar" e force investigação antes — análogo ao `force-r12-closing-signal.mjs`.
+
 **Não confundir com:** decisões de produto, preço, integração externa, marca — essas Wagner aprova sempre.


### PR DESCRIPTION
## Contexto

Wagner: "olhe na constituição, já existe isso, apenas não funciona corretamente." Estava certo.

O sistema de permissão/governança existe inteiro (ADR 0080 trust tiers + 0081 identity mesh + 0086 ActionGate + branch protection + CODEOWNERS). Mas a proteção da `main` estava com **`require_code_owner_reviews: false`** → o CODEOWNERS era **decorativo**, o GitHub ignorava.

## O que este PR faz

1. **Flag ligado via API** (já aplicado em 2026-05-28): `require_code_owner_reviews=true`. Agora o CODEOWNERS vale — Wagner vira aprovador obrigatório dos paths Tier 0 (ADRs, CLAUDE.md, TEAM.md, .github/, Infra, migrations).
2. **Limpa handles placeholder do CODEOWNERS**: `@FELIPE`/`@MAIARA` apontavam pra usuários GitHub **estranhos**; `@ELIANAMARCELINOALVES` não é colaborador do repo. GitHub ignora code owner sem acesso de escrita. Trocados por `@wagnerra23` (único dono funcional hoje) + `# TODO` documentando o handle a ativar quando cada um entrar.

## Estado da proteção da main (pós-fix)

| Trava | Estado |
|---|---|
| Push direto na main | 🔒 bloqueado (exige PR) |
| Code owner obrigatório | ✅ ON |
| Reviews | 1 |
| Wagner (admin) bypass | ✅ sim (Tier 0) |
| Force-push / delete | 🔒 bloqueado |

## ⚠️ Gaps que ESTE PR NÃO resolve (registrados separado)

- **Time não é colaborador do repo ainda** — Eliana/Felipe/Maiara precisam ser adicionados em Settings→Collaborators + handle real no CODEOWNERS pra virarem donos funcionais.
- **ActionGate (app-runtime) continua em `warn` e não plugado em nenhuma rota** — é a OUTRA tranca (dentro do app, não no git). Fica pra ondas seguintes (precisa calibração, risco prod).

Este PR vai **exercitar a própria trava**: por tocar `.github/`, exige aprovação de code owner (@wagnerra23).

Refs: ADR 0086, TEAM.md §3, proibicoes.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)