### PR TITLE
feat(jana): Advisor Metade A — clarify reativo (Modo Consultor §10.4)

### DIFF
--- a/Modules/Jana/Ai/Agents/ClarificadorAgent.php
+++ b/Modules/Jana/Ai/Agents/ClarificadorAgent.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Ai\Agents;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Messages\Message;
+use Laravel\Ai\Promptable;
+use Modules\Jana\Support\ContextoNegocio;
+use Stringable;
+
+/**
+ * ClarificadorAgent — o "disambiguador" da cascata Decidir → Clarificar → Responder
+ * (Jana "Modo Consultor" / Advisor — Metade A, proposta §10.4).
+ *
+ * NÃO recria o chat — ESTENDE o conjunto de Agents da Jana (ChatCopilotoAgent /
+ * BriefDiarioAgent / SugestoesMetasAgent / BriefingAgent). Roda só no ~20% "cinza"
+ * que a heurística local (zero-custo) não resolveu — por isso pode ser frontier.
+ *
+ * Fundamento (estado-da-arte 2025):
+ *   - Active Task Disambiguation (ICLR 2025 Spotlight): "não é dar respostas melhores,
+ *     é fazer perguntas melhores" — pergunta de MAIOR ganho de informação.
+ *   - INTENT-SIM (NAACL 2025): decoupla AMBIGUIDADE-DE-INTENÇÃO (perguntar) de
+ *     FALTA-DE-DADO (buscar, não perguntar). É o erro nº1 dos LLMs.
+ *
+ * Roteamento de modelo (custo-consciente, §10.4 cross-cutting): raciocínio difícil →
+ * frontier. `provider()`/`model()` leem de config (`copiloto.clarify.*`) — o SDK
+ * laravel/ai honra esses métodos em runtime (Promptable::getProvidersAndModels).
+ * Default fica num modelo mais forte que o mini do chat, mas só dispara no cinza.
+ *
+ * Honestidade (anti-alucinação): o agente PODE responder tipo='claro' (heurística deu
+ * falso-positivo) e PODE deixar `pergunta` vazia mesmo em 'ambiguo' se não houver
+ * pergunta de alto valor — a cascata então responde normal. Nunca inventa pergunta.
+ *
+ * @see \Modules\Jana\Services\Ai\Clarify\ClarifyCascadeService
+ * @see \Modules\Jana\Support\ClarifyResult
+ */
+class ClarificadorAgent implements Agent, HasStructuredOutput
+{
+    use Promptable;
+
+    /**
+     * @param array<int, array{role: string, content: string}> $historicoRecente
+     *        Últimos turnos (já redigidos/PII-safe pela cascata) p/ resolver dêixis
+     *        ("aquele cliente", "isso", "e agora?"). Ordem cronológica.
+     */
+    public function __construct(
+        public readonly string $mensagem,
+        public readonly array $historicoRecente = [],
+        public readonly ?ContextoNegocio $ctx = null,
+    ) {
+    }
+
+    /**
+     * Provider de IA pro disambiguador. Null → cai no config('ai.default') (mesmo do chat).
+     * Configurável p/ rotear pra um provider frontier sem mexer em código.
+     */
+    public function provider(): ?string
+    {
+        $p = config('copiloto.clarify.provider');
+
+        return is_string($p) && $p !== '' ? $p : null;
+    }
+
+    /**
+     * Modelo pro raciocínio difícil. Null → default do provider. Default de config aponta
+     * pra um modelo mais forte que o mini do chat (gpt-4o) — "hard → frontier", seletivo.
+     */
+    public function model(): ?string
+    {
+        $m = config('copiloto.clarify.model');
+
+        return is_string($m) && $m !== '' ? $m : null;
+    }
+
+    public function instructions(): Stringable|string
+    {
+        $base = <<<PROMPT
+        Você é o módulo de DESAMBIGUAÇÃO do copiloto Jana (ERP de PMEs brasileiras).
+        Sua única função é decidir, ANTES da resposta, qual o tipo da mensagem do gestor.
+        Responda SEMPRE em português brasileiro. Você NÃO responde a pergunta do gestor —
+        você só classifica e, se for o caso, formula UMA pergunta de esclarecimento.
+
+        Classifique a última mensagem do gestor em UM tipo:
+
+        1. "claro" — a intenção é única e acionável. Responda direto (não pergunte).
+           Inclui saudações, agradecimentos e pedidos específicos com objeto definido.
+
+        2. "falta_dado" — a intenção é ÚNICA, mas falta um dado que a Jana BUSCA sozinha
+           (vendas, inadimplência, cliente X, fiscal...). NÃO pergunte ao gestor — a
+           resposta sai de uma tool/consulta. Ex: "quanto vendi ontem?" não é ambíguo:
+           é só buscar. PERGUNTAR aqui irrita.
+
+        3. "ambiguo" — há VÁRIAS leituras plausíveis e responder a errada custaria caro
+           ou re-trabalho. SÓ AQUI você pergunta. Ex: "melhora isso", "e aquele cliente?",
+           "resolve pra mim", "manda a régua" (qual? pra quem?).
+
+        REGRA DE OURO (decoupling INTENT-SIM): não confunda "eu não sei o dado" (→ falta_dado,
+        busca) com "há várias intenções" (→ ambiguo, pergunta). Perguntar quando é só falta
+        de dado é o erro nº1 — não cometa.
+
+        QUANDO for "ambiguo", gere a pergunta de MAIOR GANHO DE INFORMAÇÃO: a que mais
+        SEPARA as leituras candidatas (não a primeira que vier, não genérica). Curta, direta,
+        no máximo 1 frase, oferecendo as opções quando ajudar ("Você quer A ou B?").
+
+        HONESTIDADE: se não houver leitura realmente concorrente, classifique "claro" ou
+        "falta_dado" e deixe "pergunta" vazia. NÃO invente ambiguidade pra parecer útil.
+        Se o gestor está RESPONDENDO a uma pergunta sua anterior (veja o histórico),
+        classifique "claro" — não pergunte de novo.
+        PROMPT;
+
+        $partes = [$base];
+
+        // Grounding leve (não-PII): números agregados ajudam a formular a pergunta certa
+        // ("você quer dizer a queda de 68% em maio?"). Nome/observações já vêm sanitizados.
+        if ($this->ctx !== null) {
+            $partes[] = $this->hintNegocio($this->ctx);
+        }
+
+        return implode("\n\n", $partes);
+    }
+
+    /**
+     * Schema do veredito. `pergunta` e `intencoes` são opcionais (honestidade: vazio é válido).
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'tipo' => $schema->string()->enum(['claro', 'falta_dado', 'ambiguo'])->required(),
+            'confianca' => $schema->number()->description('0..1 — confiança na classificação')->required(),
+            'pergunta' => $schema->string()->description('Pergunta de maior ganho de info. Vazia se não for ambiguo OU se não houver pergunta de alto valor.'),
+            'intencoes' => $schema->array()->items($schema->string())->description('Leituras candidatas que você enxergou (2-4). Vazio se claro.'),
+        ];
+    }
+
+    /**
+     * Prompt operacional — a mensagem a classificar. Mantido curto (decisão barata).
+     */
+    public function montarPrompt(): string
+    {
+        return "Mensagem do gestor a classificar:\n\"{$this->mensagem}\"\n\n"
+            . 'Classifique conforme as instruções e, se ambíguo, formule a pergunta de maior ganho.';
+    }
+
+    /**
+     * Injeta histórico recente (já PII-safe) p/ resolver dêixis e detectar
+     * "gestor respondendo pergunta anterior".
+     *
+     * @return iterable<Message>
+     */
+    public function messages(): iterable
+    {
+        $msgs = [];
+        foreach ($this->historicoRecente as $m) {
+            $role = ($m['role'] ?? 'user') === 'assistant' ? 'assistant' : 'user';
+            $content = (string) ($m['content'] ?? '');
+            if ($content !== '') {
+                $msgs[] = new Message($role, $content);
+            }
+        }
+
+        return $msgs;
+    }
+
+    /**
+     * Resumo NÃO-PII do negócio (números/contagens/labels) p/ grounding da pergunta.
+     */
+    protected function hintNegocio(ContextoNegocio $ctx): string
+    {
+        $linhas = ['CONTEXTO (só p/ formular a pergunta — não é a resposta):'];
+        $linhas[] = 'Empresa: ' . $ctx->businessName;
+
+        if ($ctx->clientesAtivos > 0) {
+            $linhas[] = "Clientes ativos: {$ctx->clientesAtivos}";
+        }
+
+        if (! empty($ctx->faturamento90d)) {
+            // Cópia local — `end()` é by-ref e ContextoNegocio::$faturamento90d é readonly.
+            $fat = $ctx->faturamento90d;
+            $ultimo = end($fat);
+            $bruto = (float) ($ultimo['bruto'] ?? $ultimo['valor'] ?? 0);
+            $linhas[] = sprintf('Faturamento mês recente (%s): R$ %s', $ultimo['mes'] ?? '?', number_format($bruto, 2, ',', '.'));
+        }
+
+        if (! empty($ctx->metasAtivas)) {
+            $nomes = collect($ctx->metasAtivas)->pluck('nome')->filter()->implode(', ');
+            if ($nomes !== '') {
+                $linhas[] = 'Metas ativas: ' . $nomes;
+            }
+        }
+
+        if (! empty($ctx->modulosAtivos)) {
+            $linhas[] = 'Módulos ativos: ' . implode(', ', $ctx->modulosAtivos);
+        }
+
+        return implode("\n", $linhas);
+    }
+}

