### PR TITLE
fix(cliente): upload e exclusão de anexos no drawer (Operações → Documentos)

### DIFF
--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -1528,6 +1528,126 @@ class ContactController extends Controller
     }
 
     /**
+     * Wagner 2026-06-01 — UPLOAD de anexo do cliente pro drawer (Operações → Documentos).
+     * Fecha o gap do PR #2086: o GET (anexos) já lista, mas o upload estava quebrado.
+     * O endpoint legado /post-document-upload (DocumentAndNoteController::postMedia) só
+     * rodava Media::uploadFile() — gravava o arquivo em disco e devolvia { file_name },
+     * SEM criar o DocumentAndNote nem vincular o media ao contato (arquivo órfão) e sem
+     * devolver o `document` que o React espera. Aqui criamos 1 DocumentAndNote + media
+     * via Media::uploadMedia (espelhando o store() canônico) e devolvemos o DocumentItem
+     * (mesmo shape do GET) pro React inserir na lista sem refetch.
+     *
+     * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): contato + nota + media TODOS scoped em
+     * business_id. O legado DocumentAndNoteController::__getPermission concede
+     * view/create/delete a quem vê o contato (App\Contact) — e o drawer só abre pra
+     * contatos da listagem (já gated). Sem relação/has() — larastan-clean igual ao GET.
+     *
+     * POST /cliente/{id}/anexos (campo `file`) → { document: DocumentItem }
+     */
+    public function anexosStore(Request $request, $id)
+    {
+        $business_id = $request->session()->get('user.business_id');
+
+        // 404 cross-tenant: o contato precisa existir DENTRO do business.
+        $contact = \App\Contact::where('business_id', $business_id)->findOrFail($id);
+
+        $request->validate([
+            'file' => ['required', 'file'],
+        ]);
+
+        // 1 upload = 1 DocumentAndNote (espelha store() legacy: business_id + created_by
+        // + morph notable apontando pro contato). is_private=false explícito evita NOT NULL.
+        $note = new \App\DocumentAndNote();
+        $note->business_id = $business_id;
+        $note->notable_id = $contact->id;
+        $note->notable_type = \App\Contact::class;
+        $note->created_by = $request->session()->get('user.id');
+        $note->is_private = false;
+        $note->save();
+
+        // Anexa o arquivo do campo `file` ao note (is_single=true). uploadFile engole
+        // silenciosamente arquivos acima de constants.document_size_limit (retorna null).
+        \App\Media::uploadMedia($business_id, $note, $request, 'file', true);
+
+        $media = \App\Media::where('business_id', $business_id)
+            ->where('model_type', \App\DocumentAndNote::class)
+            ->where('model_id', $note->id)
+            ->orderByDesc('id')
+            ->first();
+
+        if ($media === null) {
+            // Upload não persistiu (ex: arquivo grande demais) → remove a nota vazia
+            // pra não deixar lixo e devolve erro explícito (React mostra alerta).
+            $note->delete();
+
+            return response()->json(['message' => __('messages.something_went_wrong')], 422);
+        }
+
+        return response()->json([
+            'document' => [
+                'id' => (int) $media->id,
+                'file_name' => $media->file_name,
+                'display_name' => $media->display_name,
+                'description' => $media->description,
+                'file_size' => null,
+                'mime_type' => null,
+                'uploaded_by_name' => null,
+                'created_at' => optional($media->created_at)->toISOString(),
+                'download_url' => $media->display_url,
+            ],
+        ], 201);
+    }
+
+    /**
+     * Wagner 2026-06-01 — EXCLUSÃO de anexo do cliente (drawer Operações → Documentos).
+     * Recebe o ID do MEDIA (não da nota): corrige a semântica errada do handleDelete
+     * antigo, que mandava o media id pra DELETE /note-documents/{noteId}. Valida que o
+     * media é de um document-note DESTE contato + business antes de excluir (Tier 0).
+     * Remove também a nota dona se ela ficar órfã (no fluxo de upload do drawer cada
+     * nota carrega 1 anexo e nenhum texto).
+     *
+     * Multi-tenant Tier 0 (ADR 0093 IRREVOGÁVEL): contato + media + nota dona TODOS
+     * scoped em business_id; o media só some se a nota dona for deste contato. Sem
+     * relação/has() — larastan-clean igual ao GET (reusa Media::deleteMedia canônico).
+     *
+     * DELETE /cliente/{id}/anexos/{mediaId} → { success: true }
+     */
+    public function anexosDestroy(Request $request, $id, $mediaId)
+    {
+        $business_id = $request->session()->get('user.business_id');
+
+        // 404 cross-tenant: o contato precisa existir DENTRO do business.
+        \App\Contact::where('business_id', $business_id)->findOrFail($id);
+
+        // O media precisa ser de um document-note (model_type) e do business.
+        $media = \App\Media::where('business_id', $business_id)
+            ->where('model_type', \App\DocumentAndNote::class)
+            ->findOrFail($mediaId);
+
+        // A nota dona precisa ser um document-note DESTE contato (Tier 0 + escopo).
+        $note = \App\DocumentAndNote::where('business_id', $business_id)
+            ->where('notable_type', \App\Contact::class)
+            ->where('notable_id', $id)
+            ->where('id', $media->model_id)
+            ->firstOrFail();
+
+        // Reusa o helper canônico (apaga arquivo do disco + linha, scoped business_id).
+        \App\Media::deleteMedia($business_id, $media->id);
+
+        // Remove a nota se ficou sem anexos nem texto (fluxo upload do drawer = 1:1).
+        $stillHasMedia = \App\Media::where('business_id', $business_id)
+            ->where('model_type', \App\DocumentAndNote::class)
+            ->where('model_id', $note->id)
+            ->exists();
+
+        if (! $stillHasMedia && blank($note->description) && blank($note->heading)) {
+            $note->delete();
+        }
+
+        return response()->json(['success' => true]);
+    }
+
+    /**
      * Store a newly created resource in storage.
      *
      * Slice 7 — type-hint StoreContactRequest wira App\Rules\BR\CpfCnpj +

--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -2077,6 +2077,17 @@ function ClienteSheet({
                   contact={{ id: contact.id, name: contact.name }}
                   activeSubTab={opsSubTab}
                   onSubTabChange={setOpsSubTab}
+                  permissions={{
+                    // Documentos (anexos + notas): o legado DocumentAndNoteController::
+                    // __getPermission concede view/create/delete pra App\Contact a quem
+                    // VÊ o contato — e o drawer só abre pra contatos da listagem (já
+                    // gated). Sem essas flags o botão "Enviar", o excluir e a textarea
+                    // de Notas ficavam inativos (default false do OssTab). O backend
+                    // re-valida tudo com scope business_id (Tier 0 · ADR 0093).
+                    upload: true,
+                    delete_document: true,
+                    edit_note: true,
+                  }}
                 />
               )}
               {activeTab === 'placas' && oficinaAutoEnabled && (

--- a/resources/js/Pages/Cliente/_show/DocumentsTab.tsx
+++ b/resources/js/Pages/Cliente/_show/DocumentsTab.tsx
@@ -1,14 +1,15 @@
 // Wave D — US-CRM-066 Tab Documents & Note (MWART F3 paridade /contacts/{id} tab documents_and_notes)
-// Restrições Tier 0 (ADR 0093): backend DocumentAndNoteController filtra business_id global scope.
-// Backend endpoints existentes (routes/web.php linhas 599-601):
-//   POST /post-document-upload (DocumentAndNoteController::postMedia)
-//   GET  /note-documents (index, datatable)
-//   GET  /note-documents/{id} (show)
-//   POST /note-documents (store — notes)
-//   PUT  /note-documents/{id} (update)
-//   DELETE /note-documents/{id} (destroy)
+// Restrições Tier 0 (ADR 0093): backend filtra business_id em TODAS as queries.
+// Backend endpoints:
+//   ANEXOS (drawer Cliente · ContactController · scope business_id Tier 0):
+//     GET    /cliente/{id}/anexos           → lista media dos document-notes do contato (#2086)
+//     POST   /cliente/{id}/anexos (campo file) → cria DocumentAndNote + media, devolve { document }
+//     DELETE /cliente/{id}/anexos/{mediaId} → valida media do contato (Tier 0) + exclui
+//   NOTAS (DocumentAndNoteController · autosave da nota primária):
+//     POST /note-documents (store) · PUT /note-documents/{id} (update)
 //
-// Modelo polimórfico: notable_id={contact.id}, notable_type='App\Contact'
+// Modelo polimórfico: DocumentAndNote.notable_id={contact.id}, notable_type='App\Contact';
+//   Media.model_id={note.id}, model_type='App\DocumentAndNote' (1 anexo = 1 note no drawer).
 //
 // Pattern reuse: Essentials/Documents/Index.tsx (upload + list) + textarea autosave debounced 1.5s.
 
@@ -167,6 +168,11 @@ export default function DocumentsTab({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [primaryNote, noteHeading]);
 
+  // Wagner 2026-06-01 — upload via POST /cliente/{id}/anexos (ContactController::
+  // anexosStore), que cria o DocumentAndNote + media e devolve { document } no shape
+  // DocumentItem. Substitui o endpoint legado postMedia (que só gravava arquivo
+  // órfão, sem nota nem vínculo, e nunca devolvia `document`). 1 arquivo por request
+  // (loop); cada resposta traz o DocumentItem canônico, inserimos direto sem refetch.
   const handleUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
     const files = e.target.files;
     if (!files || files.length === 0) return;
@@ -174,11 +180,9 @@ export default function DocumentsTab({
     try {
       for (const file of Array.from(files)) {
         const fd = new FormData();
-        fd.append('notable_id', String(contactId));
-        fd.append('notable_type', notableType);
-        fd.append('document', file);
+        fd.append('file', file);
 
-        const res = await fetch('/post-document-upload', {
+        const res = await fetch(`/cliente/${contactId}/anexos`, {
           method: 'POST',
           body: fd,
           credentials: 'same-origin',
@@ -191,7 +195,7 @@ export default function DocumentsTab({
         if (!res.ok) throw new Error(`HTTP ${res.status}`);
         const data = await res.json().catch(() => null);
         if (data?.document) {
-          setDocuments((prev) => [data.document, ...prev]);
+          setDocuments((prev) => [data.document as DocumentItem, ...prev]);
         }
       }
     } catch (err) {
@@ -203,17 +207,16 @@ export default function DocumentsTab({
     }
   };
 
-  const handleDelete = async (docId: number) => {
+  // Wagner 2026-06-01 — exclusão via DELETE /cliente/{id}/anexos/{mediaId}
+  // (ContactController::anexosDestroy). `mediaId` é o id do MEDIA (o que o GET devolve
+  // em DocumentItem.id), corrigindo a semântica antiga que mandava o media id pra
+  // DELETE /note-documents/{noteId}. Backend valida que o media pertence a um
+  // document-note deste contato (Tier 0) antes de excluir. Remoção otimista da lista.
+  const handleDelete = async (mediaId: number) => {
     if (!confirm('Excluir este anexo?')) return;
     try {
-      const fd = new FormData();
-      fd.append('_method', 'DELETE');
-      fd.append('notable_id', String(contactId));
-      fd.append('notable_type', notableType);
-
-      const res = await fetch(`/note-documents/${docId}`, {
-        method: 'POST',
-        body: fd,
+      const res = await fetch(`/cliente/${contactId}/anexos/${mediaId}`, {
+        method: 'DELETE',
         credentials: 'same-origin',
         headers: {
           'X-CSRF-TOKEN': getCsrf(),
@@ -222,7 +225,7 @@ export default function DocumentsTab({
         },
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setDocuments((prev) => prev.filter((d) => d.id !== docId));
+      setDocuments((prev) => prev.filter((d) => d.id !== mediaId));
     } catch {
       // eslint-disable-next-line no-alert
       alert('Erro ao excluir anexo.');

--- a/routes/web.php
+++ b/routes/web.php
@@ -267,6 +267,11 @@ Route::middleware(['setData', 'auth', 'SetSessionData', 'language', 'timezone', 
     // Tier 0 multi-tenant: scope business_id no controller (ContactController::anexos).
     Route::get('/cliente/{id}/anexos', [ContactController::class, 'anexos'])
         ->name('cliente.anexos.index')->whereNumber('id');
+    // Upload (cria DocumentAndNote + media) e exclusão (por media id, valida dono).
+    Route::post('/cliente/{id}/anexos', [ContactController::class, 'anexosStore'])
+        ->name('cliente.anexos.store')->whereNumber('id');
+    Route::delete('/cliente/{id}/anexos/{mediaId}', [ContactController::class, 'anexosDestroy'])
+        ->name('cliente.anexos.destroy')->whereNumber('id')->whereNumber('mediaId');
 
     Route::get('taxonomies-ajax-index-page', [TaxonomyController::class, 'getTaxonomyIndexPage']);
     Route::resource('taxonomies', TaxonomyController::class);

--- a/tests/Feature/Cliente/ClienteAnexosEndpointTest.php
+++ b/tests/Feature/Cliente/ClienteAnexosEndpointTest.php
@@ -70,3 +70,106 @@ test('GUARD 4 — GET /cliente/{id}/anexos nao vaza anexos sem auth', function (
     // (vazaria anexos sem sessao) nem 500 (erro de codigo).
     expect(in_array($response->status(), [302, 401, 403, 404], true))->toBeTrue();
 });
+
+// ─── GUARD 5: rotas POST + DELETE registradas ─────────────────────────────
+// Wagner 2026-06-01 — upload/exclusao de anexo (fecha o gap do PR #2086 que so
+// carregava). Endpoints novos no ContactController (espelham o GET anexos).
+
+test('GUARD 5 — routes/web.php registra POST + DELETE /cliente/{id}/anexos', function () {
+    $path = __DIR__ . '/../../../routes/web.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("Route::post('/cliente/{id}/anexos', [ContactController::class, 'anexosStore'])")
+        ->toContain("->name('cliente.anexos.store')")
+        ->toContain("Route::delete('/cliente/{id}/anexos/{mediaId}', [ContactController::class, 'anexosDestroy'])")
+        ->toContain("->name('cliente.anexos.destroy')");
+});
+
+// ─── GUARD 6: anexosStore — tenant scope + cria nota + uploadMedia + retorna ──
+
+test('GUARD 6 — ContactController::anexosStore cria DocumentAndNote + media (Tier 0)', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain('public function anexosStore(Request $request, $id)')
+        // Tier 0 (ADR 0093): contato scoped antes de criar nada.
+        ->toContain("Contact::where('business_id', \$business_id)->findOrFail(\$id)")
+        // Cria 1 DocumentAndNote apontando pro contato (morph notable).
+        ->toContain('new \App\DocumentAndNote()')
+        ->toContain('$note->notable_type = \App\Contact::class')
+        ->toContain('$note->business_id = $business_id')
+        // Anexa o arquivo do campo `file` via helper canonico (is_single=true).
+        ->toContain("Media::uploadMedia(\$business_id, \$note, \$request, 'file', true)")
+        // Devolve o DocumentItem (mesmo shape do GET) pro React inserir sem refetch.
+        ->toContain("'download_url' => \$media->display_url")
+        ->toContain("'document' =>");
+});
+
+// ─── GUARD 7: anexosDestroy — valida media -> nota -> contato (Tier 0) + apaga ─
+
+test('GUARD 7 — ContactController::anexosDestroy valida dono e exclui (Tier 0)', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain('public function anexosDestroy(Request $request, $id, $mediaId)')
+        // Tier 0: contato + media (model_type) + nota dona TODOS scoped business_id.
+        ->toContain("Contact::where('business_id', \$business_id)->findOrFail(\$id)")
+        ->toContain("Media::where('business_id', \$business_id)")
+        ->toContain('->findOrFail($mediaId)')
+        // A nota dona precisa ser um document-note DESTE contato (anti cross-tenant).
+        ->toContain("->where('notable_type', \\App\\Contact::class)")
+        ->toContain("->where('notable_id', \$id)")
+        ->toContain("->where('id', \$media->model_id)")
+        // Exclui arquivo + linha via helper canonico scoped business_id.
+        ->toContain('Media::deleteMedia($business_id, $media->id)');
+});
+
+// ─── GUARD 8: DocumentsTab usa os endpoints novos (nao os legados quebrados) ──
+
+test('GUARD 8 — DocumentsTab faz upload/exclusao pelos endpoints /cliente/{id}/anexos', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/_show/DocumentsTab.tsx';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        // Upload: campo `file` (que Media::uploadMedia le) pro POST anexos.
+        ->toContain("fd.append('file', file)")
+        // Exclusao: DELETE real por media id.
+        ->toContain('/cliente/${contactId}/anexos/${mediaId}')
+        ->toContain("method: 'DELETE'")
+        // Nao usa mais o endpoint legado quebrado (arquivo orfao, sem `document`).
+        ->not->toContain('/post-document-upload')
+        ->not->toContain("fd.append('document', file)")
+        // Nao manda mais media id pra DELETE /note-documents/{noteId} (semantica errada).
+        ->not->toContain('/note-documents/${docId}');
+});
+
+// ─── GUARD 9: Index.tsx plumba permissoes reais pro OssTab/DocumentsTab ───────
+
+test('GUARD 9 — Index.tsx passa permissions ao OssTab (botoes/textarea ativos)', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx';
+    $contents = file_get_contents($path);
+
+    // Sem essas flags o botao "Enviar", o excluir e a textarea de Notas ficam
+    // inativos no drawer (default false do OssTab). Legado concede a quem ve o contato.
+    expect($contents)
+        ->toContain('upload: true,')
+        ->toContain('delete_document: true,')
+        ->toContain('edit_note: true,');
+});
+
+// ─── GUARD 10: endpoints de escrita exigem sessao (nao gravam sem auth) ───────
+
+test('GUARD 10 — POST/DELETE /cliente/{id}/anexos nao escrevem sem auth', function () {
+    if (! \Illuminate\Support\Facades\Schema::hasTable('contacts')) {
+        $this->markTestSkipped('Schema UltimatePOS ausente (sqlite memory) — rode com DB_CONNECTION=mysql.');
+    }
+
+    $post = $this->post('/cliente/1/anexos');
+    expect(in_array($post->status(), [302, 401, 403, 404, 419], true))->toBeTrue();
+
+    $delete = $this->delete('/cliente/1/anexos/1');
+    expect(in_array($delete->status(), [302, 401, 403, 404, 419], true))->toBeTrue();
+});


### PR DESCRIPTION
## Problema

No drawer de Cliente (**Operações → Documentos**), o painel **carrega** os anexos existentes (PR #2086, `GET /cliente/{id}/anexos`), mas **upload e exclusão estavam não-funcionais**:

1. **Botões ocultos por permissão** — `Index.tsx` renderizava `<OssTab>` sem prop `permissions`, então o OssTab repassava `upload/delete_document/edit_note = false` pro `DocumentsTab`. Resultado: botão **"Enviar"**, botão **excluir** e até a **textarea de Notas** (disabled) ficavam inativos. O legado `DocumentAndNoteController::__getPermission` concede `['view','create','delete']` pra qualquer um que vê o `App\Contact`.
2. **Upload quebrado** — `handleUpload` postava em `/post-document-upload` (`postMedia`), que só roda `Media::uploadFile()` e devolve `{success, file_name}` — **não** cria o `DocumentAndNote`, **não** vincula o media ao contato (arquivo órfão) e **nunca** devolve o `document` que o React espera.
3. **Delete com semântica errada** — `handleDelete` fazia `DELETE /note-documents/{docId}` passando o **id do media** (não o da nota).

## Fix

**Backend (`ContactController`, espelha o GET `anexos` larastan-clean — queries raw, sem `has()`):**
- `POST /cliente/{id}/anexos` (`anexosStore`) — cria **1 `DocumentAndNote`** (morph notable → contato) + `Media::uploadMedia($business_id, $note, $request, 'file', true)`; devolve o `DocumentItem` (mesmo shape do GET) → React insere na lista sem refetch. Cleanup da nota se o upload não persistir (arquivo grande demais).
- `DELETE /cliente/{id}/anexos/{mediaId}` (`anexosDestroy`) — recebe o **id do media**; valida que ele pertence a um document-note **DESTE contato** (Tier 0 `business_id` scope) antes de excluir via `Media::deleteMedia`; remove a nota órfã.

**Frontend (`DocumentsTab.tsx`):** `handleUpload`/`handleDelete` reescritos pros novos endpoints (campo `file`, `DELETE` real).

**Permissões (`Index.tsx`):** plumba `upload/delete_document/edit_note = true` pro `<OssTab>` (legado concede a quem vê o contato; backend revalida Tier 0).

## Multi-tenant Tier 0 (ADR 0093)

Contato + nota + media **scoped em `business_id`** em todas as queries dos 2 endpoints. O delete só apaga o media se a nota dona for um document-note deste contato (anti cross-tenant).

## Gates

| Gate | Resultado |
|---|---|
| `phpstan` (larastan level 5, scoped ContactController) | ✅ No errors (corrigido `is_private` bool) |
| `pest` (`ClienteAnexosEndpointTest`) | ✅ 8 passed / 2 skipped (auth-gate skip-graceful sqlite) |
| `eslint` (scoped) | ✅ contagem idêntica antes/depois (zero regressão) |
| `ui:lint` (scoped `resources/js/Pages/Cliente`) | ✅ sem regressões |

> ⚠️ A run **completa** de `ui:lint` aponta 1 regressão pré-existente em `resources/js/Pages/Jana/Pro.tsx` (R1 0→2, do PR #2069 — baseline desatualizado). **Não tocada** por este PR; fora do escopo.

Refs: PR #2082 (chip+count), PR #2086 (load), ADR 0093 (multi-tenant Tier 0), ADR 0179 (drawer 760).

🤖 Generated with [Claude Code](https://claude.com/claude-code)