### PR TITLE
infra(jana): INFRA-ACESSO-CANON + fix Dockerfile MCP (exts faltantes)

### DIFF
--- a/docker/oimpresso-mcp/Dockerfile.octane
+++ b/docker/oimpresso-mcp/Dockerfile.octane
@@ -10,7 +10,11 @@ FROM dunglas/frankenphp:php8.4-alpine
 
 WORKDIR /var/www/html
 
-# Extensões PHP do Laravel (mesmo set do FPM anterior)
+# Extensões PHP do Laravel.
+# gd/soap/sockets/opentelemetry adicionados 2026-05-29: o composer.lock atual exige
+# essas exts (composer install falhava com "ext-gd/soap/sockets/opentelemetry missing"
+# → bloqueava deploy do código novo no container, que ficou 1302 commits atrás).
+# Ver memory/reference/INFRA-ACESSO-CANON.md (deploy oimpresso-mcp).
 RUN install-php-extensions \
         pdo_mysql \
         intl \
@@ -18,7 +22,11 @@ RUN install-php-extensions \
         zip \
         opcache \
         pcntl \
-        redis
+        redis \
+        gd \
+        soap \
+        sockets \
+        opentelemetry
 
 # OPcache + JIT em produção pra acelerar boot inicial e código quente
 COPY php.ini /usr/local/etc/php/conf.d/zz-mcp-overrides.ini

--- a/memory/INDEX.md
+++ b/memory/INDEX.md
@@ -87,6 +87,7 @@
 ## 📚 Knowledge & Reference
 
 - **[reference/](reference/)** — conhecimento canon migrado de auto-mem (post-G1, ADRs [0061](decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md)/[0131](decisions/0131-tiering-memoria-canonico-local-segredo.md))
+  - 🖥️ **[reference/INFRA-ACESSO-CANON.md](reference/INFRA-ACESSO-CANON.md)** — **mapa ÚNICO de acesso a TODA máquina** (CT 100 via `tailscale ssh root@ct100-mcp`, Hostinger SSH, deploy do MCP, Meilisearch, DNS, secrets). Claude NUNCA diz "não tenho acesso". + [hostinger.md](reference/hostinger.md)
 - [modulos/](modulos/) — 44 specs auto-geradas (36 ativos · re-index 2026-05-29) via `php artisan module:specs` + [INDEX.md](modulos/INDEX.md) + [RECOMENDACOES.md](modulos/RECOMENDACOES.md)
 - [governance/](governance/) — [CONSTITUTION.md](governance/CONSTITUTION.md), [TRUST-TIERS.md](governance/TRUST-TIERS.md), [IDENTITY-MESH.md](governance/IDENTITY-MESH.md), [ENFORCEMENT.md](governance/ENFORCEMENT.md), [MODULE-DRIFT-MIGRATION-PLAN.md](governance/MODULE-DRIFT-MIGRATION-PLAN.md)
 - [comparativos/](comparativos/) — análises CAPTERRA + concorrentes (memória, RAG, sites)

