### PR TITLE
feat(jana): health-check alerta recall backend down (resiliência Meilisearch) + Pest

### DIFF
--- a/Modules/Jana/Console/Commands/HealthCheckCommand.php
+++ b/Modules/Jana/Console/Commands/HealthCheckCommand.php
@@ -27,7 +27,10 @@ use Modules\Jana\Services\CharterHealthChecker;
  *   8. Whatsapp media pending 1h (Guardião 6 Camada 6) — mídia órfã > 1h
  *   9. MCP webhook 5xx 2h (US-FIN-043 incident 2026-05-21) — webhook GitHub
  *      retornando 5xx nas últimas 2h indica drift no DB sync (tasks/memory)
- *  10-15. Charter/loop health (ADVISORY · CharterHealthChecker, PROTOCOL §6) —
+ *  10. Memoria recall backend (resiliência Meilisearch) — MCP/Meilisearch
+ *      reachable; alerta ANTES da degradação silenciosa (chat responde sem
+ *      recall, NÃO estoura 500). McpMemoriaDriver já degrada gracioso.
+ *  11-16. Charter/loop health (ADVISORY · CharterHealthChecker, PROTOCOL §6) —
  *      charter_missing, charter_stale (>90d), charter_refs_broken,
  *      charter_method_missing, readme_handoff_block_missing (L-18),
  *      design_return_skipped (retorno §10.2 atrás do SYNC_LOG · G4).
@@ -45,7 +48,7 @@ class HealthCheckCommand extends Command
                             {--json : Output JSON em vez de tabela}
                             {--notify : Loga ALERT em jana-health channel se algo falhou}';
 
-    protected $description = 'Health check diário Jana + Constituição v2 (9 checks SQL + 6 charter/loop advisory)';
+    protected $description = 'Health check diário Jana + Constituição v2 (10 checks SQL + 6 charter/loop advisory)';
 
     public function handle(): int
     {
@@ -59,6 +62,7 @@ class HealthCheckCommand extends Command
             $this->checkSpecIdDrift(),
             $this->checkWhatsappMediaPending1h(),
             $this->checkMcpWebhookHealth2h(),
+            $this->checkMemoriaRecallBackend(),
             // Charter health (advisory — não falha exit/cron). PROTOCOL §6.
             ...CharterHealthChecker::fromApp()->checks(),
         ];
@@ -568,6 +572,75 @@ class HealthCheckCommand extends Command
                 'value' => null,
                 'threshold' => 0,
                 'message' => 'ERRO: ' . $e->getMessage(),
