### PR TITLE
feat(fiscal): FiscalStatusBadge unificado (NFC-e/NF-e/NFS-e)

### DIFF
--- a/prototipo-ui/CODE_NOTES.md
+++ b/prototipo-ui/CODE_NOTES.md
@@ -324,3 +324,33 @@ A Jana já pega erro de **saída** (golden 30Q + RAGAS + drift sentinel) mas nã
 - [ ] Confirmar check **advisory** (recomendo sim — drift de processo não pagina à noite).
 
 ### NÃO reprocessei (a comparação só confirma): guard higiene Cowork L-07/11/21/22 · collector CT100/OTel/LGPD #2073 · `design:review` #2078.
+## 2026-06-02 20:15 [CL] → [W]
+
+### Tela: Fiscal — status unificado (NFC-e/NF-e/NFS-e) · handoff `PROMPT_PARA_CODE_FISCAL-STATUS-UNIFICADO.md`
+### Status: traduzido (branch `feat/fiscal-status-unificado`, PR aberto — NÃO mergeado, aguarda F2 [W])
+### Diff: branch `feat/fiscal-status-unificado` (off `origin/main` fresco · §10.4 Passo 0)
+### Build: vitest 7/7 verde · eslint baseline Δ−60 (sem regressão) · tsc sem erro nos arquivos tocados
+### Charter atualizado: n/a (mudança de Componente, não de Page)
+
+### O que landou (reuse-first, só APRESENTAÇÃO — backend SEFAZ intocado):
+- **NOVO** `Components/NfeBrasil/FiscalStatusBadge.tsx` — componente ÚNICO de status fiscal. Cobre os 3 documentos (NFC-e 65 · NF-e 55 · NFS-e), 7 estados semânticos (emitting/waiting/authorized/rejected/denied/cancelled/inutilized), 2 variantes (`banner` card + `pill` chip). Fonte única das cores oklch de status (R-DS-002).
+- **NOVO** `Components/NfeBrasil/fiscalStatus.ts` — modelo de domínio + helpers (`docLabel`, `emissaoStatusToKind`) separados do .tsx (react-refresh).
+- **REFACTOR** `NfceStatusBadge.tsx` → vira wrapper reativo fino: mantém o polling `useNfceStatus` + a nuance "aguardando SEFAZ" (hasGivenUp) e DELEGA a renderização pro FiscalStatusBadge. Backward-compatible (mesma API).
+- **WIRE** `Sells/_components/FiscalSection.tsx` → o `StatusBadge` local (emerald/amber/rose Tailwind cru) foi DELETADO; cada linha de emissão agora usa `<FiscalStatusBadge variant="pill">`. Larissa vê o MESMO status do mesmo jeito.
+- **TEST** `tests/fiscal-status-badge.test.tsx` (7 casos: helpers + 3 docs autorizada + rejeição + pill + override).
+
+### ⚠️ Correção do achado [CC] (validado contra `main` NESTA sessão — §10.4, não confiei no prompt):
+O prompt dizia "4 implementações" — só **2** procedem; corrijo as outras 2 pra não causar regressão:
+1. ✅ **`NfceStatusBadge`** era o "bom padrão" — MAS estava **órfão** (importado em lugar nenhum, grep). Agora é a base do componente único.
+2. ✅ **Vendas `FiscalSection`** rolava status próprio — REAL duplicata, agora consome o componente. (Os modais `VdNfeEmitModal`/`VdNfseEmitModal` são wizards de EMISSÃO mock — fora de escopo, como o próprio prompt diz.)
+3. ❌ **Oficina `ServiceOrderRichSheet`** — NÃO tem badge fiscal NF-e/NFS-e. O `StatusBadge` dele (linha 647) é o status da ORDEM DE SERVIÇO (locação/order_type). Nada a unificar lá.
+4. ❌ **NotaDrawer V1 vs V2 — NÃO deletei "o legado".** É o OPOSTO do prompt: **V1 (`Nfe.tsx`) é o FUNCIONAL** (router.post real p/ cancelar/cce/retransmitir); **V2 (`Cockpit.tsx`) é o protótipo** (todos botões `disabled title="Em breve"`, dados mock). Deletar V1 = REGRESSÃO (some cancelar/CC-e/retransmitir reais). Além disso os drawers usam outro paradigma de apresentação (`fx-sefaz` CSS + cstat numérico), não o badge de polling — unificar isso é refactor separado e arriscado.
+
+### Pendências (pro Cowork/[W] decidir — NÃO fiz por serem outro intent/risco):
+- [ ] **NotaDrawer V1↔V2:** a resolução correta é MERGER as ações reais do V1 dentro do shell mais rico do V2 (ou migrar `Nfe.tsx`→V2 só depois de portar as 3 ações), não deletar. Precisa decisão de [W] (toca tela fiscal viva).
+- [ ] Higiene repo (fora do escopo, achado de passagem): há **arquivos com colisão de caixa** no git que quebram no Windows — `RecurringBilling/.../pt-BR` vs `pt-br/recurringbilling.php` e `Fiscal/Nfe-` vs `nfe-visual-comparison.md`.
+
+### new_design_memories
+- **golden**: status fiscal = 1 componente `FiscalStatusBadge` (NFC-e/NF-e/NFS-e · 7 kinds · banner+pill · oklch único); NfceStatusBadge vira wrapper de polling que delega; FiscalSection consome o pill.
+- **conflito (corrigido)**: o achado "4 implementações iguais" era ~50% — Oficina não tem badge fiscal e NotaDrawer V1 é o funcional (não legado). Só NfceStatusBadge(órfão)+FiscalSection eram a duplicata real do MODELO de polling.
+- **lição**: "deletar o legado" sem ler quem-está-wired pode apagar o funcional — V1 tinha as ações reais; V2 era o protótipo bonito-porém-mock.

