### PR TITLE
fix(jana): seed-adrs indexa fatos no Scout após insert raw (fecha furo do gap #3)

### DIFF
--- a/Modules/Jana/Console/Commands/SeedAdrsCommand.php
+++ b/Modules/Jana/Console/Commands/SeedAdrsCommand.php
@@ -5,6 +5,7 @@ namespace Modules\Jana\Console\Commands;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
+use Modules\Jana\Entities\MemoriaFato;
 
 /**
  * MEM-MULTI-1 — Seeda ADRs do MCP → copiloto_memoria_facts.
@@ -160,18 +161,47 @@ class SeedAdrsCommand extends Command
             }
         }
 
+        // Sincroniza o índice Scout/Meilisearch.
+        //
+        // O insert/update acima usa DB::table (raw) por performance — o que BYPASSA
+        // os eventos Eloquent que o Scout escuta. Sem este passo o fato entra no DB
+        // mas NUNCA no índice: o schedule diário (copiloto-seed-adrs-daily) rodava,
+        // gravava o metadata canônico e ainda assim "ADR novo não virava fato
+        // pesquisável" — o recall nunca via os ADRs seedados.
+        //
+        // Em CLI o ScopeByBusiness no-opa (HasBusinessScope L19) — por isso filtramos
+        // business_id + user_id explicitamente (multi-tenant Tier 0, ADR 0093).
+        // shouldBeSearchable() separa ativo (indexa) de superseded/valid_until (remove
+        // do índice). Com SCOUT_DRIVER=null (testes) searchable()/unsearchable() no-opam.
+        $reindexados = 0;
+        if (! $dryRun) {
+            $facts = MemoriaFato::withoutGlobalScopes()
+                ->where('business_id', $businessId)
+                ->where('user_id', $userId)
+                ->whereRaw("JSON_EXTRACT(metadata, '$.seeded_from_mcp') = true")
+                ->get();
+
+            // Métodos de instância do trait Searchable (não o macro de Collection):
+            // ativo → searchable() (indexa) · superseded → unsearchable() (remove).
+            foreach ($facts as $fact) {
+                $fact->shouldBeSearchable()
+                    ? $fact->searchable()
+                    : $fact->unsearchable();
+            }
+            $reindexados = $facts->count();
+        }
+
         $this->newLine();
         $this->info("Concluído:");
         $this->line("  inseridos   : {$stats['inserted']}");
         $this->line("  atualizados : {$stats['updated']}");
         $this->line("  superseded  : {$stats['superseded']} (valid_until preenchido)");
         $this->line("  skipped     : {$stats['skipped']}");
+        $this->line("  reindexados : {$reindexados} (sincronizados com Meilisearch via Scout)");
 
         if (! $dryRun) {
-            $total = $stats['inserted'] + $stats['updated'] + $stats['superseded'];
             $this->newLine();
-            $this->info("Próximo passo: indexar no Meilisearch e medir recall:");
-            $this->line("  php artisan scout:import \"Modules\\\\Copiloto\\\\Entities\\\\MemoriaFato\"");
+            $this->info("Fatos já sincronizados com Meilisearch (Scout). Pra medir recall:");
             $this->line("  php artisan copiloto:eval --persist --business=$businessId");
         }
 

--- a/Modules/Jana/Tests/Feature/Memoria/SeedAdrsMetadataTest.php
+++ b/Modules/Jana/Tests/Feature/Memoria/SeedAdrsMetadataTest.php
@@ -2,7 +2,9 @@
 
 declare(strict_types=1);
 
+use Illuminate\Support\Carbon;
 use Modules\Jana\Console\Commands\SeedAdrsCommand;
+use Modules\Jana\Entities\MemoriaFato;
 
 uses(Tests\TestCase::class);
 
@@ -151,4 +153,38 @@ it('published_at é null quando não há nenhuma data (não crasha o decay)', fu
     $doc = seedFakeDoc('adr');
     $doc->indexed_at = null;
     expect($cmd->resolvePublishedAt($doc, []))->toBeNull();
+});
+
+// ── 4. reindex Scout: partição ativo (indexa) vs superseded (remove) ─────────
+//
+// GAP (handoff 2026-05-29): o insert/update do command usa DB::table (raw), o que
+// BYPASSA os eventos Eloquent que o Scout escuta — sem reindex explícito o fato
+// nunca chegava ao Meilisearch (mesmo com o schedule diário rodando). O fix carrega
+// os fatos seedados e particiona: ativos → searchable(), superseded → unsearchable().
+// Aqui blindamos a LÓGICA da partição (shouldBeSearchable), que é a parte com risco
+// de bug — o searchable()/unsearchable() em si no-opa com SCOUT_DRIVER=null.
+
+it('fato ativo (valid_until null) é indexável no Scout', function () {
+    $f = new MemoriaFato();
+    $f->valid_until = null;
+    expect($f->shouldBeSearchable())->toBeTrue();
+});
+
+it('fato superseded (valid_until preenchido) NÃO é indexável (vai pra unsearchable)', function () {
+    $f = new MemoriaFato();
+    $f->valid_until = Carbon::parse('2026-01-10 00:00:00');
+    expect($f->shouldBeSearchable())->toBeFalse();
+});
+
+it('filter/reject shouldBeSearchable particiona ativos de superseded (lógica do reindex)', function () {
+    $ativo = new MemoriaFato();
+    $ativo->valid_until = null;
+
+    $superseded = new MemoriaFato();
+    $superseded->valid_until = Carbon::parse('2026-01-10 00:00:00');
+
+    $col = collect([$ativo, $superseded]);
+
+    expect($col->filter->shouldBeSearchable())->toHaveCount(1);   // → ->searchable()
+    expect($col->reject->shouldBeSearchable())->toHaveCount(1);   // → ->unsearchable()
 });


### PR DESCRIPTION
## Por quê

Continuação dos 5 gaps do pipeline freshness/retrieval da Jana ([handoff 2026-05-29](memory/handoffs/2026-05-29-0500-jana-freshness-retrieval-5-gaps.md)).

O **#1917** já tinha fechado as duas partes que o handoff atribuía ao gap #3 (chaves de metadata canônicas `doc_type`/`status`/`published_at` + schedule diário `copiloto-seed-adrs-daily`). Mas sobrava um furo silencioso: o `SeedAdrsCommand` insere/atualiza `jana_memoria_facts` via `DB::table()->insert()` (raw, por performance) — o que **bypassa os eventos Eloquent que o Scout escuta**.

Resultado: mesmo com o cron rodando todo dia e gravando metadata correto, os fatos de ADR entravam no DB **mas nunca no índice Meilisearch**. O recall jamais via os ADRs seedados — "ADR novo não virava fato pesquisável" persistia apesar de tudo parecer ligado.

## Fix

Após o batch insert/update, carrega os fatos seedados e sincroniza o Scout:

```php
foreach ($facts as $fact) {
    $fact->shouldBeSearchable()
        ? $fact->searchable()      // ativo → indexa
        : $fact->unsearchable();   // superseded (valid_until) → remove do índice
}
```

- Em CLI o `ScopeByBusiness` no-opa (`HasBusinessScope` L19) → filtramos `business_id` + `user_id` explicitamente (multi-tenant Tier 0, [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)).
- Usa os **métodos de instância** do trait `Searchable` (não o macro de Collection) — PHPStan-knowable.
- Remove o hint stale que apontava namespace velho `Modules\Copiloto\Entities\MemoriaFato` (renomeado pra `Jana`, [ADR 0092](memory/decisions/0092-rename-copiloto-jana.md)) + o `$total` morto.

## Testes

+3 cenários no `SeedAdrsMetadataTest` blindando a partição ativo vs superseded (`shouldBeSearchable`). **40 passed (60 assertions)**.

> PHPStan: o comando está em path excluído do gate (`Modules/*/Console/*` — bug Larastan 3.10 + PHP 8.4 + L13), então não há erro de gate. Mudança usa só métodos de instância existentes.

Refs: handoff 2026-05-29 gap #3 · complementa #1917 · KNOWLEDGE-AUDIT 2026-05-13

🤖 Generated with [Claude Code](https://claude.com/claude-code)
