### PR TITLE
fix(staging): deploy.sh nao mascara erro + composer:2 + build Inertia via shim php

### DIFF
--- a/docker/oimpresso-staging/deploy.sh
+++ b/docker/oimpresso-staging/deploy.sh
@@ -7,13 +7,40 @@
 # NÃO roda migration nem importa banco (são etapas à parte, com gate LGPD):
 #   - F1 (casca):   php artisan migrate --seed   (banco vazio/seed)
 #   - F3 (dados):   importar dump ANONIMIZADO    (ver anonimizar-staging)
+#
+# 2026-05-29 — correções (o deploy reportava exit 0 MASCARANDO falha de build):
+#   (1) NÃO mascara erro: cada passo crítico aborta com tail do log. Antes,
+#       `cmd | tail` deixava composer/build:inertia falharem INVISÍVEIS porque o
+#       exit do pipe é o do `tail` (0) → staging servia bundle velho calado.
+#   (2) Composer via imagem `composer:2` (a imagem mcp NÃO tem composer).
+#   (3) Assets Inertia via shim `php`: o host do CT não tem php, e o
+#       Vite/Wayfinder roda `php artisan wayfinder:generate` em build-time.
+#       O shim faz `php` cair no container mcp (com os mounts do container vivo).
+#       O bundle servido é protegido: backup → restore se o build falhar.
+#   Ref: memory/requisitos/Infra/RUNBOOK-staging-ct100.md (Pegadinhas #1, #2).
 # ─────────────────────────────────────────────────────────────────────────────
-set -e
+set -eu
 
 BRANCH="${1:-main}"
 CODE=/opt/oimpresso-staging/code
-IMG=oimpresso/mcp:latest
 COMPOSE="$CODE/docker/oimpresso-staging/docker-compose.yml"
+LOG=/tmp/oimpresso-staging-deploy.log
+: > "$LOG"
+
+# step <descrição> <cmd...> — roda, loga, e ABORTA com tail do log se falhar.
+# (sem `cmd | tail`, que mascarava o exit code e deixava a falha passar.)
+step() {
+    _desc="$1"; shift
+    echo "    \$ $*"
+    if "$@" >>"$LOG" 2>&1; then
+        return 0
+    fi
+    _rc=$?
+    echo "!! FALHOU: $_desc (exit $_rc)"
+    echo "---- últimas 30 linhas de $LOG ----"
+    tail -30 "$LOG"
+    exit 1
+}
 
 echo "==> 1/5  Código (branch: $BRANCH)"
 if [ ! -d "$CODE/.git" ]; then
@@ -26,15 +53,50 @@ git -C "$CODE" checkout -B "$BRANCH" "origin/$BRANCH"
 git -C "$CODE" reset --hard "origin/$BRANCH"
 echo "    HEAD: $(git -C "$CODE" rev-parse --short HEAD)"
 
-echo "==> 2/5  Composer (via imagem $IMG)"
-docker run --rm -v "$CODE:/var/www/html" -w /var/www/html --entrypoint sh "$IMG" \
-    -c "composer install --no-interaction --optimize-autoloader 2>&1 | tail -5"
+echo "==> 2/5  Composer (imagem composer:2 — a imagem mcp NÃO tem composer)"
+step "composer install" docker run --rm -v "$CODE:/app" -w /app composer:2 \
+    install --no-interaction --optimize-autoloader --ignore-platform-reqs --no-scripts
 
-echo "==> 3/5  Assets (Node $(node -v) no host)"
+echo "==> 3/5  Assets (Node $(node -v) no host; php via shim no container mcp)"
 cd "$CODE"