--- a/resources/js/Components/NfeBrasil/FiscalStatusBadge.tsx
+++ b/resources/js/Components/NfeBrasil/FiscalStatusBadge.tsx
@@ -1,0 +1,219 @@
+// @memcofre
+//   modulo: NfeBrasil (FiscalStatusBadge)
+//   stories: US-NFE-002 (status NFC-e) generalizado p/ NF-e 55 + NFS-e (handoff Cowork 2026-06-02)
+//   adrs: UI-0008 (cockpit), 0235 (roxo canon — status é exceção semântica R-DS-002)
+//   nota: COMPONENTE ÚNICO de apresentação de status fiscal. Cobre os 3 documentos
+//         (NFC-e 65 · NF-e 55 · NFS-e) com mesmo vocabulário, mesma cor, mesmo ícone.
+//         PURAMENTE apresentacional (sem fetch) — quem polla é o NfceStatusBadge
+//         (wrapper reativo) e quem lista é o FiscalSection. SoC: dado entra, status sai.
+
+import { Ban, CheckCircle2, Clock, FileCheck2, Loader2, XCircle } from 'lucide-react';
+
+import {
+  docLabel,
+  emissaoStatusToKind,
+  type EmissaoLikeStatus,
+  type FiscalDocModel,
+  type FiscalStatusKind,
+} from './fiscalStatus';
+
+// Re-export type-only (conveniência p/ consumidores que já importam do componente).
+export type { EmissaoLikeStatus, FiscalDocModel, FiscalStatusKind } from './fiscalStatus';
+
+// ── Tone semântico (cor + ícone por estado) ────────────────────────────────
+
+type Tone = 'info' | 'ok' | 'warn' | 'error' | 'muted';
+
+interface KindMeta {
+  tone: Tone;
+  Icon: typeof CheckCircle2;
+  /** Título base (sem o doc/numero — montados em runtime). */
+  word: string;
+}
+
+const KIND_META: Record<FiscalStatusKind, KindMeta> = {
+  emitting:   { tone: 'info',  Icon: Loader2,     word: 'Emitindo' },
+  waiting:    { tone: 'warn',  Icon: Clock,       word: 'Processando' },
+  authorized: { tone: 'ok',    Icon: CheckCircle2, word: 'Autorizada' },
+  rejected:   { tone: 'error', Icon: XCircle,     word: 'Rejeitada' },
+  denied:     { tone: 'error', Icon: Ban,         word: 'Denegada' },
+  cancelled:  { tone: 'muted', Icon: Ban,         word: 'Cancelada' },
+  inutilized: { tone: 'muted', Icon: FileCheck2,  word: 'Inutilizada' },
+};
+
+// Cores semânticas oklch (R-DS-002 exceção status — não usam o roxo canon ADR 0235).
+// Fonte ÚNICA das cores de status fiscal no app.
+const PALETTE: Record<Tone, { border: string; bg: string; bgDark: string; fg: string; fgDark: string }> = {
+  info: {
+    border: 'oklch(0.78 0.10 230)',
+    bg: 'oklch(0.96 0.03 230 / 0.85)',
+    bgDark: 'oklch(0.32 0.06 230 / 0.40)',
+    fg: 'oklch(0.42 0.10 230)',
+    fgDark: 'oklch(0.82 0.08 230)',
+  },
+  ok: {
+    border: 'oklch(0.70 0.18 145)',
+    bg: 'oklch(0.96 0.05 145 / 0.85)',
+    bgDark: 'oklch(0.32 0.10 145 / 0.40)',
+    fg: 'oklch(0.40 0.16 145)',
+    fgDark: 'oklch(0.80 0.10 145)',
+  },
+  warn: {
+    border: 'oklch(0.78 0.15 80)',
+    bg: 'oklch(0.96 0.05 80 / 0.85)',
+    bgDark: 'oklch(0.32 0.08 80 / 0.40)',
+    fg: 'oklch(0.42 0.12 80)',
+    fgDark: 'oklch(0.82 0.10 80)',
+  },
+  error: {
+    border: 'oklch(0.55 0.20 25)',
+    bg: 'oklch(0.96 0.04 25 / 0.85)',
+    bgDark: 'oklch(0.32 0.10 25 / 0.40)',
+    fg: 'oklch(0.40 0.18 25)',
+    fgDark: 'oklch(0.78 0.10 25)',
+  },
+  muted: {
+    border: 'oklch(0.80 0.01 250)',
+    bg: 'oklch(0.96 0.005 250 / 0.85)',
+    bgDark: 'oklch(0.32 0.01 250 / 0.40)',
+    fg: 'oklch(0.45 0.01 250)',
+    fgDark: 'oklch(0.78 0.005 250)',
+  },
+};
+
+// ── Componente ──────────────────────────────────────────────────────────────
+
+export interface FiscalStatusBadgeProps {
+  /** Estado do documento — string dos hooks OU kind semântico já normalizado. */
+  status: FiscalStatusKind | EmissaoLikeStatus | string | null | undefined;
+  /** Documento ('65'|'55'|'nfse') ou rótulo legado ('NFe'). Vira o label exibido. */
+  model?: FiscalDocModel | string | null;
+  /** Sobrescreve o rótulo do documento (default derivado de `model`). */
+  label?: string;
+  numero?: number | null;
+  chave?: string | null;
+  cstat?: string | number | null;
+  motivo?: string | null;
+  /** `banner` = card completo (default, ex pós-venda) · `pill` = chip inline (ex linha de lista). */
+  variant?: 'banner' | 'pill';
+  /** Banner: só ícone + chave/motivo curto. Pill: ignora detalhe. Default false. */
+  compact?: boolean;
+  /** Anima o ícone (spinner) — usado pelo wrapper de polling. */
+  spin?: boolean;
+  /** Sobrescreve o título do banner (ex "aguardando SEFAZ" quando o poll desiste). */
+  title?: string;
+  /** Sobrescreve o detalhe do banner. */
+  detail?: string;
+}
+
+function isKind(s: string): s is FiscalStatusKind {
+  return s in KIND_META;
+}
+
+/**
+ * Apresentação unificada do status de um documento fiscal (NFC-e/NF-e/NFS-e).
+ * Determinístico, sem fetch. Aceita tanto o status string dos hooks quanto o kind semântico.
+ */
+export function FiscalStatusBadge({
+  status,
+  model,
+  label,
+  numero,
+  chave,
+  cstat,
+  motivo,
+  variant = 'banner',
+  compact = false,
+  spin,
+  title,
+  detail,
+}: FiscalStatusBadgeProps) {
+  const kind: FiscalStatusKind =
+    typeof status === 'string' && isKind(status) ? status : emissaoStatusToKind(status);
+  const meta = KIND_META[kind];
+  const doc = label ?? docLabel(model);
+  const c = PALETTE[meta.tone];
+  const wantSpin = spin ?? kind === 'emitting';
+
+  // Título: "<Doc> #123 autorizada" / "Emitindo NF-e…" / "NFS-e rejeitada"
+  const computedTitle =
+    title ??
+    (kind === 'emitting'
+      ? `Emitindo ${doc}…`
+      : numero != null && kind === 'authorized'
+        ? `${doc} #${numero} ${meta.word.toLowerCase()}`
+        : `${doc} ${meta.word.toLowerCase()}`);
+
+  // Detalhe: chave + cstat (autorizada) ou motivo (rejeição).
+  const computedDetail =
+    detail ??
+    (kind === 'authorized'
+      ? compact
+        ? (chave ?? '')
+        : `Chave ${chave ?? '—'}${cstat != null ? ` · cstat ${cstat}` : ''}`
+      : kind === 'rejected' || kind === 'denied'
+        ? compact
+          ? (motivo ?? (cstat != null ? `cstat ${cstat}` : ''))
+          : `${cstat != null ? `cstat ${cstat} — ` : ''}${motivo ?? 'sem motivo informado'}`
+        : kind === 'waiting'
+          ? 'Aguardando retorno do webservice.'
+          : 'Aguardando processamento.');
+
+  if (variant === 'pill') {
+    return (
+      <span
+        role="status"
+        title={computedDetail || undefined}
+        style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          gap: 4,
+          borderRadius: 9999,
+          border: `1px solid ${c.border}`,
+          background: `light-dark(${c.bg}, ${c.bgDark})`,
+          color: `light-dark(${c.fg}, ${c.fgDark})`,
+          padding: '1px 8px',
+          fontSize: 10,
+          fontWeight: 600,
+          lineHeight: 1.4,
+          whiteSpace: 'nowrap',
+        }}
+      >
+        <meta.Icon
+          size={10}
+          aria-hidden
+          style={{ flexShrink: 0, animation: wantSpin ? 'spin 1s linear infinite' : undefined }}
+        />
+        {meta.word}
+      </span>
+    );
+  }
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        padding: '10px 12px',
+        borderRadius: 8,
+        border: `1px solid ${c.border}`,
+        background: `light-dark(${c.bg}, ${c.bgDark})`,
+        color: `light-dark(${c.fg}, ${c.fgDark})`,
+        fontSize: 12,
+      }}
+    >
+      <meta.Icon
+        size={18}
+        aria-hidden
+        style={{ flexShrink: 0, animation: wantSpin ? 'spin 1s linear infinite' : undefined }}
+      />
+      <div style={{ minWidth: 0, flex: 1 }}>
+        <div style={{ fontWeight: 600, fontSize: 13, lineHeight: 1.3 }}>{computedTitle}</div>
+        {computedDetail && <div style={{ fontSize: 11, opacity: 0.85, marginTop: 2 }}>{computedDetail}</div>}
+      </div>
+    </div>
+  );
+}

