### PR TITLE
feat(crm): tabela de preço real + mensagem de venda no cadastro de cliente + alerta POS

### DIFF
--- a/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
+++ b/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
@@ -9,6 +9,7 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Rule;
 
 /**
  * ClienteAutosaveController -- 5 endpoints PATCH cadastrais inline Wave C
@@ -339,7 +340,20 @@ class ClienteAutosaveController extends Controller
     /**
      * PATCH /cliente/{id}/comercial
      *
-     * Campos: credit_limit, pay_term_number, tabela_preco_padrao, pgto_padrao, obs_comercial.
+     * Campos: credit_limit, pay_term_number, customer_group_id, tabela_preco_padrao,
+     *         pgto_padrao, mensagem_venda, obs_comercial.
+     *
+     * `customer_group_id` é a tabela de preço REAL (UPOS canon — FK pra
+     * `customer_groups`, que aponta pra `selling_price_groups`). Substitui o
+     * antigo dropdown `tabela_preco_padrao` (enum hardcoded fake) no drawer.
+     * Validado contra `customer_groups` do MESMO business (multi-tenant Tier 0
+     * ADR 0093 — NUNCA aceitar id de outro tenant → 422).
+     *
+     * `mensagem_venda` (TEXT) é exibido como alerta ao vendedor no POS quando o
+     * cliente é selecionado (migrado de PESSOAS.MENSAGEM_PARA_VENDA Delphi).
+     *
+     * `tabela_preco_padrao` permanece aceito por compat (cadastros pré-wire),
+     * mas o drawer agora grava `customer_group_id`.
      */
     public function comercial(Request $request, int $id): JsonResponse
     {
@@ -348,11 +362,24 @@ class ClienteAutosaveController extends Controller
             return $contact;
         }
 
+        // Multi-tenant Tier 0 (ADR 0093): customer_group_id DEVE existir em
+        // customer_groups WHERE business_id = sessão. NUNCA cross-tenant.
+        $businessId = (int) $request->session()->get('user.business_id');
+
         $validator = Validator::make($request->all(), [
             'credit_limit' => ['nullable', 'numeric', 'min:0', 'max:999999999.99'],
             'pay_term_number' => ['nullable', 'integer', 'min:0', 'max:9999'],
+            // Tabela de preço REAL — FK customer_groups (scoped ao business da sessão).
+            'customer_group_id' => [
+                'nullable', 'integer',
+                Rule::exists('customer_groups', 'id')->where(
+                    fn ($q) => $q->where('business_id', $businessId)
+                ),
+            ],
             'tabela_preco_padrao' => ['nullable', 'string', 'in:' . implode(',', self::TABELAS_PRECO)],
             'pgto_padrao' => ['nullable', 'string', 'in:' . implode(',', self::PGTOS)],
+            // Mensagem exibida como alerta ao vendedor no POS.
+            'mensagem_venda' => ['nullable', 'string', 'max:5000'],
             'obs_comercial' => ['nullable', 'string', 'max:5000'],
         ], $this->messages());
 
@@ -577,8 +604,11 @@ class ClienteAutosaveController extends Controller
             'state' => $contact->state ?? null,
             'credit_limit' => $contact->credit_limit !== null ? (float) $contact->credit_limit : null,
             'pay_term_number' => $contact->pay_term_number !== null ? (int) $contact->pay_term_number : null,
+            // Tabela de preço REAL (FK customer_groups) — fonte de verdade do drawer.
+            'customer_group_id' => $contact->customer_group_id !== null ? (int) $contact->customer_group_id : null,
             'tabela_preco_padrao' => $contact->tabela_preco_padrao ?? null,
             'pgto_padrao' => $contact->pgto_padrao ?? null,
+            'mensagem_venda' => $contact->mensagem_venda ?? null,
             'obs_comercial' => $contact->obs_comercial ?? null,
             'segmento' => $contact->segmento ?? null,
             'tags' => $this->decodeTags($contact->tags ?? null),

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -309,6 +309,15 @@ class ContactController extends Controller
                     'view' => auth()->user()->can('customer.view') || auth()->user()->can('customer.view_own'),
                     'import' => auth()->user()->can('customer.create'),
                 ],
