### PR TITLE
feat(jana): jana:meilisearch-setup — codifica embedders Meilisearch (config-as-code)

### DIFF
--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -258,6 +258,46 @@ return [
         'docs_embedder' => env('JANA_MCP_DOCS_EMBEDDER', 'qwen3_local'),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Meilisearch index settings (embedders) — CONFIG-AS-CODE
+    |--------------------------------------------------------------------------
+    | Codifica o que antes era setado MANUAL via curl (Sprint 9b 2026-05-04) e
+    | SE PERDEU (jana_memoria_facts voltou a embedders {} → recall do chat degradou).
+    | Aplicado idempotente por `jana:meilisearch-setup`. Embedder ollama qwen3_local
+    | (qwen3-embedding:0.6b, 1024d) — venceu nomic (inútil PT-BR) no eval Sprint 9.
+    | URL interna CT 100. Ver INFRA-ACESSO-CANON + RUNBOOK-ragas-canary.
+    */
+    'meilisearch_indexes' => [
+        'jana_memoria_facts' => [
+            'embedders' => [
+                'qwen3_local' => [
+                    'source'                  => 'ollama',
+                    'model'                   => env('JANA_OLLAMA_EMBED_MODEL', 'qwen3-embedding:0.6b'),
+                    'dimensions'              => 1024,
+                    'documentTemplate'        => '{{doc.fato}}',
+                    'documentTemplateMaxBytes' => 400,
+                    'url'                     => env('JANA_OLLAMA_EMBED_URL', 'http://ollama-embedder:11434/api/embeddings'),
+                ],
+            ],
+            'filterableAttributes' => ['business_id', 'user_id', 'valid_until'],
+        ],
+        'mcp_memory_documents' => [
+            'embedders' => [
+                'qwen3_local' => [
+                    'source'                  => 'ollama',
+                    'model'                   => env('JANA_OLLAMA_EMBED_MODEL', 'qwen3-embedding:0.6b'),
+                    'dimensions'              => 1024,
+                    'documentTemplate'        => '{{doc.title}}. {{doc.content_excerpt}}',
+                    'documentTemplateMaxBytes' => 400,
+                    'url'                     => env('JANA_OLLAMA_EMBED_URL', 'http://ollama-embedder:11434/api/embeddings'),
+                ],
+            ],
+            // corpus MCP é GLOBAL — NÃO inclui business_id (ADR 0093 não se aplica: docs de programação)
+            'filterableAttributes' => ['status', 'type', 'module', 'slug'],
+        ],
+    ],
+
     'reranker' => [
         'enabled' => env('JANA_RERANKER_ENABLED', env('COPILOTO_RERANKER_ENABLED', true)),
         'driver'  => env('JANA_RERANKER_DRIVER', env('COPILOTO_RERANKER_DRIVER', 'rrf')),

--- a/Modules/Jana/Console/Commands/MeilisearchIndexSetupCommand.php
+++ b/Modules/Jana/Console/Commands/MeilisearchIndexSetupCommand.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * jana:meilisearch-setup — CODIFICA (config-as-code) os embedders + filterableAttributes
+ * dos índices Meilisearch da Jana. Idempotente.
+ *
+ * Origem (2026-05-29): o embedder do `jana_memoria_facts` foi setado MANUAL via curl no
+ * Sprint 9b e SE PERDEU (índice voltou a embedders `{}` → recall semântico do chat
+ * degradou; memoria-search hybrid impossível). Sem este comando, qualquer reindex/recreate
+ * do índice perde a config de novo. Agora vive no git (config copiloto.meilisearch_indexes).
+ *
+ * PATCH /indexes/{uid}/settings aplica embedders + filterableAttributes; o Meilisearch
+ * re-embeda os docs existentes ao mudar o embedder (task async). Rodar `scout:import`
+ * depois garante o reindex completo se necessário.
+ *
+ * Uso:
+ *   php artisan jana:meilisearch-setup                 # todos os índices
+ *   php artisan jana:meilisearch-setup --index=jana_memoria_facts
+ *   php artisan jana:meilisearch-setup --dry-run       # mostra payload sem aplicar
+ */
+class MeilisearchIndexSetupCommand extends Command
+{
+    protected $signature = 'jana:meilisearch-setup {--index=all : uid do índice ou "all"} {--dry-run : mostra sem aplicar}';
+
+    protected $description = 'Codifica/aplica embedders + filterableAttributes dos índices Meilisearch da Jana (idempotente)';
+
+    public function handle(): int
+    {
+        $host = rtrim((string) config('scout.meilisearch.host', 'http://localhost:7700'), '/');
+        $key  = (string) config('scout.meilisearch.key', '');
+        $alvo = (string) $this->option('index');
+        $dry  = (bool) $this->option('dry-run');
+
+        /** @var array<string, array<string, mixed>> $indexes */
+        $indexes = (array) config('copiloto.meilisearch_indexes', []);
+
+        if ($indexes === []) {
+            $this->error('config copiloto.meilisearch_indexes vazia.');
+
+            return self::FAILURE;
+        }
+
+        $this->info("Meilisearch index setup → {$host}".($dry ? ' [DRY-RUN]' : ''));
+
+        foreach ($indexes as $uid => $cfg) {
+            if ($alvo !== 'all' && $alvo !== $uid) {
+                continue;
+            }
+
+            $payload   = $this->payloadPara($cfg);
+            $embedders = implode(', ', array_keys($cfg['embedders'] ?? []));
+            $filter    = implode(', ', $cfg['filterableAttributes'] ?? []);
+            $this->line("→ {$uid}");
+            $this->line("    embedders: {$embedders}");
+            $this->line("    filterable: {$filter}");
+
+            if ($dry) {
+                continue;
+            }
+
+            $resp = Http::withToken($key)
+                ->timeout(30)
+                ->patch("{$host}/indexes/{$uid}/settings", $payload);
+
+            if ($resp->failed()) {
+                $this->error("    PATCH falhou ({$resp->status()}): ".mb_substr($resp->body(), 0, 300));
+
+                return self::FAILURE;
+            }
+
+            $this->info('    ✓ aplicado (taskUid '.data_get($resp->json(), 'taskUid', '?').')');
+        }
+
+        if (! $dry) {
+            $this->newLine();
+            $this->line('Embedder mudou → Meilisearch re-embeda os docs (task async).');
+            $this->line('Se precisar forçar reindex completo:');
+            $this->line('  php artisan scout:import "Modules\\\\Jana\\\\Entities\\\\MemoriaFato"');
+            $this->line('  php artisan scout:import "Modules\\\\Jana\\\\Entities\\\\Mcp\\\\McpMemoryDocument"');
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Monta o payload PATCH /settings a partir da config de um índice.
+     *
+     * @param  array<string, mixed> $cfg
+     * @return array<string, mixed>
+     */
+    public function payloadPara(array $cfg): array
+    {
+        $payload = [];
+
+        if (! empty($cfg['embedders'])) {
+            $payload['embedders'] = $cfg['embedders'];
+        }
+        if (! empty($cfg['filterableAttributes'])) {
+            $payload['filterableAttributes'] = $cfg['filterableAttributes'];
+        }
+
+        return $payload;
+    }
+}

--- a/Modules/Jana/Providers/JanaServiceProvider.php
+++ b/Modules/Jana/Providers/JanaServiceProvider.php
@@ -71,6 +71,7 @@ class JanaServiceProvider extends ServiceProvider
                 \Modules\Jana\Console\Commands\JanaDriftSentinelCommand::class, // Wave 23 §G2 — canary semanal drift Jana (faithfulness vs baseline)
                 \Modules\Jana\Console\Commands\RetentionPurgeCommand::class, // G1 P0 AUDIT-SENIOR-2026-05-25 — D7.d LGPD purge (Art. 16 + Art. 18 §VI)
                 \Modules\Jana\Console\Commands\IndexRegenCommand::class, // regressão 2026-05-29 — gate integridade/priorização memory/INDEX.md (Tier 0 + links + contagens)
+                \Modules\Jana\Console\Commands\MeilisearchIndexSetupCommand::class, // 2026-05-29 — config-as-code dos embedders Meilisearch (Sprint 9b se perdeu)
             ]);
         }
     }

