### PR TITLE
test(whatsapp): autentica user em MacroVariants CRUD-003 (Tier 0 scope)

### DIFF
--- a/Modules/Whatsapp/Tests/Feature/MacroVariantsCrudTest.php
+++ b/Modules/Whatsapp/Tests/Feature/MacroVariantsCrudTest.php
@@ -23,9 +23,56 @@ uses(Tests\TestCase::class);
  * @see memory/requisitos/Whatsapp/SPEC.md US-WA-049
  */
 beforeEach(function () {
-    foreach (['macro_variants', 'macros'] as $t) {
+    foreach ([
+        'macro_variants', 'macros',
+        'model_has_permissions', 'model_has_roles', 'role_has_permissions',
+        'permissions', 'roles', 'users',
+    ] as $t) {
         Schema::dropIfExists($t);
     }
+
+    // ─── Auth scaffold (Tier 0 — CRUD-003) ──────────────────────────────────
+    // O global scope ScopeByBusiness só engaja com `auth()->check()` true
+    // (ADR 0093). CRUD-003 autentica um \App\User real; pra `$user->can(
+    // 'jana.superadmin')` não quebrar, o Gate::before (AuthServiceProvider) roda
+    // `$user->hasRole(...)` e o Spatie lê `permissions` — então as tabelas
+    // mínimas Spatie + users precisam existir. Mesmo scaffold de
+    // AutoLinkContactTest. Tabelas vazias = user comum (não superadmin).
+    Schema::create('permissions', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('name');
+        $table->string('guard_name')->default('web');
+        $table->timestamps();
+    });
+    Schema::create('roles', function ($table) {
+        $table->bigIncrements('id');
+        $table->string('name');
+        $table->string('guard_name')->default('web');
+        $table->timestamps();
+    });
+    Schema::create('role_has_permissions', function ($table) {
+        $table->unsignedBigInteger('permission_id');
+        $table->unsignedBigInteger('role_id');
+    });
+    Schema::create('model_has_permissions', function ($table) {
+        $table->unsignedBigInteger('permission_id');
+        $table->string('model_type');
+        $table->unsignedBigInteger('model_id');
+    });
+    Schema::create('model_has_roles', function ($table) {
+        $table->unsignedBigInteger('role_id');
+        $table->string('model_type');
+        $table->unsignedBigInteger('model_id');
+    });
+    Schema::create('users', function ($table) {
+        $table->increments('id');
+        $table->unsignedInteger('business_id')->nullable();
+        $table->string('email', 100)->nullable();
+        $table->string('username', 100)->nullable();
+        $table->string('password')->nullable();
+        $table->softDeletes();
+        $table->timestamps();
+    });
 
     Schema::create('macros', function ($table) {
         $table->bigIncrements('id');
@@ -155,10 +202,20 @@ it('R-WA-049-CRUD-003 — Tier 0 (ADR 0093): biz=1 não acessa variante de biz=9
     ]);
     $variantAlien->save();
 
-    // Autenticado em biz=1
+    // Autenticado em biz=1 — actingAs com User real engaja o global scope
+    // ScopeByBusiness, que faz `if (! auth()->check()) return;` no topo
+    // (ScopeByBusiness.php). Sem user autenticado o scope NÃO filtra e a row
+    // biz=99 vazaria no count() sem WHERE explícito — exatamente o vazamento
+    // Tier 0 que este teste guarda (ADR 0093).
+    $user = \App\User::create([
+        'business_id' => 1,
+        'email' => 'biz1@macrovariants.test',
+        'username' => 'biz1-mv',
+    ]);
+    $this->actingAs($user);
     session()->put('user.business_id', 1);
 
-    // Listar não enxerga variante alheia
+    // Listar não enxerga variante alheia (global scope filtra business_id=1)
     $count = MacroVariant::query()->count();
     expect($count)->toBe(0);
 


### PR DESCRIPTION
## O que

Conserta o teste `MacroVariantsCrudTest::CRUD-003` (Tier 0 / ADR 0093) que falhava em `expect($count)->toBe(0)` (atual `1`).

## Causa raiz (bug no teste, não em produção)

O teste setava `session('user.business_id', 1)` mas **nunca autenticava** um user. O global scope `ScopeByBusiness` curto-circuita no topo com `if (! auth()->check()) return;` — sem user logado ele **não filtra**, e a row `biz=99` vazava no `MacroVariant::query()->count()` (sem `WHERE` explícito).

**Não há furo de produção:**
- `App\Scopes\BusinessScope` **não existe** — o scope ativo (via trait `HasBusinessScope`) é `Modules\Jana\Scopes\ScopeByBusiness`, o mesmo que o teste referencia → sem mismatch de classe; `withoutGlobalScope(ScopeByBusiness::class)` em CRUD-002 aponta pra classe correta.
- Os controllers têm `->where('business_id', $businessId)` explícito (defesa em profundidade) e requests reais são sempre autenticados.

## Mudança (test-only)

- `beforeEach`: scaffold mínimo `users` + tabelas Spatie (mesmo padrão de `AutoLinkContactTest`) pra `$user->can('jana.superadmin')` não quebrar.
- CRUD-003: cria `\App\User` em `biz=1` + `actingAs` pra o scope engajar.

Nenhum código de produção alterado.

## Teste

```
php artisan test Modules/Whatsapp/Tests/Feature/MacroVariantsCrudTest.php
# Tests: 4 passed (22 assertions)
```

Refs: ADR 0093 (multi-tenant Tier 0 IRREVOGÁVEL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
