### PR TITLE
feat(ds): placar de tarefas vivo (ds:report --write) - Cowork le o pendente

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint": "eslint resources/js --max-warnings=999999",
     "lint:baseline:write": "node scripts/eslint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/eslint-baseline.mjs",
-    "ds:report": "node scripts/ds-report.mjs"
+    "ds:report": "node scripts/ds-report.mjs",
+    "ds:report:write": "node scripts/ds-report.mjs --write"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/prototipo-ui/DS_ADOCAO_INDICE.md
+++ b/prototipo-ui/DS_ADOCAO_INDICE.md
@@ -1,5 +1,29 @@
 # DS — Adoção & Anti-Drift · ÍNDICE
 
+<!-- ds:worklist:start (auto · npm run ds:report -- --write) -->
+## Status da fila — placar de execução (auto)
+
+> Gerado por `npm run ds:report -- --write` · 2026-05-30 21:32 UTC · **total `ds/*` = 558** · fila 0/10 ✅.
+> Derivado do `ds/*` real por módulo: **✅ = 0 (concluído)** · **☐ = pendente**. `[CC]` lê isto (Sync now) pra saber o que `[CL]` JÁ executou e o que falta — sem regerar o já-feito.
+
+| # | Módulo (fila) | `ds/*` | Status |
+|---|---|---:|---|
+| 1 | Sells | 42 | ☐ pendente |
+| 2 | RecurringBilling | 58 | ☐ pendente |
+| 3 | OficinaAuto | 44 | ☐ pendente |
+| 4 | Repair | 14 | ☐ pendente |
+| 5 | Purchase | 19 | ☐ pendente |
+| 6 | Admin | 23 | ☐ pendente |
+| 7 | Whatsapp | 21 | ☐ pendente |
+| 8 | Settings | 18 | ☐ pendente |
+| 9 | Financeiro | 84 | ☐ pendente |
+| 10 | Cliente | 62 | ☐ pendente |
+
+**Fora da fila (pendentes · ordem por contagem):** Atendimento (19) · Ponto (17) · ProjectMgmt (17) · Fiscal (14) · Produto (13) · ads (12) · Jana (10) · governance (10) · StockAdjustment (9) · StockTransfer (9) · kb (7) · MemCofre (6) · NfeBrasil (5) · Site (5) · Home (4) · team-mcp (4) · Compras (3) · TransactionPayment (3) · Modules (2) · ConsultaOs (1) · Nfse (1) · Vestuario (1) · superadmin (1)
+
+**Próximo da fila:** Sells (42)
+<!-- ds:worklist:end -->
+
 > **Origem:** Cowork [CC] · 2026-05-29 · disparado pelo diagnóstico KB-9.75 do cadastro de Contacts
 > **Problema:** a DS cresce mais rápido do que o repo adota. Prova: `Cliente/Create.tsx` hand-rolou `<input type="radio">` **mesmo existindo `@/Components/ui/radio-group.tsx`**. Não foi falta de componente — foi falta de *guard*.
 > **Meta:** fechar o gap DS↔repo **e travar** pra não reabrir — sem comissionar auditoria pra sempre.

