### PR TITLE
fix(jana): Pro.tsx usa token semântico success (corrige drift ui:lint R1)

### DIFF
--- a/resources/js/Pages/Jana/Pro.tsx
+++ b/resources/js/Pages/Jana/Pro.tsx
@@ -374,7 +374,7 @@ function ProPage({ plan, pricing, proof }: Props) {
           aria-live="polite"
           className={
             state === 'done'
-              ? 'inline-flex items-center gap-2 rounded-md border border-emerald-500 bg-emerald-500 px-5 py-2.5 text-sm font-medium text-white'
+              ? 'inline-flex items-center gap-2 rounded-md border border-success bg-success px-5 py-2.5 text-sm font-medium text-success-foreground'
               : 'inline-flex items-center gap-2 rounded-md border border-primary bg-primary px-5 py-2.5 text-sm font-medium text-primary-foreground transition-colors hover:bg-primary/90 disabled:opacity-[0.85]'
           }
         >


### PR DESCRIPTION
## Problema (drift do ratchet `ui:lint` na main)

A tela **Jana Pro** (`/ia/pro`), introduzida pelo PR #2069 (`720ffdce1`), entrou na `main` com `border-emerald-500 bg-emerald-500` no botão de estado **"ativado"** — 2 cores cruas Tailwind que a regra **R1** do `ui:lint` proíbe (Constituição UI v2 · ADR UI-0013).

O `config/ui-lint-baseline.json` **não foi atualizado** no #2069, então o gate [`ui-lint.yml`](.github/workflows/ui-lint.yml) passou a falhar (**exit 1**) em **qualquer** PR que tocasse `resources/js/**` (`Jana/Pro.tsx · R1 · 0 → 2`).

## Correção (caminho preferido: refatorar, **não** bumpar baseline)

Troca o par `emerald-500` cru pelos **tokens semânticos** `bg-success` / `border-success` / `text-success-foreground`:
- pareamento **canônico** já usado em `StatusBadge.tsx` e +8 lugares (`bg-success text-success-foreground hover:bg-success/90`);
- consistente com os `text-success` que a **própria tela** já usa nos checkmarks;
- dark-mode aware (o `text-white` anterior não era).

```diff
-  ? 'inline-flex items-center gap-2 rounded-md border border-emerald-500 bg-emerald-500 px-5 py-2.5 text-sm font-medium text-white'
+  ? 'inline-flex items-center gap-2 rounded-md border border-success bg-success px-5 py-2.5 text-sm font-medium text-success-foreground'
```

**`config/ui-lint-baseline.json` NÃO foi alterado** (as cores eram um deslize, não intencionais — a tela já usava o token `success` no resto).

## Validação (PHP 8.4, igual ao CI)

```
php artisan ui:lint --path=resources/js --baseline=config/ui-lint-baseline.json --strict
→ Baseline: 7568 · Atual: 6798 (Δ-770) · "Ok · sem regressões vs baseline" · exit 0
  (Pro.tsx R1: 2 → 0; era a única regressão do tree — os demais arquivos só melhoraram)

vendor/bin/pest tests/Feature/Design/DesignReviewFreshnessTest.php
→ 4 passed (8 assertions) · exit 0
```

## Escopo
- 1 arquivo, 1 linha (`resources/js/Pages/Jana/Pro.tsx`). Sem mudança de comportamento/contrato — só token de cor. Charter/review.md/baselines intactos.

Refs: #2069 · ADR UI-0013 · PRE-MERGE-UI.md (R1 / AP1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)