### PR TITLE
feat(oficina-auto): W28 importer Firebird fino + reconcilia domínio caçamba→caminhão (ADR 0194)

### DIFF
--- a/Modules/OficinaAuto/CHANGELOG.md
+++ b/Modules/OficinaAuto/CHANGELOG.md
@@ -1,5 +1,19 @@
 # OficinaAuto — Changelog
 
+## [W28 — 2026-06-03] Importer Firebird fino + reconciliação de domínio (ADR 0194)
+
+### G4 Importer Firebird Martinho — mapping fino (sai do esqueleto W27)
+- `ImportFirebirdMartinhoCommand` completo: mapping fino ORDEM_SERVICO + ORDEM_ITENS → ServiceOrder + ServiceOrderItem.
+  - `vehicle_type` default **`cacamba` → `caminhao`** (`cacamba` nem era valor válido do enum `vehicles.vehicle_type`). Normalização via whitelist real + sinônimos de basculante → `caminhao`.
+  - Status legacy (WR Sistemas, PT livre) → FSM `manutencao` (aberta/em_servico/concluida/cancelada); histórico fechado default `concluida`.
+  - `order_type` normalizado {locacao|manutencao|mecanica}; legado default `manutencao` (migration `2026_06_02_000001`: "novo processo mecanica não mexe no legado").
+  - Tipo de item → `peca|mao_obra|servico_terceiro`.
+  - **Dry-run virou o padrão**: grava no DB só com `--commit` (`--dry-run` vence por segurança). Idempotência `FB_LEGACY_ID` preservada.
+- `scripts/firebird/export-martinho-os.py` — export local (Windows + firebird-driver) com `--dump-schema` pra mapear os nomes reais do FDB.
+
+### 🪦 Lápide de domínio (ADR 0194 · 2026-05-26 — append, não reescreve história · L-22)
+- Entradas anteriores deste changelog citam **"Martinho Caçambas"** / **"Journey Martinho Caçambas"**: "Caçambas" é o **nome comercial** da empresa, preservado. O **domínio operacional**, porém, foi reclassificado de "locação de caçamba container" → **mecânica pesada de caminhão basculante (CNAE 4520-0/01)** pela [ADR 0194](../../memory/decisions/0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada.md). Onde o texto legado sugerir "locação de caçamba" como *fluxo de negócio*, leia "mecânica de caminhão".
+
 ## [Wave 27 POLISH — 2026-05-17] Polish final 77-88 → ≥90
 
 ### D2 Pest novo

--- a/Modules/OficinaAuto/Console/Commands/ImportFirebirdMartinhoCommand.php
+++ b/Modules/OficinaAuto/Console/Commands/ImportFirebirdMartinhoCommand.php
@@ -14,26 +14,35 @@ use Modules\OficinaAuto\Services\ServiceOrderItemService;
 use Throwable;
 
 /**
- * W27 G4 — Importer ESQUELETO Firebird Martinho Caçambas → oimpresso OficinaAuto.
+ * W28 G4 — Importer Firebird Martinho → oimpresso OficinaAuto (mapping fino completo).
+ *
+ * ⚠️ Domínio corrigido ([ADR 0194](memory/decisions/0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada.md)):
+ * Martinho = **mecânica pesada de caminhão basculante** (CNAE 4520-0/01), NÃO locação
+ * de caçamba container (sub-vertical 3 hipotético, sem cliente real). O default de
+ * `vehicle_type` deixou de ser `'cacamba'` (valor que nem existia no enum) e passou a
+ * ser `'caminhao'` (whitelist real do Vehicle) — rodar como estava etiquetava os
+ * caminhões da Martinho como caçamba. Veja `normalizeVehicleType()`.
  *
  * Padrão validado em `customer-memory:enrich-firebird` (Modules/Whatsapp):
  * Firebird (Windows-only via DBeaver/python firebird-driver) NÃO é acessado direto
  * pelo Laravel. Wagner exporta JSON localmente, sobe pro Hostinger, e este comando consome.
  *
- * Fluxo previsto:
+ * Fluxo:
  *   1) Wagner local (Windows + Firebird driver):
  *      python scripts/firebird/export-martinho-os.py \
+ *          --dsn "localhost/3050:C:/dados/MARTINHO.FDB" \
  *          --output storage/app/firebird/martinho-os-YYYY-MM-DD.json
  *      (script lê ORDEM_SERVICO + ORDEM_ITENS, dumpa JSON normalizado)
  *
  *   2) Upload pro Hostinger (git/scp).
  *
- *   3) php artisan oficina:import-firebird-martinho \
- *          --business=1 \
- *          --json=storage/app/firebird/martinho-os-2026-05-17.json \
- *          --dry-run
+ *   3) Validar SEM gravar (dry-run é o padrão):
+ *      php artisan oficina:import-firebird-martinho \
+ *          --business=164 \
+ *          --json=storage/app/firebird/martinho-os-2026-06-03.json
  *
- *   4) Wagner aprova diff → roda sem --dry-run.
+ *   4) Wagner aprova o diff → roda com --commit pra gravar de fato.
+ *      php artisan oficina:import-firebird-martinho --business=164 --json=... --commit
  *
  * Idempotência: legacy_id (CODIGO Firebird ORDEM_ID) salvo em ServiceOrder.notes
  * (prefix "FB_LEGACY_ID:N") + Vehicle.legacy_id pra evitar duplicação em rerun.
@@ -41,9 +50,10 @@ use Throwable;
  * Multi-tenant Tier 0 ([ADR 0093]): --business obrigatório. Importer é ONE-WAY
  * (Firebird → oimpresso, NUNCA reverso — Firebird legacy congelado).
  *
- * Status: ESQUELETO W27 — script python de export + mapping fino entram em W28.
+ * Segurança: **dry-run é o caminho padrão** — grava no DB só com --commit explícito.
  *
  * @see Modules/Whatsapp/Console/Commands/CustomerMemoryEnrichFirebirdCommand.php  (pattern)
+ * @see scripts/firebird/export-martinho-os.py  (export local)
  * @see memory/requisitos/OficinaAuto/CAPTERRA-FICHA.md G4
  */
 class ImportFirebirdMartinhoCommand extends Command
