### PR TITLE
fix(jana): PesoRealService namespace copiloto.peso_real

### DIFF
--- a/Modules/Jana/Services/Peso/PesoRealService.php
+++ b/Modules/Jana/Services/Peso/PesoRealService.php
@@ -36,7 +36,7 @@ namespace Modules\Jana\Services\Peso;
 class PesoRealService
 {
     /**
-     * Defaults de fallback hardcoded — usados quando config('jana.peso_real.*')
+     * Defaults de fallback hardcoded — usados quando config('copiloto.peso_real.*')
      * está ausente. Garante que o service NUNCA quebra por config faltando.
      */
     private const FALLBACK_LIFECYCLE_MULT = [
@@ -207,7 +207,7 @@ class PesoRealService
     }
 
     /**
-     * Lê config('jana.peso_real.<chave>') com fallback hardcoded. Usa helper
+     * Lê config('copiloto.peso_real.<chave>') com fallback hardcoded. Usa helper
      * config() do Laravel quando disponível; senão (service puro chamado fora do
      * framework) cai no default sem quebrar.
      */
@@ -217,7 +217,7 @@ class PesoRealService
             return $fallback;
         }
 
-        $valor = config("jana.peso_real.{$chave}");
+        $valor = config("copiloto.peso_real.{$chave}");
 
         return $valor ?? $fallback;
     }

--- a/Modules/Jana/Tests/Feature/Peso/PesoRealServiceTest.php
+++ b/Modules/Jana/Tests/Feature/Peso/PesoRealServiceTest.php
@@ -172,9 +172,9 @@ it('relevancia_meta fora de faixa é clampada para 0-100', function () {
 });
 
 it('(i) config ausente usa fallback hardcoded sem quebrar', function () {
-    // Zera toda a config jana.peso_real — o service deve seguir funcionando
+    // Zera toda a config copiloto.peso_real — o service deve seguir funcionando
     // com os defaults internos.
-    config(['jana.peso_real' => null]);
+    config(['copiloto.peso_real' => null]);
 
     $svc = new PesoRealService();
 
@@ -186,7 +186,7 @@ it('(i) config ausente usa fallback hardcoded sem quebrar', function () {
 });
 
 it('config customizada sobrepõe o fallback', function () {
-    config(['jana.peso_real.piso_critico' => 0.7]);
+    config(['copiloto.peso_real.piso_critico' => 0.7]);
 
     $svc = new PesoRealService();
     // memória crítica velha → piso = 90 × 0.7 = 63 (delta p/ float).


### PR DESCRIPTION
Corrige o read de config (jana→copiloto) no PesoRealService — sem isso a config não pega (cai em fallback). Mesmo padrão do gap SeedAdrs. Testes 16/16. 🤖 Generated with [Claude Code](https://claude.com/claude-code)