### PR TITLE
fix(jana): clarify funcional — schema strict-compliant + modelo acessível (gpt-4o-mini)

### DIFF
--- a/Modules/Jana/Ai/Agents/ClarificadorAgent.php
+++ b/Modules/Jana/Ai/Agents/ClarificadorAgent.php
@@ -124,15 +124,20 @@ class ClarificadorAgent implements Agent, HasStructuredOutput
     }
 
     /**
-     * Schema do veredito. `pergunta` e `intencoes` são opcionais (honestidade: vazio é válido).
+     * Schema do veredito.
+     *
+     * TODAS as chaves são `required()` — OpenAI structured output (strict mode) exige que
+     * cada property esteja em `required` (senão 400 "Invalid schema ... 'required' is required").
+     * A honestidade ("vazio é válido") é preservada no VALOR: `pergunta` vem string vazia e
+     * `intencoes` array vazio quando não há ambiguidade — o ClarifyCascadeService trata isso.
      */
     public function schema(JsonSchema $schema): array
     {
         return [
             'tipo' => $schema->string()->enum(['claro', 'falta_dado', 'ambiguo'])->required(),
             'confianca' => $schema->number()->description('0..1 — confiança na classificação')->required(),
-            'pergunta' => $schema->string()->description('Pergunta de maior ganho de info. Vazia se não for ambiguo OU se não houver pergunta de alto valor.'),
-            'intencoes' => $schema->array()->items($schema->string())->description('Leituras candidatas que você enxergou (2-4). Vazio se claro.'),
+            'pergunta' => $schema->string()->description('Pergunta de maior ganho de info. STRING VAZIA se não for ambiguo OU se não houver pergunta de alto valor.')->required(),
+            'intencoes' => $schema->array()->items($schema->string())->description('Leituras candidatas que você enxergou (2-4). ARRAY VAZIO se claro.')->required(),
         ];
     }
 

--- a/Modules/Jana/Ai/Agents/ProximaPerguntaAgent.php
+++ b/Modules/Jana/Ai/Agents/ProximaPerguntaAgent.php
@@ -99,6 +99,8 @@ class ProximaPerguntaAgent implements Agent, HasStructuredOutput
 
     public function schema(JsonSchema $schema): array
     {
+        // TODAS as chaves `required()` — OpenAI strict mode (senão 400 "'required' is required").
+        // Honestidade preservada no VALOR: persona sem sinal → tem_pergunta=false + perguntas=[].
         return [
             'blocos' => $schema->array()->items(
                 $schema->object([
@@ -110,7 +112,7 @@ class ProximaPerguntaAgent implements Agent, HasStructuredOutput
                             'porque' => $schema->string()->required(),
                             'resposta_curta' => $schema->string()->required(),
                         ])
-                    ),
+                    )->description('Vazio quando tem_pergunta=false.')->required(),
                 ])
             )->required(),
         ];

