### PR TITLE
fix(whatsapp): inbound usa hora real do evento, não now() (fuso London na fila)

### DIFF
--- a/Modules/Whatsapp/Jobs/ProcessIncomingWebhookJob.php
+++ b/Modules/Whatsapp/Jobs/ProcessIncomingWebhookJob.php
@@ -219,6 +219,10 @@ class ProcessIncomingWebhookJob implements ShouldQueue
 
         $convId = $conversation?->id;
         $now = now();
+        // Hora real da mensagem no fuso do business — NÃO now() (este job roda na
+        // fila, fora do middleware Timezone, então now() seria Europe/London = +3h
+        // vs SP → msg no horário/dia errado). Fallback seguro pra now() embutido.
+        $sentAt = $this->resolveSentAt($msg['sent_at'] ?? null, $this->businessTimezone());
         if ($convId === null) {
             $convData = [
                 'business_id' => $this->businessId,
@@ -228,8 +232,8 @@ class ProcessIncomingWebhookJob implements ShouldQueue
                 'contact_name' => $contactName,
                 'status' => 'open',
                 'unread_count' => $fromMe ? 0 : 1, // outbound não conta como não-lida
-                'last_inbound_at' => $fromMe ? null : $now,
-                'last_message_at' => $now,
+                'last_inbound_at' => $fromMe ? null : $sentAt,
+                'last_message_at' => $sentAt,
                 'last_message_preview' => mb_substr((string) ($msg['body'] ?? ''), 0, 200),
                 'last_message_direction' => $direction,
                 'created_at' => $now,
@@ -239,7 +243,7 @@ class ProcessIncomingWebhookJob implements ShouldQueue
             // byte-idêntico ao original (não introduz coluna nova no fluxo que
             // os testes legados de inbound já cobrem).
             if ($fromMe) {
-                $convData['last_outbound_at'] = $now;
+                $convData['last_outbound_at'] = $sentAt;
             }
             $convId = \DB::table('conversations')->insertGetId($convData);
         }
@@ -265,8 +269,8 @@ class ProcessIncomingWebhookJob implements ShouldQueue
             'media_mime' => $msg['media_mime'] ?? null,
             'media_size_bytes' => $msg['media_size_bytes'] ?? null,
             'media_filename' => $msg['media_filename'] ?? null,
-            'created_at' => $now,
-            'updated_at' => $now,
+            'created_at' => $sentAt,
+            'updated_at' => $sentAt,
         ]);
 
         // Realtime Centrifugo — publica evento "message.received" no canal
@@ -310,7 +314,7 @@ class ProcessIncomingWebhookJob implements ShouldQueue
 
         if ($conversation !== null) {
             $convUpdate = [
-                'last_message_at' => $now,
+                'last_message_at' => $sentAt,
                 'last_message_preview' => mb_substr((string) ($msg['body'] ?? ''), 0, 200),
                 'last_message_direction' => $direction,
                 'updated_at' => $now,
@@ -318,11 +322,11 @@ class ProcessIncomingWebhookJob implements ShouldQueue
             if ($fromMe) {
                 // outbound: marca saída, NÃO incrementa unread, NÃO toca
                 // last_inbound_at nem contact_name (preserva nome do cliente).
-                $convUpdate['last_outbound_at'] = $now;
+                $convUpdate['last_outbound_at'] = $sentAt;
             } else {
                 // inbound: idêntico ao original (não introduz coluna nova).
                 $convUpdate['unread_count'] = ($conversation->unread_count ?? 0) + 1;
-                $convUpdate['last_inbound_at'] = $now;
+                $convUpdate['last_inbound_at'] = $sentAt;
                 $convUpdate['contact_name'] = $contactName;
             }
             \DB::table('conversations')->where('id', $convId)->update($convUpdate);
@@ -334,6 +338,47 @@ class ProcessIncomingWebhookJob implements ShouldQueue
             'conversation_id' => $convId,
             'provider_message_id' => $providerMessageId,
         ]);
