### PR TITLE
docs(design): tela-ouro Sells/Create + 10 regras binárias

### DIFF
--- a/.claude/skills/design-memoria-reprocess/SKILL.md
+++ b/.claude/skills/design-memoria-reprocess/SKILL.md
@@ -1,0 +1,58 @@
+---
+name: design-memoria-reprocess
+description: >
+  ATIVAR quando (a) o Claude Design enviar handoff com bloco `## new_design_memories`;
+  (b) um doc de design for criado/editado/aposentado (`prototipo-ui/*.md`,
+  `memory/requisitos/_DesignSystem/*.md`, `*.charter.md`); (c) um ADR UI novo com
+  `supersedes` for mergeado; (d) novo golden de arquétipo / bump de token (DS v5) /
+  mudança de método; OU (e) user pedir "reprocessar índice de design", "atualizar
+  memórias de design", "destravar fluxo de design", "/design-memoria-reprocess".
+  Mantém o INDEX-DESIGN-MEMORIAS.md vivo SEM quebrar a estrutura — append-only +
+  ratchet + freshness + idempotente. Tier B auto-trigger. Refs ADR proposto
+  governanca-evolucao-doc-design, ADR 0230/0231/0233, INDEX-DESIGN-MEMORIAS.md.
+---
+
+# design-memoria-reprocess — reprocessar a doc de design sem quebrar a estrutura
+
+> **Workflow canônico de evolução.** Mantém [`INDEX-DESIGN-MEMORIAS.md`](../../../memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md) como fonte única, vivo e coerente. Decisão-mãe: ADR proposto `governanca-evolucao-doc-design`.
+
+## Princípio (o que NÃO fazer)
+- ❌ Reprocessar o fluxo inteiro a cada mudança (churn, custo).
+- ❌ Reescrever o índice do zero (quebra rastreabilidade).
+- ❌ Deletar entrada aposentada (append-only — vira "histórico/stale").
+- ✅ Incremental + idempotente: rodar 2× = mesmo resultado.
+
+## QUANDO reprocessar — 3 gatilhos em camadas
+
+| Gatilho | Dispara quando | O que rodar |
+|---|---|---|
+| **G1 INCREMENTAL** | commit toca 1 doc de design | atualiza só a **linha daquele doc** no índice (§2/§3) + freshness dele |
+| **G2 RECONCILIAR** | handoff Claude Design com `new_design_memories` **OU** ADR UI novo com `supersedes` | re-roda **§4 conflitos + §6 stale** (só o afetado), aplica regra de ouro |
+| **G3 REPROCESSO TOTAL** | novo arquétipo/golden · bump token (DS v5) · mudança de método | **sweep completo** — N agentes paralelos por área (ADR 0231) → reconsolida o índice |
+
+## COMO reprocessar — passos idempotentes (G1/G2)
+
+1. **LER estado:** abrir o índice + `git diff` desde o último reprocesso (ponteiro no rodapé do índice).
+2. **CLASSIFICAR** o que mudou: doc novo / editado / aposentado / ADR superseded / `new_design_memories` do handoff.
+3. **APLICAR regra de ouro** (§0 do índice) mecanicamente: ADR recente c/ supersedes vence · DS v4 > v3 · código real > doc · UI-0013 hierarquia · data recente.
+4. **ATUALIZAR só as linhas afetadas:** §2 (positivo) / §3 (negativo) / §4 (conflito — append linha nova, move o vencido p/ "aposentado") / §6 (stale). **Nunca reescreve o todo.**
+5. **VALIDAR:** o índice não cita ADR `superseded` como canon vigente; toda linha tem fonte real (RTM, ADR 0230 Inv. B); ratchet OK (nada rebaixado/deletado).
+6. **REGISTRAR:** bump do ponteiro `last_reprocess: <data>` no rodapé + 1 linha no changelog do índice.
+7. **(só G3)** spawnar os agentes paralelos, depois consolidar no parent.
+
+## Contrato do handoff Claude Design (input de G2)
+Todo handoff do Claude Design DEVE carregar:
+```
+## new_design_memories
+- tipo: golden | conflito | anti-padrao | token | doc-novo
+- ref: <path ou ADR>
+- resumo: <1 linha>
+```
+> **Enforcement:** o hook `design-handoff-reprocess` detecta esse bloco e dispara esta skill (G2). O handoff **declara**; o hook **executa** — não é lembrete educado (lembrete falha; hook garante — ADR 0224 + R12).
+
+## Invariantes (ADR 0230)
+- **A — idempotência + anti-regressão:** rodar 2× = mesmo resultado; mudança estrutural cria teste com a justificativa medida do porquê não voltar.
+- **B — rastreabilidade (RTM):** toda linha cita a fonte que a originou.
+
+## Saída
+Índice atualizado (incremental) + ponteiro `last_reprocess` + linha de changelog. Em G3, também: ranking screen-grade + baseline ratchet. NUNCA commit/push automático sem aprovação humana (R10).

--- a/.claude/skills/screen-grade/SKILL.md
+++ b/.claude/skills/screen-grade/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: screen-grade
+mission: "Substituir avaliação subjetiva de tela por (1) um Pré-Flight resolver que impede a IA de inventar/repetir erro e (2) nota objetiva 0-100 ponderada por persona e Peso Real — o `module-grade` aplicado por tela."
+description: ATIVAR quando user pedir "nota da tela X", "gradear tela Y", "/screen-grade Sells/Create", "qual a maturidade da tela Z", "pré-flight da tela W", "screen-grade", "avaliar a tela de venda", OU ANTES de fazer/migrar/gradear qualquer `resources/js/Pages/<Mod>/<Tela>.tsx` (roda o Pré-Flight resolver pra não inventar token/Model/componente nem repetir anti-padrão F3). Carrega o método SCREEN-GRADE (16 dimensões, níveis Beginner→Champion, score-as-code YAML) + o resolvedor PRE-FLIGHT-TELA (4 blocos: identidade/não-inventar/não-repetir/validar) ancorados na tela-ouro `GOLDEN-REFERENCE.md`. Produz a nota + scorecard YAML + roadmap de gaps. NÃO edita a tela nem cria tasks sem aprovação humana — só resolve pré-requisitos e pontua.
+type: process-skill
+status: active
+version: 1.0.0
+trust_level: L1
+owner: wagner
+created_at: 2026-05-30
+updated_at: 2026-05-30
+charter_adr: 0230
+parent_mission: "Toda skill substitui trabalho humano repetitivo com ROI provado, rumo ao ERP autônomo de R$ 10M em 24 meses."
+triggers_on:
+  - "/screen-grade"
+  - "/screen-grade {Mod}/{Tela}"
+  - "nota da tela {X}"
+  - "maturidade da tela {X}"
+  - "gradear tela {X}"
+  - "avaliar a tela {X}"
+  - "pré-flight da tela {X}"
+  - "pré-flight de tela"
+  - "screen-grade"
+  - "método screen-grade"
+related_adrs: [0230, 0231, 0232, 0235, 0155, 0233, 0093, 0101, 0104, 0114]
+related_skills: [avaliar-modulo, constituicao-ui-aware, charter-write, design-arte, cowork-prototype-replication, comparativo-do-modulo]
+tier: B
+---
+
+# screen-grade — Pré-Flight de Tela + nota de maturidade /100
+
+> **Linhagem:** Método Governance Scorecard ([ADR 0230](../../../memory/decisions/0230-metodo-governance-scorecard.md)) + especialista-por-área ([ADR 0231](../../../memory/decisions/0231-processo-trabalho-canonico-especialista-por-area.md)) + Peso Real ([ADR 0232](../../../memory/decisions/0232-modelo-peso-real-classificacao-por-meta.md)) + `framework-15-dimensoes.md` + DS v4 roxo ([ADR 0235](../../../memory/decisions/0235-ds-v4-accent-roxo-universal.md)). É o [`module-grade`](../avaliar-modulo/SKILL.md) aplicado **por tela**.
+>
+> **Docs canônicos que esta skill operacionaliza** (leia-os, não reinvente):
+> - [`prototipo-ui/GOLDEN-REFERENCE.md`](../../../prototipo-ui/GOLDEN-REFERENCE.md) — tela-ouro `Sells/Create` + 10 regras binárias
+> - [`prototipo-ui/PRE-FLIGHT-TELA.md`](../../../prototipo-ui/PRE-FLIGHT-TELA.md) — o resolvedor (4 blocos)
+> - [`memory/requisitos/_DesignSystem/SCREEN-GRADE-METODO.md`](../../../memory/requisitos/_DesignSystem/SCREEN-GRADE-METODO.md) — método 16-dim + níveis + fórmula
+
+## Quando ativar
+
+1. **Antes de fazer/migrar/gradear** qualquer `resources/js/Pages/<Mod>/<Tela>.tsx` — roda o **Pré-Flight** (Parte 1) pra não inventar nem repetir erro. Sem pré-flight resolvido → não trabalha.
+2. **Pedido de nota** — "nota da tela X", "/screen-grade Sells/Create", "maturidade da tela de venda".
+
+> **Princípio (mata invenção):** o agente NUNCA monta o próprio contexto de cabeça. Dado o caminho da tela, **roda o resolvedor** → lê o pacote → trabalha. Nada fora do pacote pode ser inventado (ativação de memória no momento da decisão, [ADR 0233](../../../memory/decisions/0233-ativacao-memoria-momento-decisao.md)).
+
+## Parte 1 — Pré-Flight resolver (read-only probing, antes de tocar a tela)
+
+Dado o caminho da tela, materialize o pacote exato (4 blocos do `PRE-FLIGHT-TELA.md`):
+
+- **A · IDENTIDADE** → arquétipo (form/lista/dashboard/kanban/detalhe/relatório/drawer) via golden + `padroes-tela/PT-0X`; persona dona via `_DesignSystem/personas-por-modulo.yml`; Peso Real via ADR 0232.
+- **B · NÃO INVENTAR** → charter `<Tela>.charter.md` (se faltar, **PARA** e roda `charter-write`); componentes só de `REGISTRY_DS_COMPONENTES.md` → `@/Components/ui` (nunca hand-roll); tokens **DS v4 roxo `primary`** (zero `blue-*`/hex cru); Models/Controller/rotas reais via Glob+Read (não inventa `ChartOfAccount`); estrutura copiada do golden do arquétipo.
+- **C · NÃO REPETIR ERRO** → injeta no contexto `LICOES_F3_FINANCEIRO_REJEITADO.md` (21 anti-padrões) + anti-patterns do próprio charter + `PRE-MERGE-UI.md` (AP1-AP8) + `memory/proibicoes.md §UI`.
+- **D · VALIDAR** → 10 regras binárias + 16-dim + testes anti-regressão + smoke **biz=1** ([ADR 0101](../../../memory/decisions/0101-sistema-charter-capterra-governanca-escopo.md)) + `ds:report` zero `ds/*`.
+
+Saída do Pré-Flight: bullet "pacote da tela `<Mod>/<Tela>`" com arquétipo + persona + charter status + golden + tokens + lista de erros a evitar. **Determinístico:** `Sells/Create` → form + Larissa + charter live + golden form + v4 + anti-F3 + 4 gates.
+
+## Parte 2 — Nota de maturidade /100
+
+```
+NOTA = Σ(dim_i × peso_persona_i) / Σ(peso_max) × 100 × modulador_peso_real
+```
+
+16 dimensões (15 do `framework-15-dimensoes.md` + **16. Pré-Flight conformance**: tem charter live? só `@/ui`? tokens v4? zero anti-padrão repetido?). Para cada dimensão fraca: comparar com **≥3 best-of-class** (Linear/Shopify/Stripe/Notion + Bling/Tiny BR) **com o mecanismo** (não basta citar). Níveis: 🥉 Beginner 0-49 · Developing 50-69 · 🥈 Advanced 70-84 · Leader 85-94 · 🏆 Champion 95-100.
+
+**Automação futura (Passo 2 do método — ainda não existe):** `php artisan screen:grade <Mod>/<Tela> --detail` (espelho de `module:grade`, persiste o YAML). Enquanto o command não existe, esta skill roda o método **manualmente** e materializa o scorecard à mão.
+
+## Saída score-as-code (sempre gerar)
+
+```yaml
+# memory/governance/scorecards/screens/<modulo>-<tela>.yaml
+screen: Sells/Create
+path: resources/js/Pages/Sells/Create.tsx
+archetype: form
+golden: Sells/Create        # âncora do arquétipo, ou o golden do tipo
+persona: larissa
+peso_real: 1.0
+nivel: Champion
+nota: 95
+dimensoes: { density: 95, discoverability: 90, ... , preflight: 100 }
+gaps: []                     # impacto×esforço; cada fix cria teste anti-regressão (Invariante A)
+fonte_rtm: []                # cada achado cita a memória de origem (Invariante B)
+```
+
+## Como formatar a resposta
+
+1. **Nota grande + nível** no topo (ex: "**Sells/Create: 95/100 — 🏆 Champion**").
+2. Tabela 16 dimensões com score + peso persona.
+3. Top gaps por impacto×esforço → ondas (com mecanismo do best-of-class em cada um).
+4. Scorecard YAML.
+5. Se for migrar/refazer a tela: **gate visual + Wagner aprova screenshot** antes de Edit (R2/R7) — esta skill **não edita Page nem cria task** sozinha (publication-policy).
+
+## Guardrails
+
+- ⛔ Não inventar token/Model/componente/padrão — só o que o Pré-Flight materializou.
+- ⛔ Não pular o Pré-Flight pra "ir direto gradear" — a dimensão 16 mede exatamente isso.
+- ⛔ Não tocar a tela-ouro (`Sells/Create`) nem qualquer Page sem charter + gate visual (zona [`LICOES_F3_FINANCEIRO_REJEITADO.md`](../../../prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md)).
+- ⛔ Smoke sempre **biz=1** (Wagner), nunca biz=4 (ROTA LIVRE / Larissa) — ADR 0101.

