### PR TITLE
fix(jana): seed-adrs metadata canônico p/ time-decay + schedule diário

### DIFF
--- a/Modules/Jana/Console/Commands/SeedAdrsCommand.php
+++ b/Modules/Jana/Console/Commands/SeedAdrsCommand.php
@@ -118,16 +118,7 @@ class SeedAdrsCommand extends Command
             // Monta o "fato" textual que irá pro índice Meilisearch
             $fato = $this->buildFatoText($doc, $meta, $summary, $status);
 
-            $fatoMeta = json_encode([
-                'seeded_from_mcp' => true,
-                'source_type'     => $doc->type,
-                'source_slug'     => $doc->slug,
-                'source_title'    => $doc->title,
-                'adr_status'      => $status,
-                'supersedes'      => $supersedes,
-                'module'          => $meta['module'] ?? null,
-                'indexed_at'      => $doc->indexed_at,
-            ]);
+            $fatoMeta = json_encode($this->buildFatoMetadata($doc, $meta, $status, $supersedes));
 
             if ($dryRun) {
                 $this->line("  [DRY] [{$doc->slug}] status={$status} superseded=" . ($isSuperseded ? 'sim' : 'não'));
@@ -200,6 +191,93 @@ class SeedAdrsCommand extends Command
         $content = trim($content);
 
         return mb_substr($content, 0, 400);
+    }
+
+    /**
+     * Monta o metadata do fato gravado em jana_memoria_facts.metadata.
+     *
+     * GAP (auditoria 2026-05-28): o time-decay do MeilisearchDriver lê
+     * `metadata['doc_type']`, `metadata['status']` e `metadata['published_at']`
+     * (ver MeilisearchDriver::applyTimeDecay + resolveDocDate). As chaves antigas
+     * (`source_type`/`adr_status`/`indexed_at`) NÃO casavam, então TODO fato de ADR
+     * caía no fallback do decay (temporal_factor=1.0, status_multiplier=default).
+     *
+     * Solução: gravar AS NOVAS chaves canônicas (doc_type/status/published_at)
+     * MANTENDO as antigas pra back-compat (outros consumidores e fatos já gravados).
+     *
+     * - doc_type: $doc->type cru (adr|spec|reference) — vocabulário do half_life da config.
+     * - status: normalizado PT→EN (normalizeStatus) — vocabulário status_multipliers
+     *   (accepted/proposed/historical/superseded).
+     * - published_at: melhor data real disponível no metadata do MCP, com fallback
+     *   em indexed_at (decided_at > accepted_at > date > indexed_at).
+     *
+     * @param  array<string, mixed> $meta Metadata cru do mcp_memory_documents.
+     * @return array<string, mixed>
+     */
+    public function buildFatoMetadata(object $doc, array $meta, string $status, ?string $supersedes): array
+    {
+        return [
+            'seeded_from_mcp' => true,
+            'source_type'     => $doc->type,
+            'source_slug'     => $doc->slug,
+            'source_title'    => $doc->title,
+            'adr_status'      => $status,
+            'supersedes'      => $supersedes,
+            'module'          => $meta['module'] ?? null,
+            'indexed_at'      => $doc->indexed_at,
+
+            // ── chaves canônicas lidas pelo time-decay (MeilisearchDriver) ──
+            'doc_type'     => $doc->type,
+            'status'       => $this->normalizeStatus($status),
+            'published_at' => $this->resolvePublishedAt($doc, $meta),
+        ];
+    }
+
+    /**
+     * Normaliza o status do ADR (PT ou EN) pro vocabulário EN canônico do
+     * config copiloto.time_decay.status_multipliers:
+     * accepted | proposed | historical | superseded.
+     *
+     * Mapeamentos:
+     *   aceito/aceita/accepted          → accepted
+     *   proposto/proposta/proposed      → proposed
+     *   superseded/supersedido/         → superseded
+     *     supersedida/deprecated/
+     *     depreciado/rejected/rejeitado
+     *   historical/historico/histórico  → historical
+     *
+     * Status desconhecido → 'default' (multiplier 1.0, sem boost nem pena).
+     */
+    public function normalizeStatus(?string $status): string
+    {
+        $s = trim(Str::lower((string) $status));
+
+        return match ($s) {
+            'aceito', 'aceita', 'accepted', 'aceitado', 'aceitada'  => 'accepted',
+            'proposto', 'proposta', 'proposed'                      => 'proposed',
+            'superseded', 'supersedido', 'supersedida', 'substituido', 'substituída',
+            'substituida', 'deprecated', 'depreciado', 'depreciada',
+            'rejected', 'rejeitado', 'rejeitada'                    => 'superseded',
+            'historical', 'historico', 'histórico', 'historica', 'histórica' => 'historical',
+            default                                                 => 'default',
+        };
+    }
+
+    /**
+     * Resolve a data real de publicação do doc pro decay temporal.
+     * Prioridade: metadata.decided_at → accepted_at → date → fallback indexed_at.
+     *
+     * @param  array<string, mixed> $meta
+     */
+    public function resolvePublishedAt(object $doc, array $meta): ?string
+    {
+        $candidate = $meta['decided_at']
+            ?? $meta['accepted_at']
+            ?? $meta['date']
+            ?? $doc->indexed_at
+            ?? null;
+
+        return $candidate !== null ? (string) $candidate : null;
     }
 
     private function buildFatoText(object $doc, array $meta, string $summary, string $status): string

