### PR TITLE
fix(financeiro): Conciliação — audit-log + reabrir/undo (B2)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/ConciliacaoController.php
+++ b/Modules/Financeiro/Http/Controllers/ConciliacaoController.php
@@ -11,20 +11,25 @@ use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Models\Titulo;
+use Modules\Financeiro\Services\FinanceiroAuditLogger;
 
 /**
  * Conciliação OFX — Onda 19 (2026-05-19) #49.
  *
  * Workflow:
- *  1. GET  /financeiro/conciliacao — lista linhas pendentes
+ *  1. GET  /financeiro/conciliacao — lista linhas pendentes (?incluir_resolvidos=1 inclui resolvidas)
  *  2. POST /financeiro/conciliacao/upload — recebe arquivo OFX, parseia, persiste
  *  3. POST /financeiro/conciliacao/{lineId}/match — confirma match com Titulo
  *  4. POST /financeiro/conciliacao/{lineId}/ignorar — marca como ignorado
+ *  5. POST /financeiro/conciliacao/{lineId}/reabrir — desfaz conciliação/ignore (volta a pendente)
  *
  * Parser OFX simples (regex). NÃO usa biblioteca externa (mantém deps enxutas).
  * Para CNAB / formatos complexos: Onda 22 com `OfxImporter` dedicated service.
  *
  * Tier 0: business_id global scope (BankStatementLine model usa BusinessScope).
+ *
+ * Auditoria (append-only): match/ignorar/reabrir registram quem+o quê+quando via
+ * FinanceiroAuditLogger (PII redacted, business_id preservado — ADR 0093 + Wave 14 D7.a).
  */
 class ConciliacaoController extends Controller
 {
@@ -32,10 +37,18 @@ class ConciliacaoController extends Controller
     {
         $businessId = (int) session('user.business_id');
 
-        // Linhas pendentes/sugeridas ordenadas por data desc.
+        // Toggle "ver conciliados/ignorados" — quando ligado, inclui linhas
+        // resolvidas pra permitir reabrir (undo). Default (não setado) mantém o
+        // fluxo original: só pendente/sugerido.
+        $incluirResolvidos = $request->boolean('incluir_resolvidos');
+        $statusFiltro = $incluirResolvidos
+            ? ['pendente', 'sugerido', 'conciliado', 'ignorado']
+            : ['pendente', 'sugerido'];
+
+        // Linhas ordenadas por data desc.
         $linhas = DB::table('fin_bank_statement_lines')
             ->where('business_id', $businessId)
-            ->whereIn('status', ['pendente', 'sugerido'])
+            ->whereIn('status', $statusFiltro)
             ->whereNull('deleted_at')
             ->orderBy('data_movimento', 'desc')
             ->limit(200)
@@ -59,6 +72,9 @@ class ConciliacaoController extends Controller
             'linhas' => $linhas,
             'stats' => $stats,
             'contas' => $contas,
+            'filters' => [
+                'incluir_resolvidos' => $incluirResolvidos,
+            ],
         ]);
     }
 
@@ -141,17 +157,33 @@ class ConciliacaoController extends Controller
     {
         $request->validate(['titulo_id' => 'required|integer']);
         $businessId = (int) session('user.business_id');
+        $tituloId = $request->integer('titulo_id');
+        $userId = $request->user()?->id;
 
-        DB::table('fin_bank_statement_lines')
+        $afetadas = DB::table('fin_bank_statement_lines')
             ->where('id', $lineId)
             ->where('business_id', $businessId)
             ->update([
                 'status' => 'conciliado',
-                'titulo_id' => $request->integer('titulo_id'),
-                'conciliado_by' => $request->user()?->id,
+                'titulo_id' => $tituloId,
+                'conciliado_by' => $userId,
                 'conciliado_at' => now(),
                 'updated_at' => now(),
             ]);
+
+        // Auditoria append-only (ADR 0093 + Wave 14 D7.a) — quem/o quê/quando.
+        // business_id/titulo_id são chaves operacionais (não redacionadas).
+        app(FinanceiroAuditLogger::class)->info(
+            'conciliacao.match: linha conciliada com título',
+            [
+                'business_id' => $businessId,
+                'line_id' => $lineId,
+                'titulo_id' => $tituloId,
+                'status' => 'conciliado',
+                'user_id' => $userId,
+                'afetadas' => $afetadas,
+            ]
+        );
 
         return back()->with('success', 'Conciliação confirmada.');
     }
