### PR TITLE
feat(jana): US-RET-001 — business_id no índice mcp_memory_documents (pré-req tenant-safe gap #2)

### DIFF
--- a/Modules/Jana/Entities/Mcp/McpMemoryDocument.php
+++ b/Modules/Jana/Entities/Mcp/McpMemoryDocument.php
@@ -20,6 +20,8 @@ use Laravel\Scout\Searchable;
  * `business_id` nullable preserva back-compat (legado pré-MEM-MULTI-1) mas
  * default é NULL (compartilhado). Wave 25 SATURATION marker explícito pra
  * rubrica D1.c v3.2 hardened.
+ *
+ * @property int|null $business_id business_id nullable (NULL = doc plataforma). Migration ALTER pós-create — anotado p/ larastan ver no toSearchableArray (US-RET-001).
  */
 class McpMemoryDocument extends Model
 {
@@ -180,6 +182,11 @@ class McpMemoryDocument extends Model
 
         return [
             'id'              => $this->id,
+            // business_id no índice = pré-req multi-tenant (Tier 0, ADR 0093) pra
+            // rotear as tools MCP pelo hybrid SEM vazar tenant. Filtro alvo no search:
+            // (business_id IS NULL [doc plataforma] OR business_id = X) — espelha o
+            // scope doBusiness(). NULL = ADR/doc platform-wide, visível a todos.
+            'business_id'     => $this->business_id,
             'slug'            => $this->slug,
             'title'           => $this->title,
             'content_md'      => $contentIndexed,

--- a/Modules/Jana/Tests/Feature/Mcp/McpMemoryDocumentTenantIndexTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/McpMemoryDocumentTenantIndexTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Entities\Mcp\McpMemoryDocument;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-RET-001 (SPEC-retrieval-tools-mcp-unificado, gap #2) — pré-req multi-tenant.
+ *
+ * Pra rotear as tools MCP (decisions-search/memoria-search/kb-answer) pelo pipeline
+ * hybrid SEM vazar tenant, o índice Meilisearch precisa de `business_id` filterável.
+ * Aqui blindamos que toSearchableArray emite `business_id` — incl. NULL (doc plataforma
+ * = ADR visível a todos). O routing em si fica pra US-RET-003 + reindex CT 100.
+ *
+ * Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093): sem business_id no índice, o filtro
+ * de tenant some no search → vazamento cross-business (pior bug do projeto).
+ */
+
+it('toSearchableArray inclui business_id (pré-req tenant-safe do routing)', function () {
+    $doc = new McpMemoryDocument();
+    $doc->business_id = 4;
+    $doc->content_md = '# doc de teste';
+
+    $arr = $doc->toSearchableArray();
+
+    expect($arr)->toHaveKey('business_id')
+        ->and($arr['business_id'])->toBe(4);
+});
+
+it('business_id NULL (doc plataforma/ADR) é preservado no índice, não some', function () {
+    $doc = new McpMemoryDocument();
+    $doc->business_id = null;
+    $doc->content_md = '# ADR plataforma';
+
+    expect($doc->toSearchableArray())->toHaveKey('business_id')
+        ->and($doc->toSearchableArray()['business_id'])->toBeNull();
+});

--- a/config/scout.php
+++ b/config/scout.php
@@ -140,9 +140,14 @@ return [
         'host' => env('MEILISEARCH_HOST', 'http://localhost:7700'),
         'key' => env('MEILISEARCH_KEY'),
         'index-settings' => [
-            // 'users' => [
-            //     'filterableAttributes'=> ['id', 'name', 'email'],
-            // ],
+            // mcp_memory_documents — `business_id` filterable = pré-req multi-tenant
+            // (Tier 0, ADR 0093) pra rotear as tools MCP pelo hybrid SEM vazar tenant
+            // (SPEC-retrieval-tools-mcp-unificado, gap #2). Filtro alvo no search:
+            // "business_id IS NULL OR business_id = X" (espelha doBusiness()).
+            // Aplicar em prod/CT 100 com: php artisan scout:sync-index-settings
+            'mcp_memory_documents' => [
+                'filterableAttributes' => ['business_id', 'type', 'status', 'module'],
+            ],
         ],
     ],
 

--- a/memory/requisitos/Jana/SPEC-retrieval-tools-mcp-unificado.md
+++ b/memory/requisitos/Jana/SPEC-retrieval-tools-mcp-unificado.md
@@ -28,11 +28,12 @@ O chat tem retrieval estado-da-arte (`MeilisearchDriver`: hybrid+HyDE+RRF+time-d
 
 ## User stories (recalibradas ADR 0106)
 
-### US-RET-001 — Embeddings no corpus do time (`mcp_memory_documents`) · P0 · ~3-5h
-- Configurar embedder (`text-embedding-3-small` ou `qwen3_local`, alinhar com o índice do chat) no índice Scout de `McpMemoryDocument`.
-- `toSearchableArray` + `shouldBeSearchable` revisados; backfill via `scout:import`.
-- **Pré-req de tudo abaixo** — sem semântica no corpus, hybrid não tem o que recuperar. Sem bloqueio (Meilisearch já roda — ADR 0058).
-- **Aceite:** `McpMemoryDocument::search()` retorna por similaridade semântica; smoke cross-tenant (biz=1 vs biz=99) não vaza.
+### US-RET-001 — Embeddings + `business_id` no índice do corpus · P0 · 🟡 EM PARTE FEITO
+> **Correção 2026-05-29:** o estado-da-arte disse "sem embeddings" — **errado**. `McpMemoryDocument` **já tem Scout/Meilisearch hybrid + embedder** (Sprint 9, ADR 0068) + Contextual Retrieval. O embedder JÁ existe.
+> O pré-req real que faltava era **multi-tenant**: `toSearchableArray` **não emitia `business_id`** → rotear as tools pelo Scout vazaria tenant (P0).
+- ✅ **Feito (PR desta US):** `business_id` adicionado a `toSearchableArray` (NULL = doc plataforma) + `filterableAttributes` em `config/scout.php` + Pest (`McpMemoryDocumentTenantIndexTest`). PHPStan limpo (`@property` anotado).
+- ⏳ **Pendente (deploy CT 100, não-código):** `php artisan scout:sync-index-settings` + `scout:import "Modules\Jana\Entities\Mcp\McpMemoryDocument"` (reindex com o novo campo). Verificar embedder ativo no índice.
+- **Aceite:** após reindex, `McpMemoryDocument::search()->where('business_id', …)` filtra por tenant; smoke biz=1 vs biz=99 não vaza.
 
 ### US-RET-002 — Retriever business-scoped reutilizável · P0 · ~2-3h
 - Novo método/serviço de retrieval hybrid sobre `mcp_memory_documents` que recebe **`businessId` (sem `userId`)** + filtros de tipo/lifecycle, reaproveitando a lógica de hybrid+RRF+rerank+decay do `MeilisearchDriver` (extrair o que é genérico; NÃO copiar o filtro user).


### PR DESCRIPTION
## Por quê

US-RET-001 da [SPEC](memory/requisitos/Jana/SPEC-retrieval-tools-mcp-unificado.md). A investigação **corrigiu a premissa**: `McpMemoryDocument` **já tem Scout/Meilisearch hybrid + embedder** (Sprint 9, ADR 0068) — o estado-da-arte errou ao dizer "sem embeddings". 

O pré-req real que faltava é **multi-tenant**: `toSearchableArray` **não emitia `business_id`** → rotear as tools MCP pelo Scout **vazaria tenant** (P0, [ADR 0093](memory/decisions/0093-multi-tenant-isolation-tier-0.md) — pior bug do projeto). Esse é o motivo de eu **não** ter mergeado o routing às cegas.

## O que entrega (aditivo, zero mudança de comportamento)

- `toSearchableArray` agora emite `business_id` (NULL = doc plataforma/ADR, visível a todos).
- `config/scout.php`: `filterableAttributes` do índice `mcp_memory_documents` (`business_id/type/status/module`) → habilita filtro de tenant no search.
- `@property int|null $business_id` anotado (larastan não via — migration ALTER pós-create).
- Pest `McpMemoryDocumentTenantIndexTest`: business_id presente + NULL preservado. **2 passed. PHPStan: No errors.**
- SPEC US-RET-001 reescrita.

**Nenhuma tool é roteada ainda** — é só o pré-req. O routing (US-RET-003) só fica seguro após o reindex.

## Pendente (deploy CT 100 — não-código)
`php artisan scout:sync-index-settings` + `scout:import "Modules\Jana\Entities\Mcp\McpMemoryDocument"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
