### PR TITLE
fix(atendimento/macros): guard variants deferred undefined no 1o paint

### DIFF
--- a/resources/js/Pages/Atendimento/Macros/Variants.tsx
+++ b/resources/js/Pages/Atendimento/Macros/Variants.tsx
@@ -156,7 +156,10 @@ export default function MacroVariants({ macro, variants }: Props) {
     );
   }
 
-  const activeCount = variants.filter((v) => v.active).length;
+  // `variants` é deferred (undefined no 1º paint, antes do <Deferred> resolver).
+  // Guard contra crash — mirror do pattern Metricas/Index.tsx (aggregated?.series ?? []).
+  const safeVariants = variants ?? [];
+  const activeCount = safeVariants.filter((v) => v.active).length;
 
   return (
     <div className="space-y-4">
@@ -188,8 +191,8 @@ export default function MacroVariants({ macro, variants }: Props) {
             <span className="line-clamp-1">{macro.body}</span>
           </div>
           <div>
-            <strong>Variantes ativas:</strong> {activeCount}/{variants.length}
-            {activeCount === 0 && variants.length > 0 && (
+            <strong>Variantes ativas:</strong> {activeCount}/{safeVariants.length}
+            {activeCount === 0 && safeVariants.length > 0 && (
               <span className="ml-2 text-amber-600">
                 (sem variantes ativas — apply usa body padrão da macro)
               </span>


### PR DESCRIPTION
## Problema
A tela `/atendimento/macros/{id}/variants` (Variantes A/B) dava **tela branca** no 1o paint. A prop `variants` e deferred (`undefined` antes do `<Deferred>` resolver), mas `variants.filter()` rodava no topo do componente + `variants.length` no Card de resumo **fora** do `<Deferred>` — crash `Cannot read properties of undefined (reading 'filter')`.

## Fix
Guard `const safeVariants = variants ?? []` — espelha o pattern de `Metricas/Index.tsx` (`aggregated?.series ?? []`). Acessos dentro do `<Deferred>` ja estavam guardados (`!variants || variants.length === 0`).

## Verificacao
- `tsc --noEmit`: 0 erros em Variants.tsx
- ESLint: 0 erros
- Pest MacroVariantsCrudTest: CRUD-001/002/004 passam (CRUD-003 ja falhava antes — bug de setup do teste, rastreado a parte)
- Diff: 1 arquivo, +6/-3

Screen-grade estatico desta tela: 70/100 — filter-before-guard era o gap #1 de error-recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)