### PR TITLE
fix(jana): freshness pipeline — drift git-SHA wired + STALE/CRITICAL cutoffs separados

### DIFF
--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -262,10 +262,20 @@ return [
     'freshness' => [
         'enabled'      => env('JANA_FRESHNESS_PIPELINE', true),
         'auto_reindex' => env('JANA_FRESHNESS_AUTO_REINDEX', false),
+        // Semântica dos cutoffs (alinhada com StalenessDetectorService::staleness):
+        //   FRESH    → age <= fresh (1d)
+        //   WARM     → fresh < age < warm (1d–7d)
+        //   STALE    → warm <= age < stale (7d–30d)   ← faixa warning
+        //   CRITICAL → age >= critical (>=30d)         ← alerta mcp_alertas_eventos
+        // `detectStale()` usa `warm` como cutoff (pega tudo >= 7d, inclui CRITICAL);
+        // `detectCritical()` usa `critical` (pega só >= 30d). A faixa 7-30d isolada
+        // = detectStale − detectCritical. Chave `stale` mantida pro método
+        // `staleness()` (fronteira STALE→CRITICAL). BUG-2 fix 2026-05-29.
         'thresholds_days' => [
-            'fresh' => (int) env('JANA_FRESHNESS_THRESHOLD_FRESH', 1),
-            'warm'  => (int) env('JANA_FRESHNESS_THRESHOLD_WARM', 7),
-            'stale' => (int) env('JANA_FRESHNESS_THRESHOLD_STALE', 30),
+            'fresh'    => (int) env('JANA_FRESHNESS_THRESHOLD_FRESH', 1),
+            'warm'     => (int) env('JANA_FRESHNESS_THRESHOLD_WARM', 7),
+            'stale'    => (int) env('JANA_FRESHNESS_THRESHOLD_STALE', 30),
+            'critical' => (int) env('JANA_FRESHNESS_THRESHOLD_CRITICAL', 30),
         ],
     ],
 

--- a/Modules/Jana/Console/Commands/FreshnessCheckCommand.php
+++ b/Modules/Jana/Console/Commands/FreshnessCheckCommand.php
@@ -50,6 +50,12 @@ class FreshnessCheckCommand extends Command
 
         $dryRun = (bool) $this->option('dry-run');
 
+        // BUG-1 fix (2026-05-29): injeta o path real do repo git no detector.
+        // Sem isso `repoBasePath` ficava null (default do construtor) e o drift
+        // tipo-SHA (git↔DB) nunca era avaliado. shell_exec ausente (Hostinger)
+        // degrada gracioso — lerGitShaAtual retorna null e o drift git é pulado.
+        $detector->comRepoBasePath(base_path());
+
         // Fase 1 — contagem por nível
         $contagem = $detector->contagemPorNivel();
 

--- a/Modules/Jana/Services/Memoria/Freshness/StalenessDetectorService.php
+++ b/Modules/Jana/Services/Memoria/Freshness/StalenessDetectorService.php
@@ -48,6 +48,22 @@ final class StalenessDetectorService
     }
 
     /**
+     * Injeta o path do repo git (ex `base_path()`) pós-construção.
+     *
+     * BUG-1 fix (2026-05-29): o service é resolvido pelo container com
+     * `repoBasePath = null` (default), o que desligava silenciosamente o
+     * drift tipo-SHA (git↔DB). O FreshnessCheckCommand passa a chamar este
+     * setter com `base_path()` pra habilitar a detecção do drift "doc mudou
+     * no git mas o sync silenciou".
+     */
+    public function comRepoBasePath(?string $repoBasePath): static
+    {
+        $this->repoBasePath = $repoBasePath;
+
+        return $this;
+    }
+
+    /**
      * Retorna documentos com indexed_at acima do threshold de STALE/CRITICAL.
      *
      * @return array<int, McpMemoryDocument>
@@ -55,7 +71,10 @@ final class StalenessDetectorService
     public function detectStale(): array
     {
         return OtelHelper::spanBiz('jana.freshness.detect_stale', function () {
-            $staleDays = (int) config('copiloto.freshness.thresholds_days.stale', 7);
+            // BUG-2 fix (2026-05-29): STALE começa quando age >= warm (7d), não
+            // no cutoff de CRITICAL. Antes lia `stale` (=30) → a faixa 7-30d nunca
+            // era pega por detectStale. Cutoff = warm (default 7).
+            $staleDays = (int) config('copiloto.freshness.thresholds_days.warm', 7);
             $cutoff = now()->subDays($staleDays);
 
             return McpMemoryDocument::query()
@@ -238,7 +257,12 @@ final class StalenessDetectorService
      */
     public function detectCritical(): array
     {
-        $criticalDays = (int) config('copiloto.freshness.thresholds_days.stale', 30);
+        // BUG-2 fix (2026-05-29): CRITICAL lê a chave própria `critical` (>=30d),
+        // não `stale`. Fallback alinhado com staleness() (fronteira STALE→CRITICAL).
+        $criticalDays = (int) config(
+            'copiloto.freshness.thresholds_days.critical',
+            (int) config('copiloto.freshness.thresholds_days.stale', 30)
+        );
         $cutoff = now()->subDays($criticalDays);
 
         return McpMemoryDocument::query()
@@ -264,10 +288,15 @@ final class StalenessDetectorService
             return null;
         }
 
