### PR TITLE
feat(cliente): habilita enviar/excluir anexos no drawer (era read-only)

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -1528,6 +1528,116 @@ class ContactController extends Controller
     }
 
     /**
+     * Wagner 2026-06-01 — upload de anexo do cliente (drawer Operações → Documentos).
+     * Cria 1 document-note + anexa o arquivo (media) ao contato. Habilita o
+     * "anexar" que estava read-only (botão oculto + endpoint legado /post-document-upload
+     * não persistia o vínculo). Pareado com GET (listar) e DELETE (excluir).
+     *
+     * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): contato resolvido DENTRO do
+     * business; o document-note herda business_id; Media::uploadMedia grava com
+     * o mesmo scope.
+     *
+     * POST /cliente/{id}/anexos  (campo `file`)
+     */
+    public function storeAnexo(Request $request, $id)
+    {
+        $request->validate([
+            'file' => 'required|file|max:25600', // 25 MB
+        ]);
+
+        $business_id = request()->session()->get('user.business_id');
+        $user_id = request()->session()->get('user.id');
+
+        $contact = \App\Contact::where('business_id', $business_id)->findOrFail($id);
+
+        $file = $request->file('file');
+        $heading = $file instanceof \Illuminate\Http\UploadedFile
+            ? $file->getClientOriginalName()
+            : 'anexo';
+
+        \Illuminate\Support\Facades\DB::beginTransaction();
+        try {
+            $note = $contact->documentsAndnote()->create([
+                'business_id' => $business_id,
+                'created_by' => $user_id,
+                'heading' => $heading,
+            ]);
+
+            \App\Media::uploadMedia($business_id, $note, $request, 'file', true);
+
+            \Illuminate\Support\Facades\DB::commit();
+        } catch (\Throwable $e) {
+            \Illuminate\Support\Facades\DB::rollBack();
+            \Log::error('storeAnexo cliente '.$id.': '.$e->getMessage());
+
+            return response()->json(['message' => __('messages.something_went_wrong')], 500);
+        }
+
+        $media = \App\Media::where('business_id', $business_id)
+            ->where('model_type', \App\DocumentAndNote::class)
+            ->where('model_id', $note->id)
+            ->orderByDesc('id')
+            ->first();
+
+        return response()->json([
+            'success' => true,
+            'document' => $media ? [
+                'id' => (int) $media->id,
+                'file_name' => $media->file_name,
+                'display_name' => $media->display_name,
+                'description' => $media->description,
+                'file_size' => null,
+                'mime_type' => null,
+                'uploaded_by_name' => null,
+                'created_at' => optional($media->created_at)->toISOString(),
+                'download_url' => $media->display_url,
+            ] : null,
+        ], 201);
+    }
+
+    /**
+     * Wagner 2026-06-01 — exclui um anexo (media) do cliente. Valida que o media
+     * pertence a um document-note DESTE contato (Tier 0 business_id scope) antes
+     * de excluir. Remove o document-note se ficar órfão (sem media e sem texto).
+     *
+     * DELETE /cliente/{id}/anexos/{mediaId}
+     */
+    public function destroyAnexo($id, $mediaId)
+    {
+        $business_id = request()->session()->get('user.business_id');
+
+        \App\Contact::where('business_id', $business_id)->findOrFail($id);
+
+        $noteIds = \App\DocumentAndNote::where('business_id', $business_id)
+            ->where('notable_type', \App\Contact::class)
+            ->where('notable_id', $id)
+            ->pluck('id');
+
+        $media = \App\Media::where('business_id', $business_id)
+            ->where('model_type', \App\DocumentAndNote::class)
+            ->whereIn('model_id', $noteIds)
+            ->where('id', $mediaId)
+            ->firstOrFail();
+
+        $noteId = $media->model_id;
+        $media->delete();
+
+        // Remove o document-note se ficou órfão (sem outras medias e sem texto).
+        $remaining = \App\Media::where('business_id', $business_id)
+            ->where('model_type', \App\DocumentAndNote::class)
+            ->where('model_id', $noteId)
+            ->count();
+        if ($remaining === 0) {
+            \App\DocumentAndNote::where('business_id', $business_id)
+                ->where('id', $noteId)
+                ->whereNull('description')
+                ->delete();
+        }
+
+        return response()->json(['success' => true]);
+    }
+
+    /**
      * Store a newly created resource in storage.
      *
      * Slice 7 — type-hint StoreContactRequest wira App\Rules\BR\CpfCnpj +

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -2077,6 +2077,10 @@ function ClienteSheet({
                   contact={{ id: contact.id, name: contact.name }}
                   activeSubTab={opsSubTab}
                   onSubTabChange={setOpsSubTab}
+                  /* Wagner 2026-06-01 — habilita anexar/excluir/notas no drawer.
+                     Legado concede view/create/delete de documentos a quem vê o
+                     contato (DocumentAndNoteController::__getPermission p/ App\Contact). */
+                  permissions={{ upload: true, delete_document: true, edit_note: true }}
                 />
               )}
               {activeTab === 'placas' && oficinaAutoEnabled && (

--- a/resources/js/Pages/Cliente/_show/DocumentsTab.tsx
+++ b/resources/js/Pages/Cliente/_show/DocumentsTab.tsx
@@ -1,16 +1,16 @@
 // Wave D — US-CRM-066 Tab Documents & Note (MWART F3 paridade /contacts/{id} tab documents_and_notes)
-// Restrições Tier 0 (ADR 0093): backend DocumentAndNoteController filtra business_id global scope.
-// Backend endpoints existentes (routes/web.php linhas 599-601):
-//   POST /post-document-upload (DocumentAndNoteController::postMedia)
-//   GET  /note-documents (index, datatable)
-//   GET  /note-documents/{id} (show)
-//   POST /note-documents (store — notes)
-//   PUT  /note-documents/{id} (update)
-//   DELETE /note-documents/{id} (destroy)
+// Restrições Tier 0 (ADR 0093): backend filtra business_id global scope em todas as queries.
+//
+// Anexos (Wagner 2026-06-01) — endpoints dedicados ContactController, business_id scope:
+//   GET    /cliente/{id}/anexos           (listar — mesma fonte do contador "N anexos" do header)
+//   POST   /cliente/{id}/anexos           (enviar — cria document-note + anexa media ao contato)
+//   DELETE /cliente/{id}/anexos/{mediaId} (excluir — valida posse no contato antes)
+// Notas (texto) seguem no DocumentAndNoteController:
+//   POST /note-documents (store) · PUT /note-documents/{id} (update)
 //
 // Modelo polimórfico: notable_id={contact.id}, notable_type='App\Contact'
 //
-// Pattern reuse: Essentials/Documents/Index.tsx (upload + list) + textarea autosave debounced 1.5s.
+// Pattern: textarea autosave debounced 1.5s + lista de anexos recarregada do backend.
 
 import { useEffect, useRef, useState } from 'react';
 import { Download, FileText, Loader2, Paperclip, StickyNote, Trash2, Upload } from 'lucide-react';
@@ -92,31 +92,26 @@ export default function DocumentsTab({
   const fileRef = useRef<HTMLInputElement | null>(null);
   const noteTimeoutRef = useRef<number | null>(null);
 
-  // Wagner 2026-06-01 — carrega anexos existentes do backend ao montar (fecha o
-  // gap Wave D: antes o painel mostrava "Anexos (0)" mesmo com arquivos salvos,
-  // divergindo do contador "📎 N anexos" do header). Só busca quando `documents`
-  // NÃO veio por prop (preserva usos prop-driven/SSR). GET /cliente/{id}/anexos.
-  useEffect(() => {
+  // Wagner 2026-06-01 — carrega anexos do backend. Reutilizado no mount E após
+  // upload/exclusão (backend é a fonte da verdade). Só quando `documents` NÃO
+  // veio por prop (preserva usos prop-driven/SSR). GET /cliente/{id}/anexos.
+  const loadDocuments = async () => {
     if (docsProp !== undefined) return;
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await fetch(`/cliente/${contactId}/anexos`, {
-          credentials: 'same-origin',
-          headers: { 'X-Requested-With': 'XMLHttpRequest', Accept: 'application/json' },
-        });
-        if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = await res.json();
-        if (!cancelled && Array.isArray(data?.documents)) {
-          setDocuments(data.documents as DocumentItem[]);
-        }
-      } catch {
-        // silencioso: painel permanece vazio (mesmo fallback de antes).
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
+    try {
+      const res = await fetch(`/cliente/${contactId}/anexos`, {
+        credentials: 'same-origin',
+        headers: { 'X-Requested-With': 'XMLHttpRequest', Accept: 'application/json' },
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      if (Array.isArray(data?.documents)) setDocuments(data.documents as DocumentItem[]);
+    } catch {
+      // silencioso: painel permanece com o estado atual (mesmo fallback de antes).
+    }
+  };
+
+  useEffect(() => {
+    void loadDocuments();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [contactId]);
 
@@ -174,11 +169,12 @@ export default function DocumentsTab({
     try {
       for (const file of Array.from(files)) {
         const fd = new FormData();
-        fd.append('notable_id', String(contactId));
-        fd.append('notable_type', notableType);
-        fd.append('document', file);
+        fd.append('file', file);
 
-        const res = await fetch('/post-document-upload', {
+        // Wagner 2026-06-01 — endpoint dedicado que PERSISTE (cria document-note
+        // + anexa media ao contato), business_id scope. Substitui o endpoint
+        // legado (postMedia) que só subia o arquivo sem persistir o vínculo.
+        const res = await fetch(`/cliente/${contactId}/anexos`, {
           method: 'POST',
           body: fd,
           credentials: 'same-origin',
@@ -189,11 +185,9 @@ export default function DocumentsTab({
           },
         });
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
-        const data = await res.json().catch(() => null);
-        if (data?.document) {
-          setDocuments((prev) => [data.document, ...prev]);
-        }
       }
+      // Recarrega do backend (fonte da verdade) — reflete o que persistiu.
+      await loadDocuments();
     } catch (err) {
       // eslint-disable-next-line no-alert
       alert('Erro ao enviar arquivo. Tente novamente.');
@@ -207,11 +201,11 @@ export default function DocumentsTab({
     if (!confirm('Excluir este anexo?')) return;
     try {
       const fd = new FormData();
-      fd.append('_method', 'DELETE');
-      fd.append('notable_id', String(contactId));
-      fd.append('notable_type', notableType);
+      fd.append('_method', 'DELETE'); // Laravel honra _method via POST
 
-      const res = await fetch(`/note-documents/${docId}`, {
+      // docId = id do media (DocumentItem.id). Endpoint valida que pertence a um
+      // document-note DESTE contato (business_id scope) antes de excluir.
+      const res = await fetch(`/cliente/${contactId}/anexos/${docId}`, {
         method: 'POST',
         body: fd,
         credentials: 'same-origin',

--- a/routes/web.php
+++ b/routes/web.php
@@ -267,6 +267,10 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     // Tier 0 multi-tenant: scope business_id no controller (ContactController::anexos).
     Route::get('/cliente/{id}/anexos', [ContactController::class, 'anexos'])
         ->name('cliente.anexos.index')->whereNumber('id');
+    Route::post('/cliente/{id}/anexos', [ContactController::class, 'storeAnexo'])
+        ->name('cliente.anexos.store')->whereNumber('id');
+    Route::delete('/cliente/{id}/anexos/{mediaId}', [ContactController::class, 'destroyAnexo'])
+        ->name('cliente.anexos.destroy')->whereNumber('id')->whereNumber('mediaId');
 
     Route::get('taxonomies-ajax-index-page', [TaxonomyController::class, 'getTaxonomyIndexPage']);
     Route::resource('taxonomies', TaxonomyController::class);

--- a/tests/Feature/Cliente/ClienteAnexosEndpointTest.php
+++ b/tests/Feature/Cliente/ClienteAnexosEndpointTest.php
@@ -70,3 +70,58 @@ test('GUARD 4 — GET /cliente/{id}/anexos nao vaza anexos sem auth', function (
     // (vazaria anexos sem sessao) nem 500 (erro de codigo).
     expect(in_array($response->status(), [302, 401, 403, 404], true))->toBeTrue();
 });
+
+// ════════════════════════════════════════════════════════════════════════
+// Wagner 2026-06-01 — habilita ENVIAR/EXCLUIR anexos no drawer (era read-only:
+// botoes ocultos + endpoint legado /post-document-upload nao persistia).
+// ════════════════════════════════════════════════════════════════════════
+
+// ─── GUARD 5: rotas POST + DELETE registradas ─────────────────────────────
+
+test('GUARD 5 — routes/web.php registra POST + DELETE /cliente/{id}/anexos', function () {
+    $path = __DIR__ . '/../../../routes/web.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("Route::post('/cliente/{id}/anexos', [ContactController::class, 'storeAnexo'])")
+        ->toContain("->name('cliente.anexos.store')")
+        ->toContain("Route::delete('/cliente/{id}/anexos/{mediaId}', [ContactController::class, 'destroyAnexo'])")
+        ->toContain("->name('cliente.anexos.destroy')");
+});
+
+// ─── GUARD 6: storeAnexo/destroyAnexo — tenant scope + persiste ───────────
+
+test('GUARD 6 — storeAnexo/destroyAnexo com business_id scope + persistencia', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain('public function storeAnexo(Request $request, $id)')
+        ->toContain('public function destroyAnexo($id, $mediaId)')
+        // Tier 0: contato resolvido DENTRO do business nos dois metodos.
+        ->toContain("Contact::where('business_id', \$business_id)->findOrFail(\$id)")
+        // Upload persiste: cria document-note + anexa media (helper canon).
+        ->toContain('$contact->documentsAndnote()->create(')
+        ->toContain("Media::uploadMedia(\$business_id, \$note, \$request, 'file', true)")
+        // Delete valida que o media pertence a um note DESTE contato (scope).
+        ->toContain("->where('model_type', \\App\\DocumentAndNote::class)")
+        ->toContain('->firstOrFail()');
+});
+
+// ─── GUARD 7: frontend usa endpoints novos + permissoes habilitadas ───────
+
+test('GUARD 7 — DocumentsTab usa endpoints novos + Index habilita permissoes', function () {
+    $docTab = file_get_contents(__DIR__ . '/../../../resources/js/Pages/Cliente/_show/DocumentsTab.tsx');
+    $index = file_get_contents(__DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx');
+
+    expect($docTab)
+        // Upload/delete pelos endpoints dedicados (recarrega do backend).
+        ->toContain('await loadDocuments()')
+        ->toContain('/cliente/${contactId}/anexos/${docId}')
+        // Endpoint legado quebrado NAO e mais usado.
+        ->not->toContain('/post-document-upload');
+
+    // Index passa permissoes pro OssTab (senao botoes ficam ocultos no drawer).
+    expect($index)
+        ->toContain('permissions={{ upload: true, delete_document: true, edit_note: true }}');
+});


### PR DESCRIPTION
## O quê

O painel **Operações → Documentos** carregava os anexos (PR #2086) mas o **enviar/excluir ficava read-only** — exatamente o que Wagner apontou (*"não da para anexar fica read only"*). Causa dupla: (1) botões ocultos (`OssTab` repassava `permissions` `false` pro `DocumentsTab`), (2) endpoint de upload legado não persistia o vínculo (só subia o arquivo). Este PR habilita anexar/excluir de verdade.

## Mudanças (5 arquivos · +212/−45)

- **ContactController::storeAnexo** (`POST /cliente/{id}/anexos`) — cria 1 `document-note` + anexa o arquivo (`Media::uploadMedia`) ao contato. `business_id` scope.
- **ContactController::destroyAnexo** (`DELETE /cliente/{id}/anexos/{mediaId}`) — valida que o media pertence a um document-note **deste** contato (Tier 0) antes de excluir; remove o note se ficar órfão.
- **routes/web.php** — `cliente.anexos.store` + `cliente.anexos.destroy` (`whereNumber`).
- **Index.tsx** — passa `permissions={{ upload, delete_document, edit_note: true }}` pro `OssTab` (legado concede view/create/delete a quem vê o contato).
- **DocumentsTab** — `handleUpload`/`handleDelete` pelos endpoints dedicados + recarrega do backend (fonte da verdade). Remove o uso do endpoint legado.
- **Pest** — GUARD 5-7 (rotas, scope+persistência, frontend wiring).

## Verificação (código)

- ✅ PHPStan `[OK] No errors` (storeAnexo/destroyAnexo larastan-clean).
- ✅ Pest: GUARD 1-3,5,6,7 passam (GUARD 4 = `$this->get()` que só binda TestCase no checkout real do CI — mesmo padrão verde no PR #2086).
- ✅ ESLint ratchet: sem regressões. tsc: zero erro novo nos arquivos.

> ⚠️ **Browser-test pendente**: o app local (`oimpresso.test`) está em 502 (Octane/RoadRunner parado), então não consegui abrir no Chrome ainda. Validação do fluxo de anexar via browser vai em staging OU prod pós-deploy (a combinar com Wagner — sem upload de teste em dados reais de prod sem OK).

## Infra Contract

Runtime tocado: **2 rotas novas** (`POST`/`DELETE /cliente/{id}/anexos`) em `routes/web.php`, atrás de auth + `business_id` scope. Sem `.htaccess`/middleware/Kernel/ServiceProvider/bootstrap, sem migração.

### Esperado pós-deploy (preencher com cole real)

\`\`\`bash
# upload (multipart, campo file) — esperado 201 + {success:true}
$ curl -sv -X POST 'https://oimpresso.com/cliente/<ID>/anexos' -F 'file=@teste.pdf' \
    -H 'X-CSRF-TOKEN: <t>' -H 'Cookie: <sessao>' 2>&1 | grep '^< HTTP'
< HTTP/1.1 201

# excluir — esperado 200 + {success:true}
$ curl -sv -X DELETE 'https://oimpresso.com/cliente/<ID>/anexos/<MEDIA_ID>' \
    -H 'X-CSRF-TOKEN: <t>' -H 'Cookie: <sessao>' 2>&1 | grep '^< HTTP'
< HTTP/1.1 200

# sem auth — NUNCA 200/201 (não cria nada sem sessão)
$ curl -sv -X POST 'https://oimpresso.com/cliente/1/anexos' 2>&1 | grep '^< HTTP'
< HTTP/1.1 302
\`\`\`

Rollback: `git revert` (aditivo). DocumentsTab degrada graceful (alert + lista intacta) se o endpoint falhar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)