### PR TITLE
feat(governance): Scorecard Universal — runner --scope + ThemeScorecard (ADR 0236 onda 3)

### DIFF
--- a/.claude/governance-eval/scorecard.mjs
+++ b/.claude/governance-eval/scorecard.mjs
@@ -1,18 +1,21 @@
 #!/usr/bin/env node
-// GRADE DO CLAUDE DESIGN — Método Governance Scorecard (ADR 0230) aplicado à dimensão DESIGN.
+// RUNNER UNIVERSAL DE SCORECARD — ADR 0236 (Scorecard Universal / blueprint pattern).
 //
-// Responde a pergunta do Wagner (2026-05-30): "O Claude Design já vai me entender?".
-//
-// Lê a rubrica score-as-code de memory/scorecards/design.yaml (fonte de verdade) e:
-//   - pontua cada CAPACIDADE do Claude Design 0-100 vs best-of-class (etapas 1-3 do método);
-//   - ANCORA a nota em evidência objetiva do repo (anti-gaming — conta personas, charters, etc);
-//   - aplica Invariante A (ratchet): nenhuma unidade pode cair abaixo do baseline + cita o porquê;
+// Um motor só lê QUALQUER scorecard score-as-code por --scope <kind>/<nome> e:
+//   - pontua cada unidade 0-100 vs best-of-class (etapas 1-3 do método ADR 0230);
+//   - ANCORA a nota em evidência objetiva do repo (anti-gaming), quando o scope tem checks;
+//   - aplica Invariante A (ratchet): nenhuma unidade cai abaixo do baseline + cita o porquê;
 //   - aplica Invariante B (RTM): cada unidade imprime o `origin` = a memória que a originou;
 //   - aplica paired indicators (cap anti-gaming);
-//   - imprime o veredito + roadmap pro topo (etapa 4).
+//   - imprime o veredito.
 //
-// PROPOSTA — não altera comportamento (não é gate em CI ainda; Wagner aprova antes).
-// Rodar (da raiz do repo):  node .claude/governance-eval/grade-design.mjs
+// Substitui o grade-design.mjs (que era hardcoded num único scope). Os 3 kinds da ADR 0236:
+//   themes/<tema>   → ThemeScorecard (entidade virtual; checks de evidência de path)
+//   modules/<bucket>→ ModuleScorecard (entidade física; futuro: AST/SQL)
+//   governance      → RuleScorecard (regras R1-R12; futuro: casos × hooks — ver grade.mjs)
+//
+// Uso (da raiz do repo):
+//   node .claude/governance-eval/scorecard.mjs --scope themes/claude-design
 // Exit 1 se houver regressão vs baseline (ratchet) ou evidência abaixo do esperado.
 
 import { readFileSync, existsSync, readdirSync, statSync } from 'node:fs';
@@ -21,10 +24,28 @@ import { fileURLToPath } from 'node:url';
 import { parse } from 'yaml';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..', '..');
-const YAML_PATH = join(ROOT, 'memory', 'scorecards', 'design.yaml');
 
+// --- argv: --scope <kind>/<nome> ------------------------------------------
+function parseScope() {
+  const i = process.argv.indexOf('--scope');
+  if (i >= 0 && process.argv[i + 1]) return process.argv[i + 1];
+  // fallback: 1º arg não-flag
+  const a = process.argv.slice(2).find(x => !x.startsWith('--'));
+  return a || null;
+}
+const scope = parseScope();
+if (!scope) {
+  console.error('uso: node .claude/governance-eval/scorecard.mjs --scope <themes|modules|governance>/<nome>');
+  console.error('ex:  node .claude/governance-eval/scorecard.mjs --scope themes/claude-design');
+  process.exit(2);
+}
+const YAML_PATH = join(ROOT, 'memory', 'scorecards', `${scope}.yaml`);
+if (!existsSync(YAML_PATH)) {
+  console.error(`scorecard não encontrado: memory/scorecards/${scope}.yaml`);
+  process.exit(2);
+}
 const doc = parse(readFileSync(YAML_PATH, 'utf8'));
-const U = doc.unidades;
+const U = doc.unidades || {};
 
 // --- helpers de evidência objetiva (ancoragem anti-gaming) ----------------
 const rel = (...p) => join(ROOT, ...p);
