### PR TITLE
docs(design): proibições no-dup + trilha-do-tempo p/ artefato de design (handoff metricas.html)

### DIFF
--- a/memory/proibicoes.md
+++ b/memory/proibicoes.md
@@ -160,6 +160,7 @@
 - ⛔ **Tasks NÃO em markdown.** Estado vivo via tools MCP (`cycles-active`, `tasks-list`) — CURRENT.md/TASKS.md REMOVIDOS ([ADR 0070](decisions/0070-jira-style-task-management-current-md-removed.md))
 - ⛔ **NUNCA pular `brief-fetch` no início de sessão** — Tier A bloqueador via skill `brief-first` (custo trivial ~3k tokens, cache 5min, economiza ~27k tokens de exploração). Sintoma de degradação clássico: Claude começa a trabalhar via `my-work`/`tasks-list`/Read sem ter chamado brief antes → opera com dados parciais → gera plano duplicado. Catalogado sessão 2026-05-13 (Claude gerou plano de paralelização de backlog que duplicava ROADMAP existente porque não tinha brief). Auditável: se hoje você (Claude) não chamou `brief-fetch` antes de outra tool MCP/Read no início, é violação.
 - ⛔ **NUNCA criar arquivo em `memory/` sem `Glob`/`Grep` antes** pra checar duplicação. Especialmente: session logs (`memory/sessions/YYYY-MM-DD-*.md`), planos por módulo (`memory/requisitos/<Mod>/*.md`), ADRs (`memory/decisions/*.md`). Se já existe similar, EDITA o existente — não cria novo. Catalogado sessão 2026-05-13.
+- ⛔ **Artefato de DESIGN** (`.html`/protótipo/relatório *meta* do Cowork) **segue as mesmas duas regras acima** — não-duplicação (1 tema = 1 doc; edita o existente, nunca `vN.html`) + append-only/trilha-do-tempo (rodapé de evolução + lápide ao arquivar). Versão escopada + exemplos em [`prototipo-ui/CLAUDE_DESIGN_BRIEFING.md §7.1`](../prototipo-ui/CLAUDE_DESIGN_BRIEFING.md). Origem: Cowork 2026-06-01 (L-21/L-22).
 
 ## Comportamento Claude (sessão)
 

--- a/prototipo-ui/CLAUDE_DESIGN_BRIEFING.md
+++ b/prototipo-ui/CLAUDE_DESIGN_BRIEFING.md
@@ -146,6 +146,13 @@ Referências canon:
 - ❌ **Emoji em UI productiva** — só lucide-react icons
 - ❌ **Texto explicativo verbose** ("Bem-vindo! Aqui você pode...") — direto ao ponto
 
