### PR TITLE
feat(mcp): ingest cobre handoffs/reference/sprints/governance/audits/DS (GAP #1)

### DIFF
--- a/Modules/Jana/Services/Mcp/IndexarMemoryGitParaDb.php
+++ b/Modules/Jana/Services/Mcp/IndexarMemoryGitParaDb.php
@@ -254,6 +254,127 @@ class IndexarMemoryGitParaDb
             ];
         }
 
+        // ─── GAP #1 ingest-coverage (2026-05-29) ──────────────────────────
+        //
+        // Pastas cegas de ALTO VALOR e SEM PII de cliente que a whitelist de
+        // globs acima ignorava. Sem isto, handoffs ("onde paramos" entre
+        // sessões) e os 51 docs canônicos ex-auto-mem NUNCA chegavam ao MCP.
+        //
+        // ⚠️ EXCLUÍDO de propósito (LGPD): memory/clientes/** e memory/feedback/**
+        // têm PII de cliente (email/telefone) que o redactor (só CPF/CNPJ/cartão)
+        // NÃO cobre. Adicionar só quando o redactor cobrir email+telefone.
+
+        // 1. Handoffs — "onde paramos" entre sessões (CRÍTICO p/ continuidade).
+        //    memory/08-handoff.md já coletado acima como slug 'handoff' — não duplica
+        //    (pasta handoffs/ tem nomes datados, sem colisão com '08-handoff').
+        foreach (glob("$base/memory/handoffs/*.md") as $file) {
+            $name = basename($file, '.md');
+            if (str_starts_with($name, '_') || $name === 'README') continue;
+            $arquivos[] = [
+                'slug'   => "handoff-" . strtolower(str_replace(['_', ' '], '-', $name)),
+                'type'   => 'handoff',
+                'module' => $this->detectarModulo($name),
+                'path'   => "memory/handoffs/$name.md",
+                'full'   => $file,
+            ];
+        }
+
+        // 2. Reference recursivo — 51+ docs canônicos ex-auto-mem (ADR 0061).
+        foreach ($this->coletarRecursivo("$base/memory/reference", $base, 'reference', 'reference') as $info) {
+            $arquivos[] = $info;
+        }
+
+        // 3. Sprints recursivo — dossiês de sprint (s3-constituicao, etc).
+        foreach ($this->coletarRecursivo("$base/memory/sprints", $base, 'reference', 'sprint') as $info) {
+            $arquivos[] = $info;
+        }
+
+        // 4. Governance recursivo — CONSTITUTION, ENFORCEMENT, TRUST-TIERS, etc.
+        foreach ($this->coletarRecursivo("$base/memory/governance", $base, 'reference', 'governance') as $info) {
+            $arquivos[] = $info;
+        }
+
+        // 5. Audits na raiz (memory/audits/*.md — NÃO recursivo: subpastas como
+        //    2026-05-pre-sales podem conter material sensível não auditado).
+        foreach (glob("$base/memory/audits/*.md") as $file) {
+            $name = basename($file, '.md');
+            if (str_starts_with($name, '_') || $name === 'README') continue;
+            $arquivos[] = [
+                'slug'   => "audit-root-" . strtolower(str_replace(['_', ' '], '-', $name)),
+                'type'   => 'audit',
+                'module' => $this->detectarModulo($name),
+                'path'   => "memory/audits/$name.md",
+                'full'   => $file,
+            ];
+        }
+
+        // 6. Design System recursivo — PT-01, PRE-MERGE-UI, adr/ui/*.
+        foreach ($this->coletarRecursivo("$base/memory/requisitos/_DesignSystem", $base, 'reference', 'designsystem') as $info) {
+            $arquivos[] = $info;
+        }
+
+        return $arquivos;
+    }
+
+    /**
+     * GAP #1 ingest-coverage — coleta RECURSIVA de *.md numa subárvore.
+     *
+     * glob() do PHP não recursa em subdiretórios, então pastas como
+     * memory/reference/, memory/sprints/ e memory/requisitos/_DesignSystem/adr/ui/
+     * ficavam cegas. Usa RecursiveDirectoryIterator + RecursiveIteratorIterator
+     * (SKIP_DOTS) — pattern canônico PHP 8.4 — pra varrer toda a subárvore.
+     *
+     * Pula arquivos `_*` (templates/índices) e README. Slug único derivado do
+     * caminho relativo (ex: reference/adr/ui/foo.md → 'reference-adr-ui-foo')
+     * pra não colidir entre subpastas homônimas.
+     *
+     * @return list<array{slug:string, type:string, module:?string, path:string, full:string}>
+     */
+    protected function coletarRecursivo(string $dir, string $base, string $type, string $slugPrefix): array
+    {
+        if (! is_dir($dir)) {
+            return [];
+        }
+
+        $arquivos = [];
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::LEAVES_ONLY,
+        );
+
+        foreach ($iterator as $file) {
+            /** @var \SplFileInfo $file */
+            if (! $file->isFile() || strtolower($file->getExtension()) !== 'md') {
+                continue;
+            }
+
+            $name = $file->getBasename('.md');
+            if (str_starts_with($name, '_') || $name === 'README') {
+                continue;
+            }
+
+            // Caminho relativo POSIX a partir do diretório-raiz da subárvore.
+            $full = $file->getPathname();
+            $rel = ltrim(str_replace('\\', '/', substr($full, strlen($dir))), '/'); // ex: adr/ui/foo.md
+            $relSemExt = preg_replace('/\.md$/i', '', $rel);
+
+            // Slug determinístico: prefixo + caminho-relativo slugificado.
+            $slugTail = strtolower(preg_replace('/[^a-z0-9]+/i', '-', $relSemExt));
+            $slugTail = trim((string) $slugTail, '-');
+            $slug = "$slugPrefix-$slugTail";
+
+            // git_path POSIX relativo ao repo (consistente com glob branches acima).
+            $gitPath = ltrim(str_replace('\\', '/', substr($full, strlen($base))), '/');
+
+            $arquivos[] = [
+                'slug'   => $slug,
+                'type'   => $type,
+                'module' => $this->detectarModulo($rel),
+                'path'   => $gitPath,
+                'full'   => $full,
+            ];
+        }
+
         return $arquivos;
     }
 

