### PR TITLE
fix(designsystem): US-015 emoji -> lucide em 19 telas (AP6) [visivel - gate ADR 0114]

### DIFF
--- a/resources/js/Pages/Atendimento/Channels/Index.tsx
+++ b/resources/js/Pages/Atendimento/Channels/Index.tsx
@@ -14,7 +14,7 @@ import { useEffect, useState } from 'react';
 // QR vem como data URL PNG do daemon (string Baileys excede limite QR v40 23KB).
 import {
   Plus, Trash2, AlertTriangle, CheckCircle2, Circle, Loader2,
-  MessageCircle, Plug, Smartphone, Zap,
+  MessageCircle, Plug, Smartphone, Zap, Inbox,
 } from 'lucide-react';
 
 import AppShellV2 from '@/Layouts/AppShellV2';
@@ -555,7 +555,7 @@ function ChannelCard({
               className="h-7 gap-1.5"
               data-testid={`channel-card-import-history-${channel.id}`}
             >
-              📥 Importar Histórico
+              <Inbox className="h-3.5 w-3.5 mr-1" aria-hidden /> Importar Histórico
             </Button>
           )}
           <Button variant="ghost" size="icon" onClick={onDelete} title="Remover canal" className="h-7 w-7">

--- a/resources/js/Pages/Compras/components/AcoesDropdown.tsx
+++ b/resources/js/Pages/Compras/components/AcoesDropdown.tsx
@@ -9,7 +9,8 @@
 //   - Impressão / Rótulos / Reembolso → seguem Blade legacy (não migrados)
 
 import { router } from '@inertiajs/react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
