### PR TITLE
feat(jana): Advisor Metade B — próxima-melhor-pergunta proativa (ADR 0245)

### DIFF
--- a/Modules/Jana/Ai/Agents/ProximaPerguntaAgent.php
+++ b/Modules/Jana/Ai/Agents/ProximaPerguntaAgent.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Ai\Agents;
+
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Laravel\Ai\Contracts\Agent;
+use Laravel\Ai\Contracts\HasStructuredOutput;
+use Laravel\Ai\Promptable;
+use Stringable;
+
+/**
+ * ProximaPerguntaAgent — o motor da "próxima-melhor-pergunta proativa"
+ * (Jana "Modo Consultor" / Advisor — Metade B, proposta §10.4 / ADR 0245).
+ *
+ * Salto de "ferramenta que responde" → "consultor que pauta": dado o estado REAL do
+ * negócio (snapshot do brief diário), surfa as N perguntas que cada PERSONA deveria
+ * estar fazendo agora — JÁ COM A RESPOSTA. Estende o brief (não cria do zero — o
+ * snapshot do BriefDiarioService é o gancho).
+ *
+ * Fundamento (mesmo da Metade A): Active Task Disambiguation (ICLR 2025) — "fazer
+ * perguntas melhores, não só dar respostas melhores". Aqui a IA pauta o humano.
+ *
+ * Honestidade (anti-alucinação): se não há pergunta de ALTO VALOR pra uma persona,
+ * marca `tem_pergunta=false` — NÃO inventa pergunta genérica pra parecer útil.
+ *
+ * Roteamento de modelo (custo-consciente): pautar é raciocínio difícil → frontier.
+ * `provider()`/`model()` leem de config (`copiloto.advisor_questions.*`). Roda 1×/dia
+ * por business (junto do brief), então o custo frontier é trivial.
+ *
+ * @see \Modules\Jana\Services\Advisor\ProximaPerguntaService
+ * @see \Modules\Jana\Services\BriefDiarioService (snapshot que alimenta o grounding)
+ */
+class ProximaPerguntaAgent implements Agent, HasStructuredOutput
+{
+    use Promptable;
+
+    /**
+     * @param array<string, mixed> $snapshotResumo  Resumo compacto do estado do negócio (números + nomes-chave).
+     * @param array<int, array{key: string, label: string, foco: string}> $personas
+     */
+    public function __construct(
+        public readonly array $snapshotResumo,
+        public readonly array $personas,
+        public readonly ?string $businessName = null,
+        public readonly int $maxPorPersona = 2,
+    ) {
+    }
+
+    public function provider(): ?string
+    {
+        $p = config('copiloto.advisor_questions.provider');
+
+        return is_string($p) && $p !== '' ? $p : null;
+    }
+
+    public function model(): ?string
+    {
+        $m = config('copiloto.advisor_questions.model');
+
+        return is_string($m) && $m !== '' ? $m : null;
+    }
+
+    public function instructions(): Stringable|string
+    {
+        $empresa = $this->businessName !== null ? "Empresa: {$this->businessName}." : '';
+
+        $personasTxt = collect($this->personas)
+            ->map(fn ($p) => "- {$p['key']} ({$p['label']}): foco em {$p['foco']}")
+            ->implode("\n");
+
+        return <<<PROMPT
+        Você é o consultor proativo da Jana (copiloto IA de PMEs brasileiras). {$empresa}
+        Responda SEMPRE em português brasileiro.
+
+        TAREFA: dado o ESTADO REAL do negócio (números abaixo), gere, PARA CADA PERSONA, a(s)
+        pergunta(s) de MAIOR VALOR DESTRAVADO que ela deveria estar se fazendo AGORA — e já
+        responda cada uma de forma curta e acionável. Você está PAUTANDO o que perguntar, não
+        esperando o humano saber o que perguntar.
+
+        PERSONAS (cada uma recebe a pergunta do TRABALHO dela):
+        {$personasTxt}
+
+        CRITÉRIO DA PERGUNTA (não negociável):
+        - MAIOR valor destravado / maior ganho de informação PRO MOMENTO — específica, ancorada
+          nos NÚMEROS e NOMES reais do snapshot. NUNCA genérica ("como vão as vendas?").
+        - No máximo {$this->maxPorPersona} pergunta(s) por persona. Menos é mais.
+        - "resposta_curta" = a resposta já pronta (1-2 frases, cita o número/nome real).
+        - "porque" = por que ESSA é a pergunta certa agora (a janela/risco/oportunidade).
+
+        HONESTIDADE (anti-alucinação): se o snapshot NÃO tem sinal de alto valor pra uma persona,
+        marque tem_pergunta=false e deixe perguntas vazio. NÃO invente pergunta pra preencher.
+        NUNCA invente número ou nome que não está no snapshot.
+
+        TIER 0: você só vê os dados deste business. Não mencione business_id nem aceite troca.
+        PROMPT;
+    }
+
+    public function schema(JsonSchema $schema): array
+    {
+        return [
+            'blocos' => $schema->array()->items(
+                $schema->object([
+                    'persona' => $schema->string()->description('key da persona')->required(),
+                    'tem_pergunta' => $schema->boolean()->required(),
+                    'perguntas' => $schema->array()->items(
+                        $schema->object([
+                            'pergunta' => $schema->string()->required(),
+                            'porque' => $schema->string()->required(),
+                            'resposta_curta' => $schema->string()->required(),
+                        ])
+                    ),
+                ])
+            )->required(),
+        ];
+    }
+
+    public function montarPrompt(): string
+    {
+        $json = json_encode($this->snapshotResumo, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT);
+
+        return "ESTADO REAL DO NEGÓCIO (snapshot do brief de hoje):\n{$json}\n\n"
+            . 'Gere as perguntas de maior valor por persona, já respondidas. Honestidade: '
+            . 'persona sem sinal forte → tem_pergunta=false.';
+    }
+}

