### PR TITLE
fix(otel): provider compatível com SDK atual + Pest provando o boot (T1.b)

### DIFF
--- a/app/Providers/OtelServiceProvider.php
+++ b/app/Providers/OtelServiceProvider.php
@@ -59,9 +59,43 @@ class OtelServiceProvider extends ServiceProvider
 
     private function bootTracerProvider(): void
     {
+        $tracerProvider = $this->buildTracerProvider();
+
+        // `registerInitializer` mudou de assinatura: recebe um Configurator e
+        // devolve o Configurator com o TracerProvider setado (não mais `fn () => $tp`).
+        // É ISTO que liga o tracer GLOBAL que o OtelHelper::span consome — o boot
+        // antigo registrava um closure inválido e o global nunca era configurado.
+        \OpenTelemetry\API\Globals::registerInitializer(
+            fn (\OpenTelemetry\API\Instrumentation\Configurator $configurator) => $configurator->withTracerProvider($tracerProvider)
+        );
+    }
+
+    /**
+     * Constrói o TracerProvider SDK (resource + processor + sampler + exporter).
+     *
+     * Exporter injetável (default OTLP HTTP pro endpoint configurado) pra que o
+     * Pest possa provar o pipeline com InMemoryExporter sem rede.
+     *
+     * Compat de API do SDK (2026-06-01 T1.b — o boot quebrava silenciosamente):
+     *   - `ResourceAttributes::DEPLOYMENT_ENVIRONMENT` foi REMOVIDA no sem-conv
+     *     >=1.27 (renomeada p/ deployment.environment.name). Usar a chave literal
+     *     estável `deployment.environment` evita o "Undefined constant".
+     *   - `BatchSpanProcessor::__construct` passou a exigir um clock (2º arg).
+     *     `::builder($exporter)->build()` encapsula o default — version-stable.
+     */
+    public function buildTracerProvider(
+        ?\OpenTelemetry\SDK\Trace\SpanExporterInterface $exporter = null
+    ): \OpenTelemetry\SDK\Trace\TracerProviderInterface {
         // Endpoint compat: nova chave `otel.endpoint` + legacy US-WA-083 `otel.exporter.endpoint`.
-        $endpoint = (string) (config('otel.endpoint')
-            ?? config('otel.exporter.endpoint', 'http://mcp.oimpresso.com:4318/v1/traces'));
+        if ($exporter === null) {
+            $endpoint = (string) (config('otel.endpoint')
+                ?? config('otel.exporter.endpoint', 'http://mcp.oimpresso.com:4318/v1/traces'));
+
+            $transport = (new \OpenTelemetry\Contrib\Otlp\OtlpHttpTransportFactory())
+                ->create($endpoint, 'application/x-protobuf');
+
+            $exporter = new \OpenTelemetry\Contrib\Otlp\SpanExporter($transport);
+        }
 
         // Sample rate compat: novo `otel.sample_rate` + legacy `otel.sampling.local_sampler_ratio`.
         $sampleRate = (float) (config('otel.sample_rate')
@@ -71,33 +105,24 @@ class OtelServiceProvider extends ServiceProvider
         $serviceName = (string) (config('otel.service_name')
             ?? config('otel.service.name', 'oimpresso'));
 
-        $transport = (new \OpenTelemetry\Contrib\Otlp\OtlpHttpTransportFactory())
-            ->create($endpoint, 'application/x-protobuf');
-
-        $exporter = new \OpenTelemetry\Contrib\Otlp\SpanExporter($transport);
-
         $resource = \OpenTelemetry\SDK\Resource\ResourceInfo::create(
             \OpenTelemetry\SDK\Common\Attribute\Attributes::create([
                 \OpenTelemetry\SemConv\ResourceAttributes::SERVICE_NAME => $serviceName,
                 \OpenTelemetry\SemConv\ResourceAttributes::SERVICE_VERSION => (string) (config('otel.service.version') ?? '1.0.0'),
-                \OpenTelemetry\SemConv\ResourceAttributes::DEPLOYMENT_ENVIRONMENT => (string) config('app.env', 'production'),
+                'deployment.environment' => (string) config('app.env', 'production'),
                 'oimpresso.runtime' => $this->detectRuntime(),
             ])
         );
 
-        $tracerProvider = \OpenTelemetry\SDK\Trace\TracerProvider::builder()
+        return \OpenTelemetry\SDK\Trace\TracerProvider::builder()
             ->addSpanProcessor(
-                new \OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor($exporter)
+                \OpenTelemetry\SDK\Trace\SpanProcessor\BatchSpanProcessor::builder($exporter)->build()
             )
             ->setSampler(
                 new \OpenTelemetry\SDK\Trace\Sampler\TraceIdRatioBasedSampler($sampleRate)
             )
             ->setResource($resource)
             ->build();
-
-        \OpenTelemetry\API\Globals::registerInitializer(
-            fn () => $tracerProvider
-        );
     }
 
     /**

--- a/tests/Feature/Otel/OtelServiceProviderTest.php
+++ b/tests/Feature/Otel/OtelServiceProviderTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Providers\OtelServiceProvider;
+
+// tests/Feature/ já recebe Tests\TestCase via tests/Pest.php (não duplicar uses()).
+
+/**
+ * Regressão do bug T1.b (descoberto 2026-06-01): o OTel NUNCA exportou em prod.
+ *
+ * O OtelServiceProvider foi escrito contra uma API antiga do SDK e quebrava no
+ * boot — caindo silenciosamente pro NoopTracerProvider (try/catch → Log::warning):
+ *   1. `ResourceAttributes::DEPLOYMENT_ENVIRONMENT` foi REMOVIDA no sem-conv >=1.27
+ *   2. `BatchSpanProcessor::__construct` passou a exigir um clock (2º arg)
+ *
+ * Como NENHUM teste exercia o caminho com `otel.enabled=true`, o CI ficava verde
+ * e o drift passou despercebido. Este teste fecha o gap: prova que o provider
+ * constrói um TracerProvider SDK real e que um span chega no exporter.
+ *
+ * O SDK OTel vive em `require-dev` → presente no CI/dev. Em prod `--no-dev` o SDK
+ * some e o provider faz no-op (Gate 3 `class_exists`), daí o skip defensivo.
+ */
+
+test('buildTracerProvider monta o pipeline SDK e exporta o span (não cai em Noop)', function () {
+    config([
+        'otel.enabled' => true,
+        'otel.sdk_disabled' => false,
+        'otel.sample_rate' => 1.0, // 100% — determinístico (5% poderia não amostrar 1 span)
+        'otel.service_name' => 'oimpresso-test',
+    ]);
+
+    $exporter = new \OpenTelemetry\SDK\Trace\SpanExporter\InMemoryExporter();
+
+    $tracerProvider = (new OtelServiceProvider(app()))->buildTracerProvider($exporter);
+
+    // Antes do fix isto era NoopTracerProvider (boot falhava).
+    expect($tracerProvider)->not->toBeInstanceOf(\OpenTelemetry\API\Trace\NoopTracerProvider::class);
+
+    $span = $tracerProvider->getTracer('test')->spanBuilder('test.t1b.span')->startSpan();
+    $span->end();
+    $tracerProvider->forceFlush();
+
+    $spans = $exporter->getSpans();
+    expect($spans)->toHaveCount(1);
+    expect($spans[0]->getName())->toBe('test.t1b.span');
+})->skip(
+    ! class_exists(\OpenTelemetry\API\Globals::class),
+    'OTel SDK ausente (prod --no-dev) — provider faz no-op'
+);


### PR DESCRIPTION
## O bug (latente, descoberto ligando o OTel)

**O OTel NUNCA exportou em prod.** O `OtelServiceProvider` foi escrito contra uma API antiga do SDK e **quebrava no boot**, caindo silenciosamente pro `NoopTracerProvider` (try/catch → `Log::warning`). Como **nenhum teste exercia `otel.enabled=true`**, o CI ficava verde e o drift passou despercebido.

Descoberto ligando o OTel no CT 100 (2026-06-01 T1.b): Jaeger já roda há 2 semanas + SDK baked na imagem, mas os traces não fluíam. Diagnóstico in-container: `tracerProvider = NoopTracerProvider` + `[OTEL] boot falhou` no log.

## Fixes (API do SDK instalado — sdk 1.14.0, sem-conv 1.38.0)

| Break | Fix |
|---|---|
| `ResourceAttributes::DEPLOYMENT_ENVIRONMENT` removida (sem-conv >=1.27) | chave literal estável `'deployment.environment'` |
| `BatchSpanProcessor::__construct` passou a exigir um clock (2o arg) | `::builder($exporter)->build()` (encapsula o default) |
| boot não-testável | extraído `buildTracerProvider()` público com exporter injetável |

## Teste

`tests/Feature/Otel/OtelServiceProviderTest.php` — prova o pipeline real: **build → span → InMemoryExporter** (não-Noop, 1 span exportado). Verde local + CI. SDK em `require-dev` → CI testa; prod `--no-dev` faz no-op (skip defensivo).

## Infra Contract

**Mudança:** fix do `OtelServiceProvider` (observabilidade interna). **Não há mudança de comportamento HTTP em prod** — em prod `OTEL_ENABLED=false` → provider no-op (Gate 1); no Hostinger o SDK nem está instalado (`--no-dev`, Gate 3). Logo, não há endpoint prod novo pra smoke via curl.

**Validação prod:**
- Pest prova o pipeline real (build → span → InMemoryExporter, não-Noop) — verde local + CI (`PHP / Pest` pass).
- Diagnóstico in-container no CT 100 (2026-06-01) confirmou o bug (`tracerProvider=NoopTracerProvider` + `[OTEL] boot falhou`) e foi revertido pro estado limpo (`otel.enabled=false`, health 200).
- Reversível e gated: o flip de ativação (`OTEL_ENABLED=true` no CT 100) continua Tier 0 do [W]; este PR só conserta o provider pra que, quando ligado, exporte de verdade.

<!-- evidence-override: provider OTel e observabilidade interna no-op em prod (gated OTEL_ENABLED=false / SDK ausente --no-dev); validado por Pest pipeline + diagnostico CT 100, sem endpoint HTTP prod afetado -->

Refs: handoff IA champion-makers T1.b · config/otel.php · app/Util/OtelHelper.php

🤖 Generated with [Claude Code](https://claude.com/claude-code)
