### PR TITLE
fix(staging): deploy.sh força restart + optimize:clear (recarrega PHP)

### DIFF
--- a/docker/oimpresso-staging/deploy.sh
+++ b/docker/oimpresso-staging/deploy.sh
@@ -106,8 +106,18 @@ if [ ! -f "$CODE/.env" ]; then
     exit 1
 fi
 
-echo "==> 5/5  Sobe container"
+echo "==> 5/5  Sobe + recarrega container"
 docker compose -f "$COMPOSE" up -d
+
+# `up -d` NÃO recria o container quando imagem/config não mudam (caso comum: só o
+# código git mudou). Resultado: o PHP fica em cache (opcache + processo vivo) e
+# mudanças de Controller/Service NÃO entram — só o frontend (assets estáticos) e
+# colunas de DB aparecem. Por isso o restart + clear são obrigatórios no deploy.
+echo "    restart + optimize:clear (recarrega PHP — senão controller fica em cache)"
+docker compose -f "$COMPOSE" restart
+sleep 3
+docker exec oimpresso-staging php artisan optimize:clear || true
+
 echo ""
 echo "OK. HEAD $(git -C "$CODE" rev-parse --short HEAD). Smoke:  curl -I https://staging.oimpresso.com/login"
 echo "Logs:       docker logs -f oimpresso-staging"


### PR DESCRIPTION
## Problema
`docker compose up -d` **não recria** o container quando só o código git muda (caso comum no deploy de staging). Resultado: o PHP fica em cache (opcache + processo vivo) e mudanças de **Controller/Service NÃO entram** — só assets estáticos (frontend) e colunas de DB aparecem.

**Catalogado na série Nova OS (2026-06-02):** o `dvi_items` do `ServiceOrderController` só apareceu no staging depois de um `docker restart` manual; o check-in funcionou sem porque é frontend + coluna.

## Fix
Após `docker compose up -d`, no passo 5:
- `docker compose restart` (recarrega o PHP)
- `php artisan optimize:clear` (best-effort, `|| true`)

Pequeno, infra-only (`docker/oimpresso-staging/deploy.sh`). `sh -n` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)