### PR TITLE
feat(ui): Onda F componentes React + Cliente/Create elevado (F3 KB-9.75 Contacts)

### DIFF
--- a/resources/css/cowork-fields.css
+++ b/resources/css/cowork-fields.css
@@ -444,6 +444,9 @@ select.cw-input {
 }
 .cw-field-ico { width: 12px; height: 12px; flex: 0 0 12px; }
 .cw-req { color: var(--cw-error); margin-left: 2px; font-weight: 700; }
+/* Utilitários de sucesso (rail prontidão fiscal) — token, não emerald-* cru. */
+.cw-ok-text { color: var(--cw-ok); }
+.cw-ok-badge { background: var(--cw-ok-soft); color: var(--cw-ok); }
 .cw-spin { animation: cw-spin .7s linear infinite; }
 @keyframes cw-spin { to { transform: rotate(360deg); } }
 

--- a/resources/css/cowork-fields.css
+++ b/resources/css/cowork-fields.css
@@ -363,3 +363,110 @@ select.cw-input {
   background: var(--cw-surface);
   border-bottom: 1px solid var(--cw-border-2);
 }
+
+/* ═══════════════════════════════════════════════════════════════════════
+   Onda F (DS v4.1) — vocabulário de formulário · bridge React @/Components/ui
+   Pareado com segmented.tsx · form-section.tsx · input-group.tsx · field-state.tsx
+   Port do design-system.css v4.1 (PR #1971) sobre tokens --cw-* (roxo 295).
+   FormGrid reusa .cw-form-grid (já acima). ── */
+
+/* ── F1 · Segmented (Radix ToggleGroup) — substitui radio PF/PJ · Cliente/Fornecedor ── */
+.cw-segmented {
+  display: inline-flex; gap: 2px; padding: 2px;
+  background: var(--cw-bg-2); border: 1px solid var(--cw-border);
+  border-radius: 6px;
+}
+.cw-segmented button {
+  font: inherit; font-size: 12px; font-weight: 500; line-height: 1;
+  color: var(--cw-text-dim); background: transparent; border: 0;
+  border-radius: 4px; padding: 6px 13px; cursor: pointer;
+  transition: background .12s, color .12s;
+}
+.cw-segmented button:hover { color: var(--cw-text); }
+.cw-segmented button[data-state="on"] {
+  background: var(--cw-surface); color: var(--cw-text); font-weight: 600;
+  box-shadow: 0 1px 2px rgba(16, 18, 22, .10);
+}
+.cw-segmented.cw-accent button[data-state="on"] { color: var(--cw-accent); }
+.cw-segmented:focus-within { box-shadow: 0 0 0 3px var(--cw-accent-soft); }
+.cw-segmented button:focus-visible { outline: 0; box-shadow: 0 0 0 2px var(--cw-accent); }
+.cw-segmented button:disabled { opacity: .5; cursor: not-allowed; }
+
+/* ── F2 · Input group — input + botão/addon (Buscar CNPJ, R$/%) ── */
+.cw-input-group { display: flex; align-items: stretch; }
+.cw-input-group > .cw-input {
+  flex: 1; min-width: 0;
+  border-top-right-radius: 0; border-bottom-right-radius: 0;
+}
+.cw-ig-btn {
+  display: inline-flex; align-items: center; gap: 5px; white-space: nowrap;
+  padding: 0 12px; height: 30px;
+  font: inherit; font-size: 12px; font-weight: 500; color: var(--cw-text);
+  background: var(--cw-bg-2); border: 1px solid var(--cw-border); border-left: 0;
+  border-radius: 0 5px 5px 0; cursor: pointer;
+  transition: background .12s, color .12s;
+}
+.cw-ig-btn:hover:not(:disabled) { background: var(--cw-surface); }
+.cw-ig-btn svg { width: 13px; height: 13px; }
+.cw-ig-btn.cw-loading { color: var(--cw-text-mute); pointer-events: none; }
+.cw-ig-btn.cw-done {
+  color: oklch(0.45 0.12 145); background: oklch(0.94 0.06 145);
+  border-color: transparent;
+}
+.cw-ig-btn:disabled { opacity: .6; cursor: not-allowed; }
+.cw-ig-addon {
+  display: inline-flex; align-items: center; padding: 0 10px; height: 30px;
+  font: inherit; font-size: 12px; font-weight: 500; color: var(--cw-text-mute);
+  background: var(--cw-bg-2); border: 1px solid var(--cw-border); border-right: 0;
+  border-radius: 5px 0 0 5px;
+}
+.cw-input-group > .cw-ig-addon + .cw-input {
+  border-top-left-radius: 0; border-bottom-left-radius: 0;
+}
+
+/* ── F3 · Estado de campo: erro · sucesso · validando · obrigatório ── */
+.cw-field-error {
+  display: flex; align-items: center; gap: 5px; margin-top: 4px;
+  font-size: 10.5px; font-weight: 500; color: var(--cw-error);
+}
+.cw-field-success {
+  display: inline-flex; align-items: center; gap: 5px; margin-top: 4px;
+  font-size: 10.5px; font-weight: 500; color: oklch(0.45 0.12 145);
+}
+.cw-field-validating {
+  display: inline-flex; align-items: center; gap: 5px; margin-top: 4px;
+  font-size: 10.5px; color: var(--cw-text-mute);
+}
+.cw-field-ico { width: 12px; height: 12px; flex: 0 0 12px; }
+.cw-req { color: var(--cw-error); margin-left: 2px; font-weight: 700; }
+.cw-spin { animation: cw-spin .7s linear infinite; }
+@keyframes cw-spin { to { transform: rotate(360deg); } }
+
+/* ── F4 · Form section (substitui <Section> hand-rolled p-4/p-5) ── */
+.cw-form-section {
+  background: var(--cw-surface); border: 1px solid var(--cw-border);
+  border-radius: 8px; padding: 14px 16px; margin-bottom: 12px;
+}
+.cw-form-section-h {
+  display: flex; align-items: center; gap: 8px; margin: 0 0 12px;
+  font-size: 10px; font-weight: 700; line-height: 1;
+  letter-spacing: .07em; text-transform: uppercase; color: var(--cw-text-mute);
+}
+.cw-form-section-h svg { width: 14px; height: 14px; color: var(--cw-accent); }
+.cw-count {
+  margin-left: auto; font-size: 10px; font-weight: 600;
+  letter-spacing: 0; text-transform: none; color: var(--cw-text-mute);
+}
+
+/* ── F5 · Layout "Create = form + rail de contexto sticky" (pattern PT-03b) ── */
+.cw-form-layout {
+  display: grid; grid-template-columns: 1fr 300px; gap: 16px; align-items: start;
+}
+.cw-form-rail {
+  position: sticky; top: 16px;
+  display: flex; flex-direction: column; gap: 12px;
+}
+@media (max-width: 900px) {
+  .cw-form-layout { grid-template-columns: 1fr; }
+  .cw-form-rail { position: static; }
+}

--- a/resources/css/cowork-fields.css
+++ b/resources/css/cowork-fields.css
@@ -38,6 +38,9 @@
   --cw-accent-soft:  oklch(0.95 0.04 295);
   --cw-error:        oklch(0.65 0.18 25);
   --cw-error-soft:   oklch(0.94 0.04 25);
+  /* DS v4.1 Onda F — verde de sucesso (lookup CNPJ ok, field-success). */
+  --cw-ok:           oklch(0.45 0.12 145);
+  --cw-ok-soft:      oklch(0.94 0.06 145);
 }
 
 /* Dark mode — APENAS via classe .dark (canon do Inertia/shadcn no oimpresso).
@@ -63,6 +66,8 @@
   --cw-accent-soft:  oklch(0.32 0.06 295);
   --cw-error:        oklch(0.70 0.18 25);
   --cw-error-soft:   oklch(0.30 0.08 25);
+  --cw-ok:           oklch(0.72 0.15 145);  /* verde mais legivel em fundo escuro */
+  --cw-ok-soft:      oklch(0.30 0.07 145);
 }
 
 /* ── Field wrapper (label + input + error) ─────────────────────────────── */
