### PR TITLE
refactor(governance): drift de settings Meilisearch vira DriftChecker (ADR 0216), não bespoke

### DIFF
--- a/Modules/Governance/Config/config.php
+++ b/Modules/Governance/Config/config.php
@@ -77,6 +77,7 @@ return [
         \Modules\Governance\Services\Checkers\AdrLinksChecker::class,            // ADR 0219
         \Modules\Governance\Services\Checkers\ChartersFreshnessChecker::class,   // ADR 0220 — adapter charter:audit
         \Modules\Governance\Services\Checkers\RoutesZombieChecker::class,        // ADR 0221
+        \Modules\Governance\Services\Checkers\MeilisearchSettingsDriftChecker::class, // 2026-05-29 — embedder do índice se perdeu 2× (recall degrada)
     ],
 
     /*

--- a/Modules/Governance/Services/Checkers/MeilisearchSettingsDriftChecker.php
+++ b/Modules/Governance/Services/Checkers/MeilisearchSettingsDriftChecker.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Governance\Services\Checkers;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Modules\Governance\Contracts\DriftChecker;
+use Modules\Governance\Services\DriftCheckResult;
+use Modules\Governance\Services\DriftFinding;
+
+/**
+ * MeilisearchSettingsDriftChecker — settings vivos do índice != config desejada.
+ *
+ * ADR 0216 (framework DriftChecker plugável). Plugado em `governance.drift_checkers` →
+ * roda no `governance:audit --all` (já agendado). NÃO é comando bespoke nem cron próprio.
+ *
+ * Motivo (bug recorrente 2026-05-29): o embedder do Meilisearch foi setado MANUAL via curl
+ * (Sprint 9b) e SE PERDEU 2× — `jana_memoria_facts` voltou a embedders `{}` → recall
+ * semântico do chat degradou em SILÊNCIO até alguém descobrir na mão. Sem detecção, drift
+ * de settings de índice era invisível. Este checker fecha esse buraco.
+ *
+ * Desired = `config copiloto.meilisearch_indexes` (config-as-code). Observed = GET vivo.
+ * Cura = `php artisan jana:meilisearch-setup` (runtime PATCH — fica no domínio Jana).
+ *
+ * Severity high (recall degrada) · enforcement warn (Brief Jana, não bloqueia merge) ·
+ * cadence daily.
+ */
+final class MeilisearchSettingsDriftChecker implements DriftChecker
+{
+    public function name(): string
+    {
+        return 'meilisearch_settings_drift';
+    }
+
+    public function description(): string
+    {
+        return 'Embedder/filterable do índice Meilisearch != config (recall degrada em silêncio)';
+    }
+
+    public function tags(): array
+    {
+        return ['tier_1', 'retrieval', 'memory_canon'];
+    }
+
+    public function severity(): string
+    {
+        return 'high';
+    }
+
+    public function enforcement(): string
+    {
+        return 'warn';
+    }
+
+    public function cadence(): string
+    {
+        return 'daily';
+    }
+
+    public function check(array $opts = []): DriftCheckResult
+    {
+        $start = microtime(true);
+
+        /** @var array<string, array<string, mixed>> $indexes */
+        $indexes = (array) config('copiloto.meilisearch_indexes', []);
+        if ($indexes === []) {
+            return DriftCheckResult::clean($this->name(), 0, ['skipped' => 'config copiloto.meilisearch_indexes vazia']);
+        }
+
+        $host = rtrim((string) config('scout.meilisearch.host', 'http://localhost:7700'), '/');
+        $key  = (string) config('scout.meilisearch.key', '');
+
+        $findings = [];
+
+        foreach ($indexes as $uid => $cfg) {
+            try {
+                $resp = Http::withToken($key)->timeout(30)->get("{$host}/indexes/{$uid}/settings");
+            } catch (\Throwable $e) {
+                Log::channel('copiloto-ai')->warning(
+                    "MeilisearchSettingsDriftChecker: falha ao ler settings de '{$uid}' (registrado como finding): ".$e->getMessage()
+                );
+                $findings[] = new DriftFinding(
+                    target: $uid,
+                    target_type: 'meilisearch_index',
+                    severity: 'medium',
+                    message: "Não consegui ler settings do índice '{$uid}': {$e->getMessage()}",
+                    evidence: ['index' => $uid, 'error' => $e->getMessage()],
+                );
+
+                continue;
+            }
+
+            if ($resp->failed()) {
+                $findings[] = new DriftFinding(
+                    target: $uid,
+                    target_type: 'meilisearch_index',
+                    severity: 'medium',
+                    message: "GET settings do índice '{$uid}' falhou (HTTP {$resp->status()})",
+                    evidence: ['index' => $uid, 'http_status' => $resp->status()],
+                );
+
+                continue;
+            }
+
+            foreach ($this->driftsDoIndice($uid, $cfg, (array) $resp->json()) as $finding) {
+                $findings[] = $finding;
+            }
+        }
+
+        $duration = (int) round((microtime(true) - $start) * 1000);
+
+        if ($findings === []) {
+            return DriftCheckResult::clean($this->name(), $duration, ['indexes' => array_keys($indexes)]);
+        }
+
+        return DriftCheckResult::drifted($this->name(), $findings, $duration, [
+            'cura' => 'php artisan jana:meilisearch-setup',
+        ]);
+    }
+
+    /**
+     * Compara a config desejada de UM índice com os settings vivos. Pura/testável.
+     * Drift = embedder esperado ausente (o bug recorrente), source/model/dimensions
+     * divergente, ou filterableAttributes diferente (como conjunto).
+     *
+     * @param  array<string, mixed> $cfg   config desejada (embedders + filterableAttributes)
+     * @param  array<string, mixed> $vivo  settings vivos do Meilisearch
+     * @return DriftFinding[]
+     */
+    public function driftsDoIndice(string $uid, array $cfg, array $vivo): array
+    {
+        $findings = [];
+
+        /** @var array<string, array<string, mixed>> $expEmb */
+        $expEmb = (array) ($cfg['embedders'] ?? []);
+        /** @var array<string, array<string, mixed>> $vivoEmb */
+        $vivoEmb = (array) ($vivo['embedders'] ?? []);
+
+        foreach ($expEmb as $nome => $espec) {
+            if (! isset($vivoEmb[$nome])) {
+                Log::warning("MeilisearchSettingsDriftChecker: embedder '{$nome}' ausente no índice '{$uid}' — recall degrada (ADR 0212 rastreabilidade).", ['index' => $uid, 'embedder' => $nome]);
+                $findings[] = new DriftFinding(
+                    target: $uid,
+                    target_type: 'meilisearch_index',
+                    severity: 'high',
+                    message: "Índice '{$uid}': embedder '{$nome}' AUSENTE (esperado na config). "
+                        .'Recall semântico degrada. Cura: php artisan jana:meilisearch-setup',
+                    evidence: ['index' => $uid, 'embedder' => $nome, 'tipo' => 'embedder_ausente'],
+                );
+
+                continue;
+            }
+            foreach (['source', 'model', 'dimensions'] as $campo) {
+                if (! array_key_exists($campo, (array) $espec)) {
+                    continue;
+                }
+                $vivoVal = $vivoEmb[$nome][$campo] ?? null;
+                if ($vivoVal != $espec[$campo]) {
+                    $findings[] = new DriftFinding(
+                        target: $uid,
+                        target_type: 'meilisearch_index',
+                        severity: 'high',
+                        message: "Índice '{$uid}': embedder '{$nome}'.{$campo} divergente "
+                            .'(config='.json_encode($espec[$campo]).' vivo='.json_encode($vivoVal).')',
+                        evidence: ['index' => $uid, 'embedder' => $nome, 'campo' => $campo],
+                    );
+                }
+            }
+        }
+
+        $expFilt  = (array) ($cfg['filterableAttributes'] ?? []);
+        $vivoFilt = (array) ($vivo['filterableAttributes'] ?? []);
+        sort($expFilt);
+        sort($vivoFilt);
+        if ($expFilt !== $vivoFilt) {
+            $findings[] = new DriftFinding(
+                target: $uid,
+                target_type: 'meilisearch_index',
+                severity: 'medium',
+                message: "Índice '{$uid}': filterableAttributes divergente "
+                    .'(config=['.implode(',', $expFilt).'] vivo=['.implode(',', $vivoFilt).'])',
+                evidence: ['index' => $uid, 'tipo' => 'filterable_diff'],
+            );
+        }
+
+        return $findings;
+    }
+}

