### PR TITLE
fix(designsystem): US-014 R9 <main> aninhado -> div (12 telas) + R3 scorer FP

### DIFF
--- a/prototipo-ui/audit/score-mechanized.mjs
+++ b/prototipo-ui/audit/score-mechanized.mjs
@@ -73,7 +73,18 @@ function detect(src) {
   const h = {};
   h.R1 = [...(src.match(RX.hex) || []).filter((x) => !/^#(?:fff|ffffff|000|000000)$/i.test(x)), ...(src.match(RX.colorFn) || [])];
   h.R2 = src.match(RX.native) || [];
-  h.R3 = []; let m; RX.ls.lastIndex = 0; while ((m = RX.ls.exec(src))) if (!m[1].startsWith('oimpresso.')) h.R3.push(m[1]);
+  h.R3 = []; let m; RX.ls.lastIndex = 0;
+  while ((m = RX.ls.exec(src))) {
+    const key = m[1];
+    if (key.startsWith('oimpresso.')) continue;
+    // ${VAR}... — resolve a const no arquivo; se VAR = 'oimpresso.*' está OK (não é violação)
+    const tv = key.match(/^\$\{(\w+)\}/);
+    if (tv) {
+      const d = new RegExp('(?:const|let|var)\\s+' + tv[1] + '\\s*=\\s*[\'"`]([^\'"`]+)').exec(src);
+      if (d && d[1].startsWith('oimpresso.')) continue;
+    }
+    h.R3.push(key);
+  }
   h.R4 = [...(src.match(RX.svg) || []), ...(src.match(RX.iconLib) || [])];
   h.R6 = src.match(RX.emoji) || [];
   h.R7 = src.match(RX.statusFill) || [];

--- a/resources/js/Pages/Cliente/Map.tsx
+++ b/resources/js/Pages/Cliente/Map.tsx
@@ -124,7 +124,7 @@ export default function ClienteMap(props: ClienteMapPageProps) {
             </div>
           </aside>
 
-          <main className="md:col-span-2">
+          <div className="md:col-span-2">
             <div className="rounded-lg border border-border bg-background overflow-hidden h-[calc(100vh-12rem)]">
               <div className="h-full flex flex-col">
                 <div className="px-4 py-3 border-b border-border bg-muted/30">
@@ -176,7 +176,7 @@ export default function ClienteMap(props: ClienteMapPageProps) {
                 )}
               </div>
             </div>
-          </main>
+          </div>
         </div>
       </div>
     </div>

--- a/resources/js/Pages/Compras/Index.tsx
+++ b/resources/js/Pages/Compras/Index.tsx
@@ -301,7 +301,7 @@ function ComprasIndex({ filters, selected_id, permissions, kpis, rows, summary, 
         {/* BODY */}
         <div className={`bd ${drawerOpen ? 'with-drawer' : ''}`}>
           {/* LISTA */}
-          <main className="list">
+          <div className="list">
             <Deferred data="kpis" fallback={<KpisSkeleton />}>
               {kpis ? <KpisGrid k={kpis} /> : <KpisSkeleton />}
             </Deferred>
@@ -337,7 +337,7 @@ function ComprasIndex({ filters, selected_id, permissions, kpis, rows, summary, 
                 <SummaryFooter summary={summary} meta={rows.meta} onPageChange={(p) => navigateWithFilters({ page: p })} />
               ) : null}
             </Deferred>
-          </main>
+          </div>
 
           {/* DRAWER 5 tabs sobre grid */}
           {drawerOpen && (

--- a/resources/js/Pages/Financeiro/Advisor/Dashboard.tsx
+++ b/resources/js/Pages/Financeiro/Advisor/Dashboard.tsx
@@ -55,7 +55,7 @@ function Dashboard({ advisor, clientes, total_clientes }: Props) {
         </div>
       </header>
 
-      <main className="max-w-6xl mx-auto px-6 py-8 space-y-6">
+      <div className="max-w-6xl mx-auto px-6 py-8 space-y-6">
         <section>
           <h2 className="text-base font-semibold">Meus clientes ({total_clientes})</h2>
           <p className="text-sm text-muted-foreground">
@@ -109,7 +109,7 @@ function Dashboard({ advisor, clientes, total_clientes }: Props) {
             ))}
           </div>
         )}
-      </main>
+      </div>
     </div>
   );
 }

--- a/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx
+++ b/resources/js/Pages/OficinaAuto/ProducaoOficina/Index.tsx
@@ -598,7 +598,7 @@ export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
         </div>
 
         {/* ─── Kanban 5 colunas (drag-drop entre colunas) ─── */}
-        <main className="p-6">
+        <div className="p-6">
           <KanbanDndProvider onMove={handleDragMove}>
             <div className="grid grid-cols-5 gap-4">
               {columnsData.map((col) => (
@@ -612,7 +612,7 @@ export default function ProducaoOficinaIndex({ kanban, kpis, filters }: Props) {
               ))}
             </div>
           </KanbanDndProvider>
-        </main>
+        </div>
       </div>
 
       {/* Drawer rico polimórfico (locação CNAE 4581 + manutenção CNAE 4520) — Wave 2.2 US-OFICINA-027

--- a/resources/js/Pages/Produto/BulkEdit.tsx
+++ b/resources/js/Pages/Produto/BulkEdit.tsx
@@ -182,7 +182,7 @@ function ProdutoBulkEdit(props: ProdutoBulkEditPageProps) {
           </div>
         </header>
 
-        <main className="pb-16 px-6 mt-4">
+        <div className="pb-16 px-6 mt-4">
           {/* Banner aviso destrutivo */}
           <div className="rounded-md bg-amber-50 border border-amber-200 p-4 flex items-start gap-3">
             <AlertTriangle className="w-5 h-5 text-amber-700 shrink-0 mt-0.5" />
@@ -359,7 +359,7 @@ function ProdutoBulkEdit(props: ProdutoBulkEditPageProps) {
               </div>
             </div>
           </form>
-        </main>
+        </div>
       </div>
     </>
   );

--- a/resources/js/Pages/Produto/Create.tsx
+++ b/resources/js/Pages/Produto/Create.tsx
@@ -157,7 +157,7 @@ function ProdutoCreate(props: ProdutoCreatePageProps) {
           </div>
         </header>
 
-        <main className="pb-16 px-6 mt-4 max-w-5xl">
+        <div className="pb-16 px-6 mt-4 max-w-5xl">
           <form id="produto-create-form" onSubmit={handleSubmit} className="space-y-6">
             {/* Identificação */}
             <Card>
@@ -439,7 +439,7 @@ function ProdutoCreate(props: ProdutoCreatePageProps) {
               </div>
             </details>
           </form>
-        </main>
+        </div>
       </div>
     </>
   );

--- a/resources/js/Pages/Produto/Edit.tsx
+++ b/resources/js/Pages/Produto/Edit.tsx
@@ -157,7 +157,7 @@ function ProdutoEdit(props: ProdutoEditPageProps) {
           </div>
         </header>
 
-        <main className="pb-16 px-6 mt-4 max-w-5xl">
+        <div className="pb-16 px-6 mt-4 max-w-5xl">
           <form id="produto-edit-form" onSubmit={handleSubmit} className="space-y-6">
             <Card>
               <CardHeader>
@@ -398,7 +398,7 @@ function ProdutoEdit(props: ProdutoEditPageProps) {
               </div>
             </details>
           </form>
-        </main>
+        </div>
       </div>
     </>
   );

--- a/resources/js/Pages/Produto/Index.tsx
+++ b/resources/js/Pages/Produto/Index.tsx
@@ -167,7 +167,7 @@ function ProdutoIndex(props: ProdutoIndexPageProps) {
           </div>
         </header>
 
-        <main className="pb-16">
+        <div className="pb-16">
           {/* KPI strip */}
           <section className="mx-6 mt-4 rounded-md bg-white border border-stone-200 shadow-sm">
             <Deferred data="kpis" fallback={<KpisSkeleton />}>
@@ -215,7 +215,7 @@ function ProdutoIndex(props: ProdutoIndexPageProps) {
               <ProdutoCards rows={filterRows(props.rows)} permissions={permissions} />
             </Deferred>
           </section>
-        </main>
+        </div>
       </div>
     </>
   );

--- a/resources/js/Pages/Produto/SellingPrices.tsx
+++ b/resources/js/Pages/Produto/SellingPrices.tsx
@@ -139,7 +139,7 @@ function ProdutoSellingPrices(props: ProdutoSellingPricesPageProps) {
           </div>
         </header>
 
-        <main className="pb-16 px-6 mt-4">
+        <div className="pb-16 px-6 mt-4">
           {priceGroups.length === 0 ? (
             <div className="rounded-md bg-white border border-stone-200 p-6 text-center text-stone-500 text-[13px]">
               Nenhum grupo de preço cadastrado. Cadastre primeiro em Inventário › Grupos de preço.
@@ -230,7 +230,7 @@ function ProdutoSellingPrices(props: ProdutoSellingPricesPageProps) {
               </p>
             </form>
           )}
-        </main>
+        </div>
       </div>
     </>
   );

--- a/resources/js/Pages/Produto/Show.tsx
+++ b/resources/js/Pages/Produto/Show.tsx
@@ -139,7 +139,7 @@ function ProdutoShow(props: ProdutoShowPageProps) {
           </nav>
         </header>
 
-        <main className="pb-16 px-6 mt-4 max-w-5xl">
+        <div className="pb-16 px-6 mt-4 max-w-5xl">
           {activeTab === 'resumo' && <ResumoTab product={product} />}
           {activeTab === 'variacoes' && (
             <Deferred data="variations" fallback={<TabSkeleton />}>
@@ -151,7 +151,7 @@ function ProdutoShow(props: ProdutoShowPageProps) {
               <EstoqueTab rackDetails={props.rackDetails ?? []} />
             </Deferred>
           )}
-        </main>
+        </div>
       </div>
     </>
   );

--- a/resources/js/Pages/Produto/Unificado/Index.tsx
+++ b/resources/js/Pages/Produto/Unificado/Index.tsx
@@ -137,7 +137,7 @@ function ProdutoUnificadoIndex({ tela, filters, kpis, produtos, categorias, insu
           </nav>
         </header>
 
-        <main className="pb-16">
+        <div className="pb-16">
           {/* KPI strip */}
           <section className="mx-6 mt-4 rounded-md bg-white border border-stone-200 shadow-sm grid grid-cols-5 divide-x divide-stone-200 overflow-hidden">
             <Kpi label="Catálogo ativo" value={kpis.catalogo_ativo} emphasize />
@@ -153,7 +153,7 @@ function ProdutoUnificadoIndex({ tela, filters, kpis, produtos, categorias, insu
           {tela === 'insumos'    && <ListaInsumos rows={insumos} />}
           {tela === 'tabelas'    && <ListaTabelas rows={tabelas} produtos={produtos} />}
           {tela === 'historico'  && <ListaHistorico rows={historico} />}
-        </main>
+        </div>
 
         {/* Tweaks panel (canto inferior direito) — reutilizar `<TweaksPanel>` do design system. */}
         <TweaksPanel tweaks={tweaks} setTweak={setTweak} />

--- a/resources/js/Pages/Repair/ProducaoOficina/Index.tsx
+++ b/resources/js/Pages/Repair/ProducaoOficina/Index.tsx
@@ -244,7 +244,7 @@ export default function ProducaoOficinaIndex({ columns, totals, data_source, slo
       </div>
 
       {/* Kanban */}
-      <main className="flex-1 p-6 overflow-hidden">
+      <div className="flex-1 p-6 overflow-hidden">
         <div className="grid grid-cols-5 gap-4 h-full">
           {filteredColumns.map((col) => (
             <KanbanColumn
@@ -269,7 +269,7 @@ export default function ProducaoOficinaIndex({ columns, totals, data_source, slo
             />
           ))}
         </div>
-      </main>
+      </div>
 
       {/* Drawer overlay */}
       {activeCard && <JobDrawer card={activeCard} labelOverrides={label_overrides} onClose={() => setActiveCard(null)} />}


### PR DESCRIPTION
## US-_DESIGNSYSTEM-014 — lote seguro (R9 + R3)

Primeiro fix derivado da worklist. **Sem gate visual** — estrutural/invisível.

### R9 (AP9: `<main>` aninhado) — 12 telas
`<main>` dentro do `<AppShellV2>` → `<div>`. O AppShellV2 já provê o `<main>` landmark único; um 2º `<main>` na Page viola HTML5 + confunde leitor de tela. Telas: Produto/{Index,Show,Create,Edit,BulkEdit,SellingPrices,Unificado/Index} · Compras/Index · Cliente/Map · OficinaAuto/ProducaoOficina · Repair/ProducaoOficina · Financeiro/Advisor/Dashboard.
- **StockHistory pulado** (está na Onda-0 WIP de outro fluxo — evita conflito). R9 fail **13→1**.
- **Invisível confirmado:** 0 seletor CSS de elemento `main` no canon; os wrappers usam classes Tailwind explícitas (preservadas).

### R3 (localStorage prefix) — falso-positivo do scorer
`Repair/DeviceModels/Index` usa `LS_PREFIX = 'oimpresso.repair.device_models.index'` — **já compliant**. O regex do scorer não resolvia `${VAR}`. **Corrigi o scorer** (não o código) → R3 fail **1→0**.

### Evidência (close-by-evidence)
`node prototipo-ui/audit/score-mechanized.mjs` → **R9=1** (só StockHistory, fora do escopo) · **R3=0**.

Fecha o grosso de **US-_DESIGNSYSTEM-014** (StockHistory fica pra Onda 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
