### PR TITLE
feat(financeiro): RAG PR1 — InsightsService (tools read-only) [ADR arq/0006]

### DIFF
--- a/Modules/Financeiro/Services/InsightsService.php
+++ b/Modules/Financeiro/Services/InsightsService.php
@@ -1,0 +1,434 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Financeiro\Services;
+
+use App\Util\OtelHelper;
+use Carbon\CarbonImmutable;
+use Modules\Financeiro\Models\Titulo;
+use Modules\Financeiro\Models\TituloBaixa;
+
+/**
+ * InsightsService — camada de CONSULTA read-only do histórico financeiro.
+ *
+ * Camada de dados do recurso "perguntar ao histórico financeiro" (ADR ARQ-0006).
+ * Decisão: NÃO é RAG free-text — dado financeiro é estruturado, exato e Tier 0
+ * crítico. Em vez disso, expomos TOOLS determinísticas read-only que um LLM
+ * (Jana, em PR futuro) vai chamar via tool-calling pra traduzir pergunta em
+ * linguagem natural → consulta escopada por business_id → resposta CITANDO os
+ * registros-fonte (títulos/baixas). Esta PR entrega SÓ as tools (o data layer);
+ * o wrapper Jana + UI vêm na PR2.
+ *
+ * Princípio P4 (ADR ARQ-0006): copiloto PROPÕE — esta camada só LÊ. Zero
+ * mutação (sem create/update/delete). Toda agregação devolve, além da resposta,
+ * um array `fontes` com os IDs de origem (título/baixa) pra a resposta futura
+ * conseguir CITAR a fonte (fundação anti-alucinação — número sempre rastreável
+ * a registros reais).
+ *
+ * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): `business_id` SEMPRE no 1º
+ * argumento, fornecido pelo SERVIDOR — NUNCA por LLM/usuário. Todas as queries
+ * forçam `->where('business_id', $businessId)` explícito (defesa em
+ * profundidade), mesmo com o BusinessScope global já filtrando. Tests biz=1
+ * (ADR 0101) — nunca biz=4 (ROTA LIVRE prod).
+ *
+ * Observability D9.a: cada método wrap em `OtelHelper::spanBiz('financeiro.
+ * insights.<x>', ...)` (espelha UnificadoService/FluxoCaixaService/DreService).
+ *
+ * @see Modules\Financeiro\Models\Titulo                  (agingBucket / isVencido)
+ * @see Modules\Financeiro\Models\TituloBaixa             (data_baixa / estorno_de_id)
+ * @see Modules\Financeiro\Services\UnificadoService      (estilo de query KPI)
+ * @see Modules\Financeiro\Repositories\BaixaRepository   (totaisPorTipoPeriodo)
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+class InsightsService
+{
+    /**
+     * Buckets de aging — MESMOS thresholds (em dias) de Titulo::agingBucket().
+     * Mantidos como fonte única pra a resposta casar com o que a UI mostra.
+     */
+    private const AGING_BUCKETS = ['em_dia', '<30', '30-60', '60-90', '90-180', '>180'];
+
+    /**
+     * "Quanto recebi entre X e Y?" — soma das baixas REAIS (não estornadas) de
+     * títulos a-receber cuja data_baixa cai no intervalo [de, ate].
+     *
+     * Read-only. Devolve a resposta (valor + qtd) + `fontes` (IDs das baixas)
+     * pra citação. Datas no formato 'Y-m-d' (inclusive nas duas pontas).
+     *
+     * @param  int     $businessId  Tier 0 (ADR 0093) — sempre via argumento, servidor.
+     * @param  string  $de          Data inicial 'Y-m-d' (inclusive).
+     * @param  string  $ate         Data final 'Y-m-d' (inclusive).
+     *
+     * @return array{
+     *   valor: float,
+     *   qtd: int,
+     *   periodo: array{de: string, ate: string},
+     *   fontes: array<int, int>
+     * }
+     */
+    public function recebidoPorPeriodo(int $businessId, string $de, string $ate): array
+    {
+        return OtelHelper::spanBiz('financeiro.insights.recebido_por_periodo', function () use ($businessId, $de, $ate): array {
+            return $this->recebidoPorPeriodoInternal($businessId, $de, $ate);
+        }, [
+            'module'      => 'Financeiro',
+            'op'          => 'insights.recebido_por_periodo',
+            'business_id' => $businessId,
+        ]);
+    }
+
+    /**
+     * @return array{valor: float, qtd: int, periodo: array{de: string, ate: string}, fontes: array<int, int>}
+     */
+    private function recebidoPorPeriodoInternal(int $businessId, string $de, string $ate): array
+    {
+        // Baixas de títulos a-receber, no período, ignorando estornos.
+        // whereHas('titulo', tipo='receber') espelha BaixaRepository::totaisPorTipoPeriodo.
+        $baixas = TituloBaixa::query()
+            ->where('business_id', $businessId)                         // Tier 0 defesa em profundidade
+            ->whereBetween('data_baixa', [$de, $ate])
+            ->whereNull('estorno_de_id')                                // baixa estornada não conta
+            ->whereHas('titulo', function ($sub) use ($businessId): void {
+                $sub->where('business_id', $businessId)                 // Tier 0 também na relação
+                    ->where('tipo', 'receber');
+            })
+            ->orderBy('data_baixa')
+            ->get(['id', 'valor_baixa', 'data_baixa']);
+
+        $valor = (float) $baixas->sum(fn (TituloBaixa $b): float => (float) $b->valor_baixa);
+        $fontes = $baixas->pluck('id')->map(fn ($id): int => (int) $id)->values()->all();
+
+        return [
+            'valor'   => round($valor, 2),
+            'qtd'     => $baixas->count(),
+            'periodo' => ['de' => $de, 'ate' => $ate],
+            'fontes'  => $fontes,
+        ];
+    }
+
+    /**
+     * "Como está o aging dos recebíveis em aberto?" — distribui os títulos
+     * abertos/parciais nos buckets de Titulo::agingBucket() (em_dia / <30 /
+     * 30-60 / 60-90 / 90-180 / >180), com qtd + valor (valor_aberto) por bucket.
+     *
+     * Bucketing feito em PHP iterando os títulos pra reusar EXATAMENTE a regra
+     * de Titulo::agingBucket()/isVencido() — garante que a resposta case com o
+     * bucket que a UI atribui a cada título (sem divergência SQL vs model).
+     *
+     * Read-only. Devolve `fontes` (IDs dos títulos considerados) pra citação.
+     *
+     * @param  int          $businessId  Tier 0 (ADR 0093) — sempre via argumento.
+     * @param  string       $tipo        'receber' (default) | 'pagar'.
+     * @param  string|null  $hojeIso     'Y-m-d' p/ referência (testes determinísticos).
+     *
+     * @return array{
+     *   buckets: array<string, array{qtd: int, valor: float}>,
+     *   total: array{qtd: int, valor: float},
+     *   fontes: array<int, int>
+     * }
+     */
+    public function agingResumo(int $businessId, string $tipo = 'receber', ?string $hojeIso = null): array
+    {
+        return OtelHelper::spanBiz('financeiro.insights.aging_resumo', function () use ($businessId, $tipo, $hojeIso): array {
+            return $this->agingResumoInternal($businessId, $tipo, $hojeIso);
+        }, [
+            'module'      => 'Financeiro',
+            'op'          => 'insights.aging_resumo',
+            'business_id' => $businessId,
+            'tipo'        => $tipo,
+        ]);
+    }
+
+    /**
+     * @return array{buckets: array<string, array{qtd: int, valor: float}>, total: array{qtd: int, valor: float}, fontes: array<int, int>}
+     */
+    private function agingResumoInternal(int $businessId, string $tipo, ?string $hojeIso): array
+    {
+        $hoje = $hojeIso !== null
+            ? CarbonImmutable::parse($hojeIso)->startOfDay()
+            : CarbonImmutable::today();
+
+        // Inicializa todos os buckets zerados (resposta estável p/ o LLM citar).
+        $buckets = [];
+        foreach (self::AGING_BUCKETS as $b) {
+            $buckets[$b] = ['qtd' => 0, 'valor' => 0.0];
+        }
+
+        $titulos = Titulo::query()
+            ->where('business_id', $businessId)                 // Tier 0 defesa em profundidade
+            ->where('tipo', $tipo)
+            ->whereIn('status', ['aberto', 'parcial'])          // só em aberto / parcial
+            ->whereNull('deleted_at')
+            ->orderBy('vencimento')
+            ->get(['id', 'vencimento', 'valor_aberto']);
+
+        $fontes = [];
+        $totalQtd = 0;
+        $totalValor = 0.0;
+
+        foreach ($titulos as $titulo) {
+            $bucket = $this->bucketDeAging($titulo->vencimento, $hoje);
+            $valor = (float) $titulo->valor_aberto;
+
+            $buckets[$bucket]['qtd']++;
+            $buckets[$bucket]['valor'] = round($buckets[$bucket]['valor'] + $valor, 2);
+
+            $totalQtd++;
+            $totalValor += $valor;
+            $fontes[] = (int) $titulo->id;
+        }
+
+        return [
+            'buckets' => $buckets,
+            'total'   => ['qtd' => $totalQtd, 'valor' => round($totalValor, 2)],
+            'fontes'  => $fontes,
+        ];
+    }
+
+    /**
+     * Replica a regra de Titulo::agingBucket() (sem depender de now() global,
+     * pra ser determinístico em teste). vencimento futuro/hoje = 'em_dia';
+     * senão, classifica pelos MESMOS thresholds em dias de atraso.
+     *
+     * Nota Carbon 3: diffInDays() é SINALIZADO por default (negativo p/ data
+     * passada). Passamos o flag absoluto (2º arg true) — convenção do codebase
+     * (ex: NfeHealthCommand, ReopenJobSheetRequest) — pra obter a contagem
+     * POSITIVA de dias de atraso que os thresholds esperam.
+     */
+    private function bucketDeAging(?\DateTimeInterface $vencimento, CarbonImmutable $hoje): string
+    {
+        if ($vencimento === null) {
+            return 'em_dia';
+        }
+
+        $venc = CarbonImmutable::parse($vencimento->format('Y-m-d'))->startOfDay();
+
+        if ($venc->greaterThanOrEqualTo($hoje)) {
+            return 'em_dia';
+        }
+
+        // Dias de atraso (positivo) — thresholds idênticos a Titulo::agingBucket().
+        $dias = (int) $hoje->diffInDays($venc, true);
+
+        return match (true) {
+            $dias < 30  => '<30',
+            $dias < 60  => '30-60',
+            $dias < 90  => '60-90',
+            $dias < 180 => '90-180',
+            default     => '>180',
+        };
+    }
+
+    /**
+     * "Esse cliente costuma atrasar?" — perfil de pontualidade de UMA
+     * contraparte: quantos títulos tem, quantos atrasaram, % de atraso e atraso
+     * médio (em dias). "Atrasado" = título quitado com data_baixa > vencimento
+     * OU título ainda em aberto/parcial já vencido (Titulo::isVencido()).
+     *
+     * Match por `cliente_descricao LIKE %contraparte%` (mesma estratégia de
+     * busca textual do TituloRepository::aplicarFiltros).
+     *
+     * Read-only. Devolve `fontes` (IDs dos títulos da contraparte) pra citação.
+     *
+     * @param  int          $businessId   Tier 0 (ADR 0093) — sempre via argumento.
+     * @param  string       $contraparte  Trecho do nome (cliente_descricao LIKE).
+     * @param  string|null  $hojeIso      'Y-m-d' p/ referência (testes determinísticos).
+     *
+     * @return array{
+     *   contraparte: string,
+     *   qtd_titulos: int,
+     *   qtd_atrasados: int,
+     *   pct_atraso: float,
+     *   dias_medio_atraso: float,
+     *   fontes: array<int, int>
+     * }
+     */
+    public function historicoAtrasoContraparte(int $businessId, string $contraparte, ?string $hojeIso = null): array
+    {
+        return OtelHelper::spanBiz('financeiro.insights.historico_atraso_contraparte', function () use ($businessId, $contraparte, $hojeIso): array {
+            return $this->historicoAtrasoContraparteInternal($businessId, $contraparte, $hojeIso);
+        }, [
+            'module'      => 'Financeiro',
+            'op'          => 'insights.historico_atraso_contraparte',
+            'business_id' => $businessId,
+        ]);
+    }
+
+    /**
+     * @return array{contraparte: string, qtd_titulos: int, qtd_atrasados: int, pct_atraso: float, dias_medio_atraso: float, fontes: array<int, int>}
+     */
+    private function historicoAtrasoContraparteInternal(int $businessId, string $contraparte, ?string $hojeIso): array
+    {
+        $hoje = $hojeIso !== null
+            ? CarbonImmutable::parse($hojeIso)->startOfDay()
+            : CarbonImmutable::today();
+
+        $termo = '%' . trim($contraparte) . '%';
+
+        // Títulos da contraparte + última baixa NÃO estornada (pra medir atraso
+        // de quitação). eager-load escopado por business_id (Tier 0 na relação).
+        $titulos = Titulo::query()
+            ->where('business_id', $businessId)                 // Tier 0 defesa em profundidade
+            ->where('cliente_descricao', 'like', $termo)
+            ->whereIn('status', ['aberto', 'parcial', 'quitado'])   // ignora cancelado
+            ->whereNull('deleted_at')
+            ->with(['baixas' => function ($sub) use ($businessId): void {
+                $sub->where('business_id', $businessId)         // Tier 0 também na relação
+                    ->whereNull('estorno_de_id')
+                    ->orderByDesc('data_baixa');
+            }])
+            ->orderBy('id')
+            ->get(['id', 'status', 'vencimento', 'cliente_descricao']);
+
+        $qtdTitulos = $titulos->count();
+        $qtdAtrasados = 0;
+        $somaDiasAtraso = 0;
+        $fontes = [];
+
+        foreach ($titulos as $titulo) {
+            $fontes[] = (int) $titulo->id;
+
+            $diasAtraso = $this->diasAtrasoTitulo($titulo, $hoje);
+            if ($diasAtraso > 0) {
+                $qtdAtrasados++;
+                $somaDiasAtraso += $diasAtraso;
+            }
+        }
+
+        $pctAtraso = $qtdTitulos > 0
+            ? round(($qtdAtrasados / $qtdTitulos) * 100.0, 2)
+            : 0.0;
+
+        $diasMedioAtraso = $qtdAtrasados > 0
+            ? round($somaDiasAtraso / $qtdAtrasados, 2)
+            : 0.0;
+
+        return [
+            'contraparte'       => $contraparte,
+            'qtd_titulos'       => $qtdTitulos,
+            'qtd_atrasados'     => $qtdAtrasados,
+            'pct_atraso'        => $pctAtraso,
+            'dias_medio_atraso' => $diasMedioAtraso,
+            'fontes'            => $fontes,
+        ];
+    }
+
+    /**
+     * Dias de atraso de UM título:
+     *  - quitado  → data_baixa (última não estornada) − vencimento, se positivo
+     *  - aberto/parcial vencido → hoje − vencimento (Titulo::isVencido())
+     *  - caso contrário → 0 (em dia)
+     */
+    private function diasAtrasoTitulo(Titulo $titulo, CarbonImmutable $hoje): int
+    {
+        if ($titulo->vencimento === null) {
+            return 0;
+        }
+
+        $venc = CarbonImmutable::parse($titulo->vencimento->format('Y-m-d'))->startOfDay();
+
+        if ($titulo->status === 'quitado') {
+            $ultimaBaixa = $titulo->baixas->first();   // já ordenado data_baixa desc
+            if ($ultimaBaixa === null || $ultimaBaixa->data_baixa === null) {
+                return 0;
+            }
+            $pago = CarbonImmutable::parse($ultimaBaixa->data_baixa->format('Y-m-d'))->startOfDay();
+
+            // 2º arg true = absoluto (Carbon 3 é sinalizado por default).
+            return $pago->greaterThan($venc) ? (int) $venc->diffInDays($pago, true) : 0;
+        }
+
+        // aberto / parcial: atrasado se vencimento já passou.
+        return $venc->lessThan($hoje) ? (int) $venc->diffInDays($hoje, true) : 0;
+    }
+
+    /**
+     * "Quanto recebi por canal/origem no período?" — recebido (baixas reais de
+     * títulos a-receber) agrupado pela `origem` do título (manual / venda /
+     * compra / despesa / recurring / folha — o "canal" comercial).
+     *
+     * Read-only. Devolve `por_canal` ordenado por valor desc + `fontes` (IDs das
+     * baixas somadas) pra citação. Datas 'Y-m-d' inclusivas.
+     *
+     * @param  int     $businessId  Tier 0 (ADR 0093) — sempre via argumento.
+     * @param  string  $de          Data inicial 'Y-m-d' (inclusive).
+     * @param  string  $ate         Data final 'Y-m-d' (inclusive).
+     *
+     * @return array{
+     *   periodo: array{de: string, ate: string},
+     *   total: float,
+     *   por_canal: array<int, array{canal: string, valor: float, qtd: int}>,
+     *   fontes: array<int, int>
+     * }
+     */
+    public function totaisPorCanal(int $businessId, string $de, string $ate): array
+    {
+        return OtelHelper::spanBiz('financeiro.insights.totais_por_canal', function () use ($businessId, $de, $ate): array {
+            return $this->totaisPorCanalInternal($businessId, $de, $ate);
+        }, [
+            'module'      => 'Financeiro',
+            'op'          => 'insights.totais_por_canal',
+            'business_id' => $businessId,
+        ]);
+    }
+
+    /**
+     * @return array{periodo: array{de: string, ate: string}, total: float, por_canal: array<int, array{canal: string, valor: float, qtd: int}>, fontes: array<int, int>}
+     */
+    private function totaisPorCanalInternal(int $businessId, string $de, string $ate): array
+    {
+        // Baixas a-receber no período (não estornadas) + origem do título.
+        // eager-load título escopado por business_id (Tier 0 na relação).
+        $baixas = TituloBaixa::query()
+            ->where('business_id', $businessId)                 // Tier 0 defesa em profundidade
+            ->whereBetween('data_baixa', [$de, $ate])
+            ->whereNull('estorno_de_id')
+            ->whereHas('titulo', function ($sub) use ($businessId): void {
+                $sub->where('business_id', $businessId)         // Tier 0 também na relação
+                    ->where('tipo', 'receber');
+            })
+            ->with(['titulo' => function ($sub) use ($businessId): void {
+                $sub->where('business_id', $businessId)
+                    ->select('id', 'business_id', 'origem');
+            }])
+            ->orderBy('data_baixa')
+            ->get(['id', 'titulo_id', 'valor_baixa', 'data_baixa']);
+
+        $agrupado = []; // canal => ['valor' => float, 'qtd' => int]
+        $total = 0.0;
+        $fontes = [];
+
+        foreach ($baixas as $baixa) {
+            $canal = (string) ($baixa->titulo?->origem ?? 'desconhecido');
+            $valor = (float) $baixa->valor_baixa;
+
+            if (! isset($agrupado[$canal])) {
+                $agrupado[$canal] = ['valor' => 0.0, 'qtd' => 0];
+            }
+            $agrupado[$canal]['valor'] += $valor;
+            $agrupado[$canal]['qtd']++;
+
+            $total += $valor;
+            $fontes[] = (int) $baixa->id;
+        }
+
+        // Materializa lista ordenada por valor desc (mais relevante primeiro).
+        $porCanal = [];
+        foreach ($agrupado as $canal => $dados) {
+            $porCanal[] = [
+                'canal' => $canal,
+                'valor' => round($dados['valor'], 2),
+                'qtd'   => $dados['qtd'],
+            ];
+        }
+        usort($porCanal, fn (array $a, array $b): int => $b['valor'] <=> $a['valor']);
+
+        return [
+            'periodo'   => ['de' => $de, 'ate' => $ate],
+            'total'     => round($total, 2),
+            'por_canal' => $porCanal,
+            'fontes'    => $fontes,
+        ];
+    }
+}

