### PR TITLE
fix(projectmgmt): Triagem + Caixa de entrada navegaveis no menu (estavam so por URL)

### DIFF
--- a/Modules/ProjectMgmt/Resources/menus/topnav.php
+++ b/Modules/ProjectMgmt/Resources/menus/topnav.php
@@ -17,11 +17,16 @@ return [
     'label' => 'Project Mgmt',
     'icon'  => 'KanbanSquare',
     'items' => [
-        ['label' => 'My Work',  'href' => '/project-mgmt/my-work',  'icon' => 'CheckSquare',   'can' => 'copiloto.mcp.usage.all'],
-        ['label' => 'Board',    'href' => '/project-mgmt/board',    'icon' => 'KanbanSquare',  'can' => 'copiloto.mcp.usage.all'],
-        ['label' => 'Backlog',  'href' => '/project-mgmt/backlog',  'icon' => 'List',          'can' => 'copiloto.mcp.usage.all'],
-        ['label' => 'Roadmap',  'href' => '/project-mgmt/roadmap',  'icon' => 'CalendarRange', 'can' => 'copiloto.mcp.usage.all'],
-        ['label' => 'Activity', 'href' => '/project-mgmt/activity', 'icon' => 'Activity',      'can' => 'copiloto.mcp.usage.all'],
-        ['label' => 'Burndown', 'href' => '/project-mgmt/burndown', 'icon' => 'TrendingDown',  'can' => 'copiloto.mcp.usage.all'],
+        ['label' => 'My Work',          'href' => '/project-mgmt/my-work',  'icon' => 'CheckSquare',   'can' => 'copiloto.mcp.usage.all'],
+        // 2026-05-29: Triagem + Caixa de entrada adicionadas ao lado de My Work.
+        // Antes só acessíveis por URL direta — agora navegáveis via nav intra-módulo.
+        // hrefs single-prefix /project-mgmt/{triage,inbox} (NÃO dobrar o prefixo).
+        ['label' => 'Triagem',          'href' => '/project-mgmt/triage',   'icon' => 'Inbox',         'can' => 'copiloto.mcp.usage.all'],
+        ['label' => 'Caixa de entrada', 'href' => '/project-mgmt/inbox',    'icon' => 'Bell',          'can' => 'copiloto.mcp.usage.all'],
+        ['label' => 'Board',            'href' => '/project-mgmt/board',    'icon' => 'KanbanSquare',  'can' => 'copiloto.mcp.usage.all'],
+        ['label' => 'Backlog',          'href' => '/project-mgmt/backlog',  'icon' => 'List',          'can' => 'copiloto.mcp.usage.all'],
+        ['label' => 'Roadmap',          'href' => '/project-mgmt/roadmap',  'icon' => 'CalendarRange', 'can' => 'copiloto.mcp.usage.all'],
+        ['label' => 'Activity',         'href' => '/project-mgmt/activity', 'icon' => 'Activity',      'can' => 'copiloto.mcp.usage.all'],
+        ['label' => 'Burndown',         'href' => '/project-mgmt/burndown', 'icon' => 'TrendingDown',  'can' => 'copiloto.mcp.usage.all'],
     ],
 ];

--- a/Modules/TeamMcp/Http/Controllers/DataController.php
+++ b/Modules/TeamMcp/Http/Controllers/DataController.php
@@ -149,8 +149,13 @@ class DataController extends Controller
                             ['key' => 'cc-sessions', 'label' => 'CC Sessions', 'href' => '/team-mcp/cc-sessions'],
                             // Wagner 2026-05-22 P0: ProjectMgmt absorvido como ghosts do hub Equipe.
                             // Zera 6 órfãs da matriz. PageHeaderTabs auto-overflow após 5 ghosts.
+                            // 2026-05-29: + Triagem + Caixa de entrada (estavam só acessíveis
+                            // por URL direta — sem entrada de navegação). hrefs single-prefix
+                            // /project-mgmt/{triage,inbox} (NÃO dobrar prefixo). Ao lado de My Work.
                             ['key' => 'board',       'label' => 'Board',       'href' => '/project-mgmt/board'],
                             ['key' => 'my-work',     'label' => 'My Work',     'href' => '/project-mgmt/my-work'],
+                            ['key' => 'triage',      'label' => 'Triagem',           'href' => '/project-mgmt/triage'],
+                            ['key' => 'inbox',       'label' => 'Caixa de entrada',  'href' => '/project-mgmt/inbox'],
                             ['key' => 'backlog',     'label' => 'Backlog',     'href' => '/project-mgmt/backlog'],
                             ['key' => 'activity',    'label' => 'Activity',    'href' => '/project-mgmt/activity'],
                             ['key' => 'burndown',    'label' => 'Burndown',    'href' => '/project-mgmt/burndown'],

