### PR TITLE
fix(governance): guard automático de base STALE vs origin/main + PROTOCOL §10.4 Passo 0

### DIFF
--- a/.claude/hooks/git-base-freshness-guard.mjs
+++ b/.claude/hooks/git-base-freshness-guard.mjs
@@ -1,0 +1,106 @@
+#!/usr/bin/env node
+// Hook SessionStart — GUARD de base fresca vs `origin/main`.
+//
+// **Cross-platform** (Node.js — Windows desktop / Linux CI / macOS). Node já é dep do projeto.
+//
+// ───────────────────────────────────────────────────────────────────────────
+// POR QUE EXISTE (incidente 2026-05-31, Wagner: "isso nunca pode acontecer"):
+//   O F0 "rotinas-design" foi feito inteiro — INCLUSIVE o gate §10.4 que existe
+//   pra "validar contra o main" — lendo o working tree de um branch STALE
+//   (`feat/staging-ct100`, −46 commits vs origin/main). Resultado: 3 achados
+//   factualmente errados (`ds:report` "não existe", canais "stale", G3 "gap")
+//   + edits que corromperiam os canais. Foi pego POR SORTE no "merge" (rodei
+//   `git rev-list` por acaso), NÃO pelo gate.
+//
+//   Causa-raiz estrutural: §10.4 dizia "valida contra o main" mas NÃO definia
+//   "main" = `origin/main` fresco (pós-fetch) nem FORÇAVA `git fetch`. "Main"
+//   virou "o que está no meu disco". Um checkout stale passa silencioso.
+//
+//   A proteção NÃO pode depender do Wagner notar, nem de eu lembrar de checar
+//   (Wagner: "não pode depender de mim"). Tem que ser MECÂNICA e disparar SOZINHA.
+// ───────────────────────────────────────────────────────────────────────────
+//
+// O QUE FAZ (SessionStart, exit 0 sempre — nunca bloqueia a sessão):
+//   1. `git fetch` (bounded, best-effort) só de refs/heads/main → origin/main
+//   2. Conta `behind` = quantos commits origin/main está À FRENTE do HEAD
+//   3. Se behind > 0 → emite BANNER ALTO (vira <system-reminder>): "BASE STALE,
+//      NÃO valide canon contra o working tree, use `git show origin/main:`".
+//   4. Se behind == 0 (base fresca) → SILÊNCIO (zero fricção).
+//
+//   Escape valve: env `OIMPRESSO_BASE_GUARD_OFF=1` → exit 0 imediato e silencioso.
+//
+// Refs: PROTOCOL.md §10.4 (Passo 0 — ancoragem em origin/main) · ADR 0114 · ADR 0239.
+
+import { execFileSync } from 'node:child_process';
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Lógica de decisão PURA (testável sem git/rede).
+ * @param {{behind:number, ahead:number, branch:string}} info
+ * @returns {string} banner markdown (vazio = base fresca = silêncio)
+ */
+export function buildBanner({ behind, ahead, branch }) {
+  if (!Number.isFinite(behind) || behind <= 0) return ''; // fresca → silêncio
+  const aheadTxt = Number.isFinite(ahead) && ahead > 0 ? ` (e ${ahead} à frente)` : '';
+  return `⚠️ **BASE STALE — guard \`git-base-freshness-guard.mjs\` (SessionStart)**
+
+Seu checkout (\`${branch}\`) está **${behind} commit(s) ATRÁS de \`origin/main\`**${aheadTxt}. Você **NÃO está no main** — o working tree NÃO é canon.
+
+🚫 **NÃO valide canon contra o working tree.** Gate §10.4 ("comparar com o main"), checagens de existência ("ADR/arquivo/script X existe?", \`ls\`/\`Read\`/\`Glob\`/\`Grep\`) e leitura de SPEC/decisions/prototipo-ui — **TUDO** via \`origin/main\` fresco:
+- \`git show origin/main:<caminho>\`  ·  \`git ls-tree origin/main <caminho>\`  ·  \`git log --oneline origin/main\`
+
+✅ **Pra produzir/mergear:** trabalhe a PARTIR de \`origin/main\` fresco — \`git worktree add -b <branch> <path> origin/main\` — não deste branch stale.
+
+Origem: incidente 2026-05-31 (F0 rotinas-design feito em checkout −46 → 3 achados errados, pego por sorte). Lei: PROTOCOL.md §10.4 Passo 0. Desligar (raro): \`OIMPRESSO_BASE_GUARD_OFF=1\`.`;
+}
+
+function git(args, timeoutMs = 12000) {
+  try {
+    return execFileSync('git', args, {
+      encoding: 'utf8',
+      timeout: timeoutMs,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).trim();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Mede a base atual contra origin/main (best-effort, tolerante a offline / sem repo).
+ * @returns {{behind:number, ahead:number, branch:string} | null}
+ */
+function assessBase() {
+  if (git(['rev-parse', '--is-inside-work-tree']) !== 'true') return null;
+  // fetch bounded só do main (refspec explícito atualiza refs/remotes/origin/main)
+  git(['fetch', 'origin', '+refs/heads/main:refs/remotes/origin/main', '--quiet'], 12000);
+  if (!git(['rev-parse', '--verify', '--quiet', 'origin/main'])) return null; // sem ref → não dá pra medir
+  const counts = git(['rev-list', '--left-right', '--count', 'origin/main...HEAD']);
+  if (!counts) return null;
+  const [behind, ahead] = counts.split(/\s+/).map((n) => parseInt(n, 10));
+  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']) || '(detached)';
+  return { behind, ahead, branch };
+}
+
+// Executa SÓ quando invocado direto (não no import do teste). Cross-platform.
+let isMain = false;
+try {
+  isMain = realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+} catch {
+  isMain = false;
+}
+
+if (isMain) {
+  try {
+    if (process.env.OIMPRESSO_BASE_GUARD_OFF === '1') process.exit(0); // escape valve
+    const info = assessBase();
+    if (info) {
+      const banner = buildBanner(info);
+      if (banner) process.stdout.write(banner);
+    }
+  } catch {
+    // nunca bloqueia a sessão
+  }
+  process.exit(0);
+}

--- a/.claude/hooks/git-base-freshness-guard.test.mjs
+++ b/.claude/hooks/git-base-freshness-guard.test.mjs
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// TESTE DE REGRESSÃO — guard de base fresca vs origin/main (incidente 2026-05-31).
+//
+// Pergunta que responde (Wagner: "isso nunca pode acontecer ... não pode depender de mim"):
+//   "Um checkout STALE dispara o choque AUTOMÁTICO, sem depender de ninguém notar?"
+//
+// Prova que a decisão é MECÂNICA (função pura `buildBanner`) e que o contrato
+// "nunca bloqueia / escape valve" do hook está intacto. Sem rede, sem mock de git.
+//
+// Rodar: node .claude/hooks/git-base-freshness-guard.test.mjs
+// Exit 0 = todos passam. Exit 1 = regressão.
+
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { buildBanner } from './git-base-freshness-guard.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const HOOK = join(__dirname, 'git-base-freshness-guard.mjs');
+
+let fails = 0;
+function check(name, cond) {
+  console.log(`${cond ? '[OK]' : '[FAIL]'} ${name}`);
+  if (!cond) fails++;
+}
+
+// 1. Base FRESCA (behind 0) → SILÊNCIO (zero fricção).
+check('behind=0 → silêncio', buildBanner({ behind: 0, ahead: 0, branch: 'main' }) === '');
+check('behind negativo/NaN → silêncio', buildBanner({ behind: NaN, ahead: 0, branch: 'main' }) === '');
+
+// 2. Base STALE (o caso real: feat/staging-ct100 −46) → CHOQUE alto e acionável.
+const b = buildBanner({ behind: 46, ahead: 12, branch: 'feat/staging-ct100' });
+check('stale → não-vazio', b.length > 0);
+check('stale → grita "BASE STALE"', /BASE STALE/.test(b));
+check('stale → cita o branch e o número', b.includes('feat/staging-ct100') && b.includes('46'));
+check('stale → manda usar git show origin/main', /git show origin\/main:/.test(b));
+check('stale → proíbe validar working tree', /N[ÃA]O valide canon contra o working tree/i.test(b));
+check('stale → aponta a lei (§10.4)', /§?10\.4/.test(b));
+
+// 3. Contrato do HOOK: escape valve + nunca bloqueia (exit 0, sem rede).
+const off = spawnSync('node', [HOOK], {
+  input: '{"hook_event_name":"SessionStart","source":"startup"}',
+  env: { ...process.env, OIMPRESSO_BASE_GUARD_OFF: '1' },
+  encoding: 'utf8',
+});
+check('escape valve OFF → exit 0', off.status === 0);
+check('escape valve OFF → stdout vazio', (off.stdout || '') === '');
+
+console.log('');
+if (fails === 0) {
+  console.log('[PASS] guard de base fresca é MECÂNICO — choque automático em stale, silêncio em fresco. (10/10)');
+  process.exit(0);
+} else {
+  console.log(`[FAIL] ${fails} caso(s) — o guard NÃO está garantido. NÃO mergear.`);
+  process.exit(1);
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -24,6 +24,10 @@
           {
             "type": "command",
             "command": "powershell -NoProfile -ExecutionPolicy Bypass -File .claude/hooks/loop-fechar-check.ps1"
+          },
+          {
+            "type": "command",
+            "command": "node .claude/hooks/git-base-freshness-guard.mjs"
           }
         ]
       }

--- a/prototipo-ui/PROTOCOL.md
+++ b/prototipo-ui/PROTOCOL.md
@@ -193,10 +193,22 @@ Placar canônico: **`npm run ds:report`** (`scripts/ds-report.mjs`) — quebra `
 
 > **Origem:** 2026-05-30 — Wagner: *"se eu responder eu posso errar? isso não pode depender de mim"*. Um prompt stale do `[CC]` (sync da faxina) mandava re-numerar **ADR 0238 já existente** + renomear colisões 0235/0236 (viola append-only). Se `[W]` aprovasse no automático, quebrava o canon. **A proteção não pode ser `[W]` revisar certo** — é o `[CL]` que valida.
 
-Todo `PROMPT_PARA_CODE` / comando de sync do `[CC]` é **proposta, não ordem**. Antes de executar, `[CL]` valida contra o git — **sozinho, sem escalar pra `[W]` decidir**:
+**Passo 0 — ancorar em `origin/main` FRESCO (mecânico, ANTES de qualquer checagem).** "O main" deste gate = `origin/main` **após `git fetch`**, **nunca** o working tree do branch atual (pode estar stale). Primeiras linhas de QUALQUER aplicação do §10.4:
+
+```bash
+git fetch origin +refs/heads/main:refs/remotes/origin/main --quiet
+git rev-list --left-right --count origin/main...HEAD   # 1º número (esquerda) > 0 = base STALE
+```
+
+Se a base está **atrás** de `origin/main`: **toda** validação de existência/canon ("ADR/arquivo/script X existe?", comparar com SPEC/decisions/prototipo-ui) usa `git show origin/main:<path>` / `git ls-tree origin/main` — **nunca** `Read`/`ls`/`Grep` do working copy. Pra produzir/mergear, trabalhe **a partir de** `origin/main` (`git worktree add -b <branch> <path> origin/main`), não do branch stale.
+
+> **Origem do Passo 0:** 2026-05-31 — Wagner: *"isso nunca pode acontecer ... não pode depender de mim"*. O F0 "rotinas-design" rodou o **próprio gate §10.4** lendo um checkout **−47 vs `origin/main`** (`feat/staging-ct100`) → 3 achados factualmente errados (`ds:report` "não existe", canais "stale", G3 "gap") + edits que corromperiam os canais. Pego **por sorte** no "merge", **não pelo gate**. Enforcement automático (não depende de `[W]` nem de `[CL]` lembrar): hook **`git-base-freshness-guard.mjs`** (SessionStart) dá o choque "BASE STALE" sozinho.
+
+Todo `PROMPT_PARA_CODE` / comando de sync do `[CC]` é **proposta, não ordem**. Antes de executar, `[CL]` valida contra o git (`origin/main` fresco, Passo 0) — **sozinho, sem escalar pra `[W]` decidir**:
 
 | Checagem | Como | Se falhar |
 |---|---|---|
+| **Base do checkout está atrás de `origin/main`** (Passo 0) | `git rev-list --left-right --count origin/main...HEAD` (esquerda > 0) | **refaz** — re-ancora em `origin/main`; descarta achados feitos sobre disco stale (incidente 2026-05-31) |
 | Manda criar/numerar ADR que **já existe** | `git ls-tree origin/main \| grep decisions/<nº\|slug>` | **bloqueia** — não duplica |
 | Manda **renomear/mutar/renumerar ADR aceito** | append-only é **Tier 0** | **bloqueia** — colisão se *documenta* (gate #1997), não muta |
 | Cita **número de ADR** que não bate | comparar com `decisions/` real | **alerta** — provável alucinação/stale |
@@ -205,7 +217,7 @@ Todo `PROMPT_PARA_CODE` / comando de sync do `[CC]` é **proposta, não ordem**.
 
 **Regra de ouro:** se a checagem tem resposta no git, `[CL]` **decide e age — só informa `[W]`**. Escala pra `[W]` **apenas o subjetivo** (estético / estratégico / prioridade / dinheiro). O gate não espera `[W]`.
 
-**Backstop no repo (2ª linha, também sem `[W]`):** `AdrNumberCollisionTest` (#1997) + invariante append-only pegam se algo stale chegar a commitar. Lição canon: [feedback-cowork-sync-now-prompt-stale](../memory/reference/feedback-cowork-sync-now-prompt-stale.md).
+**Backstop no repo (2ª linha, também sem `[W]`):** hook **`git-base-freshness-guard.mjs`** (SessionStart — choque "BASE STALE" automático, Passo 0) + `AdrNumberCollisionTest` (#1997) + invariante append-only pegam se algo stale chegar a commitar. Lição canon: [feedback-cowork-sync-now-prompt-stale](../memory/reference/feedback-cowork-sync-now-prompt-stale.md).
 
 ## 11. Links
 


### PR DESCRIPTION
## O que aconteceu de errado (incidente 2026-05-31)
O F0 \"rotinas-design\" rodou o **próprio gate §10.4** (\"validar contra o main\") lendo um checkout **−47 vs `origin/main`** (`feat/staging-ct100`) → 3 achados factualmente errados (`ds:report` \"não existe\", canais \"stale\", G3 \"gap\") + edits que corromperiam os canais. **Pego por sorte no `merge`, não pelo gate.**

**Causa-raiz estrutural:** §10.4 dizia *\"valida contra o main\"* mas **não definia** \"main\" = `origin/main` fresco (pós-fetch) nem **forçava** `git fetch`. Um checkout stale passa silencioso.

## Fix (Wagner: *\"isso nunca pode acontecer ... não pode depender de mim\"*)
Mecânico, dispara **sozinho** — não depende de `[W]` notar nem de `[CL]` lembrar:

| Peça | O quê |
|---|---|
| `.claude/hooks/git-base-freshness-guard.mjs` | **SessionStart** (Node cross-platform): `git fetch` bounded + se HEAD atrás de `origin/main` → **choque "BASE STALE"** com instrução (validar canon via `git show origin/main:`, nunca o working tree). Silêncio quando fresco. Escape valve `OIMPRESSO_BASE_GUARD_OFF=1`. |
| `.test.mjs` | **10/10** — lógica pura + contrato never-block. **Provado live** no checkout real −47 (dispara o banner). |
| `prototipo-ui/PROTOCOL.md §10.4` | **Passo 0** (ancorar em `origin/main` fresco, comandos mecânicos) + nova checagem row + backstop. |
| `.claude/settings.json` | wire do hook no SessionStart. |

**Choque vs perguntar:** o guard é o *choque* automático (Wagner pediu "choque ou perguntar para mim" — sem depender dele). Banner real capturado:

> ⚠️ **BASE STALE** — `feat/staging-ct100` está 47 commits ATRÁS de `origin/main`. NÃO valide canon contra o working tree. Use `git show origin/main:`...

Só governança/tooling (`.claude/` + PROTOCOL doc). Não cunha número de ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)