--- a/Modules/Jana/Tests/Feature/Mcp/IndexarMemoryGitParaDbColetarTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/IndexarMemoryGitParaDbColetarTest.php
@@ -1,0 +1,249 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Services\Mcp\IndexarMemoryGitParaDb;
+
+uses(Tests\TestCase::class);
+
+/**
+ * GAP #1 ingest-coverage (2026-05-29) — cobertura da ingestão git→MCP das
+ * pastas cegas de ALTO VALOR e SEM PII de cliente.
+ *
+ * Antes desta correção a whitelist de globs em coletarArquivos() ignorava
+ * pastas inteiras de memory/ (handoffs/, reference/, sprints/, governance/,
+ * audits/, _DesignSystem/), então handoffs ("onde paramos" entre sessões) e
+ * os 51 docs canônicos ex-auto-mem NUNCA chegavam ao MCP.
+ *
+ * Cobertura:
+ *   (a) memory/handoffs/*.md são coletados (type=handoff)
+ *   (b) memory/reference/** recursivo coletado (type=reference)
+ *   (c) memory/clientes/** NÃO coletado (PII — LGPD)
+ *   (d) memory/feedback/** NÃO coletado (PII — LGPD)
+ *   (e) não duplica memory/08-handoff.md (slug 'handoff' único)
+ *   (f) pula arquivos _* (templates/índices) e README
+ *   (g) sprints/, governance/, _DesignSystem/ recursivos + audits/ raiz
+ *   (h) slugs únicos (sem colisão entre subpastas homônimas)
+ *   (i) caminhos relativos POSIX no campo 'path'
+ *
+ * Testa coletarArquivos() via reflection num repo-fixture temporário — sem DB,
+ * sem Scout, sem rede. Molde: TimeDecayTest.php (teste-por-reflection).
+ */
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Cria árvore de fixtures num diretório temporário e devolve o base path.
+ */
+function coletarFixtureRepo(): string
+{
+    $base = sys_get_temp_dir() . '/jana-ingest-' . uniqid('', true);
+
+    $files = [
+        // handoffs/ — datados + _TEMPLATE + README (estes dois devem ser pulados)
+        'memory/handoffs/2026-05-18-1115-sessao.md'   => "# Sessão handoff\nonde paramos",
+        'memory/handoffs/2026-05-20-0900-outra.md'    => "# Outra sessão\ntexto",
+        'memory/handoffs/_TEMPLATE.md'                => "# Template\nignore",
+        'memory/handoffs/README.md'                   => "# Readme\nignore",
+
+        // 08-handoff raiz — já coletado pela branch legada (slug 'handoff')
+        'memory/08-handoff.md'                        => "# Handoff canônico\nlegado",
+
+        // reference/ recursivo — inclui subpasta + _INDEX (pulado)
+        'memory/reference/cliente-rotalivre.md'       => "# Rota Livre\nperfil",
+        'memory/reference/_INDEX.md'                  => "# Index\nignore",
+        'memory/reference/adr/ui/foo-pattern.md'      => "# Foo Pattern\nui doc",
+
+        // sprints/ recursivo
+        'memory/sprints/s3-constituicao/03-skills-audit.md' => "# Skills audit\ndoc",
+
+        // governance/ recursivo
+        'memory/governance/CONSTITUTION.md'           => "# Constitution\ndoc",
+        'memory/governance/_README.md'                => "# Readme gov\nignore",
+
+        // audits/ raiz (subpasta NÃO recursada)
+        'memory/audits/AUDITORIA-MEMORIA-2026-05-15.md' => "# Auditoria\ndoc",
+        'memory/audits/2026-05-pre-sales/sensivel.md'   => "# Pre-sales\nsensivel",
+
+        // _DesignSystem recursivo
+        'memory/requisitos/_DesignSystem/padroes-tela/PT-01-Lista.md' => "# PT-01\ndoc",
+
+        // PII — devem ser IGNORADOS (não há branch que os colete)
+        'memory/clientes/martinho-cacambas.md'        => "# Martinho\nemail joao@x.com tel (11) 99999-9999",
+        'memory/feedback/algum-feedback.md'           => "# Feedback\nemail maria@y.com",
+    ];
+
+    foreach ($files as $rel => $conteudo) {
+        $full = "$base/$rel";
+        @mkdir(dirname($full), 0777, true);
+        file_put_contents($full, $conteudo);
+    }
+
+    return $base;
+}
+
+/**
+ * Invoca coletarArquivos() via reflection. Retorna list<array{slug,type,module,path,full}>.
+ */
+function coletarInvoke(string $base): array
+{
+    $svc    = new IndexarMemoryGitParaDb($base, 'test', null, 1);
+    $ref    = new ReflectionClass($svc);
+    $method = $ref->getMethod('coletarArquivos');
+    $method->setAccessible(true);
+
+    return $method->invoke($svc);
+}
+
+/** Extrai mapa slug => info pra asserts. */
+function coletarSlugMap(array $arquivos): array
+{
+    $map = [];
+    foreach ($arquivos as $a) {
+        $map[$a['slug']] = $a;
+    }
+    return $map;
+}
+
+function coletarLimpar(string $base): void
+{
+    if (! is_dir($base)) {
+        return;
+    }
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($base, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST,
+    );
+    foreach ($it as $f) {
+        $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+    }
+    @rmdir($base);
+}
+
+// ── (a) handoffs/*.md coletados ────────────────────────────────────────────
+
+it('coleta handoffs/*.md com type=handoff', function () {
+    $base = coletarFixtureRepo();
+    try {
+        $map = coletarSlugMap(coletarInvoke($base));
+
+        expect($map)->toHaveKey('handoff-2026-05-18-1115-sessao');
+        expect($map['handoff-2026-05-18-1115-sessao']['type'])->toBe('handoff');
+        expect($map['handoff-2026-05-18-1115-sessao']['path'])
+            ->toBe('memory/handoffs/2026-05-18-1115-sessao.md');
+
+        expect($map)->toHaveKey('handoff-2026-05-20-0900-outra');
+    } finally {
+        coletarLimpar($base);
+    }
+});
+
+// ── (b) reference/ recursivo coletado ───────────────────────────────────────
+
+it('coleta reference/ recursivamente (inclui subpasta adr/ui)', function () {
+    $base = coletarFixtureRepo();
+    try {
+        $map = coletarSlugMap(coletarInvoke($base));
+
+        // arquivo na raiz da subárvore
+        expect($map)->toHaveKey('reference-cliente-rotalivre');
+        expect($map['reference-cliente-rotalivre']['type'])->toBe('reference');
+
+        // arquivo aninhado (glob não pegaria — prova da recursão)
+        expect($map)->toHaveKey('reference-adr-ui-foo-pattern');
+        expect($map['reference-adr-ui-foo-pattern']['type'])->toBe('reference');
+        expect($map['reference-adr-ui-foo-pattern']['path'])
+            ->toBe('memory/reference/adr/ui/foo-pattern.md');
+    } finally {
+        coletarLimpar($base);
+    }
+});
+
+it('coleta sprints/, governance/ e _DesignSystem/ recursivos + audits/ raiz', function () {
+    $base = coletarFixtureRepo();
+    try {
+        $map = coletarSlugMap(coletarInvoke($base));
+
+        expect($map)->toHaveKey('sprint-s3-constituicao-03-skills-audit');
+        expect($map)->toHaveKey('governance-constitution');
+        expect($map)->toHaveKey('designsystem-padroes-tela-pt-01-lista');
+
+        // audits/ raiz coletado…
+        expect($map)->toHaveKey('audit-root-auditoria-memoria-2026-05-15');
+        expect($map['audit-root-auditoria-memoria-2026-05-15']['type'])->toBe('audit');
+        // …mas subpasta audits/ NÃO recursada (segurança)
+        $temPreSales = collect($map)->contains(
+            fn ($a) => str_contains($a['path'], 'audits/2026-05-pre-sales')
+        );
+        expect($temPreSales)->toBeFalse();
+    } finally {
+        coletarLimpar($base);
+    }
+});
+
+// ── (c)+(d) clientes/ e feedback/ NÃO coletados (PII — LGPD) ────────────────
+
+it('NÃO coleta memory/clientes/** nem memory/feedback/** (PII LGPD)', function () {
+    $base = coletarFixtureRepo();
+    try {
+        $arquivos = coletarInvoke($base);
+
+        $temCliente = collect($arquivos)->contains(
+            fn ($a) => str_contains($a['path'], 'memory/clientes/')
+        );
+        $temFeedback = collect($arquivos)->contains(
+            fn ($a) => str_contains($a['path'], 'memory/feedback/')
+        );
+
+        expect($temCliente)->toBeFalse();
+        expect($temFeedback)->toBeFalse();
+    } finally {
+        coletarLimpar($base);
+    }
+});
+
+// ── (e) não duplica 08-handoff ──────────────────────────────────────────────
+
+it('não duplica memory/08-handoff.md — slug handoff aparece exatamente 1×', function () {
+    $base = coletarFixtureRepo();
+    try {
+        $arquivos = coletarInvoke($base);
+
+        $slugs = array_column($arquivos, 'slug');
+
+        // slug legado 'handoff' (08-handoff.md) coletado 1× só
+        expect(array_count_values($slugs)['handoff'] ?? 0)->toBe(1);
+
+        // o 'handoff' legado aponta pro 08-handoff.md (não pra pasta handoffs/)
+        $map = coletarSlugMap($arquivos);
+        expect($map['handoff']['path'])->toBe('memory/08-handoff.md');
+
+        // nenhum slug duplicado em todo o coletor
+        expect(count($slugs))->toBe(count(array_unique($slugs)));
+    } finally {
+        coletarLimpar($base);
+    }
+});
+
+// ── (f) pula _* e README ────────────────────────────────────────────────────
+
+it('pula arquivos _* (templates/índices) e README', function () {
+    $base = coletarFixtureRepo();
+    try {
+        $arquivos = coletarInvoke($base);
+
+        $temTemplate = collect($arquivos)->contains(
+            fn ($a) => str_contains($a['path'], '_TEMPLATE')
+                || str_contains($a['path'], '_INDEX')
+                || str_contains($a['path'], '_README')
+        );
+        $temReadme = collect($arquivos)->contains(
+            fn ($a) => str_contains($a['path'], 'handoffs/README.md')
+        );
+
+        expect($temTemplate)->toBeFalse();
+        expect($temReadme)->toBeFalse();
+    } finally {
+        coletarLimpar($base);
+    }
+});


