### PR TITLE
feat(design-system): varredura azul-de-marca → primary (roxo) — 28 telas

### DIFF
--- a/prototipo-ui/AUDITORIA_DS_V4.md
+++ b/prototipo-ui/AUDITORIA_DS_V4.md
@@ -34,18 +34,21 @@ Violam *"não redeclarar tokens"* (CODE_DESIGN_CONTRACT) e ficarão azuis enquan
 
 → **✅ RESOLVIDO** (PR `feat/ds-v4-cowork-bundles-accent-roxo`, 2026-05-29): flip dos 6 bundles `--accent`/`--accent-2`/`--accent-soft` (claro + escuro) azul 220 → roxo 295, **escopado só nas linhas `--accent*`** — `--bubble-me` e `--status-partial` (que compartilham o valor azul `oklch(0.58 0.09 220)`) ficam azuis de propósito. Optou-se por **flip de valor** (não remover a redeclaração) por ser independente da ordem de carga do CSS; o débito DRY (herdar de `cockpit.css`) fica pra depois.
 
-## 3. Débito — telas Inertia/React com AZUL HARDCODED (`blue-*` Tailwind)
+## 3. Telas Inertia/React com `blue-*` hardcoded — VARRIDO
 
-**106 arquivos `.tsx`** com `blue-[3-8]00` / hex azul. Não seguem o token → ficam azuis no shell roxo. Piores no cadastro citado pelo Wagner (`Pages/Cliente/`):
+A contagem inicial de "106 arquivos com `blue-*`" era **enganosa**: a grande maioria é azul **SEMÂNTICO** (paletas de status/tipo/categoria/chart — `paid`/`partial`/`overdue`, `remessa`/`retorno`, NFe/NFSe, Débito×Crédito, dots de evento, cores de gráfico/hue, marca Asaas, convenção "lida" do WhatsApp) que **deve ficar azul** — converter quebraria o código de cor que o usuário lê.
 
-| Arquivo | Onde aparece o azul |
-|---|---|
-| `Pages/Cliente/Index.tsx` | abas ativas, seleção de linha (`ring-blue-300`), checkbox (`bg-blue-500`), chips de filtro |
-| `Pages/Cliente/Import.tsx` | ícones, dropzone hover, barra de progresso |
-| `Pages/Cliente/Map.tsx` | item selecionado, link |
-| `Pages/Cliente/Show.tsx` + `_show/*` + `_drawer/*` | abas, links de venda, focus ring, cards IA/OS |
+O **azul-de-marca** (o accent do app — links, focus rings, seleção/ativo, botões primários) foi migrado pro token `primary` (roxo) em ondas:
 
-→ **Ação:** PR `feat/cliente-accent-roxo` corrige a `Cliente/` (azul de marca/seleção/foco → token roxo; preserva azuis de status/info semântico). Demais telas por prioridade.
+| Onda / PR | Escopo | Estado |
+|---|---|---|
+| `Cliente/` (ADR 0235 §4, prévio) | cadastro KB-9.75 — primeira tela | ✅ roxo |
+| #1975 `feat/financeiro-cobranca-accent-roxo` | Sells (já só-semântico) + Financeiro/Cobrança (foco de linha + funil ativo) | ✅ roxo |
+| `feat/ds-v4-finish-brand-blue-roxo` (este) | **28 telas** restantes: ads/Admin, OficinaAuto, ProjectMgmt, Financeiro, team-mcp, governance, kb, Admin, Settings, Modules, Manufacturing, Purchase (links + focus + seleção + botões primários) | ✅ roxo |
+
+**Regra aplicada:** azul entre cores-irmãs de status/tipo → SEMÂNTICO, preserva. Azul de link/foco/seleção/ativo/ação-primária → BRAND, vira `primary`. Na dúvida, preserva.
+
+**Pendências menores (preservadas — decisão de design p/ Claude Design):** stripe decorativo `border-l-blue-500` ("Goal do cycle" em ProjectMgmt Burndown/Board), gradiente do logo (`ConsultaOs` `from-blue-500 to-violet-600`), tick "lida" do WhatsApp, dot de não-lido (MyWork). Flagados mas mantidos azuis por não serem claramente accent.
 
 ## 4. Telas Blade legado (UltimatePOS) — fora do DS
 
@@ -58,5 +61,5 @@ Violam *"não redeclarar tokens"* (CODE_DESIGN_CONTRACT) e ficarão azuis enquan
 | Shell/primary do app (`cockpit.css`) | ✅ roxo (ADR 0190) |
 | Fundação de referência (`prototipo-ui/`) | ✅ roxo (este PR) |
 | Bundles CSS financeiro/sells | ✅ roxo 295 (flip neste PR · §2) |
-| Telas Inertia (`blue-*` hardcoded) | ❌ 106 arquivos (§3 — PR-2 começa pela `Cliente/`) |
+| Telas Inertia (azul-de-marca) | ✅ roxo — Cliente + #1975 + sweep 28 telas (§3); resto é azul semântico que fica |
 | Blade legado `contact.*` | ⬜ fora do DS (§4) |

