### PR TITLE
feat(cliente): carrega anexos existentes no painel Documentos do drawer

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -1476,6 +1476,58 @@ class ContactController extends Controller
     }
 
     /**
+     * Wagner 2026-06-01 — anexos do cliente pro drawer (Operações → Documentos).
+     * Lista os arquivos (media) anexados aos document-notes do contato como JSON,
+     * fechando o gap Wave D (o painel não carregava os anexos existentes — só
+     * mostrava "Anexos (0)" até subir um arquivo na sessão). Mesma fonte do
+     * contador `documents_count` do header (media via document_and_notes).
+     *
+     * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): scope business_id em TODAS as
+     * queries (contato, notas e media). Sem relação/has() — larastan-clean igual
+     * documentsCountMap: 2 queries simples + accessors do Media pro download.
+     *
+     * GET /cliente/{id}/anexos → { documents: DocumentItem[] }
+     */
+    public function anexos($id)
+    {
+        $business_id = request()->session()->get('user.business_id');
+
+        // 404 cross-tenant: o contato precisa existir DENTRO do business.
+        \App\Contact::where('business_id', $business_id)->findOrFail($id);
+
+        $noteIds = \App\DocumentAndNote::where('business_id', $business_id)
+            ->where('notable_type', \App\Contact::class)
+            ->where('notable_id', $id)
+            ->pluck('id');
+
+        if ($noteIds->isEmpty()) {
+            return response()->json(['documents' => []]);
+        }
+
+        $media = \App\Media::where('business_id', $business_id)
+            ->where('model_type', \App\DocumentAndNote::class)
+            ->whereIn('model_id', $noteIds)
+            ->orderByDesc('id')
+            ->get();
+
+        $documents = $media->map(function ($m) {
+            return [
+                'id' => (int) $m->id,
+                'file_name' => $m->file_name,
+                'display_name' => $m->display_name,
+                'description' => $m->description,
+                'file_size' => null,
+                'mime_type' => null,
+                'uploaded_by_name' => null,
+                'created_at' => optional($m->created_at)->toISOString(),
+                'download_url' => $m->display_url,
+            ];
+        })->all();
+
+        return response()->json(['documents' => $documents]);
+    }
+
+    /**
      * Store a newly created resource in storage.
      *
      * Slice 7 — type-hint StoreContactRequest wira App\Rules\BR\CpfCnpj +

--- a/resources/js/Pages/Cliente/_show/DocumentsTab.tsx
+++ b/resources/js/Pages/Cliente/_show/DocumentsTab.tsx
@@ -92,6 +92,34 @@ export default function DocumentsTab({
   const fileRef = useRef<HTMLInputElement | null>(null);
   const noteTimeoutRef = useRef<number | null>(null);
 
+  // Wagner 2026-06-01 — carrega anexos existentes do backend ao montar (fecha o
+  // gap Wave D: antes o painel mostrava "Anexos (0)" mesmo com arquivos salvos,
+  // divergindo do contador "📎 N anexos" do header). Só busca quando `documents`
+  // NÃO veio por prop (preserva usos prop-driven/SSR). GET /cliente/{id}/anexos.
+  useEffect(() => {
+    if (docsProp !== undefined) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch(`/cliente/${contactId}/anexos`, {
+          credentials: 'same-origin',
+          headers: { 'X-Requested-With': 'XMLHttpRequest', Accept: 'application/json' },
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const data = await res.json();
+        if (!cancelled && Array.isArray(data?.documents)) {
+          setDocuments(data.documents as DocumentItem[]);
+        }
+      } catch {
+        // silencioso: painel permanece vazio (mesmo fallback de antes).
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [contactId]);
+
   // Autosave debounced 1500ms na nota primária (primeira nota; senão cria)
   useEffect(() => {
     if (primaryNote === (notesProp?.[0]?.description ?? '') && noteHeading === (notesProp?.[0]?.heading ?? '')) {

--- a/routes/web.php
+++ b/routes/web.php
@@ -263,6 +263,11 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
         return $c->show($id);
     })->name('cliente.show')->whereNumber('id');
 
+    // Wagner 2026-06-01 — anexos do cliente (drawer Operações → Documentos). JSON.
+    // Tier 0 multi-tenant: scope business_id no controller (ContactController::anexos).
+    Route::get('/cliente/{id}/anexos', [ContactController::class, 'anexos'])
+        ->name('cliente.anexos.index')->whereNumber('id');
+
     Route::get('taxonomies-ajax-index-page', [TaxonomyController::class, 'getTaxonomyIndexPage']);
     Route::resource('taxonomies', TaxonomyController::class);
 

--- a/tests/Feature/Cliente/ClienteAnexosEndpointTest.php
+++ b/tests/Feature/Cliente/ClienteAnexosEndpointTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Wagner 2026-06-01 — endpoint de anexos do cliente (drawer Operacoes -> Documentos).
+ * GET /cliente/{id}/anexos devolve os arquivos (media) anexados aos document-notes
+ * do contato como JSON, fechando o gap Wave D (o painel nao carregava os anexos
+ * existentes — mostrava "Anexos (0)" mesmo com arquivos salvos, divergindo do
+ * contador "N anexos" do header introduzido no PR #2082).
+ *
+ * GUARDs estruturais (file_get_contents, sem DB) + 1 integracao (auth gate),
+ * mesmo bar do GUARD 12 de ClienteListagemTurbinadaTest (/cliente/export).
+ *
+ * Refs: ADR 0093 (multi-tenant Tier 0) · ADR 0179 (drawer 760) · PR #2082.
+ */
+
+// ─── GUARD 1: rota registrada ─────────────────────────────────────────────
+
+test('GUARD 1 — routes/web.php registra GET /cliente/{id}/anexos', function () {
+    $path = __DIR__ . '/../../../routes/web.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("Route::get('/cliente/{id}/anexos', [ContactController::class, 'anexos'])")
+        ->toContain("->name('cliente.anexos.index')");
+});
+
+// ─── GUARD 2: ContactController::anexos — tenant scope + larastan-safe ─────
+
+test('GUARD 2 — ContactController::anexos com business_id scope em todas as queries', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain('public function anexos($id)')
+        // Tier 0 (ADR 0093 IRREVOGAVEL): contato + notas + media TODOS scoped.
+        ->toContain("Contact::where('business_id', \$business_id)->findOrFail(\$id)")
+        ->toContain("DocumentAndNote::where('business_id', \$business_id)")
+        ->toContain("Media::where('business_id', \$business_id)")
+        ->toContain("->where('model_type', \\App\\DocumentAndNote::class)")
+        // shape DocumentItem (download via accessor display_url do Media).
+        ->toContain("'download_url' => \$m->display_url")
+        ->toContain("response()->json(['documents' => \$documents])");
+});
+
+// ─── GUARD 3: DocumentsTab carrega anexos no mount ────────────────────────
+
+test('GUARD 3 — DocumentsTab busca /cliente/{id}/anexos no mount (guarda docsProp)', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/_show/DocumentsTab.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain('/cliente/${contactId}/anexos')
+        // Nao sobrescreve uso prop-driven/SSR.
+        ->toContain('if (docsProp !== undefined) return');
+});
+
+// ─── GUARD 4: endpoint exige sessao (integracao, nao vaza sem auth) ───────
+
+test('GUARD 4 — GET /cliente/{id}/anexos nao vaza anexos sem auth', function () {
+    // Cross-tenant real precisa de DB+seed que sqlite memory CI nao tem;
+    // skip-graceful pattern canon (igual GUARD 12 /cliente/export).
+    if (! \Illuminate\Support\Facades\Schema::hasTable('contacts')) {
+        $this->markTestSkipped('Schema UltimatePOS ausente (sqlite memory) — rode com DB_CONNECTION=mysql.');
+    }
+
+    $response = $this->get('/cliente/1/anexos');
+    // Sem auth: redirect login (302) ou 401/403/404. O importante e NAO 200
+    // (vazaria anexos sem sessao) nem 500 (erro de codigo).
+    expect(in_array($response->status(), [302, 401, 403, 404], true))->toBeTrue();
+});


