### PR TITLE
fix(jana): buscarHybrid aplica doBusiness — simétrico ao FULLTEXT (Tier 0)

### DIFF
--- a/Modules/Jana/Entities/Mcp/McpMemoryDocument.php
+++ b/Modules/Jana/Entities/Mcp/McpMemoryDocument.php
@@ -124,16 +124,18 @@ class McpMemoryDocument extends Model
      * Busca HYBRID (semantic + full-text) no índice Meilisearch — para as tools MCP
      * decisions-search/kb-answer recuperarem com a qualidade do pipeline do chat.
      *
-     * Corpus MCP é GLOBAL (conhecimento de programação/produto — serve TODOS os
-     * clientes). Verificado no índice live (CT 100): filterableAttributes =
-     * [status, type, module, slug], SEM business_id. Logo NÃO filtra tenant — só
-     * status ativo + type/module no Meilisearch + acessiveisPara (permissão Spatie)
-     * na hidratação. Embedder/ratio do config (qwen3_local / 0.6, mesmos do chat).
-     * `shouldBeSearchable` já exclui superseded/deprecated do índice (status = defesa extra).
+     * Multi-tenant Tier 0 (ADR 0093): aplica `doBusiness($businessId)` na hidratação
+     * — SIMÉTRICO ao caminho FULLTEXT (DecisionsSearch/KbAnswer chamam doBusiness quando
+     * businessId>0). doBusiness = `business_id = X OR business_id IS NULL`, então docs de
+     * plataforma (NULL = ADR 0053 cross-tenant by design) aparecem pra todos, mas docs
+     * de um business específico NÃO vazam pra outro tenant. (Revisão adversarial 2026-05-29
+     * pegou a assimetria: hybrid não filtrava enquanto FULLTEXT filtrava.)
+     * + acessiveisPara (permissão Spatie). Embedder/ratio do config (qwen3_local / 0.6).
+     * `shouldBeSearchable` já exclui superseded/deprecated do índice.
      *
      * @return \Illuminate\Database\Eloquent\Collection<int, static>
      */
-    public static function buscarHybrid(string $query, int $limit, ?\App\User $user, ?string $tipo = null, ?string $module = null): \Illuminate\Database\Eloquent\Collection
+    public static function buscarHybrid(string $query, int $limit, ?\App\User $user, ?string $tipo = null, ?string $module = null, int $businessId = 0): \Illuminate\Database\Eloquent\Collection
     {
         // Embedder do índice mcp_memory_documents (verificado live CT 100: nomic_local +
         // qwen3_local). NÃO usar copiloto.memoria.meilisearch.embedder — essa é a do chat
@@ -157,7 +159,14 @@ class McpMemoryDocument extends Model
 
             return $index->search($q, $params);
         })
-            ->query(fn ($q) => $q->acessiveisPara($user))
+            ->query(function ($q) use ($user, $businessId) {
+                $q->acessiveisPara($user);
+                if ($businessId > 0) {
+                    $q->doBusiness($businessId); // Tier 0 — simétrico ao FULLTEXT (ADR 0093)
+                }
+
+                return $q;
+            })
             ->take($limit)
             ->get();
     }

--- a/Modules/Jana/Mcp/Tools/DecisionsSearchTool.php
+++ b/Modules/Jana/Mcp/Tools/DecisionsSearchTool.php
@@ -62,7 +62,7 @@ class DecisionsSearchTool extends Tool
         $rows = null;
         if (! $includeArchived && config('copiloto.mcp_search.docs_pipeline', false)) {
             try {
-                $hybrid = McpMemoryDocument::buscarHybrid($query, $limit, $user instanceof \App\User ? $user : null, 'adr');
+                $hybrid = McpMemoryDocument::buscarHybrid($query, $limit, $user instanceof \App\User ? $user : null, 'adr', null, $businessId);
                 if ($hybrid->isNotEmpty()) {
                     $rows = $hybrid;
                 }

--- a/Modules/Jana/Mcp/Tools/KbAnswerTool.php
+++ b/Modules/Jana/Mcp/Tools/KbAnswerTool.php
@@ -200,6 +200,7 @@ class KbAnswerTool extends Tool
                     $user,
                     $categoria !== 'all' ? $categoria : null,
                     $module !== '' ? $module : null,
+                    $businessId, // Tier 0 — simétrico ao FULLTEXT (revisão 2026-05-29)
                 );
                 if ($hybrid->isNotEmpty()) {
                     return $hybrid;


### PR DESCRIPTION
Revisão adversarial pegou: HYBRID não filtrava business_id, FULLTEXT filtrava. Latente (tudo biz=1) mas vaza quando biz=4 ganhar docs. Fix: buscarHybrid aplica doBusiness (simétrico). Backward-compat, testes verdes, PHPStan limpo. ADR 0093.