### PR TITLE
feat(governance): ADR 0233 — ativação de memória no momento-decisão + 3 hooks + R13

### DIFF
--- a/.claude/hooks/block-serving-branch-switch.ps1
+++ b/.claude/hooks/block-serving-branch-switch.ps1
@@ -1,0 +1,57 @@
+# block-serving-branch-switch.ps1 — PreToolUse:Bash
+# Enforcement da R8 (ADR 0233): bloqueia troca de branch no checkout MAIN
+# (D:\oimpresso.com) que serve o oimpresso.test via Herd. Trabalho de feature
+# vai em worktree isolado. Worktrees linkados (.claude/worktrees/*) sao liberados.
+#
+# Fail-open: qualquer erro/parse-fail -> exit 0 (NUNCA trava sessao).
+# Escape valve: incluir 'serving-branch-override' no comando (Wagner aprovou).
+
+$ErrorActionPreference = 'SilentlyContinue'
+try {
+    $raw = [Console]::In.ReadToEnd()
+    if (-not $raw) { exit 0 }
+    $payload = $raw | ConvertFrom-Json
+    $cmd = [string]$payload.tool_input.command
+    if (-not $cmd) { exit 0 }
+
+    # Escape valve explicito
+    if ($cmd -match 'serving-branch-override') { exit 0 }
+
+    # E uma TROCA de branch? (git switch <x>, git switch -c, git checkout -b, git checkout <ref>)
+    $isSwitch = ($cmd -match 'git\s+switch\s+\S') -or
+                ($cmd -match 'git\s+checkout\s+-b\s') -or
+                ($cmd -match 'git\s+checkout\s+(?!--)(?!-)\S')
+    if (-not $isSwitch) { exit 0 }
+    # git checkout -- <path> (restaurar arquivo) nao e troca de branch
+    if ($cmd -match 'git\s+checkout\s+--') { exit 0 }
+
+    # Caminho efetivo do comando: 'cd <path>' explicito OU cwd do payload
+    $path = $null
+    if ($cmd -match 'cd\s+"?([A-Za-z]:[\\/][^"&;|]+|/[^"&;|]+)"?') { $path = $matches[1].Trim() }
+    if (-not $path) { $path = [string]$payload.cwd }
+    if (-not $path) { exit 0 }
+    $path = ($path -replace '/', '\').TrimEnd('\')
+
+    # Worktree linkado -> liberado (e o lugar certo de trabalhar)
+    if ($path -match '\.claude\\worktrees\\') { exit 0 }
+
+    # Checkout MAIN (raiz oimpresso.com) + troca de branch -> BLOQUEIA
+    if ($path -match 'oimpresso\.com$') {
+        Write-Error @"
+[R8 / ADR 0233] BLOQUEADO: troca de branch no checkout MAIN ($path).
+Esse e o checkout que serve o oimpresso.test (Herd). Trocar a branch aqui muda
+o que o cliente ve e quebra codigo-x-banco (foi o erro da sessao 2026-05-29).
+
+FACA NUM WORKTREE ISOLADO:
+  cd D:\oimpresso.com
+  git worktree add -b feat/<slug> .claude/worktrees/<slug> origin/main
+  # trabalhe, commite e abra PR de dentro do worktree
+
+Escape (so se Wagner aprovou explicito): inclua 'serving-branch-override' no comando.
+"@
+        exit 2
+    }
+    exit 0
+} catch {
+    exit 0
+}

--- a/.claude/hooks/nudge-diagnosis-without-evidence.ps1
+++ b/.claude/hooks/nudge-diagnosis-without-evidence.ps1
@@ -1,0 +1,37 @@
+# nudge-diagnosis-without-evidence.ps1 — Stop (advisory, estende R1 / ADR 0233)
+# Detecta diagnostico/causa afirmado SEM evidencia (grep/log/SQL/trace/curl).
+# Origem: sessao 2026-05-29 chutou causa do HTTP 500 2x antes de ler o log.
+# Advisory: exit 0 SEMPRE (nunca bloqueia). Fail-open.
+
+$ErrorActionPreference = 'SilentlyContinue'
+try {
+    $raw = [Console]::In.ReadToEnd()
+    if (-not $raw) { exit 0 }
+    $payload = $raw | ConvertFrom-Json
+    $tp = [string]$payload.transcript_path
+    if (-not $tp -or -not (Test-Path $tp)) { exit 0 }
+
+    $lines = @(Get-Content $tp -Tail 50 -Encoding UTF8)
+    $text = $null
+    for ($i = $lines.Count - 1; $i -ge 0; $i--) {
+        $o = $null
+        try { $o = $lines[$i] | ConvertFrom-Json } catch { continue }
+        if ($o.type -eq 'assistant' -and $o.message.content) {
+            $t = ($o.message.content | Where-Object { $_.type -eq 'text' } | ForEach-Object { $_.text }) -join "`n"
+            if ($t) { $text = $t; break }
+        }
+    }
+    if (-not $text) { exit 0 }
+
+    # Afirmacao de causa/diagnostico com certeza
+    $diag = $text -match '(?i)(a causa (e|é|raiz|foi)|o problema (e|é|foi)|isso (acontece|ocorre|quebra|d[aá]) porque|com certeza (e|é)|root cause|o motivo (e|é)|porque o banco|porque a tabela)'
+    # Marcadores de evidencia real
+    $evidence = $text -match '(?i)(grep|tail |laravel\.log|SQLSTATE|stack ?trace|\.php:\d|getComputedStyle|curl|HTTP \d{3}|migrate:status|Schema::has|linha \d|confirmad[oa]|verifiquei)'
+
+    if ($diag -and -not $evidence) {
+        Write-Output "[R1+ / ADR 0233] Voce AFIRMOU uma causa/diagnostico. Mostre a EVIDENCIA (grep/log/SQL/trace/Read) que prova, antes de cravar. Nao chute (sessao 2026-05-29 chutou causa do 500 2x). Se ainda nao tem evidencia, diga 'hipotese a confirmar'."
+    }
+    exit 0
+} catch {
+    exit 0
+}

--- a/.claude/hooks/nudge-recommend-not-menu.ps1
+++ b/.claude/hooks/nudge-recommend-not-menu.ps1
@@ -1,0 +1,36 @@
+# nudge-recommend-not-menu.ps1 — Stop (advisory, R13 / ADR 0233)
+# Detecta resposta terminando em MENU de decisao tecnica sem recomendacao cravada.
+# Advisory: exit 0 SEMPRE (nunca bloqueia/looa). Fail-open.
+
+$ErrorActionPreference = 'SilentlyContinue'
+try {
+    $raw = [Console]::In.ReadToEnd()
+    if (-not $raw) { exit 0 }
+    $payload = $raw | ConvertFrom-Json
+    $tp = [string]$payload.transcript_path
+    if (-not $tp -or -not (Test-Path $tp)) { exit 0 }
+
+    # Ultima mensagem assistant (texto)
+    $lines = @(Get-Content $tp -Tail 50 -Encoding UTF8)
+    $text = $null
+    for ($i = $lines.Count - 1; $i -ge 0; $i--) {
+        $o = $null
+        try { $o = $lines[$i] | ConvertFrom-Json } catch { continue }
+        if ($o.type -eq 'assistant' -and $o.message.content) {
+            $t = ($o.message.content | Where-Object { $_.type -eq 'text' } | ForEach-Object { $_.text }) -join "`n"
+            if ($t) { $text = $t; break }
+        }
+    }
+    if (-not $text) { exit 0 }
+
+    $hasRecommend = $text -match '(?i)recomend|minha recomenda|sugiro cravad'
+    $hasMenuList  = $text -match '(?im)^\s*(\d[\.\)]|[-*]|\|)\s'
+    $hasChoiceQ   = $text -match '(?i)(qual (voc[eê]|prefere|escolh|deles|op[cç][aã]o)|o que (voc[eê] )?prefere|voc[eê] (decide|escolhe|quem decide)|prefere\?|qual (e|é) (a )?melhor)'
+
+    if ($hasMenuList -and $hasChoiceQ -and -not $hasRecommend) {
+        Write-Output "[R13] Sua resposta parece terminar com MENU de decisao. Se for calculo tecnico (ROI/prioridade/sequencia/arquitetura), CRAVE uma recomendacao com razao e peca so validacao (Wagner valida, nao calcula). Menu so vale pra gosto/preferencia. Ref: memory/reference/feedback-recomendar-nao-menu.md"
+    }
+    exit 0
+} catch {
+    exit 0
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -93,6 +93,10 @@
           {
             "type": "command",
             "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/post-merge-ui-smoke-required.ps1"
+          },
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/block-serving-branch-switch.ps1"
           }
         ]
       },
