### PR TITLE
docs(ds): baseline medido do drift — por regra & área (639 ds/*)

### DIFF
--- a/prototipo-ui/DS_ADOCAO_INDICE.md
+++ b/prototipo-ui/DS_ADOCAO_INDICE.md
@@ -37,6 +37,43 @@ O repo já tem `Pages/Admin/GovernanceV4` + `_components/DriftAlertBanner.tsx` +
 
 ---
 
+## Baseline medido — o drift inicial (2026-05-29, pós-PR #1979)
+
+> Preenche a promessa da seção acima com o número real. Medido por **[CL] Code** rodando `eslint.config.js` (merge `fe9a182d6`) sobre `resources/js/Pages/**`. Total: **639 violações `ds/*` em 197 arquivos** (em `config/eslint-baseline.json`; total geral do baseline = 1455). É o número-base do drift — cada PR-C abaixa, meta `ds/*` → 0.
+>
+> ⚠️ O ratchet guarda as 6 regras como um único `no-restricted-syntax`, então o split por seletor **não está no JSON** — veio de re-rodar o ESLint e agrupar pela mensagem `ds/…`.
+
+### Por regra
+
+| Regra `ds/*` | Violações | % | Destino |
+|---|---:|---:|---|
+| `no-adhoc-status-text` | 410 | 64.2% | `<FieldError>`/`<FieldSuccess>`/`<Alert>` (Tipo 1) · `<Badge variant>` (Tipo 2) |
+| `no-native-select` | 103 | 16.1% | `<Select>` (@/ui) |
+| `no-rounded-xl` | 66 | 10.3% | `rounded-lg` / `<Card>` / `<Dialog>` |
+| `no-native-checkbox` | 53 | 8.3% | `<Checkbox>` |
+| `no-native-radio` | 7 | 1.1% | `<Segmented>` / `<RadioGroup>` |
+| `no-arbitrary-color` | 0 | 0% | — (já limpo) |
+
+> Os 410 `no-adhoc-status-text` casam `text-(rose/red/emerald/green)-(500/600/700)` e misturam os **dois tipos** da nuance da Matriz: Tipo 1 (form `<FieldError>` — migra primeiro) e Tipo 2 (badge `STATUS_STYLE` — baseline absorve, migra por último). O seletor não separa; só o contexto.
+
+### Por área (`Pages/<X>`) — por contagem
+
+| Área | `ds/*` | | Área | `ds/*` |
+|---|---:|---|---|---:|
+| Financeiro | 107 | | Admin | 26 |
+| Cliente | 77 | | Whatsapp | 24 |
+| RecurringBilling | 58 | | Settings | 22 |
+| OficinaAuto | 44 | | Atendimento | 19 |
+| Sells | 42 | | ProjectMgmt | 17 |
+| Repair | 35 | | Ponto | 17 |
+| Purchase | 31 | | Fiscal | 14 |
+
+> _(top 14 = 533; demais áreas ≈ 106; pior arquivo único: `Pages/Financeiro/Unificado/Index.tsx` = 25.)_
+>
+> **Contagem crua ≠ ordem do P0.** Financeiro lidera por volume, mas o P0 da Matriz é **Cliente + Sells** (telas mais tocadas, origem do diagnóstico KB-9.75). Estado real medido: **Cliente/Create + Edit já zerados** (migrados no PR-A). Próximos alvos reais: **Sells Create (6) + Edit (12)** e **Cliente/Index (12)**.
+
+---
+
 ## "Componente de DS = pronto" — a nova definição (o lock real)
 
 Antes eu entregava CSS + showcase. **A partir de agora, promover um componente só está pronto com o tripé:**


### PR DESCRIPTION
Preenche `prototipo-ui/DS_ADOCAO_INDICE.md` (seção "onde a contagem aparece") com o **número-base real** do drift, medido após o merge do guard `ds/*` (PR #1979, `fe9a182d6`).

## O que entra
- **639 violações `ds/*` em 197 arquivos** (baseline total 1455).
- **Por regra (split por seletor — não estava no JSON, veio de re-rodar o ESLint):**
  - `no-adhoc-status-text` 410 (64%) · `no-native-select` 103 · `no-rounded-xl` 66 · `no-native-checkbox` 53 · `no-native-radio` 7 · `no-arbitrary-color` 0
- **Por área:** Financeiro 107 · Cliente 77 · RecurringBilling 58 · OficinaAuto 44 · Sells 42 · Repair 35 · Purchase 31…
- **Correção de rota:** contagem crua ≠ ordem do P0. P0 da Matriz é **Cliente + Sells**; `Cliente/Create+Edit` já estão **zerados** (PR-A). Próximo real: **Sells Create (6) + Edit (12) = PR-C2 (18)**.

## Por que
É o "drift base por regra" pro **Claude Design conferir** e o insumo da dimensão **"Adoção DS"** do `GovernanceV4` (defer PR-B2). Doc-only, sem código.

Refs: ADR 0209, PR #1979, REGRAS_DS_LINT.md, MATRIZ_MIGRACAO_DS.md