### PR TITLE
feat(design): gerador design:review por tela (charter page viva) + gate de frescor [Tier 0 · espera W]

### DIFF
--- a/memory/decisions/proposals/design-review-por-tela-charter-page.md
+++ b/memory/decisions/proposals/design-review-por-tela-charter-page.md
@@ -1,0 +1,95 @@
+---
+status: proposed
+date: 2026-06-01
+deciders: [Wagner]
+mãe: [0114, 0236, 0239]
+relacionadas: [0110, 0209, 0235]
+tags: [design, loop-cowork-code, governanca, charter, ratchet]
+# Número da ADR é cunhado POR [W] no merge (soberania da constituição — ADR 0238).
+# [CL] NÃO atribui número de git (lição L-09 / 0200-0201).
+---
+
+# (proposta) Gerador `design:review` por tela — charter page viva + gatilho de frescor
+
+## Status
+
+**Proposta** (§10.4 — evolução do PROTOCOL do loop Cowork↔Code). Tier 0: abre PR e
+**espera [W]** (PROTOCOL/constituição-adjacente = não auto-merge). Origem: [W] 2026-06-01
+— *"vai precisar criar uma automatização para gerar um relatório com tarefas para você…
+compare com os melhores, dê nota e o porquê, documente o que falta, faça o champion.
+acredito que deveria ser no charter page?"* (após confirmar Jana Pro F3 feito, sem `Pro.review.md`).
+
+## Contexto
+
+A máquina de auditoria de tela **já existe meio-construída** (anti L-11 — estender, não recriar):
+
+- `prototipo-ui/audit/score-mechanized.mjs` — **Fase 1** (regex R1-R10 mecanizáveis + `ds/*`),
+  1 `design-report.json`/tela, com `measured_against_sha`.
+- `consolidate.mjs` → `CONSOLIDADO.md` (placar worst-first, média 86/100).
+- `design-report.schema.json` (já com `top_gaps{dim,best_of_class,fix,esforco}`).
+- `<Tela>.review.md` append-only ao lado do `<Tela>.charter.md`.
+- `GOLDEN-REFERENCE.md` (10 regras) + `CharterHealthChecker`.
+
+**4 gaps reais** (confirmados vs `origin/main` 2026-06-01):
+
+1. **Fase 2 LLM nunca rodou em escala** → R5/R8/R10 + nota holística + `best_of_class` vazios (nota = só conformidade-DS, mascarável).
+2. **`<Tela>.review.md` é one-off de 2026-05-17, nunca regenerado** → tela nova nasce SEM relatório de tarefas. **Caso vivo: `Jana/Pro` (#2069)** tem `.tsx` + `.charter.md` `status: live`, mas **nenhum** `Pro.review.md` (toda outra tela Jana tem review round 1).
+3. **Sem gatilho de frescor** → nada regenera o review quando o `.tsx` muda (`design_return_skipped`/G4 cobre `SYNC_LOG`, não review-vs-sha-da-tela).
+4. Charter + review + benchmark vivem em 3 arquivos soltos, não numa **charter page única**.
+
+## Decisão
+
+Formalizar o **review por tela** como artefato canônico da **charter page viva** (charter = spec;
+review = nota viva + backlog de tarefas + benchmark), e o seu **frescor** como gate ratchet:
+
+**(a) Canal de retorno F1.5/F3.5→F0 no nível da TELA.** Hoje o §10.2 só retorna no nível da
+worklist-DS. O `<Tela>.review.md` round N (append-only) passa a ser o retorno por TELA: o bloco
+"Top recomendações" É o backlog de tarefas do `[CC]`/`[CL]` pra aquela tela.
+
+**(b) PROTOCOL §6 ganha 2 checks** (já emendados neste PR):
+- `design_review_missing` — tela charter `status: live` sem `.review.md` **fora** do baseline → falha.
+- `design_review_stale` — `.review.md` com `measured_against_sha` ≠ sha do último commit do `.tsx`
+  → **advisory na v1** (reviews legados de 2026-05-17 não têm o campo), vira HARD ao regenerar.
+
+**(c) A charter page viva é o artefato canônico** — `<Tela>.charter.md` + `<Tela>.review.md`
+lado a lado. O rollup CROSS-tela continua no `CONSOLIDADO.md`/Governança, não na charter page.
+
+### Implementação (entregue neste PR — Fase 1, autônoma; Fase 2 = ratchet pago [W])
+
+| Peça | Papel | Natureza |
+|---|---|---|
+| `prototipo-ui/audit/review-gen.mjs` | `design:review <tela>` — renderiza o `design-report.json` (Fase 1) num `<Tela>.review.md` append-only, ancorado por `measured_against_sha`; puxa guardrails Tier 0 do charter (Non-Goals/Anti-hooks) | aditivo |
+| `review-freshness.mjs` | gate node (missing/stale/fresh) + ratchet `--write-baseline` | aditivo |
+| `review-freshness-baseline.json` | dívida herdada (21 telas live sem review em 2026-06-01); só encolhe | aditivo |
+| `tests/Feature/Design/DesignReviewFreshnessTest.php` | espelha o gate em PHP (roda no CT 100) | aditivo |
+| `resources/js/Pages/Jana/Pro.review.md` | **1ª execução** — fecha o gap do `Jana/Pro` | aditivo |
+| `npm run design:review[:check|:baseline]` | atalhos | aditivo |
+
+**Fase 2 (juiz LLM)** — preenche R5/R8/R10 + nota holística + `best_of_class`/`fix`/`esforco`;
+cadência real-mode na régua que **[W] paga** (espelha o gate RAGAS da IA). Ratchet: nota só sobe
+(ADR 0236). **Fora deste PR** (custo/infra = Tier 0).
+
+## Consequências
+
+**Boas:** tela nova não nasce mais sem relatório de tarefas (o teste pega); o backlog de design
+fica versionado ao lado da tela; frescor é evidência reproduzível (sha), não opinião; estende a
+máquina existente (zero duplicação).
+
+**Custo/risco:** a Fase 1 é só conformidade-DS (a nota é **teto provisório** — `Jana/Pro` = 88
+mecanizado, mas tem `oklch(...)` cru + gradient 135° que a Fase 2 precisa julgar). O `design_review_stale`
+fica advisory até os reviews legados serem regenerados (senão o gate nasce vermelho — anti
+"subir régua que quebra o próprio CI", lição RAGAS).
+
+## Benchmark (best-of-class — por que isto é "champion")
+
+SonarQube/Code Climate (gate por arquivo) · CodeRabbit/Danger (PR review) · Chromatic/Percy
+(visual-regression) · Linear (project health) · RAGAS (ratchet) · Storybook Docs/Figma Dev Mode
+(spec ao lado do componente). O `<Tela>.charter.md` + `<Tela>.review.md` = o "Storybook Docs +
+SonarQube gate" do oimpresso, versionado em git e auditado por Pest.
+
+## Refs
+
+- `prototipo-ui/audit/{review-gen,review-freshness,score-mechanized,consolidate}.mjs` · `GOLDEN-REFERENCE.md`
+- `prototipo-ui/PROTOCOL.md §6` (checks) · §10.2 (retorno) — emendados neste PR
+- ADR 0114 (loop Cowork↔Code) · 0236 (ratchet nota-só-sobe) · 0239 (SSOT do DS) · 0209 (eslint-baseline ratchet) · 0238 (soberania [W])
+- COWORK_NOTES → "Gerador `design:review`" (handoff 2026-06-01)

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "stylelint:baseline:check": "node scripts/stylelint-baseline.mjs",
     "ds:report": "node scripts/ds-report.mjs",
     "ds:report:write": "node scripts/ds-report.mjs --write",
+    "design:review": "node prototipo-ui/audit/review-gen.mjs",
+    "design:review:check": "node prototipo-ui/audit/review-freshness.mjs",
+    "design:review:baseline": "node prototipo-ui/audit/review-freshness.mjs --write-baseline",
     "test": "vitest run",
     "test:watch": "vitest"
   },

