### PR TITLE
docs(design): Design Request Ledger file-based + correção 'Claude Design só lê arquivos'

### DIFF
--- a/memory/decisions/proposals/design-request-ledger-incremental.md
+++ b/memory/decisions/proposals/design-request-ledger-incremental.md
@@ -1,6 +1,6 @@
 ---
 slug: design-request-ledger-incremental
-title: "Design Request Ledger — camada incremental (idempotency key + delta manifest + checkpoint) no MCP"
+title: "Design Request Ledger — camada incremental (idempotency key + delta manifest + checkpoint) em arquivos git"
 type: adr
 status: proposto
 authority: canonical
@@ -9,50 +9,61 @@ decided_by: [W]
 proposed_at: "2026-05-30"
 module: governance
 quarter: 2026-Q2
-tags: [governance, design-system, incremental, idempotency, checkpoint, cdc, mcp, claude-design]
+tags: [governance, design-system, incremental, idempotency, checkpoint, cdc, file-based, git-canon, claude-design]
 related:
   - 0236-governanca-evolucao-doc-design
   - 0233-ativacao-memoria-momento-decisao
+  - 0061-conhecimento-canonico-git-mcp-zero-automem
   - 0053-mcp-server-governanca-como-produto
 authors: [W, C]
 ---
 
-# Proposta — Design Request Ledger (camada incremental)
+# Proposta — Design Request Ledger (camada incremental, file-based)
 
-> **Origem:** Wagner 2026-05-30, fim de sessão. *"se adicionar requisitos técnicos, campos novos, a estrutura deve entender o que mudou e o design não precisar ler tudo... cada pedido deve ter um número e o claude entender que já processou. use o mcp pra melhorar o contexto."*
-> **Continuar com MCP ATIVADO** (esta sessão estava sem MCP conectado — só docs).
+> **Origem:** Wagner 2026-05-30, fim de sessão. *"se adicionar requisitos técnicos, campos novos, a estrutura deve entender o que mudou e o design não precisar ler tudo... cada pedido deve ter um número e o claude entender que já processou."*
+> **Correção 2026-05-30 (Wagner):** *"lembre que no design não tem o MCP. tem que ser arquivos bem organizados."* → **O Claude Design (Cowork) só enxerga ARQUIVOS** (GitHub + file-server), nunca o MCP do oimpresso. Logo o ledger é **arquivo em git**, não tabela no MCP. Ver [feedback-claude-design-so-arquivos](../../reference/feedback-claude-design-so-arquivos.md).
 
 ## Problema
-O sistema de governança de design ([ADR 0236](../0236-governanca-evolucao-doc-design.md) + índice + pré-flight + golden + grade) é o **"o quê"**, mas falta a **incrementalidade**: hoje o Claude Design releria a tela inteira a cada pedido, sem saber o que mudou nem até onde já fez nem se já processou aquele pedido.
+O sistema de governança de design ([ADR 0236](../0236-governanca-evolucao-doc-design.md) + índice + pré-flight + golden + grade) é o **"o quê"**, mas falta a **incrementalidade**: hoje o Claude Design releria a tela inteira a cada pedido, sem saber o que mudou, nem até onde já fez, nem se já processou aquele pedido.
 
-## Proposta — tabela `mcp_design_requests` no MCP (CT 100)
-Cada pedido de design = registro governado idempotente:
+## Proposta — ledger de ARQUIVOS em git (`memory/governance/design-requests/`)
+Cada pedido de design = 1 arquivo `REQ-NNN.md` versionado em git (o Claude Design lê direto):
 ```
-REQ-NNN  (idempotency key — Stripe pattern)
-  status: received → processing → done      # "já processei?" — re-ver REQ done = pula
-  delta_manifest:                            # "o que mudou?" — CDC + traceability matrix
-    - tela / seção / campo afetado + âncora por LINHA real (TraceLLM: localized rewrite)
-  checkpoint:                                # "até onde fiz?" — Temporal/LangGraph
-    - seção: done | untouched (granularidade = 1 seção, nunca no meio)
-  resultado: <hash do diff aplicado>         # retorna igual no retry (Stripe: guarda resultado, não só flag)
-  ttl: 24h pra dedup efêmero (design-state durável é append-only à parte)
+memory/governance/design-requests/
+  LEDGER.md         # índice = o "já processei?" (tabela REQ | tela | status | resultado)
+  REQ-NNN.md        # 1 pedido: frontmatter + delta_manifest + checkpoint + resultado
 ```
