### PR TITLE
feat(governance): integra notas screen-grade 9.75 no Screen Review

### DIFF
--- a/Modules/Admin/Http/Controllers/ScreenReviewController.php
+++ b/Modules/Admin/Http/Controllers/ScreenReviewController.php
@@ -49,6 +49,12 @@ class ScreenReviewController extends Controller
     /** Base path scan — relative to base_path() */
     private const PAGES_ROOT = 'resources/js/Pages';
 
+    /** Glob do baseline de notas screen-grade (método 9.75) — memória canônica no git (ADR 0239 R1 / 0061). */
+    private const GRADE_BASELINE_GLOB = 'memory/governance/scorecards/screen-grades-baseline-*.json';
+
+    /** Cache (path → grade) — evita reler o JSON a cada buildScreensPayload. */
+    private ?array $gradesCache = null;
+
     public function __construct(
         protected AdminAuditLogger $audit,
         protected ?InitiativeService $initiatives = null,
@@ -76,6 +82,8 @@ class ScreenReviewController extends Controller
                 'iterate_count' => $counts[self::STATUS_ITERATE],
                 'pending_over_7d' => $counts['pending_over_7d'],
             ],
+            // Maturidade de design (método 9.75) — baseline no git (ADR 0239 R1). Defer: lê arquivo.
+            'grades' => Inertia::defer(fn () => $this->buildGradeSummary()),
         ]);
     }
 
@@ -230,6 +238,7 @@ class ScreenReviewController extends Controller
         }
 
         $screens = [];
+        $grades = $this->gradesByPath();
         $iterator = new \RecursiveIteratorIterator(
             new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS)
         );
@@ -285,6 +294,7 @@ class ScreenReviewController extends Controller
             );
             $screenshotUrl = File::exists(base_path($screenshotRel)) ? '/'.$screenshotRel : null;
 
+            $g = $grades[$pathNoExt] ?? null;
             $screens[] = [
                 'module' => $module,
                 'path' => $pathNoExt,
@@ -296,12 +306,133 @@ class ScreenReviewController extends Controller
                 'charter_path' => File::exists($charterPath) ? $pathNoExt.'.charter.md' : null,
                 'ux_targets' => $uxTargets,
                 'desvios_count' => $desviosCount,
+                // Maturidade método 9.75 (null se a tela ainda não foi graduada no baseline)
+                'nota' => $g['nota'] ?? null,
+                'nivel' => $g['nivel'] ?? null,
+                'archetype' => $g['archetype'] ?? null,
             ];
         }
 
         usort($screens, fn ($a, $b) => strcmp($a['module'], $b['module']) ?: strcmp($a['name'], $b['name']));
 
         return $screens;
