### PR TITLE
feat(jana): ledger de lições de operação (Reflexion runtime) + graduação no health-check

### DIFF
--- a/.claude/skills/feedback-capture/SKILL.md
+++ b/.claude/skills/feedback-capture/SKILL.md
@@ -19,6 +19,7 @@ NÃO ativar pra:
 - Wagner próprio feedback dele (= não é cliente — usar TaskCreate direto)
 - Reflexão estratégica sem feedback concreto de cliente real
 - Feedback de prospect frio sem persona criada (rodar `cliente-discovery` antes)
+- **Erro de OPERAÇÃO da Jana/sistema** (job parou, config stale, sync silencioso, declarar done sem smoke) — isso é Reflexion runtime, vai pro ledger `Modules/Jana/LICOES-OPERACAO.md` via `incident-done-checklist` Bloco D, **não** é fricção de cliente. feedback-capture é só fricção de **saída/UX** reportada por cliente real.
 
 ## Workflow
 
@@ -174,3 +175,4 @@ Retorna ID da task pra preencher campo `task_mcp_id` do YAML.
 - `feedback-dashboard` — agregado/relatório/RICE ranking
 - `design-deep-analysis` — usa fricoes_conhecidas no carregamento
 - `personas-resolve` — Tier A que carrega persona em Edit/Write
+- `incident-done-checklist` (Bloco D) — gêmeo runtime: erro de OPERAÇÃO da Jana → ledger `Modules/Jana/LICOES-OPERACAO.md` (não este skill)

--- a/.claude/skills/incident-done-checklist/SKILL.md
+++ b/.claude/skills/incident-done-checklist/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: incident-done-checklist
-description: BLOQUEADOR — ATIVAR antes de declarar "incident fechado" / "está pronto" / "feature funcionando" / encerrar sessão de fix em prod. Skill carrega a Definition of Done canônica (DoD-v1) que EXIGE smoke real prod end-to-end pra cada fix antes de marcar pronto. Funciona como gate procedural — sem TODOS os checks ✅, status fica `awaiting-smoke` no commit/PR/handoff, NÃO `done`. Aprende incident 2026-05-28 onde declarei "10 PRs fechados" com 3 fixes (M1/M2/M3 mídia) NUNCA validados por smoke real → 10.144 mídias ainda órfãs prod descoberto pelo Wagner depois. Operacional Tier A — DEVE ativar SEMPRE que agente escreve "está pronto", "fechado", "completou", "deployed", "validado" em mensagem ao Wagner. Refs PATTERN-INCIDENT-RESPONSE-VELOCITY.md passo 4, ADR 0093, skill commit-discipline.
+description: BLOQUEADOR — ATIVAR antes de declarar "incident fechado" / "está pronto" / "feature funcionando" / encerrar sessão de fix em prod. Skill carrega a Definition of Done canônica (DoD-v1) que EXIGE smoke real prod end-to-end pra cada fix antes de marcar pronto. Funciona como gate procedural — sem TODOS os checks ✅, status fica `awaiting-smoke` no commit/PR/handoff, NÃO `done`. Aprende incident 2026-05-28 onde declarei "10 PRs fechados" com 3 fixes (M1/M2/M3 mídia) NUNCA validados por smoke real → 10.144 mídias ainda órfãs prod descoberto pelo Wagner depois. Operacional Tier A — DEVE ativar SEMPRE que agente escreve "está pronto", "fechado", "completou", "deployed", "validado" em mensagem ao Wagner. Bloco D (Reflexion runtime): quando o incidente foi erro de OPERAÇÃO da Jana (≠ saída do LLM), registrar a lição em Modules/Jana/LICOES-OPERACAO.md + graduar (MEC→check jana:health-check / JULG→regra). Refs PATTERN-INCIDENT-RESPONSE-VELOCITY.md passo 4, ADR 0093, skill commit-discipline.
 ---
 
 # Incident Done Checklist — Definition of Done bloqueante (DoD-v1)
@@ -46,12 +46,21 @@ Sem skill bloqueante, isso repete.
 
 - [ ] **C1** Wagner confirmou explicitamente no celular (msg WhatsApp chegou) OU na tela (preview/thumb visível)
 