--- a/Modules/Governance/Tests/Feature/MeilisearchSettingsDriftCheckerTest.php
+++ b/Modules/Governance/Tests/Feature/MeilisearchSettingsDriftCheckerTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Governance\Contracts\DriftChecker;
+use Modules\Governance\Services\Checkers\MeilisearchSettingsDriftChecker;
+use Modules\Governance\Services\DriftFinding;
+
+uses(Tests\TestCase::class);
+
+/**
+ * MeilisearchSettingsDriftChecker (ADR 0216) — detecta drift de embedder/filterable
+ * do índice. Nasce porque o embedder do Meilisearch se perdeu 2× (recall degrada em
+ * silêncio). Plugado no framework DriftChecker em vez de comando bespoke (não reinventar).
+ *
+ * `driftsDoIndice` é pura → testável sem bater no Meilisearch live.
+ */
+
+$cfg = [
+    'embedders' => ['qwen3_local' => ['source' => 'ollama', 'model' => 'qwen3-embedding:0.6b', 'dimensions' => 1024]],
+    'filterableAttributes' => ['status', 'type'],
+];
+
+it('implementa o contrato DriftChecker (plugável no framework, não bespoke)', function () {
+    expect(new MeilisearchSettingsDriftChecker())->toBeInstanceOf(DriftChecker::class)
+        ->and((new MeilisearchSettingsDriftChecker())->name())->toBe('meilisearch_settings_drift')
+        ->and((new MeilisearchSettingsDriftChecker())->severity())->toBe('high');
+});
+
+it('está registrado em governance.drift_checkers (roda no governance:audit)', function () {
+    expect((array) config('governance.drift_checkers'))
+        ->toContain(MeilisearchSettingsDriftChecker::class);
+});
+
+it('settings vivos == config → sem finding', function () use ($cfg) {
+    $vivo = ['embedders' => $cfg['embedders'], 'filterableAttributes' => ['type', 'status']];
+    expect((new MeilisearchSettingsDriftChecker())->driftsDoIndice('x', $cfg, $vivo))->toBeEmpty();
+});
+
+it('embedder VAZIO (o bug recorrente) → finding high', function () use ($cfg) {
+    $f = (new MeilisearchSettingsDriftChecker())->driftsDoIndice('jana_memoria_facts', $cfg, ['embedders' => [], 'filterableAttributes' => ['status', 'type']]);
+    expect($f)->toHaveCount(1)
+        ->and($f[0])->toBeInstanceOf(DriftFinding::class)
+        ->and($f[0]->severity)->toBe('high')
+        ->and($f[0]->message)->toContain("embedder 'qwen3_local' AUSENTE");
+});
+
+it('model divergente (ex openai/nomic) → finding', function () use ($cfg) {
+    $vivo = ['embedders' => ['qwen3_local' => ['source' => 'ollama', 'model' => 'nomic-embed-text', 'dimensions' => 1024]], 'filterableAttributes' => ['status', 'type']];
+    $f = (new MeilisearchSettingsDriftChecker())->driftsDoIndice('x', $cfg, $vivo);
+    expect($f)->toHaveCount(1)->and($f[0]->message)->toContain('.model divergente');
+});
+
+it('filterableAttributes diferente → finding', function () use ($cfg) {
+    $f = (new MeilisearchSettingsDriftChecker())->driftsDoIndice('x', $cfg, ['embedders' => $cfg['embedders'], 'filterableAttributes' => ['status']]);
+    expect($f)->toHaveCount(1)->and($f[0]->message)->toContain('filterableAttributes divergente');
+});