+            ];
+        }
+    }
+
+    /**
+     * Check 10 — Memoria recall backend (resiliência Meilisearch, ponto único de falha).
+     *
+     * O recall (tool `memoria-search`) é servido pelo MCP server CT 100 que consulta
+     * Meilisearch. Se Meilisearch/MCP cai, o McpMemoriaDriver degrada SILENCIOSAMENTE
+     * (retorna [] → chat responde sem memória, NÃO estoura 500). Bom pro usuário,
+     * cego pro ops. Este check é o alarme: prova reachability 1×/dia e alerta ANTES
+     * de alguém perceber "a Jana esqueceu tudo". Check DURO (não-advisory): recall
+     * down derruba o exit code e dispara o ALERT de cron.
+     *
+     * Skip silencioso em dev/CI (sem COPILOTO_MCP_SYSTEM_TOKEN → fallback local,
+     * não há backend remoto pra checar).
+     *
+     * @see Modules/Jana/Services/Memoria/McpMemoriaDriver.php (degradação graciosa)
+     */
+    protected function checkMemoriaRecallBackend(): array
+    {
+        $name = 'memoria_recall_backend';
+        $url = (string) config('copiloto.mcp.url', 'https://mcp.oimpresso.com/api/mcp');
+        $token = (string) config('copiloto.mcp.system_token', env('COPILOTO_MCP_SYSTEM_TOKEN', ''));
+
+        // Sem token = ambiente sem recall remoto (dev/CI). Não é falha — pula.
+        if ($url === '' || $token === '') {
+            return [
+                'name' => $name,
+                'ok' => true,
+                'value' => 'n/a',
+                'threshold' => 'reachable',
+                'message' => 'Skipped (recall MCP não configurado — dev/CI usa fallback local)',
+            ];
+        }
+
+        try {
+            $response = \Illuminate\Support\Facades\Http::withToken($token, 'Bearer')
+                ->withHeaders(['Content-Type' => 'application/json', 'Accept' => 'application/json'])
+                ->timeout((int) config('copiloto.mcp.timeout_seconds', 5))
+                ->post($url, [
+                    'jsonrpc' => '2.0',
+                    'id' => 1,
+                    'method' => 'tools/call',
+                    'params' => [
+                        'name' => 'memoria-search',
+                        'arguments' => ['query' => 'health', 'business_id' => 1, 'limit' => 1],
+                    ],
+                ]);
+
+            $ok = $response->ok();
+
+            return [
+                'name' => $name,
+                'ok' => $ok,
+                'value' => $ok ? 'up' : (string) $response->status(),
+                'threshold' => 'reachable',
+                'message' => $ok
+                    ? 'Recall backend (MCP/Meilisearch) respondendo — memória ativa'
+                    : "ALERTA: recall backend não-OK ({$response->status()}) — chat degrada SEM memória (não estoura 500). Checar MCP server + Meilisearch CT 100.",
+            ];
+        } catch (\Throwable $e) {
+            return [
+                'name' => $name,
+                'ok' => false,
+                'value' => 'down',
+                'threshold' => 'reachable',
+                'message' => 'ALERTA: recall backend inacessível (' . mb_substr($e->getMessage(), 0, 80)
+                    . ') — chat degrada SEM memória. Checar Meilisearch/MCP CT 100.',
             ];
         }
     }