+### Bloco D — Reflexão (só quando o incidente foi erro de OPERAÇÃO da Jana)
+
+> Aplica-se quando o que quebrou foi **comportamento/operação da Jana** (job que parou, config stale, sync silencioso, declarar done sem evidência) — **NÃO** quando foi erro de **saída** do LLM (alucinação/relevância), que o golden 30Q + RAGAS gate já cobrem. Reflexion runtime: o incidente vira lição append-only + graduada.
+
+- [ ] **D1** Append da lição em [`Modules/Jana/LICOES-OPERACAO.md`](../../../Modules/Jana/LICOES-OPERACAO.md) no formato canônico (`### L-OP-NNN` · Erro · Sintoma · Regra · Ref)
+- [ ] **D2** Atribuir `Graduação:` — **MEC** (mecanizável → vira `check:` no `jana:health-check`, igual `profile_distiller_drift`) **ou** **JULG** (julgamento → vira `regra:` sempre-lida no SCOPE/BRIEFING da Jana ou numa skill)
+- [ ] **D3** Se MEC e o check ainda não existe, criar o check (ou deixar `status:pendente` — o check advisory `jana_lesson_ledger_graduation` acende amarelo até fechar)
+
 ## Regras de fail
 
 - **Qualquer item ❌ em B** → status ≠ `done`. Use `awaiting-smoke` ou `partial-fix-deployed`.
 - **B3 fail (DB não bate)** → fix NÃO está realmente aplicado. Voltar pro passo 1 do DRFV (PATTERN-INCIDENT-RESPONSE-VELOCITY).
 - **B6 latência fora do alvo** → bug parcial. Catalogar como follow-up + abrir nova investigação.
 - **C1 sem confirmação Wagner em 24h** → status fica `pending-customer-validation`. Não encerra sessão.
+- **D ignorado** quando o incidente foi erro de operação da Jana → a lição se perde e o erro repete na próxima sessão. Sem append no ledger, não é Reflexion — é só apagar incêndio.
 
 ## Anti-padrões formais (NUNCA fazer)
 

--- a/Modules/Jana/Console/Commands/HealthCheckCommand.php
+++ b/Modules/Jana/Console/Commands/HealthCheckCommand.php
@@ -30,7 +30,10 @@ use Modules\Jana\Services\CharterHealthChecker;
  *  10. Memoria recall backend (resiliência Meilisearch) — MCP/Meilisearch
  *      reachable; alerta ANTES da degradação silenciosa (chat responde sem
  *      recall, NÃO estoura 500). McpMemoriaDriver já degrada gracioso.
- *  11-16. Charter/loop health (ADVISORY · CharterHealthChecker, PROTOCOL §6) —
+ *  11. Lesson ledger graduation (ADVISORY · Reflexion runtime) — toda lição de
+ *      operação em LICOES-OPERACAO.md nasceu graduada (MEC→check / JULG→regra);
+ *      acende amarelo se há entrada malformada ou `status:pendente`.
+ *  12-17. Charter/loop health (ADVISORY · CharterHealthChecker, PROTOCOL §6) —
  *      charter_missing, charter_stale (>90d), charter_refs_broken,
  *      charter_method_missing, readme_handoff_block_missing (L-18),
  *      design_return_skipped (retorno §10.2 atrás do SYNC_LOG · G4).
@@ -48,7 +51,7 @@ class HealthCheckCommand extends Command
                             {--json : Output JSON em vez de tabela}
                             {--notify : Loga ALERT em jana-health channel se algo falhou}';
 
-    protected $description = 'Health check diário Jana + Constituição v2 (10 checks SQL + 6 charter/loop advisory)';
+    protected $description = 'Health check diário Jana + Constituição v2 (10 checks SQL + ledger de lições + charter/loop advisory)';
 
     public function handle(): int
     {
@@ -63,6 +66,7 @@ class HealthCheckCommand extends Command
             $this->checkWhatsappMediaPending1h(),
             $this->checkMcpWebhookHealth2h(),
             $this->checkMemoriaRecallBackend(),
+            $this->checkLessonLedgerGraduation(),
             // Charter health (advisory — não falha exit/cron). PROTOCOL §6.
             ...CharterHealthChecker::fromApp()->checks(),
         ];
@@ -643,6 +647,114 @@ class HealthCheckCommand extends Command
                     . ') — chat degrada SEM memória. Checar Meilisearch/MCP CT 100.',
             ];
         }
