### PR TITLE
fix(financeiro): Extrato — rota /extrato sem id (B4) + session key canon (B5) [re-impl #2043]

### DIFF
--- a/Modules/Financeiro/Http/Controllers/ExtratoController.php
+++ b/Modules/Financeiro/Http/Controllers/ExtratoController.php
@@ -6,7 +6,9 @@ namespace Modules\Financeiro\Http\Controllers;
 
 use App\Http\Controllers\Controller;
 use Carbon\Carbon;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Log;
 use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Financeiro\Http\Controllers\Concerns\RendersMockCowork;
@@ -28,13 +30,41 @@ class ExtratoController extends Controller
 {
     use RendersMockCowork;
 
+    /**
+     * Ponto de entrada SEM id: /financeiro/extrato.
+     * O sidebar/topnav apontam pra /financeiro/extrato (sem contaBancariaId), mas a
+     * tela de detalhe exige id numérico (extrato.index com whereNumber) → 404 (bug B4).
+     * Resolve pra primeira conta do business e redireciona; se não há conta, manda
+     * cadastrar (com flash) — sem fallback silencioso (Log::warning antes do redirect).
+     */
+    public function selecionar(Request $request): RedirectResponse
+    {
+        $businessId = (int) $request->session()->get('user.business_id');
+
+        $conta = ContaBancaria::where('business_id', $businessId)
+            ->orderBy('id')
+            ->first();
+
+        if ($conta === null) {
+            Log::warning('Financeiro/Extrato: business sem conta bancária ao abrir /financeiro/extrato', [
+                'business_id' => $businessId,
+            ]);
+
+            return redirect('/financeiro/contas-bancarias')
+                ->with('warning', 'Cadastre uma conta bancária para visualizar o extrato.');
+        }
+
+        return redirect('/financeiro/extrato/' . $conta->id);
+    }
+
     public function index(Request $request, int $contaBancariaId): Response|\Illuminate\Http\Response
     {
         if ($mock = $this->tryRenderMockCowork()) {
             return $mock;
         }
 
-        $businessId = (int) $request->session()->get('business.id');
+        // Session key canônica UPOS `user.business_id` (B5 — padroniza com o resto do módulo).
+        $businessId = (int) $request->session()->get('user.business_id');
 
         // Conta header é cheap (firstOrFail single row) — fica eager.
         $conta = ContaBancaria::where('business_id', $businessId)

--- a/Modules/Financeiro/Routes/web.php
+++ b/Modules/Financeiro/Routes/web.php
@@ -174,6 +174,8 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
             ->name('contas-bancarias.upsert');
 
         // Extrato bancário — leitura via Banking API (US-RB-046)
+        // Entrada sem id (sidebar/topnav) → resolve pra 1ª conta do business (bug B4).
+        Route::get('/extrato', [ExtratoController::class, 'selecionar'])->name('extrato.selecionar');
         Route::get('/extrato/{contaBancariaId}', [ExtratoController::class, 'index'])
             ->whereNumber('contaBancariaId')
             ->name('extrato.index');

--- a/Modules/Financeiro/Tests/Feature/ExtratoNavRedirectTest.php
+++ b/Modules/Financeiro/Tests/Feature/ExtratoNavRedirectTest.php
@@ -1,0 +1,191 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Financeiro\Tests\Feature;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Modules\Financeiro\Http\Controllers\ExtratoController;
+use Modules\Financeiro\Models\ContaBancaria;
+use Modules\Financeiro\Models\Concerns\BusinessScopeImpl;
+
+/**
+ * Fix B4 · /financeiro/extrato (sem id) — resolver de navegação.
+ *
+ * O sidebar/topnav apontam pra /financeiro/extrato SEM contaBancariaId, mas a
+ * tela de detalhe (extrato.index) exige id numérico (whereNumber). Antes do fix
+ * o link dava 404. ExtratoController::selecionar agora resolve pra primeira
+ * conta do business (orderBy id) ou manda cadastrar conta.
+ *
+ * Cobre:
+ *   (a) GET /financeiro/extrato com business QUE TEM conta → 302 pra
+ *       /financeiro/extrato/{idDaPrimeiraContaDoBusiness}.
+ *   (b) GET /financeiro/extrato com business SEM conta → 302 pra
+ *       /financeiro/contas-bancarias (cadastrar conta).
+ *   (c) /financeiro/extrato/{id} continua entregando a página Inertia (smoke).
+ *   (d) Multi-tenant Tier 0 — conta de outro business NUNCA é o alvo do redirect.
+ *
+ * NÃO usa RefreshDatabase (UltimatePOS legacy migrations não rodam em SQLite).
+ * Cria complemento `fin_contas_bancarias` + `accounts` e limpa no tearDown.
+ */
+class ExtratoNavRedirectTest extends FinanceiroTestCase
+{
+    private int $contaBancariaId = 0;
+    private int $accountId = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->actAsAdmin();
+
+        // Cria account + complemento ContaBancaria pro business atual.
+        $this->accountId = DB::table('accounts')->insertGetId([
+            'business_id'    => $this->business->id,
+            'name'           => 'Inter NavTest ' . uniqid(),
+            'account_number' => '99887766',
+            'created_at'     => now(),
+            'updated_at'     => now(),
+        ]);
+
+        $this->contaBancariaId = DB::table('fin_contas_bancarias')->insertGetId([
+            'business_id'                => $this->business->id,
+            'account_id'                 => $this->accountId,
+            'banco_codigo'               => '077',
+            'agencia'                    => '0001',
+            'carteira'                   => '112',
+            'beneficiario_documento'     => fake()->numerify('##.###.###/####-##'),
+            'beneficiario_razao_social'  => 'Empresa NavTest',
+            'ativo_para_boleto'          => true,
+            'saldo_cached'               => 1000.00,
+            'saldo_atualizado_em'        => now(),
+            'created_at'                 => now(),
+            'updated_at'                 => now(),
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->contaBancariaId > 0) {
+            DB::table('fin_contas_bancarias')->where('id', $this->contaBancariaId)->delete();
+        }
+        if ($this->accountId > 0) {
+            DB::table('accounts')->where('id', $this->accountId)->delete();
+        }
+        parent::tearDown();
+    }
+
+    public function test_extrato_sem_id_redireciona_pra_primeira_conta_do_business(): void
+    {
+        // Alvo esperado = menor id de conta do PRÓPRIO business (orderBy id),
+        // computado sem global scope pra ser determinístico mesmo se o DB dev
+        // já tiver outras contas seedadas no business.
+        $expectedId = (int) ContaBancaria::query()
+            ->withoutGlobalScope(BusinessScopeImpl::class)
+            ->where('business_id', $this->business->id)
+            ->orderBy('id')
+            ->value('id');
+
+        $this->assertGreaterThan(0, $expectedId, 'Pré-condição: business deve ter ao menos uma conta.');
+
+        $response = $this->get('/financeiro/extrato');
+
+        $response->assertStatus(302);
+        $response->assertRedirect('/financeiro/extrato/' . $expectedId);
+    }
+
+    public function test_extrato_sem_id_sem_conta_manda_cadastrar_conta(): void
+    {
+        // Business sintético SEM conta. Chama selecionar() direto — o método só LÊ
+        // ContaBancaria (sem FK) e evita o middleware auth/SetSessionData do UPos,
+        // que sobrescreveria a session com o business do usuário autenticado.
+        $emptyBusinessId = (int) DB::table('business')->max('id') + 9999;
+
+        $request = Request::create('/financeiro/extrato', 'GET');
+        $request->setLaravelSession($this->app['session']->driver());
+        $request->session()->put('user.business_id', $emptyBusinessId);
+
+        $response = (new ExtratoController())->selecionar($request);
+
+        $this->assertStringContainsString('/financeiro/contas-bancarias', $response->getTargetUrl());
+    }
+
+    public function test_extrato_com_id_ainda_entrega_pagina_inertia(): void
+    {
+        if (! Schema::hasTable('fin_extrato_lancamentos')) {
+            $this->markTestSkipped('Migração fin_extrato_lancamentos ainda não aplicada — rodar php artisan migrate.');
+        }
+
+        // Rota de detalhe intacta — não pode quebrar com a adição do resolver.
+        $response = $this->inertiaGet('/financeiro/extrato/' . $this->contaBancariaId);
+
+        $this->assertSame(200, $response->status());
+    }
+
+    public function test_multi_tenant_redirect_nunca_aponta_pra_conta_de_outro_business(): void
+    {
+        // Outro business REAL — a FK fin_contas_bancarias.business_id → business.id
+        // (ON DELETE CASCADE) exige que o business exista. Skip se o DB só tem 1.
+        $otherBusinessId = (int) DB::table('business')
+            ->where('id', '!=', $this->business->id)
+            ->orderBy('id')
+            ->value('id');
+        if ($otherBusinessId === 0) {
+            $this->markTestSkipped('Precisa de ≥2 business no DB pra testar isolamento cross-tenant.');
+        }
+        $otherAccountId = DB::table('accounts')->insertGetId([
+            'business_id'    => $otherBusinessId,
+            'name'           => 'Outro biz NavTest ' . uniqid(),
+            'account_number' => '00000000',
+            'created_at'     => now(),
+            'updated_at'     => now(),
+        ]);
+        $otherContaId = DB::table('fin_contas_bancarias')->insertGetId([
+            'business_id'                => $otherBusinessId,
+            'account_id'                 => $otherAccountId,
+            'banco_codigo'               => '077',
+            'agencia'                    => '0001',
+            'carteira'                   => '112',
+            'beneficiario_documento'     => fake()->numerify('##.###.###/####-##'),
+            'beneficiario_razao_social'  => 'Outro biz',
+            'ativo_para_boleto'          => true,
+            'saldo_cached'               => 0,
+            'saldo_atualizado_em'        => now(),
+            'created_at'                 => now(),
+            'updated_at'                 => now(),
+        ]);
+
+        try {
+            // Acessando como NOSSO business: o redirect resolve pra uma conta do
+            // nosso business, NUNCA pra conta do outro business.
+            $response = $this->get('/financeiro/extrato');
+
+            $response->assertStatus(302);
+            $response->assertRedirectContains('/financeiro/extrato/');
+            $this->assertStringNotContainsString(
+                '/financeiro/extrato/' . $otherContaId,
+                (string) $response->headers->get('Location'),
+                'Redirect vazou conta de outro business (Tier 0 violado).'
+            );
+
+            // E a conta alvo do redirect pertence ao nosso business.
+            $targetId = (int) str_replace('/financeiro/extrato/', '', parse_url(
+                (string) $response->headers->get('Location'),
+                PHP_URL_PATH
+            ));
+            $targetBusinessId = (int) ContaBancaria::query()
+                ->withoutGlobalScope(BusinessScopeImpl::class)
+                ->where('id', $targetId)
+                ->value('business_id');
+            $this->assertSame(
+                $this->business->id,
+                $targetBusinessId,
+                'Conta alvo do redirect não pertence ao business autenticado.'
+            );
+        } finally {
+            DB::table('fin_contas_bancarias')->where('id', $otherContaId)->delete();
+            DB::table('accounts')->where('id', $otherAccountId)->delete();
+        }
+    }
+}


### PR DESCRIPTION
Re-implementação do #2043 sobre main. **Bug B4**: sidebar aponta pra `/financeiro/extrato` (sem id), mas a única rota exigia id numérico → **404**. Adiciona `ExtratoController::selecionar()` (resolve pra 1ª conta, ou manda cadastrar — sem fallback silencioso). **B5**: `index` usa `user.business_id` (canon UPOS).

- Pest `ExtratoNavRedirectTest` incl. **multi-tenant Tier 0**, biz=1 dogfooding. Validado no CT 100.
- CNPJ fake → `fake()->numerify` (resolve o PII scan falso-positivo do #2043).

Supersedes #2043.

🤖 Generated with [Claude Code](https://claude.com/claude-code)