### PR TITLE
feat(design-system): Financeiro/Cobrança — brand-blue → primary (roxo)

### DIFF
--- a/resources/js/Pages/Financeiro/Cobranca/Index.tsx
+++ b/resources/js/Pages/Financeiro/Cobranca/Index.tsx
@@ -351,7 +351,7 @@ function CobrancaPage({ cobrancas, kpis, funil, accounts = [], gateways = [], fi
                   return (
                     <tr key={c.id} onClick={() => setDrawer(c)} className={cn(
                       'border-b border-stone-100 hover:bg-stone-50/60 cursor-pointer',
-                      isFocus && 'bg-blue-50/40 ring-1 ring-inset ring-blue-300',
+                      isFocus && 'bg-primary/5 ring-1 ring-inset ring-primary/30',
                     )}>
                       <td className="pl-5 pr-2 py-2.5 text-stone-700">
                         <div className="font-medium">{fmtDate(c.vencimento)}</div>

--- a/resources/js/Pages/Financeiro/Cobranca/_components/FunnelStrip.tsx
+++ b/resources/js/Pages/Financeiro/Cobranca/_components/FunnelStrip.tsx
@@ -23,12 +23,12 @@ export default function FunnelStrip({ funil }: { funil: CobrancaFunil }) {
         ].map((s, i) => (
           <div key={i} className={cn(
             'flex-1 px-4 py-3 border-r border-stone-100 last:border-r-0',
-            s.active && 'bg-blue-50/40',
+            s.active && 'bg-primary/5',
             s.alert && 'bg-rose-50/40',
           )}>
             <div className={cn(
               'text-[10.5px] font-medium',
-              s.alert ? 'text-rose-700' : s.active ? 'text-blue-700' : 'text-stone-500',
+              s.alert ? 'text-rose-700' : s.active ? 'text-primary' : 'text-stone-500',
             )}>{s.l}</div>
             <div className="text-[18px] font-semibold tabular-nums tracking-tight mt-1">{s.v}</div>
             <div className={cn(


### PR DESCRIPTION
## O quê

Migra os **estados de interação azul-de-marca** (foco de linha, etapa ativa do funil) em **Financeiro/Cobrança** pro token `primary` (roxo DS v4) — fechando o azul-de-marca remanescente nas telas client-facing.

| Arquivo | Onde | Antes | Depois |
|---|---|---|---|
| `Cobranca/Index.tsx` | ring de foco da linha (nav J/K) | `bg-blue-50/40 ring-blue-300` | `bg-primary/5 ring-primary/30` |
| `Cobranca/_components/FunnelStrip.tsx` | etapa ativa do funil (bg) | `bg-blue-50/40` | `bg-primary/5` |
| `Cobranca/_components/FunnelStrip.tsx` | etapa ativa do funil (texto) | `text-blue-700` | `text-primary` |

## Por que SÓ isto (o achado)

Auditei todo o client-facing (Sells + Financeiro + RecurringBilling). A maior parte do azul é **semântico** e fica azul de propósito:
- **Status:** `partial`/`pending`/`overdue`/`aberto`/`emitida` (paletas verde/âmbar/azul/vermelho)
- **Tipo:** remessa/retorno, NFe/NFSe, conta corrente/virtual, plano de contas
- **Contábil:** Débito (azul) × Crédito (âmbar)
- **Evento/categoria:** dots de evento, visualizador de hue, cores de período
- **Marca de terceiro:** gateway Asaas (azul é a marca deles)

Converter esses quebraria o **código de cor** que a Larissa usa pra ler status. O azul-de-marca real (foco/ativo = accent) já tinha sido migrado no shell e no `Cliente/` (ADR 0235 §4); o que sobrava em client-facing era este punhado no Cobrança.

## Estado do "design novo full"

Com este PR + os anteriores (#1971 Onda F, #1974 bundles roxo), o **brand→roxo está completo no client-facing**. O `blue-*` restante no app (~100 arquivos) é majoritariamente semântico (status/tipo/charts) que deve ficar azul. Telas internas (governance/ads/team-mcp) podem ter algum azul-de-marca residual — separado, baixa prioridade.

## ⚠️ Gate visual

As opacidades (`primary/5`, `ring-primary/30`) são equivalentes do azul original — confirma no smoke se o realce de foco/etapa-ativa ficou na intensidade certa.

🤖 Generated with [Claude Code](https://claude.com/claude-code)