+    }
+
+    /**
+     * Check 11 — Ledger de lições de operação (Reflexion runtime · advisory).
+     *
+     * Lê Modules/Jana/LICOES-OPERACAO.md e valida o LOOP DE GRADUAÇÃO: toda lição
+     * de operação registrada precisa nascer graduada (MEC → vira check · JULG → vira
+     * regra sempre-lida). Acende amarelo (advisory, não derruba cron) se alguma entrada
+     * está malformada ou ainda `status:pendente` — fechando o loop por métrica
+     * (Constituição v2 §4) sem construir mecanismo novo: é só mais um check.
+     *
+     * Advisory de propósito: drift de processo de governança não deve paginar à noite
+     * nem falhar o exit/cron; reporta e fica visível no scorecard.
+     *
+     * Skip silencioso se o ledger ainda não existe (ambiente sem o doc / pré-merge).
+     *
+     * @see Modules/Jana/LICOES-OPERACAO.md
+     * @see memory/decisions/proposals/jana-ledger-licoes-operacao-reflexion.md
+     */
+    protected function checkLessonLedgerGraduation(): array
+    {
+        $name = 'jana_lesson_ledger_graduation';
+        $path = base_path('Modules/Jana/LICOES-OPERACAO.md');
+
+        if (! is_file($path)) {
+            return [
+                'name' => $name,
+                'ok' => true,
+                'advisory' => true,
+                'value' => 'n/a',
+                'threshold' => 0,
+                'message' => 'Skipped (ledger LICOES-OPERACAO.md ausente — pré-merge/dev)',
+            ];
+        }
+
+        $r = self::parseLessonLedger((string) file_get_contents($path));
+        $problemas = array_merge(
+            array_map(fn ($id) => "{$id} (malformada)", $r['malformed']),
+            array_map(fn ($id) => "{$id} (pendente)", $r['overdue']),
+        );
+        $count = count($problemas);
+
+        return [
+            'name' => $name,
+            'ok' => $count === 0,
+            'advisory' => true,
+            'value' => $count,
+            'threshold' => 0,
+            'message' => $count === 0
+                ? "{$r['total']} lição(ões) de operação — todas graduadas (MEC→check / JULG→regra)"
+                : 'Loop de graduação aberto: ' . implode(' · ', array_slice($problemas, 0, 6))
+                    . ($count > 6 ? ' (+' . ($count - 6) . ' mais)' : ''),
+        ];
+    }
+
+    /**
+     * Parser determinístico do ledger de lições de operação.
+     *
+     * Contrato (ver Modules/Jana/LICOES-OPERACAO.md → "Formato canônico"):
+     *   - cada lição = bloco iniciado por `### L-OP-NNN`
+     *   - linha `- **Graduação:** <MEC|JULG> · <check:`x`|regra:`y`> · status:<done|pendente>`
+     *
+     * Regras de validação:
+     *   - sem linha Graduação OU tipo ∉ {MEC,JULG} → malformed
+     *   - MEC com status done sem `check:` → malformed
+     *   - JULG com status done sem `regra:` → malformed
+     *   - status pendente (qualquer tipo) → overdue (loop ainda aberto)
+     *
+     * Público + estático pra ser testável sem tocar o filesystem real.
+     *
+     * @return array{total:int, overdue:list<string>, malformed:list<string>}
+     */
+    public static function parseLessonLedger(string $content): array
+    {
+        $overdue = [];
+        $malformed = [];
+
+        // Quebra em blocos por header de lição (### L-OP-NNN ...).
+        $blocos = preg_split('/^###\s+(L-OP-\d+)\b/m', $content, -1, PREG_SPLIT_DELIM_CAPTURE);
+        // $blocos = [prefixo, id1, corpo1, id2, corpo2, ...]
+        $total = 0;
+        for ($i = 1; $i < count($blocos); $i += 2) {
+            $id = $blocos[$i];
+            $corpo = $blocos[$i + 1] ?? '';
+            $total++;
+
+            if (! preg_match('/\*\*Gradua[çc][ãa]o:\*\*\s*(MEC|JULG)\b(.*)$/mu', $corpo, $m)) {
+                $malformed[] = $id;
+                continue;
+            }
+            $tipo = $m[1];
+            $resto = $m[2];
+
+            $pendente = (bool) preg_match('/status:\s*pendente/iu', $resto);
+            if ($pendente) {
+                $overdue[] = $id;
+                continue;
+            }
+
+            // status:done (default) — exige o binding do tipo.
+            if ($tipo === 'MEC' && ! preg_match('/check:\s*`?[\w-]+`?/u', $resto)) {
+                $malformed[] = $id;
+            } elseif ($tipo === 'JULG' && ! preg_match('/regra:\s*`?[^`·\s][^`·]*`?/u', $resto)) {
+                $malformed[] = $id;
+            }
+        }
+
+        return ['total' => $total, 'overdue' => $overdue, 'malformed' => $malformed];
     }
 
     protected function renderTable(array $checks, bool $allOk): void

