### PR TITLE
fix(financeiro): Conciliação — audit-log + reabrir/undo BACKEND (re-impl #2044)

### DIFF
--- a/Modules/Financeiro/Http/Controllers/ConciliacaoController.php
+++ b/Modules/Financeiro/Http/Controllers/ConciliacaoController.php
@@ -12,15 +12,17 @@ use Inertia\Inertia;
 use Inertia\Response;
 use Modules\Financeiro\Models\ContaBancaria;
 use Modules\Financeiro\Models\Titulo;
+use Modules\Financeiro\Services\FinanceiroAuditLogger;
 
 /**
  * Conciliação OFX — Onda 19 (2026-05-19) #49.
  *
  * Workflow:
- *  1. GET  /financeiro/conciliacao — lista linhas pendentes
+ *  1. GET  /financeiro/conciliacao — lista linhas pendentes (?incluir_resolvidos=1 inclui resolvidas)
  *  2. POST /financeiro/conciliacao/upload — recebe arquivo OFX, parseia, persiste
  *  3. POST /financeiro/conciliacao/{lineId}/match — confirma match com Titulo
  *  4. POST /financeiro/conciliacao/{lineId}/ignorar — marca como ignorado
+ *  5. POST /financeiro/conciliacao/{lineId}/reabrir — desfaz conciliação/ignore (volta a pendente)
  *
  * Parser OFX simples (regex). NÃO usa biblioteca externa (mantém deps enxutas).
  * Para CNAB / formatos complexos: Onda 22 com `OfxImporter` dedicated service.
@@ -34,6 +36,9 @@ use Modules\Financeiro\Models\Titulo;
  * `uid` ("ofx:123" / "api:456"); match/ignorar resolvem a tabela certa pela
  * `origem`. NÃO há migração de dado — só leitura unificada + status na linha API.
  * @see memory/decisions/0236-extrato-conciliacao-modelo-unificado.md
+ *
+ * Auditoria (append-only): match/ignorar/reabrir registram quem+o quê+quando via
+ * FinanceiroAuditLogger (PII redacted, business_id preservado — ADR 0093 + Wave 14 D7.a).
  */
 class ConciliacaoController extends Controller
 {
@@ -41,10 +46,18 @@ class ConciliacaoController extends Controller
     {
         $businessId = (int) session('user.business_id');
 
-        // OFX (upload manual): pendentes + sugeridas.
+        // Toggle "ver conciliados/ignorados" — quando ligado, inclui linhas
+        // resolvidas pra permitir reabrir (undo). Default (não setado) mantém o
+        // fluxo original: só pendente/sugerido. Vale pras 2 origens (OFX + API).
+        $incluirResolvidos = $request->boolean('incluir_resolvidos');
+        $statusFiltro = $incluirResolvidos
+            ? ['pendente', 'sugerido', 'conciliado', 'ignorado']
+            : ['pendente', 'sugerido'];
+
+        // OFX (upload manual): pendentes/sugeridas (+ resolvidas se o toggle ligado).
         $linhas = DB::table('fin_bank_statement_lines')
             ->where('business_id', $businessId)
-            ->whereIn('status', ['pendente', 'sugerido'])
+            ->whereIn('status', $statusFiltro)
             ->whereNull('deleted_at')
             ->orderBy('data_movimento', 'desc')
             ->limit(200)
@@ -56,7 +69,12 @@ class ConciliacaoController extends Controller
         if ($this->apiConciliavel()) {
             $api = DB::table('fin_extrato_lancamentos')
                 ->where('business_id', $businessId)
-                ->where(fn ($q) => $q->whereNull('status')->orWhere('status', 'sugerido'))
+                ->where(function ($q) use ($incluirResolvidos) {
+                    $q->whereNull('status')->orWhere('status', 'sugerido');
+                    if ($incluirResolvidos) {
+                        $q->orWhereIn('status', ['conciliado', 'ignorado']);
+                    }
+                })
                 ->orderBy('data', 'desc')
                 ->limit(200)
                 ->get()
@@ -77,6 +95,9 @@ class ConciliacaoController extends Controller
             'linhas' => $linhas,
             'stats' => $stats,
             'contas' => $contas,
+            'filters' => [
+                'incluir_resolvidos' => $incluirResolvidos,
+            ],
         ]);
     }
 
@@ -253,17 +274,35 @@ class ConciliacaoController extends Controller
             'origem'    => 'nullable|in:ofx,api',
         ]);
         $businessId = (int) session('user.business_id');