@@ -52,12 +62,28 @@ class ImportFirebirdMartinhoCommand extends Command
                             {--business= : business_id obrigatório (Tier 0 ADR 0093)}
                             {--json= : path do JSON exportado Firebird (default: storage/app/firebird/martinho-latest.json)}
                             {--limit=0 : máximo OS importadas (0=ilimitado)}
-                            {--dry-run : simula sem modificar DB}
+                            {--commit : grava de fato no DB (sem esta flag = dry-run, padrão seguro)}
+                            {--dry-run : força simulação mesmo com --commit (vence por segurança)}
                             {--detail : log linha-a-linha por OS}';
 
-    protected $description = 'Importa OS legacy Firebird Martinho → ServiceOrder + ServiceOrderItem (W27 G4 esqueleto).';
+    protected $description = 'Importa OS legacy Firebird Martinho → ServiceOrder + ServiceOrderItem (W28 G4 · mecânica pesada caminhão ADR 0194).';
 
     private const FIREBIRD_LEGACY_PREFIX = 'FB_LEGACY_ID:';
+
+    /**
+     * Default canônico pós-ADR 0194: Martinho é oficina de caminhão basculante.
+     * Tem que estar na whitelist real do enum vehicles.vehicle_type (migrations
+     * 2026_05_11_000010 + 2026_05_12_220001). `caminhao` é o valor canônico de
+     * caminhão; o antigo `cacamba` nem era um valor válido do enum.
+     */
+    private const DEFAULT_VEHICLE_TYPE = 'caminhao';
+
+    /** Whitelist real do enum vehicles.vehicle_type (NÃO inventar fora disso). */
+    private const VEHICLE_TYPE_WHITELIST = [
+        'caminhao', 'cavalo', 'semi_reboque', 'cacamba_estacionaria',
+        'cacamba_avulsa', 'cacamba_caminhao', 'recapagem',
+        'automovel', 'motocicleta', 'outros', 'outro',
+    ];
 
     public function handle(): int
     {
@@ -73,7 +99,7 @@ class ImportFirebirdMartinhoCommand extends Command
         if (! file_exists($jsonPath)) {
             $this->error("JSON não encontrado: {$jsonPath}");
             $this->warn('Rode primeiro o export Python local (Windows + firebird-driver):');
-            $this->line('  python scripts/firebird/export-martinho-os.py --output ' . $jsonPath);
+            $this->line('  python scripts/firebird/export-martinho-os.py --dsn "..." --output ' . $jsonPath);
             return Command::FAILURE;
         }
 
@@ -98,12 +124,14 @@ class ImportFirebirdMartinhoCommand extends Command
             $ordens = array_slice($ordens, 0, $limit);
         }
 
-        $dryRun = (bool) $this->option('dry-run');
+        // Dry-run é o PADRÃO seguro: só grava com --commit explícito. --dry-run
+        // vence sempre (se vier junto de --commit, manda a segurança).
+        $dryRun = ! ((bool) $this->option('commit')) || (bool) $this->option('dry-run');
         $detail = (bool) $this->option('detail');
 
         $this->info('Source JSON: ' . $jsonPath);
         $this->info('Business: ' . $businessId);
-        $this->info('Dry-run: ' . ($dryRun ? 'SIM (zero modificação DB)' : 'NÃO (commit real)'));
+        $this->info('Modo: ' . ($dryRun ? 'DRY-RUN (padrão — zero modificação DB)' : 'COMMIT (grava no DB)'));
         $this->info('OS a processar: ' . count($ordens));
 
         $stats = [
@@ -145,7 +173,7 @@ class ImportFirebirdMartinhoCommand extends Command
         );
 
         if ($dryRun) {
-            $this->warn('DRY-RUN — nenhuma modificação aplicada ao DB. Rode sem --dry-run pra commit real.');
+            $this->warn('DRY-RUN (padrão) — nenhuma modificação aplicada ao DB. Rode com --commit pra gravar.');
         }
 
         return $stats['erros'] > 0 ? Command::FAILURE : Command::SUCCESS;
@@ -205,6 +233,8 @@ class ImportFirebirdMartinhoCommand extends Command
             throw new \RuntimeException("placa ausente legacy_id={$legacyId}");
         }
 
+        $vehicleType = $this->normalizeVehicleType($ordem['vehicle_type'] ?? null);
+
         // Vehicle: localiza por placa+biz OU cria stub
         $vehicle = Vehicle::withoutGlobalScopes()
             ->where('business_id', $businessId)
