### PR TITLE
fix(nfe): retry pós-falha não viola nfe_emissoes_biz_tx_unique

### DIFF
--- a/Modules/NfeBrasil/Services/NfeService.php
+++ b/Modules/NfeBrasil/Services/NfeService.php
@@ -450,7 +450,6 @@ class NfeService
                         'original_transaction_id'   => $transactionId,
                         'inutilizada_em'            => now()->toIso8601String(),
                         'status_antes_inutilizacao' => $existente->status,
-                        'cstat_antes_inutilizacao'  => $existente->cstat,
                     ]),
                 ]);
             }

--- a/Modules/NfeBrasil/Services/NfeService.php
+++ b/Modules/NfeBrasil/Services/NfeService.php
@@ -437,7 +437,22 @@ class NfeService
                     'motivo_anterior'  => $existente->motivo,
                     'numero'           => $existente->numero,
                 ]);
-                $existente->update(['status' => 'inutilizada']);
+                // BUG FIX 2026-06-02: liberar a UNIQUE (business_id, transaction_id)
+                // setando transaction_id=null — MySQL trata NULL como distinto em
+                // UNIQUE. Sem isso, o NfeEmissao::create() abaixo (mesma transaction)
+                // viola `nfe_emissoes_biz_tx_unique` no retry pós-falha. Mesma técnica
+                // canônica do retransmitirInterno() (CONFAZ Art. 14 — nunca hard-delete;
+                // metadata.original_transaction_id preserva o vínculo pra audit).
+                $existente->update([
+                    'status' => 'inutilizada',
+                    'transaction_id' => null,
+                    'metadata' => array_merge((array) ($existente->metadata ?? []), [
+                        'original_transaction_id'   => $transactionId,
+                        'inutilizada_em'            => now()->toIso8601String(),
+                        'status_antes_inutilizacao' => $existente->status,
+                        'cstat_antes_inutilizacao'  => $existente->cstat,
+                    ]),
+                ]);
             }
         }
 

--- a/Modules/NfeBrasil/Tests/Feature/NfeServiceIdempotenciaRetryTest.php
+++ b/Modules/NfeBrasil/Tests/Feature/NfeServiceIdempotenciaRetryTest.php
@@ -38,6 +38,7 @@ const NFE_IDEMP_TX_AUTORIZADA = 999777001;
 const NFE_IDEMP_TX_PENDENTE = 999777002;
 const NFE_IDEMP_TX_CANCELADA = 999777003;
 const NFE_IDEMP_TX_REJEITADA = 999777004;
