### PR TITLE
fix(multi-tenant): recalibra guard business_id + ativa no CI (Tier 0)

### DIFF
--- a/.github/workflows/multi-tenant-gate.yml
+++ b/.github/workflows/multi-tenant-gate.yml
@@ -1,0 +1,79 @@
+name: Multi-tenant gate
+
+# Tier 0 IRREVOGÁVEL — bloqueia hardcode de business_id (visibilidade de módulo
+# por cliente) em controllers/middleware canônicos. Antes este teste existia mas
+# NÃO rodava em CI (ci.yml roda só tests/Feature/Form) — ficava dormente. Este
+# workflow o ativa. Recalibrado 2026-06-02: exemta `=== 0` (no-tenant guard) e
+# força `config('app.saas_owner_business_id')` em vez de `=== 1` cru.
+#
+# Regra: visibilidade per-business = subscription package (Modules/Superadmin),
+# NUNCA `if ($business_id === N)`. Ver memory/proibicoes.md + ADR 0093.
+# Teste: tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest.php
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Modules/**/Http/Controllers/**'
+      - 'app/Http/Middleware/AdminSidebarMenu.php'
+      - 'app/Http/Middleware/HandleInertiaRequests.php'
+      - 'tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest.php'
+      - '.github/workflows/multi-tenant-gate.yml'
+  pull_request:
+    paths:
+      - 'Modules/**/Http/Controllers/**'
+      - 'app/Http/Middleware/AdminSidebarMenu.php'
+      - 'app/Http/Middleware/HandleInertiaRequests.php'
+      - 'tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest.php'
+      - '.github/workflows/multi-tenant-gate.yml'
+
+concurrency:
+  group: multi-tenant-gate-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gate:
+    name: No hardcode business_id (Tier 0)
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP 8.4
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          extensions: mbstring, xml, ctype, json, opentelemetry
+          coverage: none
+          tools: composer:v2
+
+      - name: Cache composer
+        uses: actions/cache@v4
+        with:
+          path: ~/.composer/cache
+          key: composer-mtgate-${{ runner.os }}-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-mtgate-${{ runner.os }}-
+
+      - name: Install PHP deps
+        run: composer install --no-interaction --prefer-dist --no-progress --no-scripts
+
+      - name: Prepare storage dirs + .env mínimo
+        run: |
+          mkdir -p storage/framework/cache storage/framework/sessions storage/framework/views storage/logs bootstrap/cache
+          cat > .env <<'EOF'
+          APP_NAME=oimpresso-mt-gate
+          APP_ENV=testing
+          APP_DEBUG=false
+          APP_URL=http://localhost
+          LOG_CHANNEL=stderr
+          DB_CONNECTION=sqlite
+          DB_DATABASE=:memory:
+          CACHE_DRIVER=array
+          QUEUE_CONNECTION=sync
+          SESSION_DRIVER=array
+          MAIL_MAILER=array
+          EOF
+          php artisan key:generate
+
+      - name: Pest — anti-hardcode business_id
+        run: vendor/bin/pest tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest.php --no-coverage

--- a/Modules/Financeiro/Http/Controllers/CobrancaController.php
+++ b/Modules/Financeiro/Http/Controllers/CobrancaController.php
@@ -72,8 +72,10 @@ class CobrancaController extends Controller
             'busca' => $request->string('busca')->toString() ?: null,
         ];
 
-        // Wagner SaaS dogfooding: biz=1 vê origem subscription_license; demais não.
-        $isSaasBusiness = $businessId === 1;
+        // Wagner SaaS dogfooding: o business dono da plataforma vê origem
+        // subscription_license; demais não. Id centralizado em config (não magic
+        // number — ver NoHardcodeBusinessIdInModulesTest).
+        $isSaasBusiness = $businessId === (int) config('app.saas_owner_business_id');
 
         return Inertia::render('Financeiro/Cobranca/Index', [
             'today' => $hoje->toDateString(),

--- a/Modules/Financeiro/Listeners/OnCobrancaPagaCreateFinanceiroTitulo.php
+++ b/Modules/Financeiro/Listeners/OnCobrancaPagaCreateFinanceiroTitulo.php
@@ -42,8 +42,8 @@ final class OnCobrancaPagaCreateFinanceiroTitulo
 {
     public function handle(CobrancaPaga $event): void
     {
-        if ($event->businessId !== 1) {
-            return; // Onda 5 dogfooding processa só Wagner
+        if ($event->businessId !== (int) config('app.saas_owner_business_id')) {
+            return; // Onda 5 dogfooding processa só o business dono (SaaS)
         }
 
         $cobranca = Cobranca::withoutGlobalScopes()->find($event->cobrancaId);

--- a/config/app.php
+++ b/config/app.php
@@ -234,4 +234,19 @@ return [
         'Menu' => App\Facades\Menu::class,
         'Pesapal' => App\Vendor\Pesapal\Facades\Pesapal::class,
     ])->toArray(),
+
+    /*
+    |--------------------------------------------------------------------------
+    | SaaS owner business
+    |--------------------------------------------------------------------------
+    |
+    | Id do business "dono da plataforma" (dogfooding oimpresso). Distingue a
+    | conta-mãe SaaS dos tenants-cliente em features de dogfooding (ex.: origem
+    | subscription_license na Cobrança, listener Onda 5). NÃO confundir com
+    | visibilidade de módulo por cliente — isso é subscription package (Tier 0
+    | IRREVOGÁVEL, ver tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest).
+    | Fonte única pra não espalhar o literal `=== 1`.
+    |
+    */
+    'saas_owner_business_id' => (int) env('SAAS_OWNER_BUSINESS_ID', 1),
 ];