-npm ci --no-audit --no-fund 2>&1 | tail -3
-npm run build:inertia 2>&1 | tail -3
-npm run build 2>&1 | tail -3
+step "npm ci" npm ci --no-audit --no-fund
+
+# O Vite/Wayfinder chama `php artisan` em build-time, mas o host do CT não tem
+# php. Shim temporário: faz `php` cair dentro do container mcp com os mounts do
+# container vivo (storage + bootstrap/cache, senão o boot quebra em "cache path").
+SHIM="$(mktemp -d)"
+cat > "$SHIM/php" <<'PHP_SHIM'
+#!/bin/sh
+exec docker run --rm \
+  -v /opt/oimpresso-staging/code:/var/www/html \
+  -v /opt/oimpresso-staging/storage:/var/www/html/storage \
+  -v /opt/oimpresso-staging/bootstrap-cache:/var/www/html/bootstrap/cache \
+  -w /var/www/html --entrypoint php oimpresso/mcp:latest "$@"
+PHP_SHIM
+chmod +x "$SHIM/php"
+
+# Protege o bundle servido: o Vite esvazia o outDir no início; se o build falhar
+# no meio, restaura o bundle anterior pra staging não ficar sem assets.
+BAK="$(mktemp -d)"
+[ -d public/build-inertia ] && cp -r public/build-inertia "$BAK/build-inertia"
+
+if PATH="$SHIM:$PATH" npm run build:inertia >>"$LOG" 2>&1 \
+   && PATH="$SHIM:$PATH" npm run build >>"$LOG" 2>&1; then
+    echo "    build OK"
+    rm -rf "$SHIM" "$BAK"
+else
+    _rc=$?
+    echo "!! FALHOU: build de assets (exit $_rc)"
+    echo "---- últimas 40 linhas de $LOG ----"
+    tail -40 "$LOG"
+    if [ -d "$BAK/build-inertia" ]; then
+        rm -rf public/build-inertia
+        mv "$BAK/build-inertia" public/build-inertia
+        echo "    bundle anterior restaurado (staging intacto)"
+    fi
+    rm -rf "$SHIM" "$BAK"
+    exit 1
+fi
 rm -rf node_modules/.vite 2>/dev/null || true   # economiza disco
 
 echo "==> 4/5  .env presente?"
@@ -47,5 +109,5 @@ fi
 echo "==> 5/5  Sobe container"
 docker compose -f "$COMPOSE" up -d
 echo ""
-echo "OK. Smoke:  curl -I https://staging.oimpresso.com/login"
+echo "OK. HEAD $(git -C "$CODE" rev-parse --short HEAD). Smoke:  curl -I https://staging.oimpresso.com/login"
 echo "Logs:       docker logs -f oimpresso-staging"


### PR DESCRIPTION
## Problema

O `deploy.sh` do staging reportava **exit 0 mascarando falha de build**: com `set -e` + `cmd | tail`, o exit do pipe e o do `tail` (sempre 0). Descoberto em 2026-05-29 ao fazer deploy do roxo (DS v4 / ADR 0235): o `build:inertia` falhava **invisivel** e o staging servia o bundle **pre-roxo** calado.

Duas causas-raiz no host do CT 100:
1. **`build:inertia` precisa de `php` em build-time** — o plugin Vite `@laravel/vite-plugin-wayfinder` roda `php artisan wayfinder:generate`, mas o host do CT nao tem php (so existe dentro do container mcp). Todo build:inertia falhava.
2. **`composer` nao existe** nem no host nem na imagem `oimpresso/mcp:latest`, entao o `vendor/` nunca atualizava.

## Fix (1 arquivo)

- **Nao mascara erro:** helper `step()` roda cada passo critico e **aborta com tail do log** se falhar (sem `cmd | tail`).
- **Composer via `composer:2`** (imagem que tem composer) + `--ignore-platform-reqs --no-scripts` (RUNBOOK Pegadinha #1).
- **`build:inertia` via shim `php`:** shim temporario que faz `php` cair no container mcp com os mounts do container vivo (`storage` + `bootstrap/cache`, senao o boot quebra em "cache path").
- **Bundle protegido:** backup -> restore se o build falhar (o Vite esvazia o outDir no inicio).

## Validacao ao vivo no CT 100 (2026-05-29)

- `composer:2 install --dry-run` -> "Nothing to install" (vendor casa com lock)
- `build:inertia` via shim -> reconstruiu o bundle roxo (`--accent: oklch(.55 .15 295)` servido), `login: 200 ssl:0`
- `sh -n` (dash, o shell real do host) -> sintaxe OK

> Os componentes foram exercitados ao vivo nesta sessao; o script orquestrado completo nao rodou fim-a-fim em prod-staging (e idempotente — roda no proximo deploy/re-seed). Da pra fazer a validacao e2e (reproduz o estado roxo atual) sob demanda.

Refs: ADR 0235 (DS v4 roxo universal), memory/requisitos/Infra/RUNBOOK-staging-ct100.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)