+    }
+
+    /**
+     * Hora REAL da mensagem (do provider) no fuso do business.
+     *
+     * Por que NÃO `now()`: este job roda na fila (queue worker), que não passa
+     * pelo middleware HTTP `App\Http\Middleware\Timezone`. Logo `now()` cairia no
+     * default `config('app.timezone')` (Europe/London) e gravaria a msg +3h
+     * adiantada vs America/Sao_Paulo — "pulando de dia" perto da meia-noite.
+     *
+     * Robusto aos 2 formatos que o whatsmeow emite (time.Time do Go):
+     *   - string RFC3339 com offset ("2026-05-28T22:00:00-03:00") → respeita o offset
+     *   - epoch numérico (UTC) → createFromTimestamp
+     *
+     * Fallback seguro: sem timestamp → `now()` (mantém o comportamento anterior).
+     */
+    private function resolveSentAt(mixed $raw, string $tz): \Illuminate\Support\Carbon
+    {
+        if ($raw === null || $raw === '') {
+            return now();
+        }
+
+        try {
+            $c = is_numeric($raw)
+                ? \Illuminate\Support\Carbon::createFromTimestamp((int) $raw) // epoch é UTC
+                : \Illuminate\Support\Carbon::parse((string) $raw);           // RFC3339: offset embutido
+            return $c->setTimezone($tz); // storage UPos é local ao business, não UTC
+        } catch (\Throwable) {
+            return now(); // formato inesperado → fallback seguro
+        }
+    }
+
+    /**
+     * Fuso do business — mesmo valor que o middleware HTTP `Timezone` aplicaria
+     * num request autenticado. Sem business/time_zone → default do app (não quebra).
+     */
+    private function businessTimezone(): string
+    {
+        $tz = optional(\App\Business::find($this->businessId))->time_zone;
+
+        return is_string($tz) && $tz !== '' ? $tz : (string) config('app.timezone');
     }
 
     /**
@@ -435,6 +480,9 @@ class ProcessIncomingWebhookJob implements ShouldQueue
             // PushName em evento fromMe é o nome do operador — NÃO usar como
             // contact_name do cliente. Passa null pra preservar o nome existente.
             'push_name' => $fromMe ? null : ($info['PushName'] ?? null),
+            // Hora REAL do evento (whatsmeow serializa time.Time → RFC3339 c/ offset
+            // OU epoch). Usada no created_at em vez de now() — ver resolveSentAt().
+            'sent_at' => $info['Timestamp'] ?? null,
             'raw' => $payload,
         ]];
 

--- a/Modules/Whatsapp/Tests/Feature/WhatsmeowInboundTimezoneTest.php
+++ b/Modules/Whatsapp/Tests/Feature/WhatsmeowInboundTimezoneTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Carbon;
+use Modules\Whatsapp\Jobs\ProcessIncomingWebhookJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-WA-308 — timezone da mensagem inbound (fix do "+3h" reportado pela cliente).
+ *
+ * `ProcessIncomingWebhookJob` é `ShouldQueue` → roda no queue worker, que NÃO
+ * passa pelo middleware HTTP `App\Http\Middleware\Timezone`. Logo `now()` cairia
+ * no default `Europe/London` (UTC+0) e gravaria a msg +3h adiantada vs
+ * `America/Sao_Paulo` (UTC−3) — "pulando de dia" perto da meia-noite.
+ *
+ * O fix usa a hora REAL do evento (`Info.Timestamp` do whatsmeow) convertida pro
+ * fuso do business. Estes testes SIMULAM o worker em London (beforeEach) e provam
+ * que a msg fica no horário/dia certos.
+ *
+ * Unit puro (reflection nos métodos privados) — sem DB.
+ *
+ * Ref: auditoria timezone `now()` em contextos não-HTTP (2026-05-31).
+ */
+
+beforeEach(function () {
+    // Simula o queue worker: app no fuso DEFAULT (London), não no do business.
+    config(['app.timezone' => 'Europe/London']);
+    date_default_timezone_set('Europe/London');
+});
+
+afterEach(fn () => Carbon::setTestNow());
+
+function waTzInvoke(string $method, array $args): mixed
+{
+    $job = new ProcessIncomingWebhookJob(4, 'whatsmeow', []);
+    $m = new ReflectionMethod($job, $method);
+    $m->setAccessible(true);
+
+    return $m->invoke($job, ...$args);
+}
+
+it('resolveSentAt: RFC3339 das 22h em SP NÃO pula pro dia seguinte', function () {
+    // 22h SP = 01h do dia 29 em London. O bug gravava 2026-05-29.
+    $r = waTzInvoke('resolveSentAt', ['2026-05-28T22:00:00-03:00', 'America/Sao_Paulo']);
+
+    expect($r->format('Y-m-d H:i'))->toBe('2026-05-28 22:00');
+    expect($r->toDateString())->toBe('2026-05-28');
+});
+
+it('resolveSentAt: epoch (UTC) converte pro fuso do business', function () {
+    $epoch = Carbon::parse('2026-05-28T22:00:00-03:00')->timestamp; // 2026-05-29 01:00 UTC
+
+    $r = waTzInvoke('resolveSentAt', [$epoch, 'America/Sao_Paulo']);
+
+    expect($r->format('Y-m-d H:i'))->toBe('2026-05-28 22:00');
+});
+
+it('resolveSentAt: business em outro fuso (Manaus, UTC−4) respeita o offset', function () {
+    $r = waTzInvoke('resolveSentAt', ['2026-05-28T23:30:00-03:00', 'America/Manaus']);
+
+    // 23:30 SP (−03) = 22:30 Manaus (−04)
+    expect($r->format('Y-m-d H:i'))->toBe('2026-05-28 22:30');
+});
+
+it('resolveSentAt: sem timestamp cai no fallback now() (não regride)', function () {
+    Carbon::setTestNow('2026-05-29 01:00:00');
+
+    $r = waTzInvoke('resolveSentAt', [null, 'America/Sao_Paulo']);
+
+    expect($r->format('Y-m-d H:i:s'))->toBe(now()->format('Y-m-d H:i:s'));
+});
+
+it('extractFromWhatsmeow: expõe sent_at a partir de Info.Timestamp', function () {
+    $payload = [
+        'event' => [
+            'Info' => [
+                'Chat' => '5511999999999@s.whatsapp.net',
+                'Sender' => '5511999999999@s.whatsapp.net',
+                'IsFromMe' => false,
+                'ID' => 'WAMID.TZ.001',
+                'Type' => 'text',
+                'PushName' => 'Cliente',
+                'Timestamp' => '2026-05-28T22:00:00-03:00',
+            ],
+            'Message' => ['conversation' => 'oi'],
+        ],
+    ];
+
+    $out = waTzInvoke('extractFromWhatsmeow', [$payload]);
+
+    expect($out[0]['sent_at'])->toBe('2026-05-28T22:00:00-03:00');
+});


