### PR TITLE
feat(jana): US-RET-001 — decisions-search + kb-answer via hybrid no corpus MCP (flag OFF, gap #2)

### DIFF
--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -246,7 +246,12 @@ return [
     | aqui ainda — dependem de verificar o embedder do índice no CT 100 (US-RET-001).
     */
     'mcp_search' => [
+        // memoria-search → jana_memoria_facts (corpus Jana, BUSINESS-scoped). US-RET-002.
         'memoria_pipeline' => (bool) env('JANA_MCP_SEARCH_PIPELINE_MEMORIA', false),
+        // decisions-search + kb-answer → mcp_memory_documents (corpus MCP GLOBAL, sem
+        // filtro tenant). US-RET-001. Embedder qwen3_local + filterable status/type/module
+        // verificados no índice live (CT 100). Default OFF; só caminho ativo (não archived).
+        'docs_pipeline' => (bool) env('JANA_MCP_SEARCH_PIPELINE_DOCS', false),
     ],
 
     'reranker' => [

--- a/Modules/Jana/Entities/Mcp/McpMemoryDocument.php
+++ b/Modules/Jana/Entities/Mcp/McpMemoryDocument.php
@@ -121,6 +121,45 @@ class McpMemoryDocument extends Model
     }
 
     /**
+     * Busca HYBRID (semantic + full-text) no índice Meilisearch — para as tools MCP
+     * decisions-search/kb-answer recuperarem com a qualidade do pipeline do chat.
+     *
+     * Corpus MCP é GLOBAL (conhecimento de programação/produto — serve TODOS os
+     * clientes). Verificado no índice live (CT 100): filterableAttributes =
+     * [status, type, module, slug], SEM business_id. Logo NÃO filtra tenant — só
+     * status ativo + type/module no Meilisearch + acessiveisPara (permissão Spatie)
+     * na hidratação. Embedder/ratio do config (qwen3_local / 0.6, mesmos do chat).
+     * `shouldBeSearchable` já exclui superseded/deprecated do índice (status = defesa extra).
+     *
+     * @return \Illuminate\Database\Eloquent\Collection<int, static>
+     */
+    public static function buscarHybrid(string $query, int $limit, ?\App\User $user, ?string $tipo = null, ?string $module = null): \Illuminate\Database\Eloquent\Collection
+    {
+        $embedder = (string) config('copiloto.memoria.meilisearch.embedder', 'qwen3_local');
+        $ratio    = (float) config('copiloto.memoria.meilisearch.semantic_ratio', 0.6);
+
+        $filtros = ["status IN ['aceito','accepted','accepted-historical']"];
+        if ($tipo !== null && $tipo !== '' && $tipo !== 'all') {
+            $filtros[] = "type = '".addslashes($tipo)."'";
+        }
+        if ($module !== null && $module !== '') {
+            $filtros[] = "module = '".addslashes($module)."'";
+        }
+        $filtro = implode(' AND ', $filtros);
+
+        return static::search($query, function ($index, string $q, array $params) use ($embedder, $ratio, $filtro, $limit) {
+            $params['hybrid'] = ['embedder' => $embedder, 'semanticRatio' => $ratio];
+            $params['filter'] = $filtro;
+            $params['limit']  = $limit;
+
+            return $index->search($q, $params);
+        })
+            ->query(fn ($q) => $q->acessiveisPara($user))
+            ->take($limit)
+            ->get();
+    }
+
+    /**
      * Filtra documentos por status no metadata (triagem 2026-05-06).
      *
      * Status canônicos:

--- a/Modules/Jana/Mcp/Tools/DecisionsSearchTool.php
+++ b/Modules/Jana/Mcp/Tools/DecisionsSearchTool.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Modules\Jana\Mcp\Tools;
 
 use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\Support\Facades\Log;
 use Laravel\Mcp\Request;
 use Laravel\Mcp\Response;
 use Laravel\Mcp\Server\Tool;
@@ -55,17 +56,34 @@ class DecisionsSearchTool extends Tool
         $user = $request->user();
         $businessId = (int) data_get($user, 'business_id', 0);
 
-        // Filtra por empresa (multi-tenant MEM-MULTI-1) + permissão Spatie + status lifecycle
-        $q = McpMemoryDocument::doTipo('adr')
-            ->acessiveisPara($user)
-            ->porStatusAtivo($includeArchived)
-            ->buscarTexto($query);
-
-        if ($businessId > 0) {
-            $q->doBusiness($businessId);
+        // Gap #2 (US-RET-001) — pipeline bom HYBRID atrás de flag, fallback FULLTEXT.
+        // Corpus MCP é GLOBAL (sem filtro business_id — verificado no índice CT 100).
+        // Só no caminho ativo (índice exclui superseded; archived continua FULLTEXT).
+        $rows = null;
+        if (! $includeArchived && config('copiloto.mcp_search.docs_pipeline', false)) {
+            try {
+                $hybrid = McpMemoryDocument::buscarHybrid($query, $limit, $user instanceof \App\User ? $user : null, 'adr');
+                if ($hybrid->isNotEmpty()) {
+                    $rows = $hybrid;
+                }
+            } catch (\Throwable $e) {
+                Log::channel('copiloto-ai')->warning('decisions-search: hybrid falhou, fallback FULLTEXT: '.$e->getMessage());
+            }
         }
 
-        $rows = $q->limit($limit)->get(['slug', 'title', 'content_md', 'metadata']);
+        // FULLTEXT (default / fallback). Filtra permissão Spatie + status lifecycle.
+        if ($rows === null) {
+            $q = McpMemoryDocument::doTipo('adr')
+                ->acessiveisPara($user)
+                ->porStatusAtivo($includeArchived)
+                ->buscarTexto($query);
+
+            if ($businessId > 0) {
+                $q->doBusiness($businessId);
+            }
+
+            $rows = $q->limit($limit)->get(['slug', 'title', 'content_md', 'metadata']);
+        }
 
         if ($rows->isEmpty()) {
             $hint = $includeArchived

--- a/Modules/Jana/Mcp/Tools/KbAnswerTool.php
+++ b/Modules/Jana/Mcp/Tools/KbAnswerTool.php
@@ -190,6 +190,25 @@ class KbAnswerTool extends Tool
     ): \Illuminate\Support\Collection {
         $businessId = (int) data_get($user, 'business_id', 0);
 
+        // Gap #2 (US-RET-001) — recall HYBRID atrás de flag, fallback FULLTEXT.
+        // Corpus MCP é GLOBAL (sem filtro business_id — verificado no índice CT 100).
+        if (config('copiloto.mcp_search.docs_pipeline', false)) {
+            try {
+                $hybrid = McpMemoryDocument::buscarHybrid(
+                    $pergunta,
+                    $topK,
+                    $user,
+                    $categoria !== 'all' ? $categoria : null,
+                    $module !== '' ? $module : null,
+                );
+                if ($hybrid->isNotEmpty()) {
+                    return $hybrid;
+                }
+            } catch (\Throwable $e) {
+                Log::channel('copiloto-ai')->warning('kb-answer: hybrid falhou, fallback FULLTEXT: '.$e->getMessage());
+            }
+        }
+
         $query = McpMemoryDocument::query()
             ->acessiveisPara($user)
             ->porStatusAtivo(false)   // só docs ativos

--- a/Modules/Jana/Tests/Feature/Mcp/McpDocsHybridSearchTest.php
+++ b/Modules/Jana/Tests/Feature/Mcp/McpDocsHybridSearchTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Entities\Mcp\McpMemoryDocument;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Gap #2 US-RET-001 — decisions-search/kb-answer via HYBRID no corpus MCP (global).
+ *
+ * buscarHybrid foi VERIFICADO live no índice CT 100 (embedder qwen3_local, filtro
+ * status/type, retornou ADRs corretos). Aqui o smoke garante que o método é callable
+ * e degrada limpo com SCOUT_DRIVER=null (CI) — devolve Collection vazia, nunca fatal,
+ * o que dispara o fallback FULLTEXT nas tools. Recall real é validado em prod (US-RET-003).
+ */
+
+it('buscarHybrid é callable e degrada limpo (SCOUT_DRIVER=null → Collection vazia, sem fatal)', function () {
+    $r = McpMemoryDocument::buscarHybrid('isolamento multi-tenant', 5, null, 'adr');
+    expect($r)->toBeInstanceOf(\Illuminate\Database\Eloquent\Collection::class)
+        ->and($r)->toBeEmpty();
+});
+
+it('buscarHybrid aceita tipo/module opcionais sem quebrar', function () {
+    expect(McpMemoryDocument::buscarHybrid('x', 3, null))->toBeEmpty()
+        ->and(McpMemoryDocument::buscarHybrid('x', 3, null, 'spec', 'Financeiro'))->toBeEmpty();
+});

--- a/memory/requisitos/Jana/SPEC-retrieval-tools-mcp-unificado.md
+++ b/memory/requisitos/Jana/SPEC-retrieval-tools-mcp-unificado.md
@@ -39,11 +39,12 @@ Os **dois** corpora **já têm Scout/Meilisearch hybrid + embedder** (ADR 0068 p
 
 ## User stories (recalibradas ADR 0106)
 
-### US-RET-001 — Rotear `decisions-search` + `kb-answer` (corpus MCP, GLOBAL) · P0 · ~2-4h
-- Trocar `McpMemoryDocument::...->buscarTexto()` por `McpMemoryDocument::search($q, callback hybrid)` (índice já tem embedder, ADR 0068).
-- **SEM filtro de tenant** — corpus global de programação. Preservar só `porStatusAtivo` (não retornar superseded) + `acessiveisPara($user)` (permissões Spatie / `scope_required` / `admin_only`) — que são **permissão**, não tenant.
-- Flag `JANA_MCP_SEARCH_PIPELINE` (default OFF) + fallback gracioso pro `buscarTexto` (ADR 0036/0056).
-- **Aceite:** flag OFF = byte-a-byte atual; flag ON = recall melhor; `acessiveisPara`/`porStatusAtivo` preservados.
+### US-RET-001 — Rotear `decisions-search` + `kb-answer` (corpus MCP, GLOBAL) · P0 · ✅ FEITO
+- ✅ `McpMemoryDocument::buscarHybrid(query, limit, user, tipo?, module?)` — Scout hybrid (embedder `qwen3_local` + semanticRatio do config). **Verificado LIVE no índice CT 100**: embedder qwen3_local, filterableAttributes `[status,type,module,slug]` (SEM business_id → corpus global), 1048 docs 100% embedded; busca semântica "isolamento multi-tenant" retornou ADR 0006/0093/0218/ARQ-0001.
+- ✅ **SEM filtro de tenant** — só status ativo + type/module (Meilisearch) + `acessiveisPara` (permissão Spatie) na hidratação.
+- ✅ `decisions-search` + `kb-answer::buscarFontes` roteados atrás de `JANA_MCP_SEARCH_PIPELINE_DOCS` (default OFF) + fallback gracioso pro `buscarTexto` (erro/vazio). archived continua FULLTEXT (índice não tem superseded).
+- ✅ Testes: smoke buscarHybrid + KbAnswerToolTest (8, flag OFF = byte-a-byte). PHPStan limpo.
+- ⏳ **Pendente:** ligar `JANA_MCP_SEARCH_PIPELINE_DOCS=true` em prod + validar recall (US-RET-003).
 
 ### US-RET-002 — Rotear `memoria-search` (corpus Jana, per-cliente) · P1 · ✅ FEITO
 - ✅ `MeilisearchDriver::buscarBusiness(biz, query, topK)` — variante **`business_id`-scoped** (`userId` nullable em `buscarInterno`; com userId≠null o chat fica byte-idêntico — 29 testes do pipeline verdes). NÃO reusa `buscar(business,user)`.


### PR DESCRIPTION
## Por quê

Fecha o gap #2 pro **corpus MCP** (`mcp_memory_documents` = conhecimento de programação, **GLOBAL** — todos os clientes). `decisions-search`/`kb-answer` rodavam FULLTEXT cru.

## Verificado LIVE no CT 100 (não chutado)

Acessei o servidor (`tailscale ssh ct100-mcp`) e consultei o índice Meilisearch real:
- **embedder = `qwen3_local`** (mesmo do chat); semanticRatio do config.
- **filterableAttributes = `[status, type, module, slug]` → SEM `business_id`** (corpus global — confirma o revert #1928). 1048 docs, **100% embedded**.
- Smoke real: busca semântica "isolamento multi-tenant por business_id" → retornou **ADR 0006 / 0093 / 0218 / ARQ-0001** (`semanticHitCount: 4`).

## O que entrega

- `McpMemoryDocument::buscarHybrid()` — Scout hybrid + filtro `status`/`type`/`module` (Meilisearch) + `acessiveisPara` (permissão Spatie) na hidratação. **Sem filtro de tenant** (corpus global).
- `decisions-search` + `kb-answer::buscarFontes` roteados atrás de `JANA_MCP_SEARCH_PIPELINE_DOCS` (default **OFF**) + fallback gracioso pro `buscarTexto`. `archived` continua FULLTEXT (índice exclui superseded).
- Testes: smoke `buscarHybrid` (degrada limpo com SCOUT_DRIVER=null) + **KbAnswerToolTest 8 verdes** (flag OFF = byte-a-byte). **PHPStan: No errors.**

Flag OFF = comportamento atual idêntico. Ligar + validar recall em prod = US-RET-003.

Refs: ADR 0053/0056/0068/0093 · verificado no índice CT 100

🤖 Generated with [Claude Code](https://claude.com/claude-code)
