### PR TITLE
feat(cliente): chip "anexos" no header do drawer ao lado de placas

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -628,6 +628,35 @@ class ContactController extends Controller
                 ->toArray();
         }
 
+        // Wagner 2026-06-01 — header drawer botao contador "📎 N anexos". Conta
+        // arquivos (media) anexados aos document-notes do contato. business_id
+        // scope (Tier 0 ADR 0093) nas DUAS queries. 2 passos (sem has()/relacao,
+        // larastan-clean igual vehiclesCountMap): mapa note=>contato, depois media
+        // por nota. model_type guarda a classe cheia (sem morphMap no projeto).
+        $documentsCountMap = [];
+        if (\Illuminate\Support\Facades\Schema::hasTable('document_and_notes') && ! empty($contactIds)) {
+            $noteToContact = \App\DocumentAndNote::where('business_id', $business_id)
+                ->where('notable_type', \App\Contact::class)
+                ->whereIn('notable_id', $contactIds)
+                ->pluck('notable_id', 'id');
+
+            if ($noteToContact->isNotEmpty()) {
+                $mediaPerNote = \App\Media::where('business_id', $business_id)
+                    ->where('model_type', \App\DocumentAndNote::class)
+                    ->whereIn('model_id', $noteToContact->keys())
+                    ->selectRaw('model_id, COUNT(*) as cnt')
+                    ->groupBy('model_id')
+                    ->pluck('cnt', 'model_id');
+
+                foreach ($mediaPerNote as $noteId => $cnt) {
+                    $cid = $noteToContact[$noteId] ?? null;
+                    if ($cid !== null) {
+                        $documentsCountMap[$cid] = ($documentsCountMap[$cid] ?? 0) + (int) $cnt;
+                    }
+                }
+            }
+        }
+
         $stats = Transaction::where('transactions.business_id', $business_id)
             ->whereIn('transactions.contact_id', $contactIds)
             ->where('transactions.type', 'sell')
@@ -648,7 +677,7 @@ class ContactController extends Controller
             ->get()
             ->keyBy('contact_id');
 
