### PR TITLE
feat(oficina-auto): check-in de entrada na OS (combustível + avarias)

### DIFF
--- a/Modules/OficinaAuto/Database/Migrations/2026_06_02_000010_add_checkin_fields_to_service_orders.php
+++ b/Modules/OficinaAuto/Database/Migrations/2026_06_02_000010_add_checkin_fields_to_service_orders.php
@@ -1,0 +1,60 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Check-in de entrada na OS — US-OFICINA-038 + US-OFICINA-039.
+ *
+ * Delta do protótipo Cowork "Nova OS" (oficina-os-page.jsx) embarcado em main.
+ * Ver memory/requisitos/OficinaAuto/oficina-os-nova-prototipo-visual-comparison.md.
+ *
+ * O protótipo abre a OS com o estado de entrada do veículo — o que protege
+ * oficina e cliente (registro do que entrou na oficina). Hoje só temos `notes`
+ * (= relato do cliente). Esta migration adiciona os 2 campos do check-in que
+ * faltavam:
+ *
+ * - fuel_level_at_entry — nível de combustível na entrada (0–100%) — barra no hero
+ * - entry_damages       — avarias marcadas na entrada (array JSON de rótulos curtos)
+ *
+ * `relato do cliente` reusa a coluna `notes` existente (sem coluna nova).
+ * `fotos de entrada` ficam pra US futura (reusa HasArquivos backbone — ADR 0123).
+ *
+ * Multi-tenant Tier 0 (ADR 0093): business_id já existente preservado.
+ * Idempotente — Schema::hasColumn guards + down() reversível.
+ *
+ * @see memory/requisitos/OficinaAuto/SPEC.md US-OFICINA-038 / US-OFICINA-039
+ */
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::table('service_orders', function (Blueprint $table) {
+            if (! Schema::hasColumn('service_orders', 'fuel_level_at_entry')) {
+                $table->unsignedTinyInteger('fuel_level_at_entry')
+                    ->nullable()
+                    ->after('mileage_at_service')
+                    ->comment('Nível de combustível na entrada (0–100%) — barra no check-in do hero (US-OFICINA-039)');
+            }
+
+            if (! Schema::hasColumn('service_orders', 'entry_damages')) {
+                $table->json('entry_damages')
+                    ->nullable()
+                    ->after('fuel_level_at_entry')
+                    ->comment('Avarias marcadas na entrada — array de rótulos curtos (US-OFICINA-038)');
+            }
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('service_orders', function (Blueprint $table) {
+            if (Schema::hasColumn('service_orders', 'entry_damages')) {
+                $table->dropColumn('entry_damages');
+            }
+            if (Schema::hasColumn('service_orders', 'fuel_level_at_entry')) {
+                $table->dropColumn('fuel_level_at_entry');
+            }
+        });
+    }
+};

--- a/Modules/OficinaAuto/Entities/ServiceOrder.php
+++ b/Modules/OficinaAuto/Entities/ServiceOrder.php
@@ -36,6 +36,8 @@ use Spatie\Activitylog\Traits\LogsActivity;
  * @property \Illuminate\Support\Carbon|null $expected_return_date
  * @property string|null  $daily_rate
  * @property int|null     $mileage_at_service
+ * @property int|null     $fuel_level_at_entry  Nível combustível na entrada 0–100% (US-OFICINA-039)
+ * @property array|null   $entry_damages        Avarias marcadas no check-in (US-OFICINA-038)
  * @property string       $status
  * @property \Illuminate\Support\Carbon|null $entered_at
  * @property \Illuminate\Support\Carbon|null $expected_completion
@@ -66,6 +68,8 @@ class ServiceOrder extends Model
         'expected_return_date',
         'daily_rate',
         'mileage_at_service',
+        'fuel_level_at_entry', // US-OFICINA-039 — nível combustível na entrada (0–100%)
+        'entry_damages',       // US-OFICINA-038 — avarias marcadas no check-in (array JSON)
         'box_label',           // Wave 2.1 US-OFICINA-027 — texto livre "Elevador 1"
         'assigned_user_id',    // Wave 2.1 US-OFICINA-027 — mecânico responsável (FK lógica)
         'status',
@@ -81,6 +85,8 @@ class ServiceOrder extends Model
         'transaction_id'        => 'integer',
         'vehicle_id'            => 'integer',
         'mileage_at_service'    => 'integer',
+        'fuel_level_at_entry'   => 'integer',  // US-OFICINA-039 (0–100)
+        'entry_damages'         => 'array',    // US-OFICINA-038 (avarias de entrada)
         'assigned_user_id'      => 'integer',  // Wave 2.1 US-OFICINA-027
         'daily_rate'            => 'decimal:2',
         'expected_return_date'  => 'date',
@@ -293,6 +299,8 @@ class ServiceOrder extends Model
                 'delivery_address',
                 'expected_return_date',
                 'daily_rate',
+                'fuel_level_at_entry',
+                'entry_damages',
                 'completed_at',
             ])
             ->logOnlyDirty()

