### PR TITLE
fix(projectmgmt): guard props Inertia::defer (Board/MyWork/Backlog/Roadmap tela branca → render)

### DIFF
--- a/resources/js/Pages/ProjectMgmt/Backlog/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/Backlog/Index.tsx
@@ -27,17 +27,25 @@ interface Kpis { total: number; active: number; p0: number; overdue: number; uno
 
 interface Props {
   project: { id: number; key: string; name: string } | null;
-  tasks: BoardTask[];
-  epics: EpicOption[];
-  owners: string[];
-  sprints: string[];
-  kpis: Kpis;
+  // tasks/kpis/epics/owners/sprints chegam via Inertia::defer (BacklogController:55-59)
+  // → `undefined` no 1º paint. Tipados opcionais + default-guard no destructuring
+  // pra NÃO crashar React antes do defer chegar (skill inertia-defer-default,
+  // Opção B; espelha OficinaAuto/ServiceOrders/Index.tsx). Sintoma do bug:
+  // tasks.length sobre undefined → tela branca.
+  tasks?: BoardTask[];
+  epics?: EpicOption[];
+  owners?: string[];
+  sprints?: string[];
+  kpis?: Kpis;
   filters: {
     status: string | null; priority: string | null; owner: string | null;
     epic: number | null; cycle: number | null; sprint: string | null;
     q: string; sort: string;
   };
 }
+
+// Default-guard pro prop deferred kpis (contadores começam zerados até o defer resolver).
+const EMPTY_KPIS: Kpis = { total: 0, active: 0, p0: 0, overdue: 0, unowned: 0 };
 
 const ALL = '__all__';
 const LS = {
@@ -59,7 +67,15 @@ function fmtDate(iso: string | null): string {
   return new Date(iso + 'T00:00:00').toLocaleDateString('pt-BR', { day: '2-digit', month: '2-digit' });
 }
 
-function BacklogIndex({ project, tasks, epics, owners, sprints, kpis, filters }: Props) {
+function BacklogIndex({
+  project,
+  tasks = [],
+  epics = [],
+  owners = [],
+  sprints = [],
+  kpis = EMPTY_KPIS,
+  filters,
+}: Props) {
   const [status, setStatus] = useState(filters.status ?? localStorage.getItem(LS.STATUS) ?? ALL);
   const [priority, setPriority] = useState(filters.priority ?? localStorage.getItem(LS.PRIORITY) ?? ALL);
   const [owner, setOwner] = useState(filters.owner ?? localStorage.getItem(LS.OWNER) ?? ALL);

--- a/resources/js/Pages/ProjectMgmt/Board/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/Board/Index.tsx
@@ -71,9 +71,15 @@ interface Props {
   kanban: Record<string, BoardTask[]>;
   kpis: Kpis;
   columns: Status[];
-  epics: EpicOption[];
-  cycles: CycleOption[];
-  owners: string[];
+  // epics/cycles/owners chegam via Inertia::defer (BoardController:109-111) →
+  // `undefined` no 1º paint. Tipados opcionais + default-guard no destructuring
+  // pra NÃO crashar React antes do defer chegar (skill inertia-defer-default,
+  // Opção B; espelha OficinaAuto/ServiceOrders/Index.tsx). Sintoma do bug:
+  // cycles.map() sobre undefined → tela branca. kanban/kpis/columns/cycle ficam
+  // eager (rollback PR #963 — atalhos J/K exigem cards já no initial render).
+  epics?: EpicOption[];
+  cycles?: CycleOption[];
+  owners?: string[];
   filters: {
     project: string | null;
     cycle: number | null;
@@ -92,7 +98,7 @@ const LS = {
 
 const ALL = '__all__';
 
-function BoardIndex({ project, cycle, kanban, kpis, columns, epics, cycles, owners, filters }: Props) {
+function BoardIndex({ project, cycle, kanban, kpis, columns, epics = [], cycles = [], owners = [], filters }: Props) {
   // ── Filtros (controlled, com fallback pro localStorage)
   const [cycleId, setCycleId] = useState<string>(() => {
     if (filters.cycle) return String(filters.cycle);

--- a/resources/js/Pages/ProjectMgmt/MyWork/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/MyWork/Index.tsx
@@ -55,12 +55,21 @@ interface Kpis { doing: number; review: number; blocked: number; p0: number; ove
 interface Props {
   project: { id: number; key: string; name: string } | null;
   username: string;
-  my_work: MyWorkBucket[];
-  inbox: InboxItem[];
-  inbox_stats: { unread: number; total_30d: number };
-  kpis: Kpis;
+  // my_work/inbox/inbox_stats/kpis chegam via Inertia::defer (MyWorkController:50-53)
+  // → `undefined` no 1º paint. Tipados opcionais + default-guard no destructuring
+  // pra NÃO crashar React antes do defer chegar (skill inertia-defer-default,
+  // Opção B; espelha OficinaAuto/ServiceOrders/Index.tsx). Sintoma do bug:
+  // my_work.forEach() sobre undefined → tela branca.
+  my_work?: MyWorkBucket[];
+  inbox?: InboxItem[];
+  inbox_stats?: { unread: number; total_30d: number };
+  kpis?: Kpis;
   filters: { show_read: boolean };
 }
+
+// Default-guard pros props deferred (começam vazios/zerados até o defer resolver).
+const EMPTY_KPIS: Kpis = { doing: 0, review: 0, blocked: 0, p0: 0, overdue: 0, unread: 0 };
+const EMPTY_INBOX_STATS = { unread: 0, total_30d: 0 };
 
 const LS_FOCUS = 'oimpresso.mywork.focus';
 
@@ -102,7 +111,15 @@ function csrfToken(): string {
   return (document.querySelector('meta[name="csrf-token"]') as HTMLMetaElement)?.content ?? '';
 }
 
-function MyWorkIndex({ project, username, my_work, inbox, inbox_stats, kpis, filters }: Props) {
+function MyWorkIndex({
+  project,
+  username,
+  my_work = [],
+  inbox = [],
+  inbox_stats = EMPTY_INBOX_STATS,
+  kpis = EMPTY_KPIS,
+  filters,
+}: Props) {
   const [focus, setFocus] = useState<'work' | 'inbox'>(() => {
     if (typeof window === 'undefined') return 'work';
     return (localStorage.getItem(LS_FOCUS) as 'work' | 'inbox') === 'inbox' ? 'inbox' : 'work';

--- a/resources/js/Pages/ProjectMgmt/Roadmap/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/Roadmap/Index.tsx
@@ -30,9 +30,17 @@ interface QuarterBucket { key: string; epics: Epic[] }
 
 interface Props {
   project: { id: number; key: string; name: string } | null;
-  quarters: QuarterBucket[];
-  kpis: { total_epics: number; active_epics: number; planning_epics: number; done_epics: number };
+  // quarters/kpis chegam via Inertia::defer (RoadmapController:40-41) → `undefined`
+  // no 1º paint. Tipados opcionais + default-guard no destructuring pra NÃO crashar
+  // React antes do defer chegar (skill inertia-defer-default, Opção B; espelha
+  // OficinaAuto/ServiceOrders/Index.tsx). Sintoma do bug: kpis.total_epics sobre
+  // undefined → tela branca.
+  quarters?: QuarterBucket[];
+  kpis?: { total_epics: number; active_epics: number; planning_epics: number; done_epics: number };
 }
+
+// Default-guard pro prop deferred kpis (contadores começam zerados até o defer resolver).
+const EMPTY_KPIS = { total_epics: 0, active_epics: 0, planning_epics: 0, done_epics: 0 };
 
 const STATUS_BADGE = {
   planning:  'bg-slate-100 text-slate-600 dark:bg-slate-800 dark:text-slate-300',
@@ -86,7 +94,7 @@ function EpicCard({ e }: { e: Epic }) {
   );
 }
 
-function RoadmapIndex({ project, quarters, kpis }: Props) {
+function RoadmapIndex({ project, quarters = [], kpis = EMPTY_KPIS }: Props) {
   return (
     <>
       <PageHeader


### PR DESCRIPTION
## Problema

4 telas do ProjectMgmt renderizavam **tela branca** (crash do React no 1º paint).
Os controllers deferem props caras via `Inertia::defer(...)`, então elas chegam
`undefined` no primeiro render; as Pages tipavam essas props como obrigatórias e
chamavam `.map`/`.forEach`/`.length`/acesso-a-propriedade sem default-guard →
`Cannot read properties of undefined`.

Confirmado quebrado (headless, MySQL real, user 1 / biz=1):

| Rota | Erro | Página |
|---|---|---|
| `/project-mgmt/board` | `reading 'map'` | `Board/Index.tsx` |
| `/project-mgmt/my-work` | `reading 'forEach'` | `MyWork/Index.tsx` |
| `/project-mgmt/backlog` | `reading 'length'` | `Backlog/Index.tsx` |
| `/project-mgmt/roadmap` | `reading 'total_epics'` | `Roadmap/Index.tsx` |

Saudáveis (já corrigidas em #1962, usadas como referência): `/project-mgmt/triage` e `/project-mgmt/inbox`.

## Fix

Mesmo padrão da skill `inertia-defer-default` **Opção B** (props opcionais `?:` +
default no destructuring), espelhando #1962 (Triage/Inbox) e o canon
`OficinaAuto/ServiceOrders/Index.tsx`. Props eager (`project`/`filters`/`columns`/
`kanban`/`kpis` do Board, etc.) ficam intactas. Sem mudança de UI ou comportamento — só guard.

Guard por página (= exatamente os props deferidos no controller):

- **Board** — `epics`/`cycles`/`owners` → `[]`
- **MyWork** — `my_work`/`inbox` → `[]`, `inbox_stats`/`kpis` → `EMPTY_*`
- **Backlog** — `tasks`/`epics`/`owners`/`sprints` → `[]`, `kpis` → `EMPTY_KPIS`
- **Roadmap** — `quarters` → `[]`, `kpis` → `EMPTY_KPIS`

## Verificação (headless · `oimpresso.test` · user 1 / biz=1 · MySQL real)

Build fresco do branch servido no ambiente real e cada rota carregada com cache-bust:

| Rota | h1 renderizado | console errors |
|---|---|---|
| `/project-mgmt/board` | "Jana — Board" | **0** |
| `/project-mgmt/my-work` | "Bom dia, wr23" | **0** |
| `/project-mgmt/backlog` | "Jana — Backlog" (tabela) | **0** |
| `/project-mgmt/roadmap` | "Jana — Roadmap" | **0** |

Antes do fix: `h1=0` + `TypeError` no console. Ambiente local restaurado ao estado original após o teste.

`tsc --noEmit`: nenhum erro **novo** nestas 4 páginas (os `preserveScroll`/`noUncheckedIndexedAccess` que aparecem são pré-existentes — Triage/Inbox, já mergeadas, têm os mesmos).

## Nota: Burndown (verificado, **não** quebrado)

`BurndownController` também defere (`cycles`/`cycle`/`series`/`kpis`), mas
`Burndown/Index.tsx` tem `if (!cycle) return <empty state>` logo no topo. Como
`cycle` também é deferido e os defers do grupo default resolvem juntos, o 1º paint
cai no early-return (renderiza h1, sem crash) e, quando o defer resolve, todos os
props chegam juntos. Logo **não exibe o bug**. Um guard defensivo (Opção B) seria
consistência opcional, não correção — fora do escopo deste PR (1 PR = 1 intent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
