### PR TITLE
refactor(ds): migra controles Purchase -> DS (baixa baseline)

### DIFF
--- a/config/eslint-baseline.json
+++ b/config/eslint-baseline.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
-    "generated_at": "2026-05-29T23:55:21.807Z",
-    "total_violations": 1417,
+    "generated_at": "2026-05-30T00:42:36.910Z",
+    "total_violations": 1405,
     "eslint_version": "flat-config 9.x",
     "adr": "0209"
   },
@@ -416,11 +416,11 @@
     "resources/js/Pages/ProjectMgmt/MyWork/Index.tsx|no-restricted-syntax": 2,
     "resources/js/Pages/ProjectMgmt/Triage/Index.tsx|no-restricted-syntax": 2,
     "resources/js/Pages/Purchase/Create.tsx|no-undef": 1,
-    "resources/js/Pages/Purchase/Create.tsx|no-restricted-syntax": 11,
+    "resources/js/Pages/Purchase/Create.tsx|no-restricted-syntax": 7,
     "resources/js/Pages/Purchase/Edit.tsx|no-undef": 1,
-    "resources/js/Pages/Purchase/Edit.tsx|no-restricted-syntax": 8,
+    "resources/js/Pages/Purchase/Edit.tsx|no-restricted-syntax": 4,
     "resources/js/Pages/Purchase/Index.tsx|@typescript-eslint/no-unused-vars": 1,
-    "resources/js/Pages/Purchase/Index.tsx|no-restricted-syntax": 7,
+    "resources/js/Pages/Purchase/Index.tsx|no-restricted-syntax": 3,
     "resources/js/Pages/Purchase/Show.tsx|no-restricted-syntax": 5,
     "resources/js/Pages/RecurringBilling/Configuracoes/Index.tsx|no-restricted-syntax": 9,
     "resources/js/Pages/RecurringBilling/Faturas/Index.tsx|@typescript-eslint/no-unused-vars": 1,

--- a/resources/js/Pages/Purchase/Create.tsx
+++ b/resources/js/Pages/Purchase/Create.tsx
@@ -19,6 +19,7 @@ import { Card, CardContent, CardHeader } from '@/Components/ui/card';
 import { Input } from '@/Components/ui/input';
 import { Label } from '@/Components/ui/label';
 import { Textarea } from '@/Components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
 import { Plus, Trash2, Search, ShoppingCart, ArrowLeft, Save } from 'lucide-react';
 
 // ---------- Tipos ----------
