### PR TITLE
fix(jana): robustez de 3 commands de indexação (#4 ~~ regex, #5 resolver Windows, #6 typo silencioso)

### DIFF
--- a/Modules/Jana/Console/Commands/IndexRegenCommand.php
+++ b/Modules/Jana/Console/Commands/IndexRegenCommand.php
@@ -157,6 +157,11 @@ class IndexRegenCommand extends Command
      */
     private function resolver(string $base, string $rel): string
     {
+        // Normaliza separadores: em Windows base_path() retorna backslash
+        // (D:\oimpresso.com\memory). Sem normalizar, explode('/') deixa o path
+        // inteiro como UM segmento e o `..` popa a raiz toda em vez de subir 1 dir.
+        $base = str_replace('\\', '/', $base);
+        $rel = str_replace('\\', '/', $rel);
         $rel = rtrim($rel, '/');
         $partes = explode('/', $base.'/'.$rel);
         $pilha = [];
@@ -260,7 +265,7 @@ class IndexRegenCommand extends Command
         $sess = $drift['sessions'][1] ?? 0;
 
         $conteudo = preg_replace('/(navegável\s+\(~?)[\d.]+(\s+docs\))/', '${1}'.$this->aprox($docs).'$2', $conteudo) ?? $conteudo;
-        $conteudo = preg_replace('/(\(~?)\d+(\s+ADRs\))/', '${1}~'.$adrs.'$2', $conteudo) ?? $conteudo;
+        $conteudo = preg_replace('/(\()~?\d+(\s+ADRs\))/', '${1}~'.$adrs.'$2', $conteudo) ?? $conteudo;
         $conteudo = preg_replace('/~?\d+(\s+handoffs)/', '~'.$hand.'$1', $conteudo) ?? $conteudo;
         $conteudo = preg_replace('/~?\d+(\s+session logs)/', '~'.$sess.'$1', $conteudo) ?? $conteudo;
 

--- a/Modules/Jana/Console/Commands/MeilisearchIndexSetupCommand.php
+++ b/Modules/Jana/Console/Commands/MeilisearchIndexSetupCommand.php
@@ -54,10 +54,13 @@ class MeilisearchIndexSetupCommand extends Command
 
         $this->info("Meilisearch index setup → {$host}".($dry ? ' [DRY-RUN]' : ''));
 
+        $matched = false;
+
         foreach ($indexes as $uid => $cfg) {
             if ($alvo !== 'all' && $alvo !== $uid) {
                 continue;
             }
+            $matched = true;
 
             $payload   = $this->payloadPara($cfg);
             $embedders = implode(', ', array_keys($cfg['embedders'] ?? []));
@@ -81,6 +84,12 @@ class MeilisearchIndexSetupCommand extends Command
             }
 
             $this->info('    ✓ aplicado (taskUid '.data_get($resp->json(), 'taskUid', '?').')');
+        }
+
+        if ($alvo !== 'all' && ! $matched) {
+            $this->error("--index={$alvo} não existe em copiloto.meilisearch_indexes. Conhecidos: ".implode(', ', array_keys($indexes)));
+
+            return self::FAILURE;
         }
 
         if (! $dry) {

--- a/Modules/Jana/Tests/Feature/Console/MeilisearchIndexSetupTest.php
+++ b/Modules/Jana/Tests/Feature/Console/MeilisearchIndexSetupTest.php
@@ -46,6 +46,13 @@ it('payloadPara monta embedders + filterableAttributes', function () {
         ->and($payload['filterableAttributes'])->toBe(['business_id', 'user_id']);
 });
 
+it('--index com nome inexistente FALHA em vez de retornar SUCCESS silencioso', function () {
+    // Revisão adversarial 2026-05-29 (finding #6): --index=typo pulava todos os
+    // índices no loop e caía no return SUCCESS — no-op silencioso mascarava o erro.
+    $this->artisan('jana:meilisearch-setup', ['--index' => 'indice_que_nao_existe', '--dry-run' => true])
+        ->assertExitCode(1);
+});
+
 // NOTA: a detecção de drift (settings vivos × config) NÃO mora mais aqui — virou
 // MeilisearchSettingsDriftChecker (Modules/Governance, ADR 0216). Ver
 // Modules/Governance/Tests/.../MeilisearchSettingsDriftCheckerTest.php.


### PR DESCRIPTION
3 bugs nos meus commands de indexação: #4 double-tilde no aplicarContagens, #5 resolver quebra com backslash Windows, #6 --index=typo retorna SUCCESS silencioso. Todos corrigidos + verificados. 4 testes verdes.