+                // Tabela de preço REAL pro drawer Comercial (ADR 0093 scope).
+                // [{id,name}] das customer_groups do business — substitui o
+                // dropdown fake hardcoded (padrao/varejo/atacado/parceiro).
+                // biz=164 Martinho: MECÂNICA / FABRICANTE / FINAL.
+                'priceGroups' => CustomerGroup::where('business_id', $business_id)
+                    ->orderBy('name')
+                    ->get(['id', 'name'])
+                    ->map(fn ($g) => ['id' => (int) $g->id, 'name' => (string) $g->name])
+                    ->all(),
                 // Wagner 2026-05-27 — gate sub-tab "Placas" do OssTab drawer.
                 // Daniela @ Martinho: ve placas no drawer apenas se OficinaAuto
                 // ativo. biz=4 Larissa vestuario nao ve (graceful default false).
@@ -465,6 +474,9 @@ class ContactController extends Controller
             'contacts.balance',
             'contacts.credit_limit',
             'contacts.pay_term_number',
+            // Tabela de preço REAL (FK customer_groups) — canon UPOS, sempre presente.
+            // Drawer ComercialTab lê pra popular o dropdown de tabela de preço.
+            'contacts.customer_group_id',
             'contacts.contact_status',
             'contacts.created_at',
             // Endereço completo — sem isso, router.reload({only:['rows']}) pós lookup
