### PR TITLE
feat(jana): gap #2 Área A — memoria-search usa o pipeline bom (flag-off, fallback FULLTEXT)

### DIFF
--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -230,6 +230,29 @@ return [
     | Compat: env legado COPILOTO_RERANKER_ENABLED ainda funciona (true=usa driver, false=null).
     | Novo env JANA_RERANKER_ENABLED + JANA_RERANKER_DRIVER. Default = habilitado RRF.
     */
+    /*
+    |--------------------------------------------------------------------------
+    | MCP search tools — pipeline bom vs FULLTEXT (Gap #2)
+    |--------------------------------------------------------------------------
+    |
+    | handoff 2026-05-29 / proposta jana-mcp-search-tools-pipeline-bom.
+    |
+    | As tools MCP de busca usam FULLTEXT puro; o pipeline estado-da-arte
+    | (MemoriaContrato::buscar — hybrid+HyDE+RRF+time-decay+Peso Real+reranker)
+    | só serve o chat Copiloto. Esta flag liga o pipeline na tool memoria-search
+    | (Área A — mesma tabela jana_memoria_facts).
+    |
+    | DEFAULT OFF: comportamento atual idêntico (FULLTEXT business-scoped). Com a
+    | flag ON, memoria-search passa por MemoriaContrato::buscar(biz, user, …) — que
+    | filtra business_id AND user_id (mais estreito que o FULLTEXT business-only de
+    | hoje). Em erro/vazio cai no FULLTEXT (fallback gracioso, ADR 0036/0056).
+    |
+    | NÃO ligar default sem validar recall@5 com golden set (copiloto:eval).
+    */
+    'mcp_search' => [
+        'memoria_pipeline' => (bool) env('JANA_MCP_SEARCH_PIPELINE_MEMORIA', false),
+    ],
+
     'reranker' => [
         'enabled' => env('JANA_RERANKER_ENABLED', env('COPILOTO_RERANKER_ENABLED', true)),
         'driver'  => env('JANA_RERANKER_DRIVER', env('COPILOTO_RERANKER_DRIVER', 'rrf')),

--- a/Modules/Jana/Mcp/Tools/MemoriaSearchTool.php
+++ b/Modules/Jana/Mcp/Tools/MemoriaSearchTool.php
@@ -6,9 +6,12 @@ namespace Modules\Jana\Mcp\Tools;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
+use Modules\Jana\Contracts\MemoriaContrato;
+use Modules\Jana\Contracts\MemoriaPersistida;
 
 /**
  * MEM-MEM-MCP-1 (ADR 0056) — Tool MCP que busca fatos persistentes da memória
@@ -86,6 +89,20 @@ class MemoriaSearchTool extends Tool
             return Response::error('business_id não pôde ser resolvido.');
         }
 
+        // Gap #2 (Área A) — pipeline bom (MemoriaContrato::buscar: hybrid+HyDE+RRF+
+        // time-decay+Peso Real+reranker) atrás de flag, com fallback gracioso pro
+        // FULLTEXT. DEFAULT OFF = comportamento abaixo idêntico. Nota: buscar() filtra
+        // business_id AND user_id (mais estreito que o FULLTEXT business-only daqui),
+        // por isso só ativa quando há um user_id real do token.
+        $userId = (int) ($user->id ?? 0);
+        if ($userId > 0 && config('copiloto.mcp_search.memoria_pipeline', false)) {
+            $viaPipeline = $this->buscarViaPipeline($bizParaBusca, $userId, $query, $limit);
+            if ($viaPipeline !== null) {
+                return $viaPipeline;
+            }
+            // null = pipeline vazio/falhou → cai no FULLTEXT abaixo (fallback gracioso).
+        }
+
         // Busca via FULLTEXT em copiloto_memoria_facts
         // (não usa Meilisearch direto pra ter controle de filter biz/user/valid_until aqui;
         //  Meilisearch fica como cache/index secundário — pode ser refinement futuro)
@@ -117,6 +134,56 @@ class MemoriaSearchTool extends Tool
             $output .= "\n";
             $output .= $r->fato . "\n";
             $output .= "_Persistido em: {$r->valid_from}_\n\n";
+        }
+
+        return Response::text($output);
+    }
+
+    /**
+     * Busca via pipeline bom (MemoriaContrato::buscar — hybrid+HyDE+RRF+time-decay+
+     * Peso Real+reranker). Retorna Response formatada, ou null pra sinalizar fallback
+     * (vazio ou erro → handle() cai no FULLTEXT business-wide).
+     *
+     * @return Response|null
+     */
+    protected function buscarViaPipeline(int $businessId, int $userId, string $query, int $limit): ?Response
+    {
+        try {
+            /** @var MemoriaPersistida[] $hits */
+            $hits = app(MemoriaContrato::class)->buscar($businessId, $userId, $query, $limit);
+        } catch (\Throwable $e) {
+            Log::channel('copiloto-ai')->warning(
+                'memoria-search: pipeline falhou, fallback FULLTEXT: ' . $e->getMessage()
+            );
+
+            return null;
+        }
+
+        if ($hits === []) {
+            return null; // fallback pro FULLTEXT business-wide
+        }
+
+        $output = sprintf("Encontrados %d fato(s) na memória pra \"%s\" (pipeline):\n\n", count($hits), $query);
+        foreach ($hits as $h) {
+            $meta  = $h->metadata;
+            $cat   = (string) ($meta['categoria'] ?? $meta['doc_type'] ?? '');
+            $relev = (string) ($meta['relevancia'] ?? '');
+
+            $output .= "## Fato #{$h->id}";
+            if ($cat !== '') {
+                $output .= " [{$cat}]";
+            }
+            if ($relev !== '') {
+                $output .= " · relevância {$relev}";
+            }
+            if ($h->score !== null) {
+                $output .= sprintf(' · score %.3f', $h->score);
+            }
+            $output .= "\n" . $h->fato . "\n";
+            if ($h->validFrom !== null) {
+                $output .= "_Persistido em: {$h->validFrom}_\n";
+            }
+            $output .= "\n";
         }
 
         return Response::text($output);

--- a/Modules/Jana/Tests/Feature/Mcp/MemoriaSearchPipelineTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/MemoriaSearchPipelineTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Mcp\Response as McpResponse;
+use Modules\Jana\Contracts\MemoriaContrato;
+use Modules\Jana\Contracts\MemoriaPersistida;
+use Modules\Jana\Mcp\Tools\MemoriaSearchTool;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Gap #2 Área A (handoff 2026-05-29 / proposta jana-mcp-search-tools-pipeline-bom)
+ * — memoria-search passa a usar o pipeline bom (MemoriaContrato::buscar:
+ * hybrid+HyDE+RRF+time-decay+Peso Real+reranker) atrás da flag
+ * JANA_MCP_SEARCH_PIPELINE_MEMORIA, com fallback gracioso pro FULLTEXT.
+ *
+ * Cobre buscarViaPipeline (a parte nova): formata os hits e devolve null (=
+ * sinal de fallback) em vazio/erro — nunca propaga exceção pro time. A
+ * MemoriaContrato é mockada no container; subclasse anônima expõe o protected.
+ */
+
+function memoriaSearchToolExpondoPipeline(): MemoriaSearchTool
+{
+    return new class extends MemoriaSearchTool
+    {
+        public function chamarPipeline(int $b, int $u, string $q, int $l): ?McpResponse
+        {
+            return $this->buscarViaPipeline($b, $u, $q, $l);
+        }
+    };
+}
+
+function fatoPersistido(int $id, string $fato, array $metadata = [], ?float $score = null): MemoriaPersistida
+{
+    return new MemoriaPersistida(
+        id: $id,
+        businessId: 1,
+        userId: 1,
+        fato: $fato,
+        metadata: $metadata,
+        validFrom: '2026-05-01 00:00:00',
+        validUntil: null,
+        score: $score,
+    );
+}
+
+it('pipeline com hits formata output com marcador (pipeline) + fato + categoria + score', function () {
+    $mock = Mockery::mock(MemoriaContrato::class);
+    $mock->shouldReceive('buscar')->once()->with(1, 1, 'meta de venda', 5)->andReturn([
+        fatoPersistido(7, 'Meta R$5M/ano é o norte (ADR 0022).', ['doc_type' => 'adr'], 0.91),
+    ]);
+    app()->instance(MemoriaContrato::class, $mock);
+
+    $resp = memoriaSearchToolExpondoPipeline()->chamarPipeline(1, 1, 'meta de venda', 5);
+
+    expect($resp)->toBeInstanceOf(McpResponse::class);
+    $txt = (string) $resp->content();
+    expect($txt)->toContain('(pipeline)')
+        ->toContain('Fato #7')
+        ->toContain('Meta R$5M/ano')
+        ->toContain('[adr]')
+        ->toContain('score 0.910');
+});
+
+it('pipeline vazio devolve null (fallback pro FULLTEXT business-wide)', function () {
+    $mock = Mockery::mock(MemoriaContrato::class);
+    $mock->shouldReceive('buscar')->once()->andReturn([]);
+    app()->instance(MemoriaContrato::class, $mock);
+
+    expect(memoriaSearchToolExpondoPipeline()->chamarPipeline(1, 1, 'nada', 5))->toBeNull();
+});
+
+it('pipeline que lança devolve null (fallback gracioso — nunca propaga erro pro time)', function () {
+    $mock = Mockery::mock(MemoriaContrato::class);
+    $mock->shouldReceive('buscar')->once()->andThrow(new \RuntimeException('Meilisearch down'));
+    app()->instance(MemoriaContrato::class, $mock);
+
+    expect(memoriaSearchToolExpondoPipeline()->chamarPipeline(1, 1, 'q', 5))->toBeNull();
+});


### PR DESCRIPTION
## Por quê

Área A da [proposta #1920](https://github.com/wagnerra23/oimpresso.com/pull/1920) (gap #2 do [handoff 2026-05-29](memory/handoffs/2026-05-29-0500-jana-freshness-retrieval-5-gaps.md)): a tool MCP `memoria-search` usava **FULLTEXT puro** enquanto o pipeline estado-da-arte (`MemoriaContrato::buscar` — hybrid+HyDE+RRF+time-decay+Peso Real+reranker) só servia o chat Copiloto. Mesma tabela (`jana_memoria_facts`) → swap mais limpo, escolhido pra validar o padrão flag+fallback antes das Áreas B/C.

## O que muda

- **Flag** `JANA_MCP_SEARCH_PIPELINE_MEMORIA` (`config copiloto.mcp_search.memoria_pipeline`), **DEFAULT OFF** → comportamento atual byte-a-byte.
- Flag ON → `memoria-search` passa por `buscarViaPipeline()` → `MemoriaContrato::buscar(biz, user, query, limit)`.
- **Fallback gracioso**: pipeline vazio **ou** exceção → `null` → cai no FULLTEXT business-wide (degradação, nunca erro pro time — padrão [ADR 0036](memory/decisions/0036-replanejamento-meilisearch-first.md)/[0056](memory/decisions/0056-mcp-fonte-unica-memoria-copiloto-claude-code.md)).

## Nota de escopo (importante)

`buscar()` filtra `business_id AND user_id` (o `MeilisearchDriver::buscarInterno` scopa por user), **mais estreito** que o FULLTEXT business-only de hoje. Por isso o caminho pipeline só ativa quando há `user_id` real do token; o fallback business-wide cobre o caso de o user não ter fatos próprios. Multi-tenant Tier 0 ([ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md)) preservado (cross-tenant assert intacto).

## Segurança / reversibilidade

- Reversível por flag, sem deploy.
- **NÃO ligar default sem validar recall@5 com golden set** (gate da proposta #1920).

## Testes

+3 cenários no `MemoriaSearchPipelineTest` (hits formatados c/ score · vazio→null · exceção→null). **3 passed (11 assertions)**. PHPStan: **No errors** (`Mcp/Tools` não é excluído do gate).

Refs: handoff 2026-05-29 gap #2 Área A · proposta #1920 · ADR 0036/0056/0093/0232

🤖 Generated with [Claude Code](https://claude.com/claude-code)
