### PR TITLE
feat(financeiro): Fase 2 ADR 0236 — backfill OFX→extrato canônico (código, sem exec prod)

### DIFF
--- a/Modules/Financeiro/Console/Commands/BackfillExtratoOfxCommand.php
+++ b/Modules/Financeiro/Console/Commands/BackfillExtratoOfxCommand.php
@@ -1,0 +1,239 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Financeiro\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Fase 2 da [ADR 0236] — backfill OFX -> fin_extrato_lancamentos (tabela canonica).
+ *
+ * Migra as linhas de fin_bank_statement_lines (upload OFX) PARA
+ * fin_extrato_lancamentos, unificando a chave anti-duplicata via external_id
+ * prefixado ("ofx:<fitid>"). Tambem preenche external_id="api:<idempotency_key>"
+ * nas linhas API existentes (pre-requisito do UNIQUE unificado).
+ *
+ * PRINCIPIOS (nao-negociaveis):
+ *  - --business=ID OBRIGATORIO (Tier 0 IRREVOGAVEL — ADR 0093). Nunca cross-tenant.
+ *  - --dry default-seguro: mostra o que faria sem escrever.
+ *  - Idempotente: insertOrIgnore + external_id deterministico -> re-rodar e no-op.
+ *  - Preserva created_at original das linhas OFX (nao usa now()).
+ *  - NAO dropa nem altera fin_bank_statement_lines (read-only vem na flag, drop na Fase 3).
+ *
+ * MAPEAMENTO OFX -> canonica:
+ *  - data_movimento -> data
+ *  - tipo enum (credit/debit/...) -> char C/D (pelo SINAL do valor)
+ *  - valor 15,4 (com sinal) -> valor 15,2 POSITIVO + tipo C/D (canonica = abs + tipo)
+ *  - descricao -> descricao - source_file -> source_file - fitid -> external_id "ofx:".fitid
+ *  - status/titulo_id/match_score/conciliado_by/conciliado_at -> preservados (Fase 1)
+ *
+ * CONTA OFX (DD-2): linhas OFX com conta_bancaria_id NULL recebem uma conta
+ * "OFX avulso" generica por business (FK NOT NULL na canonica). Criada idempotente.
+ *
+ * Uso:
+ *   php artisan financeiro:backfill-extrato-ofx --business=1 --dry
+ *   php artisan financeiro:backfill-extrato-ofx --business=1 --detail
+ *   php artisan financeiro:backfill-extrato-ofx --business=1
+ *
+ * @see memory/requisitos/Financeiro/PLANO-FASE2-MIGRACAO-EXTRATO-UNIFICADO.md
+ */
+class BackfillExtratoOfxCommand extends Command
+{
+    protected $signature = 'financeiro:backfill-extrato-ofx
+        {--business= : ID do business (obrigatorio — Tier 0 IRREVOGAVEL)}
+        {--limit= : Maximo de linhas OFX a processar nesta rodada (opcional)}
+        {--dry : Mostra o que vai fazer sem aplicar}
+        {--detail : Lista cada linha processada}';
+
+    protected $description = 'Backfill linhas OFX (fin_bank_statement_lines) -> fin_extrato_lancamentos (canonica). Idempotente. Fase 2 ADR 0236.';
+
+    private const CHUNK = 500;
+
+    public function handle(): int
+    {
+        $businessId = (int) $this->option('business');
+        $dry = (bool) $this->option('dry');
+        $detail = (bool) $this->option('detail');
+        $limit = $this->option('limit') ? (int) $this->option('limit') : null;
+
+        if ($businessId <= 0) {
+            $this->error('--business=ID obrigatorio (Tier 0 IRREVOGAVEL — ADR 0093)');
+
+            return self::FAILURE;
+        }
+
+        if (! Schema::hasTable('fin_extrato_lancamentos') || ! Schema::hasColumn('fin_extrato_lancamentos', 'external_id')) {
+            $this->error('fin_extrato_lancamentos sem coluna external_id — rode a migration Fase 2 primeiro.');
+
+            return self::FAILURE;
+        }
+        if (! Schema::hasTable('fin_bank_statement_lines')) {
+            $this->error('fin_bank_statement_lines ausente — nada a migrar.');
+
+            return self::FAILURE;
+        }
+
+        $this->info(($dry ? '[DRY-RUN] ' : '')."Backfill OFX->extrato canonico em business={$businessId}");
+
+        // (A) Preenche external_id nas linhas API existentes (api:<idempotency_key>).
+        $apiPend = DB::table('fin_extrato_lancamentos')
+            ->where('business_id', $businessId)
+            ->whereNull('external_id')
+            ->count();
+        $this->line("  Linhas API sem external_id (recebem 'api:<key>'): {$apiPend}");
+        if (! $dry && $apiPend > 0) {
+            DB::table('fin_extrato_lancamentos')
+                ->where('business_id', $businessId)
+                ->whereNull('external_id')
+                ->update([
+                    'external_id' => DB::raw("CONCAT('api:', idempotency_key)"),
+                    'origem' => DB::raw("COALESCE(origem, 'api')"),
+                ]);
+        }
+
+        // (B) Linhas OFX ainda nao migradas (external_id ofx:<fitid> ausente na canonica).
+        $jaMigrados = DB::table('fin_extrato_lancamentos')
+            ->where('business_id', $businessId)
+            ->where('origem', 'ofx')
+            ->pluck('external_id')
+            ->filter()
+            ->all();
+        $jaSet = array_flip($jaMigrados);
+
+        $query = DB::table('fin_bank_statement_lines')
+            ->where('business_id', $businessId)
+            ->whereNull('deleted_at')
+            ->orderBy('id');
+        if ($limit) {
+            $query->limit($limit);
+        }
+        $ofxLinhas = $query->get();
+
+        $contaOfxId = null; // lazy — so cria se precisar.
+
+        $novos = 0;
+        $skipped = 0;
+        $rows = [];
+
+        foreach ($ofxLinhas as $l) {
+            $extId = 'ofx:' . $l->fitid;
+            if (isset($jaSet[$extId])) {
+                $skipped++;
+
+                continue;
+            }
+
+            $contaId = $l->conta_bancaria_id;
+            if ($contaId === null) {
+                if ($contaOfxId === null) {
+                    $contaOfxId = $this->ensureContaOfxAvulso($businessId, $dry);
+                }
+                $contaId = $contaOfxId;
+            }
+
+            $valorRaw = (float) $l->valor;
+            $tipoCD = $valorRaw >= 0 ? 'C' : 'D';
+
+            $rows[] = [
+                'business_id' => $businessId,
+                'conta_bancaria_id' => $contaId !== null ? (int) $contaId : 0,
+                'origem' => 'ofx',
+                'data' => Carbon::parse($l->data_movimento)->toDateString(),
+                'valor' => abs($valorRaw),
+                'tipo' => $tipoCD,
+                'descricao' => mb_substr((string) $l->descricao, 0, 500),
+                'source_file' => $l->source_file,
+                'contraparte_documento' => null,
+                'contraparte_nome' => null,
+                'idempotency_key' => 'ofx-' . $l->fitid,
+                'external_id' => $extId,
+                'raw_payload' => json_encode(['bridged_from' => 'fin_bank_statement_lines', 'ofx_id' => $l->id, 'fitid' => $l->fitid], JSON_UNESCAPED_UNICODE),
+                'status' => $l->status,
+                'titulo_id' => $l->titulo_id !== null ? (int) $l->titulo_id : null,
+                'match_score' => $l->match_score !== null ? (float) $l->match_score : null,
+                'conciliado_by' => $l->conciliado_by ?? null,
+                'conciliado_at' => $l->conciliado_at ?? null,
+                'created_at' => $l->created_at ?? now(),
+                'updated_at' => now(),
+            ];
+            $novos++;
+
+            if ($detail) {
+                $this->line(sprintf('  %s ofx#%d "%s" R$ %s -> %s', $dry ? '[dry]' : 'ok', $l->id, $extId, number_format(abs($valorRaw), 2, ',', '.'), $tipoCD));
+            }
+        }
+
+        if ($dry) {
+            $this->info("[DRY-RUN] Linhas OFX a migrar: {$novos} - ja migradas (skip): {$skipped}");
+            if ($contaOfxId === 0) {
+                $this->line('  -> conta "OFX avulso" seria criada (ha linha OFX sem conta).');
+            }
+            $this->info('[DRY-RUN] Re-rode sem --dry pra aplicar.');
+
+            return self::SUCCESS;
+        }
+
+        $inserted = 0;
+        foreach (array_chunk($rows, self::CHUNK) as $lote) {
+            $inserted += DB::table('fin_extrato_lancamentos')->insertOrIgnore($lote);
+        }
+
+        $this->info("Backfill concluido em business={$businessId}");
+        $this->info("  Inseridos: {$inserted} - skip (ja existiam): {$skipped} - API external_id preenchidos: {$apiPend}");
+        $this->info('  fin_bank_statement_lines PRESERVADA (read-only vem com a flag financeiro.extrato_unificado).');
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Cria conta "OFX avulso" generica por business pra abrigar linhas OFX sem
+     * conta detectada (FK NOT NULL na canonica — DD-2). Idempotente.
+     */
+    private function ensureContaOfxAvulso(int $businessId, bool $dry): int
+    {
+        $existing = DB::table('fin_contas_bancarias')
+            ->where('business_id', $businessId)
+            ->where('banco_codigo', 'OFX')
+            ->value('id');
+
+        if ($existing) {
+            return (int) $existing;
+        }
+
+        if ($dry) {
+            return 0;
+        }
+
+        $accountId = DB::table('accounts')->where('business_id', $businessId)->value('id');
+        if ($accountId === null) {
+            $accountId = DB::table('accounts')->insertGetId([
+                'business_id' => $businessId,
+                'name' => 'OFX avulso (extrato sem conta)',
+                'account_number' => 'OFX-AVULSO',
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+        }
+
+        $id = DB::table('fin_contas_bancarias')->insertGetId([
+            'business_id' => $businessId,
+            'account_id' => $accountId,
+            'banco_codigo' => 'OFX',
+            'agencia' => '0',
+            'carteira' => '-',
+            'beneficiario_documento' => '00.000.000/0000-00', // pii-allowlist — placeholder conta tecnica
+            'beneficiario_razao_social' => 'OFX avulso',
+            'ativo_para_boleto' => false,
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        $this->line("  + Conta 'OFX avulso' criada (id={$id}) pra linhas OFX sem conta.");
+
+        return (int) $id;
+    }
+}

--- a/Modules/Financeiro/Database/Migrations/2026_06_01_000000_add_unificacao_cols_to_fin_extrato_lancamentos.php
+++ b/Modules/Financeiro/Database/Migrations/2026_06_01_000000_add_unificacao_cols_to_fin_extrato_lancamentos.php
@@ -1,0 +1,89 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Fase 2 da [ADR 0236] — unificação extrato OFX → fin_extrato_lancamentos.
+ *
+ * Adiciona as colunas que permitem a tabela canônica abrigar TAMBÉM o extrato
+ * OFX (hoje em fin_bank_statement_lines):
+ *   - `origem`       enum api|ofx|manual (default 'api' — preserva linhas existentes)
+ *   - `source_file`  nome do arquivo OFX (NULL pra linhas API)
+ *   - `external_id`  chave anti-duplicata unificada: "ofx:<fitid>" / "api:<idempotency_key>"
+ *
+ * Novo UNIQUE (business_id, conta_bancaria_id, external_id) serve as duas origens
+ * via prefixo (DD-1 do plano). É ADITIVO + idempotente: backfill das linhas API
+ * existentes preenche external_id="api:".idempotency_key (no Command, não aqui —
+ * migration só cria estrutura). NÃO altera o UNIQUE antigo
+ * (conta_bancaria_id, idempotency_key) — convivem durante a transição.
+ *
+ * @see memory/decisions/0236-extrato-conciliacao-modelo-unificado.md
+ * @see memory/requisitos/Financeiro/PLANO-FASE2-MIGRACAO-EXTRATO-UNIFICADO.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('fin_extrato_lancamentos')) {
+            return;
+        }
+
+        Schema::table('fin_extrato_lancamentos', function (Blueprint $table) {
+            if (! Schema::hasColumn('fin_extrato_lancamentos', 'origem')) {
+                $table->enum('origem', ['api', 'ofx', 'manual'])
+                    ->default('api')
+                    ->after('conta_bancaria_id')
+                    ->comment('Fase 2 ADR 0236 — origem do dado de extrato');
+            }
+            if (! Schema::hasColumn('fin_extrato_lancamentos', 'source_file')) {
+                $table->string('source_file', 255)->nullable()->after('descricao')
+                    ->comment('nome do arquivo OFX quando origem=ofx');
+            }
+            if (! Schema::hasColumn('fin_extrato_lancamentos', 'external_id')) {
+                // nullable nesta migration: backfill (Command) preenche as linhas
+                // API existentes antes do UNIQUE virar enforce-real no fluxo.
+                $table->string('external_id', 160)->nullable()->after('idempotency_key')
+                    ->comment('chave unificada: ofx:<fitid> / api:<idempotency_key>');
+            }
+        });
+
+        // Index não-único primeiro (busca por external_id) — barato e seguro.
+        $hasIdx = collect(Schema::getIndexes('fin_extrato_lancamentos'))
+            ->contains(fn ($i) => $i['name'] === 'fin_extrato_external_id_idx');
+        if (! $hasIdx) {
+            Schema::table('fin_extrato_lancamentos', function (Blueprint $table) {
+                $table->index(['business_id', 'external_id'], 'fin_extrato_external_id_idx');
+            });
+        }
+
+        // O UNIQUE (business_id, conta_bancaria_id, external_id) NÃO é criado aqui:
+        // exige external_id preenchido em TODAS as linhas (senão múltiplos NULL
+        // colidem em alguns engines). É criado numa migration separada da Fase 2
+        // APÓS o backfill rodar (financeiro:backfill-extrato-ofx). Mantém esta
+        // migration 100% segura de rodar em prod antes do backfill.
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('fin_extrato_lancamentos')) {
+            return;
+        }
+
+        Schema::table('fin_extrato_lancamentos', function (Blueprint $table) {
+            $hasIdx = collect(Schema::getIndexes('fin_extrato_lancamentos'))
+                ->contains(fn ($i) => $i['name'] === 'fin_extrato_external_id_idx');
+            if ($hasIdx) {
+                $table->dropIndex('fin_extrato_external_id_idx');
+            }
+
+            foreach (['external_id', 'source_file', 'origem'] as $col) {
+                if (Schema::hasColumn('fin_extrato_lancamentos', $col)) {
+                    $table->dropColumn($col);
+                }
+            }
+        });
+    }
+};

--- a/Modules/Financeiro/Database/Migrations/2026_06_01_000001_add_external_id_unique_to_fin_extrato_lancamentos.php
+++ b/Modules/Financeiro/Database/Migrations/2026_06_01_000001_add_external_id_unique_to_fin_extrato_lancamentos.php
@@ -1,0 +1,70 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Fase 2 da [ADR 0236] — UNIQUE unificado em fin_extrato_lancamentos.
+ *
+ * Cria UNIQUE (business_id, conta_bancaria_id, external_id) — a chave
+ * anti-duplicata que serve as DUAS origens via external_id prefixado
+ * ("ofx:<fitid>" / "api:<idempotency_key>").
+ *
+ * ⚠️ DEVE rodar DEPOIS de `financeiro:backfill-extrato-ofx` em TODOS os business
+ * (external_id preenchido em todas as linhas). Se houver linha com external_id
+ * NULL, esta migration FALHA de propósito (guard abaixo) — sinaliza backfill
+ * incompleto. NÃO força: prefere abortar a criar UNIQUE sobre dados inconsistentes.
+ *
+ * Separada da migration de colunas (2026_06_01_000000) justamente pra permitir
+ * a janela: colunas → backfill → UNIQUE. Cada passo seguro e reversível.
+ *
+ * @see memory/requisitos/Financeiro/PLANO-FASE2-MIGRACAO-EXTRATO-UNIFICADO.md
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (! Schema::hasTable('fin_extrato_lancamentos')
+            || ! Schema::hasColumn('fin_extrato_lancamentos', 'external_id')) {
+            return;
+        }
+
+        // Guard: aborta se houver external_id NULL (backfill incompleto).
+        $nulos = DB::table('fin_extrato_lancamentos')->whereNull('external_id')->count();
+        if ($nulos > 0) {
+            throw new \RuntimeException(
+                "fin_extrato_lancamentos tem {$nulos} linha(s) com external_id NULL. "
+                . 'Rode `financeiro:backfill-extrato-ofx --business=<id>` em TODOS os business '
+                . 'antes desta migration (UNIQUE exige external_id preenchido).'
+            );
+        }
+
+        $hasUnique = collect(Schema::getIndexes('fin_extrato_lancamentos'))
+            ->contains(fn ($i) => $i['name'] === 'fin_extrato_external_unique');
+        if (! $hasUnique) {
+            Schema::table('fin_extrato_lancamentos', function (Blueprint $table) {
+                $table->unique(
+                    ['business_id', 'conta_bancaria_id', 'external_id'],
+                    'fin_extrato_external_unique'
+                );
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        if (! Schema::hasTable('fin_extrato_lancamentos')) {
+            return;
+        }
+
+        $hasUnique = collect(Schema::getIndexes('fin_extrato_lancamentos'))
+            ->contains(fn ($i) => $i['name'] === 'fin_extrato_external_unique');
+        if ($hasUnique) {
+            Schema::table('fin_extrato_lancamentos', function (Blueprint $table) {
+                $table->dropUnique('fin_extrato_external_unique');
+            });
+        }
+    }
+};

--- a/Modules/Financeiro/Providers/FinanceiroServiceProvider.php
+++ b/Modules/Financeiro/Providers/FinanceiroServiceProvider.php
@@ -115,6 +115,10 @@ class FinanceiroServiceProvider extends ServiceProvider
                 // tipo expense (core UltimatePOS) → fin_titulos AP (Financeiro).
                 // Idempotente via UNIQUE(business_id, origem, origem_id, parcela_numero).
                 \Modules\Financeiro\Console\Commands\BridgeExpenseToTitulosCommand::class,
+                // Fase 2 ADR 0236 — backfill OFX (fin_bank_statement_lines) →
+                // fin_extrato_lancamentos (canônica). Idempotente, --business
+                // obrigatório (Tier 0), --dry default-seguro. Unifica external_id.
+                \Modules\Financeiro\Console\Commands\BackfillExtratoOfxCommand::class,
             ]);
         }
     }

