### PR TITLE
docs(memory): auditoria de indexação & priorização do índice mestre (Constituição + Norte + Protocolo + contagens + links)

### DIFF
--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -1,4 +1,4 @@
-# memory/ — Índice navegável (~1.536 docs)
+# memory/ — Índice navegável (~2.300 docs)
 
 > Mapa pra navegar `memory/`. Para **estado VIVO** (cycle ativo, tasks, brief), use tools MCP: `brief-fetch`, `my-work`, `cycles-active`, `decisions-search`.
 > Documento canônico — atualizar quando criar nova categoria. Reorg: ver [AUDITORIA-KNOWLEDGE-ARCHITECTURE-2026-05-13](requisitos/Jana/AUDITORIA-KNOWLEDGE-ARCHITECTURE-2026-05-13.md) §5 (G2).
@@ -13,6 +13,18 @@
 | [governance/CONSTITUTION.md](governance/CONSTITUTION.md) | Versão operacional renderizada (artigos) | vigente |
 | **[ADR UI-0013 — Constituição UI v2](requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md)** | Constituição da **UI** (4 camadas: Fundações→Shell→Padrão de Tela→Módulo) | aceito |
 | [ADR 0079](decisions/0079-constituicao-oimpresso-7-camadas-governanca.md) · [ADR 0078](decisions/0078-constituicao-uma-frase-skill-unidade-evolucao.md) | Histórico — origem das 7 camadas + meta-skill "1 frase" | superseded por 0094 |
+
+## 🎯 Norte, Protocolo & Skills Tier A (normativo — mesmo nível da Constituição)
+
+> O que **decide o trabalho** e **como toda sessão DEVE operar**. Tão Tier 0 quanto a Constituição. Antes ficava ausente/enterrado no índice — regressão de priorização corrigida na auditoria 2026-05-29 (a Constituição foi só o 1º caso de uma classe).
+
+| Doc | O que é |
+|---|---|
+| **[NORTE-ROI.md](NORTE-ROI.md)** | **Norte único** — meta R$5M/ano ([ADR 0022](decisions/0022-meta-5mi-ano-financeira.md)). Toda decisão passa por aqui antes de virar trabalho. + [11-metas-negocio.md](11-metas-negocio.md) |
+| **[reference/PROTOCOLO-WAGNER-SEMPRE.md](reference/PROTOCOLO-WAGNER-SEMPRE.md)** | **REGRA ZERO (R1–R11)** — Tier 0 IRREVOGÁVEL, toda sessão DEVE executar. Skill `wagner-protocol-enforce` |
+| **[how-trabalhar.md](how-trabalhar.md)** | Protocolo de sessão: `brief-fetch` → `my-work` → (charter) → trabalhar → `decide` → commit |
+| **Skills Tier A (always-on)** | `brief-first` · `mcp-first` · `memory-first-secret-search` · `multi-tenant-patterns` · `commit-discipline` · `mwart-process` · `wagner-protocol-enforce` — convenção [ADR 0095](decisions/0095-skills-tiers-convencao-interna.md) · audit [s3-skills-audit](sprints/s3-constituicao/03-skills-audit.md) |
+| **[proibicoes.md](proibicoes.md)** | Proibições Tier 0 + **Multi-tenant Tier 0** ([ADR 0093](decisions/0093-multi-tenant-isolation-tier-0.md), "pior bug possível") |
 
 ## Comece aqui (onboarding 7 docs)
 
@@ -33,7 +45,7 @@
 - **[`_INDEX-SECRETS.md`](_INDEX-SECRETS.md)** — índice canon de TODOS secrets do projeto (~20 entradas): Hostinger DNS, Hostinger MySQL, MinIO CT 100, Vaultwarden, Centrifugo, Whatsmeow, Meta Cloud, Asaas, Sicoob, Mailgun, Anthropic, OpenAI, Langfuse, GitHub PAT. Ponteiro (não valor) + status (active/expired/pending/locked) + frequência rotação.
 - Skills correlatas: [`memory-first-secret-search`](../.claude/skills/memory-first-secret-search/SKILL.md) (busca canônica) + [`hostinger-dns-autonomy`](../.claude/skills/hostinger-dns-autonomy/SKILL.md) (autonomia Hostinger).
 
