### PR TITLE
docs(memory): re-index catálogo de módulos (module:specs) — estava stale desde abr/2026

### DIFF
--- a/memory/modulos/ADS.md
+++ b/memory/modulos/ADS.md
@@ -1,0 +1,203 @@
+# Módulo: ADS
+
+> **Adaptive Decision System — meta-orquestrador de decisões automatizadas. Risk Engine + Confidence Engine + Policy Engine + Decision Router + Learning Loop.**
+
+- **Alias:** `ads`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/ADS`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\ADS\Providers\AdsServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- ℹ️ Módulo sem views (provável API-only ou service)
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- 🟡 46 rotas — escopo médio
+- ✅ Tem testes (18)
+- 🔗 Acoplamento: depende de 2 outro(s) módulo(s)
+
+- **Prioridade sugerida de migração:** baixa (grande, fazer por último ou dividir)
+- **Risco estimado:** alto
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 46 |
+| Controllers | 15 |
+| Entities (Models) | 0 |
+| Services | 22 |
+| FormRequests | 16 |
+| Middleware | 1 |
+| Views Blade | 0 |
+| Migrations | 15 |
+| Arquivos de lang | 0 |
+| Testes | 18 |
+
+## Rotas
+
+### `web.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+| `GET` | `/admin/decisoes` | `[DecisoesController::class, 'index']` |
+| `GET` | `/admin/decisoes/{id}` | `[DecisoesController::class, 'show']` |
+| `POST` | `/admin/decisoes/{id}/approve` | `[DecisoesController::class, 'approve']` |
+| `POST` | `/admin/decisoes/{id}/reject` | `[DecisoesController::class, 'reject']` |
+| `POST` | `/admin/decisoes/{id}/dismiss` | `[DecisoesController::class, 'dismiss']` |
+| `GET` | `/admin/policy` | `[PolicyController::class, 'index']` |
+| `GET` | `/admin/confidence` | `[ConfidenceController::class, 'index']` |
+| `GET` | `/admin/metricas` | `[MetricasController::class, 'index']` |
+| `GET` | `/admin/patterns` | `[PatternsController::class, 'index']` |
+| `GET` | `/admin/skills` | `[SkillsController::class, 'index']` |
+| `GET` | `/admin/skills/{slug}` | `[SkillsController::class, 'show']` |
+| `GET` | `/admin/skills/{slug}/edit` | `[SkillsController::class, 'edit']` |
+| `POST` | `/admin/skills/{slug}` | `[SkillsController::class, 'store']` |
+| `GET` | `/admin/skills/{slug}/test` | `[SkillsController::class, 'test']` |
+| `POST` | `/admin/skills/{slug}/test` | `[SkillsController::class, 'runTest']` |
+| `GET` | `/admin/skills-review` | `[SkillsController::class, 'review']` |
+| `POST` | `/admin/skills/versions/{versionId}/approve` | `[SkillsController::class, 'approve']` |
+| `POST` | `/admin/skills/versions/{versionId}/reject` | `[SkillsController::class, 'reject']` |
+| `POST` | `/admin/skills/versions/{versionId}/publish` | `[SkillsController::class, 'publish']` |
+| `POST` | `/admin/skills/{slug}/move-label` | `[SkillsController::class, 'moveLabel']` |
+| `GET` | `/admin/tools` | `[ToolsController::class, 'index']` |
+| `POST` | `/admin/tools/{name}/execute` | `[ToolsController::class, 'execute']` |
+| `GET` | `/admin/learning` | `[LearningController::class, 'index']` |
+| `GET` | `/admin/meta-skills` | `[MetaSkillsController::class, 'index']` |
+| `POST` | `/admin/meta-skills/{id}/toggle` | `[MetaSkillsController::class, 'toggle']` |
+| `POST` | `/admin/meta-skills` | `[MetaSkillsController::class, 'store']` |
+| `POST` | `/admin/meta-skills/validate` | `[MetaSkillsController::class, 'validateRule']` |
+| `GET` | `/admin/team-scopes` | `[TeamScopesController::class, 'index']` |
+| `POST` | `/admin/team-scopes/grant` | `[TeamScopesController::class, 'grant']` |
+| `POST` | `/admin/team-scopes/revoke` | `[TeamScopesController::class, 'revoke']` |
+| `GET` | `/admin/graph` | `[GraphController::class, 'index']` |
+| `GET` | `/admin/conflicts` | `[ConflictsController::class, 'index']` |
+| `GET` | `/admin/projects` | `[ProjectsController::class, 'index']` |
+| `POST` | `/admin/projects` | `[ProjectsController::class, 'store']` |
+| `GET` | `/admin/projects/{id}` | `[ProjectsController::class, 'show']` |
+| `POST` | `/admin/projects/{id}/decompose` | `[ProjectsController::class, 'decompose']` |
+
+### `api.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `ads/health` | `[DecisionController::class, 'health']` |
+| `POST` | `ads/route` | `[DecisionController::class, 'route']` |
+| `GET` | `ads/recent-commits` | `[RecentEventsController::class, 'commits']` |
+| `GET` | `ads/recent-errors` | `[RecentEventsController::class, 'errors']` |
+| `GET` | `ads/scope/check` | `[ScopeController::class, 'check']` |
+| `GET` | `ads/scope/user/{user_id}` | `[ScopeController::class, 'listUserModules']` |
+| `POST` | `ads/context-for-task` | `[ContextController::class, 'forTask']` |
+
+## Controllers
+
+- **`ConfidenceController`** — 1 ação(ões): index
+- **`ConflictsController`** — 1 ação(ões): index
+- **`DecisoesController`** — 5 ação(ões): index, show, approve, reject, dismiss
+- **`LearningController`** — 1 ação(ões): index
+- **`MetaSkillsController`** — 4 ação(ões): index, toggle, store, validateRule
+- **`MetricasController`** — 1 ação(ões): index
+- **`PatternsController`** — 1 ação(ões): index
+- **`PolicyController`** — 1 ação(ões): index
+- **`SkillsController`** — 11 ação(ões): index, show, edit, store, test, runTest, review, approve +3
+- **`ContextController`** — 1 ação(ões): forTask
+- **`DecisionController`** — 2 ação(ões): route, health
+- **`RecentEventsController`** — 2 ação(ões): commits, errors
+- **`ScopeController`** — 2 ação(ões): check, listUserModules
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`InstallController`** — 0 ação(ões): 
+
+## Migrations
+
+- `2026_05_03_000001_create_mcp_file_locks_table.php`
+- `2026_05_03_000002_create_mcp_decision_thresholds_table.php`
+- `2026_05_03_000003_create_mcp_confidence_scores_table.php`
+- `2026_05_03_000004_create_mcp_dual_brain_decisions_table.php`
+- `2026_05_03_000005_create_mcp_decision_patterns_table.php`
+- `2026_05_03_180001_add_dismissed_at_to_dual_brain_decisions.php`
+- `2026_05_03_200001_add_learning_loop_columns.php`
+- `2026_05_03_220001_create_mcp_governance_rules_table.php`
+- `2026_05_03_230001_create_mcp_projects_table.php`
+- `2026_05_03_230002_create_mcp_project_parts_table.php`
+- `2026_05_03_230003_link_decisions_to_projects.php`
+- `2026_05_03_240001_create_mcp_tool_executions_table.php`
+- `2026_05_03_250001_create_mcp_decision_links_table.php`
+- `2026_05_03_260001_create_mcp_user_module_access_table.php`
+- `2026_05_11_190001_repair_dual_brain_learning_loop_drift.php`
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Processamento / eventos
+
+**Commands (artisan):** `AdsHealthCommand`, `AutoGenerateTasksCommand`, `LearnPatternsCommand`, `PlanDecisionsCommand`, `ProcessBrainBCommand`, `ReviewDecisionsCommand`, `SkillScaffoldCommand`
+
+## Peças adicionais
+
+- **Seeders:** `AdsAdminSkillsPermissionsSeeder`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `ADS` |
+| `api_key` | `9OdzFA0stWqp1GaLC3fNB8VeoxlTPvKn4hjrbcZ6DMUkwi2R` |
+| `brain_a_risk_max` | `0.3` |
+| `brain_a_conf_min` | `0.7` |
+| `brain_b_risk_max` | `0.7` |
+| `hitl1_cancel_window_seconds` | `600` |
+| `file_lock_ttl_seconds` | `1800` |
+| `confidence_human_modify_weight` | `3` |
+| `confidence_decay_days` | `90` |
+| `confidence_decay_factor` | `0.5` |
+| `confidence_initial` | `0.5` |
+| `learning_min_samples` | `10` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `Compras` | 2 |
+| `NFSe` | 2 |
+
+## Integridade do banco
+
+**Foreign Keys** (5):
+
+- `business_id` → `business.id`
+- `business_id` → `business.id`
+- `business_id` → `business.id`
+- `project_id` → `mcp_projects.id`
+- `user_id` → `users.id`
+
+**Unique indexes:** 9
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec ADS`

--- a/memory/modulos/Admin.md
+++ b/memory/modulos/Admin.md
@@ -1,0 +1,132 @@
+# Módulo: Admin
+
+> **Centro de Operações Wagner-only @ CT 100 (Tailscale-only). Agrega Curador, Health Checks, Cycles+Tasks, ADRs Tier 0 violados. Read-mostly. Não substitui Officeimpresso superadmin nem /copiloto/admin/team — agrega visão deles. Ver ADR 0122.**
+
+- **Alias:** `admin`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/Admin`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\Admin\Providers\AdminServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- ℹ️ Módulo sem views (provável API-only ou service)
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- ✅ Tem testes (19)
+- 🔗 Acoplamento: depende de 4 outro(s) módulo(s)
+
+- **Prioridade sugerida de migração:** média
+- **Risco estimado:** médio
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 20 |
+| Controllers | 8 |
+| Entities (Models) | 0 |
+| Services | 12 |
+| FormRequests | 7 |
+| Middleware | 2 |
+| Views Blade | 0 |
+| Migrations | 1 |
+| Arquivos de lang | 0 |
+| Testes | 19 |
+
+## Rotas
+
+### `web.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+| `GET` | `/` | `IndexController::class` |
+| `POST` | `mutations/curador/apply` | `[MutationsController::class, 'applyCurador']` |
+| `POST` | `mutations/mcp-token/regenerate` | `[MutationsController::class, 'regenerateMcpToken']` |
+| `POST` | `mutations/health-check/run-now` | `[MutationsController::class, 'runHealthCheckNow']` |
+| `GET` | `governance-v4` | `GovernanceV4DashboardController::class` |
+| `GET` | `governance/v4` | `[GovernanceV4DashboardController::class, 'indexV2']` |
+| `POST` | `governance/v4/initiative` | `[GovernanceV4DashboardController::class, 'createInitiative']` |
+| `POST` | `governance/v4/override-bucket` | `[GovernanceV4DashboardController::class, 'overrideBucket']` |
+| `GET` | `rag-quality` | `RagQualityDashboardController::class` |
+| `GET` | `screen-review/dashboard` | `[ScreenReviewController::class, 'dashboard']` |
+| `GET` | `screen-review` | `[ScreenReviewController::class, 'index']` |
+| `POST` | `screen-review/{screenPath}/status` | `[ScreenReviewController::class, 'updateStatus']` |
+| `GET` | `/` | `[FeatureFlagsController::class, 'index']` |
+| `GET` | `{key}` | `[FeatureFlagsController::class, 'show']` |
+| `POST` | `{key}/biz-rule` | `[FeatureFlagsController::class, 'setBizRule']` |
+| `POST` | `{key}/env-enabled` | `[FeatureFlagsController::class, 'setEnvEnabled']` |
+| `POST` | `cache/clear` | `[FeatureFlagsController::class, 'clearCache']` |
+
+## Controllers
+
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`FeatureFlagsController`** — 5 ação(ões): index, show, setBizRule, setEnvEnabled, clearCache
+- **`GovernanceV4DashboardController`** — 3 ação(ões): indexV2, createInitiative, overrideBucket
+- **`IndexController`** — 0 ação(ões): 
+- **`InstallController`** — 0 ação(ões): 
+- **`MutationsController`** — 3 ação(ões): applyCurador, regenerateMcpToken, runHealthCheckNow
+- **`RagQualityDashboardController`** — 0 ação(ões): 
+- **`ScreenReviewController`** — 3 ação(ões): dashboard, index, updateStatus
+
+## Migrations
+
+- `2026_05_10_000001_create_mcp_admin_audit_log_table.php`
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Processamento / eventos
+
+**Commands (artisan):** `AdminHealthCommand`, `ExportAuditCommand`, `ScreenCatalogGenerateCommand`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `Admin` |
+| `wagner_user_id` | `1` |
+| `wagner_business_id` | `1` |
+| `fallback_username` | `` |
+| `tailscale_cidrs` | `100.99.0.0/16` |
+| `subdomain` | `admin.oimpresso.com` |
+| `bypass_local` | `false` |
+| `bypass_tailscale` | `false` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `Governance` | 2 |
+| `Jana` | 1 |
+| `KB` | 1 |
+| `Brief` | 1 |
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec Admin`

--- a/memory/modulos/Arquivos.md
+++ b/memory/modulos/Arquivos.md
@@ -1,0 +1,124 @@
+# Módulo: Arquivos
+
+> **DMS backbone — todo arquivo anexado da empresa cai aqui (multi-tenant Tier 0). Polimorfismo Eloquent morph (arquivable_type/arquivable_id). Outros módulos adotam trait HasArquivos opt-in. Storage abstraído (disk local-ct100 + vault encrypted). Curador como engine de classificação. Soft-delete + audit log integral. Ver ADR 0123.**
+
+- **Alias:** `arquivos`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/Arquivos`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\Arquivos\Providers\ArquivosServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- ℹ️ Módulo sem views (provável API-only ou service)
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- ✅ Tem testes (22)
+- 🔗 Acoplamento: depende de 1 outro(s) módulo(s)
+
+- **Prioridade sugerida de migração:** alta (pequeno, ganho rápido)
+- **Risco estimado:** baixo
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 3 |
+| Controllers | 3 |
+| Entities (Models) | 1 |
+| Services | 4 |
+| FormRequests | 7 |
+| Middleware | 0 |
+| Views Blade | 0 |
+| Migrations | 6 |
+| Arquivos de lang | 0 |
+| Testes | 22 |
+
+## Rotas
+
+### `web.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+
+## Controllers
+
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`DownloadController`** — 0 ação(ões): 
+- **`InstallController`** — 0 ação(ões): 
+
+## Entities (Models Eloquent)
+
+- **`Arquivo`** (tabela: `arquivos`)
+
+## Migrations
+
+- `2026_05_10_000001_create_arquivos_table.php`
+- `2026_05_10_000002_create_arquivos_audit_log_table.php`
+- `2026_05_10_000003_create_arquivos_dedupe_table.php`
+- `2026_05_10_000010_backfill_nfe_xml_arquivos.php`
+- `2026_05_10_000020_backfill_consumers_arquivos.php`
+- `2026_05_10_000030_add_metadata_recalculated_at_to_arquivos.php`
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Processamento / eventos
+
+**Commands (artisan):** `AuditLogCommand`, `DedupeStatsCommand`, `ExportZipCommand`, `HealthCheckCommand`, `RecalcularMetadataCommand`, `ReencryptVaultCommand`, `RetentionCleanupCommand`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `Arquivos` |
+| `disk_default` | `local` |
+| `disk_vault` | `vault` |
+| `upload_max_mb` | `50` |
+| `vault_max_file_size_mb` | `50` |
+| `retention_days_default` | `90` |
+| `retention_days_policy` | `[array(8 itens)]` |
+| `signed_url_expiration_minutes` | `60` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `Admin` | 1 |
+
+## Integridade do banco
+
+**Foreign Keys** (3):
+
+- `business_id` → `business.id`
+- `uploaded_by_user_id` → `users.id`
+- `arquivo_id` → `arquivos.id`
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec Arquivos`

--- a/memory/modulos/AssetManagement.md
+++ b/memory/modulos/AssetManagement.md
@@ -12,7 +12,9 @@
 ## Sinais detectados
 
 - 🔗 Registra 4 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions, addTaxonomies
+- ✅ Tem testes (9)
 - 🔐 Registra 6 permissão(ões) Spatie
+- 🔗 Acoplamento: depende de 1 outro(s) módulo(s)
 
 - **Prioridade sugerida de migração:** média
 - **Risco estimado:** médio
@@ -21,16 +23,16 @@
 
 | Peça | Qtde |
 |---|---:|
-| Rotas (web+api) | 10 |
+| Rotas (web+api) | 11 |
 | Controllers | 7 |
 | Entities (Models) | 4 |
-| Services | 0 |
-| FormRequests | 0 |
+| Services | 4 |
+| FormRequests | 5 |
 | Middleware | 0 |
 | Views Blade | 17 |
 | Migrations | 7 |
 | Arquivos de lang | 16 |
-| Testes | 0 |
+| Testes | 9 |
 
 ## Rotas
 
@@ -46,6 +48,7 @@
 | `RESOURCE` | `assets` | `Modules\AssetManagement\Http\Controllers\AssetController::class` |
 | `RESOURCE` | `allocation` | `Modules\AssetManagement\Http\Controllers\AssetAllocationController::class` |
 | `RESOURCE` | `revocation` | `Modules\AssetManagement\Http\Controllers\RevokeAllocatedAssetController::class` |
+| `RESOURCE` | `/settings` | `Manufacturing\SettingsController` |
 | `RESOURCE` | `settings` | `Modules\AssetManagement\Http\Controllers\AssetSettingsController::class` |
 | `RESOURCE` | `asset-maintenance` | `'Modules\AssetManagement\Http\Controllers\AssetMaitenanceController'` |
 
@@ -60,7 +63,7 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - **`AssetMaitenanceController`** — 7 ação(ões): index, create, store, show, edit, update, destroy
 - **`AssetSettingsController`** — 7 ação(ões): index, create, store, show, edit, update, destroy
 - **`DataController`** — 5 ação(ões): superadmin_package, user_permissions, addTaxonomies, modifyAdminMenu, parse_notification
-- **`InstallController`** — 3 ação(ões): index, uninstall, update
+- **`InstallController`** — 0 ação(ões): 
 - **`RevokeAllocatedAssetController`** — 7 ação(ões): index, create, store, show, edit, update, destroy
 
 ## Entities (Models Eloquent)
@@ -120,6 +123,10 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - `asset.view_all_maintenance`
 - `asset.view_own_maintenance`
 
+## Processamento / eventos
+
+**Commands (artisan):** `AssetManagementHealthCommand`
+
 ## Peças adicionais
 
 - **Notifications:** `AssetAssignedForMaintenance`, `AssetSentForMaintenance`
@@ -132,6 +139,14 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 | `name` | `AssetManagement` |
 | `module_version` | `2.0` |
 | `pid` | `14` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `Jana` | 5 |
 
 ## Integridade do banco
 
@@ -172,84 +187,11 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ✅ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ❌ |
-| `origin/6.7-bootstrap` | ✅ |
 
 ## Diferenças vs versões anteriores
-
-### vs `origin/3.7-com-nfe`
-
-- **Arquivos alterados:** 80
-- **Linhas +:** 6389 **-:** 0
-- **Primeiros arquivos alterados:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2020_08_19_175842_add_asset_management_module_version_to_system_table.php`
-  - `Database/Migrations/2020_08_20_114339_create_assets_table.php`
-  - `Database/Migrations/2020_08_20_173031_create_asset_transactions_table.php`
-  - `Database/Migrations/2020_08_21_180138_add_asset_settings_column_to_business_table.php`
-  - `Database/Migrations/2021_10_29_110841_create_asset_warranties_table.php`
-  - `Database/Migrations/2022_03_26_062215_create_asset_maintenances_table.php`
-  - `Database/Migrations/2022_05_11_070711_add_maintenance_note_column_to_asset_maintenances_table.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/AssetManagementDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Entities/Asset.php`
-  - `Entities/AssetMaintenance.php`
-  - `Entities/AssetTransaction.php`
-  - `Entities/AssetWarranty.php`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/AssetAllocationController.php`
-  - `Http/Controllers/AssetController.php`
-  - `Http/Controllers/AssetMaitenanceController.php`
-  - `Http/Controllers/AssetSettingsController.php`
-  - `Http/Controllers/DataController.php`
-  - `Http/Controllers/InstallController.php`
-  - `Http/Controllers/RevokeAllocatedAssetController.php`
-  - `Http/Middleware/.gitkeep`
-  - `Http/Requests/.gitkeep`
-  - `Notifications/AssetAssignedForMaintenance.php`
-
-### vs `main-wip-2026-04-22` (backup das customizações)
-
-- **Arquivos alterados:** 80
-- **Linhas +:** 6389 **-:** 0
-- ⚠️ **Arquivos que podem conter customizações suas não trazidas para 6.7-react:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2020_08_19_175842_add_asset_management_module_version_to_system_table.php`
-  - `Database/Migrations/2020_08_20_114339_create_assets_table.php`
-  - `Database/Migrations/2020_08_20_173031_create_asset_transactions_table.php`
-  - `Database/Migrations/2020_08_21_180138_add_asset_settings_column_to_business_table.php`
-  - `Database/Migrations/2021_10_29_110841_create_asset_warranties_table.php`
-  - `Database/Migrations/2022_03_26_062215_create_asset_maintenances_table.php`
-  - `Database/Migrations/2022_05_11_070711_add_maintenance_note_column_to_asset_maintenances_table.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/AssetManagementDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Entities/Asset.php`
-  - `Entities/AssetMaintenance.php`
-  - `Entities/AssetTransaction.php`
-  - `Entities/AssetWarranty.php`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/AssetAllocationController.php`
-  - `Http/Controllers/AssetController.php`
-  - `Http/Controllers/AssetMaitenanceController.php`
-  - `Http/Controllers/AssetSettingsController.php`
-  - `Http/Controllers/DataController.php`
-  - `Http/Controllers/InstallController.php`
-  - `Http/Controllers/RevokeAllocatedAssetController.php`
-  - `Http/Middleware/.gitkeep`
-  - `Http/Requests/.gitkeep`
-  - `Notifications/AssetAssignedForMaintenance.php`
 
 ## Gaps & próximos passos (preencher manualmente)
 
@@ -259,5 +201,5 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:13.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec AssetManagement`

--- a/memory/modulos/Auditoria.md
+++ b/memory/modulos/Auditoria.md
@@ -1,0 +1,119 @@
+# Módulo: Auditoria
+
+> **Camada de governança transversal — UI rica /auditoria + undo sobre activity_log existente. Distingue User vs IA (causer_kind). Whitelist UNREVERTIBLE de 5 categorias. Per ADR 0127.**
+
+- **Alias:** `auditoria`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/Auditoria`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\Auditoria\Providers\AuditoriaServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- ℹ️ Módulo sem views (provável API-only ou service)
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- ✅ Tem testes (10)
+- 🔗 Acoplamento: depende de 4 outro(s) módulo(s)
+
+- **Prioridade sugerida de migração:** alta (pequeno, ganho rápido)
+- **Risco estimado:** baixo
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 7 |
+| Controllers | 3 |
+| Entities (Models) | 1 |
+| Services | 3 |
+| FormRequests | 6 |
+| Middleware | 0 |
+| Views Blade | 0 |
+| Migrations | 1 |
+| Arquivos de lang | 0 |
+| Testes | 10 |
+
+## Rotas
+
+### `web.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `/` | `[AuditoriaController::class, 'index']` |
+| `GET` | `/{activityId}` | `[AuditoriaController::class, 'show']` |
+| `POST` | `/{activityId}/revert` | `[AuditoriaController::class, 'revert']` |
+| `GET` | `/reports/activity-log` | `function (` |
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+
+### `api.php`
+
+_(arquivo existe mas parse não identificou rotas explícitas — pode ter grupos complexos)_
+
+## Controllers
+
+- **`AuditoriaController`** — 3 ação(ões): index, show, revert
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`InstallController`** — 0 ação(ões): 
+
+## Entities (Models Eloquent)
+
+- **`AuditNote`** (tabela: `auditoria_audit_notes`)
+
+## Migrations
+
+- `2026_05_16_190000_create_auditoria_audit_notes_table.php`
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Processamento / eventos
+
+**Commands (artisan):** `AuditoriaHealthCommand`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `Auditoria` |
+| `revert_window_own_hours` | `24` |
+| `revert_window_admin_days` | `30` |
+| `revert_window_unlimited` | `` |
+| `page_size` | `50` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `Governance` | 1 |
+| `Financeiro` | 1 |
+| `NfeBrasil` | 1 |
+| `Repair` | 1 |
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec Auditoria`

--- a/memory/modulos/BI.md
+++ b/memory/modulos/BI.md
@@ -36,10 +36,9 @@
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ❌ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ❌ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ❌ |
 
 ## Diferenças vs versões anteriores
 
@@ -51,5 +50,5 @@
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:13.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec BI`

--- a/memory/modulos/Boleto.md
+++ b/memory/modulos/Boleto.md
@@ -36,10 +36,9 @@
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ❌ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ❌ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ❌ |
 
 ## Diferenças vs versões anteriores
 
@@ -51,5 +50,5 @@
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:13.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Boleto`

--- a/memory/modulos/Brief.md
+++ b/memory/modulos/Brief.md
@@ -1,0 +1,88 @@
+# Módulo: Brief
+
+> **Daily Brief (camada L7) — gerador 6x/dia + tool MCP brief-fetch. Sprint 1 da Constituicao V2 (ADR 0091). Reduz onboarding de sessao Claude de 30k para 3k tokens.**
+
+- **Alias:** `brief`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/Brief`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\Brief\Providers\BriefServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- ℹ️ Módulo sem views (provável API-only ou service)
+- ℹ️ Sem migrations próprias (pode depender de tabelas de outros módulos)
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- ✅ Tem testes (8)
+
+- **Prioridade sugerida de migração:** alta (pequeno, ganho rápido)
+- **Risco estimado:** baixo
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 4 |
+| Controllers | 3 |
+| Entities (Models) | 0 |
+| Services | 3 |
+| FormRequests | 9 |
+| Middleware | 0 |
+| Views Blade | 0 |
+| Migrations | 0 |
+| Arquivos de lang | 0 |
+| Testes | 8 |
+
+## Rotas
+
+### `web.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+
+### `api.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `POST` | `/tools/brief-fetch` | `BriefFetchController::class` |
+
+## Controllers
+
+- **`BriefFetchController`** — 0 ação(ões): 
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`InstallController`** — 0 ação(ões): 
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Processamento / eventos
+
+**Commands (artisan):** `BriefHealthCommand`, `GenerateBriefCommand`
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec Brief`

--- a/memory/modulos/Chat.md
+++ b/memory/modulos/Chat.md
@@ -36,10 +36,9 @@
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ❌ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ❌ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ❌ |
 
 ## Diferenças vs versões anteriores
 
@@ -51,5 +50,5 @@
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:13.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Chat`

--- a/memory/modulos/Cms.md
+++ b/memory/modulos/Cms.md
@@ -11,7 +11,9 @@
 
 ## Sinais detectados
 
-- 🔗 Registra 1 hook(s) UltimatePOS: modifyAdminMenu
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- ✅ Tem testes (17)
+- 🔐 Registra 1 permissão(ões) Spatie
 
 - **Prioridade sugerida de migração:** baixa (grande, fazer por último ou dividir)
 - **Risco estimado:** alto
@@ -20,16 +22,16 @@
 
 | Peça | Qtde |
 |---|---:|
-| Rotas (web+api) | 12 |
+| Rotas (web+api) | 16 |
 | Controllers | 5 |
 | Entities (Models) | 3 |
-| Services | 0 |
-| FormRequests | 0 |
+| Services | 4 |
+| FormRequests | 9 |
 | Middleware | 0 |
 | Views Blade | 45 |
 | Migrations | 5 |
 | Arquivos de lang | 1 |
-| Testes | 0 |
+| Testes | 17 |
 
 ## Rotas
 
@@ -38,8 +40,12 @@
 | Método | URI | Controller |
 |---|---|---|
 | `GET` | `/` | `[Modules\Cms\Http\Controllers\CmsController::class, 'index']` |
+| `GET` | `/old` | `[Modules\Cms\Http\Controllers\CmsController::class, 'indexLegacy']` |
+| `GET` | `c/page/{page}/old` | `[Modules\Cms\Http\Controllers\CmsPageController::class, 'showPageLegacy']` |
 | `GET` | `c/page/{page}` | `[Modules\Cms\Http\Controllers\CmsPageController::class, 'showPage']` |
+| `GET` | `c/blogs/old` | `[Modules\Cms\Http\Controllers\CmsController::class, 'getBlogListLegacy']` |
 | `GET` | `c/blogs` | `[Modules\Cms\Http\Controllers\CmsController::class, 'getBlogList']` |
+| `GET` | `c/blog/{slug}-{id}/old` | `[Modules\Cms\Http\Controllers\CmsController::class, 'viewBlogLegacy']` |
 | `GET` | `c/blog/{slug}-{id}` | `[Modules\Cms\Http\Controllers\CmsController::class, 'viewBlog']` |
 | `GET` | `c/contact-us` | `[Modules\Cms\Http\Controllers\CmsController::class, 'contactUs']` |
 | `POST` | `c/submit-contact-form` | `[Modules\Cms\Http\Controllers\CmsController::class, 'postContactForm']` |
@@ -56,10 +62,10 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 ## Controllers
 
-- **`CmsController`** — 11 ação(ões): index, create, store, show, edit, update, destroy, getBlogList +3
-- **`CmsPageController`** — 7 ação(ões): index, create, store, showPage, edit, update, destroy
-- **`DataController`** — 1 ação(ões): modifyAdminMenu
-- **`InstallController`** — 4 ação(ões): index, install, uninstall, update
+- **`CmsController`** — 14 ação(ões): index, indexLegacy, create, store, show, edit, update, destroy +6
+- **`CmsPageController`** — 8 ação(ões): index, create, store, showPage, showPageLegacy, edit, update, destroy
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`InstallController`** — 0 ação(ões): 
 - **`SettingsController`** — 7 ação(ões): index, create, store, show, edit, update, destroy
 
 ## Entities (Models Eloquent)
@@ -91,6 +97,18 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 ## Hooks UltimatePOS registrados
 
 - **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Permissões
+
+**Registradas pelo módulo** (via `user_permissions()`):
+
+- `cms.access`
+
+## Processamento / eventos
+
+**Commands (artisan):** `CmsHealthCommand`, `ImportWpOfficeImpressoCommand`
 
 ## Peças adicionais
 
@@ -137,84 +155,11 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ✅ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ❌ |
-| `origin/6.7-bootstrap` | ✅ |
 
 ## Diferenças vs versões anteriores
-
-### vs `origin/3.7-com-nfe`
-
-- **Arquivos alterados:** 103
-- **Linhas +:** 9154 **-:** 0
-- **Primeiros arquivos alterados:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2022_08_04_143146_create_cms_pages_table.php`
-  - `Database/Migrations/2022_09_10_161849_add_layout_column_to_cms_pages_table.php`
-  - `Database/Migrations/2022_09_10_163209_create_cms_site_details_table.php`
-  - `Database/Migrations/2022_09_15_122547_create_cms_page_metas_table.php`
-  - `Database/Migrations/2022_09_16_130337_create_default_data_for_cms.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/CmsDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Entities/CmsPage.php`
-  - `Entities/CmsPageMeta.php`
-  - `Entities/CmsSiteDetail.php`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/CmsController.php`
-  - `Http/Controllers/CmsPageController.php`
-  - `Http/Controllers/DataController.php`
-  - `Http/Controllers/InstallController.php`
-  - `Http/Controllers/SettingsController.php`
-  - `Http/Middleware/.gitkeep`
-  - `Http/Requests/.gitkeep`
-  - `Notifications/NewLeadGeneratedNotification.php`
-  - `Providers/.gitkeep`
-  - `Providers/CmsServiceProvider.php`
-  - `Providers/RouteServiceProvider.php`
-  - `Resources/assets/.gitkeep`
-  - `Resources/assets/css/cms.css`
-
-### vs `main-wip-2026-04-22` (backup das customizações)
-
-- **Arquivos alterados:** 103
-- **Linhas +:** 9154 **-:** 0
-- ⚠️ **Arquivos que podem conter customizações suas não trazidas para 6.7-react:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2022_08_04_143146_create_cms_pages_table.php`
-  - `Database/Migrations/2022_09_10_161849_add_layout_column_to_cms_pages_table.php`
-  - `Database/Migrations/2022_09_10_163209_create_cms_site_details_table.php`
-  - `Database/Migrations/2022_09_15_122547_create_cms_page_metas_table.php`
-  - `Database/Migrations/2022_09_16_130337_create_default_data_for_cms.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/CmsDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Entities/CmsPage.php`
-  - `Entities/CmsPageMeta.php`
-  - `Entities/CmsSiteDetail.php`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/CmsController.php`
-  - `Http/Controllers/CmsPageController.php`
-  - `Http/Controllers/DataController.php`
-  - `Http/Controllers/InstallController.php`
-  - `Http/Controllers/SettingsController.php`
-  - `Http/Middleware/.gitkeep`
-  - `Http/Requests/.gitkeep`
-  - `Notifications/NewLeadGeneratedNotification.php`
-  - `Providers/.gitkeep`
-  - `Providers/CmsServiceProvider.php`
-  - `Providers/RouteServiceProvider.php`
-  - `Resources/assets/.gitkeep`
-  - `Resources/assets/css/cms.css`
 
 ## Gaps & próximos passos (preencher manualmente)
 