--- a/Modules/Jana/Tests/Feature/Memoria/RecallDegradationTest.php
+++ b/Modules/Jana/Tests/Feature/Memoria/RecallDegradationTest.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Http;
+use Modules\Jana\Services\Memoria\McpMemoriaDriver;
+
+uses(Tests\TestCase::class);
+
+/**
+ * TAREFA 3 (resiliência Meilisearch) — provar + apertar o que já existe.
+ *
+ * Meilisearch é ponto único de falha do recall (tool `memoria-search` via MCP).
+ * Comportamento canon: se cai, o McpMemoriaDriver degrada SILENCIOSAMENTE
+ * (retorna [] → chat responde sem memória, NÃO estoura 500). Estes testes:
+ *   1. PROVAM a degradação graciosa do driver (chat não estoura).
+ *   2. PROVAM que `jana:health-check` agora ALERTA antes da degradação silenciosa.
+ *
+ * @see Modules/Jana/Services/Memoria/McpMemoriaDriver.php
+ * @see Modules/Jana/Console/Commands/HealthCheckCommand.php (checkMemoriaRecallBackend)
+ */
+
+// ── Helper — roda o health-check e extrai só o check do recall backend ──────────
+function janaRecallBackendCheck(): ?array
+{
+    Artisan::call('jana:health-check', ['--json' => true]);
+    $out = Artisan::output();
+    $start = strpos($out, '{');
+    if ($start === false) {
+        return null;
+    }
+    $json = json_decode(substr($out, $start), true);
+
+    return collect($json['checks'] ?? [])->firstWhere('name', 'memoria_recall_backend');
+}
+
+// ── Driver: degradação graciosa (chat não estoura) ─────────────────────────────
+
+test('McpMemoriaDriver degrada: backend 5xx → buscar() retorna [] (chat responde sem recall, não estoura)', function () {
+    config([
+        'copiloto.mcp.url' => 'https://mcp.test/api/mcp',
+        'copiloto.mcp.system_token' => 'sys-token',
+        'copiloto.mcp.timeout_seconds' => 2,
+    ]);
+    Http::fake(['mcp.test/*' => Http::response('upstream error', 503)]);
+
+    $driver = new McpMemoriaDriver();
+
+    expect($driver->buscar(1, 1, 'como foi meu faturamento', 5))->toBe([]);
+});
+
+test('McpMemoriaDriver degrada: exceção de conexão (timeout) → buscar() retorna [] sem estourar', function () {
+    config([
+        'copiloto.mcp.url' => 'https://mcp.test/api/mcp',
+        'copiloto.mcp.system_token' => 'sys-token',
+        'copiloto.mcp.timeout_seconds' => 2,
+    ]);
+    Http::fake(function () {
+        throw new \Illuminate\Http\Client\ConnectionException('connection timed out after 2000ms');
+    });
+
+    $driver = new McpMemoriaDriver();
+
+    expect($driver->buscar(1, 1, 'qualquer query', 5))->toBe([]);
+});
+
+test('McpMemoriaDriver sem token: pula recall e retorna [] (não estoura)', function () {
+    config([
+        'copiloto.mcp.url' => 'https://mcp.test/api/mcp',
+        'copiloto.mcp.system_token' => '',
+    ]);
+    Http::fake(); // nenhuma chamada deve sair
+
+    $driver = new McpMemoriaDriver();
+
+    expect($driver->buscar(1, 1, 'q', 5))->toBe([]);
+    Http::assertNothingSent();
+});
+
+// ── Health-check: alarme antes da degradação silenciosa ────────────────────────
+
+test('jana:health-check ALERTA quando recall backend está down', function () {
+    config([
+        'copiloto.mcp.url' => 'https://mcp.test/api/mcp',
+        'copiloto.mcp.system_token' => 'sys-token',
+        'copiloto.mcp.timeout_seconds' => 2,
+    ]);
+    Http::fake(['mcp.test/*' => Http::response('meilisearch down', 503)]);
+
+    $check = janaRecallBackendCheck();
+
+    expect($check)->not->toBeNull();
+    expect($check['ok'])->toBeFalse();
+    expect($check['message'])->toContain('ALERTA');
+});
+
+test('jana:health-check OK quando recall backend responde', function () {
+    config([
+        'copiloto.mcp.url' => 'https://mcp.test/api/mcp',
+        'copiloto.mcp.system_token' => 'sys-token',
+        'copiloto.mcp.timeout_seconds' => 2,
+    ]);
+    Http::fake(['mcp.test/*' => Http::response(['jsonrpc' => '2.0', 'id' => 1, 'result' => ['content' => []]], 200)]);
+
+    $check = janaRecallBackendCheck();
+
+    expect($check)->not->toBeNull();
+    expect($check['ok'])->toBeTrue();
+});
+
+test('jana:health-check pula recall em dev/CI sem token MCP (não é falha)', function () {
+    config([
+        'copiloto.mcp.url' => 'https://mcp.test/api/mcp',
+        'copiloto.mcp.system_token' => '',
+    ]);
+
+    $check = janaRecallBackendCheck();
+
+    expect($check)->not->toBeNull();
+    expect($check['ok'])->toBeTrue();
+    expect($check['value'])->toBe('n/a');
+});

