### PR TITLE
Handoff Cowork (Claude Design) — fix KPI Financeiro @container + mirror CRM trio

### DIFF
--- a/memory/sessions/2026-06-02-handoff-cowork-bundle-inventario.md
+++ b/memory/sessions/2026-06-02-handoff-cowork-bundle-inventario.md
@@ -1,0 +1,59 @@
+---
+date: 2026-06-02
+hour: "17:30 BRT"
+topic: "Inventário do handoff bundle Claude Design (Cowork) vs origin/main — o que implementar"
+authors: [C]
+related_adrs: [0104-processo-mwart-canonico-unico-caminho, 0235-cor-primary-roxo-canon, 0110-cockpit-v2]
+---
+
+# Inventário — Handoff bundle "Oimpresso ERP Comunicação Visual" (Claude Design) vs `main`
+
+> Origem: bundle exportado de claude.ai/design (`api.anthropic.com/v1/design/h/gLpyC-…`),
+> 36 chats + `project/` (1144 arquivos). É o **espelho Cowork** deste repo.
+> Wagner pediu "implementar os designs do projeto". Este doc mapeia o que é seguro,
+> o que já está em `main`, e o que é Tier 0 (só [W]). Fontes lidas: bundle `STATUS.md`,
+> `COWORK_NOTES.md` (📥 Pendentes), `CODE_NOTES.md`, `chats/chat36.md`, 33 `PROMPT_PARA_CODE_*.md`.
+
+## ✅ FEITO nesta sessão (não-Tier-0, seguro)
+
+| # | Item | Alvo no repo | Status |
+|---|------|--------------|--------|
+| 1 | **Fix Financeiro KPI** — reflow `@media` viewport → `@container` (cura colisão 5-col na Larissa @1280px, conteúdo ~1040px pós-sidebar) | `resources/css/fin-cowork.css` (`.fin-curadoria` vira container `finbody`; `@container finbody (max-width:1100px/600px)`) | ✅ aplicado · ratchet stylelint **delta 0** |
+| 2 | **Mirror CRM trio** (docs) — charter + casos grounded em `crm-page.jsx` (8.6) | `prototipo-ui/prototipos/crm/charter.md` + `decisoes.md` | ✅ criado (pasta-por-tela, igual `clientes/`) |
+
+## ✅ JÁ EM `main` — NÃO refazer (confirmado no bundle vs CODE_NOTES)
+
+PRs merged que o bundle marca como processados (`COWORK_NOTES §📥`):
+- **#2119 + #2121** — A2 accent 220→295 (+`CockpitAccentCanonTest`) · A1 gate AppShellV2 (224→0) · B smoke core-screens · C1 `#fff`→`var(--surface)` 30× · charters Vendas/Compras + INVENTARIO mirrorados · gates ui-architecture/multi-tenant
+- **#2069** Jana Pro F3 · **#2073** prep 3 Tier 0 de IA · **#2078** gerador `design:review` por tela
+- **#2054** Stylelint gate (G5) · **#2061** charters de papel + ADR 0242 · **#2062** README HANDOFF-ENTRY · **#2064** G4 retorno · **#2053** Financeiro v10
+- Prompts `SESSAO-2026-06-02` (v3) e `REFORCO-APPSHELL-TESTES` = **DONE**.
+- DS-fusion→app.css / `@media`→`@container` (alvos errados, repo já roxo+warm) = **SUPERSEDED** no próprio bundle.
+
+## 🔒 TIER 0 — só [W] (abre PR, espera aprovação). Menu pra Wagner escolher:
+
+| Tier0 | O que é | Esforço | Risco | Arquivo-fonte handoff |
+|-------|---------|---------|-------|----------------------|
+| **T0-A** | **DS v5 → `app.css`** — espelhar a camada COMPAT do `ds-v5/tokens.css` (29 tokens de quebra via alias `var()`) na fonte canônica de token do repo; conferir `cowork-financeiro-bundle.css` (188 hex) + `Sidebar.tsx vibeAccent` 220 não brigam com roxo canon | médio | alto (token global, multi-módulo) | `COWORK_NOTES` §"DS v5 fonte única" + `_PROPOSTA-0245` |
+| **T0-B** | **CRM Blade→Inertia** — migrar UltimatePOS legado pra Inertia page seguindo a charter/casos recém-mirrorados (emoji→lucide, tokenizar hues estágio) | grande (programa) | alto (MWART 5 fases) | `PROMPT_PARA_CODE_CRM-TRIO.md` (parte 🟡) |
+| **T0-C** | **DS-ROADMAP-ATÉ-ZERO** — 6 filas em série (A controles+FieldError · B cor-crua→token · C Onda G badge +5 variants · D lote-badge 410 · E FormSection · F icons). PARA no gate visual a cada fila | grande (sequenciado) | médio (incremental) | `PROMPT_PARA_CODE_DS-ROADMAP-ATE-ZERO.md` + `PR-C1..C7` |
+| **T0-D** | **ADR formal shift 0-humano** + merge `docs/cowork-loop-protocol-10-4` + decidir migrar drift `.css` pro roxo | pequeno | Tier 0 (ADR) | `STATUS §Em aberto 0` |
+| **T0-E** | **IA — ENABLE Tier 0** — ligar OTel collector + LGPD purge prod + cadência RAGAS + Meilisearch HA (custo/infra) | grande (infra) | alto (prod/$) | `COWORK_NOTES` "IA ENABLE" |
+
+> ADRs não podem receber número por mim (soberania [W], ADR 0238 · append-only). `_PROPOSTA-0245`
+> existe no bundle como proposta; numerar = ato de [W] no git.
+
+## 🟡 Telas no bundle (design pronto) × estado no repo
+
+| Tela | Nota Cowork | Repo | Próximo passo |
+|------|-------------|------|---------------|
+| Oficina/OS | F1 build (semente v5) | Inertia parcial | F1.5 critique → F2 [W] → F3 |
+| Vendas | 9.5 | Index ok (Create POS aposentado) | F0 venda CV quando [W] retomar |
+| Compras | 9.4 | migrado (0 hex) | espelhar resto no repo |
+| Financeiro | 8.0→8.4 | Inertia vivo | **fix KPI feito**; migrar resto p/ v5 |
+| Inbox/Caixa | 9.75 (régua) | — | não mexer (gabarito de método) |
+| CRM | 8.6 | **Blade legado** | T0-B (migração) — trio mirrorado ✅ |
+| Clientes | molde PT-03 | Inertia | replicar nos 3 cadastros |
+
+## Decisão pendente de [W]
+Escolher qual(is) Tier 0 (T0-A…E) eu encaro agora. Os 2 itens seguros (fix Financeiro + mirror CRM) já estão aplicados e prontos pra commit/PR.