@@ -159,8 +191,9 @@ class ConciliacaoController extends Controller
     public function ignorar(Request $request, int $lineId): RedirectResponse
     {
         $businessId = (int) session('user.business_id');
+        $userId = $request->user()?->id;
 
-        DB::table('fin_bank_statement_lines')
+        $afetadas = DB::table('fin_bank_statement_lines')
             ->where('id', $lineId)
             ->where('business_id', $businessId)
             ->update([
@@ -168,7 +201,76 @@ class ConciliacaoController extends Controller
                 'updated_at' => now(),
             ]);
 
+        // Auditoria append-only (ADR 0093 + Wave 14 D7.a) — quem/o quê/quando.
+        app(FinanceiroAuditLogger::class)->info(
+            'conciliacao.ignorar: linha marcada como ignorada',
+            [
+                'business_id' => $businessId,
+                'line_id' => $lineId,
+                'status' => 'ignorado',
+                'user_id' => $userId,
+                'afetadas' => $afetadas,
+            ]
+        );
+
         return back()->with('success', 'Linha marcada como ignorada.');
+    }
+
+    /**
+     * Reabre (undo) uma conciliação/ignore: volta a linha pra `pendente`,
+     * limpa titulo_id + match_score, e registra a reabertura na auditoria.
+     * POST /financeiro/conciliacao/{lineId}/reabrir.
+     *
+     * Tier 0: scoped por business_id. Linha inexistente neste tenant → 404
+     * (não-silencioso). Idempotente: reabrir linha já pendente é inócuo (o
+     * UPDATE só zera campos já nulos), mas SEMPRE muta de fato (sem no-op).
+     */
+    public function reabrir(Request $request, int $lineId): RedirectResponse
+    {
+        $businessId = (int) session('user.business_id');
+        $userId = $request->user()?->id;
+
+        // Carrega estado anterior pra auditoria + valida existência no tenant.
+        $linha = DB::table('fin_bank_statement_lines')
+            ->where('id', $lineId)
+            ->where('business_id', $businessId)
+            ->whereNull('deleted_at')
+            ->first();
+
+        if (! $linha) {
+            // Não-silencioso: linha não existe pra este business (Tier 0).
+            abort(404);
+        }
+
+        $statusAnterior = $linha->status;
+
+        DB::table('fin_bank_statement_lines')
+            ->where('id', $lineId)
+            ->where('business_id', $businessId)
+            ->update([
+                'status' => 'pendente',
+                'titulo_id' => null,
+                'match_score' => null,
+                'conciliado_by' => null,
+                'conciliado_at' => null,
+                'updated_at' => now(),
+            ]);
+
+        // Auditoria append-only (ADR 0093 + Wave 14 D7.a) — registra a reabertura
+        // com o status de onde veio (conciliado/ignorado/sugerido).
+        app(FinanceiroAuditLogger::class)->info(
+            'conciliacao.reabrir: linha reaberta (volta a pendente)',
+            [
+                'business_id' => $businessId,
+                'line_id' => $lineId,
+                'status' => 'pendente',
+                'status_anterior' => $statusAnterior,
+                'titulo_id' => $linha->titulo_id,
+                'user_id' => $userId,
+            ]
+        );
+
+        return back()->with('success', 'Linha reaberta — voltou para pendente.');
     }
 
     /** OFX TRNTYPE → enum interno */

--- a/Modules/Financeiro/Routes/web.php
+++ b/Modules/Financeiro/Routes/web.php
@@ -227,6 +227,10 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
         Route::post('/conciliacao/{lineId}/ignorar', [ConciliacaoController::class, 'ignorar'])
             ->whereNumber('lineId')
             ->name('conciliacao.ignorar');
+        // Reabrir (undo) conciliação/ignore → volta a pendente + audit-log.
+        Route::post('/conciliacao/{lineId}/reabrir', [ConciliacaoController::class, 'reabrir'])
+            ->whereNumber('lineId')
+            ->name('conciliacao.reabrir');
 
         // Onda 23 (2026-05-20) US-FIN-029 — OCR boleto upload (OpenAI Vision).
         // KILLER feature vs Conta Azul. Endpoint não cria titulo direto —

