### PR TITLE
fix(nfse): ambiente de emissão resolvido por-business (cutover fiscal biz=164)

### DIFF
--- a/Modules/NFSe/Adapters/SnNfseAdapter.php
+++ b/Modules/NFSe/Adapters/SnNfseAdapter.php
@@ -27,17 +27,36 @@ class SnNfseAdapter implements NfseProviderInterface
 
     public function __construct(private readonly string $ambiente = 'homologacao')
     {
-        $this->baseUrl = $ambiente === 'producao'
+        // Fallback global usado APENAS por consultar()/cancelar() (sem contexto de
+        // payload por-business). A EMISSÃO resolve o ambiente POR-BUSINESS via
+        // $payload->ambiente — ver emitir()/resolveBaseUrl().
+        $this->baseUrl = $this->resolveBaseUrl($ambiente);
+    }
+
+    /**
+     * Resolve o endpoint SN-NFSe a partir do ambiente.
+     *
+     * Cutover fiscal por-business: o ambiente da EMISSÃO vem do payload
+     * (nfse_provider_configs.ambiente do tenant), NÃO do bind global
+     * config('nfse.ambiente'). Ligar produção pra um business (ex: biz=164)
+     * NÃO pode afetar outros tenants (ROTA LIVRE etc).
+     */
+    private function resolveBaseUrl(string $ambiente): string
+    {
+        return $ambiente === 'producao'
             ? config('nfse.endpoints.producao', 'https://sefin.nfse.gov.br/sefinnacional')
             : config('nfse.endpoints.homologacao', 'https://sefin.producaorestrita.nfse.gov.br/sefinnacional');
     }
 
     public function emitir(NfseEmissaoPayload $payload): NfseResultado
     {
+        // Ambiente POR-BUSINESS: endpoint e tpAmb derivam do payload do tenant,
+        // não do bind global. Isola o cutover de produção a 1 business.
+        $baseUrl = $this->resolveBaseUrl($payload->ambiente);
         try {
             $response = Http::timeout(30)
                 ->withOptions(['cert' => $this->certPath($payload)])
-                ->post("{$this->baseUrl}/nfse", $this->buildDps($payload));
+                ->post("{$baseUrl}/nfse", $this->buildDps($payload));
 
             if ($response->serverError() || $response->clientError()) {
                 $this->parseErro($response->json());
@@ -88,7 +107,8 @@ class SnNfseAdapter implements NfseProviderInterface
     {
         return [
             'infDps' => [
-                'tpAmb'    => $this->ambiente === 'producao' ? 1 : 2,
+                // tpAmb POR-BUSINESS (1=produção, 2=homologação) — do payload do tenant.
+                'tpAmb'    => $payload->ambiente === 'producao' ? 1 : 2,
                 'serie'    => 'RPS',
                 'nDPS'     => $payload->rpsNumero,
                 'dhEmi'    => now()->toIso8601String(),

--- a/Modules/NFSe/Models/NfseProviderConfig.php
+++ b/Modules/NFSe/Models/NfseProviderConfig.php
@@ -7,6 +7,22 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Modules\NFSe\Models\Concerns\NfseBusinessScope;
 
+/**
+ * Config NFS-e por business (1:1) — provider municipal, fiscais e ambiente.
+ *
+ * @property int         $id
+ * @property int         $business_id
+ * @property string|null $provider
+ * @property string|null $municipio_codigo_ibge
+ * @property string|null $serie_default
+ * @property string|null $cnae
+ * @property string|null $lc116_codigo_default
+ * @property string|null $aliquota_iss
+ * @property string      $ambiente               1=producao | homologacao (default)
+ * @property int|null    $cert_id
+ * @property string|null $prestador_cnpj
+ * @property string|null $prestador_im
+ */
 class NfseProviderConfig extends Model
 {
     use SoftDeletes, NfseBusinessScope;

--- a/Modules/NFSe/Services/NfseEmissaoService.php
+++ b/Modules/NFSe/Services/NfseEmissaoService.php
@@ -73,6 +73,12 @@ class NfseEmissaoService
             issRetido: (bool) ($data['iss_retido'] ?? false),
             certPfxBase64: $certPfxBase64,
             certSenha: $certSenha,
+            // Ambiente POR-BUSINESS (cutover fiscal): vem de nfse_provider_configs.ambiente
+            // do tenant — NÃO do bind global config('nfse.ambiente'). Ligar produção pra
+            // um business (ex: biz=164) não pode afetar outros tenants (ROTA LIVRE etc).
+            // Fail-safe: ausência de config → 'homologacao' (nunca emite real por acidente).
+            ambiente: $config?->ambiente ?? 'homologacao',
+            municipioIbge: $config?->municipio_codigo_ibge ?? config('nfse.municipio_ibge_default', '4218707'),
             prestadorCnpj: $config?->prestador_cnpj,
             prestadorIm: $config?->prestador_im,
             transactionId: !empty($data['transaction_id']) ? (int) $data['transaction_id'] : null,

--- a/Modules/NFSe/Tests/Feature/AmbientePorBusinessTest.php
+++ b/Modules/NFSe/Tests/Feature/AmbientePorBusinessTest.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+use Carbon\Carbon;
+use Illuminate\Support\Facades\Http;
+use Modules\NFSe\Adapters\SnNfseAdapter;
+use Modules\NFSe\DTO\NfseEmissaoPayload;
+use Modules\NFSe\Services\NfseEmissaoService;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Cutover fiscal por-business (Martinho biz=164, 2026-06-03).
+ *
+ * GAP detectado no Passo 0: o ambiente da emissão NFS-e era resolvido pelo
+ * BIND GLOBAL `config('nfse.ambiente')` (env NFSE_AMBIENTE), não pelo campo
+ * por-business `nfse_provider_configs.ambiente`. Ligar produção pra 1 tenant
+ * afetaria TODOS (ROTA LIVRE etc) — viola o requisito "não tocar outros
+ * clientes" do cutover controlado.
+ *
+ * Estes testes travam o comportamento correto: a EMISSÃO segue
+ * `$payload->ambiente` (do tenant), independente de como o adapter foi bindado.
+ *
+ * DB-free (Http::fake + adapter puro) — roda em SQLite CI sem schema MySQL.
+ *
+ * @see Modules/NFSe/Adapters/SnNfseAdapter.php
+ * @see Modules/NFSe/Services/NfseEmissaoService.php (montarPayload)
+ * @see memory/decisions/0093-multi-tenant-isolation-tier-0.md
+ */
+
+function makeNfsePayload(string $ambiente): NfseEmissaoPayload
+{
+    return new NfseEmissaoPayload(
+        businessId: 164,
+        rpsNumero: '202606030001',
+        competencia: Carbon::createFromFormat('Y-m', '2026-06'),
+        tomadorNome: 'Cliente Teste',
+        tomadorCnpj: '11222333000181',
+        tomadorCpf: null,
+        tomadorEmail: 'teste@example.com',
+        descricao: 'Servico de teste cutover',
+        lc116Codigo: '1.05',
+        valorServicos: 10.00,
+        aliquotaIss: 0.05,
+        issRetido: false,
+        certPfxBase64: base64_encode('fake-pfx'),
+        certSenha: 'senha',
+        ambiente: $ambiente,
+    );
+}
+
+it('emissao usa PRODUCAO do payload (por-business) mesmo com bind global homologacao', function () {
+    Http::fake(['*' => Http::response(['nfseId' => '1', 'protocolo' => 'P1'], 200)]);
+
+    // Adapter bindado no GLOBAL homologacao (como o container faz hoje)...
+    $adapter = new SnNfseAdapter('homologacao');
+    // ...mas o tenant biz=164 está em producao.
+    $adapter->emitir(makeNfsePayload('producao'));
+
+    Http::assertSent(function ($request) {
+        return str_starts_with($request->url(), 'https://sefin.nfse.gov.br')
+            && (int) data_get($request->data(), 'infDps.tpAmb') === 1;
+    });
+});
+
+it('emissao usa HOMOLOGACAO do payload mesmo com bind global producao (anti-vazamento)', function () {
+    Http::fake(['*' => Http::response(['nfseId' => '1', 'protocolo' => 'P1'], 200)]);
+
+    // Mesmo que alguém deixe o bind global em producao, um tenant em homolog
+    // NÃO pode emitir nota real por arraste.
+    $adapter = new SnNfseAdapter('producao');
+    $adapter->emitir(makeNfsePayload('homologacao'));
+
+    Http::assertSent(function ($request) {
+        return str_starts_with($request->url(), 'https://sefin.producaorestrita.nfse.gov.br')
+            && (int) data_get($request->data(), 'infDps.tpAmb') === 2;
+    });
+});
+
+it('montarPayload propaga o ambiente por-business do NfseProviderConfig (wiring travado)', function () {
+    $src = file_get_contents((new ReflectionClass(NfseEmissaoService::class))->getFileName());
+
+    // Garante que o ambiente do payload vem do $config (tenant), não hardcoded.
+    expect($src)->toMatch('/ambiente:\s*\$config\?->ambiente/');
+});
+
+it('DTO NfseEmissaoPayload default ambiente e fail-safe homologacao', function () {
+    $p = new NfseEmissaoPayload(
+        businessId: 1,
+        rpsNumero: '1',
+        competencia: Carbon::createFromFormat('Y-m', '2026-06'),
+        tomadorNome: 'x',
+        tomadorCnpj: null,
+        tomadorCpf: '12345678909',
+        tomadorEmail: null,
+        descricao: 'd',
+        lc116Codigo: '1.05',
+        valorServicos: 1.0,
+        aliquotaIss: 0.05,
+    );
+
+    expect($p->ambiente)->toBe('homologacao');
+});


### PR DESCRIPTION
## Contexto
Passo 0 do **cutover fiscal controlado da Martinho (biz=164)** — ligar emissão fiscal REAL sem tocar outros clientes (ROTA LIVRE etc).

## Furo detectado (Passo 0)
O ambiente da emissão **NFS-e** era resolvido pelo **bind global** `config('nfse.ambiente')` (`env NFSE_AMBIENTE`) no `SnNfseAdapter`, **não** pelo campo por-business `nfse_provider_configs.ambiente` — que existia mas estava morto (só aparecia na UI, nunca chegava no adapter).

➡️ Flipar NFS-e pra produção exigiria mudar o `.env` global → **emitiria nota real de TODOS os tenants**. Viola multi-tenant Tier 0 ([ADR 0093](../blob/main/memory/decisions/0093-multi-tenant-isolation-tier-0.md)) e o requisito "não tocar outros clientes".

NF-e 55 já era correto (`business.ambiente` → `tpAmb`). Este PR alinha NFS-e ao mesmo padrão **per-business**.

## Mudança (aditivo, sem migration — campo + DTO já existiam)
- **`NfseEmissaoService::montarPayload`** — popula `ambiente`/`municipioIbge` do tenant (`NfseProviderConfig`). Fail-safe: sem config → `homologacao` (nunca emite real por acidente).
- **`SnNfseAdapter::emitir/buildDps`** — endpoint + `tpAmb` derivam de `$payload->ambiente` por-call, não do bind global. Helper `resolveBaseUrl()`.
- **`AmbientePorBusinessTest`** (novo) — 4 testes DB-free (`Http::fake`): payload `producao` emite no endpoint real mesmo com bind global homolog + anti-vazamento inverso.

## Verificação
- `php -l` limpo nos 3 arquivos.
- Pest **não rodou local** (checkout sem `vendor/`) → roda no CI deste PR.

## Não-escopo (follow-up documentado no código)
`SnNfseAdapter::consultar()/cancelar()` ainda usam o ambiente do bind (não recebem payload). Hoje não é regressão (já eram globais); entra no PR de cancelamento ("PR separado" por escopo do cutover).

## Cutover (depende deste PR)
Sem este fix, o passo "flip NFS-e prod só biz=164" não é seguro. Detalhe completo + checklist [W] em [`prototipo-ui/CODE_NOTES.md`](../blob/main/prototipo-ui/CODE_NOTES.md) (entrada 2026-06-03).

🤖 Generated with [Claude Code](https://claude.com/claude-code)