--- a/Modules/Jana/Tests/Feature/Memoria/SeedAdrsMetadataTest.php
+++ b/Modules/Jana/Tests/Feature/Memoria/SeedAdrsMetadataTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Console\Commands\SeedAdrsCommand;
+
+uses(Tests\TestCase::class);
+
+/**
+ * GAP seed (auditoria 2026-05-28) — SeedAdrsCommand gravava metadata com chaves
+ * ERRADAS (source_type/adr_status/indexed_at), neutralizando o time-decay do
+ * MeilisearchDriver (que lê doc_type/status/published_at). Resultado: todo fato
+ * de ADR caía no fallback do decay.
+ *
+ * Cobertura:
+ *   - normalizeStatus() PT→EN no vocabulário do config status_multipliers
+ *     (accepted/proposed/historical/superseded) + fallback 'default'.
+ *   - buildFatoMetadata() grava doc_type/status/published_at corretos.
+ *   - Back-compat: chaves antigas continuam presentes.
+ *   - resolvePublishedAt() prioriza decided_at > accepted_at > date > indexed_at.
+ *
+ * Métodos public no command → invocação direta (sem reflection, sem DB, sem LLM).
+ */
+
+// ── helper ─────────────────────────────────────────────────────────────────
+
+/**
+ * Doc fake no shape que o command recebe do mcp_memory_documents (stdClass).
+ */
+function seedFakeDoc(string $type = 'adr', string $indexedAt = '2026-01-10 00:00:00'): object
+{
+    return (object) [
+        'id'         => 1,
+        'slug'       => '0093-multi-tenant-isolation-tier-0',
+        'type'       => $type,
+        'title'      => 'Multi-tenant isolation Tier 0',
+        'content_md' => '# ADR',
+        'metadata'   => '{}',
+        'indexed_at' => $indexedAt,
+    ];
+}
+
+// ── 1. normalizeStatus PT→EN ─────────────────────────────────────────────────
+
+it('normaliza status PT/EN aceito → accepted', function (string $input) {
+    $cmd = new SeedAdrsCommand();
+    expect($cmd->normalizeStatus($input))->toBe('accepted');
+})->with(['aceito', 'aceita', 'Aceito', 'ACCEPTED', 'accepted', 'aceitado']);
+
+it('normaliza status PT/EN proposto → proposed', function (string $input) {
+    $cmd = new SeedAdrsCommand();
+    expect($cmd->normalizeStatus($input))->toBe('proposed');
+})->with(['proposto', 'proposta', 'Proposed', 'PROPOSTO']);
+
+it('normaliza status PT/EN supersede/deprecated/rejected → superseded', function (string $input) {
+    $cmd = new SeedAdrsCommand();
+    expect($cmd->normalizeStatus($input))->toBe('superseded');
+})->with([
+    'superseded', 'supersedido', 'supersedida',
+    'deprecated', 'depreciado', 'depreciada',
+    'rejected', 'rejeitado', 'rejeitada',
+    'substituido', 'substituida',
+]);
+
+it('normaliza status PT/EN historico → historical', function (string $input) {
+    $cmd = new SeedAdrsCommand();
+    expect($cmd->normalizeStatus($input))->toBe('historical');
+})->with(['historical', 'historico', 'histórico', 'HISTORICAL']);
+
+it('status desconhecido cai em default (multiplier 1.0 no config)', function () {
+    $cmd = new SeedAdrsCommand();
+    expect($cmd->normalizeStatus('xpto-nao-existe'))->toBe('default');
+    expect($cmd->normalizeStatus(''))->toBe('default');
+    expect($cmd->normalizeStatus(null))->toBe('default');
+});
+
+it('só emite status do vocabulário canônico do config status_multipliers', function () {
+    $cmd = new SeedAdrsCommand();
+    $vocab = array_keys((array) config('copiloto.time_decay.status_multipliers'));
+
+    foreach (['aceito', 'proposto', 'superseded', 'historico', 'qualquer-coisa'] as $raw) {
+        expect($vocab)->toContain($cmd->normalizeStatus($raw));
+    }
+});
+
+// ── 2. buildFatoMetadata grava as chaves canônicas do time-decay ─────────────
+
+it('grava doc_type/status/published_at corretos pro time-decay ler', function () {
+    $cmd  = new SeedAdrsCommand();
+    $doc  = seedFakeDoc('adr', '2026-01-10 00:00:00');
+    $meta = ['module' => 'Jana', 'decided_at' => '2026-05-06'];
+
+    $built = $cmd->buildFatoMetadata($doc, $meta, 'aceito', null);
+
+    // chaves canônicas que MeilisearchDriver::applyTimeDecay + resolveDocDate leem
+    expect($built['doc_type'])->toBe('adr');
+    expect($built['status'])->toBe('accepted');          // PT→EN normalizado
+    expect($built['published_at'])->toBe('2026-05-06');  // decided_at, NÃO indexed_at
+});
+
+it('mantém as chaves antigas pra back-compat', function () {
+    $cmd   = new SeedAdrsCommand();
+    $doc   = seedFakeDoc('adr');
+    $built = $cmd->buildFatoMetadata($doc, ['module' => 'Jana'], 'aceito', 'ADR-0050');
+
+    expect($built)->toHaveKeys([
+        'seeded_from_mcp', 'source_type', 'source_slug', 'source_title',
+        'adr_status', 'supersedes', 'module', 'indexed_at',
+    ]);
+    expect($built['source_type'])->toBe('adr');
+    expect($built['adr_status'])->toBe('aceito');   // crú preservado (back-compat)
+    expect($built['supersedes'])->toBe('ADR-0050');
+    expect($built['module'])->toBe('Jana');
+});
+
+it('doc_type espelha o tipo cru do doc (spec/reference)', function (string $type) {
+    $cmd   = new SeedAdrsCommand();
+    $built = $cmd->buildFatoMetadata(seedFakeDoc($type), [], 'aceito', null);
+    expect($built['doc_type'])->toBe($type);
+})->with(['adr', 'spec', 'reference']);
+
+// ── 3. resolvePublishedAt: prioridade decided_at > accepted_at > date > indexed_at
+
+it('resolvePublishedAt prioriza decided_at', function () {
+    $cmd = new SeedAdrsCommand();
+    $meta = ['decided_at' => '2026-05-06', 'accepted_at' => '2026-05-07', 'date' => '2026-05-08'];
+    expect($cmd->resolvePublishedAt(seedFakeDoc('adr', '2026-01-01 00:00:00'), $meta))
+        ->toBe('2026-05-06');
+});
+
+it('resolvePublishedAt usa accepted_at quando não tem decided_at', function () {
+    $cmd = new SeedAdrsCommand();
+    expect($cmd->resolvePublishedAt(seedFakeDoc(), ['accepted_at' => '2026-05-07', 'date' => '2026-05-08']))
+        ->toBe('2026-05-07');
+});
+
+it('resolvePublishedAt usa date quando não tem decided_at/accepted_at', function () {
+    $cmd = new SeedAdrsCommand();
+    expect($cmd->resolvePublishedAt(seedFakeDoc(), ['date' => '2026-05-08']))
+        ->toBe('2026-05-08');
+});
+
+it('resolvePublishedAt cai em indexed_at quando metadata não tem datas', function () {
+    $cmd = new SeedAdrsCommand();
+    expect($cmd->resolvePublishedAt(seedFakeDoc('adr', '2026-01-10 00:00:00'), []))
+        ->toBe('2026-01-10 00:00:00');
+});
+
+it('published_at é null quando não há nenhuma data (não crasha o decay)', function () {
+    $cmd = new SeedAdrsCommand();
+    $doc = seedFakeDoc('adr');
+    $doc->indexed_at = null;
+    expect($cmd->resolvePublishedAt($doc, []))->toBeNull();
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -495,6 +495,29 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // MEM-MULTI-1 (auditoria seed 2026-05-28) — re-seed ADRs → jana_memoria_facts
+        // diário. Sem este schedule os fatos de ADR ficavam STALE: nova ADR aceita /
+        // ADR supersedida não viravam fato pesquisável até alguém rodar o command na mão.
+        //
+        // 04:45 BRT escolhido de propósito: DEPOIS do jana:freshness-check (04:30) que
+        // reindexa docs STALE/drift no Meilisearch, e bem depois do último ciclo de
+        // mcp:sync-memory (every5min — withoutOverlapping protege se o sync ainda estiver
+        // rodando). Idempotente (upsert por source_slug), safe pra cron diário.
+        // --type=all cobre adr+spec+reference numa passada.
+        $schedule->command('copiloto:seed-adrs --type=all')
+            ->dailyAt('04:45')
+            ->timezone('America/Sao_Paulo')
+            ->name('copiloto-seed-adrs-daily')
+            ->withoutOverlapping()
+            ->environments(['live'])
+            ->appendOutputTo(storage_path('logs/copiloto-seed-adrs.log'))
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('copiloto-ai')->error(
+                    'Schedule copiloto:seed-adrs FALHOU — fatos de ADR podem ficar STALE ' .
+                    '(investigar storage/logs/copiloto-seed-adrs.log)'
+                );
+            });
+
         // Sprint 1 — Daily Brief (ADR 0091, camada L7 da Constituição V2).
         // Gera o brief 6x/dia em horário comercial PT-BR (07/11/14/17/20/23h).
         // Custo médio: $0.05/run × 6 = $0.30/dia. Cap diário no command.