### PR DESCRIPTION
## O quê

Fecha o **gap Wave D** apontado no PR #2082: o painel **Operações → Documentos** do drawer de Cliente mostrava `Anexos (0)` mesmo quando o cliente tinha arquivos salvos — divergindo do contador `📎 N anexos` do header. Agora o painel **carrega os anexos do backend ao abrir**, batendo com o número do chip.

Pedido Wagner 2026-06-01: *"Feche o gap sim"* (endpoint JSON + carregar no DocumentsTab).

## Mudanças (4 arquivos · +157)

- **ContactController::anexos($id)** — `GET /cliente/{id}/anexos` devolve os arquivos (`media`) anexados aos `document-notes` do contato como JSON (`DocumentItem[]`). Mesma fonte do `documents_count` do header. `business_id` scope (Tier 0 ADR 0093) nas 3 queries; sem relação/`has()` → larastan-clean (igual `documentsCountMap`).
- **routes/web.php** — rota `cliente.anexos.index` (`whereNumber('id')`).
- **DocumentsTab** — `fetch` ao montar (guarda `docsProp` pra não sobrescrever usos prop-driven/SSR).
- **Pest** — `ClienteAnexosEndpointTest`: 4 guards (rota registrada, controller + scope `business_id`, frontend carrega, auth gate).

