### PR TITLE
docs(design): goldens de arquétipo PT-02..PT-05

### DIFF
--- a/memory/requisitos/_DesignSystem/padroes-tela/PT-02-Form-Drawer.md
+++ b/memory/requisitos/_DesignSystem/padroes-tela/PT-02-Form-Drawer.md
@@ -1,0 +1,116 @@
+---
+pattern_id: PT-02
+nome: Form/Drawer
+camada: 3-padroes-tela
+status: draft
+versao: 0.1
+created: 2026-05-30
+parent_adr: UI-0013
+related_adrs: [179, 185, 110, 149, 235]
+golden_screen: resources/js/Pages/Cliente/Create.tsx
+applied_in:
+  - Pages/Cliente/Create.tsx
+  - Pages/Cliente/Edit.tsx (via _form/ClienteForm compartilhado)
+  - Pages/Cliente/Index.tsx (ClienteSheet drawer 760)
+---
+
+# PT-02 · Form/Drawer — padrão canônico de tela-cadastro
+
+> **Camada 3 · Padrão de Tela.** Herda das [Fundações](../README.md) + [Shell](../README.md) + segue o golden de form do [GOLDEN-REFERENCE.md](../../../../prototipo-ui/GOLDEN-REFERENCE.md). Módulo configura os campos/seções, **não** muda a estrutura.
+
+## Quando aplicar
+
+Sempre que o módulo precisa **criar/editar uma entidade cadastral** (cliente, fornecedor, produto, conta, categoria, etc) — seja em página full (`Create.tsx`/`Edit.tsx`) ou em **drawer lateral** disparado da Lista (PT-01 Slot 6). Não aplicar pra: Lista (PT-01), Detalhe read-only (PT-03), Dashboard (PT-04), Config/Kanban (PT-05).
+
+## A tela-ouro: `Cliente/Create` + `_form/ClienteForm`
+
+[`resources/js/Pages/Cliente/Create.tsx`](../../../../resources/js/Pages/Cliente/Create.tsx) (página fina, 121 linhas) + corpo compartilhado [`_form/ClienteForm.tsx`](../../../../resources/js/Pages/Cliente/_form/ClienteForm.tsx) + charter [`Create.charter.md`](../../../../resources/js/Pages/Cliente/Create.charter.md).
+
+**Por que esta é o golden do arquétipo:**
+- **Score 89** no piloto SCREEN-GRADE — a tela DS-migrada de referência (Onda F).
+- **SoC exemplar:** a página só monta `useForm` + submit + chrome (`Create.tsx:28`, `:79-82`, `:84-118`); o corpo (seções, grid, ações, rail) vive em `_form/ClienteForm` reusado **Create + Edit** (~90%, `ClienteForm.tsx:26-32`).
+- Consome só `@/Components/ui` certo: `Input`/`Segmented`/`Select`/`Button`/`FormSection`/`FormGrid` (`ClienteForm.tsx:4-14`) + `Field`/`FieldError`/`InputGroup` (`Field.tsx:3-4`, `DadosFiscaisBRSection.tsx:26-27`).
+- Drawer canon 760px ([ADR 0179](../../../decisions/0179-cliente-drawer-760px-substitui-show-fullpage.md)/[0185](../../../decisions/0185-drawer-760-canon-entidades-cadastrais.md)) em `Index.tsx:1838`.
+
+## 10 regras binárias (sim/não) — ancoradas em linha real
+
+| # | Regra (pergunta sim/não) | Evidência na golden |
+|---|---|---|
+| **R1** | **Página é fina?** Só `useForm` + `transform` + `handleSubmit` + chrome — o corpo do form mora em `_form/<Entidade>Form` reusado por Create+Edit. | `Create.tsx:28` (useForm) · `:79-82` (submit) · `:103-115` (delega `<ClienteForm>`) |
+| **R2** | **Corpo é `<form>` com layout 2-col `.cw-form-layout` (form 1fr + rail 300px sticky)?** Colapsa pra 1 col abaixo de 900px. | `ClienteForm.tsx:65` (`className="cw-form-layout"`) · `:266` (`<aside className="cw-form-rail">`) · CSS `cowork-fields.css:470-480` |
+| **R3** | **Seções usam `<FormSection title icon>` + `<FormGrid>` (NÃO `<section>`/`<div>` hand-rolled)?** Ícone lucide. | `ClienteForm.tsx:68` (`<FormSection title="Identificação" icon={<User2 />}>`) · `:69` (`<FormGrid>`) · `DadosFiscaisBRSection.tsx:138` |
+| **R4** | **Todo campo é `<Field label error>` envolvendo controle `@/Components/ui` (`Input variant="cowork"`/`Select`/`Segmented`/`Checkbox`) — zero `<input>`/`<select>` nativo?** | `Field.tsx:15-53` · `ClienteForm.tsx:104` (`<Input variant="cowork">`) · `:71` (`<Select>`) · `:86` (`<Segmented>`) |
+| **R5** | **Escolha binária PF/PJ usa `<Segmented accent>` (NÃO radio nativo)?** | `ClienteForm.tsx:86-95` (`<Segmented accent ... options={[Física, Jurídica]}>`) · charter Goals "Segmented PF/PJ substitui o radio nativo" |
+| **R6** | **Erro aparece inline no campo via `<FieldError role="alert">`, com `aria-invalid`+`aria-describedby` injetados no controle?** Sem alerta global solto. | `Field.tsx:30-50` (clona child com a11y + `<FieldError id={errorId}>`) · `field-state.tsx:12-20` (`role="alert"`) |
+| **R7** | **Campos BR têm máscara visual + dígitos limpos no submit?** CPF/CNPJ formata na digitação (`formatCpfCnpj`) e desmascarado (`unmaskDigits`) antes do POST. | `DadosFiscaisBRSection.tsx:132` (`formatCpfCnpj` no onChange) · `Create.tsx:77` (`transform(... cpf_cnpj: unmaskDigits ...)`) |
+| **R8** | **Lookup assistido (CNPJ→BrasilAPI) usa `<InputGroup>`+`<InputGroupButton loading done>` e devolve `FieldError`/`FieldSuccess` — preenchimento, nunca Receita inline?** | `DadosFiscaisBRSection.tsx:144-169` (`InputGroup`+`InputGroupButton`) · `:182-184` (`FieldError`/`FieldSuccess`) · charter Non-Goal "validação CNPJ via Receita NÃO inline" |
+| **R9** | **Ações ficam num footer único alinhado à direita: `Cancelar` (`variant="cowork-ghost"`) + `Salvar` (`variant="cowork-primary"` com spinner `disabled={processing}`)?** Sem botão duplicado. | `ClienteForm.tsx:254-262` (footer `justify-end gap-2`) · `:258` (primary + `disabled={processing}` + "Salvando…") |
+| **R10** | **Cor vem dos tokens DS v4 (roxo `primary`) — rail usa `bg-primary/10 text-primary`, prontidão usa `cw-ok-*`, obrigatório usa `cw-req` — zero hex/`bg-blue-N` cru?** | `ClienteRail.tsx:53` (`bg-primary/10 text-primary`) · `:101` (`cw-ok-text`) · `:110` (`cw-ok-badge`) · `Create.tsx:97` (`<span className="cw-req">*`) · [ADR 0235](../../../decisions/0235-ds-v4-roxo-primary.md) |
+
+**Placar:** 10/10 = canon. 8-9 = 1 round de ajuste. <8 = volta pro Claude Design.
+
+## Regras de ouro
+
+### ✅ Sempre
+
+- **PT-BR** em todo label, placeholder, mensagem (`ClienteForm.tsx:99` "Nome completo", `:153` "(00) 00000-0000")
+- Header de página: `h1 text-2xl font-semibold` (NÃO `font-bold`) + breadcrumb "Voltar" (`Create.tsx:88-95`)
+- Campos PJ-only escondidos quando PF (`DadosFiscaisBRSection.tsx:199` `isJuridica &&`); seção Financeiro só quando cliente/ambos (`ClienteForm.tsx:62`, `:210`)
+- Rail de contexto **client-side** (preview vivo + prontidão fiscal computada do form, sem backend) — `ClienteRail.tsx:6-13`
+- Cabe em **1280px** sem scroll horizontal (charter UX Target; drawer 760 + sidebar 240 ≈ 1024 — `Index.tsx:1834-1836`)
+- Drawer cadastral = **760px** (`Index.tsx:1838` `w-[760px] sm:max-w-[760px]`), fullscreen abaixo de 1100px
+
+### ❌ Nunca
+
+- `<input>`/`<select>`/`<input type="radio|checkbox">` nativo — use `@/Components/ui` (R4/R5)
+- Radio PF/PJ em vez de `<Segmented>` (anti-padrão Onda F)
+- Alerta de erro global solto em vez de `<FieldError>` inline por campo (R6)
+- Enviar CPF/CNPJ mascarado pro backend — sempre `unmaskDigits` no `transform` (R7)
+- Validar CNPJ na Receita inline ao salvar (charter Non-Goal — só lookup BrasilAPI assistido)
+- Botão de ação duplicado / fora do footer (R9)
+- Cor crua (`#hex`, `bg-blue-500`) — token `primary` roxo + `cw-*` (R10, [ADR 0235](../../../decisions/0235-ds-v4-roxo-primary.md))
+- Modal full-screen — cadastro disparado da Lista usa **drawer/Sheet 760**, nunca modal sobre modal
+
+## Estados obrigatórios
+
+1. **Vazio/novo** — form limpo, defaults do `useForm` (`Create.tsx:28-57`)
+2. **Pre-fill** — via query `?prefill_name=` vindo de outra tela (`Create.tsx:32`, charter Goals)
+3. **Erro server-side** — `useForm.errors` mapeado pra `<FieldError>` por campo (`ClienteForm.tsx:61`)
+4. **Lookup carregando/ok/erro** — `InputGroupButton loading/done` + `FieldError`/`FieldSuccess` (`DadosFiscaisBRSection.tsx:155-184`)
+5. **Submetendo** — `disabled={processing}` + label "Salvando…" (`ClienteForm.tsx:258-260`)
+6. **Prontidão** — rail mostra `N de M` checklist + badge "Pronto pra emitir NF-e" quando completo (`ClienteRail.tsx:42-43`, `:109-113`)
+
+## Drift conhecido do golden (honesto — corrija ao copiar)
+
+A `Cliente/Create` é ouro em **SoC/DS/máscaras BR/a11y**, mas tem débitos catalogados — **não copie cegamente:**
+
+- ⚠️ **Charter `status: draft`** (`Create.charter.md:5`) — a tela elevada ainda não teve screenshot aprovado por Wagner (charter: *"Create elevado pendente"*, `:13`). PT-02 nasce `draft` por consequência.
+- ⚠️ **Submit hardcoded `post('/contacts')`** (`Create.tsx:81`) — rota literal na página; ao reusar o pattern, parametrize a action por prop (o corpo `ClienteForm` já recebe `onSubmit`, mas a página fixa a URL).
+- ⚠️ **`tax_number` legado UPOS** coexiste com `cpf_cnpj` BR (`ClienteForm.tsx:124-131`) — campo morto-vivo do UltimatePOS; novos módulos cadastrais **não** devem replicar esse par, só `cpf_cnpj`.
+- ⚠️ **Máscara só em CPF/CNPJ** — celular/CEP têm `placeholder` mas sem `formatPhone`/`formatCep` no onChange (`ClienteForm.tsx:153`, `:200`), apesar de `format-br.ts` exportar ambos (`format-br.ts:51`, `:65`). Aplicar ao replicar.
+- ⚠️ **Copiloto IA inerte** — slot do rail é stub sem endpoint (`ClienteRail.tsx:116-125`, PR-A2 pendente). É placeholder honesto, não feature.
+
+## Aplicado em (estado real)
+
+| Tela | R1 fina | R2 layout+rail | R3 FormSection | R4 @/ui | R5 Segmented | R6 FieldError | R7 máscara BR | R8 lookup | R9 footer | R10 token | Charter | Score |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| `Cliente/Create.tsx` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | draft v2 | **89** |
+| `Cliente/Edit.tsx` | ✓ | ✓ (via `_form`) | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | — | herda |
+| `Cliente/Index.tsx` (ClienteSheet) | — | drawer 760 | parcial | ✓ | parcial | ✓ | ✓ | — | ✓ | ✓ | ✓ v3 | — |
+
+**Métrica adoção PT-02 (2026-05-30):** 1 família cadastral (Cliente · Create/Edit/Sheet) é golden completo. Próximos candidatos: Produto, Fornecedor, contas Financeiro — todos devem nascer reusando o pattern `_form/<Entidade>Form` + drawer 760.
+
+## Referências
+
+- **ADR-mãe:** [UI-0013 Constituição UI v2](../adr/ui/0013-constituicao-ui-v2-camadas.md)
+- **Golden de form (código):** [GOLDEN-REFERENCE.md](../../../../prototipo-ui/GOLDEN-REFERENCE.md) (`Sells/Create` — 10 regras R1-R10 visuais; PT-02 estende pra cadastro BR)
+- **Drawer canon:** [ADR 0179](../../../decisions/0179-cliente-drawer-760px-substitui-show-fullpage.md) + [ADR 0185](../../../decisions/0185-drawer-760-canon-entidades-cadastrais.md)
+- **Tokens v4 roxo:** [ADR 0235](../../../decisions/0235-ds-v4-roxo-primary.md)
+- **Pattern reuse / pares:** [PT-01 Lista](PT-01-Lista.md) (Slot 6 dispara este drawer) · [ADR 0149](../../../decisions/0149-mwart-screen-pattern-reuse-cowork.md)
+- **Índice de design:** [INDEX-DESIGN-MEMORIAS.md](../INDEX-DESIGN-MEMORIAS.md) §2b
+
+## Versão
+
+**v0.1** · 2026-05-30 · primeira formalização (draft). Documenta o pattern já vivo na família Cliente (Create/Edit/Sheet).
+
+**Bump v1.0** quando: Wagner aprovar screenshot do `Cliente/Create` elevado (charter sai de draft) + ≥1 segundo módulo adotar.