### PR DESCRIPTION
## GAP (auditoria 2026-05-28)

`SeedAdrsCommand` gravava `metadata` com chaves que **não casavam** com as que o `MeilisearchDriver::applyTimeDecay` lê:

| Gravava (errado) | Decay lê (canônico) |
|---|---|
| `source_type` | `doc_type` |
| `adr_status` (PT cru) | `status` (EN: accepted/proposed/historical/superseded) |
| `indexed_at` | `published_at` |

Resultado: **todo fato de ADR caía no fallback do decay** — `temporal_factor=1.0` e `status_multiplier=default`, neutralizando o weighting temporal. E o command **não tinha schedule**, então fatos de ADR desatualizavam (nova ADR aceita / supersedida só virava fato pesquisável ao rodar na mão).

## Fix

1. **`buildFatoMetadata()`** (extraído pra método testável): grava `doc_type` / `status` / `published_at` canônicos **mantendo as chaves antigas** (back-compat com fatos já gravados + outros consumidores).
2. **`normalizeStatus()`**: PT→EN pro vocabulário do config `copiloto.time_decay.status_multipliers` (`accepted`/`proposed`/`historical`/`superseded`; desconhecido → `default` = multiplier 1.0).
3. **`resolvePublishedAt()`**: prioridade `decided_at > accepted_at > date > indexed_at`.
4. **Kernel**: schedule `copiloto:seed-adrs --type=all` daily **04:45 BRT** (após `jana:freshness-check` 04:30), `environments(['live'])`, `withoutOverlapping`, log próprio (`storage/logs/copiloto-seed-adrs.log`).

## Validação

- **Pest local (Herd php 8.4):** 37 passed (56 assertions), 10.5s. Cobre `normalizeStatus` PT→EN, montagem de metadata (doc_type/status/published_at), back-compat das chaves antigas, e prioridade do `resolvePublishedAt`. Métodos `public` → sem DB/LLM.
- **PHPStan:** No errors em `app/Console/Kernel.php`. `SeedAdrsCommand.php` está em path Console excluído da análise por bug upstream Larastan com signatures de Command (ADR 0208) — validado com `php -l` (sem syntax errors).

## Custo / latência

Zero LLM. Schedule é SQL puro (transforma `mcp_memory_documents` → `jana_memoria_facts`). Idempotente (upsert por `source_slug`). Custo desprezível.

Refs: auditoria-seed 2026-05-28

🤖 Generated with [Claude Code](https://claude.com/claude-code)