--- a/Modules/Financeiro/Tests/Feature/InsightsServiceTest.php
+++ b/Modules/Financeiro/Tests/Feature/InsightsServiceTest.php
@@ -1,0 +1,329 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+use Modules\Financeiro\Models\Titulo;
+use Modules\Financeiro\Models\TituloBaixa;
+use Modules\Financeiro\Services\InsightsService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * InsightsService — camada de consulta read-only do histórico financeiro
+ * (PR1 da feature "perguntar ao histórico financeiro" · ADR ARQ-0006).
+ *
+ * Padrão de teste herdado de MultiTenantComprehensiveTest: SQLite in-memory,
+ * tabelas criadas no beforeEach (sem depender de seed UltimatePOS — robusto CI
+ * + local). Multi-tenant Tier 0 IRREVOGÁVEL (ADR 0093). Tests biz=1 (ADR 0101).
+ *
+ * Três eixos de cobertura:
+ *  1. Tier 0 (anti-leak)        — biz=1 NUNCA enxerga dado de biz=99.
+ *  2. Correctness (anti-halluc) — agregado == valor computado à mão / SQL direto.
+ *  3. Fontes (citação)          — resultado devolve os IDs de origem corretos.
+ *
+ * @see Modules\Financeiro\Services\InsightsService
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+
+beforeEach(function () {
+    config()->set('otel.enabled', false);
+    config()->set('activitylog.enabled', false);
+
+    if (config('database.default') !== 'sqlite' && ! str_contains((string) config('database.connections.sqlite.database'), ':memory:')) {
+        $this->markTestSkipped('InsightsServiceTest roda apenas em SQLite in-memory.');
+    }
+
+    Schema::dropIfExists('fin_titulo_baixas');
+    Schema::dropIfExists('fin_titulos');
+
+    Schema::create('fin_titulos', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->string('numero', 50)->nullable();
+        $t->string('tipo', 20);
+        $t->string('status', 20)->default('aberto');
+        $t->unsignedBigInteger('cliente_id')->nullable();
+        $t->string('cliente_descricao', 150)->nullable();
+        $t->decimal('valor_total', 14, 4)->default(0);
+        $t->decimal('valor_aberto', 14, 4)->default(0);
+        $t->string('moeda', 3)->default('BRL');
+        $t->date('emissao')->nullable();
+        $t->date('vencimento')->nullable();
+        $t->string('competencia_mes', 7)->nullable();
+        $t->string('origem', 20)->default('manual');
+        $t->unsignedBigInteger('origem_id')->nullable();
+        $t->unsignedInteger('parcela_numero')->nullable();
+        $t->unsignedInteger('parcela_total')->nullable();
+        $t->unsignedBigInteger('titulo_pai_id')->nullable();
+        $t->unsignedBigInteger('plano_conta_id')->nullable();
+        $t->unsignedBigInteger('categoria_id')->nullable();
+        $t->text('observacoes')->nullable();
+        $t->json('metadata')->nullable();
+        $t->unsignedInteger('created_by')->nullable();
+        $t->unsignedInteger('updated_by')->nullable();
+        $t->timestamps();
+        $t->softDeletes();
+    });
+
+    Schema::create('fin_titulo_baixas', function ($t) {
+        $t->id();
+        $t->unsignedInteger('business_id')->index();
+        $t->unsignedBigInteger('titulo_id');
+        $t->unsignedBigInteger('conta_bancaria_id')->nullable();
+        $t->decimal('valor_baixa', 14, 4)->default(0);
+        $t->decimal('juros', 14, 4)->nullable();
+        $t->decimal('multa', 14, 4)->nullable();
+        $t->decimal('desconto', 14, 4)->nullable();
+        $t->date('data_baixa');
+        $t->string('meio_pagamento', 30);
+        $t->string('idempotency_key', 100)->nullable();
+        $t->unsignedBigInteger('transaction_payment_id')->nullable();
+        $t->unsignedBigInteger('estorno_de_id')->nullable();
+        $t->text('observacoes')->nullable();
+        $t->unsignedInteger('created_by')->nullable();
+        $t->timestamp('created_at')->nullable();
+    });
+
+    if (! Schema::hasTable('activity_log')) {
+        Schema::create('activity_log', function ($t) {
+            $t->id();
+            $t->string('log_name')->nullable();
+            $t->text('description')->nullable();
+            $t->unsignedBigInteger('subject_id')->nullable();
+            $t->string('subject_type')->nullable();
+            $t->unsignedBigInteger('causer_id')->nullable();
+            $t->string('causer_type')->nullable();
+            $t->json('properties')->nullable();
+            $t->string('event')->nullable();
+            $t->uuid('batch_uuid')->nullable();
+            $t->timestamps();
+        });
+    }
+});
+
+afterEach(function () {
+    Schema::dropIfExists('fin_titulo_baixas');
+    Schema::dropIfExists('fin_titulos');
+});
+
+// ─────────────────────────── Helpers de seed ───────────────────────────
+
+/**
+ * Cria título. Sem sessão (CLI), BusinessScope global é inerte; business_id
+ * vem explícito no array (Tier 0 — sempre fornecido pelo chamador/servidor).
+ *
+ * @param  array<string, mixed>  $attrs
+ */
+function seedTitulo(array $attrs): Titulo
+{
+    return Titulo::query()->create(array_merge([
+        'tipo'              => 'receber',
+        'status'            => 'aberto',
+        'cliente_descricao' => 'Cliente Teste',
+        'valor_total'       => 100.0,
+        'valor_aberto'      => 100.0,
+        'moeda'             => 'BRL',
+        'origem'            => 'manual',
+    ], $attrs));
+}
+
+/**
+ * Cria baixa (append-only). business_id explícito (Tier 0).
+ *
+ * @param  array<string, mixed>  $attrs
+ */
+function seedBaixa(array $attrs): TituloBaixa
+{
+    return TituloBaixa::query()->create(array_merge([
+        'meio_pagamento' => 'pix',
+        'valor_baixa'    => 100.0,
+        'estorno_de_id'  => null,
+    ], $attrs));
+}
+
+// ═══════════════════════ recebidoPorPeriodo ═══════════════════════
+
+it('recebidoPorPeriodo soma EXATAMENTE as baixas semeadas (anti-alucinação)', function () {
+    // biz=1: 3 baixas a-receber no período (100 + 250.50 + 49.50 = 400.00),
+    // + 1 fora do período (ignorada) + 1 estornada (ignorada).
+    $tA = seedTitulo(['business_id' => 1, 'tipo' => 'receber']);
+    $tB = seedTitulo(['business_id' => 1, 'tipo' => 'receber']);
+    $tC = seedTitulo(['business_id' => 1, 'tipo' => 'receber']);
+    $tPagar = seedTitulo(['business_id' => 1, 'tipo' => 'pagar']);
+
+    $b1 = seedBaixa(['business_id' => 1, 'titulo_id' => $tA->id, 'valor_baixa' => 100.00, 'data_baixa' => '2026-05-10']);
+    $b2 = seedBaixa(['business_id' => 1, 'titulo_id' => $tB->id, 'valor_baixa' => 250.50, 'data_baixa' => '2026-05-15']);
+    $b3 = seedBaixa(['business_id' => 1, 'titulo_id' => $tC->id, 'valor_baixa' => 49.50, 'data_baixa' => '2026-05-31']);
+    // fora do período (junho):
+    seedBaixa(['business_id' => 1, 'titulo_id' => $tA->id, 'valor_baixa' => 999.00, 'data_baixa' => '2026-06-02']);
+    // estornada (estorno_de_id preenchido) — não conta:
+    seedBaixa(['business_id' => 1, 'titulo_id' => $tB->id, 'valor_baixa' => 70.00, 'data_baixa' => '2026-05-20', 'estorno_de_id' => $b1->id]);
+    // baixa de título a-pagar — não entra em "recebido":
+    seedBaixa(['business_id' => 1, 'titulo_id' => $tPagar->id, 'valor_baixa' => 500.00, 'data_baixa' => '2026-05-12']);
+
+    $r = (new InsightsService())->recebidoPorPeriodo(1, '2026-05-01', '2026-05-31');
+
+    expect($r['valor'])->toBe(400.00)
+        ->and($r['qtd'])->toBe(3)
+        ->and($r['periodo'])->toBe(['de' => '2026-05-01', 'ate' => '2026-05-31']);
+
+    // Fontes = exatamente os 3 IDs das baixas válidas (citação).
+    expect($r['fontes'])->toEqualCanonicalizing([$b1->id, $b2->id, $b3->id]);
+});
+
+it('recebidoPorPeriodo NÃO vaza baixas de outro tenant (Tier 0 · ADR 0093)', function () {
+    $t1 = seedTitulo(['business_id' => 1, 'tipo' => 'receber']);
+    $b1 = seedBaixa(['business_id' => 1, 'titulo_id' => $t1->id, 'valor_baixa' => 123.45, 'data_baixa' => '2026-05-10']);
+
+    // biz=99: dado que JAMAIS pode aparecer pra biz=1.
+    $t99 = seedTitulo(['business_id' => 99, 'tipo' => 'receber']);
+    seedBaixa(['business_id' => 99, 'titulo_id' => $t99->id, 'valor_baixa' => 9999.99, 'data_baixa' => '2026-05-11']);
+
+    $r = (new InsightsService())->recebidoPorPeriodo(1, '2026-05-01', '2026-05-31');
+
+    expect($r['valor'])->toBe(123.45)
+        ->and($r['qtd'])->toBe(1)
+        ->and($r['fontes'])->toBe([$b1->id]);
+
+    // E o inverso: biz=99 também só vê o seu.
+    $r99 = (new InsightsService())->recebidoPorPeriodo(99, '2026-05-01', '2026-05-31');
+    expect($r99['valor'])->toBe(9999.99)->and($r99['qtd'])->toBe(1);
+});
+
+// ═══════════════════════ agingResumo ═══════════════════════
+
+it('agingResumo distribui títulos nos buckets de Titulo::agingBucket (correctness)', function () {
+    $hoje = '2026-05-31';
+
+    // em_dia (vence no futuro):
+    $tEmDia = seedTitulo(['business_id' => 1, 'vencimento' => '2026-06-15', 'valor_aberto' => 100.00, 'status' => 'aberto']);
+    // <30 (vencido há 10 dias):
+    $t10 = seedTitulo(['business_id' => 1, 'vencimento' => '2026-05-21', 'valor_aberto' => 200.00, 'status' => 'aberto']);
+    // 30-60 (vencido há 45 dias):
+    $t45 = seedTitulo(['business_id' => 1, 'vencimento' => '2026-04-16', 'valor_aberto' => 300.00, 'status' => 'parcial']);
+    // 90-180 (vencido há 120 dias):
+    $t120 = seedTitulo(['business_id' => 1, 'vencimento' => '2026-01-31', 'valor_aberto' => 400.00, 'status' => 'aberto']);
+    // >180 (vencido há ~365 dias):
+    $t365 = seedTitulo(['business_id' => 1, 'vencimento' => '2025-05-31', 'valor_aberto' => 500.00, 'status' => 'aberto']);
+
+    // Ruído ignorado: quitado + cancelado não entram (só aberto/parcial).
+    seedTitulo(['business_id' => 1, 'vencimento' => '2026-01-01', 'valor_aberto' => 0.0, 'status' => 'quitado']);
+    seedTitulo(['business_id' => 1, 'vencimento' => '2026-01-01', 'valor_aberto' => 777.0, 'status' => 'cancelado']);
+
+    $r = (new InsightsService())->agingResumo(1, 'receber', $hoje);
+
+    expect($r['buckets']['em_dia'])->toBe(['qtd' => 1, 'valor' => 100.00])
+        ->and($r['buckets']['<30'])->toBe(['qtd' => 1, 'valor' => 200.00])
+        ->and($r['buckets']['30-60'])->toBe(['qtd' => 1, 'valor' => 300.00])
+        ->and($r['buckets']['60-90'])->toBe(['qtd' => 0, 'valor' => 0.0])
+        ->and($r['buckets']['90-180'])->toBe(['qtd' => 1, 'valor' => 400.00])
+        ->and($r['buckets']['>180'])->toBe(['qtd' => 1, 'valor' => 500.00]);
+
+    // Total = só os 5 abertos/parciais (1500), não o quitado/cancelado.
+    expect($r['total'])->toBe(['qtd' => 5, 'valor' => 1500.00]);
+
+    // Fontes = exatamente os 5 títulos considerados (citação).
+    expect($r['fontes'])->toEqualCanonicalizing([$tEmDia->id, $t10->id, $t45->id, $t120->id, $t365->id]);
+});
+
+it('agingResumo NÃO vaza títulos de outro tenant (Tier 0 · ADR 0093)', function () {
+    $t1 = seedTitulo(['business_id' => 1, 'vencimento' => '2026-05-21', 'valor_aberto' => 200.00, 'status' => 'aberto']);
+    // biz=99: título vencido que não pode contaminar o aging de biz=1.
+    seedTitulo(['business_id' => 99, 'vencimento' => '2026-05-21', 'valor_aberto' => 9999.00, 'status' => 'aberto']);
+
+    $r = (new InsightsService())->agingResumo(1, 'receber', '2026-05-31');
+
+    expect($r['total'])->toBe(['qtd' => 1, 'valor' => 200.00])
+        ->and($r['fontes'])->toBe([$t1->id])
+        ->and($r['buckets']['<30'])->toBe(['qtd' => 1, 'valor' => 200.00]);
+});
+
+// ═══════════════════════ historicoAtrasoContraparte ═══════════════════════
+
+it('historicoAtrasoContraparte calcula % e dias médios de atraso (correctness)', function () {
+    $hoje = '2026-05-31';
+    $nome = 'Padaria do Zé';
+
+    // Quitado em dia (pago antes do vencimento) — NÃO atrasado.
+    $tOk = seedTitulo(['business_id' => 1, 'cliente_descricao' => $nome, 'status' => 'quitado', 'vencimento' => '2026-05-20', 'valor_aberto' => 0.0]);
+    seedBaixa(['business_id' => 1, 'titulo_id' => $tOk->id, 'data_baixa' => '2026-05-18']);
+
+    // Quitado com 10 dias de atraso (pago depois do vencimento).
+    $tLate1 = seedTitulo(['business_id' => 1, 'cliente_descricao' => $nome, 'status' => 'quitado', 'vencimento' => '2026-05-01', 'valor_aberto' => 0.0]);
+    seedBaixa(['business_id' => 1, 'titulo_id' => $tLate1->id, 'data_baixa' => '2026-05-11']);
+
+    // Aberto e vencido há 20 dias (vencimento 2026-05-11) — atrasado.
+    $tLate2 = seedTitulo(['business_id' => 1, 'cliente_descricao' => $nome, 'status' => 'aberto', 'vencimento' => '2026-05-11', 'valor_aberto' => 50.0]);
+
+    // Outra contraparte — não deve casar no LIKE.
+    $tOutro = seedTitulo(['business_id' => 1, 'cliente_descricao' => 'Mercado da Ana', 'status' => 'aberto', 'vencimento' => '2026-01-01', 'valor_aberto' => 80.0]);
+
+    $r = (new InsightsService())->historicoAtrasoContraparte(1, 'Padaria', $hoje);
+
+    // 3 títulos da Padaria; 2 atrasados (10d + 20d) → 30 / 2 = 15 dias médio.
+    expect($r['qtd_titulos'])->toBe(3)
+        ->and($r['qtd_atrasados'])->toBe(2)
+        ->and($r['pct_atraso'])->toBe(round((2 / 3) * 100, 2))
+        ->and($r['dias_medio_atraso'])->toBe(15.00)
+        ->and($r['contraparte'])->toBe('Padaria');
+
+    // Fontes = os 3 títulos da Padaria (não o da Ana).
+    expect($r['fontes'])->toEqualCanonicalizing([$tOk->id, $tLate1->id, $tLate2->id])
+        ->and($r['fontes'])->not->toContain($tOutro->id);
+});
+
+it('historicoAtrasoContraparte NÃO vaza títulos de outro tenant (Tier 0 · ADR 0093)', function () {
+    $nome = 'ACME Ltda';
+    $t1 = seedTitulo(['business_id' => 1, 'cliente_descricao' => $nome, 'status' => 'aberto', 'vencimento' => '2026-05-11', 'valor_aberto' => 50.0]);
+    // biz=99 com MESMO nome de contraparte — clássico vetor de leak cross-tenant.
+    seedTitulo(['business_id' => 99, 'cliente_descricao' => $nome, 'status' => 'aberto', 'vencimento' => '2026-05-11', 'valor_aberto' => 9999.0]);
+
+    $r = (new InsightsService())->historicoAtrasoContraparte(1, 'ACME', '2026-05-31');
+
+    expect($r['qtd_titulos'])->toBe(1)
+        ->and($r['fontes'])->toBe([$t1->id]);
+});
+
+// ═══════════════════════ totaisPorCanal ═══════════════════════
+
+it('totaisPorCanal agrupa recebido por origem ordenado por valor desc (correctness)', function () {
+    // venda: 300 (200 + 100) · manual: 150 · recurring: 50.
+    $tVenda1 = seedTitulo(['business_id' => 1, 'tipo' => 'receber', 'origem' => 'venda']);
+    $tVenda2 = seedTitulo(['business_id' => 1, 'tipo' => 'receber', 'origem' => 'venda']);
+    $tManual = seedTitulo(['business_id' => 1, 'tipo' => 'receber', 'origem' => 'manual']);
+    $tRecur  = seedTitulo(['business_id' => 1, 'tipo' => 'receber', 'origem' => 'recurring']);
+
+    $bv1 = seedBaixa(['business_id' => 1, 'titulo_id' => $tVenda1->id, 'valor_baixa' => 200.00, 'data_baixa' => '2026-05-10']);
+    $bv2 = seedBaixa(['business_id' => 1, 'titulo_id' => $tVenda2->id, 'valor_baixa' => 100.00, 'data_baixa' => '2026-05-12']);
+    $bm  = seedBaixa(['business_id' => 1, 'titulo_id' => $tManual->id, 'valor_baixa' => 150.00, 'data_baixa' => '2026-05-15']);
+    $br  = seedBaixa(['business_id' => 1, 'titulo_id' => $tRecur->id, 'valor_baixa' => 50.00, 'data_baixa' => '2026-05-20']);
+
+    $r = (new InsightsService())->totaisPorCanal(1, '2026-05-01', '2026-05-31');
+
+    expect($r['total'])->toBe(500.00);
+
+    // Ordenado por valor desc: venda (300) > manual (150) > recurring (50).
+    expect($r['por_canal'])->toBe([
+        ['canal' => 'venda', 'valor' => 300.00, 'qtd' => 2],
+        ['canal' => 'manual', 'valor' => 150.00, 'qtd' => 1],
+        ['canal' => 'recurring', 'valor' => 50.00, 'qtd' => 1],
+    ]);
+
+    // Fontes = todas as 4 baixas somadas (citação).
+    expect($r['fontes'])->toEqualCanonicalizing([$bv1->id, $bv2->id, $bm->id, $br->id]);
+});
+
+it('totaisPorCanal NÃO vaza baixas de outro tenant (Tier 0 · ADR 0093)', function () {
+    $t1 = seedTitulo(['business_id' => 1, 'tipo' => 'receber', 'origem' => 'venda']);
+    $b1 = seedBaixa(['business_id' => 1, 'titulo_id' => $t1->id, 'valor_baixa' => 80.00, 'data_baixa' => '2026-05-10']);
+
+    $t99 = seedTitulo(['business_id' => 99, 'tipo' => 'receber', 'origem' => 'venda']);
+    seedBaixa(['business_id' => 99, 'titulo_id' => $t99->id, 'valor_baixa' => 5000.00, 'data_baixa' => '2026-05-10']);
+
+    $r = (new InsightsService())->totaisPorCanal(1, '2026-05-01', '2026-05-31');
+
+    expect($r['total'])->toBe(80.00)
+        ->and($r['por_canal'])->toBe([['canal' => 'venda', 'valor' => 80.00, 'qtd' => 1]])
+        ->and($r['fontes'])->toBe([$b1->id]);
+});


