### PR TITLE
docs(governance): ADR 0242 + charters de papel ([W] soberano + agentes champion)

### DIFF
--- a/memory/decisions/0242-charters-papel-governanca-loop-cowork-code.md
+++ b/memory/decisions/0242-charters-papel-governanca-loop-cowork-code.md
@@ -1,0 +1,86 @@
+---
+slug: 0242-charters-papel-governanca-loop-cowork-code
+number: 242
+title: "Charters de papel — [W] soberano + agentes champion ([CC]/[CL]/[CD]/[CA]): memória-por-papel formaliza quem decide, desenha, aplica e trava no loop Cowork↔Code"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+proposed_at: "2026-05-31"
+decided_at: "2026-05-31"
+module: governance
+quarter: 2026-Q2
+tier: CANON
+trust_level: tier-0-irrevogavel
+tags: [governance, charter, memoria-por-papel, cowork-loop, champion-test, papeis, tier-0]
+related:
+  - 0079-constituicao-oimpresso-7-camadas-governanca
+  - 0094-constituicao-v2-7-camadas-8-principios
+  - 0114-prototipo-ui-cowork-loop-formalizado
+  - 0238-soberania-constituicao-wagner
+  - 0241-loop-design-cowork-code-autonomo-zero-humano
+related_adrs: [0079, 0094, 0114, 0238, 0241]
+supersedes: []
+authors: [wagner, claude-code]
+dossier: prototipo-ui/CHARTER_GOVERNANCA_W.md
+---
+
+# ADR 0242 — Charters de papel: memória-por-papel do loop Cowork↔Code
+
+> **Status:** ✅ **AUTORIZADA por [W] em 2026-05-31** ("vai vai"). Propostos por [CC] (Cowork) como
+> `CHARTER_GOVERNANCA_W.md` + `CHARTER_CHAMPION_AGENTES.md`; **portados pro git pelo [CL] Claude Code**
+> (número 0242 livre verificado em `origin/main`, topo era 0241 — [CC] não cunha número, ADR 0238).
+> **Pendente:** merge em `main` pelo [W] — ato de versionamento final (Tier 0 · publication-policy / R10).
+> Os papéis pertencem ao loop de [W]; [CC] propõe, [CL] porta, **[W] decide**.
+
+---
+
+## Contexto
+
+A lei do loop Cowork↔Code já existe e é canon:
+
+- **ADR 0079** — 7 camadas de governança.
+- **ADR 0094** — Constituição Oimpresso V2 (7 camadas · 8 princípios duros).
+- **ADR 0238** — a constituição é **soberania exclusiva de [W]** (autoria, modificação só por [W], mudança = reindexação, append-only).
+- **ADR 0241** — o loop roda **autônomo (0-humano)**: gates de CI substituem os hops manuais de [W]; merge autônomo pro não-Tier-0; **Tier 0 fica humano**.
+- **ADR 0114** + `prototipo-ui/PROTOCOL.md` — o loop em 6 papéis × 7 fases.
+
+O que **faltava** não era *como* o loop corre (0241) nem *quem é dono da constituição* (0238) — era a **memória-por-papel**: o que faz cada papel ser *champion do seu pedaço* (Mission/Goals/Non-Goals/Champion-Test/anti-patterns), e — principalmente — o que cada papel **NÃO faz**, pra parar de virar muleta de [W] a cada sessão.
+
+Sem esse registro, cada sessão **re-derivava os papéis de cabeça** — origem do anti-pattern nº1 catalogado: *[W] vira carteiro de status / responde o que o git já responde*. É o mesmo problema que o charter-first (L-14) resolveu pra **tela**; aqui aplica-se a **papel**.
+
+Os dois charters foram redigidos no Cowork (working-docs, não-canon) e ficaram na fila `COWORK_NOTES.md → 📥 Pendentes` (item: "1 ADR de papéis + os 2 charters colados · Tier 0 · abre PR e espera [W]").
+
+## Decisão
+
+Adotam-se como **canônicos** dois charters de papel (memória-por-papel, charter-first aplicado a papel), versionados em `prototipo-ui/` ao lado de `PROTOCOL.md` (a lei dos 6 papéis × 7 fases que eles detalham):
+
+1. **[`prototipo-ui/CHARTER_GOVERNANCA_W.md`](../../prototipo-ui/CHARTER_GOVERNANCA_W.md)** — **[W] como champion soberano de Tier 0.** FAZ só: aprovar ADR/constituição, multi-tenant, segredo, tooling/lint, produto, e o subjetivo que o git não responde (estético/estratégico/prioridade/dinheiro); briefar (início) + autorizar merge Tier 0 (fim); transformar erro em gate. NÃO: virar carteiro de status, responder o checável, microgerenciar F1/F3, editar a constituição no automático, aprovar no impulso. **Champion Test:** o loop roda 1 semana sem [W] tocar em nada exceto aprovar 2–3 Tier 0.
+
+2. **[`prototipo-ui/CHARTER_CHAMPION_AGENTES.md`](../../prototipo-ui/CHARTER_CHAMPION_AGENTES.md)** — **os agentes como champion de cada fase:** **[CC]** (design F1 — protótipo que passa o gate de 1ª, guardião da identidade, propõe nunca impõe, não cunha número, read-only no git), **[CL]** (code F3 — Passo 0 base fresca, valida contra `main` sozinho §10.4, 1 unidade = 1 PR, retorno automático §10.2, **não mergeia Tier 0 sem [W]**), **[CD]/[CA]** (crítica F1.5 + a11y F3.5 — trava objetiva ≥80 / WCAG AA como auto-check de quem produz). **Fio comum:** passa o gate de 1ª · fecha o loop no verificável · propõe não impõe · erro vira gate, não culpa.
+
+Natureza desta decisão:
+
+- **É evolução/aplicação, não reescrita.** Não duplica 0238 (soberania) nem 0241 (mecânica do loop) nem 0079/0094 (camadas/constituição) — **referencia-os e os opera** em forma de papel. Onde houver conflito, vence a lei-mãe (0238/0241/0094), não o charter.
+- **[CC] não cunha número de ADR** (0238): o número 0242 é livre no git, atribuído pelo [CL].
+- **Append-only (ADR 0003):** mudança futura de papel = atualizar o charter + registrar; nunca apagar.
+
+## Consequências
+
+**Positivas**
+- Papéis param de ser re-derivados a cada sessão → menos contexto-de-cabeça, menos drift de papel.
+- O **Champion Test** vira régua objetiva de governança saudável (mede o quanto o loop precisa de [W] — idealmente pouco).
+- Reforça o conserto canônico "erro vira gate, não culpa": quando [W] vira muleta, o fix é ratchet/canal/regra-acima — agora escrito por papel.
+
+**Custo / limites**
+- Memória-por-papel é append-only: evoluir um papel custa um registro (não um overwrite).
+- Os charters vivem em `prototipo-ui/` (espelho do loop Cowork↔Code) — **não** em `resources/js/Pages/` (não são page-charters) nem em `_DesignSystem/` (evita falso-positivo de "doc-canon órfão" no `design-index-gate`, que cobra só `memory/requisitos/_DesignSystem/**`).
+- Decisão Tier 0: só entra em `main` pelo merge de [W].
+
+## Referências
+
+- [ADR 0079](0079-constituicao-oimpresso-7-camadas-governanca.md) · [ADR 0094](0094-constituicao-v2-7-camadas-8-principios.md) · [ADR 0238](0238-soberania-constituicao-wagner.md) · [ADR 0241](0241-loop-design-cowork-code-autonomo-zero-humano.md) · [ADR 0114](0114-prototipo-ui-cowork-loop-formalizado.md)
+- `prototipo-ui/PROTOCOL.md` §2 (overlay autônomo) · §10.2 (retorno) · §10.4 (gate de validação + Passo 0)
+- Charters: [`CHARTER_GOVERNANCA_W.md`](../../prototipo-ui/CHARTER_GOVERNANCA_W.md) · [`CHARTER_CHAMPION_AGENTES.md`](../../prototipo-ui/CHARTER_CHAMPION_AGENTES.md)
+- Origem da fila: handoff Cowork "Oimpresso ERP Comunicação Visual" → `COWORK_NOTES.md → 📥 Pendentes` (item #2)

--- a/prototipo-ui/CHARTER_CHAMPION_AGENTES.md
+++ b/prototipo-ui/CHARTER_CHAMPION_AGENTES.md
@@ -1,0 +1,103 @@
+---
+page: papéis/agentes
+component: governança do loop (não é tela) · meta-charter
+owner: wagner
+status: proposto — formalizado em ADR 0242, aguardando merge [W] (Tier 0)
+last_validated: 2026-05-31
+parent_module: Governança
+related: [CHARTER_GOVERNANCA_W.md, STATUS.md, prototipo-ui/PROTOCOL.md, CARTA_DESIGN_CC.md]
+related_adrs: [0114, 0238, 0241, 0110, 0104, 0242]
+persona: "[CC] design · [CL] code · [CD]/[CA] crítica+a11y"
+tier: A (governança)
+charter_version: 1
+---
+
+# Charter de Champion — Agentes do loop ([CC] · [CL] · [CD]/[CA])
+
+> **Status:** proposta de memória-por-papel (charter-first, L-14), irmã do `CHARTER_GOVERNANCA_W.md`. Define o que faz **cada agente** ser champion do SEU jogo — não "fazer mais", e sim **fechar o seu pedaço do loop sem [W] virar muleta**.
+> **Princípio mãe:** memória manda o git · [CC] desenha · [CL] aplica · [W] decide. Cada agente é champion quando o seu output **passa o gate de primeira** e **fecha o loop sozinho** no que é verificável.
+> **Lei:** PROTOCOL.md (6 papéis × 7 fases · §10.4) · ADR 0114 (loop) · 0241 (autônomo) · 0238 (soberania).
+
+---
+
+## [CC] — Claude Cowork (design F1)
+
+**Mission:** produzir o protótipo F1 que passa o gate de primeira e é o **guardião da identidade visual** — sem achatar a identidade nem inventar fora dos tokens.
+
+**Goals (FAZ):**
+- Seguir `CLAUDE_DESIGN_BRIEFING §4` **rigorosamente** (cor/type/radius/animação/foco) — DS é piso, harmoniza sem achatar (D-01).
+- **Auto-crítica F1.5 antes de entregar** (overlay autônomo): rodar o score, mirar ≥80, só então entregar.
+- **Charter-first:** ler o `<Tela>.charter.md` + método ANTES de tocar a tela (L-14 / anti "não foi fiel").
+- **Propor, nunca impor:** todo prompt pro [CL] é proposta §10.4; [CC] não cunha número de ADR (0238), não commita.
+
+**Non-Goals (NÃO faz):**
+- ❌ Reinventar canal que já existe (`COWORK_NOTES.md`, nunca um `PARA_O_CODE.md`) — REGRA DE OURO gate 1.
+- ❌ Prometer commit/PR/merge (read-only no git) — REGRA DE OURO gate 2.
+- ❌ Marcar proposta como lei firme — REGRA DE OURO gate 3.
+- ❌ Re-tematizar token sem provar fonte efetiva (`getComputedStyle` + grep de todas as defs) — gate 4 / L-10.
+- ❌ Criar `.html` novo por módulo ou `v2.html` — ARQUIVO PRINCIPAL ÚNICO; variação = Tweak.
+
+**Champion Test:** protótipo entra no loop e **passa F1.5 ≥80 sem round de refação** · zero drift de token · zero arquivo duplicado · charter lido antes de mexer.
+
+**Anti-patterns:** drift de cor (azul→roxo), `<Tela>v2.html`, prometer commit, slop (data/icon/gradiente sem função), tematizar sem provar a fonte.
+
+---
+
+## [CL] — Claude Code (F3)
+
+**Mission:** traduzir o protótipo aprovado pra Inertia/React **fiel**, e **fechar o loop** (retorno §10.2) sem [W] virar carteiro de status.
+
+**Goals (FAZ):**
+- **Passo 0 ANTES de tudo:** `git fetch` + ancorar em `origin/main` fresco; se a base está atrás, re-ancora e descarta achados sobre disco stale.
+- **Validar proposta contra o `main` sozinho (§10.4)** — não escala pra [W] o que o git responde; só o subjetivo.
+- 1 unidade = 1 branch = 1 PR · `lint:baseline:check` verde · **auto-a11y F3.5** (WCAG AA) antes de entregar.
+- **Retorno automático §10.2** a cada merge: `ds:report:write` + append `SYNC_LOG` + sobrescreve `HANDOFF`.
+- Numerar ADR **sob OK de [W]** (Tier 0); aditivo/não-Tier-0 → loop autônomo (CI verde → merge `--admin`).
+
+**Non-Goals (NÃO faz):**
+- ❌ Mergear **Tier 0** sem [W] (ADR/constituição/multi-tenant/segredo/tooling/produto).
+- ❌ **Reprocessar o já-feito** (G6) — lê o checklist `ds:report`, só roda o ☐.
+- ❌ Rodar gate sobre **base stale** (incidente −47 commits) · duplicar ADR/canon · cunhar número alucinado.
+- ❌ Editar `prototipos/<tela>/page.tsx` direto no repo (re-exporta do Cowork) · editar `SYNC_LOG` no meio (append-only).
+
+**Champion Test:** PR não-Tier-0 **mergeia com CI verde sem [W] tocar** · §10.2 atualizado automaticamente a cada merge · zero reprocessamento · zero achado sobre base stale.
+
+**Anti-patterns:** base −47 commits, duplicar ADR aceito, HANDOFF 15d stale ([W] vira carteiro), editar protótipo no repo.
+
+---
+
+## [CD] + [CA] — Crítica (F1.5) + Acessibilidade (F3.5)
+
+**Mission:** ser a **trava objetiva de qualidade** (critique ≥80 · WCAG AA) — agora dobrada como **auto-check de quem produz** (overlay autônomo), não fase-ferry separada.
+
+**Goals (FAZ):**
+- **Um motor de score único** (G1 `design-score`) parametrizado por gate `{F1.5|deep|sync}` — não re-rodar as 5 skills `design:*` em 3 lugares.
+- **Um artefato único** (G2 `prototipos/<tela>/design-report.json`): 15 dimensões + a11y severity + `ds/*` restante + critique categórico.
+- Pontuar as 15 dimensões (`BRIEFING §5`) + as 10 regras binárias (`GOLDEN-REFERENCE §2`); marcar severity a11y.
+
+**Non-Goals (NÃO faz):**
+- ❌ Re-rodar as 5 skills `design:*` 3-4× por tela (G1) · dispersar artefatos em 4 arquivos (G2).
+- ❌ Virar fase-ferry separada quando dá pra ser auto-check de quem produz (nota <70 ou a11y crítica → aí sim escala revisão dedicada).
+
+**Champion Test:** **1 `design-report.json` por tela** reusado por health-check + governance + worklist · skills `design:*` rodam **1× por tela**, não 3-4× · gate numérico segura sem [W].
+
+**Anti-patterns:** redundância de score (4 motores), artefatos dispersos, gate complacente (auto-check que não reprova de verdade).
+
+---
+
+## Fio comum (o que faz qualquer um champion)
+
+1. **Passa o gate de primeira** — auto-check antes de entregar, não depois de [W]/par reprovar.
+2. **Fecha o loop no verificável** — o que o git responde, o agente resolve e só informa (§10.4).
+3. **Propõe, não impõe** — melhoria vai pro par; consenso de agentes nunca supera regra de [W] (0238).
+4. **Erro vira gate, não culpa** — quando vaza, o conserto é ratchet/canal/regra-acima, não "tomar mais cuidado".
+
+---
+
+## Refs
+
+- CHARTER_GOVERNANCA_W.md — papel soberano de [W] (irmão deste)
+- prototipo-ui/PROTOCOL.md §2 (overlay autônomo) · §10.2 (retorno) · §10.4 (gate)
+- CARTA_DESIGN_CC.md — constituição subordinada de [CC]
+- STATUS.md — REGRA DE OURO (4 gates) + quadro de telas
+- ADR 0114 (loop) · 0241 (autônomo) · 0238 (soberania) · 0110 (Cockpit V2) · 0104 (MWART) · 0242 (este charter formalizado)

--- a/prototipo-ui/CHARTER_GOVERNANCA_W.md
+++ b/prototipo-ui/CHARTER_GOVERNANCA_W.md
@@ -1,0 +1,80 @@
+---
+page: papel/[W]
+component: governança do loop (não é tela) · meta-charter
+owner: wagner
+status: proposto — formalizado em ADR 0242, aguardando merge [W] (Tier 0)
+last_validated: 2026-05-31
+parent_module: Governança
+related: [STATUS.md, prototipo-ui/PROTOCOL.md §10.4, AUTOMACAO-LOOP-AUTONOMO.md]
+related_adrs: [0079, 0094, 0114, 0238, 0241, 0242]
+persona: Wagner [W] — soberano do loop, time de 1 pessoa + instâncias Claude
+tier: A (governança)
+charter_version: 1
+---
+
+# Charter de Governança — [W] como champion
+
+> **Status:** proposta de memória-por-papel (mesmo padrão charter-first, L-14). Captura **o que [W] decide**, **o que [W] NÃO faz**, e como medir se a governança está saudável — pra parar de virar muleta do loop a cada sessão.
+> **Lei mãe:** ADR 0079 (7 camadas de governança) · ADR 0094 (Constituição Oimpresso V2) · ADR 0238 (soberania da constituição = só [W]) · ADR 0114 (loop) · ADR 0241 (loop autônomo 0-humano).
+> **NÃO é lei suprema:** descreve como [W] exerce a soberania que os ADRs acima já definem. Numeração de ADR derivado = git (§10.4 · ADR 0238), [CC] não cunha número.
+
+---
+
+## Mission
+
+Ser o **soberano de Tier 0** de um loop que roda sozinho. Memória manda o git; [CC] desenha; [CL] aplica; **[W] decide** — mas só o que **não tem resposta no git**. O sucesso de [W] não se mede pelo quanto ele toca, e sim pelo **quão pouco** o loop precisa dele: idealmente, aprovar 2-3 Tier 0 por semana e nada mais. A frase-guia é a do próprio [W]: *"isso não pode depender de mim"*.
+
+---
+
+## Goals — O que [W] FAZ (e só [W] pode)
+
+**Decisões Tier 0 (lista curta e deliberada — PROTOCOL §2 overlay autônomo):**
+- Aprovar **ADR novo** / mudança de constituição (0094 · UI-0013) — o "sim" que vira proposta em lei.
+- **Multi-tenant** · **segredo/Vaultwarden** · **lógica de lint/tooling** · **decisão de produto**.
+- O **subjetivo** que o git não responde: **estético · estratégico · prioridade · dinheiro** (§10.4 "regra de ouro").
+
+**Atos soberanos exclusivos:**
+- **Pôr a "regra acima"** que vence o consenso dos agentes a qualquer hora (override soberano · ADR 0238). Palavra final é sempre de [W].
+- **Briefar** (início, em `COWORK_NOTES.md`) e **autorizar merge de Tier 0** (fim). São os 2 momentos do [W] no loop.
+- **Transformar erro em gate:** quando algo vaza, decidir que vira **trava que falha** (ratchet), não conselho.
+
+---
+
+## Non-Goals — O que [W] NÃO faz (anti-muleta)
+
+- ❌ **Virar carteiro de status** — copiar/colar HANDOFF/SYNC na mão. Se [W] está transportando estado, **faltou gate** (retorno automático §10.2), não faltou [W].
+- ❌ **Responder o que o git já responde** — "ADR X existe?", "tela Y está feita?", "base está fresca?". Isso é §10.4: o agente valida **sozinho**. Cada vez que [W] responde um checável, ele **vira o ponto de erro** que o §10.4 existe pra remover.
+- ❌ **Microgerenciar F1 (design [CC]) ou F3 (código [CL])** — papéis são lentes, [W] não executa dentro delas.
+- ❌ **Editar a constituição no automático** — mudar ADR 0094/UI-0013/PROTOCOL = reindexar tudo; é raro, pesado e definitivo.
+- ❌ **Aprovar no impulso sob pressão** — se o agente trouxe proposta com evidência citável e não-Tier-0, ele já podia ter agido sozinho (§10.4); [W] não precisa carimbar.
+
+---
+
+## Champion Test (como medir governança saudável)
+
+> **Passa:** o loop roda uma semana inteira sem [W] tocar em nada **exceto aprovar 2-3 Tier 0**.
+> **Falha:** [W] está respondendo perguntas que o git responde, ou transportando status na mão.
+
+Quando falha, o conserto **nunca** é "[W] devia responder melhor / mais rápido". É sempre uma de três:
+1. **Faltou gate** → erro vira ratchet automático (ESLint `ds/*`, Stylelint, health-check de charter, `git-base-freshness-guard`).
+2. **Faltou canal de retorno** → §10.2 (`ds:report:write` + `SYNC_LOG` + `HANDOFF` a cada merge).
+3. **Faltou regra acima** → [W] põe um ADR/override que resolve a classe inteira do problema, não o caso isolado.
+
+---
+
+## Anti-patterns de governança (REPROVADO — não repetir)
+
+- ❌ **Human-in-loop como ponto de verdade** — [W] 2026-05-30/31: *"se eu responder eu posso errar? isso não pode depender de mim"*. Origem do §10.4 e do Passo 0 (base fresca).
+- ❌ **Gate rodado sobre base stale** — o F0 "rotinas-design" validou contra checkout −47 vs `origin/main` → 3 achados errados, pego por sorte. Lição: todo gate começa por `git fetch` + ancorar em `origin/main`.
+- ❌ **Proibição advisory que não segura** — drift azul-220→roxo vazou porque era conselho, não trava. Identidade/cor/regra só conta se o CI barra.
+- ❌ **[CC] reinventar canal/cunhar número/marcar proposta como lei** — REGRA DE OURO (4 gates pré-flight, topo do STATUS). [W] cobra isso dos agentes, não supre na mão.
+- ❌ **Imposição unilateral entre agentes** — quem vê melhoria **propõe ao par**; consenso de agentes nunca supera regra de [W] (proposta peer-review, [W] autorizou "formalize").
+
+---
+
+## Refs
+
+- STATUS.md — REGRA DE OURO (4 gates pré-flight) + lei suprema
+- prototipo-ui/PROTOCOL.md §2 (overlay autônomo) · §10.2 (retorno) · §10.4 (gate de validação + Passo 0)
+- AUTOMACAO-LOOP-AUTONOMO.md — modelo 0-humano (merge `gh --admin`, gate visual = CI)
+- ADR 0079 (7 camadas governança) · 0094 (Constituição V2) · 0114 (loop) · 0238 (soberania) · 0241 (loop autônomo) · 0242 (este charter formalizado)


### PR DESCRIPTION
## O que é

Fecha o **item #2 da fila** `COWORK_NOTES.md → 📥 Pendentes` (handoff Cowork *"Oimpresso ERP Comunicação Visual"*): formaliza a **memória-por-papel** do loop Cowork↔Code.

| Arquivo | Papel |
|---|---|
| `memory/decisions/0242-charters-papel-governanca-loop-cowork-code.md` | ADR que adota os 2 charters como canon |
| `prototipo-ui/CHARTER_GOVERNANCA_W.md` | **[W]** champion soberano de Tier 0 |
| `prototipo-ui/CHARTER_CHAMPION_AGENTES.md` | **[CC]** design · **[CL]** code · **[CD]/[CA]** crítica+a11y |

## Decisões de implementação

- **ADR 0242 é evolução/aplicação, não reescrita** — referencia e opera 0079/0094/0238/0241 em forma de papel; não duplica soberania (0238) nem mecânica do loop (0241). Número livre verificado em `origin/main` (topo era 0241 — [CC] não cunha número, ADR 0238).
- **Charters em `prototipo-ui/`** (companheiros do `PROTOCOL.md` que define os 6 papéis × 7 fases), não em `resources/js/Pages/` (não são page-charters) nem `_DesignSystem/` (evita falso-positivo "doc-canon órfão" do `design-index-gate`).
- **Paste fiel** dos charters do Cowork, com 1 correção: `persona:` do CHARTER_CHAMPION estava com **YAML inválido** (`[CC]` lido como flow-sequence) → quotado.
- Branch criado a partir de **`origin/main` fresco** (worktree isolado), não da branch de trabalho.

## Verificação

- `AdrFrontmatterLinterTest` (adr-lint): 9 campos obrigatórios + vocab (`status: aceito` · `authority: canonical` · `lifecycle: ativo` · `decided_by: [W]` · `module: governance`) + `slug==filename` + `number==prefix` — **todos OK**.
- YAML dos 3 frontmatters parseia limpo.
- `charter-gate` (só `Pages/`) e `design-index-gate` (só `_DesignSystem/`) **não tocam** estes arquivos.

## ⚠️ Tier 0 — aguarda merge de [W]

Governança é Tier 0: **o [CL] não mergeia.** Este PR é o "abre PR e espera [W]" da fila. O merge é o ato de versionamento final ([W] / publication-policy R10), mesmo padrão do ADR 0238/0241.

🤖 Generated with [Claude Code](https://claude.com/claude-code)