--- a/prototipo-ui/prototipos/crm/charter.md
+++ b/prototipo-ui/prototipos/crm/charter.md
@@ -1,0 +1,89 @@
+---
+page: /crm · window.CrmPage
+component: crm-page.jsx (+ crm-page.css)
+repo_alvo: Inertia CRM/Index — ⚠️ HOJE É BLADE LEGADO (UltimatePOS, sem Inertia page · CODE_NOTES 2026-06-02 / L-26). Migração Blade→Inertia pendente.
+status: proposta (Cowork) — trio criado pra DESTRAVAR a migração do legado. [W] confirma aprovações/reprovações.
+owner: wagner
+last_validated: 2026-06-02
+validated_against: crm-page.jsx @ cowork-2026-06-02
+persona: vendedor/comercial (funil) · Wagner (pipeline/conversão)
+identidade: azul 220 — accent ESCOPADO `.crm-scope{ --accent: oklch(0.45 0.11 220) }` (ADR 0200 D-02, proposta). Estágios têm hues SEMÂNTICOS próprios (lead 250 · qual 270 · prop 70 · negoc 30 · ganho 145) — não confundir com o accent da tela. Roxo canon (ADR 0235) intacto fora do escopo.
+nota_atual: 8.6
+irmao: CRM.casos.md (6 UCs grounded no código)
+tier: B
+charter_version: 1
+---
+
+# Page Charter — /crm (Funil comercial / kanban)
+
+> **Status:** memória-por-tela (L-14), grounded em `crm-page.jsx`. Captura o estado vivo pra a migração Blade→Inertia ser fiel. [W] confirma aprovações/reprovações.
+> **Padrão visual:** Cockpit V2 (ADR 0110) · kanban + drawer lateral.
+> **⚠️ Contexto (L-26):** o CRM do repo ainda é **Blade legado UltimatePOS** (provável sobre `resources/views/contact` / customer_group). Esta charter + os casos são o alvo da migração — não há Inertia page ainda.
+
+---
+
+## Mission
+
+O funil comercial da gráfica: ver todas as oportunidades num kanban por estágio, arrastar pra avançar, e abrir o detalhe pra ligar/cobrar/orçar. A pergunta que responde primeiro é **"o que está quente e o que vai fechar?"** — pipeline e conversão num relance, com as oportunidades em risco saltando aos olhos.
+
+---
+
+## Goals — Features (PRECISA TER)
+
+**Vivo hoje no protótipo (aprovado / manter):**
+- **Kanban 5 estágios:** Lead → Qualificado → Proposta → Negociação → Ganho, com **total por coluna** + contador (`STAGES`/`byCol`) — _UC-C01_
+- **Drag-drop pra avançar:** arrasta o card pra outra coluna → muda `stage` + **toast** de confirmação (`moveDeal`/`crm-toast`) — _UC-C02_
+- **KPI strip:** Pipeline ativo · Ganhas no mês (+ticket) · Taxa de conversão · Ciclo médio (`stats`) — _UC-C03_
+- **Filtro "Só quentes":** mostra só os deals `warn`/`bad` (em risco) — _UC-C04_
+- **Drawer do deal:** valor, **flow de estágio clicável** (move pelo drawer), ações (Ligar · WhatsApp · Orçamento · Próxima ação), histórico — _UC-C05_
+- **Novo lead** (drawer de criação) — _UC-C06_
+- **Badge semântico por card:** novo/indicação/orçamento ok/aguarda decisão/Nd sem resp./fechando/contrato/NFe (cores ok/warn/bad/win/info)
+
+---
+
+## Non-Goals — Features (NÃO faz)
+
+- ❌ Cadastro completo de cliente (isso é o módulo Clientes/Contatos · drawer 760 PT-03)
+- ❌ Emissão de orçamento/venda na tela (dispara pro módulo Vendas/Orçamento)
+- ❌ Atendimento/chat omnichannel (isso é Caixa Unificada / Inbox)
+- ❌ Inglês em UI cliente-facing
+
+---
+
+## UX Targets
+
+- Cabe em 1280px; kanban com scroll horizontal só se necessário (5 colunas folgadas)
+- Oportunidade em risco (warn/bad) salta aos olhos no card + filtro "só quentes" em 1 clique
+- Mover deal = arrastar (drag-drop) OU pelo flow no drawer — sempre com toast
+- escala warm semântica nos badges; estágios com hue próprio consistente
+- 0 erros JS console
+
+---
+
+## UX Anti-patterns (REPROVADO — não repetir)
+
+- ❌ **Emoji em ações** (`📞 Ligar`, `💬 WhatsApp`, `📄 Orçamento`) — proibição DS "só lucide-react, sem emoji". **Na migração F3: trocar por ícones lucide** (Phone/MessageCircle/FileText).
+- ❌ **Cor crua / paleta inventada** fora dos tokens — identidade só por `.crm-scope{--accent}`; os hues de estágio devem virar tokens semânticos, não oklch solto espalhado.
+- ❌ Modal full-screen pra detalhe (usar drawer lateral — já é o padrão aqui)
+- ❌ `rounded-xl+` · `font-bold` em h1
+
+> **Nota sobre WhatsApp:** o botão "WhatsApp" no drawer é **ação interna do operador** (abrir conversa com o lead), NÃO um CTA "Fale no WhatsApp" em landing pública — então **não** fere a proibição charter (que é sobre landing cliente-facing). Manter.
+
+---
+
+## Identidade & DS
+
+- **Accent escopado azul 220** (`.crm-scope{ --accent: oklch(0.45 0.11 220) }`) herdando componentes do `ds-v5`. Roxo canon intacto fora do escopo.
+- **Hues de estágio** (lead/qual/prop/negoc/ganho) = semânticos do funil; na migração, tokenizar (`--stage-lead` etc.) em vez de oklch inline por card.
+- Reusa shell: `.os-page`/`.os-stats`/`.os-btn` + `.crm-*` + `.fin-stat-hero` (compartilhado).
+
+---
+
+## Refs
+
+- CRM.casos.md — 6 UCs grounded em `crm-page.jsx`
+- ADR 0110 — Cockpit V2 · ADR 0235 — roxo canon · ADR 0200 — DS é piso / accent escopado
+- L-26 — repo é UltimatePOS híbrido; CRM = legado Blade a migrar
+
+## Trilha do tempo
+- 2026-06-02 · [CC] criou o trio (charter+casos) grounded no `crm-page.jsx` (8.6), pra destravar a migração Blade→Inertia que [CL] flagou pendente (CODE_NOTES 17:16). Travado: emoji→lucide na F3, WhatsApp é ação interna (mantém), accent escopado azul 220. Aguarda confirmação de [W] + decisão de prioridade da migração.

