### PR TITLE
feat(design-system): Onda F — vocabulário de formulário (v4.1)

### DIFF
--- a/prototipo-ui/design-system.css
+++ b/prototipo-ui/design-system.css
@@ -1420,3 +1420,91 @@
   --ok-bg: oklch(0.30 0.07 145); --warn-bg: oklch(0.30 0.07 60); --danger-bg: oklch(0.30 0.07 25);
   border-radius: var(--radius-md); padding: 20px;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   F · ONDA F — VOCABULÁRIO DE FORMULÁRIO (v4.1 · 2026-05-29)
+   Promovido de "Design System v4.html". Origem: diagnóstico KB-9.75 do
+   cadastro de Contacts (Cliente/Create). 4 componentes que faltavam pra
+   todo Create do ERP + máscaras + obrigatório. Zero token novo, nenhuma
+   classe redeclarada. Aplicar nas telas Create é o passo F3 seguinte.
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* ── F1 · Segmented control ── (PF/PJ · Cliente/Fornecedor · vistas) */
+.segmented{
+  display: inline-flex; gap: 2px; padding: 2px;
+  background: var(--bg-2); border: 1px solid var(--border);
+  border-radius: var(--radius);
+}
+.segmented button, .segmented .seg{
+  font: 500 12px/1 var(--font-sans); color: var(--text-dim);
+  background: transparent; border: 0;
+  border-radius: calc(var(--radius) - 2px);
+  padding: 6px 13px; cursor: pointer;
+  transition: background var(--t-fast), color var(--t-fast);
+}
+.segmented button:hover{ color: var(--text); }
+.segmented button.on, .segmented .seg.on, .segmented button[aria-selected="true"]{
+  background: var(--surface); color: var(--text); font-weight: 600;
+  box-shadow: var(--shadow-1);
+}
+.segmented.accent button.on{ color: var(--accent); }
+.segmented:focus-within{ box-shadow: 0 0 0 3px var(--accent-soft); }
+
+/* ── F2 · Input group ── input + addon/botão à direita (CNPJ+Buscar, R$) */
+.input-group{ display: flex; align-items: stretch; }
+.input-group > .input{ border-top-right-radius: 0; border-bottom-right-radius: 0; flex: 1; min-width: 0; }
+.input-group > .ig-btn{
+  display: inline-flex; align-items: center; gap: 5px; white-space: nowrap;
+  padding: 0 12px; height: var(--field-h);
+  font: 500 12px/1 var(--font-sans); color: var(--text);
+  background: var(--bg-2); border: 1px solid var(--border); border-left: 0;
+  border-radius: 0 var(--radius) var(--radius) 0; cursor: pointer;
+  transition: background var(--t-fast), color var(--t-fast);
+}
+.input-group > .ig-btn:hover{ background: var(--surface); }
+.input-group > .ig-btn svg{ width: 13px; height: 13px; }
+.input-group > .ig-btn.loading{ color: var(--text-mute); pointer-events: none; }
+.input-group > .ig-btn.done{ color: var(--ok-fg); background: var(--ok-bg); border-color: transparent; }
+.input-group > .ig-addon{
+  display: inline-flex; align-items: center; padding: 0 10px; height: var(--field-h);
+  font: 500 12px/1 var(--font-mono); color: var(--text-mute);
+  background: var(--bg-2); border: 1px solid var(--border); border-right: 0;
+  border-radius: var(--radius) 0 0 var(--radius);
+}
+.input-group > .ig-addon + .input{ border-top-left-radius: 0; border-bottom-left-radius: 0; }
+
+/* ── F3 · Estado de campo: validando + sucesso ── (completa o trio do .field-error) */
+.field-success{
+  display: inline-flex; align-items: center; gap: 6px; margin-top: 4px;
+  font: 500 11.5px/1.4 var(--font-sans); color: var(--ok-fg);
+}
+.field-success svg{ flex: 0 0 12px; width: 12px; height: 12px; }
+.field-validating{
+  display: inline-flex; align-items: center; gap: 6px; margin-top: 4px;
+  font: 400 11.5px/1.4 var(--font-sans); color: var(--text-mute);
+}
+.field-validating .spin{ width: 12px; height: 12px; animation: spin 0.7s linear infinite; } /* reusa @keyframes spin existente */
+.req{ color: var(--danger-fg); margin-left: 2px; font-weight: 700; }
+
+/* ── F4 · Form section + grid ── (substitui o <Section> hand-rolled de Create.tsx) */
+.form-section{
+  background: var(--surface); border: 1px solid var(--border);
+  border-radius: var(--radius-md); padding: 14px 16px; margin-bottom: 12px;
+}
+.form-section > .form-section-h{
+  display: flex; align-items: center; gap: 8px; margin: 0 0 12px;
+  font: 700 10.5px/1 var(--font-sans);
+  letter-spacing: 0.05em; text-transform: uppercase; color: var(--text-mute);
+}
+.form-section > .form-section-h svg{ width: 14px; height: 14px; color: var(--accent); }
+.form-section > .form-section-h .count{
+  margin-left: auto; font: 600 10px/1 var(--font-mono);
+  letter-spacing: 0; text-transform: none; color: var(--text-mute);
+}
+.form-grid{ display: grid; grid-template-columns: 1fr 1fr; gap: 10px 12px; }
+.form-grid > .col2{ grid-column: 1 / -1; }
+
+/* ── F5 · Layout Create: form + rail de contexto ── (pattern PT-03b) */
+.form-layout{ display: grid; grid-template-columns: 1fr 312px; gap: 16px; align-items: start; }
+.form-layout > .form-rail{ position: sticky; top: 16px; display: flex; flex-direction: column; gap: 14px; }
+@container (max-width: 900px){ .form-layout{ grid-template-columns: 1fr; } }


