### PR TITLE
feat(governance): G4 retorno automático §10.2 — design_return_skipped + workflow pós-merge

### DIFF
--- a/.github/workflows/design-return-gate.yml
+++ b/.github/workflows/design-return-gate.yml
@@ -1,0 +1,84 @@
+name: Design return gate (§10.2 pós-merge)
+
+# Hook POS-merge do loop Cowork<->Code (G4 / fila COWORK_NOTES Pendentes #1).
+#
+# Quando um merge na main toca TELA/DS (resources/js/Pages/**/*.tsx ou
+# prototipo-ui/prototipos/**) mas NAO atualiza prototipo-ui/SYNC_LOG.md, o retorno
+# §10.2 ([CL]->[CC]) foi pulado -> o [CC] nao ve via MCP o que mudou e pode regerar
+# o ja-feito (origem do incidente "HANDOFF 15d stale / SYNC_LOG parado").
+#
+# ADVISORY: NAO falha o job (o merge ja aconteceu — bloquear nao desfaz). So torna o
+# skip VISIVEL sozinho (warning + job summary) -> tira [W] de carteiro de status.
+# Gemeo barato do health-check filesystem `design_return_skipped` (jana:health-check,
+# diario). A AUTO-GERACAO do retorno (auto-commit ds:report:write+SYNC_LOG+HANDOFF) e
+# decisao de arquitetura Tier 0 de [W] (auto-commit na main + token) — fica fora deste PR.
+#
+# Refs: PROTOCOL §10.2 · ADR 0241 (loop autonomo) · CHARTER_CHAMPION_AGENTES ([CL] retorno)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'resources/js/Pages/**/*.tsx'
+      - 'prototipo-ui/prototipos/**'
+      - 'prototipo-ui/SYNC_LOG.md'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: design-return-gate-${{ github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  return-check:
+    name: retorno §10.2 pos-merge
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2 # ver o merge: HEAD~1..HEAD
+
+      - name: Detectar retorno §10.2 pulado (advisory)
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if ! changed=$(git diff --name-only HEAD~1 HEAD 2>/dev/null); then
+            echo "Sem HEAD~1 (push inicial/raso) — nada a checar."
+            exit 0
+          fi
+
+          # Telas (.tsx em Pages) ou exports de prototipo tocados neste merge.
+          tela_ds=$(printf '%s\n' "$changed" \
+            | grep -E '^(resources/js/Pages/.+\.tsx$|prototipo-ui/prototipos/)' || true)
+
+          if [ -z "$tela_ds" ]; then
+            echo "Merge nao tocou tela/DS — retorno §10.2 nao se aplica. OK."
+            exit 0
+          fi
+
+          if printf '%s\n' "$changed" | grep -qx 'prototipo-ui/SYNC_LOG.md'; then
+            echo "OK — merge tocou tela/DS E atualizou prototipo-ui/SYNC_LOG.md (retorno §10.2 presente)."
+            exit 0
+          fi
+
+          # Skip detectado -> advisory (warning + summary, exit 0).
+          {
+            echo "## design_return_skipped (§10.2)"
+            echo ""
+            echo "Este merge tocou **tela/DS** mas **nao** atualizou \`prototipo-ui/SYNC_LOG.md\`."
+            echo "O retorno \`[CL] -> [CC]\` (PROTOCOL §10.2) foi pulado -> o \`[CC]\` nao enxerga via MCP o que mudou."
+            echo ""
+            echo "Tela/DS neste merge:"
+            printf '%s\n' "$tela_ds" | sed 's/^/- /'
+            echo ""
+            echo "Conserto (§10.2): \`npm run ds:report:write\` + append \`SYNC_LOG.md\` + overwrite \`HANDOFF.md\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          while IFS= read -r f; do
+            [ -n "$f" ] && echo "::warning file=${f}::design_return_skipped — merge tocou tela/DS sem retorno §10.2 (SYNC_LOG nao atualizado)"
+          done <<< "$tela_ds"
+
+          echo "ADVISORY: retorno §10.2 pulado (warning, nao bloqueia — o merge ja aconteceu)."
+          exit 0

--- a/Modules/Jana/Console/Commands/HealthCheckCommand.php
+++ b/Modules/Jana/Console/Commands/HealthCheckCommand.php
@@ -27,9 +27,10 @@ use Modules\Jana\Services\CharterHealthChecker;
  *   8. Whatsapp media pending 1h (Guardião 6 Camada 6) — mídia órfã > 1h
  *   9. MCP webhook 5xx 2h (US-FIN-043 incident 2026-05-21) — webhook GitHub
  *      retornando 5xx nas últimas 2h indica drift no DB sync (tasks/memory)
- *  10-14. Charter health (ADVISORY · CharterHealthChecker, PROTOCOL §6) —
+ *  10-15. Charter/loop health (ADVISORY · CharterHealthChecker, PROTOCOL §6) —
  *      charter_missing, charter_stale (>90d), charter_refs_broken,
- *      charter_method_missing, readme_handoff_block_missing (L-18).
+ *      charter_method_missing, readme_handoff_block_missing (L-18),
+ *      design_return_skipped (retorno §10.2 atrás do SYNC_LOG · G4).
  *      Reportam mas NÃO falham o exit code nem o ALERT de cron (viram
  *      ratchet depois que o baseline de charters existir).
  *
@@ -44,7 +45,7 @@ class HealthCheckCommand extends Command
                             {--json : Output JSON em vez de tabela}
                             {--notify : Loga ALERT em jana-health channel se algo falhou}';
 
-    protected $description = 'Health check diário Jana + Constituição v2 (9 checks SQL + 5 charter advisory)';
+    protected $description = 'Health check diário Jana + Constituição v2 (9 checks SQL + 6 charter/loop advisory)';
 
     public function handle(): int
     {

--- a/Modules/Jana/Services/CharterHealthChecker.php
+++ b/Modules/Jana/Services/CharterHealthChecker.php
@@ -26,6 +26,7 @@ namespace Modules\Jana\Services;
  *   - charter_refs_broken      — refs (component/runbook/parent_capterra + links) inexistentes
  *   - charter_method_missing   — charter tier A sem referência a método/bench (leve)
  *   - readme_handoff_block_missing — prototipo-ui/README.md sem `<!-- HANDOFF-ENTRY -->` (L-18)
+ *   - design_return_skipped    — HANDOFF.md atrás do último merge no SYNC_LOG (retorno §10.2 pulou o canal HANDOFF · G4 / COWORK_NOTES #1)
  */
 class CharterHealthChecker
 {
@@ -52,6 +53,7 @@ class CharterHealthChecker
             $this->charterRefsBroken($charters),
             $this->charterMethodMissing($charters),
             $this->readmeHandoffBlockMissing(),
+            $this->designReturnSkipped(),
         ];
     }
 
@@ -220,7 +222,63 @@ class CharterHealthChecker
         );
     }
 
+    /**
+     * design_return_skipped — o retorno §10.2 ([CL]→[CC]) pulou o canal HANDOFF.
+     *
+     * Sinal filesystem-only e determinístico (sem git por-arquivo, flaky em CI/clone
+     * raso — mesma escolha do charter_stale): o HANDOFF.md ("sobrescreve" a cada
+     * retorno) deve refletir data ≥ a do último merge logado no SYNC_LOG.md ("append").
+     * Se HANDOFF < último SYNC_LOG, o canal HANDOFF ficou pra trás → retorno parcial
+     * (origem do incidente "HANDOFF 15d stale", PROTOCOL §10). Gêmeo do workflow
+     * design-return-gate.yml (pós-merge, pega o skip TOTAL via git diff do merge).
+     */
+    private function designReturnSkipped(): array
+    {
+        $handoff = $this->basePath . '/prototipo-ui/HANDOFF.md';
+        $syncLog = $this->basePath . '/prototipo-ui/SYNC_LOG.md';
+
+        if (! is_file($handoff) || ! is_file($syncLog)) {
+            return $this->row('design_return_skipped', true, 'n/a',
+                'Canais §10.2 (HANDOFF/SYNC_LOG) ausentes — n/a', 'sincronizado');
+        }
+
+        $syncDate = $this->maxLineLeadingIsoDate((string) @file_get_contents($syncLog));
+        preg_match('/Estado atual:\s*(\d{4}-\d{2}-\d{2})/u',
+            (string) @file_get_contents($handoff), $hm);
+        $handoffDate = $hm[1] ?? null;
+
+        if ($syncDate === null || $handoffDate === null) {
+            return $this->row('design_return_skipped', true, 'n/a',
+                'Sem data ISO parseável em HANDOFF/SYNC_LOG — n/a', 'sincronizado');
+        }
+
+        // ISO YYYY-MM-DD: comparação lexicográfica == cronológica.
+        $skipped = $handoffDate < $syncDate;
+
+        return $this->row(
+            'design_return_skipped',
+            ! $skipped,
+            $skipped ? "HANDOFF {$handoffDate} < SYNC_LOG {$syncDate}" : 'sincronizado',
+            $skipped
+                ? "ALERTA §10.2: HANDOFF.md ({$handoffDate}) atrás do último SYNC_LOG ({$syncDate}) — retorno [CL]→[CC] pulou o canal HANDOFF"
+                : "HANDOFF.md ({$handoffDate}) em dia com o SYNC_LOG ({$syncDate})",
+            'sincronizado',
+        );
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────
+
+    /** Maior data ISO (YYYY-MM-DD) em início de linha; null se nenhuma. */
+    private function maxLineLeadingIsoDate(string $text): ?string
+    {
+        if (! preg_match_all('/^(\d{4}-\d{2}-\d{2})\b/m', $text, $m)) {
+            return null;
+        }
+        $dates = $m[1];
+        sort($dates);
+
+        return end($dates) ?: null;
+    }
 
     private function pagesDir(): string
     {

--- a/Modules/Jana/Tests/Feature/CharterHealthCheckerTest.php
+++ b/Modules/Jana/Tests/Feature/CharterHealthCheckerTest.php
@@ -219,3 +219,45 @@ it('repo real (fromApp): roda os 5 checks advisory sem quebrar', function () {
         expect($c['advisory'])->toBeTrue();
     }
 });
+
+// ── design_return_skipped (G4 / COWORK_NOTES #1 — retorno §10.2) ──────────────
+
+it('design_return_skipped OK quando HANDOFF >= ultimo SYNC_LOG', function () {
+    $tmp = charterHcTmp([
+        'prototipo-ui/HANDOFF.md' => "# HANDOFF\n\n## Estado atual: 2026-06-01 — x\n",
+        'prototipo-ui/SYNC_LOG.md' => "2026-05-30 ~10:00 [CL] a merged PR #1\n2026-06-01 ~01:00 [CL] b merged PR #2\n",
+    ]);
+
+    $row = charterHcRow((new CharterHealthChecker($tmp))->checks(), 'design_return_skipped');
+
+    expect($row['ok'])->toBeTrue()->and($row['advisory'])->toBeTrue();
+
+    charterHcRmrf($tmp);
+});
+
+it('design_return_skipped FLAG quando HANDOFF atras do ultimo SYNC_LOG', function () {
+    $tmp = charterHcTmp([
+        'prototipo-ui/HANDOFF.md' => "## Estado atual: 2026-05-29 — x\n",
+        'prototipo-ui/SYNC_LOG.md' => "2026-05-20 ~10:00 [CL] a merged PR #1\n2026-06-01 ~01:00 [CL] b merged PR #2\n",
+    ]);
+
+    $row = charterHcRow((new CharterHealthChecker($tmp))->checks(), 'design_return_skipped');
+
+    expect($row['ok'])->toBeFalse()
+        ->and($row['advisory'])->toBeTrue()
+        ->and($row['value'])->toContain('2026-05-29');
+
+    charterHcRmrf($tmp);
+});
+
+it('design_return_skipped n/a quando canais §10.2 ausentes', function () {
+    $tmp = charterHcTmp([
+        'resources/js/Pages/Demo/Index.tsx' => 'x',  // base existe, sem prototipo-ui/
+    ]);
+
+    $row = charterHcRow((new CharterHealthChecker($tmp))->checks(), 'design_return_skipped');
+
+    expect($row['ok'])->toBeTrue()->and($row['value'])->toBe('n/a');
+
+    charterHcRmrf($tmp);
+});


### PR DESCRIPTION
## O que é

Fecha o **item #1 da fila** `COWORK_NOTES.md → 📥 Pendentes`: *"§10.2 vira hook pós-merge + health-check `design_return_skipped`"*. Objetivo declarado: **tira [W] de carteiro de status** — o skip do retorno §10.2 (`[CL]→[CC]`) passa a se **denunciar sozinho**, em vez de o Wagner ter que perceber.

Dois detectores complementares (ambos **advisory** — reportam, não derrubam):

| Peça | Quando roda | Pega |
|---|---|---|
| **`design_return_skipped`** (CharterHealthChecker → `jana:health-check`) | diário / local | **skip parcial**: `HANDOFF.md` atrás do último merge no `SYNC_LOG.md`. Filesystem-only, determinístico (sem git por-arquivo — mesma escolha do `charter_stale`). |
| **`design-return-gate.yml`** (push `main`) | pós-merge | **skip total**: merge que tocou tela/DS (`Pages/**/*.tsx` ou `prototipos/**`) **sem** atualizar `SYNC_LOG.md`. `git diff HEAD~1 HEAD` → warning + job summary. |

## Verificação

- `php -l` ✓ nos 3 arquivos PHP.
- **Lógica validada standalone** (sem vendor): `sync→ok` · `skip→FLAG` (`HANDOFF 2026-05-29 < SYNC_LOG 2026-06-01`) · `canais ausentes→n/a`. +3 Pest no `CharterHealthCheckerTest`.
- Workflow YAML válido; advisory (`exit 0` sempre — o merge já aconteceu, bloquear não desfaz).

## ⚠️ Tier 0 — espera [W]

Tooling/governança = Tier 0 (`CHARTER_GOVERNANCA_W`): **não mergeio.** Abre PR e espera você.

**Decisão de arquitetura que deixei pra você (fora deste PR):** a **auto-geração** do retorno (um workflow que *auto-commita* `ds:report:write` + `SYNC_LOG` + `HANDOFF` na `main`) remove o passo manual de vez, mas envolve **auto-commit na main + token de bot** — é arquitetura Tier 0 sua (casa com o bootstrap `grokwr2` do `AUTOMACAO-LOOP-AUTONOMO.md §3`). Este PR entrega a **detecção** (o "denuncia sozinho"); a **auto-escrita** fica pro teu call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)