+        // Redireciona stderr cross-platform: `2>/dev/null` (POSIX/prod Linux) ou
+        // `2>NUL` (Windows dev). `2>/dev/null` no cmd.exe é interpretado como path
+        // inválido e faz o comando inteiro falhar (silenciava o drift git no dev).
+        $nullDevice = stripos(PHP_OS, 'WIN') === 0 ? '2>NUL' : '2>/dev/null';
         $cmd = sprintf(
-            'git -C %s log -n 1 --format=%%H -- %s 2>/dev/null',
+            'git -C %s log -n 1 --format=%%H -- %s %s',
             escapeshellarg($this->repoBasePath),
-            escapeshellarg($relativePath)
+            escapeshellarg($relativePath),
+            $nullDevice
         );
         try {
             $sha = trim((string) @shell_exec($cmd));

--- a/Modules/Jana/Tests/Feature/Memoria/Freshness/StalenessDetectorTest.php
+++ b/Modules/Jana/Tests/Feature/Memoria/Freshness/StalenessDetectorTest.php
@@ -89,6 +89,7 @@ beforeEach(function () {
     config()->set('copiloto.freshness.thresholds_days.fresh', 1);
     config()->set('copiloto.freshness.thresholds_days.warm', 7);
     config()->set('copiloto.freshness.thresholds_days.stale', 30);
+    config()->set('copiloto.freshness.thresholds_days.critical', 30);
 });
 
 afterEach(function () {
@@ -114,6 +115,19 @@ function freshFazDoc(string $slug, ?\DateTimeInterface $indexedAt, array $extras
         ], $extras));
         return $doc;
     });
+}
+
+/**
+ * Nivela indexed_at = updated_at (mesmo instante) pra um doc — isola o drift
+ * tipo-B (git-SHA) do tipo-A (updated_at > indexed_at). Usa update direto no DB
+ * pra não re-bumpar updated_at via Eloquent.
+ */
+function freshNivelaTimestamps(int $id): void
+{
+    $ts = now();
+    DB::table('mcp_memory_documents')
+        ->where('id', $id)
+        ->update(['indexed_at' => $ts, 'updated_at' => $ts]);
 }
 
 // ─── testes ─────────────────────────────────────────────────────────────────