--- a/Modules/Jana/LICOES-OPERACAO.md
+++ b/Modules/Jana/LICOES-OPERACAO.md
@@ -1,0 +1,94 @@
+# Jana — Ledger de Lições de Operação (Reflexion runtime)
+
+> **O que é:** registro **append-only** dos erros de **operação/comportamento** da própria
+> Jana — *não* dos erros de **saída** do LLM (alucinação/relevância), que o golden 30Q +
+> RAGAS gate + drift sentinel já cobrem. É o padrão **Reflexion** (auto-reflexão verbal em
+> memória persistente) aplicado ao *runtime* da Jana: cada erro vira lição, cada lição vira
+> **check** (mecanizável) ou **regra sempre-lida** (julgamento).
+>
+> **Por que existe:** lacuna #1 da Jana no placar [CC]×Jana×Champion (Aprendizado-com-erro
+> Jana ~6.5 vs [CC] ~9.0). O [CC] já tem um ledger das próprias lições; a Jana pegava só erro
+> de saída. Este doc fecha o gêmeo *runtime* do ledger de design do [CC].
+>
+> **Natureza:** working doc **proposto** (§10.4) — vira canon quando [W] aprovar o PR.
+> NÃO duplica `proibicoes.md` (proibições globais Tier 0) nem o `LICOES_CC` do design ([CC]).
+> Escopo: erros de operação **da Jana/Modules/Jana**.
+
+---
+
+## Formato canônico (1 lição = 1 entrada `### L-OP-NNN`)
+
+Cada lição nasce com `Graduação:` — esse é o coração do loop. O parser do
+`jana:health-check` (check `jana_lesson_ledger_graduation`) lê estas entradas e falha
+(advisory) se alguma estiver **malformada** ou **pendente**.
+
+```
+### L-OP-NNN · <título curto>
+- **Data:** AAAA-MM-DD
+- **Erro:** o que a Jana fez de errado (operação, não saída)
+- **Sintoma:** como apareceu / como foi detectado
+- **Regra:** a lição — o que passa a valer daqui pra frente
+- **Ref:** ADR/PR/incident/arquivo que ancora
+- **Graduação:** MEC · check:`<nome_do_check>` · status:done   ← mecanizável vira check
+        ou
+- **Graduação:** JULG · regra:`<ponteiro>` · status:done       ← julgamento vira regra sempre-lida
+```
+
+**Regras de graduação (espelham a 5ª camada do [CC] — `APRENDER-COM-ERRO`, agora no runtime):**
+
+| Tipo | Significado | Destino | `status:done` exige |
+|---|---|---|---|
+| **MEC** | dá pra detectar por SQL/código determinístico | vira **check** no `jana:health-check` (igual `profile_distiller_drift`) | `check:` apontando um check existente |
+| **JULG** | exige julgamento humano/contexto, não mecanizável | vira **regra sempre-lida** (SCOPE/BRIEFING da Jana ou skill) | `regra:` apontando o documento que carrega a regra |
+
+`status:pendente` = lição registrada mas ainda **não** graduada → o check advisory acende
+amarelo até alguém fechar (criar o check ou escrever a regra). Loop fechado por métrica
+(Constituição v2 §4).
+
+---
+
+## Gatilho (quando registrar)
+
+Quando um **incidente de operação da Jana** é resolvido — *não* um bug de resposta (esses já
+têm golden/RAGAS) — append uma entrada aqui + atribua `Graduação:`. Operacionalizado pela
+skill `incident-done-checklist` (Bloco D), que já é o ponto onde se declara um fix fechado.
+Erro de operação ≠ feedback de cliente (`feedback-capture` cobre fricção de **saída/UX**).
+
+---
+
+## Lições
+
+<!-- append-only · nunca editar/deletar entrada existente · só acrescentar abaixo -->
+
+### L-OP-001 · Webhook MCP respondia 5xx por config cache stale
+- **Data:** 2026-05-21
+- **Erro:** `'mcp' => [...]` duplicado no `Modules/Jana/Config/config.php` + config cache stale fez `config('copiloto.mcp.sync_webhook_token')` retornar NULL → webhook GitHub→MCP respondia 500. SPEC.md/memory pushados não viravam task no DB; o time (Maiara/Felipe/Eliana) ficou sem ver tasks atribuídas, em silêncio.
+- **Sintoma:** entregas 5xx no webhook; drift DB↔git invisível até alguém cobrar.
+- **Regra:** drift de sync do MCP tem que ser **observável**, não descoberto por humano. Config duplicada é erro de operação, não de saída.
+- **Ref:** incident US-FIN-043 (2026-05-21) · `HealthCheckCommand::checkMcpWebhookHealth2h`
+- **Graduação:** MEC · check:`mcp_webhook_5xx_2h` · status:done
+
+### L-OP-002 · ProfileDistiller parou e ninguém viu (Brain A 24h sem rodar)
+- **Data:** 2026-05-13
+- **Erro:** o job diário que regenera `jana_business_profile` parou; profiles ficaram >7d stale e o chat passou a responder com contexto velho — degradação silenciosa de operação (o LLM "acertava" a resposta sobre dados errados, então golden/RAGAS não pegavam).
+- **Sintoma:** profile com `gerado_em` antigo; narrativa Brain A desatualizada.
+- **Regra:** job de manutenção que para é incidente de operação — precisa de sentinela própria, não confiar que "se quebrasse alguém notaria".
+- **Ref:** COPI-26 · `HealthCheckCommand::checkProfileDrift`
+- **Graduação:** MEC · check:`profile_distiller_drift` · status:done
+
+### L-OP-003 · Declarar "fechado" sem smoke real prod
+- **Data:** 2026-05-28
+- **Erro:** declarei fixes/PRs "fechados" com PR mergeado + Pest verde + deploy OK, mas **sem** smoke real ponta-a-ponta — 10.144 mídias seguiam órfãs em prod. Confundir "código em prod" com "funciona em prod" é erro de operação, não mecanizável por um único SQL (cada fix tem seu próprio smoke).
+- **Sintoma:** Wagner cobrou "ainda não consolidou"; audit honesto revelou estado real divergente do declarado.
+- **Regra:** sem Bloco B (smoke real prod) completo, status ≠ `done` — usar `awaiting-smoke`. É julgamento por-fix, não um check único.
+- **Ref:** incident 2026-05-28 · skill `incident-done-checklist` (DoD-v1) · `PATTERN-INCIDENT-RESPONSE-VELOCITY.md`
+- **Graduação:** JULG · regra:`.claude/skills/incident-done-checklist/SKILL.md` · status:done
+
+---
+
+## Refs
+
+- Origem: sessão [CC] 2026-06-02 — comparação [CC]×Jana×Champion (view `rep-cc-vs-jana` no `metricas.html`); pesquisa Reflexion · Voyager · Letta · Zep/Graphiti.
+- Proposta §10.4: [`memory/decisions/proposals/jana-ledger-licoes-operacao-reflexion.md`](../../memory/decisions/proposals/jana-ledger-licoes-operacao-reflexion.md)
+- Mecanismo: `Modules/Jana/Console/Commands/HealthCheckCommand.php` → check `jana_lesson_ledger_graduation`
+- Constituição v2 §4 (loop fechado por métrica) · §8 (confiabilidade com fallback)

