### PR TITLE
docs(adr): 0239 governança do Design System — regra única (git SSOT + regressão IA)

### DIFF
--- a/.github/workflows/design-index-gate.yml
+++ b/.github/workflows/design-index-gate.yml
@@ -1,0 +1,75 @@
+name: Design index single-source gate
+
+# ADR 0239 R5 + ADR 0236 (índice = fonte única): bloqueia PR que deixe o
+# INDEX-DESIGN-MEMORIAS com link quebrado, doc-canon órfão, OU regra de design
+# (ADR de governança do DS) NÃO referenciada no índice.
+# Teste: tests/Feature/Design/DesignIndexSingleSourceTest.php (file-based, sem DB/rede).
+# Antes deste workflow o teste só rodava local — não gateava PR (gap corrigido 2026-05-30).
+
+on:
+  push:
+    branches: [main, 6.7-react]
+    paths:
+      - 'memory/requisitos/_DesignSystem/**'
+      - 'memory/decisions/**'
+      - 'prototipo-ui/**'
+      - 'tests/Feature/Design/DesignIndexSingleSourceTest.php'
+      - '.github/workflows/design-index-gate.yml'
+  pull_request:
+    paths:
+      - 'memory/requisitos/_DesignSystem/**'
+      - 'memory/decisions/**'
+      - 'prototipo-ui/**'
+      - 'tests/Feature/Design/DesignIndexSingleSourceTest.php'
+      - '.github/workflows/design-index-gate.yml'
+
+concurrency:
+  group: design-index-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: Design index (fonte única)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: mbstring, xml, ctype, json, opentelemetry
+          coverage: none
+          tools: composer:v2
+
+      - name: Cache composer
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-design-index-${{ runner.os }}-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-design-index-${{ runner.os }}-
+
+      - name: Install PHP deps
+        run: composer install --no-interaction --prefer-dist --no-progress --no-scripts
+
+      - name: Prepare storage dirs + .env mínimo
+        run: |
+          mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views storage/logs bootstrap/cache
+          cat > .env <<'EOF'
+          APP_NAME=oimpresso-design-index
+          APP_ENV=testing
+          APP_DEBUG=false
+          APP_URL=http://localhost
+          LOG_CHANNEL=stderr
+          DB_CONNECTION=sqlite
+          DB_DATABASE=:memory:
+          CACHE_DRIVER=array
+          QUEUE_CONNECTION=sync
+          SESSION_DRIVER=array
+          MAIL_MAILER=array
+          EOF
+          php artisan key:generate
+
+      - name: Pest — Design index single-source (a links · b docs-canon · c regras-design)
+        run: vendor/bin/pest tests/Feature/Design/DesignIndexSingleSourceTest.php --no-coverage

--- a/memory/decisions/0239-governanca-design-system-git-ssot-regressao-ia.md
+++ b/memory/decisions/0239-governanca-design-system-git-ssot-regressao-ia.md
@@ -88,7 +88,7 @@ estiver no índice. Ninguém precisa pedir — é **gate, não memória**.
 | R2 fluxo Cowork→Code | loop ADR 0114 + canais `CODE_NOTES`/`COWORK_NOTES`/`SYNC_LOG` | — |
 | R3 regressão-IA | `visual-regression.yml` · skill `screen-grade` · `RagasJudgeService`/`ragas-gate.yml` · `critique-score` (plugin) · `DesignDocsFreshnessChecker` | adicionar trigger por path `design-system.css`/`tokens.css` num `ds-regression-gate.yml` que orquestra os acima |
 | R4 arquivamento | `_arquivo/INDEX.md` + changelog (v1.x) | — (regra operacional; Cowork executa) |
-| R5 índice obrigatório | `INDEX-DESIGN-MEMORIAS.md` + `DesignIndexSingleSourceTest` (inv. c) | — (gate já existe; estendido neste PR) |
+| R5 índice obrigatório | `DesignIndexSingleSourceTest` (inv. c) — teste já existia | **`design-index-gate.yml`** (novo neste PR — antes o teste só rodava local, não gateava PR) |
 
 ## Responsabilidades
 