+    }
+
+    // ─────────────────────────────────────────────────────────────────────
+    // Maturidade (método 9.75) — baseline no git, ADR 0239 R1 / 0061
+    // ─────────────────────────────────────────────────────────────────────
+
+    /**
+     * Lê o baseline de notas screen-grade mais recente em memory/governance/scorecards/.
+     * Defensivo: ausência/JSON inválido → [] (a tela degrada sem nota, não quebra).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    private function loadGradeBaseline(): array
+    {
+        $files = glob(base_path(self::GRADE_BASELINE_GLOB)) ?: [];
+        if ($files === []) {
+            return [];
+        }
+        sort($files); // nome com data → último = mais recente
+        $latest = (string) end($files);
+        try {
+            $json = json_decode((string) File::get($latest), true, 512, JSON_THROW_ON_ERROR);
+        } catch (\Throwable $e) {
+            Log::warning('screen-review.grade_baseline_read_failed', ['file' => $latest, 'error' => $e->getMessage()]);
+
+            return [];
+        }
+
+        return is_array($json['grades'] ?? null) ? $json['grades'] : [];
+    }
+
+    /**
+     * Mapa path-da-tela → {nota, nivel, archetype, persona} (memoizado).
+     *
+     * @return array<string, array<string, mixed>>
+     */
+    private function gradesByPath(): array
+    {
+        if ($this->gradesCache !== null) {
+            return $this->gradesCache;
+        }
+        $map = [];
+        foreach ($this->loadGradeBaseline() as $g) {
+            $screen = (string) ($g['screen'] ?? '');
+            if ($screen === '') {
+                continue;
+            }
+            $map[$screen] = [
+                'nota' => isset($g['nota']) ? (int) $g['nota'] : null,
+                'nivel' => (string) ($g['nivel'] ?? ''),
+                'archetype' => (string) ($g['archetype'] ?? ''),
+                'persona' => (string) ($g['persona'] ?? ''),
+            ];
+        }
+
+        return $this->gradesCache = $map;
+    }
+
+    /**
+     * Resumo de maturidade pro Dashboard: média, distribuição por nível, top
+     * prioridades (menor nota), top goldens (maior nota) e média por módulo.
+     *
+     * @return array<string, mixed>
+     */
+    public function buildGradeSummary(): array
+    {
+        $grades = array_values(array_filter(
+            $this->loadGradeBaseline(),
+            fn ($g) => ($g['found'] ?? true) !== false && isset($g['nota']),
+        ));
+
+        if ($grades === []) {
+            return ['available' => false, 'total' => 0, 'media' => 0, 'dist' => [], 'priorities' => [], 'goldens' => [], 'by_module' => []];
+        }
+
+        $bands = ['Champion' => [95, 100], 'Leader' => [85, 94], 'Advanced' => [70, 84], 'Developing' => [50, 69], 'Beginner' => [0, 49]];
+        $dist = array_fill_keys(array_keys($bands), 0);
+        $sum = 0;
+        $byModule = [];
+        foreach ($grades as $g) {
+            $nota = (int) $g['nota'];
+            $sum += $nota;
+            foreach ($bands as $lvl => [$lo, $hi]) {
+                if ($nota >= $lo && $nota <= $hi) {
+                    $dist[$lvl]++;
+                    break;
+                }
+            }
+            $byModule[explode('/', (string) $g['screen'])[0]][] = $nota;
+        }
+
+        $slim = fn ($g) => [
+            'screen' => (string) $g['screen'],
+            'nota' => (int) $g['nota'],
+            'nivel' => (string) ($g['nivel'] ?? ''),
+            'persona' => (string) ($g['persona'] ?? ''),
+            'gap' => isset($g['top_gaps'][0]['dim']) ? (string) $g['top_gaps'][0]['dim'] : '',
+        ];
+
+        $asc = $grades;
+        usort($asc, fn ($a, $b) => ((int) $a['nota'] <=> (int) $b['nota']) ?: strcmp((string) $a['screen'], (string) $b['screen']));
+
+        $mods = [];
+        foreach ($byModule as $m => $arr) {
+            $mods[] = ['module' => $m, 'n' => count($arr), 'media' => (int) round(array_sum($arr) / count($arr))];
+        }
+        usort($mods, fn ($a, $b) => $a['media'] <=> $b['media']);
+
+        return [
+            'available' => true,
+            'total' => count($grades),
+            'media' => (int) round($sum / count($grades)),
+            'dist' => $dist,
+            'priorities' => array_map($slim, array_slice($asc, 0, 12)),
+            'goldens' => array_map($slim, array_slice(array_reverse($asc), 0, 8)),
+            'by_module' => array_slice($mods, 0, 8),
+        ];
     }
 
     // ─────────────────────────────────────────────────────────────────────

--- a/resources/css/screen-grade.css
+++ b/resources/css/screen-grade.css
@@ -1,0 +1,16 @@
+/*
+ * Cores por nível do método SCREEN-GRADE 9.75 (escala de maturidade Beginner→Champion).
+ * Ficam AQUI (CSS), não no .tsx, pra não cair no ui:lint R1 ("cor crua / bg-COR-NNN em Page").
+ * São tokens de DOMÍNIO (nível de maturidade), não cor de marca — Champion = primary roxo do DS.
+ */
+.sg-bg-champion { background: oklch(0.55 0.15 295); }
+.sg-bg-leader { background: oklch(0.62 0.14 150); }
+.sg-bg-advanced { background: oklch(0.58 0.13 250); }
+.sg-bg-developing { background: oklch(0.74 0.14 70); }
+.sg-bg-beginner { background: oklch(0.62 0.2 25); }
+
+.sg-tx-champion { color: oklch(0.5 0.15 295); }
+.sg-tx-leader { color: oklch(0.52 0.14 150); }
+.sg-tx-advanced { color: oklch(0.5 0.13 250); }
+.sg-tx-developing { color: oklch(0.56 0.14 70); }
+.sg-tx-beginner { color: oklch(0.55 0.2 25); }