@@ -242,4 +256,197 @@ it('doc com indexed_at NULL é CRITICAL (nunca foi indexado)', function () {
 
     $stale = $detector->detectStale();
     expect($stale)->toHaveCount(1);
+});
+
+// ─── BUG-2 regression — STALE (7-30d) isolado de CRITICAL (>=30d) ─────────────
+
+it('BUG-2: doc de 15d é detectStale mas NÃO detectCritical (faixa STALE 7-30d isolada)', function () {
+    $doc = freshFazDoc('stale-15d', now()->subDays(15));
+
+    $detector = new StalenessDetectorService();
+
+    // detectStale (cutoff = warm = 7d) deve pegar o doc de 15d.
+    $stale = $detector->detectStale();
+    expect($stale)->toHaveCount(1);
+    expect($stale[0]->slug)->toBe('stale-15d');
+
+    // detectCritical (cutoff = critical = 30d) NÃO deve pegar 15d.
+    $critical = $detector->detectCritical();
+    expect($critical)->toHaveCount(0);
+
+    // staleness() confirma classificação STALE (não CRITICAL).
+    expect($detector->staleness($doc))->toBe(StalenessDetectorService::NIVEL_STALE);
+});
+
+it('BUG-2: doc de 40d é CRITICAL (detectCritical pega, staleness classifica CRITICAL)', function () {
+    $doc = freshFazDoc('critical-40d', now()->subDays(40));
+
+    $detector = new StalenessDetectorService();
+
+    $critical = $detector->detectCritical();
+    expect($critical)->toHaveCount(1);
+    expect($critical[0]->slug)->toBe('critical-40d');
+
+    // 40d também é stale (superset), mas o ponto é: NÃO some do CRITICAL.
+    expect($detector->detectStale())->toHaveCount(1);
+
+    expect($detector->staleness($doc))->toBe(StalenessDetectorService::NIVEL_CRITICAL);
+});
+
+it('BUG-2: faixa 7-30d separa STALE de CRITICAL (8d/15d/29d stale-only; 31d/45d critical)', function () {
+    // Valores afastados das fronteiras exatas (7/30) — as queries usam `<` no
+    // cutoff (strict), então um doc indexed_at EXATO em now-30d cai na borda do
+    // microssegundo. Os cenários reais nunca batem o limite no microssegundo.
+    foreach ([8, 15, 29] as $d) {
+        freshFazDoc("warn-{$d}d", now()->subDays($d));
+    }
+    foreach ([31, 45] as $d) {
+        freshFazDoc("crit-{$d}d", now()->subDays($d));
+    }
+
+    $detector = new StalenessDetectorService();
+
+    // detectStale pega todos >= 7d (3 stale-only + 2 critical = 5).
+    expect($detector->detectStale())->toHaveCount(5);
+
+    // detectCritical pega só >= 30d (2).
+    $critical = $detector->detectCritical();
+    expect($critical)->toHaveCount(2);
+    expect(collect($critical)->pluck('slug')->sort()->values()->all())
+        ->toBe(['crit-31d', 'crit-45d']);
+});
+
+// ─── BUG-1 regression — drift tipo-SHA (git↔DB) ──────────────────────────────
+//
+// StalenessDetectorService é `final` (não subclassável de propósito). Em vez de
+// stubar lerGitShaAtual, exercitamos o ramo git real montando um repo git
+// temporário (fixture). Pula gracioso quando git/shell_exec ausente — que é
+// exatamente o cenário de degradação coberto pelo último teste.
+
+function freshGitDisponivel(): bool
+{
+    if (! function_exists('shell_exec')) {
+        return false;
+    }
+    $disabled = explode(',', (string) ini_get('disable_functions'));
+    if (in_array('shell_exec', $disabled, true)) {
+        return false;
+    }
+    $probe = @shell_exec('git --version 2>&1');
+
+    return is_string($probe) && str_contains($probe, 'git version');
+}
+
+function freshMontaRepoGitTemp(): string
+{
+    $dir = sys_get_temp_dir() . '/fresh_git_' . bin2hex(random_bytes(6));
+    mkdir($dir, 0777, true);
+    mkdir($dir . '/memory/decisions', 0777, true);
+    file_put_contents($dir . '/memory/decisions/drift-sha-doc.md', "# doc\nv1\n");
+
+    $q = escapeshellarg($dir);
+    shell_exec("git -C {$q} init -q 2>&1");
+    shell_exec("git -C {$q} config user.email t@t.dev 2>&1");
+    shell_exec("git -C {$q} config user.name tester 2>&1");
+    shell_exec("git -C {$q} add . 2>&1");
+    shell_exec("git -C {$q} commit -q -m init 2>&1");
+
+    return $dir;
+}
+
+function freshRemoveDir(string $dir): void
+{
+    if (! is_dir($dir)) {
+        return;
+    }
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+        RecursiveIteratorIterator::CHILD_FIRST
+    );
+    foreach ($it as $f) {
+        $f->isDir() ? @rmdir($f->getPathname()) : @unlink($f->getPathname());
+    }
+    @rmdir($dir);
+}
+
+it('BUG-1: drift por SHA detectado quando repoBasePath setado e git_sha diverge', function () {
+    if (! freshGitDisponivel()) {
+        $this->markTestSkipped('git/shell_exec indisponível — ramo git-SHA coberto pelo teste de degradação.');
+    }
+
+    $repo = freshMontaRepoGitTemp();
+
+    try {
+        // git_sha no DB diverge do HEAD real do arquivo no repo → drift tipo-B.
+        // indexed_at >= updated_at isola o cenário (evita drift tipo-A).
+        $doc = freshFazDoc('drift-sha-doc', now(), [
+            'git_sha'  => 'staleshanaobate0000000000000000000000000',
+            'git_path' => 'memory/decisions/drift-sha-doc.md',
+        ]);
+        freshNivelaTimestamps($doc->id);
+
+        $detector = (new StalenessDetectorService())->comRepoBasePath($repo);
+        $drift = $detector->detectDrift();
+
+        expect($drift)->toHaveCount(1);
+        expect($drift[0]->slug)->toBe('drift-sha-doc');
+    } finally {
+        freshRemoveDir($repo);
+    }
+});
+
+it('BUG-1: NÃO acusa drift-SHA quando git_sha bate com HEAD real do repo', function () {
+    if (! freshGitDisponivel()) {
+        $this->markTestSkipped('git/shell_exec indisponível.');
+    }
+
+    $repo = freshMontaRepoGitTemp();
+
+    try {
+        $q = escapeshellarg($repo);
+        $headSha = trim((string) shell_exec(
+            "git -C {$q} log -n 1 --format=%H -- memory/decisions/drift-sha-doc.md 2>&1"
+        ));
+
+        // git_sha do DB == HEAD real → sem divergência. indexed_at >= updated_at.
+        $doc = freshFazDoc('drift-sha-doc', now(), [
+            'git_sha'  => $headSha,
+            'git_path' => 'memory/decisions/drift-sha-doc.md',
+        ]);
+        freshNivelaTimestamps($doc->id);
+
+        $detector = (new StalenessDetectorService())->comRepoBasePath($repo);
+
+        expect($detector->detectDrift())->toHaveCount(0);
+    } finally {
+        freshRemoveDir($repo);
+    }
+});
+
+it('BUG-1: setter comRepoBasePath é fluent e retorna o próprio service', function () {
+    $detector = new StalenessDetectorService();
+
+    expect($detector->comRepoBasePath(base_path()))
+        ->toBeInstanceOf(StalenessDetectorService::class);
+});
+
+it('BUG-1: degrada gracioso quando repoBasePath aponta pra dir sem git (Hostinger sem shell_exec)', function () {
+    // Sem repoBasePath (default null) o ramo git-SHA nem roda. E apontando pra
+    // um dir que NÃO é repo git, lerGitShaAtual retorna null → nenhum drift-SHA
+    // acusado e zero crash (fallback NULL preservado).
+    $dirSemGit = sys_get_temp_dir() . '/fresh_nogit_' . bin2hex(random_bytes(4));
+    mkdir($dirSemGit, 0777, true);
+
+    try {
+        $doc = freshFazDoc('no-git-doc', now()); // sem drift tipo-A
+        freshNivelaTimestamps($doc->id);
+
+        $detector = (new StalenessDetectorService())->comRepoBasePath($dirSemGit);
+
+        // Não lança, e como git_sha não bate com "HEAD inexistente" (null),
+        // o doc NÃO entra em drift-SHA (null != sha → pulado).
+        expect($detector->detectDrift())->toHaveCount(0);
+    } finally {
+        freshRemoveDir($dirSemGit);
+    }
 });