--- a/memory/decisions/proposals/governanca-evolucao-doc-design.md
+++ b/memory/decisions/proposals/governanca-evolucao-doc-design.md
@@ -1,0 +1,74 @@
+---
+slug: governanca-evolucao-doc-design
+number: null  # atribuir no aceite (próximo livre — cuidado colisão paralela tipo ADR 0180)
+title: "Governança de evolução da documentação de design — append-only + índice fonte-única + ratchet + freshness gate + reprocesso por gatilho"
+type: adr
+status: proposto
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+proposed_at: "2026-05-30"
+module: governance
+quarter: 2026-Q2
+tags: [governance, design-system, documentacao, append-only, ratchet, freshness, reprocesso, event-driven, idempotente, claude-design]
+related:
+  - 0094-constituicao-v2-7-camadas-8-principios
+  - 0220-charters-freshness-checker-adapter
+  - 0230-metodo-governance-scorecard
+  - 0233-ativacao-memoria-momento-decisao
+  - 0235-ds-v4-accent-roxo-universal
+authors: [W, C]
+---
+
+# ADR (proposto) — Governança de evolução da documentação de design
+
+## Contexto
+
+A sessão 2026-05-30 consolidou 88 docs de design num índice mestre ([INDEX-DESIGN-MEMORIAS.md](../../requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md)) + golden + pré-flight + método. Wagner: *"como vai evoluir no tempo a documentação sem quebrar a estrutura?"*. Risco real: o `CLAUDE_COWORK_PRIMER` envelheceu silenciosamente de 2026-05-09 a 30 (3 semanas → DS v3→v4, golden, pré-flight não chegaram a ele). Sem mecanismo, o índice repete esse apodrecimento.
+
+## Decisão
+
+Documentação de design evolui pelas **mesmas máquinas que o código** — append-only, ratchet, gate de CI, event-driven — separando **esqueleto** (raro, ADR-gated) de **recheio** (frequente, livre).
+
+### Princípio mestre — esqueleto vs recheio
+- **Esqueleto** (contrato, muda só via ADR): hierarquia 4 camadas (UI-0013), os 4 blocos do pré-flight, as categorias do índice, a regra de ouro.
+- **Recheio** (dado, muda livre): qual golden, valor de token, telas em drift, notas screen-grade.
+> Quebra de estrutura só acontece se esqueleto mudar sem ADR. Recheio não tem como quebrar moldura.
+
+### As 5 máquinas
+1. **Append-only + supersedes** — nunca editar canon aceito; o velho vira `historical` (coluna "aposentado" do índice, nunca delete). *(já lei — ADR 0094 + governance-gate.yml)*
+2. **Índice = fonte única** — todo doc de design criado/aposentado obriga 1 linha no INDEX-DESIGN-MEMORIAS. Atualizar o índice faz parte do "pronto". *(wiring: skill `design-memoria-reprocess`)*
+3. **Ratchet** — golden novo só entra se bate o atual (promotion); nota de tela só sobe; regra de ouro resolve conflito mecanicamente. *(padrão existe — module-grades/eslint baseline)*
+4. **Freshness gate** — checker varre docs citando ADR `superseded` ou token velho → marca §6 stale automaticamente; CI falha se doc cita canon aposentado como vigente. *(wiring: estender ADR 0220)*
+5. **Indireção (pré-flight)** — consumidor lê o resolvedor, não o doc cru; doc muda → só o ponteiro muda. *(já criado — ADR 0233 JIT)*
+
+### Modelo de reprocesso — gatilhos em camadas (event-driven, idempotente)
+| Gatilho | Quando | O que roda | Custo |
+|---|---|---|---|
+| **G1 INCREMENTAL** | commit toca `prototipo-ui/*.md` ou `_DesignSystem/*.md` | atualiza a linha do doc no índice + freshness dele | trivial |
+| **G2 RECONCILIAR** | **Claude Design envia handoff com `new_design_memories`** OU ADR UI novo com `supersedes` mergeado | re-roda §4 conflitos + §6 stale (só o afetado) | médio |
+| **G3 REPROCESSO TOTAL** | mudança estrutural (novo arquétipo/golden, bump token v5, mudança de método) | sweep completo (N agentes paralelos, ADR 0231) | alto, raro |
+
+### Contrato do handoff Claude Design (o input de G2)
+Todo handoff do Claude Design carrega bloco estruturado:
+```
+## new_design_memories
+- tipo: golden | conflito | anti-padrao | token | doc-novo
+- ref: <path ou ADR>
+- resumo: <1 linha>
+```
+**Enforcement:** um **hook** detecta o bloco e dispara a skill `design-memoria-reprocess` (G2) — NÃO o handoff "pedindo educadamente" (lembrete é esquecível; hook é garantido — ADR 0224, R12).
+
+### Invariantes (herdados ADR 0230)
+- **A — Idempotência + anti-regressão:** rodar 2× = mesmo resultado; o reprocesso nunca rebaixa nem deleta (append-only). Toda mudança estrutural cria teste com a justificativa medida do porquê não voltar.
+- **B — Rastreabilidade (RTM):** toda linha do índice cita a fonte (doc/ADR/handoff) que a originou.
+
+## Consequências
+- ✅ índice nunca apodrece (atualizar é parte do "pronto" + freshness automático)
+- ✅ conflito não reaparece (regra de ouro mecânica + ratchet)
+- ✅ Claude Design sempre lê o estado atual (indireção pré-flight)
+- ⚠️ exige ligar 2 wirings: skill `design-memoria-reprocess` (G1/G2) + freshness-checker de design (estender ADR 0220) + hook do handoff
+- ⚠️ número do ADR a atribuir no aceite (evitar colisão paralela — lição ADR 0180)
+
+## Estado-da-arte (validação)
+Event-driven + incremental + idempotente + append-only é o padrão de: reindex incremental de RAG, compilação incremental, git hooks por-diff, e o próprio webhook git→MCP do projeto. Reprocessar tudo-sempre seria anti-padrão (churn). A intuição "dispara quando chega memória nova" está correta; o refino é tier + hook + idempotência.