--- a/prototipo-ui/PROTOCOL.md
+++ b/prototipo-ui/PROTOCOL.md
@@ -164,13 +164,15 @@ A cada PR mergeado, `[CL]` escreve nos **3 canais que `[CC]` lê via MCP** (webh
 
 | # | Canal | Ação | Conteúdo |
 |---|---|---|---|
-| 1 | `DS_ADOCAO_INDICE.md` | atualiza | a linha do módulo com o `ds/*` novo (o placar) |
+| 1 | `DS_ADOCAO_INDICE.md` | **`npm run ds:report:write`** | regenera o **placar de tarefas** (checklist ✅/☐ por módulo, entre marcadores `ds:worklist`) — derivado do `ds/*` real, é como `[CC]` sabe **o que `[CL]` já executou e o que falta**, sem regerar o já-feito |
 | 2 | `SYNC_LOG.md` | **append** | `YYYY-MM-DD HH:MM [CL] <fase> <módulo> merged · ds/*: <antes>→<depois> · PR #N` |
 | 3 | `HANDOFF.md` | **sobrescreve** | "agora": fase/módulo corrente · próximo da fila · `ds/*` total restante |
 
-Placar canônico: **`npm run ds:report`** (`scripts/ds-report.mjs`) — quebra `ds/*` por **regra × módulo** (o baseline agrega tudo sob `no-restricted-syntax`; este separa). `npm run ds:report -- --json` alimenta o `DS_ADOCAO_INDICE.md` e a dimensão "Adoção DS" do GovernanceV4.
+Placar canônico: **`npm run ds:report`** (`scripts/ds-report.mjs`) — quebra `ds/*` por **regra × módulo** (o baseline agrega tudo sob `no-restricted-syntax`; este separa). Modos:
+- **`npm run ds:report:write`** (= `-- --write`) — regenera o **checklist da fila** no `DS_ADOCAO_INDICE.md` (**✅ = `ds/*`=0 concluído · ☐ = pendente**), derivado do estado real. **Rodar a cada PR** — é o "tarefa concluída" que `[CC]` lê (Sync now) pra não regerar o já-feito.
+- `-- --worklist` mostra só o checklist no stdout · `-- --json` alimenta a dimensão "Adoção DS" do GovernanceV4.
 
-`[CC]` lê esses 3 via MCP e solta a próxima fila — **sem o Wagner copiar status na mão.**
+`[CC]` lê esses 3 via MCP e solta a próxima fila **só do que está ☐** — sem o Wagner copiar status na mão, sem regerar tarefa já concluída.
 
 ### 10.3 Por que git, não chat
 

--- a/scripts/ds-report.mjs
+++ b/scripts/ds-report.mjs
@@ -1,36 +1,49 @@
 #!/usr/bin/env node
 // scripts/ds-report.mjs — placar de adoção do Design System (ds/* por regra × módulo)
+// + checklist da fila (--worklist / --write) que o [CC] Cowork lê pra saber o pendente.
 //
-// O baseline (scripts/eslint-baseline.mjs) agrega TODO ds/* sob `no-restricted-syntax`,
-// então não dá pra ver "quanto falta no módulo X" nem "qual regra domina". Este script
-// roda o mesmo ESLint mas quebra as violações pela MENSAGEM (`ds/no-native-select` …) e
-// pelo módulo (segmento após Pages/ ou Modules/). É o "placar" que o roadmap de adoção
-// referencia: `npm run ds:report` → meta ds/* = 0.
+// O baseline (scripts/eslint-baseline.mjs) agrega TODO ds/* sob `no-restricted-syntax`;
+// este quebra por mensagem (`ds/no-native-select`…) e por módulo. Com `--write`, grava um
+// "placar de tarefas" vivo no DS_ADOCAO_INDICE.md entre marcadores — é o canal §10.2 que o
+// Cowork lê (Sync now) pra saber o que o Code JÁ executou (✅) e o que falta (☐).
 //
 // Uso:
-//   node scripts/ds-report.mjs                 # tabela por regra + por módulo
-//   node scripts/ds-report.mjs --json          # saída JSON (CI / DS_ADOCAO_INDICE.md)
+//   node scripts/ds-report.mjs                 # tabela por regra + módulo
+//   node scripts/ds-report.mjs --json          # JSON (CI / scorecard)
 //   node scripts/ds-report.mjs --module Sells  # filtra um módulo
+//   node scripts/ds-report.mjs --worklist      # checklist da fila (✅/☐) no stdout
+//   node scripts/ds-report.mjs --write         # idem + grava no DS_ADOCAO_INDICE.md
 //
-// Refs: ADR 0209 (ratchet ESLint 9), ADR 0239 (governança DS — git SSOT),
-//       prototipo-ui/DS_ADOCAO_INDICE.md (o placar canônico que isto alimenta).
+// Refs: ADR 0209 (ratchet), ADR 0239 (governança DS git=SSOT), PROTOCOL.md §10.2.
 
 import { execSync } from 'node:child_process';
+import { readFileSync, writeFileSync, existsSync } from 'node:fs';
+import { resolve } from 'node:path';
 
 const TARGET = 'resources/js';
 const AS_JSON = process.argv.includes('--json');
+const AS_WORKLIST = process.argv.includes('--worklist');
+const DO_WRITE = process.argv.includes('--write');
 const modIdx = process.argv.indexOf('--module');
 const ONLY_MODULE = modIdx !== -1 ? process.argv[modIdx + 1] : null;
 
+// Fila canônica de execução (PR-C-WORKLIST.md — módulo = ID, "C#" deprecado).
+// Ordem = prioridade de migração. ✅ quando ds/*=0 nesse módulo (todas as fases limpas).
+const WORKLIST = [
+  'Sells', 'RecurringBilling', 'OficinaAuto', 'Repair', 'Purchase',
+  'Admin', 'Whatsapp', 'Settings', 'Financeiro', 'Cliente',
+];
+
+const INDICE_PATH = resolve(process.cwd(), 'prototipo-ui/DS_ADOCAO_INDICE.md');
+const MARK_START = '<!-- ds:worklist:start (auto · npm run ds:report -- --write) -->';
+const MARK_END = '<!-- ds:worklist:end -->';
+
 function runEslint() {
-  // Windows: npx é .cmd → shell:true. ESLint sai 1 quando há warnings/erros, mas stdout é JSON válido.
   const cmd = `npx --no-install eslint "${TARGET}" --format=json --max-warnings=999999`;
   try {
     return JSON.parse(execSync(cmd, {
-      encoding: 'utf8',
-      maxBuffer: 100 * 1024 * 1024,
-      stdio: ['ignore', 'pipe', 'ignore'],
-      shell: true,
+      encoding: 'utf8', maxBuffer: 100 * 1024 * 1024,
+      stdio: ['ignore', 'pipe', 'ignore'], shell: true,
     }));
   } catch (err) {
     if (err.stdout) return JSON.parse(err.stdout);
@@ -38,71 +51,106 @@ function runEslint() {
   }
 }
 
-const RULE_RE = /^(ds\/[a-z0-9-]+)/; // a message começa com o pseudo-rule "ds/no-..."
-
+const RULE_RE = /^(ds\/[a-z0-9-]+)/;
 function moduleOf(path) {
-  const p = path.replace(/\\/g, '/');
-  const m = p.match(/\/(?:Pages|Modules)\/([^/]+)/);
+  const m = path.replace(/\\/g, '/').match(/\/(?:Pages|Modules)\/([^/]+)/);
   return m ? m[1] : '(outros)';
 }
 
-function main() {
+function collect() {
   const cwd = process.cwd().replace(/\\/g, '/');
   const results = runEslint();
-
-  const byRule = {};
-  const byModule = {};
-  const byModuleRule = {};
+  const byRule = {}, byModule = {}, byModuleRule = {};
   let total = 0;
-
   for (const result of results) {
     const path = result.filePath.replace(/\\/g, '/').replace(`${cwd}/`, '');
     const mod = moduleOf(path);
     if (ONLY_MODULE && mod.toLowerCase() !== ONLY_MODULE.toLowerCase()) continue;
     for (const msg of result.messages) {
       const mm = (msg.message || '').match(RULE_RE);
-      if (!mm) continue; // só conta ds/*
-      const rule = mm[1];
-      byRule[rule] = (byRule[rule] || 0) + 1;
+      if (!mm) continue;
+      byRule[mm[1]] = (byRule[mm[1]] || 0) + 1;
       byModule[mod] = (byModule[mod] || 0) + 1;
-      byModuleRule[`${mod}|${rule}`] = (byModuleRule[`${mod}|${rule}`] || 0) + 1;
+      byModuleRule[`${mod}|${mm[1]}`] = (byModuleRule[`${mod}|${mm[1]}`] || 0) + 1;
       total++;
     }
   }
+  return { total, byRule, byModule, byModuleRule };
+}
 
-  if (AS_JSON) {
-    console.log(JSON.stringify(
-      { total, byRule, byModule, byModuleRule, generated_at: new Date().toISOString() },
-      null, 2,
-    ));
-    return;
+// markdown do checklist — a "fila viva" que o [CC] lê pra saber o pendente
+function worklistMarkdown({ total, byModule }) {
+  const stamp = new Date().toISOString().slice(0, 16).replace('T', ' ') + ' UTC';
+  const done = WORKLIST.filter((m) => (byModule[m] || 0) === 0).length;
+  const L = [];
+  L.push(MARK_START);
+  L.push('## Status da fila — placar de execução (auto)');
+  L.push('');
+  L.push(`> Gerado por \`npm run ds:report -- --write\` · ${stamp} · **total \`ds/*\` = ${total}** · fila ${done}/${WORKLIST.length} ✅.`);
+  L.push('> Derivado do `ds/*` real por módulo: **✅ = 0 (concluído)** · **☐ = pendente**. `[CC]` lê isto (Sync now) pra saber o que `[CL]` JÁ executou e o que falta — sem regerar o já-feito.');
+  L.push('');
+  L.push('| # | Módulo (fila) | `ds/*` | Status |');
+  L.push('|---|---|---:|---|');
+  WORKLIST.forEach((mod, i) => {
+    const n = byModule[mod] || 0;
+    L.push(`| ${i + 1} | ${mod} | ${n} | ${n === 0 ? '✅ concluído' : '☐ pendente'} |`);
+  });
+  const extras = Object.entries(byModule)
+    .filter(([m, n]) => n > 0 && !WORKLIST.includes(m) && m !== '(outros)')
+    .sort((a, b) => b[1] - a[1]);
+  if (extras.length) {
+    L.push('');
+    L.push('**Fora da fila (pendentes · ordem por contagem):** ' +
+      extras.map(([m, n]) => `${m} (${n})`).join(' · '));
   }
+  const next = WORKLIST.find((m) => (byModule[m] || 0) > 0);
+  L.push('');
+  L.push(`**Próximo da fila:** ${next ? `${next} (${byModule[next]})` : '— tudo zerado 🎉'}`);
+  L.push(MARK_END);
+  return L.join('\n');
+}
 
+function writeIndice(md) {
+  if (!existsSync(INDICE_PATH)) { console.error(`nao achei ${INDICE_PATH}`); process.exit(1); }
+  let txt = readFileSync(INDICE_PATH, 'utf8');
+  const esc = (s) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (txt.includes(MARK_START) && txt.includes(MARK_END)) {
+    txt = txt.replace(new RegExp(`${esc(MARK_START)}[\\s\\S]*?${esc(MARK_END)}`), md);
+  } else {
+    txt = txt.replace(/(^#[^\n]*\n)/, `$1\n${md}\n`);
+  }
+  writeFileSync(INDICE_PATH, txt);
+  console.log('checklist escrito em prototipo-ui/DS_ADOCAO_INDICE.md');
+}
+
+function printReport({ total, byRule, byModule }) {
   const pad = (s, n) => String(s).padEnd(n);
   const lpad = (s, n) => String(s).padStart(n);
-
   console.log(`\n  DS adoption · ds/* = ${total}${ONLY_MODULE ? ` · módulo ${ONLY_MODULE}` : ''}\n`);
-
   console.log('  Por regra');
   console.log('  ' + '-'.repeat(48));
   const rules = Object.entries(byRule).sort((a, b) => b[1] - a[1]);
-  if (rules.length === 0) console.log('  (nenhuma)');
+  if (!rules.length) console.log('  (nenhuma)');
   for (const [rule, n] of rules) {
     const pct = total ? ((n / total) * 100).toFixed(1) : '0.0';
     console.log(`  ${pad(rule, 30)} ${lpad(n, 5)}  ${lpad(pct, 5)}%`);
   }
-
   console.log('\n  Por módulo (top 20)');
   console.log('  ' + '-'.repeat(48));
   const mods = Object.entries(byModule).sort((a, b) => b[1] - a[1]).slice(0, 20);
-  if (mods.length === 0) console.log('  (nenhum)');
-  for (const [mod, n] of mods) {
-    console.log(`  ${pad(mod, 30)} ${lpad(n, 5)}`);
-  }
-
+  if (!mods.length) console.log('  (nenhum)');
+  for (const [mod, n] of mods) console.log(`  ${pad(mod, 30)} ${lpad(n, 5)}`);
   console.log(`\n  Meta: ds/* -> 0. Hoje: ${total}.`);
   if (total === 0) console.log('  ZERO — adocao completa.');
   console.log('');
+}
+
+function main() {
+  const data = collect();
+  if (AS_JSON) { console.log(JSON.stringify({ ...data, generated_at: new Date().toISOString() }, null, 2)); return; }
+  if (DO_WRITE) { const md = worklistMarkdown(data); writeIndice(md); console.log('\n' + md + '\n'); return; }
+  if (AS_WORKLIST) { console.log('\n' + worklistMarkdown(data) + '\n'); return; }
+  printReport(data);
 }
 
 main();


### PR DESCRIPTION
Fecha o loop §10.2 com a peca que faltava (pedido Wagner): um checklist de tarefas no git que o Cowork le pra saber o que o Code JA executou (✅ ds/*=0) e o que falta (☐), sem regerar o ja-feito. `npm run ds:report:write` regenera derivado do estado real. Doc+script, sem mudanca de runtime.