### PR TITLE
feat(jana): SettingsReconciler — jana:meilisearch-setup --check (drift de embedder)

### DIFF
--- a/Modules/Jana/Console/Commands/MeilisearchIndexSetupCommand.php
+++ b/Modules/Jana/Console/Commands/MeilisearchIndexSetupCommand.php
@@ -27,9 +27,9 @@ use Illuminate\Support\Facades\Http;
  */
 class MeilisearchIndexSetupCommand extends Command
 {
-    protected $signature = 'jana:meilisearch-setup {--index=all : uid do índice ou "all"} {--dry-run : mostra sem aplicar}';
+    protected $signature = 'jana:meilisearch-setup {--index=all : uid do índice ou "all"} {--dry-run : mostra sem aplicar} {--check : SÓ compara settings vivos × config, exit 1 se drift (SettingsReconciler)}';
 
-    protected $description = 'Codifica/aplica embedders + filterableAttributes dos índices Meilisearch da Jana (idempotente)';
+    protected $description = 'Codifica/aplica/reconcilia embedders + filterableAttributes dos índices Meilisearch da Jana (idempotente)';
 
     public function handle(): int
     {
@@ -45,6 +45,12 @@ class MeilisearchIndexSetupCommand extends Command
             $this->error('config copiloto.meilisearch_indexes vazia.');
 
             return self::FAILURE;
+        }
+
+        // SettingsReconciler (gap "embedder perdido 2×"): compara settings VIVOS × config
+        // desejada e FALHA se driftou. CI-friendly (gate de PR) + cron (alerta). NÃO cura.
+        if ($this->option('check')) {
+            return $this->reconcileCheck($host, $key, $alvo, $indexes);
         }
 
         $this->info("Meilisearch index setup → {$host}".($dry ? ' [DRY-RUN]' : ''));
@@ -107,5 +113,114 @@ class MeilisearchIndexSetupCommand extends Command
         }
 
         return $payload;
+    }
+
+    /**
+     * SettingsReconciler — GET settings vivos de cada índice, compara com a config
+     * desejada, reporta drift. exit 1 se qualquer drift (gate). Alerta idempotente.
+     *
+     * @param  array<string, array<string, mixed>> $indexes
+     */
+    protected function reconcileCheck(string $host, string $key, string $alvo, array $indexes): int
+    {
+        $this->info("SettingsReconciler --check → {$host}");
+        $totalDrift = [];
+
+        foreach ($indexes as $uid => $cfg) {
+            if ($alvo !== 'all' && $alvo !== $uid) {
+                continue;
+            }
+
+            $resp = Http::withToken($key)->timeout(30)->get("{$host}/indexes/{$uid}/settings");
+            if ($resp->failed()) {
+                $this->error("  {$uid}: GET settings falhou ({$resp->status()})");
+
+                return self::FAILURE;
+            }
+
+            $drift = $this->detectarDrift($uid, $cfg, (array) $resp->json());
+            if ($drift === []) {
+                $this->line("  ✓ {$uid}: em dia");
+            } else {
+                foreach ($drift as $d) {
+                    $this->error("  ✗ {$d}");
+                }
+                $totalDrift = array_merge($totalDrift, $drift);
+            }
+        }
+
+        if ($totalDrift !== []) {
+            // Alerta idempotente por dia (mesmo padrão do freshness-check).
+            try {
+                \Illuminate\Support\Facades\DB::table('mcp_alertas_eventos')->updateOrInsert(
+                    ['chave_idempotencia' => 'index_settings_drift:'.now()->toDateString()],
+                    [
+                        'tipo'       => 'index_settings_drift',
+                        'severidade' => 'high',
+                        'business_id' => null,
+                        'metadata'   => json_encode(['drift' => $totalDrift]),
+                        'updated_at' => now(),
+                        'created_at' => now(),
+                    ],
+                );
+            } catch (\Throwable $e) {
+                $this->warn('  (alerta não persistido: '.$e->getMessage().')');
+            }
+
+            $this->newLine();
+            $this->error('DRIFT detectado — rode `php artisan jana:meilisearch-setup` pra curar.');
+
+            return self::FAILURE;
+        }
+
+        $this->info('Settings de todos os índices == config. Nenhum drift.');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Compara a config desejada de UM índice com os settings vivos. Pura/testável.
+     * Drift = embedder esperado ausente, source/model/dimensions divergente, ou
+     * filterableAttributes diferente (como conjunto).
+     *
+     * @param  array<string, mixed> $cfg   config desejada (embedders + filterableAttributes)
+     * @param  array<string, mixed> $vivo  settings vivos do Meilisearch
+     * @return string[] lista de drifts (vazia = em dia)
+     */
+    public function detectarDrift(string $uid, array $cfg, array $vivo): array
+    {
+        $drift = [];
+
+        /** @var array<string, array<string, mixed>> $expEmb */
+        $expEmb = (array) ($cfg['embedders'] ?? []);
+        /** @var array<string, array<string, mixed>> $vivoEmb */
+        $vivoEmb = (array) ($vivo['embedders'] ?? []);
+
+        foreach ($expEmb as $nome => $espec) {
+            if (! isset($vivoEmb[$nome])) {
+                $drift[] = "{$uid}: embedder '{$nome}' AUSENTE no índice (esperado na config)";
+
+                continue;
+            }
+            foreach (['source', 'model', 'dimensions'] as $campo) {
+                if (! array_key_exists($campo, (array) $espec)) {
+                    continue;
+                }
+                $vivoVal = $vivoEmb[$nome][$campo] ?? null;
+                if ($vivoVal != $espec[$campo]) {
+                    $drift[] = "{$uid}: embedder '{$nome}'.{$campo} difere (config=".json_encode($espec[$campo]).' vivo='.json_encode($vivoVal).')';
+                }
+            }
+        }
+
+        $expFilt  = (array) ($cfg['filterableAttributes'] ?? []);
+        $vivoFilt = (array) ($vivo['filterableAttributes'] ?? []);
+        sort($expFilt);
+        sort($vivoFilt);
+        if ($expFilt !== $vivoFilt) {
+            $drift[] = "{$uid}: filterableAttributes difere (config=[".implode(',', $expFilt).'] vivo=['.implode(',', $vivoFilt).'])';
+        }
+
+        return $drift;
     }
 }

