### PR TITLE
feat(oficina-auto): painel fiscal NF-e/NFS-e na OS (split por natureza)

### DIFF
--- a/memory/requisitos/OficinaAuto/SPEC.md
+++ b/memory/requisitos/OficinaAuto/SPEC.md
@@ -1355,6 +1355,19 @@ Delta #5 do protótipo Cowork "Nova OS" (card "Aprovação do cliente"). O mecâ
 - [x] Pest (status→orcamento + job disparado · OS aprovada não reenvia)
 - ℹ️ "Reenviar link" (job idempotência 7d) fica pra US futura
 
+### US-OFICINA-042 · Painel fiscal NF-e/NFS-e na OS
+
+> owner: — · priority: p3 · estimate: 1h (IA-pair fator 10x ADR 0106) · status: review · type: story · origin: delta protótipo Cowork "Nova OS" (oficina-os-page.jsx) · 2026-06-02
+> blocked_by: —
+
+Delta #6 do protótipo Cowork "Nova OS" (seção "Fiscal"). Painel **presentacional** que separa os itens da OS por natureza fiscal: peças = mercadoria → **NF-e 55**, mão de obra/serviço → **NFS-e**, com valores. Computado de `order.items` (já no payload) — a emissão real sai pela Transaction derivada (Observer ADR 0192). Converge com o componente único `FiscalStatusBadge` (NfeBrasil) quando a OS carregar status de doc emitido.
+
+**DoD:**
+- [x] `FiscalSplitCard` (Show) — split peças (NF-e 55) / mão de obra (NFS-e) + nota de garantia 90 dias
+- [x] Frontend-only (sem backend/migration) — usa `order.items` existente; tokens semânticos
+- [x] Renderiza só quando há itens
+- ℹ️ Status fiscal LIVE (badge reativo) quando OS expor transaction fiscal — US futura (converge `FiscalStatusBadge`)
+
 ---
 
