### PR TITLE
feat(jana): ADR 0245 + liga Metade A (clarify) em homolog

### DIFF
--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -477,16 +477,16 @@ return [
     | Medição: log channel copiloto-ai → evento `clarify_event` (gray-hit, taxa de
     | clarify, false-clarify proxy). Sem isso é fé, não engenharia.
     |
-    | VALORES DIRETOS, SEM env() — Larastan barra env() fora de config/ raiz (mesma
-    | razão do bloco peso_real). Default OFF. Pra LIGAR em homolog, Wagner seta via
-    | config() runtime (`config(['copiloto.clarify.enabled' => true])`) ou registra
-    | override no published config/copiloto.php. O `model` aponta um frontier (gpt-4o,
-    | mais forte que o gpt-4o-mini do chat); trocável pelo mesmo caminho.
+    | CONTROLE POR AMBIENTE: o flag/modelo/provider são env-driven (homolog liga, prod
+    | espera) — ADR 0245. As 3 chaves env() entram na contagem baselined do Larastan
+    | (noEnvCallsOutsideOfConfig) deste arquivo, igual reranker/freshness. As demais são
+    | constantes de tuning (valores diretos). Default OFF: com a flag OFF o pipeline de
+    | chat é byte-idêntico ao legado.
     */
     'clarify' => [
-        'enabled'  => false,            // default OFF — Wagner liga em homolog (config runtime/published)
-        'provider' => null,             // null → config('ai.default') (mesmo provider do chat)
-        'model'    => 'gpt-4o',         // roteamento seletivo difícil → frontier (vs gpt-4o-mini do chat)
+        'enabled'  => (bool) env('JANA_CLARIFY_ENABLED', false),   // homolog liga; prod espera (ADR 0245)
+        'provider' => env('JANA_CLARIFY_PROVIDER'),                // null → config('ai.default') (provider do chat)
+        'model'    => env('JANA_CLARIFY_MODEL', 'gpt-4o'),         // frontier seletivo (vs gpt-4o-mini do chat)
         // Confiança mínima do disambiguador p/ realmente perguntar (anti false-clarify).
         'min_confianca'          => 0.6,
         // Heurística 1a (zero-custo) — limites do "cinza".

--- a/docker/oimpresso-staging/.env.staging.example
+++ b/docker/oimpresso-staging/.env.staging.example
@@ -52,5 +52,11 @@ SCOUT_DRIVER=null                     # sem Meilisearch (ou apontar índice _sta
 MCP_TOOLS_EXPOSED=false
 CENTRIFUGO_ENABLED=false
 
+# Jana Advisor — Metade A (clarify reativo, ADR 0245): LIGADO em homolog pra medir
+# `clarify_event`. Default OFF em prod. Modelo frontier gpt-4o (provider openai, só dispara
+# no ~20% cinza). Acompanhar log copiloto-ai (gray-hit / taxa de clarify / false-clarify).
+JANA_CLARIFY_ENABLED=true
+JANA_CLARIFY_MODEL=gpt-4o
+
 # Octane OFF: staging roda FrankenPHP modo clássico (ver entrypoint-staging.sh)
 OCTANE_SERVER=

--- a/memory/decisions/0245-jana-advisor-modo-consultor-clarify.md
+++ b/memory/decisions/0245-jana-advisor-modo-consultor-clarify.md
@@ -9,7 +9,7 @@ lifecycle: ativo
 decided_by: [W]
 decided_at: "2026-06-02"
 proposed_at: "2026-06-02"
-module: Jana
+module: jana
 quarter: 2026-Q2
 supersedes: []
 related:

--- a/memory/decisions/0245-jana-advisor-modo-consultor-clarify.md
+++ b/memory/decisions/0245-jana-advisor-modo-consultor-clarify.md
@@ -1,0 +1,90 @@
+---
+slug: 0245-jana-advisor-modo-consultor-clarify
+number: 245
+title: "Jana Modo Consultor (Advisor) — clarify reativo (cascata Decidir→Clarificar→Responder)"
+type: adr
+status: aceito
+authority: canonical
+lifecycle: ativo
+decided_by: [W]
+decided_at: "2026-06-02"
+proposed_at: "2026-06-02"
+module: Jana
+quarter: 2026-Q2
+supersedes: []
+related:
+  - 0035-stack-ai-canonica-wagner-2026-04-26
+  - 0091-daily-brief
+  - 0141-agents-tool-use-pattern-claude-code
+  - 0093-multi-tenant-isolation-tier-0
+  - 0047-wagner-solo-sprint-memoria-agente
+---
+
+# ADR 0245 — Jana "Modo Consultor" (Advisor): clarify reativo
+
+> Promove a proposta `memory/decisions/proposals/jana-advisor-modo-consultor.md` (§10.4),
+> mergeada em [PR #2134](https://github.com/wagnerra23/oimpresso.com/pull/2134), a decisão canônica.
+> **Metade A** desta ADR. A **Metade B** (próxima-melhor-pergunta proativa) entra em ADR/PR próprio.
+
+## Contexto
+
+O chat da Jana respondia toda mensagem direto: **chutava** quando a intenção era ambígua e às
+vezes **perguntava** quando era só falta de dado (que ele busca sozinho via tool/RAG). Confundir
+**ambiguidade-de-intenção** com **falta-de-dado** é o erro nº1 dos LLMs.
+
+Estado-da-arte 2025 que ancora a decisão:
+- **Active Task Disambiguation** (ICLR 2025 Spotlight): qualidade vem de **fazer perguntas melhores**,
+  não só dar respostas melhores — a pergunta de **maior ganho de informação**.
+- **INTENT-SIM** (NAACL 2025): **decoupla** ambiguidade-de-intenção (→ perguntar) de falta-de-dado
+  (→ buscar). Cascata p/ latência.
+
+Princípio: subir o raciocínio é **andaime** (scaffold), **não** troca de modelo — a escolha de
+scaffold move desempenho em até ~30pp no mesmo modelo.
+
+## Decisão
+
+Introduzir a cascata **Decidir → Clarificar → Responder** no chat da Jana, como capacidade
+**aditiva** que **estende** (não recria) os Agents/driver/`MemoriaContrato`:
+
+1. **Decidir (barato):** heurística local zero-LLM (`ClarifyCascadeService::pareceCinza`) resolve
+   ~80% direto → responde. Default conservador = responder.
+2. **Clarificar (caro, só no ~20% "cinza"):** `ClarificadorAgent` (5º agente, `HasStructuredOutput`,
+   **roteamento de modelo seletivo difícil→frontier** via config) decide `claro | falta_dado | ambiguo`
+   e, se ambíguo, devolve a pergunta de **maior ganho de informação**.
+3. **Responder:** com a intenção resolvida, segue o pipeline normal (`ChatCopilotoAgent`).
+
+Garantias duras (Tier 0):
+- **Default-OFF** (`copiloto.clarify.enabled`) — com a flag OFF o pipeline de chat é
+  **byte-idêntico** ao legado (mesma postura de `contextual_retrieval` / `peso_real`).
+- **Fail-open:** qualquer erro → responde (a cascata nunca quebra o chat).
+- **Honestidade:** não inventa pergunta; só clarifica quando o disambiguador devolve uma de alto valor.
+- **Anti-loop:** não pergunta 2× seguidas (marcador TTL em cache).
+- **PII Tier 0 (ADR 0093):** histórico/contexto vão PII-redigidos pro disambiguador.
+- **Medição:** log `copiloto-ai` → evento `clarify_event` (gray-hit, taxa de clarify, false-clarify).
+
+Roteamento de modelo: `copiloto.clarify.model` (default `gpt-4o`, provider `openai` já configurado —
+mais forte que o `gpt-4o-mini` do chat, mas só dispara no cinza). Toggle e modelo são **env-driven**
+(`JANA_CLARIFY_ENABLED` / `JANA_CLARIFY_MODEL`) para controle por ambiente (homolog liga, prod espera).
+
+## Consequências
+
+**Positivas:**
+- Conserta o pior hábito (chutar no ambíguo) sem trocar de modelo — andaime barato.
+- Menos re-trabalho do gestor; menos resposta-errada-confiante.
+- Base p/ a Metade B (a IA passa a **pautar**, não só responder).
+
+**Custos/riscos:**
+- +1 chamada LLM (frontier) no ~20% cinza — mitigado pela cascata (heurística resolve ~80% free).
+- Risco de **false-clarify** (perguntar no óbvio) — mitigado por heurística conservadora +
+  gate de confiança + medição `clarify_event`.
+- Métrica **pergunta→ação** (sinal de valor real) precisa de hook no frontend — pendência aberta
+  (ver RUNBOOK).
+
+**Rollout:** ligar em **homolog** primeiro (`JANA_CLARIFY_ENABLED=true`, modelo `gpt-4o`), medir
+`clarify_event` 1-2 semanas, então decidir prod. Sem migration — flag reverte sem rollback.
+
+## Referências
+
+- PR #2134 (Metade A) · proposta `proposals/jana-advisor-modo-consultor.md`
+- RUNBOOK `memory/requisitos/Jana/RUNBOOK-jana-advisor-clarify.md`
+- Active Task Disambiguation (ICLR 2025 Spotlight) · INTENT-SIM (NAACL 2025)

--- a/memory/decisions/proposals/jana-advisor-modo-consultor.md
+++ b/memory/decisions/proposals/jana-advisor-modo-consultor.md
@@ -1,6 +1,6 @@
 # Jana "Modo Consultor" (Advisor) — Metade A: clarify reativo — 2026-06-02
 
-> **Status:** PROPOSAL §10.4 · **não-canon, não-ADR** · número de ADR **não cunhado** (soberania [W], ADR 0238 — [W] numera se promover).
+> **Status:** ✅ PROMOVIDO → **[ADR 0245](../0245-jana-advisor-modo-consultor-clarify.md)** (aceito por [W] em 2026-06-02, pós-merge PR #2134). Este proposal vira registro histórico da origem §10.4; a decisão canônica vive na ADR 0245.
 > **Tipo:** evolução de produto (Modules/Jana — chat/raciocínio) · **Tier 0** (produto + custo) → PR aberto, **espera [W]**.
 > **Autor:** [CL] Claude Code · **Origem:** peer-review (L-17) do pedido [CC] `PROMPT_PARA_CODE_JANA-ADVISOR-MODE.md` (sessão 2026-06-02). Insight [W]: *"as melhores respostas vêm quando eu pergunto que pergunta eu deveria fazer, porque nem eu sei o que é melhor."*
 > **Natureza:** peer-review, não ordem — [CL] avaliou se procede e onde mora melhor.

--- a/memory/requisitos/Jana/RUNBOOK-jana-advisor-clarify.md
+++ b/memory/requisitos/Jana/RUNBOOK-jana-advisor-clarify.md
@@ -2,13 +2,15 @@
 title: "Jana Advisor (Modo Consultor) — Metade A: Clarify reativo"
 module: Jana
 owner: W
-status: rascunho
+status: ativo
 last_validated: "2026-06-02"
+related_adrs:
+  - 0245-jana-advisor-modo-consultor-clarify
 preconditions:
-  - "copiloto.clarify.enabled=true (default OFF — via config runtime/published)"
-  - "copiloto.clarify.model = modelo frontier"
+  - "JANA_CLARIFY_ENABLED=true (default OFF; ligado em homolog via .env.staging)"
+  - "JANA_CLARIFY_MODEL = modelo frontier (default gpt-4o)"
 steps:
-  - "Ligar a flag em homolog"
+  - "Ligar a flag em homolog (.env.staging JANA_CLARIFY_ENABLED=true)"
   - "Disparar mensagens cinza e claras no chat da Jana"
   - "Medir clarify_event no log copiloto-ai (gray-hit, taxa de clarify, false-clarify)"
   - "Validar fail-open e anti-loop"
@@ -51,25 +53,23 @@ erros nº1 dos LLMs (INTENT-SIM, NAACL 2025 + Active Task Disambiguation, ICLR 2
 - Novos: `ClarificadorAgent` (5º agente, ao lado de ChatCopiloto/BriefDiario/Sugestoes/Briefing),
   `ClarifyCascadeService`, `ClarifyResult`. Recall (`MemoriaContrato`) e brief **intactos**.
 
-## Como ligar (homolog)
+## Como ligar (homolog) — ADR 0245
 
-Os knobs vivem em `Modules/Jana/Config/config.php` (bloco `clarify`, merged como
-`copiloto.clarify.*`). **Valores diretos, sem `env()`** — Larastan barra `env()` fora de
-`config/` raiz (mesma razão do bloco `peso_real`). Pra ligar em homolog, Wagner seta via
-**config runtime** (ex. num ServiceProvider/published config):
+O flag/modelo/provider são **env-driven** (controle por ambiente: homolog liga, prod espera).
+Em homolog já vem ligado via `docker/oimpresso-staging/.env.staging.example`:
 
-```php
-config(['copiloto.clarify.enabled' => true]);   // default false
-// opcionais:
-config(['copiloto.clarify.model' => 'gpt-4o']);          // frontier (vs gpt-4o-mini do chat)
-config(['copiloto.clarify.provider' => 'anthropic']);    // null = config('ai.default')
-config(['copiloto.clarify.min_confianca' => 0.6]);       // anti false-clarify
-config(['copiloto.clarify.gray_max_words' => 8]);        // limites do "cinza" (heurística 1a)
-config(['copiloto.clarify.anti_loop_ttl_segundos' => 600]);
+```env
+JANA_CLARIFY_ENABLED=true
+JANA_CLARIFY_MODEL=gpt-4o          # frontier seletivo (vs gpt-4o-mini do chat); só dispara no cinza
+# JANA_CLARIFY_PROVIDER=anthropic  # opcional; vazio = config('ai.default') (openai, provider do chat)
 ```
 
-Com `enabled=false` (default) o pipeline de chat é **byte-idêntico** ao legado (mesma
-postura de `contextual_retrieval` / `peso_real`).
+As constantes de tuning (`min_confianca`, `gray_max_words/chars`, `historico_turnos`,
+`anti_loop_ttl_segundos`) ficam diretas no bloco `clarify` de `Modules/Jana/Config/config.php`
+(merged como `copiloto.clarify.*`) — ajuste lá se precisar.
+
+Com `JANA_CLARIFY_ENABLED=false` (default em prod) o pipeline de chat é **byte-idêntico** ao
+legado (mesma postura de `contextual_retrieval` / `peso_real`).
 
 ## Como medir (senão é fé, não engenharia)
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -9500,7 +9500,7 @@ parameters:
 		-
 			message: '#^Called ''env'' outside of the config directory which returns null when the config is cached, use ''config''\.$#'
 			identifier: larastan.noEnvCallsOutsideOfConfig
-			count: 76
+			count: 79
 			path: Modules/Jana/Config/config.php
 
 		-


### PR DESCRIPTION
## Oficializa + habilita a Metade A do Jana Advisor (clarify reativo)

Sequência aprovada por [W] pós-merge da Metade A ([#2134](https://github.com/wagnerra23/oimpresso.com/pull/2134)).

### 1. ADR 0245 (aceito, canonical)
Promove o proposal §10.4 `jana-advisor-modo-consultor.md` → **decisão canônica**. Registra contexto (INTENT-SIM/ICLR 2025), decisão (cascata Decidir→Clarificar→Responder), e consequências (custo/risco/rollout). Proposal vira registro histórico apontando pra ADR.

> **Nota de numeração:** `memory/decisions/` topa em 0236 no main, mas config/brief referenciam 0237–0244 (in-flight/MCP). Usei **0245** acima da faixa referenciada. Se colidir com ADR em voo, é só renomear (tooling existe) — soberania de numeração é tua.

### 2. Flag env-driven (controle por ambiente)
`enabled`/`model`/`provider` viram `env()` (`JANA_CLARIFY_*`) — homolog liga, prod espera. +3 `env()` no bloco clarify → **baseline Larastan 76→79** (mesma convenção de reranker/freshness; as constantes de tuning seguem diretas, sem env). Verificado: PHPStan sem `ignore.count` mismatch.

### 3. Ligado em homolog
`docker/oimpresso-staging/.env.staging.example`: `JANA_CLARIFY_ENABLED=true` + `JANA_CLARIFY_MODEL=gpt-4o` (provider openai já configurado, só dispara no ~20% cinza). Mede `clarify_event` antes de prod.

**Default em prod continua OFF** → pipeline de chat byte-idêntico ao legado.

RUNBOOK atualizado (status ativo, related_adrs 0245, "como ligar" via env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)