--- a/prototipo-ui/PROTOCOL.md
+++ b/prototipo-ui/PROTOCOL.md
@@ -98,8 +98,12 @@ A adicionar em `php artisan jana:health-check`:
 | `design_critique_skipped` | conta `prototipos/*/critique-score.json` ausentes | ≥1 protótipo sem critique |
 | `design_a11y_skipped` | conta merges sem `a11y-report.md` no path | ≥1 merge sem a11y |
 | `design_loop_active_count` | conta entradas `HANDOFF.md` em fase ≠ done | informativo |
+| `design_review_missing` | tela charter `status: live` sem `<Tela>.review.md` **fora** do `review-freshness-baseline.json` (ratchet) — `node prototipo-ui/audit/review-freshness.mjs` | ≥1 (tela nova nasceu sem review) |
+| `design_review_stale` | `<Tela>.review.md` cujo `measured_against_sha` ≠ sha do último commit que tocou o `.tsx` | informativo na v1 (advisory) · vira ≥1 ao hardenizar o ratchet |
 
 Falha → ALERT em `storage/logs/laravel.log`.
+
+> Os 2 checks `design_review_*` (charter page viva — o `<Tela>.review.md` é o relatório de tarefas por tela ao lado do `.charter.md`) são gerados por `prototipo-ui/audit/review-gen.mjs` (`npm run design:review <Mod/Tela>`) e auditados por `review-freshness.mjs` (`npm run design:review:check`) + `tests/Feature/Design/DesignReviewFreshnessTest.php`. Ratchet = `review-freshness-baseline.json` (espelha `config/eslint-baseline.json`, ADR 0209): só FALHA por tela live nova fora do baseline; o baseline só encolhe. Ver proposta `memory/decisions/proposals/design-review-por-tela-charter-page.md` (evolução do loop · mãe 0114/0236/0239).
 
 ## 7. Como lidar com batch (várias telas relacionadas)
 

--- a/prototipo-ui/audit/README.md
+++ b/prototipo-ui/audit/README.md
@@ -64,6 +64,31 @@ NÃO escreva mais nada. NÃO consolide. 1 arquivo por tela.
 | [`example.design-report.json`](example.design-report.json) | 1 exemplo versionado (amostra do schema) |
 | [`consolidate.mjs`](consolidate.mjs) | Determinístico: lê `reports/` → `CONSOLIDADO.md` + `CONSOLIDADO.json` |
 | `CONSOLIDADO.md` | Placar único versionado (gerado — Cowork lê daqui; nunca editado à mão) |
+| [`review-gen.mjs`](review-gen.mjs) | **`design:review <tela>`** — renderiza o `design-report.json` (Fase 1) num `<Tela>.review.md` append-only ao lado do `<Tela>.charter.md` (charter page viva), ancorado por `measured_against_sha` |
+| [`review-freshness.mjs`](review-freshness.mjs) | Gate de **frescor** (missing/stale/fresh) + ratchet `--write-baseline`. Espelha o Pest `DesignReviewFreshnessTest` |
+| `review-freshness-baseline.json` | Ratchet (espelha `config/eslint-baseline.json`) — dívida herdada de telas live sem review; **só encolhe** |
+
+## Review por tela (charter page viva) — `design:review`
+
+A Fase 1 cospe `reports/*.design-report.json` (gitignored, regenerável). Pra virar **relatório de
+tarefas versionado por tela**, o `review-gen.mjs` renderiza esse report num `<Tela>.review.md`
+append-only **ao lado do `<Tela>.charter.md`** (= charter page viva: spec + nota viva + backlog).
+
+```bash
+npm run design:review Jana/Pro        # gera/append round N em resources/js/Pages/Jana/Pro.review.md
+npm run design:review:check           # gate: tela live sem review (fora do baseline) = falha
+npm run design:review:baseline        # (re)grava o ratchet review-freshness-baseline.json
+```
+
+**Frescor (anti-stale):** cada `<Tela>.review.md` carrega `measured_against_sha` = sha do último
+commit que tocou o `.tsx`. `review-freshness.mjs` compara e classifica `fresh`/`stale`/`missing`.
+Ratchet (espelha `config/eslint-baseline.json`, ADR 0209): só falha por tela live **nova** fora do
+baseline; o baseline **só encolhe** (ao gerar o review, rode `--write-baseline` pra podar).
+
+`stale` é **advisory na v1** (reviews legados de 2026-05-17 não têm `measured_against_sha`); vira
+HARD quando regenerados. PROTOCOL §6 ganha `design_review_missing` + `design_review_stale`. A
+**Fase 2 (juiz LLM)** preenche R5/R8/R10 + nota holística + `best_of_class` — cadência paga [W].
+Proposta: [`memory/decisions/proposals/design-review-por-tela-charter-page.md`](../../memory/decisions/proposals/design-review-por-tela-charter-page.md).
 
 ## Calibração & honestidade (v1, 2026-05-31)
 

