### PR TITLE
feat(legacy-migration): tipos de cliente + mensagem de venda + anti-fantasma (CYCLE-06 Martinho)

### DIFF
--- a/database/migrations/2026_05_28_120000_add_mensagem_venda_to_contacts.php
+++ b/database/migrations/2026_05_28_120000_add_mensagem_venda_to_contacts.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * ADR 0197 (Bucket A complemento) — coluna dedicada `mensagem_venda`.
+ *
+ * Origem: PESSOAS.MENSAGEM_PARA_VENDA (WR Comercial Delphi). Campo DISTINTO de
+ * OBSERVACAO (->obs_comercial): a "Mensagem para a Venda" é o alerta exibido ao
+ * vendedor no momento da venda (ex.: "cliente tem haver de R$ X", restrições),
+ * enquanto OBSERVACAO é nota cadastral geral. Confirmado por Wagner 2026-05-28.
+ *
+ * Por que TEXT e não custom_field: enrich-contacts-v2 colocou a mensagem em
+ * custom_field1 (varchar 191), TRUNCANDO 16 registros (máx real 522 chars) e
+ * sobrecarregando o campo. TEXT preserva o conteúdo completo sem truncar.
+ *
+ * IDEMPOTENTE — Schema::hasColumn antes do add (col já aplicada em prod biz=164
+ * via script de migração; aqui registra o schema p/ demais ambientes e evita
+ * drift). Reversível via down().
+ *
+ * @see scripts/legacy-migration/enrich-mensagem-venda.py
+ * @see memory/decisions/0197-extend-contacts-absorcao-pessoas-legacy.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('contacts', function (Blueprint $table) {
+            if (! Schema::hasColumn('contacts', 'mensagem_venda')) {
+                $table->text('mensagem_venda')->nullable()->after('obs_comercial');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('contacts', function (Blueprint $table) {
+            if (Schema::hasColumn('contacts', 'mensagem_venda')) {
+                $table->dropColumn('mensagem_venda');
+            }
+        });
+    }
+};

--- a/scripts/legacy-migration/enrich-contacts-v2.py
+++ b/scripts/legacy-migration/enrich-contacts-v2.py
@@ -1,0 +1,206 @@
+"""
+Enrich contacts v2 — preenche campos que a UI lê de verdade + mapeamentos.
+
+CORRIGE v1: campo de endereço da UI é address_line_1 (NÃO rua).
+
+Mapeia de PESSOAS (+ CIDADES + CONDICAO_PAGTO lookup):
+  - address_line_1 ← ENDERECO       (CRÍTICO — UI EnderecoTab lê isto)
+  - numero         ← NUMERO
+  - address_line_2 ← COMPLEMENTO
+  - zip_code       ← CEP
+  - city           ← CIDADES.DESCRICAO via CODCIDADE
+  - city_code      ← CODCIDADE (IBGE)
+  - pgto_padrao    ← map CONDICAO_PAGTO.DESCRICAO → enum(pix|boleto|cartao|dinheiro|transferencia)
+  - custom_field1  ← MENSAGEM_PARA_VENDA (não há campo dedicado no schema)
+  - custom_field2  ← TABELA_PRECO/grupo literal (FABRICANTE não cabe no enum fixo)
+
+Uso:
+    python enrich-contacts-v2.py --alias "Martinho online" --target-business 164 --target prod --confirm
+"""
+from __future__ import annotations
+import argparse, os, re, sys
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+sys.path.insert(0, str(Path(__file__).parent))
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+from lib.firebird_reader import firebird_connect  # noqa: E402
+import pymysql, pymysql.cursors
+
+
+def digits(s):
+    return re.sub(r'\D', '', s or '')
+
+
+def norm(s, n=None):
+    if s is None: return None
+    s = str(s).strip()
+    if not s: return None
+    return s[:n] if n else s
+
+
+def map_pgto(desc):
+    """CONDICAO_PAGTO.DESCRICAO Delphi → enum oimpresso."""
+    if not desc:
+        return None
+    d = desc.upper()
+    if 'PIX' in d: return 'pix'
+    if 'BOLETO' in d: return 'boleto'
+    if 'CART' in d: return 'cartao'
+    if 'DINHEIRO' in d or 'ESPECIE' in d or 'VISTA' in d: return 'dinheiro'
+    if 'TRANSF' in d or 'DEP' in d or 'TED' in d or 'DOC' in d: return 'transferencia'
+    return 'boleto'  # default mais comum no B2B
+
+
+def table_exists(con, name):
+    cur = con.cursor()
+    try:
+        cur.execute(f"SELECT FIRST 1 1 FROM {name}")
+        cur.fetchone()
+        return True
+    except Exception:
+        return False
+    finally:
+        cur.close()
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--alias", required=True)
+    p.add_argument("--target-business", type=int, required=True)
+    p.add_argument("--target", choices=["local", "prod"], default="local")
+    p.add_argument("--mysql-host", default=os.environ.get("MYSQL_HOST", "127.0.0.1"))
+    p.add_argument("--mysql-port", type=int, default=int(os.environ.get("MYSQL_PORT", "3306")))
+    p.add_argument("--mysql-user", default=os.environ.get("MYSQL_USER", "root"))
+    p.add_argument("--mysql-password", default=os.environ.get("MYSQL_PASSWORD", ""))
+    p.add_argument("--mysql-database", default=os.environ.get("MYSQL_DATABASE", "oimpresso"))
+    p.add_argument("--firebird-password", default=os.environ.get("FIREBIRD_PASSWORD", "masterkey"))
+    p.add_argument("--confirm", action="store_true")
+    args = p.parse_args()
+    if args.target == "prod" and not args.confirm:
+        print("[ERRO] --target prod requer --confirm", file=sys.stderr); return 2
+
+    print("== Enricher CONTACTS v2 (endereço correto + mapeamentos) ==")
+
+    # 1. Lê PESSOAS + CIDADES + CONDICAO_PAGTO
+    print("\n[1/2] Lendo PESSOAS Firebird (com lookups)...")
+    pessoas = {}
+    with firebird_connect(args.alias, password_override=args.firebird_password) as fb:
+        # Descobre nome da tabela de cidade
+        cidade_tbl = None
+        for cand in ("CIDADES", "CIDADE", "MUNICIPIO", "MUNICIPIOS"):
+            if table_exists(fb, cand):
+                cidade_tbl = cand
+                break
+        cond_tbl = None
+        for cand in ("CONDICAO_PAGTO", "CONDICAOPAGTO", "CONDICAO_PAGAMENTO"):
+            if table_exists(fb, cand):
+                cond_tbl = cand
+                break
+        print(f"  cidade_tbl={cidade_tbl} cond_tbl={cond_tbl}")
+
+        cid_join = f"LEFT JOIN {cidade_tbl} CID ON CID.CODIGO = P.CODCIDADE" if cidade_tbl else ""
+        cid_sel = "CID.DESCRICAO AS CIDADE_NOME," if cidade_tbl else "CAST(NULL AS VARCHAR(1)) AS CIDADE_NOME,"
+        cond_join = f"LEFT JOIN {cond_tbl} CP ON CP.CODIGO = P.CODCONDICAOPAGTO" if cond_tbl else ""
+        cond_sel = "CP.DESCRICAO AS COND_DESC," if cond_tbl else "CAST(NULL AS VARCHAR(1)) AS COND_DESC,"
+
+        sql = (
+            f"SELECT P.CNPJCPF, P.ENDERECO, P.NUMERO, P.COMPLEMENTO, P.CEP, P.CODCIDADE, "
+            f" {cid_sel} {cond_sel} P.MENSAGEM_PARA_VENDA, P.CODPESSOAS_GRUPO "
+            f"FROM PESSOAS P {cid_join} {cond_join} "
+            f"WHERE P.ATIVO='S' AND P.CNPJCPF IS NOT NULL"
+        )
+        cur = fb.cursor()
+        cur.execute(sql)
+        cols = [d[0] for d in cur.description]
+        for row in cur:
+            d = dict(zip(cols, row))
+            k = digits(d.get("CNPJCPF"))
+            if k:
+                pessoas.setdefault(k, d)
+        cur.close()
+    print(f"  PESSOAS indexadas: {len(pessoas)}")
+
+    # 2. UPDATE contacts
+    print("\n[2/2] Atualizando contacts...")
+    con = pymysql.connect(
+        host=args.mysql_host, port=args.mysql_port,
+        user=args.mysql_user, password=args.mysql_password,
+        database=args.mysql_database, charset="utf8mb4",
+        cursorclass=pymysql.cursors.DictCursor, autocommit=False,
+    )
+    stats = {"matched": 0, "updated": 0, "no_match": 0, "errors": 0}
+    try:
+        with con.cursor() as cur:
+            cur.execute(
+                "SELECT id, tax_number FROM contacts WHERE business_id=%s AND deleted_at IS NULL "
+                "AND tax_number IS NOT NULL AND tax_number<>''",
+                (args.target_business,),
+            )
+            rows = cur.fetchall()
+        print(f"  contacts: {len(rows)}")
+
+        batch = 0
+        for c in rows:
+            pp = pessoas.get(digits(c['tax_number']))
+            if not pp:
+                stats["no_match"] += 1; continue
+            stats["matched"] += 1
+            try:
+                with con.cursor() as w:
+                    w.execute(
+                        "UPDATE contacts SET "
+                        " address_line_1=%s, numero=%s, address_line_2=%s, "
+                        " zip_code=%s, city=%s, city_code=%s, "
+                        " pgto_padrao=%s, "
+                        " custom_field1=%s, custom_field2=%s, "
+                        " updated_at=NOW() "
+                        "WHERE id=%s",
+                        (
+                            norm(pp.get("ENDERECO"), 191),
+                            norm(pp.get("NUMERO"), 30),
+                            norm(pp.get("COMPLEMENTO"), 191),
+                            norm(pp.get("CEP"), 20),
+                            norm(pp.get("CIDADE_NOME"), 100),
+                            norm(str(pp.get("CODCIDADE")) if pp.get("CODCIDADE") else None, 20),
+                            map_pgto(pp.get("COND_DESC")),
+                            norm(pp.get("MENSAGEM_PARA_VENDA"), 250),
+                            norm(f"grupo_delphi={pp.get('CODPESSOAS_GRUPO')}", 100),
+                            c['id'],
+                        ),
+                    )
+                    if w.rowcount > 0:
+                        stats["updated"] += 1
+            except Exception as e:
+                stats["errors"] += 1
+                if stats["errors"] < 5:
+                    print(f"  [err] id={c['id']}: {e}")
+                continue
+            batch += 1
+            if batch >= 500:
+                con.commit()
+                print(f"  [batch] matched={stats['matched']} updated={stats['updated']}", flush=True)
+                batch = 0
+        con.commit()
+        print("  [final] commit OK")
+    except Exception as e:
+        con.rollback(); print(f"[ERRO] {e}", file=sys.stderr); raise
+    finally:
+        con.close()
+
+    print("\n== Relatório ==")
+    for k, v in stats.items():
+        print(f"  {k:12s}: {v}")
+    print("[OK] Enricher v2 concluido")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/legacy-migration/enrich-contacts.py
+++ b/scripts/legacy-migration/enrich-contacts.py
@@ -1,0 +1,213 @@
+"""
+Enrich contacts a partir de PESSOAS Firebird (campos completos).
+
+import-contacts-from-venda.py original extraía só dados INLINE de VENDA
+(parcial). Esta enriquecimento pega tudo de PESSOAS direto:
+
+- inscricao_estadual ← INSCIDENT
+- contato ← CONTATO
+- fantasia + nome_fantasia + supplier_business_name ← FANTASIA
+- rua ← ENDERECO
+- neighborhood ← BAIRRO
+- mobile ← FONE1
+- tel2 ← FONE2
+- email canonical ← EMAIL (sobrescreve concatenações incorretas)
+- obs_comercial ← OBSERVACAO (se existir)
+- officeimpresso_codigo ← CODIGO Delphi
+- pgto_padrao (best-effort)
+
+Match contact ↔ PESSOAS via tax_number = digits-only(CNPJCPF).
+
+Uso:
+    python enrich-contacts.py --alias "Martinho online" --target-business 164 --target prod --confirm
+"""
+from __future__ import annotations
+import argparse, os, re, sys
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+sys.path.insert(0, str(Path(__file__).parent))
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+from lib.firebird_reader import firebird_connect  # noqa: E402
+try:
+    import pymysql
+    import pymysql.cursors
+except ImportError:
+    pymysql = None  # type: ignore
+
+
+def digits(s):
+    return re.sub(r'\D', '', s or '')
+
+
+def norm(s, max_len=None):
+    if s is None: return None
+    s = str(s).strip()
+    if not s: return None
+    if max_len: s = s[:max_len]
+    return s
+
+
+def has_col(con, table, col):
+    cur = con.cursor()
+    try:
+        cur.execute(f"SELECT FIRST 1 * FROM {table}")
+        cols = {d[0] for d in cur.description or []}
+        return col in cols
+    finally:
+        cur.close()
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--alias", required=True)
+    parser.add_argument("--target-business", type=int, required=True)
+    parser.add_argument("--target", choices=["local", "prod"], default="local")
+    parser.add_argument("--mysql-host", default=os.environ.get("MYSQL_HOST", "127.0.0.1"))
+    parser.add_argument("--mysql-port", type=int, default=int(os.environ.get("MYSQL_PORT", "3306")))
+    parser.add_argument("--mysql-user", default=os.environ.get("MYSQL_USER", "root"))
+    parser.add_argument("--mysql-password", default=os.environ.get("MYSQL_PASSWORD", ""))
+    parser.add_argument("--mysql-database", default=os.environ.get("MYSQL_DATABASE", "oimpresso"))
+    parser.add_argument("--firebird-password", default=os.environ.get("FIREBIRD_PASSWORD", "masterkey"))
+    parser.add_argument("--confirm", action="store_true")
+    args = parser.parse_args()
+
+    if args.target == "prod" and not args.confirm:
+        print("[ERRO] --target prod requer --confirm", file=sys.stderr); return 2
+
+    print(f"== Enricher CONTACTS v0.1.0 ==")
+    print(f"  Alias Firebird   : {args.alias}")
+    print(f"  business_id alvo : {args.target_business}")
+    print(f"  Target MySQL     : {args.target}")
+
+    if pymysql is None:
+        print("[ERRO] pymysql não instalado", file=sys.stderr); return 3
+
+    # 1. Lê PESSOAS Firebird → dict CNPJ_digits → fields
+    print("\n[1/3] Lendo PESSOAS Firebird...")
+    pessoas_by_cnpj = {}
+    with firebird_connect(args.alias, password_override=args.firebird_password) as fb_con:
+        has_obs = has_col(fb_con, "PESSOAS", "OBSERVACAO")
+        sel = ("SELECT CODIGO, RAZAOSOCIAL, FANTASIA, CNPJCPF, INSCIDENT, CONTATO, "
+               "ENDERECO, BAIRRO, CEP, UF, FONE1, FONE2, EMAIL, ATIVO, CODCONDICAOPAGTO" +
+               (", OBSERVACAO" if has_obs else "") +
+               " FROM PESSOAS WHERE ATIVO='S' AND CNPJCPF IS NOT NULL")
+        cur = fb_con.cursor()
+        cur.execute(sel)
+        cols = [d[0] for d in cur.description]
+        for row in cur:
+            d = dict(zip(cols, row))
+            cnpj = digits(d.get("CNPJCPF"))
+            if not cnpj:
+                continue
+            # Se houver múltiplas pessoas com mesmo CNPJ (raro), keep a primeira
+            pessoas_by_cnpj.setdefault(cnpj, d)
+        cur.close()
+    print(f"  PESSOAS ATIVO indexadas por CNPJ: {len(pessoas_by_cnpj)}")
+
+    # 2. UPDATE contacts MySQL em batches
+    print("\n[2/3] Conectando MySQL e enriquecendo contacts...")
+    con = pymysql.connect(
+        host=args.mysql_host, port=args.mysql_port,
+        user=args.mysql_user, password=args.mysql_password,
+        database=args.mysql_database, charset="utf8mb4",
+        cursorclass=pymysql.cursors.DictCursor, autocommit=False,
+    )
+
+    stats = {"matched": 0, "updated": 0, "no_match": 0, "errors": 0}
+    try:
+        with con.cursor() as cur:
+            cur.execute(
+                "SELECT id, tax_number FROM contacts "
+                "WHERE business_id=%s AND deleted_at IS NULL "
+                "AND tax_number IS NOT NULL AND tax_number <> ''",
+                (args.target_business,),
+            )
+            all_contacts = cur.fetchall()
+        print(f"  contacts pra processar: {len(all_contacts)}")
+
+        batch_count = 0
+        for c in all_contacts:
+            cnpj = digits(c['tax_number'])
+            p = pessoas_by_cnpj.get(cnpj)
+            if not p:
+                stats["no_match"] += 1
+                continue
+            stats["matched"] += 1
+
+            # Tenta UPDATE com todos os campos importantes
+            try:
+                with con.cursor() as wcur:
+                    wcur.execute(
+                        "UPDATE contacts SET "
+                        # Anti-fantasma: NULLIF+COALESCE → nome vazio nunca sobrescreve nome existente
+                        " name=COALESCE(NULLIF(%s,''), name), supplier_business_name=%s, fantasia=%s, nome_fantasia=%s, "
+                        " inscricao_estadual=%s, ie=%s, contato=%s, "
+                        " rua=%s, neighborhood=%s, "
+                        " mobile=%s, tel2=%s, landline=%s, "
+                        " email=%s, "
+                        " state=%s, "
+                        " obs_comercial=%s, "
+                        " officeimpresso_codigo=%s, "
+                        " contact_status='active', "
+                        " updated_at=NOW() "
+                        "WHERE id=%s",
+                        (
+                            # name: cadeia anti-fantasma RAZAOSOCIAL → FANTASIA → CONTATO
+                            norm(p.get("RAZAOSOCIAL"), 191) or norm(p.get("FANTASIA"), 191) or norm(p.get("CONTATO"), 191),
+                            norm(p.get("FANTASIA"), 191),
+                            norm(p.get("FANTASIA"), 191),
+                            norm(p.get("FANTASIA"), 191),
+                            norm(p.get("INSCIDENT"), 50),
+                            norm(p.get("INSCIDENT"), 50),
+                            norm(p.get("CONTATO"), 191),
+                            norm(p.get("ENDERECO"), 191),
+                            norm(p.get("BAIRRO"), 191),
+                            norm(p.get("FONE1"), 50),
+                            norm(p.get("FONE2"), 50),
+                            norm(p.get("FONE2"), 50),
+                            norm(p.get("EMAIL"), 191),  # SOBRESCREVE com canonical
+                            norm(p.get("UF"), 2),
+                            norm(p.get("OBSERVACAO"), 500) if "OBSERVACAO" in p else None,
+                            norm(str(p.get("CODIGO")), 50),
+                            c['id'],
+                        ),
+                    )
+                    if wcur.rowcount > 0:
+                        stats["updated"] += 1
+            except Exception as e:
+                stats["errors"] += 1
+                if stats["errors"] < 5:
+                    print(f"  [err] id={c['id']} cnpj={cnpj}: {e}")
+                continue
+
+            batch_count += 1
+            if batch_count >= 500:
+                con.commit()
+                print(f"  [batch] matched={stats['matched']} updated={stats['updated']}", flush=True)
+                batch_count = 0
+        con.commit()
+        print(f"  [final] commit OK")
+    except Exception as e:
+        con.rollback()
+        print(f"[ERRO] {e}", file=sys.stderr)
+        raise
+    finally:
+        con.close()
+
+    print("\n== Relatório ==")
+    for k, v in stats.items():
+        print(f"  {k:15s}: {v}")
+    print(f"[OK] Enricher CONTACTS concluido")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/legacy-migration/enrich-mensagem-venda.py
+++ b/scripts/legacy-migration/enrich-mensagem-venda.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+"""
+enrich-mensagem-venda.py — Migra PESSOAS.MENSAGEM_PARA_VENDA (campo DISTINTO de
+OBSERVACAO) para uma coluna dedicada contacts.mensagem_venda (TEXT, sem truncar).
+
+Contexto: enrich-contacts-v2 colocou a mensagem em custom_field1 (varchar 191),
+truncando textos >191 (16 casos, máx 522 chars) e sobrecarregando o campo.
+Wagner confirmou: Observação ≠ Mensagem para Venda — devem ser campos separados.
+
+Ações:
+ 1. ALTER TABLE contacts ADD COLUMN mensagem_venda TEXT NULL (idempotente).
+ 2. Popula mensagem_venda com o texto COMPLETO da origem (match por officeimpresso_codigo).
+ 3. Limpa custom_field1 onde ele == LEFT(mensagem,191) (remove a cópia truncada duplicada).
+ 4. obs_comercial (=OBSERVACAO) fica intacta.
+
+Migration Laravel equivalente: ver database/migrations/..._add_mensagem_venda_to_contacts.php
+"""
+from __future__ import annotations
+import argparse, os, sys
+os.environ.setdefault("FIREBIRD_PY_DRIVER", "fdb")
+sys.path.insert(0, os.path.dirname(__file__))
+from lib.firebird_reader import firebird_connect  # noqa
+import pymysql, pymysql.cursors  # noqa
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--alias", default="Martinho online")
+    p.add_argument("--target-business", type=int, default=164)
+    p.add_argument("--firebird-password", default=os.environ.get("FIREBIRD_PASSWORD", "masterkey"))
+    p.add_argument("--confirm", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+    if not (args.confirm or args.dry_run):
+        print("[ERRO] requer --confirm (ou --dry-run)", file=sys.stderr); return 2
+    biz = args.target_business
+
+    print("== enrich-mensagem-venda v1.0 ==")
+    # 1) Lê MENSAGEM_PARA_VENDA da origem
+    print("[1/4] Lendo MENSAGEM_PARA_VENDA Firebird...")
+    msgs: dict[str, str] = {}
+    with firebird_connect(args.alias, password_override=args.firebird_password) as fb:
+        cur = fb.cursor()
+        cur.execute("SELECT CODIGO, MENSAGEM_PARA_VENDA FROM PESSOAS "
+                    "WHERE MENSAGEM_PARA_VENDA IS NOT NULL AND CHAR_LENGTH(TRIM(MENSAGEM_PARA_VENDA))>0")
+        for cod, msg in cur:
+            cod = str(cod).strip() if cod is not None else ""
+            if cod and msg and str(msg).strip():
+                msgs[cod] = str(msg).strip()
+        cur.close()
+    print(f"  mensagens lidas: {len(msgs)}")
+
+    con = pymysql.connect(host=os.environ.get("MYSQL_HOST", "127.0.0.1"),
+                          port=int(os.environ.get("MYSQL_PORT", "3306")),
+                          user=os.environ.get("MYSQL_USER", "root"),
+                          password=os.environ.get("MYSQL_PASSWORD", ""),
+                          database=os.environ.get("MYSQL_DATABASE", "oimpresso"),
+                          charset="utf8mb4", cursorclass=pymysql.cursors.DictCursor, autocommit=False)
+    stats = {"col_criada": 0, "atualizados": 0, "custom1_limpos": 0, "sem_match": 0}
+    try:
+        # 2) Garante coluna (additive, nullable)
+        with con.cursor() as cur:
+            cur.execute("SELECT COUNT(*) n FROM information_schema.COLUMNS "
+                        "WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='contacts' AND COLUMN_NAME='mensagem_venda'")
+            existe = cur.fetchone()["n"] > 0
+        if not existe:
+            print("[2/4] Criando coluna contacts.mensagem_venda TEXT NULL...")
+            if not args.dry_run:
+                with con.cursor() as cur:
+                    cur.execute("ALTER TABLE contacts ADD COLUMN mensagem_venda TEXT NULL AFTER obs_comercial")
+                stats["col_criada"] = 1
+        else:
+            print("[2/4] Coluna mensagem_venda já existe.")
+
+        # 3) Popula + limpa custom_field1 truncado
+        print("[3/4] Populando mensagem_venda + limpando custom_field1 truncado...")
+        if not args.dry_run:
+            with con.cursor() as cur:
+                for cod, msg in msgs.items():
+                    cur.execute(
+                        "UPDATE contacts SET mensagem_venda=%s, updated_at=NOW() "
+                        "WHERE business_id=%s AND officeimpresso_codigo=%s AND deleted_at IS NULL",
+                        (msg, biz, cod))
+                    if cur.rowcount > 0:
+                        stats["atualizados"] += 1
+                        # limpa custom_field1 se for só a cópia (truncada) da mensagem
+                        cur.execute(
+                            "UPDATE contacts SET custom_field1=NULL "
+                            "WHERE business_id=%s AND officeimpresso_codigo=%s AND deleted_at IS NULL "
+                            "AND custom_field1 IS NOT NULL AND custom_field1=LEFT(%s,191)",
+                            (biz, cod, msg))
+                        stats["custom1_limpos"] += cur.rowcount
+                    else:
+                        stats["sem_match"] += 1
+            con.commit()
+        else:
+            con.rollback()
+
+        # 4) verificação FAN COM
+        if not args.dry_run:
+            with con.cursor() as cur:
+                cur.execute("SELECT CHAR_LENGTH(mensagem_venda) ml, CHAR_LENGTH(obs_comercial) ol, custom_field1 "
+                            "FROM contacts WHERE business_id=%s AND officeimpresso_codigo='651-1' AND deleted_at IS NULL", (biz,))
+                print("[4/4] FAN COM → mensagem_venda len, obs len, custom_field1:", cur.fetchone())
+    finally:
+        con.close()
+
+    print("\nResultado:")
+    for k, v in stats.items():
+        print(f"  {k:16} = {v}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/legacy-migration/enrich-tipos.py
+++ b/scripts/legacy-migration/enrich-tipos.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""
+enrich-tipos.py — Migra a classificação de tipo de pessoa do WR Comercial (Delphi)
+para os contatos do oimpresso, fielmente (ADR 0188 multi-type flags + ADR 0197 primary_role).
+
+FONTE (Firebird PESSOAS): colunas dinâmicas IS_<TIPO> (S/N), uma por tipo do catálogo
+PESSOAS_TIPO. Confirmado em Classes.Pessoas.pas:161-190 (a aba "Tipos" lê IS_<COD> de PESSOAS).
+
+Catálogo Martinho:
+  CLI=Cliente · COM=Comércio/Revenda · FIN=Consumidor Final · FAB=Fabricante-Indústria
+  ISE=Isento · SST=Uso/Consumo s/ ST · USO=Uso/Consumo c/ ST · CPF=CPF · PES=Pessoa
+  FOR=Fornecedor · FUN=Funcionário · REP=Representante
+
+DESTINO (MySQL contacts):
+  - is_customer/is_supplier/is_employee/is_representative  (4 flags ADR 0188)
+  - primary_role (enum) + type (papel principal, sincronizado — invariante 5 do ADR 0188)
+  - custom_field3 = classificação fiscal legível ("Fabricante-Indústria", etc.) — perfil
+    fiscal do COMPRADOR, ortogonal ao papel; resolve a queixa "FAN COM marcado como cliente".
+  - business.custom_labels.contact.custom_field_3 = rótulo visível na tela.
+
+Match: contacts.officeimpresso_codigo == PESSOAS.CODIGO (cobre 9771/9794 biz=164).
+Idempotente: UPDATE puro; custom_field3 via COALESCE(NULLIF(...)) não apaga valor já bom.
+"""
+from __future__ import annotations
+import argparse, os, sys, json
+os.environ.setdefault("FIREBIRD_PY_DRIVER", "fdb")
+sys.path.insert(0, os.path.dirname(__file__))
+from lib.firebird_reader import firebird_connect  # noqa: E402
+
+try:
+    import pymysql
+    import pymysql.cursors
+except ImportError:
+    pymysql = None
+
+# Tipos que classificam um COMPRADOR (perfil fiscal) → todos implicam is_customer.
+BUYER_TYPES = {
+    "CLI": "Cliente",
+    "COM": "Comércio/Revenda",
+    "FIN": "Consumidor Final",
+    "FAB": "Fabricante-Indústria",
+    "ISE": "Isento",
+    "SST": "Uso e Consumo (sem ST)",
+    "USO": "Uso e Consumo (com ST)",
+    "CPF": "CPF",
+    "PES": "Pessoa",
+}
+# Tipos que são PAPEL relacional distinto.
+ROLE_TYPES = {
+    "FOR": ("is_supplier", "Fornecedor"),
+    "FUN": ("is_employee", "Funcionário"),
+    "REP": ("is_representative", "Representante"),
+}
+ALL_CODES = list(BUYER_TYPES.keys()) + list(ROLE_TYPES.keys())
+
+
+def s(v) -> bool:
+    return str(v).strip().upper() == "S" if v is not None else False
+
+
+def classify(row: dict) -> dict:
+    """row tem IS_<COD> (S/N). Retorna flags + primary_role + type + classif. fiscal."""
+    is_supplier = s(row.get("IS_FOR"))
+    is_employee = s(row.get("IS_FUN"))
+    is_representative = s(row.get("IS_REP"))
+    buyer_active = [c for c in BUYER_TYPES if s(row.get(f"IS_{c}"))]
+    is_customer = bool(buyer_active)
+    # Pegadinha ADR 0188: nunca todas flags 0. Sem nenhum papel → default cliente.
+    if not (is_customer or is_supplier or is_employee or is_representative):
+        is_customer = True
+
+    # primary_role: prioridade cliente > fornecedor > representante > funcionário
+    if is_customer:
+        primary = "customer"
+    elif is_supplier:
+        primary = "supplier"
+    elif is_representative:
+        primary = "representative"
+    elif is_employee:
+        primary = "employee"
+    else:
+        primary = "customer"
+
+    # Classificação fiscal legível (só perfis de comprador; ordem do catálogo)
+    classif = ", ".join(BUYER_TYPES[c] for c in BUYER_TYPES if c in buyer_active)
+    return {
+        "is_customer": int(is_customer),
+        "is_supplier": int(is_supplier),
+        "is_employee": int(is_employee),
+        "is_representative": int(is_representative),
+        "primary_role": primary,
+        "type": primary,
+        "classif": classif or None,
+    }
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--alias", default="Martinho online")
+    p.add_argument("--target-business", type=int, default=164)
+    p.add_argument("--target", choices=["local", "prod"], default="prod")
+    p.add_argument("--mysql-host", default=os.environ.get("MYSQL_HOST", "127.0.0.1"))
+    p.add_argument("--mysql-port", type=int, default=int(os.environ.get("MYSQL_PORT", "3306")))
+    p.add_argument("--mysql-user", default=os.environ.get("MYSQL_USER", "root"))
+    p.add_argument("--mysql-password", default=os.environ.get("MYSQL_PASSWORD", ""))
+    p.add_argument("--mysql-database", default=os.environ.get("MYSQL_DATABASE", "oimpresso"))
+    p.add_argument("--firebird-password", default=os.environ.get("FIREBIRD_PASSWORD", "masterkey"))
+    p.add_argument("--label", default="Classificação (WR Comercial)")
+    p.add_argument("--confirm", action="store_true")
+    p.add_argument("--dry-run", action="store_true")
+    args = p.parse_args()
+
+    if args.target == "prod" and not (args.confirm or args.dry_run):
+        print("[ERRO] --target prod requer --confirm (ou --dry-run)", file=sys.stderr)
+        return 2
+    if pymysql is None:
+        print("[ERRO] pymysql não instalado", file=sys.stderr)
+        return 3
+
+    biz = args.target_business
+    print("== enrich-tipos v1.0 ==")
+    print(f"  Alias Firebird   : {args.alias}")
+    print(f"  business_id alvo : {biz}")
+    print(f"  Target / dry-run : {args.target} / {args.dry_run}")
+
+    # 1) Lê PESSOAS Firebird → dict por CODIGO
+    flagsel = ", ".join(f"IS_{c}" for c in ALL_CODES)
+    print("\n[1/4] Lendo flags IS_* de PESSOAS Firebird...")
+    pessoas: dict[str, dict] = {}
+    with firebird_connect(args.alias, password_override=args.firebird_password) as fb:
+        cur = fb.cursor()
+        cur.execute(f"SELECT CODIGO, {flagsel} FROM PESSOAS")
+        cols = [d[0] for d in cur.description]
+        for r in cur:
+            d = dict(zip(cols, r))
+            cod = (str(d.get("CODIGO")).strip() if d.get("CODIGO") is not None else "")
+            if cod:
+                pessoas[cod] = d
+        cur.close()
+    print(f"  PESSOAS lidas: {len(pessoas)}")
+
+    # 2) Conecta MySQL e processa contacts por officeimpresso_codigo
+    print("\n[2/4] Conectando MySQL e classificando contacts...")
+    con = pymysql.connect(
+        host=args.mysql_host, port=args.mysql_port, user=args.mysql_user,
+        password=args.mysql_password, database=args.mysql_database,
+        charset="utf8mb4", cursorclass=pymysql.cursors.DictCursor, autocommit=False,
+    )
+    stats = {"matched": 0, "updated": 0, "no_match": 0, "errors": 0,
+             "is_customer": 0, "is_supplier": 0, "is_employee": 0, "is_representative": 0}
+    examples = []
+    # Agrupa contatos por assinatura de classificação → 1 UPDATE por combo (lote)
+    # em vez de 9771 round-trips pelo túnel SSH (lento + risco de lock).
+    groups: dict[tuple, list[int]] = {}
+    try:
+        with con.cursor() as cur:
+            cur.execute(
+                "SELECT id, officeimpresso_codigo, name FROM contacts "
+                "WHERE business_id=%s AND deleted_at IS NULL "
+                "AND officeimpresso_codigo IS NOT NULL AND officeimpresso_codigo<>''",
+                (biz,),
+            )
+            rows = cur.fetchall()
+        print(f"  contacts com officeimpresso_codigo: {len(rows)}")
+
+        for c in rows:
+            cod = str(c["officeimpresso_codigo"]).strip()
+            p = pessoas.get(cod)
+            if not p:
+                stats["no_match"] += 1
+                continue
+            stats["matched"] += 1
+            cl = classify(p)
+            for k in ("is_customer", "is_supplier", "is_employee", "is_representative"):
+                stats[k] += cl[k]
+            sig = (cl["is_customer"], cl["is_supplier"], cl["is_employee"],
+                   cl["is_representative"], cl["primary_role"], cl["type"], cl["classif"])
+            groups.setdefault(sig, []).append(c["id"])
+            if args.dry_run and len(examples) < 12 and (cl["is_supplier"] or cl["is_employee"]
+                                                        or cl["is_representative"] or cl["classif"]):
+                examples.append((cod, c["name"][:30], cl["type"], cl["is_customer"],
+                                 cl["is_supplier"], cl["is_employee"],
+                                 cl["is_representative"], cl["classif"]))
+
+        print(f"  combinações distintas: {len(groups)}")
+        if not args.dry_run:
+            CHUNK = 1000
+            for sig, ids in groups.items():
+                isc, iss, ise, isr, prole, ptype, classif = sig
+                # classif None → não tocar custom_field3 (preserva valor de outras origens)
+                if classif:
+                    set_clause = ("is_customer=%s, is_supplier=%s, is_employee=%s, "
+                                  "is_representative=%s, primary_role=%s, type=%s, "
+                                  "custom_field3=%s, updated_at=NOW()")
+                    head = [isc, iss, ise, isr, prole, ptype, classif]
+                else:
+                    set_clause = ("is_customer=%s, is_supplier=%s, is_employee=%s, "
+                                  "is_representative=%s, primary_role=%s, type=%s, "
+                                  "updated_at=NOW()")
+                    head = [isc, iss, ise, isr, prole, ptype]
+                for i in range(0, len(ids), CHUNK):
+                    chunk = ids[i:i + CHUNK]
+                    ph = ",".join(["%s"] * len(chunk))
+                    try:
+                        with con.cursor() as wcur:
+                            wcur.execute(
+                                f"UPDATE contacts SET {set_clause} WHERE id IN ({ph})",
+                                head + chunk,
+                            )
+                            stats["updated"] += wcur.rowcount
+                    except Exception as e:
+                        stats["errors"] += 1
+                        if stats["errors"] <= 5:
+                            print(f"  [erro] sig={sig}: {e}")
+
+        # 3) Rotula custom_field_3 no business.custom_labels (visível na tela)
+        if not args.dry_run:
+            print("\n[3/4] Rotulando custom_field_3 no business...")
+            with con.cursor() as cur:
+                cur.execute("SELECT custom_labels FROM business WHERE id=%s", (biz,))
+                row = cur.fetchone()
+                labels = {}
+                if row and row.get("custom_labels"):
+                    try:
+                        labels = json.loads(row["custom_labels"])
+                    except Exception:
+                        labels = {}
+                labels.setdefault("contact", {})
+                if not labels["contact"].get("custom_field_3"):
+                    labels["contact"]["custom_field_3"] = args.label
+                    cur.execute("UPDATE business SET custom_labels=%s WHERE id=%s",
+                                (json.dumps(labels, ensure_ascii=False), biz))
+                    print(f"  rótulo custom_field_3 = {args.label!r}")
+                else:
+                    print(f"  custom_field_3 já rotulado: {labels['contact']['custom_field_3']!r}")
+
+        if args.dry_run:
+            con.rollback()
+            print("\n[dry-run] Amostra (cod, nome, type, cust, sup, emp, rep, classif):")
+            for e in examples:
+                print("   ", e)
+        else:
+            con.commit()
+    finally:
+        con.close()
+
+    print("\n[4/4] Resultado:")
+    for k, v in stats.items():
+        print(f"  {k:18} = {v}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/legacy-migration/import-contacts-from-venda.py
+++ b/scripts/legacy-migration/import-contacts-from-venda.py
@@ -168,7 +168,11 @@ def map_venda_to_contact(
         return None  # sem CNPJ não dá pra dedup → skip
 
     razao = normalize_str(row.get("RAZAOSOCIAL"))
+    contato = normalize_str(row.get("CONTATO"))
     contact_type = derive_contact_type(row.get("RESPONSAVEL_TIPO"))
+    # Anti-fantasma: name NUNCA pode ficar vazio. Cadeia: RAZAOSOCIAL → CONTATO → CNPJ.
+    # (incidente HEINIG id=30525: contact criado com name='' por RAZAOSOCIAL vazio)
+    nome_final = razao or contato or f"Legacy CNPJ {cnpj[:6]}..."
 
     # Schema contacts UltimatePOS: varchar tamanhos justos — truncar pra evitar overflow.
     # cpf_cnpj(20), ie_rg(18), rua(80), numero(10), bairro(40), zip_code(20),
@@ -177,7 +181,7 @@ def map_venda_to_contact(
         "business_id": business_id,
         "type": "customer",  # cliente (não fornecedor) — Martinho oficina/locação
         "contact_type": contact_type,
-        "name": normalize_str(razao, 191) or f"Legacy CNPJ {cnpj[:6]}...",
+        "name": normalize_str(nome_final, 191),
         "supplier_business_name": normalize_str(razao, 191),
         "cpf_cnpj": cnpj[:20],
         "tax_number": cnpj[:20],

--- a/scripts/legacy-migration/import-tabelas-preco.py
+++ b/scripts/legacy-migration/import-tabelas-preco.py
@@ -1,0 +1,231 @@
+"""
+Import tabelas de preço Delphi → oimpresso (DINÂMICO, business-scoped, zero hardcode).
+
+Cada empresa cria suas próprias tabelas de preço (PRODUTO_TABELA). Este importer
+lê os NOMES reais da origem e cria o modelo relacional do oimpresso:
+
+  PRODUTO_TABELA (CODIGO, DESCRICAO)      → selling_price_groups (name, business_id)
+                                          → customer_groups (name, selling_price_group_id)
+  PRODUTO_TABELA_PRECO (produto × tabela) → variation_group_prices (variation_id, price_group_id, price)
+  PESSOAS.CODPRODUTO_TABELA               → contacts.customer_group_id
+
+Cadeia oimpresso: contacts.customer_group_id → customer_groups.selling_price_group_id
+                  → selling_price_groups (tabela com preços por produto)
+
+Multi-tenant Tier 0: tudo business_id scoped. "FABRICANTE" do Martinho (biz 164)
+≠ "FABRICANTE" de outro cliente — FK isola. Generaliza pra qualquer cliente.
+
+Uso:
+    python import-tabelas-preco.py --alias "Martinho online" --target-business 164 --target prod --confirm
+"""
+from __future__ import annotations
+import argparse, os, sys
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+sys.path.insert(0, str(Path(__file__).parent))
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+from lib.firebird_reader import firebird_connect  # noqa: E402
+import pymysql, pymysql.cursors
+
+
+def norm(s, n=None):
+    if s is None: return None
+    s = str(s).strip()
+    if not s: return None
+    return s[:n] if n else s
+
+
+def dec(v):
+    try: return float(v) if v is not None else 0.0
+    except (ValueError, TypeError): return 0.0
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--alias", required=True)
+    p.add_argument("--target-business", type=int, required=True)
+    p.add_argument("--target", choices=["local", "prod"], default="local")
+    p.add_argument("--mysql-host", default=os.environ.get("MYSQL_HOST", "127.0.0.1"))
+    p.add_argument("--mysql-port", type=int, default=int(os.environ.get("MYSQL_PORT", "3306")))
+    p.add_argument("--mysql-user", default=os.environ.get("MYSQL_USER", "root"))
+    p.add_argument("--mysql-password", default=os.environ.get("MYSQL_PASSWORD", ""))
+    p.add_argument("--mysql-database", default=os.environ.get("MYSQL_DATABASE", "oimpresso"))
+    p.add_argument("--firebird-password", default=os.environ.get("FIREBIRD_PASSWORD", "masterkey"))
+    p.add_argument("--created-by", type=int, default=int(os.environ.get("CREATED_BY", "1")))
+    p.add_argument("--confirm", action="store_true")
+    args = p.parse_args()
+
+    if args.target == "prod" and not args.confirm:
+        print("[ERRO] --target prod requer --confirm", file=sys.stderr); return 2
+
+    print(f"== Import Tabelas de Preço (dinâmico) biz={args.target_business} ==")
+
+    stats = {"tabelas": 0, "spg_ins": 0, "cg_ins": 0, "precos_ins": 0,
+             "contacts_linked": 0, "precos_skip_no_prod": 0}
+
+    my = pymysql.connect(
+        host=args.mysql_host, port=args.mysql_port,
+        user=args.mysql_user, password=args.mysql_password,
+        database=args.mysql_database, charset="utf8mb4",
+        cursorclass=pymysql.cursors.DictCursor, autocommit=False,
+    )
+
+    try:
+        with firebird_connect(args.alias, password_override=args.firebird_password) as fb:
+            # ===== 1. PRODUTO_TABELA → selling_price_groups + customer_groups =====
+            print("\n[1/4] PRODUTO_TABELA → selling_price_groups + customer_groups")
+            cur = fb.cursor()
+            cur.execute("SELECT CODIGO, DESCRICAO FROM PRODUTO_TABELA WHERE ATIVO='S' ORDER BY CODIGO")
+            tabelas = [(r[0], norm(r[1], 191) or f"Tabela {r[0]}") for r in cur.fetchall()]
+            cur.close()
+            stats["tabelas"] = len(tabelas)
+            print(f"  Tabelas Delphi: {[(c, d) for c, d in tabelas]}")
+
+            # CODPRODUTO_TABELA Delphi → {spg_id, cg_id}
+            tabela_map = {}
+            with my.cursor() as w:
+                # lookups existentes
+                w.execute("SELECT id, name FROM selling_price_groups WHERE business_id=%s AND deleted_at IS NULL",
+                          (args.target_business,))
+                spg_by_name = {r["name"].upper(): r["id"] for r in w.fetchall()}
+                w.execute("SELECT id, name, selling_price_group_id FROM customer_groups WHERE business_id=%s",
+                          (args.target_business,))
+                cg_by_name = {r["name"].upper(): r for r in w.fetchall()}
+
+                for cod, desc in tabelas:
+                    key = desc.upper()
+                    # selling_price_group
+                    if key in spg_by_name:
+                        spg_id = spg_by_name[key]
+                    else:
+                        w.execute(
+                            "INSERT INTO selling_price_groups (name, business_id, created_at, updated_at) "
+                            "VALUES (%s, %s, NOW(), NOW())", (desc, args.target_business))
+                        spg_id = w.lastrowid
+                        stats["spg_ins"] += 1
+                    # customer_group apontando pro spg
+                    if key in cg_by_name:
+                        cg_id = cg_by_name[key]["id"]
+                        # garante FK correta
+                        w.execute("UPDATE customer_groups SET selling_price_group_id=%s WHERE id=%s",
+                                  (spg_id, cg_id))
+                    else:
+                        w.execute(
+                            "INSERT INTO customer_groups (business_id, name, amount, price_calculation_type, "
+                            "selling_price_group_id, created_by, created_at, updated_at) "
+                            "VALUES (%s, %s, 0, 'percentage', %s, %s, NOW(), NOW())",
+                            (args.target_business, desc, spg_id, args.created_by))
+                        cg_id = w.lastrowid
+                        stats["cg_ins"] += 1
+                    tabela_map[str(cod)] = {"spg": spg_id, "cg": cg_id}
+            my.commit()
+            print(f"  selling_price_groups INSERT: {stats['spg_ins']} · customer_groups INSERT: {stats['cg_ins']}")
+            print(f"  tabela_map: {tabela_map}")
+
+            # ===== 2. PRODUTO_TABELA_PRECO → variation_group_prices =====
+            print("\n[2/4] PRODUTO_TABELA_PRECO → variation_group_prices")
+            # lookup sku → variation_id
+            with my.cursor() as w:
+                w.execute(
+                    "SELECT p.sku, v.id AS vid FROM products p "
+                    "JOIN variations v ON v.product_id=p.id WHERE p.business_id=%s",
+                    (args.target_business,))
+                sku_to_var = {str(r["sku"]).strip(): r["vid"] for r in w.fetchall() if r["sku"]}
+            print(f"  variations indexadas: {len(sku_to_var)}")
+
+            cur = fb.cursor()
+            cur.execute("SELECT CODPRODUTO_TABELA, CODPRODUTO, VALOR FROM PRODUTO_TABELA_PRECO WHERE VALOR > 0")
+            batch = 0
+            with my.cursor() as w:
+                for r in cur:
+                    cod_tab, cod_prod, valor = str(r[0]), str(r[1]).strip(), dec(r[2])
+                    tm = tabela_map.get(cod_tab)
+                    vid = sku_to_var.get(cod_prod)
+                    if not tm or not vid or valor <= 0:
+                        stats["precos_skip_no_prod"] += 1
+                        continue
+                    # idempotente: delete + insert
+                    w.execute("DELETE FROM variation_group_prices WHERE variation_id=%s AND price_group_id=%s",
+                              (vid, tm["spg"]))
+                    w.execute(
+                        "INSERT INTO variation_group_prices (variation_id, price_group_id, price_inc_tax, created_at, updated_at) "
+                        "VALUES (%s, %s, %s, NOW(), NOW())", (vid, tm["spg"], valor))
+                    stats["precos_ins"] += 1
+                    batch += 1
+                    if batch >= 1000:
+                        my.commit(); batch = 0
+                        print(f"  ... precos_ins {stats['precos_ins']}", flush=True)
+            cur.close()
+            my.commit()
+            print(f"  variation_group_prices INSERT: {stats['precos_ins']} · skip(sem prod): {stats['precos_skip_no_prod']}")
+
+            # ===== 3. PESSOAS.CODPRODUTO_TABELA → contacts.customer_group_id =====
+            print("\n[3/4] PESSOAS.CODPRODUTO_TABELA → contacts.customer_group_id")
+            import re
+            cur = fb.cursor()
+            cur.execute("SELECT CNPJCPF, CODPRODUTO_TABELA FROM PESSOAS "
+                        "WHERE ATIVO='S' AND CODPRODUTO_TABELA IS NOT NULL AND CNPJCPF IS NOT NULL")
+            cnpj_to_cg = {}
+            for r in cur.fetchall():
+                cnpj = re.sub(r'\D', '', r[0] or '')
+                tm = tabela_map.get(str(r[1]))
+                if cnpj and tm:
+                    cnpj_to_cg[cnpj] = tm["cg"]
+            cur.close()
+            print(f"  PESSOAS com tabela definida: {len(cnpj_to_cg)}")
+
+            with my.cursor() as w:
+                w.execute("SELECT id, tax_number FROM contacts WHERE business_id=%s AND deleted_at IS NULL "
+                          "AND tax_number IS NOT NULL AND tax_number<>''", (args.target_business,))
+                rows = w.fetchall()
+            batch = 0
+            with my.cursor() as w:
+                for c in rows:
+                    cnpj = re.sub(r'\D', '', c["tax_number"] or '')
+                    cg = cnpj_to_cg.get(cnpj)
+                    if not cg:
+                        continue
+                    w.execute("UPDATE contacts SET customer_group_id=%s, updated_at=NOW() WHERE id=%s",
+                              (cg, c["id"]))
+                    if w.rowcount > 0:
+                        stats["contacts_linked"] += 1
+                    batch += 1
+                    if batch >= 1000:
+                        my.commit(); batch = 0
+            my.commit()
+            print(f"  contacts linkados a customer_group: {stats['contacts_linked']}")
+
+            # ===== 4. Validação =====
+            print("\n[4/4] Validação")
+            with my.cursor() as w:
+                w.execute("SELECT COUNT(*) c FROM selling_price_groups WHERE business_id=%s AND deleted_at IS NULL", (args.target_business,))
+                print(f"  selling_price_groups total: {w.fetchone()['c']}")
+                w.execute("SELECT COUNT(*) c FROM variation_group_prices vgp "
+                          "JOIN selling_price_groups s ON s.id=vgp.price_group_id WHERE s.business_id=%s", (args.target_business,))
+                print(f"  variation_group_prices total: {w.fetchone()['c']}")
+                w.execute("SELECT COUNT(*) c FROM contacts WHERE business_id=%s AND customer_group_id IS NOT NULL AND deleted_at IS NULL", (args.target_business,))
+                print(f"  contacts com customer_group: {w.fetchone()['c']}")
+    except Exception as e:
+        my.rollback()
+        print(f"[ERRO] {e}", file=sys.stderr)
+        raise
+    finally:
+        my.close()
+
+    print("\n== Relatório ==")
+    for k, v in stats.items():
+        print(f"  {k:22s}: {v}")
+    print("[OK] Tabelas de preço concluido")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/legacy-migration/probe-contacts-cols.py
+++ b/scripts/legacy-migration/probe-contacts-cols.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Probe focado: colunas de classificação/role em contacts + uso atual biz=164."""
+import os, pymysql
+pw = os.environ["MYSQL_PASSWORD"]
+con = pymysql.connect(host="127.0.0.1", port=33069, user="u906587222_oimpresso",
+                      password=pw, database="u906587222_oimpresso", charset="utf8mb4")
+cur = con.cursor()
+
+print("=== Colunas de tipo/classificação/custom em contacts ===")
+cur.execute(
+    "SELECT COLUMN_NAME, COLUMN_TYPE, IS_NULLABLE, COLUMN_DEFAULT "
+    "FROM information_schema.COLUMNS WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='contacts' "
+    "AND (COLUMN_NAME IN ('type','primary_role','is_customer','is_supplier','is_employee',"
+    "'is_representative','situacao','indicador_ie','regime','customer_group_id','contact_type',"
+    "'sub_status','contact_status','bloqueado') "
+    "OR COLUMN_NAME LIKE 'custom_field%') ORDER BY ORDINAL_POSITION"
+)
+for r in cur.fetchall():
+    print(f"  {r[0]:22} {r[1]:28} null={r[2]} def={r[3]}")
+
+print("=== Distribuição type/primary_role/flags biz=164 (vivos) ===")
+cur.execute(
+    "SELECT type, primary_role, is_customer, is_supplier, is_employee, is_representative, COUNT(*) "
+    "FROM contacts WHERE business_id=164 AND deleted_at IS NULL "
+    "GROUP BY type, primary_role, is_customer, is_supplier, is_employee, is_representative "
+    "ORDER BY COUNT(*) DESC LIMIT 20"
+)
+print("  type | primary_role | cust sup emp rep | qtd")
+for r in cur.fetchall():
+    print(f"  {str(r[0]):10} {str(r[1]):14} {r[2]} {r[3]} {r[4]} {r[5]}  | {r[6]}")
+
+print("=== custom_field1..10 preenchidos? (amostra biz=164) ===")
+for i in range(1, 11):
+    col = f"custom_field{i}"
+    try:
+        cur.execute(f"SELECT COUNT(*), COUNT(DISTINCT {col}) FROM contacts WHERE business_id=164 AND deleted_at IS NULL AND {col} IS NOT NULL AND {col}<>''")
+        c, d = cur.fetchone()
+        cur.execute(f"SELECT {col} FROM contacts WHERE business_id=164 AND deleted_at IS NULL AND {col} IS NOT NULL AND {col}<>'' LIMIT 1")
+        s = cur.fetchone()
+        print(f"  {col:16} preenchidos={c:5} distintos={d:5} ex={s[0] if s else None!r}")
+    except Exception as e:
+        print(f"  {col:16} ERRO {e}")
+
+print("=== FAN COM (651-1) atual no oimpresso ===")
+cur.execute(
+    "SELECT id, name, type, primary_role, is_customer, is_supplier, customer_group_id, "
+    "officeimpresso_codigo FROM contacts WHERE business_id=164 AND deleted_at IS NULL "
+    "AND officeimpresso_codigo='651-1'"
+)
+for r in cur.fetchall():
+    print("  ", r)
+con.close()
+print("PROBE OK")

--- a/scripts/legacy-migration/probe-tipos.py
+++ b/scripts/legacy-migration/probe-tipos.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Probe schema dos tipos de pessoa nos 2 lados (Firebird PESSOAS.IS_* + MySQL contacts flags)."""
+from __future__ import annotations
+import os, re, sys
+os.environ.setdefault("FIREBIRD_PY_DRIVER", "fdb")  # driver de produção (FB 3.0.12 servidor-crm)
+sys.path.insert(0, os.path.dirname(__file__))
+from lib.firebird_reader import firebird_connect, query  # noqa
+import pymysql
+
+# ---- Firebird: colunas IS_* / SEQUENCIA_* em PESSOAS ----
+ALIAS = os.environ.get("FB_ALIAS", "Martinho online")
+_ctx = firebird_connect(ALIAS, password_override="masterkey")
+con = _ctx.__enter__()
+cur = con.cursor()
+cur.execute(
+    "SELECT TRIM(rf.RDB$FIELD_NAME) FROM RDB$RELATION_FIELDS rf "
+    "WHERE rf.RDB$RELATION_NAME='PESSOAS' "
+    "AND (rf.RDB$FIELD_NAME LIKE 'IS\\_%' ESCAPE '\\' OR rf.RDB$FIELD_NAME LIKE 'SEQUENCIA\\_%' ESCAPE '\\') "
+    "ORDER BY rf.RDB$FIELD_NAME"
+)
+cols = [r[0] for r in cur.fetchall()]
+is_cols = sorted([c for c in cols if c.startswith("IS_")])
+print("=== PESSOAS IS_* cols ===")
+print(is_cols)
+
+# catálogo de tipos
+cur.execute("SELECT TRIM(CODIGO), TRIM(DESCRICAO) FROM PESSOAS_TIPO ORDER BY CODIGO")
+print("=== Catálogo PESSOAS_TIPO ===")
+catalogo = cur.fetchall()
+for c in catalogo:
+    print(f"  {c[0]:6} {c[1]}")
+
+# distribuição de flags na base inteira
+sel_cnt = ", ".join([f"SUM(CASE WHEN {c}='S' THEN 1 ELSE 0 END) AS {c}" for c in is_cols])
+cur.execute(f"SELECT COUNT(*) AS TOTAL, {sel_cnt} FROM PESSOAS")
+row = cur.fetchone()
+desc = [d[0] for d in cur.description]
+print("=== Distribuição IS_* (toda PESSOAS) ===")
+for name, val in zip(desc, row):
+    print(f"  {name:18} = {val}")
+
+# amostra FAN COM 651-1
+flagsel = ", ".join(is_cols)
+cur.execute(f"SELECT CODIGO, RAZAOSOCIAL, FANTASIA, {flagsel} FROM PESSOAS WHERE CODIGO='651-1'")
+r = cur.fetchone()
+if r:
+    d = [x[0] for x in cur.description]
+    print("=== FAN COM (651-1) flags ===")
+    for name, val in zip(d, r):
+        print(f"  {name:18} = {val!r}")
+_ctx.__exit__(None, None, None)
+
+# ---- MySQL: flags ADR 0188 em contacts ----
+pw = open("/tmp/_dbpass.txt").read().strip()
+mcon = pymysql.connect(host="127.0.0.1", port=33069, user="u906587222_oimpresso",
+                       password=pw, database="u906587222_oimpresso", charset="utf8mb4")
+mcur = mcon.cursor()
+mcur.execute(
+    "SELECT COLUMN_NAME, DATA_TYPE, COLUMN_DEFAULT FROM information_schema.COLUMNS "
+    "WHERE TABLE_SCHEMA=DATABASE() AND TABLE_NAME='contacts' "
+    "AND COLUMN_NAME IN ('is_customer','is_supplier','is_employee','is_representative','type','primary_role','officeimpresso_codigo')"
+)
+print("=== contacts flags (ADR 0188) ===")
+for r in mcur.fetchall():
+    print(f"  {r}")
+mcur.execute(
+    "SELECT SUM(is_customer), SUM(is_supplier), SUM(is_employee), SUM(is_representative), "
+    "GROUP_CONCAT(DISTINCT type), COUNT(*) "
+    "FROM contacts WHERE business_id=164 AND deleted_at IS NULL"
+)
+print("=== distribuição atual biz=164 (customers, suppliers, employees, reps, types, total) ===")
+print(" ", mcur.fetchone())
+mcon.close()
+print("PROBE OK")

--- a/scripts/legacy-migration/validate-migration.py
+++ b/scripts/legacy-migration/validate-migration.py
@@ -1,0 +1,172 @@
+"""
+Validate-migration — teste massivo comparando todos clientes Firebird vs oimpresso.
+
+Para cada campo: % fidelidade + amostra de divergências (top 20).
+Saída: stdout + CSV opcional em output/.
+
+Uso:
+    python validate-migration.py --alias "Martinho online" --target-business 164
+"""
+from __future__ import annotations
+import argparse, csv, os, re, sys
+from pathlib import Path
+
+if hasattr(sys.stdout, "reconfigure"):
+    sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+sys.path.insert(0, str(Path(__file__).parent))
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except ImportError:
+    pass
+
+from lib.firebird_reader import firebird_connect  # noqa: E402
+import pymysql, pymysql.cursors
+
+
+def digits(s):
+    return re.sub(r'\D', '', s or '')
+
+
+def norm(s):
+    if s is None: return ""
+    return str(s).strip().upper()
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--alias", required=True)
+    p.add_argument("--target-business", type=int, required=True)
+    p.add_argument("--mysql-host", default=os.environ.get("MYSQL_HOST", "127.0.0.1"))
+    p.add_argument("--mysql-port", type=int, default=int(os.environ.get("MYSQL_PORT", "3306")))
+    p.add_argument("--mysql-user", default=os.environ.get("MYSQL_USER", "root"))
+    p.add_argument("--mysql-password", default=os.environ.get("MYSQL_PASSWORD", ""))
+    p.add_argument("--mysql-database", default=os.environ.get("MYSQL_DATABASE", "oimpresso"))
+    p.add_argument("--firebird-password", default=os.environ.get("FIREBIRD_PASSWORD", "masterkey"))
+    p.add_argument("--csv", help="Output CSV path with all gaps")
+    args = p.parse_args()
+
+    print(f"== Validate migration biz={args.target_business} ==")
+
+    # 1. Read all PESSOAS ativas Firebird → dict cnpj → fields
+    print("\n[1/3] Lendo PESSOAS Firebird...")
+    pessoas = {}
+    with firebird_connect(args.alias, password_override=args.firebird_password) as fb:
+        cur = fb.cursor()
+        cur.execute(
+            "SELECT CODIGO, RAZAOSOCIAL, FANTASIA, CNPJCPF, INSCIDENT, CONTATO, "
+            "ENDERECO, BAIRRO, UF, FONE1, EMAIL "
+            "FROM PESSOAS WHERE ATIVO='S' AND CNPJCPF IS NOT NULL"
+        )
+        cols = [d[0] for d in cur.description]
+        for row in cur:
+            d = dict(zip(cols, row))
+            k = digits(d["CNPJCPF"])
+            if k:
+                pessoas.setdefault(k, d)
+        cur.close()
+    print(f"  PESSOAS ATIVAS com CNPJ: {len(pessoas)}")
+
+    # 2. Read all contacts oimpresso
+    print("\n[2/3] Lendo contacts oimpresso...")
+    my = pymysql.connect(
+        host=args.mysql_host, port=args.mysql_port,
+        user=args.mysql_user, password=args.mysql_password,
+        database=args.mysql_database, charset="utf8mb4",
+        cursorclass=pymysql.cursors.DictCursor,
+    )
+    contacts = {}
+    with my.cursor() as cur:
+        cur.execute(
+            "SELECT id, tax_number, name, fantasia, inscricao_estadual, contato, "
+            "rua, neighborhood, state, mobile, email "
+            "FROM contacts WHERE business_id=%s AND deleted_at IS NULL "
+            "AND tax_number IS NOT NULL AND tax_number<>''",
+            (args.target_business,),
+        )
+        for r in cur.fetchall():
+            k = digits(r["tax_number"])
+            if k:
+                contacts.setdefault(k, r)
+    my.close()
+    print(f"  contacts ativos com tax_number: {len(contacts)}")
+
+    # 3. Compare field by field
+    print("\n[3/3] Comparando...")
+    field_map = [
+        ("name", "RAZAOSOCIAL"),
+        ("fantasia", "FANTASIA"),
+        ("inscricao_estadual", "INSCIDENT"),
+        ("contato", "CONTATO"),
+        ("rua", "ENDERECO"),
+        ("neighborhood", "BAIRRO"),
+        ("state", "UF"),
+        ("mobile", "FONE1"),
+        ("email", "EMAIL"),
+    ]
+
+    in_both = set(pessoas) & set(contacts)
+    only_fb = set(pessoas) - set(contacts)
+    only_my = set(contacts) - set(pessoas)
+    print(f"  CNPJs em AMBOS         : {len(in_both)}")
+    print(f"  CNPJs SÓ Firebird (faltam migrar): {len(only_fb)}")
+    print(f"  CNPJs SÓ oimpresso (não estão FB ATIVO): {len(only_my)}")
+
+    results = {fb_field: {"match": 0, "diff": 0, "both_empty": 0, "fb_empty_my_set": 0, "fb_set_my_empty": 0}
+                for _, fb_field in field_map}
+    gaps = []
+
+    for cnpj in in_both:
+        p = pessoas[cnpj]
+        c = contacts[cnpj]
+        for my_field, fb_field in field_map:
+            v_fb = norm(p.get(fb_field))
+            v_my = norm(c.get(my_field))
+            r = results[fb_field]
+            if not v_fb and not v_my:
+                r["both_empty"] += 1
+            elif v_fb == v_my:
+                r["match"] += 1
+            elif not v_fb and v_my:
+                r["fb_empty_my_set"] += 1
+            elif v_fb and not v_my:
+                r["fb_set_my_empty"] += 1
+                if len(gaps) < 1000:
+                    gaps.append({"cnpj": cnpj, "field": fb_field, "type": "fb_set_my_empty",
+                                 "firebird": (p.get(fb_field) or '')[:100],
+                                 "oimpresso": "", "name": (p.get("RAZAOSOCIAL") or '')[:60]})
+            else:
+                r["diff"] += 1
+                if len(gaps) < 1000:
+                    gaps.append({"cnpj": cnpj, "field": fb_field, "type": "diff",
+                                 "firebird": str(p.get(fb_field) or '')[:100],
+                                 "oimpresso": str(c.get(my_field) or '')[:100],
+                                 "name": (p.get("RAZAOSOCIAL") or '')[:60]})
+
+    # Print report
+    print(f"\n{'='*70}")
+    print(f"{'Campo (Delphi)':<20} {'Match%':>8} {'Match':>8} {'Diff':>7} {'FB→Vazio':>10} {'Vazio→OI':>10}")
+    print(f"{'='*70}")
+    for _, fb_field in field_map:
+        r = results[fb_field]
+        total = r["match"] + r["diff"] + r["fb_set_my_empty"] + r["fb_empty_my_set"]
+        pct = 100.0 * r["match"] / total if total else 0
+        print(f"{fb_field:<20} {pct:>7.1f}% {r['match']:>8} {r['diff']:>7} {r['fb_set_my_empty']:>10} {r['fb_empty_my_set']:>10}")
+    print(f"{'='*70}")
+
+    # Save CSV
+    out_path = args.csv or f"scripts/legacy-migration/output/validation-gaps-biz{args.target_business}.csv"
+    Path(os.path.dirname(out_path)).mkdir(parents=True, exist_ok=True)
+    with open(out_path, "w", encoding="utf-8", newline="") as f:
+        w = csv.DictWriter(f, fieldnames=["cnpj","name","field","type","firebird","oimpresso"])
+        w.writeheader()
+        w.writerows(gaps)
+    print(f"\n[CSV] {out_path}  ({len(gaps)} gaps sample)")
+
+    print(f"\n[OK] Validate concluido")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/legacy-migration/validate-tipos.py
+++ b/scripts/legacy-migration/validate-tipos.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+validate-tipos.py — Teste de fidelidade da migração de tipos.
+Compara, para CADA contato migrado, as flags IS_* do Firebird PESSOAS vs
+is_customer/is_supplier/is_employee/is_representative no oimpresso.
+Reporta divergências (deveria ser ZERO). Também valida custom_field3 (classif fiscal).
+"""
+from __future__ import annotations
+import argparse, os, sys
+os.environ.setdefault("FIREBIRD_PY_DRIVER", "fdb")
+sys.path.insert(0, os.path.dirname(__file__))
+from lib.firebird_reader import firebird_connect  # noqa
+import pymysql, pymysql.cursors  # noqa
+
+
+def main() -> int:
+    p = argparse.ArgumentParser()
+    p.add_argument("--alias", default="Martinho online")
+    p.add_argument("--target-business", type=int, default=164)
+    p.add_argument("--firebird-password", default=os.environ.get("FIREBIRD_PASSWORD", "masterkey"))
+    args = p.parse_args()
+    biz = args.target_business
+
+    # importa a MESMA lógica de classificação do enricher (single source of truth)
+    sys.path.insert(0, os.path.dirname(__file__))
+    import importlib.util
+    spec = importlib.util.spec_from_file_location(
+        "enrich_tipos", os.path.join(os.path.dirname(__file__), "enrich-tipos.py"))
+    et = importlib.util.module_from_spec(spec); spec.loader.exec_module(et)  # type: ignore
+
+    flagsel = ", ".join(f"IS_{c}" for c in et.ALL_CODES)
+    print("[1/2] Lendo PESSOAS Firebird...")
+    pessoas = {}
+    with firebird_connect(args.alias, password_override=args.firebird_password) as fb:
+        cur = fb.cursor(); cur.execute(f"SELECT CODIGO, {flagsel} FROM PESSOAS")
+        cols = [d[0] for d in cur.description]
+        for r in cur:
+            d = dict(zip(cols, r))
+            cod = str(d.get("CODIGO")).strip() if d.get("CODIGO") is not None else ""
+            if cod:
+                pessoas[cod] = d
+        cur.close()
+    print(f"  PESSOAS: {len(pessoas)}")
+
+    con = pymysql.connect(host=os.environ.get("MYSQL_HOST", "127.0.0.1"),
+                          port=int(os.environ.get("MYSQL_PORT", "3306")),
+                          user=os.environ.get("MYSQL_USER", "root"),
+                          password=os.environ.get("MYSQL_PASSWORD", ""),
+                          database=os.environ.get("MYSQL_DATABASE", "oimpresso"),
+                          charset="utf8mb4", cursorclass=pymysql.cursors.DictCursor)
+    print("[2/2] Comparando contacts...")
+    with con.cursor() as cur:
+        cur.execute(
+            "SELECT id, officeimpresso_codigo, name, is_customer, is_supplier, is_employee, "
+            "is_representative, primary_role, type, custom_field3 FROM contacts "
+            "WHERE business_id=%s AND deleted_at IS NULL "
+            "AND officeimpresso_codigo IS NOT NULL AND officeimpresso_codigo<>''", (biz,))
+        rows = cur.fetchall()
+    con.close()
+
+    checked = mism = no_src = 0
+    diffs = []
+    FIELDS = ("is_customer", "is_supplier", "is_employee", "is_representative")
+    for c in rows:
+        cod = str(c["officeimpresso_codigo"]).strip()
+        src = pessoas.get(cod)
+        if not src:
+            no_src += 1
+            continue
+        checked += 1
+        expect = et.classify(src)
+        bad = [f for f in FIELDS if int(c[f]) != int(expect[f])]
+        if c["primary_role"] != expect["primary_role"] or c["type"] != expect["type"]:
+            bad.append("role/type")
+        if (c["custom_field3"] or None) != expect["classif"]:
+            bad.append("classif")
+        if bad:
+            mism += 1
+            if len(diffs) < 20:
+                diffs.append((cod, c["name"][:24], bad,
+                              {f: int(c[f]) for f in FIELDS}, c["custom_field3"],
+                              {f: expect[f] for f in FIELDS}, expect["classif"]))
+
+    print("\n=== RESULTADO ===")
+    print(f"  contacts c/ codigo : {len(rows)}")
+    print(f"  validados (c/ fonte): {checked}")
+    print(f"  sem fonte Firebird : {no_src}")
+    print(f"  DIVERGÊNCIAS       : {mism}")
+    for d in diffs:
+        print("   ", d)
+    print("\n", "[OK] FIDELIDADE 100%" if mism == 0 else f"[FALHA] {mism} divergencias")
+    return 0 if mism == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Intent
Versiona o trabalho de migração WR Comercial (Firebird) → oimpresso biz=164 desta sessão. **Os dados já estão aplicados em prod**; este PR versiona o código (migration + scripts) para eliminar drift.

## O que entra
- **Tipos de cliente** (`enrich-tipos.py`): `PESSOAS.IS_*` → flags ADR 0188 (`is_customer/is_supplier/is_employee/is_representative`) + `primary_role` + `type` + classificação fiscal (Fabricante-Indústria, Comércio/Revenda, Consumidor Final…) em `custom_field3`. **9771 contatos, fidelidade 100%** (`validate-tipos.py`: 0 divergências Firebird × MySQL).
- **Mensagem de venda** (migration `add_mensagem_venda` + `enrich-mensagem-venda.py`): `PESSOAS.MENSAGEM_PARA_VENDA` → coluna dedicada `contacts.mensagem_venda` TEXT, **campo distinto de `obs_comercial`** (semântica diferente: alerta ativo ao vendedor vs nota de cadastro). 144 contatos, texto completo (corrige truncamento de 191 em `custom_field1`).
- **Anti-fantasma** (`enrich-contacts.py` + `import-contacts-from-venda.py`): `name` nunca vazio — cadeia `RAZAOSOCIAL→FANTASIA/CONTATO` + `COALESCE/NULLIF`. Corrige o incidente HEINIG (contato com nome vazio).
- **Testes de fidelidade massivos**: `validate-tipos.py`, `validate-migration.py` — comparam todos os contatos origem × destino.
- Scripts de apoio do pipeline: `import-tabelas-preco.py`, `enrich-contacts-v2.py`, `probe-*`.

## Migration
`2026_05_28_120000_add_mensagem_venda_to_contacts.php` — aditiva, idempotente (`hasColumn`), nullable, reversível. Em prod já aplicada via ALTER (idempotente = no-op).

## Refs
ADR 0188 (multi-type flags) · ADR 0197 (absorção PESSOAS legacy) · CYCLE-06 Martinho biz=164.

🤖 Generated with [Claude Code](https://claude.com/claude-code)