### PR TITLE
fix(ui-lint): blue-* -> token primary nas telas DRAFT ProjectMgmt (restaura ratchet)

### DIFF
--- a/resources/js/Pages/ProjectMgmt/Inbox/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/Inbox/Index.tsx
@@ -316,7 +316,7 @@ function InboxIndex({ inbox = [], inbox_stats = EMPTY_INBOX_STATS, filters }: Pr
                         aria-current={isSelected ? 'true' : undefined}
                         className={[
                           'group flex items-start gap-2 p-3 rounded-lg border bg-card transition-colors',
-                          isSelected ? 'ring-1 ring-inset ring-blue-400/60' : '',
+                          isSelected ? 'ring-1 ring-inset ring-primary/60' : '',
                           wasRead ? 'opacity-60' : 'hover:bg-muted/40',
                         ].filter(Boolean).join(' ')}
                       >
@@ -348,7 +348,7 @@ function InboxIndex({ inbox = [], inbox_stats = EMPTY_INBOX_STATS, filters }: Pr
                             className="shrink-0 inline-flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground px-1.5 py-1 rounded hover:bg-muted"
                             title="Marcar como lida"
                           >
-                            <span className="w-1.5 h-1.5 rounded-full bg-blue-500" aria-hidden="true" />
+                            <span className="w-1.5 h-1.5 rounded-full bg-primary" aria-hidden="true" />
                             marcar lida
                           </button>
                         ) : (

--- a/resources/js/Pages/ProjectMgmt/Triage/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/Triage/Index.tsx
@@ -297,7 +297,7 @@ function TriageIndex({
                     aria-current={isSelected ? 'true' : undefined}
                     className={[
                       'grid grid-cols-1 md:grid-cols-[minmax(0,1fr)_140px_150px_150px_150px] gap-3 px-4 py-3 items-center transition-colors',
-                      isSelected ? 'bg-muted/60 ring-1 ring-inset ring-blue-400/60' : 'hover:bg-muted/40',
+                      isSelected ? 'bg-muted/60 ring-1 ring-inset ring-primary/60' : 'hover:bg-muted/40',
                     ].join(' ')}
                   >
                     {/* Task: id + título + chips de motivo */}


### PR DESCRIPTION
## Problema

O check **`UI Lint · ratchet vs baseline`** está vermelho em `main` por dívida herdada do #1940 (telas DRAFT ProjectMgmt **Triage** + **Inbox**, "precisa gate visual"). Elas entraram com R1 (cor crua) **acima do baseline**, e o ratchet falha **por arquivo**:

```
REGRESSÃO · 2 arquivo(s) com hits AUMENTADOS:
  resources/js/Pages/ProjectMgmt/Inbox/Index.tsx  · R1 · 7  → 8  (Δ+1)
  resources/js/Pages/ProjectMgmt/Triage/Index.tsx · R1 · 21 → 22 (Δ+1)
```

Como qualquer PR que atualiza com `main` herda essas 2 regressões por arquivo, todos ficam vermelhos — foi o caso do #1965 (DS v4 Cliente roxo), que precisou ser mergeado via `--admin` mesmo **reduzindo 54 violações**.

## Fix (opção 1 — preferível: corrigir a cor, não rebaselinar)

De-hardcoda os 3 `blue-*` que as telas DRAFT introduziram, trocando pelo token semântico `primary` (accent roxo `oklch(0.55 0.15 295)`, canon DS v4 · ADR 0235):

| Arquivo | Local | Antes | Depois |
|---|---|---|---|
| `Triage/Index.tsx` | ring de seleção (J/K) | `ring-blue-400/60` | `ring-primary/60` |
| `Inbox/Index.tsx` | ring de seleção (J/K) | `ring-blue-400/60` | `ring-primary/60` |
| `Inbox/Index.tsx` | bolinha "não-lida" | `bg-blue-500` | `bg-primary` |

Resultado R1: **Triage 22 → 21** (= baseline) · **Inbox 8 → 6** (< baseline). O `config/ui-lint-baseline.json` **não foi tocado** — o ratchet só falha em regressão, ficar `≤ baseline` já passa.

## Validação (local, Herd PHP)

```
$ php artisan ui:lint --baseline=config/ui-lint-baseline.json --strict
Baseline: 7548 violações · Atual: 7491 · Delta: -57
Ok · sem regressões vs baseline
# exit 0
```

## Escopo

- **Não** mexe em `MyWork`/`Board` — os `blue-*` de lá já estão no baseline e não regridem (fora de escopo deste fix de CI).
- As 2 telas **continuam DRAFT**: o gate visual de SCREENSHOT do Wagner (ADR 0107/0114) segue pendente. Este PR só destrava o ratchet, **não** "abençoa" as telas.

Refs: ADR UI-0013, ADR 0235 · desbloqueia o ratchet introduzido por #1940 / sofrido por #1965.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