### PR DESCRIPTION
## P2 RAG — PR1 (data layer only)
Implementa a camada de **tools read-only** do recurso "perguntar ao histórico financeiro" (ADR **arq/0006**, aceita por você 2026-05-31). Por design da ADR (anti-trap F3): **tools + Pest primeiro**; LLM/Jana + UI vêm no **PR2**.

## InsightsService — 4 tools determinísticas
Cada uma: `(int $businessId, …)`, **read-only**, `OtelHelper::spanBiz`, devolve a resposta **+ `fontes`** (IDs de título/baixa) pra citação:
- `recebidoPorPeriodo` — "quanto recebi entre X e Y?"
- `agingResumo` — distribuição dos recebíveis abertos por bucket (em_dia/<30/30-60/60-90/90-180/>180)
- `historicoAtrasoContraparte` — "esse cliente costuma atrasar?" (qtd, % atraso, dias médios)
- `totaisPorCanal` — recebido agrupado por origem/canal

## Garantias
- **Tier 0** (ADR 0093): `business_id` sempre via argumento do **servidor** (nunca LLM/user); `where business_id` explícito em TODA query, inclusive nas relações (whereHas/with).
- **Read-only**: zero mutação.
- **fontes** em toda resposta → fundação anti-alucinação (número rastreável a registros reais).
- **Pest** (8 casos, biz=1 vs biz=99): anti-leak Tier 0 + correção vs valor calculado na mão + fontes. ⚠️ Não rodado aqui (sem php/vendor) — CI valida.

## Nota / achado
A service usa `diffInDays(,true)` (absoluto) e **não** replica um **bug Carbon-3 em `Titulo::agingBucket()`** (lá o `diffInDays` é sinalizado por default → classificaria todo atrasado como `<30`). Flagado pra fix separado.

**Sem rota/controller/UI/Jana/migration.** Não merge automático.

🤖 Generated with [Claude Code](https://claude.com/claude-code)