--- a/resources/js/Components/NfeBrasil/NfceStatusBadge.tsx
+++ b/resources/js/Components/NfeBrasil/NfceStatusBadge.tsx
@@ -2,12 +2,14 @@
 //   modulo: NfeBrasil (NfceStatusBadge)
 //   stories: US-NFE-002 fase 2C (badge UI status NFC-e pós-venda)
 //   adrs: UI-0008 (cockpit), 0058 (Centrifugo CT 100), 0062 (Hostinger sem daemons)
-//   nota: badge reativo que polla status NFC-e via useNfceStatus + renderiza
-//         estado visual semântico (loading spinner / OK verde / erro vermelho).
-//         Plugável em qualquer Page Inertia que tenha transaction_id em props.
+//   nota: WRAPPER REATIVO — polla status via useNfceStatus e delega a apresentação
+//         pro FiscalStatusBadge (componente único de status fiscal). A cor/ícone/
+//         vocabulário moram lá; aqui fica só o transport (polling) + a nuance de
+//         "aguardando SEFAZ" quando o poll desiste (hasGivenUp).
 
 import { useNfceStatus } from '@/Hooks/useNfceStatus';
-import { CheckCircle2, Clock, Loader2, XCircle } from 'lucide-react';
+
+import { FiscalStatusBadge } from './FiscalStatusBadge';
 
 interface NfceStatusBadgeProps {
   transactionId: number;
@@ -24,22 +26,23 @@ export function NfceStatusBadge({
 }: NfceStatusBadgeProps) {
   const { data, isPolling, hasGivenUp } = useNfceStatus(transactionId);
 
-  // Estado: ainda emitindo (sem dados ou status pendente/null)
+  // Estado: ainda emitindo (sem dados ou status pendente/null).
   if (!data || data.status === null || data.status === 'pendente') {
     if (hasGivenUp) {
+      // Poll desistiu — SEFAZ lenta. Banner warn explícito (≠ "emitindo").
       return (
-        <Banner
-          tone="warn"
-          Icon={Clock}
+        <FiscalStatusBadge
+          status="waiting"
+          label={label}
           title={`${label}: aguardando SEFAZ`}
           detail="A SEFAZ pode estar lenta. Atualize em alguns minutos."
         />
       );
     }
     return (
-      <Banner
-        tone="info"
-        Icon={isPolling ? Loader2 : Clock}
+      <FiscalStatusBadge
+        status="emitting"
+        label={label}
         spin={isPolling}
         title={`Emitindo ${label}…`}
         detail={
@@ -51,107 +54,16 @@ export function NfceStatusBadge({
     );
   }
 
-  if (data.status === 'autorizada') {
-    return (
-      <Banner
-        tone="ok"
-        Icon={CheckCircle2}
-        title={`${label} #${data.numero} autorizada`}
-        detail={
-          compact
-            ? data.chave_44 ?? ''
-            : `Chave ${data.chave_44 ?? '—'} · cstat ${data.cstat ?? '—'}`
-        }
-      />
-    );
-  }
-
-  // rejeitada / denegada
+  // Estado terminal — delega o mapeamento status→cor/ícone pro componente único.
   return (
-    <Banner
-      tone="error"
-      Icon={XCircle}
-      title={`${label} ${data.status}`}
-      detail={
-        compact
-          ? data.motivo ?? `cstat ${data.cstat ?? '—'}`
-          : `cstat ${data.cstat ?? '—'} — ${data.motivo ?? 'sem motivo'}`
-      }
+    <FiscalStatusBadge
+      status={data.status}
+      label={label}
+      numero={data.numero}
+      chave={data.chave_44}
+      cstat={data.cstat}
+      motivo={data.motivo}
+      compact={compact}
     />
-  );
-}
-
-// ── Internal banner ──────────────────────────────────────────────────────
-
-type Tone = 'info' | 'ok' | 'warn' | 'error';
-
-interface BannerProps {
-  tone: Tone;
-  Icon: typeof CheckCircle2;
-  title: string;
-  detail: string;
-  spin?: boolean;
-}
-
-function Banner({ tone, Icon, title, detail, spin = false }: BannerProps) {
-  // Cores semânticas oklch (R-DS-002 exceção status).
-  const palette: Record<Tone, { border: string; bg: string; bgDark: string; fg: string; fgDark: string }> = {
-    info: {
-      border: 'oklch(0.78 0.10 230)',
-      bg: 'oklch(0.96 0.03 230 / 0.85)',
-      bgDark: 'oklch(0.32 0.06 230 / 0.40)',
-      fg: 'oklch(0.42 0.10 230)',
-      fgDark: 'oklch(0.82 0.08 230)',
-    },
-    ok: {
-      border: 'oklch(0.70 0.18 145)',
-      bg: 'oklch(0.96 0.05 145 / 0.85)',
-      bgDark: 'oklch(0.32 0.10 145 / 0.40)',
-      fg: 'oklch(0.40 0.16 145)',
-      fgDark: 'oklch(0.80 0.10 145)',
-    },
-    warn: {
-      border: 'oklch(0.78 0.15 80)',
-      bg: 'oklch(0.96 0.05 80 / 0.85)',
-      bgDark: 'oklch(0.32 0.08 80 / 0.40)',
-      fg: 'oklch(0.42 0.12 80)',
-      fgDark: 'oklch(0.82 0.10 80)',
-    },
-    error: {
-      border: 'oklch(0.55 0.20 25)',
-      bg: 'oklch(0.96 0.04 25 / 0.85)',
-      bgDark: 'oklch(0.32 0.10 25 / 0.40)',
-      fg: 'oklch(0.40 0.18 25)',
-      fgDark: 'oklch(0.78 0.10 25)',
-    },
-  };
-  const c = palette[tone];
-
-  return (
-    <div
-      role="status"
-      aria-live="polite"
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        gap: 10,
-        padding: '10px 12px',
-        borderRadius: 8,
-        border: `1px solid ${c.border}`,
-        background: `light-dark(${c.bg}, ${c.bgDark})`,
-        color: `light-dark(${c.fg}, ${c.fgDark})`,
-        fontSize: 12,
-      }}
-    >
-      <Icon
-        size={18}
-        aria-hidden
-        style={{ flexShrink: 0, animation: spin ? 'spin 1s linear infinite' : undefined }}
-      />
-      <div style={{ minWidth: 0, flex: 1 }}>
-        <div style={{ fontWeight: 600, fontSize: 13, lineHeight: 1.3 }}>{title}</div>
-        <div style={{ fontSize: 11, opacity: 0.85, marginTop: 2 }}>{detail}</div>
-      </div>
-    </div>
   );
 }

--- a/resources/js/Components/NfeBrasil/fiscalStatus.ts
+++ b/resources/js/Components/NfeBrasil/fiscalStatus.ts
@@ -1,0 +1,52 @@
+// fiscalStatus.ts — modelo de domínio + helpers do status fiscal (sem JSX).
+//
+// Separado do FiscalStatusBadge.tsx pra não misturar export de função com export
+// de componente (react-refresh/only-export-components). Fonte ÚNICA do vocabulário
+// de status fiscal: cobre os 3 documentos (NFC-e 65 · NF-e 55 · NFS-e).
+
+/** Documento fiscal. '65' = NFC-e (consumidor) · '55' = NF-e (B2B) · 'nfse' = serviço municipal. */
+export type FiscalDocModel = '55' | '65' | 'nfse';
+
+/** Estado semântico unificado do documento fiscal (independe do doc). */
+export type FiscalStatusKind =
+  | 'emitting'    // job disparado, ainda sem retorno SEFAZ/prefeitura
+  | 'waiting'     // pendente/processando — aguardando webservice
+  | 'authorized'  // autorizada / emitida com sucesso
+  | 'rejected'    // rejeitada (erro de validação)
+  | 'denied'      // denegada (irregularidade cadastral)
+  | 'cancelled'   // cancelada após autorização
+  | 'inutilized'; // faixa de numeração inutilizada
+
+/** Status string vindos dos hooks (useEmissoesPorTransaction / useNfceStatus). */
+export type EmissaoLikeStatus =
+  | 'pendente' | 'autorizada' | 'rejeitada' | 'denegada' | 'cancelada' | 'inutilizada';
+
+const DOC_LABEL: Record<FiscalDocModel, string> = {
+  '55': 'NF-e',
+  '65': 'NFC-e',
+  nfse: 'NFS-e',
+};
+
+/** Rótulo amigável do documento. `modelo_label` dos hooks ('NFe'/'NFC-e') também aceito. */
+export function docLabel(model?: FiscalDocModel | string | null): string {
+  if (!model) return 'Documento fiscal';
+  if (model === '55' || model === '65' || model === 'nfse') return DOC_LABEL[model];
+  // Normaliza rótulos legados ('NFe' → 'NF-e').
+  if (model === 'NFe') return 'NF-e';
+  return model;
+}
+
+/** Mapeia o status string dos hooks para o estado semântico unificado. */
+export function emissaoStatusToKind(
+  status: EmissaoLikeStatus | string | null | undefined,
+): FiscalStatusKind {
+  switch (status) {
+    case 'autorizada': return 'authorized';
+    case 'rejeitada': return 'rejected';
+    case 'denegada': return 'denied';
+    case 'cancelada': return 'cancelled';
+    case 'inutilizada': return 'inutilized';
+    case 'pendente': return 'waiting';
+    default: return 'emitting'; // null / desconhecido = ainda emitindo
+  }
+}

--- a/resources/js/Pages/Sells/_components/FiscalSection.tsx
+++ b/resources/js/Pages/Sells/_components/FiscalSection.tsx
@@ -6,7 +6,6 @@ import { useState } from 'react';
 import {
   AlertTriangle,
   CheckCircle2,
-  Clock,
   Download,
   ExternalLink,
   FileText,
@@ -16,30 +15,13 @@ import {
   Send,
 } from 'lucide-react';
 import { Button } from '@/Components/ui/button';
-import { useEmissoesPorTransaction, type Emissao, type EmissaoStatus } from '@/Hooks/useEmissoesPorTransaction';
+import { FiscalStatusBadge } from '@/Components/NfeBrasil/FiscalStatusBadge';
+import { useEmissoesPorTransaction, type Emissao } from '@/Hooks/useEmissoesPorTransaction';
 
 interface Props {
   saleId: number;
   enabled?: boolean;
 }
-
-const STATUS_LABEL: Record<EmissaoStatus, string> = {
-  pendente: 'Processando',
-  autorizada: 'Autorizada',
-  rejeitada: 'Rejeitada',
-  denegada: 'Denegada',
-  cancelada: 'Cancelada',
-  inutilizada: 'Inutilizada',
-};
-
-const STATUS_STYLE: Record<EmissaoStatus, string> = {
-  autorizada: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-950/40 dark:text-emerald-300',
-  pendente: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-950/40 dark:text-amber-300',
-  rejeitada: 'bg-rose-50 text-rose-700 border-rose-200 dark:bg-rose-950/40 dark:text-rose-300',
-  denegada: 'bg-rose-50 text-rose-700 border-rose-200 dark:bg-rose-950/40 dark:text-rose-300',
-  cancelada: 'bg-muted text-muted-foreground border-border',
-  inutilizada: 'bg-muted text-muted-foreground border-border',
-};
 
 export default function FiscalSection({ saleId, enabled = true }: Props) {
   const { emissoes, loading, error, isPolling, refetch } = useEmissoesPorTransaction(saleId, { enabled });
@@ -200,7 +182,15 @@ function EmissaoRow({
             <span className="text-xs text-muted-foreground tabular-nums">
               {em.serie}-{em.numero}
             </span>
-            <StatusBadge status={em.status} />
+            <FiscalStatusBadge
+              variant="pill"
+              model={em.modelo}
+              status={em.status}
+              numero={em.numero}
+              chave={em.chave_44}
+              cstat={em.cstat}
+              motivo={em.motivo}
+            />
           </div>
           {em.chave_44 && (
             <div className="font-mono text-[10px] text-muted-foreground break-all leading-tight">
@@ -241,14 +231,3 @@ function EmissaoRow({
   );
 }
 
-function StatusBadge({ status }: { status: EmissaoStatus }) {
-  const cls = STATUS_STYLE[status];
-  const label = STATUS_LABEL[status];
-  const Icon = status === 'autorizada' ? CheckCircle2 : status === 'pendente' ? Clock : AlertTriangle;
-  return (
-    <span className={'inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[10px] font-medium ' + cls}>
-      <Icon size={10} />
-      {label}
-    </span>
-  );
-}

--- a/tests/fiscal-status-badge.test.tsx
+++ b/tests/fiscal-status-badge.test.tsx
@@ -1,0 +1,82 @@
+// FiscalStatusBadge — testa o COMPONENTE ÚNICO de status fiscal (handoff Cowork 2026-06-02).
+//
+// Cobre o que importa pra Larissa: o mesmo status renderiza igual nos 3 documentos
+// (NFC-e 65 · NF-e 55 · NFS-e) — vocabulário + label coerentes. Determinístico, sem fetch.
+//
+// Nota: usa getByText (lança se ausente = asserção de presença) + textContent, em vez
+// de @testing-library/jest-dom (não está no setup do projeto — ver tests/js/setup.ts).
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/react';
+
+import { FiscalStatusBadge } from '@/Components/NfeBrasil/FiscalStatusBadge';
+import { docLabel, emissaoStatusToKind } from '@/Components/NfeBrasil/fiscalStatus';
+
+afterEach(cleanup);
+
+describe('FiscalStatusBadge — helpers de domínio', () => {
+  it('docLabel cobre os 3 documentos + normaliza rótulo legado NFe', () => {
+    expect(docLabel('65')).toBe('NFC-e');
+    expect(docLabel('55')).toBe('NF-e');
+    expect(docLabel('nfse')).toBe('NFS-e');
+    expect(docLabel('NFe')).toBe('NF-e'); // rótulo legado dos hooks
+    expect(docLabel(null)).toBe('Documento fiscal');
+  });
+
+  it('emissaoStatusToKind mapeia os status string dos hooks p/ kind semântico', () => {
+    expect(emissaoStatusToKind('autorizada')).toBe('authorized');
+    expect(emissaoStatusToKind('rejeitada')).toBe('rejected');
+    expect(emissaoStatusToKind('denegada')).toBe('denied');
+    expect(emissaoStatusToKind('cancelada')).toBe('cancelled');
+    expect(emissaoStatusToKind('inutilizada')).toBe('inutilized');
+    expect(emissaoStatusToKind('pendente')).toBe('waiting');
+    expect(emissaoStatusToKind(null)).toBe('emitting');
+  });
+});
+
+describe('FiscalStatusBadge — apresentação unificada', () => {
+  it('autorizada (banner) mostra doc + número + chave nos 3 modelos', () => {
+    for (const [model, label] of [['65', 'NFC-e'], ['55', 'NF-e'], ['nfse', 'NFS-e']] as const) {
+      render(
+        <FiscalStatusBadge status="autorizada" model={model} numero={42} chave="CHAVE-44" />,
+      );
+      expect(screen.getByText(`${label} #42 autorizada`)).toBeTruthy();
+      expect(screen.getByText(/Chave CHAVE-44/)).toBeTruthy();
+      cleanup();
+    }
+  });
+
+  it('rejeitada (banner) mostra motivo + cstat', () => {
+    render(
+      <FiscalStatusBadge status="rejeitada" model="55" cstat="691" motivo="NCM divergente" />,
+    );
+    expect(screen.getByText('NF-e rejeitada')).toBeTruthy();
+    expect(screen.getByText(/cstat 691 — NCM divergente/)).toBeTruthy();
+  });
+
+  it('pill é compacto — só a palavra de estado, com role=status', () => {
+    render(<FiscalStatusBadge variant="pill" model="65" status="autorizada" numero={7} />);
+    const pill = screen.getByRole('status');
+    expect(pill.textContent).toContain('Autorizada');
+    // pill não despeja o título longo "#7 autorizada"
+    expect(pill.textContent).not.toContain('#7');
+  });
+
+  it('aceita kind semântico direto (waiting) sem passar pelo mapeamento string', () => {
+    render(<FiscalStatusBadge status="waiting" model="nfse" />);
+    expect(screen.getByText('NFS-e processando')).toBeTruthy();
+  });
+
+  it('título e detalhe podem ser sobrescritos (usado pelo wrapper de polling)', () => {
+    render(
+      <FiscalStatusBadge
+        status="waiting"
+        label="NFC-e"
+        title="NFC-e: aguardando SEFAZ"
+        detail="A SEFAZ pode estar lenta."
+      />,
+    );
+    expect(screen.getByText('NFC-e: aguardando SEFAZ')).toBeTruthy();
+    expect(screen.getByText('A SEFAZ pode estar lenta.')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Handoff Cowork → Code (F3)
Responde `prototipo-ui-patch/PROMPT_PARA_CODE_FISCAL-STATUS-UNIFICADO.md` (auditoria [CC] 2026-06-02). **Reuse-first, só apresentação** — backend SEFAZ (`_lib/sefaz-actions.ts`/`sefaz-codes.ts`) intocado.

## O que muda
- **NOVO** `FiscalStatusBadge.tsx` — componente **único** de status fiscal: 3 documentos (NFC-e 65 · NF-e 55 · NFS-e), 7 estados (emitting/waiting/authorized/rejected/denied/cancelled/inutilized), 2 variantes (`banner` + `pill`). Fonte única das cores oklch de status.
- **NOVO** `fiscalStatus.ts` — domínio + helpers (`docLabel`, `emissaoStatusToKind`).
- **REFACTOR** `NfceStatusBadge.tsx` → wrapper reativo fino (mantém polling `useNfceStatus` + nuance "aguardando SEFAZ"), delega render. API preservada.
- **WIRE** `Sells/_components/FiscalSection.tsx` → consome o `pill` único; deleta o `StatusBadge` local (Tailwind emerald/amber/rose cru).
- **TEST** `tests/fiscal-status-badge.test.tsx` (7 casos).

## ⚠️ Correção do achado (validado contra `main` — §10.4)
O prompt dizia "4 implementações"; só **2** procedem:
- ✅ `NfceStatusBadge` era o bom padrão **mas estava órfão** (importado em lugar nenhum) → agora é a base.
- ✅ `FiscalSection` = duplicata real → consome o componente.
- ❌ **Oficina `ServiceOrderRichSheet` NÃO tem badge fiscal** — seu `StatusBadge` é status da OS (locação/order_type).
- ❌ **NotaDrawer V1 NÃO é legado morto** — é o **funcional** (cancelar/CC-e/retransmitir reais via `router.post`); **V2 é o protótipo** (botões `disabled`, mock). Deletar V1 = regressão. **Não toquei nos drawers.**

## Fica pra decisão de [W] (fora deste PR)
- NotaDrawer V1↔V2: merge das ações reais do V1 no shell rico do V2 (refactor separado, toca tela fiscal viva).

## Validação
- vitest **7/7** · eslint baseline **Δ−60, sem regressão** · `tsc --noEmit` sem erro nos arquivos tocados.

## Gate
🚦 **NÃO mergear** — aguarda F2 (screenshot [W2]) + F3.5 a11y, per PROTOCOL.md. Retorno [CL] em `prototipo-ui/CODE_NOTES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)