### PR TITLE
feat(governance): UC-guards + protocol_freshness — Casos de Uso → GUARD Pest

### DIFF
--- a/Modules/Jana/Console/Commands/HealthCheckCommand.php
+++ b/Modules/Jana/Console/Commands/HealthCheckCommand.php
@@ -33,6 +33,10 @@ use Modules\Jana\Services\CharterHealthChecker;
  *  11. Lesson ledger graduation (ADVISORY · Reflexion runtime) — toda lição de
  *      operação em LICOES-OPERACAO.md nasceu graduada (MEC→check / JULG→regra);
  *      acende amarelo se há entrada malformada ou `status:pendente`.
+ *  11b. governanca_graduation_ratio (ADVISORY) — espelha (11) pros 2 ledgers.
+ *  11c. protocol_freshness (ADVISORY · espelha review-freshness #2078) — UC das
+ *      telas canon (uc-registry.json) amarrado a GUARD Pest `uc-<id>`; acende UC
+ *      sem cobertura / GUARD sumido / charter ausente / UC morto. Ratchet baseline.
  *  12-17. Charter/loop health (ADVISORY · CharterHealthChecker, PROTOCOL §6) —
  *      charter_missing, charter_stale (>90d), charter_refs_broken,
  *      charter_method_missing, readme_handoff_block_missing (L-18),
@@ -68,6 +72,7 @@ class HealthCheckCommand extends Command
             $this->checkMemoriaRecallBackend(),
             $this->checkLessonLedgerGraduation(),
             $this->checkGovernancaGraduationRatio(),
+            $this->checkProtocolFreshness(),
             // Charter health (advisory — não falha exit/cron). PROTOCOL §6.
             ...CharterHealthChecker::fromApp()->checks(),
         ];
@@ -800,6 +805,143 @@ class HealthCheckCommand extends Command
                 ? 'Graduação incompleta (meta 9.7 = ambos 100%): ' . implode(' · ', $partes)
                 : 'Ambos ledgers 100% graduados — ' . implode(' · ', $partes),
         ];