--- a/resources/js/Pages/Admin/FeatureFlags/Index.tsx
+++ b/resources/js/Pages/Admin/FeatureFlags/Index.tsx
@@ -127,7 +127,7 @@ export default function FeatureFlagsIndex({
                       <td className="py-2 font-mono">
                         <Link
                           href={route('admin.feature-flags.show', { key: f.id })}
-                          className="text-blue-600 hover:underline"
+                          className="text-primary hover:underline"
                         >
                           {f.id}
                         </Link>
@@ -152,7 +152,7 @@ export default function FeatureFlagsIndex({
                       <td>
                         <Link
                           href={route('admin.feature-flags.show', { key: f.id })}
-                          className="text-blue-600 hover:underline text-xs"
+                          className="text-primary hover:underline text-xs"
                         >
                           editar →
                         </Link>
@@ -201,7 +201,7 @@ export default function FeatureFlagsIndex({
                       <td className="font-mono">
                         <Link
                           href={route('admin.feature-flags.show', { key: a.flag_key })}
-                          className="text-blue-600 hover:underline"
+                          className="text-primary hover:underline"
                         >
                           {a.flag_key}
                         </Link>

--- a/resources/js/Pages/Admin/FeatureFlags/Show.tsx
+++ b/resources/js/Pages/Admin/FeatureFlags/Show.tsx
@@ -100,7 +100,7 @@ export default function FeatureFlagsShow({
         <div className="flex items-center gap-2 text-sm text-muted-foreground">
           <Link
             href={route('admin.feature-flags.index')}
-            className="text-blue-600 hover:underline"
+            className="text-primary hover:underline"
           >
             ← Feature Flags
           </Link>

--- a/resources/js/Pages/Admin/_components/WidgetCycles.tsx
+++ b/resources/js/Pages/Admin/_components/WidgetCycles.tsx
@@ -47,7 +47,7 @@ export default function WidgetCycles({ data }: Props) {
           <div
             key={cycle.id}
             className={`border rounded p-3 ${
-              cycle.id === data.current_cycle ? 'bg-blue-50 border-blue-300' : 'bg-white'
+              cycle.id === data.current_cycle ? 'bg-primary/5 border-primary/30' : 'bg-white'
             }`}
           >
             <div className="font-medium">{cycle.name}</div>

--- a/resources/js/Pages/Admin/_components/WidgetMutations.tsx
+++ b/resources/js/Pages/Admin/_components/WidgetMutations.tsx
@@ -49,7 +49,7 @@ const ACTIONS: ActionConfig[] = [
       type: 'text',
       placeholder: '2026-05-10-sensitive-001',
     }],
-    buttonClass: 'bg-blue-600 hover:bg-blue-700',
+    buttonClass: 'bg-primary hover:bg-primary/90',
   },
   {
     key: 'regen_token',

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -735,7 +735,7 @@ function LinhaTabela({ row, dens, selected, onSelect, onBaixar, conferido, comme
   };
   return (
     <tr
-      className={`${dens.row} ${dens.text} border-b border-stone-100 hover:bg-stone-50/60 cursor-pointer ${selected ? 'bg-amber-50/40' : ''} ${bulkSelected ? 'bg-blue-50/50' : ''}`}
+      className={`${dens.row} ${dens.text} border-b border-stone-100 hover:bg-stone-50/60 cursor-pointer ${selected ? 'bg-amber-50/40' : ''} ${bulkSelected ? 'bg-primary/5' : ''}`}
       onClick={onSelect}
     >
       {/* Onda 12 (2026-05-20): checkbox bulk-select. stopPropagation pra nao abrir drawer. */}

--- a/resources/js/Pages/Manufacturing/Index.tsx
+++ b/resources/js/Pages/Manufacturing/Index.tsx
@@ -52,7 +52,7 @@ export default function Index({ productions = [], summary }: Props) {
           </div>
           <button
             type="button"
-            className="px-4 py-2 bg-blue-600 text-white rounded-md text-sm font-medium hover:bg-blue-700"
+            className="px-4 py-2 bg-primary text-white rounded-md text-sm font-medium hover:bg-primary/90"
             disabled
             title="Em construção — use a rota legacy enquanto isso"
           >

--- a/resources/js/Pages/Modules/Index.tsx
+++ b/resources/js/Pages/Modules/Index.tsx
@@ -410,14 +410,14 @@ function ActiveChip({
   onRemove: () => void;
 }) {
   return (
-    <span className="inline-flex items-center gap-1 rounded-md border border-blue-300 bg-blue-50 px-2 py-0.5 text-[11px] text-blue-700 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-300">
+    <span className="inline-flex items-center gap-1 rounded-md border border-primary/30 bg-primary/5 px-2 py-0.5 text-[11px] text-primary">
       <span className="font-medium">{label}:</span>
       <span>{value}</span>
       <button
         type="button"
         onClick={onRemove}
         aria-label={`Remover filtro ${label}`}
-        className="hover:text-blue-900 dark:hover:text-blue-100"
+        className="hover:text-primary/80"
       >
         <X size={10} />
       </button>
@@ -521,7 +521,7 @@ function FilterDropdown({
         className={
           'inline-flex items-center gap-1 rounded-md border px-2.5 py-1 text-xs font-medium transition-colors ' +
           (hasSel
-            ? 'border-blue-300 bg-blue-50 text-blue-700 dark:border-blue-800 dark:bg-blue-950/40 dark:text-blue-300'
+            ? 'border-primary/30 bg-primary/5 text-primary'
             : 'border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground')
         }
         aria-haspopup="listbox"
@@ -562,7 +562,7 @@ function FilterDropdown({
                 className={
                   'w-full text-left rounded px-2 py-1.5 text-xs transition-colors ' +
                   (isOn
-                    ? 'bg-blue-50 text-blue-700 dark:bg-blue-950/40 dark:text-blue-300'
+                    ? 'bg-primary/5 text-primary'
                     : 'text-foreground hover:bg-muted')
                 }
               >

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/CacambaCard.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/CacambaCard.tsx
@@ -203,7 +203,7 @@ function CacambaCardImpl({ cacamba, variant, onClick }: Props) {
       {...listeners}
       className={`${cardBg} ${opacityClass} relative rounded border border-t-2 ${cardBaseBorder} ${TOP_BORDER_COLOR[variant]} p-3 transition-colors ${
         isDragging
-          ? 'opacity-50 cursor-grabbing ring-2 ring-blue-400 ring-offset-1'
+          ? 'opacity-50 cursor-grabbing ring-2 ring-primary/60 ring-offset-1'
           : 'cursor-grab active:cursor-grabbing hover:shadow-sm'
       }`}
       onClick={(e) => {

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/CacambaKanbanColumn.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/CacambaKanbanColumn.tsx
@@ -59,7 +59,7 @@ function CacambaKanbanColumnImpl({ status, label, cards, onCardClick }: Props) {
 
   // Visual feedback quando algo está sendo arrastado sobre a coluna
   const overClasses = isOver
-    ? 'ring-2 ring-blue-400 ring-offset-2 bg-blue-50/40'
+    ? 'ring-2 ring-primary/60 ring-offset-2 bg-primary/5'
     : '';
 
   return (

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/KanbanDndProvider.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/_components/KanbanDndProvider.tsx
@@ -51,7 +51,7 @@ interface KanbanDndProviderProps {
 function CardDragPreview({ cacamba }: { cacamba: CacambaCardData }) {
   return (
     <div
-      className="bg-white border-2 border-blue-500 rounded shadow-lg p-3 max-w-[260px] cursor-grabbing rotate-2 opacity-95"
+      className="bg-white border-2 border-primary rounded shadow-lg p-3 max-w-[260px] cursor-grabbing rotate-2 opacity-95"
       role="presentation"
       aria-hidden="true"
     >

--- a/resources/js/Pages/ProjectMgmt/Backlog/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/Backlog/Index.tsx
@@ -267,7 +267,7 @@ function BacklogIndex({
       </Card>
 
       {selected.size > 0 && (
-        <div className="sticky top-2 z-20 mt-3 flex flex-wrap items-center gap-2 px-4 py-2 rounded-xl border bg-blue-50 dark:bg-blue-950/40 shadow">
+        <div className="sticky top-2 z-20 mt-3 flex flex-wrap items-center gap-2 px-4 py-2 rounded-xl border bg-primary/5 shadow">
           <span className="text-xs font-semibold">{selected.size} selecionada{selected.size > 1 ? 's' : ''}</span>
 
           <span className="text-xs text-muted-foreground">Status:</span>
@@ -339,7 +339,7 @@ function BacklogIndex({
                     key={t.task_id}
                     className={[
                       'border-b transition-colors',
-                      sel ? 'bg-blue-50 dark:bg-blue-950/30' : 'hover:bg-muted/40',
+                      sel ? 'bg-primary/5' : 'hover:bg-muted/40',
                       t.is_blocked ? 'bg-red-50/40 dark:bg-red-950/10' : '',
                     ].filter(Boolean).join(' ')}
                   >

--- a/resources/js/Pages/ProjectMgmt/MyWork/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/MyWork/Index.tsx
@@ -299,7 +299,7 @@ function MyWorkIndex({
         <section
           className={[
             'rounded-xl border bg-muted/20 p-4 transition-all',
-            focus === 'work' ? 'ring-2 ring-blue-400/60' : 'opacity-90',
+            focus === 'work' ? 'ring-2 ring-primary/60' : 'opacity-90',
           ].join(' ')}
           onClick={() => setFocus('work')}
         >
@@ -369,7 +369,7 @@ function MyWorkIndex({
         <section
           className={[
             'rounded-xl border bg-muted/20 p-4 transition-all',
-            focus === 'inbox' ? 'ring-2 ring-blue-400/60' : 'opacity-90',
+            focus === 'inbox' ? 'ring-2 ring-primary/60' : 'opacity-90',
           ].join(' ')}
           onClick={() => setFocus('inbox')}
         >
@@ -433,7 +433,7 @@ function MyWorkIndex({
                   }}
                   className={[
                     'group flex items-start gap-2 p-2 rounded-md text-left transition-colors hover:bg-muted',
-                    focus === 'inbox' && selectedInboxId === item.id ? 'bg-muted ring-1 ring-blue-400/60' : '',
+                    focus === 'inbox' && selectedInboxId === item.id ? 'bg-muted ring-1 ring-primary/60' : '',
                     wasRead ? 'opacity-60' : '',
                   ].filter(Boolean).join(' ')}
                 >

--- a/resources/js/Pages/Purchase/Show.tsx
+++ b/resources/js/Pages/Purchase/Show.tsx
@@ -201,7 +201,7 @@ function PurchaseShow({ purchase, permissions }: Props) {
             {purchase.supplier_mobile && <div className="text-stone-600 text-[12px]">Tel: {purchase.supplier_mobile}</div>}
             {purchase.supplier_email && <div className="text-stone-600 text-[12px]">{purchase.supplier_email}</div>}
             {purchase.document_path && (
-              <a href={purchase.document_path} download={purchase.document_name ?? ''} className="inline-flex items-center text-blue-600 hover:underline text-[12px] mt-2">
+              <a href={purchase.document_path} download={purchase.document_name ?? ''} className="inline-flex items-center text-primary hover:underline text-[12px] mt-2">
                 <Download className="h-3 w-3 mr-1" /> Documento anexo
               </a>
             )}

--- a/resources/js/Pages/Settings/PaymentGateways/Index.tsx
+++ b/resources/js/Pages/Settings/PaymentGateways/Index.tsx
@@ -212,7 +212,7 @@ function PaymentGatewaysPage({ gateways, accounts, kpis, today, nfeCertificadoAt
                   return (
                     <tr key={g.id} onClick={() => setDrawer(g)} className={cn(
                       'border-b border-stone-100 hover:bg-stone-50/60 cursor-pointer',
-                      isFocus && 'bg-blue-50/40 ring-1 ring-inset ring-blue-300',
+                      isFocus && 'bg-primary/5 ring-1 ring-inset ring-primary/30',
                     )}>
                       <td className="pl-5 pr-2 py-2.5">
                         <div className="font-medium text-stone-900">{g.nome}</div>

--- a/resources/js/Pages/ads/Admin/Conflicts.tsx
+++ b/resources/js/Pages/ads/Admin/Conflicts.tsx
@@ -104,11 +104,11 @@ const Conflicts: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
                     <Badge variant="outline">{c.gap_minutes}min entre eventos</Badge>
                   </div>
                   <div className="flex items-center gap-2 flex-wrap text-xs">
-                    <Link href={`/ads/admin/decisoes/${c.decision_a.id}`} className="text-blue-600 hover:underline">
+                    <Link href={`/ads/admin/decisoes/${c.decision_a.id}`} className="text-primary hover:underline">
                       #{c.decision_a.id} {c.decision_a.event_type} → {c.decision_a.destination}
                     </Link>
                     <span className="text-muted-foreground">⟷</span>
-                    <Link href={`/ads/admin/decisoes/${c.decision_b.id}`} className="text-blue-600 hover:underline">
+                    <Link href={`/ads/admin/decisoes/${c.decision_b.id}`} className="text-primary hover:underline">
                       #{c.decision_b.id} {c.decision_b.event_type} → {c.decision_b.destination}
                     </Link>
                   </div>
@@ -167,7 +167,7 @@ const Conflicts: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
               {judgment_conflicts.map((c, i) => (
                 <li key={i} className="text-sm space-y-1 border-l-2 border-blue-300 pl-3">
                   <div className="flex items-center gap-2 flex-wrap">
-                    <Link href={`/ads/admin/decisoes/${c.decision_id}`} className="text-blue-600 hover:underline font-medium">
+                    <Link href={`/ads/admin/decisoes/${c.decision_id}`} className="text-primary hover:underline font-medium">
                       #{c.decision_id} {c.event_type}
                     </Link>
                     <Badge variant="outline">{c.domain}</Badge>

--- a/resources/js/Pages/ads/Admin/DecisaoShow.tsx
+++ b/resources/js/Pages/ads/Admin/DecisaoShow.tsx
@@ -252,7 +252,7 @@ function DrillDownChain({ decision: d, chain }: { decision: Decision; chain: Cha
           <ChainBlock title="Decisão pai" icon="↑">
             <Link
               href={`/ads/admin/decisoes/${chain.parent.id}`}
-              className="text-sm font-medium text-blue-600 hover:underline"
+              className="text-sm font-medium text-primary hover:underline"
             >
               #{String(chain.parent.id).padStart(4, '0')} — {chain.parent.event_type}
             </Link>
@@ -268,7 +268,7 @@ function DrillDownChain({ decision: d, chain }: { decision: Decision; chain: Cha
             <ul className="space-y-1">
               {chain.children.map(c => (
                 <li key={c.id} className="text-sm flex items-center gap-2 flex-wrap">
-                  <Link href={`/ads/admin/decisoes/${c.id}`} className="text-blue-600 hover:underline font-mono text-xs">
+                  <Link href={`/ads/admin/decisoes/${c.id}`} className="text-primary hover:underline font-mono text-xs">
                     #{String(c.id).padStart(4, '0')}
                   </Link>
                   <code className="text-xs">{c.event_type}</code>
@@ -289,7 +289,7 @@ function DrillDownChain({ decision: d, chain }: { decision: Decision; chain: Cha
         {hasSkill && chain.skill && (
           <ChainBlock title="Skill aprendido (mcp_decision_patterns)" icon="⚡">
             <div className="text-sm">
-              <Link href="/ads/admin/skills" className="text-blue-600 hover:underline font-medium">
+              <Link href="/ads/admin/skills" className="text-primary hover:underline font-medium">
                 {chain.skill.description}
               </Link>
               <div className="text-xs text-muted-foreground mt-1 flex items-center gap-2 flex-wrap">
@@ -308,7 +308,7 @@ function DrillDownChain({ decision: d, chain }: { decision: Decision; chain: Cha
             <ul className="space-y-1.5">
               {chain.meta_skills.map(m => (
                 <li key={m.id} className="text-sm">
-                  <Link href="/ads/admin/meta-skills" className="text-blue-600 hover:underline font-medium">
+                  <Link href="/ads/admin/meta-skills" className="text-primary hover:underline font-medium">
                     {m.name}
                   </Link>
                   <div className="text-xs text-muted-foreground">

--- a/resources/js/Pages/ads/Admin/ProjectShow.tsx
+++ b/resources/js/Pages/ads/Admin/ProjectShow.tsx
@@ -244,7 +244,7 @@ const ProjectShow: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = 
                 <ul className="space-y-1.5">
                   {decisions.map(d => (
                     <li key={d.id} className="text-sm flex items-center gap-2 flex-wrap">
-                      <Link href={`/ads/admin/decisoes/${d.id}`} className="font-mono text-xs text-blue-600 hover:underline">
+                      <Link href={`/ads/admin/decisoes/${d.id}`} className="font-mono text-xs text-primary hover:underline">
                         #{String(d.id).padStart(4, '0')}
                       </Link>
                       <code className="text-xs">{d.event_type}</code>

--- a/resources/js/Pages/ads/Admin/Skills/Edit.tsx
+++ b/resources/js/Pages/ads/Admin/Skills/Edit.tsx
@@ -46,7 +46,7 @@ const Edit: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ skil
 
   return (
     <div className="mx-auto max-w-5xl p-6 space-y-4">
-      <Link href={`/ads/admin/skills/${skill.slug}`} className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline">
+      <Link href={`/ads/admin/skills/${skill.slug}`} className="inline-flex items-center gap-1 text-sm text-primary hover:underline">
         <ArrowLeft className="w-4 h-4" /> Voltar pro detalhe
       </Link>
 

--- a/resources/js/Pages/ads/Admin/Skills/Index.tsx
+++ b/resources/js/Pages/ads/Admin/Skills/Index.tsx
@@ -119,7 +119,7 @@ const Skills: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ sk
                     <td className="px-4 py-2 font-mono text-xs">
                       <Link
                         href={`/ads/admin/skills/${s.slug}`}
-                        className="text-blue-600 hover:underline"
+                        className="text-primary hover:underline"
                       >
                         {s.slug}
                       </Link>

--- a/resources/js/Pages/ads/Admin/Skills/Review.tsx
+++ b/resources/js/Pages/ads/Admin/Skills/Review.tsx
@@ -79,7 +79,7 @@ const Review: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ dr
               <CardHeader>
                 <CardTitle className="text-sm flex items-center justify-between">
                   <span>
-                    <Link href={`/ads/admin/skills/${d.skill_slug}`} className="text-blue-600 hover:underline">
+                    <Link href={`/ads/admin/skills/${d.skill_slug}`} className="text-primary hover:underline">
                       {d.skill_name}
                     </Link>
                     <span className="text-muted-foreground"> · v{d.version}</span>
@@ -107,7 +107,7 @@ const Review: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ dr
                   ) : (
                     <span className="text-amber-600">⚠️ Sem test runs anexados</span>
                   )}
-                  <Link href={`/ads/admin/skills/${d.skill_slug}/test`} className="inline-flex items-center gap-1 text-blue-600 hover:underline">
+                  <Link href={`/ads/admin/skills/${d.skill_slug}/test`} className="inline-flex items-center gap-1 text-primary hover:underline">
                     Testar primeiro <ExternalLink className="w-3 h-3" />
                   </Link>
                 </div>

--- a/resources/js/Pages/ads/Admin/Skills/Show.tsx
+++ b/resources/js/Pages/ads/Admin/Skills/Show.tsx
@@ -57,7 +57,7 @@ const Show: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ skil
   return (
     <div className="mx-auto max-w-5xl p-6 space-y-4">
       <div className="flex items-center justify-between">
-        <Link href="/ads/admin/skills" className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline">
+        <Link href="/ads/admin/skills" className="inline-flex items-center gap-1 text-sm text-primary hover:underline">
           <ArrowLeft className="w-4 h-4" /> Voltar pra lista
         </Link>
         <div className="flex items-center gap-2">
@@ -212,7 +212,7 @@ const Show: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ skil
             prose-pre:bg-zinc-900 prose-pre:text-zinc-100 prose-pre:rounded-md prose-pre:p-4 prose-pre:text-xs
             prose-code:before:content-none prose-code:after:content-none
             prose-code:bg-muted prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-xs prose-code:font-mono prose-code:font-normal
-            prose-a:text-blue-600 dark:prose-a:text-blue-400 prose-a:no-underline hover:prose-a:underline
+            prose-a:text-primary prose-a:no-underline hover:prose-a:underline
             prose-table:text-xs prose-th:text-xs prose-td:py-1 prose-td:px-2">
             <ReactMarkdown remarkPlugins={[remarkGfm]}>{skill.body}</ReactMarkdown>
           </article>

--- a/resources/js/Pages/ads/Admin/Skills/Test.tsx
+++ b/resources/js/Pages/ads/Admin/Skills/Test.tsx
@@ -59,7 +59,7 @@ const Test: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({ skil
 
   return (
     <div className="mx-auto max-w-5xl p-6 space-y-4">
-      <Link href={`/ads/admin/skills/${skill.slug}`} className="inline-flex items-center gap-1 text-sm text-blue-600 hover:underline">
+      <Link href={`/ads/admin/skills/${skill.slug}`} className="inline-flex items-center gap-1 text-sm text-primary hover:underline">
         <ArrowLeft className="w-4 h-4" /> Voltar pro detalhe
       </Link>
 

--- a/resources/js/Pages/ads/Admin/TeamScopes.tsx
+++ b/resources/js/Pages/ads/Admin/TeamScopes.tsx
@@ -105,7 +105,7 @@ const TeamScopes: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = (
                     <button
                       type="button"
                       onClick={() => setSelectedUser(u)}
-                      className={`w-full text-left px-4 py-3 hover:bg-muted/50 ${selectedUser?.id === u.id ? 'bg-blue-50' : ''}`}
+                      className={`w-full text-left px-4 py-3 hover:bg-muted/50 ${selectedUser?.id === u.id ? 'bg-primary/5' : ''}`}
                     >
                       <div className="font-medium text-sm">{u.name}</div>
                       <div className="text-xs text-muted-foreground">{u.email}</div>

--- a/resources/js/Pages/governance/Dashboard.tsx
+++ b/resources/js/Pages/governance/Dashboard.tsx
@@ -222,7 +222,7 @@ const Dashboard: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
                 <span className="text-amber-600">📋</span>
                 ADRs aguardando você ({pending_adrs.length})
               </h3>
-              <Link href="/copiloto/admin/memoria?type=adr" className="text-sm text-blue-600 hover:underline">
+              <Link href="/copiloto/admin/memoria?type=adr" className="text-sm text-primary hover:underline">
                 ver todos →
               </Link>
             </div>
@@ -235,7 +235,7 @@ const Dashboard: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
                   <li key={adr.slug} className="flex items-start gap-2 text-sm border-b border-zinc-100 dark:border-zinc-800 pb-2 last:border-0">
                     <Link
                       href={`/copiloto/admin/memoria/${adr.slug}`}
-                      className="font-mono text-xs text-blue-600 hover:underline shrink-0"
+                      className="font-mono text-xs text-primary hover:underline shrink-0"
                     >
                       {adr.slug.split('-')[0]}
                     </Link>
@@ -256,7 +256,7 @@ const Dashboard: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
                 <span className="text-zinc-700 dark:text-zinc-300">📊</span>
                 Audit Highlights 24h ({audit_highlights.length})
               </h3>
-              <Link href="/governance/audit" className="text-sm text-blue-600 hover:underline">
+              <Link href="/governance/audit" className="text-sm text-primary hover:underline">
                 drill-down →
               </Link>
             </div>
@@ -297,7 +297,7 @@ const Dashboard: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
                 <span className="text-zinc-700 dark:text-zinc-300">🤖</span>
                 Narrativas Brain A 24h ({narratives.length})
               </h3>
-              <Link href="/copiloto/admin/memoria?type=narrative" className="text-sm text-blue-600 hover:underline">
+              <Link href="/copiloto/admin/memoria?type=narrative" className="text-sm text-primary hover:underline">
                 histórico →
               </Link>
             </div>
@@ -361,14 +361,14 @@ const Dashboard: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
         <CardContent className="p-4">
           <h3 className="text-lg font-semibold mb-3">Documentos canônicos</h3>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-2 text-sm">
-            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/CONSTITUTION.md" target="_blank" rel="noreferrer" className="text-blue-600 hover:underline">📜 Constituição v1.1.0</a>
-            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/TRUST-TIERS.md" target="_blank" rel="noreferrer" className="text-blue-600 hover:underline">🔐 Trust Tiers</a>
-            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/ARCHITECTURE.md" target="_blank" rel="noreferrer" className="text-blue-600 hover:underline">🏗️ Architecture</a>
-            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/IDENTITY-MESH.md" target="_blank" rel="noreferrer" className="text-blue-600 hover:underline">👥 Identity Mesh</a>
-            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/ENFORCEMENT.md" target="_blank" rel="noreferrer" className="text-blue-600 hover:underline">🛡️ Enforcement (8 mecanismos)</a>
-            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/MODULE-DRIFT-MIGRATION-PLAN.md" target="_blank" rel="noreferrer" className="text-blue-600 hover:underline">📐 Drift Migration Plan</a>
-            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/audit-2026-05-05-v1.1.md" target="_blank" rel="noreferrer" className="text-blue-600 hover:underline">📋 Audit cascata v1.1</a>
-            <Link href="/copiloto/admin/memoria" className="text-blue-600 hover:underline">📚 KB completo →</Link>
+            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/CONSTITUTION.md" target="_blank" rel="noreferrer" className="text-primary hover:underline">📜 Constituição v1.1.0</a>
+            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/TRUST-TIERS.md" target="_blank" rel="noreferrer" className="text-primary hover:underline">🔐 Trust Tiers</a>
+            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/ARCHITECTURE.md" target="_blank" rel="noreferrer" className="text-primary hover:underline">🏗️ Architecture</a>
+            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/IDENTITY-MESH.md" target="_blank" rel="noreferrer" className="text-primary hover:underline">👥 Identity Mesh</a>
+            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/ENFORCEMENT.md" target="_blank" rel="noreferrer" className="text-primary hover:underline">🛡️ Enforcement (8 mecanismos)</a>
+            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/MODULE-DRIFT-MIGRATION-PLAN.md" target="_blank" rel="noreferrer" className="text-primary hover:underline">📐 Drift Migration Plan</a>
+            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/audit-2026-05-05-v1.1.md" target="_blank" rel="noreferrer" className="text-primary hover:underline">📋 Audit cascata v1.1</a>
+            <Link href="/copiloto/admin/memoria" className="text-primary hover:underline">📚 KB completo →</Link>
           </div>
         </CardContent>
       </Card>

--- a/resources/js/Pages/kb/Index.tsx
+++ b/resources/js/Pages/kb/Index.tsx
@@ -359,7 +359,7 @@ function KbIndex(props: Props) {
                 return (
                   <tr
                     key={d.id}
-                    className={`border-b cursor-pointer hover:bg-muted/40 ${isSel ? 'bg-blue-50 dark:bg-blue-950/30 border-l-2 border-l-blue-500' : ''} ${d.deleted_at ? 'opacity-50' : ''}`}
+                    className={`border-b cursor-pointer hover:bg-muted/40 ${isSel ? 'bg-primary/5 border-l-2 border-primary' : ''} ${d.deleted_at ? 'opacity-50' : ''}`}
                     onClick={() => openDoc(d.slug)}
                   >
                     <td className="py-1.5 px-2 align-top">
@@ -527,7 +527,7 @@ function KbIndex(props: Props) {
               prose-pre:bg-zinc-900 prose-pre:text-zinc-100 prose-pre:rounded-md prose-pre:p-4 prose-pre:text-xs
               prose-code:before:content-none prose-code:after:content-none
               prose-code:bg-muted prose-code:px-1.5 prose-code:py-0.5 prose-code:rounded prose-code:text-xs prose-code:font-mono prose-code:font-normal
-              prose-a:text-blue-600 dark:prose-a:text-blue-400 prose-a:no-underline hover:prose-a:underline
+              prose-a:text-primary prose-a:no-underline hover:prose-a:underline
               prose-table:text-xs prose-th:text-xs prose-td:py-1 prose-td:px-2
               prose-blockquote:border-l-4 prose-blockquote:border-blue-500 prose-blockquote:pl-4 prose-blockquote:italic prose-blockquote:text-muted-foreground
               prose-hr:my-6 prose-hr:border-border

--- a/resources/js/Pages/team-mcp/CcSessions/Index.tsx
+++ b/resources/js/Pages/team-mcp/CcSessions/Index.tsx
@@ -263,7 +263,7 @@ function CcSessionsIndex(props: Props) {
               {' '}
               <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/requisitos/Copiloto/SPEC-cc-sessions.md#us-copi-cc-040--watcher-node-ingere-sessions-jsonl-local"
                  target="_blank" rel="noopener noreferrer"
-                 className="text-blue-600 hover:underline">SPEC US-COPI-CC-040</a>.
+                 className="text-primary hover:underline">SPEC US-COPI-CC-040</a>.
             </div>
             <div className="text-[10px] text-muted-foreground">
               Endpoint pronto: <code className="font-mono">POST /api/cc/ingest</code>
@@ -286,7 +286,7 @@ function CcSessionsIndex(props: Props) {
                   const isSel = s.session_uuid === selectedUuid;
                   return (
                     <tr key={s.id}
-                      className={`border-b cursor-pointer hover:bg-muted/40 ${isSel ? 'bg-blue-50 dark:bg-blue-950/30 border-l-2 border-l-blue-500' : ''}`}
+                      className={`border-b cursor-pointer hover:bg-muted/40 ${isSel ? 'bg-primary/5 border-l-2 border-primary' : ''}`}
                       onClick={() => openSession(s.session_uuid)}>
                       <td className="py-1.5 px-2 align-top">
                         <div className="font-medium text-xs leading-tight">{s.user_nome}</div>
@@ -532,7 +532,7 @@ function MessageBubble({ m }: { m: Message }) {
       )}
       {isLong && (
         <button onClick={() => setExpanded(!expanded)}
-          className="text-[10px] text-blue-600 hover:underline mt-1">
+          className="text-[10px] text-primary hover:underline mt-1">
           {expanded ? '▲ recolher' : `▼ ver mais (${text.length} chars)`}
         </button>
       )}

--- a/resources/js/Pages/team-mcp/Tasks/Index.tsx
+++ b/resources/js/Pages/team-mcp/Tasks/Index.tsx
@@ -135,7 +135,7 @@ function KanbanView({ kanban }: { kanban: Record<string, Task[]> }) {
       {COLUNAS.map(col => (
         <div
           key={col.key}
-          className={`rounded-xl border-t-4 ${col.color} bg-muted/30 p-3 min-h-[300px] transition-colors ${draggingOver === col.key ? 'bg-muted/60 ring-2 ring-blue-400' : ''}`}
+          className={`rounded-xl border-t-4 ${col.color} bg-muted/30 p-3 min-h-[300px] transition-colors ${draggingOver === col.key ? 'bg-muted/60 ring-2 ring-primary/60' : ''}`}
           onDragOver={e => { e.preventDefault(); setDraggingOver(col.key); }}
           onDragLeave={() => setDraggingOver(null)}
           onDrop={() => handleDrop(col.key)}

--- a/resources/js/Pages/team-mcp/Team/Index.tsx
+++ b/resources/js/Pages/team-mcp/Team/Index.tsx
@@ -365,7 +365,7 @@ function TeamIndex(props: Props) {
                         </span>
                       ) : (
                         <button
-                          className="text-xs text-blue-600 hover:underline"
+                          className="text-xs text-primary hover:underline"
                           onClick={() => setEditQuotaUser(m)}
                         >
                           definir
@@ -379,7 +379,7 @@ function TeamIndex(props: Props) {
                         </span>
                       ) : (
                         <button
-                          className="text-xs text-blue-600 hover:underline"
+                          className="text-xs text-primary hover:underline"
                           onClick={() => setEditQuotaUser(m)}
                         >
                           definir


### PR DESCRIPTION
## O quê

Finaliza o **DS v4 roxo** (ADR 0235 §3): varre o **azul-de-marca remanescente** (o accent do app) → token `primary` (roxo) em **28 telas Inertia**. Fecha o "design novo full".

## Convertido (azul-de-marca → `primary`) — ~56 trocas, todas accent genuíno

- **Links** (`text-blue-600 hover:underline` → `text-primary`): ads/Admin (Conflicts, DecisaoShow, ProjectShow, Skills/*), governance/Dashboard, Admin/FeatureFlags, Purchase, kb (prose)…
- **Focus / drag rings** (`ring-blue-400` → `ring-primary/60`): OficinaAuto Kanban (card/coluna/dnd), ProjectMgmt/MyWork, team-mcp/Tasks, Settings/PaymentGateways
- **Seleção / ativo** (`bg-blue-50` keyed by selected/current/isSel/bulkSelected → `bg-primary/5`): Admin/WidgetCycles, ProjectMgmt/Backlog, kb/Index, CcSessions, TeamScopes, Financeiro/Unificado, Modules (filtros)
- **Botões primários** (`bg-blue-600 hover:bg-blue-700` → `bg-primary hover:bg-primary/90`): Admin/WidgetMutations, Manufacturing

## Preservado de propósito (SEMÂNTICO — não é accent)

A maioria dos "~106 arquivos com `blue-*`" era semântica e **fica azul** (converter quebraria o código de cor):
- **Status:** paid/partial/overdue, aberto/emitida, ordered/received, active/inactive
- **Tipo/categoria:** remessa/retorno, NFe/NFSe, conta corrente/virtual, plano de contas, tons KB, buckets curador
- **Contábil:** Débito (azul) × Crédito
- **Data-viz/evento:** dots de evento, gráfico/burndown, hue visualizer, kanban column colors, paletas de stage multi-hue (`blue:` key nomeada)
- **Convenção externa:** marca Asaas, tick "lida" do WhatsApp

## Verificação

- ✅ Zero `blue-*` adicionado (toda troca removeu blue → primary)
- ✅ Zero `dark:*-blue-*` órfão (pares dark removidos onde o token já cobre claro+escuro)
- ✅ Só `.tsx` em escopo tocados; **cada linha convertida revisada** (link/foco/seleção/botão — nenhuma entrada de paleta semântica)
- Executado por 4 agentes paralelos com ruleset estrito "na dúvida, preserva"; consolidado e auditado por mim.

## Pendências menores (preservadas — decisão de design / Claude Design)

Flagadas e mantidas azuis por não serem claramente accent: stripe `border-l-blue-500` ("Goal do cycle" em ProjectMgmt Burndown/Board), gradiente do logo (`ConsultaOs`), dot de não-lido (MyWork). 1 linha cada se quiser roxo.

## ⚠️ Gate visual

29 arquivos, mas mudança mecânica (troca de token, não redesign). CI `visual-regression` + `PR UI Judge` validam. Recomendo smoke nas telas internas mais usadas (governance, ProjectMgmt) antes do merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)