--- a/memory/governance/screen-grades-pilot.md
+++ b/memory/governance/screen-grades-pilot.md
@@ -1,0 +1,60 @@
+# Screen-Grade — Ledger do Piloto (evoluções gravadas)
+
+> **Método:** [SCREEN-GRADE-METODO.md](../requisitos/_DesignSystem/SCREEN-GRADE-METODO.md) §7. 6 telas-piloto × 3 simulações (S0 atual → S1 próxima onda → S2 Champion), 6 agentes especialistas em paralelo (ADR 0231), code-first/READ-ONLY.
+> **Data:** 2026-05-30 · sessão `2026-05-30-screen-grade-metodo-estado-arte.md` · PR #1991.
+
+---
+
+## Evoluções (S0 → S1 → S2)
+
+| Tela | Arquétipo | Persona | S0 | nível S0 | S1 | S2 | nível S2 | ΔS0→S1 | ΔS1→S2 | T1 confiança |
+|---|---|---|---:|---|---:|---:|---|---:|---:|---|
+| **Sells/Create** | form | Larissa | **89** | Leader | 93 | 97 | Champion | +4 | +4 | alta |
+| **Cliente/Create** | form | Larissa | **89** | Leader | 93 | 97 | Leader→Champion | +4 | +4 | alta |
+| **Cliente/Index** | lista | Larissa+Eliana | **82** | Advanced | 89 | 95 | Champion | +7 | +6 | alta |
+| **Sells/Edit** | form | Larissa | **71** | Advanced | 84 | 95 | Champion | +13 | +11 | média |
+| **Financeiro/Unificado** | dashboard | Eliana | **71** | Advanced | 80 | 90 | Leader | +9 | +10 | média |
+| **Repair/ProducaoOficina** | kanban | Técnico | **68** | Developing | 80 | 92 | Leader | +12 | +12 | média |
+
+> Média S0 piloto: **78,3** · S1: **86,5** · S2: **94,3**.
+
+---
+
+## Os 3 testes de validade do modelo
+
+### T1 · Confiabilidade (test-retest, σ ≤ 3) — ⚠️ PARCIAL
+- **Alta** onde a dimensão é **binária/grep-able**: violações `ds/*`, header sticky, pills, footer, tokens v4, uso de `@/Components/ui` — reproduzem ±0-1pt.
+- **Média** nas dimensões **perceptuais** (mobile_fit, a11y, aesthetic, cognitive_load) — gradadas code-only (READ-ONLY, sem screenshot/Lighthouse/cronômetro de tarefa). Os 3 agentes "média" citaram o MESMO motivo: σ pode passar de 3pt nessas dims sem smoke real.
+- **Veredito:** o modelo é confiável onde é objetivo; as dims perceptuais **exigem o upgrade #5 (visual-regression + Chrome MCP smoke)** pra fechar σ≤3. Isso confirma o roadmap, não o contradiz.
+
+### T2 · Validade discriminante — ✅ PASS
+- `Sells/Create` (89, golden) **≫** `Sells/Edit` (71) — **mesmo arquétipo, mesma persona**, gap de 18 explicado por 7 elementos nativos + `rounded-xl` que o Edit replicou e o Create não tem. Direção correta.
+- As notas mais baixas (Repair 68 Developing, Financeiro 71) são exatamente as de **menor adoção de DS / mais drift** — o modelo aponta a fraqueza certa.
+
+### T3 · Monotonicidade da evolução — ✅ PASS
+- **Todas** as 6 telas: S0 < S1 < S2 (crescente, sem exceção).
+- **Calibração correta:** telas já-boas (Sells/Create, Cliente/Create) têm Δ pequeno (+4/+4, pouco espaço) e teto 97; telas com drift (Sells/Edit, Repair, Financeiro) têm Δ grande (+11 a +12, muito a ganhar). O modelo mede "espaço de evolução" corretamente.
+- **Teto por arquétipo:** forms capam 95-97 (calibrado contra golden Sells/Create); **dashboard capa em 90 — sinalizado pelo agente porque NÃO existe golden-dashboard pra calibrar** (gap conhecido do método).
+
+---
+
+## Meta-achado (o "não inventar / não repetir" funcionou)
+
+Dois agentes **refutaram a documentação anterior** lendo o código real (code-first):
+- **Cliente/Index:** a `MATRIZ_MIGRACAO_DS` listava "modais hand-rolled fixed inset-0 ~2301/2445" → na verdade são `CommandPalette`/`CheatSheet` (⌘K/?, `fixed inset-0` é o padrão correto, não drift); "select nativo ~2150" → é `<Select>` shadcn (falso-positivo); `rounded-xl` → hoje já é `rounded-lg`. Os drifts **reais** são `STATUS_STYLE` com bg-fill + header/filtros hand-rolled.
+- **Financeiro/Unificado:** separou "A+ 9,75 visual" (estética) de "adoção real de DS" (45/100 preflight) — exatamente a confusão E3 do diagnóstico inicial. Confirmou ~25 violações `ds/no-adhoc-status-text` (pior arquivo do projeto) + bundle CSS paralelo de 8.663 LOC.
+
+**Conclusão:** o método code-first pega erro de doc e separa estética de adoção — as duas dores originais do Wagner.
+
+---
+
+## Veredito do piloto
+
+✅ **Modelo validado pra escalar.** T2 e T3 passam limpo; T1 passa nas dims objetivas e mapeia exatamente onde precisa de smoke real (upgrade #5). O método discrimina, é monotônico, calibra teto por arquétipo, e o pré-flight pegou erro de documentação.
+
+**Antes de rodar nas 272:**
+1. Eleger **golden-dashboard** (calibra teto — hoje estimado vs Stripe/Linear externo).
+2. Ligar **Chrome MCP smoke** nas 4 dims perceptuais (fecha T1 σ≤3).
+3. `ScreenGradeCommand` persiste cada linha como `scorecards/screens/<tela>.yaml` + baseline ratchet.
+
+**Top fixes baratos já revelados (Δ alto, esforço baixo):** Sells/Edit 7 nativos→`@/ui` (+13); Repair colunas flex + drag-handle (+12); Financeiro ~25 `ds/no-adhoc-status-text`→`<Badge>` (+9).

--- a/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
+++ b/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
@@ -148,3 +148,15 @@ Sem: CTA WhatsApp cliente-facing · modal full-screen (usar drawer/Sheet) · ing
 ---
 
 > _Atualizar este índice sempre que um doc de design for criado/aposentado. É a fonte da verdade do que o Claude Design consome._
+
+---
+
+## 7 · Estado do reprocesso (mantido pela skill `design-memoria-reprocess`)
+
+- **last_reprocess:** `2026-05-30` (consolidação inicial — 4 agentes paralelos, ADR 0231)
+- **Como evolui sem quebrar:** ADR proposto [`governanca-evolucao-doc-design`](../../decisions/proposals/governanca-evolucao-doc-design.md) — append-only + ratchet + freshness + 3 gatilhos (G1 incremental / G2 reconciliar / G3 total). Workflow executável: skill [`design-memoria-reprocess`](../../../.claude/skills/design-memoria-reprocess/SKILL.md).
+
+### Changelog
+| Data | Gatilho | Mudança |
+|---|---|---|
+| 2026-05-30 | G3 (inicial) | Índice criado: 88 docs revisados, regra de ouro, conflitos reconciliados, positivo+negativo. |

--- a/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
+++ b/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
@@ -1,0 +1,150 @@
+# ÍNDICE-MESTRE — Memórias de Design que o Claude Design pode usar
+
+> **Pra que serve:** ponto único de partida do Claude Design. Lista TODAS as memórias de design do projeto — **positivas** (o que copiar/seguir) e **negativas** (o que NÃO repetir) — já reconciliadas, com a **regra de ouro** que resolve conflito. Substitui a tarefa de "montar contexto de cabeça" (origem da invenção e do erro repetido).
+> **Gerado:** 2026-05-30 por 4 agentes especialistas em paralelo (ADR 0231) revisando 27 docs `prototipo-ui/` + 26 `_DesignSystem/` + 17 ADRs UI + 18 decisions. Sessão `2026-05-30-screen-grade-metodo-estado-arte.md`. PR #1991.
+
+---
+
+## 0 · REGRA DE OURO (como resolver qualquer conflito)
+
+Quando duas memórias divergem, vence nesta ordem:
+
+1. **ADR canon mais recente com `supersedes`** (memórias são append-only — o aposentado vira histórico, NÃO se usa).
+2. **DS v4 roxo (ADR 0235) > DS v3 > v2.** Cor canon = `primary` roxo `oklch(0.55 0.15 295)`. Azul em tela = **débito a migrar**, nunca padrão novo.
+3. **Código real > documento.** Se a doc diz "tela X tem drift Y" e o código não tem mais, o código vence (a MATRIZ_MIGRACAO_DS tem falsos-positivos confirmados — ver §4).
+4. **Constituição UI v2 (ADR UI-0013):** Fundações → Shell → Padrão de Tela → Módulo. Camada superior herda e **nunca contradiz** a inferior.
+5. **Data mais recente** vence em docs operacionais (briefings, handoffs, notes).
+
+> **Meta-regra única (a frase):** *Crie DENTRO do que existe — copie o golden do arquétipo, rode o PRE-FLIGHT, use só `@/Components/ui` + token `primary` roxo, e NUNCA invente (componente, Model, paleta) nem repita um anti-padrão já catalogado. Em dúvida, pergunte (UI-0013 regra-mestre).*
+
+---
+
+## 1 · ORDEM DE LEITURA (sempre, antes de qualquer tela)
+
+1. **[PRE-FLIGHT-TELA.md](../../../prototipo-ui/PRE-FLIGHT-TELA.md)** — monta o pacote de pré-requisitos DAQUELA tela (identidade/não-inventar/não-repetir/validar).
+2. **[GOLDEN-REFERENCE.md](../../../prototipo-ui/GOLDEN-REFERENCE.md)** — a tela-ouro do arquétipo + 10 regras binárias. "Faça idêntico, mude só X."
+3. **[REGISTRY_DS_COMPONENTES.md](../../../prototipo-ui/REGISTRY_DS_COMPONENTES.md)** — componentes `@/Components/ui` disponíveis. Se está aqui, **não hand-rola**. ⚠️ Onda F (`Segmented`/`FormSection`/`InputGroup`/`FieldState`) **ainda NÃO existe** — não assuma que existe.
+4. **[LICOES_F3_FINANCEIRO_REJEITADO.md](../../../prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md)** — os 21 anti-padrões (exemplo errado). Leitura obrigatória antes de F3.
+5. **[SCREEN-GRADE-METODO.md](SCREEN-GRADE-METODO.md)** — como a tela será notada (16 dim, níveis Beginner→Champion).
+
+---
+
+## 2 · ÍNDICE POSITIVO (o que usar)
+
+### 2a. Entrada / identidade do projeto
+| Memória | Usar pra |
+|---|---|
+| [memory/why-oimpresso.md](../../why-oimpresso.md) | **Posicionamento REAL: ERP modular multi-vertical** (ADR 0121). Larissa/ROTA LIVRE = **vestuário** (não gráfica). ⚠️ corrige briefings antigos |
+| [personas-por-modulo.yml](personas-por-modulo.yml) + ADR UI-0016 | Persona dona da tela (Larissa 1280px densidade · Eliana tabela densa · técnico touch ≥44px) |
+| [prototipo-ui/GLOSSARY.md](../../../prototipo-ui/GLOSSARY.md) | Siglas, fases, comparáveis externos por arquétipo |
+
+### 2b. Padrões — o que COPIAR
+| Memória | Usar pra |
+|---|---|
+| **GOLDEN-REFERENCE.md** | tela-ouro `Sells/Create` (form) + 10 regras binárias R1-R10 |
+| **padroes-tela/PT-01-Lista.md** | golden do arquétipo **lista** (status sem bg-fill, slots) |
+| **REGISTRY_DS_COMPONENTES.md** | componentes reais `@/Components/ui` |
+| **tokens v4** (`resources/css/inertia.css`, ADR 0235) | cor = `primary` roxo. Zero `blue-*` de marca |
+| ADR 0110 (Cockpit Pattern V2) + UI-0010 `os-page.jsx` + UI-0012 | padrão list+detail / shell |
+| ADR UI-0015 | campos de form default `variant="cowork"` |
+| [framework-15-dimensoes.md](framework-15-dimensoes.md) | as 15 dim de qualidade + ponderação por persona |
+| [pageheader-matriz-diferencas.md](pageheader-matriz-diferencas.md) | PageHeader: F1-F16 fixas vs V1-V9 variáveis |
+| [PRE-MERGE-UI.md](PRE-MERGE-UI.md) · [SPEC.md](SPEC.md) (R-DS-001..012) · README.md · ARCHITECTURE.md | regras duras + checklist + mapa da stack |
+| RUNBOOK-{replicar-prototipo-cowork,onda-cowork,design-deep,inertia-defer-pattern}.md | receitas de execução (portar protótipo, ondas, defer) |
+
+> ⚠️ **Goldens de arquétipo: só existe PT-01-Lista.** Faltam **PT-02 Form/Drawer · PT-03 Detalhe · PT-04 Dashboard · PT-05 Config/Kanban** (confirmado por 2 agentes + piloto). Até existirem, o Claude Design usa o golden de código (GOLDEN-REFERENCE = form) e, p/ outros tipos, **pergunta** em vez de inventar.
+
+### 2c. Validação / definição de pronto
+| Memória | Usar pra |
+|---|---|
+| **SCREEN-GRADE-METODO.md** | nota 16-dim, níveis, score-as-code |
+| [PRE-MERGE-UI.md](PRE-MERGE-UI.md) | checklist AP1-AP8 antes de merge |
+| `php artisan ui:lint` (R1-R6, CI ratchet) | cor crua, FontAwesome, emoji, PT-01, origens, blade |
+| `ds:report` (regras `ds/*`, ADR 0209) | violações de DS (zero é meta) |
+
+---
+
+## 3 · ÍNDICE NEGATIVO (não repetir — memórias negativas)
+
+> Estas existem pra o Claude Design **não repetir erro já pago**. Anthropic context-engineering: "manter o erro no contexto previne repeti-lo."
+
+### 3a. Meta-anti-padrões (LICOES_F3 — comportamento)
+| Código | Não fazer |
+|---|---|
+| M-AP-1 | auto-doc/aprendizado não é gate — não pular validação sob pressão |
+| M-AP-2 | marketing otimista — não chamar 4/5 stubs mock de "F3 completo" |
+| M-AP-3 | "f3" no chat ≠ aprovação dos gates F1.5+F2 |
+| M-AP-4 | schema/Model proposto NÃO vira código sem ADR |
+| M-AP-5 | decisão pendente NÃO vira default silencioso hardcoded |
+| **M-AP-6** | **"criar componente se não existe" institucionaliza invenção** — proibido |
+
+### 3b. Anti-padrões técnicos (não inventar)
+| Código | Não fazer |
+|---|---|
+| T-AP-1/2 | **Models inventados** — `FinancialEntry`/`BankAccount`/`ChartOfAccount` NÃO existem; reais = `Titulo`/`ContaBancaria`/`Categoria` |
+| T-AP-2 | Controller sem tenant scope (Tier 0 / ADR 0093) |
+| T-AP-3 | middleware fantasma `'tenant'` — canon = `['web','auth','language','timezone','AdminSidebarMenu']` |
+| T-AP-4 | sobrescrever Controller de tela já em prod (regressão silenciosa) |
+| T-AP-7 | Services inventados sem `Glob Modules/<Mod>/Services/` |
+| T-AP-8 | `auth()->user()->business_id` — canon = `session('user.business_id')` (Job/CLI) |
+| T-AP-13 | mutação NO-OP `return back()` (botão clica, nada persiste) |
+| T-AP-15 | sidebar inventado (`sidebar.php`) — canon = `DataController::user_permissions` + `SIDEBAR_GROUPS` |
+| T-AP-18 | fallback default sem `Log::warning` (bug Larissa R9) |
+
+### 3c. Proibições visuais (lista canônica = [PRE-MERGE-UI.md](PRE-MERGE-UI.md) AP1-AP10 + PT-01 §Nunca + pageheader F12-F16)
+Sem: CTA WhatsApp cliente-facing · modal full-screen (usar drawer/Sheet) · inglês em UI · `rounded-xl+` · emoji em UI produtiva · cor crua fora dos tokens · gradiente 135° bluish-purple · sombra forte · **reinventar shared** (Table/Drawer/PageHeader — AP2) · localStorage sem prefixo `oimpresso.<mod>.*` · ícone fora do lucide · **status badge com bg-fill** (canon = dot + texto colorido, Stripe-style — AP7) · label não-PT-BR · `<main>` aninhado · chain de overflow sem `h-full`/`min-h-0` · primary magenta legacy (hue 330) · botão que duplica navegação já coberta por ghost.
+> ⚠️ `ui:lint` **NÃO** pega AP2/AP5/AP7/AP8 (componente reinventado, gradient, bg-fill badge, copy não-PT-BR) — esses dependem de revisão humana/golden.
+
+### 3d. Drifts de implementação catalogados
+| Origem | Erro |
+|---|---|
+| GOLDEN-REFERENCE §4 | a própria golden usa `rounded-xl` nos KPI (`Sells/Create:916,924,932,942`) → corrigir p/ `rounded-lg` ao copiar |
+| DS_ADOCAO_INDICE | drift-raiz: hand-rolou `<input radio>` existindo `radio-group.tsx` — falta de guard |
+| HANDOFF/SYNC_LOG | NÃO copiar zip Cowork `{Modules,Pages,resources}` direto pra raiz (viola Tier 0, regride prod) |
+
+---
+
+## 4 · CONFLITOS RECONCILIADOS (a regra de ouro aplicada)
+
+| Tema | Canon HOJE | Aposentado / não-usar | Regra |
+|---|---|---|---|
+| **Cor / accent** | **ADR 0235 — roxo `primary` `oklch(0.55 0.15 295)`** universal | ADR 0190 (`superseded`) · azul de marca | R1+R2 |
+| **Sidebar (cor)** | **light** por padrão (UI-0009 + UI-0014) | "sidebar dark sempre" (rejeitada) | R1 |
+| **Sidebar (estrutura)** | single-pane scroll, user menu cascata (UI-0011) | toggle Chat↔Menu dual-pane (UI-0008/0039) | R1 |
+| **DS v3 vs UI v2** | **coexistem** — DS v3 é o "como", UI v2 é o "o quê" (UI-0017) | — | R4 |
+| **MATRIZ Cliente/Index "modais/select nativo"** | **código real**: já é `rounded-lg` + `<Select>` shadcn | entradas P0-3 da MATRIZ (falsos-positivos) | R3 |
+| **Azul na golden** | preservar azul **semântico** (status); trocar azul **de marca** (link/foco) → `primary` | — | R2 (nuance AUDITORIA_DS_V4 §3) |
+| **Posicionamento do produto** | **ERP multi-vertical**, Larissa = vestuário (why-oimpresso, ADR 0121) | "só comunicação visual" (briefing antigo) | R5 |
+| **Onda F componentes** | **não existem ainda** (REGISTRY) — hand-rola até criar | assumir `<Segmented>` etc. existe (= M-AP-6) | R3 |
+| **Topbar** | presente no Cockpit (UI-0008) | UI-0007 (removida) — só AppShell legado | R1 |
+| **Sidebar hue-per-grupo** | **código `cockpit/shared.ts SIDEBAR_GROUP_HUE`** (reconciliado 2026-05-25) | hues de GUIA-SIDEBAR / sidebar-rail-mode (antigos) | R3 |
+| **PageHeader (estrutura)** | **3 blocos fechados** separados, gap 12px (ADR 0189 v3.1, pageheader-matriz F1) | "layout flat 3 zonas" (ADR 0182) | R1 |
+| **Azul que SOBREVIVE** | **origin-badge CRM = blue** (sistema de badge de origem, ≠ botão primary) — continua válido | confundir com cor de marca | R2 (nuance) |
+
+---
+
+## 5 · HIERARQUIA CANÔNICA HOJE (estado final)
+
+**Fundações** (tokens DS v3, accent **roxo 295** via DS v4/ADR 0235) → **Shell** (AppShellV2/Cockpit, sidebar **light** single-pane) → **Padrão de Tela** (PT-01 Lista / Cockpit Pattern V2 / `os-page.jsx`) → **Módulo**. Owner da UI = **Claude Design plugin** (ADR 0235 §3), dentro do loop MWART (0104→0114) + persona (UI-0016).
+
+---
+
+## 6 · DOCS STALE (a refrescar — não são canon de cor/posicionamento)
+
+| Doc | Problema | Ação |
+|---|---|---|
+| `CLAUDE_COWORK_PRIMER.md` | `last_sync 2026-05-09` — não conhece DS v4/GOLDEN/PRE-FLIGHT | **header canon adicionado 2026-05-30** (aponta pra este índice) |
+| `CLAUDE_DESIGN_BRIEFING.md` | §2 "só comunicação visual" (errado) · §4 tokens azul/shadcn genérico | refresh: posicionamento multi-vertical + token roxo |
+| `CODE_DESIGN_CONTRACT.md` | versão para em DS v3.1, cita "Design System.html" | bump v4 + apontar `Design System v4.html` |
+| `PROTOCOL.md` | v1.0, F3 "1 linha" (já estendido por PROTOCOL-F3) | costurar GOLDEN/PRE-FLIGHT como gate |
+| `HANDOFF.md` | congelado 2026-05-15 | regenerar |
+| `GLOSSARY.md` | `[M]=Manus` diverge de `[M]=Maiara` (canon) | reconciliar tabela de pessoas |
+| `MATRIZ_MIGRACAO_DS.md` §P0-3 | 3 falsos-positivos Cliente/Index | corrigir (Cliente já migrado) |
+| **`BRIEFING_CLAUDE_DESIGN.md`** ⚠️ URGENTE | doc-âncora do Claude Design, mas 2026-04-27: "sidebar dark" + accent hue 220 | reconciliar p/ sidebar light + roxo 295 + PT-01 + UI-0013 |
+| `CATALOGO_ACABAMENTOS.md` | snapshot 2026-04-27, accent hue 220 | tipografia/estrutura úteis; cor via ADR 0235 |
+| `SPEC.md` (R-DS-002) + `ARCHITECTURE.md` + `AUTOMATION-ROADMAP.md` | exemplos `bg-blue-500` | trocar exemplo p/ roxo (confunde com primary) |
+| `GUIA-SIDEBAR-V3` + `sidebar-rail-mode` | hues divergem de `shared.ts` | validar estado real antes de seguir |
+
+---
+
+> _Atualizar este índice sempre que um doc de design for criado/aposentado. É a fonte da verdade do que o Claude Design consome._

--- a/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
+++ b/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
@@ -27,6 +27,8 @@ Quando duas memórias divergem, vence nesta ordem:
 4. **[LICOES_F3_FINANCEIRO_REJEITADO.md](../../../prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md)** — os 21 anti-padrões (exemplo errado). Leitura obrigatória antes de F3.
 5. **[SCREEN-GRADE-METODO.md](SCREEN-GRADE-METODO.md)** — como a tela será notada (16 dim, níveis Beginner→Champion).
 
+> **Atalho operacional:** a skill **[`screen-grade`](../../../.claude/skills/screen-grade/SKILL.md)** (Tier B) dispara o Pré-Flight resolver + a nota automaticamente — basta "nota da tela X" / "/screen-grade Mod/Tela" ou tocar um `Pages/<Mod>/<Tela>.tsx`. Materializa os 5 passos acima sem montar contexto de cabeça.
+
 ---
 
 ## 2 · ÍNDICE POSITIVO (o que usar)

--- a/memory/requisitos/_DesignSystem/SCREEN-GRADE-METODO.md
+++ b/memory/requisitos/_DesignSystem/SCREEN-GRADE-METODO.md
@@ -93,3 +93,27 @@ Agregado → ranking das 272 + dimensão "Design Maturity" no **GovernanceV4** +
 | enforcement (ratchet+GovernanceV4) | Soundcheck CI gate | 7/10 | ligar |
 
 **Nota geral do método:** conceito **85/100 (Advanced→Leader)** · execução atual **40/100 (Developing)** · ponderada **~68/100**. Todos os gaps são **wiring** (doc→tool), nenhum é conceitual. Em 2 pontos (Peso Real ROI + code-first sem Figma) está **à frente** dos frameworks genéricos.
+
+---
+
+## 7. Como testar o modelo (validade de um scorecard / LLM-as-judge)
+
+Um modelo de grade só vale se passar em 3 propriedades (literatura de scorecard + LLM-as-judge):
+
+| Teste | Pergunta | Critério de aceite |
+|---|---|---|
+| **T1 · Confiabilidade** (test-retest) | gradar a MESMA tela 2-3× dá a mesma nota? | desvio σ ≤ **3 pts**. Se diverge muito → rubrica subjetiva, endurecer critérios binários |
+| **T2 · Validade discriminante** | separa tela boa de ruim na direção certa? | gap grande: golden (Sells/Create) ≫ tela com drift alto |
+| **T3 · Monotonicidade da evolução** | cada fix sobe a nota, e o teto bate no golden real? | S0 < S1 < S2 e S2(Champion) ≈ nota real do golden do arquétipo (calibração) |
+
+### As 3 simulações por tela (a escada de evolução — "grave as evoluções")
+
+Pra cada tela, 3 simulações **em paralelo** (1 agente especialista por tela, ADR 0231):
+
+- **S0 · Estado atual** — grade as-is das 16 dim → nota + nível
+- **S1 · Próxima onda** — top-3 fixes do roadmap aplicados → nota projetada
+- **S2 · Champion** — teto do arquétipo (benchmark best-of-class) → nota projetada
+
+### Ledger (grava a evolução)
+
+`memory/governance/screen-grades-pilot.md` — tabela `tela × {arquétipo, persona, S0, S1, S2, ΔS0→S1, ΔS1→S2, nível S0→S2}` + nota de confiabilidade (T1) + veredito discriminante (T2) + monotonicidade (T3). Cada linha vira depois um `scorecards/screens/<tela>.yaml` com baseline ratchet (Invariante A — nota só sobe).

--- a/memory/requisitos/_DesignSystem/SCREEN-GRADE-METODO.md
+++ b/memory/requisitos/_DesignSystem/SCREEN-GRADE-METODO.md
@@ -1,0 +1,95 @@
+# SCREEN-GRADE — método de maturidade de tela (nota /100 comparativa)
+
+> **O que é:** o `module-grade` ([ADR 0155](../../decisions/0155-rubrica-module-grade-v3.md)/[0160](../../decisions/0160-governance-v4-scoped-scorecards-buckets.md)) aplicado **por tela**. Nota 0-100 comparativa vs golden do arquétipo + ≥3 best-of-class, ponderada por persona e por Peso Real.
+> **Linhagem:** Método Governance Scorecard ([ADR 0230](../../decisions/0230-metodo-governance-scorecard.md)) + processo especialista-por-área ([ADR 0231](../../decisions/0231-processo-trabalho-canonico-especialista-por-area.md)) + Peso Real ([ADR 0232](../../decisions/0232-modelo-peso-real-classificacao-por-meta.md)) + `framework-15-dimensoes.md` + escala de maturidade USWDS/Figma DesignOps + score-as-code Backstage Soundcheck/Cortex.
+> **Origem:** 2026-05-30 (sessão `2026-05-30-screen-grade-metodo-estado-arte.md`). Candidata a ADR canon.
+
+---
+
+## 1. Fórmula
+
+```
+NOTA_TELA (0-100) = Σ(dim_i × peso_persona_i) / Σ(peso_persona_max) × 100 × modulador_peso_real
+```
+
+- **dim_i** = nota 0-100 da dimensão i (16 dimensões, §3)
+- **peso_persona_i** = 1-3× pela persona dona da tela (tabela `framework-15-dimensoes.md`)
+- **modulador_peso_real** = 0.85-1.0 por contribuição à meta R$5M ([ADR 0232](../../decisions/0232-modelo-peso-real-classificacao-por-meta.md)) — tela de receita direta (Sells/Create, Larissa 99%) pesa cheio; tela de apoio raro modula pra baixo a urgência, não a nota
+
+---
+
+## 2. Níveis nomeados (escala USWDS/Figma — cada tela cai num nível)
+
+| Nível | Faixa | Significa |
+|---|---|---|
+| 🥉 **Beginner** | 0-49 | inventa/repete erro, sem charter, drift alto |
+| **Developing** | 50-69 | charter existe, segue golden parcial, dívida `ds/*` |
+| 🥈 **Advanced** | 70-84 | golden seguido, tokens v4, lint passando |
+| **Leader** | 85-94 | 10 regras binárias 10/10 + testes + a11y AA |
+| 🏆 **Champion** | 95-100 | benchmark do arquétipo + grade rodada em prod + ratchet verde |
+
+> **Meta de programa:** Champion = grade rodada em **todas as 272 telas** (USWDS: *"scoring run on all live applications"*).
+
+---
+
+## 3. As 16 dimensões (15 do framework + Pré-Flight)
+
+1-15 = `framework-15-dimensoes.md` (Density · Discoverability · Speed-to-task · Error recovery · Cognitive load · Aesthetic-usability · Affordance · Brand confidence · Mobile fit · A11y WCAG · i18n PT-BR · Performance perceived · Information hierarchy · Microcopy · Internal consistency).
+
+**16. Pré-Flight conformance** (nova, [PRE-FLIGHT-TELA.md](../../../prototipo-ui/PRE-FLIGHT-TELA.md)): tem charter live? usa só `@/Components/ui`? tokens v4 (`primary`, zero `blue-*`)? zero anti-padrão repetido (LICOES_F3)? — mede objetivamente **"não inventou / não repetiu erro"**.
+
+---
+
+## 4. As 4 etapas por tela (ADR 0230)
+
+1. **Dividir** — cada tela é uma unidade pontuável (o agente especialista pega um módulo).
+2. **Pontuar** — 16 dim × persona, nível Beginner→Champion, **score-as-code** YAML (§5).
+3. **Comparar com o melhor — e POR QUÊ** — cada dim fraca vs **≥3 best-of-class** (Linear/Shopify/Stripe/Notion + Bling/Tiny BR) **com o mecanismo** (não basta citar).
+4. **Roadmap** — gaps por impacto×esforço → ondas → meta. **Invariante A:** todo fix cria teste anti-regressão com a justificativa medida. **Invariante B:** cada achado cita a memória de origem (RTM).
+
+---
+
+## 5. Saída score-as-code (template por tela)
+
+```yaml
+# memory/governance/scorecards/screens/<modulo>-<tela>.yaml
+screen: Sells/Create
+path: resources/js/Pages/Sells/Create.tsx
+archetype: form
+golden: Sells/Create          # é a própria âncora do arquétipo form
+persona: larissa
+peso_real: 1.0                 # receita direta, 99% volume
+nota: 0                        # 0-100 (preenchido pelo agente)
+nivel: ""                      # Beginner|Developing|Advanced|Leader|Champion
+dimensoes:                     # 0-100 cada
+  density: 0
+  # ... 16 dimensões
+  preflight_conformance: 0
+gaps:
+  - dim: ""
+    nota: 0
+    best_of_class: ""          # quem faz melhor
+    porque: ""                 # o mecanismo (ADR 0230 etapa 3)
+    fix: ""
+    esforco: baixo|medio|alto
+    origin: ""                 # memória de origem (RTM)
+baseline_anterior: null        # ratchet — nota só sobe
+```
+
+Agregado → ranking das 272 + dimensão "Design Maturity" no **GovernanceV4** + `screen-grades-baseline.json` (ratchet).
+
+---
+
+## 6. Validação do método vs estado-da-arte (2026)
+
+| Peça do método | SOTA equivalente | Nota | Gap |
+|---|---|---:|---|
+| Pré-Flight resolver | Spec-Kit grounding hooks + Anthropic JIT | 9/10 | virar tool, não checklist |
+| Não-inventar (REGISTRY+token+Model) | Figma Code Connect / MCP | 8/10 | REGISTRY virar índice consultável |
+| Não-repetir-erro (LICOES_F3) | Anthropic "erro no contexto" + memory | 9/10 | auto-injetar |
+| screen-grade (16-dim×persona×PesoReal, score-as-code, ratchet) | USWDS/VA.gov + Soundcheck/Cortex | 9/10 | **superior** em ROI+persona |
+| golden-por-arquétipo | reference implementation / golden path | 7/10 | faltam goldens dashboard/kanban/detalhe/relatório/drawer |
+| especialistas paralelos | Anthropic sub-agents (framework 7) | 9/10 | — |
+| enforcement (ratchet+GovernanceV4) | Soundcheck CI gate | 7/10 | ligar |
+
+**Nota geral do método:** conceito **85/100 (Advanced→Leader)** · execução atual **40/100 (Developing)** · ponderada **~68/100**. Todos os gaps são **wiring** (doc→tool), nenhum é conceitual. Em 2 pontos (Peso Real ROI + code-first sem Figma) está **à frente** dos frameworks genéricos.

--- a/memory/sessions/2026-05-30-screen-grade-metodo-estado-arte.md
+++ b/memory/sessions/2026-05-30-screen-grade-metodo-estado-arte.md
@@ -1,0 +1,66 @@
+---
+date: '2026-05-30'
+topic: "Screen-grade método + Pré-Flight de Tela — estado-da-arte de governança de design, foco Wagner fraco em design"
+type: session
+authors: [W, C]
+prs: [1991]
+related_adrs:
+  - 0230-metodo-governance-scorecard
+  - 0231-processo-trabalho-canonico-especialista-por-area
+  - 0232-modelo-peso-real-classificacao-por-meta
+  - 0235-ds-v4-accent-roxo-universal
+  - 0155-rubrica-module-grade-v3
+status: in-progress
+owner: W
+---
+
+# Screen-grade + Pré-Flight de Tela — estado-da-arte (2026-05-30)
+
+## Contexto
+
+Wagner: *"foco em design, estou muito fraco nessa área; o Claude Design não entende as regras e eu não sei instruir ele"*. Evoluiu pra: criar método de **maturidade de tela** comparativo aos melhores, com **pré-flight** que impede a IA de inventar/repetir erro, rodado por **agentes em paralelo**. Branch `claude/design-governance-progress-NRXE3`, PR #1991.
+
+## Decisões tomadas
+
+1. **Tela-ouro** = `Sells/Create` (A+ 9,75, charter live, 39 testes) → `prototipo-ui/GOLDEN-REFERENCE.md` + 10 regras binárias.
+2. **Não inventar método** — operacionalizar o que já existe: `framework-15-dimensoes` + ADR 0230 (scorecard) + 0231 (especialista/área) + 0232 (Peso Real). Vira `SCREEN-GRADE-METODO.md` (espelho do `module-grade`).
+3. **Pré-Flight de Tela** (`prototipo-ui/PRE-FLIGHT-TELA.md`) — resolvedor de pré-requisitos por tela (4 blocos: identidade/não-inventar/não-repetir/validar). Princípio: o agente nunca monta o próprio contexto, roda o resolvedor.
+4. **Piloto** (escolha Wagner): 10-12 telas top-Peso-Real (Sells+Cliente+Financeiro), validar método antes de escalar p/272.
+5. **Agentes** (escolha Wagner): reusar `coordenador-paralelo` + `design-arte` (anti-dup), criar só `ScreenGradeCommand` p/ persistir.
+
+## Estado-da-arte pesquisado (alguém já fez "isso"? SIM — 4 convergentes)
+
+| SOTA | Resolve | Mecanismo |
+|---|---|---|
+| GitHub **Spec-Kit** / **Kiro** (spec-driven) | pré-flight | context-grounding hooks read-only probing ancorados em evidência do repo |
+| Anthropic **context engineering** | pré-flight + não-repetir | JIT retrieval + "erro no contexto previne repetir" + memory fleet |
+| Figma **Dev Mode MCP + Code Connect** | não-inventar | liga componente↔código → reusa real; hex→token |
+| **USWDS/VA.gov/Figma DesignOps** maturity scale | a grade | níveis Beginner→Champion; Champion = scoring em todas as live apps |
+
+**Achado:** o oimpresso reinventou a convergência dos 4, **code-first** (sem Figma), e está **à frente** em 2: Peso Real (ROI→R$5M) + persona-weighting. Nenhum dos 4 SOTA pondera por receita.
+
+## Nota geral do método (vs estado-da-arte)
+
+- Conceito/desenho: **85/100** (Advanced→Leader)
+- Execução/wiring atual: **40/100** (Developing — ainda é doc, não tool/gate)
+- **Ponderada: ~68/100** — todos os gaps são wiring (doc→tool), nenhum conceitual.
+
+## Pontos de quebra identificados + fix
+
+B1 1-golden≠272-tipos → golden por arquétipo · B2 v3 azul vs v4 roxo → dim "DS v4" + migrar âncora · B3 sem enforcement → ratchet+GovernanceV4 · B4 não-escala → agentes paralelos · B5 golden envelhece → Invariante A · B6 151/272 sem charter → dim 16 Pré-Flight.
+
+## Artefatos criados (PR #1991)
+
+- `prototipo-ui/GOLDEN-REFERENCE.md` — tela-ouro + 10 regras binárias + validação SOTA
+- `prototipo-ui/PRE-FLIGHT-TELA.md` — resolvedor de pré-requisitos
+- `memory/requisitos/_DesignSystem/SCREEN-GRADE-METODO.md` — método 16-dim + níveis + score-as-code
+- este session log
+
+## Próximos passos
+
+1. Migrar âncora `Sells/Create` pra DS v4 (roxo).
+2. `ScreenGradeCommand` (espelho `ModuleGradeCommand`) — persiste `memory/governance/scorecards/screens/*.yaml`.
+3. Disparar piloto (coordenador-paralelo → design-arte × Sells/Cliente/Financeiro).
+4. Goldens dos arquétipos faltantes (dashboard/kanban/detalhe/relatório/drawer).
+5. Wiring: pré-flight vira hook/skill; REGISTRY vira índice consultável; dimensão Design Maturity no GovernanceV4.
+6. Candidata a ADR canon (método screen-grade).

--- a/memory/sessions/2026-05-30-screen-grade-metodo-estado-arte.md
+++ b/memory/sessions/2026-05-30-screen-grade-metodo-estado-arte.md
@@ -58,9 +58,13 @@ B1 1-golden≠272-tipos → golden por arquétipo · B2 v3 azul vs v4 roxo → d
 
 ## Próximos passos
 
-1. Migrar âncora `Sells/Create` pra DS v4 (roxo).
-2. `ScreenGradeCommand` (espelho `ModuleGradeCommand`) — persiste `memory/governance/scorecards/screens/*.yaml`.
+1. Migrar âncora `Sells/Create` pra DS v4 (roxo). ⚠️ tela-ouro/zona F3 — exige gate visual + Wagner aprova screenshot (R2/R7).
+2. `ScreenGradeCommand` (espelho `ModuleGradeCommand`) — persiste `memory/governance/scorecards/screens/*.yaml`. (precisa de runtime PHP/vendor pra validar)
 3. Disparar piloto (coordenador-paralelo → design-arte × Sells/Cliente/Financeiro).
 4. Goldens dos arquétipos faltantes (dashboard/kanban/detalhe/relatório/drawer).
-5. Wiring: pré-flight vira hook/skill; REGISTRY vira índice consultável; dimensão Design Maturity no GovernanceV4.
+5. ✅ **Pré-flight vira skill — FEITO** (continuação 2026-05-30, sessão `status-PSG8g`): `.claude/skills/screen-grade/SKILL.md` (Tier B) operacionaliza PRE-FLIGHT resolver + nota 16-dim, dispara em "nota da tela X"/"/screen-grade"/edit de Page. Resta: REGISTRY vira índice consultável + dimensão Design Maturity no GovernanceV4.
 6. Candidata a ADR canon (método screen-grade).
+
+## Continuação 2026-05-30 (sessão `status-PSG8g`) — recuperação + Passo 5
+
+Wagner pediu pra recuperar e continuar esta sessão (branch `claude/design-governance-progress-NRXE3`, PR #1991) de onde parou. Nada se perdeu — 4 commits docs-only já estavam no git. Container de continuação é clone fresco **sem `vendor/`** → não roda artisan/Pest/browser; por isso Passo 1 (Page golden) e Passo 2 (command) ficaram pendentes (precisam runtime + gate visual) e fechei o **Passo 5** (skill, markdown puro, verificável aqui). Entregue: skill `screen-grade` + atalho no `INDEX-DESIGN-MEMORIAS.md`.

--- a/prototipo-ui/CLAUDE_COWORK_PRIMER.md
+++ b/prototipo-ui/CLAUDE_COWORK_PRIMER.md
@@ -4,9 +4,20 @@ title: "CLAUDE.md primer Cowork — sincronizado com main 2026-05-09"
 type: cowork-primer
 status: ativo
 last_sync: '2026-05-09'
+canon_refresh: '2026-05-30'
 ---
 
 # CLAUDE.md — primer Cowork pra oimpresso (sincronizado com `main`)
+
+> ## ⚠️ CANON ATUAL (2026-05-30) — LEIA ANTES DE TUDO
+>
+> O corpo abaixo é de **2026-05-09** e está parcialmente defasado. **Onde divergir, vence o que está aqui:**
+>
+> 1. **Ponto de entrada único:** antes de qualquer tela, leia **[`memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md`](../memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md)** — índice mestre de TODAS as memórias de design (positivas + negativas) já reconciliadas + a **regra de ouro**.
+> 2. **Fluxo por tela:** **PRE-FLIGHT-TELA.md** (monta contexto) → **GOLDEN-REFERENCE.md** (copia a tela-ouro do arquétipo + 10 regras binárias) → **REGISTRY** (componentes reais; Onda F ainda NÃO existe) → **LICOES_F3** (não repetir 21 anti-padrões) → **SCREEN-GRADE-METODO.md** (como será notado).
+> 3. **Cor = roxo.** Token `primary` `oklch(0.55 0.15 295)` (DS v4, ADR 0235). **Zero `blue-*` de marca** — azul só semântico (status). O §4/§12 abaixo (shadcn genérico/stone-50) está defasado.
+> 4. **Posicionamento correto:** oimpresso é **ERP modular multi-vertical** (ADR 0121). A **Larissa/ROTA LIVRE é VESTUÁRIO** (não gráfica). O §2 abaixo ("só comunicação visual") está errado.
+> 5. **Regra-mestre:** crie DENTRO do que existe — nunca invente componente/Model/paleta (M-AP-6, T-AP-1), nunca repita anti-padrão catalogado. Em dúvida, pergunte (UI-0013).
 
 > **Como Wagner usa este arquivo:** copia 100% do conteúdo abaixo e cola no `CLAUDE.md` do projeto Cowork "Oimpresso ERP Comunicação Visual" (claude.ai/projects). Cowork lê em todo chat novo via GitHub connector + esse arquivo colado.
 >

--- a/prototipo-ui/GOLDEN-REFERENCE.md
+++ b/prototipo-ui/GOLDEN-REFERENCE.md
@@ -1,0 +1,99 @@
+# GOLDEN-REFERENCE.md — a tela-ouro do oimpresso
+
+> **Pra que serve:** você (Wagner) não precisa ser designer. Precisa de **uma tela 10/10** que todas as outras **copiam** — em vez de regra em prosa que o Claude Design interpreta de 100 jeitos.
+> **Como nasce a "regra":** design não se ensina por constituição, se ensina por **exemplo**. Esta é a fonte da verdade visual: *"faça igual a esta tela, mudando só X"*.
+> **Origem:** 2026-05-30 — Wagner: *"estou muito fraco em design, o Claude Design não entende as regras e eu não sei instruir ele"*. Solução: tela-ouro + 10 perguntas sim/não (substitui ~800 linhas espalhadas em 8 docs).
+
+---
+
+## 1. A tela-ouro: `Sells/Create`
+
+[`resources/js/Pages/Sells/Create.tsx`](../resources/js/Pages/Sells/Create.tsx) · charter [`Sells/Create.charter.md`](../resources/js/Pages/Sells/Create.charter.md)
+
+**Por que esta e não outra:**
+- **A+ · 9,75/10** no loop Claude Design (KB-9.75 v2, PR #1064) — "melhor da turma" no `MATRIZ_MIGRACAO_DS.md`
+- Charter `status: live`, 39+ testes anti-regressão, é o **form pattern canon** do Cockpit Pattern V2 ([ADR 0110](../memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md))
+- Já consome `@/Components/ui` certo (Select/Card/Button/Input)
+- É a tela que a **Larissa** mais usa (99% do volume) em 1280px — passou no teste de tarefa real, não só de gosto
+
+> **O juiz final de design não é o Wagner — é a Larissa fazendo a venda.** Tela boa = ela termina mais rápido, com menos erro, em 1280px. Isso se mede com cronômetro, não com "tá bonito?".
+
+---
+
+## 2. As 10 regras binárias (sim/não) — você roda em 2 minutos
+
+Cada regra tem **como testar** + **evidência na golden** (linha real). Se a tela nova responde "não" a qualquer uma, **não é canon ainda**.
+
+| # | Regra (pergunta sim/não) | Evidência na golden |
+|---|---|---|
+| **R1** | **Header é sticky e o h1 é `text-2xl font-semibold` (NÃO `font-bold`)?** subtitle `text-sm text-muted-foreground`. | `Create.tsx:856` (sticky) · `:860` (h1) · charter UX target "h1 24px" + anti-pattern "font-bold em h1" |
+| **R2** | **Navegação entre seções usa pills `rounded-full` (NÃO tabs `border-b-2`)?** Button `variant ghost/default` + ícone lucide 13px + counter. | `:870-908` · charter anti-pattern "Tabs border-b-2 em vez de pills" |
+| **R3** | **Tem KPIs gigantes em grid 4-col, value ≥ `text-3xl tabular-nums`, label `uppercase tracking-widest text-[11px]`?** | `:914-920` · charter "KPI value 36px" |
+| **R4** | **Todo status usa a escala warm semântica (`emerald/amber/rose/sky`-50 + -700), nunca cor crua (`bg-gray/red-N`)?** | `:946-964` · `CLAUDE_DESIGN_BRIEFING.md §4` · charter anti-pattern "Cor crua bg-(gray\|red)-N" |
+| **R5** | **Cabe em 1280px sem scroll horizontal?** `container mx-auto max-w-7xl px-8` + grids `grid-cols-1 md:grid-cols-2 lg:grid-cols-4`. | `:912` · `:986` · charter UX target "1280px sem scroll horizontal (ROTA LIVRE)" |
+| **R6** | **Todo campo vem de `@/Components/ui` (Input/Select/Card/Button) — zero `<select>`/`<input radio\|checkbox>` nativo?** | imports `:23-43` · regra DS `ds/no-native-select` etc. |
+| **R7** | **Superfícies usam `<Card>` ou `rounded-lg` (NÃO `rounded-xl`)?** | `:982` (`<Card>`) · `:1375` (`rounded-lg`) — ⚠️ ver drift §4 |
+| **R8** | **As ações (Cancelar/Salvar) ficam só no footer sticky, 1× (sem botão duplicado)?** | `:1582` · charter feature "footer sticky" + anti-pattern "botões duplicados" |
+| **R9** | **Erro aparece inline no campo (`<FieldError role="alert">`), não em alerta global solto?** Campo colapsado com erro auto-abre. | charter feature US-SELL-010 |
+| **R10** | **Espaçamento usa a escala canon: `space-y-6` entre seções · `gap-4` entre cards · `p-6` interno?** | `:912` `:915` `:979` · `CLAUDE_DESIGN_BRIEFING.md §espaçamento` |
+
+**Placar:** 10/10 = canon. 8-9 = 1 round de ajuste. <8 = volta pro Claude Design.
+
+---
+
+## 3. Como usar (3 modos, nenhum exige talento de design)
+
+### Modo A — instruir o Claude Design (o que destrava você)
+Pare de escrever briefing do zero. O prompt passa a ser:
+> *"Faça a tela `<X>` **idêntica à `Sells/Create`** (mesma estrutura: header sticky 24px → pills rounded-full → 4 KPIs gigantes → cards `@/ui` → footer sticky). Mude **só**: [campos/seções específicos de X]. Siga as 10 regras do `GOLDEN-REFERENCE.md`."*
+
+Você não instrui design — você **aponta pro exemplo**.
+
+### Modo B — você julgando (checklist de 2 min)
+Abra o screenshot, rode as 10 perguntas da §2. Não pergunte *"ficou bom?"*. Pergunte *"R1 sim? R2 sim?..."*. Objetivo, não estético.
+
+### Modo C — few-shot (ensina por contraste)
+No prompt, anexe **2 exemplos**: o certo (`Sells/Create`) + o errado ([`LICOES_F3_FINANCEIRO_REJEITADO.md`](LICOES_F3_FINANCEIRO_REJEITADO.md) — 21 anti-padrões). Dois exemplos contrastados ensinam mais que 800 linhas de regra.
+
+---
+
+## 4. Onde a própria golden tem drift (honestidade — corrija ao copiar)
+
+A `Sells/Create` é ouro em **estrutura/densidade/fluxo**, mas tem **1 drift** que o `ds/*` já pega — **não copie isto, já corrija:**
+
+- ⚠️ **KPI cards usam `rounded-xl`** (`:916,924,932,942`) → o canon é `rounded-lg` ou `<Card>` (regra `ds/no-rounded-xl`). Ao replicar, troque `rounded-xl` → `rounded-lg`.
+
+Os cores warm de status (`bg-emerald-50` etc.) são **canon hoje** (briefing §4); a evolução futura pra `<Badge variant>` é "tipo 2" da `MATRIZ_MIGRACAO_DS.md` (baseline absorve, migra por último) — **não bloqueia** copiar.
+
+---
+
+## 5. Validação contra o estado-da-arte (2026) + upgrades incorporados
+
+Esta ideia foi confrontada com as melhores práticas. Veredito honesto: **conceito certo, forma fraca em 2 pontos.**
+
+| Minha peça | Equivale a | Nota | Por quê / upgrade |
+|---|---|---:|---|
+| Tela-ouro única | **Golden Path / Paved Road** (Spotify/Netflix) | **6/10** | Conceito é exatamente o nome da indústria. MAS *"golden path vira sistema quando torna a escolha certa mais barata que qualquer alternativa — doc não, scaffold sim"*. **Upgrade:** o golden precisa virar **scaffold executável** (`make:page` que cospe o esqueleto da Sells/Create), não só este doc. Doc é o começo, não o fim. |
+| 10 regras binárias | **Heurísticas de Nielsen** (10, binário 0/1) | **9/10** | Validado: avaliação heurística binária é padrão desde 1994. **Upgrade:** cruzar as 10 com as 10 de Nielsen pra achar buraco de **interação** (minhas são visual-estruturais; faltam "visibilidade de status/loading", "prevenção de erro", "desfazer"). |
+| Juiz = Larissa, tarefa cronometrada | **NN/g Task Success Rate** + **efeito estética-usabilidade** | **10/10** | "Success rate é a métrica de usabilidade mais simples" (NN/g). E o *efeito estética-usabilidade* prova: bonito **parece** usável → por isso o Wagner não deve confiar em "tá bonito". **Upgrade:** medir os 3 — sucesso (0/1) + tempo + 1 pergunta de facilidade (SEQ). |
+| Few-shot (certo+errado+diff) | **Few-shot CoT pra UI-gen** (arXiv 2025) | **7/10** | 2 achados viram regra: (1) *"o primeiro exemplo domina, os seguintes têm retorno decrescente"* → o golden TEM que ser o exemplo #1; (2) *"LLM opera por texto, designer pensa visual → saída perde direção estilística"*. **Upgrade: few-shot VISUAL** — anexar **screenshot** do golden + do rejeitado, não só link de código. Texto sozinho sempre perde. |
+| Promotion (golden evolui) | **Spotify Encore promotion rules** | **8/10** | Federado validado. Mantém. |
+| Condensar 8 docs em 1 | **Unified specification** (SpecifyUI) | **8/10** | "Spec unificada é a fundação da geração consistente." O charter já é metade disso. |
+| *(faltava)* enforcement automático | **Visual regression baseline** (Percy/Applitools 2025) | **❌ gap** | O golden não pode ser só aspiracional. **Nova ideia:** snapshot da Sells/Create vira **baseline de visual-regression no CI** — todo PR compara contra ela, e o AI visual review filtra falso-positivo. Aí o golden deixa de ser doc e vira **gate** (conecta no ratchet que já estava solto). |
+
+### Os 5 upgrades que entram na prática
+1. **Golden executável** — `make:page-from-golden` (scaffold), não só este doc. *(torna copiar mais barato que inventar)*
+2. **Few-shot VISUAL** — screenshot golden + screenshot rejeitado no prompt. *(LLM perde intenção visual via texto)*
+3. **Cross-map Nielsen** — mapear as 10 regras §2 ↔ 10 heurísticas, plugar buracos de interação.
+4. **Métrica tripla do juiz** — success rate (0/1) + tempo + SEQ. *(beware efeito estética-usabilidade)*
+5. **Baseline de visual-regression** — a Sells/Create vira snapshot no CI; o golden vira gate, não sugestão.
+
+---
+
+## 6. Limite / próximo passo
+
+Este doc resolve *"não sei instruir o Claude Design"* (Modo A) + *"não sei julgar"* (Modo B). O que **ainda não** está feito (oferta seguinte):
+- **(b)** condensar os 8 docs (`CLAUDE_DESIGN_BRIEFING` + `PROTOCOL` + `CLAUDE_COWORK_PRIMER` + …) num **único** briefing de 1 página que você cola e pronto;
+- **(c)** template few-shot pronto (certo + errado + diff) pro próximo prompt.
+
+> Quando uma tela nova marcar 10/10 nas regras §2 **e** for melhor que a Sells/Create num eixo, ela vira a nova golden (promotion). A tela-ouro evolui — não é eterna.

--- a/prototipo-ui/PRE-FLIGHT-TELA.md
+++ b/prototipo-ui/PRE-FLIGHT-TELA.md
@@ -1,0 +1,64 @@
+# PRE-FLIGHT-TELA.md — o resolvedor de pré-requisitos por tela
+
+> **Pra que serve:** impedir que o Claude Design (ou qualquer agente) **invente** (token, Model, componente, padrão) e **repita erro** já catalogado, ao fazer/gradear uma tela. É a peça que faltava entre o `GOLDEN-REFERENCE.md` (o exemplo) e o `SCREEN-GRADE-METODO.md` (a nota).
+> **Origem:** 2026-05-30 — Wagner: *"como o design deveria ler os pré-requisitos para fazer cada tela, para ele não inventar e não repetir os erros?"*.
+> **Linhagem estado-da-arte (absorvido):** GitHub **Spec-Kit** *context-grounding hooks (read-only probing)* · **Kiro** spec-driven 3-fases · Anthropic **context engineering** *just-in-time retrieval* + *"manter erro no contexto previne repetir"* · Figma **Code Connect** *reusar componente real em vez de inventar*. Aqui tudo é **code-first** (fonte = charter + código, não Figma).
+
+---
+
+## Princípio (a regra que mata invenção)
+
+> **O agente NUNCA monta o próprio contexto de cabeça.** É aí que entram invenção e erro repetido. Ele **roda o resolvedor** que, dado o caminho da tela, devolve o **pacote exato** de pré-requisitos. Lê o pacote → trabalha. Nada fora do pacote pode ser inventado.
+
+Isso é *just-in-time context* (Anthropic): o agente carrega identificadores leves (caminho da tela) e o resolvedor materializa só o necessário no momento da decisão (ADR 0233).
+
+---
+
+## O resolvedor — 4 blocos, cada linha = pergunta → fonte canônica → ação se faltar
+
+### Bloco A · IDENTIDADE (resolve a partir do caminho da tela)
+| Pergunta | Fonte canônica | Se faltar |
+|---|---|---|
+| **Arquétipo?** (form/lista/dashboard/kanban/detalhe/relatório/drawer) | golden do arquétipo + `padroes-tela/PT-0X` | criar o golden do tipo ANTES |
+| **Persona dona?** | `_DesignSystem/personas-por-modulo.yml` + ADR UI-0016 | herda persona do módulo |
+| **Peso Real?** (quanto investir) | ADR 0232 (contribuição R$5M) | calcula pelo módulo |
+
+### Bloco B · NÃO INVENTAR (Figma Code Connect, code-first)
+| Pergunta | Fonte | Se faltar |
+|---|---|---|
+| **Contrato da tela?** | `<Tela>.charter.md` (Mission/Goals/Non-Goals) | **PARA** — gera charter draft (`charter-write`) |
+| **Componentes disponíveis?** | `REGISTRY_DS_COMPONENTES.md` → `@/Components/ui` | usa o registry, **nunca** hand-roll |
+| **Tokens?** | **DS v4 roxo** `primary` (ADR 0235, `resources/css/inertia.css`) — **zero `blue-*`/hex cru** | nunca inventa paleta |
+| **Models/Controller/rotas reais?** | pré-flight `CLAUDE_COWORK_PRIMER §3` (Glob Models, Read 1 Controller, copiar middleware) | não inventa `ChartOfAccount` — usa o real |
+| **Estrutura de referência?** | golden do arquétipo (`GOLDEN-REFERENCE.md`) | copia, não recria |
+
+### Bloco C · NÃO REPETIR ERRO (Anthropic: erro no contexto)
+| Fonte de erro catalogado | Cobre |
+|---|---|
+| `LICOES_F3_FINANCEIRO_REJEITADO.md` | 21 anti-padrões (6 meta + 15 técnicos) |
+| Anti-patterns do **próprio charter** | ex: tabs `border-b-2`, `font-bold` em h1 |
+| `PRE-MERGE-UI.md` (AP1-AP8) + `memory/proibicoes.md §UI` | cherry-pick bundle, BOM PowerShell, cor crua |
+
+### Bloco D · COMO VALIDAR (definição de pronto)
+| Gate | Fonte |
+|---|---|
+| 10 regras binárias + 16-dim grade | `GOLDEN-REFERENCE.md` + `SCREEN-GRADE-METODO.md` |
+| Testes anti-regressão + smoke biz=1 + screenshot | charter `Tests` + ADR 0101 |
+| `ds:report` zero violações `ds/*` | ADR 0209 (ratchet) |
+
+---
+
+## Os 4 upgrades do estado-da-arte (já embutidos acima)
+
+1. **Resolvedor executável, não checklist** — alvo: virar hook/skill `screen-preflight` que roda *read-only probing* (Spec-Kit) e devolve o pacote. Hoje é spec; a wiring vira tool.
+2. **REGISTRY como índice consultável** — `@/Components/ui` indexado (Code-Connect-like) pra o agente não conseguir referenciar componente inexistente.
+3. **Erros auto-injetados** — `LICOES_F3` + anti-patterns do charter entram no contexto automaticamente (Anthropic memory), não dependem de "lembrar de abrir".
+4. **Tokens v4 como SSOT** — `primary` roxo é a única fonte de cor; azul hardcoded é violação medida.
+
+---
+
+## Como pluga no resto
+
+- **Todo agente roda o Pré-Flight ANTES** de fazer/gradear a tela. Sem pré-flight resolvido → não trabalha.
+- A grade (`SCREEN-GRADE-METODO.md`) tem a **dimensão 16 "Pré-Flight conformance"**: tem charter? só `@/ui`? tokens v4? zero anti-padrão repetido? — mede objetivamente "não inventou / não repetiu".
+- Determinístico: `Sells/Create` → arquétipo `form` → golden form + charter Sells/Create + persona Larissa + tokens v4 + anti-padrões F3 + 4 gates. **Wagner não instrui nada — o pacote se monta.**


### PR DESCRIPTION
## O que é

`prototipo-ui/GOLDEN-REFERENCE.md` — a **tela-ouro** do oimpresso. Resolve a dor do Wagner: *"estou fraco em design, o Claude Design não entende as regras e eu não sei instruir ele"*.

Princípio: **design não se ensina por constituição, se ensina por exemplo.** Em vez de ~800 linhas espalhadas em 8 docs, uma tela 10/10 que as outras copiam + 10 perguntas sim/não que até quem não é designer roda em 2 min.

## Conteúdo

- **Tela-ouro = `Sells/Create`** (A+ 9,75 KB-9.75, charter `live`, 39+ testes, form pattern canon Cockpit V2 ADR 0110)
- **10 regras binárias** ancoradas em linha real do código + charter (header sticky 24px, pills não-tabs, KPIs gigantes, escala warm de status, 1280-safe, `@/ui` zero-nativo, Card/rounded-lg, footer sticky, FieldError inline, espaçamento canon)
- **3 modos de uso**: instruir Claude Design ("copie a golden, mude só X") · julgar (checklist 2 min) · few-shot (certo + errado + diff)
- **Honestidade**: o drift `rounded-xl` da própria golden está sinalizado pra corrigir ao copiar
- **§5 validação estado-da-arte 2026**: pontua cada peça vs golden path (Spotify/Netflix), Nielsen, NN/g task success, few-shot CoT (arXiv), visual-regression (Percy) + 5 upgrades

## Reframe central

O juiz de design não é o Wagner — é a **Larissa fazendo a venda**. Tela boa = ela termina mais rápido, com menos erro, em 1280px. Mede com cronômetro, não com "tá bonito?" (efeito estética-usabilidade).

## Tipo

Docs-only (`prototipo-ui/`). Sem mudança de UI/código.

<!-- no-ui-smoke: docs-only, nenhum .tsx/.css/.blade tocado -->

https://claude.ai/code/session_01LxrKQrr5SWpjawfNhEqK14

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxrKQrr5SWpjawfNhEqK14)_