+    }
+
+    /**
+     * Check protocol_freshness (ADVISORY · frescor do protocolo UC→charter→GUARD).
+     *
+     * Espelha em PHP o `prototipo-ui/audit/protocol-freshness.mjs` (que espelha o
+     * molde `review-freshness.mjs` #2078). Acende amarelo quando:
+     *   (a) UC com `guard:true` no registro sem GUARD linkado nos testes (regressão);
+     *   (b) tela canon sem charter;
+     *   (c) charter cita UC que não existe mais no registro (UC morto);
+     *   + lista (advisory, ratchet via baseline) os UCs sem cobertura (gaps).
+     *
+     * A LEI (PROTOCOL/charter) continua de [W]; o check só ACENDE e o [CL] propõe
+     * a reconciliação (§10.4). Emite storage/reports/protocol-freshness.json pro
+     * ciclo diário (governanca:ciclo-diario) ler. Advisory: não derruba cron.
+     *
+     * @see prototipo-ui/audit/uc-registry.json  (fonte única UC→tela→GUARD)
+     */
+    protected function checkProtocolFreshness(): array
+    {
+        $name = 'protocol_freshness';
+        $registryPath = base_path('prototipo-ui/audit/uc-registry.json');
+
+        if (! is_file($registryPath)) {
+            return [
+                'name' => $name, 'ok' => true, 'advisory' => true, 'value' => 'n/a',
+                'threshold' => '0 regressão', 'message' => 'Skipped (uc-registry.json ausente — ponte UC-guards não landada)',
+            ];
+        }
+
+        $registry = json_decode((string) file_get_contents($registryPath), true);
+        $baseline = is_file($b = base_path('prototipo-ui/audit/protocol-freshness-baseline.json'))
+            ? (json_decode((string) file_get_contents($b), true)['sem_cobertura'] ?? [])
+            : [];
+        $baseSem = array_flip(is_array($baseline) ? $baseline : []);
+
+        $testsText = $this->concatTestsText();
+        $geradorWired = str_contains($testsText, 'uc-registry.json');
+
+        $cobertos = $semCobertura = $guardQuebrado = $charterAusente = $ucMorto = [];
+        $idsRegistro = [];
+        foreach (($registry['screens'] ?? []) as $s) {
+            foreach (($s['ucs'] ?? []) as $uc) {
+                $idsRegistro[$uc['uc']] = true;
+            }
+        }
+
+        foreach (($registry['screens'] ?? []) as $s) {
+            $charterAbs = base_path($s['charter']);
+            if (! is_file($charterAbs)) {
+                $charterAusente[] = "{$s['id']}:{$s['charter']}";
+            } else {
+                preg_match_all('/UC-[A-Z0-9]+/', (string) file_get_contents($charterAbs), $m);
+                foreach (array_unique($m[0] ?? []) as $cit) {
+                    if (! isset($idsRegistro[$cit])) {
+                        $ucMorto[] = "{$s['id']}:{$cit}";
+                    }
+                }
+            }
+            foreach (($s['ucs'] ?? []) as $uc) {
+                $tag = 'uc-' . strtolower((string) preg_replace('/^UC-/', '', $uc['uc']));
+                if ($uc['guard'] ?? false) {
+                    if ($geradorWired || str_contains($testsText, "'{$tag}'") || str_contains($testsText, "\"{$tag}\"")) {
+                        $cobertos[] = "{$s['id']}:{$uc['uc']}";
+                    } else {
+                        $guardQuebrado[] = "{$s['id']}:{$uc['uc']}";
+                    }
+                } else {
+                    $semCobertura[] = "{$s['id']}:{$uc['uc']}";
+                }
+            }
+        }
+
+        $novoSem = array_values(array_filter($semCobertura, fn ($x) => ! isset($baseSem[$x])));
+        $acende = array_merge(
+            array_map(fn ($x) => ['tipo' => 'sem_cobertura', 'ref' => $x], $semCobertura),
+            array_map(fn ($x) => ['tipo' => 'guard_quebrado', 'ref' => $x], $guardQuebrado),
+            array_map(fn ($x) => ['tipo' => 'charter_ausente', 'ref' => $x], $charterAusente),
+            array_map(fn ($x) => ['tipo' => 'uc_morto', 'ref' => $x], $ucMorto),
+        );
+        $regressao = array_merge($guardQuebrado, $charterAusente, $ucMorto, $novoSem);
+
+        $this->emitProtocolReport([
+            'generated_against_sha' => null,
+            'cobertos' => $cobertos,
+            'acende' => $acende,
+            'regressao_count' => count($regressao),
+            'baseline_sem_cobertura' => array_keys($baseSem),
+        ]);
+
+        $value = sprintf('%d cobertos · %d gaps · %d regressão', count($cobertos), count($semCobertura), count($regressao));
+
+        return [
+            'name' => $name,
+            'ok' => $regressao === [],
+            'advisory' => true,
+            'value' => $value,
+            'threshold' => '0 regressão (gaps ⊆ baseline)',
+            'message' => $regressao === []
+                ? "Protocolo fresco — {$value} (gaps conhecidos no baseline)"
+                : 'Regressão de protocolo (GUARD/charter/UC): ' . implode(' · ', array_slice($regressao, 0, 6)),
+        ];
+    }
+
+    /** Concatena o texto dos testes Pest (procura wiring do gerador + tags uc-<id>). */
+    private function concatTestsText(): string
+    {
+        $dir = base_path('tests');
+        if (! is_dir($dir)) {
+            return '';
+        }
+        $buf = '';
+        $it = new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS));
+        foreach ($it as $f) {
+            if ($f->isFile() && $f->getExtension() === 'php') {
+                $buf .= (string) file_get_contents($f->getPathname()) . "\n";
+            }
+        }
+
+        return $buf;
+    }
+
+    /** @param array<string, mixed> $payload */
+    private function emitProtocolReport(array $payload): void
+    {
+        try {
+            $dir = storage_path('reports');
+            if (! is_dir($dir)) {
+                mkdir($dir, 0775, true);
+            }
+            file_put_contents(
+                $dir . '/protocol-freshness.json',
+                json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES) . "\n"
+            );
+        } catch (\Throwable) {
+            // advisory — falha ao escrever o report não derruba o check.
+        }
     }
 
     /**

--- a/Modules/Jana/Tests/Feature/Smoke/ProtocolFreshnessCheckTest.php
+++ b/Modules/Jana/Tests/Feature/Smoke/ProtocolFreshnessCheckTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Artisan;
+
+uses(Tests\TestCase::class);
+
+/**
+ * Smoke do check `protocol_freshness` no jana:health-check (ADVISORY).
+ *
+ * Valida que o check (espelho PHP do protocol-freshness.mjs) entra na lista de
+ * checks, é advisory, e — com o registro UC presente neste branch — fica OK
+ * (gaps ⊆ baseline), nunca derrubando o exit code do cron.
+ *
+ * @see Modules/Jana/Console/Commands/HealthCheckCommand.php::checkProtocolFreshness
+ * @see prototipo-ui/audit/uc-registry.json
+ */
+function protocolFreshnessCheck(): ?array
+{
+    Artisan::call('jana:health-check', ['--json' => true]);
+    $out = Artisan::output();
+    $start = strpos($out, '{');
+    $json = $start === false ? [] : json_decode(substr($out, (int) $start), true);
+
+    foreach (($json['checks'] ?? []) as $c) {
+        if (($c['name'] ?? null) === 'protocol_freshness') {
+            return $c;
+        }
+    }
+
+    return null;
+}
+
+test('protocol_freshness entra na lista de checks e é advisory', function () {
+    $check = protocolFreshnessCheck();
+
+    expect($check)->not->toBeNull('check protocol_freshness ausente do jana:health-check');
+    expect($check['advisory'] ?? false)->toBeTrue();
+    expect($check)->toHaveKeys(['name', 'ok', 'value', 'threshold', 'message']);
+});
+
+test('protocol_freshness fica OK (gaps no baseline) com o registro deste branch', function () {
+    $check = protocolFreshnessCheck();
+
+    // Com uc-registry.json + baseline presentes, nenhuma regressão → ok=true.
+    expect($check['ok'])->toBeTrue("protocol_freshness acusou regressão: {$check['message']}");
+    // o value reporta cobertos/gaps/regressão — formato "N cobertos · M gaps · K regressão".
+    expect($check['value'])->toContain('cobertos');
+});
+
+test('o check é advisory — não derruba o exit code do health-check', function () {
+    $exit = Artisan::call('jana:health-check', ['--json' => true]);
+    // advisory: mesmo com gaps/charters, protocol_freshness não força FAILURE sozinho.
+    expect(in_array($exit, [0, 1], true))->toBeTrue();
+});

--- a/prototipo-ui/audit/protocol-freshness-baseline.json
+++ b/prototipo-ui/audit/protocol-freshness-baseline.json
@@ -1,0 +1,18 @@
+{
+  "_doc": "Ratchet de frescor do protocolo (espelha review-freshness-baseline.json · ADR 0209). Dívida HERDADA = UC das telas canon SEM cobertura (guard=false) hoje. O gate só FALHA por regressão NOVA (GUARD que sumiu, tela canon sem charter, UC morto citado). A lista só ENCOLHE: ao cobrir um UC (marker + GUARD uc-<id>), mude guard=true no registro e rode --write-baseline.",
+  "generated_against_sha": "7a60eddbb",
+  "sem_cobertura": [
+    "sells-create:UC-V04",
+    "sells-create:UC-R01",
+    "sells-create:UC-C01",
+    "sells-show:UC-V04S",
+    "sells-show:UC-V05",
+    "sells-show:UC-V06",
+    "sells-show:UC-V07",
+    "oficina-show:UC-04",
+    "oficina-show:UC-06",
+    "oficina-show:UC-07",
+    "oficina-show:UC-08",
+    "oficina-show:UC-10"
+  ]
+}