--- a/prototipo-ui/prototipos/crm/decisoes.md
+++ b/prototipo-ui/prototipos/crm/decisoes.md
@@ -1,0 +1,44 @@
+---
+casos: CRM · window.CrmPage (crm-page.jsx)
+irmaos: CRM.charter.md · crm-page.css
+tecnica: Caso de uso = narrativa do cliente + aceite verificável (Dado/Quando/Então)
+nota_tela: 8.6
+owner: wagner · last_run: 2026-06-02
+---
+
+# Casos de Uso & Aceite — CRM
+
+> Derivados do código real (`crm-page.jsx`). Funil kanban Lead→Qualificado→Proposta→Negociação→Ganho. ⚠️ tela do repo ainda é Blade legado (L-26) — estes casos guiam a migração Inertia.
+
+## UC-C01 · Ver o funil num relance
+- **Persona:** comercial/Wagner. **Como usa:** bate o olho no kanban — 5 colunas, cada deal um card, total e contador por coluna.
+- **Aceite:** Então 5 colunas (`STAGES`) com cards por `stage`, total em R$ e nº por coluna.
+- **Check:** static `STAGES` + `byCol` + `crm-col-n`. · **Status: ✅ static · live ⬜**
+
+## UC-C02 · Avançar arrastando
+- **Persona:** comercial. **Como usa:** arrasta um card pra outra coluna pra mudar o estágio.
+- **Aceite:** Quando solta numa coluna · Então `stage` muda + toast "Cliente → Estágio".
+- **Check:** static `moveDeal` + `handleDrop` + `crm-toast`. · **Status: ✅ static · live ⬜**
+
+## UC-C03 · Os números do pipeline
+- **Persona:** Wagner. **Como usa:** lê Pipeline ativo, Ganhas no mês (+ticket), Conversão, Ciclo médio.
+- **Aceite:** Então KPI strip com `stats.pipeline/wonValue/conv` + ciclo médio.
+- **Check:** static `stats` useMemo + `.crm-stats`. · **Status: ✅ static**
+
+## UC-C04 · Focar nos quentes
+- **Persona:** comercial. **Como usa:** botão "Só quentes" filtra os deals em risco (warn/bad).
+- **Aceite:** Quando ativa · Então só os `warn`/`bad` aparecem no kanban.
+- **Check:** static `filter==="hot"` + `byCol`. · **Status: ✅ static**
+
+## UC-C05 · Abrir a oportunidade (drawer)
+- **Persona:** comercial. **Como usa:** clica o card → drawer com valor, flow de estágio clicável (move por aqui também), ações (Ligar/WhatsApp/Orçamento/Próxima ação) e histórico.
+- **Aceite:** Quando abre · Então `crm-drawer` com `crm-flow` (estágios clicáveis) + ações + timeline.
+- **Check:** static `drawerDeal` + `crm-flow-step` + `crm-drawer-actions`. · **Status: ✅ static · live ⬜**
+
+## UC-C06 · Novo lead
+- **Persona:** comercial. **Como usa:** "+ Novo lead" abre drawer de criação → cria em Leads.
+- **Aceite:** Quando cria · Então o card entra na coluna Lead + toast.
+- **Check:** static `newOpen` + `setDeals`. · **Status: ✅ static · live ⬜**
+
+## Evolução
+- 2026-06-02 · [CC] criou a suíte (6 UCs) grounded em `crm-page.jsx`. ⚠️ Tela do repo é Blade legado (sem Inertia page) — `live ⬜` até a migração F3. Ajustes travados no charter: emoji→lucide, tokenizar hues de estágio.