+        $tituloId = $request->integer('titulo_id');
+        $userId = $request->user()?->id;
 
-        $this->conciliacaoTable($request->input('origem', 'ofx'))
+        // Fase 1 ADR 0236: conciliacaoTable() resolve a tabela certa pela origem
+        // (OFX/API). $afetadas alimenta a auditoria (quantas linhas o UPDATE tocou).
+        $afetadas = $this->conciliacaoTable($request->input('origem', 'ofx'))
             ->where('id', $lineId)
             ->where('business_id', $businessId)
             ->update([
                 'status'        => 'conciliado',
-                'titulo_id'     => $request->integer('titulo_id'),
-                'conciliado_by' => $request->user()?->id,
+                'titulo_id'     => $tituloId,
+                'conciliado_by' => $userId,
                 'conciliado_at' => now(),
                 'updated_at'    => now(),
             ]);
+
+        // Auditoria append-only (ADR 0093 + Wave 14 D7.a) — quem/o quê/quando.
+        // business_id/titulo_id são chaves operacionais (não redacionadas).
+        app(FinanceiroAuditLogger::class)->info(
+            'conciliacao.match: linha conciliada com título',
+            [
+                'business_id' => $businessId,
+                'line_id' => $lineId,
+                'titulo_id' => $tituloId,
+                'status' => 'conciliado',
+                'user_id' => $userId,
+                'afetadas' => $afetadas,
+            ]
+        );
 
         return back()->with('success', 'Conciliação confirmada.');
     }
@@ -272,14 +311,27 @@ class ConciliacaoController extends Controller
     {
         $request->validate(['origem' => 'nullable|in:ofx,api']);
         $businessId = (int) session('user.business_id');
+        $userId = $request->user()?->id;
 
-        $this->conciliacaoTable($request->input('origem', 'ofx'))
+        $afetadas = $this->conciliacaoTable($request->input('origem', 'ofx'))
             ->where('id', $lineId)
             ->where('business_id', $businessId)
             ->update([
                 'status'     => 'ignorado',
                 'updated_at' => now(),
             ]);
+
+        // Auditoria append-only (ADR 0093 + Wave 14 D7.a) — quem/o quê/quando.
+        app(FinanceiroAuditLogger::class)->info(
+            'conciliacao.ignorar: linha marcada como ignorada',
+            [
+                'business_id' => $businessId,
+                'line_id' => $lineId,
+                'status' => 'ignorado',
+                'user_id' => $userId,
+                'afetadas' => $afetadas,
+            ]
+        );
 
         return back()->with('success', 'Linha marcada como ignorada.');
     }
@@ -296,6 +348,70 @@ class ConciliacaoController extends Controller
         }
 
         return DB::table('fin_bank_statement_lines');
+    }
+
+    /**
+     * Reabre (undo) uma conciliação/ignore: volta a linha pra "pendente",
+     * limpa titulo_id + match_score, e registra a reabertura na auditoria.
+     * POST /financeiro/conciliacao/{lineId}/reabrir com {origem?}.
+     *
+     * Tier 0: scoped por business_id. Linha inexistente neste tenant → 404
+     * (não-silencioso). Fase 1 ADR 0236: `origem` (ofx|api) decide a tabela.
+     * Na origem API o estado "pendente" é representado por status NULL
+     * (nunca avaliada), pra reentrar no fluxo de sugestão.
+     */
+    public function reabrir(Request $request, int $lineId): RedirectResponse
+    {
+        $request->validate(['origem' => 'nullable|in:ofx,api']);
+        $origem = (string) $request->input('origem', 'ofx');
+        $businessId = (int) session('user.business_id');
+        $userId = $request->user()?->id;
+
+        // Carrega estado anterior pra auditoria + valida existência no tenant.
+        $linha = $this->conciliacaoTable($origem)
+            ->where('id', $lineId)
+            ->where('business_id', $businessId)
+            ->first();
+
+        if (! $linha) {
+            // Não-silencioso: linha não existe pra este business (Tier 0).
+            abort(404);
+        }
+
+        $statusAnterior = $linha->status;
+
+        // Campos comuns às 2 origens; conciliado_by/at só existem no OFX.
+        $update = [
+            'status'      => $origem === 'api' ? null : 'pendente',
+            'titulo_id'   => null,
+            'match_score' => null,
+            'updated_at'  => now(),
+        ];
+        if ($origem === 'ofx') {
+            $update['conciliado_by'] = null;
+            $update['conciliado_at'] = null;
+        }
+
+        $this->conciliacaoTable($origem)
+            ->where('id', $lineId)
+            ->where('business_id', $businessId)
+            ->update($update);
+
+        // Auditoria append-only (ADR 0093 + Wave 14 D7.a) — status de onde veio.
+        app(FinanceiroAuditLogger::class)->info(
+            'conciliacao.reabrir: linha reaberta (volta a pendente)',
+            [
+                'business_id' => $businessId,
+                'line_id' => $lineId,
+                'origem' => $origem,
+                'status' => 'pendente',
+                'status_anterior' => $statusAnterior,
+                'titulo_id' => $linha->titulo_id ?? null,
+                'user_id' => $userId,
+            ]
+        );
+
+        return back()->with('success', 'Linha reaberta — voltou para pendente.');
     }
 
     /** OFX TRNTYPE → enum interno */

