### PR TITLE
test(infra): corrige asserção stale do FeatureFlagService (fallback default TRUE)

### DIFF
--- a/tests/Feature/Services/FeatureFlagServiceTest.php
+++ b/tests/Feature/Services/FeatureFlagServiceTest.php
@@ -30,7 +30,11 @@ it('retorna fallback default quando GROWTHBOOK_SDK_KEY ausente no .env', functio
 
     $service = new FeatureFlagService();
 
-    expect($service->isOn('useV2SellsCreate'))->toBeFalse();
+    // useV2SellsCreate tem fallback default TRUE (flip Wagner 2026-05-27, pós-cadeia
+    // de hotfixes — ver FeatureFlagService::$fallbackDefaults). Sem GrowthBook
+    // configurado, isOn() cai no fallback e retorna esse default.
+    expect($service->isOn('useV2SellsCreate'))->toBeTrue();
+    // flagInexistente não está em $fallbackDefaults → false conservador.
     expect($service->isOn('flagInexistente'))->toBeFalse();
 });
 


### PR DESCRIPTION
## O que

Corrige a asserção **stale** em `tests/Feature/Services/FeatureFlagServiceTest.php:33`.

O teste _"retorna fallback default quando GROWTHBOOK_SDK_KEY ausente no .env"_ assertava `isOn('useV2SellsCreate')` → `toBeFalse()`. Mas `FeatureFlagService::$fallbackDefaults` define `useV2SellsCreate => true` — flip **intencional** do Wagner em 2026-05-27 ("ative para todos pronto", pós-cadeia de 14 hotfixes; comentário no próprio service). Sem GrowthBook configurado, `getFeatures()` retorna `null` → `isOn()` cai no `fallback()` → retorna `true`. A asserção falhava.

## Por que nunca quebrou CI

Test e service flipado **nasceram no mesmo commit** (#1886) com a contradição embutida. Nunca foi detectada porque **nenhum workflow roda `tests/Feature/Services/`**:

| Workflow | Roda |
|---|---|
| `ci.yml` (PHP / Pest Unit) | só `tests/Feature/Form` |
| `modules-pest.yml` | path-filtered `Modules/**` |
| `adr-lint` / `ragas-gate` / `visual-regression` | Memory / Ragas / Browser |

## Mudança (1 arquivo, +5/−1)

- L33: `toBeFalse()` → `toBeTrue()` + comentário explicando o fallback default (anti-regressão: evita que alguém "conserte" de volta).
- `flagInexistente` **intacto** — não está em `$fallbackDefaults` → `false` conservador, continua correto.
- **Não toca o service** — o comportamento `=> true` é o intencional; era o teste que estava errado.
- Cenários 5xx (L47) e empty-features (L123) **não eram stale**: retornam `[]` (não `null`), então o GrowthBook avalia a flag desconhecida como `false` sem tocar `$fallbackDefaults`.

## Verificação (local, MySQL)

```
vendor/bin/pest tests/Feature/Services/FeatureFlagServiceTest.php
# antes:  1 failed (L33 "Failed asserting that true is false"), 5 passed
# depois: 6 passed (8 assertions)
```

## Follow-up — intent separado (NÃO neste PR)

`tests/Feature/Services/` segue **sem cobertura de CI**. Em PR próprio (commit-discipline = 1 intent):

- **Barato / sqlite-safe**: incluir `FeatureFlagServiceTest` (DB-less, validado rodando em sqlite `:memory:`) no job pest do `ci.yml`.
- **Maior**: `GrowthBookAdminServiceTest` usa `RefreshDatabase` → esbarra na migration MySQL-only `ALTER TABLE transactions MODIFY COLUMN type ENUM(...)`. Precisa de MySQL service no CI **ou** `markTestSkipped` defensivo (padrão `modules-pest.yml`).

Refs: US-INFRA-001, #1886

🤖 Generated with [Claude Code](https://claude.com/claude-code)