-**Fluxo:** pedido → REQ-NNN → consulta ledger MCP → se `done`, pula (idempotente) → senão lê **só o delta ancorado** (não a tela toda) → aplica regra do golden do arquétipo → grava checkpoint + resultado no MCP.
+Campos do `REQ-NNN.md`:
+```
+req: REQ-NNN        (idempotency key — Stripe pattern; nº monotônico = maior REQ na pasta + 1)
+status: received → processing → done     # "já processei?" — REQ done = pula
+delta_manifest:                          # "o que mudou?" — CDC + traceability ancorado por LINHA
+  - tela / seção / campo afetado + âncora por linha real (TraceLLM: localized rewrite)
+checkpoint:                              # "até onde fiz?" — Temporal/LangGraph; 1 seção, nunca no meio
+  - seção: done | untouched
+resultado: <hash/PR do diff aplicado>    # retorna igual no retry (Stripe: guarda resultado, não flag)
+```
+**Fluxo (sem DB):** pedido → próximo `REQ-NNN` → Claude Design lê `LEDGER.md` → se `done`, pula (idempotente) → senão lê **só o delta ancorado** (não a tela toda) → aplica regra do golden do arquétipo → grava checkpoint + resultado no `REQ-NNN.md` + linha no `LEDGER.md`. **Append-only** (REQ não se apaga).
+
+**MCP = só espelho de leitura.** O webhook git→MCP indexa esses arquivos de graça (Claude Code/time buscam via `memoria-search`), mas **nunca é dependência nem canal pro Claude Design** — alinha [ADR 0061](../0061-conhecimento-canonico-git-mcp-zero-automem.md) (git é SSOT, MCP é índice sobre o git).
 
 ## Estado-da-arte (validação + grade da ideia do Wagner)
 | Componente | Padrão SOTA | Nota |
 |---|---|---:|
-| nº de pedido / "já processei" | Idempotency Key (Stripe) — guarda resultado, não flag; TTL | 8/10 |
+| nº de pedido / "já processei" | Idempotency Key (Stripe) — guarda resultado, não só flag | 8/10 |
 | estrutura entende o que mudou | CDC + Requirements Traceability Matrix (TraceLLM/IncreRTL) — delta ancorado por linha | 7/10 |
 | resume de onde parou | Durable execution / checkpoint (Temporal/LangGraph) — entre unidades, não no meio | 8/10 |
-| usar o MCP como contexto | State backend durável (DynamoDB/Redis) — projeto já tem `mcp_*` | 9/10 |
-| **Geral** | a intuição está no nível dos melhores; 20% = mecânica precisa | **80/100** |
+| state backend durável | **git versionado** (não DB) — append-only, auditável, **lido pelo consumidor sem MCP** | 9/10 |
+| **Geral** | a intuição está no nível dos melhores; 20% = mecânica precisa (agora file-based) | **80/100** |
 
