### PR TITLE
feat(oficina-auto): gate de aprovação do cliente na OS (WhatsApp)

### DIFF
--- a/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
+++ b/Modules/OficinaAuto/Http/Controllers/ServiceOrderController.php
@@ -550,6 +550,40 @@ class ServiceOrderController extends Controller
             ->with('status', ['success' => 1, 'msg' => 'OS atualizada.']);
     }
 
+    /**
+     * US-OFICINA-041 — Enviar orçamento pro cliente aprovar (gate de aprovação).
+     *
+     * Delta do protótipo Cowork "Nova OS" (card "Aprovação do cliente"): o mecânico
+     * dispara o pedido de aprovação com 1 clique. Reusa o pipeline AUTOMÁTICO já
+     * existente — transicionar status → `orcamento` faz o `ServiceOrderObserver`
+     * despachar o `EnviarLinkAprovacaoWhatsappJob` (link público + PIN, US-OFICINA-014).
+     *
+     * A execução não inicia até o cliente aprovar (status vira `aprovada` via
+     * AprovacaoOsController público). Gate visual no Show reflete o estado.
+     *
+     * Defesa em profundidade: Policy update(ServiceOrder) (sameTenant ADR 0093).
+     */
+    public function enviarAprovacao(ServiceOrder $order): RedirectResponse
+    {
+        $this->authorize('update', $order);
+
+        // Estados terminais/já-aprovados não reenviam aprovação.
+        if (in_array($order->status, ['aprovada', 'concluida', 'entregue', 'cancelada'], true)) {
+            return back()->with('status', [
+                'success' => 0,
+                'msg'     => 'OS já está aprovada ou finalizada.',
+            ]);
+        }
+
+        // status → orcamento dispara o Observer (WhatsApp link + PIN ao cliente).
+        $order->update(['status' => 'orcamento']);
+
+        return back()->with('status', [
+            'success' => 1,
+            'msg'     => 'Orçamento enviado ao cliente para aprovação (WhatsApp).',
+        ]);
+    }
+
     public function destroy(ServiceOrder $order): RedirectResponse
     {
         // D8 Security Wave 15: Policy multi-tenant sameTenant guard.

--- a/Modules/OficinaAuto/Routes/web.php
+++ b/Modules/OficinaAuto/Routes/web.php
@@ -72,6 +72,13 @@ Route::middleware(['web', 'SetSessionData', 'auth', 'language', 'timezone', 'Adm
             ->middleware('throttle:30,1')
             ->name('oficinaauto.orders.destroy');
 
+        // US-OFICINA-041 — Gate de aprovação: envia orçamento pro cliente (status → orcamento,
+        // Observer dispara WhatsApp link+PIN). Delta protótipo Cowork "Nova OS".
+        Route::post('ordens-servico/{order}/enviar-aprovacao',
+            [ServiceOrderController::class, 'enviarAprovacao'])
+            ->middleware('throttle:30,1')
+            ->name('oficinaauto.orders.enviar-aprovacao');
+
         // ─────────────────────────────────────────────────────────────────────
         // Gap 3 — Imprimir OS PDF profissional A4 (US-OFICINA-037).
         // AJAX-only endpoint que retorna {success, receipt:{html_content,print_title}}.

--- a/Modules/OficinaAuto/Tests/Feature/ServiceOrderEnviarAprovacaoTest.php
+++ b/Modules/OficinaAuto/Tests/Feature/ServiceOrderEnviarAprovacaoTest.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Facades\Schema;
+use Modules\OficinaAuto\Entities\ServiceOrder;
+use Modules\OficinaAuto\Entities\Vehicle;
+use Modules\OficinaAuto\Jobs\EnviarLinkAprovacaoWhatsappJob;
+
+uses(Tests\TestCase::class);
+
+/**
+ * US-OFICINA-041 — Gate de aprovação: enviar orçamento pro cliente (status → orcamento).
+ *
+ * Delta do protótipo Cowork "Nova OS" (card "Aprovação do cliente"). O endpoint
+ * transiciona status → orcamento, o que faz o ServiceOrderObserver despachar o
+ * EnviarLinkAprovacaoWhatsappJob (link público + PIN). Tests biz=1 (ADR 0101).
+ */
+
+const BIZ_APR = 1;
+const PLATE_APR_PREFIX = 'WAPR';
+
+beforeEach(function () {
+    if (DB::connection()->getDriverName() === 'sqlite') {
+        $this->markTestSkipped('SQLite-incompatível: requer schema MySQL UltimatePOS (ADR 0101)');
+    }
+});
+
+function apr_criaOs(string $suffix, string $status = 'aberta', int $biz = BIZ_APR): ServiceOrder
+{
+    $vehicle = Vehicle::withoutGlobalScopes()->create([
+        'business_id'  => $biz,
+        'plate'        => PLATE_APR_PREFIX . $suffix,
+        'vehicle_type' => 'automovel',
+    ]);
+
+    return ServiceOrder::withoutGlobalScopes()->create([
+        'business_id' => $biz,
+        'vehicle_id'  => $vehicle->id,
+        'status'      => $status,
+    ]);
+}
+
+function apr_cleanup(string $suffix): void
+{
+    $vehicles = Vehicle::withoutGlobalScopes()
+        ->where('plate', PLATE_APR_PREFIX . $suffix)
+        ->pluck('id')->toArray();
+    if (! empty($vehicles)) {
+        ServiceOrder::withoutGlobalScopes()->whereIn('vehicle_id', $vehicles)->forceDelete();
+        Vehicle::withoutGlobalScopes()->whereIn('id', $vehicles)->forceDelete();
+    }
+}
+
+it('envia aprovação: status vira orcamento e dispara job WhatsApp', function () {
+    Queue::fake();
+    session(['user.business_id' => BIZ_APR]);
+    $user = \App\User::withoutGlobalScopes()->where('business_id', BIZ_APR)->first();
+    if ($user === null) {
+        $this->markTestSkipped('Sem user disponível em biz=1');
+    }
+
+    $os = apr_criaOs('A', 'aberta');
+
+    $resp = $this->actingAs($user)->post("/oficina-auto/ordens-servico/{$os->id}/enviar-aprovacao");
+    $resp->assertRedirect();
+
+    expect(ServiceOrder::withoutGlobalScopes()->find($os->id)->status)->toBe('orcamento');
+    Queue::assertPushed(EnviarLinkAprovacaoWhatsappJob::class);
+})->afterEach(fn () => apr_cleanup('A'));
+
+it('não reenvia aprovação em OS já aprovada (status preservado)', function () {
+    Queue::fake();
+    session(['user.business_id' => BIZ_APR]);
+    $user = \App\User::withoutGlobalScopes()->where('business_id', BIZ_APR)->first();
+    if ($user === null) {
+        $this->markTestSkipped('Sem user disponível em biz=1');
+    }
+
+    $os = apr_criaOs('B', 'aprovada');
+
+    $this->actingAs($user)->post("/oficina-auto/ordens-servico/{$os->id}/enviar-aprovacao")
+        ->assertRedirect();
+
+    // status NÃO muda + nenhum job de aprovação disparado
+    expect(ServiceOrder::withoutGlobalScopes()->find($os->id)->status)->toBe('aprovada');
+    Queue::assertNotPushed(EnviarLinkAprovacaoWhatsappJob::class);
+})->afterEach(fn () => apr_cleanup('B'));

--- a/memory/requisitos/OficinaAuto/SPEC.md
+++ b/memory/requisitos/OficinaAuto/SPEC.md
@@ -1341,6 +1341,20 @@ Delta #4 do protótipo Cowork "Nova OS" — botão **"+ orçamento"** na inspeç
 - [x] `DviBudgetSection` (Show) — lista vistoria + botão "+orçamento" optimistic
 - [x] Pest (conversão 201 + idempotência 409 + cross-OS 404)
 
+### US-OFICINA-041 · Gate de aprovação do cliente in-screen
+
+> owner: — · priority: p2 · estimate: 2h (IA-pair fator 10x ADR 0106) · status: review · type: story · origin: delta protótipo Cowork "Nova OS" (oficina-os-page.jsx) · 2026-06-02
+> blocked_by: —
+
+Delta #5 do protótipo Cowork "Nova OS" (card "Aprovação do cliente"). O mecânico envia o orçamento pro cliente aprovar com 1 clique; a execução não inicia até aprovar. **Reusa o pipeline automático existente** (US-OFICINA-014): transicionar status → `orcamento` faz o `ServiceOrderObserver` despachar o `EnviarLinkAprovacaoWhatsappJob` (link público + PIN). O gate visual no Show reflete aguardando→aprovado.
+
+**DoD:**
+- [x] `ServiceOrderController::enviarAprovacao` — status → orcamento (dispara Observer WhatsApp); Policy update; rejeita estados terminais
+- [x] Rota `POST ordens-servico/{order}/enviar-aprovacao` (throttle 30,1)
+- [x] `ApprovalGateCard` (Show) — 3 estados (pré/aguardando/aprovado), tokens semânticos success/warning
+- [x] Pest (status→orcamento + job disparado · OS aprovada não reenvia)
+- ℹ️ "Reenviar link" (job idempotência 7d) fica pra US futura
+
 ---
 
-**Última atualização:** 2026-06-02 — US-OFICINA-040 DVI→orçamento (wire-up Wave 3b). 2026-06-02 — US-OFICINA-038/039 check-in de entrada (combustível + avarias) — delta protótipo Cowork "Nova OS". 2026-05-26 — US-OFICINA-035 DVI Vistoria Digital backend (schema + Model + Service + HTTP API + Pest) — wedge CAPTERRA Repair gap #3. UI Wave 3b. 2026-05-15 — US-OFICINA-026 adicionada (goal #1 CYCLE-06 Martinho prod). 2026-05-10 — SPEC criada **antecipatória** sem cliente piloto. Status `feature-wish` lifecycle `aguarda-sinal-qualificado`. Não codar até gatilho §9 satisfeito. Revisar trimestralmente — se 12 meses sem sinal, considerar arquivar como `historical` (ADR 0095 lifecycle).
+**Última atualização:** 2026-06-02 — US-OFICINA-041 gate de aprovação in-screen (status→orcamento dispara WhatsApp). 2026-06-02 — US-OFICINA-040 DVI→orçamento (wire-up Wave 3b). 2026-06-02 — US-OFICINA-038/039 check-in de entrada (combustível + avarias) — delta protótipo Cowork "Nova OS". 2026-05-26 — US-OFICINA-035 DVI Vistoria Digital backend (schema + Model + Service + HTTP API + Pest) — wedge CAPTERRA Repair gap #3. UI Wave 3b. 2026-05-15 — US-OFICINA-026 adicionada (goal #1 CYCLE-06 Martinho prod). 2026-05-10 — SPEC criada **antecipatória** sem cliente piloto. Status `feature-wish` lifecycle `aguarda-sinal-qualificado`. Não codar até gatilho §9 satisfeito. Revisar trimestralmente — se 12 meses sem sinal, considerar arquivar como `historical` (ADR 0095 lifecycle).

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx
@@ -18,6 +18,7 @@ import ServiceOrderItemRow, {
 } from './_components/ServiceOrderItemRow';
 import ServiceOrderItemFormSheet from './_components/ServiceOrderItemFormSheet';
 import DviBudgetSection, { type DviItemDto } from './_components/DviBudgetSection';
+import ApprovalGateCard from './_components/ApprovalGateCard';
 
 interface ServiceOrder {
   id: number;
@@ -275,6 +276,9 @@ export default function ServiceOrdersShow({ order }: Props) {
             </div>
           )}
         </div>
+
+        {/* Gate de aprovação do cliente (US-OFICINA-041) — execução travada até aprovar */}
+        <ApprovalGateCard serviceOrderId={order.id} status={order.status} />
 
         {/* Vistoria DVI → orçamento (US-OFICINA-040) — item reprovado vira linha de orçamento */}
         <DviBudgetSection

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ApprovalGateCard.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/ApprovalGateCard.tsx
@@ -1,0 +1,88 @@
+// ApprovalGateCard — gate de aprovação do cliente (US-OFICINA-041).
+// Delta do protótipo Cowork "Nova OS" (card "Aprovação do cliente"):
+//   aguardando → enviado/aguardando resposta → aprovado.
+// A execução não inicia até o cliente aprovar. Botão dispara status → orcamento,
+// que faz o ServiceOrderObserver enviar o link público + PIN via WhatsApp.
+
+import { useState } from 'react';
+import { router } from '@inertiajs/react';
+import { Clock, Send, Loader2, ShieldCheck } from 'lucide-react';
+
+interface Props {
+  serviceOrderId: number;
+  status: string;
+}
+
+export default function ApprovalGateCard({ serviceOrderId, status }: Props) {
+  const [sending, setSending] = useState(false);
+
+  const aprovada = ['aprovada', 'concluida', 'entregue'].includes(status);
+  const aguardando = status === 'orcamento';
+  const cancelada = status === 'cancelada';
+
+  if (cancelada) return null;
+
+  function enviar() {
+    setSending(true);
+    router.post(
+      `/oficina-auto/ordens-servico/${serviceOrderId}/enviar-aprovacao`,
+      {},
+      {
+        preserveScroll: true,
+        onFinish: () => setSending(false),
+      },
+    );
+  }
+
+  // Aprovado — liberado pra execução
+  if (aprovada) {
+    return (
+      <div className="rounded-md border border-success/40 bg-success/5 p-4 mt-4">
+        <div className="flex items-center gap-2">
+          <ShieldCheck className="size-5 text-success-foreground" />
+          <h2 className="text-sm font-semibold text-foreground">Aprovado pelo cliente</h2>
+        </div>
+        <p className="text-xs text-muted-foreground mt-1">
+          Liberado para execução — o mecânico já pode iniciar o serviço.
+        </p>
+      </div>
+    );
+  }
+
+  // Aguardando aprovação (orçamento enviado)
+  if (aguardando) {
+    return (
+      <div className="rounded-md border border-warning/40 bg-warning/5 p-4 mt-4">
+        <div className="flex items-center gap-2">
+          <Clock className="size-5 text-warning-foreground" />
+          <h2 className="text-sm font-semibold text-foreground">Aguardando aprovação do cliente</h2>
+        </div>
+        <p className="text-xs text-muted-foreground mt-1">
+          Orçamento enviado por WhatsApp (link + PIN). A execução não inicia até o cliente aprovar.
+        </p>
+      </div>
+    );
+  }
+
+  // Pré-aprovação — botão pra enviar
+  return (
+    <div className="rounded-md border bg-card p-4 mt-4">
+      <div className="flex items-center gap-2">
+        <Clock className="size-5 text-muted-foreground" />
+        <h2 className="text-sm font-semibold text-foreground">Aprovação do cliente</h2>
+      </div>
+      <p className="text-xs text-muted-foreground mt-1 mb-3">
+        A execução não inicia sem o cliente autorizar. Envie o orçamento com a vistoria por WhatsApp.
+      </p>
+      <button
+        type="button"
+        onClick={enviar}
+        disabled={sending}
+        className="inline-flex items-center gap-2 rounded-md bg-primary text-primary-foreground px-3 py-2 text-sm font-medium hover:opacity-90 disabled:opacity-50"
+      >
+        {sending ? <Loader2 className="size-4 animate-spin" /> : <Send className="size-4" />}
+        Enviar orçamento por WhatsApp
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Contexto
Delta **#5** do protótipo Cowork "Nova OS" — US-OFICINA-041. Segue PRs [#2136](https://github.com/wagnerra23/oimpresso.com/pull/2136) (check-in) e [#2138](https://github.com/wagnerra23/oimpresso.com/pull/2138) (DVI→orçamento), ambos já validados no staging.

Card **"Aprovação do cliente"** no Show: o mecânico envia o orçamento pro cliente aprovar com 1 clique; a execução não inicia até aprovar.

**Reusa o pipeline automático existente** (US-OFICINA-014) — nada de backend de aprovação novo: transicionar status → `orcamento` faz o `ServiceOrderObserver` despachar o `EnviarLinkAprovacaoWhatsappJob` (link público + PIN).

## Mudanças
- `ServiceOrderController::enviarAprovacao` — status→orcamento (Observer dispara WhatsApp); Policy `update`; rejeita estados terminais
- rota `POST ordens-servico/{order}/enviar-aprovacao`
- `ApprovalGateCard` (Show) — 3 estados (pré-envio / aguardando / aprovado), tokens semânticos `success`/`warning`
- Pest: status→orcamento + job disparado (`Queue::fake`) · OS aprovada não reenvia

## Validação
- ✅ `php -l` limpo · Pest MySQL + lint/PHPStan no CI · tokens semânticos (zero cor crua)
- Multi-tenant Tier 0 (ADR 0093): Policy update sameTenant
- Smoke no staging após merge (junto do PR C)

Merge fica com o Wagner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)