### PR TITLE
chore(governance): auditoria IA-OS Team OS + Automation Registry (ADR 0234 proposta) + rotina Fechar o Loop

### DIFF
--- a/.claude/hooks/loop-fechar-check.ps1
+++ b/.claude/hooks/loop-fechar-check.ps1
@@ -1,0 +1,70 @@
+# loop-fechar-check.ps1 - Rotina "Fechar o Loop" do IA-OS
+# Disparado em SessionStart (apos brief-fetch) pelo .claude/settings.json
+# Origem: AUDIT IA-OS 2026-05-29 (nota 68/100). Wagner pediu rotina idempotente
+#   atrelada ao brief que verifica o que ja foi feito e avanca o que falta.
+# REGRA DURA: NUNCA toca Brain B / autonomia ADS / ads-route (decisao Wagner: nao
+#   ligar 2o cerebro agora - custo recorrente nao desejado).
+# Manifesto: .claude/loop-fechar-o-loop.json (fonte de verdade + estado).
+# PS 5.1 compat: ASCII puro, sem emoji.
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+try {
+    $manifestPath = Join-Path $PSScriptRoot '..\loop-fechar-o-loop.json'
+    if (-not (Test-Path $manifestPath)) { exit 0 }
+
+    $repo = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+    $m = Get-Content $manifestPath -Raw -Encoding UTF8 | ConvertFrom-Json
+    if (-not $m.itens) { exit 0 }
+
+    # Resolve estado de cada item (idempotencia)
+    $itens = @()
+    foreach ($it in $m.itens) {
+        $done = $false
+        if ($it.detect.tipo -eq 'manual') {
+            $done = [bool]$it.done
+        } elseif ($it.detect.tipo -eq 'file_any') {
+            foreach ($p in $it.detect.paths) {
+                if (Test-Path (Join-Path $repo $p)) { $done = $true; break }
+            }
+        }
+        $itens += [pscustomobject]@{
+            ordem = [int]$it.ordem; gap = $it.gap; titulo = $it.titulo
+            done = $done; prio = $it.prioridade; custo = $it.custo_recorrente
+            aprova = [bool]$it.precisa_aprovacao_wagner; nota = $it.nota_aprovacao
+        }
+    }
+    $itens = $itens | Sort-Object ordem
+
+    $pendentes = @($itens | Where-Object { -not $_.done })
+
+    Write-Host ""
+    Write-Host "=== ROTINA: FECHAR O LOOP DO IA-OS (audit 2026-05-29) ==="
+    foreach ($i in $itens) {
+        $mark = if ($i.done) { "[OK]" } else { "[--]" }
+        Write-Host ("  {0} #{1} {2} - {3}" -f $mark, $i.gap, $i.prio, $i.titulo)
+    }
+
+    if ($pendentes.Count -eq 0) {
+        Write-Host ""
+        Write-Host "  LOOP FECHADO - nada a fazer. IA-OS com painel + alarme + LGPD no ar."
+        Write-Host "  (Para reabrir um item, mude 'done' no manifesto.)"
+    } else {
+        $next = $pendentes[0]
+        Write-Host ""
+        Write-Host ("  PROXIMO PENDENTE: #{0} - {1}" -f $next.gap, $next.titulo)
+        Write-Host ("  Custo recorrente: {0}" -f $next.custo)
+        if ($next.aprova) {
+            Write-Host "  >> EXIGE APROVACAO DO WAGNER antes de avancar (custo/risco). Nota:"
+            Write-Host ("     {0}" -f $next.nota)
+        }
+        Write-Host ""
+        Write-Host "  ACAO CLAUDE: avise o Wagner que ha item do loop pendente e pergunte"
+        Write-Host ("  'quer que eu faca o #{0} agora?'. NAO comece sem ele confirmar." -f $next.gap)
+        Write-Host "  NUNCA inclua Brain B / autonomia ADS nesta rotina (decisao Wagner)."
+    }
+    Write-Host ""
+} catch {
+    # Falha silenciosa: rotina-nudge nao deve quebrar inicio de sessao.
+    exit 0
+}

--- a/.claude/loop-fechar-o-loop.json
+++ b/.claude/loop-fechar-o-loop.json
@@ -1,0 +1,90 @@
+{
+  "_automation_registry": true,
+  "slug": "loop-fechar-o-loop",
+  "tipo": "routine",
+  "gatilho": "SessionStart pos brief-fetch",
+  "descricao": "Rotina IA-OS Fechar o Loop: verifica idempotentemente os 4 gaps P0 da auditoria IA-OS (RAGAS CI, drift sentinel, observability, LGPD purge) e aponta o proximo pendente. NUNCA toca Brain B/autonomia.",
+  "arquivo": ".claude/hooks/loop-fechar-check.ps1",
+  "owner": "wagner",
+  "governed_by_adr": "automation-registry-mcp",
+  "enabled": true,
+  "_titulo": "Rotina 'Fechar o Loop' do IA-OS",
+  "_origem": "AUDIT IA-OS 2026-05-29 (nota 68/100). Wagner: criar rotina idempotente atrelada ao brief que verifica o que ja foi feito e avanca o que falta.",
+  "_decisao_wagner": "NAO ligar o 2o cerebro (Brain B / autonomia ADS - gap #1). Custo que ele nao quer fazer agora. Esta rotina NUNCA toca Brain B, ADS routing, nem ads-route.",
+  "_como_funciona": "Hook SessionStart .claude/hooks/loop-fechar-check.ps1 le este arquivo a cada brief. Para itens code-based: 'feito' = artefato existe no repo (detect file_any). Para item de infra (#4): 'feito' = flag done manual (vira true apos deploy+smoke). Mostra o PROXIMO pendente e Claude pergunta ao Wagner se faz na hora.",
+  "_ordem_racional": "Custo-zero primeiro (#2,#3,#6). Item com mensalidade recorrente (#4 Langfuse) por ultimo, gated na aprovacao do Wagner igual a decisao do Brain B.",
+  "atualizado_em": "2026-05-29",
+  "itens": [
+    {
+      "id": "loop-2-ragas-ci",
+      "gap": 2,
+      "ordem": 1,
+      "prioridade": "P0",
+      "titulo": "RAGAS gate em CI (gold-set 30q bloqueia PR que toca Modules/Jana/Ai ou Services/Memoria)",
+      "custo_recorrente": "R$0 infra (~R$5-10/mes LLM eval)",
+      "precisa_aprovacao_wagner": false,
+      "detect": {
+        "tipo": "file_any",
+        "paths": [
+          ".github/workflows/ragas-canary.yml",
+          "Modules/Jana/Tests/Feature/Ai/RagasCanaryGateTest.php"
+        ]
+      },
+      "done": false,
+      "ref": "AUDIT-SENIOR-2026-05-25 G2 + IA-MATURITY-FICHA gap#1"
+    },
+    {
+      "id": "loop-3-drift-sentinel",
+      "gap": 3,
+      "ordem": 2,
+      "prioridade": "P0",
+      "titulo": "Drift sentinel / canary semanal + alerta (recall<80% ou halluc>5%)",
+      "custo_recorrente": "R$0 infra",
+      "precisa_aprovacao_wagner": false,
+      "detect": {
+        "tipo": "file_any",
+        "paths": [
+          "scripts/ragas-eval.py",
+          ".github/workflows/jana-canary-semanal.yml"
+        ]
+      },
+      "done": false,
+      "ref": "IA-MATURITY-FICHA gap#2 + RUNBOOK-ragas-canary.md"
+    },
+    {
+      "id": "loop-6-lgpd-purge",
+      "gap": 6,
+      "ordem": 3,
+      "prioridade": "P0",
+      "titulo": "LGPD purge job (jana:retention-purge) + DSR Art.18 SVI (LgpdEsquecerTitularTool)",
+      "custo_recorrente": "R$0",
+      "precisa_aprovacao_wagner": true,
+      "nota_aprovacao": "Codigo pode ser feito; ativar JANA_RETENTION_ENABLED=true em prod exige canary 7d biz=1 + sign-off Wagner. NUNCA roda automated em biz=4 Larissa (ADR 0101).",
+      "detect": {
+        "tipo": "file_any",
+        "paths": [
+          "Modules/Jana/Console/Commands/RetentionPurgeCommand.php",
+          "Modules/Jana/Services/Privacy/RetentionPurgeService.php"
+        ]
+      },
+      "done": false,
+      "ref": "AUDIT-SENIOR-2026-05-25 G1 + Config/retention.php"
+    },
+    {
+      "id": "loop-4-observability",
+      "gap": 4,
+      "ordem": 4,
+      "prioridade": "P0",
+      "titulo": "Ligar Langfuse + OTel collector CT 100 (painel custo/latencia/halluc)",
+      "custo_recorrente": "R$50-80/mes CT 100 (Postgres+ClickHouse)",
+      "precisa_aprovacao_wagner": true,
+      "nota_aprovacao": "Mensalidade recorrente - mesma regua do Brain B. So avancar com OK explicito de orcamento do Wagner. ADR 0132 ja decidiu a arquitetura; falta ligar.",
+      "detect": {
+        "tipo": "manual",
+        "como_marcar": "Apos deploy Langfuse no CT 100 + OtelExportSmokeTest verde, mudar 'done' para true aqui."
+      },
+      "done": false,
+      "ref": "ADR 0132 + AUDIT-SENIOR-2026-05-25 G3 + IA-MATURITY-FICHA gap#3"
+    }
+  ]
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,6 +20,10 @@
           {
             "type": "command",
             "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/tier-a-banner.ps1"
+          },
+          {
+            "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/loop-fechar-check.ps1"
           }
         ]
       }