-**Última atualização:** 2026-06-02 — US-OFICINA-041 gate de aprovação in-screen (status→orcamento dispara WhatsApp). 2026-06-02 — US-OFICINA-040 DVI→orçamento (wire-up Wave 3b). 2026-06-02 — US-OFICINA-038/039 check-in de entrada (combustível + avarias) — delta protótipo Cowork "Nova OS". 2026-05-26 — US-OFICINA-035 DVI Vistoria Digital backend (schema + Model + Service + HTTP API + Pest) — wedge CAPTERRA Repair gap #3. UI Wave 3b. 2026-05-15 — US-OFICINA-026 adicionada (goal #1 CYCLE-06 Martinho prod). 2026-05-10 — SPEC criada **antecipatória** sem cliente piloto. Status `feature-wish` lifecycle `aguarda-sinal-qualificado`. Não codar até gatilho §9 satisfeito. Revisar trimestralmente — se 12 meses sem sinal, considerar arquivar como `historical` (ADR 0095 lifecycle).
+**Última atualização:** 2026-06-02 — US-OFICINA-042 painel fiscal NF-e/NFS-e (split presentacional). 2026-06-02 — US-OFICINA-041 gate de aprovação in-screen (status→orcamento dispara WhatsApp). 2026-06-02 — US-OFICINA-040 DVI→orçamento (wire-up Wave 3b). 2026-06-02 — US-OFICINA-038/039 check-in de entrada (combustível + avarias) — delta protótipo Cowork "Nova OS". 2026-05-26 — US-OFICINA-035 DVI Vistoria Digital backend (schema + Model + Service + HTTP API + Pest) — wedge CAPTERRA Repair gap #3. UI Wave 3b. 2026-05-15 — US-OFICINA-026 adicionada (goal #1 CYCLE-06 Martinho prod). 2026-05-10 — SPEC criada **antecipatória** sem cliente piloto. Status `feature-wish` lifecycle `aguarda-sinal-qualificado`. Não codar até gatilho §9 satisfeito. Revisar trimestralmente — se 12 meses sem sinal, considerar arquivar como `historical` (ADR 0095 lifecycle).

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx
@@ -19,6 +19,7 @@ import ServiceOrderItemRow, {
 import ServiceOrderItemFormSheet from './_components/ServiceOrderItemFormSheet';
 import DviBudgetSection, { type DviItemDto } from './_components/DviBudgetSection';
 import ApprovalGateCard from './_components/ApprovalGateCard';
+import FiscalSplitCard from './_components/FiscalSplitCard';
 
 interface ServiceOrder {
   id: number;
@@ -346,6 +347,9 @@ export default function ServiceOrdersShow({ order }: Props) {
             </div>
           )}
         </section>
+
+        {/* Painel fiscal — split NF-e 55 (peças) / NFS-e (mão de obra) · US-OFICINA-042 */}
+        <FiscalSplitCard items={items} />
 
         <ServiceOrderItemFormSheet
           serviceOrderId={order.id}

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/_components/FiscalSplitCard.tsx
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/_components/FiscalSplitCard.tsx
@@ -1,0 +1,70 @@
+// FiscalSplitCard — split fiscal da OS por natureza (US-OFICINA-042).
+// Delta #6 do protótipo Cowork "Nova OS" (seção "Fiscal"): peças = mercadoria → NF-e 55,
+// mão de obra/serviço = serviço → NFS-e. Painel de planejamento (presentacional), computado
+// de order.items — a emissão real sai pela Transaction derivada (Observer · ADR 0192).
+// Converge com o componente único FiscalStatusBadge (NfeBrasil) quando a OS carregar
+// status de doc emitido — por ora mostra a natureza + valor.
+
+import { Receipt, ShieldCheck } from 'lucide-react';
+import type { ServiceOrderItemDto } from './ServiceOrderItemRow';
+
+interface Props {
+  items: ServiceOrderItemDto[];
+}
+
+function toFloat(value: number | string | null | undefined): number {
+  if (value === null || value === undefined || value === '') return 0;
+  const n = typeof value === 'string' ? parseFloat(value) : value;
+  return Number.isNaN(n) ? 0 : n;
+}
+
+function formatBRL(value: number): string {
+  return value.toLocaleString('pt-BR', { style: 'currency', currency: 'BRL' });
+}
+
+export default function FiscalSplitCard({ items }: Props) {
+  if (items.length === 0) return null;
+
+  const pecas = items
+    .filter((it) => it.tipo === 'peca')
+    .reduce((sum, it) => sum + toFloat(it.valor_total), 0);
+  const servicos = items
+    .filter((it) => it.tipo === 'mao_obra' || it.tipo === 'servico_terceiro')
+    .reduce((sum, it) => sum + toFloat(it.valor_total), 0);
+
+  return (
+    <section className="mt-6 rounded-md border bg-card p-4">
+      <div className="flex items-center gap-2 mb-3">
+        <Receipt className="size-4 text-muted-foreground" />
+        <h2 className="text-sm font-semibold text-foreground">Fiscal</h2>
+        <span className="text-[11px] text-muted-foreground">naturezas distintas</span>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between text-sm">
+          <span className="flex items-center gap-2">
+            <span className="rounded bg-secondary text-secondary-foreground text-[10px] font-semibold px-1.5 py-0.5">
+              NF-e 55
+            </span>
+            Peças <span className="text-muted-foreground text-xs">mercadoria</span>
+          </span>
+          <span className="tabular-nums">{formatBRL(pecas)}</span>
+        </div>
+        <div className="flex items-center justify-between text-sm">
+          <span className="flex items-center gap-2">
+            <span className="rounded bg-secondary text-secondary-foreground text-[10px] font-semibold px-1.5 py-0.5">
+              NFS-e
+            </span>
+            Mão de obra <span className="text-muted-foreground text-xs">serviço</span>
+          </span>
+          <span className="tabular-nums">{formatBRL(servicos)}</span>
+        </div>
+      </div>
+
+      <div className="mt-3 pt-3 border-t flex items-center gap-2 text-xs text-muted-foreground">
+        <ShieldCheck className="size-3.5" />
+        Garantia de 90 dias em serviço e peça
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
## Contexto
Delta **#6** (último) do protótipo Cowork "Nova OS" — US-OFICINA-042. Fecha a série de deltas P1/P2/P3 (check-in #2136, DVI→orçamento #2138, gate de aprovação #2141).

Painel **"Fiscal"** no Show: separa os itens por natureza fiscal — **peças = mercadoria → NF-e 55**, **mão de obra/serviço → NFS-e** — com valores + nota de garantia 90 dias. É a dualidade fiscal brasileira que o protótipo destaca.

## Mudanças
- `FiscalSplitCard` (Show) — split computado de `order.items` (já no payload)
- **Frontend-only**: sem backend/migration; tokens semânticos; renderiza só quando há itens
- Converge com o componente único `FiscalStatusBadge` (NfeBrasil) — quando a OS expor status de doc emitido pela Transaction derivada (ADR 0192), plugar o badge reativo (US futura)

## Validação
- ✅ sem cor crua · tsc/ESLint/PHPStan no CI
- Sem toque em multi-tenant (presentacional puro)
- Smoke no staging após merge

## Série Nova OS — status
| Delta | US | PR |
|---|---|---|
| Check-in (combustível+avarias) | 038/039 | #2136 ✅ |
| DVI → orçamento | 040 | #2138 ✅ |
| Gate de aprovação WhatsApp | 041 | #2141 ✅ |
| **Painel fiscal** | **042** | **este** |
| Consolidação 1-tela (Tier 0) | — | ADR aguarda Wagner (doc em `oficina-os-nova-prototipo-visual-comparison.md`) |

Merge fica com o Wagner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)