--- a/Modules/Jana/Tests/Feature/Console/MeilisearchIndexSetupTest.php
+++ b/Modules/Jana/Tests/Feature/Console/MeilisearchIndexSetupTest.php
@@ -45,3 +45,36 @@ it('payloadPara monta embedders + filterableAttributes', function () {
         ->and($payload['embedders'])->toHaveKey('qwen3_local')
         ->and($payload['filterableAttributes'])->toBe(['business_id', 'user_id']);
 });
+
+// ── SettingsReconciler — detectarDrift (o gate "nunca mais perder o embedder") ──
+
+$cfg = [
+    'embedders' => ['qwen3_local' => ['source' => 'ollama', 'model' => 'qwen3-embedding:0.6b', 'dimensions' => 1024]],
+    'filterableAttributes' => ['status', 'type'],
+];
+
+it('detectarDrift: settings vivos == config → sem drift', function () use ($cfg) {
+    $vivo = ['embedders' => $cfg['embedders'], 'filterableAttributes' => ['type', 'status']]; // ordem diferente OK
+    expect((new MeilisearchIndexSetupCommand())->detectarDrift('x', $cfg, $vivo))->toBeEmpty();
+});
+
+it('detectarDrift: embedder VAZIO (o bug recorrente) → drift', function () use ($cfg) {
+    $vivo = ['embedders' => [], 'filterableAttributes' => ['status', 'type']];
+    $d = (new MeilisearchIndexSetupCommand())->detectarDrift('jana_memoria_facts', $cfg, $vivo);
+    expect($d)->not->toBeEmpty()
+        ->and($d[0])->toContain("embedder 'qwen3_local' AUSENTE");
+});
+
+it('detectarDrift: model divergente (ex openai) → drift', function () use ($cfg) {
+    $vivo = ['embedders' => ['qwen3_local' => ['source' => 'ollama', 'model' => 'nomic-embed-text', 'dimensions' => 1024]], 'filterableAttributes' => ['status', 'type']];
+    expect((new MeilisearchIndexSetupCommand())->detectarDrift('x', $cfg, $vivo))
+        ->toHaveCount(1)
+        ->and(implode('', (new MeilisearchIndexSetupCommand())->detectarDrift('x', $cfg, $vivo)))->toContain('.model difere');
+});
+
+it('detectarDrift: filterableAttributes diferente → drift', function () use ($cfg) {
+    $vivo = ['embedders' => $cfg['embedders'], 'filterableAttributes' => ['status']];
+    expect((new MeilisearchIndexSetupCommand())->detectarDrift('x', $cfg, $vivo))
+        ->toHaveCount(1)
+        ->and(implode('', (new MeilisearchIndexSetupCommand())->detectarDrift('x', $cfg, $vivo)))->toContain('filterableAttributes difere');
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -495,6 +495,23 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // SettingsReconciler (estado-da-arte reconcile-loop 2026-05-29) — guarda contra
+        // o bug recorrente "embedder do Meilisearch se perdeu" (jana_memoria_facts voltou
+        // a {} 2×). Compara settings vivos × config copiloto.meilisearch_indexes; exit 1 +
+        // alerta idempotente index_settings_drift se driftar. Roda DEPOIS do freshness.
+        $schedule->command('jana:meilisearch-setup --check')
+            ->dailyAt('04:40')
+            ->timezone('America/Sao_Paulo')
+            ->onOneServer()
+            ->withoutOverlapping(20)
+            ->environments(['live'])
+            ->appendOutputTo(storage_path('logs/jana-meilisearch-reconcile.log'))
+            ->onFailure(function () {
+                \Illuminate\Support\Facades\Log::channel('copiloto-ai')->error(
+                    'Schedule jana:meilisearch-setup --check FALHOU — DRIFT de settings/embedder do índice (rodar jana:meilisearch-setup pra curar)'
+                );
+            });
+
         // MEM-MULTI-1 (auditoria seed 2026-05-28) — re-seed ADRs → jana_memoria_facts
         // diário. Sem este schedule os fatos de ADR ficavam STALE: nova ADR aceita /
         // ADR supersedida não viravam fato pesquisável até alguém rodar o command na mão.


### PR DESCRIPTION
1ª peça do reconcile-loop (estado-da-arte 2026-05-29, nota 63/100). --check compara settings vivos × config + exit 1 + alerta idempotente se driftar. Mata o bug recorrente 'embedder perdido 2×'. Cron daily + gate PR. +4 testes (7 total). Espelha ChannelsReconcilerCommand + ADR 0216.