### PR TITLE
Reforço AppShell + testes + CSS (handoff Cowork 2026-06-02)

### DIFF
--- a/.github/workflows/ui-architecture-gate.yml
+++ b/.github/workflows/ui-architecture-gate.yml
@@ -1,0 +1,90 @@
+name: UI architecture gate
+
+# Gate de arquitetura UI (handoff Cowork 2026-06-02 · REFORCO-APPSHELL-TESTES).
+# Roda os testes estruturais de tests/Feature/Architecture/ que de outra forma NÃO
+# entram no CI (ci.yml roda só tests/Feature/Form). Sem este workflow os gates A1/A2
+# seriam código morto. Testes puros de filesystem (sem DB) — rápidos.
+#
+# Cobre:
+#   - AppShellUsageGateTest      (A1) toda tela Inertia usa AppShellV2
+#   - CockpitAccentCanonTest     (A2) accent = roxo canon 295 (não azul 220)
+#   - CoreScreensIntegrityTest   (B)  telas-núcleo: page + AppShellV2 + charter
+#
+# NOTA: NoHardcodeBusinessIdInModulesTest (guard Tier 0 business_id) NÃO está aqui
+# de propósito — hoje ele false-positiva no padrão legítimo `=== 0` (no-tenant guard).
+# Recalibrar o escopo dele é decisão Tier 0 de [W] (ver PR/discussão).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'resources/js/Pages/**'
+      - 'resources/js/Layouts/AppShellV2.tsx'
+      - 'resources/js/Components/cockpit/**'
+      - 'resources/css/cockpit.css'
+      - 'tests/Feature/Architecture/**'
+      - '.github/workflows/ui-architecture-gate.yml'
+  pull_request:
+    paths:
+      - 'resources/js/Pages/**'
+      - 'resources/js/Layouts/AppShellV2.tsx'
+      - 'resources/js/Components/cockpit/**'
+      - 'resources/css/cockpit.css'
+      - 'tests/Feature/Architecture/**'
+      - '.github/workflows/ui-architecture-gate.yml'
+
+concurrency:
+  group: ui-architecture-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: UI architecture (AppShell + accent + core screens)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: mbstring, xml, ctype, json, opentelemetry
+          coverage: none
+          tools: composer:v2
+
+      - name: Cache composer
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-uiarch-${{ runner.os }}-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-uiarch-${{ runner.os }}-
+
+      - name: Install PHP deps
+        run: composer install --no-interaction --prefer-dist --no-progress --no-scripts
+
+      - name: Prepare storage dirs + .env mínimo
+        run: |
+          mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views storage/logs bootstrap/cache
+          cat > .env <<'EOF'
+          APP_NAME=oimpresso-ui-arch
+          APP_ENV=testing
+          APP_DEBUG=false
+          APP_URL=http://localhost
+          LOG_CHANNEL=stderr
+          DB_CONNECTION=sqlite
+          DB_DATABASE=:memory:
+          CACHE_DRIVER=array
+          QUEUE_CONNECTION=sync
+          SESSION_DRIVER=array
+          MAIL_MAILER=array
+          EOF
+          php artisan key:generate
+
+      - name: Pest — UI architecture gates
+        run: |
+          vendor/bin/pest \
+            tests/Feature/Architecture/AppShellUsageGateTest.php \
+            tests/Feature/Architecture/CockpitAccentCanonTest.php \
+            tests/Feature/Architecture/CoreScreensIntegrityTest.php \
+            --no-coverage