--- a/prototipo-ui/audit/review-freshness-baseline.json
+++ b/prototipo-ui/audit/review-freshness-baseline.json
@@ -1,0 +1,28 @@
+{
+  "_doc": "Ratchet de frescor de review por tela (espelha config/eslint-baseline.json · ADR 0209). Dívida HERDADA de reviews ausentes em telas `status: live`. O gate (review-freshness.mjs / DesignReviewFreshnessTest) só FALHA por uma tela live NOVA fora desta lista. A lista só ENCOLHE: ao gerar o review (review-gen.mjs), rode --write-baseline pra podar. NUNCA adicionar tela à mão.",
+  "generated_against_sha": "43c9ce563",
+  "missing": [
+    "Admin/ScreenReviewDashboard",
+    "Cliente/Index",
+    "Financeiro/Caixa/Index",
+    "Financeiro/Cobranca/Index",
+    "Financeiro/Conciliacao/Index",
+    "Financeiro/Dre/Index",
+    "Home/Index",
+    "RecurringBilling/Configuracoes/Index",
+    "RecurringBilling/Faturas/Index",
+    "RecurringBilling/Index",
+    "RecurringBilling/Planos/Create",
+    "RecurringBilling/Planos/Edit",
+    "RecurringBilling/Planos/Index",
+    "Settings/PaymentGateways/Index",
+    "Whatsapp/Settings",
+    "governance/Audit",
+    "governance/Dashboard",
+    "governance/DriftAlerts",
+    "governance/ModuleGrades/Index",
+    "governance/ModuleGrades/Show",
+    "governance/Policies"
+  ],
+  "stale_advisory_count": 36
+}

--- a/prototipo-ui/audit/review-freshness.mjs
+++ b/prototipo-ui/audit/review-freshness.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+// review-freshness.mjs — gatilho de FRESCOR do review por tela (gap #3 da fila Cowork).
+//
+// Pergunta canônica (COWORK_NOTES → "Gerador design:review", resposta direta ao [W]
+// "qual teste/automatização?"): toda `Pages/<Mod>/<Tela>.tsx` com charter `status: live`
+// tem um `<Tela>.review.md` cujo `measured_against_sha` == sha do ÚLTIMO commit que tocou
+// o `.tsx`? Senão = **missing** (sem review) ou **stale** (review velho vs a tela mudou).
+//
+// Espelha em NODE a lógica do Pest `DesignReviewFreshnessTest` (testes rodam no CT 100,
+// não localmente — feedback #2076). Roda local: é a EVIDÊNCIA reproduzível por terceiro.
+//
+// Ratchet (mesmo padrão de `config/eslint-baseline.json`, ADR 0209): a dívida pré-existente
+// vive em `review-freshness-baseline.json`; o gate só falha por uma tela NOVA fora do baseline
+// (anti-regressão), nunca pela dívida herdada. `stale` é ADVISORY na v1 (reviews legados de
+// 2026-05-17 não têm o campo sha) — vira HARD quando regenerados (proposta ADR).
+//
+// Uso:
+//   node prototipo-ui/audit/review-freshness.mjs               # checa (exit 1 se regressão)
+//   node prototipo-ui/audit/review-freshness.mjs --json        # saída JSON
+//   node prototipo-ui/audit/review-freshness.mjs --write-baseline  # (re)grava o baseline
+
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname, basename, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, '..', '..');
+const PAGES = join(REPO, 'resources/js/Pages');
+const BASELINE = join(HERE, 'review-freshness-baseline.json');
+const norm = (p) => p.replace(/\\/g, '/');
+const argv = process.argv.slice(2);
+const FLAG = (f) => argv.includes(f);
+
+function gitSha(absFile) {
+  try {
+    const rel = norm(relative(REPO, absFile));
+    return execSync(`git log -1 --format=%h -- "${rel}"`, { cwd: REPO }).toString().trim() || 'sem-commit';
+  } catch { return 'sem-commit'; }
+}
+
+function fmField(src, key) {
+  const m = src.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!m) return null;
+  const r = m[1].match(new RegExp(`^${key}:\\s*(.*)$`, 'm'));
+  return r ? r[1].trim() : null;
+}
+
+function walkCharters(dir, acc = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walkCharters(p, acc);
+    else if (name.endsWith('.charter.md')) acc.push(p);
+  }
+  return acc;
+}
+
+// classifica cada tela live em fresh / stale / missing.
+function audit() {
+  const fresh = [], stale = [], missing = [];
+  for (const ch of walkCharters(PAGES)) {
+    const src = readFileSync(ch, 'utf8');
+    if (fmField(src, 'status') !== 'live') continue; // só telas live
+    const dir = dirname(ch);
+    const base = basename(ch, '.charter.md');
+    const tsx = join(dir, `${base}.tsx`);
+    if (!existsSync(tsx)) continue; // charter órfã sem tela — fora de escopo deste gate
+    const screen = norm(relative(PAGES, join(dir, base)));
+    const review = join(dir, `${base}.review.md`);
+    if (!existsSync(review)) { missing.push(screen); continue; }
+    const recorded = fmField(readFileSync(review, 'utf8'), 'measured_against_sha');
+    const last = gitSha(tsx);
+    if (recorded && recorded === last) fresh.push(screen);
+    else stale.push({ screen, recorded: recorded || '(sem campo)', last });
+  }
+  return { fresh: fresh.sort(), stale: stale.sort((a, b) => a.screen.localeCompare(b.screen)), missing: missing.sort() };
+}
+
+function loadBaseline() {
+  if (!existsSync(BASELINE)) return { missing: [], stale_advisory_count: 0 };
+  try { return JSON.parse(readFileSync(BASELINE, 'utf8')); } catch { return { missing: [], stale_advisory_count: 0 }; }
+}
+
+function main() {
+  const res = audit();
+
+  if (FLAG('--write-baseline')) {
+    let sha = 'unknown';
+    try { sha = execSync('git rev-parse --short HEAD', { cwd: REPO }).toString().trim(); } catch {}
+    const baseline = {
+      _doc: 'Ratchet de frescor de review por tela (espelha config/eslint-baseline.json · ADR 0209). '
+        + 'Dívida HERDADA de reviews ausentes em telas `status: live`. O gate (review-freshness.mjs / '
+        + 'DesignReviewFreshnessTest) só FALHA por uma tela live NOVA fora desta lista. A lista só ENCOLHE: '
+        + 'ao gerar o review (review-gen.mjs), rode --write-baseline pra podar. NUNCA adicionar tela à mão.',
+      generated_against_sha: sha,
+      missing: res.missing,
+      stale_advisory_count: res.stale.length,
+    };
+    writeFileSync(BASELINE, JSON.stringify(baseline, null, 2) + '\n', 'utf8');
+    console.log(`[freshness] baseline gravado: ${res.missing.length} missing (herdado) · ${res.stale.length} stale (advisory) · sha ${sha}`);
+    return;
+  }
+
+  const baseline = loadBaseline();
+  const baselineMissing = new Set(baseline.missing || []);
+  const newMissing = res.missing.filter((s) => !baselineMissing.has(s)); // regressão = missing fora do baseline
+
+  if (FLAG('--json')) {
+    console.log(JSON.stringify({ ...res, new_missing: newMissing, baseline_missing: baseline.missing || [] }, null, 2));
+  } else {
+    console.log(`[freshness] live: ${res.fresh.length} fresh · ${res.stale.length} stale (advisory) · ${res.missing.length} missing (${baselineMissing.size} no baseline)`);
+    if (res.fresh.length) console.log(`  fresh: ${res.fresh.join(', ')}`);
+    if (res.stale.length) console.log(`  stale (ADVISORY — regenerar via review-gen.mjs): ${res.stale.map((s) => `${s.screen}[${s.recorded}≠${s.last}]`).join(', ')}`);
+    if (newMissing.length) {
+      console.error(`\n[freshness] ✗ FALHA: ${newMissing.length} tela(s) live SEM review e FORA do baseline (regressão):`);
+      for (const s of newMissing) console.error(`  - ${s} → rode: node prototipo-ui/audit/review-gen.mjs ${s}`);
+    }
+  }
+
+  if (newMissing.length) process.exit(1);
+  console.log('[freshness] OK — nenhuma regressão de frescor (missing ⊆ baseline).');
+}
+
+main();