-## 🏛️ Governance & Decisões (148 ADRs)
+## 🏛️ Governance & Decisões (~220 ADRs)
 
 - **[decisions/](decisions/)** — todas ADRs Nygard, **append-only**. Status: `accepted | proposed | historical | superseded`
 - [decisions/_INDEX-LIFECYCLE.md](decisions/_INDEX-LIFECYCLE.md) — índice oficial por lifecycle
@@ -50,7 +62,7 @@
 
 [Lista completa via MCP `decisions-search`]
 
-## 📦 Requisitos por Módulo (37 SPECs)
+## 📦 Requisitos por Módulo (~70 pastas em requisitos/)
 
 `memory/requisitos/<Mod>/SPEC.md` é canônico por módulo. Estrutura típica: `SPEC.md` + `CAPTERRA-FICHA.md` + `CAPTERRA-INVENTARIO.md` + `RUNBOOK-*.md` + `adr/` + `audits/`.
 
@@ -75,7 +87,7 @@
 ## 📚 Knowledge & Reference
 
 - **[reference/](reference/)** — conhecimento canon migrado de auto-mem (post-G1, ADRs [0061](decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md)/[0131](decisions/0131-tiering-memoria-canonico-local-segredo.md))
-- [modulos/](modulos/) — 29 specs auto-geradas via `php artisan module:specs` + [INDEX.md](modulos/INDEX.md) + [RECOMENDACOES.md](modulos/RECOMENDACOES.md)
+- [modulos/](modulos/) — 44 specs auto-geradas (36 ativos · re-index 2026-05-29) via `php artisan module:specs` + [INDEX.md](modulos/INDEX.md) + [RECOMENDACOES.md](modulos/RECOMENDACOES.md)
 - [governance/](governance/) — [CONSTITUTION.md](governance/CONSTITUTION.md), [TRUST-TIERS.md](governance/TRUST-TIERS.md), [IDENTITY-MESH.md](governance/IDENTITY-MESH.md), [ENFORCEMENT.md](governance/ENFORCEMENT.md), [MODULE-DRIFT-MIGRATION-PLAN.md](governance/MODULE-DRIFT-MIGRATION-PLAN.md)
 - [comparativos/](comparativos/) — análises CAPTERRA + concorrentes (memória, RAG, sites)
 - [audits/](audits/) — auditorias históricas ([2026-05-pre-sales/](audits/2026-05-pre-sales/))
@@ -87,9 +99,9 @@
 
 ## 📝 Sessions & Handoffs
 
-- **[handoffs/](handoffs/)** — 15 handoffs **append-only** ([ADR 0130](decisions/0130-handoff-append-only-mcp-first.md)). Sempre ler o mais recente.
+- **[handoffs/](handoffs/)** — ~55 handoffs **append-only** ([ADR 0130](decisions/0130-handoff-append-only-mcp-first.md)). Sempre ler o mais recente.
 - [08-handoff.md](08-handoff.md) — índice "Últimos handoffs" (top 5)
-- **[sessions/](sessions/)** — 81 session logs narrativos (YYYY-MM-DD-slug.md)
+- **[sessions/](sessions/)** — ~227 session logs narrativos (YYYY-MM-DD-slug.md)
 - [CHANGELOG.md](CHANGELOG.md) — eventos estruturais cronológicos (Keep a Changelog)
 
 ## 🌌 Sprints & Programs
@@ -119,5 +131,5 @@ Mantidos por compatibilidade (PontoWr2 origem do projeto). Para core moderno, ve
 - **Tasks NÃO em markdown** ([ADR 0070](decisions/0070-jira-style-task-management-current-md-removed.md)) — use tools MCP `tasks-*`
 
 ---