--- a/Modules/Financeiro/Tests/Feature/ConciliacaoAuditReabrirTest.php
+++ b/Modules/Financeiro/Tests/Feature/ConciliacaoAuditReabrirTest.php
@@ -1,0 +1,207 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Spatie\Permission\Models\Permission;
+
+uses(Tests\TestCase::class);
+
+/**
+ * B2 — Auditoria + Reabrir (undo) da Conciliação OFX.
+ *
+ * Cobre invariantes:
+ *  (a) match()/ignorar() escrevem entrada de auditoria via FinanceiroAuditLogger
+ *      (sink = Log facade; espiamos com Log::spy + shouldHaveReceived).
+ *  (b) reabrir() volta status pra `pendente` e zera titulo_id/match_score.
+ *  (c) reabrir() de linha de OUTRO business → 404 (Tier 0 ADR 0093 IRREVOGÁVEL).
+ *
+ * Padrão Financeiro (CaixaControllerTest/UnificadoControllerTest): sem
+ * RefreshDatabase (UltimatePOS tem 100+ migrations + triggers), roda contra DB
+ * dev real, skip gracioso quando greenfield ou módulo não instalado.
+ *
+ * Rodar local: `vendor/bin/pest Modules/Financeiro/Tests/Feature/ConciliacaoAuditReabrirTest.php`
+ */
+
+function conciliacaoBootstrap(): User
+{
+    try {
+        $business = Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: '.$e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco — rode seeder UltimatePOS antes.');
+    }
+
+    $user = User::where('business_id', $business->id)->first();
+    if (! $user) {
+        test()->markTestSkipped('Sem user no business.');
+    }
+
+    // Tabela alvo precisa existir neste env (módulo instalado).
+    if (! \Illuminate\Support\Facades\Schema::hasTable('fin_bank_statement_lines')) {
+        test()->markTestSkipped('Tabela fin_bank_statement_lines ausente — financeiro:install pendente.');
+    }
+
+    Permission::firstOrCreate(['name' => 'financeiro.conciliacao.manage', 'guard_name' => 'web']);
+    if (! $user->hasPermissionTo('financeiro.conciliacao.manage')) {
+        $user->givePermissionTo('financeiro.conciliacao.manage');
+    }
+
+    session([
+        'user.business_id' => $business->id,
+        'user.id'          => $user->id,
+        'business.id'      => $business->id,
+        'business.name'    => $business->name,
+        'is_admin'         => true,
+    ]);
+
+    return $user;
+}
+
+/** Insere uma linha de extrato pendente pro business do user e devolve o id. */
+function inserirLinhaConciliacao(int $businessId, array $overrides = []): int
+{
+    return (int) DB::table('fin_bank_statement_lines')->insertGetId(array_merge([
+        'business_id'    => $businessId,
+        'fitid'          => 'pest-'.uniqid('', true),
+        'data_movimento' => now()->toDateString(),
+        'descricao'      => 'Lançamento de teste B2',
+        'valor'          => -123.45,
+        'tipo'           => 'debit',
+        'status'         => 'pendente',
+        'source_file'    => 'pest.ofx',
+        'created_at'     => now(),
+        'updated_at'     => now(),
+    ], $overrides));
+}
+
+it('match() escreve entrada de auditoria via FinanceiroAuditLogger', function () {
+    $user = conciliacaoBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    $lineId = inserirLinhaConciliacao($businessId);
+
+    Log::spy();
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/conciliacao')
+        ->post("/financeiro/conciliacao/{$lineId}/match", ['titulo_id' => 999999]);
+
+    expect($response->status())->toBeIn([302, 303]);
+
+    // Sink do FinanceiroAuditLogger é o Log facade (Log::info após redação PII).
+    Log::shouldHaveReceived('info')
+        ->withArgs(function (string $msg, array $ctx) use ($lineId, $businessId) {
+            return str_contains($msg, 'conciliacao.match')
+                && ($ctx['business_id'] ?? null) === $businessId
+                && ($ctx['line_id'] ?? null) === $lineId
+                && ($ctx['status'] ?? null) === 'conciliado'
+                && ($ctx['titulo_id'] ?? null) === 999999;
+        })
+        ->once();
+
+    // Cleanup.
+    DB::table('fin_bank_statement_lines')->where('id', $lineId)->delete();
+});
+
+it('ignorar() escreve entrada de auditoria via FinanceiroAuditLogger', function () {
+    $user = conciliacaoBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    $lineId = inserirLinhaConciliacao($businessId);
+
+    Log::spy();
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/conciliacao')
+        ->post("/financeiro/conciliacao/{$lineId}/ignorar");
+
+    expect($response->status())->toBeIn([302, 303]);
+
+    Log::shouldHaveReceived('info')
+        ->withArgs(function (string $msg, array $ctx) use ($lineId, $businessId) {
+            return str_contains($msg, 'conciliacao.ignorar')
+                && ($ctx['business_id'] ?? null) === $businessId
+                && ($ctx['line_id'] ?? null) === $lineId
+                && ($ctx['status'] ?? null) === 'ignorado';
+        })
+        ->once();
+
+    DB::table('fin_bank_statement_lines')->where('id', $lineId)->delete();
+});
+
+it('reabrir() volta status pra pendente e zera titulo_id/match_score', function () {
+    $user = conciliacaoBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    // Linha já conciliada (com titulo_id + match_score) pra ter o que desfazer.
+    $lineId = inserirLinhaConciliacao($businessId, [
+        'status'        => 'conciliado',
+        'titulo_id'     => 12345,
+        'match_score'   => 0.85,
+        'conciliado_by' => $user->id,
+        'conciliado_at' => now(),
+    ]);
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/conciliacao')
+        ->post("/financeiro/conciliacao/{$lineId}/reabrir");
+
+    expect($response->status())->toBeIn([302, 303]);
+
+    $linha = DB::table('fin_bank_statement_lines')->where('id', $lineId)->first();
+    expect($linha->status)->toBe('pendente');
+    expect($linha->titulo_id)->toBeNull();
+    expect($linha->match_score)->toBeNull();
+
+    DB::table('fin_bank_statement_lines')->where('id', $lineId)->delete();
+});
+
+it('reabrir() é idempotente — linha já pendente continua pendente (sem erro)', function () {
+    $user = conciliacaoBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    $lineId = inserirLinhaConciliacao($businessId); // já pendente
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/conciliacao')
+        ->post("/financeiro/conciliacao/{$lineId}/reabrir");
+
+    expect($response->status())->toBeIn([302, 303]);
+
+    $linha = DB::table('fin_bank_statement_lines')->where('id', $lineId)->first();
+    expect($linha->status)->toBe('pendente');
+
+    DB::table('fin_bank_statement_lines')->where('id', $lineId)->delete();
+});
+
+it('Tier 0: reabrir() de linha de OUTRO business retorna 404 (ADR 0093)', function () {
+    $user = conciliacaoBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    $businessB = Business::where('id', '!=', $businessId)->first();
+    if (! $businessB) {
+        test()->markTestSkipped('Apenas 1 business no DB — não há cross-tenant pra testar.');
+    }
+
+    // Linha pertencente ao businessB (NÃO ao tenant logado).
+    $lineId = inserirLinhaConciliacao($businessB->id, ['status' => 'conciliado']);
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/conciliacao')
+        ->post("/financeiro/conciliacao/{$lineId}/reabrir");
+
+    expect($response->status())->toBe(404);
+
+    // Garante que NÃO mutou a linha do outro tenant (continua conciliado).
+    $linha = DB::table('fin_bank_statement_lines')->where('id', $lineId)->first();
+    expect($linha->status)->toBe('conciliado');
+
+    DB::table('fin_bank_statement_lines')->where('id', $lineId)->delete();
+});

