### PR TITLE
feat(hooks): preflight-new-capability — gate anti-reinvenção (saber o que existe antes)

### DIFF
--- a/.claude/hooks/preflight-new-capability.ps1
+++ b/.claude/hooks/preflight-new-capability.ps1
@@ -1,0 +1,47 @@
+# Hook PreToolUse — AVISA ao CRIAR capability NOVA sem checar o que já existe.
+#
+# Causa raiz das reinvenções (sessão 2026-05-29): construí um DriftChecker/--check
+# bespoke quando o framework ADR 0216 já existia (3ª reinvenção da sessão). Este hook
+# dispara no MOMENTO EXATO da criação de um arquivo de capability nova e força o reflexo
+# "saber o que existe antes" (skills como-integrar + mcp-first).
+#
+# Lê JSON stdin: { "tool_name": "Write", "tool_input": { "file_path": "...", "content": "..." } }
+# Só dispara em Write de ARQUIVO NOVO (não existe) que casa padrão de capability, sob Modules/ ou app/.
+# Advisory (permissionDecision=allow) — aparece no contexto na hora, não bloqueia.
+
+$ErrorActionPreference = 'Stop'
+$raw = [Console]::In.ReadToEnd()
+try { $p = $raw | ConvertFrom-Json } catch { exit 0 }
+
+if ($p.tool_name -ne 'Write') { exit 0 }
+$path = [string]$p.tool_input.file_path
+if (-not $path) { exit 0 }
+
+# Padrão de capability -> framework/registry que JÁ existe (não reinventar)
+$caps = [ordered]@{
+    'Checker\.php$'    = "DriftChecker (ADR 0216): implemente Modules\Governance\Contracts\DriftChecker + registre em config('governance.drift_checkers'). NAO crie comando/cron/alerta bespoke."
+    'Reconciler\.php$' = "Reconciler JA existe (ChannelsReconcilerCommand WhatsApp); governance:audit ja orquestra. NAO crie orquestrador novo."
+    'Tool\.php$'       = "MCP Tools vivem em Modules\Jana\Mcp\Tools\ + registry OimpressoMcpServer. Veja as tools existentes."
+    'Command\.php$'    = "rode decisions-search '<dominio>' + grep comando similar. Pode ja existir (ou ser DriftChecker)."
+    'Service\.php$'    = "grep Service similar em Modules/**/Services antes de criar."
+}
+
+$reason = $null
+foreach ($pat in $caps.Keys) {
+    if ($path -match $pat -and ($path -match 'Modules[\\/]' -or $path -match 'app[\\/]')) {
+        if (-not (Test-Path -LiteralPath $path)) { $reason = $caps[$pat] }  # só arquivo NOVO
+        break
+    }
+}
+
+if (-not $reason) { exit 0 }
+
+@{
+    hookSpecificOutput = @{
+        hookEventName            = 'PreToolUse'
+        permissionDecision       = 'allow'
+        permissionDecisionReason = "[oimpresso-anti-reinvencao] Criando capability NOVA: $path. ANTES de codar, saiba o que JA existe -> $reason  (licao 2026-05-29: bespoke duplicou framework existente). Skills: como-integrar, mcp-first."
+    }
+} | ConvertTo-Json -Compress -Depth 3
+
+exit 0

--- a/.claude/hooks/preflight-new-capability.test.ps1
+++ b/.claude/hooks/preflight-new-capability.test.ps1
@@ -1,0 +1,64 @@
+# Smoke test -- preflight-new-capability.ps1 (anti-reinvenção)
+
+$ErrorActionPreference = 'Stop'
+$here = Split-Path $MyInvocation.MyCommand.Path -Parent
+$hook = Join-Path $here 'preflight-new-capability.ps1'
+
+$failures = 0
+$total = 0
+
+function Test-Hook {
+    param([string]$Name, [hashtable]$Payload, [bool]$ExpectWarn)
+
+    $script:total++
+    $json = $Payload | ConvertTo-Json -Compress -Depth 10
+    $tmp = [System.IO.Path]::GetTempFileName()
+    [System.IO.File]::WriteAllText($tmp, $json, (New-Object System.Text.UTF8Encoding $false))
+    $output = & cmd /c "powershell -NoProfile -ExecutionPolicy Bypass -File `"$hook`" < `"$tmp`" 2>NUL"
+    Remove-Item $tmp -Force -ErrorAction SilentlyContinue
+
+    $joined = ($output | Out-String)
+    $warned = [bool]($joined -match 'oimpresso-anti-reinvencao')
+    if ($warned -eq $ExpectWarn) {
+        Write-Host "  OK  $Name (warn=$warned)"
+    } else {
+        Write-Host "  FAIL $Name -- expected warn=$ExpectWarn got=$warned" -ForegroundColor Red
+        $script:failures++
+    }
+}
+
+Write-Host "=== preflight-new-capability smoke ==="
+
+# 1. Checker NOVO (não existe) → avisa (o bug recorrente)
+Test-Hook 'Checker novo avisa' @{
+    tool_name = 'Write'
+    tool_input = @{ file_path = 'D:\oimpresso.com\Modules\Governance\Services\Checkers\FooBarChecker.php'; content = '<?php' }
+} $true
+
+# 2. Reconciler novo → avisa
+Test-Hook 'Reconciler novo avisa' @{
+    tool_name = 'Write'
+    tool_input = @{ file_path = 'D:\oimpresso.com\Modules\Jana\Services\FooReconciler.php'; content = '<?php' }
+} $true
+
+# 3. Arquivo NÃO-capability (ex Page.tsx) → silêncio
+Test-Hook 'nao-capability silencioso' @{
+    tool_name = 'Write'
+    tool_input = @{ file_path = 'D:\oimpresso.com\resources\js\Pages\Foo\Index.tsx'; content = 'x' }
+} $false
+
+# 4. Arquivo capability que JÁ EXISTE (edit, não criar) → silêncio
+Test-Hook 'capability existente (edit) silencioso' @{
+    tool_name = 'Write'
+    tool_input = @{ file_path = 'D:\oimpresso.com\Modules\Governance\Services\Checkers\AdrLinksChecker.php'; content = 'x' }
+} $false
+
+# 5. tool != Write → silêncio
+Test-Hook 'Read silencioso' @{
+    tool_name = 'Read'
+    tool_input = @{ file_path = 'D:\oimpresso.com\Modules\X\Services\YChecker.php' }
+} $false
+
+Write-Host ""
+if ($failures -eq 0) { Write-Host "PASS ($total testes)" -ForegroundColor Green; exit 0 }
+else { Write-Host "FAIL ($failures/$total)" -ForegroundColor Red; exit 1 }

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -59,6 +59,10 @@
           },
           {
             "type": "command",
+            "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/preflight-new-capability.ps1"
+          },
+          {
+            "type": "command",
             "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/block-bom-encoding.ps1"
           },
           {


### PR DESCRIPTION
Wagner: 'antes de qualquer erro novo vai ter que saber o que existe?'. Causa raiz das reinvenções (DriftChecker bespoke 3×): não buscar o framework existente antes de criar capability. Hook PreToolUse(Write) dispara ao criar *Checker/*Reconciler/*Tool/*Command/*Service NOVO → injeta o framework canônico a reusar (DriftChecker ADR 0216, etc). Advisory, silencioso em edit/não-capability. +5 smoke tests (5/5). Honesto: B ataca a causa das reinvenções; estado-perdido ainda precisa do A (reconcilers).