### PR TITLE
feat(design-system): completa DS v4 roxo — flip --accent dos 6 bundles cowork

### DIFF
--- a/prototipo-ui/AUDITORIA_DS_V4.md
+++ b/prototipo-ui/AUDITORIA_DS_V4.md
@@ -32,7 +32,7 @@ Violam *"não redeclarar tokens"* (CODE_DESIGN_CONTRACT) e ficarão azuis enquan
 - `resources/css/sells-cowork-show.css`
 - `resources/css/sells-cowork.css`
 
-→ **Ação futura:** remover a redefinição local; herdar `--accent` roxo do `cockpit.css`. (Fora do escopo deste PR.)
+→ **✅ RESOLVIDO** (PR `feat/ds-v4-cowork-bundles-accent-roxo`, 2026-05-29): flip dos 6 bundles `--accent`/`--accent-2`/`--accent-soft` (claro + escuro) azul 220 → roxo 295, **escopado só nas linhas `--accent*`** — `--bubble-me` e `--status-partial` (que compartilham o valor azul `oklch(0.58 0.09 220)`) ficam azuis de propósito. Optou-se por **flip de valor** (não remover a redeclaração) por ser independente da ordem de carga do CSS; o débito DRY (herdar de `cockpit.css`) fica pra depois.
 
 ## 3. Débito — telas Inertia/React com AZUL HARDCODED (`blue-*` Tailwind)
 
@@ -57,6 +57,6 @@ Violam *"não redeclarar tokens"* (CODE_DESIGN_CONTRACT) e ficarão azuis enquan
 |---|---|
 | Shell/primary do app (`cockpit.css`) | ✅ roxo (ADR 0190) |
 | Fundação de referência (`prototipo-ui/`) | ✅ roxo (este PR) |
-| Bundles CSS financeiro/sells | ❌ azul 220 redeclarado (§2) |
+| Bundles CSS financeiro/sells | ✅ roxo 295 (flip neste PR · §2) |
 | Telas Inertia (`blue-*` hardcoded) | ❌ 106 arquivos (§3 — PR-2 começa pela `Cliente/`) |
 | Blade legado `contact.*` | ⬜ fora do DS (§4) |

--- a/resources/css/cowork-canon-financeiro-bundle.css
+++ b/resources/css/cowork-canon-financeiro-bundle.css
@@ -21,9 +21,9 @@
   --text-dim:     oklch(0.50 0.01 80);
   --text-mute:    oklch(0.65 0.01 80);
 
-  --accent:       oklch(0.58 0.09 220);
-  --accent-2:     oklch(0.66 0.09 220);
-  --accent-soft:  oklch(0.94 0.025 220);
+  --accent:       oklch(0.55 0.15 295);
+  --accent-2:     oklch(0.62 0.15 295);
+  --accent-soft:  oklch(0.95 0.04 295);
   --accent-fg:    #ffffff;
 
   --bubble-me:    oklch(0.58 0.09 220);
@@ -61,7 +61,7 @@
   --text-dim:  oklch(0.68 0.005 90);
   --text-mute: oklch(0.55 0.005 90);
   --bubble-them: oklch(0.24 0.005 240);
-  --accent-soft: oklch(0.30 0.04 220);
+  --accent-soft: oklch(0.32 0.06 295);
 
   --origin-OS-bg:  oklch(0.30 0.07 60);   --origin-OS-fg:  oklch(0.85 0.07 60);
   --origin-CRM-bg: oklch(0.30 0.07 220);  --origin-CRM-fg: oklch(0.85 0.07 220);

--- a/resources/css/cowork-financeiro-bundle.css
+++ b/resources/css/cowork-financeiro-bundle.css
@@ -49,9 +49,9 @@
   --text-dim:     oklch(0.50 0.01 80);
   --text-mute:    oklch(0.65 0.01 80);
 
