### PR TITLE
test(governance): gate contra colisão de número de ADR + completa registro (11 colisões)

### DIFF
--- a/memory/decisions/_INDEX-LIFECYCLE.md
+++ b/memory/decisions/_INDEX-LIFECYCLE.md
@@ -1,6 +1,6 @@
 ---
 title: Index de Lifecycle das ADRs — pós-triagem 2026-05-06 (refresh 2026-05-09)
-description: Single source of truth pra status de lifecycle das ADRs canon (4 colisões 0101/0102/0119/0195). Aprovado por Wagner em 2026-05-06; Bloco 8 apendado em 2026-05-09; entrada colisão 0195 apendada em 2026-05-27. Tool MCP `decisions-search` filtra por este index.
+description: Single source of truth pra status de lifecycle das ADRs canon (11 colisões de número — ver numbering_collisions + Bloco 11). Aprovado por Wagner em 2026-05-06; Bloco 8 apendado em 2026-05-09; entrada colisão 0195 apendada em 2026-05-27; colisão 0235 + auditoria de 6 colisões históricas apendadas em 2026-05-30. Tool MCP `decisions-search` filtra por este index.
 type: index
 status: aceito
 authority: [Wagner]
@@ -8,7 +8,7 @@ last_reviewed: 2026-05-09
 next_review: 2026-08-09  # trimestral
 total_adrs: 119
 unique_numbers: 116
-numbering_collisions: [0101, 0102, 0119, 0195]  # ADR 0028 não cumprido em 4 casos — pendente housekeeping (ADR 0120). Colisão 0195 adicionada 2026-05-27 (PR #1714 feedback-relevance + PR #1736 tabs-autosave mergeados mesmo dia).
+numbering_collisions: [0101, 0102, 0119, 0126, 0141, 0170, 0178, 0180, 0195, 0216, 0235]  # ADR 0028 não cumprido em 11 casos — pendente housekeeping (ADR 0120). 0195 add 2026-05-27 (PR #1714+#1736). 0235 add 2026-05-30 (PR #1963 roxo + PR #1973 staging; renumber PR #1995 bloqueado pelo gate append-only). 6 colisões históricas (0126/0141/0170×3/0178/0180/0216) surfaçadas + registradas 2026-05-30 pelo novo AdrNumberCollisionTest — ver Bloco 11.
 governance_principle: append-only — ADRs nunca deletadas; lifecycle reflete uso, não validade histórica
 ---
 
@@ -306,3 +306,35 @@ governance_principle: append-only — ADRs nunca deletadas; lifecycle reflete us
 > "Antes de criar pattern novo, faça `git grep` de patterns canon existentes."
 
 Ver [memory/sessions/2026-05-27-diagnostico-hostinger-martinho-biz164.md](../sessions/2026-05-27-diagnostico-hostinger-martinho-biz164.md) pra retrospectiva completa.