--- a/Modules/Jana/SCOPE.md
+++ b/Modules/Jana/SCOPE.md
@@ -26,6 +26,9 @@ contains:
   - "DataController — sidebar/permissions"
   - "InstallController — install/uninstall hooks"
   - "SuperadminController — superadmin package"
+  # Aprendizado com erro / Reflexion runtime
+  - "LICOES-OPERACAO.md — ledger append-only dos erros de OPERAÇÃO da Jana (≠ saída, que golden/RAGAS cobrem); cada lição gradua MEC→check no jana:health-check ou JULG→regra sempre-lida. Proposta §10.4 (aguarda [W])"
+  - "Console/Commands/HealthCheckCommand — check jana_lesson_ledger_graduation valida o loop de graduação do ledger (advisory)"
 not_contains:
   - "MemoriaController (browser KB) → Modules/KB"
   - "FontesController (knowledge sources) → Modules/KB"

--- a/Modules/Jana/Tests/Feature/Smoke/JanaHealthCheckTest.php
+++ b/Modules/Jana/Tests/Feature/Smoke/JanaHealthCheckTest.php
@@ -62,6 +62,7 @@ test('cada check tem campos canonicos', function () {
         'whatsapp_media_pending_1h',
         'mcp_webhook_5xx_2h',
         'memoria_recall_backend',
+        'jana_lesson_ledger_graduation',
     ];
 
     $namesReais = array_column($json['checks'], 'name');
@@ -84,4 +85,59 @@ test('comando nao crasha mesmo se tabelas degraded', function () {
 
     expect($exit1)->toBeIn([0, 1]);
     expect($exit2)->toBeIn([0, 1]);
+});
+
+/**
+ * Loop de graduação do ledger de lições de operação (Reflexion runtime).
+ * Parser determinístico — testável sem tocar o filesystem real.
+ *
+ * @see Modules/Jana/Console/Commands/HealthCheckCommand::parseLessonLedger
+ * @see Modules/Jana/LICOES-OPERACAO.md
+ */
+use Modules\Jana\Console\Commands\HealthCheckCommand;
+
+test('parser do ledger: lição MEC e JULG bem-formadas passam', function () {
+    $md = <<<'MD'
+    ### L-OP-001 · check existente
+    - **Graduação:** MEC · check:`mcp_webhook_5xx_2h` · status:done
+
+    ### L-OP-002 · regra existente
+    - **Graduação:** JULG · regra:`.claude/skills/incident-done-checklist/SKILL.md` · status:done
+    MD;
+
+    $r = HealthCheckCommand::parseLessonLedger($md);
+    expect($r['total'])->toBe(2);
+    expect($r['overdue'])->toBe([]);
+    expect($r['malformed'])->toBe([]);
+});
+
+test('parser do ledger: status pendente vira overdue (loop aberto)', function () {
+    $md = "### L-OP-003 · ainda não graduada\n- **Graduação:** MEC · check:`x` · status:pendente";
+    $r = HealthCheckCommand::parseLessonLedger($md);
+    expect($r['overdue'])->toBe(['L-OP-003']);
+    expect($r['malformed'])->toBe([]);
+});
+
+test('parser do ledger: MEC sem check e bloco sem graduação são malformados', function () {
+    $md = <<<'MD'
+    ### L-OP-004 · MEC sem binding
+    - **Graduação:** MEC · status:done
+
+    ### L-OP-005 · sem linha de graduação
+    - **Erro:** algo
+    MD;
+
+    $r = HealthCheckCommand::parseLessonLedger($md);
+    expect($r['malformed'])->toBe(['L-OP-004', 'L-OP-005']);
+    expect($r['overdue'])->toBe([]);
+});
+
+test('ledger canônico Modules/Jana/LICOES-OPERACAO.md está todo graduado', function () {
+    $path = base_path('Modules/Jana/LICOES-OPERACAO.md');
+    expect(is_file($path))->toBeTrue('Ledger canônico ausente');
+
+    $r = HealthCheckCommand::parseLessonLedger((string) file_get_contents($path));
+    expect($r['total'])->toBeGreaterThanOrEqual(3);
+    expect($r['overdue'])->toBe([]);
+    expect($r['malformed'])->toBe([]);
 });

--- a/memory/decisions/proposals/jana-ledger-licoes-operacao-reflexion.md
+++ b/memory/decisions/proposals/jana-ledger-licoes-operacao-reflexion.md
@@ -1,0 +1,66 @@
+# Jana ganha um ledger de auto-reflexão de erros de OPERAÇÃO (Reflexion runtime) — 2026-06-02
+
+> **Status:** PROPOSAL §10.4 · **não-canon, não-ADR** · número de ADR **não cunhado** (soberania [W], ADR 0238 — [W] numera se promover).
+> **Tipo:** evolução de módulo (Modules/Jana) · **Tier 0** (toca governança de módulo) → PR aberto, **espera [W]**.
+> **Autor:** [CL] Claude Code · **Origem:** peer-review (L-17) do pedido [CC] `PROMPT_PARA_CODE_JANA-LICOES-REFLEXION.md` (sessão 2026-06-02, comparação [CC]×Jana×Champion — view `rep-cc-vs-jana` do `metricas.html`).
+> **Natureza:** peer-review, não ordem — [CL] avaliou se procede e onde mora melhor.
+
+---
+
+## 1. Veredito do peer-review: **procede** (aditivo, alto ROI, espelha padrão já aceito)
+
+O achado é real e checável contra `origin/main`:
+
+- A Jana já é estado-da-arte em erro de **saída** do LLM: golden de alucinação 30Q + RAGAS gate bloqueante + drift sentinel. ✅
+- A Jana **não tinha** o que o [CC] tem: um ledger dos próprios erros de **operação/comportamento** que **gradua cada um** em check ou regra — o padrão *Reflexion* (auto-reflexão verbal em memória persistente) aplicado ao runtime. ❌ → lacuna #1 no placar (Aprendizado-com-erro: Jana ~6.5 vs [CC] ~9.0).
+
+Não é mecanismo novo a construir: a infra de graduação **já existe** (`jana:health-check` é o harness; basta mais um check, igual `profile_distiller_drift`). O salto champion (Voyager) é a lição virar **artefato verificável**, não prosa — e o destino de toda lição MEC aqui já é um **check**. Atende os 4 testes da meta-skill (substitui memória humana do erro · repetitivo a cada incidente · ROI = erro evitado + onboarding · acelera autonomia).
+
+## 2. Passo 0 contra `origin/main` fresco (`de72198ae`) — onde mora, sem duplicar
+
+| Verifiquei | Achado | Decisão |
+|---|---|---|
+| `memory/LICOES_CC.md` / `APRENDER-COM-ERRO.md` | **Não estão no canon** — só em `prototipo-ui/_BACKUP-NAO-USAR/...` (design/[CC]) | Não duplico. O ledger da Jana é o **gêmeo runtime**, novo, escopo Jana. |
+| `memory/proibicoes.md` (34 KB, proibições globais Tier 0) | Cobre proibição **global**, não lição de operação de módulo | Não duplico. Regras JULG **globais** poderiam ir lá; JULG **escopo-Jana** vão no SCOPE/BRIEFING da Jana. |
+| `Modules/Jana/Console/Commands/HealthCheckCommand.php` | 10 checks duros + advisory (CharterHealthChecker); flag `advisory` já existe | **Estendi** com 1 check advisory — não recriei harness. |
+| `incident-done-checklist` / `feedback-capture` (skills) | Existem | **Estendi** (Bloco D / nota de fronteira) — não recriei. |
+| Erros já graduados | `mcp_webhook_5xx_2h` (L-OP-001) e `profile_distiller_drift` (L-OP-002) **já são checks** em `main` | Seed do ledger ancora em fatos do `main` → check verde no dia 1. |
+
+**Home canônico escolhido:** `Modules/Jana/LICOES-OPERACAO.md` (vive com o módulo, append-only, irmão runtime do ledger de design do [CC]). Lido pelo `jana:health-check` via `base_path()`.
+
+## 3. O que entra neste PR (tudo aditivo)
+
+1. **`Modules/Jana/LICOES-OPERACAO.md`** — ledger append-only. Formato `### L-OP-NNN` · Erro · Sintoma · Regra · Ref · **Graduação** (MEC→check / JULG→regra). Seed: 3 lições reais do `main` (webhook 5xx, profile drift, declarar-done-sem-smoke).
+2. **`jana:health-check` → check `jana_lesson_ledger_graduation`** (advisory) — parser determinístico valida o **loop de graduação**: acende amarelo se alguma lição está malformada ou `status:pendente`. Não derruba cron (drift de processo não pagina à noite). `parseLessonLedger()` é estático/puro → testável.
+3. **Pest** — 4 testes do parser (bem-formado / pendente→overdue / malformado / ledger canônico verde) + presença do check no smoke.
+4. **`Modules/Jana/SCOPE.md`** — registra o ledger + o check no `contains:`.
+5. **Skills (estendidas, não recriadas):** `incident-done-checklist` ganha **Bloco D** (gatilho: incidente de operação resolvido → append + graduar); `feedback-capture` ganha nota de fronteira (operação ≠ fricção de cliente).
+
+## 4. O loop de graduação (a 5ª camada [CC], agora no runtime)
+
+```
+incidente de operação resolvido
+        │  (incident-done-checklist Bloco D)
+        ▼
+append no ledger  ──►  Graduação:
+                         ├─ MEC  → vira check no jana:health-check  (igual profile_distiller_drift)
+                         └─ JULG → vira regra sempre-lida (SCOPE/BRIEFING Jana ou skill)
+        │
+        ▼
+check advisory jana_lesson_ledger_graduation acende amarelo
+enquanto houver lição pendente/malformada  (loop fechado por métrica · Constituição v2 §4)
+```
+
+## 5. O que NÃO é este pedido (anti-L-09/L-12 — não reprocessado)
+
+- ❌ Guard de higiene Cowork (`no-new-root-html`, L-07/11/21/22) — já pendente ("Loop de graduação de lição"). Este é o **gêmeo runtime**, não substituto.
+- ❌ Collector CT 100 + OTel + LGPD purge (#2073) — já pendente, falta só ENABLE Tier 0 de [W]. A comparação champion **confirma**; não adiciona trabalho.
+- ❌ Score/rubrica de design (`design:review` #2078) — já em `main`.
+
+## 6. Decisão aberta pra [W] (Tier 0)
+
+1. **Aprovar** o ledger como mecanismo canônico da Jana (vira canon ao mergear) — ou ajustar o home.
+2. **Numerar ADR** se quiser elevar de proposal a decisão (soberania [W] — não cunhei número).
+3. Confirmar que o check certo é **advisory** (não derruba cron) — minha recomendação é sim.
+
+— [CL], 2026-06-02. Não mergeei (Tier 0 · publication-policy). Retorno em `prototipo-ui/CODE_NOTES.md`.

--- a/prototipo-ui/CODE_NOTES.md
+++ b/prototipo-ui/CODE_NOTES.md
@@ -289,3 +289,38 @@ Só docs, mas mexe na família de governança do loop (`prototipo-ui/*` + `memor
 - **golden**: dedupe bundle duplo Financeiro (−327KB; paridade validada por [CL]: 2309 idênticas, 0 seletor real só-no-antigo, 30 OLD→CANON + `.rec-paper` eram todos `var(--surface)`→`#fff` no-op porque dark-theme nunca ativa).
 - **conflito**: 2 bundles Financeiro ~327KB ambos `@import`, antigo vence cascade — resolver adotando canon (feito #2127).
 - **lição**: token-discipline ratchet (C1) num bundle slated-for-delete vira trabalho perdido — mirar sempre o canon.
+
+---
+
+## 2026-06-02 (c) [CL] → [W]/[CC] — Jana ganha ledger de auto-reflexão de erros de OPERAÇÃO (Reflexion runtime)
+
+### Handoff: `PROMPT_PARA_CODE_JANA-LICOES-REFLEXION.md` (Cowork→Code) · racional `rep-cc-vs-jana` do `metricas.html`
+### Natureza: peer-review (L-17) · **Tier 0** (governança de módulo) → PR aberto, **NÃO mergeei**, espera [W]
+### Status: PR aberto · branch `feat/jana-ledger-licoes-operacao` · base `main` fresco (`de72198ae`)
+
+### Veredito do peer-review: **procede** (aditivo, ROI alto, espelha 5ª camada já aceita pro [CC])
+A Jana já pega erro de **saída** (golden 30Q + RAGAS + drift sentinel) mas não tinha o ledger dos próprios erros de **operação** que **gradua** cada um — lacuna #1 (Aprendizado ~6.5 vs [CC] ~9.0). Não é mecanismo novo: `jana:health-check` já é o harness; é só +1 check.
+
+### Passo 0 contra `origin/main` (não dupliquei nada):
+- `LICOES_CC`/`APRENDER-COM-ERRO` **não estão no canon** (só em `_BACKUP-NAO-USAR`, design/[CC]) → ledger da Jana é o **gêmeo runtime**, novo.
+- `proibicoes.md` = proibição global, não lição de operação → não toquei.
+- `incident-done-checklist` + `feedback-capture` + `jana:health-check` **estendidos**, não recriados.
+- **Achado que ancora**: `mcp_webhook_5xx_2h` e `profile_distiller_drift` **já são checks** em `main` → viraram seed (L-OP-001/002) → ledger nasce verde.
+
+### O que entrou (tudo aditivo):
+- `Modules/Jana/LICOES-OPERACAO.md` — ledger append-only · formato `### L-OP-NNN` · Erro·Sintoma·Regra·Ref·**Graduação** (MEC→check / JULG→regra) · 3 lições seed reais.
+- `jana:health-check` → check **advisory** `jana_lesson_ledger_graduation` (parser `parseLessonLedger()` puro/estático) — acende amarelo se lição malformada/`pendente`; não derruba cron.
+- Pest: 4 testes do parser (verde local, incl. ledger canônico) + presença no smoke. `php -l` limpo. Parser validado isolado: **ALL GREEN**.
+- `Modules/Jana/SCOPE.md` (+2 linhas) · `incident-done-checklist` **Bloco D** (gatilho) · `feedback-capture` nota de fronteira.
+- Proposta §10.4: `memory/decisions/proposals/jana-ledger-licoes-operacao-reflexion.md`.
+
+### Tier 0 respeitado:
+- **Não cunhei nº de ADR** (soberania [W], 0238) — é proposal slug-only. [W] numera se promover.
+- **Não mergeei** (publication-policy). PR espera [W].
+
+### Decisão aberta pra [W]:
+- [ ] Aprovar o ledger como mecanismo canônico da Jana (vira canon ao mergear) ou ajustar o home.
+- [ ] Numerar ADR se quiser elevar proposal → decisão.
+- [ ] Confirmar check **advisory** (recomendo sim — drift de processo não pagina à noite).
+
+### NÃO reprocessei (a comparação só confirma): guard higiene Cowork L-07/11/21/22 · collector CT100/OTel/LGPD #2073 · `design:review` #2078.


### PR DESCRIPTION
## Peer-review (§10.4 · L-17) · **Tier 0 — aguarda [W], NÃO mergear**

Resposta ao handoff Cowork `PROMPT_PARA_CODE_JANA-LICOES-REFLEXION.md` (origem: comparação [CC]×Jana×Champion, view `rep-cc-vs-jana` do `metricas.html`).

### Veredito: **procede** (aditivo, ROI alto, espelha 5ª camada já aceita pro [CC])
A Jana já é estado-da-arte em erro de **saída** (golden 30Q + RAGAS gate + drift sentinel), mas **não tinha** o ledger dos próprios erros de **operação** que **gradua** cada um em check/regra — o padrão **Reflexion** no runtime. Lacuna #1 do placar (Aprendizado ~6.5 vs [CC] ~9.0). Não é mecanismo novo: `jana:health-check` já é o harness — é só +1 check.

### Passo 0 contra `origin/main` fresco (`de72198ae`) — não dupliquei
- `LICOES_CC` / `APRENDER-COM-ERRO` **não estão no canon** (só em `_BACKUP-NAO-USAR`, design/[CC]) → o ledger da Jana é o **gêmeo runtime**, novo.
- `proibicoes.md` = proibição **global**, não lição de operação de módulo → intacto.
- `incident-done-checklist` + `feedback-capture` + `jana:health-check` **estendidos, não recriados**.
- **Ancora no main**: `mcp_webhook_5xx_2h` e `profile_distiller_drift` **já são checks** → viraram seed (L-OP-001/002) → ledger nasce **verde**.

### O que entra (tudo aditivo)
| Arquivo | O quê |
|---|---|
| `Modules/Jana/LICOES-OPERACAO.md` | Ledger append-only · `### L-OP-NNN` · Erro·Sintoma·Regra·Ref·**Graduação** (MEC→check / JULG→regra) · 3 seeds reais |
| `Console/Commands/HealthCheckCommand.php` | Check **advisory** `jana_lesson_ledger_graduation` + parser puro/estático `parseLessonLedger()` |
| `Tests/.../JanaHealthCheckTest.php` | +4 Pest (parser: ok / pendente→overdue / malformado / ledger canônico verde) + presença no smoke |
| `Modules/Jana/SCOPE.md` | Registra ledger + check |
| `incident-done-checklist/SKILL.md` | **Bloco D** — gatilho (incidente de operação resolvido → append + graduar) |
| `feedback-capture/SKILL.md` | Nota de fronteira (operação ≠ fricção de cliente) |
| `memory/decisions/proposals/jana-ledger-licoes-operacao-reflexion.md` | Proposta §10.4 (slug, **sem nº de ADR**) |
| `prototipo-ui/CODE_NOTES.md` | Retorno [CL]→[W] |

### O loop de graduação
\`\`\`
incidente de operação resolvido → (incident-done-checklist Bloco D) → append no ledger → Graduação:
   MEC  → vira check no jana:health-check (igual profile_distiller_drift)
   JULG → vira regra sempre-lida (SCOPE/BRIEFING da Jana ou skill)
check advisory jana_lesson_ledger_graduation acende amarelo enquanto houver lição pendente/malformada
\`\`\`

### Verificação local
- `php -l` limpo (command + test). Parser validado isolado contra o ledger canônico: **ALL GREEN** (3 lições, 0 overdue, 0 malformed). CI roda o Pest completo.

### Tier 0 — decisão aberta pra [W]
- [ ] Aprovar o ledger como mecanismo canônico da Jana (vira canon ao mergear) ou ajustar o home
- [ ] **Numerar ADR** se quiser elevar proposal → decisão (não cunhei número — soberania [W], ADR 0238)
- [ ] Confirmar check **advisory** (recomendo: sim — drift de processo não pagina à noite)

> **NÃO mergear sem [W]** (publication-policy · Tier 0). NÃO reprocessei: guard higiene Cowork L-07/11/21/22 · collector CT100/OTel/LGPD #2073 · `design:review` #2078 (a comparação só confirma).

🤖 Generated with [Claude Code](https://claude.com/claude-code)