@@ -214,13 +244,14 @@ class ImportFirebirdMartinhoCommand extends Command
         if ($vehicle === null) {
             if ($dryRun) {
                 if ($detail) {
-                    $this->line("  + (dry-run) Vehicle stub: placa={$placa}");
+                    $this->line("  + (dry-run) Vehicle stub: placa={$placa} tipo={$vehicleType}");
                 }
             } else {
                 $vehicle = Vehicle::withoutGlobalScopes()->create([
                     'business_id'  => $businessId,
                     'plate'        => $placa,
-                    'vehicle_type' => 'cacamba', // Martinho-specific
+                    // ADR 0194: caminhão (não caçamba). Vem do JSON se mapeável, senão default caminhao.
+                    'vehicle_type' => $vehicleType,
                     'legacy_id'    => (string) ($ordem['veiculo_id'] ?? null),
                 ]);
             }
@@ -229,12 +260,17 @@ class ImportFirebirdMartinhoCommand extends Command
         $itensInput = (array) ($ordem['itens'] ?? []);
         $itensCriados = 0;
 
+        $orderType = $this->normalizeOrderType($ordem['order_type'] ?? null);
+        $status    = $this->normalizeStatus($ordem['status'] ?? null);
+
         if ($dryRun) {
             if ($detail) {
                 $this->line(sprintf(
-                    '  + (dry-run) OS legacy_id=%s placa=%s itens=%d',
+                    '  + (dry-run) OS legacy_id=%s placa=%s tipo=%s status=%s itens=%d',
                     $legacyId,
                     $placa,
+                    $orderType,
+                    $status,
                     count($itensInput)
                 ));
             }
@@ -247,6 +283,8 @@ class ImportFirebirdMartinhoCommand extends Command
             $businessId,
             $vehicle,
             $legacyId,
+            $orderType,
+            $status,
             $itensInput,
             $itemService,
             &$itensCriados,
@@ -255,8 +293,8 @@ class ImportFirebirdMartinhoCommand extends Command
             $os = ServiceOrder::withoutGlobalScopes()->create([
                 'business_id'        => $businessId,
                 'vehicle_id'         => $vehicle->id,
-                'order_type'         => (string) ($ordem['order_type'] ?? 'manutencao'),
-                'status'             => (string) ($ordem['status'] ?? 'concluida'), // legacy = histórico
+                'order_type'         => $orderType,
+                'status'             => $status,
                 'entered_at'         => $ordem['entered_at'] ?? null,
                 'completed_at'       => $ordem['completed_at'] ?? null,
                 // ADR 0121 §P8 — vocab shared: data_get() em vez de bracket-array-access
@@ -269,7 +307,7 @@ class ImportFirebirdMartinhoCommand extends Command
 
             foreach ($itensInput as $itemData) {
                 $itemService->addItem($businessId, $os->id, [
-                    'tipo'           => (string) ($itemData['tipo'] ?? 'peca'),
+                    'tipo'           => $this->normalizeItemTipo($itemData['tipo'] ?? null),
                     'descricao'      => (string) ($itemData['descricao'] ?? 'Sem descrição'),
                     'quantidade'     => (float) ($itemData['quantidade'] ?? 1),
                     'valor_unitario' => (float) ($itemData['valor_unitario'] ?? 0),
@@ -292,5 +330,114 @@ class ImportFirebirdMartinhoCommand extends Command
         });
 
         return ['criada' => true, 'pulada' => false, 'itens' => $itensCriados];
+    }
+
+    /**
+     * Normaliza vehicle_type pro enum REAL do Vehicle (ADR 0194: caminhão, não caçamba).
+     *
+     * - valor já na whitelist → mantém;
+     * - sinônimos de caminhão basculante (cacamba/basculante/caminhao_basculante/...) → 'caminhao';
+     * - vazio/desconhecido → DEFAULT_VEHICLE_TYPE ('caminhao').
+     *
+     * NÃO inventa valor fora do enum. O domínio do Martinho é mecânica pesada de
+     * caminhão — etiquetar como 'cacamba' era o drift pré-ADR-0194.
+     */
+    private function normalizeVehicleType(mixed $raw): string
+    {
+        $v = strtolower(trim((string) ($raw ?? '')));
+        if ($v === '') {
+            return self::DEFAULT_VEHICLE_TYPE;
+        }
+
+        if (in_array($v, self::VEHICLE_TYPE_WHITELIST, true)) {
+            return $v;
+        }
+
+        // Sinônimos de "caminhão basculante" que apareciam em docs/JSON legacy mas
+        // não estão na whitelist (caminhao_basculante, cacamba_basculante, cacamba...).
+        $caminhaoSinonimos = ['cacamba', 'basculante', 'caminhao_basculante', 'cacamba_basculante', 'caminhao_cacamba', 'truck'];
+        if (in_array($v, $caminhaoSinonimos, true)) {
+            return 'caminhao';
+        }
+
+        return self::DEFAULT_VEHICLE_TYPE;
+    }
+
+    /**
+     * Mapeia order_type legacy → {locacao|manutencao|mecanica}.
+     *
+     * Default 'manutencao' = bucket do legado (migration 2026_06_02_000001 decidiu
+     * "novo processo mecanica não mexe no legado"). OS históricas importadas ficam
+     * em 'manutencao'. [W] decide se quer reclassificar pra 'mecanica' (ver CODE_NOTES).
+     */
+    private function normalizeOrderType(mixed $raw): string
+    {
+        $v = strtolower(trim((string) ($raw ?? '')));
+        return match (true) {
+            $v === 'mecanica'  => 'mecanica',
+            $v === 'locacao'   => 'locacao',
+            default            => 'manutencao',
+        };
+    }
+
+    /**
+     * Mapeia status legacy (WR Sistemas, PT livre) → status canônico do FSM
+     * manutencao (aberta|em_servico|concluida|cancelada).
+     *
+     * OS legacy são histórico fechado → default 'concluida'.
+     */
+    private function normalizeStatus(mixed $raw): string
+    {
+        $v = $this->foldAccents(strtolower(trim((string) ($raw ?? ''))));
+        $v = str_replace(['_', '-'], ' ', $v);
+
+        return match (true) {
+            $v === '' => 'concluida', // legacy histórico
+            str_contains($v, 'cancel')                                   => 'cancelada',
+            str_contains($v, 'andamento') || str_contains($v, 'execu')
+                || str_contains($v, 'servic') || str_contains($v, 'aberto execu') => 'em_servico',
+            str_contains($v, 'abert') || str_contains($v, 'orcament')    => 'aberta',
+            str_contains($v, 'conclu') || str_contains($v, 'finaliz')
+                || str_contains($v, 'fechad') || str_contains($v, 'entreg')
+                || str_contains($v, 'pronto')                            => 'concluida',
+            default => 'concluida',
+        };
+    }
+
+    /**
+     * Mapeia tipo de item legacy → ServiceOrderItem::TIPOS_VALIDOS
+     * (peca|mao_obra|servico_terceiro). Default 'peca'.
+     */
+    private function normalizeItemTipo(mixed $raw): string
+    {
+        $v = $this->foldAccents(strtolower(trim((string) ($raw ?? ''))));
+
+        if (in_array($v, ServiceOrderItem::TIPOS_VALIDOS, true)) {
+            return $v;
+        }
+
+        return match (true) {
+            str_contains($v, 'terceir')                                  => 'servico_terceiro',
+            str_contains($v, 'mao') || str_contains($v, 'obra')
+                || str_contains($v, 'hora') || str_contains($v, 'servic')
+                || str_contains($v, 'labor')                             => 'mao_obra',
+            default => 'peca',
+        };
+    }
+
+    /**
+     * Folding ASCII de acentos PT-BR — legacy WR Sistemas grava status/tipo com
+     * acento ('ORÇAMENTO', 'EXECUÇÃO', 'SERVIÇO'); os matchers comparam em ASCII.
+     */
+    private function foldAccents(string $v): string
+    {
+        return strtr($v, [
+            'á' => 'a', 'à' => 'a', 'â' => 'a', 'ã' => 'a', 'ä' => 'a',
+            'é' => 'e', 'è' => 'e', 'ê' => 'e', 'ë' => 'e',
+            'í' => 'i', 'ì' => 'i', 'î' => 'i', 'ï' => 'i',
+            'ó' => 'o', 'ò' => 'o', 'ô' => 'o', 'õ' => 'o', 'ö' => 'o',
+            'ú' => 'u', 'ù' => 'u', 'û' => 'u', 'ü' => 'u',
+            'ç' => 'c', 'ñ' => 'n',
+        ]);
     }
 }

--- a/Modules/OficinaAuto/README.md
+++ b/Modules/OficinaAuto/README.md
@@ -24,7 +24,7 @@ Candidatos secundários: Vargas (recapagem complexa fluxo 5 estados).
 | Passo | Onde | Resultado esperado |
 |-------|------|-------------------|
 | 1. Login biz=1 + entrar `/oficina-auto/veiculos` | `VehicleController@index` | Lista veículos com KPIs (disponivel/locada/manutencao/atrasada) |
-| 2. Criar veículo placa `WAG0001`, tipo `cacamba_basculante` | `POST /oficina-auto/veiculos` | Veículo persistido com `business_id=1` |
+| 2. Criar veículo placa `WAG0001`, tipo `caminhao` (basculante — ADR 0194; `cacamba_basculante` **não** é valor do enum) | `POST /oficina-auto/veiculos` | Veículo persistido com `business_id=1` |
 | 3. Abrir OS de manutenção pra `WAG0001` | `POST /oficina-auto/ordens-servico` | OS criada status `aberta` |
 | 4. Transição FSM → `em_servico` → `concluida` | `ExecuteStageActionService` (US-OFICINA-003) | Audit log em `sale_stage_history` |
 | 5. Gerar link WhatsApp aprovação (OS orçamento) | `AprovacaoOsService::gerarTokenAprovacao` | Token HMAC + PIN 4 dígitos no cache 7d |

--- a/Modules/OficinaAuto/Tests/Feature/ImportFirebirdMartinhoW28Test.php
+++ b/Modules/OficinaAuto/Tests/Feature/ImportFirebirdMartinhoW28Test.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\OficinaAuto\Console\Commands\ImportFirebirdMartinhoCommand;
+use Modules\OficinaAuto\Entities\ServiceOrderItem;
+
+/**
+ * W28 G4 — Importer Firebird Martinho (mapping fino + reconciliação domínio ADR 0194).
+ *
+ * Pattern do módulo (Wave 25/27): reflection-only, ZERO hit DB — roda paralelizado
+ * em N worktrees sem conflito e não depende do suite de migration completo. Cobre a
+ * lógica de mapping pura (vehicle_type/status/order_type/item) + os contratos imutáveis
+ * (default 'caminhao' não 'cacamba'; whitelist do enum). O caminho DB-real (criar OS +
+ * idempotência) é provado por smoke dry-run contra o DB migrado + CI.
+ *
+ * @see Modules/OficinaAuto/Console/Commands/ImportFirebirdMartinhoCommand.php
+ * @see memory/decisions/0194-correcao-dominio-oficinaauto-martinho-mecanica-pesada.md
+ */
+
+function w28Invoke(string $method, mixed $arg): mixed
+{
+    $cmd = new ImportFirebirdMartinhoCommand();
+    $m = new ReflectionMethod($cmd, $method);
+    $m->setAccessible(true);
+
+    return $m->invoke($cmd, $arg);
+}
+
+it('normalizeVehicleType: ADR 0194 — caminhao, NUNCA cacamba', function () {
+    expect(w28Invoke('normalizeVehicleType', null))->toBe('caminhao');        // vazio → default
+    expect(w28Invoke('normalizeVehicleType', ''))->toBe('caminhao');
+    expect(w28Invoke('normalizeVehicleType', 'cacamba'))->toBe('caminhao');   // o bug antigo → corrigido
+    expect(w28Invoke('normalizeVehicleType', 'cacamba_basculante'))->toBe('caminhao'); // doc legacy não-whitelisted
+    expect(w28Invoke('normalizeVehicleType', 'caminhao_basculante'))->toBe('caminhao'); // docblock legacy
+    expect(w28Invoke('normalizeVehicleType', 'BASCULANTE'))->toBe('caminhao');
+    expect(w28Invoke('normalizeVehicleType', 'desconhecido_xyz'))->toBe('caminhao');
+});
+
+it('normalizeVehicleType: valor já na whitelist do enum é preservado', function () {
+    expect(w28Invoke('normalizeVehicleType', 'caminhao'))->toBe('caminhao');
+    expect(w28Invoke('normalizeVehicleType', 'automovel'))->toBe('automovel');
+    expect(w28Invoke('normalizeVehicleType', 'cacamba_estacionaria'))->toBe('cacamba_estacionaria');
+    expect(w28Invoke('normalizeVehicleType', 'semi_reboque'))->toBe('semi_reboque');
+});
+
+it('normalizeStatus: legacy WR (PT livre) → FSM manutencao', function () {
+    expect(w28Invoke('normalizeStatus', 'ABERTA'))->toBe('aberta');
+    expect(w28Invoke('normalizeStatus', 'orçamento'))->toBe('aberta');
+    expect(w28Invoke('normalizeStatus', 'EM ANDAMENTO'))->toBe('em_servico');
+    expect(w28Invoke('normalizeStatus', 'em_servico'))->toBe('em_servico');
+    expect(w28Invoke('normalizeStatus', 'FINALIZADA'))->toBe('concluida');
+    expect(w28Invoke('normalizeStatus', 'fechado'))->toBe('concluida');
+    expect(w28Invoke('normalizeStatus', 'CANCELADO'))->toBe('cancelada');
+    expect(w28Invoke('normalizeStatus', null))->toBe('concluida');   // histórico
+    expect(w28Invoke('normalizeStatus', ''))->toBe('concluida');
+});
+
+it('normalizeOrderType: default manutencao (legado), respeita mecanica/locacao', function () {
+    expect(w28Invoke('normalizeOrderType', null))->toBe('manutencao');
+    expect(w28Invoke('normalizeOrderType', 'mecanica'))->toBe('mecanica');
+    expect(w28Invoke('normalizeOrderType', 'locacao'))->toBe('locacao');
+    expect(w28Invoke('normalizeOrderType', 'qualquer_coisa'))->toBe('manutencao');
+});
+
+it('normalizeItemTipo: legacy → TIPOS_VALIDOS', function () {
+    expect(w28Invoke('normalizeItemTipo', 'PRODUTO'))->toBe('peca');
+    expect(w28Invoke('normalizeItemTipo', 'material'))->toBe('peca');
+    expect(w28Invoke('normalizeItemTipo', 'MAO DE OBRA'))->toBe('mao_obra');
+    expect(w28Invoke('normalizeItemTipo', 'hora trabalhada'))->toBe('mao_obra');
+    expect(w28Invoke('normalizeItemTipo', 'servico_terceiro'))->toBe('servico_terceiro');
+    expect(w28Invoke('normalizeItemTipo', 'terceirizado'))->toBe('servico_terceiro');
+    expect(w28Invoke('normalizeItemTipo', null))->toBe('peca');
+    foreach (['PRODUTO', 'MAO DE OBRA', 'terceiro', null, 'xyz'] as $in) {
+        expect(w28Invoke('normalizeItemTipo', $in))->toBeIn(ServiceOrderItem::TIPOS_VALIDOS);
+    }
+});
+
+it('contratos imutáveis: default caminhao + whitelist sem o pseudo-valor cacamba', function () {
+    $rc = new ReflectionClass(ImportFirebirdMartinhoCommand::class);
+    expect($rc->getConstant('DEFAULT_VEHICLE_TYPE'))->toBe('caminhao');
+
+    $whitelist = $rc->getConstant('VEHICLE_TYPE_WHITELIST');
+    expect($whitelist)->toContain('caminhao');
+    expect($whitelist)->not->toContain('cacamba'); // 'cacamba' puro nunca foi valor do enum
+});
+
+it('o código não regrediu pro default cacamba hardcoded', function () {
+    $src = file_get_contents((new ReflectionClass(ImportFirebirdMartinhoCommand::class))->getFileName());
+    expect($src)->not->toContain("'vehicle_type' => 'cacamba'");
+    expect($src)->toContain('ADR 0194');
+});

--- a/prototipo-ui/CODE_NOTES.md
+++ b/prototipo-ui/CODE_NOTES.md
@@ -537,3 +537,41 @@ O furo (exatamente o que o "não assumir" pega): o NFS-e resolvia ambiente pelo 
 ### new_design_memories
 - **golden**: export de governança da Cowork (conclusão/raciocínio, não só o número do scorecard) vai pro git **verbatim** como charter irmão, cortado de `origin/main` fresco — durabilidade + re-derivação por sessão futura ([CL]/[CC]).
 - **anti-padrao**: commitar doc de governança numa branch poluída (WIP de outro intent) — fura commit-discipline (1 PR = 1 intent). Worktree novo de `origin/main` isola o arquivo.
+
+---
+
+## 2026-06-03 [CL] → [W] — W28 importer Firebird + reconciliação domínio "Caçamba"→caminhão (Martinho biz=164)
+
+### Tarefa: §10.4 PROPOSTA (Tarefa A do prompt `W28-FIREBIRD-DOMINIO-MARTINHO`)
+### Status: traduzido · branch `feat/oficina-w28-firebird-dominio` · PR aberto · **NÃO mergeado (Tier 0 = [W])**
+### Validação vs `origin/main` (74bc2ea77 · worktree off origin/main, não o working tree):
+- `ImportFirebirdMartinhoCommand` confirmado **ESQUELETO W27** (mapping fino não existia) — não duplicquei, completei.
+- `scripts/firebird/export-martinho-os.py` **não existia** — criado do zero (template `export-customers.py`).
+- Achado que ancora confirmado @main: o importer hardcodava `'vehicle_type' => 'cacamba'` — e **`cacamba` nem é valor válido** do enum `vehicles.vehicle_type` (whitelist real: `caminhao, cavalo, semi_reboque, cacamba_estacionaria, cacamba_avulsa, cacamba_caminhao, recapagem, automovel, motocicleta, outros, outro`). Rodar como estava etiquetava os caminhões da Martinho como caçamba (drift pré-ADR 0194).
+
+### Decisões de tradução:
+- **vehicle_type default `cacamba` → `caminhao`** (ADR 0194 · valor canônico de caminhão na whitelist real). `normalizeVehicleType()` mapeia sinônimos de basculante (`cacamba`/`basculante`/`caminhao_basculante`/`cacamba_basculante`) → `caminhao`; valor já-whitelisted é preservado; default `caminhao`. **NÃO inventei** valor fora do enum (o `caminhao_basculante` do docblock e `cacamba_basculante` do README/E2E **não** estão no enum — só funcionavam em SQLite de test).
+- **status legacy→FSM** (`normalizeStatus`, accent-fold PT): ABERTA/orçamento→`aberta`, andamento/execução/serviço→`em_servico`, finalizada/fechado/concluída→`concluida`, cancel*→`cancelada`; histórico vazio→`concluida`.
+- **order_type** (`normalizeOrderType`): default `manutencao` (bucket do legado — migration `2026_06_02_000001` "novo processo mecanica não mexe no legado"); respeita `mecanica`/`locacao` se vier do JSON.
+- **item tipo** → `peca|mao_obra|servico_terceiro`. Idempotência `FB_LEGACY_ID` preservada.
+- **Dry-run virou o PADRÃO**: grava só com `--commit` (`--dry-run` vence por segurança se vier junto). "Commit real só com diff aprovado" passou a ser enforced por default, não por disciplina.
+- **Docs curados** (append, não reescreve história · L-22): `CHANGELOG.md` ganhou entrada W28 + lápide ADR 0194 ("Caçambas" = nome comercial preservado; *domínio* reclassificado p/ mecânica de caminhão); `README.md` journey passo 2 `cacamba_basculante`→`caminhao` (valor válido).
+
+### Build / Tests:
+- `ImportFirebirdMartinhoW28Test` — **7 passed (41 assertions)**, reflection-only (pattern Wave 25/27 do módulo, zero-DB): cobre todos os mappings + contrato "default caminhao, nunca cacamba" + source-grep anti-regressão.
+- `php -l` ok nos 2 PHP; `python -m ast` ok no `.py`.
+- ⚠️ **Não rodei o caminho DB-real local**: o dev DB local não tem as tabelas OficinaAuto e o suite de migration completo não re-roda do zero localmente (migration pré-existente `ALTER TABLE transactions MODIFY ...` quebra em SQLite; e FK `fin_contas_bancarias→rb_boleto_credentials` fora de ordem em MySQL fresco). Não é do meu diff — roda em CI/MySQL.
+
+### Tarefa B (preflight de cutover observável): **PULADA** (escopo · 1 PR = 1 intent). Reportada como follow-up [W].
+
+### Pendências / fica de [W]:
+- [ ] **[W]** decidir se OS históricas devem entrar como `order_type='mecanica'` (domínio real ADR 0194) em vez de `manutencao` (default conservador atual). É decisão de domínio.
+- [ ] **[W]** rodar `oficina:migration-report {biz} --detail` + `oficina:sanity-check` no fixture/staging pós-import (prova: vendas órfãs / OS sem NFe / pendentes) — exige DB migrado (CI/staging).
+- [ ] **[W]** ajustar o SCHEMA MAP do `export-martinho-os.py` aos nomes REAIS das tabelas do FDB (rodar `--dump-schema` no Windows + Firebird local) antes do export de verdade.
+- [ ] **[W]** drift residual a decidir: README/E2E ainda têm `cacamba_basculante` (não-whitelisted, passa só em SQLite) + docblock do Vehicle recomenda `caminhao_basculante` (não-whitelisted) — opção [W]: adicionar valor de enum dedicado via migration OU consolidar tudo em `caminhao`/`cacamba_caminhao`. Não inventei migration de schema.
+- [ ] **[W]** import real só contra staging/prod biz=164 (NÃO toquei dado real; fixture/dry-run only).
+- [ ] **[W]** mergear (Tier 0 = soberania [W]).
+
+### new_design_memories
+- **anti-padrao**: default `vehicle_type='cacamba'` + docs "Caçambas" eram pré-ADR-0194 (domínio = mecânica pesada de caminhão basculante). Pior: `cacamba` nem era valor do enum — rodar o import etiquetava caminhão errado. Reconciliado no W28 (default `caminhao` + normalização contra a whitelist real).
+- **golden**: cutover/import irreversível-ish = **dry-run por padrão, grava só com `--commit`** ("interceptar a ação", não confiar na disciplina de lembrar `--dry-run`).

--- a/scripts/firebird/export-martinho-os.py
+++ b/scripts/firebird/export-martinho-os.py
@@ -1,0 +1,295 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+W28 G4 — Exporta Ordens de Serviço do Firebird (Martinho · WR Sistemas legacy)
+para JSON consumido por `php artisan oficina:import-firebird-martinho`.
+
+⚠️ Domínio (ADR 0194): Martinho = mecânica pesada de CAMINHÃO basculante, NÃO
+locação de caçamba. O default de vehicle_type no importer é 'caminhao'. Este
+script só normaliza/dumpa; a classificação canônica acontece no comando artisan.
+
+Wagner roda LOCAL (Windows) onde tem o Firebird instalado. Output sobe pro
+Hostinger via scp/git, e o importer consome com --dry-run (padrão) → --commit.
+
+USO:
+    # Instalar dep (1x)
+    pip install firebird-driver
+
+    # Descobrir os nomes REAIS das tabelas/colunas do FDB (ajustar o SCHEMA MAP abaixo)
+    python scripts/firebird/export-martinho-os.py \
+        --dsn "localhost/3050:C:/dados/MARTINHO.FDB" \
+        --user SYSDBA --password masterkey \
+        --dump-schema
+
+    # Exportar OS + itens
+    python scripts/firebird/export-martinho-os.py \
+        --dsn "localhost/3050:C:/dados/MARTINHO.FDB" \
+        --user SYSDBA --password masterkey \
+        --output storage/app/firebird/martinho-os-2026-06-03.json
+
+    # Limitar (debug / amostra)
+    python scripts/firebird/export-martinho-os.py --dsn "..." --output ... --limit 50
+
+VARIÁVEIS DE AMBIENTE (alternativa às flags):
+    FB_DSN=...    FB_USER=SYSDBA    FB_PASSWORD=...
+
+ESQUEMA OUTPUT (consumido por ImportFirebirdMartinhoCommand):
+{
+  "meta": {
+    "exported_at": "2026-06-03T18:00:00-03:00",
+    "source_dsn_masked": "localhost/3050:***",
+    "row_count": 91,
+    "script_version": "1.0.0"
+  },
+  "ordens": [
+    {
+      "ordem_id": 1234,            # CODIGO/ID da ORDEM_SERVICO (idempotência FB_LEGACY_ID)
+      "placa": "ABC1D23",          # placa do caminhão (96% têm placa no Firebird Martinho)
+      "veiculo_id": 55,            # CODIGO do veículo legacy (Vehicle.legacy_id)
+      "vehicle_type": "caminhao",  # opcional — importer normaliza p/ enum real
+      "order_type": "mecanica",    # opcional — default 'manutencao' no importer
+      "status": "concluida",       # status legacy livre — importer mapeia p/ FSM
+      "entered_at": "2024-03-15T08:00:00",
+      "completed_at": "2024-03-18T17:00:00",
+      "km": 184500,                # odômetro/hodômetro
+      "notes": "Troca cilindro hidráulico basculante",
+      "itens": [
+        {
+          "legacy_item_id": 9001,
+          "tipo": "peca",          # peca | mao_obra | servico_terceiro (importer normaliza)
+          "descricao": "Cilindro hidráulico 3 estágios",
+          "quantidade": 1,
+          "valor_unitario": 4200.00
+        }
+      ]
+    }
+  ]
+}
+
+Schema Firebird referência (genérico WR Sistemas):
+- memory/requisitos/Officeimpresso/OFFICEIMPRESSO-FIREBIRD-SCHEMA.md
+
+LGPD: DSN redacted no log. JSON tem dado operacional (placas) — armazenar com
+cuidado, NÃO commitar pro git (storage/app/firebird/ deve estar no .gitignore).
+"""
+
+import argparse
+import datetime
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# SCHEMA MAP — AJUSTAR AOS NOMES REAIS DO FDB DO MARTINHO.
+# Use `--dump-schema` pra listar tabelas/colunas e preencher abaixo.
+# Os nomes default são convenção WR Sistemas; cada cliente pode variar.
+# ---------------------------------------------------------------------------
+OS_TABLE = "ORDEM_SERVICO"
+OS_ITENS_TABLE = "ORDEM_ITENS"
+
+# Colunas da ORDEM_SERVICO  → chave do JSON de saída.
+OS_COLS = {
+    "ordem_id":     "CODIGO",
+    "placa":        "PLACA",
+    "veiculo_id":   "VEICULO_ID",
+    "vehicle_type": "TIPO_VEICULO",
+    "order_type":   "TIPO_OS",
+    "status":       "SITUACAO",
+    "entered_at":   "DATA_ENTRADA",
+    "completed_at": "DATA_SAIDA",
+    "km":           "KM",
+    "notes":        "OBSERVACAO",
+}
+
+# Colunas da ORDEM_ITENS → chave do JSON. FK pro ORDEM_SERVICO em OS_ITENS_FK.
+OS_ITENS_FK = "ORDEM_ID"
+OS_ITENS_COLS = {
+    "legacy_item_id": "CODIGO",
+    "tipo":           "TIPO",
+    "descricao":      "DESCRICAO",
+    "quantidade":     "QUANTIDADE",
+    "valor_unitario": "VALOR_UNITARIO",
+}
+
+
+def normalize_str(raw):
+    if raw is None:
+        return None
+    s = str(raw).strip()
+    return s if s else None
+
+
+def normalize_num(raw):
+    if raw is None:
+        return None
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def normalize_date(raw):
+    if raw is None:
+        return None
+    if isinstance(raw, (datetime.date, datetime.datetime)):
+        return raw.isoformat()
+    return str(raw)
+
+
+def mask_dsn(dsn):
+    return re.sub(r'(://)[^/]+', r'\1***', dsn) if dsn else 'unknown'
+
+
+def _connect(args):
+    try:
+        import firebird.driver as fdb
+    except ImportError:
+        print("ERRO: dependência 'firebird-driver' não instalada.", file=sys.stderr)
+        print("Rode: pip install firebird-driver", file=sys.stderr)
+        sys.exit(2)
+
+    dsn = args.dsn or os.environ.get('FB_DSN')
+    user = args.user or os.environ.get('FB_USER', 'SYSDBA')
+    password = args.password or os.environ.get('FB_PASSWORD', 'masterkey')
+    if not dsn:
+        print("ERRO: --dsn ou FB_DSN obrigatório.", file=sys.stderr)
+        sys.exit(2)
+
+    print(f"[fb-export] DSN: {mask_dsn(dsn)}")
+    return fdb.connect(dsn, user=user, password=password)
+
+
+def dump_schema(args):
+    """Lista tabelas + colunas pra ajudar a preencher o SCHEMA MAP."""
+    with _connect(args) as con:
+        cur = con.cursor()
+        cur.execute("""
+            SELECT TRIM(RDB$RELATION_NAME)
+            FROM RDB$RELATIONS
+            WHERE RDB$SYSTEM_FLAG = 0 AND RDB$VIEW_BLR IS NULL
+            ORDER BY RDB$RELATION_NAME
+        """)
+        tabelas = [r[0] for r in cur]
+        alvo = {OS_TABLE.upper(), OS_ITENS_TABLE.upper()}
+        for t in tabelas:
+            destaque = '  <<< OS' if t.upper() in alvo else ''
+            print(f"TABLE {t}{destaque}")
+            if t.upper() in alvo or args.all_columns:
+                cur.execute("""
+                    SELECT TRIM(RDB$FIELD_NAME)
+                    FROM RDB$RELATION_FIELDS
+                    WHERE RDB$RELATION_NAME = ?
+                    ORDER BY RDB$FIELD_POSITION
+                """, (t,))
+                for (col,) in cur:
+                    print(f"    - {col}")
+    return 0
+
+
+def _select(cur, table, cols_map, where='', params=()):
+    """SELECT só das colunas mapeadas; tolera coluna ausente caindo pra NULL."""
+    select_cols = ', '.join(cols_map.values())
+    sql = f"SELECT {select_cols} FROM {table} {where}"
+    cur.execute(sql, params)
+    keys = list(cols_map.keys())
+    out = []
+    for row in cur:
+        out.append({keys[i]: row[i] for i in range(len(keys))})
+    return out
+
+
+def export_os(args):
+    with _connect(args) as con:
+        cur = con.cursor()
+
+        first = f"FIRST {int(args.limit)}" if args.limit else ""
+        os_where = f"ORDER BY {OS_COLS['ordem_id']}"
+        if first:
+            # Firebird: FIRST vai logo após SELECT — refaz a query manualmente.
+            select_cols = ', '.join(OS_COLS.values())
+            cur.execute(f"SELECT {first} {select_cols} FROM {OS_TABLE} {os_where}")
+            keys = list(OS_COLS.keys())
+            os_rows = [{keys[i]: r[i] for i in range(len(keys))} for r in cur]
+        else:
+            os_rows = _select(cur, OS_TABLE, OS_COLS, os_where)
+
+        # Itens indexados por FK pra evitar N+1.
+        itens_por_os = {}
+        for it in _select(cur, OS_ITENS_TABLE, {**{'_fk': OS_ITENS_FK}, **OS_ITENS_COLS}):
+            fk = it.pop('_fk')
+            itens_por_os.setdefault(int(fk) if fk is not None else fk, []).append(it)
+
+    ordens = []
+    for r in os_rows:
+        oid = r.get('ordem_id')
+        oid_int = int(oid) if oid is not None else None
+        itens = []
+        for it in itens_por_os.get(oid_int, []):
+            itens.append({
+                'legacy_item_id': it.get('legacy_item_id'),
+                'tipo': normalize_str(it.get('tipo')),
+                'descricao': normalize_str(it.get('descricao')) or 'Sem descrição',
+                'quantidade': normalize_num(it.get('quantidade')) or 1,
+                'valor_unitario': normalize_num(it.get('valor_unitario')) or 0,
+            })
+        ordens.append({
+            'ordem_id': oid_int,
+            'placa': normalize_str(r.get('placa')),
+            'veiculo_id': r.get('veiculo_id'),
+            'vehicle_type': normalize_str(r.get('vehicle_type')),
+            'order_type': normalize_str(r.get('order_type')),
+            'status': normalize_str(r.get('status')),
+            'entered_at': normalize_date(r.get('entered_at')),
+            'completed_at': normalize_date(r.get('completed_at')),
+            'km': normalize_num(r.get('km')),
+            'notes': normalize_str(r.get('notes')),
+            'itens': itens,
+        })
+
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        'meta': {
+            'exported_at': datetime.datetime.now().astimezone().isoformat(),
+            'source_dsn_masked': mask_dsn(args.dsn or os.environ.get('FB_DSN')),
+            'row_count': len(ordens),
+            'script_version': '1.0.0',
+        },
+        'ordens': ordens,
+    }
+    with open(output_path, 'w', encoding='utf-8') as f:
+        json.dump(payload, f, ensure_ascii=False, indent=2)
+
+    print(f"[fb-export] OK · {len(ordens)} OS exportadas → {output_path}")
+    return 0
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description='Exporta Ordens de Serviço do Firebird Martinho pra JSON (W28 G4).',
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument('--dsn', help='Firebird DSN (ex: localhost/3050:C:/dados/MARTINHO.FDB)')
+    parser.add_argument('--user', default=None, help='Firebird user (default: env FB_USER ou SYSDBA)')
+    parser.add_argument('--password', default=None, help='Firebird password (default: env FB_PASSWORD)')
+    parser.add_argument('--output', default=None, help='Arquivo JSON de saída')
+    parser.add_argument('--limit', type=int, default=0, help='Máx. OS exportadas (0=todas)')
+    parser.add_argument('--dump-schema', action='store_true', help='Lista tabelas/colunas e sai (ajustar SCHEMA MAP)')
+    parser.add_argument('--all-columns', action='store_true', help='Com --dump-schema: lista colunas de TODAS as tabelas')
+    args = parser.parse_args()
+
+    if args.dump_schema:
+        return dump_schema(args)
+
+    if not args.output:
+        print("ERRO: --output obrigatório (ou use --dump-schema).", file=sys.stderr)
+        sys.exit(2)
+
+    return export_os(args)
+
+
+if __name__ == '__main__':
+    sys.exit(main())


### PR DESCRIPTION
## §10.4 PROPOSTA — [CL] validou vs `origin/main` fresco (74bc2ea77, worktree off origin/main) e agiu autônomo no que é mergeable. **NÃO mergear — Tier 0 = [W].**

### O que faz (Tarefa A do prompt `W28-FIREBIRD-DOMINIO-MARTINHO`)
Tira o `ImportFirebirdMartinhoCommand` do estado esqueleto (W27) e fecha o mapping fino + reconcilia o drift de domínio que peguei lendo o `main`.

- **vehicle_type default `cacamba` → `caminhao`** (ADR 0194). O `cacamba` hardcodado **nem era valor válido** do enum `vehicles.vehicle_type` — rodar como estava etiquetava os caminhões da Martinho como caçamba. `normalizeVehicleType()` mapeia sinônimos de basculante contra a whitelist real (`caminhao, cavalo, semi_reboque, cacamba_estacionaria, cacamba_avulsa, cacamba_caminhao, recapagem, automovel, motocicleta, outros, outro`) **sem inventar** valor fora do enum.
- **status legacy→FSM** (`normalizeStatus`, accent-fold PT): ABERTA/orçamento→`aberta`, andamento/execução→`em_servico`, finalizada/concluída→`concluida`, cancel*→`cancelada`; histórico vazio→`concluida`.
- **order_type** {locacao|manutencao|mecanica} (default `manutencao` = legado, migration `2026_06_02_000001`); **item tipo** → peca|mao_obra|servico_terceiro. Idempotência `FB_LEGACY_ID` preservada.
- **Dry-run virou o PADRÃO**: grava só com `--commit` (`--dry-run` vence por segurança).
- **`scripts/firebird/export-martinho-os.py`** (Windows + firebird-driver, com `--dump-schema` pra mapear os nomes reais do FDB).
- **Docs curados (append · L-22)**: CHANGELOG W28 + lápide ADR 0194; README journey passo 2 `cacamba_basculante`→`caminhao`.

### Tests
- `ImportFirebirdMartinhoW28Test` — **7 passed (41 assertions)**, reflection-only (pattern Wave 25/27 do módulo, zero-DB).
- `php -l` ok · `python -m ast` ok.
- ⚠️ Caminho DB-real (`oficina:migration-report`/`oficina:sanity-check`) roda em CI/MySQL — dev DB local não tem as tabelas OficinaAuto e o suite de migration completo não re-roda do zero localmente (issues pré-existentes, não deste diff).

### Guards respeitados
NÃO flipa fiscal · NÃO numera ADR (0238) · NÃO roda import real (fixture/dry-run) · **NÃO mergeia (Tier 0 = [W])**.

### Fica de [W] (checklist em `prototipo-ui/CODE_NOTES.md`)
- [ ] Decidir se OS históricas entram como `order_type='mecanica'` (domínio real) vs `manutencao` (default conservador).
- [ ] Rodar `oficina:migration-report`/`sanity-check` no fixture/staging pós-import.
- [ ] Ajustar SCHEMA MAP do `.py` aos nomes reais do FDB (`--dump-schema`).
- [ ] Drift residual: README/E2E `cacamba_basculante` + docblock `caminhao_basculante` (ambos não-whitelisted) — [W] decide enum dedicado vs consolidar em `caminhao`.
- [ ] Mergear.

Tarefa B (preflight cutover observável) **pulada** por escopo (1 PR = 1 intent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)