-        $rows = $contacts->getCollection()->map(function ($contact) use ($stats, $hasWaveBCols, $hasCanonBrCols, $hasDrawerCols, $hasEmailsExtras, $hasSefazCols, $hasBucketACols, $hasContatoCol, $hasMensagemVendaCol, $vehiclesCountMap) {
+        $rows = $contacts->getCollection()->map(function ($contact) use ($stats, $hasWaveBCols, $hasCanonBrCols, $hasDrawerCols, $hasEmailsExtras, $hasSefazCols, $hasBucketACols, $hasContatoCol, $hasMensagemVendaCol, $vehiclesCountMap, $documentsCountMap) {
             $row = $stats->get($contact->id);
             $totalOs = $row ? (int) $row->total_os : 0;
             $abertas = $row ? (int) $row->os_abertas : 0;
@@ -801,6 +830,9 @@ class ContactController extends Controller
 
             // ── Wagner 2026-05-27: contador de veiculos pro header drawer (botao "🚛 N placas")
             $payload['vehicles_count'] = (int) ($vehiclesCountMap[$contact->id] ?? 0);
+
+            // ── Wagner 2026-06-01: contador de anexos pro header drawer (botao "📎 N anexos")
+            $payload['documents_count'] = (int) ($documentsCountMap[$contact->id] ?? 0);
 
             return $payload;
         })->all();

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -34,6 +34,7 @@ import {
   List,
   Loader2,
   MoreVertical,
+  Paperclip,
   Phone,
   Plus,
   Search,
@@ -71,7 +72,7 @@ import EnderecoTab from './_drawer/EnderecoTab';
 import ComercialTab, { type PriceGroupOption } from './_drawer/ComercialTab';
 import ClassificacaoTab from './_drawer/ClassificacaoTab';
 // Wave D/E/F — OSs wrapper, IA 4 cards, Auditoria timeline LGPD (ADR 0179).
-import OssTab from './_drawer/OssTab';
+import OssTab, { type OssSubTabKey } from './_drawer/OssTab';
 import IATab from './_drawer/IATab';
 import AuditoriaTab from './_drawer/AuditoriaTab';
 // Wagner 2026-05-27 iteracao 2: Placas promovido pra tab principal (botao header).
@@ -163,6 +164,9 @@ interface ClienteRow {
   // Wagner 2026-05-27 iteracao 2 — contador veiculos pro botao header drawer.
   // Lazy: count so existe se modulo OficinaAuto instalado (gate hasTable).
   vehicles_count?: number | null;
+  // Wagner 2026-06-01 — contador de anexos (document-notes com media) pro chip
+  // "📎 N anexos" no header do drawer. Count server-side em ContactController.
+  documents_count?: number | null;
 }
 
 interface ListMeta {
@@ -1793,6 +1797,10 @@ function ClienteSheet({
   // o EnderecoTab continuaria mostrando state local antigo. Incrementar key
   // descarta state local e re-monta com novo `contact.zip_code/address_line_1/...`.
   const [enderecoVersion, setEnderecoVersion] = useState(0);
+  // Wagner 2026-06-01 — sub-aba ativa da tab Operações (OssTab). Controlada aqui
+  // pra o chip header "📎 N anexos" cair direto em Documentos. Reset p/ 'ledger'
+  // quando entra na tab Operações pelo caminho normal (tab bar).
+  const [opsSubTab, setOpsSubTab] = useState<OssSubTabKey>('ledger');
 
   // Reset tab ao abrir contact diferente. Drawer abre default em "Identificação".
   useEffect(() => {
@@ -1931,6 +1939,28 @@ function ClienteSheet({
                 <span>placas</span>
               </button>
             )}
+            {/* Wagner 2026-06-01 — chip "anexos" ao lado de placas: acesso 1-clique
+                aos documentos (abre Operações → Documentos). Universal (sem gate):
+                anexos valem pra todo cliente, não só OficinaAuto. */}
+            <button
+              type="button"
+              onClick={() => {
+                setOpsSubTab('documents');
+                setActiveTab('operacoes');
+              }}
+              className={
+                'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1 text-[11px] font-medium transition-colors ' +
+                (activeTab === 'operacoes' && opsSubTab === 'documents'
+                  ? 'border-primary bg-primary/10 text-primary'
+                  : 'border-input bg-background text-muted-foreground hover:text-foreground hover:bg-muted/40')
+              }
+              aria-pressed={activeTab === 'operacoes' && opsSubTab === 'documents'}
+              title="Ver anexos do cliente (comprovantes, contratos, fotos)"
+            >
+              <Paperclip size={11} aria-hidden />
+              <span>{contact?.documents_count ?? 0}</span>
+              <span>anexos</span>
+            </button>
             <button
               type="button"
               onClick={() => setActiveTab('auditoria')}
@@ -1978,7 +2008,12 @@ function ClienteSheet({
                 type="button"
                 role="tab"
                 aria-selected={isActive}
-                onClick={() => setActiveTab(t.key)}
+                onClick={() => {
+                  setActiveTab(t.key);
+                  // Entrar em Operações pela tab bar começa no Extrato (não herda
+                  // 'documents' deixado por um clique anterior no chip de anexos).
+                  if (t.key === 'operacoes') setOpsSubTab('ledger');
+                }}
                 className={
                   'inline-flex items-center gap-2 px-3 py-2.5 text-sm font-medium border-b-2 transition-colors -mb-px whitespace-nowrap ' +
                   (isActive
@@ -2038,7 +2073,11 @@ function ClienteSheet({
                 <ClassificacaoTab contact={contact} />
               </div>
               {activeTab === 'operacoes' && (
-                <OssTab contact={{ id: contact.id, name: contact.name }} />
+                <OssTab
+                  contact={{ id: contact.id, name: contact.name }}
+                  activeSubTab={opsSubTab}
+                  onSubTabChange={setOpsSubTab}
+                />
               )}
               {activeTab === 'placas' && oficinaAutoEnabled && (
                 <PlacasMainTab contactId={contact.id} />

--- a/resources/js/Pages/Cliente/_drawer/OssTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/OssTab.tsx
@@ -43,7 +43,7 @@ import type { ContactInfo } from './IdentificacaoTab';
 // Wagner 2026-05-27 -- iteracao 2: removido sub-tab `placas` (promovido pra
 // tab principal acessado via botao header) + removido sub-tab `activities`
 // (duplicava tab principal `Auditoria` -- mesma fonte `activity_log` Spatie).
-type OssSubTabKey =
+export type OssSubTabKey =
   | 'ledger'
   | 'sales'
   | 'payments'
@@ -54,6 +54,14 @@ type OssSubTabKey =
 
 export interface OssTabProps {
   contact: ContactInfo;
+  /**
+   * Sub-aba controlada de fora (Wagner 2026-06-01): o chip "📎 N anexos" do
+   * header do drawer (Index.tsx) passa `activeSubTab='documents'` pra cair
+   * direto nos anexos. Se ausente, OssTab usa estado interno (default 'ledger').
+   */
+  activeSubTab?: OssSubTabKey;
+  /** Reporta troca de sub-aba (clique interno) pro pai manter sync — highlight do chip. */
+  onSubTabChange?: (key: OssSubTabKey) => void;
   /**
    * Permissoes injetadas pelo Index.tsx (Wave futura pode estender ContactController::index).
    * Por ora todas default false — sub-tabs operam em modo read-only.
@@ -78,8 +86,22 @@ const SUB_TABS: Array<{ key: OssSubTabKey; label: string; icon: LucideIcon }> = 
   { key: 'rewards', label: 'Pontos', icon: Gift },
 ];
 
-export default function OssTab({ contact, permissions = {}, locations = [] }: OssTabProps) {
-  const [active, setActive] = useState<OssSubTabKey>('ledger');
+export default function OssTab({
+  contact,
+  activeSubTab,
+  onSubTabChange,
+  permissions = {},
+  locations = [],
+}: OssTabProps) {
+  // Estado interno = fallback quando OssTab roda sem controle externo. Quando o
+  // pai passa `activeSubTab` (Index.tsx via chip header), ELE manda na renderização.
+  const [internalActive, setInternalActive] = useState<OssSubTabKey>('ledger');
+  const active = activeSubTab ?? internalActive;
+
+  const selectSubTab = (key: OssSubTabKey) => {
+    setInternalActive(key);
+    onSubTabChange?.(key);
+  };
 
   return (
     <div
@@ -103,7 +125,7 @@ export default function OssTab({ contact, permissions = {}, locations = [] }: Os
               key={t.key}
               type="button"
               role="tab"
-              onClick={() => setActive(t.key)}
+              onClick={() => selectSubTab(t.key)}
               aria-selected={isActive}
               aria-controls={`oss-subpanel-${t.key}`}
               data-testid={`oss-subtab-${t.key}`}

--- a/tests/Feature/Cliente/ClienteDrawerHeaderButtonsReorgTest.php
+++ b/tests/Feature/Cliente/ClienteDrawerHeaderButtonsReorgTest.php
@@ -132,3 +132,77 @@ test('GUARD 7 — PlacasMainTab.tsx existe + endpoint canon mantido', function (
     $oldDir = __DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/oss';
     expect(is_dir($oldDir))->toBeFalse();
 });
+
+// ════════════════════════════════════════════════════════════════════════
+// Wagner 2026-06-01 — chip "📎 N anexos" no header, ao lado de placas.
+// Clique abre Operações → Documentos. Count server-side: document-notes COM
+// media (anexos reais). Universal (sem gate OficinaAuto — anexos valem p/ todo
+// cliente). GUARDs estruturais (file_get_contents, sem DB) — mesmo bar do
+// vehicles_count (GUARD 1).
+// ════════════════════════════════════════════════════════════════════════
+
+// ─── GUARD 8: Backend payload tem documents_count (business_id scope) ─────
+
+test('GUARD 8 — ContactController retorna documents_count com gate hasTable + business_id scope', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        // Gate hasTable (graceful se tabela ausente).
+        ->toContain("Schema::hasTable('document_and_notes')")
+        // Tier 0 (ADR 0093 IRREVOGAVEL): scope business_id obrigatorio nas DUAS queries.
+        ->toContain("DocumentAndNote::where('business_id', \$business_id)")
+        ->toContain("->where('notable_type', \\App\\Contact::class)")
+        ->toContain("->whereIn('notable_id', \$contactIds)")
+        ->toContain("Media::where('business_id', \$business_id)")
+        // So anexos reais (media anexada aos document-notes), via model_type cheio.
+        ->toContain("->where('model_type', \\App\\DocumentAndNote::class)")
+        ->toContain("->groupBy('model_id')")
+        // Payload com chave canon EN snake_case.
+        ->toMatch("/\\\$payload\\['documents_count'\\]\\s*=\\s*\\(int\\)/");
+});
+
+// ─── GUARD 9: ClienteRow interface declara documents_count ───────────────
+
+test('GUARD 9 — Cliente/Index.tsx ClienteRow declara documents_count', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain('documents_count?: number | null');
+});
+
+// ─── GUARD 10: chip Anexos no header (universal, sem gate OficinaAuto) ────
+
+test('GUARD 10 — drawer header tem chip Anexos abrindo Operações → Documentos', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        // aria-pressed composto: tab operacoes + sub-aba documents.
+        ->toContain("aria-pressed={activeTab === 'operacoes' && opsSubTab === 'documents'}")
+        // Contador usa documents_count.
+        ->toContain('contact?.documents_count ?? 0')
+        // Icone clipe (lucide Paperclip) importado e usado.
+        ->toContain('Paperclip,')
+        ->toContain('<Paperclip size={11}')
+        // Clique leva pra Operacoes na sub-aba Documentos.
+        ->toContain("setOpsSubTab('documents')")
+        // OssTab controlado pelo header (single source of truth da sub-aba).
+        ->toContain('activeSubTab={opsSubTab}')
+        ->toContain('onSubTabChange={setOpsSubTab}');
+});
+
+// ─── GUARD 11: OssTab aceita controle externo da sub-aba ──────────────────
+
+test('GUARD 11 — OssTab.tsx expõe activeSubTab/onSubTabChange (controlado pelo header)', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/OssTab.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain('export type OssSubTabKey')
+        ->toContain('activeSubTab?: OssSubTabKey')
+        ->toContain('onSubTabChange?: (key: OssSubTabKey) => void')
+        // active derivado: controle externo tem prioridade sobre estado interno.
+        ->toContain('const active = activeSubTab ?? internalActive');
+});


### PR DESCRIPTION
## O quê

Chip **`[📎 N anexos]`** na toolbar do header do drawer de Cliente, ao lado de `[🚗 N placas]`. Clique abre **Operações → Documentos** (sub-aba que já tem Notas + Anexos). Universal — sem gate OficinaAuto (anexos valem pra todo cliente).

Pedido Wagner 2026-06-01: *"no cadastro de clientes contacts, pode colocar o anexo ao lado da placa"*.

## Mudanças (4 arquivos · +161/−8)

- **ContactController** — `documents_count` no payload do índice: document-notes COM media (anexos reais), escopo `business_id` (Tier 0 ADR 0093), guard `Schema::hasTable`, query agrupada sem N+1 (espelha `vehicles_count`).
- **OssTab** — sub-aba controlável via `activeSubTab`/`onSubTabChange` (single source of truth, com fallback interno).
- **Index** — chip + ícone `Paperclip` + estado `opsSubTab` + reset ao entrar em Operações pela tab bar.
- **Pest** — GUARD 8-11 em `ClienteDrawerHeaderButtonsReorgTest` (count+scope business_id, ClienteRow, chip, OssTab controlado).

## Verificação

- ✅ Pest: 11/11 (58 assertions), incluindo os 4 guards novos.
- ✅ tsc: zero erros novos nos arquivos alterados.
- ✅ eslint baseline ratchet: zero regressão nos meus arquivos (delta global −58).

## Gap conhecido (fast-follow)

O painel interno **Documentos é stub Wave D**: não carrega anexos existentes nem persiste upload direito → mostra "Anexos (0)" até subir arquivo na sessão. Logo o chip pode contar N (dados legados) e o painel abrir em 0. **PR seguinte fecha esse gap** (endpoint JSON + carregar/persistir no DocumentsTab).

🤖 Generated with [Claude Code](https://claude.com/claude-code)