--- a/prototipo-ui/audit/review-gen.mjs
+++ b/prototipo-ui/audit/review-gen.mjs
@@ -1,0 +1,309 @@
+#!/usr/bin/env node
+// review-gen.mjs — `design:review <tela>` · gerador DETERMINÍSTICO do `<Tela>.review.md`.
+//
+// Fecha o gap #2 da fila Cowork (COWORK_NOTES → "Gerador design:review"): o
+// `<Tela>.review.md` era one-off de 2026-05-17 e nunca era regenerado → tela nova
+// (ex: Jana/Pro) nascia SEM relatório de tarefas. Este script ESTENDE a máquina já
+// existente (NÃO recria — anti L-11):
+//   - score-mechanized.mjs  → Fase 1 (regex R1..R10 + ds/*), 1 design-report.json/tela
+//   - ESTE script           → renderiza o report num `<Tela>.review.md` append-only,
+//                             ancorado por `measured_against_sha` (anti-stale, gap #3)
+//   - consolidate.mjs       → rollup cross-tela (inalterado)
+//
+// É a "charter page viva": charter (spec) + review (nota viva + backlog de tarefas).
+// A Fase 2 (juiz LLM: R5/R8/R10 + nota holística + best_of_class) é refino pago [W];
+// este gerador entrega o backlog mecanizado SOZINHO, custo zero de agente.
+//
+// Uso:
+//   node prototipo-ui/audit/review-gen.mjs Jana/Pro          # 1 tela (lógico)
+//   node prototipo-ui/audit/review-gen.mjs resources/js/Pages/Jana/Pro.tsx
+//   node prototipo-ui/audit/review-gen.mjs --missing-live    # bootstrap: só telas live sem review
+
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs';
+import { join, dirname, basename, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, '..', '..');
+const PAGES = join(REPO, 'resources/js/Pages');
+const REPORTS = join(HERE, 'reports');
+
+const argv = process.argv.slice(2);
+const FLAG = (f) => argv.includes(f);
+const norm = (p) => p.replace(/\\/g, '/');
+
+// ── helpers de descoberta ─────────────────────────────────────────────────────
+
+function gitSha(absFile) {
+  try {
+    const rel = norm(relative(REPO, absFile));
+    const out = execSync(`git log -1 --format=%h -- "${rel}"`, { cwd: REPO }).toString().trim();
+    return out || 'sem-commit';
+  } catch {
+    return 'sem-commit';
+  }
+}
+
+// frontmatter mínimo (sem dep externa): pega `chave: valor` do bloco --- ... ---.
+function frontmatter(src) {
+  const m = src.match(/^---\s*\n([\s\S]*?)\n---/);
+  if (!m) return {};
+  const fm = {};
+  for (const line of m[1].split('\n')) {
+    const kv = line.match(/^([A-Za-z_][\w-]*):\s*(.*)$/);
+    if (kv) fm[kv[1]] = kv[2].trim();
+  }
+  return fm;
+}
+
+// extrai bullets `- ❌ ...` de uma seção cujo heading começa com `## <titulo>`,
+// até o próximo heading `## ` (varredura por linha — NÃO usa `$`/flag-m, que com
+// multiline casa fim-de-LINHA e truncava a seção no 1º bullet).
+function sectionBullets(src, titulo) {
+  const head = new RegExp(`^##+\\s*${titulo}`, 'i');
+  let inSec = false;
+  const buf = [];
+  for (const ln of src.split('\n')) {
+    if (head.test(ln)) { inSec = true; continue; }
+    if (inSec && /^##\s/.test(ln)) break; // próximo heading fecha a seção
+    if (inSec) buf.push(ln);
+  }
+  return [...buf.join('\n').matchAll(/^\s*-\s*❌\s*(.+)$/gm)].map((x) => x[1].trim());
+}
+
+// localiza o RUNBOOK DA TELA (não do módulo): memory/requisitos/<Mod>/RUNBOOK-<base>.md
+// (case-insensitive, aceita sufixo). Sem match exato da tela → null (anti-falso-positivo:
+// NÃO atribui o RUNBOOK de outra tela só por estar no mesmo módulo).
+function findRunbook(modulo, base) {
+  const dir = join(REPO, 'memory/requisitos', modulo);
+  if (!existsSync(dir) || !base) return null;
+  try {
+    const re = new RegExp(`^RUNBOOK-${base}(?:-.*)?\\.md$`, 'i');
+    const f = readdirSync(dir).find((n) => re.test(n));
+    return f ? norm(`memory/requisitos/${modulo}/${f}`) : null;
+  } catch {
+    return null;
+  }
+}
+
+// ── Fase 1: roda score-mechanized pra UMA tela e lê o report ───────────────────
+
+function loadReport(screen) {
+  const slug = screen.replace(/\//g, '__');
+  const reportPath = join(REPORTS, `${slug}.design-report.json`);
+  try {
+    execSync(`node "${join(HERE, 'score-mechanized.mjs')}" --only "${screen}"`, { cwd: REPO, stdio: 'pipe' });
+  } catch (e) {
+    console.warn(`[review-gen] score-mechanized falhou pra ${screen}: ${e.message}`);
+  }
+  if (!existsSync(reportPath)) {
+    throw new Error(`design-report.json não gerado pra ${screen} (esperado ${norm(relative(REPO, reportPath))})`);
+  }
+  return JSON.parse(readFileSync(reportPath, 'utf8'));
+}
+
+// ── prioridade P0-P3 por peso da regra (GOLDEN-REFERENCE) ──────────────────────
+
+const RULE_PRIO = { R1: 'P0', R2: 'P0', R7: 'P1', R9: 'P1', R10: 'P1', R3: 'P2', R4: 'P2', R5: 'P2', R6: 'P2', R8: 'P2' };
+const RULE_NOME = {
+  R1: 'cor crua → tokens DS (roxo 295)', R2: 'componente nativo → shared (@/ui)', R3: 'localStorage prefixado oimpresso.*',
+  R4: 'ícone fora de lucide-react / svg inline', R5: 'gradient decorativo (julgado)', R6: 'emoji em UI',
+  R7: 'status bg-fill → dot+texto (Stripe)', R8: 'copy em inglês (julgado)', R9: '<main> aninhado', R10: 'overflow-chain',
+};
+
+// ── render do bloco de 1 round ─────────────────────────────────────────────────
+
+function renderRound(round, report, ctx) {
+  const failed = report.rules.filter((r) => r.mechanized && r.status === 'fail');
+  const judged = report.rules.filter((r) => !r.mechanized);
+  const L = [];
+
+  L.push(round === 1 ? `# Review — \`${report.screen}.tsx\` (Round 1)` : `\n## Round ${round} — ${report.scored_at} (design:review mecanizado)`);
+  L.push('');
+  if (round === 1) {
+    L.push('> Append-only. Próximos rounds entram ABAIXO (NUNCA editar/remover blocos anteriores).');
+    L.push('> Gerado por `prototipo-ui/audit/review-gen.mjs` (Fase 1 mecanizada). Fase 2 (juiz LLM) refina R5/R8/R10 + nota holística.');
+    L.push('');
+  }
+  L.push(`**Nota mecanizada:** ${report.nota}/100 (${report.nivel}) · **medido vs SHA** \`${report.measured_against_sha}\` · **ds/\\*:** ${report.ds_violations?.total ?? 0}`);
+  L.push('');
+
+  L.push('## Sinais técnicos');
+  L.push('');
+  for (const s of ctx.sinais) L.push(`- ${s}`);
+  L.push('');
+
+  L.push('## Riscos / Guardrails Tier 0');
+  L.push('');
+  if (ctx.riscos.length) {
+    for (const r of ctx.riscos) L.push(`- ${r}`);
+  } else {
+    L.push('- (charter sem Non-Goals/Anti-hooks explícitos — Fase 2 LLM avalia riscos de domínio.)');
+  }
+  L.push('');
+
+  L.push('## Top recomendações (backlog de tarefas — worst-first)');
+  L.push('');
+  let n = 1;
+  if (failed.length) {
+    for (const r of failed) {
+      L.push(`${n++}. **${RULE_PRIO[r.id] || 'P2'} — ${r.id}** ${RULE_NOME[r.id] || ''} — evidência: \`${r.evidence}\`. (GOLDEN-REFERENCE)`);
+    }
+  }
+  if ((report.ds_violations?.total ?? 0) > 0) {
+    L.push(`${n++}. **P0 — zerar ds/\\* (${report.ds_violations.total})** via componentes do DS (ESLint baseline, ADR 0209).`);
+  }
+  if (!failed.length && (report.ds_violations?.total ?? 0) === 0) {
+    L.push(`${n++}. **OK mecanizado** — 0 regra mecanizada falhando + ds/\\*=0. Resta a **Fase 2 LLM** (refino).`);
+  }
+  L.push(`${n++}. **P2 — Fase 2 LLM** pendente (R5 gradient · R8 PT-BR · R10 overflow-chain = \`${judged.map((j) => j.id).join('/')}\`) + nota holística + \`best_of_class\` — gate \`$\` [W] (cadência real-mode, ADR ratchet 0236).`);
+  if (report.top_gaps?.[0]?.best_of_class) {
+    L.push('');
+    L.push(`> **Benchmark (best-of-class):** ${report.top_gaps[0].best_of_class}.`);
+  }
+  L.push('');
+  return L.join('\n');
+}
+
+// ── monta o contexto (sinais + riscos) a partir do .tsx + charter ──────────────
+
+function buildContext(tsxAbs, charterAbs, modulo) {
+  const base = basename(tsxAbs, '.tsx');
+  const tsx = existsSync(tsxAbs) ? readFileSync(tsxAbs, 'utf8') : '';
+  const charter = charterAbs && existsSync(charterAbs) ? readFileSync(charterAbs, 'utf8') : '';
+  const cfm = frontmatter(charter);
+
+  const sinais = [];
+  sinais.push(/AppShellV2/.test(tsx) ? 'Shell `AppShellV2` ✓ (Cockpit V2)' : '⚠️ não importa `AppShellV2` — confirmar shell.');
+  sinais.push(/from\s+['"]lucide-react['"]/.test(tsx) ? 'Ícones `lucide-react` ✓ (R4)' : '⚠️ nenhum import lucide-react.');
+  const hooks = (tsx.match(/\buse(?:State|Effect|Memo|Callback|Ref)\b/g) || []);
+  if (hooks.length) sinais.push(`Hooks React: ${[...new Set(hooks)].join(', ')}`);
+  if (/@inertiajs\/react/.test(tsx)) sinais.push('Inertia `@inertiajs/react` ✓');
+  if (charter) sinais.push(`Charter ✓ (\`status: ${cfm.status || '?'}\`${cfm.related_adrs ? ` · ADRs ${cfm.related_adrs.replace(/[[\]]/g, '')}` : ''})`);
+  const runbook = findRunbook(modulo, base);
+  sinais.push(runbook ? `RUNBOOK ✓ (\`${runbook}\`)` : 'RUNBOOK da tela — ausente');
+
+  // Riscos = Non-Goals + Anti-hooks do charter (guardrails que viram GUARD se houver Pest)
+  const riscos = [];
+  for (const b of sectionBullets(charter, 'Non-Goals')) riscos.push(`Guardrail (NÃO faz): ${b}`);
+  for (const b of sectionBullets(charter, 'Automation Anti-hooks')) riscos.push(`Anti-hook: ${b}`);
+  // temas Tier 0 canônicos evidenciados no código
+  if (/business_?[iI]d/.test(tsx)) riscos.push('Multi-tenant Tier 0: `business_id` sempre da sessão (ADR 0093) — confirmar nenhum cross-tenant.');
+  if (/localStorage/.test(tsx)) riscos.push('Persistência `localStorage` presente — prefixo `oimpresso.<modulo>.*` (R3/ADR 0093).');
+
+  return { sinais, riscos, charterPresent: !!charter, charterFm: cfm };
+}
+
+// ── gera 1 review ──────────────────────────────────────────────────────────────
+
+function genOne(screen) {
+  const tsxAbs = join(PAGES, `${screen}.tsx`);
+  if (!existsSync(tsxAbs)) {
+    console.error(`[review-gen] .tsx não encontrado: ${norm(relative(REPO, tsxAbs))}`);
+    return false;
+  }
+  const dir = dirname(tsxAbs);
+  const base = basename(tsxAbs, '.tsx');
+  const charterAbs = join(dir, `${base}.charter.md`);
+  const reviewAbs = join(dir, `${base}.review.md`);
+  const modulo = screen.split('/')[0];
+
+  const report = loadReport(screen);
+  report.measured_against_sha = gitSha(tsxAbs); // sha do ÚLTIMO commit que tocou o .tsx (anti-stale)
+  const ctx = buildContext(tsxAbs, charterAbs, modulo);
+
+  const exists = existsSync(reviewAbs);
+  let round = 1;
+  let prev = '';
+  if (exists) {
+    prev = readFileSync(reviewAbs, 'utf8');
+    const rounds = [...prev.matchAll(/(?:^review_round:\s*(\d+)|^##\s*Round\s*(\d+))/gm)].map((m) => parseInt(m[1] || m[2], 10));
+    round = (rounds.length ? Math.max(...rounds) : 0) + 1;
+  }
+
+  const body = renderRound(round, report, ctx);
+  const runbook = findRunbook(modulo, base);
+
+  let out;
+  if (round === 1) {
+    const fm = [
+      '---',
+      `review_round: 1`,
+      `review_type: static-analysis`,
+      `reviewer: design:review (Fase 1 mecanizada)`,
+      `review_at: ${report.scored_at}`,
+      `page: ${screen}`,
+      `file: ${report.file}`,
+      `measured_against_sha: ${report.measured_against_sha}`,
+      `nota: ${report.nota}`,
+      `nivel: ${report.nivel}`,
+      `charter_present: ${ctx.charterPresent}`,
+      ...(ctx.charterPresent ? [`charter_file: ${base}.charter.md`] : []),
+      `runbook_present: ${!!runbook}`,
+      ...(runbook ? [`runbook_file: ${runbook}`] : []),
+      `append_only: true`,
+      '---',
+      '',
+    ].join('\n');
+    out = fm + body + '\n';
+  } else {
+    // append-only: mantém o conteúdo anterior INTACTO, acrescenta o round novo.
+    out = prev.replace(/\s*$/, '') + '\n' + body + '\n';
+  }
+
+  writeFileSync(reviewAbs, out, 'utf8');
+  console.log(`[review-gen] ${exists ? `round ${round} apenso` : 'round 1 criado'}: ${norm(relative(REPO, reviewAbs))} · nota ${report.nota} (${report.nivel}) · sha ${report.measured_against_sha}`);
+  return true;
+}
+
+// ── descobre telas live sem review (bootstrap) ─────────────────────────────────
+
+function walk(dir, acc = []) {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, acc);
+    else if (name.endsWith('.charter.md')) acc.push(p);
+  }
+  return acc;
+}
+
+function missingLiveScreens() {
+  const out = [];
+  for (const ch of walk(PAGES)) {
+    const src = readFileSync(ch, 'utf8');
+    if (!/^status:\s*live\b/m.test(src)) continue;
+    const dir = dirname(ch);
+    const base = basename(ch, '.charter.md');
+    if (existsSync(join(dir, `${base}.review.md`))) continue;
+    if (!existsSync(join(dir, `${base}.tsx`))) continue;
+    out.push(norm(relative(PAGES, join(dir, base))));
+  }
+  return out;
+}
+
+// ── main ────────────────────────────────────────────────────────────────────
+
+function resolveScreen(arg) {
+  let s = norm(arg).replace(/^.*resources\/js\/Pages\//, '').replace(/\.tsx$/, '').replace(/\.charter$/, '');
+  return s;
+}
+
+function main() {
+  if (FLAG('--missing-live')) {
+    const screens = missingLiveScreens();
+    console.log(`[review-gen] ${screens.length} tela(s) live SEM review — gerando round 1:`);
+    let ok = 0;
+    for (const s of screens) if (genOne(s)) ok++;
+    console.log(`[review-gen] ${ok}/${screens.length} reviews geradas.`);
+    return;
+  }
+  const positional = argv.filter((a) => !a.startsWith('--'));
+  if (!positional.length) {
+    console.error('Uso: node review-gen.mjs <Mod/Tela | path.tsx> | --missing-live');
+    process.exit(2);
+  }
+  for (const arg of positional) genOne(resolveScreen(arg));
+}
+
+main();

--- a/resources/js/Pages/Jana/Pro.review.md
+++ b/resources/js/Pages/Jana/Pro.review.md
@@ -1,0 +1,52 @@
+---
+review_round: 1
+review_type: static-analysis
+reviewer: design:review (Fase 1 mecanizada)
+review_at: 2026-06-01
+page: Jana/Pro
+file: resources/js/Pages/Jana/Pro.tsx
+measured_against_sha: 720ffdce1
+nota: 88
+nivel: Leader
+charter_present: true
+charter_file: Pro.charter.md
+runbook_present: false
+append_only: true
+---
+# Review — `Jana/Pro.tsx` (Round 1)
+
+> Append-only. Próximos rounds entram ABAIXO (NUNCA editar/remover blocos anteriores).
+> Gerado por `prototipo-ui/audit/review-gen.mjs` (Fase 1 mecanizada). Fase 2 (juiz LLM) refina R5/R8/R10 + nota holística.
+
+**Nota mecanizada:** 88/100 (Leader) · **medido vs SHA** `720ffdce1` · **ds/\*:** 0
+
+## Sinais técnicos
+
+- Shell `AppShellV2` ✓ (Cockpit V2)
+- Ícones `lucide-react` ✓ (R4)
+- Hooks React: useEffect, useState
+- Inertia `@inertiajs/react` ✓
+- Charter ✓ (`status: live` · ADRs 0140, 0110, 0190, 0093)
+- RUNBOOK da tela — ausente
+
+## Riscos / Guardrails Tier 0
+
+- Guardrail (NÃO faz): Billing real (assinatura Asaas, gateway, cobrança) — é **Sprint JANA-B**
+- Guardrail (NÃO faz): Downgrade/gestão de assinatura (cancelar, trocar cartão) — backlog Sprint B.
+- Guardrail (NÃO faz): WhatsApp como canal de contato ("Falar com a Jana" → `/ia`, nunca WA — proibição).
+- Guardrail (NÃO faz): Modal full-screen, emoji, cor crua de status (`text-emerald/rose`) — usa tokens.
+- Guardrail (NÃO faz): Comparar mais de 2 planos (Enterprise R$ 499 entra só em GA — Sprint JANA-C).
+- Guardrail (NÃO faz): Escrever no banco no render (tela de leitura + 1 ação; sem efeito colateral).
+- Guardrail (NÃO faz): Mostrar dados de outro `business_id` (Tier 0 — businessId sempre da sessão).
+- Anti-hook: Não dispara email/SMS/WhatsApp ao abrir nem ao clicar (CTA é mock até Sprint B).
+- Anti-hook: Não chama LLM/Brain B no render.
+- Anti-hook: Não persiste nada no client além do estado efêmero da CTA (sem localStorage).
+- Anti-hook: Não cobra nem cria assinatura (billing é Sprint JANA-B, gated por Wagner).
+
+## Top recomendações (backlog de tarefas — worst-first)
+
+1. **P0 — R1** cor crua → tokens DS (roxo 295) — evidência: `11× — oklch(`. (GOLDEN-REFERENCE)
+2. **P2 — Fase 2 LLM** pendente (R5 gradient · R8 PT-BR · R10 overflow-chain = `R5/R8/R10`) + nota holística + `best_of_class` — gate `$` [W] (cadência real-mode, ADR ratchet 0236).
+
+> **Benchmark (best-of-class):** Linear/Stripe (zero cor crua, componente DS, sem nativo).
+

--- a/tests/Feature/Design/DesignReviewFreshnessTest.php
+++ b/tests/Feature/Design/DesignReviewFreshnessTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+// Tests\TestCase já é aplicado globalmente em tests/Pest.php (uses(TestCase::class)->in('Feature')).
+// NÃO redeclarar aqui — Pest 4 lança TestCaseAlreadyInUse.
+
+/**
+ * DesignReviewFreshnessTest — gate de FRESCOR do review por tela.
+ *
+ * Resposta direta ao [W] (COWORK_NOTES → "Gerador design:review", "qual teste/automatização?"):
+ * toda `resources/js/Pages/<Mod>/<Tela>.tsx` com charter `status: live` PRECISA ter um
+ * `<Tela>.review.md` ao lado (o "relatório de tarefas por tela" = charter page viva). Tela
+ * nova nascendo SEM review = a falha que pegou o Jana/Pro (criado no #2069 sem review).
+ *
+ * Espelha em PHP a lógica de `prototipo-ui/audit/review-freshness.mjs` (que roda local como
+ * evidência; o Pest roda no CT 100 — feedback #2076). Teste PURO de arquivo: lê disco + assert,
+ * SEM banco/business_id/rede (mesmo padrão de DesignLedgerIntegrityTest / DesignIndexSingleSourceTest).
+ *
+ * Ratchet (espelha config/eslint-baseline.json · ADR 0209): a dívida HERDADA (telas live sem
+ * review em 2026-06-01) vive em `review-freshness-baseline.json`. O gate só FALHA por uma tela
+ * NOVA fora do baseline (anti-regressão), nunca pela dívida herdada — e o baseline só ENCOLHE.
+ *
+ * `stale` (review existe mas `measured_against_sha` != sha do último commit do .tsx) é ADVISORY
+ * na v1 (reviews legados de 2026-05-17 não têm o campo) → checado pelo .mjs, vira HARD aqui quando
+ * regenerados (proposta de ADR de evolução do loop).
+ *
+ * Refs:
+ *   - prototipo-ui/audit/review-gen.mjs · review-freshness.mjs · review-freshness-baseline.json
+ *   - prototipo-ui/audit/GOLDEN-REFERENCE.md · score-mechanized.mjs (Fase 1)
+ *   - memory/decisions/proposals/design-review-por-tela-charter-page.md (evolução do loop · mãe 0114/0236/0239)
+ *
+ * @group docs
+ * @group design
+ */
+
+const REVIEW_PAGES_REL = 'resources/js/Pages';
+const REVIEW_BASELINE_REL = 'prototipo-ui/audit/review-freshness-baseline.json';
+
+function reviewPagesDir(): string
+{
+    return base_path(REVIEW_PAGES_REL);
+}
+
+/**
+ * Enumera as telas com charter `status: live` + paths irmãos (.tsx / .review.md).
+ * Só telas cujo .tsx EXISTE entram (charter órfã sem tela = fora de escopo deste gate).
+ *
+ * @return array<array{screen:string, tsx:string, review:string}>
+ */
+function reviewLiveCharters(): array
+{
+    $dir = reviewPagesDir();
+    if (! is_dir($dir)) {
+        return [];
+    }
+    $it = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($dir, FilesystemIterator::SKIP_DOTS),
+    );
+    $out = [];
+    foreach ($it as $f) {
+        if (! $f->isFile() || ! str_ends_with($f->getFilename(), '.charter.md')) {
+            continue;
+        }
+        $src = (string) file_get_contents($f->getPathname());
+        // só telas live (frontmatter `status: live`).
+        if (! preg_match('/^status:\s*live\s*$/m', $src)) {
+            continue;
+        }
+        $base = substr($f->getFilename(), 0, -strlen('.charter.md'));
+        $screenDir = $f->getPath();
+        $tsx = $screenDir . DIRECTORY_SEPARATOR . $base . '.tsx';
+        if (! is_file($tsx)) {
+            continue; // charter sem tela — não é caso deste gate
+        }
+        $screen = str_replace('\\', '/', substr($screenDir . DIRECTORY_SEPARATOR . $base, strlen($dir) + 1));
+        $out[] = [
+            'screen' => $screen,
+            'tsx' => $tsx,
+            'review' => $screenDir . DIRECTORY_SEPARATOR . $base . '.review.md',
+        ];
+    }
+    usort($out, fn ($a, $b) => strcmp($a['screen'], $b['screen']));
+
+    return $out;
+}
+
+/**
+ * Carrega o baseline-ratchet (dívida herdada de reviews ausentes).
+ *
+ * @return array{missing:list<string>}
+ */
+function reviewBaseline(): array
+{
+    $f = base_path(REVIEW_BASELINE_REL);
+    if (! is_file($f)) {
+        return ['missing' => []];
+    }
+    $j = json_decode((string) file_get_contents($f), true);
+
+    return is_array($j) && isset($j['missing']) && is_array($j['missing'])
+        ? ['missing' => $j['missing']]
+        : ['missing' => []];
+}
+
+beforeEach(function () {
+    // Skip gracioso quando o filesystem do repo não está acessível (CI ephemeral) —
+    // mesmo padrão de DesignIndexSingleSourceTest / WaveZ2DocumentationGuardTest.
+    if (! is_dir(reviewPagesDir())) {
+        $this->markTestSkipped('resources/js/Pages não acessível (CI ephemeral).');
+    }
+});
+
+// ─── SANIDADE — prova que a varredura roda (anti-verde-vacuo) ─────────────────
+
+it('SANIDADE: há telas live + baseline + scripts do gerador existem', function () {
+    expect(count(reviewLiveCharters()))->toBeGreaterThan(
+        0,
+        'Nenhuma charter `status: live` encontrada — a varredura quebrou (os HARD passariam vacuamente).',
+    );
+    expect(is_file(base_path(REVIEW_BASELINE_REL)))->toBeTrue(
+        'review-freshness-baseline.json ausente — sem baseline o ratchet não funciona.',
+    );
+    expect(is_file(base_path('prototipo-ui/audit/review-gen.mjs')))->toBeTrue('review-gen.mjs (gerador) ausente.');
+    expect(is_file(base_path('prototipo-ui/audit/review-freshness.mjs')))->toBeTrue('review-freshness.mjs (gate node) ausente.');
+});
+
+// ─── (HARD) toda tela live tem review — ou está no baseline herdado ───────────
+
+it('(HARD) toda tela live tem .review.md (ou está no baseline herdado)', function () {
+    $baselineMissing = reviewBaseline()['missing'];
+    $newMissing = [];
+    foreach (reviewLiveCharters() as $c) {
+        if (is_file($c['review'])) {
+            continue;
+        }
+        if (in_array($c['screen'], $baselineMissing, true)) {
+            continue; // dívida herdada, grandfathered no ratchet
+        }
+        $newMissing[] = $c['screen'];
+    }
+    expect($newMissing)->toBe(
+        [],
+        'Tela(s) live SEM `.review.md` e FORA do baseline (regressão — tela nova nasceu sem relatório):'
+        . PHP_EOL . '  - ' . implode(PHP_EOL . '  - ', $newMissing)
+        . PHP_EOL . 'Gere com: node prototipo-ui/audit/review-gen.mjs <Mod/Tela> '
+        . '(depois `--write-baseline` pra podar o ratchet).',
+    );
+});
+
+// ─── (REGRESSÃO) o 1º caso do gerador (Jana/Pro) fica fechado de verdade ──────
+
+it('(REGRESSÃO) Jana/Pro tem review real e NÃO está grandfathered no baseline', function () {
+    $tsx = reviewPagesDir() . '/Jana/Pro.tsx';
+    if (! is_file($tsx)) {
+        $this->markTestSkipped('Jana/Pro.tsx não existe nesta branch — nada a checar.');
+    }
+    expect(is_file(reviewPagesDir() . '/Jana/Pro.review.md'))->toBeTrue(
+        'Jana/Pro.review.md ausente — o 1º caso de teste do gerador `design:review` regrediu.',
+    );
+    expect(reviewBaseline()['missing'])->not->toContain(
+        'Jana/Pro',
+        'Jana/Pro foi parar no baseline (grandfathered) em vez de ter review gerado de verdade.',
+    );
+});
+
+// ─── (RATCHET) baseline só encolhe — nenhuma entrada já-resolvida sobra ───────
+
+it('(RATCHET) nenhuma entrada do baseline já tem review (o ratchet só encolhe)', function () {
+    $stillBaselined = [];
+    foreach (reviewBaseline()['missing'] as $screen) {
+        if (is_file(reviewPagesDir() . '/' . $screen . '.review.md')) {
+            $stillBaselined[] = $screen;
+        }
+    }
+    expect($stillBaselined)->toBe(
+        [],
+        'Baseline lista tela(s) que JÁ têm `.review.md` — o ratchet não foi podado:'
+        . PHP_EOL . '  - ' . implode(PHP_EOL . '  - ', $stillBaselined)
+        . PHP_EOL . 'Rode: node prototipo-ui/audit/review-freshness.mjs --write-baseline',
+    );
+});


### PR DESCRIPTION
## O que / por quê

Fecha o **gap #2** da fila Cowork (handoff 2026-06-01, `COWORK_NOTES → "Gerador design:review"`): o `<Tela>.review.md` era one-off de 2026-05-17 e nunca regenerado → tela nova nasce **sem relatório de tarefas**. Caso vivo: **`Jana/Pro` (#2069)** tem `.tsx` + `.charter.md status:live` mas **nenhum** `Pro.review.md`.

Estende a máquina já existente em `prototipo-ui/audit/` (anti **L-11** — não recria):

- **`review-gen.mjs`** (`npm run design:review <tela>`) — renderiza o `design-report.json` (Fase 1 / `score-mechanized.mjs`) num `<Tela>.review.md` **append-only** ao lado do charter (= charter page viva: spec + nota viva + backlog), ancorado por `measured_against_sha`, com guardrails Tier 0 puxados do charter (Non-Goals/Anti-hooks).
- **`review-freshness.mjs`** + **`review-freshness-baseline.json`** — gate `missing`/`stale`/`fresh` + **ratchet** que espelha `config/eslint-baseline.json` (ADR 0209) — só encolhe.
- **`tests/Feature/Design/DesignReviewFreshnessTest.php`** — espelha o gate em PHP (roda no CT 100).
- **`PROTOCOL.md §6`** — +2 checks `design_review_missing` / `design_review_stale`.
- **1ª execução** = `resources/js/Pages/Jana/Pro.review.md` (nota mecanizada **88 / Leader**).

## Prova (rodei o gate localmente)

```
[freshness] live: 1 fresh · 36 stale (advisory) · 21 missing (21 no baseline)
  fresh: Jana/Pro
[freshness] OK — nenhuma regressão (missing ⊆ baseline) · exit 0
```

- `Jana/Pro`: **missing → fresh** (sha-anchored, **não** grandfathered no baseline).
- Achou **dente real**: `Pro.tsx` tem `oklch(...)` cru (10×) + `linear-gradient(135deg, oklch…)` — o trope que **R5/AP5** proíbe → vira **P0** no backlog do review.
- CI-safety: ADR-frontmatter-linter e number-collision-test **excluem `proposals/`** (glob não-recursivo); `node --check` limpo nos 2 scripts.

## ⚠️ Tier 0 — espera [W], NÃO auto-merge

Mexe em `PROTOCOL.md` + abre **ADR proposta** (`memory/decisions/proposals/design-review-por-tela-charter-page.md`, **sem número** — soberania [W], ADR 0238). **[W] cunha o número no merge.**

## Honestidade (o que NÃO está aqui)

- **Fase 1 only**: nota = teto provisório (só conformidade-DS). A **Fase 2 (juiz LLM: R5/R8/R10 + nota holística + `best_of_class`)** + cadência real-mode = **custo → Tier 0 [W]**, fora deste PR.
- **Pest não rodou local** (sem PHP nesta máquina — roda no CT 100, feedback #2076); a prova local foi o **espelho em node** (`review-freshness.mjs`, passa).
- **`stale` é advisory na v1** (os 36 reviews legados de 2026-05-17 não têm `measured_against_sha`) — vira HARD ao regenerar, pra não nascer com CI vermelho (lição "não subir régua que quebra o próprio CI").

## Test plan

- `npm run design:review:check` → **exit 0** (verde, missing ⊆ baseline).
- CI / CT 100: `DesignReviewFreshnessTest` — 4 testes (SANIDADE anti-verde-vácuo · HARD-missing · REGRESSÃO `Jana/Pro` · RATCHET só-encolhe).

## Notas

- Os 2 arquivos-fantasma (`Modules/RecurringBilling/.../recurringbilling.php`, `memory/requisitos/Fiscal/Nfe-visual-comparison.md`) **NÃO entram** — WIP de fundo não-relacionado (os "fantasmas" das stashes).
- Refs: `COWORK_NOTES` "Gerador design:review" · mãe ADR **0114** (loop) / **0236** (ratchet) / **0239** (SSOT) · **0209** (eslint-baseline ratchet) · **0238** (soberania [W]).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