--- a/Modules/OficinaAuto/Http/Requests/StoreServiceOrderRequest.php
+++ b/Modules/OficinaAuto/Http/Requests/StoreServiceOrderRequest.php
@@ -39,6 +39,10 @@ class StoreServiceOrderRequest extends FormRequest
             'vehicle_id'          => ['required', 'integer', 'exists:vehicles,id'],
             'transaction_id'      => ['nullable', 'integer'],
             'mileage_at_service'  => ['nullable', 'integer', 'min:0'],
+            // Check-in de entrada (US-OFICINA-038/039) — delta protótipo Cowork Nova OS
+            'fuel_level_at_entry' => ['nullable', 'integer', 'min:0', 'max:100'],
+            'entry_damages'       => ['nullable', 'array'],
+            'entry_damages.*'     => ['string', 'max:80'],
             'status'              => ['required', 'string', 'max:30'],
             'entered_at'          => ['nullable', 'date'],
             'expected_completion' => ['nullable', 'date'],

--- a/Modules/OficinaAuto/Http/Requests/UpdateServiceOrderRequest.php
+++ b/Modules/OficinaAuto/Http/Requests/UpdateServiceOrderRequest.php
@@ -33,6 +33,10 @@ class UpdateServiceOrderRequest extends FormRequest
             'vehicle_id'          => ['required', 'integer', 'exists:vehicles,id'],
             'transaction_id'      => ['nullable', 'integer'],
             'mileage_at_service'  => ['nullable', 'integer', 'min:0'],
+            // Check-in de entrada (US-OFICINA-038/039) — delta protótipo Cowork Nova OS
+            'fuel_level_at_entry' => ['nullable', 'integer', 'min:0', 'max:100'],
+            'entry_damages'       => ['nullable', 'array'],
+            'entry_damages.*'     => ['string', 'max:80'],
             'status'              => ['required', 'string', 'max:30'],
             'entered_at'          => ['nullable', 'date'],
             'expected_completion' => ['nullable', 'date'],