+const NFE_IDEMP_TX_ERRO_ENVIO = 999777005;
 
 beforeEach(function () {
     if (DB::connection()->getDriverName() === 'sqlite') {
@@ -63,6 +64,7 @@ afterEach(function () {
                 NFE_IDEMP_TX_PENDENTE,
                 NFE_IDEMP_TX_CANCELADA,
                 NFE_IDEMP_TX_REJEITADA,
+                NFE_IDEMP_TX_ERRO_ENVIO,
             ])
             ->forceDelete();
     } catch (\Throwable) {
@@ -279,4 +281,76 @@ it('idempotência scoped por business_id — biz=1 NÃO reusa emissao de biz=99'
 
     // Cleanup defensivo extra biz=99 deste teste
     NfeEmissao::withoutGlobalScopes()->where('business_id', 99)->where('numero', 555099)->forceDelete();
+});
+
+// ------------------------------------------------------------------
+// BUG FIX 2026-06-02: retry pós-falha NÃO pode violar nfe_emissoes_biz_tx_unique
+// ------------------------------------------------------------------
+// Regressão real (prod homologação 2026-06-02): 1ª emissão falhou no SOAP
+// (connection reset), deixando registro status=erro_envio. O retry chamava
+// emitirInterno() → guarda marcava `inutilizada` MAS mantinha o transaction_id →
+// o NfeEmissao::create() seguinte (mesma transaction) violava a UNIQUE
+// (business_id, transaction_id). Fix: setar transaction_id=null na inutilização
+// (MySQL trata NULL como distinto), igual ao retransmitirInterno(). Aqui invocamos
+// emitirInterno() DE VERDADE — a guarda roda antes do cert/SEFAZ, então o efeito
+// colateral do fix acontece mesmo o fluxo parando depois por falta de certificado.
+
+it('retry pós erro_envio inutiliza com transaction_id=null (libera a UNIQUE biz+tx)', function () {
+    $emissaoId = DB::table('nfe_emissoes')->insertGetId([
+        'business_id'    => NFE_IDEMP_BIZ,
+        'transaction_id' => NFE_IDEMP_TX_ERRO_ENVIO,
+        'modelo'         => '65',
+        'serie'          => '1',
+        'numero'         => 555005,
+        'status'         => 'erro_envio',
+        'motivo'         => 'Recv failure: Connection reset by peer (SOAP)',
+        'valor_total'    => 90.00,
+        'created_at'     => now()->subMinutes(5),
+        'updated_at'     => now()->subMinutes(5),
+    ]);
+
+    session(['business.id' => NFE_IDEMP_BIZ]);
+
+    $service = new NfeService();
+    $reflection = new ReflectionClass(NfeService::class);
+    $method = $reflection->getMethod('emitirInterno');
+    $method->setAccessible(true);
+
+    // A guarda de idempotência (nosso fix) roda ANTES do cert. O fluxo segue pra
+    // cert/SEFAZ e lança (sem certificado no ambiente de teste) — mas o efeito
+    // colateral do fix já ocorreu.
+    try {
+        $method->invoke(
+            $service,
+            NFE_IDEMP_BIZ,
+            ['valor_total' => 90.00, 'modelo' => '65'],
+            '65',
+            NFE_IDEMP_TX_ERRO_ENVIO
+        );
+    } catch (\Throwable) {
+        // esperado: para no cert/SEFAZ (sem certificado no teste)
+    }
+
+    $antiga = NfeEmissao::withoutGlobalScopes()->find($emissaoId);
+    expect($antiga)->not->toBeNull();                       // CONFAZ Art. 14 — nunca hard-delete
+    expect($antiga->status)->toBe('inutilizada');
+    expect($antiga->transaction_id)->toBeNull();            // ← o FIX: libera a UNIQUE
+    expect((int) $antiga->numero)->toBe(555005);            // sequencial preservado (audit)
+    expect((array) $antiga->metadata)->toHaveKey('original_transaction_id');
+    expect((int) $antiga->metadata['original_transaction_id'])->toBe(NFE_IDEMP_TX_ERRO_ENVIO);
+
+    // Prova concreta: novo registro com a MESMA transaction_id agora insere sem
+    // violar nfe_emissoes_biz_tx_unique (o antigo está com transaction_id=null).
+    $novoId = DB::table('nfe_emissoes')->insertGetId([
+        'business_id'    => NFE_IDEMP_BIZ,
+        'transaction_id' => NFE_IDEMP_TX_ERRO_ENVIO,
+        'modelo'         => '65',
+        'serie'          => '1',
+        'numero'         => 555006,
+        'status'         => 'enviando',
+        'valor_total'    => 90.00,
+        'created_at'     => now(),
+        'updated_at'     => now(),
+    ]);
+    expect((int) $novoId)->toBeGreaterThan(0);
 });


### PR DESCRIPTION
## Bug (prod homologação 2026-06-02)
Ao testar emissão NFC-e: 1ª tentativa falhou no SOAP (connection reset → status `erro_envio`). O **retry** quebrou com **SQLSTATE 23000 — `nfe_emissoes_biz_tx_unique`**.

## Causa raiz
`NfeService::emitirInterno()` (guarda de idempotência): quando a emissão anterior é rejeitada/erro_envio, marcava `status='inutilizada'` **mas mantinha o `transaction_id`**. O `NfeEmissao::create()` seguinte (mesma transaction) violava a UNIQUE `(business_id, transaction_id)`.

## Fix
Setar `transaction_id=null` ao inutilizar (MySQL trata NULL como distinto em UNIQUE), preservando o vínculo em `metadata.original_transaction_id`. **Mesma técnica canônica já usada em `retransmitirInterno()`** (CONFAZ Art. 14 — nunca hard-delete).

## Teste
`NfeServiceIdempotenciaRetryTest`: novo caso invoca `emitirInterno()` de verdade (a guarda roda antes do cert), valida que a antiga vira `inutilizada` com `transaction_id=null` + metadata, e que um novo insert com a mesma transaction_id **não viola** mais a UNIQUE.

Refs: US-NFE-064

🤖 Generated with [Claude Code](https://claude.com/claude-code)