## Verificação local

- ✅ PHPStan: `[OK] No errors` no ContactController (método `anexos` larastan-clean).
- ✅ Pest: structural guards passam; auth-gate robusto (status lenient + skip sqlite).
- ✅ ESLint ratchet: `Sem regressões vs baseline`.
- ✅ tsc: zero erros no DocumentsTab.
- ui:lint: mudança é **lógica pura** (sem JSX/className) → não regride regras `ds/*`.

## Infra Contract

Runtime tocado: **1 rota GET nova** (`routes/web.php`), aditiva, read-only, atrás de auth + scope `business_id`. Sem `.htaccess`/middleware/Kernel/ServiceProvider/bootstrap, sem migração/schema. Os curls abaixo são o critério **esperado pós-deploy** (preencher com cole real após `git pull` no Hostinger — Pest local NÃO prova prod).

### 1. Happy path (esperado)

\`\`\`bash
$ curl -sv 'https://oimpresso.com/cliente/<ID>/anexos' \
    -H 'Cookie: <sessao biz=X>' -H 'X-Requested-With: XMLHttpRequest' 2>&1 | grep '^< HTTP'
< HTTP/1.1 200      # JSON {"documents":[...]} APENAS do business da sessao
\`\`\`

### 2. Regression adjacent (NÃO devem mudar)

\`\`\`bash
$ curl -sv 'https://oimpresso.com/cliente/<ID>' 2>&1 | grep '^< HTTP'
< HTTP/1.1 302      # drawer redirect (inalterado)
$ curl -sv 'https://oimpresso.com/cliente/export' 2>&1 | grep '^< HTTP'
< HTTP/1.1 302      # sem auth -> login (inalterado)
\`\`\`

### 3. Sem auth não vaza

\`\`\`bash
$ curl -sv 'https://oimpresso.com/cliente/1/anexos' 2>&1 | grep '^< HTTP'
< HTTP/1.1 302      # redirect login — NUNCA 200 com anexos
\`\`\`

### 4. Environment delta + rollback

Rota JSON simples (sem `.htaccess`/SCRIPT_NAME/LiteSpeed quirks). **Pest local + ratchets NÃO provam prod** — `curl -sv` pós-deploy obrigatório. Rollback: `git revert` (aditivo, sem migração; DocumentsTab degrada graceful → painel vazio se endpoint falhar).

## Fora de escopo (follow-up)

O **upload/exclusão** de anexos pelo drawer continua oculto (`permissions.upload/delete_document` chegam `false` do OssTab → botões não renderizam) — gap de *plumbing* de permissões separado, pré-existente. Este PR entrega só a **leitura** (carregar/exibir), que é o gap visível que o chip expôs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)