--- a/prototipo-ui/audit/protocol-freshness.mjs
+++ b/prototipo-ui/audit/protocol-freshness.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+// protocol-freshness.mjs — frescor do PROTOCOLO (UC → charter PRECISA TER → GUARD).
+//
+// Pergunta canônica ([W]: "põe o botão e que nunca mais saia aquela merda de lá"):
+// cada Caso de Uso ("A tela precisa:") das telas canon está AMARRADO a um GUARD Pest
+// `uc-<id>`? O doc de casos para de defasar porque o que existe está travado no teste,
+// e o que falta ACENDE aqui (não fica esquecido em prosa).
+//
+// Espelha em NODE o padrão de `review-freshness.mjs` (#2078): ratchet via baseline
+// (ADR 0209) — a dívida herdada (UC sem cobertura HOJE) vive em
+// `protocol-freshness-baseline.json`; o gate só FALHA por uma REGRESSÃO nova:
+//   (a) GUARD some — UC guard=true sem teste `uc-<id>` linkado (regressão dura);
+//   (b) tela canon sem charter (fora do baseline);
+//   (c) charter cita UC que não existe mais no registro (UC morto).
+// Gaps conhecidos (UC guard=false) são ADVISORY — acendem no digest, entram no baseline.
+//
+// A LEI (PROTOCOL/charter) continua de [W]: o check só ACENDE e o [CL] propõe (§10.4).
+//
+// Uso:
+//   node prototipo-ui/audit/protocol-freshness.mjs                 # checa (exit 1 só em regressão)
+//   node prototipo-ui/audit/protocol-freshness.mjs --json          # saída JSON (+ storage/reports)
+//   node prototipo-ui/audit/protocol-freshness.mjs --write-baseline
+
+import { readFileSync, writeFileSync, existsSync, readdirSync, statSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { execSync } from 'node:child_process';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const REPO = join(HERE, '..', '..');
+const REGISTRY = join(HERE, 'uc-registry.json');
+const BASELINE = join(HERE, 'protocol-freshness-baseline.json');
+const TESTS_DIR = join(REPO, 'tests');
+const argv = process.argv.slice(2);
+const FLAG = (f) => argv.includes(f);
+
+function read(p) { return readFileSync(p, 'utf8'); }
+
+// junta todo o texto dos testes Pest uma vez (procura tags `uc-<id>`).
+function allTestsText() {
+  const acc = [];
+  const walk = (dir) => {
+    for (const name of readdirSync(dir)) {
+      const p = join(dir, name);
+      const st = statSync(p);
+      if (st.isDirectory()) walk(p);
+      else if (name.endsWith('.php')) acc.push(read(p));
+    }
+  };
+  if (existsSync(TESTS_DIR)) walk(TESTS_DIR);
+  return acc.join('\n');
+}
+
+function ucTag(id) {
+  return 'uc-' + id.replace(/^UC-/, '').toLowerCase();
+}
+
+// extrai tokens UC-xxx citados num charter (pra detectar UC morto — item c).
+function ucsCitadosNoCharter(src) {
+  const m = src.match(/UC-[A-Z0-9]+/g) || [];
+  return [...new Set(m)];
+}
+
+function audit() {
+  const registry = JSON.parse(read(REGISTRY));
+  const testsText = allTestsText();
+  // O GUARD pode ser linkado de 2 formas: (1) tag literal `'uc-<id>'` num teste
+  // manual, ou (2) um teste GERADO a partir do registro (itera uc-registry.json e
+  // cria 1 teste/UC guard=true). Se o gerador está wired, todo guard=true está
+  // coberto — apagar o gerador = regressão massiva (todos viram guard_quebrado).
+  const geradorWired = testsText.includes('uc-registry.json');
+
+  const semCobertura = [];   // (advisory) UC guard=false — gap conhecido
+  const guardQuebrado = [];  // (regressão) UC guard=true sem teste uc-<id>
+  const charterAusente = []; // (regressão) tela canon sem charter
+  const ucMorto = [];        // (regressão) charter cita UC fora do registro
+  const cobertos = [];
+
+  const idsRegistro = new Set();
+  for (const s of registry.screens || []) {
+    for (const uc of s.ucs || []) idsRegistro.add(uc.uc);
+  }
+
+  for (const s of registry.screens || []) {
+    const charterAbs = join(REPO, s.charter);
+    if (!existsSync(charterAbs)) {
+      charterAusente.push(`${s.id}:${s.charter}`);
+    } else {
+      // item (c) — UC citado no charter mas ausente do registro = UC morto.
+      for (const cit of ucsCitadosNoCharter(read(charterAbs))) {
+        if (!idsRegistro.has(cit)) ucMorto.push(`${s.id}:${cit}`);
+      }
+    }
+
+    for (const uc of s.ucs || []) {
+      const tag = ucTag(uc.uc);
+      if (uc.guard) {
+        const linkadoLiteral = testsText.includes(`'${tag}'`) || testsText.includes(`"${tag}"`);
+        if (geradorWired || linkadoLiteral) {
+          cobertos.push(`${s.id}:${uc.uc}`);
+        } else {
+          guardQuebrado.push(`${s.id}:${uc.uc} (tag ${tag} ausente nos testes)`);
+        }
+      } else {
+        semCobertura.push(`${s.id}:${uc.uc}`);
+      }
+    }
+  }
+
+  return { cobertos, semCobertura, guardQuebrado, charterAusente, ucMorto };
+}
+
+function sha() {
+  try { return execSync('git rev-parse --short HEAD', { cwd: REPO }).toString().trim(); } catch { return 'unknown'; }
+}
+
+function loadBaseline() {
+  if (!existsSync(BASELINE)) return { sem_cobertura: [] };
+  try { return JSON.parse(read(BASELINE)); } catch { return { sem_cobertura: [] }; }
+}
+
+function emitJson(payload) {
+  const dir = join(REPO, 'storage', 'reports');
+  try { if (!existsSync(dir)) mkdirSync(dir, { recursive: true }); writeFileSync(join(dir, 'protocol-freshness.json'), JSON.stringify(payload, null, 2) + '\n'); } catch {}
+}
+
+function main() {
+  const res = audit();
+
+  if (FLAG('--write-baseline')) {
+    const baseline = {
+      _doc: 'Ratchet de frescor do protocolo (espelha review-freshness-baseline.json · ADR 0209). '
+        + 'Dívida HERDADA = UC das telas canon SEM cobertura (guard=false) hoje. O gate só FALHA por '
+        + 'regressão NOVA (GUARD que sumiu, tela canon sem charter, UC morto citado). A lista só ENCOLHE: '
+        + 'ao cobrir um UC (marker + GUARD uc-<id>), mude guard=true no registro e rode --write-baseline.',
+      generated_against_sha: sha(),
+      sem_cobertura: res.semCobertura,
+    };
+    writeFileSync(BASELINE, JSON.stringify(baseline, null, 2) + '\n');
+    console.log(`[protocol] baseline gravado: ${res.semCobertura.length} sem cobertura (herdado) · ${res.cobertos.length} cobertos · sha ${baseline.generated_against_sha}`);
+    return;
+  }
+
+  const baseline = loadBaseline();
+  const baseSem = new Set(baseline.sem_cobertura || []);
+  const novoSem = res.semCobertura.filter((x) => !baseSem.has(x)); // gap novo fora do baseline
+
+  // acende (advisory) = tudo que precisa de atenção; regressão = subset que FALHA o gate.
+  const acende = [
+    ...res.semCobertura.map((x) => ({ tipo: 'sem_cobertura', ref: x })),
+    ...res.guardQuebrado.map((x) => ({ tipo: 'guard_quebrado', ref: x })),
+    ...res.charterAusente.map((x) => ({ tipo: 'charter_ausente', ref: x })),
+    ...res.ucMorto.map((x) => ({ tipo: 'uc_morto', ref: x })),
+  ];
+  const regressao = [
+    ...res.guardQuebrado.map((x) => ({ tipo: 'guard_quebrado', ref: x })),
+    ...res.charterAusente.map((x) => ({ tipo: 'charter_ausente', ref: x })),
+    ...res.ucMorto.map((x) => ({ tipo: 'uc_morto', ref: x })),
+    ...novoSem.map((x) => ({ tipo: 'sem_cobertura_novo', ref: x })),
+  ];
+
+  const payload = { generated_against_sha: sha(), cobertos: res.cobertos, acende, regressao, baseline_sem_cobertura: [...baseSem] };
+  emitJson(payload);
+
+  if (FLAG('--json')) {
+    console.log(JSON.stringify(payload, null, 2));
+  } else {
+    console.log(`[protocol] canon: ${res.cobertos.length} UC cobertos · ${res.semCobertura.length} sem cobertura (${baseSem.size} no baseline) · ${res.guardQuebrado.length} guard quebrado · ${res.charterAusente.length} charter ausente · ${res.ucMorto.length} UC morto`);
+    if (res.cobertos.length) console.log(`  cobertos: ${res.cobertos.join(', ')}`);
+    if (res.semCobertura.length) console.log(`  sem cobertura (ADVISORY): ${res.semCobertura.join(', ')}`);
+    if (regressao.length) {
+      console.error(`\n[protocol] ✗ FALHA: ${regressao.length} regressão(ões) fora do baseline:`);
+      for (const r of regressao) console.error(`  - [${r.tipo}] ${r.ref}`);
+    }
+  }
+
+  if (regressao.length) process.exit(1);
+  console.log('[protocol] OK — nenhuma regressão de protocolo (gaps ⊆ baseline).');
+}
+
+main();

--- a/prototipo-ui/audit/uc-registry.json
+++ b/prototipo-ui/audit/uc-registry.json
@@ -1,0 +1,61 @@
+{
+  "_doc": "Registro canônico UC → tela canon → PRECISA TER + GUARD Pest (uc-<id>). Fonte única lida por: tests/Feature/Guards/UcGuardsTest.php (afirma o marker), prototipo-ui/audit/protocol-freshness.mjs (acende gaps) e Modules/Jana checkProtocolFreshness (espelho no jana:health-check). Origem: 2 docs de Casos de Uso ([W] anexou — Vendas + Oficina). guard=true ⇒ o elemento JÁ existe na tela (marker presente) e o GUARD trava anti-regressão; guard=false ⇒ gap conhecido (UC sem cobertura) que o protocol_freshness lista. Começar pelas telas canon — NÃO varrer 239 telas (Tier 0 guard do prompt).",
+  "_convencao": "marker = string estável que DEVE aparecer no(s) arquivo(s) (componente importado / data-testid / termo de domínio). some o marker = build vermelho. Preferir nome de componente (estável) a texto visível (i18n).",
+  "screens": [
+    {
+      "id": "sells-create",
+      "charter": "resources/js/Pages/Sells/Create.charter.md",
+      "tsx": "resources/js/Pages/Sells/Create.tsx",
+      "ucs": [
+        { "uc": "UC-V01", "rationale": "abrir orçamento/pedido rastreável", "precisa": "busca rápida de cliente/produto, aplicação automática de tabela de preços, campo de condições (prazo, pagamento, endereço), distinção rascunho × pedido confirmado", "guard": true, "marker": "CustomerSearchAutocomplete", "files": ["resources/js/Pages/Sells/Create.tsx"] },
+        { "uc": "UC-V02", "rationale": "adicionar item com estoque/prazo visível", "precisa": "busca de produto com estoque/prazo visível, campo de desconto com validação de limite, observação por item", "guard": true, "marker": "ProductSearchAutocomplete", "files": ["resources/js/Pages/Sells/Create.tsx"] },
+        { "uc": "UC-V03", "rationale": "tabela de preços + desconto com limite/aprovação", "precisa": "seletor de tabela de preços, campo de desconto com limite visível, fluxo de aprovação de desconto", "guard": true, "marker": "desconto", "files": ["resources/js/Pages/Sells/Create.tsx"] },
+        { "uc": "UC-V04", "rationale": "enviar orçamento + registrar aprovação", "precisa": "botão de envio com registro de canal e data, estado 'Aguardando aprovação' visível, registro da aprovação do cliente, histórico de versões do orçamento", "guard": false },
+        { "uc": "UC-R01", "rationale": "item de composição (kit/bundle)", "precisa": "busca de kits distinta de produtos simples, expansão dos filhos, subtotal do kit, substituir filho, reserva de estoque dos filhos", "guard": false },
+        { "uc": "UC-C01", "rationale": "item personalizado (dimensão/material/acabamento/arte)", "precisa": "formulário de item personalizado (dimensão, material, acabamento, arte), preço em tempo real por fórmula, observações de produção", "guard": false }
+      ]
+    },
+    {
+      "id": "sells-show",
+      "charter": "resources/js/Pages/Sells/Show.charter.md",
+      "tsx": "resources/js/Pages/Sells/Show.tsx",
+      "ucs": [
+        { "uc": "UC-V04S", "rationale": "estado de aprovação visível na OS/venda", "precisa": "estado 'Aguardando aprovação' visível + registro da aprovação do cliente", "guard": false },
+        { "uc": "UC-V05", "rationale": "registrar entrega + confirmar recebimento", "precisa": "campo de transportadora/rastreio, upload de foto de entrega, confirmação de recebimento, registro de tentativas frustradas", "guard": false },
+        { "uc": "UC-V06", "rationale": "faturar + emitir NF (produto/serviço)", "precisa": "seleção de tipo de NF, forma de pagamento com parcelas, integração fiscal, baixa automática de estoque/insumos", "guard": false },
+        { "uc": "UC-V07", "rationale": "histórico de pedidos + repetir pedido", "precisa": "histórico de pedidos no perfil do cliente, filtro por período/estado/tipo, botão repetir pedido, ticket médio/frequência", "guard": false }
+      ]
+    },
+    {
+      "id": "oficina-create",
+      "charter": "resources/js/Pages/OficinaAuto/ServiceOrders/Create.charter.md",
+      "tsx": "resources/js/Pages/OficinaAuto/ServiceOrders/Create.tsx",
+      "ucs": [
+        { "uc": "UC-01", "rationale": "abrir OS + check-in do veículo", "precisa": "formulário de check-in com busca por placa, chassi/renavam/hodômetro/combustível, fotos de entrada e relato do diagnóstico", "guard": true, "marker": "EntryCheckinFields", "files": ["resources/js/Pages/OficinaAuto/ServiceOrders/Create.tsx"] }
+      ]
+    },
+    {
+      "id": "oficina-show",
+      "charter": "resources/js/Pages/OficinaAuto/ServiceOrders/Show.charter.md",
+      "tsx": "resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx",
+      "ucs": [
+        { "uc": "UC-03", "rationale": "vistoria digital (DVI) item a item", "precisa": "DVI por item com foto/vídeo e mapeamento achado→item de orçamento", "guard": true, "marker": "DviBudgetSection", "files": ["resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx"] },
+        { "uc": "UC-05", "rationale": "aprovar/recusar itens — gate de aprovação", "precisa": "aprovação item a item, registro de recusados, aprovação parcial, estado da OS refletindo 'Aprovada'", "guard": true, "marker": "ApprovalGateCard", "files": ["resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx"] },
+        { "uc": "UC-09", "rationale": "faturar — split fiscal NF-e (peça) × NFS-e (serviço)", "precisa": "split fiscal: soma peças = NF-e, soma serviços = NFS-e (a tela prepara; emissão é listener)", "guard": true, "marker": "FiscalSplitCard", "files": ["resources/js/Pages/OficinaAuto/ServiceOrders/Show.tsx"] },
+        { "uc": "UC-04", "rationale": "compor e enviar orçamento — estado explícito", "precisa": "estado explícito 'Orçamento enviado' + agrupar itens por seção + envio com registro", "guard": false },
+        { "uc": "UC-06", "rationale": "ciclo de peça (cotar→comprar→receber→reservar)", "precisa": "ciclo de peça (necessária→cotada→pedida→recebida), reserva e baixa de estoque vinculada à OS", "guard": false },
+        { "uc": "UC-07", "rationale": "executar serviço + apontar tempo", "precisa": "apontamento de tempo, checklist de roteiro e pausa com motivo", "guard": false },
+        { "uc": "UC-08", "rationale": "controle de qualidade antes da entrega", "precisa": "etapa/checklist de qualidade entre execução e pronto", "guard": false },
+        { "uc": "UC-10", "rationale": "pós-venda: garantia, NPS, lembretes", "precisa": "histórico do veículo (passagens anteriores), vínculo de retorno de garantia e gatilho de lembrete", "guard": false }
+      ]
+    },
+    {
+      "id": "oficina-board",
+      "charter": "resources/js/Pages/OficinaAuto/ServiceOrders/Board.charter.md",
+      "tsx": "resources/js/Pages/OficinaAuto/ServiceOrders/Board.tsx",
+      "ucs": [
+        { "uc": "UC-02", "rationale": "triar a fila + alocar mecânico/box (drag-drop)", "precisa": "visão de ocupação do pátio, fila ordenável, e atribuição por arraste (drag-drop por box/mecânico)", "guard": true, "marker": "drag", "files": ["resources/js/Pages/OficinaAuto/ServiceOrders/Board.tsx"] }
+      ]
+    }
+  ]
+}

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Board.charter.md
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Board.charter.md
@@ -63,3 +63,10 @@ corrigido pela [ADR 0194]. Este quadro roda no processo FSM **`oficina_mecanica_
 - Nunca hardcodar colunas: ler do payload `columns` (etapas reais do processo).
 - Nunca exibir vocabulário de caçamba/locação (m³, diária, recolhimento) — é carro.
 - Nunca cor de status crua `text-rose/emerald-700` — usar `text-destructive`/`text-success`.
+
+## UCs cobertos (PRECISA TER · rastreável · §10.4 [CC])
+
+> Casos de Uso ("A tela precisa:") amarrados a GUARD Pest `uc-<id>` via [`prototipo-ui/audit/uc-registry.json`](../../../../../prototipo-ui/audit/uc-registry.json).
+> ✅ presente+travado (some o elemento = build vermelho) · 🟡 gap (acende no `protocol_freshness`).
+
+- ✅ **UC-02** (`uc-02`) — triar a fila + alocar mecânico/box: visão de ocupação do pátio, fila ordenável, atribuição por arraste (drag-drop).

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Create.charter.md
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Create.charter.md
@@ -68,3 +68,10 @@ Permitir abertura rápida de OS pelo atendente em ≤ 30s — escolher vehicle (
 - [SPEC.md US-OFICINA-001](../../../../../memory/requisitos/OficinaAuto/SPEC.md)
 - [RUNBOOK-create.md](../../../../../memory/requisitos/OficinaAuto/RUNBOOK-create.md)
 - [ADR 0137 §"Escopo arquitetural V0"](../../../../../memory/decisions/0137-modules-oficinaauto-qualificada.md)
+
+## UCs cobertos (PRECISA TER · rastreável · §10.4 [CC])
+
+> Casos de Uso ("A tela precisa:") amarrados a GUARD Pest `uc-<id>` via [`prototipo-ui/audit/uc-registry.json`](../../../../../prototipo-ui/audit/uc-registry.json).
+> ✅ presente+travado (some o elemento = build vermelho) · 🟡 gap (acende no `protocol_freshness`).
+
+- ✅ **UC-01** (`uc-01`) — check-in do veículo: busca por placa, chassi/renavam/hodômetro/combustível, fotos de entrada + relato do diagnóstico (`EntryCheckinFields`).

--- a/resources/js/Pages/OficinaAuto/ServiceOrders/Show.charter.md
+++ b/resources/js/Pages/OficinaAuto/ServiceOrders/Show.charter.md
@@ -73,3 +73,17 @@ Tela única-fonte-da-verdade sobre 1 OS — mecânico/atendente acompanha estado
 - [RUNBOOK-show.md](../../../../../memory/requisitos/OficinaAuto/RUNBOOK-show.md)
 - [ADR 0143 FSM pipeline LIVE prod](../../../../../memory/decisions/0143-fsm-pipeline-live-prod-marco-2026-05-12.md)
 - [ADR 0129 FSM canônica tabular](../../../../../memory/decisions/0129-state-machine-canonica-fsm-rbac.md)
+
+## UCs cobertos (PRECISA TER · rastreável · §10.4 [CC])
+
+> Casos de Uso ("A tela precisa:") amarrados a GUARD Pest `uc-<id>` via [`prototipo-ui/audit/uc-registry.json`](../../../../../prototipo-ui/audit/uc-registry.json).
+> ✅ presente+travado (some o elemento = build vermelho) · 🟡 gap (acende no `protocol_freshness`, advisory).
+
+- ✅ **UC-03** (`uc-03`) — vistoria digital (DVI) por item com foto + mapeamento achado→item de orçamento (`DviBudgetSection`).
+- ✅ **UC-05** (`uc-05`) — gate de aprovação: aprovação item a item, recusados, parcial, estado "Aprovada" (`ApprovalGateCard`).
+- ✅ **UC-09** (`uc-09`) — split fiscal: soma peças = NF-e, soma serviços = NFS-e (a tela prepara; emissão é listener) (`FiscalSplitCard`).
+- 🟡 **UC-04** — estado explícito "Orçamento enviado" + agrupar itens por seção + envio com registro. _(sem cobertura)_
+- 🟡 **UC-06** — ciclo de peça (necessária→cotada→pedida→recebida), reserva e baixa de estoque vinculada à OS. _(sem cobertura)_
+- 🟡 **UC-07** — apontamento de tempo, checklist de roteiro, pausa com motivo. _(sem cobertura)_
+- 🟡 **UC-08** — etapa/checklist de qualidade entre execução e pronto. _(sem cobertura)_
+- 🟡 **UC-10** — histórico do veículo (passagens anteriores), retorno de garantia, gatilho de lembrete. _(sem cobertura)_

--- a/resources/js/Pages/Sells/Create.charter.md
+++ b/resources/js/Pages/Sells/Create.charter.md
@@ -88,3 +88,16 @@ Cadastrar venda completa (cliente + produtos + pagamento + frete + impostos) num
 - [Design.md §16 Cockpit V2](../../../../Design.md)
 - [ADR 0110 Cockpit Pattern V2](../../../../memory/decisions/0110-cockpit-pattern-v2-canon-list-detail.md)
 - PR #257, #258, #259, #261 — sequência migração visual
+
+## UCs cobertos (PRECISA TER · rastreável · §10.4 [CC])
+
+> Cada item vem de um Caso de Uso ("A tela precisa:") amarrado a um GUARD Pest `uc-<id>`
+> (`tests/Feature/Guards/UcGuardsTest.php`) via [`prototipo-ui/audit/uc-registry.json`](../../../../prototipo-ui/audit/uc-registry.json).
+> ✅ = elemento presente + travado (some o elemento = build vermelho). 🟡 = gap conhecido (acende no `protocol_freshness`, advisory).
+
+- ✅ **UC-V01** (`uc-v01`) — busca rápida de cliente/produto, tabela de preços automática, condições (prazo/pagamento/endereço), rascunho × pedido confirmado.
+- ✅ **UC-V02** (`uc-v02`) — busca de produto com estoque/prazo visível, desconto com limite, observação por item.
+- ✅ **UC-V03** (`uc-v03`) — seletor de tabela de preços, desconto com limite visível, aprovação de desconto.
+- 🟡 **UC-V04** — botão de envio com registro de canal+data, estado "Aguardando aprovação", registro da aprovação, histórico de versões. _(sem cobertura)_
+- 🟡 **UC-R01** — busca de kits distinta, expansão dos filhos, subtotal do kit, substituir filho, reserva de estoque dos filhos. _(sem cobertura)_
+- 🟡 **UC-C01** — formulário de item personalizado (dimensão/material/acabamento/arte), preço em tempo real, observações de produção. _(sem cobertura)_

--- a/resources/js/Pages/Sells/Create.charter.md
+++ b/resources/js/Pages/Sells/Create.charter.md
@@ -3,9 +3,9 @@ page: /sells/create
 component: resources/js/Pages/Sells/Create.tsx
 owner: wagner
 status: live
-last_validated: 2026-05-08
+last_validated: "2026-05-08"
 parent_module: Sells
-related_adrs: [0110, 0107, 0104, 0093]
+related_adrs: [110, 107, 104, 93]
 tier: A
 charter_version: 1
 ---

--- a/resources/js/Pages/Sells/Show.charter.md
+++ b/resources/js/Pages/Sells/Show.charter.md
@@ -2,10 +2,10 @@
 page: /sells/{id}
 component: resources/js/Pages/Sells/Show.tsx
 owner: wagner
-status: wave1-draft
-last_validated: 2026-05-15
+status: draft
+last_validated: "2026-05-15"
 parent_module: Sells
-related_adrs: [0104, 0107, 0110, 0143, 0149, 0093]
+related_adrs: [104, 107, 110, 143, 149, 93]
 tier: A
 charter_version: 1
 mwart_pattern_reuse:

--- a/resources/js/Pages/Sells/Show.charter.md
+++ b/resources/js/Pages/Sells/Show.charter.md
@@ -113,3 +113,13 @@ Mostrar detalhe completo de uma venda — linhas, pagamentos, frete, atividades 
 - [show-visual-comparison.md](../../../../memory/requisitos/Sells/show-visual-comparison.md)
 - Blueprint Cowork: `prototipo-ui/prototipos/vendas-cockpit/`
 - Parent visual: `resources/js/Pages/Sells/Index.charter.md`
+
+## UCs cobertos (PRECISA TER · rastreável · §10.4 [CC])
+
+> Casos de Uso ("A tela precisa:") amarrados a GUARD Pest `uc-<id>` via [`prototipo-ui/audit/uc-registry.json`](../../../../prototipo-ui/audit/uc-registry.json).
+> ✅ presente+travado · 🟡 gap (acende no `protocol_freshness`). Show é `wave1-draft` — os UCs de gestão pós-venda ainda são gaps.
+
+- 🟡 **UC-V04** — estado "Aguardando aprovação" visível + registro da aprovação do cliente. _(sem cobertura)_
+- 🟡 **UC-V05** — campo de transportadora/rastreio, foto de entrega, confirmação de recebimento, tentativas frustradas. _(sem cobertura)_
+- 🟡 **UC-V06** — seleção de tipo de NF, forma de pagamento c/ parcelas, integração fiscal, baixa de estoque/insumos. _(sem cobertura)_
+- 🟡 **UC-V07** — histórico de pedidos no perfil, filtro por período/estado/tipo, repetir pedido, ticket médio/frequência. _(sem cobertura)_

--- a/tests/Feature/Guards/UcGuardsTest.php
+++ b/tests/Feature/Guards/UcGuardsTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+use Tests\TestCase;
+
+uses(TestCase::class);
+
+/**
+ * GUARDs de Caso de Uso — telas canon (Vendas + Oficina).
+ *
+ * Cada UC com `guard: true` no registro (`prototipo-ui/audit/uc-registry.json`)
+ * tem aqui um teste tagueado `uc-<id>` que afirma a presença do **marker** (o
+ * elemento que materializa o "A tela precisa:") no(s) arquivo(s) da tela. Some o
+ * elemento = build VERMELHO ([W]: "põe o botão e que nunca mais saia aquela
+ * merda de lá"). Estende o padrão charter→GUARD que já existe — NÃO inventa.
+ *
+ * UCs com `guard: false` são GAPS conhecidos (UC sem cobertura) — NÃO viram teste
+ * aqui (não dá pra afirmar presença de elemento ausente sem ficar vermelho à toa);
+ * o `protocol_freshness` (advisory) lista esses gaps. A lista do que ficou sem
+ * cobertura está no registro + no relatório do check.
+ *
+ * Convenção de marker: nome de componente estável > texto visível (i18n).
+ *
+ * @see prototipo-ui/audit/uc-registry.json   (fonte única)
+ * @see prototipo-ui/audit/protocol-freshness.mjs   (acende os gaps)
+ * @see Modules/Jana/Console/Commands/HealthCheckCommand.php  (check espelho)
+ */
+$repoRoot = dirname(__DIR__, 3);
+$registry = json_decode((string) file_get_contents($repoRoot . '/prototipo-ui/audit/uc-registry.json'), true);
+
+foreach (($registry['screens'] ?? []) as $screen) {
+    foreach (($screen['ucs'] ?? []) as $uc) {
+        if (! ($uc['guard'] ?? false)) {
+            continue; // gap — coberto pelo protocol_freshness, não por GUARD verde
+        }
+
+        $id = $uc['uc'];
+        $marker = $uc['marker'];
+        $files = $uc['files'];
+        $screenId = $screen['id'];
+
+        it("GUARD {$id} ({$screenId}): tela mantém o elemento de '{$uc['rationale']}'", function () use ($marker, $files, $id) {
+            $repoRoot = dirname(__DIR__, 3);
+            $achou = false;
+            foreach ($files as $rel) {
+                $abs = $repoRoot . '/' . $rel;
+                expect(is_file($abs))->toBeTrue("arquivo da tela sumiu: {$rel} (UC {$id})");
+                if (str_contains((string) file_get_contents($abs), $marker)) {
+                    $achou = true;
+                }
+            }
+            // PRECISA TER: o marker (elemento que materializa o UC) tem que estar presente.
+            expect($achou)->toBeTrue(
+                "GUARD {$id} VERMELHO: marker '{$marker}' sumiu da(s) tela(s) " . implode(', ', $files)
+                . '. Um Caso de Uso regrediu — restaure o elemento ou reconcilie o registro/charter.'
+            );
+        })->group('guard', 'uc', 'uc-' . strtolower(str_replace('UC-', '', $id)));
+    }
+}
+
+it('registro UC é íntegro: todo guard=true tem marker + files existentes', function () use ($registry) {
+    $repoRoot = dirname(__DIR__, 3);
+    foreach (($registry['screens'] ?? []) as $screen) {
+        // charter da tela canon tem que existir (espelha protocol_freshness item (b)).
+        expect(is_file($repoRoot . '/' . $screen['charter']))
+            ->toBeTrue("tela canon sem charter: {$screen['charter']}");
+
+        foreach (($screen['ucs'] ?? []) as $uc) {
+            if (! ($uc['guard'] ?? false)) {
+                continue;
+            }
+            expect($uc['marker'] ?? null)->not->toBeEmpty("UC {$uc['uc']} guard=true sem marker");
+            expect($uc['files'] ?? [])->not->toBeEmpty("UC {$uc['uc']} guard=true sem files");
+        }
+    }
+})->group('guard', 'uc');


### PR DESCRIPTION
## §10.4 PROPOSTA — Cowork `UC-GUARDS-PROTOCOL-FRESHNESS` (lote design [CC])

> **NÃO MERGEAR sem [W].** Advisory/aditivo. Não numera ADR (soberania [W], 0238). Não auto-mergeia Tier 0.

### O que faz
Dos 2 docs de Casos de Uso (Vendas + Oficina, [W] anexou) gera, **só pras telas canon**, o par **PRECISA TER (o porquê) + GUARD Pest `uc-<id>` (a trava)**. Some o elemento = build vermelho ([W]: *"põe o botão e que nunca mais saia aquela merda de lá"*). Estende o padrão charter→GUARD + `review-freshness` (#2078) — não inventa.

- **`prototipo-ui/audit/uc-registry.json`** — fonte única UC→tela→marker→GUARD (lida pelo Pest, pelo node e pelo check PHP).
- **`tests/Feature/Guards/UcGuardsTest.php`** — 8 GUARDs verdes tagueados `uc-<id>` (anti-regressão): UC-V01/V02/V03 (Sells/Create), UC-01 (Oficina/Create), UC-03/05/09 (Oficina/Show), UC-02 (Oficina/Board).
- **`prototipo-ui/audit/protocol-freshness.mjs`** + baseline ratchet (ADR 0209) — espelha `review-freshness.mjs`; acende **UC sem cobertura / GUARD sumido / charter ausente / UC morto**. Exit 1 só em **regressão nova** (gaps herdados ⊆ baseline).
- **`checkProtocolFreshness()`** advisory no `jana:health-check` (+ Pest smoke) — emite `storage/reports/protocol-freshness.json` pro ciclo diário (#2152) ler.
- **5 charters canon** ganham a seção *"UCs cobertos (PRECISA TER · rastreável)"*.

### Validação vs `origin/main` fresco (worktree off `origin/main` @ `7a60eddbb`)
- `protocol_freshness` / `uc-<id>` guards / `uc-registry.json` **ausentes** em main → real work.
- Padrão reusado: charter `PRECISA TER` (ex. `OficinaAuto/Os/Create.charter.md`) + Pest source-assert (`CockpitPatternConformanceTest`) + `review-freshness.mjs` ratchet. `data-testid` esparso no canon → markers usam **nome de componente** (mais estável que i18n).

### Números reais do main hoje (`node protocol-freshness.mjs` + simulação do Pest)
- **8 UC cobertos** (GUARD verde — todos PASS): UC-V01, UC-V02, UC-V03, UC-01, UC-03, UC-05, UC-09, UC-02.
- **12 sem cobertura** (gaps → baseline, acendem advisory): UC-V04, UC-R01, UC-C01, UC-V04S, UC-V05, UC-V06, UC-V07 (Sells) · UC-04, UC-06, UC-07, UC-08, UC-10 (Oficina).
- **0** guard quebrado · **0** charter ausente · **0** UC morto · **0 regressão**.

### Guards / Tier 0
- GUARDs verdes = **hard** (regressão de UC existente falha o build — é o pedido). `protocol_freshness` = **advisory** (gaps não derrubam CI/cron). Começa pelo canon — não varre 239 telas. Tokens DS + nome de componente, sem cor crua.

> Pest roda no CI/CT100 (norma do repo, #2076); localmente validei os 8 guards verdes por simulação da asserção + rodei o `protocol-freshness.mjs` real (exit 0, baseline gravado).

🤖 Generated with [Claude Code](https://claude.com/claude-code)