### PR TITLE
feat(sells): navegação por teclado no dropdown de produto + 1ª infra de teste de componente

### DIFF
--- a/memory/requisitos/Sells/SPEC.md
+++ b/memory/requisitos/Sells/SPEC.md
@@ -892,6 +892,55 @@ Migrar 14 vendas biz=1 do estado legacy pro FSM canon ADR 0143 (goal #3 CYCLE-06
 - **Estimate:** 4h código + 7d canary monitoring (relógio mundo real)
 - **blocked_by:** nenhum (FSM canon LIVE prod biz=1 desde 2026-05-12, ADR 0143)
 
+### US-SELL-041 · NFC-e "emitir agora" no fim do Create (paridade Bling)
+
+> owner: wagner · priority: p1 · estimate: 4h · status: todo · type: story
+> blocked_by: —
+
+**Origem:** benchmark `tela-venda-arte` 2026-05-31 (gap **G5**, P1) — `memory/sessions/2026-05-31-tela-venda-arte.md`.
+
+**Problema:** o Bling emite NFC-e DENTRO do fluxo da venda; no oimpresso a NFe/NFC-e só sai depois (drawer do Index ou flag listener auto). A Larissa (biz=4) vende E fatura — hoje precisa sair do Create e ir ao Index pra emitir.
+
+**Aceite:**
+- [ ] Botão "Salvar e emitir NFC-e" no footer/pós-save do Create, reusando `VdNfeEmitModal` (já existe) + `FiscalSection`.
+- [ ] Gate por flag fiscal do business (só aparece se biz tem emissão habilitada — ex biz=4).
+- [ ] Não quebra o fluxo "só salvar" (botão primário continua "Salvar venda").
+- [ ] Pest cobrindo: salva venda → emite NFC-e cstat 100; venda sem flag → botão ausente.
+
+**Impacto:** alto (paridade concorrente BR + sinal forte Larissa fatura). **Esforço IA-pair:** ~3-5h.
+
+### US-SELL-042 · Batch no handlePriceGroupChange — elimina N+1 em /products/list
+
+> owner: wagner · priority: p1 · estimate: 2h · status: todo · type: story
+> blocked_by: —
+
+**Origem:** benchmark `tela-venda-arte` 2026-05-31 (gap **G4**, P1) — `memory/sessions/2026-05-31-tela-venda-arte.md`.
+
+**Problema:** ao trocar o grupo de preço do cliente, `handlePriceGroupChange` (`Sells/Create.tsx` ~L353-419) refaz **1 request por item** do carrinho pra re-buscar preço → N+1. Com carrinho grande, trava perceptível.
+
+**Aceite:**
+- [ ] Batchar num único `/products/list` (ou endpoint que aceite lista de variation_ids) em vez de 1 request por linha.
+- [ ] Preço/grupo reaplicado a todas as linhas após 1 round-trip.
+- [ ] Sem regressão no auto-aplica grupo de preço ao trocar cliente (US-SELL R8).
+
+**Impacto:** médio (perf percebida com carrinho grande). **Esforço IA-pair:** ~1-2h. **Pré-req:** endpoint aceitar batch.
+
+### US-SELL-043 · Migrar CSS Cowork (.sells-cowork / vd-*) → tokens DS no Sells/Index
+
+> owner: wagner · priority: p1 · estimate: 6h · status: todo · type: story
+> blocked_by: —
+
+**Origem:** benchmark `tela-venda-arte` 2026-05-31 (gap **G6**, P1) — `memory/sessions/2026-05-31-tela-venda-arte.md`.
+
+**Problema:** `Sells/Index.tsx` (~1806 linhas) é o cockpit de vendas (board 90, Leader) mas desvia do DS por **CSS Cowork scoped** (`.sells-cowork`, `vd-*`, oklch/hex/blue cru) fora do DS v4. É o que separa o Index de Champion (95+).
+
+**Aceite:**
+- [ ] Mapa classe↔token (auditar `vd-*` / `.sells-cowork` no bundle + no .tsx).
+- [ ] Migrar pra tokens DS v4 / roxo 295; eliminar hex/blue cru (respeitando cores de status semânticas — ver convenção do projeto).
+- [ ] Sem regressão visual (gate PRE-MERGE-UI + screenshot Wagner).
+
+**Impacto:** médio (não move agulha da Larissa, mas destrava Champion). **Esforço IA-pair:** ~4-8h. **Relacionado:** cycle DS-v3 (provável ADR pra tokens semânticos de status).
+
 ---
 
-**Última atualização:** 2026-05-15 — US-SELL-036 adicionada (goal #3 CYCLE-06 FSM rollout). 2026-05-12 — **discovery + spec executable Pipeline Vendas (7 GAPs)**. Wagner valida casos de uso + testes failing-first **antes** de implementar (estratégia: pagar custo agora com poucos clientes ativos vs. retrabalho exponencial com mais clientes). Antes era heatmap v3 → agora pipeline canon completo Orçamento→Produção→Venda→Faturamento. Total SPEC: **5 P0 + 5 P1 + 3 P2 + 1 P3 (US-015..028) + 4 P0 + 2 P1 + 1 P2 (US-029..035) + 1 P0 (US-036) = 22 US ativas**. Cumpre [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) (sinal qualificado pelo próprio Wagner — pain points reportados em sessão).
+**Última atualização:** 2026-05-31 — US-SELL-041/042/043 adicionadas (benchmark `tela-venda-arte` 2026-05-31, gaps P1 — G5 NFC-e inline no Create / G4 batch price-group / G6 CSS Cowork→tokens no Index). 2026-05-15 — US-SELL-036 adicionada (goal #3 CYCLE-06 FSM rollout). 2026-05-12 — **discovery + spec executable Pipeline Vendas (7 GAPs)**. Wagner valida casos de uso + testes failing-first **antes** de implementar (estratégia: pagar custo agora com poucos clientes ativos vs. retrabalho exponencial com mais clientes). Antes era heatmap v3 → agora pipeline canon completo Orçamento→Produção→Venda→Faturamento. Total SPEC: **5 P0 + 5 P1 + 3 P2 + 1 P3 (US-015..028) + 4 P0 + 2 P1 + 1 P2 (US-029..035) + 1 P0 (US-036) = 22 US ativas**. Cumpre [ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md) (sinal qualificado pelo próprio Wagner — pain points reportados em sessão).

--- a/memory/requisitos/Sells/SPEC.md
+++ b/memory/requisitos/Sells/SPEC.md
@@ -1,3 +1,14 @@
+---
+slug: sells
+title: "Especificação funcional — Sells (migração MWART de /sells/create)"
+type: spec
+module: Sells
+status: ativo
+owner: wagner
+version: 1.0.0
+last_updated: 2026-05-31
+---
+
 # Especificação funcional — Sells (migração MWART de /sells/create)
 
 > **Convenção do ID:** `US-SELL-NNN` para user stories.
@@ -257,7 +268,7 @@ Como ter certeza que vai dar certo:
 3. **Pest tests do `store()`** — 5+ fixtures cobrindo casos reais (à vista, prazo, desconto %, fixo, frete, split). Baseline de regressão ANTES de qualquer mudança.
 4. **Smoke biz=1, NUNCA biz=4** — auto-mem `feedback_test_business_id_1_nunca_4`. Wagner WR2 SC é cobaia segura; Larissa nunca.
 5. **Canary 7 dias Wagner** — flag ON só em biz=1 antes de tocar biz=4. Bug encontrado → fix antes do cutover.
-6. **Audit cockpit-runbook modo B obrigatório** — score ≥ 70 em CADA US-SELL-00X antes de mergear PR. CRITICAL bloqueia merge.
+6. **Audit cockpit-runbook modo B obrigatório** — score ≥ 70 em CADA US-SELL-NNN antes de mergear PR. CRITICAL bloqueia merge.
 7. **Backup DB antes do cutover** — `mysqldump` das 4 tabelas críticas. Restore em <5min se necessário.
 8. **Aviso prévio pra Larissa** — humano-no-loop, ela sabe que mudança rolou e tem canal direto pra reportar.
 9. **30 dias monitorando antes de remover Blade** — janela longa pra qualquer regressão de borda aparecer.

--- a/memory/sessions/2026-05-31-tela-venda-arte.md
+++ b/memory/sessions/2026-05-31-tela-venda-arte.md
@@ -1,0 +1,170 @@
+# Tela de Venda — Estado-da-Arte & Nota (oimpresso vs melhores 2026)
+
+> **Agente:** `tela-venda-arte` · **Data:** 2026-05-31 · **Escopo:** `Sells/Create.tsx` (form criar venda, 1647 linhas) + `Sells/Index.tsx` (cockpit lista, 1806 linhas).
+> **Pesquisa limpa** (Fase 1 sem contaminar com memória oimpresso) → **comparação código real** (Fase 2) → **gaps** (Fase 3) → **nota + ação** (Fase 4).
+> **Resultado em 1 linha:** Create **88/100** · Index **90/100** · referência topo (Shopify POS / Square) **~92/100**. Gap pequeno (-4). Causa: conformidade DS (cor crua + header fora do canon + CSS Cowork scoped) e 1 gap de fluxo (NFC-e não emite dentro do Create).
+
+---
+
+## 1. PESQUISA — os melhores (Fase 1)
+
+Pesquisa web limpa, 9 players + camada AI-first. Foco: como cada um resolve a **tela de venda / checkout**, não marketing.
+
+| Player | Público | Como resolve a tela de venda (mecanismo concreto) | Por que é referência |
+|---|---|---|---|
+| **Shopify POS Pro** | Varejo omnichannel global | Smart Grid dinâmico (tiles respondem ao carrinho); navegação 100% teclado (search→add→checkout sem trocar pra touch); product search com word-completion + variante no resultado; returns/exchanges pelo mesmo fluxo do carrinho | Escala global, UX doc pública, keyboard-first maduro |
+| **Square Register 2.0** | PME/varejo/food US | Dual-screen (operador + cliente); checkout "lightning-fast"; split payment; AI search que casa a linguagem do caixa; customer-facing display com itens/tax/loyalty sem interromper pagamento | Hardware+SW integrados, 2ª geração fev/2026 |
+| **Stripe Terminal + Elements** | Devs / plataformas | POS como **biblioteca**: SDK JS/React, você constrói a tela; `loadStripe` 2026 só baixa módulos dos métodos ativos (bundle enxuto); on-reader input; Payments Foundation Model prevê falha de pagamento | Padrão de componentização de checkout; quem constrói POS custom |
+| **Toast POS** | Restaurante (QSR + full) | Drive-thru mode (vehicle ID, lane tagging, menos passos); Advanced Order Confirmation Screen; AI Voice ordering; **estabilidade de condicionamento** (mudanças aditivas, não quebra muscle-memory do caixa) | Vence em "não reaprende a tela"; speed-of-service |
+| **Lightspeed Retail** | Varejo multi-vertical inventory-heavy | Sales screen central: search+add, cliente, desconto/promoção; matriz de variantes (tamanho/cor) superior; barcode integrado; multi-localidade/transfer num dashboard | Melhor inventário de catálogo grande; mas **dívida de UX** (sem redesign 2023-26) |
+| **Bling ERP (PDV)** | PME BR | Frente de caixa limpa: busca por código/nome/leitor; desconto+cupom+finalizar em poucos cliques; **NFC-e emitida automaticamente durante a venda**; estoque/financeiro atualizam no ato; PIX/QR/cartão/misto | Concorrente direto BR; NFC-e inline é o benchmark fiscal |
+| **Tiny ERP (Olist)** | PME/e-commerce BR | PDV registra venda ágil; inclui produto, troco, forma de pagamento, abre/fecha caixa **com poucos cliques ou atalhos de teclado**; unifica venda multicanal | Concorrente direto BR; atalhos de teclado explícitos |
+| **Omie.PDV Varejo** | PME BR | **Pré-venda no balcão** (consulta preço/estoque, negocia desconto, **bloqueia estoque**) → finaliza no PDV; tempo-real com ERP; balança+leitor | Concorrente direto BR; reserva de estoque na pré-venda |
+| **Conta Azul Pro** | PME/serviços BR | Nova venda: cliente→itens→condição pagamento→salva; tipos Orçamento/Avulsa/Recorrente; ajuda contextual inline na própria tela | Concorrente BR forte em serviços/financeiro |
+| **AI-first (Microsoft Copilot Checkout + Google UCP)** | Agentic commerce 2026 | Checkout conversacional dentro do assistente (sem redirect); UCP = protocolo aberto agente↔comércio (Shopify/Stripe/Adyen/Visa endorsed) | Vanguarda 2026: a "tela" some, vira conversa |
+
+**Framework neutro de calibração** — o benchmark independente *POS UX 2026: The Coherence Gap* (interface-design.co.uk) avalia 4 eixos operacionais que adoto como régua:
+1. **Attention economy** — usar sem foco visual sustentado.
+2. **Conditioning stability** — sobreviver a updates sem quebrar muscle-memory (Toast vence; Square perdeu em set/2025 com rollout forçado → busca 2-3s mais lenta).
+3. **Taxonomy alignment** — search casa com como o caixa nomeia o produto.
+4. **Error-recovery speed** — passos/tempo quando a transação falha (Toast falha aqui: void/refund quebra no meio).
+Tese central: **"feature accumulation ≠ operational coherence"** — acumular feature não é o mesmo investimento que coerência operacional. Isso vale direto pro oimpresso.
+
+### Ranking visual — top 3 referências
+
+```
+🥇 Shopify POS Pro    — keyboard-first + smart grid + search com variante. Teto de UX de fluxo.
+🥈 Square Register 2.0 — checkout mais rápido + dual-screen + AI search. Teto de velocidade.
+🥉 Bling PDV (BR)      — NFC-e inline na venda + estoque/financeiro no ato. Teto fiscal BR / concorrente direto.
+```
+
+> **Leitura estratégica:** os globais (Shopify/Square/Toast) ganham em **fluidez de fluxo e estabilidade**. Os BR (Bling/Omie/Tiny) ganham em **fiscal-no-fluxo + reserva de estoque + atalhos**. O oimpresso já tem o lado BR forte (e mais: FSM, comissão, IA) — falta fechar a **fluidez/conformidade** que os globais têm.
+
+---
+
+## 2. COMPARA — 15 dimensões canônicas (Fase 2)
+
+Lido do código real em `D:\oimpresso.com\resources\js\Pages\Sells\`. Distingo **Inertia v2** (Create.tsx + Index.tsx — o que está em prod biz=1 e em rollout) do **POS Blade legacy** (`/sale-pos/create`, `sale_pos/create.blade.php` — Non-Goal do charter, mas é onde o balcão de alto-volume cairia).
+
+> Nota importante: o brief do Wagner pediu para focar em Create + Index Inertia. O "Blade legacy" do POS rápido é **Non-Goal explícito do charter** (linha 46) — avalio-o como fluxo paralelo, sem inflar nem punir as telas Inertia por ele.
+
+| # | Dimensão | Estado-da-arte (Fase 1) | oimpresso Inertia v2 (Create+Index) | POS Blade legacy (`/sale-pos`) | Distância | Nota /10 |
+|---|---|---|---|---|---|---|
+| 1 | **Velocidade fluxo** | Shopify/Square: walk-in+3 itens+pagto em ~6-8 ações, tudo teclado | Walk-in já é default; scanner Enter→autoselect; Cmd+Enter salva; ~7-9 ações. Bom, mas form longo (scroll) vs grid 1-tela | Grid clássico 1-tela, foco balcão | curta | **8** |
+| 2 | **Busca produto** | Shopify word-completion + variante no resultado | `ProductSearchAutocomplete`: debounce 250ms via TanStack (cancela stale), match SKU/EAN exato, scanner sync no Enter, **agrupa variações + popover tamanho**, `search_fields[]` configurável persistido (nome/SKU/lote/4 custom) | Busca legacy pos.js | **bate/supera** | **9** |
+| 3 | **Busca + cadastro cliente inline** | Shopify: add customer por atalho | `CustomerSearchAutocomplete` + **`QuickAddCustomerSheet`** (5 campos, Sheet lateral, **preserva draft**, fetch direto não-Inertia); auto-aplica grupo de preço/prazo/endereço ao selecionar; mostra saldo devedor | Modal in-place legacy | **bate/supera** | **9** |
+| 4 | **Atalhos teclado** | Shopify keyboard-first; Tiny atalhos | Create: `/` foca busca, Cmd+Enter salva, Esc blur. Index: J/K nav, ⌘K palette+IA, N nova, ? cheatsheet, B/X/E/R/F. Falta **navegação por seta no dropdown de produto** (só Enter) | Hotkeys legacy | curta | **8** |
+| 5 | **Layout/hierarquia visual** | Stripe/Linear: 100% tokens, densidade calibrada | Create: KPIs gigantes + pills scroll-spy + footer sticky. **Cor crua** `bg-amber-50/blue-50/emerald-50` nos KPI/status (viola token). Index: denso e bonito mas **CSS Cowork scoped** (`vd-*`) fora do DS | — | média | **7** |
+| 6 | **Mobile/touch** | Square dual-screen touch-first | Charter exige 1280px sem scroll-h (Larissa); funciona em tablet mas é **desktop-first** (form longo, touch targets pequenos na tabela de itens) | Blade responsivo limitado | média | **6** |
+| 7 | **Múltiplos pagamentos** | Square/Stripe split + gateways | `PaymentRow` split real, troco/falta/exato automático, **venda a prazo (fiado)** com payment_status=due, contas. Gateways (Asaas/Inter/Stripe) **não no fluxo de criar** | Split legacy | curta | **8** |
+| 8 | **Estoque real-time** | Omie bloqueia estoque na pré-venda; Lightspeed multi-local | Search mostra `qty_available` + est. total por variação inline. **Não reserva/bloqueia** estoque no rascunho (Omie faz); sem alerta de zero no carrinho | Legacy | média | **6** |
+| 9 | **NFe inline (BR)** | Bling: **NFC-e emitida durante a venda** | NFe/NFCe existe (`VdNfeEmitModal`/`FiscalSection`) **mas só no drawer pós-venda (Index)** ou por flag listener auto. **Create NÃO emite no fluxo** (Non-Goal). Forte em backend (CFOP/FSM), fraco em "1 clique emite na hora" | Legacy separado | **média** | **6** |
+| 10 | **Descontos/promoções** | Shopify discount tiles | Desconto por item + por pedido (% ou fixo), **validação de max_discount por permissão**. Sem cupom/regra promocional automática no fluxo; sem redeem reward | Legacy | média | **6** |
+| 11 | **Offline/resiliência** | POS sérios: fila offline | **Autosave draft localStorage multi-tenant** (`{biz}.{user}`, TTL 24h, recover com AlertDialog); R9 guard anti-drift de data; failsafe em refetch de preço. **Não tem fila offline real** (sem network = sem salvar no server) | Nenhum | média | **6** |
+| 12 | **Histórico/auditoria** | — | `SaleSheet` drawer com `SaleTimeline` + `SaleAuditTrail` + FSM timeline + comentários por item. Estado-da-arte, **mas vive no Index/drawer, não no Create** | Legacy fraco | **supera** | **9** |
+| 13 | **Customização per-business** | Lightspeed multi-vertical | Campos colapsáveis condicionais (commission/price-group só se aplicável); `source` balcão/oficina/online (ADR 0192); visões Operacional/Financeira/Produção. Vertical-specific real | Genérico | **bate/supera** | **8** |
+| 14 | **Integração/automação** | AI-first 2026 (Copilot/UCP) | **`SaleAiPanel` (Jana copilot)** no drawer + ⌘K "Perguntar à IA"; webhooks; cross-módulo Vendas×Oficina. Falta WhatsApp pós-venda **no fluxo** + gateway automático inline | Nenhum | curta | **8** |
+| 15 | **UX feedback** | Linear: estados ricos | Loading (Loader2), erro com scroll-pra-seção + auto-open `<details>`, toast sonner PT-BR, EmptyState, microcopy calorosa ("Digite ou bipe…"). Forte | Legacy básico | curta | **8** |
+
+### Onde o oimpresso BATE o mercado (registrar honestamente)
+- **Busca de produto com variação** (dim 2): popover de tamanho + search_fields configurável + scanner sync supera Bling/Tiny e empata Shopify.
+- **Cadastro de cliente inline preservando draft** (dim 3): `QuickAddCustomerSheet` é melhor que abrir aba/modal cego.
+- **Auditoria/FSM/IA no drawer** (dim 12/14): `SaleAiPanel` + `SaleTimeline` + FSM são features que **nenhum POS global tem** — é vantagem de ERP-com-IA.
+- **NumericInputPtBR** (dim 15): parser pt-BR-safe que nasceu de bug real de R$25k (vírgula decimal). Detalhe que os globais não precisam mas no BR é crítico.
+- **Multi-tenant em tudo** (Tier 0 ADR 0093): draft key, localStorage de filtros — `business_id` scoped em cada chave. Shopify/Square são single-tenant por loja.
+
+### Onde PERDE (sem inflar)
+- **Conformidade DS** (dim 5): cor crua no Create + CSS Cowork scoped no Index. É o gap nº1 do board (88/90) e o que separa de Champion.
+- **NFC-e no fluxo de criar** (dim 9): Bling emite na venda; oimpresso emite depois. Gap de fluxo, não de capacidade.
+- **Mobile/touch** (dim 6): desktop-first; Square é touch-first.
+- **Reserva de estoque** (dim 8) e **fila offline** (dim 11): Omie reserva; POS sérios têm fila. oimpresso não.
+
+---
+
+## 3. AVALIA — gaps rankeados (Fase 3)
+
+Esforço recalibrado IA-pair (ADR 0106, fator 10x + margem 2x). Gap só é US ativa com sinal de cliente (ADR 0105) — marco abaixo.
+
+| # | Gap | Impacto | Esforço (IA-pair) | Pré-req? | Risco | Sinal cliente? |
+|---|---|---|---|---|---|---|
+| G1 | **Cor crua → tokens** nos 4 KPI + card status (Create) | médio (conformidade, não move agulha de UX) | ~30-45 min | não | baixo | board/ratchet (ADR 0236) |
+| G2 | **PageHeader canon** no Create (já importado, não usado) | médio (consistência sistêmica) | ~30 min | não | baixo | board |
+| G3 | **Navegação por seta ↑↓** no dropdown de produto (hoje só Enter) | **alto** (Larissa teclado, fricção por clique) | ~1-2h | não | baixo | Larissa usa scanner+teclado |
+| G4 | **N+1 em `handlePriceGroupChange`** → batchar `/products/list` 1 request | médio (perf percebida com carrinho grande) | ~1-2h | endpoint aceitar batch | médio | latência |
+| G5 | **NFC-e "emitir agora" no fim do Create** (botão pós-save → VdNfeEmitModal já existe) | **alto** (paridade Bling; balcão vestuário vende+NF) | ~3-5h | flag fiscal biz=4 ativa | médio | **Larissa biz=4 vende e fatura** |
+| G6 | **CSS Cowork → tokens DS** no Index (auditar `vd-*`/oklch, eliminar hex/blue) | médio (não move agulha, mas trava Champion) | ~4-8h (1806 linhas) | mapa token↔classe | médio | board/ratchet |
+| G7 | **aria-live no foco de linha + aria-sort** nos headers (Index) | médio (a11y WCAG) | ~1-2h | não | baixo | nenhum direto |
+| G8 | **Reserva de estoque** no rascunho (paridade Omie pré-venda) | médio | ~1-2 dias | FSM + lock estoque | alto | nenhum ainda |
+| G9 | **Fila offline real** (network down = enfileira) | baixo-médio | ~2-3 dias | service worker | alto | nenhum (Larissa tem net) |
+| G10 | **Touch/mobile** otimizar tabela de itens + targets | médio | ~1 dia | — | médio | nenhum (monitor 1280px) |
+
+### Categorização
+
+- **P0 — esta semana (alto impacto + baixo esforço, sem pré-req bloqueante):**
+  - **G3** (seta no dropdown de produto) — alto impacto UX teclado, ~1-2h, zero pré-req. **Esta é a que move a agulha.**
+  - **G1 + G2** (cor crua + PageHeader) — baixo esforço (~1h juntos), destrava 2 dos 3 gaps do board do Create. Necessário pro Champion mas é cleanup, não UX.
+
+- **P1 — próximo cycle (alto impacto + médio esforço):**
+  - **G5** (NFC-e emitir-agora no Create) — alto impacto, sinal forte (Larissa fatura), ~3-5h. Botão "Salvar e emitir NFC-e" reusando `VdNfeEmitModal`.
+  - **G4** (batch price group) — perf, ~1-2h.
+  - **G6** (CSS Cowork→tokens no Index) — necessário pro Index virar Champion, ~4-8h.
+
+- **P2 — backlog (médio impacto / qualquer esforço):**
+  - **G7** (a11y aria-live/aria-sort), **G10** (touch/mobile), **G8** (reserva estoque — só se Omie virar objeção comercial).
+
+- **P3 — descartar OU virar ADR feature-wish (ADR 0105):**
+  - **G9** (fila offline) — **sem sinal**: Larissa tem internet estável. "Porque POS sério tem" não basta → vira ADR feature-wish, não US ativa.
+  - **Checkout conversacional / agentic (UCP)** — vanguarda real mas **sem cliente pedindo**. ADR feature-wish para observar 2026.
+
+> **Distinção que o Wagner pediu — cleanup vs agulha:**
+> - **Cleanup de conformidade (G1, G2, G6, G7):** *necessário mas insuficiente.* Tira o Create/Index de Leader e habilita Champion no score, mas Larissa **não percebe diferença** no dia-a-dia. É dívida de DS/ratchet.
+> - **UX que move a agulha (G3, G5):** *o que Larissa sente.* Seta no dropdown corta cliques reais; NFC-e no fluxo elimina ir ao Index depois pra faturar. **São essas que justificam ir a Champion de verdade**, não só no número.
+
+---
+
+## 4. NOTA + RECOMENDAÇÃO (Fase 4)
+
+**Cálculo ponderado** (15 dimensões, foco oimpresso/PME BR — telas Inertia v2 em prod/rollout):
+
+| Faixa | Dimensões | Peso | Notas | Σ(dim×peso) |
+|---|---|---|---|---|
+| Fluxo+busca+atalhos | 1(8) 2(9) 3(9) 4(8) | 3 | 34 | 102 |
+| Visual+mobile+pagto+estoque+NFe | 5(7) 6(6) 7(8) 8(6) 9(6) | 2 | 33 | 66 |
+| Desc+offline+hist+custom+integ+feedback | 10(6) 11(6) 12(9) 13(8) 14(8) 15(8) | 1 | 45 | 45 |
+| **Total** | | **Σpeso = 4×3 + 5×2 + 6×1 = 28** | | **Σ = 213** |
+
+`nota_final = 213 / 28 × 10 = ` **76,1/100** (média ponderada bruta das 15 dimensões do agente).
+
+Esse 76 é a média ponderada **bruta** das 15 dimensões deste agente (mais severa que o board interno porque inclui mobile/offline/reserva-estoque onde o oimpresso é fraco). O board interno (16 dimensões com peso de conformidade DS/craft) dá:
+
+```
+NOTA OIMPRESSO Create.tsx (Inertia v2, rollout): 88/100   (board · Leader)
+NOTA OIMPRESSO Index.tsx  (Inertia v2, prod):    90/100   (board · Leader)
+NOTA agregada 15-dim deste agente (fluxo-cêntrica): 76/100
+NOTA REFERÊNCIA TOPO (Shopify POS / Square 2.0):  ~92/100
+
+Gap p/ topo: Create -4 / Index -2 pontos.
+Causa principal: conformidade DS (cor crua no Create, CSS Cowork scoped no Index) +
+1 gap de fluxo (NFC-e não emite dentro do Create como o Bling faz).
+```
+
+> **Por que duas notas divergem (88 vs 76):** o board mede *craft + conformidade DS + maturidade de feature* (onde oimpresso brilha: charter, autosave, FSM, IA). Este agente pondera *fluxo de venda puro* e pune mobile/offline/reserva-estoque. **Ambas são verdadeiras.** A leitura honesta: o oimpresso é **Leader sólido em craft e fiscal BR**, mas tem **teto em fluidez touch/offline** que os globais resolvem. Não está a 1 PR de Champion — está a ~3-4 PRs focados.
+
+### Recomendação concreta — comece por G3
+
+**Comece por G3 (navegação por seta ↑↓ no dropdown de produto do `ProductSearchAutocomplete`).** Alto-impacto (Larissa é teclado+scanner, hoje precisa clicar pra escolher variação), baixo-esforço (~1-2h, o componente já tem `groups`, `expandedProductId`, `handleSelectVariation` — falta `highlightedIndex` + handler ↑↓/Enter, espelhando o que o `CustomerSearchAutocomplete` já faz com `highlightedIndex`). **Sem pré-req bloqueante.** É a única P0 que Larissa *sente*.
+
+**Próxima ação hoje:** abrir `D:\oimpresso.com\resources\js\Pages\Sells\_components\ProductSearchAutocomplete.tsx`, adicionar estado `highlightedIndex` + tratamento `ArrowDown`/`ArrowUp`/`Enter` no `handleKeyDown` (linha ~369) navegando os `groups` achatados, com Pest cobrindo: (1) ↓ destaca 1º item, (2) Enter no destacado seleciona, (3) ↓ em grupo com >1 variação abre popover. Depois emparelhar G1+G2 (cor crua→token + PageHeader) no mesmo cycle — cleanup de ~1h que fecha 2 dos 3 gaps do board do Create.
+
+**Não fazer agora:** G9 (fila offline) e checkout conversacional — sem sinal de cliente, viram ADR feature-wish (ADR 0105), não US ativa.
+
+---
+
+### Refs de código (paths absolutos)
+- `D:\oimpresso.com\resources\js\Pages\Sells\Create.tsx` (1647 linhas) — cor crua KPI L916-975, header hand-roll L856-909 (PageHeader importado L21 não usado), N+1 `handlePriceGroupChange` L353-419.
+- `D:\oimpresso.com\resources\js\Pages\Sells\_components\ProductSearchAutocomplete.tsx` — `handleKeyDown` L369 (alvo G3), `groups` L199.
+- `D:\oimpresso.com\resources\js\Pages\Sells\_components\CustomerSearchAutocomplete.tsx` — `highlightedIndex` L84 (padrão a copiar pro G3).
+- `D:\oimpresso.com\resources\js\Pages\Sells\_components\QuickAddCustomerSheet.tsx` — cadastro inline preservando draft.
+- `D:\oimpresso.com\resources\js\Pages\Sells\Index.tsx` (1806 linhas) — CSS Cowork `.sells-cowork`/`vd-*` (gap G6/G7).
+- `D:\oimpresso.com\resources\js\Pages\Sells\_components\{VdNfeEmitModal,FiscalSection}.tsx` — NFC-e existe (reuso p/ G5).
+- Board: `D:\oimpresso.com\memory\governance\scorecards\SCREEN-GRADE-BOARD-2026-05-30.md` (Create 88, Index 90).

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "lint:baseline:write": "node scripts/eslint-baseline.mjs --write",
     "lint:baseline:check": "node scripts/eslint-baseline.mjs",
     "ds:report": "node scripts/ds-report.mjs",
-    "ds:report:write": "node scripts/ds-report.mjs --write"
+    "ds:report:write": "node scripts/ds-report.mjs --write",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",

--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -18,7 +18,6 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { ReactNode } from 'react';
 import { useAuth, useBusiness } from '@/Hooks/usePageProps';
 import { CreditCard, FileText, Loader2, Package, Plus, Printer, Receipt, Search, Settings2, Trash2 } from 'lucide-react';
-import PageHeader from '@/Components/shared/PageHeader';
 import EmptyState from '@/Components/shared/EmptyState';
 import { Button } from '@/Components/ui/button';
 import { Input } from '@/Components/ui/input';
@@ -937,6 +936,14 @@ export default function SellsCreate(props: SellsCreatePageProps) {
             {formatBRL(totalPago)}
           </div>
         </div>
+        {/*
+          G1 (tela-venda-arte 2026-05-31) — board flagou "cor crua" aqui, mas
+          AVALIADO e MANTIDO de propósito: amber/blue/emerald é SEMÂNTICA DE STATUS
+          de pagamento (falta / troco / exato). O projeto mantém cores de status
+          intocadas por convenção (resources/css/cowork-payment-gateway-bundle.css:12)
+          e o charter lista "tone semântico" como Goal. Tokenizar (--success/--warning)
+          é decisão de fundações DS-v3 (ADR), não cleanup desta tela.
+        */}
         <div
           className={
             'rounded-lg border p-6 shadow-sm ' +

--- a/resources/js/Pages/Sells/_components/ProductSearchAutocomplete.tsx
+++ b/resources/js/Pages/Sells/_components/ProductSearchAutocomplete.tsx
@@ -178,6 +178,13 @@ export default function ProductSearchAutocomplete({
   const [loading, setLoading] = useState(false);
   const [open, setOpen] = useState(false);
   const [expandedProductId, setExpandedProductId] = useState<number | null>(null);
+  // G3 (2026-05-31) — navegação por teclado no dropdown (paridade CustomerSearchAutocomplete).
+  // `highlightedIndex` percorre os GRUPOS do dropdown; `variationHighlightedIndex`
+  // percorre as VARIAÇÕES dentro do popover aberto (caso multi-tamanho — o comum
+  // pra Larissa @ vestuário). -1 = nada destacado. Larissa opera teclado+scanner,
+  // então o dropdown precisa ser 100% navegável sem mouse (gap board → Champion).
+  const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
+  const [variationHighlightedIndex, setVariationHighlightedIndex] = useState<number>(-1);
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   // R7 anti-race — timestamp da última seleção. Bloqueia fetches em flight do
@@ -266,6 +273,9 @@ export default function ProductSearchAutocomplete({
     setResults(productQuery.data);
     setOpen(true);
     setExpandedProductId(null);
+    // G3 — dado novo zera o destaque de teclado (índice antigo ficaria stale).
+    setHighlightedIndex(-1);
+    setVariationHighlightedIndex(-1);
   }, [productQuery.data]);
 
   // Limpa results quando o termo cai abaixo do mínimo (debounce já zerou a key).
@@ -369,9 +379,42 @@ export default function ProductSearchAutocomplete({
 
   const handleKeyDown = async (e: React.KeyboardEvent<HTMLInputElement>) => {
     if (e.key === 'Escape') {
+      // G3 — popover de variação aberto: Esc fecha só o popover (volta pro grupo).
+      if (expandedProductId !== null) {
+        setExpandedProductId(null);
+        setVariationHighlightedIndex(-1);
+        return;
+      }
       setOpen(false);
       setExpandedProductId(null);
+      setHighlightedIndex(-1);
       inputRef.current?.blur();
+      return;
+    }
+
+    // G3 — navegação por seta (paridade CustomerSearchAutocomplete:170-181).
+    // Quando o popover de variação está aberto, as setas navegam as VARIAÇÕES;
+    // caso contrário, navegam os GRUPOS do dropdown.
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      if (expandedProductId !== null) {
+        const grp = groups.find((g) => g.product_id === expandedProductId);
+        const n = grp ? grp.variations.length : 0;
+        setVariationHighlightedIndex((prev) => Math.min(prev + 1, n - 1));
+        return;
+      }
+      if (!open && groups.length > 0) setOpen(true);
+      setHighlightedIndex((prev) => Math.min(prev + 1, groups.length - 1));
+      return;
+    }
+
+    if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      if (expandedProductId !== null) {
+        setVariationHighlightedIndex((prev) => Math.max(prev - 1, 0));
+        return;
+      }
+      setHighlightedIndex((prev) => Math.max(prev - 1, -1));
       return;
     }
 
@@ -389,6 +432,33 @@ export default function ProductSearchAutocomplete({
       // anterior). Um 2º Enter rápido (operadora insistindo) cairia no mesmo branch
       // e poderia duplicar. Ignora.
       if (loading) return;
+
+      // G3 — popover de variação aberto: Enter seleciona a variação destacada
+      // (ou a 1ª, se nenhuma foi navegada). Precede o scanner/match — o usuário
+      // já está num sub-fluxo explícito de escolha de tamanho.
+      if (expandedProductId !== null) {
+        const grp = groups.find((g) => g.product_id === expandedProductId);
+        const idx = variationHighlightedIndex >= 0 ? variationHighlightedIndex : 0;
+        const v = grp?.variations[idx];
+        if (v) handleSelectVariation(v);
+        return;
+      }
+
+      // G3 — grupo destacado por seta: 1 variação → seleciona direto; multi → abre
+      // o popover e destaca a 1ª variação. Só dispara quando o usuário navegou de
+      // fato (highlightedIndex >= 0); o scanner (Enter sem seta) cai no match exato
+      // abaixo com highlightedIndex == -1 — comportamento legado intacto.
+      if (highlightedIndex >= 0 && groups[highlightedIndex]) {
+        const grp = groups[highlightedIndex];
+        const onlyVar = grp.variations[0];
+        if (grp.variations.length === 1 && onlyVar) {
+          handleSelectVariation(onlyVar);
+        } else {
+          setExpandedProductId(grp.product_id);
+          setVariationHighlightedIndex(0);
+        }
+        return;
+      }
 
       const q = query.trim();
 
@@ -441,6 +511,8 @@ export default function ProductSearchAutocomplete({
     setResults([]);
     setOpen(false);
     setExpandedProductId(null);
+    setHighlightedIndex(-1);
+    setVariationHighlightedIndex(-1);
     inputRef.current?.focus();
   };
 
@@ -453,6 +525,8 @@ export default function ProductSearchAutocomplete({
     setResults([]);
     setOpen(false);
     setExpandedProductId(null);
+    setHighlightedIndex(-1);
+    setVariationHighlightedIndex(-1);
     inputRef.current?.focus();
   };
 
@@ -465,6 +539,8 @@ export default function ProductSearchAutocomplete({
     }
     // >1 variação → toggla popover (open/close em click)
     setExpandedProductId((prev) => (prev === group.product_id ? null : group.product_id));
+    // G3 — abrir/fechar por clique zera o destaque de variação (teclado retoma do 0).
+    setVariationHighlightedIndex(-1);
   };
 
   return (
@@ -570,8 +646,9 @@ export default function ProductSearchAutocomplete({
           role="listbox"
           className="absolute z-50 mt-1 w-full max-h-72 overflow-auto rounded-md border border-border bg-popover shadow-md"
         >
-          {groups.map((group) => {
+          {groups.map((group, index) => {
             const isExpanded = expandedProductId === group.product_id;
+            const isHighlighted = index === highlightedIndex; // G3 — destaque teclado
             const firstVar = group.variations[0];
             // group.variations sempre tem ≥1 (garantido pelo groupResults).
             // Type guard explícito pro TS narrow.
@@ -588,8 +665,13 @@ export default function ProductSearchAutocomplete({
                   key={`g-${group.product_id}-${firstVar.variation_id}`}
                   type="button"
                   role="option"
+                  aria-selected={isHighlighted}
                   onClick={() => handleSelectVariation(firstVar)}
-                  className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none"
+                  className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm focus:outline-none ${
+                    isHighlighted
+                      ? 'bg-accent text-accent-foreground'
+                      : 'hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground'
+                  }`}
                 >
                   <div className="flex flex-col min-w-0">
                     <span className="font-medium truncate">{displayName}</span>
@@ -615,16 +697,24 @@ export default function ProductSearchAutocomplete({
               <Popover
                 key={`g-${group.product_id}`}
                 open={isExpanded}
-                onOpenChange={(o) => setExpandedProductId(o ? group.product_id : null)}
+                onOpenChange={(o) => {
+                  setExpandedProductId(o ? group.product_id : null);
+                  if (!o) setVariationHighlightedIndex(-1); // G3 — fechar zera destaque
+                }}
               >
                 <PopoverTrigger asChild>
                   <button
                     type="button"
                     role="option"
+                    aria-selected={isHighlighted}
                     aria-expanded={isExpanded}
                     aria-haspopup="listbox"
                     onClick={() => handleGroupClick(group)}
-                    className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none"
+                    className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm focus:outline-none ${
+                      isHighlighted || isExpanded
+                        ? 'bg-accent text-accent-foreground'
+                        : 'hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground'
+                    }`}
                   >
                     <div className="flex items-center gap-2 min-w-0">
                       <Package className="h-4 w-4 text-muted-foreground shrink-0" aria-hidden />
@@ -656,8 +746,12 @@ export default function ProductSearchAutocomplete({
                   align="start"
                   sideOffset={8}
                   className="w-80 p-0"
-                  // Evita roubar foco do input principal — popover lida com seu próprio teclado
+                  // Foco permanece no input principal: o popover é navegado pelas setas
+                  // do próprio input (G3). Prevenir open+close auto-focus evita que o
+                  // Radix mande o foco pro PopoverContent (abrir) ou pro trigger (fechar)
+                  // — qualquer um dos dois quebraria a navegação por teclado seguinte.
                   onOpenAutoFocus={(e) => e.preventDefault()}
+                  onCloseAutoFocus={(e) => e.preventDefault()}
                 >
                   <div className="border-b border-border px-3 py-2">
                     <p className="text-xs font-medium text-muted-foreground">
@@ -665,13 +759,18 @@ export default function ProductSearchAutocomplete({
                     </p>
                   </div>
                   <ul role="listbox" aria-label={`Variações de ${group.name}`} className="max-h-72 overflow-auto">
-                    {group.variations.map((v) => (
+                    {group.variations.map((v, vIndex) => (
                       <li key={`v-${v.variation_id}`}>
                         <button
                           type="button"
                           role="option"
+                          aria-selected={vIndex === variationHighlightedIndex}
                           onClick={() => handleSelectVariation(v)}
-                          className="flex w-full items-center justify-between px-3 py-2 text-left text-sm hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground focus:outline-none"
+                          className={`flex w-full items-center justify-between px-3 py-2 text-left text-sm focus:outline-none ${
+                            vIndex === variationHighlightedIndex
+                              ? 'bg-accent text-accent-foreground'
+                              : 'hover:bg-accent hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground'
+                          }`}
                         >
                           <div className="flex flex-col min-w-0">
                             <span className="font-medium truncate">

--- a/tests/product-keyboard-nav.test.tsx
+++ b/tests/product-keyboard-nav.test.tsx
@@ -1,0 +1,180 @@
+// Keyboard navigation test — G3 (2026-05-31, tela-venda-arte gap P0).
+//
+// Larissa @ Rota Livre opera teclado + scanner; antes do G3 o dropdown de
+// produto só respondia a Enter (match exato/scanner), forçando o mouse pra
+// escolher entre vários resultados ou pra abrir o popover de tamanhos. Este
+// teste exercita a navegação por seta que o G3 adicionou — comportamento que o
+// Pest estrutural (tests/Feature/Sells/) não consegue verificar.
+//
+// Estratégia: TIMERS REAIS + stub direto de `fetch` + queries assíncronas
+// (findBy/waitFor). Diferente do scanner-race.test.tsx (fake timers + MSW pra
+// controlar o race), aqui o caminho exercitado é o do debounce/useQuery
+// populando o dropdown — fake timers + MSW + react-query nesse encadeamento é
+// instável (o commit do react-query não settla determinística­mente sob
+// advanceTimersByTimeAsync). findBy espera o async naturalmente; o fetch stub
+// resolve na hora e o debounce de 250ms passa em tempo real.
+//
+// 3 cenários (o gap pedia exatamente estes):
+//   1) ↓ destaca o 1º item do dropdown (aria-selected)
+//   2) Enter no item destacado (variação única) seleciona o produto
+//   3) Enter num grupo multi-variação abre o popover e ↓+Enter escolhe o tamanho
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  render,
+  screen,
+  cleanup,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import ProductSearchAutocomplete, {
+  type ProductSearchResult,
+} from '@/Pages/Sells/_components/ProductSearchAutocomplete';
+
+// Catálogo espelhando a Larissa (vestuário): 1 item de variação única (boné) +
+// 1 item multi-variação com 3 tamanhos (camiseta P/M/G — o caso comum dela).
+const PRODUCTS: ProductSearchResult[] = [
+  {
+    product_id: 1,
+    variation_id: 11,
+    name: 'Boné Liso',
+    type: 'single',
+    sku: 'BONE-1',
+    selling_price: 30,
+    qty_available: 5,
+    unit: 'un',
+  },
+  {
+    product_id: 2,
+    variation_id: 21,
+    name: 'Camiseta',
+    type: 'variable',
+    variation: 'P',
+    sku: 'CAM-P',
+    selling_price: 50,
+    qty_available: 3,
+    unit: 'un',
+  },
+  {
+    product_id: 2,
+    variation_id: 22,
+    name: 'Camiseta',
+    type: 'variable',
+    variation: 'M',
+    sku: 'CAM-M',
+    selling_price: 50,
+    qty_available: 2,
+    unit: 'un',
+  },
+  {
+    product_id: 2,
+    variation_id: 23,
+    name: 'Camiseta',
+    type: 'variable',
+    variation: 'G',
+    sku: 'CAM-G',
+    selling_price: 50,
+    qty_available: 1,
+    unit: 'un',
+  },
+];
+
+beforeEach(() => {
+  // Stub direto de fetch — resolve na hora (sem MSW). react-query consome o array.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(
+      async () =>
+        ({
+          ok: true,
+          json: async () => PRODUCTS,
+        }) as unknown as Response,
+    ),
+  );
+});
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+});
+
+function renderAutocomplete() {
+  const onSelect = vi.fn();
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0, staleTime: 0 } },
+  });
+  render(
+    <QueryClientProvider client={queryClient}>
+      <ProductSearchAutocomplete locationId={1} onSelect={onSelect} />
+    </QueryClientProvider>,
+  );
+  return { onSelect };
+}
+
+// Digita um termo e espera o dropdown popular (debounce 250ms + fetch).
+async function typeAndOpen(input: HTMLInputElement, term: string) {
+  fireEvent.change(input, { target: { value: term } });
+  // findAllByRole aguarda (até 2s) o debounce + react-query abrirem o dropdown.
+  return screen.findAllByRole('option', undefined, { timeout: 2000 });
+}
+
+describe('ProductSearchAutocomplete — navegação por teclado (G3)', () => {
+  it('1) seta ↓ destaca o primeiro item do dropdown', async () => {
+    renderAutocomplete();
+    const input = screen.getByLabelText('Buscar produto') as HTMLInputElement;
+    const before = await typeAndOpen(input, 'ca');
+
+    // Grupos na ordem do payload: [Boné (single), Camiseta (multi)].
+    expect(before.length).toBeGreaterThanOrEqual(2);
+    expect(before[0]?.getAttribute('aria-selected')).toBe('false');
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' });
+
+    const after = screen.getAllByRole('option');
+    expect(after[0]?.getAttribute('aria-selected')).toBe('true');
+    expect(after[1]?.getAttribute('aria-selected')).toBe('false');
+  });
+
+  it('2) Enter no item destacado (variação única) seleciona o produto e fecha o dropdown', async () => {
+    const { onSelect } = renderAutocomplete();
+    const input = screen.getByLabelText('Buscar produto') as HTMLInputElement;
+    await typeAndOpen(input, 'ca');
+
+    fireEvent.keyDown(input, { key: 'ArrowDown' }); // destaca Boné (índice 0)
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(onSelect).toHaveBeenCalledTimes(1));
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ product_id: 1, variation_id: 11 }),
+    );
+    // Seleção limpa a query e fecha o dropdown.
+    await waitFor(() => expect(screen.queryByRole('listbox')).toBeNull());
+  });
+
+  it('3) Enter num grupo multi-variação abre o popover; ↓+Enter escolhe o tamanho por teclado', async () => {
+    const { onSelect } = renderAutocomplete();
+    const input = screen.getByLabelText('Buscar produto') as HTMLInputElement;
+    await typeAndOpen(input, 'ca');
+
+    // Navega até a Camiseta (índice 1, multi-variação).
+    fireEvent.keyDown(input, { key: 'ArrowDown' }); // 0 = Boné
+    fireEvent.keyDown(input, { key: 'ArrowDown' }); // 1 = Camiseta
+
+    // Enter abre o popover de tamanhos — NÃO seleciona ainda.
+    fireEvent.keyDown(input, { key: 'Enter' });
+    expect(onSelect).not.toHaveBeenCalled();
+
+    // As variações (P, M, G) aparecem no popover Radix (portal — espera 1 tick).
+    await screen.findByText('M', undefined, { timeout: 2000 });
+
+    // ↓ destaca a 2ª variação (M) e Enter seleciona.
+    fireEvent.keyDown(input, { key: 'ArrowDown' }); // variação 0 (P) -> 1 (M)
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => expect(onSelect).toHaveBeenCalledTimes(1));
+    expect(onSelect).toHaveBeenCalledWith(
+      expect.objectContaining({ variation_id: 22, variation: 'M' }),
+    );
+  });
+});


### PR DESCRIPTION
## Contexto
Parte do benchmark **tela-venda-arte** (2026-05-31) — gap **P0** priorizado: navegação 100% teclado no dropdown de produto. A Larissa (@ ROTA LIVRE, vestuário) opera teclado+scanner e tinha que pegar o mouse pra escolher variação/tamanho.

## O que muda

### G3 — navegação por teclado (o que move a agulha)
`ProductSearchAutocomplete`:
- ↑↓ navegam os **grupos** do dropdown e, dentro do popover, as **variações** (P/M/G — comum no vestuário).
- Enter: 1 variação → adiciona; multi → abre o popover destacando a 1ª; no popover → seleciona o tamanho.
- Esc recua (popover → grupo → fecha). `aria-selected` em cada item.
- **Preservado**: scanner físico (bipe+Enter), match SKU exato e a defesa anti-race R7 — as setas só agem com highlight ativo; scanner (Enter sem seta) cai no caminho legado intacto.

### Vitest ligado + 1º teste de componente do projeto
- Adiciona script `test`/`test:watch` (a config `vitest.config.ts` + `tests/js/setup.ts` já existiam da Onda 4 / ADR 0211, mas nunca tinham sido ligadas — faltava o script).
- `tests/product-keyboard-nav.test.tsx`: 3 cenários comportamentais (↓ destaca, Enter seleciona, popover multi-variação por teclado).

### G2 — remove import morto
Removido `import PageHeader` (sem uso). O header sticky-com-pills **é** o canon Cockpit V2 do charter — mantido (adotar o PageHeader global aqui contradiria o charter).

### G1 — cores de status mantidas de propósito (só anotado)
amber/blue/emerald no card "Status pgto" são **semântica de status** (convenção do projeto mantém cores de status intocadas). Anotado no código. Tokenizar = decisão de fundações DS-v3 (ADR), não desta tela.

## Validação
- ✅ **Vitest 50/50** (numberPtBR 44 + scanner-race 3 + keyboard-nav 3) — scanner-race **intacto**.
- ✅ **eslint baseline 1336 vs 1340 (delta −4)** — sem regressão.
- ✅ typecheck: 0 erro novo. Integra limpo com #2026 (DS migration do Sells).

## Notas
- Doc do benchmark com nota + top 5 gaps: `memory/sessions/2026-05-31-tela-venda-arte.md`.
- Restante do P1 (NFC-e inline no Create, batch price-group) fica pra próximo ciclo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
