### PR TITLE
test(recurringbilling): suite RB 100% verde (fatal + 46 falhas + 246 deprec -> 0)

### DIFF
--- a/Modules/RecurringBilling/Tests/Feature/DomainModelsTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/DomainModelsTest.php
@@ -28,6 +28,7 @@ beforeEach(function () {
         $table->increments('id'); // int unsigned
         $table->unsignedInteger('business_id')->index();
         $table->string('name')->nullable();
+        $table->softDeletes();
         $table->timestamps();
     });
     Schema::create('fin_contas_bancarias', function ($table) {
@@ -65,6 +66,12 @@ beforeEach(function () {
         $table->dateTime('canceled_at')->nullable();
         $table->dateTime('paused_at')->nullable();
         $table->unsignedInteger('conta_bancaria_id')->nullable();
+        $table->unsignedSmallInteger('total_paid_cached')->default(0);
+        $table->unsignedSmallInteger('failed_count_cached')->default(0);
+        $table->decimal('total_revenue_cached', 14, 2)->default(0);
+        $table->date('paused_until')->nullable();
+        $table->string('churn_reason', 64)->nullable();
+        $table->string('contact_phone_cached', 32)->nullable();
         $table->json('metadata')->nullable();
         $table->timestamps();
         $table->softDeletes();

--- a/Modules/RecurringBilling/Tests/Feature/RecurringV975SchemaTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/RecurringV975SchemaTest.php
@@ -21,6 +21,7 @@ beforeEach(function () {
     foreach ([
         'rb_subscription_events', 'rb_subscription_favorites', 'rb_subscription_notes',
         'rb_subscriptions', 'rb_plans', 'users', 'contacts',
+        'model_has_roles', 'model_has_permissions', 'role_has_permissions', 'roles', 'permissions',
     ] as $t) {
         Schema::dropIfExists($t);
     }
@@ -28,11 +29,33 @@ beforeEach(function () {
     Schema::create('contacts', function ($t) {
         $t->increments('id');
         $t->unsignedInteger('business_id')->index();
+        $t->softDeletes();
         $t->timestamps();
+    });
+    // Auth scaffold mínimo — ScopeByBusiness (ADR 0093) só filtra com auth()->check()
+    // true; o Gate::before chama $user->can(...) → Spatie lê estas tabelas (vazias = user comum).
+    Schema::create('permissions', function ($t) {
+        $t->bigIncrements('id'); $t->string('name'); $t->string('guard_name')->default('web'); $t->timestamps();
+    });
+    Schema::create('roles', function ($t) {
+        $t->bigIncrements('id'); $t->string('name'); $t->string('guard_name')->default('web'); $t->timestamps();
+    });
+    Schema::create('role_has_permissions', function ($t) {
+        $t->unsignedBigInteger('permission_id'); $t->unsignedBigInteger('role_id');
+    });
+    Schema::create('model_has_permissions', function ($t) {
+        $t->unsignedBigInteger('permission_id'); $t->string('model_type'); $t->unsignedBigInteger('model_id');
+    });
+    Schema::create('model_has_roles', function ($t) {
+        $t->unsignedBigInteger('role_id'); $t->string('model_type'); $t->unsignedBigInteger('model_id');
     });
     Schema::create('users', function ($t) {
         $t->increments('id');
+        $t->unsignedInteger('business_id')->nullable();
+        $t->string('email', 100)->nullable();
         $t->string('username')->nullable();
+        $t->string('password')->nullable();
+        $t->softDeletes();
         $t->timestamps();
     });
     Schema::create('rb_plans', function ($t) {
@@ -121,7 +144,7 @@ afterEach(function () {
     }
 });
 
-function makeSub(int $bizId = 1, string $method = null): Subscription
+function makeV975Sub(int $bizId = 1, ?string $method = null): Subscription
 {
     $plan = Plan::create([
         'business_id' => $bizId, 'name' => 'P', 'slug' => "p-{$bizId}",
@@ -154,7 +177,7 @@ it('Plan aceita campos fiscais v9,75 (fiscal_type + cfop + servico)', function (
 });
 
 it('Subscription aceita payment_method + paused_until + churn_reason + cached cols', function () {
-    $sub = makeSub(1, 'pix');
+    $sub = makeV975Sub(1, 'pix');
     $sub->total_paid_cached = 14;
     $sub->failed_count_cached = 0;
     $sub->total_revenue_cached = 6720;
@@ -172,7 +195,7 @@ it('Subscription aceita payment_method + paused_until + churn_reason + cached co
 });
 
 it('SubscriptionNote cria + is_pinned cast bool + scope pinned()', function () {
-    $sub = makeSub();
+    $sub = makeV975Sub();
     SubscriptionNote::create([
         'business_id' => 1, 'subscription_id' => $sub->id, 'user_id' => 1,
         'body' => 'Nota normal', 'is_pinned' => false,
@@ -188,7 +211,7 @@ it('SubscriptionNote cria + is_pinned cast bool + scope pinned()', function () {
 });
 
 it('SubscriptionFavorite UNIQUE(user_id, subscription_id) impede duplicação', function () {
-    $sub = makeSub();
+    $sub = makeV975Sub();
     SubscriptionFavorite::create(['business_id' => 1, 'subscription_id' => $sub->id, 'user_id' => 1]);
 
     expect(fn () => SubscriptionFavorite::create([
@@ -197,7 +220,7 @@ it('SubscriptionFavorite UNIQUE(user_id, subscription_id) impede duplicação', 
 });
 
 it('SubscriptionEvent registra kind canônico + ordena por occurred_at desc (scope recent)', function () {
-    $sub = makeSub();
+    $sub = makeV975Sub();
     SubscriptionEvent::create([
         'business_id' => 1, 'subscription_id' => $sub->id,
         'kind' => SubscriptionEvent::KIND_CREATE, 'by_actor' => 'sistema',
@@ -216,8 +239,8 @@ it('SubscriptionEvent registra kind canônico + ordena por occurred_at desc (sco
 });
 
 it('multi-tenant: biz=99 não enxerga notes/favorites/events de biz=1 via HasBusinessScope', function () {
-    $subA = makeSub(1);
-    $subB = makeSub(99);
+    $subA = makeV975Sub(1);
+    $subB = makeV975Sub(99);
 
     SubscriptionNote::create(['business_id' => 1, 'subscription_id' => $subA->id, 'user_id' => 1, 'body' => 'a']);
     SubscriptionNote::create(['business_id' => 99, 'subscription_id' => $subB->id, 'user_id' => 1, 'body' => 'b']);
@@ -226,7 +249,10 @@ it('multi-tenant: biz=99 não enxerga notes/favorites/events de biz=1 via HasBus
     SubscriptionEvent::create(['business_id' => 1, 'subscription_id' => $subA->id, 'kind' => 'note', 'by_actor' => 'x', 'body' => 'a', 'occurred_at' => now()]);
     SubscriptionEvent::create(['business_id' => 99, 'subscription_id' => $subB->id, 'kind' => 'note', 'by_actor' => 'x', 'body' => 'b', 'occurred_at' => now()]);
 
-    session(['business' => ['id' => 1]]);
+    // Engaja ScopeByBusiness (ADR 0093): precisa auth()->check() + session('user.business_id').
+    $user = \App\User::create(['business_id' => 1, 'email' => 'biz1@rb.test', 'username' => 'biz1-rb']);
+    $this->actingAs($user);
+    session(['user' => ['business_id' => 1]]);
 
     expect(SubscriptionNote::count())->toBe(1)
         ->and(SubscriptionFavorite::count())->toBe(1)

--- a/Modules/RecurringBilling/Tests/Feature/Wave27PolishTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/Wave27PolishTest.php
@@ -41,7 +41,7 @@ describe('Wave 27 RecurringBilling POLISH FINAL', function () {
             ->toArray();
 
         foreach (['emitir', 'cancelar', 'pdf', 'refundAsaas', 'fetchPaymentAsaas'] as $m) {
-            expect($methods)->toContain($m, "BoletoService deve expor método público {$m}");
+            expect($methods)->toContain($m);
         }
     });
 
@@ -77,7 +77,7 @@ describe('Wave 27 RecurringBilling POLISH FINAL', function () {
             ->toArray();
 
         foreach (['criar', 'pausar', 'retomar', 'cancelar', 'calcularProximoVencimento'] as $m) {
-            expect($methods)->toContain($m, "AssinaturaService deve expor método público {$m}");
+            expect($methods)->toContain($m);
         }
     });
 

--- a/Modules/RecurringBilling/Tests/Feature/Wave4PresenterIndexTest.php
+++ b/Modules/RecurringBilling/Tests/Feature/Wave4PresenterIndexTest.php
@@ -25,7 +25,7 @@ uses(Tests\TestCase::class);
 /**
  * Helper — cria Subscription em-memory (sem persistir) com Plan eager.
  */
-function makeSub(string $status, array $extra = []): Subscription
+function makeWave4Sub(string $status, array $extra = []): Subscription
 {
     $plan = new Plan(['name' => 'Plano X', 'valor' => 480.0, 'ciclo' => 'monthly', 'ativo' => true]);
     $plan->id = 1;
@@ -53,16 +53,16 @@ function makeSub(string $status, array $extra = []): Subscription
 }
 
 it('R-RB-WAVE4-1 — deriveVisualStatus mapeia 5 estados DB → 5 estados Cowork', function () {
-    expect(SubscriptionIndexPresenter::deriveVisualStatus(makeSub('active')))->toBe('em_dia');
-    expect(SubscriptionIndexPresenter::deriveVisualStatus(makeSub('trialing')))->toBe('em_dia');
-    expect(SubscriptionIndexPresenter::deriveVisualStatus(makeSub('paused')))->toBe('pausada');
-    expect(SubscriptionIndexPresenter::deriveVisualStatus(makeSub('canceled')))->toBe('cancelada');
+    expect(SubscriptionIndexPresenter::deriveVisualStatus(makeWave4Sub('active')))->toBe('em_dia');
+    expect(SubscriptionIndexPresenter::deriveVisualStatus(makeWave4Sub('trialing')))->toBe('em_dia');
+    expect(SubscriptionIndexPresenter::deriveVisualStatus(makeWave4Sub('paused')))->toBe('pausada');
+    expect(SubscriptionIndexPresenter::deriveVisualStatus(makeWave4Sub('canceled')))->toBe('cancelada');
     // past_due sem lastInvoice → retentando (lastAttemptCount=0 < 3)
-    expect(SubscriptionIndexPresenter::deriveVisualStatus(makeSub('past_due')))->toBe('retentando');
+    expect(SubscriptionIndexPresenter::deriveVisualStatus(makeWave4Sub('past_due')))->toBe('retentando');
 });
 
 it('R-RB-WAVE4-2 — toListRow retorna campos canônicos pra Page Inertia', function () {
-    $sub = makeSub('active', [
+    $sub = makeWave4Sub('active', [
         'payment_method'       => 'boleto',
         'next_due_date'        => '2026-06-10',
         'total_paid_cached'    => 12,
@@ -91,7 +91,7 @@ it('R-RB-WAVE4-3 — computeKpis converte trimestral pra mensal equivalente no M
     $planTri = new Plan(['name' => 'Trimestral', 'valor' => 900.0, 'ciclo' => 'quarterly', 'ativo' => true]);
     $planTri->id = 2;
 
-    $sub1 = makeSub('active'); // mensal 480 → MRR contrib 480
+    $sub1 = makeWave4Sub('active'); // mensal 480 → MRR contrib 480
     $sub2 = new Subscription([
         'business_id'         => 1,
         'plan_id'             => 2,
@@ -113,9 +113,9 @@ it('R-RB-WAVE4-3 — computeKpis converte trimestral pra mensal equivalente no M
 
 it('R-RB-WAVE4-4 — computeKpis churn_rate calcula sobre total non-trialing', function () {
     Carbon::setTestNow('2026-05-17 12:00:00');
-    $subCanceledNow = makeSub('canceled', ['canceled_at' => Carbon::parse('2026-05-10 10:00:00')]);
-    $subActive1 = makeSub('active', ['id' => 2]);
-    $subActive2 = makeSub('active', ['id' => 3]);
+    $subCanceledNow = makeWave4Sub('canceled', ['canceled_at' => Carbon::parse('2026-05-10 10:00:00')]);
+    $subActive1 = makeWave4Sub('active', ['id' => 2]);
+    $subActive2 = makeWave4Sub('active', ['id' => 3]);
 
     $kpis = SubscriptionIndexPresenter::computeKpis(new Collection([
         $subCanceledNow, $subActive1, $subActive2,
@@ -129,7 +129,7 @@ it('R-RB-WAVE4-4 — computeKpis churn_rate calcula sobre total non-trialing', f
 });
 
 it('R-RB-WAVE4-5 — toDrawerPayload inclui contact + note + fiscal blocks', function () {
-    $sub = makeSub('em_dia');
+    $sub = makeWave4Sub('em_dia');
 
     $payload = SubscriptionIndexPresenter::toDrawerPayload($sub);
 
@@ -137,5 +137,5 @@ it('R-RB-WAVE4-5 — toDrawerPayload inclui contact + note + fiscal blocks', fun
         ->toHaveKeys(['contact', 'note', 'fiscal', 'churn_reason', 'paused_until', 'canceled_at'])
         ->and($payload['contact'])->toHaveKeys(['name', 'phone', 'email'])
         ->and($payload['fiscal'])->toHaveKeys(['type', 'channels', 'last_nf'])
-        ->and($payload['note'])->toBeNull(); // pinnedNote=null no makeSub helper
+        ->and($payload['note'])->toBeNull(); // pinnedNote=null no makeWave4Sub helper
 });

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,3 +11,44 @@ $kbFeatureDir = realpath(__DIR__ . '/../Modules/KB/Tests/Feature');
 $kbUnitDir    = realpath(__DIR__ . '/../Modules/KB/Tests/Unit');
 if ($kbFeatureDir !== false) { uses(TestCase::class)->in($kbFeatureDir); }
 if ($kbUnitDir    !== false) { uses(TestCase::class)->in($kbUnitDir); }
+
+// RecurringBilling — Spatie LogsActivity está ATIVO em Plan/Subscription/Invoice, mas
+// vários testes do módulo montam schema sqlite manual sem `activity_log`, quebrando com
+// "no such table: activity_log" no 1º create de model logável. Garante a tabela
+// (idempotente, guarded) num beforeEach do módulo. Nenhum teste RB dropa/assume ausência
+// de activity_log, então a criação central é segura (roda antes do beforeEach do arquivo).
+$rbFeatureDir = realpath(__DIR__ . '/../Modules/RecurringBilling/Tests/Feature');
+if ($rbFeatureDir !== false) {
+    uses()->beforeEach(function () {
+        if (! \Illuminate\Support\Facades\Schema::hasTable('activity_log')) {
+            \Illuminate\Support\Facades\Schema::create('activity_log', function ($t) {
+                $t->id();
+                $t->string('log_name')->nullable();
+                $t->text('description')->nullable();
+                $t->unsignedBigInteger('subject_id')->nullable();
+                $t->string('subject_type')->nullable();
+                $t->unsignedBigInteger('causer_id')->nullable();
+                $t->string('causer_type')->nullable();
+                $t->json('properties')->nullable();
+                $t->string('event')->nullable();
+                $t->uuid('batch_uuid')->nullable();
+                $t->timestamps();
+            });
+        }
+
+        // contacts — Subscription/Invoice referenciam contact_id; o model Contact usa
+        // SoftDeletes (query `deleted_at is null`). Garante a tabela (com deleted_at) pros
+        // testes que não a montam. Quem dropa+recria contacts próprio sobrescreve.
+        if (! \Illuminate\Support\Facades\Schema::hasTable('contacts')) {
+            \Illuminate\Support\Facades\Schema::create('contacts', function ($t) {
+                $t->increments('id');
+                $t->unsignedInteger('business_id')->nullable()->index();
+                $t->string('type')->nullable();
+                $t->string('supplier_business_name')->nullable();
+                $t->string('name')->nullable();
+                $t->softDeletes();
+                $t->timestamps();
+            });
+        }
+    })->in($rbFeatureDir);
+}


### PR DESCRIPTION
Cherry-pick do conserto da suite de testes RecurringBilling (9f600dc7e da staging-ct100). A suite RB morria num fatal (makeSub redeclarado) + 46 falhas + 246 deprecations PRE-EXISTENTES que o CI (escopo estreito) nunca pegou.

Fixes: rename makeV975Sub/makeWave4Sub - beforeEach central activity_log+contacts (tests/Pest.php) - softDeletes + 6 colunas cached (DomainModels) - Wave27 toContain misuse - multi-tenant auth scaffold (ScopeByBusiness ADR 0093) - ?nullable PHP 8.4.

246 passed, 0 failed, 0 deprecated. Verificado local (CI nao roda esses testes RB). Detalhe: memory/handoffs/2026-05-31-0600-ds-prc-recurringbilling-merge-admin-rb-tests-verde.md