--- a/memory/requisitos/_DesignSystem/padroes-tela/PT-03-Detalhe.md
+++ b/memory/requisitos/_DesignSystem/padroes-tela/PT-03-Detalhe.md
@@ -1,0 +1,135 @@
+---
+pattern_id: PT-03
+nome: Detalhe
+camada: 3-padroes-tela
+status: draft
+versao: 0.1
+created: 2026-05-30
+parent_adr: UI-0013
+golden: resources/js/Pages/Sells/Show.tsx
+applied_in:
+  - Pages/Sells/Show.tsx
+  - Pages/Cliente/Show.tsx
+  - Pages/Repair/Show.tsx
+  - Pages/OficinaAuto/ServiceOrders/Show.tsx
+---
+
+# PT-03 · Detalhe — padrão canônico de tela-Show (1 registro)
+
+> **Camada 3 · Padrão de Tela.** Herda das [Fundações](../README.md) + [Shell](../README.md) e nunca contradiz. Módulo configura os slots, **não** muda a estrutura.
+> **Golden code-first** no espírito da [GOLDEN-REFERENCE](../../../../prototipo-ui/GOLDEN-REFERENCE.md): cada regra cita **linha real**. Em dúvida, pergunta ([UI-0013 regra-mestre](../adr/ui/0013-constituicao-ui-v2-camadas.md)) — não inventa.
+
+## Quando aplicar
+
+Tela **full-page de UM registro** (Show): detalhar 1 venda, 1 cliente, 1 OS, 1 OS de oficina. Cabeçalho com a identidade do registro + KPIs/resumo + seções de conteúdo + ações contextuais + histórico.
+
+Não aplicar pra: lista paginável → [PT-01 Lista](PT-01-Lista.md) · cadastro/edição em drawer 760px → PT-02 (drawer-first, [ADR 0185](../../../decisions/0185-drawer-760-canon-entidades-cadastrais.md) — Cliente já migrou via [ADR 0179](../../../decisions/0179-cliente-drawer-760px-substitui-show-fullpage.md)) · dashboard de gráficos → PT-04.
+
+## Golden eleito — `Sells/Show.tsx`
+
+Entre as 4 candidatas, **`Sells/Show.tsx`** é o golden do arquétipo Detalhe. **Por quê:**
+
+- **Anatomia completa dos 6 slots** num só arquivo: header com identidade (`:263-318`), 4 KPIs grandes (`:321-350`), layout 2-col 8/4 (`:353`), seções de conteúdo deferred (`:382-388`), ações contextuais FSM (`:400-422`), histórico unificado (`:665-680`).
+- **Charter `tier: A`, vivo** (`Show.charter.md` — Mission/Goals/Non-Goals/UX targets/anti-patterns), 16+ testes anti-regressão (Wave1ShowBaselineTest + Wave1ShowInertiaTest).
+- **`Inertia::defer` + `<Deferred fallback>`** correto (`:382`, `DetailSkeleton :150`) — SPA-feel, Tier 0 ([RUNBOOK-inertia-defer-pattern](../RUNBOOK-inertia-defer-pattern.md)).
+- **`@/Components/ui`** (Button, DropdownMenu — `:25-31`) + shared (`KpiCard`, `EmptyState`).
+- **Ações contextuais por estado** via `VdNextActionPanel` + `FsmActionPanel` ([ADR 0143 FSM LIVE](../../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md)) — diferencial-chave do arquétipo Detalhe vs Lista.
+- **Timeline unificada** (FSM + pagamentos + atividades, `mode="unified"` `:673`).
+
+**Por que descartei as outras:**
+
+- **`Cliente/Show.tsx`** — bom (header avatar `:152`, 4 StatCard `:197`, defer), MAS o charter está **`status: superseded`** ([ADR 0179](../../../decisions/0179-cliente-drawer-760px-substitui-show-fullpage.md) inverteu pra drawer 760px) — não pode ser golden de um padrão vivo. E usa **tabs `border-b-2`** (`:245`), que é anti-padrão do golden de form (GOLDEN-REFERENCE R2).
+- **`Repair/Show.tsx`** — usa `PageHeader` shared (✓) mas tem **cor crua hardcoded** `STAGE_COLOR_MAP` (`:60-67`, `bg-blue-100`/`bg-red-100` — anti-padrão AP1), FSM panel é **stub textual** (`:235`), histórico é placeholder vazio (`:247`).
+- **`OficinaAuto/ServiceOrders/Show.tsx`** — V0 scaffold (`:2`), **sem KPIs grandes** (só `<dl>` de status), **sem histórico**, status como `bg-muted` cru (`:183`). Bom uso de Sheet 480px pra itens, mas incompleto pro arquétipo.
+
+## Anatomia · 6 slots fixos
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1 · Header-identidade   ← voltar · h1 #ID + subtítulo · ações│
+├─────────────────────────────────────────────────────────────┤
+│ 2 · KPIs/Resumo         grid 4-col · valor grande tabular    │
+├──────────────────────────────────┬──────────────────────────┤
+│ 3 · Seções conteúdo (8/12)       │ 5 · Ações contextuais     │
+│     cliente · linhas · pagtos    │     (4/12) próxima ação   │
+│     · frete (deferred)           │     + pipeline + atalhos  │
+│ 4 · Histórico/Timeline           │                           │
+└──────────────────────────────────┴──────────────────────────┘
+                              6 · Overlays (print · emit · cheat-sheet)
+```
+
+## 8 regras binárias (sim/não) · âncora em linha real do golden
+
+| # | Regra (pergunta sim/não) | Evidência na golden |
+|---|---|---|
+| **R1** | **Header tem botão Voltar (ghost icon) + `h1 text-2xl font-semibold` com a identidade do registro (`#{id}`) + subtítulo `text-sm text-muted-foreground`?** Nunca `font-bold`. | `Sells/Show.tsx:265-269` (voltar ghost) · `:271` (h1) · `:274` (subtítulo data·local) |
+| **R2** | **Ações ficam à direita do header, primária `variant="default"`, secundárias `outline`/`ghost`, agrupadas em dropdown quando >3?** | `:281-317` (Imprimir `DropdownMenu` + Editar `variant default`) |
+| **R3** | **Resumo é grid de KPIs (`grid-cols-1 sm:grid-cols-2 lg:grid-cols-4`) com valor grande `tabular-nums` via `<KpiCard>` shared?** | `:321` (grid 4-col) · `:322-339` (`<KpiCard>` Total/Pago/Falta) |
+| **R4** | **Conteúdo principal usa layout 2-col `lg:grid-cols-12` (8/4) — conteúdo à esquerda (`col-span-8`), ações/contexto à direita (`col-span-4`)?** | `:353` (grid-12) · `:355` (`lg:col-span-8`) · `:392` (`lg:col-span-4` aside) |
+| **R5** | **Props caras (linhas, pagamentos, atividades) vêm `Inertia::defer` no controller e o frontend embrulha em `<Deferred fallback={skeleton}>`?** | `:382` (`<Deferred data="detail" fallback={<DetailSkeleton/>}>`) · `:150` (skeleton) |
+| **R6** | **Tem zona de ações CONTEXTUAIS por estado do registro (próxima ação / transições FSM), separada das ações genéricas do header?** | `:400-409` (`<VdNextActionPanel>`) · `:413-422` (`<FsmActionPanel>` em `<section>` card) — [ADR 0143](../../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md) |
+| **R7** | **Tem seção Histórico/Timeline cronológica (FSM + pagamentos + atividades num stream)?** | `:665-680` (`<section>` Histórico + `<SaleTimeline mode="unified">` `:673`) |
+| **R8** | **Cada seção é card `rounded-lg border border-border bg-card` + título `font-semibold text-sm` com ícone lucide, e estado vazio usa `<EmptyState>` shared (não texto solto)?** | `:358` (card cliente) · `:549` (card itens) · `:556` `:611` (`<EmptyState>`) |
+
+**Placar:** 8/8 = canon. 6-7 = 1 round de ajuste. <6 = volta pro Claude Design.
+
+## ✅ Sempre
+
+- **PT-BR** em todo label/copy. Valores BRL via `Intl.NumberFormat('pt-BR')` (`:133`), datas via `pt-BR` (`:137`).
+- `tabular-nums` em todo valor/qtd/timestamp (`:584` `:593` `:633`).
+- `@/Components/ui` (Button/DropdownMenu) — zero controle nativo. `KpiCard`/`EmptyState` shared (`:23-24`).
+- `Inertia::defer` + `<Deferred fallback>` em tudo que custa query (R5).
+- Status como **badge sem bg-fill cru** — derivar tom de mapa de tokens (`PAYMENT_STATUS_TONE :119` usa escala `emerald/amber` semântica, não `bg-blue-500` literal).
+- Atalhos da tela: `E` editar · `P` imprimir · `Esc` voltar · `?` cheat-sheet (`:218-248`).
+- Charter `.charter.md` ao lado do `.tsx` ([skill `charter-first`](../../../../.claude/skills/charter-first/SKILL.md)) + RUNBOOK-show.md ([skill `mwart-process`](../../../../.claude/skills/mwart-process/SKILL.md)).
+- Multi-tenant Tier 0: scope `business_id` no controller ([ADR 0093](../../../decisions/0093-multi-tenant-isolation-tier-0.md)).
+
+## ❌ Nunca
+
+- Mudar a ordem dos slots (Header-identidade sempre topo · KPIs logo abaixo · ações contextuais na coluna direita).
+- **Cor crua hardcoded** em mapa de status (`bg-blue-100`/`bg-red-100` — anti-padrão AP1; é o drift de `Repair/Show.tsx:60-67`). Use escala semântica via token.
+- **Tabs `border-b-2`** pra alternar conteúdo — preferir pills `rounded-full` (drift de `Cliente/Show.tsx:245`, GOLDEN-REFERENCE R2).
+- Editar inline no Show — edição vai pra `/{rota}/{id}/edit` (Non-Goal do charter).
+- Mudar stage FSM por UPDATE direto — `current_stage_id` é trait-protected ([ADR 0143](../../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md)); transição só via `ExecuteStageActionService`/`FsmActionPanel`.
+- FSM panel ou histórico como **stub textual/placeholder vazio** (drift de `Repair/Show.tsx:235` e `:247`) — ou implementa de verdade, ou omite a seção.
+- Modal full-screen Bootstrap legacy. Overlays print/emit são print-only ou Sheet lateral.
+
+## Estados obrigatórios
+
+1. **Carregado** — headline eager + detail resolvido.
+2. **Loading** — `<DetailSkeleton>` (`:150`) enquanto `Inertia::defer` resolve.
+3. **Seção vazia** — `<EmptyState>` por seção ("Nenhum item" `:556`, "Nenhum pagamento" `:611`).
+4. **Registro sem sub-dado opcional** — seção condicional não renderiza (frete só se `cost > 0`, `:643`).
+5. **Sem permissão** — ação some do header (`permissions.edit`/`permissions.print` gating, `:282` `:309`).
+
+## ⚠️ Drift conhecido (corrija ao copiar)
+
+- **KPI "Status pgto" hand-rola `rounded-xl`** (`Sells/Show.tsx:340`) em vez de `<KpiCard>`/`rounded-lg` — mesmo drift `rounded-xl` da GOLDEN-REFERENCE §4. Ao replicar, padronize via `<KpiCard>` ou `rounded-lg`.
+- **`PAYMENT_STATUS_TONE` usa `bg-blue-50` pra "partial"** (`:122`) — azul **semântico** sobrevive como status, mas confere se não vira azul-de-marca (regra de ouro [INDEX-DESIGN](../INDEX-DESIGN-MEMORIAS.md) §0 R2 — accent canon é roxo `primary`).
+- Charter de `Sells/Show` está `status: wave1-draft` — bump pra `live` quando smoke biz=1 + canary 7d concluírem (Cutover plan do charter).
+
+## Aplicado em (estado real)
+
+| Página | S1 Header | S2 KPIs | S3 Seções | S4 Histórico | S5 Ações ctx | @/ui | Charter | Nota |
+|---|---|---|---|---|---|---|---|---|
+| `Sells/Show.tsx` | ✓ | ✓ (4) | ✓ defer | ✓ unified | ✓ FSM | ✓ | ✓ A | **golden** |
+| `Cliente/Show.tsx` | ✓ avatar | ✓ (4) | ✓ tabs | parcial | dropdown ações | ✓ | superseded | bom (drawer agora) |
+| `Repair/Show.tsx` | ✓ PageHeader | — | ✓ | stub | stub | ✓ | ✓ | parcial |
+| `OficinaAuto/.../Show.tsx` | ✓ PageHeader | — | ✓ Sheet itens | — | — | ✓ | ✓ | V0 scaffold |
+
+**Métrica adoção PT-03 (2026-05-30):** 4/4 telas-Show têm Slot 1 (Header-identidade) + Slot 3 (Seções). Slot 2 (KPIs grandes) cobertura ~50%. Slot 4 (Histórico real) só Sells. Slot 5 (Ações contextuais FSM) só Sells. Meta: subir Repair/OficinaAuto pra KPIs + histórico real.
+
+## Referências
+
+- **ADR-mãe:** [UI-0013 Constituição UI v2](../adr/ui/0013-constituicao-ui-v2-camadas.md)
+- **Golden code:** [Sells/Show.tsx](../../../../resources/js/Pages/Sells/Show.tsx) + charter [Sells/Show.charter.md](../../../../resources/js/Pages/Sells/Show.charter.md)
+- **Form golden (irmão):** [GOLDEN-REFERENCE.md](../../../../prototipo-ui/GOLDEN-REFERENCE.md) (Sells/Create)
+- **Lista (irmão):** [PT-01-Lista.md](PT-01-Lista.md)
+- **Cockpit Pattern V2:** [ADR 0110](../../../decisions/0110-cockpit-pattern-v2-canon-list-detail.md) · **Pattern reuse:** [ADR 0149](../../../decisions/0149-mwart-screen-pattern-reuse-cowork.md)
+- **FSM (ações contextuais):** [ADR 0143](../../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md)
+- **Defer:** [RUNBOOK-inertia-defer-pattern.md](../RUNBOOK-inertia-defer-pattern.md)
+- **Índice mestre design:** [INDEX-DESIGN-MEMORIAS.md](../INDEX-DESIGN-MEMORIAS.md)
+
+## Versão
+
+**v0.1** · 2026-05-30 · primeira formalização (`status: draft`). Golden = Sells/Show. Promove pra `live` quando charter Sells/Show virar `live` + ≥2 telas marcarem 8/8.