### PR DESCRIPTION
## O quê

Promove a **Onda F (v4.1)** do `Design System v4.html` pro `prototipo-ui/design-system.css` canônico — os 5 grupos de componentes de formulário que faltavam pra todo **Create** do ERP. Origem: diagnóstico **KB-9.75** do cadastro de Contacts (`Cliente/Create.tsx` + `DadosFiscaisBRSection`), exportado como design handoff bundle do Cowork.

## Componentes (zero token novo)

| Classe | Substitui / serve |
|---|---|
| `.segmented` (+`.accent`) | radio nativo PF/PJ e Cliente/Fornecedor |
| `.input-group` (`.ig-btn .loading/.done`, `.ig-addon`) | input + botão/addon — CNPJ+Buscar, CEP+ViaCEP, prefixo R$/% |
| `.field-success` / `.field-validating` / `.req` | completa o trio de estado com o `.field-error` existente |
| `.form-section` / `.form-grid` (`.col2`) | unifica o `<Section>` hand-rolled duplicado de Create.tsx |
| `.form-layout` / `.form-rail` | pattern "Create = form + rail de contexto" (PT-03b) |

## Por que é seguro (contrato Code do DS)

- ✅ **Zero token novo** — usa só os 18 tokens existentes de `tokens.css`
- ✅ **Nenhuma classe redeclarada** — cada seletor definido 1×, sem colisão (`.count`/`.seg` ficam escopados sob `.form-section-h`/`.segmented`)
- ✅ **Zero cor hardcoded** — spinner reusa `@keyframes spin`; lift usa `var(--shadow-1)` em vez do `rgba()` do showcase
- ✅ **Puramente aditivo** — +88 linhas, nada removido/alterado
- ✅ Braces balanceadas (506/506)

## Fora de escopo (decisão sua)

- **Shell roxo / v4 full** (`tokens.css` hue 220→295) — **supersede ADR 0190**, recolore tudo que consome os tokens. Branch separada (`feat/design-system-v4-roxo`).
- **F3** — aplicar nas telas Create reais (radio→segmented, Section→form-section, rail). PR próprio, governado por MWART.
- **Showcase** — `Design System v4.html` (seção `#form-vocab`) ainda não está no repo; landa junto com o v4 full se quiser demo navegável.

🤖 Generated with [Claude Code](https://claude.com/claude-code)