-  --accent:       oklch(0.58 0.09 220);
-  --accent-2:     oklch(0.66 0.09 220);
-  --accent-soft:  oklch(0.94 0.025 220);
+  --accent:       oklch(0.55 0.15 295);
+  --accent-2:     oklch(0.62 0.15 295);
+  --accent-soft:  oklch(0.95 0.04 295);
   --accent-fg:    #ffffff;
 
   --bubble-me:    oklch(0.58 0.09 220);
@@ -89,7 +89,7 @@
   --text-dim:  oklch(0.68 0.005 90);
   --text-mute: oklch(0.55 0.005 90);
   --bubble-them: oklch(0.24 0.005 240);
-  --accent-soft: oklch(0.30 0.04 220);
+  --accent-soft: oklch(0.32 0.06 295);
 
   --origin-OS-bg:  oklch(0.30 0.07 60);   --origin-OS-fg:  oklch(0.85 0.07 60);
   --origin-CRM-bg: oklch(0.30 0.07 220);  --origin-CRM-fg: oklch(0.85 0.07 220);

--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -518,9 +518,9 @@
   --text-dim:     oklch(0.50 0.01 80);
   --text-mute:    oklch(0.65 0.01 80);
 
-  --accent:       oklch(0.58 0.09 220);
-  --accent-2:     oklch(0.66 0.09 220);
-  --accent-soft:  oklch(0.94 0.025 220);
+  --accent:       oklch(0.55 0.15 295);
+  --accent-2:     oklch(0.62 0.15 295);
+  --accent-soft:  oklch(0.95 0.04 295);
   --accent-fg:    #ffffff;
 
   --radius:       8px;

--- a/resources/css/sells-cowork-edit.css
+++ b/resources/css/sells-cowork-edit.css
@@ -34,9 +34,9 @@
   --text-dim:     oklch(0.50 0.01 80);
   --text-mute:    oklch(0.65 0.01 80);
 
-  --accent:       oklch(0.58 0.09 220);
-  --accent-2:     oklch(0.66 0.09 220);
-  --accent-soft:  oklch(0.94 0.025 220);
+  --accent:       oklch(0.55 0.15 295);
+  --accent-2:     oklch(0.62 0.15 295);
+  --accent-soft:  oklch(0.95 0.04 295);
   --accent-fg:    #ffffff;
 
   /* Form states (focus/error — semantic via oklch) */
@@ -76,7 +76,7 @@
   --text:      oklch(0.92 0.005 90);
   --text-dim:  oklch(0.68 0.005 90);
   --text-mute: oklch(0.55 0.005 90);
-  --accent-soft:  oklch(0.30 0.04 220);
+  --accent-soft:  oklch(0.32 0.06 295);
   --focus-ring:   oklch(0.55 0.10 220);
   --error-bg:     oklch(0.28 0.08 25);
   --disabled-bg:  oklch(0.18 0.003 240);

--- a/resources/css/sells-cowork-show.css
+++ b/resources/css/sells-cowork-show.css
@@ -31,9 +31,9 @@
   --text-dim:     oklch(0.50 0.01 80);
   --text-mute:    oklch(0.65 0.01 80);
 
-  --accent:       oklch(0.58 0.09 220);
-  --accent-2:     oklch(0.66 0.09 220);
-  --accent-soft:  oklch(0.94 0.025 220);
+  --accent:       oklch(0.55 0.15 295);
+  --accent-2:     oklch(0.62 0.15 295);
+  --accent-soft:  oklch(0.95 0.04 295);
   --accent-fg:    #ffffff;
 
   /* Status pgto (semantic colors via oklch — NÃO bg-*-500 cru) */
@@ -75,7 +75,7 @@
   --text:      oklch(0.92 0.005 90);
   --text-dim:  oklch(0.68 0.005 90);
   --text-mute: oklch(0.55 0.005 90);
-  --accent-soft: oklch(0.30 0.04 220);
+  --accent-soft: oklch(0.32 0.06 295);
   --status-paid-bg:    oklch(0.28 0.06 145);
   --status-due-bg:     oklch(0.28 0.07 75);
   --status-partial-bg: oklch(0.28 0.05 220);