--- a/Modules/Jana/Ai/Agents/ClarificadorAgent.php
+++ b/Modules/Jana/Ai/Agents/ClarificadorAgent.php
@@ -155,8 +155,8 @@ class ClarificadorAgent implements Agent, HasStructuredOutput
     {
         $msgs = [];
         foreach ($this->historicoRecente as $m) {
-            $role = ($m['role'] ?? 'user') === 'assistant' ? 'assistant' : 'user';
-            $content = (string) ($m['content'] ?? '');
+            $role = $m['role'] === 'assistant' ? 'assistant' : 'user';
+            $content = $m['content'];
             if ($content !== '') {
                 $msgs[] = new Message($role, $content);
             }
@@ -181,8 +181,8 @@ class ClarificadorAgent implements Agent, HasStructuredOutput
             // Cópia local — `end()` é by-ref e ContextoNegocio::$faturamento90d é readonly.
             $fat = $ctx->faturamento90d;
             $ultimo = end($fat);
-            $bruto = (float) ($ultimo['bruto'] ?? $ultimo['valor'] ?? 0);
-            $linhas[] = sprintf('Faturamento mês recente (%s): R$ %s', $ultimo['mes'] ?? '?', number_format($bruto, 2, ',', '.'));
+            $bruto = (float) $ultimo['bruto'];
+            $linhas[] = sprintf('Faturamento mês recente (%s): R$ %s', $ultimo['mes'], number_format($bruto, 2, ',', '.'));
         }
 
         if (! empty($ctx->metasAtivas)) {

--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -476,21 +476,26 @@ return [
     |
     | Medição: log channel copiloto-ai → evento `clarify_event` (gray-hit, taxa de
     | clarify, false-clarify proxy). Sem isso é fé, não engenharia.
+    |
+    | VALORES DIRETOS, SEM env() — Larastan barra env() fora de config/ raiz (mesma
+    | razão do bloco peso_real). Default OFF. Pra LIGAR em homolog, Wagner seta via
+    | config() runtime (`config(['copiloto.clarify.enabled' => true])`) ou registra
+    | override no published config/copiloto.php. O `model` aponta um frontier (gpt-4o,
+    | mais forte que o gpt-4o-mini do chat); trocável pelo mesmo caminho.
     */
     'clarify' => [
-        'enabled'      => (bool) env('JANA_CLARIFY_ENABLED', false),
-        // Roteamento de modelo seletivo (difícil → frontier). null = default do provider.
-        'provider'     => env('JANA_CLARIFY_PROVIDER'),                 // null → config('ai.default')
-        'model'        => env('JANA_CLARIFY_MODEL', 'gpt-4o'),          // frontier (vs gpt-4o-mini do chat)
+        'enabled'  => false,            // default OFF — Wagner liga em homolog (config runtime/published)
+        'provider' => null,             // null → config('ai.default') (mesmo provider do chat)
+        'model'    => 'gpt-4o',         // roteamento seletivo difícil → frontier (vs gpt-4o-mini do chat)
         // Confiança mínima do disambiguador p/ realmente perguntar (anti false-clarify).
-        'min_confianca'         => (float) env('JANA_CLARIFY_MIN_CONFIANCA', 0.6),
+        'min_confianca'          => 0.6,
         // Heurística 1a (zero-custo) — limites do "cinza".
-        'gray_max_chars'        => (int) env('JANA_CLARIFY_GRAY_MAX_CHARS', 140),
-        'gray_max_words'        => (int) env('JANA_CLARIFY_GRAY_MAX_WORDS', 8),
+        'gray_max_chars'         => 140,
+        'gray_max_words'         => 8,
         // Quantos turnos recentes (PII-redigidos) alimentam o disambiguador.
-        'historico_turnos'      => (int) env('JANA_CLARIFY_HISTORICO_TURNOS', 4),
-        // Anti-loop: TTL do marcador "turno anterior foi clarify" (não pergunta 2x seguidas).
-        'anti_loop_ttl_segundos' => (int) env('JANA_CLARIFY_ANTI_LOOP_TTL', 600),
+        'historico_turnos'       => 4,
+        // Anti-loop: TTL (s) do marcador "turno anterior foi clarify" (não pergunta 2x seguidas).
+        'anti_loop_ttl_segundos' => 600,
     ],
 
     /*

--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -454,6 +454,47 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | JANA ADVISOR — Metade A: Clarify reativo (Modo Consultor, proposta §10.4)
+    |--------------------------------------------------------------------------
+    | Cascata Decidir → Clarificar → Responder no chat. Decoupla AMBIGUIDADE-DE-
+    | INTENÇÃO (perguntar) de FALTA-DE-DADO (buscar) — INTENT-SIM (NAACL 2025) +
+    | Active Task Disambiguation (ICLR 2025): "fazer perguntas melhores, não só
+    | dar respostas melhores".
+    |
+    | Cascata por latência:
+    |   1a. heurística local (zero LLM) resolve ~80% direto → responde.
+    |   1b. disambiguador FRONTIER (só no ~20% cinza) decide e gera a pergunta de
+    |       maior ganho de informação.
+    |
+    | DEFAULT OFF (toca o coração do chat — mesma postura de contextual_retrieval /
+    | peso_real): com a flag OFF o pipeline é byte-idêntico ao legado. Wagner liga
+    | em homolog após validação ([W] soberania ADR 0238).
+    |
+    | Roteamento de modelo (custo-consciente): raciocínio difícil → frontier. Default
+    | gpt-4o (mais forte que o gpt-4o-mini do chat), mas só dispara no cinza. Wagner
+    | pode trocar p/ um modelo de raciocínio estendido via JANA_CLARIFY_MODEL.
+    |
+    | Medição: log channel copiloto-ai → evento `clarify_event` (gray-hit, taxa de
+    | clarify, false-clarify proxy). Sem isso é fé, não engenharia.
+    */
+    'clarify' => [
+        'enabled'      => (bool) env('JANA_CLARIFY_ENABLED', false),
+        // Roteamento de modelo seletivo (difícil → frontier). null = default do provider.
+        'provider'     => env('JANA_CLARIFY_PROVIDER'),                 // null → config('ai.default')
+        'model'        => env('JANA_CLARIFY_MODEL', 'gpt-4o'),          // frontier (vs gpt-4o-mini do chat)
+        // Confiança mínima do disambiguador p/ realmente perguntar (anti false-clarify).
+        'min_confianca'         => (float) env('JANA_CLARIFY_MIN_CONFIANCA', 0.6),
+        // Heurística 1a (zero-custo) — limites do "cinza".
+        'gray_max_chars'        => (int) env('JANA_CLARIFY_GRAY_MAX_CHARS', 140),
+        'gray_max_words'        => (int) env('JANA_CLARIFY_GRAY_MAX_WORDS', 8),
+        // Quantos turnos recentes (PII-redigidos) alimentam o disambiguador.
+        'historico_turnos'      => (int) env('JANA_CLARIFY_HISTORICO_TURNOS', 4),
+        // Anti-loop: TTL do marcador "turno anterior foi clarify" (não pergunta 2x seguidas).
+        'anti_loop_ttl_segundos' => (int) env('JANA_CLARIFY_ANTI_LOOP_TTL', 600),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Onda 5 — A1 Auto-summary docs longos (dossier 2026-05-13 §6)
     |--------------------------------------------------------------------------
     | AutoSummarizerService (Modules/Jana/Services/Summarizer/) comprime

--- a/Modules/Jana/Services/Ai/Clarify/ClarifyCascadeService.php
+++ b/Modules/Jana/Services/Ai/Clarify/ClarifyCascadeService.php
@@ -1,0 +1,285 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Services\Ai\Clarify;
+
+use App\Util\OtelHelper;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Ai\Agents\ClarificadorAgent;
+use Modules\Jana\Entities\Conversa;
+use Modules\Jana\Services\Privacy\PiiRedactor;
+use Modules\Jana\Support\ClarifyResult;
+use Modules\Jana\Support\ContextoNegocio;
+use Throwable;
+
+/**
+ * ClarifyCascadeService — orquestra a cascata Decidir → Clarificar → Responder do
+ * "Modo Consultor" (Advisor — Metade A, proposta §10.4).
+ *
+ * Cascata por LATÊNCIA (senão mata o tempo de resposta):
+ *   Estágio 1a — HEURÍSTICA LOCAL (zero LLM): resolve ~80% direto. Default = "responder";
+ *                só cai pro cinza se a mensagem tem cara de ambígua (curta + dêitica +
+ *                imperativo solto, sem objeto concreto). Latência ~µs.
+ *   Estágio 1b — DISAMBIGUADOR (frontier, só no cinza ~20%): ClarificadorAgent decide
+ *                ambiguo vs falta_dado vs claro e, se ambíguo, dá a pergunta de maior ganho.
+ *
+ * Princípios duros desta peça:
+ *   - FAIL-OPEN: QUALQUER erro/exceção → 'responder' (a cascata NUNCA quebra o chat).
+ *   - HONESTIDADE: não inventa pergunta; só clarifica quando o disambiguador devolve uma.
+ *   - ANTI-LOOP: se o turno anterior já foi um clarify, não pergunta de novo (TTL cache).
+ *   - MEDIÇÃO: loga `clarify_event` (gray-hit, false-clarify proxy) — engenharia, não fé.
+ *   - TIER 0: histórico/contexto vão PII-redigidos pro LLM (defense-in-depth).
+ *
+ * @see \Modules\Jana\Ai\Agents\ClarificadorAgent
+ * @see \Modules\Jana\Support\ClarifyResult
+ */
+class ClarifyCascadeService
+{
+    public function __construct(
+        protected PiiRedactor $pii,
+    ) {
+    }
+
+    /**
+     * Decide se a Jana deve clarificar antes de responder.
+     *
+     * @param string $original  Mensagem crua do user (heurística local usa esta — sinal melhor).
+     * @param string $redigida  Mensagem já PII-redigida (é a que vai pro LLM).
+     */
+    public function decidir(Conversa $conv, string $original, string $redigida, ?ContextoNegocio $ctx = null): ClarifyResult
+    {
+        if (! (bool) config('copiloto.clarify.enabled', false)) {
+            return ClarifyResult::responder('claro', 'flag_off');
+        }
+
+        try {
+            return OtelHelper::span('jana.clarify.decidir', [
+                'business_id' => $conv->business_id,
+                'conversa_id' => $conv->id,
+            ], fn () => $this->decidirInternal($conv, $original, $redigida, $ctx));
+        } catch (Throwable $e) {
+            // FAIL-OPEN absoluto — clarify nunca derruba o chat.
+            Log::channel('copiloto-ai')->warning('clarify cascade falhou (fail-open → responder)', [
+                'conversa_id' => $conv->id,
+                'error' => mb_substr($e->getMessage(), 0, 200),
+            ]);
+
+            return ClarifyResult::responder('claro', 'erro_fail_open');
+        }
+    }
+
+    protected function decidirInternal(Conversa $conv, string $original, string $redigida, ?ContextoNegocio $ctx): ClarifyResult
+    {
+        // ANTI-LOOP — se o turno anterior já foi um clarify, o user provavelmente está
+        // respondendo. Consome o marcador e responde (não pergunta de novo).
+        if ($this->turnoAnteriorFoiClarify($conv)) {
+            $this->limparMarcadorClarify($conv);
+            $resultado = ClarifyResult::responder('claro', 'anti_loop_resposta_a_clarify');
+            $this->logEvento($conv, $original, $resultado);
+
+            return $resultado;
+        }
+
+        // ESTÁGIO 1a — heurística local (zero LLM). Default = responder.
+        if (! $this->pareceCinza($original)) {
+            $resultado = ClarifyResult::responder('claro', 'heuristica_acionavel');
+            $this->logEvento($conv, $original, $resultado);
+
+            return $resultado;
+        }
+
+        // ESTÁGIO 1b — cinza: paga o disambiguador frontier.
+        $resultado = $this->disambiguar($conv, $redigida, $ctx);
+
+        if ($resultado->deveClarificar()) {
+            $this->marcarClarify($conv);
+        }
+
+        $this->logEvento($conv, $original, $resultado);
+
+        return $resultado;
+    }
+
+    /**
+     * Estágio 1b — chama o ClarificadorAgent (structured output, frontier) e marshaliza
+     * o veredito em ClarifyResult. Honestidade: ambiguo SEM pergunta de alto valor → responde.
+     */
+    protected function disambiguar(Conversa $conv, string $redigida, ?ContextoNegocio $ctx): ClarifyResult
+    {
+        $historico = $this->historicoRedigido($conv);
+
+        $agent = new ClarificadorAgent(
+            mensagem: $redigida,
+            historicoRecente: $historico,
+            ctx: $ctx,
+        );
+
+        $resp = $agent->prompt($agent->montarPrompt());
+
+        $tipo = (string) ($resp['tipo'] ?? 'claro');
+        $confianca = isset($resp['confianca']) ? (float) $resp['confianca'] : null;
+        $pergunta = trim((string) ($resp['pergunta'] ?? ''));
+        $intencoes = is_array($resp['intencoes'] ?? null) ? array_values(array_filter(array_map('strval', $resp['intencoes']))) : [];
+
+        // Gate de confiança — abaixo do mínimo, responde (não arrisca falso-clarify).
+        $minConfianca = (float) config('copiloto.clarify.min_confianca', 0.6);
+
+        if ($tipo === 'ambiguo' && $pergunta !== '' && ($confianca === null || $confianca >= $minConfianca)) {
+            return ClarifyResult::clarificar($pergunta, 'llm_ambiguo', $confianca, $intencoes);
+        }
+
+        // Honestidade: ambiguo sem pergunta / baixa confiança / falta_dado / claro → responde.
+        $tipoNormalizado = in_array($tipo, ['claro', 'falta_dado', 'ambiguo'], true) ? $tipo : 'claro';
+
+        return ClarifyResult::responder(
+            $tipoNormalizado,
+            $tipo === 'ambiguo' ? 'llm_ambiguo_sem_pergunta_ou_baixa_confianca' : "llm_{$tipoNormalizado}",
+            custoLlm: true,
+            confianca: $confianca,
+        );
+    }
+
+    /**
+     * Estágio 1a — heurística "parece cinza?" (zero-custo). Conservadora: default = NÃO
+     * (responde). Só vira cinza quando há SINAL forte de ambiguidade. Tunável via config.
+     *
+     * Sinais de cinza:
+     *   - Mensagem curta E (dêixis sem antecedente concreto OU imperativo solto sem objeto).
+     * Sinais de NÃO-cinza (curto-circuito p/ "responder"):
+     *   - Vazia/saudação/agradecimento, longa (já específica), ou termina com '?' tendo objeto.
+     */
+    public function pareceCinza(string $msg): bool
+    {
+        $t = trim(mb_strtolower($msg));
+
+        if ($t === '') {
+            return false;
+        }
+
+        // Longa o bastante = já tem especificidade suficiente → responde.
+        $maxChars = (int) config('copiloto.clarify.gray_max_chars', 140);
+        if (mb_strlen($t) > $maxChars) {
+            return false;
+        }
+
+        $palavras = preg_split('/\s+/u', $t) ?: [];
+        $nPalavras = count(array_filter($palavras, fn ($p) => $p !== ''));
+
+        $maxPalavras = (int) config('copiloto.clarify.gray_max_words', 8);
+        if ($nPalavras > $maxPalavras) {
+            return false;
+        }
+
+        // Saudações / social puro → responde (não clarifica).
+        if (preg_match('/^(oi|ol[áa]|e a[íi]|bom dia|boa tarde|boa noite|obrigad[oa]|valeu|tchau|blz|beleza)\b/iu', $t)) {
+            return false;
+        }
+
+        // Dêixis/anáfora sem antecedente concreto (precisa de contexto → cinza).
+        $deiticos = config('copiloto.clarify.deiticos', [
+            'isso', 'isto', 'aquilo', 'aquele', 'aquela', 'aqueles', 'aquelas',
+            'esse', 'essa', 'esses', 'essas', 'ele', 'ela', 'eles', 'elas',
+            'l[áa]', 'ali', 'disso', 'nisso', 'desse', 'dessa', 'assim',
+        ]);
+        $reDeitico = '/\b(' . implode('|', $deiticos) . ')\b/iu';
+        $temDeitico = (bool) preg_match($reDeitico, $t);
+
+        // Imperativo solto (verbo de ação sem objeto definido).
+        $imperativos = config('copiloto.clarify.imperativos', [
+            'manda', 'mande', 'envia', 'envie', 'cria', 'crie', 'faz', 'faça', 'fazer',
+            'resolve', 'resolva', 'analisa', 'analise', 'melhora', 'melhore', 'arruma',
+            'arrume', 'gera', 'gere', 'dispara', 'dispare', 'mostra', 'mostre', 'ajusta', 'ajuste',
+        ]);
+        $reImper = '/^\s*(' . implode('|', $imperativos) . ')\b/iu';
+        $imperativoSolto = preg_match($reImper, $t) && $nPalavras <= 4;
+
+        // Pergunta curta E vaga: só é cinza se tiver dêixis OU casar um "stem vago"
+        // ("e agora?", "como tá?", "e aí?"). Uma pergunta curta MAS específica
+        // ("quanto vendi ontem?") NÃO é cinza — é falta_dado, responde direto.
+        $stemsVagos = config('copiloto.clarify.stems_vagos', [
+            'e agora', 'e a[íi]', 'e da[íi]', 'e ent[ãa]o', 'como assim',
+            'como t[áa]', 'como est[áa]', 'que mais', 'pode ser', 'tipo o que',
+        ]);
+        $reStem = '/^\s*(' . implode('|', $stemsVagos) . ')\b/iu';
+        $perguntaVaga = str_ends_with($t, '?')
+            && $nPalavras <= $maxPalavras
+            && ($temDeitico || (bool) preg_match($reStem, $t));
+
+        return ($temDeitico && $nPalavras <= $maxPalavras) || $imperativoSolto || $perguntaVaga;
+    }
+
+    /**
+     * Últimos turnos da conversa, PII-redigidos, p/ alimentar o disambiguador
+     * (resolução de dêixis + detecção de "respondendo pergunta anterior").
+     *
+     * @return array<int, array{role: string, content: string}>
+     */
+    protected function historicoRedigido(Conversa $conv): array
+    {
+        $limite = (int) config('copiloto.clarify.historico_turnos', 4);
+
+        try {
+            return $conv->mensagens()
+                ->whereIn('role', ['user', 'assistant'])
+                ->orderByDesc('created_at')
+                ->limit($limite)
+                ->get(['role', 'content'])
+                ->reverse()
+                ->map(fn ($m) => [
+                    'role' => (string) $m->role,
+                    'content' => $this->pii->redact((string) $m->content),
+                ])
+                ->values()
+                ->all();
+        } catch (Throwable) {
+            return [];
+        }
+    }
+
+    protected function turnoAnteriorFoiClarify(Conversa $conv): bool
+    {
+        return (bool) Cache::get($this->cacheKeyClarify($conv));
+    }
+
+    protected function marcarClarify(Conversa $conv): void
+    {
+        $ttl = (int) config('copiloto.clarify.anti_loop_ttl_segundos', 600);
+        Cache::put($this->cacheKeyClarify($conv), true, $ttl);
+    }
+
+    protected function limparMarcadorClarify(Conversa $conv): void
+    {
+        Cache::forget($this->cacheKeyClarify($conv));
+    }
+
+    protected function cacheKeyClarify(Conversa $conv): string
+    {
+        return "jana:clarify:last:{$conv->id}";
+    }
+
+    /**
+     * MEDIÇÃO — `clarify_event` no channel copiloto-ai. Permite calcular:
+     *   - gray-hit rate   = eventos com custo_llm=true / total
+     *   - false-clarify    = clarify em mensagem que depois o user ignorou (cruzar com ação)
+     *   - taxa de clarify  = acao=clarificar / total
+     */
+    protected function logEvento(Conversa $conv, string $original, ClarifyResult $r): void
+    {
+        try {
+            Log::channel('copiloto-ai')->info('clarify_event', [
+                'business_id' => $conv->business_id !== null ? (int) $conv->business_id : null,
+                'conversa_id' => (int) $conv->id,
+                'acao' => $r->acao,
+                'tipo' => $r->tipo,
+                'motivo' => $r->motivo,
+                'custo_llm' => $r->custoLlm,
+                'confianca' => $r->confianca,
+                'msg_chars' => mb_strlen($original),
+            ]);
+        } catch (Throwable) {
+            // Medição nunca quebra a cascata.
+        }
+    }
+}

--- a/Modules/Jana/Services/Ai/Clarify/ClarifyCascadeService.php
+++ b/Modules/Jana/Services/Ai/Clarify/ClarifyCascadeService.php
@@ -56,8 +56,8 @@ class ClarifyCascadeService
 
         try {
             return OtelHelper::span('jana.clarify.decidir', [
-                'business_id' => $conv->business_id,
-                'conversa_id' => $conv->id,
+                'business_id' => $conv->getAttribute('business_id'),
+                'conversa_id' => $conv->getAttribute('id'),
             ], fn () => $this->decidirInternal($conv, $original, $redigida, $ctx));
         } catch (Throwable $e) {
             // FAIL-OPEN absoluto — clarify nunca derruba o chat.
@@ -228,8 +228,8 @@ class ClarifyCascadeService
                 ->get(['role', 'content'])
                 ->reverse()
                 ->map(fn ($m) => [
-                    'role' => (string) $m->role,
-                    'content' => $this->pii->redact((string) $m->content),
+                    'role' => (string) $m->getAttribute('role'),
+                    'content' => $this->pii->redact((string) $m->getAttribute('content')),
                 ])
                 ->values()
                 ->all();
@@ -268,9 +268,10 @@ class ClarifyCascadeService
     protected function logEvento(Conversa $conv, string $original, ClarifyResult $r): void
     {
         try {
+            $bizId = $conv->getAttribute('business_id');
             Log::channel('copiloto-ai')->info('clarify_event', [
-                'business_id' => $conv->business_id !== null ? (int) $conv->business_id : null,
-                'conversa_id' => (int) $conv->id,
+                'business_id' => $bizId !== null ? (int) $bizId : null,
+                'conversa_id' => (int) $conv->getAttribute('id'),
                 'acao' => $r->acao,
                 'tipo' => $r->tipo,
                 'motivo' => $r->motivo,

--- a/Modules/Jana/Services/Ai/LaravelAiSdkDriver.php
+++ b/Modules/Jana/Services/Ai/LaravelAiSdkDriver.php
@@ -152,20 +152,31 @@ class LaravelAiSdkDriver implements AiAdapter
             }
         }
 
+        // COPI-43 (LGPD): redacta PII BR antes de enviar pro LLM externo (vide responderChat).
+        $mensagemPraLlm = $this->mascararDocumentos($mensagem);
+
+        // MEM-HOT-2 — snapshot de contexto (reusado pela cascata clarify E pelo chat).
+        $ctx = $this->snapshotContexto($conv);
+
+        // JANA ADVISOR (Metade A — clarify reativo, proposta §10.4). Cascata
+        // Decidir→Clarificar→Responder ANTES do recall/LLM: se a entrada é AMBÍGUA de
+        // intenção, a Jana devolve a pergunta de maior ganho em vez de chutar. Flag
+        // default-OFF; fail-open → segue normal. A pergunta vai como 1 chunk e termina.
+        if ($pergunta = $this->talvezClarificar($conv, $mensagem, $mensagemPraLlm, $ctx)) {
+            yield $pergunta;
+            return;
+        }
+
         // Mesma pipeline do responderChat() blocking — DRY.
         $recall = $this->recallMemoria($conv, $mensagem);
         $memoriaContexto = $recall['texto'];
         $memoriaIds = $recall['ids'];
-        $ctx = $this->snapshotContexto($conv);
         $agent = new ChatCopilotoAgent($conv, $memoriaContexto, $ctx);
 
         $startedAt = microtime(true);
         $tokensIn = 0;
         $tokensOut = 0;
         $textoCompleto = '';
-
-        // COPI-43 (LGPD): redacta PII BR antes de enviar pro LLM externo (vide responderChat).
-        $mensagemPraLlm = $this->mascararDocumentos($mensagem);
 
         try {
             // laravel/ai Agent::stream() — retorna StreamableAgentResponse iterável.
@@ -283,26 +294,35 @@ class LaravelAiSdkDriver implements AiAdapter
             }
         }
 
-        // Sprint 5 (ADR 0036) — recall de memória semântica antes de chamar LLM.
-        $recall = $this->recallMemoria($conv, $mensagem);
-        $memoriaContexto = $recall['texto'];
-        $memoriaIds = $recall['ids'];
-
         // MEM-HOT-2 (ADR 0047, Caminho A do ADR 0046) — snapshot de contexto de
         // negócio (faturamento/clientes/metas reais) injetado no system prompt.
         // Cache 10min em ContextSnapshotService; degradação silenciosa em erro.
+        // Subido p/ ANTES do recall: reusado pela cascata clarify E pelo chat.
         $ctx = $this->snapshotContexto($conv);
-
-        $agent = new ChatCopilotoAgent($conv, $memoriaContexto, $ctx);
-
-        // MEM-OTEL-1 (ADR 0051) — clock pra medir gen_ai.response.duration_ms
-        $startedAt = microtime(true);
 
         // COPI-43 (LGPD): redacta PII BR antes de enviar pro LLM externo.
         // Mensagem original já persistida em jana_mensagens pelo controller — NÃO afeta
         // visualização do user no chat (que vê dado real). Recall memória usa $mensagem
         // original (busca interna, não sai pra rede). Aqui apenas o que vai pra OpenAI.
         $mensagemPraLlm = $this->mascararDocumentos($mensagem);
+
+        // JANA ADVISOR (Metade A — clarify reativo, proposta §10.4). Cascata
+        // Decidir→Clarificar→Responder ANTES do recall/LLM: se a entrada é AMBÍGUA de
+        // intenção, devolve a pergunta de maior ganho em vez de chutar. Flag default-OFF;
+        // fail-open → segue normal. Sai sem gravar cache nem extrair fatos (não houve resposta).
+        if ($pergunta = $this->talvezClarificar($conv, $mensagem, $mensagemPraLlm, $ctx)) {
+            return $pergunta;
+        }
+
+        // Sprint 5 (ADR 0036) — recall de memória semântica antes de chamar LLM.
+        $recall = $this->recallMemoria($conv, $mensagem);
+        $memoriaContexto = $recall['texto'];
+        $memoriaIds = $recall['ids'];
+
+        $agent = new ChatCopilotoAgent($conv, $memoriaContexto, $ctx);
+
+        // MEM-OTEL-1 (ADR 0051) — clock pra medir gen_ai.response.duration_ms
+        $startedAt = microtime(true);
 
         try {
             $response = $agent->prompt($mensagemPraLlm);
@@ -619,6 +639,45 @@ class LaravelAiSdkDriver implements AiAdapter
                 'business_id' => $conv->business_id,
                 'error' => $e->getMessage(),
             ]);
+            return null;
+        }
+    }
+
+    /**
+     * JANA ADVISOR (Metade A — clarify reativo, proposta §10.4).
+     *
+     * Roda a cascata Decidir→Clarificar→Responder via ClarifyCascadeService. Retorna a
+     * PERGUNTA de maior ganho de informação quando a entrada é ambígua de intenção, ou
+     * `null` quando o chat deve seguir e responder normalmente.
+     *
+     * Contrato de segurança:
+     *   - Flag `copiloto.clarify.enabled` default-OFF → retorna null sem custo (no-op).
+     *   - FAIL-OPEN: o service captura tudo internamente; aqui ainda há try/catch de
+     *     defense-in-depth pra NUNCA quebrar o chat por causa do advisor.
+     *
+     * `$ctx` é reusado (já snapshotado/sanitizado) pra não duplicar consulta.
+     */
+    protected function talvezClarificar(
+        Conversa $conv,
+        string $mensagemOriginal,
+        string $mensagemRedigida,
+        ?ContextoNegocio $ctx,
+    ): ?string {
+        if (! (bool) config('copiloto.clarify.enabled', false)) {
+            return null;
+        }
+
+        try {
+            $resultado = app(\Modules\Jana\Services\Ai\Clarify\ClarifyCascadeService::class)
+                ->decidir($conv, $mensagemOriginal, $mensagemRedigida, $ctx);
+
+            return $resultado->deveClarificar() ? $resultado->pergunta : null;
+        } catch (\Throwable $e) {
+            Log::channel('copiloto-ai')->warning('talvezClarificar fail-open (segue resposta)', [
+                'conversa_id' => $conv->id,
+                'error' => $this->redactErrorMessage($e),
+            ]);
+
             return null;
         }
     }

--- a/Modules/Jana/Support/ClarifyResult.php
+++ b/Modules/Jana/Support/ClarifyResult.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Support;
+
+/**
+ * ClarifyResult — DTO imutável do resultado da cascata Decidir → Clarificar → Responder
+ * (Jana "Modo Consultor" / Advisor — Metade A, proposta §10.4).
+ *
+ * Decoupla os dois erros nº1 dos LLMs (INTENT-SIM, NAACL 2025):
+ *   - AMBÍGUO de intenção → várias leituras plausíveis → PERGUNTAR (a IA não chuta).
+ *   - FALTA de dado       → resposta única, só precisa buscar → NÃO perguntar, responde via tool/RAG.
+ *   - CLARO               → entrada acionável direto → responde.
+ *
+ * `acao`:
+ *   - 'responder'  → segue o pipeline normal (ChatCopilotoAgent). Default seguro.
+ *   - 'clarificar' → a IA devolve `pergunta` (a de MAIOR ganho de informação) em vez de responder.
+ *
+ * `custoLlm` registra se a decisão consumiu uma chamada ao disambiguador (frontier) — só ~20%
+ * "cinza" devem pagar isso (cascata p/ latência). Serve à medição de false-clarify / gray-hit.
+ */
+final class ClarifyResult
+{
+    public function __construct(
+        public readonly string $acao,            // 'responder' | 'clarificar'
+        public readonly ?string $pergunta,       // pergunta de maior ganho (só quando 'clarificar')
+        public readonly string $tipo,            // 'claro' | 'ambiguo' | 'falta_dado'
+        public readonly string $motivo,          // proveniência da decisão (heurística/llm/erro)
+        public readonly bool $custoLlm,          // true se rodou o disambiguador frontier
+        public readonly ?float $confianca = null,
+        /** @var string[] leituras candidatas que o disambiguador enxergou (debug/observability) */
+        public readonly array $intencoes = [],
+    ) {
+    }
+
+    public static function responder(string $tipo, string $motivo, bool $custoLlm = false, ?float $confianca = null): self
+    {
+        return new self('responder', null, $tipo, $motivo, $custoLlm, $confianca);
+    }
+
+    public static function clarificar(string $pergunta, string $motivo, ?float $confianca = null, array $intencoes = []): self
+    {
+        return new self('clarificar', $pergunta, 'ambiguo', $motivo, true, $confianca, $intencoes);
+    }
+
+    public function deveClarificar(): bool
+    {
+        return $this->acao === 'clarificar' && $this->pergunta !== null && trim($this->pergunta) !== '';
+    }
+}

--- a/Modules/Jana/Tests/Feature/Ai/Clarify/ClarificadorAgentTest.php
+++ b/Modules/Jana/Tests/Feature/Ai/Clarify/ClarificadorAgentTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Ai\Agents\ClarificadorAgent;
+use Modules\Jana\Support\ContextoNegocio;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-JANA-ADVISOR-AGENT — GUARD tests do ClarificadorAgent (disambiguador frontier).
+ *
+ *  001. roteamento de modelo seletivo lê de config (difícil → frontier)
+ *  002. provider null quando não configurado (cai no default do SDK)
+ *  003. instructions decoupla ambiguidade-de-intenção de falta-de-dado
+ *  004. grounding não-PII aparece quando há ContextoNegocio
+ *  005. messages() mapeia histórico recente (resolução de dêixis)
+ */
+it('R-JANA-ADVISOR-AGENT-001 — model() roteia pra frontier via config', function () {
+    config(['copiloto.clarify.model' => 'gpt-4o']);
+    expect((new ClarificadorAgent('x'))->model())->toBe('gpt-4o');
+
+    config(['copiloto.clarify.model' => 'claude-sonnet-4-6']);
+    expect((new ClarificadorAgent('x'))->model())->toBe('claude-sonnet-4-6');
+
+    config(['copiloto.clarify.model' => '']);
+    expect((new ClarificadorAgent('x'))->model())->toBeNull();
+});
+
+it('R-JANA-ADVISOR-AGENT-002 — provider null quando não configurado', function () {
+    config(['copiloto.clarify.provider' => null]);
+    expect((new ClarificadorAgent('x'))->provider())->toBeNull();
+
+    config(['copiloto.clarify.provider' => 'anthropic']);
+    expect((new ClarificadorAgent('x'))->provider())->toBe('anthropic');
+});
+
+it('R-JANA-ADVISOR-AGENT-003 — instructions decoupla intenção de dado', function () {
+    $instr = (string) (new ClarificadorAgent('manda a régua'))->instructions();
+
+    expect($instr)
+        ->toContain('ambiguo')
+        ->toContain('falta_dado')
+        ->toContain('claro')
+        // a regra de ouro INTENT-SIM (não perguntar quando é só falta de dado)
+        ->toContain('GANHO DE INFORMAÇÃO')
+        // honestidade anti-alucinação
+        ->toContain('NÃO invente');
+});
+
+it('R-JANA-ADVISOR-AGENT-004 — grounding não-PII aparece com ContextoNegocio', function () {
+    $ctx = new ContextoNegocio(
+        businessId: 1,
+        businessName: 'ACME LTDA',
+        faturamento90d: [['mes' => '2026-05', 'valor' => 47150.0, 'bruto' => 47150.0, 'liquido' => 47150.0, 'caixa' => 40000.0]],
+        clientesAtivos: 8856,
+        modulosAtivos: ['Financeiro', 'Whatsapp'],
+        metasAtivas: [['nome' => 'Faturamento junho', 'valor_alvo' => 50000.0, 'realizado' => 12000.0]],
+        observacoes: null,
+    );
+
+    $instr = (string) (new ClarificadorAgent('e agora?', [], $ctx))->instructions();
+
+    expect($instr)
+        ->toContain('ACME LTDA')
+        ->toContain('8856')
+        ->toContain('Faturamento junho')
+        ->toContain('Financeiro');
+});
+
+it('R-JANA-ADVISOR-AGENT-005 — messages() mapeia histórico recente', function () {
+    $hist = [
+        ['role' => 'user', 'content' => 'quem deve mais?'],
+        ['role' => 'assistant', 'content' => 'VARGAS, R$ 385k.'],
+    ];
+
+    $msgs = iterator_to_array((new ClarificadorAgent('e ele?', $hist))->messages());
+
+    expect($msgs)->toHaveCount(2)
+        ->and($msgs[0]->role->value)->toBe('user')
+        ->and($msgs[1]->role->value)->toBe('assistant')
+        ->and($msgs[1]->content)->toContain('VARGAS');
+});

--- a/Modules/Jana/Tests/Feature/Ai/Clarify/ClarifyCascadeServiceTest.php
+++ b/Modules/Jana/Tests/Feature/Ai/Clarify/ClarifyCascadeServiceTest.php
@@ -1,0 +1,238 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Schema;
+use Laravel\Ai\Ai;
+use Modules\Jana\Ai\Agents\ClarificadorAgent;
+use Modules\Jana\Entities\Conversa;
+use Modules\Jana\Entities\Mensagem;
+use Modules\Jana\Services\Ai\Clarify\ClarifyCascadeService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-JANA-ADVISOR-A — GUARD tests da cascata clarify reativo (Metade A, proposta §10.4).
+ *
+ * Cobre o contrato canônico:
+ *  001. heurística 1a (pareceCinza) — positivos (cinza) e negativos (acionável)
+ *  002. flag OFF → no-op total (sem LLM, sempre responder)
+ *  003. heurística acionável curto-circuita o LLM (cascata p/ latência)
+ *  004. cinza + LLM ambiguo+pergunta → clarifica (com custo LLM)
+ *  005. honestidade — LLM falta_dado → responde (não pergunta)
+ *  006. honestidade — LLM ambiguo SEM pergunta → responde
+ *  007. anti false-clarify — confiança < mínimo → responde
+ *  008. anti-loop — turno seguinte a um clarify → responde
+ *  009. fail-open — exceção no disambiguador → responde (chat nunca quebra)
+ */
+beforeEach(function () {
+    foreach (['jana_conversas', 'jana_mensagens'] as $t) {
+        Schema::dropIfExists($t);
+    }
+
+    Schema::create('jana_conversas', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedInteger('business_id');
+        $t->unsignedInteger('user_id')->nullable();
+        $t->string('titulo', 150)->nullable();
+        $t->string('status', 20)->default('ativa');
+        $t->timestamp('iniciada_em')->nullable();
+        $t->json('metadata')->nullable();
+        $t->timestamps();
+    });
+
+    Schema::create('jana_mensagens', function (Blueprint $t) {
+        $t->bigIncrements('id');
+        $t->unsignedBigInteger('conversa_id');
+        $t->string('role', 20);
+        $t->longText('content');
+        $t->unsignedInteger('tokens_in')->nullable();
+        $t->unsignedInteger('tokens_out')->nullable();
+        $t->timestamps();
+    });
+
+    // Conversa usa Spatie LogsActivity (D7 LGPD) → loga no create. Garante a tabela
+    // (idempotente) — mesma estratégia central do tests/Pest.php p/ RecurringBilling.
+    if (! Schema::hasTable('activity_log')) {
+        Schema::create('activity_log', function (Blueprint $t) {
+            $t->id();
+            $t->string('log_name')->nullable();
+            $t->text('description')->nullable();
+            $t->unsignedBigInteger('subject_id')->nullable();
+            $t->string('subject_type')->nullable();
+            $t->unsignedBigInteger('causer_id')->nullable();
+            $t->string('causer_type')->nullable();
+            $t->json('properties')->nullable();
+            $t->string('event')->nullable();
+            $t->uuid('batch_uuid')->nullable();
+            $t->timestamps();
+        });
+    }
+
+    Cache::flush();
+
+    // Liga a feature p/ exercitar a cascata (default é OFF).
+    config(['copiloto.clarify.enabled' => true]);
+    config(['copiloto.clarify.min_confianca' => 0.6]);
+});
+
+function novaConversa(): Conversa
+{
+    return Conversa::create([
+        'business_id' => 1,
+        'user_id' => 1,
+        'titulo' => 'Test',
+        'status' => 'ativa',
+        'iniciada_em' => now(),
+    ]);
+}
+
+function cascade(): ClarifyCascadeService
+{
+    return app(ClarifyCascadeService::class);
+}
+
+it('R-JANA-ADVISOR-A-001 — pareceCinza separa ambíguo de acionável', function () {
+    $svc = cascade();
+
+    // CINZA (ambíguo de intenção — dêixis / imperativo solto / pergunta vaga curta)
+    $cinza = [
+        'e aquele cliente?',
+        'resolve isso',
+        'manda a régua',
+        'melhora aí',
+        'e agora?',
+        'como tá?',
+        'faz pra mim',
+    ];
+    foreach ($cinza as $m) {
+        expect($svc->pareceCinza($m))->toBeTrue("Devia ser cinza: '$m'");
+    }
+
+    // ACIONÁVEL (não-cinza — saudação, específico, ou longo o bastante)
+    $acionavel = [
+        'oi',
+        'bom dia',
+        'obrigado',
+        'quanto vendi ontem?',
+        'quero criar uma meta de faturamento de R$ 50 mil pro mês de junho',
+        'quais os 5 maiores devedores hoje, ordenados por saldo?',
+        '',
+    ];
+    foreach ($acionavel as $m) {
+        expect($svc->pareceCinza($m))->toBeFalse("Não devia ser cinza: '$m'");
+    }
+});
+
+it('R-JANA-ADVISOR-A-002 — flag OFF é no-op total (sem LLM)', function () {
+    config(['copiloto.clarify.enabled' => false]);
+
+    // Se o LLM fosse chamado com este fake, clarificaria — mas flag OFF não chama.
+    Ai::fakeAgent(ClarificadorAgent::class, [[
+        'tipo' => 'ambiguo', 'confianca' => 0.99, 'pergunta' => 'NUNCA', 'intencoes' => ['a', 'b'],
+    ]]);
+
+    $r = cascade()->decidir(novaConversa(), 'e aquele cliente?', 'e aquele cliente?');
+
+    expect($r->acao)->toBe('responder')
+        ->and($r->motivo)->toBe('flag_off')
+        ->and($r->custoLlm)->toBeFalse();
+});
+
+it('R-JANA-ADVISOR-A-003 — heurística acionável curto-circuita o LLM', function () {
+    // Fake ambiguo: SE o LLM rodasse, clarificaria. Mensagem é acionável → não roda.
+    Ai::fakeAgent(ClarificadorAgent::class, [[
+        'tipo' => 'ambiguo', 'confianca' => 0.99, 'pergunta' => 'NUNCA DEVIA APARECER', 'intencoes' => [],
+    ]]);
+
+    $msg = 'quero criar uma meta de faturamento de R$ 50 mil pro mês de junho';
+    $r = cascade()->decidir(novaConversa(), $msg, $msg);
+
+    expect($r->acao)->toBe('responder')
+        ->and($r->motivo)->toBe('heuristica_acionavel')
+        ->and($r->custoLlm)->toBeFalse();
+});
+
+it('R-JANA-ADVISOR-A-004 — cinza + LLM ambiguo → clarifica com pergunta', function () {
+    Ai::fakeAgent(ClarificadorAgent::class, [[
+        'tipo' => 'ambiguo',
+        'confianca' => 0.9,
+        'pergunta' => 'Você quer dizer a régua de cobrança ou a de reativação?',
+        'intencoes' => ['régua de cobrança', 'régua de reativação'],
+    ]]);
+
+    $r = cascade()->decidir(novaConversa(), 'manda a régua', 'manda a régua');
+
+    expect($r->deveClarificar())->toBeTrue()
+        ->and($r->acao)->toBe('clarificar')
+        ->and($r->pergunta)->toContain('régua')
+        ->and($r->custoLlm)->toBeTrue();
+});
+
+it('R-JANA-ADVISOR-A-005 — honestidade: falta_dado responde (não pergunta)', function () {
+    Ai::fakeAgent(ClarificadorAgent::class, [[
+        'tipo' => 'falta_dado', 'confianca' => 0.95, 'pergunta' => '', 'intencoes' => [],
+    ]]);
+
+    $r = cascade()->decidir(novaConversa(), 'e aquele cliente?', 'e aquele cliente?');
+
+    expect($r->acao)->toBe('responder')
+        ->and($r->tipo)->toBe('falta_dado')
+        ->and($r->custoLlm)->toBeTrue();
+});
+
+it('R-JANA-ADVISOR-A-006 — honestidade: ambiguo sem pergunta responde', function () {
+    Ai::fakeAgent(ClarificadorAgent::class, [[
+        'tipo' => 'ambiguo', 'confianca' => 0.9, 'pergunta' => '', 'intencoes' => ['a', 'b'],
+    ]]);
+
+    $r = cascade()->decidir(novaConversa(), 'resolve isso', 'resolve isso');
+
+    expect($r->acao)->toBe('responder')
+        ->and($r->deveClarificar())->toBeFalse();
+});
+
+it('R-JANA-ADVISOR-A-007 — anti false-clarify: confiança baixa responde', function () {
+    Ai::fakeAgent(ClarificadorAgent::class, [[
+        'tipo' => 'ambiguo', 'confianca' => 0.3, 'pergunta' => 'Pergunta de baixa confiança?', 'intencoes' => [],
+    ]]);
+
+    $r = cascade()->decidir(novaConversa(), 'faz pra mim', 'faz pra mim');
+
+    expect($r->acao)->toBe('responder')
+        ->and($r->deveClarificar())->toBeFalse();
+});
+
+it('R-JANA-ADVISOR-A-008 — anti-loop: turno seguinte a clarify responde', function () {
+    $conv = novaConversa();
+
+    // 1º turno cinza → clarifica e marca.
+    Ai::fakeAgent(ClarificadorAgent::class, [[
+        'tipo' => 'ambiguo', 'confianca' => 0.9, 'pergunta' => 'A ou B?', 'intencoes' => ['a', 'b'],
+    ]]);
+    $r1 = cascade()->decidir($conv, 'manda a régua', 'manda a régua');
+    expect($r1->deveClarificar())->toBeTrue();
+
+    // 2º turno (resposta do user) — mesmo sendo cinza, NÃO pergunta de novo.
+    Ai::fakeAgent(ClarificadorAgent::class, [[
+        'tipo' => 'ambiguo', 'confianca' => 0.99, 'pergunta' => 'NÃO DEVIA', 'intencoes' => [],
+    ]]);
+    $r2 = cascade()->decidir($conv, 'a de cobrança', 'a de cobrança');
+
+    expect($r2->acao)->toBe('responder')
+        ->and($r2->motivo)->toBe('anti_loop_resposta_a_clarify');
+});
+
+it('R-JANA-ADVISOR-A-009 — fail-open: exceção no disambiguador responde', function () {
+    // Closure que lança → prompt() propaga → service captura → fail-open.
+    Ai::fakeAgent(ClarificadorAgent::class, function () {
+        throw new RuntimeException('provider down');
+    });
+
+    $r = cascade()->decidir(novaConversa(), 'e aquele cliente?', 'e aquele cliente?');
+
+    expect($r->acao)->toBe('responder')
+        ->and($r->motivo)->toBe('erro_fail_open');
+});

--- a/memory/decisions/proposals/jana-advisor-modo-consultor.md
+++ b/memory/decisions/proposals/jana-advisor-modo-consultor.md
@@ -1,0 +1,54 @@
+# Jana "Modo Consultor" (Advisor) — Metade A: clarify reativo — 2026-06-02
+
+> **Status:** PROPOSAL §10.4 · **não-canon, não-ADR** · número de ADR **não cunhado** (soberania [W], ADR 0238 — [W] numera se promover).
+> **Tipo:** evolução de produto (Modules/Jana — chat/raciocínio) · **Tier 0** (produto + custo) → PR aberto, **espera [W]**.
+> **Autor:** [CL] Claude Code · **Origem:** peer-review (L-17) do pedido [CC] `PROMPT_PARA_CODE_JANA-ADVISOR-MODE.md` (sessão 2026-06-02). Insight [W]: *"as melhores respostas vêm quando eu pergunto que pergunta eu deveria fazer, porque nem eu sei o que é melhor."*
+> **Natureza:** peer-review, não ordem — [CL] avaliou se procede e onde mora melhor.
+
+---
+
+## 1. Veredito do peer-review: **procede** (andaime de raciocínio, não troca de modelo)
+
+O achado bate com o estado-da-arte 2025 e é checável contra `origin/main`:
+
+- **Active Task Disambiguation** (ICLR 2025 Spotlight): subir qualidade não é dar respostas melhores — é **fazer perguntas melhores** (a de maior ganho de informação).
+- **INTENT-SIM** (NAACL 2025): decoupla **ambiguidade-de-intenção** (→ perguntar) de **falta-de-dado** (→ buscar). Confundir as duas é o erro nº1 dos LLMs (perguntam quando não sabem; chutam quando é ambíguo).
+- A Jana hoje **chuta** no ambíguo e às vezes **pergunta** no que era só falta de dado. Esta capacidade é o **andaime** (scaffold) que conserta o pior hábito — sobe o raciocínio pela arquitetura, **não** pelo provider.
+
+Atende os 4 testes da meta-skill: substitui o [W] *saber qual pergunta fazer* · repetitivo (todo dia, toda persona) · ROI = decisão melhor + menos chute · acelera ERP autônomo (a IA pauta, o humano decide). Começa pela **Metade A** (mais barata), como [W] sequenciou.
+
+## 2. Passo 0 contra `origin/main` fresco (`2e9f5881e`) — onde mora, sem duplicar
+
+| Verifiquei | Achado | Decisão |
+|---|---|---|
+| `LaravelAiSdkDriver::responderChat[Stream]` | Pipeline real: cache → recall(MemoriaContrato) → snapshot(ContextoNegocio) → `ChatCopilotoAgent` | **Estendi**: guard `talvezClarificar()` ANTES do recall/LLM. `ContextoNegocio` **reusado** (1 snapshot serve cascata e chat). |
+| `BriefDiarioChatTrigger` | Já pré-empta o chat por intent (regex-first) | Precedente de interceptação — a cascata pluga na **mesma forma**. |
+| 4 Agents (ChatCopiloto/BriefDiario/Sugestoes/Briefing) | Existem; `SugestoesMetasAgent` já usa `HasStructuredOutput` | **Estendi** com 5º agente (`ClarificadorAgent`) — mesmo padrão structured output. Os 4 ficam intactos. |
+| Brief diário (ADR 0091) | É o gancho da **Metade B** (próxima-melhor-pergunta) | Não toquei nesta fase — Metade B estende o brief, spec à parte. |
+| Convenção de flag (`contextual_retrieval`, `peso_real`) | Tudo que toca o coração do chat nasce **default-OFF**, [W] liga em homolog | Segui: `JANA_CLARIFY_ENABLED=false`. Com OFF o pipeline é **byte-idêntico** ao legado. |
+
+## 3. O que entra neste PR (tudo aditivo, default-OFF)
+
+1. **`Modules/Jana/Ai/Agents/ClarificadorAgent.php`** — disambiguador `HasStructuredOutput`. Decide `claro | falta_dado | ambiguo` (+ confiança, intenções) e, se ambíguo, devolve a **pergunta de maior ganho de informação**. Roteamento de modelo seletivo via `provider()`/`model()` (config) — **difícil → frontier** (default `gpt-4o`, vs `gpt-4o-mini` do chat), mas só dispara no cinza. Honestidade no prompt: pode classificar `claro` e deixar pergunta vazia; **não inventa** ambiguidade.
+2. **`Modules/Jana/Services/Ai/Clarify/ClarifyCascadeService.php`** — a cascata por latência: **1a heurística local (zero LLM)** resolve ~80% direto; **1b disambiguador frontier** só no ~20% cinza. Fail-open (qualquer erro → responde), anti-loop (não pergunta 2× seguidas, marcador TTL), e **medição** (`clarify_event` no log `copiloto-ai`). Histórico/contexto PII-redigidos (defense-in-depth).
+3. **`Modules/Jana/Support/ClarifyResult.php`** — DTO imutável do veredito.
+4. **`LaravelAiSdkDriver`** — guard `talvezClarificar()` em blocking + stream (sai sem gravar cache nem extrair fatos: não houve resposta real).
+5. **`Modules/Jana/Config/config.php`** — bloco `copiloto.clarify.*` (flag, model/provider, min_confiança, limites do cinza, anti-loop TTL).
+6. **RUNBOOK** `memory/requisitos/Jana/RUNBOOK-jana-advisor-clarify.md` + **14 testes Pest** (verdes).
+
+## 4. Como medir (senão é fé, não engenharia)
+
+Log `copiloto-ai` → `clarify_event`: **gray-hit rate** (custo_llm/total), **taxa de clarify**, **false-clarify** (clarify só no cinza?). A métrica **pergunta→ação** (sinal de valor real) precisa de hook no frontend — pendência honesta listada no RUNBOOK. Ratchet futuro na família `jana:health-check`/`design:review`.
+
+## 5. Tier 0 respeitado
+
+- **Não cunhei nº de ADR** (soberania [W], 0238). Proposal slug-only.
+- **Não mergeei** (publication-policy). PR espera [W].
+- Default-OFF → custo zero até [W] ligar e escolher o modelo frontier.
+
+## 6. Decisão aberta pra [W]
+
+- [ ] Aprovar a Metade A (vira canon ao mergear) ou ajustar.
+- [ ] Numerar ADR se elevar proposal → decisão.
+- [ ] Ligar em homolog p/ medir `clarify_event` antes de prod.
+- [ ] Dar sinal verde pra **Metade B** (próxima-melhor-pergunta proativa por persona, estendendo o brief diário).

--- a/memory/requisitos/Jana/RUNBOOK-jana-advisor-clarify.md
+++ b/memory/requisitos/Jana/RUNBOOK-jana-advisor-clarify.md
@@ -1,0 +1,81 @@
+# RUNBOOK — Jana Advisor (Modo Consultor) · Metade A: Clarify reativo
+
+> **Status:** proposta §10.4 · **Tier 0** (produto + custo) · peer-review (L-17), não ordem.
+> **Default OFF** — `[W]` liga em homolog após validar. Não cunha nº de ADR (soberania `[W]`, ADR 0238).
+> Origem: sessão `[CC]` 2026-06-02 — *"as melhores respostas vêm quando eu pergunto que pergunta eu deveria fazer."*
+
+## O que é
+
+Cascata **Decidir → Clarificar → Responder** no chat da Jana. Antes de responder, a Jana
+decide se a mensagem é **ambígua de intenção** (várias leituras → **pergunta** a de maior ganho
+de informação) ou só **falta dado** (resposta única → **busca**, não pergunta). Decoupla os dois
+erros nº1 dos LLMs (INTENT-SIM, NAACL 2025 + Active Task Disambiguation, ICLR 2025 Spotlight).
+
+**Não troca de modelo — é andaime** (scaffold). Sobe o raciocínio pela arquitetura, não pelo provider.
+
+## Como funciona (cascata por latência)
+
+| Estágio | Onde | Custo | Resolve |
+|---|---|---|---|
+| **1a heurística local** | `ClarifyCascadeService::pareceCinza()` | zero LLM (~µs) | ~80% direto → responde |
+| **1b disambiguador** | `ClarificadorAgent` (frontier, structured output) | 1 chamada LLM | só o ~20% "cinza" |
+
+- **1a** é conservadora: default = responder. Só vira "cinza" com sinal forte de ambiguidade
+  (curta + dêixis sem antecedente / imperativo solto / pergunta vaga curta).
+- **1b** classifica `claro | falta_dado | ambiguo` + (se ambíguo) a **pergunta de maior ganho**.
+- **Honestidade:** ambíguo sem pergunta de alto valor, ou confiança < mínimo → **responde** (não inventa).
+- **Anti-loop:** se o turno anterior já foi um clarify, não pergunta de novo (marcador TTL em cache).
+- **Fail-open:** qualquer erro → responde normal. A cascata **nunca** quebra o chat.
+
+## Onde plugou (estendeu, não recriou — §10.4 Passo 0)
+
+- `LaravelAiSdkDriver::responderChat()` e `responderChatStream()` → guard `talvezClarificar()`
+  ANTES do recall/LLM (espelha a interceptação do `BriefDiarioChatTrigger`). `ContextoNegocio`
+  é **reusado** (snapshot único) pela cascata e pelo chat.
+- Novos: `ClarificadorAgent` (5º agente, ao lado de ChatCopiloto/BriefDiario/Sugestoes/Briefing),
+  `ClarifyCascadeService`, `ClarifyResult`. Recall (`MemoriaContrato`) e brief **intactos**.
+
+## Como ligar (homolog)
+
+```env
+JANA_CLARIFY_ENABLED=true
+# Roteamento de modelo seletivo (difícil → frontier). Default gpt-4o (vs gpt-4o-mini do chat).
+JANA_CLARIFY_MODEL=gpt-4o            # ou um modelo de raciocínio estendido
+# JANA_CLARIFY_PROVIDER=anthropic    # opcional; vazio = config('ai.default')
+JANA_CLARIFY_MIN_CONFIANCA=0.6       # confiança mínima p/ realmente perguntar
+JANA_CLARIFY_GRAY_MAX_WORDS=8        # limites do "cinza" da heurística 1a
+JANA_CLARIFY_GRAY_MAX_CHARS=140
+JANA_CLARIFY_ANTI_LOOP_TTL=600       # s — não pergunta 2x seguidas
+```
+
+Com a flag **OFF** o pipeline de chat é **byte-idêntico** ao legado (mesma postura de
+`contextual_retrieval` / `peso_real`).
+
+## Como medir (senão é fé, não engenharia)
+
+Log channel `copiloto-ai` → evento `clarify_event`:
+
+```bash
+tail -f storage/logs/copiloto-ai.log | grep clarify_event
+```
+
+Métricas a acompanhar:
+- **gray-hit rate** = eventos `custo_llm=true` / total (quanto a heurística 1a deixou passar).
+- **taxa de clarify** = `acao=clarificar` / total.
+- **false-clarify** = clarify que o user ignorou (cruzar com a próxima ação — hook de produto,
+  pendência abaixo).
+
+## Pendências / fronteira (honestidade de escopo)
+
+- [ ] **pergunta→ação** (sinal de valor real) precisa de instrumentação no frontend
+      (registrar se a próxima msg do user responde a pergunta). Backend já loga a decisão.
+- [ ] Golden/RAGAS de clarify (casos cinza canônicos) — ratchet na família `jana:health-check`.
+- [ ] **Metade B** (próxima-melhor-pergunta proativa, estende o brief diário por persona) —
+      próxima na fila, spec à parte.
+
+## Testes
+
+- `Modules/Jana/Tests/Feature/Ai/Clarify/ClarifyCascadeServiceTest.php` (9 guards: heurística,
+  flag-off no-op, curto-circuito, clarifica, honestidade ×2, anti false-clarify, anti-loop, fail-open).
+- `Modules/Jana/Tests/Feature/Ai/Clarify/ClarificadorAgentTest.php` (5 guards: routing, instructions,
+  grounding, messages).

--- a/memory/requisitos/Jana/RUNBOOK-jana-advisor-clarify.md
+++ b/memory/requisitos/Jana/RUNBOOK-jana-advisor-clarify.md
@@ -3,10 +3,10 @@ title: "Jana Advisor (Modo Consultor) — Metade A: Clarify reativo"
 module: Jana
 owner: W
 status: rascunho
-last_validated: 2026-06-02
+last_validated: "2026-06-02"
 preconditions:
-  - "JANA_CLARIFY_ENABLED=true (default OFF)"
-  - "Provider/modelo frontier configurado (JANA_CLARIFY_MODEL)"
+  - "copiloto.clarify.enabled=true (default OFF — via config runtime/published)"
+  - "copiloto.clarify.model = modelo frontier"
 steps:
   - "Ligar a flag em homolog"
   - "Disparar mensagens cinza e claras no chat da Jana"
@@ -53,19 +53,23 @@ erros nº1 dos LLMs (INTENT-SIM, NAACL 2025 + Active Task Disambiguation, ICLR 2
 
 ## Como ligar (homolog)
 
-```env
-JANA_CLARIFY_ENABLED=true
-# Roteamento de modelo seletivo (difícil → frontier). Default gpt-4o (vs gpt-4o-mini do chat).
-JANA_CLARIFY_MODEL=gpt-4o            # ou um modelo de raciocínio estendido
-# JANA_CLARIFY_PROVIDER=anthropic    # opcional; vazio = config('ai.default')
-JANA_CLARIFY_MIN_CONFIANCA=0.6       # confiança mínima p/ realmente perguntar
-JANA_CLARIFY_GRAY_MAX_WORDS=8        # limites do "cinza" da heurística 1a
-JANA_CLARIFY_GRAY_MAX_CHARS=140
-JANA_CLARIFY_ANTI_LOOP_TTL=600       # s — não pergunta 2x seguidas
+Os knobs vivem em `Modules/Jana/Config/config.php` (bloco `clarify`, merged como
+`copiloto.clarify.*`). **Valores diretos, sem `env()`** — Larastan barra `env()` fora de
+`config/` raiz (mesma razão do bloco `peso_real`). Pra ligar em homolog, Wagner seta via
+**config runtime** (ex. num ServiceProvider/published config):
+
+```php
+config(['copiloto.clarify.enabled' => true]);   // default false
+// opcionais:
+config(['copiloto.clarify.model' => 'gpt-4o']);          // frontier (vs gpt-4o-mini do chat)
+config(['copiloto.clarify.provider' => 'anthropic']);    // null = config('ai.default')
+config(['copiloto.clarify.min_confianca' => 0.6]);       // anti false-clarify
+config(['copiloto.clarify.gray_max_words' => 8]);        // limites do "cinza" (heurística 1a)
+config(['copiloto.clarify.anti_loop_ttl_segundos' => 600]);
 ```
 
-Com a flag **OFF** o pipeline de chat é **byte-idêntico** ao legado (mesma postura de
-`contextual_retrieval` / `peso_real`).
+Com `enabled=false` (default) o pipeline de chat é **byte-idêntico** ao legado (mesma
+postura de `contextual_retrieval` / `peso_real`).
 
 ## Como medir (senão é fé, não engenharia)
 

--- a/memory/requisitos/Jana/RUNBOOK-jana-advisor-clarify.md
+++ b/memory/requisitos/Jana/RUNBOOK-jana-advisor-clarify.md
@@ -1,3 +1,19 @@
+---
+title: "Jana Advisor (Modo Consultor) — Metade A: Clarify reativo"
+module: Jana
+owner: W
+status: rascunho
+last_validated: 2026-06-02
+preconditions:
+  - "JANA_CLARIFY_ENABLED=true (default OFF)"
+  - "Provider/modelo frontier configurado (JANA_CLARIFY_MODEL)"
+steps:
+  - "Ligar a flag em homolog"
+  - "Disparar mensagens cinza e claras no chat da Jana"
+  - "Medir clarify_event no log copiloto-ai (gray-hit, taxa de clarify, false-clarify)"
+  - "Validar fail-open e anti-loop"
+---
+
 # RUNBOOK — Jana Advisor (Modo Consultor) · Metade A: Clarify reativo
 
 > **Status:** proposta §10.4 · **Tier 0** (produto + custo) · peer-review (L-17), não ordem.

--- a/prototipo-ui/CODE_NOTES.md
+++ b/prototipo-ui/CODE_NOTES.md
@@ -324,3 +324,42 @@ A Jana já pega erro de **saída** (golden 30Q + RAGAS + drift sentinel) mas nã
 - [ ] Confirmar check **advisory** (recomendo sim — drift de processo não pagina à noite).
 
 ### NÃO reprocessei (a comparação só confirma): guard higiene Cowork L-07/11/21/22 · collector CT100/OTel/LGPD #2073 · `design:review` #2078.
+
+---
+
+## 2026-06-02 — [CL] → [W]: Jana "Modo Consultor" (Advisor) — Metade A (clarify reativo)
+
+### Handoff: `PROMPT_PARA_CODE_JANA-ADVISOR-MODE.md` (Cowork→Code) · insight [W]: *"as melhores respostas vêm quando eu pergunto que pergunta eu deveria fazer"*
+### Natureza: peer-review (L-17) · **Tier 0** (produto + custo) → PR aberto, **NÃO mergeei**, espera [W]
+### Status: PR aberto · branch `feat/jana-advisor-clarify` · base `origin/main` fresco (`2e9f5881e`)
+
+### Veredito do peer-review: **procede** (andaime de raciocínio, não troca de modelo)
+Bate com o estado-da-arte: Active Task Disambiguation (ICLR 2025 Spotlight) + INTENT-SIM (NAACL 2025 — decoupla ambiguidade-de-intenção de falta-de-dado). A Jana hoje **chuta** quando é ambíguo e **pergunta** quando é só falta de dado — o erro nº1. Esta capacidade conserta o pior hábito primeiro (Metade A, a mais barata), como você pediu.
+
+### §10.4 Passo 0 contra `origin/main` (estendi, NÃO recriei):
+- Chat resolve hoje: `ChatController::send/sendStream` → `LaravelAiSdkDriver::responderChat[Stream]` → `recallMemoria`(MemoriaContrato) + `snapshotContexto`(ContextoNegocio) → `ChatCopilotoAgent` (laravel/ai).
+- Precedente de interceptação: `BriefDiarioChatTrigger` já pré-empta o chat por intent — a cascata clarify pluga na MESMA forma, antes do recall/LLM.
+- Os 4 Agents (ChatCopiloto/BriefDiario/Sugestoes/Briefing), o brief diário (ADR 0091), a `MemoriaContrato` e o roteamento `laravel/ai` ficaram **intactos**. `ContextoNegocio` é **reusado** (snapshot único serve cascata E chat — zero consulta a mais).
+
+### O que entrou (tudo aditivo, default-OFF):
+- **`ClarificadorAgent`** (5º agente) — disambiguador `HasStructuredOutput` que decide `claro|falta_dado|ambiguo` e, se ambíguo, dá a **pergunta de maior ganho de informação**. Roteamento de modelo seletivo via `provider()`/`model()` (config) — **difícil → frontier** (default `gpt-4o` vs `gpt-4o-mini` do chat), mas só dispara no ~20% cinza.
+- **`ClarifyCascadeService`** — cascata por latência: **1a heurística local (zero LLM)** resolve ~80% direto; **1b disambiguador frontier** só no cinza. Honestidade (não inventa pergunta), **fail-open** (qualquer erro → responde), **anti-loop** (não pergunta 2× seguidas), **medição** (`clarify_event` no log `copiloto-ai`).
+- **`ClarifyResult`** (DTO) + guard `talvezClarificar()` em `LaravelAiSdkDriver` (blocking + stream).
+- **Config** `copiloto.clarify.*` (flag `JANA_CLARIFY_ENABLED` default-OFF — mesma postura de `contextual_retrieval`/`peso_real`; com OFF o pipeline é byte-idêntico ao legado).
+- **RUNBOOK** `memory/requisitos/Jana/RUNBOOK-jana-advisor-clarify.md` (como ligar/medir).
+- Proposta §10.4: `memory/decisions/proposals/jana-advisor-modo-consultor.md`.
+
+### Build / testes:
+- **14/14 Pest verdes** (54 assertions): `ClarifyCascadeServiceTest` (9 — heurística, flag-off no-op, curto-circuito, clarifica, honestidade ×2, anti false-clarify, anti-loop, fail-open) + `ClarificadorAgentTest` (5 — routing frontier, instructions INTENT-SIM, grounding não-PII, messages). `php -l` limpo nos 7 arquivos.
+- Regressão: suite `Jana/Tests/Feature/Ai` + brief trigger = **50 passaram** com o driver editado. As 2 falhas restantes são **pré-existentes** (`BriefDiarioChatTriggerTest` sem `activity_log` em run isolado — gap do `tests/Pest.php`, não coberto pra Jana), **não-relacionadas** a este PR.
+
+### Tier 0 respeitado:
+- **Não cunhei nº de ADR** (soberania [W], 0238) — proposal slug-only. [W] numera se promover.
+- **Não mergeei** (publication-policy). PR espera [W].
+- Histórico/contexto vão **PII-redigidos** pro disambiguador (defense-in-depth, reusa `PiiRedactor`).
+
+### Decisão aberta pra [W]:
+- [ ] Aprovar a Metade A como caminho (vira canon ao mergear) ou ajustar.
+- [ ] Numerar ADR se quiser elevar proposal → decisão.
+- [ ] Ligar em homolog (`JANA_CLARIFY_ENABLED=true` + escolher o modelo frontier) p/ medir `clarify_event` antes de prod.
+- [ ] **Metade B** (próxima-melhor-pergunta proativa, estende o brief por persona) — próxima na fila, spec à parte, como você sequenciou.


### PR DESCRIPTION
## Jana "Modo Consultor" (Advisor) — Metade A: clarify reativo

> **Tier 0** (produto + custo) · **proposta §10.4** · peer-review (L-17), **não ordem** → **espera [W]**.
> nº de ADR **não cunhado** (soberania [W], ADR 0238). **Não mergear** sem [W].

Origem: pedido [CC] `PROMPT_PARA_CODE_JANA-ADVISOR-MODE.md`. Insight [W]: *"as melhores respostas vêm quando eu pergunto que pergunta eu deveria fazer."*

### O que faz
Cascata **Decidir → Clarificar → Responder** no chat da Jana. Decoupla **ambiguidade-de-intenção** (→ pergunta a de maior ganho) de **falta-de-dado** (→ busca, não pergunta) — INTENT-SIM (NAACL 2025) + Active Task Disambiguation (ICLR 2025). **Andaime de raciocínio, não troca de modelo.**

Cascata por latência: **1a heurística local (zero LLM)** resolve ~80% direto; **1b disambiguador frontier** (`ClarificadorAgent`, structured output) só no ~20% cinza. Roteamento de modelo seletivo (difícil → frontier) via config.

### Estende (não recria) — §10.4 Passo 0 vs `origin/main`
- Guard `talvezClarificar()` em `LaravelAiSdkDriver::responderChat[Stream]`, ANTES do recall/LLM — mesma forma do `BriefDiarioChatTrigger`. `ContextoNegocio` **reusado** (1 snapshot).
- Novos: `ClarificadorAgent` (5º agente), `ClarifyCascadeService`, `ClarifyResult`. `MemoriaContrato`, brief diário e os 4 Agents **intactos**.

### Segurança / rollout
- **Flag default-OFF** (`JANA_CLARIFY_ENABLED=false`) — com OFF o pipeline é **byte-idêntico** ao legado (mesma postura de `contextual_retrieval`/`peso_real`). [W] liga em homolog.
- **Fail-open** (qualquer erro → responde), **anti-loop**, **honestidade** (não inventa pergunta), histórico/contexto **PII-redigidos**.
- **Medição**: log `copiloto-ai` → `clarify_event` (gray-hit, taxa de clarify, false-clarify).

### Testes
- **14/14 Pest verdes** (54 assertions) — `ClarifyCascadeServiceTest` (9) + `ClarificadorAgentTest` (5). `php -l` limpo.
- Regressão suite `Jana/Tests/Feature/Ai` + brief trigger: 50 passaram; as 2 falhas remanescentes são **pré-existentes** (`BriefDiarioChatTriggerTest` sem `activity_log` em run isolado), não-relacionadas.

### Decisão aberta pra [W]
- [ ] Aprovar Metade A (vira canon ao mergear) ou ajustar.
- [ ] Numerar ADR se elevar proposal → decisão.
- [ ] Ligar em homolog + escolher modelo frontier; medir `clarify_event`.
- [ ] Sinal verde p/ **Metade B** (próxima-melhor-pergunta proativa por persona, estende o brief).

Docs: `memory/decisions/proposals/jana-advisor-modo-consultor.md` · RUNBOOK `memory/requisitos/Jana/RUNBOOK-jana-advisor-clarify.md` · retorno em `prototipo-ui/CODE_NOTES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)