### PR TITLE
docs(financeiro): session log Fase 1 prod + plano Fase 2 + bug CI ui:judge-pr

### DIFF
--- a/memory/requisitos/Financeiro/PLANO-FASE2-MIGRACAO-EXTRATO-UNIFICADO.md
+++ b/memory/requisitos/Financeiro/PLANO-FASE2-MIGRACAO-EXTRATO-UNIFICADO.md
@@ -1,0 +1,149 @@
+# Fase 2 — Migração de dados: unificar extrato OFX → tabela canônica
+
+> **Origem:** [ADR 0236](../../decisions/0236-extrato-conciliacao-modelo-unificado.md) (aceita 2026-05-31).
+> **Pré-requisito:** Fase 1 em produção ✅ (conciliação já lê as 2 origens — 2026-06-01).
+> **Escopo:** migrar as linhas de `fin_bank_statement_lines` (OFX) PARA
+> `fin_extrato_lancamentos` (canônica), unificando a chave de dedupe, e reapontar
+> o `upload()` OFX pra gravar na tabela canônica. A tabela antiga vira read-only.
+> **Status:** PLANO — aguarda gate Wagner. NÃO implementar sem aprovação + sinal.
+
+---
+
+## ⚠️ Por que esta fase é a arriscada
+
+Diferente da Fase 1 (aditiva, zero migração de dado), a Fase 2 **move dado em
+produção financeira com cliente real** (biz=4 Larissa). Os princípios:
+
+- **Append-only + LGPD** ([retention.php](../../../Modules/Financeiro/Config/retention.php)):
+  extrato tem retenção 5 anos (CTN Art. 195) + audit trail. Backfill **preserva**
+  `created_at` e a trilha — nunca apaga-e-recria.
+- **Multi-tenant Tier 0** ([ADR 0093](../../decisions/0093-multi-tenant-isolation-tier-0.md)):
+  backfill por `business_id`, jamais cross-tenant.
+- **Reversível**: tabela antiga NÃO é dropada nesta fase (só read-only). Drop fica
+  pra Fase 3 (ADR de deprecação dedicada).
+- **Sinal qualificado** ([ADR 0105](../../decisions/0105-cliente-como-sinal-guiar-sem-mandar.md)):
+  só executar se houver cliente com banco conectado **e** que sobe OFX do mesmo banco
+  (risco de duplicata cross-origem real), OU métrica detectando o drift.
+
+---
+
+## O problema que a Fase 2 resolve
+
+Hoje (pós-Fase 1) as 2 origens **convivem** mas em tabelas separadas:
+- Mesma transação pode entrar 2× (OFX + API) porque as chaves de dedupe não se
+  enxergam — `(business_id, fitid)` vs `(conta_bancaria_id, idempotency_key)`.
+- 2 tabelas, 2 models, 2 regras de manutenção.
+
+A Fase 2 colapsa tudo numa tabela só com **uma** chave anti-duplicata.
+
+---
+
+## Decisões de desenho
+
+### DD-1 — `external_id` unificado (a parte mais delicada)
+A ADR define UNIQUE `(business_id, conta_bancaria_id, external_id)`. O `external_id`
+precisa servir as 2 origens **sem colidir**. Estratégia: **prefixo por origem**.
+- OFX: `external_id = "ofx:" . fitid`
+- API: `external_id = "api:" . idempotency_key`
+
+Assim, mesmo que um FITID e um idempotency_key sejam numericamente iguais, os
+prefixos os separam. **Caveat de produto** (decisão Wagner): se a intenção é que
+a MESMA transação vinda de OFX e de API seja deduplicada entre si, o prefixo
+**impede** isso (elas teriam external_id diferente). Se for esse o objetivo,
+precisamos de uma chave derivada do conteúdo (ex. hash de `valor+data+contraparte`)
+— mais complexo e sujeito a falso-positivo. **Recomendação:** começar com prefixo
+(conservador, nunca funde linhas distintas), e tratar dedup cross-origem como
+feature separada se virar sinal real.
+
+### DD-2 — `conta_bancaria_id` NOT NULL no alvo
+OFX hoje aceita `conta_bancaria_id` NULL (quando o upload não detecta a conta).
+A tabela canônica tem FK NOT NULL. Tratamento: criar **1 conta "OFX genérica" por
+business** (tipo_conta `ofx_avulso`) pra abrigar linhas OFX sem conta detectada,
+OU exigir seleção de conta no upload (mudança de UX). **Recomendação:** conta
+genérica por business (não quebra o fluxo atual de upload).
+
+### DD-3 — Backfill idempotente, em lote, por business
+- `insertOrIgnore` na canônica (respeitando o novo UNIQUE) — re-rodar é no-op.
+- Preserva `created_at` original (não usa `now()`).
+- Mapeia campos: `data_movimento`→`data`, enum `tipo` OFX (credit/debit/fee/transfer)
+  → `C`/`D` (fee/transfer viram D/C conforme sinal), `valor` 15,4 → 15,2 (cuidado
+  com truncamento — validar que não há centavo perdido).
+- Em chunks de 500, por `business_id`, com log de quantas migraram vs puladas.
+- Workflow de conciliação (`status`/`titulo_id`/`match_score`/`conciliado_by`/
+  `conciliado_at`) já existe na canônica (Fase 1) — backfill carrega junto.
+
+### DD-4 — Feature flag controla a leitura/escrita
+- Flag `financeiro.extrato_unificado` (off por padrão).
+- **Off**: comportamento Fase 1 (lê as 2 tabelas).
+- **On**: `upload()` grava na canônica; leitura só da canônica; `fin_bank_statement_lines`
+  read-only.
+- Permite ligar em biz=1 (canary), observar, depois biz=4.
+
+### DD-5 — Tabela antiga read-only (não drop)
+- Após backfill + flag on, `fin_bank_statement_lines` não recebe mais escrita.
+- Guard no model/Observer: bloqueia INSERT (DomainException) com mensagem clara.
+- Drop real = Fase 3 (ADR de deprecação, após período de observação).
+
+---
+
+## Mudanças por arquivo (escopo)
+
+1. **Migration** — adiciona `origem`/`source_file`/`external_id` em
+   `fin_extrato_lancamentos` + cria UNIQUE `(business_id, conta_bancaria_id, external_id)`.
+   Idempotente. (Nota: `status` etc. já entraram na Fase 1.)
+2. **Command** `financeiro:backfill-extrato-ofx` — `--business=` obrigatório (Tier 0),
+   `--dry` default, lote 500, log por business. Idempotente.
+3. **`ConciliacaoController`** — atrás da flag: `upload()` grava na canônica;
+   `index`/`sugerirMatches`/`match`/`ignorar` leem só canônica quando flag on.
+4. **`BankStatementLine` model / Observer** — guard read-only quando flag on.
+5. **Conta OFX genérica** — seeder/migration cria 1 por business (DD-2).
+6. **Flag** `financeiro.extrato_unificado` no sistema de feature flags.
+
+---
+
+## Testes (Pest) — antes de qualquer canary
+
+- Backfill idempotente: rodar 2× não duplica (UNIQUE).
+- Backfill preserva `created_at` + workflow status.
+- `external_id` com prefixo não colide (FITID == idempotency_key numérico → 2 linhas).
+- Tier 0: backfill `--business=A` não toca linhas de B.
+- Valor 15,4 → 15,2 sem perda (ou documenta arredondamento).
+- Flag off = comportamento Fase 1 intacto (regressão).
+- Flag on = upload grava na canônica + antiga read-only (DomainException no insert).
+- Conta OFX genérica criada por business (DD-2).
+
+---
+
+## Roteiro de execução (gate Wagner em cada marco)
+
+1. **Gate 0** — Wagner aprova este plano + confirma DD-1 (prefixo vs hash de conteúdo).
+2. Migration + command + flag + testes (PR isolado, CI verde).
+3. **Canary biz=1**: backfill dry → real → liga flag → observa 1 ciclo (sync 07:00 +
+   upload manual). Métrica: zero duplicata, conciliação funcionando.
+4. **Gate 1** — Wagner aprova ir pra biz=4 após biz=1 limpo.
+5. **biz=4** (Larissa): backup → backfill dry → real → flag on → smoke + observa.
+6. **Gate 2** — período de observação (ex. 30d) antes de marcar antiga deprecável (Fase 3).
+
+---
+
+## Riscos & mitigação
+
+| Risco | Mitigação |
+|---|---|
+| Backfill corrompe/perde dado | dry-run obrigatório + `insertOrIgnore` + preserva created_at + tabela antiga intacta (read-only, não drop) |
+| Duplicata cross-origem não resolvida | DD-1 conservador (prefixo) — nunca funde linhas distintas; dedup real é feature separada |
+| Truncamento 15,4→15,2 | teste de valor + log de divergência; se houver centavo, escala Wagner |
+| Tier 0 | `--business=` obrigatório + teste cross-tenant |
+| Flag liga cedo demais | off por padrão + canary biz=1 antes de biz=4 |
+| Prod financeira | backup pré + maintenance + smoke (via deploy.yml, igual Fase 1) |
+
+## O que a Fase 2 NÃO faz
+- ❌ Não dropa `fin_bank_statement_lines` (Fase 3).
+- ❌ Não unifica a UI numa tela só (Fase 3).
+- ❌ Não muda o algoritmo de match (segue MVP valor+data±3d).
+- ❌ Não resolve dedup cross-origem por conteúdo (feature separada, se virar sinal).
+
+## Estimativa
+Codável com IA-pair: migration + command + flag + testes ≈ 1-2 sessões. O relógio
+real está nos **gates humanos**: canary biz=1 (observar ≥1 ciclo) + biz=4 (observar
+≥30d antes da Fase 3). Sem atalho nesses prazos — é dinheiro real.