--- a/Modules/Jana/Console/Commands/MeilisearchIndexSetupCommand.php
+++ b/Modules/Jana/Console/Commands/MeilisearchIndexSetupCommand.php
@@ -27,10 +27,15 @@ use Illuminate\Support\Facades\Http;
  */
 class MeilisearchIndexSetupCommand extends Command
 {
-    protected $signature = 'jana:meilisearch-setup {--index=all : uid do índice ou "all"} {--dry-run : mostra sem aplicar} {--check : SÓ compara settings vivos × config, exit 1 se drift (SettingsReconciler)}';
+    protected $signature = 'jana:meilisearch-setup {--index=all : uid do índice ou "all"} {--dry-run : mostra sem aplicar}';
 
-    protected $description = 'Codifica/aplica/reconcilia embedders + filterableAttributes dos índices Meilisearch da Jana (idempotente)';
+    protected $description = 'Aplica (cura) embedders + filterableAttributes dos índices Meilisearch da Jana (idempotente)';
 
+    /**
+     * NOTA: a DETECÇÃO de drift NÃO mora aqui — é o MeilisearchSettingsDriftChecker
+     * (Modules/Governance, ADR 0216) plugado em `governance:audit --all`. Este comando
+     * é só a CURA (apply/PATCH runtime). Detect = framework; heal = domínio Jana.
+     */
     public function handle(): int
     {
         $host = rtrim((string) config('scout.meilisearch.host', 'http://localhost:7700'), '/');
@@ -45,12 +50,6 @@ class MeilisearchIndexSetupCommand extends Command
             $this->error('config copiloto.meilisearch_indexes vazia.');
 
             return self::FAILURE;
-        }
-
-        // SettingsReconciler (gap "embedder perdido 2×"): compara settings VIVOS × config
-        // desejada e FALHA se driftou. CI-friendly (gate de PR) + cron (alerta). NÃO cura.
-        if ($this->option('check')) {
-            return $this->reconcileCheck($host, $key, $alvo, $indexes);
         }
 
         $this->info("Meilisearch index setup → {$host}".($dry ? ' [DRY-RUN]' : ''));
@@ -113,114 +112,5 @@ class MeilisearchIndexSetupCommand extends Command
         }
 
         return $payload;
