### PR TITLE
test(governance): testes Pest de estrutura dos docs de design (índice fonte-única + ledger)

### DIFF
--- a/tests/Feature/Design/DesignIndexSingleSourceTest.php
+++ b/tests/Feature/Design/DesignIndexSingleSourceTest.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')).
+// NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
+
+/**
+ * Design Index SINGLE-SOURCE GUARD — "índice = fonte única" (ADR 0236).
+ *
+ * O ADR 0236 (governanca-evolucao-doc-design) define a máquina onde TODO doc de
+ * design é apontado pelo índice-mestre `INDEX-DESIGN-MEMORIAS.md`, e esse índice
+ * NUNCA pode ter link quebrado/órfão. Antes deste teste não havia gate — um link
+ * stale (apontando pra `proposals/governanca-evolucao-doc-design.md`, que já virou
+ * o ADR aceito 0236) passou despercebido.
+ *
+ * Invariantes (puras de arquivo — lê disco + assert, SEM banco/business_id/rede):
+ *   (a) HARD — todo link markdown LOCAL relativo dentro do INDEX RESOLVE (o arquivo
+ *       destino existe). Caminhos relativos resolvidos a partir do diretório do INDEX.
+ *       Ignora http(s)://, mailto: e âncoras puras (#...). Falha listando os quebrados.
+ *       (Esta asserção teria pego o link stale.)
+ *   (b) HARD (curado/determinístico) — todo doc CANÔNICO de leitura-obrigatória que o
+ *       próprio INDEX designa (§1 ORDEM DE LEITURA + §2 ÍNDICE POSITIVO) está
+ *       referenciado pelo nome de arquivo em ALGUM lugar do INDEX. Decisão deliberada
+ *       de escopo (ver bloco "DECISÃO (b)" abaixo) — varredura total de órfãos é ruidosa.
+ *
+ * Refs:
+ *   - memory/decisions/0236-governanca-evolucao-doc-design.md
+ *   - memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
+ *   - memory/sessions/2026-05-30-screen-grade-metodo-estado-arte.md
+ *
+ * @group docs
+ * @group design
+ */
+
+// Raiz do repo: este arquivo vive em tests/Feature/Design/ → sobe 3 níveis.
+// Espelha WaveZ2DocumentationGuardTest (resolução por __DIR__, sem depender de base_path()/app bootada).
+const DESIGN_INDEX_ROOT = __DIR__ . '/../../..';
+
+// Caminho relativo (a partir da raiz) do índice-mestre e do seu diretório.
+const DESIGN_INDEX_REL = 'memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md';
+const DESIGN_INDEX_DIR_REL = 'memory/requisitos/_DesignSystem';
+
+/**
+ * DECISÃO (b) — conjunto CURADO em vez de varredura total de órfãos.
+ *
+ * Medição no estado atual (2026-05-30): uma checagem "todo *.md consumível em
+ * prototipo-ui/ + _DesignSystem/ tem que estar no índice" acusa ~24 órfãos
+ * LEGÍTIMOS — templates (BRIEFING-TEMPLATE, CHARTER-TEMPLATE), changelogs, notes
+ * de sessão (COWORK_NOTES.amendment-*, COMPARISON-KB975-*), e vários RUNBOOKs que
+ * o índice cita por brace-expansion (`RUNBOOK-{replicar-prototipo-cowork,onda-cowork,
+ * design-deep,inertia-defer-pattern}.md`) — forma que um grep de basename literal
+ * não casa. Isso tornaria a varredura total RUIDOSA (falha hoje em doc auxiliar
+ * legítimo), violando determinismo.
+ *
+ * Escolha: assertar que o conjunto CANÔNICO que o índice se compromete a apontar
+ * (§1 ORDEM DE LEITURA + §2 ÍNDICE POSITIVO — leitura-obrigatória) está, de fato,
+ * referenciado pelo NOME DE ARQUIVO no índice. É exatamente a garantia "fonte única
+ * aponta pro canon", sem falso-positivo. Cada um destes é citado por basename no
+ * índice HOJE (verificado), então o teste PASSA no estado atual.
+ *
+ * NOTA de precisão: só `PT-01-Lista.md` entra. PT-02..PT-05 EXISTEM como arquivo,
+ * mas o índice (§2b) declara explicitamente que ainda NÃO são goldens e os cita só
+ * por rótulo curto ("PT-02 Form/Drawer"), nunca por filename — incluí-los aqui daria
+ * falso-negativo. Quando virarem canon e forem listados por nome, adicionar à lista.
+ */
+const DESIGN_INDEX_CANON_DOCS = [
+    // §1 ORDEM DE LEITURA (sempre, antes de qualquer tela)
+    'PRE-FLIGHT-TELA.md',
+    'GOLDEN-REFERENCE.md',
+    'REGISTRY_DS_COMPONENTES.md',
+    'LICOES_F3_FINANCEIRO_REJEITADO.md',
+    'SCREEN-GRADE-METODO.md',
+    // §2 ÍNDICE POSITIVO — padrões a copiar / validação
+    'PT-01-Lista.md',
+    'PRE-MERGE-UI.md',
+    'SPEC.md',
+    'framework-15-dimensoes.md',
+    'pageheader-matriz-diferencas.md',
+    'LEDGER.md',
+];
+
+beforeEach(function () {
+    // Skip gracioso quando filesystem do repo não está acessível (CI ephemeral) —
+    // mesmo padrão defensivo do WaveZ2DocumentationGuardTest.
+    if (! is_dir(DESIGN_INDEX_ROOT)) {
+        $this->markTestSkipped('Filesystem do repo não acessível (CI ephemeral).');
+    }
+    if (! is_file(DESIGN_INDEX_ROOT . '/' . DESIGN_INDEX_REL)) {
+        $this->markTestSkipped('INDEX-DESIGN-MEMORIAS.md ausente nesta branch.');
+    }
+});
+
+/**
+ * Lê o conteúdo do índice-mestre.
+ */
+function designIndexContent(): string
+{
+    return (string) file_get_contents(DESIGN_INDEX_ROOT . '/' . DESIGN_INDEX_REL);
+}
+
+/**
+ * Extrai os ALVOS (URL part) de TODOS os links markdown `[texto](alvo)` do índice.
+ * Regex robusto pedido pela tarefa: \[([^\]]+)\]\(([^)]+)\).
+ *
+ * @return string[] lista de alvos crus (na ordem em que aparecem)
+ */
+function designIndexLinkTargets(string $content): array
+{
+    preg_match_all('/\[([^\]]+)\]\(([^)]+)\)/', $content, $matches);
+
+    return $matches[2] ?? [];
+}
+
+/**
+ * Normaliza um caminho relativo resolvendo `.` e `..` SEM tocar o disco
+ * (realpath() falharia/retornaria false pra inexistente — aqui queremos o caminho
+ * candidato pra depois testar file_exists e reportar o que faltou).
+ */
+function designNormalizePath(string $path): string
+{
+    $path = str_replace('\\', '/', $path);
+    $isAbsolute = str_starts_with($path, '/') || (bool) preg_match('#^[A-Za-z]:/#', $path);
+
+    $segments = explode('/', $path);
+    $out = [];
+    foreach ($segments as $seg) {
+        if ($seg === '' || $seg === '.') {
+            continue;
+        }
+        if ($seg === '..') {
+            if (! empty($out) && end($out) !== '..') {
+                array_pop($out);
+            } elseif (! $isAbsolute) {
+                $out[] = '..';
+            }
+
+            continue;
+        }
+        $out[] = $seg;
+    }
+
+    $prefix = $isAbsolute ? (str_starts_with($path, '/') ? '/' : '') : '';
+
+    return $prefix . implode('/', $out);
+}
+
+// ─── (a) HARD — todo link LOCAL relativo RESOLVE ─────────────────────────────
+
+it('(a) HARD: todo link markdown LOCAL do índice resolve (arquivo destino existe)', function () {
+    $content = designIndexContent();
+    $indexDir = DESIGN_INDEX_ROOT . '/' . DESIGN_INDEX_DIR_REL;
+
+    $broken = [];
+    foreach (designIndexLinkTargets($content) as $rawTarget) {
+        $target = trim($rawTarget);
+
+        // Ignora links externos e não-arquivo: http(s)://, mailto:, âncora pura (#...).
+        if (preg_match('#^(https?:)//#i', $target)) {
+            continue;
+        }
+        if (str_starts_with($target, 'mailto:')) {
+            continue;
+        }
+        if (str_starts_with($target, '#')) {
+            continue;
+        }
+
+        // Descarta fragmento de âncora e/ou "title" opcional do destino:
+        //   ../foo.md#secao   ->  ../foo.md
+        //   ../foo.md "Título" ->  ../foo.md
+        $target = preg_split('/\s+/', $target, 2)[0];      // corta ` "title"`
+        $target = explode('#', $target, 2)[0];             // corta `#ancora`
+        $target = trim($target);
+
+        // Após limpar, pode sobrar vazio (ex.: link era só "#") — já tratado acima,
+        // mas guarda defensiva.
+        if ($target === '') {
+            continue;
+        }
+
+        // Resolve relativo ao DIRETÓRIO do índice (regra do ADR 0236).
+        $candidate = designNormalizePath($indexDir . '/' . $target);
+
+        if (! file_exists($candidate)) {
+            $broken[] = $rawTarget;
+        }
+    }
+
+    expect($broken)->toBe(
+        [],
+        "Links LOCAIS quebrados no INDEX-DESIGN-MEMORIAS.md (destino não existe):"
+        . PHP_EOL . '  - ' . implode(PHP_EOL . '  - ', $broken)
+        . PHP_EOL . 'Corrija o link ou crie o arquivo. (ADR 0236: índice = fonte única, zero link órfão.)',
+    );
+});
+
+// ─── (b) HARD (curado) — docs CANÔNICOS estão referenciados no índice ────────
+
+it('(b) HARD: todo doc CANÔNICO de leitura-obrigatória está referenciado no índice (zero órfão canon)', function () {
+    $content = designIndexContent();
+
+    $orphans = [];
+    foreach (DESIGN_INDEX_CANON_DOCS as $basename) {
+        // "Referenciado" = nome do arquivo aparece em ALGUM lugar do texto do índice
+        // (link markdown OU menção em prosa/tabela). str_contains é determinístico e
+        // independe de o índice usar `[texto](path)` ou backticks/prosa.
+        if (! str_contains($content, $basename)) {
+            $orphans[] = $basename;
+        }
+    }
+
+    expect($orphans)->toBe(
+        [],
+        "Docs CANÔNICOS de design NÃO referenciados no índice-mestre (órfãos):"
+        . PHP_EOL . '  - ' . implode(PHP_EOL . '  - ', $orphans)
+        . PHP_EOL . 'Todo doc canon (ordem-de-leitura/índice-positivo) DEVE estar no índice. '
+        . 'Adicione a entrada em INDEX-DESIGN-MEMORIAS.md. (ADR 0236: índice = fonte única.)',
+    );
+});
+
+// ─── Sanidade — o índice e os alvos foram realmente parseados ────────────────
+
+it('SANIDADE: índice tem links markdown e a lista canon não está vazia (guarda anti-regex-quebrado)', function () {
+    $content = designIndexContent();
+    $targets = designIndexLinkTargets($content);
+
+    // Se o regex parar de casar (ex.: alguém reformatar o índice), os HARD acima
+    // passariam vacuamente — esta guarda evita "verde falso".
+    expect(count($targets))->toBeGreaterThan(0, 'Nenhum link markdown extraído do índice (regex quebrou?).');
+    expect(DESIGN_INDEX_CANON_DOCS)->not->toBeEmpty('Lista de docs canônicos vazia.');
+});

