### PR TITLE
fix(tests): stop Pest TestCaseAlreadyInUse double-binding + parse error in tests/Feature

### DIFF
--- a/tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest.php
+++ b/tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-uses(Tests\TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * ARCHITECTURE TEST — Anti-regressão GLOBAL hardcode business_id.

--- a/tests/Feature/Docs/WaveZ2DocumentationGuardTest.php
+++ b/tests/Feature/Docs/WaveZ2DocumentationGuardTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-uses(Tests\TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * Wave Z-2 Documentation GUARD — Integração Vendas × Oficina (ADR 0192).

--- a/tests/Feature/Domain/Fsm/InitialStageResolverTest.php
+++ b/tests/Feature/Domain/Fsm/InitialStageResolverTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use App\Domain\Fsm\Services\InitialStageResolver;
 use App\Transaction;
 
-uses(Tests\TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * Service InitialStageResolver — testa lógica de mapeamento status legacy → stage FSM.

--- a/tests/Feature/Modules/OficinaAuto/CacambaFsmSeederTest.php
+++ b/tests/Feature/Modules/OficinaAuto/CacambaFsmSeederTest.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Schema;
 use Modules\Jana\Scopes\ScopeByBusiness;
 use Modules\OficinaAuto\Database\Seeders\OficinaAutoFsmSeeder;
 
-uses(Tests\TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * Seeder OficinaAutoFsmSeeder — 2 processos FSM caçamba (locacao + manutencao).

--- a/tests/Feature/Modules/OficinaAuto/CacambaSchemaTest.php
+++ b/tests/Feature/Modules/OficinaAuto/CacambaSchemaTest.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Schema;
 use Modules\OficinaAuto\Entities\ServiceOrder;
 use Modules\OficinaAuto\Entities\Vehicle;
 
-uses(Tests\TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * Schema + accessors caçamba avulsa estacionária — leitura PRÉ-ADR 0194.

--- a/tests/Feature/Modules/OficinaAuto/KanbanDragDropTest.php
+++ b/tests/Feature/Modules/OficinaAuto/KanbanDragDropTest.php
@@ -18,7 +18,7 @@ use Modules\OficinaAuto\Entities\Vehicle;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
 
-uses(Tests\TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * Kanban Produção · Oficina — Drag-and-Drop entre colunas (Martinho 13/maio).

--- a/tests/Feature/Modules/OficinaAuto/ProducaoOficinaIndexTest.php
+++ b/tests/Feature/Modules/OficinaAuto/ProducaoOficinaIndexTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Modules\OficinaAuto\Entities\Vehicle;
 
-uses(Tests\TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * ProducaoOficinaController@index — Kanban estado caçambas (demo Martinho 13/maio).

--- a/tests/Feature/Modules/OficinaAuto/ProducaoOficinaRichUITest.php
+++ b/tests/Feature/Modules/OficinaAuto/ProducaoOficinaRichUITest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Modules\OficinaAuto\Entities\Vehicle;
 
-uses(Tests\TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * ProducaoOficinaController@index — payload V2 RICA (espelha visual-source.html).

--- a/tests/Feature/Modules/OficinaAuto/ServiceOrderFsmActionControllerTest.php
+++ b/tests/Feature/Modules/OficinaAuto/ServiceOrderFsmActionControllerTest.php
@@ -21,7 +21,7 @@ use Modules\OficinaAuto\Entities\Vehicle;
 use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
 
-uses(Tests\TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * ServiceOrderFsmActionController — Wave 7-A wire-up FSM (espelha SaleFsmActionController).

--- a/tests/Feature/Modules/OficinaAuto/ServiceOrdersIndexTest.php
+++ b/tests/Feature/Modules/OficinaAuto/ServiceOrdersIndexTest.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Schema;
 use Modules\OficinaAuto\Entities\ServiceOrder;
 use Modules\OficinaAuto\Entities\Vehicle;
 
-uses(Tests\TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * ServiceOrders Index Dashboard — KPIs, filtros e cross-tenant.

--- a/tests/Feature/Modules/OficinaAuto/VehiclesIndexKpisTest.php
+++ b/tests/Feature/Modules/OficinaAuto/VehiclesIndexKpisTest.php
@@ -6,7 +6,7 @@ use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 use Modules\OficinaAuto\Entities\Vehicle;
 
-uses(Tests\TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * VehicleController@index — KPIs + filter + cross-tenant (US-OFICINA-001 evoluída).

--- a/tests/Feature/OtelHelperTest.php
+++ b/tests/Feature/OtelHelperTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 use App\Util\OtelHelper;
 
-uses(Tests\TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * OtelHelper — facade zero-cost pra instrumentation OTel.

--- a/tests/Feature/PhpStan/NoMissingTenantScopeRuleTest.php
+++ b/tests/Feature/PhpStan/NoMissingTenantScopeRuleTest.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  *  3. Registrada em phpstan.neon.dist via services + tag phpstan.rules.rule
  *  4. getNodeType retorna ClassMethod::class
  *  5. ELOQUENT_METHODS lista contém query/where/find/all/create/etc
- *  6. Path filter restrito a Modules/*/Http/Controllers/*Controller.php
+ *  6. Path filter restrito a Modules/{mod}/Http/Controllers/{Nome}Controller.php
  *  7. Skip métodos privados + __construct
  *  8. Heurística business_id mention aceita 3 formas
  *  9. RuleErrorBuilder usa identifier 'oimpresso.missingTenantScope'

--- a/tests/Feature/Ragas/BriefDiarioFaithfulnessTest.php
+++ b/tests/Feature/Ragas/BriefDiarioFaithfulnessTest.php
@@ -22,9 +22,8 @@ declare(strict_types=1);
  */
 
 use Modules\Jana\Services\Ragas\RagasJudgeService;
-use Tests\TestCase;
 
-uses(TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * Dataset canônico — perguntas com ground_truth conhecida.

--- a/tests/Feature/Ragas/KbAnswerRelevancyTest.php
+++ b/tests/Feature/Ragas/KbAnswerRelevancyTest.php
@@ -19,9 +19,8 @@ declare(strict_types=1);
  */
 
 use Modules\Jana\Services\Ragas\RagasJudgeService;
-use Tests\TestCase;
 
-uses(TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 function ragasKbQueries(): array
 {

--- a/tests/Feature/Ragas/RagasJudgeServiceTest.php
+++ b/tests/Feature/Ragas/RagasJudgeServiceTest.php
@@ -20,9 +20,8 @@ declare(strict_types=1);
  */
 
 use Modules\Jana\Services\Ragas\RagasJudgeService;
-use Tests\TestCase;
 
-uses(TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 it('retorna mock scores quando enableMock() é chamado', function () {
     $judge = new RagasJudgeService();

--- a/tests/Feature/Schema/TransactionsSourceOsRefSchemaTest.php
+++ b/tests/Feature/Schema/TransactionsSourceOsRefSchemaTest.php
@@ -6,7 +6,7 @@ use App\Transaction;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-uses(Tests\TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * Schema GUARDs — Onda 1 do plano F3 Integração Vendas × Oficina (ADR 0192).

--- a/tests/Feature/Sells/CommissionSplitEditorTest.php
+++ b/tests/Feature/Sells/CommissionSplitEditorTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
-uses(Tests\TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * ADR 0192 Onda 2 follow-up — Editor UI commission_split (mecânico/balcão).

--- a/tests/Feature/Sells/CriarOsPorVendaTest.php
+++ b/tests/Feature/Sells/CriarOsPorVendaTest.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Schema;
 use Modules\OficinaAuto\Entities\ServiceOrder;
 use Modules\OficinaAuto\Entities\Vehicle;
 
-uses(Tests\TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * US-OFICINA-OS-LINK — CriarOsPorVendaService coverage.

--- a/tests/Feature/Sells/SellsFilterHintStaleTest.php
+++ b/tests/Feature/Sells/SellsFilterHintStaleTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-uses(Tests\TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * Fix bug 2026-05-18 "vendas só aparecem até dia 14" — testes estruturais.

--- a/tests/Feature/Sidebar/Biz4RotaLivreSidebarTest.php
+++ b/tests/Feature/Sidebar/Biz4RotaLivreSidebarTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-uses(Tests\TestCase::class);
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')). NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
 
 /**
  * Anti-regressão hardcode biz=N — Wagner regra 2026-05-18 IRREVOGÁVEL.


### PR DESCRIPTION
## Problem
The full Pest suite (`php artisan test` / `vendor/bin/pest` with no path filter) failed immediately at bootstrap:

> ERROR Test case [Tests\TestCase] can not be used. The folder [tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest.php] already uses the test case [Tests\TestCase].

`tests/Pest.php:5` already binds `Tests\TestCase` to the entire `Feature/` folder via `uses(TestCase::class)->in('Feature')`. **20** files under `tests/Feature/` *also* declared a file-level `uses(Tests\TestCase::class)`. Pest 4 (v4.6.3) treats a second binding of the base test-case class as a fatal `TestCaseAlreadyInUse` (`TestRepository.php:190`) — aborting the whole suite before any test ran. Pest stops at the first offender (Architecture), so this affected every no-filter run, not just that one file.

## Fix
- Removed the redundant `uses(Tests\TestCase::class)` from all **20** files, replacing each with an explanatory comment matching the convention already used by `Expense/MultiTenantSqlGuardTest.php`, `Home/HomeIndexInertiaTest.php`, etc.
- Dropped the now-unused `use Tests\TestCase;` import in the 3 `Ragas/*` files.
- Trait `uses()` (`DatabaseTransactions` / `RefreshDatabase`) untouched — Pest applies traits via a different path and they never conflict.
- **Also** fixes a pre-existing parse error masked behind the crash: `tests/Feature/PhpStan/NoMissingTenantScopeRuleTest.php` had `Modules/*/Http/Controllers/*Controller.php` inside a `/** */` docblock; the `*/` closed the comment early → `unexpected token "const"`. Rephrased with `{mod}`/`{Nome}` placeholders.

`KB` module tests (the only module `Pest.php` covers via `->in()`) were already clean. Other `Modules/*/Tests/` correctly keep their own `uses()` and are untouched.

## Validation
- `pest tests/Feature/Architecture` → loads & runs (binding error gone).
- `pest --list-tests` → no binding error suite-wide.
- `Modules/ProjectMgmt/Tests/Feature` → **53 passed, 52 skipped** (skips are env: no `users` table in the ad-hoc SQLite db).
- All 21 changed files `php -l` clean.

## Out of scope (pre-existing, follow-up)
Fixing the binding error unmasked a separate systemic blocker for full-suite runs: global const/function name collisions across test files (fatal `Cannot redeclare function readEditController()` between `Sells/Wave1EditBaselineTest.php` and `Purchase/Wave2EditBaselineTest.php`, plus 16 duplicate global consts). Tracked separately. Path/module-scoped runs work now.

Discovered 2026-05-29 running the ProjectMgmt suite; pre-existing, not a regression of the Triage/Inbox work (d1314a5e7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)