--- a/Modules/Jana/Tests/Feature/Smoke/JanaHealthCheckTest.php
+++ b/Modules/Jana/Tests/Feature/Smoke/JanaHealthCheckTest.php
@@ -36,9 +36,11 @@ test('--json output tem shape canonico', function () {
         ->toHaveKey('checked_at')
         ->toHaveKey('checks');
 
-    // 8 checks: multi_tenant, brief_uptime, custo_brain_b, pii_leak,
-    // profile_drift, procedure_drift, spec_id_drift, whatsapp_media_pending_1h.
-    expect($json['checks'])->toBeArray()->toHaveCount(8);
+    // ≥10 checks duros (SQL/operacionais) + N charter/loop advisory (dinâmico via
+    // CharterHealthChecker). Não cravamos count exato porque os advisory variam —
+    // a presença dos duros é garantida no teste abaixo.
+    expect($json['checks'])->toBeArray();
+    expect(count($json['checks']))->toBeGreaterThanOrEqual(10);
 });
 
 test('cada check tem campos canonicos', function () {
@@ -46,7 +48,10 @@ test('cada check tem campos canonicos', function () {
     $output = \Illuminate\Support\Facades\Artisan::output();
     $json = json_decode(substr($output, strpos($output, '{')), true);
 
-    $namesEsperados = [
+    // Checks DUROS obrigatórios (operacionais). Os charter/loop advisory entram
+    // a mais (dinâmico via CharterHealthChecker), por isso checamos presença
+    // (subset), não igualdade exata.
+    $duros = [
         'multi_tenant_isolation',
         'brief_uptime_24h',
         'custo_brain_b_24h',
@@ -55,10 +60,12 @@ test('cada check tem campos canonicos', function () {
         'procedure_drift',
         'spec_id_drift',
         'whatsapp_media_pending_1h',
+        'mcp_webhook_5xx_2h',
+        'memoria_recall_backend',
     ];
 
     $namesReais = array_column($json['checks'], 'name');
-    expect($namesReais)->toEqualCanonicalizing($namesEsperados);
+    expect(array_diff($duros, $namesReais))->toBe([]);
 
     foreach ($json['checks'] as $check) {
         expect($check)


### PR DESCRIPTION
## O que é (TAREFA 3 — champion-maker IA)

Provar + apertar o que já existe, **sem recriar** (handoff §10.4 PASSO 0: re-ancorado em `origin/main` fresco).

Meilisearch é ponto único de falha do recall (tool `memoria-search` via MCP server CT 100). O `McpMemoriaDriver` **já degrada gracioso** (backend down → `buscar()` retorna `[]` → chat responde sem memória, **NÃO estoura 500**), mas a queda era **silenciosa** pro ops.

## Mudanças

- **`HealthCheckCommand`** — check 10 `memoria_recall_backend` (DURO, não-advisory): prova reachability 1×/dia e **ALERTA antes da degradação silenciosa**. Convive com os checks charter/loop advisory já existentes. Skip silencioso em dev/CI (sem `COPILOTO_MCP_SYSTEM_TOKEN`).
- **`RecallDegradationTest`** (novo Pest) — prova a degradação graciosa do driver (5xx / timeout / sem-token → `[]` sem estourar) + o alarme do health-check (down→ALERTA, up→ok, dev→skip).
- **`JanaHealthCheckTest`** (smoke) — assertions robustas (`count>=10` + **subset** dos checks duros, incl. `mcp_webhook_5xx_2h` e `memoria_recall_backend`) que toleram os charter advisory dinâmicos. Corrige brittleness pré-existente (cravava 8 enquanto o comando já tinha 9+).

## Escopo

- ✅ Aditivo puro (sem dinheiro/infra) → autônomo, 1 branch = 1 PR.
- ⛔ **Tier 0** (réplica/HA do Meilisearch, se exigir custo) — documentado, espera [W]. Não incluído.
- Multi-tenant Tier 0 preservado (ADR 0093). Sem efeito colateral (probe read-only 1×/dia).

## Verificação

- `php -l` limpo · `RecallDegradationTest` rodou **6/6 verde** na base equivalente (o código do check é idêntico).
- Smoke com assertions robustas (sempre verdes com o check presente + ≥10 checks).
- Base = `main` (rebase limpo) · diff = **3 arquivos**.

> ⚠️ Nota honesta: a validação local final foi na base equivalente — rodar o código do worktree direto esbarra no autoload absoluto do vendor. A suíte completa roda no CI (modelo "CI verde → merge" do handoff).

Refs: handoff IA champion-makers (Avaliação de Estrutura de IA 2026-06-01), ADR 0093

🤖 Generated with [Claude Code](https://claude.com/claude-code)