@@ -541,6 +553,13 @@ class ContactController extends Controller
         $hasContatoCol = \Illuminate\Support\Facades\Schema::hasColumn('contacts', 'contato');
         if ($hasContatoCol) {
             $selectCols[] = 'contacts.contato';
+        }
+        // `mensagem_venda` (TEXT) — migrado de PESSOAS.MENSAGEM_PARA_VENDA Delphi.
+        // Exibido como alerta ao vendedor no POS + editavel no drawer Comercial.
+        // Migration 2026_05_29_120000_add_mensagem_venda_to_contacts.
+        $hasMensagemVendaCol = \Illuminate\Support\Facades\Schema::hasColumn('contacts', 'mensagem_venda');
+        if ($hasMensagemVendaCol) {
+            $selectCols[] = 'contacts.mensagem_venda';
         }
         if ($hasWaveBCols) {
             $selectCols = array_merge($selectCols, [
@@ -629,7 +648,7 @@ class ContactController extends Controller
             ->get()
             ->keyBy('contact_id');
 
-        $rows = $contacts->getCollection()->map(function ($contact) use ($stats, $hasWaveBCols, $hasCanonBrCols, $hasDrawerCols, $hasEmailsExtras, $hasSefazCols, $hasBucketACols, $hasContatoCol, $vehiclesCountMap) {
+        $rows = $contacts->getCollection()->map(function ($contact) use ($stats, $hasWaveBCols, $hasCanonBrCols, $hasDrawerCols, $hasEmailsExtras, $hasSefazCols, $hasBucketACols, $hasContatoCol, $hasMensagemVendaCol, $vehiclesCountMap) {
             $row = $stats->get($contact->id);
             $totalOs = $row ? (int) $row->total_os : 0;
             $abertas = $row ? (int) $row->os_abertas : 0;
@@ -746,8 +765,14 @@ class ContactController extends Controller
             $payload['limite_credito'] = $payload['credit_limit'];
             $payload['pay_term_number'] = $contact->pay_term_number !== null ? (int) $contact->pay_term_number : null;
             $payload['prazo_padrao_dias'] = $payload['pay_term_number'];
+            // Tabela de preço REAL (FK customer_groups) — canon UPOS. Drawer
+            // ComercialTab popula o dropdown com priceGroups e grava aqui.
+            $payload['customer_group_id'] = $contact->customer_group_id !== null
+                ? (int) $contact->customer_group_id : null;
             $payload['tabela_preco_padrao'] = $hasDrawerCols ? ($contact->tabela_preco_padrao ?? null) : null;
             $payload['pgto_padrao'] = $hasDrawerCols ? ($contact->pgto_padrao ?? null) : null;
+            // mensagem_venda (alerta ao vendedor no POS · editavel no drawer).
+            $payload['mensagem_venda'] = $hasMensagemVendaCol ? ($contact->mensagem_venda ?? null) : null;
             $payload['obs_comercial'] = $hasDrawerCols ? ($contact->obs_comercial ?? null) : null;
 
             // ── ClassificacaoTab: contact_status enum UPOS ───────────────────
@@ -2162,6 +2187,9 @@ class ContactController extends Controller
                 'pay_term_type',
                 'balance',
                 'supplier_business_name',
+                // mensagem_venda — alerta ao vendedor no POS quando o cliente é
+                // selecionado (migrado de PESSOAS.MENSAGEM_PARA_VENDA Delphi).
+                'contacts.mensagem_venda',
                 'cg.amount as discount_percent',
                 'cg.price_calculation_type',
                 'cg.selling_price_group_id',

--- a/database/migrations/2026_05_29_120000_add_mensagem_venda_to_contacts.php
+++ b/database/migrations/2026_05_29_120000_add_mensagem_venda_to_contacts.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * `contacts.mensagem_venda` — texto livre exibido como ALERTA ao vendedor no
+ * POS/venda quando o cliente é selecionado. Absorve `PESSOAS.MENSAGEM_PARA_VENDA`
+ * do ERP Delphi WR Comercial (ex.: Martinho biz=164 FAN COM tem 398 chars).
+ *
+ * O dado já foi migrado para esta coluna em produção (biz=164) pelo importer
+ * Python; esta migration torna o schema reproduzível em CI e novos ambientes.
+ *
+ * Editável no drawer 760 Cliente (aba Comercial, autosave on blur via
+ * ClienteAutosaveController::comercial) e lido pelo select2 do customer no POS
+ * (ContactController::getCustomers → public/js/pos.js).
+ *
+ * IDEMPOTENTE — Schema::hasColumn check antes de add. Reversível via down()
+ * sem perda (coluna nullable, ninguém depende dela pré-existente fora do POS).
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): `business_id` já existe em
+ * `contacts` + indexado — coluna texto herda scope automático.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('contacts', function (Blueprint $table) {
+            if (! Schema::hasColumn('contacts', 'mensagem_venda')) {
+                $table->text('mensagem_venda')->nullable();
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('contacts', function (Blueprint $table) {
+            if (Schema::hasColumn('contacts', 'mensagem_venda')) {
+                $table->dropColumn('mensagem_venda');
+            }
+        });
+    }
+};

--- a/public/js/pos.js
+++ b/public/js/pos.js
@@ -150,6 +150,20 @@ $(document).ready(function() {
         if ($('.contact_due_text').length) {
             get_contact_due(data.id);
         }
+
+        // Mensagem para a venda — alerta ao vendedor (migrado de
+        // PESSOAS.MENSAGEM_PARA_VENDA do Delphi). Exibe num <small> próprio
+        // quando o cliente selecionado tem texto; esconde caso contrário.
+        if ($('.contact_mensagem_venda_text').length) {
+            var mensagem_venda = data.mensagem_venda ? $.trim(data.mensagem_venda) : '';
+            if (mensagem_venda !== '') {
+                $('.contact_mensagem_venda_text').find('span').text(mensagem_venda);
+                $('.contact_mensagem_venda_text').removeClass('hide');
+            } else {
+                $('.contact_mensagem_venda_text').find('span').text('');
+                $('.contact_mensagem_venda_text').addClass('hide');
+            }
+        }
     });
 
     set_default_customer();

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -67,7 +67,7 @@ import {
 import IdentificacaoTab from './_drawer/IdentificacaoTab';
 import ContatoTab from './_drawer/ContatoTab';
 import EnderecoTab from './_drawer/EnderecoTab';
-import ComercialTab from './_drawer/ComercialTab';
+import ComercialTab, { type PriceGroupOption } from './_drawer/ComercialTab';
 import ClassificacaoTab from './_drawer/ClassificacaoTab';
 // Wave D/E/F — OSs wrapper, IA 4 cards, Auditoria timeline LGPD (ADR 0179).
 import OssTab from './_drawer/OssTab';
@@ -137,8 +137,12 @@ interface ClienteRow {
   state?: string | null;
   limite_credito?: number | null;
   prazo_padrao_dias?: number | null;
+  // Tabela de preço REAL (FK customer_groups). Substitui o fake tabela_preco_padrao.
+  customer_group_id?: number | null;
   tabela_preco_padrao?: string | null;
   pgto_padrao?: string | null;
+  // Mensagem exibida como alerta ao vendedor no POS (migrado do Delphi).
+  mensagem_venda?: string | null;
   obs_comercial?: string | null;
   segmento?: string | null;
   tags?: string[] | null;
@@ -225,6 +229,12 @@ export interface ClienteIndexPageProps {
     view: boolean;
     import: boolean;
   };
+  /**
+   * Tabelas de preço REAIS do business (customer_groups id+name). Server-side
+   * em ContactController::index (scope business_id). Alimenta o dropdown de
+   * tabela de preço no drawer ComercialTab — substitui o enum fake hardcoded.
+   */
+  priceGroups?: PriceGroupOption[];
   /** Wagner 2026-05-27 — gate sub-tab "Placas" do OssTab drawer. true se modulo
    *  OficinaAuto ativo no business. Default false (biz=4 Larissa vestuario). */
   oficinaauto_enabled?: boolean;
@@ -1281,6 +1291,7 @@ export default function ClienteIndex(props: ClienteIndexPageProps) {
         open={openContactId !== null}
         rows={rows}
         draftContact={draftContact}
+        priceGroups={props.priceGroups ?? []}
         oficinaAutoEnabled={props.oficinaauto_enabled ?? false}
         onOpenChange={(open) => {
           if (!open) setDraftContact(null);
@@ -1742,6 +1753,7 @@ function ClienteSheet({
   open,
   rows,
   draftContact,
+  priceGroups = [],
   oficinaAutoEnabled = false,
   onOpenChange,
   onContactUpdated,
@@ -1753,6 +1765,8 @@ function ClienteSheet({
    * via state Index.tsx pra não depender do `rows.find()` (que falha porque
    * draft recém-criado pode estar fora da página paginada da listagem). */
   draftContact?: ClienteRow | null;
+  /** Tabelas de preço REAIS (customer_groups) pro dropdown do ComercialTab. */
+  priceGroups?: PriceGroupOption[];
   /** Wagner 2026-05-27 — gate sub-tab "Placas" do OssTab. */
   oficinaAutoEnabled?: boolean;
   onOpenChange: (open: boolean) => void;
@@ -2017,7 +2031,7 @@ function ClienteSheet({
                 />
               </div>
               <div hidden={activeTab !== 'comercial'}>
-                <ComercialTab contact={contact} />
+                <ComercialTab contact={contact} priceGroups={priceGroups} />
               </div>
               <div hidden={activeTab !== 'classificacao'}>
                 <ClassificacaoTab contact={contact} />

--- a/resources/js/Pages/Cliente/_drawer/ComercialTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/ComercialTab.tsx
@@ -5,13 +5,16 @@
 // Cowork blueprint: prototipo-ui/prototipos/clientes/clientes-drawer.jsx::SectionComercial
 //
 // Contrato:
-//   PATCH /cliente/{id}/comercial  body: { limite_credito, prazo_padrao_dias, tabela_preco_padrao, pgto_padrao, obs_comercial }
+//   PATCH /cliente/{id}/comercial  body: { limite_credito, prazo_padrao_dias, customer_group_id, pgto_padrao, mensagem_venda, obs_comercial }
 //
 // Pegadinhas:
 //  - limite_credito é INTEGER (centavos no banco — opcional, vazio = sem limite)
 //  - prazo é INTEGER em dias
-//  - Tabela preço: padrao/varejo/atacado/parceiro (4 valores)
+//  - Tabela de preço: customer_group_id REAL (FK customer_groups) — lista vem
+//    via prop `priceGroups` (id+name do business, multi-tenant scope). Substitui
+//    o antigo dropdown fake hardcoded `tabela_preco_padrao`.
 //  - Pgto: pix/boleto/cartao/dinheiro/transferencia (5 valores)
+//  - Mensagem para a venda: textarea livre, exibida como alerta ao vendedor no POS
 //  - Obs comercial: textarea livre
 //  - Autosave on blur (debounce 800ms) + optimistic UI + rollback 4xx/5xx
 
@@ -28,29 +31,36 @@ import {
   SelectValue,
 } from '@/Components/ui/select';
 
+export interface PriceGroupOption {
+  id: number;
+  name: string;
+}
+
 export interface ContactInfo {
   id: number;
   limite_credito?: number | null;
   prazo_padrao_dias?: number | null;
-  tabela_preco_padrao?: string | null;
+  // Tabela de preço REAL (FK customer_groups). Fonte de verdade do drawer.
+  customer_group_id?: number | null;
   pgto_padrao?: string | null;
+  // Mensagem exibida como alerta ao vendedor no POS (migrado do Delphi).
+  mensagem_venda?: string | null;
   obs_comercial?: string | null;
 }
 
 export interface ComercialTabProps {
   contact: ContactInfo;
+  /**
+   * Tabelas de preço REAIS do business (customer_groups id+name). Lista
+   * server-side (ContactController::index, scope business_id). Substitui o
+   * dropdown fake hardcoded. `undefined`/`[]` → dropdown vazio com aviso.
+   */
+  priceGroups?: PriceGroupOption[];
   onSaved?: (field: string, value: unknown) => void;
   disabled?: boolean;
 }
 
 const DEBOUNCE_MS = 800;
-
-const TABELA_PRECO_OPTIONS: Array<{ value: string; label: string }> = [
-  { value: 'padrao', label: 'Padrão (atacado quando ≥ 100 un)' },
-  { value: 'varejo', label: 'Varejo' },
-  { value: 'atacado', label: 'Atacado fixo' },
-  { value: 'parceiro', label: 'Parceiro (desconto 12%)' },
-];
 
 const PGTO_OPTIONS: Array<{ value: string; label: string }> = [
   { value: 'pix', label: 'PIX' },
@@ -72,15 +82,28 @@ function toNumberOrNull(v: string): number | null {
   return Number.isFinite(n) ? n : null;
 }
 
-export default function ComercialTab({ contact, onSaved, disabled = false }: ComercialTabProps) {
+// Sentinel pro item "sem tabela" — shadcn Select proíbe SelectItem value="".
+const NO_GROUP = '__none__';
+
+export default function ComercialTab({
+  contact,
+  priceGroups = [],
+  onSaved,
+  disabled = false,
+}: ComercialTabProps) {
   const [limite, setLimite] = useState<string>(
     contact.limite_credito != null ? String(contact.limite_credito) : ''
   );
   const [prazo, setPrazo] = useState<string>(
     contact.prazo_padrao_dias != null ? String(contact.prazo_padrao_dias) : ''
   );
-  const [tabelaPreco, setTabelaPreco] = useState<string>(contact.tabela_preco_padrao ?? '');
+  // customer_group_id real (FK customer_groups). Armazenado como string no
+  // Select (NO_GROUP = sem tabela); convertido pra number|null no autosave.
+  const [grupoPreco, setGrupoPreco] = useState<string>(
+    contact.customer_group_id != null ? String(contact.customer_group_id) : NO_GROUP
+  );
   const [pgto, setPgto] = useState<string>(contact.pgto_padrao ?? '');
+  const [mensagemVenda, setMensagemVenda] = useState<string>(contact.mensagem_venda ?? '');
   const [obs, setObs] = useState<string>(contact.obs_comercial ?? '');
 
   const [savingField, setSavingField] = useState<string | null>(null);
@@ -93,8 +116,9 @@ export default function ComercialTab({ contact, onSaved, disabled = false }: Com
   useEffect(() => {
     setLimite(contact.limite_credito != null ? String(contact.limite_credito) : '');
     setPrazo(contact.prazo_padrao_dias != null ? String(contact.prazo_padrao_dias) : '');
-    setTabelaPreco(contact.tabela_preco_padrao ?? '');
+    setGrupoPreco(contact.customer_group_id != null ? String(contact.customer_group_id) : NO_GROUP);
     setPgto(contact.pgto_padrao ?? '');
+    setMensagemVenda(contact.mensagem_venda ?? '');
     setObs(contact.obs_comercial ?? '');
     setErrorField(null);
     setSavedField(null);
@@ -103,8 +127,9 @@ export default function ComercialTab({ contact, onSaved, disabled = false }: Com
   const rollbackField = useCallback((field: string, prev: unknown) => {
     if (field === 'limite_credito') setLimite(prev != null ? String(prev) : '');
     else if (field === 'prazo_padrao_dias') setPrazo(prev != null ? String(prev) : '');
-    else if (field === 'tabela_preco_padrao') setTabelaPreco((prev as string) ?? '');
+    else if (field === 'customer_group_id') setGrupoPreco(prev != null ? String(prev) : NO_GROUP);
     else if (field === 'pgto_padrao') setPgto((prev as string) ?? '');
+    else if (field === 'mensagem_venda') setMensagemVenda((prev as string) ?? '');
     else if (field === 'obs_comercial') setObs((prev as string) ?? '');
   }, []);
 
@@ -194,15 +219,29 @@ export default function ComercialTab({ contact, onSaved, disabled = false }: Com
     [performSave]
   );
 
-  const handleSelectChange = useCallback(
-    (field: 'tabela_preco_padrao' | 'pgto_padrao', v: string) => {
-      const prev = field === 'tabela_preco_padrao' ? tabelaPreco : pgto;
+  const handlePgtoChange = useCallback(
+    (v: string) => {
+      const prev = pgto;
       if (prev === v) return;
-      if (field === 'tabela_preco_padrao') setTabelaPreco(v);
-      else setPgto(v);
-      performSave(field, v, prev);
+      setPgto(v);
+      performSave('pgto_padrao', v, prev);
     },
-    [tabelaPreco, pgto, performSave]
+    [pgto, performSave]
+  );
+
+  // Tabela de preço REAL: converte string do Select (NO_GROUP | id) pra
+  // number|null antes de salvar `customer_group_id`. prev preserva o valor
+  // STRING anterior pra rollback fiel.
+  const handleGrupoPrecoChange = useCallback(
+    (v: string) => {
+      const prev = grupoPreco;
+      if (prev === v) return;
+      setGrupoPreco(v);
+      const id = v === NO_GROUP ? null : Number.parseInt(v, 10);
+      const prevId = prev === NO_GROUP ? null : Number.parseInt(prev, 10);
+      performSave('customer_group_id', id, prevId);
+    },
+    [grupoPreco, performSave]
   );
 
   return (
@@ -265,25 +304,31 @@ export default function ComercialTab({ contact, onSaved, disabled = false }: Com
             Tabela de preço
           </Label>
           <Select
-            value={tabelaPreco}
-            onValueChange={(v) => handleSelectChange('tabela_preco_padrao', v)}
-            disabled={disabled}
+            value={grupoPreco}
+            onValueChange={handleGrupoPrecoChange}
+            disabled={disabled || priceGroups.length === 0}
           >
             <SelectTrigger id="cm-tabela" variant="cowork" className="w-full">
               <SelectValue placeholder="Selecionar tabela" />
             </SelectTrigger>
             <SelectContent>
-              {TABELA_PRECO_OPTIONS.map((o) => (
-                <SelectItem key={o.value} value={o.value}>
-                  {o.label}
+              <SelectItem value={NO_GROUP}>Sem tabela (preço padrão)</SelectItem>
+              {priceGroups.map((g) => (
+                <SelectItem key={g.id} value={String(g.id)}>
+                  {g.name}
                 </SelectItem>
               ))}
             </SelectContent>
           </Select>
+          {priceGroups.length === 0 && (
+            <p className="mt-1 text-xs text-muted-foreground">
+              Nenhuma tabela de preço cadastrada neste negócio.
+            </p>
+          )}
           <FieldStatus
-            saving={savingField === 'tabela_preco_padrao'}
-            saved={savedField === 'tabela_preco_padrao'}
-            backendError={errorField?.field === 'tabela_preco_padrao' ? errorField.message : null}
+            saving={savingField === 'customer_group_id'}
+            saved={savedField === 'customer_group_id'}
+            backendError={errorField?.field === 'customer_group_id' ? errorField.message : null}
           />
         </div>
 
@@ -293,7 +338,7 @@ export default function ComercialTab({ contact, onSaved, disabled = false }: Com
           </Label>
           <Select
             value={pgto}
-            onValueChange={(v) => handleSelectChange('pgto_padrao', v)}
+            onValueChange={handlePgtoChange}
             disabled={disabled}
           >
             <SelectTrigger id="cm-pgto" variant="cowork" className="w-full">
@@ -311,6 +356,32 @@ export default function ComercialTab({ contact, onSaved, disabled = false }: Com
             saving={savingField === 'pgto_padrao'}
             saved={savedField === 'pgto_padrao'}
             backendError={errorField?.field === 'pgto_padrao' ? errorField.message : null}
+          />
+        </div>
+
+        <div className="md:col-span-2">
+          <Label htmlFor="cm-mensagem-venda" className="cw-label">
+            Mensagem para a venda{' '}
+            <span className="text-muted-foreground font-normal">(alerta ao vendedor no PDV)</span>
+          </Label>
+          <Textarea
+            id="cm-mensagem-venda"
+            value={mensagemVenda}
+            placeholder="Ex.: cliente paga só com boleto · conferir limite antes de faturar…"
+            disabled={disabled}
+            rows={3}
+            onChange={(e) => {
+              const prev = mensagemVenda;
+              const v = e.target.value;
+              setMensagemVenda(v);
+              scheduleAutosave('mensagem_venda', v, prev);
+            }}
+            onBlur={(e) => handleBlurText('mensagem_venda', e.target.value)}
+          />
+          <FieldStatus
+            saving={savingField === 'mensagem_venda'}
+            saved={savedField === 'mensagem_venda'}
+            backendError={errorField?.field === 'mensagem_venda' ? errorField.message : null}
           />
         </div>
 

--- a/resources/views/sale_pos/partials/pos_form.blade.php
+++ b/resources/views/sale_pos/partials/pos_form.blade.php
@@ -24,6 +24,7 @@
 				</span>
 			</div>
 			<small class="text-danger hide contact_due_text"><strong>@lang('account.customer_due'):</strong> <span></span></small>
+			<small class="text-warning hide contact_mensagem_venda_text"><strong>Mensagem:</strong> <span></span></small>
 		</div>
 	</div>
 	<div class="col-md-8">

--- a/resources/views/sale_pos/partials/pos_form_edit.blade.php
+++ b/resources/views/sale_pos/partials/pos_form_edit.blade.php
@@ -21,6 +21,7 @@
 				</span>
 			</div>
 			<small class="text-danger @if(empty($customer_due)) hide @endif contact_due_text"><strong>@lang('account.customer_due'):</strong> <span>{{$customer_due ?? ''}}</span></small>
+			<small class="text-warning hide contact_mensagem_venda_text"><strong>Mensagem:</strong> <span></span></small>
 		</div>
 	</div>
 	<div class="col-md-8">

--- a/resources/views/sell/create.blade.php
+++ b/resources/views/sell/create.blade.php
@@ -149,6 +149,7 @@
 							</span>
 						</div>
 						<small class="text-danger hide contact_due_text"><strong>@lang('account.customer_due'):</strong> <span></span></small>
+						<small class="text-warning hide contact_mensagem_venda_text"><strong>Mensagem:</strong> <span></span></small>
 					</div>
 					<small>
 					<strong>

--- a/resources/views/sell/edit.blade.php
+++ b/resources/views/sell/edit.blade.php
@@ -105,6 +105,7 @@
 							</span>
 						</div>
 						<small class="text-danger @if(empty($customer_due)) hide @endif contact_due_text"><strong>@lang('account.customer_due'):</strong> <span>{{$customer_due ?? ''}}</span></small>
+						<small class="text-warning hide contact_mensagem_venda_text"><strong>Mensagem:</strong> <span></span></small>
 					</div>
 					<small>
 						<strong>


### PR DESCRIPTION
## Intent
Liga o **drawer de cadastro de cliente** (e o POS) aos dados reais migrados do ERP Delphi. Antes o drawer mostrava placeholders fake (tabela de preço) e não exibia a mensagem de venda. Autorizado por Wagner.

## O que muda

### (A) Tabela de preço — agora real
O dropdown "Tabela de preço" do `ComercialTab` listava valores **hardcoded fake** (`padrao/varejo/atacado/parceiro`, gravados em `tabela_preco_padrao` — beco sem saída). Agora lista os **`customer_groups` reais** do business (ex. Martinho: MECÁNICA / FABRICANTE / FINAL) e grava `contacts.customer_group_id` (FK canônica UltimatePOS → `selling_price_groups`). FAN COM (customer_group_id=6) passa a mostrar **FABRICANTE** selecionado.
- `priceGroups` agora vai via `Inertia::render` (antes `CustomerGroup::forDropdown` só ia pra Blade legada).
- **Multi-tenant Tier 0 (ADR 0093):** `customer_group_id` só é aceito se existir em `customer_groups` do business da sessão (`Rule::exists` scoped) → cross-tenant = 422.

### (B) Mensagem para a venda — no cadastro
Novo textarea no `ComercialTab` lê/grava `contacts.mensagem_venda` (migrado de `PESSOAS.MENSAGEM_PARA_VENDA`). Autosave on blur, mesmo padrão optimistic/rollback dos demais campos.

### (C) Alerta no POS
`getCustomers()` passa `mensagem_venda`; `pos.js` exibe em `.contact_mensagem_venda_text` ao selecionar o cliente (espelha o `.contact_due_text` de saldo). Replica o comportamento do Delphi (alerta ao vendedor no momento da venda).

## Arquivos
Backend: `ClienteAutosaveController::comercial` (valida+persiste customer_group_id+mensagem_venda), `ContactController` (index expõe priceGroups; buildClienteIndexCustomers inclui os 2 campos nas rows; getCustomers + mensagem_venda). Front: `ComercialTab.tsx`, `Index.tsx`. POS: `pos.js` + 4 blades. Migration `mensagem_venda` idempotente.

## Validação
- `npm run build:inertia` + `npm run build` → OK.
- `lint:baseline:check` → **delta 0** (zero regressão).
- PHP não rodou local (sem PHP/vendor na máquina) — edições revisadas manualmente (validação multi-tenant conferida).

## Notas
- A migration `2026_05_29_..._add_mensagem_venda` é idempotente (`hasColumn`) e **coincide intencionalmente** com a do PR de migração de dados (#1942) — em qualquer ordem de merge, a segunda vira no-op. Em prod (biz 164) a coluna já existe.
- `tabela_preco_padrao` permanece aceito por compat, mas o drawer agora usa `customer_group_id`.

Refs: ADR 0188 · ADR 0197 · ADR 0093 · CYCLE-06 Martinho.

🤖 Generated with [Claude Code](https://claude.com/claude-code)