@@ -224,5 +169,5 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:13.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Cms`

--- a/memory/modulos/Compras.md
+++ b/memory/modulos/Compras.md
@@ -1,0 +1,107 @@
+# Módulo: Compras
+
+> **Compras como cockpit operacional: FSM 6 estágios (rascunho/pedido/trânsito/recebido/conferido/pago), import XML DF-e, entrada matricial tam×cor pra vestuário. Substitui Blade legacy purchase/*.**
+
+- **Alias:** `compras`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/Compras`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\Compras\Providers\ComprasServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- ℹ️ Módulo sem views (provável API-only ou service)
+- ℹ️ Sem migrations próprias (pode depender de tabelas de outros módulos)
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- ✅ Tem testes (5)
+- 🔐 Registra 5 permissão(ões) Spatie
+- 🔗 Acoplamento: depende de 2 outro(s) módulo(s)
+
+- **Prioridade sugerida de migração:** alta (pequeno, ganho rápido)
+- **Risco estimado:** baixo
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 5 |
+| Controllers | 3 |
+| Entities (Models) | 0 |
+| Services | 1 |
+| FormRequests | 1 |
+| Middleware | 0 |
+| Views Blade | 0 |
+| Migrations | 0 |
+| Arquivos de lang | 0 |
+| Testes | 5 |
+
+## Rotas
+
+### `web.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+| `GET` | `/` | `[ComprasController::class, 'index']` |
+| `GET` | `/{id}/detalhe` | `[ComprasController::class, 'show']` |
+
+## Controllers
+
+- **`ComprasController`** — 2 ação(ões): index, show
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`InstallController`** — 3 ação(ões): index, uninstall, update
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Permissões
+
+**Registradas pelo módulo** (via `user_permissions()`):
+
+- `compras.view`
+- `compras.create`
+- `compras.edit`
+- `compras.delete`
+- `compras.import_xml`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `Compras` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `NfeBrasil` | 2 |
+| `Connector` | 1 |
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec Compras`

--- a/memory/modulos/ComunicacaoVisual.md
+++ b/memory/modulos/ComunicacaoVisual.md
@@ -1,0 +1,132 @@
+# Módulo: ComunicacaoVisual
+
+> **Modules/ComunicacaoVisual — vertical gráfica rápida e comunicação visual BR (CNAE 1813-0/01). Estado em construção (planejado piloto 2026-Q3 entre 6 saudáveis OfficeImpresso). Concorrentes: Mubisys, Zênite, Calcgraf. Diferencial: cálculo m² + PCP gráfico + apontamento + NFe-de-boleto-pago + IA conversacional. Ver memory/requisitos/ComunicacaoVisual/SPEC.md.**
+
+- **Alias:** `comunicacao-visual`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/ComunicacaoVisual`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\ComunicacaoVisual\Providers\ComunicacaoVisualServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- ℹ️ Módulo sem views (provável API-only ou service)
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- ✅ Tem testes (20)
+
+- **Prioridade sugerida de migração:** alta (pequeno, ganho rápido)
+- **Risco estimado:** baixo
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 12 |
+| Controllers | 4 |
+| Entities (Models) | 10 |
+| Services | 2 |
+| FormRequests | 6 |
+| Middleware | 0 |
+| Views Blade | 0 |
+| Migrations | 9 |
+| Arquivos de lang | 1 |
+| Testes | 20 |
+
+## Rotas
+
+### `web.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `/` | `function (` |
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+| `POST` | `calcular` | `[OrcamentoController::class, 'calcular']` |
+| `POST` | `orcamentos` | `[OrcamentoController::class, 'store']` |
+| `GET` | `orcamentos/{id}` | `[OrcamentoController::class, 'show']` |
+| `GET` | `apontamentos/em-andamento` | `[ApontamentoController::class, 'emAndamento']` |
+| `GET` | `apontamentos` | `[ApontamentoController::class, 'index']` |
+| `POST` | `apontamentos/iniciar` | `[ApontamentoController::class, 'iniciar']` |
+| `POST` | `apontamentos/{apontamento}/finalizar` | `[ApontamentoController::class, 'finalizar']` |
+| `POST` | `apontamentos/{apontamento}/cancelar` | `[ApontamentoController::class, 'cancelar']` |
+
+## Controllers
+
+- **`ApontamentoController`** — 5 ação(ões): index, iniciar, finalizar, cancelar, emAndamento
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`InstallController`** — 0 ação(ões): 
+- **`OrcamentoController`** — 3 ação(ões): calcular, store, show
+
+## Entities (Models Eloquent)
+
+- **`Acabamento`** (tabela: `cv_acabamentos`)
+- **`Apontamento`** (tabela: `comvis_apontamentos`)
+- **`Instalacao`** (tabela: `cv_instalacoes`)
+- **`InstalacaoCatalogo`** (tabela: `cv_instalacoes_catalogo`)
+- **`Material`** (tabela: `comvis_materiais`)
+- **`Orcamento`** (tabela: `comvis_orcamentos`)
+- **`OrcamentoItem`** (tabela: `comvis_orcamento_itens`)
+- **`OrdemProducao`** (tabela: `cv_ordens_producao`)
+- **`Os`** (tabela: `comvis_os`)
+- **`Substrato`** (tabela: `cv_substratos`)
+
+## Migrations
+
+- `2026_05_10_000040_create_comvis_materiais_table.php`
+- `2026_05_10_000041_create_comvis_orcamentos_table.php`
+- `2026_05_10_000042_create_comvis_os_table.php`
+- `2026_05_10_000043_create_comvis_apontamentos_table.php`
+- `2026_05_12_000010_create_cv_substratos_table.php`
+- `2026_05_12_000011_create_cv_acabamentos_table.php`
+- `2026_05_12_000012_create_cv_instalacoes_catalogo_table.php`
+- `2026_05_12_000013_create_cv_ordens_producao_table.php`
+- `2026_05_12_000014_create_cv_instalacoes_table.php`
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Processamento / eventos
+
+**Commands (artisan):** `ComvisHealthCommand`, `DemoSeedCommand`
+
+## Peças adicionais
+
+- **Seeders:** `MaterialSeeder`, `RepairSettingsSeeder`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `ComunicacaoVisual` |
+| `cnae` | `1813-0/01` |
+| `unidade_medida_default` | `m2` |
+
+## Integridade do banco
+
+**Unique indexes:** 3
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec ComunicacaoVisual`

--- a/memory/modulos/Connector.md
+++ b/memory/modulos/Connector.md
@@ -11,8 +11,10 @@
 
 ## Sinais detectados
 
-- 🔗 Registra 2 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
 - 🔴 +50 rotas — módulo grande, migrar em fases
+- ✅ Tem testes (9)
+- 🔐 Registra 1 permissão(ões) Spatie
 - 🔗 Acoplamento: depende de 3 outro(s) módulo(s)
 
 - **Prioridade sugerida de migração:** baixa (grande, fazer por último ou dividir)
@@ -22,16 +24,16 @@
 
 | Peça | Qtde |
 |---|---:|
-| Rotas (web+api) | 55 |
-| Controllers | 25 |
+| Rotas (web+api) | 61 |
+| Controllers | 30 |
 | Entities (Models) | 0 |
-| Services | 0 |
-| FormRequests | 0 |
+| Services | 2 |
+| FormRequests | 15 |
 | Middleware | 1 |
 | Views Blade | 2 |
 | Migrations | 1 |
 | Arquivos de lang | 16 |
-| Testes | 0 |
+| Testes | 9 |
 
 ## Rotas
 
@@ -45,12 +47,18 @@
 | `GET` | `install/update` | `[Modules\Connector\Http\Controllers\InstallController::class, 'update']` |
 | `GET` | `/api` | `[Modules\Connector\Http\Controllers\ConnectorController::class, 'index']` |
 | `GET` | `/regenerate` | `[Modules\Connector\Http\Controllers\ClientController::class, 'regenerate']` |
+| `RESOURCE` | `client` | `Officeimpresso\ClientController` |
 | `RESOURCE` | `/client` | `'Modules\Connector\Http\Controllers\ClientController'` |
 
 ### `api.php`
 
 | Método | URI | Controller |
 |---|---|---|
+| `POST` | `processa-dados-cliente` | `[ \Modules\Connector\Http\Controllers\Api\LicencaComputadorController::class, 'ProcessaDadosCliente' ]` |
+| `POST` | `salvar-cliente` | `[ \Modules\Connector\Http\Controllers\Api\BusinessController::class, 'saveBusiness' ]` |
+| `POST` | `salvar-equipamento/{business_id}` | `[ \Modules\Connector\Http\Controllers\Api\LicencaComputadorController::class, 'saveEquipamento' ]` |
+| `POST` | `oimpresso/registrar` | `[ \Modules\Connector\Http\Controllers\Api\OImpressoRegistroController::class, 'registrar' ]` |
+| `POST` | `check-update` | `[ \Modules\Connector\Http\Controllers\Api\CheckUpdateController::class, 'check' ]` |
 | `POST` | `contactapi-payment` | `[Modules\Connector\Http\Controllers\Api\ContactController::class, 'contactPay']` |
 | `GET` | `selling-price-group` | `[Modules\Connector\Http\Controllers\Api\ProductController::class, 'getSellingPriceGroup']` |
 | `GET` | `variation/{id?}` | `[Modules\Connector\Http\Controllers\Api\ProductController::class, 'listVariations']` |
@@ -86,28 +94,28 @@
 | `POST` | `field-force/create` | `[Modules\Connector\Http\Controllers\Api\FieldForce\FieldForceController::class, 'store']` |
 | `POST` | `field-force/update-visit-status/{id}` | `[Modules\Connector\Http\Controllers\Api\FieldForce\FieldForceController::class, 'updateStatus']` |
 | `RESOURCE` | `business-location` | `Modules\Connector\Http\Controllers\Api\BusinessLocationController::class` |
-| `RESOURCE` | `contactapi` | `Modules\Connector\Http\Controllers\Api\ContactController::class` |
-| `RESOURCE` | `unit` | `Modules\Connector\Http\Controllers\Api\UnitController::class` |
-| `RESOURCE` | `taxonomy` | `'Modules\Connector\Http\Controllers\Api\CategoryController'` |
-| `RESOURCE` | `brand` | `Modules\Connector\Http\Controllers\Api\BrandController::class` |
-| `RESOURCE` | `product` | `Modules\Connector\Http\Controllers\Api\ProductController::class` |
 
-_... +8 rotas_
+_... +13 rotas_
 
 ## Controllers
 
 - **`ApiController`** — 7 ação(ões): getStatusCode, setStatusCode, respondUnauthorized, respond, modelNotFoundExceptionResult, otherExceptions, getClient
 - **`AttendanceController`** — 4 ação(ões): getAttendance, clockin, clockout, getHolidays
+- **`BaseApiController`** — 2 ação(ões): syncData, getData
 - **`BrandController`** — 2 ação(ões): index, show
+- **`BusinessController`** — 8 ação(ões): index, create, store, show, edit, update, destroy, saveBusiness
 - **`BusinessLocationController`** — 2 ação(ões): index, show
 - **`CashRegisterController`** — 3 ação(ões): index, store, show
 - **`CategoryController`** — 2 ação(ões): index, show
+- **`CheckUpdateController`** — 1 ação(ões): check
 - **`CommonResourceController`** — 7 ação(ões): getPaymentAccounts, getPaymentMethods, getBusinessDetails, getProfitLoss, getProductStock, getNotifications, getLocation
 - **`ContactController`** — 5 ação(ões): index, store, show, update, contactPay
 - **`CallLogsController`** — 2 ação(ões): saveCallLogs, searchUser
 - **`FollowUpController`** — 6 ação(ões): index, getFollowUpResources, store, show, update, getLeads
 - **`ExpenseController`** — 6 ação(ões): index, show, store, update, listExpenseRefund, listExpenseCategories
 - **`FieldForceController`** — 3 ação(ões): index, store, updateStatus
+- **`LicencaComputadorController`** — 7 ação(ões): ProcessaDadosCliente, saveEquipamento, index, store, show, update, destroy
+- **`OImpressoRegistroController`** — 1 ação(ões): registrar
 - **`ProductController`** — 4 ação(ões): index, show, listVariations, getSellingPriceGroup
 - **`ProductSellController`** — 3 ação(ões): newProduct, newSell, newContactApi
 - **`SellController`** — 8 ação(ões): index, show, store, update, destroy, updateSellShippingStatus, addSellReturn, listSellReturn
@@ -119,8 +127,8 @@ _... +8 rotas_
 - **`UserController`** — 7 ação(ões): index, show, loggedin, updatePassword, registerUser, generateRandomString, forgetPassword
 - **`ClientController`** — 8 ação(ões): index, create, store, show, edit, update, destroy, regenerate
 - **`ConnectorController`** — 7 ação(ões): index, create, store, show, edit, update, destroy
-- **`DataController`** — 2 ação(ões): superadmin_package, modifyAdminMenu
-- **`InstallController`** — 4 ação(ões): index, install, uninstall, update
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`InstallController`** — 0 ação(ões): 
 
 ## Migrations
 
@@ -139,12 +147,21 @@ _... +8 rotas_
 
 - **`modifyAdminMenu()`** — Injeta itens na sidebar admin
 - **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
 
 ## Permissões
+
+**Registradas pelo módulo** (via `user_permissions()`):
+
+- `connector.access`
 
 **Usadas nas views** (`@can`/`@cannot`):
 
 - `superadmin`
+
+## Processamento / eventos
+
+**Commands (artisan):** `ConnectorHealthCommand`
 
 ## Peças adicionais
 
@@ -195,84 +212,11 @@ _Referências a outros módulos encontradas no código PHP._
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ✅ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ✅ |
 
 ## Diferenças vs versões anteriores
-
-### vs `origin/3.7-com-nfe`
-
-- **Arquivos alterados:** 85
-- **Linhas +:** 12460 **-:** 0
-- **Primeiros arquivos alterados:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2020_08_18_123107_add_connector_module_version_to_system_table.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/ConnectorDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/Api/ApiController.php`
-  - `Http/Controllers/Api/AttendanceController.php`
-  - `Http/Controllers/Api/BrandController.php`
-  - `Http/Controllers/Api/BusinessLocationController.php`
-  - `Http/Controllers/Api/CashRegisterController.php`
-  - `Http/Controllers/Api/CategoryController.php`
-  - `Http/Controllers/Api/CommonResourceController.php`
-  - `Http/Controllers/Api/ContactController.php`
-  - `Http/Controllers/Api/Crm/CallLogsController.php`
-  - `Http/Controllers/Api/Crm/FollowUpController.php`
-  - `Http/Controllers/Api/ExpenseController.php`
-  - `Http/Controllers/Api/FieldForce/FieldForceController.php`
-  - `Http/Controllers/Api/ProductController.php`
-  - `Http/Controllers/Api/ProductSellController.php`
-  - `Http/Controllers/Api/SellController.php`
-  - `Http/Controllers/Api/SuperadminController.php`
-  - `Http/Controllers/Api/TableController.php`
-  - `Http/Controllers/Api/TaxController.php`
-  - `Http/Controllers/Api/TypesOfServiceController.php`
-  - `Http/Controllers/Api/UnitController.php`
-
-### vs `main-wip-2026-04-22` (backup das customizações)
-
-- **Arquivos alterados:** 85
-- **Linhas +:** 12460 **-:** 0
-- ⚠️ **Arquivos que podem conter customizações suas não trazidas para 6.7-react:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2020_08_18_123107_add_connector_module_version_to_system_table.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/ConnectorDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/Api/ApiController.php`
-  - `Http/Controllers/Api/AttendanceController.php`
-  - `Http/Controllers/Api/BrandController.php`
-  - `Http/Controllers/Api/BusinessLocationController.php`
-  - `Http/Controllers/Api/CashRegisterController.php`
-  - `Http/Controllers/Api/CategoryController.php`
-  - `Http/Controllers/Api/CommonResourceController.php`
-  - `Http/Controllers/Api/ContactController.php`
-  - `Http/Controllers/Api/Crm/CallLogsController.php`
-  - `Http/Controllers/Api/Crm/FollowUpController.php`
-  - `Http/Controllers/Api/ExpenseController.php`
-  - `Http/Controllers/Api/FieldForce/FieldForceController.php`
-  - `Http/Controllers/Api/ProductController.php`
-  - `Http/Controllers/Api/ProductSellController.php`
-  - `Http/Controllers/Api/SellController.php`
-  - `Http/Controllers/Api/SuperadminController.php`
-  - `Http/Controllers/Api/TableController.php`
-  - `Http/Controllers/Api/TaxController.php`
-  - `Http/Controllers/Api/TypesOfServiceController.php`
-  - `Http/Controllers/Api/UnitController.php`
 
 ## Gaps & próximos passos (preencher manualmente)
 
@@ -282,5 +226,5 @@ _Referências a outros módulos encontradas no código PHP._
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:14.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Connector`

--- a/memory/modulos/ConsultaOs.md
+++ b/memory/modulos/ConsultaOs.md
@@ -1,0 +1,100 @@
+# Módulo: ConsultaOs
+
+> **Portal público de consulta de Ordem de Serviço — cliente acompanha pipeline de produção (orçado → aprovação → produção → acabamento → expedição → entregue) sem login.**
+
+- **Alias:** `consultaos`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/ConsultaOs`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\ConsultaOs\Providers\ConsultaOsServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- ℹ️ Módulo sem views (provável API-only ou service)
+- ℹ️ Sem migrations próprias (pode depender de tabelas de outros módulos)
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- ✅ Tem testes (11)
+- 🔗 Acoplamento: depende de 1 outro(s) módulo(s)
+
+- **Prioridade sugerida de migração:** alta (pequeno, ganho rápido)
+- **Risco estimado:** baixo
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 5 |
+| Controllers | 3 |
+| Entities (Models) | 0 |
+| Services | 1 |
+| FormRequests | 3 |
+| Middleware | 0 |
+| Views Blade | 0 |
+| Migrations | 0 |
+| Arquivos de lang | 0 |
+| Testes | 11 |
+
+## Rotas
+
+### `web.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `/` | `[ConsultaOsController::class, 'index']` |
+| `GET` | `/buscar` | `[ConsultaOsController::class, 'buscar']` |
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+
+## Controllers
+
+- **`ConsultaOsController`** — 2 ação(ões): index, buscar
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`InstallController`** — 0 ação(ões): 
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Processamento / eventos
+
+**Commands (artisan):** `ConsultaOsHealthCommand`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `ConsultaOs` |
+| `mock_enabled` | `true` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `Jana` | 1 |
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec ConsultaOs`

--- a/memory/modulos/Crm.md
+++ b/memory/modulos/Crm.md
@@ -14,7 +14,9 @@
 - 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, user_permissions, addTaxonomies
 - 🔴 +50 rotas — módulo grande, migrar em fases
 - 🔴 +50 views — trabalho pesado
+- ✅ Tem testes (13)
 - 🔐 Registra 13 permissão(ões) Spatie
+- 🗃️ 11 foreign keys — alto acoplamento em dados
 
 - **Prioridade sugerida de migração:** baixa (grande, fazer por último ou dividir)
 - **Risco estimado:** alto
@@ -23,16 +25,16 @@
 
 | Peça | Qtde |
 |---|---:|
-| Rotas (web+api) | 52 |
-| Controllers | 21 |
-| Entities (Models) | 11 |
-| Services | 0 |
-| FormRequests | 0 |
+| Rotas (web+api) | 75 |
+| Controllers | 27 |
+| Entities (Models) | 12 |
+| Services | 9 |
+| FormRequests | 16 |
 | Middleware | 2 |
 | Views Blade | 68 |
-| Migrations | 26 |
+| Migrations | 27 |
 | Arquivos de lang | 16 |
-| Testes | 0 |
+| Testes | 13 |
 
 ## Rotas
 
@@ -62,7 +64,6 @@
 | `GET` | `install/update` | `[Modules\Crm\Http\Controllers\InstallController::class, 'update']` |
 | `GET` | `lead/{id}/convert` | `[Modules\Crm\Http\Controllers\LeadController::class, 'convertToCustomer']` |
 | `GET` | `lead/{id}/post-life-stage` | `[Modules\Crm\Http\Controllers\LeadController::class, 'postLifeStage']` |
-| `GET` | `{id}/send-campaign-notification` | `[Modules\Crm\Http\Controllers\CampaignController::class, 'sendNotification']` |
 | `GET` | `dashboard` | `[Modules\Crm\Http\Controllers\CrmDashboardController::class, 'index']` |
 | `GET` | `reports` | `[Modules\Crm\Http\Controllers\ReportController::class, 'index']` |
 | `GET` | `follow-ups-by-user` | `[Modules\Crm\Http\Controllers\ReportController::class, 'followUpsByUser']` |
@@ -70,18 +71,19 @@
 | `GET` | `lead-to-customer-report` | `[Modules\Crm\Http\Controllers\ReportController::class, 'leadToCustomerConversion']` |
 | `GET` | `lead-to-customer-details/{user_id}` | `[Modules\Crm\Http\Controllers\ReportController::class, 'showLeadToCustomerConversionDetails']` |
 | `GET` | `call-log` | `[Modules\Crm\Http\Controllers\CallLogController::class, 'index'], ['only' => ['index']]` |
-| `POST` | `mass-delete-call-log` | `[Modules\Crm\Http\Controllers\CallLogController::class, 'massDestroy']` |
 | `GET` | `edit-proposal-template` | `[Modules\Crm\Http\Controllers\ProposalTemplateController::class, 'getEdit']` |
 | `POST` | `update-proposal-template` | `[Modules\Crm\Http\Controllers\ProposalTemplateController::class, 'postEdit']` |
 | `GET` | `view-proposal-template` | `[Modules\Crm\Http\Controllers\ProposalTemplateController::class, 'getView']` |
-| `GET` | `send-proposal` | `[Modules\Crm\Http\Controllers\ProposalTemplateController::class, 'send']` |
 | `DELETE` | `delete-proposal-media/{id}` | `[Modules\Crm\Http\Controllers\ProposalTemplateController::class, 'deleteProposalMedia']` |
 | `GET` | `settings` | `[Modules\Crm\Http\Controllers\CrmSettingsController::class, 'index']` |
 | `POST` | `update-settings` | `[Modules\Crm\Http\Controllers\CrmSettingsController::class, 'updateSettings']` |
 | `GET` | `order-request` | `[Modules\Crm\Http\Controllers\OrderRequestController::class, 'listOrderRequests']` |
 | `GET` | `b2b-marketplace` | `[Modules\Crm\Http\Controllers\CrmMarketplaceController::class, 'index']` |
+| `POST` | `save-marketplace` | `[Modules\Crm\Http\Controllers\CrmMarketplaceController::class, 'save']` |
+| `GET` | `import-leads` | `[Modules\Crm\Http\Controllers\CrmMarketplaceController::class, 'importLeads']` |
+| `POST` | `draft` | `[\Modules\Crm\Http\Controllers\ClienteAutosaveController::class, 'draft']` |
 
-_... +12 rotas_
+_... +35 rotas_
 
 ### `api.php`
 
@@ -91,6 +93,12 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 - **`CallLogController`** — 3 ação(ões): index, massDestroy, allUsersCallLog
 - **`CampaignController`** — 9 ação(ões): index, create, store, show, edit, update, destroy, sendNotification +1
+- **`ClienteAuditoriaController`** — 2 ação(ões): index, export
+- **`ClienteAutosaveController`** — 7 ação(ões): draft, identificacao, contato, endereco, comercial, classificacao, papeis
+- **`ClienteIaController`** — 4 ação(ões): resumo, segmento, proximaAcao, scoreRisco
+- **`ClienteLookupController`** — 3 ação(ões): cep, cnpj, cnpjSefaz
+- **`ClienteOssDataController`** — 8 ação(ões): ledger, sales, payments, documents, activities, persons, subscriptions, rewards
+- **`ClienteVeiculosController`** — 1 ação(ões): index
 - **`ContactBookingController`** — 7 ação(ões): index, create, store, show, edit, update, destroy
 - **`ContactLoginController`** — 9 ação(ões): index, create, store, show, edit, update, destroy, allContactsLoginList +1
 - **`CrmDashboardController`** — 7 ação(ões): index, create, store, show, edit, update, destroy
@@ -98,7 +106,7 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - **`CrmSettingsController`** — 2 ação(ões): index, updateSettings
 - **`DashboardController`** — 7 ação(ões): index, create, store, show, edit, update, destroy
 - **`DataController`** — 12 ação(ões): after_payment_status_updated, deleteCommissionWithSale, parse_notification, modifyAdminMenu, get_contact_view_tabs, addTaxonomies, user_permissions, calendarEvents +4
-- **`InstallController`** — 4 ação(ões): index, install, uninstall, update
+- **`InstallController`** — 0 ação(ões): 
 - **`LeadController`** — 9 ação(ões): index, create, store, show, edit, update, destroy, convertToCustomer +1
 - **`LedgerController`** — 2 ação(ões): index, getLedger
 - **`ManageProfileController`** — 3 ação(ões): getProfile, updateProfile, updatePassword
@@ -118,6 +126,7 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - **`CrmContact`** (tabela: `contacts`)
 - **`CrmContactPersonCommission`** (tabela: `—`)
 - **`CrmMarketplace`** (tabela: `—`)
+- **`Deal`** (tabela: `crm_deals`)
 - **`Leaduser`** (tabela: `crm_lead_users`)
 - **`Proposal`** (tabela: `crm_proposals`)
 - **`ProposalTemplate`** (tabela: `crm_proposal_templates`)
@@ -153,6 +162,7 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - `2022_03_02_180929_add_followup_category_id.php`
 - `2022_05_26_061553_create_crm_contact_person_commissions_table.php`
 - `2022_06_06_073006_add_cc_and_bcc_columns_to_crm_proposals_table.php`
+- `2026_05_17_120000_create_crm_deals_table.php`
 
 ## Views (Blade)
 
@@ -228,10 +238,11 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 ## Processamento / eventos
 
-**Commands (artisan):** `CreateRecursiveFollowup`, `SendScheduleNotification`
+**Commands (artisan):** `CrmHealthCommand`, `CreateRecursiveFollowup`, `SendScheduleNotification`
 
 ## Peças adicionais
 
+- **Policies:** `CampaignPolicy`, `ProposalPolicy`
 - **Notifications:** `ScheduleNotification`, `SendCampaignNotification`, `SendProposalNotification`
 - **Seeders:** `CrmDatabaseSeeder`
 
@@ -245,7 +256,7 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 ## Integridade do banco
 
-**Foreign Keys** (10):
+**Foreign Keys** (11):
 
 - `crm_contact_id` → `contacts.id`
 - `business_id` → `business.id`
@@ -257,6 +268,7 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - `business_id` → `business.id`
 - `business_id` → `business.id`
 - `contact_id` → `contacts.id`
+- `business_id` → `business.id`
 
 ## Assets (JS / CSS)
 
@@ -286,84 +298,11 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ✅ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ✅ |
 
 ## Diferenças vs versões anteriores
-
-### vs `origin/3.7-com-nfe`
-
-- **Arquivos alterados:** 176
-- **Linhas +:** 19919 **-:** 0
-- **Primeiros arquivos alterados:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Console/CreateRecursiveFollowup.php`
-  - `Console/SendScheduleNotification.php`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2020_03_19_130231_add_contact_id_to_users_table.php`
-  - `Database/Migrations/2020_03_27_133605_create_schedules_table.php`
-  - `Database/Migrations/2020_03_27_133628_create_schedule_users_table.php`
-  - `Database/Migrations/2020_03_30_112834_create_schedule_logs_table.php`
-  - `Database/Migrations/2020_04_02_182331_add_crm_module_version_to_system_table.php`
-  - `Database/Migrations/2020_04_08_153231_modify_cloumn_in_contacts_table.php`
-  - `Database/Migrations/2020_04_09_101052_create_lead_users_table.php`
-  - `Database/Migrations/2020_04_16_114747_create_crm_campaigns_table.php`
-  - `Database/Migrations/2021_01_07_155757_add_followup_additional_info_column_to_crm_schedules_table.php`
-  - `Database/Migrations/2021_02_02_140021_add_additional_info_to_crm_campaigns_table.php`
-  - `Database/Migrations/2021_02_02_173651_add_new_columns_to_contacts_table.php`
-  - `Database/Migrations/2021_02_04_120439_create_call_logs_table.php`
-  - `Database/Migrations/2021_02_08_172047_add_mobile_name_column_to_crm_call_logs_table.php`
-  - `Database/Migrations/2021_02_16_190038_add_crm_module_indexing.php`
-  - `Database/Migrations/2021_02_19_120846_create_crm_followup_invoices.php`
-  - `Database/Migrations/2021_02_22_132125_add_follow_up_by_to_crm_schedules_table.php`
-  - `Database/Migrations/2021_03_24_160736_add_department_and_designation_to_users_table.php`
-  - `Database/Migrations/2021_06_15_152924_create_proposal_templates_table.php`
-  - `Database/Migrations/2021_06_16_114448_add_recursive_fields_to_crm_schedules_table.php`
-  - `Database/Migrations/2021_06_16_125740_create_proposals_table.php`
-  - `Database/Migrations/2021_09_24_065738_add_crm_settings_column_to_business_table.php`
-  - `Database/Migrations/2022_02_09_055012_create_crm_marketplaces_table.php`
-  - `Database/Migrations/2022_02_17_113045_add_source_id_to_marketplace.php`
-  - `Database/Migrations/2022_03_02_180929_add_followup_category_id.php`
-
-### vs `main-wip-2026-04-22` (backup das customizações)
-
-- **Arquivos alterados:** 176
-- **Linhas +:** 19919 **-:** 0
-- ⚠️ **Arquivos que podem conter customizações suas não trazidas para 6.7-react:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Console/CreateRecursiveFollowup.php`
-  - `Console/SendScheduleNotification.php`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2020_03_19_130231_add_contact_id_to_users_table.php`
-  - `Database/Migrations/2020_03_27_133605_create_schedules_table.php`
-  - `Database/Migrations/2020_03_27_133628_create_schedule_users_table.php`
-  - `Database/Migrations/2020_03_30_112834_create_schedule_logs_table.php`
-  - `Database/Migrations/2020_04_02_182331_add_crm_module_version_to_system_table.php`
-  - `Database/Migrations/2020_04_08_153231_modify_cloumn_in_contacts_table.php`
-  - `Database/Migrations/2020_04_09_101052_create_lead_users_table.php`
-  - `Database/Migrations/2020_04_16_114747_create_crm_campaigns_table.php`
-  - `Database/Migrations/2021_01_07_155757_add_followup_additional_info_column_to_crm_schedules_table.php`
-  - `Database/Migrations/2021_02_02_140021_add_additional_info_to_crm_campaigns_table.php`
-  - `Database/Migrations/2021_02_02_173651_add_new_columns_to_contacts_table.php`
-  - `Database/Migrations/2021_02_04_120439_create_call_logs_table.php`
-  - `Database/Migrations/2021_02_08_172047_add_mobile_name_column_to_crm_call_logs_table.php`
-  - `Database/Migrations/2021_02_16_190038_add_crm_module_indexing.php`
-  - `Database/Migrations/2021_02_19_120846_create_crm_followup_invoices.php`
-  - `Database/Migrations/2021_02_22_132125_add_follow_up_by_to_crm_schedules_table.php`
-  - `Database/Migrations/2021_03_24_160736_add_department_and_designation_to_users_table.php`
-  - `Database/Migrations/2021_06_15_152924_create_proposal_templates_table.php`
-  - `Database/Migrations/2021_06_16_114448_add_recursive_fields_to_crm_schedules_table.php`
-  - `Database/Migrations/2021_06_16_125740_create_proposals_table.php`
-  - `Database/Migrations/2021_09_24_065738_add_crm_settings_column_to_business_table.php`
-  - `Database/Migrations/2022_02_09_055012_create_crm_marketplaces_table.php`
-  - `Database/Migrations/2022_02_17_113045_add_source_id_to_marketplace.php`
-  - `Database/Migrations/2022_03_02_180929_add_followup_category_id.php`
 
 ## Gaps & próximos passos (preencher manualmente)
 
@@ -373,5 +312,5 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:14.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Crm`

--- a/memory/modulos/Dashboard.md
+++ b/memory/modulos/Dashboard.md
@@ -36,10 +36,9 @@
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ❌ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ❌ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ❌ |
 
 ## Diferenças vs versões anteriores
 
@@ -51,5 +50,5 @@
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:14.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Dashboard`

--- a/memory/modulos/Essentials.md
+++ b/memory/modulos/Essentials.md
@@ -14,8 +14,9 @@
 - 🔗 Registra 5 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions, addTaxonomies, moduleViewPartials
 - 🔴 +50 rotas — módulo grande, migrar em fases
 - 🔴 +50 views — trabalho pesado
-- ✅ Tem testes (2)
+- ✅ Tem testes (12)
 - 🔐 Registra 23 permissão(ões) Spatie
+- 🔗 Acoplamento: depende de 2 outro(s) módulo(s)
 
 - **Prioridade sugerida de migração:** baixa (grande, fazer por último ou dividir)
 - **Risco estimado:** alto
@@ -24,16 +25,16 @@
 
 | Peça | Qtde |
 |---|---:|
-| Rotas (web+api) | 53 |
+| Rotas (web+api) | 55 |
 | Controllers | 19 |
 | Entities (Models) | 18 |
-| Services | 0 |
-| FormRequests | 4 |
+| Services | 4 |
+| FormRequests | 10 |
 | Middleware | 0 |
 | Views Blade | 87 |
 | Migrations | 36 |
 | Arquivos de lang | 16 |
-| Testes | 2 |
+| Testes | 12 |
 
 ## Rotas
 
@@ -46,6 +47,7 @@
 | `GET` | `/install/update` | `[Modules\Essentials\Http\Controllers\InstallController::class, 'update']` |
 | `GET` | `/install/uninstall` | `[Modules\Essentials\Http\Controllers\InstallController::class, 'uninstall']` |
 | `GET` | `/` | `[Modules\Essentials\Http\Controllers\EssentialsController::class, 'index']` |
+| `POST` | `document` | `[Modules\Essentials\Http\Controllers\DocumentController::class, 'store']` |
 | `GET` | `document/download/{id}` | `[Modules\Essentials\Http\Controllers\DocumentController::class, 'download']` |
 | `POST` | `todo/add-comment` | `[Modules\Essentials\Http\Controllers\ToDoController::class, 'addComment']` |
 | `GET` | `todo/delete-comment/{id}` | `[Modules\Essentials\Http\Controllers\ToDoController::class, 'deleteComment']` |
@@ -53,6 +55,7 @@
 | `POST` | `todo/upload-document` | `[Modules\Essentials\Http\Controllers\ToDoController::class, 'uploadDocument']` |
 | `GET` | `view-todo-{id}-share-docs` | `[Modules\Essentials\Http\Controllers\ToDoController::class, 'viewSharedDocs']` |
 | `GET` | `get-new-messages` | `[Modules\Essentials\Http\Controllers\EssentialsMessageController::class, 'getNewMessages']` |
+| `POST` | `messages` | `[Modules\Essentials\Http\Controllers\EssentialsMessageController::class, 'store']` |
 | `GET` | `user-sales-targets` | `[Modules\Essentials\Http\Controllers\DashboardController::class, 'getUserSalesTargets']` |
 | `GET` | `/dashboard` | `[Modules\Essentials\Http\Controllers\DashboardController::class, 'hrmDashboard']` |
 | `POST` | `/change-status` | `[Modules\Essentials\Http\Controllers\EssentialsLeaveController::class, 'changeStatus']` |
@@ -79,10 +82,8 @@
 | `GET` | `/shift/assign-users/{shift_id}` | `[Modules\Essentials\Http\Controllers\ShiftController::class, 'getAssignUsers']` |
 | `POST` | `/shift/assign-users` | `[Modules\Essentials\Http\Controllers\ShiftController::class, 'postAssignUsers']` |
 | `GET` | `/sales-target` | `[Modules\Essentials\Http\Controllers\SalesTargetController::class, 'index']` |
-| `GET` | `/set-sales-target/{id}` | `[Modules\Essentials\Http\Controllers\SalesTargetController::class, 'setSalesTarget']` |
-| `POST` | `/save-sales-target` | `[Modules\Essentials\Http\Controllers\SalesTargetController::class, 'saveSalesTarget']` |
 
-_... +13 rotas_
+_... +15 rotas_
 
 ### `api.php`
 
@@ -262,6 +263,7 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 ## Peças adicionais
 
+- **Policies:** `DocumentPolicy`, `KnowledgeBasePolicy`, `ToDoPolicy`
 - **Notifications:** `DocumentShareNotification`, `LeaveStatusNotification`, `NewLeaveNotification`, `NewMessageNotification`, `NewTaskCommentNotification`, `NewTaskDocumentNotification`, `NewTaskNotification`, `PayrollNotification`
 - **Seeders:** `EssentialsDatabaseSeeder`
 
@@ -272,6 +274,15 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 | `name` | `Essentials` |
 | `module_version` | `4.0` |
 | `chat_refresh_interval` | `20` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `KB` | 1 |
+| `NfeBrasil` | 1 |
 
 ## Integridade do banco
 
@@ -306,84 +317,11 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ✅ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ✅ |
 
 ## Diferenças vs versões anteriores
-
-### vs `origin/3.7-com-nfe`
-
-- **Arquivos alterados:** 219
-- **Linhas +:** 22920 **-:** 0
-- **Primeiros arquivos alterados:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Console/AutoClockOutUser.php`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2018_10_01_151252_create_documents_table.php`
-  - `Database/Migrations/2018_10_02_151803_create_document_shares_table.php`
-  - `Database/Migrations/2018_10_09_134558_create_reminders_table.php`
-  - `Database/Migrations/2018_11_16_170756_create_to_dos_table.php`
-  - `Database/Migrations/2019_02_22_120329_essentials_messages.php`
-  - `Database/Migrations/2019_02_22_161513_add_message_permissions.php`
-  - `Database/Migrations/2019_03_29_164339_add_essentials_version_to_system_table.php`
-  - `Database/Migrations/2019_05_17_153306_create_essentials_leave_types_table.php`
-  - `Database/Migrations/2019_05_17_175921_create_essentials_leaves_table.php`
-  - `Database/Migrations/2019_05_21_154517_add_essentials_settings_columns_to_business_table.php`
-  - `Database/Migrations/2019_05_21_181653_create_table_essentials_attendance.php`
-  - `Database/Migrations/2019_05_30_110049_create_essentials_payrolls_table.php`
-  - `Database/Migrations/2019_06_04_105723_create_essentials_holidays_table.php`
-  - `Database/Migrations/2019_06_28_134217_add_payroll_columns_to_transactions_table.php`
-  - `Database/Migrations/2019_08_26_103520_add_approve_leave_permission.php`
-  - `Database/Migrations/2019_08_27_103724_create_essentials_allowance_and_deduction_table.php`
-  - `Database/Migrations/2019_08_27_105236_create_essentials_user_allowances_and_deductions.php`
-  - `Database/Migrations/2019_09_20_115906_add_more_columns_to_essentials_to_dos_table.php`
-  - `Database/Migrations/2019_09_23_120439_create_essentials_todo_comments_table.php`
-  - `Database/Migrations/2019_12_05_170724_add_hrm_columns_to_users_table.php`
-  - `Database/Migrations/2019_12_09_105809_add_allowance_and_deductions_permission.php`
-  - `Database/Migrations/2020_03_28_152838_create_essentials_shift_table.php`
-  - `Database/Migrations/2020_03_30_162029_create_user_shifts_table.php`
-  - `Database/Migrations/2020_03_31_134558_add_shift_id_to_attendance_table.php`
-  - `Database/Migrations/2020_11_05_105157_modify_todos_date_column_type.php`
-
-### vs `main-wip-2026-04-22` (backup das customizações)
-
-- **Arquivos alterados:** 219
-- **Linhas +:** 22920 **-:** 0
-- ⚠️ **Arquivos que podem conter customizações suas não trazidas para 6.7-react:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Console/AutoClockOutUser.php`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2018_10_01_151252_create_documents_table.php`
-  - `Database/Migrations/2018_10_02_151803_create_document_shares_table.php`
-  - `Database/Migrations/2018_10_09_134558_create_reminders_table.php`
-  - `Database/Migrations/2018_11_16_170756_create_to_dos_table.php`
-  - `Database/Migrations/2019_02_22_120329_essentials_messages.php`
-  - `Database/Migrations/2019_02_22_161513_add_message_permissions.php`
-  - `Database/Migrations/2019_03_29_164339_add_essentials_version_to_system_table.php`
-  - `Database/Migrations/2019_05_17_153306_create_essentials_leave_types_table.php`
-  - `Database/Migrations/2019_05_17_175921_create_essentials_leaves_table.php`
-  - `Database/Migrations/2019_05_21_154517_add_essentials_settings_columns_to_business_table.php`
-  - `Database/Migrations/2019_05_21_181653_create_table_essentials_attendance.php`
-  - `Database/Migrations/2019_05_30_110049_create_essentials_payrolls_table.php`
-  - `Database/Migrations/2019_06_04_105723_create_essentials_holidays_table.php`
-  - `Database/Migrations/2019_06_28_134217_add_payroll_columns_to_transactions_table.php`
-  - `Database/Migrations/2019_08_26_103520_add_approve_leave_permission.php`
-  - `Database/Migrations/2019_08_27_103724_create_essentials_allowance_and_deduction_table.php`
-  - `Database/Migrations/2019_08_27_105236_create_essentials_user_allowances_and_deductions.php`
-  - `Database/Migrations/2019_09_20_115906_add_more_columns_to_essentials_to_dos_table.php`
-  - `Database/Migrations/2019_09_23_120439_create_essentials_todo_comments_table.php`
-  - `Database/Migrations/2019_12_05_170724_add_hrm_columns_to_users_table.php`
-  - `Database/Migrations/2019_12_09_105809_add_allowance_and_deductions_permission.php`
-  - `Database/Migrations/2020_03_28_152838_create_essentials_shift_table.php`
-  - `Database/Migrations/2020_03_30_162029_create_user_shifts_table.php`
-  - `Database/Migrations/2020_03_31_134558_add_shift_id_to_attendance_table.php`
-  - `Database/Migrations/2020_11_05_105157_modify_todos_date_column_type.php`
 
 ## Gaps & próximos passos (preencher manualmente)
 
@@ -393,5 +331,5 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 16:19.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Essentials`

