### PR TITLE
feat(jana): PesoRealService — função pura do Peso Real (ADR 0232, Área A)

### DIFF
--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -483,11 +483,11 @@ return [
         ],
 
         // (b) MEMÓRIA — meia-vida default do decay exponencial, em dias (ADR 0195).
-        'half_life' => (int) env('JANA_PESO_REAL_HALF_LIFE', 60),
+        'half_life' => 60,
 
         // (b) MEMÓRIA — piso crítico (fração de relevancia_meta). Memória que
         // protege cliente pagante não cai abaixo deste piso, mesmo velha.
-        'piso_critico' => (float) env('JANA_PESO_REAL_PISO_CRITICO', 0.5),
+        'piso_critico' => 0.5,
 
         // (c) INICIATIVA — sinal de cliente (ADR 0105).
         'sinal' => [

--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -458,4 +458,48 @@ return [
         'redact_query'            => (bool) env('JANA_REDACT_QUERY_IN_SPANS', true),
         'audit_log_enabled'       => (bool) env('JANA_RETRIEVAL_AUDIT_LOG', true),
     ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Peso Real — classificação por contribuição à meta R$5M (ADR 0232)
+    |--------------------------------------------------------------------------
+    | Multiplicadores das três fórmulas do Peso Real, lidos por
+    | Modules\Jana\Services\Peso\PesoRealService (função PURA, sem I/O).
+    |
+    | ÁREA A / ETAPA 5 IAOS — PROPOSTA, NÃO plugada em retrieval/prod.
+    | O service tem defaults de fallback hardcoded; estas entradas só permitem
+    | tunar sem editar código. Não quebra se a chave for removida.
+    |
+    | @see memory/decisions/0232-modelo-peso-real-classificacao-por-meta.md
+    */
+    'peso_real' => [
+        // (a) DECISÃO/ADR — multiplicador por lifecycle (não decai por tempo).
+        'lifecycle_mult' => [
+            'accepted'            => 1.0,
+            'accepted-historical' => 0.8,
+            'sunsetting'          => 0.4,
+            'superseded'          => 0.1,
+            'deprecated'          => 0.1,
+        ],
+
+        // (b) MEMÓRIA — meia-vida default do decay exponencial, em dias (ADR 0195).
+        'half_life' => (int) env('JANA_PESO_REAL_HALF_LIFE', 60),
+
+        // (b) MEMÓRIA — piso crítico (fração de relevancia_meta). Memória que
+        // protege cliente pagante não cai abaixo deste piso, mesmo velha.
+        'piso_critico' => (float) env('JANA_PESO_REAL_PISO_CRITICO', 0.5),
+
+        // (c) INICIATIVA — sinal de cliente (ADR 0105).
+        'sinal' => [
+            'paga_reporta' => 1.0,
+            'qualificado'  => 0.5,
+            'hipotese'     => 0.2,
+        ],
+
+        // (c) INICIATIVA — time_criticality (Cost of Delay / WSJF).
+        'time_criticality' => [
+            'normal'     => 1.0,
+            'compliance' => 1.5,
+        ],
+    ],
 ];

--- a/Modules/Jana/Services/Peso/PesoRealService.php
+++ b/Modules/Jana/Services/Peso/PesoRealService.php
@@ -1,0 +1,224 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Services\Peso;
+
+/**
+ * PesoRealService — função PURA de cálculo do Peso Real (ADR 0232).
+ *
+ * "Classificar memórias, decisões e iniciativas por contribuição à meta R$5M/ano"
+ * (ADR 0022). Uma fórmula-mãe, três sabores — cada tipo tem natureza temporal
+ * diferente, mas tudo aponta pra mesma meta:
+ *
+ *   PESO_REAL = relevancia_meta(0-100) × modulador_do_tipo
+ *
+ * IMPORTANTE — este service é PURO:
+ *   - SEM I/O, SEM DB, SEM query business_id (é só aritmética).
+ *   - Multi-tenant Tier 0 (ADR 0093) NÃO se aplica: não toca tabela alguma.
+ *     Quem plugar este cálculo em retrieval/prod é que carrega o business_id
+ *     scope — esta classe só recebe números já resolvidos.
+ *   - Determinístico: mesma entrada → mesma saída. Testável sem fixtures de DB.
+ *
+ * Área A da Etapa 5 do IAOS — PROPOSTA, NÃO plugada (não toca MeilisearchDriver,
+ * retrieval, settings nem prod). Ver ADR 0232 (status: proposto).
+ *
+ * Estado-da-arte que sustenta as fórmulas:
+ *   - Iniciativas: WSJF / Cost of Delay (SAFe / Reinertsen) — value÷effort com
+ *     time_criticality como componente de Cost of Delay.
+ *   - Memórias: Generative Agents (recency exponencial × importance) +
+ *     ADR 0195 (decay adaptativo) — generalizado pra qualquer memória.
+ *   - Decisões: fitness-function / evergreen — perde peso por supersede, nunca
+ *     por idade.
+ *
+ * @see memory/decisions/0232-modelo-peso-real-classificacao-por-meta.md
+ */
+class PesoRealService
+{
+    /**
+     * Defaults de fallback hardcoded — usados quando config('jana.peso_real.*')
+     * está ausente. Garante que o service NUNCA quebra por config faltando.
+     */
+    private const FALLBACK_LIFECYCLE_MULT = [
+        'accepted'            => 1.0,
+        'accepted-historical' => 0.8,
+        'sunsetting'          => 0.4,
+        'superseded'          => 0.1,
+        'deprecated'          => 0.1,
+    ];
+
+    private const FALLBACK_HALF_LIFE = 60; // dias (ADR 0195)
+
+    /**
+     * Piso crítico (fração de relevancia_meta) aplicado a memórias que "protegem
+     * cliente" — lição que evita erro que custa cliente NÃO decai abaixo deste
+     * piso, por mais antiga que seja. Default 0.5 = nível HOT.
+     */
+    private const FALLBACK_PISO_CRITICO = 0.5;
+
+    private const FALLBACK_SINAL = [
+        'paga_reporta' => 1.0,
+        'qualificado'  => 0.5,
+        'hipotese'     => 0.2,
+    ];
+
+    private const FALLBACK_TIME_CRITICALITY = [
+        'normal'     => 1.0,
+        'compliance' => 1.5,
+    ];
+
+    /**
+     * (a) DECISÃO / ADR — NÃO decai por tempo.
+     *
+     *   PESO_ADR = relevancia_meta × lifecycle_mult
+     *
+     * Decisão é evergreen: perde peso por supersede, nunca por idade. Lifecycle
+     * desconhecido cai no fallback 'deprecated' (0.1) — conservador: item de
+     * lifecycle não-mapeado não infla ranking.
+     *
+     * @param int    $relevanciaMeta 0-100 (clampado).
+     * @param string $lifecycle      accepted | accepted-historical | sunsetting | superseded | deprecated
+     */
+    public function pesoDecisao(int $relevanciaMeta, string $lifecycle): float
+    {
+        $rel = $this->clampRelevancia($relevanciaMeta);
+        $tabela = $this->config('lifecycle_mult', self::FALLBACK_LIFECYCLE_MULT);
+
+        // Lifecycle desconhecido → trata como deprecated (peso mínimo).
+        $mult = $tabela[$lifecycle] ?? ($tabela['deprecated'] ?? 0.1);
+
+        return $rel * (float) $mult;
+    }
+
+    /**
+     * (b) MEMÓRIA / lição / fato / session — DECAI por tempo.
+     *
+     *   PESO_MEM = max(piso, relevancia_meta × exp(-dias/half_life)
+     *                        × (1 + log10(recorrencia+1)/log10(6)))
+     *
+     * - Decay exponencial (Generative Agents / ADR 0195): quanto mais antiga,
+     *   menor o peso.
+     * - Bônus de recorrência: memória que reaparece N vezes ganha boost
+     *   logarítmico (saturante — não explode).
+     * - Floor crítico ($critica=true): memória que protege cliente pagante NUNCA
+     *   cai abaixo do piso (fração de relevancia_meta), mesmo muito velha.
+     *
+     * @param int  $relevanciaMeta 0-100 (clampado).
+     * @param int  $diasDesde      dias desde o evento (negativo tratado como 0).
+     * @param bool $critica        true = aplica floor anti-decay (protege cliente).
+     * @param int  $recorrencia    nº de vezes que a memória reapareceu (>=0).
+     * @param int  $halfLife       meia-vida em dias (default config / 60).
+     */
+    public function pesoMemoria(
+        int $relevanciaMeta,
+        int $diasDesde,
+        bool $critica = false,
+        int $recorrencia = 0,
+        int $halfLife = 60,
+    ): float {
+        $rel = $this->clampRelevancia($relevanciaMeta);
+        $dias = max(0, $diasDesde);
+        $rec = max(0, $recorrencia);
+
+        // half_life: usa o argumento se != default explícito; senão config; senão 60.
+        $hl = $halfLife > 0 ? $halfLife : (int) $this->config('half_life', self::FALLBACK_HALF_LIFE);
+        if ($hl <= 0) {
+            $hl = self::FALLBACK_HALF_LIFE;
+        }
+
+        $decay = exp(-$dias / $hl);
+        // Boost de recorrência: log10(rec+1)/log10(6). Normalizado pra que
+        // recorrencia=5 dê ~+1.0 (dobra). Saturante.
+        $boost = 1.0 + (log10($rec + 1) / log10(6));
+
+        $peso = $rel * $decay * $boost;
+
+        if ($critica) {
+            $fracao = (float) $this->config('piso_critico', self::FALLBACK_PISO_CRITICO);
+            $piso = $rel * $fracao;
+            $peso = max($piso, $peso);
+        }
+
+        return $peso;
+    }
+
+    /**
+     * (c) INICIATIVA / módulo — ROI (WSJF / Cost of Delay).
+     *
+     *   PESO_INI = (receita_anual × sinal_cliente × time_criticality) ÷ esforço
+     *
+     * É o NORTE-ROI com time_criticality (Cost of Delay / WSJF) somado: NFe com
+     * prazo SEFAZ pontua acima de módulo de igual valor sem urgência.
+     *
+     * Edge: esforço <= 0 → divisor protegido por 1.0 (evita divisão por zero;
+     * trata como "esforço mínimo / desconhecido", retornando o numerador puro).
+     *
+     * Os fatores sinal_cliente e time_criticality são passados já resolvidos
+     * (use sinalCliente()/timeCriticality() pra mapear rótulos → fator).
+     *
+     * @param float $receitaAnual   receita anual estimada (R$).
+     * @param float $sinalCliente   1.0 paga+reporta · 0.5 qualificado · 0.2 hipótese (ADR 0105).
+     * @param float $timeCriticality 1.0 normal · 1.5 prazo legal/compliance.
+     * @param float $esforco        esforço estimado (dev-days ou pontos). >0.
+     */
+    public function pesoIniciativa(
+        float $receitaAnual,
+        float $sinalCliente,
+        float $timeCriticality,
+        float $esforco,
+    ): float {
+        $numerador = $receitaAnual * $sinalCliente * $timeCriticality;
+
+        // Proteção divisão por zero (e esforço negativo, que não faz sentido).
+        $divisor = $esforco > 0 ? $esforco : 1.0;
+
+        return $numerador / $divisor;
+    }
+
+    /**
+     * Mapeia rótulo de sinal de cliente → fator (ADR 0105).
+     * Rótulo desconhecido → 'hipotese' (0.2, conservador).
+     */
+    public function sinalCliente(string $rotulo): float
+    {
+        $tabela = $this->config('sinal', self::FALLBACK_SINAL);
+
+        return (float) ($tabela[$rotulo] ?? ($tabela['hipotese'] ?? 0.2));
+    }
+
+    /**
+     * Mapeia rótulo de time_criticality → fator (Cost of Delay / WSJF).
+     * Rótulo desconhecido → 'normal' (1.0).
+     */
+    public function timeCriticality(string $rotulo): float
+    {
+        $tabela = $this->config('time_criticality', self::FALLBACK_TIME_CRITICALITY);
+
+        return (float) ($tabela[$rotulo] ?? ($tabela['normal'] ?? 1.0));
+    }
+
+    /**
+     * relevancia_meta é 0-100 por definição (ADR 0232). Clampa pra blindar
+     * entradas fora de faixa.
+     */
+    private function clampRelevancia(int $valor): float
+    {
+        return (float) max(0, min(100, $valor));
+    }
+
+    /**
+     * Lê config('jana.peso_real.<chave>') com fallback hardcoded. Usa helper
+     * config() do Laravel quando disponível; senão (service puro chamado fora do
+     * framework) cai no default sem quebrar.
+     */
+    private function config(string $chave, mixed $fallback): mixed
+    {
+        if (! function_exists('config')) {
+            return $fallback;
+        }
+
+        $valor = config("jana.peso_real.{$chave}");
+
+        return $valor ?? $fallback;
+    }
+}

--- a/Modules/Jana/Tests/Feature/Peso/PesoRealServiceTest.php
+++ b/Modules/Jana/Tests/Feature/Peso/PesoRealServiceTest.php
@@ -1,0 +1,194 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Services\Peso\PesoRealService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Área A / Etapa 5 IAOS — PesoRealService (ADR 0232).
+ *
+ * Função PURA: testes sem DB, sem business_id, sem I/O. Só aritmética
+ * determinística. Cobrem as três fórmulas + edges + fallback de config.
+ *
+ * @see memory/decisions/0232-modelo-peso-real-classificacao-por-meta.md
+ */
+beforeEach(function () {
+    $this->svc = new PesoRealService();
+});
+
+/*
+|--------------------------------------------------------------------------
+| (a) DECISÃO / ADR
+|--------------------------------------------------------------------------
+*/
+
+it('(a) decisão accepted ranka acima de superseded com relevância igual', function () {
+    $accepted   = $this->svc->pesoDecisao(80, 'accepted');
+    $superseded = $this->svc->pesoDecisao(80, 'superseded');
+
+    expect($accepted)->toBe(80.0)            // 80 × 1.0
+        ->and($superseded)->toBe(8.0)        // 80 × 0.1
+        ->and($accepted)->toBeGreaterThan($superseded);
+});
+
+it('(b) decisão NÃO muda com o tempo — peso é função só de relevância × lifecycle', function () {
+    // pesoDecisao nem aceita "idade": a evergreen-ness é estrutural. Provamos
+    // que o mesmo input dá o mesmo peso e que a tabela de lifecycle é monotônica.
+    $hoje  = $this->svc->pesoDecisao(90, 'accepted');
+    $amanha = $this->svc->pesoDecisao(90, 'accepted');
+
+    expect($hoje)->toBe($amanha)->toBe(90.0);
+
+    // lifecycle degrada o peso (supersede), nunca a idade.
+    expect($this->svc->pesoDecisao(90, 'accepted'))
+        ->toBeGreaterThan($this->svc->pesoDecisao(90, 'accepted-historical'))
+        ->and($this->svc->pesoDecisao(90, 'accepted-historical'))
+        ->toBeGreaterThan($this->svc->pesoDecisao(90, 'sunsetting'))
+        ->and($this->svc->pesoDecisao(90, 'sunsetting'))
+        ->toBeGreaterThan($this->svc->pesoDecisao(90, 'superseded'));
+});
+
+it('decisão com lifecycle desconhecido cai no fallback mínimo', function () {
+    expect($this->svc->pesoDecisao(100, 'inexistente'))->toBe(10.0); // 100 × 0.1
+});
+
+/*
+|--------------------------------------------------------------------------
+| (b) MEMÓRIA / lição / fato
+|--------------------------------------------------------------------------
+*/
+
+it('(c) memória decai com os dias', function () {
+    $fresca = $this->svc->pesoMemoria(80, diasDesde: 0);
+    $velha  = $this->svc->pesoMemoria(80, diasDesde: 120);
+    $antiga = $this->svc->pesoMemoria(80, diasDesde: 365);
+
+    expect($fresca)->toBeGreaterThan($velha)
+        ->and($velha)->toBeGreaterThan($antiga);
+
+    // dias=0, recorrencia=0 → decay=1, boost=1 → peso == relevância.
+    expect($fresca)->toBe(80.0);
+});
+
+it('(d) memória crítica não cai abaixo do piso, mesmo muito velha', function () {
+    // 10 anos: o decay puro derrubaria pra ~0.
+    $rel = 90;
+    $semFloor = $this->svc->pesoMemoria($rel, diasDesde: 3650, critica: false);
+    $comFloor = $this->svc->pesoMemoria($rel, diasDesde: 3650, critica: true);
+
+    $piso = $rel * 0.5; // fallback piso_critico = 0.5
+
+    expect($semFloor)->toBeLessThan($piso)        // sem floor afundou
+        ->and($comFloor)->toBe($piso)             // floor segurou exatamente no piso
+        ->and($comFloor)->toBeGreaterThan($semFloor);
+});
+
+it('memória crítica nova fica acima do piso (floor não limita pra baixo o que já é alto)', function () {
+    $rel = 90;
+    $criticaNova = $this->svc->pesoMemoria($rel, diasDesde: 0, critica: true);
+
+    expect($criticaNova)->toBe(90.0)              // decay=1 → peso cheio
+        ->and($criticaNova)->toBeGreaterThan($rel * 0.5);
+});
+
+it('(e) recorrência aumenta o peso da memória', function () {
+    $semRec = $this->svc->pesoMemoria(80, diasDesde: 30, recorrencia: 0);
+    $comRec = $this->svc->pesoMemoria(80, diasDesde: 30, recorrencia: 5);
+
+    expect($comRec)->toBeGreaterThan($semRec);
+});
+
+it('half_life maior preserva mais peso (decay mais lento)', function () {
+    $curto = $this->svc->pesoMemoria(80, diasDesde: 60, halfLife: 30);
+    $longo = $this->svc->pesoMemoria(80, diasDesde: 60, halfLife: 120);
+
+    expect($longo)->toBeGreaterThan($curto);
+});
+
+/*
+|--------------------------------------------------------------------------
+| (c) INICIATIVA / módulo
+|--------------------------------------------------------------------------
+*/
+
+it('(f) iniciativa com sinal 1.0 > iniciativa com sinal 0.2 (resto igual)', function () {
+    $paga     = $this->svc->pesoIniciativa(100000, sinalCliente: 1.0, timeCriticality: 1.0, esforco: 10);
+    $hipotese = $this->svc->pesoIniciativa(100000, sinalCliente: 0.2, timeCriticality: 1.0, esforco: 10);
+
+    expect($paga)->toBeGreaterThan($hipotese)
+        ->and($paga)->toBe(10000.0)    // 100000×1.0×1.0 / 10
+        ->and($hipotese)->toBe(2000.0); // 100000×0.2×1.0 / 10
+});
+
+it('(g) time_criticality 1.5 eleva a iniciativa (Cost of Delay / WSJF)', function () {
+    $normal     = $this->svc->pesoIniciativa(100000, 1.0, timeCriticality: 1.0, esforco: 10);
+    $compliance = $this->svc->pesoIniciativa(100000, 1.0, timeCriticality: 1.5, esforco: 10);
+
+    expect($compliance)->toBeGreaterThan($normal)
+        ->and($compliance)->toBe(15000.0); // ×1.5
+});
+
+it('(h) edge: esforço 0 não divide por zero (divisor protegido por 1.0)', function () {
+    $r = $this->svc->pesoIniciativa(50000, 1.0, 1.0, esforco: 0);
+
+    expect($r)->toBe(50000.0)            // numerador puro
+        ->and(is_finite($r))->toBeTrue(); // sem INF/NAN
+});
+
+it('edge: esforço negativo também protegido', function () {
+    $r = $this->svc->pesoIniciativa(50000, 1.0, 1.0, esforco: -5);
+
+    expect($r)->toBe(50000.0)
+        ->and(is_finite($r))->toBeTrue();
+});
+
+/*
+|--------------------------------------------------------------------------
+| Mapeamento de rótulos
+|--------------------------------------------------------------------------
+*/
+
+it('mapeia rótulos de sinal e time_criticality, com fallback conservador', function () {
+    expect($this->svc->sinalCliente('paga_reporta'))->toBe(1.0)
+        ->and($this->svc->sinalCliente('qualificado'))->toBe(0.5)
+        ->and($this->svc->sinalCliente('hipotese'))->toBe(0.2)
+        ->and($this->svc->sinalCliente('desconhecido'))->toBe(0.2)   // fallback hipótese
+        ->and($this->svc->timeCriticality('normal'))->toBe(1.0)
+        ->and($this->svc->timeCriticality('compliance'))->toBe(1.5)
+        ->and($this->svc->timeCriticality('desconhecido'))->toBe(1.0); // fallback normal
+});
+
+/*
+|--------------------------------------------------------------------------
+| Robustez
+|--------------------------------------------------------------------------
+*/
+
+it('relevancia_meta fora de faixa é clampada para 0-100', function () {
+    expect($this->svc->pesoDecisao(150, 'accepted'))->toBe(100.0)  // clamp topo
+        ->and($this->svc->pesoDecisao(-30, 'accepted'))->toBe(0.0); // clamp piso
+});
+
+it('(i) config ausente usa fallback hardcoded sem quebrar', function () {
+    // Zera toda a config jana.peso_real — o service deve seguir funcionando
+    // com os defaults internos.
+    config(['jana.peso_real' => null]);
+
+    $svc = new PesoRealService();
+
+    expect($svc->pesoDecisao(80, 'accepted'))->toBe(80.0)           // lifecycle fallback
+        ->and($svc->pesoDecisao(80, 'superseded'))->toBe(8.0)
+        ->and($svc->pesoMemoria(90, diasDesde: 3650, critica: true))->toBe(45.0) // piso fallback 0.5
+        ->and($svc->sinalCliente('paga_reporta'))->toBe(1.0)        // sinal fallback
+        ->and($svc->timeCriticality('compliance'))->toBe(1.5);      // time_crit fallback
+});
+
+it('config customizada sobrepõe o fallback', function () {
+    config(['jana.peso_real.piso_critico' => 0.7]);
+
+    $svc = new PesoRealService();
+    // memória crítica velha → piso = 90 × 0.7 = 63 (delta p/ float).
+    expect($svc->pesoMemoria(90, diasDesde: 3650, critica: true))->toEqualWithDelta(63.0, 0.0001);
+});


### PR DESCRIPTION
## O quê

Área A da Etapa 5 do IAOS: a **função PURA** de cálculo do **Peso Real** (ADR 0232 — `memory/decisions/0232-modelo-peso-real-classificacao-por-meta.md`, status `proposto`).

Classifica memórias, decisões e iniciativas por **contribuição à meta R$5M/ano** (ADR 0022). Uma fórmula-mãe, três sabores:

- **(a) `pesoDecisao`** — ADR/decisão é evergreen: modula por `lifecycle_mult` (accepted=1.0 … superseded/deprecated=0.1), **não decai por tempo**.
- **(b) `pesoMemoria`** — decay exponencial (`exp(-dias/half_life)`, ADR 0195) + boost log de recorrência + **floor crítico anti-decay** (lição que protege cliente pagante não cai abaixo do piso, mesmo velha).
- **(c) `pesoIniciativa`** — ROI WSJF / Cost of Delay: `(receita × sinal_cliente × time_criticality) ÷ esforço` (ADR 0105 p/ sinal).

## Características

- Service **PURO**: sem I/O, sem DB, sem `business_id` query — só aritmética determinística. Multi-tenant Tier 0 (ADR 0093) não se aplica (não toca tabela alguma); quem plugar em prod carrega o scope.
- Multiplicadores em `config('jana.peso_real.*')` com **defaults de fallback hardcoded** — não quebra se a config sumir.
- Edge esforço=0 protegido (sem divisão por zero).

## Escopo

**PROPOSTA, NÃO plugada.** Não toca `MeilisearchDriver`, retrieval, settings nem prod. É a função isolada da Área A.

## Testes

16 testes Pest, **43 assertions, 100% passando** (~4.8s). Cobrem: ranking accepted>superseded, decisão invariante no tempo, decay por dias, floor crítico, recorrência, sinal 1.0>0.2, time_criticality 1.5, edge esforço=0, e fallback de config ausente.

Refs: ADR 0232 (proposto)

🤖 Generated with [Claude Code](https://claude.com/claude-code)