--- a/config/stylelint-baseline.json
+++ b/config/stylelint-baseline.json
@@ -1,7 +1,7 @@
 {
   "_meta": {
-    "generated_at": "2026-05-31T23:46:15.538Z",
-    "total_violations": 1095,
+    "generated_at": "2026-06-02T19:48:07.945Z",
+    "total_violations": 1065,
     "stylelint_version": "17.x",
     "adr": "0209",
     "note": "G5 anti-drift CSS — gêmeo do eslint-baseline. Ratchet por path+rule, falha só em delta>0."
@@ -15,7 +15,7 @@
     "resources/css/cowork-canon-financeiro-bundle.css|no-duplicate-selectors": 44,
     "resources/css/cowork-compras-bundle.css|color-no-hex": 51,
     "resources/css/cowork-fields.css|color-no-hex": 5,
-    "resources/css/cowork-financeiro-bundle.css|color-no-hex": 188,
+    "resources/css/cowork-financeiro-bundle.css|color-no-hex": 158,
     "resources/css/cowork-financeiro-bundle.css|declaration-no-important": 43,
     "resources/css/cowork-financeiro-bundle.css|no-duplicate-selectors": 44,
     "resources/css/cowork-payment-gateway-bundle.css|color-no-hex": 2,

--- a/prototipo-ui/INVENTARIO_CLASSES.md
+++ b/prototipo-ui/INVENTARIO_CLASSES.md
@@ -1,0 +1,67 @@
+# INVENTÁRIO DE CLASSES — integridade do host (2026-06-02 · [CC])
+
+> Pedido de [W]: "ficou alguma class perdida… um inventário seria perfeito agora para manter 100% íntegro."
+> Método: varredura programática (`run_script`) — classes **usadas** no markup (67 `.jsx`/`.js` + html carregados) × **definidas** no CSS (19 folhas do host), filtrando utilitários Tailwind. Fonte de verdade: o que o `oimpresso.com.html` realmente carrega.
+
+---
+
+## 🔴 ACHADO PRINCIPAL — vocabulário `os-*` DUPLICADO no styles.css (55 seletores)
+
+**O que é:** `styles.css` tem **duas definições concorrentes** dos componentes do shell (`.os-tab`, `.os-table`, `.os-search`, `.os-row`, `.os-drawer`, `.icon-btn`, `.os-tabs`, `.os-table thead th`, etc.) — uma original limpa baseada em token, outra colada de outro módulo quando layouts foram juntados.
+
+| Versão | Característica | Exemplo `.os-table` |
+|---|---|---|
+| **[0] canônica** | token-based, limpa | `width:100%; border-collapse:separate; border-spacing:0; font-size:13px;` |
+| **[1] colada (drift)** | cores HARDCODED, fura v5 | `width:100%; border-collapse:collapse; background:#fff; border:1px solid var(--border, oklch(0.93 0.01 250));` |
+
+**Impacto:** a **[1] vence no cascade** (está mais abaixo no arquivo) → telas renderizam com cores cruas que **ignoram a migração v5 de tokens**. É a "duplicata de layout" que [W] sentiu.
+
+**Seletores afetados (amostra):** `body` (3×) · `.os-tab` `.os-tab:hover` `.os-tab.active` `.os-tabs` · `.os-table` `.os-table thead th` · `.os-search` `.os-search input` · `.os-row` `.os-row:hover` `.os-row.urgent` · `.os-drawer` `.os-drawer-h` `.os-drawer-actions` · `.icon-btn` `.icon-btn:hover` · `.sb-group-h` `.sb-user-btn` · `.os-page-h-r` (uma cópia é `display:none!important`) · `.os-modal` `.os-new-price-i` …
+
+**Remediação (proposta — precisa de OK de [W], blast radius alto = todas as telas):**
+1. Adotar a **[0] token-based como canônica** (respeita o v5).
+2. Portar qualquer ajuste **intencional** da [1] (ex: paddings novos) pra [0].
+3. **Deletar a [1]** (a cópia hardcoded). Slima o styles.css E remove drift de cor que briga com o v5.
+4. Testar cada tela (a [1] vence hoje, então remover muda o render — verificar antes/depois).
+> ⚠️ NÃO é delete cego: a [1] vence hoje, então a remoção reverte pro look [0]. Reconciliação por seletor + gate visual.
+
+### ✅ PROGRESSO 2026-06-02 — Fase 1: DE-DRIFT do bloco [1] (feito + verificado)
+[W] autorizou ("pode fazer, você é o responsável, compara antes/depois"). Como a [1] vence e o look dela está bom (tabelas brancas bordadas), a decisão foi **manter a estrutura [1] e tokenizar as cores cruas** (em vez de deletar e reverter pro [0]). Tokenizado em `styles.css` (8 pontos do bloco `.os-kpi/.os-tabs/.os-tab .count/.os-search/.os-table/.os-table thead th/.os-table td/.os-drawer-head/.vd-stepper`):
+- `#fff` → `var(--surface)` · `oklch(0.98 0.005 250)` (frio) → `var(--bg-2)` · `oklch(0.96 0.01 250)` → `var(--border-2)` · `var(--border, oklch(...))` → `var(--border)`.
+- **Verificado por `eval_js` (computed styles):** `.os-table` bg = `oklch(1 0 0)` (surface), `thead` e `td` agora hue **95 quente** (era 250 frio). Zero cor crua 250 restante. Value-preserving (branco=branco; near-whites quentes). Console limpo. Screenshot do agente estava fora do ar → verificação por computed-style + verificador forkado.
+- **Nota:** a maioria das cores do bloco já era `var(--token, fallback)` = já resolvia no v5; o drift real era pequeno (~6 cores cruas). Risco baixo, confirmado.
+
+### ⏭️ Fase 2 (pendente): COLAPSAR [0]+[1] em UMA regra
+Agora ambas as cópias são v5-consistentes (sem conflito de cor). Falta remover a duplicação estrutural (colapsar pra 1 def por seletor) — fazer com gate visual antes/depois por tela quando a ferramenta de screenshot voltar. Único idêntico-exato seguro hoje: `.vd-step.done .vd-step-num`.
+
+**Idênticos (remoção 100% segura, sem mudança visual):** só `.vd-step.done .vd-step-num` (2× cópia exata).
+
+---
+
+## 🟡 ÓRFÃS (usadas no markup, sem CSS no host) — 139 estritas, MAS quase todas benignas
+
+Triagem honesta (verificado por grep):
+- **Contêineres-pai sem estilo próprio** (`os-approve`, `fin-comments`, `vd-create`): os FILHOS é que têm CSS (`.os-approve-body`, `.fin-comments-h`). O pai é só hook — **não é perda**. As defs "completas" só existem em `resources/css/*` (repo, não carregado) scopadas sob `.fin-cowork`.
+- **`twk-*` (21):** o painel Tweaks (`tweaks-panel.jsx`) injeta `<style>` próprio em runtime — **não é perda**.
+- **Dinâmicas** (`kb-block--${t}`, `ofc-grade-`, `vd-ai-${state}`): a base+variante existe no CSS; o literal com `-`/`${}` não casa no grep — **falso positivo**.
+- **`[∅]` palavras soltas** (`kanban`, `compact`, `lead`, `tab`): variáveis JS / valores de estado capturados como token — **não são classes**.
+
+**Veredito:** nenhuma órfã é regressão da fusão de tokens. O app renderiza íntegro (6 telas + verificador confirmaram). Resíduo real a investigar 1-a-1 (baixa prioridade): `vco-page`, `vrep-page`, `vendas-table`, `pdv-pay`, `nfe-review` — provável que sejam telas-mockup ou hooks.
+
+---
+
+## ⚪ MORTAS (CSS definido, nunca usado) — 471 candidatas
+
+Maioria = blocos de mockup/legado (`casos-*`, `bi-*`, `br-*`, `art-v1/2/3`, `bc-*`) e variantes não-acionadas. Limpeza é higiene, não urgência. NÃO deletar sem checar dinâmicas (`stage-${x}` usa `.stage-pago` etc. que parecem "mortas" mas são montadas em runtime).
+
+---
+
+## Sequência recomendada (slim seguro → "no final só 1")
+
+1. **[este doc]** inventário — mapa pronto. ✅
+2. **Reconciliar os 55 `os-*` duplicados** (adotar [0] token-based, deletar [1] hardcoded) — **maior ganho**: slima styles.css + cura drift de cor anti-v5. Gate visual por tela. ← *próximo passo real, aguarda OK de [W]*
+3. **Migração de vocabulário** `os-*` → `ds-v5/components.css` (`.os-btn`→`.btn` etc.) — **por tela, atrás dos casos**, NÃO bulk (vocabulários paralelos: 272 classes v5 não existem no shell, só 52 batem e são modificadores).
+4. **Limpeza de mortas** — por último, com cuidado com classes dinâmicas.
+
+## Trilha do tempo
+- 2026-06-02 · [CC] gerou o inventário após [W] pedir integridade pós-fusão de tokens. Achado-chave: 55 `os-*` duplicados (drift hardcoded vence cascade). Órfãs = benignas (hooks/runtime/dinâmicas). Recomendação: reconciliar os duplicados como próximo slim.

--- a/prototipo-ui/prototipos/compras/charter.md
+++ b/prototipo-ui/prototipos/compras/charter.md
@@ -1,0 +1,85 @@
+---
+page: /compras · window.ComprasPage
+component: compras-page.jsx (+ compras-page.css)
+repo_alvo: Inertia Purchases/Index (controller a confirmar no git)
+status: APROVADO por [W] (chat 2026-06-02 — "pode fazer sim, nada estranho"). Backfill que TRAVA o estado vivo (já migrado ao DS roxo, 9.4). Mirror no git pendente (L-13).
+owner: wagner
+last_validated: 2026-06-02
+validated_against: compras-page.jsx @ cowork-2026-06-02
+persona: Eliana [E] (financeiro/entrada de nota) · Wagner (volume/fornecedores)
+identidade: roxo 295 — usa o **accent canônico do DS** (ADR 0235), SEM escopo próprio. Já migrada: 0 hex cru, classes `--cmp-*` → tokens DS (STATUS 2026-05-30).
+nota_atual: 9.4 (migrado DS roxo 295)
+irmao: Compras.casos.md (6 UCs grounded no código)
+tier: A
+charter_version: 1
+---
+
+# Page Charter — /compras
+
+> **Status:** memória-por-tela (L-14), backfill que trava o conceito da tela **já migrada ao DS** (0 hex, 9.4). [W] confirma aprovações/reprovações explícitas.
+> **Padrão visual:** Cockpit V2 (ADR 0110) · list + detail com drawer FSM.
+> Personas: Eliana (entra nota, concilia, paga) · Wagner (volume, fornecedores).
+
+---
+
+## Mission
+
+A entrada de compras da gráfica: receber a **NF-e do fornecedor** (por XML ou manual), acompanhar a compra pelo seu ciclo de vida, conferir o que chegou e pagar. A pergunta que responde primeiro é **"o que tenho a pagar e o que está chegando?"** — com a nota fiscal de entrada grudada e a ação certa em cada etapa.
+
+---
+
+## Goals — Features (PRECISA TER)
+
+**Vivo hoje (aprovado / manter):**
+- **FSM de compra:** rascunho → pedido → trânsito → recebido → conferido → pago — o trilho (`fsm-track`/`fsm-step`) marca onde está (`now`/`done`) — _UC-K04_
+- **Filtros por status:** Todas / A pagar / Rascunhos / Em trânsito, com contagem (`filter`) — _UC-K01_
+- **4 KPIs:** A pagar · Em trânsito · Volume do mês · Fornecedores ativos (`kpi.aberto/transito/mes/fornec`) — _UC-K02_
+- **Entrada de nota:** "Importar XML" (NF-e do fornecedor) ou "Nova compra" manual (atalhos I/N) — _UC-K03_
+- **Ação certa por etapa** (rodapé do drawer): "Enviar pedido" (rascunho) · "Marcar recebida" (trânsito) · "Conferir itens" (recebido) · "Pagar agora" (conferido+devendo) — _UC-K05_
+- **Busca** por NF-e, fornecedor, ref ou chave SEFAZ; `/` foca a busca — _UC-K06_
+
+---
+
+## Non-Goals — Features (NÃO faz)
+
+- ❌ Detalhe em modal full-screen (canon = drawer lateral / Sheet)
+- ❌ Emissão fiscal de saída (isso é Vendas/NFe; aqui é **entrada** de nota do fornecedor)
+- ❌ Contas a pagar recorrentes / financeiro completo (vínculo com Financeiro, não duplicar o módulo)
+- ❌ Inglês em UI cliente-facing
+
+---
+
+## UX Targets
+
+- Cabe em 1280px sem scroll horizontal (Eliana escritório / Larissa balcão)
+- A etapa do FSM é legível num relance; o botão de ação **muda com a etapa** (nunca todos visíveis)
+- Importar XML é caminho de 1 clique (entrada de nota é o fluxo quente)
+- escala warm semântica (a pagar/atraso), zero cor crua — **manter os 0 hex da migração**
+- 0 erros JS console
+
+---
+
+## UX Anti-patterns (REPROVADO — não repetir)
+
+- ❌ **Reintroduzir hex cru / `--cmp-*` bespoke** — a tela já foi migrada pra tokens DS (0 hex). Regressão pra cor crua = desfaz o trabalho (L-02/L-23). Cor só via token do DS.
+- ❌ **Mostrar todos os botões de ação a toda hora** — a ação é condicional ao `stage` (UC-K05); mostrar tudo quebra o "ação certa da etapa".
+- ❌ Modal full-screen pra detalhe (usar drawer FSM)
+- ❌ `rounded-xl+` · `font-bold` em h1
+- ❌ Confundir entrada (compras) com saída (vendas) no vocabulário fiscal
+
+---
+
+## Identidade & DS
+
+- **Roxo canônico do DS** (ADR 0235) — Compras **não** tem accent escopado próprio; usa o `var(--accent)` canon direto. Foi a 1ª tela a provar a migração completa (navy/cream → tokens DS, 0 hex).
+- Migração pro `ds-v5`: barata (já está em tokens). Confirmar que nenhum `--cmp-*` residual sobrou; gate visual F1.5 antes/depois.
+
+---
+
+## Refs
+
+- Compras.casos.md — 6 UCs grounded em `compras-page.jsx`
+- ADR 0110 — Cockpit V2 · ADR 0235 — roxo canon · ADR 0200 — DS é piso
+
+## Trilha do tempo
+- 2026-06-02 · [CC] criou o charter (backfill) travando o estado vivo da tela migrada 9.4, grounded nos 6 UCs. Passo 2 do `_PROPOSTA-0245` (trio antes de migrar pro v5). Aguarda confirmação de [W] + mirror no git.

--- a/prototipo-ui/prototipos/vendas/charter.md
+++ b/prototipo-ui/prototipos/vendas/charter.md
@@ -1,0 +1,90 @@
+---
+page: /vendas · window.VendasPage
+component: vendas-page.jsx (+ vendas-extras.jsx, vendas-ai.jsx, vendas-curation.jsx, vendas-shortcuts.jsx, vendas-tweaks.jsx, vendas-output.jsx, data-vendas.jsx)
+repo_alvo: Inertia Sells/Index (lista) — NÃO confundir com Sells/Create (git Sells/Create.charter.md, telा de cadastro)
+status: APROVADO por [W] (chat 2026-06-02 — "pode fazer sim, nada estranho"). Backfill que TRAVA o estado vivo (piloto aprovado). Mirror no git pendente (L-13).
+owner: wagner
+last_validated: 2026-06-02
+validated_against: vendas-page.jsx @ cowork-2026-06-02
+persona: Larissa (balcão 1280px) · Eliana [E] (financeiro/fiscal) · Wagner (governança)
+identidade: verde 155 — accent ESCOPADO `.vendas-scope{ --accent: oklch(0.45 0.11 155) }` por cima do DS (ADR 0200 D-02, proposta). NÃO redeclara token global; o roxo canon (ADR 0235) segue intacto fora do escopo.
+nota_atual: 9.5 (piloto aprovado [W])
+irmao: Vendas.casos.md (8 UCs grounded no código)
+tier: A
+charter_version: 1
+---
+
+# Page Charter — /vendas (Index / lista)
+
+> **Status:** memória-por-tela (L-14), backfill DEPOIS do build pra travar o conceito da tela **piloto aprovada** (9.5). Captura o que está vivo e aprovado pra eu não regredir nem repetir pergunta. [W] confirma aprovações/reprovações explícitas.
+> **Padrão visual:** Cockpit V2 (ADR 0110) · golden = `Sells/Create` (10 regras GOLDEN-REFERENCE).
+> Personas: Larissa (balcão, teclado-first) · Eliana (fiscal) · Wagner (governança).
+
+---
+
+## Mission
+
+A lista de vendas da gráfica: ver **o dia em números**, achar qualquer venda por visão salva/filtro, abrir o detalhe com o **fiscal grudado** (NF-e de produto + NFS-e de serviço), e cobrar o que está a receber. A pergunta que responde primeiro é **"o que faturei e o que falta receber hoje?"** — com a venda que nasceu na Oficina aparecendo aqui sem retrabalho.
+
+---
+
+## Goals — Features (PRECISA TER)
+
+**Vivo hoje (aprovado / manter):**
+- **KPI hero** "Faturado hoje" + sparkline 30d, "Ticket médio", "A receber" (`vd-kpi-hero`) — _UC-V01_
+- **Nova venda** num toque: botão + tecla **N** + **⌘K** — _UC-V02_
+- **Visões salvas (árvore):** Pendentes (por vendedor) · Faturadas (B2B/B2C) · Origem (balcão/oficina/online) · Favoritas (`topView`/`subView`) — _UC-V03_
+- **A receber com ageing/SLA:** KPI marca alerta + CTA "ver estouradas" filtra os títulos vencidos (`slaCounts` · view `atrasadas`) — _UC-V04_
+- **Fiscal no drawer:** `VdFiscalCard` por documento — **NF-e** (produto) + **NFS-e** (serviço), número/chave SEFAZ 44 díg. copiável — _UC-V05_
+- **Ponte Oficina→Vendas:** OS pronta gera venda derivada (origin=oficina); listener `oimpresso:open-venda{id}` abre; filtro Origem=oficina lista as derivadas — _UC-V06_ (contraparte do UC-08 da Oficina)
+- **⌘K** teclado-first: Nova venda · Emitir NF-e em lote · Buscar por chave SEFAZ — _UC-V07_
+- **Emitir NF-e em lote:** seleção > 0 → fluxo de emissão em lote (`setBulkEmitOpen`) — _UC-V08_
+
+---
+
+## Non-Goals — Features (NÃO faz)
+
+- ❌ **Não é POS de balcão.** O "Create POS" foi **aposentado** (2026-06-01); a superfície de criação rica migrou pra **Oficina/OS** (documento vivo). Vendas = lista + detalhe + fiscal + cobrança, não cupom de caixa.
+- ❌ Cobrança via WhatsApp cliente-facing (proibição charter)
+- ❌ Detalhe em modal full-screen (canon = drawer lateral / Sheet)
+- ❌ Emissão fiscal completa na tela (aqui só dispara + mostra status/chave; o motor vive nos módulos NFe/NFSe)
+- ❌ Inglês em UI cliente-facing
+
+---
+
+## UX Targets
+
+- Cabe em 1280px sem scroll horizontal (Larissa) — KPIs e árvore refluem, nunca esmagam
+- Teclado-first: N (nova) · ⌘K (paleta) · `/` (busca) · J/K (navegar) — Larissa quase não usa mouse
+- Fiscal split visível: produto→NF-e, serviço→NFS-e, sempre os dois cards quando há os dois
+- A receber estourado salta aos olhos (alerta no KPI, 1 clique pros vencidos)
+- escala warm semântica (emerald pago · amber vencendo · rose atrasado), zero cor crua
+- 0 erros JS console
+
+---
+
+## UX Anti-patterns (REPROVADO — não repetir)
+
+- ❌ **Recriar o POS de balcão aqui** — foi decisão de [W] aposentar e migrar pra Oficina/OS. Não ressuscitar create pesado na lista.
+- ❌ **Esconder o split fiscal** (mostrar só "NF" genérica) — produto e serviço têm documentos distintos; o card tem que separar.
+- ❌ Cor crua fora dos tokens / `--<prefixo>-*` inventado — identidade só por `.vendas-scope{--accent}` herdando os componentes do DS
+- ❌ `rounded-xl+` · `font-bold` em h1 · modal full-screen pra detalhe
+- ❌ Mexer na estrutura sem ler este charter + casos antes (a tela é **piloto aprovado** — regressão aqui é cara)
+
+---
+
+## Identidade & DS
+
+- **Accent escopado verde 155** (`.vendas-scope{ --accent: oklch(0.45 0.11 155) }`) — herda os componentes do `ds-v5`, que se pintam sozinhos via `var(--accent)`. NÃO redeclara token global; roxo canon (ADR 0235) intacto fora do escopo.
+- Migração pro `ds-v5`: aditiva, reuse-first. Gate visual F1.5 (antes/depois) obrigatório — é piloto, qualquer regressão de layout barra o merge.
+
+---
+
+## Refs
+
+- Vendas.casos.md — 8 UCs grounded em `vendas-page.jsx`
+- ADR 0110 — Cockpit V2 · ADR 0235 — roxo canon · ADR 0200 — DS é piso / accent escopado
+- git Sells/Create.charter.md — a tela IRMÃ de cadastro (não confundir)
+
+## Trilha do tempo
+- 2026-06-02 · [CC] criou o charter (backfill) travando o estado vivo da lista 9.5, grounded nos 8 UCs. Passo 2 do `_PROPOSTA-0245` (trio antes de migrar pro v5). Aguarda confirmação de [W] das aprovações/reprovações + mirror no git.

--- a/resources/css/cowork-financeiro-bundle.css
+++ b/resources/css/cowork-financeiro-bundle.css
@@ -4075,7 +4075,7 @@
 .fin-cowork .vendas-page .vd-total { font-weight:600; font-variant-numeric:tabular-nums; font-size:13px; }
 .fin-cowork .vendas-page .vd-os-pill { display:inline-block; padding:1px 6px; border-radius:4px; background:oklch(0.95 0.01 250); font-family:var(--font-mono); font-size:10px; margin-right:3px; color:oklch(0.40 0.04 250); }
 .fin-cowork .vendas-page .vd-no-os { font-size:11px; color:oklch(0.55 0.02 250); font-style:italic; }
-.fin-cowork .kbd-hint { display:inline-block; padding:1px 5px; margin-left:4px; border:1px solid oklch(0.85 0.02 250); border-radius:3px; font-family:var(--font-mono); font-size:9px; color:oklch(0.40 0.04 250); background:#fff; }
+.fin-cowork .kbd-hint { display:inline-block; padding:1px 5px; margin-left:4px; border:1px solid oklch(0.85 0.02 250); border-radius:3px; font-family:var(--font-mono); font-size:9px; color:oklch(0.40 0.04 250); background:var(--surface); }
 /* Drawer venda */
 .fin-cowork .vd-section { padding:14px 20px; border-bottom:1px solid oklch(0.95 0.01 250); }
 .fin-cowork .vd-section:last-child { border-bottom:none; }
@@ -4091,7 +4091,7 @@
 /* Stepper */
 .fin-cowork .vd-stepper { display:flex; align-items:center; gap:6px; padding:10px 20px; background:oklch(0.98 0.01 250); border-bottom:1px solid oklch(0.92 0.01 250); overflow-x:auto; }
 .fin-cowork .vd-step { display:flex; align-items:center; gap:6px; padding:6px 10px; background:transparent; border:none; cursor:pointer; font-size:12px; color:oklch(0.50 0.02 250); border-radius:4px; }
-.fin-cowork .vd-step.active { color:oklch(0.30 0.10 240); font-weight:600; background:#fff; box-shadow:0 1px 2px rgba(0,0,0,0.04); }
+.fin-cowork .vd-step.active { color:oklch(0.30 0.10 240); font-weight:600; background:var(--surface); box-shadow:0 1px 2px rgba(0,0,0,0.04); }
 .fin-cowork .vd-step.done { color:oklch(0.45 0.12 145); }
 .fin-cowork .vd-step-num { display:inline-flex; align-items:center; justify-content:center; width:20px; height:20px; border-radius:50%; background:oklch(0.92 0.01 250); font-size:11px; font-weight:600; }
 .fin-cowork .vd-step.active .vd-step-num { background:oklch(0.55 0.14 240); color:#fff; }
@@ -4099,13 +4099,13 @@
 .fin-cowork .vd-step-sep { color:oklch(0.75 0.01 250); margin:0 2px; }
 /* Create body */
 .fin-cowork .vd-create-body { padding:0; }
-.fin-cowork .vd-search-wrap { display:flex; align-items:center; gap:8px; padding:8px 12px; background:#fff; border:1px solid oklch(0.88 0.01 250); border-radius:6px; }
+.fin-cowork .vd-search-wrap { display:flex; align-items:center; gap:8px; padding:8px 12px; background:var(--surface); border:1px solid oklch(0.88 0.01 250); border-radius:6px; }
 .fin-cowork .vd-search-wrap input { flex:1; border:none; outline:none; font-size:13px; }
 .fin-cowork .vd-search-wrap input:focus { outline:none; }
 .fin-cowork .vd-walkin { background:oklch(0.92 0.04 240); color:oklch(0.30 0.10 240); border:none; padding:4px 10px; border-radius:4px; font-size:11px; cursor:pointer; }
 .fin-cowork .vd-walkin:hover { background:oklch(0.88 0.05 240); }
 .fin-cowork .vd-client-list { display:grid; grid-template-columns:1fr 1fr; gap:6px; margin-top:10px; }
-.fin-cowork .vd-client-card { text-align:left; padding:10px 12px; border:1px solid oklch(0.92 0.01 250); border-radius:6px; background:#fff; cursor:pointer; }
+.fin-cowork .vd-client-card { text-align:left; padding:10px 12px; border:1px solid oklch(0.92 0.01 250); border-radius:6px; background:var(--surface); cursor:pointer; }
 .fin-cowork .vd-client-card:hover { border-color:oklch(0.55 0.14 240); background:oklch(0.98 0.02 240); }
 .fin-cowork .vd-client-card-name { font-weight:600; font-size:13px; }
 .fin-cowork .vd-client-card-meta { font-size:11px; color:oklch(0.50 0.02 250); margin-top:2px; }
@@ -4114,7 +4114,7 @@
 .fin-cowork .vd-fields label { display:flex; flex-direction:column; gap:4px; font-size:11px; color:oklch(0.45 0.02 250); }
 .fin-cowork .vd-fields input, .fin-cowork .vd-fields select { padding:6px 8px; border:1px solid oklch(0.88 0.01 250); border-radius:4px; font-size:13px; }
 /* Itens */
-.fin-cowork .vd-prod-suggest { margin-top:6px; background:#fff; border:1px solid oklch(0.92 0.01 250); border-radius:6px; max-height:240px; overflow:auto; }
+.fin-cowork .vd-prod-suggest { margin-top:6px; background:var(--surface); border:1px solid oklch(0.92 0.01 250); border-radius:6px; max-height:240px; overflow:auto; }
 .fin-cowork .vd-prod-row { display:flex; justify-content:space-between; align-items:center; width:100%; padding:8px 12px; border:none; background:transparent; cursor:pointer; font-size:13px; text-align:left; border-bottom:1px solid oklch(0.96 0.01 250); }
 .fin-cowork .vd-prod-row:hover { background:oklch(0.97 0.01 250); }
 .fin-cowork .vd-prod-row:last-child { border-bottom:none; }
@@ -4131,7 +4131,7 @@
 .fin-cowork .vd-foot-r { text-align:right; padding-top:10px !important; font-weight:700; font-size:14px; }
 /* Pagamento */
 .fin-cowork .vd-pay-grid { display:grid; grid-template-columns:repeat(3, 1fr); gap:8px; }
-.fin-cowork .vd-pay-card { display:flex; flex-direction:column; gap:2px; align-items:flex-start; padding:12px; border:1px solid oklch(0.92 0.01 250); border-radius:6px; background:#fff; cursor:pointer; text-align:left; }
+.fin-cowork .vd-pay-card { display:flex; flex-direction:column; gap:2px; align-items:flex-start; padding:12px; border:1px solid oklch(0.92 0.01 250); border-radius:6px; background:var(--surface); cursor:pointer; text-align:left; }
 .fin-cowork .vd-pay-card.active { border-color:oklch(0.55 0.14 240); background:oklch(0.97 0.03 240); box-shadow:0 0 0 2px oklch(0.55 0.14 240 / 0.15); }
 .fin-cowork .vd-pay-icon { font-size:18px; }
 .fin-cowork .vd-pay-label { font-weight:600; font-size:13px; }
@@ -4159,7 +4159,7 @@
 .fin-cowork .vm-subnav {
   display:flex; align-items:center; justify-content:space-between;
   padding:0 20px; border-bottom:1px solid oklch(0.93 0.01 250);
-  background:#fff; flex-shrink:0;
+  background:var(--surface); flex-shrink:0;
 }
 .fin-cowork .vm-subnav-tabs { display:flex; gap:0; }
 .fin-cowork .vm-subtab {
@@ -4173,7 +4173,7 @@
 .fin-cowork .vm-pdv-btn {
   display:inline-flex; align-items:center; gap:8px;
   padding:6px 12px; border:1px solid oklch(0.85 0.02 250);
-  border-radius:6px; background:#fff; cursor:pointer;
+  border-radius:6px; background:var(--surface); cursor:pointer;
   font-size:12px; color:oklch(0.30 0.02 250); font-weight:500;
 }
 .fin-cowork .vm-pdv-btn:hover { background:oklch(0.97 0.01 250); }
@@ -4194,7 +4194,7 @@
 }
 .fin-cowork .vc-grid > .vc-card:nth-child(3) { grid-column: 1 / -1; }
 .fin-cowork .vc-card {
-  background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px;
+  background:var(--surface); border:1px solid oklch(0.93 0.01 250); border-radius:8px;
   overflow:hidden;
 }
 .fin-cowork .vc-card-h {
@@ -4244,7 +4244,7 @@
 }
 .fin-cowork .vc-move-add input, .fin-cowork .vc-move-add select {
   padding:6px 10px; border:1px solid oklch(0.88 0.01 250);
-  border-radius:5px; font-size:12px; background:#fff;
+  border-radius:5px; font-size:12px; background:var(--surface);
 }
 .fin-cowork .vc-counter {
   display:grid; grid-template-columns:1fr 1.2fr 1fr; gap:24px;
@@ -4253,7 +4253,7 @@
 .fin-cowork .vc-counter label { display:flex; flex-direction:column; gap:6px; font-size:11px; color:oklch(0.50 0.02 250); text-transform:uppercase; letter-spacing:0.04em; }
 .fin-cowork .vc-counter input {
   padding:8px 12px; border:1px solid oklch(0.88 0.01 250); border-radius:6px;
-  font-size:14px; font-variant-numeric:tabular-nums; background:#fff;
+  font-size:14px; font-variant-numeric:tabular-nums; background:var(--surface);
 }
 .fin-cowork .vc-counter-big { font-size:22px !important; font-weight:600; padding:12px !important; }
 .fin-cowork .vc-counter-summary { margin:0; display:grid; grid-template-columns:1fr auto; gap:6px 12px; font-size:12px; }
@@ -4273,15 +4273,15 @@
 .fin-cowork .vdv-match:hover { background:oklch(0.93 0.02 250); }
 .fin-cowork .vdv-selected { display:flex; align-items:center; gap:14px; padding:12px; background:oklch(0.96 0.02 145); border-radius:6px; }
 .fin-cowork .vdv-reasons { display:flex; flex-wrap:wrap; gap:6px; margin-bottom:10px; }
-.fin-cowork .vdv-reason-btn { padding:6px 12px; border:1px solid oklch(0.85 0.02 250); border-radius:20px; background:#fff; cursor:pointer; font-size:12px; }
+.fin-cowork .vdv-reason-btn { padding:6px 12px; border:1px solid oklch(0.85 0.02 250); border-radius:20px; background:var(--surface); cursor:pointer; font-size:12px; }
 .fin-cowork .vdv-reason-btn.active { background:var(--accent); border-color:var(--accent); color:#fff; }
 .fin-cowork .vdv-textarea { width:100%; min-height:60px; padding:8px 12px; border:1px solid oklch(0.85 0.02 250); border-radius:6px; font-family:inherit; font-size:12px; resize:vertical; }
 /* ──── COMISSÕES ──── */
 .fin-cowork .vco-period { display:inline-flex; border:1px solid oklch(0.85 0.02 250); border-radius:6px; overflow:hidden; }
-.fin-cowork .vco-period button { padding:6px 12px; border:none; background:#fff; cursor:pointer; font-size:12px; color:oklch(0.40 0.02 250); }
+.fin-cowork .vco-period button { padding:6px 12px; border:none; background:var(--surface); cursor:pointer; font-size:12px; color:oklch(0.40 0.02 250); }
 .fin-cowork .vco-period button.active { background:var(--accent); color:#fff; }
 .fin-cowork .vco-grid { display:grid; grid-template-columns:repeat(auto-fill, minmax(340px, 1fr)); gap:14px; padding:0 20px 14px; }
-.fin-cowork .vco-card { background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px; padding:16px; position:relative; }
+.fin-cowork .vco-card { background:var(--surface); border:1px solid oklch(0.93 0.01 250); border-radius:8px; padding:16px; position:relative; }
 .fin-cowork .vco-card header { display:grid; grid-template-columns:auto 1fr auto; gap:12px; align-items:center; margin-bottom:14px; }
 .fin-cowork .vco-card header h3 { margin:0 0 2px; font-size:14px; }
 .fin-cowork .vco-card header span { font-size:11px; color:oklch(0.55 0.02 250); }
@@ -4305,26 +4305,26 @@
 .fin-cowork .vco-mix { display:flex; flex-wrap:wrap; gap:4px; }
 .fin-cowork .vco-chip { padding:2px 8px; background:oklch(0.96 0.01 250); border-radius:10px; font-size:10px; color:oklch(0.40 0.02 250); }
 .fin-cowork .vco-chip em { font-style:normal; font-weight:600; color:var(--accent); margin-left:2px; }
-.fin-cowork .vco-table-card { margin:0 20px 20px; padding:16px; background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px; }
+.fin-cowork .vco-table-card { margin:0 20px 20px; padding:16px; background:var(--surface); border:1px solid oklch(0.93 0.01 250); border-radius:8px; }
 .fin-cowork .vco-table-card h3 { margin:0 0 12px; font-size:12px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.30 0.02 250); }
 .fin-cowork .vco-rules { width:100%; border-collapse:collapse; font-size:13px; }
 .fin-cowork .vco-rules th, .fin-cowork .vco-rules td { padding:8px 12px; text-align:left; border-bottom:1px solid oklch(0.96 0.01 250); }
 .fin-cowork .vco-rules th { font-size:11px; color:oklch(0.50 0.02 250); font-weight:500; }
 /* ──── RELATÓRIOS ──── */
 .fin-cowork .vrep-tabs { display:flex; gap:6px; padding:0 20px 12px; }
-.fin-cowork .vrep-tabs button { padding:6px 14px; border:1px solid oklch(0.88 0.01 250); border-radius:20px; background:#fff; cursor:pointer; font-size:12px; }
+.fin-cowork .vrep-tabs button { padding:6px 14px; border:1px solid oklch(0.88 0.01 250); border-radius:20px; background:var(--surface); cursor:pointer; font-size:12px; }
 .fin-cowork .vrep-tabs button.active { background:var(--accent); border-color:var(--accent); color:#fff; }
 .fin-cowork .vrep-summary {
   display:grid; grid-template-columns:repeat(4, 1fr); gap:10px;
   padding:0 20px 14px;
 }
 .fin-cowork .vrep-summary > div {
-  background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px;
+  background:var(--surface); border:1px solid oklch(0.93 0.01 250); border-radius:8px;
   padding:12px 14px; display:flex; flex-direction:column; gap:4px;
 }
 .fin-cowork .vrep-summary span { font-size:10px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.50 0.02 250); }
 .fin-cowork .vrep-summary strong { font-size:18px; font-variant-numeric:tabular-nums; }
-.fin-cowork .vrep-card { margin:0 20px 14px; padding:16px; background:#fff; border:1px solid oklch(0.93 0.01 250); border-radius:8px; }
+.fin-cowork .vrep-card { margin:0 20px 14px; padding:16px; background:var(--surface); border:1px solid oklch(0.93 0.01 250); border-radius:8px; }
 .fin-cowork .vrep-card h3 { margin:0 0 14px; font-size:12px; text-transform:uppercase; letter-spacing:0.04em; color:oklch(0.30 0.02 250); }
 .fin-cowork .vrep-bars {
   display:flex; align-items:flex-end; gap:14px;
@@ -4362,7 +4362,7 @@
   position:relative;
 }
 .fin-cowork .vrep-donut::after {
-  content:""; position:absolute; inset:25px; background:#fff; border-radius:50%;
+  content:""; position:absolute; inset:25px; background:var(--surface); border-radius:50%;
 }
 .fin-cowork .vrep-donut > * { position:relative; z-index:1; }
 .fin-cowork .vrep-donut span { font-size:24px; font-weight:600; }
@@ -4409,7 +4409,7 @@
 .fin-cowork .pdv-suggest {
   position:absolute; top:100%; left:0; right:0; z-index:10;
   margin:4px 0 0; padding:0; list-style:none;
-  background:#fff; border-radius:8px; overflow:hidden;
+  background:var(--surface); border-radius:8px; overflow:hidden;
   box-shadow:0 8px 24px rgba(0,0,0,0.4);
 }
 .fin-cowork .pdv-suggest li {
@@ -4425,7 +4425,7 @@
 .fin-cowork .pdv-items th { padding:12px 14px; background:oklch(0.92 0.01 250); text-align:left; font-size:11px; color:oklch(0.40 0.02 250); text-transform:uppercase; letter-spacing:0.04em; }
 .fin-cowork .pdv-items td { padding:12px 14px; border-bottom:1px solid oklch(0.92 0.01 250); }
 .fin-cowork .pdv-qty { display:inline-flex; align-items:center; gap:6px; }
-.fin-cowork .pdv-qty button { width:24px; height:24px; border-radius:4px; border:1px solid oklch(0.85 0.02 250); background:#fff; cursor:pointer; font-weight:600; }
+.fin-cowork .pdv-qty button { width:24px; height:24px; border-radius:4px; border:1px solid oklch(0.85 0.02 250); background:var(--surface); cursor:pointer; font-weight:600; }
 .fin-cowork .pdv-qty span { min-width:24px; text-align:center; font-weight:600; }
 .fin-cowork .pdv-prod { font-weight:500; }
 .fin-cowork .pdv-num { text-align:right; font-variant-numeric:tabular-nums; }
@@ -4477,7 +4477,7 @@
 .fin-cowork .rec-layout { display:inline-flex; border:1px solid oklch(0.40 0.02 250); border-radius:6px; overflow:hidden; }
 .fin-cowork .rec-layout button { padding:6px 12px; border:none; background:transparent; color:oklch(0.85 0.02 250); cursor:pointer; font-size:12px; }
 .fin-cowork .rec-layout button.active { background:var(--accent); color:#fff; }
-.fin-cowork .rec-paper { background:#fff; color:#222; padding:20px; }
+.fin-cowork .rec-paper { background:var(--surface); color:#222; padding:20px; }
 .fin-cowork .rec-termica {
   width:300px; font-family:var(--font-mono);
   font-size:12px; line-height:1.4;
@@ -4519,7 +4519,7 @@
 .fin-cowork .nfe-cfop { display:grid; grid-template-columns:repeat(3, 1fr); gap:8px; margin-bottom:14px; }
 .fin-cowork .nfe-cfop-btn, .fin-cowork .nfe-transp-btn {
   padding:12px; border:1.5px solid oklch(0.88 0.01 250); border-radius:8px;
-  background:#fff; cursor:pointer; text-align:left; display:flex; flex-direction:column; gap:3px;
+  background:var(--surface); cursor:pointer; text-align:left; display:flex; flex-direction:column; gap:3px;
 }
 .fin-cowork .nfe-cfop-btn.active, .fin-cowork .nfe-transp-btn.active { border-color:var(--accent); background:oklch(0.97 0.04 var(--accent-h, 220)); }
 .fin-cowork .nfe-cfop-btn strong { font-size:13px; }
@@ -4543,7 +4543,7 @@
 }
 @media print {
 .fin-cowork body > * { display:none !important; }
-.fin-cowork .pdv-overlay { position:static; background:#fff; color:#000; }
+.fin-cowork .pdv-overlay { position:static; background:var(--surface); color:#000; }
 .fin-cowork .pdv-head, .fin-cowork .rec-layout, .fin-cowork .pdv-close, .fin-cowork .os-btn { display:none !important; }
 .fin-cowork .rec-stage { padding:0; }
 .fin-cowork .rec-paper { box-shadow:none; }
@@ -4561,7 +4561,7 @@
   gap:10px; padding:0 24px 14px;
 }
 .fin-cowork .os-kpi {
-  background:#fff; border:1px solid var(--border, oklch(0.93 0.01 250));
+  background:var(--surface); border:1px solid var(--border, oklch(0.93 0.01 250));
   border-radius:8px; padding:12px 14px;
   display:flex; flex-direction:column; gap:4px;
 }
@@ -4592,13 +4592,13 @@
 .fin-cowork .os-search {
   display:inline-flex; align-items:center; gap:6px;
   padding:5px 10px; border:1px solid var(--border, oklch(0.85 0.02 250));
-  border-radius:6px; background:#fff;
+  border-radius:6px; background:var(--surface);
 }
 .fin-cowork .os-search input { border:none; outline:none; background:transparent; font-size:12px; min-width:200px; }
 .fin-cowork .os-table-wrap { padding:14px 24px 20px; overflow:auto; }
 .fin-cowork .os-table {
   width:100%; border-collapse:collapse;
-  background:#fff; border:1px solid var(--border, oklch(0.93 0.01 250));
+  background:var(--surface); border:1px solid var(--border, oklch(0.93 0.01 250));
   border-radius:8px; overflow:hidden;
 }
 .fin-cowork .os-table thead th {
@@ -4621,7 +4621,7 @@
 .fin-cowork .os-drawer-head {
   display:flex; align-items:flex-start; justify-content:space-between;
   gap:12px; padding:18px 20px; border-bottom:1px solid var(--border, oklch(0.93 0.01 250));
-  background:#fff;
+  background:var(--surface);
 }
 .fin-cowork .os-drawer-head-l { flex:1; min-width:0; }
 .fin-cowork .os-drawer-id { font-family:var(--font-mono); font-size:11px; color:var(--text-dim); text-transform:uppercase; letter-spacing:0.06em; }
@@ -4729,7 +4729,7 @@
   flex: 1;
   width: 100%;
   border: 0;
-  background: #fff;
+  background: var(--surface);
   display: block;
 }
 /* ────────────────── Sidebar lean ────────────────── */
@@ -5809,7 +5809,7 @@
 .fin-cowork .vendas-aplus .vd-plate {
   display: inline-flex; flex-direction: column; align-items: stretch;
   width: 78px; flex-shrink: 0;
-  background: #fff;
+  background: var(--surface);
   border: 1px solid oklch(0.30 0 0); border-radius: 3px;
   overflow: hidden;
   font-family: var(--font-mono);

--- a/resources/js/Components/cockpit/Sidebar.tsx
+++ b/resources/js/Components/cockpit/Sidebar.tsx
@@ -1147,7 +1147,7 @@ function VibesSubpanel({
 /** Cor visual do dot por vibe — usa oklch idêntico ao cockpit.css */
 function vibeAccent(vibe: Vibe): string {
   switch (vibe) {
-    case 'workspace': return 'oklch(0.58 0.09 220)'; // accent default azul
+    case 'workspace': return 'oklch(0.55 0.15 295)'; // accent default roxo canon (ADR 0190 — era 220 azul)
     case 'daylight':  return 'oklch(0.72 0.13 60)';  // âmbar quente
     case 'focus':     return 'oklch(0.45 0.02 240)'; // cinza-azul dessaturado
   }

--- a/resources/js/Layouts/AppShellV2.tsx
+++ b/resources/js/Layouts/AppShellV2.tsx
@@ -326,10 +326,11 @@ export default function AppShellV2({
     const v = Number(localStorage.getItem(LS.TW_DENSITY));
     return isFinite(v) && v > 0 ? v : 50;
   });
+  // Default = roxo canon hue 295 (ADR 0190). Era 220 (azul) — re-azulava o cockpit.css via style inline.
   const [accentHue, setAccentHue] = useState<number>(() => {
-    if (typeof window === 'undefined') return 220;
+    if (typeof window === 'undefined') return 295;
     const v = Number(localStorage.getItem(LS.TW_HUE));
-    return isFinite(v) && v > 0 ? v : 220;
+    return isFinite(v) && v > 0 ? v : 295;
   });
 
   // ── Persistência localStorage
@@ -347,10 +348,11 @@ export default function AppShellV2({
   const cockpitStyle: React.CSSProperties = {
     ['--row-h' as never]: `${26 + (density / 100) * 16}px`,
     ['--card-pad' as never]: `${8 + (density / 100) * 8}px`,
-    ['--accent' as never]: `oklch(0.58 0.12 ${accentHue})`,
-    ['--accent-2' as never]: `oklch(0.66 0.12 ${accentHue})`,
-    ['--accent-soft' as never]: `oklch(0.94 0.04 ${accentHue})`,
-    ['--bubble-me' as never]: `oklch(0.58 0.12 ${accentHue})`,
+    // L/C alinhados ao canon cockpit.css .cockpit{} (ADR 0190): no hue default (295) o resting state bate exato.
+    ['--accent' as never]: `oklch(0.55 0.15 ${accentHue})`,
+    ['--accent-2' as never]: `oklch(0.62 0.15 ${accentHue})`,
+    ['--accent-soft' as never]: `oklch(0.95 0.04 ${accentHue})`,
+    ['--bubble-me' as never]: `oklch(0.55 0.15 ${accentHue})`,
   };
   const densityLabel = density < 30 ? 'skim' : density > 70 ? 'briefing' : 'normal';
 

--- a/tests/Browser/CoreScreens/SmokeTest.php
+++ b/tests/Browser/CoreScreens/SmokeTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Pest 4 Browser smoke — telas-núcleo montam no AppShellV2 sem erro de console.
+ *
+ * Origem: handoff Cowork 2026-06-02 (PROMPT_PARA_CODE_REFORCO-APPSHELL-TESTES §B).
+ * Espelha o idioma de tests/Browser/Sells/CreateScreenshotTest.php (ADR 0108).
+ *
+ * Camadas de validação por tela:
+ *   - Tier 1 estrutural: tests/Feature/Architecture/CoreScreensIntegrityTest.php (roda sempre)
+ *   - Tier 2 browser (este arquivo): runtime real renderizado — OPT-IN (precisa chromium)
+ *
+ * Rodar (CI ou local com chromium):
+ *   composer install && npm install && npx playwright install chromium
+ *   ./vendor/bin/pest tests/Browser/CoreScreens/
+ *
+ * tests/Browser NÃO está no suite default (phpunit.xml) — só roda quando alvo
+ * explícito, então não quebra o `pest` normal em ambiente sem chromium.
+ *
+ * Locators resilientes (texto/role), nunca classe CSS (L-24 / _PROPOSTA-0244).
+ *
+ * @see tests/Feature/Architecture/CoreScreensIntegrityTest.php
+ */
+
+use App\Business;
+use App\User;
+
+beforeEach(function () {
+    \Carbon\Carbon::setTestNow('2026-06-02 12:00:00');
+});
+
+afterEach(function () {
+    \Carbon\Carbon::setTestNow();
+});
+
+$browserMissing = ! class_exists(\Pest\Browser\Bootstrap::class);
+
+/**
+ * Telas-núcleo: rota + um texto-âncora que prova que a tela (não um erro) montou.
+ * Permissão mínima exigida pelo controller pra não cair em 403.
+ */
+$screens = [
+    'Financeiro/Unificado' => ['/financeiro/unificado',      'financeiro.unificado.access', 'Financeiro'],
+    'Compras'              => ['/compras',                    'compras.view',               'Compras'],
+    'Clientes'             => ['/cliente',                    'customer.view',              'Cliente'],
+    'Oficina/OS'           => ['/oficina-auto/ordens-servico', 'oficinaauto.orders.view',   'Ordens'],
+];
+
+foreach ($screens as $nome => [$rota, $permissao, $ancora]) {
+    it("{$nome} monta no AppShellV2 sem erro de console", function () use ($rota, $permissao, $ancora) {
+        $user = User::factory()->create(['business_id' => 1]);
+        // Permissão best-effort: se o nome exato não existir no seed, segue (o gate
+        // real do teste é montar sem erro de console; ajustar o slug se 403 em CI).
+        try {
+            $user->givePermissionTo($permissao);
+        } catch (\Throwable) {
+            // slug de permissão pode variar por módulo — não falha o smoke por isso.
+        }
+
+        $page = visit($rota);
+
+        // A tela tem que renderizar conteúdo (âncora) e não vazar erro de console.
+        $page->assertSee($ancora)
+            ->assertNoConsoleLogs();
+    })->skip($browserMissing, 'pest-plugin-browser/chromium ausente — roda só no CI visual');
+}

--- a/tests/Feature/Architecture/AppShellUsageGateTest.php
+++ b/tests/Feature/Architecture/AppShellUsageGateTest.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Gate A1 — toda tela Inertia (screen entrypoint) renderiza dentro do AppShellV2.
+ *
+ * Origem: handoff Cowork 2026-06-02 (PROMPT_PARA_CODE_REFORCO-APPSHELL-TESTES §A1).
+ * Hoje a convenção vive em CLAUDE.md §10.3/§10.10 SEM enforcement — este teste
+ * transforma a convenção em check automático (estrutural, sem DB nem browser).
+ *
+ * Ground-truth de "é uma tela": o backend a renderiza via `Inertia::render('X/Y')`
+ * ou `inertia('X/Y')`. Sub-componentes (drawers, _lib, components) não são alvo de
+ * render, então não entram no gate — evita falso-positivo.
+ *
+ * Allowlist = telas públicas/auth que legitimamente NÃO usam o shell do cockpit
+ * (site de marketing, login/registro, aprovação pública de OS por link).
+ *
+ * Calibrado contra origin/main 2026-06-02 (8ce7ce1e4): 224 alvos → 0 violação.
+ *
+ * @see resources/js/Layouts/AppShellV2.tsx
+ */
+
+// Prefixos de telas públicas/auth isentas do shell cockpit.
+const APPSHELL_ALLOWLIST_PREFIXES = [
+    'Site/',                        // marketing + auth (Home, Login, Register, Pricing, Blog…)
+];
+
+// Telas isentas por caminho exato (público sem login).
+const APPSHELL_ALLOWLIST_EXACT = [
+    'OficinaAuto/AprovacaoPublica', // aprovação de OS por link público (sem sessão)
+];
+
+/**
+ * Descobre todos os alvos de `Inertia::render('X/Y')` / `inertia('X/Y')`
+ * em app/ e Modules/.
+ *
+ * @return array<int, string>
+ */
+function appShellRepoRoot(): string
+{
+    // tests/Feature/Architecture -> repo root (3 níveis acima). Sem depender de base_path()
+    // (este é um teste estrutural de filesystem, não precisa do app bootstrapado).
+    return dirname(__DIR__, 3);
+}
+
+function inertiaScreenTargets(): array
+{
+    $roots = [appShellRepoRoot().'/app', appShellRepoRoot().'/Modules'];
+    $targets = [];
+
+    foreach ($roots as $root) {
+        if (! is_dir($root)) {
+            continue;
+        }
+
+        $it = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($it as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $code = file_get_contents($file->getPathname());
+            if ($code === false || ! str_contains($code, 'nertia')) {
+                continue;
+            }
+
+            if (preg_match_all(
+                "/(?:Inertia::render|inertia)\(\s*'([A-Za-z0-9_\/]+)'/",
+                $code,
+                $m
+            )) {
+                foreach ($m[1] as $t) {
+                    $targets[$t] = true;
+                }
+            }
+        }
+    }
+
+    return array_keys($targets);
+}
+
+function isAppShellAllowlisted(string $target): bool
+{
+    if (in_array($target, APPSHELL_ALLOWLIST_EXACT, true)) {
+        return true;
+    }
+
+    foreach (APPSHELL_ALLOWLIST_PREFIXES as $prefix) {
+        if (str_starts_with($target, $prefix)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+it('toda tela Inertia renderiza dentro do AppShellV2 (exceto allowlist pública/auth)', function () {
+    $targets = inertiaScreenTargets();
+
+    // Sanidade: o crawler tem que achar um volume realista de telas.
+    expect(count($targets))->toBeGreaterThan(100);
+
+    $violations = [];
+
+    foreach ($targets as $target) {
+        if (isAppShellAllowlisted($target)) {
+            continue;
+        }
+
+        $tsx = appShellRepoRoot()."/resources/js/Pages/{$target}.tsx";
+        if (! is_file($tsx)) {
+            // Alvo sem .tsx correspondente (Blade legacy / nome dinâmico) — fora do gate.
+            continue;
+        }
+
+        $content = file_get_contents($tsx);
+        if ($content === false || ! str_contains($content, 'AppShellV2')) {
+            $violations[] = $target;
+        }
+    }
+
+    sort($violations);
+
+    expect($violations)->toBe([], sprintf(
+        "Telas Inertia sem AppShellV2 (%d). Envolva em <AppShellV2> ou, se for pública/auth, "
+        ."adicione à allowlist em %s:\n  - %s",
+        count($violations),
+        'tests/Feature/Architecture/AppShellUsageGateTest.php',
+        implode("\n  - ", $violations)
+    ));
+});

--- a/tests/Feature/Architecture/CockpitAccentCanonTest.php
+++ b/tests/Feature/Architecture/CockpitAccentCanonTest.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Gate A2 — accent do cockpit = ROXO canon (hue 295), nunca o azul 220 antigo.
+ *
+ * Origem: handoff Cowork 2026-06-02 (bug confirmado): AppShellV2 escrevia
+ * `--accent` inline a partir de `accentHue` default 220 (azul), VENCENDO o
+ * cascade sobre `cockpit.css .cockpit{ --accent: oklch(0.55 0.15 295) }` (ADR 0190).
+ * Resultado: o shell re-azulava o roxo canon pra todo usuário sem tweak salvo.
+ *
+ * Estrutural (lê o source, sem browser) — protege contra reintrodução do 220.
+ *
+ * @see resources/js/Layouts/AppShellV2.tsx
+ * @see resources/js/Components/cockpit/Sidebar.tsx
+ * @see resources/css/cockpit.css
+ */
+
+function accentRepoRoot(): string
+{
+    return dirname(__DIR__, 3);
+}
+
+it('AppShellV2 usa hue default 295 (roxo canon), não 220 (azul)', function () {
+    $src = file_get_contents(accentRepoRoot().'/resources/js/Layouts/AppShellV2.tsx');
+
+    // Default do accentHue (SSR + fallback localStorage) deve ser 295, nunca 220.
+    expect($src)->toContain('return 295;')
+        ->and($src)->not->toContain('return 220;');
+});
+
+it('AppShellV2 escreve --accent inline com L/C do canon (0.55 0.15)', function () {
+    $src = file_get_contents(accentRepoRoot().'/resources/js/Layouts/AppShellV2.tsx');
+
+    expect($src)->toContain('oklch(0.55 0.15 ${accentHue})')   // --accent + --bubble-me
+        ->and($src)->toContain('oklch(0.62 0.15 ${accentHue})') // --accent-2
+        ->and($src)->not->toContain('oklch(0.58 0.12 ${accentHue})'); // valor antigo off-canon
+});
+
+it('Sidebar vibeAccent(workspace) é roxo 295, não azul 220', function () {
+    $src = file_get_contents(accentRepoRoot().'/resources/js/Components/cockpit/Sidebar.tsx');
+
+    // A linha do workspace deve apontar pro hue 295.
+    expect($src)->toMatch("/case 'workspace':\\s*return 'oklch\\([^)]*295\\)'/")
+        ->and($src)->not->toContain('oklch(0.58 0.09 220)');
+});
+
+it('cockpit.css ancora o --accent canon em hue 295 (fonte da verdade ADR 0190)', function () {
+    $css = file_get_contents(accentRepoRoot().'/resources/css/cockpit.css');
+
+    expect($css)->toContain('--accent:       oklch(0.55 0.15 295)');
+});

--- a/tests/Feature/Architecture/CoreScreensIntegrityTest.php
+++ b/tests/Feature/Architecture/CoreScreensIntegrityTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * Gate B (camada estrutural, roda sem browser) — integridade das telas-núcleo.
+ *
+ * Origem: handoff Cowork 2026-06-02 (PROMPT_PARA_CODE_REFORCO-APPSHELL-TESTES §B).
+ * O handoff pede smoke browser test por tela-núcleo. Browser test exige chromium
+ * (tests/Browser/, opt-in, fora do suite default) — esta camada estrutural roda
+ * SEMPRE no CI e garante o esqueleto: a tela existe, monta no AppShellV2, e tem
+ * charter (contrato de não-regressão · tests/Charter).
+ *
+ * Nota L-26 (repo = UltimatePOS híbrido): "CRM" do protótipo ainda é Blade legado
+ * (sem Inertia page) — por isso NÃO está aqui. As 4 telas abaixo são Inertia reais.
+ *
+ * @see tests/Browser/CoreScreens/SmokeTest.php  (camada browser, CI com chromium)
+ */
+
+const CORE_SCREENS = [
+    // page (sob resources/js/Pages) => rota de runtime (referência pro browser test)
+    'Financeiro/Unificado/Index'    => '/financeiro/unificado',
+    'Compras/Index'                 => '/compras',
+    'Cliente/Index'                 => '/cliente',
+    'OficinaAuto/ServiceOrders/Index' => '/oficina-auto/ordens-servico',
+];
+
+function coreScreenRoot(): string
+{
+    return dirname(__DIR__, 3);
+}
+
+it('toda tela-núcleo tem a Page Inertia, monta no AppShellV2 e tem charter', function () {
+    $faltas = [];
+
+    foreach (array_keys(CORE_SCREENS) as $page) {
+        $tsx     = coreScreenRoot()."/resources/js/Pages/{$page}.tsx";
+        $charter = coreScreenRoot()."/resources/js/Pages/{$page}.charter.md";
+
+        if (! is_file($tsx)) {
+            $faltas[] = "{$page}: Page .tsx ausente";
+            continue;
+        }
+
+        $src = (string) file_get_contents($tsx);
+        if (! str_contains($src, 'AppShellV2')) {
+            $faltas[] = "{$page}: não monta no AppShellV2";
+        }
+        if (! is_file($charter)) {
+            $faltas[] = "{$page}: charter.md ausente (contrato de não-regressão)";
+        }
+    }
+
+    expect($faltas)->toBe([], "Telas-núcleo com integridade quebrada:\n  - ".implode("\n  - ", $faltas));
+});


### PR DESCRIPTION
## Origem
Handoff Cowork (Claude Design) 2026-06-02 — prompts `REFORCO-APPSHELL-TESTES` + `SESSAO-2026-06-02` (v3). Implementado contra **origin/main fresco** (não a `feat/staging-ct100`, que está 137 commits atrás), honrando L-26 ("ler o main, não as notas").

## Fronts (1 commit = 1 intent)

### A2 — `fix(cockpit)`: accent default roxo canon 295 (era azul 220)
Bug verificado: `AppShellV2` escrevia `--accent` inline a partir de `accentHue` default **220 (azul)**, vencendo o cascade sobre `cockpit.css .cockpit{ --accent: oklch(0.55 0.15 295) }` (ADR 0190) — re-azulava o roxo pra todo usuário sem tweak salvo. Idem `Sidebar.vibeAccent('workspace')`.
- default 220→295 + L/C inline alinhados ao canon → resting state bate exato com `cockpit.css`.
- Guard estrutural `CockpitAccentCanonTest` trava reintrodução do 220.

### A1 — `test(arch)`: gate "toda tela Inertia usa AppShellV2"
Convenção §10.3/§10.10 vira check automático. Ground-truth `Inertia::render` → `.tsx` deve ter `AppShellV2`; allowlist = público/auth (`Site/*`, `AprovacaoPublica`). **224 alvos → 0 violação** em main.

### B — `test(core-screens)`: smoke estrutural + scaffold browser
4 telas Inertia reais (Financeiro/Unificado, Compras, Cliente, OficinaAuto/ServiceOrders). "CRM" do protótipo **ainda é Blade legado** (L-26) → fora de escopo.
- `CoreScreensIntegrityTest` (roda sempre, sem browser): page + AppShellV2 + charter.
- `tests/Browser/CoreScreens/SmokeTest` (idioma Sells/ADR 0108, skip-guarded, opt-in): CI visual com chromium.

### C1 — `refactor(css)`: tokeniza `background:#fff` → `var(--surface)`
30 surfaces no `cowork-financeiro-bundle.css`. Value-preserving no light, theme-correct no dark. Subset seguro (texto-sobre-cor/borda/sombra intactos). Ratchet stylelint **−30** (1095→1065), baseline regravado.

### docs — mirror seguro
Charters Vendas/Compras + `INVENTARIO_CLASSES` em `prototipo-ui/`. **ADR _PROPOSTA-0245 NÃO incluído** — numeração de ADR é soberania [W] (ADR 0238).

## Testado
- `pest tests/Feature/Architecture/{CockpitAccentCanon,AppShellUsageGate,CoreScreensIntegrity}` → **6 passed, 11 assertions**.
- `stylelint-baseline` validate → delta −30, sem regressão.
- `eslint-baseline` validate → sem regressão dos edits JS.
- Browser smoke = CI-gated (chromium não disponível no ambiente de implementação) — `php -l` ok, fora do suite default.

## NÃO feito (deliberado)
- ❌ COMPAT de tokens em `app.css` / `@media→@container` em `fin-cowork.css` — alvos que o próprio Cowork retratou (repo já roxo+warm; `app.css` é manifesto vazio).
- ⚠️ Pré-existente em main: `tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest` falha (hardcode de `business_id` em Modules) — **não tocado, fora de escopo**.

## Tier 0
Mudança de Shell (AppShellV2) — abre PR e **espera [W]** pro merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)