### PR TITLE
feat(cliente+sells): múltiplos endereços de entrega — cadastro + seletor na venda (US-CRM-078)

### DIFF
--- a/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
+++ b/Modules/Crm/Http/Controllers/ClienteAutosaveController.php
@@ -309,6 +309,12 @@ class ClienteAutosaveController extends Controller
             'state' => ['nullable', 'string', 'in:' . implode(',', self::UFS)],
             // city_code IBGE (7 digitos numericos) -- Wagner 2026-05-22.
             'city_code' => ['nullable', 'string', 'max:7'],
+            // Endereco de entrega (shipping_address) -- texto livre opcional.
+            // Wagner 2026-06-02: cliente cadastra endereco de entrega distinto do
+            // principal; a venda puxa daqui (fase 2). Coluna existe desde 2020
+            // (migration add_shipping_address_to_contacts). Mesma regra de
+            // StoreContactRequest/UpdateContactRequest (nullable string).
+            'shipping_address' => ['nullable', 'string'],
         ], $this->messages());
 
         // Validacao customizada CEP 8 digitos quando preenchido.
@@ -602,6 +608,9 @@ class ClienteAutosaveController extends Controller
             'neighborhood' => $contact->neighborhood ?? null,
             'city' => $contact->city ?? null,
             'state' => $contact->state ?? null,
+            // Endereço de entrega (shipping_address) — devolvido na response do
+            // autosave pro EnderecoTab confirmar o valor canônico. Wagner 2026-06-02.
+            'shipping_address' => $contact->shipping_address ?? null,
             'credit_limit' => $contact->credit_limit !== null ? (float) $contact->credit_limit : null,
             'pay_term_number' => $contact->pay_term_number !== null ? (int) $contact->pay_term_number : null,
             // Tabela de preço REAL (FK customer_groups) — fonte de verdade do drawer.

--- a/app/Http/Controllers/ContactController.php
+++ b/app/Http/Controllers/ContactController.php
@@ -485,6 +485,10 @@ class ContactController extends Controller
             'contacts.zip_code',
             'contacts.address_line_1',
             'contacts.address_line_2',
+            // Endereço de entrega (shipping_address) — coluna UPOS desde 2020.
+            // Sem isso, o drawer EnderecoTab reabre com o campo vazio mesmo salvo
+            // (mesma classe de bug do zip_code/address_line acima). Wagner 2026-06-02.
+            'contacts.shipping_address',
         ];
         // `neighborhood` e `numero` (BR canon) — migrations aditivas recentes
         // (2026_05_22_120000 e 2026_05_22_180000). hasColumn graceful pra
@@ -730,6 +734,7 @@ class ContactController extends Controller
                 'numero' => $contact->numero ?? null,
                 'city' => $contact->city,
                 'state' => $contact->state,
+                'shipping_address' => $contact->shipping_address,
             ];
 
             // Wave G — campos opcionais quando migration Wave B rodou.
@@ -2125,6 +2130,7 @@ class ContactController extends Controller
                     'city' => $contact->city ?? null,
                     'state' => $contact->state ?? null,
                     'zip_code' => $contact->zip_code ?? null,
+                    'shipping_address' => $contact->shipping_address ?? null,
                     'customer_group_id' => $contact->customer_group_id ?? null,
                     'credit_limit' => $contact->credit_limit ?? null,
                     // Dados Fiscais BR (migration 2026_05_21_140000). Diferente do Show()