@@ -44,7 +65,6 @@ function countPersonas() {
     return n;
   });
 }
-
 function countCharters() {
   return safe(() => {
     const base = rel('resources', 'js');
@@ -64,7 +84,6 @@ function countCharters() {
     return n;
   });
 }
-
 function countAntiPatterns() {
   return safe(() => {
     const f = rel('memory', 'requisitos', '_DesignSystem', 'PRE-MERGE-UI.md');
@@ -74,14 +93,18 @@ function countAntiPatterns() {
   });
 }
 
-// check por unidade: {fn, expect, label}. Unidade sem check = evidência documental.
-const CHECKS = {
-  CD1_compreensao_cliente: { fn: countPersonas, expect: 4, label: 'personas de cliente real (.yml)' },
-  CD3_rubrica_pontuada: { fn: () => existsSync(rel('memory', 'requisitos', '_DesignSystem', 'framework-15-dimensoes.md')) ? 1 : 0, expect: 1, label: 'framework-15-dimensoes.md existe' },
-  CD6_anti_regressao_design: { fn: countAntiPatterns, expect: 8, label: 'anti-padrões AP catalogados (PRE-MERGE-UI)' },
-  CD7_rastreabilidade_rtm: { fn: countCharters, expect: 1, label: 'charters (*.charter.md) no repo' },
-  CD9_metodo_executavel: { fn: () => (existsSync(YAML_PATH) ? 1 : 0) + (existsSync(rel('.claude', 'governance-eval', 'grade-design.mjs')) ? 1 : 0), expect: 2, label: 'design.yaml + grade-design.mjs presentes' },
+// Registro de evidence-checks por scope (anti-gaming). Scope sem registro = sem ancoragem.
+// (Evolução futura — ADR 0236 onda 5: mover os checks pro próprio YAML, score-as-code puro.)
+const EVIDENCE_CHECKS = {
+  'themes/claude-design': {
+    CD1_compreensao_cliente: { fn: countPersonas, expect: 4, label: 'personas de cliente real (.yml)' },
+    CD3_rubrica_pontuada: { fn: () => existsSync(rel('memory', 'requisitos', '_DesignSystem', 'framework-15-dimensoes.md')) ? 1 : 0, expect: 1, label: 'framework-15-dimensoes.md existe' },
+    CD6_anti_regressao_design: { fn: countAntiPatterns, expect: 8, label: 'anti-padrões AP catalogados (PRE-MERGE-UI)' },
+    CD7_rastreabilidade_rtm: { fn: countCharters, expect: 1, label: 'charters (*.charter.md) no repo' },
+    CD9_metodo_executavel: { fn: () => (existsSync(YAML_PATH) ? 1 : 0) + (existsSync(rel('.claude', 'governance-eval', 'scorecard.mjs')) ? 1 : 0), expect: 2, label: 'scorecard YAML + runner scorecard.mjs presentes' },
+  },
 };
+const checks = EVIDENCE_CHECKS[scope] || {};
 
 const levelOf = (n) => (n >= 80 ? 'GOLD' : n >= 50 ? 'SILVER' : 'BRONZE');
 const firstLine = (s) => String(s || '').split('\n').map(x => x.trim()).filter(Boolean)[0] || '';
@@ -91,8 +114,7 @@ const maturities = {};
 for (const [k, u] of Object.entries(U)) maturities[k] = u.maturity;
 const caps = [];
 for (const pi of doc.paired_indicators || []) {
-  // rule no formato: 'se VEL >= X mas QUAL < Y, VEL cap em Z'
-  const m = /se .+ >= (\d+) mas .+ < (\d+), .+ cap em (\d+)/.exec(pi.rule);
+  const m = /se .+ >= (\d+) mas .+ < (\d+), .+ cap em (\d+)/.exec(pi.rule || '');
   if (!m) continue;
   const [X, Y, Z] = [Number(m[1]), Number(m[2]), Number(m[3])];
   if (maturities[pi.velocidade] >= X && maturities[pi.qualidade] < Y) {
@@ -118,7 +140,7 @@ for (const [k, u] of Object.entries(U)) {
   out.push(`    ⚖ anti-regressão (A): ${firstLine(u.justification)}`);
   out.push(`    ↳ origin (B): ${u.origin}`);
 
-  const chk = CHECKS[k];
+  const chk = checks[k];
   if (chk) {
     const val = chk.fn();
     const ok = val >= chk.expect;
@@ -129,15 +151,17 @@ for (const [k, u] of Object.entries(U)) {
   }
   if (u.gaps && u.gaps.length) out.push(`    gap: ${u.gaps[0]}`);
 
-  somaPond += mat * u.peso;
-  somaPeso += u.peso;
+  somaPond += mat * (u.peso || 1);
+  somaPeso += (u.peso || 1);
 }
 
 const agregado = Math.round(somaPond / somaPeso);
+const metaGold = (doc.calculo && doc.calculo.meta_gold) || 80;
+const antes = (doc.calculo && doc.calculo.agregado_antes);
 
 console.log('================================================================');
-console.log(' GRADE DO CLAUDE DESIGN — Método ADR 0230 aplicado a DESIGN');
-console.log(' Pergunta: "O Claude Design já vai me entender?"');
+console.log(` SCORECARD: ${scope}  (kind: ${doc.kind || '?'})  —  ADR 0236 runner universal`);
+if (doc.metadata && doc.metadata.pergunta) console.log(` Pergunta: "${doc.metadata.pergunta}"`);
 console.log('================================================================');
 console.log(out.join('\n'));
 
@@ -147,12 +171,14 @@ if (caps.length) caps.forEach(c => console.log(`   ⚠ ${c}`));
 else console.log('   ✓ todas as parelhas batem (nenhum cap aplicado)');
 
 console.log(`----------------------------------------------------------------`);
-console.log(` AGREGADO: ${agregado}/100 (${levelOf(agregado)})  ·  meta GOLD: ${doc.calculo.meta_gold}  ·  antes da sessão: ${doc.calculo.agregado_antes}`);
+console.log(` AGREGADO: ${agregado}/100 (${levelOf(agregado)})  ·  meta GOLD: ${metaGold}${antes != null ? `  ·  antes: ${antes}` : ''}`);
 console.log(` Regressões (ratchet A): ${regressions}  ·  Evidências abaixo do esperado: ${evidenceFails}`);
-console.log(` Invariante A (ratchet): nenhuma capacidade pode cair abaixo do baseline.`);
-console.log(` Invariante B (RTM): toda capacidade cita origin = a memória do porquê.`);
+console.log(` Invariante A (ratchet): nenhuma unidade pode cair abaixo do baseline.`);
+console.log(` Invariante B (RTM): toda unidade cita origin = a memória do porquê.`);
 console.log(`----------------------------------------------------------------`);
-console.log(` VEREDITO: ${doc.veredito.resposta_curta}`);
-console.log(`----------------------------------------------------------------`);
+if (doc.veredito && doc.veredito.resposta_curta) {
+  console.log(` VEREDITO: ${doc.veredito.resposta_curta}`);
+  console.log(`----------------------------------------------------------------`);
+}
 
 process.exit(regressions > 0 || evidenceFails > 0 ? 1 : 0);

--- a/memory/scorecards/themes/claude-design.yaml
+++ b/memory/scorecards/themes/claude-design.yaml
@@ -7,7 +7,7 @@
 # O lado DESIGN tinha o framework-15-dimensoes.md (já é "nota 0-100 por dimensão ponderada por
 # persona") MAS sem o rigor do ADR 0230: sem score-as-code executável, sem ratchet (Invariante A),
 # sem rastreabilidade origin (Invariante B), sem a etapa "≥3 best-of-class + POR QUÊ" registrada.
-# Este arquivo + .claude/governance-eval/grade-design.mjs fecham esse furo.
+# Este arquivo + .claude/governance-eval/scorecard.mjs (runner universal --scope) fecham esse furo.
 #
 # As unidades pontuáveis aqui NÃO são telas — são as CAPACIDADES do Claude Design, agrupadas
 # pelas 4 etapas + 2 invariantes do próprio método grade. Cada uma pergunta: "isso ajuda o
@@ -16,14 +16,15 @@
 ---
 
 apiVersion: oimpresso.governance/v1
-kind: CapabilityScorecard          # não é ModuleScorecard (0160) nem regra R1-R12 (0230 governança): é capacidade
+kind: ThemeScorecard               # ADR 0236: entidade VIRTUAL/transversal (não módulo, não regra) — tema/capacidade
 metadata:
   scope: claude-design
   metodo: 'ADR 0230 — Método Governance Scorecard aplicado à dimensão DESIGN'
   pergunta: 'O Claude Design já vai me entender?'
   owner: '[W]'                     # Wagner — único aprovador
   cliente_real: 'larissa@rota-livre (biz=4) + jair/kamila/daniela@martinho-cacambas'
-  status: 'proposto'               # baseline inicial — Wagner aprova antes de virar gate
+  status: 'baseline'               # aceito 2026-05-30 (Wagner) — advisory, ainda NÃO é gate CI (ADR 0236)
+  kind_ref: 'ThemeScorecard (ADR 0236) — rodar via: node .claude/governance-eval/scorecard.mjs --scope themes/claude-design'
   baseline_date: 2026-05-30
   proxima_revisao: 2026-08-30      # revisão trimestral (a própria grade tem nota — auto-aprimoramento)
   origin: "sessão 2026-05-30 — Wagner: 'aplique método grade ADR 0230, quero saber se o Claude Design já vai me entender'"
@@ -314,8 +315,8 @@ unidades:
     origin: "sessão 2026-05-30 — Wagner pediu aplicar ADR 0230 ao Claude Design"
     best_of_class: [cortex_opslevel_port]
     evidence:
-      - 'memory/scorecards/design.yaml (este arquivo — score-as-code)'
-      - '.claude/governance-eval/grade-design.mjs (grade executável + ratchet)'
+      - 'memory/scorecards/themes/claude-design.yaml (este arquivo — score-as-code)'
+      - '.claude/governance-eval/scorecard.mjs (runner universal --scope + ratchet)'
     forte: 'Agora o veredito do Claude Design é REPRODUZÍVEL (roda a grade) e versionado por PR.'
     gaps:
       - 'Notas ainda atribuídas pelo método (não AI-driven leitura de telemetria como Cortex MCP).'
@@ -387,7 +388,7 @@ roadmap:
     itens:
       - 'CD1: +personas de novos ramos (gráfica, fiscal) com cliente real + cadência de re-entrevista'
       - 'CD2: teste de regressão "pedido vago foi refinado" (fecha o gap orientação→enforcement)'
-      - 'CD9: plugar grade-design.mjs no CI como gate (Wagner aprova) + tendência AI-driven'
+      - 'CD9: plugar scorecard.mjs no CI como gate (Wagner aprova) + tendência AI-driven'
     ganho_estimado: 'agregado ~80+ (GOLD — "te entende sem repetir")'
 
 # ===========================================================================


### PR DESCRIPTION
## O que é

Implementa a **Onda 3** do [ADR 0236](memory/decisions/0236-scorecard-universal-entidade-arbitraria.md) (aceito agora — `accepted`): o framework de scorecard deixa de ser amarrado a "módulo" e passa a tratar **entidade arbitrária** (blueprint pattern Port).

## Mudanças

- **`design.yaml` → `memory/scorecards/themes/claude-design.yaml`** (`kind: ThemeScorecard`) — 1º tema na gaveta canônica `themes/`.
- **`.claude/governance-eval/scorecard.mjs`** — **runner universal** `--scope <kind>/<nome>`: lê qualquer scorecard YAML, ancora em evidência objetiva, aplica ratchet (Inv. A) + paired indicators + RTM (Inv. B). Absorve o `grade-design.mjs` (git detecta como **rename**, preserva histórico).
- **ADR 0236**: `proposto → accepted`.

## Validação

```
$ node .claude/governance-eval/scorecard.mjs --scope themes/claude-design
AGREGADO: 72/100 (SILVER) · 0 regressões · evidências OK (5 personas, 10 AP, 121 charters) · exit 0
```

Mesmo 72/100 de antes — mas agora por um **motor genérico**, não script hardcoded. Próximo tema (`observability`, `reranker`) roda mudando só o `--scope`.

## Cautela (mantida)

- `module-grade-v4` intacto; temas seguem **advisory** (fora do gate CI) até você promover.
- Governança (`grade.mjs`, R1-R12) vive em outra branch; absorvida no runner numa onda futura (sem colisão agora).

Refs: ADR 0236 (accepted) · ADR 0230 · ADR 0160

🤖 Generated with [Claude Code](https://claude.com/claude-code)