### PR DESCRIPTION
## GAP #1 — continuidade entre sessões (maior ROI)

A ingestão git→MCP (`IndexarMemoryGitParaDb::coletarArquivos()`) era uma **whitelist de globs** que ignorava pastas inteiras de `memory/`. Resultado: **handoffs** ("onde paramos" entre sessões) e os **51 docs canônicos ex-auto-mem** (ADR 0061) NUNCA chegavam ao MCP — quebrando a continuidade entre sessões.

### Mudança (aditiva — zero remoção de globs existentes)
| Pasta | Type | Modo |
|---|---|---|
| `memory/handoffs/*.md` | `handoff` | flat (pula `_*`/README) |
| `memory/reference/**` | `reference` | recursivo |
| `memory/sprints/**` | `reference` | recursivo |
| `memory/governance/**` | `reference` | recursivo |
| `memory/audits/*.md` | `audit` | raiz (subpasta NÃO recursada) |
| `memory/requisitos/_DesignSystem/**` | `reference` | recursivo |

Novo helper `coletarRecursivo()` usa `RecursiveDirectoryIterator` (glob do PHP não recursa). Slug determinístico por caminho relativo (sem colisão entre subpastas homônimas). Não duplica `memory/08-handoff.md` (slug `handoff` único).

### LGPD — exclusão proposital
`memory/clientes/**` e `memory/feedback/**` **NÃO** são coletados: contêm PII de cliente (email/telefone) que o redactor atual (só CPF/CNPJ/cartão) não cobre. Adicionar só quando o redactor cobrir email+telefone.

### Validação
- **Sanity real-tree:** total 1057 docs · `handoff=55` · `reference=294` · `audit=15` · **0 slugs duplicados** · **0 PII vazada** de clientes/feedback.
- **Pest:** 6 passed (22 assertions).
- **PHPStan:** No errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)