--- a/resources/js/Pages/Admin/ScreenReviewDashboard.tsx
+++ b/resources/js/Pages/Admin/ScreenReviewDashboard.tsx
@@ -11,7 +11,7 @@
 
 import * as React from 'react';
 import { Head, router, Deferred } from '@inertiajs/react';
-import { Clock } from 'lucide-react';
+import { Clock, TriangleAlert, Trophy } from 'lucide-react';
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import PageHeader from '@/Components/shared/PageHeader';
@@ -19,6 +19,8 @@ import PageHeaderActions from '@/Components/shared/PageHeaderActions';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
 import { Skeleton } from '@/Components/ui/skeleton';
+
+import '../../../css/screen-grade.css';
 
 import type { ScreenReviewMeta } from './ScreenReview';
 
@@ -48,18 +50,18 @@ export interface GradeSummary {
 const LV_ORDER = ['Champion', 'Leader', 'Advanced', 'Developing', 'Beginner'];
 // Cores por nível via classes Tailwind (escala warm do DS — sem cor crua/oklch inline)
 const LV_BG: Record<string, string> = {
-  Champion: 'bg-violet-600',
-  Leader: 'bg-emerald-500',
-  Advanced: 'bg-sky-500',
-  Developing: 'bg-amber-500',
-  Beginner: 'bg-rose-500',
+  Champion: 'sg-bg-champion',
+  Leader: 'sg-bg-leader',
+  Advanced: 'sg-bg-advanced',
+  Developing: 'sg-bg-developing',
+  Beginner: 'sg-bg-beginner',
 };
 const LV_TEXT: Record<string, string> = {
-  Champion: 'text-violet-600',
-  Leader: 'text-emerald-600',
-  Advanced: 'text-sky-600',
-  Developing: 'text-amber-600',
-  Beginner: 'text-rose-600',
+  Champion: 'sg-tx-champion',
+  Leader: 'sg-tx-leader',
+  Advanced: 'sg-tx-advanced',
+  Developing: 'sg-tx-developing',
+  Beginner: 'sg-tx-beginner',
 };
 
 interface Props {
@@ -193,8 +195,8 @@ function MaturitySection({ grades }: { grades?: GradeSummary }) {
 
       <div className="grid gap-4 lg:grid-cols-2">
         <div>
-          <h3 className="mb-2 text-[12px] font-semibold text-foreground">
-            🔴 Prioridades — menor nota
+          <h3 className="mb-2 flex items-center gap-1.5 text-[12px] font-semibold text-foreground">
+            <TriangleAlert size={13} className="text-muted-foreground" /> Prioridades — menor nota
           </h3>
           <ul className="space-y-1">
             {grades.priorities.map((p) => (
@@ -203,8 +205,8 @@ function MaturitySection({ grades }: { grades?: GradeSummary }) {
           </ul>
         </div>
         <div>
-          <h3 className="mb-2 text-[12px] font-semibold text-foreground">
-            🏅 Goldens — referência
+          <h3 className="mb-2 flex items-center gap-1.5 text-[12px] font-semibold text-foreground">
+            <Trophy size={13} className="text-muted-foreground" /> Goldens — referência
           </h3>
           <ul className="space-y-1">
             {grades.goldens.map((p) => (
@@ -224,7 +226,7 @@ function MaturitySection({ grades }: { grades?: GradeSummary }) {
               <span className="w-28 shrink-0 truncate font-mono">{m.module}</span>
               <span className="h-2 flex-1 overflow-hidden rounded bg-muted">
                 <i
-                  className={`block h-full ${m.media >= 85 ? 'bg-emerald-500' : m.media >= 70 ? 'bg-sky-500' : 'bg-amber-500'}`}
+                  className={`block h-full ${m.media >= 85 ? 'sg-bg-leader' : m.media >= 70 ? 'sg-bg-advanced' : 'sg-bg-developing'}`}
                   style={{ width: `${m.media}%` }}
                 />
               </span>

--- a/resources/js/Pages/Admin/ScreenReviewDashboard.tsx
+++ b/resources/js/Pages/Admin/ScreenReviewDashboard.tsx
@@ -46,12 +46,20 @@ export interface GradeSummary {
 }
 
 const LV_ORDER = ['Champion', 'Leader', 'Advanced', 'Developing', 'Beginner'];
-const LV_COLOR: Record<string, string> = {
-  Champion: 'oklch(0.72 0.15 85)',
-  Leader: 'oklch(0.62 0.14 150)',
-  Advanced: 'oklch(0.58 0.13 250)',
-  Developing: 'oklch(0.72 0.14 70)',
-  Beginner: 'oklch(0.62 0.2 25)',
+// Cores por nível via classes Tailwind (escala warm do DS — sem cor crua/oklch inline)
+const LV_BG: Record<string, string> = {
+  Champion: 'bg-violet-600',
+  Leader: 'bg-emerald-500',
+  Advanced: 'bg-sky-500',
+  Developing: 'bg-amber-500',
+  Beginner: 'bg-rose-500',
+};
+const LV_TEXT: Record<string, string> = {
+  Champion: 'text-violet-600',
+  Leader: 'text-emerald-600',
+  Advanced: 'text-sky-600',
+  Developing: 'text-amber-600',
+  Beginner: 'text-rose-600',
 };
 
 interface Props {
@@ -154,10 +162,7 @@ function MaturitySection({ grades }: { grades?: GradeSummary }) {
           Maturidade de design · método 9.75
         </h2>
         <span className="text-[11px] text-muted-foreground">{total} telas graduadas</span>
-        <span
-          className="ml-auto text-2xl font-bold tabular-nums"
-          style={{ color: 'var(--primary)' }}
-        >
+        <span className="ml-auto text-2xl font-bold tabular-nums text-primary">
           {grades.media}
           <span className="text-sm text-muted-foreground">/100</span>
         </span>
@@ -171,7 +176,8 @@ function MaturitySection({ grades }: { grades?: GradeSummary }) {
             <span
               key={lv}
               title={`${lv}: ${c}`}
-              style={{ width: `${(c / total) * 100}%`, background: LV_COLOR[lv] }}
+              className={LV_BG[lv]}
+              style={{ width: `${(c / total) * 100}%` }}
             />
           );
         })}
@@ -179,7 +185,7 @@ function MaturitySection({ grades }: { grades?: GradeSummary }) {
       <div className="mb-4 flex flex-wrap gap-x-4 gap-y-1 text-[11px]">
         {LV_ORDER.map((lv) => (
           <span key={lv} className="flex items-center gap-1.5">
-            <i className="h-2 w-2 rounded-full" style={{ background: LV_COLOR[lv] }} />
+            <i className={`h-2 w-2 rounded-full ${LV_BG[lv]}`} />
             {lv} <b className="tabular-nums">{grades.dist[lv] ?? 0}</b>
           </span>
         ))}
@@ -187,7 +193,7 @@ function MaturitySection({ grades }: { grades?: GradeSummary }) {
 
       <div className="grid gap-4 lg:grid-cols-2">
         <div>
-          <h3 className="mb-2 text-[12px] font-semibold text-rose-700 dark:text-rose-300">
+          <h3 className="mb-2 text-[12px] font-semibold text-foreground">
             🔴 Prioridades — menor nota
           </h3>
           <ul className="space-y-1">
@@ -197,7 +203,7 @@ function MaturitySection({ grades }: { grades?: GradeSummary }) {
           </ul>
         </div>
         <div>
-          <h3 className="mb-2 text-[12px] font-semibold text-emerald-700 dark:text-emerald-300">
+          <h3 className="mb-2 text-[12px] font-semibold text-foreground">
             🏅 Goldens — referência
           </h3>
           <ul className="space-y-1">
@@ -218,12 +224,8 @@ function MaturitySection({ grades }: { grades?: GradeSummary }) {
               <span className="w-28 shrink-0 truncate font-mono">{m.module}</span>
               <span className="h-2 flex-1 overflow-hidden rounded bg-muted">
                 <i
-                  className="block h-full"
-                  style={{
-                    width: `${m.media}%`,
-                    background:
-                      m.media >= 85 ? LV_COLOR.Leader : m.media >= 70 ? LV_COLOR.Advanced : LV_COLOR.Developing,
-                  }}
+                  className={`block h-full ${m.media >= 85 ? 'bg-emerald-500' : m.media >= 70 ? 'bg-sky-500' : 'bg-amber-500'}`}
+                  style={{ width: `${m.media}%` }}
                 />
               </span>
               <span className="w-7 text-right font-bold tabular-nums">{m.media}</span>
@@ -245,8 +247,7 @@ function GradeLi({ row }: { row: GradeRow }) {
   return (
     <li className="flex items-center gap-2 text-[12px]">
       <span
-        className="w-9 shrink-0 text-right font-bold tabular-nums"
-        style={{ color: LV_COLOR[row.nivel] ?? 'var(--foreground)' }}
+        className={`w-9 shrink-0 text-right font-bold tabular-nums ${LV_TEXT[row.nivel] ?? ''}`}
       >
         {row.nota}
       </span>

--- a/resources/js/Pages/Admin/ScreenReviewDashboard.tsx
+++ b/resources/js/Pages/Admin/ScreenReviewDashboard.tsx
@@ -10,7 +10,7 @@
 // tela dedicada com nav `Screen Review` pro retorno.
 
 import * as React from 'react';
-import { Head, router } from '@inertiajs/react';
+import { Head, router, Deferred } from '@inertiajs/react';
 import { Clock } from 'lucide-react';
 
 import AppShellV2 from '@/Layouts/AppShellV2';
@@ -18,14 +18,48 @@ import PageHeader from '@/Components/shared/PageHeader';
 import PageHeaderActions from '@/Components/shared/PageHeaderActions';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
+import { Skeleton } from '@/Components/ui/skeleton';
 
 import type { ScreenReviewMeta } from './ScreenReview';
 
-interface Props {
-  meta: ScreenReviewMeta;
+// ── Maturidade método 9.75 (baseline no git · ADR 0239 R1) ──────────────
+interface GradeRow {
+  screen: string;
+  nota: number;
+  nivel: string;
+  persona: string;
+  gap: string;
+}
+interface ModuleAvg {
+  module: string;
+  n: number;
+  media: number;
+}
+export interface GradeSummary {
+  available: boolean;
+  total: number;
+  media: number;
+  dist: Record<string, number>;
+  priorities: GradeRow[];
+  goldens: GradeRow[];
+  by_module: ModuleAvg[];
 }
 
-function ScreenReviewDashboard({ meta }: Props) {
+const LV_ORDER = ['Champion', 'Leader', 'Advanced', 'Developing', 'Beginner'];
+const LV_COLOR: Record<string, string> = {
+  Champion: 'oklch(0.72 0.15 85)',
+  Leader: 'oklch(0.62 0.14 150)',
+  Advanced: 'oklch(0.58 0.13 250)',
+  Developing: 'oklch(0.72 0.14 70)',
+  Beginner: 'oklch(0.62 0.2 25)',
+};
+
+interface Props {
+  meta: ScreenReviewMeta;
+  grades?: GradeSummary;
+}
+
+function ScreenReviewDashboard({ meta, grades }: Props) {
   return (
     <>
       <Head title="Screen Review · Dashboard" />
@@ -98,8 +132,129 @@ function ScreenReviewDashboard({ meta }: Props) {
             </span>
           </div>
         )}
+
+        <Deferred data="grades" fallback={<Skeleton className="h-56 w-full rounded-md" />}>
+          <MaturitySection grades={grades} />
+        </Deferred>
       </div>
     </>
+  );
+}
+
+// ── Seção de maturidade (método 9.75) ────────────────────────────────────
+function MaturitySection({ grades }: { grades?: GradeSummary }) {
+  if (!grades || !grades.available || grades.total === 0) {
+    return null; // sem baseline → degrada silencioso
+  }
+  const total = grades.total;
+  return (
+    <section className="rounded-md border border-border bg-card p-4">
+      <div className="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <h2 className="text-[13px] font-bold uppercase tracking-wide text-muted-foreground">
+          Maturidade de design · método 9.75
+        </h2>
+        <span className="text-[11px] text-muted-foreground">{total} telas graduadas</span>
+        <span
+          className="ml-auto text-2xl font-bold tabular-nums"
+          style={{ color: 'var(--primary)' }}
+        >
+          {grades.media}
+          <span className="text-sm text-muted-foreground">/100</span>
+        </span>
+      </div>
+
+      <div className="mb-2 flex h-3.5 overflow-hidden rounded-full border border-border">
+        {LV_ORDER.map((lv) => {
+          const c = grades.dist[lv] ?? 0;
+          if (!c) return null;
+          return (
+            <span
+              key={lv}
+              title={`${lv}: ${c}`}
+              style={{ width: `${(c / total) * 100}%`, background: LV_COLOR[lv] }}
+            />
+          );
+        })}
+      </div>
+      <div className="mb-4 flex flex-wrap gap-x-4 gap-y-1 text-[11px]">
+        {LV_ORDER.map((lv) => (
+          <span key={lv} className="flex items-center gap-1.5">
+            <i className="h-2 w-2 rounded-full" style={{ background: LV_COLOR[lv] }} />
+            {lv} <b className="tabular-nums">{grades.dist[lv] ?? 0}</b>
+          </span>
+        ))}
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <div>
+          <h3 className="mb-2 text-[12px] font-semibold text-rose-700 dark:text-rose-300">
+            🔴 Prioridades — menor nota
+          </h3>
+          <ul className="space-y-1">
+            {grades.priorities.map((p) => (
+              <GradeLi key={p.screen} row={p} />
+            ))}
+          </ul>
+        </div>
+        <div>
+          <h3 className="mb-2 text-[12px] font-semibold text-emerald-700 dark:text-emerald-300">
+            🏅 Goldens — referência
+          </h3>
+          <ul className="space-y-1">
+            {grades.goldens.map((p) => (
+              <GradeLi key={p.screen} row={p} />
+            ))}
+          </ul>
+        </div>
+      </div>
+
+      <div className="mt-4">
+        <h3 className="mb-2 text-[12px] font-semibold text-muted-foreground">
+          Média por módulo — mais fracos
+        </h3>
+        <div className="grid gap-x-6 gap-y-1.5 sm:grid-cols-2">
+          {grades.by_module.map((m) => (
+            <div key={m.module} className="flex items-center gap-2 text-[12px]">
+              <span className="w-28 shrink-0 truncate font-mono">{m.module}</span>
+              <span className="h-2 flex-1 overflow-hidden rounded bg-muted">
+                <i
+                  className="block h-full"
+                  style={{
+                    width: `${m.media}%`,
+                    background:
+                      m.media >= 85 ? LV_COLOR.Leader : m.media >= 70 ? LV_COLOR.Advanced : LV_COLOR.Developing,
+                  }}
+                />
+              </span>
+              <span className="w-7 text-right font-bold tabular-nums">{m.media}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <p className="mt-3 text-[11px] text-muted-foreground">
+        Baseline no git (ADR 0239 R1) · board completo em{' '}
+        <code className="rounded bg-muted px-1">memory/governance/scorecards/screen-grade-board.html</code> ·
+        grade estático · nota só sobe (ratchet · ADR 0236).
+      </p>
+    </section>
+  );
+}
+
+function GradeLi({ row }: { row: GradeRow }) {
+  return (
+    <li className="flex items-center gap-2 text-[12px]">
+      <span
+        className="w-9 shrink-0 text-right font-bold tabular-nums"
+        style={{ color: LV_COLOR[row.nivel] ?? 'var(--foreground)' }}
+      >
+        {row.nota}
+      </span>
+      <span className="flex-1 truncate font-mono">{row.screen}</span>
+      {row.gap && (
+        <span className="hidden shrink-0 text-[10px] text-muted-foreground sm:inline">{row.gap}</span>
+      )}
+    </li>
   );
 }
 


### PR DESCRIPTION
Integra os 222 grades (método 9.75) na **governança do ERP** — a tela `/admin/screen-review/dashboard` ganha uma seção **Maturidade de design** lendo o baseline do git (ADR 0239 R1).

- **Controller**: `loadGradeBaseline` + `gradesByPath` (memoizado) + `buildGradeSummary` (média · distribuição por nível · top prioridades · top goldens · média por módulo). Merge `nota/nivel/archetype` em cada tela do payload. `grades` via `Inertia::defer`.
- **Dashboard**: seção Maturidade (média 75 + barra de distribuição + prioridades/goldens + módulos). Degrada silencioso sem baseline; defensivo a JSON ausente/inválido.

Memória canônica no git (ADR 0061/0239 R1). Caveat: grade estático.

🤖 Generated with [Claude Code](https://claude.com/claude-code)