### PR TITLE
feat(governance): governanca:scorecard — placar [CC]×Jana mecanizado (graduação de lições)

### DIFF
--- a/Modules/Governance/Console/Commands/GovernancaScorecardCommand.php
+++ b/Modules/Governance/Console/Commands/GovernancaScorecardCommand.php
@@ -1,0 +1,188 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Governance\Console\Commands;
+
+use Illuminate\Console\Command;
+use Modules\Jana\Console\Commands\HealthCheckCommand;
+use ReflectionClass;
+use ReflectionMethod;
+use Throwable;
+
+/**
+ * `governanca:scorecard` (camada 3) — mecaniza o placar de governança [CC]×Jana.
+ *
+ * Por quê: o placar (8.2/8.7) era DIGITADO À MÃO — o anti-padrão que o próprio
+ * report critica (prosa que envelhece). A meta 9.7 tem métrica contável: a razão
+ * de graduação de lições nos dois ledgers. Este comando AGREGA o que já existe
+ * (reusa `HealthCheckCommand::parseLessonLedger` + `::ledgerGraduationStats`) e
+ * escreve um JSON que o `metricas.html` do Cowork passa a LER no re-sync — frescor
+ * por mecanismo, não por memória humana (o ProfileDistiller da governança).
+ *
+ * NÃO recria motor de score (já há 6 — score-mechanized.mjs, module:grade,
+ * screen-grade, ESLint ds/*, etc.). AGREGA (anti G1 do AUDITORIA_ROTINAS_DESIGN).
+ *
+ * Honestidade de escopo: mecaniza só o contável (graduação + contagem de checks +
+ * presença de baselines). Eixos subjetivos ficam marcados `source: "estimativa [CC]"`
+ * — não finge objetividade onde não há.
+ *
+ * Advisory: não numera ADR (soberania [W], ADR 0238) — proposta slug-only até [W].
+ *
+ * @see Modules/Jana/Console/Commands/HealthCheckCommand.php  (parser + check espelho)
+ * @see Modules/Jana/LICOES-OPERACAO.md · memory/LICOES_CC.md  (os dois ledgers)
+ */
+class GovernancaScorecardCommand extends Command
+{
+    protected $signature = 'governanca:scorecard
+                            {--json : escreve storage/reports/governanca-scorecard.json}
+                            {--pipe-unico : marca o pipe único [CC]+Jana como presente (flag manual — condição 9.7)}';
+
+    protected $description = 'Agrega o placar de governança [CC]×Jana (graduação de lições mecanizada) e opcionalmente escreve JSON.';
+
+    private const OUTPUT_PATH = 'reports/governanca-scorecard.json';
+
+    /** Eixos subjetivos do report [CC] — NÃO mecanizados (honestidade de escopo). */
+    private const EIXOS_SUBJETIVOS = [
+        ['nome' => 'Tiering de risco',         'valor' => 8.5, 'source' => 'estimativa [CC]'],
+        ['nome' => 'Clareza de papéis [CC]×[W]', 'valor' => 8.7, 'source' => 'estimativa [CC]'],
+        ['nome' => 'Frescor de memória',       'valor' => 8.2, 'source' => 'estimativa [CC]'],
+    ];
+
+    public function handle(): int
+    {
+        $scorecard = $this->buildScorecard();
+
+        $this->renderTable($scorecard);
+
+        if ($this->option('json')) {
+            $dir = storage_path('reports');
+            if (! is_dir($dir)) {
+                mkdir($dir, 0775, true);
+            }
+            $path = storage_path(self::OUTPUT_PATH);
+            file_put_contents(
+                $path,
+                json_encode($scorecard, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n"
+            );
+            $this->info("JSON escrito: {$path}");
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function buildScorecard(): array
+    {
+        $ledgers = [];
+        $ratios = [];
+        foreach (HealthCheckCommand::GOVERNANCA_LEDGERS as $key => $cfg) {
+            $stats = HealthCheckCommand::ledgerGraduationStats(base_path($cfg['path']), $cfg['header']);
+            if ($stats === null) {
+                $ledgers[$key] = ['path' => $cfg['path'], 'presente' => false];
+                continue;
+            }
+            $ledgers[$key] = [
+                'path'             => $cfg['path'],
+                'presente'         => true,
+                'total'            => $stats['total'],
+                'graduadas'        => $stats['graduadas'],
+                'pendentes'        => $stats['pendentes'],
+                'pendentes_ids'    => $stats['pendentes_ids'],
+                'graduation_ratio' => $stats['graduation_ratio'],
+            ];
+            $ratios[] = $stats['graduation_ratio'];
+        }
+
+        $ratioMedio = $ratios !== [] ? round(array_sum($ratios) / count($ratios), 4) : 1.0;
+        // enforcement_score (0-10) DERIVADO da razão de graduação — a fraqueza do
+        // lado [CC] (seção 02 do report) se reflete aqui sem número digitado à mão.
+        $enforcementScore = round($ratioMedio * 10, 2);
+
+        $ambos100 = $ratios !== [] && count(array_filter($ratios, fn ($r) => $r >= 1.0)) === count($ratios);
+        $pipeUnico = (bool) $this->option('pipe-unico');
+
+        return [
+            'meta' => [
+                'generator'            => 'governanca:scorecard',
+                'version'              => '1.0.0',
+                'generated_at'         => now()->toIso8601String(),
+                'measured_against_sha' => $this->currentSha(),
+                'note'                 => 'Mecaniza só o contável (graduação de lições + contagem de checks + baselines). Eixos subjetivos = estimativa [CC] (source marcado).',
+            ],
+            'ledgers' => $ledgers,
+            'mecanizado' => [
+                'enforcement_score'      => $enforcementScore,
+                'graduation_ratio_medio' => $ratioMedio,
+                'health_checks_count'    => $this->healthChecksCount(),
+                'baselines_presentes'    => [
+                    'module_grades' => file_exists(base_path('governance/module-grades-baseline.json')),
+                    'screen_grades' => file_exists(base_path('memory/governance/scorecards/screen-grades-baseline-2026-05-30.json')),
+                ],
+            ],
+            'eixos_subjetivos' => self::EIXOS_SUBJETIVOS,
+            'condicao_9_7' => [
+                'ambos_ledgers_100'  => $ambos100,
+                'pipe_unico_cc_jana' => $pipeUnico,
+                'atingido'           => $ambos100 && $pipeUnico,
+            ],
+        ];
+    }
+
+    /**
+     * Conta os métodos de check do jana:health-check via reflection (mecanizável,
+     * sem bootar os checks SQL). Proxy honesto de "quantos checks a governança roda".
+     */
+    private function healthChecksCount(): int
+    {
+        try {
+            $rc = new ReflectionClass(HealthCheckCommand::class);
+            $count = 0;
+            foreach ($rc->getMethods(ReflectionMethod::IS_PROTECTED) as $m) {
+                if (preg_match('/^check[A-Z]/', $m->getName())) {
+                    $count++;
+                }
+            }
+            return $count;
+        } catch (Throwable) {
+            return 0;
+        }
+    }
+
+    private function currentSha(): ?string
+    {
+        try {
+            $out = @shell_exec('git rev-parse --short HEAD 2>&1');
+            $sha = is_string($out) ? trim($out) : '';
+            return preg_match('/^[0-9a-f]{7,40}$/', $sha) === 1 ? $sha : null;
+        } catch (Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $sc
+     */
+    private function renderTable(array $sc): void
+    {
+        $this->newLine();
+        $this->info('GOVERNANÇA — Scorecard [CC]×Jana (camada 3 · mecanizado)');
+        $rows = [];
+        foreach ($sc['ledgers'] as $key => $l) {
+            $rows[] = ($l['presente'] ?? false)
+                ? [$key, "{$l['graduadas']}/{$l['total']}", number_format((float) $l['graduation_ratio'] * 100, 0) . '%', $l['pendentes'] . ' pendente(s)']
+                : [$key, '—', '—', 'ausente'];
+        }
+        $this->table(['Ledger', 'Graduadas', 'Ratio', 'Status'], $rows);
+
+        $m = $sc['mecanizado'];
+        $this->line("enforcement_score: {$m['enforcement_score']}/10  ·  ratio médio: {$m['graduation_ratio_medio']}  ·  health checks: {$m['health_checks_count']}");
+        $c = $sc['condicao_9_7'];
+        $this->line('condição 9.7 → ambos 100%: ' . ($c['ambos_ledgers_100'] ? 'sim' : 'não')
+            . '  ·  pipe único: ' . ($c['pipe_unico_cc_jana'] ? 'sim' : 'não')
+            . '  ·  atingido: ' . ($c['atingido'] ? 'SIM' : 'não'));
+        $this->newLine();
+    }
+}

--- a/Modules/Governance/Providers/GovernanceServiceProvider.php
+++ b/Modules/Governance/Providers/GovernanceServiceProvider.php
@@ -65,6 +65,7 @@ class GovernanceServiceProvider extends ServiceProvider
                 \Modules\Governance\Console\Commands\ObservabilityAggregateCommand::class,  // Wave 26 Agent 3 — ADR 0162
                 \Modules\Governance\Console\Commands\ScorecardInitiativeSyncCommand::class, // Wave 28 Agent 1 — Initiatives Cortex-style
                 \Modules\Governance\Console\Commands\GovernanceAuditCommand::class,        // ADR 0216 — DriftChecker orchestrator
+                \Modules\Governance\Console\Commands\GovernancaScorecardCommand::class,    // W28 — placar [CC]×Jana mecanizado (graduação de lições)
             ]);
         }
     }

--- a/Modules/Governance/Tests/Feature/GovernancaScorecardCommandTest.php
+++ b/Modules/Governance/Tests/Feature/GovernancaScorecardCommandTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use Modules\Jana\Console\Commands\HealthCheckCommand;
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+/**
+ * W28 — `governanca:scorecard` (camada 3) + generalização do parseLessonLedger.
+ *
+ * Cobre: parser rodando no header do ledger [CC] (## L-NN), cálculo de
+ * graduation_ratio nos dois formatos, e o comando que escreve o JSON agregado.
+ *
+ * @see Modules/Governance/Console/Commands/GovernancaScorecardCommand.php
+ * @see Modules/Jana/Console/Commands/HealthCheckCommand.php
+ */
+
+it('parseLessonLedger generaliza pro header do ledger [CC] (## L-NN)', function () {
+    $content = implode("\n", [
+        '# LIÇÕES [CC]',
+        '## L-01 — graduada',
+        '- **Graduação:** MEC · check:`foo` · status:done',
+        '## L-02 — sem graduação (design comum)',
+        'texto qualquer, sem linha de graduação',
+        '## L-03 — pendente',
+        '- **Graduação:** JULG · regra:`bar` · status:pendente',
+    ]);
+
+    $r = HealthCheckCommand::parseLessonLedger($content, '/^##\s+(L-\d+)\b/m');
+
+    expect($r['total'])->toBe(3);
+    expect($r['malformed'])->toContain('L-02');  // sem graduação → não-graduada
+    expect($r['overdue'])->toContain('L-03');    // status:pendente
+});
+
+it('default do parseLessonLedger continua sendo o ledger de operação (### L-OP-NNN)', function () {
+    $content = implode("\n", [
+        '### L-OP-001 · x',
+        '- **Graduação:** MEC · check:`abc` · status:done',
+        '## L-99 — não deve ser pego pelo header default',
+    ]);
+
+    $r = HealthCheckCommand::parseLessonLedger($content); // sem 2º arg = backward-compat
+
+    expect($r['total'])->toBe(1);
+    expect($r['malformed'])->toBe([]);
+    expect($r['overdue'])->toBe([]);
+});
+
+it('ledgerGraduationStats calcula graduadas/pendentes/ratio', function () {
+    $path = tempnam(sys_get_temp_dir(), 'ledger-') . '.md';
+    file_put_contents($path, implode("\n", [
+        '## L-01 — a', '- **Graduação:** MEC · check:`x` · status:done',
+        '## L-02 — b', '(sem graduação)',
+        '## L-03 — c', '- **Graduação:** JULG · regra:`y` · status:done',
+        '## L-04 — d', '- **Graduação:** MEC · check:`z` · status:pendente',
+    ]));
+
+    $s = HealthCheckCommand::ledgerGraduationStats($path, '/^##\s+(L-\d+)\b/m');
+
+    expect($s)->not->toBeNull();
+    expect($s['total'])->toBe(4);
+    expect($s['graduadas'])->toBe(2);            // L-01 + L-03
+    expect($s['pendentes'])->toBe(2);            // L-02 (sem grad) + L-04 (pendente)
+    expect($s['graduation_ratio'])->toBe(0.5);
+
+    unlink($path);
+});
+
+it('ledgerGraduationStats retorna null se o arquivo não existe', function () {
+    expect(HealthCheckCommand::ledgerGraduationStats('/no/such/ledger.md', '/^##\s+(L-\d+)\b/m'))->toBeNull();
+});
+
+it('ledger vazio = ratio 1.0 (vacuosamente fechado)', function () {
+    $path = tempnam(sys_get_temp_dir(), 'ledger-empty-') . '.md';
+    file_put_contents($path, "# sem lições\n");
+    $s = HealthCheckCommand::ledgerGraduationStats($path, '/^##\s+(L-\d+)\b/m');
+    expect($s['total'])->toBe(0);
+    expect($s['graduation_ratio'])->toBe(1.0);
+    unlink($path);
+});
+
+it('governanca:scorecard --json escreve o JSON agregado', function () {
+    $path = storage_path('reports/governanca-scorecard.json');
+    if (file_exists($path)) {
+        unlink($path);
+    }
+
+    $this->artisan('governanca:scorecard', ['--json' => true])->assertExitCode(0);
+
+    expect(file_exists($path))->toBeTrue();
+
+    $json = json_decode((string) file_get_contents($path), true);
+    expect($json)->toBeArray();
+    expect($json['meta']['generator'])->toBe('governanca:scorecard');
+    expect($json['ledgers'])->toHaveKeys(['operacao', 'cc']);
+    expect($json['mecanizado']['enforcement_score'])
+        ->toBeGreaterThanOrEqual(0)->toBeLessThanOrEqual(10);
+    expect($json['mecanizado']['health_checks_count'])->toBeGreaterThan(0);
+    expect($json['condicao_9_7'])->toHaveKeys(['ambos_ledgers_100', 'pipe_unico_cc_jana', 'atingido']);
+    // honestidade de escopo: eixos subjetivos marcados como estimativa
+    expect($json['eixos_subjetivos'][0]['source'])->toBe('estimativa [CC]');
+});
+
+it('condicao_9_7.atingido só é true com ambos 100% E pipe único', function () {
+    // sem --pipe-unico, atingido é necessariamente false (mesmo se ambos 100%)
+    $this->artisan('governanca:scorecard', ['--json' => true])->assertExitCode(0);
+    $json = json_decode((string) file_get_contents(storage_path('reports/governanca-scorecard.json')), true);
+    if (! $json['condicao_9_7']['pipe_unico_cc_jana']) {
+        expect($json['condicao_9_7']['atingido'])->toBeFalse();
+    }
+});

--- a/Modules/Jana/Console/Commands/HealthCheckCommand.php
+++ b/Modules/Jana/Console/Commands/HealthCheckCommand.php
@@ -67,6 +67,7 @@ class HealthCheckCommand extends Command
             $this->checkMcpWebhookHealth2h(),
             $this->checkMemoriaRecallBackend(),
             $this->checkLessonLedgerGraduation(),
+            $this->checkGovernancaGraduationRatio(),
             // Charter health (advisory — não falha exit/cron). PROTOCOL §6.
             ...CharterHealthChecker::fromApp()->checks(),
         ];
