### PR TITLE
feat(cliente): endereço de entrega no cadastro + auto-preenche na venda

### DIFF
--- a/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
+++ b/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
@@ -308,6 +308,12 @@ class ClienteAutosaveController extends Controller
             'state' => ['nullable', 'string', 'in:' . implode(',', self::UFS)],
             // city_code IBGE (7 digitos numericos) -- Wagner 2026-05-22.
             'city_code' => ['nullable', 'string', 'max:7'],
+            // Endereco de entrega (shipping_address) -- texto livre opcional.
+            // Wagner 2026-06-02: cliente cadastra endereco de entrega distinto do
+            // principal; a venda puxa daqui (Fase 2). Coluna existe desde 2020
+            // (migration add_shipping_address_to_contacts). Mesma regra de
+            // StoreContactRequest/UpdateContactRequest (nullable string).
+            'shipping_address' => ['nullable', 'string'],
         ], $this->messages());
 
         // Validacao customizada CEP 8 digitos quando preenchido.
@@ -575,6 +581,9 @@ class ClienteAutosaveController extends Controller
             'neighborhood' => $contact->neighborhood ?? null,
             'city' => $contact->city ?? null,
             'state' => $contact->state ?? null,
+            // Endereço de entrega (shipping_address) — devolvido na response do
+            // autosave pro EnderecoTab confirmar o valor canônico. Wagner 2026-06-02.
+            'shipping_address' => $contact->shipping_address ?? null,
             'credit_limit' => $contact->credit_limit !== null ? (float) $contact->credit_limit : null,
             'pay_term_number' => $contact->pay_term_number !== null ? (int) $contact->pay_term_number : null,
             'tabela_preco_padrao' => $contact->tabela_preco_padrao ?? null,

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -473,6 +473,10 @@ class ContactController extends Controller
             'contacts.zip_code',
             'contacts.address_line_1',
             'contacts.address_line_2',
+            // Endereço de entrega (shipping_address) — coluna UPOS desde 2020.
+            // Sem isso, o drawer EnderecoTab reabre com o campo vazio mesmo salvo
+            // (mesma classe de bug do zip_code/address_line acima). Wagner 2026-06-02.
+            'contacts.shipping_address',
         ];
         // `neighborhood` e `numero` (BR canon) — migrations aditivas recentes
         // (2026_05_22_120000 e 2026_05_22_180000). hasColumn graceful pra
@@ -682,6 +686,7 @@ class ContactController extends Controller
                 'numero' => $contact->numero ?? null,
                 'city' => $contact->city,
                 'state' => $contact->state,
+                'shipping_address' => $contact->shipping_address,
             ];
 
             // Wave G — campos opcionais quando migration Wave B rodou.
@@ -1906,6 +1911,7 @@ class ContactController extends Controller
                     'city' => $contact->city ?? null,
                     'state' => $contact->state ?? null,
                     'zip_code' => $contact->zip_code ?? null,
+                    'shipping_address' => $contact->shipping_address ?? null,
                     'customer_group_id' => $contact->customer_group_id ?? null,
                     'credit_limit' => $contact->credit_limit ?? null,
                     // Dados Fiscais BR (migration 2026_05_21_140000). Diferente do Show()

--- a/resources/js/Pages/Cliente/Create.tsx
+++ b/resources/js/Pages/Cliente/Create.tsx
@@ -7,6 +7,7 @@ import { useForm } from '@inertiajs/react';
 import { type ReactNode, type FormEvent } from 'react';
 import { ChevronLeft, Save, User2 } from 'lucide-react';
 import { Input } from '@/Components/ui/input';