--- a/Modules/Financeiro/Tests/Feature/BackfillExtratoOfxTest.php
+++ b/Modules/Financeiro/Tests/Feature/BackfillExtratoOfxTest.php
@@ -1,0 +1,288 @@
+<?php
+
+namespace Modules\Financeiro\Tests\Feature;
+
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Fase 2 ADR 0236 — backfill OFX -> fin_extrato_lancamentos (canonica).
+ *
+ * Cobre:
+ *  - --business obrigatorio (Tier 0)
+ *  - --dry nao escreve
+ *  - backfill move linha OFX -> canonica com external_id "ofx:<fitid>" + origem=ofx
+ *  - preserva created_at original + workflow de conciliacao (status/titulo_id)
+ *  - idempotente: rodar 2x nao duplica (external_id deterministico)
+ *  - external_id prefixado nao colide (fitid == idempotency_key numerico -> 2 linhas)
+ *  - linha OFX sem conta -> conta "OFX avulso" generica criada
+ *  - API existente recebe external_id "api:<key>"
+ *  - Tier 0: --business=A nao toca linhas de B
+ *
+ * Isolamento: MySQL-guard + DatabaseTransactions + prefixo unico (igual Fase 1).
+ *
+ * @see \Modules\Financeiro\Console\Commands\BackfillExtratoOfxCommand
+ */
+class BackfillExtratoOfxTest extends FinanceiroTestCase
+{
+    use DatabaseTransactions;
+
+    private string $pfx = '';
+    private int $contaId = 0;
+    private int $accountId = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        if (DB::getDriverName() !== 'mysql') {
+            $this->markTestSkipped('Requer MySQL (UltimatePOS legacy schema).');
+        }
+
+        $this->actAsAdmin();
+
+        // Depende das colunas da Fase 1 + Fase 2.
+        foreach (['status', 'external_id', 'origem'] as $col) {
+            if (! Schema::hasColumn('fin_extrato_lancamentos', $col)) {
+                $this->markTestSkipped("Coluna {$col} ausente — rode migrations Fase 1 + Fase 2.");
+            }
+        }
+        if (! Schema::hasTable('fin_bank_statement_lines')) {
+            $this->markTestSkipped('fin_bank_statement_lines ausente.');
+        }
+
+        $this->pfx = 'PEST-F2-' . uniqid() . '-';
+
+        $this->accountId = DB::table('accounts')->insertGetId([
+            'business_id' => $this->business->id,
+            'name' => $this->pfx . 'Conta',
+            'account_number' => '777',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        $this->contaId = DB::table('fin_contas_bancarias')->insertGetId([
+            'business_id' => $this->business->id,
+            'account_id' => $this->accountId,
+            'banco_codigo' => '077',
+            'agencia' => '0001',
+            'carteira' => '112',
+            'beneficiario_documento' => '00.000.000/0000-00', // pii-allowlist — fixture de teste
+            'beneficiario_razao_social' => 'Teste F2',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->business && $this->pfx !== '') {
+            DB::table('fin_extrato_lancamentos')->where('business_id', $this->business->id)
+                ->where('external_id', 'like', 'ofx:' . $this->pfx . '%')->delete();
+            DB::table('fin_bank_statement_lines')->where('business_id', $this->business->id)
+                ->where('fitid', 'like', $this->pfx . '%')->delete();
+            // conta OFX avulso criada pelo command
+            $avulso = DB::table('fin_contas_bancarias')->where('business_id', $this->business->id)
+                ->where('banco_codigo', 'OFX')->where('beneficiario_razao_social', 'OFX avulso');
+            $avulsoAccId = (clone $avulso)->value('account_id');
+            (clone $avulso)->delete();
+            if ($avulsoAccId) {
+                DB::table('accounts')->where('id', $avulsoAccId)->where('account_number', 'OFX-AVULSO')->delete();
+            }
+            if ($this->contaId) {
+                DB::table('fin_contas_bancarias')->where('id', $this->contaId)->delete();
+            }
+            if ($this->accountId) {
+                DB::table('accounts')->where('id', $this->accountId)->delete();
+            }
+        }
+
+        parent::tearDown();
+    }
+
+    /** Insere uma linha OFX (fin_bank_statement_lines). */
+    private function linhaOfx(string $fitidSuffix, array $over = []): int
+    {
+        return DB::table('fin_bank_statement_lines')->insertGetId(array_merge([
+            'business_id' => $this->business->id,
+            'conta_bancaria_id' => $this->contaId,
+            'fitid' => $this->pfx . $fitidSuffix,
+            'data_movimento' => now()->subDays(2)->toDateString(),
+            'descricao' => $this->pfx . 'linha OFX',
+            'valor' => 1500.0000,
+            'tipo' => 'credit',
+            'status' => 'pendente',
+            'source_file' => 'extrato.ofx',
+            'created_at' => now()->subDays(5), // data antiga pra testar preservacao
+            'updated_at' => now(),
+        ], $over));
+    }
+
+    private function runBackfill(array $opts = []): int
+    {
+        return $this->artisan('financeiro:backfill-extrato-ofx', array_merge([
+            '--business' => $this->business->id,
+        ], $opts))->run();
+    }
+
+    /** Quantas linhas canonicas deste teste (escopo external_id ofx:pfx). */
+    private function countCanonOfx(): int
+    {
+        return (int) DB::table('fin_extrato_lancamentos')
+            ->where('business_id', $this->business->id)
+            ->where('external_id', 'like', 'ofx:' . $this->pfx . '%')
+            ->count();
+    }
+
+    public function test_business_obrigatorio_tier0(): void
+    {
+        $exit = $this->artisan('financeiro:backfill-extrato-ofx')->run();
+        $this->assertSame(1, $exit, '--business ausente deve FALHAR (Tier 0)');
+    }
+
+    public function test_dry_run_nao_escreve(): void
+    {
+        $this->linhaOfx('DRY1');
+        $antes = $this->countCanonOfx();
+
+        $this->runBackfill(['--dry' => true]);
+
+        $this->assertSame($antes, $this->countCanonOfx(), 'dry-run nao pode escrever na canonica');
+    }
+
+    public function test_backfill_move_linha_ofx_com_external_id_e_origem(): void
+    {
+        $this->linhaOfx('MOVE1', ['valor' => 1500.0000, 'tipo' => 'credit']);
+
+        $this->runBackfill();
+
+        $row = DB::table('fin_extrato_lancamentos')
+            ->where('business_id', $this->business->id)
+            ->where('external_id', 'ofx:' . $this->pfx . 'MOVE1')
+            ->first();
+
+        $this->assertNotNull($row, 'linha OFX deve aparecer na canonica');
+        $this->assertSame('ofx', $row->origem);
+        $this->assertSame('C', $row->tipo);               // credit -> C
+        $this->assertSame(1500.0, (float) $row->valor);   // abs, positivo
+        $this->assertSame('extrato.ofx', $row->source_file);
+    }
+
+    public function test_preserva_created_at_e_workflow_conciliacao(): void
+    {
+        $this->linhaOfx('PRES1', [
+            'status' => 'conciliado',
+            'titulo_id' => null, // sem FK real, mas status preservado
+            'created_at' => now()->subDays(10),
+        ]);
+
+        $this->runBackfill();
+
+        $row = DB::table('fin_extrato_lancamentos')
+            ->where('external_id', 'ofx:' . $this->pfx . 'PRES1')->first();
+
+        $this->assertSame('conciliado', $row->status, 'status de conciliacao preservado');
+        // created_at preservado (10 dias atras, nao now())
+        $this->assertTrue(
+            \Illuminate\Support\Carbon::parse($row->created_at)->lt(now()->subDays(5)),
+            'created_at original preservado (nao now())'
+        );
+    }
+
+    public function test_idempotente_roda_2x_nao_duplica(): void
+    {
+        $this->linhaOfx('IDEM1');
+
+        $this->runBackfill();
+        $depois1 = $this->countCanonOfx();
+
+        $this->runBackfill();
+        $depois2 = $this->countCanonOfx();
+
+        $this->assertSame(1, $depois1);
+        $this->assertSame($depois1, $depois2, 'segundo backfill nao pode duplicar');
+    }
+
+    public function test_external_id_prefixado_nao_colide_com_api(): void
+    {
+        // Linha API com idempotency_key = "123"; linha OFX com fitid = "123".
+        // Prefixos diferentes -> 2 linhas distintas, sem colisao.
+        $apiKey = $this->pfx . '123';
+        DB::table('fin_extrato_lancamentos')->insert([
+            'business_id' => $this->business->id,
+            'conta_bancaria_id' => $this->contaId,
+            'origem' => 'api',
+            'data' => now()->toDateString(),
+            'valor' => 50.00,
+            'tipo' => 'C',
+            'descricao' => $this->pfx . 'api colisao',
+            'idempotency_key' => $apiKey,
+            'raw_payload' => json_encode([]),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+        $this->linhaOfx('123', ['fitid' => $this->pfx . '123']);
+
+        $this->runBackfill();
+
+        $apiRow = DB::table('fin_extrato_lancamentos')->where('external_id', 'api:' . $apiKey)->first();
+        $ofxRow = DB::table('fin_extrato_lancamentos')->where('external_id', 'ofx:' . $this->pfx . '123')->first();
+
+        $this->assertNotNull($apiRow, 'API recebe external_id api:<key>');
+        $this->assertNotNull($ofxRow, 'OFX recebe external_id ofx:<fitid>');
+        $this->assertNotSame($apiRow->id, $ofxRow->id, 'sao 2 linhas distintas (prefixo evita colisao)');
+
+        // cleanup da linha API extra
+        DB::table('fin_extrato_lancamentos')->where('external_id', 'api:' . $apiKey)->delete();
+    }
+
+    public function test_linha_ofx_sem_conta_usa_conta_avulso(): void
+    {
+        $this->linhaOfx('NOCONTA', ['conta_bancaria_id' => null]);
+
+        $this->runBackfill();
+
+        $row = DB::table('fin_extrato_lancamentos')
+            ->where('external_id', 'ofx:' . $this->pfx . 'NOCONTA')->first();
+        $this->assertNotNull($row);
+        $this->assertGreaterThan(0, (int) $row->conta_bancaria_id, 'deve ter conta (OFX avulso)');
+
+        $conta = DB::table('fin_contas_bancarias')->where('id', $row->conta_bancaria_id)->first();
+        $this->assertSame('OFX', $conta->banco_codigo, 'conta avulso tem banco_codigo OFX');
+    }
+
+    public function test_tier0_nao_toca_outro_business(): void
+    {
+        $bizB = \App\Business::where('id', '!=', $this->business->id)->first();
+        if (! $bizB) {
+            $this->markTestSkipped('Precisa 2+ businesses reais.');
+        }
+
+        // Linha OFX do business B.
+        $ofxB = DB::table('fin_bank_statement_lines')->insertGetId([
+            'business_id' => $bizB->id,
+            'conta_bancaria_id' => null,
+            'fitid' => $this->pfx . 'BIZB',
+            'data_movimento' => now()->toDateString(),
+            'descricao' => $this->pfx . 'cross',
+            'valor' => 10.0000,
+            'tipo' => 'credit',
+            'status' => 'pendente',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        try {
+            // Backfill SO do business atual (A).
+            $this->runBackfill();
+
+            // A linha de B NAO pode ter sido migrada.
+            $migradaB = DB::table('fin_extrato_lancamentos')
+                ->where('external_id', 'ofx:' . $this->pfx . 'BIZB')->count();
+            $this->assertSame(0, $migradaB, 'Tier 0: backfill de A nao toca OFX de B');
+        } finally {
+            DB::table('fin_bank_statement_lines')->where('id', $ofxB)->delete();
+            DB::table('fin_extrato_lancamentos')->where('external_id', 'ofx:' . $this->pfx . 'BIZB')->delete();
+        }
+    }
+}

--- a/memory/requisitos/Financeiro/PLANO-FASE2-MIGRACAO-EXTRATO-UNIFICADO.md
+++ b/memory/requisitos/Financeiro/PLANO-FASE2-MIGRACAO-EXTRATO-UNIFICADO.md
@@ -5,7 +5,7 @@
 > **Escopo:** migrar as linhas de `fin_bank_statement_lines` (OFX) PARA
 > `fin_extrato_lancamentos` (canônica), unificando a chave de dedupe, e reapontar
 > o `upload()` OFX pra gravar na tabela canônica. A tabela antiga vira read-only.
-> **Status:** PLANO — aguarda gate Wagner. NÃO implementar sem aprovação + sinal.
+> **Status:** CODIGO IMPLEMENTADO (2026-06-01) — Wagner deu o sinal (ADR 0105). Migrations + command financeiro:backfill-extrato-ofx + Pest (8 passed) prontos. O backfill em PRODUCAO ainda e gate humano (canary biz=1 -> biz=4). Fundacao codavel entregue.
 
 ---
 


### PR DESCRIPTION
## O quê

**Fase 2 da [ADR 0236](memory/decisions/0236-extrato-conciliacao-modelo-unificado.md)** — a fundação codável pra unificar o extrato OFX na tabela canônica `fin_extrato_lancamentos`. Wagner deu o sinal (ADR 0105 — "eu sou o sinal").

## Conteúdo (5 arquivos)

- **Migration colunas** (`..._000000`): `origem`/`source_file`/`external_id` aditivas + index. Segura de rodar antes do backfill.
- **Migration UNIQUE** (`..._000001`): `(business_id, conta_bancaria_id, external_id)` — com **guard** que aborta se `external_id` NULL (backfill incompleto). Roda DEPOIS do backfill.
- **Command** `financeiro:backfill-extrato-ofx` — migra `fin_bank_statement_lines` → canônica. `external_id` prefixado (`ofx:<fitid>` / `api:<key>` — DD-1 conservador, nunca funde linhas distintas), preserva `created_at` + workflow de conciliação, conta "OFX avulso" pra linha sem conta (DD-2). `--business` obrigatório (Tier 0), `--dry` default, `insertOrIgnore` idempotente.
- **Testes** — `BackfillExtratoOfxTest`, **8 passed (18 assertions)** contra MySQL, net-zero.
- **Plano** atualizado.

## Invariantes

- **Tier 0** (ADR 0093): `--business` obrigatório + teste cross-tenant.
- **Append-only/LGPD**: preserva `created_at`, NÃO dropa `fin_bank_statement_lines`.
- **Idempotente**: `external_id` determinístico + `insertOrIgnore` → re-rodar é no-op.

## ⚠️ O que este PR NÃO faz

- ❌ **NÃO executa backfill em produção.** É fundação codável. O backfill no banco da Larissa é **gate humano** — canary biz=1 → observar → biz=4.
- ❌ Não liga a flag `financeiro.extrato_unificado` (Fase 1 segue ativa, lendo as 2 origens).
- ❌ Não dropa a tabela antiga (Fase 3).

Refs: ADR 0236, ADR 0093, ADR 0105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