--- a/resources/js/Pages/Financeiro/Conciliacao/Index.tsx
+++ b/resources/js/Pages/Financeiro/Conciliacao/Index.tsx
@@ -9,7 +9,7 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { useForm, router } from '@inertiajs/react';
 import { type ReactNode, type FormEvent, useState } from 'react';
-import { Upload, Check, X, Search } from 'lucide-react';
+import { Upload, Check, X, Search, RotateCcw } from 'lucide-react';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
 import { PageHeader } from '@/Components/PageHeader';
 import {
@@ -39,6 +39,7 @@ interface Props {
   linhas: Linha[];
   stats: Stats;
   contas: { id: number; nome: string }[];
+  filters: { incluir_resolvidos: boolean };
 }
 
 const brl = (v: number) =>
@@ -51,7 +52,7 @@ const STATUS_CLR: Record<Linha['status'], string> = {
   ignorado:   'bg-stone-100 text-stone-400 border-stone-200',
 };
 
-function FinanceiroConciliacao({ linhas, stats, contas }: Props) {
+function FinanceiroConciliacao({ linhas, stats, contas, filters }: Props) {
   const [busca, setBusca] = useState('');
 
   const uploadForm = useForm<{ arquivo: File | null; conta_bancaria_id: string }>({
@@ -81,6 +82,21 @@ function FinanceiroConciliacao({ linhas, stats, contas }: Props) {
 
   const ignorar = (lineId: number) => {
     router.post(`/financeiro/conciliacao/${lineId}/ignorar`, {}, { preserveScroll: true });
+  };
+
+  // Reabrir (undo): volta linha conciliada/ignorada pra pendente.
+  const reabrir = (lineId: number) => {
+    router.post(`/financeiro/conciliacao/${lineId}/reabrir`, {}, { preserveScroll: true });
+  };
+
+  // Toggle "ver conciliados/ignorados" — recarrega o index com/sem o query param.
+  // GET só dos dados de `linhas`+`filters` (preserva scroll/estado de form).
+  const toggleResolvidos = () => {
+    router.get(
+      '/financeiro/conciliacao',
+      filters.incluir_resolvidos ? {} : { incluir_resolvidos: 1 },
+      { preserveScroll: true, preserveState: true, only: ['linhas', 'filters'] },
+    );
   };
 
   const filtradas = linhas.filter((l) =>
@@ -182,15 +198,25 @@ function FinanceiroConciliacao({ linhas, stats, contas }: Props) {
         </p>
       </div>
 
-      {/* Filtro busca */}
+      {/* Filtro busca + toggle "ver conciliados/ignorados" */}
       {linhas.length > 0 && (
-        <div className="mt-4 fin-search-wrap" style={{ maxWidth: 400 }}>
-          <Search size={13} aria-hidden="true" />
-          <input
-            placeholder="Buscar por descrição…"
-            value={busca}
-            onChange={(e) => setBusca(e.target.value)}
-          />
+        <div className="mt-4 flex flex-wrap items-center gap-3">
+          <div className="fin-search-wrap" style={{ maxWidth: 400, flex: 1 }}>
+            <Search size={13} aria-hidden="true" />
+            <input
+              placeholder="Buscar por descrição…"
+              value={busca}
+              onChange={(e) => setBusca(e.target.value)}
+            />
+          </div>
+          <label className="flex items-center gap-1.5 text-[12px] text-stone-600 cursor-pointer select-none">
+            <input
+              type="checkbox"
+              checked={filters.incluir_resolvidos}
+              onChange={toggleResolvidos}
+            />
+            Ver conciliados/ignorados
+          </label>
         </div>
       )}
 
@@ -259,6 +285,17 @@ function FinanceiroConciliacao({ linhas, stats, contas }: Props) {
                       title="Ignorar linha"
                     >
                       <X size={11} /> Ignorar
+                    </button>
+                  )}
+                  {(l.status === 'conciliado' || l.status === 'ignorado') && (
+                    <button
+                      type="button"
+                      className="os-btn ghost"
+                      style={{ padding: '4px 8px', fontSize: 11 }}
+                      onClick={() => reabrir(l.id)}
+                      title="Reabrir — volta para pendente"
+                    >
+                      <RotateCcw size={11} /> Reabrir
                     </button>
                   )}
                 </td>


### PR DESCRIPTION
## Bug (B2 · auditoria 2026-05-31)
`match()`/`ignorar()` mutavam `fin_bank_statement_lines` **sem audit log** (apesar do comentário "append-only audit"), e **não havia undo** — linha resolvida some do index sem volta.

## Fix
- **Audit:** `match()`/`ignorar()`/`reabrir()` registram via `FinanceiroAuditLogger->info()` (mesma API do `TituloAutoService`, PII-redacted, `business_id` preservado).
- **Reabrir (undo):** `POST /conciliacao/{id}/reabrir` → volta a `pendente`, zera `titulo_id`/`match_score`; **404 cross-tenant** (Tier 0, não-silencioso); muta de fato (sem NO-OP).
- **index():** filtro **opt-in** `?incluir_resolvidos=1` (default = fluxo original byte-a-byte).
- **Frontend:** toggle "ver conciliados/ignorados" + botão **Reabrir** só em linhas resolvidas; Confirmar/Ignorar **intactos** (sem regressão).

## Teste
`ConciliacaoAuditReabrirTest` (Pest): (a) match/ignorar logam (`Log::spy`); (b) reabrir → pendente + nulls; (c) reabrir cross-tenant → 404. ⚠️ Não rodado localmente (sem php/vendor) — CI valida.

## ⚠️ Governança
`Conciliacao/Index.tsx` **não tinha charter** (gap pré-existente do módulo). A mudança é aditiva. Se o **mwart-gate** exigir charter, adiciono em follow-up com sua revisão dos Non-Goals/Anti-hooks (não autoro charter sozinho).

Docs-of-record: `AUDIT-METODO-9.75-TELAS-2026-05-31.md` (PR #2040). Não merge automático.

🤖 Generated with [Claude Code](https://claude.com/claude-code)