-## Próximos passos (sessão com MCP)
-1. Validar com `decisions-search` se já há schema `mcp_design_requests` (anti-dup).
-2. Emenda ao ADR 0236 OU ADR novo + spec da tabela (DDL idempotente, multi-tenant `business_id`).
-3. Skill `design-memoria-reprocess` (gatilhos G1/G2/G3) passa a consumir o ledger.
-4. Time MCP implementa a tabela no CT 100 (mcp.oimpresso.com).
+## Próximos passos
+1. ✅ **Anti-dup confirmado** (`decisions-search`, MCP ativo): não existe `mcp_design_requests` nem ledger prévio.
+2. ✅ **Scaffold de arquivos criado** — `memory/governance/design-requests/{LEDGER,_TEMPLATE-REQ}.md` (este PR).
+3. **Aceitar via emenda ao [ADR 0236](../0236-governanca-evolucao-doc-design.md) OU ADR novo** — formaliza o ledger file-based como mecanismo canon (status hoje: **scaffold pré-ADR**).
+4. Skill `design-memoria-reprocess` (gatilhos G1/G2/G3) passa a abrir/atualizar `REQ-NNN`.
+5. (opcional) `ScreenGradeCommand` grava o `resultado` (nota pós) no REQ quando rodar.
+
+> **Removido da v1:** *"Time MCP implementa a tabela no CT 100"* — desnecessário; é arquivo, eu mesmo crio. O MCP só indexa por webhook.
 
 ## Sources (pesquisa 2026-05-30)
-Stripe idempotent requests · LangGraph durable execution · Diagrid "checkpoints ≠ durable execution" · TraceLLM/IncreRTL (arXiv) traceability incremental.
+Stripe idempotent requests · LangGraph durable execution · Diagrid "checkpoints ≠ durable execution" · TraceLLM/IncreRTL (arXiv) traceability incremental · [ADR 0061](../0061-conhecimento-canonico-git-mcp-zero-automem.md) (git SSOT).

--- a/memory/governance/design-requests/LEDGER.md
+++ b/memory/governance/design-requests/LEDGER.md
@@ -1,0 +1,23 @@
+# Design Request Ledger — registro incremental de pedidos de design (file-based)
+
+> **Pra que serve:** dar a cada pedido de design um número **REQ-NNN** com registro em **arquivo git**,
+> pra o agente saber (a) se **já processou** [idempotência], (b) **o que mudou** [delta manifest],
+> (c) **até onde fez** [checkpoint] — sem reler a tela toda a cada pedido.
+> **Por que arquivo e não MCP:** o **Claude Design (Cowork) só lê arquivos** (GitHub + file-server),
+> nunca o MCP do oimpresso. Ver [feedback-claude-design-so-arquivos](../../reference/feedback-claude-design-so-arquivos.md).
+> **Proposta:** [design-request-ledger-incremental](../../decisions/proposals/design-request-ledger-incremental.md) ·
+> **status: scaffold pré-ADR** (vira mecanismo canon quando aceito via emenda [ADR 0236](../../decisions/0236-governanca-evolucao-doc-design.md) ou ADR novo).
+
+## Como funciona (sem DB)
+1. **Novo pedido** → próximo `REQ-NNN` = maior número nesta pasta + 1 (monotônico).
+2. **Cria** `REQ-NNN.md` a partir de [`_TEMPLATE-REQ.md`](_TEMPLATE-REQ.md).
+3. **Antes de trabalhar** o Claude Design lê a tabela abaixo: REQ `done` = **pula** (idempotente).
+4. **Trabalha** lendo só o `delta_manifest` do REQ (não a tela toda); grava `checkpoint` por seção.
+5. **Fecha** com `status: done` + `resultado` (hash/PR do diff). **Append-only** — REQ nunca se apaga.
+
+## Índice (o "já processei?")
+| REQ | data | tela / arquétipo | status | delta (resumo) | resultado |
+|---|---|---|---|---|---|
+| _(vazio)_ | — | — | — | _o 1º pedido cria `REQ-001`_ | — |
+
+> Atualizar esta tabela faz parte do "pronto" de cada REQ — espelha a regra **"índice = fonte única"** do [ADR 0236](../../decisions/0236-governanca-evolucao-doc-design.md).