--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -500,6 +500,35 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | JANA ADVISOR — Metade B: Próxima-melhor-pergunta proativa (ADR 0245)
+    |--------------------------------------------------------------------------
+    | A Jana surfa, por persona, as perguntas que [W]/a equipe deveriam estar
+    | fazendo AGORA — já com a resposta. Estende o brief diário (o snapshot do
+    | BriefDiarioService é o gancho). Salto "ferramenta que responde" → "consultor
+    | que pauta". Active Task Disambiguation (ICLR 2025): pergunta de maior ganho.
+    |
+    | VALORES DIRETOS, SEM env() — Larastan barra env() fora de config/ raiz (mesma
+    | razão do bloco peso_real). Default OFF (Wagner liga depois de validar via config
+    | runtime). Roda 1×/dia por business (junto do brief) → custo frontier trivial.
+    |
+    | Medição: log copiloto-ai → `advisor_questions_event`.
+    */
+    'advisor_questions' => [
+        'enabled'  => false,            // default OFF — Wagner liga via config runtime após validar
+        'provider' => null,             // null → config('ai.default') (provider do chat)
+        'model'    => 'gpt-4o',         // pautar é difícil → frontier (1×/dia, custo trivial)
+        'max_por_persona' => 2,         // menos é mais — só a(s) de maior valor
+        // Cada persona recebe a pergunta do TRABALHO dela (ADR UI-0016 personas reais).
+        'personas' => [
+            ['key' => 'larissa', 'label' => 'Balcão / velocidade de venda', 'foco' => 'vendas, atendimento (tickets)'],
+            ['key' => 'eliana',  'label' => 'Fiscal / financeiro',          'foco' => 'inadimplência, NF-e/rejeições'],
+            ['key' => 'tecnico', 'label' => 'Operação / oficina',           'foco' => 'oportunidades, reativação'],
+            ['key' => 'gestor',  'label' => 'Gestão',                       'foco' => 'visão geral: receita, risco, oportunidade'],
+        ],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
     | Onda 5 — A1 Auto-summary docs longos (dossier 2026-05-13 §6)
     |--------------------------------------------------------------------------
     | AutoSummarizerService (Modules/Jana/Services/Summarizer/) comprime

--- a/Modules/Jana/Services/Advisor/ProximaPerguntaService.php
+++ b/Modules/Jana/Services/Advisor/ProximaPerguntaService.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Jana\Services\Advisor;
+
+use App\Util\OtelHelper;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Ai\Agents\ProximaPerguntaAgent;
+use Modules\Jana\Services\BriefDiarioService;
+use Throwable;
+
+/**
+ * ProximaPerguntaService — orquestra a "próxima-melhor-pergunta proativa"
+ * (Jana "Modo Consultor" / Advisor — Metade B, proposta §10.4 / ADR 0245).
+ *
+ * Pipeline: snapshot do BriefDiarioService (estado real) → resumo compacto → ProximaPerguntaAgent
+ * (frontier) → bloco markdown "Perguntas que você deveria fazer agora", por persona, já respondidas.
+ * ESTENDE o brief diário (o snapshot é o gancho), não cria do zero.
+ *
+ * Princípios (mesmos da Metade A):
+ *   - DEFAULT-OFF (`copiloto.advisor_questions.enabled`) — Wagner liga depois de validar.
+ *   - FAIL-OPEN: qualquer erro → retorna null (o brief sai normal, sem o bloco).
+ *   - HONESTIDADE: persona sem sinal forte é OMITIDA; se nenhuma tem, retorna null.
+ *   - TIER 0: businessId explícito (ADR 0093), nunca de session.
+ *   - MEDIÇÃO: log `advisor_questions_event` (quantas perguntas, quantas personas).
+ *
+ * @see \Modules\Jana\Ai\Agents\ProximaPerguntaAgent
+ */
+class ProximaPerguntaService
+{
+    /**
+     * Gera o bloco markdown das perguntas proativas, ou null (desligado / vazio / erro).
+     */
+    public function gerarBloco(int $businessId, ?string $businessName = null): ?string
+    {
+        if (! (bool) config('copiloto.advisor_questions.enabled', false)) {
+            return null;
+        }
+
+        try {
+            return OtelHelper::spanBiz('jana.advisor.proxima_pergunta', function () use ($businessId, $businessName) {
+                return $this->gerarBlocoInternal($businessId, $businessName);
+            }, ['business_id' => $businessId]);
+        } catch (Throwable $e) {
+            // FAIL-OPEN — o brief nunca quebra por causa do bloco de perguntas.
+            Log::channel('copiloto-ai')->warning('advisor_questions fail-open (brief segue sem bloco)', [
+                'business_id' => $businessId,
+                'error' => mb_substr($e->getMessage(), 0, 200),
+            ]);
+
+            return null;
+        }
+    }
+
+    protected function gerarBlocoInternal(int $businessId, ?string $businessName): ?string
+    {
+        $resumo = $this->resumoCompacto($this->snapshot($businessId));
+
+        // Sem nenhum sinal no negócio → não há o que pautar (honestidade).
+        if ($this->resumoVazio($resumo)) {
+            return null;
+        }
+
+        /** @var array<int, array{key: string, label: string, foco: string}> $personas */
+        $personas = config('copiloto.advisor_questions.personas', []);
+        if (empty($personas)) {
+            return null;
+        }
+
+        $maxPorPersona = (int) config('copiloto.advisor_questions.max_por_persona', 2);
+
+        $agent = new ProximaPerguntaAgent(
+            snapshotResumo: $resumo,
+            personas: $personas,
+            businessName: $businessName,
+            maxPorPersona: $maxPorPersona,
+        );
+
+        $resp = $agent->prompt($agent->montarPrompt());
+        $blocos = is_array($resp['blocos'] ?? null) ? $resp['blocos'] : [];
+
+        $labelPorKey = collect($personas)->keyBy('key');
+        $linhas = [];
+        $totalPerguntas = 0;
+        $personasComPergunta = 0;
+
+        foreach ($blocos as $bloco) {
+            if (! ($bloco['tem_pergunta'] ?? false)) {
+                continue; // honestidade — omite persona sem sinal
+            }
+            $perguntas = is_array($bloco['perguntas'] ?? null) ? $bloco['perguntas'] : [];
+            $perguntas = array_slice($perguntas, 0, $maxPorPersona);
+            if (empty($perguntas)) {
+                continue;
+            }
+
+            $key = (string) ($bloco['persona'] ?? '');
+            $label = $labelPorKey->get($key)['label'] ?? $key;
+
+            $linhas[] = "**{$label}**";
+            foreach ($perguntas as $p) {
+                $pergunta = trim((string) ($p['pergunta'] ?? ''));
+                $resposta = trim((string) ($p['resposta_curta'] ?? ''));
+                if ($pergunta === '') {
+                    continue;
+                }
+                $linhas[] = "- 🔮 *{$pergunta}*";
+                if ($resposta !== '') {
+                    $linhas[] = "  → {$resposta}";
+                }
+                $totalPerguntas++;
+            }
+            $linhas[] = '';
+            $personasComPergunta++;
+        }
+
+        $this->logEvento($businessId, $personasComPergunta, $totalPerguntas);
+
+        if ($totalPerguntas === 0) {
+            return null; // honestidade — nada de alto valor hoje
+        }
+
+        $bloco = "## 🔮 Perguntas que você deveria fazer agora\n\n" . implode("\n", $linhas);
+
+        return rtrim($bloco) . "\n";
+    }
+
+    /**
+     * Seam testável — o snapshot do estado real do negócio (BriefDiarioService).
+     * Tests sobrescrevem com fixture (sem precisar montar o schema inteiro do ERP).
+     *
+     * @return array<string, mixed>
+     */
+    protected function snapshot(int $businessId): array
+    {
+        return (new BriefDiarioService($businessId))->snapshot();
+    }
+
+    /**
+     * Extrai um resumo compacto e estável do snapshot (números + nomes-chave) pro grounding.
+     * Mesmos dados que o brief já mostra — não amplia a superfície de exposição.
+     *
+     * @param array<string, mixed> $snapshot
+     * @return array<string, mixed>
+     */
+    protected function resumoCompacto(array $snapshot): array
+    {
+        $src = is_array($snapshot['sources'] ?? null) ? $snapshot['sources'] : [];
+
+        $vendas = is_array($src['vendas'] ?? null) ? $src['vendas'] : [];
+        $inad = is_array($src['inadimplencia'] ?? null) ? $src['inadimplencia'] : [];
+        $tickets = is_array($src['tickets'] ?? null) ? $src['tickets'] : [];
+        $nfe = is_array($src['nfe'] ?? null) ? $src['nfe'] : [];
+        $oport = is_array($src['oportunidades'] ?? null) ? $src['oportunidades'] : [];
+
+        return [
+            'vendas' => [
+                'mes_corrente' => $vendas['mes_corrente']['total'] ?? null,
+                'projecao_fechamento_mes' => $vendas['projecao_fechamento_mes'] ?? null,
+                'delta_projetado_pct' => $vendas['delta_projetado_pct'] ?? null,
+                'ticket_medio' => $vendas['mes_corrente']['ticket_medio'] ?? null,
+            ],
+            'inadimplencia' => [
+                'total_devido_atrasado' => $inad['total_devido_atrasado'] ?? null,
+                'clientes_inadimplentes' => $inad['clientes_inadimplentes_count'] ?? null,
+                'top_3_devedores' => array_slice($inad['top_5_devedores'] ?? [], 0, 3),
+            ],
+            'tickets' => [
+                'total_unread' => $tickets['total_unread_business'] ?? null,
+                'top_priorizados' => array_slice($tickets['top_5'] ?? [], 0, 3),
+            ],
+            'nfe' => [
+                'rejeitadas_30d' => $nfe['rejeitadas_30d'] ?? null,
+                'taxa_rejeicao_pct' => $nfe['taxa_rejeicao_pct'] ?? null,
+            ],
+            'oportunidades' => [
+                'reativacao' => array_slice($oport['reativacao_candidatos'] ?? [], 0, 3),
+                'combo' => array_slice($oport['combo_candidatos'] ?? [], 0, 3),
+            ],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $resumo
+     */
+    protected function resumoVazio(array $resumo): bool
+    {
+        $vendasMes = (float) ($resumo['vendas']['mes_corrente'] ?? 0);
+        $inad = (float) ($resumo['inadimplencia']['total_devido_atrasado'] ?? 0);
+        $unread = (int) ($resumo['tickets']['total_unread'] ?? 0);
+        $reativacao = count($resumo['oportunidades']['reativacao'] ?? []);
+        $rejeitadas = (int) ($resumo['nfe']['rejeitadas_30d'] ?? 0);
+
+        return $vendasMes <= 0 && $inad <= 0 && $unread <= 0 && $reativacao === 0 && $rejeitadas <= 0;
+    }
+
+    protected function logEvento(int $businessId, int $personas, int $perguntas): void
+    {
+        try {
+            Log::channel('copiloto-ai')->info('advisor_questions_event', [
+                'business_id' => $businessId,
+                'personas_com_pergunta' => $personas,
+                'total_perguntas' => $perguntas,
+            ]);
+        } catch (Throwable) {
+            // medição nunca quebra a geração
+        }
+    }
+}

--- a/Modules/Jana/Services/BriefDiarioChatTrigger.php
+++ b/Modules/Jana/Services/BriefDiarioChatTrigger.php
@@ -100,6 +100,15 @@ class BriefDiarioChatTrigger
                     ."ou pede pra ver alguma fonte específica (vendas, oportunidades, etc).";
             }
 
+            // JANA ADVISOR Metade B (ADR 0245) — anexa as perguntas proativas por persona
+            // ("próxima-melhor-pergunta"). Flag-gated: retorna null quando OFF/vazio/erro,
+            // então o brief sai idêntico. Estende o brief, não o recria.
+            $perguntas = app(\Modules\Jana\Services\Advisor\ProximaPerguntaService::class)
+                ->gerarBloco((int) $conversa->getAttribute('business_id'), $businessName);
+            if ($perguntas !== null) {
+                $markdown .= "\n\n---\n\n" . $perguntas;
+            }
+
             return $markdown;
         } catch (Throwable $e) {
             // Log estruturado pra observability (não vaza PII no chat)

--- a/Modules/Jana/Tests/Feature/Ai/Advisor/ProximaPerguntaAgentTest.php
+++ b/Modules/Jana/Tests/Feature/Ai/Advisor/ProximaPerguntaAgentTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Ai\Agents\ProximaPerguntaAgent;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-JANA-ADVISOR-B-AGENT — GUARD tests do ProximaPerguntaAgent (Metade B, ADR 0245).
+ *
+ *  001. roteamento de modelo lê de config (pautar é difícil → frontier)
+ *  002. instructions trazem personas + critério de maior valor + honestidade
+ *  003. montarPrompt embute o snapshot real (grounding)
+ */
+function novoAgente(array $resumo = [], array $personas = []): ProximaPerguntaAgent
+{
+    return new ProximaPerguntaAgent(
+        snapshotResumo: $resumo ?: ['vendas' => ['mes_corrente' => 47150]],
+        personas: $personas ?: [
+            ['key' => 'larissa', 'label' => 'Balcão', 'foco' => 'vendas'],
+            ['key' => 'eliana', 'label' => 'Fiscal', 'foco' => 'inadimplência'],
+        ],
+        businessName: 'ACME LTDA',
+        maxPorPersona: 2,
+    );
+}
+
+it('R-JANA-ADVISOR-B-AGENT-001 — model() roteia pra frontier via config', function () {
+    config(['copiloto.advisor_questions.model' => 'gpt-4o']);
+    expect(novoAgente()->model())->toBe('gpt-4o');
+
+    config(['copiloto.advisor_questions.model' => '']);
+    expect(novoAgente()->model())->toBeNull();
+
+    config(['copiloto.advisor_questions.provider' => null]);
+    expect(novoAgente()->provider())->toBeNull();
+    config(['copiloto.advisor_questions.provider' => 'anthropic']);
+    expect(novoAgente()->provider())->toBe('anthropic');
+});
+
+it('R-JANA-ADVISOR-B-AGENT-002 — instructions trazem personas + valor + honestidade', function () {
+    $instr = (string) novoAgente()->instructions();
+
+    expect($instr)
+        ->toContain('larissa')
+        ->toContain('eliana')
+        ->toContain('MAIOR VALOR')
+        ->toContain('tem_pergunta=false')
+        ->toContain('NÃO invente')
+        ->toContain('ACME LTDA');
+});
+
+it('R-JANA-ADVISOR-B-AGENT-003 — montarPrompt embute o snapshot (grounding)', function () {
+    $resumo = ['inadimplencia' => ['total_devido_atrasado' => 4535636]];
+    $prompt = novoAgente($resumo)->montarPrompt();
+
+    expect($prompt)
+        ->toContain('4535636')
+        ->toContain('snapshot');
+});

--- a/Modules/Jana/Tests/Feature/Ai/Advisor/ProximaPerguntaServiceTest.php
+++ b/Modules/Jana/Tests/Feature/Ai/Advisor/ProximaPerguntaServiceTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+use Laravel\Ai\Ai;
+use Modules\Jana\Ai\Agents\ProximaPerguntaAgent;
+use Modules\Jana\Services\Advisor\ProximaPerguntaService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * R-JANA-ADVISOR-B — GUARD tests da próxima-melhor-pergunta proativa (Metade B, ADR 0245).
+ *
+ *  001. flag OFF → no-op (sem LLM, sem bloco)
+ *  002. snapshot vazio → null (honestidade: nada a pautar)
+ *  003. happy path → bloco markdown com label da persona + pergunta + resposta
+ *  004. honestidade — todas tem_pergunta=false → null
+ *  005. max_por_persona corta o excesso
+ *  006. fail-open — agente lança → null (brief sai sem o bloco)
+ */
+$snapshotCheio = [
+    'sources' => [
+        'vendas' => [
+            'mes_corrente' => ['total' => 47150.0, 'ticket_medio' => 1890.0],
+            'projecao_fechamento_mes' => 60000.0,
+            'delta_projetado_pct' => -68.0,
+        ],
+        'inadimplencia' => [
+            'total_devido_atrasado' => 4535636.0,
+            'clientes_inadimplentes_count' => 4255,
+            'top_5_devedores' => [['name' => 'VARGAS LEANDRO', 'devido' => 385195.0]],
+        ],
+        'tickets' => ['total_unread_business' => 7, 'top_5' => []],
+        'nfe' => ['rejeitadas_30d' => 2, 'taxa_rejeicao_pct' => 5.0],
+        'oportunidades' => [
+            'reativacao_candidatos' => [['contact_name' => 'EXTREMA SOLDAS', 'ltv' => 71000.0, 'dias_sem_comprar' => 98]],
+            'combo_candidatos' => [],
+        ],
+    ],
+];
+
+$snapshotVazio = [
+    'sources' => [
+        'vendas' => ['mes_corrente' => ['total' => 0.0]],
+        'inadimplencia' => ['total_devido_atrasado' => 0.0, 'clientes_inadimplentes_count' => 0, 'top_5_devedores' => []],
+        'tickets' => ['total_unread_business' => 0, 'top_5' => []],
+        'nfe' => ['rejeitadas_30d' => 0],
+        'oportunidades' => ['reativacao_candidatos' => [], 'combo_candidatos' => []],
+    ],
+];
+
+/** Subclasse que injeta um snapshot fixo (sem montar o schema do ERP). */
+function svcComSnapshot(array $snap): ProximaPerguntaService
+{
+    return new class($snap) extends ProximaPerguntaService {
+        /** @param array<string,mixed> $snap */
+        public function __construct(private array $snap) {}
+        protected function snapshot(int $businessId): array { return $this->snap; }
+    };
+}
+
+beforeEach(function () {
+    config([
+        'copiloto.advisor_questions.enabled' => true,
+        'copiloto.advisor_questions.max_por_persona' => 2,
+        'copiloto.advisor_questions.personas' => [
+            ['key' => 'larissa', 'label' => 'Balcão / velocidade de venda', 'foco' => 'vendas'],
+            ['key' => 'eliana',  'label' => 'Fiscal / financeiro',          'foco' => 'inadimplência'],
+        ],
+    ]);
+});
+
+it('R-JANA-ADVISOR-B-001 — flag OFF é no-op (sem LLM)', function () use ($snapshotCheio) {
+    config(['copiloto.advisor_questions.enabled' => false]);
+    Ai::fakeAgent(ProximaPerguntaAgent::class, [['blocos' => [
+        ['persona' => 'larissa', 'tem_pergunta' => true, 'perguntas' => [['pergunta' => 'X?', 'porque' => 'y', 'resposta_curta' => 'z']]],
+    ]]]);
+
+    expect(svcComSnapshot($snapshotCheio)->gerarBloco(1, 'ACME'))->toBeNull();
+});
+
+it('R-JANA-ADVISOR-B-002 — snapshot vazio → null (honestidade)', function () use ($snapshotVazio) {
+    Ai::fakeAgent(ProximaPerguntaAgent::class, [['blocos' => [
+        ['persona' => 'larissa', 'tem_pergunta' => true, 'perguntas' => [['pergunta' => 'NUNCA', 'porque' => 'y', 'resposta_curta' => 'z']]],
+    ]]]);
+
+    // snapshot vazio curto-circuita ANTES do LLM.
+    expect(svcComSnapshot($snapshotVazio)->gerarBloco(1, 'ACME'))->toBeNull();
+});
+
+it('R-JANA-ADVISOR-B-003 — happy path gera bloco por persona', function () use ($snapshotCheio) {
+    Ai::fakeAgent(ProximaPerguntaAgent::class, [['blocos' => [
+        ['persona' => 'eliana', 'tem_pergunta' => true, 'perguntas' => [
+            ['pergunta' => 'Quanto dos R$ 4,5M vencidos está nos top 3 devedores?', 'porque' => 'concentração', 'resposta_curta' => 'VARGAS sozinho concentra R$ 385k.'],
+        ]],
+        ['persona' => 'larissa', 'tem_pergunta' => false, 'perguntas' => []],
+    ]]]);
+
+    $bloco = svcComSnapshot($snapshotCheio)->gerarBloco(1, 'ACME');
+
+    expect($bloco)->toContain('Perguntas que você deveria fazer agora')
+        ->and($bloco)->toContain('Fiscal / financeiro')
+        ->and($bloco)->toContain('🔮')
+        ->and($bloco)->toContain('VARGAS')
+        // larissa (tem_pergunta=false) NÃO aparece — honestidade
+        ->and($bloco)->not->toContain('Balcão / velocidade');
+});
+
+it('R-JANA-ADVISOR-B-004 — todas sem pergunta → null', function () use ($snapshotCheio) {
+    Ai::fakeAgent(ProximaPerguntaAgent::class, [['blocos' => [
+        ['persona' => 'larissa', 'tem_pergunta' => false, 'perguntas' => []],
+        ['persona' => 'eliana', 'tem_pergunta' => false, 'perguntas' => []],
+    ]]]);
+
+    expect(svcComSnapshot($snapshotCheio)->gerarBloco(1, 'ACME'))->toBeNull();
+});
+
+it('R-JANA-ADVISOR-B-005 — max_por_persona corta excesso', function () use ($snapshotCheio) {
+    config(['copiloto.advisor_questions.max_por_persona' => 1]);
+    Ai::fakeAgent(ProximaPerguntaAgent::class, [['blocos' => [
+        ['persona' => 'eliana', 'tem_pergunta' => true, 'perguntas' => [
+            ['pergunta' => 'Pergunta 1?', 'porque' => 'a', 'resposta_curta' => 'r1'],
+            ['pergunta' => 'Pergunta 2?', 'porque' => 'b', 'resposta_curta' => 'r2'],
+            ['pergunta' => 'Pergunta 3?', 'porque' => 'c', 'resposta_curta' => 'r3'],
+        ]],
+    ]]]);
+
+    $bloco = svcComSnapshot($snapshotCheio)->gerarBloco(1, 'ACME');
+
+    expect($bloco)->toContain('Pergunta 1?')
+        ->and($bloco)->not->toContain('Pergunta 2?')
+        ->and($bloco)->not->toContain('Pergunta 3?');
+});
+
+it('R-JANA-ADVISOR-B-006 — fail-open: agente lança → null', function () use ($snapshotCheio) {
+    Ai::fakeAgent(ProximaPerguntaAgent::class, function () {
+        throw new RuntimeException('provider down');
+    });
+
+    expect(svcComSnapshot($snapshotCheio)->gerarBloco(1, 'ACME'))->toBeNull();
+});

--- a/memory/requisitos/Jana/RUNBOOK-jana-advisor-proativo.md
+++ b/memory/requisitos/Jana/RUNBOOK-jana-advisor-proativo.md
@@ -1,0 +1,78 @@
+---
+title: "Jana Advisor (Modo Consultor) — Metade B: próxima-melhor-pergunta proativa"
+module: Jana
+owner: W
+status: rascunho
+last_validated: "2026-06-02"
+related_adrs:
+  - 0245-jana-advisor-modo-consultor-clarify
+preconditions:
+  - "copiloto.advisor_questions.enabled=true (default OFF — via config runtime)"
+  - "Brief diário funcionando (BriefDiarioService + BriefDiarioChatTrigger)"
+steps:
+  - "Ligar a flag (config runtime) em homolog"
+  - "Pedir o brief no chat da Jana (/brief) e ver a seção 'Perguntas que você deveria fazer agora'"
+  - "Conferir por persona + honestidade (persona sem sinal é omitida)"
+  - "Medir advisor_questions_event no log copiloto-ai"
+---
+
+# RUNBOOK — Jana Advisor (Modo Consultor) · Metade B: próxima-melhor-pergunta proativa
+
+> **ADR 0245** · Metade B do Advisor. Default OFF. Estende o **brief diário** (não recria).
+
+## O que é
+
+O salto de *"ferramenta que responde"* → *"consultor que pauta"*. Dado o **estado real do
+negócio** (snapshot do `BriefDiarioService`), a Jana surfa — **por persona** — as perguntas que
+[W]/a equipe **deveriam estar fazendo agora**, já com a **resposta** pronta. Critério: **maior
+valor destravado / maior ganho de informação pro momento** (Active Task Disambiguation, ICLR 2025).
+
+## Como funciona
+
+`BriefDiarioChatTrigger::gerar()` → (após o brief) → `ProximaPerguntaService::gerarBloco()`:
+
+1. **Snapshot** do estado real (reusa `BriefDiarioService`: vendas/inadimplência/tickets/nfe/oportunidades).
+2. **Resumo compacto** (números + nomes-chave — os mesmos que o brief já mostra).
+3. **`ProximaPerguntaAgent`** (frontier, structured output) gera, por persona, as perguntas de
+   maior valor — já respondidas.
+4. **Bloco markdown** `## 🔮 Perguntas que você deveria fazer agora` anexado ao brief.
+
+Personas (config `copiloto.advisor_questions.personas`): **larissa** (balcão/velocidade) ·
+**eliana** (fiscal/financeiro) · **tecnico** (operação/oficina) · **gestor** (visão geral).
+Cada uma recebe a pergunta do **trabalho dela**.
+
+Garantias:
+- **Default-OFF** → o brief sai idêntico ao atual.
+- **Fail-open** → erro/snapshot-vazio → brief sem o bloco (nunca quebra).
+- **Honestidade** → persona sem sinal de alto valor é **omitida**; se nenhuma tem, sem bloco
+  (não inventa pergunta genérica).
+- Roda **1×/dia por business** (junto do brief) → custo frontier trivial.
+
+## Como ligar
+
+```php
+config(['copiloto.advisor_questions.enabled' => true]);      // default false
+// opcionais:
+config(['copiloto.advisor_questions.model' => 'gpt-4o']);    // frontier (1×/dia)
+config(['copiloto.advisor_questions.max_por_persona' => 2]);
+```
+
+As personas e o `model` vivem no bloco `advisor_questions` de `Modules/Jana/Config/config.php`
+(valores diretos — sem `env()`, mesma razão do `peso_real`/Larastan).
+
+## Como medir
+
+Log `copiloto-ai` → `advisor_questions_event` (personas_com_pergunta, total_perguntas):
+
+```bash
+tail -f storage/logs/copiloto-ai.log | grep advisor_questions_event
+```
+
+Sinal de valor real (pendência, igual Metade A): **pergunta→ação** precisa de hook no frontend
+(registrar se [W]/persona agiu sobre a pergunta surfada).
+
+## Testes
+
+- `Modules/Jana/Tests/Feature/Ai/Advisor/ProximaPerguntaServiceTest.php` (6: flag-off, snapshot
+  vazio, happy path, honestidade, max_por_persona, fail-open).
+- `Modules/Jana/Tests/Feature/Ai/Advisor/ProximaPerguntaAgentTest.php` (3: routing, instructions, grounding).


### PR DESCRIPTION
## Jana "Modo Consultor" (Advisor) — Metade B: próxima-melhor-pergunta proativa

A frente grande, sequenciada por [W] após a Metade A ([#2134](https://github.com/wagnerra23/oimpresso.com/pull/2134)) + oficialização ([#2137](https://github.com/wagnerra23/oimpresso.com/pull/2137)).

### O que faz
Salto **"ferramenta que responde" → "consultor que pauta"**. Dado o **estado real do negócio** (snapshot do `BriefDiarioService`), a Jana surfa **por persona** as perguntas que [W]/a equipe deveriam estar fazendo **agora — já com a resposta**. Critério: maior valor destravado (Active Task Disambiguation, ICLR 2025). *"As melhores respostas vêm quando eu pergunto que pergunta eu deveria fazer."*

### Estende o brief (não recria) — §10.4
- `ProximaPerguntaAgent` (structured output, roteamento **frontier** via config) — perguntas por persona, já respondidas, ancoradas nos números/nomes reais.
- `ProximaPerguntaService` — snapshot (reusa `BriefDiarioService`) → resumo compacto → agente → bloco markdown. Seam `snapshot()` testável.
- `BriefDiarioChatTrigger` anexa **`🔮 Perguntas que você deveria fazer agora`** ao brief.
- Personas: **larissa** (balcão) · **eliana** (fiscal/financeiro) · **tecnico** (operação) · **gestor** (visão geral) — cada uma a pergunta do trabalho dela.

### Garantias
- **Default-OFF** (`copiloto.advisor_questions.enabled`) → brief **byte-idêntico** ao atual.
- **Fail-open** (erro/snapshot-vazio → brief sem o bloco), **honestidade** (omite persona sem sinal; null se nada de alto valor — não inventa), **Tier 0** (businessId explícito), **medição** (`advisor_questions_event`).
- Config **sem `env()`** (valores diretos, igual `peso_real`) → **sem mexer no phpstan-baseline** (zero conflito com #2137).
- Roda 1×/dia por business (junto do brief) → custo frontier trivial.

### Testes
- **9/9 Pest** (24 assertions): `ProximaPerguntaServiceTest` (6) + `ProximaPerguntaAgentTest` (3). PHPStan limpo. `php -l` limpo.

RUNBOOK: `memory/requisitos/Jana/RUNBOOK-jana-advisor-proativo.md`.

> Ligar depois de validar (decisão tua): `config(['copiloto.advisor_questions.enabled' => true])`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)