--- a/resources/css/sells-cowork.css
+++ b/resources/css/sells-cowork.css
@@ -39,9 +39,9 @@
   --text-dim:     oklch(0.50 0.01 80);
   --text-mute:    oklch(0.65 0.01 80);
 
-  --accent:       oklch(0.58 0.09 220);
-  --accent-2:     oklch(0.66 0.09 220);
-  --accent-soft:  oklch(0.94 0.025 220);
+  --accent:       oklch(0.55 0.15 295);
+  --accent-2:     oklch(0.62 0.15 295);
+  --accent-soft:  oklch(0.95 0.04 295);
   --accent-fg:    #ffffff;
 
   --bubble-me:    oklch(0.58 0.09 220);
@@ -79,7 +79,7 @@
   --text-dim:  oklch(0.68 0.005 90);
   --text-mute: oklch(0.55 0.005 90);
   --bubble-them: oklch(0.24 0.005 240);
-  --accent-soft: oklch(0.30 0.04 220);
+  --accent-soft: oklch(0.32 0.06 295);
 
   --origin-OS-bg:  oklch(0.30 0.07 60);   --origin-OS-fg:  oklch(0.85 0.07 60);
   --origin-CRM-bg: oklch(0.30 0.07 220);  --origin-CRM-fg: oklch(0.85 0.07 220);


### PR DESCRIPTION
## O quê

Fecha o **débito §2** da `prototipo-ui/AUDITORIA_DS_V4.md` / **ADR 0235** (DS v4 roxo universal): os 6 bundles CSS de **financeiro** e **sells** ainda redeclaravam `--accent` em **azul 220**, ficando inconsistentes com o shell que já é **roxo 295** (`cockpit.css`). Este PR alinha os bundles ao DS v4 roxo.

## Mudança (24 linhas de token · 6 arquivos)

| token | antes (azul) | depois (roxo 295) |
|---|---|---|
| `--accent` | `oklch(0.58 0.09 220)` | `oklch(0.55 0.15 295)` |
| `--accent-2` | `oklch(0.66 0.09 220)` | `oklch(0.62 0.15 295)` |
| `--accent-soft` (claro) | `oklch(0.94 0.025 220)` | `oklch(0.95 0.04 295)` |
| `--accent-soft` (escuro) | `oklch(0.30 0.04 220)` | `oklch(0.32 0.06 295)` |

Valores idênticos ao `cockpit.css` (fonte canônica do accent roxo).

## Cuidado tomado (não é find/replace cego)

- ✅ **Escopado só nas linhas `--accent*`.** `--bubble-me` (balão de chat, 3 arquivos) e `--status-partial` (badge, 1 arquivo) **compartilham** o mesmo azul `oklch(0.58 0.09 220)` e **ficam azuis de propósito** — verificado pós-flip.
- ✅ **Line endings preservados** (flip byte-level CRLF/LF) — diff limpo de 25/25 linhas, sem ruído de normalização.
- ✅ **Flip de valor** (não remoção da redeclaração) — independe da ordem de carga do CSS. Débito DRY ("herdar de `cockpit.css`") anotado na auditoria pra depois.

## ⚠️ Gate visual antes do merge

Recolore foco/links/estado-ativo de **financeiro + sells** (telas da Larissa @ biz=4) — é o **mesmo roxo já em uso no shell**, então deve ficar consistente (reduz inconsistência, não introduz design novo). Mesmo assim recomendo **smoke browser** nessas telas antes do merge (regra R1 do projeto). Rodo se a app estiver acessível.

## Próximo (ADR 0235 §3 — fora deste PR)

~106 telas `.tsx` com `blue-*` hardcoded → migração tela-por-tela pro token `primary`, começando por `Pages/Cliente/` (o cadastro do KB-9.75).

🤖 Generated with [Claude Code](https://claude.com/claude-code)