--- a/memory/reference/INFRA-ACESSO-CANON.md
+++ b/memory/reference/INFRA-ACESSO-CANON.md
@@ -1,0 +1,74 @@
+---
+name: INFRA-ACESSO-CANON — mapa único de todas as máquinas, acessos e o que roda onde
+description: Fonte ÚNICA de acesso à infra do oimpresso — Tailscale (CT 100, dev), Hostinger (ERP prod), Proxmox, DNS, secrets. Como conectar em CADA máquina + o que roda onde + deploy. Claude NUNCA deve dizer "não tenho acesso" — está tudo aqui; secrets reais no Vaultwarden.
+type: reference
+authority: canonical
+lifecycle: ativo
+decided_at: 2026-05-29
+related_adrs: [0045, 0053, 0058, 0062]
+related: [hostinger.md, hostinger-remote-mysql.md, _INDEX-SECRETS.md]
+---
+
+# INFRA-ACESSO-CANON — todas as máquinas, como acessar, o que roda
+
+> ⛔ **Claude: NUNCA diga "não tenho acesso" / "não sei como conectar".** Está tudo aqui.
+> Tudo via **Tailscale** (já up no PC). Secrets reais no **Vaultwarden** (`vault.oimpresso.com`).
+
+## Máquinas (Tailscale — `tailscale status`)
+
+| Nome | IP Tailscale | O que é | Como acessar |
+|---|---|---|---|
+| **ct100-mcp** | `100.99.207.66` | **CT 100 Proxmox** — TODOS os daemons + o MCP server | `tailscale ssh root@ct100-mcp` (auth Tailscale, **sem senha**) |
+| **pve-empresa** | `100.116.24.69` | Host Proxmox (hypervisor do CT 100) | `tailscale ssh root@pve-empresa` |
+| **oimpresso-sistema** | `100.108.23.105` | Windows (máquina dev/sistema) | Tailscale |
+| **claude-code-wagner-pc** | `100.92.78.86` | Este PC (onde o Claude Code roda) | — |
+| **Hostinger** (não-Tailscale) | `148.135.133.115:65002` | **Shared hosting — ERP `oimpresso.com` prod** | `ssh -4 -i ~/.ssh/id_ed25519_oimpresso -p 65002 u906587222@148.135.133.115` (warm-up curl 5× antes — ver [hostinger.md](hostinger.md)) |
+
+Chave SSH única: `~/.ssh/id_ed25519_oimpresso`. **Separação de runtime ([ADR 0062](../decisions/0062-separacao-runtime-hostinger-ct100.md)): Hostinger = ERP web (sem daemons); CT 100 = TODO daemon/IA/MCP.**
+
+## CT 100 (`ct100-mcp`) — o coração da infra
+
+**Acesso:** `tailscale ssh root@ct100-mcp "COMANDO"` — não pede senha (identidade Tailscale). Funciona non-interactive (ao contrário do SSH-senha, que é bloqueado neste agente GUI).
+
+**Containers (docker, ~20):**
+`meilisearch` · `ollama-embedder` · **`oimpresso-mcp`** (MCP server) · `bge-reranker` · `centrifugo` · `langfuse-web`/`worker`/`postgres-langfuse`/`redis-langfuse`/`clickhouse-langfuse` · `minio-langfuse` · `growthbook`(+`mongo`) · `whatsapp-whatsmeow` · `jaeger` · `mysql-workers` · `traefik` · `portainer` · `vaultwarden`.
+
+### oimpresso-mcp (o MCP server — `mcp.oimpresso.com`)
+- **Runtime:** FrankenPHP + Laravel Octane (16 workers, `--max-requests=500`). Laravel 13.6.
+- **Código:** bind-mount **host `/opt/oimpresso-mcp/code` → container `/var/www/html`**. git fica no **host** (`/usr/bin/git`), NÃO no container.
+- **Imagem:** `oimpresso/mcp:latest` · compose+Dockerfile: `docker/oimpresso-mcp/{docker-compose.yml,Dockerfile.octane}` (no repo).
+- **DB:** usa o **MySQL da Hostinger** `u906587222_oimpresso` (compartilhado) — migrations rodadas lá; CT 100 só roda o app.
+- **.env:** `/opt/oimpresso-mcp/code/.env` (host).
+
+**Deploy (code-only, sem migration — schema vem da Hostinger):**
+```bash
+tailscale ssh root@ct100-mcp '
+  cd /opt/oimpresso-mcp/code && git fetch origin main && git reset --hard origin/main &&
+  docker exec oimpresso-mcp sh -c "cd /var/www/html && composer install --optimize-autoloader --no-interaction" &&
+  docker exec oimpresso-mcp php artisan config:clear &&
+  docker exec oimpresso-mcp php artisan octane:reload   # reload gracioso (workers em mem)
+'
+```
+**Se mudar Dockerfile/exts → rebuild:** `cd docker/oimpresso-mcp && docker compose build && docker compose up -d` (recria container = breve downtime; tag a imagem antiga antes pra rollback).
+**Rollback:** `git reset --hard <sha-anterior>` + `octane:reload` (~30s).
+
+### Meilisearch (CT 100)
+- Não publica porta no host. Consultar **de dentro do container**: `docker exec meilisearch sh -c 'curl -s http://localhost:7700/... -H "Authorization: Bearer $MEILI_MASTER_KEY"'` (key via env interno, nunca imprimir).
+- Índices: `jana_memoria_facts` (Jana, per-cliente) + `mcp_memory_documents` (MCP, global). Embedders ollama: **`qwen3_local`** (qwen3-embedding:0.6b, 1024d) + `nomic_local`. filterableAttributes do mcp_memory_documents: `[status,type,module,slug]` (SEM business_id — corpus global).
+
+## DNS (Hostinger API)
+`developers.hostinger.com/api/dns/v1/zones/oimpresso.com` (PUT `overwrite:false`). Token no Vaultwarden (`hostinger-api-token`). A-records de serviço → **`177.74.67.30`** (IP público CT 100). Detalhe: [ADR 0045](../decisions/0045-hostinger-dns-api-endpoint-canonico.md) + [hostinger.md](hostinger.md).
+
+## Secrets
+**Vaultwarden** `vault.oimpresso.com` (container CT 100). Índice canon: [_INDEX-SECRETS.md](_INDEX-SECRETS.md). NUNCA commitar valor; sempre ponteiro.
+
+## Estado conhecido (2026-05-29)
+- ⚠️ **`oimpresso-mcp` estava 1302 commits atrás** de `origin/main` (HEAD #799). DB em dia (0 migrations pendentes). Deploy do código novo estava **bloqueado**: `Dockerfile.octane` não tinha `gd/soap/sockets/opentelemetry` → `composer install` falhava. **Corrigido no Dockerfile 2026-05-29** (rebuild necessário pra aplicar).
+
+## Regras de ouro
+- CT 100 → **`tailscale ssh root@ct100-mcp`** (sempre funciona, sem senha).
+- Hostinger → SSH `-4 -p 65002` com warm-up (ver [hostinger.md](hostinger.md)).
+- NUNCA `computer-use` pra operar servidor — sempre SSH/API.
+- NUNCA editar arquivo no servidor sem commit no git (drift).
+- NUNCA daemons/octane/meilisearch no Hostinger ([ADR 0062](../decisions/0062-separacao-runtime-hostinger-ct100.md)).
+- Meilisearch query → de dentro do container (porta não publicada).


### PR DESCRIPTION
## O que é

Wagner: "consolide esse conhecimento, nunca mais diga que não sabe sobre infra, pesquise antes". Acessei o CT 100 (`tailscale ssh`) e consolidei.

1. **`memory/reference/INFRA-ACESSO-CANON.md`** — fonte ÚNICA de acesso: Tailscale (ct100-mcp `100.99.207.66` via `tailscale ssh root@ct100-mcp` sem senha; Hostinger SSH `148.135.133.115:65002`), os 20 containers do CT 100, deploy do `oimpresso-mcp` (FrankenPHP+Octane, bind `/opt/oimpresso-mcp/code`, `octane:reload`), DB compartilhado, Meilisearch (query de dentro do container, embedders `qwen3_local`/`nomic_local`), DNS, secrets. Linkado no índice mestre.

2. **fix `Dockerfile.octane`** — adiciona `gd/soap/sockets/opentelemetry`. O `composer.lock` atual exige; sem elas `composer install` falha → deploy do container travava.

## Descoberta (crítica)
O `oimpresso-mcp` em prod estava **1302 commits atrás** (HEAD #799), DB em dia (0 migrations pendentes). Deploy bloqueado pelas exts faltantes — destravado por este PR. **Rebuild da imagem aplica** (próximo passo, ativação do gap #2).

Refs: ADR 0045/0053/0058/0062 · hostinger.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)