+import { Textarea } from '@/Components/ui/textarea';
 import { Button } from '@/Components/ui/button';
 import { Label } from '@/Components/ui/label';
 import DadosFiscaisBRSection, {
@@ -42,6 +43,7 @@ type ClienteFormData = DadosFiscaisBRData & {
   city: string;
   state: string;
   zip_code: string;
+  shipping_address: string;
   customer_group_id: string;
   opening_balance: string;
   credit_limit: string;
@@ -64,6 +66,7 @@ export default function ClienteCreate(props: ClienteCreatePageProps) {
     city: '',
     state: '',
     zip_code: '',
+    shipping_address: '',
     customer_group_id: '',
     opening_balance: '0',
     credit_limit: '',
@@ -275,6 +278,14 @@ export default function ClienteCreate(props: ClienteCreatePageProps) {
                   value={data.zip_code}
                   onChange={(e) => setData('zip_code', e.target.value)}
                   placeholder="00000-000"
+                />
+              </Field>
+              <Field label="Endereço de entrega" error={errors.shipping_address} colSpan={2}>
+                <Textarea
+                  value={data.shipping_address}
+                  onChange={(e) => setData('shipping_address', e.target.value)}
+                  placeholder="Preencha se a entrega for em endereço diferente do cadastro acima."
+                  rows={2}
                 />
               </Field>
             </div>

--- a/resources/js/Pages/Cliente/Edit.tsx
+++ b/resources/js/Pages/Cliente/Edit.tsx
@@ -7,6 +7,7 @@ import { useForm } from '@inertiajs/react';
 import { type ReactNode, type FormEvent } from 'react';
 import { ChevronLeft, Save, User2 } from 'lucide-react';
 import { Input } from '@/Components/ui/input';
+import { Textarea } from '@/Components/ui/textarea';
 import { Button } from '@/Components/ui/button';
 import { Label } from '@/Components/ui/label';
 import DadosFiscaisBRSection, {
@@ -33,6 +34,7 @@ interface ContactInfo {
   city: string | null;
   state: string | null;
   zip_code: string | null;
+  shipping_address: string | null;
   customer_group_id: number | null;
   credit_limit: string | null;
   // Campos BR (migration 2026_05_21_140000). Backend pode mandar null em legacy.
@@ -70,6 +72,7 @@ type ClienteFormData = DadosFiscaisBRData & {
   city: string;
   state: string;
   zip_code: string;
+  shipping_address: string;
   customer_group_id: string;
   opening_balance: string;
   credit_limit: string;
@@ -92,6 +95,7 @@ export default function ClienteEdit(props: ClienteEditPageProps) {
     city: c.city ?? '',
     state: c.state ?? '',
     zip_code: c.zip_code ?? '',
+    shipping_address: c.shipping_address ?? '',
     customer_group_id: c.customer_group_id ? String(c.customer_group_id) : '',
     opening_balance: props.opening_balance ?? '0',
     credit_limit: c.credit_limit ?? '',
@@ -244,6 +248,14 @@ export default function ClienteEdit(props: ClienteEditPageProps) {
               </Field>
               <Field label="CEP" error={errors.zip_code}>
                 <Input value={data.zip_code} onChange={(e) => setData('zip_code', e.target.value)} />
+              </Field>
+              <Field label="Endereço de entrega" error={errors.shipping_address} colSpan={2}>
+                <Textarea
+                  value={data.shipping_address}
+                  onChange={(e) => setData('shipping_address', e.target.value)}
+                  placeholder="Preencha se a entrega for em endereço diferente do cadastro acima."
+                  rows={2}
+                />
               </Field>
             </div>
           </Section>

--- a/resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx
@@ -27,6 +27,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Loader2, Search, CheckCircle2, AlertCircle } from 'lucide-react';
 import { Input } from '@/Components/ui/input';
+import { Textarea } from '@/Components/ui/textarea';
 import { Button } from '@/Components/ui/button';
 import { Label } from '@/Components/ui/label';
 import {
@@ -49,6 +50,8 @@ export interface ContactInfo {
   neighborhood?: string | null;
   city?: string | null;
   state?: string | null;
+  // Endereço de entrega (shipping_address) — opcional, texto livre.
+  shipping_address?: string | null;
   // Aliases PT-BR (legado — listagem em /cliente emite assim hoje).
   cep?: string | null;
   endereco?: string | null;
@@ -101,6 +104,7 @@ export default function EnderecoTab({ contact, onSaved, onContactUpdated, disabl
   const [neighborhood, setNeighborhood] = useState<string>(contact.neighborhood ?? contact.bairro ?? '');
   const [city, setCity] = useState<string>(contact.city ?? contact.cidade ?? '');
   const [stateUf, setStateUf] = useState<string>(contact.state ?? contact.uf ?? '');
+  const [shippingAddress, setShippingAddress] = useState<string>(contact.shipping_address ?? '');
 
   const [savingField, setSavingField] = useState<string | null>(null);
   const [savedField, setSavedField] = useState<string | null>(null);
@@ -130,6 +134,7 @@ export default function EnderecoTab({ contact, onSaved, onContactUpdated, disabl
     setNeighborhood((contact.neighborhood ?? contact.bairro ?? '') as string);
     setCity((contact.city ?? contact.cidade ?? '') as string);
     setStateUf((contact.state ?? contact.uf ?? '') as string);
+    setShippingAddress((contact.shipping_address ?? '') as string);
     setErrorField(null);
     setSavedField(null);
     setCepLookup('idle');
@@ -154,6 +159,7 @@ export default function EnderecoTab({ contact, onSaved, onContactUpdated, disabl
     else if (field === 'neighborhood') setNeighborhood(s);
     else if (field === 'city') setCity(s);
     else if (field === 'state') setStateUf(s);
+    else if (field === 'shipping_address') setShippingAddress(s);
   }, []);
 
   const performSave = useCallback(
@@ -535,6 +541,32 @@ export default function EnderecoTab({ contact, onSaved, onContactUpdated, disabl
             saving={savingField === 'state'}
             saved={savedField === 'state'}
             backendError={errorField?.field === 'state' ? errorField.message : null}
+          />
+        </div>
+
+        <div className="md:col-span-2">
+          <Label htmlFor="ed-shipping" className="cw-label">
+            Endereço de entrega{' '}
+            <span className="text-muted-foreground font-normal">(opcional — se diferente do acima)</span>
+          </Label>
+          <Textarea
+            id="ed-shipping"
+            value={shippingAddress}
+            placeholder="Endereço completo onde a mercadoria será entregue, se diferente do cadastro."
+            rows={2}
+            disabled={disabled}
+            onChange={(e) => {
+              const prev = shippingAddress;
+              const v = e.target.value;
+              setShippingAddress(v);
+              scheduleAutosave('shipping_address', v, prev);
+            }}
+            onBlur={(e) => handleBlur('shipping_address', e.target.value)}
+          />
+          <FieldStatus
+            saving={savingField === 'shipping_address'}
+            saved={savedField === 'shipping_address'}
+            backendError={errorField?.field === 'shipping_address' ? errorField.message : null}
           />
         </div>
       </div>

--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -913,7 +913,15 @@ export default function SellsCreate(props: SellsCreatePageProps) {
             <Label htmlFor="contact_id">Cliente</Label>
             <CustomerSearchAutocomplete
               defaultName={props.walkInCustomer.name}
-              onSelect={(c) => setData('contact_id', c.id)}
+              onSelect={(c) => {
+                setData('contact_id', c.id);
+                // Fase 2 (Wagner 2026-06-02) — auto-preenche o endereço de entrega
+                // da venda com o do cadastro do cliente, SEM sobrescrever o que o
+                // vendedor já digitou. Continua editável no campo "Entrega / Frete".
+                if (c.shipping_address && !data.shipping.address.trim()) {
+                  setData('shipping', { ...data.shipping, address: c.shipping_address });
+                }
+              }}
               onClear={() => setData('contact_id', props.walkInCustomer.id)}
               forcedValue={forcedCustomer}
             />

--- a/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
+++ b/resources/js/Pages/Sells/_components/CustomerSearchAutocomplete.tsx
@@ -21,6 +21,8 @@ export interface CustomerSearchResult {
   text: string;
   mobile?: string | null;
   city?: string | null;
+  /** Endereço de entrega cadastrado do cliente (shipping_address) — auto-preenche a venda. */
+  shipping_address?: string | null;
   /** Saldo devedor cliente (R$). >0 = devedor — exibe badge vermelho. */
   balance?: number | string | null;
 }

--- a/tests/Feature/Cliente/ClienteDrawerCadastroAutosaveTest.php
+++ b/tests/Feature/Cliente/ClienteDrawerCadastroAutosaveTest.php
@@ -249,6 +249,18 @@ test('PATCH /endereco field-a-field -- state persiste no DB', function () {
     $this->assertDatabaseHas('contacts', ['id' => $this->contactId, 'state' => 'SP']);
 });
 
+// Wagner 2026-06-02 — endereço de entrega (shipping_address) cadastrável no
+// drawer Cliente. Coluna UPOS desde 2020; antes não havia UI nem aceite no
+// autosave. A venda puxa daqui (Fase 2). Texto livre (aceita multi-linha).
+test('PATCH /endereco field-a-field -- shipping_address (endereço de entrega) persiste no DB + retorna na response', function () {
+    $endereco = "Rua da Entrega, 500 - Galpao 3\nGuarulhos/SP - aos cuidados do Joao";
+    $response = $this->patchJson("/cliente/{$this->contactId}/endereco", [
+        'shipping_address' => $endereco,
+    ]);
+    $response->assertStatus(200)->assertJsonPath('contact.shipping_address', $endereco);
+    $this->assertDatabaseHas('contacts', ['id' => $this->contactId, 'shipping_address' => $endereco]);
+});
+
 test('PATCH /endereco -- naming PT-BR (cep, endereco, bairro, cidade, uf) e descartado silenciosamente (regression)', function () {
     // Documenta o bug original — frontend antigo enviava nomes PT-BR. Backend
     // valida apenas canon (whitelist), entao Validator::validated() retorna

--- a/tests/Feature/Cliente/ClienteDrawerRowsCanonBrPayloadTest.php
+++ b/tests/Feature/Cliente/ClienteDrawerRowsCanonBrPayloadTest.php
@@ -173,3 +173,29 @@ test('GUARD 8 — payload[status] ainda eh late|active|idle derivado OS (Frescor
         ->toContain("\$status = \$atrasadas > 0 ? 'late' : (\$abertas > 0 ? 'active' : 'idle')")
         ->toMatch("/'status'\\s*=>\\s*\\\$status/");
 });
+
+// ─── GUARD 9: shipping_address (endereço de entrega) — Wagner 2026-06-02 ────
+// Sem o campo no select + payload, o drawer EnderecoTab reabre vazio mesmo com
+// dado salvo no DB (mesma classe do bug zip_code/address_line). A venda (Fase 2)
+// puxa o endereço de entrega daqui.
+
+test('GUARD 9 — buildClienteIndexCustomers select + payload incluem shipping_address', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("'contacts.shipping_address'")
+        ->toContain("'shipping_address' => \$contact->shipping_address");
+});
+
+test('GUARD 9b — EnderecoTab.tsx declara shipping_address + autosave on blur', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx';
+    expect($path)->toBeReadableFile();
+
+    $contents = file_get_contents($path);
+    expect($contents)
+        ->toContain('shipping_address?: string | null')
+        ->toContain("useState<string>(contact.shipping_address ??")
+        ->toContain("scheduleAutosave('shipping_address'")
+        ->toContain("handleBlur('shipping_address'");
+});


### PR DESCRIPTION
## O que
Endereço de entrega (shipping_address) do cliente, ponta a ponta.

### Fase 1 — Cliente (cadastro)
- Campo "Endereço de entrega" no **drawer EnderecoTab** (autosave on-blur) — caminho canônico ADR 0179
- Mesmo campo nas páginas Create/Edit
- Backend: `ClienteAutosaveController` valida e devolve; `edit()` e `buildClienteIndexCustomers` (select + payload) retornam o campo; `store/update` já aceitavam
- **Sem migration** (`contacts.shipping_address` existe desde 2020)

### Fase 2 — Venda
- Ao selecionar o cliente em `Sells/Create`, auto-preenche "Endereço de entrega" da venda (editável, sem sobrescrever digitação)
- `getCustomers` já retornava o campo; tipado em `CustomerSearchResult` + tratado no `onSelect`

## Validação
- TypeScript sem erros novos (8 pré-existentes em `main` = 8 com este PR)
- 10 testes structural verdes (payload + EnderecoTab); persistência do autosave roda no CI
- Multi-tenant intacto (`Contact $guarded` + `locateContact` scope)

## Nota
Gate visual (screenshot) não gerado: disco C: do ambiente dev 100% cheio bloqueou subir a app local. Mudança é aditiva e coberta por testes — validar visualmente no ambiente após merge.

Refs: pedido Wagner 2026-06-02 · ADR 0179 · ADR 0093

🤖 Generated with [Claude Code](https://claude.com/claude-code)