@@ -133,6 +137,14 @@
           {
             "type": "command",
             "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/memory-pending.ps1"
+          },
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/nudge-recommend-not-menu.ps1"
+          },
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/nudge-diagnosis-without-evidence.ps1"
           }
         ]
       }

--- a/memory/decisions/0233-ativacao-memoria-momento-decisao.md
+++ b/memory/decisions/0233-ativacao-memoria-momento-decisao.md
@@ -1,0 +1,110 @@
+---
+slug: 0233-ativacao-memoria-momento-decisao
+number: 233
+title: "Ativação de memória no momento-decisão — ciclo de vida 8 etapas + convenção gatilho/evento + hooks comportamentais"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: "2026-05-29"
+proposed_at: "2026-05-29"
+module: governance
+quarter: 2026-Q2
+tags: [governance, memoria, ativacao, hooks, momento-decisao, gatilho, enforcement, comportamental, worktree]
+supersedes: []
+related:
+  - 0061-conhecimento-canonico-git-mcp-zero-automem
+  - 0131-tiering-memoria-canonico-local-segredo
+  - 0095-skills-tiers-convencao-interna
+  - 0130-handoff-append-only-mcp-first
+  - 0094-constituicao-v2-7-camadas-8-principios
+authors:
+  - W
+  - C
+---
+
+# 0233 — Ativação de memória no momento-decisão
+
+## Contexto
+
+Wagner (2026-05-29), depois de uma sessão onde Claude tinha **todas as regras escritas** (CLAUDE.md, `proibicoes.md`, `PROTOCOLO-WAGNER-SEMPRE.md`) e mesmo assim **violou várias**: pulou `brief-fetch`, trocou a branch do checkout que serve o `oimpresso.test` (violou R8) em vez de usar worktree, devolveu menu de decisão técnica em vez de recomendar, e chutou a causa de um HTTP 500 duas vezes sem ler o log.
+
+Pergunta do Wagner: *"explique melhor como isso vai funcionar... liste como deveria ser, verifique como está hoje, avalie cada etapa, planeje como deveria ser."* Queixa recorrente (catalogada em R12, mesmo dia): *"mas não está funcionando porque? se existe mas não funciona tá errado. qual momento tem que ser ativado?"*
+
+**O problema não é falta de memória — é a memória não DISPARAR no momento da decisão.** Conhecimento canônico que carrega no `SessionStart` (banner Tier A) **decai em sessão longa** (200+ turnos / 8h+) e sai do contexto do Claude.
+
+## Diagnóstico — ciclo de vida de 8 etapas (conhecimento → comportamento)
+
+Pra um aprendizado virar comportamento garantido, ele precisa atravessar 8 etapas. Verificado contra o encanamento real (`.claude/settings.json` + docs canon):
+
+| # | Etapa | Como está hoje | Nota |
+|---|---|---|---|
+| 1 | Capturar | Manual (Wagner fala → às vezes vira `feedback-*.md`) | 🟡 |
+| 2 | Armazenar | Forte: `memory/reference/*.md`, `decisions/*.md` append-only, `governance-gate.yml` | 🟢 |
+| 3 | **Classificar gatilho** | Parcial: matchers por **tipo de tool** (`Write/Edit/Bash/Read`); momentos **comportamentais** não mapeados | 🟠 |
+| 4 | Distribuir | Forte: webhook GitHub→MCP; hooks/skills no git | 🟢 |
+| 5 | **Ativar no momento** | DIVIDIDO: ops arquivo/bash = `PreToolUse` por-tool (forte); comportamental = `tier-a-banner.ps1` SessionStart (**decai**) | 🔴 |
+| 6 | **Forçar** | DIVIDIDO: `block-automem`/`block-mwart` bloqueiam (exit 2); comportamental = banner mole | 🔴 |
+| 7 | **Verificar** | Parcial: `block-claim-without-evidence` exige curl; aderência comportamental não auditada | 🟠 |
+| 8 | Evoluir | Forte: ADR supersedes, `ui-lint` ratchet, post-mortem | 🟢 |
+
+**Conclusão:** o projeto é forte em armazenar/distribuir/evoluir (2,4,8) e em ativar/forçar **operações de arquivo/bash** (5,6 para Write/Edit/Bash). O furo é estreito e específico: **ativação + enforcement do conhecimento COMPORTAMENTAL** (etapas 3,5,6,7). As 4 violações desta sessão caem todas nessas mesmas etapas, só no eixo comportamental — não é azar, é furo estrutural.
+
+## Decisão
+
+### D1 — Convenção `gatilho:`/`evento:` em todo conhecimento comportamental (fecha etapa 3)
+
+Todo `feedback-*.md` comportamental novo **nasce com frontmatter declarando o momento de ativação**:
+
+```yaml
+gatilho: "Claude vai devolver menu de decisão técnica sem recomendar"
+evento: Stop            # SessionStart | PreToolUse:<matcher> | PostToolUse | Stop | UserPromptSubmit
+hook: nudge-recommend-not-menu.ps1   # arquivo que ativa (ou "n/a — só protocolo")
+enforcement: advisory   # block (exit 2) | advisory (nudge) | banner (passivo)
+```
+
+Sem `gatilho:` mapeado, não há como ativar — vira "passivo que não dispara". Isso é regra de governança: feedback sem gatilho é incompleto.
+
+### D2 — Modelo de 3 camadas de ativação (canoniza o que a R12 já provou)
+
+A R12 (fechamento de sessão) descobriu empiricamente (2026-05-28) que regra comportamental precisa de **3 camadas em depth**. Generalizamos:
+
+| Camada | Mecanismo | Garantia |
+|---|---|---|
+| 1 | Skill Tier A (`wagner-protocol-enforce`) | SessionStart eager — **decai em sessão longa** |
+| 2 | Skill Tier B description-match lazy | recarrega inline no trigger word |
+| 3 | **Hook de momento-decisão** (`PreToolUse`/`Stop`/`UserPromptSubmit`) | **determinístico no instante** |
+
+Camada 3 é a que faltava pro comportamental. Regra-mestre: **comportamento crítico = camada 1 (baseline) + camada 3 (garantia).**
+
+### D3 — 3 hooks de momento-decisão (fecha etapas 5,6,7 das violações desta sessão)
+
+| Hook | Evento | Fecha | Enforcement |
+|---|---|---|---|
+| `block-serving-branch-switch.ps1` | `PreToolUse:Bash` | Troca de branch no checkout servido (dá dentes à **R8** existente, que não tinha hook) | **block** (exit 2) + escape `serving-branch-override` |
+| `nudge-recommend-not-menu.ps1` | `Stop` | Menu de decisão técnica sem recomendação (**R13** nova) | advisory |
+| `nudge-diagnosis-without-evidence.ps1` | `Stop` | Diagnóstico afirmado sem evidência (grep/log) — estende R1 | advisory |
+
+### D4 — R13 nova no PROTOCOLO
+
+**R13 — Recomendar decisão técnica, não devolver menu.** Cálculo de prioridade/ROI/sequenciamento é trabalho do Claude (recomenda com razão; Wagner valida). Menu só pra **preferência/gosto** do Wagner (ex: "roxo ou azul?"). Origem: Wagner 2026-05-29 *"eu não deveria decidir isso, eu vou errar a escolha. qual escolha é melhor pro meu caso?"*.
+
+## Consequências
+
+**Positivas:**
+- Comportamental ganha enforcement no momento-decisão, não só banner que decai.
+- R8 ganha hook (a violação central desta sessão não se repete silenciosamente).
+- Convenção `gatilho:` força todo feedback futuro a declarar COMO será ativado — fecha a etapa 3 na raiz.
+- Padrão replicável: próximo feedback comportamental = doc + gatilho + hook.
+
+**Negativas / limites (honestidade):**
+- Hooks `Stop` comportamentais são fuzzy (regex erra em casos sutis) — por isso são **advisory** (nudge, não block), fail-open (erro do hook → exit 0, nunca trava sessão).
+- Não é 100%: leva de "passivo que não dispara" pra "dispara na maioria das vezes no momento certo". O salto que importa.
+- Mais hooks = +latência marginal por tool call (mitigado: hooks rápidos, fail-open).
+
+## Alternativas consideradas
+
+- **Só escrever mais memória (doc/PROTOCOLO):** rejeitado — é exatamente o que já falhava (passivo, decai).
+- **Tudo via skill Tier A always-on:** rejeitado — decai em sessão longa (causa-raiz da R12).
+- **Hooks block (exit 2) para comportamental:** rejeitado pro fuzzy — false-positive bloquearia trabalho legítimo do time. Block só pro determinístico (git-guard).

