### PR TITLE
refactor(financeiro): model BankStatementLine + BusinessScope (B3) [empilha em #2044]

### DIFF
--- a/Modules/Financeiro/Http/Controllers/ConciliacaoController.php
+++ b/Modules/Financeiro/Http/Controllers/ConciliacaoController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Support\Facades\DB;
 use Inertia\Inertia;
 use Inertia\Response;
+use Modules\Financeiro\Models\BankStatementLine;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Models\Titulo;
 use Modules\Financeiro\Services\FinanceiroAuditLogger;
@@ -46,20 +47,26 @@ class ConciliacaoController extends Controller
             : ['pendente', 'sugerido'];
 
         // Linhas ordenadas por data desc.
-        $linhas = DB::table('fin_bank_statement_lines')
-            ->where('business_id', $businessId)
+        // B3 (Tier 0): roteado pela Model BankStatementLine (BusinessScope global
+        // scope + SoftDeletes cuidam de business_id/deleted_at). Mantemos o
+        // where('business_id', …) EXPLÍCITO como defesa em profundidade (padrão
+        // do módulo). `->toBase()->get()` devolve stdClass — payload Inertia
+        // byte-for-byte idêntico ao DB::table anterior (casts da Model NÃO
+        // reformatam datas/decimais no wire). Os scopes globais são aplicados
+        // antes do toBase() (Eloquent\Builder::toBase() chama applyScopes()).
+        $linhas = BankStatementLine::where('business_id', $businessId)
             ->whereIn('status', $statusFiltro)
-            ->whereNull('deleted_at')
             ->orderBy('data_movimento', 'desc')
             ->limit(200)
+            ->toBase()
             ->get();
 
-        // Stats.
+        // Stats. (mesma blindagem: BusinessScope + SoftDeletes + where explícito).
         $stats = [
-            'pendentes'   => DB::table('fin_bank_statement_lines')->where('business_id', $businessId)->where('status', 'pendente')->whereNull('deleted_at')->count(),
-            'sugeridos'   => DB::table('fin_bank_statement_lines')->where('business_id', $businessId)->where('status', 'sugerido')->whereNull('deleted_at')->count(),
-            'conciliados' => DB::table('fin_bank_statement_lines')->where('business_id', $businessId)->where('status', 'conciliado')->whereNull('deleted_at')->count(),
-            'ignorados'   => DB::table('fin_bank_statement_lines')->where('business_id', $businessId)->where('status', 'ignorado')->whereNull('deleted_at')->count(),
+            'pendentes'   => BankStatementLine::where('business_id', $businessId)->where('status', 'pendente')->count(),
+            'sugeridos'   => BankStatementLine::where('business_id', $businessId)->where('status', 'sugerido')->count(),
+            'conciliados' => BankStatementLine::where('business_id', $businessId)->where('status', 'conciliado')->count(),
+            'ignorados'   => BankStatementLine::where('business_id', $businessId)->where('status', 'ignorado')->count(),
         ];
 
         // ContaBancaria.nome é accessor que lê de Account.name (eager load needed)
@@ -160,8 +167,11 @@ class ConciliacaoController extends Controller
         $tituloId = $request->integer('titulo_id');
         $userId = $request->user()?->id;
 
-        $afetadas = DB::table('fin_bank_statement_lines')
-            ->where('id', $lineId)
+        // B3 (Tier 0): UPDATE roteado pela Model (BusinessScope + SoftDeletes +
+        // where('business_id') explícito). Linha soft-deleted não é afetada
+        // (SoftDeletes), mas a tabela é append-only — sem delete real no fluxo —
+        // então o conjunto afetado é idêntico ao DB::table anterior.
+        $afetadas = BankStatementLine::where('id', $lineId)
             ->where('business_id', $businessId)
             ->update([
                 'status' => 'conciliado',
@@ -193,8 +203,9 @@ class ConciliacaoController extends Controller
         $businessId = (int) session('user.business_id');
         $userId = $request->user()?->id;
 
-        $afetadas = DB::table('fin_bank_statement_lines')
-            ->where('id', $lineId)
+        // B3 (Tier 0): UPDATE roteado pela Model (BusinessScope + SoftDeletes +
+        // where('business_id') explícito) — conjunto afetado idêntico.
+        $afetadas = BankStatementLine::where('id', $lineId)
             ->where('business_id', $businessId)
             ->update([
                 'status' => 'ignorado',
@@ -231,10 +242,11 @@ class ConciliacaoController extends Controller
         $userId = $request->user()?->id;
 
         // Carrega estado anterior pra auditoria + valida existência no tenant.
-        $linha = DB::table('fin_bank_statement_lines')
-            ->where('id', $lineId)
+        // B3 (Tier 0): roteado pela Model (BusinessScope + SoftDeletes cuidam de
+        // business_id/deleted_at) + where('business_id') explícito. Lê só
+        // status/titulo_id da instância — casts não alteram esse comportamento.
+        $linha = BankStatementLine::where('id', $lineId)
             ->where('business_id', $businessId)
-            ->whereNull('deleted_at')
             ->first();
 
         if (! $linha) {
@@ -244,8 +256,7 @@ class ConciliacaoController extends Controller
 
         $statusAnterior = $linha->status;
 
-        DB::table('fin_bank_statement_lines')
-            ->where('id', $lineId)
+        BankStatementLine::where('id', $lineId)
             ->where('business_id', $businessId)
             ->update([
                 'status' => 'pendente',
@@ -289,10 +300,12 @@ class ConciliacaoController extends Controller
      */
     private function sugerirMatches(int $businessId): void
     {
-        $pendentes = DB::table('fin_bank_statement_lines')
-            ->where('business_id', $businessId)
+        // B3 (Tier 0): candidatas roteadas pela Model (BusinessScope + SoftDeletes
+        // + where('business_id') explícito). As instâncias expõem valor/data_movimento/id
+        // exatamente como antes para o fuzzy match (CarbonImmutable::parse aceita o
+        // cast date; (float) aceita o cast decimal) — lógica do match inalterada.
+        $pendentes = BankStatementLine::where('business_id', $businessId)
             ->where('status', 'pendente')
-            ->whereNull('deleted_at')
             ->get();
 
         foreach ($pendentes as $linha) {
@@ -308,8 +321,11 @@ class ConciliacaoController extends Controller
                 ->first();
 
             if ($candidato) {
-                DB::table('fin_bank_statement_lines')
-                    ->where('id', $linha->id)
+                // where('business_id', $businessId) explícito amarra o UPDATE ao
+                // tenant recebido pelo método (não só ao global scope da sessão) —
+                // mesma linha já carregada acima, conjunto afetado idêntico.
+                BankStatementLine::where('id', $linha->id)
+                    ->where('business_id', $businessId)
                     ->update([
                         'status' => 'sugerido',
                         'titulo_id' => $candidato->id,

--- a/Modules/Financeiro/Models/BankStatementLine.php
+++ b/Modules/Financeiro/Models/BankStatementLine.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Modules\Financeiro\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Modules\Financeiro\Models\Concerns\BusinessScope;
+
+/**
+ * Linha de extrato bancário importada (OFX/CNAB) — Conciliação OFX, Onda 19 #49.
+ *
+ * Mapeia a tabela EXISTENTE `fin_bank_statement_lines` (migration
+ * 2026_05_19_220000). NÃO cria schema — só dá a esta tabela o mesmo
+ * tratamento Eloquent das demais Models do Financeiro.
+ *
+ * MOTIVO (B3 · Tier 0 hardening, ADR 0093): antes a tabela só era acessada via
+ * `DB::table(...)` cru no ConciliacaoController, sem o NET do global scope
+ * BusinessScope. O isolamento multi-tenant dependia 100% de cada query repetir
+ * `where('business_id', …)` na mão — qualquer query futura que esquecesse
+ * vazaria cross-tenant. Esta Model adiciona o global scope por business_id por
+ * cima (defesa em profundidade), mantendo o `where('business_id', …)` explícito
+ * dos callers como segunda camada (padrão do módulo).
+ *
+ * Lifecycle do status: pendente → sugerido → conciliado | ignorado
+ * (reabrir() volta pra pendente). Tabela append-only de auditoria de import.
+ */
+class BankStatementLine extends Model
+{
+    use HasFactory, SoftDeletes, BusinessScope;
+
+    protected $table = 'fin_bank_statement_lines';
+
+    protected $fillable = [
+        'business_id',
+        'conta_bancaria_id',
+        'fitid',
+        'data_movimento',
+        'descricao',
+        'valor',
+        'tipo',
+        'memo',
+        'status',
+        'titulo_id',
+        'conciliado_by',
+        'conciliado_at',
+        'match_score',
+        'source_file',
+        'uploaded_by',
+    ];
+
+    protected $casts = [
+        'data_movimento' => 'date',
+        'valor' => 'decimal:4',       // decimal(15,4) — mesmo padrão de Titulo.valor_total
+        'match_score' => 'decimal:2', // decimal(5,2) 0.00-1.00 confiança do match
+        'conciliado_at' => 'datetime',
+    ];
+
+    /** Título conciliado a esta linha (FK fin_titulos.id, nullable). */
+    public function titulo(): BelongsTo
+    {
+        return $this->belongsTo(Titulo::class, 'titulo_id');
+    }
+}

--- a/Modules/Financeiro/Tests/Feature/BankStatementLineModelTest.php
+++ b/Modules/Financeiro/Tests/Feature/BankStatementLineModelTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Financeiro\Models\BankStatementLine;
+use Modules\Financeiro\Models\Concerns\BusinessScopeImpl;
+use Spatie\Permission\Models\Permission;
+
+uses(Tests\TestCase::class);
+
+/**
+ * B3 — Model BankStatementLine (hardening Tier 0 da Conciliação OFX).
+ *
+ * A tabela fin_bank_statement_lines passou a ter Model própria (antes só
+ * DB::table cru no ConciliacaoController). Esta Model adiciona o NET do global
+ * scope BusinessScope (isolamento multi-tenant por business_id) + SoftDeletes +
+ * casts. Estes testes provam as duas invariantes que justificam a Model:
+ *
+ *  (a) BusinessScope auto-filtra por business_id — uma linha de biz=99 fica
+ *      INVISÍVEL quando a sessão age como outro business, MESMO numa query SEM
+ *      where('business_id') explícito (o global scope segura sozinho). É a
+ *      defesa que faltava: qualquer query futura que esquecer o where não vaza.
+ *      Tier 0 ADR 0093 IRREVOGÁVEL.
+ *
+ *  (b) $fillable/$casts roundtrip — match_score volta como decimal cast
+ *      (decimal:2, string "0.85") e data_movimento volta como date cast (Carbon).
+ *
+ * Padrão Financeiro (ConciliacaoAuditReabrirTest/CaixaControllerTest): sem
+ * RefreshDatabase (UltimatePOS tem 100+ migrations + triggers), roda contra DB
+ * dev real, skip gracioso quando greenfield ou módulo não instalado.
+ *
+ * biz=99 é o tenant-fantasma canônico dos testes (ADR 0101 — NUNCA biz=4 RotaLivre).
+ *
+ * Rodar local: `vendor/bin/pest Modules/Financeiro/Tests/Feature/BankStatementLineModelTest.php`
+ */
+
+/** Tenant-fantasma que nunca existe em dev — usado pra provar isolamento. */
+const BSL_BIZ_FANTASMA = 99;
+
+/** Bootstrap: exige business + user + tabela instalada, seta sessão. */
+function bankStatementLineBootstrap(): User
+{
+    try {
+        $business = Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: '.$e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco — rode seeder UltimatePOS antes.');
+    }
+
+    $user = User::where('business_id', $business->id)->first();
+    if (! $user) {
+        test()->markTestSkipped('Sem user no business.');
+    }
+
+    if (! Schema::hasTable('fin_bank_statement_lines')) {
+        test()->markTestSkipped('Tabela fin_bank_statement_lines ausente — financeiro:install pendente.');
+    }
+
+    Permission::firstOrCreate(['name' => 'financeiro.conciliacao.manage', 'guard_name' => 'web']);
+    if (! $user->hasPermissionTo('financeiro.conciliacao.manage')) {
+        $user->givePermissionTo('financeiro.conciliacao.manage');
+    }
+
+    session([
+        'user.business_id' => $business->id,
+        'user.id'          => $user->id,
+        'business.id'      => $business->id,
+        'business.name'    => $business->name,
+        'is_admin'         => true,
+    ]);
+
+    return $user;
+}
+
+/**
+ * Insere uma linha RAW (DB::table) pra um business arbitrário — bypassa o
+ * global scope de propósito, pra montar o cenário cross-tenant. Devolve o id.
+ */
+function inserirLinhaRaw(int $businessId, array $overrides = []): int
+{
+    return (int) DB::table('fin_bank_statement_lines')->insertGetId(array_merge([
+        'business_id'    => $businessId,
+        'fitid'          => 'pest-b3-'.uniqid('', true),
+        'data_movimento' => '2026-05-20',
+        'descricao'      => 'Linha de teste B3',
+        'valor'          => -123.45,
+        'tipo'           => 'debit',
+        'status'         => 'pendente',
+        'source_file'    => 'pest-b3.ofx',
+        'created_at'     => now(),
+        'updated_at'     => now(),
+    ], $overrides));
+}
+
+it('(a) BusinessScope auto-filtra: linha de biz=99 é invisível pra outro tenant SEM where explícito', function () {
+    $user = bankStatementLineBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    // Linha plantada no tenant-fantasma biz=99 (NÃO o tenant logado).
+    $lineFantasma = inserirLinhaRaw(BSL_BIZ_FANTASMA, ['fitid' => 'pest-b3-fantasma-'.uniqid('', true)]);
+
+    try {
+        // Query SEM where('business_id') — só o global scope BusinessScope segura.
+        // Sessão = tenant logado (≠ 99). A linha de biz=99 NÃO pode aparecer.
+        // (sem auth check de superadmin aqui: actingAs não foi chamado → can()
+        //  retorna false → scope ativo, exatamente como em produção pro user comum.)
+        $aindaVisivelSemWhere = BankStatementLine::where('id', $lineFantasma)->exists();
+        expect($aindaVisivelSemWhere)->toBeFalse(
+            'VAZAMENTO Tier 0: global scope NÃO filtrou a linha de biz=99 (ADR 0093).'
+        );
+
+        // E o count geral do tenant logado também não conta a linha-fantasma.
+        $fantasmaNoTenantLogado = BankStatementLine::where('id', $lineFantasma)
+            ->where('business_id', $businessId)
+            ->exists();
+        expect($fantasmaNoTenantLogado)->toBeFalse();
+
+        // Sanidade: bypassando o scope (admin/auditor), a linha existe de fato —
+        // prova que o sumiço acima é o scope agindo, não a linha faltando.
+        $existeCruDeFato = BankStatementLine::withoutGlobalScope(BusinessScopeImpl::class)
+            ->where('id', $lineFantasma)
+            ->exists();
+        expect($existeCruDeFato)->toBeTrue('Setup inválido: a linha de biz=99 nem foi inserida.');
+    } finally {
+        // Cleanup raw (hard delete) — bypassa scope/SoftDeletes.
+        DB::table('fin_bank_statement_lines')->where('id', $lineFantasma)->delete();
+    }
+});
+
+it('(a2) BusinessScope deixa o tenant logado VER a própria linha (não filtra demais)', function () {
+    $user = bankStatementLineBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    $linePropria = inserirLinhaRaw($businessId, ['fitid' => 'pest-b3-propria-'.uniqid('', true)]);
+
+    try {
+        // Sessão = dono da linha → scope deixa enxergar SEM where explícito.
+        $visivel = BankStatementLine::where('id', $linePropria)->exists();
+        expect($visivel)->toBeTrue('Scope filtrou demais: tenant não enxerga a própria linha.');
+    } finally {
+        DB::table('fin_bank_statement_lines')->where('id', $linePropria)->delete();
+    }
+});
+
+it('(b) $fillable/$casts roundtrip: match_score (decimal) e data_movimento (date) voltam tipados', function () {
+    $user = bankStatementLineBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    // Insere com match_score + data_movimento conhecidos.
+    $lineId = inserirLinhaRaw($businessId, [
+        'fitid'          => 'pest-b3-casts-'.uniqid('', true),
+        'status'         => 'sugerido',
+        'match_score'    => 0.85,
+        'data_movimento' => '2026-05-20',
+        'valor'          => -123.45,
+    ]);
+
+    try {
+        $linha = BankStatementLine::where('business_id', $businessId)
+            ->where('id', $lineId)
+            ->first();
+
+        expect($linha)->not->toBeNull();
+
+        // data_movimento: cast 'date' → instância Carbon, dia exato preservado.
+        expect($linha->data_movimento)->toBeInstanceOf(Carbon::class);
+        expect($linha->data_movimento->toDateString())->toBe('2026-05-20');
+
+        // match_score: cast 'decimal:2' → string normalizada "0.85" (2 casas).
+        expect($linha->match_score)->toBe('0.85');
+
+        // valor: cast 'decimal:4' → string com 4 casas "-123.4500".
+        expect($linha->valor)->toBe('-123.4500');
+
+        // conciliado_at nulo → permanece nulo (não vira Carbon de "agora").
+        expect($linha->conciliado_at)->toBeNull();
+
+        // Campos $fillable básicos chegaram intactos.
+        expect($linha->status)->toBe('sugerido');
+        expect($linha->tipo)->toBe('debit');
+        expect($linha->descricao)->toBe('Linha de teste B3');
+    } finally {
+        DB::table('fin_bank_statement_lines')->where('id', $lineId)->delete();
+    }
+});
+
+it('Model usa BusinessScope + SoftDeletes (mesmo contrato das demais Models do Financeiro)', function () {
+    $traits = class_uses_recursive(BankStatementLine::class);
+
+    expect($traits)->toContain(\Modules\Financeiro\Models\Concerns\BusinessScope::class);
+    expect($traits)->toContain(\Illuminate\Database\Eloquent\SoftDeletes::class);
+
+    // Aponta pra tabela certa.
+    expect((new BankStatementLine())->getTable())->toBe('fin_bank_statement_lines');
+});


### PR DESCRIPTION
## Tier 0 hardening (B3 · auditoria 2026-05-31)
`fin_bank_statement_lines` só era acessada via `DB::table` cru — **sem o NET do global scope** `BusinessScope`. Isolamento dependia 100% de cada query lembrar o `where business_id`; esquecer = vazamento cross-tenant.

## Fix (refactor puro, sem mudar comportamento)
- **Novo model** `BankStatementLine` (`BusinessScope` + `SoftDeletes` + casts), espelhando `Titulo`.
- Roteado SELECT/UPDATE (index, stats, match, ignorar, reabrir, sugerirMatches) pela model.
- **Comportamento idêntico:** `index()` usa `->toBase()->get()` → `stdClass`, payload Inertia byte-a-byte (casts NÃO reformatam data/decimal no wire — senão quebraria `l.data_movimento.slice(0,10)` no frontend). `where business_id` explícito **mantido** (defesa em profundidade). Bulk INSERT do `upload()` fica `DB::table` (não é risco Tier 0).
- `sugerirMatches` per-row UPDATE **ganhou** `where business_id` (mesmo conjunto, mais seguro).

## ⚠️ Risco / como validar
Refactor **sensível a comportamento, NÃO rodei testes aqui** (sem php/vendor no ambiente GUI). Antes de mergear, rode contra o DB dev:
```
vendor/bin/pest Modules/Financeiro/Tests/Feature/BankStatementLineModelTest.php
vendor/bin/pest Modules/Financeiro/Tests/Feature/ConciliacaoAuditReabrirTest.php
```
(o 2º é o teste funcional do controller — exercita match/ignorar/reabrir end-to-end; ambos devem ficar verdes).

**Empilhado em [#2044](https://github.com/wagnerra23/oimpresso.com/pull/2044)** (B2) — mergear #2044 primeiro, depois este. Docs: `AUDIT-METODO-9.75-TELAS-2026-05-31.md` (#2040).

🤖 Generated with [Claude Code](https://claude.com/claude-code)