--- a/memory/modulos/Financeiro.md
+++ b/memory/modulos/Financeiro.md
@@ -1,0 +1,265 @@
+# Módulo: Financeiro
+
+> **Contas a pagar, a receber, fluxo de caixa e DRE — tudo na mesma tela. Foundation BR pra virar ERP completo.**
+
+- **Alias:** `financeiro`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/Financeiro`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\Financeiro\Providers\FinanceiroServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- 🔴 +50 rotas — módulo grande, migrar em fases
+- ✅ Tem testes (57)
+- ⚙️ Processamento assíncrono: 7 peça(s) (jobs/events/listeners)
+- 🔗 Acoplamento: depende de 2 outro(s) módulo(s)
+- 🗃️ 31 foreign keys — alto acoplamento em dados
+
+- **Prioridade sugerida de migração:** baixa (grande, fazer por último ou dividir)
+- **Risco estimado:** alto
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 67 |
+| Controllers | 23 |
+| Entities (Models) | 0 |
+| Services | 13 |
+| FormRequests | 10 |
+| Middleware | 1 |
+| Views Blade | 3 |
+| Migrations | 22 |
+| Arquivos de lang | 1 |
+| Testes | 57 |
+
+## Rotas
+
+### `web.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+| `GET` | `assinaturas/atualizar` | `[AssinaturaController::class, 'showAtualizar']` |
+| `PATCH` | `assinaturas/{assinatura}` | `[AssinaturaController::class, 'atualizar']` |
+| `GET` | `/` | `[DashboardController::class, 'index']` |
+| `GET` | `/unificado` | `[UnificadoController::class, 'index']` |
+| `GET` | `/unificado/novo` | `[UnificadoController::class, 'novo']` |
+| `POST` | `/unificado/{id}/baixar` | `[UnificadoController::class, 'baixar']` |
+| `POST` | `/unificado/bulk-update-categoria` | `[UnificadoController::class, 'bulkUpdateCategoria']` |
+| `PUT` | `/unificado/{id}` | `[UnificadoController::class, 'update']` |
+| `POST` | `/unificado` | `[UnificadoController::class, 'store']` |
+| `POST` | `/unificado/{id}/conferir` | `[UnificadoController::class, 'conferir']` |
+| `DELETE` | `/unificado/{id}/conferir` | `[UnificadoController::class, 'unconferir']` |
+| `GET` | `/unificado/saldo-sparkline` | `[UnificadoController::class, 'saldoSparkline']` |
+| `GET` | `/unificado/sugerir-valor` | `[UnificadoController::class, 'sugerirValor']` |
+| `GET` | `/unificado/buscar-cliente` | `[UnificadoController::class, 'buscarCliente']` |
+| `GET` | `/cowork-sidebar-data` | `[\Modules\Financeiro\Http\Controllers\CoworkSidebarController::class, 'data']` |
+| `GET` | `/unificado/{tituloId}/comments` | `[UnificadoController::class, 'comments']` |
+| `POST` | `/unificado/{tituloId}/comments` | `[UnificadoController::class, 'addComment']` |
+| `GET` | `/unificado/{tituloId}/audit` | `[UnificadoController::class, 'auditTrail']` |
+| `GET` | `/fluxo` | `[FluxoController::class, 'index']` |
+| `GET` | `/dre` | `[DreController::class, 'index']` |
+| `GET` | `/dre/export-pdf` | `[DreController::class, 'exportPdf']` |
+| `GET` | `/dre/export-xlsx` | `[DreController::class, 'exportXlsx']` |
+| `GET` | `/dre/export-csv` | `[DreController::class, 'exportCsv']` |
+| `GET` | `/contas-receber` | `[ContaReceberController::class, 'index']` |
+| `POST` | `/contas-receber/{tituloId}/boleto` | `[ContaReceberController::class, 'emitirBoleto']` |
+| `POST` | `/boletos/{remessaId}/cancelar` | `[BoletoController::class, 'cancelar']` |
+| `GET` | `/cobranca` | `[CobrancaController::class, 'index']` |
+| `POST` | `/cobranca/emitir` | `[CobrancaController::class, 'store']` |
+| `POST` | `/cobranca/cartao` | `[CobrancaController::class, 'storeCartao']` |
+| `GET` | `/contas-pagar` | `[ContaPagarController::class, 'index']` |
+| `POST` | `/contas-pagar/{tituloId}/pagar` | `[ContaPagarController::class, 'pagar']` |
+| `GET` | `/contas-bancarias` | `[ContaBancariaController::class, 'index']` |
+| `POST` | `/contas-bancarias/{accountId}` | `[ContaBancariaController::class, 'upsert']` |
+| `GET` | `/extrato/{contaBancariaId}` | `[ExtratoController::class, 'index']` |
+| `GET` | `/relatorios` | `[RelatoriosController::class, 'index']` |
+| `GET` | `/relatorios/export-csv` | `[RelatoriosController::class, 'exportCsv']` |
+| `GET` | `/caixa` | `[CaixaController::class, 'index']` |
+
+_... +26 rotas_
+
+### `api.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `financeiro` | `fn (Request $request` |
+
+## Controllers
+
+- **`AdvisorAccessController`** — 3 ação(ões): index, grant, revoke
+- **`AdvisorAuthController`** — 3 ação(ões): showLogin, login, logout
+- **`AdvisorPortalController`** — 1 ação(ões): index
+- **`AssinaturaController`** — 2 ação(ões): showAtualizar, atualizar
+- **`BoletoController`** — 2 ação(ões): index, cancelar
+- **`CaixaController`** — 2 ação(ões): index, lancar
+- **`CategoriaController`** — 5 ação(ões): index, store, update, destroy, toggleAtivo
+- **`CobrancaController`** — 3 ação(ões): index, store, storeCartao
+- **`ConciliacaoController`** — 4 ação(ões): index, upload, match, ignorar
+- **`ContaBancariaController`** — 2 ação(ões): index, upsert
+- **`ContaPagarController`** — 2 ação(ões): index, pagar
+- **`ContaReceberController`** — 2 ação(ões): index, emitirBoleto
+- **`CoworkSidebarController`** — 1 ação(ões): data
+- **`DashboardController`** — 1 ação(ões): index
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`DreController`** — 4 ação(ões): index, exportPdf, exportXlsx, exportCsv
+- **`ExtratoController`** — 1 ação(ões): index
+- **`FinanceiroController`** — 7 ação(ões): index, create, store, show, edit, update, destroy
+- **`FluxoController`** — 1 ação(ões): index
+- **`InstallController`** — 0 ação(ões): 
+- **`PlanoContaController`** — 1 ação(ões): index
+- **`RelatoriosController`** — 2 ação(ões): index, exportCsv
+- **`UnificadoController`** — 22 ação(ões): index, novo, store, update, bulkUpdateCategoria, conferir, unconferir, baixar +14
+
+## Migrations
+
+- `2026_04_24_140001_create_fin_planos_conta_table.php`
+- `2026_04_24_140002_create_fin_categorias_table.php`
+- `2026_04_24_140003_create_fin_contas_bancarias_table.php`
+- `2026_04_24_140004_create_fin_titulos_table.php`
+- `2026_04_24_140005_create_fin_titulo_baixas_table.php`
+- `2026_04_24_140006_create_fin_caixa_movimentos_table.php`
+- `2026_04_25_140101_create_fin_boleto_remessas_table.php`
+- `2026_05_06_000001_add_rb_gateway_credential_to_fin_contas_bancarias.php`
+- `2026_05_06_000002_add_saldo_cached_to_fin_contas_bancarias.php`
+- `2026_05_07_220000_create_fin_extrato_lancamentos_table.php`
+- `2026_05_09_210000_create_accounts_legacy_map_table.php`
+- `2026_05_09_210001_add_legacy_columns_to_fin_contas_bancarias.php`
+- `2026_05_18_180000_add_conferido_to_fin_titulos.php`
+- `2026_05_18_190000_create_fin_titulo_comments_table.php`
+- `2026_05_19_220000_create_fin_bank_statement_lines_table.php`
+- `2026_05_19_220001_create_fin_titulo_anexos_table.php`
+- `2026_05_19_220002_add_aprovacao_to_fin_titulos.php`
+- `2026_05_20_140000_create_advisors_table.php`
+- `2026_05_20_140001_create_advisor_business_access_table.php`
+- `2026_05_20_180000_create_ai_usage_log_table.php`
+- `2026_05_20_200000_make_titulo_baixa_conta_bancaria_optional.php`
+- `2026_05_21_220000_add_caixa_bridge_to_fin_titulos_and_contas.php`
+
+## Views (Blade)
+
+**Total:** 3 arquivos
+
+**Pastas principais:**
+
+- `D:/` — 1 arquivo(s)
+- `layouts/` — 1 arquivo(s)
+- `pdf/` — 1 arquivo(s)
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Processamento / eventos
+
+**Jobs (queue):** `CriarTituloDeVendaJob`
+
+**Commands (artisan):** `BackfillPlanoContaCommand`, `BridgeExpenseToTitulosCommand`, `FinanceiroHealthCommand`, `InstallCommand`
+
+**Events:** `CashRegisterClosed`, `TituloCriado`
+
+**Listeners:** `OnCashRegisterClosedCreateFinanceiroTitulo`, `OnCobrancaPagaCreateFinanceiroTitulo`, `OnTituloCriadoLog`, `ProcessAsaasPixWebhookListener`
+
+**Observers:** `CashRegisterObserver`, `TransactionObserver`, `TransactionPaymentObserver`
+
+## Peças adicionais
+
+- **Seeders:** `FinanceiroDatabaseSeeder`, `FinanceiroDemoSeeder`, `PlanoContasBrSeeder`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `Financeiro` |
+| `module_version` | `0.1.0` |
+| `juros_mora_diario` | `0.0033` |
+| `multa_atraso` | `0.02` |
+| `asaas` | `[array(4 itens)]` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `PaymentGateway` | 2 |
+| `Superadmin` | 1 |
+
+## Integridade do banco
+
+**Foreign Keys** (31):
+
+- `business_id` → `business.id`
+- `parent_id` → `fin_planos_conta.id`
+- `business_id` → `business.id`
+- `plano_conta_id` → `fin_planos_conta.id`
+- `business_id` → `business.id`
+- `account_id` → `accounts.id`
+- `business_id` → `business.id`
+- `plano_conta_id` → `fin_planos_conta.id`
+- `categoria_id` → `fin_categorias.id`
+- `titulo_pai_id` → `fin_titulos.id`
+- `created_by` → `users.id`
+- `business_id` → `business.id`
+- `titulo_id` → `fin_titulos.id`
+- `conta_bancaria_id` → `fin_contas_bancarias.id`
+- `estorno_de_id` → `fin_titulo_baixas.id`
+- `created_by` → `users.id`
+- `business_id` → `business.id`
+- `conta_bancaria_id` → `fin_contas_bancarias.id`
+- `created_by` → `users.id`
+- `titulo_id` → `fin_titulos.id`
+- _... +11 FKs_
+
+**Unique indexes:** 12
+
+## Assets (JS / CSS)
+
+| Tipo | Qtde |
+|---|---:|
+| JavaScript (.js/.mjs) | 1 |
+| TypeScript (.ts) | 0 |
+| Vue SFC (.vue) | 0 |
+| CSS/SCSS | 1 |
+| Imagens | 0 |
+
+- Build: **Vite** (vite.config.js/ts presente)
+- `package.json` presente
+- **Deps JS:** `axios`, `laravel-vite-plugin`, `sass`, `postcss`, `vite`
+
+**Arquivos JS** (primeiros 1):
+
+- `js\app.js` (0 B)
+
+**Arquivos CSS/SCSS** (primeiros 1):
+
+- `sass\app.scss` (0 B)
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec Financeiro`

--- a/memory/modulos/Fiscal.md
+++ b/memory/modulos/Fiscal.md
@@ -1,45 +1,112 @@
 # Módulo: Fiscal
 
-> **—**
+> **Cockpit fiscal unificado — agrega NF-e/NFC-e (Modules/NfeBrasil) + NFS-e (Modules/NFSe) + Manifesto DF-e + Eventos (CC-e/Cancelamento/Inutilização) + Certificado/Config + SPED em uma só visão. Não duplica backend — Controllers thin agregam Services existentes.**
 
-- **Alias:** `—`
+- **Alias:** `fiscal`
 - **Versão:** ?
 - **Path:** `D:\oimpresso.com\Modules/Fiscal`
-- **Status:** ⚪ inativo
-- **Providers:** —
+- **Status:** 🟢 ativo
+- **Providers:** Modules\Fiscal\Providers\FiscalServiceProvider
 - **Requires (módulo.json):** nenhum
 
 ## Sinais detectados
 
-- ❌ NÃO EXISTE na branch atual (só em branches antigas — migração perdida?)
-- ⚪ Inativo em `modules_statuses.json`
+- ℹ️ Módulo sem views (provável API-only ou service)
+- ℹ️ Sem migrations próprias (pode depender de tabelas de outros módulos)
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- ✅ Tem testes (18)
+- ⚙️ Processamento assíncrono: 1 peça(s) (jobs/events/listeners)
+- 🔗 Acoplamento: depende de 3 outro(s) módulo(s)
 
-- **Prioridade sugerida de migração:** baixa (desativado)
-- **Risco estimado:** baixo
+- **Prioridade sugerida de migração:** média
+- **Risco estimado:** médio
 
 ## Escopo
 
 | Peça | Qtde |
 |---|---:|
-| Rotas (web+api) | 0 |
-| Controllers | 0 |
+| Rotas (web+api) | 17 |
+| Controllers | 11 |
 | Entities (Models) | 0 |
-| Services | 0 |
+| Services | 1 |
 | FormRequests | 0 |
 | Middleware | 0 |
 | Views Blade | 0 |
 | Migrations | 0 |
-| Arquivos de lang | 0 |
-| Testes | 0 |
+| Arquivos de lang | 1 |
+| Testes | 18 |
+
+## Rotas
+
+### `web.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+| `GET` | `/` | `[CockpitController::class, 'index']` |
+| `GET` | `/nfe` | `[NfeCockpitController::class, 'index']` |
+| `GET` | `/nfse` | `[NfseCockpitController::class, 'index']` |
+| `GET` | `/eventos` | `[EventosController::class, 'index']` |
+| `GET` | `/dfe` | `[DfeController::class, 'index']` |
+| `GET` | `/config` | `[ConfigController::class, 'index']` |
+| `GET` | `/sped` | `[SpedController::class, 'index']` |
+| `GET` | `/sped/icms-ipi/{ano}/{mes}` | `[SpedController::class, 'gerar']` |
+| `POST` | `/acoes/nfe/{emissao}/cancelar` | `[AcoesController::class, 'cancelarNfe']` |
+| `POST` | `/acoes/dfe/{recebido}/{acao}` | `[AcoesController::class, 'manifestarDfe']` |
+| `POST` | `/acoes/nfe/{emissao}/cce` | `[AcoesController::class, 'cartaCorrecao']` |
+| `POST` | `/acoes/nfe/inutilizar` | `[AcoesController::class, 'inutilizar']` |
+| `POST` | `/acoes/nfe/{emissao}/retransmitir` | `[AcoesController::class, 'retransmitir']` |
+| `GET` | `/palette/search` | `[PaletteSearchController::class, 'search']` |
+
+### `api.php`
+
+_(arquivo existe mas parse não identificou rotas explícitas — pode ter grupos complexos)_
+
+## Controllers
+
+- **`AcoesController`** — 5 ação(ões): cancelarNfe, manifestarDfe, cartaCorrecao, inutilizar, retransmitir
+- **`CockpitController`** — 2 ação(ões): index, kpisCacheKey
+- **`ConfigController`** — 1 ação(ões): index
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`DfeController`** — 1 ação(ões): index
+- **`EventosController`** — 1 ação(ões): index
+- **`InstallController`** — 0 ação(ões): 
+- **`NfeCockpitController`** — 1 ação(ões): index
+- **`NfseCockpitController`** — 1 ação(ões): index
+- **`PaletteSearchController`** — 1 ação(ões): search
+- **`SpedController`** — 2 ação(ões): index, gerar
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Processamento / eventos
+
+**Commands (artisan):** `HabilitarBusinessCommand`
+
+**Listeners:** `InvalidaCockpitCacheListener`
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `NfeBrasil` | 2 |
+| `Financeiro` | 1 |
+| `ProductCatalogue` | 1 |
 
 ## Presença em branches
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ❌ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ❌ |
 
 ## Diferenças vs versões anteriores
 
@@ -51,5 +118,5 @@
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:14.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Fiscal`

--- a/memory/modulos/Governance.md
+++ b/memory/modulos/Governance.md
@@ -1,0 +1,142 @@
+# Módulo: Governance
+
+> **Governança consolidada — ActionGate runtime, audit dashboard, ADRs pending approvals, policies CRUD, drift alerts. Constituição Art. 8 + Art. 9 operacional. Trust L1 (Wagner + ADR aprovado).**
+
+- **Alias:** `governance`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/Governance`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\Governance\Providers\GovernanceServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- ℹ️ Módulo sem views (provável API-only ou service)
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- ✅ Tem testes (32)
+- 🔐 Registra 3 permissão(ões) Spatie
+- 🔗 Acoplamento: depende de 3 outro(s) módulo(s)
+
+- **Prioridade sugerida de migração:** alta (pequeno, ganho rápido)
+- **Risco estimado:** baixo
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 11 |
+| Controllers | 7 |
+| Entities (Models) | 1 |
+| Services | 18 |
+| FormRequests | 4 |
+| Middleware | 1 |
+| Views Blade | 0 |
+| Migrations | 4 |
+| Arquivos de lang | 3 |
+| Testes | 32 |
+
+## Rotas
+
+### `routes.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `/` | `fn (` |
+| `GET` | `/dashboard` | `[DashboardController::class, 'index']` |
+| `GET` | `/policies` | `[PoliciesController::class, 'index']` |
+| `POST` | `/policies/{id}/toggle` | `[PoliciesController::class, 'toggle']` |
+| `GET` | `/audit` | `[AuditController::class, 'index']` |
+| `GET` | `/drift` | `[DriftAlertsController::class, 'index']` |
+| `GET` | `/module-grades` | `[ModuleGradeController::class, 'index']` |
+| `GET` | `/module-grades/{name}` | `[ModuleGradeController::class, 'show']` |
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+
+## Controllers
+
+- **`AuditController`** — 1 ação(ões): index
+- **`DashboardController`** — 1 ação(ões): index
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`DriftAlertsController`** — 1 ação(ões): index
+- **`InstallController`** — 0 ação(ões): 
+- **`ModuleGradeController`** — 2 ação(ões): index, show
+- **`PoliciesController`** — 2 ação(ões): index, toggle
+
+## Entities (Models Eloquent)
+
+- **`Initiative`** (tabela: `mcp_governance_initiatives`)
+
+## Migrations
+
+- `2026_05_16_120000_create_mcp_module_grades_history_table.php`
+- `2026_05_17_000001_create_mcp_scorecard_runs_table.php`
+- `2026_05_17_000002_create_mcp_observability_spans_table.php`
+- `2026_05_17_000003_create_mcp_governance_initiatives_table.php`
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Permissões
+
+**Registradas pelo módulo** (via `user_permissions()`):
+
+- `governance.dashboard.view`
+- `governance.policies.edit`
+- `governance.audit.view`
+
+## Processamento / eventos
+
+**Commands (artisan):** `CharterAuditCommand`, `CharterHealthCommand`, `CharterMetricsCommand`, `DetectDriftCommand`, `GovernanceAuditCommand`, `GovernanceHealthCommand`, `ModuleGradeCommand`, `ModuleGradeSnapshotCommand`, `ModuleGradeV4Command`, `ObservabilityAggregateCommand`, `ScorecardInitiativeSyncCommand`, `ScorecardSnapshotCommand`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `Governance` |
+| `actiongate_mode` | `warn` |
+| `next_review_at` | `2026-08-05` |
+| `d1_hardened` | `true` |
+| `drift_framework_enabled` | `true` |
+| `drift_checkers` | `[array(6 itens)]` |
+| `multi_tenant_scope_allowlist` | `[array(6 itens)]` |
+| `routes_zombie_allowlist` | `[array(7 itens)]` |
+| `drift_centrifugo_channel` | `governance:drift` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `TeamMcp` | 1 |
+| `ADS` | 1 |
+| `Vestuario` | 1 |
+
+## Integridade do banco
+
+**Unique indexes:** 1
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec Governance`

--- a/memory/modulos/Help.md
+++ b/memory/modulos/Help.md
@@ -36,10 +36,9 @@
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ❌ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ❌ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ❌ |
 
 ## Diferenças vs versões anteriores
 
@@ -51,5 +50,5 @@
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:14.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Help`

--- a/memory/modulos/INDEX.md
+++ b/memory/modulos/INDEX.md
@@ -1,57 +1,65 @@
 # Índice de Specs dos Módulos
 
-Gerado por `php artisan module:specs` em 2026-04-22 14:14.
+Gerado por `php artisan module:specs` em 2026-05-29 08:06.
 
-**Total:** 29 módulos únicos encontrados em todas as branches conhecidas (atual, `main-wip-2026-04-22`, `origin/3.7-com-nfe`, `origin/6.7-bootstrap`).
+**Total:** 44 módulos únicos encontrados em todas as branches conhecidas (atual, `main-wip-2026-04-22`, `origin/3.7-com-nfe`).
 
-## 🟢 Ativos (15)
-
-| # | Módulo | Prioridade | Risco | Rotas | Views | Migrations | Permissões | Hooks |
-|--:|---|---|---|--:|--:|--:|--:|--:|
-| 1 | [AiAssistance](AiAssistance.md) | alta (pequeno, ganho rápido) | baixo | 8 | 6 | 2 | 1 | 3 |
-| 2 | [ProductCatalogue](ProductCatalogue.md) | média | médio | 7 | 8 | 1 | 0 | 2 |
-| 3 | [Spreadsheet](Spreadsheet.md) | média | médio | 9 | 7 | 4 | 2 | 3 |
-| 4 | [AssetManagement](AssetManagement.md) | média | médio | 10 | 17 | 7 | 6 | 4 |
-| 5 | [Woocommerce](Woocommerce.md) | média | médio | 19 | 13 | 13 | 5 | 3 |
-| 6 | [Manufacturing](Manufacturing.md) | média | médio | 14 | 20 | 13 | 4 | 3 |
-| 7 | [Cms](Cms.md) | baixa (grande, fazer por último ou dividir) | alto | 12 | 45 | 5 | 0 | 1 |
-| 8 | [Connector](Connector.md) | baixa (grande, fazer por último ou dividir) | alto | 55 | 2 | 1 | 0 | 2 |
-| 9 | [Project](Project.md) | baixa (grande, fazer por último ou dividir) | alto | 20 | 43 | 11 | 3 | 4 |
-| 10 | [PontoWr2](PontoWr2.md) | baixa (grande, fazer por último ou dividir) | alto | 40 | 26 | 8 | 5 | 3 |
-| 11 | [Superadmin](Superadmin.md) | baixa (grande, fazer por último ou dividir) | alto | 33 | 45 | 12 | 1 | 2 |
-| 12 | [Repair](Repair.md) | baixa (grande, fazer por último ou dividir) | alto | 30 | 52 | 16 | 12 | 7 |
-| 13 | [Crm](Crm.md) | baixa (grande, fazer por último ou dividir) | alto | 52 | 68 | 26 | 13 | 3 |
-| 14 | [Essentials](Essentials.md) | baixa (grande, fazer por último ou dividir) | alto | 53 | 87 | 36 | 23 | 5 |
-| 15 | [Accounting](Accounting.md) | baixa (grande, fazer por último ou dividir) | alto | 69 | 91 | 21 | 12 | 3 |
-
-## ⚪ Inativos no branch atual (5)
-
-_Existem em `Modules/` mas com flag `false` em `modules_statuses.json`._
+## 🟢 Ativos (36)
 
 | # | Módulo | Prioridade | Risco | Rotas | Views | Migrations | Permissões | Hooks |
 |--:|---|---|---|--:|--:|--:|--:|--:|
-| 1 | [Officeimpresso](Officeimpresso.md) | baixa (desativado) | baixo | 7 | 8 | 1 | 0 | 2 |
-| 2 | [Officeimpresso1](Officeimpresso1.md) | baixa (desativado) | baixo | 16 | 8 | 2 | 0 | 2 |
-| 3 | [IProduction](IProduction.md) | baixa (desativado) | baixo | 14 | 20 | 0 | 0 | 0 |
-| 4 | [Writebot](Writebot.md) | baixa (desativado) | baixo | 14 | 20 | 0 | 0 | 0 |
-| 5 | [Grow](Grow.md) | baixa (desativado) | baixo | 797 | 957 | 1 | 1 | 3 |
+| 1 | [Arquivos](Arquivos.md) | alta (pequeno, ganho rápido) | baixo | 3 | 0 | 6 | 0 | 3 |
+| 2 | [Brief](Brief.md) | alta (pequeno, ganho rápido) | baixo | 4 | 0 | 0 | 0 | 3 |
+| 3 | [Compras](Compras.md) | alta (pequeno, ganho rápido) | baixo | 5 | 0 | 0 | 5 | 3 |
+| 4 | [ConsultaOs](ConsultaOs.md) | alta (pequeno, ganho rápido) | baixo | 5 | 0 | 0 | 0 | 3 |
+| 5 | [Auditoria](Auditoria.md) | alta (pequeno, ganho rápido) | baixo | 7 | 0 | 1 | 0 | 3 |
+| 6 | [Vestuario](Vestuario.md) | alta (pequeno, ganho rápido) | baixo | 6 | 1 | 3 | 0 | 0 |
+| 7 | [NFSe](NFSe.md) | alta (pequeno, ganho rápido) | baixo | 9 | 0 | 5 | 0 | 3 |
+| 8 | [Governance](Governance.md) | alta (pequeno, ganho rápido) | baixo | 11 | 0 | 4 | 3 | 3 |
+| 9 | [ComunicacaoVisual](ComunicacaoVisual.md) | alta (pequeno, ganho rápido) | baixo | 12 | 0 | 9 | 0 | 3 |
+| 10 | [ProductCatalogue](ProductCatalogue.md) | média | médio | 7 | 8 | 1 | 1 | 3 |
+| 11 | [Spreadsheet](Spreadsheet.md) | média | médio | 9 | 7 | 4 | 2 | 3 |
+| 12 | [Fiscal](Fiscal.md) | média | médio | 17 | 0 | 0 | 0 | 3 |
+| 13 | [SRS](SRS.md) | média | médio | 17 | 0 | 8 | 2 | 3 |
+| 14 | [TeamMcp](TeamMcp.md) | média | médio | 18 | 0 | 3 | 0 | 3 |
+| 15 | [Admin](Admin.md) | média | médio | 20 | 0 | 1 | 0 | 3 |
+| 16 | [PaymentGateway](PaymentGateway.md) | média | médio | 22 | 0 | 9 | 0 | 3 |
+| 17 | [ProjectMgmt](ProjectMgmt.md) | média | médio | 23 | 0 | 0 | 0 | 3 |
+| 18 | [AssetManagement](AssetManagement.md) | média | médio | 11 | 17 | 7 | 6 | 4 |
+| 19 | [RecurringBilling](RecurringBilling.md) | média | médio | 28 | 2 | 8 | 0 | 3 |
+| 20 | [Woocommerce](Woocommerce.md) | média | médio | 19 | 13 | 13 | 5 | 3 |
+| 21 | [Manufacturing](Manufacturing.md) | média | médio | 14 | 20 | 13 | 4 | 3 |
+| 22 | [OficinaAuto](OficinaAuto.md) | média | médio | 34 | 0 | 11 | 0 | 3 |
+| 23 | [Officeimpresso](Officeimpresso.md) | média | médio | 21 | 18 | 8 | 1 | 3 |
+| 24 | [KB](KB.md) | baixa (grande, fazer por último ou dividir) | alto | 43 | 0 | 12 | 4 | 3 |
+| 25 | [NfeBrasil](NfeBrasil.md) | baixa (grande, fazer por último ou dividir) | alto | 39 | 4 | 16 | 9 | 3 |
+| 26 | [ADS](ADS.md) | baixa (grande, fazer por último ou dividir) | alto | 46 | 0 | 15 | 0 | 3 |
+| 27 | [Jana](Jana.md) | baixa (grande, fazer por último ou dividir) | alto | 39 | 9 | 64 | 5 | 3 |
+| 28 | [Whatsapp](Whatsapp.md) | baixa (grande, fazer por último ou dividir) | alto | 59 | 1 | 42 | 0 | 3 |
+| 29 | [Cms](Cms.md) | baixa (grande, fazer por último ou dividir) | alto | 16 | 45 | 5 | 1 | 3 |
+| 30 | [Connector](Connector.md) | baixa (grande, fazer por último ou dividir) | alto | 61 | 2 | 1 | 1 | 3 |
+| 31 | [Ponto](Ponto.md) | baixa (grande, fazer por último ou dividir) | alto | 41 | 26 | 8 | 5 | 3 |
+| 32 | [Financeiro](Financeiro.md) | baixa (grande, fazer por último ou dividir) | alto | 67 | 3 | 22 | 0 | 3 |
+| 33 | [Superadmin](Superadmin.md) | baixa (grande, fazer por último ou dividir) | alto | 39 | 46 | 12 | 1 | 2 |
+| 34 | [Repair](Repair.md) | baixa (grande, fazer por último ou dividir) | alto | 35 | 52 | 18 | 12 | 7 |
+| 35 | [Essentials](Essentials.md) | baixa (grande, fazer por último ou dividir) | alto | 55 | 87 | 36 | 23 | 5 |
+| 36 | [Crm](Crm.md) | baixa (grande, fazer por último ou dividir) | alto | 75 | 68 | 27 | 13 | 3 |
 
-## ❌ Perdidos na migração 3.7 → 6.7 (9)
+## ❌ Perdidos na migração 3.7 → 6.7 (8)
 
 _**Existem em branches antigas** (`main-wip-2026-04-22` ou `origin/3.7-com-nfe`) **mas não na branch atual 6.7-react.**_
 _Potenciais funcionalidades que ficaram para trás. Decidir se trazer de volta ou abandonar._
 
-| Módulo | main-wip | 3.7 | 6.7-bootstrap | Ação sugerida |
-|---|:-:|:-:|:-:|---|
-| [BI](BI.md) | ✅ | ✅ | — | (definir) |
-| [Boleto](Boleto.md) | ✅ | ✅ | — | (definir) |
-| [Chat](Chat.md) | ✅ | ✅ | — | (definir) |
-| [Dashboard](Dashboard.md) | ✅ | ✅ | — | (definir) |
-| [Fiscal](Fiscal.md) | ✅ | ✅ | — | (definir) |
-| [Help](Help.md) | ✅ | ✅ | — | (definir) |
-| [Jana](Jana.md) | ✅ | ✅ | — | (definir) |
-| [Knowledgebase](Knowledgebase.md) | ✅ | ✅ | — | (definir) |
-| [codecanyon-32094844-perfect-support-ticketing-document-management-system](codecanyon-32094844-perfect-support-ticketing-document-management-system.md) | ✅ | ✅ | — | (definir) |
+| Módulo | main-wip | 3.7 | Ação sugerida |
+|---|:-:|:-:|---|
+| [BI](BI.md) | — | ✅ | (definir) |
+| [Boleto](Boleto.md) | — | ✅ | (definir) |
+| [Chat](Chat.md) | — | ✅ | (definir) |
+| [Dashboard](Dashboard.md) | — | ✅ | (definir) |
+| [Help](Help.md) | — | ✅ | (definir) |
+| [Knowledgebase](Knowledgebase.md) | — | ✅ | (definir) |
+| [Project](Project.md) | — | ✅ | (definir) |
+| [codecanyon-32094844-perfect-support-ticketing-document-management-system](codecanyon-32094844-perfect-support-ticketing-document-management-system.md) | — | ✅ | (definir) |
 
 ## Como usar
 