@@ -703,6 +704,105 @@ class HealthCheckCommand extends Command
     }
 
     /**
+     * Os DOIS ledgers de lições que a governança mecaniza (camada [CC]×Jana).
+     * `path` relativo ao base_path; `header` = regex de header (grupo 1 = ID).
+     *
+     * @var array<string, array{path:string, header:string}>
+     */
+    public const GOVERNANCA_LEDGERS = [
+        'operacao' => ['path' => 'Modules/Jana/LICOES-OPERACAO.md', 'header' => '/^###\s+(L-OP-\d+)\b/m'],
+        'cc'       => ['path' => 'memory/LICOES_CC.md',             'header' => '/^##\s+(L-\d+)\b/m'],
+    ];
+
+    /**
+     * Estatística de graduação de UM ledger (reusa parseLessonLedger).
+     *
+     * `graduadas` = lições com Graduação válida + status:done · `pendentes` = resto
+     * (status:pendente, malformada OU sem linha de Graduação). `graduation_ratio` =
+     * graduadas / total (ledger vazio = 1.0, vacuosamente "fechado").
+     *
+     * @return array{total:int, graduadas:int, pendentes:int, pendentes_ids:list<string>, graduation_ratio:float}|null  null se o arquivo não existe
+     */
+    public static function ledgerGraduationStats(string $absPath, string $headerPattern): ?array
+    {
+        if (! is_file($absPath)) {
+            return null;
+        }
+
+        $r = self::parseLessonLedger((string) file_get_contents($absPath), $headerPattern);
+        $pendentesIds = array_values(array_unique(array_merge($r['overdue'], $r['malformed'])));
+        $graduadas = max(0, $r['total'] - count($pendentesIds));
+        $ratio = $r['total'] > 0 ? round($graduadas / $r['total'], 4) : 1.0;
+
+        return [
+            'total'            => $r['total'],
+            'graduadas'        => $graduadas,
+            'pendentes'        => count($pendentesIds),
+            'pendentes_ids'    => $pendentesIds,
+            'graduation_ratio' => $ratio,
+        ];
+    }
+
+    /**
+     * Check governanca_graduation_ratio (ADVISORY · camada 3 do placar [CC]×Jana).
+     *
+     * Espelha `jana_lesson_ledger_graduation` mas pros DOIS ledgers (operação + [CC]).
+     * Acende amarelo se algum ledger tem `graduation_ratio < 1.0` ou lição pendente —
+     * é a métrica contável da meta 9.7 (placar que regenera sozinho, não prosa digitada).
+     * Advisory de propósito: drift de governança não derruba cron nem exit code.
+     *
+     * @see governanca:scorecard (Modules/Governance — agrega isto num JSON pro report [CC])
+     */
+    protected function checkGovernancaGraduationRatio(): array
+    {
+        $name = 'governanca_graduation_ratio';
+
+        $partes = [];
+        $algumProblema = false;
+        $algumPresente = false;
+
+        foreach (self::GOVERNANCA_LEDGERS as $key => $cfg) {
+            $stats = self::ledgerGraduationStats(base_path($cfg['path']), $cfg['header']);
+            if ($stats === null) {
+                continue;
+            }
+            $algumPresente = true;
+            $partes[] = sprintf(
+                '%s %d/%d (%d%%)',
+                $key,
+                $stats['graduadas'],
+                $stats['total'],
+                (int) round($stats['graduation_ratio'] * 100)
+            );
+            if ($stats['graduation_ratio'] < 1.0 || $stats['pendentes'] > 0) {
+                $algumProblema = true;
+            }
+        }
+
+        if (! $algumPresente) {
+            return [
+                'name' => $name,
+                'ok' => true,
+                'advisory' => true,
+                'value' => 'n/a',
+                'threshold' => '100%',
+                'message' => 'Skipped (nenhum ledger de lições presente — pré-merge/dev)',
+            ];
+        }
+
+        return [
+            'name' => $name,
+            'ok' => ! $algumProblema,
+            'advisory' => true,
+            'value' => implode(' · ', $partes),
+            'threshold' => '100%',
+            'message' => $algumProblema
+                ? 'Graduação incompleta (meta 9.7 = ambos 100%): ' . implode(' · ', $partes)
+                : 'Ambos ledgers 100% graduados — ' . implode(' · ', $partes),
+        ];
+    }
+
+    /**
      * Parser determinístico do ledger de lições de operação.
      *
      * Contrato (ver Modules/Jana/LICOES-OPERACAO.md → "Formato canônico"):
@@ -717,15 +817,20 @@ class HealthCheckCommand extends Command
      *
      * Público + estático pra ser testável sem tocar o filesystem real.
      *
+     * Generalizado (W28 governanca:scorecard) pra rodar nos DOIS ledgers via
+     * `$headerPattern`: default = ledger de operação (`### L-OP-NNN`). O ledger [CC]
+     * (`memory/LICOES_CC.md`) usa `## L-NN` — passa o pattern correspondente. O grupo
+     * de captura 1 do regex tem que ser o ID da lição.
+     *
      * @return array{total:int, overdue:list<string>, malformed:list<string>}
      */