### PR DESCRIPTION
## Contexto

Dois bugs no freshness pipeline da memória (`mcp_memory_documents`), GAP D7 #2 da auditoria memoria-senior 2026-05-15.

## BUG 1 — drift git↔DB tipo-SHA estava desligado

`StalenessDetectorService::doDetectDrift()` só comparava o git SHA quando `repoBasePath !== null`, mas o construtor default é `null` e nada injetava o path. Resultado: o drift "doc mudou no git mas o sync silenciou (perdeu webhook + cron)" **nunca era detectado**.

Fix:
- Setter fluent novo `comRepoBasePath()` no service.
- `FreshnessCheckCommand` injeta `base_path()` antes de rodar o detector.
- `shell_exec` ausente (Hostinger) continua degradando gracioso — fallback NULL preservado.
- Hardening cross-platform: `lerGitShaAtual` escolhe `2>NUL` (Windows) ou `2>/dev/null` (Linux). O `2>/dev/null` no cmd.exe fazia o comando git inteiro falhar (silenciava o ramo git em dev Windows).

## BUG 2 — STALE e CRITICAL usavam o mesmo cutoff

`detectStale()` lia `thresholds_days.stale` (fallback 7) e `detectCritical()` lia a **mesma** chave (fallback 30), mas a config define `stale => 30`. Logo a faixa 7-30d (STALE/warning) **nunca era isolada** e `detectStale() == detectCritical()`.

Fix (alinhado com `staleness()`):
- `detectStale()` usa `warm` (>=7d, início da faixa STALE).
- `detectCritical()` usa nova chave de config `critical` (>=30d).
- `stale` mantido para a fronteira STALE→CRITICAL em `staleness()`.

## Semântica final

| Nível | Faixa |
|---|---|
| FRESH | age <= 1d |
| WARM | 1d < age < 7d |
| STALE | 7d <= age < 30d (`detectStale` − `detectCritical`) |
| CRITICAL | age >= 30d (`detectCritical`) |

## Testes

`Modules/Jana/Tests/Feature/Memoria/Freshness/StalenessDetectorTest.php` — +9 cenários:
- BUG-2: 15d → STALE (não CRITICAL); 40d → CRITICAL; faixa 8/15/29d stale-only vs 31/45d critical.
- BUG-1: drift por SHA com repo git temporário real; sem drift quando SHA bate; setter fluent; degradação gracioso sem git.

```
Tests:    16 passed (40 assertions)
PHPStan:  No errors
```

## Multi-tenant

`mcp_memory_documents` é repo-wide (cross-tenant, sem `business_id`) — ADR 0053 pilar 6. Nenhuma query introduzida viola escopo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)