### PR TITLE
docs(jana): proposta ADR — tools MCP de busca usam o pipeline bom (gap #2)

### DIFF
--- a/memory/decisions/proposals/jana-mcp-search-tools-pipeline-bom.md
+++ b/memory/decisions/proposals/jana-mcp-search-tools-pipeline-bom.md
@@ -1,0 +1,98 @@
+---
+title: "Proposta — tools MCP de busca usam o pipeline bom (hybrid+rerank+decay), não FULLTEXT puro"
+type: adr-proposal
+status: proposed
+authority: tecnico
+lifecycle: ativo
+decided_at: 2026-05-29
+module: Jana
+related_adrs: [0031, 0036, 0053, 0056, 0067, 0094, 0232]
+gap: "freshness/retrieval handoff 2026-05-29 — gap #2"
+---
+
+# Proposta — tools MCP de busca usam o pipeline bom
+
+> **Gap #2** do handoff [2026-05-29](../../handoffs/2026-05-29-0500-jana-freshness-retrieval-5-gaps.md).
+> Esta é uma proposta de DESIGN — não código. Wagner decide antes de implementar
+> (muda recall do time inteiro: Felipe/Maiara/Eliana/Luiz + Wagner via MCP).
+
+## Problema (verificado linha-a-linha)
+
+O oimpresso tem um pipeline de retrieval estado-da-arte — `MeilisearchDriver`
+(implementa `MemoriaContrato`): hybrid (Scout `semanticRatio`) + HyDE
+(`HydeQueryExpander`) + RRF + time-decay (`applyTimeDecay`) + Peso Real (ADR 0232)
++ reranker (`LlmReranker`/`BgeReranker`/`RrfReranker`). **Só o chat Copiloto usa.**
+
+As tools MCP de busca — que o time inteiro consome — usam **FULLTEXT puro**:
+
+| Tool | Tabela | Como busca hoje | Evidência |
+|---|---|---|---|
+| `memoria-search` | `jana_memoria_facts` | `MATCH(fato) AGAINST` raw | [MemoriaSearchTool L92-101](../../../Modules/Jana/Mcp/Tools/MemoriaSearchTool.php#L92) |
+| `decisions-search` | `mcp_memory_documents` | scope `buscarTexto` (FULLTEXT) | [DecisionsSearchTool L62](../../../Modules/Jana/Mcp/Tools/DecisionsSearchTool.php#L62) |
+| `kb-answer` | `mcp_memory_documents` | `buscarTexto` + síntese gpt-4o-mini | [KbAnswerTool L196](../../../Modules/Jana/Mcp/Tools/KbAnswerTool.php#L196) |
+
+Efeito: o Claude/time recupera **pior do que poderia** — sem expansão semântica,
+sem decay temporal (ADR velho pesa igual a recente), sem rerank, sem Peso Real.
+
+## A sutileza que impede o "swap único"
+
+O pipeline bom (`MemoriaContrato::buscar`) opera sobre **`jana_memoria_facts`**
+(os *fatos* — derivados de ADRs via `seed-adrs`). Mas `decisions-search`/`kb-answer`
+buscam **`mcp_memory_documents`** (o *markdown completo* do ADR). São índices
+diferentes. Logo o gap #2 não é uniforme — divide em 3 áreas com risco distinto:
+
+### Área A — `memoria-search` → `MemoriaContrato::buscar` (BAIXO risco)
+Mesma tabela (`jana_memoria_facts`). Swap direto pro `buscar(bizId, userId, query, topK)`.
+O próprio comentário do tool já antecipa isso ([L90-91](../../../Modules/Jana/Mcp/Tools/MemoriaSearchTool.php#L90)).
+Multi-tenant já resolvido (o driver scopa por business+user). **Flag + fallback FULLTEXT.**
+
+### Área B — `decisions-search` (MÉDIO risco — depende de decisão)
+Duas opções:
+- **B1** — buscar os *fatos seedados de ADR* (`jana_memoria_facts` com
+  `metadata.doc_type=adr`) via pipeline bom. Já existe e ficou correto com #1917
+  (metadata canônico) + #1919 (indexação Scout). Muda o retorno: snippet do fato
+  vs markdown do ADR. Citação aponta `source_slug`.
+- **B2** — apontar o pipeline bom pro índice de `mcp_memory_documents`
+  (que TAMBÉM é Scout-Searchable). Mantém o markdown completo, mas o decay/HyDE/Peso
+  Real do `MeilisearchDriver` é específico de `MemoriaFato` — exigiria generalizar
+  o driver pra um segundo índice. Mais trabalho, menos reuso.
+
+**Recomendo B1** (reuso máximo; o seed já existe e ficou robusto). `decisions-fetch`
+continua servindo o markdown completo on-demand.
+
+### Área C — `kb-answer` (MÉDIO risco)
+Reusa a mesma decisão de B. A síntese gpt-4o-mini fica intacta; só a etapa de
+recuperação de fontes (`buscarFontes`) passa pelo pipeline bom. Citação obrigatória
+preservada.
+
+## Proposta
+
+1. **Flag mestre** `JANA_MCP_SEARCH_PIPELINE` (default **OFF** → comportamento atual
+   idêntico, byte-a-byte). Liga por tool se quiser (`...PIPELINE_MEMORIA`, `..._DECISIONS`, `..._KB`).
+2. **Fallback gracioso**: se o driver lançar/Meilisearch cair, cai no FULLTEXT atual
+   (degradação, nunca erro pro time). Padrão ADR 0036/0056.
+3. **Gate golden-set ANTES de ligar default**: rodar `copiloto:eval` (recall@5) com
+   pipeline ON vs FULLTEXT sobre um golden set de ~20 queries reais do time. Só vira
+   default se recall não regredir (≥ baseline). Sem isso, fica flag-off.
+4. **Multi-tenant Tier 0** (ADR 0093): o token MCP resolve user→business; cada tool
+   já asserta cross-tenant. O `buscar()` recebe business+user explícitos.
+5. **Sequência**: Área A (baixo risco, valida o padrão flag+fallback) → golden set →
+   Áreas B+C juntas (mesma decisão B1).
+
+## Custo / risco
+
+- Custo IA: HyDE usa 1 chamada LLM barata por query (já em prod no chat). Cap por tool.
+- Risco: recall regressão → **mitigado pelo gate golden-set + flag-off default**.
+- Reversível: flag OFF restaura o estado atual sem deploy.
+
+## Decisão pendente de Wagner
+
+- [ ] Aprovar o paradigma (tools MCP via pipeline bom, flag-gated)?
+- [ ] B1 (buscar fatos seedados) vs B2 (generalizar driver pros docs)?
+- [ ] Implementar Área A já (flag-off, reversível) OU esperar ADR aceita?
+
+## Relacionado
+
+- [ADR 0036](../0036-replanejamento-meilisearch-first.md) · [ADR 0056](../0056-mcp-fonte-unica-memoria-copiloto-claude-code.md) · [ADR 0067](../0067-sprint8-mcp-memory-document-searchable-retrieval.md) · [ADR 0232](../0232-modelo-peso-real-classificacao-por-meta.md)
+- [AUDIT-SENIOR Jana 2026-05-25 §5](../../requisitos/Jana/AUDIT-SENIOR-2026-05-25.md) — G4/G5 retrieval
+- PRs irmãos: #1917 (seed metadata+schedule) · #1919 (seed indexa Scout) — **pré-requisitos do B1**

--- a/memory/decisions/proposals/jana-mcp-search-tools-pipeline-bom.md
+++ b/memory/decisions/proposals/jana-mcp-search-tools-pipeline-bom.md
@@ -34,6 +34,31 @@ As tools MCP de busca — que o time inteiro consome — usam **FULLTEXT puro**:
 Efeito: o Claude/time recupera **pior do que poderia** — sem expansão semântica,
 sem decay temporal (ADR velho pesa igual a recente), sem rerank, sem Peso Real.
 
+## ⚠️ Constraint crítico (Wagner, 2026-05-29): memória é da EMPRESA
+
+A memória do oimpresso é **business-level** — fatos pertencem ao `business`, não ao
+usuário. Funcionário **ainda não foi projetado** pra ter memória individual. Logo,
+busca de memória **NÃO deve filtrar por `user_id`**.
+
+**Problema descoberto:** o pipeline bom (`MeilisearchDriver::buscarInterno`) tem
+`business_id = X AND user_id = Y` **hardcoded** no filtro Meilisearch ([L~129](../../../Modules/Jana/Services/Memoria/MeilisearchDriver.php#L120)).
+O recall do chat em prod já passa `userId: $conv->user_id` ([LaravelAiSdkDriver L568](../../../Modules/Jana/Services/Ai/LaravelAiSdkDriver.php#L568))
+— então **o escopo-por-usuário já existe hoje no chat** e contradiz o modelo de
+memória de empresa. Os ADRs seedados são `user_id=1` → outro funcionário não os veria.
+
+**Implicação pra gap #2:** rotear as tools MCP por `buscar(biz, user)` como está
+**ESTRAGARIA as regras empresariais** (estreitaria pra 1 usuário, perdendo os fatos
+da empresa). A tool `memoria-search` HOJE é corretamente **business-only** (FULLTEXT
+filtra só `business_id`, sem `user_id` — [L92-93](../../../Modules/Jana/Mcp/Tools/MemoriaSearchTool.php#L92)).
+
+**Pré-requisito do gap #2 (novo):** o pipeline precisa de uma variante
+**business-scoped** — `buscar(businessId, query, topK)` sem `user_id` (ou `userId`
+opcional que, quando ausente, sai do filtro). Sem isso, nenhuma das áreas abaixo pode
+ligar com segurança. Decidir também se o **chat** deve migrar pra business-scope
+(provável bug latente — fora do escopo desta proposta, decisão Wagner).
+
+> Tentativa de Área A user-scoped foi convertida pra **draft em #1922** por causa disto.
+
 ## A sutileza que impede o "swap único"
 
 O pipeline bom (`MemoriaContrato::buscar`) opera sobre **`jana_memoria_facts`**
@@ -41,10 +66,11 @@ O pipeline bom (`MemoriaContrato::buscar`) opera sobre **`jana_memoria_facts`**
 buscam **`mcp_memory_documents`** (o *markdown completo* do ADR). São índices
 diferentes. Logo o gap #2 não é uniforme — divide em 3 áreas com risco distinto:
 
-### Área A — `memoria-search` → `MemoriaContrato::buscar` (BAIXO risco)
-Mesma tabela (`jana_memoria_facts`). Swap direto pro `buscar(bizId, userId, query, topK)`.
-O próprio comentário do tool já antecipa isso ([L90-91](../../../Modules/Jana/Mcp/Tools/MemoriaSearchTool.php#L90)).
-Multi-tenant já resolvido (o driver scopa por business+user). **Flag + fallback FULLTEXT.**
+### Área A — `memoria-search` → pipeline **business-scoped** (BAIXO risco *após* o pré-req)
+Mesma tabela (`jana_memoria_facts`). **NÃO** é o swap direto pro `buscar(bizId, userId,…)`
+— isso estreitaria pra 1 usuário (ver constraint acima). Precisa da variante
+business-scoped do pipeline primeiro. Só então: flag + fallback FULLTEXT business-only.
+A tentativa user-scoped (#1922) ficou em **draft**.
 
 ### Área B — `decisions-search` (MÉDIO risco — depende de decisão)
 Duas opções:
@@ -74,10 +100,11 @@ preservada.
 3. **Gate golden-set ANTES de ligar default**: rodar `copiloto:eval` (recall@5) com
    pipeline ON vs FULLTEXT sobre um golden set de ~20 queries reais do time. Só vira
    default se recall não regredir (≥ baseline). Sem isso, fica flag-off.
-4. **Multi-tenant Tier 0** (ADR 0093): o token MCP resolve user→business; cada tool
-   já asserta cross-tenant. O `buscar()` recebe business+user explícitos.
-5. **Sequência**: Área A (baixo risco, valida o padrão flag+fallback) → golden set →
-   Áreas B+C juntas (mesma decisão B1).
+4. **Business-scoped, NÃO user-scoped** (constraint acima): variante de `buscar`
+   sem filtro `user_id` é **pré-requisito** de todas as áreas. Multi-tenant Tier 0
+   (ADR 0093) preservado: filtro por `business_id` + cross-tenant assert em cada tool.
+5. **Sequência**: (0) criar variante business-scoped do pipeline → (A) `memoria-search`
+   valida o padrão flag+fallback → golden set → (B+C) `decisions-search`/`kb-answer`.
 
 ## Custo / risco
 
@@ -87,9 +114,12 @@ preservada.
 
 ## Decisão pendente de Wagner
 
-- [ ] Aprovar o paradigma (tools MCP via pipeline bom, flag-gated)?
+- [ ] Confirmar: memória é **business-level** (sem user_id no recall)? → exige variante
+      business-scoped do pipeline como pré-req.
+- [ ] O **chat** (recall user-scoped hoje, LaravelAiSdkDriver L568) deve migrar pra
+      business-scope também? (bug latente — fora do escopo, mas relacionado)
+- [ ] Aprovar o paradigma (tools MCP via pipeline bom business-scoped, flag-gated)?
 - [ ] B1 (buscar fatos seedados) vs B2 (generalizar driver pros docs)?
-- [ ] Implementar Área A já (flag-off, reversível) OU esperar ADR aceita?
 
 ## Relacionado
 

--- a/memory/decisions/proposals/jana-mcp-search-tools-pipeline-bom.md
+++ b/memory/decisions/proposals/jana-mcp-search-tools-pipeline-bom.md
@@ -34,28 +34,27 @@ As tools MCP de busca — que o time inteiro consome — usam **FULLTEXT puro**:
 Efeito: o Claude/time recupera **pior do que poderia** — sem expansão semântica,
 sem decay temporal (ADR velho pesa igual a recente), sem rerank, sem Peso Real.
 
-## ⚠️ Constraint crítico (Wagner, 2026-05-29): memória é da EMPRESA
+## ⚠️ Constraint crítico (Wagner, 2026-05-29): memória do MCP é da EMPRESA
 
-A memória do oimpresso é **business-level** — fatos pertencem ao `business`, não ao
-usuário. Funcionário **ainda não foi projetado** pra ter memória individual. Logo,
-busca de memória **NÃO deve filtrar por `user_id`**.
+**Escopo desta proposta = MCP** (ingestão/retrieval de conhecimento da empresa pelas
+tools MCP). O **chat Copiloto NÃO faz parte disto** — o chat tem seu próprio modelo de
+acesso por **permissões Spatie** e é um concern separado. Não misturar os dois.
 
-**Problema descoberto:** o pipeline bom (`MeilisearchDriver::buscarInterno`) tem
-`business_id = X AND user_id = Y` **hardcoded** no filtro Meilisearch ([L~129](../../../Modules/Jana/Services/Memoria/MeilisearchDriver.php#L120)).
-O recall do chat em prod já passa `userId: $conv->user_id` ([LaravelAiSdkDriver L568](../../../Modules/Jana/Services/Ai/LaravelAiSdkDriver.php#L568))
-— então **o escopo-por-usuário já existe hoje no chat** e contradiz o modelo de
-memória de empresa. Os ADRs seedados são `user_id=1` → outro funcionário não os veria.
+No MCP, memória é **business-level** — o conhecimento (ADRs, fatos, docs) pertence ao
+`business`, não ao usuário. Logo, busca de memória via MCP **NÃO deve filtrar por
+`user_id`**. A tool `memoria-search` HOJE está correta: FULLTEXT filtra só `business_id`
+([L92-93](../../../Modules/Jana/Mcp/Tools/MemoriaSearchTool.php#L92)).
 
-**Implicação pra gap #2:** rotear as tools MCP por `buscar(biz, user)` como está
-**ESTRAGARIA as regras empresariais** (estreitaria pra 1 usuário, perdendo os fatos
-da empresa). A tool `memoria-search` HOJE é corretamente **business-only** (FULLTEXT
-filtra só `business_id`, sem `user_id` — [L92-93](../../../Modules/Jana/Mcp/Tools/MemoriaSearchTool.php#L92)).
+**O que isto implica pro gap #2:** o método `MemoriaContrato::buscar()` filtra
+`business_id AND user_id` (`MeilisearchDriver::buscarInterno`). Esse contrato foi
+desenhado pra outro consumidor; **não serve pras tools MCP** sem virar business-only.
+Rotear as tools MCP por `buscar(biz, user)` como está **ESTRAGARIA as regras
+empresariais** (estreitaria pra 1 usuário, perdendo os fatos da empresa — ex: ADRs
+seedados `user_id=1`).
 
-**Pré-requisito do gap #2 (novo):** o pipeline precisa de uma variante
-**business-scoped** — `buscar(businessId, query, topK)` sem `user_id` (ou `userId`
-opcional que, quando ausente, sai do filtro). Sem isso, nenhuma das áreas abaixo pode
-ligar com segurança. Decidir também se o **chat** deve migrar pra business-scope
-(provável bug latente — fora do escopo desta proposta, decisão Wagner).
+**Pré-requisito do gap #2 (novo):** o retrieval das tools MCP precisa de um caminho
+**business-scoped** — `buscar(businessId, query, topK)` **sem** `user_id` no filtro.
+Sem isso, nenhuma das áreas abaixo pode ligar com segurança.
 
 > Tentativa de Área A user-scoped foi convertida pra **draft em #1922** por causa disto.
 
@@ -114,11 +113,8 @@ preservada.
 
 ## Decisão pendente de Wagner
 
-- [ ] Confirmar: memória é **business-level** (sem user_id no recall)? → exige variante
-      business-scoped do pipeline como pré-req.
-- [ ] O **chat** (recall user-scoped hoje, LaravelAiSdkDriver L568) deve migrar pra
-      business-scope também? (bug latente — fora do escopo, mas relacionado)
-- [ ] Aprovar o paradigma (tools MCP via pipeline bom business-scoped, flag-gated)?
+- [ ] Confirmar: memória do MCP é **business-level** (sem `user_id` no retrieval das tools)?
+- [ ] Aprovar o paradigma (tools MCP via retrieval business-scoped, flag-gated)?
 - [ ] B1 (buscar fatos seedados) vs B2 (generalizar driver pros docs)?
 
 ## Relacionado


### PR DESCRIPTION
## O que é

Proposta de **design** (não código) pro **gap #2** do [handoff freshness/retrieval 2026-05-29](memory/handoffs/2026-05-29-0500-jana-freshness-retrieval-5-gaps.md): as tools MCP de busca (`decisions-search`/`memoria-search`/`kb-answer`) usam **FULLTEXT puro** enquanto o pipeline estado-da-arte (`MeilisearchDriver`: hybrid + HyDE + RRF + time-decay + Peso Real + reranker) **só serve o chat Copiloto**. O time inteiro (Felipe/Maiara/Eliana/Luiz + Wagner via MCP) recupera pior do que poderia.

## Por que proposta e não PR de código

Muda o **recall do time inteiro** + é decisão arquitetural (append-only). Pela Constituição v2, vai por ADR + sign-off do Wagner. Implementar às cegas, sem golden-set, arrisca **degradar** o recall sem alerta.

## Conteúdo

- Ponto de entrada reutilizável: `MemoriaContrato::buscar(bizId, userId, query, topK)`.
- **A sutileza**: `memoria-search` opera em `jana_memoria_facts` (= tabela do pipeline → swap limpo); `decisions-search`/`kb-answer` operam em `mcp_memory_documents` (índice diferente → decisão B1 buscar fatos seedados vs B2 generalizar driver).
- 3 áreas por risco: **A** (memoria-search, baixo) → **B** (decisions-search) → **C** (kb-answer).
- Flag-off default + fallback FULLTEXT + **gate golden-set (recall@5)** antes de virar default.
- B1 tem **#1917 + #1919** como pré-requisitos (seed metadata + indexação Scout) — já fechados.

## Decisão pendente de Wagner

- [ ] Aprovar o paradigma (tools MCP via pipeline bom, flag-gated)?
- [ ] B1 (buscar fatos seedados) vs B2 (generalizar driver pros docs)?
- [ ] Implementar Área A já (flag-off, reversível) OU esperar ADR aceita?

Refs: handoff 2026-05-29 gap #2 · AUDIT-SENIOR Jana §5 · ADR 0036/0056/0067/0232

🤖 Generated with [Claude Code](https://claude.com/claude-code)
