### PR TITLE
fix(financeiro): botões honestos em DRE + Cobrança (B6)

### DIFF
--- a/resources/js/Pages/Financeiro/Cobranca/Index.tsx
+++ b/resources/js/Pages/Financeiro/Cobranca/Index.tsx
@@ -17,7 +17,7 @@ import {
   useCallback, useEffect, useMemo, useRef, useState, type ReactNode,
 } from 'react';
 import {
-  Search, Plus, Download, Upload, Copy, MoreHorizontal, Settings, Webhook,
+  Search, Plus, Upload, Copy, Settings, Webhook,
   Check, AlertCircle, Receipt, Zap, Building,
 } from 'lucide-react';
 import { Btn, StatusBadge, GatewayTipoChip, OrigemChip, KpiCard} from './_components/atoms';
@@ -34,7 +34,7 @@ import SheetRemessaRetorno from './_components/SheetRemessaRetorno';
 import CheatSheet from './_components/CheatSheet';
 import AiResumoMes from './_components/AiResumoMes';
 import {
-  brl, brlNoSign, cn, fmtDate, fmtDateRel, piiMask, lsGet, lsSet,
+  brl, brlNoSign, cn, fmtDate, fmtDateRel, piiMask, lsGet, lsSet, copiar,
   DRIVERS, TIPOS, ORIGENS,
   type Cobranca, type Account, type Gateway, type CobrancaKpis, type CobrancaFunil,
   type CobrancaFiltros, type OrigemType,
@@ -273,7 +273,9 @@ function CobrancaPage({ cobrancas, kpis, funil, accounts = [], gateways = [], fi
             aria-label="Buscar cobranças" />
           <kbd className="absolute right-2 top-1/2 -translate-y-1/2 text-[9.5px] font-mono text-stone-400 px-1 border border-stone-200 rounded">/</kbd>
         </div>
-        <Btn variant="ghost"><Download className="h-3 w-3" />Exportar</Btn>
+        {/* B6 "botões honestos" (2026-05-31): "Exportar" REMOVIDO — não existe
+            rota de export de cobranças no CobrancaController/web.php. Reentra
+            quando houver endpoint real (ex GET /financeiro/cobranca/export-csv). */}
       </div>
 
       {/* FILTROS linha 2 */}
@@ -399,9 +401,21 @@ function CobrancaPage({ cobrancas, kpis, funil, accounts = [], gateways = [], fi
                       </td>
                       <td className="pl-2 pr-5 py-2.5 text-right" onClick={e => e.stopPropagation()}>
                         <div className="pg-row-actions inline-flex items-center gap-0.5">
-                          <button title="Copiar identificador" className="pg-action-btn" aria-label="Copiar"><Copy className="h-3 w-3" /></button>
-                          {c.tipo === 'boleto' && <button title="Baixar PDF" className="pg-action-btn" aria-label="Baixar PDF"><Download className="h-3 w-3" /></button>}
-                          <button title="Mais ações" className="pg-action-btn" aria-label="Mais"><MoreHorizontal className="h-3 w-3" /></button>
+                          {/* B6 "botões honestos" (2026-05-31): só "Copiar identificador"
+                              fica (ação real via clipboard). "Baixar PDF" e "Mais ações"
+                              REMOVIDOS — não há rota de PDF nem menu de ações backed. */}
+                          <button
+                            type="button"
+                            title="Copiar identificador"
+                            className="pg-action-btn"
+                            aria-label="Copiar identificador"
+                            onClick={() => copiar(
+                              c.nosso_numero || c.linha_digitavel || c.pix_emv,
+                              'Identificador copiado',
+                            )}
+                          >
+                            <Copy className="h-3 w-3" />
+                          </button>
                         </div>
                       </td>
                     </tr>

--- a/resources/js/Pages/Financeiro/Cobranca/_components/AiResumoMes.tsx
+++ b/resources/js/Pages/Financeiro/Cobranca/_components/AiResumoMes.tsx
@@ -2,7 +2,7 @@
 import { useEffect } from 'react';
 import { X } from 'lucide-react';
 import { Btn } from './atoms';
-import { brl, cn, DRIVERS, type Cobranca, type CobrancaKpis, type GatewayKey } from '../_lib/cobranca-shared';
+import { brl, cn, copiar, DRIVERS, type Cobranca, type CobrancaKpis, type GatewayKey } from '../_lib/cobranca-shared';
 
 interface Props {
   kpis: CobrancaKpis;
@@ -28,6 +28,25 @@ export default function AiResumoMes({ kpis, cobs, onClose }: Props) {
   const sortedGws = Object.entries(porGateway).sort((a, b) => b[1] - a[1]);
   const topGw = sortedGws[0];
   const mandatosCount = cobs.filter(c => c.tipo === 'pix_recv').length;
+
+  // B6 "botões honestos" (2026-05-31): monta texto plain pra "Copiar resumo"
+  // (formato WhatsApp/email) a partir dos mesmos dados que o painel renderiza.
+  const resumoTexto = (): string => {
+    const linhas: string[] = [`*Resumo Cobrança · ${monthLabel()}*`, ''];
+    linhas.push(`• ${kpis.pago_mes.qtd} cobranças liquidadas — ${brl(kpis.pago_mes.valor)}`);
+    if (kpis.aberto.qtd > 0) linhas.push(`• Em aberto: ${brl(kpis.aberto.valor)} (${kpis.aberto.qtd} títulos)`);
+    if (kpis.vencido.qtd > 0) linhas.push(`• ⚠ Vencidas: ${kpis.vencido.qtd} — ${brl(kpis.vencido.valor)} · inadimplência ${inadimplencia}%`);
+    if (sortedGws.length > 0) {
+      linhas.push('', 'Por gateway:');
+      sortedGws.forEach(([gw, vl]) => {
+        const d = DRIVERS[gw as GatewayKey];
+        if (d) linhas.push(`  - ${d.nome}: ${brl(vl)}`);
+      });
+    }
+    if (mandatosCount > 0) linhas.push('', `• PIX Automático ativo em ${mandatosCount} mandato(s)`);
+    if (kpis.mrr_pago > 0) linhas.push(`• MRR SaaS cobrado: ${brl(kpis.mrr_pago)}`);
+    return linhas.join('\n');
+  };
 
   return (
     <div className="fixed inset-0 z-40 flex justify-end" onClick={onClose} role="dialog" aria-modal="true" aria-label="Resumo IA do mês">
@@ -101,7 +120,7 @@ export default function AiResumoMes({ kpis, cobs, onClose }: Props) {
         <div className="border-t border-stone-200 p-3 bg-stone-50/60 flex items-center gap-2">
           <span className="text-[10.5px] text-stone-500">IA · gerado agora</span>
           <div className="flex-1" />
-          <Btn variant="outline" size="sm">Copiar resumo</Btn>
+          <Btn variant="outline" size="sm" onClick={() => copiar(resumoTexto(), 'Resumo copiado')}>Copiar resumo</Btn>
         </div>
       </div>
     </div>

--- a/resources/js/Pages/Financeiro/Cobranca/_components/DrawerCobranca.tsx
+++ b/resources/js/Pages/Financeiro/Cobranca/_components/DrawerCobranca.tsx
@@ -1,11 +1,11 @@
 // DrawerCobranca.tsx — drawer detalhe condicional por tipo (boleto/pix/pix_recv/card) + Timeline
 import { useEffect, useRef } from 'react';
 import {
-  X, Copy, Download, Link2, RotateCcw, RefreshCw, ShieldCheck, AlertCircle,
+  X, Copy, ShieldCheck, AlertCircle,
 } from 'lucide-react';
 import { Btn, StatusBadge, GatewayTipoChip, OrigemChip } from './atoms';
 import {
-  brl, cn, fmtDate, fmtDateRel, piiMask, DRIVERS, ORIGENS,
+  brl, cn, copiar, fmtDate, fmtDateRel, piiMask, DRIVERS, ORIGENS,
   type Cobranca, type Account,
 } from '../_lib/cobranca-shared';
 
@@ -20,8 +20,6 @@ export default function DrawerCobranca({ cob, accounts, today, onClose }: Props)
   const drawerRef = useRef<HTMLDivElement>(null);
   const drv = DRIVERS[cob.gateway];
   const acct = accounts.find(a => a.id === cob.account_id);
-  const refundDisponivel = cob.status === 'paga' && drv && ['asaas', 'inter', 'pesapal'].includes(drv.key);
-  const refundLabel = drv?.key === 'bcb_pix' ? 'Não disponível pra PIX Automático' : null;
 
   // WCAG 2.1: ESC + scroll lock + focus trap
   useEffect(() => {
@@ -105,7 +103,9 @@ export default function DrawerCobranca({ cob, accounts, today, onClose }: Props)
               <div className="bg-rose-50 border border-rose-200 rounded px-3 py-2 text-[11.5px] text-rose-900 font-mono">
                 {cob.erro_msg}
               </div>
-              <Btn variant="outline" size="xs" className="mt-2"><RefreshCw className="h-3 w-3" />Tentar reemitir</Btn>
+              {/* B6 "botões honestos" (2026-05-31): "Tentar reemitir" REMOVIDO —
+                  não há rota de reemissão (POST /cobranca/emitir é pra nova
+                  cobrança, não retry de uma falha existente). */}
             </div>
           )}
 
@@ -115,15 +115,19 @@ export default function DrawerCobranca({ cob, accounts, today, onClose }: Props)
           </div>
         </div>
 
-        <div className="border-t border-stone-200 p-3 flex items-center gap-2 bg-white">
-          {cob.tipo === 'boleto' && <Btn variant="outline"><Download className="h-3 w-3" />Baixar PDF</Btn>}
-          {cob.tipo === 'boleto' && <Btn variant="outline"><Link2 className="h-3 w-3" />Link 2ª via</Btn>}
-          {cob.tipo?.startsWith('pix') && cob.tipo !== 'pix_recv' && <Btn variant="outline"><Copy className="h-3 w-3" />Copiar BR Code</Btn>}
-          <div className="flex-1" />
-          {refundDisponivel && <Btn variant="outline" className="text-amber-700 hover:bg-amber-50"><RotateCcw className="h-3 w-3" />Estornar</Btn>}
-          {refundLabel && cob.status === 'paga' && <span className="text-[10.5px] text-stone-400" title={refundLabel}>refund indisp.</span>}
-          {!['paga', 'cancelada', 'erro'].includes(cob.status) && <Btn variant="danger"><X className="h-3 w-3" />Cancelar</Btn>}
-        </div>
+        {/* B6 "botões honestos" (2026-05-31): footer só mostra ação real AGORA.
+            "Copiar BR Code" (PIX) → clipboard via copiar(). REMOVIDOS por falta
+            de rota backend: "Baixar PDF" + "Link 2ª via" (sem endpoint boleto-pdf
+            no CobrancaController), "Estornar" (sem rota refund) e "Cancelar"
+            (POST /boletos/{id}/cancelar é pro model legacy BoletoRemessa, não pra
+            PaymentGateway\Cobranca desta tela). Reentram quando o endpoint existir. */}
+        {cob.tipo?.startsWith('pix') && cob.tipo !== 'pix_recv' && cob.pix_emv && (
+          <div className="border-t border-stone-200 p-3 flex items-center gap-2 bg-white">
+            <Btn variant="outline" onClick={() => copiar(cob.pix_emv, 'BR Code copiado')}>
+              <Copy className="h-3 w-3" />Copiar BR Code
+            </Btn>
+          </div>
+        )}
       </div>
     </div>
   );
@@ -153,7 +157,7 @@ function SectionBoleto({ cob }: { cob: Cobranca }) {
           <div className="text-[10px] uppercase tracking-widest text-stone-500 mb-1 font-medium">Linha digitável</div>
           <div className="flex items-center gap-2 bg-stone-50 border border-stone-200 rounded px-2.5 py-2">
             <div className="font-mono text-[11.5px] flex-1 break-all">{cob.linha_digitavel}</div>
-            <Btn variant="outline" size="xs"><Copy className="h-3 w-3" /></Btn>
+            <Btn variant="outline" size="xs" aria-label="Copiar linha digitável" onClick={() => copiar(cob.linha_digitavel, 'Linha digitável copiada')}><Copy className="h-3 w-3" /></Btn>
           </div>
         </div>
       )}
@@ -186,7 +190,9 @@ function SectionPix({ cob }: { cob: Cobranca }) {
           ) : (
             <div className="text-[11px] text-stone-400 italic">BR Code não disponível</div>
           )}
-          <Btn variant="outline" size="xs" className="mt-2"><Copy className="h-3 w-3" />Copiar BR Code</Btn>
+          {cob.pix_emv && (
+            <Btn variant="outline" size="xs" className="mt-2" onClick={() => copiar(cob.pix_emv, 'BR Code copiado')}><Copy className="h-3 w-3" />Copiar BR Code</Btn>
+          )}
         </div>
       </div>
     </div>

--- a/resources/js/Pages/Financeiro/Cobranca/_lib/cobranca-shared.ts
+++ b/resources/js/Pages/Financeiro/Cobranca/_lib/cobranca-shared.ts
@@ -1,6 +1,8 @@
 // cobranca-shared.ts — types + helpers + tokens (port de pg-shared.jsx Cowork F1)
 // Tokens canon DRIVERS/TIPOS/STATUS/ORIGENS + helpers brl/fmtDate/piiMask.
 
+import { toast } from 'sonner';
+
 export type CobrancaTipo = 'boleto' | 'pix_cob' | 'pix_cobv' | 'pix_recv' | 'card';
 export type CobrancaStatus = 'emitida' | 'paga' | 'vencida' | 'cancelada' | 'erro' | 'pending';
 export type OrigemType = 'sale' | 'invoice' | 'subscription_license';
@@ -470,5 +472,39 @@ export function lsSet(key: string, value: unknown): void {
     localStorage.setItem(LS_PREFIX + key, JSON.stringify(value));
   } catch {
     /* noop */
+  }
+}
+
+/**
+ * Copia texto pro clipboard + toast PT-BR de feedback (B6 "botões honestos").
+ *
+ * Usa navigator.clipboard (contexto seguro HTTPS) com fallback execCommand pra
+ * ambientes legados/sem permissão. Toast via sonner (mesmo mecanismo das outras
+ * telas Financeiro). No-op silencioso só se `texto` for vazio/null (mostra erro).
+ */
+export async function copiar(
+  texto: string | null | undefined,
+  label = 'Copiado para a área de transferência',
+): Promise<void> {
+  if (!texto) {
+    toast.error('Nada para copiar');
+    return;
+  }
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(texto);
+    } else {
+      const ta = document.createElement('textarea');
+      ta.value = texto;
+      ta.style.position = 'fixed';
+      ta.style.opacity = '0';
+      document.body.appendChild(ta);
+      ta.select();
+      document.execCommand('copy');
+      document.body.removeChild(ta);
+    }
+    toast.success(label);
+  } catch {
+    toast.error('Não foi possível copiar');
   }
 }

--- a/resources/js/Pages/Financeiro/Dre/Index.tsx
+++ b/resources/js/Pages/Financeiro/Dre/Index.tsx
@@ -17,14 +17,7 @@
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { router } from '@inertiajs/react';
 import { useState, type ReactNode } from 'react';
-import {
-  Search,
-  Sparkles,
-  CheckSquare,
-  Play,
-  Download,
-  Plus,
-} from 'lucide-react';
+import { Download } from 'lucide-react';
 import { BalancoView, type BalancoData } from './_components/BalancoView';
 import { BalanceteView, type BalanceteData } from './_components/BalanceteView';
 import FinanceiroSubNav from '@/Pages/Financeiro/_shared/FinanceiroSubNav';
@@ -203,11 +196,22 @@ function FinanceiroDre({
             active="dre"
             hidePrimary
             extraOverflowItems={[
-              { key: 'buscar',     label: 'Buscar (⌘K)', icon: <Search size={13} />,     onClick: () => { /* stub F1 — Cmd palette compartilhada vira F2 */ } },
-              { key: 'resumir',    label: 'Resumir mês', icon: <Sparkles size={13} />,   onClick: () => { /* stub F1 — narrativa DRE vira F2 */ },                title: 'Resumo executivo do mês (narrativa DRE compute-based)' },
-              { key: 'fechamento', label: 'Fechamento',  icon: <CheckSquare size={13} />, onClick: () => { /* stub F1 — checklist fechamento vira F2 */ },        title: 'Trilha de 12 passos do fechamento mensal' },
-              { key: 'apresentar', label: 'Apresentar',  icon: <Play size={13} />,        onClick: () => { /* stub F1 — modo apresentação vira F2 */ },           title: 'Modo apresentação fullscreen (Esc fecha)' },
-              { key: 'exportar',   label: 'Exportar',    icon: <Download size={13} />,    onClick: () => { /* stub F1 */ },                                       title: 'Exportar DRE (XLSX / PDF)' },
+              // B6 "botões honestos" (2026-05-31): só permanece a ação que tem
+              // capacidade real AGORA. Os stubs F1 (Buscar ⌘K / Resumir mês /
+              // Fechamento / Apresentar) foram REMOVIDOS do render — não há
+              // backend/handler ainda (roadmap vive no charter, não em botão
+              // morto). Reentram quando a capacidade existir.
+              {
+                key: 'exportar-csv',
+                label: 'Exportar CSV',
+                icon: <Download size={13} />,
+                onClick: () => {
+                  // Rota real GET /financeiro/dre/export-csv (DreController::exportCsv,
+                  // StreamedResponse BOM UTF-8). PDF + Excel já têm âncoras inline no card.
+                  window.location.href = '/financeiro/dre/export-csv';
+                },
+                title: 'Baixar DRE em CSV (Excel BR)',
+              },
             ]}
           />
           <FinanceiroPrimaryButton onClick={() => router.visit('/financeiro/unificado/novo')}>


### PR DESCRIPTION
## Bug (B6 · auditoria 2026-05-31)
DRE e Cobrança tinham vários botões **stub/NO-OP** (visual polido, ação nenhuma) — mata a confiança da Larissa/Eliana. Critério: **liga o que tem backend agora, esconde o resto** (nunca NO-OP silencioso).

## Ligados (capacidade real existe)
- **DRE** `Exportar CSV` → rota real `GET /financeiro/dre/export-csv`
- **Cobrança** `Copiar identificador` (linha) + drawer `Copiar BR Code` (PIX) + `Copiar linha digitável` (boleto) + `Copiar resumo` (AiResumoMes) → clipboard via novo helper `copiar()` (navigator.clipboard + fallback + toast sonner)

## Escondidos (sem backend; roadmap vive no charter, não em botão morto)
- **DRE**: Buscar/Resumir/Fechamento/Apresentar (stubs F1, charter-F2; `FinMonthResume`/`FinPresentationMode` não consomem o shape do DRE)
- **Cobrança**: Exportar, Baixar PDF, Mais ações, Tentar reemitir, Link 2ª via, Estornar (sem rota), **Cancelar** (a rota `/boletos/cancelar` é do model **legacy** `BoletoRemessa`, não do `PaymentGateway\Cobranca` desta tela — wirar mis-targetaria)

## Garantias
- **Frontend-only** — zero backend/rota/controller/**charter** tocado.
- **eslint baseline sem regressão** (Δ −60, removeu código morto/imports). **typecheck: 0 erros novos**.
- Fluxos que funcionam (Nova cobrança, Remessa/Retorno, Gateways, drawer, filtros, busca, abrir Resumir-mês) **intactos**. DRE PDF/Excel inline e toggle período "Em breve" (disabled honesto) preservados.

Fecha o **P0** da auditoria. Docs: `AUDIT-METODO-9.75-TELAS-2026-05-31.md` (#2040). Não merge automático.

🤖 Generated with [Claude Code](https://claude.com/claude-code)