-    public static function parseLessonLedger(string $content): array
+    public static function parseLessonLedger(string $content, string $headerPattern = '/^###\s+(L-OP-\d+)\b/m'): array
     {
         $overdue = [];
         $malformed = [];
 
-        // Quebra em blocos por header de lição (### L-OP-NNN ...).
-        $blocos = preg_split('/^###\s+(L-OP-\d+)\b/m', $content, -1, PREG_SPLIT_DELIM_CAPTURE);
+        // Quebra em blocos por header de lição (### L-OP-NNN | ## L-NN ...).
+        $blocos = preg_split($headerPattern, $content, -1, PREG_SPLIT_DELIM_CAPTURE);
         // $blocos = [prefixo, id1, corpo1, id2, corpo2, ...]
         $total = 0;
         for ($i = 1; $i < count($blocos); $i += 2) {

--- a/prototipo-ui/CODE_NOTES.md
+++ b/prototipo-ui/CODE_NOTES.md
@@ -575,3 +575,56 @@ O furo (exatamente o que o "não assumir" pega): o NFS-e resolvia ambiente pelo 
 ### new_design_memories
 - **anti-padrao**: default `vehicle_type='cacamba'` + docs "Caçambas" eram pré-ADR-0194 (domínio = mecânica pesada de caminhão basculante). Pior: `cacamba` nem era valor do enum — rodar o import etiquetava caminhão errado. Reconciliado no W28 (default `caminhao` + normalização contra a whitelist real).
 - **golden**: cutover/import irreversível-ish = **dry-run por padrão, grava só com `--commit`** ("interceptar a ação", não confiar na disciplina de lembrar `--dry-run`).
+
+---
+
+## 2026-06-03 [CC] → [W] — Charter Governança [CC]×Jana commitado verbatim (proposta §10.4)
+
+[CL] commitou **verbatim** o charter `prototipo-ui/CHARTER_GOVERNANCA_CC_JANA.md` (export Cowork, irmão de `CHARTER_GOVERNANCA_W.md` + `CHARTER_CHAMPION_AGENTES.md`). Espelha pro git a **conclusão** do report `rep-cc-vs-jana` (`metricas.html`) — pro raciocínio rumo a 9.7 ficar durável e re-derivável do `main`.
+
+- **Frescor validado vs origin/main fresco:** branch `docs/charter-governanca-cc-jana` cortado de `origin/main` @ `74bc2ea` (mesmo SHA que o charter cita no header). Worktree limpo, sem WIP do `feat/staging-ct100` contaminando o PR (1 arquivo, 1 intent — commit-discipline).
+- **NÃO numerei ADR** (instrução [W] + o próprio charter: "[W] numera/ratifica se promover a ADR — soberania 0238").
+- **PR aberto, NÃO mergeado** — merge é Tier 0 = [W] (publication-policy).
+
+### new_design_memories
+- **golden**: export de governança da Cowork (conclusão/raciocínio, não só o número do scorecard) vai pro git **verbatim** como charter irmão, cortado de `origin/main` fresco — durabilidade + re-derivação por sessão futura ([CL]/[CC]).
+- **anti-padrao**: commitar doc de governança numa branch poluída (WIP de outro intent) — fura commit-discipline (1 PR = 1 intent). Worktree novo de `origin/main` isola o arquivo.
+
+---
+
+## 2026-06-03 [CL] → [W] — `governanca:scorecard` (camada 3) · placar [CC]×Jana mecanizado
+
+### Tarefa: §10.4 PROPOSTA (prompt `GOVERNANCA-SCORECARD`)
+### Status: traduzido · branch `feat/governanca-scorecard` · PR aberto · **NÃO mergeado (Tier 0 = [W])**
+### Validação vs `origin/main` (74bc2ea77 · worktree off origin/main):
+- `HealthCheckCommand::parseLessonLedger()` + check `jana_lesson_ledger_graduation` confirmados @main — **reusei o parser** (não escrevi outro).
+- Os dois ledgers existem: `Modules/Jana/LICOES-OPERACAO.md` + `memory/LICOES_CC.md` (#2106).
+- `governanca:scorecard` **não existia** (os arquivos `*scorecard*` no repo são o motor Governance scoped — engine diferente; **não recriei** 7º motor, agreguei · anti-G1).
+
+### Decisões de tradução:
+- **`parseLessonLedger($content, $headerPattern)`** — generalizado com 2º arg = regex de header (default `### L-OP-NNN` → backward-compat; ledger [CC] usa `## L-NN`). Grupo 1 = ID.
+- **`HealthCheckCommand::ledgerGraduationStats($abs, $header)`** (helper público estático) — `graduadas` (Graduação válida + status:done) / `pendentes` (resto: pendente, malformada OU sem linha de graduação) / `graduation_ratio` (vazio = 1.0).
+- **Check `governanca_graduation_ratio`** (ADVISORY) adicionado ao `jana:health-check` — espelha `jana_lesson_ledger_graduation` pros DOIS ledgers; amarelo se algum ratio < 1.0. **Não derruba cron/exit** (drift de processo não pagina à noite).
+- **`php artisan governanca:scorecard {--json}`** (Modules/Governance, registrado no provider) escreve `storage/reports/governanca-scorecard.json`: por-ledger total/graduadas/pendentes/ratio + `enforcement_score` (derivado da razão, não digitado) + `health_checks_count` (reflection) + baselines + `measured_against_sha` + timestamp + `condicao_9_7`.
+- **Honestidade de escopo**: eixos subjetivos (Tiering de risco etc.) marcados `source: "estimativa [CC]"` no JSON — não finjo objetividade onde não há.
+
+### Build / Tests:
+- `GovernancaScorecardCommandTest` — **7 passed (31 assertions)** (parser nos 2 headers + ratio + comando escreve JSON + condição 9.7).
+- `JanaHealthCheckTest` (existente) — **8 passed (114 assertions)**, sem regressão (parser default intacto, +1 check, `>=10` mantido).
+
+### 📊 Números REAIS do `main` hoje (74bc2ea77):
+- **`operacao` (LICOES-OPERACAO.md): graduation_ratio = 1.0** (3/3 graduadas, 0 pendentes).
+- **`cc` (LICOES_CC.md): graduation_ratio = 0.0** (0/25 graduadas — L-01…L-25, nenhuma tem linha `Graduação: …status:done` canônica; L-23 usa `**MEC**` sem binding `check:`/`status:done` → conta pendente).
+- `enforcement_score` derivado = **5.0/10** (ratio médio 0.5) · `health_checks_count` = 12 · `condicao_9_7.atingido` = **false** (cc não está 100% + pipe único não setado).
+- JSON de exemplo em `storage/reports/governanca-scorecard.json` (gitignored — artefato runtime, não commitado).
+
+### Pendências / fica de [W]:
+- [ ] **[W]** o número que move o 9.7 está claro: graduar as 25 lições do `LICOES_CC.md` (formato `- **Graduação:** MEC|JULG · check:\`x\`|regra:\`y\` · status:done`). Hoje 0/25.
+- [ ] **[W]** flag `--pipe-unico` é manual por enquanto (pipe único [CC]+Jana). Quando o pipe existir de fato, virar detecção automática.
+- [ ] **[W]** promover ADR (slug-only até lá · soberania [W], 0238) se quiser canonizar o scorecard como mecanismo.
+- [ ] **[W]** (opcional) `metricas.html` do Cowork passar a LER `storage/reports/governanca-scorecard.json` no re-sync (fecha o loop de frescor sem digitar).
+- [ ] **[W]** mergear (Tier 0 = soberania [W]).
+
+### new_design_memories
+- **golden**: placar de governança [CC]×Jana deixa de ser prosa digitada e vira saída de check (`governanca_graduation_ratio`) + comando que escreve JSON que o report LÊ — frescor por mecanismo (o ProfileDistiller da governança).
+- **regra**: métrica do 9.7 = lições graduadas em check rodável ÷ total, nos dois ledgers; 9.7 exige ambos 100% + pipe único. Hoje: operação 1.0, CC 0.0.


### PR DESCRIPTION
## §10.4 PROPOSTA — [CL] validou vs `origin/main` fresco (74bc2ea77, worktree off origin/main) e estendeu o que já existe. Advisory. **NÃO mergear — Tier 0 = [W].**

### Por quê
O placar de governança (8.2/8.7) era **digitado à mão** — o anti-padrão que o próprio report critica. A meta 9.7 tem métrica contável: a razão de graduação de lições. Este PR mecaniza isso **agregando** o que já existe (NÃO recria 7º motor de score · anti-G1).

### O que faz
- **`parseLessonLedger($content, $headerPattern)`** generalizado — 2º arg = regex de header (default `### L-OP-NNN` → backward-compat; ledger [CC] usa `## L-NN`). **Reusa o parser, não escreve outro.**
- **`HealthCheckCommand::ledgerGraduationStats()`** (helper público estático): `graduadas`/`pendentes`/`graduation_ratio` por ledger.
- **Check `governanca_graduation_ratio`** (ADVISORY) no `jana:health-check` — espelha `jana_lesson_ledger_graduation` pros DOIS ledgers (operação + [CC]); amarelo se algum ratio < 1.0. Não derruba cron/exit.
- **`php artisan governanca:scorecard {--json}`** (Modules/Governance, registrado no provider) escreve `storage/reports/governanca-scorecard.json`: por-ledger total/graduadas/pendentes/ratio + `enforcement_score` derivado + `health_checks_count` (reflection) + baselines + `measured_against_sha` + timestamp + `condicao_9_7`. Eixos subjetivos marcados `source:"estimativa [CC]"` (honestidade de escopo).

### Números REAIS do `main` hoje (74bc2ea77)
| Ledger | graduadas/total | **graduation_ratio** |
|---|---|---|
| `operacao` (LICOES-OPERACAO.md) | 3/3 | **1.0** |
| `cc` (LICOES_CC.md) | 0/25 | **0.0** |

`enforcement_score` = **5.0/10** (ratio médio 0.5) · `health_checks_count` = 12 · `condicao_9_7.atingido` = **false**.

### Tests
- `GovernancaScorecardCommandTest` — **7 passed (31 assertions)**.
- `JanaHealthCheckTest` (existente) — **8 passed (114 assertions)**, sem regressão.

### Guards respeitados
Advisory (não pagina) · NÃO numera ADR (0238) · NÃO recria motor de score · **NÃO mergeia (Tier 0 = [W])**.

### Fica de [W] (checklist em `prototipo-ui/CODE_NOTES.md`)
- [ ] O número que move o 9.7: graduar as 25 lições do `LICOES_CC.md` (hoje 0/25).
- [ ] `--pipe-unico` é flag manual; virar detecção automática quando o pipe existir.
- [ ] Promover ADR (slug-only até lá) se quiser canonizar o mecanismo.
- [ ] `metricas.html` (Cowork) passar a LER o JSON no re-sync.
- [ ] Mergear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)