### PR TITLE
feat(governance): governanca:ciclo-diario — orquestrador diário advisory

### DIFF
--- a/Modules/Governance/Console/Commands/CicloDiarioGovernancaCommand.php
+++ b/Modules/Governance/Console/Commands/CicloDiarioGovernancaCommand.php
@@ -1,0 +1,376 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Modules\Governance\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Log;
+use Modules\Jana\Console\Commands\HealthCheckCommand;
+use Modules\Jana\Services\CharterHealthChecker;
+use Throwable;
+
+/**
+ * `governanca:ciclo-diario` — orquestrador diário da governança [CC]×Jana.
+ *
+ * Por quê ([W], 2026-06-03): *"não quero repetir 2x nem ficar pedindo pra
+ * organizar — resolve e gradua todo dia."* Hoje os checks existem soltos
+ * (`jana:health-check`, `governanca:scorecard`, `review-freshness`) e o placar
+ * do Cowork é mantido à mão. Este ciclo regenera o estado, roda o frescor,
+ * gradua o inbox de [W] (`COWORK_NOTES.md`) e emite UM digest/dia — [W] lê 1
+ * coisa e só toca Tier 0.
+ *
+ * NÃO cria daemon novo nem 7º motor de score: ORQUESTRA o que já existe
+ * (anti-G1 do AUDITORIA_ROTINAS_DESIGN). Estende o cron `jana:health-check`
+ * (Kernel 06:00) rodando depois dele (06:50) sobre o estado já fresco.
+ *
+ * ADVISORY: nada derruba o cron, nada auto-mergeia Tier 0, não numera ADR
+ * (soberania [W], ADR 0238). O digest é informativo; o irreversível é de [W].
+ *
+ * Defensivo: as pontes irmãs (`governanca:scorecard` já em main #2151;
+ * `protocol_freshness` chega no lote UC-guards) são lidas se presentes e
+ * marcadas como "ponte pendente" se ainda não landaram — o ciclo nunca quebra
+ * por uma ponte ausente.
+ *
+ * @see Modules/Governance/Console/Commands/GovernancaScorecardCommand.php
+ * @see Modules/Jana/Console/Commands/HealthCheckCommand.php  (graduation_ratio)
+ * @see prototipo-ui/COWORK_NOTES.md  (inbox [W]→[CC]/[CD])
+ */
+class CicloDiarioGovernancaCommand extends Command
+{
+    protected $signature = 'governanca:ciclo-diario
+                            {--json : imprime o ciclo como JSON em vez de tabela}
+                            {--code-notes : anexa o digest do dia ao prototipo-ui/CODE_NOTES.md (idempotente por data)}';
+
+    protected $description = 'Ciclo diário de governança: regenera estado + frescor + gradua inbox [W] + emite 1 digest/dia (advisory).';
+
+    private const STATE_PATH = 'reports/governanca-state.json';
+    private const DIGEST_PATH = 'reports/governanca-digest.md';
+    private const INBOX_PATH = 'prototipo-ui/COWORK_NOTES.md';
+    private const CODE_NOTES_PATH = 'prototipo-ui/CODE_NOTES.md';
+
+    public function handle(): int
+    {
+        $scorecard = $this->safeScorecard();
+        $frescor = $this->runFrescor($scorecard);
+        $inbox = $this->graduateInbox();
+        $state = $this->buildState($scorecard, $frescor, $inbox);
+
+        $this->writeJson(storage_path(self::STATE_PATH), $state);
+
+        $digest = $this->buildDigest($state);
+        $this->writeText(storage_path(self::DIGEST_PATH), $digest);
+
+        if ($this->option('code-notes')) {
+            $this->appendCodeNotes($digest, $state['date']);
+        }
+
+        if ($this->option('json')) {
+            $this->line(json_encode($state, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        } else {
+            $this->line($digest);
+        }
+
+        Log::channel('single')->info('governanca:ciclo-diario', [
+            'graduou' => $state['frescor']['graduacao'],
+            'acendeu' => $state['frescor']['acendeu'],
+            'inbox_pendentes' => $state['inbox']['pendentes'],
+            'espera_w' => $state['espera_w'],
+        ]);
+
+        // Advisory — sempre SUCCESS. Drift de governança não pagina à noite.
+        return Command::SUCCESS;
+    }
+
+    // ── 1. Estado (scorecard agregado) ──────────────────────────────────────
+
+    /**
+     * Reusa GovernancaScorecardCommand::buildScorecard (já em main #2151).
+     * Defensivo: se a ponte não estiver presente, devolve estrutura mínima.
+     *
+     * @return array<string, mixed>
+     */
+    private function safeScorecard(): array
+    {
+        try {
+            $cmd = $this->getLaravel()->make(GovernancaScorecardCommand::class);
+            if (method_exists($cmd, 'buildScorecard')) {
+                return $cmd->buildScorecard();
+            }
+        } catch (Throwable $e) {
+            $this->warn("scorecard indisponível ({$e->getMessage()}) — ciclo segue advisory");
+        }
+
+        return ['_ponte_ausente' => 'governanca:scorecard', 'ledgers' => [], 'mecanizado' => []];
+    }
+
+    // ── 2. Frescor (orquestra checks existentes) ────────────────────────────
+
+    /**
+     * @param  array<string, mixed>  $scorecard
+     * @return array<string, mixed>
+     */
+    private function runFrescor(array $scorecard): array
+    {
+        $graduacao = [];
+        $acendeu = [];
+
+        // (a) graduação dos 2 ledgers — do scorecard já calculado.
+        foreach (($scorecard['ledgers'] ?? []) as $key => $l) {
+            if (! ($l['presente'] ?? false)) {
+                continue;
+            }
+            $pct = (int) round((float) $l['graduation_ratio'] * 100);
+            $graduacao[$key] = "{$l['graduadas']}/{$l['total']} ({$pct}%)";
+            if ($l['graduation_ratio'] < 1.0 || ($l['pendentes'] ?? 0) > 0) {
+                $acendeu[] = "graduacao:{$key} {$pct}%";
+            }
+        }
+
+        // (b) cobertura de charter (advisory) — reusa CharterHealthChecker.
+        try {
+            foreach (CharterHealthChecker::fromApp()->checks() as $c) {
+                if (! ($c['ok'] ?? true)) {
+                    $acendeu[] = "{$c['name']}: {$c['value']}";
+                }
+            }
+        } catch (Throwable) {
+            // checker indisponível em dev — segue advisory.
+        }
+
+        // (c) review-freshness — lê o baseline (ratchet, ADR 0209) sem bootar node.
+        $reviewMissing = $this->reviewFreshnessMissing();
+        if ($reviewMissing > 0) {
+            $acendeu[] = "review-freshness: {$reviewMissing} missing (baseline)";
+        }
+
+        // (d) protocol_freshness — ponte irmã (lote UC-guards). Defensivo.
+        $protocol = $this->protocolFreshnessSignal();
+        if ($protocol !== null) {
+            $acendeu[] = $protocol;
+        }
+
+        return [
+            'graduacao' => $graduacao,
+            'review_freshness_missing' => $reviewMissing,
+            'acendeu' => array_values(array_unique($acendeu)),
+        ];
+    }
+
+    private function reviewFreshnessMissing(): int
+    {
+        $path = base_path('prototipo-ui/audit/review-freshness-baseline.json');
+        if (! is_file($path)) {
+            return 0;
+        }
+        $j = json_decode((string) file_get_contents($path), true);
+
+        return is_array($j) && isset($j['missing']) && is_array($j['missing']) ? count($j['missing']) : 0;
+    }
+
+    /**
+     * Sinal do protocol_freshness (ponte irmã do lote UC-guards). Lê o JSON que
+     * o check emite se já landou; senão devolve marcador de ponte pendente.
+     */
+    private function protocolFreshnessSignal(): ?string
+    {
+        $report = storage_path('reports/protocol-freshness.json');
+        if (is_file($report)) {
+            $j = json_decode((string) file_get_contents($report), true);
+            $n = is_array($j) && isset($j['acende']) && is_array($j['acende']) ? count($j['acende']) : 0;
+
+            return $n > 0 ? "protocol_freshness: {$n} acende(m)" : null;
+        }
+
+        $script = base_path('prototipo-ui/audit/protocol-freshness.mjs');
+
+        return is_file($script) ? null : 'protocol_freshness: ponte pendente (lote UC-guards)';
+    }
+
+    // ── 3. Graduação do inbox COWORK_NOTES ──────────────────────────────────
+
+    /**
+     * "Não repetir 2x": toda decisão de [W] no inbox tem que receber `Graduação:`
+     * em ≤1 ciclo (MEC→check / JULG→regra). Sem isso = pendente (amarelo).
+     *
+     * @return array{total:int, graduadas:int, pendentes:int, pendentes_ids:list<string>}
+     */
+    private function graduateInbox(): array
+    {
+        $path = base_path(self::INBOX_PATH);
+        if (! is_file($path)) {
+            return ['total' => 0, 'graduadas' => 0, 'pendentes' => 0, 'pendentes_ids' => []];
+        }
+
+        $content = (string) file_get_contents($path);
+        // Cada decisão = bloco iniciado por `## ` cujo cabeçalho marca autoria [W].
+        $blocos = preg_split('/^##\s+/m', $content, -1, PREG_SPLIT_NO_EMPTY) ?: [];
+
+        $total = 0;
+        $graduadas = 0;
+        $pendentes = [];
+
+        foreach ($blocos as $bloco) {
+            $linhas = explode("\n", $bloco, 2);
+            $cabecalho = trim($linhas[0] ?? '');
+            $corpo = $linhas[1] ?? '';
+
+            // Pula o template-modelo (linha "YYYY-MM-DD HH:MM [W] → [CC]" copiável).
+            if (str_contains($cabecalho, 'YYYY-MM-DD')) {
+                continue;
+            }
+
+            // Só decisões de [W] (autoria + seta). Pedidos de [CC]→[CL] não graduam aqui.
+            $ehDecisaoW = preg_match('/\[W\b/u', $cabecalho) === 1
+                && preg_match('/→|\[W\s*→/u', $cabecalho) === 1;
+            if (! $ehDecisaoW) {
+                continue;
+            }
+
+            $total++;
+            if (preg_match('/Gradua[çc][ãa]o:/u', $corpo) === 1) {
+                $graduadas++;
+            } else {
+                $pendentes[] = mb_substr($cabecalho, 0, 60);
+            }
+        }
+
+        return [
+            'total' => $total,
+            'graduadas' => $graduadas,
+            'pendentes' => count($pendentes),
+            'pendentes_ids' => $pendentes,
+        ];
+    }
+
+    // ── 4. State + 5. Digest ────────────────────────────────────────────────
+
+    /**
+     * @param  array<string, mixed>  $scorecard
+     * @param  array<string, mixed>  $frescor
+     * @param  array<string, mixed>  $inbox
+     * @return array<string, mixed>
+     */
+    private function buildState(array $scorecard, array $frescor, array $inbox): array
+    {
+        // Tier 0 / irreversível que ESPERA [W]: por ora o pipe único [CC]+Jana
+        // (flag manual da condição 9.7). Drift de processo NÃO entra aqui — só o
+        // que é genuinamente decisão de [W]. O ciclo nunca auto-resolve Tier 0.
+        $esperaW = [];
+        $cond = $scorecard['condicao_9_7'] ?? [];
+        if (($cond['ambos_ledgers_100'] ?? false) && ! ($cond['pipe_unico_cc_jana'] ?? false)) {
+            $esperaW[] = 'confirmar pipe único [CC]+Jana (condição 9.7 · flag manual)';
+        }
+
+        return [
+            'generator' => 'governanca:ciclo-diario',
+            'version' => '1.0.0',
+            'date' => now()->toDateString(),
+            'generated_at' => now()->toIso8601String(),
+            'measured_against_sha' => $this->currentSha(),
+            'aprovado' => [
+                'ledgers_100' => array_keys(array_filter(
+                    $scorecard['ledgers'] ?? [],
+                    fn ($l) => ($l['presente'] ?? false) && ($l['graduation_ratio'] ?? 0) >= 1.0
+                )),
+                'enforcement_score' => $scorecard['mecanizado']['enforcement_score'] ?? null,
+            ],
+            'frescor' => $frescor,
+            'inbox' => $inbox,
+            'espera_w' => $esperaW,
+            'scorecard_ref' => self::STATE_PATH,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     */
+    private function buildDigest(array $state): string
+    {
+        $grad = $state['frescor']['graduacao'] ?? [];
+        $gradStr = $grad === []
+            ? '— (nenhum ledger presente)'
+            : implode(' · ', array_map(fn ($k, $v) => "{$k} {$v}", array_keys($grad), $grad));
+
+        $acendeu = $state['frescor']['acendeu'] ?? [];
+        $acendeuStr = $acendeu === [] ? 'nada' : implode(' · ', $acendeu);
+
+        $inbox = $state['inbox'];
+        $espera = $state['espera_w'] === [] ? 'nada' : implode(' · ', $state['espera_w']);
+        $enf = $state['aprovado']['enforcement_score'] ?? 'n/a';
+
+        return <<<MD
+# Governança — Digest diário ({$state['date']})
+
+> Saída do ciclo `governanca:ciclo-diario` (advisory). [W] lê 1 coisa/dia e só toca Tier 0.
+> measured_against_sha: `{$state['measured_against_sha']}` · enforcement_score: {$enf}/10
+
+- **Graduou:** {$gradStr}
+- **Acendeu (advisory):** {$acendeuStr}
+- **Inbox [W]:** {$inbox['graduadas']} graduada(s) · {$inbox['pendentes']} pendente(s) sem `Graduação:`
+- **Espera [W] (Tier 0):** {$espera}
+
+MD;
+    }
+
+    /**
+     * Anexa o digest do dia ao CODE_NOTES.md — idempotente por data (não duplica
+     * se já rodou hoje). Usado pro marco/deliverable, NÃO pelo cron (que só grava
+     * o storage/digest pra não sujar arquivo versionado todo dia).
+     */
+    private function appendCodeNotes(string $digest, string $date): void
+    {
+        $path = base_path(self::CODE_NOTES_PATH);
+        if (! is_file($path)) {
+            $this->warn('CODE_NOTES.md ausente — pulo o append.');
+
+            return;
+        }
+        $atual = (string) file_get_contents($path);
+        $marcador = "Digest diário ({$date})";
+        if (str_contains($atual, $marcador)) {
+            $this->line("CODE_NOTES já tem o digest de {$date} — idempotente, não duplico.");
+
+            return;
+        }
+        file_put_contents($path, $atual . "\n---\n\n## ⟳ " . $marcador . " — `governanca:ciclo-diario`\n\n" . $digest . "\n");
+        $this->info("digest {$date} anexado a CODE_NOTES.md");
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────────
+
+    /** @param array<string, mixed> $data */
+    private function writeJson(string $path, array $data): void
+    {
+        $this->ensureDir(dirname($path));
+        file_put_contents(
+            $path,
+            json_encode($data, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . "\n"
+        );
+    }
+
+    private function writeText(string $path, string $text): void
+    {
+        $this->ensureDir(dirname($path));
+        file_put_contents($path, $text);
+    }
+
+    private function ensureDir(string $dir): void
+    {
+        if (! is_dir($dir)) {
+            mkdir($dir, 0775, true);
+        }
+    }
+
+    private function currentSha(): ?string
+    {
+        try {
+            $out = @shell_exec('git rev-parse --short HEAD 2>&1');
+            $sha = is_string($out) ? trim($out) : '';
+
+            return preg_match('/^[0-9a-f]{7,40}$/', $sha) === 1 ? $sha : null;
+        } catch (Throwable) {
+            return null;
+        }
+    }
+}

--- a/Modules/Governance/Providers/GovernanceServiceProvider.php
+++ b/Modules/Governance/Providers/GovernanceServiceProvider.php
@@ -66,6 +66,7 @@ class GovernanceServiceProvider extends ServiceProvider
                 \Modules\Governance\Console\Commands\ScorecardInitiativeSyncCommand::class, // Wave 28 Agent 1 — Initiatives Cortex-style
                 \Modules\Governance\Console\Commands\GovernanceAuditCommand::class,        // ADR 0216 — DriftChecker orchestrator
                 \Modules\Governance\Console\Commands\GovernancaScorecardCommand::class,    // W28 — placar [CC]×Jana mecanizado (graduação de lições)
+                \Modules\Governance\Console\Commands\CicloDiarioGovernancaCommand::class,  // ciclo diário — orquestra estado+frescor+inbox+digest (advisory)
             ]);
         }
     }

--- a/Modules/Governance/Tests/Feature/CicloDiarioGovernancaCommandTest.php
+++ b/Modules/Governance/Tests/Feature/CicloDiarioGovernancaCommandTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+/**
+ * `governanca:ciclo-diario` — orquestrador diário (advisory).
+ *
+ * Cobre: o ciclo roda sem quebrar, escreve state.json + digest.md com o shape
+ * canônico, e é advisory (exit 0 sempre). Não testa o cron (Kernel) — isso é
+ * smoke de schedule, fora de escopo aqui.
+ *
+ * @see Modules/Governance/Console/Commands/CicloDiarioGovernancaCommand.php
+ */
+beforeEach(function () {
+    foreach (['governanca-state.json', 'governanca-digest.md'] as $f) {
+        $p = storage_path("reports/{$f}");
+        if (file_exists($p)) {
+            unlink($p);
+        }
+    }
+});
+
+it('governanca:ciclo-diario roda advisory (exit 0) e escreve state + digest', function () {
+    $this->artisan('governanca:ciclo-diario')->assertExitCode(0);
+
+    expect(file_exists(storage_path('reports/governanca-state.json')))->toBeTrue();
+    expect(file_exists(storage_path('reports/governanca-digest.md')))->toBeTrue();
+});
+
+it('state.json tem o shape canônico (generator, frescor, inbox, espera_w)', function () {
+    $this->artisan('governanca:ciclo-diario --json')->assertExitCode(0);
+
+    $state = json_decode((string) file_get_contents(storage_path('reports/governanca-state.json')), true);
+
+    expect($state)->toBeArray();
+    expect($state['generator'])->toBe('governanca:ciclo-diario');
+    expect($state)->toHaveKeys(['date', 'measured_against_sha', 'aprovado', 'frescor', 'inbox', 'espera_w']);
+    expect($state['frescor'])->toHaveKeys(['graduacao', 'acendeu']);
+    expect($state['inbox'])->toHaveKeys(['total', 'graduadas', 'pendentes', 'pendentes_ids']);
+    expect($state['espera_w'])->toBeArray();
+});
+
+it('o digest é legível e cita as 4 linhas do resumo (Graduou/Acendeu/Inbox/Espera)', function () {
+    $this->artisan('governanca:ciclo-diario')->assertExitCode(0);
+
+    $digest = (string) file_get_contents(storage_path('reports/governanca-digest.md'));
+
+    expect($digest)->toContain('Digest diário');
+    expect($digest)->toContain('Graduou:');
+    expect($digest)->toContain('Acendeu (advisory):');
+    expect($digest)->toContain('Inbox [W]:');
+    expect($digest)->toContain('Espera [W] (Tier 0):');
+});
+
+it('reusa o scorecard (ponte main #2151): graduação dos 2 ledgers aparece no state', function () {
+    $this->artisan('governanca:ciclo-diario --json')->assertExitCode(0);
+
+    $state = json_decode((string) file_get_contents(storage_path('reports/governanca-state.json')), true);
+
+    // Os ledgers reais do repo (operacao + cc) graduam; o ciclo reflete o ratio.
+    expect($state['frescor']['graduacao'])->toBeArray();
+    // pelo menos um ledger presente → a chave de graduação não é vazia em main.
+    expect(count($state['frescor']['graduacao']))->toBeGreaterThanOrEqual(1);
+});

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -139,6 +139,22 @@ class Kernel extends ConsoleKernel
                 );
             });
 