@@ -374,12 +379,12 @@ select.cw-input {
 .cw-segmented {
   display: inline-flex; gap: 2px; padding: 2px;
   background: var(--cw-bg-2); border: 1px solid var(--cw-border);
-  border-radius: 6px;
+  border-radius: 5px;
 }
 .cw-segmented button {
   font: inherit; font-size: 12px; font-weight: 500; line-height: 1;
   color: var(--cw-text-dim); background: transparent; border: 0;
-  border-radius: 4px; padding: 6px 13px; cursor: pointer;
+  border-radius: 3px; padding: 6px 13px; cursor: pointer;
   transition: background .12s, color .12s;
 }
 .cw-segmented button:hover { color: var(--cw-text); }
@@ -410,7 +415,7 @@ select.cw-input {
 .cw-ig-btn svg { width: 13px; height: 13px; }
 .cw-ig-btn.cw-loading { color: var(--cw-text-mute); pointer-events: none; }
 .cw-ig-btn.cw-done {
-  color: oklch(0.45 0.12 145); background: oklch(0.94 0.06 145);
+  color: var(--cw-ok); background: var(--cw-ok-soft);
   border-color: transparent;
 }
 .cw-ig-btn:disabled { opacity: .6; cursor: not-allowed; }
@@ -431,7 +436,7 @@ select.cw-input {
 }
 .cw-field-success {
   display: inline-flex; align-items: center; gap: 5px; margin-top: 4px;
-  font-size: 10.5px; font-weight: 500; color: oklch(0.45 0.12 145);
+  font-size: 10.5px; font-weight: 500; color: var(--cw-ok);
 }
 .cw-field-validating {
   display: inline-flex; align-items: center; gap: 5px; margin-top: 4px;

--- a/resources/js/Components/ui/field-state.tsx
+++ b/resources/js/Components/ui/field-state.tsx
@@ -1,0 +1,52 @@
+import * as React from "react"
+import { AlertCircle, Check, Loader2 } from "lucide-react"
+
+import { cn } from "@/Lib/utils"
+
+/**
+ * Estados de campo canon Onda F — completam o trio da A2 + obrigatório.
+ * Substituem os `<p className="text-rose-600">` / `text-emerald-600` soltos.
+ */
+
+/** Erro de validação. role=alert (anunciado por screen reader). Não renderiza vazio. */
+function FieldError({ className, children, ...props }: React.ComponentProps<"p">) {
+  if (!children) return null
+  return (
+    <p role="alert" data-slot="field-error" className={cn("cw-field-error", className)} {...props}>
+      <AlertCircle className="cw-field-ico" aria-hidden />
+      {children}
+    </p>
+  )
+}
+
+/** Sucesso (ex.: "Dados preenchidos pela BrasilAPI"). role=status. */
+function FieldSuccess({ className, children, ...props }: React.ComponentProps<"span">) {
+  if (!children) return null
+  return (
+    <span role="status" data-slot="field-success" className={cn("cw-field-success", className)} {...props}>
+      <Check className="cw-field-ico" aria-hidden />
+      {children}
+    </span>
+  )
+}
+
+/** Validação em andamento (spinner). role=status. */
+function FieldValidating({ className, children, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span role="status" data-slot="field-validating" className={cn("cw-field-validating", className)} {...props}>
+      <Loader2 className="cw-field-ico cw-spin" aria-hidden />
+      {children}
+    </span>
+  )
+}
+
+/** Marca de campo obrigatório (`*`). Decorativo — aria-hidden. */
+function RequiredMark({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span aria-hidden data-slot="required-mark" className={cn("cw-req", className)} {...props}>
+      *
+    </span>
+  )
+}
+
+export { FieldError, FieldSuccess, FieldValidating, RequiredMark }

--- a/resources/js/Components/ui/form-section.tsx
+++ b/resources/js/Components/ui/form-section.tsx
@@ -1,0 +1,44 @@
+import * as React from "react"
+
+import { cn } from "@/Lib/utils"
+
+/**
+ * FormSection — bloco de formulário canon Onda F (`.cw-form-section`).
+ * Substitui o `<section className="rounded-lg border p-4|p-5">` hand-rolled
+ * (Create p-4 vs DadosFiscaisBR p-5 — agora um só).
+ *
+ * `count` mostra um contador opcional à direita do título (ex.: "3 de 4 ✓").
+ */
+function FormSection({
+  title,
+  icon,
+  count,
+  className,
+  children,
+  ...props
+}: {
+  title: React.ReactNode
+  icon?: React.ReactNode
+  count?: React.ReactNode
+} & React.ComponentProps<"section">) {
+  return (
+    <section data-slot="form-section" className={cn("cw-form-section", className)} {...props}>
+      <h3 className="cw-form-section-h">
+        {icon}
+        <span>{title}</span>
+        {count != null && <span className="cw-count">{count}</span>}
+      </h3>
+      {children}
+    </section>
+  )
+}
+
+/**
+ * FormGrid — grid 2-col (→1-col em ≤640px) canon Onda F (`.cw-form-grid`).
+ * Filhos full-width: adicionar a classe `full-row` no wrapper (`.cw-field`).
+ */
+function FormGrid({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="form-grid" className={cn("cw-form-grid", className)} {...props} />
+}
+
+export { FormSection, FormGrid }

--- a/resources/js/Components/ui/input-group.tsx
+++ b/resources/js/Components/ui/input-group.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+import { Check, Loader2 } from "lucide-react"
+
+import { cn } from "@/Lib/utils"
+
+/**
+ * InputGroup — input + addon/botão coeso (Onda F `.cw-input-group`).
+ * Substitui o `<div className="flex"> input + button` do "Buscar CNPJ"/ViaCEP
+ * e o prefixo `R$`/`%`. Use com `<Input variant="cowork">` dentro.
+ */
+function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return <div data-slot="input-group" className={cn("cw-input-group", className)} {...props} />
+}
+
+/**
+ * Botão acoplado à direita do input (ex.: "Buscar"). `loading` mostra spinner,
+ * `done` pinta de verde com check — feedback do lookup.
+ */
+function InputGroupButton({
+  loading = false,
+  done = false,
+  className,
+  children,
+  disabled,
+  ...props
+}: {
+  loading?: boolean
+  done?: boolean
+} & React.ComponentProps<"button">) {
+  return (
+    <button
+      type="button"
+      data-slot="input-group-button"
+      className={cn("cw-ig-btn", loading && "cw-loading", done && "cw-done", className)}
+      disabled={loading || disabled}
+      {...props}
+    >
+      {loading ? (
+        <Loader2 className="cw-spin" aria-hidden />
+      ) : done ? (
+        <Check aria-hidden />
+      ) : null}
+      {children}
+    </button>
+  )
+}
+
+/** Prefixo/sufixo não-interativo (ex.: `R$`, `%`). */
+function InputGroupAddon({ className, ...props }: React.ComponentProps<"span">) {
+  return <span data-slot="input-group-addon" className={cn("cw-ig-addon", className)} {...props} />
+}
+
+export { InputGroup, InputGroupButton, InputGroupAddon }

--- a/resources/js/Components/ui/segmented.tsx
+++ b/resources/js/Components/ui/segmented.tsx
@@ -1,0 +1,63 @@
+import * as React from "react"
+import { ToggleGroup as ToggleGroupPrimitive } from "radix-ui"
+
+import { cn } from "@/Lib/utils"
+
+export interface SegmentedOption {
+  value: string
+  label: React.ReactNode
+  disabled?: boolean
+}
+
+/**
+ * Segmented — controle de seleção única (toggle 2–3 opções) sobre Radix
+ * ToggleGroup (type single). Visual canon Onda F (`.cw-segmented`).
+ * Substitui `<input type="radio">` de PF/PJ, Cliente/Fornecedor, vistas.
+ *
+ * `accent` pinta o estado ativo em roxo (em vez de neutro) — usar quando a
+ * escolha é "de marca" (ex.: Jurídica destacada).
+ */
+function Segmented({
+  value,
+  onValueChange,
+  options,
+  accent = false,
+  className,
+  ...props
+}: {
+  value: string
+  onValueChange: (value: string) => void
+  options: SegmentedOption[]
+  accent?: boolean
+} & Omit<
+  React.ComponentProps<typeof ToggleGroupPrimitive.Root>,
+  "type" | "value" | "onValueChange"
+>) {
+  return (
+    <ToggleGroupPrimitive.Root
+      type="single"
+      data-slot="segmented"
+      value={value}
+      // type=single permite desmarcar (value -> ""); como é seleção obrigatória,
+      // ignoramos o evento vazio pra manter sempre uma opção ativa.
+      onValueChange={(v) => {
+        if (v) onValueChange(v)
+      }}
+      className={cn("cw-segmented", accent && "cw-accent", className)}
+      {...props}
+    >
+      {options.map((opt) => (
+        <ToggleGroupPrimitive.Item
+          key={opt.value}
+          value={opt.value}
+          disabled={opt.disabled}
+          data-slot="segmented-item"
+        >
+          {opt.label}
+        </ToggleGroupPrimitive.Item>
+      ))}
+    </ToggleGroupPrimitive.Root>
+  )
+}
+
+export { Segmented }

--- a/resources/js/Pages/Cliente/Create.charter.md
+++ b/resources/js/Pages/Cliente/Create.charter.md
@@ -3,14 +3,14 @@ page: /contacts/create
 component: resources/js/Pages/Cliente/Create.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-15
+last_validated: 2026-05-29
 parent_module: Cliente
-related_adrs: [0110, 0107, 0093, 0094, 0104, 0149]
+related_adrs: [0110, 0107, 0093, 0094, 0104, 0149, 0235]
 tier: A
-charter_version: 1
+charter_version: 2
 mwart_pattern_reuse:
   blueprint_cowork: "prototipo-ui/prototipos/clientes/"
-  blueprint_screenshot_approval: "SYNC_LOG (pendente)"
+  blueprint_screenshot_approval: "Wagner 2026-05-29 — PR-A Onda F (componentes aprovados; Create elevado pendente)"
   derived_screens: [Create]
   divergence_from_blueprint: "none"
 ---
@@ -29,8 +29,11 @@ Formulário de cadastro de novo cliente/fornecedor — substitui Blade `contact.
 - 4 seções: Identificação · Contato · Endereço · Financeiro
 - Validação client-side básica (required) + display de errors server-side via useForm.errors
 - Pre-fill via query `?prefill_name=` (vindo do CustomerSearchAutocomplete em Sells/Create)
-- Radio person/business em UI canon (radio nativo, não fancy)
-- Dropdown customer_group_id (eager-load — apenas N customer_groups, leve)
+- **Segmented PF/PJ** (DS v4 Onda F · `@/Components/ui/segmented`) — substitui o radio nativo
+- `<Select>` customer_group_id (eager-load — apenas N customer_groups, leve)
+- Lookup CNPJ via BrasilAPI (DadosFiscaisBRSection · `InputGroup` + `FieldSuccess`)
+- **Rail de contexto** sticky — preview vivo + prontidão fiscal client-side (PR-A; copiloto IA = PR-A2)
+- Corpo compartilhado `_form/ClienteForm` (Create + Edit dividem ~90%)
 - Submit via Inertia POST `/contacts` — backend valida e retorna redirect ou errors
 - PT-BR labels obrigatório
 

--- a/resources/js/Pages/Cliente/Create.charter.md
+++ b/resources/js/Pages/Cliente/Create.charter.md
@@ -3,9 +3,9 @@ page: /contacts/create
 component: resources/js/Pages/Cliente/Create.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-29
+last_validated: "2026-05-29"
 parent_module: Cliente
-related_adrs: [0110, 0107, 0093, 0094, 0104, 0149, 0235]
+related_adrs: [110, 107, 93, 94, 104, 149, 235]
 tier: A
 charter_version: 2
 mwart_pattern_reuse:

--- a/resources/js/Pages/Cliente/Create.tsx
+++ b/resources/js/Pages/Cliente/Create.tsx
@@ -1,23 +1,19 @@
-// W1-B3 Cliente/Create — form de cadastro Inertia/React (MWART F3).
-// Pattern reuse ADR 0149 — deriva do blueprint Cowork clientes-cockpit.
-// Backend: ContactController::create() — Inertia::render dual via config('mwart.cliente_create.enabled')
+// Cliente/Create — cadastro Inertia/React (MWART F3 · KB-9.75 Contacts).
+// PR-A (Onda F): corpo extraído pro _form/ClienteForm (compartilhado com Edit).
+// Backend: ContactController::create() — Inertia::render dual via config('mwart.cliente_create.enabled').
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { useForm } from '@inertiajs/react';
 import { type ReactNode, type FormEvent } from 'react';
-import { ChevronLeft, Save, User2 } from 'lucide-react';
-import { Input } from '@/Components/ui/input';
-import { Button } from '@/Components/ui/button';
-import { Label } from '@/Components/ui/label';
-import DadosFiscaisBRSection, {
-  type DadosFiscaisBRData,
-  type BrasilApiCnpjData,
-} from './_form/DadosFiscaisBRSection';
+import { ChevronLeft } from 'lucide-react';
+import { ClienteForm } from './_form/ClienteForm';
+import type { BrasilApiCnpjData } from './_form/DadosFiscaisBRSection';
+import type { ClienteFormShared, CustomerGroup } from './_form/cliente-form-types';
 import { unmaskDigits } from '@/Lib/format-br';
 
 interface ClienteCreatePageProps {
   types: Record<string, string>;
-  customer_groups: Array<{ id: number; name: string }>;
+  customer_groups: CustomerGroup[];
   selected_type: string | null;
   prefill_name: string;
   permissions: {
@@ -26,29 +22,10 @@ interface ClienteCreatePageProps {
   };
 }
 
-type ClienteFormData = DadosFiscaisBRData & {
-  type: string;
-  contact_type_radio: string;
-  prefix: string;
-  first_name: string;
-  middle_name: string;
-  last_name: string;
-  supplier_business_name: string;
-  tax_number: string;
-  mobile: string;
-  landline: string;
-  email: string;
-  address_line_1: string;
-  city: string;
-  state: string;
-  zip_code: string;
-  customer_group_id: string;
-  opening_balance: string;
-  credit_limit: string;
-};
+type ClienteCreateFormData = ClienteFormShared & { prefix: string };
 
 export default function ClienteCreate(props: ClienteCreatePageProps) {
-  const { data, setData, post, processing, errors, transform } = useForm<ClienteFormData>({
+  const { data, setData, post, processing, errors, transform } = useForm<ClienteCreateFormData>({
     type: props.selected_type ?? 'customer',
     contact_type_radio: 'person',
     prefix: '',
@@ -67,7 +44,6 @@ export default function ClienteCreate(props: ClienteCreatePageProps) {
     customer_group_id: '',
     opening_balance: '0',
     credit_limit: '',
-    // Dados Fiscais BR — migration 2026_05_21_140000.
     cpf_cnpj: '',
     rg: '',
     inscricao_estadual: '',
@@ -82,19 +58,12 @@ export default function ClienteCreate(props: ClienteCreatePageProps) {
 
   const isJuridica = data.contact_type_radio === 'business';
 
-  // Slice 5a — callback chamado quando DadosFiscaisBRSection recebe sucesso do
-  // /contacts/lookup/cnpj/{cnpj}. Preenche aqui os campos que NÃO vivem em
-  // DadosFiscaisBRData (supplier_business_name = razão social + endereço).
+  // Slice 5a — preenche campos fora de DadosFiscaisBRData (razão social + endereço).
   const handleCnpjLookup = (api: BrasilApiCnpjData) => {
     if (api.razao_social) {
       setData('supplier_business_name', api.razao_social);
-      // Se primeiro_nome estiver vazio, usa razao_social como base — fluxo comum
-      // de cadastrar PJ pela primeira vez.
-      if (!data.first_name) {
-        setData('first_name', api.razao_social);
-      }
+      if (!data.first_name) setData('first_name', api.razao_social);
     }
-    // Endereço — só sobrescreve se vier valor da API (preserva o que user já digitou).
     if (api.logradouro) {
       const numero = api.numero ? `, ${api.numero}` : '';
       const bairro = api.bairro ? ` — ${api.bairro}` : '';
@@ -105,263 +74,48 @@ export default function ClienteCreate(props: ClienteCreatePageProps) {
     if (api.cep) setData('zip_code', api.cep);
   };
 
-  // Normaliza cpf_cnpj pra dígitos puros antes do submit — backend Rule\BR\CpfCnpj
-  // já chama Util::onlyNumbers internamente mas mandamos limpo pra evitar
-  // pontuação persistida no banco (consistência cross-driver).
-  transform((payload) => ({
-    ...payload,
-    cpf_cnpj: unmaskDigits(payload.cpf_cnpj),
-  }));
+  transform((payload) => ({ ...payload, cpf_cnpj: unmaskDigits(payload.cpf_cnpj) }));
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    post('/contacts', {
-      preserveScroll: true,
-    });
+    post('/contacts', { preserveScroll: true });
   };
 
   return (
-    <div className="-m-6 bg-muted/30 min-h-[calc(100vh-3rem)]">
+    <div className="-m-6 min-h-[calc(100vh-3rem)] bg-muted/30">
       <div className="border-b border-border bg-background">
-        <div className="container mx-auto px-8 pt-6 pb-4 max-w-3xl">
-          <div className="flex items-center gap-3 mb-2">
-            <a
-              href="/contacts/customer"
-              className="inline-flex items-center text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <ChevronLeft size={14} className="mr-1" />
-              Voltar para clientes
-            </a>
-          </div>
+        <div className="container mx-auto max-w-5xl px-8 pb-4 pt-6">
+          <a
+            href="/contacts/customer"
+            className="mb-2 inline-flex items-center text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ChevronLeft size={14} className="mr-1" />
+            Voltar para clientes
+          </a>
           <h1 className="text-2xl font-semibold tracking-tight text-foreground">Novo cliente</h1>
-          <p className="text-sm text-muted-foreground mt-1">
-            Preencha os dados do cliente. Campos com * são obrigatórios.
+          <p className="mt-1 text-sm text-muted-foreground">
+            Preencha os dados do cliente. Campos com <span className="cw-req">*</span> são obrigatórios.
           </p>
         </div>
       </div>
 
-      <div className="container mx-auto px-8 py-5 max-w-3xl">
-        <form onSubmit={handleSubmit} className="space-y-3">
-          <Section title="Identificação" icon={User2}>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
-              <Field label="Tipo" error={errors.type}>
-                <select
-                  value={data.type}
-                  onChange={(e) => setData('type', e.target.value)}
-                  className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm"
-                  required
-                >
-                  {Object.entries(props.types).map(([k, v]) => (
-                    <option key={k} value={k}>{v}</option>
-                  ))}
-                </select>
-              </Field>
-              <Field label="Pessoa" error={errors.contact_type_radio}>
-                <div className="flex items-center gap-3 h-9">
-                  <label className="inline-flex items-center gap-1.5 text-sm">
-                    <input
-                      type="radio"
-                      name="contact_type_radio"
-                      value="person"
-                      checked={data.contact_type_radio === 'person'}
-                      onChange={(e) => setData('contact_type_radio', e.target.value)}
-                    />
-                    Física
-                  </label>
-                  <label className="inline-flex items-center gap-1.5 text-sm">
-                    <input
-                      type="radio"
-                      name="contact_type_radio"
-                      value="business"
-                      checked={data.contact_type_radio === 'business'}
-                      onChange={(e) => setData('contact_type_radio', e.target.value)}
-                    />
-                    Jurídica
-                  </label>
-                </div>
-              </Field>
-              <Field label="Nome / Razão social *" error={errors.first_name} colSpan={2}>
-                <Input
-                  type="text"
-                  value={data.first_name}
-                  onChange={(e) => setData('first_name', e.target.value)}
-                  required
-                  maxLength={100}
-                />
-              </Field>
-              <Field label="Sobrenome" error={errors.last_name}>
-                <Input
-                  type="text"
-                  value={data.last_name}
-                  onChange={(e) => setData('last_name', e.target.value)}
-                  maxLength={100}
-                />
-              </Field>
-              <Field label="Tax number (legado UPOS)" error={errors.tax_number}>
-                <Input
-                  type="text"
-                  value={data.tax_number}
-                  onChange={(e) => setData('tax_number', e.target.value)}
-                  placeholder="Use CPF / CNPJ abaixo (este campo é legacy)"
-                />
-              </Field>
-            </div>
-          </Section>
-
-          <DadosFiscaisBRSection<ClienteFormData>
-            data={data}
-            setData={setData}
-            errors={errors}
-            isJuridica={isJuridica}
-            onCnpjLookup={handleCnpjLookup}
-          />
-
-          <Section title="Contato">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
-              <Field label="Celular" error={errors.mobile}>
-                <Input
-                  type="tel"
-                  value={data.mobile}
-                  onChange={(e) => setData('mobile', e.target.value)}
-                  placeholder="(00) 00000-0000"
-                />
-              </Field>
-              <Field label="Telefone fixo" error={errors.landline}>
-                <Input
-                  type="tel"
-                  value={data.landline}
-                  onChange={(e) => setData('landline', e.target.value)}
-                  placeholder="(00) 0000-0000"
-                />
-              </Field>
-              <Field label="E-mail" error={errors.email} colSpan={2}>
-                <Input
-                  type="email"
-                  value={data.email}
-                  onChange={(e) => setData('email', e.target.value)}
-                  placeholder="cliente@exemplo.com.br"
-                />
-              </Field>
-            </div>
-          </Section>
-
-          <Section title="Endereço">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
-              <Field label="Endereço" error={errors.address_line_1} colSpan={2}>
-                <Input
-                  type="text"
-                  value={data.address_line_1}
-                  onChange={(e) => setData('address_line_1', e.target.value)}
-                />
-              </Field>
-              <Field label="Cidade" error={errors.city}>
-                <Input
-                  type="text"
-                  value={data.city}
-                  onChange={(e) => setData('city', e.target.value)}
-                />
-              </Field>
-              <Field label="UF" error={errors.state}>
-                <Input
-                  type="text"
-                  value={data.state}
-                  onChange={(e) => setData('state', e.target.value)}
-                  maxLength={2}
-                />
-              </Field>
-              <Field label="CEP" error={errors.zip_code}>
-                <Input
-                  type="text"
-                  value={data.zip_code}
-                  onChange={(e) => setData('zip_code', e.target.value)}
-                  placeholder="00000-000"
-                />
-              </Field>
-            </div>
-          </Section>
-
-          {(data.type === 'customer' || data.type === 'both') && (
-            <Section title="Financeiro">
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
-                <Field label="Saldo inicial" error={errors.opening_balance}>
-                  <Input
-                    type="text"
-                    value={data.opening_balance}
-                    onChange={(e) => setData('opening_balance', e.target.value)}
-                    placeholder="0,00"
-                  />
-                </Field>
-                <Field label="Limite de crédito" error={errors.credit_limit}>
-                  <Input
-                    type="text"
-                    value={data.credit_limit}
-                    onChange={(e) => setData('credit_limit', e.target.value)}
-                    placeholder="0,00"
-                  />
-                </Field>
-                {props.customer_groups.length > 0 && (
-                  <Field label="Grupo de clientes" error={errors.customer_group_id} colSpan={2}>
-                    <select
-                      value={data.customer_group_id}
-                      onChange={(e) => setData('customer_group_id', e.target.value)}
-                      className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm"
-                    >
-                      <option value="">— Nenhum —</option>
-                      {props.customer_groups.map((g) => (
-                        <option key={g.id} value={g.id}>{g.name}</option>
-                      ))}
-                    </select>
-                  </Field>
-                )}
-              </div>
-            </Section>
-          )}
-
-          <div className="flex items-center justify-end gap-2 pt-4 border-t border-border">
-            <Button type="button" variant="cowork-ghost" asChild>
-              <a href="/contacts/customer">Cancelar</a>
-            </Button>
-            <Button type="submit" variant="cowork-primary" disabled={processing}>
-              <Save className="mr-1.5 h-4 w-4" />
-              {processing ? 'Salvando…' : 'Salvar cliente'}
-            </Button>
-          </div>
-        </form>
+      <div className="container mx-auto max-w-5xl px-8 py-5">
+        <ClienteForm
+          data={data}
+          setData={setData}
+          errors={errors}
+          types={props.types}
+          customerGroups={props.customer_groups}
+          isJuridica={isJuridica}
+          onCnpjLookup={handleCnpjLookup}
+          processing={processing}
+          submitLabel="Salvar cliente"
+          cancelHref="/contacts/customer"
+          onSubmit={handleSubmit}
+        />
       </div>
     </div>
   );
 }
 
 ClienteCreate.layout = (page: ReactNode) => <AppShellV2>{page}</AppShellV2>;
-
-function Section({ title, icon: Icon, children }: { title: string; icon?: typeof User2; children: ReactNode }) {
-  return (
-    <section className="rounded-lg border border-border bg-background p-4">
-      <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3 flex items-center gap-2">
-        {Icon && <Icon size={14} className="text-muted-foreground" />}
-        {title}
-      </h3>
-      {children}
-    </section>
-  );
-}
-
-function Field({
-  label,
-  children,
-  error,
-  colSpan,
-}: {
-  label: string;
-  children: ReactNode;
-  error?: string;
-  colSpan?: number;
-}) {
-  return (
-    <div className={colSpan === 2 ? 'sm:col-span-2' : ''}>
-      <Label className="mb-1 block">{label}</Label>
-      {children}
-      {error && <p className="text-xs text-rose-600 mt-0.5">{error}</p>}
-    </div>
-  );
-}

--- a/resources/js/Pages/Cliente/Edit.charter.md
+++ b/resources/js/Pages/Cliente/Edit.charter.md
@@ -3,14 +3,14 @@ page: /contacts/{id}/edit
 component: resources/js/Pages/Cliente/Edit.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-15
+last_validated: 2026-05-29
 parent_module: Cliente
-related_adrs: [0110, 0107, 0093, 0094, 0104, 0149]
+related_adrs: [0110, 0107, 0093, 0094, 0104, 0149, 0235]
 tier: A
-charter_version: 1
+charter_version: 2
 mwart_pattern_reuse:
   blueprint_cowork: "prototipo-ui/prototipos/clientes/"
-  blueprint_screenshot_approval: "SYNC_LOG (pendente)"
+  blueprint_screenshot_approval: "Wagner 2026-05-29 — PR-A Onda F (espelho do Create via ClienteForm)"
   derived_screens: [Edit]
   divergence_from_blueprint: "none"
 ---
@@ -28,7 +28,7 @@ Form de edição de cliente existente, pré-preenchido. Mesmo layout de Create +
 - Pré-preenche todos os campos com dados existentes
 - Submit via Inertia PUT `/contacts/{id}` (rota legacy aceita)
 - Display opening_balance ajustado (já descontado pagamento, vindo de TransactionUtil::getTotalAmountPaid)
-- Mesmo conjunto de seções de Create
+- Mesmo corpo do Create via `_form/ClienteForm` compartilhado (DS v4 Onda F: Segmented, FormSection, InputGroup, FieldError) + rail de contexto
 
 ## Non-Goals
 

--- a/resources/js/Pages/Cliente/Edit.charter.md
+++ b/resources/js/Pages/Cliente/Edit.charter.md
@@ -3,9 +3,9 @@ page: /contacts/{id}/edit
 component: resources/js/Pages/Cliente/Edit.tsx
 owner: wagner
 status: draft
-last_validated: 2026-05-29
+last_validated: "2026-05-29"
 parent_module: Cliente
-related_adrs: [0110, 0107, 0093, 0094, 0104, 0149, 0235]
+related_adrs: [110, 107, 93, 94, 104, 149, 235]
 tier: A
 charter_version: 2
 mwart_pattern_reuse:

--- a/resources/js/Pages/Cliente/Edit.tsx
+++ b/resources/js/Pages/Cliente/Edit.tsx
@@ -1,18 +1,14 @@
-// W1-B3 Cliente/Edit — form de edição Inertia/React (MWART F3).
-// Pattern reuse ADR 0149 — deriva blueprint Cowork clientes; family visual idêntica a Create.
-// Backend: ContactController::edit($id) — Inertia::render dual via config('mwart.cliente_edit.enabled')
+// Cliente/Edit — edição Inertia/React (MWART F3). Espelho do Create.
+// PR-A (Onda F): corpo extraído pro _form/ClienteForm (compartilhado).
+// Backend: ContactController::edit($id) — Inertia::render dual via config('mwart.cliente_edit.enabled').
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { useForm } from '@inertiajs/react';
 import { type ReactNode, type FormEvent } from 'react';
-import { ChevronLeft, Save, User2 } from 'lucide-react';
-import { Input } from '@/Components/ui/input';
-import { Button } from '@/Components/ui/button';
-import { Label } from '@/Components/ui/label';
-import DadosFiscaisBRSection, {
-  type DadosFiscaisBRData,
-  type BrasilApiCnpjData,
-} from './_form/DadosFiscaisBRSection';
+import { ChevronLeft } from 'lucide-react';
+import { ClienteForm } from './_form/ClienteForm';
+import type { BrasilApiCnpjData } from './_form/DadosFiscaisBRSection';
+import type { ClienteFormShared, CustomerGroup } from './_form/cliente-form-types';
 import { unmaskDigits } from '@/Lib/format-br';
 
 interface ContactInfo {
@@ -35,7 +31,6 @@ interface ContactInfo {
   zip_code: string | null;
   customer_group_id: number | null;
   credit_limit: string | null;
-  // Campos BR (migration 2026_05_21_140000). Backend pode mandar null em legacy.
   cpf_cnpj?: string | null;
   rg?: string | null;
   inscricao_estadual?: string | null;
@@ -51,33 +46,13 @@ interface ContactInfo {
 interface ClienteEditPageProps {
   contact: ContactInfo;
   types: Record<string, string>;
-  customer_groups: Array<{ id: number; name: string }>;
+  customer_groups: CustomerGroup[];
   opening_balance: string;
 }
 
-type ClienteFormData = DadosFiscaisBRData & {
-  type: string;
-  contact_type_radio: string;
-  first_name: string;
-  middle_name: string;
-  last_name: string;
-  supplier_business_name: string;
-  tax_number: string;
-  mobile: string;
-  landline: string;
-  email: string;
-  address_line_1: string;
-  city: string;
-  state: string;
-  zip_code: string;
-  customer_group_id: string;
-  opening_balance: string;
-  credit_limit: string;
-};
-
 export default function ClienteEdit(props: ClienteEditPageProps) {
   const c = props.contact;
-  const { data, setData, put, processing, errors, transform } = useForm<ClienteFormData>({
+  const { data, setData, put, processing, errors, transform } = useForm<ClienteFormShared>({
     type: c.type ?? 'customer',
     contact_type_radio: c.contact_type ?? 'person',
     first_name: c.first_name ?? c.name ?? '',
@@ -95,7 +70,6 @@ export default function ClienteEdit(props: ClienteEditPageProps) {
     customer_group_id: c.customer_group_id ? String(c.customer_group_id) : '',
     opening_balance: props.opening_balance ?? '0',
     credit_limit: c.credit_limit ?? '',
-    // Dados Fiscais BR — pré-preenchidos do contact carregado pelo backend.
     cpf_cnpj: c.cpf_cnpj ?? '',
     rg: c.rg ?? '',
     inscricao_estadual: c.inscricao_estadual ?? '',
@@ -110,12 +84,9 @@ export default function ClienteEdit(props: ClienteEditPageProps) {
 
   const isJuridica = data.contact_type_radio === 'business';
 
-  // Slice 5a — preenche campos não-fiscais quando BrasilAPI retorna sucesso.
-  // No Edit, preservar valores existentes é mais sensível — só sobrescreve se API trouxe valor.
+  // No Edit, preservar o que existe é mais sensível — só sobrescreve com valor da API.
   const handleCnpjLookup = (api: BrasilApiCnpjData) => {
-    if (api.razao_social) {
-      setData('supplier_business_name', api.razao_social);
-    }
+    if (api.razao_social) setData('supplier_business_name', api.razao_social);
     if (api.logradouro) {
       const numero = api.numero ? `, ${api.numero}` : '';
       const bairro = api.bairro ? ` — ${api.bairro}` : '';
@@ -126,190 +97,46 @@ export default function ClienteEdit(props: ClienteEditPageProps) {
     if (api.cep) setData('zip_code', api.cep);
   };
 
-  // Mesma normalização de Create — backend Rule\BR\CpfCnpj re-aplica onlyNumbers.
-  transform((payload) => ({
-    ...payload,
-    cpf_cnpj: unmaskDigits(payload.cpf_cnpj),
-  }));
+  transform((payload) => ({ ...payload, cpf_cnpj: unmaskDigits(payload.cpf_cnpj) }));
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    put(`/contacts/${c.id}`, {
-      preserveScroll: true,
-    });
+    put(`/contacts/${c.id}`, { preserveScroll: true });
   };
 
   return (
-    <div className="-m-6 bg-muted/30 min-h-[calc(100vh-3rem)]">
+    <div className="-m-6 min-h-[calc(100vh-3rem)] bg-muted/30">
       <div className="border-b border-border bg-background">
-        <div className="container mx-auto px-8 pt-6 pb-4 max-w-3xl">
-          <div className="flex items-center gap-3 mb-2">
-            <a
-              href={`/contacts/${c.id}`}
-              className="inline-flex items-center text-xs text-muted-foreground hover:text-foreground transition-colors"
-            >
-              <ChevronLeft size={14} className="mr-1" />
-              Voltar para detalhe
-            </a>
-          </div>
+        <div className="container mx-auto max-w-5xl px-8 pb-4 pt-6">
+          <a
+            href={`/contacts/${c.id}`}
+            className="mb-2 inline-flex items-center text-xs text-muted-foreground transition-colors hover:text-foreground"
+          >
+            <ChevronLeft size={14} className="mr-1" />
+            Voltar para detalhe
+          </a>
           <h1 className="text-2xl font-semibold tracking-tight text-foreground">Editar cliente</h1>
-          <p className="text-sm text-muted-foreground mt-1">{c.name}</p>
+          <p className="mt-1 text-sm text-muted-foreground">{c.name}</p>
         </div>
       </div>
 
-      <div className="container mx-auto px-8 py-5 max-w-3xl">
-        <form onSubmit={handleSubmit} className="space-y-3">
-          <Section title="Identificação" icon={User2}>
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
-              <Field label="Tipo" error={errors.type}>
-                <select
-                  value={data.type}
-                  onChange={(e) => setData('type', e.target.value)}
-                  className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm"
-                  required
-                >
-                  {Object.entries(props.types).map(([k, v]) => (
-                    <option key={k} value={k}>{v}</option>
-                  ))}
-                </select>
-              </Field>
-              <Field label="Pessoa" error={errors.contact_type_radio}>
-                <div className="flex items-center gap-3 h-9">
-                  <label className="inline-flex items-center gap-1.5 text-sm">
-                    <input
-                      type="radio"
-                      name="contact_type_radio"
-                      value="person"
-                      checked={data.contact_type_radio === 'person'}
-                      onChange={(e) => setData('contact_type_radio', e.target.value)}
-                    />
-                    Física
-                  </label>
-                  <label className="inline-flex items-center gap-1.5 text-sm">
-                    <input
-                      type="radio"
-                      name="contact_type_radio"
-                      value="business"
-                      checked={data.contact_type_radio === 'business'}
-                      onChange={(e) => setData('contact_type_radio', e.target.value)}
-                    />
-                    Jurídica
-                  </label>
-                </div>
-              </Field>
-              <Field label="Nome / Razão social *" error={errors.first_name} colSpan={2}>
-                <Input value={data.first_name} onChange={(e) => setData('first_name', e.target.value)} required maxLength={100} />
-              </Field>
-              <Field label="Sobrenome" error={errors.last_name}>
-                <Input value={data.last_name} onChange={(e) => setData('last_name', e.target.value)} maxLength={100} />
-              </Field>
-              <Field label="Tax number (legado UPOS)" error={errors.tax_number}>
-                <Input value={data.tax_number} onChange={(e) => setData('tax_number', e.target.value)} placeholder="Use CPF / CNPJ abaixo (este campo é legacy)" />
-              </Field>
-            </div>
-          </Section>
-
-          <DadosFiscaisBRSection<ClienteFormData>
-            data={data}
-            setData={setData}
-            errors={errors}
-            isJuridica={isJuridica}
-            onCnpjLookup={handleCnpjLookup}
-          />
-
-          <Section title="Contato">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
-              <Field label="Celular" error={errors.mobile}>
-                <Input value={data.mobile} onChange={(e) => setData('mobile', e.target.value)} />
-              </Field>
-              <Field label="Telefone fixo" error={errors.landline}>
-                <Input value={data.landline} onChange={(e) => setData('landline', e.target.value)} />
-              </Field>
-              <Field label="E-mail" error={errors.email} colSpan={2}>
-                <Input type="email" value={data.email} onChange={(e) => setData('email', e.target.value)} />
-              </Field>
-            </div>
-          </Section>
-
-          <Section title="Endereço">
-            <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
-              <Field label="Endereço" error={errors.address_line_1} colSpan={2}>
-                <Input value={data.address_line_1} onChange={(e) => setData('address_line_1', e.target.value)} />
-              </Field>
-              <Field label="Cidade" error={errors.city}>
-                <Input value={data.city} onChange={(e) => setData('city', e.target.value)} />
-              </Field>
-              <Field label="UF" error={errors.state}>
-                <Input value={data.state} onChange={(e) => setData('state', e.target.value)} maxLength={2} />
-              </Field>
-              <Field label="CEP" error={errors.zip_code}>
-                <Input value={data.zip_code} onChange={(e) => setData('zip_code', e.target.value)} />
-              </Field>
-            </div>
-          </Section>
-
-          {(data.type === 'customer' || data.type === 'both') && (
-            <Section title="Financeiro">
-              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2.5">
-                <Field label="Saldo inicial" error={errors.opening_balance}>
-                  <Input value={data.opening_balance} onChange={(e) => setData('opening_balance', e.target.value)} />
-                </Field>
-                <Field label="Limite de crédito" error={errors.credit_limit}>
-                  <Input value={data.credit_limit} onChange={(e) => setData('credit_limit', e.target.value)} />
-                </Field>
-                {props.customer_groups.length > 0 && (
-                  <Field label="Grupo de clientes" error={errors.customer_group_id} colSpan={2}>
-                    <select
-                      value={data.customer_group_id}
-                      onChange={(e) => setData('customer_group_id', e.target.value)}
-                      className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm"
-                    >
-                      <option value="">— Nenhum —</option>
-                      {props.customer_groups.map((g) => (
-                        <option key={g.id} value={g.id}>{g.name}</option>
-                      ))}
-                    </select>
-                  </Field>
-                )}
-              </div>
-            </Section>
-          )}
-
-          <div className="flex items-center justify-end gap-2 pt-4 border-t border-border">
-            <Button type="button" variant="cowork-ghost" asChild>
-              <a href={`/contacts/${c.id}`}>Cancelar</a>
-            </Button>
-            <Button type="submit" variant="cowork-primary" disabled={processing}>
-              <Save className="mr-1.5 h-4 w-4" />
-              {processing ? 'Salvando…' : 'Salvar alterações'}
-            </Button>
-          </div>
-        </form>
+      <div className="container mx-auto max-w-5xl px-8 py-5">
+        <ClienteForm
+          data={data}
+          setData={setData}
+          errors={errors}
+          types={props.types}
+          customerGroups={props.customer_groups}
+          isJuridica={isJuridica}
+          onCnpjLookup={handleCnpjLookup}
+          processing={processing}
+          submitLabel="Salvar alterações"
+          cancelHref={`/contacts/${c.id}`}
+          onSubmit={handleSubmit}
+        />
       </div>
     </div>
   );
 }
 
 ClienteEdit.layout = (page: ReactNode) => <AppShellV2>{page}</AppShellV2>;
-
-function Section({ title, icon: Icon, children }: { title: string; icon?: typeof User2; children: ReactNode }) {
-  return (
-    <section className="rounded-lg border border-border bg-background p-4">
-      <h3 className="text-xs font-semibold text-muted-foreground uppercase tracking-wider mb-3 flex items-center gap-2">
-        {Icon && <Icon size={14} className="text-muted-foreground" />}
-        {title}
-      </h3>
-      {children}
-    </section>
-  );
-}
-
-function Field({ label, children, error, colSpan }: { label: string; children: ReactNode; error?: string; colSpan?: number }) {
-  return (
-    <div className={colSpan === 2 ? 'sm:col-span-2' : ''}>
-      <Label className="mb-1 block">{label}</Label>
-      {children}
-      {error && <p className="text-xs text-rose-600 mt-0.5">{error}</p>}
-    </div>
-  );
-}

--- a/resources/js/Pages/Cliente/_form/ClienteForm.tsx
+++ b/resources/js/Pages/Cliente/_form/ClienteForm.tsx
@@ -1,0 +1,271 @@
+import { type FormEvent } from "react"
+import { Banknote, Contact2, MapPin, Save, User2 } from "lucide-react"
+
+import { Button } from "@/Components/ui/button"
+import { Input } from "@/Components/ui/input"
+import { Segmented } from "@/Components/ui/segmented"
+import { FormSection, FormGrid } from "@/Components/ui/form-section"
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/Components/ui/select"
+import DadosFiscaisBRSection, {
+  type BrasilApiCnpjData,
+} from "./DadosFiscaisBRSection"
+import { Field } from "./Field"
+import { ClienteRail } from "./ClienteRail"
+import type { ClienteFormShared, CustomerGroup } from "./cliente-form-types"
+
+// Sentinela do Radix Select (não aceita value=""), mapeado pra '' no estado.
+const GRUPO_NENHUM = "__none__"
+
+/**
+ * ClienteForm — corpo compartilhado do cadastro (Create + Edit dividem ~90%).
+ * Aplica a Onda F: Segmented (PF/PJ), Select (@/ui), FormSection/FormGrid,
+ * FieldError, e envolve com `.cw-form-layout` + rail de contexto sticky.
+ *
+ * As páginas (Create/Edit) ficam finas: montam o useForm + submit + chrome e
+ * delegam o corpo pra cá.
+ */
+export function ClienteForm<T extends ClienteFormShared>({
+  data,
+  setData,
+  errors,
+  types,
+  customerGroups,
+  isJuridica,
+  onCnpjLookup,
+  processing,
+  submitLabel,
+  cancelHref,
+  onSubmit,
+}: {
+  data: T
+  setData: <K extends keyof T>(key: K, value: T[K]) => void
+  errors: Partial<Record<keyof T, string>>
+  types: Record<string, string>
+  customerGroups: CustomerGroup[]
+  isJuridica: boolean
+  onCnpjLookup: (api: BrasilApiCnpjData) => void
+  processing: boolean
+  submitLabel: string
+  cancelHref: string
+  onSubmit: (e: FormEvent<HTMLFormElement>) => void
+}) {
+  const set = (key: keyof ClienteFormShared, value: unknown) =>
+    setData(key as keyof T, value as T[keyof T])
+  // Acesso solto pros erros por nome de campo (a prop genérica tipa as chaves).
+  const err = errors as Record<string, string | undefined>
+  const showFinanceiro = data.type === "customer" || data.type === "both"
+
+  return (
+    <form onSubmit={onSubmit} className="cw-form-layout">
+      <div className="min-w-0 space-y-3">
+        {/* ── Identificação ── */}
+        <FormSection title="Identificação" icon={<User2 />}>
+          <FormGrid>
+            <Field label="Tipo" error={err.type}>
+              <Select value={data.type} onValueChange={(v) => set("type", v)}>
+                <SelectTrigger className="cw-input" aria-label="Tipo de contato">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.entries(types).map(([k, v]) => (
+                    <SelectItem key={k} value={k}>
+                      {v}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Field>
+
+            <Field label="Pessoa" error={err.contact_type_radio}>
+              <Segmented
+                accent
+                aria-label="Tipo de pessoa"
+                value={data.contact_type_radio}
+                onValueChange={(v) => set("contact_type_radio", v)}
+                options={[
+                  { value: "person", label: "Física" },
+                  { value: "business", label: "Jurídica" },
+                ]}
+              />
+            </Field>
+
+            <Field
+              label={isJuridica ? "Razão social" : "Nome completo"}
+              error={err.first_name}
+              required
+              fullRow
+            >
+              <Input
+                variant="cowork"
+                value={data.first_name}
+                onChange={(e) => set("first_name", e.target.value)}
+                required
+                maxLength={100}
+              />
+            </Field>
+
+            {!isJuridica && (
+              <Field label="Sobrenome" error={err.last_name}>
+                <Input
+                  variant="cowork"
+                  value={data.last_name}
+                  onChange={(e) => set("last_name", e.target.value)}
+                  maxLength={100}
+                />
+              </Field>
+            )}
+
+            <Field label="Tax number (legado UPOS)" error={err.tax_number}>
+              <Input
+                variant="cowork"
+                value={data.tax_number}
+                onChange={(e) => set("tax_number", e.target.value)}
+                placeholder="Use CPF / CNPJ abaixo (legacy)"
+              />
+            </Field>
+          </FormGrid>
+        </FormSection>
+
+        {/* ── Dados fiscais BR ── */}
+        <DadosFiscaisBRSection<T>
+          data={data}
+          setData={setData}
+          errors={errors}
+          isJuridica={isJuridica}
+          onCnpjLookup={onCnpjLookup}
+        />
+
+        {/* ── Contato ── */}
+        <FormSection title="Contato" icon={<Contact2 />}>
+          <FormGrid>
+            <Field label="Celular" error={err.mobile}>
+              <Input
+                variant="cowork"
+                type="tel"
+                value={data.mobile}
+                onChange={(e) => set("mobile", e.target.value)}
+                placeholder="(00) 00000-0000"
+              />
+            </Field>
+            <Field label="Telefone fixo" error={err.landline}>
+              <Input
+                variant="cowork"
+                type="tel"
+                value={data.landline}
+                onChange={(e) => set("landline", e.target.value)}
+                placeholder="(00) 0000-0000"
+              />
+            </Field>
+            <Field label="E-mail" error={err.email} fullRow>
+              <Input
+                variant="cowork"
+                type="email"
+                value={data.email}
+                onChange={(e) => set("email", e.target.value)}
+                placeholder="cliente@exemplo.com.br"
+              />
+            </Field>
+          </FormGrid>
+        </FormSection>
+
+        {/* ── Endereço ── */}
+        <FormSection title="Endereço" icon={<MapPin />}>
+          <FormGrid>
+            <Field label="Endereço" error={err.address_line_1} fullRow>
+              <Input
+                variant="cowork"
+                value={data.address_line_1}
+                onChange={(e) => set("address_line_1", e.target.value)}
+              />
+            </Field>
+            <Field label="Cidade" error={err.city}>
+              <Input variant="cowork" value={data.city} onChange={(e) => set("city", e.target.value)} />
+            </Field>
+            <Field label="UF" error={err.state}>
+              <Input
+                variant="cowork"
+                value={data.state}
+                onChange={(e) => set("state", e.target.value)}
+                maxLength={2}
+              />
+            </Field>
+            <Field label="CEP" error={err.zip_code}>
+              <Input
+                variant="cowork"
+                value={data.zip_code}
+                onChange={(e) => set("zip_code", e.target.value)}
+                placeholder="00000-000"
+              />
+            </Field>
+          </FormGrid>
+        </FormSection>
+
+        {/* ── Financeiro (só cliente/ambos) ── */}
+        {showFinanceiro && (
+          <FormSection title="Financeiro" icon={<Banknote />}>
+            <FormGrid>
+              <Field label="Saldo inicial" error={err.opening_balance}>
+                <Input
+                  variant="cowork"
+                  value={data.opening_balance}
+                  onChange={(e) => set("opening_balance", e.target.value)}
+                  placeholder="0,00"
+                />
+              </Field>
+              <Field label="Limite de crédito" error={err.credit_limit}>
+                <Input
+                  variant="cowork"
+                  value={data.credit_limit}
+                  onChange={(e) => set("credit_limit", e.target.value)}
+                  placeholder="0,00"
+                />
+              </Field>
+              {customerGroups.length > 0 && (
+                <Field label="Grupo de clientes" error={err.customer_group_id} fullRow>
+                  <Select
+                    value={data.customer_group_id || GRUPO_NENHUM}
+                    onValueChange={(v) => set("customer_group_id", v === GRUPO_NENHUM ? "" : v)}
+                  >
+                    <SelectTrigger className="cw-input" aria-label="Grupo de clientes">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value={GRUPO_NENHUM}>— Nenhum —</SelectItem>
+                      {customerGroups.map((g) => (
+                        <SelectItem key={g.id} value={String(g.id)}>
+                          {g.name}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </Field>
+              )}
+            </FormGrid>
+          </FormSection>
+        )}
+
+        {/* ── Ações ── */}
+        <div className="flex items-center justify-end gap-2 pt-2">
+          <Button type="button" variant="cowork-ghost" asChild>
+            <a href={cancelHref}>Cancelar</a>
+          </Button>
+          <Button type="submit" variant="cowork-primary" disabled={processing}>
+            <Save className="mr-1.5 h-4 w-4" />
+            {processing ? "Salvando…" : submitLabel}
+          </Button>
+        </div>
+      </div>
+
+      {/* ── Rail de contexto ── */}
+      <aside className="cw-form-rail">
+        <ClienteRail data={data} isJuridica={isJuridica} />
+      </aside>
+    </form>
+  )
+}

--- a/resources/js/Pages/Cliente/_form/ClienteRail.tsx
+++ b/resources/js/Pages/Cliente/_form/ClienteRail.tsx
@@ -1,0 +1,128 @@
+import { Building2, CheckCircle2, Circle, FileCheck2, Sparkles, User2 } from "lucide-react"
+
+import { formatCpfCnpj, unmaskDigits } from "@/Lib/format-br"
+import type { ClienteFormShared } from "./cliente-form-types"
+
+/**
+ * Rail de contexto do cadastro (pattern .cw-form-rail sticky). O salto 6,2→9,5
+ * do diagnóstico Contacts veio de mover preview + prontidão fiscal pra cá.
+ * Tudo client-side (computado do form) — sem chamada de backend.
+ *
+ * Slot do copiloto IA (dedup CNPJ + sugestão de grupo) fica preparado mas
+ * inerte — depende de endpoint (PR-A2).
+ */
+export function ClienteRail<T extends ClienteFormShared>({
+  data,
+  isJuridica,
+}: {
+  data: T
+  isJuridica: boolean
+}) {
+  const nome =
+    data.supplier_business_name?.trim() ||
+    [data.first_name, data.last_name].filter(Boolean).join(" ").trim() ||
+    (isJuridica ? "Nova empresa" : "Novo contato")
+  const inicial = (nome[0] ?? "?").toUpperCase()
+  const docDigits = unmaskDigits(data.cpf_cnpj)
+  const tipoLabel =
+    data.type === "supplier" ? "Fornecedor" : data.type === "both" ? "Cliente e fornecedor" : "Cliente"
+
+  const checks = isJuridica
+    ? [
+        { label: "CNPJ completo", done: docDigits.length === 14 },
+        { label: "Razão social", done: !!(data.supplier_business_name || data.first_name)?.trim() },
+        { label: "Inscrição estadual (ou ISENTO)", done: !!data.inscricao_estadual?.trim() },
+        { label: "Regime tributário", done: !!data.regime },
+        { label: "Indicador de IE", done: !!data.indicador_ie },
+      ]
+    : [
+        { label: "CPF completo", done: docDigits.length === 11 },
+        { label: "Nome", done: !!data.first_name?.trim() },
+      ]
+  const doneCount = checks.filter((c) => c.done).length
+  const allDone = doneCount === checks.length
+
+  return (
+    <>
+      {/* Preview vivo */}
+      <div className="rounded-lg border border-border bg-background p-3.5">
+        <div className="text-[10px] font-bold uppercase tracking-wider text-muted-foreground mb-2.5">
+          Pré-visualização
+        </div>
+        <div className="flex items-center gap-2.5">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-primary/10 text-sm font-semibold text-primary">
+            {inicial}
+          </div>
+          <div className="min-w-0">
+            <div className="truncate text-sm font-semibold text-foreground">{nome}</div>
+            <div className="flex items-center gap-1 text-[11px] text-muted-foreground">
+              {isJuridica ? <Building2 size={11} /> : <User2 size={11} />}
+              {isJuridica ? "Pessoa jurídica" : "Pessoa física"} · {tipoLabel}
+            </div>
+          </div>
+        </div>
+        <dl className="mt-3 space-y-1 text-[11.5px]">
+          {docDigits.length > 0 && (
+            <div className="flex justify-between gap-2">
+              <dt className="text-muted-foreground">{isJuridica ? "CNPJ" : "CPF"}</dt>
+              <dd className="font-mono text-foreground">{formatCpfCnpj(data.cpf_cnpj)}</dd>
+            </div>
+          )}
+          {!!data.email?.trim() && (
+            <div className="flex justify-between gap-2">
+              <dt className="text-muted-foreground">E-mail</dt>
+              <dd className="truncate text-foreground">{data.email}</dd>
+            </div>
+          )}
+          {!!data.mobile?.trim() && (
+            <div className="flex justify-between gap-2">
+              <dt className="text-muted-foreground">Celular</dt>
+              <dd className="text-foreground">{data.mobile}</dd>
+            </div>
+          )}
+        </dl>
+      </div>
+
+      {/* Prontidão fiscal (client-side) */}
+      <div className="rounded-lg border border-border bg-background p-3.5">
+        <div className="mb-2.5 flex items-center justify-between">
+          <span className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+            <FileCheck2 size={13} className="text-primary" />
+            Prontidão fiscal
+          </span>
+          <span className="font-mono text-[10px] text-muted-foreground">
+            {doneCount} de {checks.length}
+          </span>
+        </div>
+        <ul className="space-y-1.5">
+          {checks.map((c) => (
+            <li key={c.label} className="flex items-center gap-2 text-[11.5px]">
+              {c.done ? (
+                <CheckCircle2 size={13} className="shrink-0 text-emerald-600 dark:text-emerald-400" />
+              ) : (
+                <Circle size={13} className="shrink-0 text-muted-foreground/50" />
+              )}
+              <span className={c.done ? "text-foreground" : "text-muted-foreground"}>{c.label}</span>
+            </li>
+          ))}
+        </ul>
+        {allDone && (
+          <div className="mt-2.5 rounded-md bg-emerald-50 px-2.5 py-1.5 text-[11px] font-medium text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300">
+            Pronto pra emitir NF-e
+          </div>
+        )}
+      </div>
+
+      {/* Copiloto IA — slot preparado, inerte (PR-A2 liga ao endpoint) */}
+      <div className="rounded-lg border border-dashed border-border bg-muted/30 p-3.5">
+        <div className="flex items-center gap-1.5 text-[10px] font-bold uppercase tracking-wider text-muted-foreground">
+          <Sparkles size={13} className="text-primary" />
+          Copiloto
+        </div>
+        <p className="mt-1.5 text-[11.5px] text-muted-foreground">
+          Dedup (&ldquo;já existe esse CNPJ&rdquo;) e sugestão de grupo chegam em breve.
+        </p>
+      </div>
+    </>
+  )
+}

--- a/resources/js/Pages/Cliente/_form/ClienteRail.tsx
+++ b/resources/js/Pages/Cliente/_form/ClienteRail.tsx
@@ -98,7 +98,7 @@ export function ClienteRail<T extends ClienteFormShared>({
           {checks.map((c) => (
             <li key={c.label} className="flex items-center gap-2 text-[11.5px]">
               {c.done ? (
-                <CheckCircle2 size={13} className="shrink-0 text-emerald-600 dark:text-emerald-400" />
+                <CheckCircle2 size={13} className="cw-ok-text shrink-0" />
               ) : (
                 <Circle size={13} className="shrink-0 text-muted-foreground/50" />
               )}
@@ -107,7 +107,7 @@ export function ClienteRail<T extends ClienteFormShared>({
           ))}
         </ul>
         {allDone && (
-          <div className="mt-2.5 rounded-md bg-emerald-50 px-2.5 py-1.5 text-[11px] font-medium text-emerald-700 dark:bg-emerald-950/40 dark:text-emerald-300">
+          <div className="cw-ok-badge mt-2.5 rounded-md px-2.5 py-1.5 text-[11px] font-medium">
             Pronto pra emitir NF-e
           </div>
         )}

--- a/resources/js/Pages/Cliente/_form/DadosFiscaisBRSection.tsx
+++ b/resources/js/Pages/Cliente/_form/DadosFiscaisBRSection.tsx
@@ -1,27 +1,39 @@
 // Seção "Dados Fiscais BR" — compartilhada entre Cliente/Create.tsx e Cliente/Edit.tsx.
-// Slice 2 da restauração dos campos BR (PRs #1313 backend → este PR UI).
+// PR-A (Onda F): migrada pros componentes canon @/Components/ui —
+//   CNPJ lookup → InputGroup + InputGroupButton(loading/done)
+//   feedback do lookup → FieldError / FieldSuccess
+//   selects nativos (indicador IE, regime) → Select (@/ui)
+//   checkboxes nativos (flags) → Checkbox (@/ui)
+//   <section>/<Field> hand-rolled → FormSection/FormGrid + Field comum
 //
-// Recebe a tipagem mínima necessária via genéricos pra ambos os forms
-// (Create usa post '/contacts', Edit usa put '/contacts/{id}') sem
-// duplicação visual.
-//
-// Charter compliance:
-//   - Cliente/Create.charter.md: PT-BR labels, Non-Goal "Validação CNPJ via Receita
-//     Federal" → aqui só faz máscara visual + Rule BR mod-11 server-side
-//   - LGPD: máscara visual no input não é display de PII (input value é o que
-//     o user digitou, não dado retornado de banco)
+// Charter/LGPD: máscara visual no input não é display de PII; Rule BR mod-11
+// roda server-side. Lookup BrasilAPI é só preenchimento assistido (não Receita).
+
+import { useState } from 'react';
+import { FileText, Search } from 'lucide-react';
 
 import { Input } from '@/Components/ui/input';
 import { Label } from '@/Components/ui/label';
-import { Button } from '@/Components/ui/button';
-import { FileText, Search, Loader2 } from 'lucide-react';
-import { type ReactNode, useState } from 'react';
-import { formatCpfCnpj, unmaskDigits, INDICADOR_IE_OPTIONS, REGIME_TRIBUTARIO_OPTIONS } from '@/Lib/format-br';
+import { Checkbox } from '@/Components/ui/checkbox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/Components/ui/select';
+import { FormSection, FormGrid } from '@/Components/ui/form-section';
+import { InputGroup, InputGroupButton } from '@/Components/ui/input-group';
+import { FieldError, FieldSuccess } from '@/Components/ui/field-state';
+import { Field } from './Field';
+import {
+  formatCpfCnpj,
+  unmaskDigits,
+  INDICADOR_IE_OPTIONS,
+  REGIME_TRIBUTARIO_OPTIONS,
+} from '@/Lib/format-br';
 
-/**
- * Payload retornado por GET /contacts/lookup/cnpj/{cnpj}.
- * Schema espelha BrasilApiService::lookupCnpj normalized output.
- */
+/** Payload de GET /contacts/lookup/cnpj/{cnpj} (BrasilApiService normalized). */
 export interface BrasilApiCnpjData {
   cnpj: string;
   razao_social: string | null;
@@ -34,10 +46,7 @@ export interface BrasilApiCnpjData {
   uf: string | null;
 }
 
-/**
- * Campos BR usados nos dois forms (Create + Edit). Espelha colunas da
- * migration 2026_05_21_140000_restore_br_fields_to_contacts.php.
- */
+/** Campos BR usados nos dois forms (migration 2026_05_21_140000). */
 export interface DadosFiscaisBRData {
   cpf_cnpj: string;
   rg: string;
@@ -51,25 +60,15 @@ export interface DadosFiscaisBRData {
   suframa: string;
 }
 
-/**
- * Erros tipados (chave string -> mensagem) — Inertia useForm errors object.
- */
 export type DadosFiscaisBRErrors = Partial<Record<keyof DadosFiscaisBRData, string>>;
 
 interface Props<T extends DadosFiscaisBRData> {
   data: T;
   setData: <K extends keyof T>(key: K, value: T[K]) => void;
   errors: DadosFiscaisBRErrors;
-  /** Quando o tipo do contato é 'PF' a UI esconde campos PJ-only (IE, IM, suframa, nome fantasia). */
+  /** PF esconde campos PJ-only (IE, IM, suframa, nome fantasia, indicador). */
   isJuridica: boolean;
-  /**
-   * Callback Slice 5a — chamado quando lookup BrasilAPI retorna sucesso.
-   * O pai (Create/Edit) deve preencher campos que NÃO estão no DadosFiscaisBRData
-   * (supplier_business_name = razao_social, endereço completo).
-   *
-   * O próprio DadosFiscaisBRSection preenche apenas `nome_fantasia` (que está
-   * em DadosFiscaisBRData).
-   */
+  /** Slice 5a — pai preenche campos fora de DadosFiscaisBRData (razão social + endereço). */
   onCnpjLookup?: (data: BrasilApiCnpjData) => void;
 }
 
@@ -83,6 +82,10 @@ export default function DadosFiscaisBRSection<T extends DadosFiscaisBRData>({
   const [lookupLoading, setLookupLoading] = useState(false);
   const [lookupError, setLookupError] = useState<string | null>(null);
   const [lookupSuccess, setLookupSuccess] = useState<string | null>(null);
+
+  // Cast helper — chaves são keyof DadosFiscaisBRData ⊆ keyof T.
+  const set = (key: keyof DadosFiscaisBRData, value: unknown) =>
+    setData(key as keyof T, value as T[keyof T]);
 
   const cpfCnpjDigits = unmaskDigits(data.cpf_cnpj);
   const isCnpjComplete = isJuridica && cpfCnpjDigits.length === 14;
@@ -115,89 +118,78 @@ export default function DadosFiscaisBRSection<T extends DadosFiscaisBRData>({
         return;
       }
 
-      // Preenche nome_fantasia (campo deste componente).
-      if (api.nome_fantasia) {
-        setData('nome_fantasia' as keyof T, api.nome_fantasia as T[keyof T]);
-      }
-
-      // Delega pro pai preencher supplier_business_name + endereço.
+      if (api.nome_fantasia) set('nome_fantasia', api.nome_fantasia);
       onCnpjLookup?.(api);
-
       setLookupSuccess(`Dados preenchidos: ${api.razao_social ?? 'razão social'}.`);
-    } catch (e) {
+    } catch {
       setLookupError('Erro de rede ao consultar BrasilAPI.');
     } finally {
       setLookupLoading(false);
     }
   };
 
-  return (
-    <section className="rounded-lg border border-border bg-background p-5">
-      <h3 className="text-sm font-semibold text-foreground mb-4 flex items-center gap-2">
-        <FileText size={16} className="text-muted-foreground" />
-        Dados fiscais BR
-      </h3>
+  const onCpfCnpjChange = (raw: string) => {
+    set('cpf_cnpj', formatCpfCnpj(raw));
+    if (lookupError) setLookupError(null);
+    if (lookupSuccess) setLookupSuccess(null);
+  };
 
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        <Field
-          label={isJuridica ? 'CNPJ' : 'CPF'}
-          error={errors.cpf_cnpj}
-        >
-          <div className="flex items-stretch gap-2">
-            <Input
-              type="text"
-              inputMode="numeric"
-              value={formatCpfCnpj(data.cpf_cnpj)}
-              onChange={(e) => {
-                // Persiste sempre formatado pro re-render manter máscara consistente.
-                // Backend normaliza com Util::onlyNumbers via Rule BR\CpfCnpj.
-                setData('cpf_cnpj' as keyof T, formatCpfCnpj(e.target.value) as T[keyof T]);
-                // Reset feedback ao editar manualmente.
-                if (lookupError) setLookupError(null);
-                if (lookupSuccess) setLookupSuccess(null);
-              }}
-              placeholder={isJuridica ? '00.000.000/0000-00' : '000.000.000-00'}
-              maxLength={18}
-              autoComplete="off"
-              className="flex-1"
-            />
-            {isJuridica && (
-              <Button
-                type="button"
-                variant="outline"
-                size="sm"
+  return (
+    <FormSection title="Dados fiscais BR" icon={<FileText />}>
+      <FormGrid>
+        {/* CNPJ/CPF — InputGroup + lookup (PJ) ou Input simples (PF) */}
+        <div className="cw-field full-row">
+          <Label className="cw-label">{isJuridica ? 'CNPJ' : 'CPF'}</Label>
+          {isJuridica ? (
+            <InputGroup>
+              <Input
+                variant="cowork"
+                inputMode="numeric"
+                value={formatCpfCnpj(data.cpf_cnpj)}
+                onChange={(e) => onCpfCnpjChange(e.target.value)}
+                aria-invalid={errors.cpf_cnpj ? true : undefined}
+                placeholder="00.000.000/0000-00"
+                maxLength={18}
+                autoComplete="off"
+              />
+              <InputGroupButton
+                loading={lookupLoading}
+                done={!!lookupSuccess && !lookupError}
                 onClick={handleLookupCnpj}
-                disabled={!isCnpjComplete || lookupLoading}
+                disabled={!isCnpjComplete}
                 title={
                   isCnpjComplete
                     ? 'Buscar dados na BrasilAPI'
                     : 'Digite o CNPJ completo (14 dígitos) pra habilitar'
                 }
-                className="shrink-0 px-3"
               >
-                {lookupLoading ? (
-                  <Loader2 size={14} className="animate-spin" />
-                ) : (
-                  <Search size={14} />
-                )}
-                <span className="ml-1.5 hidden sm:inline">Buscar CNPJ</span>
-              </Button>
-            )}
-          </div>
-          {lookupError && (
-            <p className="text-xs text-rose-600 mt-1">{lookupError}</p>
+                {!lookupLoading && !lookupSuccess && <Search />}
+                <span className="hidden sm:inline">Buscar CNPJ</span>
+              </InputGroupButton>
+            </InputGroup>
+          ) : (
+            <Input
+              variant="cowork"
+              inputMode="numeric"
+              value={formatCpfCnpj(data.cpf_cnpj)}
+              onChange={(e) => onCpfCnpjChange(e.target.value)}
+              aria-invalid={errors.cpf_cnpj ? true : undefined}
+              placeholder="000.000.000-00"
+              maxLength={14}
+              autoComplete="off"
+            />
           )}
-          {lookupSuccess && !lookupError && (
-            <p className="text-xs text-emerald-600 mt-1">{lookupSuccess}</p>
-          )}
-        </Field>
+          <FieldError>{errors.cpf_cnpj}</FieldError>
+          <FieldError>{lookupError}</FieldError>
+          {lookupSuccess && !lookupError && <FieldSuccess>{lookupSuccess}</FieldSuccess>}
+        </div>
 
         {!isJuridica && (
           <Field label="RG" error={errors.rg}>
             <Input
-              type="text"
+              variant="cowork"
               value={data.rg}
-              onChange={(e) => setData('rg' as keyof T, e.target.value as T[keyof T])}
+              onChange={(e) => set('rg', e.target.value)}
               maxLength={20}
               autoComplete="off"
             />
@@ -206,11 +198,11 @@ export default function DadosFiscaisBRSection<T extends DadosFiscaisBRData>({
 
         {isJuridica && (
           <>
-            <Field label="Nome fantasia" error={errors.nome_fantasia} colSpan={2}>
+            <Field label="Nome fantasia" error={errors.nome_fantasia} fullRow>
               <Input
-                type="text"
+                variant="cowork"
                 value={data.nome_fantasia}
-                onChange={(e) => setData('nome_fantasia' as keyof T, e.target.value as T[keyof T])}
+                onChange={(e) => set('nome_fantasia', e.target.value)}
                 maxLength={150}
                 placeholder="Como aparece na fachada (opcional)"
               />
@@ -218,11 +210,9 @@ export default function DadosFiscaisBRSection<T extends DadosFiscaisBRData>({
 
             <Field label="Inscrição estadual (IE)" error={errors.inscricao_estadual}>
               <Input
-                type="text"
+                variant="cowork"
                 value={data.inscricao_estadual}
-                onChange={(e) =>
-                  setData('inscricao_estadual' as keyof T, e.target.value as T[keyof T])
-                }
+                onChange={(e) => set('inscricao_estadual', e.target.value)}
                 maxLength={30}
                 placeholder="ISENTO se for o caso"
               />
@@ -230,50 +220,51 @@ export default function DadosFiscaisBRSection<T extends DadosFiscaisBRData>({
 
             <Field label="Inscrição municipal (IM)" error={errors.inscricao_municipal}>
               <Input
-                type="text"
+                variant="cowork"
                 value={data.inscricao_municipal}
-                onChange={(e) =>
-                  setData('inscricao_municipal' as keyof T, e.target.value as T[keyof T])
-                }
+                onChange={(e) => set('inscricao_municipal', e.target.value)}
                 maxLength={30}
               />
             </Field>
 
             <Field label="Indicador IE (NFe)" error={errors.indicador_ie}>
-              <select
-                value={data.indicador_ie}
-                onChange={(e) =>
-                  setData('indicador_ie' as keyof T, e.target.value as T[keyof T])
-                }
-                className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm"
+              <Select
+                value={data.indicador_ie || undefined}
+                onValueChange={(v) => set('indicador_ie', v)}
               >
-                {INDICADOR_IE_OPTIONS.map((o) => (
-                  <option key={o.value} value={o.value}>
-                    {o.label}
-                  </option>
-                ))}
-              </select>
+                <SelectTrigger className="cw-input" aria-label="Indicador de IE">
+                  <SelectValue placeholder="— Selecione —" />
+                </SelectTrigger>
+                <SelectContent>
+                  {INDICADOR_IE_OPTIONS.filter((o) => o.value).map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </Field>
 
             <Field label="Regime tributário" error={errors.regime}>
-              <select
-                value={data.regime}
-                onChange={(e) => setData('regime' as keyof T, e.target.value as T[keyof T])}
-                className="h-9 w-full rounded-md border border-border bg-background px-3 text-sm"
-              >
-                {REGIME_TRIBUTARIO_OPTIONS.map((o) => (
-                  <option key={o.value} value={o.value}>
-                    {o.label}
-                  </option>
-                ))}
-              </select>
+              <Select value={data.regime || undefined} onValueChange={(v) => set('regime', v)}>
+                <SelectTrigger className="cw-input" aria-label="Regime tributário">
+                  <SelectValue placeholder="— Selecione —" />
+                </SelectTrigger>
+                <SelectContent>
+                  {REGIME_TRIBUTARIO_OPTIONS.filter((o) => o.value).map((o) => (
+                    <SelectItem key={o.value} value={o.value}>
+                      {o.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </Field>
 
             <Field label="SUFRAMA" error={errors.suframa}>
               <Input
-                type="text"
+                variant="cowork"
                 value={data.suframa}
-                onChange={(e) => setData('suframa' as keyof T, e.target.value as T[keyof T])}
+                onChange={(e) => set('suframa', e.target.value)}
                 maxLength={20}
                 placeholder="Apenas Zona Franca"
               />
@@ -281,53 +272,27 @@ export default function DadosFiscaisBRSection<T extends DadosFiscaisBRData>({
           </>
         )}
 
-        <Field label="Flags" colSpan={2}>
-          <div className="flex flex-wrap items-center gap-x-6 gap-y-2 h-9">
-            <label className="inline-flex items-center gap-1.5 text-sm">
-              <input
-                type="checkbox"
+        {/* Flags fiscais */}
+        <div className="cw-field full-row">
+          <Label className="cw-label">Flags</Label>
+          <div className="flex flex-wrap items-center gap-x-6 gap-y-2 pt-1">
+            <label className="inline-flex cursor-pointer items-center gap-2 text-[12px] text-foreground">
+              <Checkbox
                 checked={data.contribuinte}
-                onChange={(e) =>
-                  setData('contribuinte' as keyof T, e.target.checked as T[keyof T])
-                }
+                onCheckedChange={(c) => set('contribuinte', c === true)}
               />
               Contribuinte ICMS
             </label>
-            <label className="inline-flex items-center gap-1.5 text-sm">
-              <input
-                type="checkbox"
+            <label className="inline-flex cursor-pointer items-center gap-2 text-[12px] text-foreground">
+              <Checkbox
                 checked={data.consumidor_final}
-                onChange={(e) =>
-                  setData('consumidor_final' as keyof T, e.target.checked as T[keyof T])
-                }
+                onCheckedChange={(c) => set('consumidor_final', c === true)}
               />
               Consumidor final (NFe)
             </label>
           </div>
-        </Field>
-      </div>
-    </section>
-  );
-}
-
-// ─── Subcomponents ──────────────────────────────────────────────────────────
-
-function Field({
-  label,
-  children,
-  error,
-  colSpan,
-}: {
-  label: string;
-  children: ReactNode;
-  error?: string;
-  colSpan?: number;
-}) {
-  return (
-    <div className={colSpan === 2 ? 'sm:col-span-2' : ''}>
-      <Label className="text-xs font-medium text-muted-foreground mb-1.5 block">{label}</Label>
-      {children}
-      {error && <p className="text-xs text-rose-600 mt-1">{error}</p>}
-    </div>
+        </div>
+      </FormGrid>
+    </FormSection>
   );
 }

--- a/resources/js/Pages/Cliente/_form/DadosFiscaisBRSection.tsx
+++ b/resources/js/Pages/Cliente/_form/DadosFiscaisBRSection.tsx
@@ -276,20 +276,26 @@ export default function DadosFiscaisBRSection<T extends DadosFiscaisBRData>({
         <div className="cw-field full-row">
           <Label className="cw-label">Flags</Label>
           <div className="flex flex-wrap items-center gap-x-6 gap-y-2 pt-1">
-            <label className="inline-flex cursor-pointer items-center gap-2 text-[12px] text-foreground">
+            <div className="inline-flex items-center gap-2">
               <Checkbox
+                id="flag-contribuinte"
                 checked={data.contribuinte}
                 onCheckedChange={(c) => set('contribuinte', c === true)}
               />
-              Contribuinte ICMS
-            </label>
-            <label className="inline-flex cursor-pointer items-center gap-2 text-[12px] text-foreground">
+              <Label htmlFor="flag-contribuinte" className="cursor-pointer text-[12px] text-foreground">
+                Contribuinte ICMS
+              </Label>
+            </div>
+            <div className="inline-flex items-center gap-2">
               <Checkbox
+                id="flag-consumidor-final"
                 checked={data.consumidor_final}
                 onCheckedChange={(c) => set('consumidor_final', c === true)}
               />
-              Consumidor final (NFe)
-            </label>
+              <Label htmlFor="flag-consumidor-final" className="cursor-pointer text-[12px] text-foreground">
+                Consumidor final (NFe)
+              </Label>
+            </div>
           </div>
         </div>
       </FormGrid>

--- a/resources/js/Pages/Cliente/_form/Field.tsx
+++ b/resources/js/Pages/Cliente/_form/Field.tsx
@@ -1,0 +1,53 @@
+import * as React from "react"
+
+import { Label } from "@/Components/ui/label"
+import { FieldError, RequiredMark } from "@/Components/ui/field-state"
+import { cn } from "@/Lib/utils"
+
+/**
+ * Field — wrapper canon de campo do cadastro Cliente (label + controle + erro).
+ * Consolida o `<Field>` que estava duplicado em Create/Edit/DadosFiscais.
+ *
+ * a11y (ajuste Claude Design): quando há erro, injeta no controle filho
+ * `aria-invalid` + `aria-describedby` apontando pro id do <FieldError> (que é
+ * role=alert). Funciona direto pro <Input> (props passam pro <input>).
+ */
+export function Field({
+  label,
+  error,
+  required = false,
+  fullRow = false,
+  children,
+}: {
+  label: React.ReactNode
+  error?: string
+  required?: boolean
+  fullRow?: boolean
+  children: React.ReactNode
+}) {
+  const errorId = React.useId()
+
+  const child =
+    error && React.isValidElement(children)
+      ? React.cloneElement(children as React.ReactElement<Record<string, unknown>>, {
+          "aria-invalid": true,
+          "aria-describedby": [
+            (children as React.ReactElement<Record<string, unknown>>).props["aria-describedby"],
+            errorId,
+          ]
+            .filter(Boolean)
+            .join(" "),
+        })
+      : children
+
+  return (
+    <div className={cn("cw-field", fullRow && "full-row", error && "has-error")}>
+      <Label className="cw-label">
+        {label}
+        {required && <RequiredMark />}
+      </Label>
+      {child}
+      <FieldError id={errorId}>{error}</FieldError>
+    </div>
+  )
+}

--- a/resources/js/Pages/Cliente/_form/cliente-form-types.ts
+++ b/resources/js/Pages/Cliente/_form/cliente-form-types.ts
@@ -1,0 +1,31 @@
+import type { DadosFiscaisBRData } from "./DadosFiscaisBRSection"
+
+/**
+ * Campos do formulário compartilhados por Cliente/Create e Cliente/Edit
+ * (os dois dividem ~90%). Cada página estende este shape com o que é seu
+ * (ex.: Create tem `prefix`). Usado por ClienteForm/ClienteRail genéricos.
+ */
+export type ClienteFormShared = DadosFiscaisBRData & {
+  type: string
+  contact_type_radio: string
+  first_name: string
+  middle_name: string
+  last_name: string
+  supplier_business_name: string
+  tax_number: string
+  mobile: string
+  landline: string
+  email: string
+  address_line_1: string
+  city: string
+  state: string
+  zip_code: string
+  customer_group_id: string
+  opening_balance: string
+  credit_limit: string
+}
+
+export interface CustomerGroup {
+  id: number
+  name: string
+}

--- a/resources/js/Pages/_Showcase/OndaF.tsx
+++ b/resources/js/Pages/_Showcase/OndaF.tsx
@@ -1,0 +1,125 @@
+// @memcofre
+//   tela: /showcase/onda-f
+//   module: _DesignSystem
+//   status: showcase
+//   stories: Segmented · FormSection/FormGrid · InputGroup · FieldState
+//
+// Stories da Onda F (DS v4.1) — prova os 4 componentes fora da tela real e
+// alimenta a regressão visual. Renderiza cada um em densidade default e compact.
+
+import AppShellV2 from '@/Layouts/AppShellV2';
+import { useState, type ReactNode } from 'react';
+import { Input } from '@/Components/ui/input';
+import { Label } from '@/Components/ui/label';
+import { Segmented } from '@/Components/ui/segmented';
+import { FormSection, FormGrid } from '@/Components/ui/form-section';
+import { InputGroup, InputGroupButton, InputGroupAddon } from '@/Components/ui/input-group';
+import { FieldError, FieldSuccess, FieldValidating, RequiredMark } from '@/Components/ui/field-state';
+import { Building2 } from 'lucide-react';
+
+function Story({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <section className="space-y-3">
+      <h2 className="text-sm font-semibold text-foreground">{title}</h2>
+      <div className="flex flex-wrap items-start gap-6">{children}</div>
+    </section>
+  );
+}
+
+export default function OndaFShowcase() {
+  const [tipo, setTipo] = useState('customer');
+  const [pessoa, setPessoa] = useState('person');
+
+  return (
+    <div className="container mx-auto max-w-4xl px-8 py-8 space-y-10">
+      <header>
+        <h1 className="text-2xl font-semibold tracking-tight">Onda F — vocabulário de formulário</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          DS v4.1 · Segmented · FormSection · InputGroup · FieldState. Visual canon{' '}
+          <code className="text-xs">cowork-fields.css</code>.
+        </p>
+      </header>
+
+      <Story title="Segmented">
+        <Segmented
+          value={tipo}
+          onValueChange={setTipo}
+          options={[
+            { value: 'customer', label: 'Cliente' },
+            { value: 'supplier', label: 'Fornecedor' },
+            { value: 'both', label: 'Ambos' },
+          ]}
+        />
+        <Segmented
+          accent
+          value={pessoa}
+          onValueChange={setPessoa}
+          options={[
+            { value: 'person', label: 'Física' },
+            { value: 'business', label: 'Jurídica' },
+          ]}
+        />
+      </Story>
+
+      <Story title="InputGroup">
+        <div className="grid gap-3 w-full max-w-md">
+          <InputGroup>
+            <Input variant="cowork" defaultValue="12.345.678/0001-90" />
+            <InputGroupButton done>Encontrado</InputGroupButton>
+          </InputGroup>
+          <InputGroup>
+            <Input variant="cowork" placeholder="74000-000" />
+            <InputGroupButton loading>Buscando</InputGroupButton>
+          </InputGroup>
+          <InputGroup>
+            <InputGroupAddon>R$</InputGroupAddon>
+            <Input variant="cowork" placeholder="0,00" />
+          </InputGroup>
+        </div>
+      </Story>
+
+      <Story title="FieldState">
+        <div className="grid gap-3 w-full max-w-md">
+          <div className="cw-field">
+            <Label className="cw-label">
+              CNPJ <RequiredMark />
+            </Label>
+            <Input variant="cowork" defaultValue="12.345.678/0001-90" />
+            <FieldSuccess>Dados preenchidos pela BrasilAPI</FieldSuccess>
+          </div>
+          <div className="cw-field">
+            <Label className="cw-label">CEP</Label>
+            <Input variant="cowork" defaultValue="74000-000" />
+            <FieldValidating>Consultando endereço…</FieldValidating>
+          </div>
+          <div className="cw-field has-error">
+            <Label className="cw-label">E-mail</Label>
+            <Input variant="cowork" aria-invalid defaultValue="invalido@" />
+            <FieldError>Informe um e-mail válido.</FieldError>
+          </div>
+        </div>
+      </Story>
+
+      <Story title="FormSection + FormGrid">
+        <FormSection title="Identificação" icon={<Building2 />} count="3 de 4 ✓" className="w-full max-w-lg !mb-0">
+          <FormGrid>
+            <div className="cw-field full-row">
+              <Label className="cw-label">Razão social <RequiredMark /></Label>
+              <Input variant="cowork" defaultValue="Acme Comércio Ltda" />
+            </div>
+            <div className="cw-field">
+              <Label className="cw-label">Nome fantasia</Label>
+              <Input variant="cowork" defaultValue="Acme Materiais" />
+            </div>
+            <div className="cw-field">
+              <Label className="cw-label">Regime</Label>
+              <Input variant="cowork" defaultValue="Simples Nacional" />
+            </div>
+          </FormGrid>
+        </FormSection>
+      </Story>
+    </div>
+  );
+}
+
+OndaFShowcase.layout = (page: ReactNode) => <AppShellV2>{page}</AppShellV2>;


### PR DESCRIPTION
PR-A da Onda F (DS v4.1). 3 partes, 1 PR. **Não mergear** — aguarda [W2] aprovar o screenshot do `Cliente/Create` elevado.

## Parte 1 — 4 componentes React em `@/Components/ui`
- **`Segmented`** (Radix ToggleGroup, type single) — substitui `<input type=radio>` PF/PJ · Cliente/Fornecedor
- **`FormSection` + `FormGrid`** — substitui o `<Section>` hand-rolled (Create p-4 / DadosFiscais p-5)
- **`InputGroup`** + `InputGroupButton(loading/done)` + `InputGroupAddon` — lookup CNPJ, R$/%
- **`FieldError`**(role=alert) / `FieldSuccess` / `FieldValidating`(role=status) / `RequiredMark`

Visual canon em `cowork-fields.css` (`.cw-*` sobre tokens `--cw-*`). Sem dep nova (ToggleGroup vem do `radix-ui` unificado).

## Parte 2 — Stories
`Pages/_Showcase/OndaF.tsx` (alimenta visual-regression). Screenshot aprovado por Wagner + Claude Design 🟢.

## Parte 3 — Aplicado no cadastro de Contacts
`Cliente/Create` + `Edit` + `_form/DadosFiscaisBRSection`: radio→Segmented, select→Select, Section→FormSection, erro→FieldError, CNPJ→InputGroup+FieldSuccess, checkbox→Checkbox. **Extrai `_form/ClienteForm` comum** (Create+Edit dividem ~90% — páginas ficam finas) + **rail de contexto sticky** (`ClienteRail`): preview vivo + prontidão fiscal client-side + slot copiloto inerte.

## Ajustes do review (Claude Design 🟢)
- ✅ tokens `--cw-ok`/`--cw-ok-soft` (light+dark) no lugar do verde cru
- ✅ `aria-label` em cada `<Segmented>`
- ✅ `aria-describedby` do input → id do `<FieldError>` (via `Field`)
- ✅ nit `.cw-segmented` radius 6→5

## Defer
- **PR-A2** (precisa backend): copiloto IA dedup CNPJ + sugestão de grupo — slot do rail pronto, sem chamada
- **PR-B**: guard `ds/*` + ratchet

## Notas
- Charter `Create.charter.md` (draft 2026-05-15) ainda diz "radio nativo" — desatualizado pelo DS v4; atualizar em follow-up.
- Gate: aprovar o **screenshot do Create elevado** antes do merge.

Refs: REGISTRY_DS_COMPONENTES.md · MATRIZ_MIGRACAO_DS.md P0-1/P0-2 · PROMPT_PARA_CODE_PR-A · DS v4.1 (#1971)

🤖 Generated with [Claude Code](https://claude.com/claude-code)