--- a/memory/reference/PROTOCOLO-WAGNER-SEMPRE.md
+++ b/memory/reference/PROTOCOLO-WAGNER-SEMPRE.md
@@ -355,6 +355,26 @@ Camada 2 + 3 = defesa em depth. Mesmo em sessão de 17 PRs / 8h+, ao detectar pa
 
 ---
 
+## R13 — Recomendar decisão técnica, não devolver menu
+
+**Origem:** Wagner 2026-05-29, sessão DS v4 roxo OficinaAuto:
+
+> *"eu acho que eu não deveria decidir isso, eu vou errar a escolha. qual escolha é melhor para o meu caso?"*
+
+Decisão de **prioridade / ROI / arquitetura / sequenciamento** é trabalho do Claude (especialista — [ADR 0231](../decisions/0231-processo-trabalho-canonico-especialista-por-area.md)). Claude **crava UMA recomendação** com razão fundamentada nos sinais reais (brief/cycle, [ADR 0105](../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md), [ADR 0232](../decisions/0232-modelo-peso-real-classificacao-por-meta.md)); Wagner **valida** (sim/não/ajusta), não calcula.
+
+**Menu (opções 1/2/3) só é permitido pra PREFERÊNCIA/GOSTO do Wagner** — onde não há resposta técnica "certa":
+- ✅ "quer o primário roxo ou azul?" (gosto) · "nome A ou B?"
+- ❌ "conserto Compras (59) ou investigo o gap D8? qual prefere?" (isso é ROI → Claude calcula e recomenda)
+
+**Quando dispara:** Claude vai terminar resposta com menu de decisão técnica sem recomendação cravada.
+
+**Sinal de violação:** Wagner responde "eu não deveria decidir isso" / "qual é melhor pro meu caso?" / "você que sabe".
+
+**Ativação (3 camadas, ADR 0233):** (1) skill `wagner-protocol-enforce` Tier A · (2) este doc · (3) hook `nudge-recommend-not-menu.ps1` (`Stop`, advisory). Doc base: [feedback-recomendar-nao-menu.md](feedback-recomendar-nao-menu.md).
+
+---
+
 ## Como Claude detecta violação no meio da sessão (auto-check)
 
 Após cada turno, Claude se pergunta:

--- a/memory/reference/feedback-recomendar-nao-menu.md
+++ b/memory/reference/feedback-recomendar-nao-menu.md
@@ -1,0 +1,39 @@
+# Feedback — Recomendar decisão técnica, não devolver menu (R13)
+
+> Catalogado 2026-05-29. Exemplar da convenção `gatilho:`/`evento:` da [ADR 0233](../decisions/0233-ativacao-memoria-momento-decisao.md).
+
+```yaml
+tipo: feedback
+regra: R13
+gatilho: "Claude vai terminar resposta com menu de decisão TÉCNICA (ROI/prioridade/sequenciamento) sem cravar recomendação"
+evento: Stop
+hook: nudge-recommend-not-menu.ps1
+enforcement: advisory
+origem: "Wagner 2026-05-29, sessão DS v4 roxo OficinaAuto"
+```
+
+## A regra
+
+**Decisão de prioridade/ROI/arquitetura/sequenciamento = trabalho do Claude.** Claude **recomenda uma** com a razão; Wagner valida (sim/não/ajusta). Claude **NÃO** devolve "opção 1/2/3, qual você prefere?" pra cálculo técnico.
+
+**Menu é permitido SÓ pra preferência/gosto do Wagner** — onde não existe resposta "certa" técnica:
+- ✅ permitido: "quer o primário roxo ou azul?" (gosto visual), "nome A ou B pro módulo?"
+- ❌ proibido: "conserto Compras (59) ou investigo o gap D8 sistêmico? qual você prefere?" (isso é ROI, Claude calcula e recomenda)
+
+## Why
+
+Wagner palavras textuais 2026-05-29: *"eu acho que eu não deveria decidir isso, eu vou errar a escolha. qual escolha é melhor para o meu caso?"*. Devolver menu técnico:
+1. **Transfere pro Wagner uma decisão que é especialidade do Claude** — ele pode escolher errado por falta de contexto técnico que o Claude tem.
+2. **É não-trabalho disfarçado de opção** — parece colaborativo, mas é o Claude se eximindo do cálculo.
+3. Pareia com proibição existente *"Wagner NÃO é helpdesk do agente"* e com o princípio especialista (ADR 0231).
+
+## How to apply
+
+Antes de terminar uma resposta que envolve escolha:
+1. É **gosto/preferência** do Wagner? → pode oferecer opções.
+2. É **cálculo técnico** (ROI, prioridade, sequência, arquitetura, trade-off)? → **cravar UMA recomendação** com razão fundamentada nos sinais reais (brief/cycle, [ADR 0105 cliente-como-sinal](../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md), [ADR 0232 peso-real](../decisions/0232-modelo-peso-real-classificacao-por-meta.md)). Wagner valida, não calcula.
+3. Estrutura certa: *"Recomendo X porque [razão]. Confirma?"* — não *"X ou Y ou Z, qual prefere?"*.
+
+**Sinal de violação:** Wagner responde "eu não deveria decidir isso" / "qual é melhor pro meu caso?" / "você que sabe". Quando isso acontece, a resposta anterior tinha menu técnico — recalibrar pra recomendação.
+
+Relacionado: [[feedback-modulo-mexeu-registra-sempre]] · R10/R11 (autonomia dentro do escopo) · [[PROTOCOLO-WAGNER-SEMPRE]] R13.


