### PR TITLE
fix(jana): buscarHybrid usa embedder qwen3_local (não 'openai' do chat)

### DIFF
--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -252,6 +252,10 @@ return [
         // filtro tenant). US-RET-001. Embedder qwen3_local + filterable status/type/module
         // verificados no índice live (CT 100). Default OFF; só caminho ativo (não archived).
         'docs_pipeline' => (bool) env('JANA_MCP_SEARCH_PIPELINE_DOCS', false),
+        // Embedder do índice mcp_memory_documents (qwen3_local OU nomic_local — ambos
+        // existem no índice). Separado da config do chat (que resolve 'openai', inexistente
+        // neste índice). Verificado live CT 100 2026-05-29.
+        'docs_embedder' => env('JANA_MCP_DOCS_EMBEDDER', 'qwen3_local'),
     ],
 
     'reranker' => [

--- a/Modules/Jana/Entities/Mcp/McpMemoryDocument.php
+++ b/Modules/Jana/Entities/Mcp/McpMemoryDocument.php
@@ -135,7 +135,10 @@ class McpMemoryDocument extends Model
      */
     public static function buscarHybrid(string $query, int $limit, ?\App\User $user, ?string $tipo = null, ?string $module = null): \Illuminate\Database\Eloquent\Collection
     {
-        $embedder = (string) config('copiloto.memoria.meilisearch.embedder', 'qwen3_local');
+        // Embedder do índice mcp_memory_documents (verificado live CT 100: nomic_local +
+        // qwen3_local). NÃO usar copiloto.memoria.meilisearch.embedder — essa é a do chat
+        // (jana_memoria_facts), que no prod resolve 'openai' e NÃO existe neste índice.
+        $embedder = (string) config('copiloto.mcp_search.docs_embedder', 'qwen3_local');
         $ratio    = (float) config('copiloto.memoria.meilisearch.semantic_ratio', 0.6);
 
         $filtros = ["status IN ['aceito','accepted','accepted-historical']"];


### PR DESCRIPTION
Smoke live no CT 100 pegou: `buscarHybrid` usava o embedder do chat (`config copiloto.memoria.meilisearch.embedder` = `openai` em prod), mas o índice `mcp_memory_documents` só tem `nomic_local`/`qwen3_local` → `Cannot find embedder 'openai'` → fallback FULLTEXT (não quebrou, mas hybrid nunca ativava).

Fix: config própria `copiloto.mcp_search.docs_embedder` (default `qwen3_local`, verificado no índice live).

Finding separado: `jana_memoria_facts` tem embedders `{}` — recall semântico do chat também está degradado (keyword-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