--- a/Modules/Financeiro/Routes/web.php
+++ b/Modules/Financeiro/Routes/web.php
@@ -229,6 +229,10 @@ Route::middleware(['web', 'auth', 'language', 'timezone', 'AdminSidebarMenu'])
         Route::post('/conciliacao/{lineId}/ignorar', [ConciliacaoController::class, 'ignorar'])
             ->whereNumber('lineId')
             ->name('conciliacao.ignorar');
+        // Reabrir (undo) conciliação/ignore → volta a pendente + audit-log.
+        Route::post('/conciliacao/{lineId}/reabrir', [ConciliacaoController::class, 'reabrir'])
+            ->whereNumber('lineId')
+            ->name('conciliacao.reabrir');
 
         // Onda 23 (2026-05-20) US-FIN-029 — OCR boleto upload (OpenAI Vision).
         // KILLER feature vs Conta Azul. Endpoint não cria titulo direto —

--- a/Modules/Financeiro/Tests/Feature/ConciliacaoAuditReabrirTest.php
+++ b/Modules/Financeiro/Tests/Feature/ConciliacaoAuditReabrirTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Business;
+use App\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Spatie\Permission\Models\Permission;
+
+uses(Tests\TestCase::class);
+
+/**
+ * B2 — Auditoria + Reabrir (undo) da Conciliação OFX.
+ *
+ * Cobre invariantes:
+ *  (a) match()/ignorar() escrevem entrada de auditoria via FinanceiroAuditLogger
+ *      (sink = Log facade; espiamos com Log::spy + shouldHaveReceived).
+ *  (b) reabrir() volta status pra `pendente` e zera titulo_id/match_score.
+ *  (c) reabrir() de linha de OUTRO business → 404 (Tier 0 ADR 0093 IRREVOGÁVEL).
+ *
+ * Padrão Financeiro (CaixaControllerTest/UnificadoControllerTest): sem
+ * RefreshDatabase (UltimatePOS tem 100+ migrations + triggers), roda contra DB
+ * dev real, skip gracioso quando greenfield ou módulo não instalado.
+ *
+ * Rodar local: `vendor/bin/pest Modules/Financeiro/Tests/Feature/ConciliacaoAuditReabrirTest.php`
+ */
+
+function conciliacaoBootstrap(): User
+{
+    try {
+        $business = Business::first();
+    } catch (\Throwable $e) {
+        test()->markTestSkipped('Tabela business indisponível: '.$e->getMessage());
+    }
+
+    if (! $business) {
+        test()->markTestSkipped('Sem business no banco — rode seeder UltimatePOS antes.');
+    }
+
+    $user = User::where('business_id', $business->id)->first();
+    if (! $user) {
+        test()->markTestSkipped('Sem user no business.');
+    }
+
+    // Tabela alvo precisa existir neste env (módulo instalado).
+    if (! \Illuminate\Support\Facades\Schema::hasTable('fin_bank_statement_lines')) {
+        test()->markTestSkipped('Tabela fin_bank_statement_lines ausente — financeiro:install pendente.');
+    }
+
+    Permission::firstOrCreate(['name' => 'financeiro.conciliacao.manage', 'guard_name' => 'web']);
+    if (! $user->hasPermissionTo('financeiro.conciliacao.manage')) {
+        $user->givePermissionTo('financeiro.conciliacao.manage');
+    }
+
+    session([
+        'user.business_id' => $business->id,
+        'user.id'          => $user->id,
+        'business.id'      => $business->id,
+        'business.name'    => $business->name,
+        'is_admin'         => true,
+    ]);
+
+    // POSTs do teste vão direto no controller (sem token CSRF de browser → 419).
+    test()->withoutMiddleware(\App\Http\Middleware\VerifyCsrfToken::class);
+
+    return $user;
+}
+
+/** Insere uma linha de extrato pendente pro business do user e devolve o id. */
+function inserirLinhaConciliacao(int $businessId, array $overrides = []): int
+{
+    return (int) DB::table('fin_bank_statement_lines')->insertGetId(array_merge([
+        'business_id'    => $businessId,
+        'fitid'          => 'pest-'.uniqid('', true),
+        'data_movimento' => now()->toDateString(),
+        'descricao'      => 'Lançamento de teste B2',
+        'valor'          => -123.45,
+        'tipo'           => 'debit',
+        'status'         => 'pendente',
+        'source_file'    => 'pest.ofx',
+        'created_at'     => now(),
+        'updated_at'     => now(),
+    ], $overrides));
+}
+
+it('match() escreve entrada de auditoria via FinanceiroAuditLogger', function () {
+    $user = conciliacaoBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    $lineId = inserirLinhaConciliacao($businessId);
+
+    // titulo_id REAL — fin_bank_statement_lines.titulo_id tem FK → fin_titulos.
+    $tituloId = (int) DB::table('fin_titulos')->insertGetId([
+        'business_id'     => $businessId,
+        'numero'          => 'AUDIT-'.uniqid(),
+        'tipo'            => 'receber',
+        'status'          => 'aberto',
+        'valor_total'     => 100.00,
+        'valor_aberto'    => 100.00,
+        'moeda'           => 'BRL',
+        'emissao'         => now()->toDateString(),
+        'vencimento'      => now()->toDateString(),
+        'competencia_mes' => now()->format('Y-m'),
+        'origem'          => 'manual',
+        'origem_id'       => random_int(800000, 899999),
+        'created_by'      => $user->id,
+        'created_at'      => now(),
+        'updated_at'      => now(),
+    ]);
+
+    // Captura logs via listener — NÃO mocka o Log (Log::spy faria Log::channel()
+    // retornar null e quebraria outros componentes do request → 500).
+    $logs = [];
+    Log::listen(function ($e) use (&$logs) {
+        $logs[] = ['message' => (string) $e->message, 'context' => $e->context];
+    });
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/conciliacao')
+        ->post("/financeiro/conciliacao/{$lineId}/match", ['titulo_id' => $tituloId]);
+
+    expect($response->status())->toBeIn([302, 303]);
+
+    $entry = collect($logs)->first(fn ($l) => str_contains($l['message'], 'conciliacao.match'));
+    expect($entry)->not->toBeNull();
+    expect($entry['context']['business_id'] ?? null)->toBe($businessId);
+    expect($entry['context']['line_id'] ?? null)->toBe($lineId);
+    expect($entry['context']['status'] ?? null)->toBe('conciliado');
+    expect((int) ($entry['context']['titulo_id'] ?? 0))->toBe($tituloId);
+
+    // Cleanup.
+    DB::table('fin_bank_statement_lines')->where('id', $lineId)->delete();
+    DB::table('fin_titulos')->where('id', $tituloId)->delete();
+});
+
+it('ignorar() escreve entrada de auditoria via FinanceiroAuditLogger', function () {
+    $user = conciliacaoBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    $lineId = inserirLinhaConciliacao($businessId);
+
+    $logs = [];
+    Log::listen(function ($e) use (&$logs) {
+        $logs[] = ['message' => (string) $e->message, 'context' => $e->context];
+    });
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/conciliacao')
+        ->post("/financeiro/conciliacao/{$lineId}/ignorar");
+
+    expect($response->status())->toBeIn([302, 303]);
+
+    $entry = collect($logs)->first(fn ($l) => str_contains($l['message'], 'conciliacao.ignorar'));
+    expect($entry)->not->toBeNull();
+    expect($entry['context']['business_id'] ?? null)->toBe($businessId);
+    expect($entry['context']['line_id'] ?? null)->toBe($lineId);
+    expect($entry['context']['status'] ?? null)->toBe('ignorado');
+
+    DB::table('fin_bank_statement_lines')->where('id', $lineId)->delete();
+});
+
+it('reabrir() volta status pra pendente e zera titulo_id/match_score', function () {
+    $user = conciliacaoBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    // Linha já conciliada (com titulo_id + match_score) pra ter o que desfazer.
+    $lineId = inserirLinhaConciliacao($businessId, [
+        'status'        => 'conciliado',
+        'titulo_id'     => 12345,
+        'match_score'   => 0.85,
+        'conciliado_by' => $user->id,
+        'conciliado_at' => now(),
+    ]);
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/conciliacao')
+        ->post("/financeiro/conciliacao/{$lineId}/reabrir");
+
+    expect($response->status())->toBeIn([302, 303]);
+
+    $linha = DB::table('fin_bank_statement_lines')->where('id', $lineId)->first();
+    expect($linha->status)->toBe('pendente');
+    expect($linha->titulo_id)->toBeNull();
+    expect($linha->match_score)->toBeNull();
+
+    DB::table('fin_bank_statement_lines')->where('id', $lineId)->delete();
+});
+
+it('reabrir() é idempotente — linha já pendente continua pendente (sem erro)', function () {
+    $user = conciliacaoBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    $lineId = inserirLinhaConciliacao($businessId); // já pendente
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/conciliacao')
+        ->post("/financeiro/conciliacao/{$lineId}/reabrir");
+
+    expect($response->status())->toBeIn([302, 303]);
+
+    $linha = DB::table('fin_bank_statement_lines')->where('id', $lineId)->first();
+    expect($linha->status)->toBe('pendente');
+
+    DB::table('fin_bank_statement_lines')->where('id', $lineId)->delete();
+});
+
+it('Tier 0: reabrir() de linha de OUTRO business retorna 404 (ADR 0093)', function () {
+    $user = conciliacaoBootstrap();
+    $businessId = (int) session('user.business_id');
+
+    $businessB = Business::where('id', '!=', $businessId)->first();
+    if (! $businessB) {
+        test()->markTestSkipped('Apenas 1 business no DB — não há cross-tenant pra testar.');
+    }
+
+    // Linha pertencente ao businessB (NÃO ao tenant logado).
+    $lineId = inserirLinhaConciliacao($businessB->id, ['status' => 'conciliado']);
+
+    $response = $this->actingAs($user)
+        ->from('/financeiro/conciliacao')
+        ->post("/financeiro/conciliacao/{$lineId}/reabrir");
+
+    expect($response->status())->toBe(404);
+
+    // Garante que NÃO mutou a linha do outro tenant (continua conciliado).
+    $linha = DB::table('fin_bank_statement_lines')->where('id', $lineId)->first();
+    expect($linha->status)->toBe('conciliado');
+
+    DB::table('fin_bank_statement_lines')->where('id', $lineId)->delete();
+});