--- a/tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest.php
+++ b/tests/Feature/Architecture/NoHardcodeBusinessIdInModulesTest.php
@@ -39,12 +39,21 @@ const PROJECT_ROOT = __DIR__ . '/../../..';
  * Foco em comparações IDENTITY (===, !==) ou equality (==, !=) com número
  * literal de business_id. Variáveis cobertas: $business_id, $businessId,
  * $bizId, $current_biz.
+ *
+ * EXEMÇÃO `=== 0`: business_id 0 NÃO é um tenant — é o sentinela "sem contexto
+ * de tenant" (CLI/superadmin/sessão vazia). O padrão `if ($businessId === 0)`
+ * é o guard de no-tenant que o skill multi-tenant-patterns ENDOSSA, não o
+ * anti-padrão. Por isso os patterns casam só `[1-9]\d*` (tenant real ≥ 1).
+ *
+ * O id do business dono-da-plataforma (SaaS dogfooding) também NÃO pode ser
+ * literal aqui — usar `config('app.saas_owner_business_id')` (fonte única). Um
+ * `=== 1` cru continua banido de propósito pra forçar o config.
  */
 const PATTERNS_BANIDOS = [
-    '/\$business_id\s*[!=]==?\s*\d+/',
-    '/\$businessId\s*[!=]==?\s*\d+/',
-    '/\$bizId\s*[!=]==?\s*\d+/',
-    '/\$current_biz\s*[!=]==?\s*\d+/',
+    '/\$business_id\s*[!=]==?\s*[1-9]\d*/',
+    '/\$businessId\s*[!=]==?\s*[1-9]\d*/',
+    '/\$bizId\s*[!=]==?\s*[1-9]\d*/',
+    '/\$current_biz\s*[!=]==?\s*[1-9]\d*/',
     // Variantes especiais de nomes que apareceram no incidente original
     '/\$piloto_rotalivre/',
     '/\$piloto_biz/',


### PR DESCRIPTION
## Contexto
Achado durante o PR [#2119](https://github.com/wagnerra23/oimpresso.com/pull/2119): o `NoHardcodeBusinessIdInModulesTest` (guard Tier 0 anti-hardcode de `business_id`) estava **dormente e mal-calibrado**.

- **Dormente:** nenhum workflow rodava `tests/Feature/Architecture/` (o `ci.yml` roda só `tests/Feature/Form`).
- **Mal-calibrado:** false-positivava em **10× `if ($businessId === 0)`** (guard legítimo de *no-tenant*, endossado pelo skill `multi-tenant-patterns`) e em **1× `$isSaasBusiness = $businessId === 1`** (SaaS dogfooding). Nenhum é o anti-padrão real (hardcodar módulo de cliente específico — incidente `=== 4` RotaLivre).

## Mudanças
1. **Regex** (`NoHardcodeBusinessIdInModulesTest`): bane só `[1-9]\d*` → exemta `=== 0` (biz 0 = sem tenant, nunca cliente). Continua pegando `=== 4` e qualquer literal ≥1.
2. **biz=1 → config** (`config('app.saas_owner_business_id')`, default 1, fonte única): `CobrancaController` + `OnCobrancaPagaCreateFinanceiroTitulo` deixam de usar magic number. `=== 1` cru segue **banido de propósito** pra forçar o config.
3. **CI** (`multi-tenant-gate.yml`, idioma `adr-lint.yml`): ativa o guard em PR/push que toquem controllers/middleware canônicos. Deixa de ser dormente.

## Testado
- `pest NoHardcodeBusinessIdInModulesTest` → **6 passed, 23 assertions** (inclui o self-test "regex NÃO captura uso legítimo").
- `php -l` ok nos 3 PHP editados.
- Comportamento inalterado (config default = 1) — tests Financeiro de biz=1 dogfooding mantêm semântica. As 15 falhas `BindingResolutionException` desses suites são **pré-existentes/ambiente** (rodam contra DB dev real), confirmado em `origin/main` pristino.

## Tier 0
Mudança em guard IRREVOGÁVEL multi-tenant — autorizada por [W] ("vai não pergunte"). Abre PR e espera merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)