--- a/resources/css/fin-cowork.css
+++ b/resources/css/fin-cowork.css
@@ -192,6 +192,28 @@
 .fin-cowork .fin-curadoria .fin-stat-hero .fin-spark:hover {
   opacity: 1;
 }
+/* ── Onda 27 (2026-06-02 · mirror Cowork fin-boletos.css R5 golden-reference) ──
+   Reflow do KPI strip por CONTAINER, não viewport. 5-col
+   (minmax(260px,1.6fr) repeat(4,1fr)) refluia por @media de viewport; com
+   sidebar ~240px, a Larissa (viewport 1280 → conteúdo ~1040px) caía num ponto
+   morto onde o media-query não disparava e os 5 KPIs tabulares colidiam. Com
+   `container: finbody / inline-size` no .fin-curadoria, o reflow passa a seguir
+   a largura REAL do conteúdo (pós-sidebar): ≤1100px hero full-width no topo +
+   4 KPIs folgados abaixo (Larissa cai aqui, limpa); ≤600px 2×2. Robusto também
+   com sidebar colapsada. */
+@container finbody (max-width: 1100px) {
+  .fin-cowork .fin-curadoria .fin-stats {
+    grid-template-columns: repeat(4, 1fr);
+  }
+  .fin-cowork .fin-curadoria .fin-stats .fin-stat-hero {
+    grid-column: 1 / -1;
+  }
+}
+@container finbody (max-width: 600px) {
+  .fin-cowork .fin-curadoria .fin-stats {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
 /* ─────────────────────────────────────────────────────────────
  * Toolbar (filter chips + density + search)
  * ───────────────────────────────────────────────────────────── */
@@ -485,6 +507,12 @@
 .fin-cowork .fin-curadoria {
   padding-left: 20px;
   padding-right: 20px;
+  /* Onda 27 (2026-06-02 · mirror Cowork fin-boletos.css:96) — query container
+     do KPI strip (.fin-stats). Reflow agora segue a largura real do conteúdo
+     pós-sidebar via @container (ver bloco @container finbody acima). Seguro:
+     nenhum overlay position:fixed é filho de .fin-curadoria (Sheet/CmdK via
+     portal no body = irmãos; containment não os captura). */
+  container: finbody / inline-size;
 }
 
 /* Onda 23 (2026-05-20) — alinhar glyphs Unicode (✦ ✎) com texto nos tabs.


### PR DESCRIPTION
## Origem
Handoff bundle do **Claude Design** (claude.ai/design) — espelho Cowork deste repo. Processei os 2 itens **não-Tier-0** prontos na fila `COWORK_NOTES.md §📥 Pendentes` + inventário do resto.

## O que entra (220 linhas, 2 intents)

### 1. `fix(financeiro)` — KPI strip reflua por `@container` (não viewport)
- **Problema (medido):** `.fin-stats` (5-col) refluia por `@media (viewport)`. Com sidebar ~240px, a **Larissa @1280px** (conteúdo ~1040px) caía num ponto morto onde o media-query não disparava → 5 KPIs tabulares colidiam.
- **Fix:** `.fin-curadoria` vira query container `finbody`; `@container finbody (max-width:1100px)` → 4-col + hero full-width; `(max-width:600px)` → 2×2. Reflua pela largura **real** do conteúdo, robusto com sidebar colapsada.
- **Seguro:** nenhum overlay `position:fixed` é filho de `.fin-curadoria` (Sheet/CmdK = portal no body). Espelha o golden-reference `fin-boletos.css` do Cowork.
- ✅ **Stylelint ratchet delta 0**.

### 2. `docs(crm)` — mirror trio + inventário
- `prototipo-ui/prototipos/crm/{charter.md,decisoes.md}` (pasta-por-tela, igual `clientes/`), grounded no `crm-page.jsx` (8.6). Destrava a futura migração Blade→Inertia (Tier 0, aguarda Wagner).
- `memory/sessions/2026-06-02-handoff-cowork-bundle-inventario.md` — mapa bundle-vs-`main`.

## NÃO incluído (Tier 0 — aguarda Wagner)
- **T0-A DS v5 → app.css:** verificado **no-op** — `app.css` é manifesto Tailwind vazio; tokens reais (`cockpit.css`/`inertia.css`) já são roxo canon `oklch(0.55 0.15 295)`.
- **T0-B CRM Blade→Inertia** (programa MWART 5 fases) · **T0-C DS-ROADMAP-até-zero** (6 filas, gate visual por fila).

Detalhe no inventário incluído.

🤖 Generated with [Claude Code](https://claude.com/claude-code)