-    }
-
-    /**
-     * SettingsReconciler — GET settings vivos de cada índice, compara com a config
-     * desejada, reporta drift. exit 1 se qualquer drift (gate). Alerta idempotente.
-     *
-     * @param  array<string, array<string, mixed>> $indexes
-     */
-    protected function reconcileCheck(string $host, string $key, string $alvo, array $indexes): int
-    {
-        $this->info("SettingsReconciler --check → {$host}");
-        $totalDrift = [];
-
-        foreach ($indexes as $uid => $cfg) {
-            if ($alvo !== 'all' && $alvo !== $uid) {
-                continue;
-            }
-
-            $resp = Http::withToken($key)->timeout(30)->get("{$host}/indexes/{$uid}/settings");
-            if ($resp->failed()) {
-                $this->error("  {$uid}: GET settings falhou ({$resp->status()})");
-
-                return self::FAILURE;
-            }
-
-            $drift = $this->detectarDrift($uid, $cfg, (array) $resp->json());
-            if ($drift === []) {
-                $this->line("  ✓ {$uid}: em dia");
-            } else {
-                foreach ($drift as $d) {
-                    $this->error("  ✗ {$d}");
-                }
-                $totalDrift = array_merge($totalDrift, $drift);
-            }
-        }
-
-        if ($totalDrift !== []) {
-            // Alerta idempotente por dia (mesmo padrão do freshness-check).
-            try {
-                \Illuminate\Support\Facades\DB::table('mcp_alertas_eventos')->updateOrInsert(
-                    ['chave_idempotencia' => 'index_settings_drift:'.now()->toDateString()],
-                    [
-                        'tipo'       => 'index_settings_drift',
-                        'severidade' => 'high',
-                        'business_id' => null,
-                        'metadata'   => json_encode(['drift' => $totalDrift]),
-                        'updated_at' => now(),
-                        'created_at' => now(),
-                    ],
-                );
-            } catch (\Throwable $e) {
-                $this->warn('  (alerta não persistido: '.$e->getMessage().')');
-            }
-
-            $this->newLine();
-            $this->error('DRIFT detectado — rode `php artisan jana:meilisearch-setup` pra curar.');
-
-            return self::FAILURE;
-        }
-
-        $this->info('Settings de todos os índices == config. Nenhum drift.');
-
-        return self::SUCCESS;
-    }
-
-    /**
-     * Compara a config desejada de UM índice com os settings vivos. Pura/testável.
-     * Drift = embedder esperado ausente, source/model/dimensions divergente, ou
-     * filterableAttributes diferente (como conjunto).
-     *
-     * @param  array<string, mixed> $cfg   config desejada (embedders + filterableAttributes)
-     * @param  array<string, mixed> $vivo  settings vivos do Meilisearch
-     * @return string[] lista de drifts (vazia = em dia)
-     */
-    public function detectarDrift(string $uid, array $cfg, array $vivo): array
-    {
-        $drift = [];
-
-        /** @var array<string, array<string, mixed>> $expEmb */
-        $expEmb = (array) ($cfg['embedders'] ?? []);
-        /** @var array<string, array<string, mixed>> $vivoEmb */
-        $vivoEmb = (array) ($vivo['embedders'] ?? []);
-
-        foreach ($expEmb as $nome => $espec) {
-            if (! isset($vivoEmb[$nome])) {
-                $drift[] = "{$uid}: embedder '{$nome}' AUSENTE no índice (esperado na config)";
-
-                continue;
-            }
-            foreach (['source', 'model', 'dimensions'] as $campo) {
-                if (! array_key_exists($campo, (array) $espec)) {
-                    continue;
-                }
-                $vivoVal = $vivoEmb[$nome][$campo] ?? null;
-                if ($vivoVal != $espec[$campo]) {
-                    $drift[] = "{$uid}: embedder '{$nome}'.{$campo} difere (config=".json_encode($espec[$campo]).' vivo='.json_encode($vivoVal).')';
-                }
-            }
-        }
-
-        $expFilt  = (array) ($cfg['filterableAttributes'] ?? []);
-        $vivoFilt = (array) ($vivo['filterableAttributes'] ?? []);
-        sort($expFilt);
-        sort($vivoFilt);
-        if ($expFilt !== $vivoFilt) {
-            $drift[] = "{$uid}: filterableAttributes difere (config=[".implode(',', $expFilt).'] vivo=['.implode(',', $vivoFilt).'])';
-        }
-
-        return $drift;
     }
 }