--- a/memory/decisions/0239-governanca-design-system-git-ssot-regressao-ia.md
+++ b/memory/decisions/0239-governanca-design-system-git-ssot-regressao-ia.md
@@ -1,0 +1,105 @@
+---
+slug: 0239-governanca-design-system-git-ssot-regressao-ia
+number: 239
+title: "Governança do Design System — git é fonte única; mudança flui Cowork→Code→git com regressão julgada por IA; 1 spec vigente na raiz + antigos arquivados"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+proposed_at: "2026-05-30"
+decided_at: "2026-05-30"
+module: governance
+quarter: 2026-Q2
+tier: CANON
+trust_level: tier-0-irrevogavel
+tags: [governance, design-system, ssot, git, regressao, ia-judge, ai-judge, append-only, cowork-loop, claude-design, anti-repeticao]
+related:
+  - 0235-ds-v4-accent-roxo-universal
+  - 0236-governanca-evolucao-doc-design
+  - 0238-soberania-constituicao-wagner
+  - 0237-jana-reconcile-loop-unico
+related_adrs: [0061, 0094, 0107, 0114, 0165, 0216, 0220, "UI-0013"]
+parent_charter: mission.constituicao-v2
+supersedes: []
+authors: [wagner, claude-code]
+---
+
+# ADR 0239 — Governança do Design System (regra única)
+
+> **Status:** ✅ Decidida por Wagner 2026-05-30 ("isso deveria ser uma regra só… crie uma ADR…
+> nunca mais quero repetir isso"). Numerada (0239 · ADR 0028) e portada pro git pelo [CL].
+> **Pendente:** merge em `main` por [W] = ratificação. Enforcement (R3) é wiring de follow-up
+> (compõe ferramentas que já existem — ver Mecanismo); a regra vale na aceitação.
+
+## Contexto
+
+A casa do Design System sujava a cada refino: versões de spec (`Design System v3/v4/v4.2.html`)
+acumulando na raiz, faxinas arquivando **o vigente junto com os velhos** ("cadê o v4?"), e o
+protótipo do Cowork ora sendo tratado como fonte, ora como cópia. Wagner, 2026-05-30, fechou a
+questão: **"nunca mais quero repetir isso"** — vira regra canônica única, não combinado verbal.
+
+Isto **consolida** (não contradiz) ADR 0235 (tokens/roxo + plugin dono da interface), 0236
+(governança de evolução de doc de design), 0114 (loop Cowork) e 0238 (soberania de [W]).
+
+## Decisão — a regra única (4 invariantes)
+
+### R1 · Git é a fonte única do Design System
+`design-system.css` + `tokens.css` em `wagnerra23/oimpresso.com@main` **são** o Design System.
+Tudo mais — protótipo do Cowork, qualquer `Design System vX.html`, showcases, Figma — é
+**derivado/representação**, nunca a fonte. Divergiu do git? O git vence. (ADR 0061, 0235)
+
+### R2 · Mudança de DS flui Cowork→Code→git (Cowork nunca é autoridade)
+Cowork **propõe** (F0) uma evolução do DS; **[CL] Code** aplica na fonte do git via **PR**;
+**[W] mergeia**. Cowork **não** edita, numera nem commita `design-system.css`/`tokens.css`.
+"Enviar pra Code" é obrigatório — não existe DS mudado direto no protótipo virando verdade. (ADR 0238, 0114, 0094)
+
+### R3 · Toda mudança de DS passa por regressão julgada por IA (gate obrigatório)
+PR que toca `design-system.css` ou `tokens.css` **não mergeia** sem passar na **regressão
+julgada por IA** — compõe o que já existe no repo (não inventa ferramenta nova):
+- **Diff visual antes/depois** — `visual-regression.yml` (gate F1.5/F3 · ADR 0107).
+- **IA-juíza nota as telas afetadas** — skill `screen-grade` (0–100, **gate ≥80**) + `critique-score`
+  do Claude Design plugin (≥80), no mesmo padrão LLM-as-judge do `RagasJudgeService`/`ragas-gate.yml`.
+- **Freshness** — `DesignDocsFreshnessChecker` (ADR 0236 máquina-4): nenhum doc cita token aposentado.
+Reprovou qualquer um = **não mergeia**. A nota **só sobe** (ratchet · ADR 0236).
+
+### R4 · Arquivo: 1 spec vigente na raiz; antigos linkados; changelog
+Entre os **specs visuais** (`Design System vX.html`): **exatamente 1 na raiz — o vigente** (hoje
+`Design System v4.html`), ao lado da fonte (`design-system.css`/`tokens.css`). Passados +
+propostas → `_arquivo/ds/` (histórico antigo → `_arquivo/ds-historico/`). No **fim** do
+`_arquivo/INDEX.md`, seção **"## DS — versões antigas (links)"** com 1 link por versão arquivada.
+Troca de vigente = **append-only** (move, não apaga) + 1 linha no **changelog** do INDEX + 1 no `SYNC_LOG`.
+(ADR 0003, 0236)
+
+> **Invariantes (nunca):** nunca 2 specs visuais na raiz · nunca DS mudado sem regressão-IA verde ·
+> nunca Cowork como fonte · nunca delete (append-only).
+
+## Mecanismo (compõe ferramentas existentes)
+
+| Peça da regra | Já existe no repo | Follow-up de wiring |
+|---|---|---|
+| R1 fonte git | `prototipo-ui/design-system.css` + `tokens.css` (espelho da raiz do git) | — |
+| R2 fluxo Cowork→Code | loop ADR 0114 + canais `CODE_NOTES`/`COWORK_NOTES`/`SYNC_LOG` | — |
+| R3 regressão-IA | `visual-regression.yml` · skill `screen-grade` · `RagasJudgeService`/`ragas-gate.yml` · `critique-score` (plugin) · `DesignDocsFreshnessChecker` | adicionar trigger por path `design-system.css`/`tokens.css` num `ds-regression-gate.yml` que orquestra os acima |
+| R4 arquivamento | `_arquivo/INDEX.md` + changelog (v1.x) | — (regra operacional; Cowork executa) |
+
+## Responsabilidades
+
+| Papel | Sobre o DS | Pode | Não pode |
+|---|---|---|---|
+| **[W]** | soberano | aprovar evolução, mergear, definir vigente | — |
+| **[CC] Cowork** | propõe | propor evolução (F0), manter `_arquivo`/changelog, sinalizar drift | editar/numerar/commitar a fonte; ser fonte; 2 specs na raiz |
+| **[CL] Code** | executor | aplicar no git via PR, rodar regressão-IA, abrir PR | mergear sem [W]; mergear com regressão-IA vermelha |
+
+## Consequências
+
+- **Positiva:** acaba a repetição — uma regra só, citável. DS protegido de drift; regressão-IA
+  pega quebra de layout antes do merge; raiz limpa (1 vigente) com histórico acessível por link.
+- **Negativa:** todo PR de token fica mais lento (gate de regressão-IA). **De propósito** — o DS é piso de tudo.
+- **Custo de wiring:** 1 workflow `ds-regression-gate.yml` orquestrando ferramentas que já existem (R3).
+
+## Histórico
+
+| Data | Autor | Mudança |
+|---|---|---|
+| 2026-05-30 | [W] decide + [CL] redige | esta regra única (R1–R4) — "nunca mais repetir" |

--- a/memory/decisions/0239-governanca-design-system-git-ssot-regressao-ia.md
+++ b/memory/decisions/0239-governanca-design-system-git-ssot-regressao-ia.md
@@ -71,8 +71,14 @@ propostas → `_arquivo/ds/` (histórico antigo → `_arquivo/ds-historico/`). N
 Troca de vigente = **append-only** (move, não apaga) + 1 linha no **changelog** do INDEX + 1 no `SYNC_LOG`.
 (ADR 0003, 0236)
 
+### R5 · Toda regra de design mora no índice-mestre (e o teste garante)
+Toda regra/ADR de design — este 0239, mais 0235 (tokens) e 0236 (evolução-doc) — é **referenciada
+no `INDEX-DESIGN-MEMORIAS.md`**. Atualizar o índice é **parte do "pronto"** (ADR 0236), e o
+**`DesignIndexSingleSourceTest` (invariante c) falha o CI** se uma regra de design canônica não
+estiver no índice. Ninguém precisa pedir — é **gate, não memória**.
+
 > **Invariantes (nunca):** nunca 2 specs visuais na raiz · nunca DS mudado sem regressão-IA verde ·
-> nunca Cowork como fonte · nunca delete (append-only).
+> nunca Cowork como fonte · nunca regra de design fora do índice (testado) · nunca delete (append-only).
 
 ## Mecanismo (compõe ferramentas existentes)
 
@@ -82,6 +88,7 @@ Troca de vigente = **append-only** (move, não apaga) + 1 linha no **changelog**
 | R2 fluxo Cowork→Code | loop ADR 0114 + canais `CODE_NOTES`/`COWORK_NOTES`/`SYNC_LOG` | — |
 | R3 regressão-IA | `visual-regression.yml` · skill `screen-grade` · `RagasJudgeService`/`ragas-gate.yml` · `critique-score` (plugin) · `DesignDocsFreshnessChecker` | adicionar trigger por path `design-system.css`/`tokens.css` num `ds-regression-gate.yml` que orquestra os acima |
 | R4 arquivamento | `_arquivo/INDEX.md` + changelog (v1.x) | — (regra operacional; Cowork executa) |
+| R5 índice obrigatório | `INDEX-DESIGN-MEMORIAS.md` + `DesignIndexSingleSourceTest` (inv. c) | — (gate já existe; estendido neste PR) |
 
 ## Responsabilidades
 

--- a/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
+++ b/memory/requisitos/_DesignSystem/INDEX-DESIGN-MEMORIAS.md
@@ -159,8 +159,20 @@ Sem: CTA WhatsApp cliente-facing · modal full-screen (usar drawer/Sheet) · ing
 - **last_reprocess:** `2026-05-30` (consolidação inicial — 4 agentes paralelos, ADR 0231)
 - **Como evolui sem quebrar:** [ADR 0236](../../decisions/0236-governanca-evolucao-doc-design.md) (aceito 2026-05-30) — append-only + ratchet + freshness + 3 gatilhos (G1 incremental / G2 reconciliar / G3 total). Workflow executável: skill [`design-memoria-reprocess`](../../../.claude/skills/design-memoria-reprocess/SKILL.md).
 
+### Regras canônicas de governança do DS (toda regra de design mora aqui)
+
+> **Invariante testada** (`tests/Feature/Design/DesignIndexSingleSourceTest.php` inv. c · ADR 0239 R5): toda regra de design canônica é referenciada NESTE índice — **CI falha se faltar**. Ninguém precisa lembrar de pedir.
+
+| ADR | Regra |
+|---|---|
+| [ADR 0235](../../decisions/0235-ds-v4-accent-roxo-universal.md) | DS v4 — tokens + `primary` roxo `oklch(0.55 0.15 295)` universal; Claude Design plugin dono da interface |
+| [ADR 0236](../../decisions/0236-governanca-evolucao-doc-design.md) | Evolução da doc de design — append-only + índice fonte-única + ratchet + freshness + reprocesso |
+| [ADR 0238](../../decisions/0238-soberania-constituicao-wagner.md) | Soberania de [W] sobre a constituição (memória/numeração) |
+| [ADR 0239](../../decisions/0239-governanca-design-system-git-ssot-regressao-ia.md) | Governança do DS — git SSOT · Cowork→Code · regressão-IA · 1 spec vigente na raiz |
+
 ### Changelog
 | Data | Gatilho | Mudança |
 |---|---|---|
 | 2026-05-30 | G3 (inicial) | Índice criado: 88 docs revisados, regra de ouro, conflitos reconciliados, positivo+negativo. |
 | 2026-05-30 | G1 | Ledger de pedidos **file-based** (scaffold `governance/design-requests/`) + correção canon "Claude Design = só arquivos, nunca MCP" ([feedback](../../reference/feedback-claude-design-so-arquivos.md)). |
+| 2026-05-30 | G1 | **Regras de governança do DS** (0235/0236/0238/0239) referenciadas + invariante (c) no `DesignIndexSingleSourceTest` — "toda regra de design mora no índice" (ADR 0239 R5). |

--- a/tests/Feature/Design/DesignIndexSingleSourceTest.php
+++ b/tests/Feature/Design/DesignIndexSingleSourceTest.php
@@ -80,6 +80,21 @@ const DESIGN_INDEX_CANON_DOCS = [
     'LEDGER.md',
 ];
 
+/**
+ * (c) Regras de design CANÔNICAS (ADRs de governança do DS) que DEVEM estar referenciadas no
+ * índice — ADR 0239 R5 ("toda regra de design mora no índice"). Escopo CURADO e deliberado
+ * (decisão [W] 2026-05-30): só regras de GOVERNANÇA do DS, não UI-ADRs táticas (essas dariam
+ * falso-positivo, igual à decisão de escopo de (b)). Regra de design nova? Adiciona aqui + no índice.
+ * Match por "ADR NNNN" (tolerante a "ADR-NNNN"), a forma que o índice usa pra citar ADR.
+ *
+ * @var string[] números (4 díg.) das ADRs de regra-de-design canônicas
+ */
+const DESIGN_INDEX_CANON_RULE_ADRS = [
+    '0235', // DS v4 — tokens/roxo universal + plugin dono da interface
+    '0236', // governança de evolução da doc de design
+    '0239', // governança do Design System (regra única — git SSOT + regressão-IA + 1 na raiz)
+];
+
 beforeEach(function () {
     // Skip gracioso quando filesystem do repo não está acessível (CI ephemeral) —
     // mesmo padrão defensivo do WaveZ2DocumentationGuardTest.
@@ -219,6 +234,29 @@ it('(b) HARD: todo doc CANÔNICO de leitura-obrigatória está referenciado no �
     );
 });
 
+// ─── (c) HARD (curado) — regras de design canônicas (ADRs) estão no índice ───
+
+it('(c) HARD: toda regra de design canônica (ADR) está referenciada no índice (ADR 0239 R5)', function () {
+    $content = designIndexContent();
+
+    $orphans = [];
+    foreach (DESIGN_INDEX_CANON_RULE_ADRS as $num) {
+        // "Referenciada" = o índice cita a ADR por número ("ADR 0239" / "ADR-0239").
+        // \b evita casar o número dentro de um maior; ADR[ -]? casa a forma usada no índice.
+        if (! preg_match('/\bADR[ -]?' . preg_quote($num, '/') . '\b/', $content)) {
+            $orphans[] = 'ADR ' . $num;
+        }
+    }
+
+    expect($orphans)->toBe(
+        [],
+        'Regras de design CANÔNICAS não referenciadas no índice-mestre (ADR 0239 R5):'
+        . PHP_EOL . '  - ' . implode(PHP_EOL . '  - ', $orphans)
+        . PHP_EOL . 'Toda regra de design (governança do DS) DEVE estar no índice. '
+        . 'Adicione a entrada em INDEX-DESIGN-MEMORIAS.md. (ADR 0239 R5 / ADR 0236: índice = fonte única.)',
+    );
+});
+
 // ─── Sanidade — o índice e os alvos foram realmente parseados ────────────────
 
 it('SANIDADE: índice tem links markdown e a lista canon não está vazia (guarda anti-regex-quebrado)', function () {
@@ -229,4 +267,5 @@ it('SANIDADE: índice tem links markdown e a lista canon não está vazia (guard
     // passariam vacuamente — esta guarda evita "verde falso".
     expect(count($targets))->toBeGreaterThan(0, 'Nenhum link markdown extraído do índice (regex quebrou?).');
     expect(DESIGN_INDEX_CANON_DOCS)->not->toBeEmpty('Lista de docs canônicos vazia.');
+    expect(DESIGN_INDEX_CANON_RULE_ADRS)->not->toBeEmpty('Lista de ADRs-regra de design vazia.');
 });


### PR DESCRIPTION
## Por que

Wagner, 2026-05-30: *"isso deveria ser uma regra só… crie uma ADR se necessário, **nunca mais quero repetir isso**. A fonte da verdade é o git; então se mudar tem que enviar pra Code e testar regressão com IA de julgamento."*

ADR única que consolida a governança do Design System em **4 invariantes** (append-only — 1 arquivo novo, não contradiz nada):

- **R1 · git é a fonte única** — `design-system.css` + `tokens.css` no git **são** o DS; protótipo/HTML/Figma são derivados.
- **R2 · mudança flui Cowork→Code→git** — Cowork propõe, Code aplica via PR, [W] mergeia. Cowork nunca é autoridade da fonte.
- **R3 · regressão julgada por IA é gate obrigatório** — PR que toca o DS só mergeia passando em visual-regression + `screen-grade` (≥80) + critique-score + `DesignDocsFreshnessChecker`. **Compõe o que já existe — não inventa ferramenta.**
- **R4 · 1 spec vigente na raiz** — só o DS atual (v4) na raiz; antigos em `_arquivo/` com lista de links no fim do `INDEX.md` + changelog.

## Notas pro revisor [W]

- `status: aceito` reflete sua decisão; **o merge é a ratificação** (mesmo padrão do 0238).
- **R3 é decisão + composição de ferramentas existentes.** O *enforcement* (um `ds-regression-gate.yml` que dispara por path) é wiring de follow-up — me dá o OK e eu ligo.
- Projeção operacional do R4 (instrução pro Cowork "1 vigente na raiz + links") já te entreguei no chat; posso persistir como `CODE_NOTES` se quiser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)