--- a/memory/governance/design-requests/_TEMPLATE-REQ.md
+++ b/memory/governance/design-requests/_TEMPLATE-REQ.md
@@ -1,0 +1,26 @@
+---
+req: REQ-NNN
+data: 2026-MM-DD
+tela: <Mod>/<Tela>
+arquetipo: form | lista | dashboard | kanban | detalhe | relatorio | drawer
+persona: <larissa | eliana | tecnico | ...>
+status: received          # received | processing | done
+origem: <handoff / issue / pedido Wagner / nota>
+---
+
+# REQ-NNN — <título curto do pedido>
+
+## Delta manifest — o que mudou (ancorado por LINHA, não a tela toda)
+> Claude Design lê SÓ isto, não relê a tela inteira (TraceLLM: localized rewrite).
+
+- **arquivo:** `resources/js/Pages/<Mod>/<Tela>.tsx`
+  - seção: `<nome>` · linha ~`NNN` · mudança: `<add campo X / trocar Y / ...>`
+
+## Checkpoint — até onde fiz (granularidade = 1 seção, nunca no meio)
+- [ ] `<seção A>` — untouched | processing | done
+- [ ] `<seção B>` — untouched | processing | done
+
+## Resultado
+- **diff:** `<hash do commit / link do PR>`   # retorna igual no retry (idempotente)
+- **grade pós:** `<nota screen-grade, se rodada>`
+- **golden:** `<arquétipo + 10 regras R1-R10 conferidas?>`

--- a/memory/reference/feedback-claude-design-so-arquivos.md
+++ b/memory/reference/feedback-claude-design-so-arquivos.md
@@ -1,0 +1,16 @@
+---
+name: Claude Design só enxerga ARQUIVOS — nunca o MCP
+description: Tudo que o Claude Design (Cowork) consome (golden, pré-flight, índice, método, ledger) tem que ser arquivo git bem organizado; o MCP é do Claude Code/time, o Design não tem acesso
+type: feedback
+---
+O **Claude Design** (Cowork / claude.ai design) opera só sobre **arquivos** — conectores GitHub + file-server. Ele **não tem acesso ao MCP do oimpresso** (`mcp.oimpresso.com`). O MCP é canal do **Claude Code (eu) e do time** (tasks, decisions-search, memoria-search).
+
+**Regra:** qualquer artefato que o Claude Design precise **consumir** — golden de arquétipo, pré-flight resolver, índice-mestre, método screen-grade, **ledger de pedidos de design**, score-as-code — tem que ser **arquivo bem organizado em git**. Pôr isso só numa tabela do MCP = invisível pro agente que faz o design.
+
+**Why:** Wagner 2026-05-30, ao revisar a proposta do Design Request Ledger (que liderava com tabela `mcp_design_requests` no CT 100): *"lembre que no design não tem o MCP. tem que ser arquivos bem organizados."* O handoff #1994 já tinha registrado que a própria sessão de design rodou **sem MCP** (só GitHub + file-server). É estrutural, não circunstancial.
+
+**How to apply:**
+- Ledger de design = **arquivos** (`memory/governance/design-requests/REQ-NNN.md` + `LEDGER.md`), **não** tabela MCP.
+- O webhook git→MCP indexa esses arquivos de graça → Claude Code/time buscam via `memoria-search`. Isso é **espelho de leitura**, nunca dependência nem canal pro Design.
+- Alinha [ADR 0061](../decisions/0061-conhecimento-canonico-git-mcp-zero-automem.md) — git é SSOT, MCP é índice sobre o git.
+- Vale pra qualquer feature futura de governança de design: **arquivo primeiro; MCP só espelha.**

--- a/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
+++ b/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
@@ -60,6 +60,7 @@ Quando duas memórias divergem, vence nesta ordem:
 | Memória | Usar pra |
 |---|---|
 | **SCREEN-GRADE-METODO.md** | nota 16-dim, níveis, score-as-code |
+| [design-requests/LEDGER.md](../../governance/design-requests/LEDGER.md) | ledger incremental de pedidos (REQ-NNN, **file-based**) — checar "já processei?" antes de trabalhar; grava resultado/grade ao fechar · ⚠️ scaffold pré-ADR ([proposta](../../decisions/proposals/design-request-ledger-incremental.md)) |
 | [PRE-MERGE-UI.md](PRE-MERGE-UI.md) | checklist AP1-AP8 antes de merge |
 | `php artisan ui:lint` (R1-R6, CI ratchet) | cor crua, FontAwesome, emoji, PT-01, origens, blade |
 | `ds:report` (regras `ds/*`, ADR 0209) | violações de DS (zero é meta) |