--- a/Modules/Jana/Tests/Feature/Console/MeilisearchIndexSetupTest.php
+++ b/Modules/Jana/Tests/Feature/Console/MeilisearchIndexSetupTest.php
@@ -46,35 +46,6 @@ it('payloadPara monta embedders + filterableAttributes', function () {
         ->and($payload['filterableAttributes'])->toBe(['business_id', 'user_id']);
 });
 
-// ── SettingsReconciler — detectarDrift (o gate "nunca mais perder o embedder") ──
-
-$cfg = [
-    'embedders' => ['qwen3_local' => ['source' => 'ollama', 'model' => 'qwen3-embedding:0.6b', 'dimensions' => 1024]],
-    'filterableAttributes' => ['status', 'type'],
-];
-
-it('detectarDrift: settings vivos == config → sem drift', function () use ($cfg) {
-    $vivo = ['embedders' => $cfg['embedders'], 'filterableAttributes' => ['type', 'status']]; // ordem diferente OK
-    expect((new MeilisearchIndexSetupCommand())->detectarDrift('x', $cfg, $vivo))->toBeEmpty();
-});
-
-it('detectarDrift: embedder VAZIO (o bug recorrente) → drift', function () use ($cfg) {
-    $vivo = ['embedders' => [], 'filterableAttributes' => ['status', 'type']];
-    $d = (new MeilisearchIndexSetupCommand())->detectarDrift('jana_memoria_facts', $cfg, $vivo);
-    expect($d)->not->toBeEmpty()
-        ->and($d[0])->toContain("embedder 'qwen3_local' AUSENTE");
-});
-
-it('detectarDrift: model divergente (ex openai) → drift', function () use ($cfg) {
-    $vivo = ['embedders' => ['qwen3_local' => ['source' => 'ollama', 'model' => 'nomic-embed-text', 'dimensions' => 1024]], 'filterableAttributes' => ['status', 'type']];
-    expect((new MeilisearchIndexSetupCommand())->detectarDrift('x', $cfg, $vivo))
-        ->toHaveCount(1)
-        ->and(implode('', (new MeilisearchIndexSetupCommand())->detectarDrift('x', $cfg, $vivo)))->toContain('.model difere');
-});
-
-it('detectarDrift: filterableAttributes diferente → drift', function () use ($cfg) {
-    $vivo = ['embedders' => $cfg['embedders'], 'filterableAttributes' => ['status']];
-    expect((new MeilisearchIndexSetupCommand())->detectarDrift('x', $cfg, $vivo))
-        ->toHaveCount(1)
-        ->and(implode('', (new MeilisearchIndexSetupCommand())->detectarDrift('x', $cfg, $vivo)))->toContain('filterableAttributes difere');
-});
+// NOTA: a detecção de drift (settings vivos × config) NÃO mora mais aqui — virou
+// MeilisearchSettingsDriftChecker (Modules/Governance, ADR 0216). Ver
+// Modules/Governance/Tests/.../MeilisearchSettingsDriftCheckerTest.php.

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -495,22 +495,10 @@ class Kernel extends ConsoleKernel
                 );
             });
 