--- a/Modules/Jana/Tests/Feature/Console/MeilisearchIndexSetupTest.php
+++ b/Modules/Jana/Tests/Feature/Console/MeilisearchIndexSetupTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Console\Commands\MeilisearchIndexSetupCommand;
+
+uses(Tests\TestCase::class);
+
+/**
+ * jana:meilisearch-setup — config-as-code dos embedders Meilisearch (gap "se perdeu").
+ *
+ * Blinda que a config canônica (copiloto.meilisearch_indexes) tem os 2 índices com o
+ * embedder qwen3_local correto, e que o payload PATCH é montado certo. Não bate no
+ * Meilisearch live (isso é o smoke em prod).
+ */
+
+it('config canônica tem jana_memoria_facts + mcp_memory_documents com embedder qwen3_local', function () {
+    $cfg = config('copiloto.meilisearch_indexes');
+
+    expect($cfg)->toBeArray()
+        ->toHaveKeys(['jana_memoria_facts', 'mcp_memory_documents']);
+
+    // ambos usam qwen3_local (venceu nomic no eval Sprint 9 — nomic inútil PT-BR)
+    expect($cfg['jana_memoria_facts']['embedders'])->toHaveKey('qwen3_local')
+        ->and($cfg['mcp_memory_documents']['embedders'])->toHaveKey('qwen3_local')
+        ->and($cfg['jana_memoria_facts']['embedders']['qwen3_local']['source'])->toBe('ollama')
+        ->and($cfg['jana_memoria_facts']['embedders']['qwen3_local']['documentTemplate'])->toBe('{{doc.fato}}');
+});
+
+it('mcp_memory_documents NÃO filtra business_id (corpus global); jana_memoria_facts SIM', function () {
+    $cfg = config('copiloto.meilisearch_indexes');
+
+    expect($cfg['mcp_memory_documents']['filterableAttributes'])->not->toContain('business_id')
+        ->and($cfg['jana_memoria_facts']['filterableAttributes'])->toContain('business_id');
+});
+
+it('payloadPara monta embedders + filterableAttributes', function () {
+    $cmd = new MeilisearchIndexSetupCommand();
+    $payload = $cmd->payloadPara([
+        'embedders' => ['qwen3_local' => ['source' => 'ollama']],
+        'filterableAttributes' => ['business_id', 'user_id'],
+    ]);
+
+    expect($payload)->toHaveKeys(['embedders', 'filterableAttributes'])
+        ->and($payload['embedders'])->toHaveKey('qwen3_local')
+        ->and($payload['filterableAttributes'])->toBe(['business_id', 'user_id']);
+});


### PR DESCRIPTION
O embedder do jana_memoria_facts foi setado manual (Sprint 9b) e se perdeu → índice voltou a embedders {} → recall do chat degradou. Codifica em config (copiloto.meilisearch_indexes) + comando idempotente jana:meilisearch-setup. qwen3_local pros 2 índices. +3 testes. Aplicar em prod + reindex + validar = próximo passo.