--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderCheckinTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderCheckinTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Facades\Validator;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+use Modules\OficinaAuto\Http\Requests\StoreServiceOrderRequest;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Check-in de entrada na OS — US-OFICINA-038 (avarias) + US-OFICINA-039 (combustível).
+ *
+ * Delta do protótipo Cowork "Nova OS" (oficina-os-page.jsx) — ver
+ * memory/requisitos/OficinaAuto/oficina-os-nova-prototipo-visual-comparison.md.
+ *
+ * Tests biz=1 conforme ADR 0101. Espelha harness DviInspectionItemTest.
+ */
+
+const BIZ_CHECKIN = 1;
+const PLATE_CHECKIN_PREFIX = 'WCHK';
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS (ADR 0101)');
+    }
+    if (! Schema::hasColumn('service_orders', 'fuel_level_at_entry')) {
+        $this->markTestSkipped('Rode migration 2026_06_02_000010_add_checkin_fields_to_service_orders primeiro');
+    }
+});
+
+function checkin_criaVeiculo(string $suffix, int $biz = BIZ_CHECKIN): Vehicle
+{
+    return Vehicle::withoutGlobalScopes()->create([
+        'business_id'  => $biz,
+        'plate'        => PLATE_CHECKIN_PREFIX . $suffix,
+        'vehicle_type' => 'automovel',
+    ]);
+}
+
+function checkin_cleanup(string $suffix): void
+{
+    $vehicles = Vehicle::withoutGlobalScopes()
+        ->where('plate', PLATE_CHECKIN_PREFIX . $suffix)
+        ->pluck('id')
+        ->toArray();
+
+    if (! empty($vehicles)) {
+        ServiceOrder::withoutGlobalScopes()->whereIn('vehicle_id', $vehicles)->forceDelete();
+        Vehicle::withoutGlobalScopes()->whereIn('id', $vehicles)->forceDelete();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Entity — fillable + casts (combustível int, avarias array JSON roundtrip)
+// ---------------------------------------------------------------------------
+
+it('persiste fuel_level_at_entry e entry_damages (cast array roundtrip)', function () {
+    session(['user.business_id' => BIZ_CHECKIN]);
+    $vehicle = checkin_criaVeiculo('A');
+
+    $os = ServiceOrder::withoutGlobalScopes()->create([
+        'business_id'         => BIZ_CHECKIN,
+        'vehicle_id'          => $vehicle->id,
+        'status'              => 'aberta',
+        'fuel_level_at_entry' => 35,
+        'entry_damages'       => ['Risco porta dir.', 'Amassado para-choque'],
+    ]);
+
+    $reloaded = ServiceOrder::withoutGlobalScopes()->findOrFail($os->id);
+
+    expect($reloaded->fuel_level_at_entry)->toBe(35);
+    expect($reloaded->entry_damages)->toBe(['Risco porta dir.', 'Amassado para-choque']);
+})->afterEach(fn () => checkin_cleanup('A'));
+
+it('aceita check-in vazio (campos nullable)', function () {
+    session(['user.business_id' => BIZ_CHECKIN]);
+    $vehicle = checkin_criaVeiculo('B');
+
+    $os = ServiceOrder::withoutGlobalScopes()->create([
+        'business_id' => BIZ_CHECKIN,
+        'vehicle_id'  => $vehicle->id,
+        'status'      => 'aberta',
+    ]);
+
+    $reloaded = ServiceOrder::withoutGlobalScopes()->findOrFail($os->id);
+
+    expect($reloaded->fuel_level_at_entry)->toBeNull();
+    expect($reloaded->entry_damages)->toBeNull();
+})->afterEach(fn () => checkin_cleanup('B'));
+
+// ---------------------------------------------------------------------------
+// FormRequest — regras de validação do combustível (0–100)
+// ---------------------------------------------------------------------------
+
+it('valida fuel_level_at_entry entre 0 e 100', function () {
+    $rules = (new StoreServiceOrderRequest())->rules();
+    $fuelRule = ['fuel_level_at_entry' => $rules['fuel_level_at_entry']];
+
+    expect(Validator::make(['fuel_level_at_entry' => 150], $fuelRule)->fails())->toBeTrue();
+    expect(Validator::make(['fuel_level_at_entry' => -5], $fuelRule)->fails())->toBeTrue();
+    expect(Validator::make(['fuel_level_at_entry' => 80], $fuelRule)->fails())->toBeFalse();
+    expect(Validator::make(['fuel_level_at_entry' => null], $fuelRule)->fails())->toBeFalse();
+});
+
+it('valida entry_damages como array de strings curtas', function () {
+    $rules = (new StoreServiceOrderRequest())->rules();
+    $damageRules = [
+        'entry_damages'   => $rules['entry_damages'],
+        'entry_damages.*' => $rules['entry_damages.*'],
+    ];
+
+    expect(Validator::make(['entry_damages' => ['Risco', 'Amassado']], $damageRules)->fails())->toBeFalse();
+    expect(Validator::make(['entry_damages' => 'nao-array'], $damageRules)->fails())->toBeTrue();
+    expect(Validator::make(['entry_damages' => [str_repeat('x', 90)]], $damageRules)->fails())->toBeTrue();
+});

--- a/memory/requisitos/OficinaAuto/SPEC.md
+++ b/memory/requisitos/OficinaAuto/SPEC.md
@@ -1,7 +1,7 @@
 ---
 module: OficinaAuto
-version: 0.1.0
-last_updated: "2026-05-26"
+version: 0.2.0
+last_updated: "2026-06-02"
 status: ativo
 lifecycle: ativo
 piloto: Vargas + Martinho (sinal qualificado em ADR 0137 — 2 de 4 candidatos OfficeImpresso saudáveis são oficina/recapagem)
@@ -1296,6 +1296,36 @@ Fechar 1º cliente pagante Modules/OficinaAuto (goal #1 CYCLE-06 — sinal quali
 - [ ] Se aceito: cycle dedicado ativar OficinaAuto (Sprint 0 com US-OFICINA-001..005 P0)
 - **Estimate:** 8h humano-limitado (call + análise + decisão) — relógio mundo real, não fator 10x
 
+### US-OFICINA-038 · Check-in de entrada — avarias na entrada da OS
+
+> owner: — · priority: p1 · estimate: 2h (IA-pair fator 10x ADR 0106) · status: review · type: story · origin: delta protótipo Cowork "Nova OS" (oficina-os-page.jsx) · 2026-06-02
+> blocked_by: —
+
+Delta do protótipo Cowork "Nova OS" embarcado — ver [oficina-os-nova-prototipo-visual-comparison.md](oficina-os-nova-prototipo-visual-comparison.md) (delta #8). O protótipo abre a OS registrando o estado de entrada do veículo, que protege oficina e cliente. Hoje só temos `notes` (= relato). Esta US adiciona as **avarias na entrada** (chips).
+
+**DoD:**
+- [x] Coluna `entry_damages` (json nullable) em `service_orders` — migration idempotente `2026_06_02_000010`
+- [x] `ServiceOrder` fillable + cast `array` + activitylog `logOnly`
+- [x] `StoreServiceOrderRequest` + `UpdateServiceOrderRequest` rules (`array` + `*` string max:80)
+- [x] Componente compartilhado `EntryCheckinFields` (chips + presets) usado por Create + Edit
+- [x] Show.tsx exibe avarias read-only
+- [x] Pest (roundtrip array + validação)
+- [ ] **Fotos de entrada** ficam pra US futura (reusa HasArquivos backbone — ADR 0123)
+
+### US-OFICINA-039 · Check-in de entrada — nível de combustível
+
+> owner: — · priority: p1 · estimate: 1h (IA-pair fator 10x ADR 0106) · status: review · type: story · origin: delta protótipo Cowork "Nova OS" (oficina-os-page.jsx) · 2026-06-02
+> blocked_by: —
+
+Delta #7 do protótipo Cowork "Nova OS" — barra de combustível no hero do veículo. Pareada com US-OFICINA-038 no mesmo PR (mesma migration de check-in).
+
+**DoD:**
+- [x] Coluna `fuel_level_at_entry` (unsignedTinyInteger nullable 0–100) em `service_orders` — migration `2026_06_02_000010`
+- [x] `ServiceOrder` fillable + cast `integer` + activitylog `logOnly`
+- [x] Requests rules (`integer` min:0 max:100)
+- [x] `EntryCheckinFields` input + barra; Show.tsx barra read-only
+- [x] Pest (persiste 35; valida >100 e <0 falham)
+
 ---
 
-**Última atualização:** 2026-05-26 — US-OFICINA-035 DVI Vistoria Digital backend (schema + Model + Service + HTTP API + Pest) — wedge CAPTERRA Repair gap #3. UI Wave 3b. 2026-05-15 — US-OFICINA-026 adicionada (goal #1 CYCLE-06 Martinho prod). 2026-05-10 — SPEC criada **antecipatória** sem cliente piloto. Status `feature-wish` lifecycle `aguarda-sinal-qualificado`. Não codar até gatilho §9 satisfeito. Revisar trimestralmente — se 12 meses sem sinal, considerar arquivar como `historical` (ADR 0095 lifecycle).
+**Última atualização:** 2026-06-02 — US-OFICINA-038/039 check-in de entrada (combustível + avarias) — delta protótipo Cowork "Nova OS". 2026-05-26 — US-OFICINA-035 DVI Vistoria Digital backend (schema + Model + Service + HTTP API + Pest) — wedge CAPTERRA Repair gap #3. UI Wave 3b. 2026-05-15 — US-OFICINA-026 adicionada (goal #1 CYCLE-06 Martinho prod). 2026-05-10 — SPEC criada **antecipatória** sem cliente piloto. Status `feature-wish` lifecycle `aguarda-sinal-qualificado`. Não codar até gatilho §9 satisfeito. Revisar trimestralmente — se 12 meses sem sinal, considerar arquivar como `historical` (ADR 0095 lifecycle).

--- a/memory/requisitos/OficinaAuto/oficina-os-nova-prototipo-visual-comparison.md
+++ b/memory/requisitos/OficinaAuto/oficina-os-nova-prototipo-visual-comparison.md
@@ -1,0 +1,82 @@
+---
+slug: oficinaauto-oficina-os-nova-prototipo-visual-comparison
+title: "OficinaAuto — Comparativo visual Nova OS (prototipo oficina-os-page.jsx)"
+type: visual-comparison
+module: OficinaAuto
+status: draft
+date: "2026-06-02"
+canon_reference: design-bundle Cowork "Oimpresso ERP Conunicação Visual" / oficina-os-page.jsx (351 linhas)
+blade_source: N/A (módulo novo, sem Blade legacy — já 100% Inertia)
+inertia_target: resources/js/Pages/OficinaAuto/ServiceOrders/{Create,Edit,Show}.tsx + _components/*
+related_adrs:
+  - 0104-processo-mwart-canonico-unico-caminho
+  - 0137-oficina-auto-service-order
+revisions:
+  - 2026-06-02 V1 (draft) — delta entre o protótipo Cowork "Nova OS" (oficina-os-page.jsx, versão que a cliente Kamila/Martinho reagiu em chat37) e o módulo OficinaAuto JÁ EMBARCADO em main. Gerado por [CL] a partir do handoff bundle Claude Design.
+---
+
+# OficinaAuto — Nova OS (protótipo Cowork) — Visual comparison / delta
+
+> **Achado-chave:** a tela "Oficina OS" do protótipo (`oficina-os-page.jsx`) **não é greenfield**. O módulo OficinaAuto já está 100% migrado em `main` (F1+F2+F3 do MWART completos): 3.512 linhas de TSX em `ServiceOrders/{Index,Create,Edit,Show}.tsx` + 11 componentes + backend FSM + backend DVI (`oa_inspection_items`) + aprovação pública por PIN (`AprovacaoOsController`).
+>
+> O protótipo propõe **consolidar o ciclo da OS num único workspace rico** (1 tela full-screen). Hoje o ciclo está distribuído: `Create.tsx` (form rápido em Sheet 720px) + `Show.tsx` (detalhe) + `ProducaoOficina/Index.tsx` (kanban). **Esta consolidação é decisão Tier 0 de produto (Wagner)** — vide regra do handoff "estender NÃO recriar, F1 = proposta".
+>
+> Este doc captura o protótipo como **spec acionável**: o que o protótipo agrega × o que já existe, priorizado P0–P3, com US propostas. Nenhum código foi alterado.
+
+---
+
+## Mapa de features: protótipo × embarcado
+
+| # | Feature do protótipo | Onde aparece em `oficina-os-page.jsx` | Status no main | Componente/origem |
+|---|---|---|---|---|
+| 1 | **Stepper FSM** (Recepção→Diagnóstico→Orçamento→Aprovação→Execução→Pronto) | `OfxStepper`, l.49-63, `active:2` | ✅ embarcado | `_components/ServiceOrderStagePipeline.tsx` + `ServiceOrderFsmActionPanel.tsx` |
+| 2 | **Placa Mercosul** no hero do veículo | `.ofx-plate`, l.166-169 | ✅ embarcado | `ProducaoOficina/_components/MercosulPlate.tsx` (usado em todas as telas) |
+| 3 | **Itens Serviços / Peças** com abas + busca `/` | `OfxSection "Itens da OS"`, l.248-283 | ✅ embarcado | `_components/ServiceOrderItemRow.tsx` + `ServiceOrderItemFormSheet.tsx` |
+| 4 | **Inspeção DVI** semáforo (g/y/r) + **"+ orçamento"** (reprovado vira linha de serviço) | `OfxDviRow` + `addReprov`, l.65-83 / 127-132 | 🟡 **parcial** — backend `oa_inspection_items` + `client_decision` + `DviInspectionController` existem; `DviPhotoGrid.tsx` existe em ProducaoOficina; **NÃO está cabeado no fluxo Create/Edit/Show da OS** | gap de wiring |
+| 5 | **Gate de aprovação do cliente** in-screen (aguardando→enviado→aprovado, WhatsApp, **bloqueia execução**) | `.ofx-gate` + `sendWhats`/`markApproved`, l.296-317 | 🟡 **parcial** — `Public/AprovacaoOsController` (PIN 4 díg, "a oficina foi avisada") + status `aprovada` existem; **card de gate 3-estados dentro da tela da oficina não existe** | gap de superfície |
+| 6 | **Painel fiscal dual-doc** (NF-e 55 peças / NFS-e mão de obra, lado a lado) | `.ofx-fiscal`, l.319-326 | 🟡 **parcial** — Show tem só botão "Imprimir OS A4 nota-fiscal-like" (US-OFICINA-037); **split NF-e/NFS-e por natureza não existe** | gap (cf. COWORK_NOTES item (c) "FiscalStatusBadge unificado") |
+| 7 | **Barra de combustível** no hero do veículo | `.ofx-fuel`, l.179-183 | ❌ **ausente** (grep `fuel/combustível/tanque` = 0 no módulo) | novo |
+| 8 | **Check-in de entrada** (relato + toggle de avarias + fotos de entrada) | `OfxSection "Check-in do veículo"`, l.204-230 | ❌ **ausente** (grep `avaria/check-in/relato/damage` = 0) | novo |
+| 9 | **Recap no rodapé** + "Iniciar execução" travado até aprovar | `.ofx-foot`, l.332-344 | 🟡 lógica de gate existe no FsmActionPanel; layout footer recap não | gap de layout |
+| 10 | **Switch de vertical** (Oficina / Com. Visual / Vestuário) no mesmo documento | `.ofx-vsw`, l.153-158 | ❌ ausente (decisão de arquitetura multi-vertical — fora de escopo OficinaAuto) | descartar p/ OficinaAuto |
+
+Mapeamento de status FSM: protótipo tem **6 passos** (Recepção, Diagnóstico, Orçamento, Aprovação, Execução, Pronto); backend tem **5 status** (`aberta`, `orcamento`, `aprovada`, `entregue`, `cancelada`). Delta de naming/granularidade a alinhar (não bloqueante).
+
+---
+
+## Deltas priorizados (apenas o que OficinaAuto ainda não tem)
+
+> Cada delta = 1 US = 1 PR MWART F3 (≤300 LOC, audit ≥70), **numa branch limpa a partir de `main`** — NÃO na `feat/staging-ct100` (divergida 368 commits).
+
+### P1 — alto valor, baixo risco (aditivo, sem mexer no FSM)
+- **US-OFICINA-038 · Check-in de entrada** (delta #8): seção em `Create.tsx`/`Edit.tsx` com relato do cliente (já existe `notes`), avarias na entrada (chips toggle) e fotos de entrada. Persistência: campos novos em `service_orders` ou reuso de `oa_inspection_items` tipo `entrada`. Backend baseline antes (F2).
+- **US-OFICINA-039 · Barra de combustível no hero** (delta #7): indicador `fuel_level` (0–100%) no `MercosulPlate`/hero do veículo em Show + Producao. Campo `fuel_level_at_entry` em `service_orders`.
+
+### P2 — valor alto, toca fluxo existente (precisa cuidado FSM/backend)
+- **US-OFICINA-040 · Cabear DVI → "+ orçamento" no fluxo da OS** (delta #4): superar `oa_inspection_items` (com `client_decision`) dentro de Show/Edit; item reprovado vira `ServiceOrderItem` de serviço com 1 clique. Reusa `DviPhotoGrid` + backend existente; é wiring de UI.
+- **US-OFICINA-041 · Card de gate de aprovação in-screen** (delta #5 + #9): card 3-estados (aguardando→enviado→aprovado) no Show da oficina, integrando `AprovacaoOsController` (gera link/PIN, dispara WhatsApp via Modules/Whatsapp) + recap footer com "Iniciar execução" travado. Estende, não recria, o `FsmActionPanel`.
+
+### P3 — convergente com outro item já na fila
+- **US-OFICINA-042 · Painel fiscal NF-e/NFS-e** (delta #6): split por natureza fiscal. **Convergir com COWORK_NOTES item (c)** "FiscalStatusBadge unificado" (NfceStatusBadge → NF-e 55 + NFS-e) — não duplicar. Provavelmente sai como reuso do componente fiscal compartilhado, não código novo no OficinaAuto.
+
+### Descartar p/ OficinaAuto
+- Switch de vertical (delta #10): é arquitetura multi-vertical do shell, não da OS. Fora de escopo.
+
+---
+
+## Decisão pendente de Wagner (Tier 0)
+
+**Consolidar ou estender?**
+
+- **Opção A — Estender (recomendado):** manter `Create` (form rápido) + `Show` (detalhe rico) e plugar os deltas P1/P2 no `Show`. Baixo risco, respeita "estender não recriar", cada PR pequeno. A cliente já validou o módulo atual.
+- **Opção B — Consolidar:** transformar a OS num único workspace full-screen espelhando o protótipo (Create+Show fundidos). Maior valor de UX (o que brilhou os olhos da Kamila em chat37) mas é refactor grande, Tier 0 → exige **ADR próprio** + sign-off antes de codar.
+
+Sem decisão, o caminho seguro é **Opção A, P1 primeiro** (check-in + combustível), que é aditivo e não conflita com nenhuma das duas opções futuras.
+
+---
+
+## Procedência (handoff bundle)
+
+- Fonte: Claude Design bundle `Oimpresso ERP Conunicação Visual` (claude.ai/design), arquivo `project/oficina-os-page.jsx` + `oficina-os-page.css` + `data-os.jsx`.
+- Intenção (chats): chat37 (2026-06-02) — foco na homologação Martinho; *"o fluxo real da Oficina… Recepção → Diagnóstico (DVI semáforo) → Orçamento → Aprovação (gate) → Execução… é o diferencial que brilhou os olhos dela."*
+- Regras aplicadas: README do bundle ("recriar o output visual, perguntar se ambíguo, não copiar estrutura do protótipo"), ADR 0104 (MWART), commit-discipline (1 PR = 1 US), handoff §10.4 ("F1 = proposta, estender não recriar").

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Create.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Create.tsx
@@ -45,6 +45,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/Components/ui/sheet';
+import EntryCheckinFields from './_components/EntryCheckinFields';
 
 interface Vehicle {
   id: number;
@@ -72,6 +73,8 @@ export default function ServiceOrdersCreate({ vehicles, statuses }: Props) {
     vehicle_id: '',
     transaction_id: '',
     mileage_at_service: '',
+    fuel_level_at_entry: '',
+    entry_damages: [] as string[],
     status: 'aberta',
     entered_at: '',
     expected_completion: '',
@@ -280,6 +283,14 @@ export default function ServiceOrdersCreate({ vehicles, statuses }: Props) {
                 <p className="text-sm text-destructive mt-1">{errors.notes}</p>
               )}
             </div>
+
+            <EntryCheckinFields
+              fuelLevel={data.fuel_level_at_entry}
+              damages={data.entry_damages}
+              onFuelChange={(v) => setData('fuel_level_at_entry', v)}
+              onDamagesChange={(v) => setData('entry_damages', v)}
+              fuelError={errors.fuel_level_at_entry}
+            />
 
             <div className="flex justify-end gap-2 pt-4 border-t sticky bottom-0 bg-background -mx-1 px-1 pb-2">
               <Button variant="outline" type="button" onClick={handleClose}>

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Edit.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Edit.tsx
@@ -25,6 +25,7 @@ import ServiceOrderItemRow, {
   type ServiceOrderItemDto,
 } from './_components/ServiceOrderItemRow';
 import ServiceOrderItemFormSheet from './_components/ServiceOrderItemFormSheet';
+import EntryCheckinFields from './_components/EntryCheckinFields';
 
 interface ServiceOrder {
   id: number;
@@ -32,6 +33,8 @@ interface ServiceOrder {
   transaction_id: number | null;
   status: string;
   mileage_at_service: number | null;
+  fuel_level_at_entry: number | null;
+  entry_damages: string[] | null;
   entered_at: string | null;
   expected_completion: string | null;
   completed_at: string | null;
@@ -81,6 +84,8 @@ export default function ServiceOrdersEdit({ order, vehicles, statuses }: Props) 
     vehicle_id: String(order.vehicle_id),
     transaction_id: order.transaction_id ? String(order.transaction_id) : '',
     mileage_at_service: order.mileage_at_service?.toString() ?? '',
+    fuel_level_at_entry: order.fuel_level_at_entry?.toString() ?? '',
+    entry_damages: order.entry_damages ?? [],
     status: order.status,
     entered_at: toLocalInput(order.entered_at),
     expected_completion: toLocalInput(order.expected_completion),
@@ -295,6 +300,14 @@ export default function ServiceOrdersEdit({ order, vehicles, statuses }: Props) 
                 className="w-full rounded-md border bg-background px-3 py-2 text-sm"
               />
             </div>
+
+            <EntryCheckinFields
+              fuelLevel={data.fuel_level_at_entry}
+              damages={data.entry_damages}
+              onFuelChange={(v) => setData('fuel_level_at_entry', v)}
+              onDamagesChange={(v) => setData('entry_damages', v)}
+              fuelError={errors.fuel_level_at_entry}
+            />
 
             {/* ───── Section inline "Itens da OS" (Wave 5 US-OFICINA-005-bis) ───── */}
             <section className="pt-2">

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx
@@ -7,7 +7,7 @@
 import { useCallback, useMemo, useState } from 'react';
 import AppShellV2 from '@/Layouts/AppShellV2';
 import { Head, Link } from '@inertiajs/react';
-import { Wrench, ArrowLeft, Edit, Package, Printer } from 'lucide-react';
+import { Wrench, ArrowLeft, Edit, Package, Printer, Fuel } from 'lucide-react';
 import { toast } from 'sonner';
 import { Button } from '@/Components/ui/button';
 import PageHeader from '@/Components/shared/PageHeader';
@@ -26,6 +26,8 @@ interface ServiceOrder {
   completed_at: string | null;
   delivered_at: string | null;
   mileage_at_service: number | null;
+  fuel_level_at_entry: number | null;
+  entry_damages: string[] | null;
   transaction_id: number | null;
   notes: string | null;
   vehicle: {
@@ -226,6 +228,48 @@ export default function ServiceOrdersShow({ order }: Props) {
             <div className="mt-4 pt-4 border-t">
               <p className="text-sm font-medium mb-1">Observações</p>
               <p className="text-sm text-muted-foreground whitespace-pre-wrap">{order.notes}</p>
+            </div>
+          )}
+
+          {/* Check-in de entrada — US-OFICINA-038/039 (delta protótipo Cowork Nova OS) */}
+          {(order.fuel_level_at_entry !== null ||
+            (order.entry_damages?.length ?? 0) > 0) && (
+            <div className="mt-4 pt-4 border-t space-y-3">
+              <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+                Check-in de entrada
+              </p>
+              {order.fuel_level_at_entry !== null && (
+                <div className="flex items-center gap-3">
+                  <span className="flex items-center gap-1.5 text-sm text-muted-foreground">
+                    <Fuel className="size-3.5" />
+                    Combustível
+                  </span>
+                  <div className="flex-1 max-w-xs h-2 rounded-full bg-muted overflow-hidden">
+                    <div
+                      className="h-full bg-primary"
+                      style={{ width: `${Math.max(0, Math.min(100, order.fuel_level_at_entry))}%` }}
+                    />
+                  </div>
+                  <span className="text-xs tabular-nums text-muted-foreground">
+                    {order.fuel_level_at_entry}%
+                  </span>
+                </div>
+              )}
+              {(order.entry_damages?.length ?? 0) > 0 && (
+                <div>
+                  <p className="text-sm text-muted-foreground mb-1">Avarias na entrada</p>
+                  <div className="flex flex-wrap gap-1.5">
+                    {order.entry_damages!.map((d, i) => (
+                      <span
+                        key={`${d}-${i}`}
+                        className="rounded-full bg-secondary text-secondary-foreground text-xs px-2 py-0.5"
+                      >
+                        {d}
+                      </span>
+                    ))}
+                  </div>
+                </div>
+              )}
             </div>
           )}
         </div>

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/EntryCheckinFields.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/EntryCheckinFields.tsx
@@ -1,0 +1,156 @@
+// EntryCheckinFields — check-in de entrada da OS (US-OFICINA-038 + US-OFICINA-039).
+// Delta do protótipo Cowork "Nova OS" (oficina-os-page.jsx seção "Check-in do veículo").
+// Compartilhado por Create.tsx e Edit.tsx pra não duplicar (DRY).
+//
+// Captura o estado de entrada que protege oficina e cliente:
+//  - fuel_level_at_entry: nível de combustível 0–100% (barra)
+//  - entry_damages: avarias marcadas na entrada (chips)
+// O "relato do cliente" reusa o campo `notes` existente — não entra aqui.
+
+import { useState } from 'react';
+import { Fuel, Plus, X } from 'lucide-react';
+import { Label } from '@/Components/ui/label';
+import { Input } from '@/Components/ui/input';
+import { Button } from '@/Components/ui/button';
+
+const DAMAGE_PRESETS = [
+  'Risco',
+  'Amassado',
+  'Para-brisa trincado',
+  'Farol quebrado',
+  'Retrovisor',
+  'Pneu careca',
+];
+
+interface Props {
+  fuelLevel: string;
+  damages: string[];
+  onFuelChange: (value: string) => void;
+  onDamagesChange: (value: string[]) => void;
+  fuelError?: string;
+}
+
+export default function EntryCheckinFields({
+  fuelLevel,
+  damages,
+  onFuelChange,
+  onDamagesChange,
+  fuelError,
+}: Props) {
+  const [draft, setDraft] = useState('');
+
+  const fuelPct = Math.max(0, Math.min(100, Number(fuelLevel) || 0));
+
+  function addDamage(label: string) {
+    const clean = label.trim().slice(0, 80);
+    if (!clean) return;
+    if (damages.some((d) => d.toLowerCase() === clean.toLowerCase())) return;
+    onDamagesChange([...damages, clean]);
+    setDraft('');
+  }
+
+  function removeDamage(index: number) {
+    onDamagesChange(damages.filter((_, i) => i !== index));
+  }
+
+  return (
+    <div className="rounded-md border bg-muted/30 p-3 space-y-4">
+      <p className="text-xs font-semibold text-muted-foreground uppercase tracking-wider">
+        Check-in de entrada
+      </p>
+
+      {/* Combustível — US-OFICINA-039 */}
+      <div data-field="fuel_level_at_entry">
+        <Label htmlFor="fuel_level_at_entry" className="flex items-center gap-1.5">
+          <Fuel className="size-3.5" />
+          Combustível na entrada
+        </Label>
+        <div className="flex items-center gap-3 mt-1">
+          <Input
+            id="fuel_level_at_entry"
+            type="number"
+            min={0}
+            max={100}
+            value={fuelLevel}
+            onChange={(e) => onFuelChange(e.target.value)}
+            aria-invalid={!!fuelError}
+            className="w-24"
+            placeholder="%"
+          />
+          <div
+            className="flex-1 h-2 rounded-full bg-muted overflow-hidden"
+            role="progressbar"
+            aria-valuenow={fuelPct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+          >
+            <div
+              className="h-full bg-primary transition-all"
+              style={{ width: `${fuelPct}%` }}
+            />
+          </div>
+          <span className="text-xs tabular-nums text-muted-foreground w-10 text-right">
+            {fuelLevel === '' ? '—' : `${fuelPct}%`}
+          </span>
+        </div>
+        {fuelError && <p className="text-sm text-destructive mt-1">{fuelError}</p>}
+      </div>
+
+      {/* Avarias na entrada — US-OFICINA-038 */}
+      <div>
+        <Label className="block mb-1">Avarias na entrada</Label>
+        {damages.length > 0 && (
+          <div className="flex flex-wrap gap-1.5 mb-2">
+            {damages.map((d, i) => (
+              <span
+                key={`${d}-${i}`}
+                className="inline-flex items-center gap-1 rounded-full bg-secondary text-secondary-foreground text-xs px-2 py-0.5"
+              >
+                {d}
+                <button
+                  type="button"
+                  onClick={() => removeDamage(i)}
+                  aria-label={`Remover ${d}`}
+                  className="hover:text-destructive"
+                >
+                  <X className="size-3" />
+                </button>
+              </span>
+            ))}
+          </div>
+        )}
+        <div className="flex gap-2">
+          <Input
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault();
+                addDamage(draft);
+              }
+            }}
+            placeholder="Descreva a avaria e tecle Enter…"
+            maxLength={80}
+          />
+          <Button type="button" variant="outline" onClick={() => addDamage(draft)}>
+            <Plus className="size-4" />
+          </Button>
+        </div>
+        <div className="flex flex-wrap gap-1.5 mt-2">
+          {DAMAGE_PRESETS.filter(
+            (p) => !damages.some((d) => d.toLowerCase() === p.toLowerCase()),
+          ).map((p) => (
+            <button
+              key={p}
+              type="button"
+              onClick={() => addDamage(p)}
+              className="rounded-full border border-dashed text-xs px-2 py-0.5 text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+            >
+              + {p}
+            </button>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Contexto

Implementa o **check-in de entrada do veículo** na OS — o primeiro delta do protótipo Claude Design / Cowork **"Nova OS"** (`oficina-os-page.jsx`) sobre o módulo OficinaAuto já embarcado em `main`.

Origem: handoff bundle `claude.ai/design` (`Oimpresso ERP Conunicação Visual`). A tela "Oficina OS" do protótipo **já está migrada** (MWART F1–F3 completos) — então o trabalho é fechar os *deltas*, não re-migrar. Análise completa em [`oficina-os-nova-prototipo-visual-comparison.md`](https://github.com/wagnerra23/oimpresso.com/blob/feat/oficina-os-checkin/memory/requisitos/OficinaAuto/oficina-os-nova-prototipo-visual-comparison.md).

Escopo: **delta P1 (aditivo, baixo risco)** — não consolida Create/Show (isso é decisão Tier 0 separada, com ADR).

## O que entra (US-OFICINA-038 + US-OFICINA-039)

| Delta protótipo | Antes | Agora |
|---|---|---|
| Combustível na entrada (barra) | ❌ ausente | ✅ `fuel_level_at_entry` 0–100% + barra |
| Avarias na entrada (chips) | ❌ ausente | ✅ `entry_damages` (array) + chips/presets |
| Relato do cliente | já = `notes` | reusa `notes` (sem coluna nova) |
| Fotos de entrada | — | **deferido** pra US futura (reusa `HasArquivos`, ADR 0123) |

## Mudanças
- **Migration** `2026_06_02_000010_add_checkin_fields_to_service_orders` — idempotente (`Schema::hasColumn`) + `down()` reversível
- **ServiceOrder** — fillable + casts (`integer`/`array`) + activitylog `logOnly`
- **Store/UpdateServiceOrderRequest** — regras (combustível 0–100; avarias `array`, itens `string|max:80`)
- **`EntryCheckinFields`** — componente compartilhado (Create + Edit), tokens semânticos
- **Show.tsx** — exibição read-only (barra + chips)
- **Pest** `ServiceOrderCheckinTest` — roundtrip array + validação

## Validação
- ✅ `php -l` limpo nos 5 PHP
- ✅ `tsc --noEmit` — **zero erros novos** (os erros em Index/Show/Edit são baseline pré-existente em `origin/main`, fora do meu diff)
- ⏳ **Pest MySQL roda no CI** — os testes OficinaAuto skipam em sqlite por design (ADR 0101); `phpunit.xml` usa sqlite `:memory:`, então não rodam localmente
- Multi-tenant Tier 0 (ADR 0093) preservado (business_id via global scope + creating hook)

## Notas
- MWART: F1 (RUNBOOK/SPEC já existem) + F2/F3 num PR coeso (módulo já 100% Inertia, sem Blade dual). ~421 LOC de código (156 são o componente novo + 119 o teste).
- **Merge fica com o Wagner** (publication-policy). Próximos deltas (DVI→orçamento, gate de aprovação in-screen, painel fiscal) seguem em PRs separados.

🤖 Generated with [Claude Code](https://claude.com/claude-code)