### PR TITLE
feat(governance): DeployDriftChecker — código deployado != main (fecha o 1302-commits cego)

### DIFF
--- a/Modules/Governance/Config/config.php
+++ b/Modules/Governance/Config/config.php
@@ -78,6 +78,7 @@ return [
         \Modules\Governance\Services\Checkers\ChartersFreshnessChecker::class,   // ADR 0220 — adapter charter:audit
         \Modules\Governance\Services\Checkers\RoutesZombieChecker::class,        // ADR 0221
         \Modules\Governance\Services\Checkers\MeilisearchSettingsDriftChecker::class, // 2026-05-29 — embedder do índice se perdeu 2× (recall degrada)
+        \Modules\Governance\Services\Checkers\DeployDriftChecker::class,         // 2026-05-29 — código deployado != main (1302-commits cego)
     ],
 
     /*

--- a/Modules/Governance/Services/Checkers/DeployDriftChecker.php
+++ b/Modules/Governance/Services/Checkers/DeployDriftChecker.php
@@ -1,0 +1,206 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Governance\Services\Checkers;
+
+use Illuminate\Support\Facades\Cache;
+use Modules\Governance\Contracts\DriftChecker;
+use Modules\Governance\Services\DriftCheckResult;
+use Modules\Governance\Services\DriftFinding;
+
+/**
+ * DeployDriftChecker — código deployado != GitHub main (ADR 0216).
+ *
+ * Fecha a pior dimensão do reconcile (estado-da-arte 2026-05-29, nota 20): o container
+ * MCP ficou 1302 commits atrás de main e era CEGO até quebrar. Generaliza o padrão do
+ * `Whatsapp\...\DaemonSourceDriftCheckCommand` (deploy-source drift) pro app inteiro,
+ * plugado no framework DriftChecker (NÃO comando bespoke).
+ *
+ * Fontes de verdade (sem git binary — container não tem; sem token — repo privado):
+ *  - deployado: lê `.git/HEAD` + refs (arquivo) → SHA do código que está rodando.
+ *  - main: `Cache deploy:latest_main_sha` gravado pelo webhook GitHub→MCP a cada push
+ *    em main (SyncMemoryWebhookController). Fallback: `.git/refs/remotes/origin/main`
+ *    (fetchado no último deploy — pode ser stale, mas melhor que nada).
+ *
+ * Severity high (drift de deploy = bug oculto) · enforcement warn · cadence daily.
+ * Multi-env (Hostinger via /health) = follow-up; v1 cobre o ambiente onde roda (CT 100).
+ */
+final class DeployDriftChecker implements DriftChecker
+{
+    public const CACHE_KEY = 'deploy:latest_main_sha';
+
+    public function name(): string
+    {
+        return 'deploy_drift';
+    }
+
+    public function description(): string
+    {
+        return 'Código deployado != GitHub main (o "N commits atrás" silencioso)';
+    }
+
+    public function tags(): array
+    {
+        return ['tier_1', 'deploy', 'infra'];
+    }
+
+    public function severity(): string
+    {
+        return 'high';
+    }
+
+    public function enforcement(): string
+    {
+        return 'warn';
+    }
+
+    public function cadence(): string
+    {
+        return 'daily';
+    }
+
+    public function check(array $opts = []): DriftCheckResult
+    {
+        $start = microtime(true);
+        $base  = base_path();
+
+        $deployed = $this->deployedSha($base);
+        $main     = $this->latestMainSha($base);
+
+        $duration = (int) round((microtime(true) - $start) * 1000);
+
+        $findings = $this->analisar($deployed, $main);
+
+        if ($findings === []) {
+            return DriftCheckResult::clean($this->name(), $duration, [
+                'deployed' => $deployed,
+                'main'     => $main,
+            ]);
+        }
+
+        return DriftCheckResult::drifted($this->name(), $findings, $duration, [
+            'deployed' => $deployed,
+            'main'     => $main,
+        ]);
+    }
+
+    /**
+     * Decide o finding a partir do SHA deployado × main. Puro/testável.
+     *
+     * @return DriftFinding[]
+     */
+    public function analisar(?string $deployed, ?string $main): array
+    {
+        // Sem como saber o deployado → finding de baixa severidade (config/.git ausente).
+        if ($deployed === null) {
+            return [new DriftFinding(
+                target: 'deploy',
+                target_type: 'deploy',
+                severity: 'low',
+                message: 'Não consegui ler o SHA deployado (.git/HEAD). Deploy drift não verificável.',
+                evidence: ['deployed' => null],
+            )];
+        }
+
+        // Main desconhecido (webhook ainda não gravou + sem origin/main ref) → info, não trava.
+        if ($main === null) {
+            return [new DriftFinding(
+                target: 'deploy',
+                target_type: 'deploy',
+                severity: 'info',
+                message: 'SHA de main desconhecido ainda (sem push registrado pelo webhook). Reverifica no próximo push.',
+                evidence: ['deployed' => $deployed, 'main' => null],
+            )];
+        }
+
+        if (! $this->mesmoSha($deployed, $main)) {
+            return [new DriftFinding(
+                target: 'deploy',
+                target_type: 'deploy',
+                severity: 'high',
+                message: "Código deployado ({$deployed}) != GitHub main ({$main}). "
+                    .'Deploy atrasado — `git reset --hard origin/main` + composer + octane:reload (ver INFRA-ACESSO-CANON).',
+                evidence: ['deployed' => $deployed, 'main' => $main],
+            )];
+        }
+
+        return [];
+    }
+
+    /**
+     * SHA do código deployado — lê .git/HEAD + refs/packed-refs (sem git binary).
+     */
+    public function deployedSha(string $base): ?string
+    {
+        $headFile = $base.'/.git/HEAD';
+        if (! is_file($headFile)) {
+            return null;
+        }
+        $head = trim((string) file_get_contents($headFile));
+
+        if (str_starts_with($head, 'ref: ')) {
+            return $this->resolverRef($base, trim(substr($head, 5)));
+        }
+
+        // HEAD destacado (SHA direto)
+        return $this->ehSha($head) ? $head : null;
+    }
+
+    /**
+     * SHA de main: cache do webhook (fresco) OU origin/main ref (stale fallback).
+     */
+    public function latestMainSha(string $base): ?string
+    {
+        $cached = Cache::get(self::CACHE_KEY);
+        if (is_string($cached) && $this->ehSha($cached)) {
+            return $cached;
+        }
+
+        return $this->resolverRef($base, 'refs/remotes/origin/main');
+    }
+
+    /**
+     * Resolve um ref Git lendo arquivo OU packed-refs.
+     */
+    private function resolverRef(string $base, string $ref): ?string
+    {
+        $refFile = $base.'/.git/'.$ref;
+        if (is_file($refFile)) {
+            $sha = trim((string) file_get_contents($refFile));
+
+            return $this->ehSha($sha) ? $sha : null;
+        }
+
+        $packed = $base.'/.git/packed-refs';
+        if (is_file($packed)) {
+            foreach (preg_split('/\R/', (string) file_get_contents($packed)) ?: [] as $linha) {
+                $linha = trim($linha);
+                if ($linha === '' || $linha[0] === '#' || $linha[0] === '^') {
+                    continue;
+                }
+                [$sha, $r] = array_pad(explode(' ', $linha, 2), 2, '');
+                if ($r === $ref && $this->ehSha($sha)) {
+                    return $sha;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /** Compara SHAs tolerando short vs full (prefix match, mínimo 7). */
+    public function mesmoSha(string $a, string $b): bool
+    {
+        $a = strtolower($a);
+        $b = strtolower($b);
+        $n = min(strlen($a), strlen($b));
+
+        return $n >= 7 && str_starts_with($a, substr($b, 0, $n)) && str_starts_with($b, substr($a, 0, $n));
+    }
+
+    private function ehSha(string $s): bool
+    {
+        return (bool) preg_match('/^[0-9a-f]{7,40}$/i', $s);
+    }
+}

--- a/Modules/Governance/Tests/Feature/DeployDriftCheckerTest.php
+++ b/Modules/Governance/Tests/Feature/DeployDriftCheckerTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Governance\Contracts\DriftChecker;
+use Modules\Governance\Services\Checkers\DeployDriftChecker;
+use Modules\Governance\Services\DriftFinding;
+
+uses(Tests\TestCase::class);
+
+/**
+ * DeployDriftChecker (ADR 0216) — detecta código deployado != GitHub main.
+ * Fecha o "1302-commits cego". Plugado no framework (não comando bespoke).
+ * Métodos puros (analisar/mesmoSha/deployedSha) testáveis sem rede/git binary.
+ */
+
+it('implementa DriftChecker + registrado em governance.drift_checkers', function () {
+    expect(new DeployDriftChecker())->toBeInstanceOf(DriftChecker::class)
+        ->and((new DeployDriftChecker())->name())->toBe('deploy_drift')
+        ->and((array) config('governance.drift_checkers'))->toContain(DeployDriftChecker::class);
+});
+
+it('analisar: deployado == main → sem finding', function () {
+    expect((new DeployDriftChecker())->analisar('abc1234def', 'abc1234def'))->toBeEmpty();
+});
+
+it('analisar: deployado != main → finding high (deploy atrasado)', function () {
+    $f = (new DeployDriftChecker())->analisar('aaaaaaa', 'bbbbbbb');
+    expect($f)->toHaveCount(1)
+        ->and($f[0])->toBeInstanceOf(DriftFinding::class)
+        ->and($f[0]->severity)->toBe('high')
+        ->and($f[0]->message)->toContain('deployado');
+});
+
+it('analisar: deployado null → finding low (não verificável)', function () {
+    $f = (new DeployDriftChecker())->analisar(null, 'abc1234');
+    expect($f)->toHaveCount(1)->and($f[0]->severity)->toBe('low');
+});
+
+it('analisar: main null → info (reverifica no próximo push)', function () {
+    $f = (new DeployDriftChecker())->analisar('abc1234', null);
+    expect($f)->toHaveCount(1)->and($f[0]->severity)->toBe('info');
+});
+
+it('mesmoSha: short vs full do mesmo commit → iguais', function () {
+    expect((new DeployDriftChecker())->mesmoSha('744e864', '744e86439edcabc123'))->toBeTrue()
+        ->and((new DeployDriftChecker())->mesmoSha('744e864', '999e864abc'))->toBeFalse();
+});
+
+it('deployedSha: lê .git/HEAD → ref → refs/heads/main (sem git binary)', function () {
+    $base = sys_get_temp_dir().'/deploydrift_'.uniqid();
+    mkdir($base.'/.git/refs/heads', 0777, true);
+    file_put_contents($base.'/.git/HEAD', "ref: refs/heads/main\n");
+    file_put_contents($base.'/.git/refs/heads/main', "744e86439edc0000000000000000000000000000\n");
+
+    expect((new DeployDriftChecker())->deployedSha($base))->toBe('744e86439edc0000000000000000000000000000');
+
+    // cleanup
+    @unlink($base.'/.git/refs/heads/main');
+    @unlink($base.'/.git/HEAD');
+});
+
+it('deployedSha: HEAD destacado (SHA direto) também resolve', function () {
+    $base = sys_get_temp_dir().'/deploydrift2_'.uniqid();
+    mkdir($base.'/.git', 0777, true);
+    file_put_contents($base.'/.git/HEAD', "abc1234def5678\n");
+
+    expect((new DeployDriftChecker())->deployedSha($base))->toBe('abc1234def5678');
+    @unlink($base.'/.git/HEAD');
+});

--- a/Modules/TeamMcp/Http/Controllers/Mcp/SyncMemoryWebhookController.php
+++ b/Modules/TeamMcp/Http/Controllers/Mcp/SyncMemoryWebhookController.php
@@ -80,6 +80,17 @@ class SyncMemoryWebhookController extends Controller
             ]);
         }
 
+        // DeployDriftChecker (ADR 0216): registra o SHA de main a cada push pro
+        // governance:audit detectar deploy atrasado (o "1302-commits cego"). File
+        // cache persiste entre requests/octane reload.
+        $after = (string) $request->input('after', '');
+        if (preg_match('/^[0-9a-f]{7,40}$/i', $after)) {
+            \Illuminate\Support\Facades\Cache::forever(
+                \Modules\Governance\Services\Checkers\DeployDriftChecker::CACHE_KEY,
+                $after
+            );
+        }
+
         // Sincroniza filesystem com origin/main antes de indexar.
         // Sem isso, IndexarMemoryGitParaDb indexa estado parado do disco.
         $gitInfo = $this->sincronizarComOrigin($request);


### PR DESCRIPTION
Lado A do reconcile (pior dimensão, deploy drift nota 20). Plugado no framework DriftChecker (ADR 0216), generaliza DaemonSourceDriftCheck — não bespoke. Deployado = .git/HEAD (sem git binary); main = cache do webhook GitHub→MCP a cada push (fallback origin/main ref). +8 testes, PHPStan limpo. Roda no governance:audit já agendado.