### PR TITLE
docs(financeiro): Método 9.75 Financeiro — roadmap reconstruído + correção pós pré-flight

### DIFF
--- a/memory/requisitos/Financeiro/AUDIT-METODO-9.75-TELAS-2026-05-31.md
+++ b/memory/requisitos/Financeiro/AUDIT-METODO-9.75-TELAS-2026-05-31.md
@@ -1,0 +1,103 @@
+---
+slug: audit-metodo-9-75-telas-financeiro
+title: "Auditoria Método 9.75 — telas do Financeiro (código real)"
+type: audit
+authority: canonical
+lifecycle: ativo
+session_date: '2026-05-31'
+quarter: 2026-Q2
+related:
+  - '0093'
+  - '0190'
+pii: false
+---
+
+# Auditoria Método 9.75 — telas do Financeiro (código real)
+
+> **Origem (2026-05-31):** re-auditoria **read-only** das telas do Financeiro contra o método **KB-9.75**, lendo o **código real** (`Modules/Financeiro/Http/Controllers/*` + `resources/js/Pages/Financeiro/*` + `_components`), feita por **5 agentes em paralelo** (1 por tela). Motivada pela descoberta (PR #2040) de que a [BRIEFING.md](BRIEFING.md) estava atrás do código.
+>
+> **A correção que esta auditoria traz:** o doc [METODO-9.75-FINANCEIRO.md](METODO-9.75-FINANCEIRO.md) concluiu "módulo já ~9,3". **Errado.** Só o **Unificado** está em ~9,3 — as outras telas estão muito abaixo **e carregam bugs reais** (não só falta de polish). Média real do módulo ≈ **5,2/10**.
+
+---
+
+## 1. Placar real (por tela)
+
+| Tela | Score | Nav · Cur · IA · Guia · Saída | Achado mais crítico |
+|---|---:|---|---|
+| **Unificado** | **9,3** | 9 · 9 · 5,5 · 6 · 7,5 | Flagship. aging/anexos/audit/OCR/auto-suggest/workflow já feitos (verificado em sessão anterior). |
+| **Cobrança** | **7,0** | 8 · 6 · 6 · 4 · 5 | 🟠 muitos botões **NO-OP** (Cancelar/Estornar/Reemitir/Baixar PDF/Exportar/Copiar sem `onClick`). Só "Nova cobrança→Emitir" e "Cobrar cartão" gravam. |
+| **DRE** | **6,0** | 5,5 · 3 · 1,5 · 1 · 8 | Export PDF/XLSX/CSV real ✅. Mas **5 botões topnav são stub** (Buscar/Resumir/Apresentar) + CSV funciona mas **sem botão na UI**. |
+| **Conciliação** | **3,2** | 4 · 2,5 · 1,5 · 1 · 1 | 🔴 `match_score` é **fake `0.85` hardcoded** (não calculado); **sem audit log**; usa `DB::table` raw **sem model com BusinessScope** (rede de proteção Tier 0 ausente). |
+| **Relatórios** | **3,2** | 4 · 1 · 1 · 2 · 4 | Tela sendo **esvaziada** (DRE saiu p/ `/dre`, aba Fluxo duplica `/fluxo` de forma mais pobre). Só CSV, sem PDF/XLSX. |
+| **Extrato** | **2,4** | 3 · 1,5 · 0,5 · 1,5 · 1 | 🔴 **link de sidebar quebrado** (ghost → `/financeiro/extrato` sem `contaId` → 404); **sem cross-link extrato↔título**. Tela mais fraca. |
+
+**Média ≈ 5,2.** O Unificado mascara o resto.
+
+---
+
+## 2. Cinco verdades módulo-wide (o que a documentação não contava)
+
+1. 🔴 **"IA" no Financeiro NÃO é LLM.** `FinMonthDigest`, `FinMonthResume`, `AiResumoMes`, `FinTroubleshooter` são **compute/heurística pura** (os próprios arquivos declaram "sem LLM"). O **único** uso real de modelo é `BoletoOcrService` (OCR Vision no Unificado). → **RAG "perguntar" (I2) é gap genuíno e módulo-wide.** Proposta: [ADR arq/0006](adr/arq/0006-rag-perguntar-historico-financeiro.md).
+2. 🟠 **Botões decorativos (NO-OP / stub).** Cobrança e DRE têm vários botões com visual estado-da-arte mas **sem handler**. Pior que faltar: dá feedback falso. Anti-padrão "botão decorativo" — mata confiança da Eliana/Larissa.
+3. 🔴 **Conciliação tem confiança fake + risco Tier 0.** `match_score` constante `0.85` (controller `sugerirMatches`), `DB::table('fin_bank_statement_lines')` raw sem Eloquent+`BusinessScope` (isolamento só funciona porque cada query repete `where business_id` manual — sem rede de proteção), e `match()`/`ignorar()` **não chamam** `FinanceiroAuditLogger` (que existe) apesar do comentário "append-only audit".
+4. 🟠 **Extrato e Conciliação são 2 sistemas paralelos que não se falam.** `fin_extrato_lancamentos` (sync API, sem `titulo_id`) vs `fin_bank_statement_lines` (upload OFX, com `titulo_id`/match). Decisão de produto pendente: qual é a fonte da conciliação?
+5. 🟡 **Inconsistências:** `session('business.id')` (Extrato) vs `session('user.business_id')` (resto); permissão `financeiro.relatorios.view` (DRE/Relatórios) vs `financeiro.dashboard.view` (Fluxo); `Relatorios/Index.review.md` é STALE (descreve 592 linhas/DRE/paginate que não existem mais).
+
+---
+
+## 3. Backlog priorizado (corrigido pós-auditoria)
+
+> Separa **correção (certo vs errado)** de **maturidade 9,75 (bom vs ótimo)**. Cada item respeita as restrições F3 (§4). Cada um ≈ 1 PR ≤300 linhas, charter + Pest + smoke biz=1.
+
+### 🔴 P0 — Correção / bug (não é polish)
+| # | Item | Tela | Plug-point real |
+|---|---|---|---|
+| B1 | `match_score` calculado de verdade (valor 0.7 + proximidade-data 0.3, como o docblock promete) | Conciliação | `ConciliacaoController::sugerirMatches` (hoje grava `0.85`) |
+| B2 | Chamar `FinanceiroAuditLogger` em `match()`/`ignorar()` + ação **reabrir** (desfazer) | Conciliação | controller + rota `POST /conciliacao/{id}/reabrir` |
+| B3 | Model Eloquent `BankStatementLine` com `BusinessScope` (rede Tier 0; hoje é `DB::table` raw) | Conciliação | novo model + refactor queries |
+| B4 | Corrigir ghost de sidebar do Extrato (→ seletor de conta, não `/extrato` sem id → 404) | Extrato | `DataController` ghost + rota |
+| B5 | Padronizar `session('user.business_id')` (Extrato usa `business.id`) | Extrato | `ExtratoController` |
+| B6 | Ligar **ou remover** botões NO-OP/stub (Copiar/Baixar PDF/Cancelar/Estornar/Reemitir/Exportar; topnav DRE) | Cobrança, DRE | wire `onClick` ou tirar o botão |
+
+### 🟡 P1 — Maturidade 9,75 (sem ADR, reusa o que existe)
+| # | Item | Tela | Reusa |
+|---|---|---|---|
+| M1 | Expor botão CSV do DRE (rota existe, sem botão) + dropdown CSV/PDF/XLSX | DRE | `dre/export-csv` pronta |
+| M2 | Ligar "Apresentar" (stub) ao `FinPresentationMode` | DRE, Relatórios | componente existe |
+| M3 | Export PDF/XLSX em Relatórios (paridade DRE) + `Inertia::defer` por aba | Relatórios | espelhar `DreController::exportPdf/Xlsx` |
+| M4 | Aging pill colorida (fresco/atrasando/stale) + empty-state melhor | Extrato | dado `saldo_atualizado_em` já chega |
+| M5 | Cross-link read-only extrato↔título (chip "→ Título #N") | Extrato | lookup por valor+data |
+| M6 | Auto-sugerir categoria/plano-de-contas no lançamento (I3) | Unificado, Conciliação | estende `sugerirValor` |
+| M7 | Comentários (`FinCommentsThread`) + "conferido" no drawer de Cobrança/Conciliação | Cobrança, Conciliação | componente existe no Unificado |
+
+### 🔵 P2 — Maturidade 9,75 (precisa ADR / é maior)
+| # | Item | Escopo |
+|---|---|---|
+| A1 | **RAG "perguntar ao histórico"** (I2) — maior salto de score | [ADR arq/0006](adr/arq/0006-rag-perguntar-historico-financeiro.md) proposta neste PR |
+| A2 | Trilhas de onboarding (G3) da Eliana | sem ADR, mas é feature nova |
+| A3 | Mobile cards + a11y (N5) | gap recorrente |
+| A4 | Decisão de produto: Relatórios vira só "Resumo" + redireciona Fluxo→`/fluxo`? Extrato vs Conciliação fonte única? | Wagner decide |
+
+---
+
+## 4. Restrições de execução (lições F3 — gates duros, enforcement PHPStan)
+
+- Models reais: `Titulo`/`TituloBaixa`/`ContaBancaria`/`Categoria`/`PlanoConta`/`ExtratoLancamento`/`TituloAnexo`/`TituloComment`/`BoletoRemessa`. Cobrança usa `PaymentGateway\Cobranca` (módulo separado), **não** `Titulo`.
+- `session('user.business_id')` + `can:financeiro.*` (`oimpresso.missingTenantScope`).
+- Refator/extensão de tela em prod = **PR separado sobre o controller real**, nunca regenerar.
+- Sem NO-OP `return back()` em mutação (`oimpresso.nopMutation`) · sem fallback silencioso (`oimpresso.silentFallback`) · idempotência + soft-delete.
+- Schema/Service/componente-shared novo = **ADR primeiro**.
+
+---
+
+## 5. Recomendação de execução
+
+1. **P0 primeiro** — são bugs/risco, não estética. O `match_score` fake (B1) e o `DB::table` raw sem BusinessScope (B3) são os mais sérios (engana a Eliana + risco Tier 0). B4 (link 404) e B6 (botões mortos) são baratos e de alta percepção.
+2. **P1 em wave paralela** — M1..M7 são isolados por tela, reusam código existente, baixo risco → bom candidato a paralelizar (como esta auditoria).
+3. **P2 com gate** — RAG (A1) só após Wagner aceitar a [ADR arq/0006](adr/arq/0006-rag-perguntar-historico-financeiro.md). A4 é decisão de produto.
+
+**Meta realista:** fechar P0 + P1 leva o módulo de ~5,2 → ~8,5 (telas secundárias deixam de arrastar). RAG (P2) + trilhas levam a 9,75.
+
+---
+
+**Status:** auditoria concluída 2026-05-31 (5 agentes paralelos, código real). Backlog aguardando Wagner priorizar. Nenhum código alterado nesta auditoria.

--- a/memory/requisitos/Financeiro/BRIEFING.md
+++ b/memory/requisitos/Financeiro/BRIEFING.md
@@ -2,7 +2,32 @@
 
 > Visão unificada de AR/AP (Contas a Receber / Contas a Pagar) + Fluxo de Caixa + Boletos + Conciliação OFX + Plano de Contas BR + Workflow Aprovação. Cockpit V2 persona Eliana [E] (financeiro escritório, densidade alta, atalhos teclado).
 
-**Última atualização:** 2026-05-20 tarde · **27 PRs Ondas 12-26** ([#1158→#1252](https://github.com/wagnerra23/oimpresso.com/pulls)) · Bundle copy CSS canon 9054 LOC · 7 funções novas · paridade canon 4.8→**9.8/10** · drawer detalhe **10/10** · cobertura funcional 75%→**87%**.
+**Última atualização:** 2026-05-31 — **reconciliação BRIEFING × código real** (pré-flight do [Método 9.75 Financeiro](METODO-9.75-FINANCEIRO.md), [PR #2040](https://github.com/wagnerra23/oimpresso.com/pull/2040)). A entrada anterior (2026-05-20) ficou **atrás do código**: uma wave de features (US-FIN-021..029) entrou depois e não estava documentada aqui — o que induziu um roadmap errado. Bloco de reconciliação abaixo. Histórico 05-20 preservado mais abaixo (append-only).
+
+## 🔁 Reconciliação 2026-05-31 — features US-FIN-021..029 já em `main` (não estavam na briefing)
+
+> **Como foi verificado:** leitura direta de `Modules/Financeiro/Http/Controllers/UnificadoController.php` + `resources/js/Pages/Financeiro/Unificado/Index.tsx` + `_components/*` no código de `origin/main` (2026-05-31). Fonte da verdade = código, não doc. ⚠️ O [CHANGELOG.md](CHANGELOG.md) também está atrás (parado na Wave 18) — atualizar junto numa próxima.
+
+**Funções que a briefing 05-20 NÃO listava mas existem em prod** (método real no controller entre parênteses):
+
+| US / função | Evidência no código |
+|---|---|
+| US-FIN-021 — Insert manual de título | `UnificadoController::store()` (substitui stub `/unificado/novo`) |
+| US-FIN-022 — Aging buckets (filtro) | `agingBreakdown()` + chips `lt30/30-60/60-90/gt90/gt180` (Index.tsx:1164) |
+| US-FIN-023 — Delta % MoM nos KPIs | `kpis()` → `deltaPct()` |
+| US-FIN-024 — Combobox cliente + atalhos | `buscarCliente()` + J/K/↑↓/Space/Enter/Esc/⌘K/`/`/B/N/R/P (Index.tsx:936-1005) |
+| US-FIN-025 — Auto-sugerir valor | `sugerirValor()` (último + média + count por contraparte) |
+| US-FIN-026 — Anexos UI (listar/baixar) | `listarAnexos()` · `baixarAnexo()` · `anexar()` · `removerAnexo()` |
+| US-FIN-027/028 — Workflow aprovação + gate Spatie | `solicitarAprovacao()` · `aprovar()`/`rejeitar()` com `can:financeiro.titulo.aprovar` |
+| US-FIN-029 — OCR boleto (killer vs Conta Azul) | `ocrBoleto()` + `BoletoOcrService` (OpenAI Vision) |
+| Audit diff "ver edições" | `auditTrail()` retorna `{field, from, to}` (componente `FinAuditTrail`) |
+| Troubleshooter · Resumir · Anomaly · Imprimir PDF · Apresentação · Favoritos | `FinTroubleshooter` · `FinMonthDigest` · `FinAnomalyDetector` · `FinTranscriptPDF` · `FinPresentationMode` · `useFinFavs` |
+
+**Leitura real do módulo:** o Unificado (tela-carro-chefe) está em **~9,3/10** pelo método KB-9.75 — não 8,5. A maior parte de Navegação/Curadoria/Saída/Guia está fechada.
+
+**Gap REAL pra 9,75** (ver [METODO-9.75-FINANCEIRO.md](METODO-9.75-FINANCEIRO.md) §3): (1) 🔴 RAG "perguntar ao histórico" — precisa ADR (Jana + corpus); (2) 🔴 trilhas de onboarding; (3) 🟡 auto-sugerir categoria/plano-de-contas; (4) 🟡 mobile cards + a11y. Pendente também: **re-auditar as outras telas** (Conciliação/DRE/Cobrança/Relatórios/Extrato) contra o código real — a briefing por-tela abaixo é de 05-20.
+
+---
 
 ## Estado UI 2026-05-20 tarde — Drawer canon 10/10 ✅
 

--- a/memory/requisitos/Financeiro/METODO-9.75-FINANCEIRO.md
+++ b/memory/requisitos/Financeiro/METODO-9.75-FINANCEIRO.md
@@ -1,0 +1,131 @@
+---
+slug: metodo-9-75-financeiro
+title: "Método KB-9.75 — aplicado ao Financeiro"
+type: roadmap
+authority: draft-aguardando-wagner
+lifecycle: proposto
+session_date: '2026-05-31'
+quarter: 2026-Q2
+related:
+  - '0093'
+  - '0104'
+  - '0107'
+  - '0114'
+  - '0190'
+pii: false
+---
+
+# Método KB-9.75 — aplicado ao Financeiro
+
+> **🟡 DRAFT pra Wagner — corrigido após pré-flight no código real.**
+>
+> **Origem (2026-05-31):** o `Método 9.75 Financeiro.html` do Cowork **não veio no export** (snapshot 28/mai; arquivo mais novo). Wagner pediu reconstrução ancorada no módulo real.
+>
+> **🔴 CORREÇÃO IMPORTANTE (pré-flight no código real, 2026-05-31):** a 1ª versão deste doc usou a [BRIEFING.md](BRIEFING.md) de **2026-05-20** + [DOC_TELAS_E_SCORE.md](DOC_TELAS_E_SCORE.md) de **2026-04-25** — **ambas obsoletas**. Ao ler `UnificadoController.php` + `Unificado/Index.tsx` reais, descobri que as **Ondas 22-29 (US-FIN-021..029, PRs E/F/G/H/I/J, 2026-05-25)** já fecharam **quase todo o Refino #1-#3** que eu ia propor. **Não implementei nada** — seria re-fazer feature existente (anti-padrão T-AP-4 das lições F3). Este doc agora reflete a **realidade do código**, não a briefing velha.
+
+---
+
+## 1. Ancoragem — o Financeiro JÁ está perto de 9,75
+
+O Financeiro é o módulo **mais maduro do ERP** e avançou muito entre 20/mai e 25/mai. Evidência no código real (`Modules/Financeiro/Http/Controllers/UnificadoController.php` + `resources/js/Pages/Financeiro/Unificado/Index.tsx`):
+
+| O que eu ia propor (R1-R3) | Estado REAL no código | Onda/US |
+|---|---|---|
+| Aging buckets + cor | ✅ `agingBreakdown()` + chips filtro 5 buckets (lt30/30-60/60-90/gt90/gt180) | PR E · US-FIN-022 |
+| J/K + atalhos teclado | ✅ J/K/↑↓/Space/Enter/Esc + ⌘K + `/` + B + N/R/P (Index.tsx:936-1005) | PR G · US-FIN-024 |
+| Anexos UI (listar/baixar) | ✅ `listarAnexos()` + `baixarAnexo()` + remove | US-FIN-026 |
+| Diff "ver edições" | ✅ `auditTrail()` com `{field, from, to}` (FinAuditTrail) | Onda DB |
+| Resumir IA | ✅ `FinMonthDigest` / `FinMonthResume` | Onda 7c |
+| Auto-sugerir valor | ✅ `sugerirValor()` (último + média + count por contraparte) | PR I · US-FIN-025 |
+| OCR de boleto (killer vs Conta Azul) | ✅ `ocrBoleto()` OpenAI Vision + `BoletoOcrService` | Onda 23 · US-FIN-029 |
+| Troubleshooter | ✅ `FinTroubleshooter` dialog | Onda 7b |
+| Imprimir com brand / apresentação / favoritos | ✅ `FinTranscriptPDF` · `FinPresentationMode` · `useFinFavs` (atalho B) | Onda 7b/7c |
+| Workflow aprovação + Spatie gate | ✅ solicitar/aprovar/rejeitar `can:financeiro.titulo.aprovar` | Onda 21-22 · US-FIN-027/028 |
+| Delta % MoM | ✅ `deltaPct()` nos KPIs | PR H · US-FIN-023 |
+
+**Conclusão honesta:** o Unificado (tela-carro-chefe) está realisticamente em **~9,2-9,4/10**, não 8,5. O roadmap "4 refinos" da v1 estava errado — a maior parte **já foi entregue** pelo time nas Ondas 22-29.
+
+---
+
+## 2. As 22 features-tipo — status REAL (pós código)
+
+✅ feito · 🟡 parcial · ❌ falta de verdade · ❓ não verificado nesta sessão
+
+| Cat | Feature | Status real | Evidência / gap |
+|---|---|---|---|
+| Nav | N1 Tri/quad-pane | ✅ | Cockpit + drawer 440 (Unificado 10/10) |
+| Nav | N2 ⌘K palette | ✅ | Index.tsx:936 |
+| Nav | N3 J/K + atalhos | ✅ | Index.tsx:961-1005 (era 🟡 na v1 — **estava errado**) |
+| Nav | N4 Subcategorias tree | ✅ | Plano de Contas BR 49 entries |
+| Nav | N5 Responsive tablet | ❓→provável ❌ | não confirmei cards mobile; gap antigo do DOC |
+| Cur | C1 Editor inline | ✅ | `TituloEditSheet` + guard imutabilidade |
+| Cur | C2 Histórico + diff | ✅ | `auditTrail()` diff (era 🟡 — **corrigido**) |
+| Cur | C3 Frescor + aging | ✅ | `FinPillFrescor` + `agingBreakdown` chips |
+| Cur | C4 Re-verificar | ✅ | `FinConferidoToggle` per-user DB |
+| Cur | C5 Comentários inline | ✅ | `FinCommentsThread` |
+| IA | I1 Resumir | ✅ | `FinMonthDigest` |
+| IA | **I2 Perguntar (RAG)** | ❌ | 🔴 **gap real.** `sugerirValor()` é heurística (média/último), NÃO RAG. Falta "esse cliente costuma atrasar?" sobre histórico via Jana. **Precisa ADR.** |
+| IA | I3 Auto-sugest meta | 🟡 | `sugerirValor` + `FinAnomalyDetector` existem; falta auto-sugerir **categoria/plano-de-contas** |
+| IA | I4 Empty-state IA | ❓→provável ❌ | busca vazia → "perguntar à IA" não confirmado |
+| Gui | G1 Troubleshooter | ✅ | `FinTroubleshooter` (era ❌ — **corrigido**) |
+| Gui | G2 Editor visual de árvore | ❓→provável ❌ | criar fluxo sem código |
+| Gui | **G3 Trilhas onboarding** | ❌ | 🔴 **gap real.** Onboarding Eliana (fechar mês, conciliar). |
+| Gui | G4 Cross-link auto | ✅ | `FinCrossLinkify` #V-/#PC- |
+| Saí | S1 Favoritos | ✅ | `useFinFavs` (atalho B) |
+| Saí | S2 Apresentação | ✅ | `FinPresentationMode` |
+| Saí | S3 Imprimir brand | ✅ | `FinTranscriptPDF` + OCR boleto |
+| Saí | S4 Anexos/imagens | ✅ | `listarAnexos`+`baixarAnexo` (era 🟡 — **corrigido**) |
+
+---
+
+## 3. O gap REAL pra 9,75 (o que sobra de verdade)
+
+Só **3-4 frentes**, todas concentradas em **Inteligência profunda + Guia + Reach** — e a maior precisa de ADR:
+
+1. 🔴 **I2 — Perguntar ao histórico (RAG)** — "esse cliente costuma atrasar?", "quanto recebi desse canal em 90d?". Toca Jana + corpus financeiro. **Precisa ADR própria** (schema/integração). Maior salto de score.
+2. 🔴 **G3 — Trilhas de onboarding** financeiro (Eliana treina substituto: fechar mês → conciliar → emitir boleto).
+3. 🟡 **I3.b — Auto-sugerir categoria/plano-de-contas** no lançamento (estende o `sugerirValor` que já existe).
+4. 🟡 **N5/a11y — Cards mobile + aria-labels/tab-order** (gap recorrente do DOC; reach pra tablet).
+
+**Antes de propor PRs disto, falta uma coisa:** uma **re-auditoria das OUTRAS telas** (Conciliação, DRE, Cobrança, Relatórios, Extrato) contra o **código real** — porque a v1 deste doc provou que a briefing está atrás do código. Não vou confiar em score documentado de novo.
+
+---
+
+## 4. Pré-requisitos arquiteturais
+
+| | Pré-requisito | Estado real |
+|---|---|---|
+| **A1** | Integração cruzada | 🟡 `#V-`/`#PC-` (Venda/Compra) ✅ + `FinPartyHistory` ✅; falta ligação completa Título↔NFe. Pré-req do RAG (I2). |
+| **A2** | Multi-tenant + grupo econômico | **Tier 0 ✅** (`BusinessScope`, D1 30/30). Tier 1 (filiais) / Tier 2 (holding + DRE consolidada) = futuro, não bloqueia o gap acima. |
+
+---
+
+## 5. Restrições de execução (lições F3 — gates duros, já com enforcement PHPStan)
+
+- Models reais: `Titulo`(`tipo: receber|pagar`)/`TituloBaixa`/`ContaBancaria`/`Categoria`/`PlanoConta`/`ExtratoLancamento`/`TituloAnexo`/`TituloComment`. NUNCA inventar.
+- `session('user.business_id')` + `can:financeiro.*` (`oimpresso.missingTenantScope`).
+- **Tela em prod = refator/extensão em PR separado sobre o controller REAL. JAMAIS regenerar/sobrescrever.** ← foi exatamente o que o pré-flight evitou hoje.
+- Idempotência (`idempotency_key` UUID) · soft-delete + trava histórico · sem NO-OP `return back()` (`oimpresso.nopMutation`) · sem fallback silencioso sem `Log::warning` (`oimpresso.silentFallback`).
+- Schema/Service/componente-shared novo = **ADR primeiro**. O RAG (I2) cai aqui.
+- Cada item = PR ≤300 linhas, charter + Pest ao lado, gate visual, smoke biz=1.
+
+---
+
+## 6. O que revisar (Wagner) + recomendação
+
+1. **A correção bate?** Confirma que as Ondas 22-29 já entregaram aging/anexos/audit-diff/OCR/troubleshooter/auto-suggest? (eu li no código, mas você conhece o histórico melhor)
+2. **A BRIEFING.md (05-20) está desatualizada** — não reflete US-FIN-021..029. Quer que eu **atualize a briefing** pra parar de enganar quem ler?
+3. Dos 4 gaps reais (RAG · trilhas onboarding · auto-categoria · mobile/a11y), **qual primeiro?**
+4. **RAG (I2)** precisa de ADR (Jana + corpus financeiro). Proponho a ADR, ou começamos pelos itens sem-ADR (auto-categoria, mobile/a11y, trilhas)?
+
+**Recomendação:** o Financeiro **já é ~9,3**. Em vez de "4 refinos", o caminho honesto pra 9,75 é:
+- **(a)** atualizar a BRIEFING (parar o drift de documentação), e
+- **(b)** fazer uma **re-auditoria das outras telas contra o código real** pra achar onde o gap de verdade está hoje (a v1 provou que a doc mente),
+- **(c)** depois atacar 1-2 dos 4 gaps reais — começando pelos sem-ADR (auto-categoria de lançamento + mobile/a11y), deixando o RAG pra uma ADR dedicada.
+
+Não vou escrever código redundante. O valor desta sessão foi **descobrir que o módulo já está quase lá** e **mapear o que falta de verdade** — não inflar PRs.
+
+---
+
+**Status:** DRAFT 2026-05-31 · corrigido pós pré-flight no código real.
+**Reconstruído por:** Claude Code (Opus 4.8). O `.html` original do Cowork não estava no export; o diagnóstico foi ancorado no código de produção (`UnificadoController` + `Unificado/Index.tsx`), não na briefing.

--- a/memory/requisitos/Financeiro/adr/arq/0006-rag-perguntar-historico-financeiro.md
+++ b/memory/requisitos/Financeiro/adr/arq/0006-rag-perguntar-historico-financeiro.md
@@ -1,0 +1,69 @@
+# ADR ARQ-0006 (Financeiro) · RAG "perguntar ao histórico financeiro" — Jana copiloto que cita fonte
+
+- **Status**: proposed
+- **Data**: 2026-05-31
+- **Decisores**: Wagner (pendente)
+- **Categoria**: arq
+- **Relacionado**: [KB-9.75 I2](../../METODO-9.75-FINANCEIRO.md) · [AUDIT-METODO-9.75-TELAS-2026-05-31](../../AUDIT-METODO-9.75-TELAS-2026-05-31.md) · [ADR 0035 stack IA](../../../../decisions/0035-stack-ia.md) · [ADR 0093 multi-tenant Tier 0](../../../../decisions/0093-multi-tenant-isolation-tier-0.md) · ADR tech/0001 (idempotência)
+
+## Contexto
+
+O método **KB-9.75** define a feature-tipo **I2 — "perguntar ao corpus"** (RAG): o operador pergunta em linguagem natural sobre os dados e recebe resposta **citando a fonte**. É a feature de maior ganho de score (+0,5 estimado) e a mais ausente.
+
+A [auditoria de 2026-05-31](../../AUDIT-METODO-9.75-TELAS-2026-05-31.md) confirmou no código real: **nenhuma das "IAs" do Financeiro é LLM**. `FinMonthDigest`, `FinMonthResume`, `AiResumoMes`, `FinTroubleshooter` são heurística/compute pura (os arquivos declaram "sem LLM"). O único uso real de modelo é `BoletoOcrService` (OCR Vision). Logo **I2 não existe em lugar nenhum** do módulo.
+
+A persona Eliana [E] quer perguntas como: *"esse cliente costuma atrasar?"*, *"quanto recebi desse canal nos últimos 90 dias?"*, *"qual fornecedor mais cresceu em despesa este trimestre?"*. Hoje ela exporta CSV e calcula na planilha — exatamente o que a proposta de valor promete eliminar.
+
+**Restrições duras:**
+- Dados financeiros são **estruturados** (`fin_titulos`, `fin_titulo_baixas`, `fin_extrato_lancamentos`) e já isolados por `business_id` (Tier 0, ADR 0093 IRREVOGÁVEL).
+- Resposta **precisa citar fonte exata** (IDs de título/baixa) — número financeiro sem rastreabilidade é inaceitável (auditoria fiscal).
+- Princípio P4 do método: **IA copiloto** — propõe, humano confere, **nunca muta** estado.
+- PII: contraparte/documento não pode vazar pra prompt/log sem cuidado (LGPD).
+
+## Decisão (proposta)
+
+Implementar I2 como **tool-calling estruturado** (LLM traduz a pergunta → chama *tools* read-only já escopadas por `business_id` → responde citando os registros retornados), **não** como RAG de texto livre sobre um índice vetorial.
+
+**Por quê tool-calling > RAG vetorial aqui:**
+- Os dados são tabulares e exatos — "quanto recebi" é um `SUM`, não uma busca semântica. Tool-calling dá resposta **determinística e citável**; RAG vetorial alucinaria números.
+- `business_id` entra **no servidor** (na assinatura da tool), nunca via prompt — o LLM não consegue burlar o Tier 0.
+- Reusa a stack IA canônica (ADR 0035) + `ai_usage_log` (já existe, migration) pra custo.
+
+**Forma:**
+1. Conjunto pequeno de tools read-only (ex.: `titulos_por_contraparte`, `recebido_por_periodo`, `aging_resumo`, `serie_temporal`) — cada uma recebe `int $businessId` no 1º arg (igual `UnificadoService`/`TituloRepository`) e devolve dados + IDs de origem.
+2. Jana (ADR 0035) faz orquestração: pergunta PT-BR → escolhe tool(s) → compõe resposta PT-BR **com bloco "Fontes: #título-N, baixa-M"** clicável (reusa `FinCrossLinkify`).
+3. UI: painel irmão do `AiResumoMes`/overflow ✦ no Unificado (e depois DRE/Relatórios), com a pergunta + resposta + fontes. **Read-only**, sem botão que mute.
+
+## Consequências
+
+**Positivas**
+- Fecha o maior gap de 9,75 (Inteligência) reusando Tier 0 já pronto.
+- Resposta citável → confiável pra contexto fiscal (diferencial vs Conta Azul/Bling, que não têm).
+- Mais barato que indexar corpus vetorial; custo por pergunta logado (`ai_usage_log`).
+
+**Negativas / custo**
+- Custo de LLM por pergunta (mitigar: cache de perguntas frequentes + modelo Haiku pra roteamento).
+- Precisa **eval anti-alucinação** (Pest com perguntas-fixture + asserção de que a resposta bate com SQL direto).
+- Trabalho de scaffold antes da UI: as tools read-only + o roteador.
+
+**Bloqueios / sequência (anti regressão F3)**
+1. Wagner aceita esta ADR (`status: accepted`).
+2. PR separado: tools read-only + Pest (sem UI ainda).
+3. SÓ ENTÃO: PR de UI (painel de pergunta) consumindo as tools.
+
+## Alternativas consideradas
+
+- **(B) RAG vetorial sobre dump textual dos títulos** — rejeitada: alucina números, fonte imprecisa, caro de indexar, e dados já são estruturados.
+- **(C) Text-to-SQL livre** — rejeitada: risco de query arbitrária cross-tenant (o LLM montaria o `where`), difícil de blindar Tier 0. Tool-calling com `business_id` server-side é mais seguro.
+- **(D) Não fazer (manter heurística)** — é o estado atual; deixa o módulo travado em ~Inteligência 5,5 e não atinge 9,75.
+
+## Riscos
+
+- **Tier 0:** `business_id` SEMPRE no servidor, nunca no prompt/payload do LLM. Pest cross-tenant obrigatório (biz=1 vs biz=99) como em `TituloRepositoryWave18Test`.
+- **Alucinação numérica:** toda resposta com número cita a fonte; eval compara com SQL direto.
+- **PII (LGPD):** documento/nome de contraparte não vai pro log; redigir antes de `ai_usage_log`.
+- **Custo:** teto por business + cache; monitorar via `ai_usage_log`.
+
+---
+
+**Proposta por:** Claude Code (Opus 4.8), 2026-05-31, ancorada na [auditoria das telas](../../AUDIT-METODO-9.75-TELAS-2026-05-31.md). Aguarda decisão Wagner antes de qualquer código.

--- a/memory/requisitos/Financeiro/adr/arq/0006-rag-perguntar-historico-financeiro.md
+++ b/memory/requisitos/Financeiro/adr/arq/0006-rag-perguntar-historico-financeiro.md
@@ -1,8 +1,8 @@
 # ADR ARQ-0006 (Financeiro) · RAG "perguntar ao histórico financeiro" — Jana copiloto que cita fonte
 
-- **Status**: proposed
+- **Status**: accepted
 - **Data**: 2026-05-31
-- **Decisores**: Wagner (pendente)
+- **Decisores**: Wagner (aprovado 2026-05-31)
 - **Categoria**: arq
 - **Relacionado**: [KB-9.75 I2](../../METODO-9.75-FINANCEIRO.md) · [AUDIT-METODO-9.75-TELAS-2026-05-31](../../AUDIT-METODO-9.75-TELAS-2026-05-31.md) · [ADR 0035 stack IA](../../../../decisions/0035-stack-ia.md) · [ADR 0093 multi-tenant Tier 0](../../../../decisions/0093-multi-tenant-isolation-tier-0.md) · ADR tech/0001 (idempotência)
 
@@ -66,4 +66,4 @@ Implementar I2 como **tool-calling estruturado** (LLM traduz a pergunta → cham
 
 ---
 
-**Proposta por:** Claude Code (Opus 4.8), 2026-05-31, ancorada na [auditoria das telas](../../AUDIT-METODO-9.75-TELAS-2026-05-31.md). Aguarda decisão Wagner antes de qualquer código.
+**Proposta por:** Claude Code (Opus 4.8), 2026-05-31, ancorada na [auditoria das telas](../../AUDIT-METODO-9.75-TELAS-2026-05-31.md). **Aprovada por Wagner em 2026-05-31.** Sequência: PR1 (tools read-only `InsightsService` + Pest) em andamento → PR2 (Jana tool-calling + painel de pergunta) depois.


### PR DESCRIPTION
## Contexto

Handoff Cowork: Wagner pediu implementar **`Método 9.75 Financeiro.html`**. O arquivo **não veio no export** (snapshot 28/mai; arquivo mais novo). Wagner aprovou reconstruir o diagnóstico/roadmap **ancorado no código real** (não no protótipo).

## O que este PR entrega

Um único doc — [`memory/requisitos/Financeiro/METODO-9.75-FINANCEIRO.md`](../blob/feat/financeiro-975-r1/memory/requisitos/Financeiro/METODO-9.75-FINANCEIRO.md) — o **Método KB-9.75 aplicado ao Financeiro**, com diagnóstico honesto.

## 🔴 A descoberta (por que NÃO tem código de feature)

Pré-flight obrigatório (lições F3) no `UnificadoController.php` + `Unificado/Index.tsx` reais mostrou que as **Ondas 22-29 (US-FIN-021..029, 25/mai)** já entregaram quase tudo que eu ia propor:

| Proposto (R1-R3) | Real | US |
|---|---|---|
| Aging buckets | ✅ `agingBreakdown()` + chips | US-FIN-022 |
| J/K + atalhos | ✅ Index.tsx:961-1005 | US-FIN-024 |
| Anexos UI | ✅ `listarAnexos`/`baixarAnexo` | US-FIN-026 |
| Audit diff | ✅ `auditTrail()` | — |
| OCR boleto | ✅ `ocrBoleto()` Vision | US-FIN-029 |
| Troubleshooter / resumir / auto-suggest | ✅ FinTroubleshooter / FinMonthDigest / sugerirValor | Ondas 7b/22-25 |

Implementar isso = re-fazer feature existente (**anti-padrão T-AP-4** de `LICOES_F3_FINANCEIRO_REJEITADO`). O pré-flight evitou a regressão.

## Gap REAL pra 9,75 (módulo já está ~9,3)

1. 🔴 **RAG "perguntar ao histórico"** (I2) — precisa **ADR** (Jana + corpus).
2. 🔴 **Trilhas de onboarding** (G3).
3. 🟡 **Auto-sugerir categoria/plano-de-contas** (I3.b).
4. 🟡 **Mobile cards + a11y** (N5).
+ **re-auditoria das outras telas** (Conciliação/DRE/Cobrança) contra o código — a BRIEFING (05-20) está atrás do código.

## Escopo / segurança

- **Docs-only.** Zero código de feature, zero migration, zero controller tocado.
- Não merge automático — decisão sua (publication-policy). Aguarda revisão da lista (§6 do doc).

🤖 Generated with [Claude Code](https://claude.com/claude-code)