--- a/Modules/Jana/Config/config.php
+++ b/Modules/Jana/Config/config.php
@@ -486,7 +486,11 @@ return [
     'clarify' => [
         'enabled'  => (bool) env('JANA_CLARIFY_ENABLED', false),   // homolog liga; prod espera (ADR 0245)
         'provider' => env('JANA_CLARIFY_PROVIDER'),                // null → config('ai.default') (provider do chat)
-        'model'    => env('JANA_CLARIFY_MODEL', 'gpt-4o'),         // frontier seletivo (vs gpt-4o-mini do chat)
+        // Default gpt-4o-mini: é o ÚNICO modelo a que o projeto OpenAI atual tem acesso
+        // (gpt-4o → 403 "does not have access"; validado E2E no staging CT 100). Pra subir pro
+        // frontier de verdade: conceder gpt-4o ao projeto OU provider=anthropic (claude-sonnet) —
+        // ambos via env JANA_CLARIFY_MODEL/JANA_CLARIFY_PROVIDER, sem code change.
+        'model'    => env('JANA_CLARIFY_MODEL', 'gpt-4o-mini'),
         // Confiança mínima do disambiguador p/ realmente perguntar (anti false-clarify).
         'min_confianca'          => 0.6,
         // Heurística 1a (zero-custo) — limites do "cinza".
@@ -516,7 +520,7 @@ return [
     'advisor_questions' => [
         'enabled'  => false,            // default OFF — Wagner liga via config runtime após validar
         'provider' => null,             // null → config('ai.default') (provider do chat)
-        'model'    => 'gpt-4o',         // pautar é difícil → frontier (1×/dia, custo trivial)
+        'model'    => 'gpt-4o-mini',    // projeto OpenAI atual só tem gpt-4o-mini (gpt-4o → 403); subir via config quando houver acesso frontier
         'max_por_persona' => 2,         // menos é mais — só a(s) de maior valor
         // Cada persona recebe a pergunta do TRABALHO dela (ADR UI-0016 personas reais).
         'personas' => [

--- a/docker/oimpresso-staging/.env.staging.example
+++ b/docker/oimpresso-staging/.env.staging.example
@@ -53,10 +53,12 @@ MCP_TOOLS_EXPOSED=false
 CENTRIFUGO_ENABLED=false
 
 # Jana Advisor — Metade A (clarify reativo, ADR 0245): LIGADO em homolog pra medir
-# `clarify_event`. Default OFF em prod. Modelo frontier gpt-4o (provider openai, só dispara
-# no ~20% cinza). Acompanhar log copiloto-ai (gray-hit / taxa de clarify / false-clarify).
+# `clarify_event`. Default OFF em prod. Só dispara no ~20% cinza. Modelo gpt-4o-mini — é o
+# único a que o projeto OpenAI atual tem acesso (gpt-4o → 403). Validado E2E no CT 100:
+# "manda a régua" → "Qual régua, a de vendas ou a de clientes?". Subir pro frontier (gpt-4o
+# OU provider=anthropic claude) quando houver acesso. Log copiloto-ai (gray-hit/clarify/false).
 JANA_CLARIFY_ENABLED=true
-JANA_CLARIFY_MODEL=gpt-4o
+JANA_CLARIFY_MODEL=gpt-4o-mini
 
 # Octane OFF: staging roda FrankenPHP modo clássico (ver entrypoint-staging.sh)
 OCTANE_SERVER=


### PR DESCRIPTION
## Resolve o clarify pra funcionar de verdade (validado E2E no homolog CT 100)

Ao ligar o LLM no staging, dois bugs reais apareceram (os testes fake não pegam — não validam schema/modelo no provider):

### 1. Schema structured output não-strict → OpenAI 400
`ClarificadorAgent`/`ProximaPerguntaAgent` deixavam properties opcionais (`pergunta`/`intencoes`/`perguntas`). OpenAI strict mode exige **todas** em `required` → `400 Invalid schema ... 'required' is required`. Agora todas `required()`; honestidade preservada no **valor** (string vazia / array vazio quando sem sinal — o service já trata).

### 2. Modelo gpt-4o inacessível → 403
O projeto OpenAI atual (mesma key da prod) **só tem `gpt-4o-mini`** — `gpt-4o` dá `403 does not have access`. Default trocado pra `gpt-4o-mini` (clarify + advisor). Subir pro frontier (gpt-4o OU `provider=anthropic` claude) via env quando houver acesso — sem code change.

### ✅ Validação E2E real (gpt-4o-mini, staging CT 100)
- GRAY `"manda a régua"` → **clarificar** (ambiguo, custoLlm=true) → **"Qual régua você deseja que eu envie, a de vendas ou a de clientes?"**
- CLEAR `"quanto vendi ontem?"` → responder (heurística, zero custo LLM)

Exatamente o desenho da cascata. 23 Pest seguem verdes (fakes não afetados). Default-OFF em prod mantido.

🤖 Generated with [Claude Code](https://claude.com/claude-code)