### PR DESCRIPTION
## Problema (origem: sessão 2026-05-29)
Claude tinha **todas as regras escritas** (CLAUDE.md, proibicoes, PROTOCOLO) e mesmo assim violou: pulou `brief-fetch`, **trocou a branch do checkout que serve o `oimpresso.test`** (violou R8) em vez de usar worktree, devolveu menu de decisão técnica, e chutou a causa de um HTTP 500 2× sem ler o log.

**Diagnóstico:** conhecimento canônico não falha em existir — falha em **disparar no momento da decisão**. Banner Tier A carrega no SessionStart e **decai em sessão longa**.

## Ciclo de vida 8 etapas (verificado em `settings.json`)
Forte em armazenar/distribuir/evoluir (2,4,8) e em ativar/forçar **ops de arquivo/bash** (5,6). O furo é estreito: **ativação + enforcement do COMPORTAMENTAL** (etapas 3,5,6,7). As 4 violações da sessão caem todas aí.

## O que este PR faz
- **ADR 0233** — ciclo 8 etapas + convenção `gatilho:`/`evento:` no frontmatter de feedback (fecha etapa 3 na raiz) + modelo 3 camadas de ativação (canoniza o que a R12 já provou).
- **R13** no PROTOCOLO — recomendar decisão técnica, não devolver menu (menu só pra gosto/preferência).
- **3 hooks de momento-decisão** (todos **fail-open**, testados standalone):
  | Hook | Evento | Ação |
  |---|---|---|
  | `block-serving-branch-switch.ps1` | PreToolUse:Bash | **BLOCK** — dá dentes à R8 (bloqueia troca de branch no checkout servido). Escape: `serving-branch-override` |
  | `nudge-recommend-not-menu.ps1` | Stop | advisory (R13) |
  | `nudge-diagnosis-without-evidence.ps1` | Stop | advisory (estende R1) |
- **`feedback-recomendar-nao-menu.md`** — exemplar da convenção.

## Testes
- Hook A: **6/6** (bloqueia main · libera worktree · `checkout -- file` ok · override ok · stdin vazio ok).
- Hooks B/C: detectam o padrão (nudge=True) e **exit 0 sempre** (fail-open); não disparam quando há recomendação/evidência.
- `settings.json` validado (JSON OK). Frontmatter ADR validado contra `_schema.json`.

## Limites (honestidade)
Hooks `Stop` comportamentais são fuzzy (regex) → **advisory, não block**, fail-open. Não é 100% — leva de "passivo que não dispara" pra "dispara na maioria das vezes no momento certo".

## Notas
- Feito **num worktree isolado** (não na branch que serve o `oimpresso.test`) — aplicando a própria lição.
- 311 inserções, 7 arquivos. 1 intent (mecanismo de ativação de memória).

🤖 Generated with [Claude Code](https://claude.com/claude-code)