+
+---
+
+## Bloco 11 — Apendado 2026-05-30 — colisão 0235 + auditoria completa de colisões (enforçada por teste)
+
+### Colisão 0235 (DS v4 roxo + staging CT 100)
+
+| Numero | Lifecycle | Notas |
+|---|---|---|
+| 0235a | A | **DS v4 — accent roxo universal** (amends ADR 0190) (PR #1963 — 2026-05-29) · slug `0235-ds-v4-accent-roxo-universal` · ⚠️ colisão com 0235b |
+| 0235b | A | **Ambiente staging CT 100 — clone anonimizado** (emenda ADR 0062) (PR #1973 — 2026-05-29) · slug `0235-staging-ct100-clone-anonimizado` · ⚠️ colisão com 0235a |
+
+**Causa:** 2 PRs paralelos no mesmo dia (2026-05-29) numeraram `0235` sem coordenação cross-branch. Ironia: o [ADR 0236](0236-governanca-evolucao-doc-design.md), aceito no dia seguinte, alerta "evitar colisão paralela (lição 0180)" — o defeito já estava em main.
+
+**Renumber rejeitado:** PR #1995 tentou `git mv 0235-staging → 0237` mas o gate `Append-only canon` bloqueou (Constituição Art. 3 + ADR 0095). Wagner decidiu (Tier 0): **documentar, não mutar** — coexistência tech-debt, igual 0195. Ambos VIGENTES.
+
+### Auditoria completa de colisões (2026-05-30) — disparada pelo novo teste
+
+Ao escrever o gate Pest [`AdrNumberCollisionTest`](../../tests/Feature/Memory/AdrNumberCollisionTest.php) (falha se um número colide sem registro AQUI), a varredura surfaçou **6 colisões históricas nunca registradas** — `numbering_collisions` estava em drift com o disco:
+
+| Numero | Arquivos (slugs) |
+|---|---|
+| 0126 | `mcp-jira-projects-modulos-verticais` + `vault-chunked-encryption-sprint-2` |
+| 0141 | `agents-tool-use-pattern-claude-code` + `skill-migracao-blade-react` |
+| 0170 | `bancos-nativos-top5-drivers-separados` + `onda5-simplificada` + `paymentgateway-extracao-camada-cobranca` (×3) |
+| 0178 | `restauracao-campos-fiscais-br-canon` + `sells-unified-tabs-visao-supersede-0136` |
+| 0180 | `drift-numero-adr-0178-conflito-paralelo` + `sidebar-v3-5-grupos-ghosts-header` |
+| 0216 | `deploy-webhook-rodar-composer-dump-autoload` + `governance-drift-framework-driftchecker-plugavel` |
+
+**Achado-chave:** `0180-drift-numero-adr-0178-conflito-paralelo` é uma ADR *sobre* a colisão do 0178 — o time **documentou em prosa** mas **nunca atualizou o registro**, e o próprio 0180 colidiu depois. Prova de que doc-em-prosa não basta: precisa de **registro estruturado + teste**. Os 11 estão agora em `numbering_collisions` e o teste impede a 12ª.
+
+**Política (consolidada):** colisão de número = tech-debt aceito (Constituição append-only proíbe rename retroativo — gate provado em PR #1995). Descoberta: **referencie ADR por slug**, não pelo número cru; `decisions-search` retorna todos os slugs ao filtrar por number. Housekeeping eventual = ADR 0120.

--- a/tests/Feature/Memory/AdrNumberCollisionTest.php
+++ b/tests/Feature/Memory/AdrNumberCollisionTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/**
+ * Governança de docs canônicos — guarda contra COLISÃO de número de ADR.
+ *
+ * Invariante (ADR 0028 — numeração monotônica): cada número de 4 dígitos
+ * `NNNN-*.md` em memory/decisions/ deve identificar UMA única ADR. Quando 2+
+ * arquivos compartilham o mesmo número, isso é uma COLISÃO.
+ *
+ * Por que este teste existe: já houve 5 colisões históricas (0101/0102/0119/
+ * 0195/0235) e NENHUMA foi pega por teste — entraram em main via PRs paralelos
+ * que numeraram igual sem coordenação cross-branch. A 5ª (0235: DS v4 roxo +
+ * staging CT 100, ambos mergeados 2026-05-29) motivou esta camada de enforcement
+ * (pedido Wagner: "testes que garantem que ninguém bagunça").
+ *
+ * Como uma colisão é tolerada: append-only Tier 0 IRREVOGÁVEL (Constituição Art. 3
+ * + ADR 0095) PROÍBE renumerar uma ADR já aceita. Então uma colisão pré-existente
+ * só é aceita se estiver REGISTRADA no frontmatter `numbering_collisions: [...]`
+ * de memory/decisions/_INDEX-LIFECYCLE.md (single source of truth de lifecycle).
+ * Registrar = decisão consciente de carregar o débito; não-registrar = bug.
+ *
+ * O que este teste GARANTE:
+ *   1. Toda colisão presente no disco está registrada em `numbering_collisions`
+ *      — colisão NÃO registrada FALHA o teste (lista número + arquivos).
+ *   2. Todo número listado em `numbering_collisions` realmente colide no disco
+ *      — entrada órfã/stale (número que não tem mais 2+ arquivos) FALHA o teste.
+ *
+ * Teste PURO de arquivo: lê do disco + assert. Sem banco, sem rede, determinístico.
+ * Mecânica espelha AdrFrontmatterLinterTest/AdrFrontmatterTest: base_path() +
+ * glob() + Symfony\Component\Yaml\Yaml.
+ */
+
+use Symfony\Component\Yaml\Yaml;
+
+const COLLISION_ADR_DIR        = 'memory/decisions';
+const COLLISION_LIFECYCLE_FILE = 'memory/decisions/_INDEX-LIFECYCLE.md';
+
+/**
+ * Mapeia número de 4 dígitos -> lista de filenames (sem extensão) que o usam.
+ *
+ * Varre SÓ o nível raiz de memory/decisions/ (glob não é recursivo, então o
+ * subdir proposals/ fica naturalmente de fora — propostas não são ADRs aceitas
+ * e não disputam numeração canon). Casa apenas `^(\d{4})-.*\.md$`; ignora
+ * `_INDEX`/`_SCHEMA`/`_TEMPLATE`/README e qualquer arquivo sem prefixo numérico.
+ *
+ * @return array<string, list<string>>  ex: ['0235' => ['0235-ds-v4-...', '0235-staging-...']]
+ */
+function adrNumerosParaArquivos(): array
+{
+    $base = base_path(COLLISION_ADR_DIR);
+    $arquivos = glob("$base/*.md") ?: [];
+
+    $porNumero = [];
+    foreach ($arquivos as $path) {
+        $nome = basename($path, '.md');
+        // Padrão canon: 4 dígitos + hífen + slug. `_INDEX`, `_SCHEMA`, `_TEMPLATE`,
+        // `README` e afins não casam e são descartados aqui.
+        if (! preg_match('/^(\d{4})-.+$/', $nome, $m)) {
+            continue;
+        }
+        $numero = $m[1]; // mantém zero-padding como string canônica '0235'
+        $porNumero[$numero][] = $nome;
+    }
+
+    return $porNumero;
+}
+
+/**
+ * Lê `numbering_collisions: [...]` do frontmatter de _INDEX-LIFECYCLE.md e
+ * devolve o conjunto de números colisão REGISTRADOS, normalizados pra string
+ * de 4 dígitos com zero-padding.
+ *
+ * Cuidado: YAML coage `[0101, 0102, ...]` pra INTEIROS (101, 102, ...) — o
+ * zero-padding se perde no parse. Por isso re-formatamos com sprintf('%04d').
+ * Aceita também valores já-string ('0101') por robustez.
+ *
+ * @return list<string>  ex: ['0101', '0102', '0119', '0195', '0235']
+ */
+function colisoesRegistradas(): array
+{
+    $path = base_path(COLLISION_LIFECYCLE_FILE);
+    $conteudo = file_get_contents($path);
+
+    if (! preg_match('/^---\s*\n(.*?)\n---\s*\n/s', $conteudo, $m)) {
+        return [];
+    }
+
+    try {
+        $fm = Yaml::parse($m[1]);
+    } catch (\Throwable $e) {
+        return [];
+    }
+
+    $lista = (is_array($fm) && isset($fm['numbering_collisions']) && is_array($fm['numbering_collisions']))
+        ? $fm['numbering_collisions']
+        : [];
+
+    $normalizados = [];
+    foreach ($lista as $valor) {
+        // Extrai só os dígitos (cobre int 101, string '0101', etc.) e re-padroniza.
+        $digitos = preg_replace('/\D/', '', (string) $valor);
+        if ($digitos === '') {
+            continue;
+        }
+        $normalizados[] = sprintf('%04d', (int) $digitos);
+    }
+
+    return array_values(array_unique($normalizados));
+}
+
+it('toda colisão de número de ADR no disco está registrada em _INDEX-LIFECYCLE.numbering_collisions', function () {
+    $porNumero = adrNumerosParaArquivos();
+    $registradas = colisoesRegistradas();
+
+    // Colisão = número usado por 2+ arquivos no nível raiz.
+    $colisoesNoDisco = array_filter($porNumero, fn (array $arquivos) => count($arquivos) >= 2);
+
+    $naoRegistradas = [];
+    foreach ($colisoesNoDisco as $numero => $arquivos) {
+        if (! in_array((string) $numero, $registradas, true)) {
+            sort($arquivos);
+            $naoRegistradas[] = sprintf(
+                'ADR %s colide em %d arquivos: %s',
+                $numero,
+                count($arquivos),
+                implode(', ', array_map(fn ($n) => "$n.md", $arquivos))
+            );
+        }
+    }
+    sort($naoRegistradas);
+
+    expect($naoRegistradas)->toBeEmpty(
+        "Colisão de número de ADR NÃO registrada (ADR 0028 violada).\n" .
+        "Append-only Tier 0 proíbe renumerar ADR aceita — então: registre o número em\n" .
+        "memory/decisions/_INDEX-LIFECYCLE.md no frontmatter `numbering_collisions: [...]`\n" .
+        "OU renumere o arquivo ainda-não-mergeado ANTES do merge.\n  - " .
+        implode("\n  - ", $naoRegistradas)
+    );
+});
+
+it('todo número listado em numbering_collisions realmente colide no disco (sem entrada órfã)', function () {
+    $porNumero = adrNumerosParaArquivos();
+    $registradas = colisoesRegistradas();
+
+    $orfas = [];
+    foreach ($registradas as $numero) {
+        $qtd = isset($porNumero[$numero]) ? count($porNumero[$numero]) : 0;
+        if ($qtd < 2) {
+            $orfas[] = sprintf(
+                'ADR %s está em numbering_collisions mas tem %d arquivo(s) no disco (esperado >= 2)',
+                $numero,
+                $qtd
+            );
+        }
+    }
+    sort($orfas);
+
+    expect($orfas)->toBeEmpty(
+        "Entrada órfã/stale em `numbering_collisions` de _INDEX-LIFECYCLE.md.\n" .
+        "Um número só deve constar ali enquanto a colisão existir no disco.\n" .
+        "Remova a entrada do índice (a colisão foi resolvida) OU confirme que os 2+\n" .
+        "arquivos ainda existem.\n  - " .
+        implode("\n  - ", $orfas)
+    );
+});

--- a/tests/Feature/Memory/AdrNumberCollisionTest.php
+++ b/tests/Feature/Memory/AdrNumberCollisionTest.php
@@ -80,6 +80,9 @@ function colisoesRegistradas(): array
 {
     $path = base_path(COLLISION_LIFECYCLE_FILE);
     $conteudo = file_get_contents($path);
+    if ($conteudo === false) {
+        return [];
+    }
 
     if (! preg_match('/^---\s*\n(.*?)\n---\s*\n/s', $conteudo, $m)) {
         return [];
@@ -98,7 +101,9 @@ function colisoesRegistradas(): array
     $normalizados = [];
     foreach ($lista as $valor) {
         // Extrai só os dígitos (cobre int 101, string '0101', etc.) e re-padroniza.
-        $digitos = preg_replace('/\D/', '', (string) $valor);
+        // is_scalar guard: $valor é mixed (vem do YAML) — evita cast inseguro de array→string.
+        $bruto = is_scalar($valor) ? (string) $valor : '';
+        $digitos = preg_replace('/\D/', '', $bruto) ?? '';
         if ($digitos === '') {
             continue;
         }


### PR DESCRIPTION
## O que é
Resposta à pergunta do Wagner: *"vai ter testes que garantem que ninguém bagunça?"*. Primeiro gate da camada de enforcement da governança de docs.

## Novo gate Pest
`tests/Feature/Memory/AdrNumberCollisionTest.php` — falha se dois `memory/decisions/NNNN-*.md` compartilham número **sem registro** em `_INDEX-LIFECYCLE.numbering_collisions`. Puro de arquivo (sem DB/rede), determinístico, mensagens PT-BR.

## Achado ao escrever o teste 🔴
A varredura surfaçou **6 colisões históricas que NUNCA foram registradas** (o registro estava em drift com o disco):
`0126, 0141, 0170 (×3), 0178, 0180, 0216` — todas ADRs reais distintas.

**Ironia reveladora:** `0180-drift-numero-adr-0178-conflito-paralelo` é uma ADR *sobre* a colisão do 0178 — o time **documentou em prosa** mas **nunca atualizou o registro**, e o próprio 0180 colidiu depois. Prova de que doc-em-prosa não basta: precisa de **registro estruturado + teste**.

## Fix (append-only-safe)
Registra **todas as 11** colisões em `numbering_collisions` + **Bloco 11** documentando a auditoria + a colisão 0235 (renumber bloqueado pela Constituição no [PR #1995](https://github.com/wagnerra23/oimpresso.com/pull/1995); Wagner decidiu **documentar, não mutar**). `_INDEX-LIFECYCLE` é `type:index` — não passa pelo gate append-only.

## Política consolidada
Colisão de número = tech-debt aceito (append-only proíbe rename retroativo). Descoberta por **slug**, não por número cru. Housekeeping eventual = ADR 0120. O teste impede a **12ª**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)