-**Última atualização:** 2026-05-29 — Constituição promovida a **LEI MÁXIMA** no topo do índice (ADR 0094 mãe + UI-0013 + governance/CONSTITUTION.md). Antes só aparecia enterrada em "ADRs mais citadas" — regressão de indexação reportada pelo Wagner.
+**Última atualização:** 2026-05-29 — **auditoria de indexação & priorização** (Wagner). (1) Constituição promovida a LEI MÁXIMA. (2) Novo bloco "Norte, Protocolo & Skills Tier A" — NORTE-ROI, PROTOCOLO-WAGNER-SEMPRE, how-trabalhar e Skills Tier A estavam ausentes/enterrados (mesma classe de regressão da Constituição). (3) Contagens corrigidas (handoffs 15→~55, sessions 81→~227, ADRs 148→~220, docs 1.536→~2.300, modulos 29→44). Links quebrados de `requisitos/INDEX.md` (7) corrigidos. Pendência: contagens não têm regen automático (drift volta).
 **2026-05-13** — reescrito de 64 linhas (stale, só PontoWr2) → mapa completo. Gap reportado em [AUDITORIA-KNOWLEDGE-ARCHITECTURE-2026-05-13.md](requisitos/Jana/AUDITORIA-KNOWLEDGE-ARCHITECTURE-2026-05-13.md) §5 (G2 P0).

--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -3,6 +3,17 @@
 > Mapa pra navegar `memory/`. Para **estado VIVO** (cycle ativo, tasks, brief), use tools MCP: `brief-fetch`, `my-work`, `cycles-active`, `decisions-search`.
 > Documento canônico — atualizar quando criar nova categoria. Reorg: ver [AUDITORIA-KNOWLEDGE-ARCHITECTURE-2026-05-13](requisitos/Jana/AUDITORIA-KNOWLEDGE-ARCHITECTURE-2026-05-13.md) §5 (G2).
 
+## 🏛️ LEI MÁXIMA — a Constituição (ler ANTES de tudo)
+
+> Documento **supremo** do projeto. Toda decisão, skill, ADR e código **herda** disto e **nunca contradiz**. Append-only (mudança só via nova ADR com `supersedes`).
+
+| Doc | O que é | Status |
+|---|---|---|
+| **[ADR 0094 — Constituição v2](decisions/0094-constituicao-v2-7-camadas-8-principios.md)** | **MÃE** — 7 camadas + 8 princípios duros (Multi-tenant Tier 0 · Context-as-product · Charter>Spec · Loop fechado por métrica · SoC brutal · Transparência · Confiabilidade c/ fallback · Tiered cost) | aceito (vigente) |
+| [governance/CONSTITUTION.md](governance/CONSTITUTION.md) | Versão operacional renderizada (artigos) | vigente |
+| **[ADR UI-0013 — Constituição UI v2](requisitos/_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md)** | Constituição da **UI** (4 camadas: Fundações→Shell→Padrão de Tela→Módulo) | aceito |
+| [ADR 0079](decisions/0079-constituicao-oimpresso-7-camadas-governanca.md) · [ADR 0078](decisions/0078-constituicao-uma-frase-skill-unidade-evolucao.md) | Histórico — origem das 7 camadas + meta-skill "1 frase" | superseded por 0094 |
+
 ## Comece aqui (onboarding 7 docs)
 
 | # | Documento | Quando ler |
@@ -108,4 +119,5 @@ Mantidos por compatibilidade (PontoWr2 origem do projeto). Para core moderno, ve
 - **Tasks NÃO em markdown** ([ADR 0070](decisions/0070-jira-style-task-management-current-md-removed.md)) — use tools MCP `tasks-*`
 
 ---
