### PR TITLE
chore(jana): declara ProController no SCOPE.md (drift do #2069)

### DIFF
--- a/Modules/Jana/SCOPE.md
+++ b/Modules/Jana/SCOPE.md
@@ -11,6 +11,7 @@ contains:
   # Custos / Qualidade
   - "Admin/CustosController — dashboard custos LLM"
   - "Admin/JanaProController — brief diário invocável (US-COPI-203)"
+  - "ProController — paywall Jana Pro (/ia/pro), tela de conversão F3 design (#2069)"
   - "Admin/QualidadeController — qualidade RAG/memória (RAGAS)"
   - "Admin/RoadmapController — timeline Gantt do cycle ativo (Onda 5 V1)"
   # Metas / Períodos


### PR DESCRIPTION
Drift do #2069 (Jana Pro paywall) — `ProController` não declarado no `contains[]` do SCOPE.md do Jana → check-scope bloqueava todo PR que tocasse controller. 1 linha desbloqueia o gate globalmente.

🤖 Generated with [Claude Code](https://claude.com/claude-code)