--- a/resources/js/Pages/Cliente/Create.tsx
+++ b/resources/js/Pages/Cliente/Create.tsx
@@ -41,6 +41,7 @@ export default function ClienteCreate(props: ClienteCreatePageProps) {
     city: '',
     state: '',
     zip_code: '',
+    shipping_address: '',
     customer_group_id: '',
     opening_balance: '0',
     credit_limit: '',

--- a/resources/js/Pages/Cliente/Edit.tsx
+++ b/resources/js/Pages/Cliente/Edit.tsx
@@ -29,6 +29,7 @@ interface ContactInfo {
   city: string | null;
   state: string | null;
   zip_code: string | null;
+  shipping_address: string | null;
   customer_group_id: number | null;
   credit_limit: string | null;
   cpf_cnpj?: string | null;
@@ -67,6 +68,7 @@ export default function ClienteEdit(props: ClienteEditPageProps) {
     city: c.city ?? '',
     state: c.state ?? '',
     zip_code: c.zip_code ?? '',
+    shipping_address: c.shipping_address ?? '',
     customer_group_id: c.customer_group_id ? String(c.customer_group_id) : '',
     opening_balance: props.opening_balance ?? '0',
     credit_limit: c.credit_limit ?? '',

--- a/resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx
+++ b/resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx
@@ -27,6 +27,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Loader2, Search, CheckCircle2, AlertCircle } from 'lucide-react';
 import { Input } from '@/Components/ui/input';
+import { Textarea } from '@/Components/ui/textarea';
 import { Button } from '@/Components/ui/button';
 import { Label } from '@/Components/ui/label';
 import {
@@ -49,6 +50,8 @@ export interface ContactInfo {
   neighborhood?: string | null;
   city?: string | null;
   state?: string | null;
+  // Endereço de entrega (shipping_address) — opcional, texto livre.
+  shipping_address?: string | null;
   // Aliases PT-BR (legado — listagem em /cliente emite assim hoje).
   cep?: string | null;
   endereco?: string | null;
@@ -101,6 +104,7 @@ export default function EnderecoTab({ contact, onSaved, onContactUpdated, disabl
   const [neighborhood, setNeighborhood] = useState<string>(contact.neighborhood ?? contact.bairro ?? '');
   const [city, setCity] = useState<string>(contact.city ?? contact.cidade ?? '');
   const [stateUf, setStateUf] = useState<string>(contact.state ?? contact.uf ?? '');
+  const [shippingAddress, setShippingAddress] = useState<string>(contact.shipping_address ?? '');
 
   const [savingField, setSavingField] = useState<string | null>(null);
   const [savedField, setSavedField] = useState<string | null>(null);
@@ -130,6 +134,7 @@ export default function EnderecoTab({ contact, onSaved, onContactUpdated, disabl
     setNeighborhood((contact.neighborhood ?? contact.bairro ?? '') as string);
     setCity((contact.city ?? contact.cidade ?? '') as string);
     setStateUf((contact.state ?? contact.uf ?? '') as string);
+    setShippingAddress((contact.shipping_address ?? '') as string);
     setErrorField(null);
     setSavedField(null);
     setCepLookup('idle');
@@ -154,6 +159,7 @@ export default function EnderecoTab({ contact, onSaved, onContactUpdated, disabl
     else if (field === 'neighborhood') setNeighborhood(s);
     else if (field === 'city') setCity(s);
     else if (field === 'state') setStateUf(s);
+    else if (field === 'shipping_address') setShippingAddress(s);
   }, []);
 
   const performSave = useCallback(
@@ -535,6 +541,32 @@ export default function EnderecoTab({ contact, onSaved, onContactUpdated, disabl
             saving={savingField === 'state'}
             saved={savedField === 'state'}
             backendError={errorField?.field === 'state' ? errorField.message : null}
+          />
+        </div>
+
+        <div className="md:col-span-2">
+          <Label htmlFor="ed-shipping" className="cw-label">
+            Endereço de entrega{' '}
+            <span className="text-muted-foreground font-normal">(opcional — se diferente do acima)</span>
+          </Label>
+          <Textarea
+            id="ed-shipping"
+            value={shippingAddress}
+            placeholder="Endereço completo onde a mercadoria será entregue, se diferente do cadastro."
+            rows={2}
+            disabled={disabled}
+            onChange={(e) => {
+              const prev = shippingAddress;
+              const v = e.target.value;
+              setShippingAddress(v);
+              scheduleAutosave('shipping_address', v, prev);
+            }}
+            onBlur={(e) => handleBlur('shipping_address', e.target.value)}
+          />
+          <FieldStatus
+            saving={savingField === 'shipping_address'}
+            saved={savedField === 'shipping_address'}
+            backendError={errorField?.field === 'shipping_address' ? errorField.message : null}
           />
         </div>
       </div>

--- a/resources/js/Pages/Cliente/_form/ClienteForm.tsx
+++ b/resources/js/Pages/Cliente/_form/ClienteForm.tsx
@@ -3,6 +3,7 @@ import { Banknote, Contact2, MapPin, Save, User2 } from "lucide-react"
 
 import { Button } from "@/Components/ui/button"
 import { Input } from "@/Components/ui/input"
+import { Textarea } from "@/Components/ui/textarea"
 import { Segmented } from "@/Components/ui/segmented"
 import { FormSection, FormGrid } from "@/Components/ui/form-section"
 import {
@@ -201,6 +202,15 @@ export function ClienteForm<T extends ClienteFormShared>({
                 value={data.zip_code}
                 onChange={(e) => set("zip_code", e.target.value)}
                 placeholder="00000-000"
+              />
+            </Field>
+            <Field label="Endereço de entrega" error={err.shipping_address} fullRow>
+              <Textarea
+                variant="cowork"
+                value={data.shipping_address}
+                onChange={(e) => set("shipping_address", e.target.value)}
+                placeholder="Preencha se a entrega for em endereço diferente do cadastro acima."
+                rows={2}
               />
             </Field>
           </FormGrid>

--- a/resources/js/Pages/Cliente/_form/cliente-form-types.ts
+++ b/resources/js/Pages/Cliente/_form/cliente-form-types.ts
@@ -20,6 +20,7 @@ export type ClienteFormShared = DadosFiscaisBRData & {
   city: string
   state: string
   zip_code: string
+  shipping_address: string
   customer_group_id: string
   opening_balance: string
   credit_limit: string

--- a/resources/js/Pages/Sells/Create.tsx
+++ b/resources/js/Pages/Sells/Create.tsx
@@ -215,6 +215,38 @@ export default function SellsCreate(props: SellsCreatePageProps) {
 
   // Persistir <details> open state em localStorage (DESIGN.md §12)
   const [advancedOpen, setAdvancedOpen] = useState<boolean>(false);
+
+  // US-CRM-078 — endereços salvos do cliente selecionado (dropdown na seção
+  // Entrega). Busca read-only de /cliente/{id}/enderecos; selecionar preenche
+  // o campo de endereço de entrega (snapshot string — mesmo fluxo da venda).
+  // Mínimo de risco vs PR2 revertido (#2104): NÃO toca getCustomers (causa do
+  // 500), NÃO mexe no save (string snapshot intacto), NÃO altera o toggle.
+  type SavedAddress = {
+    id: number;
+    label: string | null;
+    one_line: string;
+    is_default: boolean;
+    is_shipping: boolean;
+  };
+  const [savedAddresses, setSavedAddresses] = useState<SavedAddress[]>([]);
+
+  const loadContactAddresses = async (contactId: number) => {
+    try {
+      const res = await fetch(`/cliente/${contactId}/enderecos`, {
+        headers: { Accept: 'application/json', 'X-Requested-With': 'XMLHttpRequest' },
+        credentials: 'same-origin',
+      });
+      if (!res.ok) {
+        setSavedAddresses([]);
+        return;
+      }
+      const json = (await res.json()) as { addresses?: SavedAddress[] };
+      setSavedAddresses(Array.isArray(json.addresses) ? json.addresses : []);
+    } catch {
+      setSavedAddresses([]);
+    }
+  };
+
   useEffect(() => {
     try {
       const stored = localStorage.getItem(ADVANCED_OPEN_KEY);
@@ -430,6 +462,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
   // shipping_address vive em data.shipping.address (nested) — setData usa dot path.
   const handleCustomerSelect = (c: CustomerSearchResult) => {
     setData('contact_id', c.id);
+    void loadContactAddresses(c.id);
     if (c.pay_term_number !== null && c.pay_term_number !== undefined && c.pay_term_number !== '') {
       setData('pay_term_number', String(c.pay_term_number));
     }
@@ -451,6 +484,7 @@ export default function SellsCreate(props: SellsCreatePageProps) {
   // R8 — reset ao limpar cliente. Volta pros defaults (walk-in + props default).
   const handleCustomerClear = () => {
     setData('contact_id', props.walkInCustomer.id);
+    setSavedAddresses([]);
     setData('pay_term_number', '');
     setData('pay_term_type', 'days');
     // shipping fica como user editou — não auto-limpa (pode ser endereço manual)
@@ -1515,6 +1549,32 @@ export default function SellsCreate(props: SellsCreatePageProps) {
           {/* Bloco frete colapsável dentro de Mais opções (5 campos juntos) */}
           <div className="rounded-md border border-border p-4 space-y-4">
             <h3 className="text-sm font-semibold text-foreground">Entrega / Frete</h3>
+            {savedAddresses.length > 0 && (
+              <div className="space-y-1.5">
+                <Label htmlFor="saved_address">Endereços salvos do cliente</Label>
+                <Select
+                  value=""
+                  onValueChange={(v) => {
+                    const addr = savedAddresses.find((a) => String(a.id) === v);
+                    if (addr) {
+                      setData('shipping', { ...data.shipping, address: addr.one_line });
+                    }
+                  }}
+                >
+                  <SelectTrigger id="saved_address">
+                    <SelectValue placeholder="Escolher um endereço salvo…" />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {savedAddresses.map((a) => (
+                      <SelectItem key={a.id} value={String(a.id)}>
+                        {(a.label ? `${a.label} — ` : '') + a.one_line}
+                        {a.is_shipping ? ' (entrega)' : a.is_default ? ' (principal)' : ''}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+            )}
             <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
               <div className="space-y-1.5">
                 <Label htmlFor="shipping_details">Detalhes de envio</Label>

--- a/tests/Feature/Cliente/ClienteDrawerCadastroAutosaveTest.php
+++ b/tests/Feature/Cliente/ClienteDrawerCadastroAutosaveTest.php
@@ -249,6 +249,18 @@ test('PATCH /endereco field-a-field -- state persiste no DB', function () {
     $this->assertDatabaseHas('contacts', ['id' => $this->contactId, 'state' => 'SP']);
 });
 
+// Wagner 2026-06-02 — endereço de entrega (shipping_address) cadastrável no
+// drawer Cliente. Coluna UPOS desde 2020; antes não havia UI nem aceite no
+// autosave. A venda puxa daqui (Fase 2). Texto livre (aceita multi-linha).
+test('PATCH /endereco field-a-field -- shipping_address (endereço de entrega) persiste no DB + retorna na response', function () {
+    $endereco = "Rua da Entrega, 500 - Galpao 3\nGuarulhos/SP - aos cuidados do Joao";
+    $response = $this->patchJson("/cliente/{$this->contactId}/endereco", [
+        'shipping_address' => $endereco,
+    ]);
+    $response->assertStatus(200)->assertJsonPath('contact.shipping_address', $endereco);
+    $this->assertDatabaseHas('contacts', ['id' => $this->contactId, 'shipping_address' => $endereco]);
+});
+
 test('PATCH /endereco -- naming PT-BR (cep, endereco, bairro, cidade, uf) e descartado silenciosamente (regression)', function () {
     // Documenta o bug original — frontend antigo enviava nomes PT-BR. Backend
     // valida apenas canon (whitelist), entao Validator::validated() retorna

--- a/tests/Feature/Cliente/ClienteDrawerRowsCanonBrPayloadTest.php
+++ b/tests/Feature/Cliente/ClienteDrawerRowsCanonBrPayloadTest.php
@@ -173,3 +173,29 @@ test('GUARD 8 — payload[status] ainda eh late|active|idle derivado OS (Frescor
         ->toContain("\$status = \$atrasadas > 0 ? 'late' : (\$abertas > 0 ? 'active' : 'idle')")
         ->toMatch("/'status'\\s*=>\\s*\\\$status/");
 });
+
+// ─── GUARD 9: shipping_address (endereço de entrega) — Wagner 2026-06-02 ────
+// Sem o campo no select + payload, o drawer EnderecoTab reabre vazio mesmo com
+// dado salvo no DB (mesma classe do bug zip_code/address_line). A venda (Fase 2)
+// puxa o endereço de entrega daqui.
+
+test('GUARD 9 — buildClienteIndexCustomers select + payload incluem shipping_address', function () {
+    $path = __DIR__ . '/../../../app/Http/Controllers/ContactController.php';
+    $contents = file_get_contents($path);
+
+    expect($contents)
+        ->toContain("'contacts.shipping_address'")
+        ->toContain("'shipping_address' => \$contact->shipping_address");
+});
+
+test('GUARD 9b — EnderecoTab.tsx declara shipping_address + autosave on blur', function () {
+    $path = __DIR__ . '/../../../resources/js/Pages/Cliente/_drawer/EnderecoTab.tsx';
+    expect($path)->toBeReadableFile();
+
+    $contents = file_get_contents($path);
+    expect($contents)
+        ->toContain('shipping_address?: string | null')
+        ->toContain("useState<string>(contact.shipping_address ??")
+        ->toContain("scheduleAutosave('shipping_address'")
+        ->toContain("handleBlur('shipping_address'");
+});


### PR DESCRIPTION
## O que
Completa a feature **múltiplos endereços de entrega por contato** (US-CRM-078):
- **Cadastro** (drawer Cliente): campo de endereço de entrega no EnderecoTab + autosave + plumbing `shipping_address` (coluna UPOS desde 2020) em ContactController/ClienteAutosaveController.
- **Venda** (`Sells/Create.tsx`): dropdown **"Endereços salvos do cliente"** que busca `GET /cliente/{id}/enderecos` e preenche o campo de endereço de entrega.

## Re-do do PR2 revertido (#2104 → revert #2107)
A integração na venda foi revertida em 2026-06-02 (cliente reportou regressão, mergeado sem smoke visual). Esta versão é **minimal-risk** e evita as 3 causas-raiz do incidente:
1. ❌ NÃO toca `getCustomers` com `->with('addresses')` (causa do 500) — só adiciona a coluna plana `shipping_address` ao SELECT.
2. ❌ NÃO mexe no toggle Entrega/Retirada (causa do 'não salva').
3. ❌ Sem migration nova; snapshot string intacto (`TransactionUtil`).

## Smoke REAL feito (lição do incidente cumprida) — CT100 staging, biz=1
- `GET /cliente/1/enderecos` → **200** (sem 500).
- Dropdown renderiza os endereços salvos (Principal/Obra Centro).
- Selecionar preenche o campo de endereço de entrega.
- Console **limpo**.
- Venda salva (OS00133) → DB: `shipping_address = 'Rua das Palmeiras, 450 — Centro — Blumenau/SC · 89010-100'` ✅ (endereço escolhido).

Refs: US-CRM-078

🤖 Generated with [Claude Code](https://claude.com/claude-code)