--- a/resources/js/Pages/ProjectMgmt/Inbox/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/Inbox/Index.tsx
@@ -237,6 +237,7 @@ function InboxIndex({ inbox = [], inbox_stats = EMPTY_INBOX_STATS, filters }: Pr
       <PageHeader
         icon="Inbox"
         title="Caixa de entrada"
+        moduleNav
         description={`${inbox_stats.unread} não-lidas · ${inbox_stats.total_30d} nos últimos 30 dias`}
         action={
           <div className="flex items-center gap-2">

--- a/resources/js/Pages/ProjectMgmt/Triage/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/Triage/Index.tsx
@@ -231,6 +231,7 @@ function TriageIndex({
       <PageHeader
         icon="Inbox"
         title={project ? `${project.name} — Triagem` : 'Triagem'}
+        moduleNav
         description={
           `${kpis.total} pra triar · ${kpis.sem_owner} sem dono · ${kpis.sem_prio} sem prioridade · ${kpis.backlog} em backlog`
         }


### PR DESCRIPTION
## Problema

`Triagem` (`/project-mgmt/triage`) e `Caixa de entrada` (`/project-mgmt/inbox`) só eram acessíveis **digitando a URL** — não havia entrada de navegação. Quando o usuário digitava, caía em **404 por prefixo dobrado** (`/project-mgmt/project-mgmt/triage`).

## Causa

- As 2 telas existem (controllers + rotas + Inertia pages) mas **nunca foram registradas em nenhuma superfície de navegação** (nem ghosts do hub Equipe, nem topnav do módulo). Por isso o usuário recorreu a digitar a URL → dobra de prefixo.
- A dobra **não vem de nenhum link gerado** — `route('project-mgmt.triage.index')` gera single-prefix. Era artefato de digitação/colagem de path relativo.

## Solução (ADR 0180 — "sidebar é mapa de destinos; sub-views = ghosts no PageHeader")

ProjectMgmt **não tem entry própria no sidebar** (Wagner removeu 2026-05-22; virou ghosts do hub **Equipe**). Então registrei as 2 telas nas **duas superfícies canônicas de navegação intra-módulo**:

1. **`Modules/TeamMcp/Http/Controllers/DataController.php`** — ghosts do hub "Equipe", ao lado de `My Work` (mesmo padrão de Board/My Work/Backlog).
2. **`Modules/ProjectMgmt/Resources/menus/topnav.php`** — itens `Triagem` + `Caixa de entrada`.
3. **`Triage/Index.tsx` + `Inbox/Index.tsx`** — prop `moduleNav` no PageHeader liga o dropdown **"Project Mgmt ⌄"** (`PageHeaderModuleNav`, alimentado por `shell.topnavs`). Como `hideTopbar=true` é default (esconde a topbar horizontal), esse dropdown é a superfície **visível e clicável** de navegação.

hrefs **absolutos single-prefix** (`/project-mgmt/triage`, `/project-mgmt/inbox`) — sem dobra.

## Smoke headless — jornada completa provada (Playwright/Edge, MySQL real, acting as biz=1 user=1)

| Passo | Resultado |
|---|---|
| Menu lista "Triagem" → `/project-mgmt/triage` (single-prefix) | PASS |
| Menu lista "Caixa de entrada" → `/project-mgmt/inbox` (single-prefix) | PASS |
| Clicar "Caixa de entrada" no menu → navega `/project-mgmt/inbox` (sem dobra), h1 "Caixa de entrada", body 989 | PASS |
| Clicar "Triagem" no menu → navega `/project-mgmt/triage` (sem dobra), h1 "Jana — Triagem", body 1065 | PASS |
| Erros de console na jornada inteira | 0 |

Screenshots: `storage/smoke/journey-{sidebar,menu-open,inbox,triage}.png`.

## Escopo / nota

Durante o smoke detectei que **4 telas ProjectMgmt (Board, My Work, Backlog, Roadmap) estão em tela-branca** por `Inertia::defer` undefined no 1º paint (mesmo bug que Triage/Inbox já tiveram corrigido em #1962). **Fora do escopo deste PR** (1 PR = 1 intent) — flaggeado pra task separada.

Refs: ADR 0180 (sidebar v3 / ghosts) · skill `sidebar-menu-arch`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
