### PR TITLE
fix(projectmgmt): hotfix tela branca Triage+Inbox (guard props Inertia::defer)

### DIFF
--- a/resources/js/Pages/ProjectMgmt/Inbox/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/Inbox/Index.tsx
@@ -41,10 +41,18 @@ interface InboxItem {
 }
 
 interface Props {
-  inbox: InboxItem[];
-  inbox_stats: { unread: number; total_30d: number };
+  // inbox/inbox_stats chegam via Inertia::defer (InboxController) → `undefined`
+  // no 1º paint. Tipados opcionais + default-guard no destructuring pra NÃO
+  // crashar React antes do defer chegar (skill inertia-defer-default, Opção B;
+  // espelha OficinaAuto/ServiceOrders/Index.tsx). Sintoma do bug: inbox.forEach()
+  // sobre undefined → tela branca (PR #1940).
+  inbox?: InboxItem[];
+  inbox_stats?: { unread: number; total_30d: number };
   filters: { show_read: boolean };
 }
+
+// Default-guard pros props deferred (contadores começam zerados até o defer resolver).
+const EMPTY_INBOX_STATS = { unread: 0, total_30d: 0 };
 
 const TYPE_ICON: Record<InboxType, typeof AtSign> = {
   mention:          AtSign,
@@ -100,7 +108,7 @@ function timeAgo(iso: string | null): string {
   return d.toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' });
 }
 
-function InboxIndex({ inbox, inbox_stats, filters }: Props) {
+function InboxIndex({ inbox = [], inbox_stats = EMPTY_INBOX_STATS, filters }: Props) {
   const [optimisticRead, setOptimisticRead] = useState<Set<number>>(new Set());
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   // Item em foco pra navegação J/K (mesma mecânica do MyWork/Board).

--- a/resources/js/Pages/ProjectMgmt/Triage/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/Triage/Index.tsx
@@ -51,16 +51,24 @@ interface Kpis { total: number; sem_owner: number; sem_prio: number; backlog: nu
 
 interface Props {
   project: { id: number; key: string; name: string } | null;
-  tasks: TriageTask[];
-  cycles: CycleOption[];
-  epics: EpicOption[];
-  owners: string[];
-  kpis: Kpis;
+  // tasks/cycles/epics/owners/kpis chegam via Inertia::defer (TriageController) →
+  // `undefined` no 1º paint. Tipados opcionais + default-guard no destructuring
+  // pra NÃO crashar React antes do defer chegar (skill inertia-defer-default,
+  // Opção B; espelha OficinaAuto/ServiceOrders/Index.tsx). Sintoma do bug:
+  // tasks.filter() sobre undefined → tela branca (PR #1940).
+  tasks?: TriageTask[];
+  cycles?: CycleOption[];
+  epics?: EpicOption[];
+  owners?: string[];
+  kpis?: Kpis;
   filters: { project: string | null };
 }
 
 const NONE = '__none__';
 const PRIORITIES: Priority[] = ['p0', 'p1', 'p2', 'p3'];
+
+// Default-guard pros props deferred (kpis começa zerado até o defer resolver).
+const EMPTY_KPIS: Kpis = { total: 0, sem_owner: 0, sem_prio: 0, backlog: 0 };
 
 const PRIORITY_LABEL: Record<Priority, string> = {
   p0: 'P0 — urgente',
@@ -89,7 +97,14 @@ function timeAgo(iso: string | null): string {
 
 type AssignPatch = Partial<{ owner: string; priority: Priority; cycle_id: number | null; epic_id: number | null }>;
 
-function TriageIndex({ project, tasks, cycles, epics, owners, kpis }: Props) {
+function TriageIndex({
+  project,
+  tasks = [],
+  cycles = [],
+  epics = [],
+  owners = [],
+  kpis = EMPTY_KPIS,
+}: Props) {
   // Tasks que saíram da lista (still_triage=false) — escondidas localmente até reload.
   const [resolved, setResolved] = useState<Set<string>>(new Set());
   // Overlay otimista por task (campos já aplicados antes do servidor confirmar).


### PR DESCRIPTION
**Hotfix de prod.** As telas Triage/Inbox do #1940 davam TELA BRANCA (Uncaught TypeError undefined.filter/.forEach) — props Inertia::defer chegavam undefined no 1º paint sem guard. Fix: default-guard (Opção B skill inertia-defer-default, espelha OficinaAuto #1197). **Re-smoke headless VERDE** + screenshots verificados a olho: ambas renderizam (h1 + KPIs + sidebar + atalhos), 0 console error. Antes 7.9KB branco → depois 80KB renderizado. \n\n🤖 Generated with [Claude Code](https://claude.com/claude-code)