+### 7.1 Estrutura & evolução (artefato de design)
+
+> Espelha pra **design** as duas regras canônicas de [`memory/proibicoes.md`](../memory/proibicoes.md) — referencia, **não duplica**: *não-duplicação* ("NUNCA criar arquivo … sem `Glob`/`Grep` … edita o existente") e *append-only* ("ADRs CANON são append-only"). Origem: 2 HTMLs de governança duplicados no Cowork (2026-06-01).
+
+- ❌ **Criar `.html`/artefato de design novo sem checar duplicação antes** (`Glob`/grep do tema). Tela/módulo/**variação** de ERP = rota ou Tweak (`useTweaks`) no **layout único do shell**, nunca arquivo novo. Relatório/avaliação *meta* = **1 tema = 1 doc**; se já existe irmão, **edita o existente** — **nunca `vN.html`**. _(L-21.)_
+- ❌ **Mover/consolidar artefato sem deixar trilha.** Todo artefato vivo (HTML de app/relatório, doc canônico) carrega **no fim** um bloco `Trilha do tempo` **append-only** (`data · o que mudou · o que supersedeu · → pra onde o anterior foi arquivado`); ao mover, deixa **lápide** na origem ou em `_arquivo/<pasta>/INDEX.md` (origem→destino + substituto). Nada some sem rastro legível. _(Concretiza L-07 · L-22.)_
+
 ## 8. Output esperado por fase
 
 ### F1 (você produz protótipo)

--- a/prototipo-ui/CODE_NOTES.md
+++ b/prototipo-ui/CODE_NOTES.md
@@ -144,3 +144,22 @@ Detalhes: ADR 0242 e evolucao/aplicacao de 0079/0094/0238/0241 (nao reescrita). 
 
 ### FICA [W]
 - #1 G4: PR Tier 0 aguarda merge [W]. #4 auditoria aguarda go.
+
+---
+
+## 2026-06-01 [CL] → [W] — Handoff `metricas.html` (Cowork→Code): regras de design no git
+
+### Origem: bundle Cowork "oimpresso-erp-comunicação-visual" (chat33 · `metricas.html`). [W]: "implemente os aspectos relevantes do design".
+### Status: Regras 1+2 traduzidas · Regra 3 N/A (justificado) · **aguarda merge [W]** (Tier 0)
+### Diff: branch `docs/design-no-dup-trilha` → PR
+
+**Passo 0 (vs `origin/main` fresco):** bundle estava stale — Jana Pro `#2069` e o prep dos 3 Tier 0 de IA `#2073` JÁ em `main` (o bundle dizia "⏸️ não disparar"). Cada item batido contra o `main` antes de agir (L-09).
+
+- **Regra 1 — no-duplicação de design (L-21) → ✅** bullet em `CLAUDE_DESIGN_BRIEFING §7.1`, referenciando o pai em `proibicoes.md` (não duplica).
+- **Regra 2 — trilha do tempo / lápide (L-22) → ✅** bullet em `§7.1` + 1 forward-ref em `proibicoes.md` (Memória/governança).
+- **Regra 3 — rename shell `Oimpresso ERP - Chat.html` → `oimpresso.com.html` → ⏭️ N/A.** Não há shell vivo no repo: esse HTML só existe em pastas-snapshot (`_arquivo/`, `cowork-2026-05-26-…/`) — o repo guarda bundles Cowork como snapshots datados, não 1 HTML vivo. `metricas.html` é Cowork-local (não vai pro repo, por decisão sua no chat33). Nada a renomear.
+
+### Adaptação §10.4 (não copiei literal): o bullet usa "layout único do shell" em vez de citar `Oimpresso ERP - Chat.html` (inexistente no repo).
+
+### FICA [W]
+- Proibição/design = Tier 0 = **seu merge**. Não auto-mergeei.


### PR DESCRIPTION
## O que é

Processa o **handoff Cowork→Code** do bundle `metricas.html` (chat33 do bundle "oimpresso-erp-comunicação-visual"). [W] pediu: *"implemente os aspectos relevantes do design"*.

`metricas.html` é um hub Cowork **não-canon** (relatórios meta Governança/IA/Diagnóstico) — por decisão sua no chat33, **fica Cowork-local, não vira tela**. O que o Cowork ([CC]) preparou pra normalizar no git são **2 regras de design** desta sessão.

## Mudanças (aditivas, doc-only — 27 inserções)

| Arquivo | Mudança |
|---|---|
| `prototipo-ui/CLAUDE_DESIGN_BRIEFING.md` | **§7.1 novo**: ❌ no-duplicação de design (1 tema = 1 doc, nunca `vN.html` · L-21) + ❌ trilha-do-tempo/lápide (rodapé append-only · L-22) |
| `memory/proibicoes.md` | 1 forward-ref (Memória/governança) → BRIEFING §7.1 (referencia os pais, **não duplica**) |
| `prototipo-ui/CODE_NOTES.md` | retorno [CL]→[W] (§10.2) |

## Passo 0 (§10.4 — validado vs `origin/main` fresco)

- Bundle estava **stale**: Jana Pro `#2069` + prep dos 3 Tier 0 de IA `#2073` JÁ em `main` (o bundle dizia "⏸️ não disparar"). Cada item batido contra o `main` antes de agir (L-09).
- **Regra 3** (rename shell `Oimpresso ERP - Chat.html` → `oimpresso.com.html`) = **N/A**: não há shell vivo no repo (só snapshots datados em `_arquivo/`, `cowork-2026-05-26-…/`). Nada a renomear. `metricas.html` não vai pro repo.

## Por que aguarda você

Proibição/design = **Tier 0**. Conforme o protocolo do handoff + skill `publication-policy`: [CL] valida + propõe; **[W] mergeia**. Não auto-mergeei.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