--- a/memory/requisitos/_DesignSystem/padroes-tela/PT-04-Dashboard.md
+++ b/memory/requisitos/_DesignSystem/padroes-tela/PT-04-Dashboard.md
@@ -1,0 +1,124 @@
+---
+pattern_id: PT-04
+nome: Dashboard
+camada: 3-padroes-tela
+status: draft
+versao: 0.1
+created: 2026-05-30
+parent_adr: UI-0013
+applied_in:
+  - Pages/governance/Dashboard.tsx
+---
+
+# PT-04 · Dashboard — padrão canônico de tela-painel
+
+> **Camada 3 · Padrão de Tela.** Herda das [Fundações](../README.md#camada-1--fundacoes) + [Shell](../README.md#camada-2--shell) e nunca contradiz. Módulo só configura os slots (KPIs, painéis, períodos), **não** muda a estrutura.
+>
+> ⚠️ **status: draft.** Golden eleito por código real (não há golden por arquétipo Dashboard ainda — [INDEX-DESIGN-MEMORIAS §2b](../INDEX-DESIGN-MEMORIAS.md)). Promove a `live` quando ≥2 dashboards convergirem no padrão + revisão Wagner.
+
+## Quando aplicar
+
+Tela cujo **propósito primário é leitura agregada** (KPIs gigantes + painéis de resumo/gráfico/lista-top-N + filtro de período), sem ser a lista paginável de uma entidade. Ex: visão geral de OS, painel de governança, metas, saúde do ecossistema.
+
+Não aplicar pra: lista paginável de entidades → [PT-01 Lista](PT-01-Lista.md); form/drawer de cadastro → PT-02; detalhe full-page → PT-03.
+
+## Golden eleito · `governance/Dashboard.tsx`
+
+[`resources/js/Pages/governance/Dashboard.tsx`](../../../../resources/js/Pages/governance/Dashboard.tsx) · controller [`Modules/Governance/Http/Controllers/DashboardController.php`](../../../../Modules/Governance/Http/Controllers/DashboardController.php)
+
+**Por que esta:**
+- **Único candidato que usa os shared `@/Components/shared`** canônicos de dashboard: `KpiGrid` (`:11`) + `KpiCard` (`:12`) + `PageHeader` (`:10`) + `EmptyState` (`:13`). Os outros hand-rolam.
+- **Hierarquia de leitura clara em 2 tiers de KPI** com sub-cabeçalho seccionador (`:129` "Constituição" cols=6 · `:180` "Saúde do ecossistema" cols=3) — exatamente o que um painel precisa: o olho desce por grupos.
+- **Tom semântico em vez de cor crua** via `tone` do KpiCard (`failedJobsTone` `:73`, `custoIaTone` `:80`, `severityTone` `:87`) — verde/âmbar/vermelho derivados do dado, não literais.
+- **Painéis de resumo em `<Card>`** com drill-down (`:216-324`: ADRs pendentes / Audit highlights / Narrativas) + `EmptyState` em cada um (`:231`, `:265`, `:306`).
+- `tabular-nums` nos valores via KpiCard (`KpiCard.tsx:127`), PT-BR em todo label, `pt-BR` locale em datas/moeda (`:199`, `:243`).
+
+**Por que descartei os outros:**
+- **`Financeiro/Advisor/Dashboard.tsx`** (anti-golden parcial) — não usa nenhum shared: `os-btn primary/ghost` cru (`:51,93,100`), `<div className="rounded-md border bg-white">` hand-rolado (`:67,76`), `bg-slate-50`/`bg-white` literais (`:38,39`) em vez de tokens, sem `KpiCard`/`PageHeader`/`AppShellV2`. É um portal isolado, não painel canônico. **Financeiro/Unificado** já marcado piloto como "ilha CSS" (bundle paralelo 8.663 LOC) — anti-golden absoluto, nem entra.
+- **`Repair/Dashboard/Index.tsx`** — usa `KpiCard` + `PageHeader` certo, mas é **raso demais pra golden**: só 2 KPIs, painéis são `SimpleListCard` hand-rolada (`:105`), tem `FIXME US-REPAIR-DASH-1` aberto (`:34`), sem tiers nem tom semântico. Bom aluno, não professor.
+- **`Jana/Dashboard.tsx`** — rico, mas **contaminado por mocks e CSS escopado paralelo**: `JanaKpiStrip` é placeholder que "não consulta DB" (`:190-191`), wrapper `.sells-cowork` puxa tokens `.vd-insights-*` de bundle escopado (`:276`), gradientes `from-violet-600 via-fuchsia-500` (`:294`) e `bg-gradient-to-br` (`:239`). Viola "sem bundle CSS paralelo" e "sem gradiente bluish-purple". Desqualifica.
+
+## Anatomia · 5 slots fixos
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1 · PageHeader     ícone · título · descrição · período/badge │ ← sticky
+├─────────────────────────────────────────────────────────────┤
+│ 2 · KPI Tier(s)    <KpiGrid cols=N> de <KpiCard> gigantes     │
+│                    sub-h2 uppercase seccionando cada tier     │
+├─────────────────────────────────────────────────────────────┤
+│ 3 · Painéis        grid de <Card> resumo/top-N/gráfico        │
+│                    cada um com título + drill-down + Empty     │
+├─────────────────────────────────────────────────────────────┤
+│ 4 · Quick actions  (opcional) grid de atalhos navegação       │
+├─────────────────────────────────────────────────────────────┤
+│ 5 · Estados        loading skeleton · vazio · erro            │ ← transversal
+└─────────────────────────────────────────────────────────────┘
+```
+
+## 8 regras binárias (sim/não) — ancoradas em linha real
+
+| # | Regra (pergunta sim/não) | Evidência na golden |
+|---|---|---|
+| **R1** | **KPIs gigantes vêm de `<KpiGrid cols=N>` + `<KpiCard>` shared (NÃO `<div>` hand-rolado)?** value `text-2xl/4xl font-semibold tabular-nums`, label `text-[11px] uppercase tracking-widest`. | `Dashboard.tsx:133,184` (KpiGrid) · `:134` (KpiCard) · `KpiCard.tsx:106-111,117,127` |
+| **R2** | **Tom do KPI é semântico via `tone` derivado do dado (NÃO cor crua `bg-red-N`)?** `default/success/warning/danger/info`. | `:73` `failedJobsTone` · `:80` `custoIaTone` · `:166` `tone={... > 0 ? 'warning' : 'success'}` · `KpiCard.tsx:33-39` |
+| **R3** | **Há hierarquia de leitura: tiers de KPI seccionados por sub-`<h2>` uppercase (NÃO um amontoado plano)?** | `:129-131` "Constituição" cols=6 · `:180-182` "Saúde do ecossistema" cols=3 |
+| **R4** | **Painéis de resumo/gráfico/top-N usam `<Card>` shadcn (NÃO `<div className="rounded-md border bg-white">`)?** | `:218,252,293` `<Card><CardContent>` — contraste: Advisor `:67,76` hand-rola |
+| **R5** | **Todo painel tem estado vazio explícito via `<EmptyState>` (NÃO some/quebra quando dado=0)?** | `:231` · `:265` · `:306` (3 painéis, 3 EmptyState) |
+| **R6** | **Header é `<PageHeader>` shared (sticky, ícone+título+descrição), com filtro de período/contexto no slot de ação?** | `:119-127` (PageHeader + `<Badge>` ActionGate no slot) · `PageHeader.tsx:46` |
+| **R7** | **Números/valores/moeda usam `tabular-nums` + locale `pt-BR` (NÃO toFixed cru sem locale)?** | `KpiCard.tsx:127` (tabular-nums) · `:199` `toLocaleString('pt-BR')` · `:243` `toLocaleDateString('pt-BR')` |
+| **R8** | **Cabe em 1280px e o container é `max-w-7xl` com `space-y-4` entre blocos (sem scroll horizontal)?** | `:118` `mx-auto max-w-7xl p-6 space-y-4` · `KpiGrid.tsx` grids responsivos `lg:grid-cols-N` |
+
+**Placar:** 8/8 = canon. 6-7 = 1 round de ajuste. <6 = volta pro Claude Design.
+
+> A golden marca **8/8 nas regras estruturais**, mas ver §Drift abaixo — ela tem débitos que você corrige ao copiar.
+
+## §Nunca
+
+- ❌ Hand-rolar KPI com `<div className="rounded-md border bg-white">` — usa `<KpiGrid>` + `<KpiCard>` (anti-padrão vivo no Advisor `:76`)
+- ❌ Cor crua em valor/tom (`bg-red-500`, `bg-slate-50`, `text-blue-700` literal) — tom vem de `tone` semântico ou token; azul de marca migra pra `primary` roxo ([INDEX §0 R2](../INDEX-DESIGN-MEMORIAS.md))
+- ❌ **Bundle CSS paralelo** escopado (`.sells-cowork`, `.vd-insights-*`, `cowork-<mod>-bundle.css`) pra estilizar dashboard — é o pecado do Financeiro/Unificado (ilha CSS 8.663 LOC) e contamina o Jana (`:276`)
+- ❌ Gradiente bluish-purple decorativo (`bg-gradient-to-br from-violet via-fuchsia`) em card de KPI/painel (Jana `:239,294`) — proibição visual [PRE-MERGE-UI](../PRE-MERGE-UI.md)
+- ❌ KPI mock que "não consulta DB" apresentado como real (Jana `JanaKpiStrip` `:190`) — M-AP-2/M-AP-5 ([INDEX §3a](../INDEX-DESIGN-MEMORIAS.md))
+- ❌ Painel sem estado vazio — todo `<Card>` de lista/top-N cobre `length === 0` com `<EmptyState>`
+- ❌ `rounded-xl+` em superfície de painel · emoji em UI produtiva (a golden usa 📋📊🤖 nos títulos — **débito**, ver §Drift) · label não-PT-BR
+- ❌ Modal full-screen pra drill-down — drill-down é `<Link>` pra rota (golden `:225,259,300`) ou drawer/Sheet
+
+## Estados obrigatórios
+
+1. **Cheio** — KPIs com valor, painéis com N linhas
+2. **Vazio/sem dado** — cada painel com `<EmptyState>` contextual (golden `:231,265,306`); KPI mostra `—` quando null (golden `:189,196,207`)
+3. **Loading skeleton** — `<Deferred data="..." fallback={<KpiSkeleton/>}>` enquanto `Inertia::defer` resolve (ver §Drift — golden hoje é eager)
+4. **Erro de fetch** — toast + retry
+
+## Drift conhecido (corrija ao copiar — não herde)
+
+- ⚠️ **`Inertia::defer` foi REVERTIDO** no controller (`DashboardController.php:47-50`, "Wave W7 #953 — Pages não tinham `<Deferred>` wrapper, kpis undefined crashava"). Hoje é **eager**. Ao copiar pra dashboard novo: wrappe os payloads pesados (`buildKpisPayload`, `buildAuditHighlightsPayload`, queries 24h) em `Inertia::defer(fn () => ...)` **e** o frontend em `<Deferred fallback={skeleton}>` juntos — skill [`inertia-defer-default`](../../../../.claude/skills/inertia-defer-default/SKILL.md). Eager aqui é débito, não modelo.
+- ⚠️ **Emoji nos títulos de painel** (`:223` 📋, `:256` 📊, `:297` 🤖, `:335-353` ⚙️📊🚨📋 nos atalhos) viola "sem emoji em UI produtiva" ([PRE-MERGE-UI](../PRE-MERGE-UI.md)). Troca por ícone lucide via `<Icon name>` ao replicar.
+- ⚠️ **`KpiCard` raiz usa `rounded-xl`** (`KpiCard.tsx:30`) — mesmo drift da GOLDEN-REFERENCE §4. Canon é `rounded-lg`; está no shared, então herda — não piora, mas não cite como exemplo de raio.
+- ⚠️ **`bg-blue-50 text-blue-700`** em `severityBadgeClass` info (`:98`) e `tone="info"` (`KpiCard.tsx:38,62`) — azul semântico **sobrevive hoje** ([INDEX §4 nuance R2](../INDEX-DESIGN-MEMORIAS.md)); azul de **marca** (link/foco) migra pra `primary` roxo.
+
+## Aplicado em (estado real)
+
+| Página | R1 KPI shared | R2 tom | R3 tiers | R4 Card | R5 Empty | R6 Header | defer | Nota |
+|---|---|---|---|---|---|---|---|---|
+| `governance/Dashboard.tsx` | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | eager (drift) | **golden** |
+| `Repair/Dashboard/Index.tsx` | ✓ | — | — | parcial | parcial | ✓ | — | bom aluno |
+| `Jana/Dashboard.tsx` | parcial (mock) | parcial | — | ✓ | ✓ | ✓ | — | mock+bundle |
+| `Financeiro/Advisor/Dashboard.tsx` | ❌ | ❌ | — | ❌ (hand-roll) | parcial | ❌ | — | anti-golden |
+
+**Métrica adoção PT-04 (2026-05-30):** 1/4 dashboards atinge canon estrutural. Próximo passo: portar `Repair/Dashboard` pros 2 tiers de KpiGrid + tom semântico (já tem base shared), e desbundlar o Jana.
+
+## Referências
+
+- **ADR-mãe**: [UI-0013 Constituição UI v2](../adr/ui/0013-constituicao-ui-v2-camadas.md)
+- **Tipografia KPI canon**: [ADR 0110 Cockpit Pattern V2](../../../decisions/0110-cockpit-pattern-v2-canon-list-detail.md) (`KpiCard.tsx:104-117`)
+- **Golden form irmão**: [GOLDEN-REFERENCE.md](../../../../prototipo-ui/GOLDEN-REFERENCE.md) (`Sells/Create`)
+- **Índice de design**: [INDEX-DESIGN-MEMORIAS.md](../INDEX-DESIGN-MEMORIAS.md) (regra de ouro + negativo)
+- **Defer**: [RUNBOOK-inertia-defer-pattern.md](../RUNBOOK-inertia-defer-pattern.md)
+- **Anti-golden catalogado**: Financeiro/Unificado (ilha CSS bundle paralelo) · [LICOES_F3_FINANCEIRO_REJEITADO.md](../../../../prototipo-ui/LICOES_F3_FINANCEIRO_REJEITADO.md)
+
+## Versão
+
+**v0.1** · 2026-05-30 · primeira formalização (draft). Golden eleito por código real (`governance/Dashboard`).
+**Bump v1.0 (→ live)** quando ≥2 dashboards convergirem no padrão + Wagner aprovar screenshot.

--- a/memory/requisitos/_DesignSystem/padroes-tela/PT-05-Kanban.md
+++ b/memory/requisitos/_DesignSystem/padroes-tela/PT-05-Kanban.md
@@ -1,0 +1,132 @@
+---
+pattern_id: PT-05
+nome: Kanban
+camada: 3-padroes-tela
+status: draft
+versao: 0.1
+created: 2026-05-30
+parent_adr: UI-0013
+golden_eleito: resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx
+golden_score: 68/100 (Developing) — estrutural com drift a corrigir
+persona: Técnico chão de fábrica (tablet, touch ≥44px, mobile_fit ALTO)
+applied_in:
+  - Pages/OficinaAuto/ProducaoOficina/Index.tsx
+  - Pages/Repair/ProducaoOficina/Index.tsx
+---
+
+# PT-05 · Kanban — board de colunas com cards arrastáveis
+
+> **Camada 3 · Padrão de Tela.** Herda das [Fundações](../README.md) + [Shell](../README.md) e nunca contradiz. Módulo só configura colunas/cards/transições, **não** muda a estrutura.
+> **Status `draft`** — golden eleito é estrutural mas ainda tem drift sério (score 68 no piloto). Use como esqueleto, **corrija os drifts da §Drift conhecido ao copiar.**
+
+## Quando aplicar
+
+Fluxo operacional com **estados sequenciais** onde o usuário move uma entidade de uma fase pra outra (OS de oficina, produção, pipeline FSM, etapas de serviço). Persona típica = operador de chão de fábrica em tablet (touch).
+
+Não aplicar pra: lista paginável ([PT-01 Lista](PT-01-Lista.md)), form/cadastro (PT-02 quando documentado), dashboard de gráficos (PT-04 quando documentado).
+
+## Golden eleito + por quê
+
+**[`Pages/OficinaAuto/ProducaoOficina/Index.tsx`](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx)** — vence a candidata `Repair/ProducaoOficina` em 4 eixos que importam pra persona touch:
+
+| Eixo | OficinaAuto (eleito) | Repair (rejeitado) |
+|---|---|---|
+| **Drag touch** | `@dnd-kit/core` — `PointerSensor` cobre mouse+touch + `KeyboardSensor` a11y ([KanbanDndProvider.tsx:86-91](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/_components/KanbanDndProvider.tsx)) | HTML5 nativo `draggable`/`onDragStart` ([Index.tsx:419-425](../../../../resources/js/Pages/Repair/ProducaoOficina/Index.tsx)) — **não dispara em touch**, gap fatal no piloto |
+| **Transição validada** | `resolveDragMapping` FSM FROM→TO + `DragConfirmDialog` ([Index.tsx:124-236](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx)) | `handleDrop` POST direto sem confirmação ([Index.tsx:136-165](../../../../resources/js/Pages/Repair/ProducaoOficina/Index.tsx)) |
+| **Token v4** | `border-primary` no preview ([KanbanDndProvider.tsx:54](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/_components/KanbanDndProvider.tsx)) | `bg-blue-400`/`bg-blue-50` crus ([Index.tsx:89-102](../../../../resources/js/Pages/Repair/ProducaoOficina/Index.tsx)) |
+| **Componentes DS** | `@/Components/ui` Input/Button ([Index.tsx:34-35](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx)) | zero `@/ui` — tudo `<button>` nativo |
+
+> **Honestidade (regra GOLDEN-REFERENCE §4):** o eleito é **golden estrutural com drift a corrigir**, score **68/100 Developing** no [piloto](../../../governance/screen-grades-pilot.md). Tem o esqueleto certo (dnd-kit + FSM + dialog + ui), mas o piloto achou: grid fixo `grid-cols-5` ([Index.tsx:603](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx)) que não rola; tones `bg-slate/amber/rose/emerald` direto no `KpiCard` ([Index.tsx:649-675](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx)) em vez de `<Badge>`; e card tap-target não auditado pra ≥44px.
+
+### O golden IDEAL (alvo do bump v1.0)
+
+1. **Colunas flex roláveis** — `flex gap-4 overflow-x-auto` com `min-w` por coluna + scroll-snap, NÃO `grid-cols-5` fixo (quebra em tablet retrato).
+2. **Drag com fallback** — dnd-kit cobre touch; **somar** botão/menu "Mover para…" em cada card pra quem não arrasta (acessibilidade + dedo grosso).
+3. **Tap ≥44px** — card inteiro clicável com altura mínima `min-h-[44px]`, ações com `h-11 w-11` (alvo WCAG 2.5.5 / persona touch).
+4. **Tokens v4** — `primary` roxo + status na escala warm semântica (`emerald/amber/rose/sky`), zero `blue-*`/`slate-*` cru de marca ([INDEX §0 regra 2](../INDEX-DESIGN-MEMORIAS.md)).
+
+## Anatomia · 5 slots fixos
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1 · PageHeader     h1 + sub · toggle Kanban|Lista · ações    │
+├─────────────────────────────────────────────────────────────┤
+│ 2 · KPI strip      cards de contagem por estado (opcional)   │
+├─────────────────────────────────────────────────────────────┤
+│ 3 · Toolbar        filtros (pills) · busca · KPI inline      │ ← sticky
+├─────────────────────────────────────────────────────────────┤
+│ 4 · Board          N colunas flex roláveis · cards arrastáv. │
+│                      header(dot+label+count) · scroll interno │
+├─────────────────────────────────────────────────────────────┤
+│ 5 · Drawer/Dialog  Sheet do card + DragConfirmDialog FSM     │
+└─────────────────────────────────────────────────────────────┘
+```
+
+| Slot | Onde no golden | Faz | Não faz |
+|---|---|---|---|
+| **1 · Header** | [Index.tsx:478-521](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx) | h1 + sub + toggle Kanban\|Lista + Novo. Migrar p/ `<PageHeader>` shared | filtros · busca |
+| **2 · KPI strip** | [Index.tsx:523-530](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx) | contagem por estado, `tabular-nums` | navegação |
+| **3 · Toolbar** | [Index.tsx:533-598](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx) | pills filtro + busca debounce 300ms + KPI inline. Sticky `z-10` | mover card |
+| **4 · Board** | [Index.tsx:601-615](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx) + `CacambaKanbanColumn` | colunas + drag dnd-kit + drop highlight `useDroppable.isOver` | persistir sem dialog |
+| **5 · Drawer/Dialog** | [Index.tsx:618-633](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx) | `Sheet` do card + `DragConfirmDialog` antes do POST FSM | modal sobre modal |
+
+## Regras binárias (sim/não)
+
+| # | Regra | Evidência no golden |
+|---|---|---|
+| **R1** | Drag usa `@dnd-kit/core` (`PointerSensor`+`KeyboardSensor`), **NÃO** HTML5 `draggable` nativo? | [KanbanDndProvider.tsx:86-91](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/_components/KanbanDndProvider.tsx) |
+| **R2** | `PointerSensor` tem `activationConstraint.distance` (≥8) pra clique-abre-drawer não virar drag acidental? | [KanbanDndProvider.tsx:87-89](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/_components/KanbanDndProvider.tsx) |
+| **R3** | Transição de coluna passa por mapping FSM (FROM→TO→action) **antes** de persistir, bloqueando inválida com toast? | [Index.tsx:124-236](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx) |
+| **R4** | Ação crítica (`isCritical`) abre `DragConfirmDialog` antes do POST — drop nunca persiste direto? | [Index.tsx:316-333](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx) + [:627-633](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx) |
+| **R5** | Persistência via endpoint FSM `service-orders/{id}/fsm/execute` com CSRF + `router.reload({only:['kanban','kpis']})` — **não** muta `current_stage_id` direto ([ADR 0143](../../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md))? | [Index.tsx:356-386](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx) |
+| **R6** | Header de coluna = dot de tom + label + count em pílula `tabular-nums`? | `CacambaKanbanColumn` (header pattern espelha [Repair Index.tsx:359-367](../../../../resources/js/Pages/Repair/ProducaoOficina/Index.tsx)) |
+| **R7** | Drop-target destaca coluna no hover (`useDroppable.isOver`), e o card arrastado tem `DragOverlay` preview leve (não duplica o card)? | [KanbanDndProvider.tsx:51-77,143-145](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/_components/KanbanDndProvider.tsx) |
+| **R8** | Handlers descendentes em `useCallback`/`useMemo` (evita re-render loop — lição PR #717)? | [Index.tsx:263-279,286,335,400-407](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx) |
+| **R9** | Busca tem debounce (≥300ms) via `router.get` `preserveState`+`preserveScroll`+`replace`, sem visit por keystroke? | [Index.tsx:244-258](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx) |
+| **R10** | Cor de status/KPI na escala warm semântica (`amber/rose/emerald`) + `primary` roxo, **NÃO** `blue-*` cru? | [Index.tsx:657-674](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx) (warm ✓) · drift `border-primary` ✓ · ver §Drift |
+
+**Placar:** 10/10 = canon. <8 = volta pro Claude Design. Golden eleito hoje: ~7/10 (falha R-touch-target e colunas-flex que viram regras do IDEAL acima).
+
+## Nunca
+
+- ❌ **Drag HTML5 nativo** (`draggable`/`onDragStart`/`onDrop`) — não funciona em touch, persona não consegue mover (gap do piloto Repair). Sempre `@dnd-kit`.
+- ❌ **Drop que persiste direto** sem `DragConfirmDialog` em ação `isCritical` — risco de transição irreversível por toque acidental.
+- ❌ **Mutar `current_stage_id` direto** (Eloquent `save()` ou POST genérico) — passa por `ExecuteStageActionService`/endpoint FSM ([ADR 0143](../../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md), [proibições](../../../proibicoes.md)).
+- ❌ **`grid-cols-N` fixo no board** — não rola em tablet retrato. Use `flex overflow-x-auto`.
+- ❌ **Cor crua** (`bg-blue-500`, `#hex`) — token CSS var / escala warm. (anti-padrão AP1 / [INDEX §3c](../INDEX-DESIGN-MEMORIAS.md))
+- ❌ **Tap-target <44px** em card ou ação — persona é dedo em tablet (WCAG 2.5.5).
+- ❌ **Drawer mock** com dados hardcoded (sintoma/fotos/preço fixos) declarado pronto — o `JobDrawer` da Repair ([Index.tsx:532-565](../../../../resources/js/Pages/Repair/ProducaoOficina/Index.tsx)) tem texto fixo "barulho na suspensão" e fotos 📷; golden real usa `ServiceOrderRichSheet` com dados do servidor.
+- ❌ **Emoji em UI produtiva** (📷/✓ no card Repair) — ícone lucide.
+- ❌ Modal sobre modal — Sheet do card + Dialog de confirmação são camadas distintas, não empilhar.
+
+## Drift conhecido do golden (corrija ao copiar)
+
+1. ⚠️ **Board `grid grid-cols-5` fixo** ([Index.tsx:603](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx)) → trocar por `flex gap-4 overflow-x-auto` + `min-w-[280px]` por coluna (board IDEAL §2).
+2. ⚠️ **`KpiCard` com tones inline** `bg-amber-50/bg-rose-50/...` ([Index.tsx:649-675](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx)) → migrar pra `<Badge variant>` shared quando existir (tipo-2 da MATRIZ — não bloqueia copiar, mas é o alvo).
+3. ⚠️ **Tap-target não auditado** — card e botões precisam `min-h-[44px]`/`h-11` explícito pra persona touch (não verificado no código atual).
+4. ⚠️ **`bg-slate-50`/`bg-slate-900` de chrome** espalhados — manter como neutro estrutural OK, mas accent/marca = `primary` roxo nunca `blue-*` ([INDEX §0](../INDEX-DESIGN-MEMORIAS.md)).
+5. ⚠️ **Header é `<header>` hand-rolled** ([Index.tsx:478](../../../../resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx)), não `<PageHeader>` shared → migrar pro componente canônico (slot 1).
+
+## Aplicado em (estado real)
+
+| Página | Drag | FSM | Confirm dialog | Token v4 | Touch ok | Score |
+|---|---|---|---|---|---|---|
+| `OficinaAuto/ProducaoOficina/Index.tsx` | dnd-kit ✓ | ✓ | ✓ | parcial (`primary` no preview, warm KPI) | parcial | **68** (golden) |
+| `Repair/ProducaoOficina/Index.tsx` | HTML5 ✗ | ✗ (POST direto) | ✗ | ✗ (`blue-*` cru) | ✗ | — |
+
+**Próximo passo:** quando OficinaAuto fechar os 5 drifts (board flex + tap≥44 + Badge + PageHeader) e marcar ≥8/10, bump PT-05 pra `status: live` e migrar a Repair pro mesmo esqueleto.
+
+## Referências
+
+- **ADR-mãe:** [UI-0013 Constituição UI v2](../adr/ui/0013-constituicao-ui-v2-camadas.md)
+- **FSM canon:** [ADR 0143](../../../decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md) (LIVE prod) · [ADR 0129](../../../decisions/0129-state-machine-canonica-fsm-rbac.md)
+- **Domínio Martinho:** [ADR 0194](../../../decisions/0194-correcao-dominio-martinho-mecanica-pesada.md) · [ADR 0137](../../../decisions/0137-oficinaauto-qualificada.md)
+- **Golden form/lista:** [GOLDEN-REFERENCE.md](../../../../prototipo-ui/GOLDEN-REFERENCE.md) · [PT-01 Lista](PT-01-Lista.md)
+- **Índice de design:** [INDEX-DESIGN-MEMORIAS.md](../INDEX-DESIGN-MEMORIAS.md) (regra de ouro + negativo)
+- **Piloto que gradeou:** [screen-grades-pilot.md](../../../governance/screen-grades-pilot.md) (Repair/ProducaoOficina kanban = 68 Developing)
+- **Protótipo de origem:** [`prototipo-ui/prototipos/producao-oficina/visual-source.html`](../../../../prototipo-ui/prototipos/producao-oficina/visual-source.html)
+
+## Versão
+
+**v0.1** · 2026-05-30 · `draft`. Golden estrutural eleito (OficinaAuto), drifts catalogados, golden IDEAL definido.
+**Bump v1.0** quando golden fechar os 5 drifts + marcar ≥8/10 nas regras binárias.


### PR DESCRIPTION
## O que é

Goldens de arquétipo de tela — fecha parte do gap "só existe PT-01 Lista" que o piloto screen-grade expôs. Agora o Claude Design tem uma **tela-ouro por arquétipo** pra copiar em vez de inventar.

Gerados por 4 agentes especialistas paralelos (ADR 0231), code-first (cada regra ancorada em linha real), honestos sobre drift do golden.

| Pattern | Golden eleito | Por quê / descarte |
|---|---|---|
| **PT-03 Detalhe** | `Sells/Show` | anatomia completa (identidade + KPIs + 2-col defer + ações FSM contextuais + timeline). Descartou Cliente/Show (superseded), Repair/Show (stub), OficinaAuto (V0) |
| **PT-04 Dashboard** | `governance/Dashboard` | KPIs + defer + @/ui + tokens v4. **Anti-golden** Financeiro/Unificado (ilha CSS 8.663 LOC) descartado. `draft` |
| **PT-05 Kanban** | `OficinaAuto/ProducaoOficina` | `@dnd-kit` touch + FSM confirm + token roxo (vs Repair HTML5/blue cru). `draft`/score 68 honesto + golden-ideal definido |
| **PT-02 Form/Drawer** | _(commit seguinte — agente finalizando)_ | candidato Cliente cadastro DS-migrado |

Cada PT tem: golden + justificativa · 8-10 regras binárias sim/não · §Nunca · drift conhecido · "aplicado em".

## Tipo
Docs-only (`memory/requisitos/_DesignSystem/padroes-tela/`). Sem código/UI.

<!-- no-ui-smoke: docs-only -->

https://claude.ai/code/session_01LxrKQrr5SWpjawfNhEqK14

---
_Generated by [Claude Code](https://claude.ai/code/session_01LxrKQrr5SWpjawfNhEqK14)_