@@ -64,6 +72,6 @@ _Potenciais funcionalidades que ficaram para trás. Decidir se trazer de volta o
 
 ```bash
 php artisan module:specs              # todos
-php artisan module:specs PontoWr2     # um só
+php artisan module:specs Ponto        # um só
 php artisan module:specs --stdout     # ver sem salvar
 ```

--- a/memory/modulos/Jana.md
+++ b/memory/modulos/Jana.md
@@ -1,45 +1,349 @@
 # Módulo: Jana
 
-> **—**
+> **Jana — chat IA conversacional do business (ex-Copiloto, renomeado Fase 3.7 PR-2). Conversa, sugere metas, monitora execução. Tenancy híbrida (business_id nullable). URL/permissions/config keys mantêm prefixo legacy `copiloto.*` por compatibilidade.**
 
-- **Alias:** `—`
+- **Alias:** `jana`
 - **Versão:** ?
 - **Path:** `D:\oimpresso.com\Modules/Jana`
-- **Status:** ⚪ inativo
-- **Providers:** —
+- **Status:** 🟢 ativo
+- **Providers:** Modules\Jana\Providers\JanaServiceProvider
 - **Requires (módulo.json):** nenhum
 
 ## Sinais detectados
 
-- ❌ NÃO EXISTE na branch atual (só em branches antigas — migração perdida?)
-- ⚪ Inativo em `modules_statuses.json`
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- 🟡 39 rotas — escopo médio
+- ✅ Tem testes (67)
+- 🔐 Registra 5 permissão(ões) Spatie
+- ⚙️ Processamento assíncrono: 8 peça(s) (jobs/events/listeners)
+- 🔗 Acoplamento: depende de 4 outro(s) módulo(s)
+- 🗃️ 31 foreign keys — alto acoplamento em dados
+- 🗄️ Tem triggers MySQL (2) — append-only / imutabilidade
 
-- **Prioridade sugerida de migração:** baixa (desativado)
-- **Risco estimado:** baixo
+- **Prioridade sugerida de migração:** baixa (grande, fazer por último ou dividir)
+- **Risco estimado:** alto
 
 ## Escopo
 
 | Peça | Qtde |
 |---|---:|
-| Rotas (web+api) | 0 |
-| Controllers | 0 |
-| Entities (Models) | 0 |
-| Services | 0 |
-| FormRequests | 0 |
-| Middleware | 0 |
-| Views Blade | 0 |
-| Migrations | 0 |
-| Arquivos de lang | 0 |
-| Testes | 0 |
+| Rotas (web+api) | 39 |
+| Controllers | 16 |
+| Entities (Models) | 40 |
+| Services | 60 |
+| FormRequests | 8 |
+| Middleware | 1 |
+| Views Blade | 9 |
+| Migrations | 64 |
+| Arquivos de lang | 1 |
+| Testes | 67 |
+
+## Rotas
+
+### `routes.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `/` | `'ChatController@index'` |
+| `GET` | `/cockpit` | `'ChatController@cockpit'` |
+| `GET` | `/painel` | `'PainelController@index'` |
+| `POST` | `/conversas` | `'ChatController@criarConversa'` |
+| `GET` | `/conversas/nova` | `'ChatController@novaConversa'` |
+| `GET` | `/conversas/{id}` | `'ChatController@show'` |
+| `POST` | `/conversas/{id}/mensagens` | `'ChatController@send'` |
+| `POST` | `/conversas/{id}/mensagens/stream` | `'ChatController@sendStream'` |
+| `PATCH` | `/conversas/{id}` | `'ChatController@updateConversa'` |
+| `POST` | `/sugestoes/{id}/escolher` | `'ChatController@escolher'` |
+| `POST` | `/sugestoes/{id}/rejeitar` | `'ChatController@rejeitar'` |
+| `GET` | `/dashboard` | `'DashboardController@index'` |
+| `POST` | `/metas/{id}/reapurar` | `'MetasController@reapurar'` |
+| `GET` | `/metas/{id}/fonte` | `[\Modules\KB\Http\Controllers\FontesController::class, 'show']` |
+| `PATCH` | `/metas/{id}/fonte` | `[\Modules\KB\Http\Controllers\FontesController::class, 'update']` |
+| `GET` | `/alertas` | `'AlertasController@index'` |
+| `GET` | `/alertas/config` | `'AlertasController@config'` |
+| `PATCH` | `/alertas/config` | `'AlertasController@updateConfig'` |
+| `GET` | `/memoria` | `[\Modules\KB\Http\Controllers\MemoriaController::class, 'index']` |
+| `PATCH` | `/memoria/{id}` | `[\Modules\KB\Http\Controllers\MemoriaController::class, 'update']` |
+| `DELETE` | `/memoria/{id}` | `[\Modules\KB\Http\Controllers\MemoriaController::class, 'destroy']` |
+| `GET` | `/brief` | `'BriefController@index'` |
+| `GET` | `/regras` | `'RegrasController@index'` |
+| `GET` | `/superadmin/metas` | `'SuperadminController@metas'` |
+| `GET` | `/admin/custos` | `'Admin\CustosController@index'` |
+| `GET` | `/admin/governanca` | `'Admin\GovernancaController@index'` |
+| `GET` | `/admin/qualidade` | `'Admin\QualidadeController@index'` |
+| `GET` | `/admin/roadmap` | `'Admin\RoadmapController@index'` |
+| `GET` | `/admin/jana-pro/preview` | `'Admin\JanaProController@preview'` |
+| `GET` | `/` | `'InstallController@index'` |
+| `POST` | `/` | `'InstallController@install'` |
+| `GET` | `/uninstall` | `'InstallController@uninstall'` |
+| `GET` | `/update` | `'InstallController@update'` |
+| `POST` | `/sync-memory` | `'SyncMemoryWebhookController@handle'` |
+| `GET` | `/health` | `'HealthController@publico'` |
+| `GET` | `/health/auth` | `'HealthController@autenticado'` |
+| `POST` | `/ingest` | `'CcIngestController@ingest'` |
+| `RESOURCE` | `/metas` | `'MetasController'` |
+| `RESOURCE` | `/metas.periodos` | `'PeriodosController'` |
+
+## Controllers
+
+- **`CustosController`** — 1 ação(ões): index
+- **`GovernancaController`** — 1 ação(ões): index
+- **`JanaProController`** — 1 ação(ões): preview
+- **`QualidadeController`** — 1 ação(ões): index
+- **`RoadmapController`** — 1 ação(ões): index
+- **`AlertasController`** — 3 ação(ões): index, config, updateConfig
+- **`BriefController`** — 1 ação(ões): index
+- **`ChatController`** — 10 ação(ões): index, show, criarConversa, novaConversa, updateConversa, send, sendStream, escolher +2
+- **`DashboardController`** — 1 ação(ões): index
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`InstallController`** — 0 ação(ões): 
+- **`MetasController`** — 8 ação(ões): index, create, store, show, edit, update, destroy, reapurar
+- **`PainelController`** — 1 ação(ões): index
+- **`PeriodosController`** — 3 ação(ões): store, update, destroy
+- **`RegrasController`** — 1 ação(ões): index
+- **`SuperadminController`** — 1 ação(ões): metas
+
+## Entities (Models Eloquent)
+
+- **`CacheSemantico`** (tabela: `jana_cache_semantico`)
+- **`Conversa`** (tabela: `jana_conversas`)
+- **`HealthNarrative`** (tabela: `jana_health_narratives`)
+- **`McpAlerta`** (tabela: `mcp_alertas`)
+- **`McpAuditLog`** (tabela: `mcp_audit_log`)
+- **`McpCcBlob`** (tabela: `mcp_cc_blobs`)
+- **`McpCcMessage`** (tabela: `mcp_cc_messages`)
+- **`McpCcSession`** (tabela: `mcp_cc_sessions`)
+- **`McpComponent`** (tabela: `mcp_components`)
+- **`McpCycle`** (tabela: `mcp_cycles`)
+- **`McpCycleGoal`** (tabela: `mcp_cycle_goals`)
+- **`McpEpic`** (tabela: `mcp_epics`)
+- **`McpInboxNotification`** (tabela: `mcp_inbox_notifications`)
+- **`McpMemoryDocument`** (tabela: `mcp_memory_documents`)
+- **`McpMemoryDocumentHistory`** (tabela: `mcp_memory_documents_history`)
+- **`McpProject`** (tabela: `mcp_jira_projects`)
+- **`McpQuota`** (tabela: `mcp_quotas`)
+- **`McpScope`** (tabela: `mcp_scopes`)
+- **`McpSkill`** (tabela: `mcp_skills`)
+- **`McpSkillApproval`** (tabela: `mcp_skill_approvals`)
+- **`McpSkillLabel`** (tabela: `mcp_skill_labels`)
+- **`McpSkillTestRun`** (tabela: `mcp_skill_test_runs`)
+- **`McpSkillVersion`** (tabela: `mcp_skill_versions`)
+- **`McpTask`** (tabela: `mcp_tasks`)
+- **`McpTaskComment`** (tabela: `mcp_task_comments`)
+- **`McpTaskDependency`** (tabela: `mcp_task_dependencies`)
+- **`McpTaskEvent`** (tabela: `mcp_task_events`)
+- **`McpTaskWatcher`** (tabela: `mcp_task_watchers`)
+- **`McpToken`** (tabela: `mcp_tokens`)
+- **`McpUsageDiaria`** (tabela: `mcp_usage_diaria`)
+- **`McpUserScope`** (tabela: `mcp_user_scopes`)
+- **`MemoriaFato`** (tabela: `jana_memoria_facts`)
+- **`MemoriaGabarito`** (tabela: `jana_memoria_gabarito`)
+- **`MemoriaMetrica`** (tabela: `jana_memoria_metricas`)
+- **`Mensagem`** (tabela: `jana_mensagens`)
+- **`Meta`** (tabela: `jana_metas`)
+- **`MetaApuracao`** (tabela: `jana_meta_apuracoes`)
+- **`MetaFonte`** (tabela: `jana_meta_fontes`)
+- **`MetaPeriodo`** (tabela: `jana_meta_periodos`)
+- **`Sugestao`** (tabela: `jana_sugestoes`)
+
+## Migrations
+
+- `2026_04_24_000001_create_copiloto_metas_table.php`
+- `2026_04_24_000002_create_copiloto_meta_periodos_table.php`
+- `2026_04_24_000003_create_copiloto_meta_fontes_table.php`
+- `2026_04_24_000004_create_copiloto_meta_apuracoes_table.php`
+- `2026_04_24_000005_create_copiloto_conversas_table.php`
+- `2026_04_24_000006_create_copiloto_mensagens_table.php`
+- `2026_04_24_000007_create_copiloto_sugestoes_table.php`
+- `2026_04_27_000001_create_copiloto_memoria_facts_table.php`
+- `2026_04_29_000001_create_copiloto_memoria_metricas_table.php`
+- `2026_04_29_100001_create_mcp_scopes_table.php`
+- `2026_04_29_100002_create_mcp_user_scopes_table.php`
+- `2026_04_29_100003_create_mcp_tokens_table.php`
+- `2026_04_29_100004_create_mcp_quotas_table.php`
+- `2026_04_29_100005_create_mcp_audit_log_table.php`
+- `2026_04_29_100006_create_mcp_usage_diaria_table.php`
+- `2026_04_29_100007_create_mcp_alertas_table.php`
+- `2026_04_29_100008_create_mcp_memory_documents_table.php`
+- `2026_04_29_100009_create_mcp_memory_documents_history_table.php`
+- `2026_04_29_200001_create_copiloto_memoria_gabarito_table.php`
+- `2026_04_29_300001_create_mcp_cc_sessions_table.php`
+- `2026_04_29_300002_create_mcp_cc_messages_table.php`
+- `2026_04_29_300003_create_mcp_cc_blobs_table.php`
+- `2026_04_29_400001_create_copiloto_cache_semantico_table.php`
+- `2026_04_29_500001_create_copiloto_business_profile_table.php`
+- `2026_04_29_500002_add_promotion_to_memoria_facts.php`
+- `2026_04_29_500003_create_copiloto_negative_cache_table.php`
+- `2026_04_29_600001_create_mcp_alertas_eventos_table.php`
+- `2026_04_30_120001_expand_mcp_memory_documents_type_enum.php`
+- `2026_04_30_180001_create_mcp_tasks_table.php`
+- `2026_04_30_200001_add_business_id_to_mcp_memory_documents.php`
+- `2026_05_01_100001_add_typed_cols_to_mcp_memory_documents.php`
+- `2026_05_01_120001_create_mcp_task_comments_table.php`
+- `2026_05_01_120002_create_mcp_task_events_table.php`
+- `2026_05_04_180001_create_mcp_jira_projects_table.php`
+- `2026_05_04_180002_create_mcp_epics_table.php`
+- `2026_05_04_180003_create_mcp_cycles_table.php`
+- `2026_05_04_180004_create_mcp_cycle_goals_table.php`
+- `2026_05_04_180005_create_mcp_components_table.php`
+- `2026_05_04_180006_create_mcp_workflows_table.php`
+- `2026_05_04_180007_create_mcp_issue_templates_table.php`
+- `2026_05_04_180008_create_mcp_views_table.php`
+- `2026_05_04_180009_create_mcp_inbox_notifications_table.php`
+- `2026_05_04_180010_create_mcp_task_dependencies_table.php`
+- `2026_05_04_180011_create_mcp_task_watchers_table.php`
+- `2026_05_04_180012_create_mcp_task_attachments_table.php`
+- `2026_05_04_180013_create_mcp_task_memory_links_table.php`
+- `2026_05_04_180014_create_mcp_git_links_table.php`
+- `2026_05_04_180015_extend_mcp_tasks_for_jira_style.php`
+- `2026_05_05_220001_create_mcp_skills_table.php`
+- `2026_05_05_220002_create_mcp_skill_versions_table.php`
+- `2026_05_05_220003_create_mcp_skill_labels_table.php`
+- `2026_05_05_220004_create_mcp_skill_test_runs_table.php`
+- `2026_05_05_220005_create_mcp_skill_approvals_table.php`
+- `2026_05_05_230001_add_immutability_triggers_to_mcp_audit_log.php`
+- `2026_05_06_120000_rename_copiloto_tables_to_jana.php`
+- `2026_05_09_140000_rename_copiloto_permissions_to_jana.php`
+- `2026_05_10_120000_seed_modulos_verticais_mcp_jira_projects.php`
+- `2026_05_10_150000_seed_auditoria_mcp_jira_project.php`
+- `2026_05_13_120000_create_mcp_handoff_summaries_table.php`
+- `2026_05_13_130000_create_mcp_handoff_diffs_table.php`
+- `2026_05_13_140000_create_mcp_weekly_digests_table.php`
+- `2026_05_13_150000_create_mcp_doc_summaries_table.php`
+- `2026_05_15_120000_add_contextual_context_to_mcp_memory_documents.php`
+- `2026_05_16_220001_create_mcp_scorecard_ai_suggestions_table.php`
+
+## Views (Blade)
+
+**Total:** 9 arquivos
+
+**Pastas principais:**
+
+- `metas/` — 4 arquivo(s)
+- `alertas/` — 2 arquivo(s)
+- `emails/` — 1 arquivo(s)
+- `fontes/` — 1 arquivo(s)
+- `superadmin/` — 1 arquivo(s)
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Permissões
+
+**Registradas pelo módulo** (via `user_permissions()`):
+
+- `jana.access`
+- `jana.chat`
+- `jana.metas.manage`
+- `jana.superadmin`
+- `jana.admin.custos.view`
+
+## Processamento / eventos
+
+**Jobs (queue):** `ApurarMetaJob`, `ExtrairFatosDaConversaJob`, `InboxAutoCleanupJob`, `ReindexarDocumentoJob`, `NarrarSaudeEcosistemaJob`, `LangfuseTraceJob`
+
+**Commands (artisan):** `ApurarMetricasCommand`, `AvaliarGabaritoCommand`, `BackfillFatosCommand`, `BackfillTasksFromMarkdownCommand`, `CacheStatsCommand`, `CleanupMemoriaCommand`, `ContextualizeBackfillCommand`, `FreshnessCheckCommand`, `HealthCheckCommand`, `JanaBacklinksSweepCommand`, `JanaCyclesAutoCloseExpiredCommand`, `JanaDriftSentinelCommand`, `JanaRagasCiCommand`, `JanaRagasEvalCommand`, `JanaValidateMemoryCommand`, `JanaWeeklyDigestCommand`, `McpAdrMigrarFrontmatterCommand`, `McpGenerateDxtCommand`, `McpSkillsImportFromGitCommand`, `McpSyncMemoryCommand`, `McpSystemTokenCommand`, `McpTasksHealthCheckCommand`, `McpTasksSyncCommand`, `McpTokenGerarCommand`, `MetricasReflexivasCommand`, `RetentionPurgeCommand`, `SeedAdrsCommand`, `SinteseSemanalCommand`, `SystemAuditCommand`
+
+**Events:** `CopilotoDesvioDetectado`
+
+**Listeners:** `NotificarDesvioListener`
+
+## Peças adicionais
+
+- **Notifications:** `MetaDesvioNotification`
+- **Seeders:** `CopilotoDatabaseSeeder`, `McpDefaultsSeeder`, `McpScopesSeeder`, `MemoriaGabaritoSeeder`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `Copiloto` |
+| `module_label` | `Copiloto` |
+| `module_description` | `Copiloto de IA do negócio — chat + metas + monitoramento` |
+| `module_icon` | `fa fa-compass` |
+| `module_version` | `0.1` |
+| `pid` | `` |
+| `ai_adapter` | `auto` |
+| `openai` | `[array(5 itens)]` |
+| `ai` | `[array(3 itens)]` |
+| `dry_run` | `false` |
+| `memoria` | `[array(4 itens)]` |
+| `apuracao` | `[array(4 itens)]` |
+| `context_cache_ttl_minutes` | `10` |
+| `alertas` | `[array(3 itens)]` |
+| `mcp` | `[array(6 itens)]` |
+| `meta_plataforma` | `[array(5 itens)]` |
+| `hits` | `[array(1 itens)]` |
+| `hyde` | `[array(1 itens)]` |
+| `reranker` | `[array(3 itens)]` |
+| `freshness` | `[array(3 itens)]` |
+| `time_decay` | `[array(4 itens)]` |
+| `negative_cache` | `[array(2 itens)]` |
+| `cache` | `[array(3 itens)]` |
+| `summarizer` | `[array(3 itens)]` |
+| `auto_summarizer` | `[array(8 itens)]` |
+| `contextual_retrieval` | `[array(7 itens)]` |
+| `telemetry` | `[array(3 itens)]` |
+| `peso_real` | `[array(7 itens)]` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `ADS` | 1 |
+| `Governance` | 1 |
+| `KB` | 1 |
+| `TeamMcp` | 1 |
+
+## Integridade do banco
+
+**Foreign Keys** (31):
+
+- `business_id` → `business.id`
+- `criada_por_user_id` → `users.id`
+- `meta_id` → `copiloto_metas.id`
+- `meta_id` → `copiloto_metas.id`
+- `meta_id` → `copiloto_metas.id`
+- `business_id` → `business.id`
+- `user_id` → `users.id`
+- `conversa_id` → `copiloto_conversas.id`
+- `conversa_id` → `copiloto_conversas.id`
+- `meta_id` → `copiloto_metas.id`
+- `business_id` → `business.id`
+- `scope_id` → `mcp_scopes.id`
+- `user_id` → `users.id`
+- `business_id` → `business.id`
+- `user_id` → `users.id`
+- `user_id` → `users.id`
+- `user_id` → `users.id`
+- `business_id` → `business.id`
+- `mcp_token_id` → `mcp_tokens.id`
+- `user_id` → `users.id`
+- _... +11 FKs_
+
+**Triggers MySQL** (2): `trg_mcp_audit_log_no_update`, `trg_mcp_audit_log_no_delete`
+
+**Unique indexes:** 34
+
+## Dependências Composer
+
+- `php` ^8.1
+- `spatie/laravel-permission` ^6.0
+- `spatie/laravel-activitylog` ^4.0
+- `openai-php/laravel` *
 
 ## Presença em branches
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ❌ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ❌ |
 
 ## Diferenças vs versões anteriores
 
@@ -51,5 +355,5 @@
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:14.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Jana`

--- a/memory/modulos/KB.md
+++ b/memory/modulos/KB.md
@@ -1,0 +1,222 @@
+# Módulo: KB
+
+> **Knowledge Base — biblioteca compartilhada de ADRs, sessions, runbooks, comparativos. Split do Copiloto (Etapa 2 modularização) — vive em /kb e consome a tabela mcp_memory_documents (sincronizada do git via webhook GitHub).**
+
+- **Alias:** `kb`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/KB`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\KB\Providers\KBServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- ℹ️ Módulo sem views (provável API-only ou service)
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- 🟡 43 rotas — escopo médio
+- ✅ Tem testes (27)
+- 🔐 Registra 4 permissão(ões) Spatie
+- ⚙️ Processamento assíncrono: 2 peça(s) (jobs/events/listeners)
+- 🔗 Acoplamento: depende de 1 outro(s) módulo(s)
+
+- **Prioridade sugerida de migração:** baixa (grande, fazer por último ou dividir)
+- **Risco estimado:** alto
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 43 |
+| Controllers | 14 |
+| Entities (Models) | 12 |
+| Services | 9 |
+| FormRequests | 5 |
+| Middleware | 0 |
+| Views Blade | 0 |
+| Migrations | 12 |
+| Arquivos de lang | 3 |
+| Testes | 27 |
+
+## Rotas
+
+### `routes.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `/` | `'KbController@index'` |
+| `GET` | `/v2` | `function (` |
+| `GET` | `/graph` | `function (` |
+| `GET` | `/graph/data` | `function (` |
+| `GET` | `/{slug}/show` | `'KbController@show'` |
+| `GET` | `/{slug}/history` | `'KbController@history'` |
+| `DELETE` | `/{slug}` | `'KbController@softDelete'` |
+| `POST` | `/{slug}/restore` | `'KbController@restore'` |
+| `GET` | `/nodes` | `'KbNodeController@index'` |
+| `POST` | `/nodes` | `'KbNodeController@store'` |
+| `GET` | `/nodes/{slug}` | `'KbNodeController@show'` |
+| `PUT` | `/nodes/{slug}` | `'KbNodeController@update'` |
+| `DELETE` | `/nodes/{slug}` | `'KbNodeController@destroy'` |
+| `POST` | `/nodes/{slug}/restore` | `'KbNodeController@restore'` |
+| `POST` | `/nodes/{slug}/reverify` | `'KbNodeController@reverify'` |
+| `GET` | `/nodes/{slug}/versions` | `'KbVersionController@index'` |
+| `POST` | `/nodes/{slug}/restore-version` | `'KbVersionController@restoreVersion'` |
+| `POST` | `/nodes/{slug}/favorite` | `'KbFavoriteController@toggle'` |
+| `POST` | `/nodes/{slug}/comments` | `'KbCommentController@store'` |
+| `DELETE` | `/comments/{id}` | `'KbCommentController@destroy'` |
+| `GET` | `/paths` | `'KbPathController@index'` |
+| `POST` | `/paths` | `'KbPathController@store'` |
+| `GET` | `/paths/{slug}` | `'KbPathController@show'` |
+| `PUT` | `/paths/{slug}` | `'KbPathController@update'` |
+| `GET` | `/decision-trees` | `'KbDecisionTreeController@index'` |
+| `POST` | `/decision-trees` | `'KbDecisionTreeController@store'` |
+| `GET` | `/decision-trees/{slug}` | `'KbDecisionTreeController@show'` |
+| `PUT` | `/decision-trees/{slug}` | `'KbDecisionTreeController@update'` |
+| `GET` | `/edges` | `'KbEdgeController@index'` |
+| `POST` | `/edges` | `'KbEdgeController@store'` |
+| `DELETE` | `/edges/{id}` | `'KbEdgeController@destroy'` |
+| `GET` | `/print-sop/{slug}` | `'PrintSopController@show'` |
+| `GET` | `/` | `'InstallController@index'` |
+| `POST` | `/` | `'InstallController@install'` |
+| `GET` | `/uninstall` | `'InstallController@uninstall'` |
+| `GET` | `/update` | `'InstallController@update'` |
+| `GET` | `/` | `function (` |
+| `POST` | `/ask` | `'KbAiController@ask'` |
+| `POST` | `/summarize/{slug}` | `'KbAiController@summarize'` |
+| `POST` | `/suggest-meta` | `'KbAiController@suggestMeta'` |
+
+### `api.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `/health` | `function (` |
+| `POST` | `/tools/kb-search` | `KbSearchMcpController::class` |
+| `GET` | `/api/kb/ping` | `function (` |
+
+## Controllers
+
+- **`GraphController`** — 1 ação(ões): index
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`FontesController`** — 2 ação(ões): show, update
+- **`InstallController`** — 0 ação(ões): 
+- **`KbAiController`** — 3 ação(ões): ask, summarize, suggestMeta
+- **`KbCommentController`** — 2 ação(ões): store, destroy
+- **`KbController`** — 5 ação(ões): index, show, softDelete, restore, history
+- **`KbDecisionTreeController`** — 4 ação(ões): index, show, store, update
+- **`KbEdgeController`** — 3 ação(ões): index, store, destroy
+- **`KbFavoriteController`** — 1 ação(ões): toggle
+- **`KbNodeController`** — 7 ação(ões): index, show, store, update, destroy, restore, reverify
+- **`KbPathController`** — 4 ação(ões): index, show, store, update
+- **`KbVersionController`** — 2 ação(ões): index, restoreVersion
+- **`MemoriaController`** — 3 ação(ões): index, destroy, update
+
+## Entities (Models Eloquent)
+
+- **`KbBridgeState`** (tabela: `kb_bridge_state`)
+- **`KbCategory`** (tabela: `kb_categories`)
+- **`KbComment`** (tabela: `kb_comments`)
+- **`KbDecisionTree`** (tabela: `kb_decision_trees`)
+- **`KbDecisionTreeStep`** (tabela: `kb_decision_tree_steps`)
+- **`KbEdge`** (tabela: `kb_edges`)
+- **`KbFavorite`** (tabela: `kb_favorites`)
+- **`KbNode`** (tabela: `kb_nodes`)
+- **`KbNodeVersion`** (tabela: `kb_node_versions`)
+- **`KbPath`** (tabela: `kb_paths`)
+- **`KbPathStep`** (tabela: `kb_path_steps`)
+- **`KbSubcategory`** (tabela: `kb_subcategories`)
+
+## Migrations
+
+- `2026_05_15_100001_create_kb_categories_table.php`
+- `2026_05_15_100002_create_kb_subcategories_table.php`
+- `2026_05_15_100003_create_kb_nodes_table.php`
+- `2026_05_15_100004_create_kb_edges_table.php`
+- `2026_05_15_100005_create_kb_paths_table.php`
+- `2026_05_15_100006_create_kb_path_steps_table.php`
+- `2026_05_15_100007_create_kb_decision_trees_table.php`
+- `2026_05_15_100008_create_kb_decision_tree_steps_table.php`
+- `2026_05_15_100009_create_kb_node_versions_table.php`
+- `2026_05_15_100010_create_kb_favorites_table.php`
+- `2026_05_15_100011_create_kb_comments_table.php`
+- `2026_05_15_100012_create_kb_bridge_state_table.php`
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Permissões
+
+**Registradas pelo módulo** (via `user_permissions()`):
+
+- `kb.view`
+- `kb.softdelete`
+- `kb.restore`
+- `kb.history.view`
+
+## Processamento / eventos
+
+**Jobs (queue):** `KbBridgeFromMcpJob`, `KbEdgeAutoDeriverJob`
+
+**Commands (artisan):** `KbDriftDetectorCommand`, `KbHealthCommand`, `KbReindexCommand`
+
+**Observers:** `KbDecisionTreeStepObserver`, `KbNodeObserver`, `KbNodeVersionObserver`
+
+## Peças adicionais
+
+- **Factories:** 11 (`KbCategoryFactory`, `KbCommentFactory`, `KbDecisionTreeFactory`, `KbDecisionTreeStepFactory`, `KbEdgeFactory`)
+- **Seeders:** `KbBridgeFromMcpSeeder`, `KbCategoriesSeeder`, `KbDatabaseSeeder`, `KbOperacionalSeeder`, `KbSubcategoriesSeeder`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `KB` |
+| `module_label` | `Knowledge Base` |
+| `module_description` | `Knowledge Base — biblioteca compartilhada de ADRs, sessions, runbooks, comparativos.` |
+| `module_icon` | `fa fa-book-open` |
+| `module_version` | `0.1` |
+| `pid` | `` |
+| `retention` | `[array(6 itens)]` |
+| `pii_redaction` | `[array(2 itens)]` |
+| `activity_log` | `[array(1 itens)]` |
+| `bge` | `[array(3 itens)]` |
+| `usd_to_brl` | `5` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `Jana` | 5 |
+
+## Integridade do banco
+
+**Unique indexes:** 10
+
+## Dependências Composer
+
+- `php` ^8.1
+- `spatie/laravel-permission` ^6.0
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec KB`

--- a/memory/modulos/Knowledgebase.md
+++ b/memory/modulos/Knowledgebase.md
@@ -36,10 +36,9 @@
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ❌ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ❌ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ❌ |
 
 ## Diferenças vs versões anteriores
 
@@ -51,5 +50,5 @@
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:14.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Knowledgebase`

--- a/memory/modulos/Manufacturing.md
+++ b/memory/modulos/Manufacturing.md
@@ -12,6 +12,7 @@
 ## Sinais detectados
 
 - 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- ✅ Tem testes (17)
 - 🔐 Registra 4 permissão(ões) Spatie
 
 - **Prioridade sugerida de migração:** média
@@ -24,13 +25,13 @@
 | Rotas (web+api) | 14 |
 | Controllers | 6 |
 | Entities (Models) | 3 |
-| Services | 0 |
-| FormRequests | 0 |
+| Services | 2 |
+| FormRequests | 7 |
 | Middleware | 0 |
 | Views Blade | 20 |
 | Migrations | 13 |
 | Arquivos de lang | 14 |
-| Testes | 0 |
+| Testes | 17 |
 
 ## Rotas
 
@@ -60,9 +61,9 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 ## Controllers
 
 - **`DataController`** — 4 ação(ões): superadmin_package, user_permissions, modifyAdminMenu, profitLossReportData
-- **`InstallController`** — 4 ação(ões): index, install, update, uninstall
+- **`InstallController`** — 0 ação(ões): 
 - **`ManufacturingController`** — 7 ação(ões): index, create, store, show, edit, update, destroy
-- **`ProductionController`** — 8 ação(ões): index, create, store, show, edit, update, destroy, getManufacturingReport
+- **`ProductionController`** — 9 ação(ões): index, create, store, show, edit, update, destroy, indexV2 +1
 - **`RecipeController`** — 11 ação(ões): index, create, store, show, getIngredientRow, addIngredients, getRecipeDetails, getIngredientGroupForm +3
 - **`SettingsController`** — 2 ação(ões): index, store
 
@@ -121,6 +122,10 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - `manufacturing.access_production`
 - `manufacturing.add_recipe`
 
+## Processamento / eventos
+
+**Commands (artisan):** `ManufacturingHealthCommand`
+
 ## Peças adicionais
 
 - **Seeders:** `ManufacturingDatabaseSeeder`
@@ -165,84 +170,11 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ✅ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ✅ |
 
 ## Diferenças vs versões anteriores
-
-### vs `origin/3.7-com-nfe`
-
-- **Arquivos alterados:** 84
-- **Linhas +:** 6280 **-:** 0
-- **Primeiros arquivos alterados:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2019_07_15_114211_add_manufacturing_module_version_to_system_table.php`
-  - `Database/Migrations/2019_07_15_114403_create_mfg_recipes_table.php`
-  - `Database/Migrations/2019_07_18_180217_add_production_columns_to_transactions_table.php`
-  - `Database/Migrations/2019_07_26_110753_add_manufacturing_settings_column_to_business_table.php`
-  - `Database/Migrations/2019_07_26_170450_add_manufacturing_permissions.php`
-  - `Database/Migrations/2019_08_08_110035_create_mfg_recipe_ingredients_table.php`
-  - `Database/Migrations/2019_08_08_172837_add_recipe_add_edit_permissions.php`
-  - `Database/Migrations/2019_08_12_114610_add_ingredient_waste_percent_columns.php`
-  - `Database/Migrations/2019_11_05_115136_create_ingredient_groups_table.php`
-  - `Database/Migrations/2020_02_22_120303_add_column_to_mfg_recipe_ingredients_table.php`
-  - `Database/Migrations/2020_08_19_103831_add_production_cost_type_to_recipe_and_transaction_table.php`
-  - `Database/Migrations/2021_02_16_190302_add_manufacturing_module_indexing.php`
-  - `Database/Migrations/2021_04_07_154331_add_mfg_ingredient_group_id_to_transaction_sell_lines_table.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/ManufacturingDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Entities/MfgIngredientGroup.php`
-  - `Entities/MfgRecipe.php`
-  - `Entities/MfgRecipeIngredient.php`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/DataController.php`
-  - `Http/Controllers/InstallController.php`
-  - `Http/Controllers/ManufacturingController.php`
-  - `Http/Controllers/ProductionController.php`
-  - `Http/Controllers/RecipeController.php`
-
-### vs `main-wip-2026-04-22` (backup das customizações)
-
-- **Arquivos alterados:** 84
-- **Linhas +:** 6280 **-:** 0
-- ⚠️ **Arquivos que podem conter customizações suas não trazidas para 6.7-react:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2019_07_15_114211_add_manufacturing_module_version_to_system_table.php`
-  - `Database/Migrations/2019_07_15_114403_create_mfg_recipes_table.php`
-  - `Database/Migrations/2019_07_18_180217_add_production_columns_to_transactions_table.php`
-  - `Database/Migrations/2019_07_26_110753_add_manufacturing_settings_column_to_business_table.php`
-  - `Database/Migrations/2019_07_26_170450_add_manufacturing_permissions.php`
-  - `Database/Migrations/2019_08_08_110035_create_mfg_recipe_ingredients_table.php`
-  - `Database/Migrations/2019_08_08_172837_add_recipe_add_edit_permissions.php`
-  - `Database/Migrations/2019_08_12_114610_add_ingredient_waste_percent_columns.php`
-  - `Database/Migrations/2019_11_05_115136_create_ingredient_groups_table.php`
-  - `Database/Migrations/2020_02_22_120303_add_column_to_mfg_recipe_ingredients_table.php`
-  - `Database/Migrations/2020_08_19_103831_add_production_cost_type_to_recipe_and_transaction_table.php`
-  - `Database/Migrations/2021_02_16_190302_add_manufacturing_module_indexing.php`
-  - `Database/Migrations/2021_04_07_154331_add_mfg_ingredient_group_id_to_transaction_sell_lines_table.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/ManufacturingDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Entities/MfgIngredientGroup.php`
-  - `Entities/MfgRecipe.php`
-  - `Entities/MfgRecipeIngredient.php`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/DataController.php`
-  - `Http/Controllers/InstallController.php`
-  - `Http/Controllers/ManufacturingController.php`
-  - `Http/Controllers/ProductionController.php`
-  - `Http/Controllers/RecipeController.php`
 
 ## Gaps & próximos passos (preencher manualmente)
 