--- a/tests/Feature/Design/DesignLedgerIntegrityTest.php
+++ b/tests/Feature/Design/DesignLedgerIntegrityTest.php
@@ -1,0 +1,271 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest test PURO de arquivo — integridade do Design Request Ledger (file-based).
+ *
+ * O Design Request Ledger vive em `memory/governance/design-requests/` (arquivos git,
+ * NÃO MCP — o Claude Design / Cowork só lê arquivos). Estrutura:
+ *   - LEDGER.md          — índice (tabela markdown REQ | data | tela | status | delta | resultado).
+ *   - _TEMPLATE-REQ.md   — molde com placeholders (REQ-NNN, <...>, 2026-MM-DD).
+ *   - REQ-NNN.md         — 1 por pedido (frontmatter req:/status:/... + delta + checkpoint + resultado).
+ *
+ * Camada de ENFORCEMENT — trava o ledger antes de virar zona quando o time MCP entrar.
+ * Invariantes verificadas:
+ *   (a) BIJEÇÃO  — todo REQ-*.md (exceto template) tem linha no LEDGER e vice-versa (match por ID).
+ *   (b) IDENTIDADE — IDs REQ únicos; campo `req:` do frontmatter == nome do arquivo.
+ *   (c) ANTI-VAZAMENTO — nenhum REQ real contém placeholder do template (copiou e esqueceu de preencher).
+ *   (d) VOCABULÁRIO — `status` de cada REQ ∈ {received, processing, done}.
+ *
+ * Estado 2026-05-30: NÃO existe REQ-NNN.md real ainda (só _TEMPLATE-REQ.md + LEDGER vazio).
+ * O teste PASSA vacuamente hoje, MAS protege o futuro. O caso vazio é tratado com elegância
+ * e há asserts que PROVAM que a varredura roda mesmo com 0 REQs (template existe + NÃO conta como REQ).
+ *
+ * Teste determinístico, sem banco / business_id / rede. Mecanismo de frontmatter espelha
+ * tests/Feature/Memory/AdrFrontmatterLinterTest.php (symfony/yaml).
+ *
+ * Refs: memory/governance/design-requests/LEDGER.md
+ *       memory/decisions/proposals/design-request-ledger-incremental.md
+ *       ADR 0236 (governança evolução doc design — "índice = fonte única")
+ */
+
+use Symfony\Component\Yaml\Yaml;
+
+const DESIGN_LEDGER_DIR_REL = 'memory/governance/design-requests';
+
+/** Vocabulário canon do campo `status:` (frontmatter _TEMPLATE-REQ.md linha 7). */
+const REQ_STATUS_VALIDOS = ['received', 'processing', 'done'];
+
+/**
+ * Placeholders do _TEMPLATE-REQ.md que NUNCA podem sobrar num REQ real preenchido.
+ * Pega o caso "copiou o template e esqueceu de trocar <...> / REQ-NNN / data".
+ */
+const REQ_PLACEHOLDERS_PROIBIDOS = [
+    'REQ-NNN',     // id placeholder do template
+    '<',           // qualquer <Mod>/<Tela>, <título curto>, <hash do commit>, ...
+    'YYYY-MM-DD',  // formato de data genérico
+    '2026-MM-DD',  // data placeholder do template (linha 2)
+];
+
+/**
+ * Caminho absoluto da pasta do ledger. `base_path()` resolve worktrees / junctions
+ * (mesmo mecanismo de CockpitPatternConformanceTest + AdrFrontmatterLinterTest).
+ */
+function designLedgerDir(): string
+{
+    return base_path(DESIGN_LEDGER_DIR_REL);
+}
+
+/**
+ * Lista os arquivos REQ REAIS da pasta — `REQ-NNN.md` preenchidos.
+ *
+ * EXCLUI qualquer arquivo começando com `_` (ex: `_TEMPLATE-REQ.md`) — espelha o guard
+ * `str_starts_with($name, '_')` do AdrFrontmatterLinterTest::adrsParaValidar(). Assim o
+ * template (e futuros `_*.md` auxiliares) NUNCA é tratado como REQ real.
+ *
+ * @return array<array{path:string, name:string, id:string, content:string}>
+ *         `id` = nome do arquivo sem extensão (ex: "REQ-001").
+ */
+function designReqsReais(): array
+{
+    $base = designLedgerDir();
+    if (! is_dir($base)) {
+        return [];
+    }
+    $arquivos = glob("$base/REQ-*.md") ?: [];
+
+    $reqs = [];
+    foreach ($arquivos as $path) {
+        $name = basename($path, '.md');
+        // Defesa em profundidade: `_TEMPLATE-REQ.md` já não casa com glob `REQ-*.md`,
+        // mas qualquer `_*.md` auxiliar futuro também não pode contar como REQ real.
+        if (str_starts_with($name, '_')) {
+            continue;
+        }
+        $reqs[] = [
+            'path'    => $path,
+            'name'    => $name,
+            'id'      => $name,
+            'content' => (string) file_get_contents($path),
+        ];
+    }
+    return $reqs;
+}
+
+/**
+ * Extrai o frontmatter YAML entre `---` (idêntico ao extrairFrontmatter do AdrFrontmatterLinterTest).
+ *
+ * @return array{frontmatter:?array, body:string, raw:?string}
+ */
+function extrairFrontmatterReq(string $conteudo): array
+{
+    if (! preg_match('/^---\s*\n(.*?)\n---\s*\n(.*)$/s', $conteudo, $m)) {
+        return ['frontmatter' => null, 'body' => $conteudo, 'raw' => null];
+    }
+    try {
+        $fm = Yaml::parse($m[1]);
+    } catch (\Throwable $e) {
+        return ['frontmatter' => null, 'body' => $m[2], 'raw' => $m[1]];
+    }
+    return ['frontmatter' => is_array($fm) ? $fm : null, 'body' => $m[2], 'raw' => $m[1]];
+}
+
+/**
+ * Lê o LEDGER.md e devolve os IDs REQ-NNN citados na tabela markdown do índice.
+ *
+ * A tabela tem a forma `| REQ-001 | ... |`. Hoje a única linha-dado é `| _(vazio)_ | ... |`
+ * (placeholder de "tabela vazia"), que NÃO casa o padrão REQ-NNN e portanto vira lista vazia.
+ *
+ * @return list<string> IDs únicos preservando ordem de aparição (ex: ["REQ-001", "REQ-002"]).
+ */
+function ledgerReqIds(): array
+{
+    $ledger = designLedgerDir() . '/LEDGER.md';
+    if (! is_file($ledger)) {
+        return [];
+    }
+    $conteudo = (string) file_get_contents($ledger);
+
+    $ids = [];
+    // Casa qualquer "REQ-NNN" (>=1 dígito) dentro de uma célula de tabela markdown.
+    // `\b` evita casar prefixo de "REQ-NNN" placeholder (que tem letras, não dígitos).
+    if (preg_match_all('/\|\s*(REQ-\d+)\b/', $conteudo, $m)) {
+        foreach ($m[1] as $id) {
+            if (! in_array($id, $ids, true)) {
+                $ids[] = $id;
+            }
+        }
+    }
+    return $ids;
+}
+
+// ─── Sanidade da varredura — PROVA que o scan funciona mesmo com 0 REQs ───────────────
+
+it('SCAN: a pasta do ledger e o LEDGER.md existem (pré-condição da governança)', function () {
+    expect(is_dir(designLedgerDir()))->toBeTrue(
+        'Pasta do Design Request Ledger ausente: ' . DESIGN_LEDGER_DIR_REL,
+    );
+    expect(is_file(designLedgerDir() . '/LEDGER.md'))->toBeTrue(
+        'LEDGER.md (índice "já processei?") ausente em ' . DESIGN_LEDGER_DIR_REL,
+    );
+});
+
+it('SCAN: _TEMPLATE-REQ.md existe e NÃO é contado como REQ real (prova o filtro com 0 REQs)', function () {
+    // (1) O molde tem que existir — sem ele não há como abrir REQ novo.
+    expect(is_file(designLedgerDir() . '/_TEMPLATE-REQ.md'))->toBeTrue(
+        '_TEMPLATE-REQ.md (molde de pedido) ausente — não dá pra criar REQ-NNN.',
+    );
+
+    // (2) O template NÃO pode aparecer entre os REQs reais. Este assert sozinho prova que a
+    //     varredura está funcionando mesmo HOJE (0 REQs reais): o filtro `_`-prefix segura o molde.
+    $ids = array_column(designReqsReais(), 'id');
+    expect($ids)->not->toContain('_TEMPLATE-REQ');
+    expect($ids)->not->toContain('TEMPLATE-REQ');
+});
+
+// ─── (a) BIJEÇÃO REQ-file ⇄ linha no LEDGER ───────────────────────────────────────────
+
+it('(a) todo REQ-*.md real tem linha correspondente na tabela do LEDGER.md', function () {
+    $idsLedger = ledgerReqIds();
+    $faltando = [];
+    foreach (designReqsReais() as $req) {
+        if (! in_array($req['id'], $idsLedger, true)) {
+            $faltando[] = $req['id'];
+        }
+    }
+    expect($faltando)->toBeEmpty(
+        'REQ com arquivo mas SEM linha no LEDGER (atualizar a tabela faz parte do "pronto"):'
+        . PHP_EOL . '  - ' . implode(PHP_EOL . '  - ', $faltando),
+    );
+});
+
+it('(a) toda linha REQ-NNN do LEDGER.md tem arquivo REQ-NNN.md correspondente', function () {
+    $idsArquivo = array_column(designReqsReais(), 'id');
+    $orfaos = [];
+    foreach (ledgerReqIds() as $idLedger) {
+        if (! in_array($idLedger, $idsArquivo, true)) {
+            $orfaos[] = $idLedger;
+        }
+    }
+    expect($orfaos)->toBeEmpty(
+        'LEDGER cita REQ que NÃO tem arquivo (linha órfã — append-only quebrado):'
+        . PHP_EOL . '  - ' . implode(PHP_EOL . '  - ', $orfaos),
+    );
+});
+
+// ─── (b) IDENTIDADE — IDs únicos + frontmatter `req:` casa com filename ────────────────
+
+it('(b) IDs REQ são únicos (sem dois arquivos REQ-NNN com mesmo número)', function () {
+    $ids = array_column(designReqsReais(), 'id');
+    $duplicados = array_keys(array_filter(array_count_values($ids), fn ($n) => $n > 1));
+    expect($duplicados)->toBeEmpty(
+        'IDs REQ duplicados na pasta: ' . implode(', ', $duplicados),
+    );
+});
+
+it('(b) campo `req:` do frontmatter de cada REQ bate com o nome do arquivo', function () {
+    $erros = [];
+    foreach (designReqsReais() as $req) {
+        $fm = extrairFrontmatterReq($req['content'])['frontmatter'];
+        if ($fm === null) {
+            $erros[] = "{$req['id']}: sem frontmatter YAML válido (bloco --- ausente ou inválido)";
+            continue;
+        }
+        if (! array_key_exists('req', $fm)) {
+            $erros[] = "{$req['id']}: frontmatter sem campo `req:`";
+            continue;
+        }
+        if ((string) $fm['req'] !== $req['id']) {
+            $erros[] = "{$req['id']}: frontmatter req=`{$fm['req']}` divergente do nome do arquivo";
+        }
+    }
+    expect($erros)->toBeEmpty(
+        'Identidade req:/filename violada:' . PHP_EOL . '  - ' . implode(PHP_EOL . '  - ', $erros),
+    );
+});
+
+// ─── (c) ANTI-VAZAMENTO — nenhum placeholder do template num REQ real ─────────────────
+
+it('(c) nenhum REQ real contém placeholder do template (vazou sem preencher)', function () {
+    $erros = [];
+    foreach (designReqsReais() as $req) {
+        $achados = [];
+        foreach (REQ_PLACEHOLDERS_PROIBIDOS as $placeholder) {
+            if (str_contains($req['content'], $placeholder)) {
+                $achados[] = $placeholder;
+            }
+        }
+        if ($achados !== []) {
+            $erros[] = "{$req['id']}: placeholder(s) não preenchido(s) [" . implode(', ', $achados) . ']';
+        }
+    }
+    expect($erros)->toBeEmpty(
+        'REQ com placeholder do _TEMPLATE-REQ.md (copiou o molde e esqueceu de preencher):'
+        . PHP_EOL . '  - ' . implode(PHP_EOL . '  - ', $erros),
+    );
+});
+
+// ─── (d) VOCABULÁRIO — status ∈ {received, processing, done} ──────────────────────────
+
+it('(d) status de cada REQ está no vocabulário {received, processing, done}', function () {
+    $erros = [];
+    foreach (designReqsReais() as $req) {
+        $fm = extrairFrontmatterReq($req['content'])['frontmatter'];
+        if ($fm === null) {
+            // Frontmatter ausente/ inválido já é reportado em (b); aqui só pula.
+            continue;
+        }
+        if (! array_key_exists('status', $fm)) {
+            $erros[] = "{$req['id']}: frontmatter sem campo `status:`";
+            continue;
+        }
+        if (! in_array($fm['status'], REQ_STATUS_VALIDOS, true)) {
+            $erros[] = "{$req['id']}: status inválido `{$fm['status']}` "
+                . '(use received | processing | done)';
+        }
+    }
+    expect($erros)->toBeEmpty(
+        'Vocabulário de status violado:' . PHP_EOL . '  - ' . implode(PHP_EOL . '  - ', $erros),
+    );
+});


### PR DESCRIPTION
## O que é
Camada de enforcement (pergunta Wagner: *"testes que garantem que ninguém bagunça"*). 2 testes Pest puros-de-arquivo, determinísticos.

## DesignIndexSingleSourceTest
Máquina **"índice = fonte única"** do ADR 0236:
- (a) HARD — todo link markdown local em `INDEX-DESIGN-MEMORIAS.md` **resolve** (pega link quebrado/stale — ex. o `../proposals/governanca-...` que estava stale).
- (b) HARD — os 11 docs canon de leitura-obrigatória estão referenciados no índice (órfão = falha). Conjunto curado (não varredura total) pra evitar falso-positivo de templates/notes — justificado pelo agente.

## DesignLedgerIntegrityTest
Protege o Design Request Ledger file-based (`memory/governance/design-requests/`):
bijeção `REQ-*.md` ⇄ linha no `LEDGER.md`; IDs únicos; `status` válido; **anti-vazamento de placeholder** do template. Trata o caso vazio (0 REQs hoje) com elegância + prova que o `_TEMPLATE` não conta como REQ.

Passam hoje, falham na quebra (cenários validados por injeção pelos agentes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)