-        // SettingsReconciler (estado-da-arte reconcile-loop 2026-05-29) — guarda contra
-        // o bug recorrente "embedder do Meilisearch se perdeu" (jana_memoria_facts voltou
-        // a {} 2×). Compara settings vivos × config copiloto.meilisearch_indexes; exit 1 +
-        // alerta idempotente index_settings_drift se driftar. Roda DEPOIS do freshness.
-        $schedule->command('jana:meilisearch-setup --check')
-            ->dailyAt('04:40')
-            ->timezone('America/Sao_Paulo')
-            ->onOneServer()
-            ->withoutOverlapping(20)
-            ->environments(['live'])
-            ->appendOutputTo(storage_path('logs/jana-meilisearch-reconcile.log'))
-            ->onFailure(function () {
-                \Illuminate\Support\Facades\Log::channel('copiloto-ai')->error(
-                    'Schedule jana:meilisearch-setup --check FALHOU — DRIFT de settings/embedder do índice (rodar jana:meilisearch-setup pra curar)'
-                );
-            });
+        // NOTA: a detecção de drift de settings/embedder do Meilisearch NÃO tem cron
+        // próprio — é o MeilisearchSettingsDriftChecker (Modules/Governance, ADR 0216)
+        // que roda no `governance:audit --all --notify` já agendado abaixo. Cura =
+        // `php artisan jana:meilisearch-setup`.
 
         // MEM-MULTI-1 (auditoria seed 2026-05-28) — re-seed ADRs → jana_memoria_facts
         // diário. Sem este schedule os fatos de ADR ficavam STALE: nova ADR aceita /


### PR DESCRIPTION
Inspeção séria do Wagner confirmou: o #1937 reinventou o framework DriftChecker (ADR 0216) com um --check bespoke + cron próprio. Correção: MeilisearchSettingsDriftChecker plugado em governance.drift_checkers (roda no governance:audit já agendado) + revert do bespoke (jana:meilisearch-setup fica só com a cura/apply). Detecção=Governance, cura=Jana. +6 testes, PHPStan limpo.