### PR DESCRIPTION
## Problema (produção)

`ProcessIncomingWebhookJob` é `ShouldQueue` → roda no **queue worker**, que não passa pelo middleware HTTP `App\Http\Middleware\Timezone`. Logo `now()` cai no default `config('app.timezone')` = **`Europe/London`** (UTC+0), não no `business.time_zone` (ex `America/Sao_Paulo`, UTC−3).

Resultado: a mensagem inbound gravava `created_at`/`last_message_at` **+3h adiantada** → mensagens da noite (após 21h SP) "pulavam pro dia seguinte". **Cliente reportou datas/horas com ~3h de diferença no inbox.**

> Bug ortogonal ao Carbon-3 `diffInDays` (sinal): aqui é o `now()` no fuso errado em contexto de fila.

## Fix

- `extractFromWhatsmeow` passa a expor o `Info.Timestamp` real do evento como `sent_at` (hoje descartado).
- Novo `resolveSentAt(raw, tz)` converte pro fuso do business — robusto aos 2 formatos que o whatsmeow emite (**RFC3339 com offset** _ou_ **epoch UTC**), com **fallback seguro pra `now()`** quando o provider não manda timestamp (não regride).
- `created_at` e `last_*_at` da mensagem e da conversa passam a refletir a **hora real do evento** (corrige também o drift de fila — `now()` era quando o job rodou, não quando a msg chegou).

**Escopo:** provider `whatsmeow` (o de produção). Legacy `meta_cloud`/`zapi`/`baileys` ficam de follow-up.

## Teste

`WhatsmeowInboundTimezoneTest` — **5 casos / 6 assertions** (verde local):
- RFC3339 das 22h em SP **não pula** pro dia seguinte
- epoch (UTC) converte pro fuso do business
- business em Manaus (UTC−4) respeita o offset
- sem timestamp → fallback `now()` (não regride)
- `extractFromWhatsmeow` expõe `sent_at`

## Contexto

Parte da auditoria de timezone `now()` em contextos não-HTTP (queue/CLI rodam em `Europe/London`). Tasks irmãs: **US-FIN-047** (webhooks de pagamento) e **US-FIN-048** (guard-rail: job middleware `SetsBusinessTimezone` + PHPStan `no-naive-now-in-queue`). Doc: `memory/sessions/2026-05-31-auditoria-timezone-now-contextos-nao-http.md`.

Refs: US-WA-308

🤖 Generated with [Claude Code](https://claude.com/claude-code)
