### PR TITLE
fix(cliente): chip "anexos" reflete contagem viva (não somava após upload)

### DIFF
--- a/resources/js/Pages/Cliente/Index.tsx
+++ b/resources/js/Pages/Cliente/Index.tsx
@@ -1801,11 +1801,16 @@ function ClienteSheet({
   // pra o chip header "📎 N anexos" cair direto em Documentos. Reset p/ 'ledger'
   // quando entra na tab Operações pelo caminho normal (tab bar).
   const [opsSubTab, setOpsSubTab] = useState<OssSubTabKey>('ledger');
+  // Wagner 2026-06-01 — contagem VIVA de anexos pro chip "📎 N anexos". null =
+  // usa o valor estático do payload (documents_count); quando o painel Documentos
+  // carrega/sobe/exclui, o OssTab reporta o número real e o chip passa a refletir.
+  const [liveAnexosCount, setLiveAnexosCount] = useState<number | null>(null);
 
   // Reset tab ao abrir contact diferente. Drawer abre default em "Identificação".
   useEffect(() => {
     if (open && contactId) {
       setActiveTab('identificacao');
+      setLiveAnexosCount(null); // novo contact → count do payload até o painel carregar
     }
   }, [open, contactId]);
 
@@ -1958,7 +1963,7 @@ function ClienteSheet({
               title="Ver anexos do cliente (comprovantes, contratos, fotos)"
             >
               <Paperclip size={11} aria-hidden />
-              <span>{contact?.documents_count ?? 0}</span>
+              <span>{liveAnexosCount ?? contact?.documents_count ?? 0}</span>
               <span>anexos</span>
             </button>
             <button
@@ -2081,6 +2086,8 @@ function ClienteSheet({
                      Legado concede view/create/delete de documentos a quem vê o
                      contato (DocumentAndNoteController::__getPermission p/ App\Contact). */
                   permissions={{ upload: true, delete_document: true, edit_note: true }}
+                  /* chip "📎 N anexos" reflete a contagem viva após load/upload/delete */
+                  onDocumentsCountChange={setLiveAnexosCount}
                 />
               )}
               {activeTab === 'placas' && oficinaAutoEnabled && (

--- a/resources/js/Pages/Cliente/_drawer/OssTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/OssTab.tsx
@@ -62,6 +62,8 @@ export interface OssTabProps {
   activeSubTab?: OssSubTabKey;
   /** Reporta troca de sub-aba (clique interno) pro pai manter sync — highlight do chip. */
   onSubTabChange?: (key: OssSubTabKey) => void;
+  /** Wagner 2026-06-01 — repassa a contagem viva de anexos pro header (chip "📎 N anexos"). */
+  onDocumentsCountChange?: (count: number) => void;
   /**
    * Permissoes injetadas pelo Index.tsx (Wave futura pode estender ContactController::index).
    * Por ora todas default false — sub-tabs operam em modo read-only.
@@ -90,6 +92,7 @@ export default function OssTab({
   contact,
   activeSubTab,
   onSubTabChange,
+  onDocumentsCountChange,
   permissions = {},
   locations = [],
 }: OssTabProps) {
@@ -178,6 +181,7 @@ export default function OssTab({
               delete_document: permissions.delete_document ?? false,
               edit_note: permissions.edit_note ?? false,
             }}
+            onCountChange={onDocumentsCountChange}
           />
         )}
         {/* Wagner 2026-05-27 iteracao 2: `placas` virou tab principal acessada

--- a/resources/js/Pages/Cliente/_show/DocumentsTab.tsx
+++ b/resources/js/Pages/Cliente/_show/DocumentsTab.tsx
@@ -48,6 +48,9 @@ export interface DocumentsTabProps {
     delete_document: boolean;
     edit_note: boolean;
   };
+  /** Wagner 2026-06-01 — reporta a contagem VIVA de anexos (após load/upload/delete)
+   * pro header (chip "📎 N anexos"), que senão fica no valor estático do payload. */
+  onCountChange?: (count: number) => void;
 }
 
 const formatBytes = (bytes: number | null) => {
@@ -80,6 +83,7 @@ export default function DocumentsTab({
   notes: notesProp,
   notableType = 'App\\Contact',
   permissions = { upload: true, delete_document: true, edit_note: true },
+  onCountChange,
 }: DocumentsTabProps) {
   const [documents, setDocuments] = useState<DocumentItem[]>(docsProp ?? []);
   // notes list não é renderizada inteira (UI mostra só primary note); mantido pra futura grid.
@@ -100,11 +104,15 @@ export default function DocumentsTab({
     try {
       const res = await fetch(`/cliente/${contactId}/anexos`, {
         credentials: 'same-origin',
+        cache: 'no-store', // pós-upload precisa do estado fresco, nunca cache do GET
         headers: { 'X-Requested-With': 'XMLHttpRequest', Accept: 'application/json' },
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
       const data = await res.json();
-      if (Array.isArray(data?.documents)) setDocuments(data.documents as DocumentItem[]);
+      if (Array.isArray(data?.documents)) {
+        setDocuments(data.documents as DocumentItem[]);
+        onCountChange?.(data.documents.length); // sincroniza o chip do header
+      }
     } catch {
       // silencioso: painel permanece com o estado atual (mesmo fallback de antes).
     }
@@ -216,7 +224,9 @@ export default function DocumentsTab({
         },
       });
       if (!res.ok) throw new Error(`HTTP ${res.status}`);
-      setDocuments((prev) => prev.filter((d) => d.id !== docId));
+      const next = documents.filter((d) => d.id !== docId);
+      setDocuments(next);
+      onCountChange?.(next.length); // decrementa o chip do header
     } catch {
       // eslint-disable-next-line no-alert
       alert('Erro ao excluir anexo.');

--- a/tests/Feature/Cliente/ClienteAnexosEndpointTest.php
+++ b/tests/Feature/Cliente/ClienteAnexosEndpointTest.php
@@ -125,3 +125,27 @@ test('GUARD 7 — DocumentsTab usa endpoints novos + Index habilita permissoes',
     expect($index)
         ->toContain('permissions={{ upload: true, delete_document: true, edit_note: true }}');
 });
+
+// ─── GUARD 8: chip do header reflete contagem VIVA (Wagner: "nao somou") ───
+
+test('GUARD 8 — chip anexos sincroniza contagem viva apos upload/delete', function () {
+    $docTab = file_get_contents(__DIR__ . '/../../../resources/js/Pages/Cliente/_show/DocumentsTab.tsx');
+    $ossTab = file_get_contents(__DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/OssTab.tsx');
+    $index = file_get_contents(__DIR__ . '/../../../resources/js/Pages/Cliente/Index.tsx');
+
+    // DocumentsTab reporta a contagem viva + GET sem cache (pos-upload fresco).
+    expect($docTab)
+        ->toContain('onCountChange?: (count: number) => void')
+        ->toContain('onCountChange?.(data.documents.length)')
+        ->toContain("cache: 'no-store'");
+
+    // OssTab repassa o callback pro DocumentsTab.
+    expect($ossTab)
+        ->toContain('onDocumentsCountChange')
+        ->toContain('onCountChange={onDocumentsCountChange}');
+
+    // Index: chip usa o count vivo (cai pro payload quando ausente) + wiring.
+    expect($index)
+        ->toContain('liveAnexosCount ?? contact?.documents_count ?? 0')
+        ->toContain('onDocumentsCountChange={setLiveAnexosCount}');
+});


### PR DESCRIPTION
## O quê

Wagner testou em prod e reportou: *"não somou humm mais gravou o anexo"* — o upload **persistia** (PR #2088) mas o chip **`📎 N anexos`** do header **não incrementava** na mesma sessão.

**Causa:** o chip usa `contact.documents_count`, que vem do payload da listagem (calculado **1×** no load da página). Após um upload dentro do drawer, não havia mecanismo pra atualizar esse número — só somava num reload. O painel "Anexos (N)" atualizava (via refetch), mas o chip não.

## Fix (4 arquivos · +48/−3, frontend)

- **DocumentsTab** — `onCountChange` reporta a contagem **viva** (no load, upload e delete) + `GET` com `cache: 'no-store'` (pós-upload precisa do estado fresco, sem cache do navegador).
- **OssTab** — repassa `onDocumentsCountChange` → `DocumentsTab.onCountChange`.
- **Index** — `liveAnexosCount` (`null` = usa o payload) sincroniza o chip; reseta por contact ao abrir o drawer. Chip exibe `liveAnexosCount ?? documents_count ?? 0`.
- **Pest** — GUARD 8 (wiring da contagem viva).

Comportamento: abre o drawer → chip = count do payload; abre Documentos → chip sincroniza com o real; **anexa → chip incrementa**; exclui → decrementa.

## Verificação

- ✅ Pest: GUARD 8 + estruturais passam (GUARD 4 = `$this->get()` só binda no CI, verde lá).
- ✅ ESLint ratchet: sem regressões. tsc: zero erro novo. Sem mudança de backend (sem Infra Contract).

🤖 Generated with [Claude Code](https://claude.com/claude-code)