### PR TITLE
fix(nfe): retry-with-backoff em erro de transporte SEFAZ (connection reset)

### DIFF
--- a/Modules/NfeBrasil/Services/NfeService.php
+++ b/Modules/NfeBrasil/Services/NfeService.php
@@ -500,7 +500,35 @@ class NfeService
             $xmlSigned = $tools->signNFe($xml);
 
             $idLote  = str_pad((string) $emissao->id, 15, '0', STR_PAD_LEFT);
-            $response = $tools->sefazEnviaLote([$xmlSigned], $idLote, 1);
+
+            // Retry-with-backoff em erro de TRANSPORTE transitório (connection reset,
+            // recv failure, timeout, SSL) — SEFAZ (SVRS homolog/prod) às vezes fecha o
+            // socket sem processar. Reenvio é idempotente: idLote/chave são
+            // determinísticos → SEFAZ deduplica (cStat 204/539 duplicidade tratado em
+            // processarRetorno). NÃO retenta rejeição por cStat — essa volta em
+            // $response (não vira exception), seguindo direto pro processamento.
+            $maxTentativas = 3;
+            for ($tentativa = 1; ; $tentativa++) {
+                try {
+                    $response = $tools->sefazEnviaLote([$xmlSigned], $idLote, 1);
+                    break;
+                } catch (\Throwable $envioErro) {
+                    $transitorio = (bool) preg_match(
+                        '/connection reset|recv failure|broken pipe|timed?\s*out|timeout|could not resolve|ssl|curl|comunica/i',
+                        $envioErro->getMessage()
+                    );
+                    if (! $transitorio || $tentativa >= $maxTentativas) {
+                        throw $envioErro;
+                    }
+                    Log::warning('NfeService: erro transitório SEFAZ — retry de envio', [
+                        'business_id' => $businessId,
+                        'emissao_id'  => $emissao->id,
+                        'tentativa'   => $tentativa,
+                        'error'       => substr($envioErro->getMessage(), 0, 200),
+                    ]);
+                    usleep(1_500_000 * $tentativa); // backoff progressivo: 1.5s, 3s
+                }
+            }
         } catch (\Throwable $e) {
             $emissao->update([
                 'status' => 'erro_envio',


### PR DESCRIPTION
## Problema
Emissão NF-e/NFC-e falhava com **"Connection reset by peer"** (SVRS autorização). O `sefazEnviaLote` não tinha retry — qualquer erro de **transporte transitório** virava `erro_envio` imediato. O endpoint de status responde (cstat 107), mas o de **autorização** do SVRS oscila e fecha o socket sem processar.

## Fix
3 tentativas com backoff progressivo (1.5s, 3s) **apenas em erro de transporte** (connection reset / recv failure / timeout / ssl — regex no message). 
- Reenvio **idempotente**: idLote/chave determinísticos → SEFAZ deduplica (cStat 204/539 duplicidade tratado em `processarRetorno`).
- **Rejeição por cStat NÃO é retentada** (volta em `$response`, não vira exception) — só transporte.

## Contexto
Pareado com o fix anterior (#2120, retry sem unique-violation). Juntos: o retry pós-falha não crasha (SQL) **e** erros de SEFAZ transitórios se auto-resolvem. Produção é mais estável que homologação, então a emissão real do cliente tende a passar; o backoff cobre os blips.

Refs: US-NFE-064

🤖 Generated with [Claude Code](https://claude.com/claude-code)