+import { Eye, Printer, Trash2, Tag, Wallet } from 'lucide-react';
 
 export interface AcaoVisibility {
   canEdit: boolean;
@@ -31,7 +32,7 @@ interface AcoesDropdownProps {
 interface ActionItem {
   id: string;
   label: string;
-  icon: string;
+  icon: ReactNode;
   onClick: () => void;
   divider?: 'before' | 'after';
   variant?: 'default' | 'danger';
@@ -97,7 +98,7 @@ export default function AcoesDropdown({
     {
       id: 'ver',
       label: 'Ver',
-      icon: '👁',
+      icon: <Eye className="h-4 w-4" />,
       onClick: () => {
         onOpenDrawer(compraId, 'resumo');
         setOpen(false);
@@ -106,7 +107,7 @@ export default function AcoesDropdown({
     {
       id: 'impressao',
       label: 'Impressão',
-      icon: '🖨',
+      icon: <Printer className="h-4 w-4" />,
       onClick: () => openBladeNewTab(`/purchases/print/${compraId}`),
     },
     {
@@ -124,7 +125,7 @@ export default function AcoesDropdown({
     {
       id: 'excluir',
       label: 'Excluir',
-      icon: '🗑',
+      icon: <Trash2 className="h-4 w-4" />,
       variant: 'danger',
       hidden: !visibility.canDelete,
       onClick: handleDelete,
@@ -132,14 +133,14 @@ export default function AcoesDropdown({
     {
       id: 'rotulos',
       label: 'Rótulos',
-      icon: '🏷',
+      icon: <Tag className="h-4 w-4" />,
       divider: 'after',
       onClick: () => openBladeNewTab(`/labels/show?purchase_id=${compraId}`),
     },
     {
       id: 'pagamentos',
       label: 'Ver pagamentos',
-      icon: '💰',
+      icon: <Wallet className="h-4 w-4" />,
       onClick: () => {
         onOpenDrawer(compraId, 'pagamentos');
         setOpen(false);

--- a/resources/js/Pages/Financeiro/Caixa/Index.tsx
+++ b/resources/js/Pages/Financeiro/Caixa/Index.tsx
@@ -6,6 +6,7 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { router, usePage } from '@inertiajs/react';
 import { ReactNode, useMemo } from 'react';
+import { Lightbulb } from 'lucide-react';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 import { PageHeader } from '@/Components/PageHeader';
 
@@ -273,7 +274,7 @@ function Caixa({ caixas, stats, filters, links }: Props) {
       </section>
 
       <div className="text-xs text-stone-500">
-        💡 Para fechar um caixa aberto, clique no botão "Fechar caixa registradora" na header da{' '}
+        <Lightbulb className="h-3.5 w-3.5 mr-1 inline align-text-bottom" /> Para fechar um caixa aberto, clique no botão "Fechar caixa registradora" na header da{' '}
         <a href={links.pos_create} className="underline">
           tela POS
         </a>

--- a/resources/js/Pages/Financeiro/Conciliacao/Index.tsx
+++ b/resources/js/Pages/Financeiro/Conciliacao/Index.tsx
@@ -9,7 +9,7 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { useForm, router } from '@inertiajs/react';
 import { type ReactNode, type FormEvent, useState } from 'react';
-import { Upload, Check, X, Search } from 'lucide-react';
+import { Upload, Check, X, Search, Inbox } from 'lucide-react';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 import { PageHeader } from '@/Components/PageHeader';
 import {
@@ -280,7 +280,7 @@ function FinanceiroConciliacao({ linhas, stats, contas }: Props) {
           <b className="fin-num-pos">{stats.conciliados}</b> conciliados
         </span>
         <span className="spacer" />
-        <span>📥 Parser OFX simples · próxima Onda: CNAB + Open Banking API</span>
+        <span className="inline-flex items-center gap-1"><Inbox className="h-3.5 w-3.5" /> Parser OFX simples · próxima Onda: CNAB + Open Banking API</span>
       </div>
     </div>
   );

--- a/resources/js/Pages/Financeiro/PlanoContas/Index.tsx
+++ b/resources/js/Pages/Financeiro/PlanoContas/Index.tsx
@@ -9,7 +9,7 @@
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { type ReactNode, useMemo, useState } from 'react';
-import { Lock, FileText, Search } from 'lucide-react';
+import { Lock, FileText, Search, BookOpen } from 'lucide-react';
 import { router } from '@inertiajs/react';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 import { PageHeader } from '@/Components/PageHeader';
@@ -211,7 +211,7 @@ function FinanceiroPlanoContas({ planos, stats }: Props) {
           <b className="fin-num-neg">{stats.despesa}</b> despesa
         </span>
         <span className="spacer" />
-        <span>📖 Hierarquia BR · Receita Federal DCASP simplificado</span>
+        <span className="inline-flex items-center gap-1"><BookOpen className="h-3.5 w-3.5" /> Hierarquia BR · Receita Federal DCASP simplificado</span>
       </div>
     </div>
   );

--- a/resources/js/Pages/Financeiro/Unificado/Index.tsx
+++ b/resources/js/Pages/Financeiro/Unificado/Index.tsx
@@ -17,7 +17,7 @@ import React, { useState, useMemo, useCallback, useEffect, type ReactNode } from
 // Onda 12 (2026-05-19) — paridade 100% canon REAL (/cowork-preview/Oimpresso ERP - Chat.html):
 // emoji → lucide-react nos 8 botões + Download icon adicional + remoção FinMonthDigest
 // (não-canon) + summary numérica footer + KPI hero dark.
-import { Search, Plus, Sparkles, CheckSquare, Check, Play, Printer, RefreshCw, FolderOpen, Download, ChevronDown, TrendingUp, TrendingDown } from 'lucide-react';
+import { Search, Plus, Sparkles, CheckSquare, Check, Play, Printer, RefreshCw, FolderOpen, Download, ChevronDown, TrendingUp, TrendingDown, Camera, Landmark, Link as LinkIcon, Eye, FileText } from 'lucide-react';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -1088,7 +1088,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
               </DropdownMenuItem>
               <DropdownMenuSeparator />
               <DropdownMenuItem onClick={() => setOcrSheetOpen(true)} title="Importar boleto via foto/PDF (OCR via IA)">
-                <span className="mr-2">📷</span> Importar boleto OCR
+                <Camera className="mr-2 h-3.5 w-3.5" /> Importar boleto OCR
               </DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
@@ -1260,7 +1260,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
 
         <div className="fin-toolbar-r">
           <div className="fin-search-wrap">
-            <span aria-hidden="true">🔍</span>
+            <Search className="h-3.5 w-3.5" aria-hidden="true" />
             <input
               id="fin-search-input"
               placeholder="Buscar lançamento…"
@@ -1581,7 +1581,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                     <div className="col-span-2">
                       <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Conta</div>
                       <div className="mt-0.5 text-stone-700 flex items-center gap-1.5">
-                        <span className="text-stone-400" aria-hidden>🏦</span>
+                        <Landmark className="h-4 w-4 text-stone-400" aria-hidden />
                         <span>{selected.conta_bancaria || '—'}</span>
                       </div>
                     </div>
@@ -1601,7 +1601,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                         <div className="text-[11px] text-stone-500 uppercase tracking-widest font-medium">Conciliação extrato</div>
                         {settled ? (
                           <div className="mt-2 rounded-md border border-emerald-200 bg-emerald-50/60 px-3 py-2.5 flex items-start gap-2.5">
-                            <span className="text-emerald-700 mt-0.5" aria-hidden>🔗</span>
+                            <LinkIcon className="h-4 w-4 text-emerald-700 mt-0.5" aria-hidden />
                             <div className="text-[12.5px]">
                               <div className="text-emerald-800 font-medium">Conciliado com extrato bancário</div>
                               <div className="text-emerald-700/80">{selected.liquidacao || '—'} · {brl(selected.valor)} · 100% match</div>
@@ -1716,7 +1716,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
                 <div className="fin-drawer-footer fin-drawer-footer-sticky">
                   {selected.nfe_numero && (
                     <Button variant="outline" size="sm" className="fin-foot-icon-btn" title="Ver NFe" onClick={() => router.visit(`/fiscal/nfe?numero=${selected.nfe_numero}`)}>
-                      <span aria-hidden>👁</span>
+                      <Eye className="h-4 w-4" aria-hidden />
                       <span className="ml-1">Ver NFe</span>
                     </Button>
                   )}
@@ -1812,7 +1812,7 @@ function FinanceiroUnificado({ kpis, lancamentos, pagination, filters, contas, c
               ✦ Resumir mês (narrativa exec)
             </CommandItem>
             <CommandItem onSelect={() => { setPaletteOpen(false); setTranscriptOnlyFavs(false); setTranscriptOpen(true); }}>
-              📄 Imprimir período (folha jurídica)
+              <FileText className="h-3.5 w-3.5 mr-1" /> Imprimir período (folha jurídica)
             </CommandItem>
             {favs.count > 0 && (
               <CommandItem onSelect={() => { setPaletteOpen(false); setTranscriptOnlyFavs(true); setTranscriptOpen(true); }}>

--- a/resources/js/Pages/Fiscal/Config.tsx
+++ b/resources/js/Pages/Fiscal/Config.tsx
@@ -11,7 +11,7 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, useForm, usePage } from '@inertiajs/react';
 import type { PageProps } from '@inertiajs/core';
-import { Archive, CheckCircle2, FileText, KeyRound, Loader2, PlugZap, Settings, Shield, Upload, XCircle } from 'lucide-react';
+import { Archive, CheckCircle2, FileText, KeyRound, Loader2, Lock, PlugZap, Settings, Shield, Upload, XCircle } from 'lucide-react';
 import { type FormEvent, useRef, useState } from 'react';
 import { toast } from 'sonner';
 
@@ -479,7 +479,7 @@ export default function Config({ certificado, config, painel, seriesMock = [] }:
             <dt>Próximo número</dt>
             <dd className="fx-mono">{painel.proximoNumero}</dd>
             <dt>Emissão auto</dt>
-            <dd>{config?.autoEmissionEnabled ? '✅ Habilitada' : '🔒 Manual'}</dd>
+            <dd>{config?.autoEmissionEnabled ? '✅ Habilitada' : <><Lock className="h-3.5 w-3.5 mr-1 inline align-text-bottom" />Manual</>}</dd>
             <dt>Tributação default</dt>
             <dd>
               {config && Object.keys(config.tributacaoDefault).length > 0

--- a/resources/js/Pages/Jana/Cockpit.tsx
+++ b/resources/js/Pages/Jana/Cockpit.tsx
@@ -17,6 +17,7 @@
 
 import { Head } from '@inertiajs/react';
 import { useEffect, useMemo, useRef, useState } from 'react';
+import { BarChart3, Bot, Calendar, Lightbulb, MessageSquare, TrendingUp, Wallet } from 'lucide-react';
 
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { BusinessOpt } from '@/Components/cockpit/shared';
@@ -215,7 +216,7 @@ function BriefDiario({ today, brief }: { today: string; brief: Brief }) {
   return (
     <section className="rounded-lg border border-border bg-card p-4 mb-4 shadow-sm">
       <div className="flex items-center gap-2 mb-2 text-sm">
-        <span>📅</span>
+        <Calendar className="h-4 w-4" />
         <b className="text-foreground">Brief diário</b>
         <span className="opacity-40">·</span>
         <span className="text-muted-foreground">{today}</span>
@@ -788,7 +789,7 @@ function ConverseComJana({ chat }: { chat: ChatBlock }) {
   return (
     <section className="rounded-lg border border-border bg-card flex flex-col h-[calc(100vh-220px)] min-h-[480px] overflow-hidden">
       <div className="px-4 py-2.5 border-b border-border flex items-center gap-2">
-        <span>💬</span>
+        <MessageSquare className="h-4 w-4" />
         <b className="text-sm">Converse com Jana</b>
         <small className="text-[11.5px] text-muted-foreground ml-auto">
           Chat com contexto do seu negócio
@@ -805,18 +806,18 @@ function ConverseComJana({ chat }: { chat: ChatBlock }) {
             </p>
             <div className="grid grid-cols-2 gap-2 mt-2 max-w-md w-full">
               {[
-                { icon: '📈', label: 'Vendas de hoje', prompt: 'Quantas vendas tive hoje?' },
+                { icon: <TrendingUp className="h-3.5 w-3.5" />, label: 'Vendas de hoje', prompt: 'Quantas vendas tive hoje?' },
                 { icon: '⏰', label: 'OS atrasadas', prompt: 'Listar OS atrasadas' },
-                { icon: '💰', label: 'Inadimplentes', prompt: 'Top 5 clientes em débito' },
-                { icon: '📊', label: 'Financeiro mensal', prompt: 'Resumo financeiro do mês' },
+                { icon: <Wallet className="h-3.5 w-3.5" />, label: 'Inadimplentes', prompt: 'Top 5 clientes em débito' },
+                { icon: <BarChart3 className="h-3.5 w-3.5" />, label: 'Financeiro mensal', prompt: 'Resumo financeiro do mês' },
               ].map((p, i) => (
                 <button
                   key={i}
                   type="button"
                   onClick={() => setDraft(p.prompt)}
-                  className="text-xs px-3 py-2 rounded-md border border-border bg-card hover:bg-muted/40 transition text-left"
+                  className="inline-flex items-center gap-1.5 text-xs px-3 py-2 rounded-md border border-border bg-card hover:bg-muted/40 transition text-left"
                 >
-                  <span className="mr-1.5">{p.icon}</span>
+                  <span className="shrink-0">{p.icon}</span>
                   {p.label}
                 </button>
               ))}
@@ -961,8 +962,8 @@ export default function Cockpit({
 
         <nav className="flex gap-1 border-b border-border mb-5" aria-label="Modo do Jana">
           {[
-            { key: 'dashboard' as const, label: 'Dashboard', icon: '📊' },
-            { key: 'ia' as const, label: 'Analista IA', icon: '🤖' },
+            { key: 'dashboard' as const, label: 'Dashboard', icon: <BarChart3 className="h-4 w-4" /> },
+            { key: 'ia' as const, label: 'Analista IA', icon: <Bot className="h-4 w-4" /> },
           ].map((t) => {
             const active = tab === t.key;
             return (
@@ -992,7 +993,7 @@ export default function Cockpit({
               ))}
             </div>
             <h2 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">
-              <span>📊</span> Análises principais
+              <BarChart3 className="h-4 w-4" /> Análises principais
             </h2>
             <div className="grid grid-cols-1 lg:grid-cols-2 xl:grid-cols-3 gap-3 mb-5">
               {jana.analises.map((a) => (
@@ -1000,7 +1001,7 @@ export default function Cockpit({
               ))}
             </div>
             <h2 className="flex items-center gap-2 text-sm font-semibold uppercase tracking-wider text-muted-foreground mb-3">
-              <span>💡</span> Ações que {jana.person.name} sugere
+              <Lightbulb className="h-4 w-4" /> Ações que {jana.person.name} sugere
             </h2>
             <div className="space-y-2">
               {jana.acoes.map((a) => (

--- a/resources/js/Pages/ProjectMgmt/MyWork/Index.tsx
+++ b/resources/js/Pages/ProjectMgmt/MyWork/Index.tsx
@@ -19,7 +19,7 @@ import { Button } from '@/Components/ui/button';
 import { Badge } from '@/Components/ui/badge';
 import {
   AlertCircle, AtSign, BellOff, CheckCircle2, CheckSquare, Clock,
-  Flame, Inbox as InboxIcon, MessageSquare, RefreshCw, Send, UserPlus,
+  Flame, Inbox as InboxIcon, MessageSquare, RefreshCw, Send, Target, UserPlus,
 } from 'lucide-react';
 import PageHeader from '@/Components/shared/PageHeader';
 import KpiGrid from '@/Components/shared/KpiGrid';
@@ -343,7 +343,7 @@ function MyWorkIndex({
                   </div>
                   {bucket.header.goal && (
                     <p className="text-[11px] text-muted-foreground italic mb-2 px-1 line-clamp-2">
-                      🎯 {bucket.header.goal}
+                      <Target className="h-3 w-3 mr-1 inline align-text-bottom not-italic" /> {bucket.header.goal}
                     </p>
                   )}
                   <div className="flex flex-col gap-2">

--- a/resources/js/Pages/Repair/ProducaoOficina/Index.tsx
+++ b/resources/js/Pages/Repair/ProducaoOficina/Index.tsx
@@ -14,6 +14,7 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { router } from '@inertiajs/react';
 import { useEffect, useMemo, useState } from 'react';
+import { Camera } from 'lucide-react';
 import { toast } from 'sonner';
 import VendaDerivadaCard, {
   type VendaDerivada,
@@ -543,7 +544,7 @@ function JobDrawer({ card, labelOverrides, onClose }: { card: Card; labelOverrid
                 key={label}
                 className="aspect-square rounded bg-slate-200 grid place-items-center text-slate-400 text-[10px]"
               >
-                📷 {label}
+                <span className="inline-flex items-center gap-1"><Camera className="h-3 w-3" /> {label}</span>
               </div>
             ))}
           </div>

--- a/resources/js/Pages/Sells/Caixa/Index.tsx
+++ b/resources/js/Pages/Sells/Caixa/Index.tsx
@@ -11,7 +11,10 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { useCallback, useMemo, useState, type ReactNode } from 'react';
 import { usePage, router } from '@inertiajs/react';
-import { Printer, CheckCircle2 } from 'lucide-react';
+import {
+  Printer, CheckCircle2,
+  Banknote, CreditCard, FileText, Landmark, Wallet, ReceiptText,
+} from 'lucide-react';
 
 // ──────────────────────────────────────────────────────────────
 // TIPOS — paridade backend SellController@inertiaCaixa
@@ -332,21 +335,23 @@ export default function SellsCaixaIndex() {
   );
 }
 
-// Mapeia keyword → emoji simples (paridade Cowork ícones leves).
-function paymentIcon(name: string): string {
+// Mapeia keyword → ícone lucide (AP6 · paridade Cowork ícones leves).
+// O wrapper <span className="vc-pay-icon"> já provê margin-right:6px (sells-cowork.css).
+function paymentIcon(name: string): ReactNode {
+  const cls = 'h-3.5 w-3.5 inline-block align-text-bottom';
   switch (name) {
     case 'cash':
-      return '💵';
+      return <Banknote className={cls} />;
     case 'card':
-      return '💳';
+      return <CreditCard className={cls} />;
     case 'cheque':
-      return '📄';
+      return <FileText className={cls} />;
     case 'transfer':
-      return '🏦';
+      return <Landmark className={cls} />;
     case 'advance':
-      return '💰';
+      return <Wallet className={cls} />;
     default:
-      return '🧾';
+      return <ReceiptText className={cls} />;
   }
 }
 

--- a/resources/js/Pages/Site/Pricing.tsx
+++ b/resources/js/Pages/Site/Pricing.tsx
@@ -3,6 +3,7 @@ import SiteLayout from '@/Layouts/SiteLayout';
 import { Button } from '@/Components/ui/button';
 import PricingTiers from '@/Components/Site/PricingTiers';
 import PricingFaq from '@/Components/Site/PricingFaq';
+import { Lock } from 'lucide-react';
 
 interface SitePricingProps {
   packages?: any[] | null;
@@ -69,7 +70,7 @@ function SitePricing({ packages }: SitePricingProps) {
         <div className="mx-auto grid max-w-5xl grid-cols-1 gap-6 px-4 text-center sm:grid-cols-3 sm:px-6 lg:px-8">
           {[
             { icon: '🇧🇷', title: 'Suporte humano', desc: 'Em português, do mesmo fuso.' },
-            { icon: '🔒', title: 'Seus dados, seus', desc: 'Backup diário. LGPD compliant.' },
+            { icon: <Lock className="mx-auto h-7 w-7" strokeWidth={1.75} />, title: 'Seus dados, seus', desc: 'Backup diário. LGPD compliant.' },
             { icon: '↩️', title: 'Cancela quando quiser', desc: 'Sem multa, sem fidelidade.' },
           ].map((item) => (
             <div key={item.title}>

--- a/resources/js/Pages/ads/Admin/DecisaoShow.tsx
+++ b/resources/js/Pages/ads/Admin/DecisaoShow.tsx
@@ -10,7 +10,7 @@ import { Badge } from '@/Components/ui/badge'
 import { Button } from '@/Components/ui/button'
 import PageHeader from '@/Components/shared/PageHeader'
 import StatusBadge from '@/Components/shared/StatusBadge'
-import { ArrowLeft, CheckCircle2, XCircle, Archive, ShieldAlert } from 'lucide-react'
+import { ArrowLeft, CheckCircle2, XCircle, Archive, ShieldAlert, Workflow } from 'lucide-react'
 
 interface Instruction {
   title?: string
@@ -304,7 +304,7 @@ function DrillDownChain({ decision: d, chain }: { decision: Decision; chain: Cha
 
         {/* Meta-skills aplicáveis */}
         {hasMeta && (
-          <ChainBlock title={`Meta-skills aplicáveis (${chain.meta_skills.length})`} icon="🧬">
+          <ChainBlock title={`Meta-skills aplicáveis (${chain.meta_skills.length})`} icon={<Workflow className="h-3 w-3" />}>
             <ul className="space-y-1.5">
               {chain.meta_skills.map(m => (
                 <li key={m.id} className="text-sm">
@@ -374,7 +374,7 @@ function DrillDownChain({ decision: d, chain }: { decision: Decision; chain: Cha
   )
 }
 
-function ChainBlock({ title, icon, children }: { title: string; icon: string; children: React.ReactNode }) {
+function ChainBlock({ title, icon, children }: { title: string; icon: React.ReactNode; children: React.ReactNode }) {
   return (
     <div className="border-l-2 border-blue-300 pl-3 py-1">
       <div className="text-xs uppercase font-semibold text-blue-700 mb-1.5 flex items-center gap-1">

--- a/resources/js/Pages/ads/Admin/Graph.tsx
+++ b/resources/js/Pages/ads/Admin/Graph.tsx
@@ -13,7 +13,7 @@ import ReactFlow, {
   type Node as RFNode, type Edge as RFEdge,
 } from 'reactflow'
 import 'reactflow/dist/style.css'
-import { Brain, Zap, Wrench, Shield, Database } from 'lucide-react'
+import { Brain, Zap, Wrench, Shield, Database, Save, Workflow } from 'lucide-react'
 
 interface GraphNode {
   id: string
@@ -60,7 +60,7 @@ function layoutNodes(nodes: GraphNode[]): RFNode[] {
     positions.push({
       id: n.id, type: 'default',
       position: { x: cx, y: cy },
-      data: nodeData(n, '💾'),
+      data: nodeData(n, <Save className="h-4 w-4 mx-auto" />),
       style: nodeStyle(n.type),
     })
   })
@@ -82,7 +82,7 @@ function layoutNodes(nodes: GraphNode[]): RFNode[] {
     positions.push({
       id: n.id, type: 'default',
       position: { x: cx - 480, y: 100 + i * 110 },
-      data: nodeData(n, '🧬'),
+      data: nodeData(n, <Workflow className="h-4 w-4 mx-auto" />),
       style: nodeStyle(n.type),
     })
   })
@@ -92,7 +92,7 @@ function layoutNodes(nodes: GraphNode[]): RFNode[] {
     positions.push({
       id: n.id, type: 'default',
       position: { x: cx + 380, y: 100 + i * 90 },
-      data: nodeData(n, '🔧'),
+      data: nodeData(n, <Wrench className="h-4 w-4 mx-auto" />),
       style: nodeStyle(n.type),
     })
   })
@@ -102,7 +102,7 @@ function layoutNodes(nodes: GraphNode[]): RFNode[] {
     positions.push({
       id: n.id, type: 'default',
       position: { x: 100 + i * 240, y: cy + 280 },
-      data: nodeData(n, '🛡️'),
+      data: nodeData(n, <Shield className="h-4 w-4 mx-auto" />),
       style: nodeStyle(n.type),
     })
   })
@@ -110,7 +110,7 @@ function layoutNodes(nodes: GraphNode[]): RFNode[] {
   return positions
 }
 
-function nodeData(n: GraphNode, icon: string): any {
+function nodeData(n: GraphNode, icon: ReactNode): any {
   const lines: string[] = []
   if (n.data.success_rate !== undefined) lines.push(`taxa ${(n.data.success_rate * 100).toFixed(0)}%`)
   if (n.data.total_count !== undefined)  lines.push(`${n.data.total_count} exec`)

--- a/resources/js/Pages/ads/Admin/ProjectShow.tsx
+++ b/resources/js/Pages/ads/Admin/ProjectShow.tsx
@@ -12,7 +12,7 @@ import PageHeader from '@/Components/shared/PageHeader'
 import KpiGrid from '@/Components/shared/KpiGrid'
 import KpiCard from '@/Components/shared/KpiCard'
 import EmptyState from '@/Components/shared/EmptyState'
-import { ArrowLeft, Zap, ArrowRight } from 'lucide-react'
+import { ArrowLeft, Zap, ArrowRight, Wallet } from 'lucide-react'
 
 interface Part {
   id: number
@@ -193,7 +193,7 @@ const ProjectShow: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = 
 
                       <div className="flex items-center gap-3 text-xs text-muted-foreground flex-wrap">
                         {part.estimativa_horas && <span>⏱ {part.estimativa_horas}h</span>}
-                        {part.valor_estimado_brl && <span>💰 {brl(part.valor_estimado_brl)}</span>}
+                        {part.valor_estimado_brl && <span className="inline-flex items-center"><Wallet className="h-3 w-3 mr-1" /> {brl(part.valor_estimado_brl)}</span>}
                         {part.dependencias.length > 0 && (
                           <span>↳ depende de: {part.dependencias.join(', ')}</span>
                         )}

--- a/resources/js/Pages/governance/Dashboard.tsx
+++ b/resources/js/Pages/governance/Dashboard.tsx
@@ -11,6 +11,19 @@ import PageHeader from '@/Components/shared/PageHeader'
 import KpiGrid from '@/Components/shared/KpiGrid'
 import KpiCard from '@/Components/shared/KpiCard'
 import EmptyState from '@/Components/shared/EmptyState'
+import {
+  ClipboardList,
+  BarChart3,
+  Bot,
+  AlertTriangle,
+  History,
+  KeyRound,
+  Construction,
+  Users,
+  Shield,
+  Ruler,
+  BookOpen,
+} from 'lucide-react'
 
 interface Adr {
   slug: string
@@ -219,7 +232,7 @@ const Dashboard: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
           <CardContent className="p-4">
             <div className="flex items-center justify-between mb-3">
               <h3 className="text-lg font-semibold flex items-center gap-2">
-                <span className="text-amber-600">📋</span>
+                <ClipboardList className="h-4 w-4 text-amber-600" />
                 ADRs aguardando você ({pending_adrs.length})
               </h3>
               <Link href="/copiloto/admin/memoria?type=adr" className="text-sm text-primary hover:underline">
@@ -253,7 +266,7 @@ const Dashboard: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
           <CardContent className="p-4">
             <div className="flex items-center justify-between mb-3">
               <h3 className="text-lg font-semibold flex items-center gap-2">
-                <span className="text-zinc-700 dark:text-zinc-300">📊</span>
+                <BarChart3 className="h-4 w-4 text-zinc-700 dark:text-zinc-300" />
                 Audit Highlights 24h ({audit_highlights.length})
               </h3>
               <Link href="/governance/audit" className="text-sm text-primary hover:underline">
@@ -294,7 +307,7 @@ const Dashboard: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
           <CardContent className="p-4">
             <div className="flex items-center justify-between mb-3">
               <h3 className="text-lg font-semibold flex items-center gap-2">
-                <span className="text-zinc-700 dark:text-zinc-300">🤖</span>
+                <Bot className="h-4 w-4 text-zinc-700 dark:text-zinc-300" />
                 Narrativas Brain A 24h ({narratives.length})
               </h3>
               <Link href="/copiloto/admin/memoria?type=narrative" className="text-sm text-primary hover:underline">
@@ -338,19 +351,19 @@ const Dashboard: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
               href="/governance/audit"
               className="px-4 py-3 bg-zinc-50 dark:bg-zinc-900 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-md border border-zinc-200 dark:border-zinc-700 text-sm font-medium transition-colors"
             >
-              📊 Audit log
+              <BarChart3 className="h-3.5 w-3.5 mr-1 inline-block" /> Audit log
             </Link>
             <Link
               href="/governance/drift"
               className="px-4 py-3 bg-zinc-50 dark:bg-zinc-900 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-md border border-zinc-200 dark:border-zinc-700 text-sm font-medium transition-colors"
             >
-              🚨 Drift alerts
+              <AlertTriangle className="h-3.5 w-3.5 mr-1 inline-block" /> Drift alerts
             </Link>
             <Link
               href="/copiloto/admin/memoria?type=adr&status=proposto"
               className="px-4 py-3 bg-zinc-50 dark:bg-zinc-900 hover:bg-zinc-100 dark:hover:bg-zinc-800 rounded-md border border-zinc-200 dark:border-zinc-700 text-sm font-medium transition-colors"
             >
-              📋 ADRs proposto
+              <ClipboardList className="h-3.5 w-3.5 mr-1 inline-block" /> ADRs proposto
             </Link>
           </div>
         </CardContent>
@@ -361,14 +374,14 @@ const Dashboard: React.FC<Props> & { layout?: (p: ReactNode) => ReactNode } = ({
         <CardContent className="p-4">
           <h3 className="text-lg font-semibold mb-3">Documentos canônicos</h3>
           <div className="grid grid-cols-2 md:grid-cols-4 gap-2 text-sm">
-            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/CONSTITUTION.md" target="_blank" rel="noreferrer" className="text-primary hover:underline">📜 Constituição v1.1.0</a>
-            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/TRUST-TIERS.md" target="_blank" rel="noreferrer" className="text-primary hover:underline">🔐 Trust Tiers</a>
-            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/ARCHITECTURE.md" target="_blank" rel="noreferrer" className="text-primary hover:underline">🏗️ Architecture</a>
-            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/IDENTITY-MESH.md" target="_blank" rel="noreferrer" className="text-primary hover:underline">👥 Identity Mesh</a>
-            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/ENFORCEMENT.md" target="_blank" rel="noreferrer" className="text-primary hover:underline">🛡️ Enforcement (8 mecanismos)</a>
-            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/MODULE-DRIFT-MIGRATION-PLAN.md" target="_blank" rel="noreferrer" className="text-primary hover:underline">📐 Drift Migration Plan</a>
-            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/audit-2026-05-05-v1.1.md" target="_blank" rel="noreferrer" className="text-primary hover:underline">📋 Audit cascata v1.1</a>
-            <Link href="/copiloto/admin/memoria" className="text-primary hover:underline">📚 KB completo →</Link>
+            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/CONSTITUTION.md" target="_blank" rel="noreferrer" className="text-primary hover:underline"><History className="h-3.5 w-3.5 mr-1 inline-block" /> Constituição v1.1.0</a>
+            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/TRUST-TIERS.md" target="_blank" rel="noreferrer" className="text-primary hover:underline"><KeyRound className="h-3.5 w-3.5 mr-1 inline-block" /> Trust Tiers</a>
+            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/ARCHITECTURE.md" target="_blank" rel="noreferrer" className="text-primary hover:underline"><Construction className="h-3.5 w-3.5 mr-1 inline-block" /> Architecture</a>
+            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/IDENTITY-MESH.md" target="_blank" rel="noreferrer" className="text-primary hover:underline"><Users className="h-3.5 w-3.5 mr-1 inline-block" /> Identity Mesh</a>
+            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/ENFORCEMENT.md" target="_blank" rel="noreferrer" className="text-primary hover:underline"><Shield className="h-3.5 w-3.5 mr-1 inline-block" /> Enforcement (8 mecanismos)</a>
+            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/MODULE-DRIFT-MIGRATION-PLAN.md" target="_blank" rel="noreferrer" className="text-primary hover:underline"><Ruler className="h-3.5 w-3.5 mr-1 inline-block" /> Drift Migration Plan</a>
+            <a href="https://github.com/wagnerra23/oimpresso.com/blob/main/memory/governance/audit-2026-05-05-v1.1.md" target="_blank" rel="noreferrer" className="text-primary hover:underline"><ClipboardList className="h-3.5 w-3.5 mr-1 inline-block" /> Audit cascata v1.1</a>
+            <Link href="/copiloto/admin/memoria" className="text-primary hover:underline"><BookOpen className="h-3.5 w-3.5 mr-1 inline-block" /> KB completo →</Link>
           </div>
         </CardContent>
       </Card>

--- a/resources/js/Pages/kb/Index.tsx
+++ b/resources/js/Pages/kb/Index.tsx
@@ -35,6 +35,7 @@ import PageHeader from '@/Components/shared/PageHeader';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
 import { toast } from 'sonner';
+import { Copy, Lock, Github, History, Trash2, BookOpen } from 'lucide-react';
 
 interface DocRow {
   id: number;
@@ -435,7 +436,7 @@ function KbIndex(props: Props) {
         <div className="flex items-center gap-1 shrink-0">
           {detail && (
             <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={() => copySlug(detail.slug)} title="Copiar slug">
-              📋
+              <Copy className="h-4 w-4" />
             </Button>
           )}
           <Button variant="ghost" size="sm" className="h-7 w-7 p-0" onClick={closePreview} title="Fechar (Esc)">
@@ -469,7 +470,7 @@ function KbIndex(props: Props) {
               {detail.module && <Badge variant="outline" className="text-xs">{detail.module}</Badge>}
               {detail.scope_required && (
                 <Badge variant="outline" className="bg-purple-50 text-purple-700 border-purple-200 text-xs" title="Spatie permission requerida">
-                  🔒 {detail.scope_required}
+                  <Lock className="h-3 w-3 mr-1" /> {detail.scope_required}
                 </Badge>
               )}
               {detail.admin_only && <Badge variant="outline" className="bg-red-50 text-red-700 border-red-200 text-xs">admin only</Badge>}
@@ -490,12 +491,12 @@ function KbIndex(props: Props) {
             <div className="flex gap-2 flex-wrap mt-2">
               {detail.github_url && (
                 <a href={detail.github_url} target="_blank" rel="noopener noreferrer">
-                  <Button variant="outline" size="sm" className="h-7 text-xs">📂 GitHub</Button>
+                  <Button variant="outline" size="sm" className="h-7 text-xs"><Github className="h-3.5 w-3.5 mr-1" /> GitHub</Button>
                 </a>
               )}
               {detail.history_count > 0 && (
                 <Button variant="outline" size="sm" className="h-7 text-xs" disabled title="Em breve (O11)">
-                  📜 {detail.history_count} versões
+                  <History className="h-3.5 w-3.5 mr-1" /> {detail.history_count} versões
                 </Button>
               )}
               {!detail.deleted_at ? (
@@ -504,7 +505,7 @@ function KbIndex(props: Props) {
                   className="h-7 text-xs"
                   onClick={() => setConfirmDelete(detail)}
                 >
-                  🗑️ Soft-delete LGPD
+                  <Trash2 className="h-3.5 w-3.5 mr-1" /> Soft-delete LGPD
                 </Button>
               ) : (
                 <Button
@@ -658,7 +659,7 @@ function KbIndex(props: Props) {
           )}
           {!previewOpen && selectedSlug && (
             <Button variant="default" size="sm" className="h-8 text-xs" onClick={() => openDoc(selectedSlug)}>
-              📖 Abrir preview
+              <BookOpen className="h-3.5 w-3.5 mr-1" /> Abrir preview
             </Button>
           )}
         </CardContent>

--- a/resources/js/Pages/team-mcp/CcSessions/Index.tsx
+++ b/resources/js/Pages/team-mcp/CcSessions/Index.tsx
@@ -19,6 +19,7 @@ import {
 } from '@/Components/ui/select';
 import { Label } from '@/Components/ui/label';
 import { ScrollArea } from '@/Components/ui/scroll-area';
+import { FolderOpen, Inbox } from 'lucide-react';
 import PageHeader from '@/Components/shared/PageHeader';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
@@ -255,7 +256,7 @@ function CcSessionsIndex(props: Props) {
       <CardContent className="p-0 flex-1 overflow-hidden">
         {isEmpty ? (
           <div className="p-8 text-center text-muted-foreground space-y-3">
-            <div className="text-4xl">📭</div>
+            <Inbox className="h-10 w-10 mx-auto text-muted-foreground/60" />
             <div className="text-sm font-medium">Nenhuma sessão Claude Code ingestada ainda</div>
             <div className="text-xs max-w-md mx-auto">
               Schema <code className="font-mono text-[10px]">mcp_cc_*</code> está pronto, mas o
@@ -369,8 +370,8 @@ function CcSessionsIndex(props: Props) {
               {detail.session.entrypoint && <Badge variant="outline" className="text-[10px]">{detail.session.entrypoint}</Badge>}
               {detail.session.git_branch && <Badge variant="outline" className="text-[10px] font-mono">{detail.session.git_branch}</Badge>}
             </div>
-            <div className="text-[11px] text-muted-foreground">
-              📁 <span className="font-mono">{detail.session.project_path}</span>
+            <div className="text-[11px] text-muted-foreground inline-flex items-center">
+              <FolderOpen className="h-3 w-3 mr-1 shrink-0" /> <span className="font-mono">{detail.session.project_path}</span>
             </div>
             <div className="text-[11px] text-muted-foreground">
               {fmtDateTime(detail.session.started_at)} → {detail.session.ended_at ? fmtDateTime(detail.session.ended_at) : 'em curso'}

--- a/resources/js/Pages/team-mcp/Team/Index.tsx
+++ b/resources/js/Pages/team-mcp/Team/Index.tsx
@@ -28,6 +28,7 @@ import {
   AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle,
 } from '@/Components/ui/alert-dialog';
 import { Badge } from '@/Components/ui/badge';
+import { BarChart3, ClipboardList, Package, Trash2 } from 'lucide-react';
 import PageHeader from '@/Components/shared/PageHeader';
 import KpiGrid from '@/Components/shared/KpiGrid';
 import KpiCard from '@/Components/shared/KpiCard';
@@ -251,7 +252,7 @@ function TeamIndex(props: Props) {
         action={
           <div className="flex gap-2">
             <Button variant="outline" size="sm" onClick={exportarCsv}>
-              📊 Export CSV
+              <BarChart3 className="h-3.5 w-3.5 mr-1" /> Export CSV
             </Button>
           </div>
         }
@@ -402,7 +403,7 @@ function TeamIndex(props: Props) {
                           className="text-xs"
                           title="Gera token + arquivo .dxt pro Claude Desktop"
                         >
-                          📦 + DXT
+                          <Package className="h-3.5 w-3.5 mr-1" /> + DXT
                         </Button>
                         <Button
                           variant="outline" size="sm"
@@ -465,7 +466,7 @@ function TeamIndex(props: Props) {
                 toast.success('Copiado pro clipboard');
               }
             }}>
-              📋 Copiar
+              <ClipboardList className="h-4 w-4 mr-1" /> Copiar
             </Button>
             <Button variant="outline" onClick={() => setTokenGerado(null)}>Fechar</Button>
           </DialogFooter>
@@ -677,7 +678,7 @@ function TokensListDialog({
                           title={isInactive ? 'Já inativo' : `Revogar token ${t.name}`}
                           className="text-xs"
                         >
-                          🗑 Revogar
+                          <Trash2 className="h-3.5 w-3.5 mr-1" /> Revogar
                         </Button>
                       </td>
                     </tr>


### PR DESCRIPTION
## US-_DESIGNSYSTEM-015 — emoji → lucide (AP6) · 19 telas

⚠️ **MUDANÇA VISÍVEL** — `visual-regression` vai **falhar de propósito** (emoji vira ícone, pixel muda). Por ADR 0114, **você aprova o screenshot** antes do merge. Não auto-mergeio.

### O que foi feito
6 agentes paralelos aplicaram o **mapa que você aprovou** (📊→BarChart3, 🤖→Bot, 🔒→Lock, 💰→Wallet, 🗑→Trash2, 📂→Github, …) em **19 telas**. Emoji em **texto JSX** → componente lucide, tamanho por contexto (badge `h-3`, botão sm `h-3.5`, ícone/heading `h-4`).

### R6: 21 → 6 (os 6 são leaves justificados)
- `ads/Graph` 🔒👁 — em `string[].join(' · ')` (vira texto único; trocar quebraria o join)
- `Qualidade` 🔴 · `Team` 🚫 · `Cockpit` 📨 — campo string de função (`gateStatus`/`quotaBadge`/mock-stream)
- `Cockpit` 🤖 · `JanaCockpitV2` 📅 — em comentário de código
- `Site/Pricing` 🇧🇷 — bandeira, **lucide não tem flag**

### Build-risk verificado (sem node_modules local)
- ✅ **72 nomes lucide existem** no pacote (checado via require) — sem break de import inexistente
- ✅ imports presentes nas 19 · edits landed (grep confirma `<Copy>` etc nos lugares certos)
- Tipos `string→ReactNode` onde emoji era prop (Sells/Caixa `paymentIcon`, ads `ChainBlock`/`nodeData`, Compras `AcoesDropdown`) — esbuild ignora tipos, render aceita ReactNode

### Pra você
Olha o before/after no `visual-regression` (ou nas telas) — se algum ícone ficou esquisito/desalinhado, me fala qual que eu ajusto. Aprovou → merge via `--admin` (o visual-regression "falhar" é esperado).

Fecha **US-_DESIGNSYSTEM-015**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