--- a/memory/sessions/2026-06-01-fase1-conciliacao-extrato-api-prod.md
+++ b/memory/sessions/2026-06-01-fase1-conciliacao-extrato-api-prod.md
@@ -1,0 +1,52 @@
+# Sessão 2026-06-01 — Fase 1 ADR 0236 em produção + bug CI ui:judge-pr
+
+> De um bug de race condition num upload até uma feature em produção. Sessão longa,
+> ciclo fechado fim-a-fim (código → ADR → staging → PR → CI → merge → deploy prod).
+
+## O que entregou
+
+| Etapa | Resultado |
+|---|---|
+| Bug original | Race condition no upload OFX (`ConciliacaoController::upload` check-then-insert → 500 no clique-duplo) → `insertOrIgnore` idempotente |
+| Descoberta | Extrato bancário vivia em 2 tabelas separadas pelo eixo errado (origem do dado, não responsabilidade) — `fin_bank_statement_lines` (OFX) vs `fin_extrato_lancamentos` (API) |
+| [ADR 0236](../decisions/0236-extrato-conciliacao-modelo-unificado.md) | Modelo unificado: origem como atributo + conciliação como camada. **Aceita** por Wagner. Plano faseado (gate por fase) |
+| Fase 1 | Conciliação passa a ler/conciliar as 2 origens + coluna **Origem** (chip Banco/OFX). Migration aditiva, Tier 0 preservado. ZERO migração de dado |
+| Validação | Staging (`staging.oimpresso.com`) — Wagner aprovou screenshot |
+| [PR #2060](https://github.com/wagnerra23/oimpresso.com/pull/2060) | Squash em `main` (commit `5f6727ec5`). 24/25 checks verdes |
+| Deploy prod | `deploy.yml` (run 26731185922) — backup + 5 migrations + assets + smoke. Migration `[164] Ran`. Colunas confirmadas no DB prod. Smoke `/financeiro/conciliacao` → 302 (não 500) |
+
+## Problemas reais do meu código que o CI pegou (e eu consertei)
+
+Defesa em profundidade funcionando — cada um era bug real, corrigido na raiz (não silenciado):
+1. **PII scan** — CNPJ literal `12.345.678/0001-99` no teste → `00.000.000/0000-00` + `# pii-allowlist`
+2. **UI Lint R1** — cor crua `bg-sky-50`/`bg-violet-50` no chip → tokens semânticos `bg-accent`/`bg-transparent`
+3. **PHPStan** — `!== null` redundante após `isset()` em `normalizeApi` → removido
+4. **Charter schema** — `last_validated` sem aspas (virou date) + `related_adrs` com zero-leading → string + integers
+5. **MWART gate** — tela nunca teve charter/visual-comparison → criados (nome derivado do basename `Index.tsx` → `index-visual-comparison.md`, status `approved`)
+
+## 🐞 BUG CONHECIDO — CI `ui:judge-pr` quebra com UTF-8 malformado
+
+**Sintoma:** o check **"PR UI Judge · Claude Sonnet 4.5"** (workflow `pr-ui-judge.yml`) falhou no PR #2060 com:
+```
+PrUiJudgeAgent falhou: json_encode error: Malformed UTF-8 characters, possibly incorrectly encoded
+##[error]Process completed with exit code 1.
+```
+Saiu com exit 1 em ~1s — **antes** de avaliar a UI (não calculou score). NÃO é qualidade da tela.
+
+**Causa raiz provável:** `Modules/Jana/Ai/Agents/PrUiJudgeAgent.php` recebe o `git diff` filtrado (.tsx/.jsx/.css) no user prompt e serializa via `json_encode` pra mandar pro Sonnet. Se **qualquer byte** do diff não for UTF-8 válido, o `json_encode` aborta (sem flag de tolerância). Fontes possíveis do byte ruim: arquivo de terceiros no range do diff, ou conteúdo com encoding latin-1.
+
+**Por que não bloqueou o merge:** o check **não é required** na branch protection de `main` (único required: `ADR frontmatter`, que estava verde). Merge via `gh pr merge --admin` com Wagner autorizando.
+
+**Fix sugerido (quando alguém pegar):** no `PrUiJudgeAgent` (ou no `UiJudgePrCommand`), sanitizar o diff antes do `json_encode`:
+- `mb_convert_encoding($diff, 'UTF-8', 'UTF-8')` (descarta bytes inválidos), OU
+- `json_encode(..., JSON_INVALID_UTF8_SUBSTITUTE)` (PHP 7.2+, troca byte ruim por U+FFFD), OU
+- filtrar arquivos binários/não-UTF8 do diff antes de montar o prompt.
+
+**Refs:** workflow `.github/workflows/pr-ui-judge.yml` · `app/Console/Commands/UiJudgePrCommand.php` · `Modules/Jana/Ai/Agents/PrUiJudgeAgent.php`.
+
+## Pendências (pós-sessão)
+
+- **Fase 2** (ADR 0236): migração de dado `fin_bank_statement_lines` → `fin_extrato_lancamentos` (backfill idempotente + flag + canary biz=1→biz=4). Gate Wagner. Só com sinal.
+- **Fase 3**: unificação de UI + deprecação da tabela antiga (ADR de deprecação dedicada).
+- **Bug CI acima**: corrigir o `json_encode` do `ui:judge-pr`.
+- Backup de prod pré-deploy: `~/backup-predeploy-*.tar.gz` no servidor Hostinger.


### PR DESCRIPTION
## O quê

Dois docs canônicos da sessão que levou a **Fase 1 da ADR 0236 pra produção** (2026-06-01):

1. **[session log](memory/sessions/2026-06-01-fase1-conciliacao-extrato-api-prod.md)** — ciclo fim-a-fim (bug race condition → ADR 0236 → staging → PR #2060 → deploy prod) + registro **acionável** do bug do CI `ui:judge-pr` (`json_encode: Malformed UTF-8` — não-required, contornado via --admin).
2. **[PLANO-FASE2](memory/requisitos/Financeiro/PLANO-FASE2-MIGRACAO-EXTRATO-UNIFICADO.md)** — migração de dado unificada (backfill idempotente, `external_id` prefixado, flag, canary biz=1→biz=4). Só plano — **aguarda gate Wagner + sinal qualificado** (ADR 0105).

## Por que

Conhecimento canônico precisa ir pra `main` pra propagar pro time via MCP (webhook GitHub→MCP). Docs-only, zero código.

Refs: ADR 0236, ADR 0105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