@@ -252,5 +184,5 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:14.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Manufacturing`

--- a/memory/modulos/NFSe.md
+++ b/memory/modulos/NFSe.md
@@ -1,0 +1,144 @@
+# Módulo: NFSe
+
+> **Emissão de Nota Fiscal de Serviços Eletrônica via Sistema Nacional NFSe (LC 214/2025). Integração direta com webservice federal — sem provider terceiro, custo zero por emissão.**
+
+- **Alias:** `nfse`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/NFSe`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\NFSe\Providers\NfseServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- ℹ️ Módulo sem views (provável API-only ou service)
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- ✅ Tem testes (9)
+- ⚙️ Processamento assíncrono: 1 peça(s) (jobs/events/listeners)
+- 🔗 Acoplamento: depende de 1 outro(s) módulo(s)
+
+- **Prioridade sugerida de migração:** alta (pequeno, ganho rápido)
+- **Risco estimado:** baixo
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 9 |
+| Controllers | 3 |
+| Entities (Models) | 0 |
+| Services | 1 |
+| FormRequests | 3 |
+| Middleware | 0 |
+| Views Blade | 0 |
+| Migrations | 5 |
+| Arquivos de lang | 0 |
+| Testes | 9 |
+
+## Rotas
+
+### `web.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+| `GET` | `/` | `[NfseController::class, 'index']` |
+| `GET` | `/emitir` | `[NfseController::class, 'create']` |
+| `POST` | `/emitir` | `[NfseController::class, 'store']` |
+| `GET` | `/{nfse}` | `[NfseController::class, 'show']` |
+| `POST` | `/{nfse}/cancelar` | `[NfseController::class, 'cancelar']` |
+| `GET` | `/{nfse}/pdf` | `[NfseController::class, 'pdf']` |
+
+### `api.php`
+
+_(arquivo existe mas parse não identificou rotas explícitas — pode ter grupos complexos)_
+
+## Controllers
+
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`InstallController`** — 0 ação(ões): 
+- **`NfseController`** — 6 ação(ões): index, create, store, show, cancelar, pdf
+
+## Migrations
+
+- `2026_05_01_000001_create_nfe_certificados_table.php`
+- `2026_05_01_000002_create_nfse_provider_configs_table.php`
+- `2026_05_01_000003_create_nfse_emissoes_table.php`
+- `2026_05_01_000004_add_prestador_cnpj_to_nfse_provider_configs.php`
+- `2026_05_03_000001_add_transaction_id_to_nfse_emissoes.php`
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Processamento / eventos
+
+**Jobs (queue):** `EmitirNfseJob`
+
+**Commands (artisan):** `ImportarCertificadoCommand`, `NfseHealthCommand`
+
+**Observers:** `TransactionNfseObserver`
+
+## Peças adicionais
+
+- **Seeders:** `NfseSeeder`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `NFSe` |
+| `module_version` | `0.1.0` |
+| `ambiente` | `homologacao` |
+| `cert_path` | `` |
+| `cert_senha` | `` |
+| `endpoints` | `[array(2 itens)]` |
+| `municipio_ibge_default` | `4218707` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `NfeBrasil` | 1 |
+
+## Integridade do banco
+
+**Foreign Keys** (4):
+
+- `business_id` → `business.id`
+- `business_id` → `business.id`
+- `cert_id` → `nfe_certificados.id`
+- `business_id` → `business.id`
+
+**Unique indexes:** 2
+
+## Dependências Composer
+
+- `nfse-nacional/nfse-php` ^1.19
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec NFSe`

--- a/memory/modulos/NfeBrasil.md
+++ b/memory/modulos/NfeBrasil.md
@@ -1,0 +1,235 @@
+# Módulo: NfeBrasil
+
+> **Vender com nota fiscal sem virar contador. NFC-e em 1 clique no caixa, NF-e B2B sem fricção, SPED pronto no fim do mês.**
+
+- **Alias:** `nfebrasil`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/NfeBrasil`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\NfeBrasil\Providers\NfeBrasilServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- 🟡 39 rotas — escopo médio
+- ✅ Tem testes (45)
+- 🔐 Registra 9 permissão(ões) Spatie
+- ⚙️ Processamento assíncrono: 15 peça(s) (jobs/events/listeners)
+- 🔗 Acoplamento: depende de 3 outro(s) módulo(s)
+
+- **Prioridade sugerida de migração:** baixa (grande, fazer por último ou dividir)
+- **Risco estimado:** alto
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 39 |
+| Controllers | 11 |
+| Entities (Models) | 0 |
+| Services | 15 |
+| FormRequests | 6 |
+| Middleware | 0 |
+| Views Blade | 4 |
+| Migrations | 16 |
+| Arquivos de lang | 1 |
+| Testes | 45 |
+
+## Rotas
+
+### `web.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+| `GET` | `certificado` | `fn (` |
+| `POST` | `certificado` | `[CertificadoController::class, 'upload']` |
+| `POST` | `certificado/testar` | `[CertificadoController::class, 'testar']` |
+| `POST` | `certificado/ambiente` | `[CertificadoController::class, 'updateAmbiente']` |
+| `GET` | `/` | `[TributacaoController::class, 'index']` |
+| `POST` | `auto-emission/toggle` | `[TributacaoController::class, 'toggleAutoEmission']` |
+| `GET` | `config-default` | `[ConfigDefaultController::class, 'show']` |
+| `POST` | `config-default` | `[ConfigDefaultController::class, 'upsert']` |
+| `POST` | `templates/{slug}/aplicar` | `[TributacaoController::class, 'aplicarTemplate']` |
+| `GET` | `regras/create` | `[TributacaoController::class, 'create']` |
+| `POST` | `regras` | `[TributacaoController::class, 'store']` |
+| `GET` | `regras/{id}/edit` | `[TributacaoController::class, 'edit']` |
+| `PUT` | `regras/{id}` | `[TributacaoController::class, 'update']` |
+| `DELETE` | `regras/{id}` | `[TributacaoController::class, 'destroy']` |
+| `GET` | `import` | `[ImportRegrasController::class, 'show']` |
+| `POST` | `import/preview` | `[ImportRegrasController::class, 'preview']` |
+| `POST` | `import/aplicar` | `[ImportRegrasController::class, 'aplicar']` |
+| `GET` | `transactions/{tx}/nfe-status` | `[NfeStatusController::class, 'show']` |
+| `GET` | `transactions/{tx}/emissoes` | `[\Modules\NfeBrasil\Http\Controllers\NfeEmissaoController::class, 'listar']` |
+| `POST` | `transactions/{tx}/emitir` | `[\Modules\NfeBrasil\Http\Controllers\NfeEmissaoController::class, 'emitir']` |
+| `POST` | `emissoes/{id}/reenviar-email` | `[\Modules\NfeBrasil\Http\Controllers\NfeEmissaoController::class, 'reenviarEmail']` |
+| `GET` | `emissoes/{id}/danfe-pdf` | `[\Modules\NfeBrasil\Http\Controllers\NfeEmissaoController::class, 'danfePdf']` |
+| `GET` | `{tx}/status` | `[NfeStatusController::class, 'showPage']` |
+| `GET` | `/` | `[NfeInutilizacaoController::class, 'index']` |
+| `POST` | `/` | `[NfeInutilizacaoController::class, 'store']` |
+| `GET` | `/` | `[\Modules\NfeBrasil\Http\Controllers\ManifestacaoController::class, 'index']` |
+| `POST` | `{id}/cienciar` | `[\Modules\NfeBrasil\Http\Controllers\ManifestacaoController::class, 'cienciar']` |
+| `POST` | `{id}/confirmar` | `[\Modules\NfeBrasil\Http\Controllers\ManifestacaoController::class, 'confirmar']` |
+| `POST` | `{id}/desconhecer` | `[\Modules\NfeBrasil\Http\Controllers\ManifestacaoController::class, 'desconhecer']` |
+| `POST` | `{id}/nao-realizada` | `[\Modules\NfeBrasil\Http\Controllers\ManifestacaoController::class, 'naoRealizada']` |
+| `POST` | `bulk/confirmar` | `[\Modules\NfeBrasil\Http\Controllers\ManifestacaoController::class, 'bulkConfirmar']` |
+| `POST` | `sync-now` | `[\Modules\NfeBrasil\Http\Controllers\ManifestacaoController::class, 'syncNow']` |
+| `GET` | `{id}/itens` | `[\Modules\NfeBrasil\Http\Controllers\ManifestacaoController::class, 'listarItens']` |
+| `GET` | `{id}/eventos` | `[\Modules\NfeBrasil\Http\Controllers\ManifestacaoController::class, 'listarEventos']` |
+| `RESOURCE` | `nfebrasil` | `NfeBrasilController::class` |
+
+### `api.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `nfebrasil` | `fn (Request $request` |
+
+## Controllers
+
+- **`CertificadoController`** — 4 ação(ões): status, upload, testar, updateAmbiente
+- **`ConfigDefaultController`** — 2 ação(ões): show, upsert
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`ImportRegrasController`** — 3 ação(ões): show, preview, aplicar
+- **`InstallController`** — 0 ação(ões): 
+- **`ManifestacaoController`** — 9 ação(ões): index, cienciar, confirmar, desconhecer, naoRealizada, bulkConfirmar, syncNow, listarItens +1
+- **`NfeBrasilController`** — 7 ação(ões): index, create, store, show, edit, update, destroy
+- **`NfeEmissaoController`** — 4 ação(ões): emitir, reenviarEmail, danfePdf, listar
+- **`NfeInutilizacaoController`** — 2 ação(ões): index, store
+- **`NfeStatusController`** — 2 ação(ões): show, showPage
+- **`TributacaoController`** — 8 ação(ões): index, toggleAutoEmission, aplicarTemplate, create, store, edit, update, destroy
+
+## Migrations
+
+- `2026_05_06_002000_create_nfe_certificados_table.php`
+- `2026_05_06_002001_create_nfe_emissoes_table.php`
+- `2026_05_06_002002_create_nfe_eventos_table.php`
+- `2026_05_06_002003_create_nfe_inutilizacoes_table.php`
+- `2026_05_06_010000_create_nfe_fiscal_rules_table.php`
+- `2026_05_06_010001_create_nfe_business_configs_table.php`
+- `2026_05_06_020000_create_nfe_fiscal_rule_tax_rate_links_table.php`
+- `2026_05_08_000000_add_auto_emission_enabled_to_nfe_business_configs.php`
+- `2026_05_09_100000_create_nfe_dfe_recebidos_table.php`
+- `2026_05_09_100001_create_nfe_dfe_itens_table.php`
+- `2026_05_09_100002_create_nfe_dfe_eventos_table.php`
+- `2026_05_09_100003_create_nfe_dfe_nsu_state_table.php`
+- `2026_05_10_120000_alter_nfe_emissoes_status_enum_add_enviando_erro_envio.php`
+- `2026_05_11_150001_create_nfse_emissoes_table.php`
+- `2026_05_12_120000_create_nfse_eventos_cancelamento_table.php`
+- `2026_05_26_000001_add_ibs_cbs_to_nfe_fiscal_rules.php`
+
+## Views (Blade)
+
+**Total:** 4 arquivos
+
+**Pastas principais:**
+
+- `mail/` — 2 arquivo(s)
+- `D:/` — 1 arquivo(s)
+- `layouts/` — 1 arquivo(s)
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Permissões
+
+**Registradas pelo módulo** (via `user_permissions()`):
+
+- `nfebrasil.access`
+- `nfebrasil.emit.manage`
+- `nfebrasil.consult.view`
+- `nfebrasil.sped.view`
+- `nfebrasil.settings.manage`
+- `nfe.configuracao.manage`
+- `nfe.tributacao.manage`
+- `nfe.manifestacao.view`
+- `nfe.manifestacao.manage`
+
+## Processamento / eventos
+
+**Jobs (queue):** `BuscarDfesRecebidosJob`, `CancelarNfeJob`, `CancelarNfseJob`, `EmitirNFSeJob`, `EmitirNfceJob`
+
+**Commands (artisan):** `MigrateCertFromBusiness`, `NfeHealthCommand`, `PuxarDfesRecebidosCommand`
+
+**Events:** `FiscalRuleCreated`, `FiscalRuleDeleted`, `FiscalRuleUpdated`, `NFCeAutorizada`, `NFeAutorizada`
+
+**Listeners:** `EmitirNFeAoReceberPagamento`, `EmitirNfceAoFinalizarVenda`, `EnviarDanfeNFCePorEmail`, `EnviarDanfePorEmail`, `SyncFiscalRuleToTaxRate`
+
+## Peças adicionais
+
+- **Seeders:** `NfeBrasilDatabaseSeeder`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `NfeBrasil` |
+| `module_version` | `0.1.0` |
+| `ambiente_default` | `homologacao` |
+| `auto_emission_on_invoice_paid` | `false` |
+| `auto_emission_on_sell_completed` | `false` |
+| `email_danfe_on_autorizada` | `true` |
+| `email_danfe_nfce_on_autorizada` | `false` |
+| `resp_tec` | `[array(4 itens)]` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `Fiscal` | 1 |
+| `Jana` | 1 |
+| `RecurringBilling` | 1 |
+
+## Integridade do banco
+
+**Unique indexes:** 9
+
+## Assets (JS / CSS)
+
+| Tipo | Qtde |
+|---|---:|
+| JavaScript (.js/.mjs) | 1 |
+| TypeScript (.ts) | 0 |
+| Vue SFC (.vue) | 0 |
+| CSS/SCSS | 1 |
+| Imagens | 0 |
+
+- Build: **Vite** (vite.config.js/ts presente)
+- `package.json` presente
+- **Deps JS:** `axios`, `laravel-vite-plugin`, `sass`, `postcss`, `vite`
+
+**Arquivos JS** (primeiros 1):
+
+- `js\app.js` (0 B)
+
+**Arquivos CSS/SCSS** (primeiros 1):
+
+- `sass\app.scss` (0 B)
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec NfeBrasil`

--- a/memory/modulos/Officeimpresso.md
+++ b/memory/modulos/Officeimpresso.md
@@ -5,32 +5,36 @@
 - **Alias:** `officeimpresso`
 - **Versão:** ?
 - **Path:** `D:\oimpresso.com\Modules/Officeimpresso`
-- **Status:** ⚪ inativo
+- **Status:** 🟢 ativo
 - **Providers:** Modules\Officeimpresso\Providers\OfficeimpressoServiceProvider
 - **Requires (módulo.json):** nenhum
 
 ## Sinais detectados
 
-- 🔗 Registra 2 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package
-- ⚪ Inativo em `modules_statuses.json`
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- 🟡 21 rotas — escopo médio
+- ✅ Tem testes (12)
+- 🔐 Registra 1 permissão(ões) Spatie
+- ⚙️ Processamento assíncrono: 1 peça(s) (jobs/events/listeners)
+- 🗄️ Tem triggers MySQL (4) — append-only / imutabilidade
 
-- **Prioridade sugerida de migração:** baixa (desativado)
-- **Risco estimado:** baixo
+- **Prioridade sugerida de migração:** média
+- **Risco estimado:** médio
 
 ## Escopo
 
 | Peça | Qtde |
 |---|---:|
-| Rotas (web+api) | 7 |
-| Controllers | 3 |
-| Entities (Models) | 0 |
-| Services | 0 |
-| FormRequests | 0 |
-| Middleware | 0 |
-| Views Blade | 8 |
-| Migrations | 1 |
-| Arquivos de lang | 1 |
-| Testes | 0 |
+| Rotas (web+api) | 21 |
+| Controllers | 7 |
+| Entities (Models) | 2 |
+| Services | 4 |
+| FormRequests | 5 |
+| Middleware | 3 |
+| Views Blade | 18 |
+| Migrations | 8 |
+| Arquivos de lang | 2 |
+| Testes | 12 |
 
 ## Rotas
 
@@ -38,42 +42,94 @@
 
 | Método | URI | Controller |
 |---|---|---|
-| `GET` | `catalogue-qr` | `[\Modules\Officeimpresso\Http\Controllers\OfficeimpressoController::class, 'generateQr']` |
-| `GET` | `/catalogue/{business_id}/{location_id}` | `[\Modules\Officeimpresso\Http\Controllers\OfficeimpressoController::class, 'index']` |
-| `GET` | `/show-catalogue/{business_id}/{product_id}` | `[\Modules\Officeimpresso\Http\Controllers\OfficeimpressoController::class, 'show']` |
-| `GET` | `install` | `[\Modules\Officeimpresso\Http\Controllers\InstallController::class, 'index']` |
-| `POST` | `install` | `[\Modules\Officeimpresso\Http\Controllers\InstallController::class, 'install']` |
-| `GET` | `install/uninstall` | `[\Modules\Officeimpresso\Http\Controllers\InstallController::class, 'uninstall']` |
-| `GET` | `install/update` | `[\Modules\Officeimpresso\Http\Controllers\InstallController::class, 'update']` |
+| `GET` | `catalogue-qr` | `[OfficeimpressoController::class, 'generateQr']` |
+| `GET` | `/catalogue/{business_id}/{location_id}` | `[OfficeimpressoController::class, 'index']` |
+| `GET` | `/show-catalogue/{business_id}/{product_id}` | `[OfficeimpressoController::class, 'show']` |
+| `GET` | `/regenerate` | `[ClientController::class, 'regenerate']` |
+| `GET` | `businessall` | `[LicencaComputadorController::class, 'businessall']` |
+| `GET` | `computadores` | `[LicencaComputadorController::class, 'computadores']` |
+| `GET` | `/licenca_computador/{id}/toggle-block` | `[LicencaComputadorController::class, 'toggleBlock']` |
+| `POST` | `/licenca_computador/businessupdate/{id}` | `[LicencaComputadorController::class, 'businessupdate']` |
+| `GET` | `/licenca_computador/businessbloqueado/{id}` | `[LicencaComputadorController::class, 'businessbloqueado']` |
+| `GET` | `/licenca_computado/licencas/{id}` | `[LicencaComputadorController::class, 'viewLicencas']` |
+| `GET` | `licenca_log/timeline/{licenca_id}` | `[LicencaLogController::class, 'timeline']` |
+| `GET` | `/docs` | `function (` |
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `POST` | `install` | `[InstallController::class, 'install']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+| `RESOURCE` | `client` | `ClientController::class` |
+| `RESOURCE` | `licenca_computador` | `LicencaComputadorController::class` |
+| `RESOURCE` | `licenca_log` | `LicencaLogController::class` |
 
 ### `api.php`
 
-_(arquivo existe mas parse não identificou rotas explícitas — pode ter grupos complexos)_
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `/officeimpresso` | `function (Request $request` |
+| `POST` | `/officeimpresso/audit` | `[ \Modules\Officeimpresso\Http\Controllers\AuditController::class, 'store' ]` |
 
 ## Controllers
 
-- **`DataController`** — 2 ação(ões): superadmin_package, modifyAdminMenu
-- **`InstallController`** — 4 ação(ões): index, install, uninstall, update
+- **`AuditController`** — 1 ação(ões): store
+- **`ClientController`** — 8 ação(ões): index, create, store, show, edit, update, destroy, regenerate
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`InstallController`** — 0 ação(ões): 
+- **`LicencaComputadorController`** — 13 ação(ões): index, computadores, viewLicencas, businessall, create, edit, store, show +5
+- **`LicencaLogController`** — 3 ação(ões): index, timeline, show
 - **`OfficeimpressoController`** — 3 ação(ões): index, show, generateQr
+
+## Entities (Models Eloquent)
+
+- **`LicencaLog`** (tabela: `licenca_log`)
+- **`Licenca_Computador`** (tabela: `licenca_computador`)
 
 ## Migrations
 
+- `2024_11_05_101935_create_licenca_computador_table.php`
+- `2024_11_07_083505_update_licenca_computador_table.php`
 - `2025_02_07_184909_add_officeimpresso_version.php`
+- `2026_04_23_200000_create_licenca_log_table.php`
+- `2026_04_23_200100_create_licenca_log_triggers.php`
+- `2026_04_23_200200_add_indexes_to_licenca_computador.php`
+- `2026_04_24_000000_drop_licenca_log_triggers.php`
+- `2026_04_24_100500_add_business_location_id_to_licenca_log.php`
 
 ## Views (Blade)
 
-**Total:** 8 arquivos
+**Total:** 18 arquivos
 
 **Pastas principais:**
 
 - `catalogue/` — 6 arquivo(s)
+- `licenca_computador/` — 4 arquivo(s)
+- `layouts/` — 3 arquivo(s)
+- `licenca_log/` — 2 arquivo(s)
+- `clients/` — 1 arquivo(s)
 - `D:/` — 1 arquivo(s)
-- `layouts/` — 1 arquivo(s)
+- `licencas_log/` — 1 arquivo(s)
 
 ## Hooks UltimatePOS registrados
 
 - **`modifyAdminMenu()`** — Injeta itens na sidebar admin
 - **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Permissões
+
+**Registradas pelo módulo** (via `user_permissions()`):
+
+- `officeimpresso.access`
+
+**Usadas nas views** (`@can`/`@cannot`):
+
+- `superadmin`
+
+## Processamento / eventos
+
+**Commands (artisan):** `ImportOfficeimpressoCommand`, `OfficeimpressoHealthCommand`, `InspectDelphiApiCommand`, `ParseLicencaLogCommand`
+
+**Listeners:** `LogPassportAccessToken`
 
 ## Peças adicionais
 
@@ -86,6 +142,16 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 | `name` | `Officeimpresso` |
 | `module_version` | `1.0` |
 | `pid` | `19` |
+
+## Integridade do banco
+
+**Foreign Keys** (1):
+
+- `business_id` → `business.id`
+
+**Triggers MySQL** (4): `licenca_log_after_oauth_access_token_insert`, `licenca_log_after_oauth_refresh_token_insert`, `licenca_log_after_oauth_access_token_insert`, `licenca_log_after_oauth_refresh_token_insert`
+
+**Unique indexes:** 1
 
 ## Assets (JS / CSS)
 
@@ -113,84 +179,11 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ✅ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ✅ |
 
 ## Diferenças vs versões anteriores
-
-### vs `origin/3.7-com-nfe`
-
-- **Arquivos alterados:** 39
-- **Linhas +:** 1319 **-:** 0
-- **Primeiros arquivos alterados:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2025_02_07_184909_add_officeimpresso_version.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/OfficeimpressoDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/DataController.php`
-  - `Http/Controllers/InstallController.php`
-  - `Http/Controllers/OfficeimpressoController.php`
-  - `Http/Middleware/.gitkeep`
-  - `Http/Requests/.gitkeep`
-  - `Providers/.gitkeep`
-  - `Providers/OfficeimpressoServiceProvider.php`
-  - `Providers/RouteServiceProvider.php`
-  - `Resources/assets/.gitkeep`
-  - `Resources/assets/plugins/easy.qrcode.min.js`
-  - `Resources/assets/sass/app.scss`
-  - `Resources/lang/.gitkeep`
-  - `Resources/lang/en/lang.php`
-  - `Resources/views/.gitkeep`
-  - `Resources/views/catalogue/generate_qr.blade.php`
-  - `Resources/views/catalogue/index.blade.php`
-  - `Resources/views/catalogue/partials/combo_product_details.blade.php`
-  - `Resources/views/catalogue/partials/single_product_details.blade.php`
-  - `Resources/views/catalogue/partials/variable_product_details.blade.php`
-  - `Resources/views/catalogue/show.blade.php`
-
-### vs `main-wip-2026-04-22` (backup das customizações)
-
-- **Arquivos alterados:** 39
-- **Linhas +:** 1319 **-:** 0
-- ⚠️ **Arquivos que podem conter customizações suas não trazidas para 6.7-react:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2025_02_07_184909_add_officeimpresso_version.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/OfficeimpressoDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/DataController.php`
-  - `Http/Controllers/InstallController.php`
-  - `Http/Controllers/OfficeimpressoController.php`
-  - `Http/Middleware/.gitkeep`
-  - `Http/Requests/.gitkeep`
-  - `Providers/.gitkeep`
-  - `Providers/OfficeimpressoServiceProvider.php`
-  - `Providers/RouteServiceProvider.php`
-  - `Resources/assets/.gitkeep`
-  - `Resources/assets/plugins/easy.qrcode.min.js`
-  - `Resources/assets/sass/app.scss`
-  - `Resources/lang/.gitkeep`
-  - `Resources/lang/en/lang.php`
-  - `Resources/views/.gitkeep`
-  - `Resources/views/catalogue/generate_qr.blade.php`
-  - `Resources/views/catalogue/index.blade.php`
-  - `Resources/views/catalogue/partials/combo_product_details.blade.php`
-  - `Resources/views/catalogue/partials/single_product_details.blade.php`
-  - `Resources/views/catalogue/partials/variable_product_details.blade.php`
-  - `Resources/views/catalogue/show.blade.php`
 
 ## Gaps & próximos passos (preencher manualmente)
 
@@ -200,5 +193,5 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:14.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Officeimpresso`

--- a/memory/modulos/OficinaAuto.md
+++ b/memory/modulos/OficinaAuto.md
@@ -1,0 +1,173 @@
+# Módulo: OficinaAuto
+
+> **Modules/OficinaAuto — vertical oficinas automotivas BR (CNAEs 4520-0/01, 2212-9/00, 4581-4/00). Estado V0 em construção (ADR 0137 — qualificada por sinal Vargas + Martinho). Scaffold inicial com CRUD Vehicle + ServiceOrder multi-tenant Tier 0. Ver memory/requisitos/OficinaAuto/SPEC.md.**
+
+- **Alias:** `oficina-auto`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/OficinaAuto`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\OficinaAuto\Providers\OficinaAutoServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- ℹ️ Módulo sem views (provável API-only ou service)
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- 🟡 34 rotas — escopo médio
+- ✅ Tem testes (30)
+- ⚙️ Processamento assíncrono: 1 peça(s) (jobs/events/listeners)
+- 🔗 Acoplamento: depende de 3 outro(s) módulo(s)
+
+- **Prioridade sugerida de migração:** média
+- **Risco estimado:** médio
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 34 |
+| Controllers | 8 |
+| Entities (Models) | 4 |
+| Services | 6 |
+| FormRequests | 9 |
+| Middleware | 0 |
+| Views Blade | 0 |
+| Migrations | 11 |
+| Arquivos de lang | 1 |
+| Testes | 30 |
+
+## Rotas
+
+### `web.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+| `GET` | `producao-oficina` | `[ProducaoOficinaController::class, 'index']` |
+| `GET` | `veiculos` | `[VehicleController::class, 'index']` |
+| `GET` | `veiculos/create` | `[VehicleController::class, 'create']` |
+| `POST` | `veiculos` | `[VehicleController::class, 'store']` |
+| `GET` | `veiculos/{vehicle}` | `[VehicleController::class, 'show']` |
+| `GET` | `veiculos/{vehicle}/edit` | `[VehicleController::class, 'edit']` |
+| `PUT` | `veiculos/{vehicle}` | `[VehicleController::class, 'update']` |
+| `DELETE` | `veiculos/{vehicle}` | `[VehicleController::class, 'destroy']` |
+| `GET` | `ordens-servico` | `[ServiceOrderController::class, 'index']` |
+| `GET` | `ordens-servico/create` | `[ServiceOrderController::class, 'create']` |
+| `POST` | `ordens-servico` | `[ServiceOrderController::class, 'store']` |
+| `GET` | `ordens-servico/{order}` | `[ServiceOrderController::class, 'show']` |
+| `GET` | `ordens-servico/{order}/edit` | `[ServiceOrderController::class, 'edit']` |
+| `PUT` | `ordens-servico/{order}` | `[ServiceOrderController::class, 'update']` |
+| `DELETE` | `ordens-servico/{order}` | `[ServiceOrderController::class, 'destroy']` |
+| `GET` | `ordens-servico/{order}/print` | `[ServiceOrderController::class, 'printInvoice']` |
+| `POST` | `ordens-servico/{order}/items` | `[ServiceOrderItemController::class, 'store']` |
+| `PUT` | `ordens-servico/{order}/items/{item}` | `[ServiceOrderItemController::class, 'update']` |
+| `DELETE` | `ordens-servico/{order}/items/{item}` | `[ServiceOrderItemController::class, 'destroy']` |
+| `GET` | `service-orders/{order}` | `[ServiceOrderController::class, 'show']` |
+| `GET` | `service-orders/{order}/fsm/actions` | `[ServiceOrderFsmActionController::class, 'actions']` |
+| `POST` | `service-orders/{order}/fsm/execute` | `[ServiceOrderFsmActionController::class, 'execute']` |
+| `POST` | `service-orders/{order}/fsm/start-pipeline` | `[ServiceOrderFsmActionController::class, 'startPipeline']` |
+| `GET` | `service-orders/{order}/history` | `[ServiceOrderFsmActionController::class, 'history']` |
+| `POST` | `ordens-servico/{order}/dvi` | `[DviInspectionController::class, 'store']` |
+| `PUT` | `ordens-servico/{order}/dvi/{item}` | `[DviInspectionController::class, 'update']` |
+| `DELETE` | `ordens-servico/{order}/dvi/{item}` | `[DviInspectionController::class, 'destroy']` |
+| `POST` | `ordens-servico/{order}/dvi/{item}/photo` | `[DviInspectionController::class, 'uploadPhoto']` |
+| `DELETE` | `ordens-servico/{order}/dvi/{item}/photo/{arquivo}` | `[DviInspectionController::class, 'deletePhoto']` |
+| `GET` | `/aprovar-os/{token}` | `[AprovacaoOsController::class, 'show']` |
+| `POST` | `/aprovar-os/{token}` | `[AprovacaoOsController::class, 'submit']` |
+
+## Controllers
+
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`DviInspectionController`** — 5 ação(ões): store, update, destroy, uploadPhoto, deletePhoto
+- **`InstallController`** — 0 ação(ões): 
+- **`ProducaoOficinaController`** — 1 ação(ões): index
+- **`AprovacaoOsController`** — 2 ação(ões): show, submit
+- **`ServiceOrderController`** — 8 ação(ões): index, create, store, show, edit, update, destroy, printInvoice
+- **`ServiceOrderItemController`** — 3 ação(ões): store, update, destroy
+- **`VehicleController`** — 7 ação(ões): index, create, store, show, edit, update, destroy
+
+## Entities (Models Eloquent)
+
+- **`OaInspectionItem`** (tabela: `oa_inspection_items`)
+- **`ServiceOrder`** (tabela: `service_orders`)
+- **`ServiceOrderItem`** (tabela: `oficina_service_order_items`)
+- **`Vehicle`** (tabela: `vehicles`)
+
+## Migrations
+
+- `2026_05_11_000010_create_vehicles_table.php`
+- `2026_05_11_000020_create_service_orders_table.php`
+- `2026_05_12_220001_add_cacamba_fields_to_vehicles.php`
+- `2026_05_12_220002_add_rental_fields_to_service_orders.php`
+- `2026_05_12_230001_add_transaction_sell_line_id_to_service_orders.php`
+- `2026_05_13_010001_add_current_stage_id_to_service_orders.php`
+- `2026_05_13_010002_add_contact_id_to_service_orders.php`
+- `2026_05_17_000010_create_oficina_service_order_items_table.php`
+- `2026_05_26_120001_add_box_and_assigned_user_to_service_orders.php`
+- `2026_05_26_120002_create_oa_inspection_items_table.php`
+- `2026_05_27_000010_add_client_decision_to_oa_inspection_items.php`
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Processamento / eventos
+
+**Jobs (queue):** `EnviarLinkAprovacaoWhatsappJob`
+
+**Commands (artisan):** `ImportFirebirdMartinhoCommand`, `OficinaAutoCleanupMigratedClientCommand`, `OficinaAutoMigrationReportCommand`, `OficinaAutoSanityCheckCommand`
+
+**Observers:** `ServiceOrderObserver`
+
+## Peças adicionais
+
+- **Policies:** `ServiceOrderPolicy`, `VehiclePolicy`
+- **Seeders:** `OficinaAutoDatabaseSeeder`, `OficinaAutoFsmSeeder`, `RepairSettingsSeeder`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `OficinaAuto` |
+| `module_version` | `0.1.0` |
+| `cnaes` | `[array(3 itens)]` |
+| `cnae_principal` | `4520-0/01` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `Repair` | 2 |
+| `Jana` | 1 |
+| `Whatsapp` | 1 |
+
+## Integridade do banco
+
+**Unique indexes:** 4
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec OficinaAuto`

--- a/memory/modulos/PaymentGateway.md
+++ b/memory/modulos/PaymentGateway.md
@@ -1,0 +1,148 @@
+# Módulo: PaymentGateway
+
+> **Camada técnica de cobrança BR — drivers Inter/C6/Asaas/Pix Automático BCB, webhooks, CNAB, credenciais. Consumida por Sell, RecurringBilling, NFSe, Superadmin.**
+
+- **Alias:** `paymentgateway`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/PaymentGateway`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\PaymentGateway\Providers\PaymentGatewayServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- ℹ️ Módulo sem views (provável API-only ou service)
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- 🟡 22 rotas — escopo médio
+- ✅ Tem testes (40)
+- ⚙️ Processamento assíncrono: 8 peça(s) (jobs/events/listeners)
+- 🔗 Acoplamento: depende de 2 outro(s) módulo(s)
+
+- **Prioridade sugerida de migração:** média
+- **Risco estimado:** médio
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 22 |
+| Controllers | 12 |
+| Entities (Models) | 0 |
+| Services | 21 |
+| FormRequests | 0 |
+| Middleware | 0 |
+| Views Blade | 0 |
+| Migrations | 9 |
+| Arquivos de lang | 1 |
+| Testes | 40 |
+
+## Rotas
+
+### `web.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+| `GET` | `payment-gateways` | `[PaymentGatewaysController::class, 'index']` |
+| `POST` | `payment-gateways` | `[PaymentGatewaysController::class, 'store']` |
+| `PUT` | `payment-gateways/{credentialId}` | `[PaymentGatewaysController::class, 'update']` |
+| `DELETE` | `payment-gateways/{credentialId}` | `[PaymentGatewaysController::class, 'destroy']` |
+| `POST` | `payment-gateways/health-check` | `[PaymentGatewaysController::class, 'healthCheck']` |
+| `POST` | `payment-gateways/{credentialId}/health-check` | `[PaymentGatewaysController::class, 'healthCheck']` |
+| `POST` | `payment-gateways/{credentialId}/toggle` | `[PaymentGatewaysController::class, 'toggle']` |
+| `GET` | `payment-gateways/{credentialId}/history` | `[PaymentGatewaysController::class, 'history']` |
+| `GET` | `payment-gateways/{credentialId}/webhook-events` | `[PaymentGatewaysController::class, 'webhookEvents']` |
+| `GET` | `payment-gateways/{credentialId}/quota` | `[PaymentGatewaysController::class, 'quota']` |
+| `GET` | `payment-gateways/{credentialId}/cnab-retorno` | `[PaymentGatewaysCnabRetornoController::class, 'index']` |
+| `POST` | `payment-gateways/{credentialId}/cnab-retorno` | `[PaymentGatewaysCnabRetornoController::class, 'store']` |
+| `POST` | `inter/{businessId}` | `[InterWebhookController::class, 'handle']` |
+| `POST` | `c6/{businessId}` | `[C6WebhookController::class, 'handle']` |
+| `POST` | `asaas/{businessId}` | `[AsaasWebhookController::class, 'handle']` |
+| `POST` | `bcb-pix/{businessId}` | `[BcbPixWebhookController::class, 'handle']` |
+| `POST` | `pagarme/{businessId}` | `[PagarmeWebhookController::class, 'handle']` |
+| `POST` | `sicoob-api/{businessId}` | `[SicoobApiWebhookController::class, 'handle']` |
+| `POST` | `webhooks/inter/{credentialId}` | `[InterPixWebhookController::class, 'handle']` |
+
+## Controllers
+
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`InstallController`** — 0 ação(ões): 
+- **`PaymentGatewaysCnabRetornoController`** — 2 ação(ões): index, store
+- **`PaymentGatewaysController`** — 9 ação(ões): index, healthCheck, store, update, destroy, history, webhookEvents, quota +1
+- **`AsaasWebhookController`** — 1 ação(ões): handle
+- **`BcbPixWebhookController`** — 1 ação(ões): handle
+- **`C6WebhookController`** — 1 ação(ões): handle
+- **`InterPixWebhookController`** — 1 ação(ões): handle
+- **`InterWebhookController`** — 1 ação(ões): handle
+- **`PagarmeWebhookController`** — 1 ação(ões): handle
+- **`SicoobApiWebhookController`** — 1 ação(ões): handle
+- **`WebhookProcessor`** — 2 ação(ões): handle, validateSignature
+
+## Migrations
+
+- `2026_05_19_120000_create_payment_gateway_credentials_table.php`
+- `2026_05_19_120001_create_cobrancas_table.php`
+- `2026_05_19_120002_create_gateway_webhook_events_table.php`
+- `2026_05_19_130000_add_payment_gateway_credential_id_to_fin_contas_bancarias.php`
+- `2026_05_20_120000_create_inter_webhook_log_table.php`
+- `2026_05_26_120000_expand_payment_gateway_credentials_gateway_key_for_cnab.php`
+- `2026_05_26_120100_create_cnab_retorno_uploads_table.php`
+- `2026_05_27_120000_add_sicoob_api_to_payment_gateway_credentials.php`
+- `2026_05_27_140000_drop_mtls_columns_sicoob_reusa_nfecertificado.php`
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Processamento / eventos
+
+**Jobs (queue):** `CnabRetornoProcessor`, `ProcessarWebhookPixInterJob`, `RetryOrphanWebhookJob`
+
+**Commands (artisan):** `EmitTrialExpiredCobrancasCommand`, `MigrateCredentialsCommand`, `RegisterPermissionsCommand`, `RetryOrphanWebhookCommand`, `RewrapCredentialsCommand`
+
+**Events:** `CobrancaCancelada`, `CobrancaEmitida`, `CobrancaErro`, `CobrancaPaga`, `CobrancaVencida`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `PaymentGateway` |
+| `module_version` | `0.1.0` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `Financeiro` | 1 |
+| `NfeBrasil` | 1 |
+
+## Integridade do banco
+
+**Unique indexes:** 4
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec PaymentGateway`

--- a/memory/modulos/Ponto.md
+++ b/memory/modulos/Ponto.md
@@ -1,0 +1,261 @@
+# Módulo: Ponto
+
+> **Módulo de Ponto Eletrônico conforme Portaria MTP 671/2021 — WR2 Sistemas (ex-PontoWr2, renomeado Fase 3.7 PR-2). Estende UltimatePOS 6 + Essentials & HRM. URL/permissions/config keys mantêm prefixo legacy `pontowr2.*` por compatibilidade.**
+
+- **Alias:** `ponto`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/Ponto`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\Ponto\Providers\PontoServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- 🟡 41 rotas — escopo médio
+- ✅ Tem testes (26)
+- 🔐 Registra 5 permissão(ões) Spatie
+- ⚙️ Processamento assíncrono: 2 peça(s) (jobs/events/listeners)
+- 🔗 Acoplamento: depende de 3 outro(s) módulo(s)
+- 🗃️ 26 foreign keys — alto acoplamento em dados
+- 🗄️ Tem triggers MySQL (2) — append-only / imutabilidade
+
+- **Prioridade sugerida de migração:** baixa (grande, fazer por último ou dividir)
+- **Risco estimado:** alto
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 41 |
+| Controllers | 13 |
+| Entities (Models) | 10 |
+| Services | 10 |
+| FormRequests | 7 |
+| Middleware | 1 |
+| Views Blade | 26 |
+| Migrations | 8 |
+| Arquivos de lang | 2 |
+| Testes | 26 |
+
+## Rotas
+
+### `routes.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `/` | `'DashboardController@index'` |
+| `GET` | `/react` | `function (` |
+| `GET` | `/espelho` | `'EspelhoController@index'` |
+| `GET` | `/espelho/{colaborador}` | `'EspelhoController@show'` |
+| `GET` | `/espelho/{colaborador}/imprimir` | `'EspelhoController@imprimir'` |
+| `GET` | `/aprovacoes` | `'AprovacaoController@index'` |
+| `POST` | `/aprovacoes/{id}/aprovar` | `'AprovacaoController@aprovar'` |
+| `POST` | `/aprovacoes/{id}/rejeitar` | `'AprovacaoController@rejeitar'` |
+| `POST` | `/aprovacoes/lote` | `'AprovacaoController@aprovarEmLote'` |
+| `POST` | `/intercorrencias/{id}/submeter` | `'IntercorrenciaController@submeter'` |
+| `POST` | `/intercorrencias/{id}/cancelar` | `'IntercorrenciaController@cancelar'` |
+| `POST` | `/intercorrencias-ai/classify` | `'IntercorrenciaController@aiClassify'` |
+| `GET` | `/banco-horas` | `'BancoHorasController@index'` |
+| `GET` | `/banco-horas/{colaborador}` | `'BancoHorasController@show'` |
+| `POST` | `/banco-horas/{colaborador}/ajuste` | `'BancoHorasController@ajustarManual'` |
+| `GET` | `/importacoes` | `'ImportacaoController@index'` |
+| `GET` | `/importacoes/novo` | `'ImportacaoController@create'` |
+| `POST` | `/importacoes` | `'ImportacaoController@store'` |
+| `GET` | `/importacoes/{id}` | `'ImportacaoController@show'` |
+| `GET` | `/importacoes/{id}/original` | `'ImportacaoController@baixarOriginal'` |
+| `GET` | `/relatorios` | `'RelatorioController@index'` |
+| `GET` | `/relatorios/{chave}` | `'RelatorioController@gerar'` |
+| `GET` | `/colaboradores` | `'ColaboradorController@index'` |
+| `GET` | `/colaboradores/{id}/editar` | `'ColaboradorController@edit'` |
+| `PUT` | `/colaboradores/{id}` | `'ColaboradorController@update'` |
+| `GET` | `/configuracoes` | `'ConfiguracaoController@index'` |
+| `GET` | `/configuracoes/reps` | `'ConfiguracaoController@reps'` |
+| `POST` | `/configuracoes/reps` | `'ConfiguracaoController@storeRep'` |
+| `POST` | `/marcar` | `function (` |
+| `GET` | `/marcacoes/hoje` | `function (` |
+| `GET` | `/saldo` | `function (` |
+| `GET` | `/intercorrencias` | `function (` |
+| `POST` | `/intercorrencias` | `function (` |
+| `GET` | `/escala/hoje` | `function (` |
+| `GET` | `/dashboard/kpis` | `function (` |
+| `GET` | `/` | `'InstallController@index'` |
+| `POST` | `/` | `'InstallController@install'` |
+| `GET` | `/uninstall` | `'InstallController@uninstall'` |
+| `GET` | `/update` | `'InstallController@update'` |
+| `RESOURCE` | `/intercorrencias` | `'IntercorrenciaController'` |
+
+_... +1 rotas_
+
+## Controllers
+
+- **`MobileMarcacaoController`** — 2 ação(ões): registrar, pendentesValidacao
+- **`AprovacaoController`** — 4 ação(ões): index, aprovar, rejeitar, aprovarEmLote
+- **`BancoHorasController`** — 3 ação(ões): index, show, ajustarManual
+- **`ColaboradorController`** — 3 ação(ões): index, edit, update
+- **`ConfiguracaoController`** — 3 ação(ões): index, reps, storeRep
+- **`DashboardController`** — 1 ação(ões): index
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`EscalaController`** — 6 ação(ões): index, create, store, edit, update, destroy
+- **`EspelhoController`** — 3 ação(ões): index, show, imprimir
+- **`ImportacaoController`** — 5 ação(ões): index, create, store, show, baixarOriginal
+- **`InstallController`** — 0 ação(ões): 
+- **`IntercorrenciaController`** — 9 ação(ões): index, create, store, show, edit, update, submeter, cancelar +1
+- **`RelatorioController`** — 2 ação(ões): index, gerar
+
+## Entities (Models Eloquent)
+
+- **`ApuracaoDia`** (tabela: `ponto_apuracao_dia`)
+- **`BancoHorasMovimento`** (tabela: `ponto_banco_horas_movimentos`)
+- **`BancoHorasSaldo`** (tabela: `ponto_banco_horas_saldo`)
+- **`Colaborador`** (tabela: `ponto_colaborador_config`)
+- **`Escala`** (tabela: `ponto_escalas`)
+- **`EscalaTurno`** (tabela: `ponto_escala_turnos`)
+- **`Importacao`** (tabela: `ponto_importacoes`)
+- **`Intercorrencia`** (tabela: `ponto_intercorrencias`)
+- **`Marcacao`** (tabela: `ponto_marcacoes`)
+- **`Rep`** (tabela: `ponto_reps`)
+
+## Migrations
+
+- `2026_04_18_000001_create_ponto_colaborador_config_table.php`
+- `2026_04_18_000002_create_ponto_reps_table.php`
+- `2026_04_18_000003_create_ponto_escalas_table.php`
+- `2026_04_18_000004_create_ponto_marcacoes_table.php`
+- `2026_04_18_000005_create_ponto_intercorrencias_table.php`
+- `2026_04_18_000006_create_ponto_apuracao_dia_table.php`
+- `2026_04_18_000007_create_ponto_banco_horas_table.php`
+- `2026_04_18_000008_create_ponto_importacoes_table.php`
+
+## Views (Blade)
+
+**Total:** 26 arquivos
+
+**Pastas principais:**
+
+- `intercorrencias/` — 5 arquivo(s)
+- `escalas/` — 4 arquivo(s)
+- `importacoes/` — 3 arquivo(s)
+- `aprovacoes/` — 2 arquivo(s)
+- `banco-horas/` — 2 arquivo(s)
+- `colaboradores/` — 2 arquivo(s)
+- `configuracoes/` — 2 arquivo(s)
+- `espelho/` — 2 arquivo(s)
+- `dashboard/` — 1 arquivo(s)
+- `layouts/` — 1 arquivo(s)
+- `relatorios/` — 1 arquivo(s)
+- `reports/` — 1 arquivo(s)
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Permissões
+
+**Registradas pelo módulo** (via `user_permissions()`):
+
+- `ponto.access`
+- `ponto.colaboradores.manage`
+- `ponto.aprovacoes.manage`
+- `ponto.relatorios.view`
+- `ponto.configuracoes.manage`
+
+## Processamento / eventos
+
+**Jobs (queue):** `ProcessarImportacaoAfdJob`, `ReapurarDiaJob`
+
+**Commands (artisan):** `AfdInspecionarCommand`, `ImportAfdCommand`, `PontoHealthCommand`
+
+## Peças adicionais
+
+- **Factories:** 5 (`ColaboradorFactory`, `EscalaFactory`, `EscalaTurnoFactory`, `IntercorrenciaFactory`, `MarcacaoFactory`)
+- **Seeders:** `DevPontoSeeder`, `PontoWr2DatabaseSeeder`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `PontoWr2` |
+| `module_label` | `Ponto WR2` |
+| `module_description` | `Ponto Eletrônico · Portaria 671/2021` |
+| `module_icon` | `fa fa-clock-o` |
+| `module_version` | `0.1` |
+| `pid` | `` |
+| `clt` | `[array(9 itens)]` |
+| `banco_horas` | `[array(7 itens)]` |
+| `rep` | `[array(5 itens)]` |
+| `afd` | `[array(4 itens)]` |
+| `marcacao` | `[array(3 itens)]` |
+| `esocial` | `[array(5 itens)]` |
+| `ultimatepos` | `[array(4 itens)]` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `Jana` | 3 |
+| `ProjectMgmt` | 1 |
+| `Repair` | 1 |
+
+## Integridade do banco
+
+**Foreign Keys** (26):
+
+- `user_id` → `users.id`
+- `business_id` → `business.id`
+- `business_id` → `business.id`
+- `business_id` → `business.id`
+- `escala_id` → `ponto_escalas.id`
+- `escala_atual_id` → `ponto_escalas.id`
+- `business_id` → `business.id`
+- `colaborador_config_id` → `ponto_colaborador_config.id`
+- `rep_id` → `ponto_reps.id`
+- `usuario_criador_id` → `users.id`
+- `business_id` → `business.id`
+- `colaborador_config_id` → `ponto_colaborador_config.id`
+- `solicitante_id` → `users.id`
+- `aprovador_id` → `users.id`
+- `business_id` → `business.id`
+- `colaborador_config_id` → `ponto_colaborador_config.id`
+- `escala_id` → `ponto_escalas.id`
+- `business_id` → `business.id`
+- `colaborador_config_id` → `ponto_colaborador_config.id`
+- `business_id` → `business.id`
+- _... +6 FKs_
+
+**Triggers MySQL** (2): `trg_ponto_marcacoes_no_update`, `trg_ponto_marcacoes_no_delete`
+
+**Unique indexes:** 7
+
+## Dependências Composer
+
+- `php` ^8.1
+- `spatie/laravel-permission` ^6.0
+- `spatie/laravel-activitylog` ^4.0
+- `maatwebsite/excel` ^3.1
+- `barryvdh/laravel-dompdf` ^2.0
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec Ponto`

--- a/memory/modulos/ProductCatalogue.md
+++ b/memory/modulos/ProductCatalogue.md
@@ -11,7 +11,10 @@
 
 ## Sinais detectados
 
-- 🔗 Registra 2 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- ✅ Tem testes (7)
+- 🔐 Registra 1 permissão(ões) Spatie
+- 🔗 Acoplamento: depende de 1 outro(s) módulo(s)
 
 - **Prioridade sugerida de migração:** média
 - **Risco estimado:** médio
@@ -23,13 +26,13 @@
 | Rotas (web+api) | 7 |
 | Controllers | 3 |
 | Entities (Models) | 0 |
-| Services | 0 |
-| FormRequests | 0 |
+| Services | 2 |
+| FormRequests | 5 |
 | Middleware | 0 |
 | Views Blade | 8 |
 | Migrations | 1 |
 | Arquivos de lang | 1 |
-| Testes | 0 |
+| Testes | 7 |
 
 ## Rotas
 
@@ -51,8 +54,8 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 ## Controllers
 
-- **`DataController`** — 2 ação(ões): superadmin_package, modifyAdminMenu
-- **`InstallController`** — 4 ação(ões): index, install, uninstall, update
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`InstallController`** — 0 ação(ões): 
 - **`ProductCatalogueController`** — 3 ação(ões): index, show, generateQr
 
 ## Migrations
@@ -73,6 +76,17 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 - **`modifyAdminMenu()`** — Injeta itens na sidebar admin
 - **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Permissões
+
+**Registradas pelo módulo** (via `user_permissions()`):
+
+- `productcatalogue.access`
+
+## Processamento / eventos
+
+**Commands (artisan):** `ProductCatalogueHealthCommand`
 
 ## Peças adicionais
 
@@ -85,6 +99,14 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 | `name` | `ProductCatalogue` |
 | `module_version` | `1.0` |
 | `pid` | `8` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `Jana` | 1 |
 
 ## Assets (JS / CSS)
 
@@ -112,84 +134,11 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ✅ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ✅ |
 
 ## Diferenças vs versões anteriores
-
-### vs `origin/3.7-com-nfe`
-
-- **Arquivos alterados:** 39
-- **Linhas +:** 1315 **-:** 0
-- **Primeiros arquivos alterados:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2020_09_29_184909_add_product_catalogue_version.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/ProductCatalogueDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/DataController.php`
-  - `Http/Controllers/InstallController.php`
-  - `Http/Controllers/ProductCatalogueController.php`
-  - `Http/Middleware/.gitkeep`
-  - `Http/Requests/.gitkeep`
-  - `Providers/.gitkeep`
-  - `Providers/ProductCatalogueServiceProvider.php`
-  - `Providers/RouteServiceProvider.php`
-  - `Resources/assets/.gitkeep`
-  - `Resources/assets/plugins/easy.qrcode.min.js`
-  - `Resources/assets/sass/app.scss`
-  - `Resources/lang/.gitkeep`
-  - `Resources/lang/en/lang.php`
-  - `Resources/views/.gitkeep`
-  - `Resources/views/catalogue/generate_qr.blade.php`
-  - `Resources/views/catalogue/index.blade.php`
-  - `Resources/views/catalogue/partials/combo_product_details.blade.php`
-  - `Resources/views/catalogue/partials/single_product_details.blade.php`
-  - `Resources/views/catalogue/partials/variable_product_details.blade.php`
-  - `Resources/views/catalogue/show.blade.php`
-
-### vs `main-wip-2026-04-22` (backup das customizações)
-
-- **Arquivos alterados:** 39
-- **Linhas +:** 1315 **-:** 0
-- ⚠️ **Arquivos que podem conter customizações suas não trazidas para 6.7-react:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2020_09_29_184909_add_product_catalogue_version.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/ProductCatalogueDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/DataController.php`
-  - `Http/Controllers/InstallController.php`
-  - `Http/Controllers/ProductCatalogueController.php`
-  - `Http/Middleware/.gitkeep`
-  - `Http/Requests/.gitkeep`
-  - `Providers/.gitkeep`
-  - `Providers/ProductCatalogueServiceProvider.php`
-  - `Providers/RouteServiceProvider.php`
-  - `Resources/assets/.gitkeep`
-  - `Resources/assets/plugins/easy.qrcode.min.js`
-  - `Resources/assets/sass/app.scss`
-  - `Resources/lang/.gitkeep`
-  - `Resources/lang/en/lang.php`
-  - `Resources/views/.gitkeep`
-  - `Resources/views/catalogue/generate_qr.blade.php`
-  - `Resources/views/catalogue/index.blade.php`
-  - `Resources/views/catalogue/partials/combo_product_details.blade.php`
-  - `Resources/views/catalogue/partials/single_product_details.blade.php`
-  - `Resources/views/catalogue/partials/variable_product_details.blade.php`
-  - `Resources/views/catalogue/show.blade.php`
 
 ## Gaps & próximos passos (preencher manualmente)
 
@@ -199,5 +148,5 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:14.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec ProductCatalogue`

--- a/memory/modulos/Project.md
+++ b/memory/modulos/Project.md
@@ -1,279 +1,46 @@
 # Módulo: Project
 
-> **Project Management Module**
+> **—**
 
-- **Alias:** `project`
+- **Alias:** `—`
 - **Versão:** ?
 - **Path:** `D:\oimpresso.com\Modules/Project`
-- **Status:** 🟢 ativo
-- **Providers:** Modules\Project\Providers\ProjectServiceProvider
+- **Status:** ⚪ inativo
+- **Providers:** —
 - **Requires (módulo.json):** nenhum
 
 ## Sinais detectados
 
-- 🔗 Registra 4 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions, addTaxonomies
-- 🔐 Registra 3 permissão(ões) Spatie
+- ❌ NÃO EXISTE na branch atual (só em branches antigas — migração perdida?)
+- ⚪ Inativo em `modules_statuses.json`
 
-- **Prioridade sugerida de migração:** baixa (grande, fazer por último ou dividir)
-- **Risco estimado:** alto
+- **Prioridade sugerida de migração:** baixa (desativado)
+- **Risco estimado:** baixo
 
 ## Escopo
 
 | Peça | Qtde |
 |---|---:|
-| Rotas (web+api) | 20 |
-| Controllers | 9 |
-| Entities (Models) | 10 |
+| Rotas (web+api) | 0 |
+| Controllers | 0 |
+| Entities (Models) | 0 |
 | Services | 0 |
 | FormRequests | 0 |
 | Middleware | 0 |
-| Views Blade | 43 |
-| Migrations | 11 |
-| Arquivos de lang | 16 |
+| Views Blade | 0 |
+| Migrations | 0 |
+| Arquivos de lang | 0 |
 | Testes | 0 |
-
-## Rotas
-
-### `web.php`
-
-| Método | URI | Controller |
-|---|---|---|
-| `PUT` | `project/{id}/post-status` | `[Modules\Project\Http\Controllers\ProjectController::class, 'postProjectStatus']` |
-| `PUT` | `project-settings` | `[Modules\Project\Http\Controllers\ProjectController::class, 'postSettings']` |
-| `GET` | `project-task-get-status` | `[Modules\Project\Http\Controllers\TaskController::class, 'getTaskStatus']` |
-| `PUT` | `project-task/{id}/post-status` | `[Modules\Project\Http\Controllers\TaskController::class, 'postTaskStatus']` |
-| `PUT` | `project-task/{id}/post-description` | `[Modules\Project\Http\Controllers\TaskController::class, 'postTaskDescription']` |
-| `POST` | `post-media-dropzone-upload` | `[Modules\Project\Http\Controllers\TaskCommentController::class, 'postMedia']` |
-| `GET` | `project-invoice-tax-report` | `[Modules\Project\Http\Controllers\InvoiceController::class, 'getProjectInvoiceTaxReport']` |
-| `GET` | `project-employee-timelog-reports` | `[Modules\Project\Http\Controllers\ReportController::class, 'getEmployeeTimeLogReport']` |
-| `GET` | `project-timelog-reports` | `[Modules\Project\Http\Controllers\ReportController::class, 'getProjectTimeLogReport']` |
-| `GET` | `project-reports` | `[Modules\Project\Http\Controllers\ReportController::class, 'index']` |
-| `GET` | `/install` | `[Modules\Project\Http\Controllers\InstallController::class, 'index']` |
-| `POST` | `/install` | `[Modules\Project\Http\Controllers\InstallController::class, 'install']` |
-| `GET` | `/install/uninstall` | `[Modules\Project\Http\Controllers\InstallController::class, 'uninstall']` |
-| `GET` | `/install/update` | `[Modules\Project\Http\Controllers\InstallController::class, 'update']` |
-| `RESOURCE` | `project` | `'Modules\Project\Http\Controllers\ProjectController'` |
-| `RESOURCE` | `project-task` | `'Modules\Project\Http\Controllers\TaskController'` |
-| `RESOURCE` | `project-task-comment` | `'Modules\Project\Http\Controllers\TaskCommentController'` |
-| `RESOURCE` | `project-task-time-logs` | `'Modules\Project\Http\Controllers\ProjectTimeLogController'` |
-| `RESOURCE` | `activities` | `'Modules\Project\Http\Controllers\ActivityController'` |
-| `RESOURCE` | `invoice` | `'Modules\Project\Http\Controllers\InvoiceController'` |
-
-### `api.php`
-
-_(arquivo existe mas parse não identificou rotas explícitas — pode ter grupos complexos)_
-
-## Controllers
-
-- **`ActivityController`** — 7 ação(ões): index, create, store, show, edit, update, destroy
-- **`DataController`** — 9 ação(ões): parse_notification, modifyAdminMenu, grossProfit, user_permissions, superadmin_package, addDocumentAndNotes, addTaxonomies, getTaxReportViewTabs +1
-- **`InstallController`** — 4 ação(ões): index, install, uninstall, update
-- **`InvoiceController`** — 8 ação(ões): index, create, store, show, edit, update, destroy, getProjectInvoiceTaxReport
-- **`ProjectController`** — 9 ação(ões): index, create, store, show, edit, update, destroy, postSettings +1
-- **`ProjectTimeLogController`** — 7 ação(ões): index, create, store, show, edit, update, destroy
-- **`ReportController`** — 3 ação(ões): index, getEmployeeTimeLogReport, getProjectTimeLogReport
-- **`TaskCommentController`** — 8 ação(ões): index, create, store, show, edit, update, destroy, postMedia
-- **`TaskController`** — 10 ação(ões): index, create, store, show, edit, update, destroy, getTaskStatus +2
-
-## Entities (Models Eloquent)
-
-- **`InvoiceLine`** (tabela: `pjt_invoice_lines`)
-- **`Project`** (tabela: `pjt_projects`)
-- **`ProjectCategory`** (tabela: `categorizables`)
-- **`ProjectMember`** (tabela: `pjt_project_members`)
-- **`ProjectTask`** (tabela: `pjt_project_tasks`)
-- **`ProjectTaskComment`** (tabela: `pjt_project_task_comments`)
-- **`ProjectTaskMember`** (tabela: `pjt_project_task_members`)
-- **`ProjectTimeLog`** (tabela: `pjt_project_time_logs`)
-- **`ProjectTransaction`** (tabela: `—`)
-- **`ProjectUser`** (tabela: `users`)
-
-## Migrations
-
-- `2019_11_12_163135_create_projects_table.php`
-- `2019_11_12_164431_create_project_members_table.php`
-- `2019_11_14_112230_create_project_tasks_table.php`
-- `2019_11_14_112258_create_project_task_members_table.php`
-- `2019_11_18_154617_create_project_task_comments_table.php`
-- `2019_11_19_134807_create_project_time_logs_table.php`
-- `2019_12_11_102549_add_more_fields_in_transactions_table.php`
-- `2019_12_11_102735_create_invoice_lines_table.php`
-- `2020_01_07_172852_add_project_permissions.php`
-- `2020_01_08_115422_add_project_module_version_to_system_table.php`
-- `2020_07_10_114514_set_location_id_on_existing_invoice.php`
-
-## Views (Blade)
-
-**Total:** 43 arquivos
-
-**Pastas principais:**
-
-- `task/` — 9 arquivo(s)
-- `invoice/` — 6 arquivo(s)
-- `project/` — 6 arquivo(s)
-- `reports/` — 5 arquivo(s)
-- `activity/` — 4 arquivo(s)
-- `layouts/` — 3 arquivo(s)
-- `tax_report/` — 3 arquivo(s)
-- `time_logs/` — 3 arquivo(s)
-- `avatar/` — 1 arquivo(s)
-- `D:/` — 1 arquivo(s)
-- `my_task/` — 1 arquivo(s)
-- `settings/` — 1 arquivo(s)
-
-## Hooks UltimatePOS registrados
-
-- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
-- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
-- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
-- **`addTaxonomies()`** — Registra taxonomias/categorias customizadas
-
-## Permissões
-
-**Registradas pelo módulo** (via `user_permissions()`):
-
-- `project.create_project`
-- `project.edit_project`
-- `project.delete_project`
-
-**Usadas nas views** (`@can`/`@cannot`):
-
-- `project.create_project`
-- `project.edit_project`
-- `project.delete_project`
-
-## Peças adicionais
-
-- **Notifications:** `NewCommentOnTaskNotification`, `NewProjectAssignedNotification`, `NewTaskAssignedNotification`
-- **Seeders:** `ProjectDatabaseSeeder`
-
-## Configuração (`Config/config.php`)
-
-| Chave | Valor |
-|---|---|
-| `name` | `Project` |
-| `module_version` | `2.1` |
-| `pid` | `5` |
-
-## Integridade do banco
-
-**Foreign Keys** (8):
-
-- `project_id` → `pjt_projects.id`
-- `project_id` → `pjt_projects.id`
-- `project_task_id` → `pjt_project_tasks.id`
-- `project_task_id` → `pjt_project_tasks.id`
-- `project_id` → `pjt_projects.id`
-- `project_task_id` → `pjt_project_tasks.id`
-- `pjt_project_id` → `pjt_projects.id`
-- `transaction_id` → `transactions.id`
-
-## Assets (JS / CSS)
-
-| Tipo | Qtde |
-|---|---:|
-| JavaScript (.js/.mjs) | 1 |
-| TypeScript (.ts) | 0 |
-| Vue SFC (.vue) | 0 |
-| CSS/SCSS | 1 |
-| Imagens | 0 |
-
-- Build: **Laravel Mix** (webpack.mix.js presente)
-- `package.json` presente
-- **Deps JS:** `cross-env`, `laravel-mix`, `laravel-mix-merge-manifest`
-
-**Frameworks/libs detectados no JS:** jQuery, Bootstrap, DataTables, Select2, SweetAlert, Toastr, TinyMCE
-
-**Arquivos JS** (primeiros 1):
-
-- `js\project.js` (43.2 KB)
-
-**Arquivos CSS/SCSS** (primeiros 1):
-
-- `sass\project.css` (562 B)
 
 ## Presença em branches
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ✅ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ❌ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ✅ |
 
 ## Diferenças vs versões anteriores
-
-### vs `origin/3.7-com-nfe`
-
-- **Arquivos alterados:** 119
-- **Linhas +:** 11834 **-:** 0
-- **Primeiros arquivos alterados:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2019_11_12_163135_create_projects_table.php`
-  - `Database/Migrations/2019_11_12_164431_create_project_members_table.php`
-  - `Database/Migrations/2019_11_14_112230_create_project_tasks_table.php`
-  - `Database/Migrations/2019_11_14_112258_create_project_task_members_table.php`
-  - `Database/Migrations/2019_11_18_154617_create_project_task_comments_table.php`
-  - `Database/Migrations/2019_11_19_134807_create_project_time_logs_table.php`
-  - `Database/Migrations/2019_12_11_102549_add_more_fields_in_transactions_table.php`
-  - `Database/Migrations/2019_12_11_102735_create_invoice_lines_table.php`
-  - `Database/Migrations/2020_01_07_172852_add_project_permissions.php`
-  - `Database/Migrations/2020_01_08_115422_add_project_module_version_to_system_table.php`
-  - `Database/Migrations/2020_07_10_114514_set_location_id_on_existing_invoice.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/ProjectDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Entities/InvoiceLine.php`
-  - `Entities/Project.php`
-  - `Entities/ProjectCategory.php`
-  - `Entities/ProjectMember.php`
-  - `Entities/ProjectTask.php`
-  - `Entities/ProjectTaskComment.php`
-  - `Entities/ProjectTaskMember.php`
-  - `Entities/ProjectTimeLog.php`
-  - `Entities/ProjectTransaction.php`
-  - `Entities/ProjectUser.php`
-  - `Http/Controllers/.gitkeep`
-
-### vs `main-wip-2026-04-22` (backup das customizações)
-
-- **Arquivos alterados:** 119
-- **Linhas +:** 11834 **-:** 0
-- ⚠️ **Arquivos que podem conter customizações suas não trazidas para 6.7-react:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2019_11_12_163135_create_projects_table.php`
-  - `Database/Migrations/2019_11_12_164431_create_project_members_table.php`
-  - `Database/Migrations/2019_11_14_112230_create_project_tasks_table.php`
-  - `Database/Migrations/2019_11_14_112258_create_project_task_members_table.php`
-  - `Database/Migrations/2019_11_18_154617_create_project_task_comments_table.php`
-  - `Database/Migrations/2019_11_19_134807_create_project_time_logs_table.php`
-  - `Database/Migrations/2019_12_11_102549_add_more_fields_in_transactions_table.php`
-  - `Database/Migrations/2019_12_11_102735_create_invoice_lines_table.php`
-  - `Database/Migrations/2020_01_07_172852_add_project_permissions.php`
-  - `Database/Migrations/2020_01_08_115422_add_project_module_version_to_system_table.php`
-  - `Database/Migrations/2020_07_10_114514_set_location_id_on_existing_invoice.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/ProjectDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Entities/InvoiceLine.php`
-  - `Entities/Project.php`
-  - `Entities/ProjectCategory.php`
-  - `Entities/ProjectMember.php`
-  - `Entities/ProjectTask.php`
-  - `Entities/ProjectTaskComment.php`
-  - `Entities/ProjectTaskMember.php`
-  - `Entities/ProjectTimeLog.php`
-  - `Entities/ProjectTransaction.php`
-  - `Entities/ProjectUser.php`
-  - `Http/Controllers/.gitkeep`
 
 ## Gaps & próximos passos (preencher manualmente)
 
@@ -283,5 +50,5 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:14.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Project`

--- a/memory/modulos/ProjectMgmt.md
+++ b/memory/modulos/ProjectMgmt.md
@@ -1,0 +1,128 @@
+# Módulo: ProjectMgmt
+
+> **Project Management Jira-style — Kanban + Backlog + Roadmap + My Work + Inbox + Triage sobre as tabelas mcp_jira_projects/epics/cycles/tasks. Promovido a módulo próprio em 2026-05-04 (ADR 0070, supersede absorção em TeamMcp).**
+
+- **Alias:** `projectmgmt`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/ProjectMgmt`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\ProjectMgmt\Providers\ProjectMgmtServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- ℹ️ Módulo sem views (provável API-only ou service)
+- ℹ️ Sem migrations próprias (pode depender de tabelas de outros módulos)
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- 🟡 23 rotas — escopo médio
+- ✅ Tem testes (11)
+- 🔗 Acoplamento: depende de 1 outro(s) módulo(s)
+
+- **Prioridade sugerida de migração:** média
+- **Risco estimado:** médio
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 23 |
+| Controllers | 10 |
+| Entities (Models) | 0 |
+| Services | 2 |
+| FormRequests | 9 |
+| Middleware | 0 |
+| Views Blade | 0 |
+| Migrations | 0 |
+| Arquivos de lang | 2 |
+| Testes | 11 |
+
+## Rotas
+
+### `routes.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `/` | `function (` |
+| `GET` | `/board` | `'BoardController@index'` |
+| `PATCH` | `/board/{taskId}/status` | `'BoardController@updateStatus'` |
+| `GET` | `/board/{taskId}/detail` | `'BoardController@show'` |
+| `POST` | `/board/{taskId}/comment` | `'BoardController@addComment'` |
+| `GET` | `/board/users/suggest` | `'BoardController@suggestUsers'` |
+| `POST` | `/board/{taskId}/watch` | `'BoardController@watch'` |
+| `DELETE` | `/board/{taskId}/watch` | `'BoardController@unwatch'` |
+| `POST` | `/board/{taskId}/subtask` | `'BoardController@addSubtask'` |
+| `GET` | `/search` | `'SearchController@index'` |
+| `GET` | `/my-work` | `'MyWorkController@index'` |
+| `POST` | `/my-work/inbox/read-all` | `'MyWorkController@markAllRead'` |
+| `POST` | `/my-work/inbox/{id}/read` | `'MyWorkController@markRead'` |
+| `PATCH` | `/my-work/{taskId}/status` | `'MyWorkController@bumpStatus'` |
+| `GET` | `/backlog` | `'BacklogController@index'` |
+| `POST` | `/backlog/bulk` | `'BacklogController@bulk'` |
+| `GET` | `/roadmap` | `'RoadmapController@index'` |
+| `GET` | `/activity` | `'ActivityController@index'` |
+| `GET` | `/burndown` | `'BurndownController@index'` |
+| `GET` | `/` | `'InstallController@index'` |
+| `POST` | `/` | `'InstallController@install'` |
+| `GET` | `/uninstall` | `'InstallController@uninstall'` |
+| `GET` | `/update` | `'InstallController@update'` |
+
+## Controllers
+
+- **`ActivityController`** — 1 ação(ões): index
+- **`ProjectsController`** — 4 ação(ões): index, show, store, decompose
+- **`BacklogController`** — 2 ação(ões): index, bulk
+- **`BoardController`** — 8 ação(ões): index, updateStatus, show, addComment, suggestUsers, watch, unwatch, addSubtask
+- **`BurndownController`** — 1 ação(ões): index
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`InstallController`** — 0 ação(ões): 
+- **`MyWorkController`** — 4 ação(ões): index, markRead, markAllRead, bumpStatus
+- **`RoadmapController`** — 1 ação(ões): index
+- **`SearchController`** — 1 ação(ões): index
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Processamento / eventos
+
+**Commands (artisan):** `ProjectMgmtHealthCommand`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `ProjectMgmt` |
+| `module_version` | `0.1` |
+| `default_project_key` | `COPI` |
+| `kanban_columns` | `[array(5 itens)]` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `TeamMcp` | 1 |
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec ProjectMgmt`

--- a/memory/modulos/RecurringBilling.md
+++ b/memory/modulos/RecurringBilling.md
@@ -1,0 +1,193 @@
+# Módulo: RecurringBilling
+
+> **Cobrança recorrente brasileira: assinaturas, Pix Automático, smart retries, NFSe automática, régua de inadimplência.**
+
+- **Alias:** `recurringbilling`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/RecurringBilling`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\RecurringBilling\Providers\RecurringBillingServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- 🟡 28 rotas — escopo médio
+- ✅ Tem testes (34)
+- ⚙️ Processamento assíncrono: 8 peça(s) (jobs/events/listeners)
+- 🔗 Acoplamento: depende de 1 outro(s) módulo(s)
+
+- **Prioridade sugerida de migração:** média
+- **Risco estimado:** médio
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 28 |
+| Controllers | 11 |
+| Entities (Models) | 0 |
+| Services | 10 |
+| FormRequests | 7 |
+| Middleware | 0 |
+| Views Blade | 2 |
+| Migrations | 8 |
+| Arquivos de lang | 1 |
+| Testes | 34 |
+
+## Rotas
+
+### `web.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+| `GET` | `/` | `[RecurringBillingController::class, 'index']` |
+| `POST` | `/` | `[RecurringBillingController::class, 'store']` |
+| `POST` | `/{id}/cancelar` | `[RecurringBillingController::class, 'cancelar']` |
+| `POST` | `/{id}/pausar` | `[RecurringBillingController::class, 'pausar']` |
+| `POST` | `/{id}/reativar` | `[RecurringBillingController::class, 'reativar']` |
+| `POST` | `/{subscriptionId}/notes` | `[SubscriptionNoteController::class, 'store']` |
+| `DELETE` | `/{subscriptionId}/notes/{noteId}` | `[SubscriptionNoteController::class, 'destroy']` |
+| `POST` | `/{subscriptionId}/notes/{noteId}/pin` | `[SubscriptionNoteController::class, 'togglePin']` |
+| `POST` | `/{subscriptionId}/favorite` | `[SubscriptionFavoriteController::class, 'toggle']` |
+| `GET` | `/{subscriptionId}/events` | `[SubscriptionEventController::class, 'index']` |
+| `POST` | `/{subscriptionId}/events` | `[SubscriptionEventController::class, 'store']` |
+| `POST` | `/{subscriptionId}/reenviar-nfe` | `[RecurringBillingController::class, 'reenviarNfe']` |
+| `GET` | `/faturas` | `[InvoiceController::class, 'index']` |
+| `GET` | `/configuracoes` | `[ConfiguracoesController::class, 'index']` |
+| `GET` | `/` | `[PlanController::class, 'index']` |
+| `GET` | `/novo` | `[PlanController::class, 'create']` |
+| `POST` | `/` | `[PlanController::class, 'store']` |
+| `GET` | `/{id}/editar` | `[PlanController::class, 'edit']` |
+| `PUT` | `/{id}` | `[PlanController::class, 'update']` |
+| `DELETE` | `/{id}` | `[PlanController::class, 'destroy']` |
+| `GET` | `/recurringbilling/{any}` | `function ($any` |
+| `POST` | `rb-invoices/{invoice}/cancelar` | `[InvoiceController::class, 'cancel']` |
+| `POST` | `/webhooks/inter/pix/{businessId}` | `[InterWebhookController::class, 'handle']` |
+
+### `api.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `recurringbilling` | `fn (Request $request` |
+| `POST` | `webhooks/asaas/{businessId}` | `[\Modules\RecurringBilling\Http\Controllers\AsaasWebhookController::class, 'handle']` |
+
+## Controllers
+
+- **`AsaasWebhookController`** — 1 ação(ões): handle
+- **`ConfiguracoesController`** — 1 ação(ões): index
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`InstallController`** — 0 ação(ões): 
+- **`InterWebhookController`** — 1 ação(ões): handle
+- **`InvoiceController`** — 2 ação(ões): index, cancel
+- **`PlanController`** — 6 ação(ões): index, create, store, edit, update, destroy
+- **`RecurringBillingController`** — 11 ação(ões): index, store, cancelar, pausar, reativar, reenviarNfe, create, show +3
+- **`SubscriptionEventController`** — 2 ação(ões): index, store
+- **`SubscriptionFavoriteController`** — 1 ação(ões): toggle
+- **`SubscriptionNoteController`** — 3 ação(ões): store, destroy, togglePin
+
+## Migrations
+
+- `2026_05_06_000001_create_rb_boleto_credentials_table.php`
+- `2026_05_06_000002_add_conta_bancaria_fk_to_rb_boleto_credentials.php`
+- `2026_05_06_000003_create_pg_webhook_events_table.php`
+- `2026_05_06_001000_create_rb_plans_table.php`
+- `2026_05_06_001001_create_rb_subscriptions_table.php`
+- `2026_05_06_001002_create_rb_invoices_table.php`
+- `2026_05_06_001003_create_rb_charge_attempts_table.php`
+- `2026_05_16_120000_recurring_v975_schema.php`
+
+## Views (Blade)
+
+**Total:** 2 arquivos
+
+**Pastas principais:**
+
+- `D:/` — 1 arquivo(s)
+- `layouts/` — 1 arquivo(s)
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Processamento / eventos
+
+**Jobs (queue):** `CancelarCobrancaAsaasJob`, `ProcessAsaasWebhookJob`, `ProcessInterWebhookJob`, `RefundCobrancaAsaasJob`, `SyncBankBalancesJob`, `SyncBankStatementsJob`
+
+**Commands (artisan):** `BackfillCachedFieldsCommand`, `RecurringHealthCommand`, `SyncBankBalancesCommand`
+
+**Events:** `AssinaturaAtualizada`, `InvoicePaid`
+
+**Observers:** `SubscriptionCachedFieldsObserver`
+
+## Peças adicionais
+
+- **Policies:** `SubscriptionPolicy`
+- **Seeders:** `RecurringBillingDatabaseSeeder`, `RecurringBillingDemoSeeder`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `RecurringBilling` |
+| `module_version` | `0.1.0` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `NfeBrasil` | 1 |
+
+## Integridade do banco
+
+**Unique indexes:** 6
+
+## Assets (JS / CSS)
+
+| Tipo | Qtde |
+|---|---:|
+| JavaScript (.js/.mjs) | 1 |
+| TypeScript (.ts) | 0 |
+| Vue SFC (.vue) | 0 |
+| CSS/SCSS | 1 |
+| Imagens | 0 |
+
+- Build: **Vite** (vite.config.js/ts presente)
+- `package.json` presente
+- **Deps JS:** `axios`, `laravel-vite-plugin`, `sass`, `postcss`, `vite`
+
+**Arquivos JS** (primeiros 1):
+
+- `js\app.js` (0 B)
+
+**Arquivos CSS/SCSS** (primeiros 1):
+
+- `sass\app.scss` (0 B)
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec RecurringBilling`

--- a/memory/modulos/Repair.md
+++ b/memory/modulos/Repair.md
@@ -12,9 +12,12 @@
 ## Sinais detectados
 
 - 🔗 Registra 7 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions, get_pos_screen_view, after_sale_saved, after_product_saved, addTaxonomies
-- 🟡 30 rotas — escopo médio
+- 🟡 35 rotas — escopo médio
 - 🔴 +50 views — trabalho pesado
+- ✅ Tem testes (22)
 - 🔐 Registra 12 permissão(ões) Spatie
+- ⚙️ Processamento assíncrono: 1 peça(s) (jobs/events/listeners)
+- 🔗 Acoplamento: depende de 1 outro(s) módulo(s)
 - 🗃️ 13 foreign keys — alto acoplamento em dados
 
 - **Prioridade sugerida de migração:** baixa (grande, fazer por último ou dividir)
@@ -24,16 +27,16 @@
 
 | Peça | Qtde |
 |---|---:|
-| Rotas (web+api) | 30 |
-| Controllers | 9 |
+| Rotas (web+api) | 35 |
+| Controllers | 11 |
 | Entities (Models) | 3 |
-| Services | 0 |
-| FormRequests | 0 |
+| Services | 1 |
+| FormRequests | 6 |
 | Middleware | 0 |
 | Views Blade | 52 |
-| Migrations | 16 |
+| Migrations | 18 |
 | Arquivos de lang | 16 |
-| Testes | 0 |
+| Testes | 22 |
 
 ## Rotas
 
@@ -65,6 +68,11 @@
 | `POST` | `job-sheet/get-part-row` | `[Modules\Repair\Http\Controllers\JobSheetController::class, 'jobsheetPartRow']` |
 | `POST` | `update-repair-jobsheet-settings` | `[Modules\Repair\Http\Controllers\RepairSettingsController::class, 'updateJobsheetSettings']` |
 | `GET` | `job-sheet/print-label/{id}` | `[Modules\Repair\Http\Controllers\JobSheetController::class, 'printLabel']` |
+| `GET` | `producao-oficina` | `[Modules\Repair\Http\Controllers\ProducaoOficinaController::class, 'index']` |
+| `POST` | `producao-oficina/{id}/move` | `[Modules\Repair\Http\Controllers\ProducaoOficinaController::class, 'move']` |
+| `GET` | `/api/repair/job-sheets/{id}/fsm-actions` | `[Modules\Repair\Http\Controllers\RepairFsmActionController::class, 'actions']` |
+| `POST` | `/repair/job-sheets/{id}/fsm-action` | `[Modules\Repair\Http\Controllers\RepairFsmActionController::class, 'execute']` |
+| `POST` | `/repair/job-sheets/{id}/fsm-start-pipeline` | `[Modules\Repair\Http\Controllers\RepairFsmActionController::class, 'startPipeline']` |
 | `RESOURCE` | `/repair` | `'Modules\Repair\Http\Controllers\RepairController'` |
 | `RESOURCE` | `/status` | `'Modules\Repair\Http\Controllers\RepairStatusController'` |
 | `RESOURCE` | `/repair-settings` | `'Modules\Repair\Http\Controllers\RepairSettingsController'` |
@@ -82,9 +90,11 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - **`DashboardController`** — 7 ação(ões): index, create, store, show, edit, update, destroy
 - **`DataController`** — 9 ação(ões): after_sale_saved, user_permissions, superadmin_package, modifyAdminMenu, get_pos_screen_view, addTaxonomies, get_product_screen_top_view, after_product_saved +1
 - **`DeviceModelController`** — 9 ação(ões): index, create, store, show, edit, update, destroy, getDeviceModels +1
-- **`InstallController`** — 4 ação(ões): index, install, uninstall, update
+- **`InstallController`** — 0 ação(ões): 
 - **`JobSheetController`** — 17 ação(ões): index, create, store, show, edit, update, destroy, editStatus +9
+- **`ProducaoOficinaController`** — 2 ação(ões): index, move
 - **`RepairController`** — 9 ação(ões): index, create, show, edit, editRepairStatus, updateRepairStatus, deleteMedia, printLabel +1
+- **`RepairFsmActionController`** — 3 ação(ões): actions, execute, startPipeline
 - **`RepairSettingsController`** — 3 ação(ões): index, store, updateJobsheetSettings
 - **`RepairStatusController`** — 5 ação(ões): index, create, store, edit, update
 
@@ -112,6 +122,8 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - `2020_12_30_101842_add_use_for_repair_column_to_brands_table.php`
 - `2021_02_16_190423_add_repair_module_indexing.php`
 - `2022_12_23_162847_add_repair_jobsheet_settings_column_to_business_table.php`
+- `2026_05_06_180000_add_repair_listing_indexes.php`
+- `2026_05_12_050001_add_current_stage_id_to_job_sheets.php`
 
 ## Views (Blade)
 
@@ -171,6 +183,12 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - `edit_repair_settings`
 - `repair_status.update`
 
+## Processamento / eventos
+
+**Events:** `RepairStatusChanged`
+
+**Observers:** `JobSheetObserver`
+
 ## Peças adicionais
 
 - **Notifications:** `RepairStatusUpdated`
@@ -184,6 +202,14 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 | `module_version` | `2.0` |
 | `pid` | `6` |
 | `enable_repair_check_using_mobile_num` | `true` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `NfeBrasil` | 1 |
 
 ## Integridade do banco
 
@@ -229,84 +255,11 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ✅ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ✅ |
 
 ## Diferenças vs versões anteriores
-
-### vs `origin/3.7-com-nfe`
-
-- **Arquivos alterados:** 124
-- **Linhas +:** 16143 **-:** 0
-- **Primeiros arquivos alterados:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2019_03_07_155813_make_repair_statuses_table.php`
-  - `Database/Migrations/2019_03_08_120634_add_repair_columns_to_transactions_table.php`
-  - `Database/Migrations/2019_03_14_182704_add_repair_permissions.php`
-  - `Database/Migrations/2019_03_29_110241_add_repair_version_column_to_system_table.php`
-  - `Database/Migrations/2019_04_12_113901_add_repair_settings_column_to_business_table.php`
-  - `Database/Migrations/2020_05_05_125008_create_device_models_table.php`
-  - `Database/Migrations/2020_05_06_103135_add_repair_model_id_column_to_products_table.php`
-  - `Database/Migrations/2020_07_11_120308_add_columns_to_repair_statuses_table.php`
-  - `Database/Migrations/2020_07_31_130737_create_job_sheets_table.php`
-  - `Database/Migrations/2020_08_07_124241_add_job_sheet_id_to_transactions_table.php`
-  - `Database/Migrations/2020_08_22_104640_add_email_template_field_to_repair_status_table.php`
-  - `Database/Migrations/2020_10_19_131934_add_job_sheet_custom_fields_to_repair_job_sheets_table.php`
-  - `Database/Migrations/2020_11_25_111050_add_parts_column_to_repair_job_sheets_table.php`
-  - `Database/Migrations/2020_12_30_101842_add_use_for_repair_column_to_brands_table.php`
-  - `Database/Migrations/2021_02_16_190423_add_repair_module_indexing.php`
-  - `Database/Migrations/2022_12_23_162847_add_repair_jobsheet_settings_column_to_business_table.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/RepairDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Entities/DeviceModel.php`
-  - `Entities/JobSheet.php`
-  - `Entities/RepairStatus.php`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/CustomerRepairStatusController.php`
-  - `Http/Controllers/DashboardController.php`
-
-### vs `main-wip-2026-04-22` (backup das customizações)
-
-- **Arquivos alterados:** 124
-- **Linhas +:** 16143 **-:** 0
-- ⚠️ **Arquivos que podem conter customizações suas não trazidas para 6.7-react:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2019_03_07_155813_make_repair_statuses_table.php`
-  - `Database/Migrations/2019_03_08_120634_add_repair_columns_to_transactions_table.php`
-  - `Database/Migrations/2019_03_14_182704_add_repair_permissions.php`
-  - `Database/Migrations/2019_03_29_110241_add_repair_version_column_to_system_table.php`
-  - `Database/Migrations/2019_04_12_113901_add_repair_settings_column_to_business_table.php`
-  - `Database/Migrations/2020_05_05_125008_create_device_models_table.php`
-  - `Database/Migrations/2020_05_06_103135_add_repair_model_id_column_to_products_table.php`
-  - `Database/Migrations/2020_07_11_120308_add_columns_to_repair_statuses_table.php`
-  - `Database/Migrations/2020_07_31_130737_create_job_sheets_table.php`
-  - `Database/Migrations/2020_08_07_124241_add_job_sheet_id_to_transactions_table.php`
-  - `Database/Migrations/2020_08_22_104640_add_email_template_field_to_repair_status_table.php`
-  - `Database/Migrations/2020_10_19_131934_add_job_sheet_custom_fields_to_repair_job_sheets_table.php`
-  - `Database/Migrations/2020_11_25_111050_add_parts_column_to_repair_job_sheets_table.php`
-  - `Database/Migrations/2020_12_30_101842_add_use_for_repair_column_to_brands_table.php`
-  - `Database/Migrations/2021_02_16_190423_add_repair_module_indexing.php`
-  - `Database/Migrations/2022_12_23_162847_add_repair_jobsheet_settings_column_to_business_table.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/RepairDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Entities/DeviceModel.php`
-  - `Entities/JobSheet.php`
-  - `Entities/RepairStatus.php`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/CustomerRepairStatusController.php`
-  - `Http/Controllers/DashboardController.php`
 
 ## Gaps & próximos passos (preencher manualmente)
 
@@ -316,5 +269,5 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:14.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Repair`

--- a/memory/modulos/SRS.md
+++ b/memory/modulos/SRS.md
@@ -1,0 +1,158 @@
+# Módulo: SRS
+
+> **SRS — System Requirements Spec (ex-MemCofre, renomeado Fase 3.7 PR-2). Cofre de documentação viva — ingestão de evidências (screenshots, chat logs, erros) → IA classifica → vira requisitos estruturados em memory/requisitos/. URL/permissions/config keys mantêm prefixo legacy `memcofre.*` por compatibilidade.**
+
+- **Alias:** `srs`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/SRS`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\SRS\Providers\SrsServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- ℹ️ Módulo sem views (provável API-only ou service)
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- ✅ Tem testes (10)
+- 🔐 Registra 2 permissão(ões) Spatie
+- 🔗 Acoplamento: depende de 1 outro(s) módulo(s)
+
+- **Prioridade sugerida de migração:** média
+- **Risco estimado:** médio
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 17 |
+| Controllers | 8 |
+| Entities (Models) | 7 |
+| Services | 6 |
+| FormRequests | 4 |
+| Middleware | 0 |
+| Views Blade | 0 |
+| Migrations | 8 |
+| Arquivos de lang | 1 |
+| Testes | 10 |
+
+## Rotas
+
+### `routes.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `/` | `[\Modules\SRS\Http\Controllers\DashboardController::class, 'index']` |
+| `GET` | `/ingest` | `[\Modules\SRS\Http\Controllers\IngestController::class, 'show']` |
+| `POST` | `/ingest` | `[\Modules\SRS\Http\Controllers\IngestController::class, 'store']` |
+| `GET` | `/inbox` | `[\Modules\SRS\Http\Controllers\InboxController::class, 'index']` |
+| `POST` | `/inbox/{evidence}/triage` | `[\Modules\SRS\Http\Controllers\InboxController::class, 'triage']` |
+| `POST` | `/inbox/{evidence}/apply` | `[\Modules\SRS\Http\Controllers\InboxController::class, 'apply']` |
+| `DELETE` | `/inbox/{evidence}` | `[\Modules\SRS\Http\Controllers\InboxController::class, 'destroy']` |
+| `GET` | `/modulos/{module}` | `[\Modules\SRS\Http\Controllers\ModuloController::class, 'show']` |
+| `GET` | `/memoria` | `[\Modules\SRS\Http\Controllers\MemoriaController::class, 'index']` |
+| `GET` | `/memoria/file` | `[\Modules\SRS\Http\Controllers\MemoriaController::class, 'file']` |
+| `GET` | `/chat` | `[\Modules\SRS\Http\Controllers\ChatController::class, 'index']` |
+| `POST` | `/chat/ask` | `[\Modules\SRS\Http\Controllers\ChatController::class, 'ask']` |
+| `POST` | `/chat/new` | `[\Modules\SRS\Http\Controllers\ChatController::class, 'newSession']` |
+| `GET` | `/` | `[\Modules\SRS\Http\Controllers\InstallController::class, 'index']` |
+| `POST` | `/` | `[\Modules\SRS\Http\Controllers\InstallController::class, 'install']` |
+| `GET` | `/uninstall` | `[\Modules\SRS\Http\Controllers\InstallController::class, 'uninstall']` |
+| `GET` | `/update` | `[\Modules\SRS\Http\Controllers\InstallController::class, 'update']` |
+
+## Controllers
+
+- **`ChatController`** — 3 ação(ões): index, ask, newSession
+- **`DashboardController`** — 1 ação(ões): index
+- **`DataController`** — 3 ação(ões): modifyAdminMenu, superadmin_package, user_permissions
+- **`InboxController`** — 4 ação(ões): index, triage, apply, destroy
+- **`IngestController`** — 2 ação(ões): show, store
+- **`InstallController`** — 0 ação(ões): 
+- **`MemoriaController`** — 2 ação(ões): index, file
+- **`ModuloController`** — 1 ação(ões): show
+
+## Entities (Models Eloquent)
+
+- **`DocChatMessage`** (tabela: `docs_chat_messages`)
+- **`DocEvidence`** (tabela: `docs_evidences`)
+- **`DocLink`** (tabela: `docs_links`)
+- **`DocPage`** (tabela: `docs_pages`)
+- **`DocRequirement`** (tabela: `docs_requirements`)
+- **`DocSource`** (tabela: `docs_sources`)
+- **`DocValidationRun`** (tabela: `docs_validation_runs`)
+
+## Migrations
+
+- `2026_04_22_000001_create_docs_sources_table.php`
+- `2026_04_22_000002_create_docs_evidences_table.php`
+- `2026_04_22_000003_create_docs_requirements_table.php`
+- `2026_04_22_000004_create_docs_links_table.php`
+- `2026_04_22_000005_create_docs_chat_messages_table.php`
+- `2026_04_22_000006_create_docs_pages_table.php`
+- `2026_04_22_000007_create_docs_validation_runs_table.php`
+- `2026_04_22_000008_add_fulltext_index_to_docs_evidences.php`
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Permissões
+
+**Registradas pelo módulo** (via `user_permissions()`):
+
+- `memcofre.access`
+- `memcofre.admin`
+
+## Processamento / eventos
+
+**Commands (artisan):** `AuditModuleCommand`, `GenTestCommand`, `InstallHooksCommand`, `MigrateModuleCommand`, `SrsHealthCommand`, `SyncMemoriesCommand`, `SyncPagesCommand`, `ValidateCommand`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `MemCofre` |
+| `module_label` | `MemCofre` |
+| `module_description` | `Documentação viva · evidências → requisitos` |
+| `module_icon` | `fa fa-folder-open` |
+| `module_version` | `0.1` |
+| `requirements_dir` | `D:\oimpresso.com\memory/requisitos` |
+| `memory` | `[array(3 itens)]` |
+| `source_types` | `[array(6 itens)]` |
+| `evidence_status` | `[array(5 itens)]` |
+| `ai` | `[array(4 itens)]` |
+| `upload` | `[array(4 itens)]` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `Jana` | 1 |
+
+## Integridade do banco
+
+**Unique indexes:** 3
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec SRS`

--- a/memory/modulos/Spreadsheet.md
+++ b/memory/modulos/Spreadsheet.md
@@ -12,6 +12,7 @@
 ## Sinais detectados
 
 - 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- ✅ Tem testes (9)
 - 🔐 Registra 2 permissão(ões) Spatie
 
 - **Prioridade sugerida de migração:** média
@@ -24,13 +25,13 @@
 | Rotas (web+api) | 9 |
 | Controllers | 3 |
 | Entities (Models) | 2 |
-| Services | 0 |
-| FormRequests | 0 |
+| Services | 1 |
+| FormRequests | 5 |
 | Middleware | 0 |
 | Views Blade | 7 |
 | Migrations | 4 |
 | Arquivos de lang | 16 |
-| Testes | 0 |
+| Testes | 9 |
 
 ## Rotas
 
@@ -55,7 +56,7 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 ## Controllers
 
 - **`DataController`** — 5 ação(ões): superadmin_package, user_permissions, modifyAdminMenu, parse_notification, getSharedSpreadsheetForGivenData
-- **`InstallController`** — 4 ação(ões): index, install, uninstall, update
+- **`InstallController`** — 0 ação(ões): 
 - **`SpreadsheetController`** — 12 ação(ões): index, create, store, show, edit, update, destroy, getShareSpreadsheet +4
 
 ## Entities (Models Eloquent)
@@ -97,6 +98,10 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 - `create.spreadsheet`
 - `superadmin`
+
+## Processamento / eventos
+
+**Commands (artisan):** `SpreadsheetHealthCommand`
 
 ## Peças adicionais
 
@@ -144,84 +149,11 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ✅ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ❌ |
-| `origin/6.7-bootstrap` | ✅ |
 
 ## Diferenças vs versões anteriores
-
-### vs `origin/3.7-com-nfe`
-
-- **Arquivos alterados:** 59
-- **Linhas +:** 2545 **-:** 0
-- **Primeiros arquivos alterados:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2020_12_23_125610_add_spreadsheet_version_to_system_table.php`
-  - `Database/Migrations/2020_12_23_153255_create_spreadsheets_table.php`
-  - `Database/Migrations/2021_03_12_175416_create_spreadsheet_shares_table.php`
-  - `Database/Migrations/2023_01_16_124948_add_folder_id_column_to_sheet_spreadsheets_table.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/SpreadsheetDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Entities/Spreadsheet.php`
-  - `Entities/SpreadsheetShare.php`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/DataController.php`
-  - `Http/Controllers/InstallController.php`
-  - `Http/Controllers/SpreadsheetController.php`
-  - `Http/Middleware/.gitkeep`
-  - `Http/Requests/.gitkeep`
-  - `Notifications/SpreadsheetShared.php`
-  - `Providers/.gitkeep`
-  - `Providers/RouteServiceProvider.php`
-  - `Providers/SpreadsheetServiceProvider.php`
-  - `Resources/assets/.gitkeep`
-  - `Resources/assets/js/app.js`
-  - `Resources/assets/sass/app.scss`
-  - `Resources/lang/.gitkeep`
-  - `Resources/lang/ar/lang.php`
-  - `Resources/lang/ce/lang.php`
-
-### vs `main-wip-2026-04-22` (backup das customizações)
-
-- **Arquivos alterados:** 59
-- **Linhas +:** 2545 **-:** 0
-- ⚠️ **Arquivos que podem conter customizações suas não trazidas para 6.7-react:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2020_12_23_125610_add_spreadsheet_version_to_system_table.php`
-  - `Database/Migrations/2020_12_23_153255_create_spreadsheets_table.php`
-  - `Database/Migrations/2021_03_12_175416_create_spreadsheet_shares_table.php`
-  - `Database/Migrations/2023_01_16_124948_add_folder_id_column_to_sheet_spreadsheets_table.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/SpreadsheetDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Entities/Spreadsheet.php`
-  - `Entities/SpreadsheetShare.php`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/DataController.php`
-  - `Http/Controllers/InstallController.php`
-  - `Http/Controllers/SpreadsheetController.php`
-  - `Http/Middleware/.gitkeep`
-  - `Http/Requests/.gitkeep`
-  - `Notifications/SpreadsheetShared.php`
-  - `Providers/.gitkeep`
-  - `Providers/RouteServiceProvider.php`
-  - `Providers/SpreadsheetServiceProvider.php`
-  - `Resources/assets/.gitkeep`
-  - `Resources/assets/js/app.js`
-  - `Resources/assets/sass/app.scss`
-  - `Resources/lang/.gitkeep`
-  - `Resources/lang/ar/lang.php`
-  - `Resources/lang/ce/lang.php`
 
 ## Gaps & próximos passos (preencher manualmente)
 
@@ -231,5 +163,5 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:14.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Spreadsheet`

--- a/memory/modulos/Superadmin.md
+++ b/memory/modulos/Superadmin.md
@@ -12,8 +12,11 @@
 ## Sinais detectados
 
 - 🔗 Registra 2 hook(s) UltimatePOS: modifyAdminMenu, user_permissions
-- 🟡 33 rotas — escopo médio
+- 🟡 39 rotas — escopo médio
+- ✅ Tem testes (15)
 - 🔐 Registra 1 permissão(ões) Spatie
+- ⚙️ Processamento assíncrono: 2 peça(s) (jobs/events/listeners)
+- 🔗 Acoplamento: depende de 1 outro(s) módulo(s)
 
 - **Prioridade sugerida de migração:** baixa (grande, fazer por último ou dividir)
 - **Risco estimado:** alto
@@ -22,16 +25,16 @@
 
 | Peça | Qtde |
 |---|---:|
-| Rotas (web+api) | 33 |
-| Controllers | 13 |
+| Rotas (web+api) | 39 |
+| Controllers | 14 |
 | Entities (Models) | 4 |
-| Services | 0 |
-| FormRequests | 0 |
+| Services | 4 |
+| FormRequests | 6 |
 | Middleware | 0 |
-| Views Blade | 45 |
+| Views Blade | 46 |
 | Migrations | 12 |
 | Arquivos de lang | 16 |
-| Testes | 0 |
+| Testes | 15 |
 
 ## Rotas
 
@@ -40,6 +43,12 @@
 | Método | URI | Controller |
 |---|---|---|
 | `GET` | `/pricing` | `[Modules\Superadmin\Http\Controllers\PricingController::class, 'index']` |
+| `GET` | `/pricing/old` | `[Modules\Superadmin\Http\Controllers\PricingController::class, 'indexLegacy']` |
+| `GET` | `/usuarios` | `[Modules\Superadmin\Http\Controllers\Usuario360Controller::class, 'index']` |
+| `GET` | `/usuarios/{id}/360` | `[Modules\Superadmin\Http\Controllers\Usuario360Controller::class, 'show']` |
+| `POST` | `/usuarios/{id}/lock` | `[Modules\Superadmin\Http\Controllers\Usuario360Controller::class, 'lock']` |
+| `POST` | `/usuarios/{id}/unlock` | `[Modules\Superadmin\Http\Controllers\Usuario360Controller::class, 'unlock']` |
+| `GET` | `/usuarios/{id}/history` | `[Modules\Superadmin\Http\Controllers\Usuario360Controller::class, 'history']` |
 | `GET` | `/install` | `[Modules\Superadmin\Http\Controllers\InstallController::class, 'index']` |
 | `GET` | `/install/update` | `[Modules\Superadmin\Http\Controllers\InstallController::class, 'update']` |
 | `GET` | `/install/uninstall` | `[Modules\Superadmin\Http\Controllers\InstallController::class, 'uninstall']` |
@@ -87,11 +96,12 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - **`PackagesController`** — 7 ação(ões): index, create, store, show, edit, update, destroy
 - **`PageController`** — 7 ação(ões): index, create, store, showPage, edit, update, destroy
 - **`PesaPalController`** — 1 ação(ões): pesaPalPaymentConfirmation
-- **`PricingController`** — 1 ação(ões): index
+- **`PricingController`** — 2 ação(ões): index, indexLegacy
 - **`SubscriptionController`** — 10 ação(ões): index, pay, registerPay, confirm, paypalExpressCheckout, getRedirectToPaystack, postPaymentPaystackCallback, postFlutterwavePaymentCallback +2
 - **`SuperadminController`** — 2 ação(ões): index, stats
 - **`SuperadminSettingsController`** — 2 ação(ões): edit, update
 - **`SuperadminSubscriptionsController`** — 9 ação(ões): index, create, store, show, edit, update, destroy, editSubscription +1
+- **`Usuario360Controller`** — 5 ação(ões): index, show, lock, unlock, history
 
 ## Entities (Models Eloquent)
 
@@ -117,11 +127,11 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 ## Views (Blade)
 
-**Total:** 45 arquivos
+**Total:** 46 arquivos
 
 **Pastas principais:**
 
-- `subscription/` — 13 arquivo(s)
+- `subscription/` — 14 arquivo(s)
 - `superadmin_settings/` — 9 arquivo(s)
 - `layouts/` — 5 arquivo(s)
 - `business/` — 4 arquivo(s)
@@ -151,10 +161,15 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 ## Processamento / eventos
 
-**Commands (artisan):** `SubscriptionExpiryAlert`
+**Commands (artisan):** `SubscriptionExpiryAlert`, `SuperadminHealthCommand`
+
+**Listeners:** `OnCobrancaPagaUpdateSubscription`, `OnCobrancaVencidaBloqueaSubscription`
+
+**Observers:** `BusinessAutoSubscriptionObserver`
 
 ## Peças adicionais
 
+- **Policies:** `PackagePolicy`
 - **Notifications:** `NewBusinessNotification`, `NewBusinessWelcomNotification`, `NewSubscriptionNotification`, `PasswordUpdateNotification`, `SendSubscriptionExpiryAlert`, `SubscriptionOfflinePaymentActivationConfirmation`, `SuperadminCommunicator`
 - **Seeders:** `SuperadminDatabaseSeeder`
 
@@ -164,6 +179,14 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 |---|---|
 | `name` | `Superadmin` |
 | `module_version` | `4.0` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `PaymentGateway` | 2 |
 
 ## Integridade do banco
 
@@ -197,84 +220,11 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ✅ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ✅ |
 
 ## Diferenças vs versões anteriores
-
-### vs `origin/3.7-com-nfe`
-
-- **Arquivos alterados:** 124
-- **Linhas +:** 11272 **-:** 0
-- **Primeiros arquivos alterados:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Console/SubscriptionExpiryAlert.php`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2018_06_27_185405_create_packages_table.php`
-  - `Database/Migrations/2018_06_28_182803_create_subscriptions_table.php`
-  - `Database/Migrations/2018_07_17_182021_add_rows_to_system_table.php`
-  - `Database/Migrations/2018_07_19_131721_add_options_to_packages_table.php`
-  - `Database/Migrations/2018_08_17_155534_add_min_termination_alert_days.php`
-  - `Database/Migrations/2018_08_28_105945_add_business_based_username_settings_to_system_table.php`
-  - `Database/Migrations/2018_08_30_105906_add_superadmin_communicator_logs_table.php`
-  - `Database/Migrations/2018_11_02_130636_add_custom_permissions_to_packages_table.php`
-  - `Database/Migrations/2018_11_05_161848_add_more_fields_to_packages_table.php`
-  - `Database/Migrations/2018_12_10_124621_modify_system_table_values_null_default.php`
-  - `Database/Migrations/2019_05_10_135434_add_missing_database_column_indexes.php`
-  - `Database/Migrations/2019_08_16_115300_create_superadmin_frontend_pages_table.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/SuperadminDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Entities/Package.php`
-  - `Entities/Subscription.php`
-  - `Entities/SuperadminCommunicatorLog.php`
-  - `Entities/SuperadminFrontendPage.php`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/BaseController.php`
-  - `Http/Controllers/BusinessController.php`
-  - `Http/Controllers/CommunicatorController.php`
-  - `Http/Controllers/DataController.php`
-
-### vs `main-wip-2026-04-22` (backup das customizações)
-
-- **Arquivos alterados:** 124
-- **Linhas +:** 11272 **-:** 0
-- ⚠️ **Arquivos que podem conter customizações suas não trazidas para 6.7-react:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Console/SubscriptionExpiryAlert.php`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2018_06_27_185405_create_packages_table.php`
-  - `Database/Migrations/2018_06_28_182803_create_subscriptions_table.php`
-  - `Database/Migrations/2018_07_17_182021_add_rows_to_system_table.php`
-  - `Database/Migrations/2018_07_19_131721_add_options_to_packages_table.php`
-  - `Database/Migrations/2018_08_17_155534_add_min_termination_alert_days.php`
-  - `Database/Migrations/2018_08_28_105945_add_business_based_username_settings_to_system_table.php`
-  - `Database/Migrations/2018_08_30_105906_add_superadmin_communicator_logs_table.php`
-  - `Database/Migrations/2018_11_02_130636_add_custom_permissions_to_packages_table.php`
-  - `Database/Migrations/2018_11_05_161848_add_more_fields_to_packages_table.php`
-  - `Database/Migrations/2018_12_10_124621_modify_system_table_values_null_default.php`
-  - `Database/Migrations/2019_05_10_135434_add_missing_database_column_indexes.php`
-  - `Database/Migrations/2019_08_16_115300_create_superadmin_frontend_pages_table.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/SuperadminDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Entities/Package.php`
-  - `Entities/Subscription.php`
-  - `Entities/SuperadminCommunicatorLog.php`
-  - `Entities/SuperadminFrontendPage.php`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/BaseController.php`
-  - `Http/Controllers/BusinessController.php`
-  - `Http/Controllers/CommunicatorController.php`
-  - `Http/Controllers/DataController.php`
 
 ## Gaps & próximos passos (preencher manualmente)
 
@@ -284,5 +234,5 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:14.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Superadmin`

--- a/memory/modulos/TeamMcp.md
+++ b/memory/modulos/TeamMcp.md
@@ -1,0 +1,133 @@
+# Módulo: TeamMcp
+
+> **Team MCP — governança self-host equivalente ao Anthropic Team plan: tokens MCP, DXT, quotas, Kanban backlog do time e auditoria de sessões Claude Code. Separado do Copiloto (agente IA do ERP) — ver ADR 0055/0057/0059.**
+
+- **Alias:** `teammcp`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/TeamMcp`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\TeamMcp\Providers\TeamMcpServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- ℹ️ Módulo sem views (provável API-only ou service)
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- ✅ Tem testes (11)
+
+- **Prioridade sugerida de migração:** média
+- **Risco estimado:** médio
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 18 |
+| Controllers | 11 |
+| Entities (Models) | 1 |
+| Services | 7 |
+| FormRequests | 5 |
+| Middleware | 0 |
+| Views Blade | 0 |
+| Migrations | 3 |
+| Arquivos de lang | 2 |
+| Testes | 11 |
+
+## Rotas
+
+### `routes.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `/team` | `'TeamController@index'` |
+| `POST` | `/team/{user}/token` | `'TeamController@gerarToken'` |
+| `POST` | `/team/{user}/dxt` | `'TeamController@gerarDxt'` |
+| `GET` | `/team/{user}/tokens` | `'TeamController@listTokens'` |
+| `DELETE` | `/team/{user}/token/{tokenId}` | `'TeamController@revokeToken'` |
+| `DELETE` | `/team/token/{token}` | `'TeamController@revogarToken'` |
+| `POST` | `/team/{user}/quota` | `'TeamController@atualizarQuota'` |
+| `GET` | `/team/export.csv` | `'TeamController@exportCsv'` |
+| `GET` | `/tasks` | `'TasksAdminController@index'` |
+| `PATCH` | `/tasks/{taskId}/status` | `'TasksAdminController@updateStatus'` |
+| `GET` | `/cc-sessions` | `'CcSessionsController@index'` |
+| `GET` | `/cc-sessions/search` | `'CcSessionsController@search'` |
+| `GET` | `/cc-sessions/{sessionUuid}` | `'CcSessionsController@show'` |
+| `GET` | `/scorecard` | `'ScorecardController@index'` |
+| `GET` | `/` | `'InstallController@index'` |
+| `POST` | `/` | `'InstallController@install'` |
+| `GET` | `/uninstall` | `'InstallController@uninstall'` |
+| `GET` | `/update` | `'InstallController@update'` |
+
+## Controllers
+
+- **`TeamScopesController`** — 3 ação(ões): index, grant, revoke
+- **`ToolsController`** — 2 ação(ões): index, execute
+- **`CcSessionsController`** — 3 ação(ões): index, show, search
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`InstallController`** — 0 ação(ões): 
+- **`CcIngestController`** — 1 ação(ões): ingest
+- **`HealthController`** — 2 ação(ões): publico, autenticado
+- **`SyncMemoryWebhookController`** — 1 ação(ões): handle
+- **`ScorecardController`** — 1 ação(ões): index
+- **`TasksAdminController`** — 2 ação(ões): index, updateStatus
+- **`TeamController`** — 8 ação(ões): index, gerarToken, gerarDxt, revogarToken, listTokens, revokeToken, atualizarQuota, exportCsv
+
+## Entities (Models Eloquent)
+
+- **`McpActor`** (tabela: `mcp_actors`)
+
+## Migrations
+
+- `2026_05_05_240001_create_mcp_actors_and_link_tokens.php`
+- `2026_05_05_240002_seed_initial_actors.php`
+- `2026_05_07_140000_update_actor_display_name_maiara.php`
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Processamento / eventos
+
+**Commands (artisan):** `RotateTokenCommand`, `SeedActorsCommand`
+
+## Peças adicionais
+
+- **Seeders:** `McpActorsSeeder`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `TeamMcp` |
+| `module_label` | `Team MCP` |
+| `module_description` | `Governança self-host: tokens MCP, DXT, quotas, Kanban e auditoria Claude Code do time.` |
+| `module_icon` | `fa fa-users` |
+| `module_version` | `0.1` |
+| `pid` | `` |
+
+## Integridade do banco
+
+**Unique indexes:** 1
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec TeamMcp`

--- a/memory/modulos/Vestuario.md
+++ b/memory/modulos/Vestuario.md
@@ -1,0 +1,110 @@
+# Módulo: Vestuario
+
+> **Modules/Vestuario — vertical lojas de vestuário/moda BR (CNAE 4781-4/00). Cliente piloto: ROTA LIVRE biz=4 (Larissa Termas do Gravatal/SC) em prod desde 2024-Q1. Estado especial: SPEC live + scaffold formal (ADR 0121 §P7). Consome shared Modules/Repair (kanban OS opcional) + núcleo UltimatePOS. Ver memory/requisitos/Vestuario/SPEC.md.**
+
+- **Alias:** `vestuario`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/Vestuario`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\Vestuario\Providers\VestuarioServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- ✅ Tem testes (15)
+
+- **Prioridade sugerida de migração:** alta (pequeno, ganho rápido)
+- **Risco estimado:** baixo
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 6 |
+| Controllers | 2 |
+| Entities (Models) | 1 |
+| Services | 4 |
+| FormRequests | 2 |
+| Middleware | 0 |
+| Views Blade | 1 |
+| Migrations | 3 |
+| Arquivos de lang | 0 |
+| Testes | 15 |
+
+## Rotas
+
+### `web.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+| `GET` | `/` | `[EtiquetaTagController::class, 'index']` |
+| `POST` | `lote/zpl` | `[EtiquetaTagController::class, 'storeZpl']` |
+| `POST` | `lote/pdf` | `[EtiquetaTagController::class, 'storePdf']` |
+
+## Controllers
+
+- **`EtiquetaTagController`** — 3 ação(ões): index, storeZpl, storePdf
+- **`InstallController`** — 0 ação(ões): 
+
+## Entities (Models Eloquent)
+
+- **`VestuarioSetting`** (tabela: `vestuario_settings`)
+
+## Migrations
+
+- `2026_05_10_000001_create_vestuario_settings_table.php`
+- `2026_05_17_000001_create_vestuario_devolucoes_table.php`
+- `2026_05_17_000002_create_vestuario_creditos_cliente_table.php`
+
+## Views (Blade)
+
+**Total:** 1 arquivos
+
+**Pastas principais:**
+
+- `etiquetas/` — 1 arquivo(s)
+
+## Processamento / eventos
+
+**Commands (artisan):** `VestuarioHealthCommand`, `VestuarioSettingsCommand`
+
+## Peças adicionais
+
+- **Seeders:** `RepairSettingsSeeder`
+
+## Integridade do banco
+
+**Foreign Keys** (6):
+
+- `business_id` → `business.id`
+- `business_id` → `business.id`
+- `transaction_id` → `transactions.id`
+- `processed_by_user_id` → `users.id`
+- `business_id` → `business.id`
+- `contact_id` → `contacts.id`
+
+**Unique indexes:** 2
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec Vestuario`

--- a/memory/modulos/Whatsapp.md
+++ b/memory/modulos/Whatsapp.md
@@ -1,0 +1,283 @@
+# Módulo: Whatsapp
+
+> **Whatsapp transacional via Z-API (driver default) + Meta Cloud (fallback obrigatório). Status OS, boleto/NFe, lembrete, dunning, bot Jana com HITL.**
+
+- **Alias:** `whatsapp`
+- **Versão:** ?
+- **Path:** `D:\oimpresso.com\Modules/Whatsapp`
+- **Status:** 🟢 ativo
+- **Providers:** Modules\Whatsapp\Providers\WhatsappServiceProvider
+- **Requires (módulo.json):** nenhum
+
+## Sinais detectados
+
+- 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- 🔴 +50 rotas — módulo grande, migrar em fases
+- ✅ Tem testes (110)
+- ⚙️ Processamento assíncrono: 29 peça(s) (jobs/events/listeners)
+- 🔗 Acoplamento: depende de 2 outro(s) módulo(s)
+
+- **Prioridade sugerida de migração:** baixa (grande, fazer por último ou dividir)
+- **Risco estimado:** alto
+
+## Escopo
+
+| Peça | Qtde |
+|---|---:|
+| Rotas (web+api) | 59 |
+| Controllers | 19 |
+| Entities (Models) | 23 |
+| Services | 47 |
+| FormRequests | 6 |
+| Middleware | 6 |
+| Views Blade | 1 |
+| Migrations | 42 |
+| Arquivos de lang | 2 |
+| Testes | 110 |
+
+## Rotas
+
+### `web.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `install` | `[InstallController::class, 'index']` |
+| `GET` | `install/uninstall` | `[InstallController::class, 'uninstall']` |
+| `GET` | `install/update` | `[InstallController::class, 'update']` |
+| `GET` | `/templates` | `[TemplatesController::class, 'index']` |
+| `POST` | `/templates/sync-meta` | `[TemplatesController::class, 'syncMeta']` |
+| `POST` | `/templates` | `[TemplatesController::class, 'store']` |
+| `GET` | `/settings` | `[SettingsController::class, 'settings']` |
+| `GET` | `/settings/meta-oauth-init` | `[SettingsController::class, 'metaOauthInit']` |
+| `POST` | `/settings/meta-embedded-callback` | `[SettingsController::class, 'metaEmbeddedCallback']` |
+| `PUT` | `/settings` | `fn (` |
+| `GET` | `/` | `[CaixaUnificadaController::class, 'index']` |
+| `GET` | `/customer/{external_id}/profile` | `[CustomerProfileController::class, 'show']` |
+| `GET` | `/employee/scorecards` | `[EmployeeScorecardController::class, 'index']` |
+| `GET` | `/employee/{user_identifier}/scorecard` | `[EmployeeScorecardController::class, 'show']` |
+| `GET` | `/caixa-unificada` | `[CaixaUnificadaController::class, 'index']` |
+| `GET` | `/midia/{path}` | `[CaixaUnificadaController::class, 'serveMedia']` |
+| `POST` | `/inbox/{id}/send` | `[InboxController::class, 'send']` |
+| `POST` | `/inbox/{id}/send-media` | `[InboxController::class, 'sendMedia']` |
+| `POST` | `/inbox/conversations/{id}/send-interactive` | `[InboxController::class, 'sendInteractive']` |
+| `PATCH` | `/inbox/{id}` | `[InboxController::class, 'updateStatus']` |
+| `POST` | `/feedback/capture` | `[ClientFeedbackController::class, 'capture']` |
+| `GET` | `/feedback` | `[ClientFeedbackController::class, 'index']` |
+| `PATCH` | `/feedback/{id}/status` | `[ClientFeedbackController::class, 'updateStatus']` |
+| `PATCH` | `/inbox/{id}/tags` | `[InboxController::class, 'updateTags']` |
+| `GET` | `/inbox/contacts/search` | `[InboxController::class, 'searchContacts']` |
+| `PATCH` | `/inbox/{id}/contact` | `[InboxController::class, 'linkContact']` |
+| `POST` | `/inbox/{id}/contact/create-from-phone` | `[InboxController::class, 'createContactFromPhone']` |
+| `PATCH` | `/inbox/{id}/block` | `[InboxController::class, 'blockContact']` |
+| `GET` | `/canais` | `[ChannelsController::class, 'index']` |
+| `POST` | `/canais` | `[ChannelsController::class, 'store']` |
+| `GET` | `/canais/{id}` | `[ChannelsController::class, 'show']` |
+| `DELETE` | `/canais/{id}` | `[ChannelsController::class, 'destroy']` |
+| `POST` | `/canais/{id}/connect` | `[ChannelsController::class, 'connect']` |
+| `GET` | `/canais/{id}/status` | `[ChannelsController::class, 'status']` |
+| `GET` | `/canais/{id}/whatsmeow-status` | `[ChannelsController::class, 'whatsmeowStatus']` |
+| `POST` | `/canais/{id}/import-history` | `[ChannelsController::class, 'importHistory']` |
+| `POST` | `/canais/{id}/users` | `[ChannelsController::class, 'grantUser']` |
+| `DELETE` | `/canais/{id}/users/{userId}` | `[ChannelsController::class, 'revokeUser']` |
+| `GET` | `/canais/jana-templates` | `[SettingsController::class, 'show']` |
+| `PUT` | `/canais/jana-templates` | `[SettingsController::class, 'update']` |
+
+_... +13 rotas_
+
+### `api.php`
+
+| Método | URI | Controller |
+|---|---|---|
+| `GET` | `/meta/{business_uuid}` | `[MetaWebhookController::class, 'verify']` |
+| `POST` | `/meta/{business_uuid}` | `[MetaWebhookController::class, 'handle']` |
+| `POST` | `/zapi/{business_uuid}` | `[ZapiWebhookController::class, 'handle']` |
+| `POST` | `/baileys/{business_uuid}` | `[BaileysWebhookController::class, 'handle']` |
+| `POST` | `/whatsmeow/{business_uuid}` | `[WhatsmeowWebhookController::class, 'handle']` |
+| `POST` | `/baileys/{channel_uuid}` | `[ChannelBaileysWebhookController::class, 'handle']` |
+
+## Controllers
+
+- **`CaixaUnificadaController`** — 2 ação(ões): index, serveMedia
+- **`ChannelsController`** — 10 ação(ões): index, store, destroy, show, grantUser, revokeUser, connect, whatsmeowStatus +2
+- **`ClientFeedbackController`** — 3 ação(ões): capture, index, updateStatus
+- **`CsatController`** — 1 ação(ões): index
+- **`InboxController`** — 10 ação(ões): index, updateTags, send, blockContact, updateStatus, searchContacts, linkContact, createContactFromPhone +2
+- **`MacroVariantsController`** — 5 ação(ões): index, store, update, destroy, markWinner
+- **`MacrosController`** — 6 ação(ões): index, list, store, update, destroy, apply
+- **`MetricsController`** — 1 ação(ões): index
+- **`SettingsController`** — 5 ação(ões): show, update, settings, metaOauthInit, metaEmbeddedCallback
+- **`TemplatesController`** — 3 ação(ões): index, syncMeta, store
+- **`BaileysWebhookController`** — 1 ação(ões): handle
+- **`ChannelBaileysWebhookController`** — 1 ação(ões): handle
+- **`CustomerProfileController`** — 1 ação(ões): show
+- **`EmployeeScorecardController`** — 2 ação(ões): show, index
+- **`MetaWebhookController`** — 2 ação(ões): verify, handle
+- **`WhatsmeowWebhookController`** — 1 ação(ões): handle
+- **`ZapiWebhookController`** — 1 ação(ões): handle
+- **`DataController`** — 3 ação(ões): superadmin_package, user_permissions, modifyAdminMenu
+- **`InstallController`** — 0 ação(ões): 
+
+## Entities (Models Eloquent)
+
+- **`Channel`** (tabela: `channels`)
+- **`ChannelUserAccess`** (tabela: `channel_user_access`)
+- **`ClientFeedback`** (tabela: `clients_feedbacks`)
+- **`Conversation`** (tabela: `conversations`)
+- **`ConversationMetric`** (tabela: `whatsapp_conversation_metricas`)
+- **`CsatResponse`** (tabela: `whatsapp_csat_responses`)
+- **`CustomerMemory`** (tabela: `customer_memory`)
+- **`EmployeePerformance`** (tabela: `employee_performance`)
+- **`JanaCorrecao`** (tabela: `whatsapp_jana_correcoes`)
+- **`LidPhoneMap`** (tabela: `whatsapp_lid_pn_map`)
+- **`Macro`** (tabela: `macros`)
+- **`MacroVariant`** (tabela: `macro_variants`)
+- **`Message`** (tabela: `messages`)
+- **`SlaPolicy`** (tabela: `sla_policies`)
+- **`Tag`** (tabela: `whatsapp_tags`)
+- **`WhatsappBusinessConfig`** (tabela: `whatsapp_business_configs`)
+- **`WhatsappBusinessPhone`** (tabela: `whatsapp_business_phones`)
+- **`WhatsappContactBotOverride`** (tabela: `whatsapp_contact_bot_overrides`)
+- **`WhatsappConversation`** (tabela: `whatsapp_conversations`)
+- **`WhatsappMessage`** (tabela: `whatsapp_messages`)
+- **`WhatsappPhoneUserAccess`** (tabela: `whatsapp_phone_user_access`)
+- **`WhatsappReminder`** (tabela: `whatsapp_reminders`)
+- **`WhatsappTemplate`** (tabela: `whatsapp_templates`)
+
+## Migrations
+
+- `2026_05_07_000001_create_whatsapp_business_configs_table.php`
+- `2026_05_07_000002_create_whatsapp_conversations_table.php`
+- `2026_05_07_000003_create_whatsapp_messages_table.php`
+- `2026_05_07_000004_create_whatsapp_templates_table.php`
+- `2026_05_09_000001_simplify_baileys_columns_in_whatsapp_business_configs.php`
+- `2026_05_09_120000_create_whatsapp_business_phones_table.php`
+- `2026_05_09_120100_create_whatsapp_phone_user_access_table.php`
+- `2026_05_09_120200_add_phone_id_to_whatsapp_conversations_and_messages.php`
+- `2026_05_09_120300_seed_whatsapp_business_phones_from_configs.php`
+- `2026_05_11_000001_create_omnichannel_tables.php`
+- `2026_05_11_120000_create_conversation_tags_tables.php`
+- `2026_05_11_130000_add_is_blocked_to_conversations.php`
+- `2026_05_11_200000_add_updated_at_to_whatsapp_conversation_tags.php`
+- `2026_05_12_000001_add_last_message_denormalized_to_conversations.php`
+- `2026_05_12_140000_add_is_internal_note_to_messages.php`
+- `2026_05_12_150000_add_media_to_messages.php`
+- `2026_05_12_160000_create_channel_user_access_table.php`
+- `2026_05_12_170000_create_whatsapp_jana_correcoes_table.php`
+- `2026_05_12_180000_create_whatsapp_reminders_table.php`
+- `2026_05_12_190000_create_whatsapp_contact_bot_overrides_table.php`
+- `2026_05_12_200000_add_media_download_tracking_to_messages.php`
+- `2026_05_12_210000_create_whatsapp_lid_pn_map_table.php`
+- `2026_05_12_220000_create_sla_policies_table.php`
+- `2026_05_12_220000_create_whatsapp_conversation_metricas_table.php`
+- `2026_05_12_220000_create_whatsapp_csat_responses_table.php`
+- `2026_05_13_000001_create_macros_table.php`
+- `2026_05_13_100001_create_macro_variants_table.php`
+- `2026_05_13_100002_add_macro_variant_id_to_messages.php`
+- `2026_05_13_205208_add_index_display_identifier_to_channels.php`
+- `2026_05_14_010001_create_jobs_table_for_whatsapp_queue.php`
+- `2026_05_14_020001_create_webhook_nonces_table.php`
+- `2026_05_15_010000_add_identity_columns_to_conversations.php`
+- `2026_05_15_020000_fix_identity_columns_whatsapp_conversations.php`
+- `2026_05_15_230000_create_customer_memory_table.php`
+- `2026_05_15_240000_add_employee_complaints_external_to_customer_memory.php`
+- `2026_05_15_250000_create_employee_performance_table.php`
+- `2026_05_27_180000_create_clients_feedbacks_table.php`
+- `2026_05_27_220000_add_dev_task_requested_to_clients_feedbacks.php`
+- `2026_05_27_240000_add_signature_relevance_to_clients_feedbacks.php`
+- `2026_05_28_000001_drop_baileys_columns_from_whatsapp_business_configs.php`
+- `2026_05_28_000002_drop_whatsapp_baileys_auth_state_table.php`
+- `2026_05_28_000003_add_meta_waba_id_to_whatsapp_business_configs.php`
+
+## Views (Blade)
+
+**Total:** 1 arquivos
+
+**Pastas principais:**
+
+- `D:/` — 1 arquivo(s)
+
+## Hooks UltimatePOS registrados
+
+- **`modifyAdminMenu()`** — Injeta itens na sidebar admin
+- **`superadmin_package()`** — Registra pacote de licenciamento no Superadmin
+- **`user_permissions()`** — Registra permissões Spatie no cadastro de Roles
+
+## Processamento / eventos
+
+**Jobs (queue):** `BackfillLidConversationsJob`, `DeleteBaileysInstanceJob`, `DispatchCsatJob`, `DownloadMediaJob`, `NotificarClienteCancelamentoJob`, `PersistContactsFromHistorySyncJob`, `PersistHistorySyncBatchJob`, `ProcessIncomingWebhookJob`, `ProcessRemindersJob`, `RebuildCustomerMemoryJob`, `RebuildEmployeePerformanceJob`, `RetryFailedMediaDownloadsJob`, `SendInteractiveJob`, `SendMediaJob`, `SendWhatsappMessageJob`, `TranscribeAudioJob`, `WhatsappDriverHealthCheckJob`
+
+**Commands (artisan):** `AutoLinkConversationContactsCommand`, `BackfillChannelAccessCommand`, `BackfillMediaDownloadCommand`, `ChannelResetCommand`, `ChannelsReconcilerCommand`, `CleanupStaleJobsCommand`, `CleanupWebhookNoncesCommand`, `CustomerMemoryBackfillCommand`, `CustomerMemoryEnrichFirebirdCommand`, `CustomerMemoryRefreshDailyCommand`, `DaemonSourceDriftCheckCommand`, `DriverHealthCheckAllCommand`, `EmployeePerformanceBackfillCommand`, `EmployeePerformanceRefreshDailyCommand`, `FeedbackReindexCommand`, `HealthProbeChannelsCommand`, `ImportHistoryCommand`, `LidBackfillCommand`, `MetricsAggregateCommand`, `ReconnectAndImportCommand`, `RegisterWhatsappPermissionsCommand`, `ReparseMediaFromPayloadCommand`, `RetryRecentMediaDownloadsCommand`, `ScanMediaDriftCommand`, `SlaScanCommand`, `WhatsappAuthStateDriftCheckCommand`, `WhatsappObservabilityHealthCommand`
+
+**Events:** `OmnichannelMessageReceived`, `OmnichannelMessageSent`, `WhatsappMessageFailed`, `WhatsappMessageQueued`, `WhatsappMessageReceived`, `WhatsappMessageSent`
+
+**Listeners:** `DispatchToJanaBot`, `NotifyRepairCustomer`, `PublishMessageReceivedToCentrifugo`, `PublishMessageSentToCentrifugo`, `PublishOmnichannelToCentrifugo`, `TouchCustomerMemoryOnMessage`
+
+**Observers:** `ChannelObserver`, `ClientFeedbackObserver`, `ContactObserver`, `LidPhoneMapObserver`, `MessageObserver`, `WhatsappMessageObserver`
+
+## Configuração (`Config/config.php`)
+
+| Chave | Valor |
+|---|---|
+| `name` | `Whatsapp` |
+| `default_driver` | `meta_cloud` |
+| `zapi` | `[array(2 itens)]` |
+| `meta` | `[array(6 itens)]` |
+| `whatsmeow` | `[array(4 itens)]` |
+| `health_check` | `[array(4 itens)]` |
+| `fallback` | `[array(4 itens)]` |
+| `forbidden_drivers` | `[array(3 itens)]` |
+| `queue` | `whatsapp` |
+| `queues` | `[array(2 itens)]` |
+| `default_queue` | `comercial` |
+| `webhook` | `[array(1 itens)]` |
+| `backpressure` | `[array(5 itens)]` |
+| `centrifugo` | `[array(7 itens)]` |
+| `bot` | `[array(1 itens)]` |
+| `customer_memory` | `[array(4 itens)]` |
+| `audio` | `[array(1 itens)]` |
+| `media` | `[array(3 itens)]` |
+| `csat` | `[array(1 itens)]` |
+| `history_import` | `[array(1 itens)]` |
+| `retention` | `[array(4 itens)]` |
+
+## Dependências cross-module detectadas
+
+_Referências a outros módulos encontradas no código PHP._
+
+| Módulo referenciado | Ocorrências |
+|---|---:|
+| `Jana` | 2 |
+| `Repair` | 1 |
+
+## Integridade do banco
+
+**Foreign Keys** (5):
+
+- `message_id_errada` → `messages.id`
+- `business_id` → `business.id`
+- `channel_id` → `channels.id`
+- `macro_id` → `macros.id`
+- `macro_variant_id` → `macro_variants.id`
+
+**Unique indexes:** 26
+
+## Presença em branches
+
+| Branch | Presente |
+|---|:-:|
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
+| `origin/3.7-com-nfe` (versão antiga) | ❌ |
+
+## Diferenças vs versões anteriores
+
+## Gaps & próximos passos (preencher manualmente)
+
+- [ ] Identificar customizações do Wagner (comparar com UltimatePOS 6.7 original)
+- [ ] Listar bugs conhecidos no módulo
+- [ ] Priorizar telas para migração React
+- [ ] Marcar rotas que devem virar Inertia
+
+---
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
+**Reaxecutar com:** `php artisan module:spec Whatsapp`

--- a/memory/modulos/Woocommerce.md
+++ b/memory/modulos/Woocommerce.md
@@ -12,6 +12,7 @@
 ## Sinais detectados
 
 - 🔗 Registra 3 hook(s) UltimatePOS: modifyAdminMenu, superadmin_package, user_permissions
+- ✅ Tem testes (8)
 - 🔐 Registra 5 permissão(ões) Spatie
 
 - **Prioridade sugerida de migração:** média
@@ -24,13 +25,13 @@
 | Rotas (web+api) | 19 |
 | Controllers | 4 |
 | Entities (Models) | 1 |
-| Services | 0 |
-| FormRequests | 0 |
+| Services | 3 |
+| FormRequests | 2 |
 | Middleware | 0 |
 | Views Blade | 13 |
 | Migrations | 13 |
 | Arquivos de lang | 10 |
-| Testes | 0 |
+| Testes | 8 |
 
 ## Rotas
 
@@ -38,25 +39,25 @@
 
 | Método | URI | Controller |
 |---|---|---|
-| `POST` | `/webhook/order-created/{business_id}` | `[Modules\Woocommerce\Http\Controllers\WoocommerceWebhookController::class, 'orderCreated']` |
-| `POST` | `/webhook/order-updated/{business_id}` | `[Modules\Woocommerce\Http\Controllers\WoocommerceWebhookController::class, 'orderUpdated']` |
-| `POST` | `/webhook/order-deleted/{business_id}` | `[Modules\Woocommerce\Http\Controllers\WoocommerceWebhookController::class, 'orderDeleted']` |
-| `POST` | `/webhook/order-restored/{business_id}` | `[Modules\Woocommerce\Http\Controllers\WoocommerceWebhookController::class, 'orderRestored']` |
-| `GET` | `/install` | `[Modules\Woocommerce\Http\Controllers\InstallController::class, 'index']` |
-| `GET` | `/install/update` | `[Modules\Woocommerce\Http\Controllers\InstallController::class, 'update']` |
-| `GET` | `/install/uninstall` | `[Modules\Woocommerce\Http\Controllers\InstallController::class, 'uninstall']` |
-| `GET` | `/` | `[Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'index']` |
-| `GET` | `/api-settings` | `[Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'apiSettings']` |
-| `POST` | `/update-api-settings` | `[Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'updateSettings']` |
-| `GET` | `/sync-categories` | `[Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'syncCategories']` |
-| `GET` | `/sync-products` | `[Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'syncProducts']` |
-| `GET` | `/sync-log` | `[Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'getSyncLog']` |
-| `GET` | `/sync-orders` | `[Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'syncOrders']` |
-| `POST` | `/map-taxrates` | `[Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'mapTaxRates']` |
-| `GET` | `/view-sync-log` | `[Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'viewSyncLog']` |
-| `GET` | `/get-log-details/{id}` | `[Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'getLogDetails']` |
-| `GET` | `/reset-categories` | `[Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'resetCategories']` |
-| `GET` | `/reset-products` | `[Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'resetProducts']` |
+| `POST` | `/webhook/order-created/{business_id}` | `[\Modules\Woocommerce\Http\Controllers\WoocommerceWebhookController::class, 'orderCreated']` |
+| `POST` | `/webhook/order-updated/{business_id}` | `[\Modules\Woocommerce\Http\Controllers\WoocommerceWebhookController::class, 'orderUpdated']` |
+| `POST` | `/webhook/order-deleted/{business_id}` | `[\Modules\Woocommerce\Http\Controllers\WoocommerceWebhookController::class, 'orderDeleted']` |
+| `POST` | `/webhook/order-restored/{business_id}` | `[\Modules\Woocommerce\Http\Controllers\WoocommerceWebhookController::class, 'orderRestored']` |
+| `GET` | `/install` | `[\Modules\Woocommerce\Http\Controllers\InstallController::class, 'index']` |
+| `GET` | `/install/update` | `[\Modules\Woocommerce\Http\Controllers\InstallController::class, 'update']` |
+| `GET` | `/install/uninstall` | `[\Modules\Woocommerce\Http\Controllers\InstallController::class, 'uninstall']` |
+| `GET` | `/` | `[\Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'index']` |
+| `GET` | `/api-settings` | `[\Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'apiSettings']` |
+| `POST` | `/update-api-settings` | `[\Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'updateSettings']` |
+| `GET` | `/sync-categories` | `[\Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'syncCategories']` |
+| `GET` | `/sync-products` | `[\Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'syncProducts']` |
+| `GET` | `/sync-log` | `[\Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'getSyncLog']` |
+| `GET` | `/sync-orders` | `[\Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'syncOrders']` |
+| `POST` | `/map-taxrates` | `[\Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'mapTaxRates']` |
+| `GET` | `/view-sync-log` | `[\Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'viewSyncLog']` |
+| `GET` | `/get-log-details/{id}` | `[\Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'getLogDetails']` |
+| `GET` | `/reset-categories` | `[\Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'resetCategories']` |
+| `GET` | `/reset-products` | `[\Modules\Woocommerce\Http\Controllers\WoocommerceController::class, 'resetProducts']` |
 
 ### `api.php`
 
@@ -125,7 +126,7 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 ## Processamento / eventos
 
-**Commands (artisan):** `WooCommerceSyncOrder`, `WoocommerceSyncProducts`
+**Commands (artisan):** `WoocommerceHealthCommand`, `WooCommerceSyncOrder`, `WoocommerceSyncProducts`
 
 ## Peças adicionais
 
@@ -165,84 +166,11 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ✅ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ✅ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ✅ |
 
 ## Diferenças vs versões anteriores
-
-### vs `origin/3.7-com-nfe`
-
-- **Arquivos alterados:** 73
-- **Linhas +:** 5944 **-:** 0
-- **Primeiros arquivos alterados:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Console/WooCommerceSyncOrder.php`
-  - `Console/WoocommerceSyncProducts.php`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2018_10_10_110400_add_module_version_to_system_table.php`
-  - `Database/Migrations/2018_10_10_122845_add_woocommerce_api_settings_to_business_table.php`
-  - `Database/Migrations/2018_10_10_162041_add_woocommerce_category_id_to_categories_table.php`
-  - `Database/Migrations/2018_10_11_173839_create_woocommerce_sync_logs_table.php`
-  - `Database/Migrations/2018_10_16_123522_add_woocommerce_tax_rate_id_column_to_tax_rates_table.php`
-  - `Database/Migrations/2018_10_23_111555_add_woocommerce_attr_id_column_to_variation_templates_table.php`
-  - `Database/Migrations/2018_12_03_163945_add_woocommerce_permissions.php`
-  - `Database/Migrations/2019_02_18_154414_change_woocommerce_sync_logs_table.php`
-  - `Database/Migrations/2019_04_19_174129_add_disable_woocommerce_sync_column_to_products_table.php`
-  - `Database/Migrations/2019_06_08_132440_add_woocommerce_wh_oc_secret_column_to_business_table.php`
-  - `Database/Migrations/2019_10_01_171828_add_woocommerce_media_id_columns.php`
-  - `Database/Migrations/2020_09_07_124952_add_woocommerce_skipped_orders_fields_to_business_table.php`
-  - `Database/Migrations/2021_02_16_190608_add_woocommerce_module_indexing.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/AddDummySyncLogTableSeeder.php`
-  - `Database/Seeders/WoocommerceDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Entities/WoocommerceSyncLog.php`
-  - `Exceptions/WooCommerceError.php`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/DataController.php`
-  - `Http/Controllers/InstallController.php`
-  - `Http/Controllers/WoocommerceController.php`
-
-### vs `main-wip-2026-04-22` (backup das customizações)
-
-- **Arquivos alterados:** 73
-- **Linhas +:** 5944 **-:** 0
-- ⚠️ **Arquivos que podem conter customizações suas não trazidas para 6.7-react:**
-  - `Config/.gitkeep`
-  - `Config/config.php`
-  - `Console/.gitkeep`
-  - `Console/WooCommerceSyncOrder.php`
-  - `Console/WoocommerceSyncProducts.php`
-  - `Database/Migrations/.gitkeep`
-  - `Database/Migrations/2018_10_10_110400_add_module_version_to_system_table.php`
-  - `Database/Migrations/2018_10_10_122845_add_woocommerce_api_settings_to_business_table.php`
-  - `Database/Migrations/2018_10_10_162041_add_woocommerce_category_id_to_categories_table.php`
-  - `Database/Migrations/2018_10_11_173839_create_woocommerce_sync_logs_table.php`
-  - `Database/Migrations/2018_10_16_123522_add_woocommerce_tax_rate_id_column_to_tax_rates_table.php`
-  - `Database/Migrations/2018_10_23_111555_add_woocommerce_attr_id_column_to_variation_templates_table.php`
-  - `Database/Migrations/2018_12_03_163945_add_woocommerce_permissions.php`
-  - `Database/Migrations/2019_02_18_154414_change_woocommerce_sync_logs_table.php`
-  - `Database/Migrations/2019_04_19_174129_add_disable_woocommerce_sync_column_to_products_table.php`
-  - `Database/Migrations/2019_06_08_132440_add_woocommerce_wh_oc_secret_column_to_business_table.php`
-  - `Database/Migrations/2019_10_01_171828_add_woocommerce_media_id_columns.php`
-  - `Database/Migrations/2020_09_07_124952_add_woocommerce_skipped_orders_fields_to_business_table.php`
-  - `Database/Migrations/2021_02_16_190608_add_woocommerce_module_indexing.php`
-  - `Database/Seeders/.gitkeep`
-  - `Database/Seeders/AddDummySyncLogTableSeeder.php`
-  - `Database/Seeders/WoocommerceDatabaseSeeder.php`
-  - `Database/factories/.gitkeep`
-  - `Entities/.gitkeep`
-  - `Entities/WoocommerceSyncLog.php`
-  - `Exceptions/WooCommerceError.php`
-  - `Http/Controllers/.gitkeep`
-  - `Http/Controllers/DataController.php`
-  - `Http/Controllers/InstallController.php`
-  - `Http/Controllers/WoocommerceController.php`
 
 ## Gaps & próximos passos (preencher manualmente)
 
@@ -252,5 +180,5 @@ _(arquivo existe mas parse não identificou rotas explícitas — pode ter grupo
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:14.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec Woocommerce`

--- a/memory/modulos/codecanyon-32094844-perfect-support-ticketing-document-management-system.md
+++ b/memory/modulos/codecanyon-32094844-perfect-support-ticketing-document-management-system.md
@@ -36,10 +36,9 @@
 
 | Branch | Presente |
 |---|:-:|
-| atual (6.7-react) | ❌ |
-| `main-wip-2026-04-22` (backup Wagner) | ✅ |
+| atual (main) | ❌ |
+| `main-wip-2026-04-22` (backup Wagner) | ❌ |
 | `origin/3.7-com-nfe` (versão antiga) | ✅ |
-| `origin/6.7-bootstrap` | ❌ |
 
 ## Diferenças vs versões anteriores
 
@@ -51,5 +50,5 @@
 - [ ] Marcar rotas que devem virar Inertia
 
 ---
-**Gerado automaticamente por `ModuleSpecGenerator` em 2026-04-22 14:14.**
+**Gerado automaticamente por `ModuleSpecGenerator` em 2026-05-29 08:06.**
 **Reaxecutar com:** `php artisan module:spec codecanyon-32094844-perfect-support-ticketing-document-management-system`


### PR DESCRIPTION
## Por quê

Wagner apontou uma **regressão**: o agente afirmou que "não existe índice consolidado de módulos" quando **`memory/INDEX.md`** (índice mestre, ~1.536 docs) e **`memory/modulos/INDEX.md`** (catálogo auto-gerado) **já existiam**. O agente re-derivou manualmente dos 36 SCOPE.md em vez de abrir o índice — violando o protocolo `mcp-first`/`memory-first` do próprio projeto.

O catálogo `memory/modulos/` estava **stale desde 2026-04-22**: 29 módulos, nomes antigos (`Project`/`PontoWr2`/`Accounting`), faltando Compras/Vestuario/OficinaAuto/Fiscal/PaymentGateway/ComunicacaoVisual/etc.

## O que muda

`php artisan module:specs` regenerado → **44 módulos detectados / 36 ativos**, refletindo o código real. 45 arquivos (22 novos + 23 atualizados).

O índice mestre **`memory/INDEX.md`** continua sendo a porta de entrada canônica.

Refs: memory/INDEX.md · ADR 0013 (inventário ecossistema módulos)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