-**Última atualização:** 2026-05-13 — reescrito de 64 linhas (stale, só PontoWr2) → mapa completo. Gap reportado em [AUDITORIA-KNOWLEDGE-ARCHITECTURE-2026-05-13.md](requisitos/Jana/AUDITORIA-KNOWLEDGE-ARCHITECTURE-2026-05-13.md) §5 (G2 P0).
+**Última atualização:** 2026-05-29 — Constituição promovida a **LEI MÁXIMA** no topo do índice (ADR 0094 mãe + UI-0013 + governance/CONSTITUTION.md). Antes só aparecia enterrada em "ADRs mais citadas" — regressão de indexação reportada pelo Wagner.
+**2026-05-13** — reescrito de 64 linhas (stale, só PontoWr2) → mapa completo. Gap reportado em [AUDITORIA-KNOWLEDGE-ARCHITECTURE-2026-05-13.md](requisitos/Jana/AUDITORIA-KNOWLEDGE-ARCHITECTURE-2026-05-13.md) §5 (G2 P0).

--- a/memory/requisitos/INDEX.md
+++ b/memory/requisitos/INDEX.md
@@ -28,18 +28,18 @@ Espinha dorsal do roadmap de faturamento (2 anos). Ver [_Roadmap_Faturamento.md]
 
 Clique para ver requisitos funcionais.
 
-- [Accounting](Accounting.md)
+- [Accounting](Accounting/)
 - [AssetManagement](AssetManagement.md)
 - [Cms](Cms.md)
 - [Connector](Connector.md)
-- [Crm](Crm.md)
-- [Essentials](Essentials.md)
-- [Manufacturing](Manufacturing.md)
-- [PontoWr2](PontoWr2.md) — pasta completa em `PontoWr2/`
+- [Crm](Crm/)
+- [Essentials](Essentials/)
+- [Manufacturing](Manufacturing/)
+- [PontoWr2](PontoWr2/) — pasta completa
 - [MemCofre](MemCofre/) — Cofre de Memórias / docs vivos
 - [ProductCatalogue](ProductCatalogue.md)
-- [Project](Project.md)
-- [Repair](Repair.md)
+- [ProjectMgmt](ProjectMgmt/) — (era `Project.md`, legado UltimatePOS removido)
+- [Repair](Repair/)
 - [Spreadsheet](Spreadsheet.md)
 - [Superadmin](Superadmin.md)
 - [Woocommerce](Woocommerce.md)


### PR DESCRIPTION
## Por quê

Wagner apontou que a **Constituição** não estava listada como doc principal no índice mestre. Investigação aprofundada (3 frentes paralelas: inventário de índices · integridade/órfãos · priorização) revelou que **era só o 1º caso de uma CLASSE de regressão**: o `memory/INDEX.md` surfaça bem o *navegacional* (módulos/ADRs/sessions) mas falhava sistematicamente no *normativo-supremo não-ADR*.

## Fixes

**1. Priorização (`memory/INDEX.md`)**
- 🏛️ **Constituição** promovida a LEI MÁXIMA no topo (ADR 0094 + UI-0013 + governance/CONSTITUTION.md).
- 🎯 Novo bloco **"Norte, Protocolo & Skills Tier A"** — estavam ausentes/enterrados:
  - **NORTE-ROI** (meta R$5M, "norte único") — era **AUSENTE**.
  - **PROTOCOLO-WAGNER-SEMPRE** (R1–R11, "REGRA ZERO Tier 0") — era **AUSENTE**.
  - **how-trabalhar** (protocolo de sessão) — enterrado em "onboarding".
  - **Skills Tier A** (7 always-on) — só 2 vazavam incidentalmente.

**2. Contagens stale** (o índice atualizava o rodapé mas não os números):
handoffs 15→~55 · sessions 81→~227 · ADRs 148→~220 · docs ~1.536→~2.300 · modulos 29→44.

**3. Integridade (`memory/requisitos/INDEX.md`)** — 7 links quebrados corrigidos (apontavam `.md` inexistente; alvo é pasta): `Accounting.md→Accounting/`, `Project.md→ProjectMgmt/`, Crm/Essentials/Manufacturing/PontoWr2/Repair.

## Pendência registrada
Contagens não têm regen automático → drift volta. Candidato a gate/skill `memory-sync`.

Ao mergear, sincroniza pro MCP (`mcp_memory_documents`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