### PR DESCRIPTION
Re-implementação do #2044 (backend) sobre main — a Fase 1/2 ADR 0236 reescreveu o controller pra 2 origens (OFX+API), então apliquei preservando `conciliacaoTable(origem)`.

### O que entra (backend só)
- **match/ignorar**: `FinanceiroAuditLogger` append-only (quem/o quê/quando, PII redacted, business_id preservado).
- **reabrir()** (undo): volta linha pra pendente, zera titulo_id/match_score, audita. **Suporta 2 origens** (API: status NULL = pendente). Tier 0 → 404 cross-tenant.
- **index**: `?incluir_resolvidos=1` mostra conciliados/ignorados nas 2 origens (pra reabrir).
- Rota `POST /financeiro/conciliacao/{lineId}/reabrir`.

### Validação
- **Pest 5/5 no CT 100** (MySQL biz=1): match/ignorar audit, reabrir, idempotência, **Tier 0 404**. O CT 100 pegou 3 bugs que o sqlite do CI mascarava: CSRF 419, Log::spy quebrando channel(), FK titulo_id.
- PHPStan: gate CI.

### Fora deste PR
A **UI** (botão reabrir + toggle em `Conciliacao/Index.tsx`) vem em PR separado **com aprovação visual do Wagner (R2)**.

Supersedes #2044 (parte backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)