### PR TITLE
ci: roda FeatureFlagServiceTest no job pest (cobre Feature/Services dormante)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,10 +75,18 @@ jobs:
           php artisan key:generate
           php artisan package:discover --ansi
 
-      - name: Run Pest (suite Financeiro + Form shim)
+      - name: Run Pest (Form shim + FeatureFlagService offline-safe)
         # ModuleUtil::isModuleInstalled e getModuleVersionInfo agora sao
         # graceful (try/catch) — boot da app funciona sem migrate completo.
-        run: vendor/bin/pest tests/Feature/Form --no-coverage
+        #
+        # FeatureFlagServiceTest e DB-less (sem RefreshDatabase): so usa Http::fake
+        # + Cache array, entao roda em sqlite :memory:. Damos cobertura a esse
+        # contrato (fallback offline-safe) que antes ficava dormente — nenhum
+        # workflow rodava tests/Feature/Services/.
+        # NAO incluir o diretorio inteiro: GrowthBookAdminServiceTest usa
+        # RefreshDatabase e esbarra na migration MySQL-only (ALTER TABLE
+        # transactions MODIFY COLUMN type ENUM) — fica pra um setup MySQL em CI.
+        run: vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php --no-coverage
 
   frontend:
     name: Frontend / Vite build


### PR DESCRIPTION
## O que

Adiciona `tests/Feature/Services/FeatureFlagServiceTest.php` ao job **PHP / Pest (Unit)** do `ci.yml`, fechando o buraco de cobertura que deixou a asserção stale (corrigida em #2110) passar despercebida.

```diff
- run: vendor/bin/pest tests/Feature/Form --no-coverage
+ run: vendor/bin/pest tests/Feature/Form tests/Feature/Services/FeatureFlagServiceTest.php --no-coverage
```

## Por que só esse arquivo (e não o diretório)

| Teste | DB? | Roda em sqlite `:memory:`? |
|---|---|---|
| `FeatureFlagServiceTest` | DB-less (`Http::fake` + `Cache` array) | ✅ sim — **incluído** |
| `GrowthBookAdminServiceTest` | `RefreshDatabase` → tabela `feature_flag_audits` | ❌ esbarra na migration MySQL-only `ALTER TABLE transactions MODIFY COLUMN type ENUM(...)` |

Cobrir o `GrowthBookAdminServiceTest` exige um **MySQL service** no CI (ou `markTestSkipped` defensivo, padrão `modules-pest.yml`) — fora do escopo desta mudança barata.

## Efeito

A partir do merge, qualquer drift futuro entre `FeatureFlagService::$fallbackDefaults` e o teste **quebra CI** em vez de ficar dormente. (Foi o que faltou em #1886.)

## Nota

Substitui o **#2111**, que foi auto-fechado pelo GitHub quando a branch base (#2110) foi deletada no merge. O comando combinado já rodou **verde** na CI do #2111 (`PHP / Pest (Unit)` pass, 1m50s) antes do fechamento; esta branch sai de `main` já com o fix, então o diff é só o `ci.yml`.

Refs: US-INFRA-001, #2110, #1886

🤖 Generated with [Claude Code](https://claude.com/claude-code)