@@ -84,6 +85,9 @@ export interface PurchaseCreatePageProps {
 
 const brl = (v: number) =>
   new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(v ?? 0);
+
+// Sentinela do Radix Select (não aceita value=""), mapeada pra '' no estado.
+const NENHUM = '__none__';
 
 // ---------- Página ----------
 
@@ -228,18 +232,19 @@ function PurchaseCreate({
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
             <div>
               <Label htmlFor="location_id" className="text-[12px] text-stone-600">Filial *</Label>
-              <select
-                id="location_id"
-                className="mt-1 w-full h-9 px-2 rounded-md border border-stone-200 text-[13px]"
+              <Select
                 value={form.data.location_id}
-                onChange={(e) => form.setData('location_id', e.target.value)}
-                required
+                onValueChange={(v) => form.setData('location_id', v)}
               >
-                <option value="">Selecione uma filial…</option>
-                {localOptions.map(([id, name]) => (
-                  <option key={id} value={id}>{name}</option>
-                ))}
-              </select>
+                <SelectTrigger id="location_id" className="mt-1 h-9 text-[13px]" aria-label="Filial">
+                  <SelectValue placeholder="Selecione uma filial…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {localOptions.map(([id, name]) => (
+                    <SelectItem key={id} value={id}>{name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               {form.errors.location_id && <p className="text-rose-700 text-[11px] mt-1">{form.errors.location_id}</p>}
             </div>
 
@@ -282,17 +287,19 @@ function PurchaseCreate({
 
             <div>
               <Label htmlFor="status" className="text-[12px] text-stone-600">Status *</Label>
-              <select
-                id="status"
-                className="mt-1 w-full h-9 px-2 rounded-md border border-stone-200 text-[13px]"
+              <Select
                 value={form.data.status}
-                onChange={(e) => form.setData('status', e.target.value as PurchaseStatus)}
-                required
+                onValueChange={(v) => form.setData('status', v as PurchaseStatus)}
               >
-                {Object.entries(order_statuses).map(([key, label]) => (
-                  <option key={key} value={key}>{label}</option>
-                ))}
-              </select>
+                <SelectTrigger id="status" className="mt-1 h-9 text-[13px]" aria-label="Status">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.entries(order_statuses).map(([key, label]) => (
+                    <SelectItem key={key} value={key}>{label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               {form.errors.status && <p className="text-rose-700 text-[11px] mt-1">{form.errors.status}</p>}
             </div>
           </div>
@@ -416,14 +423,18 @@ function PurchaseCreate({
             <div className="grid grid-cols-2 gap-3">
               <div>
                 <Label className="text-[12px] text-stone-600">Tipo desconto</Label>
-                <select
-                  className="mt-1 w-full h-9 px-2 rounded-md border border-stone-200 text-[13px]"
+                <Select
                   value={form.data.discount_type}
-                  onChange={(e) => form.setData('discount_type', e.target.value as DiscountType)}
+                  onValueChange={(v) => form.setData('discount_type', v as DiscountType)}
                 >
-                  <option value="fixed">Valor fixo ({currency.symbol})</option>
-                  <option value="percentage">Percentual (%)</option>
-                </select>
+                  <SelectTrigger className="mt-1 h-9 text-[13px]" aria-label="Tipo de desconto">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="fixed">Valor fixo ({currency.symbol})</SelectItem>
+                    <SelectItem value="percentage">Percentual (%)</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
               <div>
                 <Label className="text-[12px] text-stone-600">Valor desconto</Label>
@@ -439,16 +450,20 @@ function PurchaseCreate({
             <div className="grid grid-cols-2 gap-3">
               <div>
                 <Label className="text-[12px] text-stone-600">Imposto global</Label>
-                <select
-                  className="mt-1 w-full h-9 px-2 rounded-md border border-stone-200 text-[13px]"
-                  value={form.data.tax_id}
-                  onChange={(e) => form.setData('tax_id', e.target.value)}
+                <Select
+                  value={form.data.tax_id || NENHUM}
+                  onValueChange={(v) => form.setData('tax_id', v === NENHUM ? '' : v)}
                 >
-                  <option value="">Nenhum</option>
-                  {taxes.map((t) => (
-                    <option key={t.id} value={t.id}>{t.name} ({t.amount}%)</option>
-                  ))}
-                </select>
+                  <SelectTrigger className="mt-1 h-9 text-[13px]" aria-label="Imposto global">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NENHUM}>Nenhum</SelectItem>
+                    {taxes.map((t) => (
+                      <SelectItem key={t.id} value={String(t.id)}>{t.name} ({t.amount}%)</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
               <div>
                 <Label className="text-[12px] text-stone-600">Frete ({currency.symbol})</Label>

--- a/resources/js/Pages/Purchase/Edit.tsx
+++ b/resources/js/Pages/Purchase/Edit.tsx
@@ -20,6 +20,7 @@ import { Card, CardContent, CardHeader } from '@/Components/ui/card';
 import { Input } from '@/Components/ui/input';
 import { Label } from '@/Components/ui/label';
 import { Textarea } from '@/Components/ui/textarea';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
 import { Plus, Trash2, Search, ShoppingCart, ArrowLeft, Save } from 'lucide-react';
 
 // ---------- Tipos ----------
@@ -99,6 +100,9 @@ export interface PurchaseEditPageProps {
 
 const brl = (v: number) =>
   new Intl.NumberFormat('pt-BR', { style: 'currency', currency: 'BRL' }).format(v ?? 0);
+
+// Sentinela do Radix Select (não aceita value=""), mapeada pra '' no estado.
+const NENHUM = '__none__';
 
 // ---------- Página ----------
 
@@ -238,17 +242,19 @@ function PurchaseEdit({
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-3">
             <div>
               <Label className="text-[12px] text-stone-600">Filial *</Label>
-              <select
-                className="mt-1 w-full h-9 px-2 rounded-md border border-stone-200 text-[13px]"
+              <Select
                 value={form.data.location_id}
-                onChange={(e) => form.setData('location_id', e.target.value)}
-                required
+                onValueChange={(v) => form.setData('location_id', v)}
               >
-                <option value="">Selecione…</option>
-                {localOptions.map(([id, name]) => (
-                  <option key={id} value={id}>{name}</option>
-                ))}
-              </select>
+                <SelectTrigger className="mt-1 h-9 text-[13px]" aria-label="Filial">
+                  <SelectValue placeholder="Selecione…" />
+                </SelectTrigger>
+                <SelectContent>
+                  {localOptions.map(([id, name]) => (
+                    <SelectItem key={id} value={id}>{name}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
               {form.errors.location_id && <p className="text-rose-700 text-[11px] mt-1">{form.errors.location_id}</p>}
             </div>
 
@@ -285,16 +291,19 @@ function PurchaseEdit({
 
             <div>
               <Label className="text-[12px] text-stone-600">Status *</Label>
-              <select
-                className="mt-1 w-full h-9 px-2 rounded-md border border-stone-200 text-[13px]"
+              <Select
                 value={form.data.status}
-                onChange={(e) => form.setData('status', e.target.value as PurchaseStatus)}
-                required
+                onValueChange={(v) => form.setData('status', v as PurchaseStatus)}
               >
-                {Object.entries(order_statuses).map(([key, label]) => (
-                  <option key={key} value={key}>{label}</option>
-                ))}
-              </select>
+                <SelectTrigger className="mt-1 h-9 text-[13px]" aria-label="Status">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.entries(order_statuses).map(([key, label]) => (
+                    <SelectItem key={key} value={key}>{label}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
           </div>
         </CardContent>
@@ -401,14 +410,18 @@ function PurchaseEdit({
             <div className="grid grid-cols-2 gap-3">
               <div>
                 <Label className="text-[12px] text-stone-600">Tipo desconto</Label>
-                <select
-                  className="mt-1 w-full h-9 px-2 rounded-md border border-stone-200 text-[13px]"
+                <Select
                   value={form.data.discount_type}
-                  onChange={(e) => form.setData('discount_type', e.target.value as DiscountType)}
+                  onValueChange={(v) => form.setData('discount_type', v as DiscountType)}
                 >
-                  <option value="fixed">Valor fixo ({currency.symbol})</option>
-                  <option value="percentage">Percentual (%)</option>
-                </select>
+                  <SelectTrigger className="mt-1 h-9 text-[13px]" aria-label="Tipo de desconto">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="fixed">Valor fixo ({currency.symbol})</SelectItem>
+                    <SelectItem value="percentage">Percentual (%)</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
               <div>
                 <Label className="text-[12px] text-stone-600">Valor desconto</Label>
@@ -424,16 +437,20 @@ function PurchaseEdit({
             <div className="grid grid-cols-2 gap-3">
               <div>
                 <Label className="text-[12px] text-stone-600">Imposto global</Label>
-                <select
-                  className="mt-1 w-full h-9 px-2 rounded-md border border-stone-200 text-[13px]"
-                  value={form.data.tax_id}
-                  onChange={(e) => form.setData('tax_id', e.target.value)}
+                <Select
+                  value={form.data.tax_id || NENHUM}
+                  onValueChange={(v) => form.setData('tax_id', v === NENHUM ? '' : v)}
                 >
-                  <option value="">Nenhum</option>
-                  {taxes.map((t) => (
-                    <option key={t.id} value={t.id}>{t.name} ({t.amount}%)</option>
-                  ))}
-                </select>
+                  <SelectTrigger className="mt-1 h-9 text-[13px]" aria-label="Imposto global">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value={NENHUM}>Nenhum</SelectItem>
+                    {taxes.map((t) => (
+                      <SelectItem key={t.id} value={String(t.id)}>{t.name} ({t.amount}%)</SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </div>
               <div>
                 <Label className="text-[12px] text-stone-600">Frete ({currency.symbol})</Label>

--- a/resources/js/Pages/Purchase/Index.tsx
+++ b/resources/js/Pages/Purchase/Index.tsx
@@ -18,7 +18,11 @@ import { useState, useMemo, type ReactNode } from 'react';
 import { Button } from '@/Components/ui/button';
 import { Card, CardContent } from '@/Components/ui/card';
 import { Input } from '@/Components/ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/Components/ui/select';
 import { Plus, Eye, Edit, Trash2, Printer, RotateCcw, FileText } from 'lucide-react';
+
+// Sentinela do Radix Select (não aceita value=""), mapeada pra '' (= "todos") nos filtros.
+const NENHUM = '__none__';
 
 // ---------- Tipos ----------
 
@@ -174,32 +178,52 @@ function PurchaseIndex({ rows, filters, business_locations, suppliers, order_sta
       {/* Filtros sticky */}
       <Card className="mt-4 sticky top-14 z-10">
         <CardContent className="p-3 flex flex-wrap items-center gap-2">
-          <select className="h-8 px-2 rounded-md border border-stone-200 text-[12.5px]"
-                  value={filters.location_id} onChange={(e) => aplicar({ location_id: e.target.value })}>
-            <option value="">Todas as filiais</option>
-            {business_locations.map(l => <option key={l.id} value={l.id}>{l.label}</option>)}
-          </select>
+          <Select value={filters.location_id || NENHUM}
+                  onValueChange={(v) => aplicar({ location_id: v === NENHUM ? '' : v })}>
+            <SelectTrigger className="h-8 w-[160px] text-[12.5px]" aria-label="Filial">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NENHUM}>Todas as filiais</SelectItem>
+              {business_locations.map(l => <SelectItem key={l.id} value={String(l.id)}>{l.label}</SelectItem>)}
+            </SelectContent>
+          </Select>
 
-          <select className="h-8 px-2 rounded-md border border-stone-200 text-[12.5px]"
-                  value={filters.supplier_id} onChange={(e) => aplicar({ supplier_id: e.target.value })}>
-            <option value="">Todos os fornecedores</option>
-            {suppliers.map(s => <option key={s.id} value={s.id}>{s.label}</option>)}
-          </select>
+          <Select value={filters.supplier_id || NENHUM}
+                  onValueChange={(v) => aplicar({ supplier_id: v === NENHUM ? '' : v })}>
+            <SelectTrigger className="h-8 w-[190px] text-[12.5px]" aria-label="Fornecedor">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NENHUM}>Todos os fornecedores</SelectItem>
+              {suppliers.map(s => <SelectItem key={s.id} value={String(s.id)}>{s.label}</SelectItem>)}
+            </SelectContent>
+          </Select>
 
-          <select className="h-8 px-2 rounded-md border border-stone-200 text-[12.5px]"
-                  value={filters.status} onChange={(e) => aplicar({ status: e.target.value })}>
-            <option value="">Todos os status</option>
-            {order_statuses.map(s => <option key={s.id} value={s.id}>{s.label}</option>)}
-          </select>
+          <Select value={filters.status || NENHUM}
+                  onValueChange={(v) => aplicar({ status: v === NENHUM ? '' : v })}>
+            <SelectTrigger className="h-8 w-[150px] text-[12.5px]" aria-label="Status">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NENHUM}>Todos os status</SelectItem>
+              {order_statuses.map(s => <SelectItem key={s.id} value={String(s.id)}>{s.label}</SelectItem>)}
+            </SelectContent>
+          </Select>
 
-          <select className="h-8 px-2 rounded-md border border-stone-200 text-[12.5px]"
-                  value={filters.payment_status} onChange={(e) => aplicar({ payment_status: e.target.value })}>
-            <option value="">Pagamento (todos)</option>
-            <option value="paid">Pago</option>
-            <option value="due">Em aberto</option>
-            <option value="partial">Parcial</option>
-            <option value="overdue">Vencido</option>
-          </select>
+          <Select value={filters.payment_status || NENHUM}
+                  onValueChange={(v) => aplicar({ payment_status: v === NENHUM ? '' : v })}>
+            <SelectTrigger className="h-8 w-[160px] text-[12.5px]" aria-label="Pagamento">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={NENHUM}>Pagamento (todos)</SelectItem>
+              <SelectItem value="paid">Pago</SelectItem>
+              <SelectItem value="due">Em aberto</SelectItem>
+              <SelectItem value="partial">Parcial</SelectItem>
+              <SelectItem value="overdue">Vencido</SelectItem>
+            </SelectContent>
+          </Select>
 
           <Input
             type="date"


### PR DESCRIPTION
## O que

Pilot da **Onda PR-C** (controles → Design System) no módulo **Purchase**, seguindo `PARALELO-como-rodar.md` (PR-C7). Migra os 12 `<select>` nativos pras componentes DS (`@/Components/ui/select`), zerando `ds/no-native-select` em `Pages/Purchase`.

## Escopo (só isto)

- **Index.tsx** — 4 selects de filtro (filial / fornecedor / status / pagamento) → `<Select>` com sentinela `__none__` (= "todos"); `router.get` (filtros) preservado.
- **Create.tsx** — 4 selects (filial, status, tipo desconto, imposto global) → `<Select>`; `id` mantido p/ `<Label htmlFor>`; submit Inertia (`form.setData` / `form.post`) idêntico.
- **Edit.tsx** — 4 selects idem (método PUT preservado).
- **config/eslint-baseline.json** — baixa **1417 → 1405** (−12).

Padrão idêntico ao C2 Cliente (#1984): `value || __none__` + `onValueChange` mapeando `__none__ → ''`, `aria-label` no trigger, `value={String(id)}`.

## Fora de escopo (intencional)

- **Status-text** (`ds/no-adhoc-status-text` ×19) fica pra **Onda G** (lote-badge) — conforme o prompt PR-C7 ("NÃO mexer em status-text").
- Purchase **não tem** checkbox / radio / rounded-xl.
- `Show.tsx` **intocado** (só tinha status-text).
- Import `RotateCcw` não-usado (Index) e `TS2322` (Show): **pré-existentes**, já no baseline — não mexidos (1 PR = 1 intent).

## Verificação

- `ds/no-native-select` em `Pages/Purchase`: **12 → 0** ✓
- `npm run build:inertia`: ✓ (exit 0)
- `npm run lint:baseline:check`: ✓ ("Sem regressões", Δ 0)
- Sem mudança de comportamento — troca de controle/visual; validação server-side + exibição de erros preservadas.

## ⚠️ Merge

- **Não mergear com `--admin`** — Wagner dá Approve (+ confere screenshot [W2] se o visual mudou).
- Se outro PR-C (ex. C3 RecurringBilling) mergear antes: `git fetch origin main && git rebase origin/main` → `npm run lint:baseline:write` → amend no `config/eslint-baseline.json` antes do merge (passo embutido no prompt PR-C7).

Refs: `MATRIZ_MIGRACAO_DS.md` · `REGISTRY_DS_COMPONENTES.md` · `PARALELO-como-rodar.md`