+        // Ciclo diário de governança [CC]×Jana (ADVISORY — orquestra checks que já
+        // existem; não cria daemon, não numera ADR, não auto-mergeia Tier 0).
+        // Regenera o estado (governanca:scorecard) + frescor (graduation_ratio,
+        // charter coverage, review/protocol-freshness) + gradua o inbox [W]
+        // (COWORK_NOTES) + emite 1 digest/dia em storage/reports/governanca-digest.md.
+        // 06:50 BRT — DEPOIS de health-check (06:00) + grade-snapshot (06:05) +
+        // system-audit (06:15) + smoke (06:30), sobre o estado já fresco do dia.
+        // SEM --notify e SEM onFailure ALERT: drift de processo não pagina à noite.
+        // SEM --code-notes no cron: o append a CODE_NOTES.md (versionado) é manual
+        // pro marco; o cron grava só o storage/digest (não suja arquivo git diário).
+        $schedule->command('governanca:ciclo-diario')
+            ->dailyAt('06:50')
+            ->timezone('America/Sao_Paulo')
+            ->withoutOverlapping()
+            ->environments(['live']);
+
         // ADR 0153/0155 — Module Grades snapshot diário pra sparkline 7d.
         // Persiste 1 row/módulo em mcp_module_grades_history (~34 módulos × 1KB).
         // Pareado com jana:health-check (06:00) — ambos rodam após brief regenerar.