@@ -156,9 +157,10 @@ Sem: CTA WhatsApp cliente-facing · modal full-screen (usar drawer/Sheet) · ing
 ## 7 · Estado do reprocesso (mantido pela skill `design-memoria-reprocess`)
 
 - **last_reprocess:** `2026-05-30` (consolidação inicial — 4 agentes paralelos, ADR 0231)
-- **Como evolui sem quebrar:** ADR proposto [`governanca-evolucao-doc-design`](../../decisions/proposals/governanca-evolucao-doc-design.md) — append-only + ratchet + freshness + 3 gatilhos (G1 incremental / G2 reconciliar / G3 total). Workflow executável: skill [`design-memoria-reprocess`](../../../.claude/skills/design-memoria-reprocess/SKILL.md).
+- **Como evolui sem quebrar:** [ADR 0236](../../decisions/0236-governanca-evolucao-doc-design.md) (aceito 2026-05-30) — append-only + ratchet + freshness + 3 gatilhos (G1 incremental / G2 reconciliar / G3 total). Workflow executável: skill [`design-memoria-reprocess`](../../../.claude/skills/design-memoria-reprocess/SKILL.md).
 
 ### Changelog
 | Data | Gatilho | Mudança |
 |---|---|---|
 | 2026-05-30 | G3 (inicial) | Índice criado: 88 docs revisados, regra de ouro, conflitos reconciliados, positivo+negativo. |
+| 2026-05-30 | G1 | Ledger de pedidos **file-based** (scaffold `governance/design-requests/`) + correção canon "Claude Design = só arquivos, nunca MCP" ([feedback](../../reference/feedback-claude-design-so-arquivos.md)). |


### PR DESCRIPTION
## Contexto
Reavaliação da governança de design **com MCP ativo** + correção do Wagner:
> *"lembre que no design não tem o MCP. tem que ser arquivos bem organizados."*

O **Claude Design (Cowork) só enxerga arquivos** (GitHub + file-server), nunca o MCP do oimpresso. A proposta do Design Request Ledger liderava com **tabela `mcp_design_requests` no CT 100** — que seria **invisível** pro agente que faz o design.

## O que muda
- **Proposta reescrita** ([design-request-ledger-incremental](../blob/docs/design-ledger-file-based/memory/decisions/proposals/design-request-ledger-incremental.md)): `mcp_design_requests` → **ledger de arquivos em git** (`memory/governance/design-requests/`). Mantém os 4 conceitos SOTA (idempotency key / delta manifest / checkpoint / resultado); só muda o backend DB→arquivo.
- **Scaffold criado:** `LEDGER.md` (índice REQ-NNN, o "já processei?") + `_TEMPLATE-REQ.md`.
- **Feedback canon:** `feedback-claude-design-so-arquivos.md` (regra durável: Claude Design = só arquivos; MCP é espelho de leitura via webhook git→MCP, nunca dependência — alinha ADR 0061).
- **INDEX-DESIGN-MEMORIAS:** row do ledger em §2c + changelog G1 + **fix de link stale** (ADR 0236 estava como "proposto" apontando pra `proposals/`, mas já foi **aceito**).

## Status
Ledger = **scaffold pré-ADR**. Formalizar como mecanismo canon = emenda ao ADR 0236 (ou ADR novo) — próximo passo, separado.

## Verificação (MCP ativo)
- Anti-dup: `decisions-search` confirmou que **não existe** `mcp_design_requests` nem ledger prévio.
- Sem código/schema — só docs/scaffold (markdown). Multi-tenant N/A (arquivos git).

🤖 Generated with [Claude Code](https://claude.com/claude-code)