### PR TITLE
fix(migrations): regime não depende de coluna contribuinte (conserta migrate:fresh / visual-regression)

### DIFF
--- a/database/migrations/2021_01_26_155423_add_regime_table_contacts.php
+++ b/database/migrations/2021_01_26_155423_add_regime_table_contacts.php
@@ -13,10 +13,20 @@ class AddRegimeTableContacts extends Migration
      */
     public function up()
     {
+        // Fix 2026-05-29: removido `->after('contribuinte')`. A coluna `contribuinte`
+        // só passou a ser criada em 2026_05_21_140000_restore_br_fields_to_contacts,
+        // POSTERIOR a esta migration de 2021 — logo, em `migrate:fresh` (ordem
+        // cronológica) `->after('contribuinte')` quebra com "Unknown column
+        // 'contribuinte'", derrubando o setup do CI visual-regression e qualquer
+        // ambiente novo. `->after` é apenas posição física da coluna no MySQL (sem
+        // efeito funcional); sem ele, `regime` vai pro fim. Em prod já-migrado esta
+        // migration não re-roda, então é no-op lá. Guard `hasColumn` torna idempotente.
+        if (Schema::hasColumn('contacts', 'regime')) {
+            return;
+        }
+
         Schema::table('contacts', function (Blueprint $table) {
-                $table->string('regime') // Nome da coluna
-                            ->nullable() // Preenchimento não obrigatório
-                            ->after('contribuinte'); // Ordenado após a coluna "password"
+            $table->string('regime')->nullable();
         });
     }
 


### PR DESCRIPTION
## Bug
A migration `2021_01_26_155423_add_regime_table_contacts` faz `->after('contribuinte')`, mas a coluna `contribuinte` só é criada em `2026_05_21_140000_restore_br_fields_to_contacts` — **5 anos depois**. Em `migrate:fresh` (ordem cronológica) a de 2021 roda antes → `SQLSTATE[42S22] Unknown column 'contribuinte'` → o app não boota no setup do teste → os 3 `Sells\CreateScreenshotTest` falham com `Target class [config] does not exist` (0 assertions, nenhum screenshot).

**Impacto:** quebra o CI `visual-regression` de **todo PR de UI** e `migrate:fresh` em qualquer ambiente novo. (Descoberto investigando o CI do PR #1959.)

## Fix
- Remove o `->after('contribuinte')` — é apenas posição física da coluna no MySQL, sem efeito funcional; `regime` passa a ser criada no fim da tabela.
- Adiciona guard `Schema::hasColumn('contacts','regime')` → idempotente.
- Em **produção já migrada** esta migration não re-roda → **no-op** lá. Só afeta `migrate:fresh` (CI / ambientes novos), que volta a funcionar.

Não toca dados nem semântica fiscal — só a ordenação DDL.

Refs: ADR 0108 · CYCLE-06.

🤖 Generated with [Claude Code](https://claude.com/claude-code)