--- a/memory/decisions/proposals/drafts/automation-registry-mcp.md
+++ b/memory/decisions/proposals/drafts/automation-registry-mcp.md
@@ -1,0 +1,278 @@
+---
+slug: automation-registry-mcp
+number: 234
+title: "Registry de Automações no MCP — hooks/crons/rotinas governados"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+quarter: Q2-2026
+decided_at: 2026-05-29
+decided_by: [PENDENTE-WAGNER]
+module: governance
+supersedes: []
+related: [0053, 0070, 0076, 0079, 0080, 0093]
+tags: [governance, automations, hooks, cron, mcp, observability, enforcement]
+---
+
+# ADR 234 — Registry de Automações no MCP: hooks/crons/rotinas governados
+
+## Status
+
+**Proposto** — 2026-05-29. Aguardando aprovação Wagner.
+
+Origem: auditoria [`memory/requisitos/TaskRegistry/AUDIT-TEAM-OS-2026-05-29.md`](../../../requisitos/TaskRegistry/AUDIT-TEAM-OS-2026-05-29.md), gap **#11**.
+
+## Contexto
+
+O oimpresso governa **decisões** com rigor: ADRs Nygard append-only ([ADR 0070](../../0070-jira-style-task-management-current-md-removed.md)), Constituição 7 camadas ([ADR 0079](../../0079-constituicao-oimpresso-7-camadas-governanca.md)), 8 mecanismos de enforcement ([`ENFORCEMENT.md`](../../../governance/ENFORCEMENT.md)). Mas **automações** — código que roda sozinho, sem humano no loop — não têm rastro nenhum.
+
+Inventário real do que roda hoje, invisível ao MCP server, ao time (Felipe/Maiara/Eliana/Luiz) e à governança:
+
+**~35 hooks** em `.claude/hooks/` (PowerShell `*.ps1` + Node `*.mjs`), entre eles:
+- `block-automem.ps1`, `block-bom-encoding.ps1`, `block-destructive.ps1`, `block-memory-drift.ps1`, `block-module-drift.ps1`, `block-mwart-violation.ps1`, `block-routes-string-legacy.ps1`, `block-claim-without-evidence.ps1`, `block-merge-markers.ps1`, `block-pr-without-approval.mjs`, `block-serving-branch-switch.ps1` (bloqueadores `PreToolUse`)
+- `pii-redactor.ps1`, `commit-discipline-check.ps1`, `modulo-preflight-warning.ps1`, `mcp-first-warning.ps1`, `memory-pending.ps1`, `charter-validate.ps1`, `check-skills-fresh.ps1`, `tier-a-banner.ps1`, `force-r12-closing-signal.mjs`, `audit-creates-tasks.mjs`, `nudge-diagnosis-without-evidence.ps1`, `nudge-recommend-not-menu.ps1`, `post-merge-ui-smoke-required.ps1` (advisory `SessionStart`/`UserPromptSubmit`/`PostToolUse`)
+
+**~30 crons** em `app/Console/Kernel.php`, entre eles:
+- `jana:health-check` (06:00 BRT), `jana:system-audit` (06:15), `jana:weekly-digest`, `jana:cycles:auto-close-expired` (23:55), `jana:freshness-check` (04:30), `jana:retention-purge` (03:00)
+- `copiloto:metrics:apurar` (23:55), `copiloto:sintese-semanal`, `copiloto:seed-adrs` (04:45), `copiloto:cleanup-memoria` (semanal)
+- `memcofre:sync-memories` (23:00), `module:grade-snapshot` (06:05), `governance:scorecard-snapshot` (07:00), `governance:detect-drift` (06:15), `governance:initiative-sync` (08:00), `mcp:tasks:sync`, `mcp:sync-memory`, `brief:generate` (07/11/14/17/20/23h), `sells:smoke-daily` (06:30), `charter:health` (06:30), `observability:aggregate-daily` (02:00), e o bloco `ads:*` (review/learn/plan/process-brain-b)
+
+**Rotinas** (composições hook + manifesto + comando) — ex: a rotina **"Fechar o Loop"** do IA-OS: `.claude/hooks/loop-fechar-check.ps1` + manifesto `.claude/loop-fechar-o-loop.json`.
+
+O problema é uma **assimetria de governança**: o oimpresso tem trilha append-only para DECISÕES (quem decidiu, quando, por quê) mas **ZERO rastro para AUTOMAÇÕES** que executam sozinhas. Ninguém — nem Wagner, nem o time, nem um agente IA — consegue responder via MCP:
+
+- "Quais automações existem neste projeto?"
+- "O que cada uma dispara, e em qual gatilho (matcher de hook / expressão cron / pós-brief)?"
+- "Quando rodou por último, e deu `ok` / `warn` / `fail`?"
+- "Existe automação no filesystem que não está registrada (drift), ou registrada cujo arquivo sumiu?"
+
+Hoje a resposta exige `git grep` no filesystem + leitura manual de `Kernel.php` — exatamente o anti-padrão que [ADR 0070](../../0070-jira-style-task-management-current-md-removed.md) eliminou para tasks (markdown paralelo desincronizando) e [ADR 0076](../../0076-skills-db-primary-git-destino-drift-alert.md) eliminou para skills (DB-primary + drift alert). Automações são o **último artefato operacional sem registry MCP**.
+
+[`ENFORCEMENT.md`](../../../governance/ENFORCEMENT.md) cataloga 8 mecanismos NIST/Cedar/OPA aplicados às 7 camadas. Nenhum deles **inventaria e observa as próprias automações** — o doc descreve o que cada mecanismo *deveria* fazer, mas não há um lugar único onde o estado vivo (existe? habilitada? rodou quando? drift?) de cada hook/cron/rotina seja consultável. Este registry é a peça que faltava.
+
+**Restrições:**
+- Multi-tenant `business_id NULL = global` — automações são infra de plataforma (ver seção [Multi-tenant](#multi-tenant-tier-0)).
+- Webhook GitHub continua existindo ([ADR 0053](../../0053-mcp-server-governanca-como-produto.md)) — o sync pode ser disparado por push, mas o source-of-truth da varredura é o filesystem do repo (igual skills).
+- **Sem custo de LLM.** O registry é puramente observabilidade/governança — varredura determinística de arquivos + parse de `Kernel.php`. NÃO depende de Brain B nem de autonomia ADS (decisão Wagner: não ligar 2º cérebro agora).
+
+## Decisão
+
+Criar um **Registry de Automações DB-backed** seguindo **exatamente o padrão [ADR 0076](../../0076-skills-db-primary-git-destino-drift-alert.md)** (skills): **DB é primary, filesystem é a fonte, sync service espelha, drift detection alerta**. O registry é o **mecanismo de enforcement #9** de [`ENFORCEMENT.md`](../../../governance/ENFORCEMENT.md) — **inventário + observabilidade de automações**, complementar aos 8 existentes (que protegem camadas; este observa as automações que as protegem).
+
+> **Mapeamento ADR 0076 → 234** (mesma anatomia, semântica diferente):
+>
+> | ADR 0076 (skills) | ADR 234 (automações) |
+> |---|---|
+> | `mcp_skills` (entidade) | `mcp_automations` (entidade) |
+> | `mcp_skill_versions` (append-only) | `mcp_automation_runs` (append-only) |
+> | `.claude/skills/*/SKILL.md` (fonte) | `.claude/hooks/*.{ps1,mjs}` + `Kernel.php` + `.claude/*.json` (fonte) |
+> | `ImportarSkillsDoGitService` (sync) | `AutomationRegistrySync` (sync) |
+> | `mcp_skill_drift_alerts` | `mcp_alertas` (categoria `automation_drift`) |
+> | tools `skills-search`/`skills-fetch` | tool `automations-list` |
+
+### 1. Tabela `mcp_automations` (DB-primary — entidade canônica)
+
+```sql
+CREATE TABLE mcp_automations (
+  id              BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  slug            VARCHAR(100) NOT NULL UNIQUE,
+  business_id     BIGINT UNSIGNED NULL
+                  COMMENT 'NULL = global (registry de infra de plataforma, sem tenant — ADR 0093)',
+
+  tipo            ENUM('hook_sessionstart','hook_pretooluse','hook_posttooluse',
+                       'cron','routine','webhook') NOT NULL,
+
+  gatilho         VARCHAR(255) NOT NULL
+                  COMMENT 'texto livre: matcher do hook (ex Edit|Write) OU expressao cron (ex 0 6 * * *) OU "SessionStart pos brief-fetch"',
+  descricao       TEXT NULL,
+  arquivo         VARCHAR(300) NOT NULL
+                  COMMENT 'path relativo ao repo (ex .claude/hooks/pii-redactor.ps1)',
+  owner           VARCHAR(100) NULL,
+  governed_by_adr VARCHAR(100) NULL
+                  COMMENT 'slug do ADR que governa esta automacao (nullable)',
+
+  enabled         BOOLEAN NOT NULL DEFAULT TRUE,
+  last_run_at     TIMESTAMP NULL,
+  last_status     ENUM('ok','warn','fail','skip') NULL,
+  last_detail     TEXT NULL,
+
+  created_at      TIMESTAMP NULL,
+  updated_at      TIMESTAMP NULL,
+
+  INDEX idx_automations_tipo (tipo),
+  INDEX idx_automations_enabled (enabled),
+  INDEX idx_automations_last_status (last_status),
+  INDEX idx_automations_business (business_id)
+);
+```
+
+### 2. Tabela `mcp_automation_runs` (audit append-only — opcional)
+
+Espelha `mcp_skill_versions` (append-only puro): rastreia execuções ao longo do tempo, separadas do snapshot vivo em `mcp_automations.last_*` (mesma separação que ADR 0076 faz entre histórico imutável e estado corrente, e que [`ENFORCEMENT.md`](../../../governance/ENFORCEMENT.md) §L7 exige para audit).
+
+```sql
+CREATE TABLE mcp_automation_runs (
+  id              BIGINT UNSIGNED AUTO_INCREMENT PRIMARY KEY,
+  automation_id   BIGINT UNSIGNED NOT NULL,
+  ran_at          TIMESTAMP NOT NULL,
+  status          ENUM('ok','warn','fail','skip') NOT NULL,
+  detail          TEXT NULL,
+  actor           VARCHAR(100) NULL
+                  COMMENT 'quem/o-que disparou: "scheduler", "claude-code:SessionStart", username...',
+
+  INDEX idx_runs_automation_ran (automation_id, ran_at),
+  INDEX idx_runs_status (status),
+  CONSTRAINT fk_runs_automation FOREIGN KEY (automation_id)
+    REFERENCES mcp_automations(id) ON DELETE CASCADE
+);
+```
+
+> **Append-only** como `mcp_audit_log` ([`ENFORCEMENT.md`](../../../governance/ENFORCEMENT.md) §L7): nunca `UPDATE`/`DELETE` em rows existentes. Cada execução é um INSERT. Retenção via `jana:retention-purge` (já existe no Kernel) se o volume crescer.
+
+### 3. Tool MCP `automations-list`
+
+Lista as automações + estado vivo + **drift**. Mesma família de `skills-search` ([ADR 0076](../../0076-skills-db-primary-git-destino-drift-alert.md) §5) — read-only, multi-tenant-safe, sem custo de LLM.
+
+Retorno por automação:
+- `slug`, `tipo`, `gatilho`, `arquivo`, `owner`, `governed_by_adr`, `enabled`
+- `last_run_at`, `last_status`, `last_detail`
+- `drift`: enum `none` / `orphan_file` (arquivo no filesystem, não registrado) / `missing_file` (registrado, arquivo sumiu)
+
+Filtros: `tipo`, `enabled`, `last_status`, `drift` (ex.: `automations-list drift:missing_file` mostra automações zumbis). Default: todas, ordenadas por `tipo` + `slug`.
+
+### 4. Service `AutomationRegistrySync`
+
+Espelha [`ImportarSkillsDoGitService`](../../../../Modules/Jana/Services/Mcp/ImportarSkillsDoGitService.php) **traço-a-traço**: varre o filesystem do repo → `upsert` em `mcp_automations` → drift alert em `mcp_alertas`. Idempotente. Envolvido em `OtelHelper::span('jana.mcp.automation_registry_sync', [], ...)` **sem `business_id`** (registry global), igual ao span de import de skills.
+
+3 coletores (um por classe de fonte):
+
+| Coletor | Fonte | Heurística |
+|---|---|---|
+| `coletarHooks()` | `glob('.claude/hooks/*.ps1') + glob('.claude/hooks/*.mjs')` (exclui `*.test.*`) | slug = basename sem extensão; `tipo` inferido por marcador no header do arquivo OU por `.claude/settings.json` (qual evento o registra); `gatilho` = matcher do evento |
+| `coletarCrons()` | parse de `app/Console/Kernel.php` | regex em `$schedule->command('X')->...` → slug = comando; `tipo=cron`; `gatilho` = expressão cron / `dailyAt` resolvida |
+| `coletarRotinas()` | `glob('.claude/*.json')` com marcador `"_automation_registry": true` | slug + `tipo=routine` + `gatilho` + `arquivo` lidos do manifesto |
+
+**Upsert** (igual `ImportarSkillsDoGitService`): se `slug` existe → atualiza campos descritivos (não toca `last_run_at`/`last_status`, que são escritos pelas próprias automações); se não existe → cria. Após upsert, **drift em 2 direções**:
+
+```
+para cada arquivo no filesystem sem row em mcp_automations:
+    McpAlerta::create(category='automation_drift', severity='medium',
+                      detail="Automacao no filesystem nao registrada: <arquivo>")
+para cada row enabled em mcp_automations cujo `arquivo` sumiu do filesystem:
+    McpAlerta::create(category='automation_drift', severity='high',
+                      detail="Automacao registrada com arquivo ausente: <slug> -> <arquivo>")
+```
+
+Mesma reconciliação declarado-vs-observado do mecanismo #5 (drift detection cron) de [`ENFORCEMENT.md`](../../../governance/ENFORCEMENT.md), agora aplicada às próprias automações. Comando `php artisan jana:automations:sync` (manual + opcional no schedule diário).
+
+### 5. SEED — a rotina "Fechar o Loop" é a primeira automação registrada
+
+A rotina **"Fechar o Loop"** do IA-OS (manifesto `.claude/loop-fechar-o-loop.json` + check `.claude/hooks/loop-fechar-check.ps1`) é a **primeira automação** do registry — exemplo concreto de uma rotina governada por este próprio ADR:
+
+```sql
+INSERT INTO mcp_automations
+  (slug, business_id, tipo, gatilho, descricao, arquivo, owner, governed_by_adr, enabled, created_at, updated_at)
+VALUES
+  ('loop-fechar-o-loop',
+   NULL,                                       -- global (infra de plataforma)
+   'routine',
+   'SessionStart pos brief-fetch',             -- gatilho texto livre
+   'Rotina IA-OS Fechar o Loop: verifica loops abertos (decisao sem metrica, US sem evidencia) no inicio da sessao, pos brief-fetch.',
+   '.claude/hooks/loop-fechar-check.ps1',      -- arquivo (manifesto: .claude/loop-fechar-o-loop.json)
+   'wagner',
+   'automation-registry-mcp',                  -- governado por ESTE ADR
+   TRUE,
+   NOW(), NOW());
+```
+
+> O slug `governed_by_adr='automation-registry-mcp'` é auto-referente de propósito: a primeira automação registrada é governada pelo ADR que cria o registry — demonstra o padrão de ponta a ponta. Demais automações apontam para seus ADRs (ex.: `block-mwart-violation` → `0104`, `pii-redactor` → ADR de LGPD, `governance:detect-drift` → `0079`).
+
+### 6. Inventário humano paralelo IMEDIATO — `memory/governance/AUTOMATIONS.md`
+
+Antes mesmo da tabela existir, o doc canônico [`memory/governance/AUTOMATIONS.md`](../../../governance/AUTOMATIONS.md) (criado **em paralelo** a este ADR) é o inventário legível das automações. Como vive em `memory/`, **já é indexado pelo MCP** via webhook GitHub ([ADR 0053](../../0053-mcp-server-governanca-como-produto.md)) — ou seja, **resolve hoje** a pergunta do Wagner *"isso fica na rede MCP?"* (consultável via `memoria-search` / `decisions-search`), sem esperar o backend.
+
+Sequência de valor (igual ADR 0076: V0 read-only antes da UI completa):
+1. **Hoje (V0):** `AUTOMATIONS.md` em git → indexado MCP → time já enxerga o inventário.
+2. **V1 (DB-backed):** `mcp_automations` + `AutomationRegistrySync` + `automations-list` → estado vivo (`last_run`, `enabled`) + drift detection que markdown sozinho não dá.
+
+`AUTOMATIONS.md` continua o **doc legível canônico** (igual SPEC.md continua canônico para US mesmo com `mcp_tasks` — [ADR 0070](../../0070-jira-style-task-management-current-md-removed.md)); `mcp_automations` é a **evolução DB-backed** com drift + last_run que um markdown não consegue oferecer.
+
+## Multi-tenant (Tier 0)
+
+`mcp_automations` é **GLOBAL by-design**: `business_id NULL` efetivo (sem tenant). Isto é uma **exceção justificada** à regra geral de [ADR 0093](../../0093-multi-tenant-isolation-tier-0.md) (*"toda entidade de negócio carrega `business_id` em global scope"*), pela mesma razão e com a mesma convenção dos demais `mcp_*` de governança:
+
+| Tabela | `business_id` | Marcador |
+|---|---|---|
+| `mcp_skills` ([ADR 0076](../../0076-skills-db-primary-git-destino-drift-alert.md)) | `NULL` (global) | "global por default" no `ImportarSkillsDoGitService` |
+| `mcp_governance_rules` ([ADR 0080](../../0080-trust-tiers-operacional-audit-findings.md)) | sem `business_id` | "Sem business_id by design" |
+| **`mcp_automations`** (este ADR) | **`NULL` (global)** | **"Sem business_id by design — infra de plataforma"** |
+
+**Justificativa.** Hooks (`.claude/hooks/`), crons (`Kernel.php`) e rotinas (`.claude/*.json`) são **infra de plataforma**, não dados de tenant: rodam no runtime do oimpresso e governam o repo inteiro, não os dados de um cliente. Um hook `block-pii` ou um cron `jana:health-check` não "pertence" ao business 4 (RotaLivre) nem ao business 7 — pertence à plataforma. A coluna `business_id NULL` é mantida no schema (não removida) por simetria com `mcp_skills`/`mcp_governance_rules` e para abrir a porta, no futuro, a automações *custom por-tenant* (ex.: cron de billing específico de um cliente B2B) sem migração de schema — exatamente como ADR 0076 reservou `business_id NULL` para skills custom por-tenant.
+
+**Tier 0 preservado:** nenhuma query de dados de negócio é afetada. O registry não lê dados de tenant; lê arquivos do repo. O global scope de [ADR 0093](../../0093-multi-tenant-isolation-tier-0.md) continua IRREVOGÁVEL para toda entidade que carregue dados de cliente — `mcp_automations` simplesmente não é uma delas.
+
+## Consequências
+
+### Positivas
+
+- **Simetria de governança fechada:** decisões (ADR), tasks ([ADR 0070](../../0070-jira-style-task-management-current-md-removed.md)), skills ([ADR 0076](../../0076-skills-db-primary-git-destino-drift-alert.md)) e agora **automações** têm registry MCP-queryable. Acaba a assimetria "rastro pra decisão, zero pra automação".
+- **Pergunta respondível por agente:** "quais automações existem, o que disparam, quando rodaram, deu ok?" → uma chamada `automations-list`.
+- **Drift detection bidirecional:** arquivo órfão (no FS, não registrado) **e** automação zumbi (registrada, arquivo sumiu) viram alerta em `mcp_alertas` — observabilidade que git grep manual não dá.
+- **Mecanismo #9 de [`ENFORCEMENT.md`](../../../governance/ENFORCEMENT.md):** as automações que protegem as 7 camadas agora são, elas próprias, inventariadas e observadas.
+- **Time enxerga (Felipe/Maiara/Eliana/Luiz):** via tool MCP + `AUTOMATIONS.md` indexado, ninguém mais precisa de acesso ao filesystem do repo pra saber o que roda sozinho.
+- **Zero custo de LLM:** varredura determinística + parse de `Kernel.php`. Não toca Brain B / ADS.
+- **Padrão reusado, não inventado:** schema, sync service e drift espelham ADR 0076 — baixo risco, curva zero pra quem já conhece skills.
+
+### Negativas / Trade-offs
+
+- **2 tabelas novas** (`mcp_automations` + `mcp_automation_runs`). Custo de schema esperado pelo escopo; idêntico em peso ao par skills.
+- **`last_run_at`/`last_status` exigem que as automações reportem.** O `AutomationRegistrySync` popula descrição/existência, mas o estado de execução só fica fiel se cada hook/cron escrever seu run (via helper ou tool `automations-report`). **Mitigação:** V1 entrega o inventário + drift (alto valor, baixo esforço); instrumentação de `last_run` é incremental, automação a automação — `automations-list` mostra `last_run_at=NULL` honestamente até cada uma ser instrumentada (sem mentir sobre o que não sabe).
+- **Parse de `Kernel.php` por regex é frágil** a refactors do arquivo. **Mitigação:** o sync é warn-only no drift de crons (não bloqueia); se o parse falhar para um comando, vira alerta `medium`, não erro fatal. Reusa a robustez do `resolveHeadSha()` do `ImportarSkillsDoGitService` (lê estado direto, tolera formatos variados).
+- **Manutenção do `AUTOMATIONS.md` em paralelo ao DB** pode desincronizar (mesmo risco que SPEC.md vs mcp_tasks em [ADR 0070](../../0070-jira-style-task-management-current-md-removed.md)). **Mitigação:** `AutomationRegistrySync` é a fonte de verdade do *estado*; `AUTOMATIONS.md` é doc legível de *intenção/narrativa*. Um futuro check pode comparar os dois e alertar (como `governance:detect-drift` faz para SCOPE.md).
+
+### Riscos mitigados
+
+- **Não viola [ADR 0093](../../0093-multi-tenant-isolation-tier-0.md):** exceção `business_id NULL` é a mesma convenção já aceita para `mcp_skills`/`mcp_governance_rules`; nenhuma query de dados de negócio é tocada.
+- **Não depende de Brain B/ADS:** decisão Wagner explícita; registry é observabilidade pura.
+- **Webhook reusado** ([ADR 0053](../../0053-mcp-server-governanca-como-produto.md)): sync pode ser disparado por push, mas filesystem é a fonte (igual skills) — sem novo canal de integração.
+- **`mcp_automation_runs` append-only** segue a regra de imutabilidade de audit ([`ENFORCEMENT.md`](../../../governance/ENFORCEMENT.md) §L7).
+
+## Alternativas descartadas
+
+- **(a) Deixar como está (invisível).** Manter hooks/crons/rotinas só no filesystem, descobríveis por `git grep`. ❌ É o gap #11 da auditoria. Reproduz exatamente o anti-padrão que ADR 0070 (tasks) e ADR 0076 (skills) já condenaram: artefato operacional sem registry → ninguém consulta, drift garantido, time sem visibilidade.
+- **(b) Só markdown (`AUTOMATIONS.md`), sem DB.** ❌ O markdown resolve *hoje* o inventário legível (e por isso é feito em paralelo, §6) mas **não dá drift detection nem `last_run`** — não há reconciliação automática filesystem-vs-declarado, nem estado de execução vivo. Markdown é foto estática; o registry precisa de loop de observação. (Mesma razão pela qual ADR 0076 não deixou skills só em git.)
+- **(c) Reusar `mcp_governance_rules`** ([ADR 0080](../../0080-trust-tiers-operacional-audit-findings.md)) **para automações.** ❌ Semântica errada. `mcp_governance_rules` modela *políticas de decisão* (ALLOW/REVIEW/BLOCK avaliadas pelo PolicyEngine em runtime); automações são *processos que executam por gatilho* (cron/hook/rotina). Misturar as duas semânticas polui ambas e quebra mutation testing das rules (mecanismo #6 de [`ENFORCEMENT.md`](../../../governance/ENFORCEMENT.md)).
+- **(d) Arquivo YAML no git sem tool MCP.** ❌ Não é queryable por agente. Um `automations.yaml` versionado seria melhor que nada, mas um agente IA (Claude Code) ou o time via MCP precisaria ler o arquivo bruto e parsear — não há `automations-list` com filtros (`drift:missing_file`, `tipo:cron`, `last_status:fail`). Falha o requisito central: *"agente pergunta, MCP responde"*. (Idêntico ao motivo de ADR 0070 ter removido CURRENT.md/TASKS.md em favor de tools.)
+
+## Plano de implementação
+
+V1 = inventário + drift (alto valor, baixo esforço). Espelha o plano V1 de [ADR 0076](../../0076-skills-db-primary-git-destino-drift-alert.md) (backend-first, V0 read-only antes da UI).
+
+| Passo | Escopo | Estimativa (recalibrada ADR 0106) |
+|---|---|---|
+| **0** | `AUTOMATIONS.md` em `memory/governance/` (paralelo a este ADR) → push → indexado MCP. **V0 já entrega valor.** | 1h |
+| **1** | 2 migrations (`mcp_automations` + `mcp_automation_runs`) idempotentes + 2 Entities (`McpAutomation`, `McpAutomationRun`) + factories | 1h |
+| **2** | `AutomationRegistrySync` (3 coletores: hooks/crons/rotinas) espelhando `ImportarSkillsDoGitService` + command `jana:automations:sync` + drift → `mcp_alertas` | 2h |
+| **3** | Tool MCP `automations-list` (estado vivo + drift) + permission Spatie `governance.automations.read` (time inteiro) | 1h |
+| **4** | Pest: sync idempotente, drift `orphan_file`, drift `missing_file`, seed `loop-fechar-o-loop`, `automations-list` retorna estado + filtros | 1h |
+| **5** | **SEED** `loop-fechar-o-loop` (§5) + 1ª varredura real popula o inventário atual (~35 hooks + ~30 crons) | 30min |
+| **6** *(incremental, pós-V1)* | Instrumentar `last_run`/`last_status` automação a automação (helper `automations-report` chamado por hooks/crons) | contínuo |
+
+**Não-decisões deliberadas (deferred):**
+- ❌ UI Inertia `/governance/automations` — V2 (V0/V1 entregam via tool MCP, como ADR 0070 deferiu Kanban Web).
+- ❌ Habilitar/desabilitar automação **pela** tool (write) — V1 é read-only; `enabled` é espelho do estado real, não controle remoto.
+- ❌ Instrumentação `last_run` de todas as ~65 automações de uma vez — incremental (passo 6).
+
+## Referências
+
+- [ADR 0053 — MCP server governança como produto](../../0053-mcp-server-governanca-como-produto.md) (webhook + cache pattern reusados)
+- [ADR 0070 — Jira-style task management; CURRENT.md/TASKS.md removidos](../../0070-jira-style-task-management-current-md-removed.md) (registry MCP > markdown paralelo; estilo ADR)
+- [ADR 0076 — Skills DB-primary, git destino, drift alert](../../0076-skills-db-primary-git-destino-drift-alert.md) (**template conceitual**: DB-primary + filesystem fonte + sync service + drift)
+- [ADR 0079 — Constituição oimpresso 7 camadas](../../0079-constituicao-oimpresso-7-camadas-governanca.md)
+- [ADR 0080 — Trust Tiers operacional + audit findings](../../0080-trust-tiers-operacional-audit-findings.md) (`mcp_governance_rules` sem business_id by design)
+- [ADR 0093 — Multi-tenant isolation Tier 0 IRREVOGÁVEL](../../0093-multi-tenant-isolation-tier-0.md) (regra geral business_id global scope; exceção justificada aqui)
+- [`memory/governance/ENFORCEMENT.md`](../../../governance/ENFORCEMENT.md) — 8 mecanismos NIST/Cedar/OPA; este registry é o **mecanismo #9** (inventário + observabilidade de automações)
+- [`memory/governance/AUTOMATIONS.md`](../../../governance/AUTOMATIONS.md) — inventário humano legível (deliverable paralelo, V0)
+- [`Modules/Jana/Services/Mcp/ImportarSkillsDoGitService.php`](../../../../Modules/Jana/Services/Mcp/ImportarSkillsDoGitService.php) — sync service de skills que `AutomationRegistrySync` espelha
+- [`memory/requisitos/TaskRegistry/AUDIT-TEAM-OS-2026-05-29.md`](../../../requisitos/TaskRegistry/AUDIT-TEAM-OS-2026-05-29.md) — origem (gap #11)

--- a/memory/governance/AUTOMATIONS.md
+++ b/memory/governance/AUTOMATIONS.md
@@ -1,0 +1,204 @@
+---
+slug: oimpresso-automations
+title: "Inventário canônico de automações — hooks, crons, rotinas"
+type: governance-spec
+authority: canonical
+lifecycle: ativo
+maintained_by: wagner
+last_updated: 2026-05-29
+related: [automation-registry-mcp, 0076, 0079, 0080]
+pii: false
+---
+
+# Inventário canônico de automações — hooks, crons, rotinas
+
+Este é o inventário canônico de automações do oimpresso. Como vive em `memory/`, é **indexado pelo MCP server** (via `IndexarMemoryGitParaDb`) — logo o time enxerga as automações via tools MCP (resolve a lacuna histórica de automações invisíveis). Será DB-backed via ADR proposta `automation-registry-mcp` (ADR 0234, tabela `mcp_automations` + tool `automations-list`); até lá, este markdown é a fonte canônica.
+
+---
+
+## Hooks SessionStart
+
+Disparados a cada início de sessão Claude Code. Tipo ADR 0234: `hook_sessionstart`.
+
+| Ordem | Hook | O que faz | Arquivo |
+|-------|------|-----------|---------|
+| 1 | `brief-fetch-curl` | Força chamada ao MCP `brief-fetch` via curl HTTP (JSON-RPC autenticado). Garante estado consolidado (~3k tokens) no contexto mesmo em worktrees filhos onde o MCP não conecta diretamente. Fallback gracioso para handoff index em 3 cenários de falha. | `.claude/hooks/brief-fetch-curl.ps1` |
+| 2 | handoff inline | Imprime últimas 40 linhas de `memory/08-handoff.md` (se existir) + lembrete sobre tools MCP para estado de tasks/cycles (CURRENT.md/TASKS.md removidos — ADR 0070). | inline em `settings.json` (comando PowerShell direto) |
+| 3 | `check-skills-fresh` | Detecta skills novas ou modificadas em `.claude/skills/` desde o último start deste dev. Avisa para rodar `/sync-skills` se houver drift. Estado salvo em `.claude/.last-skills-sync` (gitignored). | `.claude/hooks/check-skills-fresh.ps1` |
+| 4 | `tier-a-banner` | Exibe banner lembrando as 5 Skills Tier A (nucleo) + 6 auto-trigger (ADR 0225). Recalibrado 2026-05-28: Claude 4.8 torna always-on de auto-trigger redundante; redução de 8 para 5 Tier A. | `.claude/hooks/tier-a-banner.ps1` |
+
+---
+
+## Hooks PreToolUse
+
+Disparados antes de cada uso de ferramenta. Tipo ADR 0234: `hook_pretooluse`.
+
+### Matcher: `Read|Glob|Grep`
+
+| Matcher | Hook | O que faz | Arquivo |
+|---------|------|-----------|---------|
+| `Read\|Glob\|Grep` | `mcp-first-warning` | Avisa quando Claude tenta usar Read/Glob/Grep em `memory/*`, incentivando uso de tools MCP antes de ler filesystem. Enforcement cultural do reflexo MCP-first (ADR 0070 — CURRENT.md/TASKS.md removidos). | `.claude/hooks/mcp-first-warning.ps1` |
+
+### Matcher: `Write|Edit|MultiEdit`
+
+| Matcher | Hook | O que faz | Arquivo |
+|---------|------|-----------|---------|
+| `Write\|Edit\|MultiEdit` | `block-automem` | Bloqueia Write/Edit em auto-mem privada legada (`~/.claude/projects/*/memory/*.md`). Permite `~/.claude/oimpresso-local/` (escape valve). 3 tiers: Canônico (git), Local (~/.claude/oimpresso-local/), Segredo (Vaultwarden). ADR 0061 + ADR 0131. | `.claude/hooks/block-automem.ps1` |
+| `Write\|Edit\|MultiEdit` | `block-memory-drift` | Bloqueia edits em paths canônicos (`memory/decisions/`, `memory/08-handoff.md`, etc.) sem branch `claude/*` + workflow PR. ADRs accepted são append-only irrevogáveis. ADR 0094 Art. 3 + ADR 0061 + ADR 0130. | `.claude/hooks/block-memory-drift.ps1` |
+| `Write\|Edit\|MultiEdit` | `block-mwart-violation` | Bloqueia Edit/Write em `resources/js/Pages/<Mod>/<Tela>.tsx` sem RUNBOOK existir em `memory/requisitos/<Mod>/RUNBOOK-<tela-kebab>.md`. Garante que F1 PLAN acontece antes de F3 FRONTEND. Override via comentário `/mwart-override <razão>` no PR. ADR 0104. | `.claude/hooks/block-mwart-violation.ps1` |
+| `Write\|Edit\|MultiEdit` | `charter-validate` | Avisa (modo warning, não bloqueia ainda) quando Claude tenta editar Page `.tsx` que tem `.charter.md` irmão sem ter chamado `charter-fetch` previamente. Vira bloqueante quando ROI provado (≥5 sessões). ADR 0094 + ADR 0101. | `.claude/hooks/charter-validate.ps1` |
+| `Write\|Edit\|MultiEdit` | `modulo-preflight-warning` | Aviso (não bloqueia) quando Claude tenta Edit/Write em `Modules/<X>/` sem ter lido SPEC.md/RUNBOOK/charter do módulo X na sessão atual. Implementa FASE 1 PRÉ-FLIGHT da Regra Primária Tier 0. | `.claude/hooks/modulo-preflight-warning.ps1` |
+| `Write\|Edit\|MultiEdit` | `block-bom-encoding` | Bloqueia Write/Edit que reintroduza UTF-8 BOM (EF BB BF) em arquivos de código. Origem: post-mortem v4 go-live (PR #984) — PowerShell 5.1 `Set-Content -Encoding utf8` gravava BOM que quebrava PHP (`Namespace declaration statement has to be the very first statement`). | `.claude/hooks/block-bom-encoding.ps1` |
+| `Write\|Edit\|MultiEdit` | `block-merge-markers` | Bloqueia Write/Edit que contenha git merge conflict markers não-resolvidos (`<<<<<<<`, `=======`, `>>>>>>>`). Origem: post-mortem v4 go-live (PRs #1000/#1001) — markers chegaram em prod causando PHP parse error. | `.claude/hooks/block-merge-markers.ps1` |
+| `Write\|Edit\|MultiEdit` | `block-routes-string-legacy` | Bloqueia Write/Edit em `routes/*.php` e `Modules/*/Routes/*.php` que use sintaxe string legacy `'Controller@method'`. FQCN obrigatório: `[Class::class, 'method']`. Origem: post-mortem v4 go-live (PR #843) — strings quebravam `php artisan route:cache`. | `.claude/hooks/block-routes-string-legacy.ps1` |
+
+### Matcher: `Bash`
+
+| Matcher | Hook | O que faz | Arquivo |
+|---------|------|-----------|---------|
+| `Bash` | `block-destructive` | Bloqueia comandos Bash destrutivos sem confirmação humana: `rm -rf` em paths críticos, `git push --force` em main/master, `git reset --hard origin/*`, `DROP TABLE/DATABASE`, `DELETE FROM` sem WHERE, `composer update` sem `--lock`, `migrate:fresh/reset` em prod, `TRUNCATE TABLE`. | `.claude/hooks/block-destructive.ps1` |
+| `Bash` | `pii-redactor` | Bloqueia Bash que vai commitar/printar PII (CPF, CNPJ, cartão). Escaneia `git commit` com PII na mensagem ou diff staged. LGPD Art. 7 (princípio de minimização). Whitelist de PIIs fake/fixture. | `.claude/hooks/pii-redactor.ps1` |
+| `Bash` | `commit-discipline-check` | Enforcement Skill Tier A commit-discipline via PreToolUse Bash (git commit/add). ADR 0094 §5. | `.claude/hooks/commit-discipline-check.ps1` |
+| `Bash` | `block-claim-without-evidence` | Bloqueia `gh pr create`/`gh pr merge --admin`/`git push` para branches que tocam infra crítica se o body do PR não contém evidência curl/HTTP literal. Camada B pareada com CI gate `.github/workflows/infra-contract-required.yml`. Escape: `# evidence-override: <razão>`. | `.claude/hooks/block-claim-without-evidence.ps1` |
+| `Bash` | `post-merge-ui-smoke-required` | Após `gh pr merge --admin` de PR com arquivos UI (.tsx/.css/.blade.php), marca flag pendente e bloqueia Claude de declarar "pronto"/"deployed" sem screenshot real. Enforcement Tier 0 smoke visual pós-merge. Também ativo em PreToolUse `mcp__computer-use__screenshot\|mcp__Claude_in_Chrome__.*`. | `.claude/hooks/post-merge-ui-smoke-required.ps1` |
+| `Bash` | `block-serving-branch-switch` | Bloqueia troca de branch no checkout MAIN (`D:\oimpresso.com`) que serve `oimpresso.test` via Herd. Trabalho de feature vai em worktree isolado. Worktrees linkados (`.claude/worktrees/*`) são liberados. ADR 0233. Fail-open. | `.claude/hooks/block-serving-branch-switch.ps1` |
+
+### Matcher: `mcp__computer-use__screenshot|mcp__Claude_in_Chrome__.*`
+
+| Matcher | Hook | O que faz | Arquivo |
+|---------|------|-----------|---------|
+| `mcp__computer-use__screenshot\|mcp__Claude_in_Chrome__.*` | `post-merge-ui-smoke-required` | Mesmo hook acima — também disparado em ferramentas de screenshot para verificar contexto de smoke pós-merge pendente. | `.claude/hooks/post-merge-ui-smoke-required.ps1` |
+
+---
+
+## Hooks PostToolUse
+
+Disparados após uso de ferramenta. Tipo ADR 0234: `hook_posttooluse`.
+
+| Matcher | Hook | O que faz | Arquivo |
+|---------|------|-----------|---------|
+| `Bash` | `post-merge-ui-smoke-required` | PostToolUse Bash: detecta `gh pr merge --admin` em PR que tocou arquivos UI e marca timestamp em flag `$env:TEMP/oimpresso-ui-merge-pending.flag`. Trabalha em conjunto com a verificação PreToolUse do mesmo hook. | `.claude/hooks/post-merge-ui-smoke-required.ps1` |
+| `Write\|Edit` | `audit-creates-tasks` | PostToolUse Write/Edit: detecta tasks órfãs em documentos de audit (`memory/sessions/*-audit-*.md` ou `memory/requisitos/*/AUDIT-*.md`) e propõe `tasks-create` MCP para cada gap identificado. Mecanismo 2 do ADR 0213 (audit-to-backlog loop fechado). Cross-platform Node.js. | `.claude/hooks/audit-creates-tasks.mjs` |
+
+---
+
+## Hooks Stop
+
+Disparados quando Claude encerra a resposta. Tipo ADR 0234: `hook_sessionstart` (Stop).
+
+| Ordem | Hook | O que faz | Arquivo |
+|-------|------|-----------|---------|
+| 1 | `memory-pending` | Detecta arquivos em `memory/`, `MEMORY*.md`, `*.SPEC.md` e governança raiz modificados/novos sem push, e avisa para rodar `/sync-mem` antes de encerrar o turno. Evita drift team (webhook GitHub→MCP só sincroniza após push). | `.claude/hooks/memory-pending.ps1` |
+| 2 | `nudge-recommend-not-menu` | Advisory (exit 0 sempre, nunca bloqueia): detecta resposta terminando em menu de decisão técnica sem recomendação cravada. R13 / ADR 0233. | `.claude/hooks/nudge-recommend-not-menu.ps1` |
+| 3 | `nudge-diagnosis-without-evidence` | Advisory (exit 0 sempre): detecta diagnóstico/causa afirmado sem evidência (grep/log/SQL/trace/curl). Origem: sessão 2026-05-29 chutou causa de HTTP 500 antes de ler o log. R1 / ADR 0233. | `.claude/hooks/nudge-diagnosis-without-evidence.ps1` |
+
+---
+
+## Hooks UserPromptSubmit
+
+Disparados a cada prompt enviado pelo usuário. Tipo ADR 0234: `hook_sessionstart` (UserPromptSubmit).
+
+| Ordem | Hook | O que faz | Arquivo |
+|-------|------|-----------|---------|
+| 1 | `force-r12-closing-signal` | Detecta sinal de fechamento de sessão no prompt do usuário e força protocolo R12 (encerrar-sessao). Camada 2 de ativação R12; Camada 1 é skill `encerrar-sessao` Tier B. Cross-platform Node.js (funciona Wagner + Felipe + Maiara + Eliana + Luiz em qualquer OS). | `.claude/hooks/force-r12-closing-signal.mjs` |
+
+---
+
+## Arquivos presentes em hooks/ mas NÃO ativos em settings.json
+
+| Arquivo | Observação |
+|---------|------------|
+| `block-module-drift.ps1` | Detecta Controllers fora do SCOPE.md do módulo (Mecanismo #3 ENFORCEMENT.md). Arquivo existe mas NÃO está registrado em settings.json — inativo. |
+| `block-pr-without-approval.mjs` | Bloqueia `gh pr create`/`gh pr merge` sem aprovação humana prévia (R10). Arquivo existe mas consta no cabeçalho como "PROPOSTA — ainda NÃO registrada em settings.json". Inativo. |
+
+---
+
+## Crons (app/Console/Kernel.php)
+
+Tipo ADR 0234: `cron`. Todos os schedules são ambientes `live` salvo indicação. BRT = America/Sao_Paulo.
+
+| Command | Schedule | O que faz |
+|---------|----------|-----------|
+| `backup:clean` | `daily` às 01:00 | Limpa backups antigos (env=live). |
+| `backup:run` | `daily` às 01:30 | Executa backup completo (env=live). |
+| `pos:generateSubscriptionInvoices` | `dailyAt('23:30')` | Gera faturas recorrentes de assinatura (env=live). |
+| `pos:updateRewardPoints` | `dailyAt('23:45')` | Atualiza pontos de fidelidade (env=live). |
+| `pos:autoSendPaymentReminder` | `dailyAt('8:00')` | Envia lembretes automáticos de pagamento (env=live). |
+| `memcofre:sync-memories` | `dailyAt('23:00')` | Sincroniza memória Claude para dentro do repo (SRS). Idempotente. env=local,live. Histórico: docvault:sync → memcofre:sync (ADR 0088). |
+| `jana:cycles:auto-close-expired` | `dailyAt('23:55')` BRT | Auto-fechamento de cycles expirados (Linear-style). Cria CYCLE-N+1 em planning se não há próximo. H5 Onda 3. |
+| `copiloto:metrics:apurar --business=all` | `dailyAt('23:55')` | Apura 8 métricas obrigatórias + 3 RAGAS por business. Grava 1 linha/dia em `copiloto_memoria_metricas` (upsert idempotente). MEM-MET-3 (ADRs 0050+0051). |
+| `jana:weekly-digest` | segundas `09:00` BRT | Digest Reflect-style semanal: commits, PRs, US, ADRs, handoffs, cycle goals delta + audit log. gpt-4o-mini ~R$ 0.005. H6 Onda 3. |
+| `copiloto:sintese-semanal` | sextas `18:00` | Síntese semanal automática: commits + arquivos memory/ + diffs da semana. Haiku 4.5. ~R$ 0.10/execução. MemoriaAutonoma Fase 1. |
+| `jana:health-check --notify` | `dailyAt('06:00')` BRT | 5 checks SQL: multi_tenant_isolation, brief_uptime_24h, custo_brain_b_24h, pii_leak_in_assistant_responses, profile_distiller_drift. |
+| `sells:smoke-daily --notify` | `dailyAt('06:30')` BRT | 5 sinais smoke Sells/Index Cowork: schema, multi-tenant biz=1/4, Vite manifest, CSS scoped, SellController shape. US-SELL-COWORK-R6-SMOKE. |
+| `module:grade-snapshot` | `dailyAt('06:05')` BRT | Snapshot diário de module grades (sparkline 7d). 1 row/módulo em `mcp_module_grades_history`. ADR 0153/0155. |
+| `governance:scorecard-snapshot --alert` | `dailyAt('07:00')` BRT | Scorecard snapshot bucket-scoped + drift detection. 1 row/módulo/dia em `mcp_scorecard_runs`. Alerta drifts >=5pts em `mcp_alertas`. Wave 24. |
+| `governance:initiative-sync` | `dailyAt('08:00')` BRT | Sync Initiatives ↔ scorecards (Cortex-style): abre breach, fecha recuperadas, expira deadlines. Wave 28. |
+| `observability:aggregate-daily` | `dailyAt('02:00')` BRT | Rollup diário OTel spans: computa p50/p95/p99 + error rate por (module, span_name). ADR 0162. |
+| `jana:system-audit --notify` | `dailyAt('06:15')` | Audit 5 dimensões: observability, evals, ADR-stale, cost-agg, test-coverage. SQL+FS only, ZERO LLM. ADR 0133. |
+| `mcp:tasks:health-check` | `dailyAt('06:20')` BRT | Flagga tasks dormentes em `mcp_tasks`: stale_todo >21d, stale_blocked >30d, stale_doing >7d sem commit, stale_review >5d. |
+| `NarrarSaudeEcosistemaJob` (Job) | `hourlyAt(30)` | Brain A narrador horário do Cockpit Saúde: HealthSnapshotService + HealthNarratorService (gpt-4o-mini). ~R$ 0.30/dia. US-COPI-100. |
+| `charter:health --notify` | `dailyAt('06:30')` | Drift detector daily de Page Charters. Métrica M6 anti-hallucination ratchet. S6 F2. |
+| `arquivos:health-check --alert` | `dailyAt('06:30')` BRT | 5 sinais compliance LGPD + integridade DMS: orphan_files, dedupe_inconsistent, audit_log_lag, retention_overdue, vault_encryption_ratio. ADR 0123. |
+| `governance:detect-drift` | `dailyAt('06:15')` BRT | Compara `Modules/<X>/SCOPE.md.contains[]` × filesystem real de Controllers. Persiste alertas em `mcp_alertas_eventos` (tipo=module_drift). ADR 0094 Art. 7. |
+| `SyncBankStatementsJob` (Job) | `dailyAt('07:00')` | Sync extrato bancário Inter D-7 (Banking API v2). Idempotente via UNIQUE. US-RB-046. |
+| `customer-memory:refresh-daily` | `dailyAt('02:00')` BRT | Re-dispatcha `RebuildCustomerMemoryJob` para customers com `last_rebuilt_at > 24h` ou NULL. US-WA-VOZ-001. |
+| `employee-performance:refresh-daily` | `dailyAt('02:30')` BRT | Re-dispatcha rebuild de scorecards de performance. US-WA-VOZ-003. |
+| `ads:review-decisions --limit=10` | `everyFifteenMinutes()` | Review automático de decisions sem score (G-Eval T11 ADS). |
+| `ads:learn-patterns --business=all --detect-drift` | `dailyAt('02:00')` | Pattern Learning ADS Wilson Score (T15). |
+| `ads:auto-generate-tasks` | `cron('0 9-18 * * 1-5')` | Auto Task Generator ADS Self-Instruct (T7). Horário comercial seg–sex 9h–18h. |
+| `ads:plan-decisions --limit=3` | `everyTenMinutes()` | ADS Planner (T9 PlannerAgent): decompõe decisions complexas. |
+| `ads:process-brain-b --limit=5` | `everyFiveMinutes()` | ADS Brain B: processa decisions com `destination=brain_b`. ~$0.05/dia com prompt caching Sonnet. |
+| `jana:retention-purge` | `dailyAt('03:00')` BRT | LGPD purge job: aplica `Modules/Jana/Config/retention.php` sobre 7 entidades PII-relevantes (estratégia default `anonymize`). Atrás de `JANA_RETENTION_ENABLED=true` (default false). ADR 0105. D7.d. |
+| `copiloto:cleanup-memoria` | `weeklyOn(0, '03:00')` (dom) | MEM-FASE8: remove bloat (hits=0, >30d) + expirados (valid_until >90d) + órfãos MCP. Soft-delete padrão. |
+| `mcp:sync-memory --reason=cron` | `everyFiveMinutes()` | Rede de proteção para webhook GitHub: re-indexa memory quando sha de arquivo muda. Idempotente. |
+| `mcp:tasks:sync` | `everyTenMinutes()` | Rede de proteção para task sync: `TaskParserService::syncAll()` quando SPEC.md muda. Idempotente via hash do SPEC. |
+| `jana:freshness-check --alert --reindex --limit=50` | `dailyAt('04:30')` BRT | Freshness pipeline ativo: classifica docs em FRESH/WARM/STALE/CRITICAL, detecta drift DB↔git, dispatcha `ReindexarDocumentoJob` pros stale (max 50/execução). GAP D7 #2. |
+| `copiloto:seed-adrs --type=all` | `dailyAt('04:45')` BRT | Re-seed ADRs → `jana_memoria_facts` diário. Cobre adr+spec+reference. Idempotente (upsert por source_slug). MEM-MULTI-1. |
+| `brief:generate` | `cron('0 7,11,14,17,20,23 * * *')` BRT | Gera brief 6x/dia (horário comercial PT-BR). ~$0.30/dia. ADR 0091. |
+| `ProcessRemindersJob` (Job) | `hourly()` | Processa lembretes WhatsApp pendentes (`due_at<=now()`, `notified_at IS NULL`). Publica Centrifugo per-user. US-WA-076 / ADR 0142. |
+| `whatsapp:health-check-all` | `cron('0 */6 * * *')` | Health check drivers WhatsApp (Z-API/Baileys) a cada 6h. Ativa fallback automático Meta Cloud se ban detectado. US-WA-014 / ADR 0096. |
+| `whatsapp:auto-link-contacts --business=all --limit=500` | `weeklyOn(1, '03:00')` (seg) BRT | Backfill semanal auto-link Conversation→Contact CRM por phone match. Cobre órfãs históricas. US-WA-078. |
+| `whatsapp:health-probe-channels` | `dailyAt('03:30')` BRT | Self-healing Camada 2: probe + auto-recovery canais Baileys (3 retries com backoff). |
+| `whatsapp:channels-reconcile` | `everyFiveMinutes()` | Reconcilia DB.status vs daemon.state (Baileys). Auto-corrige drift leve (disconnect sem aviso, órfã). |
+| `queue:work database --queue=whatsapp-history --max-time=55 ...` | `everyMinute()` | Worker fila `whatsapp-history`: processa `PersistHistorySyncBatchJob`. Workaround Hostinger shared hosting (sem supervisor). |
+| `queue:work database --queue=whatsapp --max-time=55 ...` | `everyMinute()` | Worker fila `whatsapp`: processa `ProcessIncomingWebhookJob`. Sem este cron, msgs entrantes não persistem (incident 2026-05-28). |
+| `whatsapp:cleanup-webhook-nonces` | `hourly()` | Cleanup nonces antigos >24h da tabela `webhook_nonces`. US-WA-082. |
+| `whatsapp:jobs-cleanup-stale` | `hourly()` | Cleanup jobs presos na fila `whatsapp-history` (>6h). Evita backpressure falso-positivo. US-WA-084. |
+| `whatsapp:daemon-source-drift-check` | `weeklyOn(1, '09:00')` (seg) BRT | Drift sentinel daemon CT 100: alerta se source do daemon prod ficou desatualizado vs main local. |
+| `whatsapp:auth-state-drift-check` | `dailyAt('03:00')` BRT | Detecta orphans, banned/inactive residuais e stale >90d em Baileys auth_state. |
+| `secrets:audit --auto-pr --notify` | `dailyAt('06:15')` BRT | Valida secrets de `memory/_INDEX-SECRETS.md`, atualiza status, alerta Centrifugo + Brief. ADR 0215 Camada 3. |
+| `secrets:scan` | `weeklyOn(1, '09:00')` BRT | Discovery semanal: procura secrets em git canon sem entry no índice. ADR 0215 Camada 1. |
+| `governance:audit --all --notify` | `dailyAt('06:35')` BRT | Governance Drift Framework (orchestrator): roda todos DriftCheckers (composer_audit, multi_tenant_scope, adr_link_rot, routes_zombie). ADR 0216. |
+| `RetryFailedMediaDownloadsJob` (Job) | `hourly()` | Retry mídia órfã (status=pending\|downloading, attempts<5, últimos 7d). Guardião 6 camadas Camada 4. |
+| `whatsapp:retry-recent-media-downloads --hours=24 --limit=200` | `hourlyAt(15)` | Retry mais permissivo de mídia recente (24h): pega estados anômalos que Camada 4 não pega. Wave 3 Agent B. |
+| `whatsapp:scan-media-drift` | `dailyAt('03:30')` BRT | Loga métricas de mídia pendente/falha (sem correção). Guardião Camada 5. |
+| `whatsapp:sla-scan --business=all` | `everyFiveMinutes()` | Scan SLA policies ativas cross-tenant; dispara actions (Centrifugo notify/reassign/set_status) para conversations que violam threshold. CYCLE-07 PR-2. |
+| `whatsapp:metrics-aggregate` | `dailyAt('02:30')` BRT | Snapshot diário de métricas omnichannel em `whatsapp_conversation_metricas`. Dashboard `/atendimento/metricas`. US-WA-021/041. |
+| `feedback:reindex` | `weeklyOn(0, '03:00')` (dom) BRT | Reindex semanal feedback: rescore + INDEX.md HOT + archive COLD. ADR 0195 Fase B. |
+| `nfebrasil:dist-dfe-puxar` | `dailyAt('06:15')` | Distribuição DFe via NSU SEFAZ ambiente nacional para businesses com cert ativo. US-NFE-051 / ADR 0116. |
+| `fsm:scan-drift transactions` | `dailyAt('03:00')` BRT | Detecta `current_stage_id` que bypassou `TransactionFsmObserver` via mass-update. ADR 0129 §Drift Detection. |
+| `InboxAutoCleanupJob` (Job) | `dailyAt('04:00')` BRT | Auto-cleanup notifications MCP inbox: marca read todas as notificações unread com `created_at > 7d`. |
+| `KbBridgeFromMcpJob` (via `schedule::call`) | `everyFifteenMinutes()` | Sincroniza `mcp_memory_documents` → `kb_nodes` (grafo KB) incrementalmente para biz=1 e biz=4. ADR 0149. |
+| `financeiro:backfill-plano-conta` (via `schedule::call`) | `weeklyOn(0, '04:00')` (dom) BRT | Backfill `plano_conta_id` NULL em títulos para businesses ativos. Idempotente. |
+| `rb:sync-bank-balances` | `hourly()` | Sincroniza saldo Asaas/Inter para `contas_bancarias.saldo_cached`. US-RB-045. |
+| `pos:dummyBusiness` | `cron('0 */3 * * *')` | Reset completo com dados dummy (env=demo APENAS). |
+
+---
+
+## Rotinas
+
+Tipo ADR 0234: `routine`. Automações orquestradas de mais alto nível que não são hooks nem crons simples.
+
+| Nome | Gatilho | O que faz | Arquivo(s) |
+|------|---------|-----------|------------|
+| **Fechar o Loop** _(primeira rotina tipo routine registrada — audit 2026-05-29)_ | SessionStart, após brief-fetch | Verifica idempotentemente os 4 gaps P0 da auditoria IA-OS (RAGAS CI, drift sentinel, observability, LGPD purge) e aponta o próximo pendente; NUNCA toca Brain B/autonomia. | `.claude/hooks/loop-fechar-check.ps1` + `.claude/loop-fechar-o-loop.json` _(criados e validados 2026-05-29; já registrados no `SessionStart` do `settings.json`)_ |
+
+---
+
+## Como manter
+
+- Ao **criar ou alterar hook** em `.claude/hooks/`: atualizar a seção correspondente neste doc (SessionStart / PreToolUse / PostToolUse / Stop / UserPromptSubmit) e registrar no `settings.json`.
+- Ao **criar ou alterar cron** em `app/Console/Kernel.php`: adicionar linha na tabela "Crons".
+- Ao **criar rotina** nova: adicionar linha na tabela "Rotinas" com gatilho e arquivos.
+- Futuramente: quando ADR 0234 (`automation-registry-mcp`) for implementada, rodar `AutomationRegistrySync` após cada mudança — este markdown passa a ser espelho humano da tabela `mcp_automations`.

--- a/memory/requisitos/TaskRegistry/AUDIT-TEAM-OS-2026-05-29.md
+++ b/memory/requisitos/TaskRegistry/AUDIT-TEAM-OS-2026-05-29.md
@@ -1,0 +1,221 @@
+---
+title: "Auditoria Team OS — TaskRegistry MCP vs Jira Team '26/Rovo + Claude Agent Teams"
+type: auditoria
+status: draft
+authority: tecnico
+lifecycle: ativo
+quarter: Q2-2026
+decided_at: 2026-05-29
+decided_by: [audit-team-os-expert]
+module: TaskRegistry
+tier: TECHNICAL_AUDIT
+trust_level: advise
+pergunta_origem: "isso (rotina/hook que criei) vai ficar na minha rede MCP?"
+related_adrs: [0053, 0055, 0070, 0076, 0093, 0094, 0105, 0106]
+parent_artifacts:
+  - memory/decisions/0070-jira-style-task-management-current-md-removed.md
+  - memory/requisitos/TaskRegistry/SPEC.md
+  - memory/governance/AUTOMATIONS.md
+authors: [audit-team-os-expert]
+score_os_solo: 82/100 (lente "Wagner + Claude solo" — MCP-first é feature pra agente IA)
+score_team_os: 70/100 (lente "5 humanos + clientes B2B" — esta é a lente que importa)
+nota_ponderada_12_funcoes: 7.0/10 (P0=4 · P1=2 · P2=1)
+correcao_v2: "2026-05-29 — UI Fase 7 JÁ existe em Modules/ProjectMgmt (Board/Backlog/MyWork/Roadmap/Burndown/Activity, 2822 linhas). Função 9 corrigida 2.5→7; Team OS 64→70. Faltam só Triage + Inbox + push."
+decisao_wagner_firme: "NÃO ligar 2º cérebro / Brain B / autonomia ADS agora (custo recorrente indesejado)"
+artefatos_alvo:
+  - memory/decisions/proposals/drafts/automation-registry-mcp.md
+  - memory/governance/AUTOMATIONS.md
+  - memory/requisitos/TaskRegistry/SPEC-UI-FASE7.md
+  - .claude/hooks/loop-fechar-check.ps1
+  - .claude/loop-fechar-o-loop.json
+---
+
+# AUDIT Team OS — 2026-05-29
+
+> ⚠️ **CORREÇÃO v2 (2026-05-29, pós-verificação paralela):** a v1 deste audit afirmou que a **UI Fase 7 "nunca foi construída" (função 9 = 2.5)**. **Errado.** A verificação durante a geração dos deliverables encontrou `Modules/ProjectMgmt` com **UI real e quality-gated**: `Board/Index.tsx` (527 linhas) + `Board/DetailSheet.tsx` (801) + `Backlog` (390) + `MyWork` (461) + `Activity` (254) + `Burndown` (243) + `Roadmap` (146) = **2.822 linhas**, todas com `.charter.md` + `.review.md`. **Kanban, Backlog, MyWork, Roadmap, Burndown e Activity JÁ EXISTEM.** Faltam apenas **Triage** e **Inbox** (dedicados) + **push de notificação**. Correção aplicada: função 9 = 2.5 → **7**; Team OS = 64 → **70**; Onda 2 reescopada de "construir Fase 7" para "completar 2 telas + polish". O erro v1 veio de um `find -iname "*board*"` que não casou `Board/Index.tsx` (nome do arquivo é `Index.tsx`). Lição: verificar com `ls` da árvore, não só por nome de arquivo.
+
+> **Pedido Wagner via parent agent:** auditar o "Team OS" do oimpresso — o sistema MCP de tasks + governança ([ADR 0070](../../decisions/0070-jira-style-task-management-current-md-removed.md) / [ADR 0053](../../decisions/0053-mcp-server-governanca-como-produto.md) / [ADR 0055](../../decisions/0055-self-host-equivalent-anthropic-team.md)) — comparando com Jira (Atlassian Team '26 + Rovo) e Claude Code Agent Teams (Opus 4.6, fev/2026).
+>
+> **Pergunta-origem (literal):** *"isso vai ficar na minha rede MCP?"* — sobre uma rotina/hook que o agente havia criado na sessão.
+>
+> **Resposta executiva curta:** O backend MCP é o **source-of-truth certo** (Jira-style, audit append-only, memory-linked) e está, em governança, **acima do Jira**. Mas faltam três coisas pra ser um *Team* OS de verdade: **(a) interface humana** (Jira é UI-first; o nosso é tool-only), **(b) agente-como-assignee que executa** e **(c) grafo de relações automático**. Duas lentes: **~82/100 como OS Wagner+Claude solo**, **~70/100 como Team OS** (5 humanos + clientes B2B, pós-correção v2). A distância 82→70 É o roadmap.
+
+---
+
+## 1. A pergunta-origem: "isso vai ficar na minha rede MCP?"
+
+**Resposta verificada: NÃO, do jeito que está.** O código revela **3 tiers de persistência** com indexação MCP distinta:
+
+| Tier | O que é | Indexado no MCP? | Indexador |
+|---|---|:---:|---|
+| **Canônico** | `memory/**` + alguns `.md` raiz | **SIM** | `IndexarMemoryGitParaDb` (varre `memory/decisions`, `sessions`, `requisitos/*/SPEC.md`, `adr`, audits, comparativos) |
+| **Skills** | `.claude/skills/*/SKILL.md` | **SIM** | `ImportarSkillsDoGitService` ([ADR 0076](../../decisions/0076-skills-no-git-importadas-mcp.md)) → `mcp_skills` |
+| **Local tooling** | `.claude/hooks/*.ps1`, `settings.json`, `.claude/*.json` | **NÃO** | nenhum — invisível ao MCP e ao time |
+
+A rotina/hook criada na sessão **caiu no tier "Local tooling"** → **não vira documento MCP**. Mesmo versionada via git, cada dev tem seu próprio `settings.json`; a Jana/MCP fica **cega** pra ela. Não existe entidade governada que registre "esta automação existe, roda em tal trigger, pertence a fulano, foi auditada".
+
+Isso expõe diretamente o **gap #11 — não existe Registry de Automações** (ver §3 e §4). A resposta executável à pergunta-origem é a **Onda 1.1** (§5): criar `mcp_automations` e cadastrar a rotina "Fechar o Loop" como a 1ª linha — **aí sim** ela passa a estar na rede MCP, auditável.
+
+---
+
+## 2. Como o estado-da-arte funciona — e como o nosso DEVERIA ser
+
+### 2.1 Jira Team '26 + Rovo (Atlassian)
+
+- **Hierarquia:** Initiative → Epic → Story/Task → Subtask + **Plans** (até 5 níveis acima do epic, via Advanced Roadmaps).
+- **Salto 2026 — Teamwork Graph:** mapa vivo com ~150 bilhões de conexões ligando *work ↔ docs ↔ goals ↔ decisões ↔ pessoas*. Não é hierarquia manual; é grafo **automático** alimentado pela telemetria dos próprios produtos Atlassian.
+- **Rovo Agents como ASSIGNEES:** agentes deixam de ser "chatbot lateral" e viram **assignee de work items**, com **audit log** e **execução multi-step autônoma** (modo Max). O agente *pega* a task e *executa*, não só sugere.
+
+### 2.2 Claude Code Agent Teams (Opus 4.6, fev/2026)
+
+- **Team lead** coordena N **teammates**, cada um em seu próprio contexto, que **conversam entre si diretamente**.
+- **Shared memory bank único** compartilhado pelo time de agentes.
+- **Custo:** ~3-4× tokens de uma sessão single-agent (cada teammate tem contexto próprio).
+
+### 2.3 Como o nosso DEVERIA ser pra igualar
+
+O **backend MCP já é o source-of-truth certo** — Jira-style, audit append-only, memory-linked. O gap não é o modelo de dados; é a *superfície*:
+
+1. **Interface humana** — Jira é **UI-first**; o nosso é **tool-only**. Bloqueia time não-técnico e board de cliente B2B.
+2. **Agente-como-assignee que executa** — hoje só *sugere* (`tasks-suggest-*` designed; ADS/Brain B dormente). Rovo Max *executa*.
+3. **Grafo de relações automático** — temos os dados crus (`mcp_git_links` + `mcp_task_memory_links` + `mcp_task_events`), mas a ligação é **manual**, não um Teamwork Graph que se monta sozinho.
+
+---
+
+## 3. NOTA — as 12 funções de um Team OS
+
+Avaliação ponderada por peso de cada função (P0=4, P1=2, P2=1). Estado atual cruzado com código real ([ADR 0070](../../decisions/0070-jira-style-task-management-current-md-removed.md) hierarquia + tools MCP).
+
+| # | Função | Peso | Estado atual | Como deveria ser | Nota |
+|---:|---|:---:|---|---|---:|
+| 1 | Modelagem do trabalho | P0 | Project→Epic→Cycle→Task→Subtask + Component | = Linear/Jira; falta **Initiative** (Tier 3) | **9** |
+| 2 | Workflow & estados | P1 | ENUM custom por projeto + transitions JSON (`mcp_workflows`) | editor **visual** de transições | **8** |
+| 3 | Identificadores & rastreio git | P1 | `COPI-123` + git bidir (fixes→done) | best-in-class, igual/melhor que Jira | **9** |
+| 4 | Views & queries | P2 | `mcp_views` saved filters | **designed mas sem UI** pra renderizar | **7** |
+| 5 | Notificações & inbox | P1 | `my-inbox` **pull-only** | falta **push** (Slack/email/WhatsApp) | **6** |
+| 6 | Integração com conhecimento | P0 | `mcp_task_memory_links` (task↔ADR/SPEC) + RAG | **diferencial**, mas manual vs Teamwork Graph automático | **8.5** |
+| 7 | Execução AI-native (agente assignee) | P0 | `tasks-suggest-*` designed; ADS/Brain B **DORMENTE** | Rovo Max executa multi-step; nós só sugerimos | **4.5** |
+| 8 | Coordenação & presença de time | P1 | request-response via tools; **sem presença** | Agent Teams lead+teammates; Jira presença live | **4** |
+| 9 | UI/acessibilidade (board, não-técnico, cliente) | P0 | **Board/Backlog/MyWork/Roadmap/Burndown/Activity JÁ existem** (`Modules/ProjectMgmt`, 2822 linhas, charters+reviews); faltam **Triage + Inbox** dedicados | Jira/Linear UI-first; completar 2 telas + validar acessibilidade não-técnico/B2B | **7** |
+| 10 | Governança & audit | P0 | `mcp_task_events` append-only + Spatie RBAC + ADS policy | best-in-class, **ACIMA de Jira** (audit irrevogável) | **9** |
+| 11 | Registry de automações (crons/hooks/rotinas) | P1 | **INEXISTENTE** — invisível ao MCP | entidade **governada + auditável** | **2** |
+| 12 | Multi-tenant / board B2B | P2 | `business_id` pronto, **não exercitado** | board de cliente; falta ativar | **7** |
+
+### 3.1 Cálculo da nota ponderada
+
+```
+P0 (funções 1, 6, 7, 9, 10): 9 + 8.5 + 4.5 + 7 + 9 = 38.0  ×4 = 152   (função 9 corrigida 2.5→7 na v2)
+P1 (funções 2, 3, 5, 8, 11): 8 + 9 + 6 + 4 + 2     = 29.0  ×2 =  58
+P2 (funções 4, 12):          7 + 7                 = 14.0  ×1 =  14
+                                            ────────────────────────
+                                            soma ponderada       = 224
+                                            soma dos pesos: 5×4 + 5×2 + 2×1 = 32
+                                            nota = 224 / 32 = 7.0 / 10
+```
+
+### 3.2 DUAS LENTES (ponto mais importante deste audit)
+
+> A nota muda **radicalmente** conforme quem é o "time". Deixar isso vago seria o erro de leitura mais caro.
+
+| Lente | Score | Por quê |
+|---|:---:|---|
+| **OS Wagner + Claude solo** | **~82/100** | MCP-first **é feature**, não bug — o "usuário" é um agente IA que lê/escreve tools nativamente. Audit, memory-links e git-sync já entregam um OS de altíssima qualidade pra um operador + copiloto. |
+| **Team OS** (5 humanos + clientes B2B) | **~70/100** | É a lente que importa pra "Team Jira / Team Claude". A UI **existe** (função 9 = 7, corrigida na v2) mas falta **Triage + Inbox**; faltam ainda **push** (função 5 = 6), **registry de automação** (função 11 = 2) e **agente-executor** (função 7 = 4.5) pro time não-técnico + cliente operarem com folga. |
+
+**A distância 82 → 70 É o roadmap.** Tudo em §4 e §5 existe pra fechar esses 12 pontos sem rasgar o que já é best-in-class (audit + memory-links + git). O maior dreno agora **não é mais UI** — é o **Registry de automações (2)**, **coordenação/presença (4)** e **execução AI-native (4.5)**.
+
+---
+
+## 4. As 10 funções faltantes (gap list)
+
+| # | Função faltante | Resolve | Dado já existe? |
+|---:|---|---|---|
+| 1 | **Registry de Automações** (`mcp_automations`) | **a pergunta-origem** — crons/hooks/rotinas viram entidade governada | parcial (rotinas existem em `.claude/`, mas fora do MCP) |
+| 2 | **Completar UI** (Triage + Inbox dedicados) — Board/Backlog/Roadmap/MyWork/Burndown/Activity **já existem** em `Modules/ProjectMgmt` | função 9 (já em 7) | backend 100% pronto; UI ~80% pronta |
+| 3 | **Push de notificações** (Slack/email/WhatsApp) | função 5 (`my-inbox` deixa de ser pull-only) | `mcp_inbox_notifications` já existe |
+| 4 | **Agente-como-assignee que executa** | função 7 (efeito Rovo Max) | `tasks-suggest-*` designed |
+| 5 | **Teamwork Graph leve** | função 6 — grafo automático task↔commit↔doc↔pessoa | **sim** — `git_links` + `memory_links` + `events` |
+| 6 | **Presença / colaboração real-time** | função 8 | **sim — Centrifugo já no stack!** ([ADR 0058](../../decisions/0058-reverb-substituido-por-centrifugo-frankenphp.md)) |
+| 7 | **Initiatives / Roadmap (Tier 3)** | função 1 — 5º nível acima do epic | adiado por design no ADR 0070 |
+| 8 | **SLA / time tracking** | função 12 — entra com 1º cliente B2B | adiado por design no ADR 0070 |
+| 9 | **Ingestão de sinais cross-tool** | WhatsApp/suporte → tasks automaticamente | — |
+| 10 | **Orquestração via Agent Teams** | função 7/8 — lead + teammates | — |
+
+---
+
+## 5. Plano em 3 ondas — COST-AWARE
+
+> **Decisão Wagner FIRME:** **NÃO ligar o 2º cérebro / Brain B / autonomia ADS agora** — custo recorrente indesejado. O plano abaixo respeita isso à risca: tudo que custa token recorrente fica **adiado conscientemente**, e o salto de nota vem de governança + UI + AI-native *barato*.
+
+### Onda 1 — custo ~zero, governança
+
+| # | Item | Esforço | Efeito |
+|---:|---|:---:|---|
+| 1.1 | **Registry de Automações** — `mcp_automations` + tool `automations-list`. A rotina **"Fechar o Loop"** vira a **1ª linha** → **aí SIM entra na rede MCP**, auditável. | ~4h | resolve a pergunta-origem; função 11: 2→8 |
+| 1.2 | **Push do `my-inbox`** → WhatsApp/email | ~3h | função 5: 6→8 |
+
+> **Sacada central:** a Onda 1.1 é a **resposta executável** à pergunta-origem. Hoje a rotina **NÃO está na rede MCP**; com o registry, **passa a estar** — sem ligar nenhum cérebro.
+
+### Onda 2 — completar a UI (não construir do zero)
+
+| # | Item | Esforço | Efeito |
+|---:|---|:---:|---|
+| 2.1 | **Completar UI** — telas **Triage** + **Inbox** dedicadas + polish de acessibilidade/não-técnico no Board/Backlog existentes (Inertia, **AppShellV2 + PT-01**) | ~5-7h | função 9: 7→9 |
+
+**Correção v2:** a Fase 7 do [ADR 0070](../../decisions/0070-jira-style-task-management-current-md-removed.md) **já foi ~80% construída** em `Modules/ProjectMgmt` (Board/Backlog/MyWork/Roadmap/Burndown/Activity, 2822 linhas, charters+reviews). A Onda 2 deixa de ser "construir o board" e vira "completar Triage + Inbox + validar usabilidade não-técnica". SPEC-alvo: [`SPEC-UI-FASE7.md`](SPEC-UI-FASE7.md).
+
+### Onda 3 — AI-native barato (efeito Rovo SEM Brain B)
+
+| # | Item | Esforço | Efeito |
+|---:|---|:---:|---|
+| 3.1 | **Jana-as-assignee READ-ONLY** — summarize / draft / link-memory / suggest-priority, usando **Brain A `gpt-4o-mini` barato** | ~6h | função 7: 4.5→7 sem custo recorrente alto |
+| 3.2 | **Teamwork Graph leve** — **view materializada, zero LLM** | ~4h | função 6: 8.5→9 |
+
+### Adiar conscientemente (decisão Wagner)
+
+- **Execução autônoma com escrita** (Brain B / Rovo Max real) — custo recorrente.
+- **Agent Teams orchestration** — ~3-4× tokens.
+- **Initiatives / SLA** — até existir cliente B2B (sinal qualificado — [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)).
+
+### Sequência visual
+
+```
+ONDA 1 (custo ~zero — governança)        ONDA 2 (completar UI)            ONDA 3 (AI-native barato)
+  ├─ 1.1 mcp_automations (~4h) ★          └─ 2.1 Triage+Inbox+polish (~5-7h) ├─ 3.1 Jana read-only (~6h)
+  │      [resolve a pergunta-origem]             [função 9: 7→9]            └─ 3.2 Graph view materializada (~4h)
+  └─ 1.2 push my-inbox (~3h)              [Board/Backlog/Roadmap já existem]
+                                          ADIAR: Brain B/Rovo Max real · Agent Teams (3-4×) · Initiatives/SLA
+```
+
+---
+
+## 6. Artefatos relacionados (cross-links)
+
+| Artefato | Caminho | Papel |
+|---|---|---|
+| **ADR proposta** (nº 0234, status *proposto*) | [`memory/decisions/proposals/drafts/automation-registry-mcp.md`](../../decisions/proposals/drafts/automation-registry-mcp.md) | Automation Registry / `mcp_automations` — a decisão que destrava a Onda 1.1 |
+| **Inventário canônico** (já indexado MCP) | [`memory/governance/AUTOMATIONS.md`](../../governance/AUTOMATIONS.md) | inventário vivo de automações do oimpresso |
+| **SPEC UI** (Onda 2) | [`memory/requisitos/TaskRegistry/SPEC-UI-FASE7.md`](SPEC-UI-FASE7.md) | Kanban + Backlog + Triage + Inbox |
+| **Rotina seed** | [`.claude/hooks/loop-fechar-check.ps1`](../../../.claude/hooks/loop-fechar-check.ps1) + [`.claude/loop-fechar-o-loop.json`](../../../.claude/loop-fechar-o-loop.json) | a "Fechar o Loop" — vira a 1ª linha de `mcp_automations` |
+
+---
+
+## 7. Fontes
+
+**Jira / Atlassian / Rovo:**
+
+- [Jira hierarchy — Epics, Stories, Themes (Atlassian)](https://www.atlassian.com/agile/project-management/epics-stories-themes)
+- [Jira Plans / Initiatives — configuring hierarchy levels (Atlassian Confluence)](https://confluence.atlassian.com/advancedroadmapsserver0329/configuring-initiatives-and-other-hierarchy-levels-1021218664.html)
+- [Rovo agents (Atlassian)](https://www.atlassian.com/software/rovo)
+- [Rovo at Team '26 (Atlassian Blog)](https://www.atlassian.com/blog/company-news/rovo-team-26)
+- [Atlassian opens Teamwork Graph, pushes Rovo agentic execution at Team '26 (SiliconANGLE)](https://siliconangle.com/2026/05/06/atlassian-opens-teamwork-graph-pushes-rovo-agentic-execution-team-26/)
+
+**Claude Code Agent Teams:**
+
+- [Claude Agent Teams (docs)](https://code.claude.com/docs/en/agent-teams)
+- [Claude Code Agent Teams & Subagents playbook 2026 (Developers Digest)](https://www.developersdigest.tech/blog/claude-code-agent-teams-subagents-2026)
+- [Claude Code subagents shared memory (Hindsight / Vectorize)](https://hindsight.vectorize.io/blog/2026/05/06/claude-code-subagents-shared-memory)
+
+---
+
+**Última atualização:** 2026-05-29 (**v2** — correção UI Fase 7) — audit-team-os-expert · TaskRegistry MCP vs Jira Team '26/Rovo + Claude Agent Teams · veredito: ~82/100 solo, ~70/100 Team OS (nota ponderada 7.0/10) · decisão Wagner: NÃO ligar Brain B agora · Onda 1.1 (`mcp_automations`) resolve a pergunta-origem · UI Fase 7 já existe em Modules/ProjectMgmt (faltam Triage+Inbox).

--- a/memory/requisitos/TaskRegistry/SPEC-UI-FASE7.md
+++ b/memory/requisitos/TaskRegistry/SPEC-UI-FASE7.md
@@ -1,0 +1,99 @@
+---
+module: TaskRegistry
+title: "SPEC — Completar UI do Team OS (Triage + Inbox + polish) sobre Modules/ProjectMgmt"
+type: spec
+status: draft
+lifecycle: ativo
+quarter: Q2-2026
+related_adrs: [0070, 0064, "UI-0013"]
+depende_de: AUDIT-TEAM-OS-2026-05-29 (Onda 2)
+project_key: TR
+owner_module: Modules/ProjectMgmt
+decided_at: 2026-05-29
+---
+
+# SPEC — Completar UI do Team OS (Onda 2)
+
+> **Correção v2 importante (2026-05-29):** este SPEC **NÃO é "construir a Fase 7 do zero"**. A verificação encontrou que `Modules/ProjectMgmt` **já tem** Board (Kanban), Backlog, MyWork, Roadmap, Burndown e Activity — **2.822 linhas de Inertia/React com `.charter.md` + `.review.md`** (passaram pelo MWART). O backend ([ADR 0070](../../decisions/0070-jira-style-task-management-current-md-removed.md) Fases 1-6) está 100% pronto. **Falta apenas: Triage dedicado + Inbox dedicado + um polish de usabilidade não-técnica.** Escopo real ≈ **5-7h IA-pair**, não 12-16h.
+
+## §1. Objetivo & escopo
+
+Fechar a função de menor folga do Team OS pro time **não-técnico** (Felipe/Maiara/Eliana/Luiz) e futuros **clientes B2B**: dar telas dedicadas pra **triar** (atribuir dono/prioridade a tasks órfãs) e pra **caixa de entrada** (notificações de menção/atribuição/review). Hoje essas duas funções só existem via tools MCP (`triage`, `my-inbox`) — sem superfície humana.
+
+**Entra:**
+1. **Triage** — tela dedicada listando tasks sem owner OU sem prioridade OU `status=backlog`, com atribuição inline de owner + prioridade (+ cycle/epic opcional).
+2. **Inbox** — tela dedicada lendo `mcp_inbox_notifications` (mention / assigned / review_requested / status_changed / commented), com marcar-lido e deep-link pra task.
+3. **Polish não-técnico** — passada de acessibilidade/clareza no Board + Backlog existentes (labels PT-BR, empty states, atalho de teclado, mobile-friendly) pra um operador não-técnico conseguir usar sem treino.
+
+**Fica fora (defer explícito, alinhado ADR 0070 Tier 3):** Roadmap Gantt avançado, Initiatives, bulk-ops na UI, editor visual de saved views, board B2B multi-tenant (entra com 1º cliente — sinal qualificado [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)).
+
+## §2. Backend reusado (NÃO recriar)
+
+A UI é casca Inertia sobre o que já existe (ADR 0070 Fases 1-6):
+
+| Recurso | Tipo | Uso na UI |
+|---|---|---|
+| `mcp_tasks` (+ `parent_task_id`, `owner`, `priority`, `status`, `custom_fields`) | tabela | cards de Triage |
+| `mcp_inbox_notifications` (type, task_id, actor_id, body, read_at) | tabela | itens do Inbox |
+| `mcp_views` (filtro `owner IS NULL OR priority IS NULL OR status='backlog'`) | view sistema | fonte do Triage |
+| tool `triage` | MCP | já retorna as órfãs (paridade UI ↔ tool) |
+| tool `my-inbox` | MCP | já retorna unread |
+| tool `tasks-update` | MCP | persistir owner/prio/status no Triage |
+| `MyWorkController` / `BoardController` (existentes) | controller | padrão Inertia a espelhar |
+
+**Princípio:** a tela e a tool devem dar a **mesma** resposta (a UI não inventa query nova; consome o mesmo filtro do `triage`/`my-inbox`).
+
+## §3. User Stories (project key `TR` — TaskRegistry)
+
+| ID | História | Critério de aceite |
+|---|---|---|
+| **US-TR-301** | Como membro do time, vejo uma tela **Triage** com todas as tasks órfãs (sem owner OU sem prio OU backlog) | lista = mesmo conjunto que a tool `triage`; vazio → empty state "Nada pra triar 🎉" |
+| **US-TR-302** | Na Triage, atribuo **owner + prioridade inline** sem abrir a task | select inline → `tasks-update` → UI otimista + rollback em erro; gera `mcp_task_events` |
+| **US-TR-303** | Na Triage, movo a task pra um **cycle/epic** opcionalmente | dropdown cycle/epic; persiste; some da lista se deixar de ser órfã |
+| **US-TR-304** | Como membro, vejo uma tela **Inbox** com minhas notificações não-lidas | lê `mcp_inbox_notifications WHERE user_id=me AND read_at IS NULL`; agrupado por tipo |
+| **US-TR-305** | No Inbox, **marco como lido** (individual e "marcar todas") | `read_at` setado; contador do badge no topnav decrementa em tempo real (Centrifugo, [ADR 0058](../../decisions/0058-reverb-substituido-por-centrifugo-frankenphp.md)) |
+| **US-TR-306** | No Inbox, clico numa notificação e vou direto pra **task/DetailSheet** | deep-link abre `Board` com `DetailSheet` da task aberto |
+| **US-TR-307** | Como operador **não-técnico**, uso Board/Backlog/Triage sem treino | labels PT-BR claros, empty states, foco-teclado, toque-friendly ≥360px; revisado por `design:accessibility-review` |
+| **US-TR-308** | Vejo no card os **ADRs/SPECs relacionados** (diferencial memory-linked) | `mcp_task_memory_links` renderizado como chips no card/DetailSheet (reusa o que o DetailSheet já faz, se já fizer) |
+
+## §4. Arquitetura Inertia
+
+Tudo dentro de **`Modules/ProjectMgmt`** (dono canônico do board — [ADR 0064](../../decisions/0064-modularizacao-split-teammcp-kb-superadmin.md)), espelhando o padrão dos controllers/pages existentes (`BoardController`, `MyWorkController`).
+
+| Camada | Novo | Padrão a seguir |
+|---|---|---|
+| Controller | `TriageController` + `InboxController` | igual `MyWorkController` (Inertia::render + `Inertia::defer` na lista) |
+| Pages | `resources/js/Pages/ProjectMgmt/Triage/Index.tsx` + `Inbox/Index.tsx` (+ `.charter.md` + `.review.md`) | igual `Board/Index.tsx`, `MyWork/Index.tsx` |
+| Shell | `AppShellV2` + `PageHeader` canon (modo NAV com SubNav) | [ADR UI-0013](../_DesignSystem/adr/ui/0013-constituicao-ui-v2-camadas.md) + [PT-01](../_DesignSystem/padroes-tela/PT-01-Lista.md) |
+| Rotas | `/projects/triage`, `/projects/inbox` (ou prefixo já usado pelo módulo) | `Modules/ProjectMgmt/Routes/web.php`, FQCN ([.claude/rules/routes.md](../../../.claude/rules/routes.md)) |
+| Realtime | canal Centrifugo `inbox.{user_id}` pro badge | [ADR 0058](../../decisions/0058-reverb-substituido-por-centrifugo-frankenphp.md) |
+
+**Tokens/CSS:** somente tokens canônicos da Constituição UI v2 (cor/tipo/espaço); zero hex hardcoded. Rodar [PRE-MERGE-UI](../_DesignSystem/PRE-MERGE-UI.md) antes do PR.
+
+## §5. Multi-tenant
+
+- **Hoje:** `mcp_tasks` / `mcp_inbox_notifications` são governança **global** (a maioria das `mcp_*` não tem `business_id` efetivo — convenção ADR 0070 + [ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md)). Triage/Inbox escopam por `user_id` (a notificação/owner é por pessoa), não por business.
+- **Futuro board B2B:** quando 1º cliente assinar, o board do cliente escopa por `business_id` (global scope). Documentar então; **não** antecipar agora (sinal qualificado [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)).
+
+## §6. QA / Pest
+
+- Smoke render Triage (200 + lista = tool `triage`) e Inbox (200 + unread = tool `my-inbox`).
+- `tasks-update` via Triage persiste owner/prio + gera `mcp_task_events` (audit).
+- "Marcar lido" seta `read_at` e some do unread.
+- Deep-link Inbox→task abre DetailSheet correto.
+- Acessibilidade: `design:accessibility-review` no Triage/Inbox.
+- Cross-tenant: deixar teste preparado (skip) pra quando board B2B existir (biz=1 vs biz=99, [ADR 0101](../../decisions/0101-tests-biz-1-nunca-cliente.md)).
+
+## §7. Estimativa
+
+[ADR 0106](../../decisions/0106-recalibracao-velocidade-fator-10x-ia-pair.md) (fator 10× IA-pair): **~5-7h IA-pair** (2 telas + polish), vs ~12-16h se fosse do zero. O grosso da Fase 7 já está entregue.
+
+## §8. Cross-links
+
+- Auditoria origem: [`AUDIT-TEAM-OS-2026-05-29.md`](AUDIT-TEAM-OS-2026-05-29.md) — Onda 2 (função 9: 7→9).
+- [ADR 0070](../../decisions/0070-jira-style-task-management-current-md-removed.md) — Fase 7 (UI) + hierarquia + tools.
+- UI existente a reusar: `resources/js/Pages/ProjectMgmt/{Board,Backlog,MyWork,Roadmap,Burndown,Activity}/Index.tsx`.
+
+---
+
+**Última atualização:** 2026-05-29 — SPEC Onda 2 (completar UI). Escopo enxuto pós-descoberta de que ProjectMgmt já tem Board/Backlog/Roadmap/MyWork/Burndown/Activity. Não depende de Brain B.


### PR DESCRIPTION
Auditoria do **Team OS** (sistema MCP de tasks + governanca) vs **Jira Team '26/Rovo** + **Claude Code Agent Teams**.

## Conteudo
- `AUDIT-TEAM-OS-2026-05-29.md` — nota **70/100** (Team lens, v2 pos-correcao UI; 82 solo), 12 funcoes, 10 gaps, plano 3 ondas cost-aware **sem ligar Brain B**.
- `automation-registry-mcp.md` — **ADR 0234 (proposta, status: proposto)** — `mcp_automations` + tool `automations-list`. Responde a pergunta "isso fica na rede MCP?".
- `AUTOMATIONS.md` — inventario canonico (28 hooks + 54 crons + rotina). Vive em `memory/` -> indexado pelo MCP.
- `SPEC-UI-FASE7.md` — Onda 2 (completar Triage+Inbox sobre ProjectMgmt existente).
- Rotina **"Fechar o Loop"** (hook + manifesto + registro SessionStart) — 1a automacao seed.

## Notas
- ADR 0234 e **proposta** — requer tua aceitacao.
- Correcao v2: a UI Fase 7 **ja existe** em ProjectMgmt (descoberto na verificacao); nota subiu 64->70.

Pareado com PRs feat/mcp-automations-registry (Onda 1.1) e feat/projectmgmt-triage-inbox (Onda 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)