--- a/prototipo-ui/CODE_NOTES.md
+++ b/prototipo-ui/CODE_NOTES.md
@@ -628,3 +628,48 @@ O furo (exatamente o que o "não assumir" pega): o NFS-e resolvia ambiente pelo 
 ### new_design_memories
 - **golden**: placar de governança [CC]×Jana deixa de ser prosa digitada e vira saída de check (`governanca_graduation_ratio`) + comando que escreve JSON que o report LÊ — frescor por mecanismo (o ProfileDistiller da governança).
 - **regra**: métrica do 9.7 = lições graduadas em check rodável ÷ total, nos dois ledgers; 9.7 exige ambos 100% + pipe único. Hoje: operação 1.0, CC 0.0.
+
+---
+
+## 2026-06-03 [CL] → [W] · Lote design [CC] §10.4 (3 tarefas) — validação vs `origin/main` fresco + entregas
+
+Worktrees off `origin/main` (@ `7a60eddbb`). Validei cada tarefa ANTES de codar (não duplicar). Não numerei ADR (soberania [W], 0238). Não mergeei nada (Tier 0 = [W]). Ordem de merge importa: **1 → 2 → 3**.
+
+### Tarefa 1 — `governanca:scorecard` → **JÁ EM `main` (#2151)**. NÃO dupliquei.
+A ponte inteira já landou (é a própria tip do `main`): `GovernancaScorecardCommand` + check `governanca_graduation_ratio` + `parseLessonLedger`/`ledgerGraduationStats` generalizados pros 2 ledgers. Revalidei os números pela **lógica pura do comando** contra os ledgers reais do `main`:
+- **`operacao` (LICOES-OPERACAO.md): graduation_ratio = 1.0** (3/3).
+- **`cc` (LICOES_CC.md): graduation_ratio = 0.0** (0/25 — as L-01…L-25 usam o formato antigo `Erro·Sintoma·Regra·Ref`, sem linha `**Graduação:**`).
+- `enforcement_score` = **5.0/10** (ratio médio 0.5) · `condicao_9_7.atingido` = **false**.
+→ Sem PR novo (já mergeado). O número que move o 9.7 segue: graduar as 25 lições do `LICOES_CC.md`.
+
+### Tarefa 2 — `governanca:ciclo-diario` → **PR #2152** (branch `feat/governanca-ciclo-diario`)
+Orquestrador diário advisory (06:50 BRT, após health-check/grade/audit/smoke). Regenera estado (reusa scorecard #2151) → `storage/reports/governanca-state.json`; roda frescor (graduation_ratio + charter coverage + review-freshness baseline + protocol_freshness se presente); gradua o inbox `COWORK_NOTES.md`; emite 1 digest/dia. Cron sem `--notify`/ALERT; append a CODE_NOTES só via `--code-notes` (manual, idempotente) — cron não suja arquivo git.
+
+**1º digest real do `main` hoje** (lógica pura do comando · boot Laravel local bloqueado pelo autoload do vendor pinado a worktree removido — Pest roda no CI/CT100, #2076):
+```
+# Governança — Digest diário (2026-06-03)
+> measured_against_sha: 7a60eddbb · enforcement_score: 5/10
+- Graduou: operacao 3/3 (100%) · cc 0/25 (0%)
+- Acendeu (advisory): graduacao:cc 0% · review-freshness: 21 missing (baseline) · protocol_freshness: ponte pendente (vira "12 gaps" após #2153)
+- Inbox [W]: 0 graduada(s) · 5 pendente(s) sem `Graduação:`  (entradas [W]→[CC]: 16:45 2026-05-09, Amendment #316 avatar, Amendment #316 block-renderer, Amendment Cockpit V2.1, F0 PaymentGateway)
+- Espera [W] (Tier 0): nada
+```
+
+### Tarefa 3 — UC-guards + `protocol_freshness` → **PR #2153** (branch `feat/uc-guards-protocol-freshness`)
+Dos 2 docs de Casos de Uso (Vendas UC-V/R/C · Oficina UC-01..10) gerei, **só nas telas canon**, `PRECISA TER` na charter + GUARD Pest `uc-<id>` + check `protocol_freshness` (advisory no health-check, espelha `review-freshness` #2078, ratchet baseline). Fonte única: `prototipo-ui/audit/uc-registry.json`.
+
+**Números reais do `main` hoje** (`node protocol-freshness.mjs` + simulação das asserções Pest):
+- **8 UC cobertos** (GUARD verde, todos PASS): UC-V01, UC-V02, UC-V03 (Sells/Create) · UC-01 (Oficina/Create) · UC-03, UC-05, UC-09 (Oficina/Show) · UC-02 (Oficina/Board).
+- **12 sem cobertura** (gaps → baseline, acendem advisory): UC-V04, UC-R01, UC-C01, UC-V04S, UC-V05, UC-V06, UC-V07 · UC-04, UC-06, UC-07, UC-08, UC-10.
+- **0** guard quebrado · **0** charter ausente · **0** UC morto · **0 regressão**.
+- Markers usam **nome de componente** (CustomerSearchAutocomplete, EntryCheckinFields, DviBudgetSection, ApprovalGateCard, FiscalSplitCard, drag) — `data-testid` é esparso no canon; componente é mais estável que i18n.
+
+### Fica de [W] (Tier 0):
+- [ ] mergear na ordem **#2151 (já) → #2152 → #2153** (Tier 0 = soberania [W]).
+- [ ] graduar as 25 lições do `LICOES_CC.md` (move o 9.7 de 0.5 → 1.0 no lado [CC]).
+- [ ] cobrir os 12 gaps de UC (vira `guard:true` no registro + GUARD `uc-<id>` + `--write-baseline`).
+- [ ] promover ADR (slug-only até lá) se quiser canonizar ciclo-diário/protocol_freshness.
+
+### new_design_memories
+- **golden**: a governança se mantém por um **ciclo diário** que regenera estado + roda frescor + gradua o inbox de [W] + emite 1 digest — tira [W] **e** [CL] do caminho recorrente.
+- **golden**: cada UC ("A tela precisa:") vira PRECISA TER (o porquê) + GUARD Pest `uc-<id>` (a trava) — some o elemento = build vermelho; o doc de casos para de defasar (amarrado ao teste, `protocol_freshness` acende o que falta).


### PR DESCRIPTION
## §10.4 PROPOSTA — Cowork `CICLO-DIARIO-GOVERNANCA` (lote design [CC])

> **NÃO MERGEAR sem [W].** Advisory/aditivo, mas toca cron (`app/Console/Kernel.php`) → [W] aprova. Não numera ADR (soberania [W], 0238). Não auto-mergeia Tier 0.

### O que faz
Orquestra **checks que já existem** num ciclo diário (não cria daemon, não cria 7º motor de score — anti-G1). Estende `jana:health-check` rodando **depois** dele sobre o estado já fresco.

1. **Regenera estado** → reusa `GovernancaScorecardCommand::buildScorecard` (#2151) → `storage/reports/governanca-state.json`.
2. **Frescor** → `graduation_ratio` (2 ledgers) + charter coverage (`CharterHealthChecker`) + `review-freshness` (baseline ratchet) + `protocol_freshness` (ponte irmã, lida se presente).
3. **Gradua o inbox [W]** → cada decisão de `[W]` em `COWORK_NOTES.md` sem `Graduação:` = pendente (amarelo). *"Não repetir 2x"*.
4. **Digest diário** → `storage/reports/governanca-digest.md` (`graduou X · acendeu Y · espera [W] em Z`).

### Validação vs `origin/main` fresco (worktree off `origin/main` @ `7a60eddbb`)
- Comando `governanca:ciclo-diario` **ausente** em main → real work, sem duplicar.
- Pré-req `governanca:scorecard` **já em main** (#2151) → reusado, não recriado.

### Guards / Tier 0
- **Advisory:** `return SUCCESS` sempre. Cron sem `--notify`/`onFailure` ALERT.
- Cron grava só `storage/digest`; append a `CODE_NOTES.md` (versionado) só via `--code-notes` (manual, idempotente por data).
- Defensivo: pontes ausentes não quebram o ciclo.

### Números reais do main hoje (lógica pura do comando, inputs reais)
- **Graduou:** `operacao 3/3 (100%)` · `cc 0/25 (0%)` → enforcement_score `5.0/10`
- **Inbox [W]:** `0 graduadas · 5 pendentes` (sem `Graduação:`)
- **Acendeu:** `graduacao:cc 0%` · `review-freshness: 21 missing (baseline)` · `protocol_freshness: ponte pendente`

> Boot Laravel local bloqueado pelo autoload do vendor compartilhado (pinado a worktree removido) — números computados pela **lógica pura do comando** contra inputs reais; Pest roda no CI/CT100 (norma do repo, feedback #2076).

🤖 Generated with [Claude Code](https://claude.com/claude-code)