### PR TITLE
docs(jana): consolida ativação completa retrieval + regra embedder qwen3_local

### DIFF
--- a/memory/reference/INFRA-ACESSO-CANON.md
+++ b/memory/reference/INFRA-ACESSO-CANON.md
@@ -54,7 +54,9 @@ tailscale ssh root@ct100-mcp '
 
 ### Meilisearch (CT 100)
 - Não publica porta no host. Consultar **de dentro do container**: `docker exec meilisearch sh -c 'curl -s http://localhost:7700/... -H "Authorization: Bearer $MEILI_MASTER_KEY"'` (key via env interno, nunca imprimir).
-- Índices: `jana_memoria_facts` (Jana, per-cliente) + `mcp_memory_documents` (MCP, global). Embedders ollama: **`qwen3_local`** (qwen3-embedding:0.6b, 1024d) + `nomic_local`. filterableAttributes do mcp_memory_documents: `[status,type,module,slug]` (SEM business_id — corpus global).
+- Índices: `jana_memoria_facts` (Jana, per-cliente) + `mcp_memory_documents` (MCP, global). filterableAttributes do mcp_memory_documents: `[status,type,module,slug]` (SEM business_id — corpus global); jana_memoria_facts: `[business_id,user_id,valid_until]`.
+- **Embedder = `qwen3_local`** (qwen3-embedding:0.6b, 1024d, via `ollama-embedder`). NÃO usar `nomic` (inútil em PT-BR — cosine ~0.97 pra tudo; eval Sprint 9: nomic 0.158 vs FULLTEXT 0.700). **`COPILOTO_MEMORIA_EMBEDDER=qwen3_local`** no .env (DEVE casar com o embedder do índice — se divergir, "Cannot find embedder X").
+- ⚙️ **Config-as-code (não setar manual!):** o embedder vive em `config copiloto.meilisearch_indexes` e é aplicado por **`php artisan jana:meilisearch-setup`** (idempotente). Era manual via curl (Sprint 9b) e SE PERDEU 2× → agora codificado. Após mudar embedder: Meilisearch re-embeda; `scout:import` força reindex.
 
 ## DNS (Hostinger API)
 `developers.hostinger.com/api/dns/v1/zones/oimpresso.com` (PUT `overwrite:false`). Token no Vaultwarden (`hostinger-api-token`). A-records de serviço → **`177.74.67.30`** (IP público CT 100). Detalhe: [ADR 0045](../decisions/0045-hostinger-dns-api-endpoint-canonico.md) + [hostinger.md](hostinger.md).

--- a/memory/requisitos/Jana/SPEC-retrieval-tools-mcp-unificado.md
+++ b/memory/requisitos/Jana/SPEC-retrieval-tools-mcp-unificado.md
@@ -19,9 +19,10 @@ fonte: [memory/sessions/2026-05-29-arte-indexacao-priorizacao-retrieval-memoria-
 
 Deployado no `oimpresso-mcp` (CT 100) — ver [INFRA-ACESSO-CANON](../../reference/INFRA-ACESSO-CANON.md). Container estava 1302 commits atrás; deploy destravado pelo fix do Dockerfile (exts).
 
-- ✅ **`decisions-search` + `kb-answer` HYBRID LIVE** (`JANA_MCP_SEARCH_PIPELINE_DOCS=true`). Smoke real no app: `buscarHybrid('isolamento multi-tenant', 4, null, 'adr')` → `0006 · 0218 · 0093 · ARQ-0001` (semântico). Embedder = `qwen3_local` (config `copiloto.mcp_search.docs_embedder` — NÃO o `openai` do chat).
-- ⏸️ **`memoria-search` OFF** (`JANA_MCP_SEARCH_PIPELINE_MEMORIA=false`). Bloqueado: o índice **`jana_memoria_facts` tem embedders `{}` (vazio)** — sem embedder configurado, hybrid impossível. Precisa configurar embedder + reindex (tarefa infra).
-- 🔴 **FINDING separado (chat):** como `jana_memoria_facts` não tem embedder, **o recall semântico do CHAT também está degradado (keyword-only)** apesar de `COPILOTO_MEMORIA_EMBEDDER=openai` no .env. O índice precisa do embedder configurado pra o chat ter hybrid de verdade. Abrir issue/ADR próprio.
+- ✅ **`decisions-search` + `kb-answer` HYBRID LIVE** (`JANA_MCP_SEARCH_PIPELINE_DOCS=true`). Smoke real: `buscarHybrid('isolamento multi-tenant')` → `0006 · 0218 · 0093 · ARQ-0001`. Embedder `qwen3_local`. Comparação recall@3 (6 golden q): **hybrid ≥ FULLTEXT** (venceu 0093, 0 perdas) — reverte com dado fresco a conclusão velha (Sprint 9: FULLTEXT 0.700 > qwen3 0.692; corpus cresceu + Contextual Retrieval entrou).
+- ✅ **`memoria-search` HYBRID LIVE** (`JANA_MCP_SEARCH_PIPELINE_MEMORIA=true`). O índice `jana_memoria_facts` estava com embedders `{}` (perdido desde Sprint 9b — era manual via curl). **Recuperado:** `jana:meilisearch-setup` configurou `qwen3_local` (31/31 docs embedded). Smoke: `buscarBusiness(1,'multi-tenant')` → 5 hits (ADR 0006/0005/0004/0010/0001).
+- ✅ **Recall do CHAT restaurado:** o embedder vazio degradava o recall do chat pra keyword-only. Corrigido junto (mesmo índice). `.env` realinhado `COPILOTO_MEMORIA_EMBEDDER=openai → qwen3_local` (= default já codificado; `openai` era drift, e não existia embedder openai no índice).
+- 🔒 **Durável agora:** embedder vive em `config copiloto.meilisearch_indexes` + `jana:meilisearch-setup` (idempotente) → não se perde mais num reindex/recreate. Validação rigorosa contínua = `jana:ragas-ci` (golden set 100q).
 
 ## ⚠️ Dois corpora distintos (Wagner, 2026-05-29 — NÃO conflar)
 


### PR DESCRIPTION
Estado final validado live: gap #2 ativado ponta-a-ponta (decisions-search/kb-answer/memoria-search hybrid). jana_memoria_facts recuperado (embedders {} → qwen3_local, 31/31 embedded), recall do chat restaurado. Embedder codificado (jana:meilisearch-setup) — não se perde mais. INFRA-ACESSO-CANON com a regra.