### PR TITLE
chore(adr): renumera ADR staging 0235 → 0237 (resolve colisão de número com DS v4 roxo)

### DIFF
--- a/.claude/skills/criar-staging/SKILL.md
+++ b/.claude/skills/criar-staging/SKILL.md
@@ -10,7 +10,7 @@ parent_adr: 0235
 
 > Clone fiel da produção no CT 100 pra equipe **testar sem tocar prod e sem disparar ação real**.
 > **RUNBOOK completo (LER):** [`memory/requisitos/Infra/RUNBOOK-staging-ct100.md`](../../../memory/requisitos/Infra/RUNBOOK-staging-ct100.md)
-> **Artefatos versionados:** [`docker/oimpresso-staging/`](../../../docker/oimpresso-staging/) · **ADR 0235** (emenda à 0062).
+> **Artefatos versionados:** [`docker/oimpresso-staging/`](../../../docker/oimpresso-staging/) · **ADR 0237** (emenda à 0062).
 
 ## Quando ativa
 Pedido tipo "criar/recriar/atualizar/re-seedar staging", "ambiente de homologação", "clone de prod pra teste", OU tocar `docker/oimpresso-staging/**`.

--- a/docker/oimpresso-staging/docker-compose.yml
+++ b/docker/oimpresso-staging/docker-compose.yml
@@ -1,6 +1,6 @@
 # Ambiente de STAGING / HOMOLOGAÇÃO do ERP oimpresso — staging.oimpresso.com
 #
-# ADR 0235 (emenda à 0062): CT 100 passa a servir UM subdomínio web de staging.
+# ADR 0237 (emenda à 0062): CT 100 passa a servir UM subdomínio web de staging.
 # ⚠️ NÃO é produção. Banco SEPARADO (oimpresso_staging) com dados ANONIMIZADOS.
 # ⚠️ Integrações externas NEUTRALIZADAS (mail=log, sem WhatsApp/Asaas/NFe reais).
 #

--- a/docker/oimpresso-staging/entrypoint-staging.sh
+++ b/docker/oimpresso-staging/entrypoint-staging.sh
@@ -3,7 +3,7 @@
 #
 # Cada request boota o framework fresh (igual PHP-FPM do Hostinger) → evita
 # state-leak do UltimatePOS, que NÃO é Octane-safe (singletons/static entre requests).
-# Ver docker/oimpresso-staging/docker-compose.yml + ADR 0235.
+# Ver docker/oimpresso-staging/docker-compose.yml + ADR 0237.
 
 set -e
 cd /var/www/html

--- a/memory/decisions/0237-staging-ct100-clone-anonimizado.md
+++ b/memory/decisions/0237-staging-ct100-clone-anonimizado.md
@@ -1,6 +1,6 @@
 ---
-slug: 0235-staging-ct100-clone-anonimizado
-number: 235
+slug: 0237-staging-ct100-clone-anonimizado
+number: 237
 title: "Ambiente de Staging no CT 100 — clone anonimizado da produção"
 type: adr
 status: aceito
@@ -21,11 +21,15 @@ tags: [infra, staging, ct100, lgpd, anonimizacao, traefik, mariadb, homologacao]
 pii: false
 ---
 
-# ADR 235 — Ambiente de Staging no CT 100: clone anonimizado da produção
+# ADR 237 — Ambiente de Staging no CT 100: clone anonimizado da produção
 
 ## Status
 
-**Aceito** — 2026-05-29 (Wagner autorizado). Implementado na branch `feat/staging-ct100`:
+**Aceito** — 2026-05-29 (Wagner autorizado).
+
+> ⚠️ **Renumerado `0235` → `0237` em 2026-05-30.** Colidia com [`0235-ds-v4-accent-roxo-universal`](0235-ds-v4-accent-roxo-universal.md) — os dois foram aceitos em paralelo no mesmo dia (2026-05-29). Renumerei o **staging** (tinha menos refs inbound) e preservei `0235` pro **DS v4 roxo**. A decisão de conteúdo é **inalterada** — só o número mudou. Conforme [ADR 0236](0236-governanca-evolucao-doc-design.md) (governança: evitar colisão de número) + lição ADR 0180.
+
+Implementado na branch `feat/staging-ct100`:
 artefatos [`docker/oimpresso-staging/`](../../docker/oimpresso-staging/) + [RUNBOOK](../requisitos/Infra/RUNBOOK-staging-ct100.md)
 + skill [`criar-staging`](../../.claude/skills/criar-staging/SKILL.md). `staging.oimpresso.com` no ar, login testado fim-a-fim.
 

--- a/memory/requisitos/Infra/RUNBOOK-staging-ct100.md
+++ b/memory/requisitos/Infra/RUNBOOK-staging-ct100.md
@@ -5,7 +5,7 @@
 > sem tocar produção e sem disparar ação no mundo real.
 >
 > **Construído:** 2026-05-29 (Wagner + Claude). **Artefatos versionados:** [`docker/oimpresso-staging/`](../../../docker/oimpresso-staging/).
-> **Decisão:** ADR 0235 (emenda à [0062](../../decisions/0062-separacao-runtime-hostinger-ct100.md) — CT 100 passa a servir 1 subdomínio web de staging).
+> **Decisão:** ADR 0237 (emenda à [0062](../../decisions/0062-separacao-runtime-hostinger-ct100.md) — CT 100 passa a servir 1 subdomínio web de staging).
 
 ## Arquitetura
 


### PR DESCRIPTION
## Problema
Reavaliação da governança de design (com MCP ativo) pegou **dois ADRs aceitos compartilhando o número 0235** — ambos aceitos em paralelo em 2026-05-29:
- `0235-ds-v4-accent-roxo-universal` (token roxo `primary`)
- `0235-staging-ct100-clone-anonimizado` (staging CT 100)

Qualquer referência a *"ADR 0235"* fica ambígua. É **exatamente a classe de defeito que o [ADR 0236](../blob/main/memory/decisions/0236-governanca-evolucao-doc-design.md) foi criado pra prevenir** ("evitar colisão paralela — lição ADR 0180").

## Fix
Renumera o **staging** → **0237** (tinha menos refs inbound) e **preserva 0235 pro DS v4 roxo** (referenciado por PRE-FLIGHT, INDEX-DESIGN-MEMORIAS, skill screen-grade, related[] do 0236). **Conteúdo da decisão inalterado — só o número.**

- `git mv` 0235-staging → 0237-staging + nota de renumeração transparente no Status
- 4 refs atualizadas: `criar-staging/SKILL.md`, `docker-compose.yml`, `entrypoint-staging.sh`, `RUNBOOK-staging-ct100.md`

## Verificação
- Refs ao slug `0235-staging`: só o próprio arquivo (blast radius pequeno, confirmado por `git grep`).
- Pós-merge: webhook git→MCP re-